### PR TITLE
Fix PIC32MX/MZ typos

### DIFF
--- a/arch/mips/src/pic32mx/pic32mx.h
+++ b/arch/mips/src/pic32mx/pic32mx.h
@@ -595,7 +595,7 @@ void pic32mx_dmadump(DMA_HANDLE handle, const struct pic32mx_dmaregs_s *regs,
  *
  * Description:
  *   If USB is supported and the board supports a pullup via GPIO (for USB software
- *   connect and disconnect), then the board software must provide pic32mx_pullup.
+ *   connect and disconnect), then the board software must provide pic32mx_usbpullup.
  *   See include/nuttx/usb/usbdev.h for additional description of this method.
  *   Alternatively, if no pull-up GPIO the following can be redefined to be
  *   NULL.

--- a/arch/mips/src/pic32mz/pic32mz_usbdev.h
+++ b/arch/mips/src/pic32mz/pic32mz_usbdev.h
@@ -77,7 +77,7 @@ extern "C"
  *
  * Description:
  *   If USB is supported and the board supports a pullup via GPIO (for USB software
- *   connect and disconnect), then the board software must provide pic32mz_pullup.
+ *   connect and disconnect), then the board software must provide pic32mz_usbpullup.
  *   See include/nuttx/usb/usbdev.h for additional description of this method.
  *   Alternatively, if no pull-up GPIO the following can be redefined to be
  *   NULL.

--- a/boards/mips/pic32mx/pic32mx-starterkit/src/pic32mx_usbdev.c
+++ b/boards/mips/pic32mx/pic32mx-starterkit/src/pic32mx_usbdev.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * boards/mips/pic32mx/pic32mx-starterkit/src/pic32mx_usbdev.c
  *
- *   Copyright (C) 2012, 2015 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -53,10 +38,10 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* PIN  NAME                            SIGNAL         NOTES
- * ---- ------------------------------- -------------- ----------------------
- *  20  VBUSON/C1IN+/AN5/CN7/RB5        VBUSON         To USB VBUS circuitry
- *  43  C2IN+/AN3/CN5/RB3               USB_PGOOD      Power good (low if bad)
+/* PIN  NAME                          SIGNAL       NOTES
+ * ---- ----------------------------- ------------ ----------------------
+ *  20  VBUSON/C1IN+/AN5/CN7/RB5      VBUSON       To USB VBUS circuitry
+ *  43  C2IN+/AN3/CN5/RB3             USB_PGOOD    Power good (low if bad)
  */
 
 #define GPIO_USB_VBUSON (GPIO_INPUT|GPIO_PORTB|GPIO_PIN5)
@@ -91,19 +76,19 @@ void weak_function pic32mx_usbdevinitialize(void)
    *  source current onto the Vbus pin.  Additionally, USB peripherals should
    *  not source current on D+ or D- when the host/hub is not actively
    *  powering the Vbus line.
-   *  When designing a self powered (as opposed to bus powered) USB peripheral
-   *  device, the firmware should make sure not to turn on the USB module and
-   *  D+ or D- pull up resistor unless Vbus is actively powered.  Therefore,
-   *  the firmware needs some means to detect when Vbus is being powered by
-   *  the host.
-   *  A 5V tolerant I/O pin can be connected to Vbus (through a resistor), and
-   *  can be used to detect when Vbus is high (host actively powering), or low
-   *  (host is shut down or otherwise not supplying power).  The USB firmware
-   *  can then periodically poll this I/O pin to know when it is okay to turn
-   *  on the USB module/D+/D- pull up resistor.  When designing a purely bus
-   *  powered peripheral device, it is not possible to source current on D+ or
-   *  D- when the host is not actively providing power on Vbus.
-   *  Therefore, implementing this bus sense feature is optional. ..."
+   *  When designing a self powered (as opposed to bus powered) USB
+   *  peripheral device, the firmware should make sure not to turn on the
+   *  USB module and D+ or D- pull up resistor unless Vbus is actively
+   *  powered.  Therefore, the firmware needs some means to detect when Vbus
+   *  is being powered by the host.
+   *  A 5V tolerant I/O pin can be connected to Vbus (through a resistor),
+   *  and can be used to detect when Vbus is high (host actively powering),
+   *  or low (host is shut down or otherwise not supplying power).  The USB
+   *  firmware can then periodically poll this I/O pin to know when it is
+   *  okay to turn on the USB module/D+/D- pull up resistor.  When designing
+   *  a purely bus powered peripheral device, it is not possible to source
+   *  current on D+ or D- when the host is not actively providing power on
+   *  Vbus.  Therefore, implementing this bus sense feature is optional. ..."
    */
 
 #ifdef CONFIG_USBHOST
@@ -139,9 +124,9 @@ void weak_function pic32mx_usbdevinitialize(void)
  * Description:
  *   If USB is supported and the board supports a pullup via GPIO (for USB
  *   software connect and disconnect), then the board software must provide
- *   stm32_pullup. See include/nuttx/usb/usbdev.h for additional description
- *   of this method.  Alternatively, if no pull-up GPIO the following EXTERN
- *   can be redefined to be NULL.
+ *   pic32mx_usbpullup. See include/nuttx/usb/usbdev.h for additional
+ *   description of this method.  Alternatively, if no pull-up GPIO the
+ *   following EXTERN can be redefined to be NULL.
  *
  ****************************************************************************/
 

--- a/boards/mips/pic32mx/pic32mx7mmb/src/pic32_usbdev.c
+++ b/boards/mips/pic32mx/pic32mx7mmb/src/pic32_usbdev.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * boards/mips/pic32mx/pic32mx7mmb/src/pic32_usbdev.c
  *
- *   Copyright (C) 2012 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -53,10 +38,10 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* PIN  NAME                            SIGNAL         NOTES
- * ---- ------------------------------- -------------- ----------------------
- *  20  VBUSON/C1IN+/AN5/CN7/RB5        VBUSON         To USB VBUS circuitry
- *  43  C2IN+/AN3/CN5/RB3               USB_PGOOD      Power good (low if bad)
+/* PIN  NAME                          SIGNAL       NOTES
+ * ---- ----------------------------- ------------ ----------------------
+ *  20  VBUSON/C1IN+/AN5/CN7/RB5      VBUSON       To USB VBUS circuitry
+ *  43  C2IN+/AN3/CN5/RB3             USB_PGOOD    Power good (low if bad)
  */
 
 #define GPIO_USB_VBUSON (GPIO_INPUT|GPIO_PORTB|GPIO_PIN5)
@@ -91,19 +76,19 @@ void weak_function pic32mx_usbdevinitialize(void)
    *  source current onto the Vbus pin.  Additionally, USB peripherals should
    *  not source current on D+ or D- when the host/hub is not actively
    *  powering the Vbus line.
-   *  When designing a self powered (as opposed to bus powered) USB peripheral
-   *  device, the firmware should make sure not to turn on the USB module and
-   *  D+ or D- pull up resistor unless Vbus is actively powered.  Therefore,
-   *  the firmware needs some means to detect when Vbus is being powered by
-   *  the host.
-   *  A 5V tolerant I/O pin can be connected to Vbus (through a resistor), and
-   *  can be used to detect when Vbus is high (host actively powering), or low
-   *  (host is shut down or otherwise not supplying power).  The USB firmware
-   *  can then periodically poll this I/O pin to know when it is okay to turn
-   *  on the USB module/D+/D- pull up resistor.  When designing a purely bus
-   *  powered peripheral device, it is not possible to source current on D+ or
-   *  D- when the host is not actively providing power on Vbus.
-   *  Therefore, implementing this bus sense feature is optional. ..."
+   *  When designing a self powered (as opposed to bus powered) USB
+   *  peripheral device, the firmware should make sure not to turn on the
+   *  USB module and D+ or D- pull up resistor unless Vbus is actively
+   *  powered.  Therefore, the firmware needs some means to detect when
+   *  Vbus is being powered by the host.
+   *  A 5V tolerant I/O pin can be connected to Vbus (through a resistor),
+   *  and can be used to detect when Vbus is high (host actively powering),
+   *  or low (host is shut down or otherwise not supplying power).  The USB
+   *  firmware can then periodically poll this I/O pin to know when it is
+   *  okay to turn on the USB module/D+/D- pull up resistor.  When designing
+   *  a purely bus powered peripheral device, it is not possible to source
+   *  current on D+ or D- when the host is not actively providing power on
+   *  Vbus.  Therefore, implementing this bus sense feature is optional. ..."
    */
 
 #ifdef CONFIG_USBHOST
@@ -139,9 +124,9 @@ void weak_function pic32mx_usbdevinitialize(void)
  * Description:
  *   If USB is supported and the board supports a pullup via GPIO (for USB
  *   software connect and disconnect), then the board software must provide
- *   pic32mx_pullup. See include/nuttx/usb/usbdev.h for additional description
- *   of this method.  Alternatively, if no pull-up GPIO the following EXTERN
- *   can be redefined to be NULL.
+ *   pic32mx_usbpullup. See include/nuttx/usb/usbdev.h for additional
+ *   description of this method.  Alternatively, if no pull-up GPIO the
+ *   following EXTERN can be redefined to be NULL.
  *
  ****************************************************************************/
 

--- a/boards/mips/pic32mx/sure-pic32mx/src/pic32mx_usbdev.c
+++ b/boards/mips/pic32mx/sure-pic32mx/src/pic32mx_usbdev.c
@@ -1,39 +1,20 @@
 /****************************************************************************
  * boards/mips/pic32mx/sure-pic32mx/src/pic32mx_usbdev.c
  *
- *   Copyright (C) 2011-2013 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * References:
- *   - Sample code and schematics provided with the Sure Electronics
- *     PIC32 board.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -107,19 +88,19 @@ void weak_function pic32mx_usbdevinitialize(void)
    *  source current onto the Vbus pin.  Additionally, USB peripherals should
    *  not source current on D+ or D- when the host/hub is not actively
    *  powering the Vbus line.
-   *  When designing a self powered (as opposed to bus powered) USB peripheral
-   *  device, the firmware should make sure not to turn on the USB module and
-   *  D+ or D- pull up resistor unless Vbus is actively powered.  Therefore,
-   *  the firmware needs some means to detect when Vbus is being powered by
-   *  the host.
-   *  A 5V tolerant I/O pin can be connected to Vbus (through a resistor), and
-   *  can be used to detect when Vbus is high (host actively powering), or low
-   *  (host is shut down or otherwise not supplying power).  The USB firmware
-   *  can then periodically poll this I/O pin to know when it is okay to turn
-   *  on the USB module/D+/D- pull up resistor.  When designing a purely bus
-   *  powered peripheral device, it is not possible to source current on D+ or
-   *  D- when the host is not actively providing power on Vbus. Therefore,
-   *  implementing this bus sense feature is optional. ..."
+   *  When designing a self powered (as opposed to bus powered) USB
+   *  peripheral device, the firmware should make sure not to turn on the
+   *  USB module and D+ or D- pull up resistor unless Vbus is actively
+   *  powered.  Therefore, the firmware needs some means to detect when
+   *  Vbus is being powered by the host.
+   *  A 5V tolerant I/O pin can be connected to Vbus (through a resistor),
+   *  and can be used to detect when Vbus is high (host actively powering),
+   *  or low (host is shut down or otherwise not supplying power).  The USB
+   *  firmware can then periodically poll this I/O pin to know when it is
+   *  okay to turn on the USB module/D+/D- pull up resistor.  When designing
+   *  a purely bus powered peripheral device, it is not possible to source
+   *  current on D+ or D- when the host is not actively providing power on
+   *  Vbus.  Therefore, implementing this bus sense feature is optional. ..."
    */
 
 #ifdef CONFIG_USBHOST
@@ -153,9 +134,9 @@ void weak_function pic32mx_usbdevinitialize(void)
  * Description:
  *   If USB is supported and the board supports a pullup via GPIO (for USB
  *   software connect and disconnect), then the board software must provide
- *   stm32_pullup. See include/nuttx/usb/usbdev.h for additional description
- *   of this method.  Alternatively, if no pull-up GPIO the following EXTERN
- *   can be redefined to be NULL.
+ *   pic32mx_usbpullup. See include/nuttx/usb/usbdev.h for additional
+ *   description of this method.  Alternatively, if no pull-up GPIO the
+ *   following EXTERN can be redefined to be NULL.
  *
  ****************************************************************************/
 

--- a/boards/mips/pic32mx/ubw32/src/pic32_usbdev.c
+++ b/boards/mips/pic32mx/ubw32/src/pic32_usbdev.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * boards/mips/pic32mx/ubw32/src/pic32_usbdev.c
  *
- *   Copyright (C) 2012 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -78,19 +63,19 @@ void weak_function pic32mx_usbdevinitialize(void)
    *  source current onto the Vbus pin.  Additionally, USB peripherals should
    *  not source current on D+ or D- when the host/hub is not actively
    *  powering the Vbus line.
-   *  When designing a self powered (as opposed to bus powered) USB peripheral
-   *  device, the firmware should make sure not to turn on the USB module and
-   *  D+ or D- pull up resistor unless Vbus is actively powered.  Therefore,
-   *  the firmware needs some means to detect when Vbus is being powered by
-   *  the host.
-   *  A 5V tolerant I/O pin can be connected to Vbus (through a resistor), and
-   *  can be used to detect when Vbus is high (host actively powering), or low
-   *  (host is shut down or otherwise not supplying power).  The USB firmware
-   *  can then periodically poll this I/O pin to know when it is okay to turn
-   *  on the USB module/D+/D- pull up resistor.  When designing a purely bus
-   *  powered peripheral device, it is not possible to source current on D+ or
-   *  D- when the host is not actively providing power on Vbus.
-   *  Therefore, implementing this bus sense feature is optional. ..."
+   *  When designing a self powered (as opposed to bus powered) USB
+   *  peripheral device, the firmware should make sure not to turn on the
+   *  USB module and D+ or D- pull up resistor unless Vbus is actively
+   *  powered.  Therefore, the firmware needs some means to detect when Vbus
+   *  is being powered by the host.
+   *  A 5V tolerant I/O pin can be connected to Vbus (through a resistor),
+   *  and can be used to detect when Vbus is high (host actively powering),
+   *  or low (host is shut down or otherwise not supplying power).  The USB
+   *  firmware can then periodically poll this I/O pin to know when it is
+   *  okay to turn on the USB module/D+/D- pull up resistor.  When designing
+   *  a purely bus powered peripheral device, it is not possible to source
+   *  current on D+ or D- when the host is not actively providing power on
+   *  Vbus.  Therefore, implementing this bus sense feature is optional. ..."
    */
 
 #ifdef CONFIG_USBHOST
@@ -120,9 +105,9 @@ void weak_function pic32mx_usbdevinitialize(void)
  * Description:
  *   If USB is supported and the board supports a pullup via GPIO (for USB
  *   software connect and disconnect), then the board software must provide
- *   stm32_pullup. See include/nuttx/usb/usbdev.h for additional description
- *   of this method.  Alternatively, if no pull-up GPIO the following EXTERN
- *   can be redefined to be NULL.
+ *   pic32mx_usbpullup. See include/nuttx/usb/usbdev.h for additional
+ *   description of this method.  Alternatively, if no pull-up GPIO the
+ *   following EXTERN can be redefined to be NULL.
  *
  ****************************************************************************/
 


### PR DESCRIPTION
## Summary

The pic32mx_usbpullup() and pic32mz_usbpullup() callbacks were referred to with various incorrect names in comments:  pic32mx_pullup(), pic32mz_pullup(), stm32_pullup().

## Impact

There should be none since only comments were changed

## Testing

N/A
