### PR TITLE
usbdev: composite: update USB_REQ_SETCONFIGURATION logic

### DIFF
--- a/drivers/usbdev/composite.c
+++ b/drivers/usbdev/composite.c
@@ -654,14 +654,37 @@ static int composite_setup(FAR struct usbdevclass_driver_s *driver,
 
                 for (i = 0; i < priv->ndevices; i++)
                   {
+                    /* The device must *NOT* submit on EP0 here */
+
                     ret = CLASS_SETUP(priv->device[i].dev,
                                       dev,
                                       ctrl,
                                       dataout,
                                       outlen);
+                    if (ret < 0)
+                      {
+                        /* FIXME does this work ? */
+
+                        ctrl->value = 0;
+
+                        for (i=i-1; i>=0; i--)
+                          {
+                            /* Reset configurations */
+
+                            CLASS_SETUP(priv->device[i].dev,
+                                            dev,
+                                            ctrl,
+                                            dataout,
+                                            outlen);
+                          }
+
+                        break;
+                      }
                   }
 
-                dispatched = true;
+                /* FIXME host is expecting only one reply */
+
+                // dispatched = true;
                 priv->config = value;
               }
           }


### PR DESCRIPTION
## Summary

DO NOT MERGE AS IT

discussion about composite driver behaviour.
I cannot get composite driver to work using multiple USB devices without this on stm32.

## Impact

Breaks all the usbdev drivers.

## Testing

