### PR TITLE
xtensa/esp32: Add option to disable raw esp-idf Wi-Fi log format

### DIFF
--- a/arch/xtensa/src/esp32/Kconfig
+++ b/arch/xtensa/src/esp32/Kconfig
@@ -938,6 +938,16 @@ config ESP32_WIFI_FS_MOUNTPT
 	help
 		Mount point of WiFi storage file system.
 
+config ESP32_WIFI_RAW_LOG_FORMAT
+	bool "Raw log format as esp-idf"
+	default n
+	depends on !SYSLOG_TIMESTAMP && \
+	           !SYSLOG_PRIORITY && \
+	           !SYSLOG_PROCESS_NAME && \
+	           !SYSLOG_PROCESSID && \
+	           !SYSLOG_PREFIX && \
+	           !SYSLOG_COLOR_OUTPUT
+
 endmenu # ESP32_WIRELESS
 
 menu "Real-Time Timer"

--- a/arch/xtensa/src/esp32/esp32_wifi_adapter.c
+++ b/arch/xtensa/src/esp32/esp32_wifi_adapter.c
@@ -3507,6 +3507,20 @@ static uint32_t esp_rand(void)
 static void esp_log_writev(uint32_t level, const char *tag,
                            const char *format, va_list args)
 {
+#ifndef CONFIG_ESP32_WIFI_RAW_LOG_FORMAT
+  int ret;
+  char *new_fmt;
+
+  ret = asprintf(&new_fmt, "%s: %s\n", tag, format);
+  if (ret < 0)
+    {
+      wlerr("Failed to transform esp-wifi log\n");
+      return ;
+    }
+
+  format = new_fmt;
+#endif
+
   switch (level)
     {
 #ifdef CONFIG_DEBUG_WIRELESS_ERROR
@@ -3528,6 +3542,10 @@ static void esp_log_writev(uint32_t level, const char *tag,
         break;
 #endif
     }
+
+#ifndef CONFIG_ESP32_WIFI_RAW_LOG_FORMAT
+  free(new_fmt);
+#endif
 }
 
 /****************************************************************************
@@ -3550,10 +3568,12 @@ void esp_log_write(uint32_t level,
                    const char *tag,
                    const char *format, ...)
 {
+#ifdef CONFIG_ESP32_WIFI_RAW_LOG_FORMAT
   va_list list;
   va_start(list, format);
   esp_log_writev(level, tag, format, list);
   va_end(list);
+#endif
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

Add option to disable raw esp-idf Wi-Fi log format.

## Impact

Try to fix log prefix being mixed from NuttX log device: https://github.com/apache/incubator-nuttx/issues/3157.

## Testing

