### PR TITLE
FAT32 fix skipping sectors at computing the number of free clusters

### DIFF
--- a/fs/fat/fs_fat32util.c
+++ b/fs/fat/fs_fat32util.c
@@ -2074,7 +2074,7 @@ int fat_computefreeclusters(struct fat_mountpt_s *fs)
 
           if (offset >= fs->fs_hwsectorsize)
             {
-              ret = fat_fscacheread(fs, fatsector++);
+              ret = fat_fscacheread(fs, fatsector);
               if (ret < 0)
                 {
                   return ret;
@@ -2154,7 +2154,7 @@ int fat_nfreeclusters(struct fat_mountpt_s *fs, off_t *pfreeclusters)
 }
 
 /****************************************************************************
- * Name: fat_nfreeclusters
+ * Name: fat_currentsector
  *
  * Description:
  *   Given the file position, set the correct current sector to access.


### PR DESCRIPTION
## Summary
Double increment of sector made computation skipping every second sector and to go beyond fat-table!

## Impact
Free number of cluster was incorrect. However, fsck.msdos under Linux still reports 2 more clusters to be free! 

## Testing

