### PR TITLE
libc/pthread: return EBUSY when barrier is in use

### DIFF
--- a/libs/libc/pthread/pthread_barrierdestroy.c
+++ b/libs/libc/pthread/pthread_barrierdestroy.c
@@ -62,6 +62,7 @@
 int pthread_barrier_destroy(FAR pthread_barrier_t *barrier)
 {
   int ret = OK;
+  int semcount;
 
   if (!barrier)
     {
@@ -69,8 +70,16 @@ int pthread_barrier_destroy(FAR pthread_barrier_t *barrier)
     }
   else
     {
-      sem_destroy(&barrier->sem);
-      barrier->count = 0;
+      sem_getvalue(&barrier->sem, &semcount);
+      if (semcount == 0)
+        {
+          sem_destroy(&barrier->sem);
+          barrier->count = 0;
+        }
+      else
+        {
+          ret = EBUSY;
+        }
     }
 
   return ret;


### PR DESCRIPTION
## Summary
specified here:
https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_barrier_destroy.html

## Impact
More confirm to the standard.

## Testing

