### PR TITLE
arch/esp32: Properly handle GPIO interrupt in SMP.

### DIFF
--- a/arch/xtensa/src/esp32/esp32_cpustart.c
+++ b/arch/xtensa/src/esp32/esp32_cpustart.c
@@ -44,6 +44,7 @@
 #include "esp32_region.h"
 #include "esp32_irq.h"
 #include "esp32_smp.h"
+#include "esp32_gpio.h"
 
 #ifdef CONFIG_SMP
 
@@ -207,6 +208,12 @@ void xtensa_appcpu_start(void)
   /* Dump registers so that we can see what is going to happen on return */
 
   xtensa_registerdump(tcb);
+
+#ifdef CONFIG_ESP32_GPIO_IRQ
+  /* Initialize GPIO interrupt support */
+
+  esp32_gpioirqinitialize(1);
+#endif
 
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
   /* And Enable interrupts */

--- a/arch/xtensa/src/esp32/esp32_gpio.h
+++ b/arch/xtensa/src/esp32/esp32_gpio.h
@@ -144,9 +144,9 @@ extern "C"
  ****************************************************************************/
 
 #ifdef CONFIG_ESP32_GPIO_IRQ
-void esp32_gpioirqinitialize(void);
+void esp32_gpioirqinitialize(int c);
 #else
-#  define esp32_gpioirqinitialize()
+#  define esp32_gpioirqinitialize(c)
 #endif
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32/esp32_irq.c
+++ b/arch/xtensa/src/esp32/esp32_irq.c
@@ -481,7 +481,7 @@ void up_irqinitialize(void)
 #ifdef CONFIG_ESP32_GPIO_IRQ
   /* Initialize GPIO interrupt support */
 
-  esp32_gpioirqinitialize();
+  esp32_gpioirqinitialize(0);
 #endif
 
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
@@ -544,6 +544,17 @@ void up_disable_irq(int irq)
       uintptr_t regaddr;
       uint8_t *intmap;
 
+#ifdef CONFIG_ESP32_GPIO_IRQ
+#ifdef CONFIG_SMP
+      /* The APP's CPU GPIO is a special case. See esp32/irq.h */
+
+      if (periph == ESP32_IRQ_APPCPU_GPIO)
+        {
+          periph = ESP32_IRQ_CPU_GPIO;
+        }
+#endif
+#endif
+
       DEBUGASSERT(periph >= 0 && periph < ESP32_NPERIPHERALS);
       esp32_intinfo(cpu, periph, &regaddr, &intmap);
 
@@ -587,6 +598,17 @@ void up_enable_irq(int irq)
       int periph = ESP32_IRQ2PERIPH(irq);
       uintptr_t regaddr;
       uint8_t *intmap;
+
+#ifdef CONFIG_ESP32_GPIO_IRQ
+#ifdef CONFIG_SMP
+      /* The APP's CPU GPIO is a special case. See esp32/irq.h */
+
+      if (periph == ESP32_IRQ_APPCPU_GPIO)
+        {
+          periph = ESP32_IRQ_CPU_GPIO;
+        }
+#endif
+#endif
 
       DEBUGASSERT(periph >= 0 && periph < ESP32_NPERIPHERALS);
 


### PR DESCRIPTION
## Summary
The PRO CPU and APP CPU have different peripherals for GPIO interrupts.
Each CPU needs to allocate an interrupt and attach it to its GPIO peripheral.

## Impact
ESP32's GPIO in SMP.
## Testing
esp32-wrover-kit:gpio with necessary configs to enable SMP.

