### PR TITLE
compiler.h: add __builtin_offsetof instead of offsetof

### DIFF
--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -53,6 +53,22 @@
 
 /* Built-in functions */
 
+/* The <stddef.h> header shall define the following macros:
+ *
+ * offsetof(type, member-designator)
+ *   Integer constant expression of type size_t, the value of which is the
+ *   offset in bytes to the structure member (member-designator), from the
+ *   beginning of its structure (type).
+ *
+ *     NOTE: This version of offsetof() depends on behaviors that could be
+ *     undefined for some compilers.  It would be better to use a builtin
+ *     function if one exists.
+ *
+ * Reference: Opengroup.org
+ */
+
+#  define offsetof(a, b) __builtin_offsetof(a, b)
+
 /* GCC 4.x have __builtin_ctz(|l|ll) and __builtin_clz(|l|ll). These count
  * trailing/leading zeros of input number and typically will generate few
  * fast bit-counting instructions. Inputting zero to these functions is
@@ -491,6 +507,8 @@
 
 #  define UNUSED(a) ((void)(1 || (a)))
 
+#  define offsetof(a, b) ((size_t)(&(((a *)(0))->b)))
+
 /* Zilog-specific definitions ***********************************************/
 
 #elif defined(__ZILOG__)
@@ -626,6 +644,8 @@
 
 #  define UNUSED(a) ((void)(1 || (a)))
 
+#  define offsetof(a, b) ((size_t)(&(((a *)(0))->b)))
+
 /* ICCARM-specific definitions **********************************************/
 
 #elif defined(__ICCARM__)
@@ -690,6 +710,8 @@
 #  undef CONFIG_HAVE_ANONYMOUS_STRUCT
 #  undef  CONFIG_HAVE_ANONYMOUS_UNION
 
+#  define offsetof(a, b) ((size_t)(&(((a *)(0))->b)))
+
 /* Unknown compiler *********************************************************/
 
 #else
@@ -741,6 +763,8 @@
 #  undef  CONFIG_HAVE_ANONYMOUS_UNION
 
 #  define UNUSED(a) ((void)(1 || (a)))
+
+#  define offsetof(a, b) ((size_t)(&(((a *)(0))->b)))
 
 #endif
 

--- a/include/stddef.h
+++ b/include/stddef.h
@@ -31,28 +31,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* The <stddef.h> header shall define the following macros:
- *
- * NULL
- *   The null pointer constant.
- *
- *     NOTE: Currently the definition of NULL is in sys/types.h but should
- *     be moved here sometime.
- *
- * offsetof(type, member-designator)
- *   Integer constant expression of type size_t, the value of which is the
- *   offset in bytes to the structure member (member-designator), from the
- *   beginning of its structure (type).
- *
- *     NOTE: This version of offsetof() depends on behaviors that could be
- *     undefined for some compilers.  It would be better to use a builtin
- *     function if one exists.
- *
- * Reference: Opengroup.org
- */
-
-#define offsetof(a, b) ((size_t)(&(((a *)(0))->b)))
-
 /****************************************************************************
  * Type Definitions
  ****************************************************************************/


### PR DESCRIPTION
The implementation of offset is diffience in C and C++,
use __builtin_offsetof will be more common for fixed language
preject.

## Summary

## Impact

## Testing
build pass on arch sim, arm

