### PR TITLE
drivers/mtd: Fix /proc/partitions column alignment on NSH

### DIFF
--- a/drivers/mtd/mtd_partition.c
+++ b/drivers/mtd/mtd_partition.c
@@ -633,16 +633,16 @@ static ssize_t part_procfs_read(FAR struct file *filep, FAR char *buffer,
           /* Terminate the partition name and add to output buffer */
 
           ret = snprintf(&buffer[total], buflen - total,
-                  "%s%7ju %7ju   %s\n",
-                  partname,
-                  (uintmax_t)attr->nextpart->firstblock / blkpererase,
-                  (uintmax_t)attr->nextpart->neraseblocks,
-                  attr->nextpart->parent->name);
+                         "%s%7ju %7ju   %s\n",
+                         partname,
+                         (uintmax_t)attr->nextpart->firstblock / blkpererase,
+                         (uintmax_t)attr->nextpart->neraseblocks,
+                         attr->nextpart->parent->name);
 #else
           ret = snprintf(&buffer[total], buflen - total, "%7ju %7ju   %s\n",
-                  (uintmax_t)attr->nextpart->firstblock / blkpererase,
-                  (uintmax_t)attr->nextpart->neraseblocks,
-                  attr->nextpart->parent->name);
+                         (uintmax_t)attr->nextpart->firstblock / blkpererase,
+                         (uintmax_t)attr->nextpart->neraseblocks,
+                         attr->nextpart->parent->name);
 #endif
 
           if (ret + total < buflen)


### PR DESCRIPTION
## Summary
This PR intends to bring one cosmetic fix to the output of `cat /proc/partitions` command when `CONFIG_MTD_PARTITION_NAMES` is selected.

## Impact
Previously:
```bash
nsh> cat /proc/partitions
Name             Start    Size   MTD
(noname)            16 256   esp32_mainflash
(noname)           272 256   esp32_mainflash
(noname)           528 64   esp32_mainflash
(noname)           592 256   esp32_mainflash
```
Fixed:
```bash
nsh> cat /proc/partitions
Name             Start    Size   MTD
(noname)            16     256   esp32_mainflash
(noname)           272     256   esp32_mainflash
(noname)           528      64   esp32_mainflash
(noname)           592     256   esp32_mainflash
```

## Testing
Tested on `esp32-wrover-kit`.
