### PR TITLE
.gitignore: Ignore *.ddc files generated during the build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 *.swp
 *.sym
 *.wsp
+*.ddc
 *~
 .depend
 /.clean_context


### PR DESCRIPTION

## Summary
These files are generated and deleted, but can be accidentally stagged if a `git add .` is performed during a build.
## Impact
N/A
## Testing
N/A
