### PR TITLE
driver/power: using upper-half structure directly in the lower-half structure.

### DIFF
--- a/drivers/power/bq2425x.c
+++ b/drivers/power/bq2425x.c
@@ -77,8 +77,7 @@ struct bq2425x_dev_s
 {
   /* The common part of the battery driver visible to the upper-half driver */
 
-  FAR const struct battery_charger_operations_s *ops; /* Battery operations */
-  sem_t batsem;                                       /* Enforce mutually exclusive access */
+  struct battery_charger_dev_s dev; /* Battery charger device */
 
   /* Data fields specific to the lower half BQ2425x driver follow */
 
@@ -788,8 +787,7 @@ FAR struct battery_charger_dev_s *
     {
       /* Initialize the BQ2425x device structure */
 
-      nxsem_init(&priv->batsem, 0, 1);
-      priv->ops       = &g_bq2425xops;
+      priv->dev.ops   = &g_bq2425xops;
       priv->i2c       = i2c;
       priv->addr      = addr;
       priv->frequency = frequency;

--- a/drivers/power/bq2429x.c
+++ b/drivers/power/bq2429x.c
@@ -117,8 +117,7 @@ struct bq2429x_dev_s
 {
   /* The common part of the battery driver visible to the upper-half driver */
 
-  FAR const struct battery_charger_operations_s *ops; /* Battery operations */
-  sem_t batsem;                                       /* Enforce mutually exclusive access */
+  struct battery_charger_dev_s dev; /* Battery charger device */
 
   /* Data fields specific to the lower half BQ2429X driver follow */
 
@@ -1260,8 +1259,7 @@ FAR struct battery_charger_dev_s *
     {
       /* Initialize the BQ2429x device structure */
 
-      nxsem_init(&priv->batsem, 0, 1);
-      priv->ops       = &g_bq2429xops;
+      priv->dev.ops   = &g_bq2429xops;
       priv->i2c       = i2c;
       priv->addr      = addr;
       priv->frequency = frequency;

--- a/drivers/power/bq27426.c
+++ b/drivers/power/bq27426.c
@@ -101,8 +101,7 @@ struct bq27426_dev_s
 {
   /* The common part of the battery driver visible to the upper-half driver */
 
-  FAR const struct battery_gauge_operations_s *ops; /* Battery operations */
-  sem_t batsem;                                     /* Enforce mutually exclusive access */
+  struct battery_gauge_dev_s dev; /* Battery gauge device */
 
   /* Data fields specific to the lower half bq27426 driver follow */
 
@@ -444,8 +443,7 @@ FAR struct battery_gauge_dev_s *bq27426_initialize(
     {
       /* Initialize the bq27426 device structure */
 
-      nxsem_init(&priv->batsem, 0, 1);
-      priv->ops       = &g_bq27426ops;
+      priv->dev.ops   = &g_bq27426ops;
       priv->i2c       = i2c;
       priv->addr      = addr;
       priv->frequency = frequency;

--- a/drivers/power/bq769x0.c
+++ b/drivers/power/bq769x0.c
@@ -94,8 +94,7 @@ struct bq769x0_dev_s
 {
   /* The common part of the battery driver visible to the upper-half driver */
 
-  FAR const struct battery_monitor_operations_s *ops; /* Battery operations */
-  sem_t batsem;                                       /* Enforce mutually exclusive access */
+  struct battery_monitor_dev_s dev; /* Battery monitor device */
 
   /* Data fields specific to the lower half BQ769x0 driver follow */
 
@@ -2096,8 +2095,7 @@ FAR struct battery_monitor_dev_s *
     {
       /* Initialize the BQ769x0 device structure */
 
-      nxsem_init(&priv->batsem, 0, 1);
-      priv->ops         = &g_bq769x0ops;
+      priv->dev.ops     = &g_bq769x0ops;
       priv->i2c         = i2c;
       priv->addr        = addr;
       priv->frequency   = frequency;

--- a/drivers/power/max1704x.c
+++ b/drivers/power/max1704x.c
@@ -162,8 +162,7 @@ struct max1704x_dev_s
 {
   /* The common part of the battery driver visible to the upper-half driver */
 
-  FAR const struct battery_gauge_operations_s *ops; /* Battery operations */
-  sem_t batsem;                                     /* Enforce mutually exclusive access */
+  struct battery_gauge_dev_s dev; /* Battery gauge device */
 
   /* Data fields specific to the lower half MAX1704x driver follow */
 
@@ -533,8 +532,7 @@ max1704x_initialize(FAR struct i2c_master_s *i2c,
     {
       /* Initialize MAX1704x device structure */
 
-      nxsem_init(&priv->batsem, 0, 1);
-      priv->ops       = &g_max1704xops;
+      priv->dev.ops   = &g_max1704xops;
       priv->i2c       = i2c;
       priv->addr      = addr;
       priv->frequency = frequency;

--- a/drivers/power/mcp73871.c
+++ b/drivers/power/mcp73871.c
@@ -73,9 +73,7 @@ struct mcp73871_dev_s
 {
   /* The common part of the battery driver visible to the upper-half driver */
 
-  FAR const struct battery_charger_operations_s *ops; /* Battery operations */
-
-  sem_t batsem;                /* Enforce mutually exclusive access */
+  struct battery_charger_dev_s dev; /* Battery charger device */
 
   /* MCP73871 configuration helpers */
 
@@ -387,9 +385,8 @@ FAR struct battery_charger_dev_s *
     {
       /* Initialize the MCP73871 device structure */
 
-      nxsem_init(&priv->batsem, 0, 1);
-      priv->ops    = &g_mcp73871ops;
-      priv->config = config;
+      priv->dev.ops = &g_mcp73871ops;
+      priv->config  = config;
 
       /* Enable the battery charge */
 


### PR DESCRIPTION

## Summary
Using upper-half structure directly in the lower-half structure.
This patch is more convenient to expand upper-half structure.

Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>

## Impact

## Testing

