### PR TITLE
wd_start: use sclock_t type replace int

### DIFF
--- a/include/nuttx/wdog.h
+++ b/include/nuttx/wdog.h
@@ -27,6 +27,7 @@
 
 #include <nuttx/config.h>
 
+#include <nuttx/clock.h>
 #include <stdint.h>
 #include <queue.h>
 
@@ -69,7 +70,7 @@ struct wdog_s
 #ifdef CONFIG_PIC
   FAR void          *picbase;    /* PIC base address */
 #endif
-  int                lag;        /* Timer associated with the delay */
+  sclock_t           lag;        /* Timer associated with the delay */
   wdparm_t           arg;        /* Callback argument */
 };
 
@@ -121,7 +122,7 @@ extern "C"
  *
  ****************************************************************************/
 
-int wd_start(FAR struct wdog_s *wdog, int32_t delay,
+int wd_start(FAR struct wdog_s *wdog, sclock_t delay,
              wdentry_t wdentry, wdparm_t arg);
 
 /****************************************************************************

--- a/sched/wdog/wd_start.c
+++ b/sched/wdog/wd_start.c
@@ -170,13 +170,13 @@ static inline void wd_expiration(void)
  *
  ****************************************************************************/
 
-int wd_start(FAR struct wdog_s *wdog, int32_t delay,
+int wd_start(FAR struct wdog_s *wdog, sclock_t delay,
              wdentry_t wdentry, wdparm_t arg)
 {
   FAR struct wdog_s *curr;
   FAR struct wdog_s *prev;
   FAR struct wdog_s *next;
-  int32_t now;
+  sclock_t now;
   irqstate_t flags;
 
   /* Verify the wdog and setup parameters */


### PR DESCRIPTION
## Summary
when enable SYSTEM_TIME64, tick may exceed the int32 range and failed to set wdog timeout.

example:
pthread_cond_clockwait
        ---->clock_abstime2ticks
                    ---->wd_start

Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>

## Impact

## Testing

