### PR TITLE
driver/sensor: support sensor_ops: selftest

### DIFF
--- a/drivers/sensors/sensor.c
+++ b/drivers/sensors/sensor.c
@@ -428,6 +428,18 @@ static int sensor_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         }
         break;
 
+      case SNIOC_SELFTEST:
+        {
+          if (lower->ops->selftest == NULL)
+            {
+              ret = -ENOTSUP;
+              break;
+            }
+
+          ret = lower->ops->selftest(lower, arg);
+        }
+        break;
+
       case SNIOC_GET_NEVENTBUF:
         {
           *val = lower->buffer_number + lower->batch_number;

--- a/include/nuttx/sensors/ioctl.h
+++ b/include/nuttx/sensors/ioctl.h
@@ -288,4 +288,13 @@
 
 #define SNIOC_GET_POSITION         _SNIOC(0x0085)
 
+/* Command:      SNIOC_SELFTEST
+ * Description:  Take a selftest for sensor.
+ * Argument:     A argument of selftest for sensor.
+ * Note:         If selftest is failed, return errno, otherwise, return OK.
+ *               This cmd is handled by sensor_ops_s::selftest.
+ */
+
+#define SNIOC_SELFTEST             _SNIOC(0x0086)
+
 #endif /* __INCLUDE_NUTTX_SENSORS_IOCTL_H */

--- a/include/nuttx/sensors/sensor.h
+++ b/include/nuttx/sensors/sensor.h
@@ -542,6 +542,28 @@ struct sensor_ops_s
                     FAR char *buffer, size_t buflen);
 
   /**************************************************************************
+   * Name: selftest
+   *
+   * Selftest allows for the testing of the mechanical and electrical
+   * portions of the sensors. When the selftest is activated, the
+   * electronics cause the sensors to be actuated and produce an output
+   * signal. The output signal is used to observe the selftest response.
+   * When the selftest response exceeds the min/max values,
+   * the part is deemed to have failed selftest.
+   *
+   * Input Parameters:
+   *   lower      - The instance of lower half sensor driver.
+   *   arg        - The parameters associated with selftest.
+   *
+   * Returned Value:
+   *   Zero (OK) on success; a negated errno value on failure.
+   *
+   **************************************************************************/
+
+  CODE int (*selftest)(FAR struct sensor_lowerhalf_s *lower,
+                        unsigned long arg);
+
+  /**************************************************************************
    * Name: control
    *
    * With this method, the user can set some special config for the sensor,


### PR DESCRIPTION


## Summary
driver/sensor: support sensor_ops: selftest
we can trigger selftest for sensor by ioctl with cmd: SNIOC_SELFTEST.

Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
## Impact
support sensor selftest
## Testing
daily test 
