### PR TITLE
net: limit NET_NACTIVESOCKETS to 4 when enable DEFAULT_SMALL

### DIFF
--- a/net/socket/Kconfig
+++ b/net/socket/Kconfig
@@ -7,7 +7,8 @@ menu "Socket Support"
 
 config NET_NACTIVESOCKETS
 	int "Max socket operations"
-	default 16
+	default 16 if !DEFAULT_SMALL
+	default 4 if DEFAULT_SMALL
 	---help---
 		Maximum number of concurrent socket operations (recv, send,
 		connection monitoring, etc.). Default: 16


### PR DESCRIPTION


## Summary
Limit NET_NACTIVESOCKETS to 4 when enable DEFAULT_SMALL to optimize code size

Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
## Impact

## Testing

