### PR TITLE
xtensa_context.S: Save and restore SCOMPARE1 when necessary.

### DIFF
--- a/arch/xtensa/include/irq.h
+++ b/arch/xtensa/include/irq.h
@@ -86,7 +86,14 @@
 #define REG_EXCCAUSE        (19)
 #define REG_EXCVADDR        (20)
 
-#define _REG_LOOPS_START    (21)
+#define _REG_EXTRA_START    (21)
+
+#if XCHAL_HAVE_S32C1I != 0
+#  define REG_SCOMPARE1       (_REG_EXTRA_START + 0)
+#  define _REG_LOOPS_START    (_REG_EXTRA_START + 1)
+#else
+#  define _REG_LOOPS_START    _REG_EXTRA_START
+#endif
 
 #if XCHAL_HAVE_LOOPS != 0
 #  define REG_LBEG          (_REG_LOOPS_START + 0)

--- a/arch/xtensa/src/common/xtensa_context.S
+++ b/arch/xtensa/src/common/xtensa_context.S
@@ -344,6 +344,11 @@ _xtensa_save_hook:
 	rsr		a3, SAR
 	s32i	a3, a2, (4 * REG_SAR)
 
+#if XCHAL_HAVE_S32C1I != 0
+	rsr		a3, SCOMPARE1
+	s32i	a3, a2, (4 * REG_SCOMPARE1)
+#endif
+
 #if XCHAL_HAVE_LOOPS != 0
 	rsr		a3, LBEG
 	s32i	a3, a2, (4 * REG_LBEG)
@@ -469,9 +474,14 @@ _xtensa_context_restore:
 #error Overly support is not implemented
 #endif
 
+#if XCHAL_HAVE_S32C1I != 0
+	l32i  a3, a2, (4 * REG_SCOMPARE1)
+	wsr   a3, SCOMPARE1
+#endif
+
 	l32i	a3, a2, (4 * REG_SAR)
-	l32i	sp, a2, (4 * REG_A1)
 	wsr		a3, SAR
+	l32i	sp, a2, (4 * REG_A1)
 	l32i	a3, a2, (4 * REG_A3)
 	l32i	a4, a2, (4 * REG_A4)
 	l32i	a5, a2, (4 * REG_A5)


### PR DESCRIPTION
## Summary
SCOMPARE1 is used by some atomic instructions and need to be preserved
during a context switch.
## Impact
This impacts Xtensa chips.  From the in-tree chips however only ESP32 supports the S32C1I instruction, so only ESP32 is affected.
## Testing
ESP32 and ESP32-S2 to confirm nothing is broken there.
