### PR TITLE
boards: risc-v: k210: Fix -march and -mabi

### DIFF
--- a/boards/risc-v/k210/maix-bit/scripts/Make.defs
+++ b/boards/risc-v/k210/maix-bit/scripts/Make.defs
@@ -41,7 +41,7 @@ ifneq ($(CONFIG_DEBUG_NOOPT),y)
   ARCHOPTIMIZATION += $(MAXOPTIMIZATION) -fno-strict-aliasing -fno-strength-reduce -fomit-frame-pointer
 endif
 
-ARCHCPUFLAGS = -march=rv64gc -mabi=lp64 -mcmodel=medany
+ARCHCPUFLAGS = -march=rv64imafc -mabi=lp64f -mcmodel=medany
 ARCHCFLAGS = -fno-builtin -ffunction-sections -fdata-sections
 ARCHCXXFLAGS = -fno-builtin -fno-exceptions -fcheck-new -fno-rtti
 ARCHWARNINGS = -Wall -Wstrict-prototypes -Wshadow -Wundef


### PR DESCRIPTION
## Summary

-march=rv64gc -mabi=lp64 does not resolve lib paths for SiFive toolchain
riscv64-unknown-elf-gcc resulting in lib not found errors.
Changing it to -march=rv64imafc -mabi=lp64f that is the default
used in Sipeed repositories.

Signed-off-by: Matheus Castello <matheus@castello.eng.br>

## Impact

To be honest I have no idea

## Testing

Tested on Sipeed Maix Dock k210 using nsh and compiling C++ application (that needs -lsupc++)
