### PR TITLE
include/nuttx/net/netconfig.h: add MSS values for usrsock

### DIFF
--- a/include/nuttx/net/netconfig.h
+++ b/include/nuttx/net/netconfig.h
@@ -272,7 +272,14 @@
 #  define TUN_UDP_MSS(h)           (CONFIG_NET_TUN_PKTSIZE - __UDP_HDRLEN - (h))
 #endif
 
+#ifdef CONFIG_NET_USRSOCK
+#  define __MIN_UDP_MSS(h)         INT_MAX
+#  define __MAX_UDP_MSS(h)         0
+#endif
+
 #ifdef CONFIG_NET_ETHERNET
+#  undef  __MIN_UDP_MSS
+#  undef  __MAX_UDP_MSS
 #  define __MIN_UDP_MSS(h)         ETH_UDP_MSS(h)
 #  define __MAX_UDP_MSS(h)         ETH_UDP_MSS(h)
 #  define __ETH_MIN_UDP_MSS(h)     ETH_UDP_MSS(h)
@@ -452,7 +459,14 @@
 #  define TUN_TCP_MSS(h)        (CONFIG_NET_TUN_PKTSIZE - __TCP_HDRLEN - (h))
 #endif
 
+#ifdef CONFIG_NET_USRSOCK
+#  define __MIN_TCP_MSS(h)         INT_MAX
+#  define __MAX_TCP_MSS(h)         0
+#endif
+
 #ifdef CONFIG_NET_ETHERNET
+#  undef  __MIN_TCP_MSS
+#  undef  __MAX_TCP_MSS
 #  define __MIN_TCP_MSS(h)         ETH_TCP_MSS(h)
 #  define __MAX_TCP_MSS(h)         ETH_TCP_MSS(h)
 #  define __ETH_MIN_TCP_MSS(h)     ETH_TCP_MSS(h)


### PR DESCRIPTION
## Summary
There is actually no way of knowing actual values supported by device/network behind usrsock interface, so use generic dummy values. This change is needed to fix compile error with TFTP client when usrsock is the only selected network link:

```
make[2]: Entering directory '/home/jni/u/nuttx/apps/netutils/tftpc'
CC:  tftpc_get.c
In file included from tftpc_get.c:39:0:
tftpc_internal.h:98:7: error: missing binary operator before token "("
 #elif MIN_UDP_MSS < TFTP_MAXPACKETSIZE
       ^
/home/jni/u/nuttx/apps/Application.mk:78: recipe for target 'tftpc_get.o' failed
```

## Impact
Minor

## Testing
Compile tested
