### PR TITLE
arch/xtensa/xtensa_cpupause.c: Allow a spin before taking the g_cpu_wait spinlock.

### DIFF
--- a/arch/xtensa/src/common/xtensa_cpupause.c
+++ b/arch/xtensa/src/common/xtensa_cpupause.c
@@ -231,10 +231,12 @@ int up_cpu_pause(int cpu)
    * handler from returning until up_cpu_resume() is called; g_cpu_paused
    * is a handshake that will prevent this function from returning until
    * the CPU is actually paused.
+   * Note that we might spin before getting g_cpu_wait, this just means that
+   * the other CPU still hasn't finished responding to the previous resume
+   * request.
    */
 
-  DEBUGASSERT(!spin_islocked(&g_cpu_wait[cpu]) &&
-              !spin_islocked(&g_cpu_paused[cpu]));
+  DEBUGASSERT(!spin_islocked(&g_cpu_paused[cpu]));
 
   spin_lock(&g_cpu_wait[cpu]);
   spin_lock(&g_cpu_paused[cpu]);


### PR DESCRIPTION
## Summary

If we repeatedly call `up_cpu_pause` and `up_cpu_resume`, there would be
cases where the next call to `up_cpu_pause` happens while the other CPU is
still responding to the previous resume request.  In this case the
`DEBUGASSERT` will trigger.  We should allow the first CPU to wait until the
other CPU has finished responding to the resume request.

## Impact
Xtensa multicore chips.

## Testing
`esp32-devkitc:wapi_smp` with other patches to come that makes it work again.
