### PR TITLE
CeDeROM add *BSD support 20211016

### DIFF
--- a/tools/configure.c
+++ b/tools/configure.c
@@ -52,6 +52,7 @@
 #define HOST_LINUX     1
 #define HOST_MACOS     2
 #define HOST_WINDOWS   3
+#define HOST_BSD       4
 
 #define WINDOWS_NATIVE 1
 #define WINDOWS_CYGWIN 2
@@ -166,7 +167,7 @@ static const char *g_optfiles[] =
 
 static void show_usage(const char *progname, int exitcode)
 {
-  fprintf(stderr, "\nUSAGE: %s  [-d] [-E] [-e] [-b|f] [-L] [-l|m|c|g|n] "
+  fprintf(stderr, "\nUSAGE: %s  [-d] [-E] [-e] [-b|f] [-L] [-l|m|c|g|n|B] "
           "[-a <app-dir>] <board-name>:<config-name> [make-opts]\n",
           progname);
   fprintf(stderr, "\nUSAGE: %s  [-h]\n", progname);
@@ -203,6 +204,7 @@ static void show_usage(const char *progname, int exitcode)
   fprintf(stderr, "    Selects the host environment.\n");
   fprintf(stderr, "    -l Selects the Linux (l) host environment.\n");
   fprintf(stderr, "    -m Selects the macOS (m) host environment.\n");
+  fprintf(stderr, "    -B Selects the *BSD (B) host environment.\n");
   fprintf(stderr, "    -c Selects the Windows Cygwin (c) environment.\n");
   fprintf(stderr, "    -g Selects the Windows MinGW/MSYS environment.\n");
   fprintf(stderr, "    -n Selects the Windows native (n) environment.\n");
@@ -266,7 +268,7 @@ static void parse_args(int argc, char **argv)
 
   /* Parse command line options */
 
-  while ((ch = getopt(argc, argv, "a:bcdEefghLlmnu")) > 0)
+  while ((ch = getopt(argc, argv, "a:bcdEefghLlmBnu")) > 0)
     {
       switch (ch)
         {
@@ -318,6 +320,10 @@ static void parse_args(int argc, char **argv)
 
           case 'm' :
             g_host = HOST_MACOS;
+            break;
+
+          case 'B' :
+            g_host = HOST_BSD;
             break;
 
           case 'n' :
@@ -1352,6 +1358,7 @@ static void set_host(const char *destconfig)
           enable_feature(destconfig, "CONFIG_HOST_LINUX");
           disable_feature(destconfig, "CONFIG_HOST_WINDOWS");
           disable_feature(destconfig, "CONFIG_HOST_MACOS");
+          disable_feature(destconfig, "CONFIG_HOST_BSD");
 
           disable_feature(destconfig, "CONFIG_WINDOWS_NATIVE");
           disable_feature(destconfig, "CONFIG_WINDOWS_CYGWIN");
@@ -1369,7 +1376,27 @@ static void set_host(const char *destconfig)
 
           disable_feature(destconfig, "CONFIG_HOST_LINUX");
           disable_feature(destconfig, "CONFIG_HOST_WINDOWS");
+          disable_feature(destconfig, "CONFIG_HOST_BSD");
           enable_feature(destconfig, "CONFIG_HOST_MACOS");
+
+          disable_feature(destconfig, "CONFIG_WINDOWS_NATIVE");
+          disable_feature(destconfig, "CONFIG_WINDOWS_CYGWIN");
+          disable_feature(destconfig, "CONFIG_WINDOWS_MSYS");
+          disable_feature(destconfig, "CONFIG_WINDOWS_OTHER");
+
+          enable_feature(destconfig, "CONFIG_SIM_X8664_SYSTEMV");
+          disable_feature(destconfig, "CONFIG_SIM_X8664_MICROSOFT");
+        }
+        break;
+
+      case HOST_BSD:
+        {
+          printf("  Select the BSD host\n");
+
+          disable_feature(destconfig, "CONFIG_HOST_LINUX");
+          disable_feature(destconfig, "CONFIG_HOST_WINDOWS");
+          disable_feature(destconfig, "CONFIG_HOST_MACOS");
+          enable_feature(destconfig, "CONFIG_HOST_BSD");
 
           disable_feature(destconfig, "CONFIG_WINDOWS_NATIVE");
           disable_feature(destconfig, "CONFIG_WINDOWS_CYGWIN");
@@ -1386,6 +1413,7 @@ static void set_host(const char *destconfig)
           enable_feature(destconfig, "CONFIG_HOST_WINDOWS");
           disable_feature(destconfig, "CONFIG_HOST_LINUX");
           disable_feature(destconfig, "CONFIG_HOST_MACOS");
+          disable_feature(destconfig, "CONFIG_HOST_BSD");
 
           disable_feature(destconfig, "CONFIG_WINDOWS_OTHER");
 

--- a/tools/configure.sh
+++ b/tools/configure.sh
@@ -21,9 +21,10 @@ set -e
 
 WD=`test -d ${0%/*} && cd ${0%/*}; pwd`
 TOPDIR="${WD}/.."
+MAKECMD="make"
 USAGE="
 
-USAGE: ${0} [-E] [-e] [-l|m|c|g|n] [L] [-a <app-dir>] <board-name>:<config-name> [make-opts]
+USAGE: ${0} [-E] [-e] [-l|m|c|g|n|B] [L] [-a <app-dir>] <board-name>:<config-name> [make-opts]
 
 Where:
   -E enforces distclean if already configured.
@@ -33,6 +34,7 @@ Where:
   -c selects the Windows host and Cygwin (c) environment.
   -g selects the Windows host and MinGW/MSYS environment.
   -n selects the Windows host and Windows native (n) environment.
+  -B selects the *BSD (B) host environment.
   Default: Use host setup in the defconfig file
   Default Windows: Cygwin
   -L  Lists all available configurations.
@@ -85,6 +87,11 @@ while [ ! -z "$1" ]; do
   -n )
     winnative=y
     host+=" $1"
+    ;;
+  -B )
+    winnative=n
+    host+=" $1"
+    MAKECMD="gmake"
     ;;
   -E )
     enforce_distclean=y
@@ -173,7 +180,7 @@ fi
 
 if [ -r ${dest_config} ]; then
   if [ "X${enforce_distclean}" = "Xy" ]; then
-    make -C ${TOPDIR} distclean
+    ${MAKECMD} -C ${TOPDIR} distclean
   else
     if cmp -s ${src_config} ${backup_config}; then
       echo "No configuration change."
@@ -181,7 +188,7 @@ if [ -r ${dest_config} ]; then
     fi
 
     if [ "X${distclean}" = "Xy" ]; then
-      make -C ${TOPDIR} distclean
+      ${MAKECMD} -C ${TOPDIR} distclean
     else
       echo "Already configured!"
       echo "Please 'make distclean' and try again."


### PR DESCRIPTION
## Summary
Initial support draft that adds support for *BSD OS for configuration scripts. Needs verification! :-)

I have chosen `-B` switch because `-b` is already taken by `tools/configure.c`. I can see that `tools/sethost.sh` can auto-detect host, maybe this is also worth implementing in `tools/configure.sh`?

## Impact
* `tools/configure.sh`
* `tools/configure.c`
* `tools/sethost.sh`

## Testing

