### PR TITLE
sched: Check g_pidhash[hash_ndx] isn't NULL before access pid field in nxsched_get_tcb

### DIFF
--- a/sched/sched/sched_gettcb.c
+++ b/sched/sched/sched_gettcb.c
@@ -56,6 +56,8 @@ FAR struct tcb_s *nxsched_get_tcb(pid_t pid)
   irqstate_t flags;
   int hash_ndx;
 
+  flags = enter_critical_section();
+
   /* Verify whether g_pidhash hash table has already been allocated and
    * whether the PID is within range.
    */
@@ -68,23 +70,21 @@ FAR struct tcb_s *nxsched_get_tcb(pid_t pid)
        * terminating asynchronously.
        */
 
-      flags = enter_critical_section();
-
       /* Get the hash_ndx associated with the pid */
 
       hash_ndx = PIDHASH(pid);
 
       /* Verify that the correct TCB was found. */
 
-      if (g_pidhash && pid == g_pidhash[hash_ndx]->pid)
+      if (g_pidhash[hash_ndx] != NULL && pid == g_pidhash[hash_ndx]->pid)
         {
           /* Return the TCB associated with this pid (if any) */
 
           ret = g_pidhash[hash_ndx];
         }
-
-      leave_critical_section(flags);
     }
+
+  leave_critical_section(flags);
 
   /* Return the TCB. */
 


### PR DESCRIPTION
## Summary
Fix the regression by commit:
```
commit 8b67944c75b81d17174bd207ad63acfa22da8983
Author: Xiang Xiao <xiaoxiang@xiaomi.com>
Date:   Thu Oct 14 11:03:07 2021 +0800

    sched: Remove pidhash_s and move ticks to tcb_s

    simplify the code logic and reduce memory a little bit

    Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>
```
Report here: https://github.com/apache/incubator-nuttx/pull/4666

## Impact
Fix the crash in SMP ostest

## Testing
maix-bit:smp
