### PR TITLE
cpuload: fix crash because of the member of g_pidhash is NULL

### DIFF
--- a/sched/sched/sched_cpuload.c
+++ b/sched/sched/sched_cpuload.c
@@ -184,8 +184,11 @@ void weak_function nxsched_process_cpuload(void)
 
       for (i = 0; i < g_npidhash; i++)
         {
-          g_pidhash[i]->ticks >>= 1;
-          total += g_pidhash[i]->ticks;
+          if (g_pidhash[i])
+            {
+              g_pidhash[i]->ticks >>= 1;
+              total += g_pidhash[i]->ticks;
+            }
         }
 
       /* Save the new total. */


### PR DESCRIPTION


## Summary
cpuload: fix crash because of the member of g_pidhash is NULL

This patch is associated with  PR https://github.com/apache/incubator-nuttx/pull/4666
Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>

## Impact

## Testing
local test
