### PR TITLE
arch:xtens:mpu: modify acc and memtype to uint32_t

### DIFF
--- a/arch/xtensa/src/common/mpu.h
+++ b/arch/xtensa/src/common/mpu.h
@@ -210,7 +210,7 @@ void mpu_control(bool enable);
  ****************************************************************************/
 
 void mpu_configure_region(uintptr_t base, size_t size,
-            uint8_t acc, uint16_t memtype);
+                          uint32_t acc, uint32_t memtype);
 
 /****************************************************************************
  * Name: mpu_priv_stronglyordered

--- a/arch/xtensa/src/common/xtensa_mpu.c
+++ b/arch/xtensa/src/common/xtensa_mpu.c
@@ -94,7 +94,7 @@ void mpu_control(bool enable)
  ****************************************************************************/
 
 void mpu_configure_region(uintptr_t base, size_t size,
-            uint8_t acc, uint16_t memtype)
+                          uint32_t acc, uint32_t memtype)
 {
   unsigned int region = mpu_allocregion();
   uint32_t at;


### PR DESCRIPTION
The type uint8_t and  type uint16_t will overflow in `MPU_ENTRY_AR`  marco.

Change-Id: I2f660c13740fea725a076f7f208214aedc5ca0ee

## Summary

## Impact

## Testing
testing pass in xtensa with mpu enable
