### PR TITLE
add include battery_ioctl.h

### DIFF
--- a/drivers/power/axp202.c
+++ b/drivers/power/axp202.c
@@ -32,6 +32,7 @@
 #include <nuttx/kmalloc.h>
 #include <nuttx/i2c/i2c_master.h>
 #include <nuttx/power/battery_charger.h>
+#include <nuttx/power/battery_ioctl.h>
 #include <nuttx/power/axp202.h>
 
 #if defined(CONFIG_I2C) && defined(CONFIG_I2C_AXP202)


### PR DESCRIPTION
## Summary
  add battery_ioctl.h for axp202.c because of 77bc1d1bdfd1312270d3b4f556bbe08cfb151c27

## Impact
  
## Testing
  compile ok
