### PR TITLE
arch/xtensa/Kconfig: add quotes in source to clean warnings from setconfig

### DIFF
--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -214,7 +214,7 @@ config XTENSA_TOOLCHAIN_ESP
 
 endchoice
 
-source arch/xtensa/src/lx6/Kconfig
+source "arch/xtensa/src/lx6/Kconfig"
 if ARCH_CHIP_ESP32
 source "arch/xtensa/src/esp32/Kconfig"
 endif


### PR DESCRIPTION
## Summary

## Impact
Minor change

## Testing

