### PR TITLE
ioexpander/gpio: Remove the hardcode 100 limitation

### DIFF
--- a/drivers/ioexpander/gpio.c
+++ b/drivers/ioexpander/gpio.c
@@ -524,11 +524,10 @@ static int gpio_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 int gpio_pin_register(FAR struct gpio_dev_s *dev, int minor)
 {
   FAR const char *fmt;
-  char devname[16];
+  char devname[32];
   int ret;
 
-  DEBUGASSERT(dev != NULL && dev->gp_ops != NULL &&
-              (unsigned int)minor < 100);
+  DEBUGASSERT(dev != NULL && dev->gp_ops != NULL);
 
   switch (dev->gp_pintype)
     {
@@ -619,7 +618,7 @@ void gpio_pin_unregister(FAR struct gpio_dev_s *dev, int minor)
         break;
     }
 
-  snprintf(devname, 16, fmt, (unsigned int)minor);
+  snprintf(devname, sizeof(devname), fmt, (unsigned int)minor);
   gpioinfo("Unregistering %s\n", devname);
 
   unregister_driver(devname);


### PR DESCRIPTION
## Summary
it's very easy to have more than 100 GPIOs on the modern SoC

## Impact
Relax the gpio number limitation.

## Testing

