### PR TITLE
fix: charger: change the operations of battery ioctl to common

### DIFF
--- a/include/nuttx/power/battery_ioctl.h
+++ b/include/nuttx/power/battery_ioctl.h
@@ -120,7 +120,6 @@ struct batio_operate_msg_s
   };
 };
 
-#if defined(CONFIG_I2C_BQ2429X)
 enum batio_operate_e
 {
   BATIO_OPRTN_NOP = 0,
@@ -134,6 +133,5 @@ enum batio_operate_e
   BATIO_OPRTN_WDOG,
   BATIO_OPRTN_END
 };
-#endif
 
 #endif /* __INCLUDE_NUTTX_POWER_BATTERY_IOCTL_H */


### PR DESCRIPTION
Almost all charger chip need the same oprations, which was not
appropriate only for BQ2429X. Therefore, open the operations to
all charger chips.

Signed-off-by: zhangguoliang <zhangguoliang3@xiaomi.com>

## Summary

## Impact

## Testing

