### PR TITLE
sim/bluetooth: remove the WIRELESS_BLUETOOTH depends if native host is in use

### DIFF
--- a/arch/sim/Kconfig
+++ b/arch/sim/Kconfig
@@ -525,7 +525,7 @@ config SIM_QSPIFLASH_PAGESIZE
 config SIM_HCISOCKET
 	bool "Attach Host Bluetooth"
 	default false
-	depends on (WIRELESS_BLUETOOTH && HOST_LINUX)
+	depends on HOST_LINUX
 	---help---
 		Attached the local bluetooth device to the simulation
 		target via HCI_CHANNEL_USER. This gives NuttX full


### PR DESCRIPTION
## Summary

sim/bluetooth: remove the WIRELESS_BLUETOOTH depends if native host is in use

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

N/A

## Testing

./tools/configure.sh  sim/bthcisock
./tools/configure.sh  sim/bthcisock