### PR TITLE
imxrt rename imxrt_lowputc to arm_lowputc and drop CONFIG_DEBUG_FEATURES

### DIFF
--- a/arch/arm/src/imxrt/imxrt_lowputc.c
+++ b/arch/arm/src/imxrt/imxrt_lowputc.c
@@ -567,9 +567,10 @@ int imxrt_lpuart_configure(uint32_t base,
  *
  ****************************************************************************/
 
-#if defined(HAVE_LPUART_DEVICE) && defined(CONFIG_DEBUG_FEATURES)
+#if defined(HAVE_LPUART_DEVICE)
 void imxrt_lowputc(int ch)
 {
+#ifdef HAVE_LPUART_CONSOLE
   while ((getreg32(IMXRT_CONSOLE_BASE + IMXRT_LPUART_STAT_OFFSET) &
          LPUART_STAT_TDRE) == 0)
     {
@@ -599,5 +600,6 @@ void imxrt_lowputc(int ch)
   /* Send the character by writing it into the UART_TXD register. */
 
   putreg32((uint32_t)ch, IMXRT_CONSOLE_BASE + IMXRT_LPUART_DATA_OFFSET);
+#endif
 }
 #endif

--- a/arch/arm/src/imxrt/imxrt_lowputc.h
+++ b/arch/arm/src/imxrt/imxrt_lowputc.h
@@ -96,7 +96,7 @@ int imxrt_lpuart_configure(uint32_t base,
  *
  ****************************************************************************/
 
-#if defined(HAVE_LPUART_DEVICE) && defined(CONFIG_DEBUG_FEATURES)
+#if defined(HAVE_LPUART_DEVICE)
 void imxrt_lowputc(int ch);
 #else
 #  define imxrt_lowputc(ch)


### PR DESCRIPTION
## Summary

Changes from imxrt_lowputc to arm_lowputc were incomplete.

syslog needs up_putc to to call arm_lowputc  not dependent on CONFIG_DEBUG_FEATURES

## Impact

master has no console output on hardfault

## Testing

px4 nxp_fmurt1062-v1
