### PR TITLE
fs: mqueue: Change MAX_MQUEUE_PATH to 64

### DIFF
--- a/fs/mqueue/mq_open.c
+++ b/fs/mqueue/mq_open.c
@@ -177,7 +177,8 @@ static int file_mq_vopen(FAR struct file *mq, FAR const char *mq_name,
       goto errout;
     }
 
-  if (strlen(mq_name) > NAME_MAX)
+  if (sizeof(CONFIG_FS_MQUEUE_MPATH) + 1 + strlen(mq_name)
+      >= MAX_MQUEUE_PATH)
     {
       ret = -ENAMETOOLONG;
       goto errout;

--- a/fs/mqueue/mqueue.h
+++ b/fs/mqueue/mqueue.h
@@ -39,6 +39,6 @@
 
 /* Sizes of things */
 
-#define MAX_MQUEUE_PATH (sizeof(CONFIG_FS_MQUEUE_MPATH) + NAME_MAX)
+#define MAX_MQUEUE_PATH 64
 
 #endif /* __FS_MQUEUE_MQUEUE_H */


### PR DESCRIPTION
## Summary

- This commit changes MAX_MQUEUE_PATH to 64 to reduce stack
  memory if the NAME_MAX is large

## Impact

- None

## Testing

- Tested with spresense:rndis_smp
