### PR TITLE
libc: Remove LIBC_MAX_TMPFILE from Kconfig

### DIFF
--- a/include/stdio.h
+++ b/include/stdio.h
@@ -76,11 +76,7 @@
 
 /* Maximum size of character array to hold tmpnam() output. */
 
-#ifndef CONFIG_LIBC_MAX_TMPFILE
-#  define CONFIG_LIBC_MAX_TMPFILE 32
-#endif
-
-#define L_tmpnam   CONFIG_LIBC_MAX_TMPFILE
+#define L_tmpnam   _POSIX_NAME_MAX
 
 /* The maximum number of unique temporary file names that can be generated */
 

--- a/libs/libc/stdlib/Kconfig
+++ b/libs/libc/stdlib/Kconfig
@@ -29,14 +29,4 @@ config LIBC_TMPDIR
 		files can be created.  This would be a good application of RAM disk:
 		To provide temporary storage for application data.
 
-config LIBC_MAX_TMPFILE
-	int "Maximum size of a temporary file path"
-	default 32
-		---help---
-		If a write-able file system is selected, then temporary file may be
-		supported at the path provided by LIBC_TMPDIR.  The tmpnam() interface
-		keeps a static copy of this last filename produced; this value is the
-		maximum size of that last filename.  This size is the size of the full
-		file path.
-
 endmenu # stdlib Options


### PR DESCRIPTION
## Summary
use _POSIX_NAME_MAX instead to avoid the inconsistent setting

## Impact

## Testing

