### PR TITLE
Improve the netdb config consistency

### DIFF
--- a/libs/libc/netdb/Kconfig
+++ b/libs/libc/netdb/Kconfig
@@ -83,7 +83,7 @@ config NETDB_DNSCLIENT_ENTRIES
 
 config NETDB_DNSCLIENT_NAMESIZE
 	int "Max size of a cached hostname"
-	default 32
+	default NAME_MAX
 	---help---
 		The size of a hostname string in the DNS resolver cache is fixed.
 		This setting provides the maximum size of a hostname.  Names longer


### PR DESCRIPTION
## Summary

- libc/netdb: Change default of NETDB_DNSCLIENT_MAXRESPONSE to NETDB_BUFSIZE
- lib/netdb: Change the default NETDB_DNSCLIENT_NAMESIZE to PATH_MAX

## Impact

## Testing

