### PR TITLE
[BACKPORT-4722]mqueue: fix memory leak cause by lost inode_release

### DIFF
--- a/fs/mqueue/mq_unlink.c
+++ b/fs/mqueue/mq_unlink.c
@@ -64,6 +64,8 @@ static void mq_inode_release(FAR struct inode *inode)
           nxmq_free_msgq(msgq);
           inode->i_private = NULL;
         }
+
+      inode_release(inode);
     }
 }
 


### PR DESCRIPTION
## Summary
Backport #4722

