### PR TITLE
fix: nxstyle: fix a bug after "'x'"

### DIFF
--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -2270,7 +2270,7 @@ int main(int argc, char **argv, char **envp)
                                  endndx++);
                           }
 
-                        n = endndx + 1;
+                        n = endndx;
                       }
                   }
                   break;


### PR DESCRIPTION
## Summary
When nxstyle.c detects a '\'', it seeks the other '\'', records the index as "endndx", then skip the "'x'" (x is any character). Then it makes the index "n" as "endndx+1". After the case of '\'', it comes to the "n++" in "for()", thus the character after "'x'" is skipped. This may bring errors. 
This patch fixed the bug mentioned above.

Signed-off-by: liucheng5 <liucheng5@xiaomi.com>

## Impact
./tools/checkpatch.sh

## Testing
For example, for the code below:

0 static struct option g_options[] =
1 {
2   {"aa", no_argument, NULL, 'i'},
3   {"bb", no_argument, NULL, 's'},
4   {"cc", no_argument, NULL, 'd'},
5   {"dd", no_argument, NULL, 'r'},
6   {"ee", no_argument, NULL, 'p'},
7 };
8

I add some "INFO" in nxstyle.c to track the n(record the character index) and bnest(brace nesting level).  
For origin nxstyle.c, the procession is:
When it comes to '{' in line 2, the bnest becomes 2. 
When it comes to '\'' in line 2, n=28, endndx=30
When it exits the case of '\'' in line 2, n=endndx+1=31 (line[31] is '}')
When it comes to "for (; line[n] != '\n' && line[n] != '\0'; n++)", line[31]=='{', so n=32. Thus line[31] is skipped.
...
When it comes to line 7 and exit the case '}', the bnest is 5, which should be 0. This will cause errors such as "No indentation line" in code below.

After modified to "n=endndx", the procession is:
When it comes to '{' in line 2, the bnest becomes 2. 
When it comes to '\'' in line 2, n=28, endndx=30
When it exits the case of '\'' in line 2, n=endndx=30 (line[30] is '\'')
When it comes to "for (; line[n] != '\n' && line[n] != '\0'; n++)", line[30]=='\'', so n=31.
When it comes to line[31] (i.e. '}'), the bnest becomes 1.
...
When it comes to line 7 and exit the case '}', the bnest is 0, which is correct.
