### PR TITLE
Revert "lib/netdb: Change the default NETDB_DNSCLIENT_NAMESIZE to NAM…

### DIFF
--- a/libs/libc/netdb/Kconfig
+++ b/libs/libc/netdb/Kconfig
@@ -83,7 +83,7 @@ config NETDB_DNSCLIENT_ENTRIES
 
 config NETDB_DNSCLIENT_NAMESIZE
 	int "Max size of a cached hostname"
-	default NAME_MAX
+	default 32
 	---help---
 		The size of a hostname string in the DNS resolver cache is fixed.
 		This setting provides the maximum size of a hostname.  Names longer


### PR DESCRIPTION
…E_MAX"

## Summary

This reverts commit 3724f6be557525a550f35fe2942f10c1d06f27c2.

Because there is no real correlation between DNS namesize and NAME_MAX
as far as I know. The former is about network and the latter is about
filesystem. While they might happen to be similar values for
some configurations, it's very confusing to use them this way.

## Impact

## Testing

