### PR TITLE
inline: switch from inline to inline_function

### DIFF
--- a/arch/arm/include/armv6-m/irq.h
+++ b/arch/arm/include/armv6-m/irq.h
@@ -219,8 +219,7 @@ struct xcptcontext
 
 /* Get/set the PRIMASK register */
 
-static inline uint8_t getprimask(void) inline_function;
-static inline uint8_t getprimask(void)
+inline_function static uint8_t getprimask(void)
 {
   uint32_t primask;
   __asm__ __volatile__
@@ -233,8 +232,7 @@ static inline uint8_t getprimask(void)
   return (uint8_t)primask;
 }
 
-static inline void setprimask(uint32_t primask) inline_function;
-static inline void setprimask(uint32_t primask)
+inline_function static void setprimask(uint32_t primask)
 {
   __asm__ __volatile__
     (
@@ -246,16 +244,14 @@ static inline void setprimask(uint32_t primask)
 
 /* Disable IRQs */
 
-static inline void up_irq_disable(void) inline_function;
-static inline void up_irq_disable(void)
+inline_function static void up_irq_disable(void)
 {
   __asm__ __volatile__ ("\tcpsid  i\n");
 }
 
 /* Save the current primask state & disable IRQs */
 
-static inline irqstate_t up_irq_save(void) inline_function;
-static inline irqstate_t up_irq_save(void)
+inline_function static irqstate_t up_irq_save(void)
 {
   unsigned short primask;
 
@@ -276,16 +272,14 @@ static inline irqstate_t up_irq_save(void)
 
 /* Enable IRQs */
 
-static inline void up_irq_enable(void) inline_function;
-static inline void up_irq_enable(void)
+inline_function static void up_irq_enable(void)
 {
   __asm__ __volatile__ ("\tcpsie  i\n");
 }
 
 /* Restore saved primask state */
 
-static inline void up_irq_restore(irqstate_t flags) inline_function;
-static inline void up_irq_restore(irqstate_t flags)
+inline_function static void up_irq_restore(irqstate_t flags)
 {
   /* If bit 0 of the primask is 0, then we need to restore
    * interrupts.
@@ -301,8 +295,7 @@ static inline void up_irq_restore(irqstate_t flags)
 
 /* Get/set IPSR */
 
-static inline uint32_t getipsr(void) inline_function;
-static inline uint32_t getipsr(void)
+inline_function static uint32_t getipsr(void)
 {
   uint32_t ipsr;
   __asm__ __volatile__
@@ -317,8 +310,7 @@ static inline uint32_t getipsr(void)
 
 /* Get/set CONTROL */
 
-static inline uint32_t getcontrol(void) inline_function;
-static inline uint32_t getcontrol(void)
+inline_function static uint32_t getcontrol(void)
 {
   uint32_t control;
   __asm__ __volatile__
@@ -331,8 +323,7 @@ static inline uint32_t getcontrol(void)
   return control;
 }
 
-static inline void setcontrol(uint32_t control) inline_function;
-static inline void setcontrol(uint32_t control)
+inline_function static void setcontrol(uint32_t control)
 {
   __asm__ __volatile__
     (

--- a/arch/arm/include/armv7-m/irq.h
+++ b/arch/arm/include/armv7-m/irq.h
@@ -180,8 +180,7 @@ struct xcptcontext
 
 /* Get/set the PRIMASK register */
 
-static inline uint8_t getprimask(void) inline_function;
-static inline uint8_t getprimask(void)
+inline_function static uint8_t getprimask(void)
 {
   uint32_t primask;
   __asm__ __volatile__
@@ -194,8 +193,7 @@ static inline uint8_t getprimask(void)
   return (uint8_t)primask;
 }
 
-static inline void setprimask(uint32_t primask) inline_function;
-static inline void setprimask(uint32_t primask)
+inline_function static void setprimask(uint32_t primask)
 {
   __asm__ __volatile__
     (
@@ -205,14 +203,12 @@ static inline void setprimask(uint32_t primask)
       : "memory");
 }
 
-static inline void cpsie(void) inline_function;
-static inline void cpsie(void)
+inline_function static void cpsie(void)
 {
   __asm__ __volatile__ ("\tcpsie  i\n");
 }
 
-static inline void cpsid(void) inline_function;
-static inline void cpsid(void)
+inline_function static void cpsid(void)
 {
   __asm__ __volatile__ ("\tcpsid  i\n");
 }
@@ -223,8 +219,7 @@ static inline void cpsid(void)
  * lower priority level as the BASEPRI value.
  */
 
-static inline uint8_t getbasepri(void) inline_function;
-static inline uint8_t getbasepri(void)
+inline_function static uint8_t getbasepri(void)
 {
   uint32_t basepri;
 
@@ -238,8 +233,7 @@ static inline uint8_t getbasepri(void)
   return (uint8_t)basepri;
 }
 
-static inline void setbasepri(uint32_t basepri) inline_function;
-static inline void setbasepri(uint32_t basepri)
+inline_function static void setbasepri(uint32_t basepri)
 {
   __asm__ __volatile__
     (
@@ -256,8 +250,7 @@ static inline void setbasepri(uint32_t basepri)
  * 837070 Workaround may be required if we are raising the priority.
  */
 
-static inline void raisebasepri(uint32_t basepri) inline_function;
-static inline void raisebasepri(uint32_t basepri)
+inline_function static void raisebasepri(uint32_t basepri)
 {
   register uint32_t primask;
 
@@ -287,8 +280,7 @@ static inline void raisebasepri(uint32_t basepri)
 
 /* Disable IRQs */
 
-static inline void up_irq_disable(void) inline_function;
-static inline void up_irq_disable(void)
+inline_function static void up_irq_disable(void)
 {
 #ifdef CONFIG_ARMV7M_USEBASEPRI
   /* Probably raising priority */
@@ -301,8 +293,7 @@ static inline void up_irq_disable(void)
 
 /* Save the current primask state & disable IRQs */
 
-static inline irqstate_t up_irq_save(void) inline_function;
-static inline irqstate_t up_irq_save(void)
+inline_function static irqstate_t up_irq_save(void)
 {
 #ifdef CONFIG_ARMV7M_USEBASEPRI
   /* Probably raising priority */
@@ -333,8 +324,7 @@ static inline irqstate_t up_irq_save(void)
 
 /* Enable IRQs */
 
-static inline void up_irq_enable(void) inline_function;
-static inline void up_irq_enable(void)
+inline_function static void up_irq_enable(void)
 {
   /* In this case, we are always retaining or lowering the priority value */
 
@@ -344,8 +334,7 @@ static inline void up_irq_enable(void)
 
 /* Restore saved primask state */
 
-static inline void up_irq_restore(irqstate_t flags) inline_function;
-static inline void up_irq_restore(irqstate_t flags)
+inline_function static void up_irq_restore(irqstate_t flags)
 {
 #ifdef CONFIG_ARMV7M_USEBASEPRI
   /* In this case, we are always retaining or lowering the priority value */
@@ -372,8 +361,7 @@ static inline void up_irq_restore(irqstate_t flags)
 
 /* Get/set IPSR */
 
-static inline uint32_t getipsr(void) inline_function;
-static inline uint32_t getipsr(void)
+inline_function static uint32_t getipsr(void)
 {
   uint32_t ipsr;
   __asm__ __volatile__
@@ -388,8 +376,7 @@ static inline uint32_t getipsr(void)
 
 /* Get/set CONTROL */
 
-static inline uint32_t getcontrol(void) inline_function;
-static inline uint32_t getcontrol(void)
+inline_function static uint32_t getcontrol(void)
 {
   uint32_t control;
   __asm__ __volatile__
@@ -402,8 +389,7 @@ static inline uint32_t getcontrol(void)
   return control;
 }
 
-static inline void setcontrol(uint32_t control) inline_function;
-static inline void setcontrol(uint32_t control)
+inline_function static void setcontrol(uint32_t control)
 {
   __asm__ __volatile__
     (

--- a/arch/arm/include/armv8-m/irq.h
+++ b/arch/arm/include/armv8-m/irq.h
@@ -185,8 +185,7 @@ struct xcptcontext
 
 /* Get/set the PRIMASK register */
 
-static inline uint8_t getprimask(void) inline_function;
-static inline uint8_t getprimask(void)
+inline_function static uint8_t getprimask(void)
 {
   uint32_t primask;
   __asm__ __volatile__
@@ -199,8 +198,7 @@ static inline uint8_t getprimask(void)
   return (uint8_t)primask;
 }
 
-static inline void setprimask(uint32_t primask) inline_function;
-static inline void setprimask(uint32_t primask)
+inline_function static void setprimask(uint32_t primask)
 {
   __asm__ __volatile__
     (
@@ -210,14 +208,12 @@ static inline void setprimask(uint32_t primask)
       : "memory");
 }
 
-static inline void cpsie(void) inline_function;
-static inline void cpsie(void)
+inline_function static void cpsie(void)
 {
   __asm__ __volatile__ ("\tcpsie  i\n");
 }
 
-static inline void cpsid(void) inline_function;
-static inline void cpsid(void)
+inline_function static void cpsid(void)
 {
   __asm__ __volatile__ ("\tcpsid  i\n");
 }
@@ -228,8 +224,7 @@ static inline void cpsid(void)
  * lower priority level as the BASEPRI value.
  */
 
-static inline uint8_t getbasepri(void) inline_function;
-static inline uint8_t getbasepri(void)
+inline_function static uint8_t getbasepri(void)
 {
   uint32_t basepri;
 
@@ -243,8 +238,7 @@ static inline uint8_t getbasepri(void)
   return (uint8_t)basepri;
 }
 
-static inline void setbasepri(uint32_t basepri) inline_function;
-static inline void setbasepri(uint32_t basepri)
+inline_function static void setbasepri(uint32_t basepri)
 {
   __asm__ __volatile__
     (
@@ -258,8 +252,7 @@ static inline void setbasepri(uint32_t basepri)
 
 /* Disable IRQs */
 
-static inline void up_irq_disable(void) inline_function;
-static inline void up_irq_disable(void)
+inline_function static void up_irq_disable(void)
 {
 #ifdef CONFIG_ARMV8M_USEBASEPRI
   /* Probably raising priority */
@@ -272,8 +265,7 @@ static inline void up_irq_disable(void)
 
 /* Save the current primask state & disable IRQs */
 
-static inline irqstate_t up_irq_save(void) inline_function;
-static inline irqstate_t up_irq_save(void)
+inline_function static irqstate_t up_irq_save(void)
 {
 #ifdef CONFIG_ARMV8M_USEBASEPRI
   /* Probably raising priority */
@@ -304,8 +296,7 @@ static inline irqstate_t up_irq_save(void)
 
 /* Enable IRQs */
 
-static inline void up_irq_enable(void) inline_function;
-static inline void up_irq_enable(void)
+inline_function static void up_irq_enable(void)
 {
   /* In this case, we are always retaining or lowering the priority value */
 
@@ -315,8 +306,7 @@ static inline void up_irq_enable(void)
 
 /* Restore saved primask state */
 
-static inline void up_irq_restore(irqstate_t flags) inline_function;
-static inline void up_irq_restore(irqstate_t flags)
+inline_function static void up_irq_restore(irqstate_t flags)
 {
 #ifdef CONFIG_ARMV8M_USEBASEPRI
   /* In this case, we are always retaining or lowering the priority value */
@@ -343,8 +333,7 @@ static inline void up_irq_restore(irqstate_t flags)
 
 /* Get/set IPSR */
 
-static inline uint32_t getipsr(void) inline_function;
-static inline uint32_t getipsr(void)
+inline_function static uint32_t getipsr(void)
 {
   uint32_t ipsr;
   __asm__ __volatile__
@@ -359,8 +348,7 @@ static inline uint32_t getipsr(void)
 
 /* Get/set CONTROL */
 
-static inline uint32_t getcontrol(void) inline_function;
-static inline uint32_t getcontrol(void)
+inline_function static uint32_t getcontrol(void)
 {
   uint32_t control;
   __asm__ __volatile__
@@ -373,8 +361,7 @@ static inline uint32_t getcontrol(void)
   return control;
 }
 
-static inline void setcontrol(uint32_t control) inline_function;
-static inline void setcontrol(uint32_t control)
+inline_function static void setcontrol(uint32_t control)
 {
   __asm__ __volatile__
     (

--- a/arch/arm/src/phy62xx/phy6222_irq.h
+++ b/arch/arm/src/phy62xx/phy6222_irq.h
@@ -215,8 +215,7 @@ struct xcptcontext
 
 /* Get/set the PRIMASK register */
 
-static inline uint8_t getprimask(void) inline_function;
-static inline uint8_t getprimask(void)
+inline_function static uint8_t getprimask(void)
 {
   uint32_t primask;
   __asm__ __volatile__
@@ -229,8 +228,7 @@ static inline uint8_t getprimask(void)
   return (uint8_t)primask;
 }
 
-static inline void setprimask(uint32_t primask) inline_function;
-static inline void setprimask(uint32_t primask)
+inline_function static void setprimask(uint32_t primask)
 {
   __asm__ __volatile__
     (
@@ -242,8 +240,7 @@ static inline void setprimask(uint32_t primask)
 
 /* Disable IRQs */
 
-static inline void up_irq_disable(void) inline_function;
-static inline void up_irq_disable(void)
+inline_function static void up_irq_disable(void)
 {
   __asm__ __volatile__ ("\tcpsid  i\n");
 }
@@ -252,8 +249,7 @@ static inline void up_irq_disable(void)
 
 typedef void (*gpiowr_t)(int id, unsigned int en);
 #if 0
-static inline irqstate_t up_irq_save(void) inline_function;
-static inline irqstate_t up_irq_save(void)
+inline_function static irqstate_t up_irq_save(void)
 {
   unsigned short primask;
 
@@ -276,16 +272,14 @@ static inline irqstate_t up_irq_save(void)
 #endif
 /* Enable IRQs */
 
-static inline void up_irq_enable(void) inline_function;
-static inline void up_irq_enable(void)
+inline_function static void up_irq_enable(void)
 {
   __asm__ __volatile__ ("\tcpsie  i\n");
 }
 
 /* Restore saved primask state */
 #if 0
-static inline void up_irq_restore(irqstate_t flags) inline_function;
-static inline void up_irq_restore(irqstate_t flags)
+inline_function static void up_irq_restore(irqstate_t flags)
 {
   /* If bit 0 of the primask is 0, then we need to restore
    * interrupts.
@@ -302,8 +296,7 @@ static inline void up_irq_restore(irqstate_t flags)
 #endif
 /* Get/set IPSR */
 
-static inline uint32_t getipsr(void) inline_function;
-static inline uint32_t getipsr(void)
+inline_function static uint32_t getipsr(void)
 {
   uint32_t ipsr;
   __asm__ __volatile__
@@ -318,8 +311,7 @@ static inline uint32_t getipsr(void)
 
 /* Get/set CONTROL */
 
-static inline uint32_t getcontrol(void) inline_function;
-static inline uint32_t getcontrol(void)
+inline_function static uint32_t getcontrol(void)
 {
   uint32_t control;
   __asm__ __volatile__
@@ -332,8 +324,7 @@ static inline uint32_t getcontrol(void)
   return control;
 }
 
-static inline void setcontrol(uint32_t control) inline_function;
-static inline void setcontrol(uint32_t control)
+inline_function static void setcontrol(uint32_t control)
 {
   __asm__ __volatile__
     (

--- a/drivers/serial/uart_bth4.c
+++ b/drivers/serial/uart_bth4.c
@@ -84,7 +84,7 @@ static int     uart_bth4_poll (FAR struct file *filep,
 static const struct file_operations g_uart_bth4_ops =
 {
   uart_bth4_open,   /* open */
-  uart_bth4_close,  /* cose */
+  uart_bth4_close,  /* close */
   uart_bth4_read,   /* read */
   uart_bth4_write,  /* write */
   NULL,             /* seek */

--- a/drivers/usbmisc/fusb303.c
+++ b/drivers/usbmisc/fusb303.c
@@ -296,7 +296,7 @@ static int fusb303_putreg(FAR struct fusb303_dev_s *priv, uint8_t regaddr,
  ****************************************************************************/
 
 #ifdef CONFIG_DEBUG_FUSB303
-static int noinline_function fusb303_dumpregs(FAR const char *funcname,
+noinline_function static int fusb303_dumpregs(FAR const char *funcname,
                                               FAR struct fusb303_dev_s *priv)
 {
   fusb303_info("'%s':\n", funcname);

--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -124,15 +124,15 @@
 
 /* Code locate */
 
-#  define locate_code(n) __attribute__ ((section(n)))
+#  define locate_code(n) __attribute__ ((section (n)))
 
 /* Data alignment */
 
-#  define aligned_data(n) __attribute__ ((aligned(n)))
+#  define aligned_data(n) __attribute__ ((aligned (n)))
 
 /* Data location */
 
-#  define locate_data(n) __attribute__ ((section(n)))
+#  define locate_data(n) __attribute__ ((section (n)))
 
 /* The packed attribute informs GCC that the structure elements are packed,
  * ignoring other alignment rules.
@@ -149,14 +149,14 @@
  * the function prolog and epilog.
  */
 
-#  define naked_function __attribute__ ((naked,no_instrument_function))
+#  define naked_function __attribute__ ((naked, no_instrument_function))
 
 /* The inline_function attribute informs GCC that the function should always
  * be inlined, regardless of the level of optimization.  The
  * noinline_function indicates that the function should never be inlined.
  */
 
-#  define inline_function __attribute__ ((always_inline,no_instrument_function))
+#  define inline_function __attribute__ ((always_inline, no_instrument_function)) inline
 #  define noinline_function __attribute__ ((noinline))
 
 /* The noinstrument_function attribute informs GCC don't instrument it */
@@ -182,14 +182,14 @@
 #  if defined(__clang__)
 #    define nostackprotect_function __attribute__ ((optnone))
 #  else
-#    define nostackprotect_function __attribute__ ((__optimize__ ("-fno-stack-protector")))
+#    define nostackprotect_function __attribute__ ((optimize ("-fno-stack-protector")))
 #  endif
 #endif
 
-/* The unsued code or data */
+/* The unused code or data */
 
-#  define unused_code __attribute__((unused))
-#  define unused_data __attribute__((unused))
+#  define unused_code __attribute__ ((unused))
+#  define unused_data __attribute__ ((unused))
 
 /* Some versions of GCC have a separate __syslog__ format.
  * http://mail-index.netbsd.org/source-changes/2015/10/14/msg069435.html
@@ -200,11 +200,11 @@
 #    define __syslog__ __printf__
 #  endif
 
-#  define formatlike(a) __attribute__((__format_arg__ (a)))
-#  define printflike(a, b) __attribute__((__format__ (__printf__, a, b)))
-#  define sysloglike(a, b) __attribute__((__format__ (__syslog__, a, b)))
-#  define scanflike(a, b) __attribute__((__format__ (__scanf__, a, b)))
-#  define strftimelike(a) __attribute__((__format__ (__strftime__, a, 0)))
+#  define formatlike(a) __attribute__ ((__format_arg__ (a)))
+#  define printflike(a, b) __attribute__ ((__format__ (__printf__, a, b)))
+#  define sysloglike(a, b) __attribute__ ((__format__ (__syslog__, a, b)))
+#  define scanflike(a, b) __attribute__ ((__format__ (__scanf__, a, b)))
+#  define strftimelike(a) __attribute__ ((__format__ (__strftime__, a, 0)))
 
 /* GCC does not use storage classes to qualify addressing */
 
@@ -684,10 +684,10 @@
 #  define UNUSED(a) ((void)(1 || (a)))
 
 #  define weak_alias(name, aliasname)
-#  define weak_data            __weak
-#  define weak_function        __weak
+#  define weak_data            _Pragma("__weak")
+#  define weak_function        _Pragma("__weak")
 #  define weak_const_function
-#  define noreturn_function
+#  define noreturn_function    _Pragma("object_attribute=__noreturn")
 #  define farcall_function
 #  define locate_code(n)
 #  define aligned_data(n)
@@ -696,8 +696,8 @@
 #  define end_packed_struct
 #  define reentrant_function
 #  define naked_function
-#  define inline_function
-#  define noinline_function
+#  define inline_function      _Pragma("inline=forced") inline
+#  define noinline_function    _Pragma("inline=never")
 #  define noinstrument_function
 #  define nostackprotect_function
 #  define unused_code

--- a/include/nuttx/tree.h
+++ b/include/nuttx/tree.h
@@ -52,12 +52,13 @@
  * The maximum height of a red-black tree is 2lg (n+1).
  */
 
+#ifndef __INCLUDE_NUTTX_TREE_H
+#define __INCLUDE_NUTTX_TREE_H
+
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
-#ifndef __INCLUDE_NUTTX_TREE_H
-#define __INCLUDE_NUTTX_TREE_H
+#include <nuttx/compiler.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -147,7 +148,7 @@ while (0)
   struct type *name##_SPLAY_REMOVE(struct name *, struct type *); \
   \
   /* Finds the node with the same key as elm */ \
-  static __inline struct type * name##_SPLAY_FIND(struct name *head, struct type *elm) \
+  inline_function static struct type * name##_SPLAY_FIND(struct name *head, struct type *elm) \
   { \
     if (SPLAY_EMPTY(head)) \
       { \
@@ -162,7 +163,7 @@ while (0)
     return (NULL); \
   } \
   \
-  static __inline struct type * name##_SPLAY_NEXT(struct name *head, struct type *elm) \
+  inline_function static struct type * name##_SPLAY_NEXT(struct name *head, struct type *elm) \
   { \
     name##_SPLAY(head, elm); \
     if (SPLAY_RIGHT(elm, field) != NULL) \
@@ -181,7 +182,7 @@ while (0)
     return (elm); \
   } \
   \
-  static __inline struct type *name##_SPLAY_MIN_MAX(struct name *head, int val) \
+  inline_function static struct type *name##_SPLAY_MIN_MAX(struct name *head, int val) \
   { \
     name##_SPLAY_MINMAX(head, val); \
     return (SPLAY_ROOT(head)); \

--- a/include/nuttx/wireless/ieee80211/ieee80211_cypto.h
+++ b/include/nuttx/wireless/ieee80211/ieee80211_cypto.h
@@ -26,6 +26,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/compiler.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -106,12 +107,12 @@ struct ieee80211_pmk
  * Inline Functions
  ****************************************************************************/
 
-static __inline int ieee80211_is_8021x_akm(enum ieee80211_akm akm)
+inline_function static int ieee80211_is_8021x_akm(enum ieee80211_akm akm)
 {
   return akm == IEEE80211_AKM_8021X || akm == IEEE80211_AKM_SHA256_8021X;
 }
 
-static __inline int ieee80211_is_sha256_akm(enum ieee80211_akm akm)
+inline_function static int ieee80211_is_sha256_akm(enum ieee80211_akm akm)
 {
   return akm == IEEE80211_AKM_SHA256_8021X ||
                 akm == IEEE80211_AKM_SHA256_PSK;

--- a/sched/pthread/pthread_create.c
+++ b/sched/pthread/pthread_create.c
@@ -23,6 +23,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/compiler.h>
 
 #include <sys/types.h>
 #include <stdbool.h>
@@ -86,10 +87,10 @@ const pthread_attr_t g_default_pthread_attr = PTHREAD_ATTR_INITIALIZER;
  *
  ****************************************************************************/
 
-static inline void pthread_tcb_setup(FAR struct pthread_tcb_s *ptcb,
-                                     pthread_trampoline_t trampoline,
-                                     pthread_addr_t arg,
-                                     pthread_exitroutine_t exit)
+inline_function static void pthread_tcb_setup(FAR struct pthread_tcb_s *ptcb,
+                                              pthread_trampoline_t trampoline,
+                                              pthread_addr_t arg,
+                                              pthread_exitroutine_t exit)
 {
 #if CONFIG_TASK_NAME_SIZE > 0
   /* Copy the pthread name into the TCB */
@@ -124,8 +125,8 @@ static inline void pthread_tcb_setup(FAR struct pthread_tcb_s *ptcb,
  *
  ****************************************************************************/
 
-static inline void pthread_addjoininfo(FAR struct task_group_s *group,
-                                       FAR struct join_s *pjoin)
+inline_function static void pthread_addjoininfo(FAR struct task_group_s *group,
+                                                FAR struct join_s *pjoin)
 {
   pjoin->next = NULL;
   if (!group->tg_jointail)

--- a/sched/pthread/pthread_mutexunlock.c
+++ b/sched/pthread/pthread_mutexunlock.c
@@ -51,7 +51,7 @@
  *
  ****************************************************************************/
 
-static inline bool pthread_mutex_islocked(FAR struct pthread_mutex_s *mutex)
+inline_function static bool pthread_mutex_islocked(FAR struct pthread_mutex_s *mutex)
 {
   int semcount = mutex->sem.semcount;
 

--- a/sched/wdog/wd_start.c
+++ b/sched/wdog/wd_start.c
@@ -93,7 +93,7 @@
  *
  ****************************************************************************/
 
-static inline void wd_expiration(void)
+inline_function static void wd_expiration(void)
 {
   FAR struct wdog_s *wdog;
   wdentry_t func;


### PR DESCRIPTION
## Summary
`inline` keyword is a C99 extension, so inline functions must be treated based of `compiler.h` selection.

## Impact

## Testing
Draft changes
