### PR TITLE
sigdeliver/smp: restored registers should be protected by critical section

### DIFF
--- a/arch/arm/src/armv6-m/arm_sigdeliver.c
+++ b/arch/arm/src/armv6-m/arm_sigdeliver.c
@@ -69,6 +69,7 @@ void arm_sigdeliver(void)
    */
 
   int16_t saved_irqcount;
+  irqstate_t flags;
 #endif
 
   board_autoled_on(LED_SIGNAL);
@@ -87,6 +88,7 @@ void arm_sigdeliver(void)
    * pre-incremented irqcount.
    */
 
+  flags          = (irqstate_t)regs[REG_PRIMASK];
   saved_irqcount = rtcb->irqcount - 1;
   DEBUGASSERT(saved_irqcount >= 0);
 
@@ -96,7 +98,7 @@ void arm_sigdeliver(void)
 
   do
     {
-      leave_critical_section((uint16_t)regs[REG_PRIMASK]);
+      leave_critical_section(flags);
     }
   while (rtcb->irqcount > 0);
 #endif /* CONFIG_SMP */
@@ -123,19 +125,20 @@ void arm_sigdeliver(void)
 
   sinfo("Resuming\n");
 
-#ifdef CONFIG_SMP
-  /* Restore the saved 'irqcount' and recover the critical section
-   * spinlocks.
+  /* Call enter_critical_section() to disable local interrupts before
+   * restoring local context.
+   *
+   * Here, we should not use up_irq_save() in SMP mode.
+   * For example, if we call up_irq_save() here and another CPU might
+   * have called up_cpu_pause() to this cpu, hence g_cpu_irqlock has
+   * been locked by the cpu, in this case, we would see a deadlock in
+   * later call of enter_critical_section() to restore irqcount.
+   * To avoid this situation, we need to call enter_critical_section().
    */
 
-  DEBUGASSERT(rtcb->irqcount == 0);
-  while (rtcb->irqcount < saved_irqcount)
-    {
-      enter_critical_section();
-    }
-#endif
-
-#ifndef CONFIG_SUPPRESS_INTERRUPTS
+#ifdef CONFIG_SMP
+  enter_critical_section();
+#else
   up_irq_save();
 #endif
 
@@ -156,6 +159,27 @@ void arm_sigdeliver(void)
   regs[REG_LR]         = rtcb->xcp.saved_lr;
 #endif
   rtcb->xcp.sigdeliver = NULL;  /* Allows next handler to be scheduled */
+
+#ifdef CONFIG_SMP
+  /* Restore the saved 'irqcount' and recover the critical section
+   * spinlocks.
+   *
+   * REVISIT:  irqcount should be one from the above call to
+   * enter_critical_section().  Could the saved_irqcount be zero?  That
+   * would be a problem.
+   */
+
+  DEBUGASSERT(rtcb->irqcount == 1);
+  while (rtcb->irqcount < saved_irqcount)
+    {
+      enter_critical_section();
+    }
+
+  if (saved_irqcount == 0)
+    {
+      leave_critical_section(flags);
+    }
+#endif
 
   /* Then restore the correct state for this thread of
    * execution.

--- a/arch/arm/src/armv7-a/arm_sigdeliver.c
+++ b/arch/arm/src/armv7-a/arm_sigdeliver.c
@@ -64,6 +64,7 @@ void arm_sigdeliver(void)
    */
 
   int16_t saved_irqcount;
+  irqstate_t flags;
 #endif
 
   board_autoled_on(LED_SIGNAL);
@@ -82,6 +83,7 @@ void arm_sigdeliver(void)
    * pre-incremented irqcount.
    */
 
+  flags          = (irqstate_t)regs[REG_CPSR];
   saved_irqcount = rtcb->irqcount - 1;
   DEBUGASSERT(saved_irqcount >= 0);
 
@@ -91,7 +93,7 @@ void arm_sigdeliver(void)
 
   do
     {
-      leave_critical_section(regs[REG_CPSR]);
+      leave_critical_section(flags);
     }
   while (rtcb->irqcount > 0);
 #endif /* CONFIG_SMP */
@@ -118,19 +120,20 @@ void arm_sigdeliver(void)
 
   sinfo("Resuming\n");
 
-#ifdef CONFIG_SMP
-  /* Restore the saved 'irqcount' and recover the critical section
-   * spinlocks.
+  /* Call enter_critical_section() to disable local interrupts before
+   * restoring local context.
+   *
+   * Here, we should not use up_irq_save() in SMP mode.
+   * For example, if we call up_irq_save() here and another CPU might
+   * have called up_cpu_pause() to this cpu, hence g_cpu_irqlock has
+   * been locked by the cpu, in this case, we would see a deadlock in
+   * later call of enter_critical_section() to restore irqcount.
+   * To avoid this situation, we need to call enter_critical_section().
    */
 
-  DEBUGASSERT(rtcb->irqcount == 0);
-  while (rtcb->irqcount < saved_irqcount)
-    {
-      enter_critical_section();
-    }
-#endif
-
-#ifndef CONFIG_SUPPRESS_INTERRUPTS
+#ifdef CONFIG_SMP
+  enter_critical_section();
+#else
   up_irq_save();
 #endif
 
@@ -147,6 +150,27 @@ void arm_sigdeliver(void)
   regs[REG_PC]         = rtcb->xcp.saved_pc;
   regs[REG_CPSR]       = rtcb->xcp.saved_cpsr;
   rtcb->xcp.sigdeliver = NULL;  /* Allows next handler to be scheduled */
+
+#ifdef CONFIG_SMP
+  /* Restore the saved 'irqcount' and recover the critical section
+   * spinlocks.
+   *
+   * REVISIT:  irqcount should be one from the above call to
+   * enter_critical_section().  Could the saved_irqcount be zero?  That
+   * would be a problem.
+   */
+
+  DEBUGASSERT(rtcb->irqcount == 1);
+  while (rtcb->irqcount < saved_irqcount)
+    {
+      enter_critical_section();
+    }
+
+  if (saved_irqcount == 0)
+    {
+      leave_critical_section(flags);
+    }
+#endif
 
   /* Then restore the correct state for this thread of execution. */
 

--- a/arch/arm/src/armv7-m/arm_sigdeliver.c
+++ b/arch/arm/src/armv7-m/arm_sigdeliver.c
@@ -64,6 +64,7 @@ void arm_sigdeliver(void)
    */
 
   int16_t saved_irqcount;
+  irqstate_t flags;
 #endif
 
   board_autoled_on(LED_SIGNAL);
@@ -82,6 +83,11 @@ void arm_sigdeliver(void)
    * pre-incremented irqcount.
    */
 
+#ifdef CONFIG_ARMV7M_USEBASEPRI
+  flags          = (irqstate_t)regs[REG_BASEPRI];
+#else
+  flags          = (irqstate_t)regs[REG_PRIMASK];
+#endif
   saved_irqcount = rtcb->irqcount - 1;
   DEBUGASSERT(saved_irqcount >= 0);
 
@@ -91,11 +97,7 @@ void arm_sigdeliver(void)
 
   do
     {
-#ifdef CONFIG_ARMV7M_USEBASEPRI
-      leave_critical_section((uint8_t)regs[REG_BASEPRI]);
-#else
-      leave_critical_section((uint16_t)regs[REG_PRIMASK]);
-#endif
+      leave_critical_section(flags);
     }
   while (rtcb->irqcount > 0);
 #endif /* CONFIG_SMP */
@@ -122,19 +124,20 @@ void arm_sigdeliver(void)
 
   sinfo("Resuming\n");
 
-#ifdef CONFIG_SMP
-  /* Restore the saved 'irqcount' and recover the critical section
-   * spinlocks.
+  /* Call enter_critical_section() to disable local interrupts before
+   * restoring local context.
+   *
+   * Here, we should not use up_irq_save() in SMP mode.
+   * For example, if we call up_irq_save() here and another CPU might
+   * have called up_cpu_pause() to this cpu, hence g_cpu_irqlock has
+   * been locked by the cpu, in this case, we would see a deadlock in
+   * later call of enter_critical_section() to restore irqcount.
+   * To avoid this situation, we need to call enter_critical_section().
    */
 
-  DEBUGASSERT(rtcb->irqcount == 0);
-  while (rtcb->irqcount < saved_irqcount)
-    {
-      enter_critical_section();
-    }
-#endif
-
-#ifndef CONFIG_SUPPRESS_INTERRUPTS
+#ifdef CONFIG_SMP
+  enter_critical_section();
+#else
   up_irq_save();
 #endif
 
@@ -159,6 +162,27 @@ void arm_sigdeliver(void)
   regs[REG_LR]         = rtcb->xcp.saved_lr;
 #endif
   rtcb->xcp.sigdeliver = NULL;  /* Allows next handler to be scheduled */
+
+#ifdef CONFIG_SMP
+  /* Restore the saved 'irqcount' and recover the critical section
+   * spinlocks.
+   *
+   * REVISIT:  irqcount should be one from the above call to
+   * enter_critical_section().  Could the saved_irqcount be zero?  That
+   * would be a problem.
+   */
+
+  DEBUGASSERT(rtcb->irqcount == 1);
+  while (rtcb->irqcount < saved_irqcount)
+    {
+      enter_critical_section();
+    }
+
+  if (saved_irqcount == 0)
+    {
+      leave_critical_section(flags);
+    }
+#endif
 
   /* Then restore the correct state for this thread of
    * execution.

--- a/arch/arm/src/armv8-m/arm_sigdeliver.c
+++ b/arch/arm/src/armv8-m/arm_sigdeliver.c
@@ -64,6 +64,7 @@ void arm_sigdeliver(void)
    */
 
   int16_t saved_irqcount;
+  irqstate_t flags;
 #endif
 
   board_autoled_on(LED_SIGNAL);
@@ -82,6 +83,11 @@ void arm_sigdeliver(void)
    * pre-incremented irqcount.
    */
 
+#ifdef CONFIG_ARMV8M_USEBASEPRI
+  flags          = (irqstate_t)regs[REG_BASEPRI];
+#else
+  flags          = (irqstate_t)regs[REG_PRIMASK];
+#endif
   saved_irqcount = rtcb->irqcount - 1;
   DEBUGASSERT(saved_irqcount >= 0);
 
@@ -91,11 +97,7 @@ void arm_sigdeliver(void)
 
   do
     {
-#ifdef CONFIG_ARMV8M_USEBASEPRI
-      leave_critical_section((uint8_t)regs[REG_BASEPRI]);
-#else
-      leave_critical_section((uint16_t)regs[REG_PRIMASK]);
-#endif
+      leave_critical_section(flags);
     }
   while (rtcb->irqcount > 0);
 #endif /* CONFIG_SMP */
@@ -122,19 +124,20 @@ void arm_sigdeliver(void)
 
   sinfo("Resuming\n");
 
-#ifdef CONFIG_SMP
-  /* Restore the saved 'irqcount' and recover the critical section
-   * spinlocks.
+  /* Call enter_critical_section() to disable local interrupts before
+   * restoring local context.
+   *
+   * Here, we should not use up_irq_save() in SMP mode.
+   * For example, if we call up_irq_save() here and another CPU might
+   * have called up_cpu_pause() to this cpu, hence g_cpu_irqlock has
+   * been locked by the cpu, in this case, we would see a deadlock in
+   * later call of enter_critical_section() to restore irqcount.
+   * To avoid this situation, we need to call enter_critical_section().
    */
 
-  DEBUGASSERT(rtcb->irqcount == 0);
-  while (rtcb->irqcount < saved_irqcount)
-    {
-      enter_critical_section();
-    }
-#endif
-
-#ifndef CONFIG_SUPPRESS_INTERRUPTS
+#ifdef CONFIG_SMP
+  enter_critical_section();
+#else
   up_irq_save();
 #endif
 
@@ -159,6 +162,27 @@ void arm_sigdeliver(void)
   regs[REG_LR]         = rtcb->xcp.saved_lr;
 #endif
   rtcb->xcp.sigdeliver = NULL;  /* Allows next handler to be scheduled */
+
+#ifdef CONFIG_SMP
+  /* Restore the saved 'irqcount' and recover the critical section
+   * spinlocks.
+   *
+   * REVISIT:  irqcount should be one from the above call to
+   * enter_critical_section().  Could the saved_irqcount be zero?  That
+   * would be a problem.
+   */
+
+  DEBUGASSERT(rtcb->irqcount == 1);
+  while (rtcb->irqcount < saved_irqcount)
+    {
+      enter_critical_section();
+    }
+
+  if (saved_irqcount == 0)
+    {
+      leave_critical_section(flags);
+    }
+#endif
 
   /* Then restore the correct state for this thread of
    * execution.

--- a/arch/risc-v/src/common/riscv_sigdeliver.c
+++ b/arch/risc-v/src/common/riscv_sigdeliver.c
@@ -66,6 +66,7 @@ void riscv_sigdeliver(void)
    */
 
   int16_t saved_irqcount;
+  irqstate_t flags;
 #endif
 
   board_autoled_on(LED_SIGNAL);
@@ -84,6 +85,7 @@ void riscv_sigdeliver(void)
    * pre-incremented irqcount.
    */
 
+  flags          = (irqstate_t)regs[REG_INT_CTX];
   saved_irqcount = rtcb->irqcount - 1;
   DEBUGASSERT(saved_irqcount >= 0);
 
@@ -93,7 +95,7 @@ void riscv_sigdeliver(void)
 
   do
     {
-      leave_critical_section(regs[REG_INT_CTX]);
+      leave_critical_section(flags);
     }
   while (rtcb->irqcount > 0);
 #endif /* CONFIG_SMP */
@@ -118,19 +120,20 @@ void riscv_sigdeliver(void)
   sinfo("Resuming EPC: %" PRIxREG " INT_CTX: %" PRIxREG "\n",
         regs[REG_EPC], regs[REG_INT_CTX]);
 
-#ifdef CONFIG_SMP
-  /* Restore the saved 'irqcount' and recover the critical section
-   * spinlocks.
+  /* Call enter_critical_section() to disable local interrupts before
+   * restoring local context.
+   *
+   * Here, we should not use up_irq_save() in SMP mode.
+   * For example, if we call up_irq_save() here and another CPU might
+   * have called up_cpu_pause() to this cpu, hence g_cpu_irqlock has
+   * been locked by the cpu, in this case, we would see a deadlock in
+   * later call of enter_critical_section() to restore irqcount.
+   * To avoid this situation, we need to call enter_critical_section().
    */
 
-  DEBUGASSERT(rtcb->irqcount == 0);
-  while (rtcb->irqcount < saved_irqcount)
-    {
-      (void)enter_critical_section();
-    }
-#endif
-
-#ifndef CONFIG_SUPPRESS_INTERRUPTS
+#ifdef CONFIG_SMP
+  enter_critical_section();
+#else
   up_irq_save();
 #endif
 
@@ -147,6 +150,27 @@ void riscv_sigdeliver(void)
   regs[REG_EPC]        = rtcb->xcp.saved_epc;
   regs[REG_INT_CTX]    = rtcb->xcp.saved_int_ctx;
   rtcb->xcp.sigdeliver = NULL;  /* Allows next handler to be scheduled */
+
+#ifdef CONFIG_SMP
+  /* Restore the saved 'irqcount' and recover the critical section
+   * spinlocks.
+   *
+   * REVISIT:  irqcount should be one from the above call to
+   * enter_critical_section().  Could the saved_irqcount be zero?  That
+   * would be a problem.
+   */
+
+  DEBUGASSERT(rtcb->irqcount == 1);
+  while (rtcb->irqcount < saved_irqcount)
+    {
+      enter_critical_section();
+    }
+
+  if (saved_irqcount == 0)
+    {
+      leave_critical_section(flags);
+    }
+#endif
 
   /* Then restore the correct state for this thread of
    * execution.


### PR DESCRIPTION
## Summary

sigdeliver/smp: restored registers should be protected by critical section

[CPU1] [24] up_assert: Assertion failed CPU1 at file:armv7-a/arm_sigdeliver.c line: 73 task: waiter
[CPU1] [24] arm_registerdump: R0: 00000001 R1: 108321d8 R2: 1081922c  R3: 108321d8
[CPU1] [24] arm_registerdump: R4: 10832158 R5: 10817070 R6: 1083a654  FP: 108321d8

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

N/A

## Testing

sabre-6quad/smp, ostest