### PR TITLE
arch/addrenv: Change text write enable/disable to generic mprot

### DIFF
--- a/arch/arm/src/armv7-a/arm_addrenv_perms.c
+++ b/arch/arm/src/armv7-a/arm_addrenv_perms.c
@@ -25,51 +25,40 @@
 #include <nuttx/config.h>
 
 #include <nuttx/arch.h>
+#include <nuttx/compiler.h>
+
+#include <sys/mman.h>
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_addrenv_text_enable_write
+ * Name: up_addrenv_mprot
  *
  * Description:
- *   Temporarily enable write access to the .text section. This must be
- *   called prior to loading the process code into memory.
+ *   Modify access rights to an address range.
  *
  * Input Parameters:
  *   addrenv - The address environment to be modified.
+ *   addr - Base address of the region.
+ *   len - Size of the region.
+ *   prot - Access right flags.
  *
  * Returned Value:
  *   Zero (OK) on success; a negated errno value on failure.
  *
  ****************************************************************************/
 
-int up_addrenv_text_enable_write(group_addrenv_t *addrenv)
+int up_addrenv_mprot(group_addrenv_t *addrenv, uintptr_t addr, size_t len,
+                     int prot)
 {
   /* Nothing needs to be done */
 
-  return OK;
-}
-
-/****************************************************************************
- * Name: up_addrenv_text_disable_write
- *
- * Description:
- *   Disable write access to the .text section. This must be called after the
- *   process code is loaded into memory.
- *
- * Input Parameters:
- *   addrenv - The address environment to be modified.
- *
- * Returned Value:
- *   Zero (OK) on success; a negated errno value on failure.
- *
- ****************************************************************************/
-
-int up_addrenv_text_disable_write(group_addrenv_t *addrenv)
-{
-  /* Nothing needs to be done */
+  UNUSED(addrenv);
+  UNUSED(addr);
+  UNUSED(len);
+  UNUSED(prot);
 
   return OK;
 }

--- a/binfmt/libelf/libelf_addrenv.c
+++ b/binfmt/libelf/libelf_addrenv.c
@@ -30,11 +30,16 @@
 #include <nuttx/arch.h>
 #include <nuttx/kmalloc.h>
 
+#include <sys/mman.h>
+
 #include "libelf.h"
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
+#define ELF_TEXT_WRE (PROT_READ | PROT_WRITE | PROT_EXEC)
+#define ELF_TEXT_WRD (PROT_READ | PROT_EXEC)
 
 /****************************************************************************
  * Private Constant Data
@@ -175,7 +180,8 @@ int elf_addrenv_select(FAR struct elf_loadinfo_s *loadinfo)
 
   /* Allow write access to .text */
 
-  ret = up_addrenv_text_enable_write(&loadinfo->addrenv);
+  ret = up_addrenv_mprot(&loadinfo->addrenv, loadinfo->textalloc,
+                         loadinfo->textsize, ELF_TEXT_WRE);
   if (ret < 0)
     {
       berr("ERROR: up_addrenv_text_enable_write failed: %d\n", ret);
@@ -207,7 +213,8 @@ int elf_addrenv_restore(FAR struct elf_loadinfo_s *loadinfo)
 
   /* Remove write access to .text */
 
-  ret = up_addrenv_text_disable_write(&loadinfo->addrenv);
+  ret = up_addrenv_mprot(&loadinfo->addrenv, loadinfo->textalloc,
+                         loadinfo->textsize, ELF_TEXT_WRD);
   if (ret < 0)
     {
       berr("ERROR: up_addrenv_text_disable_write failed: %d\n", ret);

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -1186,14 +1186,16 @@ int up_addrenv_detach(FAR struct task_group_s *group, FAR struct tcb_s *tcb);
 #endif
 
 /****************************************************************************
- * Name: up_addrenv_text_enable_write
+ * Name: up_addrenv_mprot
  *
  * Description:
- *   Temporarily enable write access to the .text section. This must be
- *   called prior to loading the process code into memory.
+ *   Modify access rights to an address range.
  *
  * Input Parameters:
  *   addrenv - The address environment to be modified.
+ *   addr - Base address of the region.
+ *   len - Size of the region.
+ *   prot - Access right flags.
  *
  * Returned Value:
  *   Zero (OK) on success; a negated errno value on failure.
@@ -1201,26 +1203,8 @@ int up_addrenv_detach(FAR struct task_group_s *group, FAR struct tcb_s *tcb);
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_ADDRENV
-int up_addrenv_text_enable_write(FAR group_addrenv_t *addrenv);
-#endif
-
-/****************************************************************************
- * Name: up_addrenv_text_disable_write
- *
- * Description:
- *   Disable write access to the .text section. This must be called after the
- *   process code is loaded into memory.
- *
- * Input Parameters:
- *   addrenv - The address environment to be modified.
- *
- * Returned Value:
- *   Zero (OK) on success; a negated errno value on failure.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_ARCH_ADDRENV
-int up_addrenv_text_disable_write(FAR group_addrenv_t *addrenv);
+int up_addrenv_mprot(group_addrenv_t *addrenv, uintptr_t addr, size_t len,
+                     int prot);
 #endif
 
 /****************************************************************************


### PR DESCRIPTION
Implement a generic access rights modification procedure instead
of the procedures that only do one thing (enable/disable write)
to one section (text).

## Summary
Follow up to https://github.com/apache/incubator-nuttx/pull/6193
## Impact
Minimal, implements the same thing with a different procedure
## Testing
icicle:knsh
