### PR TITLE
arch/arm/samv7: fix sporadic bit flip after internal flash byte write

### DIFF
--- a/arch/arm/src/samv7/Make.defs
+++ b/arch/arm/src/samv7/Make.defs
@@ -29,6 +29,7 @@ include armv7-m/Make.defs
 
 CHIP_CSRCS  = sam_start.c sam_clockconfig.c sam_irq.c sam_allocateheap.c
 CHIP_CSRCS += sam_lowputc.c sam_serial.c sam_gpio.c sam_pck.c sam_uid.c
+CHIP_CSRCS += sam_eefc.c
 
 # Configuration-dependent SAMV7 files
 
@@ -133,7 +134,7 @@ CHIP_CSRCS += sam_trng.c
 endif
 
 ifeq ($(CONFIG_SAMV7_PROGMEM),y)
-CHIP_CSRCS += sam_progmem.c sam_eefc.c
+CHIP_CSRCS += sam_progmem.c
 endif
 
 ifeq ($(CONFIG_SAMV7_PWM),y)

--- a/arch/arm/src/samv7/sam_eefc.h
+++ b/arch/arm/src/samv7/sam_eefc.h
@@ -36,9 +36,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define SAM_EFC_ACCESS_MODE_128    0
-#define SAM_EFC_ACCESS_MODE_64     EEFC_FMR_FAM
-
 /****************************************************************************
  * Public Types
  ****************************************************************************/
@@ -96,16 +93,6 @@ __ramfunc__ int sam_eefc_command(uint32_t cmd, uint32_t arg);
 
 __ramfunc__ int sam_eefc_readsequence(uint32_t start_cmd, uint32_t stop_cmd,
                                       uint32_t *buffer, size_t bufsize);
-
-/****************************************************************************
- * Name: sam_eefc_initaccess
- *
- * Description:
- *   Initial enhanced embedded flash access mode.
- *
- ****************************************************************************/
-
-void sam_eefc_initaccess(uint32_t access_mode, uint32_t wait_status);
 
 /****************************************************************************
  * Name: sam_eefc_unlock

--- a/arch/arm/src/samv7/sam_progmem.c
+++ b/arch/arm/src/samv7/sam_progmem.c
@@ -172,10 +172,6 @@ void sam_progmem_initialize(void)
 {
   uint32_t regval;
 
-  /* Set flash access mode to 128bit and wait status to 4 */
-
-  sam_eefc_initaccess(SAM_EFC_ACCESS_MODE_128, 4);
-
   /* Make sure that the read interrupt is disabled */
 
   regval  = getreg32(SAM_EEFC_FMR);

--- a/arch/arm/src/samv7/sam_uid.c
+++ b/arch/arm/src/samv7/sam_uid.c
@@ -52,10 +52,6 @@ void sam_get_uniqueid(uint8_t uniqueid[16])
   uint32_t buffer[4];
   uint8_t  index;
 
-  /* Set flash access mode to 128bit and wait status to 4 */
-
-  sam_eefc_initaccess(SAM_EFC_ACCESS_MODE_128, 4);
-
   /* Get device unique id */
 
   sam_eefc_readsequence(FCMD_STUI, FCMD_SPUI, buffer, 4);

--- a/boards/arm/samv7/same70-qmtech/include/board.h
+++ b/boards/arm/samv7/same70-qmtech/include/board.h
@@ -163,20 +163,22 @@
  *
  * Wait states Max frequency at 105 centigrade (STH conditions)
  *
- *           VDDIO
- *      1.62V     2.7V
+ *
+ * FWS      VDDIO
+ *      1.7V     3.0V
  * --- -------  -------
- *  0   26 MHz   30 MHz
- *  1   52 MHz   62 MHz
- *  2   78 MHz   93 MHz
- *  3  104 MHz  124 MHz
- *  4  131 MHz  150 MHz
- *  5  150 MHz  --- MHz
+ *  0   21 MHz   23 MHz
+ *  1   42 MHz   46 MHz
+ *  2   63 MHz   69 MHz
+ *  3   84 MHz   92 MHz
+ *  4  106 MHz  115 MHz
+ *  5  125 MHz  138 MHz
+ *  6  137 MHz  150 MHz
  *
  * Given: VDDIO=3.3V, VDDCORE=1.2V, MCK=150MHz
  */
 
-#define BOARD_FWS                  4
+#define BOARD_FWS                  6
 
 /* LED definitions **********************************************************/
 

--- a/boards/arm/samv7/same70-xplained/include/board.h
+++ b/boards/arm/samv7/same70-xplained/include/board.h
@@ -165,20 +165,22 @@
  *
  * Wait states Max frequency at 105 centigrade (STH conditions)
  *
- *           VDDIO
- *      1.62V     2.7V
+ *
+ * FWS      VDDIO
+ *      1.7V     3.0V
  * --- -------  -------
- *  0   26 MHz   30 MHz
- *  1   52 MHz   62 MHz
- *  2   78 MHz   93 MHz
- *  3  104 MHz  124 MHz
- *  4  131 MHz  150 MHz
- *  5  150 MHz  --- MHz
+ *  0   21 MHz   23 MHz
+ *  1   42 MHz   46 MHz
+ *  2   63 MHz   69 MHz
+ *  3   84 MHz   92 MHz
+ *  4  106 MHz  115 MHz
+ *  5  125 MHz  138 MHz
+ *  6  137 MHz  150 MHz
  *
  * Given: VDDIO=3.3V, VDDCORE=1.2V, MCK=150MHz
  */
 
-#define BOARD_FWS                  4
+#define BOARD_FWS                  6
 
 /* LED definitions **********************************************************/
 

--- a/boards/arm/samv7/samv71-xult/include/board.h
+++ b/boards/arm/samv7/samv71-xult/include/board.h
@@ -166,20 +166,22 @@
  *
  * Wait states Max frequency at 105 centigrade (STH conditions)
  *
- *           VDDIO
- *      1.62V     2.7V
+ *
+ * FWS      VDDIO
+ *      1.7V     3.0V
  * --- -------  -------
- *  0   26 MHz   30 MHz
- *  1   52 MHz   62 MHz
- *  2   78 MHz   93 MHz
- *  3  104 MHz  124 MHz
- *  4  131 MHz  150 MHz
- *  5  150 MHz  --- MHz
+ *  0   21 MHz   23 MHz
+ *  1   42 MHz   46 MHz
+ *  2   63 MHz   69 MHz
+ *  3   84 MHz   92 MHz
+ *  4  106 MHz  115 MHz
+ *  5  125 MHz  138 MHz
+ *  6  137 MHz  150 MHz
  *
  * Given: VDDIO=3.3V, VDDCORE=1.2V, MCK=150MHz
  */
 
-#define BOARD_FWS                  4
+#define BOARD_FWS                  6
 
 /* LED definitions **********************************************************/
 


### PR DESCRIPTION
## Summary
Fix sporadic bit flip after internal flash byte write

The number of embedded flash wait states was calculated in a wrong way and the code to set flash wait states was executed three times instead of one. Two calls are removed now and only in sam_clockconfig() remains

## Impact
Improve progmem write for SAMv7 based devices

## Testing
Verified with custom SAMe70 based board
