### PR TITLE
sched/sched/sched_timerexpiration: idle task no need RR time slice

### DIFF
--- a/sched/sched/sched_timerexpiration.c
+++ b/sched/sched/sched_timerexpiration.c
@@ -238,7 +238,18 @@ static uint32_t nxsched_cpu_scheduler(int cpu, uint32_t ticks,
     {
       /* Apply the keep alive hack */
 
-      return KEEP_ALIVE_TICKS;
+      /* The idle task always lies at the end of the task list,
+       * idle task no need time slice.
+       */
+
+      if (ntcb->flink != NULL)
+        {
+          return KEEP_ALIVE_TICKS;
+        }
+      else
+        {
+          return UINT32_MAX - 1;
+        }
     }
 #endif
 


### PR DESCRIPTION
Round robin timeslice will not run on idle task

## Summary
Low Energy device always use SCHED_TICKLESS mode, staying in idle mode as long as possible.
All thread runing on default priority is very popular in real multi thread program. Round robin timeslice is useful in that scenario to make sure all thread have chance to run, especially small RR_INTERVAL.
On the other hand, small RR_INTERVAL will break the idle task frequently. We should not split the idle task timeslice.

## Impact
Idle task will run maximum tick if possible, and it just wakeup by task switch operation.

## Testing

boards/arm/nrf52/nrf52840-dk/configs/nsh work as expected when SCHED_TICKLESS enable