### PR TITLE
Add support for the loading of ET_DYN objects

### DIFF
--- a/build-globals.sh
+++ b/build-globals.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+#
+# Script to create modlib_global.S which contains a structure define 
+# the API names and addresses we will export for resolving symbols in
+# dynamic loaded shared objects. Typically these are libc APIs.
+
+#
+# Find an entrypoint using a binary search
+#
+findEP()
+{
+	CHECK=$1
+	SIZE=${#SYM[@]}
+	L=0
+	R=$((SIZE - 1))
+	while [ ${L} -le ${R} ]
+	do
+		T=$(( L + R ))
+		M=$(( T / 2 ))
+		N=$(( T % 2 ))
+		M=$(( M - N ))
+		if [ ${SYM[${M}]} \< ${CHECK} ]; then
+			L=$(( M + 1 ))
+		elif [ ${SYM[${M}]} = ${CHECK} ]; then
+			return 1
+		else
+			R=$(( M - 1 ))
+		fi
+	done
+	return 0
+}
+
+#
+# Extract entrypoints from a library after applying a filter to
+# exclude those we aren't interested in.
+#
+getEP() 
+{
+	for ((i = 0; i < ${#OBJ[@]}; i++))
+	do
+		FUNCS=`${NM} -g --defined-only ../staging/${OBJ[$i]} | awk '{print $3}' | sort | grep -Ev ${FILTER}`
+		FUNC=(${FUNCS})
+		for ((j = 0; j < ${#FUNC[@]}; j++))
+		do
+			findEP ${FUNC[$j]}
+			if [ $? -eq 1 ]; then
+				EP[${I_EP}]=${FUNC[$j]}
+				I_EP=$((I_EP + 1))
+			fi
+		done
+	done 
+}
+	
+#
+# Symbols to ignore within the NuttX libraries
+#
+FILTER="^lib_low|^FUNCTION|^STUB|^__start|^_vect|^arm_|^arp_|^bch|^binfmt|^blake|^block_|^cdcacm|^chksum|^clock_|^close_|^crypto_|^devif_|^devnull|^devuran|^devzero|^emerg|^epoll_|^elf_|^_dbgR|^dq_|^env_|^file_|^files_|^fs_|^ftl_|^g_|^get_|^group_|^global|^hcom|^i2c_|^inode_|^iob_|^irq_|^kmm_|^lfs_|^lib_|^local_|^mm_|^modlib_|^mpu_|^mq_|^nGlobals|^net_|^netdev_|^nx|^pipecommon|^posix_spawn_file|^psock_|^ramlog|^rammap|^readline_|^register_|^sched_|^sockfd|^spawn_|^sq_|^stm32|^symtab_|^syslog_|^syslogstream|^task_|^tcp_|^timer_|^uart_|^ub[12]|^udp_|^umm_|^umount|^unload_|^unregister|^up_|^usb|^usrsock_|^watchdog|^wd_"
+
+#
+# Extract symbols from the runtime
+#
+SYMS=`${NM} ../nuttx | awk '{print $3}' | sort | grep -Ev ${FILTER}`
+SYM=(${SYMS})
+GLOBALS="../libs/libc/modlib/modlib_globals.S"
+I_EP=0
+
+#
+# Libraries to be searched
+#
+OBJS="libsched.a libdrivers.a libconfigs.a libstubs.a libkc.a libkmm.a libkarch.a libpass1.a libnet.a libcrypto.a libfs.a libbinfmt.a libxx.a libuc.a libumm.a libuarch.a libapps.a"
+OBJ=(${OBJS})
+
+#
+# Perform the extraction from the libraries
+#
+getEP
+EPS=`printf '%s\n' "${EP[@]}" | sort -u`
+EP=(${EPS})
+
+#
+# Generate the modlib_xxxx_globals.S file
+#
+	GLOBALS="libs/libc/modlib/modlib_${arch}_globals.S"
+cat >${GLOBALS} <<__EOF__
+#if __SIZEOF_POINTER__ == 8
+	.macro globalEntry index, ep
+	.weak  \p
+	.quad  .L\index
+	.quad  \ep
+	.endm
+# define ALIGN 8
+#else
+	.macro globalEntry index, ep
+	.weak  \ep		
+	.long  .L\index
+	.long  \ep
+	.endm
+# define ALIGN 4
+#endif
+#ifdef __ARM_ARCH_ISA_THUMB2
+# ifdef __ARM_ARCH_7M__
+        .arch armv7e-m
+# elif defined ___ARM_ARCH 8
+	.arch armv8-m.base
+#endif
+#ifdef __ARM_ASM_SYNTAX_UNIFIED__
+        .syntax unified
+#endif
+        .thumb
+#endif
+        .data
+        .align ALIGN
+	.global globalNames
+
+globalNames:
+__EOF__
+
+for ((i = 0; i < ${#EP[@]}; i++))
+do
+	echo ".L${i}:	.string	\"${EP[$i]}\"" >>${GLOBALS}
+done
+
+cat >>${GLOBALS} <<__EOF__
+	.size	globalNames, . - globalNames
+
+	.align	${ALIGN}
+	.global	nGlobals
+	.type	nGlobals, "object"
+nGlobals:	
+	.word	${#EP[@]}
+	.size	nGlobals, . - nGlobals
+
+	.align	${ALIGN}
+	.global globalTable
+	.type	globalTable, "object"
+globalTable:
+__EOF__
+
+for ((i = 0; i < ${#EP[@]}; i++))
+do
+	echo "  globalEntry ${i}, ${EP[$i]}" >>${GLOBALS}
+done
+
+cat >>${GLOBALS} <<__EOF__ 
+	.size	globalTable, . - globalTable
+__EOF__
+
+done
+echo "${#EP[@]} symbols defined"

--- a/include/elf.h
+++ b/include/elf.h
@@ -214,6 +214,17 @@
 #define PT_NOTE            4
 #define PT_SHLIB           5
 #define PT_PHDR            6
+
+/* Processor specific values for the Phdr p_type field.  */
+
+#define PT_ARM_EXIDX            (PT_LOPROC + 1) /* ARM unwind segment.  */
+
+/* GCC specific */
+
+#define PT_GNU_EH_FRAME 0x6474e550      /* GCC exception handler frame */
+#define PT_GNU_STACK    0x6474e551      /* Stack executability */
+#define PT_GNU_RELRO    0x6474e552      /* Read-only after relocation */
+
 #define PT_LOPROC          0x70000000
 #define PT_HIPROC          0x7fffffff
 

--- a/include/nuttx/lib/modlib.h
+++ b/include/nuttx/lib/modlib.h
@@ -87,6 +87,14 @@
  * Public Types
  ****************************************************************************/
 
+#ifdef CONFIG_LIBC_ARCH_ELF_64BIT
+typedef Elf64_Off Elf_Off;
+typedef Elf64_Dyn Elf_Dyn;
+#else
+typedef Elf32_Off Elf_Off;
+typedef Elf32_Dyn Elf_Dyn;
+#endif
+
 /* This is the type of the function that is called to uninitialize the
  * the loaded module.  This may mean, for example, un-registering a device
  * driver. If the module is successfully uninitialized, its memory will be
@@ -198,13 +206,19 @@ struct mod_loadinfo_s
   size_t            dataalign;   /* Necessary alignment of .bss/.text */
   off_t             filelen;     /* Length of the entire module file */
   Elf_Ehdr          ehdr;        /* Buffered module file header */
+  FAR Elf_Phdr     *phdr;        /* Buffered module program headers */
   FAR Elf_Shdr     *shdr;        /* Buffered module section headers */
+  FAR void	   *exported;    /* Module exports */
   uint8_t          *iobuffer;    /* File I/O buffer */
+  uintptr_t	    datasec;     /* ET_DYN - data area start from Phdr */
+  uintptr_t	    segpad;      /* Padding between text and data */
 
   uint16_t          symtabidx;   /* Symbol table section index */
   uint16_t          strtabidx;   /* String table section index */
+  uint16_t          dsymtabidx;  /* Dynamic symbol table section index */
   uint16_t          buflen;      /* size of iobuffer[] */
   int               filfd;       /* Descriptor for the file being loaded */
+  int               nexports;    /* ET_DYN - Number of symbols exported */
 };
 
 /****************************************************************************
@@ -529,5 +543,18 @@ int modlib_registry_verify(FAR struct module_s *modp);
  ****************************************************************************/
 
 int modlib_registry_foreach(mod_callback_t callback, FAR void *arg);
+
+/****************************************************************************
+ * Name: modlib_freesymtab
+ *
+ * Description:
+ *   Free a symbol table for the current module.
+ *
+ * Input Parameters:
+ *   modp - Module state descriptor
+ *
+ ****************************************************************************/
+
+void modlib_freesymtab(FAR struct module_s *modp);
 
 #endif /* __INCLUDE_NUTTX_LIB_MODLIB_H */

--- a/libs/libc/dlfcn/lib_dlclose.c
+++ b/libs/libc/dlfcn/lib_dlclose.c
@@ -142,6 +142,10 @@ static inline int dlremove(FAR void *handle)
 #endif
     }
 
+  /* Free the modules exported symmbols table */
+
+  modlib_freesymtab(modp);
+
   /* Remove the module from the registry */
 
   ret = modlib_registry_del(modp);

--- a/libs/libc/machine/arm/armv7-m/arch_elf.c
+++ b/libs/libc/machine/arm/armv7-m/arch_elf.c
@@ -497,7 +497,7 @@ int up_relocate(const Elf32_Rel *rel, const Elf32_Sym *sym, uintptr_t addr)
     case R_ARM_JUMP_SLOT :
       {
         binfo("Relocating: RELATIVE/JUMP_SLOT at %p value: %08lx with %08lx\n",
-              (void *)addr,*(unsigned log *) addr, (unsigned long) sym->st_value);
+              (void *)addr,*(unsigned long *) addr, (unsigned long) sym->st_value);
         *(uint32_t *) addr = (uint32_t) sym->st_value;
       }
       break;

--- a/libs/libc/machine/arm/armv7-m/arch_elf.c
+++ b/libs/libc/machine/arm/armv7-m/arch_elf.c
@@ -122,7 +122,8 @@ int up_relocate(const Elf32_Rel *rel, const Elf32_Sym *sym, uintptr_t addr)
    */
 
   relotype = ELF32_R_TYPE(rel->r_info);
-  if (sym == NULL && relotype != R_ARM_NONE && relotype != R_ARM_V4BX)
+  if (sym == NULL && relotype != R_ARM_NONE && relotype != R_ARM_V4BX &&
+      relotype != R_ARM_RELATIVE && relotype != R_ARM_JUMP_SLOT)
     {
       return -EINVAL;
     }
@@ -489,6 +490,15 @@ int up_relocate(const Elf32_Rel *rel, const Elf32_Sym *sym, uintptr_t addr)
 
         *(uint16_t *)addr &= 0xf800;
         *(uint16_t *)addr |= offset & 0x7ff;
+      }
+      break;
+
+    case R_ARM_RELATIVE :
+    case R_ARM_JUMP_SLOT :
+      {
+        binfo("Relocating: RELATIVE/JUMP_SLOT at %p value: %08lx with %08lx\n",
+              (void *)addr,*(unsigned log *) addr, (unsigned long) sym->st_value);
+        *(uint32_t *) addr = (uint32_t) sym->st_value;
       }
       break;
 

--- a/libs/libc/modlib/Make.defs
+++ b/libs/libc/modlib/Make.defs
@@ -23,12 +23,14 @@ ifeq ($(CONFIG_LIBC_MODLIB),y)
 # Add the nuttx/lib/modlib.h files to the build
 
 CSRCS += modlib_bind.c modlib_depend.c modlib_init.c modlib_iobuffer.c
-CSRCS += modlib_load.c modlib_loadshdrs.c
+CSRCS += modlib_load.c modlib_loadhdrs.c
 CSRCS += modlib_read.c modlib_registry.c modlib_sections.c
 CSRCS += modlib_symbols.c modlib_symtab.c modlib_uninit.c modlib_unload.c
-CSRCS += modlib_verify.c
+CSRCS += modlib_verify.c 
 
 # Add the modlib directory to the build
+
+ASRCS += modlib_globals.S
 
 DEPPATH += --dep-path modlib
 VPATH += :modlib

--- a/libs/libc/modlib/modlib.h
+++ b/libs/libc/modlib/modlib.h
@@ -83,7 +83,7 @@ int modlib_findsymtab(FAR struct mod_loadinfo_s *loadinfo);
  ****************************************************************************/
 
 int modlib_readsym(FAR struct mod_loadinfo_s *loadinfo, int index,
-                   FAR Elf_Sym *sym);
+                   FAR Elf_Sym *sym, FAR Elf_Shdr *shdr);
 
 /****************************************************************************
  * Name: modlib_symvalue
@@ -110,13 +110,64 @@ int modlib_readsym(FAR struct mod_loadinfo_s *loadinfo, int index,
  ****************************************************************************/
 
 int modlib_symvalue(FAR struct module_s *modp,
-                    FAR struct mod_loadinfo_s *loadinfo, FAR Elf_Sym *sym);
+                    FAR struct mod_loadinfo_s *loadinfo, FAR Elf_Sym *sym,
+ 		    Elf_Off offset);
+
+ /****************************************************************************
+  * Name: modlib_insertsymtab
+  *
+  * Description:
+  *   Insert a symbol table for the current module.
+  *
+  * Input Parameters:
+  *   modp     - Module state information
+  *   loadinfo - Module load information
+  *   shdr     - Symbol table section header
+  *   sym      - Symbol table entry
+  *
+  * Returned Value:
+  *   0 (OK) is returned on success and a negated errno is returned on
+  *   failure.
+  *
+  *   ENOMEM - Symbol undefined and not provided via a symbol table
+  *
+  ****************************************************************************/
+ 
+int modlib_insertsymtab(FAR struct module_s *modp, 
+ 		        FAR struct mod_loadinfo_s *loadinfo, 
+                        FAR Elf_Shdr *shdr,
+                        FAR Elf_Sym *sym);
 
 /****************************************************************************
- * Name: modlib_loadshdrs
+ * Name: modlib_findglobal
  *
  * Description:
- *   Loads section headers into memory.
+ *   Find a symbol in the global symbol table
+ *
+ * Input Parameters:
+ *   modp     - Module state information
+ *   loadinfo - Module load information
+ *   shdr     - Symbol table section header
+ *   sym      - Symbol table entry
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ *   ENOMEM - Symbol undefined and not provided via a symbol table
+ *
+ ****************************************************************************/
+
+void *modlib_findglobal(FAR struct module_s *modp, 
+		        FAR struct mod_loadinfo_s *loadinfo, 
+                        FAR Elf_Shdr *shdr,
+                        FAR Elf_Sym *sym);
+
+/****************************************************************************
+ * Name: modlib_loadhdrs
+ *
+ * Description:
+ *   Loads program and section headers into memory.
  *
  * Returned Value:
  *   0 (OK) is returned on success and a negated errno is returned on
@@ -124,7 +175,7 @@ int modlib_symvalue(FAR struct module_s *modp,
  *
  ****************************************************************************/
 
-int modlib_loadshdrs(FAR struct mod_loadinfo_s *loadinfo);
+int modlib_loadhdrs(FAR struct mod_loadinfo_s *loadinfo);
 
 /****************************************************************************
  * Name: modlib_findsection

--- a/libs/libc/modlib/modlib_armv7m_globals.S
+++ b/libs/libc/modlib/modlib_armv7m_globals.S
@@ -1,0 +1,1119 @@
+        .arch armv7e-m
+        .syntax unified
+        .thumb
+        .data
+        .align 4
+	.global globalNames
+
+globalNames:
+.L0:	.string	"_ZdlPvj"
+.L1:	.string	"__cos"
+.L2:	.string	"__cxa_pure_virtual"
+.L3:	.string	"__dso_handle"
+.L4:	.string	"__dtoa_engine"
+.L5:	.string	"__sin"
+.L6:	.string	"__swap_uint32"
+.L7:	.string	"__swap_uint64"
+.L8:	.string	"__ultoa_invert"
+.L9:	.string	"_exit"
+.L10:	.string	"abort"
+.L11:	.string	"abs"
+.L12:	.string	"accept"
+.L13:	.string	"access"
+.L14:	.string	"acos"
+.L15:	.string	"acosf"
+.L16:	.string	"acosh"
+.L17:	.string	"acoshf"
+.L18:	.string	"acoshl"
+.L19:	.string	"acosl"
+.L20:	.string	"add_file_action"
+.L21:	.string	"asin"
+.L22:	.string	"asinf"
+.L23:	.string	"asinh"
+.L24:	.string	"asinhf"
+.L25:	.string	"asinhl"
+.L26:	.string	"asinl"
+.L27:	.string	"asprintf"
+.L28:	.string	"atan"
+.L29:	.string	"atan2"
+.L30:	.string	"atan2f"
+.L31:	.string	"atan2l"
+.L32:	.string	"atanf"
+.L33:	.string	"atanh"
+.L34:	.string	"atanhf"
+.L35:	.string	"atanhl"
+.L36:	.string	"atanl"
+.L37:	.string	"b16atan2"
+.L38:	.string	"b16cos"
+.L39:	.string	"b16sin"
+.L40:	.string	"basename"
+.L41:	.string	"bind"
+.L42:	.string	"boardctl"
+.L43:	.string	"bsearch"
+.L44:	.string	"cabs"
+.L45:	.string	"cacheflush"
+.L46:	.string	"calloc"
+.L47:	.string	"cbrtf"
+.L48:	.string	"ceil"
+.L49:	.string	"ceilf"
+.L50:	.string	"ceill"
+.L51:	.string	"cfgetspeed"
+.L52:	.string	"cfmakeraw"
+.L53:	.string	"cfsetspeed"
+.L54:	.string	"chdir"
+.L55:	.string	"cimag"
+.L56:	.string	"clearenv"
+.L57:	.string	"clearerr"
+.L58:	.string	"clock"
+.L59:	.string	"close"
+.L60:	.string	"closedir"
+.L61:	.string	"connect"
+.L62:	.string	"copysign"
+.L63:	.string	"copysignf"
+.L64:	.string	"copysignl"
+.L65:	.string	"cos"
+.L66:	.string	"cosf"
+.L67:	.string	"cosh"
+.L68:	.string	"coshf"
+.L69:	.string	"coshl"
+.L70:	.string	"cosl"
+.L71:	.string	"crc16"
+.L72:	.string	"crc16part"
+.L73:	.string	"crc32"
+.L74:	.string	"crc32part"
+.L75:	.string	"crc64"
+.L76:	.string	"crc64part"
+.L77:	.string	"crc8"
+.L78:	.string	"crc8ccitt"
+.L79:	.string	"crc8part"
+.L80:	.string	"creal"
+.L81:	.string	"daemon"
+.L82:	.string	"difftime"
+.L83:	.string	"dirname"
+.L84:	.string	"div"
+.L85:	.string	"dlclose"
+.L86:	.string	"dlerror"
+.L87:	.string	"dlopen"
+.L88:	.string	"dlsym"
+.L89:	.string	"dlsymtab"
+.L90:	.string	"dns_add_nameserver"
+.L91:	.string	"dns_bind"
+.L92:	.string	"dns_find_answer"
+.L93:	.string	"dns_foreach_nameserver"
+.L94:	.string	"dns_initialize"
+.L95:	.string	"dns_notify_nameserver"
+.L96:	.string	"dns_query"
+.L97:	.string	"dns_register_notify"
+.L98:	.string	"dns_save_answer"
+.L99:	.string	"dns_semgive"
+.L100:	.string	"dns_semtake"
+.L101:	.string	"dns_unregister_notify"
+.L102:	.string	"dprintf"
+.L103:	.string	"dup"
+.L104:	.string	"dup2"
+.L105:	.string	"envpath_init"
+.L106:	.string	"envpath_next"
+.L107:	.string	"envpath_release"
+.L108:	.string	"erf"
+.L109:	.string	"erff"
+.L110:	.string	"erfl"
+.L111:	.string	"ether_ntoa"
+.L112:	.string	"exec"
+.L113:	.string	"exit"
+.L114:	.string	"exp"
+.L115:	.string	"expf"
+.L116:	.string	"expl"
+.L117:	.string	"explicit_bzero"
+.L118:	.string	"fabs"
+.L119:	.string	"fabsf"
+.L120:	.string	"fabsl"
+.L121:	.string	"fclose"
+.L122:	.string	"fcntl"
+.L123:	.string	"fdopen"
+.L124:	.string	"feof"
+.L125:	.string	"ferror"
+.L126:	.string	"fflush"
+.L127:	.string	"ffs"
+.L128:	.string	"ffsl"
+.L129:	.string	"ffsll"
+.L130:	.string	"fgetc"
+.L131:	.string	"fgetpos"
+.L132:	.string	"fgets"
+.L133:	.string	"fileno"
+.L134:	.string	"floor"
+.L135:	.string	"floorf"
+.L136:	.string	"floorl"
+.L137:	.string	"fls"
+.L138:	.string	"flsl"
+.L139:	.string	"flsll"
+.L140:	.string	"fma"
+.L141:	.string	"fmaf"
+.L142:	.string	"fmod"
+.L143:	.string	"fmodf"
+.L144:	.string	"fmodl"
+.L145:	.string	"fopen"
+.L146:	.string	"fprintf"
+.L147:	.string	"fputc"
+.L148:	.string	"fputs"
+.L149:	.string	"fread"
+.L150:	.string	"free"
+.L151:	.string	"freeaddrinfo"
+.L152:	.string	"freopen"
+.L153:	.string	"frexp"
+.L154:	.string	"frexpf"
+.L155:	.string	"frexpl"
+.L156:	.string	"fscanf"
+.L157:	.string	"fseek"
+.L158:	.string	"fsetpos"
+.L159:	.string	"fstat"
+.L160:	.string	"fstatfs"
+.L161:	.string	"fsync"
+.L162:	.string	"ftell"
+.L163:	.string	"ftruncate"
+.L164:	.string	"fwrite"
+.L165:	.string	"gai_strerror"
+.L166:	.string	"gamma"
+.L167:	.string	"getaddrinfo"
+.L168:	.string	"getcwd"
+.L169:	.string	"getenv"
+.L170:	.string	"gethostbyaddr"
+.L171:	.string	"gethostbyaddr_r"
+.L172:	.string	"gethostbyname"
+.L173:	.string	"gethostbyname_r"
+.L174:	.string	"gethostname"
+.L175:	.string	"getnameinfo"
+.L176:	.string	"getopt"
+.L177:	.string	"getoptargp"
+.L178:	.string	"getoptindp"
+.L179:	.string	"getoptoptp"
+.L180:	.string	"getpeername"
+.L181:	.string	"getpid"
+.L182:	.string	"getprotobyname"
+.L183:	.string	"getrandom"
+.L184:	.string	"gets"
+.L185:	.string	"gets_s"
+.L186:	.string	"getservbyname"
+.L187:	.string	"getservbyname_r"
+.L188:	.string	"getsockname"
+.L189:	.string	"getsockopt"
+.L190:	.string	"gettimeofday"
+.L191:	.string	"gmtime"
+.L192:	.string	"gmtime_r"
+.L193:	.string	"h_errno"
+.L194:	.string	"htonl"
+.L195:	.string	"htons"
+.L196:	.string	"hypot"
+.L197:	.string	"ilogb"
+.L198:	.string	"ilogbf"
+.L199:	.string	"imaxabs"
+.L200:	.string	"in6addr_any"
+.L201:	.string	"inet_addr"
+.L202:	.string	"inet_aton"
+.L203:	.string	"inet_ntoa"
+.L204:	.string	"inet_ntop"
+.L205:	.string	"inet_pton"
+.L206:	.string	"ioctl"
+.L207:	.string	"isatty"
+.L208:	.string	"itoa"
+.L209:	.string	"kill"
+.L210:	.string	"labs"
+.L211:	.string	"ldexp"
+.L212:	.string	"ldexpf"
+.L213:	.string	"ldexpl"
+.L214:	.string	"ldiv"
+.L215:	.string	"lgamma"
+.L216:	.string	"lgamma_r"
+.L217:	.string	"listen"
+.L218:	.string	"llabs"
+.L219:	.string	"lldiv"
+.L220:	.string	"localeconv"
+.L221:	.string	"log"
+.L222:	.string	"log10"
+.L223:	.string	"log10f"
+.L224:	.string	"log10l"
+.L225:	.string	"log2"
+.L226:	.string	"log2f"
+.L227:	.string	"log2l"
+.L228:	.string	"logf"
+.L229:	.string	"logl"
+.L230:	.string	"lseek"
+.L231:	.string	"malloc"
+.L232:	.string	"match"
+.L233:	.string	"meadow_mappings"
+.L234:	.string	"memalign"
+.L235:	.string	"memccpy"
+.L236:	.string	"memchr"
+.L237:	.string	"memcmp"
+.L238:	.string	"memcpy"
+.L239:	.string	"memmove"
+.L240:	.string	"memrchr"
+.L241:	.string	"memset"
+.L242:	.string	"mkdir"
+.L243:	.string	"mkfifo"
+.L244:	.string	"mkfifo2"
+.L245:	.string	"mkstemp"
+.L246:	.string	"mktemp"
+.L247:	.string	"mktime"
+.L248:	.string	"mmap"
+.L249:	.string	"modf"
+.L250:	.string	"modff"
+.L251:	.string	"modfl"
+.L252:	.string	"mono_main"
+.L253:	.string	"mono_should_run"
+.L254:	.string	"mount"
+.L255:	.string	"munmap"
+.L256:	.string	"nanosleep"
+.L257:	.string	"nrand"
+.L258:	.string	"ntohl"
+.L259:	.string	"ntohs"
+.L260:	.string	"open"
+.L261:	.string	"opendir"
+.L262:	.string	"optarg"
+.L263:	.string	"optind"
+.L264:	.string	"optopt"
+.L265:	.string	"perror"
+.L266:	.string	"pipe"
+.L267:	.string	"pipe2"
+.L268:	.string	"poll"
+.L269:	.string	"posix_spawnattr_dump"
+.L270:	.string	"posix_spawnattr_getflags"
+.L271:	.string	"posix_spawnattr_getschedparam"
+.L272:	.string	"posix_spawnattr_getschedpolicy"
+.L273:	.string	"posix_spawnattr_getsigmask"
+.L274:	.string	"posix_spawnattr_init"
+.L275:	.string	"posix_spawnattr_setflags"
+.L276:	.string	"posix_spawnattr_setschedparam"
+.L277:	.string	"posix_spawnattr_setschedpolicy"
+.L278:	.string	"posix_spawnattr_setsigmask"
+.L279:	.string	"pow"
+.L280:	.string	"powf"
+.L281:	.string	"powl"
+.L282:	.string	"ppoll"
+.L283:	.string	"prctl"
+.L284:	.string	"pread"
+.L285:	.string	"printf"
+.L286:	.string	"pselect"
+.L287:	.string	"psiginfo"
+.L288:	.string	"psignal"
+.L289:	.string	"pthread_attr_destroy"
+.L290:	.string	"pthread_attr_getinheritsched"
+.L291:	.string	"pthread_attr_getschedparam"
+.L292:	.string	"pthread_attr_getschedpolicy"
+.L293:	.string	"pthread_attr_getstack"
+.L294:	.string	"pthread_attr_getstacksize"
+.L295:	.string	"pthread_attr_init"
+.L296:	.string	"pthread_attr_setinheritsched"
+.L297:	.string	"pthread_attr_setschedparam"
+.L298:	.string	"pthread_attr_setschedpolicy"
+.L299:	.string	"pthread_attr_setstack"
+.L300:	.string	"pthread_attr_setstacksize"
+.L301:	.string	"pthread_barrier_destroy"
+.L302:	.string	"pthread_barrier_init"
+.L303:	.string	"pthread_barrier_wait"
+.L304:	.string	"pthread_barrierattr_destroy"
+.L305:	.string	"pthread_barrierattr_getpshared"
+.L306:	.string	"pthread_barrierattr_init"
+.L307:	.string	"pthread_barrierattr_setpshared"
+.L308:	.string	"pthread_cancel"
+.L309:	.string	"pthread_cleanup_pop"
+.L310:	.string	"pthread_cleanup_push"
+.L311:	.string	"pthread_cond_broadcast"
+.L312:	.string	"pthread_cond_destroy"
+.L313:	.string	"pthread_cond_init"
+.L314:	.string	"pthread_cond_signal"
+.L315:	.string	"pthread_cond_timedwait"
+.L316:	.string	"pthread_cond_wait"
+.L317:	.string	"pthread_condattr_destroy"
+.L318:	.string	"pthread_condattr_init"
+.L319:	.string	"pthread_create"
+.L320:	.string	"pthread_detach"
+.L321:	.string	"pthread_exit"
+.L322:	.string	"pthread_get_stackaddr_np"
+.L323:	.string	"pthread_get_stacksize_np"
+.L324:	.string	"pthread_getschedparam"
+.L325:	.string	"pthread_getspecific"
+.L326:	.string	"pthread_join"
+.L327:	.string	"pthread_key_create"
+.L328:	.string	"pthread_key_delete"
+.L329:	.string	"pthread_kill"
+.L330:	.string	"pthread_mutex_consistent"
+.L331:	.string	"pthread_mutex_destroy"
+.L332:	.string	"pthread_mutex_init"
+.L333:	.string	"pthread_mutex_lock"
+.L334:	.string	"pthread_mutex_timedlock"
+.L335:	.string	"pthread_mutex_trylock"
+.L336:	.string	"pthread_mutex_unlock"
+.L337:	.string	"pthread_mutexattr_destroy"
+.L338:	.string	"pthread_mutexattr_getprotocol"
+.L339:	.string	"pthread_mutexattr_getpshared"
+.L340:	.string	"pthread_mutexattr_getrobust"
+.L341:	.string	"pthread_mutexattr_gettype"
+.L342:	.string	"pthread_mutexattr_init"
+.L343:	.string	"pthread_mutexattr_setprotocol"
+.L344:	.string	"pthread_mutexattr_setpshared"
+.L345:	.string	"pthread_mutexattr_setrobust"
+.L346:	.string	"pthread_mutexattr_settype"
+.L347:	.string	"pthread_once"
+.L348:	.string	"pthread_rwlock_destroy"
+.L349:	.string	"pthread_rwlock_init"
+.L350:	.string	"pthread_rwlock_rdlock"
+.L351:	.string	"pthread_rwlock_timedrdlock"
+.L352:	.string	"pthread_rwlock_timedwrlock"
+.L353:	.string	"pthread_rwlock_tryrdlock"
+.L354:	.string	"pthread_rwlock_trywrlock"
+.L355:	.string	"pthread_rwlock_unlock"
+.L356:	.string	"pthread_rwlock_wrlock"
+.L357:	.string	"pthread_setcancelstate"
+.L358:	.string	"pthread_setcanceltype"
+.L359:	.string	"pthread_setschedparam"
+.L360:	.string	"pthread_setschedprio"
+.L361:	.string	"pthread_setspecific"
+.L362:	.string	"pthread_sigmask"
+.L363:	.string	"pthread_startup"
+.L364:	.string	"pthread_testcancel"
+.L365:	.string	"pthread_yield"
+.L366:	.string	"putenv"
+.L367:	.string	"puts"
+.L368:	.string	"pwrite"
+.L369:	.string	"qsort"
+.L370:	.string	"raise"
+.L371:	.string	"rand"
+.L372:	.string	"random"
+.L373:	.string	"read"
+.L374:	.string	"readdir"
+.L375:	.string	"readdir_r"
+.L376:	.string	"readv"
+.L377:	.string	"realloc"
+.L378:	.string	"recv"
+.L379:	.string	"recvfrom"
+.L380:	.string	"recvmsg"
+.L381:	.string	"remove"
+.L382:	.string	"rename"
+.L383:	.string	"rewinddir"
+.L384:	.string	"rint"
+.L385:	.string	"rintf"
+.L386:	.string	"rintl"
+.L387:	.string	"rmdir"
+.L388:	.string	"round"
+.L389:	.string	"roundf"
+.L390:	.string	"roundl"
+.L391:	.string	"scalbn"
+.L392:	.string	"scalbnf"
+.L393:	.string	"scanf"
+.L394:	.string	"seekdir"
+.L395:	.string	"select"
+.L396:	.string	"sem_destroy"
+.L397:	.string	"sem_getprotocol"
+.L398:	.string	"sem_getvalue"
+.L399:	.string	"sem_init"
+.L400:	.string	"sem_post"
+.L401:	.string	"sem_setprotocol"
+.L402:	.string	"sem_timedwait"
+.L403:	.string	"sem_trywait"
+.L404:	.string	"sem_wait"
+.L405:	.string	"send"
+.L406:	.string	"sendfile"
+.L407:	.string	"sendmsg"
+.L408:	.string	"sendto"
+.L409:	.string	"set_errno"
+.L410:	.string	"setbuf"
+.L411:	.string	"setenv"
+.L412:	.string	"sethostname"
+.L413:	.string	"setlocale"
+.L414:	.string	"setlogmask"
+.L415:	.string	"setsockopt"
+.L416:	.string	"settimeofday"
+.L417:	.string	"setvbuf"
+.L418:	.string	"shutdown"
+.L419:	.string	"sigaction"
+.L420:	.string	"sigaddset"
+.L421:	.string	"sigdelset"
+.L422:	.string	"sigemptyset"
+.L423:	.string	"sigfillset"
+.L424:	.string	"sighold"
+.L425:	.string	"sigignore"
+.L426:	.string	"sigismember"
+.L427:	.string	"signal"
+.L428:	.string	"sigpause"
+.L429:	.string	"sigpending"
+.L430:	.string	"sigprocmask"
+.L431:	.string	"sigqueue"
+.L432:	.string	"sigrelse"
+.L433:	.string	"sigset"
+.L434:	.string	"sigsuspend"
+.L435:	.string	"sigtimedwait"
+.L436:	.string	"sigwait"
+.L437:	.string	"sigwaitinfo"
+.L438:	.string	"sin"
+.L439:	.string	"sinf"
+.L440:	.string	"sinh"
+.L441:	.string	"sinhf"
+.L442:	.string	"sinhl"
+.L443:	.string	"sinl"
+.L444:	.string	"sleep"
+.L445:	.string	"snprintf"
+.L446:	.string	"socket"
+.L447:	.string	"sprintf"
+.L448:	.string	"sqrt"
+.L449:	.string	"sqrtf"
+.L450:	.string	"sqrtl"
+.L451:	.string	"srand"
+.L452:	.string	"sscanf"
+.L453:	.string	"stat"
+.L454:	.string	"statfs"
+.L455:	.string	"stpcpy"
+.L456:	.string	"stpncpy"
+.L457:	.string	"strcasecmp"
+.L458:	.string	"strcasestr"
+.L459:	.string	"strcat"
+.L460:	.string	"strchr"
+.L461:	.string	"strcmp"
+.L462:	.string	"strcoll"
+.L463:	.string	"strcpy"
+.L464:	.string	"strcspn"
+.L465:	.string	"strdup"
+.L466:	.string	"stream_semgive"
+.L467:	.string	"stream_semtake"
+.L468:	.string	"strerror"
+.L469:	.string	"strerror_r"
+.L470:	.string	"strftime"
+.L471:	.string	"strlen"
+.L472:	.string	"strncasecmp"
+.L473:	.string	"strncat"
+.L474:	.string	"strncmp"
+.L475:	.string	"strncpy"
+.L476:	.string	"strndup"
+.L477:	.string	"strnlen"
+.L478:	.string	"strpbrk"
+.L479:	.string	"strrchr"
+.L480:	.string	"strsep"
+.L481:	.string	"strsignal"
+.L482:	.string	"strspn"
+.L483:	.string	"strstr"
+.L484:	.string	"strtod"
+.L485:	.string	"strtof"
+.L486:	.string	"strtoimax"
+.L487:	.string	"strtok"
+.L488:	.string	"strtok_r"
+.L489:	.string	"strtol"
+.L490:	.string	"strtold"
+.L491:	.string	"strtoll"
+.L492:	.string	"strtoul"
+.L493:	.string	"strtoull"
+.L494:	.string	"strtoumax"
+.L495:	.string	"strxfrm"
+.L496:	.string	"swab"
+.L497:	.string	"sysconf"
+.L498:	.string	"syslog"
+.L499:	.string	"tan"
+.L500:	.string	"tanf"
+.L501:	.string	"tanh"
+.L502:	.string	"tanhf"
+.L503:	.string	"tanhl"
+.L504:	.string	"tanl"
+.L505:	.string	"tcdrain"
+.L506:	.string	"tcflow"
+.L507:	.string	"tcflush"
+.L508:	.string	"tcgetattr"
+.L509:	.string	"tcsetattr"
+.L510:	.string	"tea_decrypt"
+.L511:	.string	"tea_encrypt"
+.L512:	.string	"telldir"
+.L513:	.string	"tempnam"
+.L514:	.string	"tgamma"
+.L515:	.string	"time"
+.L516:	.string	"tmpnam"
+.L517:	.string	"trunc"
+.L518:	.string	"truncate"
+.L519:	.string	"truncf"
+.L520:	.string	"truncl"
+.L521:	.string	"uadd32x64"
+.L522:	.string	"uadd64"
+.L523:	.string	"ub32sqrtub16"
+.L524:	.string	"umul32"
+.L525:	.string	"umul32x64"
+.L526:	.string	"umul64"
+.L527:	.string	"uname"
+.L528:	.string	"ungetc"
+.L529:	.string	"unlink"
+.L530:	.string	"unsetenv"
+.L531:	.string	"usleep"
+.L532:	.string	"usub64"
+.L533:	.string	"usub64x32"
+.L534:	.string	"vasprintf"
+.L535:	.string	"vdprintf"
+.L536:	.string	"vfork"
+.L537:	.string	"vfprintf"
+.L538:	.string	"vfscanf"
+.L539:	.string	"vprintf"
+.L540:	.string	"vsnprintf"
+.L541:	.string	"vsprintf"
+.L542:	.string	"vsscanf"
+.L543:	.string	"vsyslog"
+.L544:	.string	"waitpid"
+.L545:	.string	"write"
+.L546:	.string	"writev"
+.L547:	.string	"xorshift128"
+.L548:	.string	"zalloc"
+	.size	globalNames, . - globalNames
+
+	.align	4
+	.global	nGlobals
+	.type	nGlobals, "object"
+nGlobals:	
+	.word	549
+	.size	nGlobals, . - nGlobals
+
+	.global globalTable
+	.type	globalTable, "object"
+globalTable:
+	.word	.L0, _ZdlPvj
+	.word	.L1, __cos
+	.word	.L2, __cxa_pure_virtual
+	.word	.L3, __dso_handle
+	.word	.L4, __dtoa_engine
+	.word	.L5, __sin
+	.word	.L6, __swap_uint32
+	.word	.L7, __swap_uint64
+	.word	.L8, __ultoa_invert
+	.word	.L9, _exit
+	.word	.L10, abort
+	.word	.L11, abs
+	.word	.L12, accept
+	.word	.L13, access
+	.word	.L14, acos
+	.word	.L15, acosf
+	.word	.L16, acosh
+	.word	.L17, acoshf
+	.word	.L18, acoshl
+	.word	.L19, acosl
+	.word	.L20, add_file_action
+	.word	.L21, asin
+	.word	.L22, asinf
+	.word	.L23, asinh
+	.word	.L24, asinhf
+	.word	.L25, asinhl
+	.word	.L26, asinl
+	.word	.L27, asprintf
+	.word	.L28, atan
+	.word	.L29, atan2
+	.word	.L30, atan2f
+	.word	.L31, atan2l
+	.word	.L32, atanf
+	.word	.L33, atanh
+	.word	.L34, atanhf
+	.word	.L35, atanhl
+	.word	.L36, atanl
+	.word	.L37, b16atan2
+	.word	.L38, b16cos
+	.word	.L39, b16sin
+	.word	.L40, basename
+	.word	.L41, bind
+	.word	.L42, boardctl
+	.word	.L43, bsearch
+	.word	.L44, cabs
+	.word	.L45, cacheflush
+	.word	.L46, calloc
+	.word	.L47, cbrtf
+	.word	.L48, ceil
+	.word	.L49, ceilf
+	.word	.L50, ceill
+	.word	.L51, cfgetspeed
+	.word	.L52, cfmakeraw
+	.word	.L53, cfsetspeed
+	.word	.L54, chdir
+	.word	.L55, cimag
+	.word	.L56, clearenv
+	.word	.L57, clearerr
+	.word	.L58, clock
+	.word	.L59, close
+	.word	.L60, closedir
+	.word	.L61, connect
+	.word	.L62, copysign
+	.word	.L63, copysignf
+	.word	.L64, copysignl
+	.word	.L65, cos
+	.word	.L66, cosf
+	.word	.L67, cosh
+	.word	.L68, coshf
+	.word	.L69, coshl
+	.word	.L70, cosl
+	.word	.L71, crc16
+	.word	.L72, crc16part
+	.word	.L73, crc32
+	.word	.L74, crc32part
+	.word	.L75, crc64
+	.word	.L76, crc64part
+	.word	.L77, crc8
+	.word	.L78, crc8ccitt
+	.word	.L79, crc8part
+	.word	.L80, creal
+	.word	.L81, daemon
+	.word	.L82, difftime
+	.word	.L83, dirname
+	.word	.L84, div
+	.word	.L85, dlclose
+	.word	.L86, dlerror
+	.word	.L87, dlopen
+	.word	.L88, dlsym
+	.word	.L89, dlsymtab
+	.word	.L90, dns_add_nameserver
+	.word	.L91, dns_bind
+	.word	.L92, dns_find_answer
+	.word	.L93, dns_foreach_nameserver
+	.word	.L94, dns_initialize
+	.word	.L95, dns_notify_nameserver
+	.word	.L96, dns_query
+	.word	.L97, dns_register_notify
+	.word	.L98, dns_save_answer
+	.word	.L99, dns_semgive
+	.word	.L100, dns_semtake
+	.word	.L101, dns_unregister_notify
+	.word	.L102, dprintf
+	.word	.L103, dup
+	.word	.L104, dup2
+	.word	.L105, envpath_init
+	.word	.L106, envpath_next
+	.word	.L107, envpath_release
+	.word	.L108, erf
+	.word	.L109, erff
+	.word	.L110, erfl
+	.word	.L111, ether_ntoa
+	.word	.L112, exec
+	.word	.L113, exit
+	.word	.L114, exp
+	.word	.L115, expf
+	.word	.L116, expl
+	.word	.L117, explicit_bzero
+	.word	.L118, fabs
+	.word	.L119, fabsf
+	.word	.L120, fabsl
+	.word	.L121, fclose
+	.word	.L122, fcntl
+	.word	.L123, fdopen
+	.word	.L124, feof
+	.word	.L125, ferror
+	.word	.L126, fflush
+	.word	.L127, ffs
+	.word	.L128, ffsl
+	.word	.L129, ffsll
+	.word	.L130, fgetc
+	.word	.L131, fgetpos
+	.word	.L132, fgets
+	.word	.L133, fileno
+	.word	.L134, floor
+	.word	.L135, floorf
+	.word	.L136, floorl
+	.word	.L137, fls
+	.word	.L138, flsl
+	.word	.L139, flsll
+	.word	.L140, fma
+	.word	.L141, fmaf
+	.word	.L142, fmod
+	.word	.L143, fmodf
+	.word	.L144, fmodl
+	.word	.L145, fopen
+	.word	.L146, fprintf
+	.word	.L147, fputc
+	.word	.L148, fputs
+	.word	.L149, fread
+	.word	.L150, free
+	.word	.L151, freeaddrinfo
+	.word	.L152, freopen
+	.word	.L153, frexp
+	.word	.L154, frexpf
+	.word	.L155, frexpl
+	.word	.L156, fscanf
+	.word	.L157, fseek
+	.word	.L158, fsetpos
+	.word	.L159, fstat
+	.word	.L160, fstatfs
+	.word	.L161, fsync
+	.word	.L162, ftell
+	.word	.L163, ftruncate
+	.word	.L164, fwrite
+	.word	.L165, gai_strerror
+	.word	.L166, gamma
+	.word	.L167, getaddrinfo
+	.word	.L168, getcwd
+	.word	.L169, getenv
+	.word	.L170, gethostbyaddr
+	.word	.L171, gethostbyaddr_r
+	.word	.L172, gethostbyname
+	.word	.L173, gethostbyname_r
+	.word	.L174, gethostname
+	.word	.L175, getnameinfo
+	.word	.L176, getopt
+	.word	.L177, getoptargp
+	.word	.L178, getoptindp
+	.word	.L179, getoptoptp
+	.word	.L180, getpeername
+	.word	.L181, getpid
+	.word	.L182, getprotobyname
+	.word	.L183, getrandom
+	.word	.L184, gets
+	.word	.L185, gets_s
+	.word	.L186, getservbyname
+	.word	.L187, getservbyname_r
+	.word	.L188, getsockname
+	.word	.L189, getsockopt
+	.word	.L190, gettimeofday
+	.word	.L191, gmtime
+	.word	.L192, gmtime_r
+	.word	.L193, h_errno
+	.word	.L194, htonl
+	.word	.L195, htons
+	.word	.L196, hypot
+	.word	.L197, ilogb
+	.word	.L198, ilogbf
+	.word	.L199, imaxabs
+	.word	.L200, in6addr_any
+	.word	.L201, inet_addr
+	.word	.L202, inet_aton
+	.word	.L203, inet_ntoa
+	.word	.L204, inet_ntop
+	.word	.L205, inet_pton
+	.word	.L206, ioctl
+	.word	.L207, isatty
+	.word	.L208, itoa
+	.word	.L209, kill
+	.word	.L210, labs
+	.word	.L211, ldexp
+	.word	.L212, ldexpf
+	.word	.L213, ldexpl
+	.word	.L214, ldiv
+	.word	.L215, lgamma
+	.word	.L216, lgamma_r
+	.word	.L217, listen
+	.word	.L218, llabs
+	.word	.L219, lldiv
+	.word	.L220, localeconv
+	.word	.L221, log
+	.word	.L222, log10
+	.word	.L223, log10f
+	.word	.L224, log10l
+	.word	.L225, log2
+	.word	.L226, log2f
+	.word	.L227, log2l
+	.word	.L228, logf
+	.word	.L229, logl
+	.word	.L230, lseek
+	.word	.L231, malloc
+	.word	.L232, match
+	.word	.L233, meadow_mappings
+	.word	.L234, memalign
+	.word	.L235, memccpy
+	.word	.L236, memchr
+	.word	.L237, memcmp
+	.word	.L238, memcpy
+	.word	.L239, memmove
+	.word	.L240, memrchr
+	.word	.L241, memset
+	.word	.L242, mkdir
+	.word	.L243, mkfifo
+	.word	.L244, mkfifo2
+	.word	.L245, mkstemp
+	.word	.L246, mktemp
+	.word	.L247, mktime
+	.word	.L248, mmap
+	.word	.L249, modf
+	.word	.L250, modff
+	.word	.L251, modfl
+	.word	.L252, mono_main
+	.word	.L253, mono_should_run
+	.word	.L254, mount
+	.word	.L255, munmap
+	.word	.L256, nanosleep
+	.word	.L257, nrand
+	.word	.L258, ntohl
+	.word	.L259, ntohs
+	.word	.L260, open
+	.word	.L261, opendir
+	.word	.L262, optarg
+	.word	.L263, optind
+	.word	.L264, optopt
+	.word	.L265, perror
+	.word	.L266, pipe
+	.word	.L267, pipe2
+	.word	.L268, poll
+	.word	.L269, posix_spawnattr_dump
+	.word	.L270, posix_spawnattr_getflags
+	.word	.L271, posix_spawnattr_getschedparam
+	.word	.L272, posix_spawnattr_getschedpolicy
+	.word	.L273, posix_spawnattr_getsigmask
+	.word	.L274, posix_spawnattr_init
+	.word	.L275, posix_spawnattr_setflags
+	.word	.L276, posix_spawnattr_setschedparam
+	.word	.L277, posix_spawnattr_setschedpolicy
+	.word	.L278, posix_spawnattr_setsigmask
+	.word	.L279, pow
+	.word	.L280, powf
+	.word	.L281, powl
+	.word	.L282, ppoll
+	.word	.L283, prctl
+	.word	.L284, pread
+	.word	.L285, printf
+	.word	.L286, pselect
+	.word	.L287, psiginfo
+	.word	.L288, psignal
+	.word	.L289, pthread_attr_destroy
+	.word	.L290, pthread_attr_getinheritsched
+	.word	.L291, pthread_attr_getschedparam
+	.word	.L292, pthread_attr_getschedpolicy
+	.word	.L293, pthread_attr_getstack
+	.word	.L294, pthread_attr_getstacksize
+	.word	.L295, pthread_attr_init
+	.word	.L296, pthread_attr_setinheritsched
+	.word	.L297, pthread_attr_setschedparam
+	.word	.L298, pthread_attr_setschedpolicy
+	.word	.L299, pthread_attr_setstack
+	.word	.L300, pthread_attr_setstacksize
+	.word	.L301, pthread_barrier_destroy
+	.word	.L302, pthread_barrier_init
+	.word	.L303, pthread_barrier_wait
+	.word	.L304, pthread_barrierattr_destroy
+	.word	.L305, pthread_barrierattr_getpshared
+	.word	.L306, pthread_barrierattr_init
+	.word	.L307, pthread_barrierattr_setpshared
+	.word	.L308, pthread_cancel
+	.word	.L309, pthread_cleanup_pop
+	.word	.L310, pthread_cleanup_push
+	.word	.L311, pthread_cond_broadcast
+	.word	.L312, pthread_cond_destroy
+	.word	.L313, pthread_cond_init
+	.word	.L314, pthread_cond_signal
+	.word	.L315, pthread_cond_timedwait
+	.word	.L316, pthread_cond_wait
+	.word	.L317, pthread_condattr_destroy
+	.word	.L318, pthread_condattr_init
+	.word	.L319, pthread_create
+	.word	.L320, pthread_detach
+	.word	.L321, pthread_exit
+	.word	.L322, pthread_get_stackaddr_np
+	.word	.L323, pthread_get_stacksize_np
+	.word	.L324, pthread_getschedparam
+	.word	.L325, pthread_getspecific
+	.word	.L326, pthread_join
+	.word	.L327, pthread_key_create
+	.word	.L328, pthread_key_delete
+	.word	.L329, pthread_kill
+	.word	.L330, pthread_mutex_consistent
+	.word	.L331, pthread_mutex_destroy
+	.word	.L332, pthread_mutex_init
+	.word	.L333, pthread_mutex_lock
+	.word	.L334, pthread_mutex_timedlock
+	.word	.L335, pthread_mutex_trylock
+	.word	.L336, pthread_mutex_unlock
+	.word	.L337, pthread_mutexattr_destroy
+	.word	.L338, pthread_mutexattr_getprotocol
+	.word	.L339, pthread_mutexattr_getpshared
+	.word	.L340, pthread_mutexattr_getrobust
+	.word	.L341, pthread_mutexattr_gettype
+	.word	.L342, pthread_mutexattr_init
+	.word	.L343, pthread_mutexattr_setprotocol
+	.word	.L344, pthread_mutexattr_setpshared
+	.word	.L345, pthread_mutexattr_setrobust
+	.word	.L346, pthread_mutexattr_settype
+	.word	.L347, pthread_once
+	.word	.L348, pthread_rwlock_destroy
+	.word	.L349, pthread_rwlock_init
+	.word	.L350, pthread_rwlock_rdlock
+	.word	.L351, pthread_rwlock_timedrdlock
+	.word	.L352, pthread_rwlock_timedwrlock
+	.word	.L353, pthread_rwlock_tryrdlock
+	.word	.L354, pthread_rwlock_trywrlock
+	.word	.L355, pthread_rwlock_unlock
+	.word	.L356, pthread_rwlock_wrlock
+	.word	.L357, pthread_setcancelstate
+	.word	.L358, pthread_setcanceltype
+	.word	.L359, pthread_setschedparam
+	.word	.L360, pthread_setschedprio
+	.word	.L361, pthread_setspecific
+	.word	.L362, pthread_sigmask
+	.word	.L363, pthread_startup
+	.word	.L364, pthread_testcancel
+	.word	.L365, pthread_yield
+	.word	.L366, putenv
+	.word	.L367, puts
+	.word	.L368, pwrite
+	.word	.L369, qsort
+	.word	.L370, raise
+	.word	.L371, rand
+	.word	.L372, random
+	.word	.L373, read
+	.word	.L374, readdir
+	.word	.L375, readdir_r
+	.word	.L376, readv
+	.word	.L377, realloc
+	.word	.L378, recv
+	.word	.L379, recvfrom
+	.word	.L380, recvmsg
+	.word	.L381, remove
+	.word	.L382, rename
+	.word	.L383, rewinddir
+	.word	.L384, rint
+	.word	.L385, rintf
+	.word	.L386, rintl
+	.word	.L387, rmdir
+	.word	.L388, round
+	.word	.L389, roundf
+	.word	.L390, roundl
+	.word	.L391, scalbn
+	.word	.L392, scalbnf
+	.word	.L393, scanf
+	.word	.L394, seekdir
+	.word	.L395, select
+	.word	.L396, sem_destroy
+	.word	.L397, sem_getprotocol
+	.word	.L398, sem_getvalue
+	.word	.L399, sem_init
+	.word	.L400, sem_post
+	.word	.L401, sem_setprotocol
+	.word	.L402, sem_timedwait
+	.word	.L403, sem_trywait
+	.word	.L404, sem_wait
+	.word	.L405, send
+	.word	.L406, sendfile
+	.word	.L407, sendmsg
+	.word	.L408, sendto
+	.word	.L409, set_errno
+	.word	.L410, setbuf
+	.word	.L411, setenv
+	.word	.L412, sethostname
+	.word	.L413, setlocale
+	.word	.L414, setlogmask
+	.word	.L415, setsockopt
+	.word	.L416, settimeofday
+	.word	.L417, setvbuf
+	.word	.L418, shutdown
+	.word	.L419, sigaction
+	.word	.L420, sigaddset
+	.word	.L421, sigdelset
+	.word	.L422, sigemptyset
+	.word	.L423, sigfillset
+	.word	.L424, sighold
+	.word	.L425, sigignore
+	.word	.L426, sigismember
+	.word	.L427, signal
+	.word	.L428, sigpause
+	.word	.L429, sigpending
+	.word	.L430, sigprocmask
+	.word	.L431, sigqueue
+	.word	.L432, sigrelse
+	.word	.L433, sigset
+	.word	.L434, sigsuspend
+	.word	.L435, sigtimedwait
+	.word	.L436, sigwait
+	.word	.L437, sigwaitinfo
+	.word	.L438, sin
+	.word	.L439, sinf
+	.word	.L440, sinh
+	.word	.L441, sinhf
+	.word	.L442, sinhl
+	.word	.L443, sinl
+	.word	.L444, sleep
+	.word	.L445, snprintf
+	.word	.L446, socket
+	.word	.L447, sprintf
+	.word	.L448, sqrt
+	.word	.L449, sqrtf
+	.word	.L450, sqrtl
+	.word	.L451, srand
+	.word	.L452, sscanf
+	.word	.L453, stat
+	.word	.L454, statfs
+	.word	.L455, stpcpy
+	.word	.L456, stpncpy
+	.word	.L457, strcasecmp
+	.word	.L458, strcasestr
+	.word	.L459, strcat
+	.word	.L460, strchr
+	.word	.L461, strcmp
+	.word	.L462, strcoll
+	.word	.L463, strcpy
+	.word	.L464, strcspn
+	.word	.L465, strdup
+	.word	.L466, stream_semgive
+	.word	.L467, stream_semtake
+	.word	.L468, strerror
+	.word	.L469, strerror_r
+	.word	.L470, strftime
+	.word	.L471, strlen
+	.word	.L472, strncasecmp
+	.word	.L473, strncat
+	.word	.L474, strncmp
+	.word	.L475, strncpy
+	.word	.L476, strndup
+	.word	.L477, strnlen
+	.word	.L478, strpbrk
+	.word	.L479, strrchr
+	.word	.L480, strsep
+	.word	.L481, strsignal
+	.word	.L482, strspn
+	.word	.L483, strstr
+	.word	.L484, strtod
+	.word	.L485, strtof
+	.word	.L486, strtoimax
+	.word	.L487, strtok
+	.word	.L488, strtok_r
+	.word	.L489, strtol
+	.word	.L490, strtold
+	.word	.L491, strtoll
+	.word	.L492, strtoul
+	.word	.L493, strtoull
+	.word	.L494, strtoumax
+	.word	.L495, strxfrm
+	.word	.L496, swab
+	.word	.L497, sysconf
+	.word	.L498, syslog
+	.word	.L499, tan
+	.word	.L500, tanf
+	.word	.L501, tanh
+	.word	.L502, tanhf
+	.word	.L503, tanhl
+	.word	.L504, tanl
+	.word	.L505, tcdrain
+	.word	.L506, tcflow
+	.word	.L507, tcflush
+	.word	.L508, tcgetattr
+	.word	.L509, tcsetattr
+	.word	.L510, tea_decrypt
+	.word	.L511, tea_encrypt
+	.word	.L512, telldir
+	.word	.L513, tempnam
+	.word	.L514, tgamma
+	.word	.L515, time
+	.word	.L516, tmpnam
+	.word	.L517, trunc
+	.word	.L518, truncate
+	.word	.L519, truncf
+	.word	.L520, truncl
+	.word	.L521, uadd32x64
+	.word	.L522, uadd64
+	.word	.L523, ub32sqrtub16
+	.word	.L524, umul32
+	.word	.L525, umul32x64
+	.word	.L526, umul64
+	.word	.L527, uname
+	.word	.L528, ungetc
+	.word	.L529, unlink
+	.word	.L530, unsetenv
+	.word	.L531, usleep
+	.word	.L532, usub64
+	.word	.L533, usub64x32
+	.word	.L534, vasprintf
+	.word	.L535, vdprintf
+	.word	.L536, vfork
+	.word	.L537, vfprintf
+	.word	.L538, vfscanf
+	.word	.L539, vprintf
+	.word	.L540, vsnprintf
+	.word	.L541, vsprintf
+	.word	.L542, vsscanf
+	.word	.L543, vsyslog
+	.word	.L544, waitpid
+	.word	.L545, write
+	.word	.L546, writev
+	.word	.L547, xorshift128
+	.word	.L548, zalloc
+	.size	globalTable, . - globalTable

--- a/libs/libc/modlib/modlib_bind.c
+++ b/libs/libc/modlib/modlib_bind.c
@@ -37,6 +37,14 @@
 #include "modlib/modlib.h"
 
 /****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define I_REL   0    /* Index into relxxx[] arrays for relocations */
+#define I_PLT   1    /* ... for PLTs */
+#define N_RELS  2    /* Number of relxxx[] indexes */
+
+/****************************************************************************
  * Private Types
  ****************************************************************************/
 
@@ -50,6 +58,16 @@ typedef struct
   Elf_Sym         sym;
   int             idx;
 } Elf_SymCache;
+
+struct
+{
+  int strOff;           /* Offset to string table */
+  int symOff;           /* Offset to symbol table */
+  int lSymTab;          /* Size of symbol table */
+  int relEntSz;         /* Size of relocation entry */
+  int relOff[2];        /* Offset to the relocation section */
+  int relSz[2];         /* Size of relocation table */
+} relData;
 
 /****************************************************************************
  * Private Functions
@@ -245,7 +263,8 @@ static int modlib_relocate(FAR struct module_s *modp,
 
           /* Read the symbol table entry into memory */
 
-          ret = modlib_readsym(loadinfo, symidx, sym);
+          ret = modlib_symvalue(modp, loadinfo, sym,
+                           loadinfo->shdr[loadinfo->strtabidx].sh_offset);
           if (ret < 0)
             {
               berr("ERROR: Section %d reloc %d: "
@@ -257,7 +276,8 @@ static int modlib_relocate(FAR struct module_s *modp,
 
           /* Get the value of the symbol (in sym.st_value) */
 
-          ret = modlib_symvalue(modp, loadinfo, sym);
+          ret = modlib_symvalue(modp, loadinfo, sym,
+                           loadinfo->shdr[loadinfo->strtabidx].sh_offset);
           if (ret < 0)
             {
               /* The special error -ESRCH is returned only in one condition:
@@ -433,7 +453,8 @@ static int modlib_relocateadd(FAR struct module_s *modp,
 
           /* Read the symbol table entry into memory */
 
-          ret = modlib_readsym(loadinfo, symidx, sym);
+          ret = modlib_readsym(loadinfo, symidx, sym,
+                               &loadinfo->shdr[loadinfo->symtabidx]);
           if (ret < 0)
             {
               berr("ERROR: Section %d reloc %d: "
@@ -445,7 +466,8 @@ static int modlib_relocateadd(FAR struct module_s *modp,
 
           /* Get the value of the symbol (in sym.st_value) */
 
-          ret = modlib_symvalue(modp, loadinfo, sym);
+          ret = modlib_symvalue(modp, loadinfo, sym,
+                           loadinfo->shdr[loadinfo->strtabidx].sh_offset);
           if (ret < 0)
             {
               /* The special error -ESRCH is returned only in one condition:
@@ -520,6 +542,230 @@ static int modlib_relocateadd(FAR struct module_s *modp,
 }
 
 /****************************************************************************
+ * Name: modlib_relocatedyn
+ *
+ * Description:
+ *   Perform all relocations associated with a dynamic section.
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+static int modlib_relocatedyn(FAR struct module_s *modp,
+                              FAR struct mod_loadinfo_s *loadinfo,
+                              int relidx)
+{
+  FAR Elf_Shdr *shdr = &loadinfo->shdr[relidx];
+  FAR Elf_Shdr *symhdr;
+  FAR Elf_Dyn  *dyn = NULL;
+  FAR Elf_Rel  *rels = NULL;
+  FAR Elf_Rel  *rel;
+  FAR Elf_Sym  *sym = NULL;
+  uintptr_t       addr;
+  int             ret;
+  int             i;
+  int             idx_rel;
+  int             idx_sym;
+
+  dyn = lib_malloc(shdr->sh_size);
+  ret = modlib_read(loadinfo, (FAR uint8_t *) dyn, shdr->sh_size,
+                    shdr->sh_offset);
+  if (ret < 0)
+    {
+      berr("Failed to read dynamic section header");
+      return ret;
+    }
+
+  rels = lib_malloc(CONFIG_MODLIB_RELOCATION_BUFFERCOUNT * sizeof(Elf_Rel));
+  if (!rels)
+    {
+      berr("Failed to allocate memory for elf relocation rels\n");
+      lib_free(dyn);
+      return -ENOMEM;
+    }
+
+  memset((void *) &relData, 0, sizeof(relData));
+
+  for (i = 0; dyn[i].d_tag != DT_NULL; i++)
+    {
+      switch (dyn[i].d_tag)
+	{
+          case DT_REL :
+              relData.relOff[I_REL] = dyn[i].d_un.d_val;
+              break;
+          case DT_RELSZ :
+              relData.relSz[I_REL] = dyn[i].d_un.d_val;
+              break;
+          case DT_RELENT :
+              relData.relEntSz = dyn[i].d_un.d_val;
+              break;
+	  case DT_SYMTAB :
+	      relData.symOff = dyn[i].d_un.d_val;
+ 	      break;
+	  case DT_STRTAB :
+	      relData.strOff = dyn[i].d_un.d_val;
+ 	      break;
+	  case DT_JMPREL :
+	      relData.relOff[I_PLT] = dyn[i].d_un.d_val;
+ 	      break;
+	  case DT_PLTRELSZ :
+	      relData.relSz[I_PLT] = dyn[i].d_un.d_val;
+ 	      break;
+        }
+    }
+
+  symhdr = &loadinfo->shdr[loadinfo->dsymtabidx];
+  sym = lib_malloc(symhdr->sh_size);
+  if (!sym)
+    {
+      berr("Error obtaining storage for dynamic symbol table");
+      lib_free(rels);
+      lib_free(dyn);
+      return -ENOMEM;
+    }
+
+  ret = modlib_read(loadinfo, (uint8_t *) sym, symhdr->sh_size,
+                    symhdr->sh_offset);
+  if (ret < 0)
+    {
+      berr("Error reading dynamic symbol table - %d", ret);
+      lib_free(sym);
+      lib_free(rels);
+      lib_free(dyn);
+      return ret;
+    }
+
+  relData.lSymTab = relData.strOff - relData.symOff;
+
+  for (idx_rel = 0; idx_rel < N_RELS; idx_rel++)
+    {
+      if (relData.relOff[idx_rel] == 0)
+        {
+          continue;
+        }
+
+      /* Examine each relocation in the .rel.* section. */
+
+      ret = OK;
+
+      for (i = 0; i < relData.relSz[idx_rel] / relData.relEntSz; i++)
+        {
+          /* Process each relocation entry */
+
+          rel = &rels[i % CONFIG_MODLIB_RELOCATION_BUFFERCOUNT];
+
+          if (!(i % CONFIG_MODLIB_RELOCATION_BUFFERCOUNT))
+            {
+              ret = modlib_read(loadinfo, (FAR uint8_t *) rels,
+                                sizeof(Elf_Rel) * CONFIG_MODLIB_RELOCATION_BUFFERCOUNT,
+                                relData.relOff[idx_rel] +
+                                i * sizeof(Elf_Rel));
+              if (ret < 0)
+                {
+                  berr("ERROR: Section %d reloc %d:"
+                       "Failed to read relocation entry: %d\n",
+                       relidx, i, ret);
+                  break;
+                }
+            }
+
+          /* Calculate the relocation address. */
+
+          if (rel->r_offset < 0)
+            {
+              berr("ERROR: Section %d reloc %d:"
+                   "Relocation address out of range, offset %u\n",
+                   relidx, i, (int) rel->r_offset);
+              ret = -EINVAL;
+              lib_free(sym);
+              lib_free(rels);
+              lib_free(dyn);
+              return ret;
+            }
+
+          /* Now perform the architecture-specific relocation */
+
+          if ((idx_sym = ELF_R_SYM(rel->r_info)) != 0)
+            {
+              if (sym[idx_sym].st_shndx == SHN_UNDEF)	/* We have an external reference */
+                {
+                    void *ep;
+
+                    ep = modlib_findglobal(modp, loadinfo, symhdr,
+                                           &sym[idx_sym]);
+                    if (ep == NULL)
+                      {
+                        berr("ERROR: Unable to resolve addr of ext ref %s\n",
+                             loadinfo->iobuffer);
+                        ret = -EINVAL;
+                        lib_free(sym);
+                        lib_free(rels);
+                        lib_free(dyn);
+                        return ret;
+                      }
+
+                    addr = rel->r_offset + loadinfo->textalloc;
+		    *(uintptr_t *)addr = (uintptr_t)ep;
+                }
+            }
+          else
+            {
+              Elf_Sym dynSym;
+
+              addr = rel->r_offset - loadinfo->datasec + loadinfo->datastart;
+
+              if ((*(uint32_t *) addr) < loadinfo->datasec)
+                  dynSym.st_value = *(uint32_t *) addr + loadinfo->textalloc;
+              else
+                  dynSym.st_value = *(uint32_t *) addr -
+                                    loadinfo->datasec + loadinfo->datastart;
+              ret = up_relocate(rel, &dynSym, addr);
+            }
+
+          if (ret < 0)
+            {
+              berr("ERROR: Section %d reloc %d: Relocation failed: %d\n",
+                   relidx, i, ret);
+              lib_free(sym);
+              lib_free(rels);
+              lib_free(dyn);
+              return ret;
+            }
+        }
+    }
+
+  /* Iterate through the dynamic symbol table looking for global symbols to
+   * put in our own symbol table for use with dlgetsym()
+   */
+
+  /* Relocate the entries in the table */
+
+  for (i = 0; i < (symhdr->sh_size / sizeof(Elf_Sym)); i++)
+    {
+      Elf_Shdr *s = &loadinfo->shdr[sym[i].st_shndx];
+
+      if (sym[i].st_shndx != SHN_UNDEF)
+        {
+          if (s->sh_addr < loadinfo->datasec)
+              sym[i].st_value = sym[i].st_value + loadinfo->textalloc;
+          else
+              sym[i].st_value = sym[i].st_value -
+                                loadinfo->datasec + loadinfo->datastart;
+        }
+    }
+
+  ret = modlib_insertsymtab(modp, loadinfo, symhdr, sym);
+
+  lib_free(sym);
+  lib_free(rels);
+  lib_free(dyn);
+
+  return ret;
+}
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -578,24 +824,40 @@ int modlib_bind(FAR struct module_s *modp,
           continue;
         }
 
-      /* Make sure that the section is allocated.  We can't relocate
-       * sections that were not loaded into memory.
-       */
-
-      if ((loadinfo->shdr[infosec].sh_flags & SHF_ALLOC) == 0)
+      if (loadinfo->ehdr.e_type == ET_DYN)
         {
-          continue;
+          switch (loadinfo->shdr[i].sh_type)
+            {
+              case SHT_DYNAMIC :
+                  ret = modlib_relocatedyn(modp, loadinfo, i);
+                  break;
+              case SHT_DYNSYM :
+                  loadinfo->dsymtabidx = i;
+                  break;
+            }
         }
-
-      /* Process the relocations by type */
-
-      if (loadinfo->shdr[i].sh_type == SHT_REL)
+      else
         {
-          ret = modlib_relocate(modp, loadinfo, i);
-        }
-      else if (loadinfo->shdr[i].sh_type == SHT_RELA)
-        {
-          ret = modlib_relocateadd(modp, loadinfo, i);
+          /* Make sure that the section is allocated.  We can't relocate
+           * sections that were not loaded into memory.
+           */
+
+          if ((loadinfo->shdr[i].sh_flags & SHF_ALLOC) == 0)
+            {
+                continue;
+            }
+
+          /* Process the relocations by type */
+
+          switch (loadinfo->shdr[i].sh_type)
+            {
+              case SHT_REL :
+	          ret = modlib_relocate(modp, loadinfo, i);
+                  break;
+              case SHT_RELA :
+                  ret = modlib_relocateadd(modp, loadinfo, i);
+                  break;
+            }
         }
 
       if (ret < 0)

--- a/libs/libc/modlib/modlib_globals.S
+++ b/libs/libc/modlib/modlib_globals.S
@@ -1,0 +1,1145 @@
+#if __SIZEOF_POINTER__ == 8
+	.macro globalEntry index, ep
+	.weak  \ep
+	.quad  .L\index
+	.quad  \ep
+	.endm
+# define ALIGN 8
+#else
+	.macro globalEntry index, ep
+	.weak  \ep		
+	.long  .L\index
+	.long  \ep
+	.endm
+# define ALIGN 4
+#endif
+
+#ifdef __ARM_ARCH_ISA_THUMB2
+# ifdef __ARM_ARCH_7M__
+        .arch armv7e-m
+# elif defined ___ARM_ARCH 8
+	.arch armv8-m.base
+# endif
+# ifdef __ARM_ASM_SYNTAX_UNIFIED__
+        .syntax unified
+# endif
+        .thumb
+#endif
+
+        .data
+        .align ALIGN
+	.global globalNames
+
+globalNames:
+.L0:	.string	"_ZdlPvj"
+.L1:	.string	"__cos"
+.L2:	.string	"__cxa_pure_virtual"
+.L3:	.string	"__dso_handle"
+.L4:	.string	"__dtoa_engine"
+.L5:	.string	"__sin"
+.L6:	.string	"__swap_uint32"
+.L7:	.string	"__swap_uint64"
+.L8:	.string	"__ultoa_invert"
+.L9:	.string	"_exit"
+.L10:	.string	"abort"
+.L11:	.string	"abs"
+.L12:	.string	"accept"
+.L13:	.string	"access"
+.L14:	.string	"acos"
+.L15:	.string	"acosf"
+.L16:	.string	"acosh"
+.L17:	.string	"acoshf"
+.L18:	.string	"acoshl"
+.L19:	.string	"acosl"
+.L20:	.string	"add_file_action"
+.L21:	.string	"asin"
+.L22:	.string	"asinf"
+.L23:	.string	"asinh"
+.L24:	.string	"asinhf"
+.L25:	.string	"asinhl"
+.L26:	.string	"asinl"
+.L27:	.string	"asprintf"
+.L28:	.string	"atan"
+.L29:	.string	"atan2"
+.L30:	.string	"atan2f"
+.L31:	.string	"atan2l"
+.L32:	.string	"atanf"
+.L33:	.string	"atanh"
+.L34:	.string	"atanhf"
+.L35:	.string	"atanhl"
+.L36:	.string	"atanl"
+.L37:	.string	"b16atan2"
+.L38:	.string	"b16cos"
+.L39:	.string	"b16sin"
+.L40:	.string	"basename"
+.L41:	.string	"bind"
+.L42:	.string	"boardctl"
+.L43:	.string	"bsearch"
+.L44:	.string	"cabs"
+.L45:	.string	"cacheflush"
+.L46:	.string	"calloc"
+.L47:	.string	"cbrtf"
+.L48:	.string	"ceil"
+.L49:	.string	"ceilf"
+.L50:	.string	"ceill"
+.L51:	.string	"cfgetspeed"
+.L52:	.string	"cfmakeraw"
+.L53:	.string	"cfsetspeed"
+.L54:	.string	"chdir"
+.L55:	.string	"cimag"
+.L56:	.string	"clearenv"
+.L57:	.string	"clearerr"
+.L58:	.string	"clock"
+.L59:	.string	"close"
+.L60:	.string	"closedir"
+.L61:	.string	"connect"
+.L62:	.string	"copysign"
+.L63:	.string	"copysignf"
+.L64:	.string	"copysignl"
+.L65:	.string	"cos"
+.L66:	.string	"cosf"
+.L67:	.string	"cosh"
+.L68:	.string	"coshf"
+.L69:	.string	"coshl"
+.L70:	.string	"cosl"
+.L71:	.string	"crc16"
+.L72:	.string	"crc16part"
+.L73:	.string	"crc32"
+.L74:	.string	"crc32part"
+.L75:	.string	"crc64"
+.L76:	.string	"crc64part"
+.L77:	.string	"crc8"
+.L78:	.string	"crc8ccitt"
+.L79:	.string	"crc8part"
+.L80:	.string	"creal"
+.L81:	.string	"daemon"
+.L82:	.string	"difftime"
+.L83:	.string	"dirname"
+.L84:	.string	"div"
+.L85:	.string	"dlclose"
+.L86:	.string	"dlerror"
+.L87:	.string	"dlopen"
+.L88:	.string	"dlsym"
+.L89:	.string	"dlsymtab"
+.L90:	.string	"dns_add_nameserver"
+.L91:	.string	"dns_bind"
+.L92:	.string	"dns_find_answer"
+.L93:	.string	"dns_foreach_nameserver"
+.L94:	.string	"dns_initialize"
+.L95:	.string	"dns_notify_nameserver"
+.L96:	.string	"dns_query"
+.L97:	.string	"dns_register_notify"
+.L98:	.string	"dns_save_answer"
+.L99:	.string	"dns_semgive"
+.L100:	.string	"dns_semtake"
+.L101:	.string	"dns_unregister_notify"
+.L102:	.string	"dprintf"
+.L103:	.string	"dup"
+.L104:	.string	"dup2"
+.L105:	.string	"envpath_init"
+.L106:	.string	"envpath_next"
+.L107:	.string	"envpath_release"
+.L108:	.string	"erf"
+.L109:	.string	"erff"
+.L110:	.string	"erfl"
+.L111:	.string	"ether_ntoa"
+.L112:	.string	"exec"
+.L113:	.string	"exit"
+.L114:	.string	"exp"
+.L115:	.string	"expf"
+.L116:	.string	"expl"
+.L117:	.string	"explicit_bzero"
+.L118:	.string	"fabs"
+.L119:	.string	"fabsf"
+.L120:	.string	"fabsl"
+.L121:	.string	"fclose"
+.L122:	.string	"fcntl"
+.L123:	.string	"fdopen"
+.L124:	.string	"feof"
+.L125:	.string	"ferror"
+.L126:	.string	"fflush"
+.L127:	.string	"ffs"
+.L128:	.string	"ffsl"
+.L129:	.string	"ffsll"
+.L130:	.string	"fgetc"
+.L131:	.string	"fgetpos"
+.L132:	.string	"fgets"
+.L133:	.string	"fileno"
+.L134:	.string	"floor"
+.L135:	.string	"floorf"
+.L136:	.string	"floorl"
+.L137:	.string	"fls"
+.L138:	.string	"flsl"
+.L139:	.string	"flsll"
+.L140:	.string	"fma"
+.L141:	.string	"fmaf"
+.L142:	.string	"fmod"
+.L143:	.string	"fmodf"
+.L144:	.string	"fmodl"
+.L145:	.string	"fopen"
+.L146:	.string	"fprintf"
+.L147:	.string	"fputc"
+.L148:	.string	"fputs"
+.L149:	.string	"fread"
+.L150:	.string	"free"
+.L151:	.string	"freeaddrinfo"
+.L152:	.string	"freopen"
+.L153:	.string	"frexp"
+.L154:	.string	"frexpf"
+.L155:	.string	"frexpl"
+.L156:	.string	"fscanf"
+.L157:	.string	"fseek"
+.L158:	.string	"fsetpos"
+.L159:	.string	"fstat"
+.L160:	.string	"fstatfs"
+.L161:	.string	"fsync"
+.L162:	.string	"ftell"
+.L163:	.string	"ftruncate"
+.L164:	.string	"fwrite"
+.L165:	.string	"gai_strerror"
+.L166:	.string	"gamma"
+.L167:	.string	"getaddrinfo"
+.L168:	.string	"getcwd"
+.L169:	.string	"getenv"
+.L170:	.string	"gethostbyaddr"
+.L171:	.string	"gethostbyaddr_r"
+.L172:	.string	"gethostbyname"
+.L173:	.string	"gethostbyname_r"
+.L174:	.string	"gethostname"
+.L175:	.string	"getnameinfo"
+.L176:	.string	"getopt"
+.L177:	.string	"getoptargp"
+.L178:	.string	"getoptindp"
+.L179:	.string	"getoptoptp"
+.L180:	.string	"getpeername"
+.L181:	.string	"getpid"
+.L182:	.string	"getprotobyname"
+.L183:	.string	"getrandom"
+.L184:	.string	"gets"
+.L185:	.string	"gets_s"
+.L186:	.string	"getservbyname"
+.L187:	.string	"getservbyname_r"
+.L188:	.string	"getsockname"
+.L189:	.string	"getsockopt"
+.L190:	.string	"gettimeofday"
+.L191:	.string	"gmtime"
+.L192:	.string	"gmtime_r"
+.L193:	.string	"h_errno"
+.L194:	.string	"htonl"
+.L195:	.string	"htons"
+.L196:	.string	"hypot"
+.L197:	.string	"ilogb"
+.L198:	.string	"ilogbf"
+.L199:	.string	"imaxabs"
+.L200:	.string	"in6addr_any"
+.L201:	.string	"inet_addr"
+.L202:	.string	"inet_aton"
+.L203:	.string	"inet_ntoa"
+.L204:	.string	"inet_ntop"
+.L205:	.string	"inet_pton"
+.L206:	.string	"ioctl"
+.L207:	.string	"isatty"
+.L208:	.string	"itoa"
+.L209:	.string	"kill"
+.L210:	.string	"labs"
+.L211:	.string	"ldexp"
+.L212:	.string	"ldexpf"
+.L213:	.string	"ldexpl"
+.L214:	.string	"ldiv"
+.L215:	.string	"lgamma"
+.L216:	.string	"lgamma_r"
+.L217:	.string	"listen"
+.L218:	.string	"llabs"
+.L219:	.string	"lldiv"
+.L220:	.string	"localeconv"
+.L221:	.string	"log"
+.L222:	.string	"log10"
+.L223:	.string	"log10f"
+.L224:	.string	"log10l"
+.L225:	.string	"log2"
+.L226:	.string	"log2f"
+.L227:	.string	"log2l"
+.L228:	.string	"logf"
+.L229:	.string	"logl"
+.L230:	.string	"lseek"
+.L231:	.string	"malloc"
+.L232:	.string	"match"
+.L233:	.string	"meadow_mappings"
+.L234:	.string	"memalign"
+.L235:	.string	"memccpy"
+.L236:	.string	"memchr"
+.L237:	.string	"memcmp"
+.L238:	.string	"memcpy"
+.L239:	.string	"memmove"
+.L240:	.string	"memrchr"
+.L241:	.string	"memset"
+.L242:	.string	"mkdir"
+.L243:	.string	"mkfifo"
+.L244:	.string	"mkfifo2"
+.L245:	.string	"mkstemp"
+.L246:	.string	"mktemp"
+.L247:	.string	"mktime"
+.L248:	.string	"mmap"
+.L249:	.string	"modf"
+.L250:	.string	"modff"
+.L251:	.string	"modfl"
+.L252:	.string	"mono_main"
+.L253:	.string	"mono_should_run"
+.L254:	.string	"mount"
+.L255:	.string	"munmap"
+.L256:	.string	"nanosleep"
+.L257:	.string	"nrand"
+.L258:	.string	"ntohl"
+.L259:	.string	"ntohs"
+.L260:	.string	"open"
+.L261:	.string	"opendir"
+.L262:	.string	"optarg"
+.L263:	.string	"optind"
+.L264:	.string	"optopt"
+.L265:	.string	"perror"
+.L266:	.string	"pipe"
+.L267:	.string	"pipe2"
+.L268:	.string	"poll"
+.L269:	.string	"posix_spawnattr_dump"
+.L270:	.string	"posix_spawnattr_getflags"
+.L271:	.string	"posix_spawnattr_getschedparam"
+.L272:	.string	"posix_spawnattr_getschedpolicy"
+.L273:	.string	"posix_spawnattr_getsigmask"
+.L274:	.string	"posix_spawnattr_init"
+.L275:	.string	"posix_spawnattr_setflags"
+.L276:	.string	"posix_spawnattr_setschedparam"
+.L277:	.string	"posix_spawnattr_setschedpolicy"
+.L278:	.string	"posix_spawnattr_setsigmask"
+.L279:	.string	"pow"
+.L280:	.string	"powf"
+.L281:	.string	"powl"
+.L282:	.string	"ppoll"
+.L283:	.string	"prctl"
+.L284:	.string	"pread"
+.L285:	.string	"printf"
+.L286:	.string	"pselect"
+.L287:	.string	"psiginfo"
+.L288:	.string	"psignal"
+.L289:	.string	"pthread_attr_destroy"
+.L290:	.string	"pthread_attr_getinheritsched"
+.L291:	.string	"pthread_attr_getschedparam"
+.L292:	.string	"pthread_attr_getschedpolicy"
+.L293:	.string	"pthread_attr_getstack"
+.L294:	.string	"pthread_attr_getstacksize"
+.L295:	.string	"pthread_attr_init"
+.L296:	.string	"pthread_attr_setinheritsched"
+.L297:	.string	"pthread_attr_setschedparam"
+.L298:	.string	"pthread_attr_setschedpolicy"
+.L299:	.string	"pthread_attr_setstack"
+.L300:	.string	"pthread_attr_setstacksize"
+.L301:	.string	"pthread_barrier_destroy"
+.L302:	.string	"pthread_barrier_init"
+.L303:	.string	"pthread_barrier_wait"
+.L304:	.string	"pthread_barrierattr_destroy"
+.L305:	.string	"pthread_barrierattr_getpshared"
+.L306:	.string	"pthread_barrierattr_init"
+.L307:	.string	"pthread_barrierattr_setpshared"
+.L308:	.string	"pthread_cancel"
+.L309:	.string	"pthread_cleanup_pop"
+.L310:	.string	"pthread_cleanup_push"
+.L311:	.string	"pthread_cond_broadcast"
+.L312:	.string	"pthread_cond_destroy"
+.L313:	.string	"pthread_cond_init"
+.L314:	.string	"pthread_cond_signal"
+.L315:	.string	"pthread_cond_timedwait"
+.L316:	.string	"pthread_cond_wait"
+.L317:	.string	"pthread_condattr_destroy"
+.L318:	.string	"pthread_condattr_init"
+.L319:	.string	"pthread_create"
+.L320:	.string	"pthread_detach"
+.L321:	.string	"pthread_exit"
+.L322:	.string	"pthread_get_stackaddr_np"
+.L323:	.string	"pthread_get_stacksize_np"
+.L324:	.string	"pthread_getschedparam"
+.L325:	.string	"pthread_getspecific"
+.L326:	.string	"pthread_join"
+.L327:	.string	"pthread_key_create"
+.L328:	.string	"pthread_key_delete"
+.L329:	.string	"pthread_kill"
+.L330:	.string	"pthread_mutex_consistent"
+.L331:	.string	"pthread_mutex_destroy"
+.L332:	.string	"pthread_mutex_init"
+.L333:	.string	"pthread_mutex_lock"
+.L334:	.string	"pthread_mutex_timedlock"
+.L335:	.string	"pthread_mutex_trylock"
+.L336:	.string	"pthread_mutex_unlock"
+.L337:	.string	"pthread_mutexattr_destroy"
+.L338:	.string	"pthread_mutexattr_getprotocol"
+.L339:	.string	"pthread_mutexattr_getpshared"
+.L340:	.string	"pthread_mutexattr_getrobust"
+.L341:	.string	"pthread_mutexattr_gettype"
+.L342:	.string	"pthread_mutexattr_init"
+.L343:	.string	"pthread_mutexattr_setprotocol"
+.L344:	.string	"pthread_mutexattr_setpshared"
+.L345:	.string	"pthread_mutexattr_setrobust"
+.L346:	.string	"pthread_mutexattr_settype"
+.L347:	.string	"pthread_once"
+.L348:	.string	"pthread_rwlock_destroy"
+.L349:	.string	"pthread_rwlock_init"
+.L350:	.string	"pthread_rwlock_rdlock"
+.L351:	.string	"pthread_rwlock_timedrdlock"
+.L352:	.string	"pthread_rwlock_timedwrlock"
+.L353:	.string	"pthread_rwlock_tryrdlock"
+.L354:	.string	"pthread_rwlock_trywrlock"
+.L355:	.string	"pthread_rwlock_unlock"
+.L356:	.string	"pthread_rwlock_wrlock"
+.L357:	.string	"pthread_setcancelstate"
+.L358:	.string	"pthread_setcanceltype"
+.L359:	.string	"pthread_setschedparam"
+.L360:	.string	"pthread_setschedprio"
+.L361:	.string	"pthread_setspecific"
+.L362:	.string	"pthread_sigmask"
+.L363:	.string	"pthread_startup"
+.L364:	.string	"pthread_testcancel"
+.L365:	.string	"pthread_yield"
+.L366:	.string	"putenv"
+.L367:	.string	"puts"
+.L368:	.string	"pwrite"
+.L369:	.string	"qsort"
+.L370:	.string	"raise"
+.L371:	.string	"rand"
+.L372:	.string	"random"
+.L373:	.string	"read"
+.L374:	.string	"readdir"
+.L375:	.string	"readdir_r"
+.L376:	.string	"readv"
+.L377:	.string	"realloc"
+.L378:	.string	"recv"
+.L379:	.string	"recvfrom"
+.L380:	.string	"recvmsg"
+.L381:	.string	"remove"
+.L382:	.string	"rename"
+.L383:	.string	"rewinddir"
+.L384:	.string	"rint"
+.L385:	.string	"rintf"
+.L386:	.string	"rintl"
+.L387:	.string	"rmdir"
+.L388:	.string	"round"
+.L389:	.string	"roundf"
+.L390:	.string	"roundl"
+.L391:	.string	"scalbn"
+.L392:	.string	"scalbnf"
+.L393:	.string	"scanf"
+.L394:	.string	"seekdir"
+.L395:	.string	"select"
+.L396:	.string	"sem_destroy"
+.L397:	.string	"sem_getprotocol"
+.L398:	.string	"sem_getvalue"
+.L399:	.string	"sem_init"
+.L400:	.string	"sem_post"
+.L401:	.string	"sem_setprotocol"
+.L402:	.string	"sem_timedwait"
+.L403:	.string	"sem_trywait"
+.L404:	.string	"sem_wait"
+.L405:	.string	"send"
+.L406:	.string	"sendfile"
+.L407:	.string	"sendmsg"
+.L408:	.string	"sendto"
+.L409:	.string	"set_errno"
+.L410:	.string	"setbuf"
+.L411:	.string	"setenv"
+.L412:	.string	"sethostname"
+.L413:	.string	"setlocale"
+.L414:	.string	"setlogmask"
+.L415:	.string	"setsockopt"
+.L416:	.string	"settimeofday"
+.L417:	.string	"setvbuf"
+.L418:	.string	"shutdown"
+.L419:	.string	"sigaction"
+.L420:	.string	"sigaddset"
+.L421:	.string	"sigdelset"
+.L422:	.string	"sigemptyset"
+.L423:	.string	"sigfillset"
+.L424:	.string	"sighold"
+.L425:	.string	"sigignore"
+.L426:	.string	"sigismember"
+.L427:	.string	"signal"
+.L428:	.string	"sigpause"
+.L429:	.string	"sigpending"
+.L430:	.string	"sigprocmask"
+.L431:	.string	"sigqueue"
+.L432:	.string	"sigrelse"
+.L433:	.string	"sigset"
+.L434:	.string	"sigsuspend"
+.L435:	.string	"sigtimedwait"
+.L436:	.string	"sigwait"
+.L437:	.string	"sigwaitinfo"
+.L438:	.string	"sin"
+.L439:	.string	"sinf"
+.L440:	.string	"sinh"
+.L441:	.string	"sinhf"
+.L442:	.string	"sinhl"
+.L443:	.string	"sinl"
+.L444:	.string	"sleep"
+.L445:	.string	"snprintf"
+.L446:	.string	"socket"
+.L447:	.string	"sprintf"
+.L448:	.string	"sqrt"
+.L449:	.string	"sqrtf"
+.L450:	.string	"sqrtl"
+.L451:	.string	"srand"
+.L452:	.string	"sscanf"
+.L453:	.string	"stat"
+.L454:	.string	"statfs"
+.L455:	.string	"stpcpy"
+.L456:	.string	"stpncpy"
+.L457:	.string	"strcasecmp"
+.L458:	.string	"strcasestr"
+.L459:	.string	"strcat"
+.L460:	.string	"strchr"
+.L461:	.string	"strcmp"
+.L462:	.string	"strcoll"
+.L463:	.string	"strcpy"
+.L464:	.string	"strcspn"
+.L465:	.string	"strdup"
+.L466:	.string	"stream_semgive"
+.L467:	.string	"stream_semtake"
+.L468:	.string	"strerror"
+.L469:	.string	"strerror_r"
+.L470:	.string	"strftime"
+.L471:	.string	"strlen"
+.L472:	.string	"strncasecmp"
+.L473:	.string	"strncat"
+.L474:	.string	"strncmp"
+.L475:	.string	"strncpy"
+.L476:	.string	"strndup"
+.L477:	.string	"strnlen"
+.L478:	.string	"strpbrk"
+.L479:	.string	"strrchr"
+.L480:	.string	"strsep"
+.L481:	.string	"strsignal"
+.L482:	.string	"strspn"
+.L483:	.string	"strstr"
+.L484:	.string	"strtod"
+.L485:	.string	"strtof"
+.L486:	.string	"strtoimax"
+.L487:	.string	"strtok"
+.L488:	.string	"strtok_r"
+.L489:	.string	"strtol"
+.L490:	.string	"strtold"
+.L491:	.string	"strtoll"
+.L492:	.string	"strtoul"
+.L493:	.string	"strtoull"
+.L494:	.string	"strtoumax"
+.L495:	.string	"strxfrm"
+.L496:	.string	"swab"
+.L497:	.string	"sysconf"
+.L498:	.string	"syslog"
+.L499:	.string	"tan"
+.L500:	.string	"tanf"
+.L501:	.string	"tanh"
+.L502:	.string	"tanhf"
+.L503:	.string	"tanhl"
+.L504:	.string	"tanl"
+.L505:	.string	"tcdrain"
+.L506:	.string	"tcflow"
+.L507:	.string	"tcflush"
+.L508:	.string	"tcgetattr"
+.L509:	.string	"tcsetattr"
+.L510:	.string	"tea_decrypt"
+.L511:	.string	"tea_encrypt"
+.L512:	.string	"telldir"
+.L513:	.string	"tempnam"
+.L514:	.string	"tgamma"
+.L515:	.string	"time"
+.L516:	.string	"tmpnam"
+.L517:	.string	"trunc"
+.L518:	.string	"truncate"
+.L519:	.string	"truncf"
+.L520:	.string	"truncl"
+.L521:	.string	"uadd32x64"
+.L522:	.string	"uadd64"
+.L523:	.string	"ub32sqrtub16"
+.L524:	.string	"umul32"
+.L525:	.string	"umul32x64"
+.L526:	.string	"umul64"
+.L527:	.string	"uname"
+.L528:	.string	"ungetc"
+.L529:	.string	"unlink"
+.L530:	.string	"unsetenv"
+.L531:	.string	"usleep"
+.L532:	.string	"usub64"
+.L533:	.string	"usub64x32"
+.L534:	.string	"vasprintf"
+.L535:	.string	"vdprintf"
+.L536:	.string	"vfork"
+.L537:	.string	"vfprintf"
+.L538:	.string	"vfscanf"
+.L539:	.string	"vprintf"
+.L540:	.string	"vsnprintf"
+.L541:	.string	"vsprintf"
+.L542:	.string	"vsscanf"
+.L543:	.string	"vsyslog"
+.L544:	.string	"waitpid"
+.L545:	.string	"write"
+.L546:	.string	"writev"
+.L547:	.string	"xorshift128"
+.L548:	.string	"zalloc"
+	.size	globalNames, . - globalNames
+
+	.align	ALIGN
+	.global	nGlobals
+	.type	nGlobals, "object"
+nGlobals:	
+	.word	549
+	.size	nGlobals, . - nGlobals
+
+	.align	ALIGN
+	.global globalTable
+	.type	globalTable, "object"
+globalTable:
+	globalEntry 0, _ZdlPvj
+	globalEntry 1, __cos
+	globalEntry 2, __cxa_pure_virtual
+	globalEntry 3, __dso_handle
+	globalEntry 4, __dtoa_engine
+	globalEntry 5, __sin
+	globalEntry 6, __swap_uint32
+	globalEntry 7, __swap_uint64
+	globalEntry 8, __ultoa_invert
+	globalEntry 9, _exit
+	globalEntry 10, abort
+	globalEntry 11, abs
+	globalEntry 12, accept
+	globalEntry 13, access
+	globalEntry 14, acos
+	globalEntry 15, acosf
+	globalEntry 16, acosh
+	globalEntry 17, acoshf
+	globalEntry 18, acoshl
+	globalEntry 19, acosl
+	globalEntry 20, add_file_action
+	globalEntry 21, asin
+	globalEntry 22, asinf
+	globalEntry 23, asinh
+	globalEntry 24, asinhf
+	globalEntry 25, asinhl
+	globalEntry 26, asinl
+	globalEntry 27, asprintf
+	globalEntry 28, atan
+	globalEntry 29, atan2
+	globalEntry 30, atan2f
+	globalEntry 31, atan2l
+	globalEntry 32, atanf
+	globalEntry 33, atanh
+	globalEntry 34, atanhf
+	globalEntry 35, atanhl
+	globalEntry 36, atanl
+	globalEntry 37, b16atan2
+	globalEntry 38, b16cos
+	globalEntry 39, b16sin
+	globalEntry 40, basename
+	globalEntry 41, bind
+	globalEntry 42, boardctl
+	globalEntry 43, bsearch
+	globalEntry 44, cabs
+	globalEntry 45, cacheflush
+	globalEntry 46, calloc
+	globalEntry 47, cbrtf
+	globalEntry 48, ceil
+	globalEntry 49, ceilf
+	globalEntry 50, ceill
+	globalEntry 51, cfgetspeed
+	globalEntry 52, cfmakeraw
+	globalEntry 53, cfsetspeed
+	globalEntry 54, chdir
+	globalEntry 55, cimag
+	globalEntry 56, clearenv
+	globalEntry 57, clearerr
+	globalEntry 58, clock
+	globalEntry 59, close
+	globalEntry 60, closedir
+	globalEntry 61, connect
+	globalEntry 62, copysign
+	globalEntry 63, copysignf
+	globalEntry 64, copysignl
+	globalEntry 65, cos
+	globalEntry 66, cosf
+	globalEntry 67, cosh
+	globalEntry 68, coshf
+	globalEntry 69, coshl
+	globalEntry 70, cosl
+	globalEntry 71, crc16
+	globalEntry 72, crc16part
+	globalEntry 73, crc32
+	globalEntry 74, crc32part
+	globalEntry 75, crc64
+	globalEntry 76, crc64part
+	globalEntry 77, crc8
+	globalEntry 78, crc8ccitt
+	globalEntry 79, crc8part
+	globalEntry 80, creal
+	globalEntry 81, daemon
+	globalEntry 82, difftime
+	globalEntry 83, dirname
+	globalEntry 84, div
+	globalEntry 85, dlclose
+	globalEntry 86, dlerror
+	globalEntry 87, dlopen
+	globalEntry 88, dlsym
+	globalEntry 89, dlsymtab
+	globalEntry 90, dns_add_nameserver
+	globalEntry 91, dns_bind
+	globalEntry 92, dns_find_answer
+	globalEntry 93, dns_foreach_nameserver
+	globalEntry 94, dns_initialize
+	globalEntry 95, dns_notify_nameserver
+	globalEntry 96, dns_query
+	globalEntry 97, dns_register_notify
+	globalEntry 98, dns_save_answer
+	globalEntry 99, dns_semgive
+	globalEntry 100, dns_semtake
+	globalEntry 101, dns_unregister_notify
+	globalEntry 102, dprintf
+	globalEntry 103, dup
+	globalEntry 104, dup2
+	globalEntry 105, envpath_init
+	globalEntry 106, envpath_next
+	globalEntry 107, envpath_release
+	globalEntry 108, erf
+	globalEntry 109, erff
+	globalEntry 110, erfl
+	globalEntry 111, ether_ntoa
+	globalEntry 112, exec
+	globalEntry 113, exit
+	globalEntry 114, exp
+	globalEntry 115, expf
+	globalEntry 116, expl
+	globalEntry 117, explicit_bzero
+	globalEntry 118, fabs
+	globalEntry 119, fabsf
+	globalEntry 120, fabsl
+	globalEntry 121, fclose
+	globalEntry 122, fcntl
+	globalEntry 123, fdopen
+	globalEntry 124, feof
+	globalEntry 125, ferror
+	globalEntry 126, fflush
+	globalEntry 127, ffs
+	globalEntry 128, ffsl
+	globalEntry 129, ffsll
+	globalEntry 130, fgetc
+	globalEntry 131, fgetpos
+	globalEntry 132, fgets
+	globalEntry 133, fileno
+	globalEntry 134, floor
+	globalEntry 135, floorf
+	globalEntry 136, floorl
+	globalEntry 137, fls
+	globalEntry 138, flsl
+	globalEntry 139, flsll
+	globalEntry 140, fma
+	globalEntry 141, fmaf
+	globalEntry 142, fmod
+	globalEntry 143, fmodf
+	globalEntry 144, fmodl
+	globalEntry 145, fopen
+	globalEntry 146, fprintf
+	globalEntry 147, fputc
+	globalEntry 148, fputs
+	globalEntry 149, fread
+	globalEntry 150, free
+	globalEntry 151, freeaddrinfo
+	globalEntry 152, freopen
+	globalEntry 153, frexp
+	globalEntry 154, frexpf
+	globalEntry 155, frexpl
+	globalEntry 156, fscanf
+	globalEntry 157, fseek
+	globalEntry 158, fsetpos
+	globalEntry 159, fstat
+	globalEntry 160, fstatfs
+	globalEntry 161, fsync
+	globalEntry 162, ftell
+	globalEntry 163, ftruncate
+	globalEntry 164, fwrite
+	globalEntry 165, gai_strerror
+	globalEntry 166, gamma
+	globalEntry 167, getaddrinfo
+	globalEntry 168, getcwd
+	globalEntry 169, getenv
+	globalEntry 170, gethostbyaddr
+	globalEntry 171, gethostbyaddr_r
+	globalEntry 172, gethostbyname
+	globalEntry 173, gethostbyname_r
+	globalEntry 174, gethostname
+	globalEntry 175, getnameinfo
+	globalEntry 176, getopt
+	globalEntry 177, getoptargp
+	globalEntry 178, getoptindp
+	globalEntry 179, getoptoptp
+	globalEntry 180, getpeername
+	globalEntry 181, getpid
+	globalEntry 182, getprotobyname
+	globalEntry 183, getrandom
+	globalEntry 184, gets
+	globalEntry 185, gets_s
+	globalEntry 186, getservbyname
+	globalEntry 187, getservbyname_r
+	globalEntry 188, getsockname
+	globalEntry 189, getsockopt
+	globalEntry 190, gettimeofday
+	globalEntry 191, gmtime
+	globalEntry 192, gmtime_r
+	globalEntry 193, h_errno
+	globalEntry 194, htonl
+	globalEntry 195, htons
+	globalEntry 196, hypot
+	globalEntry 197, ilogb
+	globalEntry 198, ilogbf
+	globalEntry 199, imaxabs
+	globalEntry 200, in6addr_any
+	globalEntry 201, inet_addr
+	globalEntry 202, inet_aton
+	globalEntry 203, inet_ntoa
+	globalEntry 204, inet_ntop
+	globalEntry 205, inet_pton
+	globalEntry 206, ioctl
+	globalEntry 207, isatty
+	globalEntry 208, itoa
+	globalEntry 209, kill
+	globalEntry 210, labs
+	globalEntry 211, ldexp
+	globalEntry 212, ldexpf
+	globalEntry 213, ldexpl
+	globalEntry 214, ldiv
+	globalEntry 215, lgamma
+	globalEntry 216, lgamma_r
+	globalEntry 217, listen
+	globalEntry 218, llabs
+	globalEntry 219, lldiv
+	globalEntry 220, localeconv
+	globalEntry 221, log
+	globalEntry 222, log10
+	globalEntry 223, log10f
+	globalEntry 224, log10l
+	globalEntry 225, log2
+	globalEntry 226, log2f
+	globalEntry 227, log2l
+	globalEntry 228, logf
+	globalEntry 229, logl
+	globalEntry 230, lseek
+	globalEntry 231, malloc
+	globalEntry 232, match
+	globalEntry 233, meadow_mappings
+	globalEntry 234, memalign
+	globalEntry 235, memccpy
+	globalEntry 236, memchr
+	globalEntry 237, memcmp
+	globalEntry 238, memcpy
+	globalEntry 239, memmove
+	globalEntry 240, memrchr
+	globalEntry 241, memset
+	globalEntry 242, mkdir
+	globalEntry 243, mkfifo
+	globalEntry 244, mkfifo2
+	globalEntry 245, mkstemp
+	globalEntry 246, mktemp
+	globalEntry 247, mktime
+	globalEntry 248, mmap
+	globalEntry 249, modf
+	globalEntry 250, modff
+	globalEntry 251, modfl
+	globalEntry 252, mono_main
+	globalEntry 253, mono_should_run
+	globalEntry 254, mount
+	globalEntry 255, munmap
+	globalEntry 256, nanosleep
+	globalEntry 257, nrand
+	globalEntry 258, ntohl
+	globalEntry 259, ntohs
+	globalEntry 260, open
+	globalEntry 261, opendir
+	globalEntry 262, optarg
+	globalEntry 263, optind
+	globalEntry 264, optopt
+	globalEntry 265, perror
+	globalEntry 266, pipe
+	globalEntry 267, pipe2
+	globalEntry 268, poll
+	globalEntry 269, posix_spawnattr_dump
+	globalEntry 270, posix_spawnattr_getflags
+	globalEntry 271, posix_spawnattr_getschedparam
+	globalEntry 272, posix_spawnattr_getschedpolicy
+	globalEntry 273, posix_spawnattr_getsigmask
+	globalEntry 274, posix_spawnattr_init
+	globalEntry 275, posix_spawnattr_setflags
+	globalEntry 276, posix_spawnattr_setschedparam
+	globalEntry 277, posix_spawnattr_setschedpolicy
+	globalEntry 278, posix_spawnattr_setsigmask
+	globalEntry 279, pow
+	globalEntry 280, powf
+	globalEntry 281, powl
+	globalEntry 282, ppoll
+	globalEntry 283, prctl
+	globalEntry 284, pread
+	globalEntry 285, printf
+	globalEntry 286, pselect
+	globalEntry 287, psiginfo
+	globalEntry 288, psignal
+	globalEntry 289, pthread_attr_destroy
+	globalEntry 290, pthread_attr_getinheritsched
+	globalEntry 291, pthread_attr_getschedparam
+	globalEntry 292, pthread_attr_getschedpolicy
+	globalEntry 293, pthread_attr_getstack
+	globalEntry 294, pthread_attr_getstacksize
+	globalEntry 295, pthread_attr_init
+	globalEntry 296, pthread_attr_setinheritsched
+	globalEntry 297, pthread_attr_setschedparam
+	globalEntry 298, pthread_attr_setschedpolicy
+	globalEntry 299, pthread_attr_setstack
+	globalEntry 300, pthread_attr_setstacksize
+	globalEntry 301, pthread_barrier_destroy
+	globalEntry 302, pthread_barrier_init
+	globalEntry 303, pthread_barrier_wait
+	globalEntry 304, pthread_barrierattr_destroy
+	globalEntry 305, pthread_barrierattr_getpshared
+	globalEntry 306, pthread_barrierattr_init
+	globalEntry 307, pthread_barrierattr_setpshared
+	globalEntry 308, pthread_cancel
+	globalEntry 309, pthread_cleanup_pop
+	globalEntry 310, pthread_cleanup_push
+	globalEntry 311, pthread_cond_broadcast
+	globalEntry 312, pthread_cond_destroy
+	globalEntry 313, pthread_cond_init
+	globalEntry 314, pthread_cond_signal
+	globalEntry 315, pthread_cond_timedwait
+	globalEntry 316, pthread_cond_wait
+	globalEntry 317, pthread_condattr_destroy
+	globalEntry 318, pthread_condattr_init
+	globalEntry 319, pthread_create
+	globalEntry 320, pthread_detach
+	globalEntry 321, pthread_exit
+	globalEntry 322, pthread_get_stackaddr_np
+	globalEntry 323, pthread_get_stacksize_np
+	globalEntry 324, pthread_getschedparam
+	globalEntry 325, pthread_getspecific
+	globalEntry 326, pthread_join
+	globalEntry 327, pthread_key_create
+	globalEntry 328, pthread_key_delete
+	globalEntry 329, pthread_kill
+	globalEntry 330, pthread_mutex_consistent
+	globalEntry 331, pthread_mutex_destroy
+	globalEntry 332, pthread_mutex_init
+	globalEntry 333, pthread_mutex_lock
+	globalEntry 334, pthread_mutex_timedlock
+	globalEntry 335, pthread_mutex_trylock
+	globalEntry 336, pthread_mutex_unlock
+	globalEntry 337, pthread_mutexattr_destroy
+	globalEntry 338, pthread_mutexattr_getprotocol
+	globalEntry 339, pthread_mutexattr_getpshared
+	globalEntry 340, pthread_mutexattr_getrobust
+	globalEntry 341, pthread_mutexattr_gettype
+	globalEntry 342, pthread_mutexattr_init
+	globalEntry 343, pthread_mutexattr_setprotocol
+	globalEntry 344, pthread_mutexattr_setpshared
+	globalEntry 345, pthread_mutexattr_setrobust
+	globalEntry 346, pthread_mutexattr_settype
+	globalEntry 347, pthread_once
+	globalEntry 348, pthread_rwlock_destroy
+	globalEntry 349, pthread_rwlock_init
+	globalEntry 350, pthread_rwlock_rdlock
+	globalEntry 351, pthread_rwlock_timedrdlock
+	globalEntry 352, pthread_rwlock_timedwrlock
+	globalEntry 353, pthread_rwlock_tryrdlock
+	globalEntry 354, pthread_rwlock_trywrlock
+	globalEntry 355, pthread_rwlock_unlock
+	globalEntry 356, pthread_rwlock_wrlock
+	globalEntry 357, pthread_setcancelstate
+	globalEntry 358, pthread_setcanceltype
+	globalEntry 359, pthread_setschedparam
+	globalEntry 360, pthread_setschedprio
+	globalEntry 361, pthread_setspecific
+	globalEntry 362, pthread_sigmask
+	globalEntry 363, pthread_startup
+	globalEntry 364, pthread_testcancel
+	globalEntry 365, pthread_yield
+	globalEntry 366, putenv
+	globalEntry 367, puts
+	globalEntry 368, pwrite
+	globalEntry 369, qsort
+	globalEntry 370, raise
+	globalEntry 371, rand
+	globalEntry 372, random
+	globalEntry 373, read
+	globalEntry 374, readdir
+	globalEntry 375, readdir_r
+	globalEntry 376, readv
+	globalEntry 377, realloc
+	globalEntry 378, recv
+	globalEntry 379, recvfrom
+	globalEntry 380, recvmsg
+	globalEntry 381, remove
+	globalEntry 382, rename
+	globalEntry 383, rewinddir
+	globalEntry 384, rint
+	globalEntry 385, rintf
+	globalEntry 386, rintl
+	globalEntry 387, rmdir
+	globalEntry 388, round
+	globalEntry 389, roundf
+	globalEntry 390, roundl
+	globalEntry 391, scalbn
+	globalEntry 392, scalbnf
+	globalEntry 393, scanf
+	globalEntry 394, seekdir
+	globalEntry 395, select
+	globalEntry 396, sem_destroy
+	globalEntry 397, sem_getprotocol
+	globalEntry 398, sem_getvalue
+	globalEntry 399, sem_init
+	globalEntry 400, sem_post
+	globalEntry 401, sem_setprotocol
+	globalEntry 402, sem_timedwait
+	globalEntry 403, sem_trywait
+	globalEntry 404, sem_wait
+	globalEntry 405, send
+	globalEntry 406, sendfile
+	globalEntry 407, sendmsg
+	globalEntry 408, sendto
+	globalEntry 409, set_errno
+	globalEntry 410, setbuf
+	globalEntry 411, setenv
+	globalEntry 412, sethostname
+	globalEntry 413, setlocale
+	globalEntry 414, setlogmask
+	globalEntry 415, setsockopt
+	globalEntry 416, settimeofday
+	globalEntry 417, setvbuf
+	globalEntry 418, shutdown
+	globalEntry 419, sigaction
+	globalEntry 420, sigaddset
+	globalEntry 421, sigdelset
+	globalEntry 422, sigemptyset
+	globalEntry 423, sigfillset
+	globalEntry 424, sighold
+	globalEntry 425, sigignore
+	globalEntry 426, sigismember
+	globalEntry 427, signal
+	globalEntry 428, sigpause
+	globalEntry 429, sigpending
+	globalEntry 430, sigprocmask
+	globalEntry 431, sigqueue
+	globalEntry 432, sigrelse
+	globalEntry 433, sigset
+	globalEntry 434, sigsuspend
+	globalEntry 435, sigtimedwait
+	globalEntry 436, sigwait
+	globalEntry 437, sigwaitinfo
+	globalEntry 438, sin
+	globalEntry 439, sinf
+	globalEntry 440, sinh
+	globalEntry 441, sinhf
+	globalEntry 442, sinhl
+	globalEntry 443, sinl
+	globalEntry 444, sleep
+	globalEntry 445, snprintf
+	globalEntry 446, socket
+	globalEntry 447, sprintf
+	globalEntry 448, sqrt
+	globalEntry 449, sqrtf
+	globalEntry 450, sqrtl
+	globalEntry 451, srand
+	globalEntry 452, sscanf
+	globalEntry 453, stat
+	globalEntry 454, statfs
+	globalEntry 455, stpcpy
+	globalEntry 456, stpncpy
+	globalEntry 457, strcasecmp
+	globalEntry 458, strcasestr
+	globalEntry 459, strcat
+	globalEntry 460, strchr
+	globalEntry 461, strcmp
+	globalEntry 462, strcoll
+	globalEntry 463, strcpy
+	globalEntry 464, strcspn
+	globalEntry 465, strdup
+	globalEntry 466, stream_semgive
+	globalEntry 467, stream_semtake
+	globalEntry 468, strerror
+	globalEntry 469, strerror_r
+	globalEntry 470, strftime
+	globalEntry 471, strlen
+	globalEntry 472, strncasecmp
+	globalEntry 473, strncat
+	globalEntry 474, strncmp
+	globalEntry 475, strncpy
+	globalEntry 476, strndup
+	globalEntry 477, strnlen
+	globalEntry 478, strpbrk
+	globalEntry 479, strrchr
+	globalEntry 480, strsep
+	globalEntry 481, strsignal
+	globalEntry 482, strspn
+	globalEntry 483, strstr
+	globalEntry 484, strtod
+	globalEntry 485, strtof
+	globalEntry 486, strtoimax
+	globalEntry 487, strtok
+	globalEntry 488, strtok_r
+	globalEntry 489, strtol
+	globalEntry 490, strtold
+	globalEntry 491, strtoll
+	globalEntry 492, strtoul
+	globalEntry 493, strtoull
+	globalEntry 494, strtoumax
+	globalEntry 495, strxfrm
+	globalEntry 496, swab
+	globalEntry 497, sysconf
+	globalEntry 498, syslog
+	globalEntry 499, tan
+	globalEntry 500, tanf
+	globalEntry 501, tanh
+	globalEntry 502, tanhf
+	globalEntry 503, tanhl
+	globalEntry 504, tanl
+	globalEntry 505, tcdrain
+	globalEntry 506, tcflow
+	globalEntry 507, tcflush
+	globalEntry 508, tcgetattr
+	globalEntry 509, tcsetattr
+	globalEntry 510, tea_decrypt
+	globalEntry 511, tea_encrypt
+	globalEntry 512, telldir
+	globalEntry 513, tempnam
+	globalEntry 514, tgamma
+	globalEntry 515, time
+	globalEntry 516, tmpnam
+	globalEntry 517, trunc
+	globalEntry 518, truncate
+	globalEntry 519, truncf
+	globalEntry 520, truncl
+	globalEntry 521, uadd32x64
+	globalEntry 522, uadd64
+	globalEntry 523, ub32sqrtub16
+	globalEntry 524, umul32
+	globalEntry 525, umul32x64
+	globalEntry 526, umul64
+	globalEntry 527, uname
+	globalEntry 528, ungetc
+	globalEntry 529, unlink
+	globalEntry 530, unsetenv
+	globalEntry 531, usleep
+	globalEntry 532, usub64
+	globalEntry 533, usub64x32
+	globalEntry 534, vasprintf
+	globalEntry 535, vdprintf
+	globalEntry 536, vfork
+	globalEntry 537, vfprintf
+	globalEntry 538, vfscanf
+	globalEntry 539, vprintf
+	globalEntry 540, vsnprintf
+	globalEntry 541, vsprintf
+	globalEntry 542, vsscanf
+	globalEntry 543, vsyslog
+	globalEntry 544, waitpid
+	globalEntry 545, write
+	globalEntry 546, writev
+	globalEntry 547, xorshift128
+	globalEntry 548, zalloc
+	.size	globalTable, . - globalTable

--- a/libs/libc/modlib/modlib_load.c
+++ b/libs/libc/modlib/modlib_load.c
@@ -79,36 +79,63 @@ static void modlib_elfsize(struct mod_loadinfo_s *loadinfo)
   textsize = 0;
   datasize = 0;
 
-  for (i = 0; i < loadinfo->ehdr.e_shnum; i++)
+  if (loadinfo->ehdr.e_phnum > 0) 
     {
-      FAR Elf_Shdr *shdr = &loadinfo->shdr[i];
-
-      /* SHF_ALLOC indicates that the section requires memory during
-       * execution.
-       */
-
-      if ((shdr->sh_flags & SHF_ALLOC) != 0)
+      for (i = 0; i < loadinfo->ehdr.e_phnum; i++)
         {
-          /* SHF_WRITE indicates that the section address space is write-
-           * able
-           */
-
-          if ((shdr->sh_flags & SHF_WRITE) != 0)
+          FAR Elf_Phdr *phdr = &loadinfo->phdr[i];
+          FAR void *textaddr = NULL;
+    
+          if (phdr->p_type == PT_LOAD)
             {
-              datasize = _ALIGN_UP(datasize, shdr->sh_addralign);
-              datasize += ELF_ALIGNUP(shdr->sh_size);
-              if (loadinfo->dataalign < shdr->sh_addralign)
+              if (phdr->p_flags & PF_X)
                 {
-                  loadinfo->dataalign = shdr->sh_addralign;
+                  textsize += phdr->p_memsz;
+                  textaddr = (void *) phdr->p_vaddr;
+                }
+              else
+                {
+                  datasize += phdr->p_memsz;
+                  loadinfo->datasec = phdr->p_vaddr;
+                  loadinfo->segpad  = phdr->p_vaddr -
+                                      ((uintptr_t) textaddr + textsize);
                 }
             }
-          else
+        }
+    }
+  else
+    {
+      for (i = 0; i < loadinfo->ehdr.e_shnum; i++)
+        {
+          FAR Elf_Shdr *shdr = &loadinfo->shdr[i];
+    
+          /* SHF_ALLOC indicates that the section requires memory during
+           * execution.
+           */
+    
+          if ((shdr->sh_flags & SHF_ALLOC) != 0)
             {
-              textsize = _ALIGN_UP(textsize, shdr->sh_addralign);
-              textsize += ELF_ALIGNUP(shdr->sh_size);
-              if (loadinfo->textalign < shdr->sh_addralign)
+              /* SHF_WRITE indicates that the section address space is write-
+               * able
+               */
+    
+              if ((shdr->sh_flags & SHF_WRITE) != 0)
                 {
-                  loadinfo->textalign = shdr->sh_addralign;
+                  datasize = _ALIGN_UP(datasize, shdr->sh_addralign);
+                  datasize += ELF_ALIGNUP(shdr->sh_size);
+                  if (loadinfo->dataalign < shdr->sh_addralign)
+                    {
+                      loadinfo->dataalign = shdr->sh_addralign;
+                    }
+                }
+              else
+                {
+                  textsize = _ALIGN_UP(textsize, shdr->sh_addralign);
+                  textsize += ELF_ALIGNUP(shdr->sh_size);
+                  if (loadinfo->textalign < shdr->sh_addralign)
+                    {
+                      loadinfo->textalign = shdr->sh_addralign;
+                    }
                 }
             }
         }
@@ -141,75 +168,110 @@ static inline int modlib_loadfile(FAR struct mod_loadinfo_s *loadinfo)
   int ret;
   int i;
 
-  /* Read each section into memory that is marked SHF_ALLOC + SHT_NOBITS */
+  /* Read each PT_LOAD area into memory */
 
-  binfo("Loaded sections:\n");
+  binfo("Loading sections - text: %p.%x data: %p.%x\n",
+        (void *)loadinfo->textalloc, (int) loadinfo->textsize,
+        (void *)loadinfo->datastart, (int) loadinfo->datasize);
   text = (FAR uint8_t *)loadinfo->textalloc;
   data = (FAR uint8_t *)loadinfo->datastart;
 
-  for (i = 0; i < loadinfo->ehdr.e_shnum; i++)
+  if (loadinfo->ehdr.e_phnum > 0)
     {
-      FAR Elf_Shdr *shdr = &loadinfo->shdr[i];
-
-      /* SHF_ALLOC indicates that the section requires memory during
-       * execution
-       */
-
-      if ((shdr->sh_flags & SHF_ALLOC) == 0)
+      for (i = 0; i < loadinfo->ehdr.e_phnum; i++)
         {
-          continue;
-        }
-
-      /* SHF_WRITE indicates that the section address space is write-
-       * able
-       */
-
-      if ((shdr->sh_flags & SHF_WRITE) != 0)
-        {
-          pptr = &data;
-        }
-      else
-        {
-          pptr = &text;
-        }
-
-      *pptr = (FAR uint8_t *)_ALIGN_UP((uintptr_t)*pptr, shdr->sh_addralign);
-
-      /* SHT_NOBITS indicates that there is no data in the file for the
-       * section.
-       */
-
-      if (shdr->sh_type != SHT_NOBITS)
-        {
-          /* Read the section data from sh_offset to the memory region */
-
-          ret = modlib_read(loadinfo, *pptr, shdr->sh_size, shdr->sh_offset);
-          if (ret < 0)
+          FAR Elf_Phdr *phdr = &loadinfo->phdr[i];
+    
+          if (phdr->p_type == PT_LOAD)
             {
-              berr("ERROR: Failed to read section %d: %d\n", i, ret);
-              return ret;
+              if (phdr->p_flags & PF_X)
+                {
+                  ret = modlib_read(loadinfo, text, phdr->p_filesz,
+                                    phdr->p_offset);
+                }
+              else
+                {
+                  int bssSize = phdr->p_memsz - phdr->p_filesz;
+                  ret = modlib_read(loadinfo, data, phdr->p_filesz,
+                                    phdr->p_offset);
+                  memset((FAR void *)((uintptr_t) data + phdr->p_filesz), 0,
+                         bssSize);
+                }
+    
+              if (ret < 0)
+                {
+                  berr("ERROR: Failed to read section %d: %d\n", i, ret);
+                  return ret;
+                }
             }
         }
-
-      /* If there is no data in an allocated section, then the allocated
-       * section must be cleared.
-       */
-
-      else
+    }
+  else
+    {
+      for (i = 0; i < loadinfo->ehdr.e_shnum; i++)
         {
-          memset(*pptr, 0, shdr->sh_size);
+          FAR Elf_Shdr *shdr = &loadinfo->shdr[i];
+    
+          /* SHF_ALLOC indicates that the section requires memory during
+           * execution
+           */
+    
+          if ((shdr->sh_flags & SHF_ALLOC) == 0)
+            {
+              continue;
+            }
+    
+          /* SHF_WRITE indicates that the section address space is write-
+           * able
+           */
+    
+          if ((shdr->sh_flags & SHF_WRITE) != 0)
+            {
+              pptr = &data;
+            }
+          else
+            {
+              pptr = &text;
+            }
+    
+          *pptr = (FAR uint8_t *)_ALIGN_UP((uintptr_t)*pptr, shdr->sh_addralign);
+    
+          /* SHT_NOBITS indicates that there is no data in the file for the
+           * section.
+           */
+    
+          if (shdr->sh_type != SHT_NOBITS)
+            {
+              /* Read the section data from sh_offset to the memory region */
+    
+              ret = modlib_read(loadinfo, *pptr, shdr->sh_size, shdr->sh_offset);
+              if (ret < 0)
+                {
+                  berr("ERROR: Failed to read section %d: %d\n", i, ret);
+                  return ret;
+                }
+            }
+    
+          /* If there is no data in an allocated section, then the allocated
+           * section must be cleared.
+           */
+    
+          else
+            {
+              memset(*pptr, 0, shdr->sh_size);
+            }
+    
+          /* Update sh_addr to point to copy in memory */
+    
+          binfo("%d. %08lx->%08lx\n", i,
+                (unsigned long)shdr->sh_addr, (unsigned long)*pptr);
+    
+          shdr->sh_addr = (uintptr_t)*pptr;
+    
+          /* Setup the memory pointer for the next time through the loop */
+    
+          *pptr += ELF_ALIGNUP(shdr->sh_size);
         }
-
-      /* Update sh_addr to point to copy in memory */
-
-      binfo("%d. %08lx->%08lx\n", i,
-            (unsigned long)shdr->sh_addr, (unsigned long)*pptr);
-
-      shdr->sh_addr = (uintptr_t)*pptr;
-
-      /* Setup the memory pointer for the next time through the loop */
-
-      *pptr += ELF_ALIGNUP(shdr->sh_size);
     }
 
   return OK;
@@ -239,12 +301,12 @@ int modlib_load(FAR struct mod_loadinfo_s *loadinfo)
   binfo("loadinfo: %p\n", loadinfo);
   DEBUGASSERT(loadinfo && loadinfo->filfd >= 0);
 
-  /* Load section headers into memory */
+  /* Load section and program headers into memory */
 
-  ret = modlib_loadshdrs(loadinfo);
+  ret = modlib_loadhdrs(loadinfo);
   if (ret < 0)
     {
-      berr("ERROR: modlib_loadshdrs failed: %d\n", ret);
+      berr("ERROR: modlib_loadhdrs failed: %d\n", ret);
       goto errout_with_buffers;
     }
 
@@ -261,10 +323,14 @@ int modlib_load(FAR struct mod_loadinfo_s *loadinfo)
 #if defined(CONFIG_ARCH_USE_TEXT_HEAP)
       loadinfo->textalloc = (uintptr_t)
                             up_textheap_memalign(loadinfo->textalign,
-                                                 loadinfo->textsize);
+                                                 loadinfo->textsize +
+                                                 loadinfo->datasize +
+                                                 loadinfo->segpad);
 #else
       loadinfo->textalloc = (uintptr_t)lib_memalign(loadinfo->textalign,
-                                                    loadinfo->textsize);
+                                                    loadinfo->textsize +
+                                                    loadinfo->datasize +
+                                                    loadinfo->segpad);
 #endif
       if (!loadinfo->textalloc)
         {
@@ -276,14 +342,9 @@ int modlib_load(FAR struct mod_loadinfo_s *loadinfo)
 
   if (loadinfo->datasize > 0)
     {
-      loadinfo->datastart = (uintptr_t)lib_memalign(loadinfo->dataalign,
-                                                    loadinfo->datasize);
-      if (!loadinfo->datastart)
-        {
-          berr("ERROR: Failed to allocate memory for the module data\n");
-          ret = -ENOMEM;
-          goto errout_with_buffers;
-        }
+      loadinfo->datastart = loadinfo->textalloc +
+                            loadinfo->textsize +
+                            loadinfo->segpad;
     }
 
   /* Load ELF section data into memory */

--- a/libs/libc/modlib/modlib_loadhdrs.c
+++ b/libs/libc/modlib/modlib_loadhdrs.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * libs/libc/modlib/modlib_loadshdrs.c
+ * libs/libc/modlib/modlib_loadhdrs.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -42,10 +42,10 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: modlib_loadshdrs
+ * Name: modlib_loadhdrs
  *
  * Description:
- *   Loads section headers into memory.
+ *   Loads program and section headers into memory.
  *
  * Returned Value:
  *   0 (OK) is returned on success and a negated errno is returned on
@@ -53,18 +53,28 @@
  *
  ****************************************************************************/
 
-int modlib_loadshdrs(FAR struct mod_loadinfo_s *loadinfo)
+int modlib_loadhdrs(FAR struct mod_loadinfo_s *loadinfo)
 {
   size_t shdrsize;
+  size_t phdrsize;
   int ret;
 
   DEBUGASSERT(loadinfo->shdr == NULL);
+  DEBUGASSERT(loadinfo->phdr == NULL);
 
   /* Verify that there are sections */
 
   if (loadinfo->ehdr.e_shnum < 1)
     {
       berr("ERROR: No sections(?)\n");
+      return -EINVAL;
+    }
+
+  /* Verify that there are program headers */
+
+  if (loadinfo->ehdr.e_phnum < 1)
+    {
+      berr("ERROR: No program headers(?)\n");
       return -EINVAL;
     }
 
@@ -75,6 +85,16 @@ int modlib_loadshdrs(FAR struct mod_loadinfo_s *loadinfo)
   if (loadinfo->ehdr.e_shoff + shdrsize > loadinfo->filelen)
     {
       berr("ERROR: Insufficient space in file for section header table\n");
+      return -ESPIPE;
+    }
+
+  /* Get the total size of the program header table */
+
+  phdrsize = (size_t)loadinfo->ehdr.e_phentsize *
+             (size_t)loadinfo->ehdr.e_phnum;
+  if (loadinfo->ehdr.e_phoff + phdrsize > loadinfo->filelen)
+    {
+      berr("ERROR: Insufficent space in file for program header table\n");
       return -ESPIPE;
     }
 
@@ -95,6 +115,28 @@ int modlib_loadshdrs(FAR struct mod_loadinfo_s *loadinfo)
   if (ret < 0)
     {
       berr("ERROR: Failed to read section header table: %d\n", ret);
+    }
+
+  /* Allocate memory to hold a working copy of the program header table */
+
+  loadinfo->phdr = (FAR FAR Elf_Phdr *)lib_malloc(phdrsize);
+  if (!loadinfo->shdr)
+    {
+      lib_free((FAR void *)loadinfo->shdr);
+      berr("ERROR: Failed to allocate the program header table. Size: %ld\n",
+           (long)phdrsize);
+      return -ENOMEM;
+    }
+
+  /* Read the program header table into memory */
+
+  ret = modlib_read(loadinfo, (FAR uint8_t *)loadinfo->phdr, phdrsize,
+                    loadinfo->ehdr.e_phoff);
+  if (ret < 0)
+    {
+      berr("ERROR: Failed to read program header table: %d\n", ret);
+      lib_free((FAR void *)loadinfo->phdr);
+      lib_free((FAR void *)loadinfo->shdr);
     }
 
   return ret;

--- a/libs/libc/modlib/modlib_symbols.c
+++ b/libs/libc/modlib/modlib_symbols.c
@@ -33,6 +33,7 @@
 
 #include <nuttx/lib/modlib.h>
 
+#include "libc.h"
 #include "modlib/modlib.h"
 
 /****************************************************************************
@@ -53,6 +54,12 @@ struct mod_exportinfo_s
   FAR const char *name;              /* Symbol name to find */
   FAR struct module_s *modp;         /* The module that needs the symbol */
   FAR const struct symtab_s *symbol; /* Symbol info returned (if found) */
+};
+
+struct epTable_s
+{
+  uint8_t *epName;      /* Name of global symbol */
+  void    *epAddr;      /* Address of global symbol */
 };
 
 /****************************************************************************
@@ -76,7 +83,7 @@ struct mod_exportinfo_s
  ****************************************************************************/
 
 static int modlib_symname(FAR struct mod_loadinfo_s *loadinfo,
-                          FAR const Elf_Sym *sym)
+                          FAR const Elf_Sym *sym, Elf_Off sh_offset)
 {
   FAR uint8_t *buffer;
   off_t  offset;
@@ -94,7 +101,7 @@ static int modlib_symname(FAR struct mod_loadinfo_s *loadinfo,
       return -ESRCH;
     }
 
-  offset = loadinfo->shdr[loadinfo->strtabidx].sh_offset + sym->st_name;
+  offset = sh_offset + sym->st_name;
 
   /* Loop until we get the entire symbol name into memory */
 
@@ -145,6 +152,8 @@ static int modlib_symname(FAR struct mod_loadinfo_s *loadinfo,
           berr("ERROR: mod_reallocbuffer failed: %d\n", ret);
           return ret;
         }
+
+      offset += CONFIG_MODLIB_BUFFERINCR;
     }
 
   /* We will not get here */
@@ -258,9 +267,8 @@ int modlib_findsymtab(FAR struct mod_loadinfo_s *loadinfo)
  ****************************************************************************/
 
 int modlib_readsym(FAR struct mod_loadinfo_s *loadinfo, int index,
-                   FAR Elf_Sym *sym)
+                   FAR Elf_Sym *sym, FAR Elf_Shdr *symtab)
 {
-  FAR Elf_Shdr *symtab = &loadinfo->shdr[loadinfo->symtabidx];
   off_t offset;
 
   /* Verify that the symbol table index lies within symbol table */
@@ -288,9 +296,10 @@ int modlib_readsym(FAR struct mod_loadinfo_s *loadinfo, int index,
  *   in the st_value field of the symbol table entry.
  *
  * Input Parameters:
- *   modp     - Module state information
- *   loadinfo - Load state information
- *   sym      - Symbol table entry (value might be undefined)
+ *   modp      - Module state information
+ *   loadinfo  - Load state information
+ *   sym       - Symbol table entry (value might be undefined)
+ *   sh_offset - Offset of strtab
  *
  * Returned Value:
  *   0 (OK) is returned on success and a negated errno is returned on
@@ -305,7 +314,8 @@ int modlib_readsym(FAR struct mod_loadinfo_s *loadinfo, int index,
  ****************************************************************************/
 
 int modlib_symvalue(FAR struct module_s *modp,
-                    FAR struct mod_loadinfo_s *loadinfo, FAR Elf_Sym *sym)
+                    FAR struct mod_loadinfo_s *loadinfo, FAR Elf_Sym *sym,
+                    Elf_Off sh_offset)
 {
   FAR const struct symtab_s *symbol;
   struct mod_exportinfo_s exportinfo;
@@ -335,7 +345,7 @@ int modlib_symvalue(FAR struct module_s *modp,
       {
         /* Get the name of the undefined symbol */
 
-        ret = modlib_symname(loadinfo, sym);
+        ret = modlib_symname(loadinfo, sym, sh_offset);
         if (ret < 0)
           {
             /* There are a few relocations for a few architectures that do
@@ -406,7 +416,8 @@ int modlib_symvalue(FAR struct module_s *modp,
       {
         secbase = loadinfo->shdr[sym->st_shndx].sh_addr;
 
-        binfo("Other: %08" PRIxPTR "+%08" PRIxPTR "=%08" PRIxPTR "\n",
+        binfo("Other[%d]: %08" PRIxPTR "+%08" PRIxPTR "=%08" PRIxPTR "\n",
+              sym->st_shndx,
               (uintptr_t)sym->st_value, secbase,
               (uintptr_t)(sym->st_value + secbase));
 
@@ -416,4 +427,174 @@ int modlib_symvalue(FAR struct module_s *modp,
     }
 
   return OK;
+}
+
+/****************************************************************************
+ * Name: modlib_insertsymtab
+ *
+ * Description:
+ *   Insert a symbol into the modules exportinfo array.
+ *
+ * Input Parameters:
+ *   modp     - Module state information
+ *   loadinfo - Load state information
+ *   shdr     - Symbol table section header
+ *   sym      - Symbol table entry
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ *   EINVAL - There is something inconsistent in the symbol table
+ *            (should only happen if the file is corrupted).
+ *
+ ****************************************************************************/
+
+int modlib_insertsymtab(FAR struct module_s *modp,
+                        struct mod_loadinfo_s *loadinfo,
+                        FAR Elf_Shdr *shdr, FAR Elf_Sym *sym)
+{
+  FAR struct symtab_s *symbol;
+  FAR Elf_Shdr *strTab = &loadinfo->shdr[shdr->sh_link];
+  int ret = 0;
+  int i;
+  int j;
+  int nSym;
+  int symCount;
+
+  if (modp->modinfo.exports != NULL)
+    {
+      bwarn("Module export information already present - replacing");
+      modlib_freesymtab((FAR void *) modp);
+    }
+
+  /* Count the "live" symbols */
+
+  nSym = shdr->sh_size / sizeof(Elf_Sym);
+  for (i = 0, symCount = 0; i < nSym; i++)
+    {
+      if (sym[i].st_name != 0)
+          symCount++;
+    }
+
+  if (symCount > 0)
+    {
+      modp->modinfo.exports = symbol =
+                              loadinfo->exported =
+                              lib_malloc(sizeof(*symbol) * symCount);
+      if (modp->modinfo.exports)
+        {
+          /* Build out module's symbol table */
+
+          modp->modinfo.nexports = symCount;
+          for (i = 0, j = 0; i < nSym; i++)
+            {
+              if (sym[i].st_name != 0)
+                {
+                  ret = modlib_symname(loadinfo, &sym[i], strTab->sh_offset);
+                  if (ret < 0)
+                    {
+                      lib_free((FAR void *) modp->modinfo.exports);
+                      modp->modinfo.exports = NULL;
+                      return ret;
+                    }
+
+                  symbol[j].sym_name = strdup((char *) loadinfo->iobuffer);
+                  symbol[j].sym_value = (FAR const void *) sym[i].st_value;
+                  j++;
+                }
+            }
+        }
+      else
+        {
+          berr("Unable to get memory for exported symbols table");
+          ret = -ENOMEM;
+        }
+    }
+
+  return ret;
+}
+
+/****************************************************************************
+ * Name: findEP
+ *
+ * Description:
+ *   Binary search comparison function
+ *
+ * Input Parameters:
+ *   c1 - Comparand 1
+ *   c2 - Comparand 2
+ *
+ ****************************************************************************/
+
+static int findEP(const void *c1, const void *c2)
+{
+  const struct epTable_s *m1 = (struct epTable_s *) c1;
+  const struct epTable_s *m2 = (struct epTable_s *) c2;
+  return strcmp((FAR const char *)m1->epName, (FAR const char *)m2->epName);
+}
+
+/****************************************************************************
+ * Name: modlib_findglobal
+ *
+ * Description:
+ *   Find a symbol in our library entry point table
+ *
+ * Input Parameters:
+ *   modp     - Module state information
+ *
+ ****************************************************************************/
+
+void *modlib_findglobal(FAR struct module_s *modp,
+                        struct mod_loadinfo_s *loadinfo,
+                        FAR Elf_Shdr *shdr, FAR Elf_Sym *sym)
+{
+  FAR Elf_Shdr *strTab = &loadinfo->shdr[shdr->sh_link];
+  int ret;
+  struct epTable_s key;
+  struct epTable_s *res;
+  extern struct epTable_s globalTable[];
+  extern int nGlobals;
+
+  ret = modlib_symname(loadinfo, sym, strTab->sh_offset);
+  if (ret < 0)
+      return NULL;
+
+  key.epName = loadinfo->iobuffer;
+  res = bsearch(&key, globalTable, nGlobals,
+                sizeof(struct epTable_s), findEP);
+  if (res != NULL)
+    {
+      return res->epAddr;
+    }
+  else
+    {
+      return NULL;
+    }
+}
+
+/****************************************************************************
+ * Name: modlib_freesymtab
+ *
+ * Description:
+ *   Free a symbol table
+ *
+ * Input Parameters:
+ *   modp     - Module state information
+ *
+ ****************************************************************************/
+
+void modlib_freesymtab(FAR struct module_s *modp)
+{
+  FAR const struct symtab_s *symbol;
+
+  if ((symbol = modp->modinfo.exports))
+    {
+      for (int i = 0; i < modp->modinfo.nexports; i++)
+        {
+          lib_free((FAR void *) symbol[i].sym_name);
+        }
+
+      lib_free((FAR void *) symbol);
+    }
 }

--- a/libs/libc/modlib/modlib_uninit.c
+++ b/libs/libc/modlib/modlib_uninit.c
@@ -88,6 +88,12 @@ int modlib_freebuffers(struct mod_loadinfo_s *loadinfo)
       loadinfo->shdr      = NULL;
     }
 
+  if (loadinfo->phdr != NULL)
+    {
+      lib_free((FAR void *)loadinfo->phdr);
+      loadinfo->phdr      = NULL;
+    }
+
   if (loadinfo->iobuffer != NULL)
     {
       lib_free((FAR void *)loadinfo->iobuffer);

--- a/libs/libc/modlib/modlib_verify.c
+++ b/libs/libc/modlib/modlib_verify.c
@@ -84,8 +84,11 @@ int modlib_verifyheader(FAR const Elf_Ehdr *ehdr)
 
   if (ehdr->e_type != ET_REL)
     {
-      berr("ERROR: Not a relocatable file: e_type=%d\n", ehdr->e_type);
-      return -EINVAL;
+        if (ehdr->e_type != ET_DYN)
+          {
+            berr("ERROR: Not a relocatable file: e_type=%d\n", ehdr->e_type);
+            return -EINVAL;
+          }
     }
 
   /* Verify that this file works with the currently configured architecture */

--- a/libs/libc/modlib/modlib_x32_globals.S
+++ b/libs/libc/modlib/modlib_x32_globals.S
@@ -1,0 +1,1116 @@
+        .data
+        .align 4
+	.global globalNames
+
+globalNames:
+.L0:	.string	"_ZdlPvj"
+.L1:	.string	"__cos"
+.L2:	.string	"__cxa_pure_virtual"
+.L3:	.string	"__dso_handle"
+.L4:	.string	"__dtoa_engine"
+.L5:	.string	"__sin"
+.L6:	.string	"__swap_uint32"
+.L7:	.string	"__swap_uint64"
+.L8:	.string	"__ultoa_invert"
+.L9:	.string	"_exit"
+.L10:	.string	"abort"
+.L11:	.string	"abs"
+.L12:	.string	"accept"
+.L13:	.string	"access"
+.L14:	.string	"acos"
+.L15:	.string	"acosf"
+.L16:	.string	"acosh"
+.L17:	.string	"acoshf"
+.L18:	.string	"acoshl"
+.L19:	.string	"acosl"
+.L20:	.string	"add_file_action"
+.L21:	.string	"asin"
+.L22:	.string	"asinf"
+.L23:	.string	"asinh"
+.L24:	.string	"asinhf"
+.L25:	.string	"asinhl"
+.L26:	.string	"asinl"
+.L27:	.string	"asprintf"
+.L28:	.string	"atan"
+.L29:	.string	"atan2"
+.L30:	.string	"atan2f"
+.L31:	.string	"atan2l"
+.L32:	.string	"atanf"
+.L33:	.string	"atanh"
+.L34:	.string	"atanhf"
+.L35:	.string	"atanhl"
+.L36:	.string	"atanl"
+.L37:	.string	"b16atan2"
+.L38:	.string	"b16cos"
+.L39:	.string	"b16sin"
+.L40:	.string	"basename"
+.L41:	.string	"bind"
+.L42:	.string	"boardctl"
+.L43:	.string	"bsearch"
+.L44:	.string	"cabs"
+.L45:	.string	"cacheflush"
+.L46:	.string	"calloc"
+.L47:	.string	"cbrtf"
+.L48:	.string	"ceil"
+.L49:	.string	"ceilf"
+.L50:	.string	"ceill"
+.L51:	.string	"cfgetspeed"
+.L52:	.string	"cfmakeraw"
+.L53:	.string	"cfsetspeed"
+.L54:	.string	"chdir"
+.L55:	.string	"cimag"
+.L56:	.string	"clearenv"
+.L57:	.string	"clearerr"
+.L58:	.string	"clock"
+.L59:	.string	"close"
+.L60:	.string	"closedir"
+.L61:	.string	"connect"
+.L62:	.string	"copysign"
+.L63:	.string	"copysignf"
+.L64:	.string	"copysignl"
+.L65:	.string	"cos"
+.L66:	.string	"cosf"
+.L67:	.string	"cosh"
+.L68:	.string	"coshf"
+.L69:	.string	"coshl"
+.L70:	.string	"cosl"
+.L71:	.string	"crc16"
+.L72:	.string	"crc16part"
+.L73:	.string	"crc32"
+.L74:	.string	"crc32part"
+.L75:	.string	"crc64"
+.L76:	.string	"crc64part"
+.L77:	.string	"crc8"
+.L78:	.string	"crc8ccitt"
+.L79:	.string	"crc8part"
+.L80:	.string	"creal"
+.L81:	.string	"daemon"
+.L82:	.string	"difftime"
+.L83:	.string	"dirname"
+.L84:	.string	"div"
+.L85:	.string	"dlclose"
+.L86:	.string	"dlerror"
+.L87:	.string	"dlopen"
+.L88:	.string	"dlsym"
+.L89:	.string	"dlsymtab"
+.L90:	.string	"dns_add_nameserver"
+.L91:	.string	"dns_bind"
+.L92:	.string	"dns_find_answer"
+.L93:	.string	"dns_foreach_nameserver"
+.L94:	.string	"dns_initialize"
+.L95:	.string	"dns_notify_nameserver"
+.L96:	.string	"dns_query"
+.L97:	.string	"dns_register_notify"
+.L98:	.string	"dns_save_answer"
+.L99:	.string	"dns_semgive"
+.L100:	.string	"dns_semtake"
+.L101:	.string	"dns_unregister_notify"
+.L102:	.string	"dprintf"
+.L103:	.string	"dup"
+.L104:	.string	"dup2"
+.L105:	.string	"envpath_init"
+.L106:	.string	"envpath_next"
+.L107:	.string	"envpath_release"
+.L108:	.string	"erf"
+.L109:	.string	"erff"
+.L110:	.string	"erfl"
+.L111:	.string	"ether_ntoa"
+.L112:	.string	"exec"
+.L113:	.string	"exit"
+.L114:	.string	"exp"
+.L115:	.string	"expf"
+.L116:	.string	"expl"
+.L117:	.string	"explicit_bzero"
+.L118:	.string	"fabs"
+.L119:	.string	"fabsf"
+.L120:	.string	"fabsl"
+.L121:	.string	"fclose"
+.L122:	.string	"fcntl"
+.L123:	.string	"fdopen"
+.L124:	.string	"feof"
+.L125:	.string	"ferror"
+.L126:	.string	"fflush"
+.L127:	.string	"ffs"
+.L128:	.string	"ffsl"
+.L129:	.string	"ffsll"
+.L130:	.string	"fgetc"
+.L131:	.string	"fgetpos"
+.L132:	.string	"fgets"
+.L133:	.string	"fileno"
+.L134:	.string	"floor"
+.L135:	.string	"floorf"
+.L136:	.string	"floorl"
+.L137:	.string	"fls"
+.L138:	.string	"flsl"
+.L139:	.string	"flsll"
+.L140:	.string	"fma"
+.L141:	.string	"fmaf"
+.L142:	.string	"fmod"
+.L143:	.string	"fmodf"
+.L144:	.string	"fmodl"
+.L145:	.string	"fopen"
+.L146:	.string	"fprintf"
+.L147:	.string	"fputc"
+.L148:	.string	"fputs"
+.L149:	.string	"fread"
+.L150:	.string	"free"
+.L151:	.string	"freeaddrinfo"
+.L152:	.string	"freopen"
+.L153:	.string	"frexp"
+.L154:	.string	"frexpf"
+.L155:	.string	"frexpl"
+.L156:	.string	"fscanf"
+.L157:	.string	"fseek"
+.L158:	.string	"fsetpos"
+.L159:	.string	"fstat"
+.L160:	.string	"fstatfs"
+.L161:	.string	"fsync"
+.L162:	.string	"ftell"
+.L163:	.string	"ftruncate"
+.L164:	.string	"fwrite"
+.L165:	.string	"gai_strerror"
+.L166:	.string	"gamma"
+.L167:	.string	"getaddrinfo"
+.L168:	.string	"getcwd"
+.L169:	.string	"getenv"
+.L170:	.string	"gethostbyaddr"
+.L171:	.string	"gethostbyaddr_r"
+.L172:	.string	"gethostbyname"
+.L173:	.string	"gethostbyname_r"
+.L174:	.string	"gethostname"
+.L175:	.string	"getnameinfo"
+.L176:	.string	"getopt"
+.L177:	.string	"getoptargp"
+.L178:	.string	"getoptindp"
+.L179:	.string	"getoptoptp"
+.L180:	.string	"getpeername"
+.L181:	.string	"getpid"
+.L182:	.string	"getprotobyname"
+.L183:	.string	"getrandom"
+.L184:	.string	"gets"
+.L185:	.string	"gets_s"
+.L186:	.string	"getservbyname"
+.L187:	.string	"getservbyname_r"
+.L188:	.string	"getsockname"
+.L189:	.string	"getsockopt"
+.L190:	.string	"gettimeofday"
+.L191:	.string	"gmtime"
+.L192:	.string	"gmtime_r"
+.L193:	.string	"h_errno"
+.L194:	.string	"htonl"
+.L195:	.string	"htons"
+.L196:	.string	"hypot"
+.L197:	.string	"ilogb"
+.L198:	.string	"ilogbf"
+.L199:	.string	"imaxabs"
+.L200:	.string	"in6addr_any"
+.L201:	.string	"inet_addr"
+.L202:	.string	"inet_aton"
+.L203:	.string	"inet_ntoa"
+.L204:	.string	"inet_ntop"
+.L205:	.string	"inet_pton"
+.L206:	.string	"ioctl"
+.L207:	.string	"isatty"
+.L208:	.string	"itoa"
+.L209:	.string	"kill"
+.L210:	.string	"labs"
+.L211:	.string	"ldexp"
+.L212:	.string	"ldexpf"
+.L213:	.string	"ldexpl"
+.L214:	.string	"ldiv"
+.L215:	.string	"lgamma"
+.L216:	.string	"lgamma_r"
+.L217:	.string	"listen"
+.L218:	.string	"llabs"
+.L219:	.string	"lldiv"
+.L220:	.string	"localeconv"
+.L221:	.string	"log"
+.L222:	.string	"log10"
+.L223:	.string	"log10f"
+.L224:	.string	"log10l"
+.L225:	.string	"log2"
+.L226:	.string	"log2f"
+.L227:	.string	"log2l"
+.L228:	.string	"logf"
+.L229:	.string	"logl"
+.L230:	.string	"lseek"
+.L231:	.string	"malloc"
+.L232:	.string	"match"
+.L233:	.string	"meadow_mappings"
+.L234:	.string	"memalign"
+.L235:	.string	"memccpy"
+.L236:	.string	"memchr"
+.L237:	.string	"memcmp"
+.L238:	.string	"memcpy"
+.L239:	.string	"memmove"
+.L240:	.string	"memrchr"
+.L241:	.string	"memset"
+.L242:	.string	"mkdir"
+.L243:	.string	"mkfifo"
+.L244:	.string	"mkfifo2"
+.L245:	.string	"mkstemp"
+.L246:	.string	"mktemp"
+.L247:	.string	"mktime"
+.L248:	.string	"mmap"
+.L249:	.string	"modf"
+.L250:	.string	"modff"
+.L251:	.string	"modfl"
+.L252:	.string	"mono_main"
+.L253:	.string	"mono_should_run"
+.L254:	.string	"mount"
+.L255:	.string	"munmap"
+.L256:	.string	"nanosleep"
+.L257:	.string	"nrand"
+.L258:	.string	"ntohl"
+.L259:	.string	"ntohs"
+.L260:	.string	"open"
+.L261:	.string	"opendir"
+.L262:	.string	"optarg"
+.L263:	.string	"optind"
+.L264:	.string	"optopt"
+.L265:	.string	"perror"
+.L266:	.string	"pipe"
+.L267:	.string	"pipe2"
+.L268:	.string	"poll"
+.L269:	.string	"posix_spawnattr_dump"
+.L270:	.string	"posix_spawnattr_getflags"
+.L271:	.string	"posix_spawnattr_getschedparam"
+.L272:	.string	"posix_spawnattr_getschedpolicy"
+.L273:	.string	"posix_spawnattr_getsigmask"
+.L274:	.string	"posix_spawnattr_init"
+.L275:	.string	"posix_spawnattr_setflags"
+.L276:	.string	"posix_spawnattr_setschedparam"
+.L277:	.string	"posix_spawnattr_setschedpolicy"
+.L278:	.string	"posix_spawnattr_setsigmask"
+.L279:	.string	"pow"
+.L280:	.string	"powf"
+.L281:	.string	"powl"
+.L282:	.string	"ppoll"
+.L283:	.string	"prctl"
+.L284:	.string	"pread"
+.L285:	.string	"printf"
+.L286:	.string	"pselect"
+.L287:	.string	"psiginfo"
+.L288:	.string	"psignal"
+.L289:	.string	"pthread_attr_destroy"
+.L290:	.string	"pthread_attr_getinheritsched"
+.L291:	.string	"pthread_attr_getschedparam"
+.L292:	.string	"pthread_attr_getschedpolicy"
+.L293:	.string	"pthread_attr_getstack"
+.L294:	.string	"pthread_attr_getstacksize"
+.L295:	.string	"pthread_attr_init"
+.L296:	.string	"pthread_attr_setinheritsched"
+.L297:	.string	"pthread_attr_setschedparam"
+.L298:	.string	"pthread_attr_setschedpolicy"
+.L299:	.string	"pthread_attr_setstack"
+.L300:	.string	"pthread_attr_setstacksize"
+.L301:	.string	"pthread_barrier_destroy"
+.L302:	.string	"pthread_barrier_init"
+.L303:	.string	"pthread_barrier_wait"
+.L304:	.string	"pthread_barrierattr_destroy"
+.L305:	.string	"pthread_barrierattr_getpshared"
+.L306:	.string	"pthread_barrierattr_init"
+.L307:	.string	"pthread_barrierattr_setpshared"
+.L308:	.string	"pthread_cancel"
+.L309:	.string	"pthread_cleanup_pop"
+.L310:	.string	"pthread_cleanup_push"
+.L311:	.string	"pthread_cond_broadcast"
+.L312:	.string	"pthread_cond_destroy"
+.L313:	.string	"pthread_cond_init"
+.L314:	.string	"pthread_cond_signal"
+.L315:	.string	"pthread_cond_timedwait"
+.L316:	.string	"pthread_cond_wait"
+.L317:	.string	"pthread_condattr_destroy"
+.L318:	.string	"pthread_condattr_init"
+.L319:	.string	"pthread_create"
+.L320:	.string	"pthread_detach"
+.L321:	.string	"pthread_exit"
+.L322:	.string	"pthread_get_stackaddr_np"
+.L323:	.string	"pthread_get_stacksize_np"
+.L324:	.string	"pthread_getschedparam"
+.L325:	.string	"pthread_getspecific"
+.L326:	.string	"pthread_join"
+.L327:	.string	"pthread_key_create"
+.L328:	.string	"pthread_key_delete"
+.L329:	.string	"pthread_kill"
+.L330:	.string	"pthread_mutex_consistent"
+.L331:	.string	"pthread_mutex_destroy"
+.L332:	.string	"pthread_mutex_init"
+.L333:	.string	"pthread_mutex_lock"
+.L334:	.string	"pthread_mutex_timedlock"
+.L335:	.string	"pthread_mutex_trylock"
+.L336:	.string	"pthread_mutex_unlock"
+.L337:	.string	"pthread_mutexattr_destroy"
+.L338:	.string	"pthread_mutexattr_getprotocol"
+.L339:	.string	"pthread_mutexattr_getpshared"
+.L340:	.string	"pthread_mutexattr_getrobust"
+.L341:	.string	"pthread_mutexattr_gettype"
+.L342:	.string	"pthread_mutexattr_init"
+.L343:	.string	"pthread_mutexattr_setprotocol"
+.L344:	.string	"pthread_mutexattr_setpshared"
+.L345:	.string	"pthread_mutexattr_setrobust"
+.L346:	.string	"pthread_mutexattr_settype"
+.L347:	.string	"pthread_once"
+.L348:	.string	"pthread_rwlock_destroy"
+.L349:	.string	"pthread_rwlock_init"
+.L350:	.string	"pthread_rwlock_rdlock"
+.L351:	.string	"pthread_rwlock_timedrdlock"
+.L352:	.string	"pthread_rwlock_timedwrlock"
+.L353:	.string	"pthread_rwlock_tryrdlock"
+.L354:	.string	"pthread_rwlock_trywrlock"
+.L355:	.string	"pthread_rwlock_unlock"
+.L356:	.string	"pthread_rwlock_wrlock"
+.L357:	.string	"pthread_setcancelstate"
+.L358:	.string	"pthread_setcanceltype"
+.L359:	.string	"pthread_setschedparam"
+.L360:	.string	"pthread_setschedprio"
+.L361:	.string	"pthread_setspecific"
+.L362:	.string	"pthread_sigmask"
+.L363:	.string	"pthread_startup"
+.L364:	.string	"pthread_testcancel"
+.L365:	.string	"pthread_yield"
+.L366:	.string	"putenv"
+.L367:	.string	"puts"
+.L368:	.string	"pwrite"
+.L369:	.string	"qsort"
+.L370:	.string	"raise"
+.L371:	.string	"rand"
+.L372:	.string	"random"
+.L373:	.string	"read"
+.L374:	.string	"readdir"
+.L375:	.string	"readdir_r"
+.L376:	.string	"readv"
+.L377:	.string	"realloc"
+.L378:	.string	"recv"
+.L379:	.string	"recvfrom"
+.L380:	.string	"recvmsg"
+.L381:	.string	"remove"
+.L382:	.string	"rename"
+.L383:	.string	"rewinddir"
+.L384:	.string	"rint"
+.L385:	.string	"rintf"
+.L386:	.string	"rintl"
+.L387:	.string	"rmdir"
+.L388:	.string	"round"
+.L389:	.string	"roundf"
+.L390:	.string	"roundl"
+.L391:	.string	"scalbn"
+.L392:	.string	"scalbnf"
+.L393:	.string	"scanf"
+.L394:	.string	"seekdir"
+.L395:	.string	"select"
+.L396:	.string	"sem_destroy"
+.L397:	.string	"sem_getprotocol"
+.L398:	.string	"sem_getvalue"
+.L399:	.string	"sem_init"
+.L400:	.string	"sem_post"
+.L401:	.string	"sem_setprotocol"
+.L402:	.string	"sem_timedwait"
+.L403:	.string	"sem_trywait"
+.L404:	.string	"sem_wait"
+.L405:	.string	"send"
+.L406:	.string	"sendfile"
+.L407:	.string	"sendmsg"
+.L408:	.string	"sendto"
+.L409:	.string	"set_errno"
+.L410:	.string	"setbuf"
+.L411:	.string	"setenv"
+.L412:	.string	"sethostname"
+.L413:	.string	"setlocale"
+.L414:	.string	"setlogmask"
+.L415:	.string	"setsockopt"
+.L416:	.string	"settimeofday"
+.L417:	.string	"setvbuf"
+.L418:	.string	"shutdown"
+.L419:	.string	"sigaction"
+.L420:	.string	"sigaddset"
+.L421:	.string	"sigdelset"
+.L422:	.string	"sigemptyset"
+.L423:	.string	"sigfillset"
+.L424:	.string	"sighold"
+.L425:	.string	"sigignore"
+.L426:	.string	"sigismember"
+.L427:	.string	"signal"
+.L428:	.string	"sigpause"
+.L429:	.string	"sigpending"
+.L430:	.string	"sigprocmask"
+.L431:	.string	"sigqueue"
+.L432:	.string	"sigrelse"
+.L433:	.string	"sigset"
+.L434:	.string	"sigsuspend"
+.L435:	.string	"sigtimedwait"
+.L436:	.string	"sigwait"
+.L437:	.string	"sigwaitinfo"
+.L438:	.string	"sin"
+.L439:	.string	"sinf"
+.L440:	.string	"sinh"
+.L441:	.string	"sinhf"
+.L442:	.string	"sinhl"
+.L443:	.string	"sinl"
+.L444:	.string	"sleep"
+.L445:	.string	"snprintf"
+.L446:	.string	"socket"
+.L447:	.string	"sprintf"
+.L448:	.string	"sqrt"
+.L449:	.string	"sqrtf"
+.L450:	.string	"sqrtl"
+.L451:	.string	"srand"
+.L452:	.string	"sscanf"
+.L453:	.string	"stat"
+.L454:	.string	"statfs"
+.L455:	.string	"stpcpy"
+.L456:	.string	"stpncpy"
+.L457:	.string	"strcasecmp"
+.L458:	.string	"strcasestr"
+.L459:	.string	"strcat"
+.L460:	.string	"strchr"
+.L461:	.string	"strcmp"
+.L462:	.string	"strcoll"
+.L463:	.string	"strcpy"
+.L464:	.string	"strcspn"
+.L465:	.string	"strdup"
+.L466:	.string	"stream_semgive"
+.L467:	.string	"stream_semtake"
+.L468:	.string	"strerror"
+.L469:	.string	"strerror_r"
+.L470:	.string	"strftime"
+.L471:	.string	"strlen"
+.L472:	.string	"strncasecmp"
+.L473:	.string	"strncat"
+.L474:	.string	"strncmp"
+.L475:	.string	"strncpy"
+.L476:	.string	"strndup"
+.L477:	.string	"strnlen"
+.L478:	.string	"strpbrk"
+.L479:	.string	"strrchr"
+.L480:	.string	"strsep"
+.L481:	.string	"strsignal"
+.L482:	.string	"strspn"
+.L483:	.string	"strstr"
+.L484:	.string	"strtod"
+.L485:	.string	"strtof"
+.L486:	.string	"strtoimax"
+.L487:	.string	"strtok"
+.L488:	.string	"strtok_r"
+.L489:	.string	"strtol"
+.L490:	.string	"strtold"
+.L491:	.string	"strtoll"
+.L492:	.string	"strtoul"
+.L493:	.string	"strtoull"
+.L494:	.string	"strtoumax"
+.L495:	.string	"strxfrm"
+.L496:	.string	"swab"
+.L497:	.string	"sysconf"
+.L498:	.string	"syslog"
+.L499:	.string	"tan"
+.L500:	.string	"tanf"
+.L501:	.string	"tanh"
+.L502:	.string	"tanhf"
+.L503:	.string	"tanhl"
+.L504:	.string	"tanl"
+.L505:	.string	"tcdrain"
+.L506:	.string	"tcflow"
+.L507:	.string	"tcflush"
+.L508:	.string	"tcgetattr"
+.L509:	.string	"tcsetattr"
+.L510:	.string	"tea_decrypt"
+.L511:	.string	"tea_encrypt"
+.L512:	.string	"telldir"
+.L513:	.string	"tempnam"
+.L514:	.string	"tgamma"
+.L515:	.string	"time"
+.L516:	.string	"tmpnam"
+.L517:	.string	"trunc"
+.L518:	.string	"truncate"
+.L519:	.string	"truncf"
+.L520:	.string	"truncl"
+.L521:	.string	"uadd32x64"
+.L522:	.string	"uadd64"
+.L523:	.string	"ub32sqrtub16"
+.L524:	.string	"umul32"
+.L525:	.string	"umul32x64"
+.L526:	.string	"umul64"
+.L527:	.string	"uname"
+.L528:	.string	"ungetc"
+.L529:	.string	"unlink"
+.L530:	.string	"unsetenv"
+.L531:	.string	"usleep"
+.L532:	.string	"usub64"
+.L533:	.string	"usub64x32"
+.L534:	.string	"vasprintf"
+.L535:	.string	"vdprintf"
+.L536:	.string	"vfork"
+.L537:	.string	"vfprintf"
+.L538:	.string	"vfscanf"
+.L539:	.string	"vprintf"
+.L540:	.string	"vsnprintf"
+.L541:	.string	"vsprintf"
+.L542:	.string	"vsscanf"
+.L543:	.string	"vsyslog"
+.L544:	.string	"waitpid"
+.L545:	.string	"write"
+.L546:	.string	"writev"
+.L547:	.string	"xorshift128"
+.L548:	.string	"zalloc"
+	.size	globalNames, . - globalNames
+
+	.align	4
+	.global	nGlobals
+	.type	nGlobals, "object"
+nGlobals:	
+	.word	549
+	.size	nGlobals, . - nGlobals
+
+	.global globalTable
+	.type	globalTable, "object"
+globalTable:
+	.word	.L0, _ZdlPvj
+	.word	.L1, __cos
+	.word	.L2, __cxa_pure_virtual
+	.word	.L3, __dso_handle
+	.word	.L4, __dtoa_engine
+	.word	.L5, __sin
+	.word	.L6, __swap_uint32
+	.word	.L7, __swap_uint64
+	.word	.L8, __ultoa_invert
+	.word	.L9, _exit
+	.word	.L10, abort
+	.word	.L11, abs
+	.word	.L12, accept
+	.word	.L13, access
+	.word	.L14, acos
+	.word	.L15, acosf
+	.word	.L16, acosh
+	.word	.L17, acoshf
+	.word	.L18, acoshl
+	.word	.L19, acosl
+	.word	.L20, add_file_action
+	.word	.L21, asin
+	.word	.L22, asinf
+	.word	.L23, asinh
+	.word	.L24, asinhf
+	.word	.L25, asinhl
+	.word	.L26, asinl
+	.word	.L27, asprintf
+	.word	.L28, atan
+	.word	.L29, atan2
+	.word	.L30, atan2f
+	.word	.L31, atan2l
+	.word	.L32, atanf
+	.word	.L33, atanh
+	.word	.L34, atanhf
+	.word	.L35, atanhl
+	.word	.L36, atanl
+	.word	.L37, b16atan2
+	.word	.L38, b16cos
+	.word	.L39, b16sin
+	.word	.L40, basename
+	.word	.L41, bind
+	.word	.L42, boardctl
+	.word	.L43, bsearch
+	.word	.L44, cabs
+	.word	.L45, cacheflush
+	.word	.L46, calloc
+	.word	.L47, cbrtf
+	.word	.L48, ceil
+	.word	.L49, ceilf
+	.word	.L50, ceill
+	.word	.L51, cfgetspeed
+	.word	.L52, cfmakeraw
+	.word	.L53, cfsetspeed
+	.word	.L54, chdir
+	.word	.L55, cimag
+	.word	.L56, clearenv
+	.word	.L57, clearerr
+	.word	.L58, clock
+	.word	.L59, close
+	.word	.L60, closedir
+	.word	.L61, connect
+	.word	.L62, copysign
+	.word	.L63, copysignf
+	.word	.L64, copysignl
+	.word	.L65, cos
+	.word	.L66, cosf
+	.word	.L67, cosh
+	.word	.L68, coshf
+	.word	.L69, coshl
+	.word	.L70, cosl
+	.word	.L71, crc16
+	.word	.L72, crc16part
+	.word	.L73, crc32
+	.word	.L74, crc32part
+	.word	.L75, crc64
+	.word	.L76, crc64part
+	.word	.L77, crc8
+	.word	.L78, crc8ccitt
+	.word	.L79, crc8part
+	.word	.L80, creal
+	.word	.L81, daemon
+	.word	.L82, difftime
+	.word	.L83, dirname
+	.word	.L84, div
+	.word	.L85, dlclose
+	.word	.L86, dlerror
+	.word	.L87, dlopen
+	.word	.L88, dlsym
+	.word	.L89, dlsymtab
+	.word	.L90, dns_add_nameserver
+	.word	.L91, dns_bind
+	.word	.L92, dns_find_answer
+	.word	.L93, dns_foreach_nameserver
+	.word	.L94, dns_initialize
+	.word	.L95, dns_notify_nameserver
+	.word	.L96, dns_query
+	.word	.L97, dns_register_notify
+	.word	.L98, dns_save_answer
+	.word	.L99, dns_semgive
+	.word	.L100, dns_semtake
+	.word	.L101, dns_unregister_notify
+	.word	.L102, dprintf
+	.word	.L103, dup
+	.word	.L104, dup2
+	.word	.L105, envpath_init
+	.word	.L106, envpath_next
+	.word	.L107, envpath_release
+	.word	.L108, erf
+	.word	.L109, erff
+	.word	.L110, erfl
+	.word	.L111, ether_ntoa
+	.word	.L112, exec
+	.word	.L113, exit
+	.word	.L114, exp
+	.word	.L115, expf
+	.word	.L116, expl
+	.word	.L117, explicit_bzero
+	.word	.L118, fabs
+	.word	.L119, fabsf
+	.word	.L120, fabsl
+	.word	.L121, fclose
+	.word	.L122, fcntl
+	.word	.L123, fdopen
+	.word	.L124, feof
+	.word	.L125, ferror
+	.word	.L126, fflush
+	.word	.L127, ffs
+	.word	.L128, ffsl
+	.word	.L129, ffsll
+	.word	.L130, fgetc
+	.word	.L131, fgetpos
+	.word	.L132, fgets
+	.word	.L133, fileno
+	.word	.L134, floor
+	.word	.L135, floorf
+	.word	.L136, floorl
+	.word	.L137, fls
+	.word	.L138, flsl
+	.word	.L139, flsll
+	.word	.L140, fma
+	.word	.L141, fmaf
+	.word	.L142, fmod
+	.word	.L143, fmodf
+	.word	.L144, fmodl
+	.word	.L145, fopen
+	.word	.L146, fprintf
+	.word	.L147, fputc
+	.word	.L148, fputs
+	.word	.L149, fread
+	.word	.L150, free
+	.word	.L151, freeaddrinfo
+	.word	.L152, freopen
+	.word	.L153, frexp
+	.word	.L154, frexpf
+	.word	.L155, frexpl
+	.word	.L156, fscanf
+	.word	.L157, fseek
+	.word	.L158, fsetpos
+	.word	.L159, fstat
+	.word	.L160, fstatfs
+	.word	.L161, fsync
+	.word	.L162, ftell
+	.word	.L163, ftruncate
+	.word	.L164, fwrite
+	.word	.L165, gai_strerror
+	.word	.L166, gamma
+	.word	.L167, getaddrinfo
+	.word	.L168, getcwd
+	.word	.L169, getenv
+	.word	.L170, gethostbyaddr
+	.word	.L171, gethostbyaddr_r
+	.word	.L172, gethostbyname
+	.word	.L173, gethostbyname_r
+	.word	.L174, gethostname
+	.word	.L175, getnameinfo
+	.word	.L176, getopt
+	.word	.L177, getoptargp
+	.word	.L178, getoptindp
+	.word	.L179, getoptoptp
+	.word	.L180, getpeername
+	.word	.L181, getpid
+	.word	.L182, getprotobyname
+	.word	.L183, getrandom
+	.word	.L184, gets
+	.word	.L185, gets_s
+	.word	.L186, getservbyname
+	.word	.L187, getservbyname_r
+	.word	.L188, getsockname
+	.word	.L189, getsockopt
+	.word	.L190, gettimeofday
+	.word	.L191, gmtime
+	.word	.L192, gmtime_r
+	.word	.L193, h_errno
+	.word	.L194, htonl
+	.word	.L195, htons
+	.word	.L196, hypot
+	.word	.L197, ilogb
+	.word	.L198, ilogbf
+	.word	.L199, imaxabs
+	.word	.L200, in6addr_any
+	.word	.L201, inet_addr
+	.word	.L202, inet_aton
+	.word	.L203, inet_ntoa
+	.word	.L204, inet_ntop
+	.word	.L205, inet_pton
+	.word	.L206, ioctl
+	.word	.L207, isatty
+	.word	.L208, itoa
+	.word	.L209, kill
+	.word	.L210, labs
+	.word	.L211, ldexp
+	.word	.L212, ldexpf
+	.word	.L213, ldexpl
+	.word	.L214, ldiv
+	.word	.L215, lgamma
+	.word	.L216, lgamma_r
+	.word	.L217, listen
+	.word	.L218, llabs
+	.word	.L219, lldiv
+	.word	.L220, localeconv
+	.word	.L221, log
+	.word	.L222, log10
+	.word	.L223, log10f
+	.word	.L224, log10l
+	.word	.L225, log2
+	.word	.L226, log2f
+	.word	.L227, log2l
+	.word	.L228, logf
+	.word	.L229, logl
+	.word	.L230, lseek
+	.word	.L231, malloc
+	.word	.L232, match
+	.word	.L233, meadow_mappings
+	.word	.L234, memalign
+	.word	.L235, memccpy
+	.word	.L236, memchr
+	.word	.L237, memcmp
+	.word	.L238, memcpy
+	.word	.L239, memmove
+	.word	.L240, memrchr
+	.word	.L241, memset
+	.word	.L242, mkdir
+	.word	.L243, mkfifo
+	.word	.L244, mkfifo2
+	.word	.L245, mkstemp
+	.word	.L246, mktemp
+	.word	.L247, mktime
+	.word	.L248, mmap
+	.word	.L249, modf
+	.word	.L250, modff
+	.word	.L251, modfl
+	.word	.L252, mono_main
+	.word	.L253, mono_should_run
+	.word	.L254, mount
+	.word	.L255, munmap
+	.word	.L256, nanosleep
+	.word	.L257, nrand
+	.word	.L258, ntohl
+	.word	.L259, ntohs
+	.word	.L260, open
+	.word	.L261, opendir
+	.word	.L262, optarg
+	.word	.L263, optind
+	.word	.L264, optopt
+	.word	.L265, perror
+	.word	.L266, pipe
+	.word	.L267, pipe2
+	.word	.L268, poll
+	.word	.L269, posix_spawnattr_dump
+	.word	.L270, posix_spawnattr_getflags
+	.word	.L271, posix_spawnattr_getschedparam
+	.word	.L272, posix_spawnattr_getschedpolicy
+	.word	.L273, posix_spawnattr_getsigmask
+	.word	.L274, posix_spawnattr_init
+	.word	.L275, posix_spawnattr_setflags
+	.word	.L276, posix_spawnattr_setschedparam
+	.word	.L277, posix_spawnattr_setschedpolicy
+	.word	.L278, posix_spawnattr_setsigmask
+	.word	.L279, pow
+	.word	.L280, powf
+	.word	.L281, powl
+	.word	.L282, ppoll
+	.word	.L283, prctl
+	.word	.L284, pread
+	.word	.L285, printf
+	.word	.L286, pselect
+	.word	.L287, psiginfo
+	.word	.L288, psignal
+	.word	.L289, pthread_attr_destroy
+	.word	.L290, pthread_attr_getinheritsched
+	.word	.L291, pthread_attr_getschedparam
+	.word	.L292, pthread_attr_getschedpolicy
+	.word	.L293, pthread_attr_getstack
+	.word	.L294, pthread_attr_getstacksize
+	.word	.L295, pthread_attr_init
+	.word	.L296, pthread_attr_setinheritsched
+	.word	.L297, pthread_attr_setschedparam
+	.word	.L298, pthread_attr_setschedpolicy
+	.word	.L299, pthread_attr_setstack
+	.word	.L300, pthread_attr_setstacksize
+	.word	.L301, pthread_barrier_destroy
+	.word	.L302, pthread_barrier_init
+	.word	.L303, pthread_barrier_wait
+	.word	.L304, pthread_barrierattr_destroy
+	.word	.L305, pthread_barrierattr_getpshared
+	.word	.L306, pthread_barrierattr_init
+	.word	.L307, pthread_barrierattr_setpshared
+	.word	.L308, pthread_cancel
+	.word	.L309, pthread_cleanup_pop
+	.word	.L310, pthread_cleanup_push
+	.word	.L311, pthread_cond_broadcast
+	.word	.L312, pthread_cond_destroy
+	.word	.L313, pthread_cond_init
+	.word	.L314, pthread_cond_signal
+	.word	.L315, pthread_cond_timedwait
+	.word	.L316, pthread_cond_wait
+	.word	.L317, pthread_condattr_destroy
+	.word	.L318, pthread_condattr_init
+	.word	.L319, pthread_create
+	.word	.L320, pthread_detach
+	.word	.L321, pthread_exit
+	.word	.L322, pthread_get_stackaddr_np
+	.word	.L323, pthread_get_stacksize_np
+	.word	.L324, pthread_getschedparam
+	.word	.L325, pthread_getspecific
+	.word	.L326, pthread_join
+	.word	.L327, pthread_key_create
+	.word	.L328, pthread_key_delete
+	.word	.L329, pthread_kill
+	.word	.L330, pthread_mutex_consistent
+	.word	.L331, pthread_mutex_destroy
+	.word	.L332, pthread_mutex_init
+	.word	.L333, pthread_mutex_lock
+	.word	.L334, pthread_mutex_timedlock
+	.word	.L335, pthread_mutex_trylock
+	.word	.L336, pthread_mutex_unlock
+	.word	.L337, pthread_mutexattr_destroy
+	.word	.L338, pthread_mutexattr_getprotocol
+	.word	.L339, pthread_mutexattr_getpshared
+	.word	.L340, pthread_mutexattr_getrobust
+	.word	.L341, pthread_mutexattr_gettype
+	.word	.L342, pthread_mutexattr_init
+	.word	.L343, pthread_mutexattr_setprotocol
+	.word	.L344, pthread_mutexattr_setpshared
+	.word	.L345, pthread_mutexattr_setrobust
+	.word	.L346, pthread_mutexattr_settype
+	.word	.L347, pthread_once
+	.word	.L348, pthread_rwlock_destroy
+	.word	.L349, pthread_rwlock_init
+	.word	.L350, pthread_rwlock_rdlock
+	.word	.L351, pthread_rwlock_timedrdlock
+	.word	.L352, pthread_rwlock_timedwrlock
+	.word	.L353, pthread_rwlock_tryrdlock
+	.word	.L354, pthread_rwlock_trywrlock
+	.word	.L355, pthread_rwlock_unlock
+	.word	.L356, pthread_rwlock_wrlock
+	.word	.L357, pthread_setcancelstate
+	.word	.L358, pthread_setcanceltype
+	.word	.L359, pthread_setschedparam
+	.word	.L360, pthread_setschedprio
+	.word	.L361, pthread_setspecific
+	.word	.L362, pthread_sigmask
+	.word	.L363, pthread_startup
+	.word	.L364, pthread_testcancel
+	.word	.L365, pthread_yield
+	.word	.L366, putenv
+	.word	.L367, puts
+	.word	.L368, pwrite
+	.word	.L369, qsort
+	.word	.L370, raise
+	.word	.L371, rand
+	.word	.L372, random
+	.word	.L373, read
+	.word	.L374, readdir
+	.word	.L375, readdir_r
+	.word	.L376, readv
+	.word	.L377, realloc
+	.word	.L378, recv
+	.word	.L379, recvfrom
+	.word	.L380, recvmsg
+	.word	.L381, remove
+	.word	.L382, rename
+	.word	.L383, rewinddir
+	.word	.L384, rint
+	.word	.L385, rintf
+	.word	.L386, rintl
+	.word	.L387, rmdir
+	.word	.L388, round
+	.word	.L389, roundf
+	.word	.L390, roundl
+	.word	.L391, scalbn
+	.word	.L392, scalbnf
+	.word	.L393, scanf
+	.word	.L394, seekdir
+	.word	.L395, select
+	.word	.L396, sem_destroy
+	.word	.L397, sem_getprotocol
+	.word	.L398, sem_getvalue
+	.word	.L399, sem_init
+	.word	.L400, sem_post
+	.word	.L401, sem_setprotocol
+	.word	.L402, sem_timedwait
+	.word	.L403, sem_trywait
+	.word	.L404, sem_wait
+	.word	.L405, send
+	.word	.L406, sendfile
+	.word	.L407, sendmsg
+	.word	.L408, sendto
+	.word	.L409, set_errno
+	.word	.L410, setbuf
+	.word	.L411, setenv
+	.word	.L412, sethostname
+	.word	.L413, setlocale
+	.word	.L414, setlogmask
+	.word	.L415, setsockopt
+	.word	.L416, settimeofday
+	.word	.L417, setvbuf
+	.word	.L418, shutdown
+	.word	.L419, sigaction
+	.word	.L420, sigaddset
+	.word	.L421, sigdelset
+	.word	.L422, sigemptyset
+	.word	.L423, sigfillset
+	.word	.L424, sighold
+	.word	.L425, sigignore
+	.word	.L426, sigismember
+	.word	.L427, signal
+	.word	.L428, sigpause
+	.word	.L429, sigpending
+	.word	.L430, sigprocmask
+	.word	.L431, sigqueue
+	.word	.L432, sigrelse
+	.word	.L433, sigset
+	.word	.L434, sigsuspend
+	.word	.L435, sigtimedwait
+	.word	.L436, sigwait
+	.word	.L437, sigwaitinfo
+	.word	.L438, sin
+	.word	.L439, sinf
+	.word	.L440, sinh
+	.word	.L441, sinhf
+	.word	.L442, sinhl
+	.word	.L443, sinl
+	.word	.L444, sleep
+	.word	.L445, snprintf
+	.word	.L446, socket
+	.word	.L447, sprintf
+	.word	.L448, sqrt
+	.word	.L449, sqrtf
+	.word	.L450, sqrtl
+	.word	.L451, srand
+	.word	.L452, sscanf
+	.word	.L453, stat
+	.word	.L454, statfs
+	.word	.L455, stpcpy
+	.word	.L456, stpncpy
+	.word	.L457, strcasecmp
+	.word	.L458, strcasestr
+	.word	.L459, strcat
+	.word	.L460, strchr
+	.word	.L461, strcmp
+	.word	.L462, strcoll
+	.word	.L463, strcpy
+	.word	.L464, strcspn
+	.word	.L465, strdup
+	.word	.L466, stream_semgive
+	.word	.L467, stream_semtake
+	.word	.L468, strerror
+	.word	.L469, strerror_r
+	.word	.L470, strftime
+	.word	.L471, strlen
+	.word	.L472, strncasecmp
+	.word	.L473, strncat
+	.word	.L474, strncmp
+	.word	.L475, strncpy
+	.word	.L476, strndup
+	.word	.L477, strnlen
+	.word	.L478, strpbrk
+	.word	.L479, strrchr
+	.word	.L480, strsep
+	.word	.L481, strsignal
+	.word	.L482, strspn
+	.word	.L483, strstr
+	.word	.L484, strtod
+	.word	.L485, strtof
+	.word	.L486, strtoimax
+	.word	.L487, strtok
+	.word	.L488, strtok_r
+	.word	.L489, strtol
+	.word	.L490, strtold
+	.word	.L491, strtoll
+	.word	.L492, strtoul
+	.word	.L493, strtoull
+	.word	.L494, strtoumax
+	.word	.L495, strxfrm
+	.word	.L496, swab
+	.word	.L497, sysconf
+	.word	.L498, syslog
+	.word	.L499, tan
+	.word	.L500, tanf
+	.word	.L501, tanh
+	.word	.L502, tanhf
+	.word	.L503, tanhl
+	.word	.L504, tanl
+	.word	.L505, tcdrain
+	.word	.L506, tcflow
+	.word	.L507, tcflush
+	.word	.L508, tcgetattr
+	.word	.L509, tcsetattr
+	.word	.L510, tea_decrypt
+	.word	.L511, tea_encrypt
+	.word	.L512, telldir
+	.word	.L513, tempnam
+	.word	.L514, tgamma
+	.word	.L515, time
+	.word	.L516, tmpnam
+	.word	.L517, trunc
+	.word	.L518, truncate
+	.word	.L519, truncf
+	.word	.L520, truncl
+	.word	.L521, uadd32x64
+	.word	.L522, uadd64
+	.word	.L523, ub32sqrtub16
+	.word	.L524, umul32
+	.word	.L525, umul32x64
+	.word	.L526, umul64
+	.word	.L527, uname
+	.word	.L528, ungetc
+	.word	.L529, unlink
+	.word	.L530, unsetenv
+	.word	.L531, usleep
+	.word	.L532, usub64
+	.word	.L533, usub64x32
+	.word	.L534, vasprintf
+	.word	.L535, vdprintf
+	.word	.L536, vfork
+	.word	.L537, vfprintf
+	.word	.L538, vfscanf
+	.word	.L539, vprintf
+	.word	.L540, vsnprintf
+	.word	.L541, vsprintf
+	.word	.L542, vsscanf
+	.word	.L543, vsyslog
+	.word	.L544, waitpid
+	.word	.L545, write
+	.word	.L546, writev
+	.word	.L547, xorshift128
+	.word	.L548, zalloc
+	.size	globalTable, . - globalTable

--- a/libs/libc/modlib/modlib_x64_globals.S
+++ b/libs/libc/modlib/modlib_x64_globals.S
@@ -1,0 +1,565 @@
+        .data
+        .align 8
+	.global globalNames
+
+globalNames:
+.L0:	.string	"accept4"
+.L1:	.string	"clearenv"
+.L2:	.string	"cmd_alias"
+.L3:	.string	"cmd_arp"
+.L4:	.string	"cmd_basename"
+.L5:	.string	"cmd_break"
+.L6:	.string	"cmd_cat"
+.L7:	.string	"cmd_cd"
+.L8:	.string	"cmd_cmp"
+.L9:	.string	"cmd_cp"
+.L10:	.string	"cmd_date"
+.L11:	.string	"cmd_dd"
+.L12:	.string	"cmd_dirname"
+.L13:	.string	"cmd_dmesg"
+.L14:	.string	"cmd_echo"
+.L15:	.string	"cmd_exec"
+.L16:	.string	"cmd_hexdump"
+.L17:	.string	"cmd_insmod"
+.L18:	.string	"cmd_kill"
+.L19:	.string	"cmd_lbracket"
+.L20:	.string	"cmd_losetup"
+.L21:	.string	"cmd_ls"
+.L22:	.string	"cmd_mkdir"
+.L23:	.string	"cmd_mkfifo"
+.L24:	.string	"cmd_mkrd"
+.L25:	.string	"cmd_mount"
+.L26:	.string	"cmd_mv"
+.L27:	.string	"cmd_nslookup"
+.L28:	.string	"cmd_poweroff"
+.L29:	.string	"cmd_printf"
+.L30:	.string	"cmd_pwd"
+.L31:	.string	"cmd_rm"
+.L32:	.string	"cmd_rmdir"
+.L33:	.string	"cmd_rmmod"
+.L34:	.string	"cmd_set"
+.L35:	.string	"cmd_sleep"
+.L36:	.string	"cmd_source"
+.L37:	.string	"cmd_test"
+.L38:	.string	"cmd_time"
+.L39:	.string	"cmd_truncate"
+.L40:	.string	"cmd_umount"
+.L41:	.string	"cmd_unalias"
+.L42:	.string	"cmd_uname"
+.L43:	.string	"cmd_unset"
+.L44:	.string	"cmd_uptime"
+.L45:	.string	"cmd_usleep"
+.L46:	.string	"cmd_xd"
+.L47:	.string	"cmsg_append"
+.L48:	.string	"dir_allocate"
+.L49:	.string	"exec_builtin"
+.L50:	.string	"icmp_alloc"
+.L51:	.string	"icmp_chksum_iob"
+.L52:	.string	"icmp_findconn"
+.L53:	.string	"icmp_free"
+.L54:	.string	"icmp_input"
+.L55:	.string	"icmp_ioctl"
+.L56:	.string	"icmp_nextconn"
+.L57:	.string	"icmp_poll"
+.L58:	.string	"icmp_pollsetup"
+.L59:	.string	"icmp_pollteardown"
+.L60:	.string	"icmp_recvmsg"
+.L61:	.string	"icmp_reply"
+.L62:	.string	"icmp_sendmsg"
+.L63:	.string	"icmpv6_advertise"
+.L64:	.string	"icmpv6_alloc"
+.L65:	.string	"icmpv6_autoconfig"
+.L66:	.string	"icmpv6_chksum"
+.L67:	.string	"icmpv6_foreach"
+.L68:	.string	"icmpv6_free"
+.L69:	.string	"icmpv6_input"
+.L70:	.string	"icmpv6_ioctl"
+.L71:	.string	"icmpv6_linkipaddr"
+.L72:	.string	"icmpv6_neighbor"
+.L73:	.string	"icmpv6_nextconn"
+.L74:	.string	"icmpv6_notify"
+.L75:	.string	"icmpv6_poll"
+.L76:	.string	"icmpv6_pollsetup"
+.L77:	.string	"icmpv6_pollteardown"
+.L78:	.string	"icmpv6_radvertise"
+.L79:	.string	"icmpv6_recvmsg"
+.L80:	.string	"icmpv6_reply"
+.L81:	.string	"icmpv6_rnotify"
+.L82:	.string	"icmpv6_rsolicit"
+.L83:	.string	"icmpv6_rwait"
+.L84:	.string	"icmpv6_rwait_cancel"
+.L85:	.string	"icmpv6_rwait_setup"
+.L86:	.string	"icmpv6_sendmsg"
+.L87:	.string	"icmpv6_setaddresses"
+.L88:	.string	"icmpv6_solicit"
+.L89:	.string	"icmpv6_wait"
+.L90:	.string	"icmpv6_wait_cancel"
+.L91:	.string	"icmpv6_wait_setup"
+.L92:	.string	"inet_close"
+.L93:	.string	"insmod"
+.L94:	.string	"ipv4_build_header"
+.L95:	.string	"ipv4_chksum"
+.L96:	.string	"ipv4_getpeername"
+.L97:	.string	"ipv4_getsockname"
+.L98:	.string	"ipv4_getsockopt"
+.L99:	.string	"ipv4_input"
+.L100:	.string	"ipv4_setsockopt"
+.L101:	.string	"ipv4_upperlayer_chksum"
+.L102:	.string	"ipv6_build_header"
+.L103:	.string	"ipv6_getpeername"
+.L104:	.string	"ipv6_getsockname"
+.L105:	.string	"ipv6_getsockopt"
+.L106:	.string	"ipv6_input"
+.L107:	.string	"ipv6_setsockopt"
+.L108:	.string	"ipv6_upperlayer_chksum"
+.L109:	.string	"kill"
+.L110:	.string	"kthread_create"
+.L111:	.string	"loop_register"
+.L112:	.string	"losetup"
+.L113:	.string	"loteardown"
+.L114:	.string	"lstat"
+.L115:	.string	"mkrd"
+.L116:	.string	"modhandle"
+.L117:	.string	"modsym"
+.L118:	.string	"mount"
+.L119:	.string	"neighbor_add"
+.L120:	.string	"neighbor_ethernet_out"
+.L121:	.string	"neighbor_findentry"
+.L122:	.string	"neighbor_lookup"
+.L123:	.string	"neighbor_out"
+.L124:	.string	"netdown_notifier_signal"
+.L125:	.string	"oneshot_register"
+.L126:	.string	"open_blockdriver"
+.L127:	.string	"panic_notifier_call_chain"
+.L128:	.string	"poll_notify"
+.L129:	.string	"pthread_cancel"
+.L130:	.string	"pthread_completejoin"
+.L131:	.string	"pthread_createjoininfo"
+.L132:	.string	"pthread_destroyjoin"
+.L133:	.string	"pthread_detach"
+.L134:	.string	"pthread_findjoininfo"
+.L135:	.string	"pthread_mutex_inconsistent"
+.L136:	.string	"pthread_release"
+.L137:	.string	"pthread_sem_give"
+.L138:	.string	"pthread_setup_scheduler"
+.L139:	.string	"ramdisk_register"
+.L140:	.string	"reboot_notifier_call_chain"
+.L141:	.string	"recv"
+.L142:	.string	"recvmsg"
+.L143:	.string	"rmmod"
+.L144:	.string	"romfs_checkmount"
+.L145:	.string	"romfs_datastart"
+.L146:	.string	"romfs_filecacheread"
+.L147:	.string	"romfs_fileconfigure"
+.L148:	.string	"romfs_finddirentry"
+.L149:	.string	"romfs_freenode"
+.L150:	.string	"romfs_fsconfigure"
+.L151:	.string	"romfs_hwconfigure"
+.L152:	.string	"romfs_hwread"
+.L153:	.string	"romfs_img"
+.L154:	.string	"romfs_img_len"
+.L155:	.string	"romfs_parsedirentry"
+.L156:	.string	"romfs_parsefilename"
+.L157:	.string	"rtc_initialize"
+.L158:	.string	"sem_clockwait"
+.L159:	.string	"sem_destroy"
+.L160:	.string	"sem_post"
+.L161:	.string	"sem_timedwait"
+.L162:	.string	"sem_trywait"
+.L163:	.string	"sem_wait"
+.L164:	.string	"send"
+.L165:	.string	"setenv"
+.L166:	.string	"sh_main"
+.L167:	.string	"sigpending"
+.L168:	.string	"sigprocmask"
+.L169:	.string	"sigtimedwait"
+.L170:	.string	"sotest_main"
+.L171:	.string	"sync"
+.L172:	.string	"sysinfo"
+.L173:	.string	"tcpip_hdrsize"
+.L174:	.string	"tls_init_info"
+.L175:	.string	"unsetenv"
+.L176:	.string	"waitpid"
+.L177:	.string	"work_cancel"
+.L178:	.string	"work_notifier_signal"
+.L179:	.string	"work_queue"
+.L180:	.string	"work_start_highpri"
+.L181:	.string	"work_start_lowpri"
+	.size	globalNames, . - globalNames
+
+	.align	8
+	.global	nGlobals
+	.type	nGlobals, "object"
+nGlobals:	
+	.word	182
+	.size	nGlobals, . - nGlobals
+
+        .align 8
+	.global globalTable
+	.type	globalTable, "object"
+globalTable:
+	.weak	accept4
+	.weak	clearenv
+	.weak	cmd_alias
+	.weak	cmd_arp
+	.weak	cmd_basename
+	.weak	cmd_break
+	.weak	cmd_cat
+	.weak	cmd_cd
+	.weak	cmd_cmp
+	.weak	cmd_cp
+	.weak	cmd_date
+	.weak	cmd_dd
+	.weak	cmd_dirname
+	.weak	cmd_dmesg
+	.weak	cmd_echo
+	.weak	cmd_exec
+	.weak	cmd_hexdump
+	.weak	cmd_insmod
+	.weak	cmd_kill
+	.weak	cmd_lbracket
+	.weak	cmd_losetup
+	.weak	cmd_ls
+	.weak	cmd_mkdir
+	.weak	cmd_mkfifo
+	.weak	cmd_mkrd
+	.weak	cmd_mount
+	.weak	cmd_mv
+	.weak	cmd_nslookup
+	.weak	cmd_poweroff
+	.weak	cmd_printf
+	.weak	cmd_pwd
+	.weak	cmd_rm
+	.weak	cmd_rmdir
+	.weak	cmd_rmmod
+	.weak	cmd_set
+	.weak	cmd_sleep
+	.weak	cmd_source
+	.weak	cmd_test
+	.weak	cmd_time
+	.weak	cmd_truncate
+	.weak	cmd_umount
+	.weak	cmd_unalias
+	.weak	cmd_uname
+	.weak	cmd_unset
+	.weak	cmd_uptime
+	.weak	cmd_usleep
+	.weak	cmd_xd
+	.weak	cmsg_append
+	.weak	dir_allocate
+	.weak	exec_builtin
+	.weak	icmp_alloc
+	.weak	icmp_chksum_iob
+	.weak	icmp_findconn
+	.weak	icmp_free
+	.weak	icmp_input
+	.weak	icmp_ioctl
+	.weak	icmp_nextconn
+	.weak	icmp_poll
+	.weak	icmp_pollsetup
+	.weak	icmp_pollteardown
+	.weak	icmp_recvmsg
+	.weak	icmp_reply
+	.weak	icmp_sendmsg
+	.weak	icmpv6_advertise
+	.weak	icmpv6_alloc
+	.weak	icmpv6_autoconfig
+	.weak	icmpv6_chksum
+	.weak	icmpv6_foreach
+	.weak	icmpv6_free
+	.weak	icmpv6_input
+	.weak	icmpv6_ioctl
+	.weak	icmpv6_linkipaddr
+	.weak	icmpv6_neighbor
+	.weak	icmpv6_nextconn
+	.weak	icmpv6_notify
+	.weak	icmpv6_poll
+	.weak	icmpv6_pollsetup
+	.weak	icmpv6_pollteardown
+	.weak	icmpv6_radvertise
+	.weak	icmpv6_recvmsg
+	.weak	icmpv6_reply
+	.weak	icmpv6_rnotify
+	.weak	icmpv6_rsolicit
+	.weak	icmpv6_rwait
+	.weak	icmpv6_rwait_cancel
+	.weak	icmpv6_rwait_setup
+	.weak	icmpv6_sendmsg
+	.weak	icmpv6_setaddresses
+	.weak	icmpv6_solicit
+	.weak	icmpv6_wait
+	.weak	icmpv6_wait_cancel
+	.weak	icmpv6_wait_setup
+	.weak	inet_close
+	.weak	insmod
+	.weak	ipv4_build_header
+	.weak	ipv4_chksum
+	.weak	ipv4_getpeername
+	.weak	ipv4_getsockname
+	.weak	ipv4_getsockopt
+	.weak	ipv4_input
+	.weak	ipv4_setsockopt
+	.weak	ipv4_upperlayer_chksum
+	.weak	ipv6_build_header
+	.weak	ipv6_getpeername
+	.weak	ipv6_getsockname
+	.weak	ipv6_getsockopt
+	.weak	ipv6_input
+	.weak	ipv6_setsockopt
+	.weak	ipv6_upperlayer_chksum
+	.weak	kill
+	.weak	kthread_create
+	.weak	loop_register
+	.weak	losetup
+	.weak	loteardown
+	.weak	lstat
+	.weak	mkrd
+	.weak	modhandle
+	.weak	modsym
+	.weak	mount
+	.weak	neighbor_add
+	.weak	neighbor_ethernet_out
+	.weak	neighbor_findentry
+	.weak	neighbor_lookup
+	.weak	neighbor_out
+	.weak	netdown_notifier_signal
+	.weak	oneshot_register
+	.weak	open_blockdriver
+	.weak	panic_notifier_call_chain
+	.weak	poll_notify
+	.weak	pthread_cancel
+	.weak	pthread_completejoin
+	.weak	pthread_createjoininfo
+	.weak	pthread_destroyjoin
+	.weak	pthread_detach
+	.weak	pthread_findjoininfo
+	.weak	pthread_mutex_inconsistent
+	.weak	pthread_release
+	.weak	pthread_sem_give
+	.weak	pthread_setup_scheduler
+	.weak	ramdisk_register
+	.weak	reboot_notifier_call_chain
+	.weak	recv
+	.weak	recvmsg
+	.weak	rmmod
+	.weak	romfs_checkmount
+	.weak	romfs_datastart
+	.weak	romfs_filecacheread
+	.weak	romfs_fileconfigure
+	.weak	romfs_finddirentry
+	.weak	romfs_freenode
+	.weak	romfs_fsconfigure
+	.weak	romfs_hwconfigure
+	.weak	romfs_hwread
+	.weak	romfs_img
+	.weak	romfs_img_len
+	.weak	romfs_parsedirentry
+	.weak	romfs_parsefilename
+	.weak	rtc_initialize
+	.weak	sem_clockwait
+	.weak	sem_destroy
+	.weak	sem_post
+	.weak	sem_timedwait
+	.weak	sem_trywait
+	.weak	sem_wait
+	.weak	send
+	.weak	setenv
+	.weak	sh_main
+	.weak	sigpending
+	.weak	sigprocmask
+	.weak	sigtimedwait
+	.weak	sotest_main
+	.weak	sync
+	.weak	sysinfo
+	.weak	tcpip_hdrsize
+	.weak	tls_init_info
+	.weak	unsetenv
+	.weak	waitpid
+	.weak	work_cancel
+	.weak	work_notifier_signal
+	.weak	work_queue
+	.weak	work_start_highpri
+	.weak	work_start_lowpri
+	.quad	.L0, accept4
+	.quad	.L1, clearenv
+	.quad	.L2, cmd_alias
+	.quad	.L3, cmd_arp
+	.quad	.L4, cmd_basename
+	.quad	.L5, cmd_break
+	.quad	.L6, cmd_cat
+	.quad	.L7, cmd_cd
+	.quad	.L8, cmd_cmp
+	.quad	.L9, cmd_cp
+	.quad	.L10, cmd_date
+	.quad	.L11, cmd_dd
+	.quad	.L12, cmd_dirname
+	.quad	.L13, cmd_dmesg
+	.quad	.L14, cmd_echo
+	.quad	.L15, cmd_exec
+	.quad	.L16, cmd_hexdump
+	.quad	.L17, cmd_insmod
+	.quad	.L18, cmd_kill
+	.quad	.L19, cmd_lbracket
+	.quad	.L20, cmd_losetup
+	.quad	.L21, cmd_ls
+	.quad	.L22, cmd_mkdir
+	.quad	.L23, cmd_mkfifo
+	.quad	.L24, cmd_mkrd
+	.quad	.L25, cmd_mount
+	.quad	.L26, cmd_mv
+	.quad	.L27, cmd_nslookup
+	.quad	.L28, cmd_poweroff
+	.quad	.L29, cmd_printf
+	.quad	.L30, cmd_pwd
+	.quad	.L31, cmd_rm
+	.quad	.L32, cmd_rmdir
+	.quad	.L33, cmd_rmmod
+	.quad	.L34, cmd_set
+	.quad	.L35, cmd_sleep
+	.quad	.L36, cmd_source
+	.quad	.L37, cmd_test
+	.quad	.L38, cmd_time
+	.quad	.L39, cmd_truncate
+	.quad	.L40, cmd_umount
+	.quad	.L41, cmd_unalias
+	.quad	.L42, cmd_uname
+	.quad	.L43, cmd_unset
+	.quad	.L44, cmd_uptime
+	.quad	.L45, cmd_usleep
+	.quad	.L46, cmd_xd
+	.quad	.L47, cmsg_append
+	.quad	.L48, dir_allocate
+	.quad	.L49, exec_builtin
+	.quad	.L50, icmp_alloc
+	.quad	.L51, icmp_chksum_iob
+	.quad	.L52, icmp_findconn
+	.quad	.L53, icmp_free
+	.quad	.L54, icmp_input
+	.quad	.L55, icmp_ioctl
+	.quad	.L56, icmp_nextconn
+	.quad	.L57, icmp_poll
+	.quad	.L58, icmp_pollsetup
+	.quad	.L59, icmp_pollteardown
+	.quad	.L60, icmp_recvmsg
+	.quad	.L61, icmp_reply
+	.quad	.L62, icmp_sendmsg
+	.quad	.L63, icmpv6_advertise
+	.quad	.L64, icmpv6_alloc
+	.quad	.L65, icmpv6_autoconfig
+	.quad	.L66, icmpv6_chksum
+	.quad	.L67, icmpv6_foreach
+	.quad	.L68, icmpv6_free
+	.quad	.L69, icmpv6_input
+	.quad	.L70, icmpv6_ioctl
+	.quad	.L71, icmpv6_linkipaddr
+	.quad	.L72, icmpv6_neighbor
+	.quad	.L73, icmpv6_nextconn
+	.quad	.L74, icmpv6_notify
+	.quad	.L75, icmpv6_poll
+	.quad	.L76, icmpv6_pollsetup
+	.quad	.L77, icmpv6_pollteardown
+	.quad	.L78, icmpv6_radvertise
+	.quad	.L79, icmpv6_recvmsg
+	.quad	.L80, icmpv6_reply
+	.quad	.L81, icmpv6_rnotify
+	.quad	.L82, icmpv6_rsolicit
+	.quad	.L83, icmpv6_rwait
+	.quad	.L84, icmpv6_rwait_cancel
+	.quad	.L85, icmpv6_rwait_setup
+	.quad	.L86, icmpv6_sendmsg
+	.quad	.L87, icmpv6_setaddresses
+	.quad	.L88, icmpv6_solicit
+	.quad	.L89, icmpv6_wait
+	.quad	.L90, icmpv6_wait_cancel
+	.quad	.L91, icmpv6_wait_setup
+	.quad	.L92, inet_close
+	.quad	.L93, insmod
+	.quad	.L94, ipv4_build_header
+	.quad	.L95, ipv4_chksum
+	.quad	.L96, ipv4_getpeername
+	.quad	.L97, ipv4_getsockname
+	.quad	.L98, ipv4_getsockopt
+	.quad	.L99, ipv4_input
+	.quad	.L100, ipv4_setsockopt
+	.quad	.L101, ipv4_upperlayer_chksum
+	.quad	.L102, ipv6_build_header
+	.quad	.L103, ipv6_getpeername
+	.quad	.L104, ipv6_getsockname
+	.quad	.L105, ipv6_getsockopt
+	.quad	.L106, ipv6_input
+	.quad	.L107, ipv6_setsockopt
+	.quad	.L108, ipv6_upperlayer_chksum
+	.quad	.L109, kill
+	.quad	.L110, kthread_create
+	.quad	.L111, loop_register
+	.quad	.L112, losetup
+	.quad	.L113, loteardown
+	.quad	.L114, lstat
+	.quad	.L115, mkrd
+	.quad	.L116, modhandle
+	.quad	.L117, modsym
+	.quad	.L118, mount
+	.quad	.L119, neighbor_add
+	.quad	.L120, neighbor_ethernet_out
+	.quad	.L121, neighbor_findentry
+	.quad	.L122, neighbor_lookup
+	.quad	.L123, neighbor_out
+	.quad	.L124, netdown_notifier_signal
+	.quad	.L125, oneshot_register
+	.quad	.L126, open_blockdriver
+	.quad	.L127, panic_notifier_call_chain
+	.quad	.L128, poll_notify
+	.quad	.L129, pthread_cancel
+	.quad	.L130, pthread_completejoin
+	.quad	.L131, pthread_createjoininfo
+	.quad	.L132, pthread_destroyjoin
+	.quad	.L133, pthread_detach
+	.quad	.L134, pthread_findjoininfo
+	.quad	.L135, pthread_mutex_inconsistent
+	.quad	.L136, pthread_release
+	.quad	.L137, pthread_sem_give
+	.quad	.L138, pthread_setup_scheduler
+	.quad	.L139, ramdisk_register
+	.quad	.L140, reboot_notifier_call_chain
+	.quad	.L141, recv
+	.quad	.L142, recvmsg
+	.quad	.L143, rmmod
+	.quad	.L144, romfs_checkmount
+	.quad	.L145, romfs_datastart
+	.quad	.L146, romfs_filecacheread
+	.quad	.L147, romfs_fileconfigure
+	.quad	.L148, romfs_finddirentry
+	.quad	.L149, romfs_freenode
+	.quad	.L150, romfs_fsconfigure
+	.quad	.L151, romfs_hwconfigure
+	.quad	.L152, romfs_hwread
+	.quad	.L153, romfs_img
+	.quad	.L154, romfs_img_len
+	.quad	.L155, romfs_parsedirentry
+	.quad	.L156, romfs_parsefilename
+	.quad	.L157, rtc_initialize
+	.quad	.L158, sem_clockwait
+	.quad	.L159, sem_destroy
+	.quad	.L160, sem_post
+	.quad	.L161, sem_timedwait
+	.quad	.L162, sem_trywait
+	.quad	.L163, sem_wait
+	.quad	.L164, send
+	.quad	.L165, setenv
+	.quad	.L166, sh_main
+	.quad	.L167, sigpending
+	.quad	.L168, sigprocmask
+	.quad	.L169, sigtimedwait
+	.quad	.L170, sotest_main
+	.quad	.L171, sync
+	.quad	.L172, sysinfo
+	.quad	.L173, tcpip_hdrsize
+	.quad	.L174, tls_init_info
+	.quad	.L175, unsetenv
+	.quad	.L176, waitpid
+	.quad	.L177, work_cancel
+	.quad	.L178, work_notifier_signal
+	.quad	.L179, work_queue
+	.quad	.L180, work_start_highpri
+	.quad	.L181, work_start_lowpri
+	.size	globalTable, . - globalTable


### PR DESCRIPTION
**This is not a real PR**. It follows on from my [presentation](https://www.youtube.com/watch?v=qSvYHhM7hz0&t=4711s) at NuttX 2022 Workshop. It is my 1st attempt to take my changes to our backlevel NuttX repo and apply it to the current master. It is for information only as people expressed a desire to see what was done so I thought this was the best way to do it. 

#### Caveats
* Created specifically for the Meadow project which uses an arm7m - not a general solution
* Built using a custom configuration
  - Important bits:
```
    CONFIG_BUILD_PROTECTED=y
    CONFIG_BUILD_2PASS=y
    CONFIG_PASS1_TARGET="all"
    CONFIG_PASS1_BUILDIR="boards/arm/stm32/olimex-stm32-p407/kernel"
    CONFIG_PASS1_OBJECT=""
    CONFIG_NUTTX_USERSPACE=0x08020000
    :
    CONFIG_LIBC_DLFCN=y 
    CONFIG_LIBC_MODLIB=y
    :
    #
    # Module library configuration
    #
    CONFIG_MODLIB_MAXDEPEND=2
    CONFIG_MODLIB_ALIGN_LOG2=2
    CONFIG_MODLIB_BUFFERSIZE=32
    CONFIG_MODLIB_BUFFERINCR=32
    CONFIG_MODLIB_RELOCATION_BUFFERCOUNT=256
    CONFIG_MODLIB_SYMBOL_CACHECOUNT=256
```
* Not tried in other modes other than PROTECTED
* Does not handle `.so` objects having dependencies on other `.so` objects
* Only armv7-m has its `arch_elf.c` updated with the additional relocation types
* It builds cleanly but I have not run to verify functionality

#### Change Descriptions

* build-globals.sh
  - Build the modlib_globals.S file used to resolve symbols when dynamically loading
  -  I have not looked at `mksymtab.c` to see if this will generate an architecture-independent of what I am attempting to create with this script

* include/elf.h
  - Add definitions that may be found in shared objects

* include/nuttx/lib/modlib.h
  - Add fields to mod_loadifno_s:
    - Program headers
    - Exported symbols
    - Data section address
    - Padding requirement
    - Section index for dynamic symbol table
    - Number of symbols exported
  - Add prottotype for modlib_freesymtab

* libs/libc/dlfcn/lib_dlclose.c
  - Free the symbol table when the dll is closed

* libs/libc/dlfcn/lib_dlopen.c
  - Add dump of program headers to debug routine
  - Differentiate between ET_REL and ET_DYN objects

* libs/libc/machine/arm/armv7-m/arch_elf.c
  - Add handling of R_ARM_RELATIVE and R_ARM_JUMP slot relocation types

* libs/libc/modlib/Make.defs
  - Include new file containing library APIs used when loading shared objects

* libs/libc/modlib/modlib.h
  - Add parameter to modlib_readsym prototype
  - Add prototypes for:
    - modlib_insertsymtab
    - modlib_findglobal

* libs/libc/modlib/modlib_loadshdrs.c
  - Rename modlib_loadshdrs.c to modlib_loadhdrs.c
  - Rename modlib_loadshdrs to modlib_loadhdrs
  - Add code to load program headers

* libs/libc/modlib/modlib_bind.c
  - Call modlib_readsym with pointer to symbol table
  - Add modlib_relocatedyn to manage relocation of symbols with shared object (ET_DYN)
  - Differentiate between ET_REL and ET_DYN objects

* libs/libc/modlib/modlib_load.c
  - Calculate sizes and text/data addresses based on program headers rather than section headers

* libs/libc/modlib/modlib_symbols.c
  - Define entry point structure
  - Add offset parameter to modlib_symname() and use to find symbol names
  - Add symtab section header parameter to modlib_readsym()
  - Add offset parameter to modlib_symvalue() to locate symbol names
  - Add modlib_insertsyntab() to create a symbol table for exporting and resolution
  - Add findEP() to resolve a symbol in the modlib_global table
  - Add modlib_findglobal() to find symbol in the modlib_global table
  - Add modlib_freesymtab() to free the symbol table

* libs/libc/modlib/modlib_uninit.c
  - Free header and sections from a module_loadinfo_s control block

* libs/libc/modlib/modlib_verify.c
  - Handle ET_DYN shared objects

* libs/libc/modlib/modlib_globals.S
  - Define library APIs that may be resolved when loading a shared object