### PR TITLE
mutex:move mutex holder to struct mutex_s.

### DIFF
--- a/include/nuttx/modem/alt1250.h
+++ b/include/nuttx/modem/alt1250.h
@@ -323,7 +323,7 @@ typedef struct altcom_fd_set_s altcom_fd_set;
 struct alt_queue_s
 {
   sq_queue_t queue;
-  sem_t lock;
+  mutex_t lock;
 };
 
 struct alt1250_dev_s

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -204,6 +204,7 @@ enum tstate_e
 
   TSTATE_TASK_INACTIVE,       /* BLOCKED      - Initialized but not yet activated */
   TSTATE_WAIT_SEM,            /* BLOCKED      - Waiting for a semaphore */
+  TSTATE_WAIT_MUTEX,          /* BLOCKED      - Waiting for a mutex */
   TSTATE_WAIT_SIG,            /* BLOCKED      - Waiting for a signal */
 #if !defined(CONFIG_DISABLE_MQUEUE) && !defined(CONFIG_DISABLE_MQUEUE_SYSV)
   TSTATE_WAIT_MQNOTEMPTY,     /* BLOCKED      - Waiting for a MQ to become not empty. */
@@ -453,7 +454,7 @@ struct task_group_s
 
                               /* Pthread join Info:                         */
 
-  sem_t tg_joinlock;              /* Mutually exclusive access to join data */
+  mutex_t tg_joinlock;            /* Mutually exclusive access to join data */
   FAR struct join_s *tg_joinhead; /* Head of a list of join data            */
   FAR struct join_s *tg_jointail; /* Tail of a list of join data            */
 #endif

--- a/include/nuttx/semaphore.h
+++ b/include/nuttx/semaphore.h
@@ -29,6 +29,7 @@
 
 #include <errno.h>
 #include <semaphore.h>
+#include <stdbool.h>
 
 #include <nuttx/clock.h>
 
@@ -141,6 +142,63 @@ extern "C"
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
+
+/****************************************************************************
+ * Name: _nxsem_wait
+ *
+ * Description:
+ *   This function attempts to lock the semaphore referenced by 'sem'.  If
+ *   the semaphore value is (<=) zero, then the calling task will not return
+ *   until it successfully acquires the lock.
+ *
+ *   This is an internal OS interface.  It is functionally equivalent to
+ *   sem_wait except that:
+ *
+ *   - It is not a cancellation point, and
+ *   - It does not modify the errno value.
+ *
+ * Input Parameters:
+ *   sem      - Semaphore descriptor.
+ *   is_mutex - true if mutex.
+ *
+ * Returned Value:
+ *   This is an internal OS interface and should not be used by applications.
+ *   It follows the NuttX internal error return policy:  Zero (OK) is
+ *   returned on success.  A negated errno value is returned on failure.
+ *   Possible returned errors:
+ *
+ *   - EINVAL:  Invalid attempt to get the semaphore
+ *   - EINTR:   The wait was interrupted by the receipt of a signal.
+ *
+ ****************************************************************************/
+
+int _nxsem_wait(FAR sem_t *sem, bool is_mutex);
+
+/****************************************************************************
+ * Name: _sem_wait
+ *
+ * Description:
+ *   This function attempts to lock the semaphore referenced by 'sem'.  If
+ *   the semaphore value is (<=) zero, then the calling task will not return
+ *   until it successfully acquires the lock.
+ *
+ *   This is an internal OS interface.
+ *
+ * Input Parameters:
+ *   sem - Semaphore descriptor.
+ *   is_mutex - true if mutex.
+ *
+ * Returned Value:
+ *   This function is a standard, POSIX application interface.  It returns
+ *   zero (OK) if successful.  Otherwise, -1 (ERROR) is returned and
+ *   the errno value is set appropriately.  Possible errno values include:
+ *
+ *   - EINVAL:  Invalid attempt to get the semaphore
+ *   - EINTR:   The wait was interrupted by the receipt of a signal.
+ *
+ ****************************************************************************/
+
+int _sem_wait(FAR sem_t *sem, bool is_mutex);
 
 /****************************************************************************
  * Name: nxsem_init

--- a/mm/mm_heap/mm.h
+++ b/mm/mm_heap/mm.h
@@ -220,7 +220,7 @@ struct mm_heap_s
    * the following un-named mutex.
    */
 
-  sem_t mm_lock;
+  mutex_t mm_lock;
 
   /* This is the size of the heap provided to mm */
 

--- a/sched/semaphore/sem_recover.c
+++ b/sched/semaphore/sem_recover.c
@@ -80,7 +80,8 @@ void nxsem_recover(FAR struct tcb_s *tcb)
    */
 
   flags = enter_critical_section();
-  if (tcb->task_state == TSTATE_WAIT_SEM)
+  if (tcb->task_state == TSTATE_WAIT_SEM ||
+      tcb->task_state == TSTATE_WAIT_MUTEX)
     {
       FAR sem_t *sem = tcb->waitobj;
       DEBUGASSERT(sem != NULL && sem->semcount < 0);

--- a/sched/semaphore/sem_waitirq.c
+++ b/sched/semaphore/sem_waitirq.c
@@ -78,7 +78,8 @@ void nxsem_wait_irq(FAR struct tcb_s *wtcb, int errcode)
    * and already changed the task's state.
    */
 
-  if (wtcb->task_state == TSTATE_WAIT_SEM)
+  if (wtcb->task_state == TSTATE_WAIT_SEM ||
+      wtcb->task_state == TSTATE_WAIT_MUTEX)
     {
       FAR sem_t *sem = wtcb->waitobj;
       DEBUGASSERT(sem != NULL && sem->semcount < 0);

--- a/sched/signal/sig_dispatch.c
+++ b/sched/signal/sig_dispatch.c
@@ -434,7 +434,8 @@ int nxsig_tcbdispatch(FAR struct tcb_s *stcb, siginfo_t *info)
        * be unblocked when a signal is received.
        */
 
-      if (stcb->task_state == TSTATE_WAIT_SEM)
+      if (stcb->task_state == TSTATE_WAIT_SEM ||
+          stcb->task_state == TSTATE_WAIT_MUTEX)
         {
           nxsem_wait_irq(stcb, EINTR);
         }

--- a/sched/task/task_cancelpt.c
+++ b/sched/task/task_cancelpt.c
@@ -378,7 +378,8 @@ bool nxnotify_cancellation(FAR struct tcb_s *tcb)
            * thread must be unblocked to handle the cancellation.
            */
 
-          if (tcb->task_state == TSTATE_WAIT_SEM)
+          if (tcb->task_state == TSTATE_WAIT_SEM ||
+              tcb->task_state == TSTATE_WAIT_MUTEX)
             {
               nxsem_wait_irq(tcb, ECANCELED);
             }


### PR DESCRIPTION
Signed-off-by: 田昕 <tianxin7@xiaomi.com>

## Summary
We move the mutex holder to struct mutex_s so that we can trace who holds the mutex when deadlock happens.
We also print possible mutex holder in sched_dumpstack.

## Impact
mutex_t and related code.

## Testing
Tested on ESP32C3
