### PR TITLE
split sched_node_* functions

### DIFF
--- a/drivers/note/Make.defs
+++ b/drivers/note/Make.defs
@@ -34,5 +34,7 @@ ifeq ($(CONFIG_DRIVER_NOTECTL),y)
   CSRCS += notectl_driver.c
 endif
 
+CFLAGS += ${INCDIR_PREFIX}$(TOPDIR)$(DELIM)sched
+
 DEPPATH += --dep-path note
 VPATH += :note

--- a/sched/sched/sched_note.c
+++ b/sched/sched/sched_note.c
@@ -410,11 +410,6 @@ static void note_spincommon(FAR struct tcb_s *tcb,
 {
   struct note_spinlock_s note;
 
-  if (!note_isenabled())
-    {
-      return;
-    }
-
   /* Format the note */
 
   note_common(tcb, &note.nsp_cmn, sizeof(struct note_spinlock_s), type);
@@ -429,11 +424,7 @@ static void note_spincommon(FAR struct tcb_s *tcb,
 #endif
 
 /****************************************************************************
- * Public Functions
- ****************************************************************************/
-
-/****************************************************************************
- * Name: sched_note_*
+ * Name: sched_ramnote_*
  *
  * Description:
  *   These are the hooks into the scheduling instrumentation logic.  Each
@@ -451,18 +442,13 @@ static void note_spincommon(FAR struct tcb_s *tcb,
  *
  ****************************************************************************/
 
-void sched_note_start(FAR struct tcb_s *tcb)
+static void sched_ramnote_start(FAR struct tcb_s *tcb)
 {
   struct note_startalloc_s note;
   unsigned int length;
 #if CONFIG_TASK_NAME_SIZE > 0
   int namelen;
 #endif
-
-  if (!note_isenabled())
-    {
-      return;
-    }
 
   /* Copy the task name (if possible) and get the length of the note */
 
@@ -486,14 +472,9 @@ void sched_note_start(FAR struct tcb_s *tcb)
   sched_note_add(&note, length);
 }
 
-void sched_note_stop(FAR struct tcb_s *tcb)
+static void sched_ramnote_stop(FAR struct tcb_s *tcb)
 {
   struct note_stop_s note;
-
-  if (!note_isenabled())
-    {
-      return;
-    }
 
   /* Format the note */
 
@@ -505,14 +486,9 @@ void sched_note_stop(FAR struct tcb_s *tcb)
 }
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_SWITCH
-void sched_note_suspend(FAR struct tcb_s *tcb)
+static void sched_ramnote_suspend(FAR struct tcb_s *tcb)
 {
   struct note_suspend_s note;
-
-  if (!note_isenabled_switch())
-    {
-      return;
-    }
 
   /* Format the note */
 
@@ -525,14 +501,9 @@ void sched_note_suspend(FAR struct tcb_s *tcb)
   sched_note_add(&note, sizeof(struct note_suspend_s));
 }
 
-void sched_note_resume(FAR struct tcb_s *tcb)
+static void sched_ramnote_resume(FAR struct tcb_s *tcb)
 {
   struct note_resume_s note;
-
-  if (!note_isenabled_switch())
-    {
-      return;
-    }
 
   /* Format the note */
 
@@ -545,14 +516,9 @@ void sched_note_resume(FAR struct tcb_s *tcb)
 #endif
 
 #ifdef CONFIG_SMP
-void sched_note_cpu_start(FAR struct tcb_s *tcb, int cpu)
+static void sched_ramnote_cpu_start(FAR struct tcb_s *tcb, int cpu)
 {
   struct note_cpu_start_s note;
-
-  if (!note_isenabled())
-    {
-      return;
-    }
 
   /* Format the note */
 
@@ -565,14 +531,9 @@ void sched_note_cpu_start(FAR struct tcb_s *tcb, int cpu)
   sched_note_add(&note, sizeof(struct note_cpu_start_s));
 }
 
-void sched_note_cpu_started(FAR struct tcb_s *tcb)
+static void sched_ramnote_cpu_started(FAR struct tcb_s *tcb)
 {
   struct note_cpu_started_s note;
-
-  if (!note_isenabled())
-    {
-      return;
-    }
 
   /* Format the note */
 
@@ -585,14 +546,9 @@ void sched_note_cpu_started(FAR struct tcb_s *tcb)
 }
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_SWITCH
-void sched_note_cpu_pause(FAR struct tcb_s *tcb, int cpu)
+static void sched_ramnote_cpu_pause(FAR struct tcb_s *tcb, int cpu)
 {
   struct note_cpu_pause_s note;
-
-  if (!note_isenabled_switch())
-    {
-      return;
-    }
 
   /* Format the note */
 
@@ -605,14 +561,9 @@ void sched_note_cpu_pause(FAR struct tcb_s *tcb, int cpu)
   sched_note_add(&note, sizeof(struct note_cpu_pause_s));
 }
 
-void sched_note_cpu_paused(FAR struct tcb_s *tcb)
+static void sched_ramnote_cpu_paused(FAR struct tcb_s *tcb)
 {
   struct note_cpu_paused_s note;
-
-  if (!note_isenabled_switch())
-    {
-      return;
-    }
 
   /* Format the note */
 
@@ -624,14 +575,9 @@ void sched_note_cpu_paused(FAR struct tcb_s *tcb)
   sched_note_add(&note, sizeof(struct note_cpu_paused_s));
 }
 
-void sched_note_cpu_resume(FAR struct tcb_s *tcb, int cpu)
+static void sched_ramnote_cpu_resume(FAR struct tcb_s *tcb, int cpu)
 {
   struct note_cpu_resume_s note;
-
-  if (!note_isenabled_switch())
-    {
-      return;
-    }
 
   /* Format the note */
 
@@ -644,14 +590,9 @@ void sched_note_cpu_resume(FAR struct tcb_s *tcb, int cpu)
   sched_note_add(&note, sizeof(struct note_cpu_resume_s));
 }
 
-void sched_note_cpu_resumed(FAR struct tcb_s *tcb)
+static void sched_ramnote_cpu_resumed(FAR struct tcb_s *tcb)
 {
   struct note_cpu_resumed_s note;
-
-  if (!note_isenabled_switch())
-    {
-      return;
-    }
 
   /* Format the note */
 
@@ -666,14 +607,9 @@ void sched_note_cpu_resumed(FAR struct tcb_s *tcb)
 #endif
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_PREEMPTION
-void sched_note_premption(FAR struct tcb_s *tcb, bool locked)
+static void sched_ramnote_premption(FAR struct tcb_s *tcb, bool locked)
 {
   struct note_preempt_s note;
-
-  if (!note_isenabled())
-    {
-      return;
-    }
 
   /* Format the note */
 
@@ -689,14 +625,9 @@ void sched_note_premption(FAR struct tcb_s *tcb, bool locked)
 #endif
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_CSECTION
-void sched_note_csection(FAR struct tcb_s *tcb, bool enter)
+static void sched_ramnote_csection(FAR struct tcb_s *tcb, bool enter)
 {
   struct note_csection_s note;
-
-  if (!note_isenabled())
-    {
-      return;
-    }
 
   /* Format the note */
 
@@ -713,51 +644,40 @@ void sched_note_csection(FAR struct tcb_s *tcb, bool enter)
 #endif
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_SPINLOCKS
-void sched_note_spinlock(FAR struct tcb_s *tcb, FAR volatile void *spinlock)
+void sched_ramnote_spinlock(FAR struct tcb_s *tcb,
+                            FAR volatile void *spinlock)
 {
   note_spincommon(tcb, spinlock, NOTE_SPINLOCK_LOCK);
 }
 
-void sched_note_spinlocked(FAR struct tcb_s *tcb,
+void sched_ramnote_spinlocked(FAR struct tcb_s *tcb,
                            FAR volatile void *spinlock)
 {
   note_spincommon(tcb, spinlock, NOTE_SPINLOCK_LOCKED);
 }
 
-void sched_note_spinunlock(FAR struct tcb_s *tcb,
+void sched_ramnote_spinunlock(FAR struct tcb_s *tcb,
                            FAR volatile void *spinlock)
 {
   note_spincommon(tcb, spinlock, NOTE_SPINLOCK_UNLOCK);
 }
 
-void sched_note_spinabort(FAR struct tcb_s *tcb, FAR volatile void *spinlock)
+void sched_ramnote_spinabort(FAR struct tcb_s *tcb,
+                             FAR volatile void *spinlock)
 {
   note_spincommon(tcb, spinlock, NOTE_SPINLOCK_ABORT);
 }
 #endif
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_SYSCALL
-void sched_note_syscall_enter(int nr, int argc, ...)
+static void sched_ramnote_syscall_enter(int nr, int argc, va_list ap)
 {
   struct note_syscall_enter_s note;
   FAR struct tcb_s *tcb = this_task();
   unsigned int length;
   uintptr_t arg;
   uint8_t *args;
-  va_list ap;
   int i;
-
-  if (!note_isenabled_syscall(nr))
-    {
-      return;
-    }
-
-#ifdef CONFIG_SCHED_INSTRUMENTATION_FILTER
-  if (!(g_note_filter.mode.flag & NOTE_FILTER_MODE_FLAG_SYSCALL_ARGS))
-    {
-      argc = 0;
-    }
-#endif
 
   /* Format the note */
 
@@ -787,15 +707,10 @@ void sched_note_syscall_enter(int nr, int argc, ...)
   sched_note_add((FAR const uint8_t *)&note, length);
 }
 
-void sched_note_syscall_leave(int nr, uintptr_t result)
+static void sched_ramnote_syscall_leave(int nr, uintptr_t result)
 {
   struct note_syscall_leave_s note;
   FAR struct tcb_s *tcb = this_task();
-
-  if (!note_isenabled_syscall(nr))
-    {
-      return;
-    }
 
   /* Format the note */
 
@@ -813,15 +728,10 @@ void sched_note_syscall_leave(int nr, uintptr_t result)
 #endif
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_IRQHANDLER
-void sched_note_irqhandler(int irq, FAR void *handler, bool enter)
+static void sched_ramnote_irqhandler(int irq, FAR void *handler, bool enter)
 {
   struct note_irqhandler_s note;
   FAR struct tcb_s *tcb = this_task();
-
-  if (!note_isenabled_irq(irq, enter))
-    {
-      return;
-    }
 
   /* Format the note */
 
@@ -834,6 +744,256 @@ void sched_note_irqhandler(int irq, FAR void *handler, bool enter)
 
   sched_note_add((FAR const uint8_t *)&note,
                  sizeof(struct note_irqhandler_s));
+}
+#endif
+
+#ifdef CONFIG_SCHED_INSTRUMENTATION_DUMP
+static void sched_ramnote_write(FAR void *data, size_t length)
+{
+  sched_note_add(data, length);
+}
+#endif
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: sched_note_*
+ *
+ * Description:
+ *   These are the hooks into the scheduling instrumentation logic.  Each
+ *   simply formats the note associated with the schedule event and adds
+ *   that note to the circular buffer.
+ *
+ * Input Parameters:
+ *   tcb - The TCB of the thread.
+ *
+ * Returned Value:
+ *   None
+ *
+ * Assumptions:
+ *   We are within a critical section.
+ *
+ ****************************************************************************/
+
+void sched_note_start(FAR struct tcb_s *tcb)
+{
+  if (!note_isenabled())
+    {
+      return;
+    }
+
+    sched_ramnote_start(tcb);
+}
+
+void sched_note_stop(FAR struct tcb_s *tcb)
+{
+  if (!note_isenabled())
+    {
+      return;
+    }
+}
+
+#ifdef CONFIG_SCHED_INSTRUMENTATION_SWITCH
+
+void sched_note_suspend(FAR struct tcb_s *tcb)
+{
+  if (!note_isenabled_switch())
+    {
+      return;
+    }
+
+  sched_ramnote_suspend(tcb);
+}
+
+void sched_note_resume(FAR struct tcb_s *tcb)
+{
+  if (!note_isenabled_switch())
+    {
+      return;
+    }
+
+  sched_ramnote_resume(tcb);
+}
+#endif
+
+#ifdef CONFIG_SMP
+void sched_note_cpu_start(FAR struct tcb_s *tcb, int cpu)
+{
+  if (!note_isenabled())
+    {
+      return;
+    }
+
+  sched_ramnote_cpu_start(tcb, cpu);
+}
+
+void sched_note_cpu_started(FAR struct tcb_s *tcb)
+{
+  if (!note_isenabled())
+    {
+      return;
+    }
+
+  sched_ramnote_cpu_started(tcb);
+}
+
+#ifdef CONFIG_SCHED_INSTRUMENTATION_SWITCH
+void sched_note_cpu_pause(FAR struct tcb_s *tcb, int cpu)
+{
+  if (!note_isenabled_switch())
+    {
+      return;
+    }
+
+  sched_ramnote_cpu_pause(tcb, cpu);
+}
+
+void sched_note_cpu_paused(FAR struct tcb_s *tcb)
+{
+  if (!note_isenabled_switch())
+    {
+      return;
+    }
+
+  sched_ramnote_cpu_paused(tcb);
+}
+
+void sched_note_cpu_resume(FAR struct tcb_s *tcb, int cpu)
+{
+  if (!note_isenabled_switch())
+    {
+      return;
+    }
+
+  sched_ramnote_cpu_resume(tcb, cpu);
+}
+
+void sched_note_cpu_resumed(FAR struct tcb_s *tcb)
+{
+  if (!note_isenabled_switch())
+    {
+      return;
+    }
+
+  sched_ramnote_cpu_resumed(tcb);
+}
+#endif
+#endif
+
+#ifdef CONFIG_SCHED_INSTRUMENTATION_PREEMPTION
+void sched_note_premption(FAR struct tcb_s *tcb, bool locked)
+{
+  if (!note_isenabled())
+    {
+      return;
+    }
+
+  sched_ramnote_premption(tcb, locked);
+}
+#endif
+
+#ifdef CONFIG_SCHED_INSTRUMENTATION_CSECTION
+void sched_note_csection(FAR struct tcb_s *tcb, bool enter)
+{
+  struct note_csection_s note;
+
+  if (!note_isenabled())
+    {
+      return;
+    }
+
+  sched_ramnote_csection(tcb, enter);
+}
+#endif
+
+#ifdef CONFIG_SCHED_INSTRUMENTATION_SPINLOCKS
+void sched_note_spinlock(FAR struct tcb_s *tcb, FAR volatile void *spinlock)
+{
+  if (!note_isenabled())
+    {
+      return;
+    }
+
+  sched_ramnote_spinlock(tcb, spinlock);
+}
+
+void sched_note_spinlocked(FAR struct tcb_s *tcb,
+                           FAR volatile void *spinlock)
+{
+  if (!note_isenabled())
+    {
+      return;
+    }
+
+  sched_ramnote_spinlocked(tcb, spinlock);
+}
+
+void sched_note_spinunlock(FAR struct tcb_s *tcb,
+                           FAR volatile void *spinlock)
+{
+  if (!note_isenabled())
+    {
+      return;
+    }
+
+  sched_ramnote_spinunlock(tcb, spinlock);
+}
+
+void sched_note_spinabort(FAR struct tcb_s *tcb, FAR volatile void *spinlock)
+{
+  if (!note_isenabled())
+    {
+      return;
+    }
+
+  sched_ramnote_spinabort(tcb, spinlock);
+}
+#endif
+
+#ifdef CONFIG_SCHED_INSTRUMENTATION_SYSCALL
+void sched_note_syscall_enter(int nr, int argc, ...)
+{
+  va_list ap;
+
+  if (!note_isenabled_syscall(nr))
+    {
+      return;
+    }
+
+#ifdef CONFIG_SCHED_INSTRUMENTATION_FILTER
+  if (!(g_note_filter.mode.flag & NOTE_FILTER_MODE_FLAG_SYSCALL_ARGS))
+    {
+      argc = 0;
+    }
+#endif
+
+  va_start(ap, argc);
+  sched_ramnote_syscall_enter(nr, argc, ap);
+  va_end(ap);
+}
+
+void sched_note_syscall_leave(int nr, uintptr_t result)
+{
+  if (!note_isenabled_syscall(nr))
+    {
+      return;
+    }
+
+  sched_ramnote_syscall_leave(nr, result);
+}
+#endif
+
+#ifdef CONFIG_SCHED_INSTRUMENTATION_IRQHANDLER
+void sched_note_irqhandler(int irq, FAR void *handler, bool enter)
+{
+  if (!note_isenabled_irq(irq, enter))
+    {
+      return;
+    }
+
+  sched_ramnote_irqhandler(irq, handler, enter);
 }
 #endif
 
@@ -868,11 +1028,11 @@ void sched_note_string(uintptr_t ip, FAR const char *buf)
 
   /* Add the note to circular buffer */
 
-  sched_note_add(note, length);
+  sched_ramnote_write(note, length);
 }
 
 void sched_note_dump(uintptr_t ip, uint8_t event,
-                     FAR const void *buf, size_t len)
+                                 FAR const void *buf, size_t len)
 {
   FAR struct note_binary_s *note;
   char data[255];
@@ -902,7 +1062,7 @@ void sched_note_dump(uintptr_t ip, uint8_t event,
 
   /* Add the note to circular buffer */
 
-  sched_note_add(note, length);
+  sched_ramnote_write(note, length);
 }
 
 void sched_note_vprintf(uintptr_t ip,
@@ -938,7 +1098,7 @@ void sched_note_vprintf(uintptr_t ip,
 
   /* Add the note to circular buffer */
 
-  sched_note_add(note, length);
+  sched_ramnote_write(note, length);
 }
 
 void sched_note_vbprintf(uintptr_t ip, uint8_t event,
@@ -1140,7 +1300,7 @@ void sched_note_vbprintf(uintptr_t ip, uint8_t event,
 
   /* Add the note to circular buffer */
 
-  sched_note_add(note, length);
+  sched_ramnote_write(note, length);
 }
 
 void sched_note_printf(uintptr_t ip,

--- a/sched/sched/sched_note.c
+++ b/sched/sched/sched_note.c
@@ -57,20 +57,6 @@ struct note_filter_s
 };
 #endif
 
-struct note_startalloc_s
-{
-  struct note_common_s nsa_cmn; /* Common note parameters */
-#if CONFIG_TASK_NAME_SIZE > 0
-  char nsa_name[CONFIG_TASK_NAME_SIZE + 1];
-#endif
-};
-
-#if CONFIG_TASK_NAME_SIZE > 0
-#  define SIZEOF_NOTE_START(n) (sizeof(struct note_start_s) + (n) - 1)
-#else
-#  define SIZEOF_NOTE_START(n) (sizeof(struct note_start_s))
-#endif
-
 /****************************************************************************
  * Private Data
  ****************************************************************************/
@@ -94,77 +80,6 @@ static unsigned int g_note_disabled_irq_nest[CONFIG_SMP_NCPUS];
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
-
-/****************************************************************************
- * Name: sched_note_flatten
- *
- * Description:
- *   Copy the data in the little endian layout
- *
- ****************************************************************************/
-
-static inline void sched_note_flatten(FAR uint8_t *dst,
-                                      FAR void *src, size_t len)
-{
-#ifdef CONFIG_ENDIAN_BIG
-  FAR uint8_t *end = (FAR uint8_t *)src + len - 1;
-  while (len-- > 0)
-    {
-      *dst++ = *end--;
-    }
-#else
-  memcpy(dst, src, len);
-#endif
-}
-
-/****************************************************************************
- * Name: note_common
- *
- * Description:
- *   Fill in some of the common fields in the note structure.
- *
- * Input Parameters:
- *   tcb    - The TCB containing the information
- *   note   - The common note structure to use
- *   length - The total lengthof the note structure
- *   type   - The type of the note
- *
- * Returned Value:
- *   None
- *
- ****************************************************************************/
-
-static void note_common(FAR struct tcb_s *tcb,
-                        FAR struct note_common_s *note,
-                        uint8_t length, uint8_t type)
-{
-#ifdef CONFIG_SCHED_INSTRUMENTATION_HIRES
-  struct timespec ts;
-
-  clock_systime_timespec(&ts);
-#else
-  clock_t systime = clock_systime_ticks();
-#endif
-
-  /* Save all of the common fields */
-
-  note->nc_length   = length;
-  note->nc_type     = type;
-  note->nc_priority = tcb->sched_priority;
-#ifdef CONFIG_SMP
-  note->nc_cpu      = tcb->cpu;
-#endif
-  sched_note_flatten(note->nc_pid, &tcb->pid, sizeof(tcb->pid));
-
-#ifdef CONFIG_SCHED_INSTRUMENTATION_HIRES
-  sched_note_flatten(note->nc_systime_nsec, &ts.tv_nsec, sizeof(ts.tv_nsec));
-  sched_note_flatten(note->nc_systime_sec, &ts.tv_sec, sizeof(ts.tv_sec));
-#else
-  /* Save the LS 32-bits of the system timer in little endian order */
-
-  sched_note_flatten(note->nc_systime, &systime, sizeof(systime));
-#endif
-}
 
 /****************************************************************************
  * Name: note_isenabled
@@ -389,374 +304,79 @@ static inline int note_isenabled_dump(void)
 #endif
 
 /****************************************************************************
- * Name: note_spincommon
- *
- * Description:
- *   Common logic for NOTE_SPINLOCK, NOTE_SPINLOCKED, and NOTE_SPINUNLOCK
- *
- * Input Parameters:
- *   tcb  - The TCB containing the information
- *   note - The common note structure to use
- *
- * Returned Value:
- *   None
- *
- ****************************************************************************/
-
-#ifdef CONFIG_SCHED_INSTRUMENTATION_SPINLOCKS
-static void note_spincommon(FAR struct tcb_s *tcb,
-                            FAR volatile spinlock_t *spinlock,
-                            int type)
-{
-  struct note_spinlock_s note;
-
-  /* Format the note */
-
-  note_common(tcb, &note.nsp_cmn, sizeof(struct note_spinlock_s), type);
-
-  sched_note_flatten(note.nsp_spinlock, &spinlock, sizeof(spinlock));
-  note.nsp_value = *(uint8_t *)spinlock;
-
-  /* Add the note to circular buffer */
-
-  sched_note_add(&note, sizeof(struct note_spinlock_s));
-}
-#endif
-
-/****************************************************************************
- * Name: sched_ramnote_*
- *
- * Description:
- *   These are the hooks into the scheduling instrumentation logic.  Each
- *   simply formats the note associated with the schedule event and adds
- *   that note to the circular buffer.
- *
- * Input Parameters:
- *   tcb - The TCB of the thread.
- *
- * Returned Value:
- *   None
- *
- * Assumptions:
- *   We are within a critical section.
- *
- ****************************************************************************/
-
-static void sched_ramnote_start(FAR struct tcb_s *tcb)
-{
-  struct note_startalloc_s note;
-  unsigned int length;
-#if CONFIG_TASK_NAME_SIZE > 0
-  int namelen;
-#endif
-
-  /* Copy the task name (if possible) and get the length of the note */
-
-#if CONFIG_TASK_NAME_SIZE > 0
-  namelen = strlen(tcb->name);
-
-  DEBUGASSERT(namelen <= CONFIG_TASK_NAME_SIZE);
-  strlcpy(note.nsa_name, tcb->name, sizeof(note.nsa_name));
-
-  length = SIZEOF_NOTE_START(namelen + 1);
-#else
-  length = SIZEOF_NOTE_START(0);
-#endif
-
-  /* Finish formatting the note */
-
-  note_common(tcb, &note.nsa_cmn, length, NOTE_START);
-
-  /* Add the note to circular buffer */
-
-  sched_note_add(&note, length);
-}
-
-static void sched_ramnote_stop(FAR struct tcb_s *tcb)
-{
-  struct note_stop_s note;
-
-  /* Format the note */
-
-  note_common(tcb, &note.nsp_cmn, sizeof(struct note_stop_s), NOTE_STOP);
-
-  /* Add the note to circular buffer */
-
-  sched_note_add(&note, sizeof(struct note_stop_s));
-}
-
-#ifdef CONFIG_SCHED_INSTRUMENTATION_SWITCH
-static void sched_ramnote_suspend(FAR struct tcb_s *tcb)
-{
-  struct note_suspend_s note;
-
-  /* Format the note */
-
-  note_common(tcb, &note.nsu_cmn, sizeof(struct note_suspend_s),
-              NOTE_SUSPEND);
-  note.nsu_state           = tcb->task_state;
-
-  /* Add the note to circular buffer */
-
-  sched_note_add(&note, sizeof(struct note_suspend_s));
-}
-
-static void sched_ramnote_resume(FAR struct tcb_s *tcb)
-{
-  struct note_resume_s note;
-
-  /* Format the note */
-
-  note_common(tcb, &note.nre_cmn, sizeof(struct note_resume_s), NOTE_RESUME);
-
-  /* Add the note to circular buffer */
-
-  sched_note_add(&note, sizeof(struct note_resume_s));
-}
-#endif
-
-#ifdef CONFIG_SMP
-static void sched_ramnote_cpu_start(FAR struct tcb_s *tcb, int cpu)
-{
-  struct note_cpu_start_s note;
-
-  /* Format the note */
-
-  note_common(tcb, &note.ncs_cmn, sizeof(struct note_cpu_start_s),
-              NOTE_CPU_START);
-  note.ncs_target = (uint8_t)cpu;
-
-  /* Add the note to circular buffer */
-
-  sched_note_add(&note, sizeof(struct note_cpu_start_s));
-}
-
-static void sched_ramnote_cpu_started(FAR struct tcb_s *tcb)
-{
-  struct note_cpu_started_s note;
-
-  /* Format the note */
-
-  note_common(tcb, &note.ncs_cmn, sizeof(struct note_cpu_started_s),
-              NOTE_CPU_STARTED);
-
-  /* Add the note to circular buffer */
-
-  sched_note_add(&note, sizeof(struct note_cpu_started_s));
-}
-
-#ifdef CONFIG_SCHED_INSTRUMENTATION_SWITCH
-static void sched_ramnote_cpu_pause(FAR struct tcb_s *tcb, int cpu)
-{
-  struct note_cpu_pause_s note;
-
-  /* Format the note */
-
-  note_common(tcb, &note.ncp_cmn, sizeof(struct note_cpu_pause_s),
-              NOTE_CPU_PAUSE);
-  note.ncp_target = (uint8_t)cpu;
-
-  /* Add the note to circular buffer */
-
-  sched_note_add(&note, sizeof(struct note_cpu_pause_s));
-}
-
-static void sched_ramnote_cpu_paused(FAR struct tcb_s *tcb)
-{
-  struct note_cpu_paused_s note;
-
-  /* Format the note */
-
-  note_common(tcb, &note.ncp_cmn, sizeof(struct note_cpu_paused_s),
-              NOTE_CPU_PAUSED);
-
-  /* Add the note to circular buffer */
-
-  sched_note_add(&note, sizeof(struct note_cpu_paused_s));
-}
-
-static void sched_ramnote_cpu_resume(FAR struct tcb_s *tcb, int cpu)
-{
-  struct note_cpu_resume_s note;
-
-  /* Format the note */
-
-  note_common(tcb, &note.ncr_cmn, sizeof(struct note_cpu_resume_s),
-              NOTE_CPU_RESUME);
-  note.ncr_target = (uint8_t)cpu;
-
-  /* Add the note to circular buffer */
-
-  sched_note_add(&note, sizeof(struct note_cpu_resume_s));
-}
-
-static void sched_ramnote_cpu_resumed(FAR struct tcb_s *tcb)
-{
-  struct note_cpu_resumed_s note;
-
-  /* Format the note */
-
-  note_common(tcb, &note.ncr_cmn, sizeof(struct note_cpu_resumed_s),
-              NOTE_CPU_RESUMED);
-
-  /* Add the note to circular buffer */
-
-  sched_note_add(&note, sizeof(struct note_cpu_resumed_s));
-}
-#endif
-#endif
-
-#ifdef CONFIG_SCHED_INSTRUMENTATION_PREEMPTION
-static void sched_ramnote_premption(FAR struct tcb_s *tcb, bool locked)
-{
-  struct note_preempt_s note;
-
-  /* Format the note */
-
-  note_common(tcb, &note.npr_cmn, sizeof(struct note_preempt_s),
-              locked ? NOTE_PREEMPT_LOCK : NOTE_PREEMPT_UNLOCK);
-  sched_note_flatten(note.npr_count,
-                     &tcb->lockcount, sizeof(tcb->lockcount));
-
-  /* Add the note to circular buffer */
-
-  sched_note_add(&note, sizeof(struct note_preempt_s));
-}
-#endif
-
-#ifdef CONFIG_SCHED_INSTRUMENTATION_CSECTION
-static void sched_ramnote_csection(FAR struct tcb_s *tcb, bool enter)
-{
-  struct note_csection_s note;
-
-  /* Format the note */
-
-  note_common(tcb, &note.ncs_cmn, sizeof(struct note_csection_s),
-              enter ? NOTE_CSECTION_ENTER : NOTE_CSECTION_LEAVE);
-#ifdef CONFIG_SMP
-  sched_note_flatten(note.ncs_count, &tcb->irqcount, sizeof(tcb->irqcount));
-#endif
-
-  /* Add the note to circular buffer */
-
-  sched_note_add(&note, sizeof(struct note_csection_s));
-}
-#endif
-
-#ifdef CONFIG_SCHED_INSTRUMENTATION_SPINLOCKS
-void sched_ramnote_spinlock(FAR struct tcb_s *tcb,
-                            FAR volatile void *spinlock)
-{
-  note_spincommon(tcb, spinlock, NOTE_SPINLOCK_LOCK);
-}
-
-void sched_ramnote_spinlocked(FAR struct tcb_s *tcb,
-                           FAR volatile void *spinlock)
-{
-  note_spincommon(tcb, spinlock, NOTE_SPINLOCK_LOCKED);
-}
-
-void sched_ramnote_spinunlock(FAR struct tcb_s *tcb,
-                           FAR volatile void *spinlock)
-{
-  note_spincommon(tcb, spinlock, NOTE_SPINLOCK_UNLOCK);
-}
-
-void sched_ramnote_spinabort(FAR struct tcb_s *tcb,
-                             FAR volatile void *spinlock)
-{
-  note_spincommon(tcb, spinlock, NOTE_SPINLOCK_ABORT);
-}
-#endif
-
-#ifdef CONFIG_SCHED_INSTRUMENTATION_SYSCALL
-static void sched_ramnote_syscall_enter(int nr, int argc, va_list ap)
-{
-  struct note_syscall_enter_s note;
-  FAR struct tcb_s *tcb = this_task();
-  unsigned int length;
-  uintptr_t arg;
-  uint8_t *args;
-  int i;
-
-  /* Format the note */
-
-  length = SIZEOF_NOTE_SYSCALL_ENTER(argc);
-  note_common(tcb, &note.nsc_cmn, length, NOTE_SYSCALL_ENTER);
-  DEBUGASSERT(nr <= UCHAR_MAX);
-  note.nsc_nr = nr;
-  DEBUGASSERT(argc <= MAX_SYSCALL_ARGS);
-  note.nsc_argc = argc;
-
-  /* If needed, retrieve the given syscall arguments */
-
-  va_start(ap, argc);
-
-  args = note.nsc_args;
-  for (i = 0; i < argc; i++)
-    {
-      arg = (uintptr_t)va_arg(ap, uintptr_t);
-      sched_note_flatten(args, &arg, sizeof(arg));
-      args += sizeof(uintptr_t);
-    }
-
-  va_end(ap);
-
-  /* Add the note to circular buffer */
-
-  sched_note_add((FAR const uint8_t *)&note, length);
-}
-
-static void sched_ramnote_syscall_leave(int nr, uintptr_t result)
-{
-  struct note_syscall_leave_s note;
-  FAR struct tcb_s *tcb = this_task();
-
-  /* Format the note */
-
-  note_common(tcb, &note.nsc_cmn, sizeof(struct note_syscall_leave_s),
-              NOTE_SYSCALL_LEAVE);
-  DEBUGASSERT(nr <= UCHAR_MAX);
-  note.nsc_nr = nr;
-
-  sched_note_flatten(note.nsc_result, &result, sizeof(result));
-
-  /* Add the note to circular buffer */
-
-  sched_note_add(&note, sizeof(struct note_syscall_leave_s));
-}
-#endif
-
-#ifdef CONFIG_SCHED_INSTRUMENTATION_IRQHANDLER
-static void sched_ramnote_irqhandler(int irq, FAR void *handler, bool enter)
-{
-  struct note_irqhandler_s note;
-  FAR struct tcb_s *tcb = this_task();
-
-  /* Format the note */
-
-  note_common(tcb, &note.nih_cmn, sizeof(struct note_irqhandler_s),
-              enter ? NOTE_IRQ_ENTER : NOTE_IRQ_LEAVE);
-  DEBUGASSERT(irq <= UCHAR_MAX);
-  note.nih_irq = irq;
-
-  /* Add the note to circular buffer */
-
-  sched_note_add((FAR const uint8_t *)&note,
-                 sizeof(struct note_irqhandler_s));
-}
-#endif
-
-#ifdef CONFIG_SCHED_INSTRUMENTATION_DUMP
-static void sched_ramnote_write(FAR void *data, size_t length)
-{
-  sched_note_add(data, length);
-}
-#endif
-
-/****************************************************************************
  * Public Functions
  ****************************************************************************/
+
+/****************************************************************************
+ * Name: note_common
+ *
+ * Description:
+ *   Fill in some of the common fields in the note structure.
+ *
+ * Input Parameters:
+ *   tcb    - The TCB containing the information
+ *   note   - The common note structure to use
+ *   length - The total lengthof the note structure
+ *   type   - The type of the note
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void note_common(FAR struct tcb_s *tcb,
+                FAR struct note_common_s *note,
+                uint8_t length, uint8_t type)
+{
+#ifdef CONFIG_SCHED_INSTRUMENTATION_HIRES
+  struct timespec ts;
+
+  clock_systime_timespec(&ts);
+#else
+  clock_t systime = clock_systime_ticks();
+#endif
+
+  /* Save all of the common fields */
+
+  note->nc_length   = length;
+  note->nc_type     = type;
+  note->nc_priority = tcb->sched_priority;
+#ifdef CONFIG_SMP
+  note->nc_cpu      = tcb->cpu;
+#endif
+  sched_note_flatten(note->nc_pid, &tcb->pid, sizeof(tcb->pid));
+
+#ifdef CONFIG_SCHED_INSTRUMENTATION_HIRES
+  sched_note_flatten(note->nc_systime_nsec, &ts.tv_nsec, sizeof(ts.tv_nsec));
+  sched_note_flatten(note->nc_systime_sec, &ts.tv_sec, sizeof(ts.tv_sec));
+#else
+  /* Save the LS 32-bits of the system timer in little endian order */
+
+  sched_note_flatten(note->nc_systime, &systime, sizeof(systime));
+#endif
+}
+
+/****************************************************************************
+ * Name: sched_note_flatten
+ *
+ * Description:
+ *   Copy the data in the little endian layout
+ *
+ ****************************************************************************/
+
+void sched_note_flatten(FAR uint8_t *dst,
+                        FAR void *src, size_t len)
+{
+#ifdef CONFIG_ENDIAN_BIG
+  FAR uint8_t *end = (FAR uint8_t *)src + len - 1;
+  while (len-- > 0)
+    {
+      *dst++ = *end--;
+    }
+#else
+  memcpy(dst, src, len);
+#endif
+}
 
 /****************************************************************************
  * Name: sched_note_*


### PR DESCRIPTION
## Summary
Split the sched_node_* functions into two parts
and moved from sched_note.c to noteram_driver.c

This will be used to support sched_note multi-channel output
## Impact
modified the visibility of some functions
```
note_common :         private -> public
sched_note_flatten   private ->  public
sched_note_add       public ->   private
```
## Testing

