### PR TITLE
Add iptlite packet filter modules

### DIFF
--- a/net/devif/Make.defs
+++ b/net/devif/Make.defs
@@ -55,6 +55,12 @@ ifeq ($(CONFIG_NET_CAN),y)
 NET_CSRCS += devif_cansend.c
 endif
 
+# iptlite packet filter support
+
+ifeq ($(CONFIG_NETUTILS_IPTLITE),y)
+NET_CSRCS += devif_pktfilter.c
+endif
+
 # Include network device interface build support
 
 DEPPATH += --dep-path devif

--- a/net/devif/devif.h
+++ b/net/devif/devif.h
@@ -284,6 +284,21 @@ extern "C"
  * Public Function Prototypes
  ****************************************************************************/
 
+#ifdef CONFIG_NETUTILS_IPTLITE
+#define RULE_INFO_MAX_SIZE 100
+#define RULE_MAX_SIZE 10
+#define PORTSTRLEN 6
+
+void nflite_initialize(void);
+bool nflite_addrule(int rule,
+in_addr_t srcipaddr, in_addr_t destipaddr, \
+in_port_t srcport, in_port_t destport);
+bool nflite_verify_ipv4(FAR struct net_driver_s *dev);
+void nflite_flushall(void);
+char** nflite_listall(void);
+int nflite_get_rules_counter(void);
+#endif
+
 /****************************************************************************
  * Name: devif_initialize
  *

--- a/net/devif/devif_pktfilter.c
+++ b/net/devif/devif_pktfilter.c
@@ -1,0 +1,195 @@
+/****************************************************************************
+ * net/devif/devif_pktfilter.c
+ * iptlite packet filter modules
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <netinet/in.h>
+#include <nuttx/net/ip.h>
+#include <nuttx/net/tcp.h>
+#include <nuttx/net/netconfig.h>
+#include <nuttx/net/netdev.h>
+#include "devif.h"
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+typedef enum rules
+{
+  DROP,
+  FLUSHALL,
+  LISTALL
+} rules;
+
+typedef struct chain chain;
+
+struct chain
+{
+  rules rule;
+  in_addr_t srcipaddr;
+  in_addr_t destipaddr;
+  in_port_t srcport;
+  in_port_t destport;
+  chain *next;
+};
+
+chain *chain_head;
+chain *last_rule;
+int rules_counter;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+char *get_rule_name(rules rule)
+{
+  switch (rule)
+  {
+  case DROP:
+    return "DROP";
+  case FLUSHALL:
+    return "FLUSHALL";
+  case LISTALL:
+    return "LISTALL";
+  }
+
+  return "UNDEFINED";
+}
+
+void get_rule_info(chain *node, char **table, int idx)
+{
+  char srcipaddr[INET_ADDRSTRLEN];
+  char destipaddr[INET_ADDRSTRLEN];
+  inet_ntop(AF_INET, &node->srcipaddr, srcipaddr, INET_ADDRSTRLEN);
+  inet_ntop(AF_INET, &node->destipaddr, destipaddr, INET_ADDRSTRLEN);
+
+  int srcport = ntohs(node->srcport);
+  int destport = ntohs(node->destport);
+
+  char rule[RULE_MAX_SIZE];
+  strcpy(rule, get_rule_name(node->rule));
+
+  char rule_info[RULE_INFO_MAX_SIZE];
+  sprintf(rule_info, "%2d: %10s %16s %16s %9d %9d",
+          idx, rule, srcipaddr, destipaddr, srcport, destport);
+
+  strcpy(table[idx], rule_info);
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void nflite_initialize(void)
+{
+  chain_head = (chain *)malloc(sizeof(chain));
+  chain_head->next = NULL;
+  rules_counter = 0;
+
+  last_rule = chain_head;
+}
+
+bool nflite_addrule(int rule, in_addr_t srcipaddr, in_addr_t destipaddr,
+                    in_port_t srcport, in_port_t destport)
+{
+  chain *new_chainrule = (chain *)malloc(sizeof(chain));
+  if (new_chainrule == NULL) return false;
+
+  new_chainrule->rule = rule;
+  new_chainrule->srcipaddr = srcipaddr;
+  new_chainrule->destipaddr = destipaddr;
+  new_chainrule->srcport = srcport;
+  new_chainrule->destport = destport;
+  new_chainrule->next = NULL;
+
+  last_rule->next = new_chainrule;
+  last_rule = last_rule->next;
+  rules_counter++;
+
+  return true;
+}
+
+bool nflite_verify_ipv4(FAR struct net_driver_s *dev)
+{
+  FAR struct ipv4_hdr_s *ipv4;
+  FAR struct tcp_hdr_s *tcp;
+  in_addr_t destipaddr;
+  in_addr_t srcipaddr;
+  in_port_t srcport;
+  in_port_t destport;
+  uint16_t iphdrlen;
+
+  ipv4 = ((FAR struct ipv4_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)]);
+  iphdrlen = (ipv4->vhl & IPv4_HLMASK) << 2;
+  tcp = (FAR struct tcp_hdr_s *)&dev->d_buf[iphdrlen + NET_LL_HDRLEN(dev)];
+
+  destipaddr = net_ip4addr_conv32(ipv4->destipaddr);
+  srcipaddr = net_ip4addr_conv32(ipv4->srcipaddr);
+  srcport = tcp->srcport;
+  destport = tcp->destport;
+
+  chain *current_rule = chain_head->next;
+  while (current_rule)
+    {
+      /* Verify incoming tuple */
+
+      if ((current_rule->destipaddr == 0 \
+      || current_rule->destipaddr == destipaddr) \
+      && (current_rule->srcipaddr == 0 \
+      || current_rule->srcipaddr == srcipaddr) \
+      && (current_rule->destport == 0 \
+      || current_rule->destport == destport) \
+      && (current_rule->srcport == 0 \
+      || current_rule->srcport == srcport)) return false;
+
+      current_rule = current_rule->next;
+    }
+
+  return true;
+}
+
+void nflite_flushall(void)
+{
+  chain *current_rule = chain_head->next;
+  chain *head = chain_head->next;
+  while (head != NULL)
+    {
+      current_rule = head;
+      head = head->next;
+      free(current_rule);
+    }
+
+  chain_head->next = NULL;
+  rules_counter = 0;
+
+  last_rule = chain_head;
+}
+
+char **nflite_listall(void)
+{
+  chain *head = chain_head->next;
+  char **table = (char **)malloc(rules_counter * sizeof(char *));
+
+  for (int i = 0; i < rules_counter; i++)
+    {
+      table[i] = (char *)malloc(RULE_INFO_MAX_SIZE * sizeof(char));
+    }
+
+  int idx = 0;
+  while (head != NULL)
+    {
+      get_rule_info(head, table, idx);
+      head = head->next;
+      idx++;
+    }
+
+  return table;
+}
+
+int nflite_get_rules_counter(void)
+{
+  return rules_counter;
+}

--- a/net/devif/ipv4_input.c
+++ b/net/devif/ipv4_input.c
@@ -210,6 +210,13 @@ int ipv4_input(FAR struct net_driver_s *dev)
 
   destipaddr = net_ip4addr_conv32(ipv4->destipaddr);
 
+#ifdef CONFIG_NETUTILS_IPTLITE
+  /* Check if packet needs to be dropped */
+
+  bool is_valid_packet = nflite_verify_ipv4(dev);
+  if (!is_valid_packet) goto drop;
+#endif
+
 #if defined(CONFIG_NET_BROADCAST) && defined(NET_UDP_HAVE_STACK)
   /* If IP broadcast support is configured, we check for a broadcast
    * UDP packet, which may be destined to us (even if there is no IP

--- a/net/net_initialize.c
+++ b/net/net_initialize.c
@@ -168,6 +168,12 @@ void net_initialize(void)
 
   usrsock_initialize();
 #endif
+
+#ifdef CONFIG_NETUTILS_IPTLITE
+  /* Initialize the iptlite packet filter modules */
+
+  nflite_initialize();
+#endif
 }
 
 #endif /* CONFIG_NET */


### PR DESCRIPTION
## Summary
This merge request aims to add a lightweight packet filter to NuttX, called iptlite (iptables lite), which was based on Linux firewall, iptables and netfilter. This first implementation was focused on the essential commands, such as adding a drop rule based on the 4-tuple (source IPv4 address, destination IPv4 address, source port and destination port), flush all rules and list all rules, for all ingress TCP packets.

The implementation was divided in two parts: the [iptlite app](https://github.com/apache/incubator-nuttx-apps/pull/1399), the CLI to the user, and the nflite modules (netfilter lite), which will provide the APIs to the iptlite app, that can be seen in another MR on the incubator-nuttx repository.

This project was considered the third-best security tool in the XXII Brazilian Symposium on Information Security and Computer Systems, and the [related paper](https://sol.sbc.org.br/index.php/sbseg_estendido/article/view/21705) was accepted by this conference as well.

## Impact
This lightweight packet filter could be an additional security feature, especially in the IoT environment, allowing the users to adopt, for instance, a zero trust policy, consequently, denying all ingress packet filter, except by the preset ones.

## Testing
In order to give more context about the implementation that it was made, this following link will show a [quick video demo](https://drive.google.com/file/d/18mRSa_Vd_XRkorHnBmdGTAF5x2dykjLR/view) of the project.
