### PR TITLE
cdcacm: send RX flow control only for the first time when limit is crossed

### DIFF
--- a/drivers/usbdev/cdcacm.c
+++ b/drivers/usbdev/cdcacm.c
@@ -548,11 +548,13 @@ static int cdcacm_recvpacket(FAR struct cdcacm_dev_s *priv,
            * been crossed.  It will probably activate RX flow control.
            */
 
-          if (cdcuart_rxflowcontrol(&priv->serdev, nbuffered, true))
-            {
-              /* Low-level driver activated RX flow control, exit loop now. */
+          /* Check if flow control is not already activated */
 
-              break;
+          if (!priv->iactive)
+            {
+              /* Activate RX flow control */
+
+              cdcuart_rxflowcontrol(&priv->serdev, nbuffered, true);
             }
         }
 #endif
@@ -580,7 +582,14 @@ static int cdcacm_recvpacket(FAR struct cdcacm_dev_s *priv,
 
   if (nexthead == recv->tail)
     {
-      cdcuart_rxflowcontrol(&priv->serdev, recv->size - 1, true);
+      /* Check if flow control is not already activated */
+
+      if (!priv->iactive)
+        {
+          /* Activate RX flow control */
+
+          cdcuart_rxflowcontrol(&priv->serdev, recv->size - 1, true);
+        }
     }
 #endif
 


### PR DESCRIPTION
## Summary

Current implementation sends RX flow control activation every time the limit is crossed when receive packet is read by driver. This may result in repetitious sends of RX flow control signal when some packets are left on the bus or in FIFO.

This change ensures RX flow control is send only when it is not active (priv->iactive is false). It also removes break statement from while loop when watermark is used. The driver should activate RX flow and read the rest of the packet instead of discarding it.

I am not entirely sure if this is the correct way to implement this, should be carefully checked before merged (cc to @gregory-nutt who implemented the flow control to CDC ACM).

## Impact
CDC ACM device driver.

## Testing
Tested on SAM E70 based MCU.