### PR TITLE
tools: Fix various error in Windows native build

### DIFF
--- a/libs/libc/Makefile
+++ b/libs/libc/Makefile
@@ -114,8 +114,8 @@ endif
 
 BINDIR ?= bin
 
-AOBJS = $(patsubst %.S, $(BINDIR)$(DELIM)%$(OBJEXT), $(ASRCS))
-COBJS = $(patsubst %.c, $(BINDIR)$(DELIM)%$(OBJEXT), $(CSRCS))
+AOBJS = $(patsubst %.S, $(BINDIR)$(DELIM)$(DELIM)%$(OBJEXT), $(ASRCS))
+COBJS = $(patsubst %.c, $(BINDIR)$(DELIM)$(DELIM)%$(OBJEXT), $(CSRCS))
 
 SRCS = $(ASRCS) $(CSRCS)
 OBJS = $(AOBJS) $(COBJS)
@@ -126,10 +126,12 @@ BIN ?= libc$(LIBEXT)
 all: $(BIN)
 .PHONY: clean distclean
 
-$(AOBJS): $(BINDIR)$(DELIM)%$(OBJEXT): %.S
+$(AOBJS): $(BINDIR)$(DELIM)$(DELIM)%$(OBJEXT): %.S
 	$(call ASSEMBLE, $<, $@)
 
-$(COBJS): $(BINDIR)$(DELIM)%$(OBJEXT): %.c
+# REVISIT: Backslash causes problems in $(COBJS) target
+
+$(COBJS): $(BINDIR)$(DELIM)$(DELIM)%$(OBJEXT): %.c
 	$(call COMPILE, $<, $@)
 
 # C library for the flat build and
@@ -194,9 +196,9 @@ distclean:: clean
 	$(Q) $(MAKE) -C kbin distclean
 	$(Q) $(MAKE) -C zoneinfo distclean BIN=$(BIN)
 	$(call DELFILE, exec_symtab.c)
-	$(call DELFILE, bin/Make.dep)
-	$(call DELFILE, kbin/Make.dep)
+	$(call DELFILE, bin$(DELIM)Make.dep)
+	$(call DELFILE, kbin$(DELIM)Make.dep)
 	$(call DELFILE, .depend)
 
--include bin/Make.dep
--include kbin/Make.dep
+-include bin$(DELIM)Make.dep
+-include kbin$(DELIM)Make.dep

--- a/mm/Makefile
+++ b/mm/Makefile
@@ -37,8 +37,8 @@ BINDIR ?= bin
 
 CFLAGS += ${INCDIR_PREFIX}$(TOPDIR)$(DELIM)mm
 
-AOBJS = $(patsubst %.S, $(BINDIR)$(DELIM)%$(OBJEXT), $(ASRCS))
-COBJS = $(patsubst %.c, $(BINDIR)$(DELIM)%$(OBJEXT), $(CSRCS))
+AOBJS = $(patsubst %.S, $(BINDIR)$(DELIM)$(DELIM)%$(OBJEXT), $(ASRCS))
+COBJS = $(patsubst %.c, $(BINDIR)$(DELIM)$(DELIM)%$(OBJEXT), $(CSRCS))
 
 SRCS = $(ASRCS) $(CSRCS)
 OBJS = $(AOBJS) $(COBJS)
@@ -49,10 +49,12 @@ BIN ?= libmm$(LIBEXT)
 all: $(BIN)
 .PHONY: clean distclean
 
-$(AOBJS): $(BINDIR)$(DELIM)%$(OBJEXT): %.S
+$(AOBJS): $(BINDIR)$(DELIM)$(DELIM)%$(OBJEXT): %.S
 	$(call ASSEMBLE, $<, $@)
 
-$(COBJS): $(BINDIR)$(DELIM)%$(OBJEXT): %.c
+# REVISIT: Backslash causes problems in $(COBJS) target
+
+$(COBJS): $(BINDIR)$(DELIM)$(DELIM)%$(OBJEXT): %.c
 	$(call COMPILE, $<, $@)
 
 # Memory manager for the flat build and
@@ -101,9 +103,9 @@ clean:
 distclean: clean
 	$(Q) $(MAKE) -C bin  distclean
 	$(Q) $(MAKE) -C kbin distclean
-	$(call DELFILE, bin/Make.dep)
-	$(call DELFILE, kbin/Make.dep)
+	$(call DELFILE, bin$(DELIM)Make.dep)
+	$(call DELFILE, kbin$(DELIM)Make.dep)
 	$(call DELFILE, .depend)
 
--include bin/Make.dep
--include kbin/Make.dep
+-include bin$(DELIM)Make.dep
+-include kbin$(DELIM)Make.dep

--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -444,8 +444,12 @@ endef
 # DELFILE - Delete one file
 
 ifeq ($(CONFIG_WINDOWS_NATIVE),y)
+define NEWLINE
+
+
+endef
 define DELFILE
-	$(Q) if exist $1 (del /f /q $1)
+	$(foreach FILE, $(1), $(NEWLINE) $(Q) if exist $(FILE) (del /f /q  $(FILE)))
 endef
 else
 define DELFILE
@@ -457,7 +461,7 @@ endif
 
 ifeq ($(CONFIG_WINDOWS_NATIVE),y)
 define DELDIR
-	$(Q) if exist $1 (rmdir /q /s $1)
+	$(Q) if exist $1 (rmdir /q /s $1) $(NEWLINE)
 endef
 else
 define DELDIR
@@ -495,7 +499,7 @@ endif
 
 ifeq ($(CONFIG_WINDOWS_NATIVE),y)
 define CATFILE
-	$(Q) type $(2) > $1
+	$(foreach FILE, $(2), $(NEWLINE) $(Q) type $(FILE) >> $1)
 endef
 else
 define CATFILE
@@ -523,20 +527,14 @@ ifeq ($(CONFIG_ARCH_COVERAGE),y)
 endif
 
 ifeq ($(CONFIG_WINDOWS_NATIVE),y)
-
-define NEWLINE
-
-
-endef
-
 define CLEAN
 	$(Q) if exist *$(OBJEXT) (del /f /q *$(OBJEXT))
 	$(Q) if exist *$(LIBEXT) (del /f /q *$(LIBEXT))
 	$(Q) if exist *~ (del /f /q *~)
 	$(Q) if exist (del /f /q  .*.swp)
-	$(foreach OBJ, $(OBJS), $(NEWLINE) $(call DELFILE,$(OBJ)))
-	$(Q) if exist $(BIN) (del /f /q  $(BIN))
-	$(Q) if exist $(EXTRA) (del /f /q  $(EXTRA))
+	$(call DELFILE,$(subst /,\,$(OBJS)))
+	$(Q) if exist $(BIN) (del /f /q  $(subst /,\,$(BIN)))
+	$(Q) if exist $(EXTRA) (del /f /q  $(subst /,\,$(EXTRA)))
 endef
 else
 define CLEAN

--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -394,7 +394,6 @@ endef
 # created from scratch
 
 define ARCHIVE
-	@echo "AR (create): ${shell basename $(1)} $(2)"
 	$(Q) $(RM) $1
 	$(Q) $(AR) $1 $(2)
 endef

--- a/tools/Win.mk
+++ b/tools/Win.mk
@@ -557,7 +557,9 @@ clean_bootloader:
 # pass2dep: Create pass2 build dependencies
 
 pass1dep: context tools\mkdeps$(HOSTEXEEXT)
+ifneq ($(USERDEPDIRS),)
 	$(Q) for %%G in ($(USERDEPDIRS)) do ( $(MAKE) -C %%G depend )
+endif
 
 pass2dep: context tools\mkdeps$(HOSTEXEEXT)
 	$(Q) for %%G in ($(KERNDEPDIRS)) do ( $(MAKE) -C %%G EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)" depend )

--- a/tools/Win.mk
+++ b/tools/Win.mk
@@ -446,14 +446,14 @@ clean_context:
 	$(call DELFILE, include\stdarg.h)
 	$(call DELFILE, include\setjmp.h)
 	$(call DELFILE, arch\dummy\Kconfig)
-	$(call DELFILE, $(CONTEXTDIRS_DEPS))
-	$(call DIRUNLINK, include\arch\board)
-	$(call DIRUNLINK, include\arch\chip)
-	$(call DIRUNLINK, include\arch)
-	$(call DIRUNLINK, $(ARCH_SRC)\board\board)
-	$(call DIRUNLINK, $(ARCH_SRC)\board)
-	$(call DIRUNLINK, $(ARCH_SRC)\chip)
-	$(call DIRUNLINK, $(TOPDIR)\drivers\platform)
+	$(call DELFILE, $(subst /,\,$(CONTEXTDIRS_DEPS)))
+	$(Q) $(DIRUNLINK) include\arch\board
+	$(Q) $(DIRUNLINK) include\arch\chip
+	$(Q) $(DIRUNLINK) include\arch
+	$(Q) $(DIRUNLINK) $(ARCH_SRC)\board\board
+	$(Q) $(DIRUNLINK) $(ARCH_SRC)\board
+	$(Q) $(DIRUNLINK) $(ARCH_SRC)\chip
+	$(Q) $(DIRUNLINK) $(TOPDIR)\drivers\platform
 
 # Archive targets.  The target build sequence will first create a series of
 # libraries, one per configured source file directory.  The final NuttX

--- a/tools/Win.mk
+++ b/tools/Win.mk
@@ -424,7 +424,7 @@ context: include\setjmp.h
 endif
 
 staging:
-	$(Q) mkdir -p $@
+	$(Q) mkdir $@
 
 # Pattern rule for $(CONTEXTDIRS_DEPS)
 

--- a/tools/mkdeps.c
+++ b/tools/mkdeps.c
@@ -111,7 +111,9 @@ static char g_expand[MAX_EXPAND];
 static char g_dequoted[MAX_PATH];
 static char g_posixpath[MAX_PATH];
 #endif
+#ifndef CONFIG_WINDOWS_NATIVE
 static char g_shquote[MAX_SHQUOTE];
+#endif
 
 /****************************************************************************
  * Private Functions
@@ -295,7 +297,7 @@ static void show_usage(const char *progname, const char *msg, int exitcode)
  *    https://netbsd.gw.com/cgi-bin/man-cgi?shquote++NetBSD-current
  *    However, this implementation doesn't try to elide extraneous quotes.
  ****************************************************************************/
-
+#ifndef CONFIG_WINDOWS_NATIVE
 static const char *do_shquote(const char *argument)
 {
   const char *src;
@@ -347,6 +349,7 @@ static const char *do_shquote(const char *argument)
   *dest = '\0';
   return g_shquote;
 }
+#endif
 
 static void parse_args(int argc, char **argv)
 {
@@ -443,12 +446,13 @@ static void parse_args(int argc, char **argv)
            * do_dependency() uses them as bare filenames as well.
            * (In addition to passing them to system().)
            */
-
+#ifndef CONFIG_WINDOWS_NATIVE
           if (group == 1)
             {
                arg = do_shquote(arg);
             }
 
+#endif
           append(&args, arg);
         }
     }


### PR DESCRIPTION
## Summary
These patch finally raised NuttX Windows native build!
1. tools/mkdeps:Fix an error caused by do_shquote in Windows native build:
do_shquote in Windows native build will give following error in mkdeps:
`sparc-elf-gcc: '-fno-common': No such file or directory
sparc-elf-gcc: '-Wall': No such file or directory
sparc-elf-gcc: '-Wstrict-prototypes': No such file or directory
sparc-elf-gcc: '-Wshadow': No such file or directory
sparc-elf-gcc: '-Wundef': No such file or directory
sparc-elf-gcc: '-fomit-frame-pointer': No such file or directory
sparc-elf-gcc: '-g': No such file or directory
sparc-elf-gcc: '-mcpu=leon': No such file or directory
sparc-elf-gcc: '-isystem': No such file or directory`
2. tools/Config:Fix some error call DELFILE/DELDIR/CATFILE in Windows native build:
There are so many .ddc in libc that `$(call CATFILE, bin/Make.dep, $^)` give an error: input line is too long in Windows native build. also $(call DELFILE, $^) give same error.
3. libc and mm/Makefile:Fix an error caused by backslash in Windows native build:
There is a comment in the libs/libc/Makefile and mm/Makefile of NuttX 8.2 :
`# REVISIT: Backslash causes problems in $(COBJS) target
DELIM := $(strip /)`  The `DELIM := $(strip /)` was removed thereafter, and resulted an error in $(COBJS) target in Windows native build.
4. tools/Win.mk:Fix some error in clean_context in Windows native build:
Error use of DIRUNLINK result failure in remove `include\arch\board  \include\arch\chip
include\arch    $(ARCH_SRC)\board\board  $(ARCH_SRC)\board  $(ARCH_SRC)\chip
 $(TOPDIR)\drivers\platform`
5. `mkdir -p staging` Create dir '-p' while creating dir 'staging', and the dir '-p'  cant be remove when make distclean, which result failure of `mkdir -p staging`  in next bulid.
6.  when use too many libc function, there are too many obj in $(2) and will give an error: too long input line error call ARCHIVE in Windows native build, because `@echo "AR (create): ${shell basename $(1)} $(2)"`
7. In pass1dep target, if `$(USERDEPDIRS)` is empty, there will be an error:
`for %%G in () do ( make -C %%G depend )`
`make: *** [pass1dep] error 1255297184`
## Impact
Windows native build
## Testing
Configure + Build stm32f4discovery on Windows XP/7 + GnuWin32 + MinGW + kconfig-frontends-win32
![nuttx-win32](https://user-images.githubusercontent.com/10884769/201474777-37e780af-0fa2-410f-a4e8-ecb4cf339fca.jpg)
