### PR TITLE
video: Remove the unused vbuf_curr field from video_framebuff_s

### DIFF
--- a/drivers/video/video.c
+++ b/drivers/video/video.c
@@ -3317,21 +3317,10 @@ static int video_complete_capture(uint8_t err_code, uint32_t datasize,
 
   if (err_code == 0)
     {
-      type_inf->bufinf.vbuf_curr->buf.flags = 0;
       if (type_inf->remaining_capnum > 0)
         {
           type_inf->remaining_capnum--;
         }
-    }
-  else
-    {
-      type_inf->bufinf.vbuf_curr->buf.flags = V4L2_BUF_FLAG_ERROR;
-    }
-
-  type_inf->bufinf.vbuf_curr->buf.bytesused = datasize;
-  if (ts != NULL)
-    {
-      type_inf->bufinf.vbuf_curr->buf.timestamp = *ts;
     }
 
   video_framebuff_capture_done(&type_inf->bufinf);

--- a/drivers/video/video_framebuff.c
+++ b/drivers/video/video_framebuff.c
@@ -41,7 +41,6 @@ static void init_buf_chain(video_framebuff_t *fbuf)
 
   fbuf->vbuf_empty = fbuf->vbuf_alloced;
   fbuf->vbuf_next  = NULL;
-  fbuf->vbuf_curr  = NULL;
   fbuf->vbuf_top   = NULL;
   fbuf->vbuf_tail  = NULL;
 
@@ -218,7 +217,7 @@ video_framebuff_get_vacant_container(video_framebuff_t *fbuf)
   irqstate_t flags;
 
   flags = enter_critical_section();
-  ret = fbuf->vbuf_curr = fbuf->vbuf_next;
+  ret = fbuf->vbuf_next;
   leave_critical_section(flags);
 
   return ret;
@@ -226,7 +225,6 @@ video_framebuff_get_vacant_container(video_framebuff_t *fbuf)
 
 void video_framebuff_capture_done(video_framebuff_t *fbuf)
 {
-  fbuf->vbuf_curr = NULL;
   if (fbuf->vbuf_next != NULL)
     {
       fbuf->vbuf_next = fbuf->vbuf_next->next;

--- a/drivers/video/video_framebuff.h
+++ b/drivers/video/video_framebuff.h
@@ -42,14 +42,13 @@ typedef struct vbuf_container_s vbuf_container_t;
 
 struct video_framebuff_s
 {
-  enum v4l2_buf_mode  mode;
+  enum v4l2_buf_mode mode;
   mutex_t lock_empty;
   int container_size;
   vbuf_container_t *vbuf_alloced;
   vbuf_container_t *vbuf_empty;
   vbuf_container_t *vbuf_top;
   vbuf_container_t *vbuf_tail;
-  vbuf_container_t *vbuf_curr;
   vbuf_container_t *vbuf_next;
 };
 


### PR DESCRIPTION
## Summary

since the code just assign the value to vbuf_curr, but never read it

## Impact
code refactor

## Testing
Pass CI
