### PR TITLE
net/l2/l3/l4: add support of iob offload

### DIFF
--- a/arch/sim/src/sim/sim_netdriver.c
+++ b/arch/sim/src/sim/sim_netdriver.c
@@ -72,6 +72,11 @@
 
 #include "sim_internal.h"
 
+#if CONFIG_IOB_BUFSIZE >= (MAX_NETDEV_PKTSIZE + \
+    CONFIG_NET_GUARDSIZE + CONFIG_NET_LL_GUARDSIZE)
+#  define SIM_NETDEV_IOB_OFFLOAD
+#endif
+
 /****************************************************************************
  * Private Function Prototypes
  ****************************************************************************/
@@ -95,12 +100,23 @@ static struct net_driver_s g_sim_dev[CONFIG_SIM_NETDEV_NUMBER];
  * Private Functions
  ****************************************************************************/
 
-static void netdriver_reply(struct net_driver_s *dev)
+static void netdriver_send(struct net_driver_s *dev)
 {
   int devidx = (intptr_t)dev->d_private;
+#ifdef SIM_NETDEV_IOB_OFFLOAD
+  uint8_t *buf = &dev->d_iob->io_data[CONFIG_NET_LL_GUARDSIZE -
+                                      NET_LL_HDRLEN(dev)];
+#else
+  uint8_t *buf = dev->d_buf;
+#endif
 
   UNUSED(devidx);
 
+  sim_netdev_send(devidx, buf, dev->d_len);
+}
+
+static void netdriver_reply(struct net_driver_s *dev)
+{
   /* If the receiving resulted in data that should be sent out on
    * the network, the field d_len is set to a value > 0.
    */
@@ -110,7 +126,7 @@ static void netdriver_reply(struct net_driver_s *dev)
       /* Send the packet */
 
       NETDEV_TXPACKETS(dev);
-      sim_netdev_send(devidx, dev->d_buf, dev->d_len);
+      netdriver_send(dev);
       NETDEV_TXDONE(dev);
     }
 }
@@ -131,6 +147,14 @@ static void netdriver_recv_work(void *arg)
 
   while (sim_netdev_avail(devidx))
     {
+#ifdef SIM_NETDEV_IOB_OFFLOAD
+      if (netdev_iob_prepare(dev, false, 0) != OK)
+        {
+          netdriver_txdone_interrupt(dev);
+          break;
+        }
+#endif
+
       /* sim_netdev_read will return 0 on a timeout event and > 0
        * on a data received event
        */
@@ -141,6 +165,10 @@ static void netdriver_recv_work(void *arg)
       if (dev->d_len > 0)
         {
           NETDEV_RXPACKETS(dev);
+
+#ifdef SIM_NETDEV_IOB_OFFLOAD
+          iob_update_pktlen(dev->d_iob, dev->d_len - NET_LL_HDRLEN(dev));
+#endif
 
           /* Data received event.  Check for valid Ethernet header with
            * destination == our MAC address
@@ -208,7 +236,7 @@ static void netdriver_recv_work(void *arg)
 
                   if (dev->d_len > 0)
                     {
-                      sim_netdev_send(devidx, dev->d_buf, dev->d_len);
+                      netdriver_send(dev);
                     }
                 }
               else
@@ -224,6 +252,10 @@ static void netdriver_recv_work(void *arg)
               NETDEV_RXERRORS(dev);
             }
         }
+
+#ifdef SIM_NETDEV_IOB_OFFLOAD
+      netdev_iob_release(dev);
+#endif
     }
 
   net_unlock();
@@ -231,14 +263,10 @@ static void netdriver_recv_work(void *arg)
 
 static int netdriver_txpoll(struct net_driver_s *dev)
 {
-  int devidx = (intptr_t)dev->d_private;
-
-  UNUSED(devidx);
-
   /* Send the packet */
 
   NETDEV_TXPACKETS(dev);
-  sim_netdev_send(devidx, dev->d_buf, dev->d_len);
+  netdriver_send(dev);
   NETDEV_TXDONE(dev);
 
   /* If zero is returned, the polling will continue until all connections
@@ -321,9 +349,8 @@ static void netdriver_rxready_interrupt(void *priv)
 int sim_netdriver_init(void)
 {
   struct net_driver_s *dev;
-  void *pktbuf;
-  int pktsize;
   int devidx;
+
   for (devidx = 0; devidx < CONFIG_SIM_NETDEV_NUMBER; devidx++)
     {
       dev = &g_sim_dev[devidx];
@@ -334,22 +361,19 @@ int sim_netdriver_init(void)
                   netdriver_txdone_interrupt,
                   netdriver_rxready_interrupt);
 
-      /* Update the buffer size */
-
-      pktsize = dev->d_pktsize ? dev->d_pktsize :
-                (MAX_NETDEV_PKTSIZE + CONFIG_NET_GUARDSIZE);
-
       /* Allocate packet buffer */
 
-      pktbuf = kmm_malloc(pktsize);
-      if (pktbuf == NULL)
+#ifndef SIM_NETDEV_IOB_OFFLOAD
+      dev->d_buf = kmm_malloc(dev->d_pktsize != 0 ?
+                              dev->d_pktsize :
+                              (MAX_NETDEV_PKTSIZE +
+                               CONFIG_NET_GUARDSIZE));
+      if (dev->d_buf == NULL)
         {
           return -ENOMEM;
         }
+#endif
 
-      /* Set callbacks */
-
-      dev->d_buf     = pktbuf;
       dev->d_ifup    = netdriver_ifup;
       dev->d_ifdown  = netdriver_ifdown;
       dev->d_txavail = netdriver_txavail;

--- a/drivers/net/loopback.c
+++ b/drivers/net/loopback.c
@@ -82,7 +82,6 @@ struct lo_driver_s
  ****************************************************************************/
 
 static struct lo_driver_s g_loopback;
-static uint8_t g_iobuffer[NET_LO_PKTSIZE + CONFIG_NET_GUARDSIZE];
 
 /****************************************************************************
  * Private Function Prototypes
@@ -334,7 +333,6 @@ int localhost_initialize(void)
   priv->lo_dev.d_addmac  = lo_addmac;    /* Add multicast MAC address */
   priv->lo_dev.d_rmmac   = lo_rmmac;     /* Remove multicast MAC address */
 #endif
-  priv->lo_dev.d_buf     = g_iobuffer;   /* Attach the IO buffer */
   priv->lo_dev.d_private = priv;         /* Used to recover private state from dev */
 
   /* Register the loopabck device with the OS so that socket IOCTLs can b

--- a/include/nuttx/mm/iob.h
+++ b/include/nuttx/mm/iob.h
@@ -127,7 +127,7 @@ struct iob_s
 #if CONFIG_IOB_HEADSIZE > 0
   uint8_t  io_head[CONFIG_IOB_HEADSIZE];
 #endif
-  uint8_t  io_data[CONFIG_IOB_BUFSIZE];
+  uint8_t  io_data[CONFIG_IOB_BUFSIZE] aligned_data(CONFIG_IOB_ALIGNMENT);
 };
 
 #if CONFIG_IOB_NCHAINS > 0

--- a/include/nuttx/net/netdev.h
+++ b/include/nuttx/net/netdev.h
@@ -59,8 +59,11 @@
 #include <net/ethernet.h>
 #include <arpa/inet.h>
 
+#include <nuttx/mm/iob.h>
 #include <nuttx/net/netconfig.h>
+#include <nuttx/net/net.h>
 #include <nuttx/net/ip.h>
+#include <nuttx/nuttx.h>
 
 #ifdef CONFIG_NET_IGMP
 #  include <nuttx/net/igmp.h>
@@ -307,6 +310,20 @@ struct net_driver_s
   net_ipv6addr_t d_ipv6draddr;  /* Default router IPv6 address */
   net_ipv6addr_t d_ipv6netmask; /* Network IPv6 subnet mask */
 #endif
+  /* This is a new design that uses d_iob as packets input and output
+   * buffer which used by some NICs such as celluler net driver. Case for
+   * data input, note that d_iob maybe a linked chain only when using
+   * d_iob to store reassembled datagrams, otherwise d_iob uses only
+   * one buffer to hold the entire frame data. Case for data output, note
+   * that d_iob also maybe a linked chain only when using d_iob to
+   * store fragmented datagrams, otherwise d_iob uses only one buffer
+   * to hold the entire frame data.
+   *
+   * In all cases mentioned above, d_buf always points to the beginning
+   * of the first buffer of d_iob.
+   */
+
+  FAR struct iob_s *d_iob;
 
   /* The d_buf array is used to hold incoming and outgoing packets. The
    * device driver should place incoming data into this buffer.  When sending
@@ -426,10 +443,6 @@ struct net_driver_s
 };
 
 typedef CODE int (*devif_poll_callback_t)(FAR struct net_driver_s *dev);
-
-/****************************************************************************
- * Public Data
- ****************************************************************************/
 
 /****************************************************************************
  * Public Function Prototypes
@@ -560,6 +573,19 @@ int sixlowpan_input(FAR struct radio_driver_s *ieee,
  *     return 0;
  *   }
  *
+ *   Compatible with all old flat buffer NICs
+ *
+ *                 tcp_poll()/udp_poll()/pkt_poll()/...(l3/l4)
+ *                            /              \
+ *                           /                \
+ * devif_poll_[l3/l4]_connections()     devif_iob_send() (nocopy:udp/icmp/..)
+ *            /                                   \      (copy:tcp)
+ *           /                                     \
+ *   devif_iob_poll(devif_poll_callback())  devif_poll_callback()
+ *        /                                           \
+ *       /                                             \
+ *  devif_poll("NIC"_txpoll)                     "NIC"_send()(dev->d_buf)
+ *
  ****************************************************************************/
 
 int devif_poll(FAR struct net_driver_s *dev, devif_poll_callback_t callback);
@@ -641,6 +667,26 @@ int netdev_carrier_off(FAR struct net_driver_s *dev);
 uint16_t chksum(uint16_t sum, FAR const uint8_t *data, uint16_t len);
 
 /****************************************************************************
+ * Name: chksum_iob
+ *
+ * Description:
+ *   Calculate the Internet checksum over an iob chain buffer.
+ *
+ * Input Parameters:
+ *   sum    - Partial calculations carried over from a previous call to
+ *            chksum().  This should be zero on the first time that check
+ *            sum is called.
+ *   iob    - An iob chain buffer over which the checksum is to be computed.
+ *   offset - Specifies the byte offset of the start of valid data.
+ *
+ * Returned Value:
+ *   The updated checksum value.
+ *
+ ****************************************************************************/
+
+uint16_t chksum_iob(uint16_t sum, FAR struct iob_s *iob, uint16_t offset);
+
+/****************************************************************************
  * Name: net_chksum
  *
  * Description:
@@ -667,6 +713,35 @@ uint16_t chksum(uint16_t sum, FAR const uint8_t *data, uint16_t len);
  ****************************************************************************/
 
 uint16_t net_chksum(FAR uint16_t *data, uint16_t len);
+
+/****************************************************************************
+ * Name: net_chksum_iob
+ *
+ * Description:
+ *   Calculate the Internet checksum over an iob chain buffer.
+ *
+ *   The Internet checksum is the one's complement of the one's complement
+ *   sum of all 16-bit words in the buffer.
+ *
+ *   See RFC1071.
+ *
+ *   If CONFIG_NET_ARCH_CHKSUM is defined, then this function must be
+ *   provided by architecture-specific logic.
+ *
+ * Input Parameters:
+ *   sum    - Partial calculations carried over from a previous call to
+ *            chksum().  This should be zero on the first time that check
+ *            sum is called.
+ *   iob    - An iob chain buffer over which the checksum is to be computed.
+ *   offset - Specifies the byte offset of the start of valid data.
+ *
+ * Returned Value:
+ *   The Internet checksum of the given iob chain buffer.
+ *
+ ****************************************************************************/
+
+uint16_t net_chksum_iob(uint16_t sum, FAR struct iob_s *iob,
+                        uint16_t offset);
 
 /****************************************************************************
  * Name: ipv4_upperlayer_chksum
@@ -801,5 +876,55 @@ void net_incr32(FAR uint8_t *op32, uint16_t op16);
  ****************************************************************************/
 
 int netdev_lladdrsize(FAR struct net_driver_s *dev);
+
+/****************************************************************************
+ * Name: netdev_iob_prepare
+ *
+ * Description:
+ *   Prepare data buffer for a given NIC
+ *   The iob offset will be updated to l2 gruard size by default:
+ *  ----------------------------------------------------------------
+ *  |                     iob entry                                |
+ *  ---------------------------------------------------------------|
+ *  |<--- CONFIG_NET_LL_GUARDSIZE -->|<--- io_len/io_pktlen(0) --->|
+ *  ---------------------------------------------------------------|
+ *
+ * Assumptions:
+ *   The caller has locked the network.
+ *
+ * Returned Value:
+ *   A non-zero copy is returned on success.
+ *
+ ****************************************************************************/
+
+int netdev_iob_prepare(FAR struct net_driver_s *dev, bool throttled,
+                       unsigned int timeout);
+
+/****************************************************************************
+ * Name: netdev_iob_clear
+ *
+ * Description:
+ *   Clean up buffer resources for a given NIC
+ *
+ * Assumptions:
+ *   The caller has locked the network and dev->d_iob has been
+ *   released or taken away.
+ *
+ ****************************************************************************/
+
+void netdev_iob_clear(FAR struct net_driver_s *dev);
+
+/****************************************************************************
+ * Name: netdev_iob_release
+ *
+ * Description:
+ *   Release buffer resources for a given NIC
+ *
+ * Assumptions:
+ *   The caller has locked the network.
+ *
+ ****************************************************************************/
+
+void netdev_iob_release(FAR struct net_driver_s *dev);
 
 #endif /* __INCLUDE_NUTTX_NET_NETDEV_H */

--- a/mm/iob/Kconfig
+++ b/mm/iob/Kconfig
@@ -41,7 +41,7 @@ config IOB_HEADSIZE
 
 config IOB_ALIGNMENT
 	int "Alignment size of each I/O buffer"
-	default 1
+	default 4
 	---help---
 		The member io_head of all I/O buffers is aligned to the value
 		specified by this configuration.

--- a/net/Kconfig
+++ b/net/Kconfig
@@ -117,6 +117,15 @@ config NET_GUARDSIZE
 		packet size will be chopped down to the size indicated in the TCP
 		header.
 
+config NET_LL_GUARDSIZE
+	int "Data Link Layer(L2) Guard size of Network buffer(IOB)"
+	default 14 if NET_ETHERNET
+	default 0
+	---help---
+		This is reserved l2 buffer header size of network buffer to isolate
+		the L2/L3 (MAC/IP) data on Network layer, which will be beneficial
+		to L3 network layer protocol transparent transmission and forwarding
+
 config NET_RECV_BUFSIZE
 	int "Net Receive buffer size"
 	default 0

--- a/net/arp/arp_format.c
+++ b/net/arp/arp_format.c
@@ -97,6 +97,10 @@ void arp_format(FAR struct net_driver_s *dev, in_addr_t ipaddr)
 
   eth->type        = HTONS(ETHTYPE_ARP);
   dev->d_len       = sizeof(struct arp_hdr_s) + ETH_HDRLEN;
+
+  /* Update device buffer length */
+
+  iob_update_pktlen(dev->d_iob, sizeof(struct arp_hdr_s));
 }
 
 #endif /* CONFIG_NET_ARP */

--- a/net/can/can.h
+++ b/net/can/can.h
@@ -209,10 +209,8 @@ uint16_t can_callback(FAR struct net_driver_s *dev,
  *   receive the data.
  *
  * Input Parameters:
+ *   dev  - The device which as active when the event was detected.
  *   conn - A pointer to the CAN connection structure
- *   buffer - A pointer to the buffer to be copied to the read-ahead
- *     buffers
- *   buflen - The number of bytes to copy to the read-ahead buffer.
  *
  * Returned Value:
  *   The number of bytes actually buffered is returned.  This will be either
@@ -225,8 +223,8 @@ uint16_t can_callback(FAR struct net_driver_s *dev,
  *
  ****************************************************************************/
 
-uint16_t can_datahandler(FAR struct can_conn_s *conn, FAR uint8_t *buffer,
-                         uint16_t buflen);
+uint16_t can_datahandler(FAR struct net_driver_s *dev,
+                         FAR struct can_conn_s *conn);
 
 /****************************************************************************
  * Name: can_recvmsg

--- a/net/can/can_recvmsg.c
+++ b/net/can/can_recvmsg.c
@@ -120,8 +120,9 @@ static inline void can_add_recvlen(FAR struct can_recvfrom_s *pstate,
  ****************************************************************************/
 
 static size_t can_recvfrom_newdata(FAR struct net_driver_s *dev,
-                                 FAR struct can_recvfrom_s *pstate)
+                                   FAR struct can_recvfrom_s *pstate)
 {
+  unsigned int offset;
   size_t recvlen;
 
   if (dev->d_len > pstate->pr_buflen)
@@ -135,7 +136,13 @@ static size_t can_recvfrom_newdata(FAR struct net_driver_s *dev,
 
   /* Copy the new packet data into the user buffer */
 
-  memcpy(pstate->pr_buffer, dev->d_buf, recvlen);
+  offset = (dev->d_appdata - dev->d_iob->io_data) - dev->d_iob->io_offset;
+
+  recvlen = iob_copyout(pstate->pr_buffer, dev->d_iob, recvlen, offset);
+
+  /* Trim the copied buffers */
+
+  dev->d_iob = iob_trimhead(dev->d_iob, recvlen + offset);
 
   /* Update the accumulated size of the data read */
 
@@ -175,34 +182,7 @@ static inline void can_newdata(FAR struct net_driver_s *dev,
 
   if (recvlen < dev->d_len)
     {
-      FAR struct can_conn_s *conn = pstate->pr_conn;
-      FAR uint8_t *buffer = dev->d_appdata + recvlen;
-      uint16_t buflen = dev->d_len - recvlen;
-#ifdef CONFIG_DEBUG_NET
-      uint16_t nsaved;
-
-      nsaved = can_datahandler(conn, buffer, buflen);
-#else
-      can_datahandler(conn, buffer, buflen);
-#endif
-
-      /* There are complicated buffering issues that are not addressed fully
-       * here.  For example, what if up_datahandler() cannot buffer the
-       * remainder of the packet?  In that case, the data will be dropped but
-       * still ACKed.  Therefore it would not be resent.
-       *
-       * This is probably not an issue here because we only get here if the
-       * read-ahead buffers are empty and there would have to be something
-       * serioulsy wrong with the configuration not to be able to buffer a
-       * partial packet in this context.
-       */
-
-#ifdef CONFIG_DEBUG_NET
-      if (nsaved < buflen)
-        {
-          nerr("ERROR: packet data not saved (%d bytes)\n", buflen - nsaved);
-        }
-#endif
+      can_datahandler(dev, pstate->pr_conn);
     }
 
   /* Indicate no data in the buffer */

--- a/net/devif/Make.defs
+++ b/net/devif/Make.defs
@@ -20,39 +20,44 @@
 
 # Network device interface source files
 
-NET_CSRCS += devif_initialize.c devif_send.c devif_poll.c devif_callback.c
-NET_CSRCS += devif_loopback.c
+NET_CSRCS += devif_initialize.c devif_callback.c
 
 # Device driver IP packet receipt interfaces
 
-ifeq ($(CONFIG_NET_IPv4),y)
-NET_CSRCS += ipv4_input.c
-endif
-
-ifeq ($(CONFIG_NET_IPv6),y)
-NET_CSRCS += ipv6_input.c
-endif
-
-# IP forwarding
-
-ifeq ($(CONFIG_NET_IPFORWARD),y)
-NET_CSRCS += devif_forward.c
-endif
-
-# I/O buffer chain support required?
-
 ifeq ($(CONFIG_MM_IOB),y)
-NET_CSRCS += devif_iobsend.c
-endif
 
-# Raw packet socket support
+  # IP packet
 
-ifeq ($(CONFIG_NET_PKT),y)
-NET_CSRCS += devif_pktsend.c
-endif
+  NET_CSRCS += devif_send.c devif_loopback.c
 
-ifeq ($(CONFIG_NET_CAN),y)
-NET_CSRCS += devif_cansend.c
+  ifeq ($(CONFIG_NET_IPv4),y)
+    NET_CSRCS += ipv4_input.c
+  endif
+
+  ifeq ($(CONFIG_NET_IPv6),y)
+    NET_CSRCS += ipv6_input.c
+  endif
+
+  # IP forwarding
+
+  ifeq ($(CONFIG_NET_IPFORWARD),y)
+    NET_CSRCS += devif_forward.c
+  endif
+
+  # I/O buffer chain support required?
+
+  NET_CSRCS += devif_poll.c
+  NET_CSRCS += devif_iobsend.c
+
+  # Raw packet socket support
+
+  ifeq ($(CONFIG_NET_PKT),y)
+    NET_CSRCS += devif_pktsend.c
+  endif
+
+  ifeq ($(CONFIG_NET_CAN),y)
+    NET_CSRCS += devif_cansend.c
+  endif
 endif
 
 # Include network device interface build support

--- a/net/devif/devif.h
+++ b/net/devif/devif.h
@@ -449,7 +449,8 @@ uint16_t devif_dev_event(FAR struct net_driver_s *dev, uint16_t flags);
  *
  ****************************************************************************/
 
-void devif_send(FAR struct net_driver_s *dev, FAR const void *buf, int len);
+void devif_send(FAR struct net_driver_s *dev, FAR const void *buf,
+                int len, unsigned int offset);
 
 /****************************************************************************
  * Name: devif_iob_send
@@ -469,7 +470,8 @@ void devif_send(FAR struct net_driver_s *dev, FAR const void *buf, int len);
 #ifdef CONFIG_MM_IOB
 struct iob_s;
 void devif_iob_send(FAR struct net_driver_s *dev, FAR struct iob_s *buf,
-                    unsigned int len, unsigned int offset);
+                    unsigned int len, unsigned int offset,
+                    unsigned int target_offset);
 #endif
 
 /****************************************************************************
@@ -559,6 +561,40 @@ int devif_poll_out(FAR struct net_driver_s *dev,
  ****************************************************************************/
 
 int devif_loopback(FAR struct net_driver_s *dev);
+
+/****************************************************************************
+ * Name: netdev_input
+ *
+ * Description:
+ *   This function will copy the flat buffer that does not support
+ *   Scatter/gather to the iob vector buffer.
+ *
+ *   Compatible with all old flat buffer NICs:
+ *
+ *   [tcp|udp|icmp|...]ipv[4|6]_data_handler()
+ *                     |                    (iob_concat/append to readahead)
+ *                     |
+ *              pkt/ipv[4/6]_in()/...
+ *                     |
+ *                     |
+ *                netdev_input()  // new interface, Scatter/gather flat/iobs
+ *                     |
+ *                     |
+ *           pkt/ipv[4|6]_input()/...
+ *                     |
+ *                     |
+ *     NICs io vector receive(Orignal flat buffer)
+ *
+ * Input Parameters:
+ *   callback - Input callback of L3 stack
+ *
+ * Returned Value:
+ *   A non-zero copy is returned on success.
+ *
+ ****************************************************************************/
+
+int netdev_input(FAR struct net_driver_s *dev,
+                 devif_poll_callback_t callback, bool reply);
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/net/devif/devif_cansend.c
+++ b/net/devif/devif_cansend.c
@@ -33,34 +33,6 @@
 #if defined(CONFIG_NET_CAN)
 
 /****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-/****************************************************************************
- * Private Type Declarations
- ****************************************************************************/
-
-/****************************************************************************
- * Private Function Prototypes
- ****************************************************************************/
-
-/****************************************************************************
- * Public Constant Data
- ****************************************************************************/
-
-/****************************************************************************
- * Public Data
- ****************************************************************************/
-
-/****************************************************************************
- * Private Constant Data
- ****************************************************************************/
-
-/****************************************************************************
- * Private Data
- ****************************************************************************/
-
-/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -83,16 +55,25 @@
 void devif_can_send(FAR struct net_driver_s *dev, FAR const void *buf,
                     unsigned int len)
 {
-  DEBUGASSERT(dev && len > 0 && len <= NETDEV_PKTSIZE(dev));
+  unsigned int limit = NETDEV_PKTSIZE(dev) -
+                       CONFIG_NET_LL_GUARDSIZE;
 
-  /* Copy the data into the device packet buffer */
+  if (dev == NULL || len == 0 || len > limit)
+    {
+      nerr("ERROR: devif_pkt_send fail: %p, sndlen: %u, pktlen: %u\n",
+           dev, len, limit);
+      return;
+    }
 
-  memcpy(dev->d_buf, buf, len);
+  iob_update_pktlen(dev->d_iob, 0);
 
-  /* Set the number of bytes to send */
+  /* Copy the data into the device packet buffer and set the number of
+   * bytes to send
+   */
 
-  dev->d_len    = len;
-  dev->d_sndlen = len;
+  dev->d_sndlen = iob_copyin(dev->d_iob, buf, len, 0, false) == len ?
+                  len : 0;
+  dev->d_len    = dev->d_sndlen;
 }
 
 #endif /* CONFIG_NET_CAN */

--- a/net/devif/devif_loopback.c
+++ b/net/devif/devif_loopback.c
@@ -32,6 +32,17 @@
 #include <nuttx/net/netdev.h>
 
 /****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* This is a helper pointer for accessing the contents of the ip header */
+
+#define LOIPv4BUF ((FAR struct ipv4_hdr_s *) \
+                   &dev->d_iob->io_data[CONFIG_NET_LL_GUARDSIZE])
+#define LOIPv6BUF ((FAR struct ipv6_hdr_s *) \
+                   &dev->d_iob->io_data[CONFIG_NET_LL_GUARDSIZE])
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -40,16 +51,16 @@ static bool is_loopback(FAR struct net_driver_s *dev)
   if (dev->d_len > 0)
     {
 #ifdef CONFIG_NET_IPv4
-      if ((IPv4BUF->vhl & IP_VERSION_MASK) == IPv4_VERSION &&
-           net_ipv4addr_hdrcmp(IPv4BUF->destipaddr, &dev->d_ipaddr))
+      if ((LOIPv4BUF->vhl & IP_VERSION_MASK) == IPv4_VERSION &&
+           net_ipv4addr_hdrcmp(LOIPv4BUF->destipaddr, &dev->d_ipaddr))
         {
           return true;
         }
 #endif
 
 #ifdef CONFIG_NET_IPv6
-      if ((IPv6BUF->vtc & IP_VERSION_MASK) == IPv6_VERSION &&
-          net_ipv6addr_hdrcmp(IPv6BUF->destipaddr, dev->d_ipv6addr))
+      if ((LOIPv6BUF->vtc & IP_VERSION_MASK) == IPv6_VERSION &&
+          net_ipv6addr_hdrcmp(LOIPv6BUF->destipaddr, dev->d_ipv6addr))
         {
           return true;
         }
@@ -99,7 +110,7 @@ int devif_loopback(FAR struct net_driver_s *dev)
       /* We only accept IP packets of the configured type */
 
 #ifdef CONFIG_NET_IPv4
-      if ((IPv4BUF->vhl & IP_VERSION_MASK) == IPv4_VERSION)
+      if ((LOIPv4BUF->vhl & IP_VERSION_MASK) == IPv4_VERSION)
         {
           ninfo("IPv4 frame\n");
 
@@ -109,7 +120,7 @@ int devif_loopback(FAR struct net_driver_s *dev)
       else
 #endif
 #ifdef CONFIG_NET_IPv6
-      if ((IPv6BUF->vtc & IP_VERSION_MASK) == IPv6_VERSION)
+      if ((LOIPv6BUF->vtc & IP_VERSION_MASK) == IPv6_VERSION)
         {
           ninfo("IPv6 frame\n");
 

--- a/net/icmp/icmp_input.c
+++ b/net/icmp/icmp_input.c
@@ -100,28 +100,14 @@ static uint16_t icmp_datahandler(FAR struct net_driver_s *dev,
   FAR struct ipv4_hdr_s *ipv4;
   struct sockaddr_in inaddr;
   FAR struct iob_s *iob;
-  uint16_t offset;
-  uint16_t buflen;
   uint16_t iphdrlen;
-  uint8_t addrsize;
+  uint16_t buflen;
   int ret;
-
-  /* Try to allocate on I/O buffer to start the chain without waiting (and
-   * throttling as necessary).  If we would have to wait, then drop the
-   * packet.
-   */
-
-  iob = iob_tryalloc(true);
-  if (iob == NULL)
-    {
-      nerr("ERROR: Failed to create new I/O buffer chain\n");
-      goto drop;
-    }
 
   /* Put the IPv4 address at the beginning of the read-ahead buffer */
 
-  ipv4 = IPv4BUF;
-
+  iob               = dev->d_iob;
+  ipv4              = IPv4BUF;
   inaddr.sin_family = AF_INET;
   inaddr.sin_port   = 0;
 
@@ -129,57 +115,23 @@ static uint16_t icmp_datahandler(FAR struct net_driver_s *dev,
                     net_ip4addr_conv32(ipv4->srcipaddr));
   memset(inaddr.sin_zero, 0, sizeof(inaddr.sin_zero));
 
-  /* Copy the src address info into the I/O buffer chain.  We will not wait
-   * for an I/O buffer to become available in this context.  It there is
-   * any failure to allocated, the entire I/O buffer chain will be discarded.
-   */
-
-  addrsize = sizeof(struct sockaddr_in);
-  ret      = iob_trycopyin(iob, &addrsize, sizeof(uint8_t), 0, true);
-  if (ret < 0)
-    {
-      /* On a failure, iob_trycopyin return a negated error value but does
-       * not free any I/O buffers.
-       */
-
-      nerr("ERROR: Failed to length to the I/O buffer chain: %d\n", ret);
-      goto drop_with_chain;
-    }
-
-  offset = sizeof(uint8_t);
-
-  ret = iob_trycopyin(iob, (FAR const uint8_t *)&inaddr,
-                      sizeof(struct sockaddr_in), offset, true);
-  if (ret < 0)
-    {
-      /* On a failure, iob_trycopyin return a negated error value but does
-       * not free any I/O buffers.
-       */
-
-      nerr("ERROR: Failed to source address to the I/O buffer chain: %d\n",
-           ret);
-      goto drop_with_chain;
-    }
-
-  offset += sizeof(struct sockaddr_in);
-
   /* Get the IP header length (accounting for possible options). */
 
   iphdrlen = (ipv4->vhl & IPv4_HLMASK) << 2;
 
+  /* Copy the src address info into the front of I/O buffer chain which
+   * overwrites the contents of the packet header field.
+   */
+
+  memcpy(iob->io_data, &inaddr, sizeof(struct sockaddr_in));
+
   /* Copy the new ICMP reply into the I/O buffer chain (without waiting) */
 
   buflen = ICMPSIZE(iphdrlen);
-  ret = iob_trycopyin(iob, IPBUF(iphdrlen), buflen, offset, true);
-  if (ret < 0)
-    {
-      /* On a failure, iob_copyin return a negated error value but does
-       * not free any I/O buffers.
-       */
 
-      nerr("ERROR: Failed to add data to the I/O buffer chain: %d\n", ret);
-      goto drop_with_chain;
-    }
+  /* Trim l3 header */
+
+  iob = iob_trimhead(iob, iphdrlen);
 
   /* Add the new I/O buffer chain to the tail of the read-ahead queue (again
    * without waiting).
@@ -189,19 +141,18 @@ static uint16_t icmp_datahandler(FAR struct net_driver_s *dev,
   if (ret < 0)
     {
       nerr("ERROR: Failed to queue the I/O buffer chain: %d\n", ret);
-      goto drop_with_chain;
+      iob_free_chain(iob);
+    }
+  else
+    {
+      ninfo("Buffered %d bytes\n", buflen);
     }
 
-  ninfo("Buffered %d bytes\n", buflen + addrsize + 1);
-  dev->d_len = 0;
+  /* Device buffer must be enqueue or freed, clear the handle */
+
+  netdev_iob_clear(dev);
+
   return buflen;
-
-drop_with_chain:
-  iob_free_chain(iob);
-
-drop:
-  dev->d_len = 0;
-  return 0;
 }
 #endif
 

--- a/net/icmp/icmp_sendmsg.c
+++ b/net/icmp/icmp_sendmsg.c
@@ -114,7 +114,11 @@ static void sendto_request(FAR struct net_driver_s *dev,
   /* Copy the ICMP header and payload into place after the IPv4 header */
 
   icmp              = IPBUF(IPv4_HDRLEN);
-  memcpy(icmp, pstate->snd_buf, pstate->snd_buflen);
+
+  iob_update_pktlen(dev->d_iob, IPv4_HDRLEN);
+
+  iob_copyin(dev->d_iob, pstate->snd_buf,
+             pstate->snd_buflen, IPv4_HDRLEN, false);
 
   /* Initialize the IP header. */
 
@@ -125,7 +129,7 @@ static void sendto_request(FAR struct net_driver_s *dev,
   /* Calculate the ICMP checksum. */
 
   icmp->icmpchksum  = 0;
-  icmp->icmpchksum  = ~(icmp_chksum(dev, pstate->snd_buflen));
+  icmp->icmpchksum  = ~icmp_chksum_iob(dev->d_iob);
   if (icmp->icmpchksum == 0)
     {
       icmp->icmpchksum = 0xffff;

--- a/net/icmpv6/icmpv6_advertise.c
+++ b/net/icmpv6/icmpv6_advertise.c
@@ -103,6 +103,10 @@ void icmpv6_advertise(FAR struct net_driver_s *dev,
 
   memcpy(adv->tgtlladdr, &dev->d_mac, lladdrsize);
 
+  /* Update device buffer length */
+
+  iob_update_pktlen(dev->d_iob, IPv6_HDRLEN + l3size);
+
   /* Calculate the checksum over both the ICMP header and payload */
 
   adv->chksum    = 0;

--- a/net/icmpv6/icmpv6_radvertise.c
+++ b/net/icmpv6/icmpv6_radvertise.c
@@ -193,6 +193,10 @@ void icmpv6_radvertise(FAR struct net_driver_s *dev)
   ipv6addr_mask(prefix->prefix, dev->d_ipv6addr, dev->d_ipv6netmask);
 #endif /* CONFIG_NET_ICMPv6_ROUTER_MANUAL */
 
+  /* Update device buffer length */
+
+  iob_update_pktlen(dev->d_iob, IPv6_HDRLEN + l3size);
+
   /* Calculate the checksum over both the ICMP header and payload */
 
   adv->chksum  = 0;

--- a/net/icmpv6/icmpv6_recvmsg.c
+++ b/net/icmpv6/icmpv6_recvmsg.c
@@ -232,10 +232,8 @@ static inline ssize_t icmpv6_readahead(FAR struct icmpv6_conn_s *conn,
                                      FAR struct sockaddr_in6 *from,
                                      FAR socklen_t *fromlen)
 {
-  FAR struct sockaddr_in6 bitbucket;
   FAR struct iob_s *iob;
   ssize_t ret = -ENODATA;
-  int recvlen;
 
   /* Check there is any ICMPv6 replies already buffered in a read-ahead
    * buffer.
@@ -243,68 +241,26 @@ static inline ssize_t icmpv6_readahead(FAR struct icmpv6_conn_s *conn,
 
   if ((iob = iob_peek_queue(&conn->readahead)) != NULL)
     {
-      FAR struct iob_s *tmp;
-      uint16_t offset;
-      uint8_t addrsize;
-
       DEBUGASSERT(iob->io_pktlen > 0);
-
-      /* Transfer that buffered data from the I/O buffer chain into
-       * the user buffer.
-       */
-
-      /* First get the size of the address */
-
-      recvlen = iob_copyout(&addrsize, iob, sizeof(uint8_t), 0);
-      if (recvlen != sizeof(uint8_t))
-        {
-          ret = -EIO;
-          goto out;
-        }
-
-      offset = sizeof(uint8_t);
-
-      if (addrsize > sizeof(struct sockaddr_in6))
-        {
-          ret = -EINVAL;
-          goto out;
-        }
 
       /* Then get address */
 
-      if (from == NULL)
+      if (from != NULL)
         {
-          from = &bitbucket;
+          memcpy(from, iob->io_data, sizeof(struct sockaddr_in6));
         }
 
-      recvlen = iob_copyout((FAR uint8_t *)from, iob, addrsize, offset);
-      if (recvlen != addrsize)
-        {
-          ret = -EIO;
-          goto out;
-        }
+      /* Copy to user */
 
-      if (fromlen != NULL)
-        {
-          *fromlen = addrsize;
-        }
-
-      offset += addrsize;
-
-      /* And finally, get the buffered data */
-
-      ret = (ssize_t)iob_copyout(buf, iob, buflen, offset);
+      ret = iob_copyout(buf, iob, buflen, 0);
 
       ninfo("Received %ld bytes (of %u)\n", (long)ret, iob->io_pktlen);
 
-out:
       /* Remove the I/O buffer chain from the head of the read-ahead
        * buffer queue.
        */
 
-      tmp = iob_remove_queue(&conn->readahead);
-      DEBUGASSERT(tmp == iob);
-      UNUSED(tmp);
+      iob_remove_queue(&conn->readahead);
 
       /* And free the I/O buffer chain */
 

--- a/net/icmpv6/icmpv6_rsolicit.c
+++ b/net/icmpv6/icmpv6_rsolicit.c
@@ -97,6 +97,10 @@ void icmpv6_rsolicit(FAR struct net_driver_s *dev)
 
   memcpy(sol->srclladdr, &dev->d_mac, lladdrsize);
 
+  /* Update device buffer length */
+
+  iob_update_pktlen(dev->d_iob, IPv6_HDRLEN + l3size);
+
   /* Calculate the checksum over both the ICMP header and payload */
 
   sol->chksum   = 0;

--- a/net/icmpv6/icmpv6_sendmsg.c
+++ b/net/icmpv6/icmpv6_sendmsg.c
@@ -116,7 +116,11 @@ static void sendto_request(FAR struct net_driver_s *dev,
   /* Copy the ICMPv6 request and payload into place after the IPv6 header */
 
   icmpv6         = IPBUF(IPv6_HDRLEN);
-  memcpy(icmpv6, pstate->snd_buf, pstate->snd_buflen);
+
+  iob_update_pktlen(dev->d_iob, IPv6_HDRLEN);
+
+  iob_copyin(dev->d_iob, pstate->snd_buf,
+             pstate->snd_buflen, IPv6_HDRLEN, false);
 
   /* Calculate the ICMPv6 checksum over the ICMPv6 header and payload. */
 

--- a/net/icmpv6/icmpv6_solicit.c
+++ b/net/icmpv6/icmpv6_solicit.c
@@ -120,6 +120,10 @@ void icmpv6_solicit(FAR struct net_driver_s *dev,
 
   memcpy(sol->srclladdr, &dev->d_mac, lladdrsize);
 
+  /* Update device buffer length */
+
+  iob_update_pktlen(dev->d_iob, IPv6_HDRLEN + l3size);
+
   /* Calculate the checksum over both the ICMP header and payload */
 
   sol->chksum   = 0;

--- a/net/igmp/igmp_send.c
+++ b/net/igmp/igmp_send.c
@@ -120,6 +120,10 @@ void igmp_send(FAR struct net_driver_s *dev, FAR struct igmp_group_s *group,
 
   dev->d_len        = iphdrlen + IGMP_HDRLEN;
 
+  /* Update device buffer length */
+
+  iob_update_pktlen(dev->d_iob, dev->d_len);
+
   /* The total size of the data is the size of the IGMP header */
 
   dev->d_sndlen     = IGMP_HDRLEN;

--- a/net/ipforward/ipv6_forward.c
+++ b/net/ipforward/ipv6_forward.c
@@ -399,35 +399,9 @@ static int ipv6_dev_forward(FAR struct net_driver_s *dev,
         }
 #endif
 
-      /* Try to allocate the head of an IOB chain.  If this fails, the
-       * packet will be dropped; we are not operating in a context where
-       * waiting for an IOB is a good idea
-       */
+      /* Relay the device buffer */
 
-      fwd->f_iob = iob_tryalloc(false);
-      if (fwd->f_iob == NULL)
-        {
-          nwarn("WARNING: iob_tryalloc() failed\n");
-          ret = -ENOMEM;
-          goto errout_with_fwd;
-        }
-
-      /* Copy the L2/L3 headers plus any following payload into an IOB
-       * chain.  iob_trycopin() will not wait, but will fail there are no
-       * available IOBs.
-       *
-       * REVISIT: Consider an alternative design that does not require data
-       * copying.  This would require a pool of d_buf's that are managed by
-       * the network rather than the network device.
-       */
-
-      ret = iob_trycopyin(fwd->f_iob, (FAR const uint8_t *)ipv6,
-                          dev->d_len, 0, false);
-      if (ret < 0)
-        {
-          nwarn("WARNING: iob_trycopyin() failed: %d\n", ret);
-          goto errout_with_iobchain;
-        }
+      fwd->f_iob = dev->d_iob;
 
       /* Decrement the TTL in the copy of the IPv6 header (retaining the
        * original TTL in the sourcee to handle the broadcast case).  If the
@@ -439,7 +413,7 @@ static int ipv6_dev_forward(FAR struct net_driver_s *dev,
         {
           nwarn("WARNING: Hop limit exceeded... Dropping!\n");
           ret = -EMULTIHOP;
-          goto errout_with_iobchain;
+          goto errout_with_fwd;
         }
 
       /* Then set up to forward the packet according to the protocol. */
@@ -447,15 +421,9 @@ static int ipv6_dev_forward(FAR struct net_driver_s *dev,
       ret = ipfwd_forward(fwd);
       if (ret >= 0)
         {
-          dev->d_len = 0;
+          netdev_iob_clear(dev);
           return OK;
         }
-    }
-
-errout_with_iobchain:
-  if (fwd != NULL && fwd->f_iob != NULL)
-    {
-      iob_free_chain(fwd->f_iob);
     }
 
 errout_with_fwd:

--- a/net/mld/mld_send.c
+++ b/net/mld/mld_send.c
@@ -159,6 +159,10 @@ void mld_send(FAR struct net_driver_s *dev, FAR struct mld_group_s *group,
 
   dev->d_sndlen  = RASIZE + mldsize;
 
+  /* Update device buffer length */
+
+  iob_update_pktlen(dev->d_iob, dev->d_len);
+
   /* Select the IPv6 destination address.
    * This varies with the type of message being sent:
    *

--- a/net/neighbor/neighbor_ethernet_out.c
+++ b/net/neighbor/neighbor_ethernet_out.c
@@ -196,6 +196,10 @@ void neighbor_ethernet_out(FAR struct net_driver_s *dev)
   memcpy(eth->src, dev->d_mac.ether.ether_addr_octet, ETHER_ADDR_LEN);
   eth->type  = HTONS(ETHTYPE_IP6);
 
+  /* Update device buffer length */
+
+  iob_update_pktlen(dev->d_iob, dev->d_len);
+
   /* Add the size of the layer layer header to the total size of the
    * outgoing packet.
    */

--- a/net/netdev/Make.defs
+++ b/net/netdev/Make.defs
@@ -26,6 +26,10 @@ NETDEV_CSRCS += netdev_count.c netdev_ifconf.c netdev_foreach.c
 NETDEV_CSRCS += netdev_unregister.c netdev_carrier.c netdev_default.c
 NETDEV_CSRCS += netdev_verify.c netdev_lladdrsize.c
 
+ifeq ($(CONFIG_MM_IOB),y)
+NETDEV_CSRCS += netdev_input.c netdev_iob.c
+endif
+
 ifeq ($(CONFIG_NETDOWN_NOTIFIER),y)
 SOCK_CSRCS += netdown_notifier.c
 endif

--- a/net/netdev/netdev.h
+++ b/net/netdev/netdev.h
@@ -31,6 +31,7 @@
 #include <stdbool.h>
 
 #include <nuttx/net/ip.h>
+#include <nuttx/net/netdev.h>
 
 #ifdef CONFIG_NETDOWN_NOTIFIER
 #  include <nuttx/wqueue.h>

--- a/net/netdev/netdev_input.c
+++ b/net/netdev/netdev_input.c
@@ -1,0 +1,117 @@
+/****************************************************************************
+ * net/netdev/netdev_input.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <nuttx/net/netdev.h>
+
+#include "utils/utils.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: netdev_input
+ *
+ * Description:
+ *   This function will copy the flat buffer that does not support
+ *   Scatter/gather to the iob vector buffer.
+ *
+ *   Compatible with all old flat buffer NICs:
+ *
+ *   [tcp|udp|icmp|...]ipv[4|6]_data_handler()
+ *                     |                    (iob_concat/append to readahead)
+ *                     |
+ *              pkt/ipv[4/6]_in()/...
+ *                     |
+ *                     |
+ *                netdev_input()  // new interface, Scatter/gather flat/iobs
+ *                     |
+ *                     |
+ *           pkt/ipv[4|6]_input()/...
+ *                     |
+ *                     |
+ *     NICs io vector receive(Orignal flat buffer)
+ *
+ * Input Parameters:
+ *   NULL
+ *
+ * Returned Value:
+ *  Pointer to default network driver on success; null on failure
+ *
+ ****************************************************************************/
+
+int netdev_input(FAR struct net_driver_s *dev,
+                 devif_poll_callback_t callback, bool reply)
+{
+  uint16_t llhdrlen = NET_LL_HDRLEN(dev);
+  unsigned int offset = CONFIG_NET_LL_GUARDSIZE - llhdrlen;
+  FAR uint8_t *buf = dev->d_buf;
+  unsigned int l3l4len;
+  int ret;
+
+  /* Prepare iob buffer */
+
+  ret = netdev_iob_prepare(dev, false, 0);
+  if (ret != OK)
+    {
+      return ret;
+    }
+
+  /* Copy l2 header to gruard area */
+
+  memcpy(dev->d_iob->io_data + offset, buf, llhdrlen);
+
+  /* Copy l3/l4 data to iob entry */
+
+  l3l4len = dev->d_len - llhdrlen;
+
+  ret = iob_trycopyin(dev->d_iob, buf + llhdrlen,
+                      l3l4len, 0, false);
+  if (ret == l3l4len)
+    {
+      /* Update device buffer to l2 start */
+
+      dev->d_buf = dev->d_iob->io_data + offset;
+
+      iob_update_pktlen(dev->d_iob, l3l4len);
+
+      ret = callback(dev);
+      if (dev->d_iob != NULL && reply)
+        {
+          if (ret == OK && dev->d_len > 0)
+            {
+              iob_copyout(buf + llhdrlen, dev->d_iob, dev->d_len, 0);
+              memcpy(buf, dev->d_iob->io_data + offset, llhdrlen);
+            }
+        }
+    }
+
+  netdev_iob_release(dev);
+
+  dev->d_buf = buf;
+
+  return ret;
+}

--- a/net/netdev/netdev_iob.c
+++ b/net/netdev/netdev_iob.c
@@ -1,0 +1,128 @@
+/****************************************************************************
+ * net/netdev/netdev_iob.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <debug.h>
+#include <errno.h>
+
+#include <nuttx/net/netdev.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: netdev_iob_prepare
+ *
+ * Description:
+ *   Prepare data buffer for a given NIC
+ *   The iob offset will be updated to l2 gruard size by default:
+ *  ----------------------------------------------------------------
+ *  |                     iob entry                                |
+ *  ---------------------------------------------------------------|
+ *  |<--- CONFIG_NET_LL_GUARDSIZE -->|<--- io_len/io_pktlen(0) --->|
+ *  ---------------------------------------------------------------|
+ *
+ * Assumptions:
+ *   The caller has locked the network.
+ *
+ * Returned Value:
+ *   A non-zero copy is returned on success.
+ *
+ ****************************************************************************/
+
+int netdev_iob_prepare(FAR struct net_driver_s *dev, bool throttled,
+                       unsigned int timeout)
+{
+  /* Prepare iob buffer */
+
+  if (dev->d_iob == NULL)
+    {
+      dev->d_iob = net_iobtimedalloc(false, timeout);
+      if (dev->d_iob == NULL && throttled)
+        {
+          dev->d_iob = net_iobtimedalloc(true, timeout);
+        }
+    }
+
+  if (dev->d_iob == NULL)
+    {
+      return -ENOMEM;
+    }
+
+  /* Set the device buffer to l2 */
+
+  dev->d_buf = &dev->d_iob->io_data[CONFIG_NET_LL_GUARDSIZE -
+                                    NET_LL_HDRLEN(dev)];
+
+  /* Update l2 gruard size */
+
+  iob_reserve(dev->d_iob, CONFIG_NET_LL_GUARDSIZE);
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: netdev_iob_clear
+ *
+ * Description:
+ *   Clean up buffer resources for a given NIC
+ *
+ * Assumptions:
+ *   The caller has locked the network and dev->d_iob has been
+ *   released or taken away.
+ *
+ ****************************************************************************/
+
+void netdev_iob_clear(FAR struct net_driver_s *dev)
+{
+  /* Clear the device buffer */
+
+  dev->d_iob = NULL;
+  dev->d_buf = NULL;
+  dev->d_len = 0;
+}
+
+/****************************************************************************
+ * Name: netdev_iob_release
+ *
+ * Description:
+ *   Release buffer resources for a given NIC
+ *
+ * Assumptions:
+ *   The caller has locked the network.
+ *
+ ****************************************************************************/
+
+void netdev_iob_release(FAR struct net_driver_s *dev)
+{
+  /* Release device buffer */
+
+  if (dev->d_iob != NULL)
+    {
+      iob_free_chain(dev->d_iob);
+      dev->d_iob = NULL;
+    }
+}

--- a/net/pkt/pkt_input.c
+++ b/net/pkt/pkt_input.c
@@ -36,20 +36,22 @@
 #include "pkt/pkt.h"
 
 /****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-#define PKTBUF ((FAR struct eth_hdr_s *)dev->d_buf)
-
-/****************************************************************************
- * Public Functions
+ * Private Functions
  ****************************************************************************/
 
 /****************************************************************************
- * Name: pkt_input
+ * Name: pkt_in
  *
  * Description:
  *   Handle incoming packet input
+ *
+ *   This is the iob buffer version of pkt_input(),
+ *   this function will support send/receive iob vectors directly between
+ *   the driver and l3/l4 stack to avoid unnecessary memory copies,
+ *   especially on hardware that supports Scatter/gather, which can
+ *   greatly improve performance
+ *   this function will uses d_iob as packets input which used by some
+ *   NICs such as celluler net driver.
  *
  * Input Parameters:
  *   dev - The device driver structure containing the received packet
@@ -65,10 +67,10 @@
  *
  ****************************************************************************/
 
-int pkt_input(struct net_driver_s *dev)
+static int pkt_in(FAR struct net_driver_s *dev)
 {
   FAR struct pkt_conn_s *conn;
-  FAR struct eth_hdr_s  *pbuf = PKTBUF;
+  FAR struct eth_hdr_s  *pbuf = ETHBUF;
   int ret = OK;
 
   conn = pkt_active(pbuf);
@@ -107,6 +109,40 @@ int pkt_input(struct net_driver_s *dev)
     }
 
   return ret;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: pkt_input
+ *
+ * Description:
+ *   Handle incoming packet input
+ *
+ * Input Parameters:
+ *   dev - The device driver structure containing the received packet
+ *
+ * Returned Value:
+ *   OK     The packet has been processed  and can be deleted
+ *  -EAGAIN There is a matching connection, but could not dispatch the packet
+ *          yet.  Useful when a packet arrives before a recv call is in
+ *          place.
+ *
+ * Assumptions:
+ *   The network is locked.
+ *
+ ****************************************************************************/
+
+int pkt_input(FAR struct net_driver_s *dev)
+{
+  if (dev->d_iob != NULL)
+    {
+      return pkt_in(dev);
+    }
+
+  return netdev_input(dev, pkt_in, false);
 }
 
 #endif /* CONFIG_NET && CONFIG_NET_PKT */

--- a/net/pkt/pkt_recvmsg.c
+++ b/net/pkt/pkt_recvmsg.c
@@ -115,6 +115,7 @@ static inline void pkt_add_recvlen(FAR struct pkt_recvfrom_s *pstate,
 static void pkt_recvfrom_newdata(FAR struct net_driver_s *dev,
                                  FAR struct pkt_recvfrom_s *pstate)
 {
+  unsigned int offset;
   size_t recvlen;
 
   if (dev->d_len > pstate->pr_buflen)
@@ -128,7 +129,10 @@ static void pkt_recvfrom_newdata(FAR struct net_driver_s *dev,
 
   /* Copy the new packet data into the user buffer */
 
-  memcpy(pstate->pr_buffer, dev->d_buf, recvlen);
+  offset = (dev->d_appdata - dev->d_iob->io_data) - dev->d_iob->io_offset;
+
+  recvlen = iob_copyout(pstate->pr_buffer, dev->d_iob, recvlen, offset);
+
   ninfo("Received %d bytes (of %d)\n", (int)recvlen, (int)dev->d_len);
 
   /* Update the accumulated size of the data read */

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -35,6 +35,7 @@
 #include <nuttx/mm/iob.h>
 #include <nuttx/net/ip.h>
 #include <nuttx/net/net.h>
+#include <nuttx/net/tcp.h>
 #include <nuttx/wqueue.h>
 
 #ifdef CONFIG_NET_TCP
@@ -1250,8 +1251,9 @@ uint16_t tcp_callback(FAR struct net_driver_s *dev,
  *
  ****************************************************************************/
 
-uint16_t tcp_datahandler(FAR struct tcp_conn_s *conn, FAR uint8_t *buffer,
-                         uint16_t nbytes);
+uint16_t tcp_datahandler(FAR struct net_driver_s *dev,
+                         FAR struct tcp_conn_s *conn,
+                         uint16_t offset);
 
 /****************************************************************************
  * Name: tcp_backlogcreate
@@ -2043,6 +2045,22 @@ int tcp_ioctl(FAR struct tcp_conn_s *conn, int cmd, unsigned long arg);
 #if CONFIG_NET_SEND_BUFSIZE > 0
 void tcp_sendbuffer_notify(FAR struct tcp_conn_s *conn);
 #endif /* CONFIG_NET_SEND_BUFSIZE */
+
+/****************************************************************************
+ * Name: tcpip_hdrsize
+ *
+ * Description:
+ *   Get the total size of L3 and L4 TCP header
+ *
+ * Input Parameters:
+ *   conn     The connection structure associated with the socket
+ *
+ * Returned Value:
+ *   the total size of L3 and L4 TCP header
+ *
+ ****************************************************************************/
+
+uint16_t tcpip_hdrsize(FAR struct tcp_conn_s *conn);
 
 #ifdef __cplusplus
 }

--- a/net/tcp/tcp_send_buffered.c
+++ b/net/tcp/tcp_send_buffered.c
@@ -596,7 +596,8 @@ static uint16_t psock_send_eventhandler(FAR struct net_driver_s *dev,
            * happen until the polling cycle completes).
            */
 
-          devif_iob_send(dev, TCP_WBIOB(wrb), sndlen, 0);
+          devif_iob_send(dev, TCP_WBIOB(wrb), sndlen,
+                         0, tcpip_hdrsize(conn));
 
           /* Reset the retransmission timer. */
 
@@ -882,7 +883,8 @@ static uint16_t psock_send_eventhandler(FAR struct net_driver_s *dev,
            * won't actually happen until the polling cycle completes).
            */
 
-          devif_iob_send(dev, TCP_WBIOB(wrb), sndlen, TCP_WBSENT(wrb));
+          devif_iob_send(dev, TCP_WBIOB(wrb), sndlen,
+                         TCP_WBSENT(wrb), tcpip_hdrsize(conn));
 
           /* Remember how much data we send out now so that we know
            * when everything has been acknowledged.  Just increment

--- a/net/tcp/tcp_send_unbuffered.c
+++ b/net/tcp/tcp_send_unbuffered.c
@@ -326,9 +326,8 @@ static uint16_t tcpsend_eventhandler(FAR struct net_driver_s *dev,
        * happen until the polling cycle completes).
        */
 
-      devif_send(dev,
-                 &pstate->snd_buffer[pstate->snd_acked],
-                 sndlen);
+      devif_send(dev, &pstate->snd_buffer[pstate->snd_acked],
+                 sndlen, tcpip_hdrsize(conn));
 
       /* Continue waiting */
 
@@ -409,7 +408,8 @@ static uint16_t tcpsend_eventhandler(FAR struct net_driver_s *dev,
            * happen until the polling cycle completes).
            */
 
-          devif_send(dev, &pstate->snd_buffer[pstate->snd_sent], sndlen);
+          devif_send(dev, &pstate->snd_buffer[pstate->snd_sent],
+                     sndlen, tcpip_hdrsize(conn));
 
           /* Update the amount of data sent (but not necessarily ACKed) */
 

--- a/net/udp/udp.h
+++ b/net/udp/udp.h
@@ -34,6 +34,7 @@
 #include <nuttx/semaphore.h>
 #include <nuttx/net/ip.h>
 #include <nuttx/net/net.h>
+#include <nuttx/net/udp.h>
 #include <nuttx/mm/iob.h>
 
 #ifdef CONFIG_NET_UDP_NOTIFIER
@@ -894,7 +895,7 @@ void udp_readahead_signal(FAR struct udp_conn_s *conn);
  *   When write buffer becomes empty, *all* of the workers waiting
  *   for that event data will be executed.  If there are multiple workers
  *   waiting for read-ahead data then only the first to execute will get the
- *   data.  Others will need to call tcp_writebuffer_notifier_setup() once
+ *   data.  Others will need to call udp_writebuffer_notifier_setup() once
  *   again.
  *
  * Input Parameters:
@@ -963,6 +964,22 @@ int udp_ioctl(FAR struct udp_conn_s *conn, int cmd, unsigned long arg);
 #if CONFIG_NET_SEND_BUFSIZE > 0
 void udp_sendbuffer_notify(FAR struct udp_conn_s *conn);
 #endif /* CONFIG_NET_SEND_BUFSIZE */
+
+/****************************************************************************
+ * Name: udpip_hdrsize
+ *
+ * Description:
+ *   Get the total size of L3 and L4 UDP header
+ *
+ * Input Parameters:
+ *   conn     The connection structure associated with the socket
+ *
+ * Returned Value:
+ *   the total size of L3 and L4 TCP header
+ *
+ ****************************************************************************/
+
+uint16_t udpip_hdrsize(FAR struct udp_conn_s *conn);
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/net/udp/udp_sendto_buffered.c
+++ b/net/udp/udp_sendto_buffered.c
@@ -152,6 +152,12 @@ static void sendto_writebuffer_release(FAR struct udp_conn_s *conn)
           wrb = (FAR struct udp_wrbuffer_s *)sq_remfirst(&conn->write_q);
           DEBUGASSERT(wrb != NULL);
 
+          /* Do not need to release wb_iob, the life cycle of wb_iob is
+           * handed over to the network device
+           */
+
+          wrb->wb_iob = NULL;
+
           udp_wrbuffer_release(wrb);
 
           /* Set up for the next packet transfer by setting the connection
@@ -399,6 +405,7 @@ static uint16_t sendto_eventhandler(FAR struct net_driver_s *dev,
   if (dev->d_sndlen <= 0 && (flags & UDP_NEWDATA) == 0 &&
       (flags & UDP_POLL) != 0 && !sq_empty(&conn->write_q))
     {
+      uint16_t udpiplen = udpip_hdrsize(conn);
       FAR struct udp_wrbuffer_s *wrb;
       size_t sndlen;
 
@@ -424,7 +431,7 @@ static uint16_t sendto_eventhandler(FAR struct net_driver_s *dev,
        * window size.
        */
 
-      sndlen = wrb->wb_iob->io_pktlen;
+      sndlen = wrb->wb_iob->io_pktlen - udpiplen;
       ninfo("wrb=%p sndlen=%zu\n", wrb, sndlen);
 
 #ifdef NEED_IPDOMAIN_SUPPORT
@@ -436,11 +443,16 @@ static uint16_t sendto_eventhandler(FAR struct net_driver_s *dev,
 
       sendto_ipselect(dev, conn);
 #endif
+
+      /* Release current device buffer and bypass the iob to l2 driver */
+
+      netdev_iob_release(dev);
+
       /* Then set-up to send that amount of data with the offset
        * corresponding to the size of the IP-dependent address structure.
        */
 
-      devif_iob_send(dev, wrb->wb_iob, sndlen, 0);
+      devif_iob_send(dev, wrb->wb_iob, sndlen, 0, udpiplen);
 
       /* Free the write buffer at the head of the queue and attempt to
        * setup the next transfer.
@@ -496,6 +508,7 @@ ssize_t psock_udp_sendto(FAR struct socket *psock, FAR const void *buf,
   FAR struct udp_wrbuffer_s *wrb;
   FAR struct udp_conn_s *conn;
   unsigned int timeout;
+  uint16_t udpiplen;
   bool nonblock;
   bool empty;
   int ret = OK;
@@ -737,6 +750,13 @@ ssize_t psock_udp_sendto(FAR struct socket *psock, FAR const void *buf,
           memcpy(&wrb->wb_dest, to, tolen);
         }
 
+      /* Skip l2/l3/l4 offset before copy */
+
+      udpiplen = udpip_hdrsize(conn);
+
+      iob_reserve(wrb->wb_iob, CONFIG_NET_LL_GUARDSIZE);
+      iob_update_pktlen(wrb->wb_iob, udpiplen);
+
       /* Copy the user data into the write buffer.  We cannot wait for
        * buffer space if the socket was opened non-blocking.
        */
@@ -744,7 +764,7 @@ ssize_t psock_udp_sendto(FAR struct socket *psock, FAR const void *buf,
       if (nonblock)
         {
           ret = iob_trycopyin(wrb->wb_iob, (FAR uint8_t *)buf,
-                              len, 0, false);
+                              len, udpiplen, false);
         }
       else
         {
@@ -757,7 +777,8 @@ ssize_t psock_udp_sendto(FAR struct socket *psock, FAR const void *buf,
            */
 
           blresult = net_breaklock(&count);
-          ret = iob_copyin(wrb->wb_iob, (FAR uint8_t *)buf, len, 0, false);
+          ret = iob_copyin(wrb->wb_iob, (FAR uint8_t *)buf,
+                           len, udpiplen, false);
           if (blresult >= 0)
             {
               net_restorelock(count);

--- a/net/udp/udp_sendto_unbuffered.c
+++ b/net/udp/udp_sendto_unbuffered.c
@@ -62,9 +62,7 @@
 
 struct sendto_s
 {
-#ifdef NEED_IPDOMAIN_SUPPORT
   FAR struct udp_conn_s *st_conn;     /* The UDP connection of interest */
-#endif
   FAR struct devif_callback_s *st_cb; /* Reference to callback instance */
   FAR struct net_driver_s *st_dev;    /* Driver that will perform the transmission */
   sem_t st_sem;                       /* Semaphore signals sendto completion */
@@ -206,7 +204,8 @@ static uint16_t sendto_eventhandler(FAR struct net_driver_s *dev,
 
           /* Copy the user data into d_appdata and send it */
 
-          devif_send(dev, pstate->st_buffer, pstate->st_buflen);
+          devif_send(dev, pstate->st_buffer,
+                     pstate->st_buflen, udpip_hdrsize(pstate->st_conn));
           pstate->st_sndlen = pstate->st_buflen;
         }
 
@@ -400,13 +399,11 @@ ssize_t psock_udp_sendto(FAR struct socket *psock, FAR const void *buf,
   state.st_buflen = len;
   state.st_buffer = buf;
 
-#ifdef NEED_IPDOMAIN_SUPPORT
   /* Save the reference to the conn structure if it will be needed for
    * asynchronous processing.
    */
 
   state.st_conn   = conn;
-#endif
 
   /* Check if the socket is connected */
 

--- a/net/utils/net_chksum.c
+++ b/net/utils/net_chksum.c
@@ -91,6 +91,51 @@ uint16_t chksum(uint16_t sum, FAR const uint8_t *data, uint16_t len)
 #endif /* CONFIG_NET_ARCH_CHKSUM */
 
 /****************************************************************************
+ * Name: chksum_iob
+ *
+ * Description:
+ *   Calculate the Internet checksum over an iob chain buffer.
+ *
+ * Input Parameters:
+ *   sum    - Partial calculations carried over from a previous call to
+ *            chksum().  This should be zero on the first time that check
+ *            sum is called.
+ *   iob    - An iob chain buffer over which the checksum is to be computed.
+ *   offset - Specifies the byte offset of the start of valid data.
+ *
+ * Returned Value:
+ *   The updated checksum value.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_MM_IOB
+uint16_t chksum_iob(uint16_t sum, FAR struct iob_s *iob, uint16_t offset)
+{
+  /* Skip to the I/O buffer containing the data offset */
+
+  while (iob != NULL && offset > iob->io_len)
+    {
+      offset -= iob->io_len;
+      iob     = iob->io_flink;
+    }
+
+  /* If the link pointer is not empty, loop to walk through all I/O buffer
+   * and accumulate the sum
+   */
+
+  while (iob != NULL)
+    {
+      sum = chksum(sum, iob->io_data + iob->io_offset + offset,
+                   iob->io_len - offset);
+      iob = iob->io_flink;
+      offset = 0;
+    }
+
+  return sum;
+}
+#endif /* CONFIG_MM_IOB */
+
+/****************************************************************************
  * Name: net_chksum
  *
  * Description:
@@ -122,6 +167,39 @@ uint16_t net_chksum(FAR uint16_t *data, uint16_t len)
   return HTONS(chksum(0, (uint8_t *)data, len));
 }
 #endif /* CONFIG_NET_ARCH_CHKSUM */
+
+/****************************************************************************
+ * Name: net_chksum_iob
+ *
+ * Description:
+ *   Calculate the Internet checksum over an iob chain buffer.
+ *
+ *   The Internet checksum is the one's complement of the one's complement
+ *   sum of all 16-bit words in the buffer.
+ *
+ *   See RFC1071.
+ *
+ *   If CONFIG_NET_ARCH_CHKSUM is defined, then this function must be
+ *   provided by architecture-specific logic.
+ *
+ * Input Parameters:
+ *   sum    - Partial calculations carried over from a previous call to
+ *            chksum().  This should be zero on the first time that check
+ *            sum is called.
+ *   iob    - An iob chain buffer over which the checksum is to be computed.
+ *   offset - Specifies the byte offset of the start of valid data.
+ *
+ * Returned Value:
+ *   The Internet checksum of the given iob chain buffer.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_MM_IOB
+uint16_t net_chksum_iob(uint16_t sum, FAR struct iob_s *iob, uint16_t offset)
+{
+  return HTONS(chksum_iob(sum, iob, offset));
+}
+#endif /* CONFIG_MM_IOB */
 
 /****************************************************************************
  * Name: net_chksum_adjust

--- a/net/utils/net_icmpchksum.c
+++ b/net/utils/net_icmpchksum.c
@@ -62,6 +62,22 @@ uint16_t icmp_chksum(FAR struct net_driver_s *dev, int len)
 #endif /* CONFIG_NET_ICMP */
 
 /****************************************************************************
+ * Name: icmp_chksum_iob
+ *
+ * Description:
+ *   Calculate the checksum of the ICMP message, the input can be an I/O
+ *   buffer chain
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_NET_ICMP) && defined(CONFIG_MM_IOB)
+uint16_t icmp_chksum_iob(FAR struct iob_s *iob)
+{
+  return net_chksum_iob(0, iob, 0);
+}
+#endif /* CONFIG_NET_ICMP */
+
+/****************************************************************************
  * Name: icmpv6_chksum
  *
  * Description:

--- a/net/utils/net_ipchksum.c
+++ b/net/utils/net_ipchksum.c
@@ -93,7 +93,17 @@ uint16_t ipv4_upperlayer_chksum(FAR struct net_driver_s *dev, uint8_t proto)
 
   /* Sum IP payload data. */
 
-  sum = chksum(sum, IPBUF(iphdrlen), upperlen);
+#ifdef CONFIG_MM_IOB
+  if (dev->d_iob != NULL)
+    {
+      sum = chksum_iob(sum, dev->d_iob, iphdrlen);
+    }
+  else
+#endif
+    {
+      sum = chksum(sum, IPBUF(iphdrlen), upperlen);
+    }
+
   return (sum == 0) ? 0xffff : HTONS(sum);
 }
 #endif /* CONFIG_NET_ARCH_CHKSUM */
@@ -160,7 +170,17 @@ uint16_t ipv6_upperlayer_chksum(FAR struct net_driver_s *dev,
 
   /* Sum IP payload data. */
 
-  sum = chksum(sum, IPBUF(iplen), upperlen);
+#ifdef CONFIG_MM_IOB
+  if (dev->d_iob != NULL)
+    {
+      sum = chksum_iob(sum, dev->d_iob, iplen);
+    }
+  else
+#endif
+    {
+      sum = chksum(sum, IPBUF(iplen), upperlen);
+    }
+
   return (sum == 0) ? 0xffff : HTONS(sum);
 }
 #endif /* CONFIG_NET_ARCH_CHKSUM */

--- a/net/utils/utils.h
+++ b/net/utils/utils.h
@@ -287,6 +287,19 @@ uint16_t icmp_chksum(FAR struct net_driver_s *dev, int len);
 #endif
 
 /****************************************************************************
+ * Name: icmp_chksum_iob
+ *
+ * Description:
+ *   Calculate the checksum of the ICMP message, the input can be an I/O
+ *   buffer chain
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_NET_ICMP) && defined(CONFIG_MM_IOB)
+uint16_t icmp_chksum_iob(FAR struct iob_s *iob);
+#endif /* CONFIG_NET_ICMP && CONFIG_MM_IOB */
+
+/****************************************************************************
  * Name: icmpv6_chksum
  *
  * Description:


### PR DESCRIPTION
## Summary

net/l2/l3/l4: add support of iob offload

net/l2/l3/l4: add support of iob offload

1. Add new config CONFIG_NET_LL_GUARDSIZE to isolation of l2 stack,
   which will benefit l3(IP) layer for multi-MAC(l2) implementation,
   especially in some NICs such as celluler net driver.

new configuration options: CONFIG_NET_LL_GUARDSIZE

CONFIG_NET_LL_GUARDSIZE will reserved l2 buffer header size of
network buffer to isolate the L2/L3 (MAC/IP) data on network layer,
which will be beneficial to L3 network layer protocol transparent
transmission and forwarding

------------------------------------------------------------
Layout of frist iob entry:

```
        iob_data (aligned by CONFIG_IOB_ALIGNMENT)
            |
            |                  io_offset(CONFIG_NET_LL_GUARDSIZE)
            |                                |
            -------------------------------------------------
      iob   |            Reserved            |    io_len    |
            -------------------------------------------------
```

-------------------------------------------------------------
Layout of different NICs implementation:

```
        iob_data (aligned by CONFIG_IOB_ALIGNMENT)
            |
            |                 io_offset(CONFIG_NET_LL_GUARDSIZE)
            |                                |
            -------------------------------------------------
 Ethernet   |       Reserved    | ETH_HDRLEN |    io_len    |
            ---------------------------------|---------------
 8021Q      |   Reserved  | ETH_8021Q_HDRLEN |    io_len    |
            ---------------------------------|---------------
 ipforward  |            Reserved            |    io_len    |
            -------------------------------------------------
```

--------------------------------------------------------------------

2. Support iob offload to l2 driver to avoid unnecessary memory copy

Support send/receive iob vectors directly between the NICs and l3/l4
stack to avoid unnecessary memory copies, especially on hardware that
supports Scatter/gather, which can greatly improve performance.

new interface to support iob offload:

```
  ------------------------------------------
  |    IOB version     |     original      |
  |----------------------------------------|
  |  devif_iob_poll()  |   devif_poll()    |
  |       ...          |       ...         |
  ------------------------------------------
```

--------------------------------------------------------------------

1> NIC hardware support Scatter/gather transfer

TX:

```
                tcp_poll()/udp_poll()/pkt_poll()/...(l3|l4)
                           /              \
                          /                \
devif_poll_[l3|l4]_connections()     devif_iob_send() (nocopy:udp/icmp/...)
           /                                   \      (copy:tcp)
          /                                     \
  devif_iob_poll("NIC"_txpoll)                callback() // "NIC"_txpoll
                                                  |
                            dev->d_iob:           |
                                                ---------------         ---------------
                             io_data       iob1 |  |          |    iob3 |  |          |
                                    \           ---------------         ---------------
                                  ---------------  |       --------------- |
                             iob0 |  |          |  |  iob2 |  |          | |
                                  ---------------  |       --------------- |
                                     \             |          /           /
                                        \          |       /           /
                                   ----------------------------------------------
                    NICs io vector |    |    |    |    |    |    |    |    |    |
                                   ----------------------------------------------
```

RX:

```
  [tcp|udp|icmp|...]ipv[4|6]_data_handler()(iob_concat/append to readahead)
                    |
                    |
      [tcp|udp|icmp|...]_ipv[4|6]_in()/...
                    |
                    |
          pkt/ipv[4/6]_input()/...
                    |
                    |
     NICs io vector receive(iov_base to each iobs)

```
--------------------------------------------------------------------

2> CONFIG_IOB_BUFSIZE is greater than MTU:

TX:

"(CONFIG_IOB_BUFSIZE) > (MAX_NETDEV_PKTSIZE + CONFIG_NET_GUARDSIZE + CONFIG_NET_LL_GUARDSIZE)"

```
                tcp_poll()/udp_poll()/pkt_poll()/...(l3|l4)
                           /              \
                          /                \
devif_poll_[l3|l4]_connections()     devif_iob_send() (nocopy:udp/icmp/...)
           /                                   \      (copy:tcp)
          /                                     \
  devif_iob_poll("NIC"_txpoll)                callback() // "NIC"_txpoll
                                                  |
                                             "NIC"_send()
                          (dev->d_iob->io_data[CONFIG_NET_LL_GUARDSIZE - NET_LL_HDRLEN(dev)])
```

RX:

```
  [tcp|udp|icmp|...]ipv[4|6]_data_handler()(iob_concat/append to readahead)
                    |
                    |
      [tcp|udp|icmp|...]_ipv[4|6]_in()/...
                    |
                    |
          pkt/ipv[4/6]_input()/...
                    |
                    |
     NICs io vector receive(iov_base to io_data)
```

--------------------------------------------------------------------

3> Compatible with all old flat buffer NICs

TX:
```
                tcp_poll()/udp_poll()/pkt_poll()/...(l3|l4)
                           /              \
                          /                \
devif_poll_[l3|l4]_connections()     devif_iob_send() (nocopy:udp/icmp/...)
           /                                   \      (copy:tcp)
          /                                     \
  devif_iob_poll(devif_poll_callback())  devif_poll_callback() /* new interface, gather iobs to flat buffer */
       /                                           \
      /                                             \
 devif_poll("NIC"_txpoll)                     "NIC"_send()(dev->d_buf)
```

RX:

```
  [tcp|udp|icmp|...]ipv[4|6]_data_handler()(iob_concat/append to readahead)
                    |
                    |
      [tcp|udp|icmp|...]_ipv[4|6]_in()/...
                    |
                    |
               netdev_input()  /* new interface, Scatter/gather flat/iob buffer */
                    |
                    |
          pkt/ipv[4|6]_input()/...
                    |
                    |
    NICs io vector receive(Orignal flat buffer)
```

3. Iperf passthrough on NuttX simulator:

```
  -------------------------------------------------
  |  Protocol      | Server | Client |            |
  |-----------------------------------------------|
  |  TCP           |  813   |   834  |  Mbits/sec |
  |  TCP(Offload)  | 1720   |  1100  |  Mbits/sec |
  |  UDP           |   22   |   757  |  Mbits/sec |
  |  UDP(Offload)  |   25   |  1250  |  Mbits/sec |
  -------------------------------------------------
```



Change-Id: I537b3f0330b4f3c859246c7003a3f38aa6266845
Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

NuttX net stack

## Testing

iperf passthrough test on simulator