### PR TITLE
net: Remove usrsock specific process from common code as much as possible

### DIFF
--- a/net/socket/getsockopt.c
+++ b/net/socket/getsockopt.c
@@ -33,7 +33,6 @@
 #include <errno.h>
 
 #include "socket/socket.h"
-#include "usrsock/usrsock.h"
 #include "utils/utils.h"
 
 /****************************************************************************
@@ -122,21 +121,11 @@ static int psock_socketlevel_option(FAR struct socket *psock, int option,
 
           /* Then return the timeout value to the caller */
 
-          net_dsec2timeval(timeo, (struct timeval *)value);
-          *value_len   = sizeof(struct timeval);
+          net_dsec2timeval(timeo, (FAR struct timeval *)value);
+          *value_len = sizeof(struct timeval);
           return OK;
         }
-    }
 
-#ifdef CONFIG_NET_USRSOCK
-  if (psock->s_type == SOCK_USRSOCK_TYPE)
-    {
-      return -ENOPROTOOPT;
-    }
-#endif
-
-  switch (option)
-    {
       case SO_ACCEPTCONN: /* Reports whether socket listening is enabled */
         {
           if (*value_len < sizeof(int))
@@ -295,6 +284,13 @@ int psock_getsockopt(FAR struct socket *psock, int level, int option,
   if (ret == -ENOPROTOOPT && level == SOL_SOCKET)
     {
       ret = psock_socketlevel_option(psock, option, value, value_len);
+    }
+
+  /* -ENOTTY really mean -ENOPROTOOPT, but skip the default action */
+
+  else if (ret == -ENOTTY)
+    {
+      ret = -ENOPROTOOPT;
     }
 
   return ret;

--- a/net/socket/net_sockif.c
+++ b/net/socket/net_sockif.c
@@ -38,6 +38,7 @@
 #include "pkt/pkt.h"
 #include "bluetooth/bluetooth.h"
 #include "ieee802154/ieee802154.h"
+#include "usrsock/usrsock.h"
 #include "socket/socket.h"
 
 /****************************************************************************
@@ -75,12 +76,12 @@ net_sockif(sa_family_t family, int type, int protocol)
   switch (family)
     {
 #ifdef HAVE_INET_SOCKETS
-#ifdef HAVE_PFINET_SOCKETS
+#  ifdef HAVE_PFINET_SOCKETS
     case PF_INET:
-#endif
-#ifdef HAVE_PFINET6_SOCKETS
+#  endif
+#  ifdef HAVE_PFINET6_SOCKETS
     case PF_INET6:
-#endif
+#  endif
       sockif = inet_sockif(family, type, protocol);
       break;
 #endif
@@ -130,6 +131,13 @@ net_sockif(sa_family_t family, int type, int protocol)
     default:
       nerr("ERROR: Address family unsupported: %d\n", family);
     }
+
+#ifdef CONFIG_NET_USRSOCK
+  if (sockif == NULL)
+    {
+      sockif = &g_usrsock_sockif;
+    }
+#endif
 
   return sockif;
 }

--- a/net/socket/setsockopt.c
+++ b/net/socket/setsockopt.c
@@ -38,7 +38,6 @@
 #include <netdev/netdev.h>
 
 #include "socket/socket.h"
-#include "usrsock/usrsock.h"
 #include "utils/utils.h"
 
 /****************************************************************************
@@ -134,17 +133,7 @@ static int psock_socketlevel_option(FAR struct socket *psock, int option,
 
           return OK;
         }
-    }
 
-#ifdef CONFIG_NET_USRSOCK
-  if (psock->s_type == SOCK_USRSOCK_TYPE)
-    {
-      return -ENOPROTOOPT;
-    }
-#endif
-
-  switch (option)
-    {
       case SO_BROADCAST:  /* Permits sending of broadcast messages */
       case SO_DEBUG:      /* Enables recording of debugging information */
       case SO_DONTROUTE:  /* Requests outgoing messages bypass standard routing */
@@ -327,6 +316,13 @@ int psock_setsockopt(FAR struct socket *psock, int level, int option,
   if (ret == -ENOPROTOOPT && level == SOL_SOCKET)
     {
       ret = psock_socketlevel_option(psock, option, value, value_len);
+    }
+
+  /* -ENOTTY really mean -ENOPROTOOPT, but skip the default action */
+
+  else if (ret == -ENOTTY)
+    {
+      ret = -ENOPROTOOPT;
     }
 
   return ret;

--- a/net/usrsock/usrsock.h
+++ b/net/usrsock/usrsock.h
@@ -41,11 +41,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* Internal socket type/domain for marking usrsock sockets */
-
-#define SOCK_USRSOCK_TYPE   0x7f
-#define PF_USRSOCK_DOMAIN   0x7f
-
 /* Internal event flags */
 
 #define USRSOCK_EVENT_CONNECT_READY (1 << 0)
@@ -84,7 +79,6 @@ struct usrsock_conn_s
 
   enum usrsock_conn_state_e state;   /* State of kernel<->daemon link for conn */
   bool          connected;           /* Socket has been connected */
-  int8_t        type;                /* Socket type (SOCK_STREAM, etc) */
   int16_t       usockid;             /* Connection number used for kernel<->daemon */
   uint16_t      flags;               /* Socket state flags */
 

--- a/net/usrsock/usrsock_accept.c
+++ b/net/usrsock/usrsock_accept.c
@@ -409,7 +409,6 @@ int usrsock_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
           if (ret >= 0)
             {
               newconn->connected = true;
-              newconn->type      = conn->type;
               newconn->crefs     = 1;
 
               newsock->s_type    = psock->s_type;

--- a/net/usrsock/usrsock_connect.c
+++ b/net/usrsock/usrsock_connect.c
@@ -172,7 +172,7 @@ int usrsock_connect(FAR struct socket *psock,
     }
 
   if (conn->connected &&
-      (conn->type == SOCK_STREAM || conn->type == SOCK_SEQPACKET))
+      (psock->s_type == SOCK_STREAM || psock->s_type == SOCK_SEQPACKET))
     {
       /* Already connected. */
 

--- a/net/usrsock/usrsock_poll.c
+++ b/net/usrsock/usrsock_poll.c
@@ -200,8 +200,8 @@ static int usrsock_pollsetup(FAR struct socket *psock,
 
   /* Stream sockets need to be connected or connecting (or listening). */
 
-  else if ((conn->type == SOCK_STREAM ||
-            conn->type == SOCK_SEQPACKET) &&
+  else if ((psock->s_type == SOCK_STREAM ||
+            psock->s_type == SOCK_SEQPACKET) &&
           !(conn->connected || conn->state ==
             USRSOCK_CONN_STATE_CONNECTING))
     {

--- a/net/usrsock/usrsock_recvmsg.c
+++ b/net/usrsock/usrsock_recvmsg.c
@@ -246,7 +246,7 @@ ssize_t usrsock_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
       goto errout_unlock;
     }
 
-  if (conn->type == SOCK_STREAM || conn->type == SOCK_SEQPACKET)
+  if (psock->s_type == SOCK_STREAM || psock->s_type == SOCK_SEQPACKET)
     {
       if (!conn->connected)
         {

--- a/net/usrsock/usrsock_sendmsg.c
+++ b/net/usrsock/usrsock_sendmsg.c
@@ -225,7 +225,7 @@ ssize_t usrsock_sendmsg(FAR struct socket *psock,
       goto errout_unlock;
     }
 
-  if (conn->type == SOCK_STREAM || conn->type == SOCK_SEQPACKET)
+  if (psock->s_type == SOCK_STREAM || psock->s_type == SOCK_SEQPACKET)
     {
       if (!conn->connected)
         {

--- a/net/usrsock/usrsock_setsockopt.c
+++ b/net/usrsock/usrsock_setsockopt.c
@@ -168,12 +168,13 @@ int usrsock_setsockopt(FAR struct socket *psock, int level, int option,
   int ret;
 
   DEBUGASSERT(conn);
-  if (level == SOL_SOCKET)
+
+  /* SO_[RCV|SND]TIMEO have to be handled locally to break the block i/o */
+
+  if (level == SOL_SOCKET && (option == SO_TYPE ||
+      option == SO_RCVTIMEO || option == SO_SNDTIMEO))
     {
-      if (option == SO_RCVTIMEO || option == SO_SNDTIMEO)
-        {
-          return -ENOPROTOOPT;
-        }
+      return -ENOPROTOOPT;
     }
 
   net_lock();
@@ -214,6 +215,13 @@ int usrsock_setsockopt(FAR struct socket *psock, int level, int option,
     }
 
   usrsock_teardown_request_callback(&state);
+
+  /* Skip the default socket option handler */
+
+  if (ret == -ENOPROTOOPT)
+    {
+      ret = -ENOTTY;
+    }
 
 errout_unlock:
   net_unlock();

--- a/net/usrsock/usrsock_socket.c
+++ b/net/usrsock/usrsock_socket.c
@@ -233,9 +233,6 @@ int usrsock_socket(int domain, int type, int protocol,
       goto errout_teardown_callback;
     }
 
-  psock->s_type = SOCK_USRSOCK_TYPE;
-  psock->s_domain = PF_USRSOCK_DOMAIN;
-  conn->type    = type;
   psock->s_conn = conn;
   conn->crefs   = 1;
 

--- a/net/usrsock/usrsock_sockif.c
+++ b/net/usrsock/usrsock_sockif.c
@@ -99,12 +99,7 @@ const struct sock_intf_s g_usrsock_sockif =
 
 static int usrsock_sockif_setup(FAR struct socket *psock, int protocol)
 {
-  int domain = psock->s_domain;
-  int type = psock->s_type;
   int ret;
-
-  psock->s_type = PF_UNSPEC;
-  psock->s_conn = NULL;
 
   /* Let the user socket logic handle the setup...
    *
@@ -115,7 +110,7 @@ static int usrsock_sockif_setup(FAR struct socket *psock, int protocol)
    * to open socket with kernel networking stack in this case.
    */
 
-  ret = usrsock_socket(domain, type, protocol, psock);
+  ret = usrsock_socket(psock->s_domain, psock->s_type, protocol, psock);
   if (ret == -ENETDOWN)
     {
       nwarn("WARNING: usrsock daemon is not running\n");


### PR DESCRIPTION
## Summary

## Impact
code refactor only

## Testing
sim:usrsocktest:
```
nsh> usrsocktest
Starting unit-tests...
Testing group "char_dev" =>
        Group "char_dev": [OK]
Testing group "no_daemon" =>
        Group "no_daemon": [OK]
Testing group "basic_daemon" =>
        Group "basic_daemon": [OK]
Testing group "basic_connect" =>
        Group "basic_connect": [OK]
Testing group "basic_connect_delay" =>
        Group "basic_connect_delay": [OK]
Testing group "no_block_connect" =>
        Group "no_block_connect": [OK]
Testing group "basic_send" =>
        Group "basic_send": [OK]
Testing group "no_block_send" =>
        Group "no_block_send": [OK]
Testing group "block_send" =>
        Group "block_send": [OK]
Testing group "no_block_recv" =>
        Group "no_block_recv": [OK]
Testing group "block_recv" =>
        Group "block_recv": [OK]
Testing group "remote_disconnect" =>
        Group "remote_disconnect": [OK]
Testing group "basic_setsockopt" =>
        Group "basic_setsockopt": [OK]
Testing group "basic_getsockopt" =>
        Group "basic_getsockopt": [OK]
Testing group "basic_getsockname" =>
        Group "basic_getsockname": [OK]
Testing group "wake_with_signal" =>
        Group "wake_with_signal": [OK]
Testing group "multithread" =>
        Group "multithread": [OK]
Unit-test groups done... OK:17, FAILED:0, TOTAL:17
 -- number of checks made: 3589
HEAP BEFORE TESTS:
             total       used       free    largest
Mem:      67108368     284560   66823808   66823744
HEAP AFTER TESTS:
             total       used       free    largest
Mem:      67108368     624912   66483456   66481472
nsh> 
```
