### PR TITLE
drivers/video: add support for V4L2 mmap-ed buffer

### DIFF
--- a/drivers/video/Kconfig
+++ b/drivers/video/Kconfig
@@ -58,6 +58,10 @@ config VIDEO_STREAM
 
 if VIDEO_STREAM
 
+config VIDEO_REQBUFS_COUNT_MAX
+	int "Maximum Video reqbuf buffers count"
+	default 3
+
 config VIDEO_SCENE_BACKLIGHT
 	bool "Enable backlight scene"
 	default y

--- a/drivers/video/video_framebuff.c
+++ b/drivers/video/video_framebuff.c
@@ -114,11 +114,6 @@ void video_framebuff_uninit(video_framebuff_t *fbuf)
 
 int video_framebuff_realloc_container(video_framebuff_t *fbuf, int sz)
 {
-  if (sz > V4L2_REQBUFS_COUNT_MAX)
-    {
-      return -EINVAL;
-    }
-
   if (fbuf->vbuf_alloced == NULL || fbuf->container_size != sz)
     {
       if (fbuf->container_size != sz)

--- a/include/nuttx/video/video.h
+++ b/include/nuttx/video/video.h
@@ -459,7 +459,7 @@ extern "C"
 
 /* MAX value of VIDIOC_REQBUFS count parameter */
 
-#define V4L2_REQBUFS_COUNT_MAX (256)
+#define V4L2_REQBUFS_COUNT_MAX CONFIG_VIDEO_REQBUFS_COUNT_MAX
 
 /* Buffer error flag */
 
@@ -751,7 +751,7 @@ struct v4l2_requestbuffers
 {
   uint32_t count;    /* The number of buffers requested.
                       * Supported maximum is
-                      * is V4L2_REQBUFS_COUNT_MAX(=256)
+                      * is V4L2_REQBUFS_COUNT_MAX
                       */
   uint32_t type;     /* enum #v4l2_buf_type */
   uint32_t memory;   /* enum #v4l2_memory */


### PR DESCRIPTION
## Summary
Added a naive implementation for V4L2_MEMORY_MMAP type buffers.
## Impact
Enhancement to NuttX video drivers
## Testing

