### PR TITLE
Corrects PIO errors and omissions for SAMA5D2

### DIFF
--- a/arch/arm/src/sama5/hardware/_sama5d2x_memorymap.h
+++ b/arch/arm/src/sama5/hardware/_sama5d2x_memorymap.h
@@ -517,9 +517,10 @@
 #define SAM_SFRBU_VBASE          (SAM_PERIPHC_VSECTION+SAM_SFRBU_OFFSET)
 #define SAM_CHIPID_VBASE         (SAM_PERIPHC_VSECTION+SAM_CHIPID_OFFSET)
 
-#define SAM_PIOA_VBASE           (SAM_PERIPHA_VSECTION+SAM_PIO_OFFSET)
-#define SAM_PIOB_VBASE           (SAM_PERIPHB_VSECTION+SAM_PIO_OFFSET)
-#define SAM_PIOC_VBASE           (SAM_PERIPHC_VSECTION+SAM_PIO_OFFSET)
+#define SAM_PIOA_VBASE           SAM_PIO_IOGROUPA_VBASE
+#define SAM_PIOB_VBASE           SAM_PIO_IOGROUPB_VBASE
+#define SAM_PIOC_VBASE           SAM_PIO_IOGROUPC_VBASE
+#define SAM_PIOD_VBASE           SAM_PIO_IOGROUPD_VBASE
 
 /* NuttX virtual base address
  *
@@ -883,3 +884,4 @@
  ****************************************************************************/
 
 #endif /* __ARCH_ARM_SRC_SAMA5_HARDWARE__SAMA5D2X_MEMORYMAP_H */
+

--- a/arch/arm/src/sama5/hardware/_sama5d2x_pio.h
+++ b/arch/arm/src/sama5/hardware/_sama5d2x_pio.h
@@ -40,7 +40,6 @@
 #define PIOB                       (1)
 #define PIOC                       (2)
 #define PIOD                       (3)
-#define PIOE                       (4)
 
 /* PIO register offsets *****************************************************/
 

--- a/arch/arm/src/sama5/sama5d2x_pio.c
+++ b/arch/arm/src/sama5/sama5d2x_pio.c
@@ -212,9 +212,9 @@ static uint32_t sam_configcommon(pio_pinset_t cfgset)
 
   if ((cfgset & PIO_CFG_DEGLITCH) != 0)
     {
-      if ((cfgset & PIO_CFG_DEGLITCH) != 0)
+      if ((cfgset & PIO_CFG_SLOWCLK) != 0)
         {
-          regval |= (PIO_CFGR_IFEN | PIO_CFGR_IFSCEN);
+          regval |= (PIO_CFGR_IFEN | PIO_CFG_SLOWCLK); 
         }
       else
         {
@@ -262,6 +262,32 @@ static uint32_t sam_configcommon(pio_pinset_t cfgset)
       break;
     }
 
+  /* Select Input Event selection.
+   * NOTE: Only applies to input pins
+   */
+
+  switch (cfgset & PIO_INT_MASK)
+    {
+      default:
+      case PIO_INT_NONE:
+        break;
+      case PIO_INT_FALLING:
+        regval |= PIO_CFGR_EVTSEL_FALLING;
+        break;
+      case PIO_INT_RISING:
+        regval |= PIO_CFGR_EVTSEL_RISING;
+        break;
+      case PIO_INT_BOTHEDGES:
+        regval |= PIO_CFGR_EVTSEL_BOTH;
+        break;
+      case PIO_INT_LOWLEVEL:
+        regval |= PIO_CFGR_EVTSEL_LOW;
+        break;
+      case PIO_INT_HIGHLEVEL:
+        regval |= PIO_CFGR_EVTSEL_HIGH;
+        break;
+    }
+
   return regval;
 }
 
@@ -285,7 +311,7 @@ static inline int sam_configinput(uintptr_t base, uint32_t pin,
   /* Select GPIO input */
 
   regval = sam_configcommon(cfgset);
-  regval = (PIO_CFGR_FUNC_GPIO | PIO_CFGR_DIR_INPUT);
+  regval |= (PIO_CFGR_FUNC_GPIO | PIO_CFGR_DIR_INPUT);
 
   /* Clear some output only bits.  Mostly this just simplifies debug. */
 


### PR DESCRIPTION
## Summary
4th attempt.... :)

Fixes PIO definitions for ATSAMA5D2

## Impact
none

## Testing
Used GPIO testing example app to check GPIO operation, inputs, outputs and interrupts, using custom board

