### PR TITLE
Minor fix for vsprintf and stream

### DIFF
--- a/include/nuttx/streams.h
+++ b/include/nuttx/streams.h
@@ -43,10 +43,10 @@
 #define lib_stream_puts(stream, buf, len) \
         ((FAR struct lib_outstream_s *)(stream))->puts( \
         (FAR struct lib_outstream_s *)(stream), buf, len)
-#define lib_stream_putc(stream, ch) \
-        ((FAR struct lib_outstream_s *)(stream))->putc( \
+#define lib_stream_put(stream, ch) \
+        ((FAR struct lib_outstream_s *)(stream))->put( \
         (FAR struct lib_outstream_s *)(stream), ch)
-#define lib_stream_getc(stream) \
+#define lib_stream_get(stream) \
         ((FAR struct lib_instream_s *)(stream))->get( \
         (FAR struct lib_instream_s *)(stream))
 #define lib_stream_gets(stream, buf, len) \

--- a/libs/libc/hex2bin/lib_hex2bin.c
+++ b/libs/libc/hex2bin/lib_hex2bin.c
@@ -247,17 +247,17 @@ static int readstream(FAR struct lib_instream_s *instream,
 
   /* Skip until the beginning of line start code is encountered */
 
-  ch = lib_stream_getc(instream);
+  ch = lib_stream_get(instream);
   while (ch != RECORD_STARTCODE && ch != EOF)
     {
-      ch = lib_stream_getc(instream);
+      ch = lib_stream_get(instream);
     }
 
   /* Skip over the startcode */
 
   if (ch != EOF)
     {
-      ch = lib_stream_getc(instream);
+      ch = lib_stream_get(instream);
     }
 
   /* Then read, verify, and buffer until the end of line is encountered */
@@ -286,7 +286,7 @@ static int readstream(FAR struct lib_instream_s *instream,
 
       /* Read the next character from the input stream */
 
-      ch = lib_stream_getc(instream);
+      ch = lib_stream_get(instream);
     }
 
   /* Some error occurred: Unexpected EOF, line too long, or bad character in

--- a/libs/libc/misc/lib_kbddecode.c
+++ b/libs/libc/misc/lib_kbddecode.c
@@ -139,7 +139,7 @@ int kbd_decode(FAR struct lib_instream_s *stream,
 
   /* No, ungotten characters.  Check for the beginning of an ESC sequence. */
 
-  ch = lib_stream_getc(stream);
+  ch = lib_stream_get(stream);
   if (ch == EOF)
     {
       /* End of file/stream */
@@ -163,7 +163,7 @@ int kbd_decode(FAR struct lib_instream_s *stream,
 
   /* Check for ESC-[ */
 
-  ch = lib_stream_getc(stream);
+  ch = lib_stream_get(stream);
   if (ch == EOF)
     {
       /* End of file/stream.  Return the escape character now.  We will
@@ -189,7 +189,7 @@ int kbd_decode(FAR struct lib_instream_s *stream,
 
   /* Get and verify the special keyboard data to decode */
 
-  ch = lib_stream_getc(stream);
+  ch = lib_stream_get(stream);
   if (ch == EOF)
     {
       /* End of file/stream.  Unget everything and return the ESC character.
@@ -216,7 +216,7 @@ int kbd_decode(FAR struct lib_instream_s *stream,
 
   /* Check for the final semicolon */
 
-  ch = lib_stream_getc(stream);
+  ch = lib_stream_get(stream);
   if (ch == EOF)
     {
       /* End of file/stream.  Unget everything and return the ESC character.

--- a/libs/libc/misc/lib_slcddecode.c
+++ b/libs/libc/misc/lib_slcddecode.c
@@ -177,7 +177,7 @@ enum slcdret_e slcd_decode(FAR struct lib_instream_s *stream,
 
   /* No, ungotten characters.  Get the next character from the buffer. */
 
-  ch = lib_stream_getc(stream);
+  ch = lib_stream_get(stream);
   if (ch == EOF)
     {
       /* End of file/stream (or perhaps an I/O error) */
@@ -201,7 +201,7 @@ enum slcdret_e slcd_decode(FAR struct lib_instream_s *stream,
 
   /* Get the next character from the buffer */
 
-  ch = lib_stream_getc(stream);
+  ch = lib_stream_get(stream);
   if (ch == EOF)
     {
       /* End of file/stream.  Return the escape character now.  We will
@@ -230,7 +230,7 @@ enum slcdret_e slcd_decode(FAR struct lib_instream_s *stream,
 
   /* Get the next character from the buffer */
 
-  ch = lib_stream_getc(stream);
+  ch = lib_stream_get(stream);
   if (ch == EOF)
     {
       /* End of file/stream.  Return the ESC now; return the following
@@ -278,7 +278,7 @@ enum slcdret_e slcd_decode(FAR struct lib_instream_s *stream,
 
       /* Get the next character from the buffer */
 
-      ch = lib_stream_getc(stream);
+      ch = lib_stream_get(stream);
       if (ch == EOF)
         {
           /* End of file/stream.  Return the ESC now; return the following
@@ -311,7 +311,7 @@ enum slcdret_e slcd_decode(FAR struct lib_instream_s *stream,
 
       /* Get the next character from the buffer */
 
-      ch = lib_stream_getc(stream);
+      ch = lib_stream_get(stream);
       if (ch == EOF)
         {
           /* End of file/stream.  Return the ESC now; return the following

--- a/libs/libc/stdio/lib_dtoa_engine.c
+++ b/libs/libc/stdio/lib_dtoa_engine.c
@@ -149,7 +149,7 @@ int __dtoa_engine(double x, FAR struct dtoa_s *dtoa, int max_digits,
 
       /* Now convert mantissa to decimal. */
 
-      uint64_t mant = (uint64_t) x;
+      uint64_t mant = (uint64_t)x;
       uint64_t decimal = MIN_MANT_INT;
 
       /* Compute digits */

--- a/libs/libc/stdio/lib_libvscanf.c
+++ b/libs/libc/stdio/lib_libvscanf.c
@@ -256,7 +256,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
 
   /* Get first character, we keep always the next character in c */
 
-  c = lib_stream_getc(obj);
+  c = lib_stream_get(obj);
 
   while (fmt_char(fmt))
     {
@@ -266,7 +266,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
         {
           while (isspace(c))
             {
-              c = lib_stream_getc(obj);
+              c = lib_stream_get(obj);
             }
         }
 
@@ -366,7 +366,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
 
               while (isspace(c))
                 {
-                  c = lib_stream_getc(obj);
+                  c = lib_stream_get(obj);
                 }
 
               /* But we only perform the data conversion is we still have
@@ -390,7 +390,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
                         }
 
                       fwidth++;
-                      c = lib_stream_getc(obj);
+                      c = lib_stream_get(obj);
                     }
 
                   if (!noassign)
@@ -445,7 +445,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
                         }
 
                       fwidth++;
-                      c = lib_stream_getc(obj);
+                      c = lib_stream_get(obj);
                     }
 
                   if (!fwidth)
@@ -509,7 +509,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
                         }
 
                       fwidth++;
-                      c = lib_stream_getc(obj);
+                      c = lib_stream_get(obj);
                     }
 
                   if (fwidth != width)
@@ -582,7 +582,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
 
               while (isspace(c))
                 {
-                  c = lib_stream_getc(obj);
+                  c = lib_stream_get(obj);
                 }
 
               /* But we only perform the data conversion if we still have
@@ -641,7 +641,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
                           if (!stopconv)
                             {
                               tmp[fwidth++] = c;
-                              c = lib_stream_getc(obj);
+                              c = lib_stream_get(obj);
                             }
                         }
 
@@ -691,7 +691,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
                           if (!stopconv)
                             {
                               tmp[fwidth++] = c;
-                              c = lib_stream_getc(obj);
+                              c = lib_stream_get(obj);
                             }
                         }
 
@@ -716,7 +716,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
                           if (!stopconv)
                             {
                               tmp[fwidth++] = c;
-                              c = lib_stream_getc(obj);
+                              c = lib_stream_get(obj);
                             }
                         }
 
@@ -741,7 +741,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
                           if (!stopconv)
                             {
                               tmp[fwidth++] = c;
-                              c = lib_stream_getc(obj);
+                              c = lib_stream_get(obj);
                             }
                         }
 
@@ -796,7 +796,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
                           if (!stopconv)
                             {
                               tmp[fwidth++] = c;
-                              c = lib_stream_getc(obj);
+                              c = lib_stream_get(obj);
                             }
                         }
                       break;
@@ -954,7 +954,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
 
               while (isspace(c))
                 {
-                  c = lib_stream_getc(obj);
+                  c = lib_stream_get(obj);
                 }
 
               /* But we only perform the data conversion is we still have
@@ -1038,7 +1038,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
                       if (!stopconv)
                         {
                           tmp[fwidth++] = c;
-                          c = lib_stream_getc(obj);
+                          c = lib_stream_get(obj);
                         }
                     }
 
@@ -1168,7 +1168,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
                 }
               else
                 {
-                  c = lib_stream_getc(obj);
+                  c = lib_stream_get(obj);
                 }
             }
 
@@ -1188,7 +1188,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
 
           while (isspace(c))
             {
-              c = lib_stream_getc(obj);
+              c = lib_stream_get(obj);
             }
 #endif
 
@@ -1201,7 +1201,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
           else
             {
               fmt++;
-              c = lib_stream_getc(obj);
+              c = lib_stream_get(obj);
             }
         }
       else

--- a/libs/libc/stdio/lib_libvsprintf.c
+++ b/libs/libc/stdio/lib_libvsprintf.c
@@ -459,8 +459,11 @@ static int vsprintf_internal(FAR struct lib_outstream_s *stream,
                 {
                   flags |= FL_REPD_TYPE;
                 }
+              else
+                {
+                  flags |= FL_LONG;
+                }
 
-              flags |= FL_LONG;
               flags &= ~FL_SHORT;
               continue;
             }
@@ -471,8 +474,11 @@ static int vsprintf_internal(FAR struct lib_outstream_s *stream,
                 {
                   flags |= FL_REPD_TYPE;
                 }
+              else
+                {
+                  flags |= FL_SHORT;
+                }
 
-              flags |= FL_SHORT;
               flags &= ~FL_LONG;
               continue;
             }

--- a/libs/libc/stdio/lib_libvsprintf.c
+++ b/libs/libc/stdio/lib_libvsprintf.c
@@ -67,14 +67,6 @@
 #  undef CONFIG_LIBC_LONG_LONG
 #endif
 
-/* [Re]define putc() */
-
-#ifdef putc
-#  undef putc
-#endif
-
-#define putc(c,stream)  (stream)->put(stream, c)
-
 /* Order is relevant here and matches order in format string */
 
 #define FL_ZFILL           0x0001
@@ -229,10 +221,10 @@ static int vsprintf_internal(FAR struct lib_outstream_s *stream,
 #ifdef CONFIG_LIBC_NUMBERED_ARGS
           if (stream != NULL)
             {
-              putc(c, stream);
+              lib_stream_put(stream, c);
             }
 #else
-          putc(c, stream);
+          lib_stream_put(stream, c);
 #endif
         }
 
@@ -661,7 +653,7 @@ flt_oper:
                     {
                       do
                         {
-                          putc(' ', stream);
+                          lib_stream_put(stream, ' ');
                         }
                       while (--width);
                     }
@@ -673,7 +665,7 @@ flt_oper:
 
               if (sign)
                 {
-                  putc(sign, stream);
+                  lib_stream_put(stream, sign);
                 }
 
               p = "inf";
@@ -692,7 +684,7 @@ flt_oper:
                       ndigs += 'I' - 'i';
                     }
 
-                  putc(ndigs, stream);
+                  lib_stream_put(stream, ndigs);
                   p++;
                 }
 
@@ -766,21 +758,21 @@ flt_oper:
             {
               while (width)
                 {
-                  putc(' ', stream);
+                  lib_stream_put(stream, ' ');
                   width--;
                 }
             }
 
           if (sign != 0)
             {
-              putc(sign, stream);
+              lib_stream_put(stream, sign);
             }
 
           if ((flags & FL_LPAD) == 0)
             {
               while (width)
                 {
-                  putc('0', stream);
+                  lib_stream_put(stream, '0');
                   width--;
                 }
             }
@@ -804,7 +796,7 @@ flt_oper:
 
                   if (n == -1)
                     {
-                      putc('.', stream);
+                      lib_stream_put(stream, '.');
                     }
 
                   /* Pull digits from buffer when in-range, otherwise use 0 */
@@ -822,13 +814,13 @@ flt_oper:
                     {
                       if ((flags & FL_ALT) != 0 && n == -1)
                         {
-                          putc('.', stream);
+                          lib_stream_put(stream, '.');
                         }
 
                       break;
                     }
 
-                  putc(out, stream);
+                  lib_stream_put(stream, out);
                 }
               while (1);
 
@@ -838,7 +830,7 @@ flt_oper:
                   out = '1';
                 }
 
-              putc(out, stream);
+              lib_stream_put(stream, out);
             }
           else
             {
@@ -852,25 +844,25 @@ flt_oper:
                   _dtoa.flags &= ~DTOA_CARRY;
                 }
 
-              putc(_dtoa.digits[0], stream);
+              lib_stream_put(stream, _dtoa.digits[0]);
               if (prec > 0)
                 {
                   uint8_t pos;
 
-                  putc('.', stream);
+                  lib_stream_put(stream, '.');
                   for (pos = 1; pos < 1 + prec; pos++)
                     {
-                      putc(pos < ndigs ? _dtoa.digits[pos] : '0', stream);
+                      lib_stream_put(stream, pos < ndigs ? _dtoa.digits[pos] : '0');
                     }
                 }
               else if ((flags & FL_ALT) != 0)
                 {
-                  putc('.', stream);
+                  lib_stream_put(stream, '.');
                 }
 
               /* Exponent */
 
-              putc(flags & FL_FLTUPP ? 'E' : 'e', stream);
+              lib_stream_put(stream, flags & FL_FLTUPP ? 'E' : 'e');
               ndigs = '+';
               if (exp < 0 || (exp == 0 && (_dtoa.flags & DTOA_CARRY) != 0))
                 {
@@ -878,7 +870,7 @@ flt_oper:
                   ndigs = '-';
                 }
 
-              putc(ndigs, stream);
+              lib_stream_put(stream, ndigs);
               for (ndigs = '0'; exp >= 10; exp -= 10)
                 {
                   ndigs += 1;
@@ -890,17 +882,17 @@ flt_oper:
                 {
                   if (ndigs >= 'd')
                     {
-                      putc(((ndigs - '0') / 100) + '0', stream);
+                      lib_stream_put(stream, ((ndigs - '0') / 100) + '0');
                       ndigs = (ndigs - '0') % 100 + '0';
                     }
                   else if (ndigs >= ':')
                     {
-                      putc(((ndigs - '0') / 10) + '0', stream);
+                      lib_stream_put(stream, ((ndigs - '0') / 10) + '0');
                       ndigs = (ndigs - '0') % 10 + '0';
                     }
                   else if(ndigs >= '0')
                     {
-                      putc(ndigs, stream);
+                      lib_stream_put(stream, ndigs);
                       break;
                     }
                   else
@@ -909,7 +901,7 @@ flt_oper:
                     }
                  }
 
-               putc('0' + exp, stream);
+               lib_stream_put(stream, '0' + exp);
             }
 
           goto tail;
@@ -972,14 +964,14 @@ str_lpad:
             {
               while (size < width)
                 {
-                  putc(' ', stream);
+                  lib_stream_put(stream, ' ');
                   width--;
                 }
             }
 
           while (size)
             {
-              putc(*pnt++, stream);
+              lib_stream_put(stream, *pnt++);
               if (width != 0)
                 {
                   width -= 1;
@@ -1189,7 +1181,7 @@ str_lpad:
                           pnt = symbol->sym_name;
                           while (*pnt != '\0')
                             {
-                              putc(*pnt++, stream);
+                              lib_stream_put(stream, *pnt++);
                             }
 
                           if (c == 'S')
@@ -1234,8 +1226,8 @@ str_lpad:
               break;
 
             default:
-              putc('%', stream);
-              putc(c, stream);
+              lib_stream_put(stream, '%');
+              lib_stream_put(stream, c);
               continue;
             }
 
@@ -1303,7 +1295,7 @@ str_lpad:
 
           while (len < width)
             {
-              putc(' ', stream);
+              lib_stream_put(stream, ' ');
               len++;
             }
         }
@@ -1312,10 +1304,10 @@ str_lpad:
 
       if ((flags & FL_ALT) != 0)
         {
-          putc('0', stream);
+          lib_stream_put(stream, '0');
           if ((flags & FL_ALTHEX) != 0)
             {
-              putc(flags & FL_ALTUPP ? 'X' : 'x', stream);
+              lib_stream_put(stream, flags & FL_ALTUPP ? 'X' : 'x');
             }
         }
       else if ((flags & (FL_NEGATIVE | FL_PLUS | FL_SPACE)) != 0)
@@ -1331,18 +1323,18 @@ str_lpad:
               z = '-';
             }
 
-          putc(z, stream);
+          lib_stream_put(stream, z);
         }
 
       while (prec > c)
         {
-          putc('0', stream);
+          lib_stream_put(stream, '0');
           prec--;
         }
 
       while (c)
         {
-          putc(buf[--c], stream);
+          lib_stream_put(stream, buf[--c]);
         }
 
 tail:
@@ -1351,7 +1343,7 @@ tail:
 
       while (width)
         {
-          putc(' ', stream);
+          lib_stream_put(stream, ' ');
           width--;
         }
     }

--- a/libs/libc/stdio/lib_libvsprintf.c
+++ b/libs/libc/stdio/lib_libvsprintf.c
@@ -73,7 +73,7 @@
 #  undef putc
 #endif
 
-#define putc(c,stream)  (total_len++, (stream)->put(stream, c))
+#define putc(c,stream)  (stream)->put(stream, c)
 
 /* Order is relevant here and matches order in format string */
 
@@ -201,9 +201,9 @@ static int vsprintf_internal(FAR struct lib_outstream_s *stream,
   FAR const char *pnt;
   size_t size;
   unsigned char len;
-  int total_len = 0;
 
 #ifdef CONFIG_LIBC_NUMBERED_ARGS
+  int total_len = 0;
   int argnumber = 0;
 #endif
 
@@ -1357,7 +1357,11 @@ tail:
     }
 
 ret:
-  return total_len;
+#ifdef CONFIG_LIBC_NUMBERED_ARGS
+  return stream ? stream->nput : total_len;
+#else
+  return stream->nput;
+#endif
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

- libc/stream: Rename lib_stream_[put|get]c to lib_stream_[put|get]
- libc/stdio: Don't set FL_[LONG|SHORT] repeatly in vsprintf_internal 
- libc/stdio: Don't count the output length repeatly in vsprintf_internal
- libc/stdio: Remove putc macro from lib_libvsprintf.c

## Impact

Minor, code refactor.

## Testing
sim:nsh
