### PR TITLE
net/devif: add common funtion to build L2 headers before sending

### DIFF
--- a/arch/arm/src/imx6/imx_enet.c
+++ b/arch/arm/src/imx6/imx_enet.c
@@ -705,53 +705,19 @@ static int imx_txpoll(struct net_driver_s *dev)
   struct imx_driver_s *priv =
     (struct imx_driver_s *)dev->d_private;
 
-  /* If the polling resulted in data that should be sent out on the network,
-   * the field d_len is set to a value > 0.
+  /* Send the packet */
+
+  imx_transmit(priv);
+  priv->dev.d_buf = (uint8_t *)
+    imx_swap32((uint32_t)priv->txdesc[priv->txhead].data);
+
+  /* Check if there is room in the device to hold another packet. If
+   * not, return a non-zero value to terminate the poll.
    */
 
-  ninfo("Poll result: d_len=%d\n", priv->dev.d_len);
-
-  if (priv->dev.d_len > 0)
+  if (imx_txringfull(priv))
     {
-      /* Look up the destination MAC address and add it to the Ethernet
-       * header.
-       */
-
-#ifdef CONFIG_NET_IPv4
-#ifdef CONFIG_NET_IPv6
-      if (IFF_IS_IPv4(priv->dev.d_flags))
-#endif
-        {
-          arp_out(&priv->dev);
-        }
-#endif /* CONFIG_NET_IPv4 */
-
-#ifdef CONFIG_NET_IPv6
-#ifdef CONFIG_NET_IPv4
-      else
-#endif
-        {
-          neighbor_out(&priv->dev);
-        }
-#endif /* CONFIG_NET_IPv6 */
-
-      if (!devif_loopback(&priv->dev))
-        {
-          /* Send the packet */
-
-          imx_transmit(priv);
-          priv->dev.d_buf = (uint8_t *)
-            imx_swap32((uint32_t)priv->txdesc[priv->txhead].data);
-
-          /* Check if there is room in the device to hold another packet. If
-           * not, return a non-zero value to terminate the poll.
-           */
-
-          if (imx_txringfull(priv))
-            {
-              return -EBUSY;
-            }
-        }
+      return -EBUSY;
     }
 
   /* If zero is returned, the polling will continue until

--- a/arch/arm/src/imxrt/imxrt_flexcan.c
+++ b/arch/arm/src/imxrt/imxrt_flexcan.c
@@ -772,23 +772,20 @@ static int imxrt_txpoll(struct net_driver_s *dev)
 
   if (priv->dev.d_len > 0)
     {
-      if (!devif_loopback(&priv->dev))
+      imxrt_txdone(priv);
+
+      /* Send the packet */
+
+      imxrt_transmit(priv);
+
+      /* Check if there is room in the device to hold another packet. If
+       * not, return a non-zero value to terminate the poll.
+       */
+
+      if (imxrt_txringfull(priv))
         {
-          imxrt_txdone(priv);
-
-          /* Send the packet */
-
-          imxrt_transmit(priv);
-
-          /* Check if there is room in the device to hold another packet. If
-           * not, return a non-zero value to terminate the poll.
-           */
-
-          if (imxrt_txringfull(priv))
-            {
-              spin_unlock_irqrestore(NULL, flags);
-              return -EBUSY;
-            }
+          spin_unlock_irqrestore(NULL, flags);
+          return -EBUSY;
         }
     }
 

--- a/arch/arm/src/kinetis/kinetis_enet.c
+++ b/arch/arm/src/kinetis/kinetis_enet.c
@@ -531,51 +531,19 @@ static int kinetis_txpoll(struct net_driver_s *dev)
   struct kinetis_driver_s *priv =
     (struct kinetis_driver_s *)dev->d_private;
 
-  /* If the polling resulted in data that should be sent out on the network,
-   * the field d_len is set to a value > 0.
+  /* Send the packet */
+
+  kinetis_transmit(priv);
+  priv->dev.d_buf = (uint8_t *)
+      kinesis_swap32((uint32_t)priv->txdesc[priv->txhead].data);
+
+  /* Check if there is room in the device to hold another packet.
+   * If not, return a non-zero value to terminate the poll.
    */
 
-  if (priv->dev.d_len > 0)
+  if (kinetis_txringfull(priv))
     {
-      /* Look up the destination MAC address and add it to the Ethernet
-       * header.
-       */
-
-#ifdef CONFIG_NET_IPv4
-#ifdef CONFIG_NET_IPv6
-      if (IFF_IS_IPv4(priv->dev.d_flags))
-#endif
-        {
-          arp_out(&priv->dev);
-        }
-#endif /* CONFIG_NET_IPv4 */
-
-#ifdef CONFIG_NET_IPv6
-#ifdef CONFIG_NET_IPv4
-      else
-#endif
-        {
-          neighbor_out(&priv->dev);
-        }
-#endif /* CONFIG_NET_IPv6 */
-
-      if (!devif_loopback(&priv->dev))
-        {
-          /* Send the packet */
-
-          kinetis_transmit(priv);
-          priv->dev.d_buf = (uint8_t *)
-              kinesis_swap32((uint32_t)priv->txdesc[priv->txhead].data);
-
-          /* Check if there is room in the device to hold another packet.
-           * If not, return a non-zero value to terminate the poll.
-           */
-
-          if (kinetis_txringfull(priv))
-            {
-              return -EBUSY;
-            }
-        }
+      return -EBUSY;
     }
 
   /* If zero is returned, the polling will continue until all connections

--- a/arch/arm/src/kinetis/kinetis_flexcan.c
+++ b/arch/arm/src/kinetis/kinetis_flexcan.c
@@ -795,26 +795,23 @@ static int kinetis_txpoll(struct net_driver_s *dev)
 
   if (priv->dev.d_len > 0)
     {
-      if (!devif_loopback(&priv->dev))
+      kinetis_txdone(priv);
+
+      /* Send the packet */
+
+      kinetis_transmit(priv);
+
+      /* Check if there is room in the device to hold another packet. If
+       * not, return a non-zero value to terminate the poll.
+       */
+
+      if ((getreg32(priv->base + KINETIS_CAN_ESR2_OFFSET) &
+          (CAN_ESR2_IMB | CAN_ESR2_VPS)) ==
+          (CAN_ESR2_IMB | CAN_ESR2_VPS))
         {
-          kinetis_txdone(priv);
-
-          /* Send the packet */
-
-          kinetis_transmit(priv);
-
-          /* Check if there is room in the device to hold another packet. If
-           * not, return a non-zero value to terminate the poll.
-           */
-
-          if ((getreg32(priv->base + KINETIS_CAN_ESR2_OFFSET) &
-              (CAN_ESR2_IMB | CAN_ESR2_VPS)) ==
-              (CAN_ESR2_IMB | CAN_ESR2_VPS))
+          if (kinetis_txringfull(priv))
             {
-              if (kinetis_txringfull(priv))
-                {
-                  return -EBUSY;
-                }
+              return -EBUSY;
             }
         }
     }

--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_can.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_can.c
@@ -1049,20 +1049,17 @@ static int lpc17can_txpoll(struct net_driver_s *dev)
 
   if (priv->dev.d_len > 0)
     {
-      if (!devif_loopback(&priv->dev))
+      /* Send the packet */
+
+      lpc17can_transmit(priv);
+
+      /* Check if there is room in the device to hold another packet. If
+       * not, return a non-zero value to terminate the poll.
+       */
+
+      if (lpc17can_txringfull(priv))
         {
-          /* Send the packet */
-
-          lpc17can_transmit(priv);
-
-          /* Check if there is room in the device to hold another packet. If
-           * not, return a non-zero value to terminate the poll.
-           */
-
-          if (lpc17can_txringfull(priv))
-            {
-              return -EBUSY;
-            }
+          return -EBUSY;
         }
     }
 

--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_ethernet.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_ethernet.c
@@ -712,57 +712,18 @@ static int lpc17_40_txpoll(struct net_driver_s *dev)
 {
   struct lpc17_40_driver_s *priv =
     (struct lpc17_40_driver_s *)dev->d_private;
-  int ret = OK;
 
-  /* If the polling resulted in data that should be sent out on the network,
-   * the field d_len is set to a value > 0.
+  /* Send this packet.  In this context, we know that there is space
+   * for at least one more packet in the descriptor list.
    */
 
-  if (priv->lp_dev.d_len > 0)
-    {
-      /* Look up the destination MAC address and add it to the Ethernet
-       * header.
-       */
+  lpc17_40_transmit(priv);
 
-#ifdef CONFIG_NET_IPv4
-#ifdef CONFIG_NET_IPv6
-      if (IFF_IS_IPv4(priv->lp_dev.d_flags))
-#endif
-        {
-          arp_out(&priv->lp_dev);
-        }
-#endif /* CONFIG_NET_IPv4 */
-
-#ifdef CONFIG_NET_IPv6
-#ifdef CONFIG_NET_IPv4
-      else
-#endif
-        {
-          neighbor_out(&priv->lp_dev);
-        }
-#endif /* CONFIG_NET_IPv6 */
-
-      if (!devif_loopback(&priv->lp_dev))
-        {
-          /* Send this packet.  In this context, we know that there is space
-           * for at least one more packet in the descriptor list.
-           */
-
-          lpc17_40_transmit(priv);
-
-          /* Check if there is room in the device to hold another packet. If
-           * not, return any non-zero value to terminate the poll.
-           */
-
-          ret = lpc17_40_txdesc(priv);
-        }
-    }
-
-  /* If zero is returned, the polling will continue until all connections
-   * have been examined.
+  /* Check if there is room in the device to hold another packet. If
+   * not, return any non-zero value to terminate the poll.
    */
 
-  return ret;
+  return lpc17_40_txdesc(priv);
 }
 
 /****************************************************************************

--- a/arch/arm/src/rtl8720c/amebaz_netdev.c
+++ b/arch/arm/src/rtl8720c/amebaz_netdev.c
@@ -42,49 +42,24 @@ static void amebaz_netdev_notify_tx_done(struct amebaz_dev_s *priv)
 static int amebaz_txpoll(struct net_driver_s *dev)
 {
   struct amebaz_dev_s *priv = (struct amebaz_dev_s *)dev->d_private;
-  if (priv->dev.d_len > 0)
+
+  net_lock();
+  if (!priv->curr)
     {
-#ifdef CONFIG_NET_IPv4
-#ifdef CONFIG_NET_IPv6
-      if (IFF_IS_IPv4(priv->dev.d_flags))
-#endif
-        {
-          arp_out(&priv->dev);
-        }
-
-#endif /* CONFIG_NET_IPv4 */
-#ifdef CONFIG_NET_IPv6
-#ifdef CONFIG_NET_IPv4
-      else
-#endif
-        {
-          neighbor_out(&priv->dev);
-        }
-
-#endif /* CONFIG_NET_IPv6 */
-      if (!devif_loopback(&priv->dev))
-        {
-          net_lock();
-          if (!priv->curr)
-            {
-              net_unlock();
-              amebaz_netdev_notify_tx_done(priv);
-              return false;
-            }
-
-          DEBUGASSERT(priv->curr->tail == priv->dev.d_buf);
-          skb_put(priv->curr, priv->dev.d_len);
-          rltk_wlan_send_skb(priv->devnum, priv->curr);
-          priv->dev.d_buf = NULL;
-          priv->curr = NULL;
-          net_unlock();
-          NETDEV_TXPACKETS(&priv->dev);
-          amebaz_netdev_notify_tx_done(priv);
-          return true;
-        }
+      net_unlock();
+      amebaz_netdev_notify_tx_done(priv);
+      return false;
     }
 
-  return false;
+  DEBUGASSERT(priv->curr->tail == priv->dev.d_buf);
+  skb_put(priv->curr, priv->dev.d_len);
+  rltk_wlan_send_skb(priv->devnum, priv->curr);
+  priv->dev.d_buf = NULL;
+  priv->curr = NULL;
+  net_unlock();
+  NETDEV_TXPACKETS(&priv->dev);
+  amebaz_netdev_notify_tx_done(priv);
+  return true;
 }
 
 static int amebaz_transmit(struct amebaz_dev_s *priv)

--- a/arch/arm/src/s32k1xx/s32k1xx_enet.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_enet.c
@@ -590,51 +590,19 @@ static int s32k1xx_txpoll(struct net_driver_s *dev)
   struct s32k1xx_driver_s *priv =
     (struct s32k1xx_driver_s *)dev->d_private;
 
-  /* If the polling resulted in data that should be sent out on the network,
-   * the field d_len is set to a value > 0.
+  /* Send the packet */
+
+  s32k1xx_transmit(priv);
+  priv->dev.d_buf = (uint8_t *)
+    s32k1xx_swap32((uint32_t)priv->txdesc[priv->txhead].data);
+
+  /* Check if there is room in the device to hold another packet. If
+   * not, return a non-zero value to terminate the poll.
    */
 
-  if (priv->dev.d_len > 0)
+  if (s32k1xx_txringfull(priv))
     {
-      /* Look up the destination MAC address and add it to the Ethernet
-       * header.
-       */
-
-#ifdef CONFIG_NET_IPv4
-#ifdef CONFIG_NET_IPv6
-      if (IFF_IS_IPv4(priv->dev.d_flags))
-#endif
-        {
-          arp_out(&priv->dev);
-        }
-#endif /* CONFIG_NET_IPv4 */
-
-#ifdef CONFIG_NET_IPv6
-#ifdef CONFIG_NET_IPv4
-      else
-#endif
-        {
-          neighbor_out(&priv->dev);
-        }
-#endif /* CONFIG_NET_IPv6 */
-
-      if (!devif_loopback(&priv->dev))
-        {
-          /* Send the packet */
-
-          s32k1xx_transmit(priv);
-          priv->dev.d_buf = (uint8_t *)
-            s32k1xx_swap32((uint32_t)priv->txdesc[priv->txhead].data);
-
-          /* Check if there is room in the device to hold another packet. If
-           * not, return a non-zero value to terminate the poll.
-           */
-
-          if (s32k1xx_txringfull(priv))
-            {
-              return -EBUSY;
-            }
-        }
+      return -EBUSY;
     }
 
   /* If zero is returned, the polling will continue until all connections

--- a/arch/arm/src/s32k3xx/s32k3xx_emac.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_emac.c
@@ -796,77 +796,48 @@ static int s32k3xx_txpoll(struct net_driver_s *dev)
 
   DEBUGASSERT(priv->dev.d_buf != NULL);
 
-  /* If the polling resulted in data that should be sent out on the network,
-   * the field d_len is set to a value > 0.
+  /* Send the packet */
+
+  s32k3xx_transmit(priv);
+  DEBUGASSERT(dev->d_len == 0 && dev->d_buf == NULL);
+
+  /* Check if the next TX descriptor is owned by the Ethernet DMA or
+   * CPU.  We cannot perform the TX poll if we are unable to accept
+   * another packet for transmission.
+   *
+   * In a race condition, ETH_TDES3_OWN may be cleared BUT still
+   * not available because s32k3xx_freeframe() has not yet run. If
+   * s32k3xx_freeframe() has run, the buffer1 pointer (tdes2) will be
+   * nullified (and inflight should be < CONFIG_S32K3XX_ENET_NTXBUFFERS).
    */
 
-  if (priv->dev.d_len > 0)
+  if ((priv->txhead->des3 & EMAC_TDES3_OWN_MASK) != 0 ||
+      priv->txhead->des0 != 0)
     {
-      /* Look up the destination MAC address and add it to the Ethernet
-       * header.
+      /* We have to terminate the poll if we have no more descriptors
+       * available for another transfer.
        */
 
-#ifdef CONFIG_NET_IPv4
-#ifdef CONFIG_NET_IPv6
-      if (IFF_IS_IPv4(priv->dev.d_flags))
-#endif
-        {
-          arp_out(&priv->dev);
-        }
-#endif /* CONFIG_NET_IPv4 */
+      nerr("No tx descriptors available");
 
-#ifdef CONFIG_NET_IPv6
-#ifdef CONFIG_NET_IPv4
-      else
-#endif
-        {
-          neighbor_out(&priv->dev);
-        }
-#endif /* CONFIG_NET_IPv6 */
+      return -EBUSY;
+    }
 
-      /* Send the packet */
+  /* We have the descriptor, we can continue the poll. Allocate a new
+   * buffer for the poll.
+   */
 
-      s32k3xx_transmit(priv);
-      DEBUGASSERT(dev->d_len == 0 && dev->d_buf == NULL);
+  dev->d_buf = s32k3xx_allocbuffer(priv);
 
-      /* Check if the next TX descriptor is owned by the Ethernet DMA or
-       * CPU.  We cannot perform the TX poll if we are unable to accept
-       * another packet for transmission.
-       *
-       * In a race condition, ETH_TDES3_OWN may be cleared BUT still
-       * not available because s32k3xx_freeframe() has not yet run. If
-       * s32k3xx_freeframe() has run, the buffer1 pointer (tdes2) will be
-       * nullified (and inflight should be < CONFIG_S32K3XX_ENET_NTXBUFFERS).
-       */
+  /* We can't continue the poll if we have no buffers */
 
-      if ((priv->txhead->des3 & EMAC_TDES3_OWN_MASK) != 0 ||
-          priv->txhead->des0 != 0)
-        {
-          /* We have to terminate the poll if we have no more descriptors
-           * available for another transfer.
-           */
+  if (dev->d_buf == NULL)
+    {
+      /* Terminate the poll. */
 
-          nerr("No tx descriptors available");
+      nerr("No tx buffer available");
 
-          return -EBUSY;
-        }
-
-      /* We have the descriptor, we can continue the poll. Allocate a new
-       * buffer for the poll.
-       */
-
-      dev->d_buf = s32k3xx_allocbuffer(priv);
-
-      /* We can't continue the poll if we have no buffers */
-
-      if (dev->d_buf == NULL)
-        {
-          /* Terminate the poll. */
-
-          nerr("No tx buffer available");
-
-          return -ENOMEM;
-        }
+      return -ENOMEM;
     }
 
   /* If zero is returned, the polling will continue until all connections

--- a/arch/arm/src/s32k3xx/s32k3xx_flexcan.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_flexcan.c
@@ -961,26 +961,23 @@ static int s32k3xx_txpoll(struct net_driver_s *dev)
 
   if (priv->dev.d_len > 0)
     {
-      if (!devif_loopback(&priv->dev))
+      s32k3xx_txdone(priv);
+
+      /* Send the packet */
+
+      s32k3xx_transmit(priv);
+
+      /* Check if there is room in the device to hold another packet. If
+       * not, return a non-zero value to terminate the poll.
+       */
+
+      if ((getreg32(priv->base + S32K3XX_CAN_ESR2_OFFSET) &
+          (CAN_ESR2_IMB | CAN_ESR2_VPS)) ==
+          (CAN_ESR2_IMB | CAN_ESR2_VPS))
         {
-          s32k3xx_txdone(priv);
-
-          /* Send the packet */
-
-          s32k3xx_transmit(priv);
-
-          /* Check if there is room in the device to hold another packet. If
-           * not, return a non-zero value to terminate the poll.
-           */
-
-          if ((getreg32(priv->base + S32K3XX_CAN_ESR2_OFFSET) &
-              (CAN_ESR2_IMB | CAN_ESR2_VPS)) ==
-              (CAN_ESR2_IMB | CAN_ESR2_VPS))
+          if (s32k3xx_txringfull(priv))
             {
-              if (s32k3xx_txringfull(priv))
-                {
-                  return -EBUSY;
-                }
+              return -EBUSY;
             }
         }
     }

--- a/arch/arm/src/sam34/sam_emac.c
+++ b/arch/arm/src/sam34/sam_emac.c
@@ -831,53 +831,21 @@ static int sam_txpoll(struct net_driver_s *dev)
 {
   struct sam_emac_s *priv = (struct sam_emac_s *)dev->d_private;
 
-  /* If the polling resulted in data that should be sent out on the network,
-   * the field d_len is set to a value > 0.
+  /* Send the packet */
+
+  sam_transmit(priv);
+
+  /* Check if there are any free TX descriptors.  We cannot perform
+   * the TX poll if we do not have buffering for another packet.
    */
 
-  if (priv->dev.d_len > 0)
+  if (sam_txfree(priv) == 0)
     {
-      /* Look up the destination MAC address and add it to the Ethernet
-       * header.
+      /* We have to terminate the poll if we have no more descriptors
+       * available for another transfer.
        */
 
-#ifdef CONFIG_NET_IPv4
-#ifdef CONFIG_NET_IPv6
-      if (IFF_IS_IPv4(priv->dev.d_flags))
-#endif
-        {
-          arp_out(&priv->dev);
-        }
-#endif /* CONFIG_NET_IPv4 */
-
-#ifdef CONFIG_NET_IPv6
-#ifdef CONFIG_NET_IPv4
-      else
-#endif
-        {
-          neighbor_out(&priv->dev);
-        }
-#endif /* CONFIG_NET_IPv6 */
-
-      if (!devif_loopback(&priv->dev))
-        {
-          /* Send the packet */
-
-          sam_transmit(priv);
-
-          /* Check if there are any free TX descriptors.  We cannot perform
-           * the TX poll if we do not have buffering for another packet.
-           */
-
-          if (sam_txfree(priv) == 0)
-            {
-              /* We have to terminate the poll if we have no more descriptors
-               * available for another transfer.
-               */
-
-              return -EBUSY;
-            }
-        }
+      return -EBUSY;
     }
 
   /* If zero is returned, the polling will continue until all connections

--- a/arch/arm/src/sama5/sam_emaca.c
+++ b/arch/arm/src/sama5/sam_emaca.c
@@ -866,53 +866,21 @@ static int sam_txpoll(struct net_driver_s *dev)
 {
   struct sam_emac_s *priv = (struct sam_emac_s *)dev->d_private;
 
-  /* If the polling resulted in data that should be sent out on the network,
-   * the field d_len is set to a value > 0.
+  /* Send the packet */
+
+  sam_transmit(priv);
+
+  /* Check if there are any free TX descriptors.  We cannot perform
+   * the TX poll if we do not have buffering for another packet.
    */
 
-  if (priv->dev.d_len > 0)
+  if (sam_txfree(priv) == 0)
     {
-      /* Look up the destination MAC address and add it to the Ethernet
-       * header.
+      /* We have to terminate the poll if we have no more descriptors
+       * available for another transfer.
        */
 
-#ifdef CONFIG_NET_IPv4
-#ifdef CONFIG_NET_IPv6
-      if (IFF_IS_IPv4(priv->dev.d_flags))
-#endif
-        {
-          arp_out(&priv->dev);
-        }
-#endif /* CONFIG_NET_IPv4 */
-
-#ifdef CONFIG_NET_IPv6
-#ifdef CONFIG_NET_IPv4
-      else
-#endif
-        {
-          neighbor_out(&priv->dev);
-        }
-#endif /* CONFIG_NET_IPv6 */
-
-      if (!devif_loopback(&priv->dev))
-        {
-          /* Send the packet */
-
-          sam_transmit(priv);
-
-          /* Check if there are any free TX descriptors.  We cannot perform
-           * the TX poll if we do not have buffering for another packet.
-           */
-
-          if (sam_txfree(priv) == 0)
-            {
-              /* We have to terminate the poll if we have no more descriptors
-               * available for another transfer.
-               */
-
-              return -EBUSY;
-            }
-        }
+      return -EBUSY;
     }
 
   /* If zero is returned, the polling will continue until all connections

--- a/arch/arm/src/sama5/sam_gmac.c
+++ b/arch/arm/src/sama5/sam_gmac.c
@@ -808,53 +808,21 @@ static int sam_txpoll(struct net_driver_s *dev)
 {
   struct sam_gmac_s *priv = (struct sam_gmac_s *)dev->d_private;
 
-  /* If the polling resulted in data that should be sent out on the network,
-   * the field d_len is set to a value > 0.
+  /* Send the packet */
+
+  sam_transmit(priv);
+
+  /* Check if there are any free TX descriptors.  We cannot perform
+   * the TX poll if we do not have buffering for another packet.
    */
 
-  if (priv->dev.d_len > 0)
+  if (sam_txfree(priv) == 0)
     {
-      /* Look up the destination MAC address and add it to the Ethernet
-       * header.
+      /* We have to terminate the poll if we have no more descriptors
+       * available for another transfer.
        */
 
-#ifdef CONFIG_NET_IPv4
-#ifdef CONFIG_NET_IPv6
-      if (IFF_IS_IPv4(priv->dev.d_flags))
-#endif
-        {
-          arp_out(&priv->dev);
-        }
-#endif /* CONFIG_NET_IPv4 */
-
-#ifdef CONFIG_NET_IPv6
-#ifdef CONFIG_NET_IPv4
-      else
-#endif
-        {
-          neighbor_out(&priv->dev);
-        }
-#endif /* CONFIG_NET_IPv6 */
-
-      if (!devif_loopback(&priv->dev))
-        {
-          /* Send the packet */
-
-          sam_transmit(priv);
-
-          /* Check if there are any free TX descriptors.  We cannot perform
-           * the TX poll if we do not have buffering for another packet.
-           */
-
-          if (sam_txfree(priv) == 0)
-            {
-              /* We have to terminate the poll if we have no more descriptors
-               * available for another transfer.
-               */
-
-              return -EBUSY;
-            }
-        }
+      return -EBUSY;
     }
 
   /* If zero is returned, the polling will continue until all connections

--- a/arch/arm/src/samd5e5/sam_gmac.c
+++ b/arch/arm/src/samd5e5/sam_gmac.c
@@ -796,53 +796,21 @@ static int sam_txpoll(struct net_driver_s *dev)
 {
   struct sam_gmac_s *priv = (struct sam_gmac_s *)dev->d_private;
 
-  /* If the polling resulted in data that should be sent out on the network,
-   * the field d_len is set to a value > 0.
+  /* Send the packet */
+
+  sam_transmit(priv);
+
+  /* Check if there are any free TX descriptors.  We cannot perform
+   * the TX poll if we do not have buffering for another packet.
    */
 
-  if (priv->dev.d_len > 0)
+  if (sam_txfree(priv) == 0)
     {
-      /* Look up the destination MAC address and add it to the Ethernet
-       * header.
+      /* We have to terminate the poll if we have no more descriptors
+       * available for another transfer.
        */
 
-#ifdef CONFIG_NET_IPv4
-#ifdef CONFIG_NET_IPv6
-      if (IFF_IS_IPv4(priv->dev.d_flags))
-#endif
-        {
-          arp_out(&priv->dev);
-        }
-#endif /* CONFIG_NET_IPv4 */
-
-#ifdef CONFIG_NET_IPv6
-#ifdef CONFIG_NET_IPv4
-      else
-#endif
-        {
-          neighbor_out(&priv->dev);
-        }
-#endif /* CONFIG_NET_IPv6 */
-
-      if (!devif_loopback(&priv->dev))
-        {
-          /* Send the packet */
-
-          sam_transmit(priv);
-
-          /* Check if there are any free TX descriptors.  We cannot perform
-           * the TX poll if we do not have buffering for another packet.
-           */
-
-          if (sam_txfree(priv) == 0)
-            {
-              /* We have to terminate the poll if we have no more descriptors
-               * available for another transfer.
-               */
-
-              return -EBUSY;
-            }
-        }
+      return -EBUSY;
     }
 
   /* If zero is returned, the polling will continue until all connections

--- a/arch/arm/src/samv7/sam_emac.c
+++ b/arch/arm/src/samv7/sam_emac.c
@@ -1470,53 +1470,21 @@ static int sam_txpoll(struct net_driver_s *dev)
 {
   struct sam_emac_s *priv = (struct sam_emac_s *)dev->d_private;
 
-  /* If the polling resulted in data that should be sent out on the network,
-   * the field d_len is set to a value > 0.
+  /* Send the packet */
+
+  sam_transmit(priv, EMAC_QUEUE_0);
+
+  /* Check if there are any free TX descriptors.  We cannot perform
+   * the TX poll if we do not have buffering for another packet.
    */
 
-  if (priv->dev.d_len > 0)
+  if (sam_txfree(priv, EMAC_QUEUE_0) == 0)
     {
-      /* Look up the destination MAC address and add it to the Ethernet
-       * header.
+      /* We have to terminate the poll if we have no more descriptors
+       * available for another transfer.
        */
 
-#ifdef CONFIG_NET_IPv4
-#ifdef CONFIG_NET_IPv6
-      if (IFF_IS_IPv4(priv->dev.d_flags))
-#endif
-        {
-          arp_out(&priv->dev);
-        }
-#endif /* CONFIG_NET_IPv4 */
-
-#ifdef CONFIG_NET_IPv6
-#ifdef CONFIG_NET_IPv4
-      else
-#endif
-        {
-          neighbor_out(&priv->dev);
-        }
-#endif /* CONFIG_NET_IPv6 */
-
-      if (!devif_loopback(&priv->dev))
-        {
-          /* Send the packet */
-
-          sam_transmit(priv, EMAC_QUEUE_0);
-
-          /* Check if there are any free TX descriptors.  We cannot perform
-           * the TX poll if we do not have buffering for another packet.
-           */
-
-          if (sam_txfree(priv, EMAC_QUEUE_0) == 0)
-            {
-              /* We have to terminate the poll if we have no more descriptors
-               * available for another transfer.
-               */
-
-              return -EBUSY;
-            }
-        }
+      return -EBUSY;
     }
 
   /* If zero is returned, the polling will continue until all connections

--- a/arch/arm/src/stm32/stm32_can_sock.c
+++ b/arch/arm/src/stm32/stm32_can_sock.c
@@ -1021,22 +1021,19 @@ static int stm32can_txpoll(struct net_driver_s *dev)
 
   if (priv->dev.d_len > 0)
     {
-      if (!devif_loopback(&priv->dev))
+      stm32can_txdone(priv);
+
+      /* Send the packet */
+
+      stm32can_transmit(priv);
+
+      /* Check if there is room in the device to hold another packet. If
+       * not, return a non-zero value to terminate the poll.
+       */
+
+      if (stm32can_txready(priv) == false)
         {
-          stm32can_txdone(priv);
-
-          /* Send the packet */
-
-          stm32can_transmit(priv);
-
-          /* Check if there is room in the device to hold another packet. If
-           * not, return a non-zero value to terminate the poll.
-           */
-
-          if (stm32can_txready(priv) == false)
-            {
-              return -EBUSY;
-            }
+          return -EBUSY;
         }
     }
 

--- a/arch/arm/src/stm32/stm32_eth.c
+++ b/arch/arm/src/stm32/stm32_eth.c
@@ -1246,76 +1246,44 @@ static int stm32_txpoll(struct net_driver_s *dev)
 
   DEBUGASSERT(priv->dev.d_buf != NULL);
 
-  /* If the polling resulted in data that should be sent out on the network,
-   * the field d_len is set to a value > 0.
+  /* Send the packet */
+
+  stm32_transmit(priv);
+  DEBUGASSERT(dev->d_len == 0 && dev->d_buf == NULL);
+
+  /* Check if the next TX descriptor is owned by the Ethernet DMA or
+   * CPU. We cannot perform the TX poll if we are unable to accept
+   * another packet for transmission.
+   *
+   * In a race condition, ETH_TDES0_OWN may be cleared BUT still
+   * not available because stm32_freeframe() has not yet run. If
+   * stm32_freeframe() has run, the buffer1 pointer (tdes2) will be
+   * nullified (and inflight should be < CONFIG_STM32_ETH_NTXDESC).
    */
 
-  if (priv->dev.d_len > 0)
+  if ((priv->txhead->tdes0 & ETH_TDES0_OWN) != 0 ||
+       priv->txhead->tdes2 != 0)
     {
-      /* Look up the destination MAC address and add it to the Ethernet
-       * header.
+      /* We have to terminate the poll if we have no more descriptors
+       * available for another transfer.
        */
 
-#ifdef CONFIG_NET_IPv4
-#ifdef CONFIG_NET_IPv6
-      if (IFF_IS_IPv4(priv->dev.d_flags))
-#endif
-        {
-          arp_out(&priv->dev);
-        }
-#endif /* CONFIG_NET_IPv4 */
+      return -EBUSY;
+    }
 
-#ifdef CONFIG_NET_IPv6
-#ifdef CONFIG_NET_IPv4
-      else
-#endif
-        {
-          neighbor_out(&priv->dev);
-        }
-#endif /* CONFIG_NET_IPv6 */
+  /* We have the descriptor, we can continue the poll. Allocate a new
+   * buffer for the poll.
+   */
 
-      if (!devif_loopback(&priv->dev))
-        {
-          /* Send the packet */
+  dev->d_buf = stm32_allocbuffer(priv);
 
-          stm32_transmit(priv);
-          DEBUGASSERT(dev->d_len == 0 && dev->d_buf == NULL);
+  /* We can't continue the poll if we have no buffers */
 
-          /* Check if the next TX descriptor is owned by the Ethernet DMA or
-           * CPU. We cannot perform the TX poll if we are unable to accept
-           * another packet for transmission.
-           *
-           * In a race condition, ETH_TDES0_OWN may be cleared BUT still
-           * not available because stm32_freeframe() has not yet run. If
-           * stm32_freeframe() has run, the buffer1 pointer (tdes2) will be
-           * nullified (and inflight should be < CONFIG_STM32_ETH_NTXDESC).
-           */
+  if (dev->d_buf == NULL)
+    {
+      /* Terminate the poll. */
 
-          if ((priv->txhead->tdes0 & ETH_TDES0_OWN) != 0 ||
-               priv->txhead->tdes2 != 0)
-            {
-              /* We have to terminate the poll if we have no more descriptors
-               * available for another transfer.
-               */
-
-              return -EBUSY;
-            }
-
-          /* We have the descriptor, we can continue the poll. Allocate a new
-           * buffer for the poll.
-           */
-
-          dev->d_buf = stm32_allocbuffer(priv);
-
-          /* We can't continue the poll if we have no buffers */
-
-          if (dev->d_buf == NULL)
-            {
-              /* Terminate the poll. */
-
-              return -ENOMEM;
-            }
-        }
+      return -ENOMEM;
     }
 
   /* If zero is returned, the polling will continue until all connections

--- a/arch/arm/src/stm32/stm32_fdcan_sock.c
+++ b/arch/arm/src/stm32/stm32_fdcan_sock.c
@@ -3045,22 +3045,19 @@ static int fdcan_txpoll(struct net_driver_s *dev)
 
   if (priv->dev.d_len > 0)
     {
-      if (!devif_loopback(&priv->dev))
+      fdcan_txdone(priv);
+
+      /* Send the packet */
+
+      fdcan_send(priv);
+
+      /* Check if there is room in the device to hold another packet. If
+       * not, return a non-zero value to terminate the poll.
+       */
+
+      if (fdcan_txready(priv) == false)
         {
-          fdcan_txdone(priv);
-
-          /* Send the packet */
-
-          fdcan_send(priv);
-
-          /* Check if there is room in the device to hold another packet. If
-           * not, return a non-zero value to terminate the poll.
-           */
-
-          if (fdcan_txready(priv) == false)
-            {
-              return -EBUSY;
-            }
+          return -EBUSY;
         }
     }
 

--- a/arch/arm/src/stm32f7/stm32_can_sock.c
+++ b/arch/arm/src/stm32f7/stm32_can_sock.c
@@ -1045,22 +1045,19 @@ static int stm32can_txpoll(struct net_driver_s *dev)
 
   if (priv->dev.d_len > 0)
     {
-      if (!devif_loopback(&priv->dev))
+      stm32can_txdone(priv);
+
+      /* Send the packet */
+
+      stm32can_transmit(priv);
+
+      /* Check if there is room in the device to hold another packet. If
+       * not, return a non-zero value to terminate the poll.
+       */
+
+      if (stm32can_txready(priv) == false)
         {
-          stm32can_txdone(priv);
-
-          /* Send the packet */
-
-          stm32can_transmit(priv);
-
-          /* Check if there is room in the device to hold another packet. If
-           * not, return a non-zero value to terminate the poll.
-           */
-
-          if (stm32can_txready(priv) == false)
-            {
-              return -EBUSY;
-            }
+          return -EBUSY;
         }
     }
 

--- a/arch/arm/src/stm32f7/stm32_ethernet.c
+++ b/arch/arm/src/stm32f7/stm32_ethernet.c
@@ -1288,76 +1288,44 @@ static int stm32_txpoll(struct net_driver_s *dev)
 
   DEBUGASSERT(priv->dev.d_buf != NULL);
 
-  /* If the polling resulted in data that should be sent out on the network,
-   * the field d_len is set to a value > 0.
+  /* Send the packet */
+
+  stm32_transmit(priv);
+  DEBUGASSERT(dev->d_len == 0 && dev->d_buf == NULL);
+
+  /* Check if the next TX descriptor is owned by the Ethernet DMA or
+   * CPU. We cannot perform the TX poll if we are unable to accept
+   * another packet for transmission.
+   *
+   * In a race condition, ETH_TDES0_OWN may be cleared BUT still
+   * not available because stm32_freeframe() has not yet run. If
+   * stm32_freeframe() has run, the buffer1 pointer (tdes2) will be
+   * nullified (and inflight should be < CONFIG_STM32F7_ETH_NTXDESC).
    */
 
-  if (priv->dev.d_len > 0)
+  if ((priv->txhead->tdes0 & ETH_TDES0_OWN) != 0 ||
+       priv->txhead->tdes2 != 0)
     {
-      /* Look up the destination MAC address and add it to the Ethernet
-       * header.
+      /* We have to terminate the poll if we have no more descriptors
+       * available for another transfer.
        */
 
-#ifdef CONFIG_NET_IPv4
-#ifdef CONFIG_NET_IPv6
-      if (IFF_IS_IPv4(priv->dev.d_flags))
-#endif
-        {
-          arp_out(&priv->dev);
-        }
-#endif /* CONFIG_NET_IPv4 */
+      return -EBUSY;
+    }
 
-#ifdef CONFIG_NET_IPv6
-#ifdef CONFIG_NET_IPv4
-      else
-#endif
-        {
-          neighbor_out(&priv->dev);
-        }
-#endif /* CONFIG_NET_IPv6 */
+  /* We have the descriptor, we can continue the poll. Allocate a new
+   * buffer for the poll.
+   */
 
-      if (!devif_loopback(&priv->dev))
-        {
-          /* Send the packet */
+  dev->d_buf = stm32_allocbuffer(priv);
 
-          stm32_transmit(priv);
-          DEBUGASSERT(dev->d_len == 0 && dev->d_buf == NULL);
+  /* We can't continue the poll if we have no buffers */
 
-          /* Check if the next TX descriptor is owned by the Ethernet DMA or
-           * CPU. We cannot perform the TX poll if we are unable to accept
-           * another packet for transmission.
-           *
-           * In a race condition, ETH_TDES0_OWN may be cleared BUT still
-           * not available because stm32_freeframe() has not yet run. If
-           * stm32_freeframe() has run, the buffer1 pointer (tdes2) will be
-           * nullified (and inflight should be < CONFIG_STM32F7_ETH_NTXDESC).
-           */
+  if (dev->d_buf == NULL)
+    {
+      /* Terminate the poll. */
 
-          if ((priv->txhead->tdes0 & ETH_TDES0_OWN) != 0 ||
-               priv->txhead->tdes2 != 0)
-            {
-              /* We have to terminate the poll if we have no more descriptors
-               * available for another transfer.
-               */
-
-              return -EBUSY;
-            }
-
-          /* We have the descriptor, we can continue the poll. Allocate a new
-           * buffer for the poll.
-           */
-
-          dev->d_buf = stm32_allocbuffer(priv);
-
-          /* We can't continue the poll if we have no buffers */
-
-          if (dev->d_buf == NULL)
-            {
-              /* Terminate the poll. */
-
-              return -ENOMEM;
-            }
-        }
+      return -ENOMEM;
     }
 
   /* If zero is returned, the polling will continue until all connections

--- a/arch/arm/src/stm32h7/stm32_fdcan_sock.c
+++ b/arch/arm/src/stm32h7/stm32_fdcan_sock.c
@@ -934,20 +934,17 @@ static int fdcan_txpoll(struct net_driver_s *dev)
 
   if (priv->dev.d_len > 0)
     {
-      if (!devif_loopback(&priv->dev))
+      /* Send the packet */
+
+      fdcan_transmit(priv);
+
+      /* Check if there is room in the device to hold another packet. If
+       * not, return a non-zero value to terminate the poll.
+       */
+
+      if (fdcan_txringfull(priv))
         {
-          /* Send the packet */
-
-          fdcan_transmit(priv);
-
-          /* Check if there is room in the device to hold another packet. If
-           * not, return a non-zero value to terminate the poll.
-           */
-
-          if (fdcan_txringfull(priv))
-            {
-              return -EBUSY;
-            }
+          return -EBUSY;
         }
     }
 

--- a/arch/arm/src/tiva/lm/lm3s_ethernet.c
+++ b/arch/arm/src/tiva/lm/lm3s_ethernet.c
@@ -603,54 +603,12 @@ static int tiva_transmit(struct tiva_driver_s *priv)
 static int tiva_txpoll(struct net_driver_s *dev)
 {
   struct tiva_driver_s *priv = (struct tiva_driver_s *)dev->d_private;
-  int ret = OK;
 
-  /* If the polling resulted in data that should be sent out on the network,
-   * the field d_len is set to a value > 0.
+  /* Send the packet.  tiva_transmit() will return zero if the
+   * packet was successfully handled.
    */
 
-  ninfo("Poll result: d_len=%d\n", priv->ld_dev.d_len);
-  if (priv->ld_dev.d_len > 0)
-    {
-      DEBUGASSERT(!(tiva_ethin(priv, TIVA_MAC_TR_OFFSET) & MAC_TR_NEWTX));
-
-      /* Look up the destination MAC address and add it to the Ethernet
-       * header.
-       */
-
-#ifdef CONFIG_NET_IPv4
-#ifdef CONFIG_NET_IPv6
-      if (IFF_IS_IPv4(priv->ld_dev.d_flags))
-#endif
-        {
-          arp_out(&priv->ld_dev);
-        }
-#endif /* CONFIG_NET_IPv4 */
-
-#ifdef CONFIG_NET_IPv6
-#ifdef CONFIG_NET_IPv4
-      else
-#endif
-        {
-          neighbor_out(&priv->ld_dev);
-        }
-#endif /* CONFIG_NET_IPv6 */
-
-      if (!devif_loopback(&priv->ld_dev))
-        {
-          /* Send the packet.  tiva_transmit() will return zero if the
-           * packet was successfully handled.
-           */
-
-          ret = tiva_transmit(priv);
-        }
-    }
-
-  /* If zero is returned, the polling will continue until all connections
-   * have been examined.
-   */
-
-  return ret;
+  return tiva_transmit(priv);
 }
 
 /****************************************************************************

--- a/arch/arm/src/tiva/tm4c/tm4c_ethernet.c
+++ b/arch/arm/src/tiva/tm4c/tm4c_ethernet.c
@@ -1246,76 +1246,44 @@ static int tiva_txpoll(struct net_driver_s *dev)
 
   DEBUGASSERT(priv->dev.d_buf != NULL);
 
-  /* If the polling resulted in data that should be sent out on the network,
-   * the field d_len is set to a value > 0.
+  /* Send the packet */
+
+  tiva_transmit(priv);
+  DEBUGASSERT(dev->d_len == 0 && dev->d_buf == NULL);
+
+  /* Check if the next TX descriptor is owned by the Ethernet DMA or
+   * CPU. We cannot perform the TX poll if we are unable to accept
+   * another packet for transmission.
+   *
+   * In a race condition, EMAC_TDES0_OWN may be cleared BUT still
+   * not available because tiva_freeframe() has not yet run. If
+   * tiva_freeframe() has run, the buffer1 pointer (tdes2) will be
+   * nullified (and inflight should be < CONFIG_TIVA_EMAC_NTXDESC).
    */
 
-  if (priv->dev.d_len > 0)
+  if ((priv->txhead->tdes0 & EMAC_TDES0_OWN) != 0 ||
+       priv->txhead->tdes2 != 0)
     {
-      /* Look up the destination MAC address and add it to the Ethernet
-       * header.
+      /* We have to terminate the poll if we have no more descriptors
+       * available for another transfer.
        */
 
-#ifdef CONFIG_NET_IPv4
-#ifdef CONFIG_NET_IPv6
-      if (IFF_IS_IPv4(priv->dev.d_flags))
-#endif
-        {
-          arp_out(&priv->dev);
-        }
-#endif /* CONFIG_NET_IPv4 */
+      return -EBUSY;
+    }
 
-#ifdef CONFIG_NET_IPv6
-#ifdef CONFIG_NET_IPv4
-      else
-#endif
-        {
-          neighbor_out(&priv->dev);
-        }
-#endif /* CONFIG_NET_IPv6 */
+  /* We have the descriptor, we can continue the poll. Allocate a new
+   * buffer for the poll.
+   */
 
-      if (!devif_loopback(&priv->dev))
-        {
-          /* Send the packet */
+  dev->d_buf = tiva_allocbuffer(priv);
 
-          tiva_transmit(priv);
-          DEBUGASSERT(dev->d_len == 0 && dev->d_buf == NULL);
+  /* We can't continue the poll if we have no buffers */
 
-          /* Check if the next TX descriptor is owned by the Ethernet DMA or
-           * CPU. We cannot perform the TX poll if we are unable to accept
-           * another packet for transmission.
-           *
-           * In a race condition, EMAC_TDES0_OWN may be cleared BUT still
-           * not available because tiva_freeframe() has not yet run. If
-           * tiva_freeframe() has run, the buffer1 pointer (tdes2) will be
-           * nullified (and inflight should be < CONFIG_TIVA_EMAC_NTXDESC).
-           */
+  if (dev->d_buf == NULL)
+    {
+      /* Terminate the poll. */
 
-          if ((priv->txhead->tdes0 & EMAC_TDES0_OWN) != 0 ||
-               priv->txhead->tdes2 != 0)
-            {
-              /* We have to terminate the poll if we have no more descriptors
-               * available for another transfer.
-               */
-
-              return -EBUSY;
-            }
-
-          /* We have the descriptor, we can continue the poll. Allocate a new
-           * buffer for the poll.
-           */
-
-          dev->d_buf = tiva_allocbuffer(priv);
-
-          /* We can't continue the poll if we have no buffers */
-
-          if (dev->d_buf == NULL)
-            {
-              /* Terminate the poll. */
-
-              return -ENOMEM;
-            }
-        }
+      return -ENOMEM;
     }
 
   /* If zero is returned, the polling will continue until all connections

--- a/arch/hc/src/m9s12/m9s12_ethernet.c
+++ b/arch/hc/src/m9s12/m9s12_ethernet.c
@@ -199,45 +199,9 @@ static int emac_txpoll(struct net_driver_s *dev)
   FAR struct emac_driver_s *priv =
     (FAR struct emac_driver_s *)dev->d_private;
 
-  /* If the polling resulted in data that should be sent out on the network,
-   * the field d_len is set to a value > 0.
-   */
+  /* Send the packet */
 
-  if (priv->d_dev.d_len > 0)
-    {
-      /* Look up the destination MAC address and add it to the Ethernet
-       * header.
-       */
-
-#ifdef CONFIG_NET_IPv4
-#ifdef CONFIG_NET_IPv6
-      if (IFF_IS_IPv4(priv->d_dev.d_flags))
-#endif
-        {
-          arp_out(&priv->d_dev);
-        }
-#endif /* CONFIG_NET_IPv4 */
-
-#ifdef CONFIG_NET_IPv6
-#ifdef CONFIG_NET_IPv4
-      else
-#endif
-        {
-          neighbor_out(&priv->d_dev);
-        }
-#endif /* CONFIG_NET_IPv6 */
-
-      if (!devif_loopback(&priv->d_dev))
-        {
-          /* Send the packet */
-
-          emac_transmit(priv);
-
-          /* Check if there is room in the device to hold another packet.
-           * If not, return a non-zero value to terminate the poll.
-           */
-        }
-    }
+  emac_transmit(priv);
 
   /* If zero is returned, the polling will continue until all connections
    * have been examined.

--- a/arch/mips/src/pic32mx/pic32mx_ethernet.c
+++ b/arch/mips/src/pic32mx/pic32mx_ethernet.c
@@ -1119,76 +1119,43 @@ static int pic32mx_transmit(struct pic32mx_driver_s *priv)
 static int pic32mx_txpoll(struct net_driver_s *dev)
 {
   struct pic32mx_driver_s *priv = (struct pic32mx_driver_s *)dev->d_private;
-  int ret = OK;
 
-  /* If the polling resulted in data that should be sent out on the network,
-   * the field d_len is set to a value > 0.
+  /* Send this packet.  In this context, we know that there is space
+   * for at least one more packet in the descriptor list.
    */
 
-  if (priv->pd_dev.d_len > 0)
+  pic32mx_transmit(priv);
+
+  /* Check if the next TX descriptor is available. If not, return a
+   * non-zero value to terminate the poll.
+   */
+
+  if (pic32mx_txdesc(priv) == NULL)
     {
-      /* Look up the destination MAC address and add it to the Ethernet
-       * header.
+      /* There are no more TX descriptors/buffers available..
+       * stop the poll
        */
 
-#ifdef CONFIG_NET_IPv4
-#ifdef CONFIG_NET_IPv6
-      if (IFF_IS_IPv4(priv->pd_dev.d_flags))
-#endif
-        {
-          arp_out(&priv->pd_dev);
-        }
-#endif /* CONFIG_NET_IPv4 */
+      return -EAGAIN;
+    }
 
-#ifdef CONFIG_NET_IPv6
-#ifdef CONFIG_NET_IPv4
-      else
-#endif
-        {
-          neighbor_out(&priv->pd_dev);
-        }
-#endif /* CONFIG_NET_IPv6 */
+  /* Get the next Tx buffer needed in order to continue the poll */
 
-      if (!devif_loopback(&priv->pd_dev))
-        {
-          /* Send this packet.  In this context, we know that there is space
-           * for at least one more packet in the descriptor list.
-           */
+  priv->pd_dev.d_buf = pic32mx_allocbuffer(priv);
+  if (priv->pd_dev.d_buf == NULL)
+    {
+      /* We have no more buffers available for the nex Tx.. stop the
+       * poll
+       */
 
-          pic32mx_transmit(priv);
-
-          /* Check if the next TX descriptor is available. If not, return a
-           * non-zero value to terminate the poll.
-           */
-
-          if (pic32mx_txdesc(priv) == NULL)
-            {
-              /* There are no more TX descriptors/buffers available..
-               * stop the poll
-               */
-
-              return -EAGAIN;
-            }
-
-          /* Get the next Tx buffer needed in order to continue the poll */
-
-          priv->pd_dev.d_buf = pic32mx_allocbuffer(priv);
-          if (priv->pd_dev.d_buf == NULL)
-            {
-              /* We have no more buffers available for the nex Tx.. stop the
-               * poll
-               */
-
-              return -ENOMEM;
-            }
-        }
+      return -ENOMEM;
     }
 
   /* If zero is returned, the polling will continue until all connections
    * have been examined.
    */
 
-  return ret;
+  return 0;
 }
 
 /****************************************************************************

--- a/arch/mips/src/pic32mz/pic32mz_ethernet.c
+++ b/arch/mips/src/pic32mz/pic32mz_ethernet.c
@@ -1221,76 +1221,43 @@ static int pic32mz_transmit(struct pic32mz_driver_s *priv)
 static int pic32mz_txpoll(struct net_driver_s *dev)
 {
   struct pic32mz_driver_s *priv = (struct pic32mz_driver_s *)dev->d_private;
-  int ret = OK;
 
-  /* If the polling resulted in data that should be sent out on the network,
-   * the field d_len is set to a value > 0.
+  /* Send this packet.  In this context, we know that there is space
+   * for at least one more packet in the descriptor list.
    */
 
-  if (priv->pd_dev.d_len > 0)
+  pic32mz_transmit(priv);
+
+  /* Check if the next TX descriptor is available. If not, return a
+   * non-zero value to terminate the poll.
+   */
+
+  if (pic32mz_txdesc(priv) == NULL)
     {
-      /* Look up the destination MAC address and add it to the Ethernet
-       * header.
+      /* There are no more TX descriptors/buffers available..
+       * stop the poll
        */
 
-#ifdef CONFIG_NET_IPv4
-#ifdef CONFIG_NET_IPv6
-      if (IFF_IS_IPv4(priv->pd_dev.d_flags))
-#endif
-        {
-          arp_out(&priv->pd_dev);
-        }
-#endif /* CONFIG_NET_IPv4 */
+      return -EAGAIN;
+    }
 
-#ifdef CONFIG_NET_IPv6
-#ifdef CONFIG_NET_IPv4
-      else
-#endif
-        {
-          neighbor_out(&priv->pd_dev);
-        }
-#endif /* CONFIG_NET_IPv6 */
+  /* Get the next Tx buffer needed in order to continue the poll */
 
-      if (!devif_loopback(&priv->pd_dev))
-        {
-          /* Send this packet.  In this context, we know that there is space
-           * for at least one more packet in the descriptor list.
-           */
+  priv->pd_dev.d_buf = pic32mz_allocbuffer(priv);
+  if (priv->pd_dev.d_buf == NULL)
+    {
+      /* We have no more buffers available for the next Tx..
+       * stop the poll
+       */
 
-          pic32mz_transmit(priv);
-
-          /* Check if the next TX descriptor is available. If not, return a
-           * non-zero value to terminate the poll.
-           */
-
-          if (pic32mz_txdesc(priv) == NULL)
-            {
-              /* There are no more TX descriptors/buffers available..
-               * stop the poll
-               */
-
-              return -EAGAIN;
-            }
-
-          /* Get the next Tx buffer needed in order to continue the poll */
-
-          priv->pd_dev.d_buf = pic32mz_allocbuffer(priv);
-          if (priv->pd_dev.d_buf == NULL)
-            {
-              /* We have no more buffers available for the next Tx..
-               * stop the poll
-               */
-
-              return -ENOMEM;
-            }
-        }
+      return -ENOMEM;
     }
 
   /* If zero is returned, the polling will continue until all connections
    * have been examined.
    */
 
-  return ret;
+  return 0;
 }
 
 /****************************************************************************

--- a/arch/misoc/src/common/misoc_net.c
+++ b/arch/misoc/src/common/misoc_net.c
@@ -282,45 +282,9 @@ static int misoc_net_txpoll(struct net_driver_s *dev)
   struct misoc_net_driver_s *priv =
     (struct misoc_net_driver_s *)dev->d_private;
 
-  /* If the polling resulted in data that should be sent out on the network,
-   * the field d_len is set to a value > 0.
-   */
+  /* Send the packet */
 
-  if (priv->misoc_net_dev.d_len > 0)
-    {
-      /* Look up the destination MAC address and add it to the Ethernet
-       * header.
-       */
-
-#ifdef CONFIG_NET_IPv4
-#ifdef CONFIG_NET_IPv6
-      if (IFF_IS_IPv4(priv->misoc_net_dev.d_flags))
-#endif
-        {
-          arp_out(&priv->misoc_net_dev);
-        }
-#endif /* CONFIG_NET_IPv4 */
-
-#ifdef CONFIG_NET_IPv6
-#ifdef CONFIG_NET_IPv4
-      else
-#endif
-        {
-          neighbor_out(&priv->misoc_net_dev);
-        }
-#endif /* CONFIG_NET_IPv6 */
-
-      if (!devif_loopback(&priv->misoc_net_dev))
-        {
-          /* Send the packet */
-
-          misoc_net_transmit(priv);
-
-          /* Check if there is room in the device to hold another packet.
-           * If not, return a non-zero value to terminate the poll.
-           */
-        }
-    }
+  misoc_net_transmit(priv);
 
   /* If zero is returned, the polling will continue until all connections
    * have been examined.

--- a/arch/renesas/src/rx65n/rx65n_eth.c
+++ b/arch/renesas/src/rx65n/rx65n_eth.c
@@ -1047,76 +1047,44 @@ static int rx65n_txpoll(struct net_driver_s *dev)
 
   DEBUGASSERT(priv->dev.d_buf != NULL);
 
-  /* If the polling resulted in data that should be sent out on the network,
-   * the field d_len is set to a value > 0.
+  /* Send the packet */
+
+  rx65n_transmit(priv);
+  DEBUGASSERT(dev->d_len == 0 && dev->d_buf == NULL);
+
+  /* Check if the next TX descriptor is owned by the Ethernet DMA or
+   * CPU. We cannot perform the TX poll if we are unable to accept
+   * another packet fo transmission.
+   *
+   * In a race condition, TACT may be cleared BUT still not available
+   * because rx65n_freeframe() has not yet run. If rx65n_freeframe()
+   * has run, the buffer1 pointer (tdes2) will be nullified (and
+   * inflight should be CONFIG_RX65N_ETH_NTXDESC).
    */
 
-  if (priv->dev.d_len > 0)
+  if ((priv->txhead->tdes0 & TACT) != 0 ||
+       priv->txhead->tdes2 != 0)
     {
-      /* Look up the destination MAC address and add it to the Ethernet
-       * header.
+      /* We have to terminate the poll if we have no more descriptors
+       * available for another transfer.
        */
 
-#ifdef CONFIG_NET_IPv4
-#ifdef CONFIG_NET_IPv6
-      if (IFF_IS_IPv4(priv->dev.d_flags))
-#endif
-        {
-          arp_out(&priv->dev);
-        }
-#endif /* CONFIG_NET_IPv4 */
+      return -EBUSY;
+    }
 
-#ifdef CONFIG_NET_IPv6
-#ifdef CONFIG_NET_IPv4
-      else
-#endif
-        {
-          neighbor_out(&priv->dev);
-        }
-#endif /* CONFIG_NET_IPv6 */
+  /* We have the descriptor, we can continue the poll. Allocate a new
+   * buffer for the poll.
+   */
 
-      if (!devif_loopback(&priv->dev))
-        {
-          /* Send the packet */
+  dev->d_buf = rx65n_allocbuffer(priv);
 
-          rx65n_transmit(priv);
-          DEBUGASSERT(dev->d_len == 0 && dev->d_buf == NULL);
+  /* We can't continue the poll if we have no buffers */
 
-          /* Check if the next TX descriptor is owned by the Ethernet DMA or
-           * CPU. We cannot perform the TX poll if we are unable to accept
-           * another packet fo transmission.
-           *
-           * In a race condition, TACT may be cleared BUT still not available
-           * because rx65n_freeframe() has not yet run. If rx65n_freeframe()
-           * has run, the buffer1 pointer (tdes2) will be nullified (and
-           * inflight should be CONFIG_RX65N_ETH_NTXDESC).
-           */
+  if (dev->d_buf == NULL)
+    {
+      /* Terminate the poll. */
 
-          if ((priv->txhead->tdes0 & TACT) != 0 ||
-               priv->txhead->tdes2 != 0)
-            {
-              /* We have to terminate the poll if we have no more descriptors
-               * available for another transfer.
-               */
-
-              return -EBUSY;
-            }
-
-          /* We have the descriptor, we can continue the poll. Allocate a new
-           * buffer for the poll.
-           */
-
-          dev->d_buf = rx65n_allocbuffer(priv);
-
-          /* We can't continue the poll if we have no buffers */
-
-          if (dev->d_buf == NULL)
-            {
-              /* Terminate the poll. */
-
-              return -ENOMEM;
-            }
-        }
+      return -ENOMEM;
     }
 
   /* If zero is returned, the polling will continue until all connections

--- a/arch/risc-v/src/esp32c3/esp32c3_wlan.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_wlan.c
@@ -883,45 +883,16 @@ static int wlan_txpoll(struct net_driver_s *dev)
 
   DEBUGASSERT(dev->d_buf != NULL);
 
-  /* If the polling resulted in data that should be sent out on the network,
-   * the field d_len is set to a value > 0.
-   */
+  wlan_cache_txpkt_tail(priv);
 
-  if (dev->d_len > 0)
+  pktbuf = wlan_alloc_buffer(priv);
+  if (pktbuf == NULL)
     {
-      /* Look up the destination MAC address and add it to the Ethernet
-       * header.
-       */
-
-#ifdef CONFIG_NET_IPv4
-#ifdef CONFIG_NET_IPv6
-      if (IFF_IS_IPv4(dev->d_flags))
-#endif
-        {
-          arp_out(dev);
-        }
-#endif /* CONFIG_NET_IPv4 */
-
-#ifdef CONFIG_NET_IPv6
-#ifdef CONFIG_NET_IPv4
-      else
-#endif
-        {
-          neighbor_out(dev);
-        }
-#endif /* CONFIG_NET_IPv6 */
-
-      wlan_cache_txpkt_tail(priv);
-
-      pktbuf = wlan_alloc_buffer(priv);
-      if (pktbuf == NULL)
-        {
-          return -ENOMEM;
-        }
-
-      dev->d_buf = pktbuf->buffer;
-      dev->d_len = WLAN_BUF_SIZE;
+      return -ENOMEM;
     }
+
+  dev->d_buf = pktbuf->buffer;
+  dev->d_len = WLAN_BUF_SIZE;
 
   /* If zero is returned, the polling will continue until
    * all connections have been examined.

--- a/arch/risc-v/src/litex/litex_emac.c
+++ b/arch/risc-v/src/litex/litex_emac.c
@@ -319,41 +319,9 @@ static int litex_txpoll(struct net_driver_s *dev)
 
   DEBUGASSERT(priv->dev.d_buf != NULL);
 
-  /* If the polling resulted in data that should be sent out on the network,
-   * the field d_len is set to a value > 0.
-   */
+  /* Send the packet */
 
-  if (priv->dev.d_len > 0)
-    {
-      /* Look up the destination MAC address and add it to the Ethernet
-       * header.
-       */
-
-#ifdef CONFIG_NET_IPv4
-#ifdef CONFIG_NET_IPv6
-      if (IFF_IS_IPv4(priv->dev.d_flags))
-#endif
-        {
-          arp_out(&priv->dev);
-        }
-#endif /* CONFIG_NET_IPv4 */
-
-#ifdef CONFIG_NET_IPv6
-#ifdef CONFIG_NET_IPv4
-      else
-#endif
-        {
-          neighbor_out(&priv->dev);
-        }
-#endif /* CONFIG_NET_IPv6 */
-
-      if (!devif_loopback(&priv->dev))
-        {
-          /* Send the packet */
-
-          litex_transmit(priv);
-        }
-    }
+  litex_transmit(priv);
 
   /* If zero is returned, the polling will continue until all connections
    * have been examined.

--- a/arch/risc-v/src/mpfs/mpfs_ethernet.c
+++ b/arch/risc-v/src/mpfs/mpfs_ethernet.c
@@ -1411,53 +1411,21 @@ static int mpfs_txpoll(struct net_driver_s *dev)
 {
   struct mpfs_ethmac_s *priv = (struct mpfs_ethmac_s *)dev->d_private;
 
-  /* If the polling resulted in data that should be sent out on the network,
-   * the field d_len is set to a value > 0.
+  /* Send the packet */
+
+  mpfs_transmit(priv, 0);
+
+  /* Check if there are any free TX descriptors.  We cannot perform
+   * the TX poll if we do not have buffering for another packet.
    */
 
-  if (priv->dev.d_len > 0)
+  if (mpfs_txfree(priv, 0) == 0)
     {
-      /* Look up the destination MAC address and add it to the Ethernet
-       * header.
+      /* We have to terminate the poll if we have no more descriptors
+       * available for another transfer.
        */
 
-  #ifdef CONFIG_NET_IPv4
-  #ifdef CONFIG_NET_IPv6
-      if (IFF_IS_IPv4(priv->dev.d_flags))
-  #endif
-        {
-          arp_out(&priv->dev);
-        }
-  #endif /* CONFIG_NET_IPv4 */
-
-  #ifdef CONFIG_NET_IPv6
-    #ifdef CONFIG_NET_IPv4
-      else
-  #endif
-        {
-          neighbor_out(&priv->dev);
-        }
-  #endif /* CONFIG_NET_IPv6 */
-
-      if (!devif_loopback(&priv->dev))
-        {
-          /* Send the packet */
-
-          mpfs_transmit(priv, 0);
-
-          /* Check if there are any free TX descriptors.  We cannot perform
-           * the TX poll if we do not have buffering for another packet.
-           */
-
-          if (mpfs_txfree(priv, 0) == 0)
-            {
-              /* We have to terminate the poll if we have no more descriptors
-               * available for another transfer.
-               */
-
-              return -EBUSY;
-            }
-        }
+      return -EBUSY;
     }
 
   /* If zero is returned, the polling will continue until all connections

--- a/arch/sim/src/sim/sim_netdriver.c
+++ b/arch/sim/src/sim/sim_netdriver.c
@@ -260,54 +260,11 @@ static int netdriver_txpoll(struct net_driver_s *dev)
 
   UNUSED(devidx);
 
-  /* If the polling resulted in data that should be sent out on the network,
-   * the field d_len is set to a value > 0.
-   */
+  /* Send the packet */
 
-  if (dev->d_len > 0)
-    {
-      /* Look up the destination MAC address and add it to the Ethernet
-       * header.
-       */
-
-#ifdef CONFIG_NET_IPv4
-#ifdef CONFIG_NET_IPv6
-      if (IFF_IS_IPv4(dev->d_flags))
-#endif
-        {
-          arp_out(dev);
-        }
-#endif /* CONFIG_NET_IPv4 */
-
-#ifdef CONFIG_NET_IPv6
-#ifdef CONFIG_NET_IPv4
-      else
-#endif
-        {
-          neighbor_out(dev);
-        }
-#endif /* CONFIG_NET_IPv6 */
-
-      if (!devif_loopback(dev))
-        {
-          /* Send the packet */
-
-          NETDEV_TXPACKETS(dev);
-          sim_netdev_send(devidx, dev->d_buf, dev->d_len);
-          NETDEV_TXDONE(dev);
-        }
-      else
-        {
-          /* Calling txdone callback after loopback. NETDEV_TXDONE macro is
-           * already called in devif_loopback.
-           *
-           * TODO: Maybe a unified interface with txdone callback registered
-           * is needed, then we can let devif_loopback call this callback.
-           */
-
-          netdriver_txdone_interrupt(dev);
-        }
-    }
+  NETDEV_TXPACKETS(dev);
+  sim_netdev_send(devidx, dev->d_buf, dev->d_len);
+  NETDEV_TXDONE(dev);
 
   /* If zero is returned, the polling will continue until all connections
    * have been examined.

--- a/arch/xtensa/src/esp32/esp32_wlan.c
+++ b/arch/xtensa/src/esp32/esp32_wlan.c
@@ -880,45 +880,16 @@ static int wlan_txpoll(struct net_driver_s *dev)
 
   DEBUGASSERT(dev->d_buf != NULL);
 
-  /* If the polling resulted in data that should be sent out on the network,
-   * the field d_len is set to a value > 0.
-   */
+  wlan_cache_txpkt_tail(priv);
 
-  if (dev->d_len > 0)
+  pktbuf = wlan_alloc_buffer(priv);
+  if (!pktbuf)
     {
-      /* Look up the destination MAC address and add it to the Ethernet
-       * header.
-       */
-
-#ifdef CONFIG_NET_IPv4
-#ifdef CONFIG_NET_IPv6
-      if (IFF_IS_IPv4(dev->d_flags))
-#endif
-        {
-          arp_out(dev);
-        }
-#endif /* CONFIG_NET_IPv4 */
-
-#ifdef CONFIG_NET_IPv6
-#ifdef CONFIG_NET_IPv4
-      else
-#endif
-        {
-          neighbor_out(dev);
-        }
-#endif /* CONFIG_NET_IPv6 */
-
-      wlan_cache_txpkt_tail(priv);
-
-      pktbuf = wlan_alloc_buffer(priv);
-      if (!pktbuf)
-        {
-          return -ENOMEM;
-        }
-
-      dev->d_buf = pktbuf->buffer;
-      dev->d_len = WLAN_BUF_SIZE;
+      return -ENOMEM;
     }
+
+  dev->d_buf = pktbuf->buffer;
+  dev->d_len = WLAN_BUF_SIZE;
 
   /* If zero is returned, the polling will continue until
    * all connections have been examined.

--- a/arch/z80/src/ez80/ez80_emac.c
+++ b/arch/z80/src/ez80/ez80_emac.c
@@ -1151,52 +1151,12 @@ static int ez80emac_txpoll(FAR struct net_driver_s *dev)
 {
   FAR struct ez80emac_driver_s *priv =
     (FAR struct ez80emac_driver_s *)dev->d_private;
-  int ret = 0;
 
-  /* If the polling resulted in data that should be sent out on the network,
-   * the field d_len is set to a value > 0.
+  /* Send the packet.  ez80emac_transmit() will return zero if the
+   * packet was successfully handled.
    */
 
-  ninfo("Poll result: d_len=%d\n", priv->dev.d_len);
-  if (priv->dev.d_len > 0)
-    {
-      /* Look up the destination MAC address and add it to the Ethernet
-       * header.
-       */
-
-#ifdef CONFIG_NET_IPv4
-#ifdef CONFIG_NET_IPv6
-      if (IFF_IS_IPv4(priv->dev.d_flags))
-#endif
-        {
-          arp_out(&priv->dev);
-        }
-#endif /* CONFIG_NET_IPv4 */
-
-#ifdef CONFIG_NET_IPv6
-#ifdef CONFIG_NET_IPv4
-      else
-#endif
-        {
-          neighbor_out(&priv->dev);
-        }
-#endif /* CONFIG_NET_IPv6 */
-
-      if (!devif_loopback(&priv->dev))
-        {
-          /* Send the packet.  ez80emac_transmit() will return zero if the
-           * packet was successfully handled.
-           */
-
-          ret = ez80emac_transmit(priv);
-        }
-    }
-
-  /* If zero is returned, the polling will continue until all connections
-   * have been examined.
-   */
-
-  return ret;
+  return ez80emac_transmit(priv);
 }
 
 /****************************************************************************

--- a/drivers/net/enc28j60.c
+++ b/drivers/net/enc28j60.c
@@ -1175,52 +1175,13 @@ static int enc_txpoll(struct net_driver_s *dev)
 {
   FAR struct enc_driver_s *priv = (FAR struct enc_driver_s *)dev->d_private;
 
-  /* If the polling resulted in data that should be sent out on the network,
-   * the field d_len is set to a value > 0.
-   */
+  /* Send the packet */
 
-  ninfo("Poll result: d_len=%d\n", priv->dev.d_len);
-  if (priv->dev.d_len > 0)
-    {
-      /* Look up the destination MAC address and add it to the Ethernet
-       * header.
-       */
+  enc_transmit(priv);
 
-#ifdef CONFIG_NET_IPv4
-#ifdef CONFIG_NET_IPv6
-      if (IFF_IS_IPv4(priv->dev.d_flags))
-#endif
-        {
-          arp_out(&priv->dev);
-        }
-#endif /* CONFIG_NET_IPv4 */
+  /* Stop the poll now because we can queue only one packet */
 
-#ifdef CONFIG_NET_IPv6
-#ifdef CONFIG_NET_IPv4
-      else
-#endif
-        {
-          neighbor_out(&priv->dev);
-        }
-#endif /* CONFIG_NET_IPv6 */
-
-      if (!devif_loopback(&priv->dev))
-        {
-          /* Send the packet */
-
-          enc_transmit(priv);
-
-          /* Stop the poll now because we can queue only one packet */
-
-          return -EBUSY;
-        }
-    }
-
-  /* If zero is returned, the polling will continue until all connections
-   * have been examined.
-   */
-
-  return OK;
+  return -EBUSY;
 }
 
 /****************************************************************************

--- a/drivers/net/encx24j600.c
+++ b/drivers/net/encx24j600.c
@@ -1146,51 +1146,8 @@ static int enc_txenqueue(FAR struct enc_driver_s *priv)
 static int enc_txpoll(struct net_driver_s *dev)
 {
   FAR struct enc_driver_s *priv = (FAR struct enc_driver_s *)dev->d_private;
-  int ret = OK;
 
-  /* If the polling resulted in data that should be sent out on the network,
-   * the field d_len is set to a value > 0.
-   */
-
-  ninfo("Poll result: d_len=%d\n", priv->dev.d_len);
-
-  if (priv->dev.d_len > 0)
-    {
-      /* Look up the destination MAC address and add it to the Ethernet
-       * header.
-       */
-
-#ifdef CONFIG_NET_IPv4
-#ifdef CONFIG_NET_IPv6
-      if (IFF_IS_IPv4(priv->dev.d_flags))
-#endif
-        {
-          arp_out(&priv->dev);
-        }
-#endif /* CONFIG_NET_IPv4 */
-
-#ifdef CONFIG_NET_IPv6
-#ifdef CONFIG_NET_IPv4
-      else
-#endif
-        {
-          neighbor_out(&priv->dev);
-        }
-#endif /* CONFIG_NET_IPv6 */
-
-      if (!devif_loopback(&priv->dev))
-        {
-          /* Send the packet */
-
-          ret = enc_txenqueue(priv);
-        }
-    }
-
-  /* If zero is returned, the polling will continue until all connections
-   * have been examined.
-   */
-
-  return ret;
+  return enc_txenqueue(priv);
 }
 
 /****************************************************************************

--- a/drivers/net/ftmac100.c
+++ b/drivers/net/ftmac100.c
@@ -345,45 +345,9 @@ static int ftmac100_txpoll(struct net_driver_s *dev)
   FAR struct ftmac100_driver_s *priv =
     (FAR struct ftmac100_driver_s *)dev->d_private;
 
-  /* If the polling resulted in data that should be sent out on the network,
-   * the field d_len is set to a value > 0.
-   */
+  /* Send the packet */
 
-  if (priv->ft_dev.d_len > 0)
-    {
-      /* Look up the destination MAC address and add it to the Ethernet
-       * header.
-       */
-
-#ifdef CONFIG_NET_IPv4
-#ifdef CONFIG_NET_IPv6
-      if (IFF_IS_IPv4(priv->ft_dev.d_flags))
-#endif
-        {
-          arp_out(&priv->ft_dev);
-        }
-#endif /* CONFIG_NET_IPv4 */
-
-#ifdef CONFIG_NET_IPv6
-#ifdef CONFIG_NET_IPv4
-      else
-#endif
-        {
-          neighbor_out(&priv->ft_dev);
-        }
-#endif /* CONFIG_NET_IPv6 */
-
-      if (!devif_loopback(&priv->ft_dev))
-        {
-          /* Send the packet */
-
-          ftmac100_transmit(priv);
-
-          /* Check if there is room in the device to hold another packet.  If
-           * not, return a non-zero value to terminate the poll.
-           */
-        }
-    }
+  ftmac100_transmit(priv);
 
   /* If zero is returned, the polling will continue until all connections
    * have been examined.

--- a/drivers/net/lan91c111.c
+++ b/drivers/net/lan91c111.c
@@ -496,49 +496,15 @@ static int lan91c111_txpoll(FAR struct net_driver_s *dev)
 {
   FAR struct lan91c111_driver_s *priv = dev->d_private;
 
-  /* If the polling resulted in data that should be sent out on the network,
-   * the field d_len is set to a value > 0.
+  /* Send the packet */
+
+  lan91c111_transmit(dev);
+
+  /* Check if there is room in the device to hold another packet.  If
+   * not, return a non-zero value to terminate the poll.
    */
 
-  if (dev->d_len > 0)
-    {
-      /* Look up the destination MAC address and add it to the Ethernet
-       * header.
-       */
-
-#ifdef CONFIG_NET_IPv4
-      if (IFF_IS_IPv4(dev->d_flags))
-        {
-          arp_out(dev);
-        }
-#endif /* CONFIG_NET_IPv4 */
-
-#ifdef CONFIG_NET_IPv6
-      if (IFF_IS_IPv6(dev->d_flags))
-        {
-          neighbor_out(dev);
-        }
-#endif /* CONFIG_NET_IPv6 */
-
-      if (!devif_loopback(dev))
-        {
-          /* Send the packet */
-
-          lan91c111_transmit(dev);
-
-          /* Check if there is room in the device to hold another packet.  If
-           * not, return a non-zero value to terminate the poll.
-           */
-
-          return !(getreg16(priv, MIR_REG) & MIR_FREE_MASK);
-        }
-    }
-
-  /* If zero is returned, the polling will continue until all connections
-   * have been examined.
-   */
-
-  return 0;
+  return !(getreg16(priv, MIR_REG) & MIR_FREE_MASK);
 }
 
 /****************************************************************************

--- a/drivers/net/skeleton.c
+++ b/drivers/net/skeleton.c
@@ -255,50 +255,9 @@ static int skel_txpoll(FAR struct net_driver_s *dev)
   FAR struct skel_driver_s *priv =
     (FAR struct skel_driver_s *)dev->d_private;
 
-  /* If the polling resulted in data that should be sent out on the network,
-   * the field d_len is set to a value > 0.
-   */
+  /* Send the packet */
 
-  if (priv->sk_dev.d_len > 0)
-    {
-      /* Look up the destination MAC address and add it to the Ethernet
-       * header.
-       */
-
-#ifdef CONFIG_NET_IPv4
-#ifdef CONFIG_NET_IPv6
-      if (IFF_IS_IPv4(priv->sk_dev.d_flags))
-#endif
-        {
-          arp_out(&priv->sk_dev);
-        }
-#endif /* CONFIG_NET_IPv4 */
-
-#ifdef CONFIG_NET_IPv6
-#ifdef CONFIG_NET_IPv4
-      else
-#endif
-        {
-          neighbor_out(&priv->sk_dev);
-        }
-#endif /* CONFIG_NET_IPv6 */
-
-      /* Check if the network is sending this packet to the IP address of
-       * this device.  If so, just loop the packet back into the network but
-       * don't attempt to put it on the wire.
-       */
-
-      if (!devif_loopback(&priv->sk_dev))
-        {
-          /* Send the packet */
-
-          skel_transmit(priv);
-
-          /* Check if there is room in the device to hold another packet.
-           * If not, return a non-zero value to terminate the poll.
-           */
-        }
-    }
+  skel_transmit(priv);
 
   /* If zero is returned, the polling will continue until all connections
    * have been examined.

--- a/drivers/net/slip.c
+++ b/drivers/net/slip.c
@@ -355,17 +355,7 @@ static int slip_txpoll(FAR struct net_driver_s *dev)
   FAR struct slip_driver_s *priv =
     (FAR struct slip_driver_s *)dev->d_private;
 
-  /* If the polling resulted in data that should be sent out on the network,
-   * the field d_len is set to a value > 0.
-   */
-
-  if (priv->dev.d_len > 0)
-    {
-      if (!devif_loopback(&priv->dev))
-        {
-          slip_transmit(priv);
-        }
-    }
+  slip_transmit(priv);
 
   /* If zero is returned, the polling will continue until all connections
    * have been examined.

--- a/drivers/net/tun.c
+++ b/drivers/net/tun.c
@@ -358,46 +358,12 @@ static int tun_txpoll_tap(FAR struct net_driver_s *dev)
 {
   FAR struct tun_device_s *priv = (FAR struct tun_device_s *)dev->d_private;
 
-  /* If the polling resulted in data that should be sent out on the network,
-   * the field d_len is set to a value > 0.
-   */
+  /* Send the packet */
 
-  if (priv->dev.d_len > 0)
-    {
-      /* Look up the destination MAC address and add it to the Ethernet
-       * header.
-       */
+  priv->read_d_len = priv->dev.d_len;
+  tun_fd_transmit(priv);
 
-#ifdef CONFIG_NET_IPv4
-      if (IFF_IS_IPv4(priv->dev.d_flags))
-        {
-          arp_out(&priv->dev);
-        }
-#endif /* CONFIG_NET_IPv4 */
-
-#ifdef CONFIG_NET_IPv6
-      if (IFF_IS_IPv6(priv->dev.d_flags))
-        {
-          neighbor_out(&priv->dev);
-        }
-#endif /* CONFIG_NET_IPv6 */
-
-      if (!devif_loopback(dev))
-        {
-          /* Send the packet */
-
-          priv->read_d_len = priv->dev.d_len;
-          tun_fd_transmit(priv);
-
-          return 1;
-        }
-    }
-
-  /* If zero is returned, the polling will continue until all connections
-   * have been examined.
-   */
-
-  return 0;
+  return 1;
 }
 #endif
 
@@ -430,28 +396,10 @@ static int tun_txpoll_tun(FAR struct net_driver_s *dev)
 {
   FAR struct tun_device_s *priv = (FAR struct tun_device_s *)dev->d_private;
 
-  /* If the polling resulted in data that should be sent out on the network,
-   * the field d_len is set to a value > 0.
-   */
+  priv->read_d_len = priv->dev.d_len;
+  tun_fd_transmit(priv);
 
-  if (priv->dev.d_len > 0)
-    {
-      if (!devif_loopback(dev))
-        {
-          /* Send the packet */
-
-          priv->read_d_len = priv->dev.d_len;
-          tun_fd_transmit(priv);
-
-          return 1;
-        }
-    }
-
-  /* If zero is returned, the polling will continue until all connections
-   * have been examined.
-   */
-
-  return 0;
+  return 1;
 }
 
 /****************************************************************************

--- a/drivers/usbdev/cdcecm.c
+++ b/drivers/usbdev/cdcecm.c
@@ -340,53 +340,15 @@ static int cdcecm_txpoll(FAR struct net_driver_s *dev)
   FAR struct cdcecm_driver_s *priv =
     (FAR struct cdcecm_driver_s *)dev->d_private;
 
-  /* If the polling resulted in data that should be sent out on the network,
-   * the field d_len is set to a value > 0.
+  /* Send the packet */
+
+  cdcecm_transmit(priv);
+
+  /* Check if there is room in the device to hold another packet. If
+   * not, return a non-zero value to terminate the poll.
    */
 
-  if (priv->dev.d_len > 0)
-    {
-      /* Look up the destination MAC address and add it to the Ethernet
-       * header.
-       */
-
-#ifdef CONFIG_NET_IPv4
-#ifdef CONFIG_NET_IPv6
-      if (IFF_IS_IPv4(priv->dev.d_flags))
-#endif
-        {
-          arp_out(&priv->dev);
-        }
-#endif /* CONFIG_NET_IPv4 */
-
-#ifdef CONFIG_NET_IPv6
-#ifdef CONFIG_NET_IPv4
-      else
-#endif
-        {
-          neighbor_out(&priv->dev);
-        }
-#endif /* CONFIG_NET_IPv6 */
-
-      if (!devif_loopback(&priv->dev))
-        {
-          /* Send the packet */
-
-          cdcecm_transmit(priv);
-
-          /* Check if there is room in the device to hold another packet. If
-           * not, return a non-zero value to terminate the poll.
-           */
-
-          return 1;
-        }
-    }
-
-  /* If zero is returned, the polling will continue until all connections
-   * have been examined.
-   */
-
-  return 0;
+  return 1;
 }
 
 /****************************************************************************

--- a/drivers/usbdev/rndis.c
+++ b/drivers/usbdev/rndis.c
@@ -983,53 +983,13 @@ static void rndis_rxdispatch(FAR void *arg)
 static int rndis_txpoll(FAR struct net_driver_s *dev)
 {
   FAR struct rndis_dev_s *priv = (FAR struct rndis_dev_s *)dev->d_private;
-  int ret = OK;
 
   if (!priv->connected)
     {
       return -EBUSY;
     }
 
-  /* If the polling resulted in data that should be sent out on the network,
-   * the field d_len is set to a value > 0.
-   */
-
-  ninfo("Poll result: d_len=%d\n", priv->netdev.d_len);
-  if (priv->netdev.d_len > 0)
-    {
-      /* Look up the destination MAC address and add it to the Ethernet
-       * header.
-       */
-
-#ifdef CONFIG_NET_IPv4
-#ifdef CONFIG_NET_IPv6
-      if (IFF_IS_IPv4(priv->netdev.d_flags))
-#endif
-        {
-          arp_out(&priv->netdev);
-        }
-#endif /* CONFIG_NET_IPv4 */
-
-#ifdef CONFIG_NET_IPv6
-#ifdef CONFIG_NET_IPv4
-      else
-#endif
-        {
-          neighbor_out(&priv->netdev);
-        }
-#endif /* CONFIG_NET_IPv6 */
-
-      if (!devif_loopback(&priv->netdev))
-        {
-          ret = rndis_transmit(priv);
-        }
-    }
-
-  /* If zero is returned, the polling will continue until all connections
-   * have been examined.
-   */
-
-  return ret;
+  return rndis_transmit(priv);
 }
 
 /****************************************************************************

--- a/drivers/usbhost/usbhost_cdcmbim.c
+++ b/drivers/usbhost/usbhost_cdcmbim.c
@@ -2277,15 +2277,9 @@ static int cdcmbim_txpoll(struct net_driver_s *dev)
 
   nxmutex_lock(&priv->lock);
 
-  if (priv->netdev.d_len > 0)
-    {
-      if (!devif_loopback(&priv->netdev))
-        {
-          /* Send the packet */
+  /* Send the packet */
 
-          cdcmbim_transmit(priv);
-        }
-    }
+  cdcmbim_transmit(priv);
 
   nxmutex_unlock(&priv->lock);
 

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_netdev.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_netdev.c
@@ -436,54 +436,16 @@ static int bcmf_txpoll(FAR struct net_driver_s *dev)
 {
   FAR struct bcmf_dev_s *priv = (FAR struct bcmf_dev_s *)dev->d_private;
 
-  /* If the polling resulted in data that should be sent out on the network,
-   * the field d_len is set to a value > 0.
+  /* Send the packet */
+
+  bcmf_transmit(priv, priv->cur_tx_frame);
+
+  /* TODO: Check if there is room in the device to hold another
+   * packet. If not, return a non-zero value to terminate the poll.
    */
 
-  if (priv->bc_dev.d_len > 0)
-    {
-      /* Look up the destination MAC address and add it to the Ethernet
-       * header.
-       */
-
-#ifdef CONFIG_NET_IPv4
-#ifdef CONFIG_NET_IPv6
-      if (IFF_IS_IPv4(priv->bc_dev.d_flags))
-#endif
-        {
-          arp_out(&priv->bc_dev);
-        }
-#endif /* CONFIG_NET_IPv4 */
-
-#ifdef CONFIG_NET_IPv6
-#ifdef CONFIG_NET_IPv4
-      else
-#endif
-        {
-          neighbor_out(&priv->bc_dev);
-        }
-#endif /* CONFIG_NET_IPv6 */
-
-      if (!devif_loopback(&priv->bc_dev))
-        {
-          /* Send the packet */
-
-          bcmf_transmit(priv, priv->cur_tx_frame);
-
-          /* TODO: Check if there is room in the device to hold another
-           * packet. If not, return a non-zero value to terminate the poll.
-           */
-
-          priv->cur_tx_frame = NULL;
-          return 1;
-        }
-    }
-
-  /* If zero is returned, the polling will continue until all connections
-   * have been examined.
-   */
-
-  return 0;
+  priv->cur_tx_frame = NULL;
+  return 1;
 }
 
 /****************************************************************************

--- a/include/nuttx/net/netdev.h
+++ b/include/nuttx/net/netdev.h
@@ -595,23 +595,6 @@ void neighbor_out(FAR struct net_driver_s *dev);
 #endif /* CONFIG_NET_IPv6 */
 
 /****************************************************************************
- * Name: devif_loopback
- *
- * Description:
- *   This function should be called before sending out a packet. The function
- *   checks the destination address of the packet to see whether the target
- *   of packet is ourself and then consume the packet directly by calling
- *   input process functions.
- *
- * Returned Value:
- *   Zero is returned if the packet don't loop back to ourself, otherwise
- *   a non-zero value is returned.
- *
- ****************************************************************************/
-
-int devif_loopback(FAR struct net_driver_s *dev);
-
-/****************************************************************************
  * Name: netdev_ifup / netdev_ifdown
  *
  * Description:

--- a/net/arp/arp_poll.c
+++ b/net/arp/arp_poll.c
@@ -64,7 +64,7 @@ int arp_poll(FAR struct net_driver_s *dev, devif_poll_callback_t callback)
 
   /* Call back into the driver */
 
-  return callback(dev);
+  return devif_out(dev, callback);
 }
 
 #endif /* CONFIG_NET_ARP_SEND */

--- a/net/devif/devif.h
+++ b/net/devif/devif.h
@@ -52,6 +52,7 @@
 #include <arch/irq.h>
 
 #include <nuttx/net/ip.h>
+#include <nuttx/net/netdev.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -512,6 +513,20 @@ void devif_pkt_send(FAR struct net_driver_s *dev, FAR const void *buf,
 void devif_can_send(FAR struct net_driver_s *dev, FAR const void *buf,
                     unsigned int len);
 #endif
+
+/****************************************************************************
+ * Name: devif_out
+ *
+ * Description:
+ *   Generic callback before device output to build L2 headers before sending
+ *
+ * Assumptions:
+ *   This function is called from the MAC device driver with the network
+ *   locked.
+ *
+ ****************************************************************************/
+
+int devif_out(FAR struct net_driver_s *dev, devif_poll_callback_t callback);
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/net/devif/devif.h
+++ b/net/devif/devif.h
@@ -528,6 +528,23 @@ void devif_can_send(FAR struct net_driver_s *dev, FAR const void *buf,
 
 int devif_out(FAR struct net_driver_s *dev, devif_poll_callback_t callback);
 
+/****************************************************************************
+ * Name: devif_loopback
+ *
+ * Description:
+ *   This function should be called before sending out a packet. The function
+ *   checks the destination address of the packet to see whether the target
+ *   of packet is ourself and then consume the packet directly by calling
+ *   input process functions.
+ *
+ * Returned Value:
+ *   Zero is returned if the packet don't loop back to ourself, otherwise
+ *   a non-zero value is returned.
+ *
+ ****************************************************************************/
+
+int devif_loopback(FAR struct net_driver_s *dev);
+
 #undef EXTERN
 #ifdef __cplusplus
 }

--- a/net/devif/devif_poll.c
+++ b/net/devif/devif_poll.c
@@ -377,7 +377,7 @@ static inline int devif_poll_icmp(FAR struct net_driver_s *dev,
 
           /* Call back into the driver */
 
-          bstop = callback(dev);
+          bstop = devif_out(dev, callback);
         }
     }
 
@@ -424,7 +424,7 @@ static inline int devif_poll_icmpv6(FAR struct net_driver_s *dev,
 
           /* Call back into the driver */
 
-          bstop = callback(dev);
+          bstop = devif_out(dev, callback);
         }
     }
   while (!bstop && (conn = icmpv6_nextconn(conn)) != NULL);
@@ -456,7 +456,7 @@ static inline int devif_poll_forward(FAR struct net_driver_s *dev,
 
   /* Call back into the driver */
 
-  return callback(dev);
+  return devif_out(dev, callback);
 }
 #endif /* CONFIG_NET_ICMPv6_SOCKET || CONFIG_NET_ICMPv6_NEIGHBOR*/
 
@@ -486,7 +486,7 @@ static inline int devif_poll_igmp(FAR struct net_driver_s *dev,
 
   /* Call back into the driver */
 
-  return callback(dev);
+  return devif_out(dev, callback);
 }
 #endif /* CONFIG_NET_IGMP */
 
@@ -516,7 +516,7 @@ static inline int devif_poll_mld(FAR struct net_driver_s *dev,
 
   /* Call back into the driver */
 
-  return callback(dev);
+  return devif_out(dev, callback);
 }
 #endif /* CONFIG_NET_MLD */
 
@@ -561,7 +561,7 @@ static int devif_poll_udp_connections(FAR struct net_driver_s *dev,
 
           /* Call back into the driver */
 
-          bstop = callback(dev);
+          bstop = devif_out(dev, callback);
         }
     }
 
@@ -606,7 +606,7 @@ static inline int devif_poll_tcp_connections(FAR struct net_driver_s *dev,
 
           /* Call back into the driver */
 
-          bstop = callback(dev);
+          bstop = devif_out(dev, callback);
         }
     }
 
@@ -769,6 +769,28 @@ int devif_poll(FAR struct net_driver_s *dev, devif_poll_callback_t callback)
     }
 
   return bstop;
+}
+
+/****************************************************************************
+ * Name: devif_out
+ *
+ * Description:
+ *   Generic callback before device output to build L2 headers before sending
+ *
+ * Assumptions:
+ *   This function is called from the MAC device driver with the network
+ *   locked.
+ *
+ ****************************************************************************/
+
+int devif_out(FAR struct net_driver_s *dev, devif_poll_callback_t callback)
+{
+  if (dev->d_len == 0)
+    {
+      return 0;
+    }
+
+  return callback(dev);
 }
 
 #endif /* CONFIG_NET */


### PR DESCRIPTION
## Summary

net/devif: add common funtion to build L2 headers before sending
net/devif: move preprocess of txpoll into common code

## Impact

N/A

## Testing

ci-check