### PR TITLE
boards: cxd56xx: Fix the build error in cxd56_crashdump.c

### DIFF
--- a/boards/arm/cxd56xx/common/src/cxd56_crashdump.c
+++ b/boards/arm/cxd56xx/common/src/cxd56_crashdump.c
@@ -238,5 +238,7 @@ void board_crashdump(uintptr_t currentsp, void *tcb,
 exit:
 #if defined(CONFIG_CXD56_RESET_ON_CRASH)
   board_reset_on_crash();
+#else
+  return;
 #endif
 }


### PR DESCRIPTION
## Summary

- This commit fixes the build error in cxd56_crashdump.c regressed by https://github.com/apache/nuttx/pull/7707

## Impact

- None

## Testing

- Tested with spresense:wifi

