### PR TITLE
inet: fix compile failed if not define UDP

### DIFF
--- a/net/inet/ipv4_setsockopt.c
+++ b/net/inet/ipv4_setsockopt.c
@@ -174,6 +174,7 @@ int ipv4_setsockopt(FAR struct socket *psock, int option,
         }
         break;
 
+#if defined(CONFIG_NET_UDP) && !defined(CONFIG_NET_UDP_NO_STACK)
       case IP_MULTICAST_TTL:          /* Set/read the time-to-live value of
                                        * outgoing multicast packets */
         {
@@ -230,6 +231,7 @@ int ipv4_setsockopt(FAR struct socket *psock, int option,
           ret = OK;
         }
         break;
+#endif
 
       /* The following IPv4 socket options are defined, but not implemented */
 


### PR DESCRIPTION

## Summary

inet: fix compile failed if not define UDP

inet/ipv4_setsockopt.c: In function ‘ipv4_setsockopt’: inet/ipv4_setsockopt.c:200:19: error: invalid use of undefined type ‘struct udp_conn_s’
  200 |               conn->ttl = ttl;
      |                   ^~
inet/ipv4_setsockopt.c:223:19: error: invalid use of undefined type ‘struct udp_conn_s’
  223 |               conn->flags |= _UDP_FLAG_PKTINFO;
      |                   ^~
inet/ipv4_setsockopt.c:223:30: error: ‘_UDP_FLAG_PKTINFO’ undeclared (first use in this function)
  223 |               conn->flags |= _UDP_FLAG_PKTINFO;
      |                              ^~~~~~~~~~~~~~~~~
inet/ipv4_setsockopt.c:223:30: note: each undeclared identifier is reported only once for each function it appears in
inet/ipv4_setsockopt.c:227:19: error: invalid use of undefined type ‘struct udp_conn_s’
  227 |               conn->flags &= ~_UDP_FLAG_PKTINFO;

Signed-off-by: ligd <liguiding1@xiaomi.com>


## Impact

UDP

## Testing

Build error fix