### PR TITLE
armv7-r: correct the wrong usage of ARMV7A_XX marco

### DIFF
--- a/arch/arm/include/armv7-r/irq.h
+++ b/arch/arm/include/armv7-r/irq.h
@@ -357,7 +357,7 @@ static inline irqstate_t up_irq_save(void)
     (
       "\tmrs    %0, cpsr\n"
       "\tcpsid  i\n"
-#if defined(CONFIG_ARMV7A_DECODEFIQ)
+#if defined(CONFIG_ARMV7R_DECODEFIQ)
       "\tcpsid  f\n"
 #endif
       : "=r" (cpsr)
@@ -378,7 +378,7 @@ static inline irqstate_t up_irq_enable(void)
     (
       "\tmrs    %0, cpsr\n"
       "\tcpsie  i\n"
-#if defined(CONFIG_ARMV7A_DECODEFIQ)
+#if defined(CONFIG_ARMV7R_DECODEFIQ)
       "\tcpsie  f\n"
 #endif
       : "=r" (cpsr)

--- a/arch/arm/src/armv7-r/arm_timer.h
+++ b/arch/arm/src/armv7-r/arm_timer.h
@@ -57,7 +57,7 @@ extern "C"
  *
  ****************************************************************************/
 
-#ifdef CONFIG_ARMV7A_HAVE_PTM
+#ifdef CONFIG_ARMV7R_HAVE_PTM
 struct oneshot_lowerhalf_s *arm_timer_initialize(unsigned int freq);
 #else
 #  define arm_timer_initialize(freq) NULL

--- a/arch/arm/src/armv7-r/arm_vectors.S
+++ b/arch/arm/src/armv7-r/arm_vectors.S
@@ -132,7 +132,7 @@ arm_vectorirq:
 
 	/* Switch to SYS mode */
 
-#ifdef CONFIG_ARMV7A_DECODEFIQ
+#ifdef CONFIG_ARMV7R_DECODEFIQ
 	cpsid		if, #PSR_MODE_SYS
 #else
 	cpsid		i, #PSR_MODE_SYS
@@ -242,7 +242,7 @@ arm_vectorsvc:
 
 	/* Switch to SYS mode */
 
-#ifdef CONFIG_ARMV7A_DECODEFIQ
+#ifdef CONFIG_ARMV7R_DECODEFIQ
 	cpsid		if, #PSR_MODE_SYS
 #else
 	cpsid		i, #PSR_MODE_SYS
@@ -353,7 +353,7 @@ arm_vectordata:
 
 	/* Switch to SYS mode */
 
-#ifdef CONFIG_ARMV7A_DECODEFIQ
+#ifdef CONFIG_ARMV7R_DECODEFIQ
 	cpsid		if, #PSR_MODE_SYS
 #else
 	cpsid		i, #PSR_MODE_SYS


### PR DESCRIPTION


## Summary

armv7-r: correct the wrong usage of ARMV7A_XX marco

## Impact

armv7r

## Testing

VELA