### PR TITLE
net/devif: add common interface to build L2 headers

### DIFF
--- a/net/arp/arp_poll.c
+++ b/net/arp/arp_poll.c
@@ -64,7 +64,7 @@ int arp_poll(FAR struct net_driver_s *dev, devif_poll_callback_t callback)
 
   /* Call back into the driver */
 
-  return devif_out(dev, callback);
+  return devif_poll_out(dev, callback);
 }
 
 #endif /* CONFIG_NET_ARP_SEND */

--- a/net/devif/devif.h
+++ b/net/devif/devif.h
@@ -518,6 +518,20 @@ void devif_can_send(FAR struct net_driver_s *dev, FAR const void *buf,
  * Name: devif_out
  *
  * Description:
+ *   Common interface to build L2 headers
+ *
+ * Assumptions:
+ *   This function is called from the MAC device driver with the network
+ *   locked.
+ *
+ ****************************************************************************/
+
+void devif_out(FAR struct net_driver_s *dev);
+
+/****************************************************************************
+ * Name: devif_poll_out
+ *
+ * Description:
  *   Generic callback before device output to build L2 headers before sending
  *
  * Assumptions:
@@ -526,7 +540,8 @@ void devif_can_send(FAR struct net_driver_s *dev, FAR const void *buf,
  *
  ****************************************************************************/
 
-int devif_out(FAR struct net_driver_s *dev, devif_poll_callback_t callback);
+int devif_poll_out(FAR struct net_driver_s *dev,
+                   devif_poll_callback_t callback);
 
 /****************************************************************************
  * Name: devif_loopback

--- a/net/devif/devif_poll.c
+++ b/net/devif/devif_poll.c
@@ -378,7 +378,7 @@ static inline int devif_poll_icmp(FAR struct net_driver_s *dev,
 
           /* Call back into the driver */
 
-          bstop = devif_out(dev, callback);
+          bstop = devif_poll_out(dev, callback);
         }
     }
 
@@ -425,7 +425,7 @@ static inline int devif_poll_icmpv6(FAR struct net_driver_s *dev,
 
           /* Call back into the driver */
 
-          bstop = devif_out(dev, callback);
+          bstop = devif_poll_out(dev, callback);
         }
     }
   while (!bstop && (conn = icmpv6_nextconn(conn)) != NULL);
@@ -457,7 +457,7 @@ static inline int devif_poll_forward(FAR struct net_driver_s *dev,
 
   /* Call back into the driver */
 
-  return devif_out(dev, callback);
+  return devif_poll_out(dev, callback);
 }
 #endif /* CONFIG_NET_ICMPv6_SOCKET || CONFIG_NET_ICMPv6_NEIGHBOR*/
 
@@ -487,7 +487,7 @@ static inline int devif_poll_igmp(FAR struct net_driver_s *dev,
 
   /* Call back into the driver */
 
-  return devif_out(dev, callback);
+  return devif_poll_out(dev, callback);
 }
 #endif /* CONFIG_NET_IGMP */
 
@@ -517,7 +517,7 @@ static inline int devif_poll_mld(FAR struct net_driver_s *dev,
 
   /* Call back into the driver */
 
-  return devif_out(dev, callback);
+  return devif_poll_out(dev, callback);
 }
 #endif /* CONFIG_NET_MLD */
 
@@ -562,7 +562,7 @@ static int devif_poll_udp_connections(FAR struct net_driver_s *dev,
 
           /* Call back into the driver */
 
-          bstop = devif_out(dev, callback);
+          bstop = devif_poll_out(dev, callback);
         }
     }
 
@@ -607,7 +607,7 @@ static inline int devif_poll_tcp_connections(FAR struct net_driver_s *dev,
 
           /* Call back into the driver */
 
-          bstop = devif_out(dev, callback);
+          bstop = devif_poll_out(dev, callback);
         }
     }
 
@@ -776,6 +776,54 @@ int devif_poll(FAR struct net_driver_s *dev, devif_poll_callback_t callback)
  * Name: devif_out
  *
  * Description:
+ *   Generic interface to build L2 headers
+ *
+ * Assumptions:
+ *   This function is called from the MAC device driver with the network
+ *   locked.
+ *
+ ****************************************************************************/
+
+void devif_out(FAR struct net_driver_s *dev)
+{
+  if (dev->d_len == 0)
+    {
+      return;
+    }
+
+  switch (dev->d_lltype)
+    {
+#ifdef CONFIG_NET_ETHERNET
+      case NET_LL_ETHERNET:
+      case NET_LL_IEEE80211:
+#  ifdef CONFIG_NET_IPv4
+#    ifdef CONFIG_NET_IPv6
+        if (IFF_IS_IPv4(dev->d_flags))
+#    endif /* CONFIG_NET_IPv6 */
+          {
+            arp_out(dev);
+          }
+#  endif /* CONFIG_NET_IPv4 */
+#  ifdef CONFIG_NET_IPv6
+#    ifdef CONFIG_NET_IPv4
+        else
+#    endif /* CONFIG_NET_IPv4 */
+          {
+            neighbor_out(dev);
+          }
+#  endif /* CONFIG_NET_IPv6 */
+
+        break;
+#endif /* CONFIG_NET_ETHERNET */
+      default:
+        break;
+    }
+}
+
+/****************************************************************************
+ * Name: devif_poll_out
+ *
+ * Description:
  *   Generic callback before device output to build L2 headers before sending
  *
  * Assumptions:
@@ -784,7 +832,8 @@ int devif_poll(FAR struct net_driver_s *dev, devif_poll_callback_t callback)
  *
  ****************************************************************************/
 
-int devif_out(FAR struct net_driver_s *dev, devif_poll_callback_t callback)
+int devif_poll_out(FAR struct net_driver_s *dev,
+                   devif_poll_callback_t callback)
 {
   int bstop;
 
@@ -799,29 +848,7 @@ int devif_out(FAR struct net_driver_s *dev, devif_poll_callback_t callback)
       return bstop;
     }
 
-#ifdef CONFIG_NET_ETHERNET
-  if (dev->d_lltype == NET_LL_ETHERNET ||
-      dev->d_lltype == NET_LL_IEEE80211)
-    {
-#  ifdef CONFIG_NET_IPv4
-#    ifdef CONFIG_NET_IPv6
-      if (IFF_IS_IPv4(dev->d_flags))
-#    endif /* CONFIG_NET_IPv6 */
-        {
-          arp_out(dev);
-        }
-#  endif /* CONFIG_NET_IPv4 */
-
-#  ifdef CONFIG_NET_IPv6
-#    ifdef CONFIG_NET_IPv4
-      else
-#    endif /* CONFIG_NET_IPv4 */
-        {
-          neighbor_out(dev);
-        }
-#  endif /* CONFIG_NET_IPv6 */
-    }
-#endif /* CONFIG_NET_ETHERNET */
+  devif_out(dev);
 
   return callback(dev);
 }

--- a/net/devif/ipv4_input.c
+++ b/net/devif/ipv4_input.c
@@ -406,10 +406,7 @@ int ipv4_input(FAR struct net_driver_s *dev)
     (defined(CONFIG_NET_BROADCAST) && defined(NET_UDP_HAVE_STACK))
 done:
 #endif
-  if (dev->d_len > 0)
-    {
-      arp_out(dev);
-    }
+  devif_out(dev);
 
   /* Return and let the caller do any pending transmission. */
 

--- a/net/devif/ipv6_input.c
+++ b/net/devif/ipv6_input.c
@@ -508,10 +508,7 @@ int ipv6_input(FAR struct net_driver_s *dev)
 #ifdef CONFIG_NET_IPFORWARD
 done:
 #endif
-  if (dev->d_len > 0)
-    {
-      neighbor_out(dev);
-    }
+  devif_out(dev);
 
   /* Return and let the caller do any pending transmission. */
 


### PR DESCRIPTION
## Summary

net/devif: add common interface to build L2 headers

So we can hide the implementation details of L2 NICs.

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

ci-check