### PR TITLE
tools/ci/docker/linux/Dockerfile: add libmad0-dev in docker environment

### DIFF
--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -246,6 +246,7 @@ RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" apt-get install -y -q
   libc6-dev-i386 \
   libcurl4-openssl-dev \
   libncurses5-dev \
+  libmad0-dev:i386 \
   libpulse-dev libpulse-dev:i386 \
   libpython2.7 \
   libtinfo5 \


### PR DESCRIPTION
## Summary
tools/ci/docker/linux/Dockerfile: add libmad0-dev in docker environment

## Impact
CI docker environment

## Test
VELA