### PR TITLE
net: add parameter check in psock_setsockopt

### DIFF
--- a/net/socket/setsockopt.c
+++ b/net/socket/setsockopt.c
@@ -74,13 +74,6 @@ static int psock_socketlevel_option(FAR struct socket *psock, int option,
 {
   FAR struct socket_conn_s *conn = psock->s_conn;
 
-  /* Verify that the socket option if valid (but might not be supported ) */
-
-  if (!value)
-    {
-      return -EFAULT;
-    }
-
   /* Process the options always handled locally */
 
   switch (option)
@@ -295,6 +288,13 @@ int psock_setsockopt(FAR struct socket *psock, int level, int option,
                      FAR const void *value, socklen_t value_len)
 {
   int ret = -ENOPROTOOPT;
+
+  /* Verify that the socket option if valid (but might not be supported ) */
+
+  if (!value)
+    {
+      return -EFAULT;
+    }
 
   /* Verify that the sockfd corresponds to valid, allocated socket */
 


### PR DESCRIPTION
## Summary
0  0x565a60bd in memmove (dest=0xf7fbaabe, src=0x0, count=3) at string/lib_memmove.c:58 
1  0x565d8b90 in usrsock_iovec_do (srcdst=0xf7fbaab0, srcdstlen=2018, iov=0xf3de798c, iovcnt=0, pos=0, from_iov=true, done=0xf3de78e7) at usrsock/usrsock_devif.c:155 
2  0x565d9349 in usrsock_iovec_get (dst=0xf7fbaab0, dstlen=2032, iov=0xf3de797c, iovcnt=2, pos=0, done=0xf3de78e7) at usrsock/usrsock_devif.c:612 
3  0x5659f4b9 in usrsock_request (iov=0xf3de797c, iovcnt=2) at usrsock/usrsock_rpmsg.c:210 
4  0x565d9436 in usrsock_do_request (conn=0x566316c0 <g_usrsock_connections>, iov=0xf3de797c, iovcnt=2) at usrsock/usrsock_devif.c:659 
5  0x565dcfe9 in do_setsockopt_request (conn=0x566316c0 <g_usrsock_connections>, level=1, option=7, value=0x0, value_len=4) at usrsock/usrsock_setsockopt.c:131 
6  0x565dd11e in usrsock_setsockopt (psock=0xf3dea840, level=1, option=7, value=0x0, value_len=4) at usrsock/usrsock_setsockopt.c:208 
7  0x565d4d31 in psock_setsockopt (psock=0xf3dea840, level=1, option=7, value=0x0, value_len=4) at socket/setsockopt.c:310 
8  0x565d4dde in setsockopt (sockfd=3, level=1, option=7, value=0x0, value_len=4) at socket/setsockopt.c:396

## Impact

## Testing

