### PR TITLE
meminfo: buflen identify the left of buffer

### DIFF
--- a/fs/procfs/fs_procfsmeminfo.c
+++ b/fs/procfs/fs_procfsmeminfo.c
@@ -302,7 +302,7 @@ static ssize_t meminfo_read(FAR struct file *filep, FAR char *buffer,
 
   for (entry = g_procfs_meminfo; entry != NULL; entry = entry->next)
     {
-      if (totalsize < buflen)
+      if (buflen > 0)
         {
           struct mallinfo minfo;
 
@@ -328,7 +328,7 @@ static ssize_t meminfo_read(FAR struct file *filep, FAR char *buffer,
     }
 
 #ifdef CONFIG_MM_PGALLOC
-  if (totalsize < buflen)
+  if (buflen > 0)
     {
       struct pginfo_s pginfo;
       unsigned long total;
@@ -359,7 +359,7 @@ static ssize_t meminfo_read(FAR struct file *filep, FAR char *buffer,
 #endif
 
 #if defined(CONFIG_ARCH_HAVE_PROGMEM) && defined(CONFIG_FS_PROCFS_INCLUDE_PROGMEM)
-  if (totalsize < buflen)
+  if (buflen > 0)
     {
       struct progmem_info_s progmem;
 


### PR DESCRIPTION
## Summary
It is enought to only checking the buflen's avaiable or not. (total size means total copied size)
## Impact

## Testing

