### PR TITLE
Add Hexadecimal parsing for strtof

### DIFF
--- a/libs/libc/stdlib/lib_strtod.c
+++ b/libs/libc/stdlib/lib_strtod.c
@@ -44,6 +44,8 @@
 #include <ctype.h>
 #include <errno.h>
 
+#include <stdbool.h>
+
 #ifdef CONFIG_HAVE_DOUBLE
 
 /****************************************************************************
@@ -78,6 +80,36 @@ static inline int is_real(double x)
   const double divzero = 0.0;
   const double infinite = 1.0 / divzero;
   return (x < infinite) && (x >= -infinite);
+}
+
+static bool chtod(char c, double base, FAR double *number)
+{
+  /* This function is to determine if c is keyword
+   * Then set number + base
+   */
+
+  double tmp = base;
+
+  if (isdigit(c))
+    {
+      tmp = c - '0';
+    }
+  else if (c >= 'a' && c <= 'f')
+    {
+      tmp = c - 'a' + 10;
+    }
+  else if (c >= 'A' && c <= 'F')
+    {
+      tmp = c - 'A' + 10;
+    }
+
+  if (tmp >= base)
+    {
+      return false;
+    }
+
+  *number = *number * base + tmp;
+  return true;
 }
 
 /****************************************************************************
@@ -140,16 +172,24 @@ double strtod(FAR const char *str, FAR char **endptr)
       break;
     }
 
+  p10          = 10.;
   number       = 0.;
   exponent     = 0;
   num_digits   = 0;
   num_decimals = 0;
 
+  /* Process optional 0x prefix */
+
+  if (*p == '0' && tolower(*(p + 1)) == 'x')
+    {
+      p += 2;
+      p10  = 16.;
+    }
+
   /* Process string of digits */
 
-  while (isdigit(*p))
+  while (chtod(*p, p10, &number))
     {
-      number = number * 10. + (*p - '0');
       p++;
       num_digits++;
     }
@@ -160,9 +200,8 @@ double strtod(FAR const char *str, FAR char **endptr)
     {
       p++;
 
-      while (isdigit(*p))
+      while (chtod(*p, p10, &number))
         {
-          number = number * 10. + (*p - '0');
           p++;
           num_digits++;
           num_decimals++;
@@ -188,8 +227,17 @@ double strtod(FAR const char *str, FAR char **endptr)
 
   /* Process an exponent string */
 
-  if (*p == 'e' || *p == 'E')
+  if ((p10 == 10. && (*p == 'e' || *p == 'E'))
+     || (p10 == 16. && (*p == 'p' || *p == 'P')))
     {
+      /* if the Hexadecimal system */
+
+      if (p10 == 16.)
+        {
+          exponent *= 4;
+          p10 = 2.0;
+        }
+
       /* Handle optional sign */
 
       negative = 0;
@@ -240,13 +288,20 @@ double strtod(FAR const char *str, FAR char **endptr)
       exponent > __DBL_MAX_EXP__)
     {
       set_errno(ERANGE);
-      number = infinite;
+      if (exponent < __DBL_MIN_EXP__)
+        {
+          number = divzero;
+        }
+      else
+        {
+          number = infinite;
+        }
+
       goto errout;
     }
 
   /* Scale the result */
 
-  p10 = 10.;
   n = exponent;
   if (n < 0)
     {

--- a/libs/libc/stdlib/lib_strtof.c
+++ b/libs/libc/stdlib/lib_strtof.c
@@ -48,6 +48,8 @@
 #include <ctype.h>
 #include <errno.h>
 
+#include <stdbool.h>
+
 /****************************************************************************
  * Pre-processor definitions
  ****************************************************************************/
@@ -80,6 +82,36 @@ static inline int is_real(float x)
   float divzero = 0.0F;
   const float infinite = 1.0F / divzero;
   return (x < infinite) && (x >= -infinite);
+}
+
+static bool chtof(char c, float base, FAR float *number)
+{
+  /* This function is to determine if c is keyword
+   * Then set number + base
+   */
+
+  float tmp = base;
+
+  if (isdigit(c))
+    {
+      tmp = c - '0';
+    }
+  else if (c >= 'a' && c <= 'f')
+    {
+      tmp = c - 'a' + 10;
+    }
+  else if (c >= 'A' && c <= 'F')
+    {
+      tmp = c - 'A' + 10;
+    }
+
+  if (tmp >= base)
+    {
+      return false;
+    }
+
+  *number = *number * base + tmp;
+  return true;
 }
 
 /****************************************************************************
@@ -142,16 +174,24 @@ float strtof(FAR const char *str, FAR char **endptr)
       break;
     }
 
+  p10          = 10.0f;
   number       = 0.0F;
   exponent     = 0;
   num_digits   = 0;
   num_decimals = 0;
 
+  /* Process optional 0x prefix */
+
+  if (*p == '0' && tolower(*(p + 1)) == 'x')
+    {
+      p += 2;
+      p10  = 16.0f;
+    }
+
   /* Process string of digits */
 
-  while (isdigit(*p))
+  while (chtof(*p, p10, &number))
     {
-      number = number * 10.0F + (float)(*p - '0');
       p++;
       num_digits++;
     }
@@ -162,9 +202,8 @@ float strtof(FAR const char *str, FAR char **endptr)
     {
       p++;
 
-      while (isdigit(*p))
+      while (chtof(*p, p10, &number))
         {
-          number = number * 10.0F + (float)(*p - '0');
           p++;
           num_digits++;
           num_decimals++;
@@ -190,8 +229,17 @@ float strtof(FAR const char *str, FAR char **endptr)
 
   /* Process an exponent string */
 
-  if (*p == 'e' || *p == 'E')
+  if ((p10 == 10.0f && (*p == 'e' || *p == 'E'))
+     || (p10 == 16.0f && (*p == 'p' || *p == 'P')))
     {
+      /* if the Hexadecimal system */
+
+      if (p10 == 16.0f)
+        {
+          exponent *= 4;
+          p10 = 2.0f;
+        }
+
       /* Handle optional sign */
 
       negative = 0;
@@ -242,13 +290,20 @@ float strtof(FAR const char *str, FAR char **endptr)
       exponent > __FLT_MAX_EXP__)
     {
       set_errno(ERANGE);
-      number = infinite;
+      if (exponent < __FLT_MIN_EXP__)
+        {
+          number = divzero;
+        }
+      else
+        {
+          number = infinite;
+        }
+
       goto errout;
     }
 
   /* Scale the result */
 
-  p10 = 10.0F;
   n = exponent;
   if (n < 0)
     {


### PR DESCRIPTION
## Summary
solve:
  almost the Hexadecimal string string->float
such as:
  code:float num;
       const char *s= "0x123p32lala";
       char *p;
       num=strtof(s,&p);
       printf("num is %f\n",num);
       printf("str is %s\n",p);
  output:num is 1249835483136.000000
         str is lala

but if the input number is much big;
like:
  code:const char *s2= "0x999999p100";
       num=strtof(s2,&p);
       printf("num is %f\n",num);
       printf("str is %s\n",p);
  corrent : num is 12760587998944832242938906880669384704.000000
  real:     num is 12760587998944800000000000000000000000.000000
it didn't have enough precision
I changed the types of the relevant data from float to double.But it's output changed nothing.
## Impact
add some code
## Testing
 int countnum = 1;
    float num;
    const char *s= "0x123p32";
    char *p; 
    num=strtof(s,&p);
    printf("num is %f\n",num);
    printf("str is %s\n",p);
    printf("count is %d\n",countnum++);
    printf("\n");

    const char *s1= "0x123p32jhdgyeg";
    num=strtof(s1,&p);
    printf("num is %f\n",num);
    printf("str is %s\n",p);
    printf("count is %d\n",countnum++);
    printf("\n");

    const char *s2= "0x999999p100";
    num=strtof(s2,&p);
    printf("num is %f\n",num);
    printf("str is %s\n",p);
    printf("count is %d\n",countnum++);
    printf("\n");

    const char *s3= "0x2.123ppsy32";
    num=strtof(s3,&p);
    printf("num is %f\n",num);
    printf("str is %s\n",p);
    printf("count is %d\n",countnum++);
    printf("\n");

    const char *s4= "0x642.56p90sliu";
    num=strtof(s4,&p);
    printf("num is %f\n",num);
    printf("str is %s\n",p);
    printf("count is %d\n",countnum++);


