### PR TITLE
net/loopback: reuse devif_loopback() logic for device lo(loopback)

### DIFF
--- a/net/devif/devif_loopback.c
+++ b/net/devif/devif_loopback.c
@@ -123,13 +123,6 @@ int devif_loopback(FAR struct net_driver_s *dev)
         }
 
       NETDEV_TXDONE(dev);
-
-      /* Add the link layer header length for the next loop */
-
-      if (dev->d_len != 0)
-        {
-          dev->d_len += dev->d_llhdrlen;
-        }
     }
   while (dev->d_len > 0);
 

--- a/net/devif/devif_poll.c
+++ b/net/devif/devif_poll.c
@@ -848,9 +848,14 @@ int devif_poll_out(FAR struct net_driver_s *dev,
       return bstop;
     }
 
-  devif_out(dev);
+  if (callback)
+    {
+      devif_out(dev);
 
-  return callback(dev);
+      return callback(dev);
+    }
+
+  return 0;
 }
 
 #endif /* CONFIG_NET */


### PR DESCRIPTION
## Summary

net/loopback: reuse devif_loopback() logic for device lo(loopback)

TX poll callback in device lo(loopback) can be replaced by devif_loopback()
from devif_poll() hook, remove duplicate code to reuse this logic

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

net test on localhost(127.0.0.1) & localaddr(192.*.*.*)