### PR TITLE
net/ipv4: fix shadows declaration

### DIFF
--- a/net/devif/ipv4_input.c
+++ b/net/devif/ipv4_input.c
@@ -295,8 +295,7 @@ int ipv4_input(FAR struct net_driver_s *dev)
 #ifdef CONFIG_NET_IPFORWARD
           /* Try to forward the packet */
 
-          int ret = ipv4_forward(dev, ipv4);
-          if (ret >= 0)
+          if (ipv4_forward(dev, ipv4) >= 0)
             {
               /* The packet was forwarded.  Return success; d_len will
                * be set appropriately by the forwarding logic:  Cleared


### PR DESCRIPTION

## Summary

net/ipv4: fix shadows declaration

```
devif/ipv4_input.c: In function ‘ipv4_in’:
devif/ipv4_input.c:305:15: warning: declaration of ‘ret’ shadows a previous local [-Wshadow]
  305 |           int ret = ipv4_forward(dev, ipv4);
      |               ^~~
devif/ipv4_input.c:151:7: note: shadowed declaration is here
  151 |   int ret = OK;
      |       ^~~

```
Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

ci-check