### PR TITLE
timerfd_create: initial reference count to zero

### DIFF
--- a/fs/vfs/fs_timerfd.c
+++ b/fs/vfs/fs_timerfd.c
@@ -544,9 +544,6 @@ int timerfd_create(int clockid, int flags)
   /* Initialize the timer instance */
 
   new_dev->clock = clockid;
-  new_dev->crefs = 1;
-  new_dev->delay = 0;
-  new_dev->counter = 0;
 
   /* Request a unique minor device number */
 


### PR DESCRIPTION


## Summary
timerfd_create: initial reference count to zero
nx_open in timerfd_create will increase reference count, Therefore, the reference count starts with a value of 0.

Signed-off-by: dongjiuzhu1 <dongjiuzhu1@xiaomi.com>
## Impact
release timerfd correctly
## Testing
local test
