### PR TITLE
arch: risc-v: Fix nsec overflow in riscv_mtimer_current()

### DIFF
--- a/arch/risc-v/src/common/riscv_mtimer.c
+++ b/arch/risc-v/src/common/riscv_mtimer.c
@@ -290,7 +290,7 @@ static int riscv_mtimer_current(struct oneshot_lowerhalf_s *lower,
   struct riscv_mtimer_lowerhalf_s *priv =
     (struct riscv_mtimer_lowerhalf_s *)lower;
   uint64_t mtime = riscv_mtimer_get_mtime(priv);
-  uint64_t nsec = mtime * NSEC_PER_SEC / priv->freq;
+  uint64_t nsec = mtime / (priv->freq / USEC_PER_SEC) * NSEC_PER_USEC;
 
   ts->tv_sec  = nsec / NSEC_PER_SEC;
   ts->tv_nsec = nsec % NSEC_PER_SEC;


### PR DESCRIPTION
## Summary

- I noticed that mtimer stops around 30min after boot.
- Finally, I found that nesc overflows in riscv_mtimer_current().
- This commit fixes this issue.

## Impact

- None

## Testing

- Tested with rv-virt:nsh on QEMU-7.1
