### PR TITLE
arch: arm64: Fix qemu_pl011_txint() in qemu_serial.c

### DIFF
--- a/arch/arm64/src/qemu/qemu_serial.c
+++ b/arch/arm64/src/qemu/qemu_serial.c
@@ -458,15 +458,26 @@ static void qemu_pl011_rxint(struct uart_dev_s *dev, bool enable)
 static void qemu_pl011_txint(struct uart_dev_s *dev, bool enable)
 {
   struct pl011_uart_port_s *sport = (struct pl011_uart_port_s *)dev->priv;
+  irqstate_t flags;
+
+  flags = enter_critical_section();
 
   if (enable)
     {
       pl011_irq_tx_enable(sport);
+
+      /* Fake a TX interrupt here by just calling uart_xmitchars() with
+       * interrupts disabled (note this may recurse).
+       */
+
+      uart_xmitchars(dev);
     }
   else
     {
       pl011_irq_tx_disable(sport);
     }
+
+  leave_critical_section(flags);
 }
 
 /***************************************************************************


### PR DESCRIPTION
## Summary

- I noticed that the nsh prompt can not be shown when disabling debug features. 
- Actually, the prompt will be shown when a user input happens.
- This commit fixes this issue by adding uart_xmitchars() as other serial drivers do.

## Impact

- None

## Testing

- Tested with qemu-armv8a:netnsh on QEMU-7.1

