### PR TITLE
net/devif: fix devif loopback

### DIFF
--- a/net/devif/devif_poll.c
+++ b/net/devif/devif_poll.c
@@ -842,6 +842,8 @@ int devif_poll_out(FAR struct net_driver_s *dev,
       return 0;
     }
 
+  devif_out(dev);
+
   bstop = devif_loopback(dev);
   if (bstop)
     {
@@ -850,8 +852,6 @@ int devif_poll_out(FAR struct net_driver_s *dev,
 
   if (callback)
     {
-      devif_out(dev);
-
       return callback(dev);
     }
 


### PR DESCRIPTION
## Summary

devif_loopback needs to be applied on l2 data, and was broken by commit below, now fix it.

| commit 8850dee74605890fa2a63c98f6aa816b16bcf239
| Author: chao an <anchao@xiaomi.com>
| Date:   Sun Nov 27 03:31:07 2022 +0800
|
|     net/devif: move preprocess of txpoll into common code
|
|     Signed-off-by: chao an <anchao@xiaomi.com>

Signed-off-by: Zhe Weng <wengzhe@xiaomi.com>

## Impact
- Fix logic when calling devif_loopback on ETHERNET devices.

## Testing
- Tested on sim with 2 tap devices, ping from host connected with eth0 to ip assigned to eth1, will work like following:
  - host -> eth0 -> forward -> eth1 -> loopback on eth1 -> eth1 icmp reply -> still loopback on eth1 -> forward -> eth0 -> host