### PR TITLE
net/nat: Add support for ICMP Error Message

### DIFF
--- a/Documentation/reference/os/nat.rst
+++ b/Documentation/reference/os/nat.rst
@@ -5,8 +5,14 @@ Network Address Translation (NAT)
 NuttX supports full cone NAT logic, which currently supports
 
 - TCP
+
 - UDP
-- ICMP ECHO (REQUEST & REPLY)
+
+- ICMP
+
+  - ECHO (REQUEST & REPLY)
+
+  - Error Messages (DEST_UNREACHABLE & TIME_EXCEEDED & PARAMETER_PROBLEM)
 
 Workflow
 ========
@@ -160,6 +166,12 @@ Validated on Ubuntu 22.04 x86_64 with NuttX SIM by following steps:
 
     # LAN side
     sudo ip netns exec LAN ping 8.8.8.8
+
+  ..  code-block:: shell
+
+    # LAN side
+    sudo ip netns exec LAN traceroute -n 8.8.8.8     # ICMP error msg of UDP
+    sudo ip netns exec LAN traceroute -n -T 8.8.8.8  # ICMP error msg of TCP
 
   ..  code-block:: shell
 

--- a/net/nat/Kconfig
+++ b/net/nat/Kconfig
@@ -6,9 +6,14 @@
 config NET_NAT
 	bool "Network Address Translation (NAT)"
 	default n
-	depends on NET_IPFORWARD
+	depends on NET_IPFORWARD && IOB_BUFSIZE >= 68
 	---help---
 		Enable or disable Network Address Translation (NAT) function.
+
+		Note: When forwarding IPv4 packet and applying NAT, NAT may be
+		applied directly on a single I/O buffer containing L3 packet header,
+		and NAT may need a continuous buffer of at least 68 Bytes
+		(IPv4 20B + ICMP 8B + IPv4 20B + TCP 20B).
 
 config NET_NAT_TCP_EXPIRE_SEC
 	int "TCP NAT entry expiration seconds"

--- a/net/nat/ipv4_nat_entry.c
+++ b/net/nat/ipv4_nat_entry.c
@@ -375,6 +375,7 @@ ipv4_nat_inbound_entry_find(uint8_t protocol, uint16_t external_port,
  *   protocol   - The L4 protocol of the packet.
  *   local_ip   - The local ip of the packet.
  *   local_port - The local port of the packet.
+ *   try_create - Try create the entry if no entry found.
  *
  * Returned Value:
  *   Pointer to entry on success; null on failure
@@ -383,7 +384,8 @@ ipv4_nat_inbound_entry_find(uint8_t protocol, uint16_t external_port,
 
 FAR struct ipv4_nat_entry *
 ipv4_nat_outbound_entry_find(FAR struct net_driver_s *dev, uint8_t protocol,
-                             in_addr_t local_ip, uint16_t local_port)
+                             in_addr_t local_ip, uint16_t local_port,
+                             bool try_create)
 {
   FAR sq_entry_t *p;
   FAR sq_entry_t *tmp;
@@ -410,6 +412,11 @@ ipv4_nat_outbound_entry_find(FAR struct net_driver_s *dev, uint8_t protocol,
           ipv4_nat_entry_refresh(entry);
           return entry;
         }
+    }
+
+  if (!try_create)
+    {
+      return NULL;
     }
 
   /* Failed to find the entry, create one. */

--- a/net/nat/nat.h
+++ b/net/nat/nat.h
@@ -208,6 +208,7 @@ ipv4_nat_inbound_entry_find(uint8_t protocol, uint16_t external_port,
  *   protocol   - The L4 protocol of the packet.
  *   local_ip   - The local ip of the packet.
  *   local_port - The local port of the packet.
+ *   try_create - Try create the entry if no entry found.
  *
  * Returned Value:
  *   Pointer to entry on success; null on failure
@@ -216,7 +217,8 @@ ipv4_nat_inbound_entry_find(uint8_t protocol, uint16_t external_port,
 
 FAR struct ipv4_nat_entry *
 ipv4_nat_outbound_entry_find(FAR struct net_driver_s *dev, uint8_t protocol,
-                             in_addr_t local_ip, uint16_t local_port);
+                             in_addr_t local_ip, uint16_t local_port,
+                             bool try_create);
 
 #endif /* CONFIG_NET_NAT && CONFIG_NET_IPv4 */
 #endif /* __NET_NAT_NAT_H */


### PR DESCRIPTION
## Summary
Support ICMP Error Messages in NAT

Note:
An ICMP error message contains an inner packet with ip&port on different place (src vs dst).  
For example, an inbound ICMP would be like this:
```
|          IP HDR: SRC = Peer IP,       DST = External IP |
|        ICMP HDR: ERROR MSG                              |
| <Origin> IP HDR: SRC = External IP,   DST = Peer IP     |
| <Origin> L4 HDR: SRC = External Port, DST = Peer Port   |
```

## Impact
Support ICMP Error Messages in NAT

## Testing
Same method as NAT (docs under Documentation/reference/os/nat.rst), now traceroute works.
