### PR TITLE
net/ipfwd: Support ICMP/ICMPv6 error reply when forwarding

### DIFF
--- a/net/devif/ipv4_input.c
+++ b/net/devif/ipv4_input.c
@@ -184,6 +184,12 @@ int ipv4_input(FAR struct net_driver_s *dev)
 
   dev->d_len -= llhdrlen;
 
+  /* Make sure that all packet processing logic knows that there is an IPv4
+   * packet in the device buffer.
+   */
+
+  IFF_SET_IPv4(dev->d_flags);
+
   /* Check the size of the packet.  If the size reported to us in d_len is
    * smaller the size reported in the IP header, we assume that the packet
    * has been corrupted in transit.  If the size of d_len is larger than the
@@ -353,12 +359,6 @@ int ipv4_input(FAR struct net_driver_s *dev)
       nwarn("WARNING: Bad IP checksum\n");
       goto drop;
     }
-
-  /* Make sure that all packet processing logic knows that there is an IPv4
-   * packet in the device buffer.
-   */
-
-  IFF_SET_IPv4(dev->d_flags);
 
   /* Now process the incoming packet according to the protocol. */
 

--- a/net/icmpv6/icmpv6_reply.c
+++ b/net/icmpv6/icmpv6_reply.c
@@ -112,6 +112,10 @@ void icmpv6_reply(FAR struct net_driver_s *dev, int type, int code, int data)
 
   dev->d_len = ipicmplen + datalen;
 
+  /* Copy fields from original packet */
+
+  memmove(icmpv6 + 1, ipv6, datalen);
+
   ipv6_build_header(IPv6BUF, dev->d_len - IPv6_HDRLEN, IP_PROTO_ICMP6,
                     dev->d_ipv6addr, ipv6->srcipaddr, 255);
 
@@ -119,8 +123,8 @@ void icmpv6_reply(FAR struct net_driver_s *dev, int type, int code, int data)
 
   icmpv6->type    = type;
   icmpv6->code    = code;
-  icmpv6->data[0] = data >> 16;
-  icmpv6->data[1] = data & 0xffff;
+  icmpv6->data[0] = htons(data >> 16);
+  icmpv6->data[1] = htons(data & 0xffff);
 
   /* Calculate the ICMPv6 checksum over the ICMPv6 header and payload. */
 

--- a/net/nat/nat.h
+++ b/net/nat/nat.h
@@ -71,6 +71,16 @@ struct ipv4_nat_entry
   uint32_t   expire_time;    /* The expiration time of this entry. */
 };
 
+/* NAT IP/Port manipulate type, to indicate whether to manipulate source or
+ * destination IP/Port in a packet.
+ */
+
+enum nat_manip_type_e
+{
+  NAT_MANIP_SRC,
+  NAT_MANIP_DST
+};
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
@@ -147,6 +157,7 @@ int ipv4_nat_inbound(FAR struct net_driver_s *dev,
  * Input Parameters:
  *   dev   - The device on which the packet will be sent.
  *   ipv4  - Points to the IPv4 header to be filled into dev->d_buf later.
+ *   manip_type - Whether local IP/Port is in source or destination.
  *
  * Returned Value:
  *   Zero is returned if NAT is successfully applied, or is not enabled for
@@ -156,7 +167,8 @@ int ipv4_nat_inbound(FAR struct net_driver_s *dev,
  ****************************************************************************/
 
 int ipv4_nat_outbound(FAR struct net_driver_s *dev,
-                      FAR struct ipv4_hdr_s *ipv4);
+                      FAR struct ipv4_hdr_s *ipv4,
+                      enum nat_manip_type_e manip_type);
 
 /****************************************************************************
  * Name: ipv4_nat_port_inuse


### PR DESCRIPTION
## Summary

When forwarding packets, reply ICMP for error `-ENETUNREACH`, `-EFBIG` and `-EMULTIHOP`.

patches included:
- net/ipv4_input: Set IPv4 flag at the same place as ipv6_input
- net/ipfwd: Support ICMP error reply when forwarding IPv4
- net/ipfwd: Support ICMPv6 error reply when forwarding IPv6
- net/icmpv6: Fix icmpv6_reply function

## Impact

When forwarding packets, NuttX will reply ICMP for some errors now.

## Testing
Tested on sim enabled 2 tap devices with mtu of 1500 and 300, by `ping -t1` and `ping -s 500`
