### PR TITLE
rpmsgdev: rpmsgdegv ioctl and seek buf fix

### DIFF
--- a/drivers/misc/rpmsgdev.c
+++ b/drivers/misc/rpmsgdev.c
@@ -574,6 +574,7 @@ static off_t rpmsgdev_seek(FAR struct file *filep, off_t offset, int whence)
   FAR struct rpmsgdev_s *dev;
   FAR struct rpmsgdev_priv_s *priv;
   struct rpmsgdev_lseek_s msg;
+  int ret;
 
   /* Sanity checks */
 
@@ -591,8 +592,14 @@ static off_t rpmsgdev_seek(FAR struct file *filep, off_t offset, int whence)
   msg.offset = offset;
   msg.whence = whence;
 
-  return rpmsgdev_send_recv(dev, RPMSGDEV_LSEEK, true, &msg.header,
-                            sizeof(msg), NULL);
+  ret = rpmsgdev_send_recv(dev, RPMSGDEV_LSEEK, true, &msg.header,
+                           sizeof(msg), NULL);
+  if (ret >= 0)
+    {
+      filep->f_pos = msg.offset;
+    }
+
+  return ret;
 }
 
 /****************************************************************************
@@ -953,6 +960,7 @@ static int rpmsgdev_ioctl_handler(FAR struct rpmsg_endpoint *ept,
       (FAR struct rpmsgdev_cookie_s *)(uintptr_t)header->cookie;
   FAR struct rpmsgdev_ioctl_s *rsp = data;
 
+  cookie->result = header->result;
   if (cookie->result >= 0 && rsp->arglen > 0)
     {
       memcpy(cookie->data, (FAR void *)(uintptr_t)rsp->buf, rsp->arglen);

--- a/drivers/misc/rpmsgdev.h
+++ b/drivers/misc/rpmsgdev.h
@@ -85,8 +85,8 @@ begin_packed_struct struct rpmsgdev_lseek_s
 {
   struct rpmsgdev_header_s header;
   uint64_t                 filep;
+  int64_t                  offset;
   int32_t                  whence;
-  int32_t                  offset;
 } end_packed_struct;
 
 begin_packed_struct struct rpmsgdev_ioctl_s

--- a/drivers/misc/rpmsgdev_server.c
+++ b/drivers/misc/rpmsgdev_server.c
@@ -280,7 +280,12 @@ static int rpmsgdev_lseek_handler(FAR struct rpmsg_endpoint *ept,
   FAR struct rpmsgdev_lseek_s *msg = data;
   FAR struct file *filep = (FAR struct file *)(uintptr_t)msg->filep;
 
-  msg->header.result = file_seek(filep, msg->offset, msg->whence);
+  msg->header.result = 0;
+  msg->offset = file_seek(filep, msg->offset, msg->whence);
+  if (msg->offset < 0)
+    {
+      msg->header.result = (int32_t)msg->offset;
+    }
 
   return rpmsg_send(ept, msg, len);
 }


### PR DESCRIPTION
## Summary
1. rpmsgdev ioctl: should assgin back the client return value to cookie->result, then this return value can be returned to the application;
2. rpmsgdev seek: the type "off_t" may be 64bit, so modify the offset in "struct rpmsgdev_lseek" to int64_t too;
3. rpmsgdev_seek: the rpmsgdev_seek in client should update the filep->f_pos after the seek operation;

## Impact
rpmsgdev

## Testing
sim:rpserver and sim:rpproxy
