### PR TITLE
drivers/video: add support for YUV formats

### DIFF
--- a/drivers/video/video.c
+++ b/drivers/video/video.c
@@ -500,19 +500,23 @@ static void convert_to_imgdatafmt(FAR video_format_t *video,
   data->height      = video->height;
   switch (video->pixelformat)
     {
-      case V4L2_PIX_FMT_UYVY :
+      case V4L2_PIX_FMT_YUYV:
+        data->pixelformat = IMGDATA_PIX_FMT_YUYV;
+        break;
+
+      case V4L2_PIX_FMT_UYVY:
         data->pixelformat = IMGDATA_PIX_FMT_UYVY;
         break;
 
-      case V4L2_PIX_FMT_RGB565 :
+      case V4L2_PIX_FMT_RGB565:
         data->pixelformat = IMGDATA_PIX_FMT_RGB565;
         break;
 
-      case V4L2_PIX_FMT_JPEG :
+      case V4L2_PIX_FMT_JPEG:
         data->pixelformat = IMGDATA_PIX_FMT_JPEG;
         break;
 
-      default : /* V4L2_PIX_FMT_JPEG_WITH_SUBIMG */
+      default: /* V4L2_PIX_FMT_JPEG_WITH_SUBIMG */
         data->pixelformat = IMGDATA_PIX_FMT_JPEG_WITH_SUBIMG;
         break;
     }
@@ -527,19 +531,23 @@ static void convert_to_imgsensorfmt(FAR video_format_t *video,
   sensor->height      = video->height;
   switch (video->pixelformat)
     {
-      case V4L2_PIX_FMT_UYVY :
+      case V4L2_PIX_FMT_YUYV:
+        sensor->pixelformat = IMGSENSOR_PIX_FMT_YUYV;
+        break;
+
+      case V4L2_PIX_FMT_UYVY:
         sensor->pixelformat = IMGSENSOR_PIX_FMT_UYVY;
         break;
 
-      case V4L2_PIX_FMT_RGB565 :
+      case V4L2_PIX_FMT_RGB565:
         sensor->pixelformat = IMGSENSOR_PIX_FMT_RGB565;
         break;
 
-      case V4L2_PIX_FMT_JPEG :
+      case V4L2_PIX_FMT_JPEG:
         sensor->pixelformat = IMGSENSOR_PIX_FMT_JPEG;
         break;
 
-      default : /* V4L2_PIX_FMT_JPEG_WITH_SUBIMG */
+      default: /* V4L2_PIX_FMT_JPEG_WITH_SUBIMG */
         sensor->pixelformat = IMGSENSOR_PIX_FMT_JPEG_WITH_SUBIMG;
         break;
     }
@@ -1508,6 +1516,7 @@ static int video_try_fmt(FAR struct video_mng_s *priv,
 
         break;
 
+      case V4L2_PIX_FMT_YUYV:
       case V4L2_PIX_FMT_UYVY:
       case V4L2_PIX_FMT_RGB565:
       case V4L2_PIX_FMT_JPEG:

--- a/drivers/video/video.c
+++ b/drivers/video/video.c
@@ -500,6 +500,10 @@ static void convert_to_imgdatafmt(FAR video_format_t *video,
   data->height      = video->height;
   switch (video->pixelformat)
     {
+      case V4L2_PIX_FMT_YUV420:
+        data->pixelformat = IMGDATA_PIX_FMT_YUV420P;
+        break;
+
       case V4L2_PIX_FMT_YUYV:
         data->pixelformat = IMGDATA_PIX_FMT_YUYV;
         break;
@@ -531,6 +535,10 @@ static void convert_to_imgsensorfmt(FAR video_format_t *video,
   sensor->height      = video->height;
   switch (video->pixelformat)
     {
+      case V4L2_PIX_FMT_YUV420:
+        sensor->pixelformat = IMGSENSOR_PIX_FMT_YUV420P;
+        break;
+
       case V4L2_PIX_FMT_YUYV:
         sensor->pixelformat = IMGSENSOR_PIX_FMT_YUYV;
         break;
@@ -1516,6 +1524,7 @@ static int video_try_fmt(FAR struct video_mng_s *priv,
 
         break;
 
+      case V4L2_PIX_FMT_YUV420:
       case V4L2_PIX_FMT_YUYV:
       case V4L2_PIX_FMT_UYVY:
       case V4L2_PIX_FMT_RGB565:

--- a/include/nuttx/video/imgdata.h
+++ b/include/nuttx/video/imgdata.h
@@ -43,6 +43,7 @@
 #define IMGDATA_PIX_FMT_SUBIMG_UYVY      (4)
 #define IMGDATA_PIX_FMT_SUBIMG_RGB565    (5)
 #define IMGDATA_PIX_FMT_YUYV             (6)
+#define IMGDATA_PIX_FMT_YUV420P          (7)
 
 /****************************************************************************
  * Public Types

--- a/include/nuttx/video/imgdata.h
+++ b/include/nuttx/video/imgdata.h
@@ -42,6 +42,7 @@
 #define IMGDATA_PIX_FMT_JPEG_WITH_SUBIMG (3)
 #define IMGDATA_PIX_FMT_SUBIMG_UYVY      (4)
 #define IMGDATA_PIX_FMT_SUBIMG_RGB565    (5)
+#define IMGDATA_PIX_FMT_YUYV             (6)
 
 /****************************************************************************
  * Public Types

--- a/include/nuttx/video/imgsensor.h
+++ b/include/nuttx/video/imgsensor.h
@@ -118,6 +118,7 @@
 #define IMGSENSOR_PIX_FMT_SUBIMG_UYVY      (4)
 #define IMGSENSOR_PIX_FMT_SUBIMG_RGB565    (5)
 #define IMGSENSOR_PIX_FMT_YUYV             (6)
+#define IMGSENSOR_PIX_FMT_YUV420P          (7)
 
 /****************************************************************************
  * Public Types

--- a/include/nuttx/video/imgsensor.h
+++ b/include/nuttx/video/imgsensor.h
@@ -101,7 +101,7 @@
 
 /* Status bit definition for IMGSENSOR_ID_3A_STATUS */
 
-#define IMGSENSOR_3A_STATUS_STABLE        (0) 
+#define IMGSENSOR_3A_STATUS_STABLE        (0)
 #define IMGSENSOR_3A_STATUS_AE_OPERATING  (1 << 0)
 #define IMGSENSOR_3A_STATUS_AWB_OPERATING (1 << 1)
 #define IMGSENSOR_3A_STATUS_AF_OPERATING  (1 << 2)
@@ -117,6 +117,7 @@
 #define IMGSENSOR_PIX_FMT_JPEG_WITH_SUBIMG (3)
 #define IMGSENSOR_PIX_FMT_SUBIMG_UYVY      (4)
 #define IMGSENSOR_PIX_FMT_SUBIMG_RGB565    (5)
+#define IMGSENSOR_PIX_FMT_YUYV             (6)
 
 /****************************************************************************
  * Public Types

--- a/include/nuttx/video/video.h
+++ b/include/nuttx/video/video.h
@@ -219,6 +219,10 @@ extern "C"
 #define V4L2_PIX_FMT_UYVY v4l2_fourcc('U', 'Y', 'V', 'Y')
 #define V4L2_PIX_FMT_YUYV v4l2_fourcc('Y', 'U', 'Y', 'V')
 
+/* YUV 4:2:0 */
+
+#define V4L2_PIX_FMT_YUV420  v4l2_fourcc('Y', 'U', '1', '2')
+
 /* RGB565 */
 
 #define V4L2_PIX_FMT_RGB565 v4l2_fourcc('R', 'G', 'B', 'P')

--- a/include/nuttx/video/video.h
+++ b/include/nuttx/video/video.h
@@ -217,6 +217,7 @@ extern "C"
 /* YUV 4:2:2 */
 
 #define V4L2_PIX_FMT_UYVY v4l2_fourcc('U', 'Y', 'V', 'Y')
+#define V4L2_PIX_FMT_YUYV v4l2_fourcc('Y', 'U', 'Y', 'V')
 
 /* RGB565 */
 


### PR DESCRIPTION
## Summary
Add definitions for two YUV formats (YUYV and YU12) used by most USB cameras and v4l2loopback. 
## Impact
## Testing

