### PR TITLE
littlefs: Get and return the current error status before RMDIR execution type

### DIFF
--- a/fs/littlefs/lfs_vfs.c
+++ b/fs/littlefs/lfs_vfs.c
@@ -1324,8 +1324,14 @@ static int littlefs_mkdir(FAR struct inode *mountpt, FAR const char *relpath,
 static int littlefs_rmdir(FAR struct inode *mountpt, FAR const char *relpath)
 {
   struct stat buf;
+  int ret;
 
-  littlefs_stat(mountpt, relpath, &buf);
+  ret = littlefs_stat(mountpt, relpath, &buf);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   if (S_ISDIR(buf.st_mode))
     {
       return littlefs_unlink(mountpt, relpath);


### PR DESCRIPTION
## Summary
In some cases, deleting a folder will return unexpected results. For example, ENOENT should be returned when deleting a non-existent folder, but the result will return ENOTDIR.After this patch, the error type can be returned normally.

## Impact

## Testing

