### PR TITLE
net/offload: add offload support for pkt/arp

### DIFF
--- a/net/devif/devif_poll.c
+++ b/net/devif/devif_poll.c
@@ -833,8 +833,6 @@ static int devif_iob_poll(FAR struct net_driver_s *dev,
 
   netdev_iob_release(dev);
 
-  dev->d_buf = NULL;
-
   return bstop;
 }
 

--- a/net/netdev/netdev_iob.c
+++ b/net/netdev/netdev_iob.c
@@ -124,5 +124,6 @@ void netdev_iob_release(FAR struct net_driver_s *dev)
     {
       iob_free_chain(dev->d_iob);
       dev->d_iob = NULL;
+      dev->d_buf = NULL;
     }
 }

--- a/net/pkt/pkt_input.c
+++ b/net/pkt/pkt_input.c
@@ -137,9 +137,22 @@ static int pkt_in(FAR struct net_driver_s *dev)
 
 int pkt_input(FAR struct net_driver_s *dev)
 {
+  FAR uint8_t *buf;
+  int ret;
+
   if (dev->d_iob != NULL)
     {
-      return pkt_in(dev);
+      buf = dev->d_buf;
+
+      /* Set the device buffer to l2 */
+
+      dev->d_buf = &dev->d_iob->io_data[CONFIG_NET_LL_GUARDSIZE -
+                                        NET_LL_HDRLEN(dev)];
+      ret = pkt_in(dev);
+
+      dev->d_buf = buf;
+
+      return ret;
     }
 
   return netdev_input(dev, pkt_in, false);

--- a/net/udp/udp_recvfrom.c
+++ b/net/udp/udp_recvfrom.c
@@ -447,8 +447,6 @@ static uint16_t udp_eventhandler(FAR struct net_driver_s *dev,
           /* Indicate no data in the buffer */
 
           netdev_iob_release(dev);
-
-          dev->d_buf = NULL;
         }
     }
 


### PR DESCRIPTION
## Summary

net/offload: add offload support for pkt/arp

1. add offload support for pkt/arp
2. Reset the d_buf to NULL if d_iob has released

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

enable CONFIG_NET_PKT 
iperf  ipv4/ipv6/ test , icmp reply