### PR TITLE
arm_syscall: add SYS_save_context for armv7-a

### DIFF
--- a/arch/arm/src/armv7-a/arm_syscall.c
+++ b/arch/arm/src/armv7-a/arm_syscall.c
@@ -250,6 +250,25 @@ uint32_t *arm_syscall(uint32_t *regs)
         }
         break;
 #endif
+      /* R0=SYS_save_context:  This is a save context command:
+       *
+       *   int up_saveusercontext(void *saveregs);
+       *
+       * At this point, the following values are saved in context:
+       *
+       *   R0 = SYS_save_context
+       *   R1 = saveregs
+       *
+       * In this case, we simply need to copy the current registers to the
+       * save register space references in the saved R1 and return.
+       */
+
+      case SYS_save_context:
+        {
+          DEBUGASSERT(regs[REG_R1] != 0);
+          memcpy((uint32_t *)regs[REG_R1], regs, XCPTCONTEXT_SIZE);
+        }
+        break;
 
       /* R0=SYS_restore_context:  Restore task context
        *


### PR DESCRIPTION
## Summary
I noticed that there is not register information in the crash log when DEBUGASSERT failed, the reason is that the arm_dumpstate() call up_saveusercontext() to get the context of current task but armv7-a do not support syscall SYS_save_context.

```c
crash log:
[48/12/ 7 16:14:03] [CPU1] [10] [a7] up_assert: Assertion failed CPU1 at file:mm_heap/mm_free.c line: 115 task: panel_apps
[48/12/ 7 16:14:03] [CPU1] [10] [a7] backtrace|10: 0x38443440 0x38081f30 0x38002888 0x3802cb7c 0x38036e34 0x38037978 0x380386f0 0x38037e64
[48/12/ 7 16:14:03] [CPU1] [10] [a7] backtrace|10: 0x38036edc 0x380376a0 0x38035a2c 0x380070d0 0x3804eae4 0x3802abd0 0x3802277c 0x3804b998
[48/12/ 7 16:14:03] [CPU1] [10] [a7] backtrace|10: 0x38091be8 0x38099250 0x38096adc 0x3808f134 0x3802d5d8 0x380191a4
[48/12/ 7 16:14:03] [CPU1] [10] [a7] arm_registerdump: R0: 00000000 R1: 00000000 R2: 00000000  R3: 00000000
[48/12/ 7 16:14:03] [CPU1] [10] [a7] arm_registerdump: R4: 00000000 R5: 00000000 R6: 00000000  R7: 00000000
[48/12/ 7 16:14:03] [CPU1] [10] [a7] arm_registerdump: R8: 00000000 SB: 00000000 SL: 00000000  FP: 00000000
[48/12/ 7 16:14:03] [CPU1] [10] [a7] arm_registerdump: IP: 00000000 SP: 00000000 LR: 00000000  PC: 00000000
[48/12/ 7 16:14:03] [CPU1] [10] [a7] arm_registerdump: CPSR: 00000000
```
## Impact
armv7-a crash log

## Testing
vela
