### PR TITLE
net/d_buf: remove d_buf reference from l3/l4

### DIFF
--- a/arch/arm/src/lpc54xx/lpc54_ethernet.c
+++ b/arch/arm/src/lpc54xx/lpc54_ethernet.c
@@ -253,6 +253,12 @@
 
 #define ETH8021QWBUF ((struct eth_8021qhdr_s *)priv->eth_dev.d_buf)
 
+/* This is a helper pointer for accessing the contents of the Ethernet
+ * header
+ */
+
+#define BUF ((FAR struct eth_hdr_s *)&dev->d_buf[0])
+
 /****************************************************************************
  * Private Types
  ****************************************************************************/
@@ -890,7 +896,7 @@ static void lpc54_eth_rxdispatch(struct lpc54_ethdriver_s *priv)
   /* We only accept IP packets of the configured type and ARP packets */
 
 #ifdef CONFIG_NET_IPv4
-  if (ETHBUF->type == HTONS(ETHTYPE_IP))
+  if (BUF->type == HTONS(ETHTYPE_IP))
     {
       ninfo("IPv4 packet\n");
       NETDEV_RXIPV4(dev);
@@ -906,7 +912,7 @@ static void lpc54_eth_rxdispatch(struct lpc54_ethdriver_s *priv)
   else
 #endif
 #ifdef CONFIG_NET_IPv6
-  if (ETHBUF->type == HTONS(ETHTYPE_IP6))
+  if (BUF->type == HTONS(ETHTYPE_IP6))
     {
       ninfo("IPv6 packet\n");
       NETDEV_RXIPV6(dev);
@@ -938,7 +944,7 @@ static void lpc54_eth_rxdispatch(struct lpc54_ethdriver_s *priv)
   else
 #endif
 #ifdef CONFIG_NET_ARP
-  if (ETHBUF->type == HTONS(ETHTYPE_ARP))
+  if (BUF->type == HTONS(ETHTYPE_ARP))
     {
       struct lpc54_txring_s *txring;
       unsigned int chan;

--- a/arch/arm/src/tiva/lm/lm3s_ethernet.c
+++ b/arch/arm/src/tiva/lm/lm3s_ethernet.c
@@ -160,6 +160,12 @@
 
 #define TIVA_MAX_MDCCLK 2500000
 
+/* This is a helper pointer for accessing the contents of the Ethernet
+ * header
+ */
+
+#define BUF ((FAR struct eth_hdr_s *)&dev->d_buf[0])
+
 /****************************************************************************
  * Private Types
  ****************************************************************************/
@@ -757,7 +763,7 @@ static void tiva_receive(struct tiva_driver_s *priv)
       /* We only accept IP packets of the configured type and ARP packets */
 
 #ifdef CONFIG_NET_IPv4
-      if (ETHBUF->type == HTONS(ETHTYPE_IP))
+      if (BUF->type == HTONS(ETHTYPE_IP))
         {
           ninfo("IPv4 frame\n");
           NETDEV_RXIPV4(dev);
@@ -780,7 +786,7 @@ static void tiva_receive(struct tiva_driver_s *priv)
       else
 #endif
 #ifdef CONFIG_NET_IPv6
-      if (ETHBUF->type == HTONS(ETHTYPE_IP6))
+      if (BUF->type == HTONS(ETHTYPE_IP6))
         {
           ninfo("IPv6 frame\n");
           NETDEV_RXIPV6(dev);
@@ -803,9 +809,9 @@ static void tiva_receive(struct tiva_driver_s *priv)
       else
 #endif
 #ifdef CONFIG_NET_ARP
-      if (ETHBUF->type == HTONS(ETHTYPE_ARP))
+      if (BUF->type == HTONS(ETHTYPE_ARP))
         {
-          ninfo("ARP packet received (%02x)\n", ETHBUF->type);
+          ninfo("ARP packet received (%02x)\n", BUF->type);
           NETDEV_RXARP(dev);
 
           arp_arpin(dev);
@@ -823,7 +829,7 @@ static void tiva_receive(struct tiva_driver_s *priv)
 #endif
         {
           nwarn("WARNING: Unsupported packet type dropped (%02x)\n",
-                HTONS(ETHBUF->type));
+                HTONS(BUF->type));
           NETDEV_RXDROPPED(dev);
         }
     }

--- a/arch/z80/src/ez80/ez80_emac.c
+++ b/arch/z80/src/ez80/ez80_emac.c
@@ -247,6 +247,12 @@ extern uint8_t _RAM_ADDR_U_INIT_PARAM[];
 
 #define EMAC_TXTIMEOUT         (60*CLK_TCK)
 
+/* This is a helper pointer for accessing the contents of the Ethernet
+ * header
+ */
+
+#define BUF ((FAR struct eth_hdr_s *)&dev->d_buf[0])
+
 /****************************************************************************
  * Private Types
  ****************************************************************************/
@@ -1361,7 +1367,7 @@ static int ez80emac_receive(FAR struct ez80emac_driver_s *priv)
       /* We only accept IP packets of the configured type and ARP packets */
 
 #ifdef CONFIG_NET_IPv4
-      if (ETHBUF->type == HTONS(ETHTYPE_IP))
+      if (BUF->type == HTONS(ETHTYPE_IP))
         {
           ninfo("IPv4 frame\n");
 
@@ -1385,7 +1391,7 @@ static int ez80emac_receive(FAR struct ez80emac_driver_s *priv)
       else
 #endif
 #ifdef CONFIG_NET_IPv6
-      if (ETHBUF->type == HTONS(ETHTYPE_IP6))
+      if (BUF->type == HTONS(ETHTYPE_IP6))
         {
           ninfo("IPv6 frame\n");
 
@@ -1409,9 +1415,9 @@ static int ez80emac_receive(FAR struct ez80emac_driver_s *priv)
       else
 #endif
 #ifdef CONFIG_NET_ARP
-      if (ETHBUF->type == HTONS(ETHTYPE_ARP))
+      if (BUF->type == HTONS(ETHTYPE_ARP))
         {
-          ninfo("ARP packet received (%02x)\n", ETHBUF->type);
+          ninfo("ARP packet received (%02x)\n", BUF->type);
           EMAC_STAT(priv, rx_arp);
 
           arp_arpin(&priv->dev);
@@ -1429,7 +1435,7 @@ static int ez80emac_receive(FAR struct ez80emac_driver_s *priv)
       else
 #endif
         {
-          ninfo("Unsupported packet type dropped (%02x)\n", ETHBUF->type);
+          ninfo("Unsupported packet type dropped (%02x)\n", BUF->type);
           EMAC_STAT(priv, rx_dropped);
         }
 

--- a/include/nuttx/net/netdev.h
+++ b/include/nuttx/net/netdev.h
@@ -157,17 +157,12 @@
 #  define NETDEV_ERRORS(dev)
 #endif
 
-/* There are some helper pointers for accessing the contents of the Ethernet
- * headers
- */
-
-#define ETHBUF ((FAR struct eth_hdr_s *)&dev->d_buf[0])
-
 /* There are some helper pointers for accessing the contents of the IP
  * headers
  */
 
-#define IPBUF(hl) ((FAR void *)&dev->d_buf[NET_LL_HDRLEN(dev) + (hl)])
+#define IPBUF(hl) ((FAR void *)\
+                   &dev->d_iob->io_data[CONFIG_NET_LL_GUARDSIZE + (hl)])
 
 #define IPv4BUF ((FAR struct ipv4_hdr_s *)IPBUF(0))
 #define IPv6BUF ((FAR struct ipv6_hdr_s *)IPBUF(0))

--- a/net/arp/arp.h
+++ b/net/arp/arp.h
@@ -45,6 +45,8 @@
 #include <nuttx/net/netdev.h>
 #include <nuttx/semaphore.h>
 
+#include "devif/devif.h"
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -81,8 +83,10 @@
 
 /* This is a helper pointer for accessing the contents of the IP header */
 
-#define ARPBUF    ((FAR struct arp_hdr_s *)&dev->d_buf[ETH_HDRLEN])
-#define ARPIPBUF  ((FAR struct arp_iphdr_s *)&dev->d_buf[ETH_HDRLEN])
+#define ARPBUF   ((FAR struct arp_hdr_s *)\
+                  &dev->d_iob->io_data[CONFIG_NET_LL_GUARDSIZE])
+#define ARPIPBUF ((FAR struct arp_iphdr_s *)\
+                  &dev->d_iob->io_data[CONFIG_NET_LL_GUARDSIZE])
 
 /****************************************************************************
  * Public Types

--- a/net/devif/devif.h
+++ b/net/devif/devif.h
@@ -233,6 +233,14 @@
 #  define DEVIF_IS_IPv6(dev) (0)
 #endif
 
+/* There are some helper pointers for accessing the contents of the Ethernet
+ * headers
+ */
+
+#define ETHBUF ((FAR struct eth_hdr_s *)\
+                &dev->d_iob->io_data[CONFIG_NET_LL_GUARDSIZE - \
+                                     NET_LL_HDRLEN(dev)])
+
 /****************************************************************************
  * Public Type Definitions
  ****************************************************************************/

--- a/net/devif/devif_loopback.c
+++ b/net/devif/devif_loopback.c
@@ -32,17 +32,6 @@
 #include <nuttx/net/netdev.h>
 
 /****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-/* This is a helper pointer for accessing the contents of the ip header */
-
-#define LOIPv4BUF ((FAR struct ipv4_hdr_s *) \
-                   &dev->d_iob->io_data[CONFIG_NET_LL_GUARDSIZE])
-#define LOIPv6BUF ((FAR struct ipv6_hdr_s *) \
-                   &dev->d_iob->io_data[CONFIG_NET_LL_GUARDSIZE])
-
-/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -51,16 +40,16 @@ static bool is_loopback(FAR struct net_driver_s *dev)
   if (dev->d_len > 0)
     {
 #ifdef CONFIG_NET_IPv4
-      if ((LOIPv4BUF->vhl & IP_VERSION_MASK) == IPv4_VERSION &&
-           net_ipv4addr_hdrcmp(LOIPv4BUF->destipaddr, &dev->d_ipaddr))
+      if ((IPv4BUF->vhl & IP_VERSION_MASK) == IPv4_VERSION &&
+           net_ipv4addr_hdrcmp(IPv4BUF->destipaddr, &dev->d_ipaddr))
         {
           return true;
         }
 #endif
 
 #ifdef CONFIG_NET_IPv6
-      if ((LOIPv6BUF->vtc & IP_VERSION_MASK) == IPv6_VERSION &&
-          net_ipv6addr_hdrcmp(LOIPv6BUF->destipaddr, dev->d_ipv6addr))
+      if ((IPv6BUF->vtc & IP_VERSION_MASK) == IPv6_VERSION &&
+          net_ipv6addr_hdrcmp(IPv6BUF->destipaddr, dev->d_ipv6addr))
         {
           return true;
         }
@@ -110,7 +99,7 @@ int devif_loopback(FAR struct net_driver_s *dev)
       /* We only accept IP packets of the configured type */
 
 #ifdef CONFIG_NET_IPv4
-      if ((LOIPv4BUF->vhl & IP_VERSION_MASK) == IPv4_VERSION)
+      if ((IPv4BUF->vhl & IP_VERSION_MASK) == IPv4_VERSION)
         {
           ninfo("IPv4 frame\n");
 
@@ -120,7 +109,7 @@ int devif_loopback(FAR struct net_driver_s *dev)
       else
 #endif
 #ifdef CONFIG_NET_IPv6
-      if ((LOIPv6BUF->vtc & IP_VERSION_MASK) == IPv6_VERSION)
+      if ((IPv6BUF->vtc & IP_VERSION_MASK) == IPv6_VERSION)
         {
           ninfo("IPv6 frame\n");
 

--- a/net/neighbor/neighbor_ethernet_out.c
+++ b/net/neighbor/neighbor_ethernet_out.c
@@ -196,10 +196,6 @@ void neighbor_ethernet_out(FAR struct net_driver_s *dev)
   memcpy(eth->src, dev->d_mac.ether.ether_addr_octet, ETHER_ADDR_LEN);
   eth->type  = HTONS(ETHTYPE_IP6);
 
-  /* Update device buffer length */
-
-  iob_update_pktlen(dev->d_iob, dev->d_len);
-
   /* Add the size of the layer layer header to the total size of the
    * outgoing packet.
    */

--- a/net/neighbor/neighbor_ethernet_out.c
+++ b/net/neighbor/neighbor_ethernet_out.c
@@ -33,6 +33,7 @@
 #include <nuttx/net/netdev.h>
 #include <nuttx/net/neighbor.h>
 
+#include "devif/devif.h"
 #include "route/route.h"
 #include "icmpv6/icmpv6.h"
 #include "neighbor/neighbor.h"

--- a/net/tcp/tcp_input.c
+++ b/net/tcp/tcp_input.c
@@ -63,7 +63,7 @@
 #include "utils/utils.h"
 #include "tcp/tcp.h"
 
-#define IPDATA(hl) (dev->d_buf[NET_LL_HDRLEN(dev) + (hl)])
+#define IPDATA(hl) (dev->d_iob->io_data[CONFIG_NET_LL_GUARDSIZE + (hl)])
 
 /****************************************************************************
  * Private Functions

--- a/net/utils/net_ipchksum.c
+++ b/net/utils/net_ipchksum.c
@@ -54,7 +54,8 @@
  *
  ****************************************************************************/
 
-#if !defined(CONFIG_NET_ARCH_CHKSUM) && defined(CONFIG_NET_IPv4)
+#if !defined(CONFIG_NET_ARCH_CHKSUM) && \
+    defined(CONFIG_NET_IPv4) && defined(CONFIG_MM_IOB)
 uint16_t ipv4_upperlayer_chksum(FAR struct net_driver_s *dev, uint8_t proto)
 {
   FAR struct ipv4_hdr_s *ipv4 = IPv4BUF;
@@ -93,16 +94,7 @@ uint16_t ipv4_upperlayer_chksum(FAR struct net_driver_s *dev, uint8_t proto)
 
   /* Sum IP payload data. */
 
-#ifdef CONFIG_MM_IOB
-  if (dev->d_iob != NULL)
-    {
-      sum = chksum_iob(sum, dev->d_iob, iphdrlen);
-    }
-  else
-#endif
-    {
-      sum = chksum(sum, IPBUF(iphdrlen), upperlen);
-    }
+  sum = chksum_iob(sum, dev->d_iob, iphdrlen);
 
   return (sum == 0) ? 0xffff : HTONS(sum);
 }
@@ -128,7 +120,8 @@ uint16_t ipv4_upperlayer_chksum(FAR struct net_driver_s *dev, uint8_t proto)
  *
  ****************************************************************************/
 
-#if !defined(CONFIG_NET_ARCH_CHKSUM) && defined(CONFIG_NET_IPv6)
+#if !defined(CONFIG_NET_ARCH_CHKSUM) && \
+    defined(CONFIG_NET_IPv6) && defined(CONFIG_MM_IOB)
 uint16_t ipv6_upperlayer_chksum(FAR struct net_driver_s *dev,
                                 uint8_t proto, unsigned int iplen)
 {
@@ -170,16 +163,7 @@ uint16_t ipv6_upperlayer_chksum(FAR struct net_driver_s *dev,
 
   /* Sum IP payload data. */
 
-#ifdef CONFIG_MM_IOB
-  if (dev->d_iob != NULL)
-    {
-      sum = chksum_iob(sum, dev->d_iob, iplen);
-    }
-  else
-#endif
-    {
-      sum = chksum(sum, IPBUF(iplen), upperlen);
-    }
+  sum = chksum_iob(sum, dev->d_iob, iplen);
 
   return (sum == 0) ? 0xffff : HTONS(sum);
 }


### PR DESCRIPTION
## Summary

net/d_buf: remove d_buf reference from l3/l4

l3/l4 stack will decouple the reference of d_buf gradually, Only legacy
devices still retain d_buf support, new net devices will use d_iob

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

iperf ipv4/ipv6 test