### PR TITLE
net: Rename arp_arpin to arp_input

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -217,7 +217,7 @@ include/nuttx/net/netstats.h
 include/nuttx/net/tcp.h
 include/nuttx/net/tun.h
 include/nuttx/net/udp.h
-net/arp/arp_arpin.c
+net/arp/arp_input.c
 net/arp/arp_dump.c
 net/arp/arp_format.c
 net/arp/arp_ipin.c

--- a/arch/arm/src/c5471/c5471_ethernet.c
+++ b/arch/arm/src/c5471/c5471_ethernet.c
@@ -1338,7 +1338,7 @@ static void c5471_receive(struct c5471_driver_s *priv)
 #ifdef CONFIG_NET_ARP
       if (BUF->type == HTONS(ETHTYPE_ARP))
         {
-          arp_arpin(dev);
+          arp_input(dev);
 
           /* If the above function invocation resulted in data that should be
            * sent out on the network, d_len field will set to a value > 0.

--- a/arch/arm/src/gd32f4/gd32f4xx_enet.c
+++ b/arch/arm/src/gd32f4/gd32f4xx_enet.c
@@ -1710,7 +1710,7 @@ static void gd32_receive(struct gd32_enet_mac_s *priv)
 
           /* Handle ARP packet */
 
-          arp_arpin(&priv->dev);
+          arp_input(&priv->dev);
 
           /* If the above function invocation resulted in data that should be
            * sent out on the network, d_len field will set to a value > 0.

--- a/arch/arm/src/imx6/imx_enet.c
+++ b/arch/arm/src/imx6/imx_enet.c
@@ -813,7 +813,7 @@ static inline void imx_dispatch(struct imx_driver_s *priv)
   if (BUF->type == HTONS(ETHTYPE_ARP))
     {
       NETDEV_RXARP(&priv->dev);
-      arp_arpin(&priv->dev);
+      arp_input(&priv->dev);
 
       /* If the above function invocation resulted in data that should
        * be sent out on the network, the field  d_len will set to a

--- a/arch/arm/src/imxrt/imxrt_enet.c
+++ b/arch/arm/src/imxrt/imxrt_enet.c
@@ -855,7 +855,7 @@ static inline void imxrt_dispatch(struct imxrt_driver_s *priv)
   if (BUF->type == HTONS(ETHTYPE_ARP))
     {
       NETDEV_RXARP(&priv->dev);
-      arp_arpin(&priv->dev);
+      arp_input(&priv->dev);
 
       /* If the above function invocation resulted in data that should
        * be sent out on the network, the field  d_len will set to a

--- a/arch/arm/src/kinetis/kinetis_enet.c
+++ b/arch/arm/src/kinetis/kinetis_enet.c
@@ -646,7 +646,7 @@ static void kinetis_receive(struct kinetis_driver_s *priv)
       if (BUF->type == HTONS(ETHTYPE_ARP))
         {
           NETDEV_RXARP(&priv->dev);
-          arp_arpin(&priv->dev);
+          arp_input(&priv->dev);
 
           /* If the above function invocation resulted in data that should
            * be sent out on the network, the field d_len will set to a

--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_ethernet.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_ethernet.c
@@ -962,7 +962,7 @@ static void lpc17_40_rxdone_work(void *arg)
           if (BUF->type == HTONS(ETHTYPE_ARP))
             {
               NETDEV_RXARP(&priv->lp_dev);
-              arp_arpin(&priv->lp_dev);
+              arp_input(&priv->lp_dev);
 
               /* If the above function invocation resulted in data that
                * should be sent out on the network, the field  d_len will

--- a/arch/arm/src/lpc43xx/lpc43_ethernet.c
+++ b/arch/arm/src/lpc43xx/lpc43_ethernet.c
@@ -1642,7 +1642,7 @@ static void lpc43_receive(struct lpc43_ethmac_s *priv)
 
           /* Handle ARP packet */
 
-          arp_arpin(&priv->dev);
+          arp_input(&priv->dev);
 
           /* If the above function invocation resulted in data that should be
            * sent out on the network, d_len field will set to a value > 0.

--- a/arch/arm/src/lpc54xx/lpc54_ethernet.c
+++ b/arch/arm/src/lpc54xx/lpc54_ethernet.c
@@ -945,7 +945,7 @@ static void lpc54_eth_rxdispatch(struct lpc54_ethdriver_s *priv)
 
       /* Dispatch the ARP packet to the network layer */
 
-      arp_arpin(dev);
+      arp_input(dev);
       NETDEV_RXARP(dev);
 
       /* If the above function invocation resulted in data that should be

--- a/arch/arm/src/rtl8720c/amebaz_netdev.c
+++ b/arch/arm/src/rtl8720c/amebaz_netdev.c
@@ -150,7 +150,7 @@ void amebaz_netdev_notify_receive(struct amebaz_dev_s *priv,
 #ifdef CONFIG_NET_ARP
           if (hdr->type == HTONS(ETHTYPE_ARP))
             {
-              arp_arpin(&priv->dev);
+              arp_input(&priv->dev);
               NETDEV_RXARP(&priv->dev);
               if (priv->dev.d_len > 0)
                 {

--- a/arch/arm/src/s32k1xx/s32k1xx_enet.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_enet.c
@@ -698,7 +698,7 @@ static inline void s32k1xx_dispatch(struct s32k1xx_driver_s *priv)
   if (BUF->type == HTONS(ETHTYPE_ARP))
     {
       NETDEV_RXARP(&priv->dev);
-      arp_arpin(&priv->dev);
+      arp_input(&priv->dev);
 
       /* If the above function invocation resulted in data that should
        * be sent out on the network, the field  d_len will set to a

--- a/arch/arm/src/s32k3xx/s32k3xx_emac.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_emac.c
@@ -1391,7 +1391,7 @@ static void s32k3xx_receive(struct s32k3xx_driver_s *priv)
 
           /* Handle ARP packet */
 
-          arp_arpin(&priv->dev);
+          arp_input(&priv->dev);
 
           /* If the above function invocation resulted in data that should
            * be sent out on the network, the field  d_len will set to a

--- a/arch/arm/src/sam34/sam_emac.c
+++ b/arch/arm/src/sam34/sam_emac.c
@@ -1227,7 +1227,7 @@ static void sam_receive(struct sam_emac_s *priv)
 
           /* Handle ARP packet */
 
-          arp_arpin(&priv->dev);
+          arp_input(&priv->dev);
 
           /* If the above function invocation resulted in data that should be
            * sent out on the network, d_len field will set to a value > 0.

--- a/arch/arm/src/sama5/sam_emaca.c
+++ b/arch/arm/src/sama5/sam_emaca.c
@@ -1290,7 +1290,7 @@ static void sam_receive(struct sam_emac_s *priv)
 
           /* Handle ARP packet */
 
-          arp_arpin(&priv->dev);
+          arp_input(&priv->dev);
 
           /* If the above function invocation resulted in data that should be
            * sent out on the network, d_len field will set to a value > 0.

--- a/arch/arm/src/sama5/sam_emacb.c
+++ b/arch/arm/src/sama5/sam_emacb.c
@@ -1601,7 +1601,7 @@ static void sam_receive(struct sam_emac_s *priv)
 
           /* Handle ARP packet */
 
-          arp_arpin(&priv->dev);
+          arp_input(&priv->dev);
 
           /* If the above function invocation resulted in data that should be
            * sent out on the network, d_len field will set to a value > 0.

--- a/arch/arm/src/sama5/sam_gmac.c
+++ b/arch/arm/src/sama5/sam_gmac.c
@@ -1236,7 +1236,7 @@ static void sam_receive(struct sam_gmac_s *priv)
 
           /* Handle ARP packet */
 
-          arp_arpin(&priv->dev);
+          arp_input(&priv->dev);
 
           /* If the above function invocation resulted in data that should be
            * sent out on the network, the field  d_len will set to a

--- a/arch/arm/src/samd5e5/sam_gmac.c
+++ b/arch/arm/src/samd5e5/sam_gmac.c
@@ -1219,7 +1219,7 @@ static void sam_receive(struct sam_gmac_s *priv)
 
           /* Handle ARP packet */
 
-          arp_arpin(&priv->dev);
+          arp_input(&priv->dev);
 
           /* If the above function invocation resulted in data that should be
            * sent out on the network, d_len field will set to a value > 0.

--- a/arch/arm/src/samv7/sam_emac.c
+++ b/arch/arm/src/samv7/sam_emac.c
@@ -1925,7 +1925,7 @@ static void sam_receive(struct sam_emac_s *priv, int qid)
 
           /* Handle ARP packet */
 
-          arp_arpin(&priv->dev);
+          arp_input(&priv->dev);
 
           /* If the above function invocation resulted in data that should be
            * sent out on the network, d_len field will set to a value > 0.

--- a/arch/arm/src/stm32/stm32_eth.c
+++ b/arch/arm/src/stm32/stm32_eth.c
@@ -1771,7 +1771,7 @@ static void stm32_receive(struct stm32_ethmac_s *priv)
 
           /* Handle ARP packet */
 
-          arp_arpin(&priv->dev);
+          arp_input(&priv->dev);
 
           /* If the above function invocation resulted in data that should be
            * sent out on the network, d_len field will set to a value > 0.

--- a/arch/arm/src/stm32f7/stm32_ethernet.c
+++ b/arch/arm/src/stm32f7/stm32_ethernet.c
@@ -1852,7 +1852,7 @@ static void stm32_receive(struct stm32_ethmac_s *priv)
 
           /* Handle ARP packet */
 
-          arp_arpin(&priv->dev);
+          arp_input(&priv->dev);
 
           /* If the above function invocation resulted in data that should be
            * sent out on the network, d_len field will set to a value > 0.

--- a/arch/arm/src/stm32h7/stm32_ethernet.c
+++ b/arch/arm/src/stm32h7/stm32_ethernet.c
@@ -1961,7 +1961,7 @@ static void stm32_receive(struct stm32_ethmac_s *priv)
 
           /* Handle ARP packet */
 
-          arp_arpin(&priv->dev);
+          arp_input(&priv->dev);
 
           /* If the above function invocation resulted in data that should
            * be sent out on the network, the field  d_len will set to a

--- a/arch/arm/src/tiva/lm/lm3s_ethernet.c
+++ b/arch/arm/src/tiva/lm/lm3s_ethernet.c
@@ -808,7 +808,7 @@ static void tiva_receive(struct tiva_driver_s *priv)
           ninfo("ARP packet received (%02x)\n", ETHBUF->type);
           NETDEV_RXARP(dev);
 
-          arp_arpin(dev);
+          arp_input(dev);
 
           /* If the above function invocation resulted in data that should be
            * sent out on the network, d_len field will set to a value > 0.

--- a/arch/arm/src/tiva/tm4c/tm4c_ethernet.c
+++ b/arch/arm/src/tiva/tm4c/tm4c_ethernet.c
@@ -1745,7 +1745,7 @@ static void tiva_receive(struct tiva_ethmac_s *priv)
 
           /* Handle ARP packet */
 
-          arp_arpin(&priv->dev);
+          arp_input(&priv->dev);
 
           /* If the above function invocation resulted in data that should be
            * sent out on the network, d_len field will set to a value > 0.

--- a/arch/hc/src/m9s12/m9s12_ethernet.c
+++ b/arch/hc/src/m9s12/m9s12_ethernet.c
@@ -296,7 +296,7 @@ static void emac_receive(FAR struct emac_driver_s *priv)
 #ifdef CONFIG_NET_ARP
       if (BUF->type == HTONS(ETHTYPE_ARP))
         {
-          arp_arpin(&priv->d_dev);
+          arp_input(&priv->d_dev);
 
           /* If the above function invocation resulted in data that should be
            * sent out on the network, d_len field will set to a value > 0.

--- a/arch/mips/src/pic32mx/pic32mx_ethernet.c
+++ b/arch/mips/src/pic32mx/pic32mx_ethernet.c
@@ -1431,7 +1431,7 @@ static void pic32mx_rxdone(struct pic32mx_driver_s *priv)
               /* Handle the incoming ARP packet */
 
               NETDEV_RXARP(&priv->pd_dev);
-              arp_arpin(&priv->pd_dev);
+              arp_input(&priv->pd_dev);
 
               /* If the above function invocation resulted in data that
                * should be sent out on the network, the field  d_len will

--- a/arch/mips/src/pic32mz/pic32mz_ethernet.c
+++ b/arch/mips/src/pic32mz/pic32mz_ethernet.c
@@ -1542,7 +1542,7 @@ static void pic32mz_rxdone(struct pic32mz_driver_s *priv)
               /* Handle the incoming ARP packet */
 
               NETDEV_RXARP(&priv->pd_dev);
-              arp_arpin(&priv->pd_dev);
+              arp_input(&priv->pd_dev);
 
               /* If the above function invocation resulted in data that
                * should be sent out on the network, the field  d_len will

--- a/arch/misoc/src/common/misoc_net.c
+++ b/arch/misoc/src/common/misoc_net.c
@@ -413,7 +413,7 @@ static void misoc_net_receive(struct misoc_net_driver_s *priv)
 #ifdef CONFIG_NET_ARP
       if (BUF->type == HTONS(ETHTYPE_ARP))
         {
-          arp_arpin(&priv->misoc_net_dev);
+          arp_input(&priv->misoc_net_dev);
           NETDEV_RXARP(&priv->misoc_net_dev);
 
           /* If the above function invocation resulted in data that should be

--- a/arch/renesas/src/rx65n/rx65n_eth.c
+++ b/arch/renesas/src/rx65n/rx65n_eth.c
@@ -1577,7 +1577,7 @@ static void rx65n_receive(FAR struct rx65n_ethmac_s *priv)
 
           /* Handle ARP packet */
 
-          arp_arpin(&priv->dev);
+          arp_input(&priv->dev);
 
           /* If the above function invocation resulted in data
            * that should be sent out on the network, the field

--- a/arch/risc-v/src/bl602/bl602_netdev.c
+++ b/arch/risc-v/src/bl602/bl602_netdev.c
@@ -530,7 +530,7 @@ static void bl602_net_receive(struct bl602_net_driver_s *priv)
     {
       /* Dispatch ARP packet to the network layer */
 
-      arp_arpin(&priv->net_dev);
+      arp_input(&priv->net_dev);
       NETDEV_RXARP(&priv->net_dev);
 
       if (priv->net_dev.d_len > 0)

--- a/arch/risc-v/src/esp32c3/esp32c3_wlan.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_wlan.c
@@ -768,7 +768,7 @@ static void wlan_rxpoll(void *arg)
 
           /* Handle ARP packet */
 
-          arp_arpin(&priv->dev);
+          arp_input(&priv->dev);
 
           /* If the above function invocation resulted in data
            * that should be sent out on the network, the field

--- a/arch/risc-v/src/litex/litex_emac.c
+++ b/arch/risc-v/src/litex/litex_emac.c
@@ -615,7 +615,7 @@ static void litex_receive(struct litex_emac_s *priv)
     {
       ninfo("ARP frame\n");
       NETDEV_RXARP(&priv->dev);
-      arp_arpin(&priv->dev);
+      arp_input(&priv->dev);
 
       /* If the above function invocation resulted in data that should
        * be sent out on the network, the field d_len will set to a

--- a/arch/risc-v/src/mpfs/mpfs_ethernet.c
+++ b/arch/risc-v/src/mpfs/mpfs_ethernet.c
@@ -885,7 +885,7 @@ static void mpfs_receive(struct mpfs_ethmac_s *priv, unsigned int queue)
 
           /* Handle ARP packet */
 
-          arp_arpin(&priv->dev);
+          arp_input(&priv->dev);
 
           /* If the above function invocation resulted in data that should be
            * sent out on the network, the field  d_len will set to a

--- a/arch/sim/src/sim/sim_netdriver.c
+++ b/arch/sim/src/sim/sim_netdriver.c
@@ -227,7 +227,7 @@ static void netdriver_recv_work(void *arg)
                   ninfo("ARP frame\n");
                   NETDEV_RXARP(dev);
 
-                  arp_arpin(dev);
+                  arp_input(dev);
 
                   /* If the above function invocation resulted in data that
                    * should be sent out on the network, the global variable

--- a/arch/xtensa/src/esp32/esp32_emac.c
+++ b/arch/xtensa/src/esp32/esp32_emac.c
@@ -1416,7 +1416,7 @@ static void emac_rx_interrupt_work(void *arg)
 
           /* Handle ARP packet */
 
-          arp_arpin(&priv->dev);
+          arp_input(&priv->dev);
 
           /* If the above function invocation resulted in data that should be
            * sent out on the network, the field d_len will set to a value > 0

--- a/arch/xtensa/src/esp32/esp32_wlan.c
+++ b/arch/xtensa/src/esp32/esp32_wlan.c
@@ -765,7 +765,7 @@ static void wlan_rxpoll(void *arg)
 
           /* Handle ARP packet */
 
-          arp_arpin(&priv->dev);
+          arp_input(&priv->dev);
 
           /* If the above function invocation resulted in data
            * that should be sent out on the network, the field

--- a/arch/z80/src/ez80/ez80_emac.c
+++ b/arch/z80/src/ez80/ez80_emac.c
@@ -1414,7 +1414,7 @@ static int ez80emac_receive(FAR struct ez80emac_driver_s *priv)
           ninfo("ARP packet received (%02x)\n", ETHBUF->type);
           EMAC_STAT(priv, rx_arp);
 
-          arp_arpin(&priv->dev);
+          arp_input(&priv->dev);
 
           /* If the above function invocation resulted in data that should be
            * sent out on the network, the field  d_len will set to a value >

--- a/drivers/net/dm90x0.c
+++ b/drivers/net/dm90x0.c
@@ -946,7 +946,7 @@ static void dm9x_receive(FAR struct dm9x_driver_s *priv)
 #ifdef CONFIG_NET_ARP
           if (BUF->type == HTONS(ETHTYPE_ARP))
             {
-              arp_arpin(&priv->dm_dev);
+              arp_input(&priv->dm_dev);
               NETDEV_RXARP(&priv->dm_dev);
 
               /* If the above function invocation resulted in data that

--- a/drivers/net/enc28j60.c
+++ b/drivers/net/enc28j60.c
@@ -1391,7 +1391,7 @@ static void enc_rxdispatch(FAR struct enc_driver_s *priv)
       ninfo("ARP packet received (%02x)\n", BUF->type);
       NETDEV_RXARP(&priv->dev);
 
-      arp_arpin(&priv->dev);
+      arp_input(&priv->dev);
 
       /* If the above function invocation resulted in data that should be
        * sent out on the network, d_len field will set to a value > 0.

--- a/drivers/net/encx24j600.c
+++ b/drivers/net/encx24j600.c
@@ -1488,7 +1488,7 @@ static void enc_rxdispatch(FAR struct enc_driver_s *priv)
           ninfo("ARP packet received (%02x)\n", BUF->type);
           NETDEV_RXARP(&priv->dev);
 
-          arp_arpin(&priv->dev);
+          arp_input(&priv->dev);
 
           /* ARP packets are freed immediately */
 

--- a/drivers/net/ftmac100.c
+++ b/drivers/net/ftmac100.c
@@ -695,7 +695,7 @@ static void ftmac100_receive(FAR struct ftmac100_driver_s *priv)
 #ifdef CONFIG_NET_ARP
       if (BUF->type == HTONS(ETHTYPE_ARP))
         {
-          arp_arpin(&priv->ft_dev);
+          arp_input(&priv->ft_dev);
 
           /* If the above function invocation resulted in data that should be
            * sent out on the network, the field  d_len will set to a value

--- a/drivers/net/lan91c111.c
+++ b/drivers/net/lan91c111.c
@@ -663,7 +663,7 @@ static void lan91c111_receive(FAR struct net_driver_s *dev)
 
       /* Dispatch ARP packet to the network layer */
 
-      arp_arpin(dev);
+      arp_input(dev);
 
       /* Check for a reply to the ARP packet */
 

--- a/drivers/net/rpmsgdrv.c
+++ b/drivers/net/rpmsgdrv.c
@@ -538,7 +538,7 @@ static int net_rpmsg_drv_transfer_handler(FAR struct rpmsg_endpoint *ept,
 
       /* Dispatch ARP packet to the network layer */
 
-      arp_arpin(dev);
+      arp_input(dev);
 
       /* Check for a reply to the ARP packet */
 

--- a/drivers/net/skeleton.c
+++ b/drivers/net/skeleton.c
@@ -379,7 +379,7 @@ static void skel_receive(FAR struct skel_driver_s *priv)
         {
           /* Dispatch ARP packet to the network layer */
 
-          arp_arpin(&priv->sk_dev);
+          arp_input(&priv->sk_dev);
           NETDEV_RXARP(&priv->sk_dev);
 
           /* If the above function invocation resulted in data that should be

--- a/drivers/net/tun.c
+++ b/drivers/net/tun.c
@@ -495,7 +495,7 @@ static void tun_net_receive_tap(FAR struct tun_device_s *priv)
 #ifdef CONFIG_NET_ARP
   if (BUF->type == HTONS(ETHTYPE_ARP))
     {
-      arp_arpin(&priv->dev);
+      arp_input(&priv->dev);
       NETDEV_RXARP(&priv->dev);
 
       /* If the above function invocation resulted in data that should be

--- a/drivers/net/w5500.c
+++ b/drivers/net/w5500.c
@@ -1410,7 +1410,7 @@ static void w5500_receive(FAR struct w5500_driver_s *self)
 
           /* Dispatch ARP packet to the network layer */
 
-          arp_arpin(&self->w_dev);
+          arp_input(&self->w_dev);
           NETDEV_RXARP(&self->w_dev);
 
           /* If the above function invocation resulted in data that should be

--- a/drivers/usbdev/cdcecm.c
+++ b/drivers/usbdev/cdcecm.c
@@ -461,7 +461,7 @@ static void cdcecm_receive(FAR struct cdcecm_driver_s *self)
     {
       /* Dispatch ARP packet to the network layer */
 
-      arp_arpin(&self->dev);
+      arp_input(&self->dev);
       NETDEV_RXARP(&self->dev);
 
       /* If the above function invocation resulted in data that should be

--- a/drivers/usbdev/rndis.c
+++ b/drivers/usbdev/rndis.c
@@ -904,7 +904,7 @@ static void rndis_rxdispatch(FAR void *arg)
     {
       NETDEV_RXARP(&priv->netdev);
 
-      arp_arpin(&priv->netdev);
+      arp_input(&priv->netdev);
 
       if (priv->netdev.d_len > 0)
         {

--- a/drivers/virtio/virtio-mmio-net.c
+++ b/drivers/virtio/virtio-mmio-net.c
@@ -550,7 +550,7 @@ static void virtnet_rxdispatch(FAR struct virtnet_driver_s *priv)
     {
       /* Dispatch ARP packet to the network layer */
 
-      arp_arpin(&priv->vnet_dev);
+      arp_input(&priv->vnet_dev);
       NETDEV_RXARP(&priv->vnet_dev);
 
       /* If the above function invocation resulted in data that should be

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_netdev.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_netdev.c
@@ -341,7 +341,7 @@ static void bcmf_receive(FAR struct bcmf_dev_s *priv)
 #ifdef CONFIG_NET_ARP
       if (BUF->type == HTONS(ETHTYPE_ARP))
         {
-          arp_arpin(&priv->bc_dev);
+          arp_input(&priv->bc_dev);
           NETDEV_RXARP(&priv->bc_dev);
 
           /* If the above function invocation resulted in data that should be

--- a/include/nuttx/net/arp.h
+++ b/include/nuttx/net/arp.h
@@ -131,7 +131,7 @@ void arp_ipin(FAR struct net_driver_s *dev);
 #endif
 
 /****************************************************************************
- * Name: arp_arpin
+ * Name: arp_input
  *
  * Description:
  *   This function should be called by the Ethernet device driver when an ARP
@@ -154,7 +154,7 @@ void arp_ipin(FAR struct net_driver_s *dev);
  *
  ****************************************************************************/
 
-void arp_arpin(FAR struct net_driver_s *dev);
+void arp_input(FAR struct net_driver_s *dev);
 
 /****************************************************************************
  * Name: arp_out
@@ -190,7 +190,7 @@ void arp_out(FAR struct net_driver_s *dev);
 /* If ARP is disabled, stub out all ARP interfaces */
 
 # define arp_ipin(dev)
-# define arp_arpin(dev)
+# define arp_input(dev)
 # define arp_out(dev)
 
 #endif /* CONFIG_NET_ARP */

--- a/include/nuttx/net/arp.h
+++ b/include/nuttx/net/arp.h
@@ -109,28 +109,6 @@ extern "C"
 struct net_driver_s; /* Forward reference */
 
 /****************************************************************************
- * Name: arp_ipin
- *
- * Description:
- *   The arp_ipin() function should be called by Ethernet device drivers
- *   whenever an IP packet arrives from the network.  The function will
- *   check if the address is in the ARP cache, and if so the ARP cache entry
- *   will be refreshed.
- *   If no ARP cache entry was found, a new one is created.
- *
- *   This function expects that an IP packet with an Ethernet header is
- *   present in the d_buf buffer and that the length of the packet is in the
- *   d_len field.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_NET_ARP_IPIN
-void arp_ipin(FAR struct net_driver_s *dev);
-#else
-# define arp_ipin(dev)
-#endif
-
-/****************************************************************************
  * Name: arp_input
  *
  * Description:
@@ -156,42 +134,11 @@ void arp_ipin(FAR struct net_driver_s *dev);
 
 void arp_input(FAR struct net_driver_s *dev);
 
-/****************************************************************************
- * Name: arp_out
- *
- * Description:
- *   This function should be called before sending out an IPv4 packet. The
- *   function checks the destination IPv4 address of the IPv4 packet to see
- *   what Ethernet MAC address that should be used as a destination MAC
- *   address on the Ethernet.
- *
- *   If the destination IPv4 address is in the local network (determined
- *   by logical ANDing of netmask and our IPv4 address), the function
- *   checks the ARP cache to see if an entry for the destination IPv4
- *   address is found.  If so, an Ethernet header is pre-pended at the
- *   beginning of the packet and the function returns.
- *
- *   If no ARP cache entry is found for the destination IIPv4P address, the
- *   packet in the d_buf is replaced by an ARP request packet for the
- *   IPv4 address. The IPv4 packet is dropped and it is assumed that the
- *   higher level protocols (e.g., TCP) eventually will retransmit the
- *   dropped packet.
- *
- *   Upon return in either the case, a packet to be sent is present in the
- *   d_buf buffer and the d_len field holds the length of the Ethernet
- *   frame that should be transmitted.
- *
- ****************************************************************************/
-
-void arp_out(FAR struct net_driver_s *dev);
-
 #else /* CONFIG_NET_ARP */
 
 /* If ARP is disabled, stub out all ARP interfaces */
 
-# define arp_ipin(dev)
-# define arp_input(dev)
-# define arp_out(dev)
+#  define arp_input(dev)
 
 #endif /* CONFIG_NET_ARP */
 

--- a/include/nuttx/net/netdev.h
+++ b/include/nuttx/net/netdev.h
@@ -499,7 +499,7 @@ typedef CODE int (*devif_poll_callback_t)(FAR struct net_driver_s *dev);
  *           }
  *         else if (ETHBUF->type == HTONS(ETHTYPE_ARP))
  *           {
- *             arp_arpin();
+ *             arp_input();
  *             if (dev->d_len > 0)
  *               {
  *                 devicedriver_send();

--- a/net/arp/Make.defs
+++ b/net/arp/Make.defs
@@ -21,7 +21,7 @@
 # ARP support is available for Ethernet only
 
 ifeq ($(CONFIG_NET_ARP),y)
-NET_CSRCS += arp_arpin.c arp_out.c arp_format.c arp_table.c
+NET_CSRCS += arp_input.c arp_out.c arp_format.c arp_table.c
 
 ifeq ($(CONFIG_NET_ARP_IPIN),y)
 NET_CSRCS += arp_ipin.c

--- a/net/arp/arp.h
+++ b/net/arp/arp.h
@@ -297,7 +297,7 @@ int arp_wait(FAR struct arp_notify_s *notify, unsigned int timeout);
  *
  * Assumptions:
  *   This function is called from the MAC device driver indirectly through
- *   arp_arpin() and will execute with the network locked.
+ *   arp_input() and will execute with the network locked.
  *
  ****************************************************************************/
 

--- a/net/arp/arp.h
+++ b/net/arp/arp.h
@@ -177,6 +177,57 @@ struct net_driver_s; /* Forward reference */
 void arp_format(FAR struct net_driver_s *dev, in_addr_t ipaddr);
 
 /****************************************************************************
+ * Name: arp_ipin
+ *
+ * Description:
+ *   The arp_ipin() function should be called by Ethernet device drivers
+ *   whenever an IP packet arrives from the network.  The function will
+ *   check if the address is in the ARP cache, and if so the ARP cache entry
+ *   will be refreshed.
+ *   If no ARP cache entry was found, a new one is created.
+ *
+ *   This function expects that an IP packet with an Ethernet header is
+ *   present in the d_buf buffer and that the length of the packet is in the
+ *   d_len field.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_ARP_IPIN
+void arp_ipin(FAR struct net_driver_s *dev);
+#else
+# define arp_ipin(dev)
+#endif
+
+/****************************************************************************
+ * Name: arp_out
+ *
+ * Description:
+ *   This function should be called before sending out an IPv4 packet. The
+ *   function checks the destination IPv4 address of the IPv4 packet to see
+ *   what Ethernet MAC address that should be used as a destination MAC
+ *   address on the Ethernet.
+ *
+ *   If the destination IPv4 address is in the local network (determined
+ *   by logical ANDing of netmask and our IPv4 address), the function
+ *   checks the ARP cache to see if an entry for the destination IPv4
+ *   address is found.  If so, an Ethernet header is pre-pended at the
+ *   beginning of the packet and the function returns.
+ *
+ *   If no ARP cache entry is found for the destination IIPv4P address, the
+ *   packet in the d_buf is replaced by an ARP request packet for the
+ *   IPv4 address. The IPv4 packet is dropped and it is assumed that the
+ *   higher level protocols (e.g., TCP) eventually will retransmit the
+ *   dropped packet.
+ *
+ *   Upon return in either the case, a packet to be sent is present in the
+ *   d_buf buffer and the d_len field holds the length of the Ethernet
+ *   frame that should be transmitted.
+ *
+ ****************************************************************************/
+
+void arp_out(FAR struct net_driver_s *dev);
+
+/****************************************************************************
  * Name: arp_send
  *
  * Description:
@@ -478,6 +529,8 @@ void arp_dump(FAR struct arp_hdr_s *arp);
 /* If ARP is disabled, stub out all ARP interfaces */
 
 #  define arp_format(d,i);
+#  define arp_ipin(dev)
+#  define arp_out(dev)
 #  define arp_send(i) (0)
 #  define arp_poll(d,c) (0)
 #  define arp_wait_setup(i,n)

--- a/net/arp/arp_input.c
+++ b/net/arp/arp_input.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * net/arp/arp_arpin.c
+ * net/arp/arp_input.c
  *
  *   Copyright (C) 2007-2011, 2014 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
@@ -61,7 +61,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: arp_input
+ * Name: arp_in
  *
  * Description:
  *   This function should be called by the Ethernet device driver when an
@@ -84,7 +84,7 @@
  *
  ****************************************************************************/
 
-static int arp_input(FAR struct net_driver_s *dev)
+static int arp_in(FAR struct net_driver_s *dev)
 {
   FAR struct arp_hdr_s *arp = ARPBUF;
   in_addr_t ipaddr;
@@ -163,7 +163,7 @@ static int arp_input(FAR struct net_driver_s *dev)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: arp_arpin
+ * Name: arp_input
  *
  * Description:
  *   This function should be called by the Ethernet device driver when an
@@ -186,7 +186,7 @@ static int arp_input(FAR struct net_driver_s *dev)
  *
  ****************************************************************************/
 
-void arp_arpin(FAR struct net_driver_s *dev)
+void arp_input(FAR struct net_driver_s *dev)
 {
   FAR uint8_t *buf;
 
@@ -198,13 +198,13 @@ void arp_arpin(FAR struct net_driver_s *dev)
 
       dev->d_buf = &dev->d_iob->io_data[CONFIG_NET_LL_GUARDSIZE -
                                         NET_LL_HDRLEN(dev)];
-      arp_input(dev);
+      arp_in(dev);
 
       dev->d_buf = buf;
       return;
     }
 
-  netdev_input(dev, arp_input, true);
+  netdev_input(dev, arp_in, true);
 }
 
 #endif /* CONFIG_NET_ARP */

--- a/net/arp/arp_notify.c
+++ b/net/arp/arp_notify.c
@@ -176,7 +176,7 @@ int arp_wait(FAR struct arp_notify_s *notify, unsigned int timeout)
  *
  * Assumptions:
  *   This function is called from the MAC device driver indirectly through
- *   arp_arpin() will execute with the network locked.
+ *   arp_input() will execute with the network locked.
  *
  ****************************************************************************/
 

--- a/net/devif/ipv4_input.c
+++ b/net/devif/ipv4_input.c
@@ -92,9 +92,9 @@
 #include <nuttx/net/netconfig.h>
 #include <nuttx/net/netdev.h>
 #include <nuttx/net/netstats.h>
-#include <nuttx/net/arp.h>
 #include <nuttx/net/ip.h>
 
+#include "arp/arp.h"
 #include "inet/inet.h"
 #include "tcp/tcp.h"
 #include "udp/udp.h"

--- a/net/neighbor/neighbor.h
+++ b/net/neighbor/neighbor.h
@@ -171,7 +171,7 @@ void neighbor_ethernet_out(FAR struct net_driver_s *dev);
  * Input Parameters:
  *   snapshot  - Location to return the Neighbor table copy
  *   nentries  - The size of the user provided 'dest' in entries, each of
- *               size sizeof(struct arp_entry_s)
+ *               size sizeof(struct neighbor_entry_s)
  *
  * Returned Value:
  *   On success, the number of entries actually copied is returned.  Unused

--- a/net/neighbor/neighbor_snapshot.c
+++ b/net/neighbor/neighbor_snapshot.c
@@ -47,7 +47,7 @@
  * Input Parameters:
  *   snapshot  - Location to return the Neighbor table copy
  *   nentries  - The size of the user provided 'dest' in entries, each of
- *               size sizeof(struct arp_entry_s)
+ *               size sizeof(struct neighbor_entry_s)
  *
  * Returned Value:
  *   On success, the number of entries actually copied is returned.  Unused


### PR DESCRIPTION
## Summary
align with other similar function(e.g. ipv4_input and ipv6_input)
and move arp_entry_s, arp_ipin and arp_out to private header file

## Impact
code refactor only

## Testing
Pass CI
