### PR TITLE
Minor change for video framebuff

### DIFF
--- a/drivers/video/video_framebuff.c
+++ b/drivers/video/video_framebuff.c
@@ -69,11 +69,6 @@ static inline vbuf_container_t *dequeue_vbuf_unsafe(video_framebuff_t *fbuf)
     }
   else
     {
-      if (fbuf->mode == V4L2_BUF_MODE_RING)
-        {
-          fbuf->vbuf_tail->next = fbuf->vbuf_top->next;
-        }
-
       fbuf->vbuf_top = fbuf->vbuf_top->next;
     }
 

--- a/drivers/video/video_framebuff.c
+++ b/drivers/video/video_framebuff.c
@@ -110,34 +110,31 @@ void video_framebuff_uninit(video_framebuff_t *fbuf)
 
 int video_framebuff_realloc_container(video_framebuff_t *fbuf, int sz)
 {
-  if (fbuf->vbuf_alloced == NULL || fbuf->container_size != sz)
+  if (fbuf->container_size == sz)
     {
-      if (fbuf->container_size != sz)
-        {
-          if (fbuf->vbuf_alloced != NULL)
-            {
-              kmm_free(fbuf->vbuf_alloced);
-            }
+      return OK;
+    }
 
-          fbuf->vbuf_alloced   = NULL;
-          fbuf->container_size = 0;
-        }
+  if (fbuf->vbuf_alloced != NULL)
+    {
+      kmm_free(fbuf->vbuf_alloced);
+      fbuf->vbuf_alloced   = NULL;
+      fbuf->container_size = 0;
+    }
 
-      if (sz > 0)
+  if (sz > 0)
+    {
+      fbuf->vbuf_alloced =
+        (vbuf_container_t *)kmm_malloc(sizeof(vbuf_container_t) * sz);
+      if (fbuf->vbuf_alloced == NULL)
         {
-          fbuf->vbuf_alloced
-           = (vbuf_container_t *)kmm_malloc(sizeof(vbuf_container_t)*sz);
-          if (fbuf->vbuf_alloced == NULL)
-            {
-              return -ENOMEM;
-            }
+          return -ENOMEM;
         }
 
       fbuf->container_size = sz;
     }
 
   cleanup_container(fbuf);
-
   return OK;
 }
 

--- a/drivers/video/video_framebuff.c
+++ b/drivers/video/video_framebuff.c
@@ -97,12 +97,8 @@ static inline vbuf_container_t *dequeue_vbuf_unsafe(video_framebuff_t *fbuf)
 
 void video_framebuff_init(video_framebuff_t *fbuf)
 {
-  fbuf->mode       = V4L2_BUF_MODE_RING;
-  fbuf->vbuf_empty = NULL;
-  fbuf->vbuf_top   = NULL;
-  fbuf->vbuf_tail  = NULL;
-  fbuf->vbuf_next  = NULL;
-
+  memset(fbuf, 0, sizeof(video_framebuff_t));
+  fbuf->mode = V4L2_BUF_MODE_RING;
   nxmutex_init(&fbuf->lock_empty);
 }
 

--- a/drivers/video/video_framebuff.c
+++ b/drivers/video/video_framebuff.c
@@ -72,6 +72,7 @@ static inline vbuf_container_t *dequeue_vbuf_unsafe(video_framebuff_t *fbuf)
       fbuf->vbuf_top = fbuf->vbuf_top->next;
     }
 
+  ret->next = NULL;
   return ret;
 }
 

--- a/drivers/video/video_framebuff.c
+++ b/drivers/video/video_framebuff.c
@@ -158,24 +158,24 @@ void video_framebuff_queue_container(video_framebuff_t *fbuf,
     {
       fbuf->vbuf_tail->next = tgt;
       fbuf->vbuf_tail = tgt;
-      if (fbuf->vbuf_next == NULL)
-        {
-          fbuf->vbuf_next = tgt;
-        }
     }
   else
     {
       fbuf->vbuf_top = fbuf->vbuf_tail = tgt;
+    }
+
+  if (fbuf->vbuf_next == NULL)
+    {
       fbuf->vbuf_next = tgt;
     }
 
   if (fbuf->mode == V4L2_BUF_MODE_RING)
     {
-      fbuf->vbuf_tail->next = fbuf->vbuf_top;
+      tgt->next = fbuf->vbuf_top;
     }
   else  /* Case of V4L2_BUF_MODE_FIFO */
     {
-      fbuf->vbuf_tail->next = NULL;
+      tgt->next = NULL;
     }
 
   leave_critical_section(flags);
@@ -237,15 +237,14 @@ void video_framebuff_change_mode(video_framebuff_t  *fbuf,
           if (mode == V4L2_BUF_MODE_RING)
             {
               fbuf->vbuf_tail->next = fbuf->vbuf_top;
-              fbuf->vbuf_next = fbuf->vbuf_top;
             }
           else
             {
               fbuf->vbuf_tail->next = NULL;
-              fbuf->vbuf_next = fbuf->vbuf_top;
             }
         }
 
+      fbuf->vbuf_next = fbuf->vbuf_top;
       fbuf->mode = mode;
     }
 


### PR DESCRIPTION
## Summary

- drivers/video: Zero all video_framebuff_t fields in video_framebuff_init
- drivers/video: Remove the redundant vbuf_alloced != NULL check from video_framebuff_realloc_container
- drivers/video: Clear the internal state if video_framebuff_realloc_container fail
- driver/video: Merge vbuf_next assignment in video_framebuff_queue_container
- drivers/video: Don't need update vbuf_tail in dequeue_vbuf_unsafe
- drivers/video: Zero next field of dequeued buffer before return dequeue_vbuf_unsafe

## Impact

Minor

## Testing

Pass CI