### PR TITLE
sim/netdriver: fix build break if enable NET_IPv6 only

### DIFF
--- a/arch/sim/src/sim/sim_netdriver.c
+++ b/arch/sim/src/sim/sim_netdriver.c
@@ -281,7 +281,11 @@ static int netdriver_ifup(struct net_driver_s *dev)
   int devidx = (intptr_t)dev->d_private;
 
   UNUSED(devidx);
+#ifdef CONFIG_NET_IPv4
   sim_netdev_ifup(devidx, dev->d_ipaddr);
+#else /* CONFIG_NET_IPv6 */
+  sim_netdev_ifup(devidx, INADDR_ANY);
+#endif /* CONFIG_NET_IPv4 */
   netdev_carrier_on(dev);
   return OK;
 }


### PR DESCRIPTION
## Summary

sim/netdriver: fix build break if enable NET_IPv6 only

```
In file included from sim/sim_netdriver.c:73:
sim/sim_netdriver.c: In function ‘netdriver_ifup’: sim/sim_netdriver.c:284:32: error: ‘struct net_driver_s’ has no member named ‘d_ipaddr’; did you mean ‘d_ipv6addr’?
  284 |   sim_netdev_ifup(devidx, dev->d_ipaddr);
      |                                ^~~~~~~~
sim/sim_internal.h:279:67: note: in definition of macro ‘sim_netdev_ifup’
  279 | #  define sim_netdev_ifup(idx,ifaddr)         sim_tapdev_ifup(idx,ifaddr)
      |
```

Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

ci-check