### PR TITLE
net/ip: return success if the packet was forwarded.

### DIFF
--- a/net/devif/ipv4_input.c
+++ b/net/devif/ipv4_input.c
@@ -255,8 +255,15 @@ static int ipv4_in(FAR struct net_driver_s *dev)
       /* Forward broadcast packets */
 
       ipv4_forward_broadcast(dev, ipv4);
+
+      /* Process the incoming packet if not forwardable */
+
+      if (dev->d_len > 0)
 #endif
-      ret = udp_ipv4_input(dev);
+        {
+          ret = udp_ipv4_input(dev);
+        }
+
       goto done;
     }
   else
@@ -276,8 +283,15 @@ static int ipv4_in(FAR struct net_driver_s *dev)
       /* Forward broadcast packets */
 
       ipv4_forward_broadcast(dev, ipv4);
+
+      /* Process the incoming packet if not forwardable */
+
+      if (dev->d_len > 0)
 #endif
-      ret = udp_ipv4_input(dev);
+        {
+          ret = udp_ipv4_input(dev);
+        }
+
       goto done;
     }
   else
@@ -298,6 +312,13 @@ static int ipv4_in(FAR struct net_driver_s *dev)
           /* Forward multicast packets */
 
           ipv4_forward_broadcast(dev, ipv4);
+
+          /* Return success if the packet was forwarded. */
+
+          if (dev->d_len == 0)
+            {
+              goto done;
+            }
 #endif
         }
       else

--- a/net/devif/ipv6_input.c
+++ b/net/devif/ipv6_input.c
@@ -395,6 +395,16 @@ static int ipv6_in(FAR struct net_driver_s *dev)
             }
         }
     }
+
+#ifdef CONFIG_NET_IPFORWARD
+  /* Return success if the packet was forwarded. */
+
+  if (dev->d_len == 0)
+    {
+      goto done;
+    }
+#endif
+
 #ifdef CONFIG_NET_ICMPv6
 
   /* In other cases, the device must be assigned a non-zero IP address


### PR DESCRIPTION

## Summary

net/ip: return success if the packet was forwarded.

The incoming packet should not be input to ip layer if the packet has been forwarded

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

ci check