### PR TITLE
sim/netdriver: set ipv6 addr to host route

### DIFF
--- a/arch/sim/src/sim/sim_internal.h
+++ b/arch/sim/src/sim/sim_internal.h
@@ -269,7 +269,7 @@ int sim_tapdev_avail(int devidx);
 unsigned int sim_tapdev_read(int devidx, unsigned char *buf,
                              unsigned int buflen);
 void sim_tapdev_send(int devidx, unsigned char *buf, unsigned int buflen);
-void sim_tapdev_ifup(int devidx, in_addr_t ifaddr);
+void sim_tapdev_ifup(int devidx, void *ifaddr);
 void sim_tapdev_ifdown(int devidx);
 
 #  define sim_netdev_init(idx,priv,txcb,rxcb) sim_tapdev_init(idx,priv,txcb,rxcb)

--- a/arch/sim/src/sim/sim_netdriver.c
+++ b/arch/sim/src/sim/sim_netdriver.c
@@ -282,9 +282,9 @@ static int netdriver_ifup(struct net_driver_s *dev)
 
   UNUSED(devidx);
 #ifdef CONFIG_NET_IPv4
-  sim_netdev_ifup(devidx, dev->d_ipaddr);
+  sim_netdev_ifup(devidx, &dev->d_ipaddr);
 #else /* CONFIG_NET_IPv6 */
-  sim_netdev_ifup(devidx, INADDR_ANY);
+  sim_netdev_ifup(devidx, &dev->d_ipv6addr);
 #endif /* CONFIG_NET_IPv4 */
   netdev_carrier_on(dev);
   return OK;


### PR DESCRIPTION

## Summary

sim/netdriver: set ipv6 addr to host route

Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

ci -check