### PR TITLE
Minor fix for video driver

### DIFF
--- a/drivers/video/video.c
+++ b/drivers/video/video.c
@@ -940,8 +940,6 @@ static void cleanup_streamresources(FAR video_type_inf_t *type_inf)
   video_framebuff_uninit(&type_inf->bufinf);
   nxsem_destroy(&type_inf->wait_capture.dqbuf_wait_flg);
   nxmutex_destroy(&type_inf->lock_state);
-  memset(type_inf, 0, sizeof(video_type_inf_t));
-  type_inf->remaining_capnum = VIDEO_REMAINING_CAPNUM_INFINITY;
 }
 
 static void cleanup_scene_parameter(video_scene_params_t *sp)

--- a/drivers/video/video.c
+++ b/drivers/video/video.c
@@ -824,7 +824,7 @@ static int32_t initialize_scene_gamma(uint8_t **gamma)
   if ((g_video_sensor_ops->get_supported_value == NULL) ||
       (g_video_sensor_ops->get_value == NULL))
     {
-      return -ENOTTY;
+      return 0;
     }
 
   ret = g_video_sensor_ops->get_supported_value
@@ -833,7 +833,7 @@ static int32_t initialize_scene_gamma(uint8_t **gamma)
     {
       /* Unsupported parameter */
 
-      return -EINVAL;
+      return 0;
     }
 
   switch (sup_val.type)
@@ -844,7 +844,7 @@ static int32_t initialize_scene_gamma(uint8_t **gamma)
           {
             /* Multiplication overflow */
 
-            return -EINVAL;
+            return 0;
           }
 
         break;
@@ -855,7 +855,7 @@ static int32_t initialize_scene_gamma(uint8_t **gamma)
           {
             /* Multiplication overflow */
 
-            return -EINVAL;
+            return 0;
           }
 
         break;
@@ -866,7 +866,7 @@ static int32_t initialize_scene_gamma(uint8_t **gamma)
           {
             /* Multiplication overflow */
 
-            return -EINVAL;
+            return 0;
           }
 
         break;

--- a/drivers/video/video.c
+++ b/drivers/video/video.c
@@ -3362,7 +3362,7 @@ int video_initialize(FAR const char *devpath)
 
 int video_uninitialize(void)
 {
-  if (is_initialized)
+  if (!is_initialized)
     {
       return OK;
     }

--- a/drivers/video/video.c
+++ b/drivers/video/video.c
@@ -779,7 +779,9 @@ static int32_t get_default_value(uint32_t id)
   if ((g_video_sensor_ops == NULL) ||
       (g_video_sensor_ops->get_supported_value == NULL))
     {
-      return -EINVAL;
+      /* Don't care(unsupported parameter) */
+
+      return 0;
     }
 
   ret = g_video_sensor_ops->get_supported_value(id, &value);


### PR DESCRIPTION
## Summary

- drivers/video: Return 0 in case g_video_sensor_ops or get_supported_value is NULL
- drivers/video: Return zero if gamma curve isn't supported in initialize_scene_gamma
- drivers/video: Should do uninitialization if is_initialized is true 
- drivers/video: Remove memset from cleanup_streamresources 

## Impact
Minor

## Testing
Pass CI
