### PR TITLE
mm/ubsan: fix build warning

### DIFF
--- a/mm/ubsan/ubsan.c
+++ b/mm/ubsan/ubsan.c
@@ -159,7 +159,7 @@ static int64_t get_signed_val(FAR struct type_descriptor *type,
     {
       unsigned bits = type_bit_width(type);
       uint64_t mask = (1llu << bits) - 1;
-      uint64_t ret = (uint64_t)val & mask;
+      uint64_t ret = (uintptr_t)val & mask;
 
       return (int64_t)(((ret & (1llu << (bits - 1))) != 0) ?
              ret | ~mask : ret);


### PR DESCRIPTION


## Summary

mm/ubsan: fix build warning

```
ubsan/ubsan.c: In function ‘get_signed_val’:
ubsan/ubsan.c:162:22: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
  162 |       uint64_t ret = (uint64_t)val & mask;
      |
```
Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

ci check