### PR TITLE
arch/sim: add fb poll notify support

### DIFF
--- a/arch/sim/src/sim/sim_framebuffer.c
+++ b/arch/sim/src/sim/sim_framebuffer.c
@@ -343,6 +343,7 @@ static void sim_updatework(void *arg)
 {
   work_queue(LPWORK, &g_updatework, sim_updatework, NULL, MSEC2TICK(33));
   sim_x11update();
+  fb_pollnotify(&g_fbobject);
 }
 #endif
 


### PR DESCRIPTION
## Summary
Add poll notify support for sim_framebuffer.

## Impact
Applications using the sim framebuffer device.

## Testing
Daliy test.
