### PR TITLE
boards: Remove the unused function prototype(slcd_getstream)

### DIFF
--- a/boards/arm/sam34/sam4l-xplained/src/sam_slcd.c
+++ b/boards/arm/sam34/sam4l-xplained/src/sam_slcd.c
@@ -267,7 +267,6 @@ static void slcd_setpixel(const struct slcd_pixel_s *info);
 static void slcd_clrpixel(const struct slcd_pixel_s *info);
 static inline void slcd_setdp(uint8_t curpos);
 static inline void slcd_clrdp(uint8_t curpos);
-static int slcd_getstream(struct lib_instream_s *instream);
 static uint8_t slcd_getcontrast(void);
 static int slcd_setcontrast(unsigned int contrast);
 static void slcd_writech(uint8_t ch, uint8_t curpos, uint8_t options);

--- a/boards/arm/stm32/stm32ldiscovery/src/stm32_lcd.c
+++ b/boards/arm/stm32/stm32ldiscovery/src/stm32_lcd.c
@@ -313,7 +313,6 @@ static void slcd_dumpslcd(const char *msg);
 /* Internal utilities */
 
 static void slcd_clear(void);
-static int slcd_getstream(struct lib_instream_s *instream);
 static uint8_t slcd_getcontrast(void);
 static int slcd_setcontrast(uint8_t contrast);
 static void slcd_writebar(void);


### PR DESCRIPTION
## Summary
Fix the break reported here: https://github.com/apache/nuttx/pull/7785

## Impact
Fix ci break

## Testing
Pass CI
