### PR TITLE
arch/xtensa/esp32: Modify REG_[GET/SET]_FIELD to use [get/set]reg32

### DIFF
--- a/arch/xtensa/src/esp32/hardware/esp32_soc.h
+++ b/arch/xtensa/src/esp32/hardware/esp32_soc.h
@@ -107,13 +107,13 @@
  * used when _f is not left shifted by _f##_S
  */
 
-#define REG_GET_FIELD(_r, _f) ((REG_READ(_r) >> (_f##_S)) & (_f##_V))
+#define REG_GET_FIELD(addr, field) ((getreg32(addr) >> field##_S) & field##_V)
 
 /* Set field to register,
  * used when _f is not left shifted by _f##_S
  */
 
-#define REG_SET_FIELD(_r, _f, _v) (REG_WRITE((_r),((REG_READ(_r) & ~((_f##_V) << (_f##_S)))|(((_v) & (_f##_V))<<(_f##_S)))))
+#define REG_SET_FIELD(addr, field, val) (modifyreg32(addr, (((~((uint32_t) val)) & field##_V) << field##_S), (((uint32_t) val) << field##_S)))
 
 /* Set field value from a variable,
  * used when _f is not left shifted by _f##_S


### PR DESCRIPTION
## Summary

Modify existing macros to ensure atomicity and use standard functions when using fields.

## Impact

`REG_SET_FIELD` and `REG_GET_FIELD` should be able to be used without any potential problems.

## Testing

CI build pass.
Tested using some drivers that already implement this macro like RTC.