### PR TITLE
Improve UBSan configuraion

### DIFF
--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -79,8 +79,11 @@ endif
 
 ifeq ($(CONFIG_SIM_UBSAN),y)
   ARCHOPTIMIZATION += -fsanitize=undefined
-else ifeq ($(CONFIG_MM_UBSAN_ALL),y)
-  ARCHOPTIMIZATION += $(CONFIG_MM_UBSAN_OPTION)
+else
+  ifeq ($(CONFIG_MM_UBSAN_ALL),y)
+    ARCHOPTIMIZATION += $(CONFIG_MM_UBSAN_OPTION)
+  endif
+
   ifeq ($(CONFIG_MM_UBSAN_TRAP_ON_ERROR),y)
     ARCHOPTIMIZATION += -fsanitize-undefined-trap-on-error
   endif

--- a/mm/Kconfig
+++ b/mm/Kconfig
@@ -222,7 +222,7 @@ config MM_UBSAN_OPTION
 config MM_UBSAN_TRAP_ON_ERROR
 	bool "Enable UBSan trap on error to crash immediately"
 	depends on MM_UBSAN
-	default y
+	default n
 	---help---
 		The undefined instruction trap should cause your program to crash,
 		save the code space significantly.


### PR DESCRIPTION
## Summary

- mm: Change the default of MM_UBSAN_TRAP_ON_ERROR to n let's give more information by default
- boards/sim: Decouple CONFIG_MM_UBSAN_ALL from CONFIG_MM_UBSAN_ALL 

## Impact

Minor change for UBSan

## Testing
Pass CI
