### PR TITLE
net/ipfwd: fix ipforward after IOB offload

### DIFF
--- a/include/nuttx/net/netdev.h
+++ b/include/nuttx/net/netdev.h
@@ -896,6 +896,20 @@ int netdev_iob_prepare(FAR struct net_driver_s *dev, bool throttled,
                        unsigned int timeout);
 
 /****************************************************************************
+ * Name: netdev_iob_replace
+ *
+ * Description:
+ *   Replace buffer resources for a given NIC
+ *
+ * Assumptions:
+ *   The caller has locked the network and new iob is prepared with
+ *   l2 gruard size as offset.
+ *
+ ****************************************************************************/
+
+void netdev_iob_replace(FAR struct net_driver_s *dev, FAR struct iob_s *iob);
+
+/****************************************************************************
  * Name: netdev_iob_clear
  *
  * Description:

--- a/net/devif/devif_forward.c
+++ b/net/devif/devif_forward.c
@@ -60,24 +60,14 @@
 
 void devif_forward(FAR struct forward_s *fwd)
 {
-  unsigned int offset;
-  int ret;
-
   DEBUGASSERT(fwd != NULL && fwd->f_iob != NULL && fwd->f_dev != NULL);
-  offset = NET_LL_HDRLEN(fwd->f_dev);
 
-  /* Copy the IOB chain that contains the L3L3 headers and any data payload */
+  /* Move the IOB chain that contains the L3 header and any data payload */
 
-  DEBUGASSERT(offset + fwd->f_iob->io_pktlen <= NETDEV_PKTSIZE(fwd->f_dev));
-  ret = iob_copyout(&fwd->f_dev->d_buf[offset], fwd->f_iob,
-                    fwd->f_iob->io_pktlen, 0);
-
-  DEBUGASSERT(ret == fwd->f_iob->io_pktlen);
+  netdev_iob_replace(fwd->f_dev, fwd->f_iob);
 
   fwd->f_dev->d_sndlen = 0;
-  fwd->f_dev->d_len    = fwd->f_iob->io_pktlen;
-
-  UNUSED(ret);
+  fwd->f_iob = NULL;
 }
 
 #endif /* CONFIG_NET_IPFORWARD */

--- a/net/ipforward/ipv4_forward.c
+++ b/net/ipforward/ipv4_forward.c
@@ -274,7 +274,7 @@ static int ipv4_dev_forward(FAR struct net_driver_s *dev,
    * TLL decrements to zero, then do not forward the packet.
    */
 
-  ret = ipv4_decr_ttl((FAR struct ipv4_hdr_s *)fwd->f_iob->io_data);
+  ret = ipv4_decr_ttl(ipv4);
   if (ret < 1)
     {
       nwarn("WARNING: Hop limit exceeded... Dropping!\n");
@@ -285,9 +285,7 @@ static int ipv4_dev_forward(FAR struct net_driver_s *dev,
 #ifdef CONFIG_NET_NAT
   /* Try NAT outbound, rule matching will be performed in NAT module. */
 
-  ret = ipv4_nat_outbound(fwd->f_dev,
-                          (FAR struct ipv4_hdr_s *)fwd->f_iob->io_data,
-                          NAT_MANIP_SRC);
+  ret = ipv4_nat_outbound(fwd->f_dev, ipv4, NAT_MANIP_SRC);
   if (ret < 0)
     {
       nwarn("WARNING: Performing NAT outbound failed, dropping!\n");

--- a/net/netdev/netdev_iob.c
+++ b/net/netdev/netdev_iob.c
@@ -85,6 +85,32 @@ int netdev_iob_prepare(FAR struct net_driver_s *dev, bool throttled,
 }
 
 /****************************************************************************
+ * Name: netdev_iob_replace
+ *
+ * Description:
+ *   Replace buffer resources for a given NIC
+ *
+ * Assumptions:
+ *   The caller has locked the network and new iob is prepared with
+ *   l2 gruard size as offset.
+ *
+ ****************************************************************************/
+
+void netdev_iob_replace(FAR struct net_driver_s *dev, FAR struct iob_s *iob)
+{
+  /* Release previous buffer */
+
+  netdev_iob_release(dev);
+
+  /* Set new buffer */
+
+  dev->d_iob = iob;
+  dev->d_buf = &dev->d_iob->io_data[CONFIG_NET_LL_GUARDSIZE -
+                                    NET_LL_HDRLEN(dev)];
+  dev->d_len = iob->io_pktlen;
+}
+
+/****************************************************************************
  * Name: netdev_iob_clear
  *
  * Description:


### PR DESCRIPTION
## Summary
Patches included:
- net/ipfwd: fix `devif_forward` after IOB offload. 
- net/ipfwd: fix `ipv4_dev_forward` after IOB offload. 

## Impact
Fix ipforward after applying IOB offload.

## Testing
Manually tested on simulator under Ubuntu 22.04.
