### PR TITLE
arch_alarm: don't init local variable for fpu test case fail

### DIFF
--- a/drivers/timers/arch_alarm.c
+++ b/drivers/timers/arch_alarm.c
@@ -319,7 +319,7 @@ int weak_function up_alarm_tick_start(clock_t ticks)
 
   if (g_oneshot_lower != NULL)
     {
-      clock_t now = 0;
+      clock_t now;
       clock_t delta;
 
       ONESHOT_TICK_CURRENT(g_oneshot_lower, &now);


### PR DESCRIPTION
## Summary

D16 register will be cleared in up_alarm_tick_start function when compiling with gcc.
This will cause fpu test fail on some boards.

## Impact

NA

## Testing

BES2003
