### PR TITLE
usbdev/adb: fixed usbclass steup issue

### DIFF
--- a/drivers/usbdev/adb.c
+++ b/drivers/usbdev/adb.c
@@ -528,7 +528,7 @@ static void usb_adb_wrcomplete(FAR struct usbdev_ep_s *ep,
     {
     case OK: /* Normal completion */
       {
-        usbtrace(TRACE_CLASSWRCOMPLETE, priv->nwrq);
+        usbtrace(TRACE_CLASSWRCOMPLETE, sq_count(&priv->txfree));
 
         /* Notify all waiting writers that write req is available */
 
@@ -549,7 +549,7 @@ static void usb_adb_wrcomplete(FAR struct usbdev_ep_s *ep,
 
     case -ESHUTDOWN: /* Disconnection */
       {
-        usbtrace(TRACE_CLSERROR(USBSER_TRACEERR_WRSHUTDOWN), priv->nwrq);
+        usbtrace(TRACE_CLSERROR(USBSER_TRACEERR_WRSHUTDOWN), sq_count(&priv->txfree));
       }
       break;
 
@@ -600,7 +600,7 @@ static void usb_adb_rdcomplete(FAR struct usbdev_ep_s *ep,
     {
     case 0: /* Normal completion */
 
-      usbtrace(TRACE_CLASSRDCOMPLETE, priv->nrdq);
+      usbtrace(TRACE_CLASSRDCOMPLETE, sq_count(&priv->rxpending));
 
       /* Restart request due to either no reader or
        * empty frame received.
@@ -816,7 +816,7 @@ static void usbclass_ep0incomplete(FAR struct usbdev_ep_s *ep,
 #ifdef CONFIG_USBDEV_DUALSPEED
 static int16_t usbclass_mkcfgdesc(FAR uint8_t *buf,
                                   FAR struct usbdev_devinfo_s *devinfo,
-                                  uint8_t speed, uint8_t type);
+                                  uint8_t speed, uint8_t type)
 #else
 static int16_t usbclass_mkcfgdesc(FAR uint8_t *buf,
                                   FAR struct usbdev_devinfo_s *devinfo)
@@ -1198,7 +1198,12 @@ static int usbclass_setup(FAR struct usbdevclass_driver_s *driver,
 
                   case USB_DESC_TYPE_CONFIG:
                     {
+#ifndef CONFIG_USBDEV_DUALSPEED
                       ret = usbclass_mkcfgdesc(ctrlreq->buf, NULL);
+#else
+                      ret = usbclass_mkcfgdesc(ctrlreq->buf, NULL,
+                                             dev->speed, ctrl->req);
+#endif
                     }
                     break;
 


### PR DESCRIPTION
## Summary

1. Resolve ADB compile errors
2. Set usbdev when usb class bind
3. Don't call EP_SUBMIT when receive OUT message

## Impact

NA

## Testing

sim:usbdev
