### PR TITLE
net/devif: initialize d_len to 0 before polling connections

### DIFF
--- a/net/can/can_callback.c
+++ b/net/can/can_callback.c
@@ -215,6 +215,10 @@ uint16_t can_datahandler(FAR struct net_driver_s *dev,
       ret = iob->io_pktlen;
     }
 
+  /* Device buffer must be enqueue or freed, clear the handle */
+
+  netdev_iob_clear(dev);
+
   return ret;
 }
 

--- a/net/devif/devif_cansend.c
+++ b/net/devif/devif_cansend.c
@@ -55,8 +55,7 @@
 void devif_can_send(FAR struct net_driver_s *dev, FAR const void *buf,
                     unsigned int len)
 {
-  unsigned int limit = NETDEV_PKTSIZE(dev) -
-                       CONFIG_NET_LL_GUARDSIZE;
+  unsigned int limit = NETDEV_PKTSIZE(dev) - NET_LL_HDRLEN(dev);
 
   if (dev == NULL || len == 0 || len > limit)
     {

--- a/net/devif/devif_pktsend.c
+++ b/net/devif/devif_pktsend.c
@@ -55,8 +55,7 @@
 void devif_pkt_send(FAR struct net_driver_s *dev, FAR const void *buf,
                     unsigned int len)
 {
-  unsigned int limit = NETDEV_PKTSIZE(dev) -
-                       CONFIG_NET_LL_GUARDSIZE;
+  unsigned int limit = NETDEV_PKTSIZE(dev) - NET_LL_HDRLEN(dev);
 
   if (dev == NULL || len == 0 || len > limit)
     {

--- a/net/devif/devif_poll.c
+++ b/net/devif/devif_poll.c
@@ -647,6 +647,10 @@ static int devif_poll_connections(FAR struct net_driver_s *dev,
 {
   int bstop = false;
 
+  /* Reset device buffer length */
+
+  dev->d_len = 0;
+
   /* Traverse all of the active packet connections and perform the poll
    * action.
    */

--- a/net/devif/devif_send.c
+++ b/net/devif/devif_send.c
@@ -69,7 +69,7 @@ void devif_send(FAR struct net_driver_s *dev, FAR const void *buf,
                 int len, unsigned int offset)
 {
   unsigned int limit = NETDEV_PKTSIZE(dev) -
-                       CONFIG_NET_LL_GUARDSIZE - offset;
+                       NET_LL_HDRLEN(dev) - offset;
 
   if (dev == NULL || len == 0 || len > limit)
     {


### PR DESCRIPTION
## Summary

net/devif: initialize d_len to 0 before polling connections

new driver module will check the d_len further, it will re-trigger
the txpoll to forward the data if d_len is greater than 0

Bug report here:
https://github.com/apache/nuttx/issues/7802
https://github.com/apache/nuttx/issues/7812

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

ci-check