### PR TITLE
Systemview add kconfig SEGGER_SYSVIEW_PREFIX for co-existance with other note drivers

### DIFF
--- a/drivers/segger/Kconfig
+++ b/drivers/segger/Kconfig
@@ -114,6 +114,12 @@ config SEGGER_SYSVIEW_RAM_BASE
 	---help---
 		The lowest RAM address used for IDs
 
+config SEGGER_SYSVIEW_PREFIX
+	bool "Segger note function prefix"
+	default ""
+	---help---
+		prefix sched_note functions with "sysview_" to call them indirectly
+
 endif
 
 endmenu # Segger RTT drivers

--- a/drivers/segger/note_sysview.c
+++ b/drivers/segger/note_sysview.c
@@ -28,6 +28,7 @@
 #include <nuttx/clock.h>
 #include <nuttx/sched.h>
 #include <nuttx/sched_note.h>
+#include <nuttx/note/note_sysview.h>
 
 #include <SEGGER_RTT.h>
 #include <SEGGER_SYSVIEW.h>
@@ -275,7 +276,7 @@ static inline int sysview_isenabled_syscall(int nr)
  *
  ****************************************************************************/
 
-void sched_note_start(FAR struct tcb_s *tcb)
+void PREFIX(sched_note_start)(FAR struct tcb_s *tcb)
 {
   if (!sysview_isenabled())
     {
@@ -286,7 +287,7 @@ void sched_note_start(FAR struct tcb_s *tcb)
   sysview_send_taskinfo(tcb);
 }
 
-void sched_note_stop(FAR struct tcb_s *tcb)
+void PREFIX(sched_note_stop)(FAR struct tcb_s *tcb)
 {
   if (!sysview_isenabled())
     {
@@ -297,7 +298,7 @@ void sched_note_stop(FAR struct tcb_s *tcb)
 }
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_SWITCH
-void sched_note_suspend(FAR struct tcb_s *tcb)
+void PREFIX(sched_note_suspend)(FAR struct tcb_s *tcb)
 {
   if (!sysview_isenabled())
     {
@@ -310,7 +311,7 @@ void sched_note_suspend(FAR struct tcb_s *tcb)
     }
 }
 
-void sched_note_resume(FAR struct tcb_s *tcb)
+void PREFIX(sched_note_resume)(FAR struct tcb_s *tcb)
 {
   if (!sysview_isenabled())
     {
@@ -332,7 +333,7 @@ void sched_note_resume(FAR struct tcb_s *tcb)
 #endif
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_IRQHANDLER
-void sched_note_irqhandler(int irq, FAR void *handler, bool enter)
+void PREFIX(sched_note_irqhandler)(int irq, FAR void *handler, bool enter)
 {
   if (!sysview_isenabled_irq(irq, enter))
     {
@@ -370,7 +371,7 @@ void sched_note_irqhandler(int irq, FAR void *handler, bool enter)
 #endif
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_SYSCALL
-void sched_note_syscall_enter(int nr, int argc, ...)
+void PREFIX(sched_note_syscall_enter)(int nr, int argc, ...)
 {
   nr -= CONFIG_SYS_RESERVED;
 
@@ -405,7 +406,7 @@ void sched_note_syscall_enter(int nr, int argc, ...)
   SEGGER_SYSVIEW_MarkStart(nr);
 }
 
-void sched_note_syscall_leave(int nr, uintptr_t result)
+void PREFIX(sched_note_syscall_leave)(int nr, uintptr_t result)
 {
   nr -= CONFIG_SYS_RESERVED;
 
@@ -513,8 +514,8 @@ int sysview_initialize(void)
  *
  ****************************************************************************/
 
-void sched_note_filter_mode(struct note_filter_mode_s *oldm,
-                            struct note_filter_mode_s *newm)
+void PREFIX(sched_note_filter_mode)(struct note_filter_mode_s *oldm,
+                                    struct note_filter_mode_s *newm)
 {
   irqstate_t flags;
 
@@ -578,8 +579,8 @@ void sched_note_filter_mode(struct note_filter_mode_s *oldm,
  ****************************************************************************/
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_IRQHANDLER
-void sched_note_filter_irq(struct note_filter_irq_s *oldf,
-                           struct note_filter_irq_s *newf)
+void PREFIX(sched_note_filter_irq)(struct note_filter_irq_s *oldf,
+                                   struct note_filter_irq_s *newf)
 {
   irqstate_t flags;
 
@@ -624,8 +625,8 @@ void sched_note_filter_irq(struct note_filter_irq_s *oldf,
  ****************************************************************************/
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_SYSCALL
-void sched_note_filter_syscall(struct note_filter_syscall_s *oldf,
-                               struct note_filter_syscall_s *newf)
+void PREFIX(sched_note_filter_syscall)(struct note_filter_syscall_s *oldf,
+                                       struct note_filter_syscall_s *newf)
 {
   irqstate_t flags;
 

--- a/include/nuttx/note/note_sysview.h
+++ b/include/nuttx/note/note_sysview.h
@@ -26,6 +26,17 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/sched.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifdef CONFIG_SEGGER_SYSVIEW_PREFIX
+#  define PREFIX(fun) sysview ## _ ## fun
+#else
+#  define PREFIX(fun) fun
+#endif
 
 /****************************************************************************
  * Public Function Prototypes
@@ -47,6 +58,43 @@
 
 #ifdef CONFIG_SEGGER_SYSVIEW
 int sysview_initialize(void);
-#endif
+
+#  ifdef CONFIG_SEGGER_SYSVIEW_PREFIX
+
+void PREFIX(sched_note_start)(struct tcb_s *tcb);
+
+void PREFIX(sched_note_stop)(struct tcb_s *tcb);
+
+void PREFIX(sched_note_suspend)(struct tcb_s *tcb);
+
+void PREFIX(sched_note_resume)(struct tcb_s *tcb);
+
+#    ifdef CONFIG_SCHED_INSTRUMENTATION_IRQHANDLER
+void PREFIX(sched_note_irqhandler)(int irq, void *handler, bool enter);
+#    endif
+
+#    ifdef CONFIG_SCHED_INSTRUMENTATION_SYSCALL
+void PREFIX(sched_note_syscall_enter)(int nr);
+void PREFIX(sched_note_syscall_leave)(int nr, uintptr_t result);
+#    endif
+
+#    ifdef CONFIG_SCHED_INSTRUMENTATION_FILTER
+void PREFIX(sched_note_filter_mode)(struct note_filter_mode_s *oldm,
+                            struct note_filter_mode_s *newm);
+#    endif
+
+#    ifdef CONFIG_SCHED_INSTRUMENTATION_IRQHANDLER
+void PREFIX(sched_note_filter_irq)(struct note_filter_irq_s *oldf,
+                           struct note_filter_irq_s *newf);
+#    endif
+
+#    ifdef CONFIG_SCHED_INSTRUMENTATION_SYSCALL
+void PREFIX(sched_note_filter_syscall)(struct note_filter_syscall_s *oldf,
+                               struct note_filter_syscall_s *newf);
+#    endif
+
+#  endif /* CONFIG_SEGGER_SYSVIEW_PREFIX */
+
+#endif /* CONFIG_SEGGER_SYSVIEW */
 
 #endif /* __INCLUDE_NUTTX_NOTE_NOTE_SYSVIEW_H */


### PR DESCRIPTION
## Summary
When enabling SEGGER Systemview it can conflict with other note drivers trying to hook into `sched_note_xxx`.
This patch adds SEGGER_SYSVIEW_PREFIX kconfig symbol that decouples them from the function so that other note drives can nicely co-exist with SEGGER Systemview.

## Impact
Minimal, should have no impact on normal circumstances. 

## Testing
Tested on PX4 with their own note driver implementation which can co-exist with SEGGER systemview.

