### PR TITLE
risc-v/backtrace: fix compile warning

### DIFF
--- a/arch/risc-v/src/common/riscv_backtrace.c
+++ b/arch/risc-v/src/common/riscv_backtrace.c
@@ -142,8 +142,9 @@ int up_backtrace(struct tcb_s *tcb, void **buffer, int size, int skip)
       if (up_interrupt_context())
         {
 #if CONFIG_ARCH_INTERRUPTSTACK > 15
-          ret = backtrace(g_intstackalloc,
-                          g_intstackalloc + CONFIG_ARCH_INTERRUPTSTACK,
+          ret = backtrace((uintptr_t *)g_intstackalloc,
+                          (uintptr_t *)(g_intstackalloc +
+                                       CONFIG_ARCH_INTERRUPTSTACK),
                           (void *)getfp(), NULL, buffer, size, &skip);
 #else
           ret = backtrace(rtcb->stack_base_ptr,


### PR DESCRIPTION

## Summary

risc-v/backtrace: fix compile warning


```
common/riscv_backtrace.c: In function 'up_backtrace': common/riscv_backtrace.c:145:27: error: passing argument 1 of 'backtrace' from incompatible pointer type [-Werror=incompatible-pointer-types]
  145 |           ret = backtrace(g_intstackalloc,
      |                           ^~~~~~~~~~~~~~~
      |                           |
      |                           uint8_t * {aka unsigned char *}
common/riscv_backtrace.c:64:33: note: expected 'uintptr_t *' {aka 'unsigned int *'} but argument is of type 'uint8_t *' {aka 'unsigned char *'}
   64 | static int backtrace(uintptr_t *base, uintptr_t *limit,
      |                      ~~~~~~~~~~~^~~~
common/riscv_backtrace.c:146:43: error: passing argument 2 of 'backtrace' from incompatible pointer type [-Werror=incompatible-pointer-types]
  146 |                           g_intstackalloc + CONFIG_ARCH_INTERRUPTSTACK,
      |                                           ^
      |                                           |
      |                                           uint8_t * {aka unsigned char *}
common/riscv_backtrace.c:64:50: note: expected 'uintptr_t *' {aka 'unsigned int *'} but argument is of type 'uint8_t *' {aka 'unsigned char *'}
   64 | static int backtrace(uintptr_t *base, uintptr_t *limit,
      |                                       ~~~~~~~~~~~^~~~~
```

Regression by:
```
| commit 70290b6e384e979e44fe3f9777b62e6c1aad787a
| Author: Xiang Xiao <xiaoxiang@xiaomi.com>
| Date:   Tue Sep 20 02:38:54 2022 +0800
|
|     arch: Change the linker generated symbols from uint32_t to uint8_t *
|
|     and remove the duplicated declaration
|
|     Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>
```

Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

enable CONFIG_SCHED_BACKTRACE/CONFIG_FRAME_POINTER