### PR TITLE
Remove `intr` and `EINTR` from pthread mutex

### DIFF
--- a/sched/pthread/pthread.h
+++ b/sched/pthread/pthread.h
@@ -96,12 +96,12 @@ int pthread_sem_give(sem_t *sem);
 
 #ifndef CONFIG_PTHREAD_MUTEX_UNSAFE
 int pthread_mutex_take(FAR struct pthread_mutex_s *mutex,
-                       FAR const struct timespec *abs_timeout, bool intr);
+                       FAR const struct timespec *abs_timeout);
 int pthread_mutex_trytake(FAR struct pthread_mutex_s *mutex);
 int pthread_mutex_give(FAR struct pthread_mutex_s *mutex);
 void pthread_mutex_inconsistent(FAR struct tcb_s *tcb);
 #else
-#  define pthread_mutex_take(m,abs_timeout,i)  pthread_sem_take(&(m)->sem,(abs_timeout))
+#  define pthread_mutex_take(m,abs_timeout)  pthread_sem_take(&(m)->sem,(abs_timeout))
 #  define pthread_mutex_trytake(m)             pthread_sem_trytake(&(m)->sem)
 #  define pthread_mutex_give(m)                pthread_sem_give(&(m)->sem)
 #endif

--- a/sched/pthread/pthread.h
+++ b/sched/pthread/pthread.h
@@ -88,8 +88,7 @@ FAR struct join_s *pthread_findjoininfo(FAR struct task_group_s *group,
                                         pid_t pid);
 void pthread_release(FAR struct task_group_s *group);
 
-int pthread_sem_take(FAR sem_t *sem, FAR const struct timespec *abs_timeout,
-                     bool intr);
+int pthread_sem_take(FAR sem_t *sem, FAR const struct timespec *abs_timeout);
 #ifdef CONFIG_PTHREAD_MUTEX_UNSAFE
 int pthread_sem_trytake(sem_t *sem);
 #endif
@@ -102,7 +101,7 @@ int pthread_mutex_trytake(FAR struct pthread_mutex_s *mutex);
 int pthread_mutex_give(FAR struct pthread_mutex_s *mutex);
 void pthread_mutex_inconsistent(FAR struct tcb_s *tcb);
 #else
-#  define pthread_mutex_take(m,abs_timeout,i)  pthread_sem_take(&(m)->sem,(abs_timeout),(i))
+#  define pthread_mutex_take(m,abs_timeout,i)  pthread_sem_take(&(m)->sem,(abs_timeout))
 #  define pthread_mutex_trytake(m)             pthread_sem_trytake(&(m)->sem)
 #  define pthread_mutex_give(m)                pthread_sem_give(&(m)->sem)
 #endif

--- a/sched/pthread/pthread_condclockwait.c
+++ b/sched/pthread/pthread_condclockwait.c
@@ -159,7 +159,7 @@ int pthread_cond_clockwait(FAR pthread_cond_t *cond,
 
       sinfo("Re-locking...\n");
 
-      status = pthread_mutex_take(mutex, NULL, false);
+      status = pthread_mutex_take(mutex, NULL);
       if (status == OK)
         {
           mutex->pid    = mypid;

--- a/sched/pthread/pthread_condwait.c
+++ b/sched/pthread/pthread_condwait.c
@@ -126,7 +126,7 @@ int pthread_cond_wait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex)
 
       sinfo("Reacquire mutex...\n");
 
-      status = pthread_mutex_take(mutex, NULL, false);
+      status = pthread_mutex_take(mutex, NULL);
       if (ret == OK)
         {
           /* Report the first failure that occurs */

--- a/sched/pthread/pthread_condwait.c
+++ b/sched/pthread/pthread_condwait.c
@@ -107,7 +107,7 @@ int pthread_cond_wait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex)
        * or if the thread is canceled (ECANCELED)
        */
 
-      status = pthread_sem_take(&cond->sem, NULL, false);
+      status = pthread_sem_take(&cond->sem, NULL);
       if (ret == OK)
         {
           /* Report the first failure that occurs */

--- a/sched/pthread/pthread_initialize.c
+++ b/sched/pthread/pthread_initialize.c
@@ -52,40 +52,23 @@
  *
  * Input Parameters:
  *  sem  - The semaphore to lock or unlock
- *  intr - false: ignore EINTR errors when locking; true treat EINTR as
- *         other errors by returning the errno value
  *
  * Returned Value:
  *   0 on success or an errno value on failure.
  *
  ****************************************************************************/
 
-int pthread_sem_take(FAR sem_t *sem, FAR const struct timespec *abs_timeout,
-                     bool intr)
+int pthread_sem_take(FAR sem_t *sem, FAR const struct timespec *abs_timeout)
 {
   int ret;
 
-  if (intr)
+  if (abs_timeout == NULL)
     {
-      if (abs_timeout == NULL)
-        {
-          ret = nxsem_wait(sem);
-        }
-      else
-        {
-          ret = nxsem_timedwait(sem, abs_timeout);
-        }
+      ret = nxsem_wait_uninterruptible(sem);
     }
   else
     {
-      if (abs_timeout == NULL)
-        {
-          ret = nxsem_wait_uninterruptible(sem);
-        }
-      else
-        {
-          ret = nxsem_timedwait_uninterruptible(sem, abs_timeout);
-        }
+      ret = nxsem_timedwait_uninterruptible(sem, abs_timeout);
     }
 
   return -ret;

--- a/sched/pthread/pthread_mutex.c
+++ b/sched/pthread/pthread_mutex.c
@@ -132,8 +132,6 @@ static void pthread_mutex_remove(FAR struct pthread_mutex_s *mutex)
  *
  * Input Parameters:
  *  mutex - The mutex to be locked
- *  intr  - false: ignore EINTR errors when locking; true treat EINTR as
- *          other errors by returning the errno value
  *
  * Returned Value:
  *   0 on success or an errno value on failure.
@@ -141,7 +139,7 @@ static void pthread_mutex_remove(FAR struct pthread_mutex_s *mutex)
  ****************************************************************************/
 
 int pthread_mutex_take(FAR struct pthread_mutex_s *mutex,
-                       FAR const struct timespec *abs_timeout, bool intr)
+                       FAR const struct timespec *abs_timeout)
 {
   int ret = EINVAL;
 

--- a/sched/pthread/pthread_mutex.c
+++ b/sched/pthread/pthread_mutex.c
@@ -166,7 +166,7 @@ int pthread_mutex_take(FAR struct pthread_mutex_s *mutex,
            * returns zero on success and a positive errno value on failure.
            */
 
-          ret = pthread_sem_take(&mutex->sem, abs_timeout, intr);
+          ret = pthread_sem_take(&mutex->sem, abs_timeout);
           if (ret == OK)
             {
               /* Check if the holder of the mutex has terminated without

--- a/sched/pthread/pthread_mutextimedlock.c
+++ b/sched/pthread/pthread_mutextimedlock.c
@@ -187,7 +187,7 @@ int pthread_mutex_timedlock(FAR pthread_mutex_t *mutex,
            * or default mutex.
            */
 
-          ret = pthread_mutex_take(mutex, abs_timeout, false);
+          ret = pthread_mutex_take(mutex, abs_timeout);
 
           /* If we successfully obtained the semaphore, then indicate
            * that we own it.


### PR DESCRIPTION
## Summary

Updates `pthread_sem_take` and `pthread_mutex_take` to not take `intr` parameter.

The `intr` parameter was used for allowing the call to these functions to return `EINTR` (in case of we receiving a signal).

In POSIX, this should not happen, and we should continue to be locked (while trying to acquire the lock) even when we get `EINTR`.

So after this fix, there is now some dead code than can be removed.

## Impact

The apis of the internal functions `pthread_sem_take` and `pthread_mutex_take` have been changed to not have the `intr` parameter. They can also never return `EINTR`.

## Testing

