### PR TITLE
arm: add syscall SYS_save_context support for old arm and armv7-r

### DIFF
--- a/arch/arm/src/arm/arm_syscall.c
+++ b/arch/arm/src/arm/arm_syscall.c
@@ -73,6 +73,26 @@ uint32_t *arm_syscall(uint32_t *regs)
 
   switch (cmd)
     {
+      /* R0=SYS_save_context:  This is a save context command:
+       *
+       *   int up_saveusercontext(void *saveregs);
+       *
+       * At this point, the following values are saved in context:
+       *
+       *   R0 = SYS_save_context
+       *   R1 = saveregs
+       *
+       * In this case, we simply need to copy the current registers to the
+       * save register space references in the saved R1 and return.
+       */
+
+      case SYS_save_context:
+        {
+          DEBUGASSERT(regs[REG_R1] != 0);
+          memcpy((uint32_t *)regs[REG_R1], regs, XCPTCONTEXT_SIZE);
+        }
+        break;
+
       /* R0=SYS_restore_context:  Restore task context
        *
        * void arm_fullcontextrestore(uint32_t *restoreregs)

--- a/arch/arm/src/armv7-r/arm_syscall.c
+++ b/arch/arm/src/armv7-r/arm_syscall.c
@@ -246,6 +246,25 @@ uint32_t *arm_syscall(uint32_t *regs)
         }
         break;
 #endif
+      /* R0=SYS_save_context:  This is a save context command:
+       *
+       *   int up_saveusercontext(void *saveregs);
+       *
+       * At this point, the following values are saved in context:
+       *
+       *   R0 = SYS_save_context
+       *   R1 = saveregs
+       *
+       * In this case, we simply need to copy the current registers to the
+       * save register space references in the saved R1 and return.
+       */
+
+      case SYS_save_context:
+        {
+          DEBUGASSERT(regs[REG_R1] != 0);
+          memcpy((uint32_t *)regs[REG_R1], regs, XCPTCONTEXT_SIZE);
+        }
+        break;
 
       /* R0=SYS_restore_context:  Restore task context
        *


### PR DESCRIPTION
## Summary
Continue of https://github.com/apache/nuttx/pull/7767
Dump the correct register information when assert failed in application.

## Impact
up_saveusrcontext

## Testing
Pass CI
