### PR TITLE
openamp: don't depend on pen-amp.zip and libmetal.zip in the git mode

### DIFF
--- a/openamp/libmetal.defs
+++ b/openamp/libmetal.defs
@@ -67,15 +67,17 @@ LIBMETAL_HDRS_SEDEXP := \
 	 s/@PROJECT_MACHINE_UPPER@/$(CONFIG_ARCH_CHIP)/g; \
 	 s/cmakedefine/undef/g"
 
+ifeq ($(wildcard libmetal/.git),)
 libmetal.zip:
 # Download and unpack tarball if no git repo found
-ifeq ($(wildcard libmetal/.git),)
 	$(Q) curl -L https://github.com/OpenAMP/libmetal/archive/v$(VERSION).zip -o libmetal.zip
 	$(Q) unzip -o libmetal.zip
 	$(Q) mv libmetal-$(VERSION) libmetal
-endif
 
 .libmetal_headers: libmetal.zip
+else
+.libmetal_headers:
+endif
 	$(eval headers := $(wildcard libmetal/lib/compiler/gcc/*.h))
 	$(eval headers += $(wildcard libmetal/lib/processor/$(LIBMETAL_ARCH)/*.h))
 	$(eval headers += $(wildcard libmetal/lib/system/nuttx/*.h))

--- a/openamp/open-amp.defs
+++ b/openamp/open-amp.defs
@@ -29,9 +29,9 @@ CSRCS += open-amp/lib/rpmsg/rpmsg_virtio.c
 CSRCS += open-amp/lib/virtio/virtio.c
 CSRCS += open-amp/lib/virtio/virtqueue.c
 
-open-amp.zip:
 # Download and unpack tarball if no git repo found
 ifeq ($(wildcard open-amp/.git),)
+open-amp.zip:
 	$(Q) curl -L https://github.com/OpenAMP/open-amp/archive/v$(VERSION).zip -o open-amp.zip
 	$(Q) unzip -o open-amp.zip
 	$(Q) mv open-amp-$(VERSION) open-amp
@@ -45,9 +45,11 @@ ifeq ($(wildcard open-amp/.git),)
 	$(Q) patch -p0 < 0008-remoteproc-make-all-elf_-functions-static-except-elf.patch
 	$(Q) patch -p0 < 0009-Fix-warn-declaration-of-vring_rsc-shadows-a-previous.patch
 	$(Q) patch -p0 < 0010-rptun-fix-rptun-don-t-wait-issue-when-get-tx-patyloa.patch
-endif
 
 .openamp_headers: open-amp.zip
+else
+.openamp_headers:
+endif
 	$(eval headers := $(wildcard open-amp/lib/include/openamp/*.h))
 	$(shell mkdir -p $(TOPDIR)$(DELIM)include$(DELIM)openamp$(DELIM))
 	$(foreach header,$(headers),$(shell cp -rf $(header) $(TOPDIR)$(DELIM)include$(DELIM)openamp$(DELIM)))


### PR DESCRIPTION
## Summary
since both don't exist in this mode

## Impact
MInor, same as before

## Testing
Pass CI
