### PR TITLE
libc/netdb: add proto.c

### DIFF
--- a/include/netdb.h
+++ b/include/netdb.h
@@ -221,7 +221,9 @@ struct protoent
   FAR char **p_aliases;    /* A pointer to an array of pointers to
                             * alternative protocol names, terminated by a
                             * null pointer. */
-  int        p_proto;      /* The protocol number. */
+  uint8_t    p_proto;      /* The protocol number. */
+  uint8_t    idx;          /* Index used by the local database, required
+                            * by _r version APIs */
 };
 
 struct servent
@@ -310,18 +312,20 @@ FAR struct servent  *getservbyport(int port, FAR const char *proto);
 FAR struct servent  *getservbyname(FAR const char *name,
                                    FAR const char *proto);
 
+void                 setprotoent(int stayopen);
+void                 endprotoent(void);
+FAR struct protoent *getprotobyname(FAR const char *name);
+FAR struct protoent *getprotobynumber(int proto);
+FAR struct protoent *getprotoent(void);
+
 #if 0 /* None of these are yet supported */
 FAR struct hostent  *gethostent(void);
 FAR struct netent   *getnetbyaddr(uint32_t net, int type);
 FAR struct netent   *getnetbyname(FAR const char *name);
 FAR struct netent   *getnetent(void);
-FAR struct protoent *getprotobyname(FAR const char *name);
-FAR struct protoent *getprotobynumber(int proto);
-FAR struct protoent *getprotoent(void);
 FAR struct servent  *getservent(void);
 void                 sethostent(int);
 void                 setnetent(int stayopen);
-void                 setprotoent(int stayopen);
 void                 setservent(int);
 #endif /* None of these are yet supported */
 
@@ -345,6 +349,17 @@ int getservbyport_r(int port, FAR const char *proto,
 int getservbyname_r(FAR const char *name, FAR const char *proto,
                     FAR struct servent *result_buf, FAR char *buf,
                     size_t buflen, FAR struct servent **result);
+
+void setprotoent_r(int stayopen, FAR struct protoent *result_buf);
+void endprotoent_r(FAR struct protoent *result_buf);
+int getprotoent_r(FAR struct protoent *result_buf, FAR char *buf,
+                  size_t buflen, FAR struct protoent **result);
+int getprotobyname_r(FAR const char *name,
+                     FAR struct protoent *result_buf, FAR char *buf,
+                     size_t buflen, FAR struct protoent **result);
+int getprotobynumber_r(int proto,
+                       FAR struct protoent *result_buf, FAR char *buf,
+                       size_t buflen, FAR struct protoent **result);
 
 #endif /* CONFIG_LIBC_NETDB */
 

--- a/libs/libc/netdb/Make.defs
+++ b/libs/libc/netdb/Make.defs
@@ -30,6 +30,7 @@ CSRCS += lib_getservbyname.c lib_getservbynamer.c
 CSRCS += lib_getservbyport.c lib_getservbyportr.c
 CSRCS += lib_gaistrerror.c lib_freeaddrinfo.c lib_getaddrinfo.c
 CSRCS += lib_getnameinfo.c lib_rexec.c lib_dn.c
+CSRCS += lib_proto.c lib_protor.c
 
 # Add host file support
 

--- a/libs/libc/netdb/lib_proto.c
+++ b/libs/libc/netdb/lib_proto.c
@@ -1,0 +1,69 @@
+/****************************************************************************
+ * libs/libc/netdb/lib_proto.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <netdb.h>
+#include <string.h>
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static struct protoent result_buf;
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void endprotoent(void)
+{
+  endprotoent_r(&result_buf);
+}
+
+void setprotoent(int stayopen)
+{
+  setprotoent_r(stayopen, &result_buf);
+}
+
+FAR struct protoent *getprotoent(void)
+{
+  FAR struct protoent *result;
+  int ret = getprotoent_r(&result_buf, NULL, 0, &result);
+  return ret == OK ? &result_buf : NULL;
+}
+
+FAR struct protoent *getprotobyname(FAR const char *name)
+{
+  FAR struct protoent *result;
+  int ret = getprotobyname_r(name, &result_buf, NULL, 0, &result);
+  return ret == OK ? &result_buf : NULL;
+}
+
+FAR struct protoent *getprotobynumber(int proto)
+{
+  FAR struct protoent *result;
+  int ret = getprotobynumber_r(proto, &result_buf, NULL, 0, &result);
+  return ret == OK ? &result_buf : NULL;
+}

--- a/libs/libc/netdb/lib_protor.c
+++ b/libs/libc/netdb/lib_protor.c
@@ -1,0 +1,145 @@
+/****************************************************************************
+ * libs/libc/netdb/lib_protor.c
+ *
+ * Copyright © 2005-2020 Rich Felker, et al.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <errno.h>
+#include <netdb.h>
+#include <string.h>
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static const unsigned char g_protos[] =
+{
+  "\000ip\0"
+  "\001icmp\0"
+  "\002igmp\0"
+  "\003ggp\0"
+  "\004ipencap\0"
+  "\005st\0"
+  "\006tcp\0"
+  "\010egp\0"
+  "\014pup\0"
+  "\021udp\0"
+  "\024hmp\0"
+  "\026xns-idp\0"
+  "\033rdp\0"
+  "\035iso-tp4\0"
+  "\044xtp\0"
+  "\045ddp\0"
+  "\046idpr-cmtp\0"
+  "\051ipv6\0"
+  "\053ipv6-route\0"
+  "\054ipv6-frag\0"
+  "\055idrp\0"
+  "\056rsvp\0"
+  "\057gre\0"
+  "\062esp\0"
+  "\063ah\0"
+  "\071skip\0"
+  "\072ipv6-icmp\0"
+  "\073ipv6-nonxt\0"
+  "\074ipv6-opts\0"
+  "\111rspf\0"
+  "\121vmtp\0"
+  "\131ospf\0"
+  "\136ipip\0"
+  "\142encap\0"
+  "\147pim\0"
+  "\377raw"
+};
+
+static const char *g_aliases;
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void setprotoent_r(int stayopen, FAR struct protoent *result_buf)
+{
+  result_buf->idx = 0;
+}
+
+void endprotoent_r(FAR struct protoent *result_buf)
+{
+  result_buf->idx = 0;
+}
+
+int getprotoent_r(FAR struct protoent *result_buf, FAR char *buf,
+                  size_t buflen, FAR struct protoent **result)
+{
+  int idx = result_buf->idx;
+  if (idx >= sizeof(g_protos))
+    {
+      *result = NULL;
+      return ENOENT;
+    }
+
+  result_buf->p_proto = g_protos[idx];
+  result_buf->p_name = (char *)&g_protos[idx + 1];
+  result_buf->p_aliases = (char **)&g_aliases;
+  idx += strlen(result_buf->p_name) + 2;
+  result_buf->idx = idx;
+  *result = result_buf;
+
+  return OK;
+}
+
+int getprotobyname_r(FAR const char *name,
+                     FAR struct protoent *result_buf, FAR char *buf,
+                     size_t buflen, FAR struct protoent **result)
+{
+  int ret;
+  endprotoent_r(result_buf);
+  do
+    {
+      ret = getprotoent_r(result_buf, buf, buflen, result);
+    }
+  while (ret == OK && strcmp(name, result_buf->p_name));
+
+  return ret;
+}
+
+int getprotobynumber_r(int proto,
+                       FAR struct protoent *result_buf, FAR char *buf,
+                       size_t buflen, FAR struct protoent **result)
+{
+  int ret;
+  endprotoent_r(result_buf);
+  do
+    {
+      ret = getprotoent_r(result_buf, buf, buflen, result);
+    }
+  while (ret == OK && result_buf->p_proto != proto);
+
+  return ret;
+}


### PR DESCRIPTION

## Summary
Add getproto related APIs.

Please note code is originated from [musl-libc](https://git.musl-libc.org/cgit/musl/tree/src/network/proto.c)

## Impact
No.

## Testing
Self tested.
