### PR TITLE
riscv/mmu-mappings: Mark kernel page tables as NOLOAD to save ROM space in kernel

### DIFF
--- a/boards/risc-v/mpfs/icicle/scripts/kernel-space.ld
+++ b/boards/risc-v/mpfs/icicle/scripts/kernel-space.ld
@@ -90,7 +90,7 @@ SECTIONS
     } > ksram
 
     /* Page tables here, align to 4K boundary */
-    .pgtables : ALIGN(0x1000) {
+    .pgtables (NOLOAD) : ALIGN(0x1000) {
         *(.pgtables)
          . = ALIGN(32);
         _ebss = ABSOLUTE(.);

--- a/boards/risc-v/mpfs/icicle/scripts/ld-kernel.script
+++ b/boards/risc-v/mpfs/icicle/scripts/ld-kernel.script
@@ -97,7 +97,7 @@ SECTIONS
 
     /* Page tables here, align to 4K boundary */
 
-    .pgtables : ALIGN(0x1000) {
+    .pgtables (NOLOAD) : ALIGN(0x1000) {
         *(.pgtables)
         . = ALIGN(4);
     } > ksram

--- a/boards/risc-v/qemu-rv/rv-virt/scripts/ld-kernel.script
+++ b/boards/risc-v/qemu-rv/rv-virt/scripts/ld-kernel.script
@@ -114,7 +114,7 @@ SECTIONS
 
     /* Page tables here, align to 4K boundary */
 
-    .pgtables : ALIGN(0x1000) {
+    .pgtables (NOLOAD) : ALIGN(0x1000) {
         *(.pgtables)
         . = ALIGN(4);
     } > ksram


### PR DESCRIPTION
## Summary
Save some kernel ROM memory 
## Impact
RISC-V targets with MMU only
## Testing
icicle:knsh
