### PR TITLE
arch/arm: only compare callee-saved registers for fpu

### DIFF
--- a/arch/arm/src/armv7-a/arm_fpucmp.c
+++ b/arch/arm/src/armv7-a/arm_fpucmp.c
@@ -36,6 +36,8 @@
 
 #ifdef CONFIG_ARCH_FPU
 
+#  define FPU_CALLEE_REGS   (16)
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -60,6 +62,10 @@ bool up_fpucmp(const void *saveregs1, const void *saveregs2)
   const uint32_t *regs1 = saveregs1;
   const uint32_t *regs2 = saveregs2;
 
-  return memcmp(&regs1[REG_S0], &regs2[REG_S0], 4 * FPU_CONTEXT_REGS) == 0;
+  /* Only compare callee-saved registers, caller-saved registers do not
+   * need to be preserved.
+   */
+
+  return memcmp(&regs1[REG_S16], &regs2[REG_S16], 4 * FPU_CALLEE_REGS) == 0;
 }
 #endif /* CONFIG_ARCH_FPU */

--- a/arch/arm/src/armv7-m/arm_fpucmp.c
+++ b/arch/arm/src/armv7-m/arm_fpucmp.c
@@ -60,10 +60,12 @@ bool up_fpucmp(const void *saveregs1, const void *saveregs2)
   const uint32_t *regs1 = saveregs1;
   const uint32_t *regs2 = saveregs2;
 
+  /* Only compare callee-saved registers, caller-saved registers do not
+   * need to be preserved.
+   */
+
   /* compare of hardware fp registers should skip REG_FP_RESERVED */
 
-  return memcmp(&regs1[REG_S0], &regs2[REG_S0],
-                4 * (HW_FPU_REGS - 1)) == 0 &&
-         memcmp(&regs1[REG_S16], &regs2[REG_S16], 4 * SW_FPU_REGS) == 0;
+  return memcmp(&regs1[REG_S16], &regs2[REG_S16], 4 * SW_FPU_REGS) == 0;
 }
 #endif /* CONFIG_ARCH_FPU */

--- a/arch/arm/src/armv7-r/arm_fpucmp.c
+++ b/arch/arm/src/armv7-r/arm_fpucmp.c
@@ -36,6 +36,8 @@
 
 #ifdef CONFIG_ARCH_FPU
 
+#  define FPU_CALLEE_REGS   (16)
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -60,6 +62,10 @@ bool up_fpucmp(const void *saveregs1, const void *saveregs2)
   const uint32_t *regs1 = saveregs1;
   const uint32_t *regs2 = saveregs2;
 
-  return memcmp(&regs1[REG_S0], &regs2[REG_S0], 4 * FPU_CONTEXT_REGS) == 0;
+  /* Only compare callee-saved registers, caller-saved registers do not
+   * need to be preserved.
+   */
+
+  return memcmp(&regs1[REG_S16], &regs2[REG_S16], 4 * FPU_CALLEE_REGS) == 0;
 }
 #endif /* CONFIG_ARCH_FPU */

--- a/arch/arm/src/armv8-m/arm_fpucmp.c
+++ b/arch/arm/src/armv8-m/arm_fpucmp.c
@@ -60,10 +60,12 @@ bool up_fpucmp(const void *saveregs1, const void *saveregs2)
   const uint32_t *regs1 = saveregs1;
   const uint32_t *regs2 = saveregs2;
 
+  /* Only compare callee-saved registers, caller-saved registers do not
+   * need to be preserved.
+   */
+
   /* compare of hardware fp registers should skip REG_FP_RESERVED */
 
-  return memcmp(&regs1[REG_S0], &regs2[REG_S0],
-                4 * (HW_FPU_REGS - 1)) == 0 &&
-         memcmp(&regs1[REG_S16], &regs2[REG_S16], 4 * SW_FPU_REGS) == 0;
+  return memcmp(&regs1[REG_S16], &regs2[REG_S16], 4 * SW_FPU_REGS) == 0;
 }
 #endif /* CONFIG_ARCH_FPU */

--- a/arch/arm64/src/common/arm64_fpu.c
+++ b/arch/arm64/src/common/arm64_fpu.c
@@ -42,6 +42,12 @@
 #include "arm64_fpu.h"
 
 /***************************************************************************
+ * Pre-processor Definitions
+ ***************************************************************************/
+
+#define FPU_CALLEE_REGS     (8)
+
+/***************************************************************************
  * Private Data
  ***************************************************************************/
 
@@ -245,5 +251,10 @@ bool up_fpucmp(const void *saveregs1, const void *saveregs2)
   const uint64_t *regs1  = saveregs1 + XCPTCONTEXT_GP_SIZE;
   const uint64_t *regs2  = saveregs2 + XCPTCONTEXT_GP_SIZE;
 
-  return memcmp(regs1, regs2, 8 * XCPTCONTEXT_FPU_REGS) == 0;
+  /* Only compare callee-saved registers, caller-saved registers do not
+   * need to be preserved.
+   */
+
+  return memcmp(&regs1[FPU_REG_Q4], &regs2[FPU_REG_Q4],
+                8 * FPU_CALLEE_REGS) == 0;
 }


### PR DESCRIPTION
## Summary

For fpu test, only compare callee-saved registers for fpu.
Registers S0-S15 (D0-D7, Q0-Q3) do not need to be preserved. They can be used for passing arguments or returning results in standard procedure-call variants. 
Registers D16-D31 (Q8-Q15), do not need to be preserved.

Fix issue discussed here: https://github.com/apache/nuttx/pull/7804
## Impact

fpu_test

## Testing

BES2003