### PR TITLE
net/ipfwd: limit number of ipforward struct to be less than number of IOB

### DIFF
--- a/net/devif/devif_poll.c
+++ b/net/devif/devif_poll.c
@@ -925,6 +925,7 @@ int devif_poll(FAR struct net_driver_s *dev, devif_poll_callback_t callback)
 
       if (netdev_iob_prepare(dev, false, 0) != OK)
         {
+          nwarn("WARNING: IOB Prepare failed for dev %s!\n", dev->d_ifname);
           bstop = true;
           break;
         }

--- a/net/ipforward/Kconfig
+++ b/net/ipforward/Kconfig
@@ -36,3 +36,7 @@ config NET_IPFORWARD_NSTRUCT
 		packets that may be waiting to be forwarded from one network device
 		to another.  CONFIG_IOB_NBUFFERS also limits the forward because the
 		payload of the packet (up to the MSS) is retain in IOBs.
+
+		WARNING: DO NOT set this setting to a value greater than or equal to
+		CONFIG_IOB_NBUFFERS, otherwise it may consume all the IOB and let
+		netdev fail to work.

--- a/net/ipforward/ipforward.h
+++ b/net/ipforward/ipforward.h
@@ -27,6 +27,7 @@
 
 #include <nuttx/config.h>
 
+#include <assert.h>
 #include <stdint.h>
 
 #undef HAVE_FWDALLOC
@@ -41,6 +42,9 @@
 #ifndef CONFIG_NET_IPFORWARD_NSTRUCT
 #  define CONFIG_NET_IPFORWARD_NSTRUCT 4
 #endif
+
+static_assert(CONFIG_IOB_NBUFFERS > CONFIG_NET_IPFORWARD_NSTRUCT,
+              "IP forward may consume all the IOB and break netdev logic");
 
 /* Allocate a new IP forwarding data callback */
 


### PR DESCRIPTION
## Summary
Issue:
If ipforward consumes all the IOB, devif_poll will not poll any more.
Without polling, ipforward will not release any IOB, then all the network stack may fail with no IOB available.

So add check to limit number of ipforward struct to be less than number of IOB.
## Impact
Add check to limit number of ipforward struct to be less than number of IOB.

## Testing

