### PR TITLE
esp32: Fix maximum I2C FIFO size (now SSD1306 will work)

### DIFF
--- a/arch/xtensa/src/esp32/esp32_i2c.c
+++ b/arch/xtensa/src/esp32/esp32_i2c.c
@@ -84,7 +84,7 @@
 
 /* Default option */
 
-#define I2C_FIFO_SIZE (255)
+#define I2C_FIFO_SIZE (32)
 
 #define I2C_FILTER_CYC_NUM_DEF (7)
 


### PR DESCRIPTION
## Summary
Fix maximum I2C FIFO size (now SSD1306 will work)
## Impact
I2C drivers that sends multiple data (i.e. SSD1306) will work now
## Testing
ESP32-Devkit
