### PR TITLE
ci: Fix save and restore in GitHub cache action for MacOS build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,7 +198,7 @@ jobs:
         env:
           cache-name: ${{ runner.os }}-cache-tools
         with:
-          path: prebuilt
+          path: ./sources/prebuilt
           key: ${{ runner.os }}-tools-${{ hashFiles('./sources/nuttx/tools/ci/cibuild.sh') }}
 
       - name: Export NuttX Repo SHA


### PR DESCRIPTION
## Summary
This PR intends to fix the cache saving and restoration of the prebuilt binaries in MacOS CI build.

## Impact
Fixes #7636.

## Testing
CI build pass and successfully completing the **Post Restore Tools Cache** build stage:
![image](https://user-images.githubusercontent.com/38959758/206584040-ee320c11-1a52-4497-84c1-099c949942bd.png)

