### PR TITLE
sched: move sched_note.c to drivers/note

### DIFF
--- a/drivers/note/Make.defs
+++ b/drivers/note/Make.defs
@@ -18,6 +18,13 @@
 #
 ############################################################################
 
+ifeq ($(CONFIG_SCHED_INSTRUMENTATION),y)
+ifeq ($(CONFIG_SCHED_INSTRUMENTATION_EXTERNAL),)
+CSRCS += sched_note.c
+CFLAGS += ${INCDIR_PREFIX}${TOPDIR}/sched
+endif
+endif
+
 ifeq ($(CONFIG_DRIVER_NOTE),y)
   CSRCS += note_driver.c
 endif

--- a/drivers/note/sched_note.c
+++ b/drivers/note/sched_note.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * sched/sched/sched_note.c
+ * drivers/note/sched_note.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/sched/sched/Make.defs
+++ b/sched/sched/Make.defs
@@ -89,12 +89,6 @@ ifeq ($(CONFIG_SMP),y)
 CSRCS += sched_thistask.c
 endif
 
-ifeq ($(CONFIG_SCHED_INSTRUMENTATION),y)
-ifeq ($(CONFIG_SCHED_INSTRUMENTATION_EXTERNAL),)
-CSRCS += sched_note.c
-endif
-endif
-
 ifeq ($(CONFIG_SCHED_CRITMONITOR),y)
 CSRCS += sched_critmonitor.c
 endif


### PR DESCRIPTION
## Summary
Adjust the file directory to keep all sched_note related codes together

## Impact

## Testing

