### PR TITLE
sched/nx_bringup: Set the initial stack size in kernel build as well

### DIFF
--- a/sched/init/nx_bringup.c
+++ b/sched/init/nx_bringup.c
@@ -292,9 +292,8 @@ static inline void nx_start_application(void)
   posix_spawnattr_init(&attr);
 
   attr.priority  = CONFIG_INIT_PRIORITY;
-#  ifndef CONFIG_BUILD_KERNEL
   attr.stacksize = CONFIG_INIT_STACKSIZE;
-#  endif
+
   ret = exec_spawn(CONFIG_INIT_FILEPATH, argv, NULL,
                    CONFIG_INIT_SYMTAB, CONFIG_INIT_NEXPORTS, &attr);
   DEBUGASSERT(ret >= 0);


### PR DESCRIPTION
## Summary
Use CONFIG_INIT_STACKSIZE for kernel build as well.

After #7364 this now works, so use it for the init process. It makes sense as the init process typically requires a big stack (due to init scripts).

## Impact
CONFIG_BUILD_KERNEL=y only
## Testing
icicle:knsh
