### PR TITLE
Refine the driver note structure

### DIFF
--- a/drivers/drivers_initialize.c
+++ b/drivers/drivers_initialize.c
@@ -85,7 +85,7 @@ void drivers_initialize(void)
 #endif
 
 #if defined(CONFIG_DRIVER_NOTE)
-  note_register();      /* Non-standard /dev/note */
+  note_initialize();    /* Non-standard /dev/note */
 #endif
 
 #if defined(CONFIG_CLK_RPMSG)

--- a/drivers/note/Make.defs
+++ b/drivers/note/Make.defs
@@ -26,7 +26,7 @@ endif
 endif
 
 ifeq ($(CONFIG_DRIVER_NOTE),y)
-  CSRCS += note_driver.c
+  CSRCS += note_initialize.c
 endif
 
 ifeq ($(CONFIG_DRIVER_NOTERAM),y)

--- a/drivers/note/Make.defs
+++ b/drivers/note/Make.defs
@@ -18,14 +18,11 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_SCHED_INSTRUMENTATION),y)
-ifeq ($(CONFIG_SCHED_INSTRUMENTATION_EXTERNAL),)
-CSRCS += sched_note.c
-CFLAGS += ${INCDIR_PREFIX}${TOPDIR}/sched
-endif
-endif
-
 ifeq ($(CONFIG_DRIVER_NOTE),y)
+  ifeq ($(CONFIG_SCHED_INSTRUMENTATION_EXTERNAL),)
+    CSRCS += note_driver.c
+    CFLAGS += ${INCDIR_PREFIX}${TOPDIR}/sched
+  endif
   CSRCS += note_initialize.c
 endif
 

--- a/drivers/note/note_driver.c
+++ b/drivers/note/note_driver.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * drivers/note/sched_note.c
+ * drivers/note/note_driver.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/drivers/note/note_initialize.c
+++ b/drivers/note/note_initialize.c
@@ -23,9 +23,9 @@
  ****************************************************************************/
 
 #include <nuttx/note/note_driver.h>
-#include <nuttx/note/note_sysview.h>
 #include <nuttx/note/noteram_driver.h>
 #include <nuttx/note/notectl_driver.h>
+#include <nuttx/segger/sysview.h>
 
 /****************************************************************************
  * Public Functions

--- a/drivers/note/note_initialize.c
+++ b/drivers/note/note_initialize.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * drivers/note/note_driver.c
+ * drivers/note/note_initialize.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -32,7 +32,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: note_register
+ * Name: note_initialize
  *
  * Description:
  *   Register sched note related drivers at /dev folder that can be used by
@@ -46,7 +46,7 @@
  *
  ****************************************************************************/
 
-int note_register(void)
+int note_initialize(void)
 {
   int ret = 0;
 

--- a/drivers/segger/Make.defs
+++ b/drivers/segger/Make.defs
@@ -66,7 +66,7 @@ ifeq ($(CONFIG_SYSLOG_RTT),y)
 endif
 
 ifeq ($(CONFIG_SEGGER_SYSVIEW),y)
-  CSRCS += segger/note_sysview.c
+  CSRCS += segger/sysview.c
   CSRCS += segger/SystemView/SYSVIEW/SEGGER_SYSVIEW.c
 
   CFLAGS += ${INCDIR_PREFIX}$(TOPDIR)$(DELIM)sched

--- a/drivers/segger/sysview.c
+++ b/drivers/segger/sysview.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * drivers/segger/note_sysview.c
+ * drivers/segger/sysview.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -28,7 +28,7 @@
 #include <nuttx/clock.h>
 #include <nuttx/sched.h>
 #include <nuttx/sched_note.h>
-#include <nuttx/note/note_sysview.h>
+#include <nuttx/segger/sysview.h>
 
 #include <SEGGER_RTT.h>
 #include <SEGGER_SYSVIEW.h>

--- a/include/nuttx/note/note_driver.h
+++ b/include/nuttx/note/note_driver.h
@@ -42,7 +42,7 @@
 #if defined(__KERNEL__) || defined(CONFIG_BUILD_FLAT)
 
 /****************************************************************************
- * Name: note_register
+ * Name: note_initialize
  *
  * Description:
  *   Register sched note related drivers at /dev folder that can be used by
@@ -57,7 +57,7 @@
  ****************************************************************************/
 
 #ifdef CONFIG_DRIVER_NOTE
-int note_register(void);
+int note_initialize(void);
 #endif
 
 #endif /* defined(__KERNEL__) || defined(CONFIG_BUILD_FLAT) */

--- a/include/nuttx/sched_note.h
+++ b/include/nuttx/sched_note.h
@@ -407,7 +407,7 @@ struct note_filter_mode_s
 {
   unsigned int flag;          /* Filter mode flag */
 #ifdef CONFIG_SMP
-  unsigned int cpuset;        /* The set of monitored CPUs */
+  cpu_set_t cpuset;           /* The set of monitored CPUs */
 #endif
 };
 
@@ -609,8 +609,8 @@ void sched_note_add(FAR const void *note, size_t notelen);
  ****************************************************************************/
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_FILTER
-void sched_note_filter_mode(struct note_filter_mode_s *oldm,
-                            struct note_filter_mode_s *newm);
+void sched_note_filter_mode(FAR struct note_filter_mode_s *oldm,
+                            FAR struct note_filter_mode_s *newm);
 #endif
 
 /****************************************************************************
@@ -635,8 +635,8 @@ void sched_note_filter_mode(struct note_filter_mode_s *oldm,
 
 #if defined(CONFIG_SCHED_INSTRUMENTATION_FILTER) && \
     defined(CONFIG_SCHED_INSTRUMENTATION_SYSCALL)
-void sched_note_filter_syscall(struct note_filter_syscall_s *oldf,
-                               struct note_filter_syscall_s *newf);
+void sched_note_filter_syscall(FAR struct note_filter_syscall_s *oldf,
+                               FAR struct note_filter_syscall_s *newf);
 #endif
 
 /****************************************************************************
@@ -661,8 +661,8 @@ void sched_note_filter_syscall(struct note_filter_syscall_s *oldf,
 
 #if defined(CONFIG_SCHED_INSTRUMENTATION_FILTER) && \
     defined(CONFIG_SCHED_INSTRUMENTATION_IRQHANDLER)
-void sched_note_filter_irq(struct note_filter_irq_s *oldf,
-                           struct note_filter_irq_s *newf);
+void sched_note_filter_irq(FAR struct note_filter_irq_s *oldf,
+                           FAR struct note_filter_irq_s *newf);
 #endif
 
 #endif /* defined(__KERNEL__) || defined(CONFIG_BUILD_FLAT) */

--- a/include/nuttx/segger/sysview.h
+++ b/include/nuttx/segger/sysview.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * include/nuttx/note/note_sysview.h
+ * include/nuttx/segger/sysview.h
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,8 +18,8 @@
  *
  ****************************************************************************/
 
-#ifndef __INCLUDE_NUTTX_NOTE_NOTE_SYSVIEW_H
-#define __INCLUDE_NUTTX_NOTE_NOTE_SYSVIEW_H
+#ifndef __INCLUDE_NUTTX_SEGGER_SYSVIEW_H
+#define __INCLUDE_NUTTX_SEGGER_SYSVIEW_H
 
 /****************************************************************************
  * Included Files
@@ -97,4 +97,4 @@ void PREFIX(sched_note_filter_syscall)(struct note_filter_syscall_s *oldf,
 
 #endif /* CONFIG_SEGGER_SYSVIEW */
 
-#endif /* __INCLUDE_NUTTX_NOTE_NOTE_SYSVIEW_H */
+#endif /* __INCLUDE_NUTTX_SEGGER_SYSVIEW_H */


### PR DESCRIPTION
## Summary
Follow up https://github.com/apache/nuttx/pull/7837:

- drivers/node: Rename note_register to note_initialize 
- drivers/node: Rename sched_note.c to to note_driver.c
- drivers/segger: Rename nuttx/note/note_sysview.h to nuttx/segger/sysview.h

## Impact
Code refactor only

## Testing
Pass CI
