### PR TITLE
include/stdio.h: add missing FOPEN_MAX

### DIFF
--- a/include/stdio.h
+++ b/include/stdio.h
@@ -41,6 +41,7 @@
 /* File System Definitions **************************************************/
 
 #define FILENAME_MAX _POSIX_NAME_MAX
+#define FOPEN_MAX    _POSIX_STREAM_MAX
 
 /* The (default) size of the I/O buffers */
 


### PR DESCRIPTION
## Summary

FOPEN_MAX macro is in both ISO C89 (and later) and POSIX standards.

OpenGroup about stdio.h: 
"{FOPEN_MAX}
    Number of streams which the implementation guarantees can be open simultaneously. The value is at least eight."

OpenGroup about limits.h: 
"{STREAM_MAX}
    Maximum number of streams that one process can have open at one time. If defined, it has the same value as {FOPEN_MAX} (see <stdio.h>).
    Minimum Acceptable Value: {_POSIX_STREAM_MAX}"

## Impact
Standards conformance

## Testing

