### PR TITLE
tools/ci/cibuild.sh: Fix destination path 'pinguino-compilers' already exists and is not an empty directory.

### DIFF
--- a/tools/ci/cibuild.sh
+++ b/tools/ci/cibuild.sh
@@ -253,7 +253,7 @@ function kconfig-frontends {
 }
 
 function mips-gcc-toolchain {
-  if [ ! -f "${tools}/pinguino-compilers" ]; then
+  if [ ! -d "${tools}/pinguino-compilers" ]; then
     cd "${tools}"
     git clone https://github.com/PinguinoIDE/pinguino-compilers
   fi


### PR DESCRIPTION
## Summary

## Impact

## Testing

