### PR TITLE
drivers/note: rename /dev/note to /dev/note/ram

### DIFF
--- a/drivers/note/noteram_driver.c
+++ b/drivers/note/noteram_driver.c
@@ -881,7 +881,7 @@ void sched_note_add(FAR const void *note, size_t notelen)
  * Name: noteram_register
  *
  * Description:
- *   Register a serial driver at /dev/note that can be used by an
+ *   Register a serial driver at /dev/note/ram that can be used by an
  *   application to read data from the circular note buffer.
  *
  * Input Parameters:
@@ -894,5 +894,5 @@ void sched_note_add(FAR const void *note, size_t notelen)
 
 int noteram_register(void)
 {
-  return register_driver("/dev/note", &g_noteram_fops, 0666, NULL);
+  return register_driver("/dev/note/ram", &g_noteram_fops, 0666, NULL);
 }

--- a/include/nuttx/note/noteram_driver.h
+++ b/include/nuttx/note/noteram_driver.h
@@ -93,7 +93,7 @@ struct noteram_get_taskname_s
  * Name: noteram_register
  *
  * Description:
- *   Register RAM note driver at /dev/note that can be used by an
+ *   Register RAM note driver at /dev/note/ram that can be used by an
  *   application to read note data from the circular note buffer.
  *
  * Input Parameters:


### PR DESCRIPTION
## Summary
rename note devices to support multiple note devices

Refer to this PR:  https://github.com/apache/nuttx/pull/7841
sink noteram one level to support different note drivers in the future

depends on : https://github.com/apache/nuttx-apps/pull/1455

## Impact

## Testing
sim:note
