### PR TITLE
Continue fix the macOS ci issue

### DIFF
--- a/tools/ci/cibuild.sh
+++ b/tools/ci/cibuild.sh
@@ -204,6 +204,8 @@ function elf-toolchain {
         ;;
     esac
   fi
+
+  x86_64-elf-gcc --version
 }
 
 function gen-romfs {

--- a/tools/ci/cibuild.sh
+++ b/tools/ci/cibuild.sh
@@ -512,7 +512,7 @@ function install_tools {
 
 case ${os} in
   Darwin)
-    install="arm-gcc-toolchain arm64-gcc-toolchain avr-gcc-toolchain binutils bloaty c-cache elf-toolchain gen-romfs gperf kconfig-frontends mips-gcc-toolchain python-tools riscv-gcc-toolchain rust xtensa-esp32-gcc-toolchain u-boot-tools"
+    install="arm-gcc-toolchain arm64-gcc-toolchain avr-gcc-toolchain binutils bloaty elf-toolchain gen-romfs gperf kconfig-frontends mips-gcc-toolchain python-tools riscv-gcc-toolchain rust xtensa-esp32-gcc-toolchain u-boot-tools c-cache"
     mkdir -p "${tools}"/homebrew
     export HOMEBREW_CACHE=${tools}/homebrew
     # https://github.com/actions/virtual-environments/issues/2322#issuecomment-749211076
@@ -521,7 +521,7 @@ case ${os} in
     brew update --quiet
     ;;
   Linux)
-    install="arm-clang-toolchain arm-gcc-toolchain arm64-gcc-toolchain avr-gcc-toolchain binutils bloaty c-cache clang-tidy gen-romfs gperf kconfig-frontends mips-gcc-toolchain python-tools riscv-gcc-toolchain rust rx-gcc-toolchain sparc-gcc-toolchain xtensa-esp32-gcc-toolchain u-boot-tools"
+    install="arm-clang-toolchain arm-gcc-toolchain arm64-gcc-toolchain avr-gcc-toolchain binutils bloaty clang-tidy gen-romfs gperf kconfig-frontends mips-gcc-toolchain python-tools riscv-gcc-toolchain rust rx-gcc-toolchain sparc-gcc-toolchain xtensa-esp32-gcc-toolchain u-boot-tools c-cache"
     ;;
 esac
 

--- a/tools/ci/cibuild.sh
+++ b/tools/ci/cibuild.sh
@@ -148,16 +148,15 @@ function bloaty {
   add_path "${tools}"/bloaty/bin
 
   if [ ! -f "${tools}/bloaty/bin/bloaty" ]; then
-    git clone --branch main https://github.com/google/bloaty bloaty-src
-    cd bloaty-src
+    git clone --branch main https://github.com/google/bloaty "${tools}"/bloaty-src
+    cd "${tools}"/bloaty-src
     # Due to issues with latest MacOS versions use pinned commit.
     # https://github.com/google/bloaty/pull/326
     git checkout 52948c107c8f81045e7f9223ec02706b19cfa882
     mkdir -p "${tools}"/bloaty
     cmake -D BLOATY_PREFER_SYSTEM_CAPSTONE=NO -DCMAKE_SYSTEM_PREFIX_PATH="${tools}"/bloaty
     make install -j 6
-    cd "${tools}"
-    rm -rf bloaty-src
+    git clean -xfd
   fi
 
   command bloaty --version


### PR DESCRIPTION
## Summary

- Revert "Fix ccache: error: Could not find compiler "x86_64-elf-gcc" in PATH"
- cibuild.sh: Fix "Untracked files: tools/ci/bloaty-src/" 
- cibuild.sh: Install ccache in the last step 

## Impact

## Testing
Pass CI
