### PR TITLE
tools: zipme: remove incubator from releases

### DIFF
--- a/tools/zipme.sh
+++ b/tools/zipme.sh
@@ -220,8 +220,8 @@ fi
 
 # Create the versioned tarball names
 
-NUTTX_TARNAME=apache-nuttx-${VERSION}-incubating.tar
-APPS_TARNAME=apache-nuttx-apps-${VERSION}-incubating.tar
+NUTTX_TARNAME=apache-nuttx-${VERSION}.tar
+APPS_TARNAME=apache-nuttx-apps-${VERSION}.tar
 NUTTX_ZIPNAME=${NUTTX_TARNAME}.gz
 APPS_ZIPNAME=${APPS_TARNAME}.gz
 NUTTX_ASCNAME=${NUTTX_ZIPNAME}.asc


### PR DESCRIPTION
## Summary
NuttX has graduated the incubator phase and the releases should be renamed to match the current status

## Impact
NuttX 12.0.0 release

## Testing
generated the release
