### PR TITLE
imxrt:Serial LPUART_STAT_PF s/b LPUART_STAT_NF

### DIFF
--- a/arch/arm/src/imxrt/imxrt_serial.c
+++ b/arch/arm/src/imxrt/imxrt_serial.c
@@ -1780,7 +1780,7 @@ static int imxrt_interrupt(int irq, void *context, void *arg)
           imxrt_serialout(priv, IMXRT_LPUART_STAT_OFFSET, LPUART_STAT_OR);
         }
 
-      if ((usr & LPUART_STAT_PF) != 0)
+      if ((usr & LPUART_STAT_NF) != 0)
         {
           imxrt_serialout(priv, IMXRT_LPUART_STAT_OFFSET, LPUART_STAT_NF);
         }


### PR DESCRIPTION
 ## Summary

  As a result of a typo LPUART_STAT_NF was not checked and  cleared on LPUART_STAT_PF.

## Impact

HW LPUART_STAT_NF  not p[parsed and serviced

## Testing

PX4 nxp_imxrt

