### PR TITLE
mm/iob: add support of partial bytes clone 

### DIFF
--- a/Documentation/reference/os/iob.rst
+++ b/Documentation/reference/os/iob.rst
@@ -170,6 +170,7 @@ Public Function Prototypes
   - :c:func:`iob_trycopyin()`
   - :c:func:`iob_copyout()`
   - :c:func:`iob_clone()`
+  - :c:func:`iob_clone_partial()`
   - :c:func:`iob_concat()`
   - :c:func:`iob_trimhead()`
   - :c:func:`iob_trimhead_queue()`
@@ -272,6 +273,12 @@ Public Function Prototypes
 
   Duplicate (and pack) the data in ``iob1`` in
   ``iob2``. ``iob2`` must be empty.
+
+.. c:function:: int iob_clone_partial(FAR struct iob_s *iob1, unsigned int len, \
+                      unsigned int offset1, FAR struct iob_s *iob2, \
+                      unsigned int offset2, bool throttled, bool block);
+
+  Duplicate the data from partial bytes of ``iob1`` to ``iob2``
 
 .. c:function:: void iob_concat(FAR struct iob_s *iob1, FAR struct iob_s *iob2)
 

--- a/Documentation/reference/os/iob.rst
+++ b/Documentation/reference/os/iob.rst
@@ -267,7 +267,8 @@ Public Function Prototypes
   buffer starting at ``offset`` in the I/O buffer, returning that
   actual number of bytes copied out.
 
-.. c:function:: int iob_clone(FAR struct iob_s *iob1, FAR struct iob_s *iob2, bool throttled)
+.. c:function:: int iob_clone(FAR struct iob_s *iob1, FAR struct iob_s *iob2, \
+                   bool throttled, bool block);
 
   Duplicate (and pack) the data in ``iob1`` in
   ``iob2``. ``iob2`` must be empty.

--- a/include/nuttx/mm/iob.h
+++ b/include/nuttx/mm/iob.h
@@ -464,8 +464,8 @@ unsigned int iob_tailroom(FAR struct iob_s *iob);
  *
  ****************************************************************************/
 
-int iob_clone(FAR struct iob_s *iob1,
-              FAR struct iob_s *iob2, bool throttled);
+int iob_clone(FAR struct iob_s *iob1, FAR struct iob_s *iob2,
+              bool throttled, bool block);
 
 /****************************************************************************
  * Name: iob_concat

--- a/include/nuttx/mm/iob.h
+++ b/include/nuttx/mm/iob.h
@@ -468,6 +468,31 @@ int iob_clone(FAR struct iob_s *iob1, FAR struct iob_s *iob2,
               bool throttled, bool block);
 
 /****************************************************************************
+ * Name: iob_clone_partial
+ *
+ * Description:
+ *   Duplicate the data from partial bytes of iob1 to iob2
+ *
+ * Input Parameters:
+ *   iob1      - Pointer to source iob_s
+ *   len       - Number of bytes to copy
+ *   offset1   - Offset of source iobs_s
+ *   iob2      - Pointer to destination iob_s
+ *   offset2   - Offset of destination iobs_s
+ *   throttled - An indication of the IOB allocation is "throttled"
+ *   block     - Flag of Enable/Disable nonblocking operation
+ *
+ * Returned Value:
+ *   == 0  - Partial clone successfully.
+ *   < 0   - No available to clone to destination iob.
+ *
+ ****************************************************************************/
+
+int iob_clone_partial(FAR struct iob_s *iob1, unsigned int len,
+                      unsigned int offset1, FAR struct iob_s *iob2,
+                      unsigned int offset2, bool throttled, bool block);
+
+/****************************************************************************
  * Name: iob_concat
  *
  * Description:

--- a/mm/iob/iob_clone.c
+++ b/mm/iob/iob_clone.c
@@ -53,7 +53,8 @@
  *
  ****************************************************************************/
 
-int iob_clone(FAR struct iob_s *iob1, FAR struct iob_s *iob2, bool throttled)
+int iob_clone(FAR struct iob_s *iob1, FAR struct iob_s *iob2,
+              bool throttled, bool block)
 {
   FAR uint8_t *src;
   FAR uint8_t *dest;
@@ -145,7 +146,15 @@ int iob_clone(FAR struct iob_s *iob1, FAR struct iob_s *iob2, bool throttled)
            * destination I/O buffer chain.
            */
 
-          next = iob_alloc(throttled);
+          if (block)
+            {
+              next = iob_alloc(throttled);
+            }
+          else
+            {
+              next = iob_tryalloc(throttled);
+            }
+
           if (!next)
             {
               ioberr("ERROR: Failed to allocate an I/O buffer\n");

--- a/mm/iob/iob_clone.c
+++ b/mm/iob/iob_clone.c
@@ -42,52 +42,131 @@
 #endif
 
 /****************************************************************************
+ * Static Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: iob_next
+ *
+ * Description:
+ *   Allocate or reinitialize the next node
+ *
+ ****************************************************************************/
+
+static int iob_next(FAR struct iob_s *iob, bool throttled, bool block)
+{
+  FAR struct iob_s *next = iob->io_flink;
+
+  /* Allocate new destination I/O buffer and hook it into the
+   * destination I/O buffer chain.
+   */
+
+  if (next == NULL)
+    {
+      if (block)
+        {
+          next = iob_alloc(throttled);
+        }
+      else
+        {
+          next = iob_tryalloc(throttled);
+        }
+
+      if (next == NULL)
+        {
+          ioberr("ERROR: Failed to allocate an I/O buffer\n");
+          return -ENOMEM;
+        }
+
+      iob->io_flink = next;
+    }
+  else
+    {
+      next->io_len    = 0;
+      next->io_offset = 0;
+      next->io_pktlen = 0;
+    }
+
+  return OK;
+}
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
 /****************************************************************************
- * Name: iob_clone
+ * Name: iob_clone_partial
  *
  * Description:
- *   Duplicate (and pack) the data in iob1 in iob2.  iob2 must be empty.
+ *   Duplicate the data from partial bytes of iob1 to iob2
+ *
+ * Input Parameters:
+ *   iob1      - Pointer to source iob_s
+ *   len       - Number of bytes to copy
+ *   offset1   - Offset of source iobs_s
+ *   iob2      - Pointer to destination iob_s
+ *   offset2   - Offset of destination iobs_s
+ *   throttled - An indication of the IOB allocation is "throttled"
+ *   block     - Flag of Enable/Disable nonblocking operation
+ *
+ * Returned Value:
+ *   == 0  - Partial clone successfully.
+ *   < 0   - No available to clone to destination iob.
  *
  ****************************************************************************/
 
-int iob_clone(FAR struct iob_s *iob1, FAR struct iob_s *iob2,
-              bool throttled, bool block)
+int iob_clone_partial(FAR struct iob_s *iob1, unsigned int len,
+                      unsigned int offset1, FAR struct iob_s *iob2,
+                      unsigned int offset2, bool throttled, bool block)
 {
   FAR uint8_t *src;
   FAR uint8_t *dest;
   unsigned int ncopy;
   unsigned int avail1;
   unsigned int avail2;
-  unsigned int offset1;
-  unsigned int offset2;
-
-  DEBUGASSERT(iob2->io_len == 0 && iob2->io_offset == 0 &&
-              iob2->io_pktlen == 0 && iob2->io_flink == NULL);
+  int ret;
 
   /* Copy the total packet size from the I/O buffer at the head of the
    * chain.
    */
 
-  iob2->io_pktlen = iob1->io_pktlen;
+  iob2->io_pktlen = len + offset2;
 
   /* Handle special case where there are empty buffers at the head
-   * the list.
+   * the list, Skip I/O buffer containing the data offset.
    */
 
-  while (iob1->io_len <= 0)
+  while (iob1 != NULL && offset1 >= iob1->io_len)
     {
-      iob1 = iob1->io_flink;
+      offset1 -= iob1->io_len;
+      iob1     = iob1->io_flink;
+    }
+
+  /* Skip requested offset from the destination iob */
+
+  while (iob2 != NULL)
+    {
+      avail2 = CONFIG_IOB_BUFSIZE - iob2->io_offset;
+      if (offset2 < avail2)
+        {
+          break;
+        }
+
+      iob2->io_len = avail2;
+      offset2     -= iob2->io_len;
+
+      ret = iob_next(iob2, throttled, block);
+      if (ret < 0)
+        {
+          return ret;
+        }
+
+      iob2 = iob2->io_flink;
     }
 
   /* Pack each entry from iob1 to iob2 */
 
-  offset1 = 0;
-  offset2 = 0;
-
-  while (iob1)
+  while (iob1 && len > 0)
     {
       /* Get the source I/O buffer pointer and the number of bytes to copy
        * from this address.
@@ -100,18 +179,26 @@ int iob_clone(FAR struct iob_s *iob1, FAR struct iob_s *iob2,
        * copy to that address.
        */
 
-      dest   = &iob2->io_data[offset2];
-      avail2 = CONFIG_IOB_BUFSIZE - offset2;
+      dest   = &iob2->io_data[iob2->io_offset + offset2];
+      avail2 = CONFIG_IOB_BUFSIZE - iob2->io_offset - offset2;
 
       /* Copy the smaller of the two and update the srce and destination
        * offsets.
        */
 
       ncopy = MIN(avail1, avail2);
+      if (ncopy > len)
+        {
+          ncopy = len;
+        }
+
+      len -= ncopy;
+
       memcpy(dest, src, ncopy);
 
-      offset1 += ncopy;
-      offset2 += ncopy;
+      offset1      += ncopy;
+      offset2      += ncopy;
+      iob2->io_len  = offset2;
 
       /* Have we taken all of the data from the source I/O buffer? */
 
@@ -138,34 +225,37 @@ int iob_clone(FAR struct iob_s *iob1, FAR struct iob_s *iob2,
        * transferred?
        */
 
-      if (offset2 >= CONFIG_IOB_BUFSIZE && iob1 != NULL)
+      if (offset2 >= (CONFIG_IOB_BUFSIZE - iob2->io_offset) &&
+          iob1 != NULL)
         {
-          FAR struct iob_s *next;
-
-          /* Allocate new destination I/O buffer and hook it into the
-           * destination I/O buffer chain.
-           */
-
-          if (block)
+          ret = iob_next(iob2, throttled, block);
+          if (ret < 0)
             {
-              next = iob_alloc(throttled);
-            }
-          else
-            {
-              next = iob_tryalloc(throttled);
+              return ret;
             }
 
-          if (!next)
-            {
-              ioberr("ERROR: Failed to allocate an I/O buffer\n");
-              return -ENOMEM;
-            }
-
-          iob2->io_flink = next;
-          iob2 = next;
+          iob2 = iob2->io_flink;
           offset2 = 0;
         }
     }
 
   return 0;
+}
+
+/****************************************************************************
+ * Name: iob_clone
+ *
+ * Description:
+ *   Duplicate (and pack) the data in iob1 in iob2.  iob2 must be empty.
+ *
+ ****************************************************************************/
+
+int iob_clone(FAR struct iob_s *iob1, FAR struct iob_s *iob2,
+              bool throttled, bool block)
+{
+  DEBUGASSERT(iob2->io_len == 0 && iob2->io_offset == 0 &&
+            iob2->io_pktlen == 0 && iob2->io_flink == NULL);
+
+  return iob_clone_partial(iob1, iob1->io_pktlen, 0,
+                           iob2, 0, throttled, block);
 }


### PR DESCRIPTION
## Summary

1. mm/iob: add support of nonblock iob_clone
2. mm/iob: add support of partial bytes clone
3. net/devif: replace redundant code to iob_clone_partial()

## Impact

N/A

## Testing

iperf tcp client test