### PR TITLE
S32K FlexCAN don't use a blocking wait in tx avail

### DIFF
--- a/arch/arm/src/s32k3xx/s32k3xx_flexcan.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_flexcan.c
@@ -670,9 +670,6 @@ static void s32k3xx_setfreeze(uint32_t base, uint32_t freeze);
 static uint32_t s32k3xx_waitmcr_change(uint32_t base,
                                        uint32_t mask,
                                        uint32_t target_state);
-static uint32_t s32k3xx_waitesr2_change(uint32_t base,
-                                       uint32_t mask,
-                                       uint32_t target_state);
 
 /* Interrupt handling */
 
@@ -1379,26 +1376,6 @@ static void s32k3xx_setenable(uint32_t base, uint32_t enable)
   s32k3xx_waitmcr_change(base, CAN_MCR_LPMACK, 1);
 }
 
-static uint32_t s32k3xx_waitesr2_change(uint32_t base, uint32_t mask,
-                                       uint32_t target_state)
-{
-  const uint32_t timeout = 1000;
-  uint32_t wait_ack;
-
-  for (wait_ack = 0; wait_ack < timeout; wait_ack++)
-    {
-      uint32_t state = (getreg32(base + S32K3XX_CAN_ESR2_OFFSET) & mask);
-      if (state == target_state)
-        {
-          return true;
-        }
-
-      up_udelay(10);
-    }
-
-  return false;
-}
-
 static void s32k3xx_setfreeze(uint32_t base, uint32_t freeze)
 {
   uint32_t regval;
@@ -1590,9 +1567,7 @@ static void s32k3xx_txavail_work(void *arg)
        * packet.
        */
 
-      if (s32k3xx_waitesr2_change(priv->base,
-                             (CAN_ESR2_IMB | CAN_ESR2_VPS),
-                             (CAN_ESR2_IMB | CAN_ESR2_VPS)))
+      if (!s32k3xx_txringfull(priv))
         {
           /* No, there is space for another transfer.  Poll the network for
            * new XMIT data.


### PR DESCRIPTION
## Summary
When using MSG_DONTWAIT while TX queue is full, sendmsg could block up to 10ms.
Changed to behavior of tx avail to match the IMXRT driver and don't block while executing tx_avail()

## Testing
Tested on MR-CANHUBK3 and on UCANS32K1 using PX4
