### PR TITLE
xtensa/esp32: Fix PSRAM support when Stack Smash protection is enabled

### DIFF
--- a/boards/xtensa/esp32/common/scripts/legacy_sections.ld
+++ b/boards/xtensa/esp32/common/scripts/legacy_sections.ld
@@ -18,6 +18,8 @@
  *
  ****************************************************************************/
 
+#include <nuttx/config.h>
+
 /* Default entry point: */
 
 ENTRY(__start);
@@ -71,6 +73,9 @@ SECTIONS
     _iram_text_start = ABSOLUTE(.);
     *(.iram1 .iram1.*)
     *librtc.a:(.literal .text .literal.* .text.*)
+#ifdef CONFIG_STACK_CANARIES
+    *libc.a:lib_stackchk.*(.literal .text .literal.* .text.*)
+#endif
     *libarch.a:esp32_spiflash.*(.literal .text .literal.* .text.*)
     *libarch.a:xtensa_cpupause.*(.literal .text .literal.* .text.*)
     *libarch.a:xtensa_copystate.*(.literal .text .literal.* .text.*)
@@ -130,6 +135,9 @@ SECTIONS
     *(.share.mem)
     *(.gnu.linkonce.b.*)
     *(COMMON)
+#ifdef CONFIG_STACK_CANARIES
+    *libc.a:lib_stackchk.*(.bss  .bss.*  COMMON)
+#endif
     *libarch.a:esp32_spiflash.*(.bss  .bss.*  COMMON)
     *libarch.a:xtensa_cpupause.*(.bss  .bss.*  COMMON)
     *libarch.a:xtensa_copystate.*(.bss  .bss.*  COMMON)
@@ -183,6 +191,9 @@ SECTIONS
     KEEP (*(.jcr))
     *(.dram1 .dram1.*)
     *libphy.a:(.rodata  .rodata.*)
+#ifdef CONFIG_STACK_CANARIES
+    *libc.a:lib_stackchk.*(.rodata  .rodata.*)
+#endif
     *libarch.a:esp32_spiflash.*(.rodata  .rodata.*)
     *libarch.a:xtensa_cpupause.*(.rodata  .rodata.*)
     *libarch.a:xtensa_copystate.*(.rodata  .rodata.*)


### PR DESCRIPTION
## Summary

This PR intends to fix the PSRAM support on ESP32 when Stack Smash Protection is enabled (`CONFIG_STACK_CANARIES=1`).

During PSRAM initialization the Cache needs to be disabled for MMU configuration, so all data and code for the aforementioned scope is required to be placed in Internal RAM (DRAM and IRAM regions).

## Impact

Only for PSRAM-enabled configurations on ESP32.

## Testing

Successful execution of `ramtest` application on `esp32-devkitc:psram` with `CONFIG_STACK_CANARIES=1`.
```
NuttShell (NSH) NuttX-10.4.0
nsh> ramtest -w 0x3f800000 65536
RAMTest: Marching ones: 3f800000 65536
RAMTest: Marching zeroes: 3f800000 65536
RAMTest: Pattern test: 3f800000 65536 55555555 aaaaaaaa
RAMTest: Pattern test: 3f800000 65536 66666666 99999999
RAMTest: Pattern test: 3f800000 65536 33333333 cccccccc
RAMTest: Address-in-address test: 3f800000 65536
nsh> 
```
