### PR TITLE
sched/semaphore: fix NULL pointer dereference in nxsem_release_holder

### DIFF
--- a/sched/semaphore/sem_holder.c
+++ b/sched/semaphore/sem_holder.c
@@ -833,7 +833,7 @@ void nxsem_release_holder(FAR sem_t *sem)
 
   /* The current task is not a holder */
 
-  if (total == 1)
+  if (candidate != NULL && total == 1)
     {
       /* If the semaphore has only one holder, we can decrement the counts
        * simply.


### PR DESCRIPTION
## Summary
Fix NULL pointer dereference in nxsem_release_holder

## Impact
Fix crash

## Testing
SAMv7 based boad
