### PR TITLE
s32k3 Clean up

### DIFF
--- a/arch/arm/src/s32k3xx/s32k3xx_edma.h
+++ b/arch/arm/src/s32k3xx/s32k3xx_edma.h
@@ -180,7 +180,6 @@ struct s32k3xx_edma_xfrconfig_s
     uint8_t  flags;      /* See EDMA_CONFIG_* definitions */
     uint8_t  ssize;      /* Source data transfer size (see TCD_ATTR_SIZE_* definitions in rdware/. */
     uint8_t  dsize;      /* Destination data transfer size. */
-    uint8_t  ttype;      /* Transfer type (see enum s32k3xx_edma_xfrtype_e). */
 #ifdef CONFIG_S32K3XX_EDMA_EMLIM
     uint16_t nbytes;     /* Bytes to transfer in a minor loop */
 #else

--- a/arch/arm/src/s32k3xx/s32k3xx_lpspi.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_lpspi.c
@@ -518,32 +518,6 @@ static struct s32k3xx_lpspidev_s g_lpspi5dev =
  ****************************************************************************/
 
 /****************************************************************************
- * Name: spi_modifyreg
- *
- * Description:
- *   Atomic modification of the 32-bit contents of the SPI register at offset
- *
- * Input Parameters:
- *   priv      - private SPI device structure
- *   offset    - offset to the register of interest
- *   clearbits - bits to clear
- *   clearbits - bits to set
- *
- * Returned Value:
- *   None.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_S32K3XX_LPSPI_DMA
-static inline void spi_modifyreg(struct s32k3xx_lpspidev_s *priv,
-                                 uint8_t offset, uint32_t clearbits,
-                                 uint32_t setbits)
-{
-  modifyreg32(priv->spibase + offset, clearbits, setbits);
-}
-#endif
-
-/****************************************************************************
  * Name: s32k3xx_lpspi_getreg8
  *
  * Description:
@@ -746,7 +720,7 @@ static inline uint16_t
 }
 
 /****************************************************************************
- * Name: s32k3xx_lpspi_modifyreg
+ * Name: s32k3xx_lpspi_modifyreg32
  *
  * Description:
  *   Clear and set bits in register
@@ -1104,9 +1078,9 @@ static uint32_t s32k3xx_lpspi_setfrequency(struct spi_dev_s *dev,
 
       /* Write the best values in the CCR register */
 
-      regval &= ~LPSPI_CCR_SCKDIV_MASK;
-      regval |= LPSPI_CCR_SCKDIV(best_scaler);
-      s32k3xx_lpspi_putreg32(priv, S32K3XX_LPSPI_CCR_OFFSET, regval);
+      s32k3xx_lpspi_modifyreg32(priv, S32K3XX_LPSPI_CCR_OFFSET,
+                                LPSPI_CCR_SCKDIV_MASK,
+                                LPSPI_CCR_SCKDIV(best_scaler));
 
       /* Re-enable LPSPI if it was enabled previously */
 
@@ -1764,9 +1738,9 @@ static void s32k3xx_lpspi_exchange(struct spi_dev_s *dev,
 
   regval = s32k3xx_lpspi_getreg32(priv, S32K3XX_LPSPI_CFGR1_OFFSET);
 
-  spi_modifyreg(priv, S32K3XX_LPSPI_CR_OFFSET,
-                LPSPI_CR_RTF | LPSPI_CR_RRF,
-                LPSPI_CR_RTF | LPSPI_CR_RRF);
+  s32k3xx_lpspi_modifyreg32(priv, S32K3XX_LPSPI_CR_OFFSET,
+                            LPSPI_CR_RTF | LPSPI_CR_RRF,
+                            LPSPI_CR_RTF | LPSPI_CR_RRF);
 
   s32k3xx_lpspi_putreg32(priv, S32K3XX_LPSPI_CFGR1_OFFSET, regval);
 
@@ -1821,8 +1795,8 @@ static void s32k3xx_lpspi_exchange(struct spi_dev_s *dev,
 
   /* Invoke SPI DMA */
 
-  spi_modifyreg(priv, S32K3XX_LPSPI_DER_OFFSET,
-                0, LPSPI_DER_TDDE | LPSPI_DER_RDDE);
+  s32k3xx_lpspi_modifyreg32(priv, S32K3XX_LPSPI_DER_OFFSET,
+                            0, LPSPI_DER_TDDE | LPSPI_DER_RDDE);
 
   /* Then wait for each to complete */
 

--- a/arch/arm/src/s32k3xx/s32k3xx_lpspi.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_lpspi.c
@@ -1752,6 +1752,17 @@ static void s32k3xx_lpspi_exchange(struct spi_dev_s *dev,
 
   s32k3xx_lpspi_putreg32(priv, S32K3XX_LPSPI_DER_OFFSET, 0);
 
+  if (txbuffer)
+    {
+      up_clean_dcache((uintptr_t)txbuffer, (uintptr_t)txbuffer + nbytes);
+    }
+
+  if (rxbuffer)
+    {
+     up_invalidate_dcache((uintptr_t)rxbuffer,
+                          (uintptr_t)rxbuffer + nbytes);
+    }
+
   /* Set up the DMA */
 
   adjust = (priv->nbits > 8) ? 2 : 1;
@@ -1766,7 +1777,6 @@ static void s32k3xx_lpspi_exchange(struct spi_dev_s *dev,
   config.flags  = EDMA_CONFIG_LINKTYPE_LINKNONE;
   config.ssize  = adjust == 1 ? EDMA_8BIT : EDMA_16BIT;
   config.dsize  = adjust == 1 ? EDMA_8BIT : EDMA_16BIT;
-  config.ttype  = EDMA_PERIPH2MEM;
   config.nbytes = adjust;
 #ifdef CONFIG_KINETIS_EDMA_ELINK
   config.linkch = NULL;
@@ -1781,7 +1791,6 @@ static void s32k3xx_lpspi_exchange(struct spi_dev_s *dev,
   config.flags  = EDMA_CONFIG_LINKTYPE_LINKNONE;
   config.ssize  = adjust == 1 ? EDMA_8BIT : EDMA_16BIT;
   config.dsize  = adjust == 1 ? EDMA_8BIT : EDMA_16BIT;
-  config.ttype  = EDMA_MEM2PERIPH;
   config.nbytes = adjust;
 #ifdef CONFIG_KINETIS_EDMA_ELINK
   config.linkch = NULL;
@@ -1816,9 +1825,6 @@ static void s32k3xx_lpspi_exchange(struct spi_dev_s *dev,
   /* Disable DMA */
 
   s32k3xx_lpspi_putreg32(priv, S32K3XX_LPSPI_DER_OFFSET, 0);
-
-  up_invalidate_dcache((uintptr_t)rxbuffer,
-                           (uintptr_t)rxbuffer + nbytes);
 }
 
 #endif  /* CONFIG_S32K3XX_SPI_DMA */

--- a/arch/arm/src/s32k3xx/s32k3xx_qspi.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_qspi.c
@@ -803,7 +803,6 @@ static int qspi_receive(struct s32k3xx_qspidev_s *priv,
   config.flags  = EDMA_CONFIG_LINKTYPE_LINKNONE;
   config.ssize  = EDMA_16BYTE;
   config.dsize  = EDMA_16BYTE;
-  config.ttype  = EDMA_PERIPH2MEM;
   config.nbytes = 16;
 #ifdef CONFIG_KINETIS_EDMA_ELINK
   config.linkch = NULL;
@@ -1029,6 +1028,9 @@ static int qspi_transmit(struct s32k3xx_qspidev_s *priv,
 
   putreg32(QSPI_AMBA_BASE + meminfo->addr, S32K3XX_QSPI_SFAR);
 
+  up_clean_dcache((uintptr_t)meminfo->buffer,
+                  (uintptr_t)meminfo->buffer + meminfo->buflen);
+
   /* Set up the DMA */
 
   uint32_t adjust = 1;
@@ -1043,7 +1045,6 @@ static int qspi_transmit(struct s32k3xx_qspidev_s *priv,
   config.flags  = EDMA_CONFIG_LINKTYPE_LINKNONE;
   config.ssize  = EDMA_32BIT;
   config.dsize  = EDMA_32BIT;
-  config.ttype  = EDMA_MEM2PERIPH;
   config.nbytes = 4;
   #ifdef CONFIG_KINETIS_EDMA_ELINK
   config.linkch = NULL;


### PR DESCRIPTION
## Summary

s32k3xx:LPSPI register usage cleanup removes redundant 32 reg modifiy code.

s32ke3xx:EDMA Usage Clean up. Ensure the lpspi and qspi used the eDMA and did their own  cache maintenance.  
In the past EDMA rework `ttype` was removed as was the dcache operation because the buffer extent is not know by the eDMA. 

## Impact

Should make the drivers stable with both WB/WT caching enabled.

## Testing

inspection only.

@PetervdPerk - would you please verify this PR?
