### PR TITLE
net/udp: correct udp send timeout

### DIFF
--- a/libs/libc/netdb/Kconfig
+++ b/libs/libc/netdb/Kconfig
@@ -121,6 +121,13 @@ config NETDB_DNSCLIENT_RECV_TIMEOUT
 		This is the timeout value when DNS receives response after
 		dns_send_query, unit: seconds
 
+config NETDB_DNSCLIENT_SEND_TIMEOUT
+	int "DNS send timeout"
+	default NETDB_DNSCLIENT_RECV_TIMEOUT
+	---help---
+		This is the timeout value when DNS send request on dns_send_query,
+		unit: seconds
+
 config NETDB_DNSCLIENT_RETRIES
 	int "Number of retries for DNS request"
 	default 3

--- a/libs/libc/netdb/lib_dnsbind.c
+++ b/libs/libc/netdb/lib_dnsbind.c
@@ -83,6 +83,17 @@ int dns_bind(sa_family_t family)
   tv.tv_usec = 0;
 
   ret = setsockopt(sd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(struct timeval));
+  if (ret >= 0)
+    {
+      /* Set up a send timeout */
+
+      tv.tv_sec  = CONFIG_NETDB_DNSCLIENT_SEND_TIMEOUT;
+      tv.tv_usec = 0;
+
+      ret = setsockopt(sd, SOL_SOCKET, SO_SNDTIMEO, &tv,
+                       sizeof(struct timeval));
+    }
+
   if (ret < 0)
     {
       ret = -get_errno();


### PR DESCRIPTION
## Summary

1. net/udp: correct udp send timeout
2. netdb/dns:  add support of send timeout

## Impact

N/A

## Testing

udp send test