### PR TITLE
arch: Make REG_[GET/SET]_FIELD thread safe for ESP SOCs

### DIFF
--- a/arch/risc-v/src/esp32c3/hardware/esp32c3_soc.h
+++ b/arch/risc-v/src/esp32c3/hardware/esp32c3_soc.h
@@ -294,13 +294,13 @@
  * used when _f is not left shifted by _f##_S
  */
 
-#define REG_GET_FIELD(_r, _f) ((REG_READ(_r) >> (_f##_S)) & (_f##_V))
+#define REG_GET_FIELD(addr, field) ((getreg32(addr) >> (field##_S)) & (field##_V))
 
 /* Set field to register,
  * used when _f is not left shifted by _f##_S
  */
 
-#define REG_SET_FIELD(_r, _f, _v) (REG_WRITE((_r),((REG_READ(_r) & ~((_f##_V) << (_f##_S)))|(((_v) & (_f##_V))<<(_f##_S)))))
+#define REG_SET_FIELD(addr, field, val) (modifyreg32((addr), (field##_M), (((uint32_t) val) & (field##_V)) << (field##_S)))
 
 #define SOC_SYSTIMER_BIT_WIDTH_LO (32) /* Bit width of systimer low part */
 #define SOC_SYSTIMER_BIT_WIDTH_HI (20) /* Bit width of systimer high part */

--- a/arch/xtensa/src/esp32/hardware/esp32_soc.h
+++ b/arch/xtensa/src/esp32/hardware/esp32_soc.h
@@ -107,13 +107,13 @@
  * used when _f is not left shifted by _f##_S
  */
 
-#define REG_GET_FIELD(addr, field) ((getreg32(addr) >> field##_S) & field##_V)
+#define REG_GET_FIELD(addr, field) ((getreg32(addr) >> (field##_S)) & (field##_V))
 
 /* Set field to register,
  * used when _f is not left shifted by _f##_S
  */
 
-#define REG_SET_FIELD(addr, field, val) (modifyreg32(addr, field##_M, (((uint32_t) val) & field##_V) << field##_S))
+#define REG_SET_FIELD(addr, field, val) (modifyreg32((addr), (field##_M), (((uint32_t) val) & (field##_V)) << (field##_S)))
 
 /* Set field value from a variable,
  * used when _f is not left shifted by _f##_S

--- a/arch/xtensa/src/esp32s2/hardware/esp32s2_soc.h
+++ b/arch/xtensa/src/esp32s2/hardware/esp32s2_soc.h
@@ -108,13 +108,13 @@
  * used when _f is not left shifted by _f##_S
  */
 
-#define REG_GET_FIELD(_r, _f) ((REG_READ(_r) >> (_f##_S)) & (_f##_V))
+#define REG_GET_FIELD(addr, field) ((getreg32(addr) >> (field##_S)) & (field##_V))
 
 /* Set field to register,
  * used when _f is not left shifted by _f##_S
  */
 
-#define REG_SET_FIELD(_r, _f, _v) (REG_WRITE((_r),((REG_READ(_r) & ~((_f##_V) << (_f##_S)))|(((_v) & (_f##_V))<<(_f##_S)))))
+#define REG_SET_FIELD(addr, field, val) (modifyreg32((addr), (field##_M), (((uint32_t) val) & (field##_V)) << (field##_S)))
 
 /* Set field value from a variable,
  * used when _f is not left shifted by _f##_S

--- a/arch/xtensa/src/esp32s3/hardware/esp32s3_soc.h
+++ b/arch/xtensa/src/esp32s3/hardware/esp32s3_soc.h
@@ -180,13 +180,13 @@
  * used when _f is not left shifted by _f##_S
  */
 
-#define REG_GET_FIELD(_r, _f) ((REG_READ(_r) >> (_f##_S)) & (_f##_V))
+#define REG_GET_FIELD(addr, field) ((getreg32(addr) >> (field##_S)) & (field##_V))
 
 /* Set field to register,
  * used when _f is not left shifted by _f##_S
  */
 
-#define REG_SET_FIELD(_r, _f, _v) (REG_WRITE((_r),((REG_READ(_r) & ~((_f##_V) << (_f##_S)))|(((_v) & (_f##_V))<<(_f##_S)))))
+#define REG_SET_FIELD(addr, field, val) (modifyreg32((addr), (field##_M), (((uint32_t) val) & (field##_V)) << (field##_S)))
 
 /* Get field value from a variable,
  * used when _f is not left shifted by _f##_S


### PR DESCRIPTION
## Summary

Propagate the changes introduced in #7800 and #7790 to the other ESP SOCs.

## Impact

Make using fields in ESP SOCs thread safe.

## Testing

CI build pass and local testing