### PR TITLE
drivers/note: move taskname related functions to note_taskname.c

### DIFF
--- a/Documentation/guides/tasktraceuser.rst
+++ b/Documentation/guides/tasktraceuser.rst
@@ -46,17 +46,17 @@ The following configurations are configurable parameters for trace.
 
   - If enabled, use higher resolution system timer for instrumentation.
 
-- ``CONFIG_DRIVER_NOTERAM_BUFSIZE``
-
-  - Specify the note buffer size in bytes.
-    Higher value can hold more note records, but consumes more kernel memory.
-
-- ``CONFIG_DRIVER_NOTERAM_TASKNAME_BUFSIZE``
+- ``CONFIG_DRIVER_NOTE_TASKNAME_BUFSIZE``
 
   - Specify the task name buffer size in bytes.
     The buffer is used to hold the name of the task during instrumentation.
     Trace dump can find and show a task name corresponding to given pid in the instrumentation data by using this buffer.
     If 0 is specified, this feature is disabled and trace dump shows only the name of the newly created task.
+
+- ``CONFIG_DRIVER_NOTERAM_BUFSIZE``
+
+  - Specify the note buffer size in bytes.
+    Higher value can hold more note records, but consumes more kernel memory.
 
 - ``CONFIG_DRIVER_NOTERAM_DEFAULT_NOOVERWRITE``
 

--- a/drivers/note/Kconfig
+++ b/drivers/note/Kconfig
@@ -16,6 +16,18 @@ config DRIVER_NOTE_MAX
 	---help---
 		sched_note supports the maximum number of drivers
 
+config DRIVER_NOTE_TASKNAME_BUFSIZE
+	int "Note task name buffer size"
+	default 256 if TASK_NAME_SIZE > 0
+	default 0 if TASK_NAME_SIZE = 0
+	---help---
+		The size of the in-memory task name buffer (in bytes).
+		The buffer is used to hold the name of the task during instrumentation.
+		Trace dump can find and show a task name corresponding to given pid in
+		the instrumentation data by using this buffer.
+		If 0 is specified, this feature is disabled and trace dump shows only
+		the name of the newly created task.
+
 choice
 	prompt "Note driver selection"
 	default DRIVER_NOTERAM
@@ -78,19 +90,6 @@ config DRIVER_NOTERAM_BUFSIZE
 	default 2048
 	---help---
 		The size of the in-memory, circular instrumentation buffer (in bytes).
-
-config DRIVER_NOTERAM_TASKNAME_BUFSIZE
-	int "Note RAM task name buffer size"
-	depends on DRIVER_NOTERAM
-	default 256 if TASK_NAME_SIZE > 0
-	default 0 if TASK_NAME_SIZE = 0
-	---help---
-		The size of the in-memory task name buffer (in bytes).
-		The buffer is used to hold the name of the task during instrumentation.
-		Trace dump can find and show a task name corresponding to given pid in
-		the instrumentation data by using this buffer.
-		If 0 is specified, this feature is disabled and trace dump shows only
-		the name of the newly created task.
 
 config DRIVER_NOTERAM_DEFAULT_NOOVERWRITE
 	bool "Disable overwrite by default"

--- a/include/nuttx/note/note_driver.h
+++ b/include/nuttx/note/note_driver.h
@@ -130,4 +130,26 @@ int note_initialize(void);
 
 #endif /* defined(__KERNEL__) || defined(CONFIG_BUILD_FLAT) */
 
+#if CONFIG_DRIVER_NOTE_TASKNAME_BUFSIZE > 0
+
+/****************************************************************************
+ * Name: note_get_taskname
+ *
+ * Description:
+ *   Get the task name string of the specified PID
+ *
+ * Input Parameters:
+ *   PID - Task ID
+ *   name - Task name buffer
+ *          this buffer must be greater than CONFIG_TASK_NAME_SIZE + 1
+ *
+ * Returned Value:
+ *   Retrun OK if task name can be retrieved, otherwise -ESRCH
+ *
+ ****************************************************************************/
+
+int note_get_taskname(pid_t pid, FAR char *name);
+
+#endif /* CONFIG_DRIVER_NOTE_TASKNAME_BUFSIZE > 0 */
+
 #endif /* __INCLUDE_NUTTX_NOTE_NOTE_DRIVER_H */

--- a/include/nuttx/note/noteram_driver.h
+++ b/include/nuttx/note/noteram_driver.h
@@ -56,7 +56,7 @@
 #define NOTERAM_CLEAR           _NOTERAMIOC(0x01)
 #define NOTERAM_GETMODE         _NOTERAMIOC(0x02)
 #define NOTERAM_SETMODE         _NOTERAMIOC(0x03)
-#if CONFIG_DRIVER_NOTERAM_TASKNAME_BUFSIZE > 0
+#if CONFIG_DRIVER_NOTE_TASKNAME_BUFSIZE > 0
 #define NOTERAM_GETTASKNAME     _NOTERAMIOC(0x04)
 #endif
 #endif
@@ -75,7 +75,7 @@
 
 /* This is the type of the argument passed to the NOTERAM_GETTASKNAME ioctl */
 
-#if CONFIG_DRIVER_NOTERAM_TASKNAME_BUFSIZE > 0
+#ifdef NOTERAM_GETTASKNAME
 struct noteram_get_taskname_s
 {
   pid_t pid;


### PR DESCRIPTION
## Summary
move taskname related functions to note_taskname.c
used to simplify noteram while giving taskname to other reuse

## Impact

## Testing
Pass CI
note: this patch depends on https://github.com/apache/nuttx-apps/pull/1476
