### PR TITLE
Fix S32K1XX PM which was broken by #7869

### DIFF
--- a/arch/arm/src/s32k1xx/s32k1xx_serial.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_serial.c
@@ -2011,13 +2011,13 @@ static void up_pm_notify(struct pm_callback_s *cb, int domain,
   peripheral_clock_source_t clock_source;
 
   #ifdef CONFIG_PM_SERIAL0
-    struct s32k1xx_uart_s *priv0 = g_lpuart0priv.priv;
+    struct s32k1xx_uart_s *priv0 = g_lpuart0priv.dev.priv;
   #endif
   #ifdef CONFIG_PM_SERIAL1
-    struct s32k1xx_uart_s *priv1 = g_lpuart1priv.priv;
+    struct s32k1xx_uart_s *priv1 = g_lpuart1priv.dev.priv;
   #endif
   #ifdef CONFIG_PM_SERIAL2
-    struct s32k1xx_uart_s *priv2 = g_lpuart2priv.priv;
+    struct s32k1xx_uart_s *priv2 = g_lpuart2priv.dev.priv;
   #endif
 
   uint32_t ret_reg = 0;
@@ -2254,15 +2254,15 @@ static int up_pm_prepare(struct pm_callback_s *cb, int domain,
 
   #ifdef CONFIG_PM_SERIAL0
     struct s32k1xx_uart_s *priv0 =
-        (struct s32k1xx_uart_s *)g_lpuart0priv.priv;
+        (struct s32k1xx_uart_s *)g_lpuart0priv.dev.priv;
   #endif
   #ifdef CONFIG_PM_SERIAL1
     struct s32k1xx_uart_s *priv1 =
-        (struct s32k1xx_uart_s *)g_lpuart1priv.priv;
+        (struct s32k1xx_uart_s *)g_lpuart1priv.dev.priv;
   #endif
   #ifdef CONFIG_PM_SERIAL2
     struct s32k1xx_uart_s *priv2 =
-        (struct s32k1xx_uart_s *)g_lpuart2priv.priv;
+        (struct s32k1xx_uart_s *)g_lpuart2priv.dev.priv;
   #endif
 
   uint32_t ret_reg = 0;


### PR DESCRIPTION
## Summary
#7869 changed priv definition but didn't account the PM calls, corrected this now compiles correctly with PM

## Testing
Tested with BMS772 config
