### PR TITLE
 ESP32-C3: Fix double initialization of SHA Accelerator

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_aes.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_aes.c
@@ -585,9 +585,11 @@ int esp32c3_aes_init(void)
  * Name: aes_cypher
  ****************************************************************************/
 
-int esp32c3_aes_cypher(void *out, const void *in, size_t size,
-                       const void *iv, const void *key, size_t keysize,
-                       int mode, int encrypt)
+#ifdef CONFIG_CRYPTO_AES
+
+int aes_cypher(void *out, const void *in, size_t size,
+               const void *iv, const void *key, size_t keysize,
+               int mode, int encrypt)
 {
   int ret;
   uint8_t iv_buf[AES_BLK_SIZE];
@@ -651,3 +653,5 @@ int esp32c3_aes_cypher(void *out, const void *in, size_t size,
 
   return ret;
 }
+
+#endif

--- a/arch/risc-v/src/esp32c3/esp32c3_aes.h
+++ b/arch/risc-v/src/esp32c3/esp32c3_aes.h
@@ -208,14 +208,6 @@ int esp32c3_aes_xts_setkey(struct esp32c3_aes_xts_s *aes, const void *keyptr,
 
 int esp32c3_aes_init(void);
 
-/****************************************************************************
- * Name: aes_cypher
- ****************************************************************************/
-
-int esp32c3_aes_cypher(void *out, const void *in, size_t size,
-                       const void *iv, const void *key, size_t keysize,
-                       int mode, int encrypt);
-
 #ifdef __cplusplus
 }
 #endif

--- a/arch/risc-v/src/esp32c3/esp32c3_crypto.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_crypto.c
@@ -445,11 +445,9 @@ static int esp32c3_process(struct cryptop *crp)
       switch (data->alg)
         {
           case CRYPTO_AES_CBC:
-            err = esp32c3_aes_cypher(crp->crp_dst, crp->crp_buf,
-                                     crd->crd_len,
-                                     crd->crd_iv, crd->crd_key, 16,
-                                     AES_MODE_CBC,
-                                     crd->crd_flags & CRD_F_ENCRYPT);
+            err = aes_cypher(crp->crp_dst, crp->crp_buf, crd->crd_len,
+                             crd->crd_iv, crd->crd_key, 16, AES_MODE_CBC,
+                             crd->crd_flags & CRD_F_ENCRYPT);
             if (err < 0)
               {
                 return err;
@@ -460,12 +458,9 @@ static int esp32c3_process(struct cryptop *crp)
             memcpy(iv, crd->crd_key + crd->crd_klen / 8 - 4, 4);
             memcpy(iv + 4, crd->crd_iv, 8);
             iv[15] = 0x1;
-            err = esp32c3_aes_cypher(crp->crp_dst, crp->crp_buf,
-                                     crd->crd_len,
-                                     iv, crd->crd_key,
-                                     crd->crd_klen / 8 - 4,
-                                     AES_MODE_CTR ,
-                                     crd->crd_flags & CRD_F_ENCRYPT);
+            err = aes_cypher(crp->crp_dst, crp->crp_buf, crd->crd_len, iv,
+                             crd->crd_key, crd->crd_klen / 8 - 4,
+                             AES_MODE_CTR, crd->crd_flags & CRD_F_ENCRYPT);
             if (err < 0)
               {
                 return err;

--- a/boards/risc-v/esp32c3/esp32c3-devkit-rust-1/src/esp32c3_bringup.c
+++ b/boards/risc-v/esp32c3/esp32c3-devkit-rust-1/src/esp32c3_bringup.c
@@ -95,7 +95,8 @@ int esp32c3_bringup(void)
     }
 #endif
 
-#ifdef CONFIG_ESP32C3_SHA_ACCELERATOR
+#if defined(CONFIG_ESP32C3_SHA_ACCELERATOR) && \
+    !defined(CONFIG_CRYPTO_CRYPTODEV_HARDWARE)
   ret = esp32c3_sha_init();
   if (ret < 0)
     {

--- a/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_bringup.c
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_bringup.c
@@ -126,7 +126,8 @@ int esp32c3_bringup(void)
     }
 #endif
 
-#ifdef CONFIG_ESP32C3_SHA_ACCELERATOR
+#if defined(CONFIG_ESP32C3_SHA_ACCELERATOR) && \
+    !defined(CONFIG_CRYPTO_CRYPTODEV_HARDWARE)
   ret = esp32c3_sha_init();
   if (ret < 0)
     {


### PR DESCRIPTION
## Summary

This PR intends to fix the double initialization of the SHA peripheral, which was resulting in the following error in the `esp32c3-devkit:crypto`:
```
ERROR: Failed to initialize SHA: -16
```

Also revert the renaming of `aes_cypher` function. `aes_cypher` is a function from NuttX crypto, so better use it instead of defining a new interface in the driver.

## Impact

ESP32-C3 configs relying on the AES and SHA cryptographic accelerators.

## Testing

`esp32c3-devkit:crypto` builds successfully and boots without errors.