### PR TITLE
SAMA5 serial and flexcom serial corrections

### DIFF
--- a/arch/arm/src/sama5/sam_flexcom_serial.c
+++ b/arch/arm/src/sama5/sam_flexcom_serial.c
@@ -209,7 +209,7 @@ static void flexus_shutdown(struct uart_dev_s *dev);
 static int  flexus_attach(struct uart_dev_s *dev);
 static void flexus_detach(struct uart_dev_s *dev);
 static int  flexus_ioctl(struct file *filep, int cmd, unsigned long arg);
-static int  flexus_receive(struct uart_dev_s *dev, uint32_t *status);
+static int  flexus_receive(struct uart_dev_s *dev, unsigned int *status);
 static void flexus_rxint(struct uart_dev_s *dev, bool enable);
 static bool flexus_rxavailable(struct uart_dev_s *dev);
 static void flexus_send(struct uart_dev_s *dev, int ch);
@@ -961,7 +961,7 @@ static int flexus_ioctl(struct file *filep, int cmd, unsigned long arg)
  *
  ****************************************************************************/
 
-static int flexus_receive(struct uart_dev_s *dev, uint32_t *status)
+static int flexus_receive(struct uart_dev_s *dev, unsigned int *status)
 {
   struct flexus_dev_s *priv = (struct flexus_dev_s *)dev->priv;
 

--- a/arch/arm/src/sama5/sam_serial.c
+++ b/arch/arm/src/sama5/sam_serial.c
@@ -479,23 +479,23 @@ static char g_uart3txbuffer[CONFIG_UART3_TXBUFSIZE];
 static char g_uart4rxbuffer[CONFIG_UART4_RXBUFSIZE];
 static char g_uart4txbuffer[CONFIG_UART4_TXBUFSIZE];
 #endif
-#ifdef CONFIG_USART0_SERIALDRIVER
+#if defined(CONFIG_USART0_SERIALDRIVER) && defined(CONFIG_SAMA5_USART0)
 static char g_usart0rxbuffer[CONFIG_USART0_RXBUFSIZE];
 static char g_usart0txbuffer[CONFIG_USART0_TXBUFSIZE];
 #endif
-#ifdef CONFIG_USART1_SERIALDRIVER
+#if defined(CONFIG_USART1_SERIALDRIVER) && defined(CONFIG_SAMA5_USART1)
 static char g_usart1rxbuffer[CONFIG_USART1_RXBUFSIZE];
 static char g_usart1txbuffer[CONFIG_USART1_TXBUFSIZE];
 #endif
-#ifdef CONFIG_USART2_SERIALDRIVER
+#if defined(CONFIG_USART2_SERIALDRIVER) && defined(CONFIG_SAMA5_USART2)
 static char g_usart2rxbuffer[CONFIG_USART2_RXBUFSIZE];
 static char g_usart2txbuffer[CONFIG_USART2_TXBUFSIZE];
 #endif
-#ifdef CONFIG_USART3_SERIALDRIVER
+#if defined(CONFIG_USART3_SERIALDRIVER) && defined(CONFIG_SAMA5_USART3)
 static char g_usart3rxbuffer[CONFIG_USART3_RXBUFSIZE];
 static char g_usart3txbuffer[CONFIG_USART3_TXBUFSIZE];
 #endif
-#ifdef CONFIG_USART4_SERIALDRIVER
+#if defined(CONFIG_USART4_SERIALDRIVER) && defined(CONFIG_SAMA5_USART4)
 static char g_usart4rxbuffer[CONFIG_USART4_RXBUFSIZE];
 static char g_usart4txbuffer[CONFIG_USART4_TXBUFSIZE];
 #endif


### PR DESCRIPTION
## Summary
Ongoing work with a SAMA5D2 board revealed compiler warnings that needed to be fixed.

## Impact
None.

## Testing

Custom board with SAMA5D27C-D1M