### PR TITLE
Minor improvement for sim serial driver

### DIFF
--- a/arch/sim/src/sim/sim_uart.c
+++ b/arch/sim/src/sim/sim_uart.c
@@ -428,13 +428,6 @@ static void tty_send(struct uart_dev_s *dev, int ch)
 {
   struct tty_priv_s *priv = dev->priv;
 
-  /* For console device */
-
-  if (dev->isconsole && ch == '\n')
-    {
-      host_uart_putc(1, '\r');
-    }
-
   host_uart_putc(dev->isconsole ? 1 : priv->fd, ch);
 }
 
@@ -567,6 +560,11 @@ void sim_uartloop(void)
 int up_putc(int ch)
 {
 #ifdef USE_DEVCONSOLE
+  if (ch == '\n')
+    {
+      tty_send(&g_console_dev, '\r');
+    }
+
   tty_send(&g_console_dev, ch);
 #endif
   return 0;

--- a/arch/sim/src/sim/sim_uart.c
+++ b/arch/sim/src/sim/sim_uart.c
@@ -255,16 +255,8 @@ static int tty_setup(struct uart_dev_s *dev)
 {
   struct tty_priv_s *priv = dev->priv;
 
-  if (!dev->isconsole && priv->fd < 0)
-    {
-      priv->fd = host_uart_open(priv->path);
-      if (priv->fd < 0)
-        {
-          return priv->fd;
-        }
-    }
-
-  return OK;
+  priv->fd = host_uart_open(priv->path);
+  return priv->fd;
 }
 
 /****************************************************************************
@@ -280,13 +272,10 @@ static void tty_shutdown(struct uart_dev_s *dev)
 {
   struct tty_priv_s *priv = dev->priv;
 
-  if (!dev->isconsole && priv->fd >= 0)
-    {
-      /* close file Description and reset fd */
+  /* close file Description and reset fd */
 
-      host_uart_close(priv->fd);
-      priv->fd = -1;
-    }
+  host_uart_close(priv->fd);
+  priv->fd = -1;
 }
 
 /****************************************************************************

--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -570,7 +570,11 @@ static int uart_open(FAR struct file *filep)
       ret = uart_attach(dev);
       if (ret < 0)
         {
-          uart_shutdown(dev);
+          if (!dev->isconsole)
+            {
+              uart_shutdown(dev);
+            }
+
           leave_critical_section(flags);
           goto errout_with_lock;
         }


### PR DESCRIPTION
## Summary

- drivers/serial: Don't call uart_shutdown if the serial work as a console 
- arch/sim: Don't need check isconsole in tty_setup and tty_shutdown 
- arch/sim: Move '\n' process from tty_send to up_putc

## Impact
Minor

## Testing
sim:nsh
