### PR TITLE
arch/arm/samv7: add ARCH_RAMVECTORS support

### DIFF
--- a/arch/arm/src/samv7/sam_irq.c
+++ b/arch/arm/src/samv7/sam_irq.c
@@ -34,7 +34,9 @@
 #include <arch/armv7-m/nvicpri.h>
 
 #include "nvic.h"
-#include "ram_vectors.h"
+#ifdef CONFIG_ARCH_RAMVECTORS
+#  include "ram_vectors.h"
+#endif
 #include "arm_internal.h"
 
 #ifdef CONFIG_SAMV7_GPIO_IRQ
@@ -81,7 +83,7 @@ static void sam_dumpnvic(const char *msg, int irq)
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
   irqinfo("  INTCTRL:    %08x VECTAB:  %08x\n",
-        getreg32(NVIC_INTCTRL), getreg32(NVIC_VECTAB));
+          getreg32(NVIC_INTCTRL), getreg32(NVIC_VECTAB));
 #if 0
   irqinfo("  SYSH ENABLE MEMFAULT: %08x BUSFAULT: %08x USGFAULT: %08x "
           "SYSTICK: %08x\n",
@@ -359,6 +361,13 @@ void up_irqinitialize(void)
    */
 
   arm_ramvec_initialize();
+
+  /* At this moment both I- and D-Caches have been already enabled in
+   * __start so we need to flush RAM vectors table to memory.
+   */
+
+  up_clean_dcache((uintptr_t)g_ram_vectors,
+                  (uintptr_t)g_ram_vectors + sizeof(g_ram_vectors));
 #endif
 
   /* Set all interrupts (and exceptions) to the default priority */

--- a/boards/arm/samv7/common/scripts/flash.ld.template
+++ b/boards/arm/samv7/common/scripts/flash.ld.template
@@ -88,6 +88,12 @@ SECTIONS
 
     _eronly = ABSOLUTE(.);
 
+    /* The RAM vector table (if present) should lie at the beginning of SRAM */
+
+    .ram_vectors : {
+        *(.ram_vectors)
+    } > sram
+
     .data : {
         _sdata = ABSOLUTE(.);
         *(.data .data.*)
@@ -97,7 +103,7 @@ SECTIONS
         _edata = ABSOLUTE(.);
     } > sram AT > flash
 
-    .ramfunc ALIGN(4): {
+    .ramfunc : ALIGN(4) {
         _sramfuncs = ABSOLUTE(.);
         *(.ramfunc  .ramfunc.*)
         _eramfuncs = ABSOLUTE(.);

--- a/boards/arm/samv7/common/scripts/kernel-space.ld
+++ b/boards/arm/samv7/common/scripts/kernel-space.ld
@@ -63,6 +63,12 @@ SECTIONS
 
     _eronly = ABSOLUTE(.);
 
+    /* The RAM vector table (if present) should lie at the beginning of SRAM */
+
+    .ram_vectors : {
+        *(.ram_vectors)
+    } > ksram
+
     .data : {
         _sdata = ABSOLUTE(.);
         *(.data .data.*)
@@ -72,7 +78,7 @@ SECTIONS
         _edata = ABSOLUTE(.);
     } > ksram AT > kflash
 
-    .ramfunc ALIGN(4): {
+    .ramfunc : ALIGN(4) {
         _sramfuncs = ABSOLUTE(.);
         *(.ramfunc  .ramfunc.*)
         _eramfuncs = ABSOLUTE(.);


### PR DESCRIPTION
## Summary
Add ARCH_RAMVECTORS support for SAMv7

## Impact
Bugfix

## Testing
Tested with same70-qmtech board with `CONFIG_ARCH_RAMVECTORS=y`.
