### PR TITLE
Pthread: show thread main entry when display thread name

### DIFF
--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -718,8 +718,9 @@ static ssize_t proc_cmdline(FAR struct proc_file_s *procfile,
     {
       FAR struct pthread_tcb_s *ptcb = (FAR struct pthread_tcb_s *)tcb;
 
-      linesize   = procfs_snprintf(procfile->line, STATUS_LINELEN, " %p\n",
-                                   ptcb->arg);
+      linesize   = procfs_snprintf(procfile->line, STATUS_LINELEN,
+                                   " %p %p\n",
+                                   ptcb->cmn.entry.main, ptcb->arg);
       copysize   = procfs_memcpy(procfile->line, linesize, buffer,
                                  remaining, &offset);
 

--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -251,7 +251,8 @@ static void dump_task(struct tcb_s *tcb, void *arg)
     {
       struct pthread_tcb_s *ptcb = (struct pthread_tcb_s *)tcb;
 
-      snprintf(args, sizeof(args), " %p", ptcb->arg);
+      snprintf(args, sizeof(args), " %p %p",
+               ptcb->cmn.entry.main, ptcb->arg);
     }
   else
 #endif
@@ -443,16 +444,18 @@ void _assert(FAR const char *filename, int linenum)
 
 #ifdef CONFIG_SMP
 #  if CONFIG_TASK_NAME_SIZE > 0
-  _alert("Assertion failed CPU%d at file:%s line: %d task: %s\n",
-         up_cpu_index(), filename, linenum, running_task()->name);
+  _alert("Assertion failed CPU%d at file:%s line: %d task: %s %p\n",
+         up_cpu_index(), filename, linenum, running_task()->name,
+         running_task()->entry.main);
 #  else
   _alert("Assertion failed CPU%d at file:%s line: %d\n",
          up_cpu_index(), filename, linenum);
 #  endif
 #else
 #  if CONFIG_TASK_NAME_SIZE > 0
-  _alert("Assertion failed at file:%s line: %d task: %s\n",
-         filename, linenum, running_task()->name);
+  _alert("Assertion failed at file:%s line: %d task: %s %p\n",
+         filename, linenum, running_task()->name,
+         running_task()->entry.main);
 #  else
   _alert("Assertion failed at file:%s line: %d\n",
          filename, linenum);

--- a/sched/pthread/pthread_create.c
+++ b/sched/pthread/pthread_create.c
@@ -26,7 +26,6 @@
 
 #include <sys/types.h>
 #include <stdbool.h>
-#include <stdio.h>
 #include <string.h>
 #include <pthread.h>
 #include <sched.h>
@@ -58,6 +57,16 @@
  */
 
 const pthread_attr_t g_default_pthread_attr = PTHREAD_ATTR_INITIALIZER;
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if CONFIG_TASK_NAME_SIZE > 0
+/* This is the name for name-less pthreads */
+
+static const char g_pthreadname[] = "<pthread>";
+#endif
 
 /****************************************************************************
  * Private Functions
@@ -92,8 +101,8 @@ static inline void pthread_tcb_setup(FAR struct pthread_tcb_s *ptcb,
 #if CONFIG_TASK_NAME_SIZE > 0
   /* Copy the pthread name into the TCB */
 
-  snprintf(ptcb->cmn.name, CONFIG_TASK_NAME_SIZE,
-           "pt-%p", ptcb->cmn.entry.pthread);
+  strncpy(ptcb->cmn.name, g_pthreadname, CONFIG_TASK_NAME_SIZE);
+  ptcb->cmn.name[CONFIG_TASK_NAME_SIZE] = '\0';
 #endif /* CONFIG_TASK_NAME_SIZE */
 
   /* For pthreads, args are strictly pass-by-value; that actual


### PR DESCRIPTION
## Summary

Because snprintf takes long time, so delay display pthread entry until the thread name needs to be displayed.

## Impact

pthread_create cost time:
before modify:
`24330`

after modify:
`22384`

## Testing
sabre-6quad:smp
