### PR TITLE
task_setup: set sigprocmask directly to improve performance

### DIFF
--- a/sched/task/task_setup.c
+++ b/sched/task/task_setup.c
@@ -370,6 +370,7 @@ static int nxthread_setup_scheduler(FAR struct tcb_s *tcb, int priority,
                                     start_t start, CODE void *entry,
                                     uint8_t ttype)
 {
+  FAR struct tcb_s *rtcb = this_task();
   int ret;
 
   /* Assign a unique task ID to the task. */
@@ -432,7 +433,7 @@ static int nxthread_setup_scheduler(FAR struct tcb_s *tcb, int priority,
        * inherit the signal mask of the parent thread.
        */
 
-      nxsig_procmask(SIG_SETMASK, NULL, &tcb->sigprocmask);
+      tcb->sigprocmask = rtcb->sigprocmask;
 
       /* Initialize the task state.  It does not get a valid state
        * until it is activated.


### PR DESCRIPTION
## Summary

Set sigprocmask directly to improve performance.

## Impact

pthread_create cost time:
before modify:
`22384`

after modify:
`20536`

## Testing

sabre-6quad:smp
