### PR TITLE
net/local: Support the abstract path 

### DIFF
--- a/net/local/local.h
+++ b/net/local/local.h
@@ -57,8 +57,7 @@
 
 enum local_type_e
 {
-  LOCAL_TYPE_UNTYPED = 0,      /* Type is not determined until the socket is bound */
-  LOCAL_TYPE_UNNAMED,          /* A Unix socket that is not bound to any name */
+  LOCAL_TYPE_UNNAMED = 0,      /* A Unix socket that is not bound to any name */
   LOCAL_TYPE_PATHNAME,         /* lc_path holds a null terminated string */
   LOCAL_TYPE_ABSTRACT          /* lc_path is length zero */
 };

--- a/net/local/local_bind.c
+++ b/net/local/local_bind.c
@@ -66,6 +66,7 @@ int psock_local_bind(FAR struct socket *psock,
   /* Save the address family */
 
   conn->lc_proto = psock->s_type;
+  conn->lc_instance_id = -1;
 
   /* Now determine the type of the Unix domain socket by comparing the size
    * of the address description.
@@ -75,8 +76,11 @@ int psock_local_bind(FAR struct socket *psock,
     {
       /* Zero-length sun_path... This is an abstract Unix domain socket */
 
-      conn->lc_type    = LOCAL_TYPE_ABSTRACT;
-      conn->lc_path[0] = '\0';
+      conn->lc_type = LOCAL_TYPE_ABSTRACT;
+
+      /* Copy the path into the connection structure */
+
+      strlcpy(conn->lc_path, &unaddr->sun_path[1], sizeof(conn->lc_path));
     }
   else
     {
@@ -87,7 +91,6 @@ int psock_local_bind(FAR struct socket *psock,
       /* Copy the path into the connection structure */
 
       strlcpy(conn->lc_path, unaddr->sun_path, sizeof(conn->lc_path));
-      conn->lc_instance_id = -1;
     }
 
   conn->lc_state = LOCAL_STATE_BOUND;

--- a/net/local/local_connect.c
+++ b/net/local/local_connect.c
@@ -266,6 +266,8 @@ int psock_local_connect(FAR struct socket *psock,
       switch (conn->lc_type)
         {
         case LOCAL_TYPE_UNNAMED:   /* A Unix socket that is not bound to any name */
+          break;
+
         case LOCAL_TYPE_ABSTRACT:  /* lc_path is length zero */
           {
 #warning Missing logic
@@ -314,14 +316,10 @@ int psock_local_connect(FAR struct socket *psock,
           }
           break;
 
-        default:                 /* Bad, memory must be corrupted */
-          DEBUGPANIC();          /* PANIC if debug on, else fall through */
-
-        case LOCAL_TYPE_UNTYPED: /* Type is not determined until the socket is bound */
-          {
-            net_unlock();
-            return -EINVAL;
-          }
+        default:        /* Bad, memory must be corrupted */
+          DEBUGPANIC(); /* PANIC if debug on */
+          net_unlock();
+          return -EINVAL;
         }
     }
 

--- a/net/local/local_recvutils.c
+++ b/net/local/local_recvutils.c
@@ -175,7 +175,7 @@ int local_getaddr(FAR struct local_conn_s *conn, FAR struct sockaddr *addr,
   int totlen;
   int pathlen;
 
-  DEBUGASSERT(conn && addr && addrlen && *addrlen >= sizeof(sa_family_t));
+  DEBUGASSERT(conn && addr && addrlen);
 
   /* Get the length of the path (minus the NUL terminator) and the length
    * of the whole Unix domain address.

--- a/net/local/local_sockif.c
+++ b/net/local/local_sockif.c
@@ -379,15 +379,16 @@ static int local_getsockname(FAR struct socket *psock,
 
           *addrlen = sizeof(sa_family_t);
         }
-      else /* conn->lctype = LOCAL_TYPE_PATHNAME */
+      else /* conn->lc_type = LOCAL_TYPE_PATHNAME */
         {
           /* Get the full length of the socket name (incl. null terminator) */
 
-          int namelen = strlen(conn->lc_path) + 1;
+          size_t namelen = strlen(conn->lc_path) + 1 +
+                           (conn->lc_type == LOCAL_TYPE_ABSTRACT);
 
           /* Get the available length in the user-provided buffer. */
 
-          int pathlen = *addrlen - sizeof(sa_family_t);
+          size_t pathlen = *addrlen - sizeof(sa_family_t);
 
           /* Clip the socket name size so that if fits in the user buffer */
 
@@ -398,8 +399,15 @@ static int local_getsockname(FAR struct socket *psock,
 
           /* Copy the path into the user address structure */
 
-          strlcpy(unaddr->sun_path, conn->lc_path, namelen);
-          unaddr->sun_path[pathlen - 1] = '\0';
+          if (conn->lc_type == LOCAL_TYPE_ABSTRACT)
+            {
+              unaddr->sun_path[0] = '\0';
+              strlcpy(&unaddr->sun_path[1], conn->lc_path, namelen - 1);
+            }
+          else
+            {
+              strlcpy(unaddr->sun_path, conn->lc_path, namelen);
+            }
 
           *addrlen = sizeof(sa_family_t) + namelen;
         }

--- a/net/local/local_sockif.c
+++ b/net/local/local_sockif.c
@@ -354,8 +354,7 @@ static int local_getsockname(FAR struct socket *psock,
   FAR struct local_conn_s *conn;
 
   DEBUGASSERT(psock != NULL && psock->s_conn != NULL &&
-              unaddr != NULL && addrlen != NULL &&
-              *addrlen >= sizeof(sa_family_t));
+              unaddr != NULL && addrlen != NULL);
 
   if (*addrlen < sizeof(sa_family_t))
     {


### PR DESCRIPTION
## Summary
And other minor change:

- net/local: Return -EINVAL if the address length passed to local_bind is too small
- net/local: Remove LOCAL_TYPE_UNTYPED

## Impact
local socket, new functionality

## Testing
Pass CI
