### PR TITLE
net/tcp: contig received data to reducing iob consumption

### DIFF
--- a/Documentation/reference/os/iob.rst
+++ b/Documentation/reference/os/iob.rst
@@ -318,11 +318,9 @@ Public Function Prototypes
   data offset is zero and all but the final buffer in the chain are
   filled. Any emptied buffers at the end of the chain are freed.
 
-.. c:function:: int iob_contig(FAR struct iob_s *iob, unsigned int len);
+.. c:function:: FAR struct iob_s *iob_contig(FAR struct iob_s *iob);
 
-  Ensure that there is ``len`` bytes of contiguous
-  space at the beginning of the I/O buffer chain starting at
-  ``iob``.
+  Merge an ``iob`` chain into a continuous space, thereby reducing ``iob`` consumption
 
 .. c:function:: void iob_dump(FAR const char *msg, FAR struct iob_s *iob, unsigned int len, \
                  unsigned int offset);

--- a/include/nuttx/mm/iob.h
+++ b/include/nuttx/mm/iob.h
@@ -562,12 +562,12 @@ FAR struct iob_s *iob_pack(FAR struct iob_s *iob);
  * Name: iob_contig
  *
  * Description:
- *   Ensure that there is 'len' bytes of contiguous space at the beginning
- *   of the I/O buffer chain starting at 'iob'.
+ *   Merge an iob chain into a continuous space, thereby reducing iob
+ *   consumption
  *
  ****************************************************************************/
 
-int iob_contig(FAR struct iob_s *iob, unsigned int len);
+FAR struct iob_s *iob_contig(FAR struct iob_s *iob);
 
 /****************************************************************************
  * Name: iob_reserve

--- a/net/tcp/Kconfig
+++ b/net/tcp/Kconfig
@@ -194,6 +194,20 @@ config NET_TCP_WRBUFFER_DUMP
 
 endif # NET_TCP_WRITE_BUFFERS
 
+config NET_TCP_RECV_CONTIG
+	bool "Enable TCP/IP receive data in a continuous poll"
+	default y
+	---help---
+		This option will enable TCP/IP receive data into a continuous iob chain.
+		Fragmentation of network data will intensify iob consumption, if
+		the device receives a message storm of fragmented packets, the iob
+		cache will not be effectively used, this is not allowed on iot devices
+		since the resources of such devices are limited. Of course, this
+		also takes some disadvantages: data needs to be copied.
+		This option will brings some balance on resource-constrained devices,
+		enable this config to reduce the consumption of iob, the received iob
+		buffers will be merged into the contiguous iob chain.
+
 config NET_TCPBACKLOG
 	bool "TCP/IP backlog support"
 	default n

--- a/net/tcp/tcp_callback.c
+++ b/net/tcp/tcp_callback.c
@@ -258,6 +258,14 @@ uint16_t tcp_datahandler(FAR struct net_driver_s *dev,
       iob_concat(conn->readahead, iob);
     }
 
+#ifdef CONFIG_NET_TCP_RECV_CONTIG
+  /* Merge an iob chain into a continuous space, thereby reducing iob
+   * consumption.
+   */
+
+  conn->readahead = iob_contig(conn->readahead);
+#endif
+
   netdev_iob_clear(dev);
 
 #ifdef CONFIG_NET_TCP_NOTIFIER


### PR DESCRIPTION
## Summary

1. net/tcp: contig received data to reducing iob consumption

Fragmentation of network data will intensify iob consumption, if
the device receives a message storm of fragmented packets, the iob
cache will not be effectively used, this is not allowed on iot devices
since the resources of such devices are limited. Of course, this
also takes some disadvantages: data needs to be copied.
This option will brings some balance on resource-constrained devices,
enable this config to reduce the consumption of iob, the received iob
buffers will be merged into the contiguous iob chain.

2. mm/iob/contig: enhance iob contig to support iob chain


Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

tcp server