### PR TITLE
net/tcp: rename NET_TCP_RECV_CONTIG to NET_TCP_RECV_PACK

### DIFF
--- a/Documentation/reference/os/iob.rst
+++ b/Documentation/reference/os/iob.rst
@@ -318,9 +318,11 @@ Public Function Prototypes
   data offset is zero and all but the final buffer in the chain are
   filled. Any emptied buffers at the end of the chain are freed.
 
-.. c:function:: FAR struct iob_s *iob_contig(FAR struct iob_s *iob);
+.. c:function:: int iob_contig(FAR struct iob_s *iob, unsigned int len);
 
-  Merge an ``iob`` chain into a continuous space, thereby reducing ``iob`` consumption
+  Ensure that there is ``len`` bytes of contiguous
+  space at the beginning of the I/O buffer chain starting at
+  ``iob``.
 
 .. c:function:: void iob_dump(FAR const char *msg, FAR struct iob_s *iob, unsigned int len, \
                  unsigned int offset);

--- a/include/nuttx/mm/iob.h
+++ b/include/nuttx/mm/iob.h
@@ -562,12 +562,12 @@ FAR struct iob_s *iob_pack(FAR struct iob_s *iob);
  * Name: iob_contig
  *
  * Description:
- *   Merge an iob chain into a continuous space, thereby reducing iob
- *   consumption
+ *   Ensure that there is 'len' bytes of contiguous space at the beginning
+ *   of the I/O buffer chain starting at 'iob'.
  *
  ****************************************************************************/
 
-FAR struct iob_s *iob_contig(FAR struct iob_s *iob);
+int iob_contig(FAR struct iob_s *iob, unsigned int len);
 
 /****************************************************************************
  * Name: iob_reserve

--- a/net/tcp/Kconfig
+++ b/net/tcp/Kconfig
@@ -194,7 +194,7 @@ config NET_TCP_WRBUFFER_DUMP
 
 endif # NET_TCP_WRITE_BUFFERS
 
-config NET_TCP_RECV_CONTIG
+config NET_TCP_RECV_PACK
 	bool "Enable TCP/IP receive data in a continuous poll"
 	default y
 	---help---

--- a/net/tcp/tcp_callback.c
+++ b/net/tcp/tcp_callback.c
@@ -258,12 +258,12 @@ uint16_t tcp_datahandler(FAR struct net_driver_s *dev,
       iob_concat(conn->readahead, iob);
     }
 
-#ifdef CONFIG_NET_TCP_RECV_CONTIG
+#ifdef CONFIG_NET_TCP_RECV_PACK
   /* Merge an iob chain into a continuous space, thereby reducing iob
    * consumption.
    */
 
-  conn->readahead = iob_contig(conn->readahead);
+  conn->readahead = iob_pack(conn->readahead);
 #endif
 
   netdev_iob_clear(dev);


### PR DESCRIPTION
## Summary

1. net/tcp: rename NET_TCP_RECV_CONTIG to NET_TCP_RECV_PACK

2. Revert "mm/iob/contig: enhance iob contig to support iob chain"

use iob_pack instead of iob_contig

## Impact

N/A

## Testing

iperf test