### PR TITLE
mm/iob: revert "modify iob to support header padding and alignment features"

### DIFF
--- a/include/nuttx/mm/iob.h
+++ b/include/nuttx/mm/iob.h
@@ -76,16 +76,6 @@
 #  define CONFIG_IOB_ALIGNMENT      1
 #endif
 
-#if !defined(CONFIG_IOB_HEADSIZE)
-#  define CONFIG_IOB_HEADSIZE       0
-#endif
-
-/* For backward compatibility when not using iob header padding */
-
-#if CONFIG_IOB_HEADSIZE == 0
-#  define  io_head  io_data
-#endif
-
 /* IOB helpers */
 
 #define IOB_DATA(p)      (&(p)->io_data[(p)->io_offset])
@@ -124,10 +114,7 @@ struct iob_s
 #endif
   unsigned int io_pktlen; /* Total length of the packet */
 
-#if CONFIG_IOB_HEADSIZE > 0
-  uint8_t  io_head[CONFIG_IOB_HEADSIZE];
-#endif
-  uint8_t  io_data[CONFIG_IOB_BUFSIZE] aligned_data(CONFIG_IOB_ALIGNMENT);
+  uint8_t  io_data[CONFIG_IOB_BUFSIZE];
 };
 
 #if CONFIG_IOB_NCHAINS > 0

--- a/mm/iob/Kconfig
+++ b/mm/iob/Kconfig
@@ -32,18 +32,11 @@ config IOB_BUFSIZE
 		chain.  This setting determines the data payload each preallocated
 		I/O buffer.
 
-config IOB_HEADSIZE
-	int "Head size of each I/O buffer"
-	default 0
-	---help---
-		This setting determines the reserved size in front of the payload
-		buffer in each I/O buffer.
-
 config IOB_ALIGNMENT
 	int "Alignment size of each I/O buffer"
 	default 4
 	---help---
-		The member io_head of all I/O buffers is aligned to the value
+		The member io_data of all I/O buffers is aligned to the value
 		specified by this configuration.
 
 config IOB_SECTION

--- a/mm/iob/iob_initialize.c
+++ b/mm/iob/iob_initialize.c
@@ -47,7 +47,7 @@
  ****************************************************************************/
 
 /* Following raw buffer will be divided into iob_s instances, the initial
- * procedure will ensure that the member io_head of each iob_s is aligned
+ * procedure will ensure that the member io_data of each iob_s is aligned
  * to the CONFIG_IOB_ALIGNMENT memory boundary.
  */
 
@@ -119,12 +119,12 @@ void iob_initialize(void)
   int i;
   uintptr_t buf;
 
-  /* Get a start address which plus offsetof(struct iob_s, io_head) is
+  /* Get a start address which plus offsetof(struct iob_s, io_data) is
    * aligned to the CONFIG_IOB_ALIGNMENT memory boundary
    */
 
-  buf = ROUNDUP((uintptr_t)g_iob_buffer + offsetof(struct iob_s, io_head),
-                CONFIG_IOB_ALIGNMENT) - offsetof(struct iob_s, io_head);
+  buf = ROUNDUP((uintptr_t)g_iob_buffer + offsetof(struct iob_s, io_data),
+                CONFIG_IOB_ALIGNMENT) - offsetof(struct iob_s, io_data);
 
   /* Get I/O buffer instance from the start address and add each I/O buffer
    * to the free list
@@ -141,7 +141,7 @@ void iob_initialize(void)
     }
 
 #if CONFIG_IOB_NCHAINS > 0
-      /* Add each I/O buffer chain queue container to the free list */
+  /* Add each I/O buffer chain queue container to the free list */
 
   for (i = 0; i < CONFIG_IOB_NCHAINS; i++)
     {


### PR DESCRIPTION
## Summary
1. mm/iob: decoupling iob_s and io_data

2. mm/iob: revert "modify iob to support header padding and alignment features"

we don't need to implement l2 isolation through io_head, iob offload will use io_offset

```
-------------------------------------------------------------
Layout of different NICs implementation:

        iob_data (aligned by CONFIG_IOB_ALIGNMENT)
            |
            |                 io_offset(CONFIG_NET_LL_GUARDSIZE)
            |                                |
            -------------------------------------------------
 Ethernet   |       Reserved    | ETH_HDRLEN |    io_len    |
            ---------------------------------|---------------
 8021Q      |   Reserved  | ETH_8021Q_HDRLEN |    io_len    |
            ---------------------------------|---------------
 ipforward  |            Reserved            |    io_len    |
            -------------------------------------------------

--------------------------------------------------------------------
```

Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

iperf test