### PR TITLE
procmeminfo:support memdump can show specific task

### DIFF
--- a/fs/procfs/fs_procfsmeminfo.c
+++ b/fs/procfs/fs_procfsmeminfo.c
@@ -40,6 +40,7 @@
 #include <nuttx/kmalloc.h>
 #include <nuttx/pgalloc.h>
 #include <nuttx/progmem.h>
+#include <nuttx/sched.h>
 #include <nuttx/mm/mm.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/fs/procfs.h>
@@ -452,6 +453,10 @@ static ssize_t memdump_write(FAR struct file *filep, FAR const char *buffer,
   FAR struct procfs_meminfo_entry_s *entry;
   FAR struct meminfo_file_s *procfile;
   pid_t pid = INVALID_PROCESS_ID;
+#if CONFIG_MM_BACKTRACE > 0
+  FAR struct tcb_s *tcb;
+  FAR char *p;
+#endif
 
   DEBUGASSERT(filep != NULL && buffer != NULL && buflen > 0);
 
@@ -477,6 +482,32 @@ static ssize_t memdump_write(FAR struct file *filep, FAR const char *buffer,
           entry->backtrace = false;
         }
 
+      return buflen;
+    }
+  else if ((p = strstr(buffer, "on")) != NULL)
+    {
+      *p = '\0';
+      pid = atoi(buffer);
+      tcb = nxsched_get_tcb(pid);
+      if (tcb == NULL)
+        {
+          return -EINVAL;
+        }
+
+      tcb->flags |= TCB_FLAG_HEAP_DUMP;
+      return buflen;
+    }
+  else if ((p = strstr(buffer, "off")) != NULL)
+    {
+      *p = '\0';
+      pid = atoi(buffer);
+      tcb = nxsched_get_tcb(pid);
+      if (tcb == NULL)
+        {
+          return -EINVAL;
+        }
+
+      tcb->flags &= ~TCB_FLAG_HEAP_DUMP;
       return buflen;
     }
 #endif

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -102,7 +102,8 @@
 #define TCB_FLAG_EXIT_PROCESSING   (1 << 11)                     /* Bit 10: Exitting */
 #define TCB_FLAG_FREE_STACK        (1 << 12)                     /* Bit 12: Free stack after exit */
 #define TCB_FLAG_HEAP_CHECK        (1 << 13)                     /* Bit 13: Heap check */
-                                                                 /* Bits 14-15: Available */
+#define TCB_FLAG_HEAP_DUMP         (1 << 14)                     /* Bit 14: Heap dump */
+                                                                 /* Bits 15: Available */
 
 /* Values for struct task_group tg_flags */
 

--- a/mm/mm_heap/mm.h
+++ b/mm/mm_heap/mm.h
@@ -28,6 +28,7 @@
 #include <nuttx/config.h>
 
 #include <nuttx/mutex.h>
+#include <nuttx/sched.h>
 #include <nuttx/fs/procfs.h>
 #include <nuttx/lib/math32.h>
 
@@ -82,8 +83,10 @@
        { \
          FAR struct mm_allocnode_s *tmp = (FAR struct mm_allocnode_s *)(ptr); \
          kasan_unpoison(tmp, SIZEOF_MM_ALLOCNODE); \
+         FAR strcut tcb_s *tcb; \
          tmp->pid = gettid(); \
-         if ((heap)->mm_procfs.backtrace) \
+         tcb = nxsched_get_tcb(tmp->pid); \
+         if ((heap)->mm_procfs.backtrace || (tcb && tcb->flags & TCB_FLAG_HEAP_DUMP)) \
            { \
              memset(tmp->backtrace, 0, sizeof(tmp->backtrace)); \
              backtrace(tmp->backtrace, CONFIG_MM_BACKTRACE); \


### PR DESCRIPTION
Signed-off-by: anjiahao <anjiahao@xiaomi.com>

## Summary
support memdump can show a specific task
## Impact
mem
## Testing
dialy run
