### PR TITLE
video/fb: initializes the info structure

### DIFF
--- a/drivers/video/fb.c
+++ b/drivers/video/fb.c
@@ -388,6 +388,7 @@ static int fb_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
           DEBUGASSERT(fb->vtable != NULL &&
                       fb->vtable->getoverlayinfo != NULL);
+          memset(&oinfo, 0, sizeof(oinfo));
           ret = fb->vtable->getoverlayinfo(fb->vtable, arg, &oinfo);
           if (ret == OK)
             {
@@ -555,6 +556,7 @@ static int fb_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
               break;
             }
 
+          memset(&pinfo, 0, sizeof(pinfo));
           ret = fb->vtable->getplaneinfo(fb->vtable, fb->plane, &pinfo);
           if (ret < 0)
             {
@@ -648,6 +650,7 @@ static int fb_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
               break;
             }
 
+          memset(&pinfo, 0, sizeof(pinfo));
           ret = fb->vtable->getplaneinfo(fb->vtable, fb->plane, &pinfo);
           if (ret < 0)
             {
@@ -826,6 +829,7 @@ int fb_register(int display, int plane)
   DEBUGASSERT(vinfo.nplanes > 0 && (unsigned)plane < vinfo.nplanes);
 
   DEBUGASSERT(fb->vtable->getplaneinfo != NULL);
+  memset(&pinfo, 0, sizeof(pinfo));
   ret = fb->vtable->getplaneinfo(fb->vtable, plane, &pinfo);
   if (ret < 0)
     {
@@ -845,6 +849,7 @@ int fb_register(int display, int plane)
   /* Initialize first overlay but do not select */
 
   DEBUGASSERT(fb->vtable->getoverlayinfo != NULL);
+  memset(&oinfo, 0, sizeof(oinfo));
   ret = fb->vtable->getoverlayinfo(fb->vtable, 0, &oinfo);
   if (ret < 0)
     {


### PR DESCRIPTION
## Summary
Users can obtain the parameters of the specified display and overlay by setting the `display` member in `fb_planeinfo_s` or the `overlay` member in `fb_overlayinfo_s`.
For the default value, it should be set to 0.

## Impact
Applications using framebuffer devices.

## Testing
Daliy test.