### PR TITLE
s32k3xx:EDMA fix get count

### DIFF
--- a/arch/arm/src/s32k3xx/s32k3xx_edma.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_edma.c
@@ -1479,12 +1479,13 @@ unsigned int s32k3xx_dmach_getcount(DMACH_HANDLE *handle)
 
       if ((regval16 & EDMA_TCD_CITER_ELINK) != 0)
         {
-          remaining = (regval16 & EDMA_TCD_CITER_MASK) >>
+          remaining = (regval16 & EDMA_TCD_CITER_MASK_ELINK) >>
                       EDMA_TCD_CITER_SHIFT;
         }
       else
         {
-          remaining = 1;
+          remaining = (regval16 & EDMA_TCD_CITER_MASK) >>
+                       EDMA_TCD_CITER_SHIFT;
         }
     }
 


### PR DESCRIPTION
## Summary

The code was wrong, It used a constant of 1.

## Impact

RX DMA did not work on serial;

## Testing

PX4  nxp_mr-canhubk3_fmu
