### PR TITLE
sim: remove unused variale in sim_saveusercontext()

### DIFF
--- a/arch/sim/src/sim/sim_internal.h
+++ b/arch/sim/src/sim/sim_internal.h
@@ -89,13 +89,11 @@
     ({                                                          \
        irqstate_t flags = up_irq_flags();                       \
        uint32_t *env = (uint32_t *)saveregs + JB_FLAG;          \
-       int ret;                                                 \
                                                                 \
        env[0] = flags & UINT32_MAX;                             \
        env[1] = (flags >> 32) & UINT32_MAX;                     \
                                                                 \
-       ret = setjmp(saveregs);                                  \
-       ret;                                                     \
+       setjmp(saveregs);                                        \
     })
 #define sim_fullcontextrestore(restoreregs)                     \
     do                                                          \


### PR DESCRIPTION


## Summary

sim: remove unused variable in sim_saveusercontext()

fix comment in:
https://github.com/apache/nuttx/pull/7928

## Impact



## Testing

