### PR TITLE
fs/streams: Flush streams in userspace when the process exits

### DIFF
--- a/boards/arm/lpc17xx_40xx/pnev5180b/src/lpc17_40_symtab.c
+++ b/boards/arm/lpc17xx_40xx/pnev5180b/src/lpc17_40_symtab.c
@@ -45,7 +45,7 @@ extern void *pthread_mutex_init;
 extern void *pthread_mutex_lock;
 extern void *pthread_mutex_unlock;
 extern void *puts;
-extern void *nxsched_get_streams;
+extern void *lib_get_streams;
 extern void *sem_destroy;
 extern void *sem_init;
 extern void *sem_post;
@@ -76,7 +76,7 @@ const struct symtab_s lpc17_40_exports[] =
   {"pthread_mutex_lock", &pthread_mutex_lock},
   {"pthread_mutex_unlock", &pthread_mutex_unlock},
   {"puts", &puts},
-  {"nxsched_get_streams", &nxsched_get_streams},
+  {"lib_get_streams", &lib_get_streams},
   {"sem_destroy", &sem_destroy},
   {"sem_init", &sem_init},
   {"sem_post", &sem_post},

--- a/fs/vfs/fs_fdopen.c
+++ b/fs/vfs/fs_fdopen.c
@@ -34,6 +34,7 @@
 #include <nuttx/semaphore.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/lib/lib.h>
+#include <nuttx/tls.h>
 
 #include "inode/inode.h"
 
@@ -153,11 +154,7 @@ int fs_fdopen(int fd, int oflags, FAR struct tcb_s *tcb,
 
   /* Get the stream list from the TCB */
 
-#ifdef CONFIG_MM_KERNEL_HEAP
-  slist = tcb->group->tg_streamlist;
-#else
-  slist = &tcb->group->tg_streamlist;
-#endif
+  slist = &tcb->group->tg_info->ta_streamlist;
 
   /* Allocate FILE structure */
 

--- a/include/nuttx/lib/lib.h
+++ b/include/nuttx/lib/lib.h
@@ -107,7 +107,12 @@ extern "C"
 struct task_group_s;
 void lib_stream_initialize(FAR struct task_group_s *group);
 void lib_stream_release(FAR struct task_group_s *group);
-#endif
+
+/* Functions contained in lib_getstreams.c **********************************/
+
+struct streamlist;
+FAR struct streamlist *lib_get_streams(void);
+#endif /* CONFIG_FILE_STREAM */
 
 /* Functions defined in lib_srand.c *****************************************/
 

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -495,21 +495,6 @@ struct task_group_s
 
   struct filelist tg_filelist;      /* Maps file descriptor to file         */
 
-#ifdef CONFIG_FILE_STREAM
-  /* FILE streams ***********************************************************/
-
-  /* In a flat, single-heap build.  The stream list is allocated with this
-   * structure.  But kernel mode with a kernel allocator,
-  * it must be separately allocated using a user-space allocator.
-   */
-
-#ifdef CONFIG_MM_KERNEL_HEAP
-  FAR struct streamlist *tg_streamlist;
-#else
-  struct streamlist tg_streamlist;  /* Holds C buffered I/O info            */
-#endif
-#endif
-
 #ifdef CONFIG_ARCH_ADDRENV
   /* Address Environment ****************************************************/
 
@@ -841,9 +826,6 @@ int nxsched_release_tcb(FAR struct tcb_s *tcb, uint8_t ttype);
  */
 
 FAR struct filelist *nxsched_get_files(void);
-#ifdef CONFIG_FILE_STREAM
-FAR struct streamlist *nxsched_get_streams(void);
-#endif /* CONFIG_FILE_STREAM */
 
 /****************************************************************************
  * Name: nxtask_init

--- a/include/nuttx/tls.h
+++ b/include/nuttx/tls.h
@@ -29,6 +29,7 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/atexit.h>
+#include <nuttx/fs/fs.h>
 
 #include <sys/types.h>
 #include <pthread.h>
@@ -145,6 +146,9 @@ struct task_info_s
 #endif
 #if CONFIG_LIBC_MAX_EXITFUNS > 0
   struct atexit_list_s ta_exit; /* Exit functions */
+#endif
+#ifdef CONFIG_FILE_STREAM
+  struct streamlist ta_streamlist; /* Holds C buffered I/O info */
 #endif
 };
 

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -32,7 +32,7 @@
 #include <time.h>
 
 #include <nuttx/fs/fs.h>
-#include <nuttx/sched.h>
+#include <nuttx/lib/lib.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -63,9 +63,9 @@
 
 /* The first three _iob entries are reserved for standard I/O */
 
-#define stdin      (&nxsched_get_streams()->sl_std[0])
-#define stdout     (&nxsched_get_streams()->sl_std[1])
-#define stderr     (&nxsched_get_streams()->sl_std[2])
+#define stdin      (&lib_get_streams()->sl_std[0])
+#define stdout     (&lib_get_streams()->sl_std[1])
+#define stderr     (&lib_get_streams()->sl_std[2])
 
 /* Path to the directory where temporary files can be created */
 

--- a/include/sys/syscall_lookup.h
+++ b/include/sys/syscall_lookup.h
@@ -268,7 +268,6 @@ SYSCALL_LOOKUP(futimens,                   2)
 
 #ifdef CONFIG_FILE_STREAM
   SYSCALL_LOOKUP(fs_fdopen,                4)
-  SYSCALL_LOOKUP(nxsched_get_streams,      0)
 #endif
 
 #ifndef CONFIG_DISABLE_MOUNTPOINT

--- a/libs/libc/stdio/Make.defs
+++ b/libs/libc/stdio/Make.defs
@@ -45,6 +45,7 @@ CSRCS += lib_fputs.c lib_ungetc.c lib_fprintf.c lib_vfprintf.c
 CSRCS += lib_feof.c lib_ferror.c lib_rewind.c lib_clearerr.c
 CSRCS += lib_scanf.c lib_vscanf.c lib_fscanf.c lib_vfscanf.c lib_tmpfile.c
 CSRCS += lib_setbuf.c lib_setvbuf.c lib_libstream.c lib_libfilelock.c
+CSRCS += lib_libgetstreams.c
 endif
 
 # Add the stdio directory to the build

--- a/libs/libc/stdio/lib_fclose.c
+++ b/libs/libc/stdio/lib_fclose.c
@@ -84,7 +84,7 @@ int fclose(FAR FILE *stream)
 
       /* Remove FILE structure from the stream list */
 
-      slist = nxsched_get_streams();
+      slist = lib_get_streams();
       nxmutex_lock(&slist->sl_lock);
 
       for (next = slist->sl_head; next; prev = next, next = next->fs_next)

--- a/libs/libc/stdio/lib_fflush.c
+++ b/libs/libc/stdio/lib_fflush.c
@@ -62,7 +62,7 @@ int fflush(FAR FILE *stream)
     {
       /* Yes... then this is a request to flush all streams */
 
-      ret = lib_flushall(nxsched_get_streams());
+      ret = lib_flushall(lib_get_streams());
     }
   else
     {

--- a/libs/libc/stdio/lib_libgetstreams.c
+++ b/libs/libc/stdio/lib_libgetstreams.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * sched/sched/sched_getstreams.c
+ * libs/libc/stdio/lib_libgetstreams.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -23,10 +23,9 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
-#include <sched.h>
 #include <assert.h>
 
-#include "sched/sched.h"
+#include <nuttx/tls.h>
 
 #ifdef CONFIG_FILE_STREAM
 
@@ -35,7 +34,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: nxsched_get_streams
+ * Name: lib_get_streams
  *
  * Description:
  *   Return a pointer to the streams list for this thread
@@ -50,18 +49,12 @@
  *
  ****************************************************************************/
 
-FAR struct streamlist *nxsched_get_streams(void)
+FAR struct streamlist *lib_get_streams(void)
 {
-  FAR struct tcb_s *rtcb = this_task();
-  FAR struct task_group_s *group = rtcb->group;
+  FAR struct task_info_s *info;
 
-  DEBUGASSERT(group);
-
-#ifdef CONFIG_MM_KERNEL_HEAP
-  return group->tg_streamlist;
-#else
-  return &group->tg_streamlist;
-#endif
+  info = task_get_info();
+  return &info->ta_streamlist;
 }
 
 #endif /* CONFIG_FILE_STREAM */

--- a/libs/libc/stdio/lib_libstream.c
+++ b/libs/libc/stdio/lib_libstream.c
@@ -34,6 +34,7 @@
 #include <nuttx/sched.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/lib/lib.h>
+#include <nuttx/tls.h>
 
 #include "libc.h"
 
@@ -56,13 +57,8 @@ void lib_stream_initialize(FAR struct task_group_s *group)
 {
   FAR struct streamlist *list;
 
-#ifdef CONFIG_MM_KERNEL_HEAP
-  DEBUGASSERT(group && group->tg_streamlist);
-  list = group->tg_streamlist;
-#else
-  DEBUGASSERT(group);
-  list = &group->tg_streamlist;
-#endif
+  DEBUGASSERT(group && group->tg_info);
+  list = &group->tg_info->ta_streamlist;
 
   /* Initialize the list access mutex */
 
@@ -94,13 +90,8 @@ void lib_stream_release(FAR struct task_group_s *group)
 {
   FAR struct streamlist *list;
 
-#ifdef CONFIG_MM_KERNEL_HEAP
-  DEBUGASSERT(group && group->tg_streamlist);
-  list = group->tg_streamlist;
-#else
-  DEBUGASSERT(group);
-  list = &group->tg_streamlist;
-#endif
+  DEBUGASSERT(group && group->tg_info);
+  list = &group->tg_info->ta_streamlist;
 
   /* Destroy the mutex and release the filelist */
 

--- a/libs/libc/stdlib/lib_exit.c
+++ b/libs/libc/stdlib/lib_exit.c
@@ -27,6 +27,7 @@
 #include <nuttx/atexit.h>
 #include <nuttx/compiler.h>
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 
@@ -47,9 +48,15 @@ FAR void *__dso_handle = &__dso_handle;
 
 void exit(int status)
 {
+  /* Run the registered exit functions */
+
   atexit_call_exitfuncs(status);
 
-  /* REVISIT: Need to flush files and streams */
+  /* Flush all streams */
+
+  fflush(NULL);
+
+  /* Then perform the exit */
 
   _exit(status);
 }

--- a/sched/group/group_leave.c
+++ b/sched/group/group_leave.c
@@ -33,6 +33,7 @@
 #include <nuttx/fs/fs.h>
 #include <nuttx/net/net.h>
 #include <nuttx/lib/lib.h>
+#include <nuttx/sched.h>
 
 #ifdef CONFIG_BINFMT_LOADABLE
 #  include <nuttx/binfmt/binfmt.h>

--- a/sched/group/group_leave.c
+++ b/sched/group/group_leave.c
@@ -197,33 +197,6 @@ static inline void group_release(FAR struct task_group_s *group)
     }
 #endif
 
-#if defined(CONFIG_FILE_STREAM) && defined(CONFIG_MM_KERNEL_HEAP)
-  /* In a flat, single-heap build.  The stream list is part of the
-   * group structure and, hence will be freed when the group structure
-   * is freed.  Otherwise, it is separately allocated an must be
-   * freed here.
-   */
-
-#  ifdef CONFIG_BUILD_KERNEL
-  /* In the kernel build, the unprivileged process's stream list will be
-   * allocated from with its per-process, private user heap. But in that
-   * case, there is no reason to do anything here:  That allocation resides
-   * in the user heap which which be completely freed when we destroy the
-   * process's address environment.
-   */
-
-  if ((group->tg_flags & GROUP_FLAG_PRIVILEGED) != 0)
-#  endif
-    {
-      /* But kernel threads are different in this build configuration: Their
-       * stream lists were allocated from the common, global kernel heap and
-       * must explicitly freed here.
-       */
-
-      group_free(group, group->tg_streamlist);
-    }
-#endif
-
 #ifdef CONFIG_BINFMT_LOADABLE
   /* If the exiting task was loaded into RAM from a file, then we need to
    * lease all of the memory resource when the last thread exits the task

--- a/sched/pthread/pthread_cancel.c
+++ b/sched/pthread/pthread_cancel.c
@@ -100,5 +100,5 @@ int pthread_cancel(pthread_t thread)
 
   /* Then let nxtask_terminate do the real work */
 
-  return nxtask_terminate((pid_t)thread, false);
+  return nxtask_terminate((pid_t)thread);
 }

--- a/sched/pthread/pthread_exit.c
+++ b/sched/pthread/pthread_exit.c
@@ -90,17 +90,18 @@ void nx_pthread_exit(FAR void *exit_value)
     }
 
   /* Perform common task termination logic.  This will get called again later
-   * through logic kicked off by _exit().  However, we need to call it before
-   * calling _exit() in order certain operations if this is the last thread
-   * of a task group:  (2) To handle atexit() and on_exit() callbacks and
-   * (2) so that we can flush buffered I/O (which may required suspending).
+   * through logic kicked off by up_exit().
+   *
+   * REVISIT: Tt should not be necessary to call this here, but releasing the
+   * task group (especially the group file list) requires that it is done
+   * here.
+   *
+   * The reason? up_exit removes the current process from the ready-to-run
+   * list and trying to execute code that depends on this_task() crashes at
+   * once, or does something very naughty.
    */
 
-  nxtask_exithook(tcb, EXIT_SUCCESS, false);
-
-  /* Then just exit, retaining all file descriptors and without
-   * calling atexit() functions.
-   */
+  nxtask_exithook(tcb, status);
 
   up_exit(EXIT_SUCCESS);
 }

--- a/sched/sched/Make.defs
+++ b/sched/sched/Make.defs
@@ -23,7 +23,6 @@ CSRCS += sched_addreadytorun.c sched_removereadytorun.c
 CSRCS += sched_addprioritized.c sched_mergeprioritized.c sched_mergepending.c
 CSRCS += sched_addblocked.c sched_removeblocked.c
 CSRCS += sched_gettcb.c sched_verifytcb.c sched_releasetcb.c
-CSRCS += sched_getstreams.c
 CSRCS += sched_setparam.c sched_setpriority.c sched_getparam.c
 CSRCS += sched_setscheduler.c sched_getscheduler.c
 CSRCS += sched_yield.c sched_rrgetinterval.c sched_foreach.c

--- a/sched/task/exit.c
+++ b/sched/task/exit.c
@@ -68,12 +68,18 @@ void _exit(int status)
 #endif
 
   /* Perform common task termination logic.  This will get called again later
-   * through logic kicked off by up_exit().  However, we need to call it here
-   * so that we can flush buffered I/O (both of which may required
-   * suspending). This will be fixed later when I/O flush is moved to libc.
+   * through logic kicked off by up_exit().
+   *
+   * REVISIT: Tt should not be necessary to call this here, but releasing the
+   * task group (especially the group file list) requires that it is done
+   * here.
+   *
+   * The reason? up_exit removes the current process from the ready-to-run
+   * list and trying to execute code that depends on this_task() crashes at
+   * once, or does something very naughty.
    */
 
-  nxtask_exithook(tcb, status, false);
+  nxtask_exithook(tcb, status);
 
   up_exit(status);
 }

--- a/sched/task/task.h
+++ b/sched/task/task.h
@@ -50,8 +50,8 @@ int  nxtask_setup_arguments(FAR struct task_tcb_s *tcb,
 /* Task exit */
 
 int  nxtask_exit(void);
-int  nxtask_terminate(pid_t pid, bool nonblocking);
-void nxtask_exithook(FAR struct tcb_s *tcb, int status, bool nonblocking);
+int  nxtask_terminate(pid_t pid);
+void nxtask_exithook(FAR struct tcb_s *tcb, int status);
 void nxtask_recover(FAR struct tcb_s *tcb);
 
 /* Cancellation points */

--- a/sched/task/task_delete.c
+++ b/sched/task/task_delete.c
@@ -132,7 +132,7 @@ int nxtask_delete(pid_t pid)
    * nxtask_terminate() do all of the heavy lifting.
    */
 
-  ret = nxtask_terminate(pid, false);
+  ret = nxtask_terminate(pid);
   if (ret < 0)
     {
       return ret;

--- a/sched/task/task_exit.c
+++ b/sched/task/task_exit.c
@@ -156,7 +156,7 @@ int nxtask_exit(void)
   rtcb->irqcount++;
 #endif
 
-  ret = nxtask_terminate(dtcb->pid, true);
+  ret = nxtask_terminate(dtcb->pid);
 
 #ifdef CONFIG_SMP
   rtcb->irqcount--;

--- a/sched/task/task_terminate.c
+++ b/sched/task/task_terminate.c
@@ -51,8 +51,8 @@
  *   to determine if blocking is permitted or not.
  *
  *   This function is the final function called all task termination
- *   sequences.  nxtask_terminate() is called only from task_delete() (with
- *   nonblocking == false) and from nxtask_exit() (with nonblocking == true).
+ *   sequences.  nxtask_terminate() is called only from task_delete() and
+ *   from nxtask_exit().
  *
  *   The path through nxtask_exit() supports the final stops of the exit(),
  *   _exit(), and pthread_exit
@@ -60,18 +60,12 @@
  *   - pthread_exit().  Calls _exit()
  *   - exit(). Calls _exit()
  *   - _exit().  Calls nxtask_exit() making the currently running task
- *     non-running. nxtask_exit then calls nxtask_terminate() (with nonblocking
- *     == true) to terminate the non-running task.
- *
- *   NOTE: that the state of non-blocking is irrelevant when called through
- *   exit() and pthread_exit().  In those cases nxtask_exithook() has already
- *   been called with nonblocking == false;
+ *     non-running. nxtask_exit then calls nxtask_terminate() to terminate
+ *     the non-running task.
  *
  * Input Parameters:
  *   pid - The task ID of the task to delete.  A pid of zero
  *         signifies the calling task.
- *   nonblocking - True: The task is an unhealthy, partially torn down
- *         state and is not permitted to block.
  *
  * Returned Value:
  *   OK on success; or ERROR on failure
@@ -81,7 +75,7 @@
  *
  *******************************************************************************/
 
-int nxtask_terminate(pid_t pid, bool nonblocking)
+int nxtask_terminate(pid_t pid)
 {
   FAR struct tcb_s *dtcb;
   FAR dq_queue_t *tasklist;
@@ -159,18 +153,14 @@ int nxtask_terminate(pid_t pid, bool nonblocking)
 
   leave_critical_section(flags);
 
-  /* Perform common task termination logic (flushing streams, calling
-   * functions registered by at_exit/on_exit, etc.).  We need to do
+  /* Perform common task termination logic.  We need to do
    * this as early as possible so that higher level clean-up logic
    * can run in a healthy tasking environment.
-   *
-   * In the case where the task exits via exit(), nxtask_exithook()
-   * may be called twice.
    *
    * I suppose EXIT_SUCCESS is an appropriate return value???
    */
 
-  nxtask_exithook(dtcb, EXIT_SUCCESS, nonblocking);
+  nxtask_exithook(dtcb, EXIT_SUCCESS);
 
   /* Since all tasks pass through this function as the final step in their
    * exit sequence, this is an appropriate place to inform any instrumentation

--- a/syscall/syscall.csv
+++ b/syscall/syscall.csv
@@ -74,7 +74,6 @@
 "nx_pthread_exit","nuttx/pthread.h","!defined(CONFIG_DISABLE_PTHREAD)","noreturn","pthread_addr_t"
 "nx_vsyslog","nuttx/syslog/syslog.h","","int","int","FAR const IPTR char *","FAR va_list *"
 "nxsched_get_stackinfo","nuttx/sched.h","","int","pid_t","FAR struct stackinfo_s *"
-"nxsched_get_streams","nuttx/sched.h","defined(CONFIG_FILE_STREAM)","FAR struct streamlist *"
 "open","fcntl.h","","int","FAR const char *","int","...","mode_t"
 "pgalloc", "nuttx/arch.h", "defined(CONFIG_BUILD_KERNEL)", "uintptr_t", "uintptr_t", "unsigned int"
 "pipe2","unistd.h","defined(CONFIG_PIPES) && CONFIG_DEV_PIPE_SIZE > 0","int","int [2]|FAR int *","int"


### PR DESCRIPTION
## Summary
This moves flushing the file streams into user space. It also simplifies a bit how the stream list is allocated, by moving the allocation into TLS instead of having it directly in the group structure.

## Impact
Quite significant architecturally, but should be transparent to users.
## Testing
icicle:knsh
