### PR TITLE
net/nat: Use hashtable to optimize performance

### DIFF
--- a/Documentation/reference/os/nat.rst
+++ b/Documentation/reference/os/nat.rst
@@ -46,6 +46,8 @@ Configuration Options
 ``CONFIG_NET_NAT``
   Enable or disable Network Address Translation (NAT) function.
   Depends on ``CONFIG_NET_IPFORWARD``.
+``CONFIG_NET_NAT_HASH_BITS``
+  The bits of the hashtable of NAT entries, hashtable has (1 << bits) buckets.
 ``CONFIG_NET_NAT_TCP_EXPIRE_SEC``
   The expiration time for idle TCP entry in NAT.
   The default value 86400 is suggested by RFC2663, Section 2.6,
@@ -55,6 +57,14 @@ Configuration Options
   The expiration time for idle UDP entry in NAT.
 ``CONFIG_NET_NAT_ICMP_EXPIRE_SEC``
   The expiration time for idle ICMP entry in NAT.
+``CONFIG_NET_NAT_ENTRY_RECLAIM_SEC``
+  The time to auto reclaim all expired NAT entries. A value of zero will
+  disable auto reclaiming.
+  Expired entries will be automatically reclaimed when matching
+  inbound/outbound entries, so this config does not have significant
+  impact when NAT is normally used, but very useful when the hashtable
+  is big and there are only a few connections using NAT (which will
+  only trigger reclaiming on a few chains in hashtable).
 
 Usage
 =====

--- a/include/nuttx/hashtable.h
+++ b/include/nuttx/hashtable.h
@@ -1,0 +1,100 @@
+/****************************************************************************
+ * include/nuttx/hashtable.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_NUTTX_HASHTABLE_H
+#define __INCLUDE_NUTTX_HASHTABLE_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/lib/math32.h>
+#include <nuttx/nuttx.h>
+#include <nuttx/queue.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Hash function related definitions. */
+
+#define GOLDEN_RATIO_32 0x61C88647 /* Negative golden ratio, used by Linux. */
+#define HASH(val, bits) ((uint32_t)((val) * GOLDEN_RATIO_32) >> (32 - (bits)))
+
+/* Hashtable related definitions. */
+
+#define DECLARE_HASHTABLE(table, bits) hash_head_t table[1 << (bits)]
+
+#define hashtable_size(table) (sizeof(table) / sizeof((table)[0]))
+#define hashtable_bits(table) (LOG2_FLOOR(hashtable_size(table)))
+
+#define hashtable_init(table) \
+  do \
+    { \
+      int i; \
+      for (i = 0; i < hashtable_size(table); i++) \
+        { \
+          dq_init(&table[i]); \
+        } \
+    } \
+  while(0)
+
+#define hashtable_add(table, item, key) \
+  dq_addfirst(item, &table[HASH(key, hashtable_bits(table))])
+
+#define hashtable_delete(table, item, key) \
+  dq_rem(item, &table[HASH(key, hashtable_bits(table))])
+
+/* Iterate over whole hashtable. */
+
+#define hashtable_for_every(table, item, i)         \
+  for ((i) = 0; (i) < hashtable_size(table); (i)++) \
+    sq_for_every(&table[i], item)
+
+#define hashtable_for_every_safe(table, item, temp, i) \
+  for ((i) = 0; (i) < hashtable_size(table); (i)++)    \
+    sq_for_every_safe(&table[i], item, temp)
+
+/* Iterate over all possible objects hashing to the same bucket. */
+
+#define hashtable_for_every_possible(table, item, key) \
+  sq_for_every(&table[HASH(key, hashtable_bits(table))], item)
+
+#define hashtable_for_every_possible_safe(table, item, temp, key) \
+  sq_for_every_safe(&table[HASH(key, hashtable_bits(table))], item, temp)
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/* Note: Our `list` is not suitable for hashtable, because `list` will always
+ * access `head` when iterating by `for_every`, but `head` may sometimes be
+ * accessed by hash result, then hash function will be called on each
+ * iteration. So we use `dq` instead to avoid this.
+ *
+ * Note: There is an optimized type `hlist` on Linux, which saves one pointer
+ * in list head, we can do the same optimization to save memory (but only
+ * saves a little compares to the whole hashtable).
+ */
+
+typedef dq_queue_t hash_head_t;
+typedef dq_entry_t hash_node_t;
+
+#endif /* __INCLUDE_NUTTX_HASHTABLE_H */

--- a/net/nat/Kconfig
+++ b/net/nat/Kconfig
@@ -15,6 +15,14 @@ config NET_NAT
 		and NAT may need a continuous buffer of at least 68 Bytes
 		(IPv4 20B + ICMP 8B + IPv4 20B + TCP 20B).
 
+config NET_NAT_HASH_BITS
+	int "The bits of NAT entry hashtable"
+	default 5
+	range 1 10
+	depends on NET_NAT
+	---help---
+		The hashtable of NAT entries will have (1 << bits) buckets.
+
 config NET_NAT_TCP_EXPIRE_SEC
 	int "TCP NAT entry expiration seconds"
 	default 86400

--- a/net/nat/Kconfig
+++ b/net/nat/Kconfig
@@ -53,3 +53,17 @@ config NET_NAT_ICMP_EXPIRE_SEC
 
 		Note: The default value 60 is suggested by RFC5508, Section 3.2,
 		Page 8.
+
+config NET_NAT_ENTRY_RECLAIM_SEC
+	int "The time to auto reclaim all expired entries"
+	default 3600
+	depends on NET_NAT
+	---help---
+		The time to auto reclaim all expired entries. A value of zero will
+		disable auto reclaiming.
+
+		Note: Expired entries will be automatically reclaimed when matching
+		inbound/outbound entries, so this config does not have significant
+		impact when NAT is normally used, but very useful when the hashtable
+		is big and there are only a few connections using NAT (which will
+		only trigger reclaiming on a few chains in hashtable).

--- a/net/nat/nat.h
+++ b/net/nat/nat.h
@@ -63,7 +63,7 @@ struct ipv4_nat_entry
   uint16_t   external_port;  /* The external port of local (private) host. */
   uint8_t    protocol;       /* L4 protocol (TCP, UDP etc). */
 
-  uint32_t   expire_time;    /* The expiration time of this entry. */
+  int32_t    expire_time;    /* The expiration time of this entry. */
 };
 
 /* NAT IP/Port manipulate type, to indicate whether to manipulate source or

--- a/net/nat/nat.h
+++ b/net/nat/nat.h
@@ -32,6 +32,7 @@
 
 #include <netinet/in.h>
 
+#include <nuttx/hashtable.h>
 #include <nuttx/net/ip.h>
 #include <nuttx/net/netdev.h>
 
@@ -43,14 +44,8 @@
 
 struct ipv4_nat_entry
 {
-  /* Support for doubly-linked lists.
-   *
-   * TODO: Implement a general hash table, and use it to optimize performance
-   * here.
-   */
-
-  FAR struct ipv4_nat_entry *flink;
-  FAR struct ipv4_nat_entry *blink;
+  hash_node_t hash_inbound;
+  hash_node_t hash_outbound;
 
   /*  Local Network                             External Network
    *                |----------------|


### PR DESCRIPTION
## Summary
- patches included:
  - hashtable.h: Added a hashtable implementation 
  - net/nat: Use hashtable to optimize performance 
  - net/nat: Add auto reclaim logic for NAT entries. 
  - doc/nat: update config options 

- Performance tested on simulator:
    ```
    Before optimization:      -25% bandwidth @2k entries, -64% @10k entries
    hashtable size= 32(5bits): -3% bandwidth @2k entries, -14% @10k entries
    hashtable size=256(8bits): -1% bandwidth @2k entries,  -3% @10k entries
    
    Note: Tested on worst performance, the earliest entry will be the worst.
    ```

## Impact
- Optimize NAT performance

## Testing
- Tested by simulator on Ubuntu 22.04
