### PR TITLE
mm:fix typos

### DIFF
--- a/mm/mm_heap/mm.h
+++ b/mm/mm_heap/mm.h
@@ -83,7 +83,7 @@
        { \
          FAR struct mm_allocnode_s *tmp = (FAR struct mm_allocnode_s *)(ptr); \
          kasan_unpoison(tmp, SIZEOF_MM_ALLOCNODE); \
-         FAR strcut tcb_s *tcb; \
+         FAR struct tcb_s *tcb; \
          tmp->pid = gettid(); \
          tcb = nxsched_get_tcb(tmp->pid); \
          if ((heap)->mm_procfs.backtrace || (tcb && tcb->flags & TCB_FLAG_HEAP_DUMP)) \


### PR DESCRIPTION
./mm_heap/mm.h:86:27: error: expected '=', ',', ';', 'asm' or '__attribute__' before '*' token
   86 |          FAR strcut tcb_s *tcb; \
Signed-off-by: anjiahao <anjiahao@xiaomi.com>

## Summary
fix typos
## Impact
noting
## Testing
vela
