### PR TITLE
sched/assert: Do not call the user space "exit" function

### DIFF
--- a/include/assert.h
+++ b/include/assert.h
@@ -43,9 +43,9 @@
 #undef DEBUGVERIFY  /* Like VERIFY, but only if CONFIG_DEBUG_ASSERTIONS is defined */
 
 #ifdef CONFIG_HAVE_FILENAME
-#  define PANIC()        _assert(__FILE__, __LINE__)
+#  define PANIC()        __assert(__FILE__, __LINE__)
 #else
-#  define PANIC()        _assert("unknown", 0)
+#  define PANIC()        __assert("unknown", 0)
 #endif
 
 #define ASSERT(f)        do { if (!(f)) PANIC(); } while (0)
@@ -106,7 +106,26 @@ extern "C"
  * Public Function Prototypes
  ****************************************************************************/
 
-void _assert(FAR const char *filename, int linenum) noreturn_function;
+/****************************************************************************
+ * Name: _assert
+ *
+ * Description:
+ *   This is the assert system call that performs the core dump etc. Function
+ *   might not return if it is not safe to do so (in IRQ or in IDLE task).
+ *
+ ****************************************************************************/
+
+void _assert(FAR const char *filename, int linenum);
+
+/****************************************************************************
+ * Name: __assert
+ *
+ * Description:
+ *   This is the user space assert procedure.
+ *
+ ****************************************************************************/
+
+void __assert(FAR const char *filename, int linenum) noreturn_function;
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/libs/libc/assert/Make.defs
+++ b/libs/libc/assert/Make.defs
@@ -18,6 +18,8 @@
 #
 ############################################################################
 
+CSRCS += lib_assert.c
+
 ifeq ($(CONFIG_STACK_CANARIES),y)
 CSRCS += lib_stackchk.c
 endif

--- a/libs/libc/assert/lib_assert.c
+++ b/libs/libc/assert/lib_assert.c
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * libs/libc/assert/lib_assert.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/arch.h>
+
+#include <assert.h>
+#include <stdlib.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void __assert(FAR const char *filename, int linenum)
+{
+  _assert(filename, linenum);
+  exit(EXIT_FAILURE);
+}

--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -491,5 +491,4 @@ void _assert(FAR const char *filename, int linenum)
   showtasks();
 
   assert_end();
-  exit(EXIT_FAILURE);
 }

--- a/syscall/syscall.csv
+++ b/syscall/syscall.csv
@@ -1,5 +1,5 @@
 "_exit","unistd.h","","noreturn","int"
-"_assert","assert.h","","noreturn","FAR const char *","int"
+"_assert","assert.h","","void","FAR const char *","int"
 "accept","sys/socket.h","defined(CONFIG_NET)","int","int","FAR struct sockaddr *","FAR socklen_t *"
 "adjtime","sys/time.h","defined(CONFIG_CLOCK_TIMEKEEPING)","int","FAR const struct timeval *","FAR struct timeval *"
 "aio_cancel","aio.h","defined(CONFIG_FS_AIO)","int","int","FAR struct aiocb *"


### PR DESCRIPTION
## Summary
_assert is a kernel procedure, entered via system call to make the core
dump in privileged mode.

Running exit() from this context is not OK as it runs the registered
exit functions and flushes streams, which must not be done
from privileged mode as it is a security hole.

Thus, implement assert() into user space (again) and remove the exit()
call from the kernel procedure.
## Impact
Do not run user space code in kernel.
## Testing
icicle:nsh & knsh
