### PR TITLE
riscv/addrenv: Test that satp contents make sense

### DIFF
--- a/arch/risc-v/src/common/riscv_addrenv.c
+++ b/arch/risc-v/src/common/riscv_addrenv.c
@@ -685,7 +685,7 @@ ssize_t up_addrenv_heapsize(const group_addrenv_t *addrenv)
 int up_addrenv_select(const group_addrenv_t *addrenv,
                       save_addrenv_t *oldenv)
 {
-  DEBUGASSERT(addrenv);
+  DEBUGASSERT(addrenv && addrenv->satp);
   if (oldenv)
     {
       /* Save the old environment */


### PR DESCRIPTION
## Summary
Check that satp (the page directory root) is not 0, which means it has not been set.
## Impact
Minimal, risc-v with address environments oly
## Testing
icicle:knsh
