### PR TITLE
s32k1xx\Kconfig: Add config option to enable UART invert setting.

### DIFF
--- a/arch/arm/src/s32k1xx/Kconfig
+++ b/arch/arm/src/s32k1xx/Kconfig
@@ -628,6 +628,14 @@ config S32K1XX_EDMA_EDBG
 
 endmenu # eDMA Global Configuration
 
+menu "LPUART Configuration"
+	depends on S32K1XX_LPUART
+	
+config S32K1XX_LPUART_INVERT
+	bool "Signal Invert Support"
+	default n
+endmenu	
+
 menu "LPSPI Configuration"
 	depends on S32K1XX_LPSPI
 	


### PR DESCRIPTION
## Summary
The config setting S32K1XX_LPUART_INVERT was missing in the Kconfig file. This setting is used to enable the UART invert option.

## Impact
There was no way to enable the code protected by this macro in the s32k1xx UART driver. 

## Testing
Tested on a s32k1xx board after adding this change. The UART output is inverted as expected.
