### PR TITLE
Add copyright/NOTICE for scalbn(f|l)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -5373,6 +5373,32 @@ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 
+libs/libc/math/scalbnf.c
+libs/libc/math/scalbn.c
+libs/libc/math/scalbnl.c
+======================
+
+   Copyright © 2005-2020 Rich Felker, et al.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 libs/libc/math/__cos.c
 libs/libc/math/__sin.c
 libs/libc/math/lib_lgamma.c


### PR DESCRIPTION
## Summary
add copyright/NOTICE for scalbn
## Impact
The scalbnf() implementation from musl C library was added to NuttX in commit 035656661e2c626e337f0e85ea99d742c9d85c62 (GitHub PR 7850).
## Testing

