### PR TITLE
net/devif_loopback: Add robustness to avoid infinite loop

### DIFF
--- a/net/devif/devif_loopback.c
+++ b/net/devif/devif_loopback.c
@@ -119,7 +119,9 @@ int devif_loopback(FAR struct net_driver_s *dev)
       else
 #endif
         {
+          nwarn("WARNING: Unrecognized IP version\n");
           NETDEV_RXDROPPED(dev);
+          dev->d_len = 0;
         }
 
       NETDEV_TXDONE(dev);


### PR DESCRIPTION
## Summary
When ipv4_input/ipv6_input called by devif_loopback writes wrong data into buffer (another bug we're fixing), the else block does nothing but only record the 'dropped' statistic, then infinite loop happens.

Refers to previous lo device with dropping logic:
https://github.com/apache/nuttx/blob/releases/11.0/drivers/net/loopback.c#L178-L180

## Impact
Increase robustness, actually drop packet when we want.

## Testing
pass CI; manually triggered edge case to check infinite loop disappears.

