### PR TITLE
arch: qemu-rv: Fix qemu_rv_mtimer_interrupt() for BUILD_KERNEL

### DIFF
--- a/arch/risc-v/src/qemu-rv/qemu_rv_timerisr.c
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_timerisr.c
@@ -31,6 +31,7 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/clock.h>
+#include <nuttx/init.h>
 #include <nuttx/spinlock.h>
 #include <nuttx/timers/arch_alarm.h>
 #include <arch/board/board.h>
@@ -198,9 +199,12 @@ void qemu_rv_mtimer_interrupt(void)
   g_mtimer_cnt++;
   g_stimer_pending = true;
 
-  /* Post Supervisor Software Interrupt */
+  if (OSINIT_HW_READY())
+    {
+      /* Post Supervisor Software Interrupt */
 
-  SET_CSR(sip, SIP_SSIP);
+      SET_CSR(sip, SIP_SSIP);
+    }
 }
 
 #endif /* CONFIG_BUILD_KERNEL */


### PR DESCRIPTION
## Summary

- I noticed that rv-virt:ksmp64 sometimes stops during boot.
- Finally, I found that it posts the Supervisor Software Interrupt before the OS finishes hardware initialization.
- This commit fixes this issue.

## Impact

- None

## Testing

- Tested with QEMU-7.1
