### PR TITLE
arch: Remove the unused arch color function variant

### DIFF
--- a/arch/arm/src/common/arm_checkstack.c
+++ b/arch/arm/src/common/arm_checkstack.c
@@ -182,7 +182,7 @@ void arm_stack_color(void *stackbase, size_t nbytes)
 }
 
 /****************************************************************************
- * Name: up_check_stack and friends
+ * Name: up_check_tcbstack and friends
  *
  * Description:
  *   Determine (approximately) how much stack has been used be searching the
@@ -224,31 +224,11 @@ size_t up_check_tcbstack(struct tcb_s *tcb)
   return size;
 }
 
-ssize_t up_check_tcbstack_remain(struct tcb_s *tcb)
-{
-  return tcb->adj_stack_size - up_check_tcbstack(tcb);
-}
-
-size_t up_check_stack(void)
-{
-  return up_check_tcbstack(running_task());
-}
-
-ssize_t up_check_stack_remain(void)
-{
-  return up_check_tcbstack_remain(running_task());
-}
-
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
 size_t up_check_intstack(void)
 {
   return arm_stack_check((void *)up_get_intstackbase(),
                          STACK_ALIGN_DOWN(CONFIG_ARCH_INTERRUPTSTACK));
-}
-
-size_t up_check_intstack_remain(void)
-{
-  return STACK_ALIGN_DOWN(CONFIG_ARCH_INTERRUPTSTACK) - up_check_intstack();
 }
 #endif
 

--- a/arch/arm64/src/common/arm64_checkstack.c
+++ b/arch/arm64/src/common/arm64_checkstack.c
@@ -181,7 +181,7 @@ void arm64_stack_color(void *stackbase, size_t nbytes)
 }
 
 /****************************************************************************
- * Name: up_check_stack and friends
+ * Name: up_check_tcbstack and friends
  *
  * Description:
  *   Determine (approximately) how much stack has been used by searching the
@@ -201,31 +201,11 @@ size_t up_check_tcbstack(struct tcb_s *tcb)
   return arm64_stack_check(tcb->stack_base_ptr, tcb->adj_stack_size);
 }
 
-ssize_t up_check_tcbstack_remain(struct tcb_s *tcb)
-{
-  return tcb->adj_stack_size - up_check_tcbstack(tcb);
-}
-
-size_t up_check_stack(void)
-{
-  return up_check_tcbstack(running_task());
-}
-
-ssize_t up_check_stack_remain(void)
-{
-  return up_check_tcbstack_remain(running_task());
-}
-
 #if CONFIG_ARCH_INTERRUPTSTACK > 7
 size_t up_check_intstack(void)
 {
   return arm64_stack_check((void *)up_get_intstackbase(),
                            STACK_ALIGN_DOWN(CONFIG_ARCH_INTERRUPTSTACK));
-}
-
-size_t up_check_intstack_remain(void)
-{
-  return STACK_ALIGN_DOWN(CONFIG_ARCH_INTERRUPTSTACK) - up_check_intstack();
 }
 #endif
 

--- a/arch/avr/src/avr/avr_checkstack.c
+++ b/arch/avr/src/avr/avr_checkstack.c
@@ -127,7 +127,7 @@ size_t avr_stack_check(uintptr_t alloc, size_t size)
 }
 
 /****************************************************************************
- * Name: up_check_stack and friends
+ * Name: up_check_tcbstack and friends
  *
  * Description:
  *   Determine (approximately) how much stack has been used be searching the
@@ -148,31 +148,11 @@ size_t up_check_tcbstack(FAR struct tcb_s *tcb)
                          tcb->adj_stack_size);
 }
 
-ssize_t up_check_tcbstack_remain(FAR struct tcb_s *tcb)
-{
-  return tcb->adj_stack_size - up_check_tcbstack(tcb);
-}
-
-size_t up_check_stack(void)
-{
-  return up_check_tcbstack(running_task());
-}
-
-ssize_t up_check_stack_remain(void)
-{
-  return up_check_tcbstack_remain(running_task());
-}
-
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
 size_t up_check_intstack(void)
 {
   uintptr_t start = (uintptr_t)g_intstackalloc;
   return avr_stack_check(start, CONFIG_ARCH_INTERRUPTSTACK & ~3);
-}
-
-size_t up_check_intstack_remain(void)
-{
-  return (CONFIG_ARCH_INTERRUPTSTACK & ~3) - up_check_intstack();
 }
 #endif
 

--- a/arch/ceva/src/common/ceva_checkstack.c
+++ b/arch/ceva/src/common/ceva_checkstack.c
@@ -122,7 +122,7 @@ size_t ceva_stack_check(uintptr_t alloc, size_t size)
 }
 
 /****************************************************************************
- * Name: up_check_stack and friends
+ * Name: up_check_tcbstack and friends
  *
  * Description:
  *   Determine (approximately) how much stack has been used be searching the
@@ -143,30 +143,10 @@ size_t up_check_tcbstack(struct tcb_s *tcb)
                           tcb->adj_stack_size);
 }
 
-ssize_t up_check_tcbstack_remain(struct tcb_s *tcb)
-{
-  return tcb->adj_stack_size - up_check_tcbstack(tcb);
-}
-
-size_t up_check_stack(void)
-{
-  return up_check_tcbstack(running_task());
-}
-
-ssize_t up_check_stack_remain(void)
-{
-  return up_check_tcbstack_remain(running_task());
-}
-
 size_t up_check_intstack(void)
 {
   return ceva_stack_check((uintptr_t)g_intstackalloc,
                           g_intstackbase - g_intstackalloc);
-}
-
-size_t up_check_intstack_remain(void)
-{
-  return g_intstackbase - g_intstackalloc - up_check_intstack();
 }
 
 #endif /* CONFIG_STACK_COLORATION */

--- a/arch/or1k/src/common/or1k_checkstack.c
+++ b/arch/or1k/src/common/or1k_checkstack.c
@@ -98,7 +98,7 @@ size_t or1k_stack_check(uintptr_t alloc, size_t size)
 }
 
 /****************************************************************************
- * Name: up_check_stack and friends
+ * Name: up_check_tcbstack and friends
  *
  * Description:
  *   Determine (approximately) how much stack has been used be searching the
@@ -119,31 +119,11 @@ size_t up_check_tcbstack(struct tcb_s *tcb)
                           tcb->adj_stack_size);
 }
 
-ssize_t up_check_tcbstack_remain(struct tcb_s *tcb)
-{
-  return tcb->adj_stack_size - up_check_tcbstack(tcb);
-}
-
-size_t up_check_stack(void)
-{
-  return up_check_tcbstack(running_task());
-}
-
-ssize_t up_check_stack_remain(void)
-{
-  return up_check_tcbstack_remain(running_task());
-}
-
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
 size_t up_check_intstack(void)
 {
   return or1k_stack_check((uintptr_t)g_intstackalloc,
                           (CONFIG_ARCH_INTERRUPTSTACK & ~3));
-}
-
-size_t up_check_intstack_remain(void)
-{
-  return (CONFIG_ARCH_INTERRUPTSTACK & ~3) - up_check_intstack();
 }
 #endif
 

--- a/arch/risc-v/src/common/riscv_checkstack.c
+++ b/arch/risc-v/src/common/riscv_checkstack.c
@@ -138,7 +138,7 @@ size_t riscv_stack_check(uintptr_t alloc, size_t size)
 }
 
 /****************************************************************************
- * Name: up_check_stack and friends
+ * Name: up_check_tcbstack and friends
  *
  * Description:
  *   Determine (approximately) how much stack has been used be searching the
@@ -181,31 +181,11 @@ size_t up_check_tcbstack(struct tcb_s *tcb)
   return size;
 }
 
-ssize_t up_check_tcbstack_remain(struct tcb_s *tcb)
-{
-  return tcb->adj_stack_size - up_check_tcbstack(tcb);
-}
-
-size_t up_check_stack(void)
-{
-  return up_check_tcbstack(running_task());
-}
-
-ssize_t up_check_stack_remain(void)
-{
-  return up_check_tcbstack_remain(running_task());
-}
-
 #if CONFIG_ARCH_INTERRUPTSTACK > 15
 size_t up_check_intstack(void)
 {
   return riscv_stack_check((uintptr_t)g_intstackalloc,
                            (CONFIG_ARCH_INTERRUPTSTACK & ~15));
-}
-
-size_t up_check_intstack_remain(void)
-{
-  return (CONFIG_ARCH_INTERRUPTSTACK & ~15) - up_check_intstack();
 }
 #endif
 

--- a/arch/sim/src/sim/sim_checkstack.c
+++ b/arch/sim/src/sim/sim_checkstack.c
@@ -137,7 +137,7 @@ size_t sim_stack_check(void *alloc, size_t size)
 }
 
 /****************************************************************************
- * Name: up_check_stack and friends
+ * Name: up_check_tcbstack and friends
  *
  * Description:
  *   Determine (approximately) how much stack has been used be searching the
@@ -156,19 +156,4 @@ size_t up_check_tcbstack(struct tcb_s *tcb)
 {
   return sim_stack_check((void *)(uintptr_t)tcb->stack_base_ptr,
                          tcb->adj_stack_size);
-}
-
-ssize_t up_check_tcbstack_remain(struct tcb_s *tcb)
-{
-  return tcb->adj_stack_size - up_check_tcbstack(tcb);
-}
-
-size_t up_check_stack(void)
-{
-  return up_check_tcbstack(running_task());
-}
-
-ssize_t up_check_stack_remain(void)
-{
-  return up_check_tcbstack_remain(running_task());
 }

--- a/arch/sparc/src/common/sparc_checkstack.c
+++ b/arch/sparc/src/common/sparc_checkstack.c
@@ -183,7 +183,7 @@ void sparc_stack_color(void *stackbase, size_t nbytes)
 }
 
 /****************************************************************************
- * Name: up_check_stack and friends
+ * Name: up_check_tcbstack and friends
  *
  * Description:
  *   Determine (approximately) how much stack has been used be searching the
@@ -203,31 +203,11 @@ size_t up_check_tcbstack(struct tcb_s *tcb)
   return sparc_stack_check(tcb->stack_base_ptr, tcb->adj_stack_size);
 }
 
-ssize_t up_check_tcbstack_remain(struct tcb_s *tcb)
-{
-  return tcb->adj_stack_size - up_check_tcbstack(tcb);
-}
-
-size_t up_check_stack(void)
-{
-  return up_check_tcbstack(running_task());
-}
-
-ssize_t up_check_stack_remain(void)
-{
-  return up_check_tcbstack_remain(running_task());
-}
-
 #if CONFIG_ARCH_INTERRUPTSTACK > 7
 size_t up_check_intstack(void)
 {
   return sparc_stack_check((void *)sparc_intstack_alloc(),
                            STACK_ALIGN_DOWN(CONFIG_ARCH_INTERRUPTSTACK));
-}
-
-size_t up_check_intstack_remain(void)
-{
-  return STACK_ALIGN_DOWN(CONFIG_ARCH_INTERRUPTSTACK) - up_check_intstack();
 }
 #endif
 

--- a/arch/xtensa/src/common/xtensa_checkstack.c
+++ b/arch/xtensa/src/common/xtensa_checkstack.c
@@ -141,7 +141,7 @@ size_t xtensa_stack_check(uintptr_t alloc, size_t size)
 }
 
 /****************************************************************************
- * Name: up_check_stack and friends
+ * Name: up_check_tcbstack and friends
  *
  * Description:
  *   Determine (approximately) how much stack has been used be searching the
@@ -162,30 +162,10 @@ size_t up_check_tcbstack(struct tcb_s *tcb)
                             tcb->adj_stack_size);
 }
 
-ssize_t up_check_tcbstack_remain(struct tcb_s *tcb)
-{
-  return tcb->adj_stack_size - up_check_tcbstack(tcb);
-}
-
-size_t up_check_stack(void)
-{
-  return up_check_tcbstack(running_task());
-}
-
-ssize_t up_check_stack_remain(void)
-{
-  return up_check_tcbstack_remain(running_task());
-}
-
 #if CONFIG_ARCH_INTERRUPTSTACK > 15
 size_t up_check_intstack(void)
 {
   return xtensa_stack_check(up_get_intstackbase(), INTSTACK_SIZE);
-}
-
-size_t up_check_intstack_remain(void)
-{
-  return INTSTACK_SIZE - up_check_intstack();
 }
 #endif
 

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -2255,7 +2255,7 @@ void nxsched_process_cpuload_ticks(uint32_t ticks);
 void irq_dispatch(int irq, FAR void *context);
 
 /****************************************************************************
- * Name: up_check_stack and friends
+ * Name: up_check_tcbstack and friends
  *
  * Description:
  *   Determine (approximately) how much stack has been used be searching the
@@ -2272,13 +2272,9 @@ void irq_dispatch(int irq, FAR void *context);
 
 #ifdef CONFIG_STACK_COLORATION
 struct tcb_s;
-size_t  up_check_tcbstack(FAR struct tcb_s *tcb);
-ssize_t up_check_tcbstack_remain(FAR struct tcb_s *tcb);
-size_t  up_check_stack(void);
-ssize_t up_check_stack_remain(void);
+size_t up_check_tcbstack(FAR struct tcb_s *tcb);
 #if defined(CONFIG_ARCH_INTERRUPTSTACK) && CONFIG_ARCH_INTERRUPTSTACK > 3
-size_t  up_check_intstack(void);
-size_t  up_check_intstack_remain(void);
+size_t up_check_intstack(void);
 #endif
 #endif
 


### PR DESCRIPTION
## Summary
up_check_tcbstack_remain, up_check_stack, up_check_stack_remain and up_check_intstack_remain

## Impact
Remove the dead code

## Testing
Pass CI
