### PR TITLE
Improve the assert consistence

### DIFF
--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -3911,10 +3911,10 @@ config BOARD_RESET_ON_ASSERT
 	depends on BOARDCTL_RESET
 	---help---
 		== 0 up_assert never reset the machine
-		>= 1 up_assert from interrupt handler or IDLE thread will reset the
-		     machine
+		>= 1 up_assert from interrupt handler or kernel thread will reset
+		     the machine
 		>= 2 up_assert from user or kernel thread will reset the machine.
-		     The default behavior is just to kill the asserting thread.
+		     The default behavior just kill the asserting thread.
 
 config BOARD_ASSERT_RESET_VALUE
 	int "Board reset argument"

--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -205,12 +205,7 @@ static void show_stacks(FAR struct tcb_s *rtcb)
   dump_stack("Kernel", sp,
              (uintptr_t)rtcb->xcp.kstack,
              CONFIG_ARCH_KERNEL_STACKSIZE,
-#  ifdef CONFIG_STACK_COLORATION
-             up_check_tcbstack(rtcb),
-#  else
-             0,
-#  endif
-             false);
+             0, false);
 #endif
 }
 


### PR DESCRIPTION
## Summary

- sched/assert: Don't call running_task more than once
- sched/assert: Don't call up_check_tcbstack for the kernel stack
- sched/assert: Dump the global state only when it's a fatal error

## Impact

assert

## Testing
local
