### PR TITLE
include/time.h: Typedef time_t to uint64_t when CONFIG_SYSTEM_TIME64 is true

### DIFF
--- a/include/time.h
+++ b/include/time.h
@@ -99,7 +99,7 @@
 /* Scalar types */
 
 #ifdef CONFIG_SYSTEM_TIME64
-typedef int64_t   time_t;         /* Holds time in seconds */
+typedef uint64_t  time_t;         /* Holds time in seconds */
 #else
 typedef uint32_t  time_t;         /* Holds time in seconds */
 #endif


### PR DESCRIPTION
## Summary
See the discussion here: https://github.com/apache/nuttx/pull/7115

## Impact
time_t mapping

## Testing
Pass CI
