### PR TITLE
register notelog device 

### DIFF
--- a/drivers/note/Make.defs
+++ b/drivers/note/Make.defs
@@ -19,7 +19,7 @@
 ############################################################################
 
 ifeq ($(CONFIG_DRIVER_NOTE),y)
-  ifeq ($(CONFIG_SCHED_INSTRUMENTATION_EXTERNAL),)
+  ifeq ($(CONFIG_SEGGER_SYSVIEW),)
     CSRCS += note_driver.c
     CFLAGS += ${INCDIR_PREFIX}${TOPDIR}/sched
   endif

--- a/drivers/note/note_driver.c
+++ b/drivers/note/note_driver.c
@@ -37,6 +37,7 @@
 #include <nuttx/clock.h>
 #include <nuttx/note/note_driver.h>
 #include <nuttx/note/noteram_driver.h>
+#include <nuttx/note/notelog_driver.h>
 #include <nuttx/spinlock.h>
 #include <nuttx/sched_note.h>
 
@@ -160,8 +161,12 @@ static unsigned int g_note_disabled_irq_nest[CONFIG_SMP_NCPUS];
 FAR static struct note_driver_s *g_note_drivers[CONFIG_DRIVER_NOTE_MAX + 1] =
 {
 #ifdef CONFIG_DRIVER_NOTERAM
-  &g_noteram_driver
+  &g_noteram_driver,
 #endif
+#ifdef CONFIG_DRIVER_NOTELOG
+  &g_notelog_driver,
+#endif
+  NULL
 };
 
 #if CONFIG_DRIVER_NOTE_TASKNAME_BUFSIZE > 0

--- a/drivers/note/notelog_driver.c
+++ b/drivers/note/notelog_driver.c
@@ -25,7 +25,6 @@
 #include <nuttx/config.h>
 #include <stdarg.h>
 #include <stdio.h>
-#include <syscall.h>
 #include <syslog.h>
 #include <nuttx/sched.h>
 #include <nuttx/sched_note.h>
@@ -316,36 +315,6 @@ void sched_note_spinlock(FAR struct tcb_s *tcb,
          tcb, spinlock, msg);
 #endif
 #endif
-}
-#endif
-
-#ifdef CONFIG_SCHED_INSTRUMENTATION_SYSCALL
-void sched_note_syscall_enter(int nr, int argc, ...)
-{
-  char buf[128];
-  FAR char *p = buf;
-  va_list ap;
-
-  va_start(ap, argc);
-  while (argc-- > 0)
-    {
-      if (argc)
-        {
-          p += sprintf(p, "%#"PRIxPTR", ", va_arg(ap, uintptr_t));
-        }
-      else
-        {
-          p += sprintf(p, "%#"PRIxPTR, va_arg(ap, uintptr_t));
-        }
-    }
-
-  va_end(ap);
-  syslog(LOG_INFO, "%s@%d ENTER %s\n", g_funcnames[nr], nr, buf);
-}
-
-void sched_note_syscall_leave(int nr, uintptr_t result)
-{
-  syslog(LOG_INFO, "%s@%d LEAVE %"PRIdPTR"\n", g_funcnames[nr], nr, result);
 }
 #endif
 

--- a/include/nuttx/note/notelog_driver.h
+++ b/include/nuttx/note/notelog_driver.h
@@ -1,0 +1,63 @@
+/****************************************************************************
+ * include/nuttx/note/notelog_driver.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_NUTTX_NOTE_NOTELOG_DRIVER_H
+#define __INCLUDE_NUTTX_NOTE_NOTELOG_DRIVER_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stddef.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+#if defined(__cplusplus)
+extern "C"
+{
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#ifdef CONFIG_DRIVER_NOTELOG
+extern struct note_driver_s g_notelog_driver;
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* __INCLUDE_NUTTX_NOTE_NOTELOG_DRIVER_H */


### PR DESCRIPTION
## Summary
Register notelog to the list of note drivers

## Impact
still only one note driver can be used
multi-channel functionality needs to wait for sysview changes to complete

patch 1 removes syscall_enter/leave in notelog, because syslog is a system call, which causes recursion.
patch 2 turns the original notelog function into a function pointer call to support simultaneous use with noteram/sysview

## Testing
sim:note
