### PR TITLE
esp32xx: Clear the timer interrupt to avoid losing the next interrupt

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_tim_lowerhalf.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_tim_lowerhalf.c
@@ -134,6 +134,8 @@ static int esp32c3_timer_handler(int irq, void *context, void *arg)
     (struct esp32c3_timer_lowerhalf_s *)arg;
   uint32_t next_interval_us = 0;
 
+  ESP32C3_TIM_ACKINT(priv->tim);        /* Clear the Interrupt */
+
   if (priv->callback(&next_interval_us, priv->upper))
     {
       if (next_interval_us > 0)
@@ -149,7 +151,7 @@ static int esp32c3_timer_handler(int irq, void *context, void *arg)
     }
 
   ESP32C3_TIM_SETALRM(priv->tim, true); /* Re-enables the alarm */
-  ESP32C3_TIM_ACKINT(priv->tim);        /* Clear the Interrupt */
+
   return OK;
 }
 

--- a/arch/xtensa/src/esp32/esp32_tim_lowerhalf.c
+++ b/arch/xtensa/src/esp32/esp32_tim_lowerhalf.c
@@ -159,6 +159,8 @@ static int esp32_timer_handler(int irq, void *context, void *arg)
     (struct esp32_timer_lowerhalf_s *)arg;
   uint32_t next_interval_us = 0;
 
+  ESP32_TIM_ACKINT(priv->tim);        /* Clear the Interrupt */
+
   if (priv->callback(&next_interval_us, priv->upper))
     {
       if (next_interval_us > 0)
@@ -174,7 +176,6 @@ static int esp32_timer_handler(int irq, void *context, void *arg)
     }
 
   ESP32_TIM_SETALRM(priv->tim, true); /* Re-enables the alarm */
-  ESP32_TIM_ACKINT(priv->tim);        /* Clear the Interrupt */
   return OK;
 }
 

--- a/arch/xtensa/src/esp32s2/esp32s2_tim_lowerhalf.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_tim_lowerhalf.c
@@ -153,6 +153,8 @@ static int esp32s2_timer_handler(int irq, void *context, void *arg)
     (struct esp32s2_timer_lowerhalf_s *)arg;
   uint32_t next_interval_us = 0;
 
+  ESP32S2_TIM_ACKINT(priv->tim);        /* Clear the Interrupt */
+
   if (priv->callback(&next_interval_us, priv->upper))
     {
       if (next_interval_us > 0)
@@ -168,7 +170,6 @@ static int esp32s2_timer_handler(int irq, void *context, void *arg)
     }
 
   ESP32S2_TIM_SETALRM(priv->tim, true); /* Re-enables the alarm */
-  ESP32S2_TIM_ACKINT(priv->tim);        /* Clear the Interrupt */
   return OK;
 }
 

--- a/arch/xtensa/src/esp32s3/esp32s3_tim_lowerhalf.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_tim_lowerhalf.c
@@ -158,6 +158,8 @@ static int timer_lh_handler(int irq, void *context, void *arg)
     (struct esp32s3_timer_lowerhalf_s *)arg;
   uint32_t next_interval_us = 0;
 
+  ESP32S3_TIM_ACKINT(priv->tim);        /* Clear the Interrupt */
+
   if (priv->callback(&next_interval_us, priv->upper))
     {
       if (next_interval_us > 0)
@@ -173,7 +175,6 @@ static int timer_lh_handler(int irq, void *context, void *arg)
     }
 
   ESP32S3_TIM_SETALRM(priv->tim, true); /* Re-enables the alarm */
-  ESP32S3_TIM_ACKINT(priv->tim);        /* Clear the Interrupt */
 
   return OK;
 }


### PR DESCRIPTION
## Summary
The timer interrupt must be cleared before the next interrupt is generated. So it is speculated that a nested event may occur immediately after the execution of ESP32XX_TIM_SETALRM, causing the next interrupt to occur.
## Impact
Avoid losing timer interrupts.
## Testing
Using devkit boards
