### PR TITLE
fs/signalfd: using file descriptor to accept signal

### DIFF
--- a/fs/vfs/Kconfig
+++ b/fs/vfs/Kconfig
@@ -60,3 +60,19 @@ config TIMER_FD_NPOLLWAITERS
 		Maximum number of threads that can be waiting on poll()
 
 endif # TIMER_FD
+
+config SIGNAL_FD
+	bool "SignalFD"
+	default n
+	---help---
+		Create a file descriptor for accepting signals
+
+if SIGNAL_FD
+
+config SIGNAL_FD_NPOLLWAITERS
+	int "Number of signalFD poll waiters"
+	default 2
+	---help---
+		Maximum number of threads that can be waiting on poll()
+
+endif # SIGNAL_FD

--- a/fs/vfs/Make.defs
+++ b/fs/vfs/Make.defs
@@ -54,6 +54,12 @@ ifeq ($(CONFIG_TIMER_FD),y)
 CSRCS += fs_timerfd.c
 endif
 
+# Support for signalfd
+
+ifeq ($(CONFIG_SIGNAL_FD),y)
+CSRCS += fs_signalfd.c
+endif
+
 # Include vfs build support
 
 DEPPATH += --dep-path vfs

--- a/fs/vfs/fs_signalfd.c
+++ b/fs/vfs/fs_signalfd.c
@@ -1,0 +1,403 @@
+/****************************************************************************
+ * fs/vfs/fs_signalfd.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <poll.h>
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+
+#include <debug.h>
+
+#include <nuttx/mutex.h>
+#include <nuttx/signal.h>
+
+#include <sys/signalfd.h>
+
+#include "inode/inode.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/* This structure describes the internal state of the driver */
+
+struct signalfd_priv_s
+{
+  sigset_t      sigmask; /* The set of signals caller wishes */
+  mutex_t       mutex;   /* Enforces device exclusive access */
+  uint8_t       crefs;   /* References counts on signalfd (max: 255) */
+  FAR struct pollfd *fds[CONFIG_SIGNAL_FD_NPOLLWAITERS];
+};
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static int signalfd_file_open(FAR struct file *filep);
+static int signalfd_file_close(FAR struct file *filep);
+static ssize_t signalfd_file_read(FAR struct file *filep,
+                                  FAR char *buffer, size_t len);
+static int signalfd_file_poll(FAR struct file *filep,
+                              FAR struct pollfd *fds, bool setup);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static const struct file_operations g_signalfd_fileops =
+{
+  signalfd_file_open,   /* open */
+  signalfd_file_close,  /* close */
+  signalfd_file_read,   /* read */
+  NULL,                 /* write */
+  NULL,                 /* seek */
+  NULL,                 /* ioctl */
+  signalfd_file_poll    /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL                /* unlink */
+#endif
+};
+
+static struct inode g_signalfd_inode =
+{
+  NULL,                   /* i_parent */
+  NULL,                   /* i_peer */
+  NULL,                   /* i_child */
+  1,                      /* i_crefs */
+  FSNODEFLAG_TYPE_DRIVER, /* i_flags */
+  {
+    &g_signalfd_fileops   /* u */
+  }
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static void signalfd_action(int signo, FAR siginfo_t *info,
+                            FAR void *ucontext)
+{
+  FAR struct signalfd_priv_s *dev = info->si_user;
+
+  if (sigismember(&dev->sigmask, signo) > 0)
+    {
+      poll_notify(dev->fds, CONFIG_SIGNAL_FD_NPOLLWAITERS, POLLIN);
+    }
+}
+
+static int signalfd_file_open(FAR struct file *filep)
+{
+  FAR struct signalfd_priv_s *dev = filep->f_priv;
+  int ret;
+
+  nxmutex_lock(&dev->mutex);
+  if (dev->crefs >= 255)
+    {
+      ret = -EMFILE;
+    }
+  else
+    {
+      dev->crefs += 1;
+      ret = OK;
+    }
+
+  nxmutex_unlock(&dev->mutex);
+  return ret;
+}
+
+static int signalfd_file_close(FAR struct file *filep)
+{
+  FAR struct signalfd_priv_s *dev = filep->f_priv;
+  int signo;
+
+  nxmutex_lock(&dev->mutex);
+  if (dev->crefs > 1)
+    {
+      dev->crefs--;
+      nxmutex_unlock(&dev->mutex);
+      return OK;
+    }
+
+  for (signo = MIN_SIGNO; signo <= MAX_SIGNO; signo++)
+    {
+      if (nxsig_ismember(&dev->sigmask, signo))
+        {
+          signal(signo, SIG_DFL);
+        }
+    }
+
+  nxmutex_unlock(&dev->mutex);
+  nxmutex_destroy(&dev->mutex);
+  kmm_free(dev);
+
+  return OK;
+}
+
+static ssize_t signalfd_file_read(FAR struct file *filep,
+                                  FAR char *buffer, size_t len)
+{
+  FAR struct signalfd_priv_s *dev = filep->f_priv;
+  FAR struct signalfd_siginfo *siginfo;
+  struct siginfo info;
+  sigset_t pendmask;
+  ssize_t ret;
+  int count;
+
+  count = len / sizeof(struct signalfd_siginfo);
+  if (buffer == NULL || count == 0)
+    {
+      return -EINVAL;
+    }
+
+  pendmask = nxsig_pendingset(NULL) & dev->sigmask;
+  if (pendmask == 0)
+    {
+      if (filep->f_oflags & O_NONBLOCK)
+        {
+          return -EAGAIN;
+        }
+      else
+        {
+          pendmask = dev->sigmask;
+        }
+    }
+
+  siginfo = (FAR struct signalfd_siginfo *)buffer;
+  do
+    {
+      ret = nxsig_waitinfo(&pendmask, &info);
+      if (ret < 0)
+        {
+          goto errout;
+        }
+
+      memset(siginfo, 0, sizeof(*siginfo));
+      siginfo->ssi_signo  = info.si_signo;
+      siginfo->ssi_errno  = info.si_errno;
+      siginfo->ssi_code   = info.si_code;
+#ifdef CONFIG_SCHED_HAVE_PARENT
+      siginfo->ssi_pid    = info.si_pid;
+      siginfo->ssi_status = info.si_status;
+#endif
+      siginfo->ssi_int    = info.si_value.sival_int;
+      siginfo->ssi_ptr    = (uint64_t)(uintptr_t)info.si_value.sival_ptr;
+      siginfo++;
+      pendmask = nxsig_pendingset(NULL) & dev->sigmask;
+    }
+  while (--count != 0 && pendmask != 0);
+
+errout:
+  len = (FAR char *)siginfo - buffer;
+  return len > 0 ? len : ret;
+}
+
+static int signalfd_file_poll(FAR struct file *filep,
+                              FAR struct pollfd *fds, bool setup)
+{
+  FAR struct signalfd_priv_s *dev = filep->f_priv;
+  int ret = 0;
+  int i;
+
+  nxmutex_lock(&dev->mutex);
+  if (!setup)
+    {
+      /* This is a request to tear down the poll. */
+
+      FAR struct pollfd **slot = (FAR struct pollfd **)fds->priv;
+
+      /* Remove all memory of the poll setup */
+
+      *slot     = NULL;
+      fds->priv = NULL;
+      goto out;
+    }
+
+  /* This is a request to set up the poll. Find an available
+   * slot for the poll structure reference
+   */
+
+  for (i = 0; i < CONFIG_SIGNAL_FD_NPOLLWAITERS; i++)
+    {
+      /* Find an available slot */
+
+      if (!dev->fds[i])
+        {
+          /* Bind the poll structure and this slot */
+
+          dev->fds[i] = fds;
+          fds->priv   = &dev->fds[i];
+          break;
+        }
+    }
+
+  if (i >= CONFIG_SIGNAL_FD_NPOLLWAITERS)
+    {
+      ret = -EBUSY;
+      goto out;
+    }
+
+  /* Notify the POLLIN event if the counter is not zero */
+
+  if ((nxsig_pendingset(NULL) & dev->sigmask) != 0)
+    {
+      poll_notify(dev->fds, CONFIG_SIGNAL_FD_NPOLLWAITERS, POLLIN);
+    }
+
+out:
+  nxmutex_unlock(&dev->mutex);
+  return ret;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: signalfd
+ *
+ * Description:
+ *   signalfd() creates a file descriptor that can be used to accept signals
+ *   targeted at the caller.
+ *
+ *   The mask argument specifies the set of signals that the caller wishes
+ *   to accept via the file descriptor. This argument is a signal set whose
+ *   contents can be initialized using the macros described in sigsetops.
+ *   Normally, the set of signals to be received via the file descriptor
+ *   should be blocked using sigprocmask, to prevent the signals being
+ *   handled according to their default dispositions. It is not possible
+ *   to receive SIGKILL or SIGSTOP signals via a signalfd file descriptor.
+ *   these signals are silently ignored if specified in mask.
+ *
+ *   If the fd argument is -1, then the call creates a new file descriptor
+ *   and associates the signal set specified in mask with that file
+ *   descriptor. If fd is not -1, then it must specify a valid existing
+ *   signalfd file descriptor, and mask is used to replace the signal
+ *   set associated with that file descriptor.
+ *
+ *   The following values may be bitwise ORed in flags to change the
+ *   behavior of signalfd():
+ *
+ *   SFD_NONBLOCK  Set the O_NONBLOCK file status flag on the open file
+ *                 description referred to by the new file descriptor.
+ *                 Using this flag saves extra calls to fcntl to achieve
+ *                 the same result.
+ *
+ *   SFD_CLOEXEC   Set the close-on-exec (FD_CLOEXEC) flag on the new file
+ *                 descriptor. See the description of the O_CLOEXEC flag
+ *                 in open for reasons why this may be useful.
+ *
+ * Returned Value:
+ *   On success, signalfd() returns a signalfd file descriptor; this is
+ *   either a new file descriptor (if fd was -1), or fd if fd was a valid
+ *   signalfd file descriptor. On error, -1 is returned and errno is set
+ *   to indicate the error.
+ *
+ ****************************************************************************/
+
+int signalfd(int fd, FAR const sigset_t *mask, int flags)
+{
+  FAR struct signalfd_priv_s *dev;
+  struct sigaction act;
+  int ret = EINVAL;
+  int signo;
+
+  if (flags & ~(SFD_CLOEXEC | SFD_NONBLOCK))
+    {
+      goto errout;
+    }
+
+  if (fd == -1)
+    {
+      dev = kmm_zalloc(sizeof(*dev));
+      if (dev == NULL)
+        {
+          ret = ENOMEM;
+          goto errout;
+        }
+
+      nxmutex_init(&dev->mutex);
+
+      fd = file_allocate(&g_signalfd_inode, O_RDOK | flags,
+                         0, dev, 0, true);
+      if (fd < 0)
+        {
+          ret = -fd;
+          goto errout_with_dev;
+        }
+    }
+  else
+    {
+      FAR struct file *filep;
+
+      if (fs_getfilep(fd, &filep) < 0)
+        {
+          ret = EBADF;
+          goto errout;
+        }
+
+      if (filep->f_inode->u.i_ops != &g_signalfd_fileops)
+        {
+          goto errout;
+        }
+
+      dev = filep->f_priv;
+      for (signo = MIN_SIGNO; signo <= MAX_SIGNO; signo++)
+        {
+          if (nxsig_ismember(&dev->sigmask, signo))
+            {
+              signal(signo, SIG_DFL);
+            }
+        }
+    }
+
+  dev->sigmask = *mask;
+  nxsig_delset(&dev->sigmask, SIGKILL);
+  nxsig_delset(&dev->sigmask, SIGSTOP);
+  act.sa_sigaction = signalfd_action;
+  act.sa_flags = SA_KERNELHAND | SA_SIGINFO;
+  act.sa_user = dev;
+  for (signo = MIN_SIGNO; signo <= MAX_SIGNO; signo++)
+    {
+      if (nxsig_ismember(&dev->sigmask, signo))
+        {
+          nxsig_action(signo, &act, NULL, false);
+        }
+    }
+
+  return fd;
+
+errout_with_dev:
+  nxmutex_destroy(&dev->mutex);
+  kmm_free(dev);
+
+errout:
+  set_errno(ret);
+  return ERROR;
+}

--- a/include/nuttx/signal.h
+++ b/include/nuttx/signal.h
@@ -32,6 +32,7 @@
 #include <signal.h>
 
 #include <nuttx/wqueue.h>
+#include <nuttx/sched.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -189,6 +190,24 @@ int nxsig_addset(FAR sigset_t *set, int signo);
  ****************************************************************************/
 
 int nxsig_delset(FAR sigset_t *set, int signo);
+
+/****************************************************************************
+ * Name: nxsig_pendingset
+ *
+ * Description:
+ *   Convert the list of pending signals into a signal set
+ *
+ * Input Parameters:
+ *   stcb - The specific tcb of return pending set.
+ *
+ * Returned Value:
+ *   Return the pending signal set.
+ *
+ * Assumptions:
+ *
+ ****************************************************************************/
+
+sigset_t nxsig_pendingset(FAR struct tcb_s *stcb);
 
 /****************************************************************************
  * Name: nxsig_procmask

--- a/include/signal.h
+++ b/include/signal.h
@@ -269,6 +269,7 @@
                                   * being masked in the handler */
 #define SA_RESETHAND    (1 << 6) /* Clears the handler when the signal
                                   * is delivered */
+#define SA_KERNELHAND   (1 << 7) /* Invoke the handler in kernel space directly */
 
 /* These are the possible values of the signfo si_code field */
 
@@ -371,6 +372,7 @@ struct siginfo
 #if 0                        /* Not implemented */
   FAR void    *si_addr;      /* Report address with SIGFPE, SIGSEGV, or SIGBUS */
 #endif
+  FAR void    *si_user;      /* The User info associated with sigaction */
 };
 
 #ifndef __SIGINFO_T_DEFINED
@@ -401,6 +403,7 @@ struct sigaction
   } sa_u;
   sigset_t          sa_mask;
   int               sa_flags;
+  FAR void         *sa_user;
 };
 
 /* Definitions that adjust the non-standard naming */

--- a/include/sys/signalfd.h
+++ b/include/sys/signalfd.h
@@ -1,0 +1,88 @@
+/****************************************************************************
+ * include/sys/signalfd.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_SYS_SIGNALFD_H
+#define __INCLUDE_SYS_SIGNALFD_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdint.h>
+#include <signal.h>
+#include <fcntl.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define SFD_CLOEXEC O_CLOEXEC
+#define SFD_NONBLOCK O_NONBLOCK
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+struct signalfd_siginfo
+{
+  uint32_t ssi_signo;
+  int32_t  ssi_errno;
+  int32_t  ssi_code;
+  uint32_t ssi_pid;
+  uint32_t ssi_uid;
+  int32_t  ssi_fd;
+  uint32_t ssi_tid;
+  uint32_t ssi_band;
+  uint32_t ssi_overrun;
+  uint32_t ssi_trapno;
+  int32_t  ssi_status;
+  int32_t  ssi_int;
+  uint64_t ssi_ptr;
+  uint64_t ssi_utime;
+  uint64_t ssi_stime;
+  uint64_t ssi_addr;
+  uint16_t ssi_addr_lsb;
+  uint16_t __pad2;
+  int32_t  ssi_syscall;
+  uint64_t ssi_call_addr;
+  uint32_t ssi_arch;
+  uint8_t  __pad[28];
+};
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+int signalfd(int fd, FAR const sigset_t *mask, int flags);
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __INCLUDE_SYS_TIMERFD_H */

--- a/sched/signal/sig_action.c
+++ b/sched/signal/sig_action.c
@@ -373,6 +373,7 @@ int nxsig_action(int signo, FAR const struct sigaction *act,
       sigact->act.sa_handler = handler;
       sigact->act.sa_mask    = act->sa_mask;
       sigact->act.sa_flags   = act->sa_flags;
+      sigact->act.sa_user    = act->sa_user;
     }
 
   return OK;

--- a/sched/signal/sig_pending.c
+++ b/sched/signal/sig_pending.c
@@ -58,16 +58,13 @@
 
 int sigpending(FAR sigset_t *set)
 {
-  FAR struct tcb_s *rtcb = this_task();
-  int ret = ERROR;
-
   if (set)
     {
-      *set = nxsig_pendingset(rtcb);
-      ret = OK;
+      *set = nxsig_pendingset(NULL);
+      return OK;
     }
 
-  return ret;
+  return ERROR;
 }
 
 /****************************************************************************
@@ -80,11 +77,17 @@ int sigpending(FAR sigset_t *set)
 
 sigset_t nxsig_pendingset(FAR struct tcb_s *stcb)
 {
-  FAR struct task_group_s *group = stcb->group;
+  FAR struct task_group_s *group;
   sigset_t sigpendset;
   FAR sigpendq_t *sigpend;
   irqstate_t flags;
 
+  if (stcb == NULL)
+    {
+      stcb = this_task();
+    }
+
+  group = stcb->group;
   DEBUGASSERT(group);
 
   sigpendset = NULL_SIGNAL_SET;

--- a/sched/signal/signal.h
+++ b/sched/signal/signal.h
@@ -163,10 +163,6 @@ _sa_handler_t      nxsig_default(FAR struct tcb_s *tcb, int signo,
 int                nxsig_default_initialize(FAR struct tcb_s *tcb);
 #endif
 
-/* sig_pending.c */
-
-sigset_t           nxsig_pendingset(FAR struct tcb_s *stcb);
-
 /* sig_dispatch.c */
 
 int                nxsig_tcbdispatch(FAR struct tcb_s *stcb,


### PR DESCRIPTION
## Summary
1. using file descriptor to accept signal.
2. export api nxsig_pendingset to include/nuttx/signal.h
3. Support sigaction:sa_user, siginfo_t:si_user with user info.
## Impact
signalfd
## Testing
daily test.
