### PR TITLE
drivers/note: unify the spinlock operation in noteram

### DIFF
--- a/include/nuttx/spinlock.h
+++ b/include/nuttx/spinlock.h
@@ -391,6 +391,16 @@ irqstate_t spin_lock_irqsave(spinlock_t *lock);
 #endif
 
 /****************************************************************************
+ * Name: spin_lock_irqsave_wo_note
+ ****************************************************************************/
+
+#if defined(CONFIG_SMP)
+irqstate_t spin_lock_irqsave_wo_note(spinlock_t *lock);
+#else
+#  define spin_lock_irqsave_wo_note(l) ((void)(l), up_irq_save())
+#endif
+
+/****************************************************************************
  * Name: spin_unlock_irqrestore
  *
  * Description:
@@ -423,6 +433,16 @@ irqstate_t spin_lock_irqsave(spinlock_t *lock);
 void spin_unlock_irqrestore(spinlock_t *lock, irqstate_t flags);
 #else
 #  define spin_unlock_irqrestore(l, f) up_irq_restore(f)
+#endif
+
+/****************************************************************************
+ * Name: spin_unlock_irqrestore_wo_note
+ ****************************************************************************/
+
+#if defined(CONFIG_SMP)
+void spin_unlock_irqrestore_wo_note(spinlock_t *lock, irqstate_t flags);
+#else
+#  define spin_unlock_irqrestore_wo_note(l, f) up_irq_restore(f)
 #endif
 
 #endif /* __INCLUDE_NUTTX_SPINLOCK_H */

--- a/sched/irq/irq_spinlock.c
+++ b/sched/irq/irq_spinlock.c
@@ -107,6 +107,34 @@ irqstate_t spin_lock_irqsave(spinlock_t *lock)
 }
 
 /****************************************************************************
+ * Name: spin_lock_irqsave_wo_note
+ ****************************************************************************/
+
+irqstate_t spin_lock_irqsave_wo_note(spinlock_t *lock)
+{
+  irqstate_t ret;
+  ret = up_irq_save();
+
+  if (NULL == lock)
+    {
+      int me = this_cpu();
+      if (0 == g_irq_spin_count[me])
+        {
+          spin_lock_wo_note(&g_irq_spin);
+        }
+
+      g_irq_spin_count[me]++;
+      DEBUGASSERT(0 != g_irq_spin_count[me]);
+    }
+  else
+    {
+      spin_lock_wo_note(lock);
+    }
+
+  return ret;
+}
+
+/****************************************************************************
  * Name: spin_unlock_irqrestore
  *
  * Description:
@@ -151,6 +179,31 @@ void spin_unlock_irqrestore(spinlock_t *lock, irqstate_t flags)
   else
     {
       spin_unlock(lock);
+    }
+
+  up_irq_restore(flags);
+}
+
+/****************************************************************************
+ * Name: spin_lock_irqsave_wo_note
+ ****************************************************************************/
+
+void spin_unlock_irqrestore_wo_note(spinlock_t *lock, irqstate_t flags)
+{
+  if (NULL == lock)
+    {
+      int me = this_cpu();
+      DEBUGASSERT(0 < g_irq_spin_count[me]);
+      g_irq_spin_count[me]--;
+
+      if (0 == g_irq_spin_count[me])
+        {
+          spin_unlock_wo_note(&g_irq_spin);
+        }
+    }
+  else
+    {
+      spin_unlock_wo_note(lock);
     }
 
   up_irq_restore(flags);


### PR DESCRIPTION
## Summary
Simplify shared resource protection operations in noteram

Unified use of spinlock_irqsave_wo_note

## Impact

## Testing
sim:note
