### PR TITLE
sched: group: Fix memory corruption in group_leave.c

### DIFF
--- a/sched/group/group_leave.c
+++ b/sched/group/group_leave.c
@@ -156,6 +156,12 @@ static inline void group_release(FAR struct task_group_s *group)
   pthread_release(group);
 #endif
 
+#ifdef CONFIG_FILE_STREAM
+  /* Free resource held by the stream list */
+
+  lib_stream_release(group);
+#endif /* CONFIG_FILE_STREAM */
+
   /* Free all file-related resources now.  We really need to close files as
    * soon as possible while we still have a functioning task.
    */
@@ -163,12 +169,6 @@ static inline void group_release(FAR struct task_group_s *group)
   /* Free resources held by the file descriptor list */
 
   files_releaselist(&group->tg_filelist);
-
-#ifdef CONFIG_FILE_STREAM
-  /* Free resource held by the stream list */
-
-  lib_stream_release(group);
-#endif /* CONFIG_FILE_STREAM */
 
 #ifndef CONFIG_DISABLE_ENVIRON
   /* Release all shared environment variables */


### PR DESCRIPTION
## Summary

- I noticed that nxplayer (HTTP audio streaming) + command execution via telnet sometimes causes memory corruption.
- See https://github.com/apache/nuttx/pull/7947 for the detail.
- This commit fixes this issue by calling lib_stream_release() before lib_stream_release() in group_leave.c

## Impact

- Should be none

## Testing

- Tested with spresense:wifi_smp

