### PR TITLE
libc/passwd: add pw_gecos field(userinfo)

### DIFF
--- a/include/pwd.h
+++ b/include/pwd.h
@@ -49,6 +49,7 @@ struct passwd
   FAR char *pw_name;
   uid_t     pw_uid;
   gid_t     pw_gid;
+  FAR char *pw_gecos;
   FAR char *pw_dir;
   FAR char *pw_shell;
 };

--- a/libs/libc/pwd/lib_find_pwdfile.c
+++ b/libs/libc/pwd/lib_find_pwdfile.c
@@ -219,7 +219,27 @@ static int pwd_foreach(pwd_foreach_match_t match, uintptr_t arg,
 
       *ptr++        = '\0';
       entry->pw_gid = (gid_t)atoi(save);
-      entry->pw_dir = ptr;
+      save          = ptr;
+
+      /* Skip to the end of the user information and properly terminate it.
+       * The user information must be terminated with the field delimiter
+       * ':'.
+       */
+
+      for (; *ptr != '\n' && *ptr != '\0' && *ptr != ':'; ptr++)
+        {
+        }
+
+      if (*ptr == '\n' || *ptr == '\0')
+        {
+          /* Bad line format? */
+
+          continue;
+        }
+
+      *ptr++          = '\0';
+      entry->pw_gecos = save;
+      entry->pw_dir   = ptr;
 
       /* Skip to the end of the home directory and properly terminate it.
        * The home directory must be the last thing on the line.

--- a/libs/libc/pwd/lib_getpwbuf.c
+++ b/libs/libc/pwd/lib_getpwbuf.c
@@ -54,6 +54,7 @@ static FAR struct passwd *g_pwd;
  *   uid   - Value to set the passwd structure's pw_uid field to.
  *   gid   - Value to set the passwd structure's pw_gid field to.
  *   name  - Value to set the passwd structure's pw_name field to.
+ *   geocs - Value to set the passwd structure's pw_gecos field to.
  *   dir   - Value to set the passwd structure's pw_dir field to.
  *   shell - Value to set the passwd structure's pw_shell field to.
  *
@@ -64,14 +65,16 @@ static FAR struct passwd *g_pwd;
  ****************************************************************************/
 
 FAR struct passwd *getpwbuf(uid_t uid, gid_t gid, FAR const char *name,
-                            FAR const char *dir, FAR const char *shell)
+                            FAR const char *gecos, FAR const char *dir,
+                            FAR const char *shell)
 {
   FAR struct passwd *result;
   FAR char *newbuf;
   size_t buflen;
   int err;
 
-  buflen = strlen(name) + 1 + strlen(dir) + 1 + strlen(shell) + 1;
+  buflen = strlen(name) + 1 + strlen(gecos) + 1 + strlen(dir) + 1 +
+           strlen(shell) + 1;
 
   newbuf = (FAR char *)lib_realloc(g_buf, buflen);
 
@@ -94,7 +97,7 @@ FAR struct passwd *getpwbuf(uid_t uid, gid_t gid, FAR const char *name,
       goto error;
     }
 
-  err = getpwbuf_r(uid, gid, name, dir, shell,
+  err = getpwbuf_r(uid, gid, name, gecos, dir, shell,
                    g_pwd, g_buf, buflen, &result);
 
   if (err)

--- a/libs/libc/pwd/lib_getpwbufr.c
+++ b/libs/libc/pwd/lib_getpwbufr.c
@@ -47,6 +47,7 @@
  *   uid    - Value to set the passwd structure's pw_uid field to.
  *   gid    - Value to set the passwd structure's pw_gid field to.
  *   name   - Value to set the passwd structure's pw_name field to.
+ *   gecos  - Value to set the passwd structure's pw_gecos field to.
  *   dir    - Value to set the passwd structure's pw_dir field to.
  *   shell  - Value to set the passwd structure's pw_shell field to.
  *   pwd    - Pointer to the space to store the retrieved passwd structure
@@ -63,13 +64,14 @@
  ****************************************************************************/
 
 int getpwbuf_r(uid_t uid, gid_t gid, FAR const char *name,
-               FAR const char *dir, FAR const char *shell,
-               FAR struct passwd *pwd, FAR char *buf, size_t buflen,
-               FAR struct passwd **result)
+               FAR const char *gecos, FAR const char *dir,
+               FAR const char *shell, FAR struct passwd *pwd,
+               FAR char *buf, size_t buflen, FAR struct passwd **result)
 {
   size_t reqdlen;
 
-  reqdlen = strlen(name) + 1 + strlen(dir) + 1 + strlen(shell) + 1;
+  reqdlen = strlen(name) + 1 + strlen(gecos) + 1 + strlen(dir) + 1 +
+            strlen(shell) + 1;
 
   if (buflen < reqdlen)
     {
@@ -80,12 +82,14 @@ int getpwbuf_r(uid_t uid, gid_t gid, FAR const char *name,
     }
 
   pwd->pw_name  = buf;
-  pwd->pw_dir   = &buf[strlen(name) + 1];
-  pwd->pw_shell = &buf[strlen(name) + 1 + strlen(dir) + 1];
+  pwd->pw_gecos = &buf[strlen(name) + 1];
+  pwd->pw_dir   = &buf[strlen(name) + strlen(gecos) + 2];
+  pwd->pw_shell = &buf[strlen(name) + strlen(gecos) + strlen(dir) + 3];
 
   pwd->pw_uid = uid;
   pwd->pw_gid = gid;
   strcpy(pwd->pw_name, name);
+  strcpy(pwd->pw_gecos, gecos);
   strcpy(pwd->pw_dir, dir);
   strcpy(pwd->pw_shell, shell);
 

--- a/libs/libc/pwd/lib_getpwnam.c
+++ b/libs/libc/pwd/lib_getpwnam.c
@@ -71,6 +71,7 @@ FAR struct passwd *getpwnam(FAR const char *name)
       return NULL;
     }
 
-  return getpwbuf(ROOT_UID, ROOT_GID, ROOT_NAME, ROOT_DIR, ROOT_SHELL);
+  return getpwbuf(ROOT_UID, ROOT_GID, ROOT_NAME, ROOT_NAME, ROOT_DIR,
+                  ROOT_SHELL);
 #endif
 }

--- a/libs/libc/pwd/lib_getpwnamr.c
+++ b/libs/libc/pwd/lib_getpwnamr.c
@@ -82,7 +82,7 @@ int getpwnam_r(FAR const char *name, FAR struct passwd *pwd, FAR char *buf,
       return 0;
     }
 
-  return getpwbuf_r(ROOT_UID, ROOT_GID, ROOT_NAME, ROOT_DIR, ROOT_SHELL, pwd,
-                    buf, buflen, result);
+  return getpwbuf_r(ROOT_UID, ROOT_GID, ROOT_NAME, ROOT_NAME, ROOT_DIR,
+                    ROOT_SHELL, pwd, buf, buflen, result);
 #endif
 }

--- a/libs/libc/pwd/lib_getpwuid.c
+++ b/libs/libc/pwd/lib_getpwuid.c
@@ -70,6 +70,7 @@ FAR struct passwd *getpwuid(uid_t uid)
       return NULL;
     }
 
-  return getpwbuf(ROOT_UID, ROOT_GID, ROOT_NAME, ROOT_DIR, ROOT_SHELL);
+  return getpwbuf(ROOT_UID, ROOT_GID, ROOT_NAME, ROOT_NAME, ROOT_DIR,
+                  ROOT_SHELL);
 #endif
 }

--- a/libs/libc/pwd/lib_getpwuidr.c
+++ b/libs/libc/pwd/lib_getpwuidr.c
@@ -81,7 +81,7 @@ int getpwuid_r(uid_t uid, FAR struct passwd *pwd, FAR char *buf,
       return 0;
     }
 
-  return getpwbuf_r(ROOT_UID, ROOT_GID, ROOT_NAME, ROOT_DIR, ROOT_SHELL, pwd,
-                    buf, buflen, result);
+  return getpwbuf_r(ROOT_UID, ROOT_GID, ROOT_NAME, ROOT_NAME, ROOT_DIR,
+                    ROOT_SHELL, pwd, buf, buflen, result);
 #endif
 }

--- a/libs/libc/pwd/lib_pwd.h
+++ b/libs/libc/pwd/lib_pwd.h
@@ -63,11 +63,12 @@ EXTERN char g_passwd_buffer[CONFIG_LIBC_PASSWD_LINESIZE];
  ****************************************************************************/
 
 FAR struct passwd *getpwbuf(uid_t uid, gid_t gid, FAR const char *name,
-                            FAR const char *dir, FAR const char *shell);
+                            FAR const char *gecos, FAR const char *dir,
+                            FAR const char *shell);
 int getpwbuf_r(uid_t uid, gid_t gid, FAR const char *name,
-               FAR const char *dir, FAR const char *shell,
-               FAR struct passwd *pwd, FAR char *buf, size_t buflen,
-               FAR struct passwd **result);
+               FAR const char *gecos, FAR const char *dir,
+               FAR const char *shell, FAR struct passwd *pwd,
+               FAR char *buf, size_t buflen, FAR struct passwd **result);
 
 #ifdef CONFIG_LIBC_PASSWD_FILE
 int pwd_findby_name(FAR const char *uname, FAR struct passwd *entry,


### PR DESCRIPTION


## Summary
libc/passwd: add pw_gecos field(userinfo)

The pw_gecos field is not specified in POSIX, but is present on most implementations.
passwd file format:
name:uid:gid:gecos:dir:shell
ex: `gdm:x:127:133:Gnome Display Manager:/var/lib/gdm3:/bin/false`

Signed-off-by: dongjiuzhu1 <dongjiuzhu1@xiaomi.com>
## Impact
add pw_gecos filed for struct passwd
## Testing
local test.
