### PR TITLE
sys/socket/scm: return NULL when cmsg_len is zero

### DIFF
--- a/include/sys/socket.h
+++ b/include/sys/socket.h
@@ -348,11 +348,12 @@ static inline FAR struct cmsghdr *__cmsg_nxthdr(FAR void *__ctl,
                                                 unsigned int __size,
                                                 FAR struct cmsghdr *__cmsg)
 {
-  FAR struct cmsghdr *__ptr;
+  size_t len = CMSG_ALIGN(__cmsg->cmsg_len);
+  FAR struct cmsghdr *__ptr =
+               (FAR struct cmsghdr *)(((FAR char *)__cmsg) + len);
 
-  __ptr = (FAR struct cmsghdr *)
-    (((FAR char *)__cmsg) + CMSG_ALIGN(__cmsg->cmsg_len));
-  if ((unsigned long)((FAR char *)(__ptr + 1) - (FAR char *)__ctl) > __size)
+  if (len < sizeof(*__cmsg) ||
+      (unsigned long)((FAR char *)(__ptr + 1) - (FAR char *)__ctl) > __size)
     {
       return NULL;
     }


### PR DESCRIPTION


## Summary
sys/socket/scm: return NULL when cmsg_len is zero

Signed-off-by: dongjiuzhu1 <dongjiuzhu1@xiaomi.com>
## Impact
bugfix
## Testing
local test
