### PR TITLE
Change FIOC_MMAP, FIOC_MUNMAP and FIOC_TRUNCATE into file operation c…

### DIFF
--- a/Documentation/reference/user/10_filesystem.rst
+++ b/Documentation/reference/user/10_filesystem.rst
@@ -458,12 +458,11 @@ are two conditions where ``mmap()`` can be supported:
 1. ``mmap()`` can be used to support *eXecute In Place* (XIP) on random
    access media under the following very restrictive conditions:
 
-   a. The file-system supports the ``FIOC_MMAP`` ioctl command. Any file
-      system that maps files contiguously on the media should support
-      this ``ioctl`` command. By comparison, most file system scatter
-      files over the media in non-contiguous sectors. As of this
-      writing, ROMFS is the only file system that meets this
-      requirement.
+   a. Any file system that maps files contiguously on the media
+      should implement the mmap file operation. By comparison, most
+      file system scatter files over the media in non-contiguous
+      sectors. As of this writing, ROMFS is the only file system
+      that meets this requirement.
 
    b. The underlying block driver supports the ``BIOC_XIPBASE``
       ``ioctl`` command that maps the underlying media to a randomly

--- a/arch/arm/src/cxd56xx/cxd56_geofence.c
+++ b/arch/arm/src/cxd56xx/cxd56_geofence.c
@@ -106,6 +106,7 @@ static const struct file_operations g_geofencefops =
   NULL,                 /* write */
   NULL,                 /* seek */
   cxd56_geofence_ioctl, /* ioctl */
+  NULL,                 /* truncate */
   cxd56_geofence_poll   /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL                /* unlink */

--- a/arch/arm/src/cxd56xx/cxd56_geofence.c
+++ b/arch/arm/src/cxd56xx/cxd56_geofence.c
@@ -107,6 +107,7 @@ static const struct file_operations g_geofencefops =
   NULL,                 /* seek */
   cxd56_geofence_ioctl, /* ioctl */
   NULL,                 /* truncate */
+  NULL,                 /* mmap */
   cxd56_geofence_poll   /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL                /* unlink */

--- a/arch/arm/src/cxd56xx/cxd56_gnss.c
+++ b/arch/arm/src/cxd56xx/cxd56_gnss.c
@@ -318,6 +318,7 @@ static const struct file_operations g_gnssfops =
   NULL,             /* seek */
   cxd56_gnss_ioctl, /* ioctl */
   NULL,             /* truncate */
+  NULL,             /* mmap */
   cxd56_gnss_poll   /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL            /* unlink */

--- a/arch/arm/src/cxd56xx/cxd56_gnss.c
+++ b/arch/arm/src/cxd56xx/cxd56_gnss.c
@@ -317,6 +317,7 @@ static const struct file_operations g_gnssfops =
   cxd56_gnss_write, /* write */
   NULL,             /* seek */
   cxd56_gnss_ioctl, /* ioctl */
+  NULL,             /* truncate */
   cxd56_gnss_poll   /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL            /* unlink */

--- a/arch/arm/src/cxd56xx/cxd56_hostif.c
+++ b/arch/arm/src/cxd56xx/cxd56_hostif.c
@@ -145,6 +145,7 @@ static const struct file_operations g_hif_fops =
   hif_write,   /* write */
   hif_seek,    /* seek */
   hif_ioctl,   /* ioctl */
+  NULL,        /* truncate */
   hif_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , hif_unlink /* unlink */

--- a/arch/arm/src/cxd56xx/cxd56_hostif.c
+++ b/arch/arm/src/cxd56xx/cxd56_hostif.c
@@ -146,6 +146,7 @@ static const struct file_operations g_hif_fops =
   hif_seek,    /* seek */
   hif_ioctl,   /* ioctl */
   NULL,        /* truncate */
+  NULL,        /* mmap */
   hif_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , hif_unlink /* unlink */

--- a/arch/arm/src/sama5/sam_tsd.c
+++ b/arch/arm/src/sama5/sam_tsd.c
@@ -250,6 +250,7 @@ static const struct file_operations g_tsdops =
   NULL,            /* seek */
   sam_tsd_ioctl,   /* ioctl */
   NULL,            /* truncate */
+  NULL,            /* mmap */
   sam_tsd_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL           /* unlink */

--- a/arch/arm/src/sama5/sam_tsd.c
+++ b/arch/arm/src/sama5/sam_tsd.c
@@ -249,6 +249,7 @@ static const struct file_operations g_tsdops =
   NULL,            /* write */
   NULL,            /* seek */
   sam_tsd_ioctl,   /* ioctl */
+  NULL,            /* truncate */
   sam_tsd_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL           /* unlink */

--- a/boards/arm/sam34/sam4l-xplained/src/sam_slcd.c
+++ b/boards/arm/sam34/sam4l-xplained/src/sam_slcd.c
@@ -296,6 +296,7 @@ static const struct file_operations g_slcdops =
   slcd_write,    /* write */
   NULL,          /* seek */
   slcd_ioctl,    /* ioctl */
+  NULL,          /* truncate */
   slcd_poll      /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL         /* unlink */

--- a/boards/arm/sam34/sam4l-xplained/src/sam_slcd.c
+++ b/boards/arm/sam34/sam4l-xplained/src/sam_slcd.c
@@ -297,6 +297,7 @@ static const struct file_operations g_slcdops =
   NULL,          /* seek */
   slcd_ioctl,    /* ioctl */
   NULL,          /* truncate */
+  NULL,          /* mmap */
   slcd_poll      /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL         /* unlink */

--- a/boards/arm/stm32/mikroe-stm32f4/src/stm32_touchscreen.c
+++ b/boards/arm/stm32/mikroe-stm32f4/src/stm32_touchscreen.c
@@ -268,6 +268,7 @@ static const struct file_operations tc_fops =
   NULL,       /* write */
   NULL,       /* seek */
   tc_ioctl,   /* ioctl */
+  NULL,       /* truncate */
   tc_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL      /* unlink */

--- a/boards/arm/stm32/mikroe-stm32f4/src/stm32_touchscreen.c
+++ b/boards/arm/stm32/mikroe-stm32f4/src/stm32_touchscreen.c
@@ -269,6 +269,7 @@ static const struct file_operations tc_fops =
   NULL,       /* seek */
   tc_ioctl,   /* ioctl */
   NULL,       /* truncate */
+  NULL,       /* mmap */
   tc_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL      /* unlink */

--- a/boards/arm/stm32/stm32ldiscovery/src/stm32_lcd.c
+++ b/boards/arm/stm32/stm32ldiscovery/src/stm32_lcd.c
@@ -347,6 +347,7 @@ static const struct file_operations g_slcdops =
   NULL,          /* seek */
   slcd_ioctl,    /* ioctl */
   NULL,          /* truncate */
+  NULL,          /* mmap */
   slcd_poll      /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL         /* unlink */

--- a/boards/arm/stm32/stm32ldiscovery/src/stm32_lcd.c
+++ b/boards/arm/stm32/stm32ldiscovery/src/stm32_lcd.c
@@ -346,6 +346,7 @@ static const struct file_operations g_slcdops =
   slcd_write,    /* write */
   NULL,          /* seek */
   slcd_ioctl,    /* ioctl */
+  NULL,          /* truncate */
   slcd_poll      /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL         /* unlink */

--- a/boards/mips/pic32mx/pic32mx7mmb/src/pic32_touchscreen.c
+++ b/boards/mips/pic32mx/pic32mx7mmb/src/pic32_touchscreen.c
@@ -249,6 +249,7 @@ static const struct file_operations tc_fops =
   NULL,       /* write */
   NULL,       /* seek */
   tc_ioctl,   /* ioctl */
+  NULL,       /* truncate */
   tc_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL      /* unlink */

--- a/boards/mips/pic32mx/pic32mx7mmb/src/pic32_touchscreen.c
+++ b/boards/mips/pic32mx/pic32mx7mmb/src/pic32_touchscreen.c
@@ -250,6 +250,7 @@ static const struct file_operations tc_fops =
   NULL,       /* seek */
   tc_ioctl,   /* ioctl */
   NULL,       /* truncate */
+  NULL,       /* mmap */
   tc_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL      /* unlink */

--- a/boards/mips/pic32mx/sure-pic32mx/src/pic32mx_lcd1602.c
+++ b/boards/mips/pic32mx/sure-pic32mx/src/pic32mx_lcd1602.c
@@ -182,6 +182,7 @@ static const struct file_operations g_lcdops =
   NULL,          /* seek */
   lcd_ioctl,     /* ioctl */
   NULL,          /* truncate */
+  NULL,          /* mmap */
   lcd_poll       /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL         /* unlink */

--- a/boards/mips/pic32mx/sure-pic32mx/src/pic32mx_lcd1602.c
+++ b/boards/mips/pic32mx/sure-pic32mx/src/pic32mx_lcd1602.c
@@ -181,6 +181,7 @@ static const struct file_operations g_lcdops =
   lcd_write,     /* write */
   NULL,          /* seek */
   lcd_ioctl,     /* ioctl */
+  NULL,          /* truncate */
   lcd_poll       /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL         /* unlink */

--- a/crypto/cryptodev.c
+++ b/crypto/cryptodev.c
@@ -125,6 +125,7 @@ static const struct file_operations g_cryptofops =
   cryptof_write,       /* write  */
   NULL,                /* seek   */
   cryptof_ioctl,       /* ioctl  */
+  NULL,                /* truncate */
   cryptof_poll         /* poll   */
 };
 
@@ -136,6 +137,7 @@ static const struct file_operations g_cryptoops =
   NULL,                /* write  */
   NULL,                /* seek   */
   cryptoioctl,         /* ioctl  */
+  NULL,                /* truncate */
   NULL                 /* poll   */
 };
 

--- a/crypto/cryptodev.c
+++ b/crypto/cryptodev.c
@@ -126,6 +126,7 @@ static const struct file_operations g_cryptofops =
   NULL,                /* seek   */
   cryptof_ioctl,       /* ioctl  */
   NULL,                /* truncate */
+  NULL,                /* mmap */
   cryptof_poll         /* poll   */
 };
 
@@ -138,6 +139,7 @@ static const struct file_operations g_cryptoops =
   NULL,                /* seek   */
   cryptoioctl,         /* ioctl  */
   NULL,                /* truncate */
+  NULL,                /* mmap */
   NULL                 /* poll   */
 };
 

--- a/drivers/analog/adc.c
+++ b/drivers/analog/adc.c
@@ -72,6 +72,7 @@ static const struct file_operations g_adc_fops =
   NULL,         /* write */
   NULL,         /* seek */
   adc_ioctl,    /* ioctl */
+  NULL,         /* truncate */
   adc_poll      /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL        /* unlink */

--- a/drivers/analog/adc.c
+++ b/drivers/analog/adc.c
@@ -73,6 +73,7 @@ static const struct file_operations g_adc_fops =
   NULL,         /* seek */
   adc_ioctl,    /* ioctl */
   NULL,         /* truncate */
+  NULL,         /* mmap */
   adc_poll      /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL        /* unlink */

--- a/drivers/analog/comp.c
+++ b/drivers/analog/comp.c
@@ -66,6 +66,7 @@ static const struct file_operations comp_fops =
   NULL,                         /* seek */
   comp_ioctl,                   /* ioctl */
   NULL,                         /* truncate */
+  NULL,                         /* mmap */
   comp_poll                     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL                        /* unlink */

--- a/drivers/analog/comp.c
+++ b/drivers/analog/comp.c
@@ -65,6 +65,7 @@ static const struct file_operations comp_fops =
   NULL,                         /* write */
   NULL,                         /* seek */
   comp_ioctl,                   /* ioctl */
+  NULL,                         /* truncate */
   comp_poll                     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL                        /* unlink */

--- a/drivers/bch/bchdev_driver.c
+++ b/drivers/bch/bchdev_driver.c
@@ -78,6 +78,7 @@ const struct file_operations bch_fops =
   bch_write,   /* write */
   bch_seek,    /* seek */
   bch_ioctl,   /* ioctl */
+  NULL,        /* truncate */
   bch_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , bch_unlink /* unlink */

--- a/drivers/bch/bchdev_driver.c
+++ b/drivers/bch/bchdev_driver.c
@@ -79,6 +79,7 @@ const struct file_operations bch_fops =
   bch_seek,    /* seek */
   bch_ioctl,   /* ioctl */
   NULL,        /* truncate */
+  NULL,        /* mmap */
   bch_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , bch_unlink /* unlink */

--- a/drivers/can/can.c
+++ b/drivers/can/can.c
@@ -136,6 +136,7 @@ static const struct file_operations g_canops =
   NULL,      /* seek */
   can_ioctl, /* ioctl */
   NULL,      /* truncate */
+  NULL,      /* mmap */
   can_poll   /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL     /* unlink */

--- a/drivers/can/can.c
+++ b/drivers/can/can.c
@@ -135,6 +135,7 @@ static const struct file_operations g_canops =
   can_write, /* write */
   NULL,      /* seek */
   can_ioctl, /* ioctl */
+  NULL,      /* truncate */
   can_poll   /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL     /* unlink */

--- a/drivers/crypto/dev_urandom.c
+++ b/drivers/crypto/dev_urandom.c
@@ -101,6 +101,7 @@ static const struct file_operations g_urand_fops =
   NULL,                         /* seek */
   NULL,                         /* ioctl */
   NULL,                         /* truncate */
+  NULL,                         /* mmap */
   devurand_poll                 /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL                        /* unlink */

--- a/drivers/crypto/dev_urandom.c
+++ b/drivers/crypto/dev_urandom.c
@@ -100,6 +100,7 @@ static const struct file_operations g_urand_fops =
   devurand_write,               /* write */
   NULL,                         /* seek */
   NULL,                         /* ioctl */
+  NULL,                         /* truncate */
   devurand_poll                 /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL                        /* unlink */

--- a/drivers/i2c/i2c_driver.c
+++ b/drivers/i2c/i2c_driver.c
@@ -99,6 +99,7 @@ static const struct file_operations i2cdrvr_fops =
   i2cdrvr_write,   /* write */
   NULL,            /* seek */
   i2cdrvr_ioctl,   /* ioctl */
+  NULL,            /* truncate */
   NULL             /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , i2cdrvr_unlink /* unlink */

--- a/drivers/i2c/i2c_driver.c
+++ b/drivers/i2c/i2c_driver.c
@@ -100,6 +100,7 @@ static const struct file_operations i2cdrvr_fops =
   NULL,            /* seek */
   i2cdrvr_ioctl,   /* ioctl */
   NULL,            /* truncate */
+  NULL,            /* mmap */
   NULL             /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , i2cdrvr_unlink /* unlink */

--- a/drivers/input/ads7843e.c
+++ b/drivers/input/ads7843e.c
@@ -123,6 +123,7 @@ static const struct file_operations ads7843e_fops =
   NULL,             /* seek */
   ads7843e_ioctl,   /* ioctl */
   NULL,             /* truncate */
+  NULL,             /* mmap */
   ads7843e_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL            /* unlink */

--- a/drivers/input/ads7843e.c
+++ b/drivers/input/ads7843e.c
@@ -122,6 +122,7 @@ static const struct file_operations ads7843e_fops =
   NULL,             /* write */
   NULL,             /* seek */
   ads7843e_ioctl,   /* ioctl */
+  NULL,             /* truncate */
   ads7843e_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL            /* unlink */

--- a/drivers/input/ajoystick.c
+++ b/drivers/input/ajoystick.c
@@ -136,6 +136,7 @@ static const struct file_operations ajoy_fops =
   NULL,       /* seek */
   ajoy_ioctl, /* ioctl */
   NULL,       /* truncate */
+  NULL,       /* mmap */
   ajoy_poll   /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL      /* unlink */

--- a/drivers/input/ajoystick.c
+++ b/drivers/input/ajoystick.c
@@ -135,6 +135,7 @@ static const struct file_operations ajoy_fops =
   NULL,       /* write */
   NULL,       /* seek */
   ajoy_ioctl, /* ioctl */
+  NULL,       /* truncate */
   ajoy_poll   /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL      /* unlink */

--- a/drivers/input/button_upper.c
+++ b/drivers/input/button_upper.c
@@ -134,6 +134,7 @@ static const struct file_operations btn_fops =
   NULL,      /* seek */
   btn_ioctl, /* ioctl */
   NULL,      /* truncate */
+  NULL,      /* mmap */
   btn_poll   /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL     /* unlink */

--- a/drivers/input/button_upper.c
+++ b/drivers/input/button_upper.c
@@ -133,6 +133,7 @@ static const struct file_operations btn_fops =
   btn_write, /* write */
   NULL,      /* seek */
   btn_ioctl, /* ioctl */
+  NULL,      /* truncate */
   btn_poll   /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL     /* unlink */

--- a/drivers/input/cypress_mbr3108.c
+++ b/drivers/input/cypress_mbr3108.c
@@ -224,6 +224,7 @@ static const struct file_operations g_mbr3108_fileops =
   mbr3108_write,  /* write */
   NULL,           /* seek */
   NULL,           /* ioctl */
+  NULL,           /* truncate */
   mbr3108_poll    /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL          /* unlink */

--- a/drivers/input/cypress_mbr3108.c
+++ b/drivers/input/cypress_mbr3108.c
@@ -225,6 +225,7 @@ static const struct file_operations g_mbr3108_fileops =
   NULL,           /* seek */
   NULL,           /* ioctl */
   NULL,           /* truncate */
+  NULL,           /* mmap */
   mbr3108_poll    /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL          /* unlink */

--- a/drivers/input/djoystick.c
+++ b/drivers/input/djoystick.c
@@ -135,6 +135,7 @@ static const struct file_operations djoy_fops =
   NULL,       /* write */
   NULL,       /* seek */
   djoy_ioctl, /* ioctl */
+  NULL,       /* truncate */
   djoy_poll   /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL      /* unlink */

--- a/drivers/input/djoystick.c
+++ b/drivers/input/djoystick.c
@@ -136,6 +136,7 @@ static const struct file_operations djoy_fops =
   NULL,       /* seek */
   djoy_ioctl, /* ioctl */
   NULL,       /* truncate */
+  NULL,       /* mmap */
   djoy_poll   /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL      /* unlink */

--- a/drivers/input/ft5x06.c
+++ b/drivers/input/ft5x06.c
@@ -176,6 +176,7 @@ static const struct file_operations ft5x06_fops =
   NULL,           /* write */
   NULL,           /* seek */
   ft5x06_ioctl,   /* ioctl */
+  NULL,           /* truncate */
   ft5x06_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL          /* unlink */

--- a/drivers/input/ft5x06.c
+++ b/drivers/input/ft5x06.c
@@ -177,6 +177,7 @@ static const struct file_operations ft5x06_fops =
   NULL,           /* seek */
   ft5x06_ioctl,   /* ioctl */
   NULL,           /* truncate */
+  NULL,           /* mmap */
   ft5x06_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL          /* unlink */

--- a/drivers/input/keyboard_upper.c
+++ b/drivers/input/keyboard_upper.c
@@ -88,6 +88,7 @@ static const struct file_operations g_keyboard_fops =
   keyboard_write, /* write */
   NULL,           /* seek */
   NULL,           /* ioctl */
+  NULL,           /* truncate */
   keyboard_poll   /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL          /* unlink */

--- a/drivers/input/keyboard_upper.c
+++ b/drivers/input/keyboard_upper.c
@@ -89,6 +89,7 @@ static const struct file_operations g_keyboard_fops =
   NULL,           /* seek */
   NULL,           /* ioctl */
   NULL,           /* truncate */
+  NULL,           /* mmap */
   keyboard_poll   /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL          /* unlink */

--- a/drivers/input/max11802.c
+++ b/drivers/input/max11802.c
@@ -115,6 +115,7 @@ static const struct file_operations max11802_fops =
   NULL,             /* write */
   NULL,             /* seek */
   max11802_ioctl,   /* ioctl */
+  NULL,             /* truncate */
   max11802_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL            /* unlink */

--- a/drivers/input/max11802.c
+++ b/drivers/input/max11802.c
@@ -116,6 +116,7 @@ static const struct file_operations max11802_fops =
   NULL,             /* seek */
   max11802_ioctl,   /* ioctl */
   NULL,             /* truncate */
+  NULL,             /* mmap */
   max11802_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL            /* unlink */

--- a/drivers/input/mxt.c
+++ b/drivers/input/mxt.c
@@ -280,6 +280,7 @@ static const struct file_operations mxt_fops =
   NULL,        /* write */
   NULL,        /* seek */
   mxt_ioctl,   /* ioctl */
+  NULL,        /* truncate */
   mxt_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL       /* unlink */

--- a/drivers/input/mxt.c
+++ b/drivers/input/mxt.c
@@ -281,6 +281,7 @@ static const struct file_operations mxt_fops =
   NULL,        /* seek */
   mxt_ioctl,   /* ioctl */
   NULL,        /* truncate */
+  NULL,        /* mmap */
   mxt_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL       /* unlink */

--- a/drivers/input/spq10kbd.c
+++ b/drivers/input/spq10kbd.c
@@ -256,6 +256,7 @@ static const struct file_operations g_hidkbd_fops =
   NULL,                      /* seek */
   NULL,                      /* ioctl */
   NULL,                      /* truncate */
+  NULL,                      /* mmap */
   spq10kbd_poll              /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL                     /* unlink */

--- a/drivers/input/spq10kbd.c
+++ b/drivers/input/spq10kbd.c
@@ -255,6 +255,7 @@ static const struct file_operations g_hidkbd_fops =
   spq10kbd_write,            /* write */
   NULL,                      /* seek */
   NULL,                      /* ioctl */
+  NULL,                      /* truncate */
   spq10kbd_poll              /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL                     /* unlink */

--- a/drivers/input/stmpe811_tsc.c
+++ b/drivers/input/stmpe811_tsc.c
@@ -124,6 +124,7 @@ static const struct file_operations g_stmpe811fops =
   NULL,             /* write */
   NULL,             /* seek */
   stmpe811_ioctl,   /* ioctl */
+  NULL,             /* truncate */
   stmpe811_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL            /* unlink */

--- a/drivers/input/stmpe811_tsc.c
+++ b/drivers/input/stmpe811_tsc.c
@@ -125,6 +125,7 @@ static const struct file_operations g_stmpe811fops =
   NULL,             /* seek */
   stmpe811_ioctl,   /* ioctl */
   NULL,             /* truncate */
+  NULL,             /* mmap */
   stmpe811_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL            /* unlink */

--- a/drivers/input/touchscreen_upper.c
+++ b/drivers/input/touchscreen_upper.c
@@ -91,6 +91,7 @@ static const struct file_operations g_touch_fops =
   NULL,           /* seek */
   touch_ioctl,    /* ioctl */
   NULL,           /* truncate */
+  NULL,           /* mmap */
   touch_poll      /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL          /* unlink */

--- a/drivers/input/touchscreen_upper.c
+++ b/drivers/input/touchscreen_upper.c
@@ -90,6 +90,7 @@ static const struct file_operations g_touch_fops =
   touch_write,    /* write */
   NULL,           /* seek */
   touch_ioctl,    /* ioctl */
+  NULL,           /* truncate */
   touch_poll      /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL          /* unlink */

--- a/drivers/input/tsc2007.c
+++ b/drivers/input/tsc2007.c
@@ -210,6 +210,7 @@ static const struct file_operations tsc2007_fops =
   NULL,            /* seek */
   tsc2007_ioctl,   /* ioctl */
   NULL,            /* truncate */
+  NULL,            /* mmap */
   tsc2007_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL           /* unlink */

--- a/drivers/input/tsc2007.c
+++ b/drivers/input/tsc2007.c
@@ -209,6 +209,7 @@ static const struct file_operations tsc2007_fops =
   NULL,            /* write */
   NULL,            /* seek */
   tsc2007_ioctl,   /* ioctl */
+  NULL,            /* truncate */
   tsc2007_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL           /* unlink */

--- a/drivers/lcd/ft80x.c
+++ b/drivers/lcd/ft80x.c
@@ -134,6 +134,7 @@ static const struct file_operations g_ft80x_fops =
   ft80x_write,   /* write */
   NULL,          /* seek */
   ft80x_ioctl,   /* ioctl */
+  NULL,          /* truncate */
   NULL           /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , ft80x_unlink /* unlink */

--- a/drivers/lcd/ft80x.c
+++ b/drivers/lcd/ft80x.c
@@ -135,6 +135,7 @@ static const struct file_operations g_ft80x_fops =
   NULL,          /* seek */
   ft80x_ioctl,   /* ioctl */
   NULL,          /* truncate */
+  NULL,          /* mmap */
   NULL           /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , ft80x_unlink /* unlink */

--- a/drivers/lcd/pcf8574_lcd_backpack.c
+++ b/drivers/lcd/pcf8574_lcd_backpack.c
@@ -118,6 +118,7 @@ static const struct file_operations g_pcf8574_lcd_fops =
   pcf8574_lcd_seek,             /* seek */
   pcf8574_lcd_ioctl,            /* ioctl */
   NULL,                         /* truncate */
+  NULL,                         /* mmap */
   pcf8574_lcd_poll              /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , pcf8574_lcd_unlink          /* unlink */

--- a/drivers/lcd/pcf8574_lcd_backpack.c
+++ b/drivers/lcd/pcf8574_lcd_backpack.c
@@ -117,6 +117,7 @@ static const struct file_operations g_pcf8574_lcd_fops =
   pcf8574_lcd_write,            /* write */
   pcf8574_lcd_seek,             /* seek */
   pcf8574_lcd_ioctl,            /* ioctl */
+  NULL,                         /* truncate */
   pcf8574_lcd_poll              /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , pcf8574_lcd_unlink          /* unlink */

--- a/drivers/lcd/tda19988.c
+++ b/drivers/lcd/tda19988.c
@@ -171,6 +171,7 @@ static const struct file_operations tda19988_fops =
   tda19988_seek,     /* seek */
   tda19988_ioctl,    /* ioctl */
   NULL,              /* truncate */
+  NULL,              /* mmap */
   tda19988_poll      /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , tda19988_unlink  /* unlink */

--- a/drivers/lcd/tda19988.c
+++ b/drivers/lcd/tda19988.c
@@ -170,6 +170,7 @@ static const struct file_operations tda19988_fops =
   tda19988_write,    /* write */
   tda19988_seek,     /* seek */
   tda19988_ioctl,    /* ioctl */
+  NULL,              /* truncate */
   tda19988_poll      /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , tda19988_unlink  /* unlink */

--- a/drivers/leds/ws2812.c
+++ b/drivers/leds/ws2812.c
@@ -182,8 +182,8 @@ static const struct file_operations g_ws2812fops =
 /****************************************************************************
  * #### TODO ####
  *
- * Consider supporting mmap by returning memory buffer using...
- *       file_ioctl(filep, FIOC_MMAP, (unsigned long)((uintptr_t)&addr));
+ * Consider supporting mmap by returning memory buffer using file_operations'
+ *   mmap
  * Code using this would be non-portable across architectures as the format
  * of the buffer can be different.
  *

--- a/drivers/misc/dev_null.c
+++ b/drivers/misc/dev_null.c
@@ -57,6 +57,7 @@ static const struct file_operations devnull_fops =
   devnull_write, /* write */
   NULL,          /* seek */
   NULL,          /* ioctl */
+  NULL,          /* truncate */
   devnull_poll   /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL         /* unlink */

--- a/drivers/misc/dev_null.c
+++ b/drivers/misc/dev_null.c
@@ -58,6 +58,7 @@ static const struct file_operations devnull_fops =
   NULL,          /* seek */
   NULL,          /* ioctl */
   NULL,          /* truncate */
+  NULL,          /* mmap */
   devnull_poll   /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL         /* unlink */

--- a/drivers/misc/dev_zero.c
+++ b/drivers/misc/dev_zero.c
@@ -57,6 +57,7 @@ static const struct file_operations devzero_fops =
   devzero_write, /* write */
   NULL,          /* seek */
   NULL,          /* ioctl */
+  NULL,          /* truncate */
   devzero_poll   /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL         /* unlink */

--- a/drivers/misc/dev_zero.c
+++ b/drivers/misc/dev_zero.c
@@ -58,6 +58,7 @@ static const struct file_operations devzero_fops =
   NULL,          /* seek */
   NULL,          /* ioctl */
   NULL,          /* truncate */
+  NULL,          /* mmap */
   devzero_poll   /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL         /* unlink */

--- a/drivers/misc/rpmsgdev.c
+++ b/drivers/misc/rpmsgdev.c
@@ -166,6 +166,7 @@ const struct file_operations g_rpmsgdev_ops =
   rpmsgdev_seek,          /* seek */
   rpmsgdev_ioctl,         /* ioctl */
   NULL,                   /* truncate */
+  NULL,                   /* mmap */
   rpmsgdev_poll           /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL                  /* unlink */

--- a/drivers/misc/rpmsgdev.c
+++ b/drivers/misc/rpmsgdev.c
@@ -165,6 +165,7 @@ const struct file_operations g_rpmsgdev_ops =
   rpmsgdev_write,         /* write */
   rpmsgdev_seek,          /* seek */
   rpmsgdev_ioctl,         /* ioctl */
+  NULL,                   /* truncate */
   rpmsgdev_poll           /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL                  /* unlink */

--- a/drivers/modem/alt1250/alt1250.c
+++ b/drivers/modem/alt1250/alt1250.c
@@ -77,6 +77,7 @@ static const struct file_operations g_alt1250fops =
   NULL,          /* write */
   NULL,          /* seek */
   alt1250_ioctl, /* ioctl */
+  NULL,          /* truncate */
   alt1250_poll,  /* poll */
 };
 static uint8_t g_recvbuff[ALTCOM_RX_PKT_SIZE_MAX];

--- a/drivers/modem/alt1250/alt1250.c
+++ b/drivers/modem/alt1250/alt1250.c
@@ -78,6 +78,7 @@ static const struct file_operations g_alt1250fops =
   NULL,          /* seek */
   alt1250_ioctl, /* ioctl */
   NULL,          /* truncate */
+  NULL,          /* mmap */
   alt1250_poll,  /* poll */
 };
 static uint8_t g_recvbuff[ALTCOM_RX_PKT_SIZE_MAX];

--- a/drivers/modem/u-blox.c
+++ b/drivers/modem/u-blox.c
@@ -115,6 +115,7 @@ static const struct file_operations ubxmdm_fops =
   NULL,         /* seek */
   ubxmdm_ioctl, /* ioctl */
   NULL,         /* truncate */
+  NULL,         /* mmap */
   ubxmdm_poll   /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL        /* unlink */

--- a/drivers/modem/u-blox.c
+++ b/drivers/modem/u-blox.c
@@ -114,6 +114,7 @@ static const struct file_operations ubxmdm_fops =
   ubxmdm_write, /* write */
   NULL,         /* seek */
   ubxmdm_ioctl, /* ioctl */
+  NULL,         /* truncate */
   ubxmdm_poll   /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL        /* unlink */

--- a/drivers/mtd/mtd_config.c
+++ b/drivers/mtd/mtd_config.c
@@ -120,6 +120,7 @@ static const struct file_operations mtdconfig_fops =
   NULL,            /* seek */
   mtdconfig_ioctl, /* ioctl */
   NULL,            /* truncate */
+  NULL,            /* mmap */
   mtdconfig_poll   /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL            /* unlink */

--- a/drivers/mtd/mtd_config.c
+++ b/drivers/mtd/mtd_config.c
@@ -119,6 +119,7 @@ static const struct file_operations mtdconfig_fops =
   NULL,            /* write */
   NULL,            /* seek */
   mtdconfig_ioctl, /* ioctl */
+  NULL,            /* truncate */
   mtdconfig_poll   /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL            /* unlink */

--- a/drivers/mtd/mtd_config_fs.c
+++ b/drivers/mtd/mtd_config_fs.c
@@ -141,6 +141,7 @@ static const struct file_operations g_mtdnvs_fops =
   NULL,            /* Write */
   NULL,            /* Seek */
   mtdconfig_ioctl, /* Ioctl */
+  NULL,            /* Truncate */
   mtdconfig_poll   /* Poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL           /* Unlink */

--- a/drivers/mtd/mtd_config_fs.c
+++ b/drivers/mtd/mtd_config_fs.c
@@ -142,6 +142,7 @@ static const struct file_operations g_mtdnvs_fops =
   NULL,            /* Seek */
   mtdconfig_ioctl, /* Ioctl */
   NULL,            /* Truncate */
+  NULL,            /* Mmap */
   mtdconfig_poll   /* Poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL           /* Unlink */

--- a/drivers/net/telnet.c
+++ b/drivers/net/telnet.c
@@ -190,6 +190,7 @@ static const struct file_operations g_telnet_fops =
   telnet_write,  /* write */
   NULL,          /* seek */
   telnet_ioctl,  /* ioctl */
+  NULL,          /* truncate */
   telnet_poll    /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL         /* unlink */
@@ -204,6 +205,7 @@ static const struct file_operations g_factory_fops =
   factory_write, /* write */
   NULL,          /* seek */
   factory_ioctl, /* ioctl */
+  NULL,          /* truncate */
   NULL           /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL         /* unlink */

--- a/drivers/net/telnet.c
+++ b/drivers/net/telnet.c
@@ -191,6 +191,7 @@ static const struct file_operations g_telnet_fops =
   NULL,          /* seek */
   telnet_ioctl,  /* ioctl */
   NULL,          /* truncate */
+  NULL,          /* mmap */
   telnet_poll    /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL         /* unlink */
@@ -206,6 +207,7 @@ static const struct file_operations g_factory_fops =
   NULL,          /* seek */
   factory_ioctl, /* ioctl */
   NULL,          /* truncate */
+  NULL,          /* mmap */
   NULL           /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL         /* unlink */

--- a/drivers/net/tun.c
+++ b/drivers/net/tun.c
@@ -219,6 +219,7 @@ static const struct file_operations g_tun_file_ops =
   tun_write,    /* write */
   NULL,         /* seek */
   tun_ioctl,    /* ioctl */
+  NULL,         /* truncate */
   tun_poll      /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL        /* unlink */

--- a/drivers/net/tun.c
+++ b/drivers/net/tun.c
@@ -220,6 +220,7 @@ static const struct file_operations g_tun_file_ops =
   NULL,         /* seek */
   tun_ioctl,    /* ioctl */
   NULL,         /* truncate */
+  NULL,         /* mmap */
   tun_poll      /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL        /* unlink */

--- a/drivers/pipes/fifo.c
+++ b/drivers/pipes/fifo.c
@@ -47,6 +47,7 @@ static const struct file_operations g_fifo_fops =
   pipecommon_write,    /* write */
   NULL,                /* seek */
   pipecommon_ioctl,    /* ioctl */
+  NULL,                /* truncate */
   pipecommon_poll      /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , pipecommon_unlink  /* unlink */

--- a/drivers/pipes/fifo.c
+++ b/drivers/pipes/fifo.c
@@ -48,6 +48,7 @@ static const struct file_operations g_fifo_fops =
   NULL,                /* seek */
   pipecommon_ioctl,    /* ioctl */
   NULL,                /* truncate */
+  NULL,                /* mmap */
   pipecommon_poll      /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , pipecommon_unlink  /* unlink */

--- a/drivers/pipes/pipe.c
+++ b/drivers/pipes/pipe.c
@@ -62,6 +62,7 @@ static const struct file_operations g_pipe_fops =
   NULL,                /* seek */
   pipecommon_ioctl,    /* ioctl */
   NULL,                /* truncate */
+  NULL,                /* mmap */
   pipecommon_poll      /* poll */
 };
 

--- a/drivers/pipes/pipe.c
+++ b/drivers/pipes/pipe.c
@@ -61,6 +61,7 @@ static const struct file_operations g_pipe_fops =
   pipecommon_write,    /* write */
   NULL,                /* seek */
   pipecommon_ioctl,    /* ioctl */
+  NULL,                /* truncate */
   pipecommon_poll      /* poll */
 };
 

--- a/drivers/power/battery/battery_charger.c
+++ b/drivers/power/battery/battery_charger.c
@@ -92,6 +92,7 @@ static const struct file_operations g_batteryops =
   NULL,                /* seek */
   bat_charger_ioctl,   /* ioctl */
   NULL,                /* truncate */
+  NULL,                /* mmap */
   bat_charger_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL               /* unlink */

--- a/drivers/power/battery/battery_charger.c
+++ b/drivers/power/battery/battery_charger.c
@@ -91,6 +91,7 @@ static const struct file_operations g_batteryops =
   bat_charger_write,   /* write */
   NULL,                /* seek */
   bat_charger_ioctl,   /* ioctl */
+  NULL,                /* truncate */
   bat_charger_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL               /* unlink */

--- a/drivers/power/battery/battery_gauge.c
+++ b/drivers/power/battery/battery_gauge.c
@@ -94,6 +94,7 @@ static const struct file_operations g_batteryops =
   NULL,             /* seek */
   bat_gauge_ioctl,  /* ioctl */
   NULL,             /* truncate */
+  NULL,             /* mmap */
   bat_gauge_poll    /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL            /* unlink */

--- a/drivers/power/battery/battery_gauge.c
+++ b/drivers/power/battery/battery_gauge.c
@@ -93,6 +93,7 @@ static const struct file_operations g_batteryops =
   bat_gauge_write,  /* write */
   NULL,             /* seek */
   bat_gauge_ioctl,  /* ioctl */
+  NULL,             /* truncate */
   bat_gauge_poll    /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL            /* unlink */

--- a/drivers/power/battery/battery_monitor.c
+++ b/drivers/power/battery/battery_monitor.c
@@ -92,6 +92,7 @@ static const struct file_operations g_batteryops =
   bat_monitor_write,   /* write */
   NULL,                /* seek */
   bat_monitor_ioctl,   /* ioctl */
+  NULL,                /* truncate */
   bat_monitor_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL               /* unlink */

--- a/drivers/power/battery/battery_monitor.c
+++ b/drivers/power/battery/battery_monitor.c
@@ -93,6 +93,7 @@ static const struct file_operations g_batteryops =
   NULL,                /* seek */
   bat_monitor_ioctl,   /* ioctl */
   NULL,                /* truncate */
+  NULL,                /* mmap */
   bat_monitor_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL               /* unlink */

--- a/drivers/rc/lirc_dev.c
+++ b/drivers/rc/lirc_dev.c
@@ -104,6 +104,7 @@ static const struct file_operations g_lirc_fops =
   NULL,        /* seek */
   lirc_ioctl,  /* ioctl */
   NULL,        /* truncate */
+  NULL,        /* mmap */
   lirc_poll    /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL       /* unlink */

--- a/drivers/rc/lirc_dev.c
+++ b/drivers/rc/lirc_dev.c
@@ -103,6 +103,7 @@ static const struct file_operations g_lirc_fops =
   lirc_write,  /* write */
   NULL,        /* seek */
   lirc_ioctl,  /* ioctl */
+  NULL,        /* truncate */
   lirc_poll    /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL       /* unlink */

--- a/drivers/sensors/aht10.c
+++ b/drivers/sensors/aht10.c
@@ -116,6 +116,7 @@ static const struct file_operations g_aht10fops =
   aht10_write,    /* write */
   NULL,           /* seek */
   aht10_ioctl,    /* ioctl */
+  NULL,           /* truncate */
   NULL            /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , aht10_unlink /* unlink */

--- a/drivers/sensors/aht10.c
+++ b/drivers/sensors/aht10.c
@@ -117,6 +117,7 @@ static const struct file_operations g_aht10fops =
   NULL,           /* seek */
   aht10_ioctl,    /* ioctl */
   NULL,           /* truncate */
+  NULL,           /* mmap */
   NULL            /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , aht10_unlink /* unlink */

--- a/drivers/sensors/hc_sr04.c
+++ b/drivers/sensors/hc_sr04.c
@@ -91,6 +91,7 @@ static const struct file_operations g_hcsr04ops =
   NULL,          /* seek */
   hcsr04_ioctl,  /* ioctl */
   NULL,          /* truncate */
+  NULL,          /* mmap */
   hcsr04_poll    /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL         /* unlink */

--- a/drivers/sensors/hc_sr04.c
+++ b/drivers/sensors/hc_sr04.c
@@ -90,6 +90,7 @@ static const struct file_operations g_hcsr04ops =
   hcsr04_write,  /* write */
   NULL,          /* seek */
   hcsr04_ioctl,  /* ioctl */
+  NULL,          /* truncate */
   hcsr04_poll    /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL         /* unlink */

--- a/drivers/sensors/hdc1008.c
+++ b/drivers/sensors/hdc1008.c
@@ -161,6 +161,7 @@ static const struct file_operations g_hdc1008fops =
   hdc1008_write,    /* write */
   NULL,             /* seek */
   hdc1008_ioctl,    /* ioctl */
+  NULL,             /* truncate */
   NULL              /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , hdc1008_unlink  /* unlink */

--- a/drivers/sensors/hdc1008.c
+++ b/drivers/sensors/hdc1008.c
@@ -162,6 +162,7 @@ static const struct file_operations g_hdc1008fops =
   NULL,             /* seek */
   hdc1008_ioctl,    /* ioctl */
   NULL,             /* truncate */
+  NULL,             /* mmap */
   NULL              /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , hdc1008_unlink  /* unlink */

--- a/drivers/sensors/hts221.c
+++ b/drivers/sensors/hts221.c
@@ -157,6 +157,7 @@ static const struct file_operations g_humidityops =
   hts221_write,  /* write */
   NULL,          /* seek */
   hts221_ioctl,  /* ioctl */
+  NULL,          /* truncate */
   hts221_poll    /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL         /* unlink */

--- a/drivers/sensors/hts221.c
+++ b/drivers/sensors/hts221.c
@@ -158,6 +158,7 @@ static const struct file_operations g_humidityops =
   NULL,          /* seek */
   hts221_ioctl,  /* ioctl */
   NULL,          /* truncate */
+  NULL,          /* mmap */
   hts221_poll    /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL         /* unlink */

--- a/drivers/sensors/lis2dh.c
+++ b/drivers/sensors/lis2dh.c
@@ -155,6 +155,7 @@ static const struct file_operations g_lis2dhops =
   NULL,          /* seek */
   lis2dh_ioctl,  /* ioctl */
   NULL,          /* truncate */
+  NULL,          /* mmap */
   lis2dh_poll    /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL         /* unlink */

--- a/drivers/sensors/lis2dh.c
+++ b/drivers/sensors/lis2dh.c
@@ -154,6 +154,7 @@ static const struct file_operations g_lis2dhops =
   lis2dh_write,  /* write */
   NULL,          /* seek */
   lis2dh_ioctl,  /* ioctl */
+  NULL,          /* truncate */
   lis2dh_poll    /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL         /* unlink */

--- a/drivers/sensors/max44009.c
+++ b/drivers/sensors/max44009.c
@@ -112,6 +112,7 @@ static const struct file_operations g_alsops =
   max44009_write,  /* write */
   NULL,            /* seek */
   max44009_ioctl,  /* ioctl */
+  NULL,            /* truncate */
   max44009_poll    /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL           /* unlink */

--- a/drivers/sensors/max44009.c
+++ b/drivers/sensors/max44009.c
@@ -113,6 +113,7 @@ static const struct file_operations g_alsops =
   NULL,            /* seek */
   max44009_ioctl,  /* ioctl */
   NULL,            /* truncate */
+  NULL,            /* mmap */
   max44009_poll    /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL           /* unlink */

--- a/drivers/sensors/scd30.c
+++ b/drivers/sensors/scd30.c
@@ -182,6 +182,7 @@ static const struct file_operations g_scd30fops =
   scd30_write,    /* write */
   NULL,           /* seek */
   scd30_ioctl,    /* ioctl */
+  NULL,           /* truncate */
   NULL            /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , scd30_unlink /* unlink */

--- a/drivers/sensors/scd30.c
+++ b/drivers/sensors/scd30.c
@@ -183,6 +183,7 @@ static const struct file_operations g_scd30fops =
   NULL,           /* seek */
   scd30_ioctl,    /* ioctl */
   NULL,           /* truncate */
+  NULL,           /* mmap */
   NULL            /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , scd30_unlink /* unlink */

--- a/drivers/sensors/scd41.c
+++ b/drivers/sensors/scd41.c
@@ -191,6 +191,7 @@ static const struct file_operations g_scd41fops =
   NULL,           /* seek */
   scd41_ioctl,    /* ioctl */
   NULL,           /* truncate */
+  NULL,           /* mmap */
   NULL            /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , scd41_unlink /* unlink */

--- a/drivers/sensors/scd41.c
+++ b/drivers/sensors/scd41.c
@@ -190,6 +190,7 @@ static const struct file_operations g_scd41fops =
   scd41_write,    /* write */
   NULL,           /* seek */
   scd41_ioctl,    /* ioctl */
+  NULL,           /* truncate */
   NULL            /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , scd41_unlink /* unlink */

--- a/drivers/sensors/sensor.c
+++ b/drivers/sensors/sensor.c
@@ -168,6 +168,7 @@ static const struct file_operations g_sensor_fops =
   NULL,           /* seek  */
   sensor_ioctl,   /* ioctl */
   NULL,           /* truncate */
+  NULL,           /* mmap */
   sensor_poll     /* poll  */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL          /* unlink */

--- a/drivers/sensors/sensor.c
+++ b/drivers/sensors/sensor.c
@@ -167,6 +167,7 @@ static const struct file_operations g_sensor_fops =
   sensor_write,   /* write */
   NULL,           /* seek  */
   sensor_ioctl,   /* ioctl */
+  NULL,           /* truncate */
   sensor_poll     /* poll  */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL          /* unlink */

--- a/drivers/sensors/sgp30.c
+++ b/drivers/sensors/sgp30.c
@@ -159,6 +159,7 @@ static const struct file_operations g_sgp30fops =
   sgp30_write,    /* write */
   NULL,           /* seek */
   sgp30_ioctl,    /* ioctl */
+  NULL,           /* truncate */
   NULL            /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , sgp30_unlink /* unlink */

--- a/drivers/sensors/sgp30.c
+++ b/drivers/sensors/sgp30.c
@@ -160,6 +160,7 @@ static const struct file_operations g_sgp30fops =
   NULL,           /* seek */
   sgp30_ioctl,    /* ioctl */
   NULL,           /* truncate */
+  NULL,           /* mmap */
   NULL            /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , sgp30_unlink /* unlink */

--- a/drivers/sensors/sht21.c
+++ b/drivers/sensors/sht21.c
@@ -132,6 +132,7 @@ static const struct file_operations g_sht21fops =
   NULL,           /* seek */
   sht21_ioctl,    /* ioctl */
   NULL,           /* truncate */
+  NULL,           /* mmap */
   NULL            /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , sht21_unlink /* unlink */

--- a/drivers/sensors/sht21.c
+++ b/drivers/sensors/sht21.c
@@ -131,6 +131,7 @@ static const struct file_operations g_sht21fops =
   sht21_write,    /* write */
   NULL,           /* seek */
   sht21_ioctl,    /* ioctl */
+  NULL,           /* truncate */
   NULL            /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , sht21_unlink /* unlink */

--- a/drivers/sensors/sht3x.c
+++ b/drivers/sensors/sht3x.c
@@ -171,6 +171,7 @@ static const struct file_operations g_sht3xfops =
   NULL,           /* seek */
   sht3x_ioctl,    /* ioctl */
   NULL,           /* truncate */
+  NULL,           /* mmap */
   NULL            /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , sht3x_unlink  /* unlink */

--- a/drivers/sensors/sht3x.c
+++ b/drivers/sensors/sht3x.c
@@ -170,6 +170,7 @@ static const struct file_operations g_sht3xfops =
   sht3x_write,    /* write */
   NULL,           /* seek */
   sht3x_ioctl,    /* ioctl */
+  NULL,           /* truncate */
   NULL            /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , sht3x_unlink  /* unlink */

--- a/drivers/sensors/sps30.c
+++ b/drivers/sensors/sps30.c
@@ -175,6 +175,7 @@ static const struct file_operations g_sps30fops =
   sps30_write,    /* write */
   NULL,           /* seek */
   sps30_ioctl,    /* ioctl */
+  NULL,           /* truncate */
   NULL            /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , sps30_unlink /* unlink */

--- a/drivers/sensors/sps30.c
+++ b/drivers/sensors/sps30.c
@@ -176,6 +176,7 @@ static const struct file_operations g_sps30fops =
   NULL,           /* seek */
   sps30_ioctl,    /* ioctl */
   NULL,           /* truncate */
+  NULL,           /* mmap */
   NULL            /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , sps30_unlink /* unlink */

--- a/drivers/sensors/usensor.c
+++ b/drivers/sensors/usensor.c
@@ -82,6 +82,7 @@ static const struct file_operations g_usensor_fops =
   NULL,          /* seek  */
   usensor_ioctl, /* ioctl */
   NULL,          /* truncate */
+  NULL,          /* mmap */
   NULL,          /* poll  */
 };
 

--- a/drivers/sensors/usensor.c
+++ b/drivers/sensors/usensor.c
@@ -81,6 +81,7 @@ static const struct file_operations g_usensor_fops =
   usensor_write, /* write */
   NULL,          /* seek  */
   usensor_ioctl, /* ioctl */
+  NULL,          /* truncate */
   NULL,          /* poll  */
 };
 

--- a/drivers/serial/pty.c
+++ b/drivers/serial/pty.c
@@ -127,6 +127,7 @@ static const struct file_operations g_pty_fops =
   pty_write,     /* write */
   NULL,          /* seek */
   pty_ioctl,     /* ioctl */
+  NULL,          /* truncate */
   pty_poll       /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , pty_unlink   /* unlink */

--- a/drivers/serial/pty.c
+++ b/drivers/serial/pty.c
@@ -128,6 +128,7 @@ static const struct file_operations g_pty_fops =
   NULL,          /* seek */
   pty_ioctl,     /* ioctl */
   NULL,          /* truncate */
+  NULL,          /* mmap */
   pty_poll       /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , pty_unlink   /* unlink */

--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -126,6 +126,7 @@ static const struct file_operations g_serialops =
   uart_write, /* write */
   NULL,       /* seek */
   uart_ioctl, /* ioctl */
+  NULL,       /* truncate */
   uart_poll   /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL      /* unlink */

--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -127,6 +127,7 @@ static const struct file_operations g_serialops =
   NULL,       /* seek */
   uart_ioctl, /* ioctl */
   NULL,       /* truncate */
+  NULL,       /* mmap */
   uart_poll   /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL      /* unlink */

--- a/drivers/serial/uart_bth4.c
+++ b/drivers/serial/uart_bth4.c
@@ -91,6 +91,7 @@ static const struct file_operations g_uart_bth4_ops =
   NULL,             /* seek */
   uart_bth4_ioctl,  /* ioctl */
   NULL,             /* truncate */
+  NULL,             /* mmap */
   uart_bth4_poll    /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL            /* unlink */

--- a/drivers/serial/uart_bth4.c
+++ b/drivers/serial/uart_bth4.c
@@ -90,6 +90,7 @@ static const struct file_operations g_uart_bth4_ops =
   uart_bth4_write,  /* write */
   NULL,             /* seek */
   uart_bth4_ioctl,  /* ioctl */
+  NULL,             /* truncate */
   uart_bth4_poll    /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL            /* unlink */

--- a/drivers/spi/spi_driver.c
+++ b/drivers/spi/spi_driver.c
@@ -100,6 +100,7 @@ static const struct file_operations spidrvr_fops =
   NULL,            /* seek */
   spidrvr_ioctl,   /* ioctl */
   NULL,            /* truncate */
+  NULL,            /* mmap */
   NULL             /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , spidrvr_unlink /* unlink */

--- a/drivers/spi/spi_driver.c
+++ b/drivers/spi/spi_driver.c
@@ -99,6 +99,7 @@ static const struct file_operations spidrvr_fops =
   spidrvr_write,   /* write */
   NULL,            /* seek */
   spidrvr_ioctl,   /* ioctl */
+  NULL,            /* truncate */
   NULL             /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , spidrvr_unlink /* unlink */

--- a/drivers/spi/spi_slave_driver.c
+++ b/drivers/spi/spi_slave_driver.c
@@ -128,6 +128,7 @@ static const struct file_operations g_spislavefops =
   NULL,                         /* seek */
   NULL,                         /* ioctl */
   NULL,                         /* truncate */
+  NULL,                         /* mmap */
   NULL                          /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , spi_slave_unlink            /* unlink */

--- a/drivers/spi/spi_slave_driver.c
+++ b/drivers/spi/spi_slave_driver.c
@@ -127,6 +127,7 @@ static const struct file_operations g_spislavefops =
   spi_slave_write,              /* write */
   NULL,                         /* seek */
   NULL,                         /* ioctl */
+  NULL,                         /* truncate */
   NULL                          /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , spi_slave_unlink            /* unlink */

--- a/drivers/syslog/ramlog.c
+++ b/drivers/syslog/ramlog.c
@@ -115,6 +115,7 @@ static const struct file_operations g_ramlogfops =
   NULL,              /* seek */
   ramlog_file_ioctl, /* ioctl */
   NULL,              /* truncate */
+  NULL,              /* mmap */
   ramlog_file_poll   /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL             /* unlink */

--- a/drivers/syslog/ramlog.c
+++ b/drivers/syslog/ramlog.c
@@ -114,6 +114,7 @@ static const struct file_operations g_ramlogfops =
   ramlog_file_write, /* write */
   NULL,              /* seek */
   ramlog_file_ioctl, /* ioctl */
+  NULL,              /* truncate */
   ramlog_file_poll   /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL             /* unlink */

--- a/drivers/timers/rtc.c
+++ b/drivers/timers/rtc.c
@@ -129,6 +129,7 @@ static const struct file_operations rtc_fops =
   rtc_write,     /* write */
   NULL,          /* seek */
   rtc_ioctl,     /* ioctl */
+  NULL,          /* truncate */
   NULL           /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , rtc_unlink   /* unlink */

--- a/drivers/timers/rtc.c
+++ b/drivers/timers/rtc.c
@@ -130,6 +130,7 @@ static const struct file_operations rtc_fops =
   NULL,          /* seek */
   rtc_ioctl,     /* ioctl */
   NULL,          /* truncate */
+  NULL,          /* mmap */
   NULL           /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , rtc_unlink   /* unlink */

--- a/drivers/usbdev/adb.c
+++ b/drivers/usbdev/adb.c
@@ -255,6 +255,7 @@ static const struct file_operations g_adb_fops =
   NULL,           /* seek */
   NULL,           /* ioctl */
   NULL,           /* truncate */
+  NULL,           /* mmap */
   adb_char_poll   /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL          /* unlink */

--- a/drivers/usbdev/adb.c
+++ b/drivers/usbdev/adb.c
@@ -254,6 +254,7 @@ static const struct file_operations g_adb_fops =
   adb_char_write, /* write */
   NULL,           /* seek */
   NULL,           /* ioctl */
+  NULL,           /* truncate */
   adb_char_poll   /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL          /* unlink */

--- a/drivers/usbhost/usbhost_cdcmbim.c
+++ b/drivers/usbhost/usbhost_cdcmbim.c
@@ -348,6 +348,7 @@ static const struct file_operations cdcwdm_fops =
   NULL,          /* seek */
   NULL,          /* ioctl */
   NULL,          /* truncate */
+  NULL,          /* mmap */
   cdcwdm_poll    /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL         /* unlink */

--- a/drivers/usbhost/usbhost_cdcmbim.c
+++ b/drivers/usbhost/usbhost_cdcmbim.c
@@ -347,6 +347,7 @@ static const struct file_operations cdcwdm_fops =
   cdcwdm_write,  /* write */
   NULL,          /* seek */
   NULL,          /* ioctl */
+  NULL,          /* truncate */
   cdcwdm_poll    /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL         /* unlink */

--- a/drivers/usbhost/usbhost_hidkbd.c
+++ b/drivers/usbhost/usbhost_hidkbd.c
@@ -341,6 +341,7 @@ static const struct file_operations g_hidkbd_fops =
   usbhost_write,            /* write */
   NULL,                     /* seek */
   NULL,                     /* ioctl */
+  NULL,                     /* truncate */
   usbhost_poll              /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL                    /* unlink */

--- a/drivers/usbhost/usbhost_hidkbd.c
+++ b/drivers/usbhost/usbhost_hidkbd.c
@@ -342,6 +342,7 @@ static const struct file_operations g_hidkbd_fops =
   NULL,                     /* seek */
   NULL,                     /* ioctl */
   NULL,                     /* truncate */
+  NULL,                     /* mmap */
   usbhost_poll              /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL                    /* unlink */

--- a/drivers/usbhost/usbhost_hidmouse.c
+++ b/drivers/usbhost/usbhost_hidmouse.c
@@ -392,6 +392,7 @@ static const struct file_operations g_hidmouse_fops =
   NULL,                    /* seek */
   NULL,                    /* ioctl */
   NULL,                    /* truncate */
+  NULL,                    /* mmap */
   usbhost_poll             /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL                   /* unlink */

--- a/drivers/usbhost/usbhost_hidmouse.c
+++ b/drivers/usbhost/usbhost_hidmouse.c
@@ -391,6 +391,7 @@ static const struct file_operations g_hidmouse_fops =
   usbhost_write,           /* write */
   NULL,                    /* seek */
   NULL,                    /* ioctl */
+  NULL,                    /* truncate */
   usbhost_poll             /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL                   /* unlink */

--- a/drivers/usbhost/usbhost_xboxcontroller.c
+++ b/drivers/usbhost/usbhost_xboxcontroller.c
@@ -297,6 +297,7 @@ static const struct file_operations g_xboxcontroller_fops =
   NULL,                     /* seek */
   usbhost_ioctl,            /* ioctl */
   NULL,                     /* truncate */
+  NULL,                     /* mmap */
   usbhost_poll              /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL                    /* unlink */

--- a/drivers/usbhost/usbhost_xboxcontroller.c
+++ b/drivers/usbhost/usbhost_xboxcontroller.c
@@ -296,6 +296,7 @@ static const struct file_operations g_xboxcontroller_fops =
   usbhost_write,            /* write */
   NULL,                     /* seek */
   usbhost_ioctl,            /* ioctl */
+  NULL,                     /* truncate */
   usbhost_poll              /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL                    /* unlink */

--- a/drivers/usbmisc/fusb301.c
+++ b/drivers/usbmisc/fusb301.c
@@ -94,6 +94,7 @@ static const struct file_operations g_fusb301ops =
   fusb301_write, /* write */
   NULL,          /* seek */
   fusb301_ioctl, /* ioctl */
+  NULL,          /* truncate */
   fusb301_poll   /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL         /* unlink */

--- a/drivers/usbmisc/fusb301.c
+++ b/drivers/usbmisc/fusb301.c
@@ -95,6 +95,7 @@ static const struct file_operations g_fusb301ops =
   NULL,          /* seek */
   fusb301_ioctl, /* ioctl */
   NULL,          /* truncate */
+  NULL,          /* mmap */
   fusb301_poll   /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL         /* unlink */

--- a/drivers/usbmisc/fusb303.c
+++ b/drivers/usbmisc/fusb303.c
@@ -128,6 +128,7 @@ static const struct file_operations g_fusb303ops =
   fusb303_write, /* write */
   NULL,          /* seek */
   fusb303_ioctl, /* ioctl */
+  NULL,          /* truncate */
   fusb303_poll   /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL         /* unlink */

--- a/drivers/usbmisc/fusb303.c
+++ b/drivers/usbmisc/fusb303.c
@@ -129,6 +129,7 @@ static const struct file_operations g_fusb303ops =
   NULL,          /* seek */
   fusb303_ioctl, /* ioctl */
   NULL,          /* truncate */
+  NULL,          /* mmap */
   fusb303_poll   /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL         /* unlink */

--- a/drivers/usrsock/usrsock_dev.c
+++ b/drivers/usrsock/usrsock_dev.c
@@ -104,6 +104,7 @@ static const struct file_operations g_usrsockdevops =
   usrsockdev_seek,    /* seek */
   NULL,               /* ioctl */
   NULL,               /* truncate */
+  NULL,               /* mmap */
   usrsockdev_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL              /* unlink */

--- a/drivers/usrsock/usrsock_dev.c
+++ b/drivers/usrsock/usrsock_dev.c
@@ -103,6 +103,7 @@ static const struct file_operations g_usrsockdevops =
   usrsockdev_write,   /* write */
   usrsockdev_seek,    /* seek */
   NULL,               /* ioctl */
+  NULL,               /* truncate */
   usrsockdev_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL              /* unlink */

--- a/drivers/video/fb.c
+++ b/drivers/video/fb.c
@@ -85,6 +85,7 @@ static const struct file_operations fb_fops =
   fb_write,      /* write */
   fb_seek,       /* seek */
   fb_ioctl,      /* ioctl */
+  NULL,          /* truncate */
   fb_poll        /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL         /* unlink */

--- a/drivers/video/video.c
+++ b/drivers/video/video.c
@@ -284,6 +284,7 @@ static const struct file_operations g_video_fops =
   video_write,              /* write */
   NULL,                     /* seek */
   video_ioctl,              /* ioctl */
+  NULL,                     /* truncate */
   NULL                      /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL                    /* unlink */

--- a/drivers/wireless/cc1101.c
+++ b/drivers/wireless/cc1101.c
@@ -305,6 +305,7 @@ static const struct file_operations g_cc1101ops =
   cc1101_file_write, /* write */
   NULL,              /* seek */
   NULL,              /* ioctl */
+  NULL,              /* truncate */
   cc1101_file_poll   /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL             /* unlink */

--- a/drivers/wireless/cc1101.c
+++ b/drivers/wireless/cc1101.c
@@ -306,6 +306,7 @@ static const struct file_operations g_cc1101ops =
   NULL,              /* seek */
   NULL,              /* ioctl */
   NULL,              /* truncate */
+  NULL,              /* mmap */
   cc1101_file_poll   /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL             /* unlink */

--- a/drivers/wireless/gs2200m.c
+++ b/drivers/wireless/gs2200m.c
@@ -231,6 +231,7 @@ static const struct file_operations g_gs2200m_fops =
   gs2200m_write, /* write */
   NULL,          /* seek */
   gs2200m_ioctl, /* ioctl */
+  NULL,          /* truncate */
   gs2200m_poll   /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL         /* unlink */

--- a/drivers/wireless/gs2200m.c
+++ b/drivers/wireless/gs2200m.c
@@ -232,6 +232,7 @@ static const struct file_operations g_gs2200m_fops =
   NULL,          /* seek */
   gs2200m_ioctl, /* ioctl */
   NULL,          /* truncate */
+  NULL,          /* mmap */
   gs2200m_poll   /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL         /* unlink */

--- a/drivers/wireless/lpwan/sx127x/sx127x.c
+++ b/drivers/wireless/lpwan/sx127x/sx127x.c
@@ -452,6 +452,7 @@ static const struct file_operations sx127x_fops =
   NULL,           /* seek */
   sx127x_ioctl,   /* ioctl */
   NULL,           /* truncate */
+  NULL,           /* mmap */
   sx127x_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL          /* unlink */

--- a/drivers/wireless/lpwan/sx127x/sx127x.c
+++ b/drivers/wireless/lpwan/sx127x/sx127x.c
@@ -451,6 +451,7 @@ static const struct file_operations sx127x_fops =
   sx127x_write,   /* write */
   NULL,           /* seek */
   sx127x_ioctl,   /* ioctl */
+  NULL,           /* truncate */
   sx127x_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL          /* unlink */

--- a/drivers/wireless/nrf24l01.c
+++ b/drivers/wireless/nrf24l01.c
@@ -240,6 +240,7 @@ static const struct file_operations nrf24l01_fops =
   NULL,             /* seek */
   nrf24l01_ioctl,   /* ioctl */
   NULL,             /* truncate */
+  NULL,             /* mmap */
   nrf24l01_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL            /* unlink */

--- a/drivers/wireless/nrf24l01.c
+++ b/drivers/wireless/nrf24l01.c
@@ -239,6 +239,7 @@ static const struct file_operations nrf24l01_fops =
   nrf24l01_write,   /* write */
   NULL,             /* seek */
   nrf24l01_ioctl,   /* ioctl */
+  NULL,             /* truncate */
   nrf24l01_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL            /* unlink */

--- a/fs/binfs/fs_binfs.c
+++ b/fs/binfs/fs_binfs.c
@@ -110,6 +110,7 @@ const struct mountpt_operations binfs_operations =
   NULL,              /* seek */
   binfs_ioctl,       /* ioctl */
   NULL,              /* truncate */
+  NULL,              /* mmap */
 
   NULL,              /* sync */
   binfs_dup,         /* dup */

--- a/fs/binfs/fs_binfs.c
+++ b/fs/binfs/fs_binfs.c
@@ -109,12 +109,12 @@ const struct mountpt_operations binfs_operations =
   NULL,              /* write */
   NULL,              /* seek */
   binfs_ioctl,       /* ioctl */
+  NULL,              /* truncate */
 
   NULL,              /* sync */
   binfs_dup,         /* dup */
   binfs_fstat,       /* fstat */
   NULL,              /* fchstat */
-  NULL,              /* truncate */
 
   binfs_opendir,     /* opendir */
   binfs_closedir,    /* closedir */

--- a/fs/cromfs/fs_cromfs.c
+++ b/fs/cromfs/fs_cromfs.c
@@ -185,6 +185,7 @@ const struct mountpt_operations cromfs_operations =
   NULL,              /* seek */
   cromfs_ioctl,      /* ioctl */
   NULL,              /* truncate */
+  NULL,              /* mmap */
 
   NULL,              /* sync */
   cromfs_dup,        /* dup */

--- a/fs/cromfs/fs_cromfs.c
+++ b/fs/cromfs/fs_cromfs.c
@@ -184,12 +184,12 @@ const struct mountpt_operations cromfs_operations =
   NULL,              /* write */
   NULL,              /* seek */
   cromfs_ioctl,      /* ioctl */
+  NULL,              /* truncate */
 
   NULL,              /* sync */
   cromfs_dup,        /* dup */
   cromfs_fstat,      /* fstat */
   NULL,              /* fchstat */
-  NULL,              /* truncate */
 
   cromfs_opendir,    /* opendir */
   cromfs_closedir,   /* closedir */

--- a/fs/fat/fs_fat32.c
+++ b/fs/fat/fs_fat32.c
@@ -116,6 +116,7 @@ const struct mountpt_operations fat_operations =
   fat_seek,          /* seek */
   fat_ioctl,         /* ioctl */
   fat_truncate,      /* truncate */
+  NULL,              /* mmap */
   fat_sync,          /* sync */
   fat_dup,           /* dup */
   fat_fstat,         /* fstat */

--- a/fs/fat/fs_fat32.c
+++ b/fs/fat/fs_fat32.c
@@ -115,12 +115,11 @@ const struct mountpt_operations fat_operations =
   fat_write,         /* write */
   fat_seek,          /* seek */
   fat_ioctl,         /* ioctl */
-
+  fat_truncate,      /* truncate */
   fat_sync,          /* sync */
   fat_dup,           /* dup */
   fat_fstat,         /* fstat */
   NULL,              /* fchstat */
-  fat_truncate,      /* truncate */
 
   fat_opendir,       /* opendir */
   fat_closedir,      /* closedir */

--- a/fs/hostfs/hostfs.c
+++ b/fs/hostfs/hostfs.c
@@ -143,6 +143,7 @@ const struct mountpt_operations hostfs_operations =
   hostfs_seek,          /* seek */
   hostfs_ioctl,         /* ioctl */
   hostfs_ftruncate,     /* ftruncate */
+  NULL,                 /* mmap */
 
   hostfs_sync,          /* sync */
   hostfs_dup,           /* dup */

--- a/fs/hostfs/hostfs.c
+++ b/fs/hostfs/hostfs.c
@@ -142,12 +142,12 @@ const struct mountpt_operations hostfs_operations =
   hostfs_write,         /* write */
   hostfs_seek,          /* seek */
   hostfs_ioctl,         /* ioctl */
+  hostfs_ftruncate,     /* ftruncate */
 
   hostfs_sync,          /* sync */
   hostfs_dup,           /* dup */
   hostfs_fstat,         /* fstat */
   hostfs_fchstat,       /* fchstat */
-  hostfs_ftruncate,     /* ftruncate */
 
   hostfs_opendir,       /* opendir */
   hostfs_closedir,      /* closedir */

--- a/fs/littlefs/lfs_vfs.c
+++ b/fs/littlefs/lfs_vfs.c
@@ -140,12 +140,12 @@ const struct mountpt_operations littlefs_operations =
   littlefs_write,         /* write */
   littlefs_seek,          /* seek */
   littlefs_ioctl,         /* ioctl */
+  littlefs_truncate,      /* truncate */
 
   littlefs_sync,          /* sync */
   littlefs_dup,           /* dup */
   littlefs_fstat,         /* fstat */
   NULL,                   /* fchstat */
-  littlefs_truncate,      /* truncate */
 
   littlefs_opendir,       /* opendir */
   littlefs_closedir,      /* closedir */

--- a/fs/littlefs/lfs_vfs.c
+++ b/fs/littlefs/lfs_vfs.c
@@ -141,6 +141,7 @@ const struct mountpt_operations littlefs_operations =
   littlefs_seek,          /* seek */
   littlefs_ioctl,         /* ioctl */
   littlefs_truncate,      /* truncate */
+  NULL,                   /* mmap */
 
   littlefs_sync,          /* sync */
   littlefs_dup,           /* dup */

--- a/fs/mmap/README.txt
+++ b/fs/mmap/README.txt
@@ -14,7 +14,7 @@ conditions where mmap() can be supported:
 1. mmap can be used to support eXecute In Place (XIP) on random access media
    under the following very restrictive conditions:
 
-   a. The filesystem supports the FIOC_MMAP ioctl command.  Any file
+   a. The filesystem implements the mmap file operation.  Any file
       system that maps files contiguously on the media should support
       this ioctl. (vs. file system that scatter files over the media
       in non-contiguous sectors).  As of this writing, ROMFS is the

--- a/fs/mmap/fs_munmap.c
+++ b/fs/mmap/fs_munmap.c
@@ -196,7 +196,7 @@ int file_munmap(FAR void *start, size_t length)
  *   1. mmap() is the API that is used to support direct access to random
  *     access media under the following very restrictive conditions:
  *
- *     a. The filesystem supports the FIOC_MMAP ioctl command.  Any file
+ *     a. The filesystem impelements the mmap file operation.  Any file
  *        system that maps files contiguously on the media should support
  *        this ioctl. (vs. file system that scatter files over the media
  *        in non-contiguous sectors).  As of this writing, ROMFS is the

--- a/fs/mqueue/mq_open.c
+++ b/fs/mqueue/mq_open.c
@@ -60,6 +60,7 @@ static const struct file_operations g_nxmq_fileops =
   NULL,             /* write */
   NULL,             /* seek */
   NULL,             /* ioctl */
+  NULL,             /* truncate */
   nxmq_file_poll    /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL            /* unlink */

--- a/fs/mqueue/mq_open.c
+++ b/fs/mqueue/mq_open.c
@@ -61,6 +61,7 @@ static const struct file_operations g_nxmq_fileops =
   NULL,             /* seek */
   NULL,             /* ioctl */
   NULL,             /* truncate */
+  NULL,             /* mmap */
   nxmq_file_poll    /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL            /* unlink */

--- a/fs/nfs/nfs_vfsops.c
+++ b/fs/nfs/nfs_vfsops.c
@@ -199,6 +199,7 @@ const struct mountpt_operations nfs_operations =
   NULL,                         /* seek */
   NULL,                         /* ioctl */
   nfs_truncate,                 /* truncate */
+  NULL,                         /* mmap */
 
   NULL,                         /* sync */
   nfs_dup,                      /* dup */

--- a/fs/nfs/nfs_vfsops.c
+++ b/fs/nfs/nfs_vfsops.c
@@ -198,12 +198,12 @@ const struct mountpt_operations nfs_operations =
   nfs_write,                    /* write */
   NULL,                         /* seek */
   NULL,                         /* ioctl */
+  nfs_truncate,                 /* truncate */
 
   NULL,                         /* sync */
   nfs_dup,                      /* dup */
   nfs_fstat,                    /* fstat */
   nfs_fchstat,                  /* fchstat */
-  nfs_truncate,                 /* truncate */
 
   nfs_opendir,                  /* opendir */
   nfs_closedir,                 /* closedir */

--- a/fs/nxffs/nxffs_initialize.c
+++ b/fs/nxffs/nxffs_initialize.c
@@ -59,6 +59,7 @@ const struct mountpt_operations nxffs_operations =
 #else
   NULL,              /* truncate */
 #endif
+  NULL,              /* mmap */
 
   NULL,              /* sync -- No buffered data */
   nxffs_dup,         /* dup */

--- a/fs/nxffs/nxffs_initialize.c
+++ b/fs/nxffs/nxffs_initialize.c
@@ -54,16 +54,16 @@ const struct mountpt_operations nxffs_operations =
   nxffs_write,       /* write */
   NULL,              /* seek -- Use f_pos in struct file */
   nxffs_ioctl,       /* ioctl */
-
-  NULL,              /* sync -- No buffered data */
-  nxffs_dup,         /* dup */
-  nxffs_fstat,       /* fstat */
-  NULL,              /* fchstat */
 #ifdef __NO_TRUNCATE_SUPPORT__
   nxffs_truncate,    /* truncate */
 #else
   NULL,              /* truncate */
 #endif
+
+  NULL,              /* sync -- No buffered data */
+  nxffs_dup,         /* dup */
+  nxffs_fstat,       /* fstat */
+  NULL,              /* fchstat */
 
   nxffs_opendir,     /* opendir */
   nxffs_closedir,    /* closedir */

--- a/fs/procfs/fs_procfs.c
+++ b/fs/procfs/fs_procfs.c
@@ -252,12 +252,12 @@ const struct mountpt_operations procfs_operations =
   procfs_write,      /* write */
   NULL,              /* seek */
   procfs_ioctl,      /* ioctl */
+  NULL,              /* truncate */
 
   NULL,              /* sync */
   procfs_dup,        /* dup */
   procfs_fstat,      /* fstat */
   NULL,              /* fchstat */
-  NULL,              /* truncate */
 
   procfs_opendir,    /* opendir */
   procfs_closedir,   /* closedir */

--- a/fs/procfs/fs_procfs.c
+++ b/fs/procfs/fs_procfs.c
@@ -253,6 +253,7 @@ const struct mountpt_operations procfs_operations =
   NULL,              /* seek */
   procfs_ioctl,      /* ioctl */
   NULL,              /* truncate */
+  NULL,              /* mmap */
 
   NULL,              /* sync */
   procfs_dup,        /* dup */

--- a/fs/romfs/fs_romfs.c
+++ b/fs/romfs/fs_romfs.c
@@ -119,6 +119,7 @@ const struct mountpt_operations romfs_operations =
   NULL,            /* write */
   romfs_seek,      /* seek */
   romfs_ioctl,     /* ioctl */
+  NULL,            /* truncate */
 
   NULL,            /* sync */
   romfs_dup,       /* dup */

--- a/fs/rpmsgfs/rpmsgfs.c
+++ b/fs/rpmsgfs/rpmsgfs.c
@@ -162,6 +162,7 @@ const struct mountpt_operations rpmsgfs_operations =
   rpmsgfs_seek,          /* seek */
   rpmsgfs_ioctl,         /* ioctl */
   rpmsgfs_ftruncate,     /* ftruncate */
+  NULL,                  /* mmap */
 
   rpmsgfs_sync,          /* sync */
   rpmsgfs_dup,           /* dup */

--- a/fs/rpmsgfs/rpmsgfs.c
+++ b/fs/rpmsgfs/rpmsgfs.c
@@ -161,12 +161,12 @@ const struct mountpt_operations rpmsgfs_operations =
   rpmsgfs_write,         /* write */
   rpmsgfs_seek,          /* seek */
   rpmsgfs_ioctl,         /* ioctl */
+  rpmsgfs_ftruncate,     /* ftruncate */
 
   rpmsgfs_sync,          /* sync */
   rpmsgfs_dup,           /* dup */
   rpmsgfs_fstat,         /* fstat */
   rpmsgfs_fchstat,       /* fchstat */
-  rpmsgfs_ftruncate,     /* ftruncate */
 
   rpmsgfs_opendir,       /* opendir */
   rpmsgfs_closedir,      /* closedir */

--- a/fs/smartfs/smartfs_smart.c
+++ b/fs/smartfs/smartfs_smart.c
@@ -141,6 +141,7 @@ const struct mountpt_operations smartfs_operations =
   smartfs_seek,          /* seek */
   smartfs_ioctl,         /* ioctl */
   smartfs_truncate,      /* truncate */
+  NULL,                  /* mmap */
 
   smartfs_sync,          /* sync */
   smartfs_dup,           /* dup */

--- a/fs/smartfs/smartfs_smart.c
+++ b/fs/smartfs/smartfs_smart.c
@@ -140,12 +140,12 @@ const struct mountpt_operations smartfs_operations =
   smartfs_write,         /* write */
   smartfs_seek,          /* seek */
   smartfs_ioctl,         /* ioctl */
+  smartfs_truncate,      /* truncate */
 
   smartfs_sync,          /* sync */
   smartfs_dup,           /* dup */
   smartfs_fstat,         /* fstat */
   NULL,                  /* fchstat */
-  smartfs_truncate,      /* truncate */
 
   smartfs_opendir,       /* opendir */
   smartfs_closedir,      /* closedir */

--- a/fs/socket/socket.c
+++ b/fs/socket/socket.c
@@ -64,6 +64,7 @@ static const struct file_operations g_sock_fileops =
   sock_file_write,  /* write */
   NULL,             /* seek */
   sock_file_ioctl,  /* ioctl */
+  NULL,             /* truncate */
   sock_file_poll    /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL            /* unlink */

--- a/fs/socket/socket.c
+++ b/fs/socket/socket.c
@@ -65,6 +65,7 @@ static const struct file_operations g_sock_fileops =
   NULL,             /* seek */
   sock_file_ioctl,  /* ioctl */
   NULL,             /* truncate */
+  NULL,             /* mmap */
   sock_file_poll    /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL            /* unlink */

--- a/fs/spiffs/src/spiffs_vfs.c
+++ b/fs/spiffs/src/spiffs_vfs.c
@@ -142,6 +142,7 @@ const struct mountpt_operations spiffs_operations =
   spiffs_seek,       /* seek */
   spiffs_ioctl,      /* ioctl */
   spiffs_truncate,   /* truncate */
+  NULL,              /* mmap */
 
   spiffs_sync,       /* sync */
   spiffs_dup,        /* dup */

--- a/fs/spiffs/src/spiffs_vfs.c
+++ b/fs/spiffs/src/spiffs_vfs.c
@@ -141,12 +141,12 @@ const struct mountpt_operations spiffs_operations =
   spiffs_write,      /* write */
   spiffs_seek,       /* seek */
   spiffs_ioctl,      /* ioctl */
+  spiffs_truncate,   /* truncate */
 
   spiffs_sync,       /* sync */
   spiffs_dup,        /* dup */
   spiffs_fstat,      /* fstat */
   NULL,              /* fchstat */
-  spiffs_truncate,   /* truncate */
 
   spiffs_opendir,    /* opendir */
   spiffs_closedir,   /* closedir */

--- a/fs/tmpfs/fs_tmpfs.c
+++ b/fs/tmpfs/fs_tmpfs.c
@@ -177,12 +177,12 @@ const struct mountpt_operations tmpfs_operations =
   tmpfs_write,      /* write */
   tmpfs_seek,       /* seek */
   tmpfs_ioctl,      /* ioctl */
+  tmpfs_truncate,   /* truncate */
 
   tmpfs_sync,       /* sync */
   tmpfs_dup,        /* dup */
   tmpfs_fstat,      /* fstat */
   NULL,             /* fchstat */
-  tmpfs_truncate,   /* truncate */
 
   tmpfs_opendir,    /* opendir */
   tmpfs_closedir,   /* closedir */

--- a/fs/unionfs/fs_unionfs.c
+++ b/fs/unionfs/fs_unionfs.c
@@ -223,6 +223,7 @@ const struct mountpt_operations unionfs_operations =
   unionfs_seek,        /* seek */
   unionfs_ioctl,       /* ioctl */
   unionfs_truncate,    /* truncate */
+  NULL,                /* mmap */
 
   unionfs_sync,        /* sync */
   unionfs_dup,         /* dup */

--- a/fs/unionfs/fs_unionfs.c
+++ b/fs/unionfs/fs_unionfs.c
@@ -222,12 +222,12 @@ const struct mountpt_operations unionfs_operations =
   unionfs_write,       /* write */
   unionfs_seek,        /* seek */
   unionfs_ioctl,       /* ioctl */
+  unionfs_truncate,    /* truncate */
 
   unionfs_sync,        /* sync */
   unionfs_dup,         /* dup */
   unionfs_fstat,       /* fstat */
   unionfs_fchstat,     /* fchstat */
-  unionfs_truncate,    /* truncate */
 
   unionfs_opendir,     /* opendir */
   unionfs_closedir,    /* closedir */

--- a/fs/userfs/fs_userfs.c
+++ b/fs/userfs/fs_userfs.c
@@ -160,12 +160,12 @@ const struct mountpt_operations userfs_operations =
   userfs_write,      /* write */
   userfs_seek,       /* seek */
   userfs_ioctl,      /* ioctl */
+  userfs_truncate,   /* truncate */
 
   userfs_sync,       /* sync */
   userfs_dup,        /* dup */
   userfs_fstat,      /* fstat */
   userfs_fchstat,    /* fchstat */
-  userfs_truncate,   /* truncate */
 
   userfs_opendir,    /* opendir */
   userfs_closedir,   /* closedir */

--- a/fs/userfs/fs_userfs.c
+++ b/fs/userfs/fs_userfs.c
@@ -161,6 +161,7 @@ const struct mountpt_operations userfs_operations =
   userfs_seek,       /* seek */
   userfs_ioctl,      /* ioctl */
   userfs_truncate,   /* truncate */
+  NULL,              /* mmap */
 
   userfs_sync,       /* sync */
   userfs_dup,        /* dup */

--- a/fs/vfs/fs_epoll.c
+++ b/fs/vfs/fs_epoll.c
@@ -104,6 +104,7 @@ static const struct file_operations g_epoll_ops =
   NULL,             /* write */
   NULL,             /* seek */
   NULL,             /* ioctl */
+  NULL,             /* truncate */
   epoll_do_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL            /* unlink */

--- a/fs/vfs/fs_epoll.c
+++ b/fs/vfs/fs_epoll.c
@@ -105,6 +105,7 @@ static const struct file_operations g_epoll_ops =
   NULL,             /* seek */
   NULL,             /* ioctl */
   NULL,             /* truncate */
+  NULL,             /* mmap */
   epoll_do_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL            /* unlink */

--- a/fs/vfs/fs_eventfd.c
+++ b/fs/vfs/fs_eventfd.c
@@ -100,6 +100,7 @@ static const struct file_operations g_eventfd_fops =
   eventfd_do_write, /* write */
   NULL,             /* seek */
   NULL,             /* ioctl */
+  NULL,             /* truncate */
 #ifdef CONFIG_EVENT_FD_POLL
   eventfd_do_poll   /* poll */
 #else

--- a/fs/vfs/fs_eventfd.c
+++ b/fs/vfs/fs_eventfd.c
@@ -101,6 +101,7 @@ static const struct file_operations g_eventfd_fops =
   NULL,             /* seek */
   NULL,             /* ioctl */
   NULL,             /* truncate */
+  NULL,             /* mmap */
 #ifdef CONFIG_EVENT_FD_POLL
   eventfd_do_poll   /* poll */
 #else

--- a/fs/vfs/fs_signalfd.c
+++ b/fs/vfs/fs_signalfd.c
@@ -80,6 +80,7 @@ static const struct file_operations g_signalfd_fileops =
   NULL,                 /* seek */
   NULL,                 /* ioctl */
   NULL,                 /* truncate */
+  NULL,                 /* mmap */
   signalfd_file_poll    /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL                /* unlink */

--- a/fs/vfs/fs_signalfd.c
+++ b/fs/vfs/fs_signalfd.c
@@ -79,6 +79,7 @@ static const struct file_operations g_signalfd_fileops =
   NULL,                 /* write */
   NULL,                 /* seek */
   NULL,                 /* ioctl */
+  NULL,                 /* truncate */
   signalfd_file_poll    /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL                /* unlink */

--- a/fs/vfs/fs_truncate.c
+++ b/fs/vfs/fs_truncate.c
@@ -31,7 +31,6 @@
 #include <debug.h>
 
 #include <nuttx/fs/fs.h>
-#include <nuttx/fs/ioctl.h>
 
 #include "inode/inode.h"
 
@@ -69,19 +68,7 @@ int file_truncate(FAR struct file *filep, off_t length)
    */
 
   inode = filep->f_inode;
-  if (inode == NULL)
-    {
-      return -EINVAL;
-    }
-
-  /* If inode is not mountpoint try ioctl first */
-
-  if (!INODE_IS_MOUNTPT(inode))
-    {
-      return file_ioctl(filep, FIOC_TRUNCATE, length);
-    }
-
-  if (inode->u.i_mops == NULL)
+  if (inode == NULL || !INODE_IS_MOUNTPT(inode) || inode->u.i_mops == NULL)
     {
       fwarn("WARNING:  Not a (regular) file on a mounted file system.\n");
       return -EINVAL;

--- a/fs/vfs/fs_truncate.c
+++ b/fs/vfs/fs_truncate.c
@@ -68,9 +68,14 @@ int file_truncate(FAR struct file *filep, off_t length)
    */
 
   inode = filep->f_inode;
-  if (inode == NULL || !INODE_IS_MOUNTPT(inode) || inode->u.i_mops == NULL)
+  if (inode == NULL)
     {
-      fwarn("WARNING:  Not a (regular) file on a mounted file system.\n");
+      return -EINVAL;
+    }
+
+  if (inode->u.i_ops == NULL)
+    {
+      fwarn("WARNING:  Not a file\n");
       return -EINVAL;
     }
 
@@ -78,7 +83,7 @@ int file_truncate(FAR struct file *filep, off_t length)
    * possible not the only indicator -- sufficient, but not necessary")
    */
 
-  if (inode->u.i_mops->write == NULL)
+  if (inode->u.i_ops->write == NULL)
     {
       fwarn("WARNING: File system is read-only\n");
       return -EROFS;
@@ -88,7 +93,7 @@ int file_truncate(FAR struct file *filep, off_t length)
    * a write-able file system.
    */
 
-  if (inode->u.i_mops->truncate == NULL)
+  if (inode->u.i_ops->truncate == NULL)
     {
       fwarn("WARNING: File system does not support the truncate() method\n");
       return -ENOSYS;
@@ -96,7 +101,7 @@ int file_truncate(FAR struct file *filep, off_t length)
 
   /* Yes, then tell the file system to truncate this file */
 
-  return inode->u.i_mops->truncate(filep, length);
+  return inode->u.i_ops->truncate(filep, length);
 }
 
 /****************************************************************************

--- a/graphics/nxterm/nxterm_driver.c
+++ b/graphics/nxterm/nxterm_driver.c
@@ -66,6 +66,7 @@ const struct file_operations g_nxterm_drvrops =
   nxterm_write,   /* write */
   NULL,           /* seek */
   nxterm_ioctl,   /* ioctl */
+  NULL,           /* truncate */
   nxterm_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , nxterm_unlink /* unlink */
@@ -82,6 +83,7 @@ const struct file_operations g_nxterm_drvrops =
   nxterm_write,   /* write */
   NULL,           /* seek */
   nxterm_ioctl,   /* ioctl */
+  NULL,           /* truncate */
   NULL            /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , nxterm_unlink /* unlink */

--- a/graphics/nxterm/nxterm_driver.c
+++ b/graphics/nxterm/nxterm_driver.c
@@ -67,6 +67,7 @@ const struct file_operations g_nxterm_drvrops =
   NULL,           /* seek */
   nxterm_ioctl,   /* ioctl */
   NULL,           /* truncate */
+  NULL,           /* mmap */
   nxterm_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , nxterm_unlink /* unlink */
@@ -84,6 +85,7 @@ const struct file_operations g_nxterm_drvrops =
   NULL,           /* seek */
   nxterm_ioctl,   /* ioctl */
   NULL,           /* truncate */
+  NULL,           /* mmap */
   NULL            /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , nxterm_unlink /* unlink */

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -212,6 +212,7 @@ struct file_operations
                    size_t buflen);
   off_t   (*seek)(FAR struct file *filep, off_t offset, int whence);
   int     (*ioctl)(FAR struct file *filep, int cmd, unsigned long arg);
+  int     (*truncate)(FAR struct file *filep, off_t length);
 
   /* The two structures need not be common after this point */
 
@@ -298,6 +299,7 @@ struct mountpt_operations
             size_t buflen);
   off_t   (*seek)(FAR struct file *filep, off_t offset, int whence);
   int     (*ioctl)(FAR struct file *filep, int cmd, unsigned long arg);
+  int     (*truncate)(FAR struct file *filep, off_t length);
 
   /* The two structures need not be common after this point. The following
    * are extended methods needed to deal with the unique needs of mounted
@@ -311,7 +313,6 @@ struct mountpt_operations
   int     (*fstat)(FAR const struct file *filep, FAR struct stat *buf);
   int     (*fchstat)(FAR const struct file *filep,
                      FAR const struct stat *buf, int flags);
-  int     (*truncate)(FAR struct file *filep, off_t length);
 
   /* Directory operations */
 

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -37,6 +37,7 @@
 
 #include <nuttx/mutex.h>
 #include <nuttx/semaphore.h>
+#include <nuttx/mm/map.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -213,6 +214,7 @@ struct file_operations
   off_t   (*seek)(FAR struct file *filep, off_t offset, int whence);
   int     (*ioctl)(FAR struct file *filep, int cmd, unsigned long arg);
   int     (*truncate)(FAR struct file *filep, off_t length);
+  int     (*mmap)(FAR struct file *filep, FAR struct mm_map_entry_s *map);
 
   /* The two structures need not be common after this point */
 
@@ -300,6 +302,7 @@ struct mountpt_operations
   off_t   (*seek)(FAR struct file *filep, off_t offset, int whence);
   int     (*ioctl)(FAR struct file *filep, int cmd, unsigned long arg);
   int     (*truncate)(FAR struct file *filep, off_t length);
+  int     (*mmap)(FAR struct file *filep, FAR struct mm_map_entry_s *map);
 
   /* The two structures need not be common after this point. The following
    * are extended methods needed to deal with the unique needs of mounted

--- a/include/nuttx/fs/ioctl.h
+++ b/include/nuttx/fs/ioctl.h
@@ -187,9 +187,6 @@
                                            *      configuration
                                            * OUT: None
                                            */
-#define FIOC_TRUNCATE   _FIOC(0x0010)     /* IN:  Length of the file after truncate
-                                           * OUT: None
-                                           */
 
 /* NuttX file system ioctl definitions **************************************/
 

--- a/include/nuttx/fs/ioctl.h
+++ b/include/nuttx/fs/ioctl.h
@@ -134,55 +134,50 @@
 #define _FIOCVALID(c)   (_IOC_TYPE(c)==_FIOCBASE)
 #define _FIOC(nr)       _IOC(_FIOCBASE,nr)
 
-#define FIOC_MMAP       _FIOC(0x0001)     /* IN:  Location to return address (void **)
-                                           * OUT: If media is directly accessible,
-                                           *      return (void*) base address
-                                           *      of file
-                                           */
-#define FIOC_REFORMAT   _FIOC(0x0002)     /* IN:  None
+#define FIOC_REFORMAT   _FIOC(0x0001)     /* IN:  None
                                            * OUT: None
                                            */
-#define FIOC_OPTIMIZE   _FIOC(0x0003)     /* IN:  The number of bytes to recover
+#define FIOC_OPTIMIZE   _FIOC(0x0002)     /* IN:  The number of bytes to recover
                                            *      (ignored on most file systems)
                                            * OUT: None
                                            */
-#define FIOC_FILEPATH   _FIOC(0x0004)     /* IN:  FAR char *(length >= PATH_MAX)
+#define FIOC_FILEPATH   _FIOC(0x0003)     /* IN:  FAR char *(length >= PATH_MAX)
                                            * OUT: The full file path
                                            */
-#define FIOC_INTEGRITY  _FIOC(0x0005)     /* Run a consistency check on the
+#define FIOC_INTEGRITY  _FIOC(0x0004)     /* Run a consistency check on the
                                            *      file system media.
                                            * IN:  None
                                            * OUT: None
                                            */
-#define FIOC_DUMP       _FIOC(0x0006)     /* Dump logical content of media.
+#define FIOC_DUMP       _FIOC(0x0005)     /* Dump logical content of media.
                                            * IN:  None
                                            * OUT: None
                                            */
-#define FIONREAD        _FIOC(0x0007)     /* IN:  Location to return value (int *)
+#define FIONREAD        _FIOC(0x0006)     /* IN:  Location to return value (int *)
                                            * OUT: Bytes readable from this fd
                                            */
-#define FIONWRITE       _FIOC(0x0008)     /* IN:  Location to return value (int *)
+#define FIONWRITE       _FIOC(0x0007)     /* IN:  Location to return value (int *)
                                            * OUT: Number bytes in send queue
                                            */
-#define FIONSPACE       _FIOC(0x0009)     /* IN:  Location to return value (int *)
+#define FIONSPACE       _FIOC(0x0008)     /* IN:  Location to return value (int *)
                                            * OUT: Free space in send queue.
                                            */
-#define FIONUSERFS      _FIOC(0x000a)     /* IN:  Pointer to struct usefs_config_s
+#define FIONUSERFS      _FIOC(0x0009)     /* IN:  Pointer to struct usefs_config_s
                                            *      holding userfs configuration.
                                            * OUT: Instance number is returned on
                                            *      success.
                                            */
-#define FIONBIO         _FIOC(0x000b)     /* IN:  Boolean option takes an
+#define FIONBIO         _FIOC(0x000a)     /* IN:  Boolean option takes an
                                            *      int value.
                                            * OUT: Origin option.
                                            */
-#define FIOCLEX         _FIOC(0x000c)     /* IN:  None
+#define FIOCLEX         _FIOC(0x000b)     /* IN:  None
                                            * OUT: None
                                            */
-#define FIONCLEX        _FIOC(0x000d)     /* IN:  None
+#define FIONCLEX        _FIOC(0x000c)     /* IN:  None
                                            * OUT: None
                                            */
-#define FIOC_NOTIFY     _FIOC(0x000e)     /* IN:  Pointer to struct automount_notify_s
+#define FIOC_NOTIFY     _FIOC(0x000d)     /* IN:  Pointer to struct automount_notify_s
                                            *      holding automount notification
                                            *      configuration
                                            * OUT: None

--- a/include/nuttx/mm/map.h
+++ b/include/nuttx/mm/map.h
@@ -1,0 +1,73 @@
+/****************************************************************************
+ * include/nuttx/mm/map.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_NUTTX_MM_MAP_H
+#define __INCLUDE_NUTTX_MM_MAP_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/queue.h>
+#include <nuttx/mutex.h>
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/* A memory mapping list item */
+
+struct mm_map_entry_s
+{
+  FAR struct mm_map_entry *flink;  /* this is used as sq_entry_t */
+  FAR const void *vaddr;
+  size_t length;
+  off_t offset;
+  int prot;
+  int flags;
+  FAR void *priv;
+
+  /* Drivers which register mappings may also
+   * implement the unmap function to undo anything done in mmap.
+   * Nb. Implementation must NOT use "this_task()->group" since
+   * this is not valid during process exit. The argument "group" will be
+   * NULL in this case.
+   */
+
+  int (*munmap)(FAR struct task_group_s *group,
+                FAR struct mm_map_entry_s *map,
+                FAR void *start,
+                size_t length);
+};
+
+/* A structure for the task group */
+
+struct mm_map_s
+{
+  sq_queue_t mm_map_sq;
+  mutex_t mm_map_mutex;
+};
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#endif /* __INCLUDE_NUTTX_MM_MM_MAP_H */


### PR DESCRIPTION
…alls

- Add truncate, mmap and munmap into file_operations and remove them from ioctl definitions.

- Move truncate to be common for mountpt_operations and file_operations

- Modify all drivers to initialize the operations struct accordingly

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>

## Summary

- IOCTLs are ment for communication from userspace application to the drivers. It doesn't make sense for an application to perform a direct IOCTL (such as FIOC_MMAP, FIOC_MUNMAP or FIOC_TRUNCATE). Application should always use posix mmap, munmap and truncate calls instead.

- For mmap, munmap and truncate there is a syscall lookup already in place in nuttx - there is no ioctl needed for the userspace-kernel communication

- Especially for "unmap", the ioctl doesn't make sense, since file_ioctl is supposed to work on a file pointer. But unmap cannot be done on a file. Even when unmapping a previously mapped "file", unmap can only work on inode, since there may not be an open file, or even a linked inode present. It must be possible to do "munmap" for a mapped file, even if the actual file is closed and/or deleted after mapping. 

## Impact

Cleanup of the interfaces, doesn't change the current functionality but makes it easier to add new

## Testing

Inspected only.
