### PR TITLE
script: enable forward in simhostroute.sh

### DIFF
--- a/tools/simhostroute.sh
+++ b/tools/simhostroute.sh
@@ -62,6 +62,9 @@ if [ "$STATUS" == "on" ]; then
     iptables -A FORWARD -i $IF_HOST -o $IF_BRIDGE -m state --state RELATED,ESTABLISHED -j ACCEPT
     iptables -A FORWARD -i $IF_BRIDGE -o $IF_HOST -j ACCEPT
 
+    # enable forward to make sure nat works
+    sysctl -w net.ipv4.ip_forward=1
+
     ip route show
 else
     ip route delete $IP_NET


### PR DESCRIPTION
## Summary

We found that some people don't know / forget to enable forward in linux, which keeps nat not working.

Because we don't know the previous state before 'on', and forward seldom has side effect, we don't disable it in 'off'.

## Impact

Automatically enable forward in simhostroute.sh

## Testing

Using the script.
