### PR TITLE
syslog: A trailing newline is added if none is present.

### DIFF
--- a/include/nuttx/streams.h
+++ b/include/nuttx/streams.h
@@ -230,6 +230,7 @@ struct lib_syslogstream_s
 #ifdef CONFIG_SYSLOG_BUFFER
   FAR struct iob_s *iob;
 #endif
+  int last_ch;
 };
 
 /* LZF compressed stream pipeline */
@@ -455,11 +456,7 @@ void lib_syslogstream_open(FAR struct lib_syslogstream_s *stream);
  *
  ****************************************************************************/
 
-#ifdef CONFIG_SYSLOG_BUFFER
 void lib_syslogstream_close(FAR struct lib_syslogstream_s *stream);
-#else
-#  define lib_syslogstream_close(s)
-#endif
 
 /****************************************************************************
  * Name: lib_lzfoutstream


### PR DESCRIPTION


## Summary

syslog: A trailing newline is added if none is present.

refs:
https://www.manpagez.com/man/3/syslog/

Signed-off-by: dongjiuzhu1 <dongjiuzhu1@xiaomi.com>
## Impact
A trailing newline is added if none is present for syslog
## Testing
local test.
