### PR TITLE
arm64/pinephone: Fix missing pixels in Frame Buffer Driver

### DIFF
--- a/boards/arm64/a64/pinephone/Kconfig
+++ b/boards/arm64/a64/pinephone/Kconfig
@@ -13,6 +13,7 @@ config PINEPHONE_LCD
 	select DRIVERS_VIDEO
 	select VIDEO_FB
 	select FB_OVERLAY
+	select FB_UPDATE
 	---help---
 		Select to enable support for LCD Display.
 


### PR DESCRIPTION
## Summary

This PR fixes the missing pixels in the rendered output of the Frame Buffer Driver for PINE64 PinePhone.

We fix this by copying the RAM Frame Buffer to itself on Frame Buffer Update `FBIO_UPDATE`, which will refresh the display correctly over DMA / Display Engine / Timing Controller TCON0.

### Modified Files

`boards/arm64/a64/pinephone/Kconfig`: Add requirement for Frame Buffer Update `FB_UPDATE` for PinePhone LCD Display

`boards/arm64/a64/pinephone/src/pinephone_display.c`: Implement Frame Buffer Update `FBIO_UPDATE` by copying the RAM Frame Buffer to itself

## Impact

With this PR, NuttX Apps will be able to render images correctly with the Frame Buffer API without missing pixels.

## Testing

We tested the Frame Buffer Driver with the `fb` Example App. We modified `CONFIG_FB_OVERLAY` in the app as explained here: https://github.com/apache/nuttx/pull/7988

Before Fixing: `fb` app renders an image with missing Red, Orange and Yellow pixels. [(See this)](https://lupyuen.github.io/images/fb-test2.jpg)

After Fixing: `fb` app renders the Red, Orange and Yellow boxes correctly. [(See this)](https://lupyuen.github.io/images/fb-test3.jpg)

[(See the Test Log)](https://gist.github.com/lupyuen/474b0546f213c25947105b6a0daa7c5b)

The Frame Buffer Driver also renders the `lvgldemo` Example App correctly. [(See this)](https://lupyuen.github.io/images/fb-lvgl.jpg)

[(See the LVGL Settings)](https://github.com/lupyuen/pinephone-nuttx#lvgl-on-nuttx-on-pinephone)