### PR TITLE
syscall: export UP_WRAPSYM/UP_REALSYM macro

### DIFF
--- a/include/syscall.h
+++ b/include/syscall.h
@@ -33,6 +33,18 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+#ifdef CONFIG_LIB_SYSCALL
+#  ifndef UP_WRAPSYM
+#    define UP_WRAPSYM(s) __wrap_##s
+#  endif
+#  ifndef UP_REALSYM
+#    define UP_REALSYM(s) __real_##s
+#  endif
+#else
+#  define UP_WRAPSYM(s) s
+#  define UP_REALSYM(s) s
+#endif
+
 /****************************************************************************
  * Public Type Definitions
  ****************************************************************************/

--- a/tools/mksyscall.c
+++ b/tools/mksyscall.c
@@ -595,13 +595,7 @@ static void generate_wrapper(int nfixed, int nparms)
 
   /* Define macros to get wrapper symbol */
 
-  fprintf(stream, "#include <nuttx/arch.h>\n");
-  fprintf(stream, "#ifndef UP_WRAPSYM\n");
-  fprintf(stream, "#define UP_WRAPSYM(s) __wrap_##s\n");
-  fprintf(stream, "#endif\n");
-  fprintf(stream, "#ifndef UP_REALSYM\n");
-  fprintf(stream, "#define UP_REALSYM(s) __real_##s\n");
-  fprintf(stream, "#endif\n\n");
+  fprintf(stream, "#include <nuttx/arch.h>\n\n");
 
   if (g_parm[COND_INDEX][0] != '\0')
     {


### PR DESCRIPTION
## Summary
Sometimes we don't want to go through syscall, but call the real function

Export this macro, you can get the real function name through it

## Impact

## Testing

