### PR TITLE
syslog: fix extra line breaks in syslog when SYSLOG_COLOR_OUTPUT is e…

### DIFF
--- a/drivers/syslog/vsyslog.c
+++ b/drivers/syslog/vsyslog.c
@@ -222,6 +222,11 @@ int nx_vsyslog(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
 
   ret += lib_vsprintf(&stream.public, fmt, *ap);
 
+  if (stream.last_ch != '\n')
+    {
+      lib_stream_putc(&stream.public, '\n');
+    }
+
 #if defined(CONFIG_SYSLOG_COLOR_OUTPUT)
   /* Reset the terminal style back to normal. */
 

--- a/include/nuttx/streams.h
+++ b/include/nuttx/streams.h
@@ -456,7 +456,11 @@ void lib_syslogstream_open(FAR struct lib_syslogstream_s *stream);
  *
  ****************************************************************************/
 
+#ifdef CONFIG_SYSLOG_BUFFER
 void lib_syslogstream_close(FAR struct lib_syslogstream_s *stream);
+#else
+#  define lib_syslogstream_close(s)
+#endif
 
 /****************************************************************************
  * Name: lib_lzfoutstream

--- a/libs/libc/stream/lib_syslogstream.c
+++ b/libs/libc/stream/lib_syslogstream.c
@@ -214,16 +214,11 @@ void lib_syslogstream_open(FAR struct lib_syslogstream_s *stream)
  *
  ****************************************************************************/
 
+#ifdef CONFIG_SYSLOG_BUFFER
 void lib_syslogstream_close(FAR struct lib_syslogstream_s *stream)
 {
   DEBUGASSERT(stream != NULL);
 
-  if (stream->last_ch != '\n')
-    {
-      syslogstream_putc(&stream->public, '\n');
-    }
-
-#ifdef CONFIG_SYSLOG_BUFFER
   /* Verify that there is an IOB attached (there should be) */
 
   if (stream->iob != NULL)
@@ -237,5 +232,5 @@ void lib_syslogstream_close(FAR struct lib_syslogstream_s *stream)
       iob_free(stream->iob);
       stream->iob = NULL;
     }
-#endif
 }
+#endif


### PR DESCRIPTION
## Summary
fix extra line breaks in syslog when SYSLOG_COLOR_OUTPUT is enabled

After enabling SYSLOG_COLOR_OUTPUT, the format string may already contain the '\n' end character
But at the end, a color escape character is added, resulting in the last character not being '\n', which will cause redundant blank lines to be output

regression by: https://github.com/apache/nuttx/pull/8004

## Impact
syslog

## Testing
