### PR TITLE
net_local: fix error when work with epoll

### DIFF
--- a/net/local/local_netpoll.c
+++ b/net/local/local_netpoll.c
@@ -109,6 +109,18 @@ errout:
   net_unlock();
   return ret;
 }
+
+/****************************************************************************
+ * Name: local_inout_poll_cb
+ ****************************************************************************/
+
+static void local_inout_poll_cb(FAR struct pollfd *fds)
+{
+  FAR struct pollfd *originfds = fds->arg;
+
+  poll_notify(&originfds, 1, fds->revents);
+}
+
 #endif
 
 /****************************************************************************
@@ -201,10 +213,14 @@ int local_pollsetup(FAR struct socket *psock, FAR struct pollfd *fds)
 
           shadowfds[0]         = *fds;
           shadowfds[0].fd      = 1; /* Does not matter */
+          shadowfds[0].cb      = local_inout_poll_cb;
+          shadowfds[0].arg     = fds;
           shadowfds[0].events &= ~POLLOUT;
 
           shadowfds[1]         = *fds;
           shadowfds[1].fd      = 0; /* Does not matter */
+          shadowfds[1].cb      = local_inout_poll_cb;
+          shadowfds[1].arg     = fds;
           shadowfds[1].events &= ~POLLIN;
 
           net_unlock();


### PR DESCRIPTION
epoll_wait collects revent by checking fds->revent, but local_socket will copy fds to the other two private pollfd shandow struct, then the pipe_poll will not be able to update fds->revent directly, so need local_socket save fds and implement a private poll_notify function to passing revent to original fds->revent.

Signed-off-by: zhanghongyu <zhanghongyu@xiaomi.com>

## Summary

## Impact

## Testing

