### PR TITLE
net/devif: fix devif_poll loop logic

### DIFF
--- a/net/devif/devif_poll.c
+++ b/net/devif/devif_poll.c
@@ -964,8 +964,14 @@ int devif_poll(FAR struct net_driver_s *dev, devif_poll_callback_t callback)
                 }
             }
         }
+      else
+        {
+          /* Not stopped by devif_poll_callback, just stop and return bstop */
+
+          break;
+        }
     }
-  while (bstop);
+  while (!bstop);
 
   /* Device polling completed, release iob */
 


### PR DESCRIPTION
## Summary

Previously, the `devif_poll` works in this flow:
`devif_poll_xx` -> `bstop = callback` -> continue if `!bstop` -> poll another

Now we split the polling and callback, so it should work like:
`devif_poll_connections` -> return `true` if callback need to be called -> `bstop = callback` -> loop if `!bstop` -> poll again

Conditions:
poll_connections == 0, d_len == 0, break, return 0
poll_connections == 1, d_len == 0, break, return 1 (other stop case, don't callback)
poll_connections == 1, d_len > 0, callback == 1, break, return 1
poll_connections == 1, d_len > 0, callback == 0, loop

## Impact

Fix logic of `devif_poll` for old drivers using `d_buf`.

## Testing

Tested on products using bcmf_netdev.c, may have problem when using iperf client with tcp before this commit and won't after this.