### PR TITLE
optimize syslog speed

### DIFF
--- a/drivers/syslog/vsyslog.c
+++ b/drivers/syslog/vsyslog.c
@@ -39,8 +39,22 @@
  * Private Data
  ****************************************************************************/
 
+#if defined(CONFIG_SYSLOG_COLOR_OUTPUT)
+static FAR const char * const g_priority_color[] =
+  {
+    "\e[31;1;5m", /* LOG_EMERG, Red, Bold, Blinking */
+    "\e[31;1m",   /* LOG_ALERT, Red, Bold */
+    "\e[31;1m",   /* LOG_CRIT, Red, Bold */
+    "\e[31m",     /* LOG_ERR, Red */
+    "\e[33m",     /* LOG_WARNING, Yellow */
+    "\e[1m",      /* LOG_NOTICE, Bold */
+    "",           /* LOG_INFO, Normal */
+    "\e[2m",      /* LOG_DEBUG, Dim */
+  };
+#endif
+
 #if defined(CONFIG_SYSLOG_PRIORITY)
-static FAR const char * g_priority_str[] =
+static FAR const char * const g_priority_str[] =
   {
     "EMERG", "ALERT", "CRIT", "ERROR",
     "WARN", "NOTICE", "INFO", "DEBUG"
@@ -163,39 +177,7 @@ int nx_vsyslog(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
 #if defined(CONFIG_SYSLOG_COLOR_OUTPUT)
   /* Set the terminal style according to message priority. */
 
-  switch (priority)
-    {
-      case LOG_EMERG:   /* Red, Bold, Blinking */
-        ret += lib_sprintf(&stream.public, "\e[31;1;5m");
-        break;
-
-      case LOG_ALERT:   /* Red, Bold */
-        ret += lib_sprintf(&stream.public, "\e[31;1m");
-        break;
-
-      case LOG_CRIT:    /* Red, Bold */
-        ret += lib_sprintf(&stream.public, "\e[31;1m");
-        break;
-
-      case LOG_ERR:     /* Red */
-        ret += lib_sprintf(&stream.public, "\e[31m");
-        break;
-
-      case LOG_WARNING: /* Yellow */
-        ret += lib_sprintf(&stream.public, "\e[33m");
-        break;
-
-      case LOG_NOTICE:  /* Bold */
-        ret += lib_sprintf(&stream.public, "\e[1m");
-        break;
-
-      case LOG_INFO:    /* Normal */
-        break;
-
-      case LOG_DEBUG:   /* Dim */
-        ret += lib_sprintf(&stream.public, "\e[2m");
-        break;
-    }
+  ret += lib_sprintf(&stream.public, "%s", g_priority_color[priority]);
 #endif
 
 #if defined(CONFIG_SYSLOG_PRIORITY)
@@ -215,7 +197,7 @@ int nx_vsyslog(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
 
   tcb = nxsched_get_tcb(gettid());
   ret += lib_sprintf(&stream.public, "%s: ",
-                     (tcb != NULL) ? tcb->name : "(null)");
+                     tcb != NULL ? tcb->name : "(null)");
 #endif
 
   /* Generate the output */
@@ -230,7 +212,7 @@ int nx_vsyslog(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
 #if defined(CONFIG_SYSLOG_COLOR_OUTPUT)
   /* Reset the terminal style back to normal. */
 
-  ret += lib_sprintf(&stream.public, "\e[0m");
+  ret += lib_stream_puts(&stream.public, "\e[0m", sizeof("\e[0m"));
 #endif
 
   /* Flush and destroy the syslog stream buffer */

--- a/libs/libc/stream/lib_syslogstream.c
+++ b/libs/libc/stream/lib_syslogstream.c
@@ -22,10 +22,9 @@
  * Included Files
  ****************************************************************************/
 
-#include <nuttx/config.h>
-
 #include <assert.h>
 #include <errno.h>
+#include <stddef.h>
 
 #include <nuttx/mm/iob.h>
 #include <nuttx/streams.h>
@@ -103,6 +102,37 @@ static void syslogstream_addchar(FAR struct lib_syslogstream_s *stream,
       syslogstream_flush(stream);
     }
 }
+
+static int syslogstream_addstring(FAR struct lib_syslogstream_s *stream,
+                                  FAR const char *buff, int len)
+{
+  FAR struct iob_s *iob = stream->iob;
+  int ret = 0;
+
+  do
+    {
+      int remain = CONFIG_IOB_BUFSIZE - iob->io_len;
+      remain = remain > len ? len : remain;
+      memcpy(iob->io_data + iob->io_len, buff + ret, remain);
+      iob->io_len += remain;
+      ret += remain;
+
+      /* Is the buffer enough? */
+
+      if (iob->io_len >= CONFIG_IOB_BUFSIZE)
+        {
+          /* Yes.. then flush the buffer */
+
+          syslogstream_flush(stream);
+        }
+    }
+  while (ret < len);
+
+  /* Increment the total number of bytes buffered. */
+
+  stream->public.nput += len;
+  return len;
+}
 #endif
 
 /****************************************************************************
@@ -162,6 +192,56 @@ static void syslogstream_putc(FAR struct lib_outstream_s *this, int ch)
     }
 }
 
+static int syslogstream_puts(FAR struct lib_outstream_s *this,
+                             FAR const void *buff, int len)
+{
+  FAR struct lib_syslogstream_s *stream =
+                                      (FAR struct lib_syslogstream_s *)this;
+  int ret = 0;
+
+  DEBUGASSERT(stream != NULL);
+  stream->last_ch = ((FAR const char *)buff)[len -1];
+
+#ifdef CONFIG_SYSLOG_BUFFER
+  /* Do we have an IO buffer? */
+
+  if (stream->iob != NULL)
+    {
+      /* Add the incoming string to the buffer */
+
+      ret += syslogstream_addstring(stream, buff, len);
+    }
+  else
+#endif
+    {
+      /* Try writing until the write was successful or until an
+       * irrecoverable error occurs.
+       */
+
+      do
+        {
+          /* Write the buffer to the supported logging device.  On
+           * failure, syslog_write returns a negated errno value.
+           */
+
+          ret = syslog_write(buff, len);
+          if (ret >= 0)
+            {
+              this->nput += ret;
+              return ret;
+            }
+
+          /* The special return value -EINTR means that syslog_putc() was
+           * awakened by a signal.  This is not a real error and must be
+           * ignored in this context.
+           */
+        }
+      while (ret == -EINTR);
+    }
+
+  return ret;
+}
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -189,6 +269,7 @@ void lib_syslogstream_open(FAR struct lib_syslogstream_s *stream)
   /* Initialize the common fields */
 
   stream->public.putc  = syslogstream_putc;
+  stream->public.puts  = syslogstream_puts;
   stream->public.flush = lib_noflush;
   stream->public.nput  = 0;
 


### PR DESCRIPTION
## Summary
 merge multiple lib_sprintf into one

## Impact
Syslog speed has been slightly improved
output ``` syslog(LOG_INFO, "Hello, World!!\n");```    35us->  34 us

## Testing
Any configuration, enable format options

Test Conditions: 
Hardware : STM32H743ZI nucleo
config: 
enable all syslog format options,
enable CONFIG_SYSLOG_BUFFER,
enable CONFIG_RAMLOG_SYSLOG,
disable CONFIG_SYSLOG_DEFAULT
