### PR TITLE
drivers/note: Fix the mismatch of va_end call

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_spi.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_spi.c
@@ -1456,7 +1456,7 @@ int esp32c3_spibus_uninitialize(struct spi_dev_s *dev)
 
 #ifdef CONFIG_ESP32C3_SPI2_DMA
   up_disable_irq(priv->config->irq);
-  esp32c3_free_cpuint(priv->config->periph, priv->cpuint);
+  esp32c3_teardown_irq(priv->config->periph, priv->cpuint);
   priv->cpuint = -ENOMEM;
 #endif
 

--- a/drivers/note/note_driver.c
+++ b/drivers/note/note_driver.c
@@ -1195,6 +1195,7 @@ void sched_note_syscall_enter(int nr, int argc, ...)
   for (driver = g_note_drivers; *driver; driver++)
     {
       va_list copy;
+
       va_copy(copy, ap);
       if (note_syscall_enter(*driver, nr, argc, &copy))
         {
@@ -1202,9 +1203,9 @@ void sched_note_syscall_enter(int nr, int argc, ...)
           continue;
         }
 
-      va_end(copy);
       if ((*driver)->ops->add == NULL)
         {
+          va_end(copy);
           continue;
         }
 
@@ -1230,6 +1231,8 @@ void sched_note_syscall_enter(int nr, int argc, ...)
               args += sizeof(uintptr_t);
             }
         }
+
+      va_end(copy);
 
       /* Add the note to circular buffer */
 


### PR DESCRIPTION
## Summary
Fix the typo error in: https://github.com/apache/nuttx/pull/8002

## Impact
sched_note_syscall_enter

## Testing
Pass CI
