### PR TITLE
CI/Documentation: livereload hash missmatch due to new wheel packag upload

### DIFF
--- a/Documentation/Pipfile.lock
+++ b/Documentation/Pipfile.lock
@@ -87,7 +87,8 @@
         },
         "livereload": {
             "hashes": [
-                "sha256:776f2f865e59fde56490a56bcc6773b6917366bce0c267c60ee8aaf1a0959869"
+                "sha256:776f2f865e59fde56490a56bcc6773b6917366bce0c267c60ee8aaf1a0959869",
+                "sha256:ad4ac6f53b2d62bb6ce1a5e6e96f1f00976a32348afedcb4b6d68df2a1d346e4"
             ],
             "version": "==2.6.3"
         },


### PR DESCRIPTION
## Summary
When the documentation build was run an error like this would fire:
```
 [pipenv.exceptions.InstallError]: ERROR: THESE PACKAGES DO NOT MATCH THE HASHES FROM THE REQUIREMENTS FILE. If you have updated the package versions, please update the hashes. Otherwise, examine the package contents carefully; someone may have tampered with them.
[pipenv.exceptions.InstallError]:     livereload==2.6.3 from https://files.pythonhosted.org/packages/e3/05/ed67ccf462fff0b559e6ea7b3e3fcb20dec9d57bf90b5c5e72a6f316183e/livereload-2.6.3-py2.py3-none-any.whl (from -r /tmp/pipenv-d33x7r11-requirements/pipenv-cuiotbwk-hashed-reqs.txt (line 10)):
[pipenv.exceptions.InstallError]:         Expected sha256 776f2f865e59fde56490a56bcc6773b6917366bce0c267c60ee8aaf1a0959869
[pipenv.exceptions.InstallError]:              Got        ad4ac6f53b2d62bb6ce1a5e6e96f1f00976a32348afedcb4b6d68df2a1d346e4
```
We supply a Pipfile.lock that specifies the allowed package SHAs.  Upstream had not upload a wheel package when 2.6.3 when we last locked the packages and we default to whl packages.  The maintainer for this package uploaded a wheel again for this package which then showed up as an unexpected SHA.

For reference:
https://github.com/lepture/python-livereload/issues/265

## Impact
Website can be built again in CI.

## Testing
Documentation build passing should suffice.
