### PR TITLE
drivers/note: Replace the scritical section with spin_xxx_wo_note

### DIFF
--- a/drivers/note/notelog_driver.c
+++ b/drivers/note/notelog_driver.c
@@ -79,7 +79,7 @@ static void notelog_irqhandler(FAR struct note_driver_s *drv, int irq,
  * Private Data
  ****************************************************************************/
 
-static struct note_driver_ops_s g_notelog_ops =
+static const struct note_driver_ops_s g_notelog_ops =
 {
   NULL,                  /* add */
   notelog_start,         /* start */

--- a/sched/sched/sched_gettcb.c
+++ b/sched/sched/sched_gettcb.c
@@ -56,7 +56,7 @@ FAR struct tcb_s *nxsched_get_tcb(pid_t pid)
   irqstate_t flags;
   int hash_ndx;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave_wo_note(NULL);
 
   /* Verify whether g_pidhash hash table has already been allocated and
    * whether the PID is within range.
@@ -84,7 +84,7 @@ FAR struct tcb_s *nxsched_get_tcb(pid_t pid)
         }
     }
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore_wo_note(NULL, flags);
 
   /* Return the TCB. */
 


### PR DESCRIPTION
## Summary

to avoid generating the unexpected schedule information. Follow up https://github.com/apache/nuttx/pull/7994.

## Impact

minor, sched note

## Testing
Pass CI
