### PR TITLE
fs: Move mmap callback before truncate in [file|mountpt]_operations

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_geofence.c
+++ b/arch/arm/src/cxd56xx/cxd56_geofence.c
@@ -106,8 +106,8 @@ static const struct file_operations g_geofencefops =
   NULL,                 /* write */
   NULL,                 /* seek */
   cxd56_geofence_ioctl, /* ioctl */
-  NULL,                 /* truncate */
   NULL,                 /* mmap */
+  NULL,                 /* truncate */
   cxd56_geofence_poll   /* poll */
 };
 

--- a/arch/arm/src/cxd56xx/cxd56_gnss.c
+++ b/arch/arm/src/cxd56xx/cxd56_gnss.c
@@ -317,8 +317,8 @@ static const struct file_operations g_gnssfops =
   cxd56_gnss_write, /* write */
   NULL,             /* seek */
   cxd56_gnss_ioctl, /* ioctl */
-  NULL,             /* truncate */
   NULL,             /* mmap */
+  NULL,             /* truncate */
   cxd56_gnss_poll   /* poll */
 };
 

--- a/arch/arm/src/cxd56xx/cxd56_hostif.c
+++ b/arch/arm/src/cxd56xx/cxd56_hostif.c
@@ -145,8 +145,8 @@ static const struct file_operations g_hif_fops =
   hif_write,   /* write */
   hif_seek,    /* seek */
   hif_ioctl,   /* ioctl */
-  NULL,        /* truncate */
   NULL,        /* mmap */
+  NULL,        /* truncate */
   hif_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , hif_unlink /* unlink */

--- a/arch/arm/src/sama5/sam_tsd.c
+++ b/arch/arm/src/sama5/sam_tsd.c
@@ -249,8 +249,8 @@ static const struct file_operations g_tsdops =
   NULL,            /* write */
   NULL,            /* seek */
   sam_tsd_ioctl,   /* ioctl */
-  NULL,            /* truncate */
   NULL,            /* mmap */
+  NULL,            /* truncate */
   sam_tsd_poll     /* poll */
 };
 

--- a/boards/arm/sam34/sam4l-xplained/src/sam_slcd.c
+++ b/boards/arm/sam34/sam4l-xplained/src/sam_slcd.c
@@ -296,8 +296,8 @@ static const struct file_operations g_slcdops =
   slcd_write,    /* write */
   NULL,          /* seek */
   slcd_ioctl,    /* ioctl */
-  NULL,          /* truncate */
   NULL,          /* mmap */
+  NULL,          /* truncate */
   slcd_poll      /* poll */
 };
 

--- a/boards/arm/stm32/mikroe-stm32f4/src/stm32_touchscreen.c
+++ b/boards/arm/stm32/mikroe-stm32f4/src/stm32_touchscreen.c
@@ -268,8 +268,8 @@ static const struct file_operations tc_fops =
   NULL,       /* write */
   NULL,       /* seek */
   tc_ioctl,   /* ioctl */
-  NULL,       /* truncate */
   NULL,       /* mmap */
+  NULL,       /* truncate */
   tc_poll     /* poll */
 };
 

--- a/boards/arm/stm32/stm32ldiscovery/src/stm32_lcd.c
+++ b/boards/arm/stm32/stm32ldiscovery/src/stm32_lcd.c
@@ -346,8 +346,8 @@ static const struct file_operations g_slcdops =
   slcd_write,    /* write */
   NULL,          /* seek */
   slcd_ioctl,    /* ioctl */
-  NULL,          /* truncate */
   NULL,          /* mmap */
+  NULL,          /* truncate */
   slcd_poll      /* poll */
 };
 

--- a/boards/mips/pic32mx/pic32mx7mmb/src/pic32_touchscreen.c
+++ b/boards/mips/pic32mx/pic32mx7mmb/src/pic32_touchscreen.c
@@ -249,8 +249,8 @@ static const struct file_operations tc_fops =
   NULL,       /* write */
   NULL,       /* seek */
   tc_ioctl,   /* ioctl */
-  NULL,       /* truncate */
   NULL,       /* mmap */
+  NULL,       /* truncate */
   tc_poll     /* poll */
 };
 

--- a/boards/mips/pic32mx/sure-pic32mx/src/pic32mx_lcd1602.c
+++ b/boards/mips/pic32mx/sure-pic32mx/src/pic32mx_lcd1602.c
@@ -181,8 +181,8 @@ static const struct file_operations g_lcdops =
   lcd_write,     /* write */
   NULL,          /* seek */
   lcd_ioctl,     /* ioctl */
-  NULL,          /* truncate */
   NULL,          /* mmap */
+  NULL,          /* truncate */
   lcd_poll       /* poll */
 };
 

--- a/crypto/cryptodev.c
+++ b/crypto/cryptodev.c
@@ -125,8 +125,8 @@ static const struct file_operations g_cryptofops =
   cryptof_write,       /* write  */
   NULL,                /* seek   */
   cryptof_ioctl,       /* ioctl  */
+  NULL,                /* mmap   */
   NULL,                /* truncate */
-  NULL,                /* mmap */
   cryptof_poll         /* poll   */
 };
 
@@ -138,8 +138,8 @@ static const struct file_operations g_cryptoops =
   NULL,                /* write  */
   NULL,                /* seek   */
   cryptoioctl,         /* ioctl  */
+  NULL,                /* mmap   */
   NULL,                /* truncate */
-  NULL,                /* mmap */
   NULL                 /* poll   */
 };
 

--- a/drivers/analog/adc.c
+++ b/drivers/analog/adc.c
@@ -72,8 +72,8 @@ static const struct file_operations g_adc_fops =
   NULL,         /* write */
   NULL,         /* seek */
   adc_ioctl,    /* ioctl */
-  NULL,         /* truncate */
   NULL,         /* mmap */
+  NULL,         /* truncate */
   adc_poll      /* poll */
 };
 

--- a/drivers/analog/comp.c
+++ b/drivers/analog/comp.c
@@ -65,8 +65,8 @@ static const struct file_operations comp_fops =
   NULL,                         /* write */
   NULL,                         /* seek */
   comp_ioctl,                   /* ioctl */
-  NULL,                         /* truncate */
   NULL,                         /* mmap */
+  NULL,                         /* truncate */
   comp_poll                     /* poll */
 };
 

--- a/drivers/bch/bchdev_driver.c
+++ b/drivers/bch/bchdev_driver.c
@@ -78,8 +78,8 @@ const struct file_operations bch_fops =
   bch_write,   /* write */
   bch_seek,    /* seek */
   bch_ioctl,   /* ioctl */
-  NULL,        /* truncate */
   NULL,        /* mmap */
+  NULL,        /* truncate */
   bch_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , bch_unlink /* unlink */

--- a/drivers/can/can.c
+++ b/drivers/can/can.c
@@ -135,8 +135,8 @@ static const struct file_operations g_canops =
   can_write, /* write */
   NULL,      /* seek */
   can_ioctl, /* ioctl */
-  NULL,      /* truncate */
   NULL,      /* mmap */
+  NULL,      /* truncate */
   can_poll   /* poll */
 };
 

--- a/drivers/crypto/dev_urandom.c
+++ b/drivers/crypto/dev_urandom.c
@@ -100,8 +100,8 @@ static const struct file_operations g_urand_fops =
   devurand_write,               /* write */
   NULL,                         /* seek */
   NULL,                         /* ioctl */
-  NULL,                         /* truncate */
   NULL,                         /* mmap */
+  NULL,                         /* truncate */
   devurand_poll                 /* poll */
 };
 

--- a/drivers/i2c/i2c_driver.c
+++ b/drivers/i2c/i2c_driver.c
@@ -99,8 +99,8 @@ static const struct file_operations i2cdrvr_fops =
   i2cdrvr_write,   /* write */
   NULL,            /* seek */
   i2cdrvr_ioctl,   /* ioctl */
-  NULL,            /* truncate */
   NULL,            /* mmap */
+  NULL,            /* truncate */
   NULL             /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , i2cdrvr_unlink /* unlink */

--- a/drivers/input/ads7843e.c
+++ b/drivers/input/ads7843e.c
@@ -122,8 +122,8 @@ static const struct file_operations ads7843e_fops =
   NULL,             /* write */
   NULL,             /* seek */
   ads7843e_ioctl,   /* ioctl */
-  NULL,             /* truncate */
   NULL,             /* mmap */
+  NULL,             /* truncate */
   ads7843e_poll     /* poll */
 };
 

--- a/drivers/input/ajoystick.c
+++ b/drivers/input/ajoystick.c
@@ -135,8 +135,8 @@ static const struct file_operations ajoy_fops =
   NULL,       /* write */
   NULL,       /* seek */
   ajoy_ioctl, /* ioctl */
-  NULL,       /* truncate */
   NULL,       /* mmap */
+  NULL,       /* truncate */
   ajoy_poll   /* poll */
 };
 

--- a/drivers/input/button_upper.c
+++ b/drivers/input/button_upper.c
@@ -133,8 +133,8 @@ static const struct file_operations btn_fops =
   btn_write, /* write */
   NULL,      /* seek */
   btn_ioctl, /* ioctl */
-  NULL,      /* truncate */
   NULL,      /* mmap */
+  NULL,      /* truncate */
   btn_poll   /* poll */
 };
 

--- a/drivers/input/cypress_mbr3108.c
+++ b/drivers/input/cypress_mbr3108.c
@@ -224,8 +224,8 @@ static const struct file_operations g_mbr3108_fileops =
   mbr3108_write,  /* write */
   NULL,           /* seek */
   NULL,           /* ioctl */
-  NULL,           /* truncate */
   NULL,           /* mmap */
+  NULL,           /* truncate */
   mbr3108_poll    /* poll */
 };
 

--- a/drivers/input/djoystick.c
+++ b/drivers/input/djoystick.c
@@ -135,8 +135,8 @@ static const struct file_operations djoy_fops =
   NULL,       /* write */
   NULL,       /* seek */
   djoy_ioctl, /* ioctl */
-  NULL,       /* truncate */
   NULL,       /* mmap */
+  NULL,       /* truncate */
   djoy_poll   /* poll */
 };
 

--- a/drivers/input/ft5x06.c
+++ b/drivers/input/ft5x06.c
@@ -176,8 +176,8 @@ static const struct file_operations ft5x06_fops =
   NULL,           /* write */
   NULL,           /* seek */
   ft5x06_ioctl,   /* ioctl */
-  NULL,           /* truncate */
   NULL,           /* mmap */
+  NULL,           /* truncate */
   ft5x06_poll     /* poll */
 };
 

--- a/drivers/input/keyboard_upper.c
+++ b/drivers/input/keyboard_upper.c
@@ -88,8 +88,8 @@ static const struct file_operations g_keyboard_fops =
   keyboard_write, /* write */
   NULL,           /* seek */
   NULL,           /* ioctl */
-  NULL,           /* truncate */
   NULL,           /* mmap */
+  NULL,           /* truncate */
   keyboard_poll   /* poll */
 };
 

--- a/drivers/input/max11802.c
+++ b/drivers/input/max11802.c
@@ -115,8 +115,8 @@ static const struct file_operations max11802_fops =
   NULL,             /* write */
   NULL,             /* seek */
   max11802_ioctl,   /* ioctl */
-  NULL,             /* truncate */
   NULL,             /* mmap */
+  NULL,             /* truncate */
   max11802_poll     /* poll */
 };
 

--- a/drivers/input/mxt.c
+++ b/drivers/input/mxt.c
@@ -280,8 +280,8 @@ static const struct file_operations mxt_fops =
   NULL,        /* write */
   NULL,        /* seek */
   mxt_ioctl,   /* ioctl */
-  NULL,        /* truncate */
   NULL,        /* mmap */
+  NULL,        /* truncate */
   mxt_poll     /* poll */
 };
 

--- a/drivers/input/spq10kbd.c
+++ b/drivers/input/spq10kbd.c
@@ -255,8 +255,8 @@ static const struct file_operations g_hidkbd_fops =
   spq10kbd_write,            /* write */
   NULL,                      /* seek */
   NULL,                      /* ioctl */
-  NULL,                      /* truncate */
   NULL,                      /* mmap */
+  NULL,                      /* truncate */
   spq10kbd_poll              /* poll */
 };
 

--- a/drivers/input/stmpe811_tsc.c
+++ b/drivers/input/stmpe811_tsc.c
@@ -124,8 +124,8 @@ static const struct file_operations g_stmpe811fops =
   NULL,             /* write */
   NULL,             /* seek */
   stmpe811_ioctl,   /* ioctl */
-  NULL,             /* truncate */
   NULL,             /* mmap */
+  NULL,             /* truncate */
   stmpe811_poll     /* poll */
 };
 

--- a/drivers/input/touchscreen_upper.c
+++ b/drivers/input/touchscreen_upper.c
@@ -90,8 +90,8 @@ static const struct file_operations g_touch_fops =
   touch_write,    /* write */
   NULL,           /* seek */
   touch_ioctl,    /* ioctl */
-  NULL,           /* truncate */
   NULL,           /* mmap */
+  NULL,           /* truncate */
   touch_poll      /* poll */
 };
 

--- a/drivers/input/tsc2007.c
+++ b/drivers/input/tsc2007.c
@@ -209,8 +209,8 @@ static const struct file_operations tsc2007_fops =
   NULL,            /* write */
   NULL,            /* seek */
   tsc2007_ioctl,   /* ioctl */
-  NULL,            /* truncate */
   NULL,            /* mmap */
+  NULL,            /* truncate */
   tsc2007_poll     /* poll */
 };
 

--- a/drivers/lcd/ft80x.c
+++ b/drivers/lcd/ft80x.c
@@ -134,8 +134,8 @@ static const struct file_operations g_ft80x_fops =
   ft80x_write,   /* write */
   NULL,          /* seek */
   ft80x_ioctl,   /* ioctl */
-  NULL,          /* truncate */
   NULL,          /* mmap */
+  NULL,          /* truncate */
   NULL           /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , ft80x_unlink /* unlink */

--- a/drivers/lcd/pcf8574_lcd_backpack.c
+++ b/drivers/lcd/pcf8574_lcd_backpack.c
@@ -117,8 +117,8 @@ static const struct file_operations g_pcf8574_lcd_fops =
   pcf8574_lcd_write,            /* write */
   pcf8574_lcd_seek,             /* seek */
   pcf8574_lcd_ioctl,            /* ioctl */
-  NULL,                         /* truncate */
   NULL,                         /* mmap */
+  NULL,                         /* truncate */
   pcf8574_lcd_poll              /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , pcf8574_lcd_unlink          /* unlink */

--- a/drivers/lcd/tda19988.c
+++ b/drivers/lcd/tda19988.c
@@ -170,8 +170,8 @@ static const struct file_operations tda19988_fops =
   tda19988_write,    /* write */
   tda19988_seek,     /* seek */
   tda19988_ioctl,    /* ioctl */
-  NULL,              /* truncate */
   NULL,              /* mmap */
+  NULL,              /* truncate */
   tda19988_poll      /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , tda19988_unlink  /* unlink */

--- a/drivers/misc/dev_null.c
+++ b/drivers/misc/dev_null.c
@@ -57,8 +57,8 @@ static const struct file_operations devnull_fops =
   devnull_write, /* write */
   NULL,          /* seek */
   NULL,          /* ioctl */
-  NULL,          /* truncate */
   NULL,          /* mmap */
+  NULL,          /* truncate */
   devnull_poll   /* poll */
 };
 

--- a/drivers/misc/dev_zero.c
+++ b/drivers/misc/dev_zero.c
@@ -57,8 +57,8 @@ static const struct file_operations devzero_fops =
   devzero_write, /* write */
   NULL,          /* seek */
   NULL,          /* ioctl */
-  NULL,          /* truncate */
   NULL,          /* mmap */
+  NULL,          /* truncate */
   devzero_poll   /* poll */
 };
 

--- a/drivers/misc/rpmsgdev.c
+++ b/drivers/misc/rpmsgdev.c
@@ -165,8 +165,8 @@ const struct file_operations g_rpmsgdev_ops =
   rpmsgdev_write,         /* write */
   rpmsgdev_seek,          /* seek */
   rpmsgdev_ioctl,         /* ioctl */
-  NULL,                   /* truncate */
   NULL,                   /* mmap */
+  NULL,                   /* truncate */
   rpmsgdev_poll           /* poll */
 };
 

--- a/drivers/modem/alt1250/alt1250.c
+++ b/drivers/modem/alt1250/alt1250.c
@@ -77,8 +77,8 @@ static const struct file_operations g_alt1250fops =
   NULL,          /* write */
   NULL,          /* seek */
   alt1250_ioctl, /* ioctl */
-  NULL,          /* truncate */
   NULL,          /* mmap */
+  NULL,          /* truncate */
   alt1250_poll,  /* poll */
 };
 static uint8_t g_recvbuff[ALTCOM_RX_PKT_SIZE_MAX];

--- a/drivers/modem/u-blox.c
+++ b/drivers/modem/u-blox.c
@@ -114,8 +114,8 @@ static const struct file_operations ubxmdm_fops =
   ubxmdm_write, /* write */
   NULL,         /* seek */
   ubxmdm_ioctl, /* ioctl */
-  NULL,         /* truncate */
   NULL,         /* mmap */
+  NULL,         /* truncate */
   ubxmdm_poll   /* poll */
 };
 

--- a/drivers/mtd/mtd_config.c
+++ b/drivers/mtd/mtd_config.c
@@ -119,8 +119,8 @@ static const struct file_operations mtdconfig_fops =
   NULL,            /* write */
   NULL,            /* seek */
   mtdconfig_ioctl, /* ioctl */
-  NULL,            /* truncate */
   NULL,            /* mmap */
+  NULL,            /* truncate */
   mtdconfig_poll   /* poll */
 };
 

--- a/drivers/net/telnet.c
+++ b/drivers/net/telnet.c
@@ -190,8 +190,8 @@ static const struct file_operations g_telnet_fops =
   telnet_write,  /* write */
   NULL,          /* seek */
   telnet_ioctl,  /* ioctl */
-  NULL,          /* truncate */
   NULL,          /* mmap */
+  NULL,          /* truncate */
   telnet_poll    /* poll */
 };
 

--- a/drivers/net/tun.c
+++ b/drivers/net/tun.c
@@ -219,8 +219,8 @@ static const struct file_operations g_tun_file_ops =
   tun_write,    /* write */
   NULL,         /* seek */
   tun_ioctl,    /* ioctl */
-  NULL,         /* truncate */
   NULL,         /* mmap */
+  NULL,         /* truncate */
   tun_poll      /* poll */
 };
 

--- a/drivers/pipes/fifo.c
+++ b/drivers/pipes/fifo.c
@@ -47,8 +47,8 @@ static const struct file_operations g_fifo_fops =
   pipecommon_write,    /* write */
   NULL,                /* seek */
   pipecommon_ioctl,    /* ioctl */
-  NULL,                /* truncate */
   NULL,                /* mmap */
+  NULL,                /* truncate */
   pipecommon_poll      /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , pipecommon_unlink  /* unlink */

--- a/drivers/pipes/pipe.c
+++ b/drivers/pipes/pipe.c
@@ -61,8 +61,8 @@ static const struct file_operations g_pipe_fops =
   pipecommon_write,    /* write */
   NULL,                /* seek */
   pipecommon_ioctl,    /* ioctl */
-  NULL,                /* truncate */
   NULL,                /* mmap */
+  NULL,                /* truncate */
   pipecommon_poll      /* poll */
 };
 

--- a/drivers/power/battery/battery_charger.c
+++ b/drivers/power/battery/battery_charger.c
@@ -91,8 +91,8 @@ static const struct file_operations g_batteryops =
   bat_charger_write,   /* write */
   NULL,                /* seek */
   bat_charger_ioctl,   /* ioctl */
-  NULL,                /* truncate */
   NULL,                /* mmap */
+  NULL,                /* truncate */
   bat_charger_poll     /* poll */
 };
 

--- a/drivers/power/battery/battery_gauge.c
+++ b/drivers/power/battery/battery_gauge.c
@@ -93,8 +93,8 @@ static const struct file_operations g_batteryops =
   bat_gauge_write,  /* write */
   NULL,             /* seek */
   bat_gauge_ioctl,  /* ioctl */
-  NULL,             /* truncate */
   NULL,             /* mmap */
+  NULL,             /* truncate */
   bat_gauge_poll    /* poll */
 };
 

--- a/drivers/power/battery/battery_monitor.c
+++ b/drivers/power/battery/battery_monitor.c
@@ -92,8 +92,8 @@ static const struct file_operations g_batteryops =
   bat_monitor_write,   /* write */
   NULL,                /* seek */
   bat_monitor_ioctl,   /* ioctl */
-  NULL,                /* truncate */
   NULL,                /* mmap */
+  NULL,                /* truncate */
   bat_monitor_poll     /* poll */
 };
 

--- a/drivers/rc/lirc_dev.c
+++ b/drivers/rc/lirc_dev.c
@@ -103,8 +103,8 @@ static const struct file_operations g_lirc_fops =
   lirc_write,  /* write */
   NULL,        /* seek */
   lirc_ioctl,  /* ioctl */
-  NULL,        /* truncate */
   NULL,        /* mmap */
+  NULL,        /* truncate */
   lirc_poll    /* poll */
 };
 

--- a/drivers/sensors/aht10.c
+++ b/drivers/sensors/aht10.c
@@ -116,8 +116,8 @@ static const struct file_operations g_aht10fops =
   aht10_write,    /* write */
   NULL,           /* seek */
   aht10_ioctl,    /* ioctl */
-  NULL,           /* truncate */
   NULL,           /* mmap */
+  NULL,           /* truncate */
   NULL            /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , aht10_unlink /* unlink */

--- a/drivers/sensors/hc_sr04.c
+++ b/drivers/sensors/hc_sr04.c
@@ -90,8 +90,8 @@ static const struct file_operations g_hcsr04ops =
   hcsr04_write,  /* write */
   NULL,          /* seek */
   hcsr04_ioctl,  /* ioctl */
-  NULL,          /* truncate */
   NULL,          /* mmap */
+  NULL,          /* truncate */
   hcsr04_poll    /* poll */
 };
 

--- a/drivers/sensors/hdc1008.c
+++ b/drivers/sensors/hdc1008.c
@@ -161,8 +161,8 @@ static const struct file_operations g_hdc1008fops =
   hdc1008_write,    /* write */
   NULL,             /* seek */
   hdc1008_ioctl,    /* ioctl */
-  NULL,             /* truncate */
   NULL,             /* mmap */
+  NULL,             /* truncate */
   NULL              /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , hdc1008_unlink  /* unlink */

--- a/drivers/sensors/hts221.c
+++ b/drivers/sensors/hts221.c
@@ -157,8 +157,8 @@ static const struct file_operations g_humidityops =
   hts221_write,  /* write */
   NULL,          /* seek */
   hts221_ioctl,  /* ioctl */
-  NULL,          /* truncate */
   NULL,          /* mmap */
+  NULL,          /* truncate */
   hts221_poll    /* poll */
 };
 

--- a/drivers/sensors/lis2dh.c
+++ b/drivers/sensors/lis2dh.c
@@ -154,8 +154,8 @@ static const struct file_operations g_lis2dhops =
   lis2dh_write,  /* write */
   NULL,          /* seek */
   lis2dh_ioctl,  /* ioctl */
-  NULL,          /* truncate */
   NULL,          /* mmap */
+  NULL,          /* truncate */
   lis2dh_poll    /* poll */
 };
 

--- a/drivers/sensors/max44009.c
+++ b/drivers/sensors/max44009.c
@@ -112,8 +112,8 @@ static const struct file_operations g_alsops =
   max44009_write,  /* write */
   NULL,            /* seek */
   max44009_ioctl,  /* ioctl */
-  NULL,            /* truncate */
   NULL,            /* mmap */
+  NULL,            /* truncate */
   max44009_poll    /* poll */
 };
 

--- a/drivers/sensors/scd30.c
+++ b/drivers/sensors/scd30.c
@@ -182,8 +182,8 @@ static const struct file_operations g_scd30fops =
   scd30_write,    /* write */
   NULL,           /* seek */
   scd30_ioctl,    /* ioctl */
-  NULL,           /* truncate */
   NULL,           /* mmap */
+  NULL,           /* truncate */
   NULL            /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , scd30_unlink /* unlink */

--- a/drivers/sensors/scd41.c
+++ b/drivers/sensors/scd41.c
@@ -190,8 +190,8 @@ static const struct file_operations g_scd41fops =
   scd41_write,    /* write */
   NULL,           /* seek */
   scd41_ioctl,    /* ioctl */
-  NULL,           /* truncate */
   NULL,           /* mmap */
+  NULL,           /* truncate */
   NULL            /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , scd41_unlink /* unlink */

--- a/drivers/sensors/sensor.c
+++ b/drivers/sensors/sensor.c
@@ -167,8 +167,8 @@ static const struct file_operations g_sensor_fops =
   sensor_write,   /* write */
   NULL,           /* seek  */
   sensor_ioctl,   /* ioctl */
-  NULL,           /* truncate */
   NULL,           /* mmap */
+  NULL,           /* truncate */
   sensor_poll     /* poll  */
 };
 

--- a/drivers/sensors/sgp30.c
+++ b/drivers/sensors/sgp30.c
@@ -159,8 +159,8 @@ static const struct file_operations g_sgp30fops =
   sgp30_write,    /* write */
   NULL,           /* seek */
   sgp30_ioctl,    /* ioctl */
-  NULL,           /* truncate */
   NULL,           /* mmap */
+  NULL,           /* truncate */
   NULL            /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , sgp30_unlink /* unlink */

--- a/drivers/sensors/sht21.c
+++ b/drivers/sensors/sht21.c
@@ -131,8 +131,8 @@ static const struct file_operations g_sht21fops =
   sht21_write,    /* write */
   NULL,           /* seek */
   sht21_ioctl,    /* ioctl */
-  NULL,           /* truncate */
   NULL,           /* mmap */
+  NULL,           /* truncate */
   NULL            /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , sht21_unlink /* unlink */

--- a/drivers/sensors/sht3x.c
+++ b/drivers/sensors/sht3x.c
@@ -170,8 +170,8 @@ static const struct file_operations g_sht3xfops =
   sht3x_write,    /* write */
   NULL,           /* seek */
   sht3x_ioctl,    /* ioctl */
-  NULL,           /* truncate */
   NULL,           /* mmap */
+  NULL,           /* truncate */
   NULL            /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , sht3x_unlink  /* unlink */

--- a/drivers/sensors/sps30.c
+++ b/drivers/sensors/sps30.c
@@ -175,8 +175,8 @@ static const struct file_operations g_sps30fops =
   sps30_write,    /* write */
   NULL,           /* seek */
   sps30_ioctl,    /* ioctl */
-  NULL,           /* truncate */
   NULL,           /* mmap */
+  NULL,           /* truncate */
   NULL            /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , sps30_unlink /* unlink */

--- a/drivers/sensors/usensor.c
+++ b/drivers/sensors/usensor.c
@@ -81,8 +81,8 @@ static const struct file_operations g_usensor_fops =
   usensor_write, /* write */
   NULL,          /* seek  */
   usensor_ioctl, /* ioctl */
-  NULL,          /* truncate */
   NULL,          /* mmap */
+  NULL,          /* truncate */
   NULL,          /* poll  */
 };
 

--- a/drivers/serial/pty.c
+++ b/drivers/serial/pty.c
@@ -127,8 +127,8 @@ static const struct file_operations g_pty_fops =
   pty_write,     /* write */
   NULL,          /* seek */
   pty_ioctl,     /* ioctl */
-  NULL,          /* truncate */
   NULL,          /* mmap */
+  NULL,          /* truncate */
   pty_poll       /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , pty_unlink   /* unlink */

--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -126,8 +126,8 @@ static const struct file_operations g_serialops =
   uart_write, /* write */
   NULL,       /* seek */
   uart_ioctl, /* ioctl */
-  NULL,       /* truncate */
   NULL,       /* mmap */
+  NULL,       /* truncate */
   uart_poll   /* poll */
 };
 

--- a/drivers/serial/uart_bth4.c
+++ b/drivers/serial/uart_bth4.c
@@ -90,8 +90,8 @@ static const struct file_operations g_uart_bth4_ops =
   uart_bth4_write,  /* write */
   NULL,             /* seek */
   uart_bth4_ioctl,  /* ioctl */
-  NULL,             /* truncate */
   NULL,             /* mmap */
+  NULL,             /* truncate */
   uart_bth4_poll    /* poll */
 };
 

--- a/drivers/spi/spi_driver.c
+++ b/drivers/spi/spi_driver.c
@@ -99,8 +99,8 @@ static const struct file_operations spidrvr_fops =
   spidrvr_write,   /* write */
   NULL,            /* seek */
   spidrvr_ioctl,   /* ioctl */
-  NULL,            /* truncate */
   NULL,            /* mmap */
+  NULL,            /* truncate */
   NULL             /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , spidrvr_unlink /* unlink */

--- a/drivers/spi/spi_slave_driver.c
+++ b/drivers/spi/spi_slave_driver.c
@@ -127,8 +127,8 @@ static const struct file_operations g_spislavefops =
   spi_slave_write,              /* write */
   NULL,                         /* seek */
   NULL,                         /* ioctl */
-  NULL,                         /* truncate */
   NULL,                         /* mmap */
+  NULL,                         /* truncate */
   NULL                          /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , spi_slave_unlink            /* unlink */

--- a/drivers/syslog/ramlog.c
+++ b/drivers/syslog/ramlog.c
@@ -114,8 +114,8 @@ static const struct file_operations g_ramlogfops =
   ramlog_file_write, /* write */
   NULL,              /* seek */
   ramlog_file_ioctl, /* ioctl */
-  NULL,              /* truncate */
   NULL,              /* mmap */
+  NULL,              /* truncate */
   ramlog_file_poll   /* poll */
 };
 

--- a/drivers/timers/rtc.c
+++ b/drivers/timers/rtc.c
@@ -129,8 +129,8 @@ static const struct file_operations rtc_fops =
   rtc_write,     /* write */
   NULL,          /* seek */
   rtc_ioctl,     /* ioctl */
-  NULL,          /* truncate */
   NULL,          /* mmap */
+  NULL,          /* truncate */
   NULL           /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , rtc_unlink   /* unlink */

--- a/drivers/usbdev/adb.c
+++ b/drivers/usbdev/adb.c
@@ -254,8 +254,8 @@ static const struct file_operations g_adb_fops =
   adb_char_write, /* write */
   NULL,           /* seek */
   NULL,           /* ioctl */
-  NULL,           /* truncate */
   NULL,           /* mmap */
+  NULL,           /* truncate */
   adb_char_poll   /* poll */
 };
 

--- a/drivers/usbhost/usbhost_cdcmbim.c
+++ b/drivers/usbhost/usbhost_cdcmbim.c
@@ -347,8 +347,8 @@ static const struct file_operations cdcwdm_fops =
   cdcwdm_write,  /* write */
   NULL,          /* seek */
   NULL,          /* ioctl */
-  NULL,          /* truncate */
   NULL,          /* mmap */
+  NULL,          /* truncate */
   cdcwdm_poll    /* poll */
 };
 

--- a/drivers/usbhost/usbhost_hidkbd.c
+++ b/drivers/usbhost/usbhost_hidkbd.c
@@ -341,8 +341,8 @@ static const struct file_operations g_hidkbd_fops =
   usbhost_write,            /* write */
   NULL,                     /* seek */
   NULL,                     /* ioctl */
-  NULL,                     /* truncate */
   NULL,                     /* mmap */
+  NULL,                     /* truncate */
   usbhost_poll              /* poll */
 };
 

--- a/drivers/usbhost/usbhost_hidmouse.c
+++ b/drivers/usbhost/usbhost_hidmouse.c
@@ -391,8 +391,8 @@ static const struct file_operations g_hidmouse_fops =
   usbhost_write,           /* write */
   NULL,                    /* seek */
   NULL,                    /* ioctl */
-  NULL,                    /* truncate */
   NULL,                    /* mmap */
+  NULL,                    /* truncate */
   usbhost_poll             /* poll */
 };
 

--- a/drivers/usbhost/usbhost_xboxcontroller.c
+++ b/drivers/usbhost/usbhost_xboxcontroller.c
@@ -296,8 +296,8 @@ static const struct file_operations g_xboxcontroller_fops =
   usbhost_write,            /* write */
   NULL,                     /* seek */
   usbhost_ioctl,            /* ioctl */
-  NULL,                     /* truncate */
   NULL,                     /* mmap */
+  NULL,                     /* truncate */
   usbhost_poll              /* poll */
 };
 

--- a/drivers/usbmisc/fusb301.c
+++ b/drivers/usbmisc/fusb301.c
@@ -94,8 +94,8 @@ static const struct file_operations g_fusb301ops =
   fusb301_write, /* write */
   NULL,          /* seek */
   fusb301_ioctl, /* ioctl */
-  NULL,          /* truncate */
   NULL,          /* mmap */
+  NULL,          /* truncate */
   fusb301_poll   /* poll */
 };
 

--- a/drivers/usbmisc/fusb303.c
+++ b/drivers/usbmisc/fusb303.c
@@ -128,8 +128,8 @@ static const struct file_operations g_fusb303ops =
   fusb303_write, /* write */
   NULL,          /* seek */
   fusb303_ioctl, /* ioctl */
-  NULL,          /* truncate */
   NULL,          /* mmap */
+  NULL,          /* truncate */
   fusb303_poll   /* poll */
 };
 

--- a/drivers/usrsock/usrsock_dev.c
+++ b/drivers/usrsock/usrsock_dev.c
@@ -103,8 +103,8 @@ static const struct file_operations g_usrsockdevops =
   usrsockdev_write,   /* write */
   usrsockdev_seek,    /* seek */
   NULL,               /* ioctl */
-  NULL,               /* truncate */
   NULL,               /* mmap */
+  NULL,               /* truncate */
   usrsockdev_poll     /* poll */
 };
 

--- a/drivers/video/fb.c
+++ b/drivers/video/fb.c
@@ -88,8 +88,8 @@ static const struct file_operations fb_fops =
   fb_write,      /* write */
   fb_seek,       /* seek */
   fb_ioctl,      /* ioctl */
-  NULL,          /* truncate */
   fb_mmap,       /* mmap */
+  NULL,          /* truncate */
   fb_poll        /* poll */
 };
 

--- a/drivers/video/fb.c
+++ b/drivers/video/fb.c
@@ -686,7 +686,8 @@ static int fb_mmap(FAR struct file *filep, FAR struct mm_map_entry_s *map)
 
   /* Return the address corresponding to the start of frame buffer. */
 
-  if (map->offset + map->length <= fb->fblen)
+  if (map->offset >= 0 && map->offset < fb->fblen &&
+      map->length && map->offset + map->length <= fb->fblen)
     {
       map->vaddr = (FAR char *)fb->fbmem + map->offset;
       ret = OK;

--- a/drivers/video/video.c
+++ b/drivers/video/video.c
@@ -287,7 +287,6 @@ static const struct file_operations g_video_fops =
   video_write,              /* write */
   NULL,                     /* seek */
   video_ioctl,              /* ioctl */
-  NULL,                     /* truncate */
   video_mmap,               /* mmap */
 };
 

--- a/drivers/wireless/cc1101.c
+++ b/drivers/wireless/cc1101.c
@@ -305,8 +305,8 @@ static const struct file_operations g_cc1101ops =
   cc1101_file_write, /* write */
   NULL,              /* seek */
   NULL,              /* ioctl */
-  NULL,              /* truncate */
   NULL,              /* mmap */
+  NULL,              /* truncate */
   cc1101_file_poll   /* poll */
 };
 

--- a/drivers/wireless/gs2200m.c
+++ b/drivers/wireless/gs2200m.c
@@ -231,8 +231,8 @@ static const struct file_operations g_gs2200m_fops =
   gs2200m_write, /* write */
   NULL,          /* seek */
   gs2200m_ioctl, /* ioctl */
-  NULL,          /* truncate */
   NULL,          /* mmap */
+  NULL,          /* truncate */
   gs2200m_poll   /* poll */
 };
 

--- a/drivers/wireless/lpwan/sx127x/sx127x.c
+++ b/drivers/wireless/lpwan/sx127x/sx127x.c
@@ -451,8 +451,8 @@ static const struct file_operations sx127x_fops =
   sx127x_write,   /* write */
   NULL,           /* seek */
   sx127x_ioctl,   /* ioctl */
-  NULL,           /* truncate */
   NULL,           /* mmap */
+  NULL,           /* truncate */
   sx127x_poll     /* poll */
 };
 

--- a/drivers/wireless/nrf24l01.c
+++ b/drivers/wireless/nrf24l01.c
@@ -239,8 +239,8 @@ static const struct file_operations nrf24l01_fops =
   nrf24l01_write,   /* write */
   NULL,             /* seek */
   nrf24l01_ioctl,   /* ioctl */
-  NULL,             /* truncate */
   NULL,             /* mmap */
+  NULL,             /* truncate */
   nrf24l01_poll     /* poll */
 };
 

--- a/fs/binfs/fs_binfs.c
+++ b/fs/binfs/fs_binfs.c
@@ -109,8 +109,8 @@ const struct mountpt_operations binfs_operations =
   NULL,              /* write */
   NULL,              /* seek */
   binfs_ioctl,       /* ioctl */
-  NULL,              /* truncate */
   NULL,              /* mmap */
+  NULL,              /* truncate */
 
   NULL,              /* sync */
   binfs_dup,         /* dup */

--- a/fs/cromfs/fs_cromfs.c
+++ b/fs/cromfs/fs_cromfs.c
@@ -184,8 +184,8 @@ const struct mountpt_operations cromfs_operations =
   NULL,              /* write */
   NULL,              /* seek */
   cromfs_ioctl,      /* ioctl */
-  NULL,              /* truncate */
   NULL,              /* mmap */
+  NULL,              /* truncate */
 
   NULL,              /* sync */
   cromfs_dup,        /* dup */

--- a/fs/fat/fs_fat32.c
+++ b/fs/fat/fs_fat32.c
@@ -115,8 +115,8 @@ const struct mountpt_operations fat_operations =
   fat_write,         /* write */
   fat_seek,          /* seek */
   fat_ioctl,         /* ioctl */
-  fat_truncate,      /* truncate */
   NULL,              /* mmap */
+  fat_truncate,      /* truncate */
   fat_sync,          /* sync */
   fat_dup,           /* dup */
   fat_fstat,         /* fstat */

--- a/fs/hostfs/hostfs.c
+++ b/fs/hostfs/hostfs.c
@@ -142,8 +142,8 @@ const struct mountpt_operations hostfs_operations =
   hostfs_write,         /* write */
   hostfs_seek,          /* seek */
   hostfs_ioctl,         /* ioctl */
-  hostfs_ftruncate,     /* ftruncate */
   NULL,                 /* mmap */
+  hostfs_ftruncate,     /* ftruncate */
 
   hostfs_sync,          /* sync */
   hostfs_dup,           /* dup */

--- a/fs/littlefs/lfs_vfs.c
+++ b/fs/littlefs/lfs_vfs.c
@@ -140,8 +140,8 @@ const struct mountpt_operations littlefs_operations =
   littlefs_write,         /* write */
   littlefs_seek,          /* seek */
   littlefs_ioctl,         /* ioctl */
-  littlefs_truncate,      /* truncate */
   NULL,                   /* mmap */
+  littlefs_truncate,      /* truncate */
 
   littlefs_sync,          /* sync */
   littlefs_dup,           /* dup */

--- a/fs/mqueue/mq_open.c
+++ b/fs/mqueue/mq_open.c
@@ -60,8 +60,8 @@ static const struct file_operations g_nxmq_fileops =
   NULL,             /* write */
   NULL,             /* seek */
   NULL,             /* ioctl */
-  NULL,             /* truncate */
   NULL,             /* mmap */
+  NULL,             /* truncate */
   nxmq_file_poll    /* poll */
 };
 

--- a/fs/nfs/nfs_vfsops.c
+++ b/fs/nfs/nfs_vfsops.c
@@ -198,8 +198,8 @@ const struct mountpt_operations nfs_operations =
   nfs_write,                    /* write */
   NULL,                         /* seek */
   NULL,                         /* ioctl */
-  nfs_truncate,                 /* truncate */
   NULL,                         /* mmap */
+  nfs_truncate,                 /* truncate */
 
   NULL,                         /* sync */
   nfs_dup,                      /* dup */

--- a/fs/nxffs/nxffs_initialize.c
+++ b/fs/nxffs/nxffs_initialize.c
@@ -54,12 +54,12 @@ const struct mountpt_operations nxffs_operations =
   nxffs_write,       /* write */
   NULL,              /* seek -- Use f_pos in struct file */
   nxffs_ioctl,       /* ioctl */
+  NULL,              /* mmap */
 #ifdef __NO_TRUNCATE_SUPPORT__
   nxffs_truncate,    /* truncate */
 #else
   NULL,              /* truncate */
 #endif
-  NULL,              /* mmap */
 
   NULL,              /* sync -- No buffered data */
   nxffs_dup,         /* dup */

--- a/fs/procfs/fs_procfs.c
+++ b/fs/procfs/fs_procfs.c
@@ -252,8 +252,8 @@ const struct mountpt_operations procfs_operations =
   procfs_write,      /* write */
   NULL,              /* seek */
   procfs_ioctl,      /* ioctl */
-  NULL,              /* truncate */
   NULL,              /* mmap */
+  NULL,              /* truncate */
 
   NULL,              /* sync */
   procfs_dup,        /* dup */

--- a/fs/romfs/fs_romfs.c
+++ b/fs/romfs/fs_romfs.c
@@ -580,7 +580,7 @@ errout_with_lock:
 
 static int romfs_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 {
-  FAR struct romfs_file_s    *rf;
+  FAR struct romfs_file_s *rf;
 
   finfo("cmd: %d arg: %08lx\n", cmd, arg);
 
@@ -625,8 +625,8 @@ static int romfs_mmap(FAR struct file *filep, FAR struct mm_map_entry_s *map)
    * the file.
    */
 
-  if (map && rm && rm->rm_xipbase && rf &&
-      map->offset + map->length <= rf->rf_size)
+  if (rm->rm_xipbase && map->offset >= 0 && map->offset < rf->rf_size &&
+      map->length != 0 && map->offset + map->length <= rf->rf_size)
     {
       map->vaddr = rm->rm_xipbase + rf->rf_startoffset + map->offset;
       ret = OK;

--- a/fs/romfs/fs_romfs.c
+++ b/fs/romfs/fs_romfs.c
@@ -121,8 +121,8 @@ const struct mountpt_operations romfs_operations =
   NULL,            /* write */
   romfs_seek,      /* seek */
   romfs_ioctl,     /* ioctl */
-  NULL,            /* truncate */
   romfs_mmap,      /* mmap */
+  NULL,            /* truncate */
 
   NULL,            /* sync */
   romfs_dup,       /* dup */

--- a/fs/rpmsgfs/rpmsgfs.c
+++ b/fs/rpmsgfs/rpmsgfs.c
@@ -109,7 +109,7 @@ static int     rpmsgfs_fstat(FAR const struct file *filep,
                              FAR struct stat *buf);
 static int     rpmsgfs_fchstat(FAR const struct file *filep,
                                FAR const struct stat *buf, int flags);
-static int     rpmsgfs_ftruncate(FAR struct file *filep,
+static int     rpmsgfs_truncate(FAR struct file *filep,
                                  off_t length);
 
 static int     rpmsgfs_opendir(FAR struct inode *mountpt,
@@ -162,7 +162,7 @@ const struct mountpt_operations rpmsgfs_operations =
   rpmsgfs_seek,          /* seek */
   rpmsgfs_ioctl,         /* ioctl */
   NULL,                  /* mmap */
-  rpmsgfs_ftruncate,     /* ftruncate */
+  rpmsgfs_truncate,      /* truncate */
 
   rpmsgfs_sync,          /* sync */
   rpmsgfs_dup,           /* dup */
@@ -804,7 +804,7 @@ static int rpmsgfs_fchstat(FAR const struct file *filep,
 }
 
 /****************************************************************************
- * Name: rpmsgfs_ftruncate
+ * Name: rpmsgfs_truncate
  *
  * Description:
  *   Set the length of the open, regular file associated with the file
@@ -812,7 +812,7 @@ static int rpmsgfs_fchstat(FAR const struct file *filep,
  *
  ****************************************************************************/
 
-static int rpmsgfs_ftruncate(FAR struct file *filep, off_t length)
+static int rpmsgfs_truncate(FAR struct file *filep, off_t length)
 {
   FAR struct inode *inode;
   FAR struct rpmsgfs_mountpt_s *fs;

--- a/fs/rpmsgfs/rpmsgfs.c
+++ b/fs/rpmsgfs/rpmsgfs.c
@@ -161,8 +161,8 @@ const struct mountpt_operations rpmsgfs_operations =
   rpmsgfs_write,         /* write */
   rpmsgfs_seek,          /* seek */
   rpmsgfs_ioctl,         /* ioctl */
-  rpmsgfs_ftruncate,     /* ftruncate */
   NULL,                  /* mmap */
+  rpmsgfs_ftruncate,     /* ftruncate */
 
   rpmsgfs_sync,          /* sync */
   rpmsgfs_dup,           /* dup */

--- a/fs/smartfs/smartfs_smart.c
+++ b/fs/smartfs/smartfs_smart.c
@@ -140,8 +140,8 @@ const struct mountpt_operations smartfs_operations =
   smartfs_write,         /* write */
   smartfs_seek,          /* seek */
   smartfs_ioctl,         /* ioctl */
-  smartfs_truncate,      /* truncate */
   NULL,                  /* mmap */
+  smartfs_truncate,      /* truncate */
 
   smartfs_sync,          /* sync */
   smartfs_dup,           /* dup */

--- a/fs/socket/socket.c
+++ b/fs/socket/socket.c
@@ -64,8 +64,8 @@ static const struct file_operations g_sock_fileops =
   sock_file_write,  /* write */
   NULL,             /* seek */
   sock_file_ioctl,  /* ioctl */
-  NULL,             /* truncate */
   NULL,             /* mmap */
+  NULL,             /* truncate */
   sock_file_poll    /* poll */
 };
 

--- a/fs/spiffs/src/spiffs_vfs.c
+++ b/fs/spiffs/src/spiffs_vfs.c
@@ -141,8 +141,8 @@ const struct mountpt_operations spiffs_operations =
   spiffs_write,      /* write */
   spiffs_seek,       /* seek */
   spiffs_ioctl,      /* ioctl */
-  spiffs_truncate,   /* truncate */
   NULL,              /* mmap */
+  spiffs_truncate,   /* truncate */
 
   spiffs_sync,       /* sync */
   spiffs_dup,        /* dup */

--- a/fs/tmpfs/fs_tmpfs.c
+++ b/fs/tmpfs/fs_tmpfs.c
@@ -178,8 +178,8 @@ const struct mountpt_operations tmpfs_operations =
   tmpfs_write,      /* write */
   tmpfs_seek,       /* seek */
   NULL,             /* ioctl */
-  tmpfs_truncate,   /* truncate */
   tmpfs_mmap,       /* mmap */
+  tmpfs_truncate,   /* truncate */
 
   tmpfs_sync,       /* sync */
   tmpfs_dup,        /* dup */

--- a/fs/tmpfs/fs_tmpfs.c
+++ b/fs/tmpfs/fs_tmpfs.c
@@ -1655,7 +1655,8 @@ static int tmpfs_mmap(FAR struct file *filep, FAR struct mm_map_entry_s *map)
 
   DEBUGASSERT(tfo != NULL);
 
-  if (map && map->offset + map->length <= tfo->tfo_size)
+  if (map->offset >= 0 && map->offset < tfo->tfo_size &&
+      map->length && map->offset + map->length <= tfo->tfo_size)
     {
       map->vaddr = tfo->tfo_data + map->offset;
       ret = OK;

--- a/fs/unionfs/fs_unionfs.c
+++ b/fs/unionfs/fs_unionfs.c
@@ -222,8 +222,8 @@ const struct mountpt_operations unionfs_operations =
   unionfs_write,       /* write */
   unionfs_seek,        /* seek */
   unionfs_ioctl,       /* ioctl */
-  unionfs_truncate,    /* truncate */
   NULL,                /* mmap */
+  unionfs_truncate,    /* truncate */
 
   unionfs_sync,        /* sync */
   unionfs_dup,         /* dup */

--- a/fs/userfs/fs_userfs.c
+++ b/fs/userfs/fs_userfs.c
@@ -160,8 +160,8 @@ const struct mountpt_operations userfs_operations =
   userfs_write,      /* write */
   userfs_seek,       /* seek */
   userfs_ioctl,      /* ioctl */
-  userfs_truncate,   /* truncate */
   NULL,              /* mmap */
+  userfs_truncate,   /* truncate */
 
   userfs_sync,       /* sync */
   userfs_dup,        /* dup */

--- a/fs/vfs/fs_epoll.c
+++ b/fs/vfs/fs_epoll.c
@@ -104,8 +104,8 @@ static const struct file_operations g_epoll_ops =
   NULL,             /* write */
   NULL,             /* seek */
   NULL,             /* ioctl */
-  NULL,             /* truncate */
   NULL,             /* mmap */
+  NULL,             /* truncate */
   epoll_do_poll     /* poll */
 };
 

--- a/fs/vfs/fs_eventfd.c
+++ b/fs/vfs/fs_eventfd.c
@@ -100,8 +100,8 @@ static const struct file_operations g_eventfd_fops =
   eventfd_do_write, /* write */
   NULL,             /* seek */
   NULL,             /* ioctl */
-  NULL,             /* truncate */
   NULL,             /* mmap */
+  NULL,             /* truncate */
 #ifdef CONFIG_EVENT_FD_POLL
   eventfd_do_poll   /* poll */
 #endif

--- a/fs/vfs/fs_signalfd.c
+++ b/fs/vfs/fs_signalfd.c
@@ -79,8 +79,8 @@ static const struct file_operations g_signalfd_fileops =
   NULL,                 /* write */
   NULL,                 /* seek */
   NULL,                 /* ioctl */
-  NULL,                 /* truncate */
   NULL,                 /* mmap */
+  NULL,                 /* truncate */
   signalfd_file_poll    /* poll */
 };
 

--- a/graphics/nxterm/nxterm_driver.c
+++ b/graphics/nxterm/nxterm_driver.c
@@ -66,8 +66,8 @@ const struct file_operations g_nxterm_drvrops =
   nxterm_write,   /* write */
   NULL,           /* seek */
   nxterm_ioctl,   /* ioctl */
-  NULL,           /* truncate */
   NULL,           /* mmap */
+  NULL,           /* truncate */
   nxterm_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , nxterm_unlink /* unlink */
@@ -84,8 +84,8 @@ const struct file_operations g_nxterm_drvrops =
   nxterm_write,   /* write */
   NULL,           /* seek */
   nxterm_ioctl,   /* ioctl */
-  NULL,           /* truncate */
   NULL,           /* mmap */
+  NULL,           /* truncate */
   NULL            /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , nxterm_unlink /* unlink */

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -213,8 +213,8 @@ struct file_operations
                    size_t buflen);
   off_t   (*seek)(FAR struct file *filep, off_t offset, int whence);
   int     (*ioctl)(FAR struct file *filep, int cmd, unsigned long arg);
-  int     (*truncate)(FAR struct file *filep, off_t length);
   int     (*mmap)(FAR struct file *filep, FAR struct mm_map_entry_s *map);
+  int     (*truncate)(FAR struct file *filep, off_t length);
 
   /* The two structures need not be common after this point */
 
@@ -301,8 +301,8 @@ struct mountpt_operations
             size_t buflen);
   off_t   (*seek)(FAR struct file *filep, off_t offset, int whence);
   int     (*ioctl)(FAR struct file *filep, int cmd, unsigned long arg);
-  int     (*truncate)(FAR struct file *filep, off_t length);
   int     (*mmap)(FAR struct file *filep, FAR struct mm_map_entry_s *map);
+  int     (*truncate)(FAR struct file *filep, off_t length);
 
   /* The two structures need not be common after this point. The following
    * are extended methods needed to deal with the unique needs of mounted


### PR DESCRIPTION
## Summary
since mmap may exist in block_operations, but truncate may not, moving mmap beforee truncate could make three struct more compatible.

Fix the issue found in: https://github.com/apache/nuttx/pull/8000

## Impact
Minor

## Testing
Pass CI
