### PR TITLE
net/tcp: Do not trigger retransmission if the new data has not been consumed.

### DIFF
--- a/net/tcp/tcp_send_buffered.c
+++ b/net/tcp/tcp_send_buffered.c
@@ -804,7 +804,8 @@ static uint16_t psock_send_eventhandler(FAR struct net_driver_s *dev,
    */
 
   if ((conn->tcpstateflags & TCP_ESTABLISHED) &&
-      (flags & (TCP_POLL | TCP_REXMIT)) &&
+      ((flags & TCP_NEWDATA) == 0) &&
+      (flags & (TCP_POLL | TCP_REXMIT | TCP_ACKDATA)) &&
       !(sq_empty(&conn->write_q)) &&
       conn->snd_wnd > 0)
     {


### PR DESCRIPTION
## Summary

net/tcp: Do not trigger retransmission if the new data has not been consumed.

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

iperf test