### PR TITLE
fix: sensor: new member into ECG sensor type

### DIFF
--- a/include/nuttx/sensors/sensor.h
+++ b/include/nuttx/sensors/sensor.h
@@ -506,6 +506,7 @@ struct sensor_ecg           /* Type: ECG */
 {
   uint64_t timestamp;       /* Unit is microseconds */
   float ecg;                /* Unit is μV */
+  uint32_t status;          /* Status info */
 };
 
 struct sensor_ppgd          /* Type: PPGD */


### PR DESCRIPTION
## Summary

ECG sensors usually output some status info besides ECG data, such as lead and fast-recovery status. Thus a new member "status" is added into sensor_ecg struct.

Signed-off-by: liucheng5 <liucheng5@xiaomi.com>

## Impact

No impact on current ones who use struct sensor_ecg. A new member is added while the existing members are not changed.

## Testing
