### PR TITLE
Add mm map

### DIFF
--- a/fs/mmap/Kconfig
+++ b/fs/mmap/Kconfig
@@ -23,5 +23,8 @@ config FS_RAMMAP
 
 		See nuttx/fs/mmap/README.txt for additional information.
 
-if FS_RAMMAP
-endif
+config FS_ANONMAP
+	bool "Anonymous mapping emulation"
+	default y
+	---help---
+		Simulate private anonymous mappings by plain malloc

--- a/fs/mmap/Make.defs
+++ b/fs/mmap/Make.defs
@@ -24,6 +24,10 @@ ifeq ($(CONFIG_FS_RAMMAP),y)
 CSRCS += fs_rammap.c
 endif
 
+ifeq ($(CONFIG_FS_ANONMAP),y)
+CSRCS += fs_anonmap.c
+endif
+
 # Include MMAP build support
 
 DEPPATH += --dep-path mmap

--- a/fs/mmap/fs_anonmap.c
+++ b/fs/mmap/fs_anonmap.c
@@ -1,0 +1,114 @@
+/****************************************************************************
+ * fs/mmap/fs_anonmap.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/kmalloc.h>
+#include <debug.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: unmap_anonymous
+ ****************************************************************************/
+
+static int unmap_anonymous(FAR struct task_group_s *group,
+                           FAR struct mm_map_entry_s *entry,
+                           FAR void *start,
+                           size_t length)
+{
+  int ret;
+
+  /* De-allocate memory.
+   * NB: This is incomplete anounymous mapping implementation
+   * see file_mmap_ below
+   */
+
+  if (start == entry->vaddr && length == entry->length)
+    {
+      /* entry->priv marks allocation from kernel heap */
+
+      if (entry->priv.i)
+        {
+          kmm_free(start);
+        }
+      else
+        {
+          kumm_free(start);
+        }
+
+      ret = mm_map_remove(get_group_mm(group), entry);
+    }
+  else
+    {
+      ret = -EINVAL;
+      ferr("ERROR: Unknown map type\n");
+    }
+
+  return ret;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int map_anonymous(FAR struct mm_map_entry_s *entry, bool kernel)
+{
+  int ret;
+
+  /* REVISIT:  Should reside outside of the heap.  That is really the
+   * only purpose of MAP_ANONYMOUS:  To get non-heap memory.  In KERNEL
+   * build, this could be accomplished using pgalloc(), provided that
+   * you had logic in place to assign a virtual address to the mapping.
+   */
+
+  entry->vaddr = kernel ?
+    kmm_zalloc(entry->length) : kumm_zalloc(entry->length);
+  if (entry->vaddr == NULL)
+    {
+      ferr("ERROR: kumm_alloc() failed, enable DEBUG_MM for info!\n");
+      return -ENOMEM;
+    }
+
+  entry->munmap = unmap_anonymous;
+  entry->priv.i = kernel;
+
+  ret = mm_map_add(entry);
+  if (ret < 0)
+    {
+      if (kernel)
+        {
+          kmm_free(entry->vaddr);
+        }
+      else
+        {
+          kumm_free(entry->vaddr);
+        }
+
+      entry->vaddr = NULL;
+    }
+
+  return ret;
+}

--- a/fs/mmap/fs_anonmap.h
+++ b/fs/mmap/fs_anonmap.h
@@ -1,0 +1,61 @@
+/****************************************************************************
+ * fs/mmap/fs_anonmap.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __FS_MMAP_FS_ANONMAP_H
+#define __FS_MMAP_FS_ANONMAP_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <sys/types.h>
+#include <nuttx/mm/map.h>
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: map_anonymous
+ *
+ * Description:
+ *   Support simulation of private anonymous mapping by allocating memory
+ *   from heap
+ *
+ * Input Parameters:
+ *   map     Input struct containing user request
+ *   kernel  kmm_zalloc or kumm_zalloc
+ *
+ * Returned Value:
+ *   On success returns 0. Otherwise negated errno is returned appropriately.
+ *
+ *     ENOMEM
+ *       Insufficient memory is available to simulate mapping
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_FS_ANONMAP
+int map_anonymous(FAR struct mm_map_entry_s *entry, bool kernel);
+#else
+#define map_anonymous(entry,kernel) (-ENOSYS)
+#endif /* CONFIG_FS_ANONMAP */
+
+#endif /* __FS_MMAP_FS_ANONMAP_H */

--- a/fs/mmap/fs_mmap.c
+++ b/fs/mmap/fs_mmap.c
@@ -135,7 +135,7 @@ static int file_mmap_(FAR struct file *filep, FAR void *start,
        * do much better in the KERNEL build using the MMU.
        */
 
-      return rammap(filep, length, offset, kernel, mapped);
+      return rammap(filep, &entry, kernel);
 #endif
     }
 
@@ -162,7 +162,7 @@ static int file_mmap_(FAR struct file *filep, FAR void *start,
        * do much better in the KERNEL build using the MMU.
        */
 
-      return rammap(filep, length, offset, kernel, mapped);
+      return rammap(filep, &entry, kernel);
 #else
       ferr("ERROR: mmap not supported \n");
       return -ENOSYS;

--- a/fs/mmap/fs_munmap.c
+++ b/fs/mmap/fs_munmap.c
@@ -44,122 +44,6 @@
 
 static int file_munmap_(FAR void *start, size_t length, bool kernel)
 {
-#ifdef CONFIG_FS_RAMMAP
-  FAR struct fs_rammap_s *prev;
-  FAR struct fs_rammap_s *curr;
-  FAR void *newaddr;
-  unsigned int offset;
-  int ret;
-
-  /* Find a region containing this start and length in the list of regions */
-
-  ret = nxmutex_lock(&g_rammaps.lock);
-  if (ret < 0)
-    {
-      return ret;
-    }
-
-  /* Search the list of regions */
-
-  for (prev = NULL, curr = g_rammaps.head; curr;
-       prev = curr, curr = curr->flink)
-    {
-      /* Does this region include any part of the specified range? */
-
-      if ((uintptr_t)start < (uintptr_t)curr->addr + curr->length &&
-          (uintptr_t)start + length >= (uintptr_t)curr->addr)
-        {
-          break;
-        }
-    }
-
-  /* Did we find the region */
-
-  if (!curr)
-    {
-      ferr("ERROR: Region not found\n");
-      ret = -EINVAL;
-      goto errout_with_lock;
-    }
-
-  /* Get the offset from the beginning of the region and the actual number
-   * of bytes to "unmap".  All mappings must extend to the end of the region.
-   * There is no support for free a block of memory but leaving a block of
-   * memory at the end.  This is a consequence of using kumm_realloc() to
-   * simulate the unmapping.
-   */
-
-  offset = start - curr->addr;
-  if (offset + length < curr->length)
-    {
-      ferr("ERROR: Cannot umap without unmapping to the end\n");
-      ret = -ENOSYS;
-      goto errout_with_lock;
-    }
-
-  /* Okay.. the region is beging umapped to the end.  Make sure the length
-   * indicates that.
-   */
-
-  length = curr->length - offset;
-
-  /* Are we unmapping the entire region (offset == 0)? */
-
-  if (length >= curr->length)
-    {
-      /* Yes.. remove the mapping from the list */
-
-      if (prev)
-        {
-          prev->flink = curr->flink;
-        }
-      else
-        {
-          g_rammaps.head = curr->flink;
-        }
-
-      /* Then free the region */
-
-      if (kernel)
-        {
-          kmm_free(curr);
-        }
-      else
-        {
-          kumm_free(curr);
-        }
-    }
-
-  /* No.. We have been asked to "unmap' only a portion of the memory
-   * (offset > 0).
-   */
-
-  else
-    {
-      if (kernel)
-        {
-          newaddr = kmm_realloc(curr->addr,
-                               sizeof(struct fs_rammap_s) + length);
-        }
-      else
-        {
-          newaddr = kumm_realloc(curr->addr,
-                                sizeof(struct fs_rammap_s) + length);
-        }
-
-      DEBUGASSERT(newaddr == (FAR void *)(curr->addr));
-      UNUSED(newaddr); /* May not be used */
-      curr->length = length;
-    }
-
-  nxmutex_unlock(&g_rammaps.lock);
-  return OK;
-
-errout_with_lock:
-  nxmutex_unlock(&g_rammaps.lock);
-  return ret;
-#else
-
   FAR struct tcb_s *tcb = nxsched_self();
   FAR struct task_group_s *group = tcb->group;
   FAR struct mm_map_entry_s *entry = NULL;
@@ -185,7 +69,6 @@ errout_with_lock:
     }
 
   return ret;
-#endif /* CONFIG_FS_RAMMAP */
 }
 
 /****************************************************************************

--- a/fs/mmap/fs_rammap.c
+++ b/fs/mmap/fs_rammap.c
@@ -23,9 +23,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
-
 #include <sys/types.h>
-#include <sys/mman.h>
 
 #include <string.h>
 #include <unistd.h>
@@ -35,7 +33,6 @@
 #include <nuttx/fs/fs.h>
 #include <nuttx/kmalloc.h>
 
-#include "inode/inode.h"
 #include "fs_rammap.h"
 
 #ifdef CONFIG_FS_RAMMAP
@@ -44,12 +41,83 @@
  * Public Data
  ****************************************************************************/
 
-/* This is the list of all mapped files */
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
 
-struct fs_allmaps_s g_rammaps =
+static int unmap_rammap(FAR struct task_group_s *group,
+                        FAR struct mm_map_entry_s *entry,
+                        FAR void *start,
+                        size_t length)
 {
-  NXMUTEX_INITIALIZER
-};
+  FAR void *newaddr;
+  unsigned int offset;
+  bool kernel = entry->priv.i != 0 ? true : false;
+  int ret;
+
+  /* Get the offset from the beginning of the region and the actual number
+   * of bytes to "unmap".  All mappings must extend to the end of the region.
+   * There is no support for freeing a block of memory but leaving a block of
+   * memory at the end.  This is a consequence of using kumm_realloc() to
+   * simulate the unmapping.
+   */
+
+  offset = start - entry->vaddr;
+  if (offset + length < entry->length)
+    {
+      ferr("ERROR: Cannot umap without unmapping to the end\n");
+      return -ENOSYS;
+    }
+
+  /* Okay.. the region is being unmapped to the end.  Make sure the length
+   * indicates that.
+   */
+
+  length = entry->length - offset;
+
+  /* Are we unmapping the entire region (offset == 0)? */
+
+  if (length >= entry->length)
+    {
+      /* Free the region */
+
+      if (kernel)
+        {
+          kmm_free(entry->vaddr);
+        }
+      else
+        {
+          kumm_free(entry->vaddr);
+        }
+
+      /* Then remove the mapping from the list */
+
+      ret = mm_map_remove(get_group_mm(group), entry);
+    }
+
+  /* No.. We have been asked to "unmap' only a portion of the memory
+   * (offset > 0).
+   */
+
+  else
+    {
+      if (kernel)
+        {
+          newaddr = kmm_realloc(entry->vaddr, length);
+        }
+      else
+        {
+          newaddr = kumm_realloc(entry->vaddr, length);
+        }
+
+      DEBUGASSERT(newaddr == entry->vaddr);
+      UNUSED(newaddr); /* May not be used */
+      entry->length = length;
+      ret = OK;
+    }
+
+  return ret;
+}
 
 /****************************************************************************
  * Public Functions
@@ -81,15 +149,14 @@ struct fs_allmaps_s g_rammaps =
  *
  ****************************************************************************/
 
-int rammap(FAR struct file *filep, size_t length,
-           off_t offset, bool kernel, FAR void **mapped)
+int rammap(FAR struct file *filep, FAR struct mm_map_entry_s *entry,
+           bool kernel)
 {
-  FAR struct fs_rammap_s *map;
-  FAR uint8_t *alloc;
   FAR uint8_t *rdbuffer;
   ssize_t nread;
   off_t fpos;
   int ret;
+  size_t length = entry->length;
 
   /* There is a major design flaw that I have not yet thought of fix for:
    * The goal is to have a single region of memory that represents a single
@@ -106,40 +173,29 @@ int rammap(FAR struct file *filep, size_t length,
 
   /* Allocate a region of memory of the specified size */
 
-  alloc = kernel ?
-    kmm_malloc(sizeof(struct fs_rammap_s) + length) :
-    kumm_malloc(sizeof(struct fs_rammap_s) + length);
-  if (!alloc)
+  rdbuffer = kernel ? kmm_malloc(length) : kumm_malloc(length);
+  if (!rdbuffer)
     {
       ferr("ERROR: Region allocation failed, length: %d\n", (int)length);
       return -ENOMEM;
     }
 
-  /* Initialize the region */
-
-  map         = (FAR struct fs_rammap_s *)alloc;
-  memset(map, 0, sizeof(struct fs_rammap_s));
-  map->addr   = alloc + sizeof(struct fs_rammap_s);
-  map->length = length;
-  map->offset = offset;
-
   /* Seek to the specified file offset */
 
-  fpos = file_seek(filep, offset, SEEK_SET);
+  fpos = file_seek(filep, entry->offset, SEEK_SET);
   if (fpos < 0)
     {
       /* Seek failed... errno has already been set, but EINVAL is probably
        * the correct response.
        */
 
-      ferr("ERROR: Seek to position %d failed\n", (int)offset);
+      ferr("ERROR: Seek to position %d failed\n", (int)entry->offset);
       ret = fpos;
       goto errout_with_region;
     }
 
   /* Read the file data into the memory region */
 
-  rdbuffer = map->addr;
   while (length > 0)
     {
       nread = file_read(filep, rdbuffer, length);
@@ -154,7 +210,7 @@ int rammap(FAR struct file *filep, size_t length,
               /* All other read errors are bad. */
 
               ferr("ERROR: Read failed: offset=%d ret=%d\n",
-                   (int)offset, (int)nread);
+                   (int)entry->offset, (int)nread);
 
               ret = nread;
               goto errout_with_region;
@@ -180,27 +236,26 @@ int rammap(FAR struct file *filep, size_t length,
 
   /* Add the buffer to the list of regions */
 
-  ret = nxmutex_lock(&g_rammaps.lock);
+  entry->vaddr = rdbuffer;
+  entry->priv.i = kernel ? 1 : 0;
+  entry->munmap = unmap_rammap;
+
+  ret = mm_map_add(entry);
   if (ret < 0)
     {
       goto errout_with_region;
     }
 
-  map->flink = g_rammaps.head;
-  g_rammaps.head = map;
-
-  nxmutex_unlock(&g_rammaps.lock);
-  *mapped = map->addr;
   return OK;
 
 errout_with_region:
   if (kernel)
     {
-      kmm_free(alloc);
+      kmm_free(rdbuffer);
     }
   else
     {
-      kumm_free(alloc);
+      kumm_free(rdbuffer);
     }
 
   return ret;

--- a/fs/mmap/fs_rammap.h
+++ b/fs/mmap/fs_rammap.h
@@ -18,25 +18,7 @@
  *
  ****************************************************************************/
 
-#ifndef __FS_MMAP_FS_RAMMAP_H
-#define __FS_MMAP_FS_RAMMAP_H
-
-/****************************************************************************
- * Included Files
- ****************************************************************************/
-
-#include <nuttx/config.h>
-
-#include <sys/types.h>
-#include <nuttx/mutex.h>
-
-#ifdef CONFIG_FS_RAMMAP
-
-/****************************************************************************
- * Public Types
- ****************************************************************************/
-
-/* This structure describes one file that has been copied to memory and
+/* This driver manages files that have been copied to memory and
  * managed as a share-able "memory mapped" file.  This functionality is
  * intended to provide a substitute for memory mapped files for architectures
  * that do not have MMUs and, hence, cannot support on demand paging of
@@ -53,29 +35,27 @@
  * - There are not access privileges.
  */
 
-struct fs_rammap_s
-{
-  struct fs_rammap_s *flink;       /* Implements a singly linked list */
-  FAR void           *addr;        /* Start of allocated memory */
-  size_t              length;      /* Length of region */
-  off_t               offset;      /* File offset */
-};
+#ifndef __FS_MMAP_FS_RAMMAP_H
+#define __FS_MMAP_FS_RAMMAP_H
 
-/* This structure defines all "mapped" files */
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
 
-struct fs_allmaps_s
-{
-  mutex_t             lock;        /* Provides exclusive access the list */
-  struct fs_rammap_s *head;        /* List of mapped files */
-};
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <nuttx/mm/map.h>
+
+#ifdef CONFIG_FS_RAMMAP
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
 
 /****************************************************************************
  * Public Data
  ****************************************************************************/
-
-/* This is the list of all mapped files */
-
-extern struct fs_allmaps_s g_rammaps;
 
 /****************************************************************************
  * Public Function Prototypes
@@ -107,8 +87,8 @@ extern struct fs_allmaps_s g_rammaps;
  *
  ****************************************************************************/
 
-int rammap(FAR struct file *filep, size_t length,
-           off_t offset, bool kernel, FAR void **mapped);
+int rammap(FAR struct file *filep, FAR struct mm_map_entry_s *entry,
+           bool kernel);
 
 #endif /* CONFIG_FS_RAMMAP */
 #endif /* __FS_MMAP_FS_RAMMAP_H */

--- a/include/nuttx/mm/map.h
+++ b/include/nuttx/mm/map.h
@@ -44,7 +44,7 @@ struct task_group_s;
 struct mm_map_entry_s
 {
   FAR struct mm_map_entry *flink;  /* this is used as sq_entry_t */
-  FAR const void *vaddr;
+  FAR void *vaddr;
   size_t length;
   off_t offset;
   int prot;
@@ -63,7 +63,7 @@ struct mm_map_entry_s
    */
 
   int (*munmap)(FAR struct task_group_s *group,
-                FAR struct mm_map_entry_s *map,
+                FAR struct mm_map_entry_s *entry,
                 FAR void *start,
                 size_t length);
 };
@@ -73,11 +73,159 @@ struct mm_map_entry_s
 struct mm_map_s
 {
   sq_queue_t mm_map_sq;
-  mutex_t mm_map_mutex;
+  rmutex_t mm_map_mutex;
 };
 
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
 
-#endif /* __INCLUDE_NUTTX_MM_MM_MAP_H */
+/****************************************************************************
+ * Name: mm_map_lock
+ *
+ * Description:
+ *   Get exclusive access current task_group's mm_map
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   OK on success
+ *   A negated errno value on failure
+ *
+ ****************************************************************************/
+
+int mm_map_lock(void);
+
+/****************************************************************************
+ * Name: mm_map_unlock
+ *
+ * Description:
+ *   Relinquish exclusive access to current task_group's mm_map
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void mm_map_unlock(void);
+
+/****************************************************************************
+ * Name: mm_map_initialize
+ *
+ * Description:
+ *   Initialization function, called only by group_initialize
+ *
+ * Input Parameters:
+ *   mm - Pointer to the mm_map structure to be initialized
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void mm_map_initialize(FAR struct mm_map_s *mm);
+
+/****************************************************************************
+ * Name: mm_map_destroy
+ *
+ * Description:
+ *   Uninitialization function, called only by group_release
+ *
+ * Input Parameters:
+ *   mm - Pointer to the mm_map structure to be initialized
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void mm_map_destroy(FAR struct mm_map_s *mm);
+
+/****************************************************************************
+ * Name: mm_map_add
+ *
+ * Description:
+ *   Adds a virtual memory area into the list of mappings
+ *
+ * Input Parameters:
+ *   entry - A pointer to mm_map_entry_s, mapping info to be added
+ *
+ * Returned Value:
+ *   OK        Added successfully
+ *   -EINVAL:  Invalid attempt to get the semaphore
+ *   -EINTR:   The wait was interrupted by the receipt of a signal.
+ *   -ENOMEM:  Out of memory
+ *
+ ****************************************************************************/
+
+int mm_map_add(FAR struct mm_map_entry_s *entry);
+
+/****************************************************************************
+ * Name: mm_map_next
+ *
+ * Description:
+ *   Returns the next mapping in the list, following the argument.
+ *   Can be used to iterate through all the mappings. Returns the first
+ *   mapping when the argument "entry" is NULL.
+ *
+ * Input Parameters:
+ *   entry  - Pointer to a single mapping in this task group or NULL to get
+ *            the first one
+ *
+ * Returned Value:
+ *   Pointer to the next mapping
+ *
+ ****************************************************************************/
+
+FAR struct mm_map_entry_s *mm_map_next(
+                           FAR const struct mm_map_entry_s *entry);
+
+/****************************************************************************
+ * Name: mm_map_find
+ *
+ * Description:
+ *   Find the first mapping matching address and length
+ *
+ * Input Parameters:
+ *   vaddr   - Start address of the mapped area
+ *   length  - Length of the mapping
+ *
+ * Returned Value:
+ *   Pointer to the mapping, NULL if not found
+ *
+ ****************************************************************************/
+
+FAR struct mm_map_entry_s *mm_map_find(FAR const void *vaddr,
+                                       size_t length);
+
+/****************************************************************************
+ * Name: mm_map_remove
+ *
+ * Description:
+ *   Removes a virtual memory area from the list of mappings
+ *   Sets the given pointer argument to NULL after successful removal
+ *
+ * Input Parameters:
+ *   mm      - Pointer to the list of entries, from which the entry is
+ *             removed. If passed mm is NULL, the function doesn't do
+ *             anything, but just returns OK.
+ *
+ *   entry   - Pointer to the entry to be removed. If the passed entry is
+ *             NULL the function doesn't do anything but just returns OK
+ *
+ * Returned Value:
+ *   OK:       Removed successfully
+ *   -EINVAL:  Invalid attempt to get the semaphore
+ *   -EINTR:   The wait was interrupted by the receipt of a signal.
+ *   -ENOENT:  Memory area not found
+ *
+ ****************************************************************************/
+
+int mm_map_remove(FAR struct mm_map_s *mm,
+                  FAR struct mm_map_entry_s *entry);
+
+#endif /* __INCLUDE_NUTTX_MM_MAP_H */

--- a/include/nuttx/mm/map.h
+++ b/include/nuttx/mm/map.h
@@ -49,7 +49,11 @@ struct mm_map_entry_s
   off_t offset;
   int prot;
   int flags;
-  FAR void *priv;
+  union
+  {
+    FAR void *p;
+    int i;
+  } priv;
 
   /* Drivers which register mappings may also
    * implement the unmap function to undo anything done in mmap.

--- a/include/nuttx/mm/shm.h
+++ b/include/nuttx/mm/shm.h
@@ -84,13 +84,6 @@ struct group_shm_s
    */
 
   GRAN_HANDLE gs_handle;
-
-  /* This array is used to do a reverse lookup:  Give the virtual address
-   * of a shared memory region, find the region index that performs that
-   * mapping.
-   */
-
-  uintptr_t gs_vaddr[CONFIG_ARCH_SHM_MAXREGIONS];
 };
 
 /****************************************************************************
@@ -170,6 +163,24 @@ FAR void *shm_alloc(FAR struct task_group_s *group, FAR void *vaddr,
  ****************************************************************************/
 
 void shm_free(FAR struct task_group_s *group, FAR void *vaddr, size_t size);
+
+/****************************************************************************
+ * Name: shmdt_priv
+ *
+ * Description:
+ *   This is the shmdt internal implementation of the shm driver. It takes
+ *   the task group struct as a parameter and can handle both normal detach
+ *   and cleanup during process exit.
+ *
+ * Input Parameters:
+ *   group   - A reference to the group structure from which to detach
+ *   shmaddr - Virtual start address where the allocation starts.
+ *   shmid   - Id of the allocation
+ *
+ ****************************************************************************/
+
+int shmdt_priv(FAR struct task_group_s *group, FAR const void *shmaddr,
+               int shmid);
 
 #endif /* CONFIG_MM_SHM */
 #endif /* __INCLUDE_NUTTX_MM_SHM_H */

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -43,6 +43,7 @@
 #include <nuttx/mm/shm.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/net/net.h>
+#include <nuttx/mm/map.h>
 
 #include <arch/arch.h>
 
@@ -179,6 +180,14 @@
 #  define TCB_REGS_OFF               offsetof(struct tcb_s, xcp.regs)
 #  define TCB_REG_OFF(reg)           (reg * sizeof(uint32_t))
 #endif
+
+/* Get a pointer to the process' memory map struct from the task_group */
+
+#define get_group_mm(group)          (group ? &group->tg_mm_map : NULL)
+
+/* Get a pointer to current the process' memory map struct */
+
+#define get_current_mm()             (get_group_mm(nxsched_self()->group))
 
 /****************************************************************************
  * Public Type Definitions
@@ -506,6 +515,10 @@ struct task_group_s
 
   struct group_shm_s tg_shm;        /* Task shared memory logic             */
 #endif
+
+  /* Virtual memory mapping info ********************************************/
+
+  struct mm_map_s tg_mm_map;    /* Task mmappings */
 };
 
 /* struct tcb_s *************************************************************/

--- a/mm/Makefile
+++ b/mm/Makefile
@@ -32,6 +32,7 @@ include circbuf/Make.defs
 include mempool/Make.defs
 include kasan/Make.defs
 include ubsan/Make.defs
+include map/Make.defs
 
 BINDIR ?= bin
 

--- a/mm/map/Make.defs
+++ b/mm/map/Make.defs
@@ -1,0 +1,28 @@
+############################################################################
+# mm/map/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+# Virtual memory map list support
+
+CSRCS += mm_map.c
+
+# Add the shared memory directory to the build
+
+DEPPATH += --dep-path map
+VPATH += :map

--- a/mm/map/mm_map.c
+++ b/mm/map/mm_map.c
@@ -1,0 +1,315 @@
+/****************************************************************************
+ * mm/map/mm_map.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/mm/map.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <nuttx/sched.h>
+#include <nuttx/kmalloc.h>
+#include <assert.h>
+#include <debug.h>
+
+#if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static bool in_range(FAR const void *start, size_t length,
+                     FAR const void *range_start, size_t range_length)
+{
+  FAR const char *u_start = (FAR const char *)start;
+  FAR const char *u_end = u_start + length;
+  FAR const char *r_start = (FAR const char *)range_start;
+  FAR const char *r_end = r_start + range_length;
+
+  return (u_start >= r_start && u_start < r_end && /* Start is in range. */
+          u_end >= r_start && u_end <= r_end);     /* End is in range. */
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: mm_map_lock
+ *
+ * Description:
+ *   Get exclusive access to task_group's mm_map
+ *
+ ****************************************************************************/
+
+int mm_map_lock(void)
+{
+  return nxrmutex_lock(&get_current_mm()->mm_map_mutex);
+}
+
+/****************************************************************************
+ * Name: mm_map_unlock
+ *
+ * Description:
+ *   Relinquish exclusive access to task_group's mm_map
+ *
+ ****************************************************************************/
+
+void mm_map_unlock(void)
+{
+  DEBUGVERIFY(nxrmutex_unlock(&get_current_mm()->mm_map_mutex));
+}
+
+/****************************************************************************
+ * Name: mm_map_initialize
+ *
+ * Description:
+ *   Allocates a task group specific mm_map stucture. Called when the group
+ *   is initialized
+ *
+ ****************************************************************************/
+
+void mm_map_initialize(FAR struct mm_map_s *mm)
+{
+  sq_init(&mm->mm_map_sq);
+  nxrmutex_init(&mm->mm_map_mutex);
+}
+
+/****************************************************************************
+ * Name: mm_map_destroy
+ *
+ * Description:
+ *   De-allocates a task group specific mm_map stucture and the mm_map_mutex
+ *
+ ****************************************************************************/
+
+void mm_map_destroy(FAR struct mm_map_s *mm)
+{
+  FAR struct mm_map_entry_s *entry;
+
+  while ((entry = (FAR struct mm_map_entry_s *)sq_remfirst(&mm->mm_map_sq)))
+    {
+      /* Pass null as group argument to indicate that actual MMU mappings
+       * must not be touched. The process is being deleted and we don't
+       * know in which context we are. Only kernel memory allocations
+       * need to be freed by drivers
+       */
+
+      /* Unmap the whole region */
+
+      if (entry->munmap)
+        {
+          if (entry->munmap(NULL, entry, entry->vaddr, entry->length) < 0)
+            {
+              /* This would be an error in the driver. It has defined munmap,
+               * but is not able to munmap the full area which it has mapped
+               */
+
+              merr("Driver munmap failed\n");
+            }
+        }
+
+      kmm_free(entry);
+    }
+
+  nxrmutex_destroy(&mm->mm_map_mutex);
+}
+
+/****************************************************************************
+ * Name: mm_map_add
+ *
+ * Description:
+ *   Add a mapping to task group's mm_map list
+ *
+ ****************************************************************************/
+
+int mm_map_add(FAR struct mm_map_entry_s *entry)
+{
+  FAR struct mm_map_s *mm = get_current_mm();
+  FAR struct mm_map_entry_s *new_entry;
+  int ret;
+
+  if (!entry)
+    {
+      return -EINVAL;
+    }
+
+  /* Copy the provided mapping and add to the list */
+
+  new_entry = kmm_malloc(sizeof(struct mm_map_entry_s));
+  if (!new_entry)
+    {
+      return -EINVAL;
+    }
+
+  *new_entry = *entry;
+
+  ret = nxrmutex_lock(&mm->mm_map_mutex);
+  if (ret < 0)
+    {
+      kmm_free(new_entry);
+      return ret;
+    }
+
+  sq_addfirst((sq_entry_t *)new_entry, &mm->mm_map_sq);
+
+  nxrmutex_unlock(&mm->mm_map_mutex);
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: mm_map_next
+ *
+ * Description:
+ *   Returns the next mapping in the list.
+ *
+ ****************************************************************************/
+
+FAR struct mm_map_entry_s *mm_map_next(
+                           FAR const struct mm_map_entry_s *entry)
+{
+  FAR struct mm_map_s *mm = get_current_mm();
+  FAR struct mm_map_entry_s *next_entry = NULL;
+
+  if (nxrmutex_lock(&mm->mm_map_mutex) == OK)
+    {
+      if (entry == NULL)
+        {
+          next_entry = (struct mm_map_entry_s *)sq_peek(&mm->mm_map_sq);
+        }
+      else
+        {
+          next_entry = (struct mm_map_entry_s *)
+            sq_next(((sq_entry_t *)entry));
+        }
+
+      nxrmutex_unlock(&mm->mm_map_mutex);
+    }
+
+  return next_entry;
+}
+
+/****************************************************************************
+ * Name: mm_map_find
+ *
+ * Description:
+ *   Find the first mapping containing the range from the task group's list
+ *
+ ****************************************************************************/
+
+FAR struct mm_map_entry_s *mm_map_find(FAR const void *vaddr, size_t length)
+{
+  FAR struct mm_map_s *mm = get_current_mm();
+  FAR struct mm_map_entry_s *found_entry = NULL;
+
+  if (nxrmutex_lock(&mm->mm_map_mutex) == OK)
+    {
+      found_entry = (struct mm_map_entry_s *)sq_peek(&mm->mm_map_sq);
+
+      while (found_entry && !in_range(vaddr, length,
+                                      found_entry->vaddr,
+                                      found_entry->length))
+        {
+          found_entry = (struct mm_map_entry_s *)
+            sq_next(((sq_entry_t *)found_entry));
+        }
+
+      nxrmutex_unlock(&mm->mm_map_mutex);
+    }
+
+  return found_entry;
+}
+
+/****************************************************************************
+ * Name: mm_map_remove
+ *
+ * Description:
+ *   Remove a mapping from the task  group's list
+ *
+ ****************************************************************************/
+
+int mm_map_remove(FAR struct mm_map_s *mm,
+                  FAR struct mm_map_entry_s *entry)
+{
+  FAR struct mm_map_entry_s *prev_entry;
+  FAR struct mm_map_entry_s *removed_entry = NULL;
+  int ret;
+
+  if (!mm || !entry)
+    {
+      return OK;
+    }
+
+  ret = nxrmutex_lock(&mm->mm_map_mutex);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  prev_entry = (struct mm_map_entry_s *)sq_peek(&mm->mm_map_sq);
+
+  /* Check if the list was empty */
+
+  if (!prev_entry)
+    {
+      nxrmutex_unlock(&mm->mm_map_mutex);
+      return -ENOENT;
+    }
+
+  /* Check if removing the first item */
+
+  if (entry == prev_entry)
+    {
+      sq_remfirst(&mm->mm_map_sq);
+      removed_entry = prev_entry;
+    }
+  else
+    {
+      /* Loop through the remaining items to find the one to be removed */
+
+      while ((removed_entry = (struct mm_map_entry_s *)
+              sq_next(((sq_entry_t *)prev_entry))))
+        {
+          if (entry == removed_entry)
+            {
+              sq_remafter((sq_entry_t *)prev_entry, &mm->mm_map_sq);
+              break;
+            }
+
+          prev_entry = removed_entry;
+        }
+    }
+
+  nxrmutex_unlock(&mm->mm_map_mutex);
+
+  /* If the item was removed, also delete the entry struct */
+
+  if (removed_entry)
+    {
+      kmm_free(removed_entry);
+      return OK;
+    }
+
+  return -ENOENT;
+}
+
+#endif /* defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__) */

--- a/sched/group/group_create.c
+++ b/sched/group/group_create.c
@@ -245,6 +245,10 @@ void group_initialize(FAR struct task_tcb_s *tcb)
   DEBUGASSERT(tcb && tcb->cmn.group);
   group = tcb->cmn.group;
 
+  /* Allocate mm_map list if required */
+
+  mm_map_initialize(&group->tg_mm_map);
+
 #ifdef HAVE_GROUP_MEMBERS
   /* Assign the PID of this new task as a member of the group. */
 

--- a/sched/group/group_leave.c
+++ b/sched/group/group_leave.c
@@ -176,6 +176,10 @@ static inline void group_release(FAR struct task_group_s *group)
   env_release(group);
 #endif
 
+  /* Destroy the mm_map list */
+
+  mm_map_destroy(&group->tg_mm_map);
+
 #if defined(CONFIG_BUILD_KERNEL) && defined(CONFIG_MM_SHM)
   /* Release any resource held by shared memory virtual page allocator */
 


### PR DESCRIPTION
## Summary

This PR adds a simple linked list to store mmap mappings, to support unmap.

The drivers which want to store mappings can use mm_map_add and mm_map_rm to register/unregister mappings to the task_group.

This PR also takes the mm_map into use in mm/shm driver and anonymous mappings. The sys-v shm interface still maintains it's own granule allocator in task_group

This PR also takes the mm_map into use in "rammap"

## Impact

Adds interface to make it possible to do munmap
Adds munmap for anonymous mappings
Fixes mm/shm for process exit; previously it doesn't free the reserved physical pages if they are mapped at process exit

## Testing

Tested in stm32 and mpfs riscv builds, together with inhouse posix shmfs driver


