### PR TITLE
net/local: rename NET_LOCAL_VFS_PATH to follow linux

### DIFF
--- a/net/local/Kconfig
+++ b/net/local/Kconfig
@@ -17,7 +17,7 @@ if NET_LOCAL
 
 config NET_LOCAL_VFS_PATH
 	string "Path prefix to Unix domain sockets"
-	default "/var/socket"
+	default "/var/run"
 	---help---
 		The path prefix to where Unix domain sockets will exist in the VFS namespace.
 

--- a/net/local/local_fifo.c
+++ b/net/local/local_fifo.c
@@ -66,6 +66,11 @@
 static void local_format_name(FAR const char *inpath, FAR char *outpath,
                               FAR const char *suffix, int32_t id)
 {
+  if (strcmp(inpath, CONFIG_NET_LOCAL_VFS_PATH) == 0)
+    {
+      inpath += strlen(CONFIG_NET_LOCAL_VFS_PATH);
+    }
+
   if (id < 0)
     {
       snprintf(outpath, LOCAL_FULLPATH_LEN - 1,


### PR DESCRIPTION


## Summary
net/local: rename NET_LOCAL_VFS_PATH to follow linux
And skip same prefix for unix path

Signed-off-by: dongjiuzhu1 <dongjiuzhu1@xiaomi.com>
## Impact
modify prefix for local socket path,
## Testing
local test.
