### PR TITLE
script: support IPv6 in simhostroute.sh

### DIFF
--- a/boards/sim/sim/sim/NETWORK-LINUX.txt
+++ b/boards/sim/sim/sim/NETWORK-LINUX.txt
@@ -59,7 +59,9 @@ On Linux:
 
 On the NuttX Simulator:
 
-    nsh> ifconfig eth0 10.0.1.2
+    nsh> # replace or omit dns if needed, IPv6 line is optional
+    nsh> ifconfig eth0 inet6 fc00::2/112 dns 2001:4860:4860::8888
+    nsh> ifconfig eth0 10.0.1.2 dns 8.8.8.8
     nsh> ifup eth0
 
 On Linux:

--- a/tools/netusb.sh
+++ b/tools/netusb.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #****************************************************************************
-# tools/simhostroute.sh
+# tools/netusb.sh
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
## Summary
1. Change IP address format to addr/prefix, to be compatible with both IPv4/IPv6.
   - When adding address in CIDR type, netmask/route will be automatically added.
2. Since route of whole subnet is added automatically, not specifying NuttX's IP any more.
   - Multiple NuttX simulators (with IP 10.0.1.x) attached to same bridge can surf the net at same time.
3. NAT66 is used to make sure it works even if host has only one IPv6 address.

## Impact
Add IPv6 & multiple nuttx sims support for simhostroute.sh

## Testing
Tested on sim.
