### PR TITLE
sim: Fix make tool doesn't rebuild dependencies of the libboard target

### DIFF
--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -254,7 +254,7 @@ RELLIBS += -lboard
 
 all: sim_head$(OBJEXT) libarch$(LIBEXT)
 
-.PHONY: export_startup clean distclean cleanrel depend
+.PHONY: export_startup clean distclean cleanrel depend board/libboard$(LIBEXT)
 
 $(AOBJS): %$(OBJEXT): %.S
 	$(call ASSEMBLE, $<, $@)


### PR DESCRIPTION
Signed-off-by: gaojiawei <gaojiawei@xiaomi.com>

## Summary

The issue here is that the `libboard` target doesn't depend on anything. Hence, make will not notice the file changes and rerun the recipe that is used to build `libboard`. The solution here is to mark this target as `PHONY` to force make execute the recipe all the time.

