### PR TITLE
fs/vfs: add missed truncate callback at timerfd file_operation

### DIFF
--- a/fs/vfs/fs_timerfd.c
+++ b/fs/vfs/fs_timerfd.c
@@ -111,6 +111,8 @@ static const struct file_operations g_timerfd_fops =
   NULL,          /* write */
   NULL,          /* seek */
   NULL,          /* ioctl */
+  NULL,          /* truncate */
+  NULL,          /* mmap */
 #ifdef CONFIG_TIMER_FD_POLL
   timerfd_poll   /* poll */
 #endif


### PR DESCRIPTION
Signed-off-by: qinwei1 <qinwei1@xiaomi.com>

## Summary
add missed truncate callback at timerfd file_operation

## Impact
None

## Testing
configure with CONFIG_TIMER_FD to compile with fs_timerfd.c
