### PR TITLE
watchdog:use 'V' to stop watchdog

### DIFF
--- a/drivers/timers/Kconfig
+++ b/drivers/timers/Kconfig
@@ -354,6 +354,12 @@ config WATCHDOG_DEVPATH
 		Please, check how your specific chip or board uses this symbol.
 		FYI: It's NOT used by the Auto-monitor feature.
 
+config CONFIG_WATCHDOG_MAGIC_V
+	bool "Watchdog Device Magic num"
+	default Y
+	---help---
+		The watchdog can be stopped by writing 'V' to the watchdog's device node
+
 menuconfig WATCHDOG_AUTOMONITOR
 	bool "Auto-monitor"
 	---help---

--- a/drivers/timers/watchdog.c
+++ b/drivers/timers/watchdog.c
@@ -414,7 +414,48 @@ static ssize_t wdog_read(FAR struct file *filep, FAR char *buffer,
 static ssize_t wdog_write(FAR struct file *filep, FAR const char *buffer,
                           size_t buflen)
 {
-  return 0;
+#ifdef CONFIG_WATCHDOG_MAGIC_V
+  FAR struct inode                *inode = filep->f_inode;
+  FAR struct watchdog_upperhalf_s *upper;
+  FAR struct watchdog_lowerhalf_s *lower;
+  int err = 0;
+  int i;
+
+  upper = inode->i_private;
+  DEBUGASSERT(upper != NULL);
+  lower = upper->lower;
+  DEBUGASSERT(lower != NULL);
+
+  nxmutex_lock(&upper->lock);
+
+  for (i = 0; i < buflen; i++)
+    {
+      if (buffer[i] == 'V')
+        {
+#ifdef CONFIG_WATCHDOG_AUTOMONITOR
+          watchdog_automonitor_stop(upper);
+#else
+          err = lower->ops->stop(lower);
+#endif
+          break;
+        }
+    }
+
+  if (i == buflen)
+    {
+      err = lower->ops->keepalive(lower);
+    }
+
+  nxmutex_unlock(&upper->lock);
+
+  if (err < 0)
+    {
+      return err;
+    }
+
+#endif
+
+  return buflen;
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
add a way to stop watchdog, follow Linux watchdog behavior:
https://www.kernel.org/doc/Documentation/watchdog/watchdog-api.txt:
Magic Close feature:

If a driver supports "Magic Close", the driver will not disable the
watchdog unless a specific magic character 'V' has been sent to
/dev/watchdog just before closing the file.  If the userspace daemon
closes the file without sending this special character, the driver
will assume that the daemon (and userspace in general) died, and will
stop pinging the watchdog without disabling it first.  This will then
cause a reboot if the watchdog is not re-opened in sufficient time.

## Impact
watchdog driver

## Testing
vela
