### PR TITLE
assert:add a last type to call notifier

### DIFF
--- a/include/nuttx/panic_notifier.h
+++ b/include/nuttx/panic_notifier.h
@@ -38,6 +38,7 @@ enum panic_type_e
 {
   PANIC_KERNEL         =  0,
   PANIC_TASK           =  1,
+  PANIC_KERNEL_FINAL   =  2,
 };
 
 /****************************************************************************

--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -455,7 +455,7 @@ void _assert(FAR const char *filename, int linenum)
   fatal = true;
 #endif
 
-  panic_notifier_call_chain(fatal ? PANIC_KERNEL : PANIC_TASK, NULL);
+  panic_notifier_call_chain(fatal ? PANIC_KERNEL : PANIC_TASK, rtcb);
 
 #ifdef CONFIG_SMP
 #  if CONFIG_TASK_NAME_SIZE > 0
@@ -518,6 +518,7 @@ void _assert(FAR const char *filename, int linenum)
       /* Flush any buffered SYSLOG data */
 
       syslog_flush();
+      panic_notifier_call_chain(PANIC_KERNEL_FINAL, rtcb);
 
       reboot_notifier_call_chain(SYS_HALT, NULL);
 


### PR DESCRIPTION
Signed-off-by: anjiahao <anjiahao@xiaomi.com>

## Summary
add a last type to assert call notifiler
## Impact
assert, if register a last type notifiler
## Testing
ci & vela

It can support to execute its own debug function after the output of the assert information of nuttx is completed
