### PR TITLE
arm64/a64: Fix PIO Interrupt

### DIFF
--- a/arch/arm64/include/a64/irq.h
+++ b/arch/arm64/include/a64/irq.h
@@ -85,6 +85,8 @@
 #define A64_IRQ_TIMER0          (50)  /* 0x00C8 Timer 0 interrupt */
 #define A64_IRQ_TIMER1          (51)  /* 0x00CC Timer 1 interrupt */
 
+#define A64_IRQ_PH_EINT         (53)  /* 0x00C4 PH_EINT interrupt */
+
 #define A64_IRQ_AC_DET          (60)  /* 0x00F0 Audio Codec earphone detect interrupt */
 #define A64_IRQ_AUDIO_CODEC     (61)  /* 0x00F4 Audio Codec interrupt */
 #define A64_IRQ_KEYADC          (62)  /* 0x00F8 KEYADC interrupt */

--- a/arch/arm64/src/a64/a64_pio.h
+++ b/arch/arm64/src/a64/a64_pio.h
@@ -278,6 +278,40 @@ void a64_pio_write(pio_pinset_t pinset, bool value);
 
 bool a64_pio_read(pio_pinset_t pinset);
 
+/****************************************************************************
+ * Name: a64_pio_irqenable
+ *
+ * Description:
+ *   Enable the interrupt for specified PIO pin.  Only Ports B, G and H are
+ *   supported for interrupts.
+ *
+ * Input Parameters:
+ *   pinset - Bit-encoded description of a pin. Port should be B, G or H.
+ *
+ * Returned Value:
+ *   Zero (OK) on success; -EINVAL if pin is not from Port B, G or H.
+ *
+ ****************************************************************************/
+
+int a64_pio_irqenable(pio_pinset_t pinset);
+
+/****************************************************************************
+ * Name: a64_pio_irqdisable
+ *
+ * Description:
+ *   Disable the interrupt for specified PIO pin.  Only Ports B, G and H are
+ *   supported for interrupts.
+ *
+ * Input Parameters:
+ *   pinset - Bit-encoded description of a pin. Port should be B, G or H.
+ *
+ * Returned Value:
+ *   Zero (OK) on success; -EINVAL if pin is not from Port B, G or H.
+ *
+ ****************************************************************************/
+
+int a64_pio_irqdisable(pio_pinset_t pinset);
+
 #undef EXTERN
 #if defined(__cplusplus)
 }

--- a/arch/arm64/src/a64/hardware/a64_pio.h
+++ b/arch/arm64/src/a64/hardware/a64_pio.h
@@ -70,13 +70,14 @@
 #define A64_PIO_DRV1_OFFSET(n)    (0x0018 + (n)*0x24) /* Port Multi-Driving Register 1, n=0-7 */
 #define A64_PIO_PUL0_OFFSET(n)    (0x001c + (n)*0x24) /* Port Pull Register 0, n=0-7 */
 #define A64_PIO_PUL1_OFFSET(n)    (0x0020 + (n)*0x24) /* Port Pull Register 1, n=0-7 */
-#define A64_PIO_INT_CFG0_OFFSET   0x0200              /* PIO Interrupt Configure Register 0 */
-#define A64_PIO_INT_CFG1_OFFSET   0x0204              /* PIO Interrupt Configure Register 1 */
-#define A64_PIO_INT_CFG2_OFFSET   0x0208              /* PIO Interrupt Configure Register 2 */
-#define A64_PIO_INT_CFG3_OFFSET   0x020c              /* PIO Interrupt Configure Register 3 */
-#define A64_PIO_INT_CTL_OFFSET    0x0210              /* PIO Interrupt Control Register */
-#define A64_PIO_INT_STA_OFFSET    0x0214              /* PIO Interrupt Status Register */
-#define A64_PIO_INT_DEB_OFFSET    0x0218              /* PIO Interrupt Debounce Register */
+
+#define A64_PIO_INT_CFG0_OFFSET(n) (0x0200 + (n)*0x20) /* PIO Interrupt Configure Register 0, n=0-2 */
+#define A64_PIO_INT_CFG1_OFFSET(n) (0x0204 + (n)*0x20) /* PIO Interrupt Configure Register 1, n=0-2 */
+#define A64_PIO_INT_CFG2_OFFSET(n) (0x0208 + (n)*0x20) /* PIO Interrupt Configure Register 2, n=0-2 */
+#define A64_PIO_INT_CFG3_OFFSET(n) (0x020c + (n)*0x20) /* PIO Interrupt Configure Register 3, n=0-2 */
+#define A64_PIO_INT_CTL_OFFSET(n)  (0x0210 + (n)*0x20) /* PIO Interrupt Control Register, n=0-2 */
+#define A64_PIO_INT_STA_OFFSET(n)  (0x0214 + (n)*0x20) /* PIO Interrupt Status Register, n=0-2 */
+#define A64_PIO_INT_DEB_OFFSET(n)  (0x0218 + (n)*0x20) /* PIO Interrupt Debounce Register, n=0-2 */
 
 /* Register Addresses *******************************************************/
 
@@ -89,13 +90,13 @@
 #define A64_PIO_DRV1(n)           (A64_PIO_ADDR+A64_PIO_DRV1_OFFSET(n))
 #define A64_PIO_PUL0(n)           (A64_PIO_ADDR+A64_PIO_PUL0_OFFSET(n))
 #define A64_PIO_PUL1(n)           (A64_PIO_ADDR+A64_PIO_PUL1_OFFSET(n))
-#define A64_PIO_INT_CFG0          (A64_PIO_ADDR+A64_PIO_INT_CFG0_OFFSET)
-#define A64_PIO_INT_CFG1          (A64_PIO_ADDR+A64_PIO_INT_CFG1_OFFSET)
-#define A64_PIO_INT_CFG2          (A64_PIO_ADDR+A64_PIO_INT_CFG2_OFFSET)
-#define A64_PIO_INT_CFG3          (A64_PIO_ADDR+A64_PIO_INT_CFG3_OFFSET)
-#define A64_PIO_INT_CTL           (A64_PIO_ADDR+A64_PIO_INT_CTL_OFFSET)
-#define A64_PIO_INT_STA           (A64_PIO_ADDR+A64_PIO_INT_STA_OFFSET)
-#define A64_PIO_INT_DEB           (A64_PIO_ADDR+A64_PIO_INT_DEB_OFFSET)
+#define A64_PIO_INT_CFG0(n)       (A64_PIO_ADDR+A64_PIO_INT_CFG0_OFFSET(n))
+#define A64_PIO_INT_CFG1(n)       (A64_PIO_ADDR+A64_PIO_INT_CFG1_OFFSET(n))
+#define A64_PIO_INT_CFG2(n)       (A64_PIO_ADDR+A64_PIO_INT_CFG2_OFFSET(n))
+#define A64_PIO_INT_CFG3(n)       (A64_PIO_ADDR+A64_PIO_INT_CFG3_OFFSET(n))
+#define A64_PIO_INT_CTL(n)        (A64_PIO_ADDR+A64_PIO_INT_CTL_OFFSET(n))
+#define A64_PIO_INT_STA(n)        (A64_PIO_ADDR+A64_PIO_INT_STA_OFFSET(n))
+#define A64_PIO_INT_DEB(n)        (A64_PIO_ADDR+A64_PIO_INT_DEB_OFFSET(n))
 
 #define A64_RPIO_CFG0             (A64_RPIO_ADDR+A64_PIO_CFG0_OFFSET(0))
 #define A64_RPIO_CFG1             (A64_RPIO_ADDR+A64_PIO_CFG1_OFFSET(0))
@@ -106,13 +107,13 @@
 #define A64_RPIO_DRV1             (A64_RPIO_ADDR+A64_PIO_DRV1_OFFSET(0))
 #define A64_RPIO_PUL0             (A64_RPIO_ADDR+A64_PIO_PUL0_OFFSET(0))
 #define A64_RPIO_PUL1             (A64_RPIO_ADDR+A64_PIO_PUL1_OFFSET(0))
-#define A64_RPIO_INT_CFG0         (A64_RPIO_ADDR+A64_PIO_INT_CFG0_OFFSET)
-#define A64_RPIO_INT_CFG1         (A64_RPIO_ADDR+A64_PIO_INT_CFG1_OFFSET)
-#define A64_RPIO_INT_CFG2         (A64_RPIO_ADDR+A64_PIO_INT_CFG2_OFFSET)
-#define A64_RPIO_INT_CFG3         (A64_RPIO_ADDR+A64_PIO_INT_CFG3_OFFSET)
-#define A64_RPIO_INT_CTL          (A64_RPIO_ADDR+A64_PIO_INT_CTL_OFFSET)
-#define A64_RPIO_INT_STA          (A64_RPIO_ADDR+A64_PIO_INT_STA_OFFSET)
-#define A64_RPIO_INT_DEB          (A64_RPIO_ADDR+A64_PIO_INT_DEB_OFFSET)
+#define A64_RPIO_INT_CFG0         (A64_RPIO_ADDR+A64_PIO_INT_CFG0_OFFSET(0))
+#define A64_RPIO_INT_CFG1         (A64_RPIO_ADDR+A64_PIO_INT_CFG1_OFFSET(0))
+#define A64_RPIO_INT_CFG2         (A64_RPIO_ADDR+A64_PIO_INT_CFG2_OFFSET(0))
+#define A64_RPIO_INT_CFG3         (A64_RPIO_ADDR+A64_PIO_INT_CFG3_OFFSET(0))
+#define A64_RPIO_INT_CTL          (A64_RPIO_ADDR+A64_PIO_INT_CTL_OFFSET(0))
+#define A64_RPIO_INT_STA          (A64_RPIO_ADDR+A64_PIO_INT_STA_OFFSET(0))
+#define A64_RPIO_INT_DEB          (A64_RPIO_ADDR+A64_PIO_INT_DEB_OFFSET(0))
 
 /* Register Bit Field Definitions *******************************************/
 


### PR DESCRIPTION
## Summary

The current implementation of PIO Interrupt for Allwinner A64 is incomplete. This PR fixes the implementation of PIO Interrupt for all supported PIO Ports (PB, PG and PH).

### Modified Files

`arch/arm64/src/a64/a64_pio.c`, `a64_pio.h`: Add implementation of PIO Interrupt

`arch/arm64/include/a64/irq.h`: Add IRQ for PIO Port PH

`arch/arm64/src/a64/hardware/a64_pio.h`: Fix addresses of PIO Interrupt Registers

## Impact

PIO Interrupts are not used by the existing code. PINE64 PinePhone will use PIO Interrupts in the upcoming driver for the I2C Touch Panel.

## Testing

We successfully tested PIO Interrupts with the upcoming I2C Touch Panel Driver for PinePhone. [(See this)](https://github.com/lupyuen/pinephone-nuttx#handle-interrupts-from-touch-panel)

[(Here's the Test Log)](https://gist.github.com/lupyuen/91a37a4b54f75f7386374a30821dc1b2)