### PR TITLE
segger/sysview: add up_perf_freq result chaeck

### DIFF
--- a/drivers/segger/note_sysview.c
+++ b/drivers/segger/note_sysview.c
@@ -375,6 +375,12 @@ int note_sysview_initialize(void)
       note_sysview_send_tasklist,
     };
 
+  if (freq == 0)
+    {
+      syslog(LOG_ERR, "up_perf isn't initialized, sysview isn't available");
+      PANIC();
+    }
+
   SEGGER_SYSVIEW_Init(freq, freq, &g_sysview_trace_api,
                       note_sysview_send_description);
 


### PR DESCRIPTION
## Summary
Using sysview without calling up_perf_init for initialization will cause the result to display abnormally
Add log to help locate the cause of the problem

## Impact

## Testing

