### PR TITLE
xtensa/esp32: Add option to enable ETH PHY reset pin

### DIFF
--- a/arch/xtensa/src/esp32/Kconfig
+++ b/arch/xtensa/src/esp32/Kconfig
@@ -1860,10 +1860,15 @@ config ESP32_ETH_MDIOPIN
 	default 18
 	range 0 39
 
+config ESP32_ETH_ENABLE_PHY_RSTPIN
+	bool "Enable Reset PHY Pin"
+	default y
+
 config ESP32_ETH_PHY_RSTPIN
 	int "Reset PHY Pin"
 	default 5
 	range 0 39
+	depends on ESP32_ETH_ENABLE_PHY_RSTPIN
 
 config ESP32_ETH_PHY_ADDR
 	int "PHY address"

--- a/arch/xtensa/src/esp32/esp32_emac.c
+++ b/arch/xtensa/src/esp32/esp32_emac.c
@@ -1989,10 +1989,8 @@ static int emac_ioctl(struct net_driver_s *dev, int cmd, unsigned long arg)
     }
 
   return ret;
-#else
-  return -EINVAL;
-#endif /* CONFIG_NETDEV_IOCTL */
 }
+#endif /* CONFIG_NETDEV_IOCTL */
 
 /****************************************************************************
  * Public Functions

--- a/arch/xtensa/src/esp32/esp32_emac.c
+++ b/arch/xtensa/src/esp32/esp32_emac.c
@@ -146,7 +146,9 @@
 
 /* Reset PHY chip pins */
 
-#define EMAC_PHYRST_PIN         (CONFIG_ESP32_ETH_PHY_RSTPIN)
+#ifdef CONFIG_ESP32_ETH_ENABLE_PHY_RSTPIN
+#  define EMAC_PHYRST_PIN       (CONFIG_ESP32_ETH_PHY_RSTPIN)
+#endif
 
 /* PHY chip address in SMI bus */
 
@@ -511,7 +513,9 @@ static void emac_init_gpio(void)
   esp32_gpio_matrix_out(EMAC_MDIO_PIN, EMAC_MDO_O_IDX, 0, 0);
   esp32_gpio_matrix_in(EMAC_MDIO_PIN, EMAC_MDI_I_IDX, 0);
 
+#ifdef CONFIG_ESP32_ETH_ENABLE_PHY_RSTPIN
   esp32_configgpio(EMAC_PHYRST_PIN, OUTPUT | PULLUP);
+#endif
 }
 
 /****************************************************************************
@@ -538,11 +542,14 @@ static int emac_config(void)
   uint32_t regval;
   uint8_t macaddr[6];
 
+#ifdef CONFIG_ESP32_ETH_ENABLE_PHY_RSTPIN
+
   /* Hardware reset PHY chip */
 
   esp32_gpiowrite(EMAC_PHYRST_PIN, false);
   nxsig_usleep(50);
   esp32_gpiowrite(EMAC_PHYRST_PIN, true);
+#endif
 
   /* Open hardware clock */
 


### PR DESCRIPTION
## Summary

xtensa/esp32: Add option to enable ETH PHY reset pin.

## Impact

Users can use other hardware to reset ETH PHY chip, like I2C -> GPIO chip.

## Testing

