### PR TITLE
xtensa/esp32: ESP32 SPI Flash encryption supports 16-bytes align writing

### DIFF
--- a/arch/xtensa/src/esp32/esp32_spiflash.h
+++ b/arch/xtensa/src/esp32/esp32_spiflash.h
@@ -101,6 +101,22 @@ struct mtd_dev_s *esp32_spiflash_get_mtd(void);
 
 struct mtd_dev_s *esp32_spiflash_encrypt_get_mtd(void);
 
+/****************************************************************************
+ * Name: esp32_flash_encryption_enabled
+ *
+ * Description:
+ *   Check if ESP32 enables SPI Flash encryption.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   True: SPI Flash encryption is enable, False if not.
+ *
+ ****************************************************************************/
+
+bool esp32_flash_encryption_enabled(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Summary

xtensa/esp32: ESP32 SPI Flash encryption supports 16-bytes align writing.

## Impact

Write data by 16 bytes align can save more flash space than origin 32 bytes align.

## Testing

