### PR TITLE
drivers/pipe:add PIPEIOC_POLLTHRES to set POLLIN/POLLOUT threshold

### DIFF
--- a/drivers/pipes/pipe_common.h
+++ b/drivers/pipes/pipe_common.h
@@ -120,6 +120,8 @@ struct pipe_dev_s
   pipe_ndx_t d_wrndx;       /* Index in d_buffer to save next byte written */
   pipe_ndx_t d_rdndx;       /* Index in d_buffer to return the next byte read */
   pipe_ndx_t d_bufsize;     /* allocated size of d_buffer in bytes */
+  pipe_ndx_t d_pollinthrd;  /* Buffer threshold for POLLIN to occur */
+  pipe_ndx_t d_polloutthrd; /* Buffer threshold for POLLOUT to occur */
   uint8_t    d_nwriters;    /* Number of reference counts for write access */
   uint8_t    d_nreaders;    /* Number of reference counts for read access */
   uint8_t    d_flags;       /* See PIPE_FLAG_* definitions */

--- a/include/nuttx/fs/ioctl.h
+++ b/include/nuttx/fs/ioctl.h
@@ -405,15 +405,33 @@
 
 /* FIFOs and pipe driver ioctl definitions **********************************/
 
-#define _PIPEIOCVALID(c)  (_IOC_TYPE(c)==_PIPEBASE)
-#define _PIPEIOC(nr)      _IOC(_PIPEBASE,nr)
+#define _PIPEIOCVALID(c)    (_IOC_TYPE(c)==_PIPEBASE)
+#define _PIPEIOC(nr)        _IOC(_PIPEBASE,nr)
 
-#define PIPEIOC_POLICY    _PIPEIOC(0x0001)  /* Set buffer policy
-                                             * IN: unsigned long integer
-                                             *     0=free on last close
-                                             *       (default)
-                                             *     1=fre when empty
-                                             * OUT: None */
+#define PIPEIOC_POLICY      _PIPEIOC(0x0001)  /* Set buffer policy
+                                               * IN: unsigned long integer
+                                               *     0=free on last close
+                                               *       (default)
+                                               *     1=fre when empty
+                                               * OUT: None */
+
+#define PIPEIOC_POLLINTHRD  _PIPEIOC(0x0002)  /* Set pipe POLLIN
+                                               * notifty buffer threshold.
+                                               * IN: unsigned long integer.
+                                               *     POLLIN only occurs when
+                                               *     buffer contains more
+                                               *     bytes than the
+                                               *     threshold.
+                                               * OUT: None */
+
+#define PIPEIOC_POLLOUTTHRD _PIPEIOC(0x0003)  /* Set pipe POLLOUT
+                                               * notifty buffer threshold.
+                                               * IN: unsigned long integer.
+                                               *     POLLOUT only occurs
+                                               *     when buffer can accept
+                                               *     more bytes than
+                                               *     threshold.
+                                               * OUT: None */
 
 /* RTC driver ioctl definitions *********************************************/
 


### PR DESCRIPTION
## Summary
add a new IOC command PIPEIOC_POLLTHRES to set POLLIN/POLLOUT threshold.
When local udp socket is used, this threshold will avoid non-blocking read failed with -EAGAIN when only preamble len is sent and read by reader. To do so, local udp socket should set threshold to be sizeof preamble len.

Setting local udp socket threshold will be done in another patch.

## Impact
None, only affects others after using the new command.

## Testing
Tested with CONFIG_EXAMPLES_UDGRAM
