### PR TITLE
virtio/net: Try fix virtnet logic

### DIFF
--- a/drivers/virtio/virtio-mmio-net.c
+++ b/drivers/virtio/virtio-mmio-net.c
@@ -435,11 +435,9 @@ static int virtnet_txpoll(FAR struct net_driver_s *dev)
 
   virtnet_reply(priv);
 
-  /* If zero is returned, the polling will continue until all connections
-   * have been examined.
-   */
+  /* Stop the poll now because we only have one tx buffer (g_pktbuf) */
 
-  return 0;
+  return -EBUSY;
 }
 
 /****************************************************************************
@@ -591,6 +589,7 @@ static void virtnet_rxdispatch(FAR struct virtnet_driver_s *priv)
 
 static void virtnet_receive(FAR struct virtnet_driver_s *priv)
 {
+  FAR uint8_t *buf = priv->vnet_dev.d_buf;
   uint16_t used = priv->rxq->used->idx;
   uint16_t idx;
 
@@ -632,6 +631,8 @@ static void virtnet_receive(FAR struct virtnet_driver_s *priv)
 
   priv->rxq->last_used_idx = used;
   vrtinfo("+++ rxq->last_used_idx=%d\n",  priv->rxq->last_used_idx);
+
+  priv->vnet_dev.d_buf = buf;
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
Try to fix virtnet logic after https://github.com/apache/nuttx/pull/8011

## The main problem
In `txpoll`, driver may do one of these three actions:
1. Send or copyout the `d_buf` immediately and return 0 to indicate next poll may come immediately (like arch/sim/src/sim/sim_netdriver.c)
https://github.com/apache/nuttx/blob/6214f3cde72d30a8b3a3bf37469eb0d97dad09d6/arch/sim/src/sim/sim_netdriver.c#L263-L276
2. Save the `d_buf` pointer to somewhere else and prepare another `d_buf` to `dev` (like arch/xtensa/src/esp32/esp32_wlan.c)
https://github.com/apache/nuttx/blob/6214f3cde72d30a8b3a3bf37469eb0d97dad09d6/arch/xtensa/src/esp32/esp32_wlan.c#L938-L946
3. Just use the `d_buf` without preparing another, and return a non-zero value to stop polling (like error case in esp32_wlan.c, or bcmf_netdev.c, return an errno or 1 does the same thing.)
https://github.com/apache/nuttx/blob/6214f3cde72d30a8b3a3bf37469eb0d97dad09d6/arch/xtensa/src/esp32/esp32_wlan.c#L941-L944 https://github.com/apache/nuttx/blob/6214f3cde72d30a8b3a3bf37469eb0d97dad09d6/drivers/wireless/ieee80211/bcm43xxx/bcmf_netdev.c#L401-L415

It seems that we only have one tx buffer `g_pktbuf` in our virtnet, and we cannot send it out before the `txpoll` returns. When `txpoll` is called multiple times in a very short time, it finally results in sending only one packet out (but I don't know the actual reason). So maybe return a non-zero value to stop polling is the fastest way to fix.

## Timeline
- Before IOB offload, `devif_poll` can only poll out one packet from each tcp connection at a time, so this problem may not be triggered by iperf.
- After IOB offload, the `devif_poll` will just stop when the `txpoll` returns 0, which is actually not an expected action. virtnet driver works because `devif_poll` just stops.
- After https://github.com/apache/nuttx/pull/8011 we may poll out as many packets as possible if the callback says it can handle (introduced by IOB offload but finally works after this PR)

## Other problems
- Maybe it's still possible we re-write the data in `g_pktbuf` and try to send it before previous transmission is done if `txavail` is called at a very high freq. Also, I'm not sure how `txq`'s state will be in this case.
- `virtnet_receive` has changed the `d_buf` to rx buffer but never change it back to `g_pktbuf`, also fix it.
  - But maybe not fixing it can reduce the posibility of writing into same buffer before sending it? Since we're writing into one of the rx buffer :)
- `txdone` is not implemented, so packets may be stayed in net stack if `txavail` failed to queue a work, and waits until timeout expiry to come back to normal state.

## Testing
Using the command @masayuki2009 mentioned in https://github.com/apache/nuttx/pull/8011, iperf works.
Since QEMU 6.2 can also reproduce the problem, all testing are based on QEMU 6.2.