### PR TITLE
sem_unlink: return ENOENT when the named semaphore does not exist.

### DIFF
--- a/fs/semaphore/sem_unlink.c
+++ b/fs/semaphore/sem_unlink.c
@@ -97,7 +97,7 @@ int sem_unlink(FAR const char *name)
 
   if (!INODE_IS_NAMEDSEM(inode))
     {
-      errcode = ENXIO;
+      errcode = ENOENT;
       goto errout_with_inode;
     }
 


### PR DESCRIPTION
## Summary
Follow posix, return ENOENT when the named semaphore does not exist to fix the ltp open posix sem_unlink 4-1.c test problem.

## Impact
sem_unlink

## Testing
local test with ltp open-posix sem_unlink 4-1.c testcase (apps/testing/ltp/ltp/testcases/open_posix_testsuite/conformance/interfaces/sem_unlink/4-1.c)
