### PR TITLE
s32k1xx: avoid buffer overflow when CAN time is used for non-FD CAN.

### DIFF
--- a/arch/arm/src/s32k1xx/s32k1xx_flexcan.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_flexcan.c
@@ -90,7 +90,11 @@
 
 #define POOL_SIZE                   1
 
+#if defined(CONFIG_NET_CAN_RAW_TX_DEADLINE) || defined(CONFIG_NET_TIMESTAMP)
 #define MSG_DATA                    sizeof(struct timeval)
+#else
+#define MSG_DATA                    0
+#endif
 
 /* CAN bit timing values  */
 #define CLK_FREQ                    80000000


### PR DESCRIPTION
s32k1xx: fix initialization of MAXMB field in MCR.

## Summary

This includes two fixes for s32k1xx CAN driver.

First, MSG_DATA was not included in TX/RX buffer frames for non-FD builds of the driver. However, both CONFIG_NET_CAN_RAW_TX_DEADLINE and CONFIG_NET_TIMESTAMP can be used with non-FD CAN, and doing do would cause a buffer overflow as code expects extra space for MSG_DATA to be present in those cases.

Second, MAXMB field of MCR has a reset value of 0xF. Current code just OR's the desired value into this register without cleaning it first. For the settings in the file (5 RX MBs and 2 TX MBs) this means a 7 should end up there, but without my patch, the reset 0xF is not correctly overwritten meaning the HW device tries to use unconfigured mailboxes when the expeted & configured ones are full.

## Impact

Buffer overflow is serious and will break any code using time features. In my case, I am using CONFIG_NET_TIMESTAMP and SO_TIMESTAMP in my CAN sockets and I get a buffer overflow.

The mailbox initialization will cause data loss as received CAN frames are placed on those unexpected mailboxes and RX code never checks them. On low-traffic scenarios this will be very unlikely as the first 5 RX mailboxes will be empty most of the time, not causing the "unconfigured" ones to be used.

## Testing

I have observed both issues on my custom HW.

To reproduce buffer overflow: just create a socket CAN and ioctl(...SO_TIMESTAMP...) to enable timestamping.
To observe MAXMB problem: step into s32k1xx_reset using gdb and check the value of MCR after it is written.

