### PR TITLE
libc/math: add simple implementation for sincos API

### DIFF
--- a/include/nuttx/lib/math.h
+++ b/include/nuttx/lib/math.h
@@ -394,6 +394,14 @@ long double frexpl(long double x, int *exp);
 
 /* Trigonometric Functions **************************************************/
 
+void        sincosf(float, float *, float *);
+#ifdef CONFIG_HAVE_DOUBLE
+void        sincos(double, double *, double *);
+#endif
+#ifdef CONFIG_HAVE_LONG_DOUBLE
+void        sincosl(long double, long double *, long double *);
+#endif
+
 float       sinf  (float x);
 #ifdef CONFIG_HAVE_DOUBLE
 double      sin   (double x);

--- a/libs/libc/math/Make.defs
+++ b/libs/libc/math/Make.defs
@@ -28,6 +28,7 @@ CSRCS += lib_ldexpf.c lib_logf.c lib_log10f.c lib_log2f.c lib_modff.c
 CSRCS += lib_powf.c lib_sinf.c lib_sinhf.c lib_sqrtf.c lib_tanf.c
 CSRCS += lib_tanhf.c lib_asinhf.c lib_acoshf.c lib_atanhf.c lib_erff.c
 CSRCS += lib_copysignf.c lib_scalbnf.c lib_scalbn.c lib_scalbnl.c
+CSRCS += lib_sincos.c lib_sincosf.c lib_sincosl.c
 
 CSRCS += lib_acos.c lib_asin.c lib_atan.c lib_atan2.c lib_cos.c
 CSRCS += lib_cosh.c lib_exp.c lib_fabs.c lib_fmod.c lib_frexp.c

--- a/libs/libc/math/lib_sincos.c
+++ b/libs/libc/math/lib_sincos.c
@@ -1,0 +1,42 @@
+/****************************************************************************
+ * libs/libc/math/lib_sincos.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/compiler.h>
+
+#include <math.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_HAVE_DOUBLE
+
+void sincos(double x, double *s, double *c)
+{
+  *s = sin(x);
+  *c = cos(x);
+}
+
+#endif

--- a/libs/libc/math/lib_sincosf.c
+++ b/libs/libc/math/lib_sincosf.c
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * libs/libc/math/lib_sincosf.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/compiler.h>
+
+#include <math.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void sincosf(float x, float *s, float *c)
+{
+  *s = sinf(x);
+  *c = cosf(x);
+}

--- a/libs/libc/math/lib_sincosl.c
+++ b/libs/libc/math/lib_sincosl.c
@@ -1,0 +1,42 @@
+/****************************************************************************
+ * libs/libc/math/lib_sincosl.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/compiler.h>
+
+#include <math.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_HAVE_LONG_DOUBLE
+
+void sincosl(long double x, long double *s, long double *c)
+{
+  *s = sinl(x);
+  *c = cosl(x);
+}
+
+#endif


### PR DESCRIPTION
## Summary

Use existing sin/cos function to provide `sincos` API.

This is to address the optimization issue found in `sim:lua` configuration when `CONFIG_DEBUG_FULLOPT` is enabled.
`nuttx/libs/libc/math/lib_tan.c:43: undefined reference to 'sincos'`

## Impact
No
## Testing
Compile pass
