### PR TITLE
libc: don't redefined __ARM_ARCH_XXX when __ARM_ARCH defined

### DIFF
--- a/libs/libc/machine/arm/armv7-a/gnu/acle-compat.h
+++ b/libs/libc/machine/arm/armv7-a/gnu/acle-compat.h
@@ -31,6 +31,8 @@
 #ifndef __LIBS_LIBC_MACHINE_ARM_ARMV7A_GNU_ACLE_COMPAT_H
 #define __LIBS_LIBC_MACHINE_ARM_ARMV7A_GNU_ACLE_COMPAT_H
 
+#ifndef __ARM_ARCH
+
 /* ACLE standardises a set of pre-defines that describe the ARM architecture.
  * These were mostly implemented in GCC around GCC-4.8; older versions
  * have no, or only partial support.  To provide a level of backwards
@@ -41,147 +43,141 @@
 
 /* No need to handle ARMv8, GCC had ACLE support before that.  */
 
-#ifdef __ARM_ARCH_7__
+#  ifdef __ARM_ARCH_7__
 /* The common subset of ARMv7 in all profiles.  */
-#  define __ARM_ARCH 7
-#  define __ARM_ARCH_ISA_THUMB 2
-#  define __ARM_FEATURE_CLZ
-#  define __ARM_FEATURE_LDREX 7
-#  define __ARM_FEATURE_UNALIGNED
-#endif
-
-#if defined (__ARM_ARCH_7A__) || defined (__ARM_ARCH_7R__)
-#  define __ARM_ARCH 7
-#  define __ARM_ARCH_ISA_THUMB 2
-#  define __ARM_ARCH_ISA_ARM
-#  define __ARM_FEATURE_CLZ
-#  define __ARM_FEATURE_SIMD32
-#  define __ARM_FEATURE_DSP
-#  define __ARM_FEATURE_QBIT
-#  define __ARM_FEATURE_SAT
-#  define __ARM_FEATURE_LDREX 15
-#  define __ARM_FEATURE_UNALIGNED
-#  ifdef __ARM_ARCH_7A__
-#    define __ARM_ARCH_PROFILE 'A'
-#  else
-#    define __ARM_ARCH_PROFILE 'R'
+#    define __ARM_ARCH 7
+#    define __ARM_ARCH_ISA_THUMB 2
+#    define __ARM_FEATURE_CLZ
+#    define __ARM_FEATURE_LDREX 7
+#    define __ARM_FEATURE_UNALIGNED
 #  endif
-#endif
 
-#ifdef __ARM_ARCH_7EM__
-#  define __ARM_ARCH 7
-#  define __ARM_ARCH_ISA_THUMB 2
-#  define __ARM_FEATURE_CLZ
-#  define __ARM_FEATURE_SIMD32
-#  define __ARM_FEATURE_DSP
-#  define __ARM_FEATURE_QBIT
-#  define __ARM_FEATURE_SAT
-#  define __ARM_FEATURE_LDREX 7
-#  define __ARM_FEATURE_UNALIGNED
-#  define __ARM_ARCH_PROFILE 'M'
-#endif
-
-#ifdef __ARM_ARCH_7M__
-#  define __ARM_ARCH 7
-#  define __ARM_ARCH_ISA_THUMB 2
-#  define __ARM_FEATURE_CLZ
-#  define __ARM_FEATURE_QBIT
-#  define __ARM_FEATURE_SAT
-#  define __ARM_FEATURE_LDREX 7
-#  define __ARM_FEATURE_UNALIGNED
-#  define __ARM_ARCH_PROFILE 'M'
-#endif
-
-#ifdef __ARM_ARCH_6T2__
-#  define __ARM_ARCH 6
-#  define __ARM_ARCH_ISA_THUMB 2
-#  define __ARM_ARCH_ISA_ARM
-#  define __ARM_FEATURE_CLZ
-#  define __ARM_FEATURE_SIMD32
-#  define __ARM_FEATURE_DSP
-#  define __ARM_FEATURE_QBIT
-#  define __ARM_FEATURE_SAT
-#  define __ARM_FEATURE_LDREX 4
-#  define __ARM_FEATURE_UNALIGNED
-#endif
-
-#ifdef __ARM_ARCH_6M__
-#  define __ARM_ARCH 6
-#  define __ARM_ARCH_ISA_THUMB 1
-#  define __ARM_ARCH_PROFILE 'M'
-#endif
-
-#if defined (__ARM_ARCH_6__) || defined (__ARM_ARCH_6J__) \
-  || defined (__ARM_ARCH_6K__) || defined (__ARM_ARCH_6Z__) \
-  || defined (__ARM_ARCH_6ZK__)
-#  define __ARM_ARCH 6
-#  define __ARM_ARCH_ISA_THUMB 1
-#  define __ARM_ARCH_ISA_ARM
-#  define __ARM_FEATURE_CLZ
-#  define __ARM_FEATURE_SIMD32
-#  define __ARM_FEATURE_DSP
-#  define __ARM_FEATURE_QBIT
-#  define __ARM_FEATURE_SAT
-#  define __ARM_FEATURE_UNALIGNED
-#  ifndef __thumb__
-#    if defined (__ARM_ARCH_6K__) || defined (__ARM_ARCH_6ZK__)
-#      define __ARM_FEATURE_LDREX 15
+#  if defined (__ARM_ARCH_7A__) || defined (__ARM_ARCH_7R__)
+#    define __ARM_ARCH 7
+#    define __ARM_ARCH_ISA_THUMB 2
+#    define __ARM_ARCH_ISA_ARM
+#    define __ARM_FEATURE_CLZ
+#    define __ARM_FEATURE_SIMD32
+#    define __ARM_FEATURE_DSP
+#    define __ARM_FEATURE_QBIT
+#    define __ARM_FEATURE_SAT
+#    define __ARM_FEATURE_LDREX 15
+#    define __ARM_FEATURE_UNALIGNED
+#    ifdef __ARM_ARCH_7A__
+#      define __ARM_ARCH_PROFILE 'A'
 #    else
-#      define __ARM_FEATURE_LDREX 4
+#      define __ARM_ARCH_PROFILE 'R'
 #    endif
 #  endif
-#endif
 
-#if defined (__ARM_ARCH_5TE__) || defined (__ARM_ARCH_5E__)
-#  define __ARM_ARCH 5
-#  define __ARM_ARCH_ISA_ARM
-#  ifdef __ARM_ARCH_5TE__
+#  ifdef __ARM_ARCH_7EM__
+#    define __ARM_ARCH 7
+#    define __ARM_ARCH_ISA_THUMB 2
+#    define __ARM_FEATURE_CLZ
+#    define __ARM_FEATURE_SIMD32
+#    define __ARM_FEATURE_DSP
+#    define __ARM_FEATURE_QBIT
+#    define __ARM_FEATURE_SAT
+#    define __ARM_FEATURE_LDREX 7
+#    define __ARM_FEATURE_UNALIGNED
+#    define __ARM_ARCH_PROFILE 'M'
+#  endif
+
+#  ifdef __ARM_ARCH_7M__
+#    define __ARM_ARCH 7
+#    define __ARM_ARCH_ISA_THUMB 2
+#    define __ARM_FEATURE_CLZ
+#    define __ARM_FEATURE_QBIT
+#    define __ARM_FEATURE_SAT
+#    define __ARM_FEATURE_LDREX 7
+#    define __ARM_FEATURE_UNALIGNED
+#    define __ARM_ARCH_PROFILE 'M'
+#  endif
+
+#  ifdef __ARM_ARCH_6T2__
+#    define __ARM_ARCH 6
+#    define __ARM_ARCH_ISA_THUMB 2
+#    define __ARM_ARCH_ISA_ARM
+#    define __ARM_FEATURE_CLZ
+#    define __ARM_FEATURE_SIMD32
+#    define __ARM_FEATURE_DSP
+#    define __ARM_FEATURE_QBIT
+#    define __ARM_FEATURE_SAT
+#    define __ARM_FEATURE_LDREX 4
+#    define __ARM_FEATURE_UNALIGNED
+#  endif
+
+#  ifdef __ARM_ARCH_6M__
+#    define __ARM_ARCH 6
+#    define __ARM_ARCH_ISA_THUMB 1
+#    define __ARM_ARCH_PROFILE 'M'
+#  endif
+
+#  if defined (__ARM_ARCH_6__) || defined (__ARM_ARCH_6J__) \
+    || defined (__ARM_ARCH_6K__) || defined (__ARM_ARCH_6Z__) \
+    || defined (__ARM_ARCH_6ZK__)
+#    define __ARM_ARCH 6
+#    define __ARM_ARCH_ISA_THUMB 1
+#    define __ARM_ARCH_ISA_ARM
+#    define __ARM_FEATURE_CLZ
+#    define __ARM_FEATURE_SIMD32
+#    define __ARM_FEATURE_DSP
+#    define __ARM_FEATURE_QBIT
+#    define __ARM_FEATURE_SAT
+#    define __ARM_FEATURE_UNALIGNED
+#    ifndef __thumb__
+#      if defined (__ARM_ARCH_6K__) || defined (__ARM_ARCH_6ZK__)
+#        define __ARM_FEATURE_LDREX 15
+#      else
+#        define __ARM_FEATURE_LDREX 4
+#      endif
+#    endif
+#  endif
+
+#  if defined (__ARM_ARCH_5TE__) || defined (__ARM_ARCH_5E__)
+#    define __ARM_ARCH 5
+#    define __ARM_ARCH_ISA_ARM
+#    ifdef __ARM_ARCH_5TE__
+#      define __ARM_ARCH_ISA_THUMB 1
+#    endif
+#    define __ARM_FEATURE_CLZ
+#    define __ARM_FEATURE_DSP
+#  endif
+
+#  if defined (__ARM_ARCH_5T__) || defined (__ARM_ARCH_5__)
+#    define __ARM_ARCH 5
+#    define __ARM_ARCH_ISA_ARM
+#    ifdef __ARM_ARCH_5TE__
+#      define __ARM_ARCH_ISA_THUMB 1
+#    endif
+#    define __ARM_FEATURE_CLZ
+#  endif
+
+#  ifdef __ARM_ARCH_4T__
+#    define __ARM_ARCH 4
+#    define __ARM_ARCH_ISA_ARM
 #    define __ARM_ARCH_ISA_THUMB 1
 #  endif
-#  define __ARM_FEATURE_CLZ
-#  define __ARM_FEATURE_DSP
-#endif
 
-#if defined (__ARM_ARCH_5T__) || defined (__ARM_ARCH_5__)
-#  define __ARM_ARCH 5
-#  define __ARM_ARCH_ISA_ARM
-#  ifdef __ARM_ARCH_5TE__
-#    define __ARM_ARCH_ISA_THUMB 1
+#  ifdef __ARM_ARCH_4__
+#    define __ARM_ARCH 4
+#    define __ARM_ARCH_ISA_ARM
 #  endif
-#  define __ARM_FEATURE_CLZ
-#endif
 
-#ifdef __ARM_ARCH_4T__
-#  define __ARM_ARCH 4
-#  define __ARM_ARCH_ISA_ARM
-#  define __ARM_ARCH_ISA_THUMB 1
-#endif
+#  if defined (__ARM_ARCH_3__) || defined (__ARM_ARCH_3M__)
+#    define __ARM_ARCH 3
+#    define __ARM_ARCH_ISA_ARM
+#  endif
 
-#ifdef __ARM_ARCH_4__
-#  define __ARM_ARCH 4
-#  define __ARM_ARCH_ISA_ARM
-#endif
+#  ifdef __ARM_ARCH_2__
+#    define __ARM_ARCH 2
+#    define __ARM_ARCH_ISA_ARM
+#  endif
 
-#if defined (__ARM_ARCH_3__) || defined (__ARM_ARCH_3M__)
-#  define __ARM_ARCH 3
-#  define __ARM_ARCH_ISA_ARM
-#endif
+#  ifdef __ARMEB__
+#    define __ARM_BIG_ENDIAN
+#  endif
 
-#ifdef __ARM_ARCH_2__
-#  define __ARM_ARCH 2
-#  define __ARM_ARCH_ISA_ARM
-#endif
-
-#ifdef __ARMEB__
-#  define __ARM_BIG_ENDIAN
-#endif
-
-/* If we still don't know what the target architecture is, then we're
- * probably not using GCC.
- */
-
-#ifndef __ARM_ARCH
-#  error Unable to determine architecture version.
 #endif
 
 #endif /* __LIBS_LIBC_MACHINE_ARM_ARMV7A_GNU_ACLE_COMPAT_H */

--- a/libs/libc/machine/arm/armv7-m/gnu/acle-compat.h
+++ b/libs/libc/machine/arm/armv7-m/gnu/acle-compat.h
@@ -31,6 +31,8 @@
 #ifndef __LIBS_LIBC_MACHINE_ARM_ARMV7M_GNU_ACLE_COMPAT_H
 #define __LIBS_LIBC_MACHINE_ARM_ARMV7M_GNU_ACLE_COMPAT_H
 
+#ifndef __ARM_ARCH
+
 /* ACLE standardises a set of pre-defines that describe the ARM architecture.
  * These were mostly implemented in GCC around GCC-4.8; older versions
  * have no, or only partial support.  To provide a level of backwards
@@ -41,147 +43,141 @@
 
 /* No need to handle ARMv8, GCC had ACLE support before that.  */
 
-#ifdef __ARM_ARCH_7__
+#  ifdef __ARM_ARCH_7__
 /* The common subset of ARMv7 in all profiles.  */
-#  define __ARM_ARCH 7
-#  define __ARM_ARCH_ISA_THUMB 2
-#  define __ARM_FEATURE_CLZ
-#  define __ARM_FEATURE_LDREX 7
-#  define __ARM_FEATURE_UNALIGNED
-#endif
-
-#if defined (__ARM_ARCH_7A__) || defined (__ARM_ARCH_7R__)
-#  define __ARM_ARCH 7
-#  define __ARM_ARCH_ISA_THUMB 2
-#  define __ARM_ARCH_ISA_ARM
-#  define __ARM_FEATURE_CLZ
-#  define __ARM_FEATURE_SIMD32
-#  define __ARM_FEATURE_DSP
-#  define __ARM_FEATURE_QBIT
-#  define __ARM_FEATURE_SAT
-#  define __ARM_FEATURE_LDREX 15
-#  define __ARM_FEATURE_UNALIGNED
-#  ifdef __ARM_ARCH_7A__
-#    define __ARM_ARCH_PROFILE 'A'
-#  else
-#    define __ARM_ARCH_PROFILE 'R'
+#    define __ARM_ARCH 7
+#    define __ARM_ARCH_ISA_THUMB 2
+#    define __ARM_FEATURE_CLZ
+#    define __ARM_FEATURE_LDREX 7
+#    define __ARM_FEATURE_UNALIGNED
 #  endif
-#endif
 
-#ifdef __ARM_ARCH_7EM__
-#  define __ARM_ARCH 7
-#  define __ARM_ARCH_ISA_THUMB 2
-#  define __ARM_FEATURE_CLZ
-#  define __ARM_FEATURE_SIMD32
-#  define __ARM_FEATURE_DSP
-#  define __ARM_FEATURE_QBIT
-#  define __ARM_FEATURE_SAT
-#  define __ARM_FEATURE_LDREX 7
-#  define __ARM_FEATURE_UNALIGNED
-#  define __ARM_ARCH_PROFILE 'M'
-#endif
-
-#ifdef __ARM_ARCH_7M__
-#  define __ARM_ARCH 7
-#  define __ARM_ARCH_ISA_THUMB 2
-#  define __ARM_FEATURE_CLZ
-#  define __ARM_FEATURE_QBIT
-#  define __ARM_FEATURE_SAT
-#  define __ARM_FEATURE_LDREX 7
-#  define __ARM_FEATURE_UNALIGNED
-#  define __ARM_ARCH_PROFILE 'M'
-#endif
-
-#ifdef __ARM_ARCH_6T2__
-#  define __ARM_ARCH 6
-#  define __ARM_ARCH_ISA_THUMB 2
-#  define __ARM_ARCH_ISA_ARM
-#  define __ARM_FEATURE_CLZ
-#  define __ARM_FEATURE_SIMD32
-#  define __ARM_FEATURE_DSP
-#  define __ARM_FEATURE_QBIT
-#  define __ARM_FEATURE_SAT
-#  define __ARM_FEATURE_LDREX 4
-#  define __ARM_FEATURE_UNALIGNED
-#endif
-
-#ifdef __ARM_ARCH_6M__
-#  define __ARM_ARCH 6
-#  define __ARM_ARCH_ISA_THUMB 1
-#  define __ARM_ARCH_PROFILE 'M'
-#endif
-
-#if defined (__ARM_ARCH_6__) || defined (__ARM_ARCH_6J__) \
-  || defined (__ARM_ARCH_6K__) || defined (__ARM_ARCH_6Z__) \
-  || defined (__ARM_ARCH_6ZK__)
-#  define __ARM_ARCH 6
-#  define __ARM_ARCH_ISA_THUMB 1
-#  define __ARM_ARCH_ISA_ARM
-#  define __ARM_FEATURE_CLZ
-#  define __ARM_FEATURE_SIMD32
-#  define __ARM_FEATURE_DSP
-#  define __ARM_FEATURE_QBIT
-#  define __ARM_FEATURE_SAT
-#  define __ARM_FEATURE_UNALIGNED
-#  ifndef __thumb__
-#    if defined (__ARM_ARCH_6K__) || defined (__ARM_ARCH_6ZK__)
-#      define __ARM_FEATURE_LDREX 15
+#  if defined (__ARM_ARCH_7A__) || defined (__ARM_ARCH_7R__)
+#    define __ARM_ARCH 7
+#    define __ARM_ARCH_ISA_THUMB 2
+#    define __ARM_ARCH_ISA_ARM
+#    define __ARM_FEATURE_CLZ
+#    define __ARM_FEATURE_SIMD32
+#    define __ARM_FEATURE_DSP
+#    define __ARM_FEATURE_QBIT
+#    define __ARM_FEATURE_SAT
+#    define __ARM_FEATURE_LDREX 15
+#    define __ARM_FEATURE_UNALIGNED
+#    ifdef __ARM_ARCH_7A__
+#      define __ARM_ARCH_PROFILE 'A'
 #    else
-#      define __ARM_FEATURE_LDREX 4
+#      define __ARM_ARCH_PROFILE 'R'
 #    endif
 #  endif
-#endif
 
-#if defined (__ARM_ARCH_5TE__) || defined (__ARM_ARCH_5E__)
-#  define __ARM_ARCH 5
-#  define __ARM_ARCH_ISA_ARM
-#  ifdef __ARM_ARCH_5TE__
+#  ifdef __ARM_ARCH_7EM__
+#    define __ARM_ARCH 7
+#    define __ARM_ARCH_ISA_THUMB 2
+#    define __ARM_FEATURE_CLZ
+#    define __ARM_FEATURE_SIMD32
+#    define __ARM_FEATURE_DSP
+#    define __ARM_FEATURE_QBIT
+#    define __ARM_FEATURE_SAT
+#    define __ARM_FEATURE_LDREX 7
+#    define __ARM_FEATURE_UNALIGNED
+#    define __ARM_ARCH_PROFILE 'M'
+#  endif
+
+#  ifdef __ARM_ARCH_7M__
+#    define __ARM_ARCH 7
+#    define __ARM_ARCH_ISA_THUMB 2
+#    define __ARM_FEATURE_CLZ
+#    define __ARM_FEATURE_QBIT
+#    define __ARM_FEATURE_SAT
+#    define __ARM_FEATURE_LDREX 7
+#    define __ARM_FEATURE_UNALIGNED
+#    define __ARM_ARCH_PROFILE 'M'
+#  endif
+
+#  ifdef __ARM_ARCH_6T2__
+#    define __ARM_ARCH 6
+#    define __ARM_ARCH_ISA_THUMB 2
+#    define __ARM_ARCH_ISA_ARM
+#    define __ARM_FEATURE_CLZ
+#    define __ARM_FEATURE_SIMD32
+#    define __ARM_FEATURE_DSP
+#    define __ARM_FEATURE_QBIT
+#    define __ARM_FEATURE_SAT
+#    define __ARM_FEATURE_LDREX 4
+#    define __ARM_FEATURE_UNALIGNED
+#  endif
+
+#  ifdef __ARM_ARCH_6M__
+#    define __ARM_ARCH 6
+#    define __ARM_ARCH_ISA_THUMB 1
+#    define __ARM_ARCH_PROFILE 'M'
+#  endif
+
+#  if defined (__ARM_ARCH_6__) || defined (__ARM_ARCH_6J__) \
+    || defined (__ARM_ARCH_6K__) || defined (__ARM_ARCH_6Z__) \
+    || defined (__ARM_ARCH_6ZK__)
+#    define __ARM_ARCH 6
+#    define __ARM_ARCH_ISA_THUMB 1
+#    define __ARM_ARCH_ISA_ARM
+#    define __ARM_FEATURE_CLZ
+#    define __ARM_FEATURE_SIMD32
+#    define __ARM_FEATURE_DSP
+#    define __ARM_FEATURE_QBIT
+#    define __ARM_FEATURE_SAT
+#    define __ARM_FEATURE_UNALIGNED
+#    ifndef __thumb__
+#      if defined (__ARM_ARCH_6K__) || defined (__ARM_ARCH_6ZK__)
+#        define __ARM_FEATURE_LDREX 15
+#      else
+#        define __ARM_FEATURE_LDREX 4
+#      endif
+#    endif
+#  endif
+
+#  if defined (__ARM_ARCH_5TE__) || defined (__ARM_ARCH_5E__)
+#    define __ARM_ARCH 5
+#    define __ARM_ARCH_ISA_ARM
+#    ifdef __ARM_ARCH_5TE__
+#      define __ARM_ARCH_ISA_THUMB 1
+#    endif
+#    define __ARM_FEATURE_CLZ
+#    define __ARM_FEATURE_DSP
+#  endif
+
+#  if defined (__ARM_ARCH_5T__) || defined (__ARM_ARCH_5__)
+#    define __ARM_ARCH 5
+#    define __ARM_ARCH_ISA_ARM
+#    ifdef __ARM_ARCH_5TE__
+#      define __ARM_ARCH_ISA_THUMB 1
+#    endif
+#    define __ARM_FEATURE_CLZ
+#  endif
+
+#  ifdef __ARM_ARCH_4T__
+#    define __ARM_ARCH 4
+#    define __ARM_ARCH_ISA_ARM
 #    define __ARM_ARCH_ISA_THUMB 1
 #  endif
-#  define __ARM_FEATURE_CLZ
-#  define __ARM_FEATURE_DSP
-#endif
 
-#if defined (__ARM_ARCH_5T__) || defined (__ARM_ARCH_5__)
-#  define __ARM_ARCH 5
-#  define __ARM_ARCH_ISA_ARM
-#  ifdef __ARM_ARCH_5TE__
-#    define __ARM_ARCH_ISA_THUMB 1
+#  ifdef __ARM_ARCH_4__
+#    define __ARM_ARCH 4
+#    define __ARM_ARCH_ISA_ARM
 #  endif
-#  define __ARM_FEATURE_CLZ
-#endif
 
-#ifdef __ARM_ARCH_4T__
-#  define __ARM_ARCH 4
-#  define __ARM_ARCH_ISA_ARM
-#  define __ARM_ARCH_ISA_THUMB 1
-#endif
+#  if defined (__ARM_ARCH_3__) || defined (__ARM_ARCH_3M__)
+#    define __ARM_ARCH 3
+#    define __ARM_ARCH_ISA_ARM
+#  endif
 
-#ifdef __ARM_ARCH_4__
-#  define __ARM_ARCH 4
-#  define __ARM_ARCH_ISA_ARM
-#endif
+#  ifdef __ARM_ARCH_2__
+#    define __ARM_ARCH 2
+#    define __ARM_ARCH_ISA_ARM
+#  endif
 
-#if defined (__ARM_ARCH_3__) || defined (__ARM_ARCH_3M__)
-#  define __ARM_ARCH 3
-#  define __ARM_ARCH_ISA_ARM
-#endif
+#  ifdef __ARMEB__
+#    define __ARM_BIG_ENDIAN
+#  endif
 
-#ifdef __ARM_ARCH_2__
-#  define __ARM_ARCH 2
-#  define __ARM_ARCH_ISA_ARM
-#endif
-
-#ifdef __ARMEB__
-#  define __ARM_BIG_ENDIAN
-#endif
-
-/* If we still don't know what the target architecture is, then we're
- * probably not using GCC.
- */
-
-#ifndef __ARM_ARCH
-#  error Unable to determine architecture version.
 #endif
 
 #endif /* __LIBS_LIBC_MACHINE_ARM_ARMV7M_GNU_ACLE_COMPAT_H */

--- a/libs/libc/machine/arm/armv7-r/gnu/acle-compat.h
+++ b/libs/libc/machine/arm/armv7-r/gnu/acle-compat.h
@@ -31,6 +31,8 @@
 #ifndef __LIBS_LIBC_MACHINE_ARM_ARMV7R_GNU_ACLE_COMPAT_H
 #define __LIBS_LIBC_MACHINE_ARM_ARMV7R_GNU_ACLE_COMPAT_H
 
+#ifndef __ARM_ARCH
+
 /* ACLE standardises a set of pre-defines that describe the ARM architecture.
  * These were mostly implemented in GCC around GCC-4.8; older versions
  * have no, or only partial support.  To provide a level of backwards
@@ -41,147 +43,141 @@
 
 /* No need to handle ARMv8, GCC had ACLE support before that.  */
 
-#ifdef __ARM_ARCH_7__
+#  ifdef __ARM_ARCH_7__
 /* The common subset of ARMv7 in all profiles.  */
-#  define __ARM_ARCH 7
-#  define __ARM_ARCH_ISA_THUMB 2
-#  define __ARM_FEATURE_CLZ
-#  define __ARM_FEATURE_LDREX 7
-#  define __ARM_FEATURE_UNALIGNED
-#endif
-
-#if defined (__ARM_ARCH_7A__) || defined (__ARM_ARCH_7R__)
-#  define __ARM_ARCH 7
-#  define __ARM_ARCH_ISA_THUMB 2
-#  define __ARM_ARCH_ISA_ARM
-#  define __ARM_FEATURE_CLZ
-#  define __ARM_FEATURE_SIMD32
-#  define __ARM_FEATURE_DSP
-#  define __ARM_FEATURE_QBIT
-#  define __ARM_FEATURE_SAT
-#  define __ARM_FEATURE_LDREX 15
-#  define __ARM_FEATURE_UNALIGNED
-#  ifdef __ARM_ARCH_7A__
-#    define __ARM_ARCH_PROFILE 'A'
-#  else
-#    define __ARM_ARCH_PROFILE 'R'
+#    define __ARM_ARCH 7
+#    define __ARM_ARCH_ISA_THUMB 2
+#    define __ARM_FEATURE_CLZ
+#    define __ARM_FEATURE_LDREX 7
+#    define __ARM_FEATURE_UNALIGNED
 #  endif
-#endif
 
-#ifdef __ARM_ARCH_7EM__
-#  define __ARM_ARCH 7
-#  define __ARM_ARCH_ISA_THUMB 2
-#  define __ARM_FEATURE_CLZ
-#  define __ARM_FEATURE_SIMD32
-#  define __ARM_FEATURE_DSP
-#  define __ARM_FEATURE_QBIT
-#  define __ARM_FEATURE_SAT
-#  define __ARM_FEATURE_LDREX 7
-#  define __ARM_FEATURE_UNALIGNED
-#  define __ARM_ARCH_PROFILE 'M'
-#endif
-
-#ifdef __ARM_ARCH_7M__
-#  define __ARM_ARCH 7
-#  define __ARM_ARCH_ISA_THUMB 2
-#  define __ARM_FEATURE_CLZ
-#  define __ARM_FEATURE_QBIT
-#  define __ARM_FEATURE_SAT
-#  define __ARM_FEATURE_LDREX 7
-#  define __ARM_FEATURE_UNALIGNED
-#  define __ARM_ARCH_PROFILE 'M'
-#endif
-
-#ifdef __ARM_ARCH_6T2__
-#  define __ARM_ARCH 6
-#  define __ARM_ARCH_ISA_THUMB 2
-#  define __ARM_ARCH_ISA_ARM
-#  define __ARM_FEATURE_CLZ
-#  define __ARM_FEATURE_SIMD32
-#  define __ARM_FEATURE_DSP
-#  define __ARM_FEATURE_QBIT
-#  define __ARM_FEATURE_SAT
-#  define __ARM_FEATURE_LDREX 4
-#  define __ARM_FEATURE_UNALIGNED
-#endif
-
-#ifdef __ARM_ARCH_6M__
-#  define __ARM_ARCH 6
-#  define __ARM_ARCH_ISA_THUMB 1
-#  define __ARM_ARCH_PROFILE 'M'
-#endif
-
-#if defined (__ARM_ARCH_6__) || defined (__ARM_ARCH_6J__) \
-  || defined (__ARM_ARCH_6K__) || defined (__ARM_ARCH_6Z__) \
-  || defined (__ARM_ARCH_6ZK__)
-#  define __ARM_ARCH 6
-#  define __ARM_ARCH_ISA_THUMB 1
-#  define __ARM_ARCH_ISA_ARM
-#  define __ARM_FEATURE_CLZ
-#  define __ARM_FEATURE_SIMD32
-#  define __ARM_FEATURE_DSP
-#  define __ARM_FEATURE_QBIT
-#  define __ARM_FEATURE_SAT
-#  define __ARM_FEATURE_UNALIGNED
-#  ifndef __thumb__
-#    if defined (__ARM_ARCH_6K__) || defined (__ARM_ARCH_6ZK__)
-#      define __ARM_FEATURE_LDREX 15
+#  if defined (__ARM_ARCH_7A__) || defined (__ARM_ARCH_7R__)
+#    define __ARM_ARCH 7
+#    define __ARM_ARCH_ISA_THUMB 2
+#    define __ARM_ARCH_ISA_ARM
+#    define __ARM_FEATURE_CLZ
+#    define __ARM_FEATURE_SIMD32
+#    define __ARM_FEATURE_DSP
+#    define __ARM_FEATURE_QBIT
+#    define __ARM_FEATURE_SAT
+#    define __ARM_FEATURE_LDREX 15
+#    define __ARM_FEATURE_UNALIGNED
+#    ifdef __ARM_ARCH_7A__
+#      define __ARM_ARCH_PROFILE 'A'
 #    else
-#      define __ARM_FEATURE_LDREX 4
+#      define __ARM_ARCH_PROFILE 'R'
 #    endif
 #  endif
-#endif
 
-#if defined (__ARM_ARCH_5TE__) || defined (__ARM_ARCH_5E__)
-#  define __ARM_ARCH 5
-#  define __ARM_ARCH_ISA_ARM
-#  ifdef __ARM_ARCH_5TE__
+#  ifdef __ARM_ARCH_7EM__
+#    define __ARM_ARCH 7
+#    define __ARM_ARCH_ISA_THUMB 2
+#    define __ARM_FEATURE_CLZ
+#    define __ARM_FEATURE_SIMD32
+#    define __ARM_FEATURE_DSP
+#    define __ARM_FEATURE_QBIT
+#    define __ARM_FEATURE_SAT
+#    define __ARM_FEATURE_LDREX 7
+#    define __ARM_FEATURE_UNALIGNED
+#    define __ARM_ARCH_PROFILE 'M'
+#  endif
+
+#  ifdef __ARM_ARCH_7M__
+#    define __ARM_ARCH 7
+#    define __ARM_ARCH_ISA_THUMB 2
+#    define __ARM_FEATURE_CLZ
+#    define __ARM_FEATURE_QBIT
+#    define __ARM_FEATURE_SAT
+#    define __ARM_FEATURE_LDREX 7
+#    define __ARM_FEATURE_UNALIGNED
+#    define __ARM_ARCH_PROFILE 'M'
+#  endif
+
+#  ifdef __ARM_ARCH_6T2__
+#    define __ARM_ARCH 6
+#    define __ARM_ARCH_ISA_THUMB 2
+#    define __ARM_ARCH_ISA_ARM
+#    define __ARM_FEATURE_CLZ
+#    define __ARM_FEATURE_SIMD32
+#    define __ARM_FEATURE_DSP
+#    define __ARM_FEATURE_QBIT
+#    define __ARM_FEATURE_SAT
+#    define __ARM_FEATURE_LDREX 4
+#    define __ARM_FEATURE_UNALIGNED
+#  endif
+
+#  ifdef __ARM_ARCH_6M__
+#    define __ARM_ARCH 6
+#    define __ARM_ARCH_ISA_THUMB 1
+#    define __ARM_ARCH_PROFILE 'M'
+#  endif
+
+#  if defined (__ARM_ARCH_6__) || defined (__ARM_ARCH_6J__) \
+    || defined (__ARM_ARCH_6K__) || defined (__ARM_ARCH_6Z__) \
+    || defined (__ARM_ARCH_6ZK__)
+#    define __ARM_ARCH 6
+#    define __ARM_ARCH_ISA_THUMB 1
+#    define __ARM_ARCH_ISA_ARM
+#    define __ARM_FEATURE_CLZ
+#    define __ARM_FEATURE_SIMD32
+#    define __ARM_FEATURE_DSP
+#    define __ARM_FEATURE_QBIT
+#    define __ARM_FEATURE_SAT
+#    define __ARM_FEATURE_UNALIGNED
+#    ifndef __thumb__
+#      if defined (__ARM_ARCH_6K__) || defined (__ARM_ARCH_6ZK__)
+#        define __ARM_FEATURE_LDREX 15
+#      else
+#        define __ARM_FEATURE_LDREX 4
+#      endif
+#    endif
+#  endif
+
+#  if defined (__ARM_ARCH_5TE__) || defined (__ARM_ARCH_5E__)
+#    define __ARM_ARCH 5
+#    define __ARM_ARCH_ISA_ARM
+#    ifdef __ARM_ARCH_5TE__
+#      define __ARM_ARCH_ISA_THUMB 1
+#    endif
+#    define __ARM_FEATURE_CLZ
+#    define __ARM_FEATURE_DSP
+#  endif
+
+#  if defined (__ARM_ARCH_5T__) || defined (__ARM_ARCH_5__)
+#    define __ARM_ARCH 5
+#    define __ARM_ARCH_ISA_ARM
+#    ifdef __ARM_ARCH_5TE__
+#      define __ARM_ARCH_ISA_THUMB 1
+#    endif
+#    define __ARM_FEATURE_CLZ
+#  endif
+
+#  ifdef __ARM_ARCH_4T__
+#    define __ARM_ARCH 4
+#    define __ARM_ARCH_ISA_ARM
 #    define __ARM_ARCH_ISA_THUMB 1
 #  endif
-#  define __ARM_FEATURE_CLZ
-#  define __ARM_FEATURE_DSP
-#endif
 
-#if defined (__ARM_ARCH_5T__) || defined (__ARM_ARCH_5__)
-#  define __ARM_ARCH 5
-#  define __ARM_ARCH_ISA_ARM
-#  ifdef __ARM_ARCH_5TE__
-#    define __ARM_ARCH_ISA_THUMB 1
+#  ifdef __ARM_ARCH_4__
+#    define __ARM_ARCH 4
+#    define __ARM_ARCH_ISA_ARM
 #  endif
-#  define __ARM_FEATURE_CLZ
-#endif
 
-#ifdef __ARM_ARCH_4T__
-#  define __ARM_ARCH 4
-#  define __ARM_ARCH_ISA_ARM
-#  define __ARM_ARCH_ISA_THUMB 1
-#endif
+#  if defined (__ARM_ARCH_3__) || defined (__ARM_ARCH_3M__)
+#    define __ARM_ARCH 3
+#    define __ARM_ARCH_ISA_ARM
+#  endif
 
-#ifdef __ARM_ARCH_4__
-#  define __ARM_ARCH 4
-#  define __ARM_ARCH_ISA_ARM
-#endif
+#  ifdef __ARM_ARCH_2__
+#    define __ARM_ARCH 2
+#    define __ARM_ARCH_ISA_ARM
+#  endif
 
-#if defined (__ARM_ARCH_3__) || defined (__ARM_ARCH_3M__)
-#  define __ARM_ARCH 3
-#  define __ARM_ARCH_ISA_ARM
-#endif
+#  ifdef __ARMEB__
+#    define __ARM_BIG_ENDIAN
+#  endif
 
-#ifdef __ARM_ARCH_2__
-#  define __ARM_ARCH 2
-#  define __ARM_ARCH_ISA_ARM
-#endif
-
-#ifdef __ARMEB__
-#  define __ARM_BIG_ENDIAN
-#endif
-
-/* If we still don't know what the target architecture is, then we're
- * probably not using GCC.
- */
-
-#ifndef __ARM_ARCH
-#  error Unable to determine architecture version.
 #endif
 
 #endif /* __LIBS_LIBC_MACHINE_ARM_ARMV7R_GNU_ACLE_COMPAT_H */


### PR DESCRIPTION
## Summary

Don't redefined __ARM_ARCH_XXX when __ARM_ARCH defined

## Impact

NA

## Testing

CI pass