### PR TITLE
stm32/stm32f7 CANv1: protect TX buffer during CAN error frame generation

### DIFF
--- a/arch/arm/src/stm32/stm32_can_sock.c
+++ b/arch/arm/src/stm32/stm32_can_sock.c
@@ -1666,6 +1666,8 @@ static void stm32can_sceinterrupt_work(void *arg)
 
       memcpy(frame->data, data, CAN_ERR_DLC);
 
+      net_lock();
+
       /* Copy the buffer pointer to priv->dev..  Set amount of data
        * in priv->dev.d_len
        */
@@ -1687,6 +1689,7 @@ static void stm32can_sceinterrupt_work(void *arg)
        */
 
       priv->dev.d_buf = (uint8_t *)priv->txdesc;
+      net_unlock();
     }
 
   /* Re-enable CAN SCE interrupts */

--- a/arch/arm/src/stm32f7/stm32_can_sock.c
+++ b/arch/arm/src/stm32f7/stm32_can_sock.c
@@ -1690,6 +1690,8 @@ static void stm32can_sceinterrupt_work(void *arg)
 
       memcpy(frame->data, data, CAN_ERR_DLC);
 
+      net_lock();
+
       /* Copy the buffer pointer to priv->dev..  Set amount of data
        * in priv->dev.d_len
        */
@@ -1711,6 +1713,7 @@ static void stm32can_sceinterrupt_work(void *arg)
        */
 
       priv->dev.d_buf = (uint8_t *)priv->txdesc;
+      net_unlock();
     }
 
   /* Re-enable CAN SCE interrupts */


### PR DESCRIPTION
## Summary

stm32/stm32f7 CANv1: protect TX buffer during CAN error frame generation.
Follow up to eb240e0 (PR #8060)

## Impact

## Testing
CI
