### PR TITLE
sensors/bmi160.c: fix i2C read and write behavior

### DIFF
--- a/drivers/sensors/bmi160.c
+++ b/drivers/sensors/bmi160.c
@@ -303,7 +303,7 @@ static uint8_t bmi160_getreg8(FAR struct bmi160_dev_s *priv, uint8_t regaddr)
 
   msg[0].frequency = priv->freq;
   msg[0].addr      = priv->addr;
-  msg[0].flags     = 0;
+  msg[0].flags     = I2C_M_NOSTOP;
   msg[0].buffer    = &regaddr;
   msg[0].length    = 1;
 
@@ -422,7 +422,7 @@ static uint16_t bmi160_getreg16(FAR struct bmi160_dev_s *priv,
 
   msg[0].frequency = priv->freq;
   msg[0].addr      = priv->addr;
-  msg[0].flags     = 0;
+  msg[0].flags     = I2C_M_NOSTOP;
   msg[0].buffer    = &regaddr;
   msg[0].length    = 1;
 
@@ -482,7 +482,7 @@ static void bmi160_getregs(FAR struct bmi160_dev_s *priv, uint8_t regaddr,
 
   msg[0].frequency = priv->freq;
   msg[0].addr      = priv->addr;
-  msg[0].flags     = 0;
+  msg[0].flags     = I2C_M_NOSTOP;
   msg[0].buffer    = &regaddr;
   msg[0].length    = 1;
 


### PR DESCRIPTION
## Summary

There is a problem with the original driver reading and writing behavior, refer to the driver of mpu60x0 to make corresponding changes.

## Impact

## Testing

