### PR TITLE
net/netdev: Avoid hardcoded guardsize when using d_iob

### DIFF
--- a/arch/sim/src/sim/sim_netdriver.c
+++ b/arch/sim/src/sim/sim_netdriver.c
@@ -103,8 +103,7 @@ static void netdriver_send(struct net_driver_s *dev)
 {
   int devidx = (intptr_t)dev->d_private;
 #ifdef SIM_NETDEV_IOB_OFFLOAD
-  uint8_t *buf = &dev->d_iob->io_data[CONFIG_NET_LL_GUARDSIZE -
-                                      NET_LL_HDRLEN(dev)];
+  uint8_t *buf = NETLLBUF;
 #else
   uint8_t *buf = dev->d_buf;
 #endif

--- a/include/nuttx/net/netdev.h
+++ b/include/nuttx/net/netdev.h
@@ -161,8 +161,8 @@
  * headers
  */
 
-#define IPBUF(hl) ((FAR void *)\
-                   &dev->d_iob->io_data[CONFIG_NET_LL_GUARDSIZE + (hl)])
+#define IPBUF(hl) ((FAR void *)(IOB_DATA(dev->d_iob) + (hl)))
+#define NETLLBUF  (IPBUF(0) - NET_LL_HDRLEN(dev))
 
 #define IPv4BUF ((FAR struct ipv4_hdr_s *)IPBUF(0))
 #define IPv6BUF ((FAR struct ipv6_hdr_s *)IPBUF(0))

--- a/net/arp/arp.h
+++ b/net/arp/arp.h
@@ -84,10 +84,8 @@
 
 /* This is a helper pointer for accessing the contents of the IP header */
 
-#define ARPBUF   ((FAR struct arp_hdr_s *)\
-                  &dev->d_iob->io_data[CONFIG_NET_LL_GUARDSIZE])
-#define ARPIPBUF ((FAR struct arp_iphdr_s *)\
-                  &dev->d_iob->io_data[CONFIG_NET_LL_GUARDSIZE])
+#define ARPBUF   ((FAR struct arp_hdr_s *)IPBUF(0))
+#define ARPIPBUF ((FAR struct arp_iphdr_s *)IPBUF(0))
 
 /****************************************************************************
  * Public Types

--- a/net/arp/arp_input.c
+++ b/net/arp/arp_input.c
@@ -195,8 +195,7 @@ void arp_input(FAR struct net_driver_s *dev)
 
       /* Set the device buffer to l2 */
 
-      dev->d_buf = &dev->d_iob->io_data[CONFIG_NET_LL_GUARDSIZE -
-                                        NET_LL_HDRLEN(dev)];
+      dev->d_buf = NETLLBUF;
       arp_in(dev);
 
       dev->d_buf = buf;

--- a/net/can/can_input.c
+++ b/net/can/can_input.c
@@ -228,8 +228,7 @@ int can_input(FAR struct net_driver_s *dev)
 
       /* Set the device buffer to l2 */
 
-      dev->d_buf = &dev->d_iob->io_data[CONFIG_NET_LL_GUARDSIZE -
-                                        NET_LL_HDRLEN(dev)];
+      dev->d_buf = NETLLBUF;
       ret = can_in(dev);
 
       dev->d_buf = buf;

--- a/net/devif/devif.h
+++ b/net/devif/devif.h
@@ -237,9 +237,7 @@
  * headers
  */
 
-#define ETHBUF ((FAR struct eth_hdr_s *)\
-                &dev->d_iob->io_data[CONFIG_NET_LL_GUARDSIZE - \
-                                     NET_LL_HDRLEN(dev)])
+#define ETHBUF ((FAR struct eth_hdr_s *)NETLLBUF)
 
 /****************************************************************************
  * Public Type Definitions

--- a/net/devif/devif_iobsend.c
+++ b/net/devif/devif_iobsend.c
@@ -109,8 +109,7 @@ void devif_iob_send(FAR struct net_driver_s *dev, FAR struct iob_s *iob,
 
       dev->d_iob    = iob;
       dev->d_sndlen = len;
-      dev->d_buf    = &iob->io_data[CONFIG_NET_LL_GUARDSIZE -
-                                    NET_LL_HDRLEN(dev)];
+      dev->d_buf    = NETLLBUF;
     }
 
 #ifdef CONFIG_NET_TCP_WRBUFFER_DUMP

--- a/net/devif/devif_poll.c
+++ b/net/devif/devif_poll.c
@@ -1009,8 +1009,7 @@ int devif_poll(FAR struct net_driver_s *dev, devif_poll_callback_t callback)
 
           /* Copy l2 header (arp out) */
 
-          memcpy(buf, dev->d_iob->io_data +
-                 (CONFIG_NET_LL_GUARDSIZE - llhdrlen), llhdrlen);
+          memcpy(buf, IPBUF(-llhdrlen), llhdrlen);
 
           /* Restore flat buffer pointer */
 

--- a/net/devif/ipv4_input.c
+++ b/net/devif/ipv4_input.c
@@ -497,8 +497,7 @@ int ipv4_input(FAR struct net_driver_s *dev)
 
       /* Set the device buffer to l2 */
 
-      dev->d_buf = &dev->d_iob->io_data[CONFIG_NET_LL_GUARDSIZE -
-                                        NET_LL_HDRLEN(dev)];
+      dev->d_buf = NETLLBUF;
       ret = ipv4_in(dev);
 
       dev->d_buf = buf;

--- a/net/devif/ipv6_input.c
+++ b/net/devif/ipv6_input.c
@@ -621,8 +621,7 @@ int ipv6_input(FAR struct net_driver_s *dev)
 
       /* Set the device buffer to l2 */
 
-      dev->d_buf = &dev->d_iob->io_data[CONFIG_NET_LL_GUARDSIZE -
-                                        NET_LL_HDRLEN(dev)];
+      dev->d_buf = NETLLBUF;
       ret = ipv6_in(dev);
 
       dev->d_buf = buf;

--- a/net/ipforward/ipfwd_dropstats.c
+++ b/net/ipforward/ipfwd_dropstats.c
@@ -167,8 +167,7 @@ void ipfwd_dropstats(FAR struct forward_s *fwd)
   if (fwd->f_domain == PF_INET)
 #endif
     {
-      ipv4_dropstats((FAR struct ipv4_hdr_s *)
-                     &fwd->f_iob->io_data[CONFIG_NET_LL_GUARDSIZE]);
+      ipv4_dropstats((FAR struct ipv4_hdr_s *)IOB_DATA(fwd->f_iob));
     }
 #endif
 #ifdef CONFIG_NET_IPv6
@@ -176,8 +175,7 @@ void ipfwd_dropstats(FAR struct forward_s *fwd)
   else
 #endif
     {
-      ipv6_dropstats((FAR struct ipv6_hdr_s *)
-                     &fwd->f_iob->io_data[CONFIG_NET_LL_GUARDSIZE]);
+      ipv6_dropstats((FAR struct ipv6_hdr_s *)IOB_DATA(fwd->f_iob));
     }
 #endif
 }

--- a/net/netdev/netdev_input.c
+++ b/net/netdev/netdev_input.c
@@ -67,8 +67,8 @@ int netdev_input(FAR struct net_driver_s *dev,
                  devif_poll_callback_t callback, bool reply)
 {
   uint16_t llhdrlen = NET_LL_HDRLEN(dev);
-  unsigned int offset = CONFIG_NET_LL_GUARDSIZE - llhdrlen;
   FAR uint8_t *buf = dev->d_buf;
+  unsigned int offset;
   unsigned int l3l4len;
   int ret;
 
@@ -82,6 +82,7 @@ int netdev_input(FAR struct net_driver_s *dev,
 
   /* Copy l2 header to gruard area */
 
+  offset = dev->d_iob->io_offset - llhdrlen;
   memcpy(dev->d_iob->io_data + offset, buf, llhdrlen);
 
   /* Copy l3/l4 data to iob entry */

--- a/net/netdev/netdev_iob.c
+++ b/net/netdev/netdev_iob.c
@@ -73,14 +73,13 @@ int netdev_iob_prepare(FAR struct net_driver_s *dev, bool throttled,
       return -ENOMEM;
     }
 
-  /* Set the device buffer to l2 */
-
-  dev->d_buf = &dev->d_iob->io_data[CONFIG_NET_LL_GUARDSIZE -
-                                    NET_LL_HDRLEN(dev)];
-
   /* Update l2 gruard size */
 
   iob_reserve(dev->d_iob, CONFIG_NET_LL_GUARDSIZE);
+
+  /* Set the device buffer to l2 */
+
+  dev->d_buf = NETLLBUF;
 
   return OK;
 }
@@ -106,8 +105,7 @@ void netdev_iob_replace(FAR struct net_driver_s *dev, FAR struct iob_s *iob)
   /* Set new buffer */
 
   dev->d_iob = iob;
-  dev->d_buf = &dev->d_iob->io_data[CONFIG_NET_LL_GUARDSIZE -
-                                    NET_LL_HDRLEN(dev)];
+  dev->d_buf = NETLLBUF;
   dev->d_len = iob->io_pktlen;
 }
 

--- a/net/pkt/pkt_input.c
+++ b/net/pkt/pkt_input.c
@@ -146,8 +146,7 @@ int pkt_input(FAR struct net_driver_s *dev)
 
       /* Set the device buffer to l2 */
 
-      dev->d_buf = &dev->d_iob->io_data[CONFIG_NET_LL_GUARDSIZE -
-                                        NET_LL_HDRLEN(dev)];
+      dev->d_buf = NETLLBUF;
       ret = pkt_in(dev);
 
       dev->d_buf = buf;

--- a/net/tcp/tcp_input.c
+++ b/net/tcp/tcp_input.c
@@ -63,7 +63,7 @@
 #include "utils/utils.h"
 #include "tcp/tcp.h"
 
-#define IPDATA(hl) (dev->d_iob->io_data[CONFIG_NET_LL_GUARDSIZE + (hl)])
+#define IPDATA(hl) (*(FAR uint8_t *)IPBUF(hl))
 
 /****************************************************************************
  * Private Functions


### PR DESCRIPTION
## Summary
d_iob is always prepared with io_offset = CONFIG_NET_LL_GUARDSIZE, but hardcode CONFIG_NET_LL_GUARDSIZE is not good for flexibility, use io_offset (IOB_DATA macro) instead.

## Impact
Reduce usage of CONFIG_NET_LL_GUARDSIZE, to let flexible incoming IOB with different offset become possible.

## Testing
CI + simulator(ping / iperf)
