### PR TITLE
Revert "net: downgrade iob priority of input/udp/icmp to avoid blocking devif"

### DIFF
--- a/net/icmp/icmp_reply.c
+++ b/net/icmp/icmp_reply.c
@@ -146,7 +146,7 @@ void icmp_reply(FAR struct net_driver_s *dev, int type, int code)
 
       /* Re-prepare device buffer */
 
-      if (netdev_iob_prepare(dev, true, 0) != OK)
+      if (netdev_iob_prepare(dev, false, 0) != OK)
         {
           dev->d_len = 0;
           dev->d_iob = iob;
@@ -157,7 +157,7 @@ void icmp_reply(FAR struct net_driver_s *dev, int type, int code)
       /* Copy ipv4 header to device buffer */
 
       if (iob_trycopyin(dev->d_iob, (FAR void *)ipv4,
-                        IPv4_HDRLEN, 0, true) != IPv4_HDRLEN)
+                        IPv4_HDRLEN, 0, false) != IPv4_HDRLEN)
         {
           dev->d_len = 0;
           netdev_iob_release(dev);

--- a/net/icmp/icmp_sendmsg.c
+++ b/net/icmp/icmp_sendmsg.c
@@ -118,7 +118,7 @@ static void sendto_request(FAR struct net_driver_s *dev,
   iob_update_pktlen(dev->d_iob, IPv4_HDRLEN);
 
   iob_copyin(dev->d_iob, pstate->snd_buf,
-             pstate->snd_buflen, IPv4_HDRLEN, true);
+             pstate->snd_buflen, IPv4_HDRLEN, false);
 
   /* Initialize the IP header. */
 

--- a/net/icmpv6/icmpv6_reply.c
+++ b/net/icmpv6/icmpv6_reply.c
@@ -135,7 +135,7 @@ void icmpv6_reply(FAR struct net_driver_s *dev, int type, int code, int data)
 
       /* Re-prepare device buffer */
 
-      if (netdev_iob_prepare(dev, true, 0) != OK)
+      if (netdev_iob_prepare(dev, false, 0) != OK)
         {
           dev->d_len = 0;
           dev->d_iob = iob;
@@ -146,7 +146,7 @@ void icmpv6_reply(FAR struct net_driver_s *dev, int type, int code, int data)
       /* Copy ipv4 header to device buffer */
 
       if (iob_trycopyin(dev->d_iob, (FAR void *)ipv6,
-                        IPv6_HDRLEN, 0, true) != IPv6_HDRLEN)
+                        IPv6_HDRLEN, 0, false) != IPv6_HDRLEN)
         {
           dev->d_len = 0;
           netdev_iob_release(dev);

--- a/net/icmpv6/icmpv6_sendmsg.c
+++ b/net/icmpv6/icmpv6_sendmsg.c
@@ -120,7 +120,7 @@ static void sendto_request(FAR struct net_driver_s *dev,
   iob_update_pktlen(dev->d_iob, IPv6_HDRLEN);
 
   iob_copyin(dev->d_iob, pstate->snd_buf,
-             pstate->snd_buflen, IPv6_HDRLEN, true);
+             pstate->snd_buflen, IPv6_HDRLEN, false);
 
   /* Calculate the ICMPv6 checksum over the ICMPv6 header and payload. */
 

--- a/net/netdev/netdev_input.c
+++ b/net/netdev/netdev_input.c
@@ -74,7 +74,7 @@ int netdev_input(FAR struct net_driver_s *dev,
 
   /* Prepare iob buffer */
 
-  ret = netdev_iob_prepare(dev, true, 0);
+  ret = netdev_iob_prepare(dev, false, 0);
   if (ret != OK)
     {
       return ret;

--- a/net/netdev/netdev_iob.c
+++ b/net/netdev/netdev_iob.c
@@ -60,10 +60,10 @@ int netdev_iob_prepare(FAR struct net_driver_s *dev, bool throttled,
 
   if (dev->d_iob == NULL)
     {
-      dev->d_iob = net_iobtimedalloc(true, timeout);
-      if (dev->d_iob == NULL && throttled == false)
+      dev->d_iob = net_iobtimedalloc(false, timeout);
+      if (dev->d_iob == NULL && throttled)
         {
-          dev->d_iob = net_iobtimedalloc(false, timeout);
+          dev->d_iob = net_iobtimedalloc(true, timeout);
         }
     }
 

--- a/net/udp/udp_sendto_buffered.c
+++ b/net/udp/udp_sendto_buffered.c
@@ -795,7 +795,7 @@ ssize_t psock_udp_sendto(FAR struct socket *psock, FAR const void *buf,
       if (nonblock)
         {
           ret = iob_trycopyin(wrb->wb_iob, (FAR uint8_t *)buf,
-                              len, udpiplen, true);
+                              len, udpiplen, false);
         }
       else
         {
@@ -809,7 +809,7 @@ ssize_t psock_udp_sendto(FAR struct socket *psock, FAR const void *buf,
 
           blresult = net_breaklock(&count);
           ret = iob_copyin(wrb->wb_iob, (FAR uint8_t *)buf,
-                           len, udpiplen, true);
+                           len, udpiplen, false);
           if (blresult >= 0)
             {
               net_restorelock(count);
@@ -916,7 +916,7 @@ int psock_udp_cansend(FAR struct udp_conn_s *conn)
    * many more.
    */
 
-  if (udp_wrbuffer_test() < 0 || iob_navail(true) <= 0)
+  if (udp_wrbuffer_test() < 0 || iob_navail(false) <= 0)
     {
       return -EWOULDBLOCK;
     }

--- a/net/udp/udp_wrbuffer.c
+++ b/net/udp/udp_wrbuffer.c
@@ -263,7 +263,7 @@ FAR struct udp_wrbuffer_s *udp_wrbuffer_tryalloc(void)
 
   /* Now get the first I/O buffer for the write buffer structure */
 
-  wrb->wb_iob = iob_tryalloc(true);
+  wrb->wb_iob = iob_tryalloc(false);
   if (!wrb->wb_iob)
     {
       nerr("ERROR: Failed to allocate I/O buffer\n");


### PR DESCRIPTION
Reverts apache/nuttx#8029

Not the best way to fix the problem, and may possibly block receiving ACK of TCP, revert first and try to find another way to optimize this later.