### PR TITLE
vfs/poll: Remove POLLFILE and POLLSOCK NuttX specific extension

### DIFF
--- a/fs/vfs/fs_poll.c
+++ b/fs/vfs/fs_poll.c
@@ -86,34 +86,9 @@ static inline int poll_setup(FAR struct pollfd *fds, nfds_t nfds,
        * spec, that appears to be the correct behavior.
        */
 
-      switch (fds[i].events & POLLMASK)
+      if (fds[i].fd >= 0)
         {
-        case POLLFD:
-          if (fds[i].fd >= 0)
-            {
-              ret = poll_fdsetup(fds[i].fd, &fds[i], true);
-            }
-          break;
-
-        case POLLFILE:
-          if (fds[i].ptr != NULL)
-            {
-              ret = file_poll(fds[i].ptr, &fds[i], true);
-            }
-          break;
-
-#ifdef CONFIG_NET
-        case POLLSOCK:
-          if (fds[i].ptr != NULL)
-            {
-              ret = psock_poll(fds[i].ptr, &fds[i], true);
-            }
-          break;
-#endif
-
-        default:
-          ret = -EINVAL;
-          break;
+          ret = poll_fdsetup(fds[i].fd, &fds[i], true);
         }
 
       if (ret < 0)
@@ -126,25 +101,7 @@ static inline int poll_setup(FAR struct pollfd *fds, nfds_t nfds,
 
           for (j = 0; j < i; j++)
             {
-              switch (fds[j].events & POLLMASK)
-                {
-                case POLLFD:
-                  poll_fdsetup(fds[j].fd, &fds[j], false);
-                  break;
-
-                case POLLFILE:
-                  file_poll(fds[j].ptr, &fds[j], false);
-                  break;
-
-#ifdef CONFIG_NET
-                case POLLSOCK:
-                  psock_poll(fds[j].ptr, &fds[j], false);
-                  break;
-#endif
-
-                default:
-                  break;
-                }
+              poll_fdsetup(fds[j].fd, &fds[j], false);
             }
 
           /* Indicate an error on the file descriptor */
@@ -177,34 +134,9 @@ static inline int poll_teardown(FAR struct pollfd *fds, nfds_t nfds,
   *count = 0;
   for (i = 0; i < nfds; i++)
     {
-      switch (fds[i].events & POLLMASK)
+      if (fds[i].fd >= 0)
         {
-        case POLLFD:
-          if (fds[i].fd >= 0)
-            {
-              status = poll_fdsetup(fds[i].fd, &fds[i], false);
-            }
-          break;
-
-        case POLLFILE:
-          if (fds[i].ptr != NULL)
-            {
-              status = file_poll(fds[i].ptr, &fds[i], false);
-            }
-          break;
-
-#ifdef CONFIG_NET
-        case POLLSOCK:
-            if (fds[i].ptr != NULL)
-            {
-              status = psock_poll(fds[i].ptr, &fds[i], false);
-            }
-          break;
-#endif
-
-        default:
-          status = -EINVAL;
-          break;
+          status = poll_fdsetup(fds[i].fd, &fds[i], false);
         }
 
       if (status < 0)

--- a/include/sys/poll.h
+++ b/include/sys/poll.h
@@ -78,11 +78,6 @@
 #define POLLRDHUP    (0x10)  /* NuttX does not support shutdown(fd, SHUT_RD) */
 #define POLLNVAL     (0x20)
 
-#define POLLFD       (0x00)
-#define POLLFILE     (0x40)
-#define POLLSOCK     (0x80)
-#define POLLMASK     (0xC0)
-
 /****************************************************************************
  * Public Type Definitions
  ****************************************************************************/


### PR DESCRIPTION
## Summary

Since after https://github.com/apache/nuttx/pull/8022, we don't need expose file_poll to user space anymore.

## Impact

Remove the nuttx special extension

## Testing

Pass CI