### PR TITLE
sim/hci: add depends on config for SIM_HCISOCKET to fix compile break

### DIFF
--- a/arch/sim/Kconfig
+++ b/arch/sim/Kconfig
@@ -409,7 +409,7 @@ endmenu
 config SIM_HCISOCKET
 	bool "Attach Host Bluetooth"
 	default false
-	depends on HOST_LINUX
+	depends on HOST_LINUX && (UART_BTH4 || WIRELESS_BLUETOOTH)
 	---help---
 		Attached the local bluetooth device to the simulation
 		target via HCI_CHANNEL_USER. This gives NuttX full


### PR DESCRIPTION


## Summary
sim/hci: add depends on config for SIM_HCISOCKET to fix compile break

Signed-off-by: dongjiuzhu1 <dongjiuzhu1@xiaomi.com>

## Impact
N/A
## Testing
local test
