### PR TITLE
spresense: fix sdcard operation

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_sdhci.c
+++ b/arch/arm/src/cxd56xx/cxd56_sdhci.c
@@ -3360,11 +3360,6 @@ void cxd56_sdhci_mediachange(struct sdio_dev_s *dev)
 
   if (cdstatus != priv->cdstatus)
     {
-      if (priv->cdstatus & SDIO_STATUS_PRESENT)
-        {
-          priv->cbevents &= SDIOMEDIA_INSERTED;
-        }
-
       mediachange = 1;
     }
 

--- a/boards/arm/cxd56xx/spresense/src/cxd56_sdcard.c
+++ b/boards/arm/cxd56xx/spresense/src/cxd56_sdcard.c
@@ -174,16 +174,14 @@ static void board_sdcard_enable(void *arg)
         {
           g_sdhci.cb(true);
         }
+#else
+      /* Let the automounter know about the insertion event */
+
+      board_automount_event(0, board_sdcard_inserted(0));
 #endif /* CONFIG_CXD56_SDCARD_AUTOMOUNT */
 
       g_sdhci.initialized = true;
     }
-
-#ifdef CONFIG_CXD56_SDCARD_AUTOMOUNT
-  /* Let the automounter know about the insertion event */
-
-  board_automount_event(0, board_sdcard_inserted(0));
-#endif /* CONFIG_CXD56_SDCARD_AUTOMOUNT */
 
 release_frequency_lock:
 
@@ -229,14 +227,14 @@ static void board_sdcard_disable(void *arg)
 
       cxd56_sdhci_finalize(0);
 
+#ifdef CONFIG_CXD56_SDCARD_AUTOMOUNT
+      /* Let the automounter know about the removal event */
+
+      board_automount_event(0, board_sdcard_inserted(0));
+#endif /* CONFIG_CXD56_SDCARD_AUTOMOUNT */
+
       g_sdhci.initialized = false;
     }
-
-#ifdef CONFIG_CXD56_SDCARD_AUTOMOUNT
-  /* Let the automounter know about the insertion event */
-
-  board_automount_event(0, board_sdcard_inserted(0));
-#endif /* CONFIG_CXD56_SDCARD_AUTOMOUNT */
 }
 
 #ifdef CONFIG_MMCSD_HAVE_CARDDETECT
@@ -344,15 +342,12 @@ int board_sdcard_initialize(void)
   /* Configure Interrupt pin with internal pull-up */
 
   cxd56_pin_config(PINCONF_SDIO_CD_GPIO);
+  cxd56_gpioint_config(PIN_SDIO_CD, GPIOINT_PSEUDO_EDGE_BOTH,
+                       board_sdcard_detect_int, NULL);
 
   /* Handle the case when SD card is already inserted */
 
   board_sdcard_detect_int(PIN_SDIO_CD, NULL, NULL);
-
-  /* Configure Interrupt pin with internal pull-up */
-
-  cxd56_gpioint_config(PIN_SDIO_CD, GPIOINT_PSEUDO_EDGE_BOTH,
-                       board_sdcard_detect_int, NULL);
 
   /* Enabling Interrupt */
 

--- a/fs/mount/fs_automount.c
+++ b/fs/mount/fs_automount.c
@@ -167,7 +167,7 @@ static void automount_notify(FAR struct automounter_state_s *priv)
   ret = nxmutex_lock(&priv->lock);
   if (ret < 0)
     {
-      ierr("ERROR: nxmutex_lock failed: %d\n", ret);
+      ferr("ERROR: nxmutex_lock failed: %d\n", ret);
       return;
     }
 
@@ -207,7 +207,7 @@ static int automount_open(FAR struct file *filep)
   ret = nxmutex_lock(&priv->lock);
   if (ret < 0)
     {
-      ierr("ERROR: nxmutex_lock failed: %d\n", ret);
+      ferr("ERROR: nxmutex_lock failed: %d\n", ret);
       return ret;
     }
 
@@ -217,7 +217,7 @@ static int automount_open(FAR struct file *filep)
       sizeof(struct automounter_open_s));
   if (opriv == NULL)
     {
-      ierr("ERROR: Failed to allocate open structure\n");
+      ferr("ERROR: Failed to allocate open structure\n");
       ret = -ENOMEM;
       goto errout_with_lock;
     }
@@ -261,7 +261,7 @@ static int automount_close(FAR struct file *filep)
   ret = nxmutex_lock(&priv->lock);
   if (ret < 0)
     {
-      ierr("ERROR: nxmutex_lock failed: %d\n", ret);
+      ferr("ERROR: nxmutex_lock failed: %d\n", ret);
       return ret;
     }
 
@@ -274,7 +274,7 @@ static int automount_close(FAR struct file *filep)
   DEBUGASSERT(curr);
   if (curr == NULL)
     {
-      ierr("ERROR: Failed to find open entry\n");
+      ferr("ERROR: Failed to find open entry\n");
       ret = -ENOENT;
       goto errout_with_lock;
     }
@@ -328,7 +328,7 @@ static int automount_ioctl(FAR struct file *filep, int cmd,
   ret = nxmutex_lock(&priv->lock);
   if (ret < 0)
     {
-      ierr("ERROR: nxmutex_lock failed: %d\n", ret);
+      ferr("ERROR: nxmutex_lock failed: %d\n", ret);
       return ret;
     }
 
@@ -365,7 +365,7 @@ static int automount_ioctl(FAR struct file *filep, int cmd,
         break;
 
       default:
-        ierr("ERROR: Unrecognized command: %d\n", cmd);
+        ferr("ERROR: Unrecognized command: %d\n", cmd);
         ret = -ENOTTY;
         break;
     }


### PR DESCRIPTION
## Summary
Fix regression issue reported in https://github.com/sonydevworld/spresense/pull/536 after https://github.com/apache/nuttx/pull/7584

The root cause is that pin state check (GPIO read) was done before CD pin is configured to GPIO and was always returning `true`.

## Impact
Fix spresense SD card operation

## Testing
Tested with spresense board
