### PR TITLE
net/tcp: debug feature to drop the tx/rx packet

### DIFF
--- a/net/tcp/Kconfig
+++ b/net/tcp/Kconfig
@@ -233,4 +233,43 @@ config NET_SENDFILE
 		files out a TCP connection.
 
 endif # NET_TCP && !NET_TCP_NO_STACK
+
+if NET_STATISTICS
+
+config NET_TCP_DEBUG_DROP_RECV
+	bool "TCP/IP debug feature to drop receive packet"
+	default n
+	---help---
+		This is the debug feature to drop TCP/IP received packet
+
+if NET_TCP_DEBUG_DROP_RECV
+
+config NET_TCP_DEBUG_DROP_RECV_PROBABILITY
+	int "TCP/IP drop probability of received packet"
+	range 50 10000
+	default 50
+	---help---
+		This is the drop probability of received packet, Default: 1/50
+
+endif # NET_TCP_DEBUG_DROP_RECV
+
+config NET_TCP_DEBUG_DROP_SEND
+	bool "TCP/IP debug feature to drop send packet"
+	default n
+	---help---
+		This is the debug feature to drop TCP/IP send packet
+
+if NET_TCP_DEBUG_DROP_SEND
+
+config NET_TCP_DEBUG_DROP_SEND_PROBABILITY
+	int "TCP/IP drop probability of send packet"
+	range 50 10000
+	default 50
+	---help---
+		This is the drop probability of send packet, Default: 1/50
+
+endif # NET_TCP_DEBUG_DROP_SEND
+
+endif # NET_STATISTICS
+
 endmenu # TCP/IP Networking

--- a/net/tcp/tcp_send.c
+++ b/net/tcp/tcp_send.c
@@ -575,6 +575,34 @@ void tcp_synack(FAR struct net_driver_s *dev, FAR struct tcp_conn_s *conn,
   /* Complete the common portions of the TCP message */
 
   tcp_sendcommon(dev, conn, tcp);
+
+#if defined(CONFIG_NET_STATISTICS) && \
+    defined(CONFIG_NET_TCP_DEBUG_DROP_SEND)
+
+#pragma message \
+  "CONFIG_NET_TCP_DEBUG_DROP_SEND is selected, this is debug " \
+  "feature to drop the tcp send packet on the floor, " \
+  "please confirm the configuration again if you do not want " \
+  "debug the TCP stack."
+
+  /* Debug feature to drop the tcp received packet on the floor */
+
+  if ((flags & TCP_PSH) != 0)
+    {
+      if ((g_netstats.tcp.sent %
+          CONFIG_NET_TCP_DEBUG_DROP_SEND_PROBABILITY) == 0)
+        {
+          uint32_t seq = tcp_getsequence(tcp->seqno);
+
+          ninfo("TCP DROP SNDPKT: "
+                "[%d][%" PRIu32 " : %" PRIu32 " : %d]\n",
+                g_netstats.tcp.sent, seq, TCP_SEQ_ADD(seq, dev->d_sndlen),
+                dev->d_sndlen);
+
+          dev->d_len = 0;
+        }
+    }
+#endif
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

net/tcp: debug feature to drop the tx/rx packet

Add 2 configurations
1. Config to drop recived packet
```
CONFIG_NET_TCP_DEBUG_DROP_RECV=y
CONFIG_NET_TCP_DEBUG_DROP_RECV_PROBABILITY=50 /* Default drop probability is 1/50 */
```

2. Config to drop sent packet
 
```
CONFIG_NET_TCP_DEBUG_DROP_SEND=y
CONFIG_NET_TCP_DEBUG_DROP_SEND_PROBABILITY=50 /* Default drop probability is 1/50 */
```

Iperf2 client/server test on esp32c3:

Drop(1/50):
```
CONFIG_NET_TCP_DEBUG_DROP_SEND=y
CONFIG_NET_TCP_DEBUG_DROP_SEND_PROBABILITY=50  // Drop probability: 1/50
CONFIG_NET_TCP_DEBUG_DROP_RECV=y
CONFIG_NET_TCP_DEBUG_DROP_RECV_PROBABILITY=50  // Drop probability: 1/50

```
Drop(1/50) + OFO/SACK:
```
CONFIG_NET_TCP_DEBUG_DROP_SEND=y
CONFIG_NET_TCP_DEBUG_DROP_SEND_PROBABILITY=50  // Drop probability: 1/50
CONFIG_NET_TCP_DEBUG_DROP_RECV=y
CONFIG_NET_TCP_DEBUG_DROP_RECV_PROBABILITY=50  // Drop probability: 1/50

CONFIG_NET_TCP_OUT_OF_ORDER=y
CONFIG_NET_TCP_SELECTIVE_ACK=y
```


Iperf2 client/server test on esp32c3:
```
---------------------------------------------------------
|  TCP Config            | Server | Client |            |
|-------------------------------------------------------|
|  Original              |   12   |     9  |  Mbits/sec |
|  Drop(1/50)            |  0.6   |   0.3  |  Mbits/sec |
|  Drop(1/50) + OFO/SACK |    8   |     8  |  Mbits/sec |
---------------------------------------------------------
```
OFO/SACK depends on https://github.com/apache/nuttx/pull/8062

Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

