### PR TITLE
arch/sim: add arch/math.h

### DIFF
--- a/arch/sim/Kconfig
+++ b/arch/sim/Kconfig
@@ -14,6 +14,7 @@ config HOST_X86_64
 	bool "x86_64"
 	select ARCH_HAVE_STACKCHECK
 	select LIBC_ARCH_ELF_64BIT if LIBC_ARCH_ELF && !SIM_M32
+	select ARCH_HAVE_MATH_H
 
 config HOST_X86
 	bool "x86"

--- a/arch/sim/include/math.h
+++ b/arch/sim/include/math.h
@@ -1,0 +1,34 @@
+/****************************************************************************
+ * arch/sim/include/math.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_SIM_INCLUDE_MATH_H
+#define __ARCH_SIM_INCLUDE_MATH_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include_next <math.h>
+
+#ifdef __GLIBC__
+#undef __GLIBC__
+#endif
+
+#endif /* __ARCH_SIM_INCLUDE_MATH_H */


### PR DESCRIPTION
## Summary
Direct inclusion of <math.h> will introduce the ```__GLIBC__``` symbol into build. Added arch specific header to strip unneeded macros.
## Impact

## Testing

