### PR TITLE
fs: Support O_NOFOLLOW flag

### DIFF
--- a/fs/vfs/fs_open.c
+++ b/fs/vfs/fs_open.c
@@ -99,7 +99,7 @@ static int file_vopen(FAR struct file *filep, FAR const char *path,
 
   /* Get an inode for this file */
 
-  SETUP_SEARCH(&desc, path, false);
+  SETUP_SEARCH(&desc, path, (oflags & O_NOFOLLOW) != 0);
 
   ret = inode_find(&desc);
   if (ret < 0)
@@ -116,6 +116,11 @@ static int file_vopen(FAR struct file *filep, FAR const char *path,
 
   inode = desc.node;
   DEBUGASSERT(inode != NULL);
+
+  if (desc.nofollow && INODE_IS_SOFTLINK(inode))
+    {
+      return -ELOOP;
+    }
 
 #if defined(CONFIG_BCH) && \
     !defined(CONFIG_DISABLE_MOUNTPOINT) && \

--- a/include/fcntl.h
+++ b/include/fcntl.h
@@ -53,6 +53,7 @@
 #define O_DIRECT    (1 << 9)        /* Avoid caching, write directly to hardware */
 #define O_CLOEXEC   (1 << 10)       /* Close on execute */
 #define O_DIRECTORY (1 << 11)       /* Must be a directory */
+#define O_NOFOLLOW  (1 << 12)       /* Don't follow links */
 
 /* Unsupported, but required open flags */
 


### PR DESCRIPTION
## Summary

https://pubs.opengroup.org/onlinepubs/9699919799.2013edition/functions/open.html:
O_NOFOLLOW
If path names a symbolic link, fail and set errno to [ELOOP].

## Impact

new flag

## Testing

Pass CI
