### PR TITLE
Revert "arch: Don't free the context if the reference doesn't equal z…

### DIFF
--- a/arch/arm/src/stm32/stm32_i2c_v2.c
+++ b/arch/arm/src/stm32/stm32_i2c_v2.c
@@ -2804,6 +2804,7 @@ int stm32_i2cbus_uninitialize(struct i2c_master_s *dev)
   if (--priv->refs)
     {
       nxmutex_unlock(&priv->lock);
+      kmm_free(dev);
       return OK;
     }
 

--- a/arch/arm/src/stm32f0l0g0/stm32_i2c.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_i2c.c
@@ -2803,6 +2803,7 @@ int stm32_i2cbus_uninitialize(struct i2c_master_s *dev)
   if (--priv->refs)
     {
       nxmutex_unlock(&priv->lock);
+      kmm_free(dev);
       return OK;
     }
 

--- a/arch/arm/src/stm32f7/stm32_i2c.c
+++ b/arch/arm/src/stm32f7/stm32_i2c.c
@@ -2842,6 +2842,7 @@ int stm32_i2cbus_uninitialize(struct i2c_master_s *dev)
   if (--priv->refs)
     {
       nxmutex_unlock(&priv->lock);
+      kmm_free(dev);
       return OK;
     }
 

--- a/arch/arm/src/stm32h7/stm32_i2c.c
+++ b/arch/arm/src/stm32h7/stm32_i2c.c
@@ -2805,6 +2805,7 @@ int stm32_i2cbus_uninitialize(struct i2c_master_s *dev)
   if (--priv->refs)
     {
       nxmutex_unlock(&priv->lock);
+      kmm_free(dev);
       return OK;
     }
 

--- a/arch/arm/src/stm32l4/stm32l4_1wire.c
+++ b/arch/arm/src/stm32l4/stm32l4_1wire.c
@@ -1247,6 +1247,7 @@ int stm32l4_1wireuninitialize(struct onewire_dev_s *dev)
   if (--priv->refs)
     {
       nxmutex_unlock(&priv->lock);
+      kmm_free(priv);
       return OK;
     }
 

--- a/arch/arm/src/stm32l4/stm32l4_i2c.c
+++ b/arch/arm/src/stm32l4/stm32l4_i2c.c
@@ -3007,6 +3007,7 @@ int stm32l4_i2cbus_uninitialize(struct i2c_master_s *dev)
   if (--priv->refs)
     {
       nxmutex_unlock(&priv->lock);
+      kmm_free(dev);
       return OK;
     }
 


### PR DESCRIPTION
…ero"

struct stm32_i2c_inst_s instance is allocated on every call to stm32_i2cbus_initialize, and that instance is supposed to be deleted on every call to stm32_i2cbus_uninitialize.

The "refs" counter just keeps track on when the last one is deleted, and everything is unregisterd/disabled after that.

This reverts commit 8098c80338eacf0649e3f08c6faff27bdd769334.

## Summary

I suggest reverting this patch.

Memory leak issue found a on an st32f7 platform which frequently calls stm32_i2cbus_initialize and stm32_i2cbus_uninitialize

The whole malloc in these drivers is IMHO useless. For a more proper cleanup, something like this can be considered:

https://github.com/tiiuae/nuttx/pull/80/commits/d4db1ed31ffc07d90eeffee205f4ad64239d66ea

## Impact

Fixes memory leak &eventually out-of-memory condition when a driver initilization fails and is re-tried periodically for some time.

## Testing

Tested on stm32f7 (pixhawk 5x)
