### PR TITLE
libc: Add the mininal sys/cdefs.h

### DIFF
--- a/include/sys/cdefs.h
+++ b/include/sys/cdefs.h
@@ -1,0 +1,55 @@
+/****************************************************************************
+ * include/sys/cdefs.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_SYS_CDEFS_H
+#define __INCLUDE_SYS_CDEFS_H
+
+/****************************************************************************
+ * Preprocessor definitions
+ ****************************************************************************/
+
+#if defined(__cplusplus)
+#  define __BEGIN_DECLS extern "C" {
+#  define __END_DECLS }
+#else
+#  define __BEGIN_DECLS
+#  define __END_DECLS
+#endif
+
+/* The __CONCAT macro is used to concatenate parts of symbol names, e.g.
+ * with "#define OLD(foo) __CONCAT(old,foo)", OLD(foo) produces oldfoo.
+ * The __CONCAT macro is a bit tricky to use if it must work in non-ANSI
+ * mode -- there must be no spaces between its arguments, and for nested
+ * __CONCAT's, all the __CONCAT's must be at the left.  __CONCAT can also
+ * concatenate double-quoted strings produced by the __STRING macro, but
+ * this only works with ANSI C.
+ *
+ * __XSTRING is like __STRING, but it expands any macros in its argument
+ * first.  It is only available with ANSI C.
+ */
+
+#define __CONCAT1(x,y)  x ## y
+#define __CONCAT(x,y)   __CONCAT1(x,y)
+#define ___CONCAT(x,y)  __CONCAT(x,y)
+
+#define __STRING(x)     #x
+#define ___STRING(x)    __STRING(x)
+
+#endif /* __INCLUDE_SYS_CDEFS_H */


### PR DESCRIPTION
## Summary

since most libc implementation contain sys/cdefs.h: https://android.googlesource.com/platform/bionic/+/master/libc/include/sys/cdefs.h https://github.com/bminor/glibc/blob/master/misc/sys/cdefs.h https://github.com/bminor/newlib/blob/master/newlib/libc/include/sys/cdefs.h https://github.com/freebsd/freebsd-src/blob/main/sys/sys/cdefs.h https://github.com/openbsd/src/blob/master/sys/sys/cdefs.h

## Impact

new header file

## Testing

Pass CI