### PR TITLE
sched/wqueue: do work_cancel when worker is not null

### DIFF
--- a/sched/wqueue/kwork_queue.c
+++ b/sched/wqueue/kwork_queue.c
@@ -118,7 +118,10 @@ int work_queue(int qid, FAR struct work_s *work, worker_t worker,
 
   /* Remove the entry from the timer and work queue. */
 
-  work_cancel(qid, work);
+  if (work->worker != NULL)
+    {
+      work_cancel(qid, work);
+    }
 
   /* Initialize the work structure. */
 


### PR DESCRIPTION
## Summary

work_cancel is called only when the worker is not empty, which can optimize the performance of  the work_queue.

## Impact

NA

## Testing

sabre-6quad:nsh