### PR TITLE
net/tcp: correct behavior of SO_LINGER 

### DIFF
--- a/net/socket/Kconfig
+++ b/net/socket/Kconfig
@@ -43,7 +43,6 @@ config NET_SOLINGER
 	bool "SO_LINGER socket option"
 	default n
 	depends on NET_TCP_WRITE_BUFFERS || NET_UDP_WRITE_BUFFERS
-	select NET_TCP_NOTIFIER if NET_TCP
 	select NET_UDP_NOTIFIER if NET_UDP
 	---help---
 		Enable or disable support for the SO_LINGER socket option.  Requires

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -233,7 +233,9 @@ struct tcp_conn_s
   uint16_t tx_unacked;    /* Number bytes sent but not yet ACKed */
 #endif
   uint16_t flags;         /* Flags of TCP-specific options */
-
+#ifdef CONFIG_NET_SOLINGER
+  sclock_t ltimeout;      /* Linger timeout expiration */
+#endif
   /* If the TCP socket is bound to a local address, then this is
    * a reference to the device that routes traffic on the corresponding
    * network.
@@ -851,6 +853,27 @@ void tcp_poll(FAR struct net_driver_s *dev, FAR struct tcp_conn_s *conn);
  ****************************************************************************/
 
 void tcp_timer(FAR struct net_driver_s *dev, FAR struct tcp_conn_s *conn);
+
+/****************************************************************************
+ * Name: tcp_update_timer
+ *
+ * Description:
+ *   Update the TCP timer for the provided TCP connection,
+ *   The timeout is accurate
+ *
+ * Input Parameters:
+ *   conn - The TCP "connection" to poll for TX data
+ *
+ * Returned Value:
+ *   None
+ *
+ * Assumptions:
+ *   conn is not NULL.
+ *   The connection (conn) is bound to the polling device (dev).
+ *
+ ****************************************************************************/
+
+void tcp_update_timer(FAR struct tcp_conn_s *conn);
 
 /****************************************************************************
  * Name: tcp_update_retrantimer

--- a/net/udp/udp_close.c
+++ b/net/udp/udp_close.c
@@ -85,7 +85,8 @@ int udp_close(FAR struct socket *psock)
 
   if (_SO_GETOPT(conn->sconn.s_options, SO_LINGER))
     {
-      timeout = _SO_TIMEOUT(conn->sconn.s_linger);
+      timeout = (conn->sconn.s_linger == 0) ? 0 :
+                _SO_TIMEOUT(conn->sconn.s_linger);
     }
 #endif
 


### PR DESCRIPTION

## Summary

net/tcp: correct behavior of SO_LINGER

1. Remove tcp_txdrain() from close() to avoid indefinitely block
2. Send TCP_RST immediately if linger timeout

Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

enable CONFIG_NET_SOLINGER
iperf tcp client 

```
 struct linger ling;

 ling.l_onoff  = 1;
 ling.l_linger = 0;     /* timeout is seconds */

 if (setsockopt(sockfd, SOL_SOCKET, SO_LINGER,
                &ling, sizeof(struct linger)) < 0)
   {
     printf("server: setsockopt SO_LINGER failure: %d\n", errno);
     return -1;
   }
```
