### PR TITLE
mm/mm_heap/tlsf: support global mempool to optimize small block performance

### DIFF
--- a/include/nuttx/mm/mempool.h
+++ b/include/nuttx/mm/mempool.h
@@ -281,13 +281,14 @@ void mempool_procfs_unregister(FAR struct mempool_procfs_entry_s *entry);
  *   relationship between the each block size of mempool in multiple mempool.
  *
  * Input Parameters:
- *   name        - The name of memory pool.
- *   poolsize    - The block size array for pools in multiples pool.
- *   npools      - How many pools in multiples pool.
- *   alloc       - The alloc memory function for multiples pool.
- *   free        - The free memory function for multiples pool.
- *   arg         - The alloc & free memory fuctions used arg.
- *   expandsize  - The expend mempry for all pools in multiples pool.
+ *   name            - The name of memory pool.
+ *   poolsize        - The block size array for pools in multiples pool.
+ *   npools          - How many pools in multiples pool.
+ *   alloc           - The alloc memory function for multiples pool.
+ *   free            - The free memory function for multiples pool.
+ *   arg             - The alloc & free memory fuctions used arg.
+ *   expandsize      - The expend mempry for all pools in multiples pool.
+ *   dict_expendsize - The expend number for multiple dictnoary
  *
  * Returned Value:
  *   Return an initialized multiple pool pointer on success,
@@ -302,7 +303,8 @@ mempool_multiple_init(FAR const char *name,
                       FAR size_t *poolsize, size_t npools,
                       mempool_multiple_alloc_t alloc,
                       mempool_multiple_free_t free,
-                      FAR void *arg, size_t expandsize);
+                      FAR void *arg, size_t expandsize,
+                      size_t dict_expendsize);
 
 /****************************************************************************
  * Name: mempool_multiple_alloc

--- a/mm/Kconfig
+++ b/mm/Kconfig
@@ -196,6 +196,13 @@ config MM_HEAP_MEMPOOL_EXPAND
 		This size describes the size of each expansion of each memory
 		pool with insufficient memory in the multi-level memory pool.
 
+config MM_HEAP_MEMPOOL_DICTIONARY_EXPAND
+	int "The expand size for multiple mempool's dictonary"
+	default MM_HEAP_MEMPOOL_EXPAND
+	depends on MM_HEAP_MEMPOOL_THRESHOLD != 0
+	---help---
+		This size describes the multiple mempool dictonary expend.
+
 config FS_PROCFS_EXCLUDE_MEMPOOL
 	bool "Exclude mempool"
 	default DEFAULT_SMALL

--- a/mm/mempool/mempool.c
+++ b/mm/mempool/mempool.c
@@ -317,7 +317,7 @@ out_with_lock:
 
 void mempool_free(FAR struct mempool_s *pool, FAR void *blk)
 {
-  irqstate_t flags;
+  irqstate_t flags = spin_lock_irqsave(&pool->lock);
 #if CONFIG_MM_BACKTRACE >= 0
   size_t blocksize =  ALIGN_UP(pool->blocksize +
                                sizeof(struct mempool_backtrace_s),
@@ -331,8 +331,6 @@ void mempool_free(FAR struct mempool_s *pool, FAR void *blk)
 
   pool->nalloc--;
 #endif
-
-  flags = spin_lock_irqsave(&pool->lock);
 
   if (pool->interruptsize > blocksize)
     {

--- a/mm/mempool/mempool_multiple.c
+++ b/mm/mempool/mempool_multiple.c
@@ -253,7 +253,8 @@ mempool_multiple_get_dict(FAR struct mempool_multiple_s *mpool,
  *   free            - The free memory function for multiples pool.
  *   arg             - The alloc & free memory fuctions used arg.
  *   expandsize      - The expend mempry for all pools in multiples pool.
- *   dict_expendsize -  The expend size for multiple dictnoary
+ *   dict_expendsize - The expend size for multiple dictnoary.
+ *   calibrate       - Whether to calibrate when counting memory usage.
  * Returned Value:
  *   Return an initialized multiple pool pointer on success,
  *   otherwise NULL is returned.
@@ -266,7 +267,7 @@ mempool_multiple_init(FAR const char *name,
                       mempool_multiple_alloc_t alloc,
                       mempool_multiple_free_t free,
                       FAR void *arg, size_t expandsize,
-                      size_t dict_expendsize)
+                      size_t dict_expendsize, bool calibrate)
 {
   FAR struct mempool_multiple_s *mpool;
   FAR struct mempool_s *pools;
@@ -325,6 +326,7 @@ mempool_multiple_init(FAR const char *name,
       pools[i].priv = mpool;
       pools[i].alloc = mempool_multiple_alloc_callback;
       pools[i].free = mempool_multiple_free_callback;
+      pools[i].calibrate = calibrate;
 
       ret = mempool_init(pools + i, name);
       if (ret < 0)

--- a/mm/mm_heap/mm_initialize.c
+++ b/mm/mm_heap/mm_initialize.c
@@ -256,9 +256,10 @@ FAR struct mm_heap_s *mm_initialize(FAR const char *name,
     }
 
   heap->mm_mpool = mempool_multiple_init(name, poolsize, MEMPOOL_NPOOLS,
-                                    (mempool_multiple_alloc_t)mm_memalign,
-                                    (mempool_multiple_free_t)mm_free, heap,
-                                    CONFIG_MM_HEAP_MEMPOOL_EXPAND);
+                                  (mempool_multiple_alloc_t)mm_memalign,
+                                  (mempool_multiple_free_t)mm_free, heap,
+                                  CONFIG_MM_HEAP_MEMPOOL_EXPAND,
+                                  CONFIG_MM_HEAP_MEMPOOL_DICTIONARY_EXPAND);
 #endif
 
   return heap;

--- a/mm/mm_heap/mm_initialize.c
+++ b/mm/mm_heap/mm_initialize.c
@@ -259,7 +259,8 @@ FAR struct mm_heap_s *mm_initialize(FAR const char *name,
                                   (mempool_multiple_alloc_t)mm_memalign,
                                   (mempool_multiple_free_t)mm_free, heap,
                                   CONFIG_MM_HEAP_MEMPOOL_EXPAND,
-                                  CONFIG_MM_HEAP_MEMPOOL_DICTIONARY_EXPAND);
+                                  CONFIG_MM_HEAP_MEMPOOL_DICTIONARY_EXPAND,
+                                  true);
 #endif
 
   return heap;

--- a/mm/tlsf/mm_tlsf.c
+++ b/mm/tlsf/mm_tlsf.c
@@ -801,9 +801,10 @@ FAR struct mm_heap_s *mm_initialize(FAR const char *name,
     }
 
   heap->mm_mpool = mempool_multiple_init(name, poolsize, MEMPOOL_NPOOLS,
-                                    (mempool_multiple_alloc_t)mm_memalign,
-                                    (mempool_multiple_free_t)mm_free, heap,
-                                    CONFIG_MM_HEAP_MEMPOOL_EXPAND);
+                                  (mempool_multiple_alloc_t)mm_memalign,
+                                  (mempool_multiple_free_t)mm_free, heap,
+                                  CONFIG_MM_HEAP_MEMPOOL_EXPAND,
+                                  CONFIG_MM_HEAP_MEMPOOL_DICTIONARY_EXPAND);
 #endif
 
   return heap;

--- a/mm/tlsf/mm_tlsf.c
+++ b/mm/tlsf/mm_tlsf.c
@@ -804,7 +804,8 @@ FAR struct mm_heap_s *mm_initialize(FAR const char *name,
                                   (mempool_multiple_alloc_t)mm_memalign,
                                   (mempool_multiple_free_t)mm_free, heap,
                                   CONFIG_MM_HEAP_MEMPOOL_EXPAND,
-                                  CONFIG_MM_HEAP_MEMPOOL_DICTIONARY_EXPAND);
+                                  CONFIG_MM_HEAP_MEMPOOL_DICTIONARY_EXPAND,
+                                  true);
 #endif
 
   return heap;


### PR DESCRIPTION
## Summary
This PR is based on https://github.com/apache/nuttx/pull/8116.

Support global mempool to optimize small block performance for default mm_heap and tlsf manager, you can enable this function by config CONFIG_MM_HEAP_MEMPOOL_THRESHOLD and CONFIG_MM_HEAP_MEMPOOL_EXPAND.



* why need to add this mechanism?
    There are many small memory block in NuttX system, eg: struct tcb_s, struct inode, etc, and several disadvantages about them: 
1.Their frequent allocate and free cause the system memory fragmentation.
2.Since each memory block has an overhead, the utilization of small memory blocks is relatively low, which will cause memory waste.
So we can use mempool to alloc smallo block, to improve alloc speed and utilization, to reduce fragmentation.

* how to enable or config this mechanism?
1. CONFIG_MM_HEAP_MEMPOOL_THRESHOLD is a size of threshold to avoid using multiple mempool in heap, If the size of the memory requested by the user is less than the threshold, the memory will be requested from the multiple mempool by default, default value is disable.
2. CONFIG_MM_HEAP_MEMPOOL_EXPAND is a expand size for each mempool in multiple mempool, This size describes the size of each expansion of each memory pool with insufficient memory in the multi-level memory pool. default value is 4K.
3. so, when CONFIG_MM_HEAP_MEMPOOL_THRESHOLD is 256 and CONFIG_MM_HEAP_MEMPOOL_EXPAND is 4K, 
The system allocates memory lower than 256 from the multi-level memory pool, and allocates memory higher than 256 from the default heap manager(mm_heap/tlsf) and when the multi-level memory pool is insufficient, the size of each expansion is 4K.

* Profile for this mechanism
We test based on the environment of the Vela watch AP core, and runs three-party applications, monkey for gui, and graphical lunch on the ap. Among them, the three-party applications use memory very frequently and under great pressure.

test items: (record the free command output log)
1. default (mm_heap default manager), without enabling mempool and tlsf, run the monkey for testing.
2. default with mempool (CONFIG_MM_HEAP_MEMPOOL_THRESHOLD=256, CONFIG_MM_HEAP_MEMPOOL_EXPAND=1024) 
3. default with mempool (CONFIG_MM_HEAP_MEMPOOL_THRESHOLD=256, CONFIG_MM_HEAP_MEMPOOL_EXPAND=2048) 
4. default with mempool (CONFIG_MM_HEAP_MEMPOOL_THRESHOLD=256, CONFIG_MM_HEAP_MEMPOOL_EXPAND=4096) 
5. default with mempool (CONFIG_MM_HEAP_MEMPOOL_THRESHOLD=256, CONFIG_MM_HEAP_MEMPOOL_EXPAND=8192) 
6. tlsf manager with mempool(CONFIG_MM_HEAP_MEMPOOL_THRESHOLD=256, CONFIG_MM_HEAP_MEMPOOL_EXPAND=1024)
7.  tlsf manager with mempool(CONFIG_MM_HEAP_MEMPOOL_THRESHOLD=256, CONFIG_MM_HEAP_MEMPOOL_EXPAND=2048)
8. tlsf manager with mempool(CONFIG_MM_HEAP_MEMPOOL_THRESHOLD=256, CONFIG_MM_HEAP_MEMPOOL_EXPAND=4096/4096 with addr align8)
9. tlsf manager with mempool(CONFIG_MM_HEAP_MEMPOOL_THRESHOLD=256, CONFIG_MM_HEAP_MEMPOOL_EXPAND=8192/8192 with addr align8)

test result charts:
The data for all charts is based on the output of the free command
* nfree(number of free blocks)
p1:
![image](https://user-images.githubusercontent.com/70748590/212607232-0d45f4ab-e992-4704-b2d5-4e0a486d82f9.png)
* nused(number of used blocks)
p2:
![image](https://user-images.githubusercontent.com/70748590/212607444-c74f9a1f-6bca-4e75-a059-d31da37aeee4.png)
p3:
![image](https://user-images.githubusercontent.com/70748590/212607452-8e7fbc43-b1f0-47b5-b220-d8e8c8aa4b54.png)
* largest(the largest size of  free block)
p4:
![image](https://user-images.githubusercontent.com/70748590/212607546-dec01452-7fa1-4422-8143-ec7a84d6bfdd.png)
* free(the free memory size of system)
p5:
![image](https://user-images.githubusercontent.com/70748590/212607633-42a11c44-cbb0-48b7-8864-eb570c7ba7c0.png)
* used(the allocaed memory size of system)
p6:
![image](https://user-images.githubusercontent.com/70748590/212607670-ce095de9-1f05-4ce2-9d48-0108c91b76d5.png)

test result:
1. From the comparison of the above figure, tlsf has relatively high fragmentation in each configuration, which is worse than NuttX's native heap manager.
2. When the NuttX native heap manager and mempool manage the heap together, the mempool is used for management when the heap is less than 256 bytes, and the performance is the best when the mempool is insufficient and expanded to 4K each time, as shown in the **yellow** line in the figure.


## Impact
Add global multi mempool to optimize small block performance
## Testing
Vela CI test.
