### PR TITLE
mm/tlsf: fix compile error/warning on tlsf

### DIFF
--- a/mm/tlsf/Make.defs
+++ b/mm/tlsf/Make.defs
@@ -38,7 +38,7 @@ distclean::
 
 CSRCS += mm_tlsf.c tlsf.c
 
-CFLAGS += ${shell $(DEFINE) "$(CC)" tlsf_printf=if(0)}
+CFLAGS += ${shell $(DEFINE) "$(CC)" tlsf_printf=\"if\(0\)printf\"}
 
 # Add the tlsf directory to the build
 

--- a/tools/Directories.mk
+++ b/tools/Directories.mk
@@ -165,10 +165,7 @@ CLEANDIRS += openamp
 endif
 
 ifeq ($(CONFIG_MM_TLSF_MANAGER),y)
-KERNDEPDIRS += mm
 CONTEXTDIRS += mm
-else
-CLEANDIRS += mm
 endif
 
 CLEANDIRS += $(KERNDEPDIRS) $(USERDEPDIRS)


### PR DESCRIPTION
## Summary

mm/tlsf: fix compile error/warning on tlsf

1.
make[1]: Entering directory '/home/archer/code/nuttx/n2/incubator-nuttx/mm'
/bin/sh: 1: Syntax error: "(" unexpected

2.
tools/Unix.mk:681: warning: overriding recipe for target 'mm_clean'
tools/Unix.mk:681: warning: ignoring old recipe for target 'mm_clean'
tools/Unix.mk:700: warning: overriding recipe for target 'mm_distclean'
tools/Unix.mk:700: warning: ignoring old recipe for target 'mm_distclean'

Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

enable CONFIG_MM_TLSF_MANAGER