### PR TITLE
[PATCH1]mm/heap/tlsf: add global multi-mempool for heap manager and tlsf

### DIFF
--- a/arch/sim/src/sim/sim_backtrace.c
+++ b/arch/sim/src/sim/sim_backtrace.c
@@ -33,10 +33,12 @@
  * Public Functions
  ****************************************************************************/
 
+nosanitize_address
 int up_backtrace(struct tcb_s *tcb, void **buffer, int size, int skip)
 {
   void *buf[skip + size];
   int ret = 0;
+  int i;
 
   if (tcb == running_task())
     {
@@ -49,7 +51,10 @@ int up_backtrace(struct tcb_s *tcb, void **buffer, int size, int skip)
     }
 
   ret -= skip;
-  memcpy(buffer, &buf[skip], ret * sizeof(void *));
+  for (i = 0; i < ret; i++)
+    {
+      buffer[i] = buf[skip + i];
+    }
 
   return ret;
 }

--- a/mm/Kconfig
+++ b/mm/Kconfig
@@ -172,6 +172,22 @@ config MM_SHM
 		Build in support for the shared memory interfaces shmget(), shmat(),
 		shmctl(), and shmdt().
 
+config MM_HEAP_MEMPOOL_THRESHOLD
+	int "The size of threshold to avoid using multiple mempool in heap"
+	default 0
+	---help---
+		If the size of the memory requested by the user is less
+		than the threshold, the memory will be requested from the
+		multiple mempool by default.
+
+config MM_HEAP_MEMPOOL_EXPAND
+	int "The expand size for each mempool in multiple mempool"
+	default 1024
+	depends on MM_HEAP_MEMPOOL_THRESHOLD != 0
+	---help---
+		This size describes the size of each expansion of each memory
+		pool with insufficient memory in the multi-level memory pool.
+
 config FS_PROCFS_EXCLUDE_MEMPOOL
 	bool "Exclude mempool"
 	default DEFAULT_SMALL

--- a/mm/mm_heap/mm.h
+++ b/mm/mm_heap/mm.h
@@ -31,6 +31,7 @@
 #include <nuttx/sched.h>
 #include <nuttx/fs/procfs.h>
 #include <nuttx/lib/math32.h>
+#include <nuttx/mm/mempool.h>
 
 #include <assert.h>
 #include <execinfo.h>
@@ -133,6 +134,11 @@
 
 #define SIZEOF_MM_FREENODE sizeof(struct mm_freenode_s)
 
+#if CONFIG_MM_HEAP_MEMPOOL_THRESHOLD != 0
+#  define MM_IS_FROM_MEMPOOL(mem) \
+  ((*((FAR mmsize_t *)mem - 1) & MM_ALLOC_BIT) == 0)
+#endif
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/
@@ -224,6 +230,14 @@ struct mm_heap_s
    */
 
   FAR struct mm_delaynode_s *mm_delaylist[CONFIG_SMP_NCPUS];
+
+  /* The is a multiple mempool of the heap */
+
+#if CONFIG_MM_HEAP_MEMPOOL_THRESHOLD != 0
+  struct mempool_multiple_s mm_mpool;
+  struct mempool_s mm_pools[CONFIG_MM_HEAP_MEMPOOL_THRESHOLD /
+                            sizeof(uintptr_t)];
+#endif
 
 #if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_MEMINFO)
   struct procfs_meminfo_entry_s mm_procfs;

--- a/mm/mm_heap/mm.h
+++ b/mm/mm_heap/mm.h
@@ -82,23 +82,21 @@
      do \
        { \
          FAR struct mm_allocnode_s *tmp = (FAR struct mm_allocnode_s *)(ptr); \
-         kasan_unpoison(tmp, SIZEOF_MM_ALLOCNODE); \
          FAR struct tcb_s *tcb; \
          tmp->pid = gettid(); \
          tcb = nxsched_get_tcb(tmp->pid); \
          if ((heap)->mm_procfs.backtrace || (tcb && tcb->flags & TCB_FLAG_HEAP_DUMP)) \
            { \
              int n = backtrace(tmp->backtrace, CONFIG_MM_BACKTRACE); \
-             if (n < CONFIG_MM_BACKTRACE) \
+             while (n < CONFIG_MM_BACKTRACE) \
                { \
-                 tmp->backtrace[n] = 0; \
+                 tmp->backtrace[n++] = NULL; \
                } \
            } \
          else \
            { \
              tmp->backtrace[0] = 0; \
            } \
-         kasan_poison(tmp, SIZEOF_MM_ALLOCNODE); \
        } \
      while (0)
 #else

--- a/mm/mm_heap/mm.h
+++ b/mm/mm_heap/mm.h
@@ -148,7 +148,7 @@
 #ifdef CONFIG_MM_SMALL
 typedef uint16_t mmsize_t;
 #else
-typedef uint32_t mmsize_t;
+typedef size_t mmsize_t;
 #endif
 
 /* This describes an allocated chunk.  An allocated chunk is

--- a/mm/mm_heap/mm_free.c
+++ b/mm/mm_heap/mm_free.c
@@ -82,6 +82,14 @@ void mm_free(FAR struct mm_heap_s *heap, FAR void *mem)
       return;
     }
 
+#if CONFIG_MM_HEAP_MEMPOOL_THRESHOLD != 0
+  if (MM_IS_FROM_MEMPOOL(mem))
+    {
+      mempool_multiple_free(&heap->mm_mpool, mem);
+      return;
+    }
+#endif
+
   if (mm_lock(heap) < 0)
     {
       /* Meet -ESRCH return, which means we are in situations

--- a/mm/mm_heap/mm_initialize.c
+++ b/mm/mm_heap/mm_initialize.c
@@ -226,6 +226,20 @@ FAR struct mm_heap_s *mm_initialize(FAR const char *name,
 #  endif
 #endif
 
+  /* Initialize the multiple mempool in heap */
+
+#if CONFIG_MM_HEAP_MEMPOOL_THRESHOLD != 0
+  heap->mm_mpool.pools = heap->mm_pools;
+  heap->mm_mpool.npools = sizeof(heap->mm_pools) / sizeof(heap->mm_pools[0]);
+  for (i = 0; i < heap->mm_mpool.npools; i++)
+    {
+      heap->mm_pools[i].blocksize = (i + 1) * sizeof(uintptr_t);
+      heap->mm_pools[i].expandsize = CONFIG_MM_HEAP_MEMPOOL_EXPAND;
+    }
+
+  mempool_multiple_init(&heap->mm_mpool, name);
+#endif
+
   /* Add the initial region of memory to the heap */
 
   mm_addregion(heap, heapstart, heapsize);

--- a/mm/mm_heap/mm_malloc.c
+++ b/mm/mm_heap/mm_malloc.c
@@ -120,6 +120,14 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
       return NULL;
     }
 
+#if CONFIG_MM_HEAP_MEMPOOL_THRESHOLD != 0
+  ret = mempool_multiple_alloc(&heap->mm_mpool, size);
+  if (ret != NULL)
+    {
+      return ret;
+    }
+#endif
+
   /* Adjust the size to account for (1) the size of the allocated node and
    * (2) to make sure that it is an even multiple of our granule size.
    */

--- a/mm/mm_heap/mm_malloc_size.c
+++ b/mm/mm_heap/mm_malloc_size.c
@@ -46,6 +46,13 @@ size_t mm_malloc_size(FAR void *mem)
       return 0;
     }
 
+#if CONFIG_MM_HEAP_MEMPOOL_THRESHOLD != 0
+  if (MM_IS_FROM_MEMPOOL(mem))
+    {
+      return mempool_multiple_alloc_size(mem);
+    }
+#endif
+
   /* Map the memory chunk into a free node */
 
   node = (FAR struct mm_freenode_s *)((FAR char *)mem - SIZEOF_MM_ALLOCNODE);

--- a/mm/mm_heap/mm_memalign.c
+++ b/mm/mm_heap/mm_memalign.c
@@ -43,7 +43,7 @@
  *   within that chunk that meets the alignment request and then frees any
  *   leading or trailing space.
  *
- *   The alignment argument must be a power of two.  8-byte alignment is
+ *   The alignment argument must be a power of two. 16-byte alignment is
  *   guaranteed by normal malloc calls.
  *
  ****************************************************************************/
@@ -71,6 +71,14 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment,
     {
       return NULL;
     }
+
+#if CONFIG_MM_HEAP_MEMPOOL_THRESHOLD != 0
+  node = mempool_multiple_memalign(&heap->mm_mpool, alignment, size);
+  if (node != NULL)
+    {
+      return node;
+    }
+#endif
 
   /* If this requested alinement's less than or equal to the natural
    * alignment of malloc, then just let malloc do the work.


### PR DESCRIPTION
## Summary
This PR is a part of https://github.com/apache/nuttx/pull/8131.
mm/heap/tlsf: add global multi-mempool for heap manager and tlsf
continue the work: https://github.com/apache/nuttx/pull/7450

## Impact
add blobal multi-mempool for heap manager, please look https://github.com/apache/nuttx/pull/8131 for more info.
## Testing
vela CI test.
