### PR TITLE
fs/mmap: fix mmap returned address

### DIFF
--- a/fs/mmap/fs_mmap.c
+++ b/fs/mmap/fs_mmap.c
@@ -102,7 +102,8 @@ static int file_mmap_(FAR struct file *filep, FAR void *start,
 
   if ((flags & MAP_ANONYMOUS) != 0)
     {
-      return map_anonymous(&entry, kernel);
+      ret = map_anonymous(&entry, kernel);
+      goto out;
     }
 
   if (filep == NULL)
@@ -131,10 +132,6 @@ static int file_mmap_(FAR struct file *filep, FAR void *start,
       filep->f_inode->u.i_ops->mmap != NULL)
     {
       ret = filep->f_inode->u.i_ops->mmap(filep, &entry);
-      if (ret == OK)
-        {
-          *mapped = entry.vaddr;
-        }
     }
   else
     {
@@ -146,10 +143,16 @@ static int file_mmap_(FAR struct file *filep, FAR void *start,
        * do much better in the KERNEL build using the MMU.
        */
 
-      return rammap(filep, &entry, kernel);
+      ret = rammap(filep, &entry, kernel);
     }
 
   /* Return */
+
+out:
+  if (ret == OK)
+    {
+      *mapped = entry.vaddr;
+    }
 
   return ret;
 }

--- a/fs/mmap/fs_rammap.c
+++ b/fs/mmap/fs_rammap.c
@@ -130,14 +130,13 @@ static int unmap_rammap(FAR struct task_group_s *group,
  *
  * Input Parameters:
  *   filep   file descriptor of the backing file -- required.
- *   length  The length of the mapping.  For exception #1 above, this length
- *           ignored:  The entire underlying media is always accessible.
- *   offset  The offset into the file to map
+ *   entry   mmap entry information.
+ *           field offset and length must be initialized correctly.
  *   kernel  kmm_zalloc or kumm_zalloc
- *   mapped  The pointer to the mapped area
  *
  * Returned Value:
- *  On success, rammmap returns 0. Otherwise errno is returned appropriately.
+ *  On success, rammap returns 0 and entry->vaddr points to memory mapped.
+ *     Otherwise errno is returned appropriately.
  *
  *     EBADF
  *      'fd' is not a valid file descriptor.
@@ -251,11 +250,11 @@ int rammap(FAR struct file *filep, FAR struct mm_map_entry_s *entry,
 errout_with_region:
   if (kernel)
     {
-      kmm_free(rdbuffer);
+      kmm_free(entry->vaddr);
     }
   else
     {
-      kumm_free(rdbuffer);
+      kumm_free(entry->vaddr);
     }
 
   return ret;

--- a/fs/mmap/fs_rammap.c
+++ b/fs/mmap/fs_rammap.c
@@ -179,6 +179,8 @@ int rammap(FAR struct file *filep, FAR struct mm_map_entry_s *entry,
       return -ENOMEM;
     }
 
+  entry->vaddr = rdbuffer; /* save the buffer firstly */
+
   /* Seek to the specified file offset */
 
   fpos = file_seek(filep, entry->offset, SEEK_SET);
@@ -235,7 +237,6 @@ int rammap(FAR struct file *filep, FAR struct mm_map_entry_s *entry,
 
   /* Add the buffer to the list of regions */
 
-  entry->vaddr = rdbuffer;
   entry->priv.i = kernel;
   entry->munmap = unmap_rammap;
 


### PR DESCRIPTION
## Summary

- 1. rammap should return memory start address
- 2. update output `mapped` pointer  in file_mmap_ before returning

## Impact

No.

## Testing

mmap used in gettext now works correctly.
