### PR TITLE
mm: Enable a dedicated kernel heap on `BUILD_FLAT` via `MM_KERNEL_HEAP`

### DIFF
--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -644,6 +644,9 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size);
  *   as determined by CONFIG_MM_KERNEL_HEAP=y.  This function allocates (and
  *   protects) the kernel-space heap.
  *
+ *   For Flat build (CONFIG_BUILD_FLAT=y), this function enables a separate
+ *   (although unprotected) heap for the kernel.
+ *
  ****************************************************************************/
 
 #ifdef CONFIG_MM_KERNEL_HEAP

--- a/include/nuttx/mm/mm.h
+++ b/include/nuttx/mm/mm.h
@@ -86,10 +86,16 @@
 #  define MM_KERNEL_USRHEAP_INIT 1
 #endif
 
-/* The kernel heap is never accessible from user code */
+/* When building the Userspace image under CONFIG_BUILD_KERNEL or
+ * CONFIG_BUILD_PROTECTED (i.e. !defined(__KERNEL__)), CONFIG_MM_KERNEL_HEAP
+ * must be undefined to ensure the kernel heap is never accessible from user
+ * code.
+ */
 
-#ifndef __KERNEL__
-#  undef CONFIG_MM_KERNEL_HEAP
+#if defined(CONFIG_BUILD_KERNEL) || defined(CONFIG_BUILD_PROTECTED)
+#  ifndef __KERNEL__
+#    undef CONFIG_MM_KERNEL_HEAP
+#  endif
 #endif
 
 /****************************************************************************

--- a/mm/Kconfig
+++ b/mm/Kconfig
@@ -26,16 +26,24 @@ config MM_CUSTOMIZE_MANAGER
 endchoice
 
 config MM_KERNEL_HEAP
-	bool "Support a protected, kernel heap"
-	default y
-	depends on !BUILD_FLAT
+	bool "Kernel dedicated heap"
+	default n if BUILD_FLAT
+	default y if BUILD_PROTECTED || BUILD_KERNEL
 	---help---
-		Partition heap memory into two parts:  (1) a protected, kernel-mode
-		heap accessible only by the NuttX kernel, and (2) an unprotected
-		user-mode heap for use by applications.  If you are only interested
-		in protected the kernel from read access, then this option is not
-		necessary.  If you wish to secure the kernel data as well, then
-		this option should be selected.
+		Under Flat build, this option will enable a separate heap for the kernel.
+		By separating the kernel and userspace heaps, the user is granted more
+		control over the heaps placement within the memory hierarchy, which is
+		specially useful for microcontrollers that provide External RAM.
+		Besides segregating the kernel and userspace allocations, this feature
+		does not prevent the userspace from accessing the kernel heap.
+
+		As for Protected and Kernel builds, this feature partitions heap memory
+		into two parts:
+		(1) a protected, kernel-mode heap accessible only by the NuttX kernel,
+		and (2) an unprotected user-mode heap for use by applications.
+		If you are only interested in protecting the kernel from read access,
+		then this option is not necessary. If you wish to secure the kernel data
+		as well, then this option should be selected.
 
 		The kernel heap size that is used is provided a a platform-specific
 		up_allocate_kheap() interface.  This configuration setting is made

--- a/mm/umm_heap/umm_initialize.c
+++ b/mm/umm_heap/umm_initialize.c
@@ -43,8 +43,10 @@
  *
  *   CONFIG_BUILD_FLAT:
  *     There is only kernel mode "blob" containing both kernel and
- *     application code.  There is only one heap that is used by both the
- *     kernel and application logic.
+ *     application code. Depending upon the setting of CONFIG_MM_KERNEL_HEAP
+ *     there may be a single shared heap (used by both the kernel and
+ *     application logic) or there may be separate (although unprotected)
+ *     kernel and user heaps.
  *
  *     In this configuration, this function is called early in nx_start()
  *     to initialize the common heap.

--- a/sched/group/Make.defs
+++ b/sched/group/Make.defs
@@ -48,7 +48,7 @@ ifeq ($(CONFIG_BINFMT_LOADABLE),y)
 CSRCS += group_exitinfo.c
 endif
 
-ifneq ($(CONFIG_BUILD_FLAT),y)
+ifeq ($(CONFIG_MM_KERNEL_HEAP),y)
 CSRCS += group_malloc.c group_realloc.c group_zalloc.c group_free.c
 endif
 


### PR DESCRIPTION
## Summary

This PR intends to enable a dedicated kernel heap on NuttX **Flat mode** by extending `MM_KERNEL_HEAP` feature.

By separating the kernel and userspace heaps, the user is granted more control over the heaps placement within the memory hierarchy, which is specially useful for microcontrollers that provide External RAM.

Besides segregating the kernel and userspace allocations, this feature does not prevent the userspace from accessing the kernel heap under `BUILD_FLAT`.

`MM_KERNEL_HEAP` support under `BUILD_PROTECTED` and `BUILD_KERNEL` should be unaffected.

## Impact

NuttX memory management subsystem is now extended with a new feature, enabled only on specific combination of Kconfig options.

## Testing

Successful execution of `ostest` in `esp32-devkitc:psram_usrheap` defconfig, to be submitted later.

