### PR TITLE
Ensure SFR CKTRIM register correctly set, SAMA5D2/D3 only

### DIFF
--- a/arch/arm/src/sama5/hardware/sam_sfr.h
+++ b/arch/arm/src/sama5/hardware/sam_sfr.h
@@ -144,6 +144,8 @@
 #define SFR_SECURE_ROM              (1 << 0)  /* Bit 0:  Disable Access to ROM Code */
 #define SFR_SECURE_FUSE             (1 << 8)  /* Bit 8:  Disable Access to Fuse Controller */
 
+#if defined(ATSAMA5D2) || defined(ATSAMA5D3)
+
 /* UTMI Clock Trimming Register */
 
 #define SFR_UTMICKTRIM_FREQ_SHIFT   (0)       /* Bits 0-1: UTMI Reference Clock Frequency */
@@ -151,17 +153,14 @@
 #  define SFR_UTMICKTRIM_FREQ_12MHZ (0 << SFR_UTMICKTRIM_FREQ_SHIFT) /* 12 MHz reference clock */
 #  define SFR_UTMICKTRIM_FREQ_16MHZ (1 << SFR_UTMICKTRIM_FREQ_SHIFT) /* 16 MHz reference clock */
 #  define SFR_UTMICKTRIM_FREQ_24MHZ (2 << SFR_UTMICKTRIM_FREQ_SHIFT) /* 24 MHz reference clock */
-#ifndef ATSAMA5D2
+#ifdef ATSAMA5D3
 #  define SFR_UTMICKTRIM_FREQ_48MHZ (3 << SFR_UTMICKTRIM_FREQ_SHIFT) /* 48 MHz reference clock */
 #endif
 
-#if defined(ATSAMA5D2) || defined(ATSAMA5D4)
 #  define SFR_UTMICKTRIM_VBG_SHIFT  (16)     /* Bits 16-19: UTMI Band Gap Voltage Trimming */
 #  define SFR_UTMICKTRIM_VBG_MASK   (15 << SFR_UTMICKTRIM_VBG_SHIFT)
 #    define SFR_UTMICKTRIM_VBG(n)   ((uint32_t)(n) << SFR_UTMICKTRIM_VBG_SHIFT)
-#endif
 
-#if defined(ATSAMA5D2) || defined(ATSAMA5D4)
 /* UTMI High Speed Trimming Register */
 
 #  define SFR_UTMIHSTRIM_SQUELCH_SHIFT (0)   /* Bits 0-2: UTMI HS SQUELCH Voltage Trimming */
@@ -179,9 +178,7 @@
 #  define SFR_UTMIHSTRIM_SLOPE2_SHIFT  (16)  /* Bits 16-18: UTMI HS PORT2 Transceiver Slope Trimming */
 #  define SFR_UTMIHSTRIM_SLOPE2_MASK   (7 << SFR_UTMIHSTRIM_SLOPE2_SHIFT)
 #    define SFR_UTMIHSTRIM_SLOPE2(n)   ((uint32_t)(n) << SFR_UTMIHSTRIM_SLOPE2_SHIFT)
-#endif
 
-#if defined(ATSAMA5D2) || defined(ATSAMA5D4)
 /* UTMI Full Speed Trimming Register */
 
 #  define SFR_UTMIFSTRIM_RISE_SHIFT (0)      /* Bits 0-2: FS Transceiver Output Rising Slope Trimming */
@@ -199,16 +196,15 @@
 #  define SFR_UTMIFSTRIM_ZP_SHIFT   (20)     /* Bits 20-22: FS Transceiver PMOS Impedance Trimming */
 #  define SFR_UTMIFSTRIM_ZP_MASK    (7 << SFR_UTMIHSTRIM_SLOPE2_SHIFT)
 #    define SFR_UTMIFSTRIM_ZP(n)    ((uint32_t)(n) << SFR_UTMIHSTRIM_SLOPE2_SHIFT)
-#endif
 
-#if defined(ATSAMA5D2) || defined(ATSAMA5D4)
 /* UTMI DP/DM Pin Swapping Register */
 
 #  define SFR_UTMISWAP_PORT(n)     (1 << (n)) /* Bit n:  PORT n DP/DM Pin Swapping */
 #    define SFR_UTMISWAP_PORT0     (1 << 0)   /* Bit 0:  PORT 0 DP/DM Pin Swapping */
 #    define SFR_UTMISWAP_PORT1     (1 << 1)   /* Bit 1:  PORT 1 DP/DM Pin Swapping */
 #    define SFR_UTMISWAP_PORT2     (1 << 2)   /* Bit 2:  PORT 2 DP/DM Pin Swapping */
-#endif
+
+#endif /* if defined(ATSAMA5D2) || defined(ATSAMA5D3) */
 
 /* EBI Configuration Register */
 

--- a/arch/arm/src/sama5/sam_clockconfig.c
+++ b/arch/arm/src/sama5/sam_clockconfig.c
@@ -432,6 +432,7 @@ static inline void sam_usbclockconfig(void)
    *   1) Enable UHP peripheral clock, bit (1 << AT91C_ID_UHPHS) in
    *      PMC_PCER register.
    *   2) Write CKGR_PLLCOUNT field in PMC_UCKR register.
+   *      Set CLKTRIM register if required.
    *   3) Enable UPLL, bit AT91C_CKGR_UPLLEN in PMC_UCKR register.
    *   4) Wait until UTMI_PLL is locked. LOCKU bit in PMC_SR register
    *   5) Enable BIAS, bit AT91C_CKGR_BIASEN in PMC_UCKR register.
@@ -447,6 +448,28 @@ static inline void sam_usbclockconfig(void)
    */
 
   /* 2) Write CKGR_PLLCOUNT field in PMC_UCKR register. */
+
+#if defined(ATSAMA5D2) || defined(ATSAMA5D3)
+
+  /* get UTMI timing register */
+
+  regval = getreg32(SAM_SFR_VBASE + SAM_SFR_UTMICKTRIM_OFFSET);
+  regval &= ~SFR_UTMICKTRIM_FREQ_MASK;
+
+#if BOARD_MAINOSC_FREQUENCY == (12000000)
+  regval |= SFR_UTMICKTRIM_FREQ_12MHZ;
+#elif BOARD_MAINOSC_FREQUENCY == (16000000)
+  regval |= SFR_UTMICKTRIM_FREQ_16MHZ;
+#elif BOARD_MAINOSC_FREQUENCY == (24000000)
+  regval |= SFR_UTMICKTRIM_FREQ_24MHZ;
+#elif (BOARD_MAINOSC_FREQUENCY == (48000000)) && defined(ATSAMA5D3)
+  regval |= SFR_UTMICKTRIM_FREQ_48MHZ;
+#else
+#  error Board oscillator frequency not compatible with use of UPLL
+#endif
+#endif
+
+  putreg32(regval, (SAM_SFR_VBASE + SAM_SFR_UTMICKTRIM_OFFSET));
 
   regval = PMC_CKGR_UCKR_UPLLCOUNT(BOARD_CKGR_UCKR_UPLLCOUNT);
   putreg32(regval, SAM_PMC_CKGR_UCKR);


### PR DESCRIPTION
## Summary
When using UPLL clock on SAMA5D2 and SAMA5D3 with a crystal which is NOT 12MHz, the CKTRIM SFR register bits must be set correctly to allow the 480MHz clock to run at the correct frequency.

Also found that the SFR bit definitions for this were incorrectly applied to SAMA5D4 but they only apply to SAMA5D2 and SAMA5D3 as best as I can tell.

## Impact
None, since these bits had never been set in previous versions of NuttX.

## Testing
Custom board with SAMA5D27C-D1G, using 24MHz crystal, and USB host and device connections.

