### PR TITLE
SIM bug fix when open CONFIG_SIM_WALLTIME_SIGNAL

### DIFF
--- a/arch/sim/src/sim/posix/sim_hostmemory.c
+++ b/arch/sim/src/sim/posix/sim_hostmemory.c
@@ -51,6 +51,9 @@ static atomic_int g_uordblks;
  * Public Functions
  ****************************************************************************/
 
+extern uint64_t up_irq_save(void);
+extern void up_irq_restore(uint64_t flags);
+
 /****************************************************************************
  * Name: host_allocheap
  *
@@ -61,6 +64,7 @@ static atomic_int g_uordblks;
 
 void *host_allocheap(size_t sz)
 {
+  uint64_t flags = up_irq_save();
   void *p;
 
 #if defined(CONFIG_HOST_MACOS) && defined(CONFIG_HOST_ARM64)
@@ -73,6 +77,8 @@ void *host_allocheap(size_t sz)
            MAP_ANON | MAP_PRIVATE, -1, 0);
 #endif
 
+  up_irq_restore(flags);
+
   if (p == MAP_FAILED)
     {
       return NULL;
@@ -83,6 +89,7 @@ void *host_allocheap(size_t sz)
 
 void *host_allocshmem(const char *name, size_t size, int master)
 {
+  uint64_t flags = up_irq_save();
   void *mem;
   int oflag;
   int ret;
@@ -97,6 +104,7 @@ void *host_allocshmem(const char *name, size_t size, int master)
   fd = shm_open(name, oflag, S_IRUSR | S_IWUSR);
   if (fd < 0)
     {
+      up_irq_restore(flags);
       return NULL;
     }
 
@@ -110,12 +118,14 @@ void *host_allocshmem(const char *name, size_t size, int master)
   ret = ftruncate(fd, size);
   if (ret < 0)
     {
+      up_irq_restore(flags);
       close(fd);
       return NULL;
     }
 
   mem = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
   close(fd); /* Don't need keep fd any more once the memory get mapped */
+  up_irq_restore(flags);
   if (mem == MAP_FAILED)
     {
       return NULL;
@@ -126,7 +136,9 @@ void *host_allocshmem(const char *name, size_t size, int master)
 
 void host_freeshmem(void *mem)
 {
+  uint64_t flags = up_irq_save();
   munmap(mem, 0);
+  up_irq_restore(flags);
 }
 
 size_t host_mallocsize(void *mem)
@@ -140,12 +152,14 @@ size_t host_mallocsize(void *mem)
 
 void *host_memalign(size_t alignment, size_t size)
 {
+  uint64_t flags = up_irq_save();
   void *p;
   int error;
 
   error = posix_memalign(&p, alignment, size);
   if (error != 0)
     {
+      up_irq_restore(flags);
       return NULL;
     }
 
@@ -153,26 +167,32 @@ void *host_memalign(size_t alignment, size_t size)
   g_aordblks += 1;
   g_uordblks += size;
 
+  up_irq_restore(flags);
+
   return p;
 }
 
 void host_free(void *mem)
 {
   size_t size;
+  uint64_t flags;
 
   if (mem == NULL)
     {
       return;
     }
 
+  flags = up_irq_save();
   size = host_mallocsize(mem);
   g_aordblks -= 1;
   g_uordblks -= size;
   free(mem);
+  up_irq_restore(flags);
 }
 
 void *host_realloc(void *oldmem, size_t size)
 {
+  uint64_t flags;
   size_t oldsize;
   void *mem;
 
@@ -186,16 +206,21 @@ void *host_realloc(void *oldmem, size_t size)
       return host_memalign(sizeof(void *), size);
     }
 
+  flags = up_irq_save();
+
   oldsize = host_mallocsize(oldmem);
   mem = realloc(oldmem, size);
   if (mem == NULL)
     {
+      up_irq_restore(flags);
       return NULL;
     }
 
   size = host_mallocsize(mem);
   g_uordblks -= oldsize;
   g_uordblks += size;
+
+  up_irq_restore(flags);
 
   return mem;
 }

--- a/arch/sim/src/sim/sim_oneshot.c
+++ b/arch/sim/src/sim/sim_oneshot.c
@@ -437,6 +437,7 @@ void up_timer_initialize(void)
 
 void sim_timer_update(void)
 {
+#ifdef CONFIG_SIM_WALLTIME_SLEEP
   static uint64_t until;
 
   /* Wait a bit so that the timing is close to the correct rate. */
@@ -444,7 +445,6 @@ void sim_timer_update(void)
   until += NSEC_PER_TICK;
   host_sleepuntil(until);
 
-#ifdef CONFIG_SIM_WALLTIME_SLEEP
   sim_timer_update_internal();
 #endif
 }


### PR DESCRIPTION
## Summary

sim/oneshot: don't need sleep_until when open CONFIG_SIM_WALLTIME_SIGNAL
sim/mem: don't let siwtch out when operated the host mem

## Impact

sim when open CONFIG_SIM_WALLTIME_SIGNAL

## Testing

VELA
