### PR TITLE
rpmsg socket related update

### DIFF
--- a/net/rpmsg/rpmsg_sockif.c
+++ b/net/rpmsg/rpmsg_sockif.c
@@ -107,6 +107,7 @@ struct rpmsg_socket_conn_s
 
   /* server listen-scoket listening: backlog > 0;
    * server listen-scoket closed: backlog = -1;
+   * accept scoket: backlog = -2;
    * others: backlog = 0;
    */
 
@@ -756,8 +757,9 @@ static int rpmsg_socket_accept(FAR struct socket *psock,
 
       if (conn)
         {
+          conn->backlog = -2;
           rpmsg_register_callback(conn,
-                                  rpmsg_socket_device_created,
+                                  NULL,
                                   rpmsg_socket_device_destroy,
                                   NULL,
                                   NULL);
@@ -1278,7 +1280,15 @@ static int rpmsg_socket_close(FAR struct socket *psock)
       return 0;
     }
 
-  if (conn->backlog)
+  if (conn->backlog == -2)
+    {
+      rpmsg_unregister_callback(conn,
+                                NULL,
+                                rpmsg_socket_device_destroy,
+                                NULL,
+                                NULL);
+    }
+  else if (conn->backlog)
     {
       rpmsg_unregister_callback(conn,
                                 NULL,

--- a/net/rpmsg/rpmsg_sockif.c
+++ b/net/rpmsg/rpmsg_sockif.c
@@ -1010,6 +1010,7 @@ static ssize_t rpmsg_socket_send_continuous(FAR struct socket *psock,
                                 conn->ept.dest_addr);
       if (ret < 0)
         {
+          rpmsg_release_tx_buffer(&conn->ept, msg);
           break;
         }
 
@@ -1109,6 +1110,10 @@ static ssize_t rpmsg_socket_send_single(FAR struct socket *psock,
   nxmutex_unlock(&conn->sendlock);
 
   ret = rpmsg_sendto_nocopy(&conn->ept, msg, total, conn->ept.dest_addr);
+  if (ret < 0)
+    {
+      rpmsg_release_tx_buffer(&conn->ept, msg);
+    }
 
   return ret > 0 ? len : ret;
 }


### PR DESCRIPTION
## Summary

rpmsg socket related update:
rpmsg_socket: release tx buffer when send_oncopy failed
rpmsg_socket: rpmsg_send_nocpy() should lock with rpmsg_destroy_ept
rpmsg_socket: shouldn't call create_device again after create_ept
rpmsg_socket: destroy_ept only at close

## Impact

rpmsg socket

## Testing

VELA