### PR TITLE
uinput: fix uinput compile failed, if no define CONFIG_UINPUT_TOUCH

### DIFF
--- a/drivers/input/uinput.c
+++ b/drivers/input/uinput.c
@@ -72,6 +72,7 @@ struct uinput_context_s
 
 #endif /* CONFIG_UINPUT_RPMSG */
 
+#ifdef CONFIG_UINPUT_TOUCH
 struct uinput_touch_lowerhalf_s
 {
 #ifdef CONFIG_UINPUT_RPMSG
@@ -80,7 +81,9 @@ struct uinput_touch_lowerhalf_s
 
   struct touch_lowerhalf_s lower;
 };
+#endif
 
+#ifdef CONFIG_UINPUT_BUTTONS
 struct uinput_button_lowerhalf_s
 {
 #ifdef CONFIG_UINPUT_RPMSG
@@ -92,7 +95,9 @@ struct uinput_button_lowerhalf_s
   btn_handler_t          handler;
   FAR void              *arg;
 };
+#endif
 
+#ifdef CONFIG_UINPUT_KEYBOARD
 struct uinput_keyboard_lowerhalf_s
 {
 #ifdef CONFIG_UINPUT_RPMSG
@@ -101,6 +106,7 @@ struct uinput_keyboard_lowerhalf_s
 
   struct keyboard_lowerhalf_s lower;
 };
+#endif
 
 /****************************************************************************
  * Private Function Prototypes


### PR DESCRIPTION
## Summary

uinput: fix uinput compile failed, if no define CONFIG_UINPUT_TOUCH

input/uinput.c:81:28: error: field 'lower' has incomplete type
   81 |   struct touch_lowerhalf_s lower;
      |                            ^~~~~


## Impact

uinput

## Testing

VELA
