### PR TITLE
sched: fix task_delete crash in SMP case

### DIFF
--- a/sched/sched/sched_removereadytorun.c
+++ b/sched/sched/sched_removereadytorun.c
@@ -63,7 +63,10 @@
 #ifndef CONFIG_SMP
 bool nxsched_remove_readytorun(FAR struct tcb_s *rtcb, bool merge)
 {
+  FAR dq_queue_t *tasklist;
   bool doswitch = false;
+
+  tasklist = TLIST_HEAD(rtcb);
 
   /* Check if the TCB to be removed is at the head of the ready to run list.
    * There is only one list, g_readytorun, and it always contains the
@@ -71,7 +74,7 @@ bool nxsched_remove_readytorun(FAR struct tcb_s *rtcb, bool merge)
    * then we are removing the currently active task.
    */
 
-  if (rtcb->blink == NULL)
+  if (rtcb->blink == NULL && TLIST_ISRUNNABLE(rtcb->task_state))
     {
       /* There must always be at least one task in the list (the IDLE task)
        * after the TCB being removed.
@@ -88,7 +91,7 @@ bool nxsched_remove_readytorun(FAR struct tcb_s *rtcb, bool merge)
    * is always the g_readytorun list.
    */
 
-  dq_rem((FAR dq_entry_t *)rtcb, &g_readytorun);
+  dq_rem((FAR dq_entry_t *)rtcb, tasklist);
 
   /* Since the TCB is not in any list, it is now invalid */
 


### PR DESCRIPTION
## Summary

sched: fix task_delete crash in SMP case

A testcase as following:

```
child_task()
{
  sleep(3);
}

main_task()
{
  while (1)
    {
      ret = task_create("child_task", child_task, );
      sleep(1);

      task_delete(ret);
    }
}
```

Root casuse:
task_delete hasn's cover the condition that the deleted-task is justing running on the other CPU.

Fix:
Let the nxsched_remove_readytorun() do the real work

Signed-off-by: ligd <liguiding1@xiaomi.com>

## Impact

task delete

## Testing

VELA