### PR TITLE
fs/fs_fsync:Fix the expected error of socket,fifo and pipe returning error in fsync case

### DIFF
--- a/drivers/pipes/pipe_common.c
+++ b/drivers/pipes/pipe_common.c
@@ -877,6 +877,10 @@ int pipecommon_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         }
         break;
 
+      case BIOC_FLUSH:
+        ret = -EINVAL;
+        break;
+
       default:
         ret = -ENOTTY;
         break;

--- a/net/local/local_sockif.c
+++ b/net/local/local_sockif.c
@@ -847,6 +847,9 @@ static int local_ioctl(FAR struct socket *psock, int cmd, unsigned long arg)
             ret = -ENOTCONN;
           }
         break;
+      case BIOC_FLUSH:
+        ret = -EINVAL;
+        break;
       default:
         ret = -ENOTTY;
         break;


### PR DESCRIPTION
## Summary
socket, fifo, pipe in the call to Fsync is expected to return EINVAL, the actual result returns ENOTTY. solution is to add BIOC_FLUSH judgment in pipecommon_ioctl and local_ioctl, and return EINVAL.

## Impact

## Testing

