### PR TITLE
Fix warning in file included from chip/sam_clockconfig.c:34:

### DIFF
--- a/arch/arm/src/sama5/sam_clockconfig.c
+++ b/arch/arm/src/sama5/sam_clockconfig.c
@@ -467,9 +467,9 @@ static inline void sam_usbclockconfig(void)
 #else
 #  error Board oscillator frequency not compatible with use of UPLL
 #endif
-#endif
 
   putreg32(regval, (SAM_SFR_VBASE + SAM_SFR_UTMICKTRIM_OFFSET));
+#endif
 
   regval = PMC_CKGR_UCKR_UPLLCOUNT(BOARD_CKGR_UCKR_UPLLCOUNT);
   putreg32(regval, SAM_PMC_CKGR_UCKR);


### PR DESCRIPTION
## Summary

```
chip/sam_clockconfig.c: In function 'sam_usbclockconfig': Error: /github/workspace/sources/nuttx/arch/arm/src/common/arm_internal.h:135:51: error: 'regval' is used uninitialized [-Werror=uninitialized]
  135 | #define putreg32(v,a)  (*(volatile uint32_t *)(a) = (v))
      |                                                   ^
chip/sam_clockconfig.c:422:12: note: 'regval' was declared here
  422 |   uint32_t regval;
      |            ^~~~~~
```

## Impact

Fix CI broken by https://github.com/apache/nuttx/pull/8141

## Testing

Pass CI
