### PR TITLE
arch/arm/src/armv7-a/r: fix kconfig error of l2 cache latency

### DIFF
--- a/arch/arm/src/armv7-a/Kconfig
+++ b/arch/arm/src/armv7-a/Kconfig
@@ -83,11 +83,11 @@ config PL310_TRCR_TSETLAT
 	default 1
 
 config PL310_TRCR_TRDLAT
-	bool "PL310 TRCR read access latency"
+	int "PL310 TRCR read access latency"
 	default 1
 
-config PL310_TRCR_WRLAT
-	bool "PL310 TRCR write access latency"
+config PL310_TRCR_TWRLAT
+	int "PL310 TRCR write access latency"
 	default 1
 endif # PL310_TRCR
 
@@ -96,16 +96,16 @@ config PL310_DRCR
 	default n
 
 if PL310_DRCR
-config PL310_DRCR_TSETLAT
+config PL310_DRCR_DSETLAT
 	int "PL310 DRCR setup latency"
 	default 1
 
-config PL310_DRCR_TRDLAT
-	bool "PL310 DRCR read access latency"
+config PL310_DRCR_DRDLAT
+	int "PL310 DRCR read access latency"
 	default 1
 
-config PL310_DRCR_WRLAT
-	bool "PL310 DRCR write access latency"
+config PL310_DRCR_DWRLAT
+	int "PL310 DRCR write access latency"
 	default 1
 endif # PL310_DRCR
 endif # ARMV7A_L2CC_PL310

--- a/arch/arm/src/armv7-r/Kconfig
+++ b/arch/arm/src/armv7-r/Kconfig
@@ -90,11 +90,11 @@ config PL310_TRCR_TSETLAT
 	default 1
 
 config PL310_TRCR_TRDLAT
-	bool "PL310 TRCR read access latency"
+	int "PL310 TRCR read access latency"
 	default 1
 
-config PL310_TRCR_WRLAT
-	bool "PL310 TRCR write access latency"
+config PL310_TRCR_TWRLAT
+	int "PL310 TRCR write access latency"
 	default 1
 endif # PL310_TRCR
 
@@ -103,16 +103,16 @@ config PL310_DRCR
 	default n
 
 if PL310_DRCR
-config PL310_DRCR_TSETLAT
+config PL310_DRCR_DSETLAT
 	int "PL310 DRCR setup latency"
 	default 1
 
-config PL310_DRCR_TRDLAT
-	bool "PL310 DRCR read access latency"
+config PL310_DRCR_DRDLAT
+	int "PL310 DRCR read access latency"
 	default 1
 
-config PL310_DRCR_WRLAT
-	bool "PL310 DRCR write access latency"
+config PL310_DRCR_DWRLAT
+	int "PL310 DRCR write access latency"
 	default 1
 endif # PL310_DRCR
 endif # ARMV7R_L2CC_PL310


### PR DESCRIPTION
## Summary

Fix the error of the config name and set latency config param bool to int.

## Impact

NA

## Testing

CI pass