### PR TITLE
assert: fix build break

### DIFF
--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -329,7 +329,7 @@ static void dump_task(FAR struct tcb_s *tcb, FAR void *arg)
 #ifdef CONFIG_SMP
          "  %4d"
 #endif
-         "   %p"
+         "   0x%08" PRIxPTR
          "   %7zu"
 #ifdef CONFIG_STACK_COLORATION
          "   %7zu   %3zu.%1zu%%%c"
@@ -342,7 +342,7 @@ static void dump_task(FAR struct tcb_s *tcb, FAR void *arg)
 #ifdef CONFIG_SMP
          , tcb->cpu
 #endif
-         , tcb->stack_base_ptr
+         , (uintptr_t)tcb->stack_base_ptr
          , tcb->adj_stack_size
 #ifdef CONFIG_STACK_COLORATION
          , up_check_tcbstack(tcb)
@@ -412,7 +412,7 @@ static void show_tasks(void)
 #  ifdef CONFIG_SMP
          "  ----"
 #  endif
-         "   %p"
+         "   0x%08" PRIxPTR
          "   %7u"
 #  ifdef CONFIG_STACK_COLORATION
          "   %7zu   %3zu.%1zu%%%c"

--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -110,10 +110,10 @@ static void stack_dump(uintptr_t sp, uintptr_t stack_top)
   for (stack = sp & ~0x1f; stack < (stack_top & ~0x1f); stack += 32)
     {
       FAR uint32_t *ptr = (FAR uint32_t *)stack;
-      _alert("%" PRIxPTR ": %08" PRIx32 " %08" PRIx32 " %08" PRIx32
+      _alert("%p: %08" PRIx32 " %08" PRIx32 " %08" PRIx32
              " %08" PRIx32 " %08" PRIx32 " %08" PRIx32 " %08" PRIx32
              " %08" PRIx32 "\n",
-             stack, ptr[0], ptr[1], ptr[2], ptr[3],
+             (FAR void *)stack, ptr[0], ptr[1], ptr[2], ptr[3],
              ptr[4], ptr[5], ptr[6], ptr[7]);
     }
 }
@@ -129,8 +129,8 @@ static void dump_stack(FAR const char *tag, uintptr_t sp,
   uintptr_t top = base + size;
 
   _alert("%s Stack:\n", tag);
-  _alert("sp:     %08" PRIxPTR "\n", sp);
-  _alert("  base: %08" PRIxPTR "\n", base);
+  _alert("sp:     %p\n", (FAR void *)sp);
+  _alert("  base: %p\n", (FAR void *)base);
   _alert("  size: %08zu\n", size);
 
   if (sp >= base && sp < top)
@@ -329,7 +329,7 @@ static void dump_task(FAR struct tcb_s *tcb, FAR void *arg)
 #ifdef CONFIG_SMP
          "  %4d"
 #endif
-         "   0x%08" PRIxPTR
+         "   %p"
          "   %7zu"
 #ifdef CONFIG_STACK_COLORATION
          "   %7zu   %3zu.%1zu%%%c"
@@ -342,7 +342,7 @@ static void dump_task(FAR struct tcb_s *tcb, FAR void *arg)
 #ifdef CONFIG_SMP
          , tcb->cpu
 #endif
-         , (uintptr_t)tcb->stack_base_ptr
+         , tcb->stack_base_ptr
          , tcb->adj_stack_size
 #ifdef CONFIG_STACK_COLORATION
          , up_check_tcbstack(tcb)
@@ -412,7 +412,7 @@ static void show_tasks(void)
 #  ifdef CONFIG_SMP
          "  ----"
 #  endif
-         "   0x%08" PRIxPTR
+         "   %p"
          "   %7u"
 #  ifdef CONFIG_STACK_COLORATION
          "   %7zu   %3zu.%1zu%%%c"
@@ -421,7 +421,7 @@ static void show_tasks(void)
          "     ----"
 #  endif
          "   irq\n"
-         , up_get_intstackbase()
+         , (FAR void *)up_get_intstackbase()
          , CONFIG_ARCH_INTERRUPTSTACK
 #  ifdef CONFIG_STACK_COLORATION
          , stack_used


### PR DESCRIPTION
## Summary

assert: fix build break

misc/assert.c: In function 'show_tasks':
Error: misc/assert.c:411:10: error: format '%p' expects argument of type 'void *', but argument 3 has type 'uintptr_t' {aka 'long unsigned int'} [-Werror=format=]
  411 |   _alert("  ----   ---"
      |          ^~~~~~~~~~~~~~
......
  424 |          , up_get_intstackbase()
      |            ~~~~~~~~~~~~~~~~~~~~~
      |            |
      |            uintptr_t {aka long unsigned int}

Signed-off-by: ligd <liguiding1@xiaomi.com>

## Impact

## Testing

