### PR TITLE
Documentation: Restore some esp32-devkitc openocd doc

### DIFF
--- a/Documentation/platforms/xtensa/esp32/boards/esp32-devkitc/index.rst
+++ b/Documentation/platforms/xtensa/esp32/boards/esp32-devkitc/index.rst
@@ -575,3 +575,33 @@ Find your board IP using ``nsh> ifconfig`` and then from your computer::
 
 Where x and y are the last two numbers of the IP that your router gave to
 your board.
+
+Debugging with OpenOCD
+======================
+
+Akizukidenshi FT232HL
+---------------------
+
+Akizukidenshi's FT232HL, a FT232H based JTAG adapter
+(http://akizukidenshi.com/catalog/g/gK-06503/) with JP3 and JP4 closed,
+and connected to ESP32 as:
+
++------------------+-------------+
+| ESP32-DevKitC V4 | FT232HL     |
++=======+==========+=============+
+| J2    |  J3      | J2          |
++-------+----------+-------------+
+| IO13  |          | AD0   (TCK) |
++-------+----------+-------------+
+| IO12  |          | AD1   (TDI) |
++-------+----------+-------------+
+|       |  IO15    | AD2   (TDO) |
++-------+----------+-------------+
+| IO14  |          | AD3   (TMS) |
++-------+----------+-------------+
+| GND   |          | GND         |
++-------+----------+-------------+
+
+can be used with ESP-IDF version of openocd with::
+
+    % openocd -f board/esp32-wrover-kit-1.8v.cfg


### PR DESCRIPTION
## Summary

Restore some openocd information which I occassionally need.

This is a partial revert of:
```
commit 58a5e0744b22d893675afd17a41c743fd7ec9ea4
Author: Abdelatif Guettouche <abdelatif.guettouche@espressif.com>
Date:   Mon Jul 26 21:43:42 2021 +0200

    Documentation/esp32: Remove the rest of the OpenOCD text.
    This information there is outdated and some of its content should be in
    the board documentation and not the chip.

    Signed-off-by: Abdelatif Guettouche <abdelatif.guettouche@espressif.com>
```

## Impact

## Testing

rendering on github looks ok.
https://github.com/yamt/incubator-nuttx/blob/esp32-openocd/Documentation/platforms/xtensa/esp32/boards/esp32-devkitc/index.rst#debugging-with-openocd