### PR TITLE
net/devif: bypass send length check if ip fragment enabled

### DIFF
--- a/net/devif/devif_iobsend.c
+++ b/net/devif/devif_iobsend.c
@@ -59,10 +59,7 @@ void devif_iob_send(FAR struct net_driver_s *dev, FAR struct iob_s *iob,
 #ifndef CONFIG_NET_IPFRAG
   unsigned int limit = NETDEV_PKTSIZE(dev) -
                        NET_LL_HDRLEN(dev) - target_offset;
-#endif
-  int ret;
 
-#ifndef CONFIG_NET_IPFRAG
   if (dev == NULL || len == 0 || len > limit)
 #else
   if (dev == NULL || len == 0)
@@ -95,9 +92,8 @@ void devif_iob_send(FAR struct net_driver_s *dev, FAR struct iob_s *iob,
 
       /* Clone the iob to target device buffer */
 
-      ret = iob_clone_partial(iob, len, offset, dev->d_iob,
-                              target_offset, false, false);
-      if (ret != OK)
+      if (iob_clone_partial(iob, len, offset, dev->d_iob,
+                            target_offset, false, false) != OK)
         {
           netdev_iob_release(dev);
           nerr("devif_iob_send error, not enough iob entries, "

--- a/net/devif/devif_send.c
+++ b/net/devif/devif_send.c
@@ -68,6 +68,7 @@
 void devif_send(FAR struct net_driver_s *dev, FAR const void *buf,
                 int len, unsigned int offset)
 {
+#ifndef CONFIG_NET_IPFRAG
   unsigned int limit = NETDEV_PKTSIZE(dev) -
                        NET_LL_HDRLEN(dev) - offset;
 
@@ -77,6 +78,13 @@ void devif_send(FAR struct net_driver_s *dev, FAR const void *buf,
            dev, len, limit);
       return;
     }
+#else
+  if (dev == NULL || len == 0)
+    {
+      nerr("ERROR: devif_send fail: %p, sndlen: %u\n", dev, len);
+      return;
+    }
+#endif
 
   /* Copy in iob to target device buffer */
 


### PR DESCRIPTION

## Summary

net/devif: bypass send length check if ip fragment enabled

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

NET_ICMP & NET_IPFRAG