### PR TITLE
fs/mmap: fix compile warning if set the optimize level to O3

### DIFF
--- a/fs/mmap/fs_mmap.c
+++ b/fs/mmap/fs_mmap.c
@@ -149,7 +149,7 @@ static int file_mmap_(FAR struct file *filep, FAR void *start,
   /* Return */
 
 out:
-  if (ret == OK)
+  if (ret >= OK)
     {
       *mapped = entry.vaddr;
     }


### PR DESCRIPTION

## Summary

fs/mmap: fix compile warning if set the optimize level to O3

```
| $ gcc -c "-O3" -Wall -isystem include -D__NuttX__ -D__KERNEL__ -I fs -I sched fs/mmap/fs_mmap.c -o fs_mmap.o
| include/sys/mman.h: In function ‘mmap’:
| fs/mmap/fs_mmap.c:259:13: warning: ‘mapped’ may be used uninitialized in this function [-Wmaybe-uninitialized]
|   259 |   FAR void *mapped;
|       |             ^~~~~~
```

Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

ci-check