### PR TITLE
riscv/addrenv_shm: Add missing sanity check to up_shmdt()

### DIFF
--- a/arch/risc-v/src/common/riscv_addrenv_shm.c
+++ b/arch/risc-v/src/common/riscv_addrenv_shm.c
@@ -159,6 +159,10 @@ int up_shmdt(uintptr_t vaddr, unsigned int npages)
 
       paddr = mmu_pte_to_paddr(mmu_ln_getentry(ptlevel, ptprev, vaddr));
       ptlast = riscv_pgvaddr(paddr);
+      if (!ptlast)
+        {
+          return -EFAULT;
+        }
 
       /* Then wipe the reference */
 


### PR DESCRIPTION
## Summary
A missing sanity check, make sure the last level page table actually exists before trying to clear entries from it.
## Impact
Almost nothing, only riscv up_shmdt is affected
## Testing
icicle:knsh
