### PR TITLE
group/addrenv: An assorment of fixes to address environment handling (part1)

### DIFF
--- a/arch/arm/src/armv7-a/arm_addrenv_utils.c
+++ b/arch/arm/src/armv7-a/arm_addrenv_utils.c
@@ -171,10 +171,6 @@ void arm_addrenv_destroy_region(uintptr_t **list, unsigned int listlen,
 
   for (i = 0; i < listlen; vaddr += SECTION_SIZE, i++)
     {
-      /* Unhook the L2 page table from the L1 page table */
-
-      mmu_l1_clrentry(vaddr);
-
       /* Has this page table been allocated? */
 
       paddr = (uintptr_t)list[i];

--- a/binfmt/libelf/libelf_addrenv.c
+++ b/binfmt/libelf/libelf_addrenv.c
@@ -259,9 +259,7 @@ void elf_addrenv_free(FAR struct elf_loadinfo_s *loadinfo)
 
   /* Free the address environment */
 
-  elf_addrenv_select(loadinfo);
   ret = up_addrenv_destroy(&loadinfo->addrenv);
-  elf_addrenv_restore(loadinfo);
   if (ret < 0)
     {
       berr("ERROR: up_addrenv_destroy failed: %d\n", ret);

--- a/sched/group/group_leave.c
+++ b/sched/group/group_leave.c
@@ -129,7 +129,6 @@ static void group_remove(FAR struct task_group_s *group)
 static inline void group_release(FAR struct task_group_s *group)
 {
 #ifdef CONFIG_ARCH_ADDRENV
-  save_addrenv_t oldenv;
   int i;
 #endif
 
@@ -203,10 +202,6 @@ static inline void group_release(FAR struct task_group_s *group)
 #endif
 
 #ifdef CONFIG_ARCH_ADDRENV
-  /* Switch the addrenv and also save the current addrenv */
-
-  up_addrenv_select(&group->tg_addrenv, &oldenv);
-
   /* Destroy the group address environment */
 
   up_addrenv_destroy(&group->tg_addrenv);
@@ -220,10 +215,6 @@ static inline void group_release(FAR struct task_group_s *group)
           g_group_current[i] = NULL;
         }
     }
-
-  /* Restore the previous addrenv */
-
-  up_addrenv_restore(&oldenv);
 #endif
 
 #if defined(CONFIG_SCHED_WAITPID) && !defined(CONFIG_SCHED_HAVE_PARENT)


### PR DESCRIPTION
## Summary
This removes some incorrect usage of up_addrenv_select/up_addrenv_restore. When an address environment is destroyed, there is no need to map the address environment to MMU. Everything that is freed is either from kernel memory or page pool.

Also, remove the unnecessary detaching of L2 table from L1 table in ARM / arm_addrenv_destroy_region. The region is being destroyed thus the mapping will also be naturally lost.

This is preparation for a much bigger re-factoring of the address environments, especially usage up_addrenv_select/up_addrenv_restore which is prone to system crashes if a context switch or IRQ happens in between.

More about this story can be found from here: https://github.com/apache/nuttx/pull/7966
## Impact
Removes redundant code
## Testing
icicle:knsh and sabre-6quad:netknsh with qemu
