### PR TITLE
Pthread： fixed pthread issue

### DIFF
--- a/libs/libc/pthread/pthread_exit.c
+++ b/libs/libc/pthread/pthread_exit.c
@@ -58,9 +58,7 @@ void pthread_exit(FAR void *exit_value)
    * kicked off by actions taken during pthread_exit processing.
    */
 
-#ifdef CONFIG_CANCELLATION_POINTS
   task_setcancelstate(TASK_CANCEL_DISABLE, NULL);
-#endif
 
 #ifdef CONFIG_PTHREAD_CLEANUP
   pthread_cleanup_popall(tls_get_info());

--- a/sched/pthread/pthread_findjoininfo.c
+++ b/sched/pthread/pthread_findjoininfo.c
@@ -140,7 +140,8 @@ FAR struct join_s *pthread_findjoininfo(FAR struct task_group_s *group,
     {
       FAR struct tcb_s *tcb = nxsched_get_tcb((pthread_t)pid);
 
-      if (tcb != NULL && (tcb->flags & TCB_FLAG_DETACHED) == 0)
+      if (tcb != NULL && (tcb->flags & TCB_FLAG_DETACHED) == 0 &&
+          (tcb->flags & TCB_FLAG_TTYPE_MASK) == TCB_FLAG_TTYPE_PTHREAD)
         {
           pjoin = pthread_createjoininfo((FAR struct pthread_tcb_s *)tcb);
         }

--- a/sched/task/task_exithook.c
+++ b/sched/task/task_exithook.c
@@ -469,14 +469,14 @@ void nxtask_exithook(FAR struct tcb_s *tcb, int status)
     }
 #endif
 
-#ifdef CONFIG_SMP
-  leave_critical_section(flags);
-#endif
-
   /* This function can be re-entered in certain cases.  Set a flag
    * bit in the TCB to not that we have already completed this exit
    * processing.
    */
 
   tcb->flags |= TCB_FLAG_EXIT_PROCESSING;
+
+#ifdef CONFIG_SMP
+  leave_critical_section(flags);
+#endif
 }


### PR DESCRIPTION
## Summary

1. Check pthread group and flags before join;
2. Fixed pthread_cancel and pthread_exit crash in SMP mode;

## Impact

Pthread

## Testing

sabre-6quad:smp ostest