### PR TITLE
touchscreen.h: move the #ifdef CONFIG_INPUT position

### DIFF
--- a/include/nuttx/input/touchscreen.h
+++ b/include/nuttx/input/touchscreen.h
@@ -40,8 +40,6 @@
 #include <nuttx/semaphore.h>
 #include <time.h>
 
-#ifdef CONFIG_INPUT
-
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -149,6 +147,8 @@ struct touch_sample_s
 
 #define SIZEOF_TOUCH_SAMPLE_S(n) \
   (sizeof(struct touch_sample_s) + ((n) - 1) * sizeof(struct touch_point_s))
+
+#ifdef CONFIG_INPUT_TOUCHSCREEN
 
 /* This structure is for touchscreen lower half driver */
 


### PR DESCRIPTION
## Summary
the application can access the remote cpu touch driver by rpmsgdev, so the defines and struct will be used even if not enable the CONFIG_INPUT/CONFIG_INPUT_TOUCHSCREEN.

## Impact
None

## Testing
Vela
