### PR TITLE
sched/semaphore: increase sem count when holder task exit

### DIFF
--- a/sched/semaphore/sem_holder.c
+++ b/sched/semaphore/sem_holder.c
@@ -1049,6 +1049,12 @@ void nxsem_release_all(FAR struct tcb_s *htcb)
       FAR sem_t *sem = pholder->sem;
 
       nxsem_freeholder(sem, pholder);
+
+      /* Increment the count on the semaphore, to releases the count
+       * that was taken by sem_wait() or sem_post().
+       */
+
+      sem->semcount++;
     }
 }
 


### PR DESCRIPTION
## Summary

Increase the sem count when the holder task exit, to avoid lock failure at next time.

## Impact

task exit

## Testing

sabre-6quad:smp ostest