### PR TITLE
Build warning fixes

### DIFF
--- a/drivers/can/can.c
+++ b/drivers/can/can.c
@@ -506,7 +506,7 @@ static ssize_t can_read(FAR struct file *filep, FAR char *buffer,
   FAR struct can_dev_s     *dev = inode->i_private;
 #endif
 
-  caninfo("buflen: %d\n", buflen);
+  caninfo("buflen: %zu\n", buflen);
 
   /* The caller must provide enough memory to catch the smallest possible
    * message.  This is not a system error condition, but we won't permit
@@ -743,7 +743,7 @@ static ssize_t can_write(FAR struct file *filep, FAR const char *buffer,
   int                      msglen;
   int                      ret   = 0;
 
-  caninfo("buflen: %d\n", buflen);
+  caninfo("buflen: %zu\n", buflen);
 
   /* Interrupts must disabled throughout the following */
 

--- a/mm/mempool/mempool_multiple.c
+++ b/mm/mempool/mempool_multiple.c
@@ -220,7 +220,7 @@ mempool_multiple_get_dict(FAR struct mempool_multiple_s *mpool,
   col = index - (row << mpool->dict_col_num_log2);
   if (mpool->dict[row] == NULL ||
       mpool->dict[row][col].addr != addr ||
-      blk - addr >= mpool->dict[row][col].size)
+      (FAR char *)blk - (FAR char *)addr >= mpool->dict[row][col].size)
     {
       return NULL;
     }


### PR DESCRIPTION
## Summary

This removes some build warnings on printf formatters and void * arithmetic.

## Impact

Only build warnings, no functional impact

## Testing

Built for several platforms
