### PR TITLE
riscv/addrenv: Do not free physical memory for SHM area

### DIFF
--- a/arch/risc-v/src/common/riscv_mmu.c
+++ b/arch/risc-v/src/common/riscv_mmu.c
@@ -145,3 +145,10 @@ void mmu_ln_map_region(uint32_t ptlevel, uintptr_t lnvaddr, uintptr_t paddr,
       vaddr += page_size;
     }
 }
+
+size_t mmu_get_region_size(uint32_t ptlevel)
+{
+  DEBUGASSERT(ptlevel > 0 && ptlevel <= RV_MMU_PT_LEVELS);
+
+  return g_pgt_sizes[ptlevel - 1];
+}

--- a/arch/risc-v/src/common/riscv_mmu.h
+++ b/arch/risc-v/src/common/riscv_mmu.h
@@ -405,4 +405,21 @@ void mmu_ln_restore(uint32_t ptlevel, uintptr_t lnvaddr, uintptr_t vaddr,
 void mmu_ln_map_region(uint32_t ptlevel, uintptr_t lnvaddr, uintptr_t paddr,
                        uintptr_t vaddr, size_t size, uint32_t mmuflags);
 
+/****************************************************************************
+ * Name: mmu_ln_map_region
+ *
+ * Description:
+ *   Get (giga/mega) page size for level n.
+ *
+ * Input Parameters:
+ *   ptlevel - The translation table level, amount of levels is
+ *     MMU implementation specific
+ *
+ * Returned Value:
+ *   Region size for one page at level n.
+ *
+ ****************************************************************************/
+
+size_t mmu_get_region_size(uint32_t ptlevel);
+
 #endif /* ___ARCH_RISC_V_SRC_COMMON_RISCV_MMU_H_ */


### PR DESCRIPTION
## Summary
Fix crash when SHM memory is freed twice into the page pool.

SHM area is just mapped memory, the physical backup is not owned by the process, so the process must not free it.

In ARM this is already handled as the regions are destroyed one by one, while this implementation does a page directory walk instead.
## Impact
riscv only
## Testing
icicle:knsh
