### PR TITLE
limits.h: add PTRDIFF_MAX and PTRDIFF_MIN

### DIFF
--- a/include/limits.h
+++ b/include/limits.h
@@ -309,4 +309,9 @@
 
 #define HOST_NAME_MAX  32
 
+/* ptrdiff_t limits */
+
+#define PTRDIFF_MAX PTR_MAX
+#define PTRDIFF_MIN PTR_MIN
+
 #endif /* __INCLUDE_LIMITS_H */


### PR DESCRIPTION
ptrdiff_t is defined as int in Nuttx and thus these are same as int limits. By defining these we cover platforms where this might not be the same.
