### PR TITLE
Acknowledge interrupt before installing callback

### DIFF
--- a/arch/arm/src/stm32/stm32_exti_gpio.c
+++ b/arch/arm/src/stm32/stm32_exti_gpio.c
@@ -312,6 +312,7 @@ int stm32_gpiosetevent(uint32_t pinset, bool risingedge, bool fallingedge,
 
   if (func)
     {
+      putreg32(exti, STM32_EXTI_PR);
       irq_attach(irq, handler, NULL);
       up_enable_irq(irq);
     }


### PR DESCRIPTION
## Summary
Acknowledge the interrupt before installing the callback...

## Impact
...otherwise it will fire unexpectedly if it's already pending.

## Testing
Impact no longer observed.
