### PR TITLE
c++: Change the default value of CXX_STANDARD from c++17 to gnu++17

### DIFF
--- a/libs/libxx/Kconfig
+++ b/libs/libxx/Kconfig
@@ -87,9 +87,10 @@ endif
 
 config CXX_STANDARD
 	string "Language standard"
-	default "c++17"
+	default "gnu++17"
 	---help---
-		Possible values: c++98, c++11, c++14, c++17 and c++20
+		Possible values:
+		gnu++98/c++98, gnu++11/c++11, gnu++14/c++14, gnu++17/c++17 and gnu++20/c++20
 
 config CXX_EXCEPTION
 	bool "Enable Exception Support"


### PR DESCRIPTION
## Summary

since many 3rd party code use some gnu c++ extension

## Impact

C++ default compiler option

## Testing

Pass CI