### PR TITLE
mm/mm_extend: Increase total heap size accordingly

### DIFF
--- a/mm/mm_heap/mm_extend.c
+++ b/mm/mm_heap/mm_extend.c
@@ -106,6 +106,10 @@ void mm_extend(FAR struct mm_heap_s *heap, FAR void *mem, size_t size,
   newnode->preceding = oldnode->size | MM_ALLOC_BIT;
 
   heap->mm_heapend[region] = newnode;
+
+  /* Finally, increase the total heap size accordingly */
+
+  heap->mm_heapsize += size;
   mm_unlock(heap);
 
   /* Finally "free" the new block of memory where the old terminal node was


### PR DESCRIPTION
## Summary
When adding more heap memory, the total heap size was not updated. This results in a crash in mm_mallinfo:

DEBUGASSERT((size_t)info->uordblks + info->fordblks == heap->mm_heapsize);

This commit fixes this issue
## Impact
Fix crash in mm_mallinfo if sbrk / mm_extend is used, especially happens in CONFIG_BUILD_KERNEL
## Testing
icicle:knsh
