### PR TITLE
backtrace: use CURRENT_REGS when in interrupt context

### DIFF
--- a/arch/arm/src/common/arm_backtrace_fp.c
+++ b/arch/arm/src/common/arm_backtrace_fp.c
@@ -140,8 +140,8 @@ int up_backtrace(struct tcb_s *tcb,
             {
               ret += backtrace(rtcb->stack_base_ptr,
                                rtcb->stack_base_ptr + rtcb->adj_stack_size,
-                               (void *)rtcb->xcp.regs[REG_FP],
-                               (void *)rtcb->xcp.regs[REG_PC],
+                               (void *)CURRENT_REGS[REG_FP],
+                               (void *)CURRENT_REGS[REG_PC],
                                &buffer[ret], size - ret, &skip);
             }
         }

--- a/arch/arm/src/common/arm_backtrace_sp.c
+++ b/arch/arm/src/common/arm_backtrace_sp.c
@@ -262,7 +262,7 @@ int up_backtrace(struct tcb_s *tcb,
               ret += backtrace_branch((unsigned long)
                                       rtcb->stack_base_ptr +
                                       rtcb->adj_stack_size,
-                                      rtcb->xcp.regs[REG_SP],
+                                      CURRENT_REGS[REG_SP],
                                       &buffer[ret],
                                       size - ret, &skip);
             }

--- a/arch/arm/src/common/arm_backtrace_unwind.c
+++ b/arch/arm/src/common/arm_backtrace_unwind.c
@@ -630,9 +630,9 @@ int up_backtrace(struct tcb_s *tcb,
           ret = backtrace_unwind(&frame, buffer, size, &skip);
           if (ret < size)
             {
-              frame.fp = rtcb->xcp.regs[REG_FP];
-              frame.sp = rtcb->xcp.regs[REG_SP];
-              frame.pc = rtcb->xcp.regs[REG_PC];
+              frame.fp = CURRENT_REGS[REG_FP];
+              frame.sp = CURRENT_REGS[REG_SP];
+              frame.pc = CURRENT_REGS[REG_PC];
               frame.lr = 0;
               frame.stack_top = (unsigned long)rtcb->stack_base_ptr +
                                                rtcb->adj_stack_size;

--- a/arch/risc-v/src/common/riscv_backtrace.c
+++ b/arch/risc-v/src/common/riscv_backtrace.c
@@ -155,8 +155,8 @@ int up_backtrace(struct tcb_s *tcb, void **buffer, int size, int skip)
             {
               ret += backtrace(rtcb->stack_base_ptr,
                                rtcb->stack_base_ptr + rtcb->adj_stack_size,
-                               (void *)rtcb->xcp.regs[REG_FP],
-                               (void *)rtcb->xcp.regs[REG_EPC],
+                               (void *)CURRENT_REGS[REG_FP],
+                               (void *)CURRENT_REGS[REG_EPC],
                                &buffer[ret], size - ret, &skip);
             }
         }

--- a/arch/xtensa/src/common/xtensa_backtrace.c
+++ b/arch/xtensa/src/common/xtensa_backtrace.c
@@ -255,8 +255,8 @@ int up_backtrace(struct tcb_s *tcb, void **buffer, int size, int skip)
 #endif
           ret += backtrace_stack(rtcb->stack_base_ptr,
                                  rtcb->stack_base_ptr + rtcb->adj_stack_size,
-                                 (void *)rtcb->xcp.regs[REG_A1],
-                                 (void *)rtcb->xcp.regs[REG_A0],
+                                 (void *)CURRENT_REGS[REG_A1],
+                                 (void *)CURRENT_REGS[REG_A0],
                                  &buffer[ret], size - ret, &skip);
         }
       else


### PR DESCRIPTION
## Summary

Backtrace CURRENT_REGS when in interrupt context.

Because when panic occurs in the interrupt context, xcp.regs for the running task is not updated, so need use CURRENT_REGS

## Impact

NA

## Testing

BES2003