### PR TITLE
fs: Avoid accessing filep fields if it is NULL & add DEBUGASSERTs

### DIFF
--- a/fs/inode/fs_files.c
+++ b/fs/inode/fs_files.c
@@ -269,6 +269,9 @@ int files_duplist(FAR struct filelist *plist, FAR struct filelist *clist)
   int i;
   int j;
 
+  DEBUGASSERT(clist);
+  DEBUGASSERT(plist);
+
   ret = nxmutex_lock(&plist->fl_lock);
   if (ret < 0)
     {
@@ -298,7 +301,10 @@ int files_duplist(FAR struct filelist *plist, FAR struct filelist *clist)
 #endif
 
           filep = &plist->fl_files[i][j];
-          if (filep->f_inode == NULL || (filep->f_oflags & O_CLOEXEC) != 0)
+          DEBUGASSERT(filep);
+
+          if (filep && (filep->f_inode == NULL ||
+                       (filep->f_oflags & O_CLOEXEC) != 0))
             {
               continue;
             }


### PR DESCRIPTION
## Summary
Avoid accessing filep fields if it is NULL & add DEBUGASSERTs
## Impact
Avoid crashes
## Testing
esp32-devkit
