### PR TITLE
esp32: fix lower half oneshot for usage with nxsched_oneshot_start

### DIFF
--- a/arch/xtensa/src/esp32/esp32_oneshot_lowerhalf.c
+++ b/arch/xtensa/src/esp32/esp32_oneshot_lowerhalf.c
@@ -211,7 +211,6 @@ static int esp32_lh_start(struct oneshot_lowerhalf_s *lower,
 
   DEBUGASSERT(priv != NULL);
   DEBUGASSERT(callback != NULL);
-  DEBUGASSERT(arg != NULL);
   DEBUGASSERT(ts != NULL);
 
   /* Save the callback information and start the timer */


### PR DESCRIPTION
## Summary
This fix is required for using the oneshot driver for cpuload monitoring. Otherwise an assertion is thrown since nxsched_oneshot_start pass NULL as arg.
## Impact

## Testing
Tested with esp32-devkitc.
