### PR TITLE
drivers/foc: add interface that turn off all PWM switches

### DIFF
--- a/arch/arm/src/stm32/stm32_foc.c
+++ b/arch/arm/src/stm32/stm32_foc.c
@@ -766,6 +766,7 @@ static int stm32_foc_shutdown(struct foc_dev_s *dev);
 static int stm32_foc_start(struct foc_dev_s *dev, bool state);
 static int stm32_foc_pwm_duty_set(struct foc_dev_s *dev,
                                   foc_duty_t *duty);
+static int stm32_foc_pwm_off(struct foc_dev_s *dev, bool off);
 static int stm32_foc_ioctl(struct foc_dev_s *dev, int cmd,
                            unsigned long arg);
 static int stm32_foc_bind(struct foc_dev_s *dev,
@@ -857,6 +858,7 @@ static struct foc_lower_ops_s g_stm32_foc_ops =
   .shutdown       = stm32_foc_shutdown,
   .start          = stm32_foc_start,
   .pwm_duty_set   = stm32_foc_pwm_duty_set,
+  .pwm_off        = stm32_foc_pwm_off,
   .ioctl          = stm32_foc_ioctl,
   .bind           = stm32_foc_bind,
   .fault_clear    = stm32_foc_fault_clear,
@@ -1906,6 +1908,48 @@ static int stm32_foc_pwm_duty_set(struct foc_dev_s *dev,
 #if CONFIG_MOTOR_FOC_PHASES > 3
   putreg32(ccr[3], (foc_dev->pwm_base + STM32_GTIM_CCR4_OFFSET));
 #endif
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: stm32_foc_pwm_off
+ *
+ * Description:
+ *   Set the 3-phase bridge switches in off state.
+ *
+ ****************************************************************************/
+
+static int stm32_foc_pwm_off(struct foc_dev_s *dev, bool off)
+{
+  struct stm32_pwm_dev_s *pwm = PWM_FROM_FOC_DEV_GET(dev);
+
+  if (off)
+    {
+      /* Force all transistors to low state */
+
+      PWM_MODE_UPDATE(pwm, STM32_PWM_CHAN1, PWM_MODE_HIZ);
+      PWM_MODE_UPDATE(pwm, STM32_PWM_CHAN2, PWM_MODE_HIZ);
+#if CONFIG_MOTOR_FOC_PHASES > 2
+      PWM_MODE_UPDATE(pwm, STM32_PWM_CHAN3, PWM_MODE_HIZ);
+#endif
+#if CONFIG_MOTOR_FOC_PHASES > 3
+      PWM_MODE_UPDATE(pwm, STM32_PWM_CHAN4, PWM_MODE_HIZ);
+#endif
+    }
+  else
+    {
+      /* Restore FOC operation modes */
+
+      PWM_MODE_UPDATE(pwm, STM32_PWM_CHAN1, PWM_MODE_FOC);
+      PWM_MODE_UPDATE(pwm, STM32_PWM_CHAN2, PWM_MODE_FOC);
+#if CONFIG_MOTOR_FOC_PHASES > 2
+      PWM_MODE_UPDATE(pwm, STM32_PWM_CHAN3, PWM_MODE_FOC);
+#endif
+#if CONFIG_MOTOR_FOC_PHASES > 3
+      PWM_MODE_UPDATE(pwm, STM32_PWM_CHAN4, PWM_MODE_FOC);
+#endif
+    }
 
   return OK;
 }

--- a/arch/arm/src/stm32f7/stm32_foc.c
+++ b/arch/arm/src/stm32f7/stm32_foc.c
@@ -591,6 +591,7 @@ static int stm32_foc_shutdown(struct foc_dev_s *dev);
 static int stm32_foc_start(struct foc_dev_s *dev, bool state);
 static int stm32_foc_pwm_duty_set(struct foc_dev_s *dev,
                                   foc_duty_t *duty);
+static int stm32_foc_pwm_off(struct foc_dev_s *dev, bool off);
 static int stm32_foc_ioctl(struct foc_dev_s *dev, int cmd,
                            unsigned long arg);
 static int stm32_foc_bind(struct foc_dev_s *dev,
@@ -657,6 +658,7 @@ static struct foc_lower_ops_s g_stm32_foc_ops =
   .shutdown       = stm32_foc_shutdown,
   .start          = stm32_foc_start,
   .pwm_duty_set   = stm32_foc_pwm_duty_set,
+  .pwm_off        = stm32_foc_pwm_off,
   .ioctl          = stm32_foc_ioctl,
   .bind           = stm32_foc_bind,
   .fault_clear    = stm32_foc_fault_clear,
@@ -1696,6 +1698,48 @@ static int stm32_foc_pwm_duty_set(struct foc_dev_s *dev,
 #if CONFIG_MOTOR_FOC_PHASES > 3
   putreg32(ccr[3], (foc_dev->pwm_base + STM32_GTIM_CCR4_OFFSET));
 #endif
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: stm32_foc_pwm_off
+ *
+ * Description:
+ *   Set the 3-phase bridge switches in off state.
+ *
+ ****************************************************************************/
+
+static int stm32_foc_pwm_off(struct foc_dev_s *dev, bool off)
+{
+  struct stm32_pwm_dev_s *pwm = PWM_FROM_FOC_DEV_GET(dev);
+
+  if (off)
+    {
+      /* Force all transistors to low state */
+
+      PWM_MODE_UPDATE(pwm, STM32_PWM_CHAN1, PWM_MODE_HIZ);
+      PWM_MODE_UPDATE(pwm, STM32_PWM_CHAN2, PWM_MODE_HIZ);
+#if CONFIG_MOTOR_FOC_PHASES > 2
+      PWM_MODE_UPDATE(pwm, STM32_PWM_CHAN3, PWM_MODE_HIZ);
+#endif
+#if CONFIG_MOTOR_FOC_PHASES > 3
+      PWM_MODE_UPDATE(pwm, STM32_PWM_CHAN4, PWM_MODE_HIZ);
+#endif
+    }
+  else
+    {
+      /* Restore FOC operation modes */
+
+      PWM_MODE_UPDATE(pwm, STM32_PWM_CHAN1, PWM_MODE_FOC);
+      PWM_MODE_UPDATE(pwm, STM32_PWM_CHAN2, PWM_MODE_FOC);
+#if CONFIG_MOTOR_FOC_PHASES > 2
+      PWM_MODE_UPDATE(pwm, STM32_PWM_CHAN3, PWM_MODE_FOC);
+#endif
+#if CONFIG_MOTOR_FOC_PHASES > 3
+      PWM_MODE_UPDATE(pwm, STM32_PWM_CHAN4, PWM_MODE_FOC);
+#endif
+    }
 
   return OK;
 }

--- a/drivers/motor/foc/foc_dev.c
+++ b/drivers/motor/foc/foc_dev.c
@@ -60,6 +60,7 @@ static int foc_params_set(FAR struct foc_dev_s *dev,
 static int foc_fault_clear(FAR struct foc_dev_s *dev);
 static int foc_info_get(FAR struct foc_dev_s *dev,
                         FAR struct foc_info_s *info);
+static int foc_pwm_off(FAR struct foc_dev_s *dev, bool off);
 
 static int foc_notifier(FAR struct foc_dev_s *dev,
                         FAR foc_current_t *current);
@@ -233,6 +234,9 @@ static int foc_close(FAR struct file *filep)
  *   MTRIOC_GET_INFO:     Get the FOC device info,
  *                        arg: struct foc_info_s pointer
  *
+ *   MTRIOC_PWM_OFF:      Force all PWM switches to the off state.
+ *                        arg: bool pointer
+ *
  ****************************************************************************/
 
 static int foc_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
@@ -339,7 +343,7 @@ static int foc_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
       case MTRIOC_GET_INFO:
         {
-          FAR struct foc_info_s *info = (struct foc_info_s *)arg;
+          FAR struct foc_info_s *info = (FAR struct foc_info_s *)arg;
 
           DEBUGASSERT(info != NULL);
 
@@ -351,6 +355,21 @@ static int foc_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
           break;
         }
+
+      case MTRIOC_PWM_OFF:
+      {
+        FAR bool *off = (FAR bool *)arg;
+
+        DEBUGASSERT(off != NULL);
+
+        ret = foc_pwm_off(dev, *off);
+        if (ret != OK)
+          {
+            mtrerr("MTRIOC_PWM_OFF failed %d\n", ret);
+          }
+
+        break;
+      }
 
       /* Not supported */
 
@@ -383,6 +402,7 @@ static int foc_lower_ops_assert(FAR struct foc_lower_ops_s *ops)
   DEBUGASSERT(ops->setup);
   DEBUGASSERT(ops->shutdown);
   DEBUGASSERT(ops->start);
+  DEBUGASSERT(ops->pwm_off);
   DEBUGASSERT(ops->ioctl);
   DEBUGASSERT(ops->bind);
   DEBUGASSERT(ops->fault_clear);
@@ -502,6 +522,13 @@ static int foc_start(FAR struct foc_dev_s *dev)
       goto errout;
     }
 
+  if (!dev->state.pwm_off)
+    {
+      /* Make sure that PWM is enabled if pwm_off was not called before */
+
+      ret = foc_pwm_off(dev, false);
+    }
+
   /* Start the FOC */
 
   ret = FOC_OPS_START(dev, true);
@@ -535,6 +562,10 @@ static int foc_stop(FAR struct foc_dev_s *dev)
   /* Zero duty cycle */
 
   memset(&d_zero, 0, CONFIG_MOTOR_FOC_PHASES * sizeof(foc_duty_t));
+
+  /* Make sure that PWM is disabled */
+
+  ret = foc_pwm_off(dev, true);
 
   /* Reset duty cycle */
 
@@ -684,6 +715,16 @@ static int foc_params_set(FAR struct foc_dev_s *dev,
   DEBUGASSERT(dev);
   DEBUGASSERT(params);
 
+  /* If PWM switches are turned off, the change of duty cycle has no
+   * effect.
+   */
+
+  if (dev->state.pwm_off)
+    {
+      ret = -EPERM;
+      goto errout;
+    }
+
 #ifdef CONFIG_MOTOR_FOC_TRACE
   FOC_OPS_TRACE(dev, FOC_TRACE_PARAMS, true);
 #endif
@@ -696,6 +737,7 @@ static int foc_params_set(FAR struct foc_dev_s *dev,
   FOC_OPS_TRACE(dev, FOC_TRACE_PARAMS, false);
 #endif
 
+errout:
   return ret;
 }
 
@@ -715,6 +757,25 @@ static int foc_info_get(FAR struct foc_dev_s *dev,
   memcpy(info, &dev->info, sizeof(struct foc_info_s));
 
   return OK;
+}
+
+/****************************************************************************
+ * Name: foc_info_get
+ *
+ * Description:
+ *   Force all PWM swichtes to the off state
+ *
+ ****************************************************************************/
+
+static int foc_pwm_off(FAR struct foc_dev_s *dev, bool off)
+{
+  DEBUGASSERT(dev);
+
+  /* Update device state */
+
+  dev->state.pwm_off = off;
+
+  return FOC_OPS_PWMOFF(dev, off);
 }
 
 /****************************************************************************

--- a/drivers/motor/foc/foc_dummy.c
+++ b/drivers/motor/foc/foc_dummy.c
@@ -101,6 +101,7 @@ static int foc_dummy_shutdown(FAR struct foc_dev_s *dev);
 static int foc_dummy_start(FAR struct foc_dev_s *dev, bool state);
 static int foc_dummy_pwm_duty_set(FAR struct foc_dev_s *dev,
                                   FAR foc_duty_t *duty);
+static int foc_pwm_off(struct foc_dev_s *dev, bool off);
 static int foc_dummy_ioctl(FAR struct foc_dev_s *dev, int cmd,
                            unsigned long arg);
 static int foc_dummy_bind(FAR struct foc_dev_s *dev,
@@ -140,6 +141,7 @@ static struct foc_lower_ops_s g_foc_dummy_ops =
   foc_dummy_setup,
   foc_dummy_shutdown,
   foc_dummy_pwm_duty_set,
+  foc_pwm_off,
   foc_dummy_start,
   foc_dummy_ioctl,
   foc_dummy_bind,
@@ -504,6 +506,21 @@ static int foc_dummy_pwm_duty_set(FAR struct foc_dev_s *dev,
 #else
 #  error
 #endif
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: foc_pwm_off
+ *
+ * Description:
+ *   Set the 3-phase bridge switches in off state.
+ *
+ ****************************************************************************/
+
+static int foc_pwm_off(struct foc_dev_s *dev, bool off)
+{
+  mtrinfo("[PWM_OFF] %d\n", off);
 
   return OK;
 }

--- a/include/nuttx/motor/foc/foc.h
+++ b/include/nuttx/motor/foc/foc.h
@@ -82,6 +82,7 @@ struct foc_cfg_s
 
 struct foc_state_s
 {
+  bool          pwm_off;                       /* PWM switches disabled */
   uint8_t       fault;                         /* Fault state */
   foc_current_t curr[CONFIG_MOTOR_FOC_PHASES]; /* Phase current feedback */
 };

--- a/include/nuttx/motor/foc/foc_lower.h
+++ b/include/nuttx/motor/foc/foc_lower.h
@@ -45,6 +45,7 @@
 #define FOC_OPS_SETUP(d)                (d)->lower->ops->setup(d)
 #define FOC_OPS_SHUTDOWN(d)             (d)->lower->ops->shutdown(d)
 #define FOC_OPS_START(d, s)             (d)->lower->ops->start(d, s)
+#define FOC_OPS_PWMOFF(d, o)            (d)->lower->ops->pwm_off(d, o)
 #define FOC_OPS_DUTY(d, x)              (d)->lower->ops->pwm_duty_set(d, x)
 #define FOC_OPS_IOCTL(d, c, a)          (d)->lower->ops->ioctl(d, c, a)
 #define FOC_OPS_BIND(d, c)              (d)->lower->ops->bind(d, c)
@@ -107,6 +108,10 @@ struct foc_lower_ops_s
 
   CODE int (*pwm_duty_set)(FAR struct foc_dev_s *dev,
                            FAR foc_duty_t *duty);
+
+  /* Force all PWM switches to the off state */
+
+  CODE int (*pwm_off)(FAR struct foc_dev_s *dev, bool off);
 
   /* Lower-half start/stop */
 

--- a/include/nuttx/motor/motor_ioctl.h
+++ b/include/nuttx/motor/motor_ioctl.h
@@ -49,5 +49,6 @@
 #define MTRIOC_SET_LIMITS     _MTRIOC(9)
 #define MTRIOC_SET_FAULT      _MTRIOC(10)
 #define MTRIOC_GET_FAULT      _MTRIOC(11)
+#define MTRIOC_PWM_OFF        _MTRIOC(12)
 
 #endif /* __INCLUDE_NUTTX_MOTOR_MOTOR_IOCTL_H */


### PR DESCRIPTION
## Summary
- drivers/foc: add ioctl interface that turn off all PWM switches
- stm32,stm32f7/foc: support for pwm_off()

## Impact
Initial changes to support BEMF sensing when motor is not powered (all 3-phase inverter switches must be turned off).
Releted issue: https://github.com/apache/nuttx/issues/8098

## Testing
b-g431b-esc1
