### PR TITLE
sched: Map both NZERO and PTHREAD_DEFAULT_PRIORITY to SCHED_PRIORITY_DEFAULT

### DIFF
--- a/include/limits.h
+++ b/include/limits.h
@@ -281,10 +281,10 @@
 #define NL_TEXTMAX _POSIX2_LINE_MAX
 
 /* NZERO
- *   Default process priority. Minimum Acceptable Value: 128
+ *   Default process priority. Minimum Acceptable Value: 100
  */
 
-#define NZERO 128
+#define NZERO SCHED_PRIORITY_DEFAULT
 
 /* Required for asynchronous I/O */
 

--- a/include/pthread.h
+++ b/include/pthread.h
@@ -117,7 +117,7 @@
 
 /* Default priority */
 
-#define PTHREAD_DEFAULT_PRIORITY      100
+#define PTHREAD_DEFAULT_PRIORITY      SCHED_PRIORITY_DEFAULT
 
 /* Cancellation states used by pthread_setcancelstate() */
 


### PR DESCRIPTION
## Summary

to unify the default thread priority

## Impact

NZERO change from 128 to 100

## Testing

Pass CI