### PR TITLE
epoll.h: Add u64 field like Linux

### DIFF
--- a/include/sys/epoll.h
+++ b/include/sys/epoll.h
@@ -40,6 +40,9 @@
  * Included Files
  ****************************************************************************/
 
+#include <nuttx/config.h>
+#include <nuttx/compiler.h>
+
 #include <poll.h>
 #include <fcntl.h>
 
@@ -91,12 +94,17 @@ enum
 #define EPOLL_CLOEXEC EPOLL_CLOEXEC
 };
 
-typedef union poll_data
+union epoll_data
 {
   FAR void    *ptr;
   int          fd;
   uint32_t     u32;
-} epoll_data_t;
+#ifdef CONFIG_HAVE_LONG_LONG
+  uint64_t     u64;
+#endif
+};
+
+typedef union epoll_data epoll_data_t;
 
 struct epoll_event
 {


### PR DESCRIPTION
## Summary

https://man7.org/linux/man-pages/man2/epoll_wait.2.html

## Impact

New fields

## Testing

Pass CI