### PR TITLE
stm32,stm32f7: add support for BEMF sensing

### DIFF
--- a/arch/arm/src/stm32/hardware/stm32_adc_v2.h
+++ b/arch/arm/src/stm32/hardware/stm32_adc_v2.h
@@ -686,6 +686,7 @@
 #  define ADC_CCR_DUAL_DUAL          (1 << ADC_CCR_DUAL_SHIFT)   /* Dual mode, master/slave ADCs together */
 #  define ADC_CCR_DUAL_SIMINJ        (1 << ADC_CCR_DUAL_SHIFT)   /* Combined regular sim. + injected sim. */
 #  define ADC_CCR_DUAL_SIMALT        (2 << ADC_CCR_DUAL_SHIFT)   /* Combined regular sim. + alternate trigger */
+#  define ADC_CCR_DUAL_INTINJ        (3 << ADC_CCR_DUAL_SHIFT)   /* Combined interl. mode + injected sim. */
 #  define ADC_CCR_DUAL_INJECTED      (5 << ADC_CCR_DUAL_SHIFT)   /* Injected simultaneous mode only */
 #  define ADC_CCR_DUAL_SIM           (6 << ADC_CCR_DUAL_SHIFT)   /* Regular simultaneous mode only */
 #  define ADC_CCR_DUAL_INTERLEAVE    (7 << ADC_CCR_DUAL_SHIFT)   /* Interleaved mode only */

--- a/arch/arm/src/stm32/hardware/stm32_adc_v2g4.h
+++ b/arch/arm/src/stm32/hardware/stm32_adc_v2g4.h
@@ -819,6 +819,7 @@
 #  define ADC_CCR_DUAL_DUAL            (0x1 << ADC_CCR_DUAL_SHIFT)    /* 00001: Dual mode, master/slave ADCs together */
 #  define ADC_CCR_DUAL_SIMINJ          (0x1 << ADC_CCR_DUAL_SHIFT)    /* 00001: Combined regular sim. + injected sim. */
 #  define ADC_CCR_DUAL_SIMALT          (0x2 << ADC_CCR_DUAL_SHIFT)    /* 00010: Combined regular sim. + alternate trigger */
+#  define ADC_CCR_DUAL_INTINJ          (0x3 << ADC_CCR_DUAL_SHIFT)    /* 00011: Combined interl. mode + injected sim. */
 #  define ADC_CCR_DUAL_INJECTED        (0x5 << ADC_CCR_DUAL_SHIFT)    /* 00101: Injected simultaneous mode only */
 #  define ADC_CCR_DUAL_SIM             (0x6 << ADC_CCR_DUAL_SHIFT)    /* 00110: Regular simultaneous mode only */
 #  define ADC_CCR_DUAL_INTERLEAVE      (0x7 << ADC_CCR_DUAL_SHIFT)    /* 00111: Interleaved mode only */

--- a/arch/arm/src/stm32/stm32_adc.c
+++ b/arch/arm/src/stm32/stm32_adc.c
@@ -626,6 +626,8 @@ static void adc_sampletime_set(struct stm32_adc_dev_s *dev,
 static void adc_sampletime_write(struct stm32_adc_dev_s *dev);
 #  endif
 static void adc_llops_dumpregs(struct stm32_adc_dev_s *dev);
+static int  adc_llops_multicfg(struct stm32_adc_dev_s *dev, uint8_t mode);
+static void adc_llops_enable(struct stm32_adc_dev_s *dev, bool enable);
 #endif
 
 /****************************************************************************
@@ -679,7 +681,9 @@ static const struct stm32_adc_ops_s g_adc_llops =
   .stime_set     = adc_sampletime_set,
   .stime_write   = adc_sampletime_write,
 #  endif
-  .dump_regs     = adc_llops_dumpregs
+  .dump_regs     = adc_llops_dumpregs,
+  .multi_cfg     = adc_llops_multicfg,
+  .enable        = adc_llops_enable
 };
 #endif
 
@@ -4579,6 +4583,162 @@ static void adc_llops_dumpregs(struct stm32_adc_dev_s *dev)
   struct stm32_dev_s *priv = (struct stm32_dev_s *)dev;
 
   adc_dumpregs(priv);
+}
+
+/****************************************************************************
+ * Name: adc_llops_multicfg
+ *
+ * IMPORTANT: this interface is allowed only when the ADCs are disabled!
+ *
+ ****************************************************************************/
+
+static int adc_llops_multicfg(struct stm32_adc_dev_s *dev, uint8_t mode)
+#if defined(HAVE_IP_ADC_V2)
+{
+  struct stm32_dev_s *priv    = (struct stm32_dev_s *)dev;
+  int                 ret     = OK;
+  uint32_t            setbits = 0;
+  uint32_t            clrbits = 0;
+
+  switch (mode)
+    {
+      case ADC_MULTIMODE_INDEP:
+        setbits = ADC_CCR_DUAL_IND;
+        break;
+
+      case ADC_MULTIMODE_RSISM2:
+        setbits = ADC_CCR_DUAL_SIMALT;
+        break;
+
+      case ADC_MULTIMODE_RSATM2:
+        setbits = ADC_CCR_DUAL_SIMALT;
+        break;
+
+      case ADC_MULTIMODE_IMIS2:
+        setbits = ADC_CCR_DUAL_INTINJ;
+        break;
+
+      case ADC_MULTIMODE_ISM2:
+        setbits = ADC_CCR_DUAL_INJECTED;
+        break;
+
+      case ADC_MULTIMODE_RSM2:
+        setbits = ADC_CCR_DUAL_SIM;
+        break;
+
+      case ADC_MULTIMODE_IM2:
+        setbits = ADC_CCR_DUAL_INTERLEAVE;
+        break;
+
+      case ADC_MULTIMODE_ATM2:
+        setbits = ADC_CCR_DUAL_ALT;
+        break;
+
+      default:
+        ret = -EINVAL;
+        goto errout;
+    }
+
+  clrbits = ADC_CCR_DUAL_MASK;
+  adccmn_modifyreg(priv, STM32_ADC_CCR_OFFSET, clrbits, setbits);
+
+errout:
+  return ret;
+}
+#elif defined(HAVE_IP_ADC_V1) && !defined(HAVE_BASIC_ADC)
+{
+  struct stm32_dev_s *priv    = (struct stm32_dev_s *)dev;
+  int                 ret     = OK;
+  uint32_t            setbits = 0;
+  uint32_t            clrbits = 0;
+
+  switch (mode)
+    {
+      case ADC_MULTIMODE_INDEP:
+        setbits = ADC_CCR_MULTI_NONE;
+        break;
+
+      case ADC_MULTIMODE_RSISM2:
+        setbits = ADC_CCR_MULTI_RSISM2;
+        break;
+
+      case ADC_MULTIMODE_RSATM2:
+        setbits = ADC_CCR_MULTI_RSATM2;
+        break;
+
+      case ADC_MULTIMODE_ISM2:
+        setbits = ADC_CCR_MULTI_ISM2;
+        break;
+
+      case ADC_MULTIMODE_RSM2:
+        setbits = ADC_CCR_MULTI_ISM2;
+        break;
+
+      case ADC_MULTIMODE_IM2:
+        setbits = ADC_CCR_MULTI_IM2;
+        break;
+
+      case ADC_MULTIMODE_ATM2:
+        setbits = ADC_CCR_MULTI_ATM2;
+        break;
+
+      case ADC_MULTIMODE_RSISM3:
+        setbits = ADC_CCR_MULTI_RSISM3;
+        break;
+
+      case ADC_MULTIMODE_RSATM3:
+        setbits = ADC_CCR_MULTI_RSATM3;
+        break;
+
+      case ADC_MULTIMODE_ISM3:
+        setbits = ADC_CCR_MULTI_ISM3;
+        break;
+
+      case ADC_MULTIMODE_RSM3:
+        setbits = ADC_CCR_MULTI_ISM3;
+        break;
+
+      case ADC_MULTIMODE_IM3:
+        setbits = ADC_CCR_MULTI_IM3;
+        break;
+
+      case ADC_MULTIMODE_ATM3:
+        setbits = ADC_CCR_MULTI_ATM3;
+        break;
+
+      case ADC_MULTIMODE_IMIS2:
+      case ADC_MULTIMODE_IMIS3:
+      default:
+        ret = -EINVAL;
+        goto errout;
+    }
+
+  clrbits = ADC_CCR_MULTI_MASK;
+  adccmn_modifyreg(priv, STM32_ADC_CCR_OFFSET, clrbits, setbits);
+
+errout:
+  return ret;
+}
+#else  /* ADV IPv1 BASIC */
+{
+  if (mode != ADC_MULTIMODE_INDEP)
+    {
+      return -EINVAL;
+    }
+
+  return OK;
+}
+#endif
+
+/****************************************************************************
+ * Name: adc_llops_enable
+ ****************************************************************************/
+
+static void adc_llops_enable(struct stm32_adc_dev_s *dev, bool enable)
+{
+  struct stm32_dev_s *priv = (struct stm32_dev_s *)dev;
+
+  adc_enable(priv, enable);
 }
 
 #endif /* CONFIG_STM32_ADC_LL_OPS */

--- a/arch/arm/src/stm32/stm32_adc.h
+++ b/arch/arm/src/stm32/stm32_adc.h
@@ -2056,6 +2056,10 @@
         (adc)->llops->setup(adc)
 #define STM32_ADC_SHUTDOWN(adc)                     \
         (adc)->llops->shutdown(adc)
+#define STM32_ADC_MULTICFG(adc, mode)               \
+        (adc)->llops->multi_cfg(adc, mode)
+#define STM32_ADC_ENABLE(adc, en)                   \
+        (adc)->llops->enable(adc, en)
 
 /****************************************************************************
  * Public Types
@@ -2103,6 +2107,35 @@ enum stm32_adc_resoluton_e
   ADC_RESOLUTION_10BIT = 1,     /* 10 bit */
   ADC_RESOLUTION_8BIT  = 2,     /* 8 bit */
   ADC_RESOLUTION_6BIT  = 3      /* 6 bit */
+};
+
+/* ADC multi mode selection */
+
+enum stm32_adc_multimode_e
+{
+  /* Independent mode */
+
+  ADC_MULTIMODE_INDEP  = 0,     /* Independent mode */
+
+  /* Dual mode */
+
+  ADC_MULTIMODE_RSISM2 = 1,     /* Dual combined regular sim. + injected sim. */
+  ADC_MULTIMODE_RSATM2 = 2,     /* Dual combined regular sim. + alternate trigger */
+  ADC_MULTIMODE_IMIS2  = 3,     /* Dual combined interl. mode + injected sim. */
+  ADC_MULTIMODE_ISM2   = 4,     /* Dual injected simultaneous mode only */
+  ADC_MULTIMODE_RSM2   = 5,     /* Dual degular simultaneous mode only */
+  ADC_MULTIMODE_IM2    = 6,     /* Dual interleaved mode only */
+  ADC_MULTIMODE_ATM2   = 7,     /* Dual alternate trigger mode only */
+
+  /* Triple mode */
+
+  ADC_MULTIMODE_RSISM3 = 8,     /* Triple combined regular sim. + injected sim. */
+  ADC_MULTIMODE_RSATM3 = 9,     /* Triple combined regular sim. + alternate trigger */
+  ADC_MULTIMODE_IMIS3  = 10,    /* Triple combined interl. mode + injected sim. */
+  ADC_MULTIMODE_ISM3   = 11,    /* Triple injected simultaneous mode only */
+  ADC_MULTIMODE_RSM3   = 12,    /* Triple degular simultaneous mode only */
+  ADC_MULTIMODE_IM3    = 13,    /* Triple interleaved mode only */
+  ADC_MULTIMODE_ATM3   = 14,    /* Triple alternate trigger mode only */
 };
 
 #ifdef CONFIG_STM32_ADC_LL_OPS
@@ -2229,6 +2262,14 @@ struct stm32_adc_ops_s
 #endif
 
   void (*dump_regs)(struct stm32_adc_dev_s *dev);
+
+  /* Configure ADC multi mode */
+
+  int  (*multi_cfg)(struct stm32_adc_dev_s *dev, uint8_t mode);
+
+  /* Enable/disable ADC */
+
+  void (*enable)(struct stm32_adc_dev_s *dev, bool enable);
 };
 
 #endif /* CONFIG_STM32_ADC_LL_OPS */

--- a/arch/arm/src/stm32/stm32_foc.c
+++ b/arch/arm/src/stm32/stm32_foc.c
@@ -674,7 +674,6 @@
 #define PWM_MODE_ADC_TRG   STM32_CHANMODE_PWM1
 #define PWM_MODE_HSLO_LSHI STM32_CHANMODE_OCREFHI
 #define PWM_MODE_HSHI_LSLO STM32_CHANMODE_OCREFLO
-#define PWM_MODE_HIZ       STM32_CHANMODE_FRZN
 
 /****************************************************************************
  * Private Types
@@ -1068,9 +1067,12 @@ static int stm32_foc_pwm_start(struct foc_dev_s *dev, bool state)
   DEBUGASSERT(board);
   DEBUGASSERT(pwm);
 
-  /* Configure outputs state */
+  if (!dev->state.pwm_off)
+    {
+      /* Configure outputs state */
 
-  PWM_ALL_OUTPUTS_ENABLE(pwm, state);
+      PWM_ALL_OUTPUTS_ENABLE(pwm, state);
+    }
 
   /* Call board-specific logic */
 
@@ -1932,18 +1934,24 @@ static int stm32_foc_pwm_off(struct foc_dev_s *dev, bool off)
     {
       /* Force all transistors to low state */
 
-      PWM_MODE_UPDATE(pwm, STM32_PWM_CHAN1, PWM_MODE_HIZ);
-      PWM_MODE_UPDATE(pwm, STM32_PWM_CHAN2, PWM_MODE_HIZ);
+      PWM_MODE_UPDATE(pwm, STM32_PWM_CHAN1, PWM_MODE_HSHI_LSLO);
+      PWM_MODE_UPDATE(pwm, STM32_PWM_CHAN2, PWM_MODE_HSHI_LSLO);
 #if CONFIG_MOTOR_FOC_PHASES > 2
-      PWM_MODE_UPDATE(pwm, STM32_PWM_CHAN3, PWM_MODE_HIZ);
+      PWM_MODE_UPDATE(pwm, STM32_PWM_CHAN3, PWM_MODE_HSHI_LSLO);
 #endif
 #if CONFIG_MOTOR_FOC_PHASES > 3
-      PWM_MODE_UPDATE(pwm, STM32_PWM_CHAN4, PWM_MODE_HIZ);
+      PWM_MODE_UPDATE(pwm, STM32_PWM_CHAN4, PWM_MODE_HSHI_LSLO);
 #endif
+
+      /* Disable complementary output */
+
+      PWM_OUTPUTS_ENABLE(pwm, PMW_OUTPUTS_ALL_COMP, false);
     }
   else
     {
       /* Restore FOC operation modes */
+
+      PWM_ALL_OUTPUTS_ENABLE(pwm, true);
 
       PWM_MODE_UPDATE(pwm, STM32_PWM_CHAN1, PWM_MODE_FOC);
       PWM_MODE_UPDATE(pwm, STM32_PWM_CHAN2, PWM_MODE_FOC);

--- a/arch/arm/src/stm32/stm32_foc.c
+++ b/arch/arm/src/stm32/stm32_foc.c
@@ -599,6 +599,76 @@
 #  endif
 #endif
 
+#ifdef CONFIG_MOTOR_FOC_BEMF_SENSE
+
+#  warning not tested on HW
+
+/* Additional checks for BEMF sensing */
+
+#  if defined(CONFIG_STM32_FOC_FOC0) && defined(CONFIG_STM32_FOC_FOC1)
+#    error BEMF sensing supported only for one FOC instance enabled
+#  endif
+
+#  if defined(CONFIG_STM32_FOC_FOC0_ADC2) || defined(CONFIG_STM32_FOC_FOC0_ADC3)
+#    error FOC must use ADC master
+#  endif
+#  if defined(CONFIG_STM32_FOC_FOC1_ADC2) || defined(CONFIG_STM32_FOC_FOC1_ADC3)
+#    error FOC must use ADC master
+#  endif
+
+/* Additional ADC slave in use */
+
+#  if defined(CONFIG_STM32_FOC_FOC0_ADC1) || defined(CONFIG_STM32_FOC_FOC1_ADC1)
+#    define CONFIG_STM32_FOC_USE_ADC2
+#  endif
+#  if defined(CONFIG_STM32_FOC_FOC0_ADC3) || defined(CONFIG_STM32_FOC_FOC1_ADC3)
+#    define CONFIG_STM32_FOC_USE_ADC4
+#  endif
+
+/* The number of required injected channels */
+
+#  ifdef CONFIG_STM32_FOC_G4_ADCCHAN0_WORKAROUND
+#    define FOC_VADC_INJ_CHAN_REQUIRED (CONFIG_MOTOR_FOC_PHASES + 1)
+#  else
+#    define FOC_VADC_INJ_CHAN_REQUIRED (CONFIG_MOTOR_FOC_PHASES)
+#  endif
+
+/* Slave ADC2 */
+
+#  ifdef CONFIG_STM32_FOC_USE_ADC2
+#    ifndef CONFIG_STM32_ADC2
+#      error ADC2 not supported !
+#    endif
+#    ifndef ADC2_HAVE_JEXTCFG
+#      error ADC2 must support JEXTCFG
+#    endif
+#    if CONFIG_STM32_ADC2_ANIOC_TRIGGER != 1
+#      error CONFIG_STM32_ADC2_ANIOC_TRIGGER must be 1
+#    endif
+#    if CONFIG_STM32_ADC2_INJECTED_CHAN != FOC_VADC_INJ_CHAN_REQUIRED
+#      error Invalid configuration for ADC2 injected channels
+#    endif
+#  endif
+
+/* Slave ADC4 */
+
+#  ifdef CONFIG_STM32_FOC_USE_ADC4
+#    ifndef CONFIG_STM32_ADC4
+#      error ADC4 not supported !
+#    endif
+#    ifndef ADC4_HAVE_JEXTCFG
+#      error ADC4 must support JEXTCFG
+#    endif
+#    if CONFIG_STM32_ADC4_ANIOC_TRIGGER != 1
+#      error CONFIG_STM32_ADC4_ANIOC_TRIGGER must be 1
+#    endif
+#    if CONFIG_STM32_ADC4_INJECTED_CHAN != FOC_VADC_INJ_CHAN_REQUIRED
+#      error Invalid configuration for ADC4 injected channels
+#    endif
+#  endif
+
+#endif
+
 /* Helper macros ************************************************************/
 
 /* Get arch-specific FOC private part */
@@ -622,7 +692,8 @@
 
 /* Get ADC device */
 
-#define ADC_FROM_FOC_DEV_GET(d) (STM32_FOC_DEV_FROM_DEV_GET(d)->adc)
+#define ADC_FROM_FOC_DEV_GET(d)  (STM32_FOC_DEV_FROM_DEV_GET(d)->adc)
+#define VADC_FROM_FOC_DEV_GET(d) (STM32_FOC_DEV_FROM_DEV_GET(d)->vadc)
 
 /* Define PWM all outputs */
 
@@ -698,6 +769,11 @@ struct stm32_foc_dev_s
   /* Interrupt handler for FOC device */
 
   int (*adc_isr)(struct foc_dev_s *dev);
+
+#ifdef CONFIG_MOTOR_FOC_BEMF_SENSE
+  struct adc_dev_s       *vadc_dev;  /* ADC device reference (voltage ) */
+  struct stm32_adc_dev_s *vadc;      /* STM32 ADC device reference (voltage) */
+#endif
 };
 
 /* STM32 FOC common data */
@@ -719,6 +795,11 @@ struct stm32_foc_data_s
   uint32_t      adcint_cntr;                          /* ADC interrupt counter */
   uint32_t      curr_offset[CONFIG_MOTOR_FOC_SHUNTS]; /* ADC current offset */
   int16_t       curr_raw[CONFIG_MOTOR_FOC_SHUNTS];    /* ADC current RAW */
+#ifdef CONFIG_MOTOR_FOC_BEMF_SENSE
+  foc_voltage_t volt[CONFIG_MOTOR_FOC_PHASES];        /* Voltage */
+  uint32_t      volt_offset[CONFIG_MOTOR_FOC_PHASES]; /* ADC voltage offset */
+  int16_t       volt_raw[CONFIG_MOTOR_FOC_PHASES];    /* ADC voltage RAW */
+#endif
 };
 
 /* STM32 FOC private */
@@ -786,6 +867,9 @@ static int stm32_foc_worker_handler(struct foc_dev_s *dev);
 
 static void stm32_foc_curr_get(struct foc_dev_s *dev,
                                int16_t *curr, int shunts);
+#ifdef CONFIG_MOTOR_FOC_BEMF_SENSE
+static void stm32_foc_volt_get(struct foc_dev_s *dev, int16_t *volt);
+#endif
 static int stm32_foc_notifier_cfg(struct foc_dev_s *dev, uint32_t freq);
 static int stm32_foc_pwm_cfg(struct foc_dev_s *dev, uint32_t freq);
 static int stm32_foc_adc_cfg(struct foc_dev_s *dev);
@@ -1069,7 +1153,7 @@ static int stm32_foc_pwm_start(struct foc_dev_s *dev, bool state)
 
   if (!dev->state.pwm_off)
     {
-      /* Configure outputs state */
+      /* Enable PWM outputs */
 
       PWM_ALL_OUTPUTS_ENABLE(pwm, state);
     }
@@ -1320,6 +1404,9 @@ static int stm32_foc_setup(struct foc_dev_s *dev)
   struct stm32_foc_board_s *board   = STM32_FOC_BOARD_FROM_DEV_GET(dev);
   struct stm32_foc_priv_s  *priv    = STM32_FOC_PRIV_FROM_DEV_GET(dev);
   struct stm32_adc_dev_s   *adc     = ADC_FROM_FOC_DEV_GET(dev);
+#ifdef CONFIG_MOTOR_FOC_BEMF_SENSE
+  struct stm32_adc_dev_s   *vadc    = VADC_FROM_FOC_DEV_GET(dev);
+#endif
   struct adc_sample_time_s  stime;
   int                       ret     = OK;
 
@@ -1344,6 +1431,30 @@ static int stm32_foc_setup(struct foc_dev_s *dev)
   /* Setup ADC */
 
   STM32_ADC_SETUP(foc_dev->adc);
+
+#ifdef CONFIG_MOTOR_FOC_BEMF_SENSE
+  /* Setup slave ADC */
+
+  STM32_ADC_SETUP(foc_dev->vadc);
+
+  /* Disable interrupts for slave ADC */
+
+  STM32_ADC_DISABLEINT(foc_dev->vadc);
+
+  /* Disable master and slave ADC */
+
+  STM32_ADC_ENABLE(foc_dev->adc, false);
+  STM32_ADC_ENABLE(foc_dev->vadc, false);
+
+  /* Configure dual injected simultaneous only mode */
+
+  STM32_ADC_MULTICFG(foc_dev->vadc, ADC_MULTIMODE_ISM2);
+
+  /* Enable master and slave ADC */
+
+  STM32_ADC_ENABLE(foc_dev->adc, true);
+  STM32_ADC_ENABLE(foc_dev->vadc, true);
+#endif
 
 #ifdef FOC_ADC_HAVE_CMN
   /* Lock ADC common data */
@@ -1396,6 +1507,18 @@ static int stm32_foc_setup(struct foc_dev_s *dev)
   STM32_ADC_SAMPLETIME_SET(adc, &stime);
   STM32_ADC_SAMPLETIME_WRITE(adc);
 
+#ifdef CONFIG_MOTOR_FOC_BEMF_SENSE
+  /* Configure sample times for BEMF channels */
+
+  memset(&stime, 0, sizeof(struct adc_sample_time_s));
+
+  stime.channels_nbr = board->data->vadc_cfg->nchan;
+  stime.channel      = board->data->vadc_cfg->stime;
+
+  STM32_ADC_SAMPLETIME_SET(vadc, &stime);
+  STM32_ADC_SAMPLETIME_WRITE(vadc);
+#endif
+
   /* Set the priority of the ADC interrupt vector */
 
   ret = up_prioritize_irq(foc_dev->adc_irq, NVIC_SYSH_PRIORITY_DEFAULT);
@@ -1441,6 +1564,9 @@ static int stm32_foc_setup(struct foc_dev_s *dev)
   /* Dump ADC regs */
 
   STM32_ADC_DUMP_REGS(adc);
+#ifdef CONFIG_MOTOR_FOC_BEMF_SENSE
+  STM32_ADC_DUMP_REGS(vadc);
+#endif
 
 errout:
   return ret;
@@ -1719,10 +1845,22 @@ static int stm32_foc_worker_handler(struct foc_dev_s *dev)
                                     priv->data.curr_raw,
                                     priv->data.curr);
 
+#ifdef CONFIG_MOTOR_FOC_BEMF_SENSE
+      /* Get raw voltage samples */
+
+      stm32_foc_volt_get(dev, priv->data.volt_raw);
+
+      /* Get BEMF voltages */
+
+      ret = board->ops->voltage_get(dev,
+                                    priv->data.volt_raw,
+                                    priv->data.volt);
+#endif
+
       /* Call upper-half worker callback */
 
 #ifdef CONFIG_MOTOR_FOC_BEMF_SENSE
-#  error BEMF sensing not supported yet
+      priv->cb->notifier(dev, priv->data.curr, priv->data.volt);
 #else
       priv->cb->notifier(dev, priv->data.curr, NULL);
 #endif
@@ -1746,6 +1884,9 @@ static int stm32_foc_calibration_start(struct foc_dev_s *dev)
   struct stm32_foc_board_s *board   = STM32_FOC_BOARD_FROM_DEV_GET(dev);
   struct stm32_pwm_dev_s   *pwm     = PWM_FROM_FOC_DEV_GET(dev);
   struct stm32_adc_dev_s   *adc     = ADC_FROM_FOC_DEV_GET(dev);
+#ifdef CONFIG_MOTOR_FOC_BEMF_SENSE
+  struct stm32_adc_dev_s   *vadc    = VADC_FROM_FOC_DEV_GET(dev);
+#endif
   uint8_t                   i       = 0;
   uint8_t                   ch      = 0;
   int                       ret     = OK;
@@ -1846,6 +1987,36 @@ static int stm32_foc_calibration_start(struct foc_dev_s *dev)
       STM32_ADC_OFFSET_SET(adc, ch, i, priv->data.curr_offset[i]);
     }
 
+#ifdef CONFIG_MOTOR_FOC_BEMF_SENSE
+
+  /* TODO: BEMF sensing calibartion */
+
+  for (i = 0; i < CONFIG_MOTOR_FOC_PHASES; i += 1)
+    {
+      priv->data.volt_offset[i] = 0;
+    }
+
+  /* Clear last ADC data */
+
+  for (i = 0; i < CONFIG_MOTOR_FOC_PHASES; i += 1)
+    {
+      priv->data.volt_raw[i] = 0;
+    }
+
+  /* Set ADC hardware offset for voltage channels (only injected channels) */
+
+  for (i = 0; i < CONFIG_MOTOR_FOC_PHASES; i += 1)
+    {
+      /* Get channel */
+
+      ch = board->data->vadc_cfg->chan[board->data->vadc_cfg->regch + i];
+
+      /* Write offset */
+
+      STM32_ADC_OFFSET_SET(vadc, ch, i, priv->data.volt_offset[i]);
+    }
+#endif
+
   mtrinfo("ADC offset calibration - DONE!\n");
 
 errout:
@@ -1943,7 +2114,7 @@ static int stm32_foc_pwm_off(struct foc_dev_s *dev, bool off)
       PWM_MODE_UPDATE(pwm, STM32_PWM_CHAN4, PWM_MODE_HSHI_LSLO);
 #endif
 
-      /* Disable complementary output */
+      /* Disable complementary outputs */
 
       PWM_OUTPUTS_ENABLE(pwm, PMW_OUTPUTS_ALL_COMP, false);
     }
@@ -2024,6 +2195,61 @@ static void stm32_foc_curr_get(struct foc_dev_s *dev,
 #endif
     }
 }
+
+#ifdef CONFIG_MOTOR_FOC_BEMF_SENSE
+/****************************************************************************
+ * Name: stm32_foc_volt_get
+ *
+ * Description:
+ *   Get voltage samples from ADC
+ *
+ ****************************************************************************/
+
+static void stm32_foc_volt_get(struct foc_dev_s *dev, int16_t *volt)
+{
+  struct stm32_foc_priv_s *priv = STM32_FOC_PRIV_FROM_DEV_GET(dev);
+  struct stm32_adc_dev_s  *vadc  = VADC_FROM_FOC_DEV_GET(dev);
+  int                      i    = 0;
+
+  DEBUGASSERT(dev);
+  DEBUGASSERT(priv);
+  DEBUGASSERT(vadc);
+  DEBUGASSERT(volt);
+
+  /* Make sure the conversion is complete.
+   * It is possible that the ADC master sequence will end in front of
+   * the slave sequence. In that case we just busy-wait.
+   * In the worst case scenario the slave conversion is one channel behind
+   * the master conversion (2 current channels vs 3 voltage channels).
+   *
+   * Another solution is to make sure that both conversions has the same
+   * length, but this makes the code much more complex.
+   */
+
+  while ((FOC_ADC_ISR_FOC & STM32_ADC_INT_GET(vadc)) == 0);
+
+  /* Clear status */
+
+  STM32_ADC_INT_ACK(vadc, FOC_ADC_ISR_FOC);
+
+  for (i = 0; i < CONFIG_MOTOR_FOC_PHASES; i += 1)
+    {
+      /* Get raw voltage samples.
+       * We have ADC offset enabled for injected channels so this
+       * gives us signed values.
+       * NOTE: ADC value is 11 bits + sign.
+       */
+
+#ifdef CONFIG_STM32_FOC_G4_ADCCHAN0_WORKAROUND
+      /* Ignore first channel */
+
+      volt[i] = (int16_t)STM32_ADC_INJDATA_GET(vadc, (i + 1));
+#else
+      volt[i] = (int16_t)STM32_ADC_INJDATA_GET(vadc, i);
+#endif
+    }
+}
+#endif
 
 /****************************************************************************
  * Name: stm32_foc_notifier_cfg
@@ -2168,6 +2394,91 @@ void stm32_foc_trace(struct foc_dev_s *dev, int type, bool state)
 #endif
 
 /****************************************************************************
+ * Name: stm32_foc_adc_init
+ *
+ * Description:
+ *   Initialize ADC instance
+ *
+ ****************************************************************************/
+
+struct adc_dev_s *stm32_foc_adc_init(struct stm32_foc_adc_s *adc_cfg)
+{
+  struct adc_dev_s          *adc_dev   = NULL;
+  int                        i         = 0;
+#ifdef CONFIG_STM32_FOC_G4_ADCCHAN0_WORKAROUND
+  uint8_t                   *adc_chan  = NULL;
+  uint8_t                    adc_nchan = 0;
+#endif
+
+  DEBUGASSERT(adc_cfg);
+  DEBUGASSERT(adc_cfg != NULL);
+  DEBUGASSERT(adc_cfg->pins != NULL);
+  DEBUGASSERT(adc_cfg->chan != NULL);
+
+  /* Configure pins as analog inputs for the selected channels */
+
+  for (i = 0; i < adc_cfg->nchan; i++)
+    {
+      stm32_configgpio(adc_cfg->pins[i]);
+    }
+
+  /* STM32G4 ADC channel 0 unwanted conversion workaround */
+
+#ifdef CONFIG_STM32_FOC_G4_ADCCHAN0_WORKAROUND
+  /* Add one dummy channel to conversion */
+
+  adc_nchan = (adc_cfg->nchan + 1);
+
+  /* Allocate memory for the extended list of channels */
+
+  adc_chan = zalloc(adc_nchan);
+  if (adc_chan == NULL)
+    {
+      goto errout;
+    }
+
+  /* Copy regular channels first */
+
+  for (i = 0; i < adc_cfg->regch; i += 1)
+    {
+      adc_chan[i] = adc_cfg->chan[i];
+    }
+
+  /* Add dummy channel at the beginning of injected channels */
+
+  adc_chan[adc_cfg->regch] = 0;
+
+  /* Copy injected channels */
+
+  for (i = (adc_cfg->regch + 1); i < adc_nchan; i += 1)
+    {
+      adc_chan[i] = adc_cfg->chan[i - 1];
+    }
+#endif  /* CONFIG_STM32_FOC_G4_ADCCHAN0_WORKAROUND */
+
+  /* Get the ADC interface */
+
+#ifdef CONFIG_STM32_FOC_G4_ADCCHAN0_WORKAROUND
+  adc_dev = stm32_adcinitialize(adc_cfg->intf,
+                                adc_chan,
+                                adc_nchan);
+
+  free(adc_chan);
+#else
+  adc_dev = stm32_adcinitialize(adc_cfg->intf,
+                                adc_cfg->chan,
+                                adc_cfg->nchan);
+#endif
+
+  return adc_dev;
+
+#ifdef CONFIG_STM32_FOC_G4_ADCCHAN0_WORKAROUND
+errout:
+  return NULL;
+#endif
+}
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -2204,11 +2515,6 @@ stm32_foc_initialize(int inst, struct stm32_foc_board_s *board)
   uint8_t                    pwm_inst  = 0;
   uint8_t                    adc_inst  = 0;
   uint32_t                   pwmfzbit  = 0;
-  int                        i         = 0;
-#ifdef CONFIG_STM32_FOC_G4_ADCCHAN0_WORKAROUND
-  uint8_t                   *adc_chan  = NULL;
-  uint8_t                    adc_nchan = 0;
-#endif
 
   DEBUGASSERT(board != NULL);
   DEBUGASSERT(board->ops != NULL);
@@ -2226,11 +2532,6 @@ stm32_foc_initialize(int inst, struct stm32_foc_board_s *board)
   DEBUGASSERT(board->ops->trace_init);
   DEBUGASSERT(board->ops->trace);
 #endif
-
-  /* Get ADC configuration from board data */
-
-  adc_cfg = board->data->adc_cfg;
-  DEBUGASSERT(adc_cfg);
 
   /* Get FOC instance configuration */
 
@@ -2327,86 +2628,62 @@ stm32_foc_initialize(int inst, struct stm32_foc_board_s *board)
       goto errout;
     }
 
-  /* Configure pins as analog inputs for the selected channels */
+  /* Get ADC configuration */
 
-  DEBUGASSERT(adc_cfg != NULL);
-  DEBUGASSERT(adc_cfg->pins != NULL);
-  DEBUGASSERT(adc_cfg->chan != NULL);
-
-  for (i = 0; i < adc_cfg->nchan; i++)
-    {
-      stm32_configgpio(adc_cfg->pins[i]);
-    }
+  adc_cfg = board->data->adc_cfg;
 
   /* Make sure that we are using the appropriate ADC interface */
 
   if (adc_inst != adc_cfg->intf)
     {
-      mtrerr("Configuration doesn't match %d, %d\n",
+      mtrerr("FOC ADC configuration doesn't match %d, %d\n",
              adc_inst, adc_cfg->intf);
       set_errno(EINVAL);
       goto errout;
     }
 
-  /* STM32G4 ADC channel 0 unwanted conversion workaround */
+  /* Get ADC instance */
 
-#ifdef CONFIG_STM32_FOC_G4_ADCCHAN0_WORKAROUND
-  /* Add one dummy channel to conversion */
-
-  adc_nchan = (adc_cfg->nchan + 1);
-
-  /* Allocate memory for the extended list of channels */
-
-  adc_chan = zalloc(adc_nchan);
-  if (adc_chan == NULL)
+  foc_dev->adc_dev = stm32_foc_adc_init(adc_cfg);
+  if (foc_dev->adc_dev == NULL)
     {
+      mtrerr("Failed to initialize FOC ADC%d interface\n", adc_cfg->intf);
+      set_errno(EINVAL);
       goto errout;
     }
 
-  /* Copy regular channels first */
+    /* Get ADC private part */
 
-  for (i = 0; i < adc_cfg->regch; i += 1)
+    foc_dev->adc = (struct stm32_adc_dev_s *)foc_dev->adc_dev->ad_priv;
+
+#ifdef CONFIG_MOTOR_FOC_BEMF_SENSE
+  /* Get ADC configuration */
+
+  adc_cfg = board->data->vadc_cfg;
+
+  /* Make sure that we are using the slave ADC */
+
+  if (adc_inst != adc_cfg->intf - 1)
     {
-      adc_chan[i] = adc_cfg->chan[i];
+      mtrerr("BEMF ADC must be the first slave instance of the main ADC!");
+      set_errno(EINVAL);
+      goto errout;
     }
 
-  /* Add dummy channel at the beginning of injected channels */
+  /* Get ADC instance */
 
-  adc_chan[adc_cfg->regch] = 0;
-
-  /* Copy injected channels */
-
-  for (i = (adc_cfg->regch + 1); i < adc_nchan; i += 1)
+  foc_dev->vadc_dev = stm32_foc_adc_init(adc_cfg);
+  if (foc_dev->vadc_dev == NULL)
     {
-      adc_chan[i] = adc_cfg->chan[i - 1];
-    }
-
-#endif  /* CONFIG_STM32_FOC_G4_ADCCHAN0_WORKAROUND */
-
-  /* Get the ADC interface */
-
-#ifdef CONFIG_STM32_FOC_G4_ADCCHAN0_WORKAROUND
-  foc_dev->adc_dev = stm32_adcinitialize(adc_inst,
-                                         adc_chan,
-                                         adc_nchan);
-
-  free(adc_chan);
-#else
-  foc_dev->adc_dev = stm32_adcinitialize(adc_inst,
-                                         adc_cfg->chan,
-                                         adc_cfg->nchan);
-#endif
-
-  if (foc_dev->adc_dev == NULL)
-    {
-      mtrerr("Failed to get ADC%d interface\n", adc_cfg->intf);
+      mtrerr("Failed to initialize BEMF ADC%d interface\n", adc_cfg->intf);
       set_errno(EINVAL);
       goto errout;
     }
 
   /* Get ADC private part */
 
-  foc_dev->adc = (struct stm32_adc_dev_s *)foc_dev->adc_dev->ad_priv;
+  foc_dev->vadc = (struct stm32_adc_dev_s *)foc_dev->vadc_dev->ad_priv;
+#endif
 
   /* Froze timer and reset outputs when core is halted.
    * TODO: move this to stm32_pwm.c and configure from Kconfig

--- a/arch/arm/src/stm32/stm32_foc.h
+++ b/arch/arm/src/stm32/stm32_foc.h
@@ -106,6 +106,13 @@ struct stm32_foc_board_ops_s
   int (*current_get)(struct foc_dev_s *dev, int16_t *curr_raw,
                      foc_current_t *curr);
 
+#ifdef CONFIG_MOTOR_FOC_BEMF_SENSE
+  /* Get BEMF voltage */
+
+  int (*voltage_get)(struct foc_dev_s *dev, int16_t *volt_raw,
+                     foc_voltage_t *volt);
+#endif
+
 #ifdef CONFIG_MOTOR_FOC_TRACE
   /* FOC trace interface setup */
 
@@ -124,6 +131,12 @@ struct stm32_foc_board_data_s
   /* ADC configuration */
 
   struct stm32_foc_adc_s *adc_cfg;
+
+#ifdef CONFIG_MOTOR_FOC_BEMF_SENSE
+  /* BEMF voltage ADC configuration */
+
+  struct stm32_foc_adc_s *vadc_cfg;
+#endif
 
   /* PWM deadtime register value */
 

--- a/arch/arm/src/stm32f7/stm32_adc.h
+++ b/arch/arm/src/stm32f7/stm32_adc.h
@@ -853,6 +853,10 @@
         (adc)->llops->setup(adc)
 #define STM32_ADC_SHUTDOWN(adc)                     \
         (adc)->llops->shutdown(adc)
+#define STM32_ADC_MULTICFG(adc, mode)               \
+        (adc)->llops->multi_cfg(adc, mode)
+#define STM32_ADC_ENABLE(adc, en)                   \
+        (adc)->llops->enable(adc, en)
 
 /****************************************************************************
  * Public Types
@@ -877,6 +881,35 @@ enum stm32_adc_resoluton_e
   ADC_RESOLUTION_10BIT = 1,     /* 10 bit */
   ADC_RESOLUTION_8BIT  = 2,     /* 8 bit */
   ADC_RESOLUTION_6BIT  = 3      /* 6 bit */
+};
+
+/* ADC multi mode selection */
+
+enum stm32_adc_multimode_e
+{
+  /* Independent mode */
+
+  ADC_MULTIMODE_INDEP  = 0,     /* Independent mode */
+
+  /* Dual mode */
+
+  ADC_MULTIMODE_RSISM2 = 1,     /* Dual combined regular sim. + injected sim. */
+  ADC_MULTIMODE_RSATM2 = 2,     /* Dual combined regular sim. + alternate trigger */
+  ADC_MULTIMODE_IMIS2  = 3,     /* Dual combined interl. mode + injected sim. */
+  ADC_MULTIMODE_ISM2   = 4,     /* Dual injected simultaneous mode only */
+  ADC_MULTIMODE_RSM2   = 5,     /* Dual degular simultaneous mode only */
+  ADC_MULTIMODE_IM2    = 6,     /* Dual interleaved mode only */
+  ADC_MULTIMODE_ATM2   = 7,     /* Dual alternate trigger mode only */
+
+  /* Triple mode */
+
+  ADC_MULTIMODE_RSISM3 = 8,     /* Triple combined regular sim. + injected sim. */
+  ADC_MULTIMODE_RSATM3 = 9,     /* Triple combined regular sim. + alternate trigger */
+  ADC_MULTIMODE_IMIS3  = 10,    /* Triple combined interl. mode + injected sim. */
+  ADC_MULTIMODE_ISM3   = 11,    /* Triple injected simultaneous mode only */
+  ADC_MULTIMODE_RSM3   = 12,    /* Triple degular simultaneous mode only */
+  ADC_MULTIMODE_IM3    = 13,    /* Triple interleaved mode only */
+  ADC_MULTIMODE_ATM3   = 14,    /* Triple alternate trigger mode only */
 };
 
 #ifdef CONFIG_STM32F7_ADC_LL_OPS
@@ -1001,6 +1034,14 @@ struct stm32_adc_ops_s
 #endif
 
   void (*dump_regs)(struct stm32_adc_dev_s *dev);
+
+  /* Configure ADC multi mode */
+
+  int  (*multi_cfg)(struct stm32_adc_dev_s *dev, uint8_t mode);
+
+  /* Enable/disable ADC */
+
+  void (*enable)(struct stm32_adc_dev_s *dev, bool enable);
 };
 
 #endif /* CONFIG_STM32F7_ADC_LL_OPS */

--- a/arch/arm/src/stm32f7/stm32_foc.h
+++ b/arch/arm/src/stm32f7/stm32_foc.h
@@ -106,6 +106,13 @@ struct stm32_foc_board_ops_s
   int (*current_get)(struct foc_dev_s *dev, int16_t *curr_raw,
                      foc_current_t *curr);
 
+#ifdef CONFIG_MOTOR_FOC_BEMF_SENSE
+  /* Get BEMF voltage */
+
+  int (*voltage_get)(struct foc_dev_s *dev, int16_t *volt_raw,
+                     foc_voltage_t *volt);
+#endif
+
 #ifdef CONFIG_MOTOR_FOC_TRACE
   /* FOC trace interface setup */
 
@@ -124,6 +131,12 @@ struct stm32_foc_board_data_s
   /* ADC configuration */
 
   struct stm32_foc_adc_s *adc_cfg;
+
+#ifdef CONFIG_MOTOR_FOC_BEMF_SENSE
+  /* BEMF voltage ADC configuration */
+
+  struct stm32_foc_adc_s *vadc_cfg;
+#endif
 
   /* PWM deadtime register value */
 

--- a/boards/arm/stm32/b-g431b-esc1/README.txt
+++ b/boards/arm/stm32/b-g431b-esc1/README.txt
@@ -48,9 +48,13 @@ Configuration Sub-directories
     ENCO_Z/HALL_H3   TIM4_CH3           PB8
     BUTTON           GPIO_PC10          PC10
     PWM                                 PA15
-    CAN_RX                              PA11
-    CAN_TX                              PB9
+    CAN_RX           FDCAN1_RX          PA11
+    CAN_TX           FDCAN1_TX          PB9
     CAN_TERM                            PC14
+    GPIO_BEMF                           PB5
+    BEMF1            ADC2_IN17          PA4
+    BEMF2            ADC2_IN5           PC4
+    BEMF3            ADC2_IN14          PB11
 
     Current shunt resistance          = 0.003
     PGA gain                          = 16
@@ -59,6 +63,7 @@ Configuration Sub-directories
     Vbus min                          = ?
     Vbus max                          = 25V
     Iout max                          = 40A peak
+    BEMF sense gain = 2.2k/(10k+2.2k) = 0.18
 
     IPHASE_RATIO = 1/(R_shunt*gain) = -36.47
     VBUS_RATIO   = 1/VBUS_gain      = 10.4

--- a/boards/arm/stm32/b-g431b-esc1/src/b-g431b-esc1.h
+++ b/boards/arm/stm32/b-g431b-esc1/src/b-g431b-esc1.h
@@ -103,6 +103,11 @@
 #define GPIO_CANTERM (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_50MHz| \
                       GPIO_OUTPUT_CLEAR|GPIO_PORTC|GPIO_PIN14)
 
+/* GPIO_BEMF */
+
+#define GPIO_GPIOBEMF (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_50MHz| \
+                       GPIO_OUTPUT_CLEAR|GPIO_PORTB|GPIO_PIN5)
+
 /****************************************************************************
  * Public Data
  ****************************************************************************/


### PR DESCRIPTION
## Summary
stm32,stm32f7: add support for BEMF sensing

Relate issue: https://github.com/apache/nuttx/issues/8098

## Testing
b-g431b-esc1
Below example of BEMF reconstructed for a random drone motor rotated by hand. Samples are just int16_t values without any further conversion.

The pink line shows virtual ground calculated from equation `Vzero = (Va + Vb + Vc)/3`, the others are `V1 = Va - Vzero`, `V2 = Vb  - Vzero` and `V3 = Vc - Vzero`

![Figure_1](https://user-images.githubusercontent.com/6563055/213885629-9e6a6b77-1b61-43b1-a185-5cd0034d6017.png)

