### PR TITLE
stm32f4disco: Add support to mount /tmp

### DIFF
--- a/boards/arm/stm32/stm32f4discovery/src/stm32_bringup.c
+++ b/boards/arm/stm32/stm32f4discovery/src/stm32_bringup.c
@@ -515,6 +515,17 @@ int stm32_bringup(void)
     }
 #endif
 
+#ifdef CONFIG_FS_TMPFS
+  /* Mount the tmpfs file system */
+
+  ret = nx_mount(NULL, CONFIG_LIBC_TMPDIR, "tmpfs", 0, NULL);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to mount tmpfs at %s: %d\n",
+             CONFIG_LIBC_TMPDIR, ret);
+    }
+#endif
+
 #ifdef CONFIG_STM32_ROMFS
   ret = stm32_romfs_initialize();
   if (ret < 0)


### PR DESCRIPTION
## Summary
Add support to mount /tmp on stm32f4discovery board like we do on esp32-devkit
## Impact
It is needed for some application like zmodem and even to get NuttX scripts working
## Testing
stm32f4discovery
