### PR TITLE
stm32/foc: move the warning in the right place - should be in stm32f7

### DIFF
--- a/arch/arm/src/stm32/stm32_foc.c
+++ b/arch/arm/src/stm32/stm32_foc.c
@@ -601,8 +601,6 @@
 
 #ifdef CONFIG_MOTOR_FOC_BEMF_SENSE
 
-#  warning not tested on HW
-
 /* Additional checks for BEMF sensing */
 
 #  if defined(CONFIG_STM32_FOC_FOC0) && defined(CONFIG_STM32_FOC_FOC1)

--- a/arch/arm/src/stm32f7/stm32_foc.c
+++ b/arch/arm/src/stm32f7/stm32_foc.c
@@ -427,6 +427,9 @@
 #endif
 
 #ifdef CONFIG_MOTOR_FOC_BEMF_SENSE
+
+#  warning not tested on HW
+
 /* Additional checks for BEMF sensing */
 
 #  if defined(CONFIG_STM32_FOC_FOC0) && defined(CONFIG_STM32_FOC_FOC1)


### PR DESCRIPTION
## Summary
stm32/foc: move the warning in the right place - should be in stm32f7
## Impact
None
## Testing
CI
