### PR TITLE
s32k1xx:serial Do not use TC use TDRE & TIE Bug Fix

### DIFF
--- a/arch/arm/src/s32k1xx/s32k1xx_serial.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_serial.c
@@ -1127,8 +1127,8 @@ static int s32k1xx_interrupt(int irq, void *context, void *arg)
 
       /* Handle outgoing, transmit bytes */
 
-      if ((usr & LPUART_STAT_TC) != 0 &&
-          (priv->ie & LPUART_CTRL_TCIE) != 0)
+      if ((usr & LPUART_STAT_TDRE) != 0 &&
+          (priv->ie & LPUART_CTRL_TIE) != 0)
         {
           uart_xmitchars(dev);
           handled = true;
@@ -1889,12 +1889,12 @@ static void s32k1xx_txint(struct uart_dev_s *dev, bool enable)
   if (enable)
     {
 #ifndef CONFIG_SUPPRESS_SERIAL_INTS
-      priv->ie |= LPUART_CTRL_TCIE;
+      priv->ie |= LPUART_CTRL_TIE;
 #endif
     }
   else
     {
-      priv->ie &= ~LPUART_CTRL_TCIE;
+      priv->ie &= ~LPUART_CTRL_TIE;
     }
 
   regval  = s32k1xx_serialin(priv, S32K1XX_LPUART_CTRL_OFFSET);


### PR DESCRIPTION
## Summary

In the past the Serial Driver was using Transmit Complete (I.E Shift register empty) Not Transmit Data Register Empty Flag. This is will not keep the coms 100% busy. 

The PR that added DMA missed changing the rest of the TC usage to TDRE.

## Impact

Driver would hang in non-DMA mode, servicing TC interrupts but not clearing them.

## Testing

rddrone-bms772:nsh
