### PR TITLE
litex: System clock frequency selectable from Kconfig.

### DIFF
--- a/arch/risc-v/src/litex/Kconfig
+++ b/arch/risc-v/src/litex/Kconfig
@@ -5,6 +5,12 @@
 
 comment "LITEX Configuration Options"
 
+config LITEX_SYS_CORE_FREQ_HZ
+	int "Risc-V system core frequency (Hz)"
+	default 100000000
+	---help---
+		This value should match default frequency of the FPGA fabric system clock.
+
 menu "LITEX Peripheral Support"
 
 # These "hidden" settings determine whether a peripheral option is available

--- a/arch/risc-v/src/litex/litex_clockconfig.c
+++ b/arch/risc-v/src/litex/litex_clockconfig.c
@@ -50,7 +50,7 @@ uint32_t litex_get_hfclk(void)
 {
   /* fpga fabric default sys frequency */
 
-  return 100000000UL;
+  return CONFIG_LITEX_SYS_CORE_FREQ_HZ;
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

Allow the system clock frequency for risc-v Litex to be modified using Kconfig option.

## Impact

The existing frequency (100MHz) is used as the default Kconfig option. There should be no change to the existing build.

## Testing
`./tools/configure.sh -l arty_a7:nsh && make -j 16` and inspected the Kconfig option.
