### PR TITLE
arch/ARCH_KERNEL_STACK: Fix signal handling with kernel stack

### DIFF
--- a/arch/arm/src/armv7-r/arm_syscall.c
+++ b/arch/arm/src/armv7-r/arm_syscall.c
@@ -434,11 +434,31 @@ uint32_t *arm_syscall(uint32_t *regs)
 
           if (rtcb->xcp.kstack != NULL)
             {
-              DEBUGASSERT(rtcb->xcp.kstkptr == NULL &&
-                          rtcb->xcp.ustkptr != NULL);
+              uint32_t usp;
+
+              DEBUGASSERT(rtcb->xcp.kstkptr == NULL);
+
+              /* Copy "info" into user stack */
+
+              if (rtcb->xcp.sigdeliver)
+                {
+                  usp = rtcb->xcp.saved_regs[REG_SP];
+                }
+              else
+                {
+                  usp = rtcb->xcp.regs[REG_SP];
+                }
+
+              /* Create a frame for info and copy the kernel info */
+
+              usp = usp - sizeof(siginfo_t);
+              memcpy((void *)usp, (void *)regs[REG_R2], sizeof(siginfo_t));
+
+              /* Now set the updated SP and user copy of "info" to R2 */
 
               rtcb->xcp.kstkptr = (uint32_t *)regs[REG_SP];
-              regs[REG_SP]      = (uint32_t)rtcb->xcp.ustkptr;
+              regs[REG_SP]      = usp;
+              regs[REG_R2]      = usp;
             }
 #endif
         }
@@ -476,8 +496,7 @@ uint32_t *arm_syscall(uint32_t *regs)
 
           if (rtcb->xcp.kstack != NULL)
             {
-              DEBUGASSERT(rtcb->xcp.kstkptr != NULL &&
-                          (uint32_t)rtcb->xcp.ustkptr == regs[REG_SP]);
+              DEBUGASSERT(rtcb->xcp.kstkptr != NULL);
 
               regs[REG_SP]      = (uint32_t)rtcb->xcp.kstkptr;
               rtcb->xcp.kstkptr = NULL;
@@ -536,8 +555,15 @@ uint32_t *arm_syscall(uint32_t *regs)
           if (index == 0 && rtcb->xcp.kstack != NULL)
             {
               rtcb->xcp.ustkptr = (uint32_t *)regs[REG_SP];
-              regs[REG_SP]      = (uint32_t)rtcb->xcp.kstack +
-                                   ARCH_KERNEL_STACKSIZE;
+              if (rtcb->xcp.kstkptr != NULL)
+                {
+                  regs[REG_SP]  = (uint32_t)rtcb->xcp.kstkptr;
+                }
+              else
+                {
+                  regs[REG_SP]  = (uint32_t)rtcb->xcp.kstack +
+                                  ARCH_KERNEL_STACKSIZE;
+                }
             }
 #endif
 


### PR DESCRIPTION
## Summary
There were two issues with signal handling:
- With a kernel stack the "info" parameter was passed from kernel memory. This is fixed by making a stack frame to the user stack and copying it there.
- If the signal handler uses a system call, the kernel stack was completely and unconditionally destroyed, resulting in a crash in the user application

There is also no need to check ustkptr, it is always NULL. Why ? Because signal delivery is deferred when a system call is being executed.
## Impact
Fixes signal dispatch logic when CONFIG_ARCH_KERNEL_STACK=y 
## Testing
icicle:knsh
