### PR TITLE
litex: Allow custom peripheral memory mapping and IRQ.

### DIFF
--- a/arch/risc-v/include/litex/irq.h
+++ b/arch/risc-v/include/litex/irq.h
@@ -25,6 +25,10 @@
  * Included Files
  ****************************************************************************/
 
+#ifdef CONFIG_LITEX_USE_CUSTOM_IRQ_DEFINITIONS
+#include CONFIG_LITEX_CUSTOM_IRQ_DEFINITIONS_PATH
+#else
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -40,4 +44,5 @@
 
 #define NR_IRQS            (LITEX_IRQ_SDCARD + 1)
 
+#endif /* CONFIG_LITEX_USE_CUSTOM_IRQ_DEFINITIONS */
 #endif /* __ARCH_RISCV_INCLUDE_LITEX_IRQ_H */

--- a/arch/risc-v/src/litex/Kconfig
+++ b/arch/risc-v/src/litex/Kconfig
@@ -16,6 +16,44 @@ menu "LITEX Peripheral Support"
 # These "hidden" settings determine whether a peripheral option is available
 # for the selected MCU
 
+config LITEX_USE_CUSTOM_MEMORY_MAP
+	bool "Custom peripheral memory mapping"
+	default n
+	---help---
+		Use a custom memory map for the peripheral base addresses defined in
+		arch/risc-v/src/litex/hardware/litex_memorymap.h.
+
+if LITEX_USE_CUSTOM_MEMORY_MAP
+
+config LITEX_CUSTOM_MEMORY_MAP_PATH
+	string "Path to custom memory map include file."
+	default ""
+	---help---
+		Specify the path to the file containing the peripheral memory mapping.
+		The path specified must be relative to arch/risc-v/src/litex/hardware/litex_memorymap.h.
+		The file must redefine any symbols which are intended to be overridden.
+
+endif
+
+config LITEX_USE_CUSTOM_IRQ_DEFINITIONS
+	bool "Custom IRQ mapping"
+	default n
+	---help---
+		Use custom definitions for risc-v IRQ numbers and sequence.
+		Allowing for the definitions in arch/risc-v/include/litex/irq.h to be overridden.
+		
+if LITEX_USE_CUSTOM_IRQ_DEFINITIONS
+
+config LITEX_CUSTOM_IRQ_DEFINITIONS_PATH
+	string "Path to custom IRQ mapping include file."
+	default ""
+	---help---
+		Specify the path to the file containing the custom IRQ definitions.
+		The path specified must be relative to arch/risc-v/include/litex/irq.
+		The file must redefine any symbols which are intended to be overridden.
+
+endif
+
 config LITEX_HAVE_UART0
 	bool
 	default y

--- a/arch/risc-v/src/litex/hardware/litex_memorymap.h
+++ b/arch/risc-v/src/litex/hardware/litex_memorymap.h
@@ -22,6 +22,14 @@
 #define __ARCH_RISCV_SRC_LITEX_HARDWARE_LITEX_MEMORYMAP_H
 
 /****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#ifdef CONFIG_LITEX_USE_CUSTOM_MEMORY_MAP
+#include CONFIG_LITEX_CUSTOM_MEMORY_MAP_PATH
+#else
+
+/****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
 
@@ -45,4 +53,5 @@
 #define LITEX_ETHMAC_RXBASE     0x80000000
 #define LITEX_ETHMAC_TXBASE     0x80001000
 
+#endif /* CONFIG_LITEX_USE_CUSTOM_MEMORY_MAP */
 #endif /* __ARCH_RISCV_SRC_LITEX_HARDWARE_LITEX_MEMORYMAP_H */


### PR DESCRIPTION
## Summary

When using Litex, it is possible that the chosen peripheral base addresses and IRQ index can change, depending on the gateware configuration.

I'd like to propose a method for allowing the default values to be specified in another file, which possibly resides outside of the NuttX tree. For example, when using a custom board directory.

Using the changes proposed in the pull request. I'm able, with Kconfig, to specify the path to the file containing the peripheral mapping for our gateware. Which, for example could look like this.

```c
#ifndef __LITEX_MEMORY_MAP_H
#define __LITEX_MEMORY_MAP_H

#define LITEX_TIMER0_BASE                  0xf0004000
#define LITEX_UART0_BASE                   0xf0005000

#endif // LITEX_MEMORY_MAP_H
```  
I don't have any other peripherals enabled, so I've only defined `TIMER0` and `UART0`. If a peripheral is enabled without the defined base address, compilation will fail. 

The ISR index can also be redefined, in a similar way.

The main concern I have with this solution is that the specified path, needs to be relative to the file from which it is included. So for our custom board, which resides beside the NuttX directory, `LITEX_CUSTOM_IRQ_DEFINITIONS_PATH` needs to be defined to `../../../../../boards/risc-v/litex/xxx/include/memory_map.h` 

I'd welcome suggestions on any other alternative to this issue. 

## Impact

No impact on the exiting Litex configuration. Adds additional Kconfig options to the "peripherals" menu.

## Testing

`./tools/configure.sh arty_a7:nsh &&  make` will do a build with the new Kconfig options. Specifying the relative path to the included file works as expected.