### PR TITLE
sched/pthread: restore C89 compliance in pthread_create

### DIFF
--- a/sched/pthread/pthread_create.c
+++ b/sched/pthread/pthread_create.c
@@ -189,6 +189,7 @@ int nx_pthread_create(pthread_trampoline_t trampoline, FAR pthread_t *thread,
 {
   FAR struct pthread_tcb_s *ptcb;
   struct sched_param param;
+  FAR struct tcb_s *parent;
   int policy;
   int errcode;
   pid_t pid;
@@ -472,7 +473,7 @@ int nx_pthread_create(pthread_trampoline_t trampoline, FAR pthread_t *thread,
    * so it has the same priority as the parent thread.
    */
 
-  FAR struct tcb_s *parent = this_task();
+  parent = this_task();
   DEBUGASSERT(parent != NULL);
 
   if (ptcb->cmn.sched_priority < parent->sched_priority)


### PR DESCRIPTION
## Summary
Restore C89 compliance in pthread_create

## Impact
N/A

## Testing
Pass CI