### PR TITLE
armv8-m: Fix pthread_start syscall

### DIFF
--- a/arch/arm/src/armv8-m/arm_svcall.c
+++ b/arch/arm/src/armv8-m/arm_svcall.c
@@ -315,8 +315,9 @@ int arm_svcall(int irq, void *context, void *arg)
        * At this point, the following values are saved in context:
        *
        *   R0 = SYS_pthread_start
-       *   R1 = entrypt
-       *   R2 = arg
+       *   R1 = startup (trampoline)
+       *   R2 = entrypt
+       *   R3 = arg
        */
 
 #if !defined(CONFIG_BUILD_FLAT) && !defined(CONFIG_DISABLE_PTHREAD)
@@ -334,7 +335,7 @@ int arm_svcall(int irq, void *context, void *arg)
            */
 
           regs[REG_R0]         = regs[REG_R2]; /* pthread entry */
-          regs[REG_R1]         = regs[REG_R2]; /* arg */
+          regs[REG_R1]         = regs[REG_R3]; /* arg */
         }
         break;
 #endif


### PR DESCRIPTION
## Summary

armv8-m: Fix pthread_start syscall: The 'arg' parameter is in R3, not in R2.

## Impact

pthread_create passes the argument correctly to the pthread's entrypoint function.

## Testing

Tested with my custom STM32U5 based board.

