### PR TITLE
sched/sched_releasetcb: Revert 2 changes related to stack deallocation

### DIFF
--- a/sched/sched/sched_releasetcb.c
+++ b/sched/sched/sched_releasetcb.c
@@ -126,22 +126,7 @@ int nxsched_release_tcb(FAR struct tcb_s *tcb, uint8_t ttype)
 
       if (tcb->stack_alloc_ptr)
         {
-    #ifdef CONFIG_BUILD_KERNEL
-          /* If the exiting thread is not a kernel thread, then it has an
-           * address environment.  Don't bother to release the stack memory
-           * in this case... There is no point since the memory lies in the
-           * user memory region that will be destroyed anyway (and the
-           * address environment has probably already been destroyed at
-           * this point.. so we would crash if we even tried it).  But if
-           * this is a privileged group, when we still have to release the
-           * memory using the kernel allocator.
-           */
-
-          if (ttype == TCB_FLAG_TTYPE_KERNEL)
-    #endif
-            {
-              up_release_stack(tcb, ttype);
-            }
+          up_release_stack(tcb, ttype);
         }
 
 #ifdef CONFIG_PIC

--- a/sched/sched/sched_releasetcb.c
+++ b/sched/sched/sched_releasetcb.c
@@ -126,7 +126,7 @@ int nxsched_release_tcb(FAR struct tcb_s *tcb, uint8_t ttype)
 
       if (tcb->stack_alloc_ptr)
         {
-#ifdef CONFIG_BUILD_KERNEL
+    #ifdef CONFIG_BUILD_KERNEL
           /* If the exiting thread is not a kernel thread, then it has an
            * address environment.  Don't bother to release the stack memory
            * in this case... There is no point since the memory lies in the
@@ -138,7 +138,7 @@ int nxsched_release_tcb(FAR struct tcb_s *tcb, uint8_t ttype)
            */
 
           if (ttype == TCB_FLAG_TTYPE_KERNEL)
-#endif
+    #endif
             {
               up_release_stack(tcb, ttype);
             }


### PR DESCRIPTION
## Summary
Reverts two commits. The real problem here is that the address environment is destroyed too soon when a process is exiting. See https://github.com/apache/nuttx/pull/7966 for more information about that.

The reverted change also causes increased memory consumption as stacks for pthreads are never freed when the process is running.
## Impact
CONFIG_BUILD_KERNEL=y only
## Testing
icicle:knsh
