### PR TITLE
driver/h4:increase h4 uart tx/rx buffer default size

### DIFF
--- a/drivers/serial/Kconfig
+++ b/drivers/serial/Kconfig
@@ -724,15 +724,15 @@ if UART_BTH4
 
 config UART_BTH4_TXBUFSIZE
 	int "BT H4 uart TX buffer size"
-	default 1024
+	default 2048
 	---help---
-		H4 UART TX buffer size.  Default: 1024
+		H4 UART TX buffer size.  Default: 2048
 
 config UART_BTH4_RXBUFSIZE
 	int "BT H4 uart RX buffer size"
-	default 1024
+	default 8096
 	---help---
-		H4 UART RX buffer size.  Default: 1024
+		H4 UART RX buffer size.  Default: 8096
 
 config UART_BTH4_NPOLLWAITERS
 	int "Number of poll threads"


### PR DESCRIPTION
## Summary

tx buffer size 1024 to 2048
rx buffer size 1024 to 8096

## Impact

bth4 uart driver

## Testing

Pass CI