### PR TITLE
sensors/bmi160.c: fix the problem Linux SPI doesn't working properly

### DIFF
--- a/drivers/sensors/bmi160.c
+++ b/drivers/sensors/bmi160.c
@@ -278,7 +278,7 @@ static inline void bmi160_configspi(FAR struct spi_dev_s *spi)
 {
   /* Configure SPI for the BMI160 */
 
-  SPI_SETMODE(spi, SPIDEV_MODE3);
+  SPI_SETMODE(spi, SPIDEV_MODE0);
   SPI_SETBITS(spi, 8);
   SPI_HWFEATURES(spi, 0);
   SPI_SETFREQUENCY(spi, BMI160_SPI_MAXFREQUENCY);


### PR DESCRIPTION
## Summary

CH341A chip only supports SPI MODE0, and BMI160 supports both MODE0 and MODE3. So, changing MODE3 to MODE0 makes all cases available.

## Impact

bmi160

## Testing

internally