### PR TITLE
esp32c3: Fix IRQ initialization, it was crashing on DEBUG_ASSERTIONS

### DIFF
--- a/arch/risc-v/include/esp32c3/irq.h
+++ b/arch/risc-v/include/esp32c3/irq.h
@@ -116,10 +116,8 @@
  * The ESP32-C3 CPU interrupt controller accepts 31 asynchronous interrupts.
  */
 
-#define ESP32C3_CPUINT_MIN             1
-#define ESP32C3_CPUINT_MAX             31
-
 #define ESP32C3_NCPUINTS               32
+#define ESP32C3_CPUINT_MAX             (ESP32C3_NCPUINTS - 1)
 
 #define ESP32C3_CPUINT_MAC             0
 #define ESP32C3_CPUINT_MAC_NMI         1

--- a/arch/risc-v/src/esp32c3/esp32c3_start.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_start.c
@@ -253,12 +253,6 @@ void __esp32c3_start(void)
   esp32c3_region_protection();
 #endif
 
-#ifndef CONFIG_SUPPRESS_INTERRUPTS
-  /* Put the CPU Interrupts in initial state */
-
-  esp32c3_cpuint_initialize();
-#endif
-
   /* Initialize RTC parameters */
 
   esp32c3_rtc_init();


### PR DESCRIPTION
Co-author: Alan C. Assis <alan.carvalho@espressif.com>

## Summary
Fix IRQ initialization, it was crashing on DEBUG_ASSERTIONS
## Impact
Avoid crashing when DEBUG_ASSERTIONS is enabled
## Testing
esp32c3-devkit
