### PR TITLE
Minor sim Makefile fix

### DIFF
--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -40,6 +40,9 @@ NUTTX = $(call CONVERT_PATH,$(TOPDIR)$(DELIM)nuttx$(EXEEXT))
 
 LINKOBJS = sim_head$(OBJEXT)
 REQUIREDOBJS = $(LINKOBJS) sim_doirq$(OBJEXT)
+ifeq ($(CONFIG_SIM_NETUSRSOCK),y)
+  REQUIREDOBJS += sim_usrsock$(OBJEXT)
+endif
 
 ifeq ($(CONFIG_HOST_X86_64),y)
 ifeq ($(CONFIG_SIM_M32),y)


### PR DESCRIPTION
## Summary

- arch/sim: fix undefined reference to `usrsock_event_callback' 

## Impact

sim

## Testing

sim:adb