### PR TITLE
fs/rpmsgfs: return ENOTTY to vfs to do cmd operate 

### DIFF
--- a/fs/rpmsgfs/rpmsgfs.c
+++ b/fs/rpmsgfs/rpmsgfs.c
@@ -83,7 +83,6 @@ struct rpmsgfs_mountpt_s
   char                       fs_root[PATH_MAX];
   void                       *handle;
   int                        timeout;  /* Connect timeout */
-  struct statfs              statfs;
 };
 
 /****************************************************************************
@@ -1225,20 +1224,11 @@ static int rpmsgfs_statfs(FAR struct inode *mountpt, FAR struct statfs *buf)
       return ret;
     }
 
-  if (fs->statfs.f_type == RPMSGFS_MAGIC)
-    {
-      memcpy(buf, &fs->statfs, sizeof(struct statfs));
-      nxmutex_unlock(&fs->fs_lock);
-      return 0;
-    }
-
   /* Call the host fs to perform the statfs */
 
   memset(buf, 0, sizeof(struct statfs));
   ret = rpmsgfs_client_statfs(fs->handle, fs->fs_root, buf);
   buf->f_type = RPMSGFS_MAGIC;
-
-  memcpy(&fs->statfs, buf, sizeof(struct statfs));
 
   nxmutex_unlock(&fs->fs_lock);
   return ret;

--- a/fs/rpmsgfs/rpmsgfs.c
+++ b/fs/rpmsgfs/rpmsgfs.c
@@ -635,6 +635,10 @@ static int rpmsgfs_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   /* Call our internal routine to perform the ioctl */
 
   ret = rpmsgfs_client_ioctl(fs->handle, hf->fd, cmd, arg);
+  if (ret == 0 && (cmd == FIONBIO || cmd == FIOCLEX || cmd == FIONCLEX))
+    {
+      ret = -ENOTTY;
+    }
 
   nxmutex_unlock(&fs->fs_lock);
   return ret;


### PR DESCRIPTION
## Summary

and Revert "rpmsgfs: cache statfs result in case of deadlock"  

## Impact

rpmsgfs

## Testing

Xiaomi Watch S1 Pro