### PR TITLE
include/nuttx/timers/pwm: Add user provided argument in struct pwm_info_s

### DIFF
--- a/include/nuttx/timers/pwm.h
+++ b/include/nuttx/timers/pwm.h
@@ -148,6 +148,9 @@ struct pwm_info_s
                                  * generate an indefinite number of pulses */
 #  endif
 #endif /* CONFIG_PWM_MULTICHAN */
+
+  FAR void           *arg;      /* User provided argument to be used in the
+                                 * lower half */
 };
 
 /* This structure is a set a callback functions used to call from the upper-


### PR DESCRIPTION
## Summary

Here is a case how to use arg:

If application need do the ADC conversion as the same frequency and phase of PWM, he can pass a semaphore as arg and then PWM driver will post the semaphore in he start point of every period.

## Impact

New field for IOCTL

## Testing

Pass CI