### PR TITLE
arch/addrenv: Change group_addrenv_t to arch_addrenv_t

### DIFF
--- a/Documentation/components/binfmt.rst
+++ b/Documentation/components/binfmt.rst
@@ -123,7 +123,7 @@ pointer to a write-able instance of :c:struct:`binfmt_s`.
        */
 
     #ifdef CONFIG_ARCH_ADDRENV
-      group_addrenv_t addrenv;             /* Task group address environment */
+      arch_addrenv_t addrenv;              /* Task group address environment */
     #endif
 
       size_t mapsize;                      /* Size of the mapped address region (needed for munmap) */

--- a/Documentation/reference/os/addrenv.rst
+++ b/Documentation/reference/os/addrenv.rst
@@ -22,7 +22,7 @@ The CPU-specific logic must provide two categories in interfaces:
 
 #. **Binary Loader Support**. These are low-level interfaces used
    in ``binfmt/`` to instantiate tasks with address environments.
-   These interfaces all operate on type ``group_addrenv_t`` which
+   These interfaces all operate on type ``arch_addrenv_t`` which
    is an abstract representation of a task group's address
    environment and the type must be defined in\ ``arch/arch.h`` if
    ``CONFIG_ARCH_ADDRENV`` is defined. These low-level interfaces
@@ -89,7 +89,7 @@ The CPU-specific logic must provide two categories in interfaces:
    - :c:func:`up_addrenv_kstackalloc`: Allocate the process kernel stack.
 
 .. c:function:: int up_addrenv_create(size_t textsize, size_t datasize, \
-  size_t heapsize, FAR group_addrenv_t *addrenv);
+  size_t heapsize, FAR arch_addrenv_t *addrenv);
 
   This function is called when a new task is created in order to
   instantiate an address environment for the new task group.
@@ -109,7 +109,7 @@ The CPU-specific logic must provide two categories in interfaces:
 
   :return: Zero (OK) on success; a negated errno value on failure.
 
-.. c:function:: int up_addrenv_destroy(group_addrenv_t *addrenv)
+.. c:function:: int up_addrenv_destroy(arch_addrenv_t *addrenv)
 
   This function is called when a final thread leaves the task
   group and the task group is destroyed. This function then destroys
@@ -121,7 +121,7 @@ The CPU-specific logic must provide two categories in interfaces:
 
   :return: Zero (OK) on success; a negated errno value on failure.
 
-.. c:function:: int up_addrenv_vtext(FAR group_addrenv_t addrenv, FAR void **vtext)
+.. c:function:: int up_addrenv_vtext(FAR arch_addrenv_t addrenv, FAR void **vtext)
 
   Return the virtual .text address associated with the newly create
   address environment. This function is used by the binary loaders
@@ -133,7 +133,7 @@ The CPU-specific logic must provide two categories in interfaces:
 
   :return: Zero (OK) on success; a negated errno value on failure.
 
-.. c:function:: int up_addrenv_vdata(FAR group_addrenv_t *addrenv, size_t textsize, FAR void **vdata)
+.. c:function:: int up_addrenv_vdata(FAR arch_addrenv_t *addrenv, size_t textsize, FAR void **vdata)
 
   Return the virtual .text address associated with the newly create
   address environment. This function is used by the binary loaders
@@ -149,7 +149,7 @@ The CPU-specific logic must provide two categories in interfaces:
 
   :return: Zero (OK) on success; a negated errno value on failure.
 
-.. c:function:: ssize_t up_addrenv_heapsize(FAR const group_addrenv_t *addrenv)
+.. c:function:: ssize_t up_addrenv_heapsize(FAR const arch_addrenv_t *addrenv)
 
   Return the initial heap allocation size. That is the amount of
   memory allocated by up_addrenv_create() when the heap memory
@@ -162,7 +162,7 @@ The CPU-specific logic must provide two categories in interfaces:
   :return: The initial heap size allocated is returned on success;
     a negated errno value on failure.
 
-.. c:function:: int up_addrenv_select(group_addrenv_t *addrenv, save_addrenv_t *oldenv)
+.. c:function:: int up_addrenv_select(arch_addrenv_t *addrenv, save_addrenv_t *oldenv)
 
   After an address environment has been established for a task
   (via up_addrenv_create()), this function may be called to instantiate
@@ -178,7 +178,7 @@ The CPU-specific logic must provide two categories in interfaces:
     environment that was in place before ``up_addrenv_select()``
     was called. Note that this may be a task agnostic,
     platform-specific representation that may or may not be
-    different from ``group_addrenv_t``.
+    different from ``arch_addrenv_t``.
 
   :return: Zero (OK) on success; a negated errno value on failure.
 

--- a/arch/arm/include/arch.h
+++ b/arch/arm/include/arch.h
@@ -122,7 +122,7 @@ do { \
 #ifdef CONFIG_ARCH_ADDRENV
 /* The task group resources are retained in a single structure, task_group_s
  * that is defined in the header file nuttx/include/nuttx/sched.h. The type
- * group_addrenv_t must be defined by platform specific logic in
+ * arch_addrenv_t must be defined by platform specific logic in
  * nuttx/arch/<architecture>/include/arch.h.
  *
  * These tables would hold the physical address of the level 2 page tables.
@@ -130,7 +130,7 @@ do { \
  * memory until mappings in the level 2 page table are required.
  */
 
-struct group_addrenv_s
+struct arch_addrenv_s
 {
   /* Level 1 page table entries for each group section */
 
@@ -152,12 +152,12 @@ struct group_addrenv_s
 #endif
 };
 
-typedef struct group_addrenv_s group_addrenv_t;
+typedef struct arch_addrenv_s arch_addrenv_t;
 
 /* This type is used when the OS needs to temporarily instantiate a
  * different address environment.  Used in the implementation of
  *
- *   int up_addrenv_select(group_addrenv_t addrenv, save_addrenv_t *oldenv);
+ *   int up_addrenv_select(arch_addrenv_t addrenv, save_addrenv_t *oldenv);
  *   int up_addrenv_restore(save_addrenv_t oldenv);
  *
  * In this case, the saved valued in the L1 page table are returned

--- a/arch/arm/src/armv7-a/arm_addrenv.c
+++ b/arch/arm/src/armv7-a/arm_addrenv.c
@@ -22,7 +22,7 @@
  * Address Environment Interfaces
  *
  * Low-level interfaces used in binfmt/ to instantiate tasks with address
- * environments.  These interfaces all operate on type group_addrenv_t which
+ * environments.  These interfaces all operate on type arch_addrenv_t which
  * is an abstract representation of a task group's address environment and
  * must be defined in arch/arch.h if CONFIG_ARCH_ADDRENV is defined.
  *
@@ -223,7 +223,7 @@ static int up_addrenv_initdata(uintptr_t l2table)
  ****************************************************************************/
 
 int up_addrenv_create(size_t textsize, size_t datasize, size_t heapsize,
-                      group_addrenv_t *addrenv)
+                      arch_addrenv_t *addrenv)
 {
   int ret;
 
@@ -237,7 +237,7 @@ int up_addrenv_create(size_t textsize, size_t datasize, size_t heapsize,
 
   /* Initialize the address environment structure to all zeroes */
 
-  memset(addrenv, 0, sizeof(group_addrenv_t));
+  memset(addrenv, 0, sizeof(arch_addrenv_t));
 
   /* Back the allocation up with physical pages and set up the level 2
    * mapping (which of course does nothing until the L2 page table is hooked
@@ -326,7 +326,7 @@ errout:
  *
  ****************************************************************************/
 
-int up_addrenv_destroy(group_addrenv_t *addrenv)
+int up_addrenv_destroy(arch_addrenv_t *addrenv)
 {
   binfo("addrenv=%p\n", addrenv);
   DEBUGASSERT(addrenv);
@@ -356,7 +356,7 @@ int up_addrenv_destroy(group_addrenv_t *addrenv)
 #endif
 #endif
 
-  memset(addrenv, 0, sizeof(group_addrenv_t));
+  memset(addrenv, 0, sizeof(arch_addrenv_t));
   return OK;
 }
 
@@ -378,7 +378,7 @@ int up_addrenv_destroy(group_addrenv_t *addrenv)
  *
  ****************************************************************************/
 
-int up_addrenv_vtext(group_addrenv_t *addrenv, void **vtext)
+int up_addrenv_vtext(arch_addrenv_t *addrenv, void **vtext)
 {
   binfo("return=%p\n", (void *)CONFIG_ARCH_TEXT_VBASE);
 
@@ -411,7 +411,7 @@ int up_addrenv_vtext(group_addrenv_t *addrenv, void **vtext)
  *
  ****************************************************************************/
 
-int up_addrenv_vdata(group_addrenv_t *addrenv, uintptr_t textsize,
+int up_addrenv_vdata(arch_addrenv_t *addrenv, uintptr_t textsize,
                      void **vdata)
 {
   binfo("return=%p\n",
@@ -443,7 +443,7 @@ int up_addrenv_vdata(group_addrenv_t *addrenv, uintptr_t textsize,
  ****************************************************************************/
 
 #ifdef CONFIG_BUILD_KERNEL
-int up_addrenv_vheap(const group_addrenv_t *addrenv, void **vheap)
+int up_addrenv_vheap(const arch_addrenv_t *addrenv, void **vheap)
 {
   DEBUGASSERT(addrenv && vheap);
   *vheap = (void *)CONFIG_ARCH_HEAP_VBASE;
@@ -471,7 +471,7 @@ int up_addrenv_vheap(const group_addrenv_t *addrenv, void **vheap)
  ****************************************************************************/
 
 #ifdef CONFIG_BUILD_KERNEL
-ssize_t up_addrenv_heapsize(const group_addrenv_t *addrenv)
+ssize_t up_addrenv_heapsize(const arch_addrenv_t *addrenv)
 {
   DEBUGASSERT(addrenv);
   return (ssize_t)addrenv->heapsize;
@@ -496,14 +496,14 @@ ssize_t up_addrenv_heapsize(const group_addrenv_t *addrenv)
  *     This may be used with up_addrenv_restore() to restore the original
  *     address environment that was in place before up_addrenv_select() was
  *     called.  Note that this may be a task agnostic, platform-specific
- *     representation that may or may not be different from group_addrenv_t.
+ *     representation that may or may not be different from arch_addrenv_t.
  *
  * Returned Value:
  *   Zero (OK) on success; a negated errno value on failure.
  *
  ****************************************************************************/
 
-int up_addrenv_select(const group_addrenv_t *addrenv,
+int up_addrenv_select(const arch_addrenv_t *addrenv,
                       save_addrenv_t *oldenv)
 {
   uintptr_t vaddr;
@@ -708,7 +708,7 @@ int up_addrenv_restore(const save_addrenv_t *oldenv)
  *
  ****************************************************************************/
 
-int up_addrenv_coherent(const group_addrenv_t *addrenv)
+int up_addrenv_coherent(const arch_addrenv_t *addrenv)
 {
   DEBUGASSERT(addrenv);
 
@@ -758,15 +758,15 @@ int up_addrenv_coherent(const group_addrenv_t *addrenv)
  *
  ****************************************************************************/
 
-int up_addrenv_clone(const group_addrenv_t *src,
-                     group_addrenv_t *dest)
+int up_addrenv_clone(const arch_addrenv_t *src,
+                     arch_addrenv_t *dest)
 {
   binfo("src=%p dest=%p\n", src, dest);
   DEBUGASSERT(src && dest);
 
   /* Just copy the address environment from the source to the destination */
 
-  memcpy(dest, src, sizeof(group_addrenv_t));
+  memcpy(dest, src, sizeof(arch_addrenv_t));
   return OK;
 }
 

--- a/arch/arm/src/armv7-a/arm_addrenv_kstack.c
+++ b/arch/arm/src/armv7-a/arm_addrenv_kstack.c
@@ -22,7 +22,7 @@
  * Address Environment Interfaces
  *
  * Low-level interfaces used in binfmt/ to instantiate tasks with address
- * environments.  These interfaces all operate on type group_addrenv_t which
+ * environments.  These interfaces all operate on type arch_addrenv_t which
  * is an abstract representation of a task group's address environment and
  * must be defined in arch/arch.h if CONFIG_ARCH_ADDRENV is defined.
  *

--- a/arch/arm/src/armv7-a/arm_addrenv_perms.c
+++ b/arch/arm/src/armv7-a/arm_addrenv_perms.c
@@ -50,7 +50,7 @@
  *
  ****************************************************************************/
 
-int up_addrenv_mprot(group_addrenv_t *addrenv, uintptr_t addr, size_t len,
+int up_addrenv_mprot(arch_addrenv_t *addrenv, uintptr_t addr, size_t len,
                      int prot)
 {
   /* Nothing needs to be done */

--- a/arch/arm/src/armv7-a/arm_addrenv_ustack.c
+++ b/arch/arm/src/armv7-a/arm_addrenv_ustack.c
@@ -22,7 +22,7 @@
  * Address Environment Interfaces
  *
  * Low-level interfaces used in binfmt/ to instantiate tasks with address
- * environments.  These interfaces all operate on type group_addrenv_t which
+ * environments.  These interfaces all operate on type arch_addrenv_t which
  * is an abstract representation of a task group's address environment and
  * must be defined in arch/arch.h if CONFIG_ARCH_ADDRENV is defined.
  *

--- a/arch/arm/src/armv7-a/arm_pgalloc.c
+++ b/arch/arm/src/armv7-a/arm_pgalloc.c
@@ -97,7 +97,7 @@ static uintptr_t alloc_pgtable(void)
  *
  ****************************************************************************/
 
-static int get_pgtable(group_addrenv_t *addrenv, uintptr_t vaddr)
+static int get_pgtable(arch_addrenv_t *addrenv, uintptr_t vaddr)
 {
   uint32_t l1entry;
   uintptr_t paddr;

--- a/arch/arm/src/max326xx/common/max326_icc.c
+++ b/arch/arm/src/max326xx/common/max326_icc.c
@@ -114,7 +114,7 @@ void max326_icc_invalidate(void)
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_ADDRENV
-int up_addrenv_coherent(const group_addrenv_t *addrenv)
+int up_addrenv_coherent(const arch_addrenv_t *addrenv)
 {
   max326_icc_invalidate();
 }

--- a/arch/arm64/include/arch.h
+++ b/arch/arm64/include/arch.h
@@ -59,7 +59,7 @@
 #ifdef CONFIG_ARCH_ADDRENV
 /* The task group resources are retained in a single structure, task_group_s
  * that is defined in the header file nuttx/include/nuttx/sched.h. The type
- * group_addrenv_t must be defined by platform specific logic in
+ * arch_addrenv_t must be defined by platform specific logic in
  * nuttx/arch/<architecture>/include/arch.h.
  *
  * These tables would hold the physical address of the level 2 page tables.
@@ -67,7 +67,7 @@
  * memory until mappings in the level 2 page table are required.
  */
 
-struct group_addrenv_s
+struct arch_addrenv_s
 {
   /* Level 1 page table entries for each group section */
 
@@ -89,12 +89,12 @@ struct group_addrenv_s
 #endif
 };
 
-typedef struct group_addrenv_s group_addrenv_t;
+typedef struct arch_addrenv_s arch_addrenv_t;
 
 /* This type is used when the OS needs to temporarily instantiate a
  * different address environment.  Used in the implementation of
  *
- *   int up_addrenv_select(group_addrenv_t addrenv, save_addrenv_t *oldenv);
+ *   int up_addrenv_select(arch_addrenv_t addrenv, save_addrenv_t *oldenv);
  *   int up_addrenv_restore(save_addrenv_t oldenv);
  *
  * In this case, the saved value in the L1 page table are returned

--- a/arch/or1k/include/arch.h
+++ b/arch/or1k/include/arch.h
@@ -73,7 +73,7 @@
 #ifdef CONFIG_ARCH_ADDRENV
 /* The task group resources are retained in a single structure, task_group_s
  * that is defined in the header file nuttx/include/nuttx/sched.h. The type
- * group_addrenv_t must be defined by platform specific logic in
+ * arch_addrenv_t must be defined by platform specific logic in
  * nuttx/arch/<architecture>/include/arch.h.
  *
  * These tables would hold the physical address of the level 2 page tables.
@@ -81,7 +81,7 @@
  * memory until mappings in the level 2 page table are required.
  */
 
-struct group_addrenv_s
+struct arch_addrenv_s
 {
   /* Level 1 page table entries for each group section */
 
@@ -103,12 +103,12 @@ struct group_addrenv_s
 #endif
 };
 
-typedef struct group_addrenv_s group_addrenv_t;
+typedef struct arch_addrenv_s arch_addrenv_t;
 
 /* This type is used when the OS needs to temporarily instantiate a
  * different address environment.  Used in the implementation of
  *
- *   int up_addrenv_select(group_addrenv_t addrenv, save_addrenv_t *oldenv);
+ *   int up_addrenv_select(arch_addrenv_t addrenv, save_addrenv_t *oldenv);
  *   int up_addrenv_restore(save_addrenv_t oldenv);
  *
  * In this case, the saved valued in the L1 page table are returned

--- a/arch/risc-v/include/arch.h
+++ b/arch/risc-v/include/arch.h
@@ -74,7 +74,7 @@
  *   which gives access to 2MB of memory. This is plenty for many tasks.
  */
 
-struct group_addrenv_s
+struct arch_addrenv_s
 {
   /* Pointers to MAX_LEVELS-1 tables here, one of each are allocated for the
    * task when it is created.
@@ -100,7 +100,7 @@ struct group_addrenv_s
   uintptr_t satp;
 };
 
-typedef struct group_addrenv_s group_addrenv_t;
+typedef struct arch_addrenv_s arch_addrenv_t;
 
 /* If an address environment needs to be saved, saving the satp register
  * will suffice. The register width is architecture dependent

--- a/arch/risc-v/src/common/addrenv.h
+++ b/arch/risc-v/src/common/addrenv.h
@@ -65,7 +65,7 @@
  *
  ****************************************************************************/
 
-uintptr_t riscv_get_pgtable(group_addrenv_t *addrenv, uintptr_t vaddr);
+uintptr_t riscv_get_pgtable(arch_addrenv_t *addrenv, uintptr_t vaddr);
 
 #endif /* CONFIG_ARCH_ADDRENV */
 #endif /* __ARCH_RISC_V_SRC_COMMON_ADDRENV_H */

--- a/arch/risc-v/src/common/riscv_addrenv.c
+++ b/arch/risc-v/src/common/riscv_addrenv.c
@@ -22,7 +22,7 @@
  * Address Environment Interfaces
  *
  * Low-level interfaces used in binfmt/ to instantiate tasks with address
- * environments.  These interfaces all operate on type group_addrenv_t which
+ * environments.  These interfaces all operate on type arch_addrenv_t which
  * is an abstract representation of a task group's address environment and
  * must be defined in arch/arch.h if CONFIG_ARCH_ADDRENV is defined.
  *
@@ -120,7 +120,7 @@ extern uintptr_t            g_kernel_mappings;
  *
  ****************************************************************************/
 
-static void map_spgtables(group_addrenv_t *addrenv, uintptr_t vaddr)
+static void map_spgtables(arch_addrenv_t *addrenv, uintptr_t vaddr)
 {
   int       i;
   uintptr_t prev;
@@ -161,7 +161,7 @@ static void map_spgtables(group_addrenv_t *addrenv, uintptr_t vaddr)
  *
  ****************************************************************************/
 
-static int create_spgtables(group_addrenv_t *addrenv)
+static int create_spgtables(arch_addrenv_t *addrenv)
 {
   int       i;
   uintptr_t paddr;
@@ -203,7 +203,7 @@ static int create_spgtables(group_addrenv_t *addrenv)
  *
  ****************************************************************************/
 
-static int copy_kernel_mappings(group_addrenv_t *addrenv)
+static int copy_kernel_mappings(arch_addrenv_t *addrenv)
 {
   uintptr_t user_mappings = riscv_pgvaddr(addrenv->spgtables[0]);
 
@@ -238,7 +238,7 @@ static int copy_kernel_mappings(group_addrenv_t *addrenv)
  *
  ****************************************************************************/
 
-static int create_region(group_addrenv_t *addrenv, uintptr_t vaddr,
+static int create_region(arch_addrenv_t *addrenv, uintptr_t vaddr,
                          size_t size, uint32_t mmuflags)
 {
   uintptr_t ptlast;
@@ -373,7 +373,7 @@ static inline bool vaddr_is_shm(uintptr_t vaddr)
  ****************************************************************************/
 
 int up_addrenv_create(size_t textsize, size_t datasize, size_t heapsize,
-                      group_addrenv_t *addrenv)
+                      arch_addrenv_t *addrenv)
 {
   int       ret;
   uintptr_t resvbase;
@@ -387,7 +387,7 @@ int up_addrenv_create(size_t textsize, size_t datasize, size_t heapsize,
 
   /* Make sure the address environment is wiped before doing anything */
 
-  memset(addrenv, 0, sizeof(group_addrenv_t));
+  memset(addrenv, 0, sizeof(arch_addrenv_t));
 
   /* Create the static page tables */
 
@@ -512,7 +512,7 @@ errout:
  *
  ****************************************************************************/
 
-int up_addrenv_destroy(group_addrenv_t *addrenv)
+int up_addrenv_destroy(arch_addrenv_t *addrenv)
 {
   /* Recursively destroy it all, need to table walk */
 
@@ -587,7 +587,7 @@ int up_addrenv_destroy(group_addrenv_t *addrenv)
   __ISB();
   __DMB();
 
-  memset(addrenv, 0, sizeof(group_addrenv_t));
+  memset(addrenv, 0, sizeof(arch_addrenv_t));
   return OK;
 }
 
@@ -609,7 +609,7 @@ int up_addrenv_destroy(group_addrenv_t *addrenv)
  *
  ****************************************************************************/
 
-int up_addrenv_vtext(group_addrenv_t *addrenv, void **vtext)
+int up_addrenv_vtext(arch_addrenv_t *addrenv, void **vtext)
 {
   DEBUGASSERT(addrenv && vtext);
   *vtext = (void *)addrenv->textvbase;
@@ -638,7 +638,7 @@ int up_addrenv_vtext(group_addrenv_t *addrenv, void **vtext)
  *
  ****************************************************************************/
 
-int up_addrenv_vdata(group_addrenv_t *addrenv, uintptr_t textsize,
+int up_addrenv_vdata(arch_addrenv_t *addrenv, uintptr_t textsize,
                      void **vdata)
 {
   DEBUGASSERT(addrenv && vdata);
@@ -665,7 +665,7 @@ int up_addrenv_vdata(group_addrenv_t *addrenv, uintptr_t textsize,
  ****************************************************************************/
 
 #ifdef CONFIG_BUILD_KERNEL
-int up_addrenv_vheap(const group_addrenv_t *addrenv, void **vheap)
+int up_addrenv_vheap(const arch_addrenv_t *addrenv, void **vheap)
 {
   DEBUGASSERT(addrenv && vheap);
   *vheap = (void *)addrenv->heapvbase;
@@ -693,7 +693,7 @@ int up_addrenv_vheap(const group_addrenv_t *addrenv, void **vheap)
  ****************************************************************************/
 
 #ifdef CONFIG_BUILD_KERNEL
-ssize_t up_addrenv_heapsize(const group_addrenv_t *addrenv)
+ssize_t up_addrenv_heapsize(const arch_addrenv_t *addrenv)
 {
   DEBUGASSERT(addrenv);
   return (ssize_t)addrenv->heapsize;
@@ -718,14 +718,14 @@ ssize_t up_addrenv_heapsize(const group_addrenv_t *addrenv)
  *     This may be used with up_addrenv_restore() to restore the original
  *     address environment that was in place before up_addrenv_select() was
  *     called.  Note that this may be a task agnostic, hardware
- *     representation that is different from group_addrenv_t.
+ *     representation that is different from arch_addrenv_t.
  *
  * Returned Value:
  *   Zero (OK) on success; a negated errno value on failure.
  *
  ****************************************************************************/
 
-int up_addrenv_select(const group_addrenv_t *addrenv,
+int up_addrenv_select(const arch_addrenv_t *addrenv,
                       save_addrenv_t *oldenv)
 {
   DEBUGASSERT(addrenv && addrenv->satp);
@@ -781,7 +781,7 @@ int up_addrenv_restore(const save_addrenv_t *oldenv)
  *
  ****************************************************************************/
 
-int up_addrenv_coherent(const group_addrenv_t *addrenv)
+int up_addrenv_coherent(const arch_addrenv_t *addrenv)
 {
   /* Flush the instruction and data caches */
 
@@ -807,11 +807,11 @@ int up_addrenv_coherent(const group_addrenv_t *addrenv)
  *
  ****************************************************************************/
 
-int up_addrenv_clone(const group_addrenv_t *src,
-                     group_addrenv_t *dest)
+int up_addrenv_clone(const arch_addrenv_t *src,
+                     arch_addrenv_t *dest)
 {
   DEBUGASSERT(src && dest);
-  memcpy(dest, src, sizeof(group_addrenv_t));
+  memcpy(dest, src, sizeof(arch_addrenv_t));
   return OK;
 }
 

--- a/arch/risc-v/src/common/riscv_addrenv_perms.c
+++ b/arch/risc-v/src/common/riscv_addrenv_perms.c
@@ -122,7 +122,7 @@ static int modify_region(uintptr_t vstart, uintptr_t vend, uintptr_t setmask)
  *
  ****************************************************************************/
 
-int up_addrenv_mprot(group_addrenv_t *addrenv, uintptr_t addr, size_t len,
+int up_addrenv_mprot(arch_addrenv_t *addrenv, uintptr_t addr, size_t len,
                      int prot)
 {
   uintptr_t setmask;

--- a/arch/risc-v/src/common/riscv_addrenv_utils.c
+++ b/arch/risc-v/src/common/riscv_addrenv_utils.c
@@ -58,7 +58,7 @@
  *
  ****************************************************************************/
 
-uintptr_t riscv_get_pgtable(group_addrenv_t *addrenv, uintptr_t vaddr)
+uintptr_t riscv_get_pgtable(arch_addrenv_t *addrenv, uintptr_t vaddr)
 {
   uintptr_t paddr;
   uintptr_t ptprev;

--- a/arch/z80/include/z180/arch.h
+++ b/arch/z80/include/z180/arch.h
@@ -57,7 +57,7 @@ typedef uint8_t save_addrenv_t;
  */
 
 struct z180_cbr_s;
-typedef FAR struct z180_cbr_s *group_addrenv_t;
+typedef FAR struct z180_cbr_s *arch_addrenv_t;
 #endif
 
 /****************************************************************************

--- a/arch/z80/src/z180/z180_mmu.c
+++ b/arch/z80/src/z180/z180_mmu.c
@@ -162,7 +162,7 @@ int z80_mmu_initialize(void)
  * Address Environment Interfaces
  *
  * Low-level interfaces used in binfmt/ to instantiate tasks with address
- * environments.  These interfaces all operate on type group_addrenv_t which
+ * environments.  These interfaces all operate on type arch_addrenv_t which
  * is an abstract representation of a task group's address environment and
  * must be defined in arch/arch.h if CONFIG_ARCH_ADDRENV is defined.
  *
@@ -219,7 +219,7 @@ int z80_mmu_initialize(void)
  ****************************************************************************/
 
 int up_addrenv_create(size_t textsize, size_t datasize, size_t heapsize,
-                      FAR group_addrenv_t *addrenv)
+                      FAR arch_addrenv_t *addrenv)
 {
   FAR struct z180_cbr_s *cbr;
   irqstate_t flags;
@@ -279,7 +279,7 @@ int up_addrenv_create(size_t textsize, size_t datasize, size_t heapsize,
 
   cbr->cbr     = (uint8_t)alloc;
   cbr->pages   = (uint8_t)npages;
-  *addrenv     = (group_addrenv_t)cbr;
+  *addrenv     = (arch_addrenv_t)cbr;
 
   leave_critical_section(flags);
   return OK;
@@ -308,7 +308,7 @@ errout_with_irq:
  *
  ****************************************************************************/
 
-int up_addrenv_destroy(FAR group_addrenv_t *addrenv)
+int up_addrenv_destroy(FAR arch_addrenv_t *addrenv)
 {
   FAR struct z180_cbr_s *cbr = (FAR struct z180_cbr_s *)*addrenv;
 
@@ -342,7 +342,7 @@ int up_addrenv_destroy(FAR group_addrenv_t *addrenv)
  *
  ****************************************************************************/
 
-int up_addrenv_vtext(FAR group_addrenv_t *addrenv, FAR void **vtext)
+int up_addrenv_vtext(FAR arch_addrenv_t *addrenv, FAR void **vtext)
 {
   return CONFIG_Z180_COMMON1AREA_VIRTBASE;
 }
@@ -369,7 +369,7 @@ int up_addrenv_vtext(FAR group_addrenv_t *addrenv, FAR void **vtext)
  *
  ****************************************************************************/
 
-int up_addrenv_vdata(FAR group_addrenv_t *addrenv, uintptr_t textsize,
+int up_addrenv_vdata(FAR arch_addrenv_t *addrenv, uintptr_t textsize,
                      FAR void **vdata)
 {
   return CONFIG_Z180_COMMON1AREA_VIRTBASE + textsize;
@@ -394,7 +394,7 @@ int up_addrenv_vdata(FAR group_addrenv_t *addrenv, uintptr_t textsize,
  ****************************************************************************/
 
 #ifdef CONFIG_BUILD_KERNEL
-int up_addrenv_vheap(FAR const group_addrenv_t *addrenv, FAR void **vheap)
+int up_addrenv_vheap(FAR const arch_addrenv_t *addrenv, FAR void **vheap)
 {
   /* Not implemented */
 
@@ -422,7 +422,7 @@ int up_addrenv_vheap(FAR const group_addrenv_t *addrenv, FAR void **vheap)
  ****************************************************************************/
 
 #ifdef CONFIG_BUILD_KERNEL
-ssize_t up_addrenv_heapsize(FAR const group_addrenv_t *addrenv)
+ssize_t up_addrenv_heapsize(FAR const arch_addrenv_t *addrenv)
 {
   /* Not implemented */
 
@@ -448,14 +448,14 @@ ssize_t up_addrenv_heapsize(FAR const group_addrenv_t *addrenv)
  *     This may be used with up_addrenv_restore() to restore the original
  *     address environment that was in place before up_addrenv_select() was
  *     called.  Note that this may be a task agnostic, hardware
- *     representation that is different from group_addrenv_t.
+ *     representation that is different from arch_addrenv_t.
  *
  * Returned Value:
  *   Zero (OK) on success; a negated errno value on failure.
  *
  ****************************************************************************/
 
-int up_addrenv_select(FAR const group_addrenv_t *addrenv,
+int up_addrenv_select(FAR const arch_addrenv_t *addrenv,
                       FAR save_addrenv_t *oldenv)
 {
   FAR struct z180_cbr_s *cbr = (FAR struct z180_cbr_s *)addrenv;
@@ -514,7 +514,7 @@ int up_addrenv_restore(FAR const save_addrenv_t *oldenv)
  *
  ****************************************************************************/
 
-int up_addrenv_coherent(FAR const group_addrenv_t *addrenv)
+int up_addrenv_coherent(FAR const arch_addrenv_t *addrenv)
 {
   /* There are no caches */
 
@@ -538,8 +538,8 @@ int up_addrenv_coherent(FAR const group_addrenv_t *addrenv)
  *
  ****************************************************************************/
 
-int up_addrenv_clone(FAR const group_addrenv_t *src,
-                     FAR group_addrenv_t *dest)
+int up_addrenv_clone(FAR const arch_addrenv_t *src,
+                     FAR arch_addrenv_t *dest)
 {
   DEBUGASSERT(src && dest);
 

--- a/include/nuttx/addrenv.h
+++ b/include/nuttx/addrenv.h
@@ -273,7 +273,7 @@ struct addrenv_reserve_s
  * Address Environment Interfaces
  *
  * Low-level interfaces used in binfmt/ to instantiate tasks with address
- * environments.  These interfaces all operate on type group_addrenv_t which
+ * environments.  These interfaces all operate on type arch_addrenv_t which
  * is an abstract representation of a task group's address environment and
  * must be defined in arch/arch.h if CONFIG_ARCH_ADDRENV is defined.
  *

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -775,7 +775,7 @@ bool up_textheap_heapmember(FAR void *p);
  * Address Environment Interfaces
  *
  * Low-level interfaces used in binfmt/ to instantiate tasks with address
- * environments.  These interfaces all operate on type group_addrenv_t which
+ * environments.  These interfaces all operate on type arch_addrenv_t which
  * is an abstract representation of a task group's address environment and
  * must be defined in arch/arch.h if CONFIG_ARCH_ADDRENV is defined.
  *
@@ -872,7 +872,7 @@ bool up_textheap_heapmember(FAR void *p);
 
 #ifdef CONFIG_ARCH_ADDRENV
 int up_addrenv_create(size_t textsize, size_t datasize, size_t heapsize,
-                      FAR group_addrenv_t *addrenv);
+                      FAR arch_addrenv_t *addrenv);
 #endif
 
 /****************************************************************************
@@ -892,7 +892,7 @@ int up_addrenv_create(size_t textsize, size_t datasize, size_t heapsize,
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_ADDRENV
-int up_addrenv_destroy(FAR group_addrenv_t *addrenv);
+int up_addrenv_destroy(FAR arch_addrenv_t *addrenv);
 #endif
 
 /****************************************************************************
@@ -914,7 +914,7 @@ int up_addrenv_destroy(FAR group_addrenv_t *addrenv);
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_ADDRENV
-int up_addrenv_vtext(FAR group_addrenv_t *addrenv, FAR void **vtext);
+int up_addrenv_vtext(FAR arch_addrenv_t *addrenv, FAR void **vtext);
 #endif
 
 /****************************************************************************
@@ -944,7 +944,7 @@ int up_addrenv_vtext(FAR group_addrenv_t *addrenv, FAR void **vtext);
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_ADDRENV
-int up_addrenv_vdata(FAR group_addrenv_t *addrenv, uintptr_t textsize,
+int up_addrenv_vdata(FAR arch_addrenv_t *addrenv, uintptr_t textsize,
                      FAR void **vdata);
 #endif
 
@@ -967,7 +967,7 @@ int up_addrenv_vdata(FAR group_addrenv_t *addrenv, uintptr_t textsize,
  ****************************************************************************/
 
 #if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
-int up_addrenv_vheap(FAR const group_addrenv_t *addrenv, FAR void **vheap);
+int up_addrenv_vheap(FAR const arch_addrenv_t *addrenv, FAR void **vheap);
 #endif
 
 /****************************************************************************
@@ -990,7 +990,7 @@ int up_addrenv_vheap(FAR const group_addrenv_t *addrenv, FAR void **vheap);
  ****************************************************************************/
 
 #if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
-ssize_t up_addrenv_heapsize(FAR const group_addrenv_t *addrenv);
+ssize_t up_addrenv_heapsize(FAR const arch_addrenv_t *addrenv);
 #endif
 
 /****************************************************************************
@@ -1011,7 +1011,7 @@ ssize_t up_addrenv_heapsize(FAR const group_addrenv_t *addrenv);
  *     This may be used with up_addrenv_restore() to restore the original
  *     address environment that was in place before up_addrenv_select() was
  *     called.  Note that this may be a task agnostic, platform-specific
- *     representation that may or may not be different from group_addrenv_t.
+ *     representation that may or may not be different from arch_addrenv_t.
  *
  * Returned Value:
  *   Zero (OK) on success; a negated errno value on failure.
@@ -1019,7 +1019,7 @@ ssize_t up_addrenv_heapsize(FAR const group_addrenv_t *addrenv);
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_ADDRENV
-int up_addrenv_select(FAR const group_addrenv_t *addrenv,
+int up_addrenv_select(FAR const arch_addrenv_t *addrenv,
                       FAR save_addrenv_t *oldenv);
 #endif
 
@@ -1061,7 +1061,7 @@ int up_addrenv_restore(FAR const save_addrenv_t *oldenv);
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_ADDRENV
-int up_addrenv_coherent(FAR const group_addrenv_t *addrenv);
+int up_addrenv_coherent(FAR const arch_addrenv_t *addrenv);
 #endif
 
 /****************************************************************************
@@ -1082,8 +1082,8 @@ int up_addrenv_coherent(FAR const group_addrenv_t *addrenv);
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_ADDRENV
-int up_addrenv_clone(FAR const group_addrenv_t *src,
-                     FAR group_addrenv_t *dest);
+int up_addrenv_clone(FAR const arch_addrenv_t *src,
+                     FAR arch_addrenv_t *dest);
 #endif
 
 /****************************************************************************
@@ -1157,7 +1157,7 @@ int up_addrenv_detach(FAR struct task_group_s *group, FAR struct tcb_s *tcb);
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_ADDRENV
-int up_addrenv_mprot(FAR group_addrenv_t *addrenv, uintptr_t addr,
+int up_addrenv_mprot(FAR arch_addrenv_t *addrenv, uintptr_t addr,
                      size_t len, int prot);
 #endif
 

--- a/include/nuttx/binfmt/binfmt.h
+++ b/include/nuttx/binfmt/binfmt.h
@@ -86,7 +86,7 @@ struct binary_s
    *   used to manage the tasks address space.
    */
 
-  group_addrenv_t addrenv;             /* Task group address environment */
+  arch_addrenv_t addrenv;              /* Task group address environment */
 #endif
 
   size_t mapsize;                      /* Size of the mapped address region (needed for munmap) */

--- a/include/nuttx/binfmt/elf.h
+++ b/include/nuttx/binfmt/elf.h
@@ -124,7 +124,7 @@ struct elf_loadinfo_s
    */
 
 #ifdef CONFIG_ARCH_ADDRENV
-  group_addrenv_t    addrenv;    /* Task group address environment */
+  arch_addrenv_t     addrenv;    /* Task group address environment */
   save_addrenv_t     oldenv;     /* Saved address environment */
 #endif
 

--- a/include/nuttx/binfmt/nxflat.h
+++ b/include/nuttx/binfmt/nxflat.h
@@ -89,7 +89,7 @@ struct nxflat_loadinfo_s
    */
 
 #ifdef CONFIG_ARCH_ADDRENV
-  group_addrenv_t addrenv; /* Task group address environment */
+  arch_addrenv_t addrenv;  /* Task group address environment */
   save_addrenv_t oldenv;   /* Saved address environment */
 #endif
 

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -506,7 +506,7 @@ struct task_group_s
 #ifdef CONFIG_ARCH_ADDRENV
   /* Address Environment ****************************************************/
 
-  group_addrenv_t tg_addrenv;       /* Task group address environment       */
+  arch_addrenv_t  tg_addrenv;       /* Task group address environment       */
 #endif
 
   /* Virtual memory mapping info ********************************************/


### PR DESCRIPTION
## Summary
This is preparation for moving address environments out of the group structure into the tcb.

Why move ? Because the group is destroyed very early in the exit phase, but the MMU mappings are needed until the context switch to the next process is complete. Otherwise the MMU will lose its mappings and the system will crash.

The story can be found here:
https://github.com/apache/nuttx/pull/7966
## Impact
Re-naming of a struct
## Testing
iclcle:knsh and CI
