### PR TITLE
Force sockaddr_storage to the desired alignment

### DIFF
--- a/include/sys/socket.h
+++ b/include/sys/socket.h
@@ -279,6 +279,12 @@
 #define SCM_CREDENTIALS 0x02    /* rw: struct ucred */
 #define SCM_SECURITY    0x03    /* rw: security label */
 
+/* Desired design of maximum size and alignment (see RFC2553) */
+
+#define SS_MAXSIZE      128  /* Implementation specific max size */
+#define SS_ALIGNSIZE    (sizeof(FAR struct sockaddr *))
+                             /* Implementation specific desired alignment */
+
 /****************************************************************************
  * Type Definitions
  ****************************************************************************/
@@ -292,9 +298,10 @@
 
 struct sockaddr_storage
 {
-  sa_family_t ss_family;       /* Address family */
-  char        ss_data[126];    /* 126-bytes of address data */
-};
+  sa_family_t ss_family;     /* Address family */
+  char        ss_data[SS_MAXSIZE - sizeof(sa_family_t)];
+}
+aligned_data(SS_ALIGNSIZE);  /* Force desired alignment */
 
 /* The sockaddr structure is used to define a socket address which is used
  * in the bind(), connect(), getpeername(), getsockname(), recvfrom(), and


### PR DESCRIPTION
## Summary

First configure nuttx to support ipv4 and ipv6 dual stack, then start two simulators and run Iperf ipv4 udp speed test, unaligned access exception to sockaddr_in occours.

The root cause is that struct sockaddr_storage isn't set to the desired alignment.

## Impact

Minor

## Testing

CI