### PR TITLE
sys/epool.h: add EPOLLET (edge-triggered) flag to fix compile break

### DIFF
--- a/include/sys/epoll.h
+++ b/include/sys/epoll.h
@@ -84,6 +84,8 @@ enum EPOLL_EVENTS
 #define EPOLLWAKEUP EPOLLWAKEUP
     EPOLLONESHOT = 1u << 30,
 #define EPOLLONESHOT EPOLLONESHOT
+    EPOLLET = 1u << 31,
+#define EPOLLET EPOLLET
   };
 
 /* Flags to be passed to epoll_create1.  */


### PR DESCRIPTION
## Summary

```
dbus/dbus/dbus-pollable-set-epoll.c:258:18: error: ‘EPOLLET’ undeclared (first use in this function); did you mean ‘EPOLLERR’?
  258 |   event.events = EPOLLET;
      |                  ^~~~~~~
      |                  EPOLLERR
```

## Impact

New flag

## Testing

CI