### PR TITLE
invalid dns cache entry after ttl expires

### DIFF
--- a/libs/libc/netdb/lib_dns.h
+++ b/libs/libc/netdb/lib_dns.h
@@ -222,6 +222,7 @@ int dns_query(FAR const char *hostname, FAR union dns_addr_u *addr,
  *   hostname - The hostname string to be cached.
  *   addr     - The IP addresses associated with the hostname.
  *   naddr    - The count of the IP addresses.
+ *   ttl      - The TTL of the IP addresses.
  *
  * Returned Value:
  *   None
@@ -230,7 +231,8 @@ int dns_query(FAR const char *hostname, FAR union dns_addr_u *addr,
 
 #if CONFIG_NETDB_DNSCLIENT_ENTRIES > 0
 void dns_save_answer(FAR const char *hostname,
-                     FAR const union dns_addr_u *addr, int naddr);
+                     FAR const union dns_addr_u *addr, int naddr,
+                     uint32_t ttl);
 #endif
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

Log ttl after receive dns query and invalid dns cache entry when ttl expires.

## Impact

netdb

## Testing

CI