### PR TITLE
Bugfixed the SocketCAN send via setting the dev->d_len to dev->d_sndl…

### DIFF
--- a/net/can/can_sendmsg.c
+++ b/net/can/can_sendmsg.c
@@ -107,6 +107,7 @@ static uint16_t psock_send_eventhandler(FAR struct net_driver_s *dev,
           /* Copy the packet data into the device packet buffer and send it */
 
           devif_send(dev, pstate->snd_buffer, pstate->snd_buflen, 0);
+          dev->d_len = dev->d_sndlen;
           if (dev->d_sndlen == 0)
             {
               return flags;


### PR DESCRIPTION
## Summary
Fixing the issue  #8290
## Impact
Added line of code to the can_sendmsg.c
## Testing
It was tested by not yet merged implementation of SocketCAN on the TI Tiva board.
