### PR TITLE
mm/kasan: bypass link-time optimizer

### DIFF
--- a/mm/kasan/Make.defs
+++ b/mm/kasan/Make.defs
@@ -25,6 +25,7 @@ CSRCS += kasan.c
 # Disable kernel-address in mm subsystem
 
 CFLAGS += -fno-sanitize=kernel-address
+CFLAGS += -fno-lto
 
 # Add the core heap directory to the build
 


### PR DESCRIPTION
## Summary

To avoid lto alias with override __asan_* symbols

undefined reference to `__asan_load4_noabort'
undefined reference to `__asan_load1_noabort'
undefined reference to `__asan_store1_noabort'
undefined reference to `__asan_load1_noabort'
undefined reference to `__asan_store1_noabort'
undefined reference to `__asan_load4_noabort'
undefined reference to `__asan_store4_noabort'

## Impact

kasan + lto

## Testing

CI