### PR TITLE
tcp: modify errno when connect raddr is ANY for ltp

### DIFF
--- a/net/tcp/tcp_finddev.c
+++ b/net/tcp/tcp_finddev.c
@@ -81,7 +81,7 @@ static int tcp_find_ipv4_device(FAR struct tcp_conn_s *conn,
           return OK;
         }
 
-      return -EINVAL;
+      return -ECONNREFUSED;
     }
 
   /* We need to select the device that is going to route the TCP packet
@@ -137,7 +137,7 @@ static int tcp_find_ipv6_device(FAR struct tcp_conn_s *conn,
           return OK;
         }
 
-      return -EINVAL;
+      return -ECONNREFUSED;
     }
 
   /* We need to select the device that is going to route the TCP packet


### PR DESCRIPTION
## Summary

return -ECONNREFUSED instead -EINVAL when the peer can't be found.

## Impact

Minor

## Testing

ltp