### PR TITLE
tcp_netpoll: add assert into tcp_pollsetup when pollinfo invalid

### DIFF
--- a/net/tcp/tcp_netpoll.c
+++ b/net/tcp/tcp_netpoll.c
@@ -226,6 +226,7 @@ int tcp_pollsetup(FAR struct socket *psock, FAR struct pollfd *fds)
     {
       if (++info >= &conn->pollinfo[CONFIG_NET_TCP_NPOLLWAITERS])
         {
+          DEBUGPANIC();
           ret = -ENOMEM;
           goto errout_with_lock;
         }


### PR DESCRIPTION
## Summary

In order to expose similar problems quickly in the future

## Impact

Minor

## Testing

curl