### PR TITLE
arch/arm/src/stm32f7/stm32_i2c.c: Round up stm32_i2c_toticks return v…

### DIFF
--- a/arch/arm/src/stm32f7/stm32_i2c.c
+++ b/arch/arm/src/stm32f7/stm32_i2c.c
@@ -784,11 +784,12 @@ static uint32_t stm32_i2c_toticks(int msgc, struct i2c_msg_s *msgs)
       bytecount += msgs[i].length;
     }
 
-  /* Then return a number of microseconds based on a user provided scaling
-   * factor.
+  /* Then return a number of ticks based on a user provided scaling
+   * factor, rounded up.
    */
 
-  return USEC2TICK(CONFIG_STM32F7_I2C_DYNTIMEO_USECPERBYTE * bytecount);
+  return USEC2TICK(CONFIG_STM32F7_I2C_DYNTIMEO_USECPERBYTE * bytecount +
+                   CONFIG_USEC_PER_TICK / 2 - 1);
 }
 #endif
 


### PR DESCRIPTION
…alue

When sending small number of bytes with larger CONFIG_USEC_PER_TICK this function should return at least 1. Solve this by rounding up the result.

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>

## Summary

This function should always return at least 1. For example with values

bytecount == 1
CONFIG_USEC_PER_TICK == 10000 (default)
CONFIG_STM32F7_I2C_DYNTIMEO_USECPERBYTE = 500

Since USEC2TICK does rounding to nearest, the calculation in ticks would result in (((500 * 1) + (10000 / 2)) / 10000) == ( 5500 / 10000 ) == 0 

Solve this by rounding it up (adding CONFIG_USEC_PER_TICK / 2 - 1), which always results 1 tick at 1 byte regardless of the selected USEC_PER_TICK or STM32F7_I2C_DYNTIMEO_USECPERBYTE values.

## Impact

Fixes the i2c on stm32f7 with default USEC_PER_TICK setting

## Testing

Tested on stm32f7 based board
