### PR TITLE
minidumpserver: add arm-a support

### DIFF
--- a/tools/minidumpserver.py
+++ b/tools/minidumpserver.py
@@ -130,6 +130,25 @@ reg_table = {
         "PC": 15,
         "xPSR": 16,
     },
+    "arm-a": {
+        "R0": 0,
+        "R1": 1,
+        "R2": 2,
+        "R3": 3,
+        "R4": 4,
+        "R5": 5,
+        "R6": 6,
+        "R7": 7,
+        "R8": 8,
+        "SB": 9,
+        "SL": 10,
+        "FP": 11,
+        "IP": 12,
+        "SP": 13,
+        "LR": 14,
+        "PC": 15,
+        "CPSR": 41,
+    },
     "riscv": {
         "ZERO": 0,
         "RA": 1,
@@ -186,7 +205,7 @@ reg_table = {
         "A13": 34,
         "A14": 35,
         "A15": 36,
-    }
+    },
 }
 
 
@@ -204,7 +223,7 @@ class dump_log_file:
     def close(self):
         self.fd.closeself()
 
-    def parse(self):
+    def parse(self, arch):
         data = bytes()
         start = 0
         if self.fd is None:
@@ -217,7 +236,11 @@ class dump_log_file:
             tmp = re.search("up_dump_register:", line)
             if tmp is not None:
                 # find arch
-                self.arch = tmp.group(1)
+                if arch is None:
+                    self.arch = tmp.group(1)
+                else:
+                    self.arch = arch
+
                 if self.arch not in reg_table:
                     logger.error("%s not supported" % (self.arch))
                 # init register list
@@ -427,7 +450,7 @@ class gdb_stub:
                 continue
 
             offset = addr - r["start"]
-            barray += r["data"][offset:offset + 1]
+            barray += r["data"][offset : offset + 1]
 
             addr += 1
             remaining -= 1
@@ -492,6 +515,14 @@ if __name__ == "__main__":
 
     parser.add_argument("-l", "--logfile", required=True, help="logfile")
 
+    parser.add_argument(
+        "-a",
+        "--arch",
+        help="select architecture,if not use this options,\
+                        The architecture will be inferred from the logfile",
+        choices=['arm', 'arm-a', 'riscv', 'xtensa'],
+    )
+
     parser.add_argument("-p", "--port", help="gdbport", type=int, default=1234)
 
     parser.add_argument("--debug", action="store_true", default=False)
@@ -512,7 +543,7 @@ if __name__ == "__main__":
         logger.setLevel(logging.INFO)
 
     log = dump_log_file(args.logfile)
-    log.parse()
+    log.parse(args.arch)
     elf = dump_elf_file(args.elffile)
     elf.parse()
 


### PR DESCRIPTION
## Summary

User can pass -a=xxx to specify the log from which arch since after https://github.com/apache/nuttx/pull/7875, panic log doesn't contain arch prefix anymore.

## Impact

minidumpserver.py

## Testing

Internal user