### PR TITLE
fix run ltp_interfaces_sched_setscheduler_17_1 fail

### DIFF
--- a/sched/sched/sched_setscheduler.c
+++ b/sched/sched/sched_setscheduler.c
@@ -96,6 +96,14 @@ int nxsched_set_scheduler(pid_t pid, int policy,
       return -EINVAL;
     }
 
+  /* Verify that the requested priority is in the valid range */
+
+  if (param->sched_priority < SCHED_PRIORITY_MIN ||
+      param->sched_priority > SCHED_PRIORITY_MAX)
+    {
+      return -EINVAL;
+    }
+
   /* Check if the task to modify the calling task */
 
   if (pid == 0)


### PR DESCRIPTION
## Summary

The policy has changed when sched_setscheduler called invalid args.

## Impact

Minor

## Testing

ltp