### PR TITLE
udp: remove DEBUGASSERT for ip6_is_ipv4addr

### DIFF
--- a/net/udp/udp_send.c
+++ b/net/udp/udp_send.c
@@ -101,7 +101,6 @@ void udp_send(FAR struct net_driver_s *dev, FAR struct udp_conn_s *conn)
            ip6_is_ipv4addr((FAR struct in6_addr *)conn->u.ipv6.raddr)))
 #endif
         {
-          DEBUGASSERT(IFF_IS_IPv4(dev->d_flags));
           udp = UDPIPv4BUF;
 #ifdef CONFIG_NET_IPv6
           if (conn->domain == PF_INET6 &&


### PR DESCRIPTION
## Summary

fix build break if enable CONFIG_NET_IPv6 only

## Impact

Minor

## Testing

CI