### PR TITLE
tcp: add TCP_ACKDATA flag to close event callback

### DIFF
--- a/net/tcp/tcp_close.c
+++ b/net/tcp/tcp_close.c
@@ -285,7 +285,8 @@ static inline int tcp_close_disconnect(FAR struct socket *psock)
     {
       /* Set up to receive TCP data event callbacks */
 
-      conn->clscb->flags = TCP_NEWDATA | TCP_POLL | TCP_DISCONN_EVENTS;
+      conn->clscb->flags = TCP_NEWDATA | TCP_ACKDATA |
+                           TCP_POLL | TCP_DISCONN_EVENTS;
       conn->clscb->event = tcp_close_eventhandler;
       conn->clscb->priv  = conn; /* reference for event handler to free cb */
 


### PR DESCRIPTION
## Summary

The close package cannot be sent in time without TCP_ACKDATA

## Impact

tcp close

## Testing

Xiaomi Watch S1 Pro