### PR TITLE
socket:return -EAGAIN if timeout happends in psock_tcp_send

### DIFF
--- a/net/tcp/tcp_send_buffered.c
+++ b/net/tcp/tcp_send_buffered.c
@@ -1549,6 +1549,12 @@ ssize_t psock_tcp_send(FAR struct socket *psock, FAR const void *buf,
             {
               iob_free_chain(iob);
             }
+          else
+            {
+              nerr("ERROR: no IOB available\n");
+              ret = -EAGAIN;
+              goto errout_with_lock;
+            }
         }
 
       /* Dump I/O buffer chain */


### PR DESCRIPTION
## Summary

psock_tcp_send will enter busyloop state when no IOB keeps at unavailable state when the socket is blocking socket and this will cause WDT. According to socket's manpage, -1 should be returned while errno set to EAGAIN if send/recv timeout was set.

Here's the description:
SO_RCVTIMEO and SO_SNDTIMEO
Specify the receiving or sending timeouts until reporting an error. The argument is a struct timeval. If an input or output function blocks for this period of time, and data has been sent or received, the return value of that function will be the amount of data transferred; if no data has been transferred and the timeout has been reached then -1 is returned with errno set to EAGAIN or EWOULDBLOCK, or EINPROGRESS (for connect(2)) just as if the socket was specified to be nonblocking. If the timeout is set to zero (the default) then the operation will never timeout. Timeouts only have effect for system calls that perform socket I/O (e.g., read(2), recvmsg(2), send(2), sendmsg(2)); timeouts have no effect for select(2), poll(2), epoll_wait(2), and so on.

## Impact

when exhaust iob 

## Testing

Xiaomi AI Speaker
