### PR TITLE
net_lock: fix deadlock issue when running iperf tx test on usrsock

### DIFF
--- a/net/usrsock/usrsock_conn.c
+++ b/net/usrsock/usrsock_conn.c
@@ -224,7 +224,7 @@ int usrsock_setup_request_callback(FAR struct usrsock_conn_s *conn,
 
       if ((flags & USRSOCK_EVENT_REQ_COMPLETE) != 0)
         {
-          nxsem_wait_uninterruptible(&conn->resp.sem);
+          net_sem_wait_uninterruptible(&conn->resp.sem);
           pstate->unlock = true;
         }
 

--- a/net/usrsock/usrsock_devif.c
+++ b/net/usrsock/usrsock_devif.c
@@ -665,6 +665,10 @@ int usrsock_do_request(FAR struct usrsock_conn_s *conn,
       net_sem_wait_uninterruptible(&req->acksem);
       --req->nbusy; /* net_lock held. */
     }
+  else
+    {
+      nerr("error: usrsock request failed with %d\n", ret);
+    }
 
   /* Free request line for next command. */
 


### PR DESCRIPTION
## Summary

Issue Description:
deadlock happens when runnging iperf TCP tx on usrsock with the following commands：
device command: iperf2 -c <PC IP address> -u -i 1 -p 1122  -t 10 PC command: iperf -s -u -i 1 -p 1122

iperf's thread holds net_lock before call usrsock_setup_request_callback and waits for conn->resp.sem by calling
nxsem_wait_uninterruptible(&conn->resp.sem), while conn->resp.sem can only be signaled in usrsock_response, who is waiting for net_lock in tptun's thread.

Solution:
call net_lockedwait_uninterruptible to make sure net_lock can be released when conn->resp.sem is not available.

Here's the backtrace:
```
up_block_task
nuttx/arch/arm/src/common/arm_blocktask.c:151
nxsem_wait
nuttx/sched/semaphore/sem_wait.c:185 (discriminator 2) nxsem_wait_uninterruptible
nuttx/sched/semaphore/sem_wait.c:223 (discriminator 1) usrsock_setup_request_callback
nuttx/net/usrsock/usrsock_conn.c:228
usrsock_setup_data_request_callback
nuttx/net/usrsock/usrsock_conn.c:257
usrsock_getsockopt
nuttx/net/usrsock/usrsock_getsockopt.c:202
psock_getsockopt
nuttx/net/socket/getsockopt.c:448
getsockopt
nuttx/net/socket/getsockopt.c:515
getsock_tcp_windowsize
external/iperf2/iperf2/src/tcp_window_size.c:165
reporter_reportsettings
external/iperf2/iperf2/src/ReportDefault.c:384
reporter_print
external/iperf2/iperf2/src/Reporter.c:1402
reporter_process_report
external/iperf2/iperf2/src/Reporter.c:860
reporter_process_report
external/iperf2/iperf2/src/Reporter.c:828
reporter_spawn
external/iperf2/iperf2/src/Reporter.c:720
thread_run_wrapper
external/iperf2/iperf2/compat/Thread.c:270
pthread_startup
nuttx/libs/libc/pthread/pthread_create.c:59 (discriminator 2) pthread_start
nuttx/sched/pthread/pthread_create.c:182 (discriminator 4)
```
```
up_block_task
nuttx/arch/arm/src/common/arm_blocktask.c:151
nxsem_wait
nuttx/sched/semaphore/sem_wait.c:185 (discriminator 2) sem_wait
nuttx/sched/semaphore/sem_wait.c:271
nxmutex_lock
nuttx/include/nuttx/mutex.h:165
nxrmutex_lock
nuttx/include/nuttx/mutex.h:369
usrsock_handle_req_response
nuttx/net/usrsock/usrsock_devif.c:466
usrsockdev_write
nuttx/drivers/usrsock/usrsock_dev.c:304
file_write
nuttx/fs/vfs/fs_write.c:90
usrsock_rpmsg_default_handler
apps/netutils/usrsock_rpmsg/usrsock_rpmsg_client.c:137 rpmsg_virtio_rx_callback
nuttx/openamp/open-amp/lib/rpmsg/rpmsg_virtio.c:371 virtqueue_notification
nuttx/openamp/open-amp/lib/virtio/virtqueue.c:706
rproc_virtio_notified
nuttx/openamp/open-amp/lib/remoteproc/remoteproc_virtio.c:337 (discriminator 2) remoteproc_get_notification
nuttx/openamp/open-amp/lib/remoteproc/remoteproc.c:999 rptun_worker
nuttx/drivers/rptun/rptun.c:333
rptun_thread
nuttx/drivers/rptun/rptun.c:364 (discriminator 1)
nxtask_start
nuttx/sched/task/task_start.c:144
```

## Impact

usrsock

## Testing

Xiaomi AI Speaker