### PR TITLE
drivers/wireless: Remove the duplicated bc_bifup check from bcmf_wl_auth_event_handler

### DIFF
--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c
@@ -625,11 +625,6 @@ void bcmf_wl_auth_event_handler(FAR struct bcmf_dev_s *priv,
       return;
     }
 
-  if (!priv->bc_bifup)
-    {
-      return;
-    }
-
   bcmf_hexdump((uint8_t *)event, len, (unsigned long)event);
 
   if (type == WLC_E_PSK_SUP)


### PR DESCRIPTION
## Summary

## Impact

Minor

## Testing

CI