### PR TITLE
sched/wqueue: semaphore count should be consistent with the number of work entries.

### DIFF
--- a/sched/semaphore/sem_post.c
+++ b/sched/semaphore/sem_post.c
@@ -89,7 +89,11 @@ int nxsem_post(FAR sem_t *sem)
 
   /* Check the maximum allowable value */
 
-  DEBUGASSERT(sem_count < SEM_VALUE_MAX);
+  if (sem_count >= SEM_VALUE_MAX)
+    {
+      leave_critical_section(flags);
+      return -EOVERFLOW;
+    }
 
   /* Perform the semaphore unlock operation, releasing this task as a
    * holder then also incrementing the count on the semaphore.

--- a/sched/wqueue/kwork_cancel.c
+++ b/sched/wqueue/kwork_cancel.c
@@ -88,6 +88,12 @@ static int work_qcancel(FAR struct kwork_wqueue_s *wqueue,
       else
         {
           dq_rem((FAR dq_entry_t *)work, &wqueue->q);
+
+          /* Semaphore count should be consistent with the number of
+           * work entries.
+           */
+
+          wqueue->sem.semcount--;
         }
 
       work->worker = NULL;


### PR DESCRIPTION
## Summary

1. sched/wqueue: semaphore count should be consistent with the number of work entries.

The number of work entries will be inconsistent with semaphore count
if the work is canceled, in extreme case, semaphore count will overflow
and fallback to 0 the workqueue will stop scheduling the enqueue work.

2. sched/semaphore: correct the return value of sem_post()

sem_post() should return EOVERFLOW if maximum allowable value for
a semaphore would be exceeded.

Reference:
https://man7.org/linux/man-pages/man3/sem_post.3.html


## Impact

N/A

## Testing

sabre-6quad/netnsh_wb