### PR TITLE
fs: unlock tmpfs before free the file object

### DIFF
--- a/fs/tmpfs/fs_tmpfs.c
+++ b/fs/tmpfs/fs_tmpfs.c
@@ -1444,6 +1444,7 @@ static int tmpfs_close(FAR struct file *filep)
        * have any other references.
        */
 
+      nxrmutex_destroy(&tfo->tfo_lock);
       kmm_free(tfo->tfo_data);
       kmm_free(tfo);
       return OK;


### PR DESCRIPTION
## Summary

In tmpfs_close() function, tfo object freed while hold the tfo_lock.  When CONFIG_PRIORITY_INHERITANCE is enabled, tcb will hold an invalid semaphore object, so we need destroy tfo_lock before free tfo.

## Impact

tmpfs

## Testing

libuv test