### PR TITLE
sys/queue.h:remove CONFIG_ALLOW_MIT_COMPONENTS

### DIFF
--- a/include/sys/queue.h
+++ b/include/sys/queue.h
@@ -43,8 +43,6 @@
 #include <nuttx/config.h>
 #include <stdint.h>
 
-#ifdef CONFIG_ALLOW_BSD_COMPONENTS
-
 /* This file defines five types of data structures: singly-linked lists,
  * lists, simple queues, tail queues and XOR simple queues.
  *
@@ -844,5 +842,4 @@
          ((FAR struct type *)(FAR void *)                            \
          ((FAR char *)((head)->stqh_last) - offsetof(struct type, field))))
 
-#endif /* CONFIG_ALLOW_BSD_COMPONENTS */
 #endif /* __INCLUDE_SYS_QUEUE_H */


### PR DESCRIPTION
## Summary
Remove CONFIG_BSD_COMPONENTS from header file sys/queue.h
## Impact
use sys/queue.h
## Testing
Vela
