### PR TITLE
sched: Map SCHED_OTHER to SCHED_FIFO or SCHED_RR

### DIFF
--- a/include/nuttx/pthread.h
+++ b/include/nuttx/pthread.h
@@ -37,11 +37,7 @@
 
 /* Default pthread attribute initializer */
 
-#if CONFIG_RR_INTERVAL == 0
-#  define PTHREAD_DEFAULT_POLICY SCHED_FIFO
-#else
-#  define PTHREAD_DEFAULT_POLICY SCHED_RR
-#endif
+#define PTHREAD_DEFAULT_POLICY SCHED_NORMAL
 
 /* A lot of hassle to use the old-fashioned struct initializers.  But this
  * gives us backward compatibility with some very old compilers.

--- a/include/sched.h
+++ b/include/sched.h
@@ -41,10 +41,11 @@
 
 /* POSIX-like scheduling policies */
 
+#define SCHED_NORMAL              0  /* Alias to SCHED_OTHER */
+#define SCHED_OTHER               0  /* Map to SCHED_FIFO or SCHED_RR */
 #define SCHED_FIFO                1  /* FIFO priority scheduling policy */
 #define SCHED_RR                  2  /* Round robin scheduling policy */
 #define SCHED_SPORADIC            3  /* Sporadic scheduling policy */
-#define SCHED_OTHER               4  /* Not supported */
 
 /* Maximum number of SCHED_SPORADIC replenishments */
 

--- a/libs/libc/pthread/pthread_attr_setschedpolicy.c
+++ b/libs/libc/pthread/pthread_attr_setschedpolicy.c
@@ -57,8 +57,8 @@ int pthread_attr_setschedpolicy(FAR pthread_attr_t *attr, int policy)
 
   linfo("attr=%p policy=%d\n", attr, policy);
 
-  if (!attr ||
-      (policy != SCHED_FIFO
+  if (!attr || (policy != SCHED_OTHER
+       && policy != SCHED_FIFO
 #if CONFIG_RR_INTERVAL > 0
        && policy != SCHED_RR
 #endif

--- a/libs/libc/sched/sched_getprioritymax.c
+++ b/libs/libc/sched/sched_getprioritymax.c
@@ -52,7 +52,7 @@
 
 int sched_get_priority_max(int policy)
 {
-  if (policy < SCHED_FIFO || policy > SCHED_OTHER)
+  if (policy < SCHED_OTHER || policy > SCHED_SPORADIC)
     {
       set_errno(EINVAL);
       return ERROR;

--- a/libs/libc/sched/sched_getprioritymin.c
+++ b/libs/libc/sched/sched_getprioritymin.c
@@ -52,6 +52,6 @@
 
 int sched_get_priority_min(int policy)
 {
-  DEBUGASSERT(policy >= SCHED_FIFO && policy <= SCHED_OTHER);
+  DEBUGASSERT(policy >= SCHED_OTHER && policy <= SCHED_SPORADIC);
   return SCHED_PRIORITY_MIN;
 }

--- a/libs/libc/spawn/lib_psa_dump.c
+++ b/libs/libc/spawn/lib_psa_dump.c
@@ -102,13 +102,21 @@ void posix_spawnattr_dump(posix_spawnattr_t *attr)
   _err("  priority: %d\n", attr->priority);
 
   _err("  policy:   %d\n", attr->policy);
-  if (attr->policy == SCHED_FIFO)
+  if (attr->policy == SCHED_OTHER)
+    {
+      _err("            SCHED_OTHER\n");
+    }
+  else if (attr->policy == SCHED_FIFO)
     {
       _err("            SCHED_FIFO\n");
     }
   else if (attr->policy == SCHED_RR)
     {
       _err("            SCHED_RR\n");
+    }
+  else if (attr->policy == SCHED_SPORADIC)
+    {
+      _err("            SCHED_SPORADIC\n");
     }
   else
     {

--- a/libs/libc/spawn/lib_psa_setschedpolicy.c
+++ b/libs/libc/spawn/lib_psa_setschedpolicy.c
@@ -51,7 +51,7 @@
 
 int posix_spawnattr_setschedpolicy(FAR posix_spawnattr_t *attr, int policy)
 {
-  DEBUGASSERT(attr && (policy == SCHED_FIFO || policy == SCHED_RR));
+  DEBUGASSERT(attr && (policy >= SCHED_OTHER && policy <= SCHED_SPORADIC));
   attr->policy = (uint8_t)policy;
   return OK;
 }

--- a/sched/pthread/pthread_create.c
+++ b/sched/pthread/pthread_create.c
@@ -427,12 +427,12 @@ int nx_pthread_create(pthread_trampoline_t trampoline, FAR pthread_t *thread,
   switch (policy)
     {
       default:
-        DEBUGPANIC();
       case SCHED_FIFO:
         ptcb->cmn.flags    |= TCB_FLAG_SCHED_FIFO;
         break;
 
 #if CONFIG_RR_INTERVAL > 0
+      case SCHED_OTHER:
       case SCHED_RR:
         ptcb->cmn.flags    |= TCB_FLAG_SCHED_RR;
         ptcb->cmn.timeslice = MSEC2TICK(CONFIG_RR_INTERVAL);
@@ -442,12 +442,6 @@ int nx_pthread_create(pthread_trampoline_t trampoline, FAR pthread_t *thread,
 #ifdef CONFIG_SCHED_SPORADIC
       case SCHED_SPORADIC:
         ptcb->cmn.flags    |= TCB_FLAG_SCHED_SPORADIC;
-        break;
-#endif
-
-#if 0 /* Not supported */
-      case SCHED_OTHER:
-        ptcb->cmn.flags    |= TCB_FLAG_SCHED_OTHER;
         break;
 #endif
     }

--- a/sched/sched/sched_setscheduler.c
+++ b/sched/sched/sched_setscheduler.c
@@ -84,7 +84,8 @@ int nxsched_set_scheduler(pid_t pid, int policy,
 
   /* Check for supported scheduling policy */
 
-  if (policy != SCHED_FIFO
+  if (policy != SCHED_OTHER
+      && policy != SCHED_FIFO
 #if CONFIG_RR_INTERVAL > 0
       && policy != SCHED_RR
 #endif
@@ -132,9 +133,6 @@ int nxsched_set_scheduler(pid_t pid, int policy,
   switch (policy)
     {
       default:
-        DEBUGPANIC();
-        break;
-
       case SCHED_FIFO:
         {
 #ifdef CONFIG_SCHED_SPORADIC
@@ -148,14 +146,15 @@ int nxsched_set_scheduler(pid_t pid, int policy,
 
           /* Save the FIFO scheduling parameters */
 
-          tcb->flags       |= TCB_FLAG_SCHED_FIFO;
+          tcb->flags     |= TCB_FLAG_SCHED_FIFO;
 #if CONFIG_RR_INTERVAL > 0 || defined(CONFIG_SCHED_SPORADIC)
-          tcb->timeslice    = 0;
+          tcb->timeslice  = 0;
 #endif
         }
         break;
 
 #if CONFIG_RR_INTERVAL > 0
+      case SCHED_OTHER:
       case SCHED_RR:
         {
 #ifdef CONFIG_SCHED_SPORADIC
@@ -169,8 +168,8 @@ int nxsched_set_scheduler(pid_t pid, int policy,
 
           /* Save the round robin scheduling parameters */
 
-          tcb->flags       |= TCB_FLAG_SCHED_RR;
-          tcb->timeslice    = MSEC2TICK(CONFIG_RR_INTERVAL);
+          tcb->flags     |= TCB_FLAG_SCHED_RR;
+          tcb->timeslice  = MSEC2TICK(CONFIG_RR_INTERVAL);
         }
         break;
 #endif
@@ -263,12 +262,6 @@ int nxsched_set_scheduler(pid_t pid, int policy,
               goto errout_with_irq;
             }
         }
-        break;
-#endif
-
-#if 0 /* Not supported */
-      case SCHED_OTHER:
-        tcb->flags    |= TCB_FLAG_SCHED_OTHER;
         break;
 #endif
     }


### PR DESCRIPTION
## Summary

this behaviour is explicitly specified here:
https://pubs.opengroup.org/onlinepubs/009695399/functions/xsh_chap02_08.html
and map SCHED_NORMAL to SCHED_OTHER like Linux:
https://man7.org/linux/man-pages/man7/sched.7.html

## Impact

SCHED_OTHER and SCHED_NORMAL

## Testing

CI