### PR TITLE
Revert "socket:return -EAGAIN if timeout happends in psock_tcp_send"

### DIFF
--- a/net/tcp/tcp_send_buffered.c
+++ b/net/tcp/tcp_send_buffered.c
@@ -1551,12 +1551,6 @@ ssize_t psock_tcp_send(FAR struct socket *psock, FAR const void *buf,
             {
               iob_free_chain(iob);
             }
-          else
-            {
-              nerr("ERROR: no IOB available\n");
-              ret = -EAGAIN;
-              goto errout_with_lock;
-            }
         }
 
       /* Dump I/O buffer chain */


### PR DESCRIPTION

## Summary

Revert "socket:return -EAGAIN if timeout happends in psock_tcp_send"

This reverts commit fbe641a9164ee04919f172a712f3845e47263d7d.

This issue already fixed by below change:

```
| commit 715785245c461eb696c181b0e6d09b400f20d0c0
| Author: chao an <anchao@xiaomi.com>
| Date:   Mon Jan 16 12:37:44 2023 +0800
|
|     net/tcp: fix potential busy loop in tcp_send_buffered.c
|
|     if the wrbuffer does not have enough space to send the rest of
|     the data, then the send function will loop infinitely in nonblock
|     mode, add send timeout check to avoid this issue.
|
|     Signed-off-by: chao an <anchao@xiaomi.com>
```

Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

iperf tcp client test