### PR TITLE
free TCP rx buffer immediately in tcp_close

### DIFF
--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -450,6 +450,16 @@ void tcp_initialize(void);
 FAR struct tcp_conn_s *tcp_alloc(uint8_t domain);
 
 /****************************************************************************
+ * Name: tcp_free_rx_buffers
+ *
+ * Description:
+ *   Free rx buffer of a connection
+ *
+ ****************************************************************************/
+
+void tcp_free_rx_buffers(FAR struct tcp_conn_s *conn);
+
+/****************************************************************************
  * Name: tcp_free
  *
  * Description:

--- a/net/tcp/tcp_close.c
+++ b/net/tcp/tcp_close.c
@@ -283,6 +283,10 @@ static inline int tcp_close_disconnect(FAR struct socket *psock)
        conn->tcpstateflags == TCP_LAST_ACK) &&
       (conn->clscb = tcp_callback_alloc(conn)) != NULL)
     {
+      /* Free rx buffers of the connection immediately */
+
+      tcp_free_rx_buffers(conn);
+
       /* Set up to receive TCP data event callbacks */
 
       conn->clscb->flags = TCP_NEWDATA | TCP_ACKDATA |


### PR DESCRIPTION

## Summary

free TCP rx buffer immediately in tcp_close

Issue:
TCP rx buffer is freed after 4-way handshake with current design. 3 socket's rx buffer might be consumed during ffmpeg switch music procedure, and this might cause IOB exhausted.

Solution:
free TCP rx buffer immediately in tcp_close to make sure IOB won't be exhausted.

Signed-off-by: 梁超众 <liangchaozhong@xiaomi.com>


## Impact

N/A

## Testing

Xiaomi AI speaker