### PR TITLE
arm/itm_syslog: remove invaild select config

### DIFF
--- a/arch/arm/src/armv7-m/Kconfig
+++ b/arch/arm/src/armv7-m/Kconfig
@@ -130,7 +130,6 @@ config ARMV7M_ITMSYSLOG
 	bool "ITM SYSLOG support"
 	default n
 	select ARCH_SYSLOG
-	select SYSLOG
 	---help---
 		Enable hooks to support ITM syslog output.  This requires additional
 		MCU support in order to be used.  See arch/arm/src/armv7-m/itm_syslog.h

--- a/arch/arm/src/armv7-m/arm_itm_syslog.c
+++ b/arch/arm/src/armv7-m/arm_itm_syslog.c
@@ -80,7 +80,7 @@ static const struct syslog_channel_ops_s g_itm_channel_ops =
 
 /* This structure describes the ITM SYSLOG channel */
 
-static const struct syslog_channel_s g_itm_channel =
+static struct syslog_channel_s g_itm_channel =
 {
   .sc_ops   = &g_itm_channel_ops
 };

--- a/arch/arm/src/armv8-m/Kconfig
+++ b/arch/arm/src/armv8-m/Kconfig
@@ -129,7 +129,6 @@ config ARMV8M_ITMSYSLOG
 	bool "ITM SYSLOG support"
 	default n
 	select ARCH_SYSLOG
-	select SYSLOG
 	---help---
 		Enable hooks to support ITM syslog output.  This requires additional
 		MCU support in order to be used.  See arch/arm/src/armv8-m/itm_syslog.h

--- a/arch/arm/src/armv8-m/arm_itm_syslog.c
+++ b/arch/arm/src/armv8-m/arm_itm_syslog.c
@@ -80,7 +80,7 @@ static const struct syslog_channel_ops_s g_itm_channel_ops =
 
 /* This structure describes the ITM SYSLOG channel */
 
-static const struct syslog_channel_s g_itm_channel =
+static struct syslog_channel_s g_itm_channel =
 {
   .sc_ops   = &g_itm_channel_ops
 };


### PR DESCRIPTION

## Summary

arm/itm_syslog: remove invaild select config

1. CONFIG_SYSLOG has been removed by Nutt on below commit:
 c5ac473bc06aadca3d2015fd0608d59eb45fc9a5
```
| commit c5ac473bc06aadca3d2015fd0608d59eb45fc9a5
| Author: Gregory Nutt <gnutt@nuttx.org>
| Date:   Tue Jun 21 07:58:42 2016 -0600
|
|     SYSLOG: Remove an obsolete, unused configuration item from Kconfig file
```

2. Fix comile warning

```
| armv7-m/arm_itm_syslog.c: In function 'itm_syslog_initialize': | armv7-m/arm_itm_syslog.c:183:18: warning: passing argument 1 of 'syslog_channel' discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
|   183 |   syslog_channel(&g_itm_channel);
|       |                  ^~~~~~~~~~~~~~
| In file included from armv7-m/arm_itm_syslog.c:29:
| nuttx/syslog/syslog.h:155:49: note: expected 'struct syslog_channel_s *' but argument is of type 'const struct syslog_channel_s *'
|   155 | int syslog_channel(FAR struct syslog_channel_s *channel);
|       |
```

Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

ci-check