### PR TITLE
Add smartfs loop driver registration

### DIFF
--- a/drivers/drivers_initialize.c
+++ b/drivers/drivers_initialize.c
@@ -28,6 +28,7 @@
 #include <nuttx/drivers/rpmsgdev.h>
 #include <nuttx/drivers/rpmsgblk.h>
 #include <nuttx/fs/loop.h>
+#include <nuttx/fs/smart.h>
 #include <nuttx/input/uinput.h>
 #include <nuttx/mtd/mtd.h>
 #include <nuttx/net/loopback.h>
@@ -183,5 +184,9 @@ void drivers_initialize(void)
   /* Initialize the user socket rpmsg server */
 
   usrsock_rpmsg_server_initialize();
+#endif
+
+#ifdef CONFIG_SMART_DEV_LOOP
+  smart_loop_register_driver();
 #endif
 }

--- a/drivers/mtd/smart.c
+++ b/drivers/mtd/smart.c
@@ -6289,10 +6289,6 @@ int smart_initialize(int minor, FAR struct mtd_dev_s *mtd,
         }
     }
 
-#ifdef CONFIG_SMART_DEV_LOOP
-  register_driver("/dev/smart", &g_fops, 0666, NULL);
-#endif
-
   return OK;
 
 errout:
@@ -6319,6 +6315,20 @@ errout:
   kmm_free(dev);
   return ret;
 }
+
+/****************************************************************************
+ * Name: smart_loop_register_driver
+ *
+ * Description:
+ *   Registers SmartFS Loop Driver
+ ****************************************************************************/
+
+#ifdef CONFIG_SMART_DEV_LOOP
+int smart_loop_register_driver(void)
+{
+  return register_driver("/dev/smart", &g_fops, 0666, NULL);
+}
+#endif
 
 /****************************************************************************
  * Name: smart_losetup

--- a/include/nuttx/fs/smart.h
+++ b/include/nuttx/fs/smart.h
@@ -152,6 +152,10 @@ extern "C"
  * Public Function Prototypes
  ****************************************************************************/
 
+#ifdef CONFIG_SMART_DEV_LOOP
+int smart_loop_register_driver(void);
+#endif
+
 #undef EXTERN
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
To have possibility to create loop device with SmartFS its driver should be first registered

## Impact
No impact

## Testing
PRE: File /home/user/SmartFS.dat exists and has correct size
nsh> mount -t hostfs -o fs=/home/user /host
nsh> losmart -s 1024 -e 4096 -m 0 -o 0 /host/SmartFS.dat
nsh> mksmartfs /dev/smart0
nsh> mount -t smartfs /dev/smart0 /mnt
