### PR TITLE
libs/netdb: add sanity check to avoid null pointer reference 

### DIFF
--- a/libs/libc/netdb/lib_gethostentbynamer.c
+++ b/libs/libc/netdb/lib_gethostentbynamer.c
@@ -737,7 +737,10 @@ int gethostentbyname_r(FAR const char *name,
     }
   else if ((flags & AI_NUMERICHOST) != 0)
     {
-      *h_errnop = EAI_NONAME;
+      if (h_errnop)
+        {
+          *h_errnop = EAI_NONAME;
+        }
 
       return ERROR;
     }


### PR DESCRIPTION
## Summary

libs/netdb: add sanity check to avoid null pointer reference

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

ci-check