### PR TITLE
libc/stream: fix syslogstream_addstring length error

### DIFF
--- a/libs/libc/stream/lib_syslogstream.c
+++ b/libs/libc/stream/lib_syslogstream.c
@@ -112,7 +112,7 @@ static int syslogstream_addstring(FAR struct lib_syslogstream_s *stream,
   do
     {
       int remain = CONFIG_IOB_BUFSIZE - iob->io_len;
-      remain = remain > len ? len : remain;
+      remain = remain > len - ret ? len - ret : remain;
       memcpy(iob->io_data + iob->io_len, buff + ret, remain);
       iob->io_len += remain;
       ret += remain;


### PR DESCRIPTION
## Summary
When len is greater than CONFIG_IOB_BUFSIZE, len is not updated in time, which will lead to memory stampede

## Impact

## Testing

