### PR TITLE
mm/mm_heap: reduce the memory node overhead size

### DIFF
--- a/mm/mm_heap/mm.h
+++ b/mm/mm_heap/mm.h
@@ -119,7 +119,8 @@
  */
 
 #define MM_ALLOC_BIT     0x1
-#define MM_MASK_BIT      MM_ALLOC_BIT
+#define MM_PREVFREE_BIT  0x2
+#define MM_MASK_BIT      (MM_ALLOC_BIT | MM_PREVFREE_BIT)
 #ifdef CONFIG_MM_SMALL
 # define MMSIZE_MAX      UINT16_MAX
 #else
@@ -129,6 +130,13 @@
 /* What is the size of the allocnode? */
 
 #define SIZEOF_MM_ALLOCNODE sizeof(struct mm_allocnode_s)
+
+/* What is the overhead of the allocnode
+ * Remove the space of preceding field since it locates at the end of the
+ * previous freenode
+ */
+
+#define OVERHEAD_MM_ALLOCNODE (SIZEOF_MM_ALLOCNODE - sizeof(mmsize_t))
 
 /* What is the size of the freenode? */
 

--- a/mm/mm_heap/mm.h
+++ b/mm/mm_heap/mm.h
@@ -134,6 +134,10 @@
 
 #define SIZEOF_MM_FREENODE sizeof(struct mm_freenode_s)
 
+/* Get the node size */
+
+#define SIZEOF_MM_NODE(node) ((node)->size & (~MM_MASK_BIT))
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/
@@ -153,28 +157,28 @@ typedef size_t mmsize_t;
 
 struct mm_allocnode_s
 {
+  mmsize_t preceding;                       /* Size of the preceding chunk */
+  mmsize_t size;                            /* Size of this chunk */
 #if CONFIG_MM_BACKTRACE >= 0
   pid_t pid;                                /* The pid for caller */
 #  if CONFIG_MM_BACKTRACE > 0
   FAR void *backtrace[CONFIG_MM_BACKTRACE]; /* The backtrace buffer for caller */
 #  endif
 #endif
-  mmsize_t size;                            /* Size of this chunk */
-  mmsize_t preceding;                       /* Size of the preceding chunk */
 };
 
 /* This describes a free chunk */
 
 struct mm_freenode_s
 {
+  mmsize_t preceding;                       /* Size of the preceding chunk */
+  mmsize_t size;                            /* Size of this chunk */
 #if CONFIG_MM_BACKTRACE >= 0
   pid_t pid;                                /* The pid for caller */
 #  if CONFIG_MM_BACKTRACE > 0
   FAR void *backtrace[CONFIG_MM_BACKTRACE]; /* The backtrace buffer for caller */
 #  endif
 #endif
-  mmsize_t size;                            /* Size of this chunk */
-  mmsize_t preceding;                       /* Size of the preceding chunk */
   FAR struct mm_freenode_s *flink;          /* Supports a doubly linked list */
   FAR struct mm_freenode_s *blink;
 };

--- a/mm/mm_heap/mm_addfreechunk.c
+++ b/mm/mm_heap/mm_addfreechunk.c
@@ -48,20 +48,21 @@ void mm_addfreechunk(FAR struct mm_heap_s *heap,
 {
   FAR struct mm_freenode_s *next;
   FAR struct mm_freenode_s *prev;
+  size_t nodesize = SIZEOF_MM_NODE(node);
   int ndx;
 
-  DEBUGASSERT(node->size >= SIZEOF_MM_FREENODE);
-  DEBUGASSERT((node->preceding & MM_ALLOC_BIT) == 0);
+  DEBUGASSERT(nodesize >= SIZEOF_MM_FREENODE);
+  DEBUGASSERT((node->size & MM_ALLOC_BIT) == 0);
 
   /* Convert the size to a nodelist index */
 
-  ndx = mm_size2ndx(node->size);
+  ndx = mm_size2ndx(nodesize);
 
   /* Now put the new node into the next */
 
   for (prev = &heap->mm_nodelist[ndx],
        next = heap->mm_nodelist[ndx].flink;
-       next && next->size && next->size < node->size;
+       next && next->size && SIZEOF_MM_NODE(next) < nodesize;
        prev = next, next = next->flink);
 
   /* Does it go in mid next or at the end? */

--- a/mm/mm_heap/mm_checkcorruption.c
+++ b/mm/mm_heap/mm_checkcorruption.c
@@ -40,22 +40,24 @@
 static void checkcorruption_handler(FAR struct mm_allocnode_s *node,
                                     FAR void *arg)
 {
-  if ((node->preceding & MM_ALLOC_BIT) != 0)
+  size_t nodesize = SIZEOF_MM_NODE(node);
+
+  if ((node->size & MM_ALLOC_BIT) != 0)
     {
-      assert(node->size >= SIZEOF_MM_ALLOCNODE);
+      assert(nodesize >= SIZEOF_MM_ALLOCNODE);
     }
   else
     {
       FAR struct mm_freenode_s *fnode = (FAR void *)node;
 
-      assert(node->size >= SIZEOF_MM_FREENODE);
+      assert(nodesize >= SIZEOF_MM_FREENODE);
       assert(fnode->blink->flink == fnode);
-      assert(fnode->blink->size <= fnode->size);
+      assert(SIZEOF_MM_NODE(fnode->blink) <= nodesize);
       assert(fnode->flink == NULL ||
              fnode->flink->blink == fnode);
       assert(fnode->flink == NULL ||
-             fnode->flink->size == 0 ||
-             fnode->flink->size >= fnode->size);
+             SIZEOF_MM_NODE(fnode->flink) == 0 ||
+             SIZEOF_MM_NODE(fnode->flink) >= nodesize);
     }
 }
 

--- a/mm/mm_heap/mm_extend.c
+++ b/mm/mm_heap/mm_extend.c
@@ -92,18 +92,18 @@ void mm_extend(FAR struct mm_heap_s *heap, FAR void *mem, size_t size,
    * (SIZEOF_MM_ALLOCNODE) or simply:
    */
 
-  oldnode->size = size;
+  oldnode->size = size | (oldnode->size & MM_MASK_BIT);
 
   /* The old node should already be marked as allocated */
 
-  DEBUGASSERT((oldnode->preceding & MM_ALLOC_BIT) != 0);
+  DEBUGASSERT((oldnode->size & MM_ALLOC_BIT) != 0);
 
   /* Get and initialize the new terminal node in the heap */
 
   newnode            = (FAR struct mm_allocnode_s *)
                        (blockend - SIZEOF_MM_ALLOCNODE);
-  newnode->size      = SIZEOF_MM_ALLOCNODE;
-  newnode->preceding = oldnode->size | MM_ALLOC_BIT;
+  newnode->size      = SIZEOF_MM_ALLOCNODE | MM_ALLOC_BIT;
+  newnode->preceding = size;
 
   heap->mm_heapend[region] = newnode;
 

--- a/mm/mm_heap/mm_extend.c
+++ b/mm/mm_heap/mm_extend.c
@@ -100,10 +100,9 @@ void mm_extend(FAR struct mm_heap_s *heap, FAR void *mem, size_t size,
 
   /* Get and initialize the new terminal node in the heap */
 
-  newnode            = (FAR struct mm_allocnode_s *)
-                       (blockend - SIZEOF_MM_ALLOCNODE);
-  newnode->size      = SIZEOF_MM_ALLOCNODE | MM_ALLOC_BIT;
-  newnode->preceding = size;
+  newnode       = (FAR struct mm_allocnode_s *)
+                  (blockend - SIZEOF_MM_ALLOCNODE);
+  newnode->size = SIZEOF_MM_ALLOCNODE | MM_ALLOC_BIT;
 
   heap->mm_heapend[region] = newnode;
 

--- a/mm/mm_heap/mm_foreach.c
+++ b/mm/mm_heap/mm_foreach.c
@@ -79,13 +79,14 @@ void mm_foreach(FAR struct mm_heap_s *heap, mm_node_handler_t handler,
            node = (FAR struct mm_allocnode_s *)((FAR char *)node + nodesize))
         {
           nodesize = SIZEOF_MM_NODE(node);
-          minfo("region=%d node=%p size=%zu preceding=%u (%c)\n",
+          minfo("region=%d node=%p size=%zu preceding=%u (%c %c)\n",
                 region, node, nodesize, (unsigned int)node->preceding,
+                (node->size & MM_PREVFREE_BIT) ? 'F' : 'A',
                 (node->size & MM_ALLOC_BIT) ? 'A' : 'F');
 
           handler(node, arg);
 
-          DEBUGASSERT(prev == NULL ||
+          DEBUGASSERT((node->size & MM_PREVFREE_BIT) == 0 ||
                       SIZEOF_MM_NODE(prev) == node->preceding);
           prev = node;
         }

--- a/mm/mm_heap/mm_foreach.c
+++ b/mm/mm_heap/mm_foreach.c
@@ -48,6 +48,7 @@ void mm_foreach(FAR struct mm_heap_s *heap, mm_node_handler_t handler,
 {
   FAR struct mm_allocnode_s *node;
   FAR struct mm_allocnode_s *prev;
+  size_t nodesize;
 #if CONFIG_MM_REGIONS > 1
   int region;
 #else
@@ -75,18 +76,17 @@ void mm_foreach(FAR struct mm_heap_s *heap, mm_node_handler_t handler,
 
       for (node = heap->mm_heapstart[region];
            node < heap->mm_heapend[region];
-           node = (FAR struct mm_allocnode_s *)
-                  ((FAR char *)node + node->size))
+           node = (FAR struct mm_allocnode_s *)((FAR char *)node + nodesize))
         {
-          minfo("region=%d node=%p size=%u preceding=%u (%c)\n",
-                region, node, (unsigned int)node->size,
-                (unsigned int)(node->preceding & ~MM_ALLOC_BIT),
-                (node->preceding & MM_ALLOC_BIT) ? 'A' : 'F');
+          nodesize = SIZEOF_MM_NODE(node);
+          minfo("region=%d node=%p size=%zu preceding=%u (%c)\n",
+                region, node, nodesize, (unsigned int)node->preceding,
+                (node->size & MM_ALLOC_BIT) ? 'A' : 'F');
 
           handler(node, arg);
 
           DEBUGASSERT(prev == NULL ||
-                      prev->size == (node->preceding & ~MM_MASK_BIT));
+                      SIZEOF_MM_NODE(prev) == node->preceding);
           prev = node;
         }
 

--- a/mm/mm_heap/mm_initialize.c
+++ b/mm/mm_heap/mm_initialize.c
@@ -134,19 +134,18 @@ void mm_addregion(FAR struct mm_heap_s *heap, FAR void *heapstart,
    * all available memory.
    */
 
-  heap->mm_heapstart[IDX]            = (FAR struct mm_allocnode_s *)
-                                       heapbase;
+  heap->mm_heapstart[IDX]          = (FAR struct mm_allocnode_s *)heapbase;
   MM_ADD_BACKTRACE(heap, heap->mm_heapstart[IDX]);
-  heap->mm_heapstart[IDX]->size      = SIZEOF_MM_ALLOCNODE | MM_ALLOC_BIT;
-  node                               = (FAR struct mm_freenode_s *)
-                                       (heapbase + SIZEOF_MM_ALLOCNODE);
+  heap->mm_heapstart[IDX]->size    = SIZEOF_MM_ALLOCNODE | MM_ALLOC_BIT;
+  node                             = (FAR struct mm_freenode_s *)
+                                     (heapbase + SIZEOF_MM_ALLOCNODE);
   DEBUGASSERT((((uintptr_t)node + SIZEOF_MM_ALLOCNODE) % MM_MIN_CHUNK) == 0);
-  node->size                         = heapsize - 2*SIZEOF_MM_ALLOCNODE;
-  node->preceding                    = SIZEOF_MM_ALLOCNODE;
-  heap->mm_heapend[IDX]              = (FAR struct mm_allocnode_s *)
-                                       (heapend - SIZEOF_MM_ALLOCNODE);
-  heap->mm_heapend[IDX]->size        = SIZEOF_MM_ALLOCNODE | MM_ALLOC_BIT;
-  heap->mm_heapend[IDX]->preceding   = node->size;
+  node->size                       = heapsize - 2 * SIZEOF_MM_ALLOCNODE;
+  heap->mm_heapend[IDX]            = (FAR struct mm_allocnode_s *)
+                                     (heapend - SIZEOF_MM_ALLOCNODE);
+  heap->mm_heapend[IDX]->size      = SIZEOF_MM_ALLOCNODE | MM_ALLOC_BIT |
+                                     MM_PREVFREE_BIT;
+  heap->mm_heapend[IDX]->preceding = node->size;
   MM_ADD_BACKTRACE(heap, heap->mm_heapend[IDX]);
 
 #undef IDX

--- a/mm/mm_heap/mm_initialize.c
+++ b/mm/mm_heap/mm_initialize.c
@@ -137,8 +137,7 @@ void mm_addregion(FAR struct mm_heap_s *heap, FAR void *heapstart,
   heap->mm_heapstart[IDX]            = (FAR struct mm_allocnode_s *)
                                        heapbase;
   MM_ADD_BACKTRACE(heap, heap->mm_heapstart[IDX]);
-  heap->mm_heapstart[IDX]->size      = SIZEOF_MM_ALLOCNODE;
-  heap->mm_heapstart[IDX]->preceding = MM_ALLOC_BIT;
+  heap->mm_heapstart[IDX]->size      = SIZEOF_MM_ALLOCNODE | MM_ALLOC_BIT;
   node                               = (FAR struct mm_freenode_s *)
                                        (heapbase + SIZEOF_MM_ALLOCNODE);
   DEBUGASSERT((((uintptr_t)node + SIZEOF_MM_ALLOCNODE) % MM_MIN_CHUNK) == 0);
@@ -146,8 +145,8 @@ void mm_addregion(FAR struct mm_heap_s *heap, FAR void *heapstart,
   node->preceding                    = SIZEOF_MM_ALLOCNODE;
   heap->mm_heapend[IDX]              = (FAR struct mm_allocnode_s *)
                                        (heapend - SIZEOF_MM_ALLOCNODE);
-  heap->mm_heapend[IDX]->size        = SIZEOF_MM_ALLOCNODE;
-  heap->mm_heapend[IDX]->preceding   = node->size | MM_ALLOC_BIT;
+  heap->mm_heapend[IDX]->size        = SIZEOF_MM_ALLOCNODE | MM_ALLOC_BIT;
+  heap->mm_heapend[IDX]->preceding   = node->size;
   MM_ADD_BACKTRACE(heap, heap->mm_heapend[IDX]);
 
 #undef IDX

--- a/mm/mm_heap/mm_mallinfo.c
+++ b/mm/mm_heap/mm_mallinfo.c
@@ -129,7 +129,15 @@ int mm_mallinfo(FAR struct mm_heap_s *heap, FAR struct mallinfo *info)
   mm_foreach(heap, mallinfo_handler, info);
 
   info->arena = heap->mm_heapsize;
-  info->uordblks += region * SIZEOF_MM_ALLOCNODE; /* account for the tail node */
+
+  /* Account for the heap->mm_heapend[region] node overhead and the
+   * heap->mm_heapstart[region]->preceding:
+   * heap->mm_heapend[region] overhead size     = OVERHEAD_MM_ALLOCNODE
+   * heap->mm_heapstart[region]->preceding size = sizeof(mmsize_t)
+   * and SIZEOF_MM_ALLOCNODE = OVERHEAD_MM_ALLOCNODE + sizeof(mmsize_t).
+   */
+
+  info->uordblks += region * SIZEOF_MM_ALLOCNODE;
 
   DEBUGASSERT((size_t)info->uordblks + info->fordblks == heap->mm_heapsize);
 

--- a/mm/mm_heap/mm_mallinfo.c
+++ b/mm/mm_heap/mm_mallinfo.c
@@ -39,38 +39,38 @@
 static void mallinfo_handler(FAR struct mm_allocnode_s *node, FAR void *arg)
 {
   FAR struct mallinfo *info = arg;
+  size_t nodesize = SIZEOF_MM_NODE(node);
 
-  minfo("node=%p size=%u preceding=%u (%c)\n",
-        node, (unsigned int)node->size,
-        (unsigned int)(node->preceding & ~MM_ALLOC_BIT),
-        (node->preceding & MM_ALLOC_BIT) ? 'A' : 'F');
+  minfo("node=%p size=%zu preceding=%u (%c)\n",
+        node, nodesize, (unsigned int)node->preceding,
+        (node->size & MM_ALLOC_BIT) ? 'A' : 'F');
 
   /* Check if the node corresponds to an allocated memory chunk */
 
-  if ((node->preceding & MM_ALLOC_BIT) != 0)
+  if ((node->size & MM_ALLOC_BIT) != 0)
     {
-      DEBUGASSERT(node->size >= SIZEOF_MM_ALLOCNODE);
+      DEBUGASSERT(nodesize >= SIZEOF_MM_ALLOCNODE);
       info->aordblks++;
-      info->uordblks += node->size;
+      info->uordblks += nodesize;
     }
   else
     {
       FAR struct mm_freenode_s *fnode = (FAR void *)node;
 
-      DEBUGASSERT(node->size >= SIZEOF_MM_FREENODE);
+      DEBUGASSERT(nodesize >= SIZEOF_MM_FREENODE);
       DEBUGASSERT(fnode->blink->flink == fnode);
-      DEBUGASSERT(fnode->blink->size <= fnode->size);
+      DEBUGASSERT(SIZEOF_MM_NODE(fnode->blink) <= nodesize);
       DEBUGASSERT(fnode->flink == NULL ||
                   fnode->flink->blink == fnode);
       DEBUGASSERT(fnode->flink == NULL ||
-                  fnode->flink->size == 0 ||
-                  fnode->flink->size >= fnode->size);
+                  SIZEOF_MM_NODE(fnode->flink) == 0 ||
+                  SIZEOF_MM_NODE(fnode->flink) >= nodesize);
 
       info->ordblks++;
-      info->fordblks += node->size;
+      info->fordblks += nodesize;
       if (node->size > (size_t)info->mxordblk)
         {
-          info->mxordblk = node->size;
+          info->mxordblk = nodesize;
         }
     }
 }
@@ -79,12 +79,13 @@ static void mallinfo_task_handler(FAR struct mm_allocnode_s *node,
                                   FAR void *arg)
 {
   FAR struct mallinfo_task *info = arg;
+  size_t nodesize = SIZEOF_MM_NODE(node);
 
   /* Check if the node corresponds to an allocated memory chunk */
 
-  if ((node->preceding & MM_ALLOC_BIT) != 0)
+  if ((node->size & MM_ALLOC_BIT) != 0)
     {
-      DEBUGASSERT(node->size >= SIZEOF_MM_ALLOCNODE);
+      DEBUGASSERT(nodesize >= SIZEOF_MM_ALLOCNODE);
 #if CONFIG_MM_BACKTRACE < 0
       if (info->pid == -1)
 #else
@@ -92,13 +93,13 @@ static void mallinfo_task_handler(FAR struct mm_allocnode_s *node,
 #endif
         {
           info->aordblks++;
-          info->uordblks += node->size;
+          info->uordblks += nodesize;
         }
     }
   else if (info->pid == -2)
     {
       info->aordblks++;
-      info->uordblks += node->size;
+      info->uordblks += nodesize;
     }
 }
 

--- a/mm/mm_heap/mm_malloc.c
+++ b/mm/mm_heap/mm_malloc.c
@@ -133,7 +133,7 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
    * (2) to make sure that it is an even multiple of our granule size.
    */
 
-  alignsize = MM_ALIGN_UP(size + SIZEOF_MM_ALLOCNODE);
+  alignsize = MM_ALIGN_UP(size + OVERHEAD_MM_ALLOCNODE);
   if (alignsize < size)
     {
       /* There must have been an integer overflow */
@@ -189,6 +189,13 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
           node->flink->blink = node->blink;
         }
 
+      /* Get a pointer to the next node in physical memory */
+
+      next = (FAR struct mm_freenode_s *)(((FAR char *)node) + nodesize);
+      DEBUGASSERT((next->size & MM_ALLOC_BIT) != 0 &&
+                  (next->size & MM_PREVFREE_BIT) != 0 &&
+                  next->preceding == nodesize);
+
       /* Check if we have to split the free node into one of the allocated
        * size and another smaller freenode.  In some cases, the remaining
        * bytes can be smaller (they may be SIZEOF_MM_ALLOCNODE).  In that
@@ -199,21 +206,16 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
       remaining = nodesize - alignsize;
       if (remaining >= SIZEOF_MM_FREENODE)
         {
-          /* Get a pointer to the next node in physical memory */
-
-          next = (FAR struct mm_freenode_s *)(((FAR char *)node) + nodesize);
-
           /* Create the remainder node */
 
           remainder = (FAR struct mm_freenode_s *)
             (((FAR char *)node) + alignsize);
 
-          remainder->size      = remaining;
-          remainder->preceding = alignsize;
+          remainder->size = remaining;
 
           /* Adjust the size of the node under consideration */
 
-          node->size = alignsize;
+          node->size = alignsize | (node->size & MM_MASK_BIT);
 
           /* Adjust the 'preceding' size of the (old) next node. */
 
@@ -222,6 +224,14 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
           /* Add the remainder back into the nodelist */
 
           mm_addfreechunk(heap, remainder);
+        }
+      else
+        {
+          /* Previous physical memory node is alloced, so clear the previous
+           * free bit in next->size.
+           */
+
+          next->size &= ~MM_PREVFREE_BIT;
         }
 
       /* Handle the case of an exact size match */
@@ -238,7 +248,7 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
       MM_ADD_BACKTRACE(heap, node);
       kasan_unpoison(ret, mm_malloc_size(heap, ret));
 #ifdef CONFIG_MM_FILL_ALLOCATIONS
-      memset(ret, 0xaa, alignsize - SIZEOF_MM_ALLOCNODE);
+      memset(ret, 0xaa, alignsize - OVERHEAD_MM_ALLOCNODE);
 #endif
 #ifdef CONFIG_DEBUG_MM
       minfo("Allocated %p, size %zu\n", ret, alignsize);

--- a/mm/mm_heap/mm_malloc_size.c
+++ b/mm/mm_heap/mm_malloc_size.c
@@ -62,5 +62,5 @@ size_t mm_malloc_size(FAR struct mm_heap_s *heap, FAR void *mem)
 
   DEBUGASSERT(node->size & MM_ALLOC_BIT);
 
-  return SIZEOF_MM_NODE(node) - SIZEOF_MM_ALLOCNODE;
+  return SIZEOF_MM_NODE(node) - OVERHEAD_MM_ALLOCNODE;
 }

--- a/mm/mm_heap/mm_malloc_size.c
+++ b/mm/mm_heap/mm_malloc_size.c
@@ -60,7 +60,7 @@ size_t mm_malloc_size(FAR struct mm_heap_s *heap, FAR void *mem)
 
   /* Sanity check against double-frees */
 
-  DEBUGASSERT(node->preceding & MM_ALLOC_BIT);
+  DEBUGASSERT(node->size & MM_ALLOC_BIT);
 
-  return node->size - SIZEOF_MM_ALLOCNODE;
+  return SIZEOF_MM_NODE(node) - SIZEOF_MM_ALLOCNODE;
 }

--- a/mm/mm_heap/mm_memalign.c
+++ b/mm/mm_heap/mm_memalign.c
@@ -146,7 +146,6 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment,
     {
       FAR struct mm_allocnode_s *newnode;
       FAR struct mm_allocnode_s *next;
-      FAR struct mm_freenode_s *prev;
       size_t precedingsize;
       size_t newnodesize;
 
@@ -154,8 +153,6 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment,
 
       next = (FAR struct mm_allocnode_s *)
         ((FAR char *)node + SIZEOF_MM_NODE(node));
-      prev = (FAR struct mm_freenode_s *)
-        ((FAR char *)node - node->preceding);
 
       /* Make sure that there is space to convert the preceding
        * mm_allocnode_s into an mm_freenode_s.  I think that this should
@@ -193,8 +190,11 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment,
        * set up the node size.
        */
 
-      if ((prev->size & MM_ALLOC_BIT) == 0)
+      if ((node->size & MM_PREVFREE_BIT) != 0)
         {
+          FAR struct mm_freenode_s *prev =
+            (FAR struct mm_freenode_s *)((FAR char *)node - node->preceding);
+
           /* Remove the node.  There must be a predecessor, but there may
            * not be a successor node.
            */
@@ -206,7 +206,7 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment,
               prev->flink->blink = prev->blink;
             }
 
-          precedingsize += prev->size;
+          precedingsize += SIZEOF_MM_NODE(prev);
           node = (FAR struct mm_allocnode_s *)prev;
         }
 
@@ -215,18 +215,18 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment,
       /* Set up the size of the new node */
 
       newnodesize = (uintptr_t)next - (uintptr_t)newnode;
-      newnode->size = newnodesize | MM_ALLOC_BIT;
+      newnode->size = newnodesize | MM_ALLOC_BIT | MM_PREVFREE_BIT;
       newnode->preceding = precedingsize;
 
-      /* Fix the preceding size of the next node */
+      /* Clear the previous free bit of the next node */
 
-      next->preceding = newnodesize;
+      next->size &= ~MM_PREVFREE_BIT;
 
       /* Convert the newnode chunk size back into malloc-compatible size by
-       * subtracting the header size SIZEOF_MM_ALLOCNODE.
+       * subtracting the header size OVERHEAD_MM_ALLOCNODE.
        */
 
-      allocsize = newnodesize - SIZEOF_MM_ALLOCNODE;
+      allocsize = newnodesize - OVERHEAD_MM_ALLOCNODE;
 
       /* Add the original, newly freed node to the free nodelist */
 
@@ -240,16 +240,16 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment,
     }
 
   /* Check if there is free space at the end of the aligned chunk. Convert
-   * malloc-compatible chunk size to include SIZEOF_MM_ALLOCNODE as needed
+   * malloc-compatible chunk size to include OVERHEAD_MM_ALLOCNODE as needed
    * for mm_shrinkchunk.
    */
 
-  size = MM_ALIGN_UP(size + SIZEOF_MM_ALLOCNODE);
+  size = MM_ALIGN_UP(size + OVERHEAD_MM_ALLOCNODE);
 
   if (allocsize > size)
     {
       /* Shrink the chunk by that much -- remember, mm_shrinkchunk wants
-       * internal chunk sizes that include SIZEOF_MM_ALLOCNODE.
+       * internal chunk sizes that include OVERHEAD_MM_ALLOCNODE.
        */
 
       mm_shrinkchunk(heap, node, size);

--- a/mm/mm_heap/mm_realloc.c
+++ b/mm/mm_heap/mm_realloc.c
@@ -71,7 +71,7 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
                      size_t size)
 {
   FAR struct mm_allocnode_s *oldnode;
-  FAR struct mm_freenode_s  *prev;
+  FAR struct mm_freenode_s  *prev = NULL;
   FAR struct mm_freenode_s  *next;
   size_t newsize;
   size_t oldsize;
@@ -117,7 +117,7 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
    * (2) to make sure that it is an even multiple of our granule size.
    */
 
-  newsize = MM_ALIGN_UP(size + SIZEOF_MM_ALLOCNODE);
+  newsize = MM_ALIGN_UP(size + OVERHEAD_MM_ALLOCNODE);
   if (newsize < size)
     {
       /* There must have been an integer overflow */
@@ -149,8 +149,8 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
       if (newsize < oldsize)
         {
           mm_shrinkchunk(heap, oldnode, newsize);
-          kasan_poison((FAR char *)oldnode + SIZEOF_MM_NODE(oldnode),
-                       oldsize - SIZEOF_MM_NODE(oldnode));
+          kasan_poison((FAR char *)oldnode + SIZEOF_MM_NODE(oldnode) +
+                       sizeof(mmsize_t), oldsize - SIZEOF_MM_NODE(oldnode));
         }
 
       /* Then return the original address */
@@ -169,13 +169,15 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
   next = (FAR struct mm_freenode_s *)((FAR char *)oldnode + oldsize);
   if ((next->size & MM_ALLOC_BIT) == 0)
     {
+      DEBUGASSERT((next->size & MM_PREVFREE_BIT) == 0);
       nextsize = SIZEOF_MM_NODE(next);
     }
 
-  prev = (FAR struct mm_freenode_s *)
-    ((FAR char *)oldnode - oldnode->preceding);
-  if ((prev->size & MM_ALLOC_BIT) == 0)
+  if ((oldnode->size & MM_PREVFREE_BIT) != 0)
     {
+      prev = (FAR struct mm_freenode_s *)
+        ((FAR char *)oldnode - oldnode->preceding);
+      DEBUGASSERT((prev->size & MM_ALLOC_BIT) == 0);
       prevsize = SIZEOF_MM_NODE(prev);
     }
 
@@ -251,7 +253,7 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
            * there may not be a successor node.
            */
 
-          DEBUGASSERT(prev->blink);
+          DEBUGASSERT(prev && prev->blink);
           prev->blink->flink = prev->flink;
           if (prev->flink)
             {
@@ -273,11 +275,10 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
 
               prevsize          -= takeprev;
               DEBUGASSERT(prevsize >= SIZEOF_MM_FREENODE);
-              prev->size         = prevsize;
+              prev->size         = prevsize | (prev->size & MM_MASK_BIT);
               nodesize          += takeprev;
-              newnode->size      = nodesize | MM_MASK_BIT;
+              newnode->size      = nodesize | MM_ALLOC_BIT | MM_PREVFREE_BIT;
               newnode->preceding = prevsize;
-              next->preceding    = nodesize;
 
               /* Return the previous free node to the nodelist
                * (with the new size)
@@ -289,9 +290,9 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
             {
               /* Yes.. update its size (newnode->preceding is already set) */
 
-              nodesize        += prevsize;
-              newnode->size    = nodesize | MM_ALLOC_BIT;
-              next->preceding  = nodesize;
+              nodesize     += prevsize;
+              newnode->size = nodesize | MM_ALLOC_BIT |
+                              (newnode->size & MM_MASK_BIT);
             }
 
           newmem = (FAR void *)((FAR char *)newnode + SIZEOF_MM_ALLOCNODE);
@@ -343,7 +344,6 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
                                      ((FAR char *)oldnode + nodesize);
               newnode->size        = nextsize - takenext;
               DEBUGASSERT(newnode->size >= SIZEOF_MM_FREENODE);
-              newnode->preceding   = nodesize;
               andbeyond->preceding = newnode->size;
 
               /* Add the new free node to the nodelist (with the new size) */
@@ -354,7 +354,7 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
             {
               /* Yes, just update some pointers. */
 
-              andbeyond->preceding = nodesize;
+              andbeyond->size &= ~MM_PREVFREE_BIT;
             }
         }
 
@@ -368,7 +368,7 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
            * should be safe for this.
            */
 
-          memcpy(newmem, oldmem, oldsize - SIZEOF_MM_ALLOCNODE);
+          memcpy(newmem, oldmem, oldsize - OVERHEAD_MM_ALLOCNODE);
         }
 
       return newmem;
@@ -388,7 +388,7 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
       newmem = mm_malloc(heap, size);
       if (newmem)
         {
-          memcpy(newmem, oldmem, oldsize - SIZEOF_MM_ALLOCNODE);
+          memcpy(newmem, oldmem, oldsize - OVERHEAD_MM_ALLOCNODE);
           mm_free(heap, oldmem);
         }
 

--- a/mm/mm_heap/mm_realloc.c
+++ b/mm/mm_heap/mm_realloc.c
@@ -134,12 +134,12 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
   /* We need to hold the MM mutex while we muck with the nodelist. */
 
   DEBUGVERIFY(mm_lock(heap));
-  DEBUGASSERT(oldnode->preceding & MM_ALLOC_BIT);
+  DEBUGASSERT(oldnode->size & MM_ALLOC_BIT);
   DEBUGASSERT(mm_heapmember(heap, oldmem));
 
   /* Check if this is a request to reduce the size of the allocation. */
 
-  oldsize = oldnode->size;
+  oldsize = SIZEOF_MM_NODE(oldnode);
   if (newsize <= oldsize)
     {
       /* Handle the special case where we are not going to change the size
@@ -149,8 +149,8 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
       if (newsize < oldsize)
         {
           mm_shrinkchunk(heap, oldnode, newsize);
-          kasan_poison((FAR char *)oldnode + oldnode->size,
-                       oldsize - oldnode->size);
+          kasan_poison((FAR char *)oldnode + SIZEOF_MM_NODE(oldnode),
+                       oldsize - SIZEOF_MM_NODE(oldnode));
         }
 
       /* Then return the original address */
@@ -166,18 +166,17 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
    * best decision
    */
 
-  next = (FAR struct mm_freenode_s *)
-    ((FAR char *)oldnode + oldnode->size);
-  if ((next->preceding & MM_ALLOC_BIT) == 0)
+  next = (FAR struct mm_freenode_s *)((FAR char *)oldnode + oldsize);
+  if ((next->size & MM_ALLOC_BIT) == 0)
     {
-      nextsize = next->size;
+      nextsize = SIZEOF_MM_NODE(next);
     }
 
   prev = (FAR struct mm_freenode_s *)
-    ((FAR char *)oldnode - (oldnode->preceding & ~MM_MASK_BIT));
-  if ((prev->preceding & MM_ALLOC_BIT) == 0)
+    ((FAR char *)oldnode - oldnode->preceding);
+  if ((prev->size & MM_ALLOC_BIT) == 0)
     {
-      prevsize = prev->size;
+      prevsize = SIZEOF_MM_NODE(prev);
     }
 
   /* Now, check if we can extend the current allocation or not */
@@ -185,6 +184,7 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
   if (nextsize + prevsize + oldsize >= newsize)
     {
       size_t needed = newsize - oldsize;
+      size_t nodesize = oldsize;
       size_t takeprev;
       size_t takenext;
 
@@ -271,12 +271,13 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
                * it back into the free list
                */
 
-              prev->size        -= takeprev;
-              DEBUGASSERT(prev->size >= SIZEOF_MM_FREENODE);
-              newnode->size      = oldsize + takeprev;
-              newnode->preceding = prev->size | MM_ALLOC_BIT;
-              next->preceding    = newnode->size |
-                                   (next->preceding & MM_MASK_BIT);
+              prevsize          -= takeprev;
+              DEBUGASSERT(prevsize >= SIZEOF_MM_FREENODE);
+              prev->size         = prevsize;
+              nodesize          += takeprev;
+              newnode->size      = nodesize | MM_MASK_BIT;
+              newnode->preceding = prevsize;
+              next->preceding    = nodesize;
 
               /* Return the previous free node to the nodelist
                * (with the new size)
@@ -288,10 +289,9 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
             {
               /* Yes.. update its size (newnode->preceding is already set) */
 
-              newnode->size      += oldsize;
-              newnode->preceding |= MM_ALLOC_BIT;
-              next->preceding     = newnode->size |
-                                    (next->preceding & MM_MASK_BIT);
+              nodesize        += prevsize;
+              newnode->size    = nodesize | MM_ALLOC_BIT;
+              next->preceding  = nodesize;
             }
 
           newmem = (FAR void *)((FAR char *)newnode + SIZEOF_MM_ALLOCNODE);
@@ -328,7 +328,8 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
 
           /* Extend the node into the next chunk */
 
-          oldnode->size += takenext;
+          nodesize += takenext;
+          oldnode->size = nodesize | (oldnode->size & MM_MASK_BIT);
 
           /* Did we consume the entire preceding chunk? */
 
@@ -339,12 +340,11 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
                */
 
               newnode              = (FAR struct mm_freenode_s *)
-                                     ((FAR char *)oldnode + oldnode->size);
+                                     ((FAR char *)oldnode + nodesize);
               newnode->size        = nextsize - takenext;
               DEBUGASSERT(newnode->size >= SIZEOF_MM_FREENODE);
-              newnode->preceding   = oldnode->size;
-              andbeyond->preceding = newnode->size |
-                                     (andbeyond->preceding & MM_MASK_BIT);
+              newnode->preceding   = nodesize;
+              andbeyond->preceding = newnode->size;
 
               /* Add the new free node to the nodelist (with the new size) */
 
@@ -354,8 +354,7 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
             {
               /* Yes, just update some pointers. */
 
-              andbeyond->preceding = oldnode->size |
-                                     (andbeyond->preceding & MM_MASK_BIT);
+              andbeyond->preceding = nodesize;
             }
         }
 

--- a/mm/mm_heap/mm_shrinkchunk.c
+++ b/mm/mm_heap/mm_shrinkchunk.c
@@ -72,6 +72,7 @@ void mm_shrinkchunk(FAR struct mm_heap_s *heap,
       /* Get the chunk next the next node (which could be the tail chunk) */
 
       andbeyond = (FAR struct mm_allocnode_s *)((FAR char *)next + nextsize);
+      DEBUGASSERT((andbeyond->size & MM_PREVFREE_BIT) != 0);
 
       /* Remove the next node.  There must be a predecessor, but there may
        * not be a successor node.
@@ -93,7 +94,6 @@ void mm_shrinkchunk(FAR struct mm_heap_s *heap,
       /* Set up the size of the new node */
 
       newnode->size        = nextsize + nodesize - size;
-      newnode->preceding   = size;
       node->size           = size | (node->size & MM_MASK_BIT);
       andbeyond->preceding = newnode->size;
 
@@ -118,10 +118,10 @@ void mm_shrinkchunk(FAR struct mm_heap_s *heap,
 
       /* Set up the size of the new node */
 
-      newnode->size      = nodesize - size;
-      newnode->preceding = size;
-      node->size         = size | (node->size & MM_MASK_BIT);
-      next->preceding    = newnode->size;
+      newnode->size   = nodesize - size;
+      node->size      = size | (node->size & MM_MASK_BIT);
+      next->size     |= MM_PREVFREE_BIT;
+      next->preceding = newnode->size;
 
       /* Add the new node to the freenodelist */
 

--- a/mm/mm_heap/mm_shrinkchunk.c
+++ b/mm/mm_heap/mm_shrinkchunk.c
@@ -53,24 +53,25 @@ void mm_shrinkchunk(FAR struct mm_heap_s *heap,
                     FAR struct mm_allocnode_s *node, size_t size)
 {
   FAR struct mm_freenode_s *next;
+  size_t nodesize = SIZEOF_MM_NODE(node);
 
   DEBUGASSERT((size & MM_GRAN_MASK) == 0);
 
   /* Get a reference to the next node */
 
-  next = (FAR struct mm_freenode_s *)((FAR char *)node + node->size);
+  next = (FAR struct mm_freenode_s *)((FAR char *)node + nodesize);
 
   /* Check if it is free */
 
-  if ((next->preceding & MM_ALLOC_BIT) == 0)
+  if ((next->size & MM_ALLOC_BIT) == 0)
     {
       FAR struct mm_allocnode_s *andbeyond;
       FAR struct mm_freenode_s *newnode;
+      size_t nextsize = SIZEOF_MM_NODE(next);
 
       /* Get the chunk next the next node (which could be the tail chunk) */
 
-      andbeyond = (FAR struct mm_allocnode_s *)
-                  ((FAR char *)next + next->size);
+      andbeyond = (FAR struct mm_allocnode_s *)((FAR char *)next + nextsize);
 
       /* Remove the next node.  There must be a predecessor, but there may
        * not be a successor node.
@@ -91,11 +92,10 @@ void mm_shrinkchunk(FAR struct mm_heap_s *heap,
 
       /* Set up the size of the new node */
 
-      newnode->size        = next->size + node->size - size;
+      newnode->size        = nextsize + nodesize - size;
       newnode->preceding   = size;
-      node->size           = size;
-      andbeyond->preceding = newnode->size |
-                             (andbeyond->preceding & MM_MASK_BIT);
+      node->size           = size | (node->size & MM_MASK_BIT);
+      andbeyond->preceding = newnode->size;
 
       /* Add the new node to the freenodelist */
 
@@ -106,7 +106,7 @@ void mm_shrinkchunk(FAR struct mm_heap_s *heap,
    * chunk to be shrunk.
    */
 
-  else if (node->size >= size + SIZEOF_MM_FREENODE)
+  else if (nodesize >= size + SIZEOF_MM_FREENODE)
     {
       FAR struct mm_freenode_s *newnode;
 
@@ -118,11 +118,10 @@ void mm_shrinkchunk(FAR struct mm_heap_s *heap,
 
       /* Set up the size of the new node */
 
-      newnode->size        = node->size - size;
-      newnode->preceding   = size;
-      node->size           = size;
-      next->preceding      = newnode->size |
-                             (next->preceding & MM_MASK_BIT);
+      newnode->size      = nodesize - size;
+      newnode->preceding = size;
+      node->size         = size | (node->size & MM_MASK_BIT);
+      next->preceding    = newnode->size;
 
       /* Add the new node to the freenodelist */
 


### PR DESCRIPTION
## Summary
This PR reduces the memory node overhead size to half of the original by move the `node->preceding` to previous free node in physical like TLSF does (http://www.gii.upv.es/tlsf/main/docs).

Original memory layout of Allocnode and Freenode:
![image](https://user-images.githubusercontent.com/39286361/215642945-0715c050-2ffa-4db4-98cc-643f7558810d.png)

This PR contains two commits:
Commit 1: Exchange `node->size` and `node->preceding` position and move the MM_ALLOC_BIT to `node->size`, this commit is a preparation for move the `node->preceding` to previous free node in physical address. 
After Commit 1, the memory layout of allocnode and freenode become:
![image](https://user-images.githubusercontent.com/39286361/215643033-5c40748f-8bb8-41b8-b938-794ef35b8100.png)

Commit 2: Add MM_PREVFREE_BIT in `node->size` and move the `node->preceding` to previous free node in physical. 
After Commit 2, the memory layout of allocnode and freenode become:
![image](https://user-images.githubusercontent.com/39286361/215643105-70b01c83-8eb2-49c2-bde6-db334c629c1d.png)

## Impact
Dynamic Memory Managerment

## Testing
Vela and sim memory test (mm command, you can set CONFIG_TESTING_MM=y to enable it)
