### PR TITLE
arch/sim: add toolchain library libm

### DIFF
--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -108,6 +108,10 @@ else
   STDLIBS += -lrt
 endif
 
+ifneq ($(CONFIG_LIBM),y)
+  STDLIBS += -lm
+endif
+
 ifeq ($(CONFIG_STACK_COLORATION),y)
   CSRCS += sim_checkstack.c
 endif


### PR DESCRIPTION


## Summary
arch/sim: add toolchain library libm

Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
## Impact
add toolchain math library when disable CONFIG_LIBM
## Testing
Vela CI
