### PR TITLE
libc/stdio: fix rounding errors for fractional values less than 1

### DIFF
--- a/libs/libc/stdio/lib_dtoa_engine.c
+++ b/libs/libc/stdio/lib_dtoa_engine.c
@@ -127,12 +127,13 @@ int __dtoa_engine(double x, FAR struct dtoa_s *dtoa, int max_digits,
 
       /* If limiting decimals, then limit the max digits to no more than the
        * number of digits left of the decimal plus the number of digits right
-       * of the decimal
+       * of the decimal. If the integer value is 0, there are only values to
+       * the right of the decimal point in dtoa->digits.
        */
 
       if (max_decimals != 0)
         {
-          max_digits = MIN(max_digits, max_decimals + MAX(exp + 1, 1));
+          max_digits = MIN(max_digits, max_decimals + MAX(exp + 1, 0));
         }
 
       /* Round nearest by adding 1/2 of the last digit before converting to


### PR DESCRIPTION
Signed-off-by: wangxuedong <wangxuedong@xiaomi.com>

## Summary

Now all decimal values greater than 0.5 and less than 1 are converted to strings with wrong results. This PR is to solve this 
problem.

If we want to convert decimal 0.58322f to string with one significant digit to the right of the decimal point, like this
` snprintf(buff, 8, "%.*f", 1, 0.58322ff);`. In this case the conversion result will be 0.5 instead of the expected 0.6.

The reason is because the calculate result of this code `max_digits = MIN(max_digits, max_decimals + MAX(exp + 1, 1));
` is incorrect. The calculated max_digits value is 2, and then 0.005 will be added here `x = x + g_dtoa_round[max_digits];`. After this, we get the result of 0.58822f which is wrong. To fix this error, we set max_digits to 1, 0.05 will be added to x, so we get the correct value 0.63322f.

In the case of an integer value of 0,  there is only a decimal mantissa in dtoa->digits, and the value of max_digits should be consistent with the number of digits to the right of the decimal point.
decimal point.

## Impact

Conversion of decimal values in spring functions.

## Testing

N/A
