### PR TITLE
watchdog:fix Kconfig typo

### DIFF
--- a/drivers/timers/Kconfig
+++ b/drivers/timers/Kconfig
@@ -356,7 +356,7 @@ config WATCHDOG_DEVPATH
 
 config CONFIG_WATCHDOG_MAGIC_V
 	bool "Watchdog Device Magic num"
-	default Y
+	default y
 	---help---
 		The watchdog can be stopped by writing 'V' to the watchdog's device node
 


### PR DESCRIPTION
Signed-off-by: anjiahao <anjiahao@xiaomi.com>

## Summary
watchdog:fix Kconfig typo
## Impact
watchdog
## Testing
none
