### PR TITLE
arm/unwinder: set default unwinder type to arm exidx/extab

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -1245,8 +1245,7 @@ if SCHED_BACKTRACE
 
 choice
 	prompt "Choose ARM unwinder"
-	default UNWINDER_STACK_POINTER if ARM_THUMB
-	default UNWINDER_FRAME_POINTER if !ARM_THUMB
+	default UNWINDER_ARM
 	---help---
 		This determines which method will be used for unwinding nuttx stack
 		traces for debug.


### PR DESCRIPTION
## Summary

arm/unwinder: set default unwinder type to arm exidx/extab

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

arm backtrace