### PR TITLE
arch/tiva: Remove dead store

### DIFF
--- a/arch/arm/src/tiva/common/tiva_can.c
+++ b/arch/arm/src/tiva/common/tiva_can.c
@@ -2344,7 +2344,6 @@ static int  tivacan_initfilter(struct can_dev_s *dev,
 int tiva_can_initialize(char *devpath, int modnum)
 {
   struct can_dev_s *dev;
-  struct tiva_canmod_s *canmod;
   int ret;
   caninfo("tiva_can_initialize module %d\n", modnum);
 
@@ -2371,8 +2370,6 @@ int tiva_can_initialize(char *devpath, int modnum)
       return -ENODEV;
     }
 #endif
-
-  canmod = dev->cd_priv;
 
   /* Register the driver */
 


### PR DESCRIPTION
## Summary

In `arch/arm/src/tiva/common/tiva_can.c` function `tiva_can_initialize()`, remove the local variable `canmod`, which was assigned but never used.

## Impact

Fixes this compiler warning:

```
chip/common/tiva_can.c:2347:25: warning: variable 'canmod' set but not used [-Wunused-but-set-variable]
```

## Testing

- Build
- nxstyle
