### PR TITLE
arch/xtensa/esp32: Fix RTC IRQ status clear

### DIFF
--- a/arch/xtensa/src/esp32/esp32_rtc_gpio.c
+++ b/arch/xtensa/src/esp32/esp32_rtc_gpio.c
@@ -179,11 +179,12 @@ static int rtcio_interrupt(int irq, void *context, void *arg)
   /* Read and clear the lower RTC interrupt status */
 
   status = getreg32(RTC_CNTL_INT_ST_REG);
-  putreg32(status, RTC_CNTL_INT_CLR_REG);
 
   /* Dispatch pending interrupts in the RTC status register */
 
   rtcio_dispatch(ESP32_FIRST_RTCIOIRQ_PERIPH, status, (uint32_t *)context);
+
+  putreg32(status, RTC_CNTL_INT_CLR_REG);
 
   return OK;
 }


### PR DESCRIPTION
## Summary

This PR aims to fix a potential problem with the RTC interrupt status register.
Clearing the interrupt status register before calling the lower level handlers might impact its result.

## Impact

Nothing is affected by this currently.
Avoids possible problems that might occur in the future.

## Testing

Tested using the `esp32-lyrat:buttons` defconfig.