### PR TITLE
include/sys/socket.h: Add SOCK_CTRL to socket type

### DIFF
--- a/include/nuttx/net/netconfig.h
+++ b/include/nuttx/net/netconfig.h
@@ -104,52 +104,24 @@
 
 #define NET_SOCK_PROTOCOL  0
 
-/* SOCK_DGRAM is the preferred socket type to use when we just want a
- * socket for performing driver ioctls.  However, we can't use SOCK_DRAM
- * if UDP is disabled.
- *
- * Pick a socket type (and perhaps protocol) compatible with the currently
- * selected address family.
+/* SOCK_CTRL is the preferred socket type to use when we just want a
+ * socket for performing driver ioctls.
  */
 
+#define NET_SOCK_TYPE SOCK_CTRL
+
 #if NET_SOCK_FAMILY == AF_INET
-#  if defined(CONFIG_NET_UDP)
-#    define NET_SOCK_TYPE SOCK_DGRAM
-#  elif defined(CONFIG_NET_TCP)
-#   define NET_SOCK_TYPE SOCK_STREAM
-#  elif defined(CONFIG_NET_ICMP_SOCKET)
-#   define NET_SOCK_TYPE SOCK_DGRAM
+#  if !defined(CONFIG_NET_UDP) && !defined(CONFIG_NET_TCP) && \
+      defined(CONFIG_NET_ICMP_SOCKET)
 #   undef NET_SOCK_PROTOCOL
 #   define NET_SOCK_PROTOCOL IPPROTO_ICMP
 #  endif
 #elif NET_SOCK_FAMILY == AF_INET6
-#  if defined(CONFIG_NET_UDP)
-#    define NET_SOCK_TYPE SOCK_DGRAM
-#  elif defined(CONFIG_NET_TCP)
-#   define NET_SOCK_TYPE SOCK_STREAM
-#  elif defined(CONFIG_NET_ICMPv6_SOCKET)
-#   define NET_SOCK_TYPE SOCK_DGRAM
+#  if !defined(CONFIG_NET_UDP) && !defined(CONFIG_NET_TCP) && \
+      defined(CONFIG_NET_ICMPv6_SOCKET)
 #   undef NET_SOCK_PROTOCOL
 #   define NET_SOCK_PROTOCOL IPPROTO_ICMP6
 #  endif
-#elif NET_SOCK_FAMILY == AF_LOCAL
-#  if defined(CONFIG_NET_LOCAL_DGRAM)
-#    define NET_SOCK_TYPE SOCK_DGRAM
-#  elif defined(CONFIG_NET_LOCAL_STREAM)
-#     define NET_SOCK_TYPE SOCK_STREAM
-#  endif
-#elif NET_SOCK_FAMILY == AF_PACKET
-#  define NET_SOCK_TYPE SOCK_RAW
-#elif NET_SOCK_FAMILY == AF_CAN
-#  define NET_SOCK_TYPE SOCK_RAW
-#elif NET_SOCK_FAMILY == AF_IEEE802154
-#  define NET_SOCK_TYPE SOCK_DGRAM
-#elif NET_SOCK_FAMILY == AF_BLUETOOTH
-#  define NET_SOCK_TYPE SOCK_RAW
-#elif NET_SOCK_FAMILY == AF_NETLINK
-#  define NET_SOCK_TYPE SOCK_DGRAM
-#elif NET_SOCK_FAMILY == AF_RPMSG
-#  define NET_SOCK_TYPE SOCK_STREAM
 #endif
 
 /* Eliminate dependencies on other header files.  This should not harm

--- a/include/sys/socket.h
+++ b/include/sys/socket.h
@@ -92,6 +92,10 @@
                                  * required to read an entire packet with each read
                                  * system call.
                                  */
+#define SOCK_CTRL      6        /* SOCK_CTRL is the preferred socket type to use
+                                 * when we just want a socket for performing driver
+                                 * ioctls. This definition is not POSIX compliant.
+                                 */
 #define SOCK_PACKET   10        /* Obsolete and should not be used in new programs */
 
 #define SOCK_CLOEXEC  02000000  /* Atomically set close-on-exec flag for the new

--- a/net/bluetooth/bluetooth_sockif.c
+++ b/net/bluetooth/bluetooth_sockif.c
@@ -166,7 +166,7 @@ static int bluetooth_setup(FAR struct socket *psock, int protocol)
    * Only SOCK_RAW is supported
    */
 
-  if (psock->s_type == SOCK_RAW)
+  if (psock->s_type == SOCK_RAW || psock->s_type == SOCK_CTRL)
     {
       return bluetooth_sockif_alloc(psock);
     }

--- a/net/can/can_sockif.c
+++ b/net/can/can_sockif.c
@@ -207,7 +207,8 @@ static int can_setup(FAR struct socket *psock, int protocol)
 
   /* Verify the socket type (domain should always be PF_CAN here) */
 
-  if (domain == PF_CAN && (type == SOCK_RAW || type == SOCK_DGRAM))
+  if (domain == PF_CAN &&
+      (type == SOCK_RAW || type == SOCK_DGRAM || type == SOCK_CTRL))
     {
       /* Allocate the CAN socket connection structure and save it in the
        * new socket instance.

--- a/net/icmp/icmp_sockif.c
+++ b/net/icmp/icmp_sockif.c
@@ -110,9 +110,10 @@ const struct sock_intf_s g_icmp_sockif =
 
 static int icmp_setup(FAR struct socket *psock, int protocol)
 {
-  /* Only SOCK_DGRAM and IPPROTO_ICMP are supported */
+  /* Only SOCK_DGRAM or SOCK_CTRL and IPPROTO_ICMP are supported */
 
-  if (psock->s_type == SOCK_DGRAM && protocol == IPPROTO_ICMP)
+  if ((psock->s_type == SOCK_DGRAM || psock->s_type == SOCK_CTRL) &&
+       protocol == IPPROTO_ICMP)
     {
       /* Allocate the IPPROTO_ICMP socket connection structure and save in
        * the new socket instance.

--- a/net/icmpv6/icmpv6_sockif.c
+++ b/net/icmpv6/icmpv6_sockif.c
@@ -110,9 +110,10 @@ const struct sock_intf_s g_icmpv6_sockif =
 
 static int icmpv6_setup(FAR struct socket *psock, int protocol)
 {
-  /* Only SOCK_DGRAM and IPPROTO_ICMP6 are supported */
+  /* Only SOCK_DGRAM or SOCK_CTRL and IPPROTO_ICMP6 are supported */
 
-  if (psock->s_type == SOCK_DGRAM && protocol == IPPROTO_ICMP6)
+  if ((psock->s_type == SOCK_DGRAM || psock->s_type == SOCK_CTRL) &&
+      protocol == IPPROTO_ICMP6)
     {
       /* Allocate the IPPROTO_ICMP6 socket connection structure and save in
        * the new socket instance.

--- a/net/ieee802154/ieee802154_sockif.c
+++ b/net/ieee802154/ieee802154_sockif.c
@@ -156,7 +156,7 @@ static int ieee802154_setup(FAR struct socket *psock, int protocol)
    * Only SOCK_DGRAM is supported (since the MAC header is stripped)
    */
 
-  if (psock->s_type == SOCK_DGRAM)
+  if (psock->s_type == SOCK_DGRAM || psock->s_type == SOCK_CTRL)
     {
       return ieee802154_sockif_alloc(psock);
     }

--- a/net/local/local_sockif.c
+++ b/net/local/local_sockif.c
@@ -205,6 +205,27 @@ static int local_setup(FAR struct socket *psock, int protocol)
         return local_sockif_alloc(psock);
 #endif /* CONFIG_NET_LOCAL_DGRAM */
 
+      case SOCK_CTRL:
+#ifdef CONFIG_NET_LOCAL_STREAM
+        if (protocol == 0 || protocol == IPPROTO_TCP)
+          {
+            /* Allocate and attach the local connection structure */
+
+            return local_sockif_alloc(psock);
+          }
+
+#endif
+#ifdef CONFIG_NET_LOCAL_DGRAM
+        if (protocol == 0 || protocol == IPPROTO_UDP)
+          {
+            /* Allocate and attach the local connection structure */
+
+            return local_sockif_alloc(psock);
+          }
+
+#endif
+        return -EPROTONOSUPPORT;
+
       default:
         return -EPROTONOSUPPORT;
     }

--- a/net/netlink/netlink_sockif.c
+++ b/net/netlink/netlink_sockif.c
@@ -136,7 +136,8 @@ static int netlink_setup(FAR struct socket *psock, int protocol)
 
   /* Verify the socket type (domain should always be PF_NETLINK here) */
 
-  if (domain == PF_NETLINK && (type == SOCK_RAW || type == SOCK_DGRAM))
+  if (domain == PF_NETLINK &&
+      (type == SOCK_RAW || type == SOCK_DGRAM || type == SOCK_CTRL))
     {
       /* Allocate the NetLink socket connection structure and save it in the
        * new socket instance.

--- a/net/pkt/pkt_sockif.c
+++ b/net/pkt/pkt_sockif.c
@@ -154,7 +154,7 @@ static int pkt_setup(FAR struct socket *psock, int protocol)
    * Only SOCK_RAW is supported.
    */
 
-  if (psock->s_type == SOCK_RAW)
+  if (psock->s_type == SOCK_RAW || psock->s_type == SOCK_CTRL)
     {
       return pkt_sockif_alloc(psock);
     }


### PR DESCRIPTION
## Summary

SOCK_CTRL is added to provide special control over network drivers and daemons. Currently, SOCK_DGRAM and SOCK_STREAM perform this control, but these use socket resources. In the case of usersocket in particular, this is a waste of the device's limited socket resources.

## Impact

Applications using NET_SOCK_TYPE.

## Testing

SPRESENSE LTE board.