### PR TITLE
Change sec2tick macros to round up

### DIFF
--- a/arch/arm/src/lc823450/lc823450_i2c.c
+++ b/arch/arm/src/lc823450/lc823450_i2c.c
@@ -305,7 +305,7 @@ lc823450_i2c_sem_waitdone(struct lc823450_i2c_priv_s *priv)
 
   /* Get the timeout value */
 
-  timeout = MSEC2TICK(priv->timeoms + (MSEC_PER_TICK / 2));
+  timeout = MSEC2TICK(priv->timeoms);
   timeout += SEC2TICK(CONFIG_LC823450_I2C_TIMEOSEC);
 
   /* Signal the interrupt handler that we are waiting.  NOTE:  Interrupts

--- a/arch/arm/src/stm32f7/stm32_i2c.c
+++ b/arch/arm/src/stm32f7/stm32_i2c.c
@@ -784,12 +784,11 @@ static uint32_t stm32_i2c_toticks(int msgc, struct i2c_msg_s *msgs)
       bytecount += msgs[i].length;
     }
 
-  /* Then return a number of ticks based on a user provided scaling
-   * factor, rounded up.
+  /* Then return a number of microseconds based on a user provided scaling
+   * factor.
    */
 
-  return USEC2TICK(CONFIG_STM32F7_I2C_DYNTIMEO_USECPERBYTE * bytecount +
-                   CONFIG_USEC_PER_TICK / 2 - 1);
+  return USEC2TICK(CONFIG_STM32F7_I2C_DYNTIMEO_USECPERBYTE * bytecount);
 }
 #endif
 

--- a/include/nuttx/clock.h
+++ b/include/nuttx/clock.h
@@ -145,41 +145,49 @@
  * preferred for that reason (at the risk of overflow)
  */
 
-#define TICK_PER_HOUR         (USEC_PER_HOUR / USEC_PER_TICK)            /* Truncates! */
-#define TICK_PER_MIN          (USEC_PER_MIN  / USEC_PER_TICK)            /* Truncates! */
-#define TICK_PER_SEC          (USEC_PER_SEC  / USEC_PER_TICK)            /* Truncates! */
-#define TICK_PER_MSEC         (USEC_PER_MSEC / USEC_PER_TICK)            /* Truncates! */
-#define TICK_PER_DSEC         (USEC_PER_DSEC / USEC_PER_TICK)            /* Truncates! */
-#define TICK_PER_HSEC         (USEC_PER_HSEC / USEC_PER_TICK)            /* Truncates! */
+/* TICK_PER_* truncates! */
 
-#define MSEC_PER_TICK         (USEC_PER_TICK / USEC_PER_MSEC)            /* Truncates! */
-#define NSEC_PER_TICK         (USEC_PER_TICK * NSEC_PER_USEC)            /* Exact */
+#define TICK_PER_HOUR         (USEC_PER_HOUR / USEC_PER_TICK)
+#define TICK_PER_MIN          (USEC_PER_MIN  / USEC_PER_TICK)
+#define TICK_PER_SEC          (USEC_PER_SEC  / USEC_PER_TICK)
+#define TICK_PER_MSEC         (USEC_PER_MSEC / USEC_PER_TICK)
+#define TICK_PER_DSEC         (USEC_PER_DSEC / USEC_PER_TICK)
+#define TICK_PER_HSEC         (USEC_PER_HSEC / USEC_PER_TICK)
 
-#define NSEC2TICK(nsec)       (((nsec)+(NSEC_PER_TICK/2))/NSEC_PER_TICK) /* Rounds */
-#define USEC2TICK(usec)       (((usec)+(USEC_PER_TICK/2))/USEC_PER_TICK) /* Rounds */
+/* MSEC_PER_TICK truncates! */
 
-#if (MSEC_PER_TICK * USEC_PER_MSEC) == USEC_PER_TICK
-#  define MSEC2TICK(msec)     (((msec)+(MSEC_PER_TICK/2))/MSEC_PER_TICK) /* Rounds */
-#else
-#  define MSEC2TICK(msec)     USEC2TICK((msec) * USEC_PER_MSEC)          /* Rounds */
-#endif
+#define MSEC_PER_TICK         (USEC_PER_TICK / USEC_PER_MSEC)
+#define NSEC_PER_TICK         (USEC_PER_TICK * NSEC_PER_USEC)
 
-#define DSEC2TICK(dsec)       MSEC2TICK((dsec) * MSEC_PER_DSEC)          /* Rounds */
-#define HSEC2TICK(dsec)       MSEC2TICK((dsec) * MSEC_PER_HSEC)          /* Rounds */
-#define SEC2TICK(sec)         MSEC2TICK((sec)  * MSEC_PER_SEC)           /* Rounds */
+/* ?SEC2TIC rounds up */
 
-#define TICK2NSEC(tick)       ((tick) * NSEC_PER_TICK)                   /* Exact */
-#define TICK2USEC(tick)       ((tick) * USEC_PER_TICK)                   /* Exact */
+#define NSEC2TICK(nsec)       (((nsec) + (NSEC_PER_TICK - 1)) / NSEC_PER_TICK)
+#define USEC2TICK(usec)       (((usec) + (USEC_PER_TICK - 1)) / USEC_PER_TICK)
 
 #if (MSEC_PER_TICK * USEC_PER_MSEC) == USEC_PER_TICK
-#  define TICK2MSEC(tick)     ((tick)*MSEC_PER_TICK)                     /* Exact */
+#  define MSEC2TICK(msec)     (((msec) + (MSEC_PER_TICK - 1)) / MSEC_PER_TICK)
 #else
-#  define TICK2MSEC(tick)     (((tick)*USEC_PER_TICK)/USEC_PER_MSEC)     /* Rounds */
+#  define MSEC2TICK(msec)     USEC2TICK((msec) * USEC_PER_MSEC)
 #endif
 
-#define TICK2DSEC(tick)       (((tick)+(TICK_PER_DSEC/2))/TICK_PER_DSEC) /* Rounds */
-#define TICK2HSEC(tick)       (((tick)+(TICK_PER_HSEC/2))/TICK_PER_HSEC) /* Rounds */
-#define TICK2SEC(tick)        (((tick)+(TICK_PER_SEC/2))/TICK_PER_SEC)   /* Rounds */
+#define DSEC2TICK(dsec)       MSEC2TICK((dsec) * MSEC_PER_DSEC)
+#define HSEC2TICK(dsec)       MSEC2TICK((dsec) * MSEC_PER_HSEC)
+#define SEC2TICK(sec)         MSEC2TICK((sec)  * MSEC_PER_SEC)
+
+#define TICK2NSEC(tick)       ((tick) * NSEC_PER_TICK)
+#define TICK2USEC(tick)       ((tick) * USEC_PER_TICK)
+
+#if (MSEC_PER_TICK * USEC_PER_MSEC) == USEC_PER_TICK
+#  define TICK2MSEC(tick)     ((tick) * MSEC_PER_TICK)
+#else
+#  define TICK2MSEC(tick)     (((tick) * USEC_PER_TICK) / USEC_PER_MSEC)
+#endif
+
+/* TIC2?SEC rounds to nearest */
+
+#define TICK2DSEC(tick)       (((tick) + (TICK_PER_DSEC / 2)) / TICK_PER_DSEC)
+#define TICK2HSEC(tick)       (((tick) + (TICK_PER_HSEC / 2)) / TICK_PER_HSEC)
+#define TICK2SEC(tick)        (((tick) + (TICK_PER_SEC / 2)) / TICK_PER_SEC)
 
 #if defined(CONFIG_DEBUG_FEATURES) && defined(CONFIG_SYSTEM_TIME64) && \
     !defined(CONFIG_SCHED_TICKLESS)


### PR DESCRIPTION
## Summary

This change is discussed in https://github.com/apache/nuttx/issues/8346 ; in short, this proposes changing USEC2TICK, MSEC2TICK and SEC2TICK to round up instead of round to nearest. This is the same practice that is used in many other OSs (like linux msecs_to_jiffies ; when converting a value to ticks the integer result is always greater or equivalent of the exact result. 

The rationale behind this change is that typical use is a timeout or schedule wq event. That is, to go to sleep for *at least* N msec.

## Impact

This fixes regression in i2c drivers, networking and iob caused by https://github.com/apache/nuttx/commit/1fb8c13e5e80ee4cd5758e76821378162451c2fa

## Testing

It has been tested that the change fixes the found problems on stm32f7 and mpfs targets with 10ms systick. However, this affects many drivers in many platforms, I am not able to test them all.


