### PR TITLE
drivers/mmcsd: Fix kconfig error regarding MMCSD_IOCSUPPORT

### DIFF
--- a/drivers/mmcsd/Kconfig
+++ b/drivers/mmcsd/Kconfig
@@ -28,7 +28,7 @@ menuconfig MMCSD
 if MMCSD
 
 config MMCSD_IOCSUPPORT
-	int "Enable MMC/SD ioctl support"
+	bool "Enable MMC/SD ioctl support"
 	default y
 	---help---
 		Disable it to save some code size if required.


### PR DESCRIPTION
## Summary
Something I noticed in CI:
drivers/mmcsd/Kconfig:32:warning: 'MMCSD_IOCSUPPORT': number is invalid
## Impact
Fix CI
## Testing
CI pass without the error message