### PR TITLE
tools/makefile: silent all compile output

### DIFF
--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -285,8 +285,9 @@ $(COBJS) $(LINKOBJS): %$(OBJEXT): %.c
 	$(call COMPILE, $<, $@)
 
 $(HOSTOBJS) $(HEADOBJ): %$(OBJEXT): %.c
-	$(Q) echo "CC:  $<"
+	$(Q) $(ECHO_BEGIN)"CC:  $<"
 	$(Q) "$(CC)" -c $(HOSTCFLAGS) $< -o $@
+	$(Q) $(ECHO_END)
 
 # The architecture-specific library
 

--- a/tools/Unix.mk
+++ b/tools/Unix.mk
@@ -20,6 +20,10 @@
 
 export TOPDIR := ${shell echo $(CURDIR) | sed -e 's/ /\\ /g'}
 
+ifeq ($(V),)
+  MAKE := $(MAKE) -s --no-print-directory
+endif
+
 # Build any necessary tools needed early in the build.
 # incdir - Is needed immediately by all Make.defs file.
 
@@ -664,7 +668,7 @@ savedefconfig: apps_preconfig
 # that the archiver is 'ar'
 
 export: $(NUTTXLIBS)
-	$(Q) MAKE=${MAKE} $(MKEXPORT) $(MKEXPORT_ARGS) -l "$(EXPORTLIBS)"
+	$(Q) MAKE="${MAKE}" $(MKEXPORT) $(MKEXPORT_ARGS) -l "$(EXPORTLIBS)"
 
 # General housekeeping targets:  dependencies, cleaning, etc.
 #

--- a/tools/mkexport.sh
+++ b/tools/mkexport.sh
@@ -418,7 +418,7 @@ cd "${TOPDIR}" || \
   { echo "MK: 'cd ${TOPDIR}' failed"; exit 1; }
 
 if [ -e "${APPDIR}/Makefile" ]; then
-  "${MAKE}" -C "${APPDIR}" EXPORTDIR="$(cd "${EXPORTSUBDIR}" ; pwd )" TOPDIR="${TOPDIR}" export || \
+  ${MAKE} -C "${APPDIR}" EXPORTDIR="$(cd "${EXPORTSUBDIR}" ; pwd )" TOPDIR="${TOPDIR}" export || \
       { echo "MK: call make export for APPDIR not supported"; }
 fi
 


### PR DESCRIPTION
tools/makefile: silent all compile output

In order to make compilation warnings and errors easier to be found out,
this commit will disable the printing of the compilation process as much
as possible, and also if you want to restore the log information of the
compilation process, please enable verbose build on command line:

`$ make V=0`
OR
`$ make V=1`

```
| V=0:   Exit silent mode
| V=1,2: Enable echo of commands
| V=2:   Enable bug/verbose options in tools and scripts
```

Signed-off-by: chao an <anchao@xiaomi.com>



## Impact

N/A

## Testing

ci check