### PR TITLE
checkpatch: Added encoding check with cvt2utf

### DIFF
--- a/tools/checkpatch.sh
+++ b/tools/checkpatch.sh
@@ -23,6 +23,7 @@ check=check_patch
 fail=0
 range=0
 spell=0
+encoding=0
 message=0
 
 usage() {
@@ -30,7 +31,8 @@ usage() {
   echo ""
   echo "Options:"
   echo "-h"
-  echo "-c spell check with codespell(install with: pip install codespell)"
+  echo "-c spell check with codespell (install with: pip install codespell)"
+  echo "-u encoding check with cvt2utf (install with: pip install cvt2utf)"
   echo "-r range check only (coupled with -p or -g)"
   echo "-p <patch file names> (default)"
   echo "-m Change-Id check in commit message (coupled with -g)"
@@ -72,6 +74,15 @@ check_file() {
 
     if [ $spell != 0 ]; then
       if ! codespell -q 7 ${@: -1}; then
+        fail=1
+      fi
+    fi
+
+    if [ $encoding != 0 ]; then
+      md5="$(md5sum $@)"
+      cvt2utf convert --nobak "$@" &> /dev/null
+      if [ "$md5" != "$(md5sum $@)" ]; then
+        echo "$@: error: Non-UTF8 characters detected!"
         fail=1
       fi
     fi
@@ -146,6 +157,9 @@ while [ ! -z "$1" ]; do
     ;;
   -c )
     spell=1
+    ;;
+  -u )
+    encoding=1
     ;;
   -f )
     check=check_file

--- a/tools/ci/cibuild.sh
+++ b/tools/ci/cibuild.sh
@@ -283,6 +283,7 @@ function python-tools {
   # cache restoration.
   pip3 install --force-reinstall \
     CodeChecker \
+    cvt2utf \
     cxxfilt \
     esptool==3.3.1 \
     imgtool==1.9.0 \

--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -279,6 +279,8 @@ ENV PIP_NO_CACHE_DIR=0
 RUN pip3 install setuptools wheel
 # Install CodeChecker and use it to statically analyze the code.
 RUN pip3 install CodeChecker
+# Install cvt2utf to check for non-UTF characters.
+RUN pip3 install cvt2utf
 # Install pytest
 RUN pip3 install cxxfilt
 RUN pip3 install esptool


### PR DESCRIPTION
## Summary

Added check for non-UTF characters in `checkpatch.sh`.

The check is accomplished by using [cvt2utf](https://github.com/x1angli/cvt2utf).  
All cached files are converted and then checked for differences.

If the file is modified, then it contained invalid characters that `cvt2utf` had to change.

*This change was recommended [here](https://github.com/apache/nuttx/pull/8340#issuecomment-1408364223).*

## Impact

N/A

## Testing

Tested with the files that #8340 fixes, and indeed it generates an error for these files.

*(In fact the exact same tool was used to indicate the original problem that lead to #8340.)*