### PR TITLE
net/devif: correct the judgment condition in devif_send()

### DIFF
--- a/net/devif/devif_send.c
+++ b/net/devif/devif_send.c
@@ -93,7 +93,7 @@ void devif_send(FAR struct net_driver_s *dev, FAR const void *buf,
 
   /* Append the send buffer after device buffer */
 
-  if (len > iob_navail(false) * CONFIG_IOB_BUFSIZE &&
+  if (len > iob_navail(false) * CONFIG_IOB_BUFSIZE ||
       netdev_iob_prepare(dev, false, 0) != OK)
     {
       ret = -ENOMEM;


### PR DESCRIPTION
## Summary

net/devif: correct the judgment condition in devif_send()

Regression by:

```
| commit 7fce145b3043e7ee13c72286674d51e9888935c3
| Author: chao an <anchao@xiaomi.com>
| Date:   Mon Jan 30 21:36:39 2023 +0800
|
|     net/devif: check the net device before use
|
|     Signed-off-by: chao an <anchao@xiaomi.com>
```

Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

lm3s6965-ek/discover