### PR TITLE
Makefile: fix redundant delimiters when using make V=1

### DIFF
--- a/libs/libc/Makefile
+++ b/libs/libc/Makefile
@@ -127,18 +127,18 @@ all: $(BIN)
 .PHONY: clean distclean
 
 $(AOBJS): $(BINDIR)$(DELIM)$(DELIM)%$(OBJEXT): %.S
-	$(call ASSEMBLE, $<, $@)
+	$(call ASSEMBLE, $(realpath $<), $@)
 
 # REVISIT: Backslash causes problems in $(COBJS) target
 
 $(COBJS): $(BINDIR)$(DELIM)$(DELIM)%$(OBJEXT): %.c
-	$(call COMPILE, $<, $@)
+	$(call COMPILE, $(realpath $<), $@)
 
 # C library for the flat build and
 # the user phase of the two-pass kernel build
 
 $(BIN): $(OBJS)
-	$(call ARCHIVE, $@, $(OBJS))
+	$(call ARCHIVE, $@, $(realpath $(OBJS)))
 ifeq ($(CONFIG_LIBC_ZONEINFO_ROMFS),y)
 	$(Q) $(MAKE) -C zoneinfo all BIN=$(BIN)
 endif

--- a/mm/Makefile
+++ b/mm/Makefile
@@ -52,18 +52,18 @@ all: $(BIN)
 .PHONY: context depend clean distclean
 
 $(AOBJS): $(BINDIR)$(DELIM)$(DELIM)%$(OBJEXT): %.S
-	$(call ASSEMBLE, $<, $@)
+	$(call ASSEMBLE, $(realpath $<), $@)
 
 # REVISIT: Backslash causes problems in $(COBJS) target
 
 $(COBJS): $(BINDIR)$(DELIM)$(DELIM)%$(OBJEXT): %.c
-	$(call COMPILE, $<, $@)
+	$(call COMPILE, $(realpath $<), $@)
 
 # Memory manager for the flat build and
 # the user phase of the two-pass kernel build
 
 $(BIN):	$(OBJS)
-	$(call ARCHIVE, $@, $(OBJS))
+	$(call ARCHIVE, $@, $(realpath $(OBJS)))
 
 # Memory manager for the kernel phase of the two-pass kernel build
 


### PR DESCRIPTION
## Summary
When using make V=1, the obj file will print two separators in the libc and mm directories
Use the [ realpath function](https://www.gnu.org/software/make/manual/html_node/File-Name-Functions.html#:~:text=File%20Names.-,%24(realpath%20names%E2%80%A6),-For%20each%20file) to return a canonical relative path to remove redundant separators

```
arm-none-eabi-ar rcs  libc.a    bin//lib_assert.o  bin//lib_builtin_getname.o
```

## Impact
@zouboan  Please help to verify whether it can run normally in the windows environment

## Testing

ubuntu sim/nsh
