### PR TITLE
libc/termios: Fix comment in cfmakeraw docstring.

### DIFF
--- a/libs/libc/termios/lib_cfmakeraw.c
+++ b/libs/libc/termios/lib_cfmakeraw.c
@@ -30,7 +30,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: cfgetspeed
+ * Name: cfmakeraw
  *
  * Description:
  *   The cfmakeraw() function is a non-POSIX function that sets the terminal


### PR DESCRIPTION
## Summary

Fix a copy-paste error in a comment.

## Impact

Documentation correctness. No functional change.

## Testing

nxstyle
