### PR TITLE
Kconfig: Improve help text related to *_SERIALBRK_BSDCOMPAT

### DIFF
--- a/arch/arm/src/gd32f4/Kconfig
+++ b/arch/arm/src/gd32f4/Kconfig
@@ -1985,9 +1985,10 @@ config GD32F4_SERIALBRK_BSDCOMPAT
 	---help---
 		Enable using GPIO on the TX pin to send a BSD compatible break:
 		TIOCSBRK will start the break and TIOCCBRK will end the break.
-		The current GD32F4 USARTS have no way to leave the break (TX=LOW)
-		on because the software starts the break and then the hadware automatically
-		clears the break. This makes it is difficult to sent a long break.
+		The current GD32F4 USARTS have no way to leave the break on
+		(TX=LOW) because software starts the break and then the hardware
+		automatically clears the break. This makes it difficult to send
+		a long break.
 
 config GD32F4_USART_SINGLEWIRE
 	bool "Single Wire Support"

--- a/arch/arm/src/stm32/Kconfig
+++ b/arch/arm/src/stm32/Kconfig
@@ -10298,9 +10298,10 @@ config STM32_SERIALBRK_BSDCOMPAT
 	---help---
 		Enable using GPIO on the TX pin to send a BSD compatible break:
 		TIOCSBRK will start the break and TIOCCBRK will end the break.
-		The current STM32 U[S]ARTS have no way to leave the break (TX=LOW)
-		on because the SW starts the break and then the HW automatically clears
-		the break. This makes it is difficult to sent a long break.
+		The current STM32 U[S]ARTS have no way to leave the break on
+		(TX=LOW) because software starts the break and then the hardware
+		automatically clears the break. This makes it difficult to send
+		a long break.
 
 config STM32_USART_SINGLEWIRE
 	bool "Single Wire Support"

--- a/arch/arm/src/stm32f7/Kconfig
+++ b/arch/arm/src/stm32f7/Kconfig
@@ -2085,9 +2085,10 @@ config STM32F7_SERIALBRK_BSDCOMPAT
 	---help---
 		Enable using GPIO on the TX pin to send a BSD compatible break:
 		TIOCSBRK will start the break and TIOCCBRK will end the break.
-		The current STM32 U[S]ARTS have no way to leave the break (TX=LOW)
-		on because the SW starts the break and then the HW automatically clears
-		the break. This makes it is difficult to sent a long break.
+		The current STM32F7 U[S]ARTS have no way to leave the break on
+		(TX=LOW) because software starts the break and then the hardware
+		automatically clears the break. This makes it difficult to send
+		a long break.
 
 config STM32F7_USART_SINGLEWIRE
 	bool "Single Wire Support"

--- a/arch/arm/src/stm32h7/Kconfig
+++ b/arch/arm/src/stm32h7/Kconfig
@@ -1545,9 +1545,10 @@ config STM32H7_SERIALBRK_BSDCOMPAT
 	---help---
 		Enable using GPIO on the TX pin to send a BSD compatible break:
 		TIOCSBRK will start the break and TIOCCBRK will end the break.
-		The current STM32 U[S]ARTS have no way to leave the break (TX=LOW)
-		on because the SW starts the break and then the HW automatically clears
-		the break. This makes it is difficult to sent a long break.
+		The current STM32H7 U[S]ARTS have no way to leave the break on
+		(TX=LOW) because software starts the break and then the hardware
+		automatically clears the break. This makes it difficult to send
+		a long break.
 
 config STM32H7_USART_SINGLEWIRE
 	bool "Single Wire Support"

--- a/arch/arm/src/stm32l4/Kconfig
+++ b/arch/arm/src/stm32l4/Kconfig
@@ -5953,9 +5953,10 @@ config STM32L4_SERIALBRK_BSDCOMPAT
 	---help---
 		Enable using GPIO on the TX pin to send a BSD compatible break:
 		TIOCSBRK will start the break and TIOCCBRK will end the break.
-		The current STM32 U[S]ARTS have no way to leave the break (TX=LOW)
-		on because the SW starts the break and then the HW automatically clears
-		the break. This makes it is difficult to sent a long break.
+		The current STM32L4 U[S]ARTS have no way to leave the break on
+		(TX=LOW) because software starts the break and then the hardware
+		automatically clears the break. This makes it difficult to send
+		a long break.
 
 config STM32L4_USART_SINGLEWIRE
 	bool "Single Wire Support"

--- a/arch/arm/src/stm32l5/Kconfig
+++ b/arch/arm/src/stm32l5/Kconfig
@@ -2863,9 +2863,10 @@ config STM32L5_SERIALBRK_BSDCOMPAT
 	---help---
 		Enable using GPIO on the TX pin to send a BSD compatible break:
 		TIOCSBRK will start the break and TIOCCBRK will end the break.
-		The current STM32 U[S]ARTS have no way to leave the break (TX=LOW)
-		on because the SW starts the break and then the HW automatically clears
-		the break. This makes it is difficult to sent a long break.
+		The current STM32L5 U[S]ARTS have no way to leave the break on
+		(TX=LOW) because software starts the break and then the hardware
+		automatically clears the break. This makes it difficult to send
+		a long break.
 
 config STM32L5_USART_SINGLEWIRE
 	bool "Single Wire Support"

--- a/arch/arm/src/stm32u5/Kconfig
+++ b/arch/arm/src/stm32u5/Kconfig
@@ -3109,9 +3109,10 @@ config STM32U5_SERIALBRK_BSDCOMPAT
 	---help---
 		Enable using GPIO on the TX pin to send a BSD compatible break:
 		TIOCSBRK will start the break and TIOCCBRK will end the break.
-		The current STM32 U[S]ARTS have no way to leave the break (TX=LOW)
-		on because the SW starts the break and then the HW automatically clears
-		the break. This makes it is difficult to sent a long break.
+		The current STM32U5 U[S]ARTS have no way to leave the break on
+		(TX=LOW) because software starts the break and then the hardware
+		automatically clears the break. This makes it difficult to send
+		a long break.
 
 config STM32U5_USART_SINGLEWIRE
 	bool "Single Wire Support"

--- a/arch/arm/src/stm32wb/Kconfig
+++ b/arch/arm/src/stm32wb/Kconfig
@@ -891,9 +891,10 @@ config STM32WB_SERIALBRK_BSDCOMPAT
 	---help---
 		Enable using GPIO on the TX pin to send a BSD compatible break:
 		TIOCSBRK will start the break and TIOCCBRK will end the break.
-		The current STM32WB U[S]ARTS have no way to leave the break (TX=LOW)
-		on because the SW starts the break and then the HW automatically clears
-		the break. This makes it is difficult to sent a long break.
+		The current STM32WB U[S]ARTS have no way to leave the break on
+		(TX=LOW) because software starts the break and then the hardware
+		automatically clears the break. This makes it difficult to send
+		a long break.
 
 config STM32WB_USART_SINGLEWIRE
 	bool "Single Wire Support"


### PR DESCRIPTION
## Summary

In Kconfig, improve the help text of the GD32F4_SERIALBRK_BSDCOMPAT, STM32_SERIALBRK_BSDCOMPAT, STM32F7_SERIALBRK_BSDCOMPAT, STM32H7_SERIALBRK_BSDCOMPAT, STM32L4_SERIALBRK_BSDCOMPAT, STM32L5_SERIALBRK_BSDCOMPAT, STM32U5_SERIALBRK_BSDCOMPAT, and STM32WB_SERIALBRK_BSDCOMPAT configs.

Specifically, this fixes a few typos, improves wording, and re-wraps the text so it fits in the Kconfig window at 80 character wide terminals.

## Impact

Improved documentation.

## Testing

N/A