### PR TITLE
note_driver: fix build error

### DIFF
--- a/drivers/note/note_driver.c
+++ b/drivers/note/note_driver.c
@@ -275,7 +275,7 @@ static inline int note_isenabled(void)
 #ifdef CONFIG_SMP
   /* Ignore notes that are not in the set of monitored CPUs */
 
-  if (CPU_ISSET(&g_note_filter.mode.cpuset, this_cpu()) == 0)
+  if (CPU_ISSET(this_cpu(), &g_note_filter.mode.cpuset) == 0)
     {
       /* Not in the set of monitored CPUs.  Do not log the note. */
 


### PR DESCRIPTION
## Summary

The `CPU_ISSET` parameter is reversed.

```bash
note/note_driver.c: In function 'note_isenabled':
note/note_driver.c:278:7: error: invalid type argument of unary '*' (have 'int')
  278 |   if (CPU_ISSET(&g_note_filter.mode.cpuset, this_cpu()) == 0)
      |       ^~~~~~~~~
note/note_driver.c:278:7: error: invalid operands to binary << (have 'int' and 'volatile cpu_set_t *' {aka 'volatile unsigned char *'})
  278 |   if (CPU_ISSET(&g_note_filter.mode.cpuset, this_cpu()) == 0)
      |       ^~~~~~~~~
      |                 |
      |                 volatile cpu_set_t * {aka volatile unsigned char *}
```

## Impact

## Testing

