### PR TITLE
tools: ARCHIVE uses the full path

### DIFF
--- a/libs/libc/Makefile
+++ b/libs/libc/Makefile
@@ -127,18 +127,18 @@ all: $(BIN)
 .PHONY: clean distclean
 
 $(AOBJS): $(BINDIR)$(DELIM)$(DELIM)%$(OBJEXT): %.S
-	$(call ASSEMBLE, $(realpath $<), $@)
+	$(call ASSEMBLE, $<, $@)
 
 # REVISIT: Backslash causes problems in $(COBJS) target
 
 $(COBJS): $(BINDIR)$(DELIM)$(DELIM)%$(OBJEXT): %.c
-	$(call COMPILE, $(realpath $<), $@)
+	$(call COMPILE, $<, $@)
 
 # C library for the flat build and
 # the user phase of the two-pass kernel build
 
 $(BIN): $(OBJS)
-	$(call ARCHIVE, $@, $(realpath $(OBJS)))
+	$(call ARCHIVE, $@, $(OBJS))
 ifeq ($(CONFIG_LIBC_ZONEINFO_ROMFS),y)
 	$(Q) $(MAKE) -C zoneinfo all BIN=$(BIN)
 endif

--- a/mm/Makefile
+++ b/mm/Makefile
@@ -52,18 +52,18 @@ all: $(BIN)
 .PHONY: context depend clean distclean
 
 $(AOBJS): $(BINDIR)$(DELIM)$(DELIM)%$(OBJEXT): %.S
-	$(call ASSEMBLE, $(realpath $<), $@)
+	$(call ASSEMBLE, $<, $@)
 
 # REVISIT: Backslash causes problems in $(COBJS) target
 
 $(COBJS): $(BINDIR)$(DELIM)$(DELIM)%$(OBJEXT): %.c
-	$(call COMPILE, $(realpath $<), $@)
+	$(call COMPILE, $<, $@)
 
 # Memory manager for the flat build and
 # the user phase of the two-pass kernel build
 
 $(BIN):	$(OBJS)
-	$(call ARCHIVE, $@, $(realpath $(OBJS)))
+	$(call ARCHIVE, $@, $(OBJS))
 
 # Memory manager for the kernel phase of the two-pass kernel build
 

--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -372,7 +372,7 @@ endef
 
 define INSTALL_LIB
 	@echo "IN: $1 -> $2"
-	$(Q) install -m 0644 $1 $2
+	$(Q) install -m 0644 $(abspath $1) $(abspath $2)
 endef
 
 # ARCHIVE_ADD - Add a list of files to an archive
@@ -393,7 +393,7 @@ endef
 
 define ARCHIVE_ADD
 	@echo "AR (add): ${shell basename $(1)} $(2)"
-	$(Q) $(AR) $1 $(2)
+	$(Q) $(AR) $(abspath $1) $(abspath $2)
 endef
 
 # ARCHIVE - Same as above, but ensure the archive is
@@ -401,7 +401,7 @@ endef
 
 define ARCHIVE
 	$(Q) $(RM) $1
-	$(Q) $(AR) $1 $(2)
+	$(Q) $(AR) $(abspath $1)  $(abspath $2)
 endef
 
 # PRELINK - Prelink a list of files


### PR DESCRIPTION
## Summary
https://github.com/apache/nuttx/pull/8384
There is a better solution to this problem, it would be more generic to have ARCHIVE use the full path

## Impact

## Testing

