### PR TITLE
sched/waitpid: rename nx_waitpid() to nxsched_waitpid() 

### DIFF
--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -1359,11 +1359,53 @@ int nxsched_set_affinity(pid_t pid, size_t cpusetsize,
 int nxsched_get_stackinfo(pid_t pid, FAR struct stackinfo_s *stackinfo);
 
 /****************************************************************************
- * Name: nx_wait/nx_waitid/nx_waitpid
+ * Name: nxsched_waitpid
+ *
+ * Description:
+ *   This functions will obtain status information pertaining to one
+ *   of the caller's child processes. This function will suspend
+ *   execution of the calling thread until status information for one of the
+ *   terminated child processes of the calling process is available, or until
+ *   delivery of a signal whose action is either to execute a signal-catching
+ *   function or to terminate the process. If more than one thread is
+ *   suspended in nxsched_waitpid() awaiting termination of the same process,
+ *   exactly one thread will return the process status at the time of the
+ *   target process termination. If status information is available prior to
+ *   the call to nxsched_waitpid(), return will be immediate.
+ *
+ * Input Parameters:
+ *   pid - The task ID of the thread to waid for
+ *   stat_loc - The location to return the exit status
+ *   options - ignored
+ *
+ * Returned Value:
+ *   If nxsched_waitpid() returns because the status of a child process is
+ *   available, it will return a value equal to the process ID of the child
+ *   process for which status is reported.
+ *
+ *   If nxsched_waitpid() returns due to the delivery of a signal to the
+ *   calling process, -1 will be returned and errno set to EINTR.
+ *
+ *   If nxsched_waitpid() was invoked with WNOHANG set in options, it has
+ *   at least one child process specified by pid for which status is not
+ *   available, and status is not available for any process specified by
+ *   pid, 0 is returned.
+ *
+ *   Otherwise, (pid_t)-1 will be returned, and errno set to indicate the
+ *   error:
+ *
+ *   ECHILD - The process specified by pid does not exist or is not a child
+ *            of the calling process, or the process group specified by pid
+ *            does not exist does not have any member process that is a child
+ *            of the calling process.
+ *   EINTR - The function was interrupted by a signal. The value of the
+ *           location pointed to by stat_loc is undefined.
+ *   EINVAL - The options argument is not valid.
+ *
  ****************************************************************************/
 
 #ifdef CONFIG_SCHED_WAITPID
-pid_t nx_waitpid(pid_t pid, FAR int *stat_loc, int options);
+pid_t nxsched_waitpid(pid_t pid, FAR int *stat_loc, int options);
 #endif
 
 #undef EXTERN

--- a/sched/sched/sched_waitpid.c
+++ b/sched/sched/sched_waitpid.c
@@ -44,11 +44,53 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: nx_waitpid
+ * Name: nxsched_waitpid
+ *
+ * Description:
+ *   This functions will obtain status information pertaining to one
+ *   of the caller's child processes. This function will suspend
+ *   execution of the calling thread until status information for one of the
+ *   terminated child processes of the calling process is available, or until
+ *   delivery of a signal whose action is either to execute a signal-catching
+ *   function or to terminate the process. If more than one thread is
+ *   suspended in nxsched_waitpid() awaiting termination of the same process,
+ *   exactly one thread will return the process status at the time of the
+ *   target process termination. If status information is available prior to
+ *   the call to nxsched_waitpid(), return will be immediate.
+ *
+ * Input Parameters:
+ *   pid - The task ID of the thread to waid for
+ *   stat_loc - The location to return the exit status
+ *   options - ignored
+ *
+ * Returned Value:
+ *   If nxsched_waitpid() returns because the status of a child process is
+ *   available, it will return a value equal to the process ID of the child
+ *   process for which status is reported.
+ *
+ *   If nxsched_waitpid() returns due to the delivery of a signal to the
+ *   calling process, -1 will be returned and errno set to EINTR.
+ *
+ *   If nxsched_waitpid() was invoked with WNOHANG set in options, it has
+ *   at least one child process specified by pid for which status is not
+ *   available, and status is not available for any process specified by
+ *   pid, 0 is returned.
+ *
+ *   Otherwise, (pid_t)-1 will be returned, and errno set to indicate the
+ *   error:
+ *
+ *   ECHILD - The process specified by pid does not exist or is not a child
+ *            of the calling process, or the process group specified by pid
+ *            does not exist does not have any member process that is a child
+ *            of the calling process.
+ *   EINTR - The function was interrupted by a signal. The value of the
+ *           location pointed to by stat_loc is undefined.
+ *   EINVAL - The options argument is not valid.
+ *
  ****************************************************************************/
 
 #ifndef CONFIG_SCHED_HAVE_PARENT
-pid_t nx_waitpid(pid_t pid, int *stat_loc, int options)
+pid_t nxsched_waitpid(pid_t pid, int *stat_loc, int options)
 {
   FAR struct tcb_s *ctcb;
   FAR struct task_group_s *group;
@@ -179,7 +221,7 @@ errout:
  ****************************************************************************/
 
 #else
-pid_t nx_waitpid(pid_t pid, int *stat_loc, int options)
+pid_t nxsched_waitpid(pid_t pid, int *stat_loc, int options)
 {
   FAR struct tcb_s *rtcb = this_task();
   FAR struct tcb_s *ctcb;
@@ -592,9 +634,9 @@ pid_t waitpid(pid_t pid, int *stat_loc, int options)
 
   enter_cancellation_point();
 
-  /* Let nx_waitpid() do the work. */
+  /* Let nxsched_waitpid() do the work. */
 
-  ret = nx_waitpid(pid, stat_loc, options);
+  ret = nxsched_waitpid(pid, stat_loc, options);
   if (ret < 0)
     {
       set_errno(-ret);

--- a/sched/task/task_posixspawn.c
+++ b/sched/task/task_posixspawn.c
@@ -407,7 +407,7 @@ int posix_spawn(FAR pid_t *pid, FAR const char *path,
    * for use within the OS.
    */
 
-  ret = nx_waitpid((pid_t)proxy, &status, 0);
+  ret = nxsched_waitpid((pid_t)proxy, &status, 0);
   if (ret < 0)
     {
       serr("ERROR: waitpid() failed: %d\n", ret);

--- a/sched/task/task_spawn.c
+++ b/sched/task/task_spawn.c
@@ -425,7 +425,7 @@ int task_spawn(FAR const char *name, main_t entry,
    * for use within the OS.
    */
 
-  ret = nx_waitpid(proxy, &status, 0);
+  ret = nxsched_waitpid(proxy, &status, 0);
   if (ret < 0)
     {
       serr("ERROR: waitpid() failed: %d\n", ret);


### PR DESCRIPTION
## Summary

sched/waitpid: rename nx_waitpid() to nxsched_waitpid()

align with naming style of sched

## Impact

N/A

## Testing

ci-check