### PR TITLE
sched/getpid: replace syscall getpid/tid/ppid() to kernel version 

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_farapi.c
+++ b/arch/arm/src/cxd56xx/cxd56_farapi.c
@@ -192,14 +192,14 @@ void farapi_main(int id, void *arg, struct modulelist_s *mlist)
     {
       /* Save the current cpuset */
 
-      sched_getaffinity(gettid(), sizeof(cpu_set_t), &cpuset0);
+      sched_getaffinity(nxsched_gettid(), sizeof(cpu_set_t), &cpuset0);
 
       /* Assign the current task to cpu0 */
 
       cpu_set_t cpuset1;
       CPU_ZERO(&cpuset1);
       CPU_SET(0, &cpuset1);
-      sched_setaffinity(gettid(), sizeof(cpu_set_t), &cpuset1);
+      sched_setaffinity(nxsched_gettid(), sizeof(cpu_set_t), &cpuset1);
 
       /* NOTE: a workaround to finish rescheduling */
 
@@ -267,7 +267,7 @@ err:
     {
       /* Restore the cpu affinity */
 
-      sched_setaffinity(gettid(), sizeof(cpu_set_t), &cpuset0);
+      sched_setaffinity(nxsched_gettid(), sizeof(cpu_set_t), &cpuset0);
 
       /* NOTE: a workaround to finish rescheduling */
 

--- a/arch/arm/src/cxd56xx/cxd56_gnss.c
+++ b/arch/arm/src/cxd56xx/cxd56_gnss.c
@@ -1577,7 +1577,7 @@ static int cxd56_gnss_set_signal(struct file *filep, unsigned long arg)
     }
 
   sig = NULL;
-  pid = getpid();
+  pid = nxsched_getpid();
   for (i = 0; i < CONFIG_CXD56_GNSS_NSIGNALRECEIVERS; i++)
     {
       checksig = &priv->sigs[i];

--- a/arch/arm/src/cxd56xx/cxd56_icc.c
+++ b/arch/arm/src/cxd56xx/cxd56_icc.c
@@ -519,7 +519,7 @@ int cxd56_iccnotify(int cpuid, int signo, void *sigdata)
       return -ESRCH;
     }
 
-  priv->pid     = getpid();
+  priv->pid     = nxsched_getpid();
   priv->signo   = signo;
   priv->sigdata = sigdata;
 

--- a/arch/arm/src/cxd56xx/cxd56_scu.c
+++ b/arch/arm/src/cxd56xx/cxd56_scu.c
@@ -2244,7 +2244,7 @@ static int seq_seteventnotifier(struct scufifo_s *fifo,
 
   flags = enter_critical_section();
   priv->event[mid].signo = ev->signo;
-  priv->event[mid].pid = getpid();
+  priv->event[mid].pid = nxsched_getpid();
   priv->event[mid].arg = ev->arg;
   priv->event[mid].fifo = fifo;
   leave_critical_section(flags);
@@ -2327,7 +2327,7 @@ static int seq_setwatermark(struct seq_s *seq, int fifoid,
 
   flags = enter_critical_section();
   notify->signo = wm->signo;
-  notify->pid = getpid();
+  notify->pid = nxsched_getpid();
   notify->ts = wm->ts;
   notify->fifo = fifo;
 

--- a/arch/arm/src/cxd56xx/cxd56_usbdev.c
+++ b/arch/arm/src/cxd56xx/cxd56_usbdev.c
@@ -3342,7 +3342,7 @@ int cxd56_usbdev_setsigno(int signo)
   uinfo("signo = %d\n", signo);
 
   priv->signo = signo;
-  priv->pid   = getpid();
+  priv->pid   = nxsched_getpid();
 
   return OK;
 }

--- a/arch/arm/src/lc823450/lc823450_i2s.c
+++ b/arch/arm/src/lc823450/lc823450_i2s.c
@@ -1045,11 +1045,11 @@ struct i2s_dev_s *lc823450_i2sdev_initialize(void)
 
   /* Backup the current affinity */
 
-  nxsched_get_affinity(gettid(), sizeof(cpuset0), &cpuset0);
+  nxsched_get_affinity(nxsched_gettid(), sizeof(cpuset0), &cpuset0);
 
   /* Set the new affinity which assigns to CPU0 */
 
-  nxsched_set_affinity(gettid(), sizeof(cpuset1), &cpuset1);
+  nxsched_set_affinity(nxsched_gettid(), sizeof(cpuset1), &cpuset1);
   nxsig_usleep(10 * 1000);
 #endif
 
@@ -1062,7 +1062,7 @@ struct i2s_dev_s *lc823450_i2sdev_initialize(void)
 #ifdef CONFIG_SMP
   /* Restore the original affinity */
 
-  nxsched_set_affinity(gettid(), sizeof(cpuset0), &cpuset0);
+  nxsched_set_affinity(nxsched_gettid(), sizeof(cpuset0), &cpuset0);
   nxsig_usleep(10 * 1000);
 #endif
 

--- a/arch/risc-v/src/bl602/bl602_os_hal.c
+++ b/arch/risc-v/src/bl602/bl602_os_hal.c
@@ -359,7 +359,7 @@ void bl_os_task_delete(void *task_handle)
 
 void *bl_os_task_get_current_task(void)
 {
-  pid_t pid = getpid();
+  pid_t pid = nxsched_getpid();
 
   return (void *)((uintptr_t)pid);
 }

--- a/arch/risc-v/src/esp32c3/esp32c3_libc_stubs.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_libc_stubs.c
@@ -69,7 +69,7 @@ int _fstat_r(struct _reent *r, int fd, struct stat *statbuf)
 
 int _getpid_r(struct _reent *r)
 {
-  return getpid();
+  return nxsched_getpid();
 }
 
 int _kill_r(struct _reent *r, int pid, int sig)

--- a/arch/risc-v/src/esp32c3/esp32c3_wifi_adapter.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_wifi_adapter.c
@@ -2098,7 +2098,7 @@ static int32_t esp_task_ms_to_tick(uint32_t ms)
 
 static void *esp_task_get_current_task(void)
 {
-  pid_t pid = getpid();
+  pid_t pid = nxsched_getpid();
 
   return (void *)((uintptr_t)pid);
 }
@@ -4964,7 +4964,7 @@ int esp_wifi_notify_subscribe(pid_t pid, struct sigevent *event)
             {
               if (pid == 0)
                 {
-                  pid = getpid();
+                  pid = nxsched_getpid();
                   wlinfo("Actual PID=%d\n", pid);
                 }
 

--- a/arch/sim/src/sim/sim_heap.c
+++ b/arch/sim/src/sim/sim_heap.c
@@ -217,10 +217,10 @@ void mm_free(struct mm_heap_s *heap, void *mem)
   else
 #endif
 
-  if (gettid() < 0)
+  if (nxsched_gettid() < 0)
     {
-      /* gettid() return -ESRCH, means we are in situations
-       * during context switching(See gettid's comment).
+      /* nxsched_gettid() return -ESRCH, means we are in situations
+       * during context switching(See nxsched_gettid's comment).
        * Then add to the delay list.
        */
 

--- a/arch/xtensa/src/esp32/esp32_wifi_adapter.c
+++ b/arch/xtensa/src/esp32/esp32_wifi_adapter.c
@@ -2028,7 +2028,7 @@ static int32_t esp_task_ms_to_tick(uint32_t ms)
 
 static void *esp_task_get_current_task(void)
 {
-  pid_t pid = getpid();
+  pid_t pid = nxsched_getpid();
 
   return (void *)((uintptr_t)pid);
 }
@@ -4683,7 +4683,7 @@ int esp_wifi_notify_subscribe(pid_t pid, struct sigevent *event)
             {
               if (pid == 0)
                 {
-                  pid = getpid();
+                  pid = nxsched_getpid();
                   wlinfo("Actual PID=%d\n", pid);
                 }
 

--- a/drivers/input/ajoystick.c
+++ b/drivers/input/ajoystick.c
@@ -557,7 +557,7 @@ static int ajoy_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
             opriv->ao_notify.an_press   = notify->an_press;
             opriv->ao_notify.an_release = notify->an_release;
             opriv->ao_notify.an_event   = notify->an_event;
-            opriv->ao_pid               = getpid();
+            opriv->ao_pid               = nxsched_getpid();
 
             /* Enable/disable interrupt handling */
 

--- a/drivers/input/button_upper.c
+++ b/drivers/input/button_upper.c
@@ -607,7 +607,7 @@ static int btn_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
             opriv->bo_notify.bn_press   = notify->bn_press;
             opriv->bo_notify.bn_release = notify->bn_release;
             opriv->bo_notify.bn_event   = notify->bn_event;
-            opriv->bo_pid               = getpid();
+            opriv->bo_pid               = nxsched_getpid();
 
             /* Enable/disable interrupt handling */
 

--- a/drivers/input/djoystick.c
+++ b/drivers/input/djoystick.c
@@ -553,7 +553,7 @@ static int djoy_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
             opriv->do_notify.dn_press   = notify->dn_press;
             opriv->do_notify.dn_release = notify->dn_release;
             opriv->do_notify.dn_event   = notify->dn_event;
-            opriv->do_pid               = getpid();
+            opriv->do_pid               = nxsched_getpid();
 
             /* Enable/disable interrupt handling */
 

--- a/drivers/ioexpander/gpio.c
+++ b/drivers/ioexpander/gpio.c
@@ -350,7 +350,7 @@ static int gpio_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
       case GPIOC_REGISTER:
         if (arg && dev->gp_pintype >= GPIO_INTERRUPT_PIN)
           {
-            pid = getpid();
+            pid = nxsched_getpid();
             flags = spin_lock_irqsave(NULL);
             for (i = 0; i < CONFIG_DEV_GPIO_NSIGNALS; i++)
               {
@@ -402,7 +402,7 @@ static int gpio_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
       case GPIOC_UNREGISTER:
         if (dev->gp_pintype >= GPIO_INTERRUPT_PIN)
           {
-            pid = getpid();
+            pid = nxsched_getpid();
             flags = spin_lock_irqsave(NULL);
             for (i = 0; i < CONFIG_DEV_GPIO_NSIGNALS; i++)
               {

--- a/drivers/net/phy_notify.c
+++ b/drivers/net/phy_notify.c
@@ -275,7 +275,7 @@ int phy_notify_subscribe(FAR const char *intf, pid_t pid,
 
   if (pid == 0)
     {
-      pid = getpid();
+      pid = nxsched_getpid();
       phyinfo("Actual PID=%d\n", pid);
     }
 

--- a/drivers/rptun/rptun.c
+++ b/drivers/rptun/rptun.c
@@ -258,7 +258,7 @@ static void rptun_wakeup_rx(FAR struct rptun_priv_s *priv)
 
 static void rptun_in_recursive(int tid, FAR void *arg)
 {
-  *((FAR bool *)arg) = (gettid() == tid);
+  *((FAR bool *)arg) = (nxsched_gettid() == tid);
 }
 
 static bool rptun_is_recursive(FAR struct rptun_priv_s *priv)
@@ -274,7 +274,7 @@ static int rptun_thread(int argc, FAR char *argv[])
   FAR struct rptun_priv_s *priv;
 
   priv = (FAR struct rptun_priv_s *)((uintptr_t)strtoul(argv[2], NULL, 0));
-  priv->tid = gettid();
+  priv->tid = nxsched_gettid();
 
   while (1)
     {
@@ -298,7 +298,7 @@ static void rptun_wakeup_rx(FAR struct rptun_priv_s *priv)
 
 static bool rptun_is_recursive(FAR struct rptun_priv_s *priv)
 {
-  return gettid() == priv->tid;
+  return nxsched_gettid() == priv->tid;
 }
 #endif
 

--- a/drivers/sensors/zerocross.c
+++ b/drivers/sensors/zerocross.c
@@ -424,7 +424,7 @@ static int zc_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
               /* Save the notification events */
 
               opriv->do_event = *event;
-              opriv->do_pid   = getpid();
+              opriv->do_pid   = nxsched_getpid();
 
               /* Enable/disable interrupt handling */
 

--- a/drivers/syslog/vsyslog.c
+++ b/drivers/syslog/vsyslog.c
@@ -83,7 +83,7 @@ int nx_vsyslog(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
   struct lib_syslogstream_s stream;
   int ret;
 #if CONFIG_TASK_NAME_SIZE > 0 && defined(CONFIG_SYSLOG_PROCESS_NAME)
-  FAR struct tcb_s *tcb = nxsched_get_tcb(gettid());
+  FAR struct tcb_s *tcb = nxsched_get_tcb(nxsched_gettid());
 #endif
 #ifdef CONFIG_SYSLOG_TIMESTAMP
   struct timespec ts;
@@ -218,7 +218,7 @@ int nx_vsyslog(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
 #if defined(CONFIG_SYSLOG_PROCESSID)
   /* Prepend the Thread ID */
 
-                    , (int)gettid()
+                    , (int)nxsched_gettid()
 #endif
 
 #if defined(CONFIG_SYSLOG_COLOR_OUTPUT)

--- a/drivers/timers/oneshot.c
+++ b/drivers/timers/oneshot.c
@@ -209,7 +209,7 @@ static int oneshot_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
           pid = start->pid;
           if (pid == 0)
             {
-              pid = getpid();
+              pid = nxsched_getpid();
             }
 
           priv->od_pid = pid;

--- a/drivers/timers/rtc.c
+++ b/drivers/timers/rtc.c
@@ -470,7 +470,7 @@ static int rtc_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
             pid = alarminfo->pid;
             if (pid == 0)
               {
-                pid = getpid();
+                pid = nxsched_getpid();
               }
 
             /* Save the signal info to be used to notify the caller when the
@@ -541,7 +541,7 @@ static int rtc_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
             pid = alarminfo->pid;
             if (pid == 0)
               {
-                pid = getpid();
+                pid = nxsched_getpid();
               }
 
             /* Save the signal info to be used to notify the caller when the
@@ -675,7 +675,7 @@ static int rtc_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
             pid = alarminfo->pid;
             if (pid == 0)
               {
-                pid = getpid();
+                pid = nxsched_getpid();
               }
 
             /* Save the signal info to be used to notify the caller when the

--- a/drivers/wireless/ieee802154/xbee/xbee_netdev.c
+++ b/drivers/wireless/ieee802154/xbee/xbee_netdev.c
@@ -939,7 +939,7 @@ static int xbeenet_ioctl(FAR struct net_driver_s *dev, int cmd,
                   /* Save the notification events */
 
                   priv->xd_notify_event       = netmac->u.event;
-                  priv->xd_notify_pid         = getpid();
+                  priv->xd_notify_pid         = nxsched_getpid();
                   priv->xd_notify_registered  = true;
                   ret = OK;
                 }

--- a/fs/aio/aioc_contain.c
+++ b/fs/aio/aioc_contain.c
@@ -89,7 +89,7 @@ FAR struct aio_container_s *aio_contain(FAR struct aiocb *aiocbp)
       memset(aioc, 0, sizeof(struct aio_container_s));
       aioc->aioc_aiocbp = aiocbp;
       aioc->aioc_filep  = filep;
-      aioc->aioc_pid    = getpid();
+      aioc->aioc_pid    = nxsched_getpid();
 
 #ifdef CONFIG_PRIORITY_INHERITANCE
       DEBUGVERIFY(nxsched_get_param (aioc->aioc_pid, &param));

--- a/fs/mount/fs_automount.c
+++ b/fs/mount/fs_automount.c
@@ -358,7 +358,7 @@ static int automount_ioctl(FAR struct file *filep, int cmd,
               opriv->ao_notify.an_mount  = notify->an_mount;
               opriv->ao_notify.an_umount = notify->an_umount;
               opriv->ao_notify.an_event  = notify->an_event;
-              opriv->ao_pid              = getpid();
+              opriv->ao_pid              = nxsched_getpid();
               ret = OK;
             }
         }

--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -1484,7 +1484,7 @@ static int proc_open(FAR struct file *filep, FAR const char *relpath,
 
   if (strncmp(relpath, "self", 4) == 0)
     {
-      tmp = gettid();                   /* Get the TID of the calling task */
+      tmp = nxsched_gettid();           /* Get the TID of the calling task */
       ptr = (FAR char *)relpath + 4;    /* Discard const */
     }
   else
@@ -1792,7 +1792,7 @@ static int proc_opendir(FAR const char *relpath,
 
   if (strncmp(relpath, "self", 4) == 0)
     {
-      tmp = gettid();                   /* Get the TID of the calling task */
+      tmp = nxsched_gettid();           /* Get the TID of the calling task */
       ptr = (FAR char *)relpath + 4;    /* Discard const */
     }
   else
@@ -2032,7 +2032,7 @@ static int proc_stat(const char *relpath, struct stat *buf)
 
   if (strncmp(relpath, "self", 4) == 0)
     {
-      tmp = gettid();                   /* Get the TID of the calling task */
+      tmp = nxsched_gettid();           /* Get the TID of the calling task */
       ptr = (FAR char *)relpath + 4;    /* Discard const */
     }
   else

--- a/include/execinfo.h
+++ b/include/execinfo.h
@@ -38,8 +38,9 @@
  * ARRAY and return the exact number of values stored.
  */
 
-# define backtrace(buffer, size) sched_backtrace(gettid(), buffer, size, 0)
-# define dump_stack()            sched_dumpstack(gettid())
+# define backtrace(buffer, size) sched_backtrace(_SCHED_GETTID(), \
+                                                 buffer, size, 0)
+# define dump_stack()            sched_dumpstack(_SCHED_GETTID())
 
 #else
 # define backtrace(buffer, size) 0

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -166,6 +166,16 @@
 #  define _SCHED_ERRVAL(r)           (-errno)
 #endif
 
+#if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
+#  define _SCHED_GETTID()            nxsched_gettid()
+#  define _SCHED_GETPID()            nxsched_getpid()
+#  define _SCHED_GETPPID()           nxsched_getppid()
+#else
+#  define _SCHED_GETTID()            gettid()
+#  define _SCHED_GETPID()            getpid()
+#  define _SCHED_GETPPID()           getppid()
+#endif
+
 #ifdef CONFIG_DEBUG_TCBINFO
 #  define TCB_PID_OFF                offsetof(struct tcb_s, pid)
 #  define TCB_STATE_OFF              offsetof(struct tcb_s, task_state)
@@ -1365,6 +1375,67 @@ int nxsched_get_stackinfo(pid_t pid, FAR struct stackinfo_s *stackinfo);
 #ifdef CONFIG_SCHED_WAITPID
 pid_t nx_waitpid(pid_t pid, FAR int *stat_loc, int options);
 #endif
+
+/****************************************************************************
+ * Name: nxsched_gettid
+ *
+ * Description:
+ *   Get the thread ID of the currently executing thread.
+ *
+ * Input parameters:
+ *   None
+ *
+ * Returned Value:
+ *   On success, returns the thread ID of the calling process.
+ *
+ ****************************************************************************/
+
+pid_t nxsched_gettid(void);
+
+/****************************************************************************
+ * Name: nxsched_getpid
+ *
+ * Description:
+ *   Get the Process ID of the currently executing task.
+ *
+ * Input parameters:
+ *   None
+ *
+ * Returned Value:
+ *   Normally when called from user applications, nxsched_getpid() will
+ *   return the Process ID of the currently executing task. that is,
+ *   the main task for the task groups. There is no specification for
+ *   any errors returned from nxsched_getpid().
+ *
+ ****************************************************************************/
+
+pid_t nxsched_getpid(void);
+
+/****************************************************************************
+ * Name: nxsched_getppid
+ *
+ * Description:
+ *   Get the parent task ID of the currently executing task.
+ *
+ * Input parameters:
+ *   None
+ *
+ * Returned Value:
+ *   Normally when called from user applications, nxsched_getppid() will
+ *   return the parent task ID of the currently executing task, that is,
+ *   the task at the head of the ready-to-run list.
+ *   There is no specification for any errors returned from
+ *   nxsched_getppid().
+ *
+ *   nxsched_getppid(), however, may be called from within the OS in some
+ *   cases. There are certain situations during context switching when the
+ *   OS data structures are in flux and where the current task at the head
+ *   of the ready-to-run task list is not actually running.
+ *   In that case, nxsched_getppid() will return the error: -ESRCH
+ *
+ ****************************************************************************/
+
+pid_t nxsched_getppid(void);
 
 #undef EXTERN
 #if defined(__cplusplus)

--- a/include/threads.h
+++ b/include/threads.h
@@ -120,7 +120,7 @@ typedef CODE void (*tss_dtor_t)(FAR void *);
  * thrd_t thrd_current(void);
  */
 
-#define thrd_current() ((thrd_t)gettid())
+#define thrd_current() ((thrd_t)_SCHED_GETTID())
 
 /* thrd_sleep: suspends execution of the calling thread for the given
  * period of time

--- a/libs/libc/aio/lio_listio.c
+++ b/libs/libc/aio/lio_listio.c
@@ -32,6 +32,7 @@
 #include <errno.h>
 
 #include <nuttx/signal.h>
+#include <nuttx/sched.h>
 
 #include "libc.h"
 #include "aio/aio.h"
@@ -234,7 +235,7 @@ static int lio_sigsetup(FAR struct aiocb * const *list, int nent,
   sighand->list = list;
   sighand->sig  = *sig;
   sighand->nent = nent;
-  sighand->pid  = getpid();
+  sighand->pid  = _SCHED_GETPID();
 
   /* Save this structure as the private data attached to each aiocb */
 
@@ -664,7 +665,7 @@ int lio_listio(int mode, FAR struct aiocb * const list[], int nent,
         }
       else
         {
-          status = nxsig_notification(getpid(), sig,
+          status = nxsig_notification(_SCHED_GETPID(), sig,
                                       SI_ASYNCIO, &aiocbp->aio_sigwork);
           if (status < 0 && ret == OK)
             {

--- a/libs/libc/misc/Make.defs
+++ b/libs/libc/misc/Make.defs
@@ -22,7 +22,7 @@
 
 CSRCS += lib_mknod.c lib_umask.c lib_utsname.c lib_getrandom.c
 CSRCS += lib_xorshift128.c lib_tea_encrypt.c lib_tea_decrypt.c
-CSRCS += lib_cxx_initialize.c lib_impure.c lib_memfd.c
+CSRCS += lib_cxx_initialize.c lib_impure.c lib_memfd.c lib_mutex.c
 
 # Support for platforms that do not have long long types
 

--- a/libs/libc/misc/lib_err.c
+++ b/libs/libc/misc/lib_err.c
@@ -27,6 +27,8 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+#include <nuttx/sched.h>
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -66,9 +68,10 @@ void vwarn(FAR const char *fmt, va_list ap)
 #endif
 
 #ifdef CONFIG_FILE_STREAM
-  fprintf(stderr, "%d: %pV: %s\n", gettid(), &vaf, strerror(error));
+  fprintf(stderr, "%d: %pV: %s\n", _SCHED_GETTID(), &vaf, strerror(error));
 #else
-  dprintf(STDERR_FILENO, "%d: %pV: %s\n", gettid(), &vaf, strerror(error));
+  dprintf(STDERR_FILENO, "%d: %pV: %s\n", _SCHED_GETTID(),
+                                          &vaf, strerror(error));
 #endif
 
 #ifdef va_copy
@@ -97,9 +100,9 @@ void vwarnx(FAR const char *fmt, va_list ap)
 #endif
 
 #ifdef CONFIG_FILE_STREAM
-  fprintf(stderr, "%d: %pV\n", gettid(), &vaf);
+  fprintf(stderr, "%d: %pV\n", _SCHED_GETTID(), &vaf);
 #else
-  dprintf(STDERR_FILENO, "%d: %pV\n", gettid(), &vaf);
+  dprintf(STDERR_FILENO, "%d: %pV\n", _SCHED_GETTID(), &vaf);
 #endif
 
 #ifdef va_copy

--- a/libs/libc/sched/sched_backtrace.c
+++ b/libs/libc/sched/sched_backtrace.c
@@ -31,6 +31,8 @@
 #include <execinfo.h>
 #include <unwind.h>
 
+#include <nuttx/sched.h>
+
 /****************************************************************************
  * Private Data Types
  ****************************************************************************/
@@ -110,7 +112,7 @@ int sched_backtrace(pid_t tid, FAR void **buffer, int size, int skip)
 {
   struct trace_arg arg;
 
-  if (tid != gettid())
+  if (tid != _SCHED_GETTID())
     {
       return 0;
     }

--- a/libs/libc/signal/sig_raise.c
+++ b/libs/libc/signal/sig_raise.c
@@ -25,6 +25,8 @@
 #include <signal.h>
 #include <unistd.h>
 
+#include <nuttx/sched.h>
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -41,5 +43,5 @@
 
 int raise(int signo)
 {
-  return tkill(gettid(), signo);
+  return tkill(_SCHED_GETTID(), signo);
 }

--- a/libs/libc/unistd/lib_getpriority.c
+++ b/libs/libc/unistd/lib_getpriority.c
@@ -29,6 +29,8 @@
 #include <unistd.h>
 #include <errno.h>
 
+#include <nuttx/sched.h>
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -73,7 +75,7 @@ int getpriority(int which, id_t who)
 
   if (who == 0)
     {
-      who = gettid();
+      who = _SCHED_GETTID();
     }
 
   ret = sched_getparam(who, &param);

--- a/libs/libc/unistd/lib_setpriority.c
+++ b/libs/libc/unistd/lib_setpriority.c
@@ -28,6 +28,8 @@
 #include <errno.h>
 #include <unistd.h>
 
+#include <nuttx/sched.h>
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -62,7 +64,7 @@ int setpriority(int which, id_t who, int value)
 
   if (who == 0)
     {
-      who = gettid();
+      who = _SCHED_GETTID();
     }
 
   ret = sched_getparam(who, &param);

--- a/mm/mempool/mempool.c
+++ b/mm/mempool/mempool.c
@@ -102,7 +102,7 @@ static inline void mempool_add_backtrace(FAR struct mempool_s *pool,
                                          FAR struct mempool_backtrace_s *buf)
 {
   list_add_head(&pool->alist, &buf->node);
-  buf->pid = gettid();
+  buf->pid = _SCHED_GETTID();
 #  if CONFIG_MM_BACKTRACE > 0
   if (pool->procfs.backtrace)
     {

--- a/mm/mm_heap/mm.h
+++ b/mm/mm_heap/mm.h
@@ -75,7 +75,7 @@
      do \
        { \
          FAR struct mm_allocnode_s *tmp = (FAR struct mm_allocnode_s *)(ptr); \
-         tmp->pid = gettid(); \
+         tmp->pid = _SCHED_GETTID(); \
        } \
      while (0)
 #elif CONFIG_MM_BACKTRACE > 0
@@ -84,7 +84,7 @@
        { \
          FAR struct mm_allocnode_s *tmp = (FAR struct mm_allocnode_s *)(ptr); \
          FAR struct tcb_s *tcb; \
-         tmp->pid = gettid(); \
+         tmp->pid = _SCHED_GETTID(); \
          tcb = nxsched_get_tcb(tmp->pid); \
          if ((heap)->mm_procfs.backtrace || (tcb && tcb->flags & TCB_FLAG_HEAP_DUMP)) \
            { \

--- a/mm/mm_heap/mm_lock.c
+++ b/mm/mm_heap/mm_lock.c
@@ -77,17 +77,17 @@ int mm_lock(FAR struct mm_heap_s *heap)
   else
 #endif
 
-  /* gettid() returns the task ID of the task at the head of the ready-to-
-   * run task list.  mm_lock() may be called during context
+  /* _SCHED_GETTID() returns the task ID of the task at the head of the
+   * ready-to-run task list.  mm_lock() may be called during context
    * switches.  There are certain situations during context switching when
    * the OS data structures are in flux and then can't be freed immediately
    * (e.g. the running thread stack).
    *
-   * This is handled by gettid() to return the special value -ESRCH to
-   * indicate this special situation.
+   * This is handled by _SCHED_GETTID() to return the special value -ESRCH
+   * to indicate this special situation.
    */
 
-  if (gettid() < 0)
+  if (_SCHED_GETTID() < 0)
     {
       return -ESRCH;
     }

--- a/mm/shm/shmctl.c
+++ b/mm/shm/shmctl.c
@@ -33,6 +33,7 @@
 #include <assert.h>
 #include <debug.h>
 
+#include <nuttx/sched.h>
 #include <nuttx/pgalloc.h>
 
 #include "shm/shm.h"
@@ -184,7 +185,7 @@ int shmctl(int shmid, int cmd, struct shmid_ds *buf)
   /* Save the process ID of the last operation */
 
   region = &g_shminfo.si_region[shmid];
-  region->sr_ds.shm_lpid = getpid();
+  region->sr_ds.shm_lpid = _SCHED_GETPID();
 
   /* Save the time of the last shmctl() */
 

--- a/mm/shm/shmget.c
+++ b/mm/shm/shmget.c
@@ -32,6 +32,7 @@
 #include <errno.h>
 
 #include <nuttx/pgalloc.h>
+#include <nuttx/sched.h>
 
 #include "shm/shm.h"
 
@@ -268,7 +269,7 @@ static int shm_create(key_t key, size_t size, int shmflg)
   /* Save the process ID of the creator */
 
   region = &g_shminfo.si_region[shmid];
-  region->sr_ds.shm_cpid = getpid();
+  region->sr_ds.shm_cpid = _SCHED_GETPID();
 
   /* Return the shared memory ID */
 

--- a/mm/tlsf/mm_tlsf.c
+++ b/mm/tlsf/mm_tlsf.c
@@ -145,7 +145,7 @@ static void memdump_backtrace(FAR struct mm_heap_s *heap,
   FAR struct tcb_s *tcb;
 #  endif
 
-  dump->pid = getpid();
+  dump->pid = _SCHED_GETPID();
 #  if CONFIG_MM_BACKTRACE > 0
   tcb = nxsched_get_tcb(dump->pid);
   if (heap->mm_procfs.backtrace ||
@@ -320,17 +320,17 @@ static int mm_lock(FAR struct mm_heap_s *heap)
   else
 #endif
 
-  /* gettid() returns the task ID of the task at the head of the ready-to-
-   * run task list.  mm_lock() may be called during context
+  /* _SCHED_GETTID() returns the task ID of the task at the head of the
+   * ready-to-run task list.  mm_lock() may be called during context
    * switches.  There are certain situations during context switching when
    * the OS data structures are in flux and then can't be freed immediately
    * (e.g. the running thread stack).
    *
-   * This is handled by gettid() to return the special value -ESRCH to
-   * indicate this special situation.
+   * This is handled by _SCHED_GETTID() to return the special value
+   * -ESRCH to indicate this special situation.
    */
 
-  if (gettid() < 0)
+  if (_SCHED_GETTID() < 0)
     {
       return -ESRCH;
     }

--- a/net/local/local_conn.c
+++ b/net/local/local_conn.c
@@ -131,7 +131,7 @@ FAR struct local_conn_s *local_alloc(void)
       nxmutex_init(&conn->lc_sendlock);
 
 #ifdef CONFIG_NET_LOCAL_SCM
-      conn->lc_cred.pid = getpid();
+      conn->lc_cred.pid = nxsched_getpid();
       conn->lc_cred.uid = getuid();
       conn->lc_cred.gid = getgid();
 #endif

--- a/net/netlink/netlink_sockif.c
+++ b/net/netlink/netlink_sockif.c
@@ -262,7 +262,7 @@ static int netlink_bind(FAR struct socket *psock,
   nladdr = (FAR struct sockaddr_nl *)addr;
   conn   = (FAR struct netlink_conn_s *)psock->s_conn;
 
-  conn->pid    = nladdr->nl_pid ? nladdr->nl_pid : gettid();
+  conn->pid    = nladdr->nl_pid ? nladdr->nl_pid : nxsched_gettid();
   conn->groups = nladdr->nl_groups;
 
   return OK;

--- a/net/tcp/tcp_sendfile.c
+++ b/net/tcp/tcp_sendfile.c
@@ -40,6 +40,7 @@
 #include <debug.h>
 
 #include <arch/irq.h>
+#include <nuttx/sched.h>
 #include <nuttx/semaphore.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/net/net.h>
@@ -367,7 +368,7 @@ static uint16_t sendfile_eventhandler(FAR struct net_driver_s *dev,
 
           pstate->snd_sent += sndlen;
           ninfo("pid: %d SEND: acked=%" PRId32 " sent=%zd flen=%zu\n",
-                getpid(),
+                nxsched_getpid(),
                 pstate->snd_acked, pstate->snd_sent, pstate->snd_flen);
         }
       else

--- a/sched/mqueue/mq_timedreceive.c
+++ b/sched/mqueue/mq_timedreceive.c
@@ -202,7 +202,8 @@ ssize_t file_mq_timedreceive(FAR struct file *mq, FAR char *msg,
 
       /* Start the watchdog */
 
-      wd_start(&rtcb->waitdog, ticks, nxmq_rcvtimeout, gettid());
+      wd_start(&rtcb->waitdog, ticks,
+               nxmq_rcvtimeout, nxsched_gettid());
     }
 
   /* Get the message from the message queue */

--- a/sched/mqueue/mq_timedsend.c
+++ b/sched/mqueue/mq_timedsend.c
@@ -245,7 +245,7 @@ int file_mq_timedsend(FAR struct file *mq, FAR const char *msg,
 
   /* Start the watchdog and begin the wait for MQ not full */
 
-  wd_start(&rtcb->waitdog, ticks, nxmq_sndtimeout, gettid());
+  wd_start(&rtcb->waitdog, ticks, nxmq_sndtimeout, nxsched_gettid());
 
   /* And wait for the message queue to be non-empty */
 

--- a/sched/pthread/pthread_condclockwait.c
+++ b/sched/pthread/pthread_condclockwait.c
@@ -74,7 +74,7 @@ int pthread_cond_clockwait(FAR pthread_cond_t *cond,
                            FAR const struct timespec *abstime)
 {
   irqstate_t flags;
-  int mypid = gettid();
+  int mypid = nxsched_gettid();
   int ret = OK;
   int status;
 

--- a/sched/pthread/pthread_condwait.c
+++ b/sched/pthread/pthread_condwait.c
@@ -74,7 +74,7 @@ int pthread_cond_wait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex)
 
   /* Make sure that the caller holds the mutex */
 
-  else if (mutex->pid != gettid())
+  else if (mutex->pid != nxsched_gettid())
     {
       ret = EPERM;
     }
@@ -140,7 +140,7 @@ int pthread_cond_wait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex)
         {
           /* Yes.. Then initialize it properly */
 
-          mutex->pid    = gettid();
+          mutex->pid    = nxsched_gettid();
 #ifndef CONFIG_PTHREAD_MUTEX_UNSAFE
           mutex->flags  = mflags;
 #endif

--- a/sched/pthread/pthread_exit.c
+++ b/sched/pthread/pthread_exit.c
@@ -79,7 +79,7 @@ void nx_pthread_exit(FAR void *exit_value)
 
   /* Complete pending join operations */
 
-  status = pthread_completejoin(gettid(), exit_value);
+  status = pthread_completejoin(nxsched_gettid(), exit_value);
   if (status != OK)
     {
       /* Assume that the join completion failured because this

--- a/sched/pthread/pthread_mutextimedlock.c
+++ b/sched/pthread/pthread_mutextimedlock.c
@@ -78,7 +78,7 @@
 int pthread_mutex_timedlock(FAR pthread_mutex_t *mutex,
                             FAR const struct timespec *abs_timeout)
 {
-  pid_t mypid = gettid();
+  pid_t mypid = nxsched_gettid();
   int ret = EINVAL;
 
   sinfo("mutex=%p\n", mutex);

--- a/sched/pthread/pthread_mutextrylock.c
+++ b/sched/pthread/pthread_mutextrylock.c
@@ -76,7 +76,7 @@ int pthread_mutex_trylock(FAR pthread_mutex_t *mutex)
 
   if (mutex != NULL)
     {
-      pid_t mypid = gettid();
+      pid_t mypid = nxsched_gettid();
 
       /* Make sure the semaphore is stable while we make the following
        * checks.  This all needs to be one atomic action.

--- a/sched/pthread/pthread_mutexunlock.c
+++ b/sched/pthread/pthread_mutexunlock.c
@@ -142,7 +142,7 @@ int pthread_mutex_unlock(FAR pthread_mutex_t *mutex)
        * thread owns the semaphore.
        */
 
-      if (mutex->pid != gettid())
+      if (mutex->pid != nxsched_gettid())
 
 #elif defined(CONFIG_PTHREAD_MUTEX_UNSAFE) && defined(CONFIG_PTHREAD_MUTEX_TYPES)
       /* If mutex types are not supported, then all mutexes are NORMAL (or
@@ -150,7 +150,8 @@ int pthread_mutex_unlock(FAR pthread_mutex_t *mutex)
        * non-robust NORMAL mutex type.
        */
 
-      if (mutex->type != PTHREAD_MUTEX_NORMAL && mutex->pid != gettid())
+      if (mutex->type != PTHREAD_MUTEX_NORMAL &&
+          mutex->pid != nxsched_gettid())
 
 #else /* CONFIG_PTHREAD_MUTEX_BOTH */
       /* Skip the error check if this is a non-robust NORMAL mutex */
@@ -164,7 +165,7 @@ int pthread_mutex_unlock(FAR pthread_mutex_t *mutex)
        * the EPERM error?
        */
 
-      if (errcheck && mutex->pid != gettid())
+      if (errcheck && mutex->pid != nxsched_gettid())
 #endif
         {
           /* No... return an EPERM error.

--- a/sched/sched/sched_setscheduler.c
+++ b/sched/sched/sched_setscheduler.c
@@ -109,7 +109,7 @@ int nxsched_set_scheduler(pid_t pid, int policy,
 
   if (pid == 0)
     {
-      pid = gettid();
+      pid = nxsched_gettid();
     }
 
   /* Verify that the pid corresponds to a real task */

--- a/sched/semaphore/sem_clockwait.c
+++ b/sched/semaphore/sem_clockwait.c
@@ -159,7 +159,7 @@ int nxsem_clockwait(FAR sem_t *sem, clockid_t clockid,
 
   /* Start the watchdog */
 
-  wd_start(&rtcb->waitdog, ticks, nxsem_timeout, gettid());
+  wd_start(&rtcb->waitdog, ticks, nxsem_timeout, nxsched_gettid());
 
   /* Now perform the blocking wait.  If nxsem_wait() fails, the
    * negated errno value will be returned below.

--- a/sched/semaphore/sem_tickwait.c
+++ b/sched/semaphore/sem_tickwait.c
@@ -105,7 +105,7 @@ int nxsem_tickwait(FAR sem_t *sem, uint32_t delay)
 
   /* Start the watchdog with interrupts still disabled */
 
-  wd_start(&rtcb->waitdog, delay, nxsem_timeout, gettid());
+  wd_start(&rtcb->waitdog, delay, nxsem_timeout, nxsched_gettid());
 
   /* Now perform the blocking wait */
 

--- a/sched/task/task_exithook.c
+++ b/sched/task/task_exithook.c
@@ -66,7 +66,7 @@ static inline void nxtask_exitstatus(FAR struct task_group_s *group,
     {
       /* No.. Find the exit status entry for this task in the parent TCB */
 
-      child = group_find_child(group, gettid());
+      child = group_find_child(group, nxsched_gettid());
       if (child)
         {
           /* Save the exit status..  For the case of HAVE_GROUP_MEMBERS,
@@ -105,7 +105,7 @@ static inline void nxtask_groupexit(FAR struct task_group_s *group)
     {
       /* No.. Find the exit status entry for this task in the parent TCB */
 
-      child = group_find_child(group, gettid());
+      child = group_find_child(group, nxsched_gettid());
       if (child)
         {
           /* Mark that all members of the child task group has exited */

--- a/sched/task/task_getpid.c
+++ b/sched/task/task_getpid.c
@@ -35,7 +35,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: getpid
+ * Name: nxsched_getpid
  *
  * Description:
  *   Get the Process ID of the currently executing task.
@@ -44,14 +44,14 @@
  *   None
  *
  * Returned Value:
- *   Normally when called from user applications, getpid() will return the
- *   Process ID of the currently executing task. that is, the main task
- *   for the task groups. There is no specification for any errors
- *   returned from getpid().
+ *   Normally when called from user applications, nxsched_getpid() will
+ *   return the Process ID of the currently executing task. that is,
+ *   the main task for the task groups. There is no specification for
+ *   any errors returned from nxsched_getpid().
  *
  ****************************************************************************/
 
-pid_t getpid(void)
+pid_t nxsched_getpid(void)
 {
   FAR struct tcb_s *rtcb;
 
@@ -77,4 +77,26 @@ pid_t getpid(void)
    */
 
   return IDLE_PROCESS_ID;
+}
+
+/****************************************************************************
+ * Name: getpid
+ *
+ * Description:
+ *   Get the Process ID of the currently executing task.
+ *
+ * Input parameters:
+ *   None
+ *
+ * Returned Value:
+ *   Normally when called from user applications, getpid() will return the
+ *   Process ID of the currently executing task. that is, the main task
+ *   for the task groups. There is no specification for any errors
+ *   returned from getpid().
+ *
+ ****************************************************************************/
+
+pid_t getpid(void)
+{
+  return nxsched_getpid();
 }

--- a/sched/task/task_getppid.c
+++ b/sched/task/task_getppid.c
@@ -35,7 +35,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: getppid
+ * Name: nxsched_getppid
  *
  * Description:
  *   Get the parent task ID of the currently executing task.
@@ -44,20 +44,21 @@
  *   None
  *
  * Returned Value:
- *   Normally when called from user applications, getppid() will return the
- *   parent task ID of the currently executing task, that is, the task at the
- *   head of the ready-to-run list.  There is no specification for any errors
- *   returned from getppid().
+ *   Normally when called from user applications, nxsched_getppid() will
+ *   return the parent task ID of the currently executing task, that is,
+ *   the task at the head of the ready-to-run list.
+ *   There is no specification for any errors returned from
+ *   nxsched_getppid().
  *
- *   getppid(), however, may be called from within the OS in some cases.
- *   There are certain situations during context switching when the OS data
- *   structures are in flux and where the current task at the head of the
- *   ready-to-run task list is not actually running.  In that case,
- *   getppid() will return the error: -ESRCH
+ *   nxsched_getppid(), however, may be called from within the OS in some
+ *   cases. There are certain situations during context switching when the
+ *   OS data structures are in flux and where the current task at the head
+ *   of the ready-to-run task list is not actually running.
+ *   In that case, nxsched_getppid() will return the error: -ESRCH
  *
  ****************************************************************************/
 
-pid_t getppid(void)
+pid_t nxsched_getppid(void)
 {
   FAR struct tcb_s *rtcb;
 
@@ -97,4 +98,32 @@ pid_t getppid(void)
    */
 
   return IDLE_PROCESS_ID;
+}
+
+/****************************************************************************
+ * Name: getppid
+ *
+ * Description:
+ *   Get the parent task ID of the currently executing task.
+ *
+ * Input parameters:
+ *   None
+ *
+ * Returned Value:
+ *   Normally when called from user applications, getppid() will return the
+ *   parent task ID of the currently executing task, that is, the task at the
+ *   head of the ready-to-run list.  There is no specification for any errors
+ *   returned from getppid().
+ *
+ *   getppid(), however, may be called from within the OS in some cases.
+ *   There are certain situations during context switching when the OS data
+ *   structures are in flux and where the current task at the head of the
+ *   ready-to-run task list is not actually running.  In that case,
+ *   getppid() will return the error: -ESRCH
+ *
+ ****************************************************************************/
+
+pid_t getppid(void)
+{
+  return nxsched_getppid();
 }

--- a/sched/task/task_gettid.c
+++ b/sched/task/task_gettid.c
@@ -35,7 +35,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: gettid
+ * Name: nxsched_gettid
  *
  * Description:
  *   Get the thread ID of the currently executing thread.
@@ -48,7 +48,7 @@
  *
  ****************************************************************************/
 
-pid_t gettid(void)
+pid_t nxsched_gettid(void)
 {
   FAR struct tcb_s *rtcb;
 
@@ -88,4 +88,23 @@ pid_t gettid(void)
    */
 
   return 0;
+}
+
+/****************************************************************************
+ * Name: gettid
+ *
+ * Description:
+ *   Get the thread ID of the currently executing thread.
+ *
+ * Input parameters:
+ *   None
+ *
+ * Returned Value:
+ *   On success, returns the thread ID of the calling process.
+ *
+ ****************************************************************************/
+
+pid_t gettid(void)
+{
+  return nxsched_gettid();
 }

--- a/sched/timer/timer_create.c
+++ b/sched/timer/timer_create.c
@@ -178,7 +178,7 @@ int timer_create(clockid_t clockid, FAR struct sigevent *evp,
 
   ret->pt_clock = clockid;
   ret->pt_crefs = 1;
-  ret->pt_owner = getpid();
+  ret->pt_owner = nxsched_getpid();
   ret->pt_delay = 0;
 
   /* Was a struct sigevent provided? */

--- a/wireless/ieee802154/mac802154_device.c
+++ b/wireless/ieee802154/mac802154_device.c
@@ -583,7 +583,7 @@ static int mac802154dev_ioctl(FAR struct file *filep, int cmd,
           /* Save the notification events */
 
           dev->md_notify_event      = macarg->event;
-          dev->md_notify_pid        = getpid();
+          dev->md_notify_pid        = nxsched_getpid();
           dev->md_notify_registered = true;
 
           ret = OK;

--- a/wireless/ieee802154/mac802154_netdev.c
+++ b/wireless/ieee802154/mac802154_netdev.c
@@ -939,7 +939,7 @@ static int macnet_ioctl(FAR struct net_driver_s *dev, int cmd,
                   /* Save the notification events */
 
                   priv->md_notify_event       = netmac->u.event;
-                  priv->md_notify_pid         = getpid();
+                  priv->md_notify_pid         = nxsched_getpid();
                   priv->md_notify_registered  = true;
                   ret = OK;
                 }


### PR DESCRIPTION
## Summary

1. sched/task: add kernel interface nxsched_* gettid/getpid/getppid

add new interface to implement getpid()/gettid()/getppid() for kernel version.

Signed-off-by: chao an <anchao@xiaomi.com>

2. sched/getpid: replace syscall getpid/tid/ppid() to kernel version

NuttX kernel should not use the syscall functions, especially after
enabling CONFIG_SCHED_INSTRUMENTATION_SYSCALL, all system functions
will be traced to backend, which will impact system performance.

Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

enable CONFIG_SCHED_INSTRUMENTATION_SYSCALL:

before:

```
Idle_Task-0   [0]   0.000000000: sys_sched_lock()
Idle_Task-0   [0]   0.000000000: sys_sched_lock -> 0x0
Idle_Task-0   [0]   0.000000000: sys_gettid()
Idle_Task-0   [0]   0.000000000: sys_gettid -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_wait(arg0: 0x7f8b23f16000)
Idle_Task-0   [0]   0.000000000: sys_sem_wait -> 0x0
Idle_Task-0   [0]   0.000000000: sys_gettid()
Idle_Task-0   [0]   0.000000000: sys_gettid -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_post(arg0: 0x7f8b23f16000)
Idle_Task-0   [0]   0.000000000: sys_sem_post -> 0x0
Idle_Task-0   [0]   0.000000000: sys_clock_gettime(arg0: 0x0, arg1: 0x0)
Idle_Task-0   [0]   0.000000000: sys_clock_gettime -> 0x0
Idle_Task-0   [0]   0.000000000: sys_gettid()
Idle_Task-0   [0]   0.000000000: sys_gettid -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_wait(arg0: 0x7f8b23f16000)
Idle_Task-0   [0]   0.000000000: sys_sem_wait -> 0x0
Idle_Task-0   [0]   0.000000000: sys_gettid()
Idle_Task-0   [0]   0.000000000: sys_gettid -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_post(arg0: 0x7f8b23f16000)
Idle_Task-0   [0]   0.000000000: sys_sem_post -> 0x0
Idle_Task-0   [0]   0.000000000: sys_gettid()
Idle_Task-0   [0]   0.000000000: sys_gettid -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_wait(arg0: 0x7f8b23f16000)
Idle_Task-0   [0]   0.000000000: sys_sem_wait -> 0x0
Idle_Task-0   [0]   0.000000000: sys_gettid()
Idle_Task-0   [0]   0.000000000: sys_gettid -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_post(arg0: 0x7f8b23f16000)
Idle_Task-0   [0]   0.000000000: sys_sem_post -> 0x0
Idle_Task-0   [0]   0.000000000: sys_gettid()
Idle_Task-0   [0]   0.000000000: sys_gettid -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_wait(arg0: 0x7f8b23f16000)
Idle_Task-0   [0]   0.000000000: sys_sem_wait -> 0x0
Idle_Task-0   [0]   0.000000000: sys_gettid()
Idle_Task-0   [0]   0.000000000: sys_gettid -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_post(arg0: 0x7f8b23f16000)
Idle_Task-0   [0]   0.000000000: sys_sem_post -> 0x0
Idle_Task-0   [0]   0.000000000: sys_gettid()
Idle_Task-0   [0]   0.000000000: sys_gettid -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_wait(arg0: 0x7f8b23f16000)
Idle_Task-0   [0]   0.000000000: sys_sem_wait -> 0x0
Idle_Task-0   [0]   0.000000000: sys_gettid()
Idle_Task-0   [0]   0.000000000: sys_gettid -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_post(arg0: 0x7f8b23f16000)
Idle_Task-0   [0]   0.000000000: sys_sem_post -> 0x0
Idle_Task-0   [0]   0.000000000: sys_gettid()
Idle_Task-0   [0]   0.000000000: sys_gettid -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_wait(arg0: 0x7f8b23f16000)
Idle_Task-0   [0]   0.000000000: sys_sem_wait -> 0x0
Idle_Task-0   [0]   0.000000000: sys_gettid()
Idle_Task-0   [0]   0.000000000: sys_gettid -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_post(arg0: 0x7f8b23f16000)
Idle_Task-0   [0]   0.000000000: sys_sem_post -> 0x0
Idle_Task-0   [0]   0.000000000: sys_gettid()
Idle_Task-0   [0]   0.000000000: sys_gettid -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_wait(arg0: 0x7f8b23f16000)
Idle_Task-0   [0]   0.000000000: sys_sem_wait -> 0x0
Idle_Task-0   [0]   0.000000000: sys_gettid()
Idle_Task-0   [0]   0.000000000: sys_gettid -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_post(arg0: 0x7f8b23f16000)
Idle_Task-0   [0]   0.000000000: sys_sem_post -> 0x0
Idle_Task-0   [0]   0.000000000: sys_gettid()
Idle_Task-0   [0]   0.000000000: sys_gettid -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_wait(arg0: 0x7f8b23f16000)
Idle_Task-0   [0]   0.000000000: sys_sem_wait -> 0x0
Idle_Task-0   [0]   0.000000000: sys_gettid()
Idle_Task-0   [0]   0.000000000: sys_gettid -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_post(arg0: 0x7f8b23f16000)
Idle_Task-0   [0]   0.000000000: sys_sem_post -> 0x0
Idle_Task-0   [0]   0.000000000: sys_gettid()
Idle_Task-0   [0]   0.000000000: sys_gettid -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_wait(arg0: 0x7f8b23f16000)
Idle_Task-0   [0]   0.000000000: sys_sem_wait -> 0x0
Idle_Task-0   [0]   0.000000000: sys_gettid()
Idle_Task-0   [0]   0.000000000: sys_gettid -> 0x0
```


after:
```
Idle_Task-0   [0]   0.000000000: sys_sem_wait(arg0: 0x561f120ac1e0)
Idle_Task-0   [0]   0.000000000: sys_sem_wait -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_wait(arg0: 0x7fcfbc30b000)
Idle_Task-0   [0]   0.000000000: sys_sem_wait -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_post(arg0: 0x7fcfbc30b000)
Idle_Task-0   [0]   0.000000000: sys_sem_post -> 0x0
Idle_Task-0   [0]   0.000000000: sys_clock_gettime(arg0: 0x0, arg1: 0x0)
Idle_Task-0   [0]   0.000000000: sys_clock_gettime -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_post(arg0: 0x561f120ac1e0)
Idle_Task-0   [0]   0.000000000: sys_sem_post -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_wait(arg0: 0x561f120ac1e0)
Idle_Task-0   [0]   0.000000000: sys_sem_wait -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_wait(arg0: 0x7fcfbc30b000)
Idle_Task-0   [0]   0.000000000: sys_sem_wait -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_post(arg0: 0x7fcfbc30b000)
Idle_Task-0   [0]   0.000000000: sys_sem_post -> 0x0
Idle_Task-0   [0]   0.000000000: sys_clock_gettime(arg0: 0x0, arg1: 0x0)
Idle_Task-0   [0]   0.000000000: sys_clock_gettime -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_post(arg0: 0x561f120ac1e0)
Idle_Task-0   [0]   0.000000000: sys_sem_post -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_wait(arg0: 0x561f120ac1e0)
Idle_Task-0   [0]   0.000000000: sys_sem_wait -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_wait(arg0: 0x7fcfbc30b000)
Idle_Task-0   [0]   0.000000000: sys_sem_wait -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_post(arg0: 0x7fcfbc30b000)
Idle_Task-0   [0]   0.000000000: sys_sem_post -> 0x0
Idle_Task-0   [0]   0.000000000: sys_clock_gettime(arg0: 0x0, arg1: 0x0)
Idle_Task-0   [0]   0.000000000: sys_clock_gettime -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_post(arg0: 0x561f120ac1e0)
Idle_Task-0   [0]   0.000000000: sys_sem_post -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_wait(arg0: 0x561f120ac1e0)
Idle_Task-0   [0]   0.000000000: sys_sem_wait -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_wait(arg0: 0x7fcfbc30b000)
Idle_Task-0   [0]   0.000000000: sys_sem_wait -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_post(arg0: 0x7fcfbc30b000)
Idle_Task-0   [0]   0.000000000: sys_sem_post -> 0x0
Idle_Task-0   [0]   0.000000000: sys_clock_gettime(arg0: 0x0, arg1: 0x0)
Idle_Task-0   [0]   0.000000000: sys_clock_gettime -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_wait(arg0: 0x7fcfbc30b000)
Idle_Task-0   [0]   0.000000000: sys_sem_wait -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_post(arg0: 0x7fcfbc30b000)
Idle_Task-0   [0]   0.000000000: sys_sem_post -> 0x0
Idle_Task-0   [0]   0.000000000: sys_clock_gettime(arg0: 0x0, arg1: 0x0)
Idle_Task-0   [0]   0.000000000: sys_clock_gettime -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_post(arg0: 0x561f120ac1e0)
Idle_Task-0   [0]   0.000000000: sys_sem_post -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_wait(arg0: 0x561f120ac1e0)
Idle_Task-0   [0]   0.000000000: sys_sem_wait -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_wait(arg0: 0x7fcfbc30b000)
Idle_Task-0   [0]   0.000000000: sys_sem_wait -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_post(arg0: 0x7fcfbc30b000)
Idle_Task-0   [0]   0.000000000: sys_sem_post -> 0x0
Idle_Task-0   [0]   0.000000000: sys_clock_gettime(arg0: 0x0, arg1: 0x0)
Idle_Task-0   [0]   0.000000000: sys_clock_gettime -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_post(arg0: 0x561f120ac1e0)
Idle_Task-0   [0]   0.000000000: sys_sem_post -> 0x0
Idle_Task-0   [0]   0.000000000: sched_wakeup_new: comm=Idle_Task pid=0 target_cpu=0
Idle_Task-0   [0]   0.000000000: sys_nxsched_get_stackinfo(arg0: 0x0, arg1: 0x0)
Idle_Task-0   [0]   0.000000000: sys_nxsched_get_stackinfo -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_wait(arg0: 0x561f120ac1e0)
Idle_Task-0   [0]   0.000000000: sys_sem_wait -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_post(arg0: 0x561f120ac1e0)
Idle_Task-0   [0]   0.000000000: sys_sem_post -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_wait(arg0: 0x561f120ac0f8)
Idle_Task-0   [0]   0.000000000: sys_sem_wait -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_post(arg0: 0x561f120ac0f8)
Idle_Task-0   [0]   0.000000000: sys_sem_post -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_wait(arg0: 0x7fcfbc30b390)
Idle_Task-0   [0]   0.000000000: sys_sem_wait -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_wait(arg0: 0x7fcfbc30b000)
Idle_Task-0   [0]   0.000000000: sys_sem_wait -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_post(arg0: 0x7fcfbc30b000)
Idle_Task-0   [0]   0.000000000: sys_sem_post -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_wait(arg0: 0x7fcfbc30b000)
Idle_Task-0   [0]   0.000000000: sys_sem_wait -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_post(arg0: 0x7fcfbc30b000)
Idle_Task-0   [0]   0.000000000: sys_sem_post -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_post(arg0: 0x7fcfbc30b390)
Idle_Task-0   [0]   0.000000000: sys_sem_post -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_wait(arg0: 0x7fcfbc30b390)
Idle_Task-0   [0]   0.000000000: sys_sem_wait -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_wait(arg0: 0x561f120ac1e0)
Idle_Task-0   [0]   0.000000000: sys_sem_wait -> 0x0
Idle_Task-0   [0]   0.000000000: sys_sem_post(arg0: 0x561f120ac1e0)
```