### PR TITLE
assert:add a Kconfig option to limit binfile size

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -631,6 +631,15 @@ config DEBUG_ASSERTIONS
 		set CONFIG_DEBUG_ASSERTIONS=y during debug, but disable the
 		assertions on a final, buckled up system.
 
+config DEBUG_ASSERTIONS_EXPRESSION
+	bool "Enable Debug Assertions show expression"
+	default n
+	depends on DEBUG_ASSERTIONS
+	---help---
+		This option can display the content information of the ASSERT()
+		function when it is triggered. This option maybe will take up a lot
+		of space.
+
 comment "Subsystem Debug Options"
 
 config DEBUG_AUDIO

--- a/include/assert.h
+++ b/include/assert.h
@@ -48,8 +48,14 @@
 #endif
 
 #define PANIC()          __assert(__FILE__, __LINE__, "panic")
+
+#ifdef CONFIG_DEBUG_ASSERTIONS_EXPRESSION
 #define ASSERT(f)        do { if (!(f)) __assert(__FILE__, __LINE__, #f); } while (0)
 #define VERIFY(f)        do { if ((f) < 0) __assert(__FILE__, __LINE__, #f); } while (0)
+#else
+#define ASSERT(f)        do { if (!(f)) __assert(__FILE__, __LINE__, "unknown"); } while (0)
+#define VERIFY(f)        do { if ((f) < 0) __assert(__FILE__, __LINE__, "unknown"); } while (0)
+#endif
 
 #ifdef CONFIG_DEBUG_ASSERTIONS
 #  define DEBUGPANIC()   PANIC()


### PR DESCRIPTION
Signed-off-by: anjiahao <anjiahao@xiaomi.com>

## Summary
add a Kconfig option to limit binfile size
## Impact
bin size
## Testing
vela

To display assert information causes the compiled bin size to become larger