### PR TITLE
misc/assert: remove const string from assert expression

### DIFF
--- a/include/assert.h
+++ b/include/assert.h
@@ -43,7 +43,7 @@
 #undef DEBUGVERIFY  /* Like VERIFY, but only if CONFIG_DEBUG_ASSERTIONS is defined */
 
 #ifndef CONFIG_HAVE_FILENAME
-#  define __FILE__       "unknown"
+#  define __FILE__       NULL
 #  define __LINE__       0
 #endif
 
@@ -53,8 +53,8 @@
 #define ASSERT(f)        do { if (!(f)) __assert(__FILE__, __LINE__, #f); } while (0)
 #define VERIFY(f)        do { if ((f) < 0) __assert(__FILE__, __LINE__, #f); } while (0)
 #else
-#define ASSERT(f)        do { if (!(f)) __assert(__FILE__, __LINE__, "unknown"); } while (0)
-#define VERIFY(f)        do { if ((f) < 0) __assert(__FILE__, __LINE__, "unknown"); } while (0)
+#define ASSERT(f)        do { if (!(f)) __assert(__FILE__, __LINE__, NULL); } while (0)
+#define VERIFY(f)        do { if ((f) < 0) __assert(__FILE__, __LINE__, NULL); } while (0)
 #endif
 
 #ifdef CONFIG_DEBUG_ASSERTIONS

--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -469,24 +469,24 @@ void _assert(FAR const char *filename, int linenum, FAR const char *msg)
          name.sysname, name.nodename,
          name.release, name.version, name.machine);
 
+  _alert("Assertion failed %s: at file: %s:%d task"
 #ifdef CONFIG_SMP
-#  if CONFIG_TASK_NAME_SIZE > 0
-  _alert("Assertion failed: %s at file: %s:%d task(CPU%d): %s %p\n",
-         msg, filename, linenum, up_cpu_index(), rtcb->name,
-         rtcb->entry.main);
-#  else
-  _alert("Assertion failed: %s at file: %s:%d task(CPU%d): %p\n",
-         msg, filename, linenum, up_cpu_index(), rtcb->entry.main);
-#  endif
-#else
-#  if CONFIG_TASK_NAME_SIZE > 0
-  _alert("Assertion failed: %s at file: %s:%d task: %s %p\n",
-         msg, filename, linenum, rtcb->name, rtcb->entry.main);
-#  else
-  _alert("Assertion failed: %s at file: %s:%d task: %p\n",
-         msg, filename, linenum, rtcb->entry.main);
-#  endif
+         "(CPU%d)"
 #endif
+         ": "
+#if CONFIG_TASK_NAME_SIZE > 0
+         "%s "
+#endif
+         "%p\n",
+         msg ? msg : "",
+         filename ? filename : "", linenum,
+#ifdef CONFIG_SMP
+         up_cpu_index(),
+#endif
+#if CONFIG_TASK_NAME_SIZE > 0
+         rtcb->name,
+#endif
+         rtcb->entry.main);
 
   /* Show back trace */
 


### PR DESCRIPTION

## Summary

misc/assert: remove const string from assert expression

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

assert test