### PR TITLE
sim/uart: do uart_xmitchars() when tty_txint enabled

### DIFF
--- a/arch/sim/src/sim/sim_uart.c
+++ b/arch/sim/src/sim/sim_uart.c
@@ -473,6 +473,11 @@ static void tty_txint(struct uart_dev_s *dev, bool enable)
   struct tty_priv_s *priv = dev->priv;
 
   priv->txint = enable;
+
+  if (enable)
+    {
+      uart_xmitchars(dev);
+    }
 }
 
 /****************************************************************************


### PR DESCRIPTION

## Summary

sim/uart: do uart_xmitchars() when tty_txint enabled
to speed up the logout speed


## Impact

sim uart

## Testing

sim:nsh