### PR TITLE
nuttx: Use MIN/MAX definitions from "sys/param.h"

### DIFF
--- a/arch/arm/src/phy62xx/types.h
+++ b/arch/arm/src/phy62xx/types.h
@@ -27,6 +27,9 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+
+#include <sys/param.h>
+
 typedef signed   char   int8;     /* !< Signed 8 bit integer */
 typedef unsigned char   uint8;    /* !< Unsigned 8 bit integer */
 
@@ -59,14 +62,6 @@ typedef uint8           halDataAlign_t; /* !< Used for byte alignment */
 
 #ifndef BF
     #define BF(x,b,s)  (((x) & (b)) >> (s))
-#endif
-
-#ifndef MIN
-    #define MIN(n,m)   (((n) < (m)) ? (n) : (m))
-#endif
-
-#ifndef MAX
-    #define MAX(n,m)   (((n) < (m)) ? (m) : (n))
 #endif
 
 #ifndef ABS


### PR DESCRIPTION
## Summary

nuttx: Use MIN/MAX definitions from "sys/param.h"

Follow the PR  https://github.com/apache/nuttx/pull/8397

Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

phy6222/nsh