### PR TITLE
esp32c3: fix cpuint issue

### DIFF
--- a/arch/risc-v/include/esp32c3/irq.h
+++ b/arch/risc-v/include/esp32c3/irq.h
@@ -46,8 +46,7 @@
 
 /* RESERVED interrupts: 0 to 14 */
 
-#define ESP32C3_PERIPH_MAC                 0  /* Reserved, but needed by WiFi driver */
-#define ESP32C3_PERIPH_MAC_NMI             1  /* Reserved, but needed by WiFi driver */
+#define ESP32C3_PERIPH_WMAC                1  /* Reserved, but needed by WiFi driver */
 
 #define ESP32C3_PERIPH_BT_BB               5 /* Reserved, but needed by BLE driver */
 #define ESP32C3_PERIPH_RWBLE               8 /* Reserved, but needed by BLE driver */
@@ -119,11 +118,7 @@
 #define ESP32C3_NCPUINTS               32
 #define ESP32C3_CPUINT_MAX             (ESP32C3_NCPUINTS - 1)
 
-#define ESP32C3_CPUINT_MAC             0
-#define ESP32C3_CPUINT_MAC_NMI         1
-
-#define ESP32C3_CPUINT_BT_BB           5
-#define ESP32C3_CPUINT_RWBLE_IRQ       8
+#define ESP32C3_CPUINT_ALWAYS_RSVD     0
 
 #define ESP32C3_CPUINT_PERIPHSET       0xffffffff
 
@@ -149,8 +144,7 @@
 
 /* Peripheral IRQs */
 
-#define ESP32C3_IRQ_MAC                 (ESP32C3_IRQ_FIRSTPERIPH + ESP32C3_PERIPH_MAC)
-#define ESP32C3_IRQ_MAC_NMI             (ESP32C3_IRQ_FIRSTPERIPH + ESP32C3_PERIPH_MAC_NMI)
+#define ESP32C3_IRQ_WMAC                (ESP32C3_IRQ_FIRSTPERIPH + ESP32C3_PERIPH_WMAC)
 
 #define ESP32C3_IRQ_BT_BB               (ESP32C3_IRQ_FIRSTPERIPH + ESP32C3_PERIPH_BT_BB)
 #define ESP32C3_IRQ_RWBLE               (ESP32C3_IRQ_FIRSTPERIPH + ESP32C3_PERIPH_RWBLE)

--- a/arch/risc-v/src/esp32c3/esp32c3_irq.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_irq.c
@@ -88,6 +88,14 @@
 #  define ESP32C3_WIFI_RESERVE_INT  (1 << ESP32C3_CPUINT_ALWAYS_RSVD)
 #endif
 
+#ifdef CONFIG_ESP32C3_BLE
+#  define ESP32C3_BLE_RESERVE_INT ((1 << ESP32C3_CPUINT_ALWAYS_RSVD) | \
+                                   (1 << ESP32C3_CPUINT_BT_BB) | \
+                                   (1 << ESP32C3_CPUINT_RWBLE))
+#else
+#  define ESP32C3_BLE_RESERVE_INT  (1 << ESP32C3_CPUINT_ALWAYS_RSVD)
+#endif
+
 /****************************************************************************
  * Private Data
  ****************************************************************************/
@@ -103,7 +111,8 @@ static volatile uint8_t g_irqmap[NR_IRQS];
  */
 
 static uint32_t g_cpu_freeints = ESP32C3_CPUINT_PERIPHSET &
-                                 (~ESP32C3_WIFI_RESERVE_INT);
+                                 (~ESP32C3_WIFI_RESERVE_INT &
+                                  ~ESP32C3_BLE_RESERVE_INT);
 
 /****************************************************************************
  * Private Functions

--- a/arch/risc-v/src/esp32c3/esp32c3_wifi_adapter.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_wifi_adapter.c
@@ -979,7 +979,7 @@ static void esp32c3_ints_on(uint32_t mask)
 
   wlinfo("INFO mask=%08lx irq=%d\n", mask, n);
 
-  up_enable_irq(ESP32C3_IRQ_MAC_NMI);
+  up_enable_irq(ESP32C3_IRQ_WMAC);
 }
 
 /****************************************************************************
@@ -1002,7 +1002,7 @@ static void esp32c3_ints_off(uint32_t mask)
 
   wlinfo("INFO mask=%08lx irq=%d\n", mask, n);
 
-  up_disable_irq(ESP32C3_IRQ_MAC_NMI);
+  up_disable_irq(ESP32C3_IRQ_WMAC);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
The CPUINT 0 is reserved, but it was allowed to be allocated
## Impact
It will avoid issues with allocating CPU INT
## Testing
esp32c3-devkit
