### PR TITLE
misc/mutex: fix assertion if nxmutex_reset() before nxmutex_unlock()

### DIFF
--- a/include/nuttx/mutex.h
+++ b/include/nuttx/mutex.h
@@ -248,12 +248,10 @@ int nxmutex_unlock(FAR mutex_t *mutex);
  * Parameters:
  *   mutex - mutex descriptor.
  *
- * Return Value:
- *
  ****************************************************************************/
 
 #if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
-int nxmutex_reset(FAR mutex_t *mutex);
+void nxmutex_reset(FAR mutex_t *mutex);
 #endif
 
 /****************************************************************************
@@ -472,11 +470,9 @@ int nxrmutex_unlock(FAR rmutex_t *rmutex);
  * Parameters:
  *   rmutex - rmutex descriptor.
  *
- * Return Value:
- *
  ****************************************************************************/
 #if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
-int nxrmutex_reset(FAR rmutex_t *rmutex);
+void nxrmutex_reset(FAR rmutex_t *rmutex);
 #endif
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

misc/mutex: fix assertion if nxmutex_reset() before nxmutex_unlock()


sim/rpserver

```
NuttShell (NSH) NuttX-12.0.0
server> cu
_assert: Current Version: NuttX server 12.0.0 3ead669e7a-dirty Feb  2 2023 23:53:48 sim
_assert: Assertion failed : at file: libs/libc/misc/lib_mutex.c:303 task: cu 0x5662fff4
```


## Impact

N/A

## Testing

sim/rpserver