### PR TITLE
mmcsd/mmcsd_spi: remove redundant mmcsd_unlock()

### DIFF
--- a/drivers/mmcsd/mmcsd_spi.c
+++ b/drivers/mmcsd/mmcsd_spi.c
@@ -1734,7 +1734,6 @@ static int mmcsd_mediainitialize(FAR struct mmcsd_slot_s *slot)
     {
       ferr("ERROR: Send CMD0 failed: R1=%02" PRIx32 "\n", result);
       SPI_SELECT(spi, SPIDEV_MMCSD(0), false);
-      mmcsd_unlock(slot);
       return -EIO;
     }
 
@@ -1865,7 +1864,6 @@ static int mmcsd_mediainitialize(FAR struct mmcsd_slot_s *slot)
         {
           ferr("ERROR: Failed to exit IDLE state\n");
           SPI_SELECT(spi, SPIDEV_MMCSD(0), false);
-          mmcsd_unlock(slot);
           return -EIO;
         }
     }
@@ -1874,7 +1872,6 @@ static int mmcsd_mediainitialize(FAR struct mmcsd_slot_s *slot)
     {
       ferr("ERROR: Failed to identify card\n");
       SPI_SELECT(spi, SPIDEV_MMCSD(0), false);
-      mmcsd_unlock(slot);
       return -EIO;
     }
 
@@ -1886,7 +1883,6 @@ static int mmcsd_mediainitialize(FAR struct mmcsd_slot_s *slot)
     {
       ferr("ERROR: mmcsd_getcsd(CMD9) failed: %" PRId32 "\n", result);
       SPI_SELECT(spi, SPIDEV_MMCSD(0), false);
-      mmcsd_unlock(slot);
       return -EIO;
     }
 


### PR DESCRIPTION


## Summary

mmcsd/mmcsd_spi: remove redundant mmcsd_unlock()

Assertion on **lm3s6965-ek/qemu-flat** if enable **CONFIG_DEBUG_ASSERTIONS**:

```
_assert: Current Version: NuttX  12.0.0 666b224c35 Feb  3 2023 19:36:38 arm
_assert: Assertion failed : at file: misc/lib_mutex.c:336 task: nsh_main 0xb385
```

Backtrace:
```
nuttx/libs/libc/sched/sched_dumpstack.c:69
nuttx/sched/misc/assert.c:494
nuttx/libs/libc/assert/lib_assert.c:36
nuttx/libs/libc/misc/lib_mutex.c:336
nuttx/drivers/mmcsd/mmcsd_spi.c:421
nuttx/drivers/mmcsd/mmcsd_spi.c:2072
nuttx/boards/arm/tiva/lm3s6965-ek/src/lm_bringup.c:119 (discriminator 3)
nuttx/boards/boardctl.c:335
apps/nshlib/nsh_init.c:144
apps/system/nsh/nsh_main.c:68
nuttx/libs/libc/sched/task_startup.c:70 (discriminator 2)
nuttx/sched/task/task_start.c:134
```

Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

 **lm3s6965-ek/qemu-flat** and enable **CONFIG_DEBUG_ASSERTIONS**