### PR TITLE
sim/hcisocket: correct teardown device index

### DIFF
--- a/arch/sim/src/sim/posix/sim_hosthcisocket.c
+++ b/arch/sim/src/sim/posix/sim_hosthcisocket.c
@@ -196,7 +196,7 @@ int host_bthcisock_open(int dev_idx)
 
   /* We must bring the device down before binding to user channel */
 
-  err = ioctl(fd, HCIDEVDOWN, 0);
+  err = ioctl(fd, HCIDEVDOWN, dev_idx);
   if (err < 0)
     {
       return err;


### PR DESCRIPTION

## Summary

sim/hcisocket: correct teardown device index

Parameter of HCIDEVDOWN should be the corresponding device id, not 0

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

sim/bluetooth