### PR TITLE
tools: Fix Config.mk

### DIFF
--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -48,7 +48,7 @@ else ifeq ($(V),)
 endif
 
 ifeq ($(ECHO_BEGIN),)
-  export ECHO_BEGIN=@echo
+  export ECHO_BEGIN=@echo # keep a trailing space here
   export ECHO_END=
 endif
 


### PR DESCRIPTION
## Summary

- I noticed that the following build error happened on my machine.

  make -C sched libsched.a EXTRAFLAGS="-D__KERNEL__ " 
  make[1]: Entering directory '/mnt/m2ssd/opensource/RTOS/tmp/nuttx/sched'
  /bin/sh: 1: echoCC: clock/clock_initialize.c : not found

- This commit fixes this issue


## Impact

- Should be none

## Testing

- Build on ubuntu 18.04 x86_64
