### PR TITLE
drivers/syslog: correct Kconfig name

### DIFF
--- a/drivers/syslog/Kconfig
+++ b/drivers/syslog/Kconfig
@@ -188,8 +188,8 @@ comment "SYSLOG channels"
 
 config SYSLOG_DEVPATH
 	string "System log device"
-	default "/dev/kmsg" if CONFIG_RAMLOG_SYSLOG
-	default "/dev/ttyS1" if !CONFIG_RAMLOG_SYSLOG
+	default "/dev/kmsg" if RAMLOG_SYSLOG
+	default "/dev/ttyS1" if !RAMLOG_SYSLOG
 	---help---
 		The full path to the system logging device.  For the RAMLOG SYSLOG device,
 		this is normally "/dev/kmsg".  For character SYSLOG devices, it should be


### PR DESCRIPTION

## Summary

drivers/syslog: correct Kconfig name

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

ci-check