### PR TITLE
libc: Define _assert/__assert to avoid 3rd libary redefine them

### DIFF
--- a/include/assert.h
+++ b/include/assert.h
@@ -78,6 +78,11 @@
 #  define assert(f) ASSERT(f)
 #endif
 
+/* Suppress 3rd party library redefine _assert/__assert */
+
+#define _assert _assert
+#define __assert __assert
+
 /* Definition required for C11 compile-time assertion checking.  The
  * static_assert macro simply expands to the _Static_assert keyword.
  */


### PR DESCRIPTION
## Summary

since 3rd party library may skip define these macros if they are defined before

## Impact

Minor

## Testing

CI