### PR TITLE
fix a bug of strtold

### DIFF
--- a/libs/libc/stdlib/lib_strtold.c
+++ b/libs/libc/stdlib/lib_strtold.c
@@ -401,12 +401,10 @@ static long_double decfloat(FAR char *ptr, FAR char **endptr)
   else if (num_digit + num_decimal > ldbl_max_10_exp)
     {
       errno = ERANGE;
-      return ldbl_max * ldbl_max;
     }
   else if (num_digit + num_decimal < ldbl_min_10_exp)
     {
       errno = ERANGE;
-      return ldbl_min * ldbl_min;
     }
 
   if (k % 9)


### PR DESCRIPTION
## Summary
  if input is -1e308,The output should be -100000000......
  but the output is -inf

See discussion here: https://github.com/apache/nuttx/pull/7992

## Impact

## Testing

sim:lua