### PR TITLE
tools/Config: stack usage(.su) file should be removed on clean phase

### DIFF
--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -561,6 +561,10 @@ ifeq ($(CONFIG_ARCH_COVERAGE),y)
 	EXTRA = *.gcno *.gcda
 endif
 
+ifeq ($(CONFIG_STACK_USAGE),y)
+	EXTRA += *.su
+endif
+
 ifeq ($(CONFIG_WINDOWS_NATIVE),y)
 define CLEAN
 	$(Q) if exist *$(OBJEXT) (del /f /q *$(OBJEXT))


### PR DESCRIPTION
## Summary

tools/Config: stack usage(.su) file should be removed on clean phase

Signed-off-by: chao an <anchao@xiaomi.com>

enable CONFIG_STACK_USAGE, garbage persists after distclean:
```
nuttx$ make distclean
nuttx$ git status --ignored
HEAD detached at 9ea809fced
Ignored files:
  (use "git add -f <file>..." to include in what will be committed)
	.version
	arch/arm/src/arm_allocateheap.su
	arch/arm/src/arm_backtrace_unwind.su
	arch/arm/src/arm_checkstack.su
	arch/arm/src/arm_createstack.su
	arch/arm/src/arm_doirq.su
	arch/arm/src/arm_dumpnvic.su
	arch/arm/src/arm_exit.su
	arch/arm/src/arm_getintstack.su
	arch/arm/src/arm_hardfault.su
	arch/arm/src/arm_idle.su
	arch/arm/src/arm_initialize.su
	arch/arm/src/arm_initialstate.su
	arch/arm/src/arm_lowputs.su
	arch/arm/src/arm_mdelay.su
	arch/arm/src/arm_modifyreg16.su
```

Link PR:
https://github.com/apache/nuttx/pull/8177

## Impact

N/A

## Testing

enable  CONFIG_STACK_USAGE, and distclean the garbage


