### PR TITLE
net: Remove protocol argument from si_setup callback

### DIFF
--- a/include/nuttx/net/net.h
+++ b/include/nuttx/net/net.h
@@ -142,7 +142,7 @@ struct pollfd;  /* Forward reference */
 
 struct sock_intf_s
 {
-  CODE int        (*si_setup)(FAR struct socket *psock, int protocol);
+  CODE int        (*si_setup)(FAR struct socket *psock);
   CODE sockcaps_t (*si_sockcaps)(FAR struct socket *psock);
   CODE void       (*si_addref)(FAR struct socket *psock);
   CODE int        (*si_bind)(FAR struct socket *psock,

--- a/net/bluetooth/bluetooth_sockif.c
+++ b/net/bluetooth/bluetooth_sockif.c
@@ -48,7 +48,7 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-static int        bluetooth_setup(FAR struct socket *psock, int protocol);
+static int        bluetooth_setup(FAR struct socket *psock);
 static sockcaps_t bluetooth_sockcaps(FAR struct socket *psock);
 static void       bluetooth_addref(FAR struct socket *psock);
 static int        bluetooth_bind(FAR struct socket *psock,
@@ -149,7 +149,6 @@ static int bluetooth_sockif_alloc(FAR struct socket *psock)
  * Input Parameters:
  *   psock    A pointer to a user allocated socket structure to be
  *            initialized.
- *   protocol (see sys/socket.h)
  *
  * Returned Value:
  *   Zero (OK) is returned on success.  Otherwise, a negated errno value is
@@ -157,7 +156,7 @@ static int bluetooth_sockif_alloc(FAR struct socket *psock)
  *
  ****************************************************************************/
 
-static int bluetooth_setup(FAR struct socket *psock, int protocol)
+static int bluetooth_setup(FAR struct socket *psock)
 {
   /* Allocate the appropriate connection structure.  This reserves the
    * connection structure, it is unallocated at this point.  It will not

--- a/net/can/can.h
+++ b/net/can/can.h
@@ -90,7 +90,6 @@ struct can_conn_s
 
   /* CAN-specific content follows */
 
-  uint8_t protocol;                  /* Selected CAN protocol */
   int16_t crefs;                     /* Reference count */
 
   /* The following is a list of poll structures of threads waiting for

--- a/net/can/can_sockif.c
+++ b/net/can/can_sockif.c
@@ -48,7 +48,7 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-static int  can_setup(FAR struct socket *psock, int protocol);
+static int  can_setup(FAR struct socket *psock);
 static sockcaps_t can_sockcaps(FAR struct socket *psock);
 static void can_addref(FAR struct socket *psock);
 static int  can_bind(FAR struct socket *psock,
@@ -172,7 +172,6 @@ static uint16_t can_poll_eventhandler(FAR struct net_driver_s *dev,
  * Input Parameters:
  *   psock    - A pointer to a user allocated socket structure to be
  *              initialized.
- *   protocol - CAN socket protocol (see sys/socket.h)
  *
  * Returned Value:
  *   Zero (OK) is returned on success.  Otherwise, a negated errno value is
@@ -180,16 +179,17 @@ static uint16_t can_poll_eventhandler(FAR struct net_driver_s *dev,
  *
  ****************************************************************************/
 
-static int can_setup(FAR struct socket *psock, int protocol)
+static int can_setup(FAR struct socket *psock)
 {
   int domain = psock->s_domain;
   int type = psock->s_type;
+  int proto = psock->s_proto;
 
   /* Verify that the protocol is supported */
 
-  DEBUGASSERT((unsigned int)protocol <= UINT8_MAX);
+  DEBUGASSERT((unsigned int)proto <= UINT8_MAX);
 
-  switch (protocol)
+  switch (proto)
     {
       case 0:            /* INET subsystem for netlib_ifup */
       case CAN_RAW:      /* RAW sockets */
@@ -220,10 +220,6 @@ static int can_setup(FAR struct socket *psock, int protocol)
 
           return -ENOMEM;
         }
-
-      /* Initialize the connection instance */
-
-      conn->protocol = (uint8_t)protocol;
 
       /* Set the reference count on the connection structure.  This
        * reference count will be incremented only if the socket is

--- a/net/icmp/icmp_sockif.c
+++ b/net/icmp/icmp_sockif.c
@@ -44,7 +44,7 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-static int        icmp_setup(FAR struct socket *psock, int protocol);
+static int        icmp_setup(FAR struct socket *psock);
 static sockcaps_t icmp_sockcaps(FAR struct socket *psock);
 static void       icmp_addref(FAR struct socket *psock);
 static int        icmp_bind(FAR struct socket *psock,
@@ -100,7 +100,6 @@ const struct sock_intf_s g_icmp_sockif =
  * Input Parameters:
  *   psock    A pointer to a user allocated socket structure to be
  *            initialized.
- *   protocol (see sys/socket.h)
  *
  * Returned Value:
  *   Zero (OK) is returned on success.  Otherwise, a negated errno value is
@@ -108,11 +107,11 @@ const struct sock_intf_s g_icmp_sockif =
  *
  ****************************************************************************/
 
-static int icmp_setup(FAR struct socket *psock, int protocol)
+static int icmp_setup(FAR struct socket *psock)
 {
   /* Only SOCK_DGRAM and IPPROTO_ICMP are supported */
 
-  if (psock->s_type == SOCK_DGRAM && protocol == IPPROTO_ICMP)
+  if (psock->s_type == SOCK_DGRAM && psock->s_proto == IPPROTO_ICMP)
     {
       /* Allocate the IPPROTO_ICMP socket connection structure and save in
        * the new socket instance.

--- a/net/icmpv6/icmpv6_sockif.c
+++ b/net/icmpv6/icmpv6_sockif.c
@@ -44,7 +44,7 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-static int        icmpv6_setup(FAR struct socket *psock, int protocol);
+static int        icmpv6_setup(FAR struct socket *psock);
 static sockcaps_t icmpv6_sockcaps(FAR struct socket *psock);
 static void       icmpv6_addref(FAR struct socket *psock);
 static int        icmpv6_bind(FAR struct socket *psock,
@@ -100,7 +100,6 @@ const struct sock_intf_s g_icmpv6_sockif =
  * Input Parameters:
  *   psock    A pointer to a user allocated socket structure to be
  *            initialized.
- *   protocol (see sys/socket.h)
  *
  * Returned Value:
  *   Zero (OK) is returned on success.  Otherwise, a negated errno value is
@@ -108,11 +107,11 @@ const struct sock_intf_s g_icmpv6_sockif =
  *
  ****************************************************************************/
 
-static int icmpv6_setup(FAR struct socket *psock, int protocol)
+static int icmpv6_setup(FAR struct socket *psock)
 {
   /* Only SOCK_DGRAM and IPPROTO_ICMP6 are supported */
 
-  if (psock->s_type == SOCK_DGRAM && protocol == IPPROTO_ICMP6)
+  if (psock->s_type == SOCK_DGRAM && psock->s_proto == IPPROTO_ICMP6)
     {
       /* Allocate the IPPROTO_ICMP6 socket connection structure and save in
        * the new socket instance.

--- a/net/ieee802154/ieee802154_sockif.c
+++ b/net/ieee802154/ieee802154_sockif.c
@@ -46,7 +46,7 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-static int        ieee802154_setup(FAR struct socket *psock, int protocol);
+static int        ieee802154_setup(FAR struct socket *psock);
 static sockcaps_t ieee802154_sockcaps(FAR struct socket *psock);
 static void       ieee802154_addref(FAR struct socket *psock);
 static int        ieee802154_bind(FAR struct socket *psock,
@@ -139,7 +139,6 @@ static int ieee802154_sockif_alloc(FAR struct socket *psock)
  * Input Parameters:
  *   psock    A pointer to a user allocated socket structure to be
  *            initialized.
- *   protocol (see sys/socket.h)
  *
  * Returned Value:
  *   Zero (OK) is returned on success.  Otherwise, a negated errno value is
@@ -147,7 +146,7 @@ static int ieee802154_sockif_alloc(FAR struct socket *psock)
  *
  ****************************************************************************/
 
-static int ieee802154_setup(FAR struct socket *psock, int protocol)
+static int ieee802154_setup(FAR struct socket *psock)
 {
   /* Allocate the appropriate connection structure.  This reserves the
    * connection structure, it is unallocated at this point.  It will not

--- a/net/inet/inet_sockif.c
+++ b/net/inet/inet_sockif.c
@@ -62,7 +62,7 @@ union sockaddr_u
 
 #if defined(NET_UDP_HAVE_STACK) || defined(NET_TCP_HAVE_STACK)
 
-static int        inet_setup(FAR struct socket *psock, int protocol);
+static int        inet_setup(FAR struct socket *psock);
 static sockcaps_t inet_sockcaps(FAR struct socket *psock);
 static void       inet_addref(FAR struct socket *psock);
 static int        inet_bind(FAR struct socket *psock,
@@ -239,7 +239,7 @@ static int inet_udp_alloc(FAR struct socket *psock)
  *
  ****************************************************************************/
 
-static int inet_setup(FAR struct socket *psock, int protocol)
+static int inet_setup(FAR struct socket *psock)
 {
   /* Allocate the appropriate connection structure.  This reserves the
    * the connection structure is is unallocated at this point.  It will
@@ -252,9 +252,9 @@ static int inet_setup(FAR struct socket *psock, int protocol)
     {
 #ifdef CONFIG_NET_TCP
       case SOCK_STREAM:
-        if (protocol != 0 && protocol != IPPROTO_TCP)
+        if (psock->s_proto != 0 && psock->s_proto != IPPROTO_TCP)
           {
-            nerr("ERROR: Unsupported stream protocol: %d\n", protocol);
+            nerr("ERROR: Unsupported stream protocol: %d\n", psock->s_proto);
             return -EPROTONOSUPPORT;
           }
 
@@ -270,9 +270,10 @@ static int inet_setup(FAR struct socket *psock, int protocol)
 
 #ifdef CONFIG_NET_UDP
       case SOCK_DGRAM:
-        if (protocol != 0 && protocol != IPPROTO_UDP)
+        if (psock->s_proto != 0 && psock->s_proto != IPPROTO_UDP)
           {
-            nerr("ERROR: Unsupported datagram protocol: %d\n", protocol);
+            nerr("ERROR: Unsupported datagram protocol: %d\n",
+                 psock->s_proto);
             return -EPROTONOSUPPORT;
           }
 
@@ -2303,7 +2304,7 @@ int inet_close(FAR struct socket *psock)
  ****************************************************************************/
 
 FAR const struct sock_intf_s *
-  inet_sockif(sa_family_t family, int type, int protocol)
+inet_sockif(sa_family_t family, int type, int protocol)
 {
   DEBUGASSERT(family == PF_INET || family == PF_INET6);
 

--- a/net/local/local_sockif.c
+++ b/net/local/local_sockif.c
@@ -47,7 +47,7 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-static int        local_setup(FAR struct socket *psock, int protocol);
+static int        local_setup(FAR struct socket *psock);
 static sockcaps_t local_sockcaps(FAR struct socket *psock);
 static void       local_addref(FAR struct socket *psock);
 static int        local_bind(FAR struct socket *psock,
@@ -161,7 +161,6 @@ static int local_sockif_alloc(FAR struct socket *psock)
  * Input Parameters:
  *   psock    A pointer to a user allocated socket structure
  *            to be initialized.
- *   protocol (see sys/socket.h)
  *
  * Returned Value:
  *   Zero (OK) is returned on success.  Otherwise, a negated errno value is
@@ -169,7 +168,7 @@ static int local_sockif_alloc(FAR struct socket *psock)
  *
  ****************************************************************************/
 
-static int local_setup(FAR struct socket *psock, int protocol)
+static int local_setup(FAR struct socket *psock)
 {
   /* Allocate the appropriate connection structure.  This reserves the
    * connection structure, it is unallocated at this point.  It will not
@@ -183,7 +182,7 @@ static int local_setup(FAR struct socket *psock, int protocol)
     {
 #ifdef CONFIG_NET_LOCAL_STREAM
       case SOCK_STREAM:
-        if (protocol != 0 && protocol != IPPROTO_TCP)
+        if (psock->s_proto != 0 && psock->s_proto != IPPROTO_TCP)
           {
             return -EPROTONOSUPPORT;
           }
@@ -195,7 +194,7 @@ static int local_setup(FAR struct socket *psock, int protocol)
 
 #ifdef CONFIG_NET_LOCAL_DGRAM
       case SOCK_DGRAM:
-        if (protocol != 0 && protocol != IPPROTO_UDP)
+        if (psock->s_proto != 0 && psock->s_proto != IPPROTO_UDP)
           {
             return -EPROTONOSUPPORT;
           }

--- a/net/netlink/netlink.h
+++ b/net/netlink/netlink.h
@@ -68,7 +68,6 @@ struct netlink_conn_s
   uint32_t dst_pid;                  /* Destination port ID */
   uint32_t dst_groups;               /* Destination multicast groups mask */
   uint8_t crefs;                     /* Reference counts on this instance */
-  uint8_t protocol;                  /* See NETLINK_* definitions */
 
   /* poll() support */
 

--- a/net/pkt/pkt_sockif.c
+++ b/net/pkt/pkt_sockif.c
@@ -47,7 +47,7 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-static int        pkt_setup(FAR struct socket *psock, int protocol);
+static int        pkt_setup(FAR struct socket *psock);
 static sockcaps_t pkt_sockcaps(FAR struct socket *psock);
 static void       pkt_addref(FAR struct socket *psock);
 static int        pkt_bind(FAR struct socket *psock,
@@ -137,7 +137,6 @@ static int pkt_sockif_alloc(FAR struct socket *psock)
  * Input Parameters:
  *   psock    A pointer to a user allocated socket structure to be
  *            initialized.
- *   protocol (see sys/socket.h)
  *
  * Returned Value:
  *   Zero (OK) is returned on success.  Otherwise, a negated errno value is
@@ -145,7 +144,7 @@ static int pkt_sockif_alloc(FAR struct socket *psock)
  *
  ****************************************************************************/
 
-static int pkt_setup(FAR struct socket *psock, int protocol)
+static int pkt_setup(FAR struct socket *psock)
 {
   /* Allocate the appropriate connection structure.  This reserves the
    * connection structure, it is unallocated at this point.  It will not

--- a/net/rpmsg/rpmsg_sockif.c
+++ b/net/rpmsg/rpmsg_sockif.c
@@ -127,7 +127,7 @@ struct rpmsg_socket_conn_s
  * Private Function Prototypes
  ****************************************************************************/
 
-static int        rpmsg_socket_setup(FAR struct socket *psock, int protocol);
+static int        rpmsg_socket_setup(FAR struct socket *psock);
 static sockcaps_t rpmsg_socket_sockcaps(FAR struct socket *psock);
 static void       rpmsg_socket_addref(FAR struct socket *psock);
 static int        rpmsg_socket_bind(FAR struct socket *psock,
@@ -590,7 +590,7 @@ static int rpmsg_socket_setaddr(FAR struct rpmsg_socket_conn_s *conn,
   return 0;
 }
 
-static int rpmsg_socket_setup(FAR struct socket *psock, int protocol)
+static int rpmsg_socket_setup(FAR struct socket *psock)
 {
   FAR struct rpmsg_socket_conn_s *conn;
 

--- a/net/socket/socket.c
+++ b/net/socket/socket.c
@@ -95,7 +95,7 @@ int psock_socket(int domain, int type, int protocol,
 
   /* Get the socket interface */
 
-  sockif = net_sockif(domain, psock->s_type, protocol);
+  sockif = net_sockif(domain, psock->s_type, psock->s_proto);
   if (sockif == NULL)
     {
       nerr("ERROR: socket address family unsupported: %d\n", domain);
@@ -109,7 +109,7 @@ int psock_socket(int domain, int type, int protocol,
   DEBUGASSERT(sockif->si_setup != NULL);
   psock->s_sockif = sockif;
 
-  ret = sockif->si_setup(psock, protocol);
+  ret = sockif->si_setup(psock);
   if (ret >= 0)
     {
       FAR struct socket_conn_s *conn = psock->s_conn;

--- a/net/usrsock/usrsock_sockif.c
+++ b/net/usrsock/usrsock_sockif.c
@@ -41,8 +41,7 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-static int        usrsock_sockif_setup(FAR struct socket *psock,
-                                       int protocol);
+static int        usrsock_sockif_setup(FAR struct socket *psock);
 static sockcaps_t usrsock_sockif_sockcaps(FAR struct socket *psock);
 static void       usrsock_sockif_addref(FAR struct socket *psock);
 static int        usrsock_sockif_close(FAR struct socket *psock);
@@ -90,7 +89,6 @@ const struct sock_intf_s g_usrsock_sockif =
  * Input Parameters:
  *   psock    - A pointer to a user allocated socket structure to be
  *              initialized.
- *   protocol - (see sys/socket.h)
  *
  * Returned Value:
  *   Zero (OK) is returned on success.  Otherwise, a negated errno value is
@@ -98,7 +96,7 @@ const struct sock_intf_s g_usrsock_sockif =
  *
  ****************************************************************************/
 
-static int usrsock_sockif_setup(FAR struct socket *psock, int protocol)
+static int usrsock_sockif_setup(FAR struct socket *psock)
 {
   int ret;
 
@@ -111,7 +109,8 @@ static int usrsock_sockif_setup(FAR struct socket *psock, int protocol)
    * to open socket with kernel networking stack in this case.
    */
 
-  ret = usrsock_socket(psock->s_domain, psock->s_type, protocol, psock);
+  ret = usrsock_socket(psock->s_domain, psock->s_type, psock->s_proto,
+                       psock);
   if (ret == -ENETDOWN)
     {
       nwarn("WARNING: usrsock daemon is not running\n");


### PR DESCRIPTION
## Summary

since the implementor could get the same value from socket::s_proto.
Found in review: https://github.com/apache/nuttx/pull/8370

## Impact

Minor

## Testing

CI