### PR TITLE
net/ip: fix compile break if disable NET_TCP

### DIFF
--- a/drivers/net/slip.c
+++ b/drivers/net/slip.c
@@ -862,9 +862,6 @@ static int slip_txavail(FAR struct net_driver_s *dev)
 #ifdef CONFIG_NET_MCASTGROUP
 static int slip_addmac(FAR struct net_driver_s *dev, FAR const uint8_t *mac)
 {
-  FAR struct slip_driver_s *priv =
-    (FAR struct slip_driver_s *)dev->d_private;
-
   /* Add the MAC address to the hardware multicast routing table */
 
   return OK;
@@ -892,9 +889,6 @@ static int slip_addmac(FAR struct net_driver_s *dev, FAR const uint8_t *mac)
 #ifdef CONFIG_NET_MCASTGROUP
 static int slip_rmmac(FAR struct net_driver_s *dev, FAR const uint8_t *mac)
 {
-  FAR struct slip_driver_s *priv =
-    (FAR struct slip_driver_s *)dev->d_private;
-
   /* Add the MAC address to the hardware multicast routing table */
 
   return OK;

--- a/net/devif/ipv6_input.c
+++ b/net/devif/ipv6_input.c
@@ -54,12 +54,6 @@
 #include "ipfrag/ipfrag.h"
 
 /****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-#define PAYLOAD ((FAR uint8_t *)TCPIPv6BUF)
-
-/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -273,9 +267,9 @@ static int ipv6_in(FAR struct net_driver_s *dev)
 
   /* Parse IPv6 extension headers (parsed but ignored) */
 
-  payload  = PAYLOAD;     /* Assume payload starts right after IPv6 header */
-  iphdrlen = IPv6_HDRLEN; /* Total length of the IPv6 header */
-  nxthdr   = ipv6->proto; /* Next header determined by IPv6 header prototype */
+  payload  = IPBUF(IPv6_HDRLEN); /* Assume payload starts right after IPv6 header */
+  iphdrlen = IPv6_HDRLEN;        /* Total length of the IPv6 header */
+  nxthdr   = ipv6->proto;        /* Next header determined by IPv6 header prototype */
 
   while (ipv6_exthdr(nxthdr))
     {

--- a/net/ipfrag/ipv4_frag.c
+++ b/net/ipfrag/ipv4_frag.c
@@ -120,7 +120,7 @@ ipv4_fragin_getinfo(FAR struct iob_s *iob,
 
 static uint32_t ipv4_fragin_reassemble(FAR struct ip_fragsnode_s *node)
 {
-  FAR struct iob_s *head;
+  FAR struct iob_s *head = NULL;
   FAR struct ipv4_hdr_s *ipv4;
   FAR struct ip_fraglink_s *fraglink;
 

--- a/net/ipfrag/ipv6_frag.c
+++ b/net/ipfrag/ipv6_frag.c
@@ -171,7 +171,7 @@ static int32_t ipv6_fragin_getinfo(FAR struct iob_s *iob,
 
 static uint32_t ipv6_fragin_reassemble(FAR struct ip_fragsnode_s *node)
 {
-  FAR struct iob_s *head;
+  FAR struct iob_s *head = NULL;
   FAR struct ipv6_hdr_s *ipv6;
   FAR struct ip_fraglink_s *fraglink;
 

--- a/net/local/local_sendmsg.c
+++ b/net/local/local_sendmsg.c
@@ -65,10 +65,10 @@ static int local_sendctl(FAR struct local_conn_s *conn,
   FAR struct file *filep2;
   FAR struct file *filep;
   struct cmsghdr *cmsg;
-  int count;
+  int count = 0;
   int *fds;
   int ret;
-  int i;
+  int i = 0;
 
   net_lock();
 
@@ -412,7 +412,7 @@ ssize_t local_sendmsg(FAR struct socket *psock, FAR struct msghdr *msg,
   size_t len = msg->msg_iovlen;
 #ifdef CONFIG_NET_LOCAL_SCM
   FAR struct local_conn_s *conn = psock->s_conn;
-  int count;
+  int count = 0;
 
   if (msg->msg_control &&
       msg->msg_controllen > sizeof(struct cmsghdr))


### PR DESCRIPTION
## Summary

net/ip: fix compile break if disable NET_TCP

1.
```bash
ipfrag/ipv4_frag.c: In function ‘ipv4_fragin’:
ipfrag/ipv4_frag.c:184:22: warning: ‘head’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  184 |   ipv4->len[1] = head->io_pktlen & 0xff;
      |                  ~~~~^~~~~~~~~~~
ipfrag/ipv4_frag.c:123:21: note: ‘head’ was declared here
  123 |   FAR struct iob_s *head;
      |                     ^~~~
```

2.
```bash
devif/ipv6_input.c: In function ‘ipv6_in’:
devif/ipv6_input.c:60:33: error: ‘TCPIPv6BUF’ undeclared (first use in this function); did you mean ‘UDPIPv6BUF’?
   60 | #define PAYLOAD ((FAR uint8_t *)TCPIPv6BUF)
      |                                 ^~~~~~~~~~
```
3.
```bash
nat/ipv4_nat.c: In function ‘ipv4_nat_inbound_icmp’: nat/ipv4_nat.c:67:30: error: ‘TCP_HDRLEN’ undeclared (first use in this function); did you mean ‘UDP_HDRLEN’?
   67 |   ((proto) == IP_PROTO_TCP ? TCP_HDRLEN : \
      |                              ^~~~~~~~~~
nat/ipv4_nat.c:323:47: note: in expansion of macro ‘L4_HDRLEN’
  323 |             inner_l4hdrlen = MIN(inner_l4len, L4_HDRLEN(inner->proto));
      |                                               ^~~~~~~~~
```

4.
```bash
net/slip.c:865:29: warning: unused variable ‘priv’ [-Wunused-variable]
  865 |   FAR struct slip_driver_s *priv =
      |                             ^~~~
net/slip.c: In function ‘slip_rmmac’:
net/slip.c:895:29: warning: unused variable ‘priv’ [-Wunused-variable]
  895 |   FAR struct slip_driver_s *priv =
      |                             ^~~~
```
5.
```bash
local/local_sendmsg.c: In function ‘local_sendmsg’:
local/local_sendmsg.c:423:18: warning: ‘count’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  423 |           return count;
      |                  ^~~~~
local/local_sendmsg.c:131:11: warning: ‘i’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  131 |   while (i-- > 0)
      |          ~^~
local/local_sendmsg.c:71:7: note: ‘i’ was declared here
   71 |   int i;
      |       ^
```

Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

disable CONFIG_NET_TCP