### PR TITLE
driver/serial: Convert CR to LF in driver

### DIFF
--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -790,6 +790,11 @@ static ssize_t uart_read(FAR struct file *filep,
            * IUCLC - Not Posix
            * IXON/OXOFF - no xon/xoff flow control.
            */
+#else
+          if (dev->isconsole && ch == '\r')
+            {
+              ch = '\n';
+            }
 #endif
 
           /* Store the received character */
@@ -1423,7 +1428,6 @@ static int uart_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
               dev->tc_iflag = termiosp->c_iflag;
               dev->tc_oflag = termiosp->c_oflag;
               dev->tc_lflag = termiosp->c_lflag;
-
               ret = 0;
             }
             break;
@@ -1659,6 +1663,10 @@ int uart_register(FAR const char *path, FAR uart_dev_t *dev)
       /* Enable \n -> \r\n translation for the console */
 
       dev->tc_oflag = OPOST | ONLCR;
+
+      /* Convert CR to LF by default for console */
+
+      dev->tc_iflag |= ICRNL;
     }
 #endif
 

--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -1395,7 +1395,8 @@ static int uart_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         {
           case TCGETS:
             {
-              FAR struct termios *termiosp = (FAR struct termios *)arg;
+              FAR struct termios *termiosp = (FAR struct termios *)
+                                                (uintptr_t)arg;
 
               if (!termiosp)
                 {
@@ -1415,7 +1416,8 @@ static int uart_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
           case TCSETS:
             {
-              FAR struct termios *termiosp = (FAR struct termios *)arg;
+              FAR struct termios *termiosp = (FAR struct termios *)
+                                                (uintptr_t)arg;
 
               if (!termiosp)
                 {


### PR DESCRIPTION
## Summary

Enable the behavior by default for console, but configurable by termios.

Binary size:

Before:
   text    data     bss     dec     hex filename
 326460     409    8164  335033   51cb9 nuttx/nuttx

After:
   text    data     bss     dec     hex filename
 326478     409    8164  335051   51ccb nuttx/nuttx

I'm trying to let nsh get rid of the stdio by these steps:
1. Convert CR to LF in serial input (follow linux, this patch)
2. Support O_TEXT and O_BINARY to convert CR2LF in VFS layer
3. Remove CONFIG_EOL_IS_XXX confgis
4. Echo character in serial driver instead of nsh

## Impact
serial driver
## Testing
QEMU
