### PR TITLE
ioexpander/gpio:Add gpio_pin_register_byname

### DIFF
--- a/include/nuttx/ioexpander/gpio.h
+++ b/include/nuttx/ioexpander/gpio.h
@@ -184,9 +184,46 @@ extern "C"
  *   Register GPIO pin device driver at /dev/gpioN, where N is the provided
  *   minor number.
  *
+ * Input Parameters:
+ *   dev    - A pointer to a gpio_dev_s
+ *   minor  - An integer value to be concatenated with '/dev/gpio'
+ *            to form the device name.
+ *
+ * Returned Value:
+ *   Zero on success; A negated errno value is returned on a failure
+ *   all error values returned by inode_reserve:
+ *
+ *   EINVAL - 'path' is invalid for this operation
+ *   EEXIST - An inode already exists at 'path'
+ *   ENOMEM - Failed to allocate in-memory resources for the operation
+ *
  ****************************************************************************/
 
 int gpio_pin_register(FAR struct gpio_dev_s *dev, int minor);
+
+/****************************************************************************
+ * Name: gpio_pin_register_byname
+ *
+ * Description:
+ *   Register GPIO pin device driver with it's pin name.
+ *
+ * Input Parameters:
+ *   dev      - A pointer to a gpio_dev_s
+ *   pinname  - A pointer to the name to be concatenated with '/dev/'
+ *              to form the device name.
+ *
+ * Returned Value:
+ *   Zero on success; A negated errno value is returned on a failure
+ *   all error values returned by inode_reserve:
+ *
+ *   EINVAL - 'path' is invalid for this operation
+ *   EEXIST - An inode already exists at 'path'
+ *   ENOMEM - Failed to allocate in-memory resources for the operation
+ *
+ ****************************************************************************/
+
+int gpio_pin_register_byname(FAR struct gpio_dev_s *dev,
+                             FAR const char *pinname);
 
 /****************************************************************************
  * Name: gpio_pin_unregister
@@ -195,9 +232,44 @@ int gpio_pin_register(FAR struct gpio_dev_s *dev, int minor);
  *   Unregister GPIO pin device driver at /dev/gpioN, where N is the provided
  *   minor number.
  *
+ * Input Parameters:
+ *   dev    - A pointer to a gpio_dev_s
+ *   minor  - An integer value to be concatenated with '/dev/gpio'
+ *            to form the device name.
+ *
+ * Returned Value:
+ *   Zero on success; A negated value is returned on a failure
+ *   (all error values returned by inode_remove):
+ *
+ *   ENOENT - path does not exist.
+ *   EBUSY  - Ref count is not 0;
+ *
  ****************************************************************************/
 
 int gpio_pin_unregister(FAR struct gpio_dev_s *dev, int minor);
+
+/****************************************************************************
+ * Name: gpio_pin_unregister_byname
+ *
+ * Description:
+ *   Unregister GPIO pin device driver at /dev/pinname.
+ *
+ * Input Parameters:
+ *   dev      - A pointer to a gpio_dev_s
+ *   pinname  - A pointer to the name to be concatenated with '/dev/'
+ *              to form the device name.
+ *
+ *
+ * Returned Value:
+ *   Zero on success; A negated value is returned on a failure
+ *   (all error values returned by inode_remove):
+ *
+ *   ENOENT - path does not exist.
+ *   EBUSY  - Ref count is not 0;
+ ****************************************************************************/
+
+int gpio_pin_unregister_byname(FAR struct gpio_dev_s *dev,
+                               FAR const char *pinname);
 
 /****************************************************************************
  * Name: gpio_lower_half


### PR DESCRIPTION
## Summary

Allows creation simple of the GPIO devices by pin name

For Example:
```
/****************************************************************************
 * Private Types
 ****************************************************************************/

struct myboard_gpio_dev_s {
	struct gpio_dev_s dev;
	uint32_t pincfg;
	pin_interrupt_t callback;
};

...

/****************************************************************************
 * Name: myboard_gpio_register
 *
 * Description:
 *   Initialize GPIO driver for input pin.
 *
 * Input Parameters:
 *   pincfg - The pin configuration mask for the IO pin.
 *   pintype - The pin type
 *   devname - The name of the GPIO device path to register the IO pin as.
 *
 ****************************************************************************/

int myboard_gpio_register(uint32_t pincfg, enum gpio_pintype_e pintype,
			const char *devname)
{
	FAR struct myboard_gpio_dev_s *priv;

	priv = (myboard_gpio_dev_s *) kmm_zalloc(sizeof(struct myboard_gpio_dev_s));

	if (priv == NULL) {
		gpioerr("Failed to allocate myboard_gpio_dev_s struct ERRNO: %d\n", errno);
		return -1;
	}

	priv->dev.gp_pintype = pintype;
	priv->dev.gp_ops     = &myboard_gpio_ops;
	priv->pincfg         = pincfg;

	return gpio_pin_register_byname(&priv->dev, devname);
}

/****************************************************************************
 * Public Functions
 ****************************************************************************/

void myboard_gpio_init(void)
{
	(void)myboard_gpio_register(GPIO_nLED_RED,         GPIO_OUTPUT_PIN, "nLED_RED");
	(void)myboard_gpio_register(GPIO_nLED_GREEN,       GPIO_OUTPUT_PIN, "nLED_GREEN");
	(void)myboard_gpio_register(GPIO_nLED_BLUE,        GPIO_OUTPUT_PIN, "nLED_BLUE");
}
```
## Impact
None - New Method

## Testing

PX4 
