### PR TITLE
boards/stm32f4disco: add timer driver support

### DIFF
--- a/boards/arm/stm32/stm32f4discovery/Kconfig
+++ b/boards/arm/stm32/stm32f4discovery/Kconfig
@@ -49,6 +49,11 @@ config STM32F4DISCO_QETIMER
 	default 2
 	depends on SENSORS_QENCODER
 
+config STM32F4DISCO_TIMER
+	int "Timer to use with timer driver"
+	default 4
+	depends on TIMER
+
 config STM32F4DISCO_LIS3DSH
 	bool "Enable LIS3DSH driver for the IMU on STM32F4Discovery (rev. MB997C)"
 	default n

--- a/boards/arm/stm32/stm32f4discovery/src/stm32_bringup.c
+++ b/boards/arm/stm32/stm32f4discovery/src/stm32_bringup.c
@@ -351,6 +351,16 @@ int stm32_bringup(void)
     }
 #endif
 
+#ifdef CONFIG_TIMER
+  /* Initialize TIMER and register the TIMER device. */
+
+  ret = stm32_timer_driver_setup("/dev/timer0", CONFIG_STM32F4DISCO_TIMER);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: stm32_timer_driver_setup() failed: %d\n", ret);
+    }
+#endif
+
 #ifdef CONFIG_CAPTURE
   /* Initialize Capture and register the Capture driver. */
 


### PR DESCRIPTION
## Summary
- boards/stm32f4disco: add timer driver support

## Impact

## Testing
https://github.com/apache/nuttx-apps/pull/1551
