### PR TITLE
mips/ld scripts: Fix typo in comment (s/mappled/mapped/)

### DIFF
--- a/boards/mips/pic32mz/flipnclick-pic32mz/scripts/c32-debug.ld
+++ b/boards/mips/pic32mz/flipnclick-pic32mz/scripts/c32-debug.ld
@@ -32,7 +32,7 @@ MEMORY
     /* The PIC32MZ2048ECH144 and PIC32MZ2048ECM144 chips have 160Kb of boot
      * FLASH:  80Kb at physical address 0x1fc4000 (Boot Flash 1, boot1) and
      * 80Kb at physical address 0x1fc60000 (Boot Flash 2, boot2).  Either
-     * may be mappled to the lower boot alias region (0x1fc00000,
+     * may be mapped to the lower boot alias region (0x1fc00000,
      * boolalias1) or the upper boot alias region (0x1fc20000, bootalias2).
      * This linker script assumes that Boot Flash 1 is mapped to the lower
      * alias region and Boot Flash 2 to the upper region.

--- a/boards/mips/pic32mz/flipnclick-pic32mz/scripts/mips-debug.ld
+++ b/boards/mips/pic32mz/flipnclick-pic32mz/scripts/mips-debug.ld
@@ -32,7 +32,7 @@ MEMORY
     /* The PIC32MZ2048ECH144 and PIC32MZ2048ECM144 chips have 160Kb of boot
      * FLASH:  80Kb at physical address 0x1fc4000 (Boot Flash 1, boot1) and
      * 80Kb at physical address 0x1fc60000 (Boot Flash 2, boot2).  Either
-     * may be mappled to the lower boot alias region (0x1fc00000,
+     * may be mapped to the lower boot alias region (0x1fc00000,
      * boolalias1) or the upper boot alias region (0x1fc20000, bootalias2).
      * This linker script assumes that Boot Flash 1 is mapped to the lower
      * alias region and Boot Flash 2 to the upper region.

--- a/boards/mips/pic32mz/flipnclick-pic32mz/scripts/pinguino-debug.ld
+++ b/boards/mips/pic32mz/flipnclick-pic32mz/scripts/pinguino-debug.ld
@@ -32,7 +32,7 @@ MEMORY
     /* The PIC32MZ2048ECH144 and PIC32MZ2048ECM144 chips have 160Kb of boot
      * FLASH:  80Kb at physical address 0x1fc4000 (Boot Flash 1, boot1) and
      * 80Kb at physical address 0x1fc60000 (Boot Flash 2, boot2).  Either
-     * may be mappled to the lower boot alias region (0x1fc00000,
+     * may be mapped to the lower boot alias region (0x1fc00000,
      * boolalias1) or the upper boot alias region (0x1fc20000, bootalias2).
      * This linker script assumes that Boot Flash 1 is mapped to the lower
      * alias region and Boot Flash 2 to the upper region.

--- a/boards/mips/pic32mz/flipnclick-pic32mz/scripts/xc32-debug.ld
+++ b/boards/mips/pic32mz/flipnclick-pic32mz/scripts/xc32-debug.ld
@@ -32,7 +32,7 @@ MEMORY
     /* The PIC32MZ2048ECH144 and PIC32MZ2048ECM144 chips have 160Kb of boot
      * FLASH:  80Kb at physical address 0x1fc4000 (Boot Flash 1, boot1) and
      * 80Kb at physical address 0x1fc60000 (Boot Flash 2, boot2).  Either
-     * may be mappled to the lower boot alias region (0x1fc00000,
+     * may be mapped to the lower boot alias region (0x1fc00000,
      * boolalias1) or the upper boot alias region (0x1fc20000, bootalias2).
      * This linker script assumes that Boot Flash 1 is mapped to the lower
      * alias region and Boot Flash 2 to the upper region.

--- a/boards/mips/pic32mz/pic32mz-starterkit/scripts/c32-debug.ld
+++ b/boards/mips/pic32mz/pic32mz-starterkit/scripts/c32-debug.ld
@@ -32,7 +32,7 @@ MEMORY
     /* The PIC32MZ2048ECH144 and PIC32MZ2048ECM144 chips have 160Kb of boot
      * FLASH:  80Kb at physical address 0x1fc4000 (Boot Flash 1, boot1) and
      * 80Kb at physical address 0x1fc60000 (Boot Flash 2, boot2).  Either
-     * may be mappled to the lower boot alias region (0x1fc00000,
+     * may be mapped to the lower boot alias region (0x1fc00000,
      * boolalias1) or the upper boot alias region (0x1fc20000, bootalias2).
      * This linker script assumes that Boot Flash 1 is mapped to the lower
      * alias region and Boot Flash 2 to the upper region.

--- a/boards/mips/pic32mz/pic32mz-starterkit/scripts/mips-debug.ld
+++ b/boards/mips/pic32mz/pic32mz-starterkit/scripts/mips-debug.ld
@@ -32,7 +32,7 @@ MEMORY
     /* The PIC32MZ2048ECH144 and PIC32MZ2048ECM144 chips have 160Kb of boot
      * FLASH:  80Kb at physical address 0x1fc4000 (Boot Flash 1, boot1) and
      * 80Kb at physical address 0x1fc60000 (Boot Flash 2, boot2).  Either
-     * may be mappled to the lower boot alias region (0x1fc00000,
+     * may be mapped to the lower boot alias region (0x1fc00000,
      * boolalias1) or the upper boot alias region (0x1fc20000, bootalias2).
      * This linker script assumes that Boot Flash 1 is mapped to the lower
      * alias region and Boot Flash 2 to the upper region.

--- a/boards/mips/pic32mz/pic32mz-starterkit/scripts/pinguino-debug.ld
+++ b/boards/mips/pic32mz/pic32mz-starterkit/scripts/pinguino-debug.ld
@@ -32,7 +32,7 @@ MEMORY
     /* The PIC32MZ2048ECH144 and PIC32MZ2048ECM144 chips have 160Kb of boot
      * FLASH:  80Kb at physical address 0x1fc4000 (Boot Flash 1, boot1) and
      * 80Kb at physical address 0x1fc60000 (Boot Flash 2, boot2).  Either
-     * may be mappled to the lower boot alias region (0x1fc00000,
+     * may be mapped to the lower boot alias region (0x1fc00000,
      * boolalias1) or the upper boot alias region (0x1fc20000, bootalias2).
      * This linker script assumes that Boot Flash 1 is mapped to the lower
      * alias region and Boot Flash 2 to the upper region.

--- a/boards/mips/pic32mz/pic32mz-starterkit/scripts/xc32-debug.ld
+++ b/boards/mips/pic32mz/pic32mz-starterkit/scripts/xc32-debug.ld
@@ -32,7 +32,7 @@ MEMORY
     /* The PIC32MZ2048ECH144 and PIC32MZ2048ECM144 chips have 160Kb of boot
      * FLASH:  80Kb at physical address 0x1fc4000 (Boot Flash 1, boot1) and
      * 80Kb at physical address 0x1fc60000 (Boot Flash 2, boot2).  Either
-     * may be mappled to the lower boot alias region (0x1fc00000,
+     * may be mapped to the lower boot alias region (0x1fc00000,
      * boolalias1) or the upper boot alias region (0x1fc20000, bootalias2).
      * This linker script assumes that Boot Flash 1 is mapped to the lower
      * alias region and Boot Flash 2 to the upper region.


### PR DESCRIPTION
## Summary

Fixes a typo in the explanation of PIC32MZ linker scripts.

## Impact

Documentation correctness only. No functional change.

## Testing

N/A