### PR TITLE
serial: Fix typo in comments (s/besued/because/)

### DIFF
--- a/arch/arm/src/lpc43xx/lpc43_serial.c
+++ b/arch/arm/src/lpc43xx/lpc43_serial.c
@@ -1065,7 +1065,7 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
           }
 
         /* TODO:  Handle other termios settings.
-         * Note that only cfgetispeed is used besued we have knowledge
+         * Note that only cfgetispeed is used because we have knowledge
          * that only one speed is supported.
          */
 

--- a/arch/mips/src/pic32mx/pic32mx_serial.c
+++ b/arch/mips/src/pic32mx/pic32mx_serial.c
@@ -606,7 +606,7 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
           }
 
         /* TODO:  Handle other termios settings.
-         * Note that only cfgetispeed is used besued we have knowledge
+         * Note that only cfgetispeed is used because we have knowledge
          * that only one speed is supported.
          */
 

--- a/arch/mips/src/pic32mz/pic32mz_serial.c
+++ b/arch/mips/src/pic32mz/pic32mz_serial.c
@@ -858,7 +858,7 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
           }
 
         /* TODO:  Handle other termios settings.
-         * Note that only cfgetispeed is used besued we have knowledge
+         * Note that only cfgetispeed is used because we have knowledge
          * that only one speed is supported.
          */
 

--- a/arch/sparc/src/bm3803/bm3803-serial.c
+++ b/arch/sparc/src/bm3803/bm3803-serial.c
@@ -618,7 +618,7 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
           }
 
         /* TODO:  Handle other termios settings.
-         * Note that only cfgetispeed is used besued we have knowledge
+         * Note that only cfgetispeed is used because we have knowledge
          * that only one speed is supported.
          */
 

--- a/arch/sparc/src/bm3823/bm3823-serial.c
+++ b/arch/sparc/src/bm3823/bm3823-serial.c
@@ -614,7 +614,7 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
           }
 
         /* TODO:  Handle other termios settings.
-         * Note that only cfgetispeed is used besued we have knowledge
+         * Note that only cfgetispeed is used because we have knowledge
          * that only one speed is supported.
          */
 

--- a/arch/sparc/src/s698pm/s698pm-serial.c
+++ b/arch/sparc/src/s698pm/s698pm-serial.c
@@ -680,7 +680,7 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
           }
 
         /* TODO:  Handle other termios settings.
-         * Note that only cfgetispeed is used besued we have knowledge
+         * Note that only cfgetispeed is used because we have knowledge
          * that only one speed is supported.
          */
 


### PR DESCRIPTION
## Summary

In various serial lower half drivers, fix copy-paste typo in comment (`s/besued/because/`).

## Impact

Correctness of documentation.

No functional change.

## Testing

N/A