### PR TITLE
arch/tiva: Fix inability to control serial CTS/RTS via termios

### DIFF
--- a/arch/arm/src/tiva/common/tiva_serial.c
+++ b/arch/arm/src/tiva/common/tiva_serial.c
@@ -1193,15 +1193,25 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
 
         /* Perform some sanity checks before accepting any changes */
 
-        if (termiosp->c_cflag & CRTSCTS)
+#ifndef CONFIG_SERIAL_OFLOWCONTROL
+        if (termiosp->c_cflag & CCTS_OFLOW)
           {
-            /* We don't support for flow control right now, so we report an
-             * error
-             */
+            /* CTS not supported in this build, so report error */
 
             ret = -EINVAL;
             break;
           }
+#endif /* !CONFIG_SERIAL_OFLOWCONTROL */
+
+#ifndef CONFIG_SERIAL_IFLOWCONTROL
+        if (termiosp->c_cflag & CRTS_IFLOW)
+          {
+            /* RTS not supported in this build, so report error */
+
+            ret = -EINVAL;
+            break;
+          }
+#endif /* !CONFIG_SERIAL_IFLOWCONTROL */
 
         if (termiosp->c_cflag & PARENB)
           {


### PR DESCRIPTION

## Summary

For Tiva architecture, PR #8406 added support for configuring the serial port's CTS/RTS flow control at runtime using termios when built with `CONFIG_SERIAL_TERMIOS` and either or both of `CONFIG_SERIAL_OFLOWCONTROL` and/or `CONFIG_SERIAL_IFLOWCONTROL`.

However, a runtime sanity check left over from before prevented this from working: When processing ioctl TCSETS, we would return `-EINVAL` if one or both of `CCTS_OFLOW` and/or `CRTS_IFLOW` were requested, regardless if the above Kconfigs were enabled or not.

Fixing the sanity checks.

## Impact

On Tiva architecture, CTS/RTS can be configured via termios now.

## Testing

Custom board.