### PR TITLE
group_addrenv: Fix call to group_addrenv for targets that don't need it

### DIFF
--- a/arch/arm/src/arm/arm_doirq.c
+++ b/arch/arm/src/arm/arm_doirq.c
@@ -29,11 +29,11 @@
 #include <nuttx/arch.h>
 #include <assert.h>
 
+#include <nuttx/addrenv.h>
 #include <nuttx/board.h>
 #include <arch/board/board.h>
 
 #include "arm_internal.h"
-#include "group/group.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -95,7 +95,7 @@ void arm_doirq(int irq, uint32_t *regs)
        * thread at the head of the ready-to-run list.
        */
 
-      group_addrenv(NULL);
+      addrenv_switch(NULL);
     }
 #endif
 

--- a/arch/arm/src/arm/arm_syscall.c
+++ b/arch/arm/src/arm/arm_syscall.c
@@ -29,10 +29,10 @@
 #include <debug.h>
 #include <syscall.h>
 
+#include <nuttx/addrenv.h>
 #include <nuttx/arch.h>
 
 #include "arm_internal.h"
-#include "group/group.h"
 
 /****************************************************************************
  * Public Functions
@@ -165,7 +165,7 @@ uint32_t *arm_syscall(uint32_t *regs)
        * thread at the head of the ready-to-run list.
        */
 
-      group_addrenv(NULL);
+      addrenv_switch(NULL);
     }
 #endif
 

--- a/arch/arm/src/dm320/dm320_decodeirq.c
+++ b/arch/arm/src/dm320/dm320_decodeirq.c
@@ -30,9 +30,10 @@
 #include <assert.h>
 #include <debug.h>
 
+#include <nuttx/addrenv.h>
+
 #include "chip.h"
 #include "arm_internal.h"
-#include "group/group.h"
 
 /****************************************************************************
  * Public Functions
@@ -99,7 +100,7 @@ uint32_t *arm_decodeirq(uint32_t *regs)
                * thread at the head of the ready-to-run list.
                */
 
-              group_addrenv(NULL);
+              addrenv_switch(NULL);
             }
 #endif
 

--- a/arch/arm/src/imx1/imx_decodeirq.c
+++ b/arch/arm/src/imx1/imx_decodeirq.c
@@ -30,9 +30,10 @@
 #include <assert.h>
 #include <debug.h>
 
+#include <nuttx/addrenv.h>
+
 #include "chip.h"
 #include "arm_internal.h"
-#include "group/group.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -115,7 +116,7 @@ uint32_t *arm_decodeirq(uint32_t *regs)
                * thread at the head of the ready-to-run list.
                */
 
-              group_addrenv(NULL);
+              addrenv_switch(NULL);
             }
 #endif
         }

--- a/arch/arm/src/lpc31xx/lpc31_decodeirq.c
+++ b/arch/arm/src/lpc31xx/lpc31_decodeirq.c
@@ -28,12 +28,12 @@
 #include <assert.h>
 #include <debug.h>
 
+#include <nuttx/addrenv.h>
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
 
 #include "chip.h"
 #include "arm_internal.h"
-#include "group/group.h"
 
 #include "lpc31_intc.h"
 
@@ -105,7 +105,7 @@ uint32_t *arm_decodeirq(uint32_t *regs)
                * thread at the head of the ready-to-run list.
                */
 
-              group_addrenv(NULL);
+              addrenv_switch(NULL);
             }
 #endif
 

--- a/arch/arm64/src/common/arm64_doirq.c
+++ b/arch/arm64/src/common/arm64_doirq.c
@@ -28,13 +28,14 @@
 #include <assert.h>
 #include <sched.h>
 #include <debug.h>
+
+#include <nuttx/addrenv.h>
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
 
 #include "task/task.h"
 #include "sched/sched.h"
-#include "group/group.h"
 #include "irq/irq.h"
 #include "arm64_arch.h"
 #include "arm64_internal.h"
@@ -88,7 +89,7 @@ uint64_t *arm64_doirq(int irq, uint64_t * regs)
        * thread at the head of the ready-to-run list.
        */
 
-      group_addrenv(NULL);
+      addrenv_switch(NULL);
 #endif
 
       /* Restore the cpu lock */

--- a/arch/arm64/src/common/arm64_syscall.c
+++ b/arch/arm64/src/common/arm64_syscall.c
@@ -211,7 +211,7 @@ uint64_t *arm64_syscall_switch(uint64_t * regs)
        * thread at the head of the ready-to-run list.
        */
 
-      group_addrenv(NULL);
+      addrenv_switch(NULL);
 #endif
 
     /* Restore the cpu lock */

--- a/arch/avr/src/avr32/avr_doirq.c
+++ b/arch/avr/src/avr32/avr_doirq.c
@@ -27,13 +27,13 @@
 #include <stdint.h>
 #include <assert.h>
 
+#include <nuttx/addrenv.h>
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
 #include <arch/board/board.h>
 
 #include "avr_internal.h"
-#include "group/group.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -97,7 +97,7 @@ uint32_t *avr_doirq(int irq, uint32_t *regs)
        * thread at the head of the ready-to-run list.
        */
 
-      group_addrenv(NULL);
+      addrenv_switch(NULL);
 #endif
     }
 #endif

--- a/arch/avr/src/avr32/avr_switchcontext.c
+++ b/arch/avr/src/avr32/avr_switchcontext.c
@@ -27,11 +27,12 @@
 #include <sched.h>
 #include <assert.h>
 #include <debug.h>
+
+#include <nuttx/addrenv.h>
 #include <nuttx/arch.h>
 #include <nuttx/sched.h>
 
 #include "sched/sched.h"
-#include "group/group.h"
 #include "clock/clock.h"
 #include "avr_internal.h"
 
@@ -92,7 +93,7 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
        * thread at the head of the ready-to-run list.
        */
 
-      group_addrenv(tcb);
+      addrenv_switch(tcb);
 #endif
       /* Update scheduler parameters */
 

--- a/arch/avr/src/common/avr_exit.c
+++ b/arch/avr/src/common/avr_exit.c
@@ -27,6 +27,7 @@
 #include <sched.h>
 #include <debug.h>
 
+#include <nuttx/addrenv.h>
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
 #ifdef CONFIG_DUMP_ON_EXIT
@@ -140,7 +141,7 @@ void up_exit(int status)
    * the ready-to-run list.
    */
 
-  group_addrenv(tcb);
+  addrenv_switch(tcb);
 #endif
 
   /* Then switch contexts */

--- a/arch/hc/src/common/hc_doirq.c
+++ b/arch/hc/src/common/hc_doirq.c
@@ -27,13 +27,13 @@
 #include <stdint.h>
 #include <assert.h>
 
+#include <nuttx/addrenv.h>
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
 #include <arch/board/board.h>
 
 #include "hc_internal.h"
-#include "group/group.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -97,7 +97,7 @@ uint8_t *hc_doirq(int irq, uint8_t *regs)
        * thread at the head of the ready-to-run list.
        */
 
-      group_addrenv(NULL);
+      addrenv_switch(NULL);
 #endif
     }
 #endif

--- a/arch/hc/src/common/hc_exit.c
+++ b/arch/hc/src/common/hc_exit.c
@@ -140,7 +140,7 @@ void up_exit(int status)
    * the ready-to-run list.
    */
 
-  group_addrenv(tcb);
+  addrenv_switch(tcb);
 #endif
 
   /* Then switch contexts */

--- a/arch/hc/src/common/hc_switchcontext.c
+++ b/arch/hc/src/common/hc_switchcontext.c
@@ -27,11 +27,12 @@
 #include <sched.h>
 #include <assert.h>
 #include <debug.h>
+
+#include <nuttx/addrenv.h>
 #include <nuttx/arch.h>
 #include <nuttx/sched.h>
 
 #include "sched/sched.h"
-#include "group/group.h"
 #include "clock/clock.h"
 #include "hc_internal.h"
 
@@ -95,7 +96,7 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
        * thread at the head of the ready-to-run list.
        */
 
-      group_addrenv(tcb);
+      addrenv_switch(tcb);
 #endif
       /* Update scheduler parameters */
 

--- a/arch/mips/src/mips32/mips_doirq.c
+++ b/arch/mips/src/mips32/mips_doirq.c
@@ -27,13 +27,13 @@
 #include <stdint.h>
 #include <assert.h>
 
+#include <nuttx/addrenv.h>
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
 #include <arch/board/board.h>
 
 #include "mips_internal.h"
-#include "group/group.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -103,7 +103,7 @@ uint32_t *mips_doirq(int irq, uint32_t *regs)
        * thread at the head of the ready-to-run list.
        */
 
-      group_addrenv(NULL);
+      addrenv_switch(NULL);
 #endif
     }
 #endif

--- a/arch/mips/src/pic32mx/pic32mx_decodeirq.c
+++ b/arch/mips/src/pic32mx/pic32mx_decodeirq.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 #include <assert.h>
 
+#include <nuttx/addrenv.h>
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
@@ -37,8 +38,6 @@
 #include "mips_internal.h"
 #include "pic32mx_int.h"
 #include "pic32mx.h"
-
-#include "group/group.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -157,7 +156,7 @@ uint32_t *pic32mx_decodeirq(uint32_t *regs)
        * thread at the head of the ready-to-run list.
        */
 
-      group_addrenv(NULL);
+      addrenv_switch(NULL);
 #endif
     }
 #endif

--- a/arch/mips/src/pic32mz/pic32mz_decodeirq.c
+++ b/arch/mips/src/pic32mz/pic32mz_decodeirq.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 #include <assert.h>
 
+#include <nuttx/addrenv.h>
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
@@ -36,8 +37,6 @@
 
 #include "mips_internal.h"
 #include "hardware/pic32mz_int.h"
-
-#include "group/group.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -156,7 +155,7 @@ uint32_t *pic32mz_decodeirq(uint32_t *regs)
        * thread at the head of the ready-to-run list.
        */
 
-      group_addrenv(NULL);
+      addrenv_switch(NULL);
 #endif
     }
 #endif

--- a/arch/misoc/src/lm32/lm32_doirq.c
+++ b/arch/misoc/src/lm32/lm32_doirq.c
@@ -28,6 +28,7 @@
 #include <assert.h>
 #include <debug.h>
 
+#include <nuttx/addrenv.h>
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
@@ -35,7 +36,6 @@
 #include <arch/irq.h>
 #include <arch/board/board.h>
 
-#include "group/group.h"
 #include "lm32.h"
 
 /****************************************************************************
@@ -88,7 +88,7 @@ uint32_t *lm32_doirq(int irq, uint32_t *regs)
        * thread at the head of the ready-to-run list.
        */
 
-      group_addrenv(NULL);
+      addrenv_switch(NULL);
 #endif
     }
 #endif

--- a/arch/misoc/src/minerva/minerva_doirq.c
+++ b/arch/misoc/src/minerva/minerva_doirq.c
@@ -28,6 +28,7 @@
 #include <assert.h>
 #include <debug.h>
 
+#include <nuttx/addrenv.h>
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
@@ -35,7 +36,6 @@
 #include <arch/irq.h>
 #include <arch/board/board.h>
 
-#include "group/group.h"
 #include "minerva.h"
 
 /****************************************************************************
@@ -87,7 +87,7 @@ uint32_t *minerva_doirq(int irq, uint32_t * regs)
        * the ready-to-run list.
        */
 
-      group_addrenv(NULL);
+      addrenv_switch(NULL);
 #  endif
     }
 #endif

--- a/arch/or1k/src/common/or1k_exit.c
+++ b/arch/or1k/src/common/or1k_exit.c
@@ -27,6 +27,7 @@
 #include <sched.h>
 #include <debug.h>
 
+#include <nuttx/addrenv.h>
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
 #ifdef CONFIG_DUMP_ON_EXIT
@@ -141,7 +142,7 @@ void up_exit(int status)
    * the ready-to-run list.
    */
 
-  group_addrenv(tcb);
+  addrenv_switch(tcb);
 #endif
 
   /* Then switch contexts */

--- a/arch/or1k/src/common/or1k_switchcontext.c
+++ b/arch/or1k/src/common/or1k_switchcontext.c
@@ -27,11 +27,12 @@
 #include <sched.h>
 #include <assert.h>
 #include <debug.h>
+
+#include <nuttx/addrenv.h>
 #include <nuttx/arch.h>
 #include <nuttx/sched.h>
 
 #include "sched/sched.h"
-#include "group/group.h"
 #include "clock/clock.h"
 #include "or1k_internal.h"
 
@@ -99,7 +100,7 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
        * thread at the head of the ready-to-run list.
        */
 
-      group_addrenv(tcb);
+      addrenv_switch(tcb);
 #endif
       /* Update scheduler parameters */
 

--- a/arch/renesas/src/common/renesas_doirq.c
+++ b/arch/renesas/src/common/renesas_doirq.c
@@ -100,7 +100,7 @@ uint32_t *renesas_doirq(int irq, uint32_t * regs)
            * thread at the head of the ready-to-run list.
            */
 
-          group_addrenv(NULL);
+          addrenv_switch(NULL);
 #endif
         }
 

--- a/arch/renesas/src/common/renesas_exit.c
+++ b/arch/renesas/src/common/renesas_exit.c
@@ -140,7 +140,7 @@ void up_exit(int status)
    * the ready-to-run list.
    */
 
-  group_addrenv(tcb);
+  addrenv_switch(tcb);
 #endif
 
   /* Then switch contexts */

--- a/arch/renesas/src/common/renesas_switchcontext.c
+++ b/arch/renesas/src/common/renesas_switchcontext.c
@@ -27,11 +27,12 @@
 #include <sched.h>
 #include <assert.h>
 #include <debug.h>
+
+#include <nuttx/addrenv.h>
 #include <nuttx/arch.h>
 #include <nuttx/sched.h>
 
 #include "sched/sched.h"
-#include "group/group.h"
 #include "clock/clock.h"
 #include "renesas_internal.h"
 
@@ -95,7 +96,7 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
        * thread at the head of the ready-to-run list.
        */
 
-      group_addrenv(tcb);
+      addrenv_switch(tcb);
 #endif
       /* Update scheduler parameters */
 

--- a/arch/sparc/src/sparc_v8/sparc_v8_doirq.c
+++ b/arch/sparc/src/sparc_v8/sparc_v8_doirq.c
@@ -27,13 +27,13 @@
 #include <stdint.h>
 #include <assert.h>
 
+#include <nuttx/addrenv.h>
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
 #include <arch/board/board.h>
 
 #include "sparc_internal.h"
-#include "group/group.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -98,7 +98,7 @@ uint32_t *sparc_doirq(int irq, uint32_t *regs)
        * thread at the head of the ready-to-run list.
        */
 
-      group_addrenv(NULL);
+      addrenv_switch(NULL);
 #endif
     }
 #endif

--- a/arch/x86/src/common/x86_exit.c
+++ b/arch/x86/src/common/x86_exit.c
@@ -27,6 +27,7 @@
 #include <sched.h>
 #include <debug.h>
 
+#include <nuttx/addrenv.h>
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
 #ifdef CONFIG_DUMP_ON_EXIT
@@ -142,7 +143,7 @@ void up_exit(int status)
    * the ready-to-run list.
    */
 
-  group_addrenv(tcb);
+  addrenv_switch(tcb);
 #endif
 
   /* Then switch contexts */

--- a/arch/x86/src/common/x86_switchcontext.c
+++ b/arch/x86/src/common/x86_switchcontext.c
@@ -27,11 +27,12 @@
 #include <sched.h>
 #include <assert.h>
 #include <debug.h>
+
+#include <nuttx/addrenv.h>
 #include <nuttx/arch.h>
 #include <nuttx/sched.h>
 
 #include "sched/sched.h"
-#include "group/group.h"
 #include "clock/clock.h"
 #include "x86_internal.h"
 
@@ -95,7 +96,7 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
        * thread at the head of the ready-to-run list.
        */
 
-      group_addrenv(tcb);
+      addrenv_switch(tcb);
 #endif
       /* Update scheduler parameters */
 

--- a/arch/x86/src/qemu/qemu_handlers.c
+++ b/arch/x86/src/qemu/qemu_handlers.c
@@ -113,7 +113,7 @@ static uint32_t *common_handler(int irq, uint32_t *regs)
        * thread at the head of the ready-to-run list.
        */
 
-      group_addrenv(NULL);
+      addrenv_switch(NULL);
 #endif
     }
 #endif

--- a/arch/x86_64/src/common/x86_64_exit.c
+++ b/arch/x86_64/src/common/x86_64_exit.c
@@ -146,7 +146,7 @@ void up_exit(int status)
    * the ready-to-run list.
    */
 
-  group_addrenv(tcb);
+  addrenv_switch(tcb);
 #endif
 
   /* Then switch contexts */

--- a/arch/x86_64/src/common/x86_64_switchcontext.c
+++ b/arch/x86_64/src/common/x86_64_switchcontext.c
@@ -27,13 +27,13 @@
 #include <sched.h>
 #include <assert.h>
 #include <debug.h>
+#include <nuttx/addrenv.h>
 #include <nuttx/arch.h>
 #include <nuttx/sched.h>
 
 #include <stdio.h>
 
 #include "sched/sched.h"
-#include "group/group.h"
 #include "clock/clock.h"
 #include "x86_64_internal.h"
 
@@ -101,7 +101,7 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
        * thread at the head of the ready-to-run list.
        */
 
-      group_addrenv(tcb);
+      addrenv_switch(tcb);
 #endif
       /* Update scheduler parameters */
 

--- a/arch/x86_64/src/intel64/intel64_handlers.c
+++ b/arch/x86_64/src/intel64/intel64_handlers.c
@@ -25,6 +25,7 @@
 #include <nuttx/config.h>
 #include <nuttx/compiler.h>
 
+#include <nuttx/addrenv.h>
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
 #include <nuttx/signal.h>
@@ -99,7 +100,7 @@ static uint64_t *common_handler(int irq, uint64_t *regs)
        * thread at the head of the ready-to-run list.
        */
 
-      group_addrenv(NULL);
+      addrenv_switch(NULL);
 #endif
     }
 #endif

--- a/arch/xtensa/src/common/xtensa_irqdispatch.c
+++ b/arch/xtensa/src/common/xtensa_irqdispatch.c
@@ -29,13 +29,13 @@
 #include <nuttx/arch.h>
 #include <assert.h>
 
+#include <nuttx/addrenv.h>
 #include <nuttx/board.h>
 #include <arch/board/board.h>
 #include <arch/chip/core-isa.h>
 
 #include "xtensa.h"
 
-#include "group/group.h"
 #include "sched/sched.h"
 
 /****************************************************************************
@@ -80,7 +80,7 @@ uint32_t *xtensa_irq_dispatch(int irq, uint32_t *regs)
        * thread at the head of the ready-to-run list.
        */
 
-      group_addrenv(NULL);
+      addrenv_switch(NULL);
 #endif
     }
 #endif


### PR DESCRIPTION
## Summary
Changes group_addrenv() -> addrenv_switch() for platforms that do not implement address environments, for completeness.

Follow up to #8355 
## Impact
None, just renaming a call to group_addrenv
## Testing
CI pass
