### PR TITLE
fix visual studio Compiler Error

### DIFF
--- a/fs/vfs/fs_epoll.c
+++ b/fs/vfs/fs_epoll.c
@@ -453,7 +453,7 @@ int epoll_ctl(int epfd, int op, int fd, FAR struct epoll_event *ev)
             eph->size += eph->size;
           }
 
-        epn = list_remove_head_type(&eph->free, epoll_node_t, node);
+        epn = container_of(list_remove_head(&eph->free), epoll_node_t, node);
         epn->data        = ev->data;
         epn->pfd.events  = ev->events;
         epn->pfd.fd      = fd;

--- a/include/nuttx/fs/smart.h
+++ b/include/nuttx/fs/smart.h
@@ -114,6 +114,8 @@ struct smart_procfs_data_s
 #ifdef CONFIG_MTD_SMART_ERASE_DEBUG
   const uint16_t  *erasecounts;   /* Pointer to the erase counts array */
   uint16_t        erasesize;      /* Number of entries in the erase counts array */
+#else
+  uint8_t         __pad;
 #endif
 };
 #endif

--- a/include/nuttx/lib/math.h
+++ b/include/nuttx/lib/math.h
@@ -74,15 +74,19 @@
 
 /* General Constants ********************************************************/
 
-#define INFINITY    (1.0/0.0)
-#define NAN         (0.0/0.0)
-#define HUGE_VAL    INFINITY
+#ifndef _HUGE_ENUF
+#  define _HUGE_ENUF (1e+300)  /* _HUGE_ENUF*_HUGE_ENUF must overflow */
+#endif
 
-#define INFINITY_F  (1.0F/0.0F)
-#define NAN_F       (0.0F/0.0F)
+#define INFINITY   ((double)(_HUGE_ENUF * _HUGE_ENUF))
+#define NAN        ((double)(INFINITY * 0.0F))
+#define HUGE_VAL   INFINITY
 
-#define INFINITY_L  (1.0L/0.0L)
-#define NAN_L       (0.0L/0.0L)
+#define INFINITY_F ((float)INFINITY)
+#define NAN_F      ((float)(INFINITY * 0.0F))
+
+#define INFINITY_L ((long double)INFINITY)
+#define NAN_L      ((long double)(INFINITY * 0.0F))
 
 #define isnan(x)   ((x) != (x))
 #define isnanf(x)  ((x) != (x))

--- a/include/nuttx/net/netdev.h
+++ b/include/nuttx/net/netdev.h
@@ -162,7 +162,8 @@
  */
 
 #define IPBUF(hl) ((FAR void *)(IOB_DATA(dev->d_iob) + (hl)))
-#define NETLLBUF  (IPBUF(0) - NET_LL_HDRLEN(dev))
+#define NETLLBUF  ((FAR void *) \
+                   ((FAR uint8_t *)IPBUF(0) - NET_LL_HDRLEN(dev)))
 
 #define IPv4BUF ((FAR struct ipv4_hdr_s *)IPBUF(0))
 #define IPv6BUF ((FAR struct ipv6_hdr_s *)IPBUF(0))

--- a/include/nuttx/net/netfilter/ip_tables.h
+++ b/include/nuttx/net/netfilter/ip_tables.h
@@ -117,7 +117,7 @@ struct ipt_entry
 
   struct xt_counters counters; /* Packet and byte counters. */
 
-  unsigned char elems[0];      /* The matches (if any), then the target. */
+  unsigned char elems[1];      /* The matches (if any), then the target. */
 };
 
 /* Note 1: How entries are organized in following interface arguments.

--- a/include/nuttx/net/netfilter/x_tables.h
+++ b/include/nuttx/net/netfilter/x_tables.h
@@ -62,7 +62,7 @@ struct xt_entry_target
       uint16_t target_size; /* Total length */
     } u;
 
-  unsigned char data[0];
+  unsigned char data[1];
 };
 
 struct xt_standard_target

--- a/include/sys/sysinfo.h
+++ b/include/sys/sysinfo.h
@@ -39,20 +39,19 @@
 
 struct sysinfo
 {
-  unsigned long uptime;
-  unsigned long loads[3];
-  unsigned long totalram;
-  unsigned long freeram;
-  unsigned long sharedram;
-  unsigned long bufferram;
-  unsigned long totalswap;
-  unsigned long freeswap;
-  unsigned short procs;
-  unsigned short pad;
-  unsigned long totalhigh;
-  unsigned long freehigh;
-  unsigned mem_unit;
-  char __reserved[256];
+  unsigned long uptime;    /* Seconds since boot */
+  unsigned long loads[3];  /* 1, 5, and 15 minute load averages */
+  unsigned long totalram;  /* Total usable main memory size */
+  unsigned long freeram;   /* Available memory size */
+  unsigned long sharedram; /* Amount of shared memory */
+  unsigned long bufferram; /* Memory used by buffers */
+  unsigned long totalswap; /* Total swap space size */
+  unsigned long freeswap;  /* Swap space still available */
+  unsigned short procs;    /* Number of current processes */
+  unsigned short pad;      /* Padding for alignment */
+  unsigned long totalhigh; /* Total high memory size */
+  unsigned long freehigh;  /* Available high memory size */
+  unsigned mem_unit;       /* Memory unit size in bytes */
 };
 
 /****************************************************************************

--- a/libs/libc/math/lib_gamma.c
+++ b/libs/libc/math/lib_gamma.c
@@ -32,9 +32,12 @@
  *
  ****************************************************************************/
 
-/* "A Precision Approximation of the Gamma Function" - Cornelius Lanczos (1964)
- * "Lanczos Implementation of the Gamma Function" - Paul Godfrey (2001)
- * "An Analysis of the Lanczos Gamma Approximation" - Glendon Ralph Pugh (2004)
+/* "A Precision Approximation of the Gamma Function"
+ *   - Cornelius Lanczos (1964)
+ * "Lanczos Implementation of the Gamma Function"
+ *   - Paul Godfrey (2001)
+ * "An Analysis of the Lanczos Gamma Approximation"
+ *   - Glendon Ralph Pugh (2004)
  *
  * Approximation method:
  *
@@ -133,9 +136,10 @@ static const double g_sden[N + 1] =
 static const double g_fact[] =
 {
   1, 1, 2, 6, 24, 120, 720, 5040.0, 40320.0, 362880.0, 3628800.0, 39916800.0,
-  479001600.0, 6227020800.0, 87178291200.0, 1307674368000.0, 20922789888000.0,
-  355687428096000.0, 6402373705728000.0, 121645100408832000.0,
-  2432902008176640000.0, 51090942171709440000.0, 1124000727777607680000.0,
+  479001600.0, 6227020800.0, 87178291200.0, 1307674368000.0,
+  20922789888000.0, 355687428096000.0, 6402373705728000.0,
+  121645100408832000.0, 2432902008176640000.0, 51090942171709440000.0,
+  1124000727777607680000.0,
 };
 
 /* S(x) rational function for positive x */
@@ -151,6 +155,7 @@ static double sinpi(double x)
   int n;
 
   /* argument reduction: x = |x| mod 2 */
+
   /* spurious inexact when x is odd int */
 
   x = x * 0.5;
@@ -205,7 +210,7 @@ static double s(double x)
         }
     }
 
-  return num/den;
+  return num / den;
 }
 
 /****************************************************************************
@@ -219,6 +224,7 @@ double tgamma(double x)
       double f;
       uint64_t i;
     } u;
+
   u.f = x;
 
   double absx;
@@ -241,17 +247,19 @@ double tgamma(double x)
   if (ix < (0x3ff - 54) << 20)
     {
       /* |x| < 2^-54: tgamma(x) ~ 1/x, +-0 raises div-by-zero */
+
       return 1 / x;
     }
 
   /* integer arguments */
+
   /* raise inexact when non-integer */
 
   if (x == floor(x))
     {
       if (sign)
         {
-          return 0 / 0.0;
+          return NAN;
         }
 
       if (x <= sizeof g_fact / sizeof *g_fact)
@@ -261,6 +269,7 @@ double tgamma(double x)
     }
 
   /* x >= 172: tgamma(x)=inf with overflow */
+
   /* x =< -184: tgamma(x)=+-0 with underflow */
 
   if (ix >= 0x40670000)
@@ -269,11 +278,13 @@ double tgamma(double x)
 
       if (sign)
         {
-          FORCE_EVAL((float)(0x1p-126 / x));
+          FORCE_EVAL((float)(ldexp(1.0, -126) / x));
+
           if (floor(x) * 0.5 == floor(x * 0.5))
             {
               return 0;
             }
+
           return -0.0;
         }
 
@@ -302,6 +313,7 @@ double tgamma(double x)
   if (x < 0)
     {
       /* reflection formula for negative x */
+
       /* sinpi(absx) is not 0, integers are already handled */
 
       r = -pi / (sinpi(absx) * absx * r);

--- a/libs/libc/net/lib_inetpton.c
+++ b/libs/libc/net/lib_inetpton.c
@@ -107,7 +107,7 @@ static int inet_ipv4_pton(FAR const char *src, FAR void *dest)
 
   memset(dest, 0, sizeof(struct in_addr));
 
-  ip        = (uint8_t *)dest;
+  ip        = (FAR uint8_t *)dest;
   srcoffset = 0;
   numoffset = 0;
   ndots     = 0;
@@ -297,7 +297,8 @@ static int inet_ipv6_pton(FAR const char *src, FAR void *dest)
 
               if (nrsep > 0)
                 {
-                  memcpy(dest + (16 - (nrsep << 1)), &rip[0], nrsep << 1);
+                  memcpy((FAR uint8_t *)dest +
+                         (16 - (nrsep << 1)), &rip[0], nrsep << 1);
                 }
 
               /* Return 1 if the conversion succeeds */

--- a/mm/mempool/mempool_multiple.c
+++ b/mm/mempool/mempool_multiple.c
@@ -177,7 +177,7 @@ static void mempool_multiple_free_callback(FAR struct mempool_s *pool,
 {
   FAR struct mempool_multiple_s *mpool = pool->priv;
 
-  return mpool->free(mpool->arg, (FAR char *)addr - mpool->minpoolsize);
+  mpool->free(mpool->arg, (FAR char *)addr - mpool->minpoolsize);
 }
 
 /****************************************************************************

--- a/net/procfs/net_tcp.c
+++ b/net/procfs/net_tcp.c
@@ -60,8 +60,8 @@ static ssize_t netprocfs_tcpstats(FAR struct netprocfs_file_s *priv,
   int addrlen = (domain == PF_INET) ?
                 INET_ADDRSTRLEN : INET6_ADDRSTRLEN;
   FAR struct tcp_conn_s *conn = NULL;
-  char remote[addrlen + 1];
-  char local[addrlen + 1];
+  char remote[INET6_ADDRSTRLEN + 1];
+  char local[INET6_ADDRSTRLEN + 1];
   int len = 0;
   void *laddr;
   void *raddr;

--- a/net/procfs/net_udp.c
+++ b/net/procfs/net_udp.c
@@ -60,8 +60,8 @@ static ssize_t netprocfs_udpstats(FAR struct netprocfs_file_s *priv,
   int addrlen = (domain == PF_INET) ?
                 INET_ADDRSTRLEN : INET6_ADDRSTRLEN;
   FAR struct udp_conn_s *conn = NULL;
-  char remote[addrlen + 1];
-  char local[addrlen + 1];
+  char remote[INET6_ADDRSTRLEN + 1];
+  char local[INET6_ADDRSTRLEN + 1];
   int len = 0;
   void *laddr;
   void *raddr;


### PR DESCRIPTION
## Summary

1.
```bash
mm/mempool: fix visual studio Compiler Warning C4098

D:\archer\code\nuttx\mm\mempool\mempool_multiple.c(180,72): warning C4098: "mempool_multiple_free_callback":"void" void function returning a value

Compiler Warning C4098:
A function declared with return type void has a return statement that returns a value. The compiler assumes the function returns a value of type int.

Reference:
https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4098?view=msvc-170
```

2.
```bash
fs/epoll: fix visual studio Compiler Error C2059

D:\archer\code\nuttx\fs\vfs\fs_epoll.c(456,15): error C2059: syntax error : '{'

Compiler error C2059:
The token caused a syntax error.

Reference:
https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2059?view=msvc-170
```

3.
```bash
net/procfs: fix visual studio Compiler Error C2057

D:\archer\code\nuttx\net\procfs\net_tcp.c(63,15): error C2057: expected constant expression

Compiler error C2057:
The context requires a constant expression, an expression whose value is known at compile time.

Reference:
https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2057?view=msvc-170
```

4.
```bash
fs/smart: fix visual studio Compiler Error C2229

D:\archer\code\nuttx\include\nuttx/net/netfilter/x_tables.h(71,7):
  error C2229: type 'struct xt_standard_target' has an illegal zero-sized array

Compiler error C2229:
A member of a structure or bit field contains a zero-sized array that is not the last member.

Reference:
https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2229?view=msvc-170
```

5.
```bash
fs/smart: fix visual studio Compiler Error C2016

D:\archer\code\nuttx\include\nuttx/fs/smart.h(118,1):
  error C2016: C requires that a struct or union has at least one member

Compiler error C2016: C requires that a struct or union has at least one member

Reference:
https://docs.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-errors-c2001-through-c2099?view=msvc-170
```

6.
```bash
libs: workaround for Visual Studio(MSVC) Compiler Error C2124

D:\archer\code\nuttx\libs\libc\stdlib\lib_strtod.c: error C2124: divide or mod by zero

Windows MSVC restrictions, MSVC doesn't allow division through a
zero literal, but allows it through const variable set to zero

Reference:
https://docs.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2124?view=msvc-170
```

7.
```bash
sys/sysinfo: align sysinfo define with linux

__reserved is a meaningful macro definition in msvc, cannot use this name

Fix visual studio Compiler Error:
https://social.msdn.microsoft.com/Forums/vstudio/en-US/d86ad86b-47b7-4677-95fb-e28b3230a009/reserved-problem?forum=vclanguage
```

8.
```bash
libs: fix visual studio Compiler Error C2036

D:\code\nuttx\libs\libc\net\lib_inetpton.c(300,52): error C2036: "void *" : unknown size

Reference:
https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2036?view=msvc-170
```


## Impact

N/A

## Testing

cmake + visual studio 2022