### PR TITLE
sim: sim_saveusercontext & sim_fullcontextrestore update

### DIFF
--- a/arch/sim/src/sim/sim_doirq.c
+++ b/arch/sim/src/sim/sim_doirq.c
@@ -76,5 +76,5 @@ void *sim_doirq(int irq, void *context)
       sim_fullcontextrestore(regs);
     }
 
-  return regs;
+  return NULL;
 }

--- a/arch/sim/src/sim/sim_internal.h
+++ b/arch/sim/src/sim/sim_internal.h
@@ -88,10 +88,11 @@
 #define sim_saveusercontext(saveregs)                           \
     ({                                                          \
        irqstate_t flags = up_irq_flags();                       \
-       uint32_t *env = (uint32_t *)saveregs + JB_FLAG;          \
+       xcpt_reg_t *env = saveregs;                              \
+       uint32_t *val = (uint32_t *)&env[JB_FLAG];               \
                                                                 \
-       env[0] = flags & UINT32_MAX;                             \
-       env[1] = (flags >> 32) & UINT32_MAX;                     \
+       val[0] = flags & UINT32_MAX;                             \
+       val[1] = (flags >> 32) & UINT32_MAX;                     \
                                                                 \
        setjmp(saveregs);                                        \
     })


### PR DESCRIPTION
## Summary

sim: correct save irq flags error when use sim 64bits
sim: change sim_saveusercontext & sim_fullcontextrestore to inline function

## Impact

sim switch context

## Testing

VELA
