### PR TITLE
arch/xtensa/esp32s3: Add support for touch pad interrupts

### DIFF
--- a/arch/xtensa/src/esp32s2/esp32s2_touch.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_touch.c
@@ -689,6 +689,12 @@ void esp32s2_touchirqdisable(int irq)
  * Description:
  *   Register the release callback.
  *
+ * Input Parameters:
+ *   func - The handler function to be used.
+ *
+ * Returned Value:
+ *   None.
+ *
  ****************************************************************************/
 
 void esp32s2_touchregisterreleasecb(int (*func)(int, void *, void *))

--- a/arch/xtensa/src/esp32s3/esp32s3_touch.h
+++ b/arch/xtensa/src/esp32s3/esp32s3_touch.h
@@ -85,23 +85,23 @@ struct touch_config_s
  * external GPIO.
  */
 
-static const int touch_channel_to_gpio[] =
+static const int touch_channel_to_rtcio[] =
 {
   -1,
-  TOUCH_PAD_NUM1_GPIO_NUM,
-  TOUCH_PAD_NUM2_GPIO_NUM,
-  TOUCH_PAD_NUM3_GPIO_NUM,
-  TOUCH_PAD_NUM4_GPIO_NUM,
-  TOUCH_PAD_NUM5_GPIO_NUM,
-  TOUCH_PAD_NUM6_GPIO_NUM,
-  TOUCH_PAD_NUM7_GPIO_NUM,
-  TOUCH_PAD_NUM8_GPIO_NUM,
-  TOUCH_PAD_NUM9_GPIO_NUM,
-  TOUCH_PAD_NUM10_GPIO_NUM,
-  TOUCH_PAD_NUM11_GPIO_NUM,
-  TOUCH_PAD_NUM12_GPIO_NUM,
-  TOUCH_PAD_NUM13_GPIO_NUM,
-  TOUCH_PAD_NUM14_GPIO_NUM
+  TOUCH_PAD_NUM1_CHANNEL_NUM,
+  TOUCH_PAD_NUM2_CHANNEL_NUM,
+  TOUCH_PAD_NUM3_CHANNEL_NUM,
+  TOUCH_PAD_NUM4_CHANNEL_NUM,
+  TOUCH_PAD_NUM5_CHANNEL_NUM,
+  TOUCH_PAD_NUM6_CHANNEL_NUM,
+  TOUCH_PAD_NUM7_CHANNEL_NUM,
+  TOUCH_PAD_NUM8_CHANNEL_NUM,
+  TOUCH_PAD_NUM9_CHANNEL_NUM,
+  TOUCH_PAD_NUM10_CHANNEL_NUM,
+  TOUCH_PAD_NUM11_CHANNEL_NUM,
+  TOUCH_PAD_NUM12_CHANNEL_NUM,
+  TOUCH_PAD_NUM13_CHANNEL_NUM,
+  TOUCH_PAD_NUM14_CHANNEL_NUM
 };
 
 #undef EXTERN
@@ -155,6 +155,22 @@ int esp32s3_configtouch(enum touch_pad_e tp, struct touch_config_s config);
 bool esp32s3_touchread(enum touch_pad_e tp);
 
 /****************************************************************************
+ * Name: esp32s3_touchreadraw
+ *
+ * Description:
+ *   Read the analog value of a touch pad channel.
+ *
+ * Input Parameters:
+ *   tp - The touch pad channel.
+ *
+ * Returned Value:
+ *   The number of charge cycles in the last measurement.
+ *
+ ****************************************************************************/
+
+uint32_t esp32s3_touchreadraw(enum touch_pad_e tp);
+
+/****************************************************************************
  * Name: esp32s3_touchbenchmark
  *
  * Description:
@@ -186,6 +202,64 @@ uint32_t esp32s3_touchbenchmark(enum touch_pad_e tp);
  ****************************************************************************/
 
 void esp32s3_touchsetthreshold(enum touch_pad_e tp, uint32_t threshold);
+
+/****************************************************************************
+ * Name: esp32s3_touchirqenable
+ *
+ * Description:
+ *   Enable the interrupt for the specified touch pad.
+ *
+ * Input Parameters:
+ *   irq - The touch pad irq number.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_ESP32S3_TOUCH_IRQ
+void esp32s3_touchirqenable(int irq);
+#else
+#  define esp32s3_touchirqenable(irq)
+#endif
+
+/****************************************************************************
+ * Name: esp32s3_touchirqdisable
+ *
+ * Description:
+ *   Disable the interrupt for the specified touch pad.
+ *
+ * Input Parameters:
+ *   irq - The touch pad irq number.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_ESP32S3_TOUCH_IRQ
+void esp32s3_touchirqdisable(int irq);
+#else
+#  define esp32s3_touchirqdisable(irq)
+#endif
+
+/****************************************************************************
+ * Name: esp32s3_touchregisterreleasecb
+ *
+ * Description:
+ *   Register the release callback.
+ *
+ * Input Parameters:
+ *   func - The handler function to be used.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_ESP32S3_TOUCH_IRQ
+void esp32s3_touchregisterreleasecb(int (*func)(int, void *, void *));
+#endif
 
 #ifdef __cplusplus
 }

--- a/arch/xtensa/src/esp32s3/esp32s3_touch_lowerhalf.h
+++ b/arch/xtensa/src/esp32s3/esp32s3_touch_lowerhalf.h
@@ -996,7 +996,7 @@ static inline enum touch_conn_type_e
  *
  ****************************************************************************/
 
-static inline enum touch_pad_e touch_ll_get_current_meas_channel(void)
+static inline enum touch_pad_e touch_lh_get_current_meas_channel(void)
 {
   return (enum touch_pad_e)
     REG_GET_FIELD(SENS_SAR_TOUCH_STATUS0_REG,

--- a/arch/xtensa/src/esp32s3/hardware/esp32s3_touch.h
+++ b/arch/xtensa/src/esp32s3/hardware/esp32s3_touch.h
@@ -29,8 +29,9 @@
  * Pre-preprocessor Definitions
  ****************************************************************************/
 
-#define TOUCH_SENSOR_PINS           15
+#define TOUCH_SENSOR_PINS           (15)
 #define TOUCH_MEASURE_WAIT_MAX      (0xff)
+#define TOUCH_THRESHOLD_NO_USE      (0)
 
 /* The water rejection function is fixed to TOUCH_PAD_NUM14. */
 
@@ -49,6 +50,21 @@
 /* Note: T0 is an internal channel that does not have a corresponding
  * external GPIO.
  */
+
+#define TOUCH_PAD_NUM1_CHANNEL_NUM     1
+#define TOUCH_PAD_NUM2_CHANNEL_NUM     2
+#define TOUCH_PAD_NUM3_CHANNEL_NUM     3
+#define TOUCH_PAD_NUM4_CHANNEL_NUM     4
+#define TOUCH_PAD_NUM5_CHANNEL_NUM     5
+#define TOUCH_PAD_NUM6_CHANNEL_NUM     6
+#define TOUCH_PAD_NUM7_CHANNEL_NUM     7
+#define TOUCH_PAD_NUM8_CHANNEL_NUM     8
+#define TOUCH_PAD_NUM9_CHANNEL_NUM     9
+#define TOUCH_PAD_NUM10_CHANNEL_NUM    10
+#define TOUCH_PAD_NUM11_CHANNEL_NUM    11
+#define TOUCH_PAD_NUM12_CHANNEL_NUM    12
+#define TOUCH_PAD_NUM13_CHANNEL_NUM    13
+#define TOUCH_PAD_NUM14_CHANNEL_NUM    14
 
 #define TOUCH_PAD_NUM1_GPIO_NUM     1
 #define TOUCH_PAD_NUM2_GPIO_NUM     2


### PR DESCRIPTION
## Summary

Adds support for touch pad interrupts on ESP32-S3.

## Impact

Full compatibility with the buttons example.

## Testing

Tested using an ESP32-S3-DevKitC-1.