### PR TITLE
Revert "include/sys/socket.h: Add SOCK_CTRL to socket type"

### DIFF
--- a/include/nuttx/net/netconfig.h
+++ b/include/nuttx/net/netconfig.h
@@ -104,24 +104,52 @@
 
 #define NET_SOCK_PROTOCOL  0
 
-/* SOCK_CTRL is the preferred socket type to use when we just want a
- * socket for performing driver ioctls.
+/* SOCK_DGRAM is the preferred socket type to use when we just want a
+ * socket for performing driver ioctls.  However, we can't use SOCK_DRAM
+ * if UDP is disabled.
+ *
+ * Pick a socket type (and perhaps protocol) compatible with the currently
+ * selected address family.
  */
 
-#define NET_SOCK_TYPE SOCK_CTRL
-
 #if NET_SOCK_FAMILY == AF_INET
-#  if !defined(CONFIG_NET_UDP) && !defined(CONFIG_NET_TCP) && \
-      defined(CONFIG_NET_ICMP_SOCKET)
+#  if defined(CONFIG_NET_UDP)
+#    define NET_SOCK_TYPE SOCK_DGRAM
+#  elif defined(CONFIG_NET_TCP)
+#   define NET_SOCK_TYPE SOCK_STREAM
+#  elif defined(CONFIG_NET_ICMP_SOCKET)
+#   define NET_SOCK_TYPE SOCK_DGRAM
 #   undef NET_SOCK_PROTOCOL
 #   define NET_SOCK_PROTOCOL IPPROTO_ICMP
 #  endif
 #elif NET_SOCK_FAMILY == AF_INET6
-#  if !defined(CONFIG_NET_UDP) && !defined(CONFIG_NET_TCP) && \
-      defined(CONFIG_NET_ICMPv6_SOCKET)
+#  if defined(CONFIG_NET_UDP)
+#    define NET_SOCK_TYPE SOCK_DGRAM
+#  elif defined(CONFIG_NET_TCP)
+#   define NET_SOCK_TYPE SOCK_STREAM
+#  elif defined(CONFIG_NET_ICMPv6_SOCKET)
+#   define NET_SOCK_TYPE SOCK_DGRAM
 #   undef NET_SOCK_PROTOCOL
 #   define NET_SOCK_PROTOCOL IPPROTO_ICMP6
 #  endif
+#elif NET_SOCK_FAMILY == AF_LOCAL
+#  if defined(CONFIG_NET_LOCAL_DGRAM)
+#    define NET_SOCK_TYPE SOCK_DGRAM
+#  elif defined(CONFIG_NET_LOCAL_STREAM)
+#     define NET_SOCK_TYPE SOCK_STREAM
+#  endif
+#elif NET_SOCK_FAMILY == AF_PACKET
+#  define NET_SOCK_TYPE SOCK_RAW
+#elif NET_SOCK_FAMILY == AF_CAN
+#  define NET_SOCK_TYPE SOCK_RAW
+#elif NET_SOCK_FAMILY == AF_IEEE802154
+#  define NET_SOCK_TYPE SOCK_DGRAM
+#elif NET_SOCK_FAMILY == AF_BLUETOOTH
+#  define NET_SOCK_TYPE SOCK_RAW
+#elif NET_SOCK_FAMILY == AF_NETLINK
+#  define NET_SOCK_TYPE SOCK_DGRAM
+#elif NET_SOCK_FAMILY == AF_RPMSG
+#  define NET_SOCK_TYPE SOCK_STREAM
 #endif
 
 /* Eliminate dependencies on other header files.  This should not harm

--- a/include/sys/socket.h
+++ b/include/sys/socket.h
@@ -92,10 +92,6 @@
                                  * required to read an entire packet with each read
                                  * system call.
                                  */
-#define SOCK_CTRL      6        /* SOCK_CTRL is the preferred socket type to use
-                                 * when we just want a socket for performing driver
-                                 * ioctls. This definition is not POSIX compliant.
-                                 */
 #define SOCK_PACKET   10        /* Obsolete and should not be used in new programs */
 
 #define SOCK_CLOEXEC  02000000  /* Atomically set close-on-exec flag for the new

--- a/net/bluetooth/bluetooth_sockif.c
+++ b/net/bluetooth/bluetooth_sockif.c
@@ -166,7 +166,7 @@ static int bluetooth_setup(FAR struct socket *psock, int protocol)
    * Only SOCK_RAW is supported
    */
 
-  if (psock->s_type == SOCK_RAW || psock->s_type == SOCK_CTRL)
+  if (psock->s_type == SOCK_RAW)
     {
       return bluetooth_sockif_alloc(psock);
     }

--- a/net/can/can_sockif.c
+++ b/net/can/can_sockif.c
@@ -207,8 +207,7 @@ static int can_setup(FAR struct socket *psock, int protocol)
 
   /* Verify the socket type (domain should always be PF_CAN here) */
 
-  if (domain == PF_CAN &&
-      (type == SOCK_RAW || type == SOCK_DGRAM || type == SOCK_CTRL))
+  if (domain == PF_CAN && (type == SOCK_RAW || type == SOCK_DGRAM))
     {
       /* Allocate the CAN socket connection structure and save it in the
        * new socket instance.

--- a/net/icmp/icmp_sockif.c
+++ b/net/icmp/icmp_sockif.c
@@ -110,10 +110,9 @@ const struct sock_intf_s g_icmp_sockif =
 
 static int icmp_setup(FAR struct socket *psock, int protocol)
 {
-  /* Only SOCK_DGRAM or SOCK_CTRL and IPPROTO_ICMP are supported */
+  /* Only SOCK_DGRAM and IPPROTO_ICMP are supported */
 
-  if ((psock->s_type == SOCK_DGRAM || psock->s_type == SOCK_CTRL) &&
-       protocol == IPPROTO_ICMP)
+  if (psock->s_type == SOCK_DGRAM && protocol == IPPROTO_ICMP)
     {
       /* Allocate the IPPROTO_ICMP socket connection structure and save in
        * the new socket instance.

--- a/net/icmpv6/icmpv6_sockif.c
+++ b/net/icmpv6/icmpv6_sockif.c
@@ -110,10 +110,9 @@ const struct sock_intf_s g_icmpv6_sockif =
 
 static int icmpv6_setup(FAR struct socket *psock, int protocol)
 {
-  /* Only SOCK_DGRAM or SOCK_CTRL and IPPROTO_ICMP6 are supported */
+  /* Only SOCK_DGRAM and IPPROTO_ICMP6 are supported */
 
-  if ((psock->s_type == SOCK_DGRAM || psock->s_type == SOCK_CTRL) &&
-      protocol == IPPROTO_ICMP6)
+  if (psock->s_type == SOCK_DGRAM && protocol == IPPROTO_ICMP6)
     {
       /* Allocate the IPPROTO_ICMP6 socket connection structure and save in
        * the new socket instance.

--- a/net/ieee802154/ieee802154_sockif.c
+++ b/net/ieee802154/ieee802154_sockif.c
@@ -156,7 +156,7 @@ static int ieee802154_setup(FAR struct socket *psock, int protocol)
    * Only SOCK_DGRAM is supported (since the MAC header is stripped)
    */
 
-  if (psock->s_type == SOCK_DGRAM || psock->s_type == SOCK_CTRL)
+  if (psock->s_type == SOCK_DGRAM)
     {
       return ieee802154_sockif_alloc(psock);
     }

--- a/net/inet/inet_sockif.c
+++ b/net/inet/inet_sockif.c
@@ -286,30 +286,6 @@ static int inet_setup(FAR struct socket *psock, int protocol)
 #endif
 #endif /* CONFIG_NET_UDP */
 
-#if defined(CONFIG_NET_TCP) || defined(CONFIG_NET_UDP)
-      case SOCK_CTRL:
-#  ifdef NET_UDP_HAVE_STACK
-        if (protocol == 0 || protocol == IPPROTO_UDP)
-          {
-             /* Allocate and attach the UDP connection structure */
-
-             return inet_udp_alloc(psock);
-          }
-
-#  endif
-#  ifdef NET_TCP_HAVE_STACK
-        if (protocol == 0 || protocol == IPPROTO_TCP)
-          {
-             /* Allocate and attach the TCP connection structure */
-
-             return inet_tcp_alloc(psock);
-          }
-
-#  endif
-        nerr("ERROR: Unsupported control protocol: %d\n", protocol);
-        return -EPROTONOSUPPORT;
-#endif /* CONFIG_NET_TCP || CONFIG_NET_UDP */
-
       default:
         nerr("ERROR: Unsupported type: %d\n", psock->s_type);
         return -EPROTONOSUPPORT;
@@ -2334,8 +2310,7 @@ FAR const struct sock_intf_s *
 #if defined(HAVE_PFINET_SOCKETS) && defined(CONFIG_NET_ICMP_SOCKET)
   /* PF_INET, ICMP data gram sockets are a special case of raw sockets */
 
-  if (family == PF_INET && (type == SOCK_DGRAM || type == SOCK_CTRL) &&
-      protocol == IPPROTO_ICMP)
+  if (family == PF_INET && type == SOCK_DGRAM && protocol == IPPROTO_ICMP)
     {
       return &g_icmp_sockif;
     }
@@ -2344,8 +2319,7 @@ FAR const struct sock_intf_s *
 #if defined(HAVE_PFINET6_SOCKETS) && defined(CONFIG_NET_ICMPv6_SOCKET)
   /* PF_INET, ICMP data gram sockets are a special case of raw sockets */
 
-  if (family == PF_INET6 && (type == SOCK_DGRAM || type == SOCK_CTRL) &&
-      protocol == IPPROTO_ICMP6)
+  if (family == PF_INET6 && type == SOCK_DGRAM && protocol == IPPROTO_ICMP6)
     {
       return &g_icmpv6_sockif;
     }

--- a/net/local/local_sockif.c
+++ b/net/local/local_sockif.c
@@ -205,27 +205,6 @@ static int local_setup(FAR struct socket *psock, int protocol)
         return local_sockif_alloc(psock);
 #endif /* CONFIG_NET_LOCAL_DGRAM */
 
-      case SOCK_CTRL:
-#ifdef CONFIG_NET_LOCAL_STREAM
-        if (protocol == 0 || protocol == IPPROTO_TCP)
-          {
-            /* Allocate and attach the local connection structure */
-
-            return local_sockif_alloc(psock);
-          }
-
-#endif
-#ifdef CONFIG_NET_LOCAL_DGRAM
-        if (protocol == 0 || protocol == IPPROTO_UDP)
-          {
-            /* Allocate and attach the local connection structure */
-
-            return local_sockif_alloc(psock);
-          }
-
-#endif
-        return -EPROTONOSUPPORT;
-
       default:
         return -EPROTONOSUPPORT;
     }

--- a/net/netlink/netlink_sockif.c
+++ b/net/netlink/netlink_sockif.c
@@ -136,8 +136,7 @@ static int netlink_setup(FAR struct socket *psock, int protocol)
 
   /* Verify the socket type (domain should always be PF_NETLINK here) */
 
-  if (domain == PF_NETLINK &&
-      (type == SOCK_RAW || type == SOCK_DGRAM || type == SOCK_CTRL))
+  if (domain == PF_NETLINK && (type == SOCK_RAW || type == SOCK_DGRAM))
     {
       /* Allocate the NetLink socket connection structure and save it in the
        * new socket instance.

--- a/net/pkt/pkt_sockif.c
+++ b/net/pkt/pkt_sockif.c
@@ -154,7 +154,7 @@ static int pkt_setup(FAR struct socket *psock, int protocol)
    * Only SOCK_RAW is supported.
    */
 
-  if (psock->s_type == SOCK_RAW || psock->s_type == SOCK_CTRL)
+  if (psock->s_type == SOCK_RAW)
     {
       return pkt_sockif_alloc(psock);
     }


### PR DESCRIPTION
Reverts apache/nuttx#8370

See https://github.com/apache/nuttx/pull/8370#issuecomment-1422614654 for the details.

```
NuttShell (NSH) NuttX-10.4.0
nsh> uname -a
NuttX  10.4.0 abba05a934 Feb  8 2023 22:35:51 arm lm3s6965-ek
nsh> ps
  PID GROUP PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK   STACK   USED  FILLED COMMAND
    0     0   0 FIFO     Kthread N-- Ready              00000000 001000 000464  46.4%  Idle Task
    1     1 224 RR       Kthread --- Waiting  Semaphore 00000000 001992 000276  13.8%  hpwork 0x20001cd0
    2     2  60 RR       Kthread --- Waiting  Semaphore 00000000 001992 000276  13.8%  lpwork 0x20001ce8
    3     3 100 RR       Task    --- Running            00000000 002000 001168  58.4%  nsh_main
    4     4 100 RR       Task    --- Waiting  Semaphore 00000000 002008 000564  28.0%  telnetd
nsh> free
                   total       used       free    largest  nused  nfree
        Umem:      49616      16560      33056      33056     61      1
nsh> ifconfig
             IPv4   TCP   UDP  ICMP
Received     0000  0000  0000  0000
Dropped      0000  0000  0000  0000
  IPv4        VHL: 0000   Frg: 0000
  Checksum   0000  0000  0000  ----
  TCP         ACK: 0000   SYN: 0000
              RST: 0000  0000
  Type       0000  ----  ----  0000
Sent         0000  0000  0000  0000
  Rexmit     ----  0000  ----  ----
nsh> renew eth0
ERROR: dhcpc_open() for 'eth0' failed
nsh> ifconfig
             IPv4   TCP   UDP  ICMP
Received     0000  0000  0000  0000
Dropped      0000  0000  0000  0000
  IPv4        VHL: 0000   Frg: 0000
  Checksum   0000  0000  0000  ----
  TCP         ACK: 0000   SYN: 0000
              RST: 0000  0000
  Type       0000  ----  ----  0000
Sent         0000  0000  0000  0000
  Rexmit     ----  0000  ----  ----
```

The same issue happens with spresense:rndis, qemu-armv8a:netnsh, rv-virt:netnsh and so on.