### PR TITLE
arch/tiva: Serial TIOCxBRK BSD-compatible BREAK support

### DIFF
--- a/arch/arm/src/tiva/Kconfig
+++ b/arch/arm/src/tiva/Kconfig
@@ -1081,6 +1081,19 @@ config TIVA_HCIUART_SW_TXFLOW
 
 endmenu # HCI UART Driver Configuration
 
+config TIVA_UART_BREAKS
+	bool "Add TIOxSBRK to support sending Breaks"
+	depends on TIVA_UART0 || TIVA_UART1 || TIVA_UART2 || TIVA_UART3 || TIVA_UART4 || TIVA_UART5 || TIVA_UART6 || TIVA_UART7
+	default n
+	---help---
+		Add TIOCxBRK routines to send a BSD compatible line break.
+		TIOCSBRK will start the break and TIOCCBRK will end the break.
+		This implementation uses the BRK bit (bit 0) of the UART Line
+		Control register (UARTLCRH) to send the break. The break begins
+		after the UART finishes shifting out the current character in
+		progress, if any, including its stop bit(s), and continues
+		indefinitely until stopped by software.
+
 config TIVA_SSI0
 	bool "SSI0"
 	default n


### PR DESCRIPTION
## Summary

In the lower half UART driver for Tiva architecture (TM4C12x), adding the `TIOCxBRK` ioctl calls, which allow an application to transmit a BSD compatible line BREAK. `TIOCSBRK` starts the BREAK and `TIOCCBRK` ends it.

This architecture supports BSD-style BREAK in hardware. We write to the BRK bit (bit 0) of the UART Line Control register (UARTLCRH) to start the BREAK, which begins after the UART finishes shifting out the current character in progress, if any, including its stop bit(s), and continues indefinitely until we write to the BRK bit again to stop the BREAK.

## Impact

When new Kconfig option `TIVA_UART_BREAKS` is activated, `TIOCSBRK` and `TIOCCBRK` ioctl calls are supported on Tiva architectures. When not activated, no effect.

## Testing

Custom board.