### PR TITLE
Changes to allow board-specific SAMA5 DRP/OTG support

### DIFF
--- a/arch/arm/src/sama5/Kconfig
+++ b/arch/arm/src/sama5/Kconfig
@@ -3827,7 +3827,7 @@ if SAMA5_OHCI || SAMA5_EHCI
 config SAMA5_UHPHS_RHPORT1
 	bool "Use Port A"
 	default y
-	depends on !SAMA5_UDPHS
+	depends on !SAMA5_UDPHS || SAMA5_USB_DRP
 
 config SAMA5_UHPHS_RHPORT2
 	bool "Use Port B"

--- a/arch/arm/src/sama5/sam_ehci.c
+++ b/arch/arm/src/sama5/sam_ehci.c
@@ -110,17 +110,15 @@
 #undef CONFIG_USBHOST_ISOC_DISABLE
 #define CONFIG_USBHOST_ISOC_DISABLE 1
 
-/* If UDPHS is enabled, then don't use port A */
-
-#ifdef CONFIG_SAMA5_UDPHS
-#  undef CONFIG_SAMA5_UHPHS_RHPORT1
-#endif
-
-/* For now, suppress use of PORTA in any event.  I use that for SAM-BA and
- * would prefer that the board not try to drive VBUS on that port!
+/* Suppress use of PORTA unless board-specific dual-role-port support
+ * has been included. Generally port A is used as a device-only port,
+ * typically for SAM-BA and the possibility of enabling host VBUS power
+ * for this port would be a BAD idea
  */
 
-#undef CONFIG_SAMA5_UHPHS_RHPORT1
+#if defined(CONFIG_SAMA5_UDPHS) && !defined(CONFIG_SAMA5_USBA_DRP)
+#  undef CONFIG_SAMA5_UHPHS_RHPORT1
+#endif
 
 /* Driver-private Definitions ***********************************************/
 

--- a/arch/arm/src/sama5/sam_ohci.c
+++ b/arch/arm/src/sama5/sam_ohci.c
@@ -124,17 +124,15 @@
 
 #define SAM_BUFALLOC (CONFIG_SAMA5_OHCI_TDBUFFERS * CONFIG_SAMA5_OHCI_TDBUFSIZE)
 
-/* If UDPHS is enabled, then don't use port A */
-
-#ifdef CONFIG_SAMA5_UDPHS
-#  undef CONFIG_SAMA5_UHPHS_RHPORT1
-#endif
-
-/* For now, suppress use of PORTA in any event.  I use that for SAM-BA and
- * would prefer that the board not try to drive VBUS on that port!
+/* Suppress use of PORTA unless board-specific dual-role-port support
+ * has been included. Generally port A is used as a device-only port,
+ * typically for SAM-BA and the possibility of enabling host VBUS power
+ * for this port would be a BAD idea
  */
 
-#undef CONFIG_SAMA5_UHPHS_RHPORT1
+#if defined(CONFIG_SAMA5_UDPHS) && !defined(CONFIG_SAMA5_USBA_DRP)
+#  undef CONFIG_SAMA5_UHPHS_RHPORT1
+#endif
 
 /* Debug */
 

--- a/arch/arm/src/sama5/sam_udphs.c
+++ b/arch/arm/src/sama5/sam_udphs.c
@@ -4055,6 +4055,7 @@ static int sam_selfpowered(struct usbdev_s *dev, bool selfpowered)
 
 static int sam_pullup(struct usbdev_s *dev, bool enable)
 {
+#ifndef CONFIG_SAMA5_USB_DRP
   struct sam_usbdev_s *priv = (struct sam_usbdev_s *)dev;
   uint32_t regval;
 
@@ -4102,7 +4103,7 @@ static int sam_pullup(struct usbdev_s *dev, bool enable)
           priv->devstate = UDPHS_DEVSTATE_POWERED;
         }
     }
-
+#endif /* CONFIG_SAMA5_USB_DRP */
   return OK;
 }
 


### PR DESCRIPTION
## Summary
A custom board can now implement non-native usb dual-role-port (DRP) or on-the-go (OTG) functionality to allow both usb host and device functionality to co-exist.

To allow this, some "guards" in existing peripheral driver code and Kconfig files need changing.

## Impact
Since the guards rely on CONFIG_SAMA5_USB_DRP which cannot be set from the main Kconfig files, but instead must be set from a board-specific Kconfig file, the impact should be zero.

## Testing
Custom board with SAMA5D27C-D1G with FUSB302 device to handle all the switching between usb host and device (including usb pullup and pull down resistors instead of using those in the SAMA5 itself.

