### PR TITLE
sama5/twi: add support for flexcom twi

### DIFF
--- a/arch/arm/src/sama5/Kconfig
+++ b/arch/arm/src/sama5/Kconfig
@@ -203,6 +203,26 @@ config SAMA5_FLEXCOM_TWI
 	bool
 	default n
 
+config SAMA5_FLEXCOM_TWI0
+	bool
+	default n
+
+config SAMA5_FLEXCOM_TWI1
+	bool
+	default n
+
+config SAMA5_FLEXCOM_TWI2
+	bool
+	default n
+
+config SAMA5_FLEXCOM_TWI3
+	bool
+	default n
+
+config SAMA5_FLEXCOM_TWI4
+	bool
+	default n
+
 # Chip Selection
 
 config ARCH_CHIP_SAMA5D2
@@ -864,6 +884,7 @@ config SAMA5_FLEXCOM0_SPI
 config SAMA5_FLEXCOM0_TWI
 	bool "TWI"
 	select SAMA5_FLEXCOM_TWI
+	select SAMA5_FLEXCOM_TWI0
 
 endchoice # FLEXCOM0 Configuration
 
@@ -885,6 +906,7 @@ config SAMA5_FLEXCOM1_SPI
 config SAMA5_FLEXCOM1_TWI
 	bool "TWI"
 	select SAMA5_FLEXCOM_TWI
+	select SAMA5_FLEXCOM_TWI1
 
 endchoice # FLEXCOM1 Configuration
 
@@ -906,6 +928,7 @@ config SAMA5_FLEXCOM2_SPI
 config SAMA5_FLEXCOM2_TWI
 	bool "TWI"
 	select SAMA5_FLEXCOM_TWI
+	select SAMA5_FLEXCOM_TWI2
 
 endchoice # FLEXCOM2 Configuration
 
@@ -927,6 +950,7 @@ config SAMA5_FLEXCOM3_SPI
 config SAMA5_FLEXCOM3_TWI
 	bool "TWI"
 	select SAMA5_FLEXCOM_TWI
+	select SAMA5_FLEXCOM_TWI3
 
 endchoice # FLEXCOM3 Configuration
 
@@ -948,6 +972,7 @@ config SAMA5_FLEXCOM4_SPI
 config SAMA5_FLEXCOM4_TWI
 	bool "TWI"
 	select SAMA5_FLEXCOM_TWI
+	select SAMA5_FLEXCOM_TWI4
 
 endchoice # FLEXCOM4 Configuration
 endmenu # Flexcom Configuration
@@ -3172,7 +3197,7 @@ config SAMA5_FLEXCOM_SPI_DMADEBUG
 endmenu # Flexcom SPI device driver options
 endif # SAMA5_FLEXCOM0_SPI || SAMA5_FLEXCOM1_SPI || SAMA5_FLEXCOM2_SPI || SAMA5_FLEXCOM3_SPI || SAMA5_FLEXCOM4_SPI
 
-if SAMA5_TWI0 || SAMA5_TWI1 || SAMA5_TWI2 || SAMA5_TWI3
+if SAMA5_TWI0 || SAMA5_TWI1 || SAMA5_TWI2 || SAMA5_TWI3 || SAMA5_FLEXCOM_TWI
 
 menu "TWI device driver options"
 
@@ -3196,6 +3221,32 @@ config SAMA5_TWI3_FREQUENCY
 	default 100000
 	depends on SAMA5_TWI3
 
+config SAMA5_TWI_FC0_FREQUENCY
+    int "TWI4 (flexcom-0) Frequency"
+    default 100000
+    depends on SAMA5_FLEXCOM_TWI0
+
+config SAMA5_TWI_FC1_FREQUENCY
+    int "TWI5 (flexcom-1) Frequency"
+    default 100000
+    depends on SAMA5_FLEXCOM_TWI1
+
+config SAMA5_TWI_FC2_FREQUENCY
+    int "TWI6 (flexcom-2) Frequency"
+    default 100000
+    depends on SAMA5_FLEXCOM_TWI2
+
+config SAMA5_TWI_FC3_FREQUENCY
+    int "TWI7 (flexcom-3) Frequency"
+    default 100000
+    depends on SAMA5_FLEXCOM_TWI3
+
+config SAMA5_TWI_FC4_FREQUENCY
+    int "TWI8 (flexcom-4) Frequency"
+    default 100000
+    depends on SAMA5_FLEXCOM_TWI4
+
+
 config SAMA5_TWI_REGDEBUG
 	bool "TWI register level debug"
 	depends on DEBUG_I2C_INFO
@@ -3205,7 +3256,7 @@ config SAMA5_TWI_REGDEBUG
 		Very invasive! Requires also CONFIG_DEBUG_I2C_INFO.
 
 endmenu # TWI device driver options
-endif # SAMA5_TWI0 || SAMA5_TWI1 || SAMA5_TWI2 || SAMA5_TWI3
+endif # SAMA5_TWI0 || SAMA5_TWI1 || SAMA5_TWI2 || SAMA5_TWI3 | SAMA5_FLEXCOM_TWI
 
 if SAMA5_SSC0 || SAMA5_SSC1
 menu "SSC Configuration"

--- a/arch/arm/src/sama5/Make.defs
+++ b/arch/arm/src/sama5/Make.defs
@@ -187,6 +187,9 @@ else
 ifeq ($(CONFIG_SAMA5_TWI2),y)
 CHIP_CSRCS += sam_twi.c
 endif
+ifeq ($(CONFIG_SAMA5_FLEXCOM_TWI),y)
+CHIP_CSRCS += sam_twi.c
+endif
 endif
 endif
 

--- a/arch/arm/src/sama5/hardware/_sama5d2x_memorymap.h
+++ b/arch/arm/src/sama5/hardware/_sama5d2x_memorymap.h
@@ -522,6 +522,10 @@
 #define SAM_PIOC_VBASE           SAM_PIO_IOGROUPC_VBASE
 #define SAM_PIOD_VBASE           SAM_PIO_IOGROUPD_VBASE
 
+#define SAM_FLEXCOM_USART_OFFSET (0x200)
+#define SAM_FLEXCOM_SPI_OFFSET   (0x400)
+#define SAM_FLEXCOM_TWI_OFFSET   (0x600)
+
 /* NuttX virtual base address
  *
  * The boot logic will create a temporarily mapping based on where NuttX is


### PR DESCRIPTION
## Summary
Add support for Flexcom TWI buses to existing TWI driver

## Impact
TWI bus4-8 now usable and mapped to flexcom TWI peripherals

## Testing
Tested on SAMA5D2x / Jupiter board using external RTC chip
