### PR TITLE
sim: fix nuttx consumes much CPU time

### DIFF
--- a/arch/sim/src/sim/sim_doirq.c
+++ b/arch/sim/src/sim/sim_doirq.c
@@ -43,12 +43,14 @@ void *sim_doirq(int irq, void *context)
 
   xcpt_reg_t tmp[XCPTCONTEXT_REGS];
   void *regs = (void *)tmp;
+  int ret;
 
   /* CURRENT_REGS non-zero indicates that we are processing an interrupt.
    * CURRENT_REGS is also used to manage interrupt level context switches.
    */
 
-  if (sim_saveusercontext(regs) == 0)
+  sim_saveusercontext(regs, ret);
+  if (ret == 0)
     {
       CURRENT_REGS = regs;
 

--- a/arch/sim/src/sim/sim_internal.h
+++ b/arch/sim/src/sim/sim_internal.h
@@ -85,17 +85,20 @@
 #define sim_savestate(regs) sim_copyfullstate(regs, (xcpt_reg_t *)CURRENT_REGS)
 #define sim_restorestate(regs) (CURRENT_REGS = regs)
 
-#define sim_saveusercontext(saveregs)                           \
-    ({                                                          \
-       irqstate_t flags = up_irq_flags();                       \
-       xcpt_reg_t *env = saveregs;                              \
-       uint32_t *val = (uint32_t *)&env[JB_FLAG];               \
+#define sim_saveusercontext(saveregs, ret)                      \
+    do                                                          \
+      {                                                         \
+        irqstate_t flags = up_irq_flags();                      \
+        xcpt_reg_t *env = saveregs;                             \
+        uint32_t *val = (uint32_t *)&env[JB_FLAG];              \
                                                                 \
-       val[0] = flags & UINT32_MAX;                             \
-       val[1] = (flags >> 32) & UINT32_MAX;                     \
+        val[0] = flags & UINT32_MAX;                            \
+        val[1] = (flags >> 32) & UINT32_MAX;                    \
                                                                 \
-       setjmp(saveregs);                                        \
-    })
+        ret = setjmp(saveregs);                                 \
+      }                                                         \
+    while (0)
+
 #define sim_fullcontextrestore(restoreregs)                     \
     do                                                          \
       {                                                         \

--- a/arch/sim/src/sim/sim_saveusercontext.c
+++ b/arch/sim/src/sim/sim_saveusercontext.c
@@ -48,5 +48,9 @@
 
 int up_saveusercontext(void *saveregs)
 {
-  return sim_saveusercontext(saveregs);
+  int ret;
+
+  sim_saveusercontext(saveregs, ret);
+
+  return ret;
 }

--- a/arch/sim/src/sim/sim_switchcontext.c
+++ b/arch/sim/src/sim/sim_switchcontext.c
@@ -53,6 +53,8 @@
 
 void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 {
+  int ret;
+
   sinfo("Unblocking TCB=%p\n", tcb);
 
   /* Update scheduler parameters */
@@ -80,6 +82,8 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
       /* Then switch contexts */
 
       sim_restorestate(tcb->xcp.regs);
+
+      return;
     }
 
   /* Copy the exception context into the TCB of the task that was
@@ -87,7 +91,8 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
    * then this is really the previously running task restarting!
    */
 
-  else if (!sim_saveusercontext(rtcb->xcp.regs))
+  sim_saveusercontext(rtcb->xcp.regs, ret);
+  if (ret == 0)
     {
       sinfo("New Active Task TCB=%p\n", tcb);
 


### PR DESCRIPTION
## Summary

sim: fix nuttx consumes much CPU time

And also:
Fix hang on configure sim:smp when (CONFIG_SMP_NCPUS=1), which report by https://github.com/apache/nuttx/pull/8469

## Impact

SIM

## Testing

sim:smp both CONFIG_SMP_NCPUS = 1 & CONFIG_SMP_NCPUS = 4