### PR TITLE
fs/littlefs: add full support for LittleFS block device cfg in Kconfig

### DIFF
--- a/fs/littlefs/Kconfig
+++ b/fs/littlefs/Kconfig
@@ -6,17 +6,69 @@ config FS_LITTLEFS
 		Build the LITTLEFS file system. https://github.com/littlefs-project/littlefs.
 
 if FS_LITTLEFS
-config FS_LITTLEFS_BLOCK_FACTOR
-	int "LITTLEFS Block size multiple factor"
+config FS_LITTLEFS_PROGRAM_SIZE_FACTOR
+	int "LITTLEFS Program size multiplication factor"
 	default 4
 	---help---
-		Configure the cache size of the LITTLEFS file system with a multiple factor of the block size.
-	
+		A factor used for multiplying program size.
+
+		The result is used as the minimum size of a block program in bytes.
+		All program operations will be a multiple of the result.
+
+config FS_LITTLEFS_READ_SIZE_FACTOR
+	int "LITTLEFS Read size multiplication factor"
+	default FS_LITTLEFS_PROGRAM_SIZE_FACTOR
+	---help---
+		A factor used for multiplying read size.
+
+		The result is used as the minimum size of a block read in bytes.
+		All read operations will be a multiple of the result.
+
+config FS_LITTLEFS_BLOCK_SIZE_FACTOR
+	int "LITTLEFS Block size multiplication factor"
+	default 1
+	---help---
+		A factor used for multiplying block size and dividing block count.
+
+		The result is size of an erasable block in bytes. This does not impact ram consumption
+		and may be larger than the physical erase size. However, non-inlined
+		files take up at minimum one block. Must be a multiple of the read and
+		program sizes.
+
+config FS_LITTLEFS_CACHE_SIZE_FACTOR
+	int "LITTLEFS Cache size multiplication factor"
+	default FS_LITTLEFS_READ_SIZE_FACTOR
+	---help---
+		A factor used for multiplying cache size.
+
+		The result is size of block caches in bytes.
+		Each cache buffers a portion of a block in RAM.
+		The littlefs needs a read cache, a program cache, and one additional
+		cache per file. A larger cache can improve performance by storing more
+		data and reducing the number of disk accesses. It must be a multiple of the
+		read and program sizes, and a factor of the block size.
+
+config FS_LITTLEFS_LOOKAHEAD_SIZE
+	int "LITTLEFS Lookahead size"
+	default 0
+	---help---
+		Size of the lookahead buffer in bytes. A larger lookahead buffer
+		increases the number of blocks found during an allocation pass. The
+		lookahead buffer is stored as a compact bitmap, so each byte of RAM
+		can track 8 blocks. Must be a multiple of 8.
+
+		Set value 0 for enabling internal calculation.
+
 config FS_LITTLEFS_BLOCK_CYCLE
-	int "LITTLEFS Block Cycle"
+	int "LITTLEFS Block cycle"
 	default 200
 	---help---
-		Configure the block cycle of the LITTLEFS file system.
+		Number of erase cycles before littlefs evicts metadata logs and moves
+		the metadata to another block. Suggested values are in the
+		range 100-1000, with large values having better performance at the cost
+		of less consistent wear distribution.
+
+		Set to -1 to disable block-level wear-leveling.
 
 config FS_LITTLEFS_NAME_MAX
 	int "LITTLEFS LFS_NAME_MAX"

--- a/fs/littlefs/lfs_vfs.c
+++ b/fs/littlefs/lfs_vfs.c
@@ -1088,15 +1088,23 @@ static int littlefs_bind(FAR struct inode *driver, FAR const void *data,
   fs->cfg.erase          = littlefs_erase_block;
   fs->cfg.sync           = littlefs_sync_block;
   fs->cfg.read_size      = fs->geo.blocksize *
-                           CONFIG_FS_LITTLEFS_BLOCK_FACTOR;
-  fs->cfg.prog_size      = fs->geo.blocksize;
-  fs->cfg.block_size     = fs->geo.erasesize;
-  fs->cfg.block_count    = fs->geo.neraseblocks;
+                           CONFIG_FS_LITTLEFS_READ_SIZE_FACTOR;
+  fs->cfg.prog_size      = fs->geo.blocksize *
+                           CONFIG_FS_LITTLEFS_PROGRAM_SIZE_FACTOR;
+  fs->cfg.block_size     = fs->geo.erasesize *
+                           CONFIG_FS_LITTLEFS_BLOCK_SIZE_FACTOR;
+  fs->cfg.block_count    = fs->geo.neraseblocks /
+                           CONFIG_FS_LITTLEFS_BLOCK_SIZE_FACTOR;
   fs->cfg.block_cycles   = CONFIG_FS_LITTLEFS_BLOCK_CYCLE;
   fs->cfg.cache_size     = fs->geo.blocksize *
-                           CONFIG_FS_LITTLEFS_BLOCK_FACTOR;
+                           CONFIG_FS_LITTLEFS_CACHE_SIZE_FACTOR;
+
+#if CONFIG_FS_LITTLEFS_LOOKAHEAD_SIZE == 0
   fs->cfg.lookahead_size = lfs_min(lfs_alignup(fs->cfg.block_count, 64) / 8,
                                    fs->cfg.read_size);
+#else
+  fs->cfg.lookahead_size = CONFIG_FS_LITTLEFS_LOOKAHEAD_SIZE;
+#endif
 
   /* Then get information about the littlefs filesystem on the devices
    * managed by this driver.


### PR DESCRIPTION
## Summary
This adds full control over the LittleFS granularity configuration. 
For default values, I used those from LittleFS [README.md](https://github.com/littlefs-project/littlefs/blob/master/README.md?plain=1#L49-L56)
I left the block_cycles to 200 (in the README.md is 500). 

To demonstrate the usefulness of this additional configuration,  I'll give two examples.
One with 256 Kb (32 KiB) FRAM and the other with 1Gb (125 KiB) Winbound  W25N01GV (**I can't find drivers in NuttX** yet but it will serve as an example because I have experience with it and LittleFS. )

LittleFS is is a block-based filesystem with two steps of granularity. 
First is logical block size defined by block sizes. The second is read/program granularity defined by read/program size. 
reference: https://github.com/littlefs-project/littlefs/blob/master/SPEC.md?plain=1#L20-L29
The smallest recommenced block size required for LittleFS is 128 bytes (see: https://github.com/littlefs-project/littlefs/issues/264#issuecomment-519963153).

#### (32 KiB) FRAM
FRAM has 1-byte granularity and can work as a single big page/block. To fulfill LittleFS's design as a block-based filesystem we need to divide FRAM into small sectors. For 32 KiB FRAM that is 256 blocks with 128-byte sizes.
Knowing this we can enable 1-byte granularity for FRAM. 

```
CONFIG_RAMTRON_EMULATE_PAGE_SHIFT=0
CONFIG_RAMTRON_EMULATE_SECTOR_SHIFT=0
```

Then set the next configuration for LittleFS:
```
CONFIG_FS_LITTLEFS_ADVANCED_BLOCK_DEVICE_CFG=y // Enable full control
CONFIG_FS_LITTLEFS_BLOCK_COUNT=256  // 32768/128 = 256 blocks with 128-byte sizes
CONFIG_FS_LITTLEFS_BLOCK_CYCLE=-1 // High Endurance 1 Trillion (10^12 ) Read/Writes
CONFIG_FS_LITTLEFS_BLOCK_SIZE=128 //Minimum required block size
CONFIG_FS_LITTLEFS_CACHE_SIZE=1 //NoDelay™ Writes
CONFIG_FS_LITTLEFS_LOOKAHEAD_SIZE=16 // enough for tracking 128 blocks of 256 max
CONFIG_FS_LITTLEFS_PROGRAM_SIZE=1 //1-byte program granularity with direct write to SPI
CONFIG_FS_LITTLEFS_READ_SIZE=1 // 1-byte read granularity with direct read from SPI
```
![image](https://user-images.githubusercontent.com/10188706/218089684-841029ab-6897-4a58-84f7-d34c63008ef7.png)


This was not achievable without this PR. When FRAM is set to 1-byte granularity MTD block device will report a block size of 32768 bytes and 1 block count. This is not enough blocks for LittleFS to work.

#### W25N01GV
This specific **NAND** Flash memory has a limitation that needs to be addressed before being used with LittleFS. 
The page size of W25N01GV is 2048 bytes, but it is limited to only 4 writes before it needs to be erased. 
Reference: https://igor-misic.blogspot.com/2020/12/winbond-nand-flash-w25n01gv-problem.html
So knowing this limitation we can manually setup the LittleFS configuration:

```
CONFIG_FS_LITTLEFS_ADVANCED_BLOCK_DEVICE_CFG=y // Enable full control
CONFIG_FS_LITTLEFS_BLOCK_COUNT=1024  // Blocks per DIE
CONFIG_FS_LITTLEFS_BLOCK_CYCLE=500
CONFIG_FS_LITTLEFS_BLOCK_SIZE=131072 //64 * 2048 (page size * pages per block)
CONFIG_FS_LITTLEFS_CACHE_SIZE=512
CONFIG_FS_LITTLEFS_LOOKAHEAD_SIZE=512 // enough for tracking 4096 blocks
CONFIG_FS_LITTLEFS_PROGRAM_SIZE=512 // 2048/4=512 (1 page is 2048 bytes) Limited by a number of 4 allowed writings at the same W25N01GV page
CONFIG_FS_LITTLEFS_READ_SIZE=512 
```

This way we are able to use the same page with 4 times smaller granularity than what would be possible before this change. 

For **NOR** flashes (W25Q), granularity can be even smaller because they don't suffer from the limitations that NAND Flash has, but I didn't test it yet. 

## Impact
Doesn't have any negative impact on the existing project. It just extends capabilities. 

## Testing
I am hammering the FRAM configuration from above with the BSON file for a couple of days now. I'll report here if I detect any issues. 

## Qconfig
![image](https://user-images.githubusercontent.com/10188706/218092204-1ef5ea66-0473-4ec0-99d5-a3e6d72dee18.png)

