### PR TITLE
sim: fix vfork report error

### DIFF
--- a/arch/sim/src/sim/sim_vfork.c
+++ b/arch/sim/src/sim/sim_vfork.c
@@ -31,6 +31,7 @@
 #include <errno.h>
 #include <debug.h>
 
+#include <nuttx/compiler.h>
 #include <nuttx/sched.h>
 #include <nuttx/arch.h>
 #include <arch/irq.h>
@@ -82,10 +83,15 @@
  *
  ****************************************************************************/
 
+#ifdef CONFIG_SIM_ASAN
+nosanitize_address
+#endif
 pid_t up_vfork(const xcpt_reg_t *context)
 {
   struct tcb_s *parent = this_task();
   struct task_tcb_s *child;
+  unsigned char *pout;
+  unsigned char *pin;
   xcpt_reg_t newsp;
   xcpt_reg_t newfp;
   xcpt_reg_t newtop;
@@ -130,7 +136,9 @@ pid_t up_vfork(const xcpt_reg_t *context)
   newtop = (xcpt_reg_t)child->cmn.stack_base_ptr +
                        child->cmn.adj_stack_size;
   newsp = newtop - stackutil;
-  memcpy((void *)newsp, (const void *)context[JB_SP], stackutil);
+  pout = (unsigned char *)newsp;
+  pin  = (unsigned char *)context[JB_SP];
+  while (stackutil-- > 0) *pout++ = *pin++;
 
   /* Was there a frame pointer in place before? */
 


### PR DESCRIPTION
## Summary

sim: fix vofrk report error
```
user_main: vfork() test
================================================================= ==3754757==ERROR: AddressSanitizer: stack-buffer-underflow on address 0xae9126f0 at pc 0x56845661 bp 0xae912570 sp 0xae912560 READ of size 1 at 0xae9126f0 thread T0
    #0 0x56845660 in memcpy string/lib_memcpy.c:44
    #1 0x56b70f61 in up_vfork sim/sim_vfork.c:133
    #2 0x567c0b85 in vfork (/home/ligd/platform/sim/nuttx/nuttx+0x26bb85)

0xae9126f0 is located 73456 bytes inside of 73728-byte region [0xae900800,0xae912800) allocated by thread T0 here:
    #0 0xf7ab1c2f in __interceptor_posix_memalign ../../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:226

SUMMARY: AddressSanitizer: stack-buffer-underflow string/lib_memcpy.c:44 in memcpy
```

## Impact

sim vfork

## Testing

ostest
