### PR TITLE
lcd/st7789: raise compilation error when CONFIG_SPI_CMDDATA is not set

### DIFF
--- a/drivers/lcd/st7789.c
+++ b/drivers/lcd/st7789.c
@@ -45,6 +45,12 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+/* CONFIG_SPI_CMDDATA has to be set */
+
+#ifndef CONFIG_SPI_CMDDATA
+#  error "CONFIG_SPI_CMDDATA option has to be set for SPI communication"
+#endif
+
 /* Verify that all configuration requirements have been met */
 
 #ifndef CONFIG_LCD_ST7789_SPIMODE


### PR DESCRIPTION
## Summary
CONFIG_SPI_CMDDATA is required for correct functionality of the display.

## Impact

Compilation only

