### PR TITLE
stm32_sdio: Fix in SDIO clocking configuration.

### DIFF
--- a/arch/arm/src/stm32/stm32_sdio.c
+++ b/arch/arm/src/stm32/stm32_sdio.c
@@ -1749,7 +1749,7 @@ static void stm32_clock(struct sdio_dev_s *dev, enum sdio_clock_e rate)
       default:
       case CLOCK_SDIO_DISABLED:
         clckr = STM32_CLCKCR_INIT;
-        return;
+        break;
 
       /* Enable in initial ID mode clocking (<400KHz) */
 

--- a/arch/arm/src/stm32f7/stm32_sdmmc.c
+++ b/arch/arm/src/stm32f7/stm32_sdmmc.c
@@ -2009,7 +2009,7 @@ static void stm32_clock(struct sdio_dev_s *dev, enum sdio_clock_e rate)
       default:
       case CLOCK_SDIO_DISABLED:
         clckr = STM32_CLCKCR_INIT;
-        return;
+        break;
 
       /* Enable in initial ID mode clocking (<400KHz) */
 

--- a/arch/arm/src/stm32h7/stm32_sdmmc.c
+++ b/arch/arm/src/stm32h7/stm32_sdmmc.c
@@ -2069,7 +2069,7 @@ static void stm32_clock(struct sdio_dev_s *dev, enum sdio_clock_e rate)
     default:
     case CLOCK_SDIO_DISABLED:
       clckr = STM32_CLCKCR_INIT;
-      return;
+      break;
 
     /* Enable in initial ID mode clocking (<400KHz) */
 

--- a/arch/arm/src/stm32l4/stm32l4_sdmmc.c
+++ b/arch/arm/src/stm32l4/stm32l4_sdmmc.c
@@ -1804,7 +1804,7 @@ static void stm32_clock(struct sdio_dev_s *dev, enum sdio_clock_e rate)
       default:
       case CLOCK_SDIO_DISABLED:
         clckr = STM32_CLCKCR_INIT;
-        return;
+        break;
 
       /* Enable in initial ID mode clocking (<400KHz) */
 


### PR DESCRIPTION
## Summary

Fixes clocking on STM32's SDIO peripheral, where the register value was not applied correctly.

## Impact

Proper clocking on STM32 SDIO.

## Testing

@pnb990 Can you please test this?  
The fix seems obvious, so I blindly applied it. I have no means of testing it.
