### PR TITLE
stdlib: Guard fflush in exit with CONFIG_FILE_STREAM

### DIFF
--- a/libs/libc/stdlib/lib_exit.c
+++ b/libs/libc/stdlib/lib_exit.c
@@ -88,9 +88,11 @@ void exit(int status)
 
   atexit_call_exitfuncs(status, false);
 
+#ifdef CONFIG_FILE_STREAM
   /* Flush all streams */
 
   fflush(NULL);
+#endif
 
   /* Then perform the exit */
 


### PR DESCRIPTION


## Summary
If CONFIG_FILE_STREAM disabled, fflush is a undefined function.
## Impact
Minor
## Testing
CI
