### PR TITLE
tools/ci: Switch kconfig-frontend to kconfiglib

### DIFF
--- a/boards/risc-v/esp32c6/esp32c6-devkit/Kconfig
+++ b/boards/risc-v/esp32c6/esp32c6-devkit/Kconfig
@@ -8,6 +8,5 @@ if ARCH_BOARD_ESP32C6_DEVKIT
 config ESP32C6_DEVKIT_RUN_IRAM
 	bool "Run from IRAM"
 	default n
-	---help---
 
 endif # ARCH_BOARD_ESP32C6_DEVKIT

--- a/tools/Unix.mk
+++ b/tools/Unix.mk
@@ -629,7 +629,8 @@ else
   KCONFIG_GCONFIG       = ${KCONFIG_NCONFIG}
   KCONFIG_SAVEDEFCONFIG = savedefconfig --out
 define kconfig_tweak_disable
-	sed -i '/$2/d' $1
+	$(Q) sed -i'.orig' '/$2/d' $1
+	$(Q) rm -f $1.orig
 endef
 endif
 

--- a/tools/Unix.mk
+++ b/tools/Unix.mk
@@ -605,7 +605,10 @@ pass2dep: context tools/mkdeps$(HOSTEXEEXT) tools/cnvwindeps$(HOSTEXEEXT)
 KCONFIG_ENV  = APPSDIR=${CONFIG_APPS_DIR} EXTERNALDIR=$(EXTERNALDIR)
 KCONFIG_ENV += APPSBINDIR=${CONFIG_APPS_DIR} BINDIR=${TOPDIR}
 
-KCONFIG_LIB = $(shell command -v menuconfig 2> /dev/null)
+LOADABLE = $(shell grep "=m$$" $(TOPDIR)/.config)
+ifeq ($(CONFIG_BUILD_LOADABLE)$(LOADABLE),)
+  KCONFIG_LIB = $(shell command -v menuconfig 2> /dev/null)
+endif
 
 # Prefer "kconfiglib" if host OS supports it
 
@@ -616,18 +619,19 @@ ifeq ($(KCONFIG_LIB),)
   KCONFIG_NCONFIG       = kconfig-nconf Kconfig
   KCONFIG_QCONFIG       = kconfig-qconf Kconfig
   KCONFIG_GCONFIG       = kconfig-gconf Kconfig
-  KCONFIG_SAVEDEFCONFIG = kconfig-conf Kconfig --savedefconfig
+  KCONFIG_SAVEDEFCONFIG = kconfig-conf Kconfig --savedefconfig defconfig.tmp
 define kconfig_tweak_disable
 	kconfig-tweak --file $1 -u $2
 endef
 else
-  KCONFIG_OLDCONFIG     = oldconfig
-  KCONFIG_OLDDEFCONFIG  = olddefconfig
-  KCONFIG_MENUCONFIG    = menuconfig
-  KCONFIG_NCONFIG       = guiconfig
+  PURGE_MODULE_WARNING  = 2>&1 | grep -v "warning: the 'modules' option is not supported"
+  KCONFIG_OLDCONFIG     = oldconfig ${PURGE_MODULE_WARNING}
+  KCONFIG_OLDDEFCONFIG  = olddefconfig ${PURGE_MODULE_WARNING}
+  KCONFIG_MENUCONFIG    = menuconfig ${PURGE_MODULE_WARNING}
+  KCONFIG_NCONFIG       = guiconfig ${PURGE_MODULE_WARNING}
   KCONFIG_QCONFIG       = ${KCONFIG_NCONFIG}
   KCONFIG_GCONFIG       = ${KCONFIG_NCONFIG}
-  KCONFIG_SAVEDEFCONFIG = savedefconfig --out
+  KCONFIG_SAVEDEFCONFIG = savedefconfig --out defconfig.tmp ${PURGE_MODULE_WARNING}
 define kconfig_tweak_disable
 	$(Q) sed -i'.orig' '/$2/d' $1
 	$(Q) rm -f $1.orig
@@ -672,7 +676,7 @@ gconfig: apps_preconfig
 	$(Q) ${KCONFIG_ENV} ${KCONFIG_GCONFIG}
 
 savedefconfig: apps_preconfig
-	$(Q) ${KCONFIG_ENV} ${KCONFIG_SAVEDEFCONFIG} defconfig.tmp
+	$(Q) ${KCONFIG_ENV} ${KCONFIG_SAVEDEFCONFIG}
 	$(Q) $(call kconfig_tweak_disable,defconfig.tmp,CONFIG_APPS_DIR)
 	$(Q) grep "CONFIG_ARCH=" .config >> defconfig.tmp
 	$(Q) grep "^CONFIG_ARCH_CHIP_" .config >> defconfig.tmp; true

--- a/tools/ci/cibuild.sh
+++ b/tools/ci/cibuild.sh
@@ -287,6 +287,7 @@ function python-tools {
     cxxfilt \
     esptool==3.3.1 \
     imgtool==1.9.0 \
+    kconfiglib \
     pexpect==4.8.0 \
     pyelftools \
     pyserial==3.5 \

--- a/tools/ci/cibuild.sh
+++ b/tools/ci/cibuild.sh
@@ -209,16 +209,16 @@ function elf-toolchain {
 }
 
 function gen-romfs {
-  add_path "${tools}"/genromfs/usr/bin
-
-  if [ ! -f "${tools}/genromfs/usr/bin/genromfs" ]; then
-    git clone https://bitbucket.org/nuttx/tools.git "${tools}"/nuttx-tools
-    cd "${tools}"/nuttx-tools
-    tar zxf genromfs-0.5.2.tar.gz -C "${tools}"
-    cd "${tools}"/genromfs-0.5.2
-    make install PREFIX="${tools}"/genromfs
-    cd "${tools}"
-    rm -rf genromfs-0.5.2
+  if ! type genromfs &> /dev/null; then
+    case ${os} in
+      Darwin)
+        brew tap PX4/px4
+        brew install genromfs
+        ;;
+      Linux)
+        apt-get install -y genromfs
+        ;;
+    esac
   fi
 }
 
@@ -242,6 +242,7 @@ function kconfig-frontends {
   add_path "${tools}"/kconfig-frontends/bin
 
   if [ ! -f "${tools}/kconfig-frontends/bin/kconfig-conf" ]; then
+    git clone https://bitbucket.org/nuttx/tools.git "${tools}"/nuttx-tools
     cd "${tools}"/nuttx-tools/kconfig-frontends
     ./configure --prefix="${tools}"/kconfig-frontends \
       --disable-kconfig --disable-nconf --disable-qconf \

--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -276,7 +276,8 @@ ENV PIP_NO_CACHE_DIR=0
 # We are using the minimal python installation from the system so include
 # setuptools and also wheel so we can use the binary releases of packages
 # instead of requiring them to be compiled.
-RUN pip3 install setuptools wheel
+RUN pip3 install setuptools
+RUN pip3 install wheel
 # Install CodeChecker and use it to statically analyze the code.
 RUN pip3 install CodeChecker
 # Install cvt2utf to check for non-UTF characters.
@@ -285,6 +286,7 @@ RUN pip3 install cvt2utf
 RUN pip3 install cxxfilt
 RUN pip3 install esptool
 RUN pip3 install imgtool
+RUN pip3 install kconfiglib
 RUN pip3 install pexpect==4.8.0
 RUN pip3 install pyelftools
 RUN pip3 install pyserial==3.5

--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -50,12 +50,6 @@ RUN mkdir bloaty -p \
   && cmake -DCMAKE_SYSTEM_PREFIX_PATH=/tools/bloaty \
   && make install
 
-RUN cd nuttx-tools \
-  && mkdir genromfs \
-  && tar -C genromfs --strip-components=1 -xf genromfs-0.5.2.tar.gz \
-  && cd genromfs \
-  && make install PREFIX=/tools/genromfs
-
 RUN cd nuttx-tools/kconfig-frontends \
   && ./configure --enable-mconf --disable-gconf --disable-qconf --enable-static --prefix=/tools/kconfig-frontends \
   && make install
@@ -239,6 +233,7 @@ RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" apt-get install -y -q
   gcc \
   gcc-avr \
   gcc-multilib \
+  genromfs \
   gettext \
   git \
   lib32z1-dev \
@@ -302,8 +297,6 @@ WORKDIR /tools
 # Pull in the tools we just built for nuttx
 COPY --from=nuttx-tools /tools/bloaty/ bloaty/
 ENV PATH="/tools/bloaty/bin:$PATH"
-COPY --from=nuttx-tools /tools/genromfs/ /tools/genromfs/
-ENV PATH="/tools/genromfs/usr/bin:$PATH"
 COPY --from=nuttx-tools /tools/kconfig-frontends/ kconfig-frontends/
 ENV PATH="/tools/kconfig-frontends/bin:$PATH"
 


### PR DESCRIPTION
## Summary

Follow https://github.com/apache/nuttx/pull/8494
kconfiglib can catch more error than kconfig-frontend: https://github.com/apache/nuttx/pull/8485

## Impact

build system

## Testing

CI