### PR TITLE
sched/pthread: check pthread group after find joininfo

### DIFF
--- a/sched/pthread/pthread_findjoininfo.c
+++ b/sched/pthread/pthread_findjoininfo.c
@@ -141,7 +141,8 @@ FAR struct join_s *pthread_findjoininfo(FAR struct task_group_s *group,
       FAR struct tcb_s *tcb = nxsched_get_tcb((pthread_t)pid);
 
       if (tcb != NULL && (tcb->flags & TCB_FLAG_DETACHED) == 0 &&
-          (tcb->flags & TCB_FLAG_TTYPE_MASK) == TCB_FLAG_TTYPE_PTHREAD)
+          (tcb->flags & TCB_FLAG_TTYPE_MASK) == TCB_FLAG_TTYPE_PTHREAD &&
+          tcb->group == group)
         {
           pjoin = pthread_createjoininfo((FAR struct pthread_tcb_s *)tcb);
         }


### PR DESCRIPTION
## Summary

Need check tcb or group info after find joininfo, otherwise the wrong value will be returned.

## Impact

Pthread

## Testing

libuv test