### PR TITLE
usbdev/composite: remove excess uninitialize code

### DIFF
--- a/drivers/usbdev/composite.c
+++ b/drivers/usbdev/composite.c
@@ -1049,11 +1049,6 @@ void composite_uninitialize(FAR void *handle)
 
   priv = &alloc->dev;
 
-  for (i = 0; i < priv->ndevices; i++)
-    {
-      priv->device[i].compdesc.uninitialize(priv->device[i].dev);
-    }
-
   /* Then unregister and destroy the composite class */
 
   usbdev_unregister(&alloc->drvr.drvr);


### PR DESCRIPTION
## Summary

Remove excess uninitialize code for composite_uninitialize.

## Impact

NA

## Testing

sim usbdev