### PR TITLE
usbdev: fixed DUALSPEED issue for adb/cdcecm/rndis

### DIFF
--- a/drivers/usbdev/adb.c
+++ b/drivers/usbdev/adb.c
@@ -1189,11 +1189,11 @@ static int usbclass_setup(FAR struct usbdevclass_driver_s *driver,
                     }
                     break;
 
+#ifdef CONFIG_USBDEV_DUALSPEED
                   case USB_DESC_TYPE_DEVICEQUALIFIER:
                     break;
                   case USB_DESC_TYPE_OTHERSPEEDCONFIG:
-                    break;
-
+#endif /* CONFIG_USBDEV_DUALSPEED */
                   /* If the serial device is used in as part of a composite
                    * device, then the configuration descriptor is provided by
                    * logic in the composite device implementation.


### PR DESCRIPTION
## Summary

1. Fixed DUALSPEED build issue for adb、cdcecm and rndis.
2. Support OTHERSPEEDCONFIG for adb、cdcecm and rndis;

## Impact

NA

## Testing

sim usbdev