### PR TITLE
arm: Toolchain.defs: fix reverse condition for attaching libm.

### DIFF
--- a/arch/arm/src/common/Toolchain.defs
+++ b/arch/arm/src/common/Toolchain.defs
@@ -316,7 +316,7 @@ endif
 
 EXTRA_LIBS += $(COMPILER_RT_LIB)
 
-ifneq ($(CONFIG_LIBM),y)
+ifeq ($(CONFIG_LIBM),y)
   EXTRA_LIBS += $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a))
 endif
 


### PR DESCRIPTION
arch: arm: src: common: Toolchain.defs: fix reverse condition for attaching libm.

Signed-off-by: Takeyoshi Kikuchi <kikuchi@centurysys.co.jp>
