### PR TITLE
fix mempool bug,when use MM_BACKTRACE

### DIFF
--- a/include/nuttx/mm/mempool.h
+++ b/include/nuttx/mm/mempool.h
@@ -35,6 +35,18 @@
 #include <nuttx/semaphore.h>
 
 /****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#if CONFIG_MM_BACKTRACE >= 0
+#  define MEMPOOL_REALBLOCKSIZE(pool) (ALIGN_UP(pool->blocksize + \
+                                      sizeof(struct mempool_backtrace_s), \
+                                      pool->blockalign))
+#else
+#  define MEMPOOL_REALBLOCKSIZE(pool) (pool->blocksize)
+#endif
+
+/****************************************************************************
  * Public Types
  ****************************************************************************/
 
@@ -70,6 +82,9 @@ struct mempool_procfs_entry_s
 struct mempool_s
 {
   size_t     blocksize;     /* The size for every block in mempool */
+#if CONFIG_MM_BACKTRACE >= 0
+  size_t     blockalign;    /* The alignment of the blocksize */
+#endif
   size_t     initialsize;   /* The initialize size in normal mempool */
   size_t     interruptsize; /* The initialize size in interrupt mempool */
   size_t     expandsize;    /* The size of expand block every time for mempool */
@@ -100,6 +115,17 @@ struct mempool_s
   struct mempool_procfs_entry_s procfs; /* The entry of procfs */
 #endif
 };
+
+#if CONFIG_MM_BACKTRACE >= 0
+struct mempool_backtrace_s
+{
+  FAR struct list_node node;
+  pid_t pid;
+#  if CONFIG_MM_BACKTRACE > 0
+  FAR void *backtrace[CONFIG_MM_BACKTRACE];
+#  endif
+};
+#endif
 
 struct mempoolinfo_s
 {

--- a/mm/mempool/mempool.c
+++ b/mm/mempool/mempool.c
@@ -394,6 +394,8 @@ int mempool_info(FAR struct mempool_s *pool, FAR struct mempoolinfo_s *info)
 int mempool_info_task(FAR struct mempool_s *pool,
                       FAR struct mempoolinfo_task *info)
 {
+  irqstate_t flags = spin_lock_irqsave(&pool->lock);
+
   DEBUGASSERT(info);
   if (info->pid == -2)
     {
@@ -438,6 +440,7 @@ int mempool_info_task(FAR struct mempool_s *pool,
     }
 #endif
 
+  spin_unlock_irqrestore(&pool->lock, flags);
   return OK;
 }
 

--- a/mm/mempool/mempool_multiple.c
+++ b/mm/mempool/mempool_multiple.c
@@ -328,7 +328,9 @@ mempool_multiple_init(FAR const char *name,
       pools[i].alloc = mempool_multiple_alloc_callback;
       pools[i].free = mempool_multiple_free_callback;
       pools[i].calibrate = calibrate;
-
+#if CONFIG_MM_BACKTRACE >= 0
+      pools[i].blockalign = mpool->minpoolsize;
+#endif
       ret = mempool_init(pools + i, name);
       if (ret < 0)
         {
@@ -509,7 +511,7 @@ int mempool_multiple_free(FAR struct mempool_multiple_s *mpool,
 
   blk = (FAR char *)blk - (((FAR char *)blk -
                            ((FAR char *)dict->addr + mpool->minpoolsize)) %
-                           dict->pool->blocksize);
+                           MEMPOOL_REALBLOCKSIZE(dict->pool));
   mempool_free(dict->pool, blk);
   return 0;
 }


### PR DESCRIPTION
## Summary
fix mempool bug,when use MM_BACKTRACE
## Impact
mempool
## Testing
Vela

bug 1: Use `MM_BACLTRACE`, calculated memory return address error.
bug 2: `alist` is not protected when traversing
