### PR TITLE
mempool:fix bug for realloc when shortage of memory

### DIFF
--- a/mm/mm_heap/mm_realloc.c
+++ b/mm/mm_heap/mm_realloc.c
@@ -103,8 +103,9 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
         {
           memcpy(newmem, oldmem, size);
           mm_free(heap, oldmem);
-          return newmem;
         }
+
+      return newmem;
     }
 #endif
 


### PR DESCRIPTION
## Summary
mempool bug fix

## Impact
mempool

## Testing
vela

In the case of shortage memory, it is wrongly judged whether the memory comes from the mempool