### PR TITLE
netinet: in.h: add support for Nimlang compatibility.

### DIFF
--- a/include/netinet/in.h
+++ b/include/netinet/in.h
@@ -58,6 +58,7 @@
 #define IPPROTO_ESP           50   /* Encapsulation Security Payload protocol */
 #define IPPROTO_AH            51   /* Authentication Header protocol */
 #define IPPROTO_ICMP6         58   /* Internal Control Message Protocol v6 */
+#define IPPROTO_ICMPV6        IPPROTO_ICMP6
 #define IPPROTO_NONE          59   /* IPv6 no next header. */
 #define IPPROTO_DSTOPTS       60   /* IPv6 destination options. */
 #define IPPROTO_MTP           92   /* Multicast Transport Protocol.  */


### PR DESCRIPTION
Without this POSIX-compatible definition, support for nativesockets module in Nimlang is problematic.

.nimcache/(snip)@spure@snativesockets.nim.c: In function 'toInt__pureZnativesockets_69': 
.nimcache/(snip): error: 'IPPROTO_ICMPV6' undeclared (first use in this function); did you mean 'IPPROTO_ICMP6'?
  291 |   result = IPPROTO_ICMPV6;
      |            ^~~~~~~~~~~~~~
      |            IPPROTO_ICMP6

Signed-off-by: Takeyoshi Kikuchi <kikuchi@centurysys.co.jp>
