### PR TITLE
sched/pthread: change the wrong type cast

### DIFF
--- a/sched/pthread/pthread_findjoininfo.c
+++ b/sched/pthread/pthread_findjoininfo.c
@@ -138,7 +138,7 @@ FAR struct join_s *pthread_findjoininfo(FAR struct task_group_s *group,
 
   if (pjoin == NULL)
     {
-      FAR struct tcb_s *tcb = nxsched_get_tcb((pthread_t)pid);
+      FAR struct tcb_s *tcb = nxsched_get_tcb(pid);
 
       if (tcb != NULL && (tcb->flags & TCB_FLAG_DETACHED) == 0 &&
           (tcb->flags & TCB_FLAG_TTYPE_MASK) == TCB_FLAG_TTYPE_PTHREAD &&

--- a/sched/pthread/pthread_join.c
+++ b/sched/pthread/pthread_join.c
@@ -114,7 +114,7 @@ int pthread_join(pthread_t thread, FAR pthread_addr_t *pexit_value)
     {
       /* Determine what kind of error to return */
 
-      FAR struct tcb_s *tcb = nxsched_get_tcb((pthread_t)thread);
+      FAR struct tcb_s *tcb = nxsched_get_tcb((pid_t)thread);
 
       swarn("WARNING: Could not find thread data\n");
 


### PR DESCRIPTION
## Summary

Change the wrong type cast for pthread.

## Impact

NA

## Testing

CI pass