### PR TITLE
sched/nxtask_sigchild: Set exit code when CONFIG_SCHED_CHILD_STATUS=y

### DIFF
--- a/sched/task/task_exithook.c
+++ b/sched/task/task_exithook.c
@@ -77,6 +77,8 @@ static inline void nxtask_exitstatus(FAR struct task_group_s *group,
           child->ch_status = status;
         }
     }
+
+  group->tg_exitcode = status;
 }
 #else
 


### PR DESCRIPTION
## Summary
This is a follow-up to https://github.com/apache/nuttx/pull/8486
## Impact
Fix regression after 8486
## Testing
icicle:nsh
