### PR TITLE
Simulator Documentation for macOS and X11 Linker Changes

### DIFF
--- a/Documentation/guides/simulator.rst
+++ b/Documentation/guides/simulator.rst
@@ -13,7 +13,27 @@ having a piece of embedded hardware.
 This guide assumes you're on Linux. It works on Windows and Mac too— if you know how,
 submit a PR to improve this guide!
 
-.. todo:: Add Mac and Windows instructions
+.. todo:: Windows instructions
+
+Prerequisites For macOS
+-----------------------
+
+We need ``genromfs`` to build simulators(NON GUI).
+
+   .. code-block:: console
+
+      $ git clone https://github.com/chexum/genromfs.git
+      $ cd genromfs
+      $ make 
+      $ make install
+   Now Copy the built `genromfs` `exec` to /opt/local/bin
+
+For GUI Applications we need X11 Libraries, libx11 can also be built using Homebrew or by Installing XQuartz.
+
+   .. code-block:: console
+   
+      $ sudo port install xorg-libX11
+      $ sudo port install sudo port install xorg-server
 
 Compiling
 ---------

--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -141,6 +141,9 @@ endif
 
 ifeq ($(CONFIG_SIM_X11FB),y)
   HOSTSRCS += sim_x11framebuffer.c
+ifeq ($(CONFIG_HOST_MACOS),y)
+  STDLIBS += -L/opt/X11/lib
+endif
   STDLIBS += -lX11 -lXext
 ifeq ($(CONFIG_SIM_TOUCHSCREEN),y)
   CSRCS += sim_touchscreen.c


### PR DESCRIPTION
### **Summary**

macOS requires `genromfs` and `X11 Libraries` to run Simulators.
Added instructions to install genromfs
Added instructions to install X11

### **Impact**

The Simulator will not run without these tools.

### **Testing**

This Works on ARM MacBooks.
Tested on sim:nsh
Tested on sim:lvgl_lcd
