### PR TITLE
include/sys/socket.h: Add SOCK_CTRL to socket type

### DIFF
--- a/include/nuttx/net/netconfig.h
+++ b/include/nuttx/net/netconfig.h
@@ -104,52 +104,24 @@
 
 #define NET_SOCK_PROTOCOL  0
 
-/* SOCK_DGRAM is the preferred socket type to use when we just want a
- * socket for performing driver ioctls.  However, we can't use SOCK_DRAM
- * if UDP is disabled.
- *
- * Pick a socket type (and perhaps protocol) compatible with the currently
- * selected address family.
+/* SOCK_CTRL is the preferred socket type to use when we just want a
+ * socket for performing driver ioctls.
  */
 
+#define NET_SOCK_TYPE SOCK_CTRL
+
 #if NET_SOCK_FAMILY == AF_INET
-#  if defined(CONFIG_NET_UDP)
-#    define NET_SOCK_TYPE SOCK_DGRAM
-#  elif defined(CONFIG_NET_TCP)
-#   define NET_SOCK_TYPE SOCK_STREAM
-#  elif defined(CONFIG_NET_ICMP_SOCKET)
-#   define NET_SOCK_TYPE SOCK_DGRAM
+#  if !defined(CONFIG_NET_UDP) && !defined(CONFIG_NET_TCP) && \
+      defined(CONFIG_NET_ICMP_SOCKET)
 #   undef NET_SOCK_PROTOCOL
 #   define NET_SOCK_PROTOCOL IPPROTO_ICMP
 #  endif
 #elif NET_SOCK_FAMILY == AF_INET6
-#  if defined(CONFIG_NET_UDP)
-#    define NET_SOCK_TYPE SOCK_DGRAM
-#  elif defined(CONFIG_NET_TCP)
-#   define NET_SOCK_TYPE SOCK_STREAM
-#  elif defined(CONFIG_NET_ICMPv6_SOCKET)
-#   define NET_SOCK_TYPE SOCK_DGRAM
+#  if !defined(CONFIG_NET_UDP) && !defined(CONFIG_NET_TCP) && \
+      defined(CONFIG_NET_ICMPv6_SOCKET)
 #   undef NET_SOCK_PROTOCOL
 #   define NET_SOCK_PROTOCOL IPPROTO_ICMP6
 #  endif
-#elif NET_SOCK_FAMILY == AF_LOCAL
-#  if defined(CONFIG_NET_LOCAL_DGRAM)
-#    define NET_SOCK_TYPE SOCK_DGRAM
-#  elif defined(CONFIG_NET_LOCAL_STREAM)
-#     define NET_SOCK_TYPE SOCK_STREAM
-#  endif
-#elif NET_SOCK_FAMILY == AF_PACKET
-#  define NET_SOCK_TYPE SOCK_RAW
-#elif NET_SOCK_FAMILY == AF_CAN
-#  define NET_SOCK_TYPE SOCK_RAW
-#elif NET_SOCK_FAMILY == AF_IEEE802154
-#  define NET_SOCK_TYPE SOCK_DGRAM
-#elif NET_SOCK_FAMILY == AF_BLUETOOTH
-#  define NET_SOCK_TYPE SOCK_RAW
-#elif NET_SOCK_FAMILY == AF_NETLINK
-#  define NET_SOCK_TYPE SOCK_DGRAM
-#elif NET_SOCK_FAMILY == AF_RPMSG
-#  define NET_SOCK_TYPE SOCK_STREAM
 #endif
 
 /* Eliminate dependencies on other header files.  This should not harm

--- a/include/sys/socket.h
+++ b/include/sys/socket.h
@@ -92,6 +92,10 @@
                                  * required to read an entire packet with each read
                                  * system call.
                                  */
+#define SOCK_CTRL      6        /* SOCK_CTRL is the preferred socket type to use
+                                 * when we just want a socket for performing driver
+                                 * ioctls. This definition is not POSIX compliant.
+                                 */
 #define SOCK_PACKET   10        /* Obsolete and should not be used in new programs */
 
 #define SOCK_CLOEXEC  02000000  /* Atomically set close-on-exec flag for the new

--- a/net/bluetooth/bluetooth_sockif.c
+++ b/net/bluetooth/bluetooth_sockif.c
@@ -162,10 +162,10 @@ static int bluetooth_setup(FAR struct socket *psock)
    * connection structure, it is unallocated at this point.  It will not
    * actually be initialized until the socket is connected.
    *
-   * Only SOCK_RAW is supported
+   * SOCK_RAW and SOCK_CTRL are supported
    */
 
-  if (psock->s_type == SOCK_RAW)
+  if (psock->s_type == SOCK_RAW || psock->s_type == SOCK_CTRL)
     {
       return bluetooth_sockif_alloc(psock);
     }
@@ -215,7 +215,7 @@ static void bluetooth_addref(FAR struct socket *psock)
   FAR struct bluetooth_conn_s *conn;
 
   DEBUGASSERT(psock != NULL && psock->s_conn != NULL &&
-              psock->s_type == SOCK_RAW);
+              (psock->s_type == SOCK_RAW || psock->s_type == SOCK_CTRL));
 
   conn = (FAR struct bluetooth_conn_s *)psock->s_conn;
   DEBUGASSERT(conn->bc_crefs > 0 && conn->bc_crefs < 255);
@@ -443,11 +443,11 @@ static int bluetooth_l2cap_bind(FAR struct socket *psock,
 
   /* Bind a PF_BLUETOOTH socket to an network device.
    *
-   * Only SOCK_RAW is supported
+   * SOCK_RAW and SOCK_CTRL are supported
    */
 
   if (psock == NULL || psock->s_conn == NULL ||
-      psock->s_type != SOCK_RAW)
+      (psock->s_type != SOCK_RAW && psock->s_type != SOCK_CTRL))
     {
       nerr("ERROR: Invalid socket type: %u\n", psock->s_type);
       return -EBADF;
@@ -516,11 +516,11 @@ static int bluetooth_hci_bind(FAR struct socket *psock,
 
   /* Bind a PF_BLUETOOTH socket to an network device.
    *
-   * Only SOCK_RAW is supported
+   * SOCK_RAW and SOCK_CTRL are supported
    */
 
   if (psock == NULL || psock->s_conn == NULL ||
-      psock->s_type != SOCK_RAW)
+      (psock->s_type != SOCK_RAW && psock->s_type != SOCK_CTRL))
     {
       nerr("ERROR: Invalid socket type: %u\n", psock->s_type);
       return -EBADF;
@@ -753,9 +753,10 @@ static int bluetooth_close(FAR struct socket *psock)
 
   switch (psock->s_type)
     {
-      /* Only SOCK_RAW is supported */
+      /* SOCK_RAW and SOCK_CTRL are supported */
 
       case SOCK_RAW:
+      case SOCK_CTRL:
         {
           FAR struct bluetooth_conn_s *conn = psock->s_conn;
 

--- a/net/can/can_sockif.c
+++ b/net/can/can_sockif.c
@@ -207,7 +207,8 @@ static int can_setup(FAR struct socket *psock)
 
   /* Verify the socket type (domain should always be PF_CAN here) */
 
-  if (domain == PF_CAN && (type == SOCK_RAW || type == SOCK_DGRAM))
+  if (domain == PF_CAN &&
+      (type == SOCK_RAW || type == SOCK_DGRAM || type == SOCK_CTRL))
     {
       /* Allocate the CAN socket connection structure and save it in the
        * new socket instance.

--- a/net/icmp/icmp_sockif.c
+++ b/net/icmp/icmp_sockif.c
@@ -109,9 +109,10 @@ const struct sock_intf_s g_icmp_sockif =
 
 static int icmp_setup(FAR struct socket *psock)
 {
-  /* Only SOCK_DGRAM and IPPROTO_ICMP are supported */
+  /* SOCK_DGRAM or SOCK_CTRL and IPPROTO_ICMP are supported */
 
-  if (psock->s_type == SOCK_DGRAM && psock->s_proto == IPPROTO_ICMP)
+  if ((psock->s_type == SOCK_DGRAM || psock->s_type == SOCK_CTRL) &&
+       psock->s_proto == IPPROTO_ICMP)
     {
       /* Allocate the IPPROTO_ICMP socket connection structure and save in
        * the new socket instance.

--- a/net/icmpv6/icmpv6_sockif.c
+++ b/net/icmpv6/icmpv6_sockif.c
@@ -109,9 +109,10 @@ const struct sock_intf_s g_icmpv6_sockif =
 
 static int icmpv6_setup(FAR struct socket *psock)
 {
-  /* Only SOCK_DGRAM and IPPROTO_ICMP6 are supported */
+  /* SOCK_DGRAM or SOCK_CTRL and IPPROTO_ICMP6 are supported */
 
-  if (psock->s_type == SOCK_DGRAM && psock->s_proto == IPPROTO_ICMP6)
+  if ((psock->s_type == SOCK_DGRAM || psock->s_type == SOCK_CTRL) &&
+      psock->s_proto == IPPROTO_ICMP6)
     {
       /* Allocate the IPPROTO_ICMP6 socket connection structure and save in
        * the new socket instance.

--- a/net/inet/inet_sockif.c
+++ b/net/inet/inet_sockif.c
@@ -287,6 +287,30 @@ static int inet_setup(FAR struct socket *psock)
 #endif
 #endif /* CONFIG_NET_UDP */
 
+#if defined(CONFIG_NET_TCP) || defined(CONFIG_NET_UDP)
+      case SOCK_CTRL:
+#  ifdef NET_TCP_HAVE_STACK
+        if (psock->s_proto == 0 || psock->s_proto == IPPROTO_TCP)
+          {
+             /* Allocate and attach the TCP connection structure */
+
+             return inet_tcp_alloc(psock);
+          }
+
+#  endif
+#  ifdef NET_UDP_HAVE_STACK
+        if (psock->s_proto == 0 || psock->s_proto == IPPROTO_UDP)
+          {
+             /* Allocate and attach the UDP connection structure */
+
+             return inet_udp_alloc(psock);
+          }
+
+#  endif
+        nerr("ERROR: Unsupported control protocol: %d\n", psock->s_proto);
+        return -EPROTONOSUPPORT;
+#endif /* CONFIG_NET_TCP || CONFIG_NET_UDP */
+
       default:
         nerr("ERROR: Unsupported type: %d\n", psock->s_type);
         return -EPROTONOSUPPORT;
@@ -322,6 +346,11 @@ static sockcaps_t inet_sockcaps(FAR struct socket *psock)
         return SOCKCAP_NONBLOCKING;
 #endif
 
+#if defined(NET_TCP_HAVE_STACK) || defined(NET_UDP_HAVE_STACK)
+      case SOCK_CTRL:
+        return SOCKCAP_NONBLOCKING;
+#endif
+
       default:
         return 0;
     }
@@ -347,7 +376,9 @@ static void inet_addref(FAR struct socket *psock)
   DEBUGASSERT(psock != NULL && psock->s_conn != NULL);
 
 #ifdef NET_TCP_HAVE_STACK
-  if (psock->s_type == SOCK_STREAM)
+  if (psock->s_type == SOCK_STREAM ||
+      (psock->s_type == SOCK_CTRL &&
+      (psock->s_proto == 0 || psock->s_proto == IPPROTO_TCP)))
     {
       FAR struct tcp_conn_s *conn = psock->s_conn;
       DEBUGASSERT(conn->crefs > 0 && conn->crefs < 255);
@@ -356,7 +387,9 @@ static void inet_addref(FAR struct socket *psock)
   else
 #endif
 #ifdef NET_UDP_HAVE_STACK
-  if (psock->s_type == SOCK_DGRAM)
+  if (psock->s_type == SOCK_DGRAM ||
+      (psock->s_type == SOCK_CTRL &&
+      (psock->s_proto == 0 || psock->s_proto == IPPROTO_UDP)))
     {
       FAR struct udp_conn_s *conn = psock->s_conn;
       DEBUGASSERT(conn->crefs > 0 && conn->crefs < 255);
@@ -458,6 +491,15 @@ static int inet_bind(FAR struct socket *psock,
         }
         break;
 #endif /* CONFIG_NET_UDP */
+
+#if defined(CONFIG_NET_TCP) || defined(CONFIG_NET_UDP)
+      case SOCK_CTRL:
+        {
+          nerr("ERROR:  Inappropriate socket type: %d\n", psock->s_type);
+          ret = -EOPNOTSUPP;
+        }
+        break;
+#endif
 
       default:
         nerr("ERROR: Unsupported socket type: %d\n", psock->s_type);
@@ -1269,6 +1311,14 @@ static int inet_connect(FAR struct socket *psock,
         }
 #endif /* CONFIG_NET_UDP */
 
+#if defined(CONFIG_NET_TCP) && defined(CONFIG_NET_UDP)
+      case SOCK_CTRL:
+        {
+          nerr("ERROR:  Inappropriate socket type: %d\n", psock->s_type);
+          return -EOPNOTSUPP;
+        }
+#endif
+
       default:
         return -EBADF;
     }
@@ -1458,6 +1508,14 @@ static inline int inet_pollsetup(FAR struct socket *psock,
     }
   else
 #endif /* NET_UDP_HAVE_STACK */
+#if defined(NET_TCP_HAVE_STACK) || defined(NET_UDP_HAVE_STACK)
+  if (psock->s_type == SOCK_CTRL)
+    {
+      nerr("ERROR:  Inappropriate socket type: %d\n", psock->s_type);
+      return -EOPNOTSUPP;
+    }
+  else
+#endif
     {
       return -ENOSYS;
     }
@@ -1498,6 +1556,14 @@ static inline int inet_pollteardown(FAR struct socket *psock,
     }
   else
 #endif /* NET_UDP_HAVE_STACK */
+#if defined(NET_TCP_HAVE_STACK) || defined(NET_UDP_HAVE_STACK)
+  if (psock->s_type == SOCK_CTRL)
+    {
+      nerr("ERROR:  Inappropriate socket type: %d\n", psock->s_type);
+      return -EOPNOTSUPP;
+    }
+  else
+#endif
     {
       return -ENOSYS;
     }
@@ -1633,6 +1699,15 @@ static ssize_t inet_send(FAR struct socket *psock, FAR const void *buf,
         }
         break;
 #endif /* CONFIG_NET_UDP */
+
+#if defined(CONFIG_NET_TCP) || defined(CONFIG_NET_UDP)
+      case SOCK_CTRL:
+        {
+          nerr("ERROR:  Inappropriate socket type: %d\n", psock->s_type);
+          ret = -EOPNOTSUPP;
+        }
+        break;
+#endif
 
       default:
         {
@@ -1829,14 +1904,18 @@ static int inet_ioctl(FAR struct socket *psock, int cmd, unsigned long arg)
     }
 
 #if defined(CONFIG_NET_TCP) && !defined(CONFIG_NET_TCP_NO_STACK)
-  if (psock->s_type == SOCK_STREAM)
+  if (psock->s_type == SOCK_STREAM ||
+      (psock->s_type == SOCK_CTRL &&
+      (psock->s_proto == 0 || psock->s_proto == IPPROTO_TCP)))
     {
       return tcp_ioctl(psock->s_conn, cmd, arg);
     }
 #endif
 
 #if defined(CONFIG_NET_UDP) && defined(NET_UDP_HAVE_STACK)
-  if (psock->s_type == SOCK_DGRAM)
+  if (psock->s_type == SOCK_DGRAM ||
+      (psock->s_type == SOCK_CTRL &&
+      (psock->s_proto == 0 || psock->s_proto == IPPROTO_UDP)))
     {
       return udp_ioctl(psock->s_conn, cmd, arg);
     }
@@ -2156,6 +2235,15 @@ static ssize_t inet_recvmsg(FAR struct socket *psock,
       break;
 #endif /* CONFIG_NET_UDP */
 
+#if defined(CONFIG_NET_TCP) || defined(CONFIG_NET_UDP)
+    case SOCK_CTRL:
+      {
+        nerr("ERROR:  Inappropriate socket type: %d\n", psock->s_type);
+        ret = -EOPNOTSUPP;
+      }
+      break;
+#endif
+
     default:
       {
         nerr("ERROR: Unsupported socket type: %d\n", psock->s_type);
@@ -2195,92 +2283,92 @@ int inet_close(FAR struct socket *psock)
    * types.
    */
 
-  switch (psock->s_type)
-    {
 #ifdef CONFIG_NET_TCP
-      case SOCK_STREAM:
-        {
+  if (psock->s_type == SOCK_STREAM ||
+      (psock->s_type == SOCK_CTRL &&
+      (psock->s_proto == 0 || psock->s_proto == IPPROTO_TCP)))
+    {
 #ifdef NET_TCP_HAVE_STACK
-          FAR struct tcp_conn_s *conn = psock->s_conn;
-          int ret;
+      FAR struct tcp_conn_s *conn = psock->s_conn;
+      int ret;
 
-          /* Is this the last reference to the connection structure (there
-           * could be more if the socket was dup'ed).
-           */
+      /* Is this the last reference to the connection structure (there
+       * could be more if the socket was dup'ed).
+       */
 
-          if (conn->crefs <= 1)
-            {
-              /* Yes... Clost the socket */
-
-              ret = tcp_close(psock);
-              if (ret < 0)
-                {
-                  /* This would normally occur only if there is a timeout
-                   * from a lingering close.
-                   */
-
-                  nerr("ERROR: tcp_close failed: %d\n", ret);
-                  return ret;
-                }
-            }
-          else
-            {
-              /* No.. Just decrement the reference count */
-
-              conn->crefs--;
-            }
-#else
-        nwarn("WARNING: SOCK_STREAM support is not available in this "
-              "configuration\n");
-        return -EAFNOSUPPORT;
-#endif /* NET_TCP_HAVE_STACK */
-        }
-        break;
-#endif /* CONFIG_NET_TCP */
-
-#ifdef CONFIG_NET_UDP
-      case SOCK_DGRAM:
+      if (conn->crefs <= 1)
         {
-#ifdef NET_UDP_HAVE_STACK
-          FAR struct udp_conn_s *conn = psock->s_conn;
-          int ret;
+          /* Yes... Clost the socket */
 
-          /* Is this the last reference to the connection structure (there
-           * could be more if the socket was dup'ed).
-           */
-
-          if (conn->crefs <= 1)
+          ret = tcp_close(psock);
+          if (ret < 0)
             {
-              /* Yes... Clost the socket */
+              /* This would normally occur only if there is a timeout
+               * from a lingering close.
+               */
 
-              ret = udp_close(psock);
-              if (ret < 0)
-                {
-                  /* This would normally occur only if there is a timeout
-                   * from a lingering close.
-                   */
-
-                  nerr("ERROR: udp_close failed: %d\n", ret);
-                  return ret;
-                }
+              nerr("ERROR: tcp_close failed: %d\n", ret);
+              return ret;
             }
-          else
-            {
-              /* No.. Just decrement the reference count */
-
-              conn->crefs--;
-            }
-#else
-          nwarn("WARNING: SOCK_DGRAM support is not available in this "
-                "configuration\n");
-          return -EAFNOSUPPORT;
-#endif /* NET_UDP_HAVE_STACK */
         }
-        break;
-#endif /* CONFIG_NET_UDP */
+      else
+        {
+          /* No.. Just decrement the reference count */
 
-      default:
-        return -EBADF;
+          conn->crefs--;
+        }
+#else
+      nwarn("WARNING: SOCK_STREAM support is not available in this "
+            "configuration\n");
+      return -EAFNOSUPPORT;
+#endif /* NET_TCP_HAVE_STACK */
+    }
+  else
+#endif /* CONFIG_NET_TCP */
+#ifdef CONFIG_NET_UDP
+  if (psock->s_type == SOCK_DGRAM ||
+      (psock->s_type == SOCK_CTRL &&
+      (psock->s_proto == 0 || psock->s_proto == IPPROTO_UDP)))
+    {
+#ifdef NET_UDP_HAVE_STACK
+      FAR struct udp_conn_s *conn = psock->s_conn;
+      int ret;
+
+      /* Is this the last reference to the connection structure (there
+       * could be more if the socket was dup'ed).
+       */
+
+      if (conn->crefs <= 1)
+        {
+          /* Yes... Clost the socket */
+
+          ret = udp_close(psock);
+          if (ret < 0)
+            {
+              /* This would normally occur only if there is a timeout
+               * from a lingering close.
+               */
+
+              nerr("ERROR: udp_close failed: %d\n", ret);
+              return ret;
+            }
+        }
+      else
+        {
+          /* No.. Just decrement the reference count */
+
+          conn->crefs--;
+        }
+#else
+      nwarn("WARNING: SOCK_DGRAM support is not available in this "
+            "configuration\n");
+      return -EAFNOSUPPORT;
+#endif /* NET_UDP_HAVE_STACK */
+    }
+  else
+#endif /* CONFIG_NET_UDP */
+    {
+      return -EBADF;
     }
 
   return OK;
@@ -2311,7 +2399,8 @@ inet_sockif(sa_family_t family, int type, int protocol)
 #if defined(HAVE_PFINET_SOCKETS) && defined(CONFIG_NET_ICMP_SOCKET)
   /* PF_INET, ICMP data gram sockets are a special case of raw sockets */
 
-  if (family == PF_INET && type == SOCK_DGRAM && protocol == IPPROTO_ICMP)
+  if (family == PF_INET && (type == SOCK_DGRAM || type == SOCK_CTRL) &&
+      protocol == IPPROTO_ICMP)
     {
       return &g_icmp_sockif;
     }
@@ -2320,7 +2409,8 @@ inet_sockif(sa_family_t family, int type, int protocol)
 #if defined(HAVE_PFINET6_SOCKETS) && defined(CONFIG_NET_ICMPv6_SOCKET)
   /* PF_INET, ICMP data gram sockets are a special case of raw sockets */
 
-  if (family == PF_INET6 && type == SOCK_DGRAM && protocol == IPPROTO_ICMP6)
+  if (family == PF_INET6 && (type == SOCK_DGRAM || type == SOCK_CTRL) &&
+      protocol == IPPROTO_ICMP6)
     {
       return &g_icmpv6_sockif;
     }

--- a/net/local/local_sockif.c
+++ b/net/local/local_sockif.c
@@ -204,6 +204,19 @@ static int local_setup(FAR struct socket *psock)
         return local_sockif_alloc(psock);
 #endif /* CONFIG_NET_LOCAL_DGRAM */
 
+#if defined(CONFIG_NET_LOCAL_STREAM) || defined(CONFIG_NET_LOCAL_DGRAM)
+      case SOCK_CTRL:
+        if (psock->s_proto == 0 || psock->s_proto == IPPROTO_TCP ||
+            psock->s_proto == IPPROTO_UDP)
+          {
+            /* Allocate and attach the local connection structure */
+
+            return local_sockif_alloc(psock);
+          }
+
+        return -EPROTONOSUPPORT;
+#endif
+
       default:
         return -EPROTONOSUPPORT;
     }
@@ -303,6 +316,7 @@ static int local_bind(FAR struct socket *psock,
 #ifdef CONFIG_NET_LOCAL_DGRAM
       case SOCK_DGRAM:
 #endif
+      case SOCK_CTRL:
         {
           /* Bind the Unix domain connection structure */
 
@@ -643,6 +657,14 @@ static int local_connect(FAR struct socket *psock,
         break;
 #endif /* CONFIG_NET_LOCAL_DGRAM */
 
+#if defined(CONFIG_NET_LOCAL_STREAM) || defined(CONFIG_NET_LOCAL_DGRAM)
+      case SOCK_CTRL:
+        {
+          return -ENOSYS;
+        }
+        break;
+#endif
+
       default:
         return -EBADF;
     }
@@ -766,6 +788,7 @@ static int local_close(FAR struct socket *psock)
 #ifdef CONFIG_NET_LOCAL_DGRAM
       case SOCK_DGRAM:
 #endif
+      case SOCK_CTRL:
         {
           FAR struct local_conn_s *conn = psock->s_conn;
 
@@ -1014,6 +1037,10 @@ static int local_shutdown(FAR struct socket *psock, int how)
 #endif
 #ifdef CONFIG_NET_LOCAL_DGRAM
       case SOCK_DGRAM:
+        return -EOPNOTSUPP;
+#endif
+#if defined(CONFIG_NET_LOCAL_STREAM) || defined(CONFIG_NET_LOCAL_DGRAM)
+      case SOCK_CTRL:
         return -EOPNOTSUPP;
 #endif
       default:

--- a/net/netlink/netlink_sockif.c
+++ b/net/netlink/netlink_sockif.c
@@ -136,7 +136,8 @@ static int netlink_setup(FAR struct socket *psock)
 
   /* Verify the socket type (domain should always be PF_NETLINK here) */
 
-  if (domain == PF_NETLINK && (type == SOCK_RAW || type == SOCK_DGRAM))
+  if (domain == PF_NETLINK &&
+      (type == SOCK_RAW || type == SOCK_DGRAM || type == SOCK_CTRL))
     {
       /* Allocate the NetLink socket connection structure and save it in the
        * new socket instance.

--- a/net/pkt/pkt_sockif.c
+++ b/net/pkt/pkt_sockif.c
@@ -150,10 +150,10 @@ static int pkt_setup(FAR struct socket *psock)
    * connection structure, it is unallocated at this point.  It will not
    * actually be initialized until the socket is connected.
    *
-   * Only SOCK_RAW is supported.
+   * SOCK_RAW and SOCK_CTRL are supported.
    */
 
-  if (psock->s_type == SOCK_RAW)
+  if (psock->s_type == SOCK_RAW || psock->s_type == SOCK_CTRL)
     {
       return pkt_sockif_alloc(psock);
     }
@@ -203,7 +203,7 @@ static void pkt_addref(FAR struct socket *psock)
   FAR struct pkt_conn_s *conn;
 
   DEBUGASSERT(psock != NULL && psock->s_conn != NULL &&
-              psock->s_type == SOCK_RAW);
+              (psock->s_type == SOCK_RAW || psock->s_type == SOCK_CTRL));
 
   conn = psock->s_conn;
   DEBUGASSERT(conn->crefs > 0 && conn->crefs < 255);
@@ -334,7 +334,7 @@ static int pkt_bind(FAR struct socket *psock,
 
   /* Bind a raw socket to a network device. */
 
-  if (psock->s_type == SOCK_RAW)
+  if (psock->s_type == SOCK_RAW || psock->s_type == SOCK_CTRL)
     {
       FAR struct pkt_conn_s *conn = (FAR struct pkt_conn_s *)psock->s_conn;
       FAR struct net_driver_s *dev;
@@ -517,6 +517,7 @@ static int pkt_close(FAR struct socket *psock)
   switch (psock->s_type)
     {
       case SOCK_RAW:
+      case SOCK_CTRL:
         {
           FAR struct pkt_conn_s *conn = psock->s_conn;
 


### PR DESCRIPTION
## Summary

SOCK_CTRL is added to provide special control over network drivers and daemons. Currently, SOCK_DGRAM and SOCK_STREAM perform this control, but these use socket resources. In the case of usersocket in particular, this is a waste of the device's limited socket resources.

## Impact

Applications using NET_SOCK_TYPE.

## Testing

Confirmed that it works with spresense:rndis and qemu-armv8a:netnsh config.
