### PR TITLE
STM32H7 socketcan extended filter fixes

### DIFF
--- a/arch/arm/src/stm32h7/hardware/stm32_fdcan.h
+++ b/arch/arm/src/stm32h7/hardware/stm32_fdcan.h
@@ -698,7 +698,7 @@
 /* ***************  Bit definition for FDCAN_XIDFC register  ****************/
 #define FDCAN_XIDFC_FLESA_SHIFT   (2U)
 #define FDCAN_XIDFC_FLESA_MASK    (0x3FFFU << FDCAN_XIDFC_FLESA_SHIFT)          /* 0x0000FFFC */
-#define FDCAN_XIDFC_FLESA         FDCAN_XIDFC_FLESA_MASK                        /* Filter List Standard Start Address        */
+#define FDCAN_XIDFC_FLESA         FDCAN_XIDFC_FLESA_MASK                        /* Filter List Extended Start Address        */
 #define FDCAN_XIDFC_LSE_SHIFT     (16U)
 #define FDCAN_XIDFC_LSE_MASK      (0xFFU << FDCAN_XIDFC_LSE_SHIFT)              /* 0x00FF0000 */
 #define FDCAN_XIDFC_LSE           FDCAN_XIDFC_LSE_MASK                          /* List Size Extended                        */

--- a/arch/arm/src/stm32h7/stm32_fdcan_sock.c
+++ b/arch/arm/src/stm32h7/stm32_fdcan_sock.c
@@ -2236,9 +2236,22 @@ int fdcan_initialize(struct fdcan_driver_s *priv)
   putreg32(regval, priv->base + STM32_FDCAN_SIDFC_OFFSET);
   ram_offset += n_stdid;
 
-  /* Extended ID Filters: Allow space for 128 filters (128 words) */
+  /* Extended ID Filters: Allow space for 64 filters (64 words)
+   * The register definition of FDCAN_XIDFC:LSE - List size extended, in the
+   * reference manual (RM0433 Rev 8) is defined as 8 bits and claims that a
+   * value of 0-128 (Number of extended ID filter elements) are possible, but
+   * in the text in section 56.4.22 and in STM32CubeH7's HAL it's only 64.
+   *
+   * HAL source:
+   * https://github.com/STMicroelectronics/STM32CubeH7/blob/
+   * 43c9e552ba1c038577c48723d96ca8c825b11987/Drivers/STM32H7xx_HAL_Driver/
+   * Inc/stm32h7xx_hal_fdcan.h#L112-L113
+   *
+   * Discussion:
+   * https://community.st.com/s/question/0D73W000001nzqFSAQ
+   */
 
-  const uint8_t n_extid = 128;
+  const uint8_t n_extid = 64;
   priv->message_ram.filt_extid_addr = gl_ram_base + ram_offset * WORD_LENGTH;
 
   regval = (n_extid << FDCAN_XIDFC_LSE_SHIFT) & FDCAN_XIDFC_LSE_MASK;


### PR DESCRIPTION
## Summary

When I checked how this register was set I discovered that 128 was not accepted by the H7 but 64 was ok. Looking at the STM32Cube's HAL it seems to be only 64 words long, however, the reference manual claims otherwise.

I have opened a discussion on the ST community forum https://community.st.com/s/question/0D73W000001nzqFSAQ but unfortunately not received an answer yet.

In the meantime, I think, we should update this to what I found to be working though. The respective questions is in https://community.st.com/s/question/0D53W00001xRGuQSAW.

## Impact

I expect this to help to get socketcan working on H7. Plus I needed to manually set the filters to 0 because they didn't seem to be initialized at zero. This is strange and I still need to investigate it closer.

## Testing

I've tested this on a board but it would be great if someone could cross test this on another platform, if possible.

FYI @davids5 
