### PR TITLE
arch/pic32mz: Fix PPS mappings for RPE5R register

### DIFF
--- a/arch/mips/src/pic32mz/hardware/pic32mzec_pps.h
+++ b/arch/mips/src/pic32mz/hardware/pic32mzec_pps.h
@@ -144,7 +144,7 @@
 #  define PIC32MZ_RPD15R_OFFSET          0x15fc
 #define PIC32MZ_RPEnR_OFFSET(n)          (0x1600 + ((n) << 2)) /* n=3,5,8-9 */
 #  define PIC32MZ_RPE3R_OFFSET           0x160c
-#  define PIC32MZ_RPE4R_OFFSET           0x1614
+#  define PIC32MZ_RPE5R_OFFSET           0x1614
 #  define PIC32MZ_RPE8R_OFFSET           0x1620
 #  define PIC32MZ_RPE9R_OFFSET           0x1624
 #define PIC32MZ_RPFnR_OFFSET(n)          (0x1640 + ((n) << 2)) /* n=0-5,8,12-13 */
@@ -276,7 +276,7 @@
 #  define PIC32MZ_RPD15R                 (PIC32MZ_SFR_K1BASE+PIC32MZ_RPD15R_OFFSET)
 #define PIC32MZ_RPEnR(n)                 (PIC32MZ_SFR_K1BASE+PIC32MZ_RPEnR_OFFSET(n))
 #  define PIC32MZ_RPE3R                  (PIC32MZ_SFR_K1BASE+PIC32MZ_RPE3R_OFFSET)
-#  define PIC32MZ_RPE4R                  (PIC32MZ_SFR_K1BASE+PIC32MZ_RPE4R_OFFSET)
+#  define PIC32MZ_RPE5R                  (PIC32MZ_SFR_K1BASE+PIC32MZ_RPE5R_OFFSET)
 #  define PIC32MZ_RPE8R                  (PIC32MZ_SFR_K1BASE+PIC32MZ_RPE8R_OFFSET)
 #  define PIC32MZ_RPE9R                  (PIC32MZ_SFR_K1BASE+PIC32MZ_RPE9R_OFFSET)
 #define PIC32MZ_RPFnR(n)                 (PIC32MZ_SFR_K1BASE+PIC32MZ_RPFnR_OFFSET(n))

--- a/arch/mips/src/pic32mz/hardware/pic32mzef_pps.h
+++ b/arch/mips/src/pic32mz/hardware/pic32mzef_pps.h
@@ -144,7 +144,7 @@
 #  define PIC32MZ_RPD15R_OFFSET          0x15fc
 #define PIC32MZ_RPEnR_OFFSET(n)          (0x1600 + ((n) << 2)) /* n=3,5,8-9 */
 #  define PIC32MZ_RPE3R_OFFSET           0x160c
-#  define PIC32MZ_RPE4R_OFFSET           0x1614
+#  define PIC32MZ_RPE5R_OFFSET           0x1614
 #  define PIC32MZ_RPE8R_OFFSET           0x1620
 #  define PIC32MZ_RPE9R_OFFSET           0x1624
 #define PIC32MZ_RPFnR_OFFSET(n)          (0x1640 + ((n) << 2)) /* n=0-5,8,12-13 */
@@ -278,7 +278,7 @@
 #  define PIC32MZ_RPD15R                 (PIC32MZ_SFR_K1BASE+PIC32MZ_RPD15R_OFFSET)
 #define PIC32MZ_RPEnR(n)                 (PIC32MZ_SFR_K1BASE+PIC32MZ_RPEnR_OFFSET(n))
 #  define PIC32MZ_RPE3R                  (PIC32MZ_SFR_K1BASE+PIC32MZ_RPE3R_OFFSET)
-#  define PIC32MZ_RPE4R                  (PIC32MZ_SFR_K1BASE+PIC32MZ_RPE4R_OFFSET)
+#  define PIC32MZ_RPE5R                  (PIC32MZ_SFR_K1BASE+PIC32MZ_RPE5R_OFFSET)
 #  define PIC32MZ_RPE8R                  (PIC32MZ_SFR_K1BASE+PIC32MZ_RPE8R_OFFSET)
 #  define PIC32MZ_RPE9R                  (PIC32MZ_SFR_K1BASE+PIC32MZ_RPE9R_OFFSET)
 #define PIC32MZ_RPFnR(n)                 (PIC32MZ_SFR_K1BASE+PIC32MZ_RPFnR_OFFSET(n))


### PR DESCRIPTION
## Summary

On PIC32MZ, the defines for Peripheral Pin Select (PPS) register RPE5R were called RPE4R inadvertently; however, mappings elsewhere in the file used the correct name of RPE5R, so the build would break if anyone attempted to map those peripherals to GPIO pin E5. This issue is now fixed.

## Impact

It is possible to map peripheral output pins to GPIO pin E5 now.

## Testing

Build is no longer broken on this issue in custom board port in progress.