### PR TITLE
Fix typos: s/UARt/UART/

### DIFF
--- a/arch/mips/src/pic32mz/pic32mz_lowconsole.c
+++ b/arch/mips/src/pic32mz/pic32mz_lowconsole.c
@@ -317,7 +317,7 @@ void pic32mz_consoleinit(void)
 
   /* Setup up pin selection registers for all configured UARTs.  The board.h
    * header file must provide these definitions to select the correct pin
-   * configuration for each enabled UARt.
+   * configuration for each enabled UART.
    */
 
 #ifdef CONFIG_PIC32MZ_UART1

--- a/arch/sparc/src/s698pm/s698pm-lowconsole.c
+++ b/arch/sparc/src/s698pm/s698pm-lowconsole.c
@@ -212,7 +212,7 @@ void s698pm_consoleinit(void)
 
   /* Setup up pin selection registers for all configured UARTs.  The board.h
    * header file must provide these definitions to select the correct pin
-   * configuration for each enabled UARt.
+   * configuration for each enabled UART.
    */
 
   gpreg = getreg32(S698PM_GPREG_BASE);

--- a/boards/arm/sama5/sama5d2-xult/README.txt
+++ b/boards/arm/sama5/sama5d2-xult/README.txt
@@ -72,7 +72,7 @@ REVISIT: Unverified, cloned text from the SAMA5D4-EK README.txt
 
   NuttX may be executed from SDRAM.  But this case means that the NuttX
   binary must reside on some other media (typically NAND FLASH, Serial
-  FLASH) or transferred over some interface (perhaps a UARt or even a
+  FLASH) or transferred over some interface (perhaps a UART or even a
   TFTP server).  In these cases, an intermediate bootloader such as U-Boot
   or Barebox must be used to configure the SAMA5D2 clocks and SDRAM and
   then to copy the NuttX binary into SDRAM.

--- a/boards/arm/sama5/sama5d4-ek/README.txt
+++ b/boards/arm/sama5/sama5d4-ek/README.txt
@@ -492,7 +492,7 @@ Running NuttX from SDRAM
 
   NuttX may be executed from SDRAM.  But this case means that the NuttX
   binary must reside on some other media (typically NAND FLASH, Serial
-  FLASH) or transferred over some interface (perhaps a UARt or even a
+  FLASH) or transferred over some interface (perhaps a UART or even a
   TFTP server).  In these cases, an intermediate bootloader such as U-Boot
   or Barebox must be used to configure the SAMA5D4 clocks and SDRAM and
   then to copy the NuttX binary into SDRAM.


### PR DESCRIPTION
## Summary

Fix four copy-paste instances of a typo in comments and README files.

## Impact

Correctness and greppability.

## Testing

No functional change.