### PR TITLE
mmsd fixes to ensure CPU is not busy waited

### DIFF
--- a/drivers/mmcsd/mmcsd_sdio.c
+++ b/drivers/mmcsd/mmcsd_sdio.c
@@ -1190,7 +1190,7 @@ static int mmcsd_transferready(FAR struct mmcsd_state_s *priv)
 
   /* First, check if the card has been removed. */
 
-  if (!SDIO_PRESENT(priv->dev))
+  if (IS_EMPTY(priv) || !SDIO_PRESENT(priv->dev))
     {
       ferr("ERROR: Card has been removed\n");
       return -ENODEV;

--- a/drivers/mmcsd/mmcsd_sdio.c
+++ b/drivers/mmcsd/mmcsd_sdio.c
@@ -1268,6 +1268,10 @@ static int mmcsd_transferready(FAR struct mmcsd_state_s *priv)
           goto errorout;
         }
 
+      /* Do not hog the CPU */
+
+      nxsig_usleep(1000);
+
       /* We are still in the programming state. Calculate the elapsed
        * time... we can't stay in this loop forever!
        */


### PR DESCRIPTION
## Summary

   mmcsd_removed will be called if the card is in invalid state.
   This can happen if the card is bad, or vibrations causes a power
   loss.

   mmcsd_removed resets:
     priv->capacity     = 0; /* Capacity=0 sometimes means no media */
     priv->blocksize    = 0;
     priv->probed       = false;
     priv->mediachanged = false;
     priv->wrbusy       = false;
     priv->type         = MMCSD_CARDTYPE_UNKNOWN;
     priv->rca          = 0;
     priv->selblocklen  = 0;
     priv->widebus      = false;

  If blocksize is set to 0 will cause the log2 to result
  in an infinate loop in some drivers.

  IS_EMPTY will check for priv->type = MMCSD_CARDTYPE_UNKNOWN
  and return ENODEV.

mmcsd_sdio:Release CPU during wait for Write Completion
   Even if CONFIG_MMCSD_SDIOWAIT_WRCOMPLETE is set on an error the CPU could be busy waited for a second.
   
## Impact
System will not hang.

## Testing
PX4 px4_fmu_v5x: While doing SD testing using `logger` or `sd_bench`, short the CMD line during a command. 
Prior to this change the write would fail (22) but the close would hang indefinitely.



