### PR TITLE
stm32_eth: Busy bit is cleared before accessing the MACMIIAR register.

### DIFF
--- a/arch/arm/src/stm32/stm32_eth.c
+++ b/arch/arm/src/stm32/stm32_eth.c
@@ -2853,15 +2853,21 @@ static int stm32_phyread(uint16_t phydevaddr,
   volatile uint32_t timeout;
   uint32_t regval;
 
+  regval = stm32_getreg(STM32_ETH_MACMIIAR);
+
+  /* Clear the busy bit before accessing the MACMIIAR register. */
+
+  regval &= ~ETH_MACMIIAR_MB;
+  stm32_putreg(regval, STM32_ETH_MACMIIAR);
+
   /* Configure the MACMIIAR register,
    * preserving CSR Clock Range CR[2:0] bits
    */
 
-  regval  = stm32_getreg(STM32_ETH_MACMIIAR);
   regval &= ETH_MACMIIAR_CR_MASK;
 
-  /* Set the PHY device address, PHY register address, and set the buy bit.
-   * the  ETH_MACMIIAR_MW is clear, indicating a read operation.
+  /* Set the PHY device address, PHY register address, and set the busy bit.
+   * the ETH_MACMIIAR_MW is clear, indicating a read operation.
    */
 
   regval |= (phydevaddr << ETH_MACMIIAR_PA_SHIFT) & ETH_MACMIIAR_PA_MASK;
@@ -2912,15 +2918,21 @@ static int stm32_phywrite(uint16_t phydevaddr,
   volatile uint32_t timeout;
   uint32_t regval;
 
+  regval = stm32_getreg(STM32_ETH_MACMIIAR);
+
+  /* Clear the busy bit before accessing the MACMIIAR register. */
+
+  regval &= ~ETH_MACMIIAR_MB;
+  stm32_putreg(regval, STM32_ETH_MACMIIAR);
+
   /* Configure the MACMIIAR register,
    * preserving CSR Clock Range CR[2:0] bits
    */
 
-  regval  = stm32_getreg(STM32_ETH_MACMIIAR);
   regval &= ETH_MACMIIAR_CR_MASK;
 
   /* Set the PHY device address, PHY register address, and set the busy bit.
-   * the  ETH_MACMIIAR_MW is set, indicating a write operation.
+   * the ETH_MACMIIAR_MW is set, indicating a write operation.
    */
 
   regval |= (phydevaddr << ETH_MACMIIAR_PA_SHIFT) & ETH_MACMIIAR_PA_MASK;


### PR DESCRIPTION
## Summary

According to the [reference manual](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&ved=2ahUKEwiUy5K15Jr9AhVrS_EDHRyVBBYQFnoECAkQAQ&url=https%3A%2F%2Fwww.st.com%2Fresource%2Fen%2Freference_manual%2FDM00031020-.pdf&usg=AOvVaw0nlYG0-E_-S5C6634BQCvf) page 1197, the "busy" bit in the `MACMIIAR` register **must** be cleared before accessing the `MACMIIAR` and the `MACMIIDR` registers.

Typically, this bit should already be cleared by the MAC during the last operation.  
However I cannot see any way that this is guaranteed. The previous operation may have timed-out, and the bit may be still set. I am not sure whether any errors in the MAC may leave this bit set indefinitely.

Now, the bit is always cleared, as it ought to be, before any access to the aforementioned registers.

## Impact

More "correct" operation of the STM32 Ethernet driver.  
It is possible that it also solves a very rare bug that I encounter, where the MAC data are corrupted.

## Testing

Tested on a custom target, based on the STM32F427 MCU.  
This firmware makes a lot of `SIOCGMIIREG` `ioctl()`'s and so far everything works great.

