### PR TITLE
arch/pic32mz: Serial TIOCxBRK BSD-compatible BREAK support

### DIFF
--- a/arch/mips/src/pic32mz/Kconfig
+++ b/arch/mips/src/pic32mz/Kconfig
@@ -261,6 +261,27 @@ config PIC32MZ_UART6
 	select UART6_SERIALDRIVER
 	select ARCH_HAVE_SERIAL_TERMIOS
 
+config PIC32MZ_UART_BREAKS
+	bool "Add TIOxSBRK to support sending Breaks"
+	depends on PIC32MZ_UART1 || PIC32MZ_UART2 || PIC32MZ_UART3 || PIC32MZ_UART4 || PIC32MZ_UART5 || PIC32MZ_UART6
+	default n
+	---help---
+		Add TIOCxBRK routines to send a line break per the PIC32MZ manual.
+		The break consists of a start bit, 12 zero bits, and a stop bit.
+		This is not a BSD compatible break.
+
+config PIC32MZ_SERIALBRK_BSDCOMPAT
+	bool "Use GPIO to send Break"
+	depends on PIC32MZ_UART_BREAKS
+	default n
+	---help---
+		Enable using GPIO on the TX pin to send a BSD compatible break:
+		TIOCSBRK will start the break and TIOCCBRK will end the break. The
+		current PIC32MZ UARTS have no way to leave the break on (TX=LOW)
+		because software starts the break and then the hardware
+		automatically clears the break. This makes it difficult to send a
+		long break.
+
 config PIC32MZ_ADC
 	bool "ADC1"
 	default n

--- a/arch/mips/src/pic32mz/hardware/pic32mz_pps.h
+++ b/arch/mips/src/pic32mz/hardware/pic32mz_pps.h
@@ -76,6 +76,74 @@
 #define __PPS_OUTPUT_REGVAL(a,b)  ((uint32_t)(a))
 #define PPS_OUTPUT_REGVAL(a)  __PPS_OUTPUT_REGVAL(a)
 
+/* The following macro converts from a peripheral output pin mapping to the
+ * corresponding GPIO port and pin. This allows drivers to do things like
+ * temporarily change a pin's configuration from peripheral to GPIO to
+ * override some hardware behavior. Having this macro available to driver
+ * code relieves the board's include/board.h from redundantly defining both
+ * the PPS mapping and the GPIO port/pin information.
+ *
+ * NOTE: This is written in the same odd macro forms as above for the same
+ * reason.
+ */
+#define __PPS_OUTPUT_REGADDR_TO_GPIO(a,b) ((uint32_t)( \
+          ((b) == PIC32MZ_RPA14R) ? (GPIO_PORTA | GPIO_PIN14) : \
+          ((b) == PIC32MZ_RPA15R) ? (GPIO_PORTA | GPIO_PIN15) : \
+          ((b) == PIC32MZ_RPB0R)  ? (GPIO_PORTB | GPIO_PIN0)  : \
+          ((b) == PIC32MZ_RPB10R) ? (GPIO_PORTB | GPIO_PIN10) : \
+          ((b) == PIC32MZ_RPB14R) ? (GPIO_PORTB | GPIO_PIN14) : \
+          ((b) == PIC32MZ_RPB15R) ? (GPIO_PORTB | GPIO_PIN15) : \
+          ((b) == PIC32MZ_RPB1R)  ? (GPIO_PORTB | GPIO_PIN1)  : \
+          ((b) == PIC32MZ_RPB2R)  ? (GPIO_PORTB | GPIO_PIN2)  : \
+          ((b) == PIC32MZ_RPB3R)  ? (GPIO_PORTB | GPIO_PIN3)  : \
+          ((b) == PIC32MZ_RPB5R)  ? (GPIO_PORTB | GPIO_PIN5)  : \
+          ((b) == PIC32MZ_RPB6R)  ? (GPIO_PORTB | GPIO_PIN6)  : \
+          ((b) == PIC32MZ_RPB7R)  ? (GPIO_PORTB | GPIO_PIN7)  : \
+          ((b) == PIC32MZ_RPB8R)  ? (GPIO_PORTB | GPIO_PIN8)  : \
+          ((b) == PIC32MZ_RPB9R)  ? (GPIO_PORTB | GPIO_PIN9)  : \
+          ((b) == PIC32MZ_RPC13R) ? (GPIO_PORTC | GPIO_PIN13) : \
+          ((b) == PIC32MZ_RPC14R) ? (GPIO_PORTC | GPIO_PIN14) : \
+          ((b) == PIC32MZ_RPC1R)  ? (GPIO_PORTC | GPIO_PIN1)  : \
+          ((b) == PIC32MZ_RPC2R)  ? (GPIO_PORTC | GPIO_PIN2)  : \
+          ((b) == PIC32MZ_RPC3R)  ? (GPIO_PORTC | GPIO_PIN3)  : \
+          ((b) == PIC32MZ_RPC4R)  ? (GPIO_PORTC | GPIO_PIN4)  : \
+          ((b) == PIC32MZ_RPD0R)  ? (GPIO_PORTD | GPIO_PIN0)  : \
+          ((b) == PIC32MZ_RPD10R) ? (GPIO_PORTD | GPIO_PIN10) : \
+          ((b) == PIC32MZ_RPD11R) ? (GPIO_PORTD | GPIO_PIN11) : \
+          ((b) == PIC32MZ_RPD12R) ? (GPIO_PORTD | GPIO_PIN12) : \
+          ((b) == PIC32MZ_RPD14R) ? (GPIO_PORTD | GPIO_PIN14) : \
+          ((b) == PIC32MZ_RPD15R) ? (GPIO_PORTD | GPIO_PIN15) : \
+          ((b) == PIC32MZ_RPD1R)  ? (GPIO_PORTD | GPIO_PIN1)  : \
+          ((b) == PIC32MZ_RPD2R)  ? (GPIO_PORTD | GPIO_PIN2)  : \
+          ((b) == PIC32MZ_RPD3R)  ? (GPIO_PORTD | GPIO_PIN3)  : \
+          ((b) == PIC32MZ_RPD4R)  ? (GPIO_PORTD | GPIO_PIN4)  : \
+          ((b) == PIC32MZ_RPD5R)  ? (GPIO_PORTD | GPIO_PIN5)  : \
+          ((b) == PIC32MZ_RPD6R)  ? (GPIO_PORTD | GPIO_PIN6)  : \
+          ((b) == PIC32MZ_RPD7R)  ? (GPIO_PORTD | GPIO_PIN7)  : \
+          ((b) == PIC32MZ_RPD9R)  ? (GPIO_PORTD | GPIO_PIN9)  : \
+          ((b) == PIC32MZ_RPE3R)  ? (GPIO_PORTE | GPIO_PIN3)  : \
+          ((b) == PIC32MZ_RPE5R)  ? (GPIO_PORTE | GPIO_PIN5)  : \
+          ((b) == PIC32MZ_RPE8R)  ? (GPIO_PORTE | GPIO_PIN8)  : \
+          ((b) == PIC32MZ_RPE9R)  ? (GPIO_PORTE | GPIO_PIN9)  : \
+          ((b) == PIC32MZ_RPF0R)  ? (GPIO_PORTF | GPIO_PIN0)  : \
+          ((b) == PIC32MZ_RPF12R) ? (GPIO_PORTF | GPIO_PIN12) : \
+          ((b) == PIC32MZ_RPF13R) ? (GPIO_PORTF | GPIO_PIN13) : \
+          ((b) == PIC32MZ_RPF1R)  ? (GPIO_PORTF | GPIO_PIN1)  : \
+          ((b) == PIC32MZ_RPF2R)  ? (GPIO_PORTF | GPIO_PIN2)  : \
+          ((b) == PIC32MZ_RPF3R)  ? (GPIO_PORTF | GPIO_PIN3)  : \
+          ((b) == PIC32MZ_RPF4R)  ? (GPIO_PORTF | GPIO_PIN4)  : \
+          ((b) == PIC32MZ_RPF5R)  ? (GPIO_PORTF | GPIO_PIN5)  : \
+          ((b) == PIC32MZ_RPF8R)  ? (GPIO_PORTF | GPIO_PIN8)  : \
+          ((b) == PIC32MZ_RPG0R)  ? (GPIO_PORTG | GPIO_PIN0)  : \
+          ((b) == PIC32MZ_RPG1R)  ? (GPIO_PORTG | GPIO_PIN1)  : \
+          ((b) == PIC32MZ_RPG6R)  ? (GPIO_PORTG | GPIO_PIN6)  : \
+          ((b) == PIC32MZ_RPG7R)  ? (GPIO_PORTG | GPIO_PIN7)  : \
+          ((b) == PIC32MZ_RPG8R)  ? (GPIO_PORTG | GPIO_PIN8)  : \
+          ((b) == PIC32MZ_RPG9R)  ? (GPIO_PORTG | GPIO_PIN9)  : \
+          0                                                     \
+        ))
+#define PPS_OUTPUT_REGADDR_TO_GPIO(a) __PPS_OUTPUT_REGADDR_TO_GPIO(a)
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/


### PR DESCRIPTION
## Summary

In the lower half UART driver for PIC32MZ architecture, adding the `TIOCxBRK` ioctl calls (`TIOCSBRK` and `TIOCCBRK`). These allow an application to transmit a BREAK (either hardware-native or BSD compatible).

This architecture does not support BSD-style BREAK in hardware so our implementation follows the precedent set in STM32, GD32, and Kinetis architectures: By default, if only `PIC32MZ_UART_BREAKS` is configured, we produce the hardware-native BREAK, which lasts for 12 bit lengths on this architecture; if, in addition, `PIC32MZ_SERIALBRK_BSDCOMPAT` is also configured, we generate a BSD-style BREAK by putting the TX pin in GPIO mode and driving it "manually" until told to stop.

## Impact

When `PIC32MZ_UART_BREAKS ` is activated, `TIOCSBRK` and `TIOCCBRK` ioctl calls are supported on PIC32MZ architectures. When `PIC32MZ_SERIALBRK_BSDCOMPAT` is also activated, the ioctl calls are BSD-compatible. When not activated, no effect.

## Testing

Works on custom board.
nxstyle.
