### PR TITLE
libc: unistd: lib_getrlimit: return a value for RLIMIT_NOFILE request.

### DIFF
--- a/libs/libc/unistd/lib_getrlimit.c
+++ b/libs/libc/unistd/lib_getrlimit.c
@@ -61,7 +61,7 @@ int getrlimit(int resource, FAR struct rlimit *rlp)
       case RLIMIT_NOFILE:
         {
           rlp->rlim_cur = 128;
-          rlp->rlim_max = 1024 * 1024; /* dummy */
+          rlp->rlim_max = INT_MAX; /* dummy */
         }
         break;
 

--- a/libs/libc/unistd/lib_getrlimit.c
+++ b/libs/libc/unistd/lib_getrlimit.c
@@ -60,8 +60,8 @@ int getrlimit(int resource, FAR struct rlimit *rlp)
     {
       case RLIMIT_NOFILE:
         {
-          rlp->rlim_cur = 128;
-          rlp->rlim_max = INT_MAX; /* dummy */
+          rlp->rlim_cur = OPEN_MAX;
+          rlp->rlim_max = OPEN_MAX;
         }
         break;
 

--- a/libs/libc/unistd/lib_getrlimit.c
+++ b/libs/libc/unistd/lib_getrlimit.c
@@ -55,5 +55,19 @@ int getrlimit(int resource, FAR struct rlimit *rlp)
   /* This is a dummy realization to make the compiler happy */
 
   memset(rlp, 0, sizeof(*rlp));
+
+  switch (resource)
+    {
+      case RLIMIT_NOFILE:
+        {
+          rlp->rlim_cur = 128;
+          rlp->rlim_max = 1024 * 1024; /* dummy */
+        }
+        break;
+
+      default:
+        break;
+    }
+
   return OK;
 }


### PR DESCRIPTION
In the Nim language "selectors"(I/O multiplexing) module, the maximum number of file descriptors is obtained with getrlimit() as follows.

```nim
        var fdLim: RLimit
        var res = int(getrlimit(RLIMIT_NOFILE, fdLim))
        if res >= 0:
          res = int(fdLim.rlim_cur) - 1
```

To be able to use the same implementation as other POSIX-based OS, getrlimit() should return a value.
(For now, let it return 128.)
