### PR TITLE
task/task_cancelpt: Kill the child if it is not in a cancel point

### DIFF
--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -110,6 +110,7 @@
 #define GROUP_FLAG_NOCLDWAIT       (1 << 0)                      /* Bit 0: Do not retain child exit status */
 #define GROUP_FLAG_PRIVILEGED      (1 << 1)                      /* Bit 1: Group is privileged */
 #define GROUP_FLAG_DELETED         (1 << 2)                      /* Bit 2: Group has been deleted but not yet freed */
+#define GROUP_FLAG_EXITING         (1 << 3)                      /* Bit 3: Group exit is in progress */
                                                                  /* Bits 3-7: Available */
 
 /* Values for struct child_status_s ch_flags */

--- a/sched/group/group_killchildren.c
+++ b/sched/group/group_killchildren.c
@@ -132,6 +132,8 @@ int group_kill_children(FAR struct tcb_s *tcb)
 {
   int ret;
 
+  DEBUGASSERT(tcb->group);
+
 #ifdef CONFIG_SMP
   /* NOTE: sched_lock() is not enough for SMP
    * because tcb->group will be accessed from the child tasks
@@ -145,8 +147,14 @@ int group_kill_children(FAR struct tcb_s *tcb)
 
   sched_lock();
 #endif
+
+  /* Tell the children that this group has started exiting */
+
+  tcb->group->tg_flags |= GROUP_FLAG_EXITING;
+
   ret = group_foreachchild(tcb->group, group_kill_children_handler,
                            (FAR void *)((uintptr_t)tcb->pid));
+
 #ifdef CONFIG_SMP
   leave_critical_section(flags);
 #else


### PR DESCRIPTION
## Summary
Do not allow a deferred cancellation if the group is exiting, it is too dangerous to allow the threads to execute any user space code after the exit has started.

If the cancelled thread is not inside a cancellation point, just kill it immediately via asynchronous cancellation. This will create far less problems than allowing it to continue running user code.

## Impact
group_kill_children behaves the same way whether cancel points are enabled or not

## Testing
icicle:knsh
