### PR TITLE
drivers/mtd/ramtron: change nsectors size to uint32

### DIFF
--- a/drivers/mtd/ramtron.c
+++ b/drivers/mtd/ramtron.c
@@ -143,7 +143,7 @@ struct ramtron_dev_s
   FAR struct spi_dev_s *dev;               /* Saved SPI interface instance */
   uint8_t sectorshift;
   uint8_t pageshift;
-  uint16_t nsectors;
+  uint32_t nsectors;
   uint32_t npages;
   uint32_t speed;                          /* Overridable via ioctl */
   FAR const struct ramtron_parts_s *part;  /* Part instance */


### PR DESCRIPTION
## Summary
PR https://github.com/apache/nuttx/pull/8453 allows for FRAM to reduce the size for sectors to 1 byte. 
I was testing this with FM25V05 which has a size of 65536 bytes (in this case nsectors = 65536) that was enough to not fit into uint16 with config:
```
CONFIG_RAMTRON_EMULATE_PAGE_SHIFT=0
CONFIG_RAMTRON_EMULATE_SECTOR_SHIFT=0
```

## Impact
Impacts all FRMAs with 64 KiB or more. 

## Testing
Tested with the board that has FM25V05 (64 KiB). 

