### PR TITLE
signal/sig_dispatch: Signal action was not performed if TCB_FLAG_SYSC…

### DIFF
--- a/sched/signal/sig_dispatch.c
+++ b/sched/signal/sig_dispatch.c
@@ -372,6 +372,15 @@ int nxsig_tcbdispatch(FAR struct tcb_s *stcb, siginfo_t *info)
   if (masked == 1)
 #endif
     {
+#ifdef CONFIG_LIB_SYSCALL
+      /* If the thread is in syscall, schedule the sigaction here */
+
+      if ((stcb->flags & TCB_FLAG_SYSCALL) != 0)
+        {
+          nxsig_add_pendingsignal(stcb, info);
+        }
+#endif
+
       /* Check if the task is waiting for this pending signal. If so, then
        * unblock it. This must be performed in a critical section because
        * signals can be queued from the interrupt level.


### PR DESCRIPTION
…ALL is set

## Summary
For some reason the signal action was never performed if the receiving task was within a system call, the pending queue insert was simply missing.

This fixes the issue.
## Impact
Fixes signal action delivery when  CONFIG_LIB_SYSCALL=y

## Testing
icicle:knsh
