### PR TITLE
stm32_eth: Enabled store-end-forward.

### DIFF
--- a/arch/arm/src/stm32/stm32_eth.c
+++ b/arch/arm/src/stm32/stm32_eth.c
@@ -485,12 +485,10 @@
  * ETH_DMAOMR_ST    Start/stop transmission      0 (not running)
  * ETH_DMAOMR_TTC   Transmit threshold control   0 (64 bytes)
  * ETH_DMAOMR_FTF   Flush transmit FIFO          0 (no flush)
- * ETH_DMAOMR_TSF   Transmit store and forward   Depends on
- *                                               CONFIG_STM32_ETH_HWCHECKSUM
+ * ETH_DMAOMR_TSF   Transmit store and forward   1 (enabled)
  * ETH_DMAOMR_DFRF  Disable flushing of received 0 (enabled)
  *                  frames
- * ETH_DMAOMR_RSF   Receive store and forward    Depends on
- *                                               CONFIG_STM32_ETH_HWCHECKSUM
+ * ETH_DMAOMR_RSF   Receive store and forward    1 (enabled)
  * TH_DMAOMR_DTCEFD Dropping of TCP/IP checksum  Depends on
  *                  error frames disable         CONFIG_STM32_ETH_HWCHECKSUM
  *
@@ -507,7 +505,7 @@
 #else
 #  define DMAOMR_SET_MASK \
     (ETH_DMAOMR_OSF | ETH_DMAOMR_RTC_64 | ETH_DMAOMR_TTC_64 | \
-     ETH_DMAOMR_DTCEFD)
+     ETH_DMAOMR_TSF | ETH_DMAOMR_RSF | ETH_DMAOMR_DTCEFD)
 #endif
 
 /* Clear the DMABMR bits that will be setup during MAC initialization (or


### PR DESCRIPTION
## Summary

The DMA of the Ethernet peripheral of the STM32F4's support store-and-forward.  
This functionality is disabled though.

However, I noticed in the device Errata that it **must** be enabled, due to a device limitation.

[Errata sheet - 2.17.4](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&cad=rja&uact=8&ved=2ahUKEwj0kc2isJ39AhWccfEDHeGWCjwQFnoECB4QAQ&url=https%3A%2F%2Fwww.st.com%2Fresource%2Fen%2Ferrata_sheet%2Fes0206-stm32f427437-and-stm32f429439-line-limitations-stmicroelectronics.pdf&usg=AOvVaw3cIFVVJpRRy-Tg9RM2bV7X)

> **2.17.4 - Transmit frame data corruption**
> Frame data corrupted when the TxFIFO is repeatedly transitioning from non-empty to empty
> and then back to non-empty.
> 
> **Description**
> Frame data may get corrupted when the TxFIFO is repeatedly transitioning from non-empty
> to empty for a very short period, and then from empty to non-empty, without causing an
> underflow.
> This transitioning from non-empty to empty and back to non-empty happens when the rate
> at which the data is being written to the TxFIFO is almost equal to or a little less than the
> rate at which the data is being read.
> This corruption cannot be detected by the receiver when the CRC is inserted by the MAC,
> as the corrupted data is used for the CRC computation.
> 
> **Workaround**
> Use the Store-and-Forward mode: TSF=1 (bit 21 in ETH_DMAOMR). In this mode, the data
> is transmitted only when the whole packet is available in the TxFIFO.

I think that the original author of the driver though that the store-and-forward functionality depends on MAC generated checksums (`CONFIG_STM32_ETH_HWCHECKSUM`). But in fact the opposite is true. The checksums require store-and-forward, not the other way around.

As it seems, the peripheral works perfectly with store-and-forward functionality enabled alone (and no HW checksums, or enhanced descriptors).

## Impact

More correct operation of the Ethernet peripheral of the STM32's, without hitting the erratum, or chance of data corruption.

## Testing

Tested on a custom target, based on the STM32F427.  
I tried various networking protocols, and the peripheral performs as it should.
