### PR TITLE
Add mtd loop device

### DIFF
--- a/drivers/drivers_initialize.c
+++ b/drivers/drivers_initialize.c
@@ -29,6 +29,7 @@
 #include <nuttx/drivers/rpmsgblk.h>
 #include <nuttx/fs/loop.h>
 #include <nuttx/fs/smart.h>
+#include <nuttx/fs/loopmtd.h>
 #include <nuttx/input/uinput.h>
 #include <nuttx/mtd/mtd.h>
 #include <nuttx/net/loopback.h>
@@ -188,5 +189,9 @@ void drivers_initialize(void)
 
 #ifdef CONFIG_SMART_DEV_LOOP
   smart_loop_register_driver();
+#endif
+
+#ifdef CONFIG_MTD_LOOP
+  mtd_loop_register();
 #endif
 }

--- a/drivers/mtd/Kconfig
+++ b/drivers/mtd/Kconfig
@@ -331,6 +331,10 @@ config FILEMTD_ERASESTATE
 	hex "Simulated erase state"
 	default 0xff
 
+config MTD_LOOP
+	bool "Enable MTD loop device"
+	default n
+
 endif # FILEMTD
 
 config NULLMTD

--- a/include/nuttx/fs/loopmtd.h
+++ b/include/nuttx/fs/loopmtd.h
@@ -1,0 +1,107 @@
+/****************************************************************************
+ * include/nuttx/fs/loopmtd.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_NUTTX_FS_LOOPMTD_H
+#define __INCLUDE_NUTTX_FS_LOOPMTD_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <sys/ioctl.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifdef CONFIG_MTD_LOOP
+/* Loop device IOCTL commands */
+
+/* Command:      MTD_LOOPIOC_SETUP
+ * Description:  Setup the loop device
+ * Argument:     A pointer to a read-only instance of struct losetup_s.
+ * Dependencies: The loop device must be enabled (CONFIG_MTD_LOOP=y)
+ */
+
+/* Command:      MTD_LOOPIOC_TEARDOWN
+ * Description:  Teardown a loop device previously setup vis LOOPIOC_SETUP
+ * Argument:     A read-able pointer to the path of the device to be
+ *               torn down
+ * Dependencies: The loop device must be enabled (CONFIG_MTD_LOOP=y)
+ */
+
+#define MTD_LOOPIOC_SETUP     _LOOPIOC(0x0001)
+#define MTD_LOOPIOC_TEARDOWN  _LOOPIOC(0x0002)
+
+#endif
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+#ifdef CONFIG_MTD_LOOP
+/* This is the structure referred to in the argument to the LOOPIOC_SETUP
+ * IOCTL command.
+ */
+
+struct mtd_losetup_s
+{
+  FAR const char *devname;      /* The loop mtd device to be created */
+  FAR const char *filename;     /* The file or character device to use */
+  size_t          erasesize;    /* The erase size to use on the file */
+  size_t          sectsize;     /* The sector / page size of the file */
+  off_t           offset;       /* An offset that may be applied to the device */
+};
+#endif
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#ifndef __ASSEMBLY__
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#ifdef CONFIG_MTD_LOOP
+int mtd_loop_register(void);
+#endif
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __ASSEMBLY__ */
+#endif /* __INCLUDE_NUTTX_FS_LOOPMTD_H */


### PR DESCRIPTION
## Summary
Adds kernel needed functionality to register filemtd device via IOCTL (command line tool will be added to apps folder).
This will give possibility to mount littlefs, spiffs (and potentially others) based on host's files

## Impact
No impact

## Testing
Testing should be performed when related tool will be added to apps repository.
Preparing:
config: Simulator, enable littlfs, spiffs, filemtd + mtd loop
apps: nsh component lomtd is not disabled
host: create files, e.g., littlefs.dat, spiffs.dat

./nuttx
nsh>mount -t hostfs -o fs=/home/user /host
nsh>lomtd -s 1024 -e 4096 -o 0 /dev/mtd0 /host/littlefs.dat
nsh>mount -t littlefs -o "forceformat" /dev/mtd0 /mnt0
nsh>ls /mnt0

nsh>lomtd -s 1024 -e 4096 -o 0 /dev/mtd1 /host/spiffs.dat
nsh>mount -t spiffs -o "forceformat" /dev/mtd1 /mnt1
nsh>ls /mnt1

