### PR TITLE
pwm: add PWM overwrite under CONFIG_PWM_OVERWRITE option

### DIFF
--- a/arch/arm/src/samv7/Kconfig
+++ b/arch/arm/src/samv7/Kconfig
@@ -313,6 +313,7 @@ config SAMV7_PWM
 	bool
 	default n
 	select ARCH_HAVE_PWM_MULTICHAN
+	select ARCH_HAVE_PWM_OVERWRITE
 
 config SAMV7_HAVE_SDRAMC
 	bool

--- a/arch/arm/src/samv7/sam_pwm.c
+++ b/arch/arm/src/samv7/sam_pwm.c
@@ -449,7 +449,9 @@ static int pwm_start(struct pwm_lowerhalf_s *dev,
                      const struct pwm_info_s *info)
 {
   struct sam_pwm_s *priv = (struct sam_pwm_s *)dev;
+#ifdef CONFIG_PWM_OVERWRITE
   uint32_t regval;
+#endif
 
 #ifdef CONFIG_PWM_MULTICHAN
       for (int i = 0; i < PWM_NCHANNELS; i++)
@@ -474,23 +476,25 @@ static int pwm_start(struct pwm_lowerhalf_s *dev,
               pwm_set_output(dev, priv->channels[index - 1].channel,
                              info->channels[i].duty);
 
-          if (info->channels[i].ch_outp_ovrwr)
-            {
-              regval = pwm_getreg(priv, SAMV7_PWM_OOV);
-              regval &= ~(info->channels[i].ch_outp_ovrwr_val
-                  << priv->channels[i].channel);
-              pwm_putreg(priv, SAMV7_PWM_OOV, regval);
+#ifdef CONFIG_PWM_OVERWRITE
+              if (info->channels[i].ch_outp_ovrwr)
+                {
+                  regval = pwm_getreg(priv, SAMV7_PWM_OOV);
+                  regval &= ~(info->channels[i].ch_outp_ovrwr_val
+                      << priv->channels[i].channel);
+                  pwm_putreg(priv, SAMV7_PWM_OOV, regval);
 
-              regval = (1 << priv->channels[i].channel);
-              pwm_putreg(priv, SAMV7_PWM_OSS, regval);
-            }
-          else
-            {
-              /* Release overwrite of channel */
+                  regval = (1 << priv->channels[i].channel);
+                  pwm_putreg(priv, SAMV7_PWM_OSS, regval);
+                }
+              else
+                {
+                  /* Release overwrite of channel */
 
-              regval = (1 << priv->channels[i].channel);
-              pwm_putreg(priv, SAMV7_PWM_OSC, regval);
-            }
+                  regval = (1 << priv->channels[i].channel);
+                  pwm_putreg(priv, SAMV7_PWM_OSC, regval);
+                }
+#endif
             }
         }
 #else

--- a/drivers/timers/Kconfig
+++ b/drivers/timers/Kconfig
@@ -9,6 +9,10 @@ config ARCH_HAVE_PWM_PULSECOUNT
 	bool
 	default n
 
+config ARCH_HAVE_PWM_OVERWRITE
+	bool
+	default n
+
 config ARCH_HAVE_PWM_MULTICHAN
 	bool
 	default n
@@ -31,6 +35,16 @@ config PWM_PULSECOUNT
 		This might be used, for example to support a stepper motor.  If the
 		hardware will support a fixed pulse count, then this configuration
 		should be set to enable the capability.
+
+config PWM_OVERWRITE
+	bool "PWM Overwrite Support"
+	default n
+	depends on ARCH_HAVE_PWM_OVERWRITE
+	---help---
+		Some hardware will support generation of a pin overwrite with 0 or
+		1 without the need to wait for an end of cycle. The overwrite is
+		controlled from an application level the same way duty cycle or
+		frequency is modified.
 
 config PWM_MULTICHAN
 	bool "PWM Multiple Output Channel Support"

--- a/include/nuttx/timers/pwm.h
+++ b/include/nuttx/timers/pwm.h
@@ -120,7 +120,7 @@
 struct pwm_chan_s
 {
   ub16_t duty;
-#ifdef CONFIG_SAMV7_PWM
+#ifdef CONFIG_PWM_OVERWRITE
   bool ch_outp_ovrwr;
   bool ch_outp_ovrwr_val;
 #endif


### PR DESCRIPTION
## Summary
Generic drivers shoud not use architecture related config options like CONFIG_SAMV7_PWM. This commit adds PWM pin overwrite under generic configuration option CONFIG_PWM_OVERWRITE.

Now the overwrite can be used on other architectures as well or can be completely disabled for SAMv7.

## Impact

PWM driver, should not impact functionality of any existing arch driver.

## Testing

Tested on SAMv7 custom board.

