### PR TITLE
Revert "drivrs/mtd/filemtd.c: add block device MTD interface.  Block …

### DIFF
--- a/include/nuttx/mtd/mtd.h
+++ b/include/nuttx/mtd/mtd.h
@@ -606,35 +606,6 @@ FAR struct mtd_dev_s *w25qxxxjv_initialize(FAR struct qspi_dev_s *qspi,
                                          bool unprotect);
 
 /****************************************************************************
- * Name: blockmtd_initialize
- *
- * Description:
- *   Create and initialize a BLOCK MTD device instance.
- *
- * Input Parameters:
- *   path - Path name of the block device backing the MTD device
- *
- ****************************************************************************/
-
-FAR struct mtd_dev_s *blockmtd_initialize(FAR const char *path,
-                                          size_t offset, size_t mtdlen,
-                                          int16_t sectsize,
-                                          int32_t erasesize);
-
-/****************************************************************************
- * Name: blockmtd_teardown
- *
- * Description:
- *   Teardown a previously created blockmtd device.
- *
- * Input Parameters:
- *   dev - Pointer to the mtd driver instance.
- *
- ****************************************************************************/
-
-void blockmtd_teardown(FAR struct mtd_dev_s *dev);
-
-/****************************************************************************
  * Name: filemtd_initialize
  *
  * Description:


### PR DESCRIPTION
## Summary

…MTD interface allows using block device directly as MTD instead of having to use file-system in between.  NOTE that this provides the opposite capability of FTL which will let you use an MTD interface directly as a block device."

since filemtd can handle not only char device, but also block device. This reverts commit 5ef548677a7f93f18503105c2d9d0a42d155181c.

## Impact

remove blockmtd_xxx function

## Testing

CI