### PR TITLE
boards/samv7/hsmci: add option to invert card detection pin

### DIFF
--- a/boards/arm/samv7/common/include/board_hsmci.h
+++ b/boards/arm/samv7/common/include/board_hsmci.h
@@ -59,7 +59,7 @@ extern "C"
  ****************************************************************************/
 
 int sam_hsmci_initialize(int slotno, int minor, gpio_pinset_t cdcfg,
-                         int cdirq);
+                         int cdirq, bool cdinvert);
 
 /****************************************************************************
  * Name: sam_cardinserted

--- a/boards/arm/samv7/common/src/sam_hsmci.c
+++ b/boards/arm/samv7/common/src/sam_hsmci.c
@@ -56,6 +56,7 @@ struct sam_hsmci_state_s
   int cdirq;                  /* Interrupt number (same as pid) */
   uint8_t slotno;             /* Slot number */
   bool cd;                    /* TRUE: card is inserted */
+  bool cdinvert;              /* Invert card detection to 0 signaling card */
 };
 
 /****************************************************************************
@@ -89,9 +90,9 @@ static bool sam_cardinserted_internal(struct sam_hsmci_state_s *state)
 
   /* Get the state of the PIO pin */
 
-  inserted = sam_gpioread(state->cdcfg);
-  finfo("Slot %d inserted: %s\n", state->slotno, inserted ? "NO" : "YES");
-  return !inserted;
+  inserted = sam_gpioread(state->cdcfg) != state->cdinvert;
+  finfo("Slot %d inserted: %s\n", state->slotno, inserted ? "YES" : "NO");
+  return inserted;
 }
 
 /****************************************************************************
@@ -181,7 +182,7 @@ static inline struct sam_hsmci_state_s *sam_hsmci_state(int slotno)
  ****************************************************************************/
 
 int sam_hsmci_initialize(int slotno, int minor, gpio_pinset_t cdcfg,
-                         int cdirq)
+                         int cdirq, bool cdinvert)
 {
   struct sam_hsmci_state_s *state;
   int ret;
@@ -197,6 +198,7 @@ int sam_hsmci_initialize(int slotno, int minor, gpio_pinset_t cdcfg,
 
   state->cdcfg = cdcfg;
   state->cdirq = cdirq;
+  state->cdinvert = cdinvert;
 
   /* Initialize card-detect, write-protect, and power enable PIOs */
 

--- a/boards/arm/samv7/same70-qmtech/src/sam_bringup.c
+++ b/boards/arm/samv7/same70-qmtech/src/sam_bringup.c
@@ -161,7 +161,7 @@ int sam_bringup(void)
   /* Initialize the HSMCI0 driver */
 
   ret = sam_hsmci_initialize(HSMCI0_SLOTNO, HSMCI0_MINOR, GPIO_HSMCI0_CD,
-                             IRQ_HSMCI0_CD);
+                             IRQ_HSMCI0_CD, true);
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: sam_hsmci_initialize(%d,%d) failed: %d\n",

--- a/boards/arm/samv7/same70-xplained/src/sam_bringup.c
+++ b/boards/arm/samv7/same70-xplained/src/sam_bringup.c
@@ -222,7 +222,7 @@ int sam_bringup(void)
   /* Initialize the HSMCI0 driver */
 
   ret = sam_hsmci_initialize(HSMCI0_SLOTNO, HSMCI0_MINOR, GPIO_HSMCI0_CD,
-                             IRQ_HSMCI0_CD);
+                             IRQ_HSMCI0_CD, true);
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: sam_hsmci_initialize(%d,%d) failed: %d\n",

--- a/boards/arm/samv7/samv71-xult/src/sam_bringup.c
+++ b/boards/arm/samv7/samv71-xult/src/sam_bringup.c
@@ -338,7 +338,7 @@ int sam_bringup(void)
   /* Initialize the HSMCI0 driver */
 
   ret = sam_hsmci_initialize(HSMCI0_SLOTNO, HSMCI0_MINOR, GPIO_HSMCI0_CD,
-                             IRQ_HSMCI0_CD);
+                             IRQ_HSMCI0_CD, true);
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: sam_hsmci_initialize(%d,%d) failed: %d\n",


### PR DESCRIPTION
The original code hard-coded card detection to the low when card is inserted and high when not. This might not be true on every board because it depends on the slot and wiring used. The second reason is because it is also possible to detect card with D3 pin pull-up when the slot does not provide dedicated card detection switch.

This introduces new argument to the sam_hsmci_initialize to allow invert of card detection pin. It also applies this invert to existing boards as that was the state up to this point.