### PR TITLE
fs: Map FD_SETSIZE to OPEN_MAX instead hardcoding 256

### DIFF
--- a/include/sys/select.h
+++ b/include/sys/select.h
@@ -27,6 +27,7 @@
 
 #include <nuttx/config.h>
 
+#include <limits.h>
 #include <stdint.h>
 #include <signal.h>
 #include <sys/time.h>
@@ -37,7 +38,7 @@
 
 /* Get the total number of descriptors that we will have to support */
 
-#define FD_SETSIZE 256
+#define FD_SETSIZE OPEN_MAX
 
 /* We will use a 32-bit bitsets to represent the set of descriptors.  How
  * many uint32_t's do we need to span all descriptors?

--- a/libs/libc/unistd/Kconfig
+++ b/libs/libc/unistd/Kconfig
@@ -145,7 +145,7 @@ config LIBC_HOSTNAME
 
 config LIBC_OPEN_MAX
 	int "OPEN_MAX for this device"
-	default 255
+	default 256
 	---help---
 		The maximum number of files that a process can have open
 		at any time.  Must not be less than _POSIX_OPEN_MAX.


### PR DESCRIPTION
## Summary

and change the default value of LIBC_OPEN_MAX to 256.
Here has more discussion:
https://www.mail-archive.com/dev@nuttx.apache.org/msg09095.html

## Impact

code refactor only, should same as before with the default config

## Testing

CI