### PR TITLE
libc: Remove dependence of LIBC_FLOATINGPOINT and LIBC_LONG_LONG from LIBC_NUMBERED_ARGS

### DIFF
--- a/libs/libc/stdio/Kconfig
+++ b/libs/libc/stdio/Kconfig
@@ -77,7 +77,6 @@ config LIBC_LONG_LONG
 config LIBC_NUMBERED_ARGS
 	bool "Enable numbered arguments in printf"
 	default n
-	depends on LIBC_FLOATINGPOINT || LIBC_LONG_LONG
 	---help---
 		Enables support for numbered arguments in printf.
 


### PR DESCRIPTION
## Summary

since LIBC_NUMBERED_ARGS can work without both

## Impact

Can use numbered args in more case

## Testing

CI