### PR TITLE
tools/unix: use anonymous pipes to avoid menuconfig break 

### DIFF
--- a/tools/Unix.mk
+++ b/tools/Unix.mk
@@ -624,7 +624,7 @@ define kconfig_tweak_disable
 	kconfig-tweak --file $1 -u $2
 endef
 else
-  PURGE_MODULE_WARNING  = 2>&1 | grep -v "warning: the 'modules' option is not supported"
+  PURGE_MODULE_WARNING  = 2> >(grep -v "warning: the 'modules' option is not supported")
   KCONFIG_OLDCONFIG     = oldconfig ${PURGE_MODULE_WARNING}
   KCONFIG_OLDDEFCONFIG  = olddefconfig ${PURGE_MODULE_WARNING}
   KCONFIG_MENUCONFIG    = menuconfig ${PURGE_MODULE_WARNING}


### PR DESCRIPTION
## Summary

tools/unix: use anonymous pipes to avoid menuconfig break

Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

make menuconfig

## Testing

tools/configure.sh sim/nsh  with kconfiglib