### PR TITLE
net/devif: fix null pointer reference found out by coverity 

### DIFF
--- a/net/devif/devif_filesend.c
+++ b/net/devif/devif_filesend.c
@@ -150,7 +150,11 @@ int devif_file_send(FAR struct net_driver_s *dev, FAR struct file *file,
 errout:
   if (ret < 0)
     {
-      netdev_iob_release(dev);
+      if (dev != NULL)
+        {
+          netdev_iob_release(dev);
+        }
+
       nerr("ERROR: devif_iob_send error: %d\n", ret);
     }
 


### PR DESCRIPTION
## Summary

net/devif: fix null pointer reference found out by coverity 

## Impact

N/A

## Testing

ci-check