### PR TITLE
drivers/note: fix build break by note rename change

### DIFF
--- a/Documentation/guides/tasktraceuser.rst
+++ b/Documentation/guides/tasktraceuser.rst
@@ -24,9 +24,9 @@ The following configurations must be enabled.
 - ``CONFIG_SCHED_INSTRUMENTATION_FILTER`` : Enables the filter logic of the notes.
 - ``CONFIG_SCHED_INSTRUMENTATION_SYSCALL`` : Enable system call instrumentation.
 - ``CONFIG_SCHED_INSTRUMENTATION_IRQHANDLER`` : Enables IRQ instrumentation.
-- ``CONFIG_DRIVER_NOTE`` : Enables note driver support.
-- ``CONFIG_DRIVER_NOTERAM`` : Enables ``/dev/note`` in-memory buffering driver.
-- ``CONFIG_DRIVER_NOTECTL`` : Enables ``/dev/notectl`` filter control driver.
+- ``CONFIG_DRIVERS_NOTE`` : Enables note driver support.
+- ``CONFIG_DRIVERS_NOTERAM`` : Enables ``/dev/note`` in-memory buffering driver.
+- ``CONFIG_DRIVERS_NOTECTL`` : Enables ``/dev/notectl`` filter control driver.
 - ``CONFIG_SYSTEM_TRACE`` : Enables "``trace``" command
 - ``CONFIG_SYSTEM_SYSTEM`` : Enables "``system``" command (required by :ref:`trace_cmd`)
 
@@ -46,19 +46,19 @@ The following configurations are configurable parameters for trace.
 
   - If enabled, use higher resolution system timer for instrumentation.
 
-- ``CONFIG_DRIVER_NOTE_TASKNAME_BUFSIZE``
+- ``CONFIG_DRIVERS_NOTE_TASKNAME_BUFSIZE``
 
   - Specify the task name buffer size in bytes.
     The buffer is used to hold the name of the task during instrumentation.
     Trace dump can find and show a task name corresponding to given pid in the instrumentation data by using this buffer.
     If 0 is specified, this feature is disabled and trace dump shows only the name of the newly created task.
 
-- ``CONFIG_DRIVER_NOTERAM_BUFSIZE``
+- ``CONFIG_DRIVERS_NOTERAM_BUFSIZE``
 
   - Specify the note buffer size in bytes.
     Higher value can hold more note records, but consumes more kernel memory.
 
-- ``CONFIG_DRIVER_NOTERAM_DEFAULT_NOOVERWRITE``
+- ``CONFIG_DRIVERS_NOTERAM_DEFAULT_NOOVERWRITE``
 
   - If enabled, stop overwriting old notes in the circular buffer when the buffer is full by default.
     This is useful to keep instrumentation data of the beginning of a system boot.

--- a/drivers/drivers_initialize.c
+++ b/drivers/drivers_initialize.c
@@ -87,7 +87,7 @@ void drivers_initialize(void)
   loop_register();      /* Standard /dev/loop */
 #endif
 
-#if defined(CONFIG_DRIVER_NOTE)
+#if defined(CONFIG_DRIVERS_NOTE)
   note_initialize();    /* Non-standard /dev/note */
 #endif
 

--- a/drivers/note/Make.defs
+++ b/drivers/note/Make.defs
@@ -18,21 +18,21 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_DRIVER_NOTE),y)
+ifeq ($(CONFIG_DRIVERS_NOTE),y)
   CSRCS += note_driver.c
   CSRCS += note_initialize.c
   CFLAGS += ${INCDIR_PREFIX}${TOPDIR}/sched
 endif
 
-ifeq ($(CONFIG_DRIVER_NOTERAM),y)
+ifeq ($(CONFIG_DRIVERS_NOTERAM),y)
   CSRCS += noteram_driver.c
 endif
 
-ifeq ($(CONFIG_DRIVER_NOTELOG),y)
+ifeq ($(CONFIG_DRIVERS_NOTELOG),y)
   CSRCS += notelog_driver.c
 endif
 
-ifeq ($(CONFIG_DRIVER_NOTECTL),y)
+ifeq ($(CONFIG_DRIVERS_NOTECTL),y)
   CSRCS += notectl_driver.c
 endif
 

--- a/drivers/note/note_driver.c
+++ b/drivers/note/note_driver.c
@@ -122,7 +122,7 @@ struct note_startalloc_s
 #  define SIZEOF_NOTE_START(n) (sizeof(struct note_start_s))
 #endif
 
-#if CONFIG_DRIVER_NOTE_TASKNAME_BUFSIZE > 0
+#if CONFIG_DRIVERS_NOTE_TASKNAME_BUFSIZE > 0
 struct note_taskname_info_s
 {
   uint8_t size;
@@ -134,7 +134,7 @@ struct note_taskname_s
 {
   size_t head;
   size_t tail;
-  char buffer[CONFIG_DRIVER_NOTE_TASKNAME_BUFSIZE];
+  char buffer[CONFIG_DRIVERS_NOTE_TASKNAME_BUFSIZE];
 };
 #endif
 
@@ -158,18 +158,19 @@ static unsigned int g_note_disabled_irq_nest[CONFIG_SMP_NCPUS];
 #endif
 #endif
 
-FAR static struct note_driver_s *g_note_drivers[CONFIG_DRIVER_NOTE_MAX + 1] =
+FAR static struct note_driver_s *
+  g_note_drivers[CONFIG_DRIVERS_NOTE_MAX + 1] =
 {
-#ifdef CONFIG_DRIVER_NOTERAM
+#ifdef CONFIG_DRIVERS_NOTERAM
   &g_noteram_driver,
 #endif
-#ifdef CONFIG_DRIVER_NOTELOG
+#ifdef CONFIG_DRIVERS_NOTELOG
   &g_notelog_driver,
 #endif
   NULL
 };
 
-#if CONFIG_DRIVER_NOTE_TASKNAME_BUFSIZE > 0
+#if CONFIG_DRIVERS_NOTE_TASKNAME_BUFSIZE > 0
 static struct note_taskname_s g_note_taskname;
 #endif
 
@@ -464,7 +465,7 @@ static inline int note_isenabled_dump(void)
 }
 #endif
 
-#if CONFIG_DRIVER_NOTE_TASKNAME_BUFSIZE > 0
+#if CONFIG_DRIVERS_NOTE_TASKNAME_BUFSIZE > 0
 
 /****************************************************************************
  * Name: note_find_taskname
@@ -496,9 +497,9 @@ static FAR struct note_taskname_info_s *note_find_taskname(pid_t pid)
         }
 
       n += ti->size;
-      if (n >= CONFIG_DRIVER_NOTE_TASKNAME_BUFSIZE)
+      if (n >= CONFIG_DRIVERS_NOTE_TASKNAME_BUFSIZE)
         {
-          n -= CONFIG_DRIVER_NOTE_TASKNAME_BUFSIZE;
+          n -= CONFIG_DRIVERS_NOTE_TASKNAME_BUFSIZE;
         }
     }
 
@@ -533,7 +534,7 @@ static void note_record_taskname(pid_t pid, FAR const char *name)
   tilen = sizeof(struct note_taskname_info_s) + namelen;
   DEBUGASSERT(tilen <= UCHAR_MAX);
 
-  skiplen = CONFIG_DRIVER_NOTE_TASKNAME_BUFSIZE - g_note_taskname.head;
+  skiplen = CONFIG_DRIVERS_NOTE_TASKNAME_BUFSIZE - g_note_taskname.head;
   if (skiplen >= tilen + sizeof(struct note_taskname_info_s))
     {
       skiplen = 0; /* Have enough space at the tail - needn't skip */
@@ -541,7 +542,7 @@ static void note_record_taskname(pid_t pid, FAR const char *name)
 
   if (g_note_taskname.head >= g_note_taskname.tail)
     {
-      remain = CONFIG_DRIVER_NOTE_TASKNAME_BUFSIZE -
+      remain = CONFIG_DRIVERS_NOTE_TASKNAME_BUFSIZE -
                (g_note_taskname.head - g_note_taskname.tail);
     }
   else
@@ -556,7 +557,7 @@ static void note_record_taskname(pid_t pid, FAR const char *name)
       ti = (FAR struct note_taskname_info_s *)
             &g_note_taskname.buffer[g_note_taskname.tail];
       g_note_taskname.tail = (g_note_taskname.tail + ti->size) %
-                             CONFIG_DRIVER_NOTE_TASKNAME_BUFSIZE;
+                             CONFIG_DRIVERS_NOTE_TASKNAME_BUFSIZE;
       remain += ti->size;
     }
 
@@ -673,7 +674,7 @@ void sched_note_stop(FAR struct tcb_s *tcb)
   FAR struct note_driver_s **driver;
   bool formatted = false;
 
-#if CONFIG_DRIVER_NOTE_TASKNAME_BUFSIZE > 0
+#if CONFIG_DRIVERS_NOTE_TASKNAME_BUFSIZE > 0
   note_record_taskname(tcb->pid, tcb->name);
 #endif
 
@@ -1861,7 +1862,7 @@ void sched_note_filter_irq(FAR struct note_filter_irq_s *oldf,
 
 #endif /* CONFIG_SCHED_INSTRUMENTATION_FILTER */
 
-#if CONFIG_DRIVER_NOTE_TASKNAME_BUFSIZE > 0
+#if CONFIG_DRIVERS_NOTE_TASKNAME_BUFSIZE > 0
 
 /****************************************************************************
  * Name: note_get_taskname
@@ -1917,7 +1918,7 @@ int note_driver_register(FAR struct note_driver_s *driver)
   int i;
   DEBUGASSERT(driver);
 
-  for (i = 0; i < CONFIG_DRIVER_NOTE_MAX; i++)
+  for (i = 0; i < CONFIG_DRIVERS_NOTE_MAX; i++)
     {
       if (g_note_drivers[i] == NULL)
         {

--- a/drivers/note/note_initialize.c
+++ b/drivers/note/note_initialize.c
@@ -50,7 +50,7 @@ int note_initialize(void)
 {
   int ret = 0;
 
-#ifdef CONFIG_DRIVER_NOTERAM
+#ifdef CONFIG_DRIVERS_NOTERAM
   ret = noteram_register();
   if (ret < 0)
     {
@@ -58,7 +58,7 @@ int note_initialize(void)
     }
 #endif
 
-#ifdef CONFIG_DRIVER_NOTECTL
+#ifdef CONFIG_DRIVERS_NOTECTL
   ret = notectl_register();
   if (ret < 0)
     {

--- a/drivers/note/noteram_driver.c
+++ b/drivers/note/noteram_driver.c
@@ -48,7 +48,7 @@ struct noteram_info_s
   volatile unsigned int ni_head;
   volatile unsigned int ni_tail;
   volatile unsigned int ni_read;
-  uint8_t ni_buffer[CONFIG_DRIVER_NOTERAM_BUFSIZE];
+  uint8_t ni_buffer[CONFIG_DRIVERS_NOTERAM_BUFSIZE];
 };
 
 /****************************************************************************
@@ -78,7 +78,7 @@ static const struct file_operations g_noteram_fops =
 
 static struct noteram_info_s g_noteram_info =
 {
-#ifdef CONFIG_DRIVER_NOTERAM_DEFAULT_NOOVERWRITE
+#ifdef CONFIG_DRIVERS_NOTERAM_DEFAULT_NOOVERWRITE
   NOTERAM_MODE_OVERWRITE_DISABLE
 #else
   NOTERAM_MODE_OVERWRITE_ENABLE
@@ -149,9 +149,9 @@ static inline unsigned int noteram_next(unsigned int ndx,
                                         unsigned int offset)
 {
   ndx += offset;
-  if (ndx >= CONFIG_DRIVER_NOTERAM_BUFSIZE)
+  if (ndx >= CONFIG_DRIVERS_NOTERAM_BUFSIZE)
     {
-      ndx -= CONFIG_DRIVER_NOTERAM_BUFSIZE;
+      ndx -= CONFIG_DRIVERS_NOTERAM_BUFSIZE;
     }
 
   return ndx;
@@ -178,7 +178,7 @@ static unsigned int noteram_length(void)
 
   if (tail > head)
     {
-      head += CONFIG_DRIVER_NOTERAM_BUFSIZE;
+      head += CONFIG_DRIVERS_NOTERAM_BUFSIZE;
     }
 
   return head - tail;
@@ -205,7 +205,7 @@ static unsigned int noteram_unread_length(void)
 
   if (read > head)
     {
-      head += CONFIG_DRIVER_NOTERAM_BUFSIZE;
+      head += CONFIG_DRIVERS_NOTERAM_BUFSIZE;
     }
 
   return head - read;
@@ -236,7 +236,7 @@ static void noteram_remove(void)
   /* Get the tail index of the circular buffer */
 
   tail = g_noteram_info.ni_tail;
-  DEBUGASSERT(tail < CONFIG_DRIVER_NOTERAM_BUFSIZE);
+  DEBUGASSERT(tail < CONFIG_DRIVERS_NOTERAM_BUFSIZE);
 
   /* Get the length of the note at the tail index */
 
@@ -295,7 +295,7 @@ static ssize_t noteram_get(FAR uint8_t *buffer, size_t buflen)
   /* Get the read index of the circular buffer */
 
   read    = g_noteram_info.ni_read;
-  DEBUGASSERT(read < CONFIG_DRIVER_NOTERAM_BUFSIZE);
+  DEBUGASSERT(read < CONFIG_DRIVERS_NOTERAM_BUFSIZE);
 
   /* Get the length of the note at the read index */
 
@@ -370,7 +370,7 @@ static ssize_t noteram_size(void)
   /* Get the read index of the circular buffer */
 
   read = g_noteram_info.ni_read;
-  DEBUGASSERT(read < CONFIG_DRIVER_NOTERAM_BUFSIZE);
+  DEBUGASSERT(read < CONFIG_DRIVERS_NOTERAM_BUFSIZE);
 
   /* Get the length of the note at the read index */
 
@@ -580,7 +580,7 @@ static void noteram_add(FAR struct note_driver_s *drv,
 
   /* Get the index to the head of the circular buffer */
 
-  DEBUGASSERT(note != NULL && notelen < CONFIG_DRIVER_NOTERAM_BUFSIZE);
+  DEBUGASSERT(note != NULL && notelen < CONFIG_DRIVERS_NOTERAM_BUFSIZE);
   head = g_noteram_info.ni_head;
 
   /* Loop until all bytes have been transferred to the circular buffer */

--- a/include/nuttx/note/note_driver.h
+++ b/include/nuttx/note/note_driver.h
@@ -126,13 +126,13 @@ struct note_driver_s
  *
  ****************************************************************************/
 
-#ifdef CONFIG_DRIVER_NOTE
+#ifdef CONFIG_DRIVERS_NOTE
 int note_initialize(void);
 #endif
 
 #endif /* defined(__KERNEL__) || defined(CONFIG_BUILD_FLAT) */
 
-#if CONFIG_DRIVER_NOTE_TASKNAME_BUFSIZE > 0
+#if CONFIG_DRIVERS_NOTE_TASKNAME_BUFSIZE > 0
 
 /****************************************************************************
  * Name: note_get_taskname
@@ -152,7 +152,7 @@ int note_initialize(void);
 
 int note_get_taskname(pid_t pid, FAR char *name);
 
-#endif /* CONFIG_DRIVER_NOTE_TASKNAME_BUFSIZE > 0 */
+#endif /* CONFIG_DRIVERS_NOTE_TASKNAME_BUFSIZE > 0 */
 
 /****************************************************************************
  * Name: note_driver_register

--- a/include/nuttx/note/notectl_driver.h
+++ b/include/nuttx/note/notectl_driver.h
@@ -65,7 +65,7 @@
  *                          note_filter_irq_s
  */
 
-#ifdef CONFIG_DRIVER_NOTECTL
+#ifdef CONFIG_DRIVERS_NOTECTL
 
 #define NOTECTL_GETMODE             _NOTECTLIOC(0x01)
 #define NOTECTL_SETMODE             _NOTECTLIOC(0x02)
@@ -105,7 +105,7 @@
  *
  ****************************************************************************/
 
-#ifdef CONFIG_DRIVER_NOTECTL
+#ifdef CONFIG_DRIVERS_NOTECTL
 int notectl_register(void);
 #endif
 

--- a/include/nuttx/note/notelog_driver.h
+++ b/include/nuttx/note/notelog_driver.h
@@ -48,7 +48,7 @@ extern "C"
  * Public Data
  ****************************************************************************/
 
-#ifdef CONFIG_DRIVER_NOTELOG
+#ifdef CONFIG_DRIVERS_NOTELOG
 extern struct note_driver_s g_notelog_driver;
 #endif
 

--- a/include/nuttx/note/noteram_driver.h
+++ b/include/nuttx/note/noteram_driver.h
@@ -52,18 +52,18 @@
  *                          exist.
  */
 
-#ifdef CONFIG_DRIVER_NOTERAM
+#ifdef CONFIG_DRIVERS_NOTERAM
 #define NOTERAM_CLEAR           _NOTERAMIOC(0x01)
 #define NOTERAM_GETMODE         _NOTERAMIOC(0x02)
 #define NOTERAM_SETMODE         _NOTERAMIOC(0x03)
-#if CONFIG_DRIVER_NOTE_TASKNAME_BUFSIZE > 0
+#if CONFIG_DRIVERS_NOTE_TASKNAME_BUFSIZE > 0
 #define NOTERAM_GETTASKNAME     _NOTERAMIOC(0x04)
 #endif
 #endif
 
 /* Overwrite mode definitions */
 
-#ifdef CONFIG_DRIVER_NOTERAM
+#ifdef CONFIG_DRIVERS_NOTERAM
 #define NOTERAM_MODE_OVERWRITE_DISABLE      0
 #define NOTERAM_MODE_OVERWRITE_ENABLE       1
 #define NOTERAM_MODE_OVERWRITE_OVERFLOW     2
@@ -110,7 +110,7 @@ extern struct note_driver_s g_noteram_driver;
  *
  ****************************************************************************/
 
-#ifdef CONFIG_DRIVER_NOTERAM
+#ifdef CONFIG_DRIVERS_NOTERAM
 int noteram_register(void);
 #endif
 


### PR DESCRIPTION

## Summary

drivers/note: fix build break by note rename change

Regression by:

| commit ee24396d7701bf347f64ee6d075e633c1eea332e
| Author: Xiang Xiao <xiaoxiang@xiaomi.com>
| Date:   Tue Feb 14 01:11:48 2023 +0800
|
|     drivers/note: Change DRIVER_NOTExxx to DRIVERS_NOTExxx
|
|     follow other driver config style
|
|     Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>


## Impact

N/A

## Testing

ci-check