### PR TITLE
libs/libcxx: Workaround -Wmaybe-uninitialized warning with "GCC 12.2"

### DIFF
--- a/libs/libxx/libcxx.defs
+++ b/libs/libxx/libcxx.defs
@@ -71,6 +71,21 @@ libcxx/src/locale.cpp_CXXFLAGS += -Wno-shadow
 libcxx/src/filesystem/directory_iterator.cpp_CXXFLAGS += -Wno-shadow
 libcxx/src/filesystem/operations.cpp_CXXFLAGS += -Wno-shadow
 
+# Workaround the following warning with "GCC 12.2"
+#
+# ...
+# include/libcxx/string:2156:35: warning: '__temp' may be used uninitialized [-Wmaybe-uninitialized]
+#  2156 |         this->__throw_length_error();
+#       |         ~~~~~~~~~~~~~~~~~~~~~~~~~~^~
+# include/libcxx/string:614:1: note: by argument 1 of type 'const std::__1::__basic_string_common<true>*' to 'void std::__1::__basic_string_common<<anonymous> >::__throw_length_error() const [with bool <anonymous> = true]' declared here
+#   614 | __basic_string_common<__b>::__throw_length_error() const
+#       | ^~~~~~~~~~~~~~~~~~~~~~~~~~
+# include/libcxx/string:2676:32: note: '__temp' declared here
+#  2676 |             const basic_string __temp (__first, __last, __alloc());
+#       |                                ^~~~~~
+
+libcxx/src/filesystem/operations.cpp_CXXFLAGS += -Wno-maybe-uninitialized
+
 CPPSRCS += $(notdir $(wildcard libcxx/src/*.cpp))
 CPPSRCS += $(notdir $(wildcard libcxx/src/experimental/*.cpp))
 CPPSRCS += $(notdir $(wildcard libcxx/src/filesystem/*.cpp))


### PR DESCRIPTION
## Summary

libs/libcxx: Workaround -Wmaybe-uninitialized warning with "GCC 12.2"


```bash
In file included from include/libcxx/filesystem:241,
                 from libcxx/src/filesystem/operations.cpp:9:
In member function 'std::__1::_EnableIf<std::__1::__is_cpp17_forward_iterator<_InputIter>::value> std::__1::basic_string<_CharT, _Traits, _Allocator>::__init(_ForwardIterator, _ForwardIterator) [with _ForwardIterator = const char*; _CharT = char; _Traits = std::__1::char_traits<char>; _Allocator = std::__1::allocator<char>]',
    inlined from 'std::__1::basic_string<_CharT, _Traits, _Allocator>::basic_string(_InputIterator, _InputIterator, const allocator_type&) [with _InputIterator = const char*; <template-parameter-2-2> = void; _CharT = char; _Traits = std::__1::char_traits<char>; _Allocator = std::__1::allocator<char>]' at include/libcxx/string:2195:11,
    inlined from 'std::__1::basic_string<_CharT, _Traits, _Allocator>& std::__1::basic_string<_CharT, _Traits, _Allocator>::__append_forward_unsafe(_ForwardIterator, _ForwardIterator) [with _ForwardIterator = const char*; _CharT = char; _Traits = std::__1::char_traits<char>; _Allocator = std::__1::allocator<char>]' at include/libcxx/string:2676:32,
    inlined from 'std::__1::basic_string<_CharT, _Traits, _Allocator>& std::__1::basic_string<_CharT, _Traits, _Allocator>::__append_forward_unsafe(_ForwardIterator, _ForwardIterator) [with _ForwardIterator = const char*; _CharT = char; _Traits = std::__1::char_traits<char>; _Allocator = std::__1::allocator<char>]' at include/libcxx/string:2662:1:
include/libcxx/string:2156:35: warning: '__temp' may be used uninitialized [-Wmaybe-uninitialized]
 2156 |         this->__throw_length_error();
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~^~
include/libcxx/string: In function 'std::__1::basic_string<_CharT, _Traits, _Allocator>& std::__1::basic_string<_CharT, _Traits, _Allocator>::__append_forward_unsafe(_ForwardIterator, _ForwardIterator) [with _ForwardIterator = const char*; _CharT = char; _Traits = std::__1::char_traits<char>; _Allocator = std::__1::allocator<char>]':
include/libcxx/string:614:1: note: by argument 1 of type 'const std::__1::__basic_string_common<true>*' to 'void std::__1::__basic_string_common<<anonymous> >::__throw_length_error() const [with bool <anonymous> = true]' declared here
  614 | __basic_string_common<__b>::__throw_length_error() const
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~
include/libcxx/string:2676:32: note: '__temp' declared here
 2676 |             const basic_string __temp (__first, __last, __alloc());
      |        
```


## Impact

n/a

## Testing

ci-check