### PR TITLE
samv7: add support for complementary PWM output

### DIFF
--- a/arch/arm/src/samv7/Kconfig
+++ b/arch/arm/src/samv7/Kconfig
@@ -612,17 +612,49 @@ config SAMV7_PWM0_CH0
 	bool "PWM0 Channel 0"
 	default n
 
+if SAMV7_PWM0_CH0
+
+config SAMV7_PWM0_CH0_COMP
+	bool "Use complementary output"
+	default n
+
+endif
+
 config SAMV7_PWM0_CH1
 	bool "PWM0 Channel 1"
 	default n
+
+if SAMV7_PWM0_CH1
+
+config SAMV7_PWM0_CH1_COMP
+	bool "Use complementary output"
+	default n
+
+endif
 
 config SAMV7_PWM0_CH2
 	bool "PWM0 Channel 2"
 	default n
 
+if SAMV7_PWM0_CH2
+
+config SAMV7_PWM0_CH2_COMP
+	bool "Use complementary output"
+	default n
+
+endif
+
 config SAMV7_PWM0_CH3
 	bool "PWM0 Channel 3"
 	default n
+
+if SAMV7_PWM0_CH3
+
+config SAMV7_PWM0_CH3_COMP
+	bool "Use complementary output"
+	default n
+
+endif
 
 endif
 
@@ -639,17 +671,49 @@ config SAMV7_PWM1_CH0
 	bool "PWM1 Channel 0"
 	default n
 
+if SAMV7_PWM1_CH0
+
+config SAMV7_PWM1_CH0_COMP
+	bool "Use complementary output"
+	default n
+
+endif
+
 config SAMV7_PWM1_CH1
 	bool "PWM1 Channel 1"
 	default n
+
+if SAMV7_PWM1_CH1
+
+config SAMV7_PWM1_CH1_COMP
+	bool "Use complementary output"
+	default n
+
+endif
 
 config SAMV7_PWM1_CH2
 	bool "PWM1 Channel 2"
 	default n
 
+if SAMV7_PWM1_CH2
+
+config SAMV7_PWM1_CH2_COMP
+	bool "Use complementary output"
+	default n
+
+endif
+
 config SAMV7_PWM1_CH3
 	bool "PWM1 Channel 3"
 	default n
+
+if SAMV7_PWM1_CH3
+
+config SAMV7_PWM1_CH3_COMP
+	bool "Use complementary output"
+	default n
+
+endif
 
 endif
 

--- a/arch/arm/src/samv7/sam_pwm.c
+++ b/arch/arm/src/samv7/sam_pwm.c
@@ -73,7 +73,8 @@
 struct sam_pwm_channel_s
 {
   uint8_t channel;            /* Number of PWM module */
-  gpio_pinset_t pin;          /* PWM output pin */
+  gpio_pinset_t pin_h;        /* PWM H output pin */
+  gpio_pinset_t pin_l;        /* PWM L output pin */
 };
 
 struct sam_pwm_s
@@ -114,25 +115,45 @@ static struct sam_pwm_channel_s g_pwm0_channels[] =
 #ifdef CONFIG_SAMV7_PWM0_CH0
   {
     .channel = 0,
-    .pin     = GPIO_PWMC0_H0,
+    .pin_h   = GPIO_PWMC0_H0,
+#ifdef CONFIG_SAMV7_PWM0_CH0_COMP
+    .pin_l   = GPIO_PWMC0_L0,
+#else
+    .pin_l   = 0,
+#endif
   },
 #endif
 #ifdef CONFIG_SAMV7_PWM0_CH1
   {
     .channel = 1,
-    .pin     = GPIO_PWMC0_H1,
+    .pin_h   = GPIO_PWMC0_H1,
+#ifdef CONFIG_SAMV7_PWM0_CH1_COMP
+    .pin_l   = GPIO_PWMC0_L1,
+#else
+    .pin_l   = 0,
+#endif
   },
 #endif
 #ifdef CONFIG_SAMV7_PWM0_CH2
   {
     .channel = 2,
-    .pin     = GPIO_PWMC0_H2,
+    .pin_h   = GPIO_PWMC0_H2,
+#ifdef CONFIG_SAMV7_PWM0_CH2_COMP
+    .pin_l   = GPIO_PWMC0_L2,
+#else
+    .pin_l   = 0,
+#endif
   },
 #endif
 #ifdef CONFIG_SAMV7_PWM0_CH3
   {
     .channel = 3,
-    .pin     = GPIO_PWMC0_H3,
+    .pin_h   = GPIO_PWMC0_H3,
+#ifdef CONFIG_SAMV7_PWM0_CH3_COMP
+    .pin_l   = GPIO_PWMC0_L3,
+#else
+    .pin_l   = 0,
+#endif
   },
 #endif
 };
@@ -153,25 +174,45 @@ static struct sam_pwm_channel_s g_pwm1_channels[] =
 #ifdef CONFIG_SAMV7_PWM1_CH0
   {
     .channel = 0,
-    .pin     = GPIO_PWMC1_H0
+    .pin_h   = GPIO_PWMC1_H0,
+#ifdef CONFIG_SAMV7_PWM1_CH0_COMP
+    .pin_l   = GPIO_PWMC1_L0,
+#else
+    .pin_l   = 0,
+#endif
   },
 #endif
 #ifdef CONFIG_SAMV7_PWM1_CH1
   {
     .channel = 1,
-    .pin     = GPIO_PWMC1_H1
+    .pin_h   = GPIO_PWMC1_H1,
+#ifdef CONFIG_SAMV7_PWM1_CH1_COMP
+    .pin_l   = GPIO_PWMC1_L1,
+#else
+    .pin_l   = 0,
+#endif
   },
 #endif
 #ifdef CONFIG_SAMV7_PWM1_CH2
   {
     .channel = 2,
-    .pin     = GPIO_PWMC1_H2
+    .pin_h   = GPIO_PWMC1_H2,
+#ifdef CONFIG_SAMV7_PWM1_CH2_COMP
+    .pin_l   = GPIO_PWMC1_L2,
+#else
+    .pin_l   = 0,
+#endif
   },
 #endif
 #ifdef CONFIG_SAMV7_PWM1_CH3
   {
     .channel = 3,
-    .pin     = GPIO_PWMC1_H3
+    .pin_h   = GPIO_PWMC1_H3,
+#ifdef CONFIG_SAMV7_PWM1_CH3_COMP
+    .pin_l   = GPIO_PWMC1_L3,
+#else
+    .pin_l   = 0,
+#endif
   },
 #endif
 }; /* CONFIG_SAMV7_PWM1 */
@@ -348,7 +389,8 @@ static void pwm_set_output(struct pwm_lowerhalf_s *dev, uint8_t channel,
 static int pwm_setup(struct pwm_lowerhalf_s *dev)
 {
   struct sam_pwm_s *priv = (struct sam_pwm_s *)dev;
-  gpio_pinset_t pin = 0;
+  gpio_pinset_t pin_h = 0;
+  gpio_pinset_t pin_l = 0;
   uint8_t channel;
   uint32_t regval;
 
@@ -364,11 +406,17 @@ static int pwm_setup(struct pwm_lowerhalf_s *dev)
 
   for (int i = 0; i < priv->channels_num; i++)
     {
-      pin = priv->channels[i].pin;
+      pin_h = priv->channels[i].pin_h;
+      pin_l = priv->channels[i].pin_l;
 
-      if (pin != 0)
+      if (pin_h != 0)
         {
-          sam_configgpio(pin);
+          sam_configgpio(pin_h);
+        }
+
+      if (pin_l != 0)
+        {
+          sam_configgpio(pin_l);
         }
 
       channel = priv->channels[i].channel;


### PR DESCRIPTION
## Summary
SAMv7 PWM driver supports complementary PWM output if both pins (H and L) are defined and configured. This commit adds a configuration option to configure the complementary L pin.

The pin definition has to be provided by board level support.

## Impact

SAMv7 PWM driver only.

## Testing

Tested on same70-xplained evaluation kit and on a custom board.

