### PR TITLE
Revert "tools/ci: Update GNU Arm Embedded Toolchain to Version 12.2-2022.12.22"

### DIFF
--- a/tools/ci/cibuild.sh
+++ b/tools/ci/cibuild.sh
@@ -74,11 +74,12 @@ function arm-gcc-toolchain {
         ;;
     esac
     cd "${tools}"
-    wget --quiet https://developer.arm.com/-/media/Files/downloads/gnu/12.2.rel1/binrel/arm-gnu-toolchain-12.2.rel1${flavor}-x86_64-arm-none-eabi.tar.xz
-    xz -d arm-gnu-toolchain-12.2.rel1${flavor}-x86_64-arm-none-eabi.tar.xz
-    tar xf arm-gnu-toolchain-12.2.rel1${flavor}-x86_64-arm-none-eabi.tar
-    mv arm-gnu-toolchain-12.2.rel1${flavor}-x86_64-arm-none-eabi gcc-arm-none-eabi
-    rm arm-gnu-toolchain-12.2.rel1${flavor}-x86_64-arm-none-eabi.tar
+    wget --quiet https://developer.arm.com/-/media/Files/downloads/gnu/11.3.rel1/binrel/arm-gnu-toolchain-11.3.rel1${flavor}-x86_64-arm-none-eabi.tar.xz
+    xz -d arm-gnu-toolchain-11.3.rel1${flavor}-x86_64-arm-none-eabi.tar.xz
+    tar xf arm-gnu-toolchain-11.3.rel1${flavor}-x86_64-arm-none-eabi.tar
+    mv arm-gnu-toolchain-11.3.rel1${flavor}-x86_64-arm-none-eabi gcc-arm-none-eabi
+    patch -p0 < ${nuttx}/tools/ci/patch/arm-none-eabi-workaround-for-newlib-version-break.patch
+    rm arm-gnu-toolchain-11.3.rel1${flavor}-x86_64-arm-none-eabi.tar
   fi
 
   arm-none-eabi-gcc --version

--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -84,8 +84,10 @@ RUN mkdir clang-arm-none-eabi && \
 
 # Download the latest ARM GCC toolchain prebuilt by ARM
 RUN mkdir gcc-arm-none-eabi && \
-  curl -s -L  "https://developer.arm.com/-/media/Files/downloads/gnu/12.2.rel1/binrel/arm-gnu-toolchain-12.2.rel1-x86_64-arm-none-eabi.tar.xz" \
-  | tar -C gcc-arm-none-eabi --strip-components 1 -xJ
+  curl -s -L  "https://developer.arm.com/-/media/Files/downloads/gnu/11.3.rel1/binrel/arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi.tar.xz" \
+  | tar -C gcc-arm-none-eabi --strip-components 1 -xJ  \
+  && curl -s -L -O "https://raw.githubusercontent.com/apache/nuttx/master/tools/ci/patch/arm-none-eabi-workaround-for-newlib-version-break.patch" \
+  && patch -p0 < arm-none-eabi-workaround-for-newlib-version-break.patch
 
 ###############################################################################
 # Build image for tool required by ARM64 builds

--- a/tools/ci/patch/arm-none-eabi-workaround-for-newlib-version-break.patch
+++ b/tools/ci/patch/arm-none-eabi-workaround-for-newlib-version-break.patch
@@ -1,0 +1,38 @@
+From 819ab4ac433b809fdaca33246e2bffa1426acc0f Mon Sep 17 00:00:00 2001
+From: chao an <anchao@xiaomi.com>
+Date: Tue, 11 Oct 2022 15:27:37 +0800
+Subject: [PATCH] arm-none-eabi: workaround for newlib version break
+
+Signed-off-by: chao an <anchao@xiaomi.com>
+---
+ arm-none-eabi/include/_newlib_version.h | 15 ++++-----------
+ 1 file changed, 4 insertions(+), 11 deletions(-)
+
+diff --git a/arm-none-eabi/include/_newlib_version.h gcc-arm-none-eabi/arm-none-eabi/include/_newlib_version.h
+index 0dbf962e..c5d2be6d 100644
+--- a/arm-none-eabi/include/_newlib_version.h
++++ gcc-arm-none-eabi/arm-none-eabi/include/_newlib_version.h
+@@ -3,16 +3,9 @@
+ #ifndef _NEWLIB_VERSION_H__
+ #define _NEWLIB_VERSION_H__ 1
+
+-/* The newlib version in string format. */
+-#define _NEWLIB_VERSION "@NEWLIB_VERSION@"
+-
+-/* The newlib major version number. */
+-#define __NEWLIB__ @NEWLIB_MAJOR_VERSION@
+-
+-/* The newlib minor version number. */
+-#define __NEWLIB_MINOR__ @NEWLIB_MINOR_VERSION@
+-
+-/* The newlib patch level. */
+-#define __NEWLIB_PATCHLEVEL__ @NEWLIB_PATCHLEVEL_VERSION@
++#define _NEWLIB_VERSION "4.2.0"
++#define __NEWLIB__ 4
++#define __NEWLIB_MINOR__ 2
++#define __NEWLIB_PATCHLEVEL__ 0
+
+ #endif /* !_NEWLIB_VERSION_H__ */
+--
+2.25.1
+


### PR DESCRIPTION

## Summary

Revert "tools/ci: Update GNU Arm Embedded Toolchain to Version 12.2-2022.12.22"


This reverts commit 809252e3fdd7553972f417ea7e1f6d4f1761c353.

Wrong warning array subscript [0] is outside array bounds:

```
|  chip/lpc43_usb0dev.c: In function 'lpc43_getframe': |  arch/arm/src/common/arm_internal.h:134:25: warning: array subscript 0 is outside array bounds of 'volatile uint32_t[0]' {aka 'volatile long unsigned int[]'} [-Warray-bounds]
|    134 | #define getreg32(a)    (*(volatile uint32_t *)(a))
|        |                        ~^~~~~~~~~~~~~~~~~~~~~~~~~~
|  chip/lpc43_usb0dev.c:347:33: note: in expansion of macro 'getreg32'
|    347 | # define lpc43_getreg(addr)     getreg32(addr)
|        |                                 ^~~~~~~~
|  chip/lpc43_usb0dev.c:2605:15: note: in expansion of macro 'lpc43_getreg'
|   2605 |   return (int)lpc43_getreg(LPC43_USBDEV_FRINDEX_OFFSET);
|        |
```

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523


## Impact

N/A

## Testing

ci-check