### PR TITLE
tools/ci: skip -Warray-bounds check due to bug of GCC-12.2

### DIFF
--- a/arch/arm/src/common/Toolchain.defs
+++ b/arch/arm/src/common/Toolchain.defs
@@ -227,6 +227,17 @@ else
       ARCHOPTIMIZATION += -fno-builtin
     endif
   endif
+
+  # Workaround to skip -Warray-bounds check due to bug of GCC-12.2:
+  # Wrong warning array subscript [0] is outside array bounds:
+  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523
+
+  GCCVER = $(shell $(CC) --version | grep gcc | sed -r 's/.* ([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+
+  ifeq ($(GCCVER),12.2.1)
+    ARCHOPTIMIZATION += --param=min-pagesize=0
+  endif
+
 endif
 
 # Zig compiler

--- a/fs/mount/fs_foreachmountpoint.c
+++ b/fs/mount/fs_foreachmountpoint.c
@@ -84,8 +84,8 @@ static int mountpoint_filter(FAR struct inode *node,
        * name and the path to the directory containing the inode.
        */
 
-      pathlen = strlen(dirpath);
-      namlen  = strlen(node->i_name) + 1;
+      pathlen = strnlen(dirpath, PATH_MAX);
+      namlen  = strnlen(node->i_name, PATH_MAX) + 1;
 
       /* Make sure that this would not exceed the maximum path length */
 


### PR DESCRIPTION
## Summary

tools/ci: skip -Warray-bounds check due to bug of GCC-12.2

Wrong warning array subscript [0] is outside array bounds:

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523
Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

ci-check