### PR TITLE
libs/libxx: check GCC version before set special flags

### DIFF
--- a/libs/libxx/libcxx.defs
+++ b/libs/libxx/libcxx.defs
@@ -84,7 +84,10 @@ libcxx/src/filesystem/operations.cpp_CXXFLAGS += -Wno-shadow
 #  2676 |             const basic_string __temp (__first, __last, __alloc());
 #       |                                ^~~~~~
 
-libcxx/src/filesystem/operations.cpp_CXXFLAGS += -Wno-maybe-uninitialized
+GCCVER = $(shell $(CXX) --version | grep gcc | sed -r 's/.* ([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+ifeq ($(GCCVER),12.2.1)
+  libcxx/src/filesystem/operations.cpp_CXXFLAGS += -Wno-maybe-uninitialized
+endif
 
 CPPSRCS += $(notdir $(wildcard libcxx/src/*.cpp))
 CPPSRCS += $(notdir $(wildcard libcxx/src/experimental/*.cpp))


### PR DESCRIPTION
## Summary

libs/libxx: check GCC version before set special flags

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

ci-check