### PR TITLE
tools: make the symbol table generated by mkallsyms.py two-byte aligned

### DIFF
--- a/tools/mkallsyms.py
+++ b/tools/mkallsyms.py
@@ -101,7 +101,7 @@ class SymbolTables(object):
             if self.symbol_filter(symbol) is not None:
                 symbol_name = cxxfilt.demangle(symbol.name)
                 func_name = re.sub(r"\(.*$", "", symbol_name)
-                self.symbol_list.append((symbol["st_value"], func_name))
+                self.symbol_list.append((symbol["st_value"] & ~0x01, func_name))
         self.symbol_list = sorted(self.symbol_list, key=lambda item: item[0])
 
     def emitline(self, s=""):


### PR DESCRIPTION
## Summary
When using stm32, the starting address of the function parsed by mkallsyms.py is an odd number, one large than the actual address


## Impact

## Testing
stm32h743zi：

```
arm-none-eabi-objdump:
arm-none-eabi-objdump -t nuttx/nuttx | grep hello                                                       
00000000 l    df *ABS*  00000000 hello_main.c
080131f8 g     F .text  00000010 hello_main

old mkallsyms.py：
{ "hello_main", (FAR  void *)0x80131f9 },

new mkallsyms.py：
{ "hello_main", (FAR  void *)0x80131f8 },
```

