### PR TITLE
usrsock: Do not return error when conn not found for an event

### DIFF
--- a/drivers/usrsock/usrsock_rpmsg_server.c
+++ b/drivers/usrsock/usrsock_rpmsg_server.c
@@ -129,8 +129,8 @@ static int usrsock_rpmsg_ept_cb(FAR struct rpmsg_endpoint *ept,
                                 FAR void *priv);
 
 static void usrsock_rpmsg_poll_cb(FAR struct pollfd *pfds);
-static int usrsock_rpmsg_poll_setup(FAR struct pollfd *pfds,
-                                    pollevent_t events);
+static void usrsock_rpmsg_poll_setup(FAR struct pollfd *pfds,
+                                     pollevent_t events);
 
 /****************************************************************************
  * Private Data
@@ -1021,8 +1021,8 @@ static int usrsock_rpmsg_ept_cb(FAR struct rpmsg_endpoint *ept,
   return -EINVAL;
 }
 
-static int usrsock_rpmsg_poll_setup(FAR struct pollfd *pfds,
-                                    pollevent_t events)
+static void usrsock_rpmsg_poll_setup(FAR struct pollfd *pfds,
+                                     pollevent_t events)
 {
   FAR struct usrsock_rpmsg_s *priv = (FAR struct usrsock_rpmsg_s *)pfds->arg;
   int ret = 0;
@@ -1050,7 +1050,7 @@ static int usrsock_rpmsg_poll_setup(FAR struct pollfd *pfds,
 
   net_unlock();
 
-  return ret;
+  DEBUGASSERT(ret >= 0);
 }
 
 static void usrsock_rpmsg_poll_cb(FAR struct pollfd *pfds)

--- a/net/usrsock/usrsock_devif.c
+++ b/net/usrsock/usrsock_devif.c
@@ -206,17 +206,25 @@ static ssize_t usrsock_handle_event(FAR const void *buffer, size_t len)
 
         if (len < sizeof(*hdr))
           {
-            nwarn("message too short, %zu < %zu.\n", len, sizeof(*hdr));
+            nerr("message too short, %zu < %zu.\n", len, sizeof(*hdr));
             return -EINVAL;
           }
+
+        len = sizeof(*hdr);
 
         /* Get corresponding usrsock connection. */
 
         conn = usrsock_active(hdr->usockid);
         if (!conn)
           {
-            nwarn("no active connection for usockid=%d.\n", hdr->usockid);
-            return -ENOENT;
+            nerr("no active connection for usockid=%d, events=%x.\n",
+                 hdr->usockid, hdr->head.events);
+
+            /* We may receive event after socket close if message from lower
+             * layer is out of order, but it's OK to ignore such error.
+             */
+
+            return len;
           }
 
 #ifdef CONFIG_DEV_RANDOM
@@ -233,13 +241,11 @@ static ssize_t usrsock_handle_event(FAR const void *buffer, size_t len)
           {
             return ret;
           }
-
-        len = sizeof(*hdr);
       }
       break;
 
     default:
-      nwarn("Unknown event type: %d\n", common->msgid);
+      nerr("Unknown event type: %d\n", common->msgid);
       return -EINVAL;
     }
 
@@ -447,15 +453,15 @@ static ssize_t usrsock_handle_req_response(FAR const void *buffer,
       break;
 
     default:
-      nwarn("unknown message type: %d, flags: %d, xid: %" PRIu32 ", "
-            "result: %" PRId32 "\n",
-            hdr->head.msgid, hdr->head.flags, hdr->xid, hdr->result);
+      nerr("unknown message type: %d, flags: %d, xid: %" PRIu32 ", "
+           "result: %" PRId32 "\n",
+           hdr->head.msgid, hdr->head.flags, hdr->xid, hdr->result);
       return -EINVAL;
     }
 
   if (len < hdrlen)
     {
-      nwarn("message too short, %zu < %zu.\n", len, hdrlen);
+      nerr("message too short, %zu < %zu.\n", len, hdrlen);
       return -EINVAL;
     }
 
@@ -469,8 +475,8 @@ static ssize_t usrsock_handle_req_response(FAR const void *buffer,
     {
       /* No connection waiting for this message. */
 
-      nwarn("Could find connection waiting for response"
-            "with xid=%" PRIu32 "\n", hdr->xid);
+      nerr("Could find connection waiting for response"
+           "with xid=%" PRIu32 "\n", hdr->xid);
 
       ret = -EINVAL;
       goto unlock_out;
@@ -518,6 +524,7 @@ static ssize_t usrsock_handle_message(FAR const void *buffer, size_t len,
       return usrsock_handle_req_response(buffer, len, req_done);
     }
 
+  nerr("Unknown message flags %" PRIx8 ".\n", common->flags);
   return -EINVAL;
 }
 
@@ -545,8 +552,8 @@ ssize_t usrsock_response(FAR const char *buffer, size_t len,
 
       if (len < sizeof(struct usrsock_message_common_s))
         {
-          nwarn("message too short, %zu < %zu.\n", len,
-                sizeof(struct usrsock_message_common_s));
+          nerr("message too short, %zu < %zu.\n", len,
+               sizeof(struct usrsock_message_common_s));
           return -EINVAL;
         }
 


### PR DESCRIPTION
## Summary
When rpmsg is in heavy load(e.g. rpmsgfs), it may result in out-of-ordered messages because it can trigger another callback in rpmsg_send. Then another side of usrsock may receive an event after socket is closed (e.g. SENDTO_READY event in UDP connect). Normally just drop these events might be acceptable, but we're returning error now, and triggers RPMSG_ASSERT outside.

Patches included:
- usrsock: Do not return error when conn not found for an event
  - If we receive an event to a conn after it's freed, log error and ignore it.
  - Also change log level to err when returning other negated errno, because if we return negated errno, we'll directly trigger RPMSG_ASSERT outside, so we need at least an error message to indicate the reason.
- usrsock: Add DebugAssert for poll setup result
  - We never check usrsock_rpmsg_poll_setup's result and assume it will success, so an assert should be better than retval.

## Impact
- logic change: don't return error when usrsock conn not found for an event
- robustness: logs / debug asserts

## Testing
CI & Vela
