### PR TITLE
libs/libxx: Fix typo in shell expressions 

### DIFF
--- a/libs/libxx/libcxx.defs
+++ b/libs/libxx/libcxx.defs
@@ -84,7 +84,7 @@ libcxx/src/filesystem/operations.cpp_CXXFLAGS += -Wno-shadow
 #  2676 |             const basic_string __temp (__first, __last, __alloc());
 #       |                                ^~~~~~
 
-GCCVER = $(shell $(CXX) --version | grep gcc | sed -r 's/.* ([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+GCCVER = $(shell $(CXX) --version | grep g++ | sed -r 's/.* ([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
 ifeq ($(GCCVER),12.2.1)
   libcxx/src/filesystem/operations.cpp_CXXFLAGS += -Wno-maybe-uninitialized
 endif


### PR DESCRIPTION
## Summary

libs/libxx: Fix typo in shell expressions

Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

ci-check