### PR TITLE
Kconfig: add depends on !SYSLOG_TIMESTAMP to DEBUG_SCHED

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1058,6 +1058,7 @@ endif # DEBUG_WIRELESS
 config DEBUG_SCHED
 	bool "Scheduler Debug Features"
 	default n
+	depends on !SYSLOG_TIMESTAMP
 	---help---
 		Enable OS scheduler debug features.
 


### PR DESCRIPTION
## Summary
when using the clock_gettime() function to print the timestamp, the sinfo() function is called, as same as syslog(). But syslog() itself has the ability to print a  timestamp, and called clock_gettime(). Thus, the clock_gettime() and syslog() have a recursive call problem. In order to solve this problem, it is necessary to ensure that SYSLOG_TIMESTAMP is close when DEBUG_SCHED is open.

## Impact

## Testing

