### PR TITLE
Implement the trace function and add tracepoints for the startup process

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -2006,6 +2006,65 @@ config FRAME_POINTER
 
 endmenu # Debug Options
 
+menuconfig  TRACE
+	bool "Enable tracepoints"
+	default n
+	depends on SCHED_INSTRUMENTATION
+	---help---
+		If this option is enabled, tracepoints at critical code in
+		the kernel will be enabled.
+
+if TRACE
+config TRACE_AUDIO
+	bool "Enable tracepoints in audio"
+	default n
+
+config TRACE_ARCH
+	bool "Enable tracepoints in arch"
+	default n
+
+config TRACE_BOARDS
+	bool "Enable tracepoints in boards"
+	default n
+
+config TRACE_CRYPTO
+	bool "Enable tracepoints in crypto"
+	default n
+
+config TRACE_DRIVERS
+	bool "Enable tracepoints in drivers"
+	default n
+
+config TRACE_FS
+	bool "Enable tracepoints in fs"
+	default n
+
+config TRACE_GRAPHICS
+	bool "Enable tracepoints in graphics"
+	default n
+
+config TRACE_LIBS
+	bool "Enable tracepoints in libs"
+	default n
+
+config TRACE_NET
+	bool "Enable tracepoints in net"
+	default n
+
+config TRACE_SCHED
+	bool "Enable tracepoints in sched"
+	default n
+
+config TRACE_VIDEO
+	bool "Enable tracepoints in video"
+	default n
+
+config TRACE_WIRELESS
+	bool "Enable tracepoints in wireless"
+	default n
+
+endif #TRACE
+
 config ARCH_HAVE_CUSTOMOPT
 	bool
 	default n

--- a/include/nuttx/trace.h
+++ b/include/nuttx/trace.h
@@ -1,0 +1,154 @@
+/****************************************************************************
+ * include/nuttx/trace.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_NUTTX_TRACE_H
+#define __INCLUDE_NUTTX_TRACE_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/sched_note.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifdef CONFIG_TRACE
+#  define trace_begin(tag) SCHED_NOTE_BEGIN(tag)
+#  define trace_end(tag) SCHED_NOTE_END(tag)
+#else
+#  define trace_begin(tag)
+#  define trace_end(tag)
+#endif
+
+#ifdef CONFIG_TRACE_APP
+#  define app_trace_begin() trace_begin(NOTE_TAG_APP)
+#  define app_trace_end() trace_end(NOTE_TAG_APP)
+#else
+#  define app_trace_begin()
+#  define app_trace_end()
+#endif
+
+#ifdef CONFIG_TRACE_ARCH
+#  define arch_trace_begin() trace_begin(NOTE_TAG_ARCH)
+#  define arch_trace_end() trace_end(NOTE_TAG_ARCH)
+#else
+#  define arch_trace_begin()
+#  define arch_trace_end()
+#endif
+
+#ifdef CONFIG_TRACE_AUDIO
+#  define audio_trace_begin() trace_begin(NOTE_TAG_AUDIO)
+#  define audio_trace_end() trace_end(NOTE_TAG_AUDIO)
+#else
+#  define audio_trace_begin()
+#  define audio_trace_end()
+#endif
+
+#ifdef CONFIG_TRACE_BOARDS
+#  define boards_trace_begin() trace_begin(NOTE_TAG_BOARDS)
+#  define boards_trace_end() trace_end(NOTE_TAG_BOARDS)
+#else
+#  define boards_trace_begin()
+#  define boards_trace_end()
+#endif
+
+#ifdef CONFIG_TRACE_CRYPTO
+#  define crypto_trace_begin() trace_begin(NOTE_TAG_CRYPTO)
+#  define crypto_trace_end() trace_end(NOTE_TAG_CRYPTO)
+#else
+#  define crypto_trace_begin()
+#  define crypto_trace_end()
+#endif
+
+#ifdef CONFIG_TRACE_DRIVERS
+#  define drivers_trace_begin() trace_begin(NOTE_TAG_DRIVERS)
+#  define drivers_trace_end() trace_end(NOTE_TAG_DRIVERS)
+#else
+#  define drivers_trace_begin()
+#  define drivers_trace_end()
+#endif
+
+#ifdef CONFIG_TRACE_FS
+#  define fs_trace_begin() trace_begin(NOTE_TAG_FS)
+#  define fs_trace_end() trace_end(NOTE_TAG_FS)
+#else
+#  define fs_trace_begin()
+#  define fs_trace_end()
+#endif
+
+#ifdef CONFIG_TRACE_GRAPHICS
+#  define graphics_trace_begin() trace_begin(NOTE_TAG_GRAPHICS)
+#  define graphics_trace_end() trace_end(NOTE_TAG_GRAPHICS)
+#else
+#  define graphics_trace_begin()
+#  define graphics_trace_end()
+#endif
+
+#ifdef CONFIG_TRACE_LIBS
+#  define libs_trace_begin() trace_begin(NOTE_TAG_LIBS)
+#  define libs_trace_end() trace_end(NOTE_TAG_LIBS)
+#else
+#  define libs_trace_begin()
+#  define libs_trace_end()
+#endif
+
+#ifdef CONFIG_TRACE_MM
+#  define mm_trace_begin() trace_begin(NOTE_TAG_MM)
+#  define mm_trace_end() trace_end(NOTE_TAG_MM)
+#else
+#  define mm_trace_begin()
+#  define mm_trace_end()
+#endif
+
+#ifdef CONFIG_TRACE_NET
+#  define net_trace_begin() trace_begin(NOTE_TAG_NET)
+#  define net_trace_end() trace_end(NOTE_TAG_NET)
+#else
+#  define net_trace_begin()
+#  define net_trace_end()
+#endif
+
+#ifdef CONFIG_TRACE_SCHED
+#  define sched_trace_begin() trace_begin(NOTE_TAG_SCHED)
+#  define sched_trace_end() trace_end(NOTE_TAG_SCHED)
+#else
+#  define sched_trace_begin()
+#  define sched_trace_end()
+#endif
+
+#ifdef CONFIG_TRACE_VIDEO
+#  define video_trace_begin() trace_begin(NOTE_TAG_VIDEO)
+#  define video_trace_end() trace_end(NOTE_TAG_VIDEO)
+#else
+#  define video_trace_begin()
+#  define video_trace_end()
+#endif
+
+#ifdef CONFIG_TRACE_WIRELESS
+#  define wireless_trace_begin() trace_begin(NOTE_TAG_WIRLESS)
+#  define wireless_trace_end() trace_end(NOTE_TAG_WIRLESS)
+#else
+#  define wireless_trace_begin()
+#  define wireless_trace_end()
+#endif
+
+#endif /* __INCLUDE_NUTTX_TRACE_H */


### PR DESCRIPTION
## Summary
commit 1: support note filtering at runtime
commit 2: Add trace.h and corresponding configuration
commit 3: Add the tracepoint of the startup process, and more will need to be added later

## Impact

## Testing
```sh
./tools/configure.sh  nucleo-h743zi:trace
make -j

# in nuttx:
trace dump -a 
```
Save the log of the serial port to a file, the following is an example:
[trace.log](https://github.com/apache/nuttx/files/10804071/trace.log)
Open xxx and drag this file into the browser, you will see the following results:(zoom in, zoom out and move through the wasd key)
![image](https://user-images.githubusercontent.com/33870028/220628383-bb1e6c20-7e4c-4a22-b7a9-ca55f675ab54.png)

If you need to verify in other configurations, just enable the following configuration：
```
#  Enable perf count, you need to call up_perf_init before starting
CONFIG_FS_PROCFS=y
CONFIG_SCHED_IRQMONITOR=y
CONFIG_SCHED_INSTRUMENTATION_PERFCOUNT=y

# Enable note driver to write data to noteram
CONFIG_DRIVERS_NOTE=y
CONFIG_DRIVERS_NOTECTL=y
CONFIG_DRIVERS_NOTERAM_BUFSIZE=16384
CONFIG_DRIVERS_NOTERAM_DEFAULT_NOOVERWRITE=y
CONFIG_SCHED_INSTRUMENTATION_DUMP=y
CONFIG_SCHED_INSTRUMENTATION_FILTER=y
CONFIG_SYSTEM_TRACE=y

# Select the trace type to be enabled
CONFIG_TRACE=y
CONFIG_TRACE_BOARDS=y
CONFIG_TRACE_DRIVERS=y
CONFIG_TRACE_FS=y
CONFIG_TRACE_MM=y
CONFIG_TRACE_SCHED=y
```