### PR TITLE
libs/libc: export exit() if configured in flat mode 

### DIFF
--- a/libs/libc/stdlib/lib_exit.c
+++ b/libs/libc/stdlib/lib_exit.c
@@ -31,7 +31,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-#ifndef __KERNEL__
+#if defined(CONFIG_BUILD_FLAT) || !defined(__KERNEL__)
 
 /****************************************************************************
  * Private Data


### PR DESCRIPTION
## Summary

libs/libc: export exit() if configured in flat mode 

## Impact

N/A

## Testing

ci-check