### PR TITLE
execinfo.h: include nuttx/sched.h instead sched.h

### DIFF
--- a/include/execinfo.h
+++ b/include/execinfo.h
@@ -25,8 +25,9 @@
  * Included Files
  ****************************************************************************/
 
+#include <nuttx/sched.h>
+
 #include <sys/types.h>
-#include <sched.h>
 
 /****************************************************************************
  * Pre-processor Definitions


### PR DESCRIPTION
## Summary
_SCHED_GETTID is in nuttx/sched.h, when use dump_stack() compile error log:
unqlite.c:51256: undefined reference to `_SCHED_GETTID'

## Impact
should be none

## Testing
vela
