### PR TITLE
procfs/meminfo: skip invalid character before memdump

### DIFF
--- a/fs/procfs/fs_procfsmeminfo.c
+++ b/fs/procfs/fs_procfsmeminfo.c
@@ -36,6 +36,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
+#include <ctype.h>
 
 #include <nuttx/kmalloc.h>
 #include <nuttx/pgalloc.h>
@@ -523,6 +524,11 @@ static ssize_t memdump_write(FAR struct file *filep, FAR const char *buffer,
         break;
 #if CONFIG_MM_BACKTRACE >= 0
       default:
+        if (!isdigit(buffer[0]))
+          {
+            return buflen;
+          }
+
         pid = atoi(buffer);
 #endif
     }


### PR DESCRIPTION
## Summary


procfs/meminfo: skip invalid character before memdump

In the case of echo characters, atoi will mistake CRLF as a digit character and convert it to 0

Signed-off-by: chao an <anchao@xiaomi.com>


if dump pid 5, the information of pid 0  will also be printed

```
nsh> echo 5 > /proc/memdump
[CPU0] Dump all used memory node info:
[CPU0]    PID        Size    Address Backtrace
[CPU0]      5        2624 0x1083a040 0x1080d3d2 0x10803230 0x10813468
[CPU0]      5         128 0x1083aa80 0x1080d3d2 0x10803230 0x108034d4 0x10801bc0 0x10801c88 0x1080dfba 0x108128c6 0x1081287c
[CPU0]      5         768 0x1083ab00 0x1080d3d2 0x10803230 0x108034d4 0x10808ae2 0x108089f4 0x10807302 0x10810c9c 0x10805f7e
[CPU0]      5          64 0x1083ae00 0x1080d3d2 0x10803230 0x10811304 0x10809850 0x10808c2c 0x10808a00 0x10807302 0x10810c9c
[CPU0]      5         128 0x1083ae40 0x1080d3d2 0x10803230 0x108034d4 0x1080f27c 0x1080e1e2 0x1080f7ea 0x1080f832 0x1080f8a0
[CPU0]   Total Blks  Total Size
[CPU0]            5        3712
[CPU0] Dump all used memory node info:
[CPU0]    PID        Size    Address Backtrace
[CPU0]      0          44 0x10836714
[CPU0]      0         128 0x10836740
[CPU0]      0         192 0x108367c0 0x1080d3d2 0x10803230
[CPU0]      0          64 0x10836880 0x1080d3d2 0x10803230
[CPU0]      0         512 0x108368c0 0x1080d3d2 0x10803230
[CPU0]      0         192 0x10836ac0 0x1080d3d2 0x10803230 0x108034d4 0x108052a0 0x1080392c
[CPU0]      0          64 0x10836b80 0x1080d3d2 0x10803230 0x108052aa 0x1080392c
[CPU0]      0         512 0x10836bc0 0x1080d3d2 0x10803230 0x108034d4 0x1080619a 0x108052c2 0x1080392c
[CPU0]      0         192 0x10836dc0 0x1080d3d2 0x10803230 0x108034d4 0x108052a0 0x1080392c
```


## Impact

N/A

## Testing

sabre-6quad/smp