### PR TITLE
openamp: update openamp lib

### DIFF
--- a/openamp/0011-rpmsg-fix-rpmsg_virtio_get_tx_buffer-no-idx-return.patch
+++ b/openamp/0011-rpmsg-fix-rpmsg_virtio_get_tx_buffer-no-idx-return.patch
@@ -1,0 +1,30 @@
+From 6c7a71ed16d86638141566fa7457e2aa36112202 Mon Sep 17 00:00:00 2001
+From: ligd <liguiding1@xiaomi.com>
+Date: Fri, 6 Jan 2023 22:13:49 +0800
+Subject: [PATCH 1/6] rpmsg: fix rpmsg_virtio_get_tx_buffer no idx return
+
+Change-Id: Ib7004b9039403156ec39f01ecf3d29900957c3be
+Signed-off-by: ligd <liguiding1@xiaomi.com>
+---
+ lib/rpmsg/rpmsg_virtio.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/lib/rpmsg/rpmsg_virtio.c open-amp/lib/rpmsg/rpmsg_virtio.c
+index 06c6890..fcf24cd 100644
+--- a/lib/rpmsg/rpmsg_virtio.c
++++ open-amp/lib/rpmsg/rpmsg_virtio.c
+@@ -176,8 +176,10 @@ static void *rpmsg_virtio_get_tx_buffer(struct rpmsg_virtio_device *rvdev,
+ 		data = r_desc;
+ 
+ #ifndef VIRTIO_DEVICE_ONLY
+-		if (role == RPMSG_HOST)
++		if (role == RPMSG_HOST) {
++			*idx = r_desc->idx;
+ 			*len = rvdev->config.h2r_buf_size;
++		}
+ #endif /*!VIRTIO_DEVICE_ONLY*/
+ #ifndef VIRTIO_DRIVER_ONLY
+ 		if (role == RPMSG_REMOTE) {
+-- 
+2.25.1
+

--- a/openamp/0012-rpmsg-add-new-API-rpdev_release_tx-rx_buffer.patch
+++ b/openamp/0012-rpmsg-add-new-API-rpdev_release_tx-rx_buffer.patch
@@ -1,0 +1,100 @@
+From a541d9d446e5700fd5a74cf5d8296114023b40fb Mon Sep 17 00:00:00 2001
+From: ligd <liguiding1@xiaomi.com>
+Date: Fri, 6 Jan 2023 22:57:02 +0800
+Subject: [PATCH 2/6] rpmsg: add new API rpdev_release_tx/rx_buffer()
+
+These API used for release tx/rx buffer from rpmsg_device
+For case:
+get_tx_buffer
+close ept
+release tx buffer failed
+
+Change-Id: I74f83ff336415ccbe0191e67315ed27a35be3983
+Signed-off-by: ligd <liguiding1@xiaomi.com>
+---
+ lib/include/openamp/rpmsg.h |  2 ++
+ lib/rpmsg/rpmsg.c           | 32 ++++++++++++++++++++------------
+ 2 files changed, 22 insertions(+), 12 deletions(-)
+
+diff --git a/lib/include/openamp/rpmsg.h open-amp/lib/include/openamp/rpmsg.h
+index fbd7f61..d39a7a4 100644
+--- a/lib/include/openamp/rpmsg.h
++++ open-amp/lib/include/openamp/rpmsg.h
+@@ -360,6 +360,7 @@ void rpmsg_hold_rx_buffer(struct rpmsg_endpoint *ept, void *rxbuf);
+  * @see rpmsg_hold_rx_buffer
+  */
+ void rpmsg_release_rx_buffer(struct rpmsg_endpoint *ept, void *rxbuf);
++void rpdev_release_rx_buffer(struct rpmsg_device *rdev, void *rxbuf);
+ 
+ /**
+  * @brief Gets the tx buffer for message payload.
+@@ -405,6 +406,7 @@ void *rpmsg_get_tx_payload_buffer(struct rpmsg_endpoint *ept,
+  * @see rpmsg_get_tx_payload_buffer
+  */
+ int rpmsg_release_tx_buffer(struct rpmsg_endpoint *ept, void *txbuf);
++int rpdev_release_tx_buffer(struct rpmsg_device *rdev, void *txbuf);
+ 
+ /**
+  * rpmsg_send_offchannel_nocopy() - send a message in tx buffer reserved by
+diff --git a/lib/rpmsg/rpmsg.c open-amp/lib/rpmsg/rpmsg.c
+index 4e7f7da..93a6282 100644
+--- a/lib/rpmsg/rpmsg.c
++++ open-amp/lib/rpmsg/rpmsg.c
+@@ -157,34 +157,42 @@ void rpmsg_hold_rx_buffer(struct rpmsg_endpoint *ept, void *rxbuf)
+ 		rdev->ops.hold_rx_buffer(rdev, rxbuf);
+ }
+ 
+-void rpmsg_release_rx_buffer(struct rpmsg_endpoint *ept, void *rxbuf)
++void rpdev_release_rx_buffer(struct rpmsg_device *rdev, void *rxbuf)
+ {
+-	struct rpmsg_device *rdev;
+-
+-	if (!ept || !ept->rdev || !rxbuf)
++	if (!rdev || !rxbuf)
+ 		return;
+ 
+-	rdev = ept->rdev;
+-
+ 	if (rdev->ops.release_rx_buffer)
+ 		rdev->ops.release_rx_buffer(rdev, rxbuf);
+ }
+ 
+-int rpmsg_release_tx_buffer(struct rpmsg_endpoint *ept, void *buf)
++void rpmsg_release_rx_buffer(struct rpmsg_endpoint *ept, void *rxbuf)
+ {
+-	struct rpmsg_device *rdev;
++	if (!ept)
++		return;
+ 
+-	if (!ept || !ept->rdev || !buf)
+-		return RPMSG_ERR_PARAM;
++	rpdev_release_rx_buffer(ept->rdev, rxbuf);
++}
+ 
+-	rdev = ept->rdev;
++int rpdev_release_tx_buffer(struct rpmsg_device *rdev, void *txbuf)
++{
++	if (!rdev || !txbuf)
++		return RPMSG_ERR_PERM;
+ 
+ 	if (rdev->ops.release_tx_buffer)
+-		return rdev->ops.release_tx_buffer(rdev, buf);
++		return rdev->ops.release_tx_buffer(rdev, txbuf);
+ 
+ 	return RPMSG_ERR_PERM;
+ }
+ 
++int rpmsg_release_tx_buffer(struct rpmsg_endpoint *ept, void *txbuf)
++{
++	if (!ept)
++		return RPMSG_ERR_PARAM;
++
++	return rpdev_release_tx_buffer(ept->rdev, txbuf);
++}
++
+ void *rpmsg_get_tx_payload_buffer(struct rpmsg_endpoint *ept,
+ 				  uint32_t *len, int wait)
+ {
+-- 
+2.25.1
+

--- a/openamp/0013-openamp-add-error-log-when-ept-cb-return-error.patch
+++ b/openamp/0013-openamp-add-error-log-when-ept-cb-return-error.patch
@@ -1,0 +1,33 @@
+From c47e2e05a8402997657bd0680621ffcecaaa9971 Mon Sep 17 00:00:00 2001
+From: ligd <liguiding1@xiaomi.com>
+Date: Fri, 10 Feb 2023 17:05:54 +0800
+Subject: [PATCH 3/6] openamp: add error log when ept->cb return error
+
+Change-Id: Id750dc9518a7f861a74965c34a6491e5b3463e95
+Signed-off-by: ligd <liguiding1@xiaomi.com>
+---
+ lib/rpmsg/rpmsg_virtio.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/lib/rpmsg/rpmsg_virtio.c open-amp/lib/rpmsg/rpmsg_virtio.c
+index fcf24cd..357d821 100644
+--- a/lib/rpmsg/rpmsg_virtio.c
++++ open-amp/lib/rpmsg/rpmsg_virtio.c
+@@ -571,8 +571,12 @@ static void rpmsg_virtio_rx_callback(struct virtqueue *vq)
+ 			status = ept->cb(ept, RPMSG_LOCATE_DATA(rp_hdr),
+ 					 rp_hdr->len, rp_hdr->src, ept->priv);
+ 
+-			RPMSG_ASSERT(status >= 0,
+-				     "unexpected callback status\r\n");
++			if (status < 0) {
++				metal_log(METAL_LOG_ERROR,
++					  "ept %s, cb %p, return status %d\r\n",
++					  ept->name, ept->cb, status);
++				RPMSG_ASSERT(0, "unexpected callback status\r\n");
++			}
+ 		}
+ 
+ 		metal_mutex_acquire(&rdev->lock);
+-- 
+2.25.1
+

--- a/openamp/0014-rpmsg-add-cache-flash-when-hold-rx-buffer.patch
+++ b/openamp/0014-rpmsg-add-cache-flash-when-hold-rx-buffer.patch
@@ -1,0 +1,65 @@
+From 0f3f00d2ecb1f7de470e6eaeeb74ba0ba9b66eea Mon Sep 17 00:00:00 2001
+From: ligd <liguiding1@xiaomi.com>
+Date: Mon, 13 Feb 2023 20:34:56 +0800
+Subject: [PATCH 4/6] rpmsg: add cache flash when hold rx buffer
+
+Assume we have 2 cpus, and use cached shram buffer
+
+CPU0                    CPU1
+
+1. send tx bufferX
+                        2. recv rx bufferX
+                        3. set idx to hdr->reserved
+                        4. handled rx bufferX
+                        5. return bufferX
+6. reuse tx bufferX
+                        7. dirty cache auto flushed, hdr changed
+8. buffer X meet error
+
+Change-Id: If6c347d121ced0c59b6172a490098689b9b7ffd7
+---
+ lib/rpmsg/rpmsg_virtio.c | 14 ++++++++++----
+ 1 file changed, 10 insertions(+), 4 deletions(-)
+
+diff --git a/lib/rpmsg/rpmsg_virtio.c open-amp/lib/rpmsg/rpmsg_virtio.c
+index fcf24cd..1a510e6 100644
+--- a/lib/rpmsg/rpmsg_virtio.c
++++ open-amp/lib/rpmsg/rpmsg_virtio.c
+@@ -321,7 +321,7 @@ static void rpmsg_virtio_hold_rx_buffer(struct rpmsg_device *rdev, void *rxbuf)
+ 	rp_hdr = RPMSG_LOCATE_HDR(rxbuf);
+ 
+ 	/* Set held status to keep buffer */
+-	rp_hdr->reserved |= RPMSG_BUF_HELD;
++	rp_hdr->reserved = RPMSG_BUF_HELD;
+ }
+ 
+ static void rpmsg_virtio_release_rx_buffer(struct rpmsg_device *rdev,
+@@ -553,8 +553,6 @@ static void rpmsg_virtio_rx_callback(struct virtqueue *vq)
+ 	metal_mutex_release(&rdev->lock);
+ 
+ 	while (rp_hdr) {
+-		rp_hdr->reserved = idx;
+-
+ 		/* Get the channel node from the remote device channels list. */
+ 		metal_mutex_acquire(&rdev->lock);
+ 		ept = rpmsg_get_ept_from_addr(rdev, rp_hdr->dst);
+@@ -578,7 +576,15 @@ static void rpmsg_virtio_rx_callback(struct virtqueue *vq)
+ 		metal_mutex_acquire(&rdev->lock);
+ 
+ 		/* Check whether callback wants to hold buffer */
+-		if (!(rp_hdr->reserved & RPMSG_BUF_HELD)) {
++		if (rp_hdr->reserved & RPMSG_BUF_HELD) {
++			/* Yes, save idx. */
++			rp_hdr->reserved |= idx;
++
++#ifdef VIRTIO_CACHED_BUFFERS
++			metal_cache_flush(rp_hdr, sizeof(struct rpmsg_hdr));
++#endif
++
++		} else {
+ 			/* No, return used buffers. */
+ 			rpmsg_virtio_return_buffer(rvdev, rp_hdr, len, idx);
+ 		}
+-- 
+2.25.1
+

--- a/openamp/0015-rpmsg-do-cache_invalidate-when-real-data-returned.patch
+++ b/openamp/0015-rpmsg-do-cache_invalidate-when-real-data-returned.patch
@@ -1,0 +1,28 @@
+From 7588713482056dcb8395da1d6fa470559f139e94 Mon Sep 17 00:00:00 2001
+From: ligd <liguiding1@xiaomi.com>
+Date: Thu, 16 Feb 2023 17:41:57 +0800
+Subject: [PATCH 5/6] rpmsg: do cache_invalidate() when real data returned
+
+Change-Id: Ib5788c3974e40421deda2d100a46f61348ccafbd
+Signed-off-by: ligd <liguiding1@xiaomi.com>
+---
+ lib/rpmsg/rpmsg_virtio.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/lib/rpmsg/rpmsg_virtio.c open-amp/lib/rpmsg/rpmsg_virtio.c
+index 1a510e6..3db86e6 100644
+--- a/lib/rpmsg/rpmsg_virtio.c
++++ open-amp/lib/rpmsg/rpmsg_virtio.c
+@@ -239,7 +239,8 @@ static void *rpmsg_virtio_get_rx_buffer(struct rpmsg_virtio_device *rvdev,
+ 
+ #ifdef VIRTIO_CACHED_BUFFERS
+ 	/* Invalidate the buffer before returning it */
+-	metal_cache_invalidate(data, *len);
++	if (data)
++		metal_cache_invalidate(data, *len);
+ #endif /* VIRTIO_CACHED_BUFFERS */
+ 
+ 	return data;
+-- 
+2.25.1
+

--- a/openamp/0016-openamp-add-new-API-rpmsg_virtio_get_rxbuffer_size.patch
+++ b/openamp/0016-openamp-add-new-API-rpmsg_virtio_get_rxbuffer_size.patch
@@ -1,0 +1,105 @@
+From b03e398fb8c2016029500f058e1cdaa7cc4cb92f Mon Sep 17 00:00:00 2001
+From: ligd <liguiding1@xiaomi.com>
+Date: Mon, 20 Feb 2023 21:08:35 +0800
+Subject: [PATCH 6/6] openamp: add new API rpmsg_virtio_get_rxbuffer_size()
+
+Change-Id: If98c7260be8524627cd1c272c164c22a9548198c
+Signed-off-by: ligd <liguiding1@xiaomi.com>
+---
+ lib/include/openamp/rpmsg_virtio.h | 11 ++++++++++-
+ lib/rpmsg/rpmsg_virtio.c           | 25 +++++++++++++++++++++----
+ 2 files changed, 31 insertions(+), 5 deletions(-)
+
+diff --git a/lib/include/openamp/rpmsg_virtio.h open-amp/lib/include/openamp/rpmsg_virtio.h
+index 11cb6df..bdc6cc6 100644
+--- a/lib/include/openamp/rpmsg_virtio.h
++++ open-amp/lib/include/openamp/rpmsg_virtio.h
+@@ -158,7 +158,7 @@ rpmsg_virtio_notify_wait(struct rpmsg_virtio_device *rvdev,
+ }
+ 
+ /**
+- * rpmsg_virtio_get_buffer_size - get rpmsg virtio buffer size
++ * rpmsg_virtio_get_buffer_size - get rpmsg virtio Tx buffer size
+  *
+  * @rdev - pointer to the rpmsg device
+  *
+@@ -166,6 +166,15 @@ rpmsg_virtio_notify_wait(struct rpmsg_virtio_device *rvdev,
+  */
+ int rpmsg_virtio_get_buffer_size(struct rpmsg_device *rdev);
+ 
++/**
++ * rpmsg_virtio_get_rx_buffer_size - get rpmsg virtio Rx buffer size
++ *
++ * @rdev - pointer to the rpmsg device
++ *
++ * @return - next available buffer size for text, negative value for failure
++ */
++int rpmsg_virtio_get_rx_buffer_size(struct rpmsg_device *rdev);
++
+ /**
+  * rpmsg_init_vdev - initialize rpmsg virtio device
+  * Host side:
+diff --git a/lib/rpmsg/rpmsg_virtio.c open-amp/lib/rpmsg/rpmsg_virtio.c
+index 13fd496..c44b4fd 100644
+--- a/lib/rpmsg/rpmsg_virtio.c
++++ open-amp/lib/rpmsg/rpmsg_virtio.c
+@@ -275,11 +275,12 @@ static int rpmsg_virtio_wait_remote_ready(struct rpmsg_virtio_device *rvdev)
+  * Returns buffer size available for sending messages.
+  *
+  * @param rvdev - pointer to rpmsg device
++ *        tx    - tx or rx
+  *
+  * @return - buffer size
+  *
+  */
+-static int _rpmsg_virtio_get_buffer_size(struct rpmsg_virtio_device *rvdev)
++static int _rpmsg_virtio_get_buffer_size(struct rpmsg_virtio_device *rvdev, bool tx)
+ {
+ 	unsigned int role = rpmsg_virtio_get_role(rvdev);
+ 	int length = 0;
+@@ -290,7 +291,9 @@ static int _rpmsg_virtio_get_buffer_size(struct rpmsg_virtio_device *rvdev)
+ 		 * If device role is host then buffers are provided by us,
+ 		 * so just provide the macro.
+ 		 */
+-		length = rvdev->config.h2r_buf_size - sizeof(struct rpmsg_hdr);
++		length =
++		    tx ? rvdev->config.h2r_buf_size : rvdev->config.r2h_buf_size
++		    - sizeof(struct rpmsg_hdr);
+ 	}
+ #endif /*!VIRTIO_DEVICE_ONLY*/
+ 
+@@ -301,7 +304,7 @@ static int _rpmsg_virtio_get_buffer_size(struct rpmsg_virtio_device *rvdev)
+ 		 * so get the buffer size from the virtqueue.
+ 		 */
+ 		length =
+-		    (int)virtqueue_get_desc_size(rvdev->svq) -
++		    (int)virtqueue_get_desc_size(tx ? rvdev->svq : rvdev->rvq) -
+ 		    sizeof(struct rpmsg_hdr);
+ 	}
+ #endif /*!VIRTIO_DRIVER_ONLY*/
+@@ -700,7 +703,21 @@ int rpmsg_virtio_get_buffer_size(struct rpmsg_device *rdev)
+ 		return RPMSG_ERR_PARAM;
+ 	metal_mutex_acquire(&rdev->lock);
+ 	rvdev = (struct rpmsg_virtio_device *)rdev;
+-	size = _rpmsg_virtio_get_buffer_size(rvdev);
++	size = _rpmsg_virtio_get_buffer_size(rvdev, true);
++	metal_mutex_release(&rdev->lock);
++	return size;
++}
++
++int rpmsg_virtio_get_rx_buffer_size(struct rpmsg_device *rdev)
++{
++	int size;
++	struct rpmsg_virtio_device *rvdev;
++
++	if (!rdev)
++		return RPMSG_ERR_PARAM;
++	metal_mutex_acquire(&rdev->lock);
++	rvdev = (struct rpmsg_virtio_device *)rdev;
++	size = _rpmsg_virtio_get_buffer_size(rvdev, false);
+ 	metal_mutex_release(&rdev->lock);
+ 	return size;
+ }
+-- 
+2.25.1
+

--- a/openamp/open-amp.defs
+++ b/openamp/open-amp.defs
@@ -45,6 +45,14 @@ open-amp.zip:
 	$(Q) patch -p0 < 0008-remoteproc-make-all-elf_-functions-static-except-elf.patch
 	$(Q) patch -p0 < 0009-Fix-warn-declaration-of-vring_rsc-shadows-a-previous.patch
 	$(Q) patch -p0 < 0010-rptun-fix-rptun-don-t-wait-issue-when-get-tx-patyloa.patch
+	$(Q) patch -p0 < 0011-rpmsg-fix-rpmsg_virtio_get_tx_buffer-no-idx-return.patch
+	$(Q) patch -p0 < 0012-rpmsg-add-new-API-rpdev_release_tx-rx_buffer.patch
+	$(Q) patch -p0 < 0013-openamp-add-error-log-when-ept-cb-return-error.patch
+	$(Q) patch -p0 < 0014-rpmsg-add-cache-flash-when-hold-rx-buffer.patch
+	$(Q) patch -p0 < 0015-rpmsg-do-cache_invalidate-when-real-data-returned.patch
+	$(Q) patch -p0 < 0016-openamp-add-new-API-rpmsg_virtio_get_rxbuffer_size.patch
+
+
 
 .openamp_headers: open-amp.zip
 else


### PR DESCRIPTION
## Summary

openamp: update openamp lib

openamp: add new API rpmsg_virtio_get_rxbuffer_size()
rpmsg: do cache_invalidate() when real data returned
rpmsg: add cache flash when hold rx buffer
openamp: add error log when ept->cb return error
rpmsg: add new API rpdev_release_tx/rx_buffer()
rpmsg: fix rpmsg_virtio_get_tx_buffer no idx return

## Impact

openamp IPC

## Testing

VELA
