### PR TITLE
local_socket: remove the wrong assertion in local_listen()

### DIFF
--- a/net/local/local_listen.c
+++ b/net/local/local_listen.c
@@ -111,10 +111,6 @@ int local_listen(FAR struct socket *psock, int backlog)
 
   if (server->lc_state == LOCAL_STATE_BOUND)
     {
-      /* The connection should not reside in any other list */
-
-      DEBUGASSERT(server->lc_conn.node.flink == NULL);
-
       /* And change the server state to listing */
 
       server->lc_state = LOCAL_STATE_LISTENING;


### PR DESCRIPTION

## Summary

local_socket: remove the wrong assertion in local_listen()
if 2 threads call local_alloc() time and then do local_listen() will meet this assertion

## Impact

local socket

## Testing

VELA