### PR TITLE
socket: divide errno & s_error

### DIFF
--- a/net/socket/accept.c
+++ b/net/socket/accept.c
@@ -313,6 +313,6 @@ errout_with_alloc:
 errout:
   leave_cancellation_point();
 
-  _SO_SETERRNO(psock, errcode);
+  set_errno(errcode);
   return ERROR;
 }

--- a/net/socket/bind.c
+++ b/net/socket/bind.c
@@ -152,11 +152,11 @@ int bind(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
 
   if (ret < 0)
     {
-      _SO_SETERRNO(psock, -ret);
-      return ERROR;
+      set_errno(-ret);
+      ret = ERROR;
     }
 
-  return OK;
+  return ret;
 }
 
 #endif /* CONFIG_NET */

--- a/net/socket/connect.c
+++ b/net/socket/connect.c
@@ -237,7 +237,7 @@ int connect(int sockfd, FAR const struct sockaddr *addr, socklen_t addrlen)
 
   if (ret < 0)
     {
-      _SO_SETERRNO(psock, -ret);
+      set_errno(-ret);
       ret = ERROR;
     }
 

--- a/net/socket/getpeername.c
+++ b/net/socket/getpeername.c
@@ -161,11 +161,11 @@ int getpeername(int sockfd, FAR struct sockaddr *addr,
 
   if (ret < 0)
     {
-      _SO_SETERRNO(psock, -ret);
-      return ERROR;
+      set_errno(-ret);
+      ret = ERROR;
     }
 
-  return OK;
+  return ret;
 }
 
 #endif /* CONFIG_NET */

--- a/net/socket/getsockname.c
+++ b/net/socket/getsockname.c
@@ -155,11 +155,11 @@ int getsockname(int sockfd, FAR struct sockaddr *addr,
 
   if (ret < 0)
     {
-      _SO_SETERRNO(psock, -ret);
-      return ERROR;
+      set_errno(-ret);
+      ret = ERROR;
     }
 
-  return OK;
+  return ret;
 }
 
 #endif /* CONFIG_NET */

--- a/net/socket/getsockopt.c
+++ b/net/socket/getsockopt.c
@@ -362,10 +362,10 @@ int getsockopt(int sockfd, int level, int option,
   if (ret < 0)
     {
       set_errno(-ret);
-      return ERROR;
+      ret = ERROR;
     }
 
-  return OK;
+  return ret;
 }
 
 #endif /* CONFIG_NET && CONFIG_NET_SOCKOPTS */

--- a/net/socket/listen.c
+++ b/net/socket/listen.c
@@ -150,9 +150,9 @@ int listen(int sockfd, int backlog)
 
   if (ret < 0)
     {
-      _SO_SETERRNO(psock, -ret);
-      return ERROR;
+      set_errno(-ret);
+      ret = ERROR;
     }
 
-  return OK;
+  return ret;
 }

--- a/net/socket/net_sendfile.c
+++ b/net/socket/net_sendfile.c
@@ -131,11 +131,6 @@ ssize_t psock_sendfile(FAR struct socket *psock, FAR struct file *infile,
       ret = psock->s_sockif->si_sendfile(psock, infile, offset, count);
     }
 
-  if (ret < 0)
-    {
-      _SO_SETERRNO(psock, -ret);
-    }
-
   return ret;
 }
 

--- a/net/socket/recvfrom.c
+++ b/net/socket/recvfrom.c
@@ -170,7 +170,7 @@ ssize_t recvfrom(int sockfd, FAR void *buf, size_t len, int flags,
 
   if (ret < 0)
     {
-      _SO_SETERRNO(psock, -ret);
+      set_errno(-ret);
       ret = ERROR;
     }
 

--- a/net/socket/recvmsg.c
+++ b/net/socket/recvmsg.c
@@ -168,7 +168,7 @@ ssize_t recvmsg(int sockfd, FAR struct msghdr *msg, int flags)
 
   if (ret < 0)
     {
-      _SO_SETERRNO(psock, -ret);
+      set_errno(-ret);
       ret = ERROR;
     }
 

--- a/net/socket/send.c
+++ b/net/socket/send.c
@@ -176,7 +176,7 @@ ssize_t send(int sockfd, FAR const void *buf, size_t len, int flags)
 
   if (ret < 0)
     {
-      _SO_SETERRNO(psock, -ret);
+      set_errno(-ret);
       ret = ERROR;
     }
 

--- a/net/socket/sendmsg.c
+++ b/net/socket/sendmsg.c
@@ -158,7 +158,7 @@ ssize_t sendmsg(int sockfd, FAR struct msghdr *msg, int flags)
 
   if (ret < 0)
     {
-      _SO_SETERRNO(psock, -ret);
+      set_errno(-ret);
       ret = ERROR;
     }
 

--- a/net/socket/sendto.c
+++ b/net/socket/sendto.c
@@ -216,7 +216,7 @@ ssize_t sendto(int sockfd, FAR const void *buf, size_t len, int flags,
 
   if (ret < 0)
     {
-      _SO_SETERRNO(psock, -ret);
+      set_errno(-ret);
       ret = ERROR;
     }
 

--- a/net/socket/shutdown.c
+++ b/net/socket/shutdown.c
@@ -141,7 +141,7 @@ int shutdown(int sockfd, int how)
 
   if (ret < 0)
     {
-      _SO_SETERRNO(psock, -ret);
+      set_errno(-ret);
       ret = ERROR;
     }
 

--- a/net/socket/socket.h
+++ b/net/socket/socket.h
@@ -103,7 +103,6 @@
               (FAR struct socket_conn_s *)(c); \
             _conn->s_error = (int16_t)e; \
           } \
-        set_errno(e); \
       } \
     while (0)
 
@@ -114,15 +113,11 @@
           { \
             _SO_CONN_SETERRNO((s)->s_conn, e); \
           } \
-        else \
-          { \
-            set_errno(e); \
-          } \
       } \
     while (0)
 #else
-#  define _SO_CONN_SETERRNO(c,e) set_errno(e)
-#  define _SO_SETERRNO(s,e) set_errno(e)
+#  define _SO_CONN_SETERRNO(c,e)
+#  define _SO_SETERRNO(s,e)
 #endif /* CONFIG_NET_SOCKOPTS */
 
 /****************************************************************************

--- a/net/tcp/tcp_netpoll.c
+++ b/net/tcp/tcp_netpoll.c
@@ -67,7 +67,6 @@ static uint16_t tcp_poll_eventhandler(FAR struct net_driver_s *dev,
                                       FAR void *pvpriv, uint16_t flags)
 {
   FAR struct tcp_poll_s *info = pvpriv;
-  int reason;
 
   ninfo("flags: %04x\n", flags);
 
@@ -97,6 +96,9 @@ static uint16_t tcp_poll_eventhandler(FAR struct net_driver_s *dev,
 
       if ((flags & TCP_DISCONN_EVENTS) != 0)
         {
+#ifdef CONFIG_NET_SOCKOPTS
+          int reason;
+
           /* TCP_TIMEDOUT: Connection aborted due to too many
            *               retransmissions.
            */
@@ -129,6 +131,7 @@ static uint16_t tcp_poll_eventhandler(FAR struct net_driver_s *dev,
             }
 
           _SO_CONN_SETERRNO(info->conn, reason);
+#endif
 
           /* Mark that the connection has been lost */
 


### PR DESCRIPTION
## Summary

socket: divide errno & s_error

Reference:
https: //man7.org/linux/man-pages/man2/connect.2.html

## Impact

ALL socket API effect on s_error

## Testing

VELA
