### PR TITLE
correct systime with perf count

### DIFF
--- a/Documentation/guides/tasktraceuser.rst
+++ b/Documentation/guides/tasktraceuser.rst
@@ -42,10 +42,6 @@ The following configurations are configurable parameters for trace.
     - Bit 2 = Enable IRQ instrumentation
     - Bit 3 = Enable collecting syscall arguments
 
-- ``CONFIG_SCHED_INSTRUMENTATION_HIRES``
-
-  - If enabled, use higher resolution system timer for instrumentation.
-
 - ``CONFIG_DRIVERS_NOTE_TASKNAME_BUFSIZE``
 
   - Specify the task name buffer size in bytes.

--- a/drivers/note/note_driver.c
+++ b/drivers/note/note_driver.c
@@ -223,8 +223,15 @@ static void note_common(FAR struct tcb_s *tcb,
                         FAR struct note_common_s *note,
                         uint8_t length, uint8_t type)
 {
+#ifdef CONFIG_SCHED_INSTRUMENTATION_PERFCOUNT
+  struct timespec perftime;
+#endif
   struct timespec ts;
   clock_systime_timespec(&ts);
+#ifdef CONFIG_SCHED_INSTRUMENTATION_PERFCOUNT
+  up_perf_convert(up_perf_gettime(), &perftime);
+  ts.tv_nsec = perftime.tv_nsec;
+#endif
 
   /* Save all of the common fields */
 

--- a/drivers/note/note_driver.c
+++ b/drivers/note/note_driver.c
@@ -223,13 +223,8 @@ static void note_common(FAR struct tcb_s *tcb,
                         FAR struct note_common_s *note,
                         uint8_t length, uint8_t type)
 {
-#ifdef CONFIG_SCHED_INSTRUMENTATION_HIRES
   struct timespec ts;
-
   clock_systime_timespec(&ts);
-#else
-  clock_t systime = clock_systime_ticks();
-#endif
 
   /* Save all of the common fields */
 
@@ -240,15 +235,8 @@ static void note_common(FAR struct tcb_s *tcb,
   note->nc_cpu      = tcb->cpu;
 #endif
   sched_note_flatten(note->nc_pid, &tcb->pid, sizeof(tcb->pid));
-
-#ifdef CONFIG_SCHED_INSTRUMENTATION_HIRES
   sched_note_flatten(note->nc_systime_nsec, &ts.tv_nsec, sizeof(ts.tv_nsec));
   sched_note_flatten(note->nc_systime_sec, &ts.tv_sec, sizeof(ts.tv_sec));
-#else
-  /* Save the LS 32-bits of the system timer in little endian order */
-
-  sched_note_flatten(note->nc_systime, &systime, sizeof(systime));
-#endif
 }
 
 /****************************************************************************

--- a/include/nuttx/sched_note.h
+++ b/include/nuttx/sched_note.h
@@ -217,12 +217,13 @@ struct note_common_s
 #endif
   uint8_t nc_pid[sizeof(pid_t)]; /* ID of the thread/task */
 
-#ifdef CONFIG_SCHED_INSTRUMENTATION_HIRES
-  uint8_t nc_systime_sec[sizeof(time_t)]; /* Time when note was buffered (sec) */
-  uint8_t nc_systime_nsec[sizeof(long)];  /* Time when note was buffered (nsec) */
-#else
-  uint8_t nc_systime[sizeof(clock_t)]; /* Time when note was buffered */
-#endif
+  /* Time when note was buffered (sec) */
+
+  uint8_t nc_systime_sec[sizeof(time_t)];
+
+  /* Time when note was buffered (nsec) */
+
+  uint8_t nc_systime_nsec[sizeof(long)];
 };
 
 /* This is the specific form of the NOTE_START note */

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -973,6 +973,14 @@ config SCHED_INSTRUMENTATION_CPUSET
 	---help---
 		Monitor only CPUs in the bitset.  Bit 0=CPU0, Bit1=CPU1, etc.
 
+config SCHED_INSTRUMENTATION_PERFCOUNT
+	bool "Use perf count for instrumentation"
+	default n
+	---help---
+		Enabling this option will use perfcount as the clock source for tv_nsec
+		to achieve higher precision time.
+		This requires calling up_perf_init at system startup.
+
 config SCHED_INSTRUMENTATION_FILTER
 	bool "Instrumentation filter"
 	default n

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -973,12 +973,6 @@ config SCHED_INSTRUMENTATION_CPUSET
 	---help---
 		Monitor only CPUs in the bitset.  Bit 0=CPU0, Bit1=CPU1, etc.
 
-config SCHED_INSTRUMENTATION_HIRES
-	bool "Use Hi-Res RTC for instrumentation"
-	default n
-	---help---
-		Use higher resolution system timer for instrumentation.
-
 config SCHED_INSTRUMENTATION_FILTER
 	bool "Instrumentation filter"
 	default n


### PR DESCRIPTION
## Summary
use perfcount as the clock source for tv_nsec to achieve higher precision time. 

systime has insufficient time precision and will not display correctly when viewing finer-grained traces

## Impact
Affects trace_dump.c: https://github.com/apache/nuttx-apps/pull/1593

## Testing

