### PR TITLE
sched: fix kconfig warning 

### DIFF
--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -1484,6 +1484,10 @@ config SIG_ABRT
 	int "SIGABRT"
 	default 6
 	---help---
+		The SIGABRT signal is sent to a process to tell it to abort, i.e. to
+		terminate. The signal is usually initiated by the process itself when
+		it calls abort function of the C Standard Library, but it can be sent
+		to the process from outside like any other signal.
 
 config SIG_BUS
 	int "SIGBUS"


### PR DESCRIPTION
## Summary

sched: fix kconfig warning

warning: SIG_ABRT (defined at sched/Kconfig:1481) has 'help' but empty help text

Reference: https://dsa.cs.tsinghua.edu.cn/oj/static/unix_signal.html

Signed-off-by: Junbo Zheng <zhengjunbo1@xiaomi.com>


## Impact

N/A

## Testing

ci-check