### PR TITLE
doc: Add xxd to get romfs working, reported by Simon Filgis

### DIFF
--- a/Documentation/quickstart/install.rst
+++ b/Documentation/quickstart/install.rst
@@ -22,7 +22,7 @@ First, install the following set of system dependencies according to your Operat
     .. code-block:: console
 
       $ sudo apt install \
-      bison flex gettext texinfo libncurses5-dev libncursesw5-dev \
+      bison flex gettext texinfo libncurses5-dev libncursesw5-dev xxd \
       gperf automake libtool pkg-config build-essential gperf genromfs \
       libgmp-dev libmpc-dev libmpfr-dev libisl-dev binutils-dev libelf-dev \
       libexpat-dev gcc-multilib g++-multilib picocom u-boot-tools util-linux


### PR DESCRIPTION
## Summary
Add xxd to get romfs working, reported by Simon Filgis
## Impact
Now ROMFS will be included correctly on machines that doesn't have vim installed
## Testing
N/A
