### PR TITLE
mm/circbuf: update buffer head according to real length of writing

### DIFF
--- a/mm/circbuf/circbuf.c
+++ b/mm/circbuf/circbuf.c
@@ -501,6 +501,7 @@ ssize_t circbuf_overwrite(FAR struct circbuf_s *circ,
                           FAR const void *src, size_t bytes)
 {
   size_t overwrite = 0;
+  size_t skip = 0;
   size_t space;
   size_t off;
 
@@ -514,14 +515,15 @@ ssize_t circbuf_overwrite(FAR struct circbuf_s *circ,
 
   if (bytes > circ->size)
     {
-      src = (FAR const void *)((FAR char *)src + bytes - circ->size);
+      skip = bytes - circ->size;
+      src = (FAR const void *)((FAR char *)src + skip);
       bytes = circ->size;
     }
 
   space = circbuf_space(circ);
   if (bytes > space)
     {
-      overwrite = bytes - space;
+      overwrite = bytes - space + skip;
     }
 
   off = circ->head % circ->size;
@@ -533,7 +535,7 @@ ssize_t circbuf_overwrite(FAR struct circbuf_s *circ,
 
   memcpy((FAR char *)circ->base + off, src, space);
   memcpy(circ->base, (FAR char *)src + space, bytes - space);
-  circ->head += bytes;
+  circ->head += bytes + skip;
   circ->tail += overwrite;
 
   return overwrite;


### PR DESCRIPTION



## Summary

mm/circbuf: update buffer head according to real length of writing

## Impact
update buffer head pointer correctly
## Testing
local test
