### PR TITLE
sched/env: add tg_envc in task_group_s to avoid some loops in code

### DIFF
--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -496,7 +496,8 @@ struct task_group_s
 #ifndef CONFIG_DISABLE_ENVIRON
   /* Environment variables **************************************************/
 
-  FAR char **tg_envp;               /* Allocated environment strings            */
+  FAR char **tg_envp;               /* Allocated environment strings        */
+  ssize_t    tg_envc;               /* Number of environment strings        */
 #endif
 
 #ifndef CONFIG_DISABLE_POSIX_TIMERS

--- a/sched/environ/env_dup.c
+++ b/sched/environ/env_dup.c
@@ -87,6 +87,8 @@ int env_dup(FAR struct task_group_s *group, FAR char * const *envcp)
           envc++;
         }
 
+      group->tg_envc = envc;
+
       /* A special case is that the parent has an "empty" environment
        * allocation, i.e., there is an allocation in place but it
        * contains no variable definitions and, hence, envc == 0.

--- a/sched/environ/env_findvar.c
+++ b/sched/environ/env_findvar.c
@@ -83,9 +83,9 @@ static bool env_cmpname(const char *pszname, const char *peqname)
  *
  ****************************************************************************/
 
-int env_findvar(FAR struct task_group_s *group, FAR const char *pname)
+ssize_t env_findvar(FAR struct task_group_s *group, FAR const char *pname)
 {
-  int i;
+  ssize_t i;
 
   /* Verify input parameters */
 

--- a/sched/environ/env_foreach.c
+++ b/sched/environ/env_foreach.c
@@ -66,7 +66,7 @@ int env_foreach(FAR struct task_group_s *group,
                 FAR void *arg)
 {
   int ret = OK;
-  int i;
+  size_t i;
 
   /* Verify input parameters */
 
@@ -92,6 +92,8 @@ int env_foreach(FAR struct task_group_s *group,
           break;
         }
     }
+
+  DEBUGASSERT(ret != OK || group->tg_envc == i);
 
   return ret;
 }

--- a/sched/environ/env_getenv.c
+++ b/sched/environ/env_getenv.c
@@ -61,7 +61,7 @@ FAR char *getenv(FAR const char *name)
   FAR struct tcb_s *rtcb;
   FAR struct task_group_s *group;
   FAR char *pvalue = NULL;
-  int ret = OK;
+  ssize_t ret = OK;
 
   /* Verify that a string was passed */
 

--- a/sched/environ/env_release.c
+++ b/sched/environ/env_release.c
@@ -84,6 +84,7 @@ void env_release(FAR struct task_group_s *group)
    */
 
   group->tg_envp = NULL;
+  group->tg_envc = 0;
 }
 
 #endif /* CONFIG_DISABLE_ENVIRON */

--- a/sched/environ/env_unsetenv.c
+++ b/sched/environ/env_unsetenv.c
@@ -61,7 +61,7 @@ int unsetenv(FAR const char *name)
 {
   FAR struct tcb_s *rtcb = this_task();
   FAR struct task_group_s *group = rtcb->group;
-  int idx;
+  ssize_t idx;
 
   DEBUGASSERT(group);
 

--- a/sched/environ/environ.h
+++ b/sched/environ/environ.h
@@ -120,7 +120,7 @@ void env_release(FAR struct task_group_s *group);
  *
  ****************************************************************************/
 
-int env_findvar(FAR struct task_group_s *group, FAR const char *pname);
+ssize_t env_findvar(FAR struct task_group_s *group, FAR const char *pname);
 
 /****************************************************************************
  * Name: env_removevar
@@ -143,7 +143,7 @@ int env_findvar(FAR struct task_group_s *group, FAR const char *pname);
  *
  ****************************************************************************/
 
-void env_removevar(FAR struct task_group_s *group, int index);
+void env_removevar(FAR struct task_group_s *group, ssize_t index);
 
 #undef EXTERN
 #ifdef __cplusplus


### PR DESCRIPTION
## Summary
this commit optimize the env api speed by avoiding some loops (while/for) in code

## Impact
should be none

## Testing
sim:ostest pass
