### PR TITLE
fs: Undefine CONFIG_FS_LARGEFILE if compiler doesn't support long long

### DIFF
--- a/include/aio.h
+++ b/include/aio.h
@@ -97,7 +97,7 @@
 #define LIO_NOWAIT      0
 #define LIO_WAIT        1
 
-#if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
+#if defined(CONFIG_FS_LARGEFILE)
 #  define aiocb64       aiocb
 #  define aio_read64    aio_read
 #  define aio_write64   aio_write

--- a/include/dirent.h
+++ b/include/dirent.h
@@ -86,7 +86,7 @@
 #define DIRENT_ISLINK(dtype)      ((dtype) == DTYPE_LINK)
 #define DIRENT_ISSOCK(dtype)      ((dtype) == DTYPE_SOCK)
 
-#if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
+#if defined(CONFIG_FS_LARGEFILE)
 #  define dirent64                dirent
 #  define readdir64               readdir
 #  define readdir64_r             readdir_r

--- a/include/fcntl.h
+++ b/include/fcntl.h
@@ -148,7 +148,7 @@
 
 #define creat(path, mode) open(path, O_WRONLY|O_CREAT|O_TRUNC, mode)
 
-#if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
+#if defined(CONFIG_FS_LARGEFILE)
 #  define F_GETLK64         F_GETLK
 #  define F_SETLK64         F_SETLK
 #  define F_SETLKW64        F_SETLKW

--- a/include/ftw.h
+++ b/include/ftw.h
@@ -63,7 +63,7 @@
                        * it.  */
 #endif
 
-#if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
+#if defined(CONFIG_FS_LARGEFILE)
 #  define ftw64    ftw
 #  define nftw64   nftw
 #endif

--- a/include/inttypes.h
+++ b/include/inttypes.h
@@ -308,7 +308,7 @@
 
 /* off_t */
 
-#if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
+#if defined(CONFIG_FS_LARGEFILE)
 #define PRIdOFF     PRId64
 #define PRIiOFF     PRIi64
 #define PRIoOFF     PRIo64

--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -944,6 +944,10 @@
 
 #endif
 
+#ifndef CONFIG_HAVE_LONG_LONG
+#  undef CONFIG_FS_LARGEFILE
+#endif
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -87,7 +87,7 @@
 
 #define TMP_MAX 56800235584ull
 
-#if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
+#if defined(CONFIG_FS_LARGEFILE)
 #  define tmpfile64 tmpfile
 #  define fopen64   fopen
 #  define freopen64 freopen

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -68,7 +68,7 @@
 #  define environ get_environ_ptr()
 #endif
 
-#if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
+#if defined(CONFIG_FS_LARGEFILE)
 #  define mkstemp64            mkstemp
 #  define mkostemp64           mkostemp
 #  define mkstemps64           mkstemps

--- a/include/sys/mman.h
+++ b/include/sys/mman.h
@@ -149,7 +149,7 @@
 #define MFD_HUGE_2GB      (31 << MFD_HUGE_SHIFT)
 #define MFD_HUGE_16GB     (34 << MFD_HUGE_SHIFT)
 
-#if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
+#if defined(CONFIG_FS_LARGEFILE)
 #  define mmap64 mmap
 #endif
 

--- a/include/sys/resource.h
+++ b/include/sys/resource.h
@@ -58,7 +58,7 @@
 #define RLIMIT_STACK    6           /* Limit on stack size */
 #define RLIMIT_AS       7           /* Limit on address space size */
 
-#if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
+#if defined(CONFIG_FS_LARGEFILE)
 #  define RLIM_INFINITY    UINT64_MAX /* No limit */
 #  define RLIM_SAVED_MAX   UINT64_MAX /* Unrepresentable saved hard limit */
 #  define RLIM_SAVED_CUR   UINT64_MAX /* Unrepresentable saved soft limit */
@@ -95,7 +95,7 @@
  * It must be an unsigned integral type.
  */
 
-#if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
+#if defined(CONFIG_FS_LARGEFILE)
 typedef uint64_t rlim_t;
 #else
 typedef uint32_t rlim_t;

--- a/include/sys/sendfile.h
+++ b/include/sys/sendfile.h
@@ -39,7 +39,7 @@
 #  define CONFIG_SENDFILE_BUFSIZE 512
 #endif
 
-#if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
+#if defined(CONFIG_FS_LARGEFILE)
 #  define sendfile64              sendfile
 #endif
 

--- a/include/sys/stat.h
+++ b/include/sys/stat.h
@@ -122,7 +122,7 @@
 #define st_ctime     st_ctim.tv_sec
 #define st_mtime     st_mtim.tv_sec
 
-#if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
+#if defined(CONFIG_FS_LARGEFILE)
 #  define stat64     stat
 #  define fstat64    fstat
 #  define lstat64    lstat

--- a/include/sys/statfs.h
+++ b/include/sys/statfs.h
@@ -95,7 +95,7 @@
 #define CROMFS_MAGIC          0x4d4f5243
 #define RPMSGFS_MAGIC         0x54534f47
 
-#if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
+#if defined(CONFIG_FS_LARGEFILE)
 #  define statfs64            statfs
 #  define fstatfs64           fstatfs
 #endif

--- a/include/sys/statvfs.h
+++ b/include/sys/statvfs.h
@@ -38,7 +38,7 @@
 #define ST_RDONLY             0x0001 /* Mount read-only.  */
 #define ST_NOSUID             0x0002 /* Ignore suid and sgid bits.  */
 
-#if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
+#if defined(CONFIG_FS_LARGEFILE)
 #  define statvfs64           statvfs
 #  define fstatvfs64          fstatvfs
 #endif

--- a/include/sys/types.h
+++ b/include/sys/types.h
@@ -83,7 +83,7 @@
 #define SCHED_PRIORITY_MIN       1
 #define SCHED_PRIORITY_IDLE      0
 
-#if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
+#if defined(CONFIG_FS_LARGEFILE)
 #  define fsblkcnt64_t           fsblkcnt_t
 #  define fsfilcnt64_t           fsfilcnt_t
 #  define blkcnt64_t             blkcnt_t
@@ -193,7 +193,7 @@ typedef int wint_t;
 
 typedef int wctype_t;
 
-#if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
+#if defined(CONFIG_FS_LARGEFILE)
 /* Large file versions */
 
 typedef uint64_t     fsblkcnt_t;

--- a/include/sys/uio.h
+++ b/include/sys/uio.h
@@ -48,7 +48,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
+#if defined(CONFIG_FS_LARGEFILE)
 #  define preadv64  preadv
 #  define pwritev64 pwritev
 #endif

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -265,7 +265,7 @@
 #define optind                           (*(getoptindp()))
 #define optopt                           (*(getoptoptp()))
 
-#if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
+#if defined(CONFIG_FS_LARGEFILE)
 #  define lseek64                        lseek
 #  define pread64                        pread
 #  define pwrite64                       pwrite


### PR DESCRIPTION
## Summary

to simplify the large file check in many place

## Impact

code refactory only

## Testing

CI