### PR TITLE
tools: nxstyle: add "NimMain" to whitelists.

### DIFF
--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -499,6 +499,12 @@ static const char *g_white_list[] =
 
   "CMUnitTest",
 
+  /* Ref:
+   * apps/examples/hello_nim/hello_nim_main.c
+   */
+
+  "NimMain",
+
   NULL
 };
 


### PR DESCRIPTION
Add the required functions of the Nim language to the whitelists.
