### PR TITLE
sched/Kconfig: Fix SIG_ABRT has 'help' but empty

### DIFF
--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -1484,6 +1484,7 @@ config SIG_ABRT
 	int "SIGABRT"
 	default 6
 	---help---
+		Abort signal from abort().
 
 config SIG_BUS
 	int "SIGBUS"


### PR DESCRIPTION
## Summary
Fix warning from kconfiglib
## Impact
Minor
## Testing
CI
