### PR TITLE
mm/circbuf: fix minor issue about update buffer head

### DIFF
--- a/mm/circbuf/circbuf.c
+++ b/mm/circbuf/circbuf.c
@@ -526,6 +526,7 @@ ssize_t circbuf_overwrite(FAR struct circbuf_s *circ,
       overwrite = bytes - space + skip;
     }
 
+  circ->head += skip;
   off = circ->head % circ->size;
   space = circ->size - off;
   if (bytes < space)
@@ -535,7 +536,7 @@ ssize_t circbuf_overwrite(FAR struct circbuf_s *circ,
 
   memcpy((FAR char *)circ->base + off, src, space);
   memcpy(circ->base, (FAR char *)src + space, bytes - space);
-  circ->head += bytes + skip;
+  circ->head += bytes;
   circ->tail += overwrite;
 
   return overwrite;


### PR DESCRIPTION


## Summary
mm/circbuf: fix minor issue about update buffer head

Update head pointer with skip before write buffer. 
This patch is related to https://github.com/apache/nuttx/pull/8650.
## Impact
N/A
## Testing
local test.
