### PR TITLE
esp32c3: Fix missing irq timer

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_wdt.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_wdt.c
@@ -786,7 +786,7 @@ static int32_t esp32c3_wdt_setisr(struct esp32c3_wdt_dev_s *dev,
             {
               /* Disable the provided CPU interrupt to configure it. */
 
-              up_disable_irq(wdt->cpuint);
+              up_disable_irq(wdt->irq);
 
               /* Free CPU interrupt that is attached to this peripheral
                * because we will get another from esp32c3_setup_irq()


### PR DESCRIPTION
## Summary
Fix missing irq timer
## Impact
Only ESP32C3
## Testing
ESP32C3-Devkit
