### PR TITLE
xtensa/common: Fix Xtensa interrupt stack context restore issue

### DIFF
--- a/arch/xtensa/src/common/xtensa_int_handlers.S
+++ b/arch/xtensa/src/common/xtensa_int_handlers.S
@@ -157,13 +157,20 @@ g_intstacktop:
 
 	mov		a2, RETVAL
 
-#if CONFIG_ARCH_INTERRUPTSTACK < 15
-	addi	sp, sp, XCPTCONTEXT_SIZE
-#endif
+	j		2f
 
 	/* Done */
 
 1:
+	/* No pending interrupts, simply copy the register save area pointer to
+	 * fulfill the macro exit condition.
+	 */
+
+	mov 	a2, a12
+2:
+#if CONFIG_ARCH_INTERRUPTSTACK < 15
+	addi	sp, sp, XCPTCONTEXT_SIZE
+#endif
 	.endm
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
Fix Xtensa interrupt stack context restore issue
## Impact
Avoid ESP32 sporadic crashing
## Testing
esp32-devkitc
