### PR TITLE
risc-v/esp32c3: Remove erroneous interrupt disable

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_tim.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_tim.c
@@ -706,10 +706,6 @@ static int esp32c3_tim_setisr(struct esp32c3_tim_dev_s *dev,
 
       if (priv->cpuint != -ENOMEM)
         {
-          /* Disable cpu interrupt */
-
-          up_disable_irq(priv->cpuint);
-
           /* Disable CPU Interrupt, free a previously allocated
            * CPU Interrupt
            */


### PR DESCRIPTION
## Summary

This PR intends to fix a crash occurring on the ESP32-C3 Timer driver due to a misplaced call for disabling the interrupts.

## Impact

Fix for broken driver.

## Testing

Internal CI testing on `esp32c3-devkit`.

