### PR TITLE
tools/cxd56: Fix typo in mkspk tool

### DIFF
--- a/tools/cxd56/mkspk.c
+++ b/tools/cxd56/mkspk.c
@@ -229,7 +229,9 @@ static void *create_image(struct elf_file *elf, int core, char *savename,
   Elf32_Sym *sym;
   char *name;
   int snlen;
-  int nphs, psize, imgsize;
+  int nphs;
+  int psize;
+  int imgsize;
   int i;
   int j;
   uint32_t offset;

--- a/tools/cxd56/mkspk.c
+++ b/tools/cxd56/mkspk.c
@@ -344,7 +344,7 @@ int main(int argc, char **argv)
 
   size += 16;                   /* Extend CMAC size */
 
-  snprintf(footer, 16, "MKSPK_BN_HOOTER");
+  snprintf(footer, 16, "MKSPK_BN_FOOTER");
   footer[15] = '\0';
 
   fp = fopen(args->outputfile, "wb");


### PR DESCRIPTION
## Summary
Fix typo in mkspk tool for cxd56.

## Impact
Only spresense board.

## Testing
Build all spresense defconfigs.
