### PR TITLE
tools/Unix.mk: Add VERSION_ARG to argument of version.sh

### DIFF
--- a/tools/Unix.mk
+++ b/tools/Unix.mk
@@ -57,7 +57,7 @@ else
 # Only update .version if the contents of version.tmp actually changes
 # Note: this is executed before any rule is run
 
-$(shell tools/version.sh .version.tmp > /dev/null)
+$(shell tools/version.sh $(VERSION_ARG) .version.tmp > /dev/null)
 $(shell $(call TESTANDREPLACEFILE, .version.tmp, .version))
 endif
 


### PR DESCRIPTION
## Summary
Allow the version argument to be specified externally into the .version
that is forced to be created. There is no impact as long as it is used
in the same way as before.

## Impact
None

## Testing
CI: build
