### PR TITLE
arch: cxd56xx: Update miscellaneous cxd56xx drivers

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_dmac.c
+++ b/arch/arm/src/cxd56xx/cxd56_dmac.c
@@ -731,7 +731,9 @@ void weak_function arm_dma_initialize(void)
   for (i = 0; i < NCHANNELS; i++)
     {
       g_dmach[i].chan = i;
+#ifndef CONFIG_CXD56_SUBCORE
       up_enable_irq(irq_map[i]);
+#endif
     }
 }
 

--- a/arch/arm/src/cxd56xx/cxd56_emmc.c
+++ b/arch/arm/src/cxd56xx/cxd56_emmc.c
@@ -673,7 +673,7 @@ static int emmc_hwinitialize(void)
 
 errout:
   up_disable_irq(CXD56_IRQ_EMMC);
-  emmc_pincontrol(true);
+  emmc_pincontrol(false);
   cxd56_emmc_clock_disable();
 
   return ret;

--- a/arch/arm/src/cxd56xx/cxd56_emmc.c
+++ b/arch/arm/src/cxd56xx/cxd56_emmc.c
@@ -932,6 +932,10 @@ static int cxd56_emmc_geometry(struct inode *inode,
   return OK;
 }
 
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
 int cxd56_emmcinitialize(void)
 {
   struct cxd56_emmc_state_s *priv = &g_emmcdev;
@@ -967,21 +971,25 @@ int cxd56_emmcinitialize(void)
     }
 
   ret = register_blockdriver("/dev/emmc0", &g_bops, 0, priv);
-  if (ret)
+  if (ret < 0)
     {
       ferr("register_blockdriver failed: %d\n", -ret);
+    }
+
+  return ret;
+}
+
+int cxd56_emmcuninitialize(void)
+{
+  int ret;
+
+  ret = unregister_blockdriver("/dev/emmc0");
+  if (ret < 0)
+    {
+      ferr("unregister_blockdriver failed: %d\n", -ret);
       return ret;
     }
 
-  return OK;
-}
-
-/****************************************************************************
- * Public Functions
- ****************************************************************************/
-
-int emmc_uninitialize(void)
-{
   /* Send power off command */
 
   emmc_switchcmd(EXTCSD_PON, EXTCSD_PON_POWERED_OFF_LONG);

--- a/arch/arm/src/cxd56xx/cxd56_emmc.h
+++ b/arch/arm/src/cxd56xx/cxd56_emmc.h
@@ -43,7 +43,7 @@ extern "C"
  ****************************************************************************/
 
 int cxd56_emmcinitialize(void);
-void cxd56_emmcuninitialize(void);
+int cxd56_emmcuninitialize(void);
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/arch/arm/src/cxd56xx/cxd56_serial.c
+++ b/arch/arm/src/cxd56xx/cxd56_serial.c
@@ -336,7 +336,7 @@ static inline void up_enablebreaks(struct up_dev_s *priv, bool enable)
  * Name: cxd56_serial2_pm_event
  ****************************************************************************/
 
-#ifdef CONFIG_CXD56_UART2
+#if defined(CONFIG_CXD56_UART2) && !defined(CONFIG_UART2_SERIAL_CONSOLE)
 static int cxd56_serial2_pm_event(uint8_t id)
 {
   struct up_dev_s *priv = (struct up_dev_s *)&g_uart2priv;


### PR DESCRIPTION
## Summary
* Fix eMMC uninitialize function
* Fix a warning in cxd56_serial.c
* Disable SubCore to use DMA
* Fix emmc pin control on initialization error

## Impact
Only spresense board

## Testing
Build all spresense defconfigs.
