### PR TITLE
boards: spresense: Update miscellaneous spresense drivers

### DIFF
--- a/boards/arm/cxd56xx/common/src/cxd56_emmcdev.c
+++ b/boards/arm/cxd56xx/common/src/cxd56_emmcdev.c
@@ -24,6 +24,8 @@
 
 #include <nuttx/config.h>
 
+#include <sys/mount.h>
+
 #include <stdio.h>
 #include <errno.h>
 #include <debug.h>
@@ -80,6 +82,47 @@ int board_emmc_initialize(void)
   if (ret < 0)
     {
       ferr("ERROR: Failed to mount the eMMC. %d\n", ret);
+    }
+
+  return ret;
+}
+
+/****************************************************************************
+ * Name: board_emmc_finalize
+ *
+ * Description:
+ *   Finalize the eMMC device and umount the file system.
+ *
+ ****************************************************************************/
+
+int board_emmc_finalize(void)
+{
+  int ret;
+
+  /* Un-mount the eMMC device */
+
+  ret = nx_umount2("/mnt/emmc", MNT_DETACH);
+  if (ret < 0)
+    {
+      ferr("ERROR: Failed to umount the eMMC. %d\n", ret);
+      return ret;
+    }
+
+  /* Uninitialize the eMMC device */
+
+  ret = cxd56_emmcuninitialize();
+  if (ret < 0)
+    {
+      ferr("ERROR: Failed to uninitialize eMMC. %d\n", ret);
+      return ret;
+    }
+
+  /* Power off the eMMC device */
+
+  ret = board_power_control(POWER_EMMC, false);
+  if (ret)
+    {
+      ferr("ERROR: Failed to power off eMMC. %d\n", ret);
     }
 
   return ret;

--- a/boards/arm/cxd56xx/common/src/cxd56_emmcdev.c
+++ b/boards/arm/cxd56xx/common/src/cxd56_emmcdev.c
@@ -30,6 +30,7 @@
 #include <errno.h>
 #include <debug.h>
 #include <nuttx/board.h>
+#include <nuttx/signal.h>
 #include <nuttx/fs/fs.h>
 #include <arch/board/board.h>
 #include "cxd56_emmc.h"
@@ -41,6 +42,10 @@
 #ifndef CONFIG_SFC_DEVNO
 #  define CONFIG_SFC_DEVNO 0
 #endif
+
+/* EMMC power-on time in ms */
+
+#define EMMC_POWER_ON_WAIT_MSEC 10
 
 /****************************************************************************
  * Public Functions
@@ -67,12 +72,19 @@ int board_emmc_initialize(void)
       return -ENODEV;
     }
 
+  if (POWER_EMMC != PMIC_NONE)
+    {
+      /* Wait time until eMMC device is turned power on */
+
+      nxsig_usleep(EMMC_POWER_ON_WAIT_MSEC * USEC_PER_MSEC);
+    }
+
   /* Initialize the eMMC device */
 
   ret = cxd56_emmcinitialize();
   if (ret < 0)
     {
-      ferr("ERROR: Failed to initialize eMMC. %d\n ", ret);
+      ferr("ERROR: Failed to initialize eMMC. %d\n", ret);
       return -ENODEV;
     }
 

--- a/boards/arm/cxd56xx/spresense/Kconfig
+++ b/boards/arm/cxd56xx/spresense/Kconfig
@@ -765,6 +765,14 @@ config CXD56_LTE_LATE_INITIALIZE
 
 endif # CXD56_LTE
 
+config CXD56_EMMC_LATE_INITIALIZE
+	bool "eMMC driver late initialize"
+	default n
+	depends on CXD56_EMMC
+	---help---
+		eMMC driver can be initialized on an application code after system booted up
+		by enabling this configuration switch.
+
 config CXD56_BINARY
 	bool "spk binary format"
 	default n

--- a/boards/arm/cxd56xx/spresense/Kconfig
+++ b/boards/arm/cxd56xx/spresense/Kconfig
@@ -809,4 +809,19 @@ config CXD56_SDCARD_AUTOMOUNT_UDELAY
 
 endif # CXD56_SDCARD_AUTOMOUNT
 
+choice
+	prompt "eMMC Power Pin selection"
+	default CXD56_EMMC_POWER_PIN_NONE
+
+config CXD56_EMMC_POWER_PIN_NONE
+	bool "None"
+
+config CXD56_EMMC_POWER_PIN_I2S0_BCK
+	bool "Use PIN I2S0_BCK"
+
+config CXD56_EMMC_POWER_PIN_UART2_CTS
+	bool "Use PIN UART2_CTS"
+
+endchoice
+
 endif

--- a/boards/arm/cxd56xx/spresense/Kconfig
+++ b/boards/arm/cxd56xx/spresense/Kconfig
@@ -497,6 +497,12 @@ choice
 	prompt "LCD SPI connection"
 	default LCD_ON_EXTENSION_BOARD
 
+config LCD_ON_LTE_EXTENSION_BOARD
+	bool "LTE extension board: SPI3"
+	select CXD56_SPI3
+	---help---
+		Display connected to LTE extension board.
+
 config LCD_ON_EXTENSION_BOARD
 	bool "Extension board: SPI4"
 	select CXD56_SPI4
@@ -609,7 +615,7 @@ endchoice
 
 endif
 
-if LCD_ON_EXTENSION_BOARD
+if LCD_ON_EXTENSION_BOARD || LCD_ON_LTE_EXTENSION_BOARD
 
 choice
 	prompt "LCD ILI934x RST Pin selection"

--- a/boards/arm/cxd56xx/spresense/include/board.h
+++ b/boards/arm/cxd56xx/spresense/include/board.h
@@ -201,7 +201,13 @@ enum board_power_device
 
   POWER_BTBLE           = PMIC_NONE,
   POWER_SENSOR          = PMIC_NONE,
+#if defined(CONFIG_CXD56_EMMC_POWER_PIN_I2S0_BCK)
+  POWER_EMMC            = CHIP_GPIO(PIN_I2S0_BCK),
+#elif defined(CONFIG_CXD56_EMMC_POWER_PIN_UART2_CTS)
+  POWER_EMMC            = CHIP_GPIO(PIN_UART2_CTS),
+#else
   POWER_EMMC            = PMIC_NONE,
+#endif
   POWER_LTE             = PMIC_GPO(2),
 };
 

--- a/boards/arm/cxd56xx/spresense/include/board.h
+++ b/boards/arm/cxd56xx/spresense/include/board.h
@@ -29,6 +29,7 @@
 #include <nuttx/irq.h>
 #include <sys/boardctl.h>
 #include <stdbool.h>
+#include <arch/chip/pin.h>
 
 #include "board_lcdpins.h"
 
@@ -166,11 +167,13 @@
 #define PMIC_TYPE_LSW       (1u << 8)
 #define PMIC_TYPE_GPO       (1u << 9)
 #define PMIC_TYPE_DDCLDO    (1u << 10)
+#define CHIP_TYPE_GPIO      (1u << 11)
 #define PMIC_GET_TYPE(v)    ((v) & 0xff00)
 #define PMIC_GET_CH(v)      ((v) & 0x00ff)
 #define PMIC_LSW(n)         (PMIC_TYPE_LSW | (1u << (n)))
 #define PMIC_GPO(n)         (PMIC_TYPE_GPO | (1u << (n)))
 #define PMIC_DDCLDO(n)      (PMIC_TYPE_DDCLDO | (1u << (n)))
+#define CHIP_GPIO(n)        (CHIP_TYPE_GPIO | (n))
 
 enum board_power_device
 {

--- a/boards/arm/cxd56xx/spresense/include/board.h
+++ b/boards/arm/cxd56xx/spresense/include/board.h
@@ -239,6 +239,21 @@ enum board_power_device
 #define DISPLAY_DMA_TX_MAXSIZE (192000)
 #define DISPLAY_DMA_RX_MAXSIZE (192000)
 
+#elif defined(CONFIG_LCD_ON_LTE_EXTENSION_BOARD)
+
+/* Display connected to LTE extension board. */
+
+#define DISPLAY_SPI     3
+
+/* Specify invalid channels because DMA cannot be used */
+
+#define DISPLAY_DMA_TXCH       (-1)
+#define DISPLAY_DMA_RXCH       (-1)
+#define DISPLAY_DMA_TXCH_CFG   (-1)
+#define DISPLAY_DMA_RXCH_CFG   (-1)
+#define DISPLAY_DMA_TX_MAXSIZE (192000)
+#define DISPLAY_DMA_RX_MAXSIZE (192000)
+
 #else /* Display is connected through extension board. */
 
 #define DISPLAY_SPI     4

--- a/boards/arm/cxd56xx/spresense/include/cxd56_emmcdev.h
+++ b/boards/arm/cxd56xx/spresense/include/cxd56_emmcdev.h
@@ -60,6 +60,7 @@ extern "C"
 
 #ifdef CONFIG_CXD56_EMMC
 int board_emmc_initialize(void);
+int board_emmc_finalize(void);
 #endif
 
 #undef EXTERN

--- a/boards/arm/cxd56xx/spresense/include/cxd56_power.h
+++ b/boards/arm/cxd56xx/spresense/include/cxd56_power.h
@@ -30,20 +30,6 @@
 #include <stdbool.h>
 
 /****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-#define PMIC_NONE           (0)
-#define PMIC_TYPE_LSW       (1u << 8)
-#define PMIC_TYPE_GPO       (1u << 9)
-#define PMIC_TYPE_DDCLDO    (1u << 10)
-#define PMIC_GET_TYPE(v)    ((v) & 0xff00)
-#define PMIC_GET_CH(v)      ((v) & 0x00ff)
-#define PMIC_LSW(n)         (PMIC_TYPE_LSW | (1u << (n)))
-#define PMIC_GPO(n)         (PMIC_TYPE_GPO | (1u << (n)))
-#define PMIC_DDCLDO(n)      (PMIC_TYPE_DDCLDO | (1u << (n)))
-
-/****************************************************************************
  * Public Types
  ****************************************************************************/
 
@@ -61,6 +47,10 @@ extern "C"
 #else
 #define EXTERN extern
 #endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
 
 /****************************************************************************
  * Name: board_pmic_read

--- a/boards/arm/cxd56xx/spresense/src/Make.defs
+++ b/boards/arm/cxd56xx/spresense/src/Make.defs
@@ -43,9 +43,7 @@ ifeq ($(CONFIG_ARCH_BUTTONS),y)
 CSRCS += cxd56_buttons.c
 endif
 
-ifeq ($(CONFIG_CXD56_GPIO_IRQ),y)
 CSRCS += cxd56_gpioif.c
-endif
 
 ifeq ($(CONFIG_CXD56_PWM),y)
 CSRCS += cxd56_pwm.c

--- a/boards/arm/cxd56xx/spresense/src/cxd56_bringup.c
+++ b/boards/arm/cxd56xx/spresense/src/cxd56_bringup.c
@@ -440,6 +440,16 @@ int cxd56_bringup(void)
   board_automount_initialize();
 #endif
 
+#if defined(CONFIG_CXD56_EMMC) && !defined(CONFIG_CXD56_EMMC_LATE_INITIALIZE)
+  /* Mount the eMMC block driver */
+
+  ret = board_emmc_initialize();
+  if (ret < 0)
+    {
+      _err("ERROR: Failed to initialize eMMC: %d\n", ret);
+    }
+#endif
+
 #ifdef CONFIG_CPUFREQ_RELEASE_LOCK
   /* Enable dynamic clock control and CPU clock down for power saving */
 

--- a/boards/arm/cxd56xx/spresense/src/cxd56_power.c
+++ b/boards/arm/cxd56xx/spresense/src/cxd56_power.c
@@ -200,6 +200,9 @@ int board_power_control(int target, bool en)
       pfunc = cxd56_pmic_set_ddc_ldo;
       break;
 #endif /* CONFIG_CXD56_PMIC */
+    case CHIP_TYPE_GPIO:
+      board_gpio_write(PMIC_GET_CH(target), en ? 1 : 0);
+      break;
     default:
       break;
     }
@@ -253,6 +256,10 @@ int board_power_control_tristate(int target, int value)
           usleep(1);
         }
     }
+  else if (PMIC_GET_TYPE(target) == CHIP_TYPE_GPIO)
+    {
+      board_gpio_write(PMIC_GET_CH(target), value);
+    }
   else
     {
       en = value ? true : false;
@@ -274,6 +281,7 @@ bool board_power_monitor(int target)
 {
   bool ret = false;
   bool (*pfunc)(uint8_t chset) = NULL;
+  int  status;
 
   switch (PMIC_GET_TYPE(target))
     {
@@ -288,6 +296,10 @@ bool board_power_monitor(int target)
       pfunc = cxd56_pmic_get_ddc_ldo;
       break;
 #endif /* CONFIG_CXD56_PMIC */
+    case CHIP_TYPE_GPIO:
+      status = board_gpio_read(PMIC_GET_CH(target));
+      ret = (status == 1);
+      break;
     default:
       break;
     }


### PR DESCRIPTION
## Summary
* Fix nxstyle
* Remove wrong build condition
* Remove duplicate definitions
* Support using GPIO for power control
* Update eMMC driver
  * Add configuration for eMMC power control
  * Add board function for eMMC finalization
  * Add eMMC power-on wait time
  * Support eMMC late initialization
  * Add eMMC initialization into bringup function

## Impact
Only spresense board

## Testing
Build all spresense defconfigs.
