### PR TITLE
CI: Free space on worker building container

### DIFF
--- a/.github/workflows/docker_linux.yml
+++ b/.github/workflows/docker_linux.yml
@@ -57,6 +57,11 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Free Up Extra Disk Space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/gch
       - name: Pre-build Disk Stats
         run: |
           df -h


### PR DESCRIPTION
## Summary
Remove large unused tools from worker that builds docker containers.

## Testing
CI should be able to build image again. 

With this PR
```
Run df -h
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        84G   41G   43G  50% /
tmpfs           3.4G  172K  3.4G   1% /dev/shm
tmpfs           1.4G  1.2M  1.4G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sda15      105M  6.1M   99M   6% /boot/efi
/dev/sdb1        14G  4.1G  9.0G  31% /mnt
tmpfs           695M   12K  695M   1% /run/user/1001
```

Another PR
```
Run df -h
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        84G   54G   30G  65% /
tmpfs           3.4G  172K  3.4G   1% /dev/shm
tmpfs           1.4G  1.2M  1.4G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sdb15      105M  6.1M   99M   6% /boot/efi
/dev/sda1        14G  4.1G  9.0G  31% /mnt
tmpfs           695M   12K  695M   1% /run/user/1001
```

So looks to free about 13GB on /

