### PR TITLE
stream: Exchange name of lib_rawsostream.c and lib_rawoutstream.c

### DIFF
--- a/libs/libc/stream/lib_rawsostream.c
+++ b/libs/libc/stream/lib_rawsostream.c
@@ -37,46 +37,53 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: rawoutstream_puts
+ * Name: rawsostream_putc
  ****************************************************************************/
 
-static int rawoutstream_puts(FAR struct lib_outstream_s *this,
-                             FAR const void *buf, int len)
+static void rawsostream_putc(FAR struct lib_sostream_s *this, int ch)
 {
-  FAR struct lib_rawoutstream_s *rthis =
-                                (FAR struct lib_rawoutstream_s *)this;
-  int nwritten = 0;
-  int ret = 0;
+  FAR struct lib_rawsostream_s *rthis = (FAR struct lib_rawsostream_s *)this;
+  char buffer = ch;
+  int nwritten;
+  int errcode;
 
-  while (nwritten != len)
+  DEBUGASSERT(this && rthis->fd >= 0);
+
+  /* Loop until the character is successfully transferred or until an
+   * irrecoverable error occurs.
+   */
+
+  do
     {
-      ret = _NX_WRITE(rthis->fd, (FAR const char *)buf + nwritten,
-                      len - nwritten);
-      if (ret <= 0)
+      nwritten = _NX_WRITE(rthis->fd, &buffer, 1);
+      if (nwritten == 1)
         {
-          if (_NX_GETERRNO(ret) == EINTR)
-            {
-              continue;
-            }
-
-          break;
+          this->nput++;
+          return;
         }
 
-      this->nput += ret;
-      nwritten   += ret;
-    }
+      /* The only expected error is EINTR, meaning that the write operation
+       * was awakened by a signal.  Zero would not be a valid return value
+       * from _NX_WRITE().
+       */
 
-  return nwritten > 0 ? nwritten : ret;
+      errcode = _NX_GETERRNO(nwritten);
+      DEBUGASSERT(nwritten < 0);
+    }
+  while (errcode == EINTR);
 }
 
 /****************************************************************************
- * Name: rawoutstream_putc
+ * Name: rawsostream_seek
  ****************************************************************************/
 
-static void rawoutstream_putc(FAR struct lib_outstream_s *this, int ch)
+static off_t rawsostream_seek(FAR struct lib_sostream_s *this, off_t offset,
+                              int whence)
 {
-  char tmp = ch;
-  rawoutstream_puts(this, &tmp, 1);
+  FAR struct lib_rawsostream_s *mthis = (FAR struct lib_rawsostream_s *)this;
+
+  DEBUGASSERT(this);
+  return _NX_SEEK(mthis->fd, offset, whence);
 }
 
 /****************************************************************************
@@ -84,14 +91,14 @@ static void rawoutstream_putc(FAR struct lib_outstream_s *this, int ch)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: lib_rawoutstream
+ * Name: lib_rawsostream
  *
  * Description:
  *   Initializes a stream for use with a file descriptor.
  *
  * Input Parameters:
  *   outstream - User allocated, uninitialized instance of struct
- *               lib_rawoutstream_s to be initialized.
+ *               lib_rawsostream_s to be initialized.
  *   fd        - User provided file/socket descriptor (must have been opened
  *               for write access).
  *
@@ -100,11 +107,11 @@ static void rawoutstream_putc(FAR struct lib_outstream_s *this, int ch)
  *
  ****************************************************************************/
 
-void lib_rawoutstream(FAR struct lib_rawoutstream_s *outstream, int fd)
+void lib_rawsostream(FAR struct lib_rawsostream_s *outstream, int fd)
 {
-  outstream->public.putc  = rawoutstream_putc;
-  outstream->public.puts  = rawoutstream_puts;
-  outstream->public.flush = lib_noflush;
+  outstream->public.putc  = rawsostream_putc;
+  outstream->public.flush = lib_snoflush;
+  outstream->public.seek  = rawsostream_seek;
   outstream->public.nput  = 0;
   outstream->fd           = fd;
 }


### PR DESCRIPTION
## Summary
Exchange name of lib_rawsostream.c and lib_rawoutstream.c to match their implementations.
## Impact
Rename only, but the difference looks so much by GitHub
## Testing
CI
