### PR TITLE
mtd: Extend isbad and markbad func for mtd_dev_s

### DIFF
--- a/arch/arm/src/rp2040/rp2040_flash_mtd.c
+++ b/arch/arm/src/rp2040/rp2040_flash_mtd.c
@@ -164,6 +164,8 @@ static struct rp2040_flash_dev_s my_dev =
     NULL,
 #endif
     rp2040_flash_ioctl,
+    NULL,
+    NULL,
     "rp_flash"
   },
   .lock = NXMUTEX_INITIALIZER,

--- a/drivers/mtd/mtd_progmem.c
+++ b/drivers/mtd/mtd_progmem.c
@@ -101,6 +101,8 @@ static struct progmem_dev_s g_progmem =
     progmem_write,
 #endif
     progmem_ioctl,
+    NULL,
+    NULL,
     "progmem",
   }
 };

--- a/include/nuttx/mtd/mtd.h
+++ b/include/nuttx/mtd/mtd.h
@@ -83,6 +83,8 @@
 #define MTD_READ(d,s,n,b)  ((d)->read    ? (d)->read(d,s,n,b)   : (-ENOSYS))
 #define MTD_WRITE(d,s,n,b) ((d)->write   ? (d)->write(d,s,n,b)  : (-ENOSYS))
 #define MTD_IOCTL(d,c,a)   ((d)->ioctl   ? (d)->ioctl(d,c,a)    : (-ENOSYS))
+#define MTD_ISBAD(d,b)     ((d)->isbad   ? (d)->isbad(d,b)      : (-ENOSYS))
+#define MTD_MARKBAD(d,b)   ((d)->markbad ? (d)->markbad(d,b)    : (-ENOSYS))
 
 /* If any of the low-level device drivers declare they want sub-sector erase
  * support, then define MTD_SUBSECTOR_ERASE.
@@ -184,6 +186,11 @@ struct mtd_dev_s
    */
 
   int (*ioctl)(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg);
+
+  /* Check/Mark bad block for the specified block number */
+
+  int (*isbad)(FAR struct mtd_dev_s *dev, off_t block);
+  int (*markbad)(FAR struct mtd_dev_s *dev, off_t block);
 
   /* Name of this MTD device */
 


### PR DESCRIPTION
## Add isbad and markbad interface in mtd_dev_s to support nand flash.

## Nand device driver must implement it.

## Test on yaffs2 filesystem.

