### PR TITLE
sched: add critical section in nxsched_get_stateinfo

### DIFF
--- a/sched/sched/sched_get_stateinfo.c
+++ b/sched/sched/sched_get_stateinfo.c
@@ -28,6 +28,7 @@
 #include <stdio.h>
 #include <semaphore.h>
 #include <nuttx/mutex.h>
+#include <nuttx/irq.h>
 #include "nuttx/sched.h"
 
 /****************************************************************************
@@ -80,16 +81,23 @@ static FAR const char * const g_statenames[] =
 void nxsched_get_stateinfo(FAR struct tcb_s *tcb, FAR char *state,
                            size_t length)
 {
+  irqstate_t flags;
+
   /* if the state is waiting mutex */
+
+  flags = enter_critical_section();
 
   if (tcb->task_state == TSTATE_WAIT_SEM &&
       ((FAR sem_t *)(tcb->waitobj))->flags & SEM_TYPE_MUTEX)
     {
-      snprintf(state, length, "Waiting,Mutex:%d",
-               ((FAR mutex_t *)(tcb->waitobj))->holder);
+      pid_t holder = ((FAR mutex_t *)(tcb->waitobj))->holder;
+      leave_critical_section(flags);
+
+      snprintf(state, length, "Waiting,Mutex:%d", holder);
     }
   else
     {
+      leave_critical_section(flags);
       strlcpy(state, g_statenames[tcb->task_state], length);
     }
 }


### PR DESCRIPTION
## Summary
I notice that execute the "ps" command will crash in the nxsched_get_stateinfo().
So add critical section when access the tcb->waitobj in nxsched_get_stateinfo().

## Impact
Bug fix

## Testing
Vela, execute the "ps" command periodically not crash.
