### PR TITLE
samv7: add support for PWM fault protection

### DIFF
--- a/arch/arm/src/samv7/Kconfig
+++ b/arch/arm/src/samv7/Kconfig
@@ -770,6 +770,75 @@ config SAMV7_PWM
 
 endmenu
 
+menu "PWM Fault inputs"
+
+config SAMV7_PWM0_PA9
+	bool "External fault input from PA9"
+	default n
+
+if SAMV7_PWM1_PA9
+
+config SAMV7_PWM1_PA9_POL
+	bool "Inverted polarity"
+	default n
+	---help---
+		Fault input is by default active on high level. This config
+		inverts the logic and makes fault active on low level.
+
+endif
+
+config SAMV7_PWM0_PD8
+	bool "External fault input from PD8"
+	default n
+
+if SAMV7_PWM1_PD8
+
+config SAMV7_PWM1_PD8_POL
+	bool "Inverted polarity"
+	default n
+	---help---
+		Fault input is by default active on high level. This config
+		inverts the logic and makes fault active on low level.
+
+endif
+
+config SAMV7_PWM0_PD9
+	bool "External fault input from PD9"
+	default n
+
+if SAMV7_PWM1_PD9
+
+config SAMV7_PWM1_PD9_POL
+	bool "Inverted polarity"
+	default n
+	---help---
+		Fault input is by default active on high level. This config
+		inverts the logic and makes fault active on low level.
+
+endif
+
+config SAMV7_PWM0_PMC
+	bool "External fault input from PMC"
+	default n
+
+config SAMV7_PWM0_AFEC0
+	bool "External fault input from AFEC0"
+	default n
+
+config SAMV7_PWM0_AFEC1
+	bool "External fault input from AFEC1"
+	default n
+
+config SAMV7_PWM0_ACC
+	bool "External fault input from ACC"
+	default n
+
+config SAMV7_PWM0_TIM0
+	bool "External fault input from Timer 0"
+	default n
+
+endmenu
+
 config SAMV7_PWM0_EVENT0
 	bool "Generate trigger on Event Line 0"
 	default n
@@ -914,6 +983,76 @@ config SAMV7_PWM1_TRIG7
 		an event. Value is in percentages.
 
 endmenu
+
+menu "PWM Fault inputs"
+
+config SAMV7_PWM1_PA21
+	bool "External fault input from PA21"
+	default n
+
+if SAMV7_PWM1_PA21
+
+config SAMV7_PWM1_PA21_POL
+	bool "Inverted polarity"
+	default n
+	---help---
+		Fault input is by default active on high level. This config
+		inverts the logic and makes fault active on low level.
+
+endif
+
+config SAMV7_PWM1_PA26
+	bool "External fault input from PA26"
+	default n
+
+if SAMV7_PWM1_PA26
+
+config SAMV7_PWM1_PA26_POL
+	bool "Inverted polarity"
+	default n
+	---help---
+		Fault input is by default active on high level. This config
+		inverts the logic and makes fault active on low level.
+
+endif
+
+config SAMV7_PWM1_PA28
+	bool "External fault input from PA28"
+	default n
+
+if SAMV7_PWM1_PA28
+
+config SAMV7_PWM1_PA28_POL
+	bool "Inverted polarity"
+	default n
+	---help---
+		Fault input is by default active on high level. This config
+		inverts the logic and makes fault active on low level.
+
+endif
+
+config SAMV7_PWM1_PMC
+	bool "External fault input from PMC"
+	default n
+
+config SAMV7_PWM1_AFEC0
+	bool "External fault input from AFEC0"
+	default n
+
+config SAMV7_PWM1_AFEC1
+	bool "External fault input from AFEC1"
+	default n
+
+config SAMV7_PWM1_ACC
+	bool "External fault input from ACC"
+	default n
+
+config SAMV7_PWM1_TIM0
+	bool "External fault input from Timer 0"
+	default n
+
+endmenu
+
 
 config SAMV7_PWM1_EVENT0
 	bool "Generate trigger on Event Line 0"

--- a/arch/arm/src/samv7/sam_pwm.h
+++ b/arch/arm/src/samv7/sam_pwm.h
@@ -88,6 +88,154 @@
 
 #define PWM1_NCHANNELS (PWM1_CH0 + PWM1_CH1 + PWM1_CH2 + PWM1_CH3)
 
+/* Fault protection */
+
+#ifdef CONFIG_SAMV7_PWM0_PA9
+#define PWM0_PA9 1
+#ifdef CONFIG_SAMV7_PWM0_PA9_POL
+#define PWM0_PA9_POL 0
+#else
+#define PWM0_PA9_POL 1
+#endif
+#else
+#define PWM0_PA9 0
+#define PWM0_PA9_POL 0
+#endif
+
+#ifdef CONFIG_SAMV7_PWM0_PD8
+#define PWM0_PD8 (1 << 1)
+#ifdef CONFIG_SAMV7_PWM0_PD8_POL
+#define PWM0_PD8_POL 0
+#else
+#define PWM0_PD8_POL (1 << 1)
+#endif
+#else
+#define PWM0_PD8 0
+#define PWM0_PD8_POL 0
+#endif
+
+#ifdef CONFIG_SAMV7_PWM0_PD9
+#define PWM0_PD9 (1 << 2)
+#ifdef CONFIG_SAMV7_PWM0_PD9_POL
+#define PWM0_PD9_POL 0
+#else
+#define PWM0_PD9_POL (1 << 2)
+#endif
+#else
+#define PWM0_PD9 0
+#define PWM0_PD9_POL 0
+#endif
+
+#ifdef CONFIG_SAMV7_PWM0_PMC
+#define PWM0_PMC (1 << 3)
+#else
+#define PWM0_PMC 0
+#endif
+
+#ifdef CONFIG_SAMV7_PWM0_AFEC0
+#define PWM0_AFEC0 (1 << 4)
+#else
+#define PWM0_AFEC0 0
+#endif
+
+#ifdef CONFIG_SAMV7_PWM0_AFEC1
+#define PWM0_AFEC1 (1 << 5)
+#else
+#define PWM0_AFEC1 0
+#endif
+
+#ifdef CONFIG_SAMV7_PWM0_ACC
+#define PWM0_ACC (1 << 6)
+#else
+#define PWM0_ACC 0
+#endif
+
+#ifdef CONFIG_SAMV7_PWM0_TIM0
+#define PWM0_TIM0 (1 << 7)
+#else
+#define PWM0_TIM0 0
+#endif
+
+#define PWM0_FAULTS (PWM0_PA9 + PWM0_PD8 + PWM0_PD9 + PWM0_PMC + \
+                     PWM0_AFEC0 + PWM0_AFEC1 + PWM0_ACC + PWM0_TIM0)
+
+#define PWM0_POL    (PWM0_PA9_POL + PWM0_PD8_POL + PWM0_PD9_POL + \
+                     PWM0_PMC + PWM0_AFEC0 + PWM0_AFEC1 + PWM0_ACC + \
+                     PWM0_TIM0)
+
+#ifdef CONFIG_SAMV7_PWM1_PA21
+#define PWM1_PA21 1
+#ifdef CONFIG_SAMV7_PWM1_PA21_POL
+#define PWM1_PA21_POL 0
+#else
+#define PWM1_PA21_POL 1
+#endif
+#else
+#define PWM1_PA21 0
+#define PWM1_PA21_POL 0
+#endif
+
+#ifdef CONFIG_SAMV7_PWM1_PA26
+#define PWM1_PA26 (1 << 1)
+#ifdef CONFIG_SAMV7_PWM1_PA26_POL
+#define PWM1_PA26_POL 0
+#else
+#define PWM1_PA26_POL (1 << 1)
+#endif
+#else
+#define PWM1_PA26 0
+#define PWM1_PA26_POL 0
+#endif
+
+#ifdef CONFIG_SAMV7_PWM1_PA28
+#define PWM1_PA28 (1 << 2)
+#ifdef CONFIG_SAMV7_PWM1_PA28_POL
+#define PWM1_PA28_POL 0
+#else
+#define PWM1_PA28_POL (1 << 2)
+#endif
+#else
+#define PWM1_PA28 0
+#define PWM1_PA28_POL 0
+#endif
+
+#ifdef CONFIG_SAMV7_PWM1_PMC
+#define PWM1_PMC (1 << 3)
+#else
+#define PWM1_PMC 0
+#endif
+
+#ifdef CONFIG_SAMV7_PWM1_AFEC0
+#define PWM1_AFEC0 (1 << 4)
+#else
+#define PWM1_AFEC0 0
+#endif
+
+#ifdef CONFIG_SAMV7_PWM1_AFEC1
+#define PWM1_AFEC1 (1 << 5)
+#else
+#define PWM1_AFEC1 0
+#endif
+
+#ifdef CONFIG_SAMV7_PWM1_ACC
+#define PWM1_ACC (1 << 6)
+#else
+#define PWM1_ACC 0
+#endif
+
+#ifdef CONFIG_SAMV7_PWM1_TIM0
+#define PWM1_TIM0 (1 << 7)
+#else
+#define PWM1_TIM0 0
+#endif
+
+#define PWM1_FAULTS (PWM1_PA21 + PWM1_PA26 + PWM1_PA28 + PWM1_PMC + \
+                     PWM1_AFEC0 + PWM1_AFEC1 + PWM1_ACC + PWM1_TIM0)
+
+#define PWM1_POL    (PWM1_PA21_POL + PWM1_PA26_POL + PWM1_PA28_POL + \
+                     PWM1_PMC + PWM1_AFEC0 + PWM1_AFEC1 + PWM1_ACC + \
+                     PWM1_TIM0)
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/


### PR DESCRIPTION
## Summary
This commit adds configurable fault protection to SAMv7 PWM driver. The fault input can be used from peripherals as ADC or GPIO inputs. Inputs from GPIO have configurable polarity (high or low). The PWM output is automatically set to zero if fault input is active and restored if fault input is not actived.

## Impact

SAMv7 only. Configurable

## Testing

Tested on custom board and same70-xplained evaluation kit.

