### PR TITLE
drivers/serial: Include spawn.h required by CONFIG_TTY_LAUNCH

### DIFF
--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -34,6 +34,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
+#include <spawn.h>
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>


### PR DESCRIPTION
## Summary
Fix build error with CONFIG_TTY_LAUNCH enabled
## Impact
serial driver
## Testing
QEMU
