### PR TITLE
lib.h: Remove forward declaration for streamlist

### DIFF
--- a/include/nuttx/lib/lib.h
+++ b/include/nuttx/lib/lib.h
@@ -110,7 +110,6 @@ void lib_stream_release(FAR struct task_group_s *group);
 
 /* Functions contained in lib_getstreams.c **********************************/
 
-struct streamlist;
 FAR struct streamlist *lib_get_streams(void);
 #endif /* CONFIG_FILE_STREAM */
 


### PR DESCRIPTION
## Summary
Since <nuttx/fs/fs.h> included already.
## Impact
Minor
## Testing
CI
