### PR TITLE
libc/stdio: Implement lib_get_stream

### DIFF
--- a/include/nuttx/lib/lib.h
+++ b/include/nuttx/lib/lib.h
@@ -111,6 +111,7 @@ void lib_stream_release(FAR struct task_group_s *group);
 /* Functions contained in lib_getstreams.c **********************************/
 
 FAR struct streamlist *lib_get_streams(void);
+FAR struct file_struct *lib_get_stream(int fd);
 #endif /* CONFIG_FILE_STREAM */
 
 /* Functions defined in lib_srand.c *****************************************/

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -63,9 +63,9 @@
 
 /* The first three _iob entries are reserved for standard I/O */
 
-#define stdin      (&lib_get_streams()->sl_std[0])
-#define stdout     (&lib_get_streams()->sl_std[1])
-#define stderr     (&lib_get_streams()->sl_std[2])
+#define stdin      lib_get_stream(0)
+#define stdout     lib_get_stream(1)
+#define stderr     lib_get_stream(2)
 
 /* Path to the directory where temporary files can be created */
 

--- a/libs/libc/stdio/lib_libgetstreams.c
+++ b/libs/libc/stdio/lib_libgetstreams.c
@@ -57,4 +57,18 @@ FAR struct streamlist *lib_get_streams(void)
   return &info->ta_streamlist;
 }
 
+/****************************************************************************
+ * Name: lib_get_stream
+ *
+ * Description:
+ *   Return a pointer to the file stream for this thread and given fd。
+ *   Note: only reserved fd number 0/1/2 is valid.
+ *
+ ****************************************************************************/
+
+FAR struct file_struct *lib_get_stream(int fd)
+{
+  return &lib_get_streams()->sl_std[fd];
+}
+
 #endif /* CONFIG_FILE_STREAM */


### PR DESCRIPTION

## Summary
Use lib_get_stream() to fetch stdin/stdout/stderr, since is more easy to works with other language by function call than export native C structure memory layout.

## Impact
Minor
## Testing
CI and local board
