### PR TITLE
mpfs:clear i2c ints before the transfer starts

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_i2c.c
+++ b/arch/risc-v/src/mpfs/mpfs_i2c.c
@@ -396,6 +396,11 @@ static int mpfs_i2c_irq(int cpuint, void *context, void *arg)
         break;
 
       case MPFS_I2C_ST_LOST_ARB:
+
+        /* Clear interrupt. */
+
+        modifyreg32(MPFS_I2C_CTRL, MPFS_I2C_CTRL_SI_MASK, 0);
+        clear_irq = 0u;
         modifyreg32(MPFS_I2C_CTRL, MPFS_I2C_CTRL_STA_MASK,
                     MPFS_I2C_CTRL_STA_MASK);
         break;
@@ -416,6 +421,10 @@ static int mpfs_i2c_irq(int cpuint, void *context, void *arg)
           }
         else if (msg->flags & I2C_M_NOSTOP)
           {
+            /* Clear interrupt. */
+
+            modifyreg32(MPFS_I2C_CTRL, MPFS_I2C_CTRL_SI_MASK, 0);
+            clear_irq = 0u;
             modifyreg32(MPFS_I2C_CTRL, MPFS_I2C_CTRL_STA_MASK,
                         MPFS_I2C_CTRL_STA_MASK);
 


### PR DESCRIPTION
## Summary
In some state values the transfer is restarted in irq handler and the interrupts are disabled in the end of the function after the transfer is started. This may cause early interrupts to be accidentally cleared before they are handled leading timeout error. Interrupt clearing should be done before the transfer is restarted.

## Impact
If interrupts are cleared before the transfer restart the slow bus/memory access does not affect to the timing of the start/clear operations and interrupts are not accidentally cleared.

## Testing
Running heavy load in other operating system in dual OS setup to see there is no issues in i2c transfers.
