### PR TITLE
libc/stream: unify stream return behavior

### DIFF
--- a/libs/libc/stream/lib_rawsostream.c
+++ b/libs/libc/stream/lib_rawsostream.c
@@ -45,7 +45,6 @@ static void rawsostream_putc(FAR struct lib_sostream_s *this, int ch)
   FAR struct lib_rawsostream_s *rthis = (FAR struct lib_rawsostream_s *)this;
   char buffer = ch;
   int nwritten;
-  int errcode;
 
   DEBUGASSERT(this && rthis->fd >= 0);
 
@@ -67,10 +66,10 @@ static void rawsostream_putc(FAR struct lib_sostream_s *this, int ch)
        * from _NX_WRITE().
        */
 
-      errcode = _NX_GETERRNO(nwritten);
+      nwritten = _NX_GETERRVAL(nwritten);
       DEBUGASSERT(nwritten < 0);
     }
-  while (errcode == EINTR);
+  while (nwritten == -EINTR);
 }
 
 /****************************************************************************

--- a/libs/libc/stream/lib_stdsistream.c
+++ b/libs/libc/stream/lib_stdsistream.c
@@ -71,6 +71,10 @@ static int stdsistream_gets(FAR struct lib_instream_s *this,
     {
       this->nget += nread;
     }
+  else
+    {
+      nread = _NX_GETERRVAL(nread);
+    }
 
   return nread;
 }


### PR DESCRIPTION
## Summary
Unified Stream behavior
Return the error code when all gets occur when an error is wrong, and return immediately when obtaining any valid data

## Impact

## Testing

