### PR TITLE
driver/serial: Echo only determined by ECHO flag with termios enabled

### DIFF
--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -890,9 +890,11 @@ static ssize_t uart_read(FAR struct file *filep,
           *buffer++ = ch;
           recvd++;
 
-          if (dev->isconsole
+          if (
 #ifdef CONFIG_SERIAL_TERMIOS
-              || (dev->tc_iflag & ECHO)
+              dev->tc_iflag & ECHO
+#else
+              dev->isconsole
 #endif
              )
             {


### PR DESCRIPTION


## Summary
Fix a bug that can not disable echo even if termios is enabled.
Note: If you want to disable echo for console, you can only do it by termios.
## Impact
serial driver
## Testing
custom board
