### PR TITLE
arch/imx6: Fix a compilation error with UBSan

### DIFF
--- a/arch/arm/src/imx6/imx_gpio.h
+++ b/arch/arm/src/imx6/imx_gpio.h
@@ -50,10 +50,10 @@
  */
 
 #define GPIO_MODE_SHIFT        (30)      /* Bits 30-31: Pin mode */
-#define GPIO_MODE_MASK         (3 << GPIO_MODE_SHIFT)
-#  define GPIO_INPUT           (0 << GPIO_MODE_SHIFT) /* GPIO input */
-#  define GPIO_OUTPUT          (1 << GPIO_MODE_SHIFT) /* GPIO output */
-#  define GPIO_PERIPH          (2 << GPIO_MODE_SHIFT) /* Peripheral */
+#define GPIO_MODE_MASK         (3u << GPIO_MODE_SHIFT)
+#  define GPIO_INPUT           (0u << GPIO_MODE_SHIFT) /* GPIO input */
+#  define GPIO_OUTPUT          (1u << GPIO_MODE_SHIFT) /* GPIO output */
+#  define GPIO_PERIPH          (2u << GPIO_MODE_SHIFT) /* Peripheral */
 
 /* Initial Output Value:
  *


### PR DESCRIPTION
## Summary
        Workaround for:
         chip/imx_gpio.c:545:7: error: case label does not reduce to an integer constant
         545 |       case GPIO_PERIPH:
             |       ^~~~
         
## Impact
Minor
## Testing
CI and QEMU
