### PR TITLE
sched: build error fix in task_exithook

### DIFF
--- a/sched/task/task_exithook.c
+++ b/sched/task/task_exithook.c
@@ -461,7 +461,7 @@ void nxtask_exithook(FAR struct tcb_s *tcb, int status)
   nxsig_cleanup(tcb); /* Deallocate Signal lists */
 
 #ifdef CONFIG_SCHED_DUMP_LEAK
-  if ((tcb->cmn.flags & TCB_FLAG_TTYPE_MASK) == TCB_FLAG_TTYPE_KERNEL)
+  if ((tcb->flags & TCB_FLAG_TTYPE_MASK) == TCB_FLAG_TTYPE_KERNEL)
     {
       kmm_memdump(tcb->pid);
     }


### PR DESCRIPTION
## Summary
CC:  task/task_recover.c task/task_exithook.c: In function 'nxtask_exithook': task/task_exithook.c:464:11: error: 'struct tcb_s' has no member named 'cmn'
  464 |   if ((tcb->cmn.flags & TCB_FLAG_TTYPE_MASK) == TCB_FLAG_TTYPE_KERNEL)
      |           ^~
CC:  opus/silk/shell_coder.c make[1]: *** [Makefile:60: task_exithook.o] Error 1

## Impact
Build break fix

## Testing
vela and sim:nsh with CONFIG_SCHED_DUMP_LEAK enable
