### PR TITLE
samv7: raise input flow control warning only for serial drivers

### DIFF
--- a/arch/arm/src/samv7/sam_config.h
+++ b/arch/arm/src/samv7/sam_config.h
@@ -154,14 +154,22 @@
 #undef CONFIG_UART3_IFLOWCONTROL
 #undef CONFIG_UART4_IFLOWCONTROL
 
-/* Hardware flow control requires using a DMAC channel (not yet supported) */
+/* Hardware flow control requires using a DMAC channel (not yet supported).
+ * However CONFIG_SERIAL_IFLOWCONTROL is also used for USB CDC/ACM flow
+ * control which is supported, therefore the warning flag should be raised
+ * only if flowcontrol is configured for USART drivers.
+ */
 
 #ifdef CONFIG_SERIAL_IFLOWCONTROL
-#  warning XDMAC support is required for RTS hardware flow control
-#  undef CONFIG_SERIAL_IFLOWCONTROL
-#  undef CONFIG_USART0_IFLOWCONTROL
-#  undef CONFIG_USART1_IFLOWCONTROL
-#  undef CONFIG_USART2_IFLOWCONTROL
+#  if defined(CONFIG_USART0_IFLOWCONTROL) || \
+      defined(CONFIG_USART1_IFLOWCONTROL) || \
+      defined(CONFIG_USART2_IFLOWCONTROL)
+#    warning XDMAC support is required for RTS hardware flow control
+#    undef CONFIG_USART0_IFLOWCONTROL
+#    undef CONFIG_USART1_IFLOWCONTROL
+#    undef CONFIG_USART2_IFLOWCONTROL
+#    undef CONFIG_SERIAL_IFLOWCONTROL
+#  endif
 #endif
 
 /* Serial Console ***********************************************************/


### PR DESCRIPTION
## Summary
Hardware flow control for serial requires the usage of DMAC channels which is not yet supported for SAMv7 MCU. However the same config option CONFIG_SERIAL_IFLOWCONTROL is also used for USB CDC/ACM flow control which works well. Therefore the warning message should be raised only if flow control is configured for USART driver and not for USB CDC/ACM.

## Impact

SAMv7 only.

