### PR TITLE
arm64: add arm64_serialinit/arm64_earlyserialinit

### DIFF
--- a/arch/arm64/src/a64/a64_boot.c
+++ b/arch/arm64/src/a64/a64_boot.c
@@ -118,7 +118,7 @@ void arm64_chip_boot(void)
    * driver.
    */
 
-  a64_earlyserialinit();
+  arm64_earlyserialinit();
 #endif
 }
 

--- a/arch/arm64/src/a64/a64_serial.c
+++ b/arch/arm64/src/a64/a64_serial.c
@@ -589,7 +589,7 @@ static struct uart_dev_s    g_uart1port =
  ***************************************************************************/
 
 /***************************************************************************
- * Name: a64_earlyserialinit
+ * Name: arm64_earlyserialinit
  *
  * Description:
  *   Performs the low level UART initialization early in
@@ -601,7 +601,7 @@ static struct uart_dev_s    g_uart1port =
  *
  ***************************************************************************/
 
-void a64_earlyserialinit(void)
+void arm64_earlyserialinit(void)
 {
   /* NOTE: This function assumes that low level hardware configuration
    * -- including all clocking and pin configuration -- was performed

--- a/arch/arm64/src/a64/a64_serial.h
+++ b/arch/arm64/src/a64/a64_serial.h
@@ -57,19 +57,5 @@
  * Public Function Prototypes
  ****************************************************************************/
 
-/****************************************************************************
- * Name: a64_earlyserialinit
- *
- * Description:
- *   Performs the low level UART initialization early in debug so that the
- *   serial console will be available during bootup.  This must be called
- *   before arm64_serialinit.
- *
- ****************************************************************************/
-
-#ifdef USE_EARLYSERIALINIT
-void a64_earlyserialinit(void);
-#endif
-
 #endif /* __ASSEMBLY__ */
 #endif /* __ARCH_ARM64_SRC_A64_A64_SERIAL_H */

--- a/arch/arm64/src/common/arm64_internal.h
+++ b/arch/arm64/src/common/arm64_internal.h
@@ -290,10 +290,35 @@ uint64_t * arm64_syscall_switch(uint64_t *regs);
 int arm64_syscall(uint64_t *regs);
 
 #ifdef USE_SERIALDRIVER
+/****************************************************************************
+ * Name: arm64_serialinit
+ *
+ * Description:
+ *   Register serial console and serial ports.  This assumes
+ *   that arm64_earlyserialinit was called previously.
+ *
+ ****************************************************************************/
+
 void arm64_serialinit(void);
 #endif
 
 #ifdef USE_EARLYSERIALINIT
+
+/****************************************************************************
+ * Name: arm64_earlyserialinit
+ *
+ * Description:
+ *   Performs the low level UART initialization early in debug so that the
+ *   serial console will be available during bootup.  This must be called
+ *   before arm64_serialinit.
+ *
+ * Note:
+ *   This function assumes that low level hardware configuration
+ *   including all clocking and pin configuration -- was performed
+ *   earlier in the boot sequence(eg bootloader).
+ *
+ ****************************************************************************/
+
 void arm64_earlyserialinit(void);
 #endif
 

--- a/arch/arm64/src/fvp-v8r/fvp_boot.c
+++ b/arch/arm64/src/fvp-v8r/fvp_boot.c
@@ -200,6 +200,6 @@ void arm64_chip_boot(void)
    * driver.
    */
 
-  fvp_earlyserialinit();
+  arm64_earlyserialinit();
 #endif
 }

--- a/arch/arm64/src/fvp-v8r/serial_pl011.c
+++ b/arch/arm64/src/fvp-v8r/serial_pl011.c
@@ -781,22 +781,15 @@ static struct uart_dev_s    g_uart1port =
  ***************************************************************************/
 
 /***************************************************************************
- * Name: qemu_earlyserialinit
+ * Name: arm64_earlyserialinit
  *
  * Description:
- *   Performs the low level UART initialization early in
- *   debug so that the serial console will be available
- *   during bootup.  This must be called before arm_serialinit.
+ *   see arm64_internal.h
  *
  ***************************************************************************/
 
-void fvp_earlyserialinit(void)
+void arm64_earlyserialinit(void)
 {
-  /* NOTE: This function assumes that low level hardware configuration
-   * -- including all clocking and pin configuration -- was performed by the
-   * function imx8_lowsetup() earlier in the boot sequence.
-   */
-
   /* Enable the console UART.  The other UARTs will be initialized if and
    * when they are first opened.
    */
@@ -834,8 +827,7 @@ int up_putc(int ch)
  * Name: arm64_serialinit
  *
  * Description:
- *   Register serial console and serial ports.  This assumes
- *   that imx_earlyserialinit was called previously.
+ *   see arm64_internal.h
  *
  ***************************************************************************/
 

--- a/arch/arm64/src/fvp-v8r/serial_pl011.h
+++ b/arch/arm64/src/fvp-v8r/serial_pl011.h
@@ -64,19 +64,5 @@
  * Public Function Prototypes
  ****************************************************************************/
 
-/****************************************************************************
- * Name: fvp_earlyserialinit
- *
- * Description:
- *   Performs the low level UART initialization early in debug so that the
- *   serial console will be available during bootup.  This must be called
- *   before arm_serialinit.
- *
- ****************************************************************************/
-
-#ifdef USE_EARLYSERIALINIT
-void fvp_earlyserialinit(void);
-#endif
-
 #endif /* __ASSEMBLY__ */
 #endif /* __ARCH_ARM64_SRC_FVP_V8R_SERIAL_PL011_H */

--- a/arch/arm64/src/qemu/qemu_boot.c
+++ b/arch/arm64/src/qemu/qemu_boot.c
@@ -173,6 +173,6 @@ void arm64_chip_boot(void)
    * driver.
    */
 
-  qemu_earlyserialinit();
+  arm64_earlyserialinit();
 #endif
 }

--- a/arch/arm64/src/qemu/qemu_serial.c
+++ b/arch/arm64/src/qemu/qemu_serial.c
@@ -786,22 +786,15 @@ static struct uart_dev_s    g_uart1port =
  ***************************************************************************/
 
 /***************************************************************************
- * Name: qemu_earlyserialinit
+ * Name: arm64_earlyserialinit
  *
  * Description:
- *   Performs the low level UART initialization early in
- *   debug so that the serial console will be available
- *   during bootup.  This must be called before arm_serialinit.
+ *   see arm64_internal.h
  *
  ***************************************************************************/
 
-void qemu_earlyserialinit(void)
+void arm64_earlyserialinit(void)
 {
-  /* NOTE: This function assumes that low level hardware configuration
-   * -- including all clocking and pin configuration -- was performed by the
-   * function imx8_lowsetup() earlier in the boot sequence.
-   */
-
   /* Enable the console UART.  The other UARTs will be initialized if and
    * when they are first opened.
    */
@@ -839,8 +832,7 @@ int up_putc(int ch)
  * Name: arm64_serialinit
  *
  * Description:
- *   Register serial console and serial ports.  This assumes
- *   that imx_earlyserialinit was called previously.
+ *   see arm64_internal.h
  *
  ***************************************************************************/
 

--- a/arch/arm64/src/qemu/qemu_serial.h
+++ b/arch/arm64/src/qemu/qemu_serial.h
@@ -57,19 +57,5 @@
  * Public Function Prototypes
  ****************************************************************************/
 
-/****************************************************************************
- * Name: qemu_earlyserialinit
- *
- * Description:
- *   Performs the low level UART initialization early in debug so that the
- *   serial console will be available during bootup.  This must be called
- *   before arm_serialinit.
- *
- ****************************************************************************/
-
-#ifdef USE_EARLYSERIALINIT
-void qemu_earlyserialinit(void);
-#endif
-
 #endif /* __ASSEMBLY__ */
 #endif /* __ARCH_ARM64_SRC_QEMU_QEMU_SERIAL_H */


### PR DESCRIPTION
## Summary

   add arm64_serialinit/arm64_earlyserialinit function prototype
to arm64_internal.h as common function for arm64 based chip.
   Testing with ostest in SP and SMP

## Impact
None

## Testing
Testing with ostest in SP and SMP
