### PR TITLE
arch/armv8-m: DSP extension is optional

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -481,6 +481,7 @@ config ARCH_CHIP_STM32L5
 	bool "STMicro STM32 L5"
 	select ARCH_CORTEXM33
 	select ARCH_HAVE_MPU
+	select ARCH_HAVE_DSP
 	select ARCH_HAVE_FETCHADD
 	select ARCH_HAVE_HEAPCHECK
 	select ARCH_HAVE_PROGMEM
@@ -495,6 +496,7 @@ config ARCH_CHIP_STM32U5
 	bool "STMicro STM32 U5"
 	select ARCH_CORTEXM33
 	select ARCH_HAVE_MPU
+	select ARCH_HAVE_DSP
 	select ARCH_HAVE_FETCHADD
 	select ARCH_HAVE_HEAPCHECK
 	select ARCH_HAVE_PROGMEM
@@ -1035,6 +1037,12 @@ config ARM_HAVE_NEON
 	---help---
 		Decide whether support NEON instruction
 
+config ARM_HAVE_DSP
+	bool
+	default n
+	---help---
+		Decide whether support DSP instruction
+
 config ARM_HAVE_MVE
 	bool
 	default n
@@ -1061,6 +1069,7 @@ config ARM_NEON
 config ARM_DSP
 	bool "Advanced DSP Extension"
 	default y
+	depends on ARM_HAVE_DSP
 	---help---
 		Enables DSP Extension
 

--- a/arch/arm/src/nrf53/Kconfig
+++ b/arch/arm/src/nrf53/Kconfig
@@ -20,6 +20,7 @@ endchoice # NRF53 Chip Selection
 config NRF53_APPCORE
 	bool
 	default n
+	select ARM_HAVE_DSP
 
 config NRF53_NETCORE
 	bool


### PR DESCRIPTION
## Summary
The DSP extension is optional for armv8-m cores, so it should be explicitly set by chip configuration.
Otherwise this can lead to hard to debug hardfaults for cores that do not support DSP.
## Impact
Breaking change for out-of-tree armv8-m chips. FYI @xiaoxiang781216 @anchao 
## Testing
nrf53 net core without DSP extension
