### PR TITLE
drivers/serial: Echo CR when NL is detected and the serial device is a console

### DIFF
--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -918,9 +918,12 @@ static ssize_t uart_read(FAR struct file *filep,
 
               if ((!iscntrl(ch & 0xff) || (ch == '\n')) && dev->escape == 0)
                 {
+                  if (ch == '\n')
                     {
-                      uart_putxmitchar(dev, ch, true);
+                      uart_putxmitchar(dev, '\r', true);
                     }
+
+                  uart_putxmitchar(dev, ch, true);
                 }
 
               /* Skipping character count down */


### PR DESCRIPTION
## Summary

Echo CR when NL is detected and the serial device is a console and fix https://github.com/apache/nuttx/pull/8691#issuecomment-1453676916

## Impact

The serial driver now performs the echoing console's input (https://github.com/apache/nuttx/pull/8691). In order to keep the old behavior of CR being echoed by the device, it's necessary to detect whenever NL is being echoed and send CR before sending it.

## Testing

Internal CI, NuttX's CI and test on ESP32-DevKitC.
