### PR TITLE
mm_heap: support custom the mm alignment and default to be 8

### DIFF
--- a/mm/Kconfig
+++ b/mm/Kconfig
@@ -61,6 +61,15 @@ config MM_KERNEL_HEAPSIZE
 		user-mode heap.  This value may need to be aligned to units of the
 		size of the smallest memory protection region.
 
+config MM_DFAULT_ALIGNMENT
+	int "Memory default alignment in bytes"
+	default 8
+	range 0 64
+	---help---
+		The memory default alignment in bytes, if this value is 0, the real
+		memory default alignment is equal to sizoef(uintptr), if this value
+		is not 0, this value must be 2^n and at least sizeof(uintptr).
+
 config MM_SMALL
 	bool "Small memory model"
 	default n

--- a/mm/mm_heap/mm.h
+++ b/mm/mm_heap/mm.h
@@ -110,7 +110,12 @@
 #define MM_MAX_CHUNK     (1 << MM_MAX_SHIFT)
 #define MM_NNODES        (MM_MAX_SHIFT - MM_MIN_SHIFT + 1)
 
-#define MM_GRAN_MASK     (MM_MIN_CHUNK - 1)
+#if CONFIG_MM_DFAULT_ALIGNMENT == 0
+#  define MM_ALIGN       sizeof(uintptr_t)
+#else
+#  define MM_ALIGN       CONFIG_MM_DFAULT_ALIGNMENT
+#endif
+#define MM_GRAN_MASK     (MM_ALIGN - 1)
 #define MM_ALIGN_UP(a)   (((a) + MM_GRAN_MASK) & ~MM_GRAN_MASK)
 #define MM_ALIGN_DOWN(a) ((a) & ~MM_GRAN_MASK)
 
@@ -137,10 +142,6 @@
  */
 
 #define OVERHEAD_MM_ALLOCNODE (SIZEOF_MM_ALLOCNODE - sizeof(mmsize_t))
-
-/* What is the size of the freenode? */
-
-#define SIZEOF_MM_FREENODE sizeof(struct mm_freenode_s)
 
 /* Get the node size */
 
@@ -194,8 +195,9 @@ struct mm_freenode_s
 static_assert(SIZEOF_MM_ALLOCNODE <= MM_MIN_CHUNK,
               "Error size for struct mm_allocnode_s\n");
 
-static_assert(SIZEOF_MM_FREENODE <= MM_MIN_CHUNK,
-              "Error size for struct mm_freenode_s\n");
+static_assert(MM_ALIGN >= sizeof(uintptr_t) &&
+              (MM_ALIGN & MM_GRAN_MASK) == 0,
+              "Error memory aligment\n");
 
 struct mm_delaynode_s
 {

--- a/mm/mm_heap/mm_addfreechunk.c
+++ b/mm/mm_heap/mm_addfreechunk.c
@@ -51,7 +51,7 @@ void mm_addfreechunk(FAR struct mm_heap_s *heap,
   size_t nodesize = SIZEOF_MM_NODE(node);
   int ndx;
 
-  DEBUGASSERT(nodesize >= SIZEOF_MM_FREENODE);
+  DEBUGASSERT(nodesize >= MM_MIN_CHUNK);
   DEBUGASSERT((node->size & MM_ALLOC_BIT) == 0);
 
   /* Convert the size to a nodelist index */

--- a/mm/mm_heap/mm_checkcorruption.c
+++ b/mm/mm_heap/mm_checkcorruption.c
@@ -50,7 +50,7 @@ static void checkcorruption_handler(FAR struct mm_allocnode_s *node,
     {
       FAR struct mm_freenode_s *fnode = (FAR void *)node;
 
-      assert(nodesize >= SIZEOF_MM_FREENODE);
+      assert(nodesize >= MM_MIN_CHUNK);
       assert(fnode->blink->flink == fnode);
       assert(SIZEOF_MM_NODE(fnode->blink) <= nodesize);
       assert(fnode->flink == NULL ||

--- a/mm/mm_heap/mm_initialize.c
+++ b/mm/mm_heap/mm_initialize.c
@@ -139,7 +139,7 @@ void mm_addregion(FAR struct mm_heap_s *heap, FAR void *heapstart,
   heap->mm_heapstart[IDX]->size    = SIZEOF_MM_ALLOCNODE | MM_ALLOC_BIT;
   node                             = (FAR struct mm_freenode_s *)
                                      (heapbase + SIZEOF_MM_ALLOCNODE);
-  DEBUGASSERT((((uintptr_t)node + SIZEOF_MM_ALLOCNODE) % MM_MIN_CHUNK) == 0);
+  DEBUGASSERT((((uintptr_t)node + SIZEOF_MM_ALLOCNODE) % MM_ALIGN) == 0);
   node->size                       = heapsize - 2 * SIZEOF_MM_ALLOCNODE;
   heap->mm_heapend[IDX]            = (FAR struct mm_allocnode_s *)
                                      (heapend - SIZEOF_MM_ALLOCNODE);
@@ -204,7 +204,6 @@ FAR struct mm_heap_s *mm_initialize(FAR const char *name,
   heapsize -= sizeof(struct mm_heap_s);
   heapstart = (FAR char *)heap_adj + sizeof(struct mm_heap_s);
 
-  DEBUGASSERT(MM_MIN_CHUNK >= SIZEOF_MM_FREENODE);
   DEBUGASSERT(MM_MIN_CHUNK >= SIZEOF_MM_ALLOCNODE);
 
   /* Set up global variables */

--- a/mm/mm_heap/mm_mallinfo.c
+++ b/mm/mm_heap/mm_mallinfo.c
@@ -57,7 +57,7 @@ static void mallinfo_handler(FAR struct mm_allocnode_s *node, FAR void *arg)
     {
       FAR struct mm_freenode_s *fnode = (FAR void *)node;
 
-      DEBUGASSERT(nodesize >= SIZEOF_MM_FREENODE);
+      DEBUGASSERT(nodesize >= MM_MIN_CHUNK);
       DEBUGASSERT(fnode->blink->flink == fnode);
       DEBUGASSERT(SIZEOF_MM_NODE(fnode->blink) <= nodesize);
       DEBUGASSERT(fnode->flink == NULL ||

--- a/mm/mm_heap/mm_malloc.c
+++ b/mm/mm_heap/mm_malloc.c
@@ -130,8 +130,14 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
 #endif
 
   /* Adjust the size to account for (1) the size of the allocated node and
-   * (2) to make sure that it is an even multiple of our granule size.
+   * (2) to make sure that it is aligned with MM_ALIGN and its size is at
+   * least MM_MIN_CHUNK.
    */
+
+  if (size < MM_MIN_CHUNK - OVERHEAD_MM_ALLOCNODE)
+    {
+      size = MM_MIN_CHUNK - OVERHEAD_MM_ALLOCNODE;
+    }
 
   alignsize = MM_ALIGN_UP(size + OVERHEAD_MM_ALLOCNODE);
   if (alignsize < size)
@@ -141,8 +147,7 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
       return NULL;
     }
 
-  DEBUGASSERT(alignsize >= MM_MIN_CHUNK);
-  DEBUGASSERT(alignsize >= SIZEOF_MM_FREENODE);
+  DEBUGASSERT(alignsize >= MM_ALIGN);
 
   /* We need to hold the MM mutex while we muck with the nodelist. */
 
@@ -204,7 +209,7 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
        */
 
       remaining = nodesize - alignsize;
-      if (remaining >= SIZEOF_MM_FREENODE)
+      if (remaining >= MM_MIN_CHUNK)
         {
           /* Create the remainder node */
 
@@ -277,6 +282,6 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
     }
 #endif
 
-  DEBUGASSERT(ret == NULL || ((uintptr_t)ret) % MM_MIN_CHUNK == 0);
+  DEBUGASSERT(ret == NULL || ((uintptr_t)ret) % MM_ALIGN == 0);
   return ret;
 }

--- a/mm/mm_heap/mm_memdump.c
+++ b/mm/mm_heap/mm_memdump.c
@@ -95,7 +95,7 @@ static void memdump_handler(FAR struct mm_allocnode_s *node, FAR void *arg)
     {
       FAR struct mm_freenode_s *fnode = (FAR void *)node;
 
-      DEBUGASSERT(nodesize >= SIZEOF_MM_FREENODE);
+      DEBUGASSERT(nodesize >= MM_MIN_CHUNK);
       DEBUGASSERT(fnode->blink->flink == fnode);
       DEBUGASSERT(SIZEOF_MM_NODE(fnode->blink) <= nodesize);
       DEBUGASSERT(fnode->flink == NULL ||

--- a/mm/mm_heap/mm_realloc.c
+++ b/mm/mm_heap/mm_realloc.c
@@ -110,8 +110,14 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
 #endif
 
   /* Adjust the size to account for (1) the size of the allocated node and
-   * (2) to make sure that it is an even multiple of our granule size.
+   * (2) to make sure that it is aligned with MM_ALIGN and its size is at
+   * least MM_MIN_CHUNK.
    */
+
+  if (size < MM_MIN_CHUNK - OVERHEAD_MM_ALLOCNODE)
+    {
+      size = MM_MIN_CHUNK - OVERHEAD_MM_ALLOCNODE;
+    }
 
   newsize = MM_ALIGN_UP(size + OVERHEAD_MM_ALLOCNODE);
   if (newsize < size)
@@ -256,6 +262,13 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
               prev->flink->blink = prev->blink;
             }
 
+          /* Make sure the new previous node has enough space */
+
+          if (prevsize < takeprev + MM_MIN_CHUNK)
+            {
+              takeprev = prevsize;
+            }
+
           /* Extend the node into the previous free chunk */
 
           newnode = (FAR struct mm_allocnode_s *)
@@ -270,7 +283,6 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
                */
 
               prevsize          -= takeprev;
-              DEBUGASSERT(prevsize >= SIZEOF_MM_FREENODE);
               prev->size         = prevsize | (prev->size & MM_MASK_BIT);
               nodesize          += takeprev;
               newnode->size      = nodesize | MM_ALLOC_BIT | MM_PREVFREE_BIT;
@@ -323,6 +335,13 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
               next->flink->blink = next->blink;
             }
 
+          /* Make sure the new next node has enough space */
+
+          if (nextsize < takenext + MM_MIN_CHUNK)
+            {
+              takenext = nextsize;
+            }
+
           /* Extend the node into the next chunk */
 
           nodesize += takenext;
@@ -339,7 +358,6 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
               newnode              = (FAR struct mm_freenode_s *)
                                      ((FAR char *)oldnode + nodesize);
               newnode->size        = nextsize - takenext;
-              DEBUGASSERT(newnode->size >= SIZEOF_MM_FREENODE);
               andbeyond->preceding = newnode->size;
 
               /* Add the new free node to the nodelist (with the new size) */

--- a/mm/mm_heap/mm_shrinkchunk.c
+++ b/mm/mm_heap/mm_shrinkchunk.c
@@ -106,7 +106,7 @@ void mm_shrinkchunk(FAR struct mm_heap_s *heap,
    * chunk to be shrunk.
    */
 
-  else if (nodesize >= size + SIZEOF_MM_FREENODE)
+  else if (nodesize >= size + MM_MIN_CHUNK)
     {
       FAR struct mm_freenode_s *newnode;
 

--- a/mm/mm_heap/mm_size2ndx.c
+++ b/mm/mm_heap/mm_size2ndx.c
@@ -44,6 +44,7 @@
 
 int mm_size2ndx(size_t size)
 {
+  DEBUGASSERT(size >= MM_MIN_CHUNK);
   if (size >= MM_MAX_CHUNK)
     {
       return MM_NNODES - 1;


### PR DESCRIPTION
## Summary
Support custom the memory alignment, and the default alignment is 8 bytes.
Before this PR, the memory alignment is MM_MIN_CHUNK, the minimum alignment is 16 bytes, and the alignment will be larger if enable MM_BACKTRACE, which leads some memory waste.
After this PR, the default memory alignment becomes 8 and can be customed to 4.

In addition, I will post some simple test data about the memory saving later, but this PR can be reviewed first.

## Impact
Memory Manager

## Testing
vela and  ostest and mm test pass in sim.
