### PR TITLE
tools/nxstyle: add 'IRQn_Type' to whitelists

### DIFF
--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -530,6 +530,13 @@ static const char *g_white_list[] =
   "idVendor",
   "idProduct",
 
+  /* Ref:
+   * arch/arm/src/nrf52/sdc/nrf.h
+   * arch/arm/src/nrf53/sdc/nrf.h
+   */
+
+  "IRQn_Type",
+
   NULL
 };
 


### PR DESCRIPTION
## Summary
tools/nxstyle: add 'IRQn_Type' to whitelists
needed by https://github.com/apache/nuttx/pull/8722
## Impact

## Testing

