### PR TITLE
Hotfix of local_ioctl for fcntl with O_NONBLOCK to work

### DIFF
--- a/net/local/local_sockif.c
+++ b/net/local/local_sockif.c
@@ -833,7 +833,7 @@ static int local_close(FAR struct socket *psock)
 static int local_ioctl(FAR struct socket *psock, int cmd, unsigned long arg)
 {
   FAR struct local_conn_s *conn;
-  int ret = OK;
+  int ret = -ENOTTY;
 
   conn = (FAR struct local_conn_s *)psock->s_conn;
 


### PR DESCRIPTION
## Summary

Calling fcntl with O_NONBLOCK flag on local socket was not working without this change.

## Impact

local_ioctl function

## Testing

Working with nng library, I have found the problem and this hotfix has helped.

