### PR TITLE
vfs/poll: Remove the unused ptr field from pollfd

### DIFF
--- a/include/sys/poll.h
+++ b/include/sys/poll.h
@@ -117,7 +117,6 @@ struct pollfd
 
   /* Non-standard fields used internally by NuttX. */
 
-  FAR void    *ptr;     /* The psock or file being polled */
   FAR void    *arg;     /* The poll callback function argument */
   pollcb_t     cb;      /* The poll callback function */
   FAR void    *priv;    /* For use by drivers */


### PR DESCRIPTION
## Summary

forget in the commit(https://github.com/apache/nuttx/pull/8089):
commit 0a95c7721bab13b329bb681ecf38e558498f2d77
Author: Xiang Xiao <xiaoxiang@xiaomi.com>
Date:   Fri Nov 11 03:47:07 2022 +0800

    vfs/poll: Remove POLLFILE and POLLSOCK NuttX specific extension

## Impact

None

## Testing

CI
