### PR TITLE
mm_heap: double malloced memory default alignment (4 -> 8, 8 -> 16)

### DIFF
--- a/mm/Kconfig
+++ b/mm/Kconfig
@@ -63,7 +63,7 @@ config MM_KERNEL_HEAPSIZE
 
 config MM_DFAULT_ALIGNMENT
 	int "Memory default alignment in bytes"
-	default 8
+	default 0
 	range 0 64
 	---help---
 		The memory default alignment in bytes, if this value is 0, the real

--- a/mm/mm_heap/mm.h
+++ b/mm/mm_heap/mm.h
@@ -111,7 +111,7 @@
 #define MM_NNODES        (MM_MAX_SHIFT - MM_MIN_SHIFT + 1)
 
 #if CONFIG_MM_DFAULT_ALIGNMENT == 0
-#  define MM_ALIGN       sizeof(uintptr_t)
+#  define MM_ALIGN       (2 * sizeof(uintptr_t))
 #else
 #  define MM_ALIGN       CONFIG_MM_DFAULT_ALIGNMENT
 #endif


### PR DESCRIPTION
## Summary
Base on the gnu libc standard:
https://www.gnu.org/software/libc/manual/html_node/Aligned-Memory-Blocks.html

Change the default memory aligment to 8 bytes for 32-bit system and 16 bytes for 64-bit system.

This PR fix the issue (qemu-intel64:ostest can not boot) mentioned in https://github.com/apache/nuttx/pull/8721

## Impact
Memory Manager

## Testing
qemu-intel64:ostest and sim ostest mm_test pass
