### PR TITLE
net: Remove the dummy implementation from sock_intf_s

### DIFF
--- a/net/bluetooth/bluetooth_sockif.c
+++ b/net/bluetooth/bluetooth_sockif.c
@@ -59,9 +59,6 @@ static int        bluetooth_getpeername(FAR struct socket *psock,
                     FAR struct sockaddr *addr, FAR socklen_t *addrlen);
 static int        bluetooth_connect(FAR struct socket *psock,
                     FAR const struct sockaddr *addr, socklen_t addrlen);
-static int        bluetooth_accept(FAR struct socket *psock,
-                    FAR struct sockaddr *addr, FAR socklen_t *addrlen,
-                    FAR struct socket *newsock);
 static int        bluetooth_poll_local(FAR struct socket *psock,
                     FAR struct pollfd *fds, bool setup);
 static int        bluetooth_close(FAR struct socket *psock);
@@ -88,7 +85,7 @@ const struct sock_intf_s g_bluetooth_sockif =
   bluetooth_getpeername, /* si_getpeername */
   NULL,                  /* si_listen */
   bluetooth_connect,     /* si_connect */
-  bluetooth_accept,      /* si_accept */
+  NULL,                  /* si_accept */
   bluetooth_poll_local,  /* si_poll */
   bluetooth_sendmsg,     /* si_sendmsg */
   bluetooth_recvmsg,     /* si_recvmsg */
@@ -287,58 +284,6 @@ static int bluetooth_connect(FAR struct socket *psock,
     }
 
   return ret;
-}
-
-/****************************************************************************
- * Name: bluetooth_accept
- *
- * Description:
- *   The bluetooth_accept function is used with connection-based socket types
- *   (SOCK_STREAM, SOCK_SEQPACKET and SOCK_RDM). It extracts the first
- *   connection request on the queue of pending connections, creates a new
- *   connected socket with mostly the same properties as 'sockfd', and
- *   allocates a new socket descriptor for the socket, which is returned. The
- *   newly created socket is no longer in the listening state. The original
- *   socket 'sockfd' is unaffected by this call.  Per file descriptor flags
- *   are not inherited across an bluetooth_accept.
- *
- *   The 'sockfd' argument is a socket descriptor that has been created with
- *   socket(), bound to a local address with bind(), and is listening for
- *   connections after a call to listen().
- *
- *   On return, the 'addr' structure is filled in with the address of the
- *   connecting entity. The 'addrlen' argument initially contains the size
- *   of the structure pointed to by 'addr'; on return it will contain the
- *   actual length of the address returned.
- *
- *   If no pending connections are present on the queue, and the socket is
- *   not marked as non-blocking, bluetooth_accept blocks the caller until a
- *   connection is present. If the socket is marked non-blocking and no
- *   pending connections are present on the queue, bluetooth_accept returns
- *   EAGAIN.
- *
- * Input Parameters:
- *   psock    Reference to the listening socket structure
- *   addr     Receives the address of the connecting client
- *   addrlen  Input: allocated size of 'addr',
- *            Return: returned size of 'addr'
- *   newsock  Location to return the accepted socket information.
- *
- * Returned Value:
- *   Returns 0 (OK) on success.  On failure, it returns a negated errno
- *   value.  See accept() for a description of the appropriate error value.
- *
- * Assumptions:
- *   The network is locked.
- *
- ****************************************************************************/
-
-static int bluetooth_accept(FAR struct socket *psock,
-                            FAR struct sockaddr *addr,
-                            FAR socklen_t *addrlen,
-                            FAR struct socket *newsock)
-{
-  return -EAFNOSUPPORT;
 }
 
 /****************************************************************************

--- a/net/bluetooth/bluetooth_sockif.c
+++ b/net/bluetooth/bluetooth_sockif.c
@@ -57,7 +57,6 @@ static int        bluetooth_getsockname(FAR struct socket *psock,
                     FAR struct sockaddr *addr, FAR socklen_t *addrlen);
 static int        bluetooth_getpeername(FAR struct socket *psock,
                     FAR struct sockaddr *addr, FAR socklen_t *addrlen);
-static int        bluetooth_listen(FAR struct socket *psock, int backlog);
 static int        bluetooth_connect(FAR struct socket *psock,
                     FAR const struct sockaddr *addr, socklen_t addrlen);
 static int        bluetooth_accept(FAR struct socket *psock,
@@ -87,7 +86,7 @@ const struct sock_intf_s g_bluetooth_sockif =
   bluetooth_bind,        /* si_bind */
   bluetooth_getsockname, /* si_getsockname */
   bluetooth_getpeername, /* si_getpeername */
-  bluetooth_listen,      /* si_listen */
+  NULL,                  /* si_listen */
   bluetooth_connect,     /* si_connect */
   bluetooth_accept,      /* si_accept */
   bluetooth_poll_local,  /* si_poll */
@@ -670,36 +669,6 @@ static int bluetooth_getpeername(FAR struct socket *psock,
 
   *addrlen = copylen;
   return OK;
-}
-
-/****************************************************************************
- * Name: bluetooth_listen
- *
- * Description:
- *   To accept connections, a socket is first created with psock_socket(), a
- *   willingness to accept incoming connections and a queue limit for
- *   incoming connections are specified with psock_listen(), and then the
- *   connections are accepted with psock_accept().  For the case of
- *   PF_BLUETOOTH sockets, psock_listen() calls this function.  The listen()
- *   call does not apply only to PF_BLUETOOTH sockets.
- *
- * Input Parameters:
- *   psock    Reference to an internal, boound socket structure.
- *   backlog  The maximum length the queue of pending connections may grow.
- *            If a connection request arrives with the queue full, the client
- *            may receive an error with an indication of ECONNREFUSED or,
- *            if the underlying protocol supports retransmission, the request
- *            may be ignored so that retries succeed.
- *
- * Returned Value:
- *   On success, zero is returned. On error, a negated errno value is
- *   returned.  See listen() for the set of appropriate error values.
- *
- ****************************************************************************/
-
-int bluetooth_listen(FAR struct socket *psock, int backlog)
-{
-  return -EOPNOTSUPP;
 }
 
 /****************************************************************************

--- a/net/bluetooth/bluetooth_sockif.c
+++ b/net/bluetooth/bluetooth_sockif.c
@@ -59,8 +59,6 @@ static int        bluetooth_getpeername(FAR struct socket *psock,
                     FAR struct sockaddr *addr, FAR socklen_t *addrlen);
 static int        bluetooth_connect(FAR struct socket *psock,
                     FAR const struct sockaddr *addr, socklen_t addrlen);
-static int        bluetooth_poll_local(FAR struct socket *psock,
-                    FAR struct pollfd *fds, bool setup);
 static int        bluetooth_close(FAR struct socket *psock);
 
 /* Protocol Specific Interfaces */
@@ -86,7 +84,7 @@ const struct sock_intf_s g_bluetooth_sockif =
   NULL,                  /* si_listen */
   bluetooth_connect,     /* si_connect */
   NULL,                  /* si_accept */
-  bluetooth_poll_local,  /* si_poll */
+  NULL,                  /* si_poll */
   bluetooth_sendmsg,     /* si_sendmsg */
   bluetooth_recvmsg,     /* si_recvmsg */
   bluetooth_close        /* si_close */
@@ -614,35 +612,6 @@ static int bluetooth_getpeername(FAR struct socket *psock,
 
   *addrlen = copylen;
   return OK;
-}
-
-/****************************************************************************
- * Name: bluetooth_poll
- *
- * Description:
- *   The standard poll() operation redirects operations on socket descriptors
- *   to net_poll which, indiectly, calls to function.
- *
- * Input Parameters:
- *   psock - An instance of the internal socket structure.
- *   fds   - The structure describing the events to be monitored, OR NULL if
- *           this is a request to stop monitoring events.
- *   setup - true: Setup up the poll; false: Teardown the poll
- *
- * Returned Value:
- *  0: Success; Negated errno on failure
- *
- ****************************************************************************/
-
-static int bluetooth_poll_local(FAR struct socket *psock,
-                                 FAR struct pollfd *fds, bool setup)
-{
-  /* We should need to support some kind of write ahead buffering for this
-   * feature.
-   */
-
-#warning Missing logic
-  return -ENOSYS;
 }
 
 /****************************************************************************

--- a/net/can/can_sockif.c
+++ b/net/can/can_sockif.c
@@ -53,7 +53,6 @@ static sockcaps_t can_sockcaps(FAR struct socket *psock);
 static void can_addref(FAR struct socket *psock);
 static int  can_bind(FAR struct socket *psock,
               FAR const struct sockaddr *addr, socklen_t addrlen);
-static int  can_listen(FAR struct socket *psock, int backlog);
 static int  can_connect(FAR struct socket *psock,
               FAR const struct sockaddr *addr, socklen_t addrlen);
 static int  can_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
@@ -74,7 +73,7 @@ const struct sock_intf_s g_can_sockif =
   can_bind,         /* si_bind */
   NULL,             /* si_getsockname */
   NULL,             /* si_getpeername */
-  can_listen,       /* si_listen */
+  NULL,             /* si_listen */
   can_connect,      /* si_connect */
   can_accept,       /* si_accept */
   can_poll_local,   /* si_poll */
@@ -336,37 +335,6 @@ static int can_bind(FAR struct socket *psock,
 #endif
 
   return OK;
-}
-
-/****************************************************************************
- * Name: can_listen
- *
- * Description:
- *   To accept connections, a socket is first created with psock_socket(), a
- *   willingness to accept incoming connections and a queue limit for
- *   incoming connections are specified with psock_listen(), and then the
- *   connections are accepted with psock_accept().  For the case of AFINET
- *   and AFINET6 sockets, psock_listen() calls this function.  The
- *   psock_listen() call applies only to sockets of type SOCK_STREAM or
- *   SOCK_SEQPACKET.
- *
- * Input Parameters:
- *   psock    Reference to an internal, bound socket structure.
- *   backlog  The maximum length the queue of pending connections may grow.
- *            If a connection request arrives with the queue full, the client
- *            may receive an error with an indication of ECONNREFUSED or,
- *            if the underlying protocol supports retransmission, the request
- *            may be ignored so that retries succeed.
- *
- * Returned Value:
- *   On success, zero is returned. On error, a negated errno value is
- *   returned.  See listen() for the set of appropriate error values.
- *
- ****************************************************************************/
-
-static int can_listen(FAR struct socket *psock, int backlog)
-{
-  return -EOPNOTSUPP;
 }
 
 /****************************************************************************

--- a/net/can/can_sockif.c
+++ b/net/can/can_sockif.c
@@ -53,8 +53,6 @@ static sockcaps_t can_sockcaps(FAR struct socket *psock);
 static void can_addref(FAR struct socket *psock);
 static int  can_bind(FAR struct socket *psock,
               FAR const struct sockaddr *addr, socklen_t addrlen);
-static int  can_connect(FAR struct socket *psock,
-              FAR const struct sockaddr *addr, socklen_t addrlen);
 static int  can_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
               FAR socklen_t *addrlen, FAR struct socket *newsock);
 static int  can_poll_local(FAR struct socket *psock, FAR struct pollfd *fds,
@@ -74,7 +72,7 @@ const struct sock_intf_s g_can_sockif =
   NULL,             /* si_getsockname */
   NULL,             /* si_getpeername */
   NULL,             /* si_listen */
-  can_connect,      /* si_connect */
+  NULL,             /* si_connect */
   can_accept,       /* si_accept */
   can_poll_local,   /* si_poll */
   can_sendmsg,      /* si_sendmsg */
@@ -335,32 +333,6 @@ static int can_bind(FAR struct socket *psock,
 #endif
 
   return OK;
-}
-
-/****************************************************************************
- * Name: can_connect
- *
- * Description:
- *   Perform a can connection
- *
- * Input Parameters:
- *   psock   A reference to the socket structure of the socket
- *           to be connected
- *   addr    The address of the remote server to connect to
- *   addrlen Length of address buffer
- *
- * Returned Value:
- *   None
- *
- * Assumptions:
- *
- ****************************************************************************/
-
-static int can_connect(FAR struct socket *psock,
-                       FAR const struct sockaddr *addr,
-                       socklen_t addrlen)
-{
-  return -EOPNOTSUPP;
 }
 
 /****************************************************************************

--- a/net/can/can_sockif.c
+++ b/net/can/can_sockif.c
@@ -53,8 +53,6 @@ static sockcaps_t can_sockcaps(FAR struct socket *psock);
 static void can_addref(FAR struct socket *psock);
 static int  can_bind(FAR struct socket *psock,
               FAR const struct sockaddr *addr, socklen_t addrlen);
-static int  can_getpeername(FAR struct socket *psock,
-              FAR struct sockaddr *addr, FAR socklen_t *addrlen);
 static int  can_listen(FAR struct socket *psock, int backlog);
 static int  can_connect(FAR struct socket *psock,
               FAR const struct sockaddr *addr, socklen_t addrlen);
@@ -75,7 +73,7 @@ const struct sock_intf_s g_can_sockif =
   can_addref,       /* si_addref */
   can_bind,         /* si_bind */
   NULL,             /* si_getsockname */
-  can_getpeername,  /* si_getpeername */
+  NULL,             /* si_getpeername */
   can_listen,       /* si_listen */
   can_connect,      /* si_connect */
   can_accept,       /* si_accept */
@@ -338,41 +336,6 @@ static int can_bind(FAR struct socket *psock,
 #endif
 
   return OK;
-}
-
-/****************************************************************************
- * Name: can_getpeername
- *
- * Description:
- *   The can_getpeername() function retrieves the remote-connected name
- *   of the specified packet socket, stores this address in the sockaddr
- *   structure pointed to by the 'addr' argument, and stores the length of
- *   this address in the object pointed to by the 'addrlen' argument.
- *
- *   If the actual length of the address is greater than the length of the
- *   supplied sockaddr structure, the stored address will be truncated.
- *
- *   If the socket has not been bound to a local name, the value stored in
- *   the object pointed to by address is unspecified.
- *
- * Parameters:
- *   psock    Socket structure of the socket to be queried
- *   addr     sockaddr structure to receive data [out]
- *   addrlen  Length of sockaddr structure [in/out]
- *
- * Returned Value:
- *   On success, 0 is returned, the 'addr' argument points to the address
- *   of the socket, and the 'addrlen' argument points to the length of the
- *   address.  Otherwise, a negated errno value is returned.  See
- *   getpeername() for the list of appropriate error numbers.
- *
- ****************************************************************************/
-
-static int can_getpeername(FAR struct socket *psock,
-                           FAR struct sockaddr *addr,
-                           FAR socklen_t *addrlen)
-{
-  return -EOPNOTSUPP;
 }
 
 /****************************************************************************

--- a/net/can/can_sockif.c
+++ b/net/can/can_sockif.c
@@ -53,8 +53,6 @@ static sockcaps_t can_sockcaps(FAR struct socket *psock);
 static void can_addref(FAR struct socket *psock);
 static int  can_bind(FAR struct socket *psock,
               FAR const struct sockaddr *addr, socklen_t addrlen);
-static int  can_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
-              FAR socklen_t *addrlen, FAR struct socket *newsock);
 static int  can_poll_local(FAR struct socket *psock, FAR struct pollfd *fds,
               bool setup);
 static int can_close(FAR struct socket *psock);
@@ -73,7 +71,7 @@ const struct sock_intf_s g_can_sockif =
   NULL,             /* si_getpeername */
   NULL,             /* si_listen */
   NULL,             /* si_connect */
-  can_accept,       /* si_accept */
+  NULL,             /* si_accept */
   can_poll_local,   /* si_poll */
   can_sendmsg,      /* si_sendmsg */
   can_recvmsg,      /* si_recvmsg */
@@ -333,56 +331,6 @@ static int can_bind(FAR struct socket *psock,
 #endif
 
   return OK;
-}
-
-/****************************************************************************
- * Name: can_accept
- *
- * Description:
- *   The can_accept function is used with connection-based socket
- *   types (SOCK_STREAM, SOCK_SEQPACKET and SOCK_RDM). It extracts the first
- *   connection request on the queue of pending connections, creates a new
- *   connected socket with mostly the same properties as 'sockfd', and
- *   allocates a new socket descriptor for the socket, which is returned. The
- *   newly created socket is no longer in the listening state. The original
- *   socket 'sockfd' is unaffected by this call.  Per file descriptor flags
- *   are not inherited across an inet_accept.
- *
- *   The 'sockfd' argument is a socket descriptor that has been created with
- *   socket(), bound to a local address with bind(), and is listening for
- *   connections after a call to listen().
- *
- *   On return, the 'addr' structure is filled in with the address of the
- *   connecting entity. The 'addrlen' argument initially contains the size
- *   of the structure pointed to by 'addr'; on return it will contain the
- *   actual length of the address returned.
- *
- *   If no pending connections are present on the queue, and the socket is
- *   not marked as non-blocking, inet_accept blocks the caller until a
- *   connection is present. If the socket is marked non-blocking and no
- *   pending connections are present on the queue, inet_accept returns
- *   EAGAIN.
- *
- * Input Parameters:
- *   psock    Reference to the listening socket structure
- *   addr     Receives the address of the connecting client
- *   addrlen  Input:  Allocated size of 'addr'
- *            Return: Actual size returned size of 'addr'
- *   newsock  Location to return the accepted socket information.
- *
- * Returned Value:
- *   Returns 0 (OK) on success.  On failure, it returns a negated errno
- *   value.  See accept() for a description of the appropriate error value.
- *
- * Assumptions:
- *   The network is locked.
- *
- ****************************************************************************/
-
-static int can_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
-                      FAR socklen_t *addrlen, FAR struct socket *newsock)
-{
-  return -EOPNOTSUPP;
 }
 
 /****************************************************************************

--- a/net/can/can_sockif.c
+++ b/net/can/can_sockif.c
@@ -53,8 +53,6 @@ static sockcaps_t can_sockcaps(FAR struct socket *psock);
 static void can_addref(FAR struct socket *psock);
 static int  can_bind(FAR struct socket *psock,
               FAR const struct sockaddr *addr, socklen_t addrlen);
-static int  can_getsockname(FAR struct socket *psock,
-              FAR struct sockaddr *addr, FAR socklen_t *addrlen);
 static int  can_getpeername(FAR struct socket *psock,
               FAR struct sockaddr *addr, FAR socklen_t *addrlen);
 static int  can_listen(FAR struct socket *psock, int backlog);
@@ -76,7 +74,7 @@ const struct sock_intf_s g_can_sockif =
   can_sockcaps,     /* si_sockcaps */
   can_addref,       /* si_addref */
   can_bind,         /* si_bind */
-  can_getsockname,  /* si_getsockname */
+  NULL,             /* si_getsockname */
   can_getpeername,  /* si_getpeername */
   can_listen,       /* si_listen */
   can_connect,      /* si_connect */
@@ -340,35 +338,6 @@ static int can_bind(FAR struct socket *psock,
 #endif
 
   return OK;
-}
-
-/****************************************************************************
- * Name: can_getsockname
- *
- * Description:
- *   The getsockname() function retrieves the locally-bound name of the
- *   specified socket, stores this address in the sockaddr structure pointed
- *   to by the 'addr' argument, and stores the length of this address in the
- *   object pointed to by the 'addrlen' argument.
- *
- *   If the actual length of the address is greater than the length of the
- *   supplied sockaddr structure, the stored address will be truncated.
- *
- *   If the socket has not been bound to a local name, the value stored in
- *   the object pointed to by address is unspecified.
- *
- * Input Parameters:
- *   conn     CAN socket connection structure
- *   addr     sockaddr structure to receive data [out]
- *   addrlen  Length of sockaddr structure [in/out]
- *
- ****************************************************************************/
-
-static int can_getsockname(FAR struct socket *psock,
-                           FAR struct sockaddr *addr,
-                           FAR socklen_t *addrlen)
-{
-  return -EAFNOSUPPORT;
 }
 
 /****************************************************************************

--- a/net/icmp/icmp_sockif.c
+++ b/net/icmp/icmp_sockif.c
@@ -47,7 +47,6 @@
 static int        icmp_setup(FAR struct socket *psock);
 static sockcaps_t icmp_sockcaps(FAR struct socket *psock);
 static void       icmp_addref(FAR struct socket *psock);
-static int        icmp_listen(FAR struct socket *psock, int backlog);
 static int        icmp_connect(FAR struct socket *psock,
                     FAR const struct sockaddr *addr, socklen_t addrlen);
 static int        icmp_accept(FAR struct socket *psock,
@@ -69,7 +68,7 @@ const struct sock_intf_s g_icmp_sockif =
   NULL,             /* si_bind */
   NULL,             /* si_getsockname */
   NULL,             /* si_getpeername */
-  icmp_listen,      /* si_listen */
+  NULL,             /* si_listen */
   icmp_connect,     /* si_connect */
   icmp_accept,      /* si_accept */
   icmp_netpoll,     /* si_poll */
@@ -271,36 +270,6 @@ static int icmp_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
                       FAR socklen_t *addrlen, FAR struct socket *newsock)
 {
   return -EAFNOSUPPORT;
-}
-
-/****************************************************************************
- * Name: icmp_listen
- *
- * Description:
- *   To accept connections, a socket is first created with psock_socket(), a
- *   willingness to accept incoming connections and a queue limit for
- *   incoming connections are specified with psock_listen(), and then the
- *   connections are accepted with psock_accept().  For the case of raw
- *   packet sockets, psock_listen() calls this function.  The psock_listen()
- *   call applies only to sockets of type SOCK_STREAM or SOCK_SEQPACKET.
- *
- * Input Parameters:
- *   psock    Reference to an internal, boound socket structure.
- *   backlog  The maximum length the queue of pending connections may grow.
- *            If a connection request arrives with the queue full, the client
- *            may receive an error with an indication of ECONNREFUSED or,
- *            if the underlying protocol supports retransmission, the request
- *            may be ignored so that retries succeed.
- *
- * Returned Value:
- *   On success, zero is returned. On error, a negated errno value is
- *   returned.  See listen() for the set of appropriate error values.
- *
- ****************************************************************************/
-
-int icmp_listen(FAR struct socket *psock, int backlog)
-{
-  return -EOPNOTSUPP;
 }
 
 /****************************************************************************

--- a/net/icmp/icmp_sockif.c
+++ b/net/icmp/icmp_sockif.c
@@ -47,9 +47,6 @@
 static int        icmp_setup(FAR struct socket *psock);
 static sockcaps_t icmp_sockcaps(FAR struct socket *psock);
 static void       icmp_addref(FAR struct socket *psock);
-static int        icmp_accept(FAR struct socket *psock,
-                    FAR struct sockaddr *addr, FAR socklen_t *addrlen,
-                    FAR struct socket *newsock);
 static int        icmp_netpoll(FAR struct socket *psock,
                     FAR struct pollfd *fds, bool setup);
 static int        icmp_close(FAR struct socket *psock);
@@ -68,7 +65,7 @@ const struct sock_intf_s g_icmp_sockif =
   NULL,             /* si_getpeername */
   NULL,             /* si_listen */
   NULL,             /* si_connect */
-  icmp_accept,      /* si_accept */
+  NULL,             /* si_accept */
   icmp_netpoll,     /* si_poll */
   icmp_sendmsg,     /* si_sendmsg */
   icmp_recvmsg,     /* si_recvmsg */
@@ -180,56 +177,6 @@ static void icmp_addref(FAR struct socket *psock)
   conn = psock->s_conn;
   DEBUGASSERT(conn->crefs > 0 && conn->crefs < 255);
   conn->crefs++;
-}
-
-/****************************************************************************
- * Name: icmp_accept
- *
- * Description:
- *   The icmp_accept function is used with connection-based socket types
- *   (SOCK_STREAM, SOCK_SEQPACKET and SOCK_RDM). It extracts the first
- *   connection request on the queue of pending connections, creates a new
- *   connected socket with mostly the same properties as 'sockfd', and
- *   allocates a new socket descriptor for the socket, which is returned. The
- *   newly created socket is no longer in the listening state. The original
- *   socket 'sockfd' is unaffected by this call.  Per file descriptor flags
- *   are not inherited across an icmp_accept.
- *
- *   The 'sockfd' argument is a socket descriptor that has been created with
- *   socket(), bound to a local address with bind(), and is listening for
- *   connections after a call to listen().
- *
- *   On return, the 'addr' structure is filled in with the address of the
- *   connecting entity. The 'addrlen' argument initially contains the size
- *   of the structure pointed to by 'addr'; on return it will contain the
- *   actual length of the address returned.
- *
- *   If no pending connections are present on the queue, and the socket is
- *   not marked as non-blocking, icmp_accept blocks the caller until a
- *   connection is present. If the socket is marked non-blocking and no
- *   pending connections are present on the queue, icmp_accept returns
- *   EAGAIN.
- *
- * Input Parameters:
- *   psock    Reference to the listening socket structure
- *   addr     Receives the address of the connecting client
- *   addrlen  Input: allocated size of 'addr',
- *            Return: returned size of 'addr'
- *   newsock  Location to return the accepted socket information.
- *
- * Returned Value:
- *   Returns 0 (OK) on success.  On failure, it returns a negated errno
- *   value.  See accept() for a description of the appropriate error value.
- *
- * Assumptions:
- *   The network is locked.
- *
- ****************************************************************************/
-
-static int icmp_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
-                      FAR socklen_t *addrlen, FAR struct socket *newsock)
-{
-  return -EAFNOSUPPORT;
 }
 
 /****************************************************************************

--- a/net/icmp/icmp_sockif.c
+++ b/net/icmp/icmp_sockif.c
@@ -47,8 +47,6 @@
 static int        icmp_setup(FAR struct socket *psock);
 static sockcaps_t icmp_sockcaps(FAR struct socket *psock);
 static void       icmp_addref(FAR struct socket *psock);
-static int        icmp_getpeername(FAR struct socket *psock,
-                    FAR struct sockaddr *addr, FAR socklen_t *addrlen);
 static int        icmp_listen(FAR struct socket *psock, int backlog);
 static int        icmp_connect(FAR struct socket *psock,
                     FAR const struct sockaddr *addr, socklen_t addrlen);
@@ -70,7 +68,7 @@ const struct sock_intf_s g_icmp_sockif =
   icmp_addref,      /* si_addref */
   NULL,             /* si_bind */
   NULL,             /* si_getsockname */
-  icmp_getpeername, /* si_getpeername */
+  NULL,             /* si_getpeername */
   icmp_listen,      /* si_listen */
   icmp_connect,     /* si_connect */
   icmp_accept,      /* si_accept */
@@ -271,40 +269,6 @@ static int icmp_connect(FAR struct socket *psock,
 
 static int icmp_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
                       FAR socklen_t *addrlen, FAR struct socket *newsock)
-{
-  return -EAFNOSUPPORT;
-}
-
-/****************************************************************************
- * Name: icmp_getpeername
- *
- * Description:
- *   The icmp_getpeername() function retrieves the remote-connected name of
- *   the specified packet socket, stores this address in the sockaddr
- *   structure pointed to by the 'addr' argument, and stores the length of
- *   this address in the object pointed to by the 'addrlen' argument.
- *
- *   If the actual length of the address is greater than the length of the
- *   supplied sockaddr structure, the stored address will be truncated.
- *
- *   If the socket has not been bound to a local name, the value stored in
- *   the object pointed to by address is unspecified.
- *
- * Parameters:
- *   psock    Socket structure of the socket to be queried
- *   addr     sockaddr structure to receive data [out]
- *   addrlen  Length of sockaddr structure [in/out]
- *
- * Returned Value:
- *   On success, 0 is returned, the 'addr' argument points to the address
- *   of the socket, and the 'addrlen' argument points to the length of the
- *   address.  Otherwise, a negated errno value is returned.  See
- *   getpeername() for the list of appropriate error numbers.
- *
- ****************************************************************************/
-
-static int icmp_getpeername(FAR struct socket *psock,
-                           FAR struct sockaddr *addr, FAR socklen_t *addrlen)
 {
   return -EAFNOSUPPORT;
 }

--- a/net/icmp/icmp_sockif.c
+++ b/net/icmp/icmp_sockif.c
@@ -47,8 +47,6 @@
 static int        icmp_setup(FAR struct socket *psock);
 static sockcaps_t icmp_sockcaps(FAR struct socket *psock);
 static void       icmp_addref(FAR struct socket *psock);
-static int        icmp_connect(FAR struct socket *psock,
-                    FAR const struct sockaddr *addr, socklen_t addrlen);
 static int        icmp_accept(FAR struct socket *psock,
                     FAR struct sockaddr *addr, FAR socklen_t *addrlen,
                     FAR struct socket *newsock);
@@ -69,7 +67,7 @@ const struct sock_intf_s g_icmp_sockif =
   NULL,             /* si_getsockname */
   NULL,             /* si_getpeername */
   NULL,             /* si_listen */
-  icmp_connect,     /* si_connect */
+  NULL,             /* si_connect */
   icmp_accept,      /* si_accept */
   icmp_netpoll,     /* si_poll */
   icmp_sendmsg,     /* si_sendmsg */
@@ -182,44 +180,6 @@ static void icmp_addref(FAR struct socket *psock)
   conn = psock->s_conn;
   DEBUGASSERT(conn->crefs > 0 && conn->crefs < 255);
   conn->crefs++;
-}
-
-/****************************************************************************
- * Name: icmp_connect
- *
- * Description:
- *   icmp_connect() connects the local socket referred to by the structure
- *   'psock' to the address specified by 'addr'. The addrlen argument
- *   specifies the size of 'addr'.  The format of the address in 'addr' is
- *   determined by the address space of the socket 'psock'.
- *
- *   If the socket 'psock' is of type SOCK_DGRAM then 'addr' is the address
- *   to which datagrams are sent by default, and the only address from which
- *   datagrams are received. If the socket is of type SOCK_STREAM or
- *   SOCK_SEQPACKET, this call attempts to make a connection to the socket
- *   that is bound to the address specified by 'addr'.
- *
- *   Generally, connection-based protocol sockets may successfully
- *   icmp_connect() only once; connectionless protocol sockets may use
- *   icmp_connect() multiple times to change their association.
- *   Connectionless sockets may dissolve the association by connecting to
- *   an address with the sa_family member of sockaddr set to AF_UNSPEC.
- *
- * Input Parameters:
- *   psock     Pointer to a socket structure initialized by psock_socket()
- *   addr      Server address (form depends on type of socket)
- *   addrlen   Length of actual 'addr'
- *
- * Returned Value:
- *   0 on success; a negated errno value on failure.  See connect() for the
- *   list of appropriate errno values to be returned.
- *
- ****************************************************************************/
-
-static int icmp_connect(FAR struct socket *psock,
-                       FAR const struct sockaddr *addr, socklen_t addrlen)
-{
-  return -EAFNOSUPPORT;
 }
 
 /****************************************************************************

--- a/net/icmp/icmp_sockif.c
+++ b/net/icmp/icmp_sockif.c
@@ -47,8 +47,6 @@
 static int        icmp_setup(FAR struct socket *psock);
 static sockcaps_t icmp_sockcaps(FAR struct socket *psock);
 static void       icmp_addref(FAR struct socket *psock);
-static int        icmp_getsockname(FAR struct socket *psock,
-                    FAR struct sockaddr *addr, FAR socklen_t *addrlen);
 static int        icmp_getpeername(FAR struct socket *psock,
                     FAR struct sockaddr *addr, FAR socklen_t *addrlen);
 static int        icmp_listen(FAR struct socket *psock, int backlog);
@@ -71,7 +69,7 @@ const struct sock_intf_s g_icmp_sockif =
   icmp_sockcaps,    /* si_sockcaps */
   icmp_addref,      /* si_addref */
   NULL,             /* si_bind */
-  icmp_getsockname, /* si_getsockname */
+  NULL,             /* si_getsockname */
   icmp_getpeername, /* si_getpeername */
   icmp_listen,      /* si_listen */
   icmp_connect,     /* si_connect */
@@ -273,40 +271,6 @@ static int icmp_connect(FAR struct socket *psock,
 
 static int icmp_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
                       FAR socklen_t *addrlen, FAR struct socket *newsock)
-{
-  return -EAFNOSUPPORT;
-}
-
-/****************************************************************************
- * Name: icmp_getsockname
- *
- * Description:
- *   The icmp_getsockname() function retrieves the locally-bound name of the
- *   specified packet socket, stores this address in the sockaddr structure
- *   pointed to by the 'addr' argument, and stores the length of this
- *   address in the object pointed to by the 'addrlen' argument.
- *
- *   If the actual length of the address is greater than the length of the
- *   supplied sockaddr structure, the stored address will be truncated.
- *
- *   If the socket has not been bound to a local name, the value stored in
- *   the object pointed to by address is unspecified.
- *
- * Input Parameters:
- *   psock    Socket structure of the socket to be queried
- *   addr     sockaddr structure to receive data [out]
- *   addrlen  Length of sockaddr structure [in/out]
- *
- * Returned Value:
- *   On success, 0 is returned, the 'addr' argument points to the address
- *   of the socket, and the 'addrlen' argument points to the length of the
- *   address.  Otherwise, a negated errno value is returned.  See
- *   getsockname() for the list of appropriate error numbers.
- *
- ****************************************************************************/
-
-static int icmp_getsockname(FAR struct socket *psock,
-                           FAR struct sockaddr *addr, FAR socklen_t *addrlen)
 {
   return -EAFNOSUPPORT;
 }

--- a/net/icmp/icmp_sockif.c
+++ b/net/icmp/icmp_sockif.c
@@ -47,8 +47,6 @@
 static int        icmp_setup(FAR struct socket *psock);
 static sockcaps_t icmp_sockcaps(FAR struct socket *psock);
 static void       icmp_addref(FAR struct socket *psock);
-static int        icmp_bind(FAR struct socket *psock,
-                    FAR const struct sockaddr *addr, socklen_t addrlen);
 static int        icmp_getsockname(FAR struct socket *psock,
                     FAR struct sockaddr *addr, FAR socklen_t *addrlen);
 static int        icmp_getpeername(FAR struct socket *psock,
@@ -72,7 +70,7 @@ const struct sock_intf_s g_icmp_sockif =
   icmp_setup,       /* si_setup */
   icmp_sockcaps,    /* si_sockcaps */
   icmp_addref,      /* si_addref */
-  icmp_bind,        /* si_bind */
+  NULL,             /* si_bind */
   icmp_getsockname, /* si_getsockname */
   icmp_getpeername, /* si_getpeername */
   icmp_listen,      /* si_listen */
@@ -277,35 +275,6 @@ static int icmp_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
                       FAR socklen_t *addrlen, FAR struct socket *newsock)
 {
   return -EAFNOSUPPORT;
-}
-
-/****************************************************************************
- * Name: icmp_bind
- *
- * Description:
- *   icmp_bind() gives the socket 'psock' the local address 'addr'.  'addr'
- *   is 'addrlen' bytes long.  Traditionally, this is called "assigning a
- *   name to a socket."  When a socket is created with socket(), it exists
- *   in a name space (address family) but has no name assigned.
- *
- * Input Parameters:
- *   psock    Socket structure of the socket to bind
- *   addr     Socket local address
- *   addrlen  Length of 'addr'
- *
- * Returned Value:
- *   0 on success;  A negated errno value is returned on failure.  See
- *   bind() for a list a appropriate error values.
- *
- ****************************************************************************/
-
-static int icmp_bind(FAR struct socket *psock,
-                     FAR const struct sockaddr *addr,
-                     socklen_t addrlen)
-{
-  /* An ICMP socket cannot be bound to a local address */
-
-  return -EBADF;
 }
 
 /****************************************************************************

--- a/net/icmpv6/icmpv6_sockif.c
+++ b/net/icmpv6/icmpv6_sockif.c
@@ -47,8 +47,6 @@
 static int        icmpv6_setup(FAR struct socket *psock);
 static sockcaps_t icmpv6_sockcaps(FAR struct socket *psock);
 static void       icmpv6_addref(FAR struct socket *psock);
-static int        icmpv6_getpeername(FAR struct socket *psock,
-                    FAR struct sockaddr *addr, FAR socklen_t *addrlen);
 static int        icmpv6_listen(FAR struct socket *psock, int backlog);
 static int        icmpv6_connect(FAR struct socket *psock,
                     FAR const struct sockaddr *addr, socklen_t addrlen);
@@ -70,7 +68,7 @@ const struct sock_intf_s g_icmpv6_sockif =
   icmpv6_addref,      /* si_addref */
   NULL,               /* si_bind */
   NULL,               /* si_getsockname */
-  icmpv6_getpeername, /* si_getpeername */
+  NULL,               /* si_getpeername */
   icmpv6_listen,      /* si_listen */
   icmpv6_connect,     /* si_connect */
   icmpv6_accept,      /* si_accept */
@@ -271,40 +269,6 @@ static int icmpv6_connect(FAR struct socket *psock,
 
 static int icmpv6_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
                       FAR socklen_t *addrlen, FAR struct socket *newsock)
-{
-  return -EAFNOSUPPORT;
-}
-
-/****************************************************************************
- * Name: icmpv6_getpeername
- *
- * Description:
- *   The icmpv6_getpeername() function retrieves the remote-connected name of
- *   the specified packet socket, stores this address in the sockaddr
- *   structure pointed to by the 'addr' argument, and stores the length of
- *   this address in the object pointed to by the 'addrlen' argument.
- *
- *   If the actual length of the address is greater than the length of the
- *   supplied sockaddr structure, the stored address will be truncated.
- *
- *   If the socket has not been bound to a local name, the value stored in
- *   the object pointed to by address is unspecified.
- *
- * Parameters:
- *   psock    Socket structure of the socket to be queried
- *   addr     sockaddr structure to receive data [out]
- *   addrlen  Length of sockaddr structure [in/out]
- *
- * Returned Value:
- *   On success, 0 is returned, the 'addr' argument points to the address
- *   of the socket, and the 'addrlen' argument points to the length of the
- *   address.  Otherwise, a negated errno value is returned.  See
- *   getpeername() for the list of appropriate error numbers.
- *
- ****************************************************************************/
-
-static int icmpv6_getpeername(FAR struct socket *psock,
-                           FAR struct sockaddr *addr, FAR socklen_t *addrlen)
 {
   return -EAFNOSUPPORT;
 }

--- a/net/icmpv6/icmpv6_sockif.c
+++ b/net/icmpv6/icmpv6_sockif.c
@@ -47,9 +47,6 @@
 static int        icmpv6_setup(FAR struct socket *psock);
 static sockcaps_t icmpv6_sockcaps(FAR struct socket *psock);
 static void       icmpv6_addref(FAR struct socket *psock);
-static int        icmpv6_accept(FAR struct socket *psock,
-                    FAR struct sockaddr *addr, FAR socklen_t *addrlen,
-                    FAR struct socket *newsock);
 static int        icmpv6_netpoll(FAR struct socket *psock,
                     FAR struct pollfd *fds, bool setup);
 static int        icmpv6_close(FAR struct socket *psock);
@@ -68,7 +65,7 @@ const struct sock_intf_s g_icmpv6_sockif =
   NULL,               /* si_getpeername */
   NULL,               /* si_listen */
   NULL,               /* si_connect */
-  icmpv6_accept,      /* si_accept */
+  NULL,               /* si_accept */
   icmpv6_netpoll,     /* si_poll */
   icmpv6_sendmsg,     /* si_sendmsg */
   icmpv6_recvmsg,     /* si_recvmsg */
@@ -180,56 +177,6 @@ static void icmpv6_addref(FAR struct socket *psock)
   conn = psock->s_conn;
   DEBUGASSERT(conn->crefs > 0 && conn->crefs < 255);
   conn->crefs++;
-}
-
-/****************************************************************************
- * Name: icmpv6_accept
- *
- * Description:
- *   The icmpv6_accept function is used with connection-based socket types
- *   (SOCK_STREAM, SOCK_SEQPACKET and SOCK_RDM). It extracts the first
- *   connection request on the queue of pending connections, creates a new
- *   connected socket with mostly the same properties as 'sockfd', and
- *   allocates a new socket descriptor for the socket, which is returned. The
- *   newly created socket is no longer in the listening state. The original
- *   socket 'sockfd' is unaffected by this call.  Per file descriptor flags
- *   are not inherited across an icmpv6_accept.
- *
- *   The 'sockfd' argument is a socket descriptor that has been created with
- *   socket(), bound to a local address with bind(), and is listening for
- *   connections after a call to listen().
- *
- *   On return, the 'addr' structure is filled in with the address of the
- *   connecting entity. The 'addrlen' argument initially contains the size
- *   of the structure pointed to by 'addr'; on return it will contain the
- *   actual length of the address returned.
- *
- *   If no pending connections are present on the queue, and the socket is
- *   not marked as non-blocking, icmpv6_accept blocks the caller until a
- *   connection is present. If the socket is marked non-blocking and no
- *   pending connections are present on the queue, icmpv6_accept returns
- *   EAGAIN.
- *
- * Input Parameters:
- *   psock    Reference to the listening socket structure
- *   addr     Receives the address of the connecting client
- *   addrlen  Input: allocated size of 'addr',
- *            Return: returned size of 'addr'
- *   newsock  Location to return the accepted socket information.
- *
- * Returned Value:
- *   Returns 0 (OK) on success.  On failure, it returns a negated errno
- *   value.  See accept() for a description of the appropriate error value.
- *
- * Assumptions:
- *   The network is locked.
- *
- ****************************************************************************/
-
-static int icmpv6_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
-                      FAR socklen_t *addrlen, FAR struct socket *newsock)
-{
-  return -EAFNOSUPPORT;
 }
 
 /****************************************************************************

--- a/net/icmpv6/icmpv6_sockif.c
+++ b/net/icmpv6/icmpv6_sockif.c
@@ -47,7 +47,6 @@
 static int        icmpv6_setup(FAR struct socket *psock);
 static sockcaps_t icmpv6_sockcaps(FAR struct socket *psock);
 static void       icmpv6_addref(FAR struct socket *psock);
-static int        icmpv6_listen(FAR struct socket *psock, int backlog);
 static int        icmpv6_connect(FAR struct socket *psock,
                     FAR const struct sockaddr *addr, socklen_t addrlen);
 static int        icmpv6_accept(FAR struct socket *psock,
@@ -69,7 +68,7 @@ const struct sock_intf_s g_icmpv6_sockif =
   NULL,               /* si_bind */
   NULL,               /* si_getsockname */
   NULL,               /* si_getpeername */
-  icmpv6_listen,      /* si_listen */
+  NULL,               /* si_listen */
   icmpv6_connect,     /* si_connect */
   icmpv6_accept,      /* si_accept */
   icmpv6_netpoll,     /* si_poll */
@@ -271,36 +270,6 @@ static int icmpv6_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
                       FAR socklen_t *addrlen, FAR struct socket *newsock)
 {
   return -EAFNOSUPPORT;
-}
-
-/****************************************************************************
- * Name: icmpv6_listen
- *
- * Description:
- *   To accept connections, a socket is first created with psock_socket(), a
- *   willingness to accept incoming connections and a queue limit for
- *   incoming connections are specified with psock_listen(), and then the
- *   connections are accepted with psock_accept().  For the case of raw
- *   packet sockets, psock_listen() calls this function.  The psock_listen()
- *   call applies only to sockets of type SOCK_STREAM or SOCK_SEQPACKET.
- *
- * Input Parameters:
- *   psock    Reference to an internal, boound socket structure.
- *   backlog  The maximum length the queue of pending connections may grow.
- *            If a connection request arrives with the queue full, the client
- *            may receive an error with an indication of ECONNREFUSED or,
- *            if the underlying protocol supports retransmission, the request
- *            may be ignored so that retries succeed.
- *
- * Returned Value:
- *   On success, zero is returned. On error, a negated errno value is
- *   returned.  See listen() for the set of appropriate error values.
- *
- ****************************************************************************/
-
-int icmpv6_listen(FAR struct socket *psock, int backlog)
-{
-  return -EOPNOTSUPP;
 }
 
 /****************************************************************************

--- a/net/icmpv6/icmpv6_sockif.c
+++ b/net/icmpv6/icmpv6_sockif.c
@@ -47,8 +47,6 @@
 static int        icmpv6_setup(FAR struct socket *psock);
 static sockcaps_t icmpv6_sockcaps(FAR struct socket *psock);
 static void       icmpv6_addref(FAR struct socket *psock);
-static int        icmpv6_getsockname(FAR struct socket *psock,
-                    FAR struct sockaddr *addr, FAR socklen_t *addrlen);
 static int        icmpv6_getpeername(FAR struct socket *psock,
                     FAR struct sockaddr *addr, FAR socklen_t *addrlen);
 static int        icmpv6_listen(FAR struct socket *psock, int backlog);
@@ -71,7 +69,7 @@ const struct sock_intf_s g_icmpv6_sockif =
   icmpv6_sockcaps,    /* si_sockcaps */
   icmpv6_addref,      /* si_addref */
   NULL,               /* si_bind */
-  icmpv6_getsockname, /* si_getsockname */
+  NULL,               /* si_getsockname */
   icmpv6_getpeername, /* si_getpeername */
   icmpv6_listen,      /* si_listen */
   icmpv6_connect,     /* si_connect */
@@ -273,40 +271,6 @@ static int icmpv6_connect(FAR struct socket *psock,
 
 static int icmpv6_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
                       FAR socklen_t *addrlen, FAR struct socket *newsock)
-{
-  return -EAFNOSUPPORT;
-}
-
-/****************************************************************************
- * Name: icmpv6_getsockname
- *
- * Description:
- *   The icmpv6_getsockname() function retrieves the locally-bound name of
- *   the specified packet socket, stores this address in the sockaddr
- *   structure pointed to by the 'addr' argument, and stores the length of
- *   this address in the object pointed to by the 'addrlen' argument.
- *
- *   If the actual length of the address is greater than the length of the
- *   supplied sockaddr structure, the stored address will be truncated.
- *
- *   If the socket has not been bound to a local name, the value stored in
- *   the object pointed to by address is unspecified.
- *
- * Input Parameters:
- *   psock    Socket structure of the socket to be queried
- *   addr     sockaddr structure to receive data [out]
- *   addrlen  Length of sockaddr structure [in/out]
- *
- * Returned Value:
- *   On success, 0 is returned, the 'addr' argument points to the address
- *   of the socket, and the 'addrlen' argument points to the length of the
- *   address.  Otherwise, a negated errno value is returned.  See
- *   getsockname() for the list of appropriate error numbers.
- *
- ****************************************************************************/
-
-static int icmpv6_getsockname(FAR struct socket *psock,
-                           FAR struct sockaddr *addr, FAR socklen_t *addrlen)
 {
   return -EAFNOSUPPORT;
 }

--- a/net/icmpv6/icmpv6_sockif.c
+++ b/net/icmpv6/icmpv6_sockif.c
@@ -47,8 +47,6 @@
 static int        icmpv6_setup(FAR struct socket *psock);
 static sockcaps_t icmpv6_sockcaps(FAR struct socket *psock);
 static void       icmpv6_addref(FAR struct socket *psock);
-static int        icmpv6_connect(FAR struct socket *psock,
-                    FAR const struct sockaddr *addr, socklen_t addrlen);
 static int        icmpv6_accept(FAR struct socket *psock,
                     FAR struct sockaddr *addr, FAR socklen_t *addrlen,
                     FAR struct socket *newsock);
@@ -69,7 +67,7 @@ const struct sock_intf_s g_icmpv6_sockif =
   NULL,               /* si_getsockname */
   NULL,               /* si_getpeername */
   NULL,               /* si_listen */
-  icmpv6_connect,     /* si_connect */
+  NULL,               /* si_connect */
   icmpv6_accept,      /* si_accept */
   icmpv6_netpoll,     /* si_poll */
   icmpv6_sendmsg,     /* si_sendmsg */
@@ -182,44 +180,6 @@ static void icmpv6_addref(FAR struct socket *psock)
   conn = psock->s_conn;
   DEBUGASSERT(conn->crefs > 0 && conn->crefs < 255);
   conn->crefs++;
-}
-
-/****************************************************************************
- * Name: icmpv6_connect
- *
- * Description:
- *   icmpv6_connect() connects the local socket referred to by the structure
- *   'psock' to the address specified by 'addr'. The addrlen argument
- *   specifies the size of 'addr'.  The format of the address in 'addr' is
- *   determined by the address space of the socket 'psock'.
- *
- *   If the socket 'psock' is of type SOCK_DGRAM then 'addr' is the address
- *   to which datagrams are sent by default, and the only address from which
- *   datagrams are received. If the socket is of type SOCK_STREAM or
- *   SOCK_SEQPACKET, this call attempts to make a connection to the socket
- *   that is bound to the address specified by 'addr'.
- *
- *   Generally, connection-based protocol sockets may successfully
- *   icmpv6_connect() only once; connectionless protocol sockets may use
- *   icmpv6_connect() multiple times to change their association.
- *   Connectionless sockets may dissolve the association by connecting to
- *   an address with the sa_family member of sockaddr set to AF_UNSPEC.
- *
- * Input Parameters:
- *   psock     Pointer to a socket structure initialized by psock_socket()
- *   addr      Server address (form depends on type of socket)
- *   addrlen   Length of actual 'addr'
- *
- * Returned Value:
- *   0 on success; a negated errno value on failure.  See connect() for the
- *   list of appropriate errno values to be returned.
- *
- ****************************************************************************/
-
-static int icmpv6_connect(FAR struct socket *psock,
-                       FAR const struct sockaddr *addr, socklen_t addrlen)
-{
-  return -EAFNOSUPPORT;
 }
 
 /****************************************************************************

--- a/net/icmpv6/icmpv6_sockif.c
+++ b/net/icmpv6/icmpv6_sockif.c
@@ -47,8 +47,6 @@
 static int        icmpv6_setup(FAR struct socket *psock);
 static sockcaps_t icmpv6_sockcaps(FAR struct socket *psock);
 static void       icmpv6_addref(FAR struct socket *psock);
-static int        icmpv6_bind(FAR struct socket *psock,
-                    FAR const struct sockaddr *addr, socklen_t addrlen);
 static int        icmpv6_getsockname(FAR struct socket *psock,
                     FAR struct sockaddr *addr, FAR socklen_t *addrlen);
 static int        icmpv6_getpeername(FAR struct socket *psock,
@@ -72,7 +70,7 @@ const struct sock_intf_s g_icmpv6_sockif =
   icmpv6_setup,       /* si_setup */
   icmpv6_sockcaps,    /* si_sockcaps */
   icmpv6_addref,      /* si_addref */
-  icmpv6_bind,        /* si_bind */
+  NULL,               /* si_bind */
   icmpv6_getsockname, /* si_getsockname */
   icmpv6_getpeername, /* si_getpeername */
   icmpv6_listen,      /* si_listen */
@@ -277,35 +275,6 @@ static int icmpv6_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
                       FAR socklen_t *addrlen, FAR struct socket *newsock)
 {
   return -EAFNOSUPPORT;
-}
-
-/****************************************************************************
- * Name: icmpv6_bind
- *
- * Description:
- *   icmpv6_bind() gives the socket 'psock' the local address 'addr'.  'addr'
- *   is 'addrlen' bytes long.  Traditionally, this is called "assigning a
- *   name to a socket."  When a socket is created with socket(), it exists
- *   in a name space (address family) but has no name assigned.
- *
- * Input Parameters:
- *   psock    Socket structure of the socket to bind
- *   addr     Socket local address
- *   addrlen  Length of 'addr'
- *
- * Returned Value:
- *   0 on success;  A negated errno value is returned on failure.  See
- *   bind() for a list a appropriate error values.
- *
- ****************************************************************************/
-
-static int icmpv6_bind(FAR struct socket *psock,
-                       FAR const struct sockaddr *addr,
-                       socklen_t addrlen)
-{
-  /* An ICMPv6 socket cannot be bound to a local address */
-
-  return -EBADF;
 }
 
 /****************************************************************************

--- a/net/ieee802154/ieee802154_sockif.c
+++ b/net/ieee802154/ieee802154_sockif.c
@@ -57,8 +57,6 @@ static int        ieee802154_getpeername(FAR struct socket *psock,
                     FAR struct sockaddr *addr, FAR socklen_t *addrlen);
 static int        ieee802154_connect(FAR struct socket *psock,
                     FAR const struct sockaddr *addr, socklen_t addrlen);
-static int        ieee802154_poll_local(FAR struct socket *psock,
-                    FAR struct pollfd *fds, bool setup);
 static int        ieee802154_close(FAR struct socket *psock);
 
 /****************************************************************************
@@ -76,7 +74,7 @@ const struct sock_intf_s g_ieee802154_sockif =
   NULL,                   /* si_listen */
   ieee802154_connect,     /* si_connect */
   NULL,                   /* si_accept */
-  ieee802154_poll_local,  /* si_poll */
+  NULL,                   /* si_poll */
   ieee802154_sendmsg,     /* si_sendmsg */
   ieee802154_recvmsg,     /* si_recvmsg */
   ieee802154_close        /* si_close */
@@ -488,35 +486,6 @@ static int ieee802154_getpeername(FAR struct socket *psock,
 
   *addrlen = copylen;
   return OK;
-}
-
-/****************************************************************************
- * Name: ieee802154_poll
- *
- * Description:
- *   The standard poll() operation redirects operations on socket descriptors
- *   to net_poll which, indiectly, calls to function.
- *
- * Input Parameters:
- *   psock - An instance of the internal socket structure.
- *   fds   - The structure describing the events to be monitored, OR NULL if
- *           this is a request to stop monitoring events.
- *   setup - true: Setup up the poll; false: Teardown the poll
- *
- * Returned Value:
- *  0: Success; Negated errno on failure
- *
- ****************************************************************************/
-
-static int ieee802154_poll_local(FAR struct socket *psock,
-                                 FAR struct pollfd *fds, bool setup)
-{
-  /* We should need to support some kind of write ahead buffering for this
-   * feature.
-   */
-
-#warning Missing logic
-  return -ENOSYS;
 }
 
 /****************************************************************************

--- a/net/ieee802154/ieee802154_sockif.c
+++ b/net/ieee802154/ieee802154_sockif.c
@@ -57,9 +57,6 @@ static int        ieee802154_getpeername(FAR struct socket *psock,
                     FAR struct sockaddr *addr, FAR socklen_t *addrlen);
 static int        ieee802154_connect(FAR struct socket *psock,
                     FAR const struct sockaddr *addr, socklen_t addrlen);
-static int        ieee802154_accept(FAR struct socket *psock,
-                    FAR struct sockaddr *addr, FAR socklen_t *addrlen,
-                    FAR struct socket *newsock);
 static int        ieee802154_poll_local(FAR struct socket *psock,
                     FAR struct pollfd *fds, bool setup);
 static int        ieee802154_close(FAR struct socket *psock);
@@ -78,7 +75,7 @@ const struct sock_intf_s g_ieee802154_sockif =
   ieee802154_getpeername, /* si_getpeername */
   NULL,                   /* si_listen */
   ieee802154_connect,     /* si_connect */
-  ieee802154_accept,      /* si_accept */
+  NULL,                   /* si_accept */
   ieee802154_poll_local,  /* si_poll */
   ieee802154_sendmsg,     /* si_sendmsg */
   ieee802154_recvmsg,     /* si_recvmsg */
@@ -276,58 +273,6 @@ static int ieee802154_connect(FAR struct socket *psock,
     }
 
   return ret;
-}
-
-/****************************************************************************
- * Name: ieee802154_accept
- *
- * Description:
- *   The ieee802154_accept function is used with connection-based socket
- *   types (SOCK_STREAM, SOCK_SEQPACKET and SOCK_RDM). It extracts the first
- *   connection request on the queue of pending connections, creates a new
- *   connected socket with mostly the same properties as 'sockfd', and
- *   allocates a new socket descriptor for the socket, which is returned. The
- *   newly created socket is no longer in the listening state. The original
- *   socket 'sockfd' is unaffected by this call.  Per file descriptor flags
- *   are not inherited across an ieee802154_accept.
- *
- *   The 'sockfd' argument is a socket descriptor that has been created with
- *   socket(), bound to a local address with bind(), and is listening for
- *   connections after a call to listen().
- *
- *   On return, the 'addr' structure is filled in with the address of the
- *   connecting entity. The 'addrlen' argument initially contains the size
- *   of the structure pointed to by 'addr'; on return it will contain the
- *   actual length of the address returned.
- *
- *   If no pending connections are present on the queue, and the socket is
- *   not marked as non-blocking, ieee802154_accept blocks the caller until a
- *   connection is present. If the socket is marked non-blocking and no
- *   pending connections are present on the queue, ieee802154_accept returns
- *   EAGAIN.
- *
- * Input Parameters:
- *   psock    Reference to the listening socket structure
- *   addr     Receives the address of the connecting client
- *   addrlen  Input: allocated size of 'addr',
- *            Return: returned size of 'addr'
- *   newsock  Location to return the accepted socket information.
- *
- * Returned Value:
- *   Returns 0 (OK) on success.  On failure, it returns a negated errno
- *   value.  See accept() for a description of the appropriate error value.
- *
- * Assumptions:
- *   The network is locked.
- *
- ****************************************************************************/
-
-static int ieee802154_accept(FAR struct socket *psock,
-                             FAR struct sockaddr *addr,
-                             FAR socklen_t *addrlen,
-                             FAR struct socket *newsock)
-{
-  return -EAFNOSUPPORT;
 }
 
 /****************************************************************************

--- a/net/ieee802154/ieee802154_sockif.c
+++ b/net/ieee802154/ieee802154_sockif.c
@@ -55,7 +55,6 @@ static int        ieee802154_getsockname(FAR struct socket *psock,
                     FAR struct sockaddr *addr, FAR socklen_t *addrlen);
 static int        ieee802154_getpeername(FAR struct socket *psock,
                     FAR struct sockaddr *addr, FAR socklen_t *addrlen);
-static int        ieee802154_listen(FAR struct socket *psock, int backlog);
 static int        ieee802154_connect(FAR struct socket *psock,
                     FAR const struct sockaddr *addr, socklen_t addrlen);
 static int        ieee802154_accept(FAR struct socket *psock,
@@ -77,7 +76,7 @@ const struct sock_intf_s g_ieee802154_sockif =
   ieee802154_bind,        /* si_bind */
   ieee802154_getsockname, /* si_getsockname */
   ieee802154_getpeername, /* si_getpeername */
-  ieee802154_listen,      /* si_listen */
+  NULL,                   /* si_listen */
   ieee802154_connect,     /* si_connect */
   ieee802154_accept,      /* si_accept */
   ieee802154_poll_local,  /* si_poll */
@@ -544,36 +543,6 @@ static int ieee802154_getpeername(FAR struct socket *psock,
 
   *addrlen = copylen;
   return OK;
-}
-
-/****************************************************************************
- * Name: ieee802154_listen
- *
- * Description:
- *   To accept connections, a socket is first created with psock_socket(), a
- *   willingness to accept incoming connections and a queue limit for
- *   incoming connections are specified with psock_listen(), and then the
- *   connections are accepted with psock_accept().  For the case of
- *   PF_IEEE802154 sockets, psock_listen() calls this function.  The listen()
- *   call does not apply only to PF_IEEE802154 sockets.
- *
- * Input Parameters:
- *   psock    Reference to an internal, boound socket structure.
- *   backlog  The maximum length the queue of pending connections may grow.
- *            If a connection request arrives with the queue full, the client
- *            may receive an error with an indication of ECONNREFUSED or,
- *            if the underlying protocol supports retransmission, the request
- *            may be ignored so that retries succeed.
- *
- * Returned Value:
- *   On success, zero is returned. On error, a negated errno value is
- *   returned.  See listen() for the set of appropriate error values.
- *
- ****************************************************************************/
-
-int ieee802154_listen(FAR struct socket *psock, int backlog)
-{
-  return -EOPNOTSUPP;
 }
 
 /****************************************************************************

--- a/net/local/local_sockif.c
+++ b/net/local/local_sockif.c
@@ -56,9 +56,6 @@ static int        local_getsockname(FAR struct socket *psock,
                     FAR struct sockaddr *addr, FAR socklen_t *addrlen);
 static int        local_getpeername(FAR struct socket *psock,
                     FAR struct sockaddr *addr, FAR socklen_t *addrlen);
-#ifndef CONFIG_NET_LOCAL_STREAM
-static int        local_listen(FAR struct socket *psock, int backlog);
-#endif
 static int        local_connect(FAR struct socket *psock,
                     FAR const struct sockaddr *addr, socklen_t addrlen);
 #ifndef CONFIG_NET_LOCAL_STREAM
@@ -92,7 +89,11 @@ const struct sock_intf_s g_local_sockif =
   local_bind,        /* si_bind */
   local_getsockname, /* si_getsockname */
   local_getpeername, /* si_getpeername */
+#ifdef CONFIG_NET_LOCAL_STREAM
   local_listen,      /* si_listen */
+#else
+  NULL,              /* si_listen */
+#endif
   local_connect,     /* si_connect */
   local_accept,      /* si_accept */
   local_poll,        /* si_poll */
@@ -546,38 +547,6 @@ static int local_setsockopt(FAR struct socket *psock, int level, int option,
   return -ENOPROTOOPT;
 }
 
-#endif
-
-/****************************************************************************
- * Name: local_listen
- *
- * Description:
- *   To accept connections, a socket is first created with psock_socket(), a
- *   willingness to accept incoming connections and a queue limit for
- *   incoming connections are specified with psock_listen(), and then the
- *   connections are accepted with psock_accept().  For the case of local
- *   unix sockets, psock_listen() calls this function.  The psock_listen()
- *   call applies only to sockets of type SOCK_STREAM or SOCK_SEQPACKET.
- *
- * Input Parameters:
- *   psock    Reference to an internal, boound socket structure.
- *   backlog  The maximum length the queue of pending connections may grow.
- *            If a connection request arrives with the queue full, the client
- *            may receive an error with an indication of ECONNREFUSED or,
- *            if the underlying protocol supports retransmission, the request
- *            may be ignored so that retries succeed.
- *
- * Returned Value:
- *   On success, zero is returned. On error, a negated errno value is
- *   returned.  See listen() for the set of appropriate error values.
- *
- ****************************************************************************/
-
-#ifndef CONFIG_NET_LOCAL_STREAM
-int local_listen(FAR struct socket *psock, int backlog)
-{
-  return -EOPNOTSUPP;
-}
 #endif
 
 /****************************************************************************

--- a/net/local/local_sockif.c
+++ b/net/local/local_sockif.c
@@ -58,11 +58,6 @@ static int        local_getpeername(FAR struct socket *psock,
                     FAR struct sockaddr *addr, FAR socklen_t *addrlen);
 static int        local_connect(FAR struct socket *psock,
                     FAR const struct sockaddr *addr, socklen_t addrlen);
-#ifndef CONFIG_NET_LOCAL_STREAM
-static int        local_accept(FAR struct socket *psock,
-                    FAR struct sockaddr *addr, FAR socklen_t *addrlen,
-                    FAR struct socket *newsock);
-#endif
 static int        local_poll(FAR struct socket *psock,
                     FAR struct pollfd *fds, bool setup);
 static int        local_close(FAR struct socket *psock);
@@ -95,7 +90,11 @@ const struct sock_intf_s g_local_sockif =
   NULL,              /* si_listen */
 #endif
   local_connect,     /* si_connect */
+#ifdef CONFIG_NET_LOCAL_STREAM
   local_accept,      /* si_accept */
+#else
+  NULL,              /* si_accept */
+#endif
   local_poll,        /* si_poll */
   local_sendmsg,     /* si_sendmsg */
   local_recvmsg,     /* si_recvmsg */
@@ -638,58 +637,6 @@ static int local_connect(FAR struct socket *psock,
         return -EBADF;
     }
 }
-
-/****************************************************************************
- * Name: local_accept
- *
- * Description:
- *   The pkt_accept function is used with connection-based socket types
- *   (SOCK_STREAM, SOCK_SEQPACKET and SOCK_RDM). It extracts the first
- *   connection request on the queue of pending connections, creates a new
- *   connected socket with mostly the same properties as 'sockfd', and
- *   allocates a new socket descriptor for the socket, which is returned. The
- *   newly created socket is no longer in the listening state. The original
- *   socket 'sockfd' is unaffected by this call.  Per file descriptor flags
- *   are not inherited across an pkt_accept.
- *
- *   The 'sockfd' argument is a socket descriptor that has been created with
- *   socket(), bound to a local address with bind(), and is listening for
- *   connections after a call to listen().
- *
- *   On return, the 'addr' structure is filled in with the address of the
- *   connecting entity. The 'addrlen' argument initially contains the size
- *   of the structure pointed to by 'addr'; on return it will contain the
- *   actual length of the address returned.
- *
- *   If no pending connections are present on the queue, and the socket is
- *   not marked as non-blocking, pkt_accept blocks the caller until a
- *   connection is present. If the socket is marked non-blocking and no
- *   pending connections are present on the queue, pkt_accept returns
- *   EAGAIN.
- *
- * Input Parameters:
- *   psock    Reference to the listening socket structure
- *   addr     Receives the address of the connecting client
- *   addrlen  Input: allocated size of 'addr',
- *            Return: returned size of 'addr'
- *   newsock  Location to return the accepted socket information.
- *
- * Returned Value:
- *   Returns 0 (OK) on success.  On failure, it returns a negated errno
- *   value.  See accept() for a description of the appropriate error value.
- *
- * Assumptions:
- *   The network is locked.
- *
- ****************************************************************************/
-
-#ifndef CONFIG_NET_LOCAL_STREAM
-static int local_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
-                        FAR socklen_t *addrlen, FAR struct socket *newsock)
-{
-  return -EAFNOSUPPORT;
-}
-#endif
 
 /****************************************************************************
  * Name: local_poll

--- a/net/netlink/netlink_sockif.c
+++ b/net/netlink/netlink_sockif.c
@@ -56,7 +56,6 @@ static int  netlink_getsockname(FAR struct socket *psock,
               FAR struct sockaddr *addr, FAR socklen_t *addrlen);
 static int  netlink_getpeername(FAR struct socket *psock,
               FAR struct sockaddr *addr, FAR socklen_t *addrlen);
-static int  netlink_listen(FAR struct socket *psock, int backlog);
 static int  netlink_connect(FAR struct socket *psock,
               FAR const struct sockaddr *addr, socklen_t addrlen);
 static int  netlink_accept(FAR struct socket *psock,
@@ -82,7 +81,7 @@ const struct sock_intf_s g_netlink_sockif =
   netlink_bind,         /* si_bind */
   netlink_getsockname,  /* si_getsockname */
   netlink_getpeername,  /* si_getpeername */
-  netlink_listen,       /* si_listen */
+  NULL,                 /* si_listen */
   netlink_connect,      /* si_connect */
   netlink_accept,       /* si_accept */
   netlink_poll,         /* si_poll */
@@ -363,37 +362,6 @@ static int netlink_getpeername(FAR struct socket *psock,
 
   *addrlen = sizeof(struct sockaddr_nl);
   return OK;
-}
-
-/****************************************************************************
- * Name: netlink_listen
- *
- * Description:
- *   To accept connections, a socket is first created with psock_socket(), a
- *   willingness to accept incoming connections and a queue limit for
- *   incoming connections are specified with psock_listen(), and then the
- *   connections are accepted with psock_accept().  For the case of AFINET
- *   and AFINET6 sockets, psock_listen() calls this function.  The
- *   psock_listen() call applies only to sockets of type SOCK_STREAM or
- *   SOCK_SEQPACKET.
- *
- * Input Parameters:
- *   psock    Reference to an internal, bound socket structure.
- *   backlog  The maximum length the queue of pending connections may grow.
- *            If a connection request arrives with the queue full, the client
- *            may receive an error with an indication of ECONNREFUSED or,
- *            if the underlying protocol supports retransmission, the request
- *            may be ignored so that retries succeed.
- *
- * Returned Value:
- *   On success, zero is returned. On error, a negated errno value is
- *   returned.  See listen() for the set of appropriate error values.
- *
- ****************************************************************************/
-
-static int netlink_listen(FAR struct socket *psock, int backlog)
-{
-  return -EOPNOTSUPP;
 }
 
 /****************************************************************************

--- a/net/netlink/netlink_sockif.c
+++ b/net/netlink/netlink_sockif.c
@@ -58,9 +58,6 @@ static int  netlink_getpeername(FAR struct socket *psock,
               FAR struct sockaddr *addr, FAR socklen_t *addrlen);
 static int  netlink_connect(FAR struct socket *psock,
               FAR const struct sockaddr *addr, socklen_t addrlen);
-static int  netlink_accept(FAR struct socket *psock,
-              FAR struct sockaddr *addr, FAR socklen_t *addrlen,
-              FAR struct socket *newsock);
 static int  netlink_poll(FAR struct socket *psock, FAR struct pollfd *fds,
               bool setup);
 static ssize_t netlink_sendmsg(FAR struct socket *psock,
@@ -83,7 +80,7 @@ const struct sock_intf_s g_netlink_sockif =
   netlink_getpeername,  /* si_getpeername */
   NULL,                 /* si_listen */
   netlink_connect,      /* si_connect */
-  netlink_accept,       /* si_accept */
+  NULL,                 /* si_accept */
   netlink_poll,         /* si_poll */
   netlink_sendmsg,      /* si_sendmsg */
   netlink_recvmsg,      /* si_recvmsg */
@@ -401,57 +398,6 @@ static int netlink_connect(FAR struct socket *psock,
   conn->dst_groups = nladdr->nl_groups;
 
   return OK;
-}
-
-/****************************************************************************
- * Name: netlink_accept
- *
- * Description:
- *   The netlink_accept function is used with connection-based socket
- *   types (SOCK_STREAM, SOCK_SEQPACKET and SOCK_RDM). It extracts the first
- *   connection request on the queue of pending connections, creates a new
- *   connected socket with mostly the same properties as 'sockfd', and
- *   allocates a new socket descriptor for the socket, which is returned. The
- *   newly created socket is no longer in the listening state. The original
- *   socket 'sockfd' is unaffected by this call.  Per file descriptor flags
- *   are not inherited across an inet_accept.
- *
- *   The 'sockfd' argument is a socket descriptor that has been created with
- *   socket(), bound to a local address with bind(), and is listening for
- *   connections after a call to listen().
- *
- *   On return, the 'addr' structure is filled in with the address of the
- *   connecting entity. The 'addrlen' argument initially contains the size
- *   of the structure pointed to by 'addr'; on return it will contain the
- *   actual length of the address returned.
- *
- *   If no pending connections are present on the queue, and the socket is
- *   not marked as non-blocking, accept blocks the caller until a
- *   connection is present. If the socket is marked non-blocking and no
- *   pending connections are present on the queue, inet_accept returns
- *   EAGAIN.
- *
- * Input Parameters:
- *   psock    Reference to the listening socket structure
- *   addr     Receives the address of the connecting client
- *   addrlen  Input:  Allocated size of 'addr'
- *            Return: Actual size returned size of 'addr'
- *   newsock  Location to return the accepted socket information.
- *
- * Returned Value:
- *   Returns 0 (OK) on success.  On failure, it returns a negated errno
- *   value.  See accept() for a description of the appropriate error value.
- *
- * Assumptions:
- *   The network is locked.
- *
- ****************************************************************************/
-
-static int netlink_accept(FAR struct socket *psock,
-                          FAR struct sockaddr *addr, FAR socklen_t *addrlen,
-                          FAR struct socket *newsock)
-{
-  return -EOPNOTSUPP;
 }
 
 /****************************************************************************

--- a/net/pkt/pkt_sockif.c
+++ b/net/pkt/pkt_sockif.c
@@ -52,8 +52,6 @@ static sockcaps_t pkt_sockcaps(FAR struct socket *psock);
 static void       pkt_addref(FAR struct socket *psock);
 static int        pkt_bind(FAR struct socket *psock,
                     FAR const struct sockaddr *addr, socklen_t addrlen);
-static int        pkt_getsockname(FAR struct socket *psock,
-                    FAR struct sockaddr *addr, FAR socklen_t *addrlen);
 static int        pkt_getpeername(FAR struct socket *psock,
                     FAR struct sockaddr *addr, FAR socklen_t *addrlen);
 static int        pkt_listen(FAR struct socket *psock, int backlog);
@@ -76,7 +74,7 @@ const struct sock_intf_s g_pkt_sockif =
   pkt_sockcaps,    /* si_sockcaps */
   pkt_addref,      /* si_addref */
   pkt_bind,        /* si_bind */
-  pkt_getsockname, /* si_getsockname */
+  NULL,            /* si_getsockname */
   pkt_getpeername, /* si_getpeername */
   pkt_listen,      /* si_listen */
   pkt_connect,     /* si_connect */
@@ -370,40 +368,6 @@ static int pkt_bind(FAR struct socket *psock,
     {
       return -EBADF;
     }
-}
-
-/****************************************************************************
- * Name: pkt_getsockname
- *
- * Description:
- *   The pkt_getsockname() function retrieves the locally-bound name of the
- *   specified packet socket, stores this address in the sockaddr structure
- *   pointed to by the 'addr' argument, and stores the length of this
- *   address in the object pointed to by the 'addrlen' argument.
- *
- *   If the actual length of the address is greater than the length of the
- *   supplied sockaddr structure, the stored address will be truncated.
- *
- *   If the socket has not been bound to a local name, the value stored in
- *   the object pointed to by address is unspecified.
- *
- * Input Parameters:
- *   psock    Socket structure of the socket to be queried
- *   addr     sockaddr structure to receive data [out]
- *   addrlen  Length of sockaddr structure [in/out]
- *
- * Returned Value:
- *   On success, 0 is returned, the 'addr' argument points to the address
- *   of the socket, and the 'addrlen' argument points to the length of the
- *   address.  Otherwise, a negated errno value is returned.  See
- *   getsockname() for the list of appropriate error numbers.
- *
- ****************************************************************************/
-
-static int pkt_getsockname(FAR struct socket *psock,
-                           FAR struct sockaddr *addr, FAR socklen_t *addrlen)
-{
-  return -EAFNOSUPPORT;
 }
 
 /****************************************************************************

--- a/net/pkt/pkt_sockif.c
+++ b/net/pkt/pkt_sockif.c
@@ -52,7 +52,6 @@ static sockcaps_t pkt_sockcaps(FAR struct socket *psock);
 static void       pkt_addref(FAR struct socket *psock);
 static int        pkt_bind(FAR struct socket *psock,
                     FAR const struct sockaddr *addr, socklen_t addrlen);
-static int        pkt_listen(FAR struct socket *psock, int backlog);
 static int        pkt_connect(FAR struct socket *psock,
                     FAR const struct sockaddr *addr, socklen_t addrlen);
 static int        pkt_accept(FAR struct socket *psock,
@@ -74,7 +73,7 @@ const struct sock_intf_s g_pkt_sockif =
   pkt_bind,        /* si_bind */
   NULL,            /* si_getsockname */
   NULL,            /* si_getpeername */
-  pkt_listen,      /* si_listen */
+  NULL,            /* si_listen */
   pkt_connect,     /* si_connect */
   pkt_accept,      /* si_accept */
   pkt_poll_local,  /* si_poll */
@@ -366,36 +365,6 @@ static int pkt_bind(FAR struct socket *psock,
     {
       return -EBADF;
     }
-}
-
-/****************************************************************************
- * Name: pkt_listen
- *
- * Description:
- *   To accept connections, a socket is first created with psock_socket(), a
- *   willingness to accept incoming connections and a queue limit for
- *   incoming connections are specified with psock_listen(), and then the
- *   connections are accepted with psock_accept().  For the case of raw
- *   packet sockets, psock_listen() calls this function.  The psock_listen()
- *   call applies only to sockets of type SOCK_STREAM or SOCK_SEQPACKET.
- *
- * Input Parameters:
- *   psock    Reference to an internal, boound socket structure.
- *   backlog  The maximum length the queue of pending connections may grow.
- *            If a connection request arrives with the queue full, the client
- *            may receive an error with an indication of ECONNREFUSED or,
- *            if the underlying protocol supports retransmission, the request
- *            may be ignored so that retries succeed.
- *
- * Returned Value:
- *   On success, zero is returned. On error, a negated errno value is
- *   returned.  See listen() for the set of appropriate error values.
- *
- ****************************************************************************/
-
-int pkt_listen(FAR struct socket *psock, int backlog)
-{
-  return -EOPNOTSUPP;
 }
 
 /****************************************************************************

--- a/net/pkt/pkt_sockif.c
+++ b/net/pkt/pkt_sockif.c
@@ -52,8 +52,6 @@ static sockcaps_t pkt_sockcaps(FAR struct socket *psock);
 static void       pkt_addref(FAR struct socket *psock);
 static int        pkt_bind(FAR struct socket *psock,
                     FAR const struct sockaddr *addr, socklen_t addrlen);
-static int        pkt_getpeername(FAR struct socket *psock,
-                    FAR struct sockaddr *addr, FAR socklen_t *addrlen);
 static int        pkt_listen(FAR struct socket *psock, int backlog);
 static int        pkt_connect(FAR struct socket *psock,
                     FAR const struct sockaddr *addr, socklen_t addrlen);
@@ -75,7 +73,7 @@ const struct sock_intf_s g_pkt_sockif =
   pkt_addref,      /* si_addref */
   pkt_bind,        /* si_bind */
   NULL,            /* si_getsockname */
-  pkt_getpeername, /* si_getpeername */
+  NULL,            /* si_getpeername */
   pkt_listen,      /* si_listen */
   pkt_connect,     /* si_connect */
   pkt_accept,      /* si_accept */
@@ -368,40 +366,6 @@ static int pkt_bind(FAR struct socket *psock,
     {
       return -EBADF;
     }
-}
-
-/****************************************************************************
- * Name: pkt_getpeername
- *
- * Description:
- *   The pkt_getpeername() function retrieves the remote-connected name of
- *   the specified packet socket, stores this address in the sockaddr
- *   structure pointed to by the 'addr' argument, and stores the length of
- *   this address in the object pointed to by the 'addrlen' argument.
- *
- *   If the actual length of the address is greater than the length of the
- *   supplied sockaddr structure, the stored address will be truncated.
- *
- *   If the socket has not been bound to a local name, the value stored in
- *   the object pointed to by address is unspecified.
- *
- * Parameters:
- *   psock    Socket structure of the socket to be queried
- *   addr     sockaddr structure to receive data [out]
- *   addrlen  Length of sockaddr structure [in/out]
- *
- * Returned Value:
- *   On success, 0 is returned, the 'addr' argument points to the address
- *   of the socket, and the 'addrlen' argument points to the length of the
- *   address.  Otherwise, a negated errno value is returned.  See
- *   getpeername() for the list of appropriate error numbers.
- *
- ****************************************************************************/
-
-static int pkt_getpeername(FAR struct socket *psock,
-                           FAR struct sockaddr *addr, FAR socklen_t *addrlen)
-{
-  return -EAFNOSUPPORT;
 }
 
 /****************************************************************************

--- a/net/pkt/pkt_sockif.c
+++ b/net/pkt/pkt_sockif.c
@@ -52,8 +52,6 @@ static sockcaps_t pkt_sockcaps(FAR struct socket *psock);
 static void       pkt_addref(FAR struct socket *psock);
 static int        pkt_bind(FAR struct socket *psock,
                     FAR const struct sockaddr *addr, socklen_t addrlen);
-static int        pkt_connect(FAR struct socket *psock,
-                    FAR const struct sockaddr *addr, socklen_t addrlen);
 static int        pkt_accept(FAR struct socket *psock,
                     FAR struct sockaddr *addr, FAR socklen_t *addrlen,
                     FAR struct socket *newsock);
@@ -74,7 +72,7 @@ const struct sock_intf_s g_pkt_sockif =
   NULL,            /* si_getsockname */
   NULL,            /* si_getpeername */
   NULL,            /* si_listen */
-  pkt_connect,     /* si_connect */
+  NULL,            /* si_connect */
   pkt_accept,      /* si_accept */
   pkt_poll_local,  /* si_poll */
   pkt_sendmsg,     /* si_sendmsg */
@@ -203,44 +201,6 @@ static void pkt_addref(FAR struct socket *psock)
   conn = psock->s_conn;
   DEBUGASSERT(conn->crefs > 0 && conn->crefs < 255);
   conn->crefs++;
-}
-
-/****************************************************************************
- * Name: pkt_connect
- *
- * Description:
- *   pkt_connect() connects the local socket referred to by the structure
- *   'psock' to the address specified by 'addr'. The addrlen argument
- *   specifies the size of 'addr'.  The format of the address in 'addr' is
- *   determined by the address space of the socket 'psock'.
- *
- *   If the socket 'psock' is of type SOCK_DGRAM then 'addr' is the address
- *   to which datagrams are sent by default, and the only address from which
- *   datagrams are received. If the socket is of type SOCK_STREAM or
- *   SOCK_SEQPACKET, this call attempts to make a connection to the socket
- *   that is bound to the address specified by 'addr'.
- *
- *   Generally, connection-based protocol sockets may successfully
- *   pkt_connect() only once; connectionless protocol sockets may use
- *   pkt_connect() multiple times to change their association.
- *   Connectionless sockets may dissolve the association by connecting to
- *   an address with the sa_family member of sockaddr set to AF_UNSPEC.
- *
- * Input Parameters:
- *   psock     Pointer to a socket structure initialized by psock_socket()
- *   addr      Server address (form depends on type of socket)
- *   addrlen   Length of actual 'addr'
- *
- * Returned Value:
- *   0 on success; a negated errno value on failure.  See connect() for the
- *   list of appropriate errno values to be returned.
- *
- ****************************************************************************/
-
-static int pkt_connect(FAR struct socket *psock,
-                       FAR const struct sockaddr *addr, socklen_t addrlen)
-{
-  return -EAFNOSUPPORT;
 }
 
 /****************************************************************************

--- a/net/pkt/pkt_sockif.c
+++ b/net/pkt/pkt_sockif.c
@@ -52,8 +52,6 @@ static sockcaps_t pkt_sockcaps(FAR struct socket *psock);
 static void       pkt_addref(FAR struct socket *psock);
 static int        pkt_bind(FAR struct socket *psock,
                     FAR const struct sockaddr *addr, socklen_t addrlen);
-static int        pkt_poll_local(FAR struct socket *psock,
-                    FAR struct pollfd *fds, bool setup);
 static int        pkt_close(FAR struct socket *psock);
 
 /****************************************************************************
@@ -71,7 +69,7 @@ const struct sock_intf_s g_pkt_sockif =
   NULL,            /* si_listen */
   NULL,            /* si_connect */
   NULL,            /* si_accept */
-  pkt_poll_local,  /* si_poll */
+  NULL,            /* si_poll */
   pkt_sendmsg,     /* si_sendmsg */
   pkt_recvmsg,     /* si_recvmsg */
   pkt_close        /* si_close */
@@ -272,30 +270,6 @@ static int pkt_bind(FAR struct socket *psock,
     {
       return -EBADF;
     }
-}
-
-/****************************************************************************
- * Name: pkt_poll
- *
- * Description:
- *   The standard poll() operation redirects operations on socket descriptors
- *   to net_poll which, indiectly, calls to function.
- *
- * Input Parameters:
- *   psock - An instance of the internal socket structure.
- *   fds   - The structure describing the events to be monitored, OR NULL if
- *           this is a request to stop monitoring events.
- *   setup - true: Setup up the poll; false: Teardown the poll
- *
- * Returned Value:
- *  0: Success; Negated errno on failure
- *
- ****************************************************************************/
-
-static int pkt_poll_local(FAR struct socket *psock, FAR struct pollfd *fds,
-                          bool setup)
-{
-  return -ENOSYS;
 }
 
 /****************************************************************************

--- a/net/pkt/pkt_sockif.c
+++ b/net/pkt/pkt_sockif.c
@@ -52,9 +52,6 @@ static sockcaps_t pkt_sockcaps(FAR struct socket *psock);
 static void       pkt_addref(FAR struct socket *psock);
 static int        pkt_bind(FAR struct socket *psock,
                     FAR const struct sockaddr *addr, socklen_t addrlen);
-static int        pkt_accept(FAR struct socket *psock,
-                    FAR struct sockaddr *addr, FAR socklen_t *addrlen,
-                    FAR struct socket *newsock);
 static int        pkt_poll_local(FAR struct socket *psock,
                     FAR struct pollfd *fds, bool setup);
 static int        pkt_close(FAR struct socket *psock);
@@ -73,7 +70,7 @@ const struct sock_intf_s g_pkt_sockif =
   NULL,            /* si_getpeername */
   NULL,            /* si_listen */
   NULL,            /* si_connect */
-  pkt_accept,      /* si_accept */
+  NULL,            /* si_accept */
   pkt_poll_local,  /* si_poll */
   pkt_sendmsg,     /* si_sendmsg */
   pkt_recvmsg,     /* si_recvmsg */
@@ -201,56 +198,6 @@ static void pkt_addref(FAR struct socket *psock)
   conn = psock->s_conn;
   DEBUGASSERT(conn->crefs > 0 && conn->crefs < 255);
   conn->crefs++;
-}
-
-/****************************************************************************
- * Name: pkt_accept
- *
- * Description:
- *   The pkt_accept function is used with connection-based socket types
- *   (SOCK_STREAM, SOCK_SEQPACKET and SOCK_RDM). It extracts the first
- *   connection request on the queue of pending connections, creates a new
- *   connected socket with mostly the same properties as 'sockfd', and
- *   allocates a new socket descriptor for the socket, which is returned. The
- *   newly created socket is no longer in the listening state. The original
- *   socket 'sockfd' is unaffected by this call.  Per file descriptor flags
- *   are not inherited across an pkt_accept.
- *
- *   The 'sockfd' argument is a socket descriptor that has been created with
- *   socket(), bound to a local address with bind(), and is listening for
- *   connections after a call to listen().
- *
- *   On return, the 'addr' structure is filled in with the address of the
- *   connecting entity. The 'addrlen' argument initially contains the size
- *   of the structure pointed to by 'addr'; on return it will contain the
- *   actual length of the address returned.
- *
- *   If no pending connections are present on the queue, and the socket is
- *   not marked as non-blocking, pkt_accept blocks the caller until a
- *   connection is present. If the socket is marked non-blocking and no
- *   pending connections are present on the queue, pkt_accept returns
- *   EAGAIN.
- *
- * Input Parameters:
- *   psock    Reference to the listening socket structure
- *   addr     Receives the address of the connecting client
- *   addrlen  Input: allocated size of 'addr', Return: returned size of
- *            'addr'
- *   newsock  Location to return the accepted socket information.
- *
- * Returned Value:
- *   Returns 0 (OK) on success.  On failure, it returns a negated errno
- *   value.  See accept() for a description of the appropriate error value.
- *
- * Assumptions:
- *   The network is locked.
- *
- ****************************************************************************/
-
-static int pkt_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
-                      FAR socklen_t *addrlen, FAR struct socket *newsock)
-{
-  return -EAFNOSUPPORT;
 }
 
 /****************************************************************************

--- a/net/socket/accept.c
+++ b/net/socket/accept.c
@@ -139,7 +139,11 @@ int psock_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
 
   /* Let the address family's accept() method handle the operation */
 
-  DEBUGASSERT(psock->s_sockif != NULL && psock->s_sockif->si_accept != NULL);
+  DEBUGASSERT(psock->s_sockif != NULL);
+  if (psock->s_sockif->si_accept == NULL)
+    {
+      return -EOPNOTSUPP;
+    }
 
   net_lock();
   ret = psock->s_sockif->si_accept(psock, addr, addrlen, newsock);

--- a/net/socket/bind.c
+++ b/net/socket/bind.c
@@ -87,7 +87,12 @@ int psock_bind(FAR struct socket *psock, const struct sockaddr *addr,
 
   /* Let the address family's connect() method handle the operation */
 
-  DEBUGASSERT(psock->s_sockif != NULL && psock->s_sockif->si_bind != NULL);
+  DEBUGASSERT(psock->s_sockif != NULL);
+  if (psock->s_sockif->si_bind == NULL)
+    {
+      return -EOPNOTSUPP;
+    }
+
   ret = psock->s_sockif->si_bind(psock, addr, addrlen);
 
   /* Was the bind successful */

--- a/net/socket/connect.c
+++ b/net/socket/connect.c
@@ -134,8 +134,12 @@ int psock_connect(FAR struct socket *psock, FAR const struct sockaddr *addr,
 
   /* Let the address family's connect() method handle the operation */
 
-  DEBUGASSERT(psock->s_sockif != NULL &&
-              psock->s_sockif->si_connect != NULL);
+  DEBUGASSERT(psock->s_sockif != NULL);
+  if (psock->s_sockif->si_connect == NULL)
+    {
+      return -EOPNOTSUPP;
+    }
+
   ret = psock->s_sockif->si_connect(psock, addr, addrlen);
   if (ret >= 0)
     {

--- a/net/socket/getpeername.c
+++ b/net/socket/getpeername.c
@@ -98,7 +98,6 @@ int psock_getpeername(FAR struct socket *psock, FAR struct sockaddr *addr,
   /* Let the address family's send() method handle the operation */
 
   DEBUGASSERT(psock->s_sockif != NULL);
-
   if (psock->s_sockif->si_getpeername == NULL)
     {
       return -EOPNOTSUPP;

--- a/net/socket/getsockname.c
+++ b/net/socket/getsockname.c
@@ -95,8 +95,11 @@ int psock_getsockname(FAR struct socket *psock, FAR struct sockaddr *addr,
 
   /* Let the address family's send() method handle the operation */
 
-  DEBUGASSERT(psock->s_sockif != NULL &&
-              psock->s_sockif->si_getsockname != NULL);
+  DEBUGASSERT(psock->s_sockif != NULL);
+  if (psock->s_sockif->si_getsockname == NULL)
+    {
+      return -EOPNOTSUPP;
+    }
 
   return psock->s_sockif->si_getsockname(psock, addr, addrlen);
 }

--- a/net/socket/listen.c
+++ b/net/socket/listen.c
@@ -82,7 +82,12 @@ int psock_listen(FAR struct socket *psock, int backlog)
 
   /* Let the address family's listen() method handle the operation */
 
-  DEBUGASSERT(psock->s_sockif != NULL && psock->s_sockif->si_listen != NULL);
+  DEBUGASSERT(psock->s_sockif != NULL);
+  if (psock->s_sockif->si_listen == NULL)
+    {
+      return -EOPNOTSUPP;
+    }
+
   ret = psock->s_sockif->si_listen(psock, backlog);
   if (ret >= 0)
     {

--- a/net/socket/net_poll.c
+++ b/net/socket/net_poll.c
@@ -59,6 +59,11 @@ int psock_poll(FAR struct socket *psock, FAR struct pollfd *fds, bool setup)
 
   /* Let the address family's poll() method handle the operation */
 
-  DEBUGASSERT(psock->s_sockif != NULL && psock->s_sockif->si_poll != NULL);
+  DEBUGASSERT(psock->s_sockif != NULL);
+  if (psock->s_sockif->si_poll == NULL)
+    {
+      return -EOPNOTSUPP;
+    }
+
   return psock->s_sockif->si_poll(psock, fds, setup);
 }


### PR DESCRIPTION
## Summary

- net: Make si_bind callback optional
- net: Make si_getsockname callback optional
- net: Remove the empty si_getpeername implementation
- net: Make si_listen callback optional 
- net: Make si_connect callback optional 
- net: Make si_accept callback optional 
- net: Make si_poll callback optional

## Impact

Code refactor only

## Testing

CI