### PR TITLE
Adding support for LS027B7DH01A display and MEMLCD_EXTCOMIN_MODE_HW

### DIFF
--- a/drivers/lcd/Kconfig
+++ b/drivers/lcd/Kconfig
@@ -1039,6 +1039,11 @@ config MEMLCD_LS013B7DH03
 	---help---
 		Selects the LS013B7DH03 model
 
+config MEMLCD_LS027B7DH01A
+	bool "LS027B7DH01A"
+	---help---
+		Selects the LS027B7DH01A model
+
 endchoice
 
 config MEMLCD_NINTERFACES


### PR DESCRIPTION
## Summary

Adding new Sharp Memory LS027B7DH01A to the driver and support for MEMLCD_EXTCOMIN_MODE_HW. Later doesn't need IO pin to toggle VCOM. VCOM toggling is done by sending special command to the display.

## Impact

Sharp MEMLCD driver

## Testing

Tested on EdgeProMX keyboard.

