### PR TITLE
signal/sig_dispatch: Add signal action, if task is in system call

### DIFF
--- a/sched/signal/sig_dispatch.c
+++ b/sched/signal/sig_dispatch.c
@@ -321,8 +321,8 @@ int nxsig_tcbdispatch(FAR struct tcb_s *stcb, siginfo_t *info)
   int masked;
   int ret = OK;
 
-  sinfo("TCB=%p signo=%d code=%d value=%d mask=%08" PRIx32 "\n",
-        stcb, info->si_signo, info->si_code,
+  sinfo("TCB=%p pid=%d signo=%d code=%d value=%d mask=%08" PRIx32 "\n",
+        stcb, stcb->pid, info->si_signo, info->si_code,
         info->si_value.sival_int, stcb->sigprocmask);
 
   DEBUGASSERT(stcb != NULL && info != NULL);
@@ -404,6 +404,15 @@ int nxsig_tcbdispatch(FAR struct tcb_s *stcb, siginfo_t *info)
             }
 
           leave_critical_section(flags);
+
+#ifdef CONFIG_LIB_SYSCALL
+          /* Must also add signal action if in system call */
+
+          if (masked == 0)
+            {
+              nxsig_add_pendingsignal(stcb, info);
+            }
+#endif
         }
 
       /* Its not one we are waiting for... Add it to the list of pending


### PR DESCRIPTION
## Summary
This fixes regression found in  #8605. Only the signal action should be queued when in system call, the signal should not be sent and pended which results in the user app receiving it twice.
## Impact
Fix regression from #8605
## Testing
icicle:nsh / pnsh + ostest and https://github.com/linux-test-project/ltp/blob/master/testcases/open_posix_testsuite/conformance/interfaces/timer_settime/9-2.c
