### PR TITLE
armv8-m/cortex-m85: add support of PACBTI(Authentication and Branch Target Identification Extension)

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -1049,6 +1049,12 @@ config ARM_HAVE_MVE
 	---help---
 		Decide whether support MVE instruction
 
+config ARM_HAVE_PACBTI
+	bool
+	default n
+	---help---
+		Decide whether support PACBTI(Pointer Authentication and Branch Target Identification) Extension
+
 config ARM_FPU_ABI_SOFT
 	bool "Soft Float ABI"
 	default n
@@ -1072,6 +1078,13 @@ config ARM_DSP
 	depends on ARM_HAVE_DSP
 	---help---
 		Enables DSP Extension
+
+config ARM_PACBTI
+	bool "Advanced PACBTI Extension"
+	default y
+	depends on ARM_HAVE_PACBTI
+	---help---
+		Enables PACBTI(Pointer Authentication and Branch Target Identification) Extension
 
 config ARM_HAVE_MPU_UNIFIED
 	bool

--- a/arch/arm/src/armv8-m/Toolchain.defs
+++ b/arch/arm/src/armv8-m/Toolchain.defs
@@ -24,6 +24,37 @@ ifeq ($(CONFIG_ARM_DSP),y)
   EXTCPUFLAGS = +dsp
 endif
 
+ifeq ($(CONFIG_ARM_PACBTI),y)
+  EXTCPUFLAGS := $(EXTCPUFLAGS)+pacbti
+
+  # Protects branches using pointer authentication and Branch Target Identification.
+  #
+  # The default is -mbranch-protection=none.
+  #
+  # -mbranch-protection=standard:
+  #   Enables all types of branch protection to their standard values.
+  #   The standard protection is equivalent to -mbranch-protection=bti+pac-ret.
+  #
+  # -mbranch-protection=bti:
+  #   Enables branch protection using Branch Target Identification.
+  #
+  # -mbranch-protection=pac-ret:
+  #   Enables branch protection using pointer authentication using key A.
+  #
+  #   +leaf:
+  #   Enables pointer authentication on all leaf functions, including the leaf
+  #   functions that do not save the LR on the stack.
+  #
+  #   +b-key:
+  #   Enables pointer authentication with Key B, rather than Key A.
+
+  ARCHOPTIMIZATION += -mbranch-protection=standard
+endif
+
+ifeq ($(CONFIG_ARM_HAVE_MVE),y)
+  EXTCPUFLAGS := $(EXTCPUFLAGS)+mve.fp+fp.dp
+endif
+
 ifeq ($(CONFIG_ARCH_CORTEXM23),y)
   TOOLCHAIN_MTUNE    := -mtune=cortex-m23
   TOOLCHAIN_MARCH    := -march=armv8-m.main
@@ -45,22 +76,14 @@ else ifeq ($(CONFIG_ARCH_CORTEXM35P),y)
   ZARCHCPUFLAGS := -mcpu=cortex_m35p
 else ifeq ($(CONFIG_ARCH_CORTEXM55),y)
   TOOLCHAIN_MTUNE    := -mtune=cortex-m55
-  ifeq ($(CONFIG_ARM_HAVE_MVE),y)
-    TOOLCHAIN_MARCH  := -march=armv8.1-m.main+mve.fp+fp.dp
-  else
-    TOOLCHAIN_MARCH  := -march=armv8.1-m.main$(EXTCPUFLAGS)
-  endif
+  TOOLCHAIN_MARCH    := -march=armv8.1-m.main$(EXTCPUFLAGS)
   ifeq ($(CONFIG_ARCH_FPU),y)
     TOOLCHAIN_MFLOAT := -mfpu=fpv5-d16
   endif
   ZARCHCPUFLAGS := -mcpu=cortex_m55
 else ifeq ($(CONFIG_ARCH_CORTEXM85),y)
   TOOLCHAIN_MTUNE    := -mtune=cortex-m85
-  ifeq ($(CONFIG_ARM_HAVE_MVE),y)
-    TOOLCHAIN_MARCH  := -march=armv8.1-m.main+mve.fp+fp.dp
-  else
-    TOOLCHAIN_MARCH  := -march=armv8.1-m.main$(EXTCPUFLAGS)
-  endif
+  TOOLCHAIN_MARCH    := -march=armv8.1-m.main$(EXTCPUFLAGS)
   ifeq ($(CONFIG_ARCH_FPU),y)
     TOOLCHAIN_MFLOAT := -mfpu=fpv5-d16
   endif


### PR DESCRIPTION

## Summary

armv8-m/cortex-m85: add support of PACBTI(Authentication and Branch Target Identification Extension)

Reference:
https://developer.arm.com/documentation/100748/0617/Security-features-supported-in-Arm-Compiler-for-Embedded/PACBTI-M-extension-mitigations-against-ROP-and-JOP-style-attacks
https://developer.arm.com/documentation/101754/0619/armclang-Reference/armclang-Command-line-Options/-mbranch-protection

Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

ci-check