### PR TITLE
riscv: hpm6750: add option to select hpmicro toolchain

### DIFF
--- a/arch/risc-v/Kconfig
+++ b/arch/risc-v/Kconfig
@@ -306,14 +306,21 @@ config ARCH_MPU_HAS_NAPOT
 
 choice
 	prompt "Toolchain Selection"
-	default RISCV_TOOLCHAIN_GNU_RVG
+	default RISCV_TOOLCHAIN_GNU_RV64
 
-config RISCV_TOOLCHAIN_GNU_RVG
-	bool "Generic GNU RVG toolchain"
+config RISCV_TOOLCHAIN_GNU_RV64
+	bool "Generic GNU RV64 toolchain"
 	select ARCH_TOOLCHAIN_GNU
 	---help---
 		This option should work for any modern GNU toolchain (GCC 5.2 or newer)
 		configured for riscv64-unknown-elf.
+
+config RISCV_TOOLCHAIN_GNU_RV32
+	bool "Generic GNU RV32 toolchain"
+	select ARCH_TOOLCHAIN_GNU
+	---help---
+		This option should work for any modern GNU toolchain (GCC 5.2 or newer)
+		configured for riscv32-unknown-elf.
 
 endchoice
 

--- a/arch/risc-v/src/common/Toolchain.defs
+++ b/arch/risc-v/src/common/Toolchain.defs
@@ -27,7 +27,9 @@
 # command-line selection.
 #
 
-ifeq ($(filter y, $(CONFIG_RISCV_TOOLCHAIN_GNU_RVG)),y)
+ifeq ($(filter y, $(CONFIG_RISCV_TOOLCHAIN_GNU_RV64)),y)
+  CONFIG_RISCV_TOOLCHAIN ?= GNU_RVG
+else ifeq ($(filter y, $(CONFIG_RISCV_TOOLCHAIN_GNU_RV32)),y)
   CONFIG_RISCV_TOOLCHAIN ?= GNU_RVG
 endif
 
@@ -120,7 +122,11 @@ ifeq ($(CONFIG_RISCV_TOOLCHAIN),GNU_RVG)
 
   # Generic GNU RVG toolchain
 
-  CROSSDEV ?= riscv64-unknown-elf-
+  ifeq ($(CONFIG_RISCV_TOOLCHAIN_GNU_RV32),y)
+    CROSSDEV ?= riscv32-unknown-elf-
+  else
+    CROSSDEV ?= riscv64-unknown-elf-
+  endif
 
   # Detect cpu ISA support flags
 

--- a/arch/risc-v/src/hpm6750/hpm6750_serial.c
+++ b/arch/risc-v/src/hpm6750/hpm6750_serial.c
@@ -570,9 +570,9 @@ static void up_detach(struct uart_dev_s *dev)
  *
  * Description:
  *   This is the UART interrupt handler.  It will be invoked when an
- *   interrupt received on the 'irq'  It should call uart_transmitchars or
- *   uart_receivechar to perform the appropriate data transfers.  The
- *   interrupt handling logic must be able to map the 'irq' number into the
+ *   interrupt is received on the 'irq'.  It should call uart_xmitchars or
+ *   uart_recvchars to perform the appropriate data transfers.  The
+ *   interrupt handling logic must be able to map the 'arg' into the
  *   appropriate uart_dev_s structure in order to call these functions.
  *
  ****************************************************************************/

--- a/boards/risc-v/hpm6750/hpm6750evk2/README.txt
+++ b/boards/risc-v/hpm6750/hpm6750evk2/README.txt
@@ -15,7 +15,19 @@
   $ cd nuttx
   $ make distclean
   $ ./tools/configure.sh hpm6750evk2:nsh
+  $ make menuconfig
   $ make V=1
+
+  Note: make menuconfig to config toolchain
+  ==================
+    To switch GNU riscv64 toolchain to GNU riscv32 toolchain, the following option must be selected:
+
+    System Type  --->
+        Toolchain Selection   --->
+            [ ] Generic GNU RV64 toolchain
+            [x] Generic GNU RV32 toolchain
+
+    Make sure HPMicro GNU riscv32 toolchain have been installed and be found in PATH.
 
 4. Debug the nuttx with openocd and run
 
@@ -24,7 +36,7 @@
   When using fireDAP, command as follows. Those cfg files in the path: sdk_env/hpm_sdk/boards/openocd.
   $ openocd -f probes/cmsis_dap.cfg -f soc/hpm6750-single-core.cfg -f boards/hpm6750evk2.cfg
 
-  $ riscv64-unknown-elf-gdb ./nuttx
+  $ riscv32-unknown-elf-gdb ./nuttx
   (gdb) target extended-remote [ip_addr]:3333
   (gdb) load
   (gdb) c


### PR DESCRIPTION
## Summary
For boards/risc-v/hpm6750/hpm6750evk2,  add option to select hpmicro GNU riscv32 toolchain. 
Default, using generic GNU riscv64 Toolchain.

## Impact
Don't impact others.

## Testing
hpm6750evk2:nsh
