### PR TITLE
net/pkt: Add readahead queue for pkt, call input for tx on sim

### DIFF
--- a/arch/sim/src/sim/sim_netdriver.c
+++ b/arch/sim/src/sim/sim_netdriver.c
@@ -110,6 +110,12 @@ static void netdriver_send(struct net_driver_s *dev)
 
   UNUSED(devidx);
 
+#ifdef CONFIG_NET_PKT
+  /* When packet sockets are enabled, feed the tx frame into it */
+
+  pkt_input(dev);
+#endif
+
   sim_netdev_send(devidx, buf, dev->d_len);
 }
 

--- a/include/nuttx/mm/iob.h
+++ b/include/nuttx/mm/iob.h
@@ -476,8 +476,8 @@ int iob_clone(FAR struct iob_s *iob1, FAR struct iob_s *iob2,
  ****************************************************************************/
 
 int iob_clone_partial(FAR struct iob_s *iob1, unsigned int len,
-                      unsigned int offset1, FAR struct iob_s *iob2,
-                      unsigned int offset2, bool throttled, bool block);
+                      int offset1, FAR struct iob_s *iob2,
+                      int offset2, bool throttled, bool block);
 
 /****************************************************************************
  * Name: iob_concat

--- a/mm/iob/iob_clone.c
+++ b/mm/iob/iob_clone.c
@@ -109,8 +109,8 @@ static int iob_next(FAR struct iob_s *iob, bool throttled, bool block)
  ****************************************************************************/
 
 int iob_clone_partial(FAR struct iob_s *iob1, unsigned int len,
-                      unsigned int offset1, FAR struct iob_s *iob2,
-                      unsigned int offset2, bool throttled, bool block)
+                      int offset1, FAR struct iob_s *iob2,
+                      int offset2, bool throttled, bool block)
 {
   FAR uint8_t *src;
   FAR uint8_t *dest;
@@ -129,7 +129,7 @@ int iob_clone_partial(FAR struct iob_s *iob1, unsigned int len,
    * the list, Skip I/O buffer containing the data offset.
    */
 
-  while (iob1 != NULL && offset1 >= iob1->io_len)
+  while (iob1 != NULL && (int)(offset1 - iob1->io_len) >= 0)
     {
       offset1 -= iob1->io_len;
       iob1     = iob1->io_flink;
@@ -195,7 +195,7 @@ int iob_clone_partial(FAR struct iob_s *iob1, unsigned int len,
 
       /* Have we taken all of the data from the source I/O buffer? */
 
-      if (offset1 >= iob1->io_len)
+      if ((int)(offset1 - iob1->io_len) >= 0)
         {
           /* Skip over empty entries in the chain (there should not be any
            * but just to be safe).
@@ -218,7 +218,7 @@ int iob_clone_partial(FAR struct iob_s *iob1, unsigned int len,
        * transferred?
        */
 
-      if (offset2 >= (CONFIG_IOB_BUFSIZE - iob2->io_offset) &&
+      if ((int)(offset2 + iob2->io_offset - CONFIG_IOB_BUFSIZE) >= 0 &&
           iob1 != NULL)
         {
           ret = iob_next(iob2, throttled, block);

--- a/net/devif/devif_poll.c
+++ b/net/devif/devif_poll.c
@@ -208,17 +208,25 @@ static int devif_poll_pkt_connections(FAR struct net_driver_s *dev,
 
   while (!bstop && (pkt_conn = pkt_nextconn(pkt_conn)))
     {
-      /* Perform the packet TX poll */
+      /* Skip packet connections that are bound to other polling devices */
 
-      pkt_poll(dev, pkt_conn);
+      if (dev->d_ifindex == pkt_conn->ifindex)
+        {
+          /* Perform the packet TX poll */
 
-      /* Perform any necessary conversions on outgoing packets */
+          pkt_poll(dev, pkt_conn);
 
-      devif_packet_conversion(dev, DEVIF_PKT);
+          /* Perform any necessary conversions on outgoing packets */
 
-      /* Call back into the driver */
+          devif_packet_conversion(dev, DEVIF_PKT);
 
-      bstop = callback(dev);
+          /* Call back into the driver */
+
+          if (dev->d_len > 0)
+            {
+              bstop = callback(dev);
+            }
+        }
     }
 
   return bstop;

--- a/net/pkt/pkt.h
+++ b/net/pkt/pkt.h
@@ -64,6 +64,16 @@ struct pkt_conn_s
   uint8_t    ifindex;
   uint16_t   proto;
   uint8_t    crefs;    /* Reference counts on this instance */
+
+  /* Read-ahead buffering.
+   *
+   *   readahead - A singly linked list of type struct iob_qentry_s
+   *               where the PKT read-ahead data is retained.
+   *
+   * TODO: Maybe support PACKET_MMAP for further optimize.
+   */
+
+  struct iob_queue_s readahead;   /* Read-ahead buffering */
 };
 
 /****************************************************************************
@@ -231,7 +241,7 @@ ssize_t pkt_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
  *   Select the network driver to use with the PKT transaction.
  *
  * Input Parameters:
- *   conn - PKT connection structure (not currently used).
+ *   conn - PKT connection structure.
  *
  * Returned Value:
  *   A pointer to the network driver to use.

--- a/net/pkt/pkt_conn.c
+++ b/net/pkt/pkt_conn.c
@@ -210,7 +210,8 @@ FAR struct pkt_conn_s *pkt_active(FAR struct eth_hdr_s *buf)
     {
       /* FIXME lmac in conn should have been set by pkt_bind() */
 
-      if (eth_addr_cmp(buf->dest, conn->lmac))
+      if (eth_addr_cmp(buf->dest, conn->lmac) ||
+          eth_addr_cmp(buf->src, conn->lmac))
         {
           /* Matching connection found.. return a reference to it */
 

--- a/net/pkt/pkt_finddev.c
+++ b/net/pkt/pkt_finddev.c
@@ -41,7 +41,7 @@
  *   Select the network driver to use with the PKT transaction.
  *
  * Input Parameters:
- *   conn - PKT connection structure (not currently used).
+ *   conn - PKT connection structure.
  *
  * Returned Value:
  *   A pointer to the network driver to use.
@@ -50,9 +50,7 @@
 
 FAR struct net_driver_s *pkt_find_device(FAR struct pkt_conn_s *conn)
 {
-  /* REVISIT:  This is bogus.  A better network device lookup is needed. */
-
-  return netdev_findbyname("eth0");
+  return netdev_findbyindex(conn->ifindex);
 }
 
 #endif /* CONFIG_NET && CONFIG_NET_PKT */

--- a/net/pkt/pkt_sockif.c
+++ b/net/pkt/pkt_sockif.c
@@ -305,7 +305,11 @@ static int pkt_close(FAR struct socket *psock)
 
           if (conn->crefs <= 1)
             {
-              /* Yes... free the connection structure */
+              /* Yes... free any read-ahead data */
+
+              iob_free_queue(&conn->readahead);
+
+              /* Then free the connection structure */
 
               conn->crefs = 0;          /* No more references on the connection */
               pkt_free(psock->s_conn);  /* Free network resources */


### PR DESCRIPTION
## Summary
Enhance NET_PKT functionality, in order to support https://github.com/apache/nuttx-apps/pull/1635

Patches included:
- mm/iob: Support neg offset in iob_clone 
- net/pkt: Add readahead queue for pkt, call input for tx on sim
  - Without readahead queue, we may miss lots of packets, so add one with throttled IOB cloning.
  - On linux, tx packets will also be put into `packet_rcv` from `dev_queue_xmit_nit`, so we need to call pkt_input for tx packet too, otherwise we cannot capture them.
    - However, our current code structure may generate tx packets in both poll and reply, so the common place to put pkt_input might be the transmit function in netdriver.
    - Other net devices may need to do the same modify in order to capture tx packets like sim.

## Impact
Enhance NET_PKT functionality, in order to support https://github.com/apache/nuttx-apps/pull/1635

## Testing
Manually, CI

