### PR TITLE
ramlog: optimize ramlog_addchar, copy as much content as possible at a time

### DIFF
--- a/Documentation/components/drivers/special/syslog.rst
+++ b/Documentation/components/drivers/special/syslog.rst
@@ -490,9 +490,6 @@ RAMLOG Configuration options
 
 Other miscellaneous settings
 
--  ``CONFIG_RAMLOG_CRLF``: Pre-pend a carriage return before every
-   linefeed that goes into the RAM log.
-
 -  ``CONFIG_RAMLOG_NONBLOCKING``: Reading from the RAMLOG will
    never block if the RAMLOG is empty. If the RAMLOG is empty,
    then zero is returned (usually interpreted as end-of-file). If

--- a/drivers/syslog/Kconfig
+++ b/drivers/syslog/Kconfig
@@ -34,13 +34,6 @@ config RAMLOG
 		details as needed to support logging.
 
 if RAMLOG
-config RAMLOG_CRLF
-	bool "RAMLOG CR/LF"
-	default n
-	---help---
-		Pre-pend a carriage return before every linefeed that goes into the
-		RAM log.
-
 config RAMLOG_NONBLOCKING
 	bool "RAMLOG non-block reads"
 	default y

--- a/drivers/syslog/README.txt
+++ b/drivers/syslog/README.txt
@@ -468,8 +468,6 @@ RAM Logging Device
 
   Other miscellaneous settings
 
-    * CONFIG_RAMLOG_CRLF - Pre-pend a carriage return before every linefeed
-      that goes into the RAM log.
     * CONFIG_RAMLOG_NONBLOCKING - Reading from the RAMLOG will never block
       if the RAMLOG is empty.  If the RAMLOG is empty, then zero is returned
       (usually interpreted as end-of-file).  If you do not define this, the

--- a/drivers/syslog/ramlog.c
+++ b/drivers/syslog/ramlog.c
@@ -286,25 +286,6 @@ static int ramlog_addchar(FAR struct ramlog_dev_s *priv, char ch)
 
   flags = enter_critical_section();
 
-#ifdef CONFIG_RAMLOG_CRLF
-  /* Ignore carriage returns */
-
-  if (ch == '\r')
-    {
-      leave_critical_section(flags);
-      return OK;
-    }
-
-  /* Pre-pend a carriage before a linefeed */
-
-  if (ch == '\n')
-    {
-      ch = '\r';
-    }
-
-again:
-#endif
-
   /* Calculate the write index AFTER the next byte is written */
 
   nexthead = priv->rl_head + 1;
@@ -338,14 +319,6 @@ again:
 
   priv->rl_buffer[priv->rl_head] = ch;
   priv->rl_head = nexthead;
-
-#ifdef CONFIG_RAMLOG_CRLF
-  if (ch == '\r')
-    {
-      ch = '\n';
-      goto again;
-    }
-#endif
 
   leave_critical_section(flags);
   return OK;


### PR DESCRIPTION
## Summary
patch 1:  Remove CRLF conversion in ramlog
patch 2:  Replace ramlog_addchar to ramlog_addbuf，use memcpy to replace the byte -by -byte copy

There is already CRLF checking in syslog, it is not necessary to check again in ramlog.

## Impact
Original time: 1924240
Patch1 time: 1918140
Patch2 time: 1086392

## Testing
board：nucleo-h743zi
Enable the following options: CONFIG_SYSLOG_BUFFER，CONFIG_RAMLOG， CONFIG_RAMLOG_SYSLOG
