### PR TITLE
libc/libvsprintf: use puts to replace the putc

### DIFF
--- a/libs/libc/stdio/lib_libvsprintf.c
+++ b/libs/libc/stdio/lib_libvsprintf.c
@@ -68,6 +68,8 @@
 #endif
 
 #define stream_putc(c,stream)  (total_len++, lib_stream_putc(stream, c))
+#define stream_puts(buf, len, stream) \
+        (total_len += len, lib_stream_puts(stream, buf, len))
 
 /* Order is relevant here and matches order in format string */
 
@@ -947,16 +949,9 @@ str_lpad:
                 }
             }
 
-          while (size)
-            {
-              stream_putc(*pnt++, stream);
-              if (width != 0)
-                {
-                  width -= 1;
-                }
-
-              size -= 1;
-            }
+          stream_puts(pnt, size, stream);
+          width = width >= size ? width - size : 0;
+          size = 0;
 
           goto tail;
         }


### PR DESCRIPTION
## Summary
use puts to replace the putc to reduce the number of circulation

## Impact
printf

## Testing
sim:minibasic
