### PR TITLE
driver/uart_rpmsg: Passthrough data by default

### DIFF
--- a/drivers/serial/uart_rpmsg.c
+++ b/drivers/serial/uart_rpmsg.c
@@ -412,8 +412,14 @@ int uart_rpmsg_init(FAR const char *cpuname, FAR const char *devname,
       return ret;
     }
 
+  /* Ignore the `isconsole` to passthrough all UART data,
+   * since the most common usage of rpmsg uart is to communicate with cu
+   * in other processor core, should not do CRLF convertion and ECHO.
+   * Note: you can also change this behavior by termios.
+   */
+
   dev->ops       = &g_uart_rpmsg_ops;
-  dev->isconsole = isconsole;
+  dev->isconsole = false;
   dev->recv.size = buf_size;
   dev->xmit.size = buf_size;
 
@@ -454,7 +460,7 @@ int uart_rpmsg_init(FAR const char *cpuname, FAR const char *devname,
   sprintf(dev_name, "%s%s", UART_RPMSG_DEV_PREFIX, devname);
   uart_register(dev_name, dev);
 
-  if (dev->isconsole)
+  if (isconsole)
     {
       uart_register(UART_RPMSG_DEV_CONSOLE, dev);
     }


### PR DESCRIPTION
## Summary

driver/uart_rpmsg: Passthrough data by default

Ignore the `isconsole` to passthrough all UART data,
since the most common usage of rpmsg uart is to communicate with cu
in other processor core, should not do CRLF convertion and ECHO.
Note: you can also change this behavior by termios.

## Impact
rpmsg uart
## Testing
sim:rpserver and sim:rpproxy
