### PR TITLE
signal/sig_dispatch: Revert changes that cause a regression

### DIFF
--- a/sched/signal/sig_dispatch.c
+++ b/sched/signal/sig_dispatch.c
@@ -372,15 +372,6 @@ int nxsig_tcbdispatch(FAR struct tcb_s *stcb, siginfo_t *info)
   if (masked == 1)
 #endif
     {
-#ifdef CONFIG_LIB_SYSCALL
-      /* If the thread is in syscall, schedule the sigaction here */
-
-      if ((stcb->flags & TCB_FLAG_SYSCALL) != 0)
-        {
-          nxsig_add_pendingsignal(stcb, info);
-        }
-#endif
-
       /* Check if the task is waiting for this pending signal. If so, then
        * unblock it. This must be performed in a critical section because
        * signals can be queued from the interrupt level.


### PR DESCRIPTION
## Summary
This reverts changes that cause a regression in signal handling, more info in #8740

The problem still remains where signal actions are not performed / the user signal handler is not called if:
- The signal recipient is in syscall
- The signal recipient is waiting for a signal, i.e. stcb->task_state == TSTATE_WAIT_SIG

Only the process wake up part works, but the signal action is never performed. I need more time to fix this.
## Impact
Fix regression
## Testing
CI, code goes back to something that passes https://github.com/linux-test-project/ltp/blob/master/testcases/open_posix_testsuite/conformance/interfaces/timer_settime/9-2.c
