### PR TITLE
espressif: Fix download of IDFboot binaries

### DIFF
--- a/arch/risc-v/src/esp32c3/Bootloader.mk
+++ b/arch/risc-v/src/esp32c3/Bootloader.mk
@@ -176,7 +176,7 @@ clean_bootloader:
 else ifeq ($(CONFIG_ESP32C3_APP_FORMAT_LEGACY),y)
 
 bootloader:
-	$(call DOWNLOAD,$(BOOTLOADER_URL),mcuboot-esp32c3.bin,$(TOPDIR)/mcuboot-esp32c3.bin)
+	$(call DOWNLOAD,$(BOOTLOADER_URL),bootloader-esp32c3.bin,$(TOPDIR)/bootloader-esp32c3.bin)
 	$(call DOWNLOAD,$(BOOTLOADER_URL),partition-table-esp32c3.bin,$(TOPDIR)/partition-table-esp32c3.bin)
 
 clean_bootloader:

--- a/arch/xtensa/src/esp32/Bootloader.mk
+++ b/arch/xtensa/src/esp32/Bootloader.mk
@@ -185,7 +185,7 @@ clean_bootloader:
 else ifeq ($(CONFIG_ESP32_APP_FORMAT_LEGACY),y)
 
 bootloader:
-	$(call DOWNLOAD,$(BOOTLOADER_URL),mcuboot-esp32.bin,$(TOPDIR)/mcuboot-esp32.bin)
+	$(call DOWNLOAD,$(BOOTLOADER_URL),bootloader-esp32.bin,$(TOPDIR)/bootloader-esp32.bin)
 	$(call DOWNLOAD,$(BOOTLOADER_URL),partition-table-esp32.bin,$(TOPDIR)/partition-table-esp32.bin)
 
 clean_bootloader:

--- a/arch/xtensa/src/esp32s2/Bootloader.mk
+++ b/arch/xtensa/src/esp32s2/Bootloader.mk
@@ -174,7 +174,7 @@ clean_bootloader:
 else ifeq ($(CONFIG_ESP32S2_APP_FORMAT_LEGACY),y)
 
 bootloader:
-	$(call DOWNLOAD,$(BOOTLOADER_URL),mcuboot-esp32s2.bin,$(TOPDIR)/mcuboot-esp32s2.bin)
+	$(call DOWNLOAD,$(BOOTLOADER_URL),bootloader-esp32s2.bin,$(TOPDIR)/bootloader-esp32s2.bin)
 	$(call DOWNLOAD,$(BOOTLOADER_URL),partition-table-esp32s2.bin,$(TOPDIR)/partition-table-esp32s2.bin)
 
 clean_bootloader:

--- a/arch/xtensa/src/esp32s3/Bootloader.mk
+++ b/arch/xtensa/src/esp32s3/Bootloader.mk
@@ -118,7 +118,7 @@ clean_bootloader:
 else ifeq ($(CONFIG_ESP32S3_APP_FORMAT_LEGACY),y)
 
 bootloader:
-	$(call DOWNLOAD,$(BOOTLOADER_URL),mcuboot-esp32s3.bin,$(TOPDIR)/mcuboot-esp32s3.bin)
+	$(call DOWNLOAD,$(BOOTLOADER_URL),bootloader-esp32s3.bin,$(TOPDIR)/bootloader-esp32s3.bin)
 	$(call DOWNLOAD,$(BOOTLOADER_URL),partition-table-esp32s3.bin,$(TOPDIR)/partition-table-esp32s3.bin)
 
 clean_bootloader:


### PR DESCRIPTION
## Summary
This PR intends to fix a bug introduced after #8759, which erroneously substituted the names of IDFboot binaries with the one from MCUboot.

## Impact
The correct bootloader binary is once again properly downloaded.

## Testing
`./tools/configure.sh -E esp32s3-devkit:nsh && make bootloader`
