### PR TITLE
Fix unwanted flush in the SPI slave driver

### DIFF
--- a/drivers/spi/spi_slave_driver.c
+++ b/drivers/spi/spi_slave_driver.c
@@ -299,6 +299,7 @@ static ssize_t spi_slave_read(FAR struct file *filep, FAR char *buffer,
       return -ENOBUFS;
     }
 
+  priv->rx_length = MIN(buflen, sizeof(priv->rx_buffer));
   remaining_words = SPIS_CTRLR_QPOLL(priv->ctrlr);
   if (remaining_words == 0)
     {
@@ -542,7 +543,7 @@ static size_t spi_slave_receive(FAR struct spi_slave_dev_s *dev,
                                 FAR const void *data, size_t len)
 {
   FAR struct spi_slave_driver_s *priv = (FAR struct spi_slave_driver_s *)dev;
-  size_t recv_bytes = MIN(len, sizeof(priv->rx_buffer));
+  size_t recv_bytes = MIN(len, priv->rx_length);
 
   memcpy(priv->rx_buffer, data, recv_bytes);
 


### PR DESCRIPTION
## Summary
This PR intends to fix a bug detected in the upper half SPI slave driver.  The bug appears when there are X bytes in the driver buffer and a read is performed with a smaller size buffer. In that call, the data that fits in the buffer is returned to the user, and the rest that remains to be read is discarded.
With the proposed fix, successive readings will return the rest of the bytes pending to be read.

## Impact
No data is lost when reading from the slave SPI bus.

## Testing

