### PR TITLE
arch: fixed error in the calculation of nwords caused an out of bounds

### DIFF
--- a/arch/arm/src/common/arm_checkstack.c
+++ b/arch/arm/src/common/arm_checkstack.c
@@ -172,7 +172,7 @@ void arm_stack_color(void *stackbase, size_t nbytes)
     }
 
   stkend = STACK_ALIGN_DOWN(stkend);
-  nwords = (stkend - (uintptr_t)stackbase) >> 2;
+  nwords = (stkend - (uintptr_t)stkptr) >> 2;
 
   /* Set the entire stack to the coloration value */
 

--- a/arch/ceva/src/common/ceva_createstack.c
+++ b/arch/ceva/src/common/ceva_createstack.c
@@ -253,7 +253,7 @@ void ceva_stack_color(void *stackbase, size_t nbytes)
     }
 
   stkend = STACK_ALIGN_DOWN(stkend);
-  nwords = (stkend - (uintptr_t)stackbase) >> 2;
+  nwords = (stkend - (uintptr_t)stkptr) >> 2;
 
   /* Set the entire stack to the coloration value */
 

--- a/arch/or1k/src/common/or1k_createstack.c
+++ b/arch/or1k/src/common/or1k_createstack.c
@@ -226,7 +226,7 @@ void or1k_stack_color(void *stackbase, size_t nbytes)
     }
 
   stkend = STACK_ALIGN_DOWN(stkend);
-  nwords = (stkend - (uintptr_t)stackbase) >> 2;
+  nwords = (stkend - (uintptr_t)stkptr) >> 2;
 
   /* Set the entire stack to the coloration value */
 

--- a/arch/risc-v/src/common/riscv_createstack.c
+++ b/arch/risc-v/src/common/riscv_createstack.c
@@ -236,7 +236,7 @@ void riscv_stack_color(void *stackbase, size_t nbytes)
     }
 
   stkend = STACK_ALIGN_DOWN(stkend);
-  nwords = (stkend - (uintptr_t)stackbase) >> 2;
+  nwords = (stkend - (uintptr_t)stkptr) >> 2;
 
   /* Set the entire stack to the coloration value */
 

--- a/arch/sim/src/sim/sim_createstack.c
+++ b/arch/sim/src/sim/sim_createstack.c
@@ -188,7 +188,7 @@ void nostackprotect_function sim_stack_color(void *stackbase,
     }
 
   stkend = STACK_ALIGN_DOWN(stkend);
-  nwords = (stkend - (uintptr_t)stackbase) >> 2;
+  nwords = (stkend - (uintptr_t)stkptr) >> 2;
   nwords = nwords > STACK_MARGIN_WORDS ? nwords - STACK_MARGIN_WORDS : 0;
 
   /* Set the entire stack to the coloration value */

--- a/arch/sparc/src/common/sparc_checkstack.c
+++ b/arch/sparc/src/common/sparc_checkstack.c
@@ -172,7 +172,7 @@ void sparc_stack_color(void *stackbase, size_t nbytes)
     }
 
   stkend = STACK_ALIGN_DOWN(stkend);
-  nwords = (stkend - (uintptr_t)stackbase) >> 2;
+  nwords = (stkend - (uintptr_t)stkptr) >> 2;
 
   /* Set the entire stack to the coloration value */
 

--- a/arch/xtensa/src/common/xtensa_createstack.c
+++ b/arch/xtensa/src/common/xtensa_createstack.c
@@ -242,7 +242,7 @@ void xtensa_stack_color(void *stackbase, size_t nbytes)
     }
 
   stkend = STACK_ALIGN_DOWN(stkend);
-  nwords = (stkend - (uintptr_t)stackbase) >> 2;
+  nwords = (stkend - (uintptr_t)stkptr) >> 2;
 
   /* Set the entire stack to the coloration value */
 


### PR DESCRIPTION
## Summary

 Fixed an error in the calculation of nwords caused an out of bounds.

## Impact

stack

## Testing

ostest pass