### PR TITLE
arch: Rename up_[early]serialinit to [arm64|riscv|x86_64][early]serialinit

### DIFF
--- a/arch/arm64/Kconfig
+++ b/arch/arm64/Kconfig
@@ -114,7 +114,7 @@ config ARCH_EARLY_PRINT
 		different platform, if NuttX runing at wrong ELs or state it will
 		be not normal anymore. So we need to print something in arm64_head.S
 		to debug this situation.
-		Enabling this option will need to implement up_earlyserialinit and
+		Enabling this option will need to implement arm64_earlyserialinit and
 		arm64_lowputc functions just you see in qemu, if you not sure,
 		keeping the option disable.
 

--- a/arch/arm64/src/a64/a64_lowputc.S
+++ b/arch/arm64/src/a64/a64_lowputc.S
@@ -49,15 +49,6 @@
  * Public Functions
  ****************************************************************************/
 
-/* Initialize A64 UART
- * xb: Register that contains the UART Base Address
- * c:  Scratch register number
- */
-
-GTEXT(up_earlyserialinit)
-SECTION_FUNC(text, up_earlyserialinit)
-    ret  /* Do nothing because U-Boot has already initialized UART */
-
 /* Wait for A64 UART to be ready to transmit
  * xb: Register that contains the UART Base Address
  * wt: Scratch register number

--- a/arch/arm64/src/common/arm64_head.S
+++ b/arch/arm64/src/common/arm64_head.S
@@ -193,7 +193,7 @@ primary_core:
      * Should only be called on the boot CPU
      */
 
-    bl    up_earlyserialinit
+    bl    arm64_earlyserialinit
 #endif
 
     PRINT(primary_boot, "- Ready to Boot Primary CPU\r\n")

--- a/arch/arm64/src/fvp-v8r/fvp_lowputc.S
+++ b/arch/arm64/src/fvp-v8r/fvp_lowputc.S
@@ -50,24 +50,6 @@
  * Public Functions
  ****************************************************************************/
 
-/* PL011 UART initialization
- * xb: register which contains the UART base address
- * c: scratch register number
- */
-
-GTEXT(up_earlyserialinit)
-SECTION_FUNC(text, up_earlyserialinit)
-    ldr   x15, =CONFIG_UART0_BASE
-    mov   x0, #(7372800 / EARLY_UART_PL011_BAUD_RATE % 16)
-    strh  w0, [x15, #0x28]      /* -> UARTFBRD (Baud divisor fraction) */
-    mov   x0, #(7372800 / EARLY_UART_PL011_BAUD_RATE / 16)
-    strh  w0, [x15, #0x24]      /* -> UARTIBRD (Baud divisor integer) */
-    mov   x0, #0x60             /* 8n1 */
-    str   w0, [x15, #0x2C]      /* -> UARTLCR_H (Line control) */
-    ldr   x0, =0x00000301       /* RXE | TXE | UARTEN */
-    str   w0, [x15, #0x30]      /* -> UARTCR (Control Register) */
-    ret
-
 /* PL011 UART wait UART to be ready to transmit
  * xb: register which contains the UART base address
  * c: scratch register number

--- a/arch/arm64/src/qemu/qemu_lowputc.S
+++ b/arch/arm64/src/qemu/qemu_lowputc.S
@@ -50,24 +50,6 @@
  * Public Functions
  ****************************************************************************/
 
-/* PL011 UART initialization
- * xb: register which contains the UART base address
- * c: scratch register number
- */
-
-GTEXT(up_earlyserialinit)
-SECTION_FUNC(text, up_earlyserialinit)
-    ldr   x15, =UART1_BASE_ADDRESS
-    mov   x0, #(7372800 / EARLY_UART_PL011_BAUD_RATE % 16)
-    strh  w0, [x15, #0x28]      /* -> UARTFBRD (Baud divisor fraction) */
-    mov   x0, #(7372800 / EARLY_UART_PL011_BAUD_RATE / 16)
-    strh  w0, [x15, #0x24]      /* -> UARTIBRD (Baud divisor integer) */
-    mov   x0, #0x60             /* 8n1 */
-    str   w0, [x15, #0x2C]      /* -> UARTLCR_H (Line control) */
-    ldr   x0, =0x00000301       /* RXE | TXE | UARTEN */
-    str   w0, [x15, #0x30]      /* -> UARTCR (Control Register) */
-    ret
-
 /* PL011 UART wait UART to be ready to transmit
  * xb: register which contains the UART base address
  * c: scratch register number

--- a/arch/risc-v/src/qemu-rv/chip.h
+++ b/arch/risc-v/src/qemu-rv/chip.h
@@ -29,17 +29,6 @@
 
 #include <arch/qemu-rv/chip.h>
 
-#ifndef __ASSEMBLY__
-
-/* Include the chip interrupt definition file */
-
-/* Serial initial function defined in uart_16550.c */
-
-extern void up_earlyserialinit(void);
-extern void up_serialinit(void);
-
-#endif /* __ASSEMBLY__  */
-
 #include "qemu_rv_memorymap.h"
 
 #include "hardware/qemu_rv_clint.h"

--- a/arch/risc-v/src/qemu-rv/qemu_rv_start.c
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_start.c
@@ -26,6 +26,7 @@
 
 #include <nuttx/init.h>
 #include <nuttx/arch.h>
+#include <nuttx/serial/uart_16550.h>
 #include <arch/board/board.h>
 
 #include "riscv_internal.h"
@@ -117,7 +118,7 @@ void qemu_rv_start(int mhartid)
   showprogress('A');
 
 #ifdef USE_EARLYSERIALINIT
-  up_earlyserialinit();
+  riscv_earlyserialinit();
 #endif
 
   showprogress('B');
@@ -218,7 +219,12 @@ void qemu_rv_start(int mhartid)
 }
 #endif
 
+void riscv_earlyserialinit(void)
+{
+  u16550_earlyserialinit();
+}
+
 void riscv_serialinit(void)
 {
-  up_serialinit();
+  u16550_serialinit();
 }

--- a/arch/x86/src/qemu/chip.h
+++ b/arch/x86/src/qemu/chip.h
@@ -56,7 +56,4 @@
  * Public Functions Prototypes
  ************************************************************************************/
 
-void up_earlyserialinit(void);
-void up_serialinit(void);
-
 #endif /* __ARCH_X86_SRC_QEMU_CHIP_H */

--- a/arch/x86/src/qemu/qemu_serial.c
+++ b/arch/x86/src/qemu/qemu_serial.c
@@ -93,13 +93,13 @@ int up_putc(int ch)
 #ifdef USE_EARLYSERIALINIT
 void x86_earlyserialinit(void)
 {
-  up_earlyserialinit();
+  u16550_earlyserialinit();
 }
 #endif
 
 #ifdef USE_SERIALDRIVER
 void x86_serialinit(void)
 {
-  up_serialinit();
+  u16550_serialinit();
 }
 #endif

--- a/arch/x86_64/src/intel64/chip.h
+++ b/arch/x86_64/src/intel64/chip.h
@@ -43,9 +43,4 @@
  * Public Function Prototypes
  ************************************************************************************/
 
-/* Serial initial function defined in uart_16550.c */
-
-extern void up_earlyserialinit(void);
-extern void up_serialinit(void);
-
 #endif /* __ARCH_X86_64_SRC_INTEL64_CHIP_H */

--- a/arch/x86_64/src/intel64/intel64_serial.c
+++ b/arch/x86_64/src/intel64/intel64_serial.c
@@ -101,10 +101,10 @@ int up_putc(int ch)
 
 void x86_64_earlyserialinit(void)
 {
-  up_earlyserialinit();
+  u16550_earlyserialinit();
 }
 
 void x86_64_serialinit(void)
 {
-  up_serialinit();
+  u16550_serialinit();
 }

--- a/drivers/serial/Kconfig
+++ b/drivers/serial/Kconfig
@@ -73,11 +73,6 @@ config RPMSG_UART
 	select SERIAL_REMOVABLE
 	select SERIAL_IFLOWCONTROL
 
-config RPMSG_SERIALINIT
-	bool "Add dummy up_serialinit for UART rpmsg"
-	default y if !16550_UART && !MCU_SERIAL
-	depends on RPMSG_UART
-
 #
 # Standard serial driver configuration
 #

--- a/drivers/serial/uart_16550.c
+++ b/drivers/serial/uart_16550.c
@@ -1276,7 +1276,7 @@ static void u16550_putc(FAR struct u16550_s *priv, int ch)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_earlyserialinit
+ * Name: u16550_earlyserialinit
  *
  * Description:
  *   Performs the low level UART initialization early in debug so that the
@@ -1288,7 +1288,7 @@ static void u16550_putc(FAR struct u16550_s *priv, int ch)
  *
  ****************************************************************************/
 
-void up_earlyserialinit(void)
+void u16550_earlyserialinit(void)
 {
   /* Configuration whichever one is the console */
 
@@ -1301,15 +1301,15 @@ void up_earlyserialinit(void)
 }
 
 /****************************************************************************
- * Name: up_serialinit
+ * Name: u16550_serialinit
  *
  * Description:
  *   Register serial console and serial ports.  This assumes that
- *   up_earlyserialinit was called previously.
+ *   u16550_earlyserialinit was called previously.
  *
  ****************************************************************************/
 
-void up_serialinit(void)
+void u16550_serialinit(void)
 {
 #ifdef CONSOLE_DEV
   uart_register("/dev/console", &CONSOLE_DEV);

--- a/drivers/serial/uart_rpmsg.c
+++ b/drivers/serial/uart_rpmsg.c
@@ -475,15 +475,3 @@ fail:
 
   return ret;
 }
-
-#ifdef CONFIG_RPMSG_SERIALINIT
-/* Dummy function to make linker happy */
-
-void up_earlyserialinit(void)
-{
-}
-
-void up_serialinit(void)
-{
-}
-#endif /* CONFIG_RPMSG_SERIALINIT */

--- a/include/nuttx/serial/uart_16550.h
+++ b/include/nuttx/serial/uart_16550.h
@@ -331,6 +331,32 @@ typedef uint64_t uart_addrwidth_t;
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: u16550_earlyserialinit
+ *
+ * Description:
+ *   Performs the low level UART initialization early in debug so that the
+ *   serial console will be available during bootup.  This must be called
+ *   before uart_serialinit.
+ *
+ *   NOTE: Configuration of the CONSOLE UART was performed by uart_lowsetup()
+ *   very early in the boot sequence.
+ *
+ ****************************************************************************/
+
+void u16550_earlyserialinit(void);
+
+/****************************************************************************
+ * Name: u16550_serialinit
+ *
+ * Description:
+ *   Register serial console and serial ports.  This assumes that
+ *   u16550_earlyserialinit was called previously.
+ *
+ ****************************************************************************/
+
+void u16550_serialinit(void);
+
+/****************************************************************************
  * Name: uart_getreg(), uart_putreg(), uart_ioctl()
  *
  * Description:


### PR DESCRIPTION
## Summary

The naming standard at:
https://cwiki.apache.org/confluence/display/NUTTX/Naming+of+Architecture%2C+MCU%2C+and+Board+Interfaces
requires that all MCU-private function begin with the name of the architecture, not up_.

follow the change from: https://github.com/apache/nuttx/pull/930
## Impact

arm64, riscv-v and x86[_64]

## Testing

CI