### PR TITLE
fs/mmap: try rammap when filesystem mmap don't support

### DIFF
--- a/fs/mmap/fs_mmap.c
+++ b/fs/mmap/fs_mmap.c
@@ -50,7 +50,7 @@ static int file_mmap_(FAR struct file *filep, FAR void *start,
                       size_t length, int prot, int flags,
                       off_t offset, bool kernel, FAR void **mapped)
 {
-  int ret;
+  int ret = -ENOTTY;
 
   /* Pass the information about the mapping in mm_map_entry_s structure.
    * The driver may alter the structure, and if it supports unmap, it
@@ -133,7 +133,8 @@ static int file_mmap_(FAR struct file *filep, FAR void *start,
     {
       ret = filep->f_inode->u.i_ops->mmap(filep, &entry);
     }
-  else
+
+  if (ret == -ENOTTY)
     {
       /* Caller request the private mapping. Or not directly mappable,
        * probably because the underlying media doesn't support random access.

--- a/fs/romfs/fs_romfs.c
+++ b/fs/romfs/fs_romfs.c
@@ -612,7 +612,6 @@ static int romfs_mmap(FAR struct file *filep, FAR struct mm_map_entry_s *map)
 {
   FAR struct romfs_mountpt_s *rm;
   FAR struct romfs_file_s *rf;
-  int ret = -EINVAL;
 
   /* Sanity checks */
 
@@ -631,10 +630,10 @@ static int romfs_mmap(FAR struct file *filep, FAR struct mm_map_entry_s *map)
       map->length != 0 && map->offset + map->length <= rf->rf_size)
     {
       map->vaddr = rm->rm_xipbase + rf->rf_startoffset + map->offset;
-      ret = OK;
+      return OK;
     }
 
-  return ret;
+  return -ENOTTY;
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
fs/mmap: try rammap when filesystem mmap don't support

## Impact
using mmap for romfs.
## Testing
local test
