### PR TITLE
net/icmpv6: align structs to 2 bytes.

### DIFF
--- a/include/nuttx/net/icmpv6.h
+++ b/include/nuttx/net/icmpv6.h
@@ -258,8 +258,8 @@ struct icmpv6_router_advertise_s
   uint8_t  hoplimit;         /* Current hop limit */
   uint8_t  flags;            /* See ICMPv6_RADV_FLAG_* definitions */
   uint16_t lifetime;         /* Router lifetime */
-  uint32_t reachable;        /* Reachable time */
-  uint32_t retrans;          /* Retransmission timer */
+  uint16_t reachable[2];     /* Reachable time */
+  uint16_t retrans[2];       /* Retransmission timer */
                              /* Options begin here */
 };
 
@@ -329,8 +329,8 @@ struct icmpv6_prefixinfo_s
   uint8_t  optlen;           /* "   " ": Option length: 4 octets */
   uint8_t  preflen;          /* "   " ": Prefix length */
   uint8_t  flags;            /* "   " ": Flags */
-  uint32_t vlifetime;        /* "   " ": Valid lifetime */
-  uint32_t plifetime;        /* Octet 2: Preferred lifetime */
+  uint16_t vlifetime[2];     /* "   " ": Valid lifetime */
+  uint16_t plifetime[2];     /* Octet 2: Preferred lifetime */
   uint16_t reserved[2];      /* "   " ": Reserved */
   uint16_t prefix[8];        /* Octets 3-4: Prefix */
 };
@@ -348,7 +348,7 @@ struct icmpv6_mtu_s
   uint8_t  opttype;          /* Octet 1: Option Type: ICMPv6_OPT_MTU */
   uint8_t  optlen;           /* "   " ": Option length: 1 octet */
   uint16_t reserved;         /* "   " ": Reserved */
-  uint32_t mtu;              /* "   " ": MTU */
+  uint16_t mtu[2];           /* "   " ": MTU */
 };
 
 /* The structure holding the ICMP statistics that are gathered if

--- a/net/icmpv6/icmpv6_input.c
+++ b/net/icmpv6/icmpv6_input.c
@@ -353,7 +353,7 @@ void icmpv6_input(FAR struct net_driver_s *dev, unsigned int iplen)
                   {
                     FAR struct icmpv6_mtu_s *mtuopt =
                                         (FAR struct icmpv6_mtu_s *)opt;
-                    dev->d_pktsize = NTOHL(mtuopt->mtu) + dev->d_llhdrlen;
+                    dev->d_pktsize = NTOHS(mtuopt->mtu[1]) + dev->d_llhdrlen;
                   }
                   break;
 

--- a/net/icmpv6/icmpv6_radvertise.c
+++ b/net/icmpv6/icmpv6_radvertise.c
@@ -147,8 +147,10 @@ void icmpv6_radvertise(FAR struct net_driver_s *dev)
   adv->hoplimit     = 64;                      /* Current hop limit */
   adv->flags        = ICMPv6_RADV_FLAG_M;      /* Managed address flag. */
   adv->lifetime     = HTONS(1800);             /* Router lifetime */
-  adv->reachable    = 0;                       /* Reachable time */
-  adv->retrans      = 0;                       /* Retransmission timer */
+  adv->reachable[0] = 0;                       /* Reachable time */
+  adv->reachable[1] = 0;
+  adv->retrans[0]   = 0;                       /* Retransmission timer */
+  adv->retrans[1]   = 0;
 
   /* Set up the source address option */
 
@@ -167,19 +169,22 @@ void icmpv6_radvertise(FAR struct net_driver_s *dev)
   mtu->opttype      = ICMPv6_OPT_MTU;
   mtu->optlen       = 1;
   mtu->reserved     = 0;
-  mtu->mtu          = HTONL(dev->d_pktsize - dev->d_llhdrlen);
+  mtu->mtu[0]       = 0;
+  mtu->mtu[1]       = HTONS(dev->d_pktsize - dev->d_llhdrlen);
 
   /* Set up the prefix option */
 
-  prefix              = (FAR struct icmpv6_prefixinfo_s *)
-                        ((FAR uint8_t *)mtu + sizeof(struct icmpv6_mtu_s));
-  prefix->opttype     = ICMPv6_OPT_PREFIX;
-  prefix->optlen      = 4;
-  prefix->flags       = ICMPv6_PRFX_FLAG_L | ICMPv6_PRFX_FLAG_A;
-  prefix->vlifetime   = HTONL(2592000);
-  prefix->plifetime   = HTONL(604800);
-  prefix->reserved[0] = 0;
-  prefix->reserved[1] = 0;
+  prefix               = (FAR struct icmpv6_prefixinfo_s *)
+                         ((FAR uint8_t *)mtu + sizeof(struct icmpv6_mtu_s));
+  prefix->opttype      = ICMPv6_OPT_PREFIX;
+  prefix->optlen       = 4;
+  prefix->flags        = ICMPv6_PRFX_FLAG_L | ICMPv6_PRFX_FLAG_A;
+  prefix->vlifetime[0] = HTONS(2592000 >> 16);
+  prefix->vlifetime[1] = HTONS(2592000 & 0xffff);
+  prefix->plifetime[0] = HTONS(604800 >> 16);
+  prefix->plifetime[1] = HTONS(604800 & 0xffff);
+  prefix->reserved[0]  = 0;
+  prefix->reserved[1]  = 0;
 
 #ifdef CONFIG_NET_ICMPv6_ROUTER_MANUAL
   /* Copy the configured prefex */


### PR DESCRIPTION
## Summary
Fix following misaligned errors:
```
icmpv6/icmpv6_radvertise.c:145:21: runtime error: member access within misaligned address 0x573da9e6 for type 'struct icmpv6_router_advertise_s', which requires 4 byte alignment
0x573da9e6: note: pointer points here
 00 00 00 01 85 00  d6 14 00 00 00 00 01 01  12 8c 25 08 9c f8 04 00  00 00 ff 02 00 00 00 00  00 00
             ^
icmpv6/icmpv6_radvertise.c:167:21: runtime error: member access within misaligned address 0x573da9fe for type 'struct icmpv6_mtu_s', which requires 4 byte alignment
0x573da9fe: note: pointer points here
 af 78 ab 72 00 00  00 00 00 00 00 01 ff 00  00 01 04 00 00 00 ff 02  00 00 00 00 00 00 00 00  00 01
             ^
icmpv6/icmpv6_radvertise.c:176:23: runtime error: member access within misaligned address 0x573daa06 for type 'struct icmpv6_prefixinfo_s', which requires 4 byte alignment
0x573daa06: note: pointer points here
 00 00 05 dc ff 00  00 01 04 00 00 00 ff 02  00 00 00 00 00 00 00 00  00 01 ff 08 9c f8 04 00  00 00
             ^
```

This was first introduced by d0f72617, but our network data is normally aligned to 2 bytes (such as ipaddr in ipv4_hdr_s) and cannot be assumed to be aligned by 4.

## Impact
Align icmpv6 structs to 2 bytes.

## Testing
Manually & CI
