### PR TITLE
sig_timewait:changes the macro for waitticks

### DIFF
--- a/sched/signal/sig_timedwait.c
+++ b/sched/signal/sig_timedwait.c
@@ -242,7 +242,11 @@ int nxsig_timedwait(FAR const sigset_t *set, FAR struct siginfo *info,
   sigset_t intersection;
   FAR sigpendq_t *sigpend;
   irqstate_t flags;
+#ifdef CONFIG_SYSTEM_TIME64
+  int64_t waitticks;
+#else
   int32_t waitticks;
+#endif
   bool switch_needed;
   int ret;
 
@@ -320,13 +324,11 @@ int nxsig_timedwait(FAR const sigset_t *set, FAR struct siginfo *info,
            * time in nanoseconds.
            */
 
-#ifdef CONFIG_HAVE_LONG_LONG
-          uint64_t waitticks64 = ((uint64_t)timeout->tv_sec * NSEC_PER_SEC +
-                                  (uint64_t)timeout->tv_nsec +
-                                  NSEC_PER_TICK - 1) /
-                                 NSEC_PER_TICK;
-          DEBUGASSERT(waitticks64 <= UINT32_MAX);
-          waitticks = (uint32_t)waitticks64;
+#ifdef CONFIG_SYSTEM_TIME64
+          waitticks = ((uint64_t)timeout->tv_sec * NSEC_PER_SEC +
+                      (uint64_t)timeout->tv_nsec + NSEC_PER_TICK - 1) /
+                      NSEC_PER_TICK;
+          DEBUGASSERT(waitticks <= UINT32_MAX);
 #else
           uint32_t waitmsec;
 


### PR DESCRIPTION
use SYSTEM_TIME64 inside of LONG LONG better
Sometimes longlong and system_time64 are not uniform
## Summary
changes the macro for waitticks
## Impact
signal
## Testing
sim nsh
