### PR TITLE
pwm.h: add comment regarding possible channel numbers

### DIFF
--- a/include/nuttx/timers/pwm.h
+++ b/include/nuttx/timers/pwm.h
@@ -64,6 +64,14 @@
  *   debug the PWM driver.
  */
 
+/* Channel Numbers **********************************************************/
+
+/* PWM channels should use numbers from 1 to CONFIG_PWM_NCHANNELS. Channel
+ * number 0 indicates the channel not used and therefore is skipped by
+ * the driver (its output remains at the value defined by the peripheral),
+ * number -1 indicates the channel and all following channels are not used.
+ */
+
 /* IOCTL Commands ***********************************************************/
 
 /* The PWM module uses a standard character driver framework.  However, since


### PR DESCRIPTION
## Summary
PWM drivers use channel numbers 0 and -1 to skip the channel and/or all following channels. This situation is well established in the drivers however it was not mentioned in pwm.h file. This commit adds a comment mentioning it.

## Impact
None, just a clarifying comment.

