### PR TITLE
drivers/bluetooth: bth4 depends on bluetooth definitions

### DIFF
--- a/drivers/serial/Kconfig
+++ b/drivers/serial/Kconfig
@@ -714,6 +714,7 @@ endif # PSEUDOTERM
 menuconfig UART_BTH4
 	bool "BT H4 uart pseudo device"
 	default n
+	depends on DRIVERS_BLUETOOTH
 	---help---
 		Enable support for Bluetooth H4 UART Pseudo Device(eg. /dev/ttyHCI).
 		This instantiates a serial-like interface over an existing bluetooth


### PR DESCRIPTION
## Summary
drivers/bluetooth: bth4 depends on bluetooth definitions
## Impact
fix compilation errors
## Testing
sim/btuart without DRIVERS_BLUETOOTH selected
