### PR TITLE
nrf52/nrf53: various fixes

### DIFF
--- a/arch/arm/src/nrf52/Kconfig
+++ b/arch/arm/src/nrf52/Kconfig
@@ -710,8 +710,15 @@ config NRF52_SDC_PERIPHERAL_COUNT
 		determines the number of central roles from the following:
 
 		CENTRAL_ROLES = CONFIG_BLUETOOTH_MAX_CONN - NRF52_SDC_PERIPHERAL_COUNT
+		or
+		CENTRAL_ROLES = NRF52_SDC_MAX_COUNT - NRF52_SDC_PERIPHERAL_COUNT
 
 		So by choosing these two variables you can control both capabilities.
+
+config NRF52_SDC_MAX_COUNT
+	int "Maximum number of roles to support"
+	default 1
+	depends on !NET_BLUETOOTH
 
 config NRF52_SDC_ADVERTISING
 	bool "Support advertising"

--- a/arch/arm/src/nrf52/nrf52_lowputc.c
+++ b/arch/arm/src/nrf52/nrf52_lowputc.c
@@ -74,12 +74,6 @@ static const struct uart_config_s g_console_config =
   .parity    = CONSOLE_PARITY,
   .bits      = CONSOLE_BITS,
   .stopbits2 = CONSOLE_2STOP,
-#ifdef CONFIG_SERIAL_IFLOWCONTROL
-  .iflow     = CONSOLE_IFLOW,
-#endif
-#ifdef CONFIG_SERIAL_OFLOWCONTROL
-  .oflow     = CONSOLE_OFLOW,
-#endif
   .txpin     = CONSOLE_TX_PIN,
   .rxpin     = CONSOLE_RX_PIN,
 };

--- a/arch/arm/src/nrf52/nrf52_sdc.c
+++ b/arch/arm/src/nrf52/nrf52_sdc.c
@@ -58,6 +58,12 @@
 
 /* Connections configuration ************************************************/
 
+/* If NET_BLUETOOTH not defined */
+
+#ifndef CONFIG_BLUETOOTH_MAX_CONN
+#  define CONFIG_BLUETOOTH_MAX_CONN CONFIG_NRF52_SDC_MAX_COUNT
+#endif
+
 #if defined(CONFIG_SDC_PERIPHERAL_COUNT) && \
     CONFIG_SDC_PERIPHERAL_COUNT > CONFIG_BLUETOOTH_MAX_CONN
 #  error "Cannot support more BLE peripheral roles than connections"
@@ -270,7 +276,7 @@ static int bt_open(struct bt_driver_s *btdev)
 }
 
 /****************************************************************************
- * Name: bt_open
+ * Name: bt_hci_send
  ****************************************************************************/
 
 static int bt_hci_send(struct bt_driver_s *btdev,

--- a/arch/arm/src/nrf53/Kconfig
+++ b/arch/arm/src/nrf53/Kconfig
@@ -24,6 +24,7 @@ config NRF53_APPCORE
 	select ARCH_HAVE_FPU
 	select NRF53_HAVE_PWM
 	select NRF53_HAVE_SAADC
+	select NRF53_HAVE_UART1
 
 config NRF53_NETCORE
 	bool
@@ -70,6 +71,10 @@ config NRF53_ENABLE_APPROTECT
 
 # Peripheral support
 
+config NRF53_HAVE_UART1
+	bool
+	default n
+
 config NRF53_HAVE_PWM
 	bool
 	default n
@@ -107,6 +112,7 @@ config NRF53_UART0
 config NRF53_UART1
 	bool "UART1"
 	default n
+	depends on NRF53_HAVE_UART1
 	select UART1_SERIALDRIVER
 	select NRF53_UART
 

--- a/arch/arm/src/nrf53/Kconfig
+++ b/arch/arm/src/nrf53/Kconfig
@@ -435,8 +435,15 @@ config NRF53_SDC_PERIPHERAL_COUNT
 		determines the number of central roles from the following:
 
 		CENTRAL_ROLES = CONFIG_BLUETOOTH_MAX_CONN - NRF53_SDC_PERIPHERAL_COUNT
+		or
+		CENTRAL_ROLES = NRF52_SDC_MAX_COUNT - NRF52_SDC_PERIPHERAL_COUNT
 
 		So by choosing these two variables you can control both capabilities.
+
+config NRF53_SDC_MAX_COUNT
+	int "Maximum number of roles to support"
+	default 1
+	depends on !NET_BLUETOOTH
 
 config NRF53_SDC_ADVERTISING
 	bool "Support advertising"

--- a/arch/arm/src/nrf53/nrf53_clockconfig.c
+++ b/arch/arm/src/nrf53/nrf53_clockconfig.c
@@ -95,6 +95,8 @@ void nrf53_clockconfig(void)
   putreg32(0x0, NRF53_CLOCK_EVENTS_LFCLKSTARTED);
   putreg32(0x1, NRF53_CLOCK_TASKS_LFCLKSTART);
 
+  /* NOTE: Oscillator must be configured on the app core */
+
   while (!getreg32(NRF53_CLOCK_EVENTS_LFCLKSTARTED))
     {
       /* Wait for LFCLK to be running */

--- a/arch/arm/src/nrf53/nrf53_lowputc.c
+++ b/arch/arm/src/nrf53/nrf53_lowputc.c
@@ -74,12 +74,6 @@ static const struct uart_config_s g_console_config =
   .parity    = CONSOLE_PARITY,
   .bits      = CONSOLE_BITS,
   .stopbits2 = CONSOLE_2STOP,
-#ifdef CONFIG_SERIAL_IFLOWCONTROL
-  .iflow     = CONSOLE_IFLOW,
-#endif
-#ifdef CONFIG_SERIAL_OFLOWCONTROL
-  .oflow     = CONSOLE_OFLOW,
-#endif
   .txpin     = CONSOLE_TX_PIN,
   .rxpin     = CONSOLE_RX_PIN,
 };

--- a/arch/arm/src/nrf53/nrf53_sdc.c
+++ b/arch/arm/src/nrf53/nrf53_sdc.c
@@ -62,6 +62,12 @@
 
 /* Connections configuration ************************************************/
 
+/* If NET_BLUETOOTH not defined */
+
+#ifndef CONFIG_NET_BLUETOOTH
+#  define CONFIG_BLUETOOTH_MAX_CONN CONFIG_NRF53_SDC_MAX_COUNT
+#endif
+
 #if defined(CONFIG_SDC_PERIPHERAL_COUNT) && \
     CONFIG_SDC_PERIPHERAL_COUNT > CONFIG_BLUETOOTH_MAX_CONN
 #  error "Cannot support more BLE peripheral roles than connections"
@@ -261,7 +267,7 @@ static int bt_open(struct bt_driver_s *btdev)
 }
 
 /****************************************************************************
- * Name: bt_open
+ * Name: bt_hci_send
  ****************************************************************************/
 
 static int bt_hci_send(struct bt_driver_s *btdev,


### PR DESCRIPTION
## Summary

- nrf52/nrf53: lowputc: fix compilation if flow control enabled
- nrf52/nrf53/sdc: define BLE max connection if NET_BLUETOOTH=n
- nrf53: UART1 available only on the app core
- nrf53_clockconfig.c: add comment about oscillator configuration

## Impact
various improvements
## Testing
CI
