### PR TITLE
mmcsd: add nxsig_usleep delay after MMC_CMD1 command

### DIFF
--- a/drivers/mmcsd/mmcsd_sdio.c
+++ b/drivers/mmcsd/mmcsd_sdio.c
@@ -3377,6 +3377,12 @@ static int mmcsd_cardidentify(FAR struct mmcsd_state_s *priv)
   if (ret != OK)
     {
       ferr("ERROR: CMD1 RECVR3: %d\n", ret);
+
+      /* CMD1 did not succeed, card is not MMC. This sleep let
+       * the communication to recover before another send.
+       */
+
+      nxsig_usleep(MMCSD_IDLE_DELAY);
     }
   else
     {


### PR DESCRIPTION
## Summary
MMC_CMD1 command is used to check whether card is MMC type (checked if CONFIG_MMCSD_MMCSUPPORT is enabled). This commit inserts nxsig_usleep wait if this check fails. This is to ensure the communication recovers from invalid response as this may take some time on some platforms (samv7 for example). Following command for SDHC check may fail if sleep is not used.

## Impact
If CONFIG_MMCSD_MMCSUPPORT only and only if MMC_CMD1 command fails.

## Testing
Tested on SAMv7 boards.
