### PR TITLE
arch/nrf52/nrf52_adc.c: fix device shutdown

### DIFF
--- a/arch/arm/src/nrf52/nrf52_adc.c
+++ b/arch/arm/src/nrf52/nrf52_adc.c
@@ -809,7 +809,7 @@ static void nrf52_adc_shutdown(struct adc_dev_s *dev)
 
   /* Stop SAADC */
 
-  nrf52_adc_putreg(priv, NRF52_SAADC_TASKS_STOP_OFFSET, 0);
+  nrf52_adc_putreg(priv, NRF52_SAADC_TASKS_STOP_OFFSET, 1);
 
   /* Wait for SAADC stopped */
 


### PR DESCRIPTION
## Summary
arch/nrf52/nrf52_adc.c: fix device shutdown
Task registers require writing 1, not 0
## Impact

## Testing
nrf52840-dk/adc
