### PR TITLE
arch: remove unnecessary sem_setprotocol code

### DIFF
--- a/arch/arm/src/s32k1xx/s32k1xx_serial.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_serial.c
@@ -753,7 +753,6 @@ static int s32k1xx_dma_setup(struct uart_dev_s *dev)
             }
 
           nxsem_init(&priv->txdmasem, 0, 1);
-          nxsem_set_protocol(&priv->txdmasem, SEM_PRIO_NONE);
         }
 
       /* Enable Tx DMA for the UART */

--- a/arch/arm/src/s32k3xx/s32k3xx_serial.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_serial.c
@@ -2910,7 +2910,6 @@ static int s32k3xx_dma_setup(struct uart_dev_s *dev)
             }
 
           nxsem_init(&priv->txdmasem, 0, 1);
-          nxsem_set_protocol(&priv->txdmasem, SEM_PRIO_NONE);
         }
 
       /* Enable Tx DMA for the UART */

--- a/arch/arm/src/sama5/sam_flexcom_spi.c
+++ b/arch/arm/src/sama5/sam_flexcom_spi.c
@@ -2098,7 +2098,6 @@ struct spi_dev_s *sam_flex_spibus_initialize(int port)
        */
 
       nxsem_init(&flex_spics->dmawait, 0, 0);
-      nxsem_set_protocol(&flex_spics->dmawait, SEM_PRIO_NONE);
 #endif
 
       flex_spi_dumpregs(flex_spi, "After initialization");

--- a/arch/arm/src/samd5e5/sam_usb.c
+++ b/arch/arm/src/samd5e5/sam_usb.c
@@ -8485,7 +8485,6 @@ static inline void sam_sw_initialize(struct sam_usbhost_s *priv)
     {
       priv->pipelist[epno].idx = epno;
       nxsem_init(&priv->pipelist[epno].waitsem, 0, 0);
-      sem_setprotocol(&priv->pipelist[epno].waitsem, SEM_PRIO_NONE);
 
       sam_putreg8(USBHOST_PSTATUS_PFREEZE, SAM_USBHOST_PSTATUSSET(epno));
 

--- a/libs/libc/pthread/pthread_barrierinit.c
+++ b/libs/libc/pthread/pthread_barrierinit.c
@@ -84,7 +84,6 @@ int pthread_barrier_init(FAR pthread_barrier_t *barrier,
   else
     {
       sem_init(&barrier->sem, 0, 0);
-      sem_setprotocol(&barrier->sem, SEM_PRIO_NONE);
       barrier->count = count;
     }
 

--- a/libs/libc/pthread/pthread_condinit.c
+++ b/libs/libc/pthread/pthread_condinit.c
@@ -71,12 +71,6 @@ int pthread_cond_init(FAR pthread_cond_t *cond,
     }
   else
     {
-      /* The contained semaphore is used for signaling and, hence, should
-       * not have priority inheritance enabled.
-       */
-
-      sem_setprotocol(&cond->sem, SEM_PRIO_NONE);
-
       cond->clockid = attr ? attr->clockid : CLOCK_REALTIME;
     }
 


### PR DESCRIPTION
## Summary

Semaphore does not need set protocol, so remove sem_setprotocol code for semaphore.

## Impact

pthread

## Testing

ostest pass for sabre-6quad:nsh