### PR TITLE
risc-v/espressif: Fix bootloader and app potential RAM overlap

### DIFF
--- a/arch/risc-v/src/espressif/esp_irq.h
+++ b/arch/risc-v/src/espressif/esp_irq.h
@@ -45,7 +45,7 @@ extern "C"
 #define EXTERN extern
 #endif
 
-/* CPU interrupt types. */
+/* CPU interrupt trigger types */
 
 typedef enum irq_trigger_e
 {
@@ -53,7 +53,7 @@ typedef enum irq_trigger_e
   ESP_IRQ_TRIGGER_EDGE     = 1, /* Edge-triggered interrupts */
 } irq_trigger_t;
 
-/* CPU interrupt types. */
+/* CPU interrupt priority levels */
 
 typedef enum irq_priority_e
 {

--- a/boards/risc-v/esp32c3/common/scripts/flat_memory.ld
+++ b/boards/risc-v/esp32c3/common/scripts/flat_memory.ld
@@ -43,12 +43,12 @@
 
 /* 2nd stage bootloader iram_loader_seg start address */
 
-#define SRAM_DRAM_END       0x403d0000 - I_D_SRAM_OFFSET
+#define SRAM_DRAM_END       (0x403ce710 - I_D_SRAM_OFFSET)
 
 #define SRAM_IRAM_ORG       (SRAM_IRAM_START + ICACHE_SIZE)
 #define SRAM_DRAM_ORG       (SRAM_DRAM_START + ICACHE_SIZE)
 
-#define I_D_SRAM_SIZE       SRAM_DRAM_END - SRAM_DRAM_ORG
+#define I_D_SRAM_SIZE       (SRAM_DRAM_END - SRAM_DRAM_ORG)
 
 #ifdef CONFIG_ESP32C3_FLASH_2M
 #  define FLASH_SIZE        0x200000

--- a/boards/risc-v/esp32c6/common/scripts/flat_memory.ld
+++ b/boards/risc-v/esp32c6/common/scripts/flat_memory.ld
@@ -36,12 +36,12 @@
 
 /* 2nd stage bootloader iram_loader_seg start address */
 
-#define SRAM_DRAM_END       0x40880000 - I_D_SRAM_OFFSET
+#define SRAM_DRAM_END       (0x4086e610 - I_D_SRAM_OFFSET)
 
 #define SRAM_IRAM_ORG       (SRAM_IRAM_START)
 #define SRAM_DRAM_ORG       (SRAM_DRAM_START)
 
-#define I_D_SRAM_SIZE       SRAM_DRAM_END - SRAM_DRAM_ORG
+#define I_D_SRAM_SIZE       (SRAM_DRAM_END - SRAM_DRAM_ORG)
 
 /* IDRAM0_2_SEG_SIZE_DEFAULT is used when page size is 64KB */
 

--- a/boards/risc-v/espressif/common/scripts/esp32c3_flat_memory.ld
+++ b/boards/risc-v/espressif/common/scripts/esp32c3_flat_memory.ld
@@ -48,16 +48,6 @@
 
 #define I_D_SRAM_SIZE       SRAM_DRAM_END - SRAM_DRAM_ORG
 
-#ifdef CONFIG_ESPRESSIF_FLASH_2M
-#  define FLASH_SIZE        0x200000
-#elif defined (CONFIG_ESPRESSIF_FLASH_4M)
-#  define FLASH_SIZE        0x400000
-#elif defined (CONFIG_ESPRESSIF_FLASH_8M)
-#  define FLASH_SIZE        0x800000
-#elif defined (CONFIG_ESPRESSIF_FLASH_16M)
-#  define FLASH_SIZE        0x1000000
-#endif
-
 MEMORY
 {
   /* Below values assume the flash cache is on, and have the blocks this
@@ -77,7 +67,7 @@ MEMORY
    * constraint that (paddr % 64KB == vaddr % 64KB).
    */
 
-  irom0_0_seg (RX) :      org = 0x42000020, len = FLASH_SIZE - 0x20
+  irom0_0_seg (RX) :      org = 0x42000020, len = 0x800000 - 0x20
 
   /* Shared data RAM, excluding memory reserved for ROM bss/data/stack. */
 
@@ -92,7 +82,7 @@ MEMORY
    * constraint that (paddr % 64KB == vaddr % 64KB).
    */
 
-  drom0_0_seg (R) :      org = 0x3c000020, len = FLASH_SIZE - 0x20
+  drom0_0_seg (R) :      org = 0x3c000020, len = 0x800000 - 0x20
 
   /* RTC fast memory. Persists over deep sleep. */
 

--- a/boards/risc-v/espressif/common/scripts/esp32c3_flat_memory.ld
+++ b/boards/risc-v/espressif/common/scripts/esp32c3_flat_memory.ld
@@ -41,12 +41,12 @@
 
 /* 2nd stage bootloader iram_loader_seg start address */
 
-#define SRAM_DRAM_END       0x403d0000 - I_D_SRAM_OFFSET
+#define SRAM_DRAM_END       (0x403ce710 - I_D_SRAM_OFFSET)
 
 #define SRAM_IRAM_ORG       (SRAM_IRAM_START + ICACHE_SIZE)
 #define SRAM_DRAM_ORG       (SRAM_DRAM_START + ICACHE_SIZE)
 
-#define I_D_SRAM_SIZE       SRAM_DRAM_END - SRAM_DRAM_ORG
+#define I_D_SRAM_SIZE       (SRAM_DRAM_END - SRAM_DRAM_ORG)
 
 MEMORY
 {

--- a/boards/risc-v/espressif/common/scripts/esp32c6_flat_memory.ld
+++ b/boards/risc-v/espressif/common/scripts/esp32c6_flat_memory.ld
@@ -31,26 +31,26 @@
 
 #include <nuttx/config.h>
 
-#define SRAM_IRAM_START     0x40800000
-#define SRAM_DRAM_START     0x40800000
+#define SRAM_IRAM_START       0x40800000
+#define SRAM_DRAM_START       0x40800000
 
-#define I_D_SRAM_OFFSET     (SRAM_IRAM_START - SRAM_DRAM_START)
+#define I_D_SRAM_OFFSET       (SRAM_IRAM_START - SRAM_DRAM_START)
 
 /* 2nd stage bootloader iram_loader_seg start address */
 
-#define SRAM_DRAM_END       0x40880000 - I_D_SRAM_OFFSET
+#define SRAM_DRAM_END         (0x4086e610 - I_D_SRAM_OFFSET)
 
-#define SRAM_IRAM_ORG       (SRAM_IRAM_START)
-#define SRAM_DRAM_ORG       (SRAM_DRAM_START)
+#define SRAM_IRAM_ORG         (SRAM_IRAM_START)
+#define SRAM_DRAM_ORG         (SRAM_DRAM_START)
 
-#define I_D_SRAM_SIZE       SRAM_DRAM_END - SRAM_DRAM_ORG
+#define I_D_SRAM_SIZE         (SRAM_DRAM_END - SRAM_DRAM_ORG)
 
 /* IDRAM0_2_SEG_SIZE_DEFAULT is used when page size is 64KB */
 
-#define CONFIG_MMU_PAGE_SIZE 0x10000
-#define IDRAM0_2_SEG_SIZE   (CONFIG_MMU_PAGE_SIZE << 8)
+#define CONFIG_MMU_PAGE_SIZE  0x10000
+#define IDRAM0_2_SEG_SIZE     (CONFIG_MMU_PAGE_SIZE << 8)
 
-#define DRAM0_0_SEG_LEN     I_D_SRAM_SIZE
+#define DRAM0_0_SEG_LEN       I_D_SRAM_SIZE
 
 MEMORY
 {

--- a/boards/risc-v/espressif/common/scripts/esp32h2_flat_memory.ld
+++ b/boards/risc-v/espressif/common/scripts/esp32h2_flat_memory.ld
@@ -31,26 +31,26 @@
 
 #include <nuttx/config.h>
 
-#define SRAM_IRAM_START     0x40800000
-#define SRAM_DRAM_START     0x40800000
+#define SRAM_IRAM_START       0x40800000
+#define SRAM_DRAM_START       0x40800000
 
-#define I_D_SRAM_OFFSET     (SRAM_IRAM_START - SRAM_DRAM_START)
+#define I_D_SRAM_OFFSET       (SRAM_IRAM_START - SRAM_DRAM_START)
 
 /* 2nd stage bootloader iram_loader_seg start address */
 
-#define SRAM_DRAM_END       0x40850000 - I_D_SRAM_OFFSET
+#define SRAM_DRAM_END         (0x4083efd0 - I_D_SRAM_OFFSET)
 
-#define SRAM_IRAM_ORG       (SRAM_IRAM_START)
-#define SRAM_DRAM_ORG       (SRAM_DRAM_START)
+#define SRAM_IRAM_ORG         (SRAM_IRAM_START)
+#define SRAM_DRAM_ORG         (SRAM_DRAM_START)
 
-#define I_D_SRAM_SIZE       SRAM_DRAM_END - SRAM_DRAM_ORG
+#define I_D_SRAM_SIZE         (SRAM_DRAM_END - SRAM_DRAM_ORG)
 
 /* IDRAM0_2_SEG_SIZE_DEFAULT is used when page size is 64KB */
 
-#define CONFIG_MMU_PAGE_SIZE 0x10000
-#define IDRAM0_2_SEG_SIZE   (CONFIG_MMU_PAGE_SIZE << 8)
+#define CONFIG_MMU_PAGE_SIZE  0x10000
+#define IDRAM0_2_SEG_SIZE     (CONFIG_MMU_PAGE_SIZE << 8)
 
-#define DRAM0_0_SEG_LEN     I_D_SRAM_SIZE
+#define DRAM0_0_SEG_LEN       I_D_SRAM_SIZE
 
 MEMORY
 {


### PR DESCRIPTION
## Summary

This PR intends to fix a potential RAM overlapping issue between the bootloader and application images, which has been recently addressed on the ESP-IDF project:
https://github.com/espressif/esp-idf/commit/0fb0be381763332007c269a558e5df9b23f69c18

Furthermore, it proposes another quick fix for the ESP32-C3 linker script. The length of the IROM and DROM segments should be related to the extent of the address space, and not be limited to the capacity of the External Flash device.

## Impact

Fix for a potential issue, at the cost of reduced DRAM area for Espressif RISC-V based chips.

## Testing

CI build pass.