### PR TITLE
sched/wqueue: Do as much work as possible in work_thread

### DIFF
--- a/sched/wqueue/kwork_cancel.c
+++ b/sched/wqueue/kwork_cancel.c
@@ -88,12 +88,6 @@ static int work_qcancel(FAR struct kwork_wqueue_s *wqueue,
       else
         {
           dq_rem((FAR dq_entry_t *)work, &wqueue->q);
-
-          /* Semaphore count should be consistent with the number of
-           * work entries.
-           */
-
-          wqueue->sem.semcount--;
         }
 
       work->worker = NULL;

--- a/sched/wqueue/kwork_thread.c
+++ b/sched/wqueue/kwork_thread.c
@@ -153,9 +153,13 @@ static int work_thread(int argc, FAR char *argv[])
 
       /* Remove the ready-to-execute work from the list */
 
-      work = (FAR struct work_s *)dq_remfirst(&wqueue->q);
-      if (work && work->worker)
+      while ((work = (FAR struct work_s *)dq_remfirst(&wqueue->q)) != NULL)
         {
+          if (work->worker == NULL)
+            {
+              continue;
+            }
+
           /* Extract the work description from the entry (in case the work
            * instance will be re-used after it has been de-queued).
            */

--- a/sched/wqueue/wqueue.h
+++ b/sched/wqueue/wqueue.h
@@ -26,6 +26,7 @@
 
 #include <nuttx/config.h>
 
+#include <semaphore.h>
 #include <sys/types.h>
 #include <stdbool.h>
 


### PR DESCRIPTION
## Summary
### TL;DR
When `semcount` is subtracted to **negative number** in `work_cancel` by **high priority** thread before `work_cancel` runs, it cannot put `work_thread` back to waiting state from ready state, so the `work_thread` still runs with empty work after work cancellation, which cause `semcount` become wrong state.

So decouple the semcount and the work queue length might be better in design.

### Previous Problem

If a work is queued and cancelled in **high priority** threads (or queued by timer and cancelled by another high priority thread) before `work_thread` runs, the queue operation will mark `work_thread` as **ready to run**, but the cancel operation minus the `semcount` back to -1 and makes wqueue->q empty. Then the `work_thread` **still runs**, found empty queue, and wait sem again, then `semcount` becomes -2 (being minused by 1)

This can be done multiple times, then `semcount` can become smaller and smaller. Test case to produce incorrect `semcount`:

```c
high_priority_task()
{
  for (int i = 0; i < 10000; i++)
    {
      work_queue(LPWORK, &work, worker, NULL, 0); /* The work_thread is 'ready to run' now. */
      work_cancel(LPWORK, &work);                 /* The work is poped, and semcount-- */
      usleep(1);                                  /* work_thread still runs, semcount-- */
    }

  /* Now the g_lpwork.sem.semcount is a value near -10000 */
}
```

With incorrect `semcount`, any **queue** operation when the `work_thread` is **busy**, will only increase `semcount` and push work into queue, but **cannot trigger** `work_thread` (`semcount` is negative but `work_thread` is not waiting), then there will be more and more works left in queue while the `work_thread` is waiting sem and cannot call them.

## Impact
Try fix work queue logic in special state.

## Testing
Manually & CI (https://github.com/apache/nuttx-apps/pull/1665)

