### PR TITLE
sim/uart_ioctl: return -ENOTTY for cmd which don't support

### DIFF
--- a/arch/sim/src/sim/sim_uart.c
+++ b/arch/sim/src/sim/sim_uart.c
@@ -29,6 +29,7 @@
 #include <sys/types.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <assert.h>
 
 #include "sim_internal.h"
 
@@ -363,18 +364,18 @@ static int tty_ioctl(struct file *filep, int cmd, unsigned long arg)
   struct tty_priv_s *priv = dev->priv;
   struct termios *termiosp = (struct termios *)(uintptr_t)arg;
 
-  if (!termiosp)
-    {
-      return -EINVAL;
-    }
-
   switch (cmd)
     {
       case TCGETS:
+        DEBUGASSERT(termiosp != NULL);
         return host_uart_getcflag(priv->fd, &termiosp->c_cflag);
 
       case TCSETS:
+        DEBUGASSERT(termiosp != NULL);
         return host_uart_setcflag(priv->fd, termiosp->c_cflag);
+
+      default:
+        break;
     }
 #endif
 


### PR DESCRIPTION
## Summary
sim/uart_ioctl: return -ENOTTY for cmd which don't support

## Impact
using serial.c:serial_ioctl common function correctly, ex: TIOCSCTTY/TIOCNOTTY
## Testing
local test.
