### PR TITLE
icmpv6: add RDNSS field support for route advertise message

### DIFF
--- a/include/nuttx/net/icmpv6.h
+++ b/include/nuttx/net/icmpv6.h
@@ -102,11 +102,12 @@
 
 /* Option types */
 
-#define ICMPv6_OPT_SRCLLADDR  1 /* Source Link-Layer Address */
-#define ICMPv6_OPT_TGTLLADDR  2 /* Target Link-Layer Address */
-#define ICMPv6_OPT_PREFIX     3 /* Prefix Information */
-#define ICMPv6_OPT_REDIRECT   4 /* Redirected Header */
-#define ICMPv6_OPT_MTU        5 /* MTU */
+#define ICMPv6_OPT_SRCLLADDR  1  /* Source Link-Layer Address */
+#define ICMPv6_OPT_TGTLLADDR  2  /* Target Link-Layer Address */
+#define ICMPv6_OPT_PREFIX     3  /* Prefix Information */
+#define ICMPv6_OPT_REDIRECT   4  /* Redirected Header */
+#define ICMPv6_OPT_MTU        5  /* MTU */
+#define ICMPv6_OPT_RDNSS      25 /* DNS */
 
 /* ICMPv6 Neighbor Advertisement message flags */
 
@@ -349,6 +350,15 @@ struct icmpv6_mtu_s
   uint8_t  optlen;           /* "   " ": Option length: 1 octet */
   uint16_t reserved;         /* "   " ": Reserved */
   uint16_t mtu[2];           /* "   " ": MTU */
+};
+
+struct icmpv6_rdnss_s
+{
+  uint8_t  opttype;          /* Octet 1: Option Type: ICMPv6_OPT_RNDSS */
+  uint8_t  optlen;           /* "   " ": Option length: 1 octet */
+  uint16_t reserved;         /* "   " ": Reserved */
+  uint16_t lifetime[2];      /* "   " ": lifetime */
+  uint8_t  servers[1];       /* Octets 2-: Beginning of the DNS Servers */
 };
 
 /* The structure holding the ICMP statistics that are gathered if

--- a/net/icmpv6/Kconfig
+++ b/net/icmpv6/Kconfig
@@ -202,6 +202,13 @@ config NET_ICMPv6_PREFIX_8
 		Advertisement message.  This is the last of the 8-values.  The
 		default for all eight values is fc00::0.
 
+config NET_ICMPv6_ROUTER_RDNSS
+	bool "Fill the RDNSS into Router Advertisement"
+	default n
+	---help---
+		Fill the RDNSS from the netdb DNS Server into the Router
+		Advertisement.
+
 endif # NET_ICMPv6_ROUTER_MANUAL
 endif # NET_ICMPv6_ROUTER
 

--- a/net/icmpv6/Kconfig
+++ b/net/icmpv6/Kconfig
@@ -88,6 +88,13 @@ config ICMPv6_AUTOCONF_DELAYMSEC
 		when an Router Solicitation is sent until the Router
 		Advertisement is received.
 
+config ICMPv6_AUTOCONF_RDNSS
+	bool "ICMPv6 handle RDNSS field in router advertise"
+	default n
+	---help---
+		Handle the RDNSS field in the Router Advertisement and add it to
+		netdb DNS Server.
+
 endif # NET_ICMPv6_AUTOCONF
 
 config NET_ICMPv6_ROUTER


### PR DESCRIPTION
## Summary
We have a project that requires ipv6 to support prefix and dns solicit and advertise functions. We want to simplify the implementation of these requirements, so we directly do it in the icmpv6 module. 
## Impact

## Testing
linux sim with radvd
