### PR TITLE
xtensa/esp32: Update bootloader patch to recent ESP-IDF version

### DIFF
--- a/arch/xtensa/src/esp32/bootloader/0001-esp32-Connect-Xtensa-Instruction-RAM1-to-Cache.patch
+++ b/arch/xtensa/src/esp32/bootloader/0001-esp32-Connect-Xtensa-Instruction-RAM1-to-Cache.patch
@@ -1,112 +1,56 @@
-From 3ee21d64a48018b33c1db485b5fbfb08145e4f67 Mon Sep 17 00:00:00 2001
+From 851a0b57377238386e8c786faeca422f6e11c911 Mon Sep 17 00:00:00 2001
 From: Gustavo Henrique Nihei <gustavo.nihei@espressif.com>
-Date: Wed, 6 Jul 2022 10:03:09 -0300
+Date: Mon, 20 Mar 2023 11:16:52 -0300
 Subject: [PATCH] esp32: Connect Xtensa Instruction RAM1 to Cache
 
 User application image is executed with PID 5, so it accesses the
 External Flash via virtual address starting from 0x40400000 (Vaddr2).
 
-See:
-https://github.com/espressif/esp-idf/blob/v4.4.1/components/xtensa/esp32/include/xtensa/config/core-isa.h#L301-L305
-
 Signed-off-by: Gustavo Henrique Nihei <gustavo.nihei@espressif.com>
 ---
- .../bootloader_support/src/bootloader_utility.c | 17 ++++++++++++++---
- components/soc/esp32/include/soc/mmu.h          |  1 +
- components/spi_flash/cache_utils.c              |  2 ++
- components/spi_flash/flash_mmap.c               |  8 ++++++++
- 4 files changed, 25 insertions(+), 3 deletions(-)
+ components/bootloader_support/src/bootloader_utility.c | 2 ++
+ components/hal/esp32/include/hal/mmu_ll.h              | 9 +++++++++
+ 2 files changed, 11 insertions(+)
 
 diff --git a/components/bootloader_support/src/bootloader_utility.c b/components/bootloader_support/src/bootloader_utility.c
-index ad56335253..7e343a551b 100644
+index 4e30ecad1b..15700a1c39 100644
 --- a/components/bootloader_support/src/bootloader_utility.c
 +++ b/components/bootloader_support/src/bootloader_utility.c
-@@ -737,6 +737,14 @@ static void set_cache_and_start_app(
-     for (int i = 0; i < DPORT_FLASH_MMU_TABLE_SIZE; i++) {
-         DPORT_PRO_FLASH_MMU_TABLE[i] = DPORT_FLASH_MMU_TABLE_INVALID_VAL;
+@@ -890,12 +890,14 @@ static void set_cache_and_start_app(
+     cache_ll_l1_enable_bus(0, bus_mask);
+     bus_mask = cache_ll_l1_get_bus(0, irom_load_addr_aligned, irom_size);
+     cache_ll_l1_enable_bus(0, bus_mask);
++    cache_ll_l1_enable_bus(0, CACHE_BUS_IBUS1);
+ 
+ #if !CONFIG_FREERTOS_UNICORE
+     bus_mask = cache_ll_l1_get_bus(1, drom_load_addr_aligned, drom_size);
+     cache_ll_l1_enable_bus(1, bus_mask);
+     bus_mask = cache_ll_l1_get_bus(1, irom_load_addr_aligned, irom_size);
+     cache_ll_l1_enable_bus(1, bus_mask);
++    cache_ll_l1_enable_bus(1, CACHE_BUS_IBUS1);
+ #endif
+ 
+     //----------------------Enable Cache----------------
+diff --git a/components/hal/esp32/include/hal/mmu_ll.h b/components/hal/esp32/include/hal/mmu_ll.h
+index 8a572a5455..96609fe7ee 100644
+--- a/components/hal/esp32/include/hal/mmu_ll.h
++++ b/components/hal/esp32/include/hal/mmu_ll.h
+@@ -291,6 +291,15 @@ static inline void mmu_ll_unmap_all(uint32_t mmu_id)
+     for (int i = 0; i < MMU_ENTRY_NUM; i++) {
+         mmu_ll_set_entry_invalid(mmu_id, i);
      }
 +
 +    /* Xtensa CPU does speculative load/store on VAddr1/2/3 when connected to cache.
 +     * Hence it requires all the pages of VAddr2/3 to be set valid to any physical page.
-+     * Marking any page invalid would stall the CPU
++     * Marking any page invalid would stall the CPU.
 +     */
-+    for (int i = 64; i < 256; i++) {
-+        DPORT_PRO_FLASH_MMU_TABLE[i] = 0;
-+    }
- #else
-     for (size_t i = 0; i < FLASH_MMU_TABLE_SIZE; i++) {
-         FLASH_MMU_TABLE[i] = MMU_TABLE_INVALID_VAL;
-@@ -793,11 +801,11 @@ static void set_cache_and_start_app(
-     rc = cache_flash_mmu_set(1, 0, irom_load_addr_aligned, irom_addr_aligned, 64, irom_page_count);
-     ESP_LOGV(TAG, "rc=%d", rc);
-     DPORT_REG_CLR_BIT( DPORT_PRO_CACHE_CTRL1_REG,
--                       (DPORT_PRO_CACHE_MASK_IRAM0) | (DPORT_PRO_CACHE_MASK_IRAM1 & 0) |
-+                       (DPORT_PRO_CACHE_MASK_IRAM0) | (DPORT_PRO_CACHE_MASK_IRAM1) |
-                        (DPORT_PRO_CACHE_MASK_IROM0 & 0) | DPORT_PRO_CACHE_MASK_DROM0 |
-                        DPORT_PRO_CACHE_MASK_DRAM1 );
-     DPORT_REG_CLR_BIT( DPORT_APP_CACHE_CTRL1_REG,
--                       (DPORT_APP_CACHE_MASK_IRAM0) | (DPORT_APP_CACHE_MASK_IRAM1 & 0) |
-+                       (DPORT_APP_CACHE_MASK_IRAM0) | (DPORT_APP_CACHE_MASK_IRAM1) |
-                        (DPORT_APP_CACHE_MASK_IROM0 & 0) | DPORT_APP_CACHE_MASK_DROM0 |
-                        DPORT_APP_CACHE_MASK_DRAM1 );
- #elif CONFIG_IDF_TARGET_ESP32S2
-@@ -815,7 +823,10 @@ static void set_cache_and_start_app(
-     REG_CLR_BIT(EXTMEM_ICACHE_CTRL1_REG, EXTMEM_ICACHE_SHUT_DBUS);
- #endif
- #if CONFIG_IDF_TARGET_ESP32
--    Cache_Read_Enable(0);
-+    DPORT_REG_SET_BIT(0x3ff43050, 1);
-+    DPORT_REG_SET_BIT(DPORT_PRO_CACHE_CTRL_REG, DPORT_PRO_CACHE_ENABLE);
 +
-+    asm("memw");
- #elif CONFIG_IDF_TARGET_ESP32S2
-     Cache_Resume_ICache(autoload);
- #elif CONFIG_IDF_TARGET_ESP32S3
-diff --git a/components/soc/esp32/include/soc/mmu.h b/components/soc/esp32/include/soc/mmu.h
-index bde6995516..9fff17ddba 100644
---- a/components/soc/esp32/include/soc/mmu.h
-+++ b/components/soc/esp32/include/soc/mmu.h
-@@ -32,6 +32,7 @@ extern "C" {
- #define SOC_MMU_ADDR_MASK                       DPORT_MMU_ADDRESS_MASK
- #define SOC_MMU_PAGE_IN_FLASH(page)             (page)
- #define SOC_MMU_DPORT_PRO_FLASH_MMU_TABLE       ((volatile uint32_t*) 0x3FF10000)
-+#define SOC_MMU_DPORT_APP_FLASH_MMU_TABLE       ((volatile uint32_t*) 0x3FF12000)
- #define SOC_MMU_VADDR1_START_ADDR               SOC_IROM_MASK_LOW
- #define SOC_MMU_PRO_IRAM0_FIRST_USABLE_PAGE     ((SOC_MMU_VADDR1_FIRST_USABLE_ADDR - SOC_MMU_VADDR1_START_ADDR) / SPI_FLASH_MMU_PAGE_SIZE + SOC_MMU_IROM0_PAGES_START)
- #define SOC_MMU_VADDR0_START_ADDR               SOC_DROM_LOW
-diff --git a/components/spi_flash/cache_utils.c b/components/spi_flash/cache_utils.c
-index 7715900055..b29aed2953 100644
---- a/components/spi_flash/cache_utils.c
-+++ b/components/spi_flash/cache_utils.c
-@@ -308,6 +308,8 @@ static void IRAM_ATTR spi_flash_disable_cache(uint32_t cpuid, uint32_t *saved_st
-         while (DPORT_GET_PERI_REG_BITS2(DPORT_PRO_DCACHE_DBUG0_REG, DPORT_PRO_CACHE_STATE, DPORT_PRO_CACHE_STATE_S) != 1) {
-             ;
-         }
-+        /* Disconnect from cache */
-+        DPORT_REG_WRITE(DPORT_PRO_CACHE_CTRL1_REG, 0xff);
-         DPORT_SET_PERI_REG_BITS(DPORT_PRO_CACHE_CTRL_REG, 1, 0, DPORT_PRO_CACHE_ENABLE_S);
-     }
- #if !CONFIG_FREERTOS_UNICORE
-diff --git a/components/spi_flash/flash_mmap.c b/components/spi_flash/flash_mmap.c
-index 9523bc7959..c17a9903ef 100644
---- a/components/spi_flash/flash_mmap.c
-+++ b/components/spi_flash/flash_mmap.c
-@@ -108,7 +108,15 @@ static void IRAM_ATTR spi_flash_mmap_init(void)
-         if ((entry_pro & SOC_MMU_INVALID_ENTRY_VAL) == 0 && (i == SOC_MMU_DROM0_PAGES_START || i == SOC_MMU_PRO_IRAM0_FIRST_USABLE_PAGE || entry_pro != 0)) {
-             s_mmap_page_refcnt[i] = 1;
-         } else {
-+#if CONFIG_IDF_TARGET_ESP32
-+            /* Due to Xtensa speculative load/store, pages need to be marked valid if VAddr2/VAddr3
-+             * are connected to cache. If marked invalid, CPU will halt
-+             */
-+            SOC_MMU_DPORT_PRO_FLASH_MMU_TABLE[i] = 0x00;
-+            SOC_MMU_DPORT_APP_FLASH_MMU_TABLE[i] = 0x00;
-+#else
-             SOC_MMU_DPORT_PRO_FLASH_MMU_TABLE[i] = SOC_MMU_INVALID_ENTRY_VAL;
-+#endif
- #if !CONFIG_FREERTOS_UNICORE && CONFIG_IDF_TARGET_ESP32
-             DPORT_APP_FLASH_MMU_TABLE[i] = SOC_MMU_INVALID_ENTRY_VAL;
- #endif
++    for (int i = 64; i < 256; i++) {
++        mmu_ll_write_entry(mmu_id, i, 0, MMU_TARGET_FLASH0);
++    }
+ }
+ 
+ /**
 -- 
-2.34.1
+2.37.2
 


### PR DESCRIPTION
## Summary
This PR intends to update the patch to ESP-IDF bootloader for enabling the use of the PID controller for the Protected mode support.

## Impact
`make bootloader` once again properly building the bootloader on the `esp32-devkitc:knsh` defconfig

## Testing
```bash
./tools/configure.sh -E esp32-devkitc:knsh
make bootloader
```
