### PR TITLE
arch: Set the default value of ARCH for x86_64

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -171,6 +171,7 @@ config ARCH
 	default "risc-v"  if ARCH_RISCV
 	default "sim"     if ARCH_SIM
 	default "x86"     if ARCH_X86
+	default "x86_64"  if ARCH_X86_64
 	default "xtensa"  if ARCH_XTENSA
 	default "z16"     if ARCH_Z16
 	default "z80"     if ARCH_Z80


### PR DESCRIPTION
## Summary

## Impact

x86_64

## Testing

CI