### PR TITLE
boards/sama5d3-xplained: Add reboot support.

### DIFF
--- a/arch/arm/src/sama5/hardware/sam_rstc.h
+++ b/arch/arm/src/sama5/hardware/sam_rstc.h
@@ -51,6 +51,9 @@
 /* Reset Controller Control Register */
 
 #define RSTC_CR_PROCRST         (1 << 0)   /* Bit 0:  Processor Reset */
+#if defined(CONFIG_ARCH_CHIP_SAMA5D3)
+#  define RSTC_CR_PERRST        (1 << 2)   /* Bit 2:  Peripheral Reset */
+#endif
 #define RSTC_CR_EXTRST          (1 << 3)   /* Bit 3:  External Reset */
 #define RSTC_CR_KEY_SHIFT       (24)       /* Bits 24-31:  Password */
 #define RSTC_CR_KEY_MASK        (0xff << RSTC_CR_KEY_SHIFT)

--- a/boards/arm/sama5/sama5d3-xplained/src/Makefile
+++ b/boards/arm/sama5/sama5d3-xplained/src/Makefile
@@ -112,4 +112,8 @@ ifeq ($(CONFIG_ARCH_BUTTONS),y)
 CSRCS += sam_buttons.c
 endif
 
+ifeq ($(CONFIG_BOARDCTL_RESET),y)
+CSRCS += sam_reset.c
+endif
+
 include $(TOPDIR)/boards/Board.mk

--- a/boards/arm/sama5/sama5d3-xplained/src/sam_reset.c
+++ b/boards/arm/sama5/sama5d3-xplained/src/sam_reset.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm/src/sama5/sam_systemreset.c
+ * boards/arm/sama5/sama5d3-xplained/src/sam_reset.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -24,56 +24,39 @@
 
 #include <nuttx/config.h>
 
-#include <stdint.h>
-#include <assert.h>
-
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
-#include <arch/sama5/chip.h>
 
-#include "arm_internal.h"
-#include "hardware/sam_rstc.h"
-
-#ifdef CONFIG_SAMA5_SYSTEMRESET
+#ifdef CONFIG_BOARDCTL_RESET
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_systemreset
+ * Name: board_reset
  *
  * Description:
- *   Internal reset logic.
+ *   Reset board.  Support for this function is required by board-level
+ *   logic if CONFIG_BOARDCTL_RESET is selected.
+ *
+ * Input Parameters:
+ *   status - Status information provided with the reset event.  This
+ *            meaning of this status information is board-specific.  If not
+ *            used by a board, the value zero may be provided in calls to
+ *            board_reset().
+ *
+ * Returned Value:
+ *   If this function returns, then it was not possible to power-off the
+ *   board due to some constraints.  The return value int this case is a
+ *   board-specific reason for the failure to shutdown.
  *
  ****************************************************************************/
 
-void up_systemreset(void)
+int board_reset(int status)
 {
-  uint32_t rstcr;
-#if defined(CONFIG_SAMA5_EXTRESET_ERST) && CONFIG_SAMA5_EXTRESET_ERST != 0
-  uint32_t rstmr;
-#endif
-
-  rstcr  = (RSTC_CR_PROCRST | RSTC_CR_KEY);
-
-#if defined(CONFIG_ARCH_CHIP_SAMA5D3)
-  rstcr  |= RSTC_CR_PERRST;
-#endif
-
-#if defined(CONFIG_SAMA5_EXTRESET_ERST) && CONFIG_SAMA5_EXTRESET_ERST != 0
-  rstcr |= RSTC_CR_EXTRST;
-
-  rstmr  = getreg32(SAM_RSTC_MR);
-  rstmr &= ~RSTC_MR_ERSTL_MASK;
-  rstmr &= RSTC_MR_ERSTL(CONFIG_SAMA5_EXTRESET_ERST - 1) | RSTC_MR_KEY;
-  putreg32(rstmr, SAM_RSTC_MR);
-#endif
-
-  putreg32(rstcr, SAM_RSTC_CR);
-
-  /* Wait for the reset */
-
-  for (; ; );
+  up_systemreset();
+  return 0;
 }
-#endif /* CONFIG_SAMA5_SYSTEMRESET */
+
+#endif /* CONFIG_BOARDCTL_RESET */


### PR DESCRIPTION
The peripheral reset flag was added to speed up the reboot. Rebooting takes too long (15 seconds) if this flag is not set.

## Summary
Add reboot to sama5d3-xplained

## Impact
Adds peripheral reset to all SAMA5D3 boards. Some SAMA5D2 boards do not have the peripheral reset bit.

## Testing
Rebooted the board using the nsh reboot command.
