### PR TITLE
sim_linuxi2c: fix snprintf parameter

### DIFF
--- a/arch/sim/src/sim/posix/sim_linuxi2c.c
+++ b/arch/sim/src/sim/posix/sim_linuxi2c.c
@@ -276,7 +276,7 @@ struct i2c_master_s *sim_i2cbus_initialize(int bus)
       return NULL;
     }
 
-  snprintf(filename, 19, "/dev/i2c-%d", bus);
+  snprintf(filename, sizeof(filename), "/dev/i2c-%d", bus);
   priv->file = open(filename, O_RDWR);
   if (priv->file < 0)
     {


### PR DESCRIPTION
## Summary
sim_linuxi2c: fix snprintf parameter

use `sizeof` instead of constant number

## Impact

## Testing

