### PR TITLE
sim: Fix iic/spi bus open failed

### DIFF
--- a/arch/sim/src/sim/posix/sim_linuxi2c.c
+++ b/arch/sim/src/sim/posix/sim_linuxi2c.c
@@ -269,7 +269,7 @@ struct i2c_master_s *sim_i2cbus_initialize(int bus)
   struct linux_i2cbus_master_s *priv;
   char filename[20];
 
-  priv = (struct linux_i2cbus_master_s *)malloc(sizeof(priv));
+  priv = (struct linux_i2cbus_master_s *)malloc(sizeof(*priv));
   if (priv == NULL)
     {
       ERROR("Failed to allocate private i2c master driver");

--- a/arch/sim/src/sim/posix/sim_linuxspi.c
+++ b/arch/sim/src/sim/posix/sim_linuxspi.c
@@ -702,7 +702,7 @@ struct spi_dev_s *sim_spi_initialize(const char *filename)
 {
   struct linux_spi_dev_s *priv;
 
-  priv = (struct linux_spi_dev_s *)malloc(sizeof(priv));
+  priv = (struct linux_spi_dev_s *)malloc(sizeof(*priv));
   if (priv == NULL)
     {
       ERROR("Failed to allocate private spi master driver");


### PR DESCRIPTION
## Summary
when CONFIG_SIM_I2CBUS or CONFIG_SIM_SPI enabled,the iic/spi bus will report open failed

## Impact

## Testing

