### PR TITLE
spi_xx25xx: Repair the spi bus locking mechanism when waiting for write completion

### DIFF
--- a/drivers/eeprom/spi_xx25xx.c
+++ b/drivers/eeprom/spi_xx25xx.c
@@ -377,6 +377,7 @@ static void ee25xx_waitwritecomplete(struct ee25xx_dev_s *priv)
     {
       /* Select this FLASH part */
 
+      ee25xx_lock(priv->spi);
       SPI_SELECT(priv->spi, SPIDEV_EEPROM(0), true);
 
       /* Send "Read Status Register (RDSR)" command */
@@ -392,6 +393,7 @@ static void ee25xx_waitwritecomplete(struct ee25xx_dev_s *priv)
       /* Deselect the FLASH */
 
       SPI_SELECT(priv->spi, SPIDEV_EEPROM(0), false);
+      ee25xx_unlock(priv->spi);
 
       /* Given that writing could take up to a few milliseconds,
        * the following short delay in the "busy" case will allow
@@ -400,9 +402,7 @@ static void ee25xx_waitwritecomplete(struct ee25xx_dev_s *priv)
 
       if ((status & EE25XX_SR_WIP) != 0)
         {
-          ee25xx_unlock(priv->spi);
           nxsig_usleep(1000);
-          ee25xx_lock(priv->spi);
         }
     }
   while ((status & EE25XX_SR_WIP) != 0);


### PR DESCRIPTION
## Summary
The spi_xx25xx EEPROM driver had a bug (probably from its inception in 2014) where the waitwritecomplete() function was expected to be called within an SPI bus exclusion lock, but it was not. So the write completion routine was wrongly unlocking an already unlocked mutex.

This was not seen before, but a commit on 01 feb 2023 modified libs/libc/misc/lib_mutex.c so that nxmutex_lock now calls nxmutex_is_hold

This additional test tripped on the wrong unlock.

Here we have a good change that caught a bug hidden for so many years, and obviously not tested at all by millions of hours of useless automatic build tests.

## Impact
Probably some weird stuff when several spi devices were used on the same bus.

## Testing
Absolutely untestable with the current automatic build test infrastructure. This needs runtime testing, which we have successfully completed. "Before" code produces a cascade of assertion, the new code works as perfectly as visible.

Since the automatic tests are useless here, can this PR be accepted faster than usual so we dont have to maintain local patches? Thank you.

I have run checkpatch, the tool was happy.