### PR TITLE
boards/sama5d3-xplained: Fix OHCI clock.

### DIFF
--- a/arch/arm/src/sama5/sam_usbhost.c
+++ b/arch/arm/src/sama5/sam_usbhost.c
@@ -26,6 +26,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <assert.h>
 
 #include <nuttx/usb/usbhost_trace.h>

--- a/boards/arm/sama5/sama5d3-xplained/include/board_sdram.h
+++ b/boards/arm/sama5/sama5d3-xplained/include/board_sdram.h
@@ -92,11 +92,7 @@
 #  define BOARD_CKGR_UCKR_UPLLCOUNT  (15)  /* Maximum value */
 #  define BOARD_CKGR_UCKR_BIASCOUNT  (15)  /* Maximum value */
 
-/* REVISIT:  The divisor of 10 produces a rate that is too high. Division
- * by 5, however, seems to work just fine.  No idea why?
- */
-
-#  define BOARD_UPLL_OHCI_DIV        (5)   /* Divide by 5 */
+#  define BOARD_UPLL_OHCI_DIV        (10)   /* Divide by 10 */
 #endif
 
 /* ADC Configuration

--- a/drivers/usbhost/usbhost_enumerate.c
+++ b/drivers/usbhost/usbhost_enumerate.c
@@ -115,7 +115,7 @@ static inline int usbhost_devdesc(FAR const struct usb_devdesc_s *devdesc,
   id->vid = usbhost_getle16(devdesc->vendor);
   id->pid = usbhost_getle16(devdesc->product);
 
-  uinfo("class:%d subclass:%04x protocol:%04x vid:%d pid:%d\n",
+  uinfo("class:%d subclass:%d protocol:%d vid:%04x pid:%04x\n",
         id->base, id->subclass, id->proto, id->vid, id->pid);
   return OK;
 }


### PR DESCRIPTION
Choose a divider value that matches the description provided within the same header file.
Include stddef.h to fix compiler errors because NULL is not defined. Make logs print protocol, vid and pid consistently, (decimal hex hex).

## Summary
fixes #8848

The board enumerates a USB driver successfully after this change.
The /dev/sda did not appear before this change.

## Impact
The following log message used to print vid/pid in hex. All sama5
 boards will now print vid and pid in hex. For example:
usbhost_devdesc: class:0 subclass:0 protocol:0 vid:05dc pid:c75c

## Testing
mount -t vfat /dev/sda /mnt and list files on the USB drive successfully.
