### PR TITLE
armv7-m irq: avoid uninitialized warning/error

### DIFF
--- a/arch/arm/include/armv7-m/irq.h
+++ b/arch/arm/include/armv7-m/irq.h
@@ -359,6 +359,9 @@ static inline void raisebasepri(uint32_t basepri)
    *    effect of unconditionally re-enabling interrupts.
    */
 
+#pragma GCC diagnostic push /* primask is initialized in ASM */
+#pragma GCC diagnostic ignored "-Wuninitialized"
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
   __asm__ __volatile__
     (
      "\tmrs   %0, primask\n"
@@ -368,6 +371,7 @@ static inline void raisebasepri(uint32_t basepri)
      : "+r" (primask)
      : "r"  (basepri)
      : "memory");
+#pragma GCC diagnostic pop
 }
 #else
 #  define raisebasepri(b) setbasepri(b);


### PR DESCRIPTION
## Summary
arm-none-eabi-gcc 12.2.0 gives the following warnings:
`error: 'primask' is used uninitialized`
`error: 'primask' may be used uninitialized`

We use Werror and the file is indirectly included in different places. I suggest telling the compiler to ignore these warnings since primask is initialized on the first assembly line.

## Testing
This is the only error I encountered when upgrading the compiler. After not getting the error anymore even on the target that uses this file. I didn't find any more issues in my testing so far.