### PR TITLE
openamp: fix libmetal compile error with arm64 arch

### DIFF
--- a/openamp/libmetal.defs
+++ b/openamp/libmetal.defs
@@ -32,6 +32,8 @@ LIBMETAL_ARCH = x86_64
 endif
 else ifeq ($(CONFIG_ARCH), risc-v)
 LIBMETAL_ARCH = riscv
+else ifeq ($(CONFIG_ARCH), arm64)
+LIBMETAL_ARCH = aarch64
 else
 LIBMETAL_ARCH = $(CONFIG_ARCH)
 endif


### PR DESCRIPTION
## Summary
Error log:
```c
/home/wangbowen/project/community/nuttx_rpmsg_server/nuttx/include/metal/cpu.h:15:11: fatal error: metal/processor/arm64/cpu.h: No such file or directory
   15 | # include <metal/processor/arm64/cpu.h>
```

## Impact
libmetal

## Testing
qemu-armv8a:nsh compile pass with CONFIG_OPENAMP enable
