### PR TITLE
libc/settimeofday: correct prototype of settimeofday()

### DIFF
--- a/include/sys/time.h
+++ b/include/sys/time.h
@@ -212,7 +212,8 @@ int gettimeofday(FAR struct timeval *tv, FAR struct timezone *tz);
  *
  ****************************************************************************/
 
-int settimeofday(FAR const struct timeval *tv, FAR struct timezone *tz);
+int settimeofday(FAR const struct timeval *tv,
+                 FAR const struct timezone *tz);
 
 /****************************************************************************
  * Name: adjtime

--- a/libs/libc/time/lib_settimeofday.c
+++ b/libs/libc/time/lib_settimeofday.c
@@ -54,7 +54,7 @@
  *
  ****************************************************************************/
 
-int settimeofday(FAR const struct timeval *tv, FAR struct timezone *tz)
+int settimeofday(FAR const struct timeval *tv, FAR const struct timezone *tz)
 {
   struct timespec ts;
 


### PR DESCRIPTION
## Summary

libc/settimeofday: correct prototype of settimeofday()

https://man.openbsd.org/OpenBSD-5.9/settimeofday.2

## Impact


N/A

## Testing

ci-check