### PR TITLE
arch/arm: enable eoimode only select CONFIG_XXX_GIC_EOIMODE

### DIFF
--- a/arch/arm/src/armv7-a/Kconfig
+++ b/arch/arm/src/armv7-a/Kconfig
@@ -13,6 +13,17 @@ config ARMV7A_HAVE_GICv2
 		Selected by the configuration tool if the architecture supports the
 		Generic Interrupt Controller (GIC)
 
+if ARMV7A_HAVE_GICv2
+
+config ARMV7A_GIC_EOIMODE
+	bool "Enable GIC EOImode"
+	default n
+	---help---
+		Enable GICC_CTLR.EOImode, this will separates the priority drop and interrupt
+		deactivation operations.
+
+endif # ARMV7A_HAVE_GICv2
+
 config ARMV7A_HAVE_GTM
 	bool
 	default n

--- a/arch/arm/src/armv7-a/arm_gicv2.c
+++ b/arch/arm/src/armv7-a/arm_gicv2.c
@@ -244,16 +244,17 @@ void arm_gic_initialize(void)
   iccicr |= GIC_ICCICRS_CBPR;
 #endif
 
-#if defined(CONFIG_ARCH_TRUSTZONE_SECURE) || defined(CONFIG_ARCH_TRUSTZONE_BOTH)
+#ifdef CONFIG_ARMV7A_GIC_EOIMODE
+#  if defined(CONFIG_ARCH_TRUSTZONE_SECURE) || defined(CONFIG_ARCH_TRUSTZONE_BOTH)
   /* Set EnableS=1 to enable CPU interface to signal secure interrupts.
    *
    * NOTE:  Only for processors that operate in secure state.
    */
 
   iccicr |= GIC_ICCICRS_EOIMODES;
-#endif
+#  endif
 
-#if defined(CONFIG_ARCH_TRUSTZONE_NONSECURE)
+#  if defined(CONFIG_ARCH_TRUSTZONE_NONSECURE)
   /* Set EnableNS=1 to enable the CPU to signal non-secure interrupts.
    *
    * NOTE:  Only for processors that operate in non-secure state.
@@ -261,13 +262,14 @@ void arm_gic_initialize(void)
 
   iccicr |= GIC_ICCICRS_EOIMODENS;
 
-#elif defined(CONFIG_ARCH_TRUSTZONE_BOTH)
+#  elif defined(CONFIG_ARCH_TRUSTZONE_BOTH)
   /* Set EnableNS=1 to enable the CPU to signal non-secure interrupts.
    *
    * NOTE:  Only for processors that operate in non-secure state.
    */
 
   iccicr |= GIC_ICCICRU_EOIMODENS;
+#  endif
 #endif
 
  #ifdef CONFIG_ARCH_TRUSTZONE_BOTH
@@ -370,6 +372,10 @@ uint32_t *arm_decodeirq(uint32_t *regs)
   regval = getreg32(GIC_ICCIAR);
   irq    = (regval & GIC_ICCIAR_INTID_MASK) >> GIC_ICCIAR_INTID_SHIFT;
 
+#ifdef CONFIG_ARMV7A_GIC_EOIMODE
+  putreg32(regval, GIC_ICCEOIR);
+#endif
+
   /* Ignore spurions IRQs.  ICCIAR will report 1023 if there is no pending
    * interrupt.
    */
@@ -384,7 +390,11 @@ uint32_t *arm_decodeirq(uint32_t *regs)
 
   /* Write to the end-of-interrupt register */
 
+#ifdef CONFIG_ARMV7A_GIC_EOIMODE
+  putreg32(regval, GIC_ICCDIR);
+#else
   putreg32(regval, GIC_ICCEOIR);
+#endif
   return regs;
 }
 

--- a/arch/arm/src/armv7-r/Kconfig
+++ b/arch/arm/src/armv7-r/Kconfig
@@ -13,6 +13,17 @@ config ARMV7R_HAVE_GICv2
 		Selected by the configuration tool if the architecture supports the
 		Generic Interrupt Controller (GIC)
 
+if ARMV7R_HAVE_GICv2
+
+config ARMV7R_GIC_EOIMODE
+	bool
+	default n
+	---help---
+		Enable GICC_CTLR.EOImode, this will separates the priority drop and interrupt
+		deactivation operations.
+
+endif # ARMV7R_GIC_EOIMODE
+
 config ARMV7R_HAVE_PTM
 	bool
 	default n

--- a/arch/arm64/Kconfig
+++ b/arch/arm64/Kconfig
@@ -196,6 +196,17 @@ config ARM_GIC_VERSION
 		Version of Generic Interrupt Controller (GIC) supported by the
 		architecture
 
+if ARM_GIC_VERSION = 2
+
+config ARM_GIC_EOIMODE
+	bool
+	default n
+	---help---
+		Enable GICC_CTLR.EOImode, this will separates the priority drop and interrupt
+		deactivation operations.
+
+endif
+
 if ARCH_CHIP_A64
 source "arch/arm64/src/a64/Kconfig"
 endif


### PR DESCRIPTION
## Summary

On a GICv2 implementation, setting GICC_CTLR.EOImode to 1 separates the priority drop and interrupt deactivation operations, and interrupt handling software must:
1. Perform a valid EOIR write, to cause priority drop on the GIC CPU interface.
2. Subsequently, write to the GICC_DIR, to deactivate the interrupt.

## Impact

irq

## Testing

sabre-6quad:nsh ostest pass