### PR TITLE
netlink: add RTM_NEWADDR, RTM_DELADDR and RTM_GETADDR

### DIFF
--- a/include/netpacket/if_addr.h
+++ b/include/netpacket/if_addr.h
@@ -85,6 +85,8 @@ struct ifaddrmsg
  *
  * IFA_FLAGS is a u32 attribute that extends the u8 field ifa_flags.
  * If present, the value from struct ifaddrmsg will be ignored.
+ *
+ * IFA_RT_PRIORITY is a u32 attribute, priority/metric for prefix route
  */
 
 enum
@@ -98,6 +100,7 @@ enum
   IFA_CACHEINFO,
   IFA_MULTICAST,
   IFA_FLAGS,
+  IFA_RT_PRIORITY,
   __IFA_MAX,
 };
 

--- a/include/netpacket/netlink.h
+++ b/include/netpacket/netlink.h
@@ -389,6 +389,25 @@
 #define RTNLGRP_NSID          28
 #define RTNLGRP_MAX           29
 
+/**
+ * nla_type (16 bits)
+ * +---+---+-------------------------------+
+ * | N | O | Attribute Type                |
+ * +---+---+-------------------------------+
+ * N := Carries nested attributes
+ * O := Payload stored in network byte order
+ *
+ * Note: The N and O flag are mutually exclusive.
+ */
+
+#define NLA_F_NET_BYTEORDER (1 << 14)
+#define NLA_F_NESTED        (1 << 15)
+#define NLA_TYPE_MASK       ~(NLA_F_NESTED | NLA_F_NET_BYTEORDER)
+
+#define NLA_ALIGNTO    4
+#define NLA_ALIGN(len) (((len) + NLA_ALIGNTO - 1) & ~(NLA_ALIGNTO - 1))
+#define NLA_HDRLEN     (NLA_ALIGN(sizeof(struct nlattr)))
+
 /****************************************************************************
  * Public Type Definitions
  ****************************************************************************/
@@ -501,6 +520,41 @@ struct rtmsg
   uint8_t  rtm_scope;     /* See RT_SCOPE_* definitions */
   uint8_t  rtm_type;      /* See RTN_* definitions */
   uint32_t rtm_flags;
+};
+
+/**
+ *  <------- NLA_HDRLEN ------> <-- NLA_ALIGN(payload)-->
+ * +---------------------+- - -+- - - - - - - - - -+- - -+
+ * |        Header       | Pad |     Payload       | Pad |
+ * |   (struct nlattr)   | ing |                   | ing |
+ * +---------------------+- - -+- - - - - - - - - -+- - -+
+ *  <-------------- nlattr->nla_len -------------->
+ */
+
+struct nlattr
+{
+  uint16_t nla_len;
+  uint16_t nla_type;
+};
+
+/* Generic 32 bitflags attribute content sent to the kernel.
+ *
+ * The value is a bitmap that defines the values being set
+ * The selector is a bitmask that defines which value is legit
+ *
+ * Examples:
+ *  value = 0x0, and selector = 0x1
+ *  implies we are selecting bit 1 and we want to set its value to 0.
+ *
+ *  value = 0x2, and selector = 0x2
+ *  implies we are selecting bit 2 and we want to set its value to 1.
+ *
+ */
+
+struct nla_bitfield32
+{
+  uint32_t value;
+  uint32_t selector;
 };
 
 /****************************************************************************

--- a/net/netdev/netdev_ioctl.c
+++ b/net/netdev/netdev_ioctl.c
@@ -839,6 +839,7 @@ static int netdev_ifr_ioctl(FAR struct socket *psock, int cmd,
 
       case SIOCSIFADDR:  /* Set IP address */
         ioctl_set_ipv4addr(&dev->d_ipaddr, &req->ifr_addr);
+        netlink_device_notify_ipaddr(dev, RTM_NEWADDR, AF_INET);
         break;
 
       case SIOCGIFDSTADDR:  /* Get P-to-P address */
@@ -879,6 +880,7 @@ static int netdev_ifr_ioctl(FAR struct socket *psock, int cmd,
         {
           FAR struct lifreq *lreq = (FAR struct lifreq *)req;
           ioctl_set_ipv6addr(dev->d_ipv6addr, &lreq->lifr_addr);
+          netlink_device_notify_ipaddr(dev, RTM_NEWADDR, AF_INET6);
         }
         break;
 
@@ -1040,9 +1042,11 @@ static int netdev_ifr_ioctl(FAR struct socket *psock, int cmd,
       case SIOCDIFADDR:  /* Delete IP address */
 #ifdef CONFIG_NET_IPv4
         dev->d_ipaddr = 0;
+        netlink_device_notify_ipaddr(dev, RTM_DELADDR, AF_INET);
 #endif
 #ifdef CONFIG_NET_IPv6
         memset(&dev->d_ipv6addr, 0, sizeof(net_ipv6addr_t));
+        netlink_device_notify_ipaddr(dev, RTM_DELADDR, AF_INET6);
 #endif
         break;
 

--- a/net/netlink/Kconfig
+++ b/net/netlink/Kconfig
@@ -91,6 +91,31 @@ config NETLINK_DISABLE_GETROUTE
 	---help---
 		RTM_GETROUTE is used to retrieve routing tables.
 
+config NETLINK_DISABLE_NEWADDR
+	bool "Disable RTM_NEWADDR support"
+	default n
+	---help---
+		RTM_NEWADDR is used to set netdev address.
+
+config NETLINK_DISABLE_DELADDR
+	bool "Disable RTM_DELADDR support"
+	default n
+	---help---
+		RTM_DELADDR is used to delete netdev address.
+
+config NETLINK_DISABLE_GETADDR
+	bool "Disable RTM_GETADDR support"
+	default n
+	---help---
+		RTM_GETADDR is used to get netdev address.
+
+config NETLINK_VALIDATE_POLICY
+	bool "Enable netlink message policy verification"
+	default n
+	---help---
+		VALIDATE_POLICY is used to make sure the parameters
+		you pass in are valid.
+
 endif # NETLINK_ROUTE
 endmenu # Netlink Protocols
 endif # NET_NETLINK

--- a/net/netlink/Make.defs
+++ b/net/netlink/Make.defs
@@ -26,7 +26,7 @@ SOCK_CSRCS += netlink_sockif.c
 NET_CSRCS += netlink_conn.c netlink_notifier.c
 
 ifeq ($(CONFIG_NETLINK_ROUTE),y)
-NET_CSRCS += netlink_route.c
+NET_CSRCS += netlink_route.c netlink_attr.c
 endif
 
 # Include netlink build support

--- a/net/netlink/netlink_attr.c
+++ b/net/netlink/netlink_attr.c
@@ -1,0 +1,332 @@
+/****************************************************************************
+ * net/netlink/netlink_attr.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <string.h>
+#include <assert.h>
+#include <errno.h>
+#include <debug.h>
+#include <unistd.h>
+
+#include <nuttx/net/netlink.h>
+
+#include "netlink.h"
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#ifdef CONFIG_NETLINK_VALIDATE_POLICY
+static const uint8_t g_nla_attr_len[NLA_TYPE_MAX + 1] =
+{
+  0,
+  sizeof(uint8_t),
+  sizeof(uint16_t),
+  sizeof(uint32_t),
+  sizeof(uint64_t),
+  0, 0, 0, 0, 0, 0, 0,
+  sizeof(int8_t),
+  sizeof(int16_t),
+  sizeof(int32_t),
+  sizeof(int64_t),
+};
+
+static const uint8_t g_nla_attr_minlen[NLA_TYPE_MAX + 1] =
+{
+  0,
+  sizeof(uint8_t),
+  sizeof(uint16_t),
+  sizeof(uint32_t),
+  sizeof(uint64_t),
+  0, 0,
+  sizeof(uint64_t),
+  NLA_HDRLEN,
+  0, 0, 0,
+  sizeof(int8_t),
+  sizeof(int16_t),
+  sizeof(int32_t),
+  sizeof(int64_t),
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static int validate_nla_bitfield32(FAR const struct nlattr *nla,
+                                   FAR uint32_t *valid_flags_mask)
+{
+  FAR const struct nla_bitfield32 *bf = nla_data(nla);
+
+  if (!valid_flags_mask)
+    {
+      return -EINVAL;
+    }
+
+  /* disallow invalid bit selector */
+
+  if (bf->selector & ~*valid_flags_mask)
+    {
+      return -EINVAL;
+    }
+
+  /* disallow invalid bit values */
+
+  if (bf->value & ~*valid_flags_mask)
+    {
+      return -EINVAL;
+    }
+
+  /* disallow valid bit values that are not selected */
+
+  if (bf->value & ~bf->selector)
+    {
+      return -EINVAL;
+    }
+
+  return 0;
+}
+
+static int validate_nla(FAR const struct nlattr *nla, int maxtype,
+                        FAR const struct nla_policy *policy)
+{
+  FAR const struct nla_policy *pt;
+  int minlen = 0;
+  int attrlen = nla_len(nla);
+  int type = nla_type(nla);
+
+  if (type <= 0 || type > maxtype)
+    {
+      return -EINVAL;
+    }
+
+  pt = &policy[type];
+
+  DEBUGASSERT(pt->type <= NLA_TYPE_MAX);
+
+  if (g_nla_attr_len[pt->type] && attrlen != g_nla_attr_len[pt->type])
+    {
+      nwarn("netlink: '%d': attribute type %d has an invalid length.\n",
+            getpid(), type);
+      return -EINVAL;
+    }
+
+  switch (pt->type)
+    {
+      case NLA_FLAG:
+        if (attrlen > 0)
+          {
+            return -ERANGE;
+          }
+        break;
+
+      case NLA_BITFIELD32:
+        if (attrlen != sizeof(struct nla_bitfield32))
+          {
+            return -ERANGE;
+          }
+
+        if (validate_nla_bitfield32(nla, pt->validation_data) != 0)
+          {
+            return -EINVAL;
+          }
+        break;
+
+      case NLA_NUL_STRING:
+        if (pt->len)
+          {
+            minlen = MIN(attrlen, pt->len + 1);
+          }
+        else
+          {
+            minlen = attrlen;
+          }
+
+        if (!minlen || memchr(nla_data(nla), '\0', minlen) == NULL)
+          {
+            return -EINVAL;
+          }
+
+      /* fall through */
+
+      case NLA_STRING:
+        if (attrlen < 1)
+          {
+            return -ERANGE;
+          }
+
+        if (pt->len)
+          {
+            FAR char *buf = nla_data(nla);
+
+            if (buf[attrlen - 1] == '\0')
+              {
+                attrlen--;
+              }
+
+            if (attrlen > pt->len)
+              {
+                return -ERANGE;
+              }
+          }
+        break;
+
+      case NLA_BINARY:
+        if (pt->len && attrlen > pt->len)
+          {
+            return -ERANGE;
+          }
+        break;
+
+      case NLA_NESTED_COMPAT:
+        if (attrlen < pt->len)
+          {
+            return -ERANGE;
+          }
+
+        if (attrlen < NLA_ALIGN(pt->len))
+          {
+            break;
+          }
+
+        if (attrlen < NLA_ALIGN(pt->len) + NLA_HDRLEN)
+          {
+            return -ERANGE;
+          }
+
+        nla = nla_data(nla) + NLA_ALIGN(pt->len);
+        if (attrlen < NLA_ALIGN(pt->len) + NLA_HDRLEN + nla_len(nla))
+          {
+            return -ERANGE;
+          }
+        break;
+
+      case NLA_NESTED:
+        /* a nested attributes is allowed to be empty; if its not,
+         * it must have a size of at least NLA_HDRLEN.
+         */
+
+        if (attrlen == 0)
+          {
+            break;
+          }
+
+      default:
+        if (pt->len)
+          {
+            minlen = pt->len;
+          }
+        else if (pt->type != NLA_UNSPEC)
+          {
+            minlen = g_nla_attr_minlen[pt->type];
+          }
+
+        if (attrlen < minlen)
+          {
+            return -ERANGE;
+          }
+    }
+
+  return 0;
+}
+#else
+#  define validate_nla(nla, maxtype, policy) 0
+#endif
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: nla_next
+ *
+ * Description:
+ *   Next netlink attribute in attribute stream.
+ *
+ * Input Parameters:
+ *   nla - netlink attribute.
+ *   remaining - number of bytes remaining in attribute stream.
+ *
+ * Returned Value:
+ *   Returns the next netlink attribute in the attribute stream and
+ *   decrements remaining by the size of the current attribute.
+ *
+ ****************************************************************************/
+
+FAR struct nlattr *nla_next(FAR const struct nlattr *nla,
+                            FAR int *remaining)
+{
+  unsigned int totlen = NLA_ALIGN(nla->nla_len);
+
+  *remaining -= totlen;
+  return (FAR struct nlattr *)((FAR char *)nla + totlen);
+}
+
+/****************************************************************************
+ * Name: nla_parse
+ *
+ * Description:
+ *   Parse the nested netlink attribute.
+ *
+ ****************************************************************************/
+
+int nla_parse(FAR struct nlattr **tb, int maxtype,
+              FAR const struct nlattr *head,
+              int len, FAR const struct nla_policy *policy,
+              FAR struct netlink_ext_ack *extack)
+{
+  FAR const struct nlattr *nla;
+  int rem;
+  int err = 0;
+
+  memset(tb, 0, sizeof(FAR struct nlattr *) * (maxtype + 1));
+
+  nla_for_each_attr(nla, head, len, rem)
+    {
+      uint16_t type = nla_type(nla);
+
+      if (type > 0 && type <= maxtype)
+        {
+          err = validate_nla(nla, maxtype, policy);
+          if (err < 0)
+            {
+              nl_set_err_msg_attr(extack, nla,
+                                  "Attribute failed policy validation");
+              goto errout;
+            }
+
+          tb[type] = (FAR struct nlattr *)nla;
+        }
+    }
+
+  if (rem > 0)
+    {
+      nwarn("netlink: %d bytes leftover after parsing attributes in "
+            "pid `%d'.\n", rem, getpid());
+    }
+
+errout:
+  return err;
+}


### PR DESCRIPTION
We have projects that need to sense ip address changes in time, and set ip address or clear ip address through netlink so the relevant implementation is added.
The usage and command structure are consistent with linux

## Summary
simple example to detect ip change:
```
#include <stdio.h>
#include <stdlib.h>
#include <sys/socket.h>
#include <netinet/in.h>
#include <netpacket/netlink.h>

void newaddr(struct nlmsghdr *hdr);
int main(void)
{
  struct sockaddr_nl addr;
  int sk;

  sk = socket(PF_NETLINK, SOCK_DGRAM | SOCK_CLOEXEC, NETLINK_ROUTE);
  memset(&addr, 0, sizeof(addr));
  addr.nl_family = AF_NETLINK;
  addr.nl_groups = RTMGRP_LINK | RTMGRP_IPV4_IFADDR | RTMGRP_IPV4_ROUTE |
      RTMGRP_IPV6_IFADDR | RTMGRP_IPV6_ROUTE |
      (1 << (RTNLGRP_ND_USEROPT - 1));
  bind(sk, (struct sockaddr *) &addr, sizeof(addr));

  unsigned char buf[4096];
  struct sockaddr_nl nladdr;
  socklen_t addr_len = sizeof(nladdr);
  ssize_t status;
  memset(buf, 0, sizeof(buf));
  memset(&nladdr, 0, sizeof(nladdr));

  /* This is usually poll() */

  status = recvfrom(sk, buf, sizeof(buf), 0,
                   (struct sockaddr *) &nladdr, &addr_len);

  while (status > 0)
    {
      struct nlmsghdr *hdr = (struct nlmsghdr *)buf;

      if (!NLMSG_OK(hdr, status))
        {
          break;
        }

      switch (hdr->nlmsg_type)
        {
          case NLMSG_DONE:
            return 0;
          case RTM_NEWADDR:
            newaddr(hdr);
            break;
          default:
            break;
        }
    }

  return 0;
}

void newaddr(struct nlmsghdr *hdr)
{
  struct ifaddrmsg *msg = (struct ifaddrmsg *) NLMSG_DATA(hdr);
  struct rtattr *attr;
  int bytes = IFA_PAYLOAD(hdr);

  for (attr = IFA_RTA(msg); RTA_OK(attr, bytes);
       attr = RTA_NEXT(attr, bytes))
    {
      switch (attr->rta_type)
        {
          case IFA_ADDRESS:
            if (msg->ifa_family == AF_INET)
              {
                /* ipv4 address changed */

                /* *((struct in_addr *) RTA_DATA(attr)); new addr */
              }
            else if (msg->ifa_family == AF_INET6)
              {
                /* ipv6 address changed */

                /* *((struct in6_addr *) RTA_DATA(attr)); new addr */
              }
              break;
          default:
            break;
        }
    }
}
```
## Impact

## Testing
Passed the test under simulated environment
