### PR TITLE
arm/chip/sdio/muxbus: remove all undefined symbols

### DIFF
--- a/arch/arm/src/imxrt/imxrt_usdhc.c
+++ b/arch/arm/src/imxrt/imxrt_usdhc.c
@@ -1375,8 +1375,12 @@ static int imxrt_lock(struct sdio_dev_s *dev, bool lock)
 {
   /* The multiplex bus is part of board support package. */
 
-  imxrt_muxbus_sdio_lock((dev - g_sdhcdev) /
-                         sizeof(struct imxrt_dev_s), lock);
+  /* FIXME: Implement the below function to support bus share:
+   *
+   * imxrt_muxbus_sdio_lock((dev - g_sdhcdev) /
+   *                        sizeof(struct imxrt_dev_s), lock);
+   */
+
   return OK;
 }
 #endif

--- a/arch/arm/src/kinetis/kinetis_sdhc.c
+++ b/arch/arm/src/kinetis/kinetis_sdhc.c
@@ -1202,7 +1202,11 @@ static int kinetis_lock(struct sdio_dev_s *dev, bool lock)
    * bus is part of board support package.
    */
 
-  kinetis_muxbus_sdio_lock(lock);
+  /* FIXME: Implement the below function to support bus share:
+   *
+   * kinetis_muxbus_sdio_lock(lock);
+   */
+
   return OK;
 }
 #endif

--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_sdcard.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_sdcard.c
@@ -1382,7 +1382,11 @@ static int lpc17_40_lock(struct sdio_dev_s *dev, bool lock)
    * bus is part of board support package.
    */
 
-  lpc17_40_muxbus_sdio_lock(lock);
+  /* FIXME: Implement the below function to support bus share:
+   *
+   * lpc17_40_muxbus_sdio_lock(lock);
+   */
+
   return OK;
 }
 #endif

--- a/arch/arm/src/lpc43xx/lpc43_sdmmc.c
+++ b/arch/arm/src/lpc43xx/lpc43_sdmmc.c
@@ -1201,7 +1201,11 @@ static int lpc43_lock(struct sdio_dev_s *dev, bool lock)
    * bus is part of board support package.
    */
 
-  lpc43_muxbus_sdio_lock(lock);
+  /* FIXME: Implement the below function to support bus share:
+   *
+   * lpc43_muxbus_sdio_lock(lock);
+   */
+
   return OK;
 }
 #endif

--- a/arch/arm/src/lpc54xx/lpc54_sdmmc.c
+++ b/arch/arm/src/lpc54xx/lpc54_sdmmc.c
@@ -1197,7 +1197,11 @@ static int lpc54_lock(struct sdio_dev_s *dev, bool lock)
    * bus is part of board support package.
    */
 
-  lpc54_muxbus_sdio_lock(lock);
+  /* FIXME: Implement the below function to support bus share:
+   *
+   * lpc54_muxbus_sdio_lock(lock);
+   */
+
   return OK;
 }
 #endif

--- a/arch/arm/src/sama5/sam_sdmmc.c
+++ b/arch/arm/src/sama5/sam_sdmmc.c
@@ -1473,8 +1473,12 @@ static int sam_lock(struct sdio_dev_s *dev, bool lock)
 {
   /* The multiplex bus is part of board support package. */
 
-  sam_muxbus_sdio_lock((dev - g_sdmmcdev) /
-                         sizeof(struct sam_dev_s), lock);
+  /* FIXME: Implement the below function to support bus share:
+   *
+   * sam_muxbus_sdio_lock((dev - g_sdmmcdev) /
+   *                        sizeof(struct sam_dev_s), lock);
+   */
+
   return OK;
 }
 #endif

--- a/arch/arm/src/stm32/stm32_sdio.c
+++ b/arch/arm/src/stm32/stm32_sdio.c
@@ -1580,7 +1580,11 @@ static int stm32_lock(struct sdio_dev_s *dev, bool lock)
    * bus is part of board support package.
    */
 
-  stm32_muxbus_sdio_lock(lock);
+  /* FIXME: Implement the below function to support bus share:
+   *
+   * stm32_muxbus_sdio_lock(lock);
+   */
+
   return OK;
 }
 #endif

--- a/arch/arm/src/stm32f7/stm32_sdmmc.c
+++ b/arch/arm/src/stm32f7/stm32_sdmmc.c
@@ -1832,7 +1832,11 @@ static int stm32_lock(struct sdio_dev_s *dev, bool lock)
 {
   /* The multiplex bus is part of board support package. */
 
-  stm32_muxbus_sdio_lock(dev, lock);
+  /* FIXME: Implement the below function to support bus share:
+   *
+   * stm32_muxbus_sdio_lock(dev, lock);
+   */
+
   return OK;
 }
 #endif

--- a/arch/arm/src/stm32h7/stm32_sdmmc.c
+++ b/arch/arm/src/stm32h7/stm32_sdmmc.c
@@ -1872,7 +1872,11 @@ static int stm32_lock(struct sdio_dev_s *dev, bool lock)
 {
   /* The multiplex bus is part of board support package. */
 
-  stm32_muxbus_sdio_lock(dev, lock);
+  /* FIXME: Implement the below function to support bus share:
+   *
+   * stm32_muxbus_sdio_lock(dev, lock);
+   */
+
   return OK;
 }
 #endif

--- a/arch/arm/src/stm32l4/stm32l4_sdmmc.c
+++ b/arch/arm/src/stm32l4/stm32l4_sdmmc.c
@@ -1632,7 +1632,11 @@ static int stm32_lock(struct sdio_dev_s *dev, bool lock)
 {
   /* The multiplex bus is part of board support package. */
 
-  stm32_muxbus_sdio_lock(dev, lock);
+  /* FIXME: Implement the below function to support bus share:
+   *
+   * stm32_muxbus_sdio_lock(dev, lock);
+   */
+
   return OK;
 }
 #endif

--- a/arch/risc-v/src/mpfs/mpfs_emmcsd.c
+++ b/arch/risc-v/src/mpfs/mpfs_emmcsd.c
@@ -1180,7 +1180,10 @@ static int mpfs_lock(struct sdio_dev_s *dev, bool lock)
 {
   /* The multiplex bus is part of board support package. */
 
-  mpfs_muxbus_sdio_lock(dev, lock);
+  /* FIXME: Implement the below function to support bus share:
+   *
+   * mpfs_muxbus_sdio_lock(dev, lock);
+   */
 
   return OK;
 }


### PR DESCRIPTION
## Summary

arm/chip/sdio/muxbus: remove all undefined symbols

remove all undefined symbols to avoid build break if CONFIG_SDIO_MUXBUS enabled

## Impact

N/A

## Testing

enable CONFIG_SDIO_MUXBUS in photon/wlan :

```bash
chip/stm32_sdio.c: In function 'stm32_lock':
chip/stm32_sdio.c:1583:3: warning: implicit declaration of function 'stm32_muxbus_sdio_lock' [-Wimplicit-function-declaration]
 1583 |   stm32_muxbus_sdio_lock(lock);
      |   ^~~~~~~~~~~~~~~~~~~~~~
LD: nuttx
arm-none-eabi-ld: /home/archer/code/nuttx/n9/incubator-nuttx/staging/libarch.a(stm32_sdio.o): in function `stm32_lock':
stm32_sdio.c:(.text.stm32_lock+0x4): undefined reference to `stm32_muxbus_sdio_lock'
make[1]: *** [Makefile:187: nuttx] Error 1
make: *** [tools/Unix.mk:520: nuttx] Error 2

```