### PR TITLE
Optimize implementation of strsignal()

### DIFF
--- a/include/fcntl.h
+++ b/include/fcntl.h
@@ -87,9 +87,9 @@
 #define F_GETFL         2  /* Read the file status flags */
 #define F_GETLEASE      3  /* Indicates what type of lease is held on fd (linux) */
 #define F_GETLK         4  /* Check if we could place a lock */
-#define F_GETOWN        5  /* Get the pid receiving  SIGIO and SIGURG signals for fd */
+#define F_GETOWN        5  /* Get the pid receiving SIGIO and SIGURG signals for fd */
 #define F_GETSIG        6  /* Get the signal sent */
-#define F_NOTIFY        7  /* Provide notification when directory referred to by fd changes (linux)*/
+#define F_NOTIFY        7  /* Provide notification when directory referred to by fd changes (linux) */
 #define F_SETFD         8  /* Set the file descriptor flags to value */
 #define F_SETFL         9  /* Set the file status flags to the value */
 #define F_SETLEASE      10 /* Set or remove file lease (linux) */

--- a/libs/libc/string/Kconfig
+++ b/libs/libc/string/Kconfig
@@ -9,7 +9,7 @@ config LIBC_STRERROR
 	bool "Enable strerror"
 	default n
 	---help---
-		strerror() is useful because it decodes 'errno' values into a human readable
+		strerror() is useful because it decodes 'errno' values into human readable
 		strings.  But it can also require a lot of memory.  If this option is not
 		selected, strerror() will still exist in the build but it will not decode error
 		values.  This option should be used by other logic to decide if it should use
@@ -22,11 +22,11 @@ config LIBC_STRERROR_SHORT
 	default n
 	depends on LIBC_STRERROR
 	---help---
-		If this option is selected, then strerror() will use a shortened string when
+		If this option is selected, then strerror() will use shortened string when
 		it decodes the error.  Specifically, strerror() is simply use the string that
 		is the common name for the error.  For example, the 'errno' value of 2 will
-		produce the string "No such file or directory" is LIBC_STRERROR_SHORT
-		is not defined but the string "ENOENT" is LIBC_STRERROR_SHORT is defined.
+		produce the string "No such file or directory" if LIBC_STRERROR_SHORT
+		is not defined but the string "ENOENT" if LIBC_STRERROR_SHORT is defined.
 
 config LIBC_PERROR_STDOUT
 	bool "perror() to stdout"
@@ -90,3 +90,30 @@ config MEMSET_64BIT
 		efficiently.
 
 endmenu # memcpy/memset Options
+
+menu "signal Decode Support"
+
+config LIBC_STRSIGNAL
+	bool "Enable strsignal"
+	default y
+	---help---
+		strsignal() is useful because it decodes signal number values into
+		human readable strings.  But it can also require additional memory.
+		If this option is not selected, strsignal() will still exist in the
+		build but it will not decode signal number values to specific string
+		equivalents, but a generic string 'Signal X' will be returned for the
+		valid signal number value and 'Real-time Signal X' will be returned
+		for the valid real-time signal number value.
+
+config LIBC_STRSIGNAL_SHORT
+	bool "Use short message string descriptions in strsignal()"
+	default DEFAULT_SMALL
+	depends on LIBC_STRSIGNAL
+	---help---
+		If this option is selected, then strsignal() will use a symbolic value
+		string equivalent to the signal number when signal value is decoded.
+		For example, the signal value for SIGTRAP will produce the string
+		"Trace/breakpoint trap" if LIBC_STRSIGNAL_SHORT is not defined but the
+		string "SIGTRAP" if LIBC_STRSIGNAL_SHORT is defined.
+
+endmenu # signal Decode Support


### PR DESCRIPTION
## Summary
Refine and optimise `strsignal()` implementation according to https://pubs.opengroup.org/onlinepubs/9699919799/functions/strsignal.html

The POSIX states that:
- `The strsignal() function need not be thread-safe.`
- `The returned pointer might be invalidated or the string content might be overwritten by a subsequent call to strsignal() or setlocale().`

So there is a room for using `snprintf` instead of static strings allocation in case of unknown signal value is passed to `strsignal()`

## Impact
I do not expect big impact since `CONFIG_LIBC_STRSIGNAL` is enabled by default and `CONFIG_LIBC_STRSIGNAL_SHORT` is enabled by default only for `CONFIG_DEFAULT_SMALL` case.

## Testing
Pass CI.
Tests are in progress.
