### PR TITLE
tools/export: Add LDELFFLAGS to mkexport.sh.

### DIFF
--- a/tools/Export.mk
+++ b/tools/Export.mk
@@ -67,6 +67,7 @@ ifdef ARCHSCRIPT
 endif
 	@echo "LD=\"$(LD)\"" >> $(EXPORTDIR)/makeinfo.sh
 	@echo "LDENDGROUP=\"$(LDENDGROUP)\"" >> $(EXPORTDIR)/makeinfo.sh
+	@echo "LDELFFLAGS=\"$(LDELFFLAGS)\"" >> $(EXPORTDIR)/makeinfo.sh
 	@echo "LDFLAGS=\"$(LDFLAGS)\"" >> $(EXPORTDIR)/makeinfo.sh
 	@echo "LDLIBS=\"$(LDLIBS)\"" >> $(EXPORTDIR)/makeinfo.sh
 	@echo "LDSCRIPT=\"$(LDSCRIPT)\"" >> $(EXPORTDIR)/makeinfo.sh

--- a/tools/mkexport.sh
+++ b/tools/mkexport.sh
@@ -250,6 +250,7 @@ echo "HOSTCFLAGS       = ${HOSTCFLAGS}" >>"${EXPORTDIR}/scripts/Make.defs"
 echo "HOSTLDFLAGS      = ${HOSTLDFLAGS}" >>"${EXPORTDIR}/scripts/Make.defs"
 echo "HOSTEXEEXT       = ${HOSTEXEEXT}" >>"${EXPORTDIR}/scripts/Make.defs"
 echo "LDNAME           = ${LDNAME}" >>"${EXPORTDIR}/scripts/Make.defs"
+echo "LDELFFLAGS       = ${LDELFFLAGS}" >>"${EXPORTDIR}/scripts/Make.defs"
 
 # Additional compilation options when the kernel is built
 


### PR DESCRIPTION
## Summary

Some targets, such as qemu-rv, support multiple architectures. The required flags need to passed to the linker when application elfs are build "out-of-tree", from the application directory.

This PR addresses #8666, and its modifications, or something similar would be needed in order to finalise #8643.

Without supplying the relevant architecture flags, in this case `LDELFFLAGS = --oformat elf32-littleriscv`, the `rv-virt:knsh32` build would result in:

```
riscv64-unknown-elf-ld: attempt to do relocatable link with elf32-littleriscv input and elf64-littleriscv output
riscv64-unknown-elf-ld: /home/user/toolchains/riscv64-unknown-elf-gcc-8.3.0/bin/../lib/gcc/riscv64-unknown-elf/8.3.0/rv32imac/ilp32/libgcc.a(_clzsi2.o): file class ELFCLASS32 incompatible with ELFCLASS64
riscv64-unknown-elf-ld: final link failed: file in wrong format
```

Possibly there is a better way to pass this configuration through the `make export` and `make import` targets. If so, let me know and I can remove this PR.

## Impact

An additional definition, `LDELFFLAGS` is added to the exported `Make.defs`  in the application repository `import/scripts/` directory. These flags are picked up with the additions from [this PR](https://github.com/apache/nuttx-apps/pull/1677) and used when building the application elf targets.

`$ cat import/scripts/Make.defs`
```
LDNAME           = ld-kernel32.script
LDELFFLAGS       = (flags from board Make.def, or toolchain)
```

## Testing

I've tried this out on `rv-virt:knsh32` from #8643, the upstream `rv-virt:knsh64` as well as the vexriscv-smp port I'm working on `#8762`. However this PR may have wider implications.
