### PR TITLE
arch/arm64: fixed cache issue and add more cache interface

### DIFF
--- a/arch/arm64/src/common/arm64_cache.c
+++ b/arch/arm64/src/common/arm64_cache.c
@@ -309,6 +309,48 @@ void up_invalidate_icache_all(void)
 }
 
 /****************************************************************************
+ * Name: up_enable_icache
+ *
+ * Description:
+ *   Enable the I-Cache
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void up_enable_icache(void)
+{
+  uint64_t value = read_sysreg(sctlr_el1);
+  write_sysreg((value | SCTLR_I_BIT), sctlr_el1);
+  ARM64_ISB();
+}
+
+/****************************************************************************
+ * Name: up_disable_icache
+ *
+ * Description:
+ *   Disable the I-Cache
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void up_disable_icache(void)
+{
+  uint64_t value = read_sysreg(sctlr_el1);
+  write_sysreg((value & ~SCTLR_I_BIT), sctlr_el1);
+  ARM64_ISB();
+}
+
+/****************************************************************************
  * Name: up_invalidate_dcache
  *
  * Description:
@@ -373,8 +415,8 @@ void up_invalidate_dcache_all(void)
 
 size_t up_get_dcache_linesize(void)
 {
-  uint64_t  ctr_el0;
-  uint32_t  dminline;
+  uint64_t ctr_el0;
+  uint32_t dminline;
 
   if (g_dcache_line_size != 0)
     {
@@ -451,6 +493,48 @@ void up_clean_dcache(uintptr_t start, uintptr_t end)
 void up_clean_dcache_all(void)
 {
   arm64_dcache_all(CACHE_OP_WB);
+}
+
+/****************************************************************************
+ * Name: up_enable_dcache
+ *
+ * Description:
+ *   Enable the D-Cache
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void up_enable_dcache(void)
+{
+  uint64_t value = read_sysreg(sctlr_el1);
+  write_sysreg((value | SCTLR_C_BIT), sctlr_el1);
+  ARM64_ISB();
+}
+
+/****************************************************************************
+ * Name: up_disable_dcache
+ *
+ * Description:
+ *   Disable the D-Cache
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void up_disable_dcache(void)
+{
+  uint64_t value = read_sysreg(sctlr_el1);
+  write_sysreg((value & ~SCTLR_C_BIT), sctlr_el1);
+  ARM64_ISB();
 }
 
 /****************************************************************************

--- a/arch/arm64/src/common/arm64_cpustart.c
+++ b/arch/arm64/src/common/arm64_cpustart.c
@@ -93,7 +93,7 @@ static inline void local_delay(void)
     }
 }
 
-#ifdef CONFIG_ARCH_HAVE_MMU
+#if defined (CONFIG_ARCH_HAVE_MMU) || defined (CONFIG_ARCH_HAVE_MPU)
 static void flush_boot_params(void)
 {
   uintptr_t flush_start;
@@ -103,11 +103,6 @@ static void flush_boot_params(void)
   flush_end     = flush_start + sizeof(cpu_boot_params);
 
   up_flush_dcache(flush_start, flush_end);
-}
-#else
-static void flush_boot_params(void)
-{
-  /* TODO: Flush at MPU platform */
 }
 #endif
 

--- a/arch/arm64/src/common/arm64_mmu.c
+++ b/arch/arm64/src/common/arm64_mmu.c
@@ -198,9 +198,9 @@ static const struct arm_mmu_config g_mmu_nxrt_config =
 
 static uint64_t get_tcr(int el)
 {
-  uint64_t  tcr;
-  uint64_t  va_bits = CONFIG_ARM64_VA_BITS;
-  uint64_t  tcr_ps_bits;
+  uint64_t tcr;
+  uint64_t va_bits = CONFIG_ARM64_VA_BITS;
+  uint64_t tcr_ps_bits;
 
   tcr_ps_bits = TCR_PS_BITS;
 
@@ -237,10 +237,10 @@ static int pte_desc_type(uint64_t *pte)
 
 static uint64_t *calculate_pte_index(uint64_t addr, int level)
 {
-  int           base_level = XLAT_TABLE_BASE_LEVEL;
-  uint64_t      *pte;
-  uint64_t      idx;
-  unsigned int  i;
+  int base_level = XLAT_TABLE_BASE_LEVEL;
+  uint64_t *pte;
+  uint64_t idx;
+  unsigned int i;
 
   /* Walk through all translation tables to find pte index */
 
@@ -288,8 +288,8 @@ static void set_pte_table_desc(uint64_t *pte, uint64_t *table,
 static void set_pte_block_desc(uint64_t *pte, uint64_t addr_pa,
                                unsigned int attrs, unsigned int level)
 {
-  uint64_t      desc = addr_pa;
-  unsigned int  mem_type;
+  uint64_t desc = addr_pa;
+  unsigned int mem_type;
 
   desc |= (level == 3) ? PTE_PAGE_DESC : PTE_BLOCK_DESC;
 
@@ -307,8 +307,8 @@ static void set_pte_block_desc(uint64_t *pte, uint64_t addr_pa,
 
   /* memory attribute index field */
 
-  mem_type  = MT_TYPE(attrs);
-  desc      |= PTE_BLOCK_DESC_MEMTYPE(mem_type);
+  mem_type = MT_TYPE(attrs);
+  desc |= PTE_BLOCK_DESC_MEMTYPE(mem_type);
 
   switch (mem_type)
     {
@@ -326,8 +326,8 @@ static void set_pte_block_desc(uint64_t *pte, uint64_t addr_pa,
 
         /* Map device memory as execute-never */
 
-        desc  |= PTE_BLOCK_DESC_PXN;
-        desc  |= PTE_BLOCK_DESC_UXN;
+        desc |= PTE_BLOCK_DESC_PXN;
+        desc |= PTE_BLOCK_DESC_UXN;
         break;
       }
 
@@ -383,9 +383,9 @@ static uint64_t *new_prealloc_table(void)
 
 static void split_pte_block_desc(uint64_t *pte, int level)
 {
-  uint64_t      old_block_desc = *pte;
-  uint64_t      *new_table;
-  unsigned int  i = 0;
+  uint64_t old_block_desc = *pte;
+  uint64_t *new_table;
+  unsigned int i = 0;
 
   /* get address size shift bits for next level */
 
@@ -416,14 +416,14 @@ static void split_pte_block_desc(uint64_t *pte, int level)
 
 static void init_xlat_tables(const struct arm_mmu_region *region)
 {
-  uint64_t      *pte;
-  uint64_t      virt    = region->base_va;
-  uint64_t      phys    = region->base_pa;
-  uint64_t      size    = region->size;
-  uint64_t      attrs   = region->attrs;
-  uint64_t      level_size;
-  uint64_t      *new_table;
-  unsigned int  level = XLAT_TABLE_BASE_LEVEL;
+  unsigned int level = XLAT_TABLE_BASE_LEVEL;
+  uint64_t virt = region->base_va;
+  uint64_t phys = region->base_pa;
+  uint64_t size = region->size;
+  uint64_t attrs = region->attrs;
+  uint64_t *pte;
+  uint64_t *new_table;
+  uint64_t level_size;
 
 #ifdef CONFIG_MMU_DEBUG
   sinfo("mmap: virt %llx phys %llx size %llx\n", virt, phys, size);
@@ -454,9 +454,9 @@ static void init_xlat_tables(const struct arm_mmu_region *region)
            */
 
           set_pte_block_desc(pte, phys, attrs, level);
-          virt  += level_size;
-          phys  += level_size;
-          size  -= level_size;
+          virt += level_size;
+          phys += level_size;
+          size -= level_size;
 
           /* Range is mapped, start again for next range */
 
@@ -484,15 +484,15 @@ static void init_xlat_tables(const struct arm_mmu_region *region)
 
 static void setup_page_tables(void)
 {
-  unsigned int                  index;
-  const struct arm_mmu_region   *region;
-  uint64_t                      max_va = 0, max_pa = 0;
+  uint64_t max_va = 0, max_pa = 0;
+  const struct arm_mmu_region *region;
+  unsigned int index;
 
   for (index = 0; index < g_mmu_config.num_regions; index++)
     {
-      region    = &g_mmu_config.mmu_regions[index];
-      max_va    = MAX(max_va, region->base_va + region->size);
-      max_pa    = MAX(max_pa, region->base_pa + region->size);
+      region = &g_mmu_config.mmu_regions[index];
+      max_va = MAX(max_va, region->base_va + region->size);
+      max_pa = MAX(max_pa, region->base_pa + region->size);
     }
 
   __MMU_ASSERT(max_va <= (1ULL << CONFIG_ARM64_VA_BITS),
@@ -557,8 +557,8 @@ static void enable_mmu_el1(unsigned int flags)
 
 int arm_mmu_set_memregion(const struct arm_mmu_region *region)
 {
-  uint64_t  virt    = region->base_va;
-  uint64_t  size    = region->size;
+  uint64_t virt = region->base_va;
+  uint64_t size = region->size;
 
   if (((virt & (PAGE_SIZE - 1)) == 0) &&
       ((size & (PAGE_SIZE - 1)) == 0))
@@ -582,10 +582,8 @@ int arm_mmu_set_memregion(const struct arm_mmu_region *region)
 
 int arm64_mmu_init(bool is_primary_core)
 {
-  uint64_t  val;
-  unsigned  flags = 0;
-  uint64_t  ctr_el0;
-  uint32_t  dminline;
+  uint64_t val;
+  unsigned flags = 0;
 
   /* Current MMU code supports only EL1 */
 
@@ -617,12 +615,6 @@ int arm64_mmu_init(bool is_primary_core)
   /* currently only EL1 is supported */
 
   enable_mmu_el1(flags);
-
-  /* get cache line size */
-
-  ctr_el0 = read_sysreg(CTR_EL0);
-  dminline = (ctr_el0 >> CTR_EL0_DMINLINE_SHIFT) & CTR_EL0_DMINLINE_MASK;
-  g_dcache_line_size = 4 << dminline;
 
   return 0;
 }

--- a/arch/arm64/src/common/arm64_mmu.h
+++ b/arch/arm64/src/common/arm64_mmu.h
@@ -241,7 +241,6 @@ struct arm_mmu_ptables
  */
 
 extern const struct arm_mmu_config g_mmu_config;
-extern size_t g_dcache_line_size;
 
 /****************************************************************************
  * Public Function Prototypes

--- a/arch/arm64/src/common/arm64_mpu.c
+++ b/arch/arm64/src/common/arm64_mpu.c
@@ -99,7 +99,7 @@ void arm64_core_mpu_enable(void)
   uint64_t val;
 
   val   = read_sysreg(sctlr_el1);
-  val   |= SCTLR_M_BIT;
+  val   |= (SCTLR_M_BIT | SCTLR_C_BIT);
   write_sysreg(val, sctlr_el1);
   ARM64_DSB();
   ARM64_ISB();
@@ -118,7 +118,7 @@ void arm64_core_mpu_disable(void)
   ARM64_DMB();
 
   val   = read_sysreg(sctlr_el1);
-  val   &= ~SCTLR_M_BIT;
+  val   &= ~(SCTLR_M_BIT | SCTLR_C_BIT);
   write_sysreg(val, sctlr_el1);
   ARM64_DSB();
   ARM64_ISB();

--- a/arch/arm64/src/common/arm64_mpu.h
+++ b/arch/arm64/src/common/arm64_mpu.h
@@ -202,13 +202,23 @@
     .mair_idx = MPU_MAIR_INDEX_DEVICE,                    \
   }
 
-#define REGION_RAM_ATTR                                   \
-  {                                                       \
-    /* AP, XN, SH */                                      \
-    .rbar = NOT_EXEC | P_RW_U_NA_MSK | NON_SHAREABLE_MSK, \
-    /* Cache-ability */                                   \
-    .mair_idx = MPU_MAIR_INDEX_SRAM,                      \
-  }
+#ifdef CONFIG_SMP
+#  define REGION_RAM_ATTR                                        \
+    {                                                            \
+      /* AP, XN, SH */                                           \
+      .rbar = (NOT_EXEC | P_RW_U_NA_MSK | INNER_SHAREABLE_MSK) , \
+      /* Cache-ability */                                        \
+      .mair_idx = MPU_MAIR_INDEX_SRAM,                           \
+    }
+#else
+#  define REGION_RAM_ATTR                                   \
+    {                                                       \
+      /* AP, XN, SH */                                      \
+      .rbar = NOT_EXEC | P_RW_U_NA_MSK | NON_SHAREABLE_MSK, \
+      /* Cache-ability */                                   \
+      .mair_idx = MPU_MAIR_INDEX_SRAM,                      \
+    }
+#endif
 
 #define REGION_RAM_TEXT_ATTR                   \
   {                                            \
@@ -232,11 +242,11 @@ struct arm64_mpu_region_attr
 {
   /* Attributes belonging to PRBAR */
 
-  uint8_t rbar : 5;
+  uint8_t rbar;
 
   /* MAIR index for attribute indirection */
 
-  uint8_t mair_idx : 3;
+  uint8_t mair_idx;
 };
 
 /* Region definition data structure */

--- a/boards/arm64/fvp-v8r/fvp-armv8r/scripts/fvp_cfg_smp.txt
+++ b/boards/arm64/fvp-v8r/fvp-armv8r/scripts/fvp_cfg_smp.txt
@@ -22,4 +22,4 @@ bp.pl011_uart3.unbuffered_output=1
 bp.terminal_3.start_telnet=0
 bp.vis.disable_visualisation=1
 bp.vis.rate_limit-enable=0
-cache_state_modelled=0
+cache_state_modelled=1


### PR DESCRIPTION
## Summary

1.  When there has no mmu, the cache size will fail to be obtained. Therefore, the initial cache size is set the first time up_get_dcache_linesize is called.
2.  Add cache enable and disable interface.

## Impact

Cache

## Testing

fvp-armv8r:nsh fvp-armv8r:nsh_smp qemu-armv8a-nsh qemu-armv8a-nsh_smp