### PR TITLE
Correct Real Time signal definitions.

### DIFF
--- a/include/limits.h
+++ b/include/limits.h
@@ -82,7 +82,7 @@
  *
  * Required for sigqueue
  *
- *   _POSIX_RTSIG_MAX      Difference between SIGRTMIN and SIGRTMAX
+ *   _POSIX_RTSIG_MAX      Number of realtime signals reserved for application
  *   _POSIX_SIGQUEUE_MAX   Max number signals a task can queue
  *
  * Required for POSIX timers
@@ -146,7 +146,7 @@
 
 /* Required for sigqueue */
 
-#define _POSIX_RTSIG_MAX      31
+#define _POSIX_RTSIG_MAX      2    /*  Number of reserved realtime signals */
 #define _POSIX_SIGQUEUE_MAX   32
 
 /* Required for symbolic links */

--- a/include/signal.h
+++ b/include/signal.h
@@ -39,14 +39,15 @@
 
 #define NULL_SIGNAL_SET ((sigset_t)0x00000000)
 #define ALL_SIGNAL_SET  ((sigset_t)0xffffffff)
-#define MIN_SIGNO       1
-#define MAX_SIGNO       31
+#define MIN_SIGNO       1               /* Lowest valid signal number */
+#define MAX_SIGNO       31              /* Highest valid signal number */
 #define GOOD_SIGNO(s)   ((((unsigned)(s)) <= MAX_SIGNO))
 #define SIGNO2SET(s)    ((sigset_t)1 << (s))
 
-/* All signals are "real time" signals */
+/* Definitions for "real time" signals */
 
-#define SIGRTMIN        MIN_SIGNO       /* First real time signal */
+#define SIGSTDMAX       29              /* Last standard signal number */
+#define SIGRTMIN        (SIGSTDMAX + 1) /* First real time signal */
 #define SIGRTMAX        MAX_SIGNO       /* Last real time signal */
 #define _NSIG           (MAX_SIGNO + 1) /* Biggest signal number + 1 */
 


### PR DESCRIPTION
## Summary

There are number problems with the implementation of real-time signals in NuttX as discussed in Issue #8869.  A first step to correcting any of these is to correct the definitions of SIGRTMIN, SIGRTMAX, and RTSIG_SIX.

**SIGRTMIN** is the first real-time signals.  Real-time signal numbers must not overlap the standard signal numbers.  Before this fix, it was set equal to the first standard signal.  Real-time signals differ from standard signals in that (1) they have no default actions, and (2) real time signal actions are prioritized whereas standard signal actions are processed FIFO.

Within the OS, the range of real time signals must no overlap the range of standard signals so that they can be distinguished for these differences in functionality (someday).

The primary use of SIGRTMIN by applications is for the OS-independent assignment of signal numbers to application-specific real time signals:  SIGRTMIN is the first available real time signal, SIGRTMIN+1 is the second, etc.  It is useless for this purpose if the real time signal numbers are defined so that they overlap the pre-defined standard, non-real time signals.  That would cause the assignment of real time signal numbers that conflict with standard signals.

**SIGRTMAX** is the last real-time signal.  This has not changed (yet).

**RTSIG_MAX**.   The maximum number of real time signals reserved for application use.  This must be set equal to SIGRTMAX - SIGRTMIN + 1,  So if SIGRTMIN changes so must RTSIG_MAX.  Since SIGRTMIN is now 30, the correct value of RTSIG_MX is two.

Yes, more real-time signals are needed now that there are 29 pre-defined standard signals.

## Impact

The change corrects the definitions but has not impact at all because none of there definitions are currently used in the OS.  But they will be when prioritized real time signal handling is implemented.

## Testing

Since this change has no impact to any code, testing only consists of successfully passing CI
