### PR TITLE
stm32/otgdev: remove invalid use of the priv field for EP

### DIFF
--- a/arch/arm/src/efm32/efm32_usbdev.c
+++ b/arch/arm/src/efm32/efm32_usbdev.c
@@ -1526,8 +1526,8 @@ static inline void efm32_ep0out_receive(struct efm32_ep_s *privep,
 
   /* Sanity Checking */
 
-  DEBUGASSERT(privep && privep->ep.priv);
-  priv = (struct efm32_usbdev_s *)privep->ep.priv;
+  DEBUGASSERT(privep && privep->dev);
+  priv = (struct efm32_usbdev_s *)privep->dev;
 
   uinfo("EP0: bcnt=%d\n", bcnt);
   usbtrace(TRACE_READ(EP0), bcnt);
@@ -5148,9 +5148,6 @@ static void efm32_swinitialize(struct efm32_usbdev_s *priv)
 
   priv->epavail[0] = EFM32_EP_AVAILABLE;
   priv->epavail[1] = EFM32_EP_AVAILABLE;
-
-  priv->epin[EP0].ep.priv  = priv;
-  priv->epout[EP0].ep.priv = priv;
 
   /* Initialize the endpoint lists */
 

--- a/arch/arm/src/stm32/stm32_otgfsdev.c
+++ b/arch/arm/src/stm32/stm32_otgfsdev.c
@@ -1571,8 +1571,8 @@ static inline void stm32_ep0out_receive(struct stm32_ep_s *privep,
 
   /* Sanity Checking */
 
-  DEBUGASSERT(privep && privep->ep.priv);
-  priv = (struct stm32_usbdev_s *)privep->ep.priv;
+  DEBUGASSERT(privep && privep->dev);
+  priv = (struct stm32_usbdev_s *)privep->dev;
 
   uinfo("EP0: bcnt=%d\n", bcnt);
   usbtrace(TRACE_READ(EP0), bcnt);
@@ -5233,9 +5233,6 @@ static void stm32_swinitialize(struct stm32_usbdev_s *priv)
 
   priv->epavail[0] = STM32_EP_AVAILABLE;
   priv->epavail[1] = STM32_EP_AVAILABLE;
-
-  priv->epin[EP0].ep.priv  = priv;
-  priv->epout[EP0].ep.priv = priv;
 
   /* Initialize the endpoint lists */
 

--- a/arch/arm/src/stm32/stm32_otghsdev.c
+++ b/arch/arm/src/stm32/stm32_otghsdev.c
@@ -1520,8 +1520,8 @@ static inline void stm32_ep0out_receive(struct stm32_ep_s *privep,
 
   /* Sanity Checking */
 
-  DEBUGASSERT(privep && privep->ep.priv);
-  priv = (struct stm32_usbdev_s *)privep->ep.priv;
+  DEBUGASSERT(privep && privep->dev);
+  priv = (struct stm32_usbdev_s *)privep->dev;
 
   uinfo("EP0: bcnt=%d\n", bcnt);
   usbtrace(TRACE_READ(EP0), bcnt);
@@ -5137,9 +5137,6 @@ static void stm32_swinitialize(struct stm32_usbdev_s *priv)
 
   priv->epavail[0] = STM32_EP_AVAILABLE;
   priv->epavail[1] = STM32_EP_AVAILABLE;
-
-  priv->epin[EP0].ep.priv  = priv;
-  priv->epout[EP0].ep.priv = priv;
 
   /* Initialize the endpoint lists */
 

--- a/arch/arm/src/stm32f7/stm32_otgdev.c
+++ b/arch/arm/src/stm32f7/stm32_otgdev.c
@@ -1628,8 +1628,8 @@ static inline void stm32_ep0out_receive(struct stm32_ep_s *privep,
 
   /* Sanity Checking */
 
-  DEBUGASSERT(privep && privep->ep.priv);
-  priv = (struct stm32_usbdev_s *)privep->ep.priv;
+  DEBUGASSERT(privep && privep->dev);
+  priv = (struct stm32_usbdev_s *)privep->dev;
 
   uinfo("EP0: bcnt=%d\n", bcnt);
   usbtrace(TRACE_READ(EP0), bcnt);
@@ -5249,9 +5249,6 @@ static void stm32_swinitialize(struct stm32_usbdev_s *priv)
 
   priv->epavail[0] = STM32_EP_AVAILABLE;
   priv->epavail[1] = STM32_EP_AVAILABLE;
-
-  priv->epin[EP0].ep.priv = priv;
-  priv->epout[EP0].ep.priv = priv;
 
   /* Initialize the endpoint lists */
 

--- a/arch/arm/src/stm32h7/stm32_otgdev.c
+++ b/arch/arm/src/stm32h7/stm32_otgdev.c
@@ -1582,8 +1582,8 @@ static inline void stm32_ep0out_receive(struct stm32_ep_s *privep,
 
   /* Sanity Checking */
 
-  DEBUGASSERT(privep && privep->ep.priv);
-  priv = (struct stm32_usbdev_s *)privep->ep.priv;
+  DEBUGASSERT(privep && privep->dev);
+  priv = (struct stm32_usbdev_s *)privep->dev;
 
   uinfo("EP0: bcnt=%d\n", bcnt);
   usbtrace(TRACE_READ(EP0), bcnt);
@@ -5162,9 +5162,6 @@ static void stm32_swinitialize(struct stm32_usbdev_s *priv)
 
   priv->epavail[0] = STM32_EP_AVAILABLE;
   priv->epavail[1] = STM32_EP_AVAILABLE;
-
-  priv->epin[EP0].ep.priv  = priv;
-  priv->epout[EP0].ep.priv = priv;
 
   /* Initialize the endpoint lists */
 

--- a/arch/arm/src/stm32l4/stm32l4_otgfsdev.c
+++ b/arch/arm/src/stm32l4/stm32l4_otgfsdev.c
@@ -1634,8 +1634,8 @@ static inline void stm32l4_ep0out_receive(struct stm32l4_ep_s *privep,
 
   /* Sanity Checking */
 
-  DEBUGASSERT(privep && privep->ep.priv);
-  priv = (struct stm32l4_usbdev_s *)privep->ep.priv;
+  DEBUGASSERT(privep && privep->dev);
+  priv = (struct stm32l4_usbdev_s *)privep->dev;
 
   uinfo("EP0: bcnt=%d\n", bcnt);
   usbtrace(TRACE_READ(EP0), bcnt);
@@ -5286,9 +5286,6 @@ static void stm32l4_swinitialize(struct stm32l4_usbdev_s *priv)
 
   priv->epavail[0] = STM32L4_EP_AVAILABLE;
   priv->epavail[1] = STM32L4_EP_AVAILABLE;
-
-  priv->epin[EP0].ep.priv  = priv;
-  priv->epout[EP0].ep.priv = priv;
 
   /* Initialize the IN endpoint list */
 


### PR DESCRIPTION
## Summary

- {stm32/stm32l4/stm32f7/stm32h7/efm32}/otgdev: remove invalid use of the priv field for EP
This field is for use in the class driver, not in the controller logic

## Impact
One of the problems I found when debugging USBDEV composite on the STM32 OTG.

## Testing
CI
