### PR TITLE
signal: remove unused SIGCONDTIMEDOUT

### DIFF
--- a/include/signal.h
+++ b/include/signal.h
@@ -295,14 +295,6 @@
 
 /* The following are non-standard signal definitions */
 
-#ifndef CONFIG_DISABLE_PTHREAD
-#  ifndef CONFIG_SIG_SIGCONDTIMEDOUT
-#    define SIGCONDTIMEDOUT 30  /* Used in the implementation of pthread_cond_timedwait */
-#  else
-#    define SIGCONDTIMEDOUT CONFIG_SIG_SIGCONDTIMEDOUT
-#  endif
-#endif
-
 /* SIGWORK is used to wake up various internal NuttX worker threads */
 
 #if defined(CONFIG_SCHED_WORKQUEUE) || defined(CONFIG_PAGING)

--- a/libs/libc/string/lib_strsignal.c
+++ b/libs/libc/string/lib_strsignal.c
@@ -160,11 +160,6 @@ FAR char *strsignal(int signum)
 
       /* Non-standard signals */
 
-#ifdef SIGCONDTIMEDOUT
-      case SIGCONDTIMEDOUT:
-        return (FAR char *)"SIGCONDTIMEDOUT";
-#endif
-
 #ifdef SIGWORK
       case SIGWORK:
         return (FAR char *)"SIGWORK";

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -1649,14 +1649,6 @@ config SIG_POLL
 
 comment "Non-standard Signal Numbers"
 
-config SIG_SIGCONDTIMEDOUT
-	int "SIGCONDTIMEDOUT"
-	default 30
-	depends on !DISABLE_PTHREAD
-	---help---
-		This non-standard signal number is used the implementation of
-		pthread_cond_timedwait(). Default 30.
-
 config SIG_SIGWORK
 	int "SIGWORK"
 	default 31

--- a/sched/pthread/pthread_condclockwait.c
+++ b/sched/pthread/pthread_condclockwait.c
@@ -141,8 +141,8 @@ int pthread_cond_clockwait(FAR pthread_cond_t *cond,
       ret        = pthread_mutex_give(mutex);
       if (ret == 0)
         {
-          status = nxsem_clockwait_uninterruptible(
-                   &cond->sem, clockid, abstime);
+          status = nxsem_clockwait_uninterruptible(&cond->sem,
+                                                   clockid, abstime);
           if (status < 0)
             {
               ret = -status;


### PR DESCRIPTION
## Summary
Remove unused `SIGCONDTIMEDOUT`

## Impact
None

## Testing
Pass CI