### PR TITLE
include/nuttx/usb/usbmsc.h: fix compiler error when USBMSC_COMPOSITE=y

### DIFF
--- a/include/nuttx/usb/usbmsc.h
+++ b/include/nuttx/usb/usbmsc.h
@@ -169,6 +169,7 @@ int usbmsc_exportluns(FAR void *handle);
  ****************************************************************************/
 
 #if defined(CONFIG_USBDEV_COMPOSITE) && defined(CONFIG_USBMSC_COMPOSITE)
+struct usbdev_devinfo_s;
 struct usbdevclass_driver_s;
 int usbmsc_classobject(FAR void *handle,
                        FAR struct usbdev_devinfo_s *devinfo,


### PR DESCRIPTION


## Summary
- include/nuttx/usb/usbmsc.h: fix compiler error when USBMSC_COMPOSITE=y
```
usbdev/usbmsc.c:1758:5: error: conflicting types for 'usbmsc_classobject'; have 'int(void *, struct usbdev_devinfo_s *, struct usbdevclass_driver_s **)'
 1758 | int usbmsc_classobject(FAR void *handle,
      |     ^~~~~~~~~~~~~~~~~~
In file included from /home/raiden00/git/RTOS/nuttx/nuttx/include/nuttx/usb/usbdev.h:36,
                 from usbdev/usbmsc.c:68:
/home/raiden00/git/RTOS/nuttx/nuttx/include/nuttx/usb/usbmsc.h:173:5: note: previous declaration of 'usbmsc_classobject' with type 'int(void *, struct usbdev_devinfo_s *, struct usbdevclass_driver_s **)'
  173 | int usbmsc_classobject(FAR void *handle,
```
## Impact

## Testing
ci
