### PR TITLE
usbmsc: do not sent deferred response if USBMSC_COMPOSITE=y

### DIFF
--- a/drivers/usbdev/usbmsc.c
+++ b/drivers/usbdev/usbmsc.c
@@ -1219,6 +1219,7 @@ void usbmsc_rdcomplete(FAR struct usbdev_ep_s *ep,
 
 void usbmsc_deferredresponse(FAR struct usbmsc_dev_s *priv, bool failed)
 {
+#ifndef CONFIG_USBMSC_COMPOSITE
   FAR struct usbdev_s *dev;
   FAR struct usbdev_req_s *ctrlreq;
   int ret;
@@ -1260,6 +1261,7 @@ void usbmsc_deferredresponse(FAR struct usbmsc_dev_s *priv, bool failed)
       usbtrace(TRACE_CLSERROR(USBMSC_TRACEERR_DEFERREDRESPSTALLED), 0);
       EP_STALL(dev->ep0);
     }
+#endif
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
- usbmsc: do not send deferred response if we are part of the composite device
EP0 is owned by the composite class so it shouldn't be directly accessed by usbmsc

## Impact
rndis + usbmsc works on stm32 otg. Host was unable to register the composite device due to multiple USB_REQ_SETCONFIGURATION responses.

## Testing
spresense and stm32 otg with usbmsc composite enabled
