### PR TITLE
{stm32f7,stm32h7}/otg: fix compilation for USBDEV when USB_DEBUG=y

### DIFF
--- a/arch/arm/src/stm32f7/Make.defs
+++ b/arch/arm/src/stm32f7/Make.defs
@@ -107,13 +107,12 @@ endif
 
 ifeq ($(CONFIG_USBHOST),y)
 CHIP_CSRCS += stm32_otghost.c
-endif
-
 ifeq ($(CONFIG_USBHOST_TRACE),y)
 CHIP_CSRCS += stm32_usbhost.c
 else
 ifeq ($(CONFIG_DEBUG_USB),y)
 CHIP_CSRCS += stm32_usbhost.c
+endif
 endif
 endif
 

--- a/arch/arm/src/stm32h7/Make.defs
+++ b/arch/arm/src/stm32h7/Make.defs
@@ -128,13 +128,12 @@ endif
 
 ifeq ($(CONFIG_USBHOST),y)
 CHIP_CSRCS += stm32_otghost.c
-endif
-
 ifeq ($(CONFIG_USBHOST_TRACE),y)
 CHIP_CSRCS += stm32_usbhost.c
 else
 ifeq ($(CONFIG_DEBUG_USB),y)
 CHIP_CSRCS += stm32_usbhost.c
+endif
 endif
 endif
 


### PR DESCRIPTION
## Summary

- {stm32f7,stm32h7}/otg: fix compilation for USBDEV when USB_DEBUG=y

## Impact

## Testing
ci
