### PR TITLE
fs/fs_initialize.c:Sync fs in system restart callback

### DIFF
--- a/fs/fs_initialize.c
+++ b/fs/fs_initialize.c
@@ -40,7 +40,11 @@
 static int sync_reboot_handler(FAR struct notifier_block *nb,
                                unsigned long action, FAR void *data)
 {
-  sync();
+  if (action == SYS_DOWN || action == SYS_RESTART)
+    {
+      sync();
+    }
+
   return 0;
 }
 

--- a/fs/fs_initialize.c
+++ b/fs/fs_initialize.c
@@ -23,10 +23,39 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/reboot_notifier.h>
 
 #include "rpmsgfs/rpmsgfs.h"
 #include "inode/inode.h"
 #include "aio/aio.h"
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: sync_reboot_handler
+ ****************************************************************************/
+
+static int sync_reboot_handler(FAR struct notifier_block *nb,
+                               unsigned long action, FAR void *data)
+{
+  sync();
+  return 0;
+}
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: fs_sync_reboot_nb
+ ****************************************************************************/
+
+static struct notifier_block g_sync_nb =
+{
+  sync_reboot_handler
+};
 
 /****************************************************************************
  * Public Functions
@@ -57,4 +86,6 @@ void fs_initialize(void)
 #ifdef CONFIG_FS_RPMSGFS_SERVER
   rpmsgfs_server_init();
 #endif
+
+  register_reboot_notifier(&g_sync_nb);
 }


### PR DESCRIPTION
## Summary

sync will be performed only when SYS_RESTART/SYS_DOWN situation occurs, avoiding unpredictable results caused by handling locks or semaphores in interrupts.

## Impact

## Testing

