### PR TITLE
drivers/lcd/st7789: Support mirror X/Y

### DIFF
--- a/drivers/lcd/Kconfig
+++ b/drivers/lcd/Kconfig
@@ -729,6 +729,14 @@ if LCD_ST7789
 		---help---
 			Specifies the Y offset of the LCD.
 
+	config LCD_ST7789_MIRRORX
+		bool "ST7789 Mirror X"
+		default n
+
+	config LCD_ST7789_MIRRORY
+		bool "ST7789 Mirror Y"
+		default n
+
 	config LCD_ST7789_BPP
 		int "Bit Per Pixel (12 or 16)"
 		default 16

--- a/drivers/lcd/st7789.c
+++ b/drivers/lcd/st7789.c
@@ -355,30 +355,46 @@ static void st7789_display(FAR struct st7789_dev_s *dev, bool on)
 
 static void st7789_setorientation(FAR struct st7789_dev_s *dev)
 {
-  /* No need to change the orientation in PORTRAIT mode */
+  /* Default value on reset */
 
-#if !defined(CONFIG_LCD_PORTRAIT)
+  uint8_t madctl = 0x00;
+
   st7789_sendcmd(dev, ST7789_MADCTL);
   st7789_select(dev->spi, 8);
+
+#if !defined(CONFIG_LCD_PORTRAIT)
 
 #  if defined(CONFIG_LCD_RLANDSCAPE)
   /* RLANDSCAPE : MY=1 MV=1 */
 
-  SPI_SEND(dev->spi, 0xa0);
+  madctl = 0xa0;
 
 #  elif defined(CONFIG_LCD_LANDSCAPE)
   /* LANDSCAPE : MX=1 MV=1 */
 
-  SPI_SEND(dev->spi, 0x70);
+  madctl = 0x70;
 
 #  elif defined(CONFIG_LCD_RPORTRAIT)
   /* RPORTRAIT : MX=1 MY=1 */
 
-  SPI_SEND(dev->spi, 0xc0);
+  madctl = 0xc0;
 #  endif
 
-  st7789_deselect(dev->spi);
 #endif
+
+  /* Mirror X/Y for current setting */
+
+#ifdef CONFIG_LCD_ST7789_MIRRORX
+  madctl ^= 0x40;
+#endif
+
+#ifdef CONFIG_LCD_ST7789_MIRRORY
+  madctl ^= 0x80;
+#endif
+
+  SPI_SEND(dev->spi, madctl);
+
+  st7789_deselect(dev->spi);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
Support mirror display by X/Y axis, it's useful for single portrait/landscape but need to mirror specific direction.
## Impact
New feature, st7789 only
## Testing
custom boards
