### PR TITLE
Fix LTO warnings with GCC 12

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -2103,6 +2103,44 @@ config DEBUG_OPTLEVEL
 		This string represents the custom optimization level that will be
 		used if DEBUG_CUSTOMOPT.
 
+choice
+	prompt "Link Time Optimization (LTO)"
+	default LTO_NONE
+	---help---
+		This option enables Link Time Optimization (LTO), which allows the
+		compiler to optimize binaries globally.
+
+		If unsure, select LTO_NONE. Note that LTO is very resource-intensive
+		so it's disabled by default.
+
+config LTO_NONE
+	bool "None"
+	---help---
+		Build the kernel normally, without Link Time Optimization (LTO).
+
+config LTO_FULL
+	bool "GNU Full LTO (EXPERIMENTAL)"
+	depends on ARCH_TOOLCHAIN_GNU
+	---help---
+		Link time optimization is implemented as a GCC front end for a bytecode
+		bytecode representation of GIMPLE that is emitted in special sections
+		of .o files. Currently, LTO support is enabled in most ELF-based systems,
+		as well as darwin, cygwin and mingw systems.
+
+config LTO_THIN
+	bool "Clang ThinLTO (EXPERIMENTAL)"
+	depends on ARCH_TOOLCHAIN_CLANG
+	---help---
+		This option enables Clang's ThinLTO, which allows for parallel
+		optimization and faster incremental compiles compared to the
+		CONFIG_LTO_FULL option. More information can be found
+		from Clang's documentation:
+
+		https://clang.llvm.org/docs/ThinLTO.html
+
+		If unsure, say Y.
+endchoice
+
 config DEBUG_OPT_UNUSED_SECTIONS
 	bool "Optimization to eliminate the unused input sections"
 	default y

--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -246,44 +246,6 @@ config ARCH_TOOLCHAIN_CLANG
 	select ARCH_TOOLCHAIN_GNU
 	default n
 
-choice
-	prompt "Link Time Optimization (LTO)"
-	default LTO_NONE
-	---help---
-		This option enables Link Time Optimization (LTO), which allows the
-		compiler to optimize binaries globally.
-
-		If unsure, select LTO_NONE. Note that LTO is very resource-intensive
-		so it's disabled by default.
-
-config LTO_NONE
-	bool "None"
-	---help---
-		Build the kernel normally, without Link Time Optimization (LTO).
-
-config LTO_FULL
-	bool "GNU Full LTO (EXPERIMENTAL)"
-	depends on ARCH_TOOLCHAIN_GNU
-	---help---
-		Link time optimization is implemented as a GCC front end for a bytecode
-		bytecode representation of GIMPLE that is emitted in special sections
-		of .o files. Currently, LTO support is enabled in most ELF-based systems,
-		as well as darwin, cygwin and mingw systems.
-
-config LTO_THIN
-	bool "Clang ThinLTO (EXPERIMENTAL)"
-	depends on ARCH_TOOLCHAIN_CLANG
-	---help---
-		This option enables Clang's ThinLTO, which allows for parallel
-		optimization and faster incremental compiles compared to the
-		CONFIG_LTO_FULL option. More information can be found
-		from Clang's documentation:
-
-		https://clang.llvm.org/docs/ThinLTO.html
-
-		If unsure, say Y.
-endchoice
-
 config ARCH_GNU_NO_WEAKFUNCTIONS
 	bool
 	depends on ARCH_TOOLCHAIN_GNU

--- a/arch/arm/src/common/Toolchain.defs
+++ b/arch/arm/src/common/Toolchain.defs
@@ -74,42 +74,8 @@ ifeq ($(CONFIG_MM_KASAN_ALL),y)
   ARCHOPTIMIZATION += -fsanitize=kernel-address
 endif
 
-ifeq ($(CONFIG_ARM_THUMB),y)
-  ARCHOPTIMIZATION += -mthumb
-
-  # GCC Manual:
-  # -mthumb
-  # ... If you want to force assembler files to be interpreted as Thumb
-  # code, either add a `.thumb' directive to the source or pass the
-  # -mthumb option directly to the assembler by prefixing it with -Wa.
-
-  ARCHOPTIMIZATION += -Wa,-mthumb
-
-  # Outputs an implicit IT block when there is a conditional instruction
-  # without an enclosing IT block.
-
-  ARCHOPTIMIZATION += -Wa,-mimplicit-it=always
-endif
-
 ifeq ($(CONFIG_UNWINDER_ARM),y)
   ARCHOPTIMIZATION += -funwind-tables -fasynchronous-unwind-tables
-endif
-
-# Link Time Optimization
-
-ifeq ($(CONFIG_LTO_THIN),y)
-  ARCHOPTIMIZATION += -flto=thin
-  ifeq ($(CONFIG_ARM_TOOLCHAIN_ARMCLANG),y)
-    LDFLAGS += --lto
-  endif
-else ifeq ($(CONFIG_LTO_FULL),y)
-  ARCHOPTIMIZATION += -flto
-  ifeq ($(CONFIG_ARM_TOOLCHAIN_GNU_EABI),y)
-    ARCHOPTIMIZATION += -fuse-linker-plugin
-  endif
-  ifeq ($(CONFIG_ARM_TOOLCHAIN_ARMCLANG),y)
-    LDFLAGS += --lto
-  endif
 endif
 
 # NuttX buildroot under Linux or Cygwin
@@ -232,9 +198,9 @@ else
   # Wrong warning array subscript [0] is outside array bounds:
   # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523
 
-  GCCVER = $(shell $(CC) --version | grep gcc | sed -r 's/.* ([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+  GCCVER = $(shell $(CC) --version | grep gcc | sed -r 's/.* ([0-9]+\.[0-9]+).*/\1/')
 
-  ifeq ($(GCCVER),12.2.1)
+  ifeq ($(GCCVER),12.2)
     ARCHOPTIMIZATION += --param=min-pagesize=0
   endif
 
@@ -246,6 +212,27 @@ ZIG := zig
 
 ifeq ($(CONFIG_ARCH_TOOLCHAIN_CLANG),y)
   ARCHOPTIMIZATION += -fshort-enums
+endif
+
+# Link Time Optimization
+
+ifeq ($(CONFIG_LTO_THIN),y)
+  ARCHOPTIMIZATION += -flto=thin
+  ifeq ($(CONFIG_ARM_TOOLCHAIN_ARMCLANG),y)
+    LDFLAGS += --lto
+  endif
+else ifeq ($(CONFIG_LTO_FULL),y)
+  ifeq ($(GCCVER),12.2)
+    ARCHOPTIMIZATION += -flto=auto
+  else
+    ARCHOPTIMIZATION += -flto
+  endif
+  ifeq ($(CONFIG_ARM_TOOLCHAIN_GNU_EABI),y)
+    ARCHOPTIMIZATION += -fuse-linker-plugin
+  endif
+  ifeq ($(CONFIG_ARM_TOOLCHAIN_ARMCLANG),y)
+    LDFLAGS += --lto
+  endif
 endif
 
 # Architecture flags
@@ -266,6 +253,29 @@ ifneq ($(CONFIG_CXX_RTTI),y)
 endif
 
 ARCHOPTIMIZATION += -fno-common -Wall -Wshadow -Wundef
+
+ifeq ($(CONFIG_ARM_THUMB),y)
+  ARCHOPTIMIZATION += -mthumb
+
+  # Add assembler options only if GCC LTO is not enabled. Otherwise we get
+  # lto-wrapper: warning: Extra option to '-Xassembler': -mthumb, dropping
+  # all '-Xassembler' and '-Wa' options.
+
+  ifneq ($(LD),$(CC))
+    # GCC Manual:
+    # -mthumb
+    # ... If you want to force assembler files to be interpreted as Thumb
+    # code, either add a `.thumb' directive to the source or pass the
+    # -mthumb option directly to the assembler by prefixing it with -Wa.
+
+    ARCHOPTIMIZATION += -Wa,-mthumb
+
+    # Outputs an implicit IT block when there is a conditional instruction
+    # without an enclosing IT block.
+
+    ARCHOPTIMIZATION += -Wa,-mimplicit-it=always
+  endif
+endif
 
 ifeq ($(CONFIG_ARM_TOOLCHAIN_ARMCLANG),y)
   ARCHOPTIMIZATION += -nostdlib


### PR DESCRIPTION
## Summary
Fix LTO warnings with GCC 12

## Impact
No warnings with GCC 12

## Testing
Build code locally