### PR TITLE
ld: fix warning reported by GCC 12 linker

### DIFF
--- a/arch/arm/src/common/Toolchain.defs
+++ b/arch/arm/src/common/Toolchain.defs
@@ -236,6 +236,9 @@ else
 
   ifeq ($(GCCVER),12.2.1)
     ARCHOPTIMIZATION += --param=min-pagesize=0
+    ifeq ($(CONFIG_ARCH_RAMFUNCS),y)
+      LDFLAGS += --no-warn-rwx-segments
+    endif
   endif
 
 endif


### PR DESCRIPTION
## Summary
Fix `warning: nuttx has a LOAD segment with RWX permissions`

## Impact
None

## Testing
Local build