### PR TITLE
video/fb: add vsync offset support

### DIFF
--- a/Documentation/components/drivers/special/framebuffer.rst
+++ b/Documentation/components/drivers/special/framebuffer.rst
@@ -48,6 +48,20 @@ This example will walk through the path from userspace to hardware-specific deta
 
     #. ``include/nuttx/lcd/lcd.h`` provides structures and APIs needed to work with LCD screens, whereas using the framebuffer adapter or the :doc:`lcd`;
 
+VSYNC
+======
+
+Vertical synchronization (VSync) synchronizes the frame rate of an application's graphics with the refresh rate of the display, helping to establish stability.
+If not synchronized, it may cause screen tearing, which is the effect of the image appearing to have horizontal jagged edges or ghosting across the entire screen.
+
+VSYNC Offset
+------------
+
+During the VSYNC event, the screen starts displaying frame N while the renderer begins compositing window for frame N+1.
+The application processes waiting input and generates frame N+2.
+When the renderer has a short rendering time, it can cause a delay of almost two frames from the end of rendering to the completion of screen display.
+To solve this problem, ``FBIOSET_VSYNCOFFSET`` can be used to set the VSYNC offset time (in microseconds) and reduce the delay from input device to screen using the VSYNC offset.
+
 
 Examples
 ========

--- a/include/nuttx/video/fb.h
+++ b/include/nuttx/video/fb.h
@@ -288,12 +288,15 @@
 
 #define FBIO_CLEARNOTIFY      _FBIOC(0x0017)  /* Clear notify signal */
 
+#define FBIOSET_VSYNCOFFSET   _FBIOC(0x0018)  /* Set VSync offset in usec
+                                               * Argument:             int */
+
 /* Linux Support ************************************************************/
 
-#define FBIOGET_VSCREENINFO   _FBIOC(0x0018)  /* Get video variable info */
+#define FBIOGET_VSCREENINFO   _FBIOC(0x0019)  /* Get video variable info */
                                               /* Argument: writable struct
                                                *           fb_var_screeninfo */
-#define FBIOGET_FSCREENINFO   _FBIOC(0x0019)  /* Get video fix info */
+#define FBIOGET_FSCREENINFO   _FBIOC(0x001a)  /* Get video fix info */
                                               /* Argument: writable struct
                                                *           fb_fix_screeninfo */
 


### PR DESCRIPTION
## Summary

Add vsync offest to reduce latency.
Android Documentation: https://source.android.com/docs/core/graphics/implement-vsync#vsync_offset

## Impact
Application using poll as fb vsync.

## Testing
None.
