### PR TITLE
usrsock_server: Do not poll SOCK_CTRL

### DIFF
--- a/drivers/usrsock/usrsock_rpmsg_server.c
+++ b/drivers/usrsock/usrsock_rpmsg_server.c
@@ -24,7 +24,9 @@
 
 #include <nuttx/config.h>
 
+#include <debug.h>
 #include <errno.h>
+#include <inttypes.h>
 #include <poll.h>
 #include <string.h>
 
@@ -1048,9 +1050,15 @@ static void usrsock_rpmsg_poll_setup(FAR struct pollfd *pfds,
       ret = psock_poll(&priv->socks[pfds->fd], pfds, false);
     }
 
-  net_unlock();
+  if (ret < 0)
+    {
+      nerr("psock_poll failed. ret %d domain %u type %u pfds->fd %d"
+           ", pfds->events %08" PRIx32 ", pfds->revents %08" PRIx32,
+           ret, priv->socks[pfds->fd].s_domain, priv->socks[pfds->fd].s_type,
+           pfds->fd, pfds->events, pfds->revents);
+    }
 
-  DEBUGASSERT(ret >= 0);
+  net_unlock();
 }
 
 static void usrsock_rpmsg_poll_cb(FAR struct pollfd *pfds)

--- a/net/inet/inet_sockif.c
+++ b/net/inet/inet_sockif.c
@@ -1503,7 +1503,7 @@ static inline int inet_pollsetup(FAR struct socket *psock,
   else
 #endif /* NET_TCP_HAVE_STACK */
 #ifdef NET_UDP_HAVE_STACK
-  if (psock->s_type != SOCK_STREAM)
+  if (psock->s_type == SOCK_DGRAM)
     {
       return udp_pollsetup(psock, fds);
     }


### PR DESCRIPTION
## Summary
After https://github.com/apache/nuttx/pull/8609/commits/7fd95ccbacd68f82f3d4c8a1695b89364d662d5a, we found a case that may cause usrsock poll fail - the `SOCK_CTRL`

It seems that we don't need to poll the `SOCK_CTRL` sockets, so skip them in usrsock server. We also found a problem that the `SOCK_CTRL` will be setup as udp poll in `inet_pollsetup`, but not do so in teardown, also fix that.

Patches included:
- usrsock_server: add debug info for poll_setup
- net/inet: Only setup poll for UDP when s_type == SOCK_DGRAM
- usrsock_server: Do not poll SOCK_CTRL

## Impact
Do not poll `SOCK_CTRL` in usrsock server.

## Testing
Manually, CI
