### PR TITLE
asprintf: Fixed possible memory leak if print fails.

### DIFF
--- a/libs/libc/stdio/lib_vasprintf.c
+++ b/libs/libc/stdio/lib_vasprintf.c
@@ -121,12 +121,16 @@ int vasprintf(FAR char **ptr, FAR const IPTR char *fmt, va_list ap)
   /* Return a pointer to the string to the caller.  NOTE: the memstream put()
    * method has already added the NUL terminator to the end of the string
    * (not included in the nput count).
-   *
-   * Hmmm.. looks like the memory would be stranded if lib_vsprintf()
-   * returned an error.  Does that ever happen?
    */
 
   DEBUGASSERT(nbytes < 0 || nbytes == nulloutstream.nput);
+
+  if (nbytes < 0)
+    {
+      lib_free(buf);
+      return ERROR;
+    }
+
   *ptr = buf;
   return nbytes;
 }


### PR DESCRIPTION
## Summary

In `apsrintf`, when the memory allocation was successful, but the print to the buffer failed, the memory buffer will remain dangling.

This PR will handle this error case, free'ing the memory in case of such an issue, and eliminating the possible memory leak.

## Impact

Fixed possible memory leak.

## Testing

Build test.

