### PR TITLE
net/tcp: Reply RST when we cannot receive data

### DIFF
--- a/net/tcp/tcp_input.c
+++ b/net/tcp/tcp_input.c
@@ -1545,7 +1545,15 @@ found:
 
         if (dev->d_len > 0)
           {
-            tcp_send(dev, conn, TCP_ACK, tcpiplen);
+            /* Due to RFC 2525, Section 2.17, we SHOULD send RST if we can no
+             * longer read any received data. Also set state into TCP_CLOSED
+             * because the peer will not send FIN after RST received.
+             *
+             * TODO: Modify shutdown behavior to allow read in FIN_WAIT.
+             */
+
+            conn->tcpstateflags = TCP_CLOSED;
+            tcp_reset(dev, conn);
             return;
           }
 
@@ -1572,7 +1580,13 @@ found:
 
         if (dev->d_len > 0)
           {
-            tcp_send(dev, conn, TCP_ACK, tcpiplen);
+            /* Due to RFC 2525, Section 2.17, we SHOULD send RST if we can no
+             * longer read any received data. Also set state into TCP_CLOSED
+             * because the peer will not send FIN after RST received.
+             */
+
+            conn->tcpstateflags = TCP_CLOSED;
+            tcp_reset(dev, conn);
             return;
           }
 


### PR DESCRIPTION
## Summary
According to RFC 2525, Section 2.17:
"When an application closes a connection in such a way that it can no longer read any received data, the TCP SHOULD, per section 4.2.2.13 of RFC 1122, send a RST if there is any unread received data, or if any new data is received. "

When our TCP socket is closed (even when the thread has exited), the peer can keep sending data and NuttX keeps replying ACK (we've tried for ~12h). This is not a good behavior (also different from Linux), so send RST instead of ACK for data receiving in FIN_WAIT.

## Impact
TCP, sending RST instead of ACK for data receiving in FIN_WAIT.

## Testing
iperf2, CI
