### PR TITLE
sched: fix compile error when SCHED_CRITMONITOR is enabled

### DIFF
--- a/sched/sched/sched_critmonitor.c
+++ b/sched/sched/sched_critmonitor.c
@@ -27,6 +27,7 @@
 #include <sys/types.h>
 #include <sched.h>
 #include <assert.h>
+#include <debug.h>
 
 #include "sched/sched.h"
 

--- a/sched/wdog/wd_start.c
+++ b/sched/wdog/wd_start.c
@@ -30,6 +30,7 @@
 #include <unistd.h>
 #include <sched.h>
 #include <assert.h>
+#include <debug.h>
 #include <errno.h>
 
 #include <nuttx/irq.h>


### PR DESCRIPTION
## Summary
Compilation error occurs after SCHED_CRITMONITOR is enabled

sched/sched_critmonitor.c:315: undefined reference to `serr'

## Impact

## Testing

