### PR TITLE
risc-v/espressif: Fix NULL-dereferencing in WDT interrupt handling

### DIFF
--- a/arch/risc-v/src/espressif/esp_wdt.c
+++ b/arch/risc-v/src/espressif/esp_wdt.c
@@ -74,7 +74,7 @@ struct esp_wdt_lowerhalf_s
   uint32_t                     lastreset; /* The last reset time */
   bool                         started;   /* True: Timer has been started */
   xcpt_t                       handler;   /* User Handler */
-  void *                       upper;     /* Pointer to watchdog_upperhalf_s */
+  void                        *upper;     /* Pointer to watchdog_upperhalf_s */
 };
 
 /****************************************************************************
@@ -577,7 +577,7 @@ int esp_wdt_initialize(void)
 
   /* Attach the handler for the timer IRQ */
 
-  irq_attach(ESP_IRQ_TG0_WDT_LEVEL, (xcpt_t)wdt_handler, NULL);
+  irq_attach(ESP_IRQ_TG0_WDT_LEVEL, (xcpt_t)wdt_handler, lower);
 
   /* Enable the allocated CPU interrupt */
 


### PR DESCRIPTION
## Summary

This PR intends to provide a fix for the WDT interrupt handling when using the `WDIOC_CAPTURE` feature.

## Impact

Bugfix, now the `WDIOC_CAPTURE` ioctl is properly handled.

## Testing

`esp32c3-generic:watchdog` with `EXAMPLES_WATCHER` enabled.

The `watcher` application can now properly capture the WDT expiration and notify it.
