### PR TITLE
usbhost_hidkbd: Add the option to use interrupt transfers.

### DIFF
--- a/drivers/usbhost/Kconfig
+++ b/drivers/usbhost/Kconfig
@@ -361,6 +361,12 @@ config HIDKBD_NODEBOUNCE
 		If set to y normal debouncing is disabled.  Default:
 		Debounce enabled (No repeat keys).
 
+config HIDKBD_NOGETREPORT
+	bool "Use Interrupt pipe to get keys"
+	default n
+	---help---
+		Use the INTERRUPT IN pipe to get keyboard input reports.
+
 endif
 
 config USBHOST_HIDMOUSE


### PR DESCRIPTION
## Summary
Using the interrupt pipe is recommended in the Get_Report request section of the HID standard. This option has been added to support some keyboards that refuse to return valid keys when polled using the Get_Report request. Support for the Caps Lock key, including the LED, has also been added.

The interrupt transfers are not enabled by default. This will enable the feature:
CONFIG_HIDKBD_NOGETREPORT=y

## Impact
Affects the HID keyboard driver only.

## Testing
Used the hidkbd application.
Also used "cat /dev/kbda &"  and  "cat /dev/kbdb &"  to test two keyboards at the same time. Pressing caps lock changes the light on both keyboards.

