### PR TITLE
tools/riscv: Map extensions to certain cpu model for LLVM based toolc…

### DIFF
--- a/arch/risc-v/src/common/Toolchain.defs
+++ b/arch/risc-v/src/common/Toolchain.defs
@@ -132,27 +132,22 @@ ifeq ($(CONFIG_RISCV_TOOLCHAIN),GNU_RVG)
 
   ifeq ($(CONFIG_ARCH_RV_ISA_M),y)
     ARCHRVISAM = m
-    ZARCHRVISAM := +m
   endif
 
   ifeq ($(CONFIG_ARCH_RV_ISA_A),y)
     ARCHRVISAA = a
-    ZARCHRVISAA := +a
   endif
 
   ifeq ($(CONFIG_ARCH_RV_ISA_C),y)
     ARCHRVISAC = c
-    ZARCHRVISAC := +c
   endif
 
   ifeq ($(CONFIG_ARCH_FPU),y)
     ARCHRVISAF = f
-    ZARCHRVISAF := +f
   endif
 
   ifeq ($(CONFIG_ARCH_DPFPU),y)
     ARCHRVISAD = d
-    ZARCHRVISAD := +d
   endif
 
   # Detect abi type
@@ -169,7 +164,8 @@ ifeq ($(CONFIG_RISCV_TOOLCHAIN),GNU_RVG)
 
   # Construct arch flags
 
-  ARCHCPUFLAGS = -march=$(ARCHTYPE)i$(ARCHRVISAM)$(ARCHRVISAA)$(ARCHRVISAF)$(ARCHRVISAD)$(ARCHRVISAC)
+  ARCHCPUEXTFLAGS = i$(ARCHRVISAM)$(ARCHRVISAA)$(ARCHRVISAF)$(ARCHRVISAD)$(ARCHRVISAC)
+  ARCHCPUFLAGS = -march=$(ARCHTYPE)$(ARCHCPUEXTFLAGS)
 
   # Construct arch abi flags
 
@@ -184,6 +180,30 @@ ifeq ($(CONFIG_RISCV_TOOLCHAIN),GNU_RVG)
     LLVM_ABITYPE := $(ARCHABITYPE)
   endif
 
+endif
+
+# RISCV has a modular instruction set. It's hard to define cpu-model to support all toolchain.
+# For Zig, cpu model is this formal: generic_rv[32|64][i][m][a][f][d][c]
+# For Rust, cpu model is this formal: riscv[32|64][i][m][a][f][d][c]
+# So, it's better to map the NuttX config to LLVM builtin cpu model, these models supported by
+# all LLVM based toolchain.
+# Refer to : https://github.com/llvm/llvm-project/blob/release/15.x/llvm/lib/Target/RISCV/RISCV.td
+# These models can't cover all implementation of RISCV, but it's enough for most cases.
+
+ifeq ($(CONFIG_ARCH_RV32),y)
+  ifeq ($(ARCHCPUEXTFLAGS), imc)
+    LLVM_CPUTYPE := sifive-e20
+  else ifeq ($(ARCHCPUEXTFLAGS), imac)
+    LLVM_CPUTYPE := sifive-e31
+  else ifeq ($(ARCHCPUEXTFLAGS), imafc)
+    LLVM_CPUTYPE := sifive-e76
+  endif
+else
+  ifeq ($(ARCHCPUEXTFLAGS), imac)
+    LLVM_CPUTYPE := sifive-s51
+  else ifeq ($(ARCHCPUEXTFLAGS), imafdc)
+    LLVM_CPUTYPE := sifive-u54
+  endif
 endif
 
 ifeq ($(CONFIG_MM_KASAN_ALL),y)

--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -20,7 +20,6 @@
 
 include $(TOPDIR)/.config
 include $(TOPDIR)/tools/Config.mk
-include $(TOPDIR)/tools/Zig.defs
 
 # NuttX is sometimes built as a native target.
 # In that case, the __NuttX__ macro is predefined by the compiler.
@@ -125,7 +124,14 @@ endif
 ifeq ($(CONFIG_SIM_M32),y)
   ARCHCFLAGS += -m32
   ARCHCXXFLAGS += -m32
+  LLVM_ARCHTYPE := x86
+  LLVM_CPUTYPE := i686
+else
+  LLVM_ARCHTYPE := x86_64
+  LLVM_CPUTYPE  := native
 endif
+
+LLVM_ABITYPE := gnu
 
 ARCHPICFLAGS = -fpic
 
@@ -144,7 +150,10 @@ NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy
 OBJDUMP = $(CROSSDEV)objdump
 RUSTC = rustc --edition 2021
-ZIG = zig
+
+# Zig toolchain
+
+include $(TOPDIR)/tools/Zig.defs
 
 CFLAGS := $(ARCHOPTIMIZATION) $(ARCHCFLAGS) $(ARCHINCLUDES) $(ARCHDEFINES) $(EXTRAFLAGS) -pipe
 CXXFLAGS := $(ARCHOPTIMIZATION) $(ARCHCXXFLAGS) $(ARCHXXINCLUDES) $(ARCHDEFINES) $(EXTRAFLAGS) -pipe

--- a/tools/Zig.defs
+++ b/tools/Zig.defs
@@ -20,36 +20,7 @@
 
 ZIG := zig
 
-ifeq ($(CONFIG_ARCH_RISCV),y)
-
-  ZIGFLAGS := -target $(LLVM_ARCHTYPE)-freestanding-none
-
-  # Detect cpu ISA support flags for risc-v
-
-  ifeq ($(CONFIG_ARCH_RV_ISA_M),y)
-    ZARCHRVISAM := +m
-  endif
-
-  ifeq ($(CONFIG_ARCH_RV_ISA_A),y)
-    ZARCHRVISAA := +a
-  endif
-
-  ifeq ($(CONFIG_ARCH_RV_ISA_C),y)
-    ZARCHRVISAC := +c
-  endif
-
-  ifeq ($(CONFIG_ARCH_FPU),y)
-    ZARCHRVISAF := +f
-  endif
-
-  ifeq ($(CONFIG_ARCH_DPFPU),y)
-    ZARCHRVISAD := +d
-  endif
-
-  ZIGFLAGS += -mcpu generic$(ZARCHRVISAM)$(ZARCHRVISAA)$(ZARCHRVISAF)$(ZARCHRVISAD)$(ZARCHRVISAC)
-  ZIGFLAGS += -mcmodel=medium
-
-else ifeq ($(CONFIG_ARCH_ARM),y)
+ifeq ($(CONFIG_ARCH_ARM),y)
 
   ifeq ($(CONFIG_ARM_THUMB),y)
     ZIGFLAGS := -target thumb-freestanding-$(LLVM_ABITYPE)
@@ -57,13 +28,15 @@ else ifeq ($(CONFIG_ARCH_ARM),y)
     ZIGFLAGS := -target arm-freestanding-$(LLVM_ABITYPE)
   endif
 
-  # Convert cortex-xxx to cortex_xxx for zig
-  ZIGFLAGS += -mcpu $(subst -,_,$(LLVM_CPUTYPE))
+else ifeq ($(CONFIG_ARCH_RISCV),y)
 
-else ifeq ($(CONFIG_ARCH_SIM),y)
-  ifeq ($(CONFIG_SIM_M32),y)
-    ZIGFLAGS := -target x86-freestanding-gnu
-  else
-    ZIGFLAGS := -target x86_64-freestanding-gnu
-  endif
+  ZIGFLAGS := -target $(LLVM_ARCHTYPE)-freestanding-none
+  ZIGFLAGS += -mcmodel=medium
+
+else 
+  ZIGFLAGS := -target $(LLVM_ARCHTYPE)-freestanding-$(LLVM_ABITYPE)
 endif
+
+# Convert cortex-xxx/sifive-exx to cortex_xxx/sifive_exx
+
+ZIGFLAGS += -mcpu $(subst -,_,$(LLVM_CPUTYPE))


### PR DESCRIPTION


## Summary

RISCV has a modular instruction set. It's hard to define cpu-model to support all toolchain.

For Zig, cpu model is this formal: generic_rv[32|64][i][m][a][f][d][c]

For Rust, cpu model is this formal: riscv[32|64][i][m][a][f][d][c]


So, it's better to map the NuttX config to LLVM builtin cpu model, these models supported by all LLVM based toolchain.

Refer to : https://github.com/llvm/llvm-project/blob/release/15.x/llvm/lib/Target/RISCV/RISCV.td

These models can't cover all implementation of RISCV, but it's enough for most cases (All NuttX supported chips).

## Impact
non-c compiler only
## Testing
CI and local machine
