### PR TITLE
tools: Move Rust relative settings to Rust.defs

### DIFF
--- a/arch/arm/src/common/Toolchain.defs
+++ b/arch/arm/src/common/Toolchain.defs
@@ -341,3 +341,7 @@ endif
 # Zig toolchain
 
 include $(TOPDIR)/tools/Zig.defs
+
+# Rust toolchain
+
+include $(TOPDIR)/tools/Rust.defs

--- a/arch/risc-v/src/common/Toolchain.defs
+++ b/arch/risc-v/src/common/Toolchain.defs
@@ -262,3 +262,7 @@ endif
 # Zig toolchain
 
 include $(TOPDIR)/tools/Zig.defs
+
+# Rust toolchain
+
+include $(TOPDIR)/tools/Rust.defs

--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -42,7 +42,6 @@ ARCHDEFINES += -U__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__
 
 ifeq ($(CONFIG_DEBUG_SYMBOLS),y)
   ARCHOPTIMIZATION += -g
-  ARCHOPTIMIZATIONRUST += -g
 endif
 
 ifeq ($(CONFIG_DEBUG_CUSTOMOPT),y)
@@ -53,8 +52,6 @@ endif
 
 ifneq ($(CONFIG_DEBUG_NOOPT),y)
   ARCHOPTIMIZATION += -fno-strict-aliasing
-else
-  ARCHOPTIMIZATIONRUST += -C opt-level=0
 endif
 
 ifeq ($(CONFIG_FRAME_POINTER),y)
@@ -124,14 +121,34 @@ endif
 ifeq ($(CONFIG_SIM_M32),y)
   ARCHCFLAGS += -m32
   ARCHCXXFLAGS += -m32
-  LLVM_ARCHTYPE := x86
-  LLVM_CPUTYPE := i686
-else
-  LLVM_ARCHTYPE := x86_64
-  LLVM_CPUTYPE  := native
 endif
 
-LLVM_ABITYPE := gnu
+# LLVM style architecture flags
+
+ifeq ($(CONFIG_HOST_X86_64),y)
+  ifeq ($(CONFIG_SIM_M32),y)
+    LLVM_ARCHTYPE := x86
+    LLVM_CPUTYPE := i686
+  else
+    LLVM_ARCHTYPE := x86_64
+    LLVM_CPUTYPE := skylake
+  endif
+else ifeq ($(CONFIG_HOST_X86_32),y)
+  LLVM_ARCHTYPE := x86
+  LLVM_CPUTYPE := i686
+else ifeq ($(CONFIG_HOST_ARM64),y)
+  LLVM_ARCHTYPE := aarch64
+  LLVM_CPUTYPE := cortex-a53
+else ifeq ($(CONFIG_HOST_ARM),y)
+  LLVM_ARCHTYPE := arm
+  LLVM_CPUTYPE := cortex-a9
+endif
+
+ifeq ($(CONFIG_HOST_LINUX),y)
+  LLVM_ABITYPE := gnu
+else ifeq ($(CONFIG_HOST_MACOS),y)
+  LLVM_ABITYPE := darwin
+endif
 
 ARCHPICFLAGS = -fpic
 
@@ -149,17 +166,19 @@ endif
 NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy
 OBJDUMP = $(CROSSDEV)objdump
-RUSTC = rustc --edition 2021
 
 # Zig toolchain
 
 include $(TOPDIR)/tools/Zig.defs
 
+# Rust toolchain
+
+include $(TOPDIR)/tools/Rust.defs
+
 CFLAGS := $(ARCHOPTIMIZATION) $(ARCHCFLAGS) $(ARCHINCLUDES) $(ARCHDEFINES) $(EXTRAFLAGS) -pipe
 CXXFLAGS := $(ARCHOPTIMIZATION) $(ARCHCXXFLAGS) $(ARCHXXINCLUDES) $(ARCHDEFINES) $(EXTRAFLAGS) -pipe
 CPPFLAGS := $(ARCHINCLUDES) $(ARCHDEFINES) $(EXTRAFLAGS)
 AFLAGS := $(CFLAGS) -D__ASSEMBLY__
-RUSTFLAGS := $(ARCHOPTIMIZATIONRUST)
 
 ifeq ($(CONFIG_LIBCXX),y)
   ifeq ($(CONFIG_HOST_MACOS),y)

--- a/tools/Rust.defs
+++ b/tools/Rust.defs
@@ -1,0 +1,54 @@
+############################################################################
+# tools/Rust.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+RUSTC := rustc --edition 2021
+
+RUSTFLAGS :=
+
+ifeq ($(CONFIG_DEBUG_SYMBOLS),y)
+  RUSTFLAGS += -g
+endif
+
+ifeq ($(CONFIG_DEBUG_NOOPT),y)
+  RUSTFLAGS += -C opt-level=0
+endif
+
+# Special handling for the SIM
+
+ifeq ($(CONFIG_ARCH_SIM),y)
+  ifeq ($(CONFIG_HOST_LINUX),y)
+    ifeq ($(LLVM_ARCHTYPE),x86)
+      # Only for x86 based host or x64 but m32 build
+      RUSTFLAGS += --target i686-unknown-linux-$(LLVM_ABITYPE)
+    else
+      # For other archs, such as aarch64, arm etc
+      RUSTFLAGS += --target $(LLVM_ARCHTYPE)-unknown-linux-$(LLVM_ABITYPE)
+    endif
+  else ifeq ($(CONFIG_HOST_MACOS),y)
+    RUSTFLAGS += --target $(LLVM_ARCHTYPE)-apple-$(LLVM_ABITYPE)
+  endif
+else ifeq ($(CONFIG_ARCH_RISCV),y)
+  # Traget triple is riscv[32|64][isa]-unknown-none-elf
+  RUSTFLAGS += --target $(LLVM_ARCHTYPE)i$(ARCHRVISAM)$(ARCHRVISAA)$(ARCHRVISAF)$(ARCHRVISAD)$(ARCHRVISAC)-unknown-none-elf
+else
+  # For arm, but there are some other archs not support yet,
+  # such as xtensa, x86 bare metal, etc.
+  RUSTFLAGS += --target $(LLVM_ARCHTYPE)-none-$(LLVM_ABITYPE)
+endif


### PR DESCRIPTION
## Summary
Move Rust relative settings to Rust.defs, only SIM support rust before, with this patch arm/risc-v works with Rust now. 
## Impact
Rust only
## Testing
CI and QEMU
