### PR TITLE
boardioc: Reset & poweroff are protected by critical section.

### DIFF
--- a/boards/boardctl.c
+++ b/boards/boardctl.c
@@ -31,6 +31,8 @@
 #include <assert.h>
 
 #include <nuttx/board.h>
+#include <nuttx/arch.h>
+#include <nuttx/irq.h>
 #include <nuttx/lib/modlib.h>
 #include <nuttx/binfmt/symtab.h>
 #include <nuttx/drivers/ramdisk.h>
@@ -362,8 +364,10 @@ int boardctl(unsigned int cmd, uintptr_t arg)
 
       case BOARDIOC_POWEROFF:
         {
+          irqstate_t flags = enter_critical_section();
           reboot_notifier_call_chain(SYS_POWER_OFF, (FAR void *)arg);
           ret = board_power_off((int)arg);
+          leave_critical_section(flags);
         }
         break;
 #endif
@@ -378,8 +382,10 @@ int boardctl(unsigned int cmd, uintptr_t arg)
 
       case BOARDIOC_RESET:
         {
+          irqstate_t flags = enter_critical_section();
           reboot_notifier_call_chain(SYS_RESTART, (FAR void *)arg);
           ret = board_reset((int)arg);
+          leave_critical_section(flags);
         }
         break;
 #endif


### PR DESCRIPTION
## Summary

I noticed that `boardctl(BOARDIOC_RESET, 0)` calls `reboot_notifier_call_chain()` before the reset.  
The operations of `reboot_notifier_call_chain()` are happening within a critical section.

The reboot notifier will typically cause a `sync()` to be executed for all open files (at least on my system).

But, after `reboot_notifier_call_chain()` returns, there is nothing ensuring that the reset will be executed immediately.  
At this point, this task may be preempted, and new writes to the files may be performed. A new `sync()` would be needed but it will not happen.

Wrapping everything in a critical section ensures that when the notifier completes, the system will immediately reset, without leaving room for other tasks to spoil the ready-to-reset state of the system.

## Impact

The reset procedure is executed correctly.

## Testing

Tested on a custom target based on the STM32F427.  
Reboot is being executed correctly, without any issues or side-effects.

