### PR TITLE
fs: Flush the file system cache in BOARDIOC_POWEROFF too

### DIFF
--- a/fs/fs_initialize.c
+++ b/fs/fs_initialize.c
@@ -40,7 +40,7 @@
 static int sync_reboot_handler(FAR struct notifier_block *nb,
                                unsigned long action, FAR void *data)
 {
-  if (action == SYS_DOWN || action == SYS_RESTART)
+  if (action == SYS_POWER_OFF || action == SYS_RESTART)
     {
       sync();
     }

--- a/include/nuttx/reboot_notifier.h
+++ b/include/nuttx/reboot_notifier.h
@@ -34,8 +34,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define SYS_DOWN        0x0001     /* Notify of system down */
-#define SYS_RESTART     SYS_DOWN
+#define SYS_RESTART     0x0001     /* Notify of system restart */
 #define SYS_HALT        0x0002     /* Notify of system halt */
 #define SYS_POWER_OFF   0x0003     /* Notify of system power off */
 


### PR DESCRIPTION
## Summary

and remove the check of SYS_DOWN since it defines to SYS_RESTART in reboot_notifer.h:
```
  #define SYS_DOWN        0x0001     /* Notify of system down */
  #define SYS_RESTART     SYS_DOWN
  #define SYS_HALT        0x0002     /* Notify of system halt */
  #define SYS_POWER_OFF   0x0003     /* Notify of system power off */
```

## Impact

flush the cache in the power off path

## Testing

internal