### PR TITLE
stm32_eth: Added error handling for abnormal interrupts.

### DIFF
--- a/arch/arm/src/stm32/stm32_eth.c
+++ b/arch/arm/src/stm32/stm32_eth.c
@@ -2027,17 +2027,13 @@ static void stm32_interrupt_work(void *arg)
       stm32_putreg(ETH_DMAINT_NIS, STM32_ETH_DMASR);
     }
 
-  /* Handle error interrupt only if CONFIG_DEBUG_NET is eanbled */
-
-#ifdef CONFIG_DEBUG_NET
-
-  /* Check if there are pending "anormal" interrupts */
+  /* Check if there are pending "abnormal" interrupts */
 
   if ((dmasr & ETH_DMAINT_AIS) != 0)
     {
       /* Just let the user know what happened */
 
-      nerr("ERROR: Abormal event(s): %08x\n", dmasr);
+      nerr("ERROR: Abnormal event(s): %08" PRIx32 "\n", dmasr);
 
       /* Clear all pending abnormal events */
 
@@ -2046,8 +2042,23 @@ static void stm32_interrupt_work(void *arg)
       /* Clear the pending abnormal summary interrupt */
 
       stm32_putreg(ETH_DMAINT_AIS, STM32_ETH_DMASR);
+
+      /* As per the datasheet's recommendation, the MAC
+       * needs to be reset for all abnormal events. The
+       * scheduled job will take the interface down and
+       * up again.
+       */
+
+      work_queue(ETHWORK, &priv->irqwork, stm32_txtimeout_work, priv, 0);
+
+      /* Interrupts need to remain disabled, no other
+       * processing will take place. After reset
+       * everything will be restored.
+       */
+
+      net_unlock();
+      return;
     }
-#endif
 
   net_unlock();
 


### PR DESCRIPTION
## Summary

Fixes the issue reported in #8576.

Essentially, when "abnormal" events occurred, the datasheet dictates that the MAC must be reset.
However, there is no error-handling at all.

This PR will check the relevant register, and execute the MAC reset, as needed.

## Impact

STM32 Ethernet operations should be more reliable now.

## Testing

I couldn't "force" this interrupt to trigger, but I used my debugger to create such an "artificial" event, and force this code branch to be taken.

Indeed the MAC resets. After that, network operations are resumed and everything seems normal.
