### PR TITLE
libc: Print error code for unknown errors in strerror/gai_strerror

### DIFF
--- a/libs/libc/netdb/Kconfig
+++ b/libs/libc/netdb/Kconfig
@@ -19,6 +19,14 @@ config LIBC_GAISTRERROR
 		of memory. If this option is not selected, gai_strerror() will still exist in
 		the build but it will not decode error values.
 
+config LIBC_GAISTRERROR_ERRNUM
+	bool "Print unknown error code in gai_strerror()"
+	default !LIBC_GAISTRERROR
+	---help---
+		If this option is selected, then gai_strerror() will print error code
+		for unknown errors like "Unknown error 11". Default enabled when
+		LIBC_GAISTRERROR is not selected.
+
 config NETDB_BUFSIZE
 	int "gethostbyname/gethostbyaddr buffer size"
 	depends on LIBC_NETDB

--- a/libs/libc/netdb/lib_gaistrerror.c
+++ b/libs/libc/netdb/lib_gaistrerror.c
@@ -25,7 +25,15 @@
 #include <nuttx/config.h>
 
 #include <stdint.h>
+#include <stdio.h>
 #include <netdb.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define STRERROR_UNKNOWN "Unknown error"
+#define STRERROR_BUFSIZE sizeof(STRERROR_UNKNOWN " 10")
 
 /****************************************************************************
  * Private Types
@@ -82,6 +90,9 @@ static const struct errno_strmap_s g_gaierrnomap[] =
 
 FAR const char *gai_strerror(int errnum)
 {
+#ifdef CONFIG_LIBC_GAISTRERROR_ERRNUM
+  static char s_err[STRERROR_BUFSIZE];
+#endif
 #ifdef CONFIG_LIBC_GAISTRERROR
   int ndxlow = 0;
   int ndxhi  = NERRNO_STRS - 1;
@@ -105,5 +116,15 @@ FAR const char *gai_strerror(int errnum)
     }
   while (ndxlow <= ndxhi);
 #endif
-  return "Unknown error";
+#ifdef CONFIG_LIBC_GAISTRERROR_ERRNUM
+  if (snprintf(s_err, sizeof(s_err), STRERROR_UNKNOWN " %d", errnum)
+      < sizeof(s_err))
+    {
+      return s_err;
+    }
+#elif !defined(CONFIG_LIBC_GAISTRERROR)
+  UNUSED(errnum);
+#endif
+
+  return STRERROR_UNKNOWN;
 }

--- a/libs/libc/string/Kconfig
+++ b/libs/libc/string/Kconfig
@@ -28,6 +28,14 @@ config LIBC_STRERROR_SHORT
 		produce the string "No such file or directory" is LIBC_STRERROR_SHORT
 		is not defined but the string "ENOENT" is LIBC_STRERROR_SHORT is defined.
 
+config LIBC_STRERROR_ERRNUM
+	bool "Print unknown error code in strerror()"
+	default !LIBC_STRERROR
+	---help---
+		If this option is selected, then strerror() will print error code
+		for unknown errors like "Unknown error 101". Default enabled when
+		LIBC_STRERROR is not selected.
+
 config LIBC_PERROR_STDOUT
 	bool "perror() to stdout"
 	default n

--- a/libs/libc/string/lib_strerror.c
+++ b/libs/libc/string/lib_strerror.c
@@ -25,12 +25,16 @@
 #include <nuttx/config.h>
 
 #include <stdint.h>
+#include <stdio.h>
 #include <string.h>
 #include <errno.h>
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
+#define STRERROR_UNKNOWN "Unknown error"
+#define STRERROR_BUFSIZE sizeof(STRERROR_UNKNOWN " 2000")
 
 /****************************************************************************
  * Private Types
@@ -367,6 +371,9 @@ static const struct errno_strmap_s g_errnomap[] =
 
 FAR char *strerror(int errnum)
 {
+#ifdef CONFIG_LIBC_STRERROR_ERRNUM
+  static char s_err[STRERROR_BUFSIZE];
+#endif
 #ifdef CONFIG_LIBC_STRERROR
   int ndxlow = 0;
   int ndxhi  = NERRNO_STRS - 1;
@@ -389,8 +396,16 @@ FAR char *strerror(int errnum)
         }
     }
   while (ndxlow <= ndxhi);
-#else
+#endif
+#ifdef CONFIG_LIBC_STRERROR_ERRNUM
+  if (snprintf(s_err, sizeof(s_err), STRERROR_UNKNOWN " %d", errnum)
+      < sizeof(s_err))
+    {
+      return s_err;
+    }
+#elif !defined(CONFIG_LIBC_STRERROR)
   UNUSED(errnum);
 #endif
-  return "Unknown error";
+
+  return STRERROR_UNKNOWN;
 }


### PR DESCRIPTION
## Summary
Print error code for unknown errors in strerror/gai_strerror

Ref: Linux print unknown errors like "Unknown error nnn" 
https://man7.org/linux/man-pages/man3/strerror.3.html#RETURN_VALUE

Note:
These interfaces are called at low freq, so a static buffer may be enough.

## Impact
Print error code for unknown errors in strerror/gai_strerror
A little bit more memory consumption (~20Bytes each) if enabled.

## Testing
Manually & CI
