### PR TITLE
arch/boards: fix stm32f411-mininum:nsh compilation failure 

### DIFF
--- a/arch/arm/src/stm32/stm32_start.c
+++ b/arch/arm/src/stm32/stm32_start.c
@@ -30,6 +30,7 @@
 
 #include <nuttx/init.h>
 
+#include "arch/board/board.h"
 #include "arm_internal.h"
 #include "nvic.h"
 #include "mpu.h"


### PR DESCRIPTION
## Summary
arch/boards: fix stm32f411-mininum:nsh compilation failure after enabling IRQMONITOR

https://github.com/apache/nuttx/pull/8040#issuecomment-1493500471

## Impact

## Testing

