### PR TITLE
drivers/video: passthrough unknown ioctl commands for customized scenarios in fb driver

### DIFF
--- a/drivers/video/fb.c
+++ b/drivers/video/fb.c
@@ -674,8 +674,15 @@ static int fb_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         break;
 
       default:
-        gerr("ERROR: Unsupported IOCTL command: %d\n", cmd);
-        ret = -ENOTTY;
+        if (fb->vtable->ioctl != NULL)
+          {
+            ret = fb->vtable->ioctl(fb->vtable, cmd, arg);
+          }
+        else
+          {
+            gerr("ERROR: Unsupported IOCTL command: %d\n", cmd);
+            ret = -ENOTTY;
+          }
         break;
     }
 

--- a/include/nuttx/video/fb.h
+++ b/include/nuttx/video/fb.h
@@ -790,6 +790,10 @@ struct fb_vtable_s
 
   int (*setpower)(FAR struct fb_vtable_s *vtable, int power);
 
+  /* Passthrough the unknown ioctl commands. */
+
+  int (*ioctl)(FAR struct fb_vtable_s *vtable, int cmd, unsigned long arg);
+
   /* Pointer to framebuffer device private data. */
 
   FAR void *priv;


### PR DESCRIPTION
## Summary
passthrough the custom ioctl commands to framebuffer driver 

## Impact
None

## Testing
Daily
