### PR TITLE
risc-v/espressif: Panic if CPU interrupt allocation fails

### DIFF
--- a/arch/risc-v/src/espressif/esp_irq.c
+++ b/arch/risc-v/src/espressif/esp_irq.c
@@ -422,8 +422,7 @@ void esp_route_intr(int source, int cpuint, irq_priority_t priority,
  *   type          - Interrupt trigger type.
  *
  * Returned Value:
- *   The allocated CPU interrupt on success, a negated errno value on
- *   failure.
+ *   Allocated CPU interrupt.
  *
  ****************************************************************************/
 
@@ -449,11 +448,10 @@ int esp_setup_irq(int source, irq_priority_t priority, irq_trigger_t type)
   cpuint = esp_cpuint_alloc(irq);
   if (cpuint < 0)
     {
-      irqerr("Unable to allocate CPU interrupt for priority=%d and type=%d",
+      _alert("Unable to allocate CPU interrupt for source=%d\n",
              priority, type);
-      leave_critical_section(irqstate);
 
-      return cpuint;
+      PANIC();
     }
 
   esp_route_intr(source, cpuint, priority, type);

--- a/arch/risc-v/src/espressif/esp_irq.h
+++ b/arch/risc-v/src/espressif/esp_irq.h
@@ -115,8 +115,7 @@ void esp_route_intr(int source, int cpuint, irq_priority_t priority,
  *   type          - Interrupt trigger type.
  *
  * Returned Value:
- *   The allocated CPU interrupt on success, a negated errno value on
- *   failure.
+ *   Allocated CPU interrupt.
  *
  ****************************************************************************/
 

--- a/arch/risc-v/src/espressif/esp_serial.c
+++ b/arch/risc-v/src/espressif/esp_serial.c
@@ -493,10 +493,6 @@ static int esp_attach(uart_dev_t *dev)
 
   priv->cpuint = esp_setup_irq(priv->source, priv->int_pri,
                                ESP_IRQ_TRIGGER_LEVEL);
-  if (priv->cpuint < 0)
-    {
-      return priv->cpuint;
-    }
 
   /* Attach and enable the IRQ */
 


### PR DESCRIPTION
## Summary

This PR intends to simplify the error handling of CPU interrupt allocation for Espressif's chis supported within `risc-v/espressif` tree.

Instead of propagating an `-ENOMEM` error value, `esp_setup_irq` now adopts a fail-fast approach and simply panics. CPU interrupt allocation errors are unrecoverable, so the reliability of the execution becomes compromised.

## Impact

Serial driver no longer performs the error checking, resulting is less code.

## Testing

Verification in internal CI that all available defconfig within `boards/risc-v/espressif` boot properly.

Also forced the error by hardcoding `esp_cpuint_alloc` return value as `-ENOMEM`:

```
esp_setup_irq: Unable to allocate CPU interrupt for source=1
_assert: Current Version: NuttX  10.4.0 12fda1da1c-dirty Apr  3 2023 15:29:42 risc-v
_assert: Assertion failed panic: at file: chip/esp_irq.c:454 task: Idle Task 0x42003f5a
```

