### PR TITLE
sim_x11eventloop: fix X11 event accumulation

### DIFF
--- a/arch/sim/src/sim/posix/sim_x11eventloop.c
+++ b/arch/sim/src/sim/posix/sim_x11eventloop.c
@@ -103,9 +103,9 @@ void sim_x11events(void)
 {
   XEvent event;
 
-  /* Check if there are any pending, queue X11 events. */
+  /* Dequeue any pending X11 events. */
 
-  if (g_display && XPending(g_display) > 0)
+  while (g_display && XPending(g_display) > 0)
     {
       /* Yes, get the event (this should not block since we know there are
        * pending events)


### PR DESCRIPTION
## Summary

`sim_x11events` should process all x11 events in each event loop, otherwise it will cause events to accumulate in the queue and affect the interaction, as shown in the following demonstration:

Fix before:

https://user-images.githubusercontent.com/26767803/229782287-1090a0ea-b991-4b5c-97f1-dabded2d5c64.mp4

Fix after:

https://user-images.githubusercontent.com/26767803/229782301-12a5d9d3-299e-4e46-b8c1-76ed3c096294.mp4

## Impact
simulator

## Testing
```
cu nuttx
./tools/configure.sh -l sim:lvgl_fb
make -j
./nuttx
```
