### PR TITLE
esp32/wifi: Fix Wi-Fi driver parameter settings

### DIFF
--- a/arch/xtensa/src/esp32/esp32_wifi_adapter.c
+++ b/arch/xtensa/src/esp32/esp32_wifi_adapter.c
@@ -63,6 +63,7 @@
 #include "esp32_wifi_adapter.h"
 #include "esp32_rt_timer.h"
 #include "esp32_wifi_utils.h"
+#include "esp32_wlan.h"
 
 #ifdef CONFIG_PM
 #  include "esp32_pm.h"
@@ -2245,11 +2246,23 @@ static void esp_evt_work_cb(void *arg)
           case WIFI_ADPT_EVT_STA_CONNECT:
             wlinfo("Wi-Fi sta connect\n");
             g_sta_connected = true;
+            ret = esp32_wlan_sta_set_linkstatus(true);
+            if (ret < 0)
+              {
+                wlerr("ERROR: Failed to set Wi-Fi station link status\n");
+              }
+
             break;
 
           case WIFI_ADPT_EVT_STA_DISCONNECT:
             wlinfo("Wi-Fi sta disconnect\n");
             g_sta_connected = false;
+            ret = esp32_wlan_sta_set_linkstatus(false);
+            if (ret < 0)
+              {
+                wlerr("ERROR: Failed to set Wi-Fi station link status\n");
+              }
+
             if (g_sta_reconnect)
               {
                 ret = esp_wifi_connect();

--- a/arch/xtensa/src/esp32/esp32_wifi_adapter.h
+++ b/arch/xtensa/src/esp32/esp32_wifi_adapter.h
@@ -495,7 +495,7 @@ int esp_wifi_sta_country(struct iwreq *iwr, bool set);
  ****************************************************************************/
 
 int esp_wifi_sta_rssi(struct iwreq *iwr, bool set);
-#endif
+#endif /* ESP32_WLAN_HAS_STA */
 
 #ifdef ESP32_WLAN_HAS_SOFTAP
 

--- a/arch/xtensa/src/esp32/esp32_wlan.c
+++ b/arch/xtensa/src/esp32/esp32_wlan.c
@@ -223,7 +223,7 @@ static const struct wlan_ops g_sta_ops =
   .event      = esp_wifi_notify_subscribe,
   .stop       = esp_wifi_sta_stop
 };
-#endif
+#endif /* ESP32_WLAN_HAS_STA */
 
 #ifdef ESP32_WLAN_HAS_SOFTAP
 static const struct wlan_ops g_softap_ops =
@@ -246,7 +246,7 @@ static const struct wlan_ops g_softap_ops =
   .event      = esp_wifi_notify_subscribe,
   .stop       = esp_wifi_softap_stop
 };
-#endif
+#endif /* ESP32_WLAN_HAS_SOFTAP */
 
 /****************************************************************************
  * Private Function Prototypes
@@ -1712,7 +1712,7 @@ static void wlan_sta_tx_done(uint8_t *data, uint16_t *len, bool status)
 
   wlan_tx_done(priv);
 }
-#endif
+#endif /* ESP32_WLAN_HAS_STA */
 
 /****************************************************************************
  * Function: wlan_softap_rx_done
@@ -1763,7 +1763,7 @@ static void wlan_softap_tx_done(uint8_t *data, uint16_t *len, bool status)
 
   wlan_tx_done(priv);
 }
-#endif
+#endif /* ESP32_WLAN_HAS_SOFTAP */
 
 /****************************************************************************
  * Public Functions
@@ -1827,7 +1827,7 @@ int esp32_wlan_sta_initialize(void)
 
   return OK;
 }
-#endif
+#endif /* ESP32_WLAN_HAS_STA */
 
 /****************************************************************************
  * Name: esp32_wlan_softap_initialize
@@ -1888,6 +1888,6 @@ int esp32_wlan_softap_initialize(void)
 
   return OK;
 }
-#endif
+#endif /* ESP32_WLAN_HAS_SOFTAP */
 
 #endif  /* CONFIG_ESP32_WIFI */

--- a/arch/xtensa/src/esp32/esp32_wlan.c
+++ b/arch/xtensa/src/esp32/esp32_wlan.c
@@ -1770,6 +1770,40 @@ static void wlan_softap_tx_done(uint8_t *data, uint16_t *len, bool status)
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: esp32_wlan_sta_set_linkstatus
+ *
+ * Description:
+ *   Set Wi-Fi station link status
+ *
+ * Parameters:
+ *   linkstatus - true Notifies the networking layer about an available
+ *                carrier, false Notifies the networking layer about an
+ *                disappeared carrier.
+ *
+ * Returned Value:
+ *   OK on success; Negated errno on failure.
+ *
+ ****************************************************************************/
+
+#ifdef ESP32_WLAN_HAS_STA
+int esp32_wlan_sta_set_linkstatus(bool linkstatus)
+{
+  int ret = -EINVAL;
+  FAR struct wlan_priv_s *priv = &g_wlan_priv[ESP32_WLAN_STA_DEVNO];
+
+  if (linkstatus)
+    {
+      ret = netdev_carrier_on(&priv->dev);
+    }
+  else
+    {
+      ret = netdev_carrier_off(&priv->dev);
+    }
+
+  return ret;
+}
+
+/****************************************************************************
  * Name: esp32_wlan_sta_initialize
  *
  * Description:
@@ -1783,7 +1817,6 @@ static void wlan_softap_tx_done(uint8_t *data, uint16_t *len, bool status)
  *
  ****************************************************************************/
 
-#ifdef ESP32_WLAN_HAS_STA
 int esp32_wlan_sta_initialize(void)
 {
   int ret;

--- a/arch/xtensa/src/esp32/esp32_wlan.h
+++ b/arch/xtensa/src/esp32/esp32_wlan.h
@@ -62,7 +62,7 @@ extern "C"
 
 #ifdef ESP32_WLAN_HAS_STA
 int esp32_wlan_sta_initialize(void);
-#endif
+#endif /* ESP32_WLAN_HAS_STA */
 
 /****************************************************************************
  * Name: esp32_wlan_softap_initialize
@@ -80,7 +80,7 @@ int esp32_wlan_sta_initialize(void);
 
 #ifdef ESP32_WLAN_HAS_SOFTAP
 int esp32_wlan_softap_initialize(void);
-#endif
+#endif /* ESP32_WLAN_HAS_SOFTAP */
 
 #endif /* CONFIG_ESP32_WIFI */
 #ifdef __cplusplus

--- a/arch/xtensa/src/esp32/esp32_wlan.h
+++ b/arch/xtensa/src/esp32/esp32_wlan.h
@@ -61,6 +61,39 @@ extern "C"
  ****************************************************************************/
 
 #ifdef ESP32_WLAN_HAS_STA
+
+/****************************************************************************
+ * Name: esp32_wlan_sta_set_linkstatus
+ *
+ * Description:
+ *   Set Wi-Fi station link status
+ *
+ * Parameters:
+ *   linkstatus - true Notifies the networking layer about an available
+ *                carrier, false Notifies the networking layer about an
+ *                disappeared carrier.
+ *
+ * Returned Value:
+ *   OK on success; Negated errno on failure.
+ *
+ ****************************************************************************/
+
+int esp32_wlan_sta_set_linkstatus(bool linkstatus);
+
+/****************************************************************************
+ * Name: esp32_wlan_sta_initialize
+ *
+ * Description:
+ *   Initialize the ESP32 WLAN station netcard driver
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   OK on success; Negated errno on failure.
+ *
+ ****************************************************************************/
+
 int esp32_wlan_sta_initialize(void);
 #endif /* ESP32_WLAN_HAS_STA */
 

--- a/boards/xtensa/esp32/common/src/esp32_board_wlan.c
+++ b/boards/xtensa/esp32/common/src/esp32_board_wlan.c
@@ -71,7 +71,7 @@ int board_wlan_init(void)
       wlerr("ERROR: Failed to initialize Wi-Fi station\n");
       return ret;
     }
-#endif
+#endif /* ESP32_WLAN_HAS_STA */
 
 #ifdef ESP32_WLAN_HAS_SOFTAP
   ret = esp32_wlan_softap_initialize();
@@ -80,7 +80,7 @@ int board_wlan_init(void)
       wlerr("ERROR: Failed to initialize Wi-Fi softAP\n");
       return ret;
     }
-#endif
+#endif /* ESP32_WLAN_HAS_SOFTAP */
 
   return ret;
 }


### PR DESCRIPTION
## Summary

This PR fixes [#7857](https://github.com/apache/nuttx/issues/7857) and [#7193](https://github.com/apache/nuttx/issues/7193) by saving Wi-Fi parameters and setting them at once, avoiding unknown behaviors of the Wi-Fi driver, like setting auth mode without a valid password.

Also, it enables setting the auth of the STA/softAP modes while connecting to/providing the wireless network.

Finally, it notifies the networking layer about the current state of the STA interface.

## Impact

Fix known bugs of the Wi-Fi driver on ESP32 (C3 is not affected because of its driver implementation) and improve security as it sets the minimum auth method to connect to an AP.

## Testing

Internal CI testing that covers erroneous behavior prior to this MR.
