### PR TITLE
board: define boardioc_softreset_subreason_e in CONFIG_BOARDCTL_RESET

### DIFF
--- a/include/sys/boardctl.h
+++ b/include/sys/boardctl.h
@@ -410,7 +410,7 @@ struct boardioc_boot_info_s
 };
 #endif
 
-#ifdef CONFIG_BOARDCTL_RESET_CAUSE
+#if defined(CONFIG_BOARDCTL_RESET) || defined(CONFIG_BOARDCTL_RESET_CAUSE)
 /* Describes the reason of last reset */
 
 enum boardioc_reset_cause_e


### PR DESCRIPTION
## Summary

so user could pass boardioc_softreset_subreason_e to board_reset too, found by https://github.com/apache/nuttx-apps/pull/1696

## Impact

minor

## Testing

CI