### PR TITLE
Fixed improper access of g_pidhash.

### DIFF
--- a/sched/task/task_setup.c
+++ b/sched/task/task_setup.c
@@ -83,6 +83,7 @@ static int nxtask_assign_pid(FAR struct tcb_s *tcb)
   FAR struct tcb_s **pidhash;
   pid_t next_pid;
   int   hash_ndx;
+  void *temp;
   int   i;
 
   /* NOTE:
@@ -160,8 +161,9 @@ retry:
 
   /* Release resource for original g_pidhash, using new g_pidhash */
 
-  kmm_free(g_pidhash);
+  temp = g_pidhash;
   g_pidhash = pidhash;
+  kmm_free(temp);
 
   /* Let's try every allowable pid again */
 


### PR DESCRIPTION
## Summary

Fixes potential garbage access to `g_pidhash`.

Also see [here](https://lists.apache.org/list.html?dev@nuttx.apache.org).

## Impact

Bug fix.

## Testing

Tested on sim, running ostest with KASAN enabled.
