### PR TITLE
arch: k210: Fix k210 timer on QEMU 6.1 or later

### DIFF
--- a/arch/risc-v/src/k210/k210_timerisr.c
+++ b/arch/risc-v/src/k210/k210_timerisr.c
@@ -45,7 +45,7 @@
  ****************************************************************************/
 
 #ifdef CONFIG_K210_WITH_QEMU
-#define MTIMER_FREQ 10000000
+#define MTIMER_FREQ 1000000
 #else
 #define MTIMER_FREQ (k210_get_cpuclk() / 50)
 #endif


### PR DESCRIPTION
## Summary

- I noticed that 'sleep 1' on nsh took 10 seconds on QEMU-6.1, though the old version (e.g. QEMU-5.2) works correctly.
- I think we should implement PLL for the QEMU environment. However, this fix works as a tentative solution.

## Impact

- K210 on QEMU only

## Testing

- Tested with QEMU-7.1
