### PR TITLE
{stm32f7,stm32h7,stm32l4}/sdmmc: callback support requires HPWORK

### DIFF
--- a/arch/arm/src/stm32f7/stm32_sdmmc.c
+++ b/arch/arm/src/stm32f7/stm32_sdmmc.c
@@ -115,8 +115,8 @@
 #  endif
 #endif
 
-#ifndef CONFIG_SCHED_WORKQUEUE
-#  error "Callback support requires CONFIG_SCHED_WORKQUEUE"
+#if !defined(CONFIG_SCHED_WORKQUEUE) || !defined(CONFIG_SCHED_HPWORK)
+#  error "Callback support requires CONFIG_SCHED_WORKQUEUE and CONFIG_SCHED_HPWORK"
 #endif
 
 #ifdef CONFIG_STM32F7_SDMMC1

--- a/arch/arm/src/stm32h7/stm32_sdmmc.c
+++ b/arch/arm/src/stm32h7/stm32_sdmmc.c
@@ -138,8 +138,8 @@
 #  define SRAM4_END     (SRAM4_START + STM32H7_SRAM4_SIZE)
 #endif
 
-#ifndef CONFIG_SCHED_WORKQUEUE
-#  error "Callback support requires CONFIG_SCHED_WORKQUEUE"
+#if !defined(CONFIG_SCHED_WORKQUEUE) || !defined(CONFIG_SCHED_HPWORK)
+#  error "Callback support requires CONFIG_SCHED_WORKQUEUE and CONFIG_SCHED_HPWORK"
 #endif
 
 #undef HAVE_SDMMC_SDIO_MODE

--- a/arch/arm/src/stm32l4/stm32l4_sdmmc.c
+++ b/arch/arm/src/stm32l4/stm32l4_sdmmc.c
@@ -93,8 +93,8 @@
 #  endif
 #endif
 
-#ifndef CONFIG_SCHED_WORKQUEUE
-#  error "Callback support requires CONFIG_SCHED_WORKQUEUE"
+#if !defined(CONFIG_SCHED_WORKQUEUE) || !defined(CONFIG_SCHED_HPWORK)
+#  error "Callback support requires CONFIG_SCHED_WORKQUEUE and CONFIG_SCHED_HPWORK"
 #endif
 
 #ifdef CONFIG_STM32L4_SDMMC1


### PR DESCRIPTION
## Summary
{stm32f7,stm32h7,stm32l4}/sdmmc: callback support requires HPWORK
https://github.com/apache/nuttx/blob/5e7d48f4b0a40e8b067738f07fee96f299fb521c/include/nuttx/sdio.h#L822-L824
## Impact
raise error when the required HPWORK is not supported
## Testing
CI
