### PR TITLE
stm32/otg: rasie an assertion if IN request is not possible to transfer

### DIFF
--- a/arch/arm/src/efm32/efm32_usbdev.c
+++ b/arch/arm/src/efm32/efm32_usbdev.c
@@ -1336,6 +1336,19 @@ static void efm32_epin_request(struct efm32_usbdev_s *priv,
           empmsk |= USB_DIEPEMPMSK(privep->epphy);
           efm32_putreg(empmsk, EFM32_USB_DIEPEMPMSK);
 
+#ifdef CONFIG_DEBUG_FEATURES
+          /* Check if the configured TXFIFO size is sufficient for a given
+           * request. If not, raise an assertion here.
+           */
+
+          regval = emf32_putreg(regval, EMF32_USB_DIEPTXF(privep->epphy));
+          regval &= _USB_DIEPTXF1_INEPNTXFDEP_MASK;
+          regval >>= _USB_DIEPTXF1_INEPNTXFDEP_SHIFT;
+          uerr("EP%" PRId8 " TXLEN=%" PRId32 " nwords=%d\n",
+               privep->epphy, regval, nwords);
+          DEBUGASSERT(regval >= nwords);
+#endif
+
           /* Terminate the transfer.  We will try again when the TxFIFO empty
            * interrupt is received.
            */

--- a/arch/arm/src/stm32/stm32_otgfsdev.c
+++ b/arch/arm/src/stm32/stm32_otgfsdev.c
@@ -1378,6 +1378,19 @@ static void stm32_epin_request(struct stm32_usbdev_s *priv,
           empmsk |= OTGFS_DIEPEMPMSK(privep->epphy);
           stm32_putreg(empmsk, STM32_OTGFS_DIEPEMPMSK);
 
+#ifdef CONFIG_DEBUG_FEATURES
+          /* Check if the configured TXFIFO size is sufficient for a given
+           * request. If not, raise an assertion here.
+           */
+
+          regval = stm32_putreg(regval, STM32_OTGFS_DIEPTXF(privep->epphy));
+          regval &= OTGFS_DIEPTXF_INEPTXFD_MASK;
+          regval >>= OTGFS_DIEPTXF_INEPTXFD_SHIFT;
+          uerr("EP%" PRId8 " TXLEN=%" PRId32 " nwords=%d\n",
+               privep->epphy, regval, nwords);
+          DEBUGASSERT(regval >= nwords);
+#endif
+
           /* Terminate the transfer.  We will try again when the TxFIFO empty
            * interrupt is received.
            */

--- a/arch/arm/src/stm32/stm32_otghsdev.c
+++ b/arch/arm/src/stm32/stm32_otghsdev.c
@@ -1328,6 +1328,19 @@ static void stm32_epin_request(struct stm32_usbdev_s *priv,
           empmsk |= OTGHS_DIEPEMPMSK(privep->epphy);
           stm32_putreg(empmsk, STM32_OTGHS_DIEPEMPMSK);
 
+#ifdef CONFIG_DEBUG_FEATURES
+          /* Check if the configured TXFIFO size is sufficient for a given
+           * request. If not, raise an assertion here.
+           */
+
+          regval = stm32_putreg(regval, STM32_OTGHS_DIEPTXF(privep->epphy));
+          regval &= OTGHS_DIEPTXF_INEPTXFD_MASK;
+          regval >>= OTGHS_DIEPTXF_INEPTXFD_SHIFT;
+          uerr("EP%" PRId8 " TXLEN=%" PRId32 " nwords=%d\n",
+               privep->epphy, regval, nwords);
+          DEBUGASSERT(regval >= nwords);
+#endif
+
           /* Terminate the transfer.  We will try again when the TxFIFO empty
            * interrupt is received.
            */

--- a/arch/arm/src/stm32f7/stm32_otgdev.c
+++ b/arch/arm/src/stm32f7/stm32_otgdev.c
@@ -1438,6 +1438,19 @@ static void stm32_epin_request(struct stm32_usbdev_s *priv,
           empmsk |= OTG_DIEPEMPMSK(privep->epphy);
           stm32_putreg(empmsk, STM32_OTG_DIEPEMPMSK);
 
+#ifdef CONFIG_DEBUG_FEATURES
+          /* Check if the configured TXFIFO size is sufficient for a given
+           * request. If not, raise an assertion here.
+           */
+
+          regval = stm32_putreg(regval, STM32_OTG_DIEPTXF(privep->epphy));
+          regval &= OTG_DIEPTXF_INEPTXFD_MASK;
+          regval >>= OTG_DIEPTXF_INEPTXFD_SHIFT;
+          uerr("EP%" PRId8 " TXLEN=%" PRId32 " nwords=%d\n",
+               privep->epphy, regval, nwords);
+          DEBUGASSERT(regval >= nwords);
+#endif
+
           /* Terminate the transfer.  We will try again when the TxFIFO empty
            * interrupt is received.
            */

--- a/arch/arm/src/stm32h7/stm32_otgdev.c
+++ b/arch/arm/src/stm32h7/stm32_otgdev.c
@@ -1401,6 +1401,19 @@ static void stm32_epin_request(struct stm32_usbdev_s *priv,
           empmsk |= OTG_DIEPEMPMSK(privep->epphy);
           stm32_putreg(empmsk, STM32_OTG_DIEPEMPMSK);
 
+#ifdef CONFIG_DEBUG_FEATURES
+          /* Check if the configured TXFIFO size is sufficient for a given
+           * request. If not, raise an assertion here.
+           */
+
+          regval = stm32_putreg(regval, STM32_OTG_DIEPTXF(privep->epphy));
+          regval &= OTG_DIEPTXF_INEPTXFD_MASK;
+          regval >>= OTG_DIEPTXF_INEPTXFD_SHIFT;
+          uerr("EP%" PRId8 " TXLEN=%" PRId32 " nwords=%d\n",
+               privep->epphy, regval, nwords);
+          DEBUGASSERT(regval >= nwords);
+#endif
+
           /* Terminate the transfer.  We will try again when the TxFIFO empty
            * interrupt is received.
            */

--- a/arch/arm/src/stm32l4/stm32l4_otgfsdev.c
+++ b/arch/arm/src/stm32l4/stm32l4_otgfsdev.c
@@ -1438,6 +1438,20 @@ static void stm32l4_epin_request(struct stm32l4_usbdev_s *priv,
           empmsk |= OTGFS_DIEPEMPMSK(privep->epphy);
           stm32l4_putreg(empmsk, STM32L4_OTGFS_DIEPEMPMSK);
 
+#ifdef CONFIG_DEBUG_FEATURES
+          /* Check if the configured TXFIFO size is sufficient for a given
+           * request. If not, raise an assertion here.
+           */
+
+          regval = stm32l4_putreg(regval,
+                                  STM32L4_OTG_DIEPTXF(privep->epphy));
+          regval &= OTGFS_DIEPTXF_INEPTXFD_MASK;
+          regval >>= OTGFS_DIEPTXF_INEPTXFD_SHIFT;
+          uerr("EP%" PRId8 " TXLEN=%" PRId32 " nwords=%d\n",
+               privep->epphy, regval, nwords);
+          DEBUGASSERT(regval >= nwords);
+#endif
+
           /* Terminate the transfer.  We will try again when the TxFIFO empty
            * interrupt is received.
            */


### PR DESCRIPTION
## Summary
- {stm32,stm32f7,stm32h7,stm32l4,efm32}/otg: rasie an assertion if IN request is not possible to transfer.
Otherwise, a request will never be transferred and there is no information to the user that something is wrong.
For example, when using default values for TXFIFO in HS mode, USBMSC will never work because the maximum request len is 512B which is lower than the default TXFIFO size for IN EP.

## Impact
Incorrect configuration is easier to debug and find a problem

## Testing
h7
