### PR TITLE
arch/xtensa: Remove FAR qualifier for Xtensa-specific files

### DIFF
--- a/arch/xtensa/src/esp32/esp32_wlan.c
+++ b/arch/xtensa/src/esp32/esp32_wlan.c
@@ -1789,7 +1789,7 @@ static void wlan_softap_tx_done(uint8_t *data, uint16_t *len, bool status)
 int esp32_wlan_sta_set_linkstatus(bool linkstatus)
 {
   int ret = -EINVAL;
-  FAR struct wlan_priv_s *priv = &g_wlan_priv[ESP32_WLAN_STA_DEVNO];
+  struct wlan_priv_s *priv = &g_wlan_priv[ESP32_WLAN_STA_DEVNO];
 
   if (linkstatus)
     {

--- a/arch/xtensa/src/esp32s3/esp32s3_wlan.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_wlan.c
@@ -1462,7 +1462,7 @@ static void wlan_softap_tx_done(uint8_t *data, uint16_t *len, bool status)
 int esp32s3_wlan_sta_set_linkstatus(bool linkstatus)
 {
   int ret = -EINVAL;
-  FAR struct wlan_priv_s *priv = &g_wlan_priv[ESP32S3_WLAN_STA_DEVNO];
+  struct wlan_priv_s *priv = &g_wlan_priv[ESP32S3_WLAN_STA_DEVNO];
 
   if (priv != NULL)
     {


### PR DESCRIPTION
## Summary

This PR intends to remove all references to the FAR and CODE qualifiers from Xtensa files.
FAR and CODE are defined as nothing on both architectures.

This PR refers to https://github.com/apache/nuttx/pull/8963#pullrequestreview-1373425046

## Impact

Should have no impact.

## Testing

CI build pass.