### PR TITLE
fs/nxffs: Fix typo(nxem_wait->nxmutex_lock) error in comment

### DIFF
--- a/fs/nxffs/nxffs_ioctl.c
+++ b/fs/nxffs/nxffs_ioctl.c
@@ -70,7 +70,7 @@ int nxffs_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   ret = nxmutex_lock(&volume->lock);
   if (ret < 0)
     {
-      ferr("ERROR: nxsem_wait failed: %d\n", ret);
+      ferr("ERROR: nxmutex_lock failed: %d\n", ret);
       goto errout;
     }
 

--- a/fs/nxffs/nxffs_open.c
+++ b/fs/nxffs/nxffs_open.c
@@ -690,7 +690,7 @@ static inline int nxffs_rdopen(FAR struct nxffs_volume_s *volume,
   ret = nxmutex_lock(&volume->lock);
   if (ret != OK)
     {
-      ferr("ERROR: nxsem_wait failed: %d\n", ret);
+      ferr("ERROR: nxmutex_lock failed: %d\n", ret);
       goto errout;
     }
 
@@ -1134,7 +1134,7 @@ int nxffs_close(FAR struct file *filep)
   ret = nxmutex_lock(&volume->lock);
   if (ret != OK)
     {
-      ferr("ERROR: nxsem_wait failed: %d\n", ret);
+      ferr("ERROR: nxmutex_lock failed: %d\n", ret);
       goto errout;
     }
 

--- a/fs/nxffs/nxffs_read.c
+++ b/fs/nxffs/nxffs_read.c
@@ -160,7 +160,7 @@ ssize_t nxffs_read(FAR struct file *filep, FAR char *buffer, size_t buflen)
   ret = nxmutex_lock(&volume->lock);
   if (ret < 0)
     {
-      ferr("ERROR: nxsem_wait failed: %d\n", ret);
+      ferr("ERROR: nxmutex_lock failed: %d\n", ret);
       goto errout;
     }
 

--- a/fs/nxffs/nxffs_stat.c
+++ b/fs/nxffs/nxffs_stat.c
@@ -201,7 +201,7 @@ int nxffs_fstat(FAR const struct file *filep, FAR struct stat *buf)
   ret = nxmutex_lock(&volume->lock);
   if (ret != OK)
     {
-      ferr("ERROR: nxsem_wait failed: %d\n", ret);
+      ferr("ERROR: nxmutex_lock failed: %d\n", ret);
       return ret;
     }
 

--- a/fs/nxffs/nxffs_truncate.c
+++ b/fs/nxffs/nxffs_truncate.c
@@ -75,7 +75,7 @@ int nxffs_truncate(FAR struct file *filep, off_t length)
   ret = nxmutex_lock(&volume->lock);
   if (ret < 0)
     {
-      ferr("ERROR: nxsem_wait failed: %d\n", ret);
+      ferr("ERROR: nxmutex_lock failed: %d\n", ret);
       goto errout;
     }
 

--- a/fs/nxffs/nxffs_write.c
+++ b/fs/nxffs/nxffs_write.c
@@ -537,7 +537,7 @@ ssize_t nxffs_write(FAR struct file *filep, FAR const char *buffer,
   ret = nxmutex_lock(&volume->lock);
   if (ret < 0)
     {
-      ferr("ERROR: nxsem_wait failed: %d\n", ret);
+      ferr("ERROR: nxmutex_lock failed: %d\n", ret);
       goto errout;
     }
 


### PR DESCRIPTION
## Summary

change the comment only

## Impact

Minor

## Testing

CI