### PR TITLE
drivers/pipe: make pipe and named pipe (mkfifo) POSIX-compliant (blocking `open`)

### DIFF
--- a/drivers/pipes/pipe_common.h
+++ b/drivers/pipes/pipe_common.h
@@ -115,8 +115,10 @@ typedef uint8_t pipe_ndx_t;   /*  8-bit index */
 struct pipe_dev_s
 {
   mutex_t    d_bflock;      /* Used to serialize access to d_buffer and indices */
-  sem_t      d_rdsem;       /* Empty buffer - Reader waits for data write */
-  sem_t      d_wrsem;       /* Full buffer - Writer waits for data read */
+  sem_t      d_rdsem;       /* Empty buffer - Reader waits for data write AND
+                             * block O_RDONLY open until there is at least one writer */
+  sem_t      d_wrsem;       /* Full buffer - Writer waits for data read AND
+                             * block O_WRONLY open until there is at least one reader */
   pipe_ndx_t d_wrndx;       /* Index in d_buffer to save next byte written */
   pipe_ndx_t d_rdndx;       /* Index in d_buffer to return the next byte read */
   pipe_ndx_t d_bufsize;     /* allocated size of d_buffer in bytes */


### PR DESCRIPTION
## Summary

Nowadays, opening a FIFO for write-only (with `O_NONBLOCK` cleared) won't block even if there are no readers. Only opening for read-only (with no writers) would block. This is not a POSIX-compliant behavior. 

According to https://pubs.opengroup.org/onlinepubs/9699919799/functions/open.html

 > When opening a FIFO with O_RDONLY or O_WRONLY set:
 >  * If O_NONBLOCK is set, an open() for reading-only shall return without delay. An open() for writing-only shall return an error if no process currently has the file open for reading.
>
>  * If O_NONBLOCK is clear, an open() for reading-only shall block the calling thread until a thread opens the file for writing. An open() for writing-only shall block the calling thread until a thread opens the file for reading. 

This commit has an equivalent on nuttx-apps: `EXAMPLES_PIPE` app was updated to check pipes and named pipes behavior.

## Impact

It would be a _possible_ breaking change if any application was written specifically to expect an `open` for write-only (and `O_NONBLOCK` cleared, of course) to be non-blocking even if there are no readers. Being able to port POSIX-compliant applications that expect `open` to block when opening for write-only with no readers would enhance NuttX's objective of "to achieve a high degree of standards compliance. The primary governing standards are POSIX and ANSI standards". That is the case for [RTP Tools](https://github.com/apache/nuttx-apps/pull/1651), for instance.

## Testing

`sim:citest`, running [`pipe` app](https://github.com/apache/nuttx-apps/pull/1707) and [RTP Tools](https://github.com/apache/nuttx-apps/pull/1651) on  ESP32-LyraT v4.1 with `rtpdump`.
