### PR TITLE
fix note_drivers error

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -2009,7 +2009,7 @@ endmenu # Debug Options
 menuconfig  TRACE
 	bool "Enable tracepoints"
 	default n
-	depends on SCHED_INSTRUMENTATION
+	depends on SCHED_INSTRUMENTATION_DUMP
 	---help---
 		If this option is enabled, tracepoints at critical code in
 		the kernel will be enabled.

--- a/drivers/note/note_driver.c
+++ b/drivers/note/note_driver.c
@@ -467,7 +467,7 @@ static inline int note_isenabled_dump(uint32_t tag)
   /* If the dump trace is disabled, do nothing. */
 
   if (!(g_note_filter.mode.flag & NOTE_FILTER_MODE_FLAG_DUMP) ||
-      NOTE_FILTER_DUMPMASK_ISSET(tag, &g_note_filter.tag_mask))
+      NOTE_FILTER_TAGMASK_ISSET(tag, &g_note_filter.tag_mask))
     {
       return false;
     }
@@ -1876,7 +1876,7 @@ void sched_note_filter_irq(FAR struct note_filter_irq_s *oldf,
  * Name: sched_note_filter_tag
  *
  * Description:
- *   Set and get tsg filter setting
+ *   Set and get tag filter setting
  *   (Same as NOTECTL_GETDUMPFILTER / NOTECTL_SETDUMPFILTER ioctls)
  *
  * Input Parameters:
@@ -1893,8 +1893,8 @@ void sched_note_filter_irq(FAR struct note_filter_irq_s *oldf,
  ****************************************************************************/
 
 #  ifdef CONFIG_SCHED_INSTRUMENTATION_DUMP
-void sched_note_filter_dump(FAR struct note_filter_tag_s *oldf,
-                            FAR struct note_filter_tag_s *newf)
+void sched_note_filter_tag(FAR struct note_filter_tag_s *oldf,
+                           FAR struct note_filter_tag_s *newf)
 {
   irqstate_t falgs;
 

--- a/include/nuttx/sched_note.h
+++ b/include/nuttx/sched_note.h
@@ -109,13 +109,13 @@
 /* Helper macros for dump instrumentation filter */
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_DUMP
-#  define NOTE_FILTER_DUMPMASK_SET(tag, s) \
+#  define NOTE_FILTER_TAGMASK_SET(tag, s) \
   ((s)->tag_mask[(tag) / 8] |= (1 << ((tag) % 8)))
-#  define NOTE_FILTER_DUMPMASK_CLR(tag, s) \
+#  define NOTE_FILTER_TAGMASK_CLR(tag, s) \
   ((s)->tag_mask[(tag) / 8] &= ~(1 << ((tag) % 8)))
-#  define NOTE_FILTER_DUMPMASK_ISSET(tag, s) \
+#  define NOTE_FILTER_TAGMASK_ISSET(tag, s) \
   ((s)->tag_mask[(tag) / 8] & (1 << ((tag) % 8)))
-#  define NOTE_FILTER_DUMPMASK_ZERO(s) \
+#  define NOTE_FILTER_TAGMASK_ZERO(s) \
   memset((s), 0, sizeof(struct note_filter_tag_s));
 #endif
 
@@ -686,7 +686,7 @@ void sched_note_filter_irq(FAR struct note_filter_irq_s *oldf,
 #endif
 
 #if defined(CONFIG_SCHED_INSTRUMENTATION_FILTER) && \
-    defined(CONFIG_SCHED_INSTRUMENTATION_IRQHANDLER)
+    defined(CONFIG_SCHED_INSTRUMENTATION_DUMP)
 void sched_note_filter_tag(FAR struct note_filter_tag_s *oldf,
                            FAR struct note_filter_tag_s *newf);
 #endif

--- a/include/nuttx/trace.h
+++ b/include/nuttx/trace.h
@@ -32,8 +32,8 @@
  ****************************************************************************/
 
 #ifdef CONFIG_TRACE
-#  define trace_begin(tag) SCHED_NOTE_BEGIN(tag)
-#  define trace_end(tag) SCHED_NOTE_END(tag)
+#  define trace_begin(tag) sched_note_begin(tag)
+#  define trace_end(tag) sched_note_end(tag)
 #else
 #  define trace_begin(tag)
 #  define trace_end(tag)


### PR DESCRIPTION
## Summary
patch 1: replace SCHED_NOTE_BEGIN to sched_note_begin
patch 2: replace sched_note_filter_dump to sched_note_filter_tag 

## Impact

## Testing

