### PR TITLE
fix copy-paste errors for d356ad633f

### DIFF
--- a/arch/arm/src/efm32/efm32_usbdev.c
+++ b/arch/arm/src/efm32/efm32_usbdev.c
@@ -1341,7 +1341,7 @@ static void efm32_epin_request(struct efm32_usbdev_s *priv,
            * request. If not, raise an assertion here.
            */
 
-          regval = emf32_putreg(regval, EMF32_USB_DIEPTXF(privep->epphy));
+          regval = efm32_getreg(EFM32_USB_DIEPTXF(privep->epphy));
           regval &= _USB_DIEPTXF1_INEPNTXFDEP_MASK;
           regval >>= _USB_DIEPTXF1_INEPNTXFDEP_SHIFT;
           uerr("EP%" PRId8 " TXLEN=%" PRId32 " nwords=%d\n",

--- a/arch/arm/src/stm32/stm32_otgfsdev.c
+++ b/arch/arm/src/stm32/stm32_otgfsdev.c
@@ -1383,7 +1383,7 @@ static void stm32_epin_request(struct stm32_usbdev_s *priv,
            * request. If not, raise an assertion here.
            */
 
-          regval = stm32_putreg(regval, STM32_OTGFS_DIEPTXF(privep->epphy));
+          regval = stm32_getreg(STM32_OTGFS_DIEPTXF(privep->epphy));
           regval &= OTGFS_DIEPTXF_INEPTXFD_MASK;
           regval >>= OTGFS_DIEPTXF_INEPTXFD_SHIFT;
           uerr("EP%" PRId8 " TXLEN=%" PRId32 " nwords=%d\n",

--- a/arch/arm/src/stm32/stm32_otghsdev.c
+++ b/arch/arm/src/stm32/stm32_otghsdev.c
@@ -1333,7 +1333,7 @@ static void stm32_epin_request(struct stm32_usbdev_s *priv,
            * request. If not, raise an assertion here.
            */
 
-          regval = stm32_putreg(regval, STM32_OTGHS_DIEPTXF(privep->epphy));
+          regval = stm32_getreg(STM32_OTGHS_DIEPTXF(privep->epphy));
           regval &= OTGHS_DIEPTXF_INEPTXFD_MASK;
           regval >>= OTGHS_DIEPTXF_INEPTXFD_SHIFT;
           uerr("EP%" PRId8 " TXLEN=%" PRId32 " nwords=%d\n",

--- a/arch/arm/src/stm32f7/stm32_otgdev.c
+++ b/arch/arm/src/stm32f7/stm32_otgdev.c
@@ -1443,7 +1443,7 @@ static void stm32_epin_request(struct stm32_usbdev_s *priv,
            * request. If not, raise an assertion here.
            */
 
-          regval = stm32_putreg(regval, STM32_OTG_DIEPTXF(privep->epphy));
+          regval = stm32_getreg(STM32_OTG_DIEPTXF(privep->epphy));
           regval &= OTG_DIEPTXF_INEPTXFD_MASK;
           regval >>= OTG_DIEPTXF_INEPTXFD_SHIFT;
           uerr("EP%" PRId8 " TXLEN=%" PRId32 " nwords=%d\n",

--- a/arch/arm/src/stm32h7/stm32_otgdev.c
+++ b/arch/arm/src/stm32h7/stm32_otgdev.c
@@ -1406,7 +1406,7 @@ static void stm32_epin_request(struct stm32_usbdev_s *priv,
            * request. If not, raise an assertion here.
            */
 
-          regval = stm32_putreg(regval, STM32_OTG_DIEPTXF(privep->epphy));
+          regval = stm32_getreg(STM32_OTG_DIEPTXF(privep->epphy));
           regval &= OTG_DIEPTXF_INEPTXFD_MASK;
           regval >>= OTG_DIEPTXF_INEPTXFD_SHIFT;
           uerr("EP%" PRId8 " TXLEN=%" PRId32 " nwords=%d\n",

--- a/arch/arm/src/stm32l4/stm32l4_otgfsdev.c
+++ b/arch/arm/src/stm32l4/stm32l4_otgfsdev.c
@@ -1443,8 +1443,7 @@ static void stm32l4_epin_request(struct stm32l4_usbdev_s *priv,
            * request. If not, raise an assertion here.
            */
 
-          regval = stm32l4_putreg(regval,
-                                  STM32L4_OTG_DIEPTXF(privep->epphy));
+          regval = stm32l4_getreg(STM32L4_OTG_DIEPTXF(privep->epphy));
           regval &= OTGFS_DIEPTXF_INEPTXFD_MASK;
           regval >>= OTGFS_DIEPTXF_INEPTXFD_SHIFT;
           uerr("EP%" PRId8 " TXLEN=%" PRId32 " nwords=%d\n",


### PR DESCRIPTION
## Summary
fix copy-paste errors for d356ad633f
## Impact

## Testing
one configuration from a given arch with debug options enabled. CI can't catch the debug-related errors