### PR TITLE
Arm64/arm64 pmu supported

### DIFF
--- a/arch/arm/src/armv7-a/arm_perf.c
+++ b/arch/arm/src/armv7-a/arm_perf.c
@@ -32,7 +32,7 @@
  * Private Data
  ****************************************************************************/
 
-static uint32_t g_cpu_freq;
+static unsigned long g_cpu_freq;
 
 /****************************************************************************
  * Public Functions
@@ -60,26 +60,26 @@ static uint32_t g_cpu_freq;
 
 void up_perf_init(void *arg)
 {
-  g_cpu_freq = (uint32_t)(uintptr_t)arg;
+  g_cpu_freq = (unsigned long)(uintptr_t)arg;
 
   cp15_pmu_uer(PMUER_UME);
   cp15_pmu_pmcr(PMCR_E);
   cp15_pmu_cesr(PMCESR_CCES);
 }
 
-uint32_t up_perf_getfreq(void)
+unsigned long up_perf_getfreq(void)
 {
   return g_cpu_freq;
 }
 
-uint32_t up_perf_gettime(void)
+unsigned long up_perf_gettime(void)
 {
   return cp15_pmu_rdccr();
 }
 
-void up_perf_convert(uint32_t elapsed, struct timespec *ts)
+void up_perf_convert(unsigned long elapsed, struct timespec *ts)
 {
-  uint32_t left;
+  unsigned long left;
 
   ts->tv_sec  = elapsed / g_cpu_freq;
   left        = elapsed - ts->tv_sec * g_cpu_freq;

--- a/arch/arm/src/armv7-m/arm_perf.c
+++ b/arch/arm/src/armv7-m/arm_perf.c
@@ -34,7 +34,7 @@
  * Private Data
  ****************************************************************************/
 
-static uint32_t g_cpu_freq;
+static unsigned long g_cpu_freq;
 
 /****************************************************************************
  * Public Functions
@@ -42,7 +42,7 @@ static uint32_t g_cpu_freq;
 
 void up_perf_init(void *arg)
 {
-  g_cpu_freq = (uint32_t)(uintptr_t)arg;
+  g_cpu_freq = (unsigned long)(uintptr_t)arg;
 
   /* Enable ITM and DWT resources, if not left enabled by debugger. */
 
@@ -56,19 +56,19 @@ void up_perf_init(void *arg)
   modifyreg32(DWT_CTRL, 0, DWT_CTRL_CYCCNTENA_MASK);
 }
 
-uint32_t up_perf_getfreq(void)
+unsigned long up_perf_getfreq(void)
 {
   return g_cpu_freq;
 }
 
-uint32_t up_perf_gettime(void)
+unsigned long up_perf_gettime(void)
 {
   return getreg32(DWT_CYCCNT);
 }
 
-void up_perf_convert(uint32_t elapsed, struct timespec *ts)
+void up_perf_convert(unsigned long elapsed, struct timespec *ts)
 {
-  uint32_t left;
+  unsigned long left;
 
   ts->tv_sec  = elapsed / g_cpu_freq;
   left        = elapsed - ts->tv_sec * g_cpu_freq;

--- a/arch/arm/src/armv7-r/arm_perf.c
+++ b/arch/arm/src/armv7-r/arm_perf.c
@@ -32,7 +32,7 @@
  * Private Data
  ****************************************************************************/
 
-static uint32_t g_cpu_freq;
+static unsigned long g_cpu_freq;
 
 /****************************************************************************
  * Public Functions
@@ -60,26 +60,26 @@ static uint32_t g_cpu_freq;
 
 void up_perf_init(void *arg)
 {
-  g_cpu_freq = (uint32_t)(uintptr_t)arg;
+  g_cpu_freq = (unsigned long)(uintptr_t)arg;
 
   cp15_pmu_uer(PMUER_UME);
   cp15_pmu_pmcr(PMCR_E);
   cp15_pmu_cesr(PMCESR_CCES);
 }
 
-uint32_t up_perf_getfreq(void)
+unsigned long up_perf_getfreq(void)
 {
   return g_cpu_freq;
 }
 
-uint32_t up_perf_gettime(void)
+unsigned long up_perf_gettime(void)
 {
   return cp15_pmu_rdccr();
 }
 
-void up_perf_convert(uint32_t elapsed, struct timespec *ts)
+void up_perf_convert(unsigned long elapsed, struct timespec *ts)
 {
-  uint32_t left;
+  unsigned long left;
 
   ts->tv_sec  = elapsed / g_cpu_freq;
   left        = elapsed - ts->tv_sec * g_cpu_freq;

--- a/arch/arm64/Kconfig
+++ b/arch/arm64/Kconfig
@@ -49,6 +49,13 @@ config ARCH_CHIP_FVP_ARMV8R
 	select ARCH_CORTEX_R82
 	---help---
 		ARM FVP virt platform (ARMv8r)
+
+config ARCH_CHIP_ARM64_CUSTOM
+	bool "Custom ARM64 chip"
+	select ARCH_CHIP_CUSTOM
+	---help---
+		Select this option if there is no directory for the chip under arch/arm64/src/.
+
 endchoice
 
 config ARCH_ARMV8A

--- a/arch/arm64/src/common/Make.defs
+++ b/arch/arm64/src/common/Make.defs
@@ -48,6 +48,7 @@ CMN_CSRCS += arm64_releasestack.c arm64_stackframe.c arm64_usestack.c
 CMN_CSRCS += arm64_task_sched.c arm64_exit.c arm64_vfork.c arm64_switchcontext.c
 CMN_CSRCS += arm64_schedulesigaction.c arm64_sigdeliver.c
 CMN_CSRCS += arm64_backtrace.c arm64_getintstack.c arm64_registerdump.c
+CMN_CSRCS += arm64_perf.c
 
 # Common C source files ( hardware BSP )
 CMN_CSRCS += arm64_arch_timer.c arm64_cache.c

--- a/arch/arm64/src/common/arm64_boot.c
+++ b/arch/arm64/src/common/arm64_boot.c
@@ -193,5 +193,6 @@ void arm64_boot_primary_c_routine(void)
 {
   boot_early_memset(_START_BSS, 0, _END_BSS - _START_BSS);
   arm64_chip_boot();
+  up_perf_init(NULL);
   nx_start();
 }

--- a/arch/arm64/src/common/arm64_cpustart.c
+++ b/arch/arm64/src/common/arm64_cpustart.c
@@ -268,6 +268,8 @@ void arm64_boot_secondary_c_routine(void)
 
   arm64_gic_secondary_init();
 
+  up_perf_init(NULL);
+
   up_enable_irq(SGI_CPU_PAUSE);
 
   func  = cpu_boot_params.func;

--- a/arch/arm64/src/common/arm64_pmu.h
+++ b/arch/arm64/src/common/arm64_pmu.h
@@ -1,0 +1,235 @@
+/****************************************************************************
+ * arch/arm64/src/common/arm64_pmu.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM64_SRC_COMMON_ARM64_PMU_H
+#define __ARCH_ARM64_SRC_COMMON_ARM64_PMU_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include "arm64_arch.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* PMCCFILTR_EL0 */
+
+#define PMCCFILTR_EL0_P          (1ul << 31)  /* Privileged filtering bit */
+#define PMCCFILTR_EL0_U          (1ul << 30)  /* User filtering bit */
+#define PMCCFILTR_EL0_NSK        (1ul << 29)  /* Non-secure EL1 (kernel) modes filtering bit */
+#define PMCCFILTR_EL0_NSU        (1ul << 28)  /* Non-secure EL0 (Unprivileged) filtering */
+#define PMCCFILTR_EL0_NSH        (1ul << 27)  /* Non-secure EL2 (Hypervisor) filtering bit */
+#define PMCCFILTR_EL0_M          (1ul << 26)  /* Secure EL3 filtering bit */
+
+/* PMCNTENCLR_EL0 */
+
+#define PMCNTENCLR_EL0_C         (1ul << 31)  /* PMCCNTR_EL0 disable bit */
+
+/* PMINTENCLR_EL1 */
+
+#define PMINTENCLR_EL1_C         (1ul << 31)  /* PMCCNTR_EL0 overflow interrupt request disable bit */
+
+/* PMCNTENSET_EL0 */
+
+#define PMCNTENSET_EL0_C         (1ul << 31)  /* Enables the cycle counter register */
+
+/* PMCR_EL0 */
+
+#define PMCR_EL0_LC              (1ul << 6)   /* Long cycle counter enable */
+#define PMCR_EL0_DP              (1ul << 5)   /* Disable cycle counter when event counting is prohibited */
+#define PMCR_EL0_X               (1ul << 4)   /* Enable export of events */
+#define PMCR_EL0_D               (1ul << 3)   /* Clock divider */
+#define PMCR_EL0_C               (1ul << 2)   /* Cycle counter reset */
+#define PMCR_EL0_P               (1ul << 1)   /* Event counter reset */
+#define PMCR_EL0_E               (1ul << 0)   /* All counters that are accessible at Non-secure EL1 are enabled by PMCNTENSET_EL0 */
+
+/* PMINTENCLR_EL1 */
+
+#define PMINTENCLR_EL1_C         (1ul << 31)  /* PMCCNTR_EL0 overflow interrupt request disable bit */
+
+/* PMINTENSET_EL1 */
+
+#define PMINTENSET_EL1_C         (1ul << 31)  /* PMCCNTR_EL0 overflow interrupt request enable bit */
+
+/* PMOVSCLR_EL0 */
+
+#define PMOVSCLR_EL0_C           (1ul << 31)  /* PMCCNTR_EL0 overflow bit */
+
+/* PMSELR_EL0 */
+
+#define PMSELR_EL0_SEL_C         (0x1ful << 0) /* When PMSELR_EL0.SEL is 0b11111, it selects the cycle counter */
+
+/* PMUSERENR_EL0 */
+
+#define PMUSERENR_EL0_ER         (1ul << 3)    /* Event counter read trap control */
+#define PMUSERENR_EL0_CR         (1ul << 2)    /* Cycle counter read trap control */
+#define PMUSERENR_EL0_SW         (1ul << 1)    /* Software Increment write trap control */
+#define PMUSERENR_EL0_EN         (1ul << 0)    /* Software can access all PMU registers at EL0 */
+
+/****************************************************************************
+ * Inline Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: pmu_get_ccntr
+ *
+ * Description:
+ *   Read cycle counter.
+ *
+ * Return Value:
+ *   Cycle count.
+ *
+ ****************************************************************************/
+
+static inline uint64_t pmu_get_ccntr(void)
+{
+  return read_sysreg(pmccntr_el0);
+}
+
+/****************************************************************************
+ * Name: pmu_ccntr_ccfiltr_config
+ *
+ * Description:
+ *   Determines the modes in which the Cycle Counter.
+ *
+ * Parameters:
+ *   mask - Filter flags for Cycle Counters.
+ *
+ ****************************************************************************/
+
+static inline void pmu_ccntr_ccfiltr_config(uint64_t mask)
+{
+  write_sysreg(mask, pmccfiltr_el0);
+}
+
+/****************************************************************************
+ * Name: pmu_cntr_select
+ *
+ * Description:
+ *   Selects the current event counter or the cycle counter.
+ *
+ * Parameters:
+ *   mask - Select counter flag.
+ *
+ ****************************************************************************/
+
+static inline void pmu_cntr_select(uint64_t mask)
+{
+  write_sysreg(mask, pmselr_el0);
+}
+
+/****************************************************************************
+ * Name: pmu_cntr_trap_control
+ *
+ * Description:
+ *   Enables or disables EL0 access to the Performance Monitors.
+ *
+ * Parameters:
+ *   mask - traped caused by operate counters through mask bit control
+ *
+ ****************************************************************************/
+
+static inline void pmu_cntr_trap_control(uint64_t mask)
+{
+  write_sysreg(mask, pmuserenr_el0);
+}
+
+/****************************************************************************
+ * Name: pmu_cntr_control_config
+ *
+ * Description:
+ *   Config counters.
+ *
+ * Parameters:
+ *   mask - Configuration flags for counters.
+ *
+ ****************************************************************************/
+
+static inline void pmu_cntr_control_config(uint64_t mask)
+{
+  write_sysreg(mask, pmcr_el0);
+}
+
+/****************************************************************************
+ * Name: pmu_cntr_enable
+ *
+ * Description:
+ *   Enable counters.
+ *
+ * Parameters:
+ *   mask - Counters to enable.
+ *
+ * Note:
+ *   Enables one or more of the following:
+ *     event counters (0-30)
+ *     cycle counter
+ *
+ ****************************************************************************/
+
+static inline void pmu_cntr_enable(uint64_t mask)
+{
+  write_sysreg(mask, pmcntenset_el0);
+}
+
+/****************************************************************************
+ * Name: pmu_cntr_irq_enable
+ *
+ * Description:
+ *   Enable counter overflow interrupt request.
+ *
+ * Parameters:
+ *   mask - Counter overflow interrupt request bits to set.
+ *
+ * Note:
+ *   Sets overflow interrupt request bits for one or more of the following:
+ *     event counters (0-30)
+ *     cycle counter
+ *
+ ****************************************************************************/
+
+static inline void pmu_cntr_irq_enable(uint64_t mask)
+{
+  write_sysreg(mask, pmintenset_el1);
+}
+
+/****************************************************************************
+ * Name: pmu_cntr_irq_disable
+ *
+ * Description:
+ *   Disable counter overflow interrupt request.
+ *
+ * Parameters:
+ *   mask - Counter overflow interrupt request bits to clear.
+ *
+ * Note:
+ *   Sets overflow interrupt request bits for one or more of the following:
+ *     event counters (0-30)
+ *     cycle counter
+ *
+ ****************************************************************************/
+
+static inline void pmu_cntr_irq_disable(uint64_t mask)
+{
+  write_sysreg(mask, pmintenclr_el1);
+}
+
+#endif /* __ARCH_ARM64_SRC_COMMON_ARM64_PMU_H */

--- a/arch/risc-v/src/esp32c3/esp32c3_perf.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_perf.c
@@ -58,7 +58,7 @@ void up_perf_init(void *arg)
  * Name: up_perf_gettime
  ****************************************************************************/
 
-uint32_t IRAM_ATTR up_perf_gettime(void)
+unsigned long IRAM_ATTR up_perf_gettime(void)
 {
   return READ_CSR(CSR_PCCR_MACHINE);
 }
@@ -67,7 +67,7 @@ uint32_t IRAM_ATTR up_perf_gettime(void)
  * Name: up_perf_getfreq
  ****************************************************************************/
 
-uint32_t up_perf_getfreq(void)
+unsigned long up_perf_getfreq(void)
 {
   return CYCLE_PER_SEC;
 }
@@ -76,9 +76,9 @@ uint32_t up_perf_getfreq(void)
  * Name: up_perf_convert
  ****************************************************************************/
 
-void up_perf_convert(uint32_t elapsed, struct timespec *ts)
+void up_perf_convert(unsigned long elapsed, struct timespec *ts)
 {
   ts->tv_sec  = elapsed / CYCLE_PER_SEC;
-  elapsed    -= (uint64_t)ts->tv_sec * CYCLE_PER_SEC;
+  elapsed    -= ts->tv_sec * CYCLE_PER_SEC;
   ts->tv_nsec = elapsed * NSEC_PER_CYCLE;
 }

--- a/arch/xtensa/src/common/xtensa_perf.c
+++ b/arch/xtensa/src/common/xtensa_perf.c
@@ -32,7 +32,7 @@
  * Private Data
  ****************************************************************************/
 
-static uint32_t g_cpu_freq;
+static unsigned long g_cpu_freq;
 
 /****************************************************************************
  * Public Functions
@@ -40,22 +40,22 @@ static uint32_t g_cpu_freq;
 
 void up_perf_init(void *arg)
 {
-  g_cpu_freq = (uint32_t)(uintptr_t)arg;
+  g_cpu_freq = (unsigned long)(uintptr_t)arg;
 }
 
-uint32_t up_perf_getfreq(void)
+unsigned long up_perf_getfreq(void)
 {
   return g_cpu_freq;
 }
 
-uint32_t up_perf_gettime(void)
+unsigned long up_perf_gettime(void)
 {
   return xtensa_getcount();
 }
 
-void up_perf_convert(uint32_t elapsed, struct timespec *ts)
+void up_perf_convert(unsigned long elapsed, struct timespec *ts)
 {
-  uint32_t left;
+  unsigned long left;
 
   ts->tv_sec  = elapsed / g_cpu_freq;
   left        = elapsed - ts->tv_sec * g_cpu_freq;

--- a/drivers/note/notesnap_driver.c
+++ b/drivers/note/notesnap_driver.c
@@ -42,7 +42,7 @@ struct notesnap_chunk_s
 #endif
   pid_t pid;
 #ifdef CONFIG_SCHED_INSTRUMENTATION_PERFCOUNT
-  uint32_t count;
+  unsigned long count;
 #else
   struct timespec time;
 #endif
@@ -399,7 +399,7 @@ void notesnap_dump_with_stream(FAR struct lib_outstream_s *stream)
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_PERFCOUNT
       struct timespec time;
-      uint32_t elapsed = note->count < lastcount ?
+      unsigned long elapsed = note->count < lastcount ?
                          note->count + UINT32_MAX - lastcount :
                          note->count - lastcount;
       up_perf_convert(elapsed, &time);

--- a/drivers/rptun/rptun_ping.c
+++ b/drivers/rptun/rptun_ping.c
@@ -121,7 +121,7 @@ static int rptun_ping_once(FAR struct rpmsg_endpoint *ept,
   return ret;
 }
 
-static void rptun_ping_logout(FAR const char *s, uint32_t value)
+static void rptun_ping_logout(FAR const char *s, unsigned long value)
 {
   struct timespec ts;
 
@@ -141,8 +141,8 @@ static void rptun_ping_logout(FAR const char *s, uint32_t value)
 int rptun_ping(FAR struct rpmsg_endpoint *ept,
                FAR const struct rptun_ping_s *ping)
 {
-  uint32_t min = UINT32_MAX;
-  uint32_t max = 0;
+  unsigned long min = ULONG_MAX;
+  unsigned long max = 0;
   uint64_t total = 0;
   int i;
 
@@ -153,7 +153,7 @@ int rptun_ping(FAR struct rpmsg_endpoint *ept,
 
   for (i = 0; i < ping->times; i++)
     {
-      uint32_t tm = up_perf_gettime();
+      unsigned long tm = up_perf_gettime();
 
       int ret = rptun_ping_once(ept, ping->len, ping->ack);
       if (ret < 0)
@@ -169,7 +169,7 @@ int rptun_ping(FAR struct rpmsg_endpoint *ept,
       usleep(ping->sleep * USEC_PER_MSEC);
     }
 
-  syslog(LOG_INFO, "current CPU freq: %" PRIu32 ", ping times: %d\n",
+  syslog(LOG_INFO, "current CPU freq: %lu, ping times: %d\n",
                     up_perf_getfreq(), ping->times);
 
   rptun_ping_logout("avg", total / ping->times);

--- a/drivers/segger/config/SEGGER_SYSVIEW_Conf.h
+++ b/drivers/segger/config/SEGGER_SYSVIEW_Conf.h
@@ -73,7 +73,7 @@ extern "C"
  ****************************************************************************/
 
 unsigned int note_sysview_get_interrupt_id(void);
-unsigned int note_sysview_get_timestamp(void);
+unsigned long note_sysview_get_timestamp(void);
 
 #undef EXTERN
 #if defined(__cplusplus)

--- a/drivers/segger/note_sysview.c
+++ b/drivers/segger/note_sysview.c
@@ -348,7 +348,7 @@ unsigned int note_sysview_get_interrupt_id(void)
  *
  ****************************************************************************/
 
-unsigned int note_sysview_get_timestamp(void)
+unsigned long note_sysview_get_timestamp(void)
 {
   return up_perf_gettime();
 }
@@ -369,7 +369,7 @@ unsigned int note_sysview_get_timestamp(void)
 
 int note_sysview_initialize(void)
 {
-  uint32_t freq = up_perf_getfreq();
+  unsigned long freq = up_perf_getfreq();
 
   static const SEGGER_SYSVIEW_OS_API g_sysview_trace_api =
     {

--- a/drivers/timers/arch_alarm.c
+++ b/drivers/timers/arch_alarm.c
@@ -356,9 +356,9 @@ int weak_function up_alarm_tick_start(clock_t ticks)
  *   units.
  ****************************************************************************/
 
-uint32_t weak_function up_perf_gettime(void)
+unsigned long weak_function up_perf_gettime(void)
 {
-  uint32_t ret = 0;
+  unsigned long ret = 0;
 
   if (g_oneshot_lower != NULL)
     {
@@ -371,12 +371,13 @@ uint32_t weak_function up_perf_gettime(void)
   return ret;
 }
 
-uint32_t weak_function up_perf_getfreq(void)
+unsigned long weak_function up_perf_getfreq(void)
 {
   return USEC_PER_SEC;
 }
 
-void weak_function up_perf_convert(uint32_t elapsed, FAR struct timespec *ts)
+void weak_function up_perf_convert(unsigned long elapsed,
+                                   FAR struct timespec *ts)
 {
   timespec_from_usec(ts, elapsed);
 }

--- a/drivers/timers/arch_timer.c
+++ b/drivers/timers/arch_timer.c
@@ -395,9 +395,9 @@ int weak_function up_timer_tick_start(clock_t ticks)
  *   units.
  ****************************************************************************/
 
-uint32_t weak_function up_perf_gettime(void)
+unsigned long weak_function up_perf_gettime(void)
 {
-  uint32_t ret = 0;
+  unsigned long ret = 0;
 
   if (g_timer.lower != NULL)
     {
@@ -407,12 +407,13 @@ uint32_t weak_function up_perf_gettime(void)
   return ret;
 }
 
-uint32_t weak_function up_perf_getfreq(void)
+unsigned long weak_function up_perf_getfreq(void)
 {
   return USEC_PER_SEC;
 }
 
-void weak_function up_perf_convert(uint32_t elapsed, FAR struct timespec *ts)
+void weak_function up_perf_convert(unsigned long elapsed,
+                                   FAR struct timespec *ts)
 {
   timespec_from_usec(ts, elapsed);
 }

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -2526,9 +2526,9 @@ void arch_sporadic_resume(FAR struct tcb_s *tcb);
  ****************************************************************************/
 
 void up_perf_init(FAR void *arg);
-uint32_t up_perf_gettime(void);
-uint32_t up_perf_getfreq(void);
-void up_perf_convert(uint32_t elapsed, FAR struct timespec *ts);
+unsigned long up_perf_gettime(void);
+unsigned long up_perf_getfreq(void);
+void up_perf_convert(unsigned long elapsed, FAR struct timespec *ts);
 
 /****************************************************************************
  * Name: up_saveusercontext

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -633,12 +633,12 @@ struct tcb_s
   /* Pre-emption monitor support ********************************************/
 
 #ifdef CONFIG_SCHED_CRITMONITOR
-  uint32_t premp_start;                  /* Time when preemption disabled   */
-  uint32_t premp_max;                    /* Max time preemption disabled    */
-  uint32_t crit_start;                   /* Time critical section entered   */
-  uint32_t crit_max;                     /* Max time in critical section    */
-  uint32_t run_start;                    /* Time when thread begin run      */
-  uint32_t run_max;                      /* Max time thread run             */
+  unsigned long premp_start;             /* Time when preemption disabled   */
+  unsigned long premp_max;               /* Max time preemption disabled    */
+  unsigned long crit_start;              /* Time critical section entered   */
+  unsigned long crit_max;                /* Max time in critical section    */
+  unsigned long run_start;               /* Time when thread begin run      */
+  unsigned long run_max;                 /* Max time thread run             */
 #endif
 
   /* State save areas *******************************************************/
@@ -762,8 +762,8 @@ extern "C"
 #ifdef CONFIG_SCHED_CRITMONITOR
 /* Maximum time with pre-emption disabled or within critical section. */
 
-EXTERN uint32_t g_premp_max[CONFIG_SMP_NCPUS];
-EXTERN uint32_t g_crit_max[CONFIG_SMP_NCPUS];
+EXTERN unsigned long g_premp_max[CONFIG_SMP_NCPUS];
+EXTERN unsigned long g_crit_max[CONFIG_SMP_NCPUS];
 #endif /* CONFIG_SCHED_CRITMONITOR */
 
 #ifdef CONFIG_DEBUG_TCBINFO

--- a/sched/irq/irq_dispatch.c
+++ b/sched/irq/irq_dispatch.c
@@ -81,8 +81,8 @@
      do \
        { \
          struct timespec delta; \
-         uint32_t start; \
-         uint32_t elapsed; \
+         unsigned long start; \
+         unsigned long elapsed; \
          start = up_perf_gettime(); \
          vector(irq, context, arg); \
          elapsed = up_perf_gettime() - start; \
@@ -98,7 +98,7 @@
          if (CONFIG_SCHED_CRITMONITOR_MAXTIME_IRQ > 0 && \
              elapsed > CONFIG_SCHED_CRITMONITOR_MAXTIME_IRQ) \
            { \
-             serr("IRQ %d(%p), execute time too long %"PRIu32"\n", \
+             serr("IRQ %d(%p), execute time too long %lu\n", \
                   irq, vector, elapsed); \
            } \
        } \

--- a/sched/sched/sched_critmonitor.c
+++ b/sched/sched/sched_critmonitor.c
@@ -103,8 +103,8 @@
 
 /* Start time when pre-emption disabled or critical section entered. */
 
-static uint32_t g_premp_start[CONFIG_SMP_NCPUS];
-static uint32_t g_crit_start[CONFIG_SMP_NCPUS];
+static unsigned long g_premp_start[CONFIG_SMP_NCPUS];
+static unsigned long g_crit_start[CONFIG_SMP_NCPUS];
 
 /****************************************************************************
  * Public Data
@@ -112,8 +112,8 @@ static uint32_t g_crit_start[CONFIG_SMP_NCPUS];
 
 /* Maximum time with pre-emption disabled or within critical section. */
 
-uint32_t g_premp_max[CONFIG_SMP_NCPUS];
-uint32_t g_crit_max[CONFIG_SMP_NCPUS];
+unsigned long g_premp_max[CONFIG_SMP_NCPUS];
+unsigned long g_crit_max[CONFIG_SMP_NCPUS];
 
 /****************************************************************************
  * Public Functions
@@ -148,8 +148,8 @@ void nxsched_critmon_preemption(FAR struct tcb_s *tcb, bool state)
     {
       /* Re-enabling.. Check for the max elapsed time */
 
-      uint32_t now     = up_perf_gettime();
-      uint32_t elapsed = now - tcb->premp_start;
+      unsigned long now     = up_perf_gettime();
+      unsigned long elapsed = now - tcb->premp_start;
 
       if (elapsed > tcb->premp_max)
         {
@@ -196,8 +196,8 @@ void nxsched_critmon_csection(FAR struct tcb_s *tcb, bool state)
     {
       /* Leaving .. Check for the max elapsed time */
 
-      uint32_t now     = up_perf_gettime();
-      uint32_t elapsed = now - tcb->crit_start;
+      unsigned long now     = up_perf_gettime();
+      unsigned long elapsed = now - tcb->crit_start;
 
       if (elapsed > tcb->crit_max)
         {
@@ -230,9 +230,9 @@ void nxsched_critmon_csection(FAR struct tcb_s *tcb, bool state)
 
 void nxsched_resume_critmon(FAR struct tcb_s *tcb)
 {
-  uint32_t current = up_perf_gettime();
+  unsigned long current = up_perf_gettime();
   int cpu = this_cpu();
-  uint32_t elapsed;
+  unsigned long elapsed;
 
   tcb->run_start = current;
 
@@ -294,8 +294,8 @@ void nxsched_resume_critmon(FAR struct tcb_s *tcb)
 
 void nxsched_suspend_critmon(FAR struct tcb_s *tcb)
 {
-  uint32_t current = up_perf_gettime();
-  uint32_t elapsed = current - tcb->run_start;
+  unsigned long current = up_perf_gettime();
+  unsigned long elapsed = current - tcb->run_start;
 
   if (elapsed > tcb->run_max)
     {

--- a/sched/wdog/wd_start.c
+++ b/sched/wdog/wd_start.c
@@ -52,14 +52,14 @@
 #  define CALL_FUNC(func, arg) \
      do \
        { \
-         uint32_t start; \
-         uint32_t elapsed; \
+         unsigned long start; \
+         unsigned long elapsed; \
          start = up_perf_gettime(); \
          func(arg); \
          elapsed = up_perf_gettime() - start; \
          if (elapsed > CONFIG_SCHED_CRITMONITOR_MAXTIME_WDOG) \
            { \
-             serr("WDOG %p, %s IRQ, execute too long %"PRIu32"\n", \
+             serr("WDOG %p, %s IRQ, execute too long %lu\n", \
                    func, up_interrupt_context() ? "IN" : "NOT", elapsed); \
            } \
        } \

--- a/sched/wqueue/kwork_thread.c
+++ b/sched/wqueue/kwork_thread.c
@@ -54,14 +54,14 @@
 #  define CALL_WORKER(worker, arg) \
      do \
        { \
-         uint32_t start; \
-         uint32_t elapsed; \
+         unsigned long start; \
+         unsigned long elapsed; \
          start = up_perf_gettime(); \
          worker(arg); \
          elapsed = up_perf_gettime() - start; \
          if (elapsed > CONFIG_SCHED_CRITMONITOR_MAXTIME_WQUEUE) \
            { \
-             serr("WORKER %p execute too long %"PRIu32"\n", \
+             serr("WORKER %p execute too long %lu\n", \
                    worker, elapsed); \
            } \
        } \


### PR DESCRIPTION
## Summary
1、Adds custom chip option for the ARM64.
2、Implement arm64 PMU api interface, and use PMU capability to implement perf interface.
## Impact
Code that affects the call perf interface.
## Testing
The test calls perf interface, works properly, and the ostest test passes.
