### PR TITLE
procfs: add total time running time of task

### DIFF
--- a/Documentation/applications/nsh/commands.rst
+++ b/Documentation/applications/nsh/commands.rst
@@ -703,6 +703,41 @@ attached interrupts.
    15 0000800d 00000000        817  100.000
    30 00000fd5 20000018         20    2.490
 
+.. _cmdcritmon:
+
+Show Critical Monitor Status (critmon)
+**************************************
+
+**Command Syntax**::
+
+  critmon
+
+**Synopsis**. Show the preemption time, critical section time,
+longest single run time, total run time, process ID (PID),
+and thread description of each thread in the system.
+
+**Example**::
+
+  nsh> critmon
+  PRE-EMPTION   CSECTION      RUN         TIME         PID   DESCRIPTION
+  0.010265000   0.000037000   ----------- ------------ ----  CPU 0
+  0.000000000   0.000000000   0.001237000 28.421047000 0     Idle Task
+  0.000011000   0.000037000   0.000046000 0.034211000  1     loop_task
+  0.000000000   0.000028000   0.000067000 0.236657000  2     hpwork
+
+In this example, the output shows the preemption time, critical section time,
+longest single run time, total run time, and thread description for each
+thread in the system.
+
+The output of the ``critmon`` command displays the following columns:
+
+- PRE-EMPTION: Preemption time
+- CSECTION: Critical section time
+- RUN: Longest single run time of the thread
+- TIME: Total run time of the thread
+- PID: Process ID of the thread
+- DESCRIPTION: Thread description (name)
+
 .. _cmdkill:
 
 Send a signal to a task (kill)

--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -762,6 +762,7 @@ static ssize_t proc_critmon(FAR struct proc_file_s *procfile,
                             size_t buflen, off_t offset)
 {
   struct timespec maxtime;
+  struct timespec runtime;
   size_t remaining;
   size_t linesize;
   size_t copysize;
@@ -851,12 +852,18 @@ static ssize_t proc_critmon(FAR struct proc_file_s *procfile,
   /* Reset the maximum */
 
   tcb->run_max = 0;
+  up_perf_convert(tcb->run_time, &runtime);
 
-  /* Generate output for maximum time thread running */
+  /* Output the maximum time the thread has run and
+   * the total time the thread has run
+   */
 
-  linesize = procfs_snprintf(procfile->line, STATUS_LINELEN, "%lu.%09lu\n",
+  linesize = procfs_snprintf(procfile->line, STATUS_LINELEN,
+                             "%lu.%09lu,%lu.%09lu\n",
                              (unsigned long)maxtime.tv_sec,
-                             (unsigned long)maxtime.tv_nsec);
+                             (unsigned long)maxtime.tv_nsec,
+                             (unsigned long)runtime.tv_sec,
+                             (unsigned long)(runtime.tv_nsec));
   copysize = procfs_memcpy(procfile->line, linesize, buffer, remaining,
                            &offset);
 

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -639,6 +639,7 @@ struct tcb_s
   unsigned long crit_max;                /* Max time in critical section    */
   unsigned long run_start;               /* Time when thread begin run      */
   unsigned long run_max;                 /* Max time thread run             */
+  unsigned long run_time;                /* Total time thread run           */
 #endif
 
   /* State save areas *******************************************************/

--- a/sched/sched/sched_critmonitor.c
+++ b/sched/sched/sched_critmonitor.c
@@ -297,6 +297,7 @@ void nxsched_suspend_critmon(FAR struct tcb_s *tcb)
   unsigned long current = up_perf_gettime();
   unsigned long elapsed = current - tcb->run_start;
 
+  tcb->run_time += elapsed;
   if (elapsed > tcb->run_max)
     {
       tcb->run_max = elapsed;


### PR DESCRIPTION
## Summary
add total time running time of task

```sh
  nsh> critmon
  PRE-EMPTION   CSECTION      RUN         TIME         PID   DESCRIPTION
  0.010265000   0.000037000   ----------- -----        ----  CPU 0
  0.000000000   0.000000000   0.001237000 28.421047000 0     Idle Task
  0.000011000   0.000037000   0.000046000 0.034211000  1     loop_task
  0.000000000   0.000028000   0.000067000 0.236657000  2     hpwork
```
## Impact

## Testing

