### PR TITLE
xtensa/esp32: Add support for universal mac addresses

### DIFF
--- a/arch/xtensa/src/esp32/Kconfig
+++ b/arch/xtensa/src/esp32/Kconfig
@@ -2167,6 +2167,45 @@ config ESP32_BLE_MAX_CONN
 
 endmenu # BLE Configuration
 
+choice ESP32_UNIVERSAL_MAC_ADDRESSES
+	bool "Number of universally administered (by IEEE) MAC addresses"
+	default ESP32_UNIVERSAL_MAC_ADDRESSES_FOUR
+	depends on ESP32_WIFI || ESP32_BLE
+	---help---
+		Configure the number of universally administered (by IEEE) MAC addresses.
+		During initialization, MAC addresses for each network interface are generated or derived from a
+		single base MAC address.
+		If the number of universal MAC addresses is four, all four interfaces (WiFi station, WiFi softap,
+		Bluetooth and Ethernet) receive a universally administered MAC address. These are generated
+		sequentially by adding 0, 1, 2 and 3 (respectively) to the final octet of the base MAC address.
+		If the number of universal MAC addresses is two, only two interfaces (WiFi station and Bluetooth)
+		receive a universally administered MAC address. These are generated sequentially by adding 0
+		and 1 (respectively) to the base MAC address. The remaining two interfaces (WiFi softap and Ethernet)
+		receive local MAC addresses. These are derived from the universal WiFi station and Bluetooth MAC
+		addresses, respectively.
+		When using the default (Espressif-assigned) base MAC address, either setting can be used. When using
+		a custom universal MAC address range, the correct setting will depend on the allocation of MAC
+		addresses in this range (either 2 or 4 per device.)
+
+config ESP32_UNIVERSAL_MAC_ADDRESSES_TWO
+	bool "Two"
+	select ESP_MAC_ADDR_UNIVERSE_WIFI_STA
+	select ESP_MAC_ADDR_UNIVERSE_BT
+
+config ESP32_UNIVERSAL_MAC_ADDRESSES_FOUR
+	bool "Four"
+	select ESP_MAC_ADDR_UNIVERSE_WIFI_STA
+	select ESP_MAC_ADDR_UNIVERSE_WIFI_AP
+	select ESP_MAC_ADDR_UNIVERSE_BT
+	select ESP_MAC_ADDR_UNIVERSE_ETH
+
+endchoice
+
+config ESP32_UNIVERSAL_MAC_ADDRESSES
+	int
+	default 2 if ESP32_UNIVERSAL_MAC_ADDRESSES_TWO
+	default 4 if ESP32_UNIVERSAL_MAC_ADDRESSES_FOUR
+
 menu "Real-Time Timer"
 	depends on ESP32_RT_TIMER
 

--- a/arch/xtensa/src/esp32/esp32_emac.c
+++ b/arch/xtensa/src/esp32/esp32_emac.c
@@ -470,6 +470,29 @@ static int emac_read_mac(uint8_t *mac)
       return -EINVAL;
     }
 
+#ifdef CONFIG_ESP_MAC_ADDR_UNIVERSE_ETH
+  mac[5] += 3;
+#else
+  mac[5] += 1;
+  uint8_t tmp = mac[0];
+  for (i = 0; i < 64; i++)
+    {
+      mac[0] = tmp | 0x02;
+      mac[0] ^= i << 2;
+
+      if (mac[0] != tmp)
+        {
+          break;
+        }
+    }
+
+  if (i >= 64)
+    {
+      wlerr("Failed to generate ethernet MAC\n");
+      return -1;
+    }
+#endif
+
   return 0;
 }
 

--- a/arch/xtensa/src/esp32/esp32_wireless.c
+++ b/arch/xtensa/src/esp32/esp32_wireless.c
@@ -37,6 +37,16 @@
 #include "phy_init_data.h"
 
 /****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifdef CONFIG_ESP32_UNIVERSAL_MAC_ADDRESSES_FOUR
+#  define MAC_ADDR_UNIVERSE_BT_OFFSET 2
+#else
+#  define MAC_ADDR_UNIVERSE_BT_OFFSET 1
+#endif
+
+/****************************************************************************
  * Private Function Prototypes
  ****************************************************************************/
 
@@ -296,7 +306,6 @@ void esp32_phy_disable_clock(void)
 int32_t esp_read_mac(uint8_t *mac, esp_mac_type_t type)
 {
   uint32_t regval[2];
-  uint8_t tmp;
   uint8_t *data = (uint8_t *)regval;
   uint8_t crc;
   int i;
@@ -324,7 +333,10 @@ int32_t esp_read_mac(uint8_t *mac, esp_mac_type_t type)
 
   if (type == ESP_MAC_WIFI_SOFTAP)
     {
-      tmp = mac[0];
+#ifdef CONFIG_ESP_MAC_ADDR_UNIVERSE_WIFI_AP
+      mac[5] += 1;
+#else
+      uint8_t tmp = mac[0];
       for (i = 0; i < 64; i++)
         {
           mac[0] = tmp | 0x02;
@@ -341,23 +353,14 @@ int32_t esp_read_mac(uint8_t *mac, esp_mac_type_t type)
           wlerr("Failed to generate SoftAP MAC\n");
           return -1;
         }
+#endif
     }
 
   if (type == ESP_MAC_BT)
     {
-      tmp = mac[0];
-      for (i = 0; i < 64; i++)
-        {
-          mac[0] = tmp | 0x02;
-          mac[0] ^= i << 2;
-
-          if (mac[0] != tmp)
-            {
-              break;
-            }
-        }
-
-      mac[5] += 1;
+#ifdef CONFIG_ESP_MAC_ADDR_UNIVERSE_BT
+      mac[5] += MAC_ADDR_UNIVERSE_BT_OFFSET;
+#endif
     }
 
   return 0;


### PR DESCRIPTION
## Summary

<p data-sourcepos="0:0-0:0" dir="auto">The MAC addresses for the various network interfaces are calculated from a single base MAC address. By default, the Espressif base MAC address is used. This base MAC address is pre-programmed into the ESP32 eFuse in the factory during production.</p>


Interface | MAC Address (4 universally administered, default) | MAC Address (2 universally administered)
-- | -- | --
Wi-Fi Station | base_mac | base_mac
Wi-Fi SoftAP | base_mac, +1 to the last octet | Local MAC (derived from Wi-Fi Station MAC)
Bluetooth | base_mac, +2 to the last octet | base_mac, +1 to the last octet
Ethernet | base_mac, +3 to the last octet | Local MAC (derived from Bluetooth MAC)


## Impact

- Provide universal mac addresses support on ESP32

## Testing

- Tested with ESP32-Devkitc, configure the number of universally administered (by IEEE) MAC addresses through `make menuconfig`