### PR TITLE
arch/arm64: fixed arm64 backtrace issue

### DIFF
--- a/arch/arm64/src/common/Make.defs
+++ b/arch/arm64/src/common/Make.defs
@@ -47,7 +47,7 @@ CMN_CSRCS += arm64_nputs.c arm64_idle.c arm64_copystate.c arm64_createstack.c
 CMN_CSRCS += arm64_releasestack.c arm64_stackframe.c arm64_usestack.c
 CMN_CSRCS += arm64_task_sched.c arm64_exit.c arm64_vfork.c arm64_switchcontext.c
 CMN_CSRCS += arm64_schedulesigaction.c arm64_sigdeliver.c
-CMN_CSRCS += arm64_backtrace.c arm64_getintstack.c arm64_registerdump.c
+CMN_CSRCS += arm64_getintstack.c arm64_registerdump.c
 CMN_CSRCS += arm64_perf.c
 
 # Common C source files ( hardware BSP )
@@ -114,4 +114,8 @@ endif
 
 ifeq ($(CONFIG_STACK_COLORATION),y)
 CMN_CSRCS += arm64_checkstack.c
+endif
+
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+CMN_CSRCS += arm64_backtrace.c
 endif

--- a/arch/arm64/src/common/arm64_backtrace.c
+++ b/arch/arm64/src/common/arm64_backtrace.c
@@ -53,14 +53,13 @@ static int backtrace(uintptr_t *base, uintptr_t *limit,
 
   if (pc)
     {
-      i++;
       if (*skip-- <= 0)
         {
-          *buffer++ = pc;
+          buffer[i++] = pc;
         }
     }
 
-  for (; i < size; fp = (uintptr_t *)*(fp - 1), i++)
+  for (; i < size; fp = (uintptr_t *)*fp)
     {
       if (fp > limit || fp < base || *fp == 0)
         {
@@ -69,7 +68,7 @@ static int backtrace(uintptr_t *base, uintptr_t *limit,
 
       if (*skip-- <= 0)
         {
-          *buffer++ = (void *)*fp;
+          buffer[i++] = (void *)*(fp + 1);
         }
     }
 

--- a/arch/arm64/src/common/arm64_backtrace.c
+++ b/arch/arm64/src/common/arm64_backtrace.c
@@ -53,7 +53,7 @@ static int backtrace(uintptr_t *base, uintptr_t *limit,
 
   if (pc)
     {
-      if (*skip-- <= 0)
+      if ((*skip)-- <= 0)
         {
           buffer[i++] = pc;
         }
@@ -66,7 +66,7 @@ static int backtrace(uintptr_t *base, uintptr_t *limit,
           break;
         }
 
-      if (*skip-- <= 0)
+      if ((*skip)-- <= 0)
         {
           buffer[i++] = (void *)*(fp + 1);
         }

--- a/arch/arm64/src/common/arm64_fatal.c
+++ b/arch/arm64/src/common/arm64_fatal.c
@@ -302,25 +302,6 @@ void up_mdelay(unsigned int milliseconds)
 }
 
 /****************************************************************************
- * Name: arm64_dump_fatal
- ****************************************************************************/
-
-void arm64_dump_fatal(struct regs_context *regs)
-{
-#ifdef CONFIG_SCHED_BACKTRACE
-  struct tcb_s *rtcb = (struct tcb_s *)regs->tpidr_el1;
-
-  /* Show back trace */
-
-  sched_dumpstack(rtcb->pid);
-#endif
-
-  /* Dump the registers */
-
-  up_dump_register(regs);
-}
-
-/****************************************************************************
  * Name: arm64_fatal_error
  *
  * Description:
@@ -330,10 +311,10 @@ void arm64_dump_fatal(struct regs_context *regs)
 void arm64_fatal_error(unsigned int reason, struct regs_context * reg)
 {
   uint64_t el, esr, elr, far;
-  int cpu = up_cpu_index();
 
   sinfo("reason = %d\n", reason);
-  sinfo("arm64_fatal_error: CPU%d task: %s\n", cpu, running_task()->name);
+
+  CURRENT_REGS = (uint64_t *)reg;
 
   if (reason != K_ERR_SPURIOUS_IRQ)
     {
@@ -391,13 +372,5 @@ void arm64_fatal_error(unsigned int reason, struct regs_context * reg)
         }
     }
 
-  if (reg != NULL)
-    {
-      arm64_dump_fatal(reg);
-    }
-
-  for (; ; )
-    {
-      up_mdelay(1000);
-    }
+  PANIC();
 }


### PR DESCRIPTION
## Summary

1.  Obtaining the correct fp pointer;
2.  Call PANIC in arm64_fatal_error;
3.  Fixed backtrace skip calc error;

## Impact

backtrace

## Testing

qemu-armv8a:nsh