### PR TITLE
tools/nxstyle: skip mixed case check for particular headers

### DIFF
--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -127,6 +127,7 @@ static int g_rangenumber        = 0;
 static int g_rangestart[RANGE_NUMBER];
 static int g_rangecount[RANGE_NUMBER];
 static char g_file_name[PATH_MAX];
+static bool g_skipmixedcase;
 
 static const struct file_section_s g_section_info[] =
 {
@@ -540,6 +541,12 @@ static const char *g_white_list[] =
   NULL
 };
 
+static const char *g_white_headers[] =
+{
+  "windows.h",
+  NULL
+};
+
 /********************************************************************************
  * Private Functions
  ********************************************************************************/
@@ -913,6 +920,16 @@ static bool white_list(const char *ident, int lineno)
     {
       len = strlen(str);
       if (strncmp(ident, str, len) == 0)
+        {
+          return true;
+        }
+    }
+
+  for (pptr = g_white_headers;
+       (str = *pptr) != NULL;
+       pptr++)
+    {
+      if (strstr(ident, str) != NULL)
         {
           return true;
         }
@@ -1487,6 +1504,10 @@ int main(int argc, char **argv, char **envp)
                                "section",
                                lineno, ii);
                         }
+                      else if (white_list(&line[ii], lineno))
+                        {
+                          g_skipmixedcase = true;
+                        }
                     }
                   else if (strncmp(&line[ii], "if", 2) == 0)
                     {
@@ -2023,7 +2044,8 @@ int main(int argc, char **argv, char **envp)
                 {
                   /* Ignore symbols that begin with white-listed prefixes */
 
-                  if (white_list(&line[ident_index], lineno))
+                  if (g_skipmixedcase ||
+                      white_list(&line[ident_index], lineno))
                     {
                       /* No error */
                     }


### PR DESCRIPTION

## Summary

tools/nxstyle: skip mixed case check for particular headers

Add header keywords into whitelist, skip the warning if the
particular headers will contain the functions with mixed case

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

./tools/checkpatch.sh with windows.h