### PR TITLE
drivers/mpu60x0 Fix the error when reset mpu60x0 in SPI case

### DIFF
--- a/drivers/sensors/mpu60x0.c
+++ b/drivers/sensors/mpu60x0.c
@@ -661,7 +661,7 @@ static int mpu_reset(FAR struct mpu_dev_s *dev)
   /* Awaken chip, issue hardware reset */
 
   ret = __mpu_write_pwr_mgmt_1(dev, PWR_MGMT_1__DEVICE_RESET);
-  if (ret != OK)
+  if (ret < 0)
     {
       nxmutex_unlock(&dev->lock);
       snerr("Could not find mpu60x0!\n");


### PR DESCRIPTION
## Summary
In SPI mpu60x0 case, call `__mpu_write_reg()` will return the write buffer length, rather than `OK` of I2C case, which will result `mpu_reset` give an error:`Could not find mpu60x0!` when call `__mpu_write_pwr_mgmt_1`
## Impact
mpu60x0 in SPI case
## Testing
ci
