### PR TITLE
fs/hostfs: align operation flags define with fcntl.h

### DIFF
--- a/include/nuttx/fs/hostfs.h
+++ b/include/nuttx/fs/hostfs.h
@@ -82,7 +82,7 @@
 #define NUTTX_O_TRUNC           (1 << 5)  /* Delete contents */
 #define NUTTX_O_NONBLOCK        (1 << 6)  /* Don't wait for data */
 #define NUTTX_O_SYNC            (1 << 7)  /* Synchronize output on write */
-#define NUTTX_O_BINARY          (1 << 8)  /* Open the file in binary mode. */
+#define NUTTX_O_TEXT            (1 << 8)  /* Open the file in text (translated) mode. */
 #define NUTTX_O_DIRECT          (1 << 9)  /* Avoid caching, write directly to hardware */
 #define NUTTX_O_CLOEXEC         (1 << 10) /* Close on execute */
 #define NUTTX_O_DIRECTORY       (1 << 11) /* Must be a directory */


### PR DESCRIPTION
## Summary

fs/hostfs: align operation flags define with fcntl.h

1. align the operation flags define with fcntl.h

follow the change: https://github.com/apache/nuttx/pull/6357

2. enable O_BINARY flag to set the default setting to untranslated mode

Since the initial default setting in MSVC is text mode ( _O_TEXT ):
https://learn.microsoft.com/en-us/cpp/c-runtime-library/text-and-binary-mode-file-i-o?view=msvc-170

Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

ci check