### PR TITLE
S32K3XX EMAC MCAST support

### DIFF
--- a/arch/arm/src/s32k3xx/s32k3xx_emac.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_emac.c
@@ -301,7 +301,9 @@
 #  define BOARD_PHY_100BASET(s) 1 /* PHY only supports 100BASE-T1 */
 #  define BOARD_PHY_ISDUPLEX(s) 1 /* PHY only supports fullduplex */
 
-#  define CLAUSE45              1
+#  ifdef CONFIG_NETDEV_IOCTL
+#    define CLAUSE45            1
+#  endif
 #  define MMD1                  1
 #  define MMD1_PMA_STATUS1      1
 #  define MMD1_PS1_RECEIVE_LINK_STATUS (1 << 2)
@@ -2276,12 +2278,12 @@ static int s32k3xx_addmac(struct net_driver_s *dev, const uint8_t *mac)
 
   if (hashindex > 31)
     {
-      registeraddress = S32K3XX_ENET_GAUR;
+      registeraddress = S32K3XX_EMAC_MAC_HASH_TABLE_REG1;
       hashindex      -= 32;
     }
   else
     {
-      registeraddress = S32K3XX_ENET_GALR;
+      registeraddress = S32K3XX_EMAC_MAC_HASH_TABLE_REG0;
     }
 
   temp  = getreg32(registeraddress);
@@ -2324,12 +2326,12 @@ static int s32k3xx_rmmac(struct net_driver_s *dev, const uint8_t *mac)
 
   if (hashindex > 31)
     {
-      registeraddress = S32K3XX_ENET_GAUR;
+      registeraddress = S32K3XX_EMAC_MAC_HASH_TABLE_REG1;
       hashindex      -= 32;
     }
   else
     {
-      registeraddress = S32K3XX_ENET_GALR;
+      registeraddress = S32K3XX_EMAC_MAC_HASH_TABLE_REG0;
     }
 
   temp  = getreg32(registeraddress);


### PR DESCRIPTION
## Summary
S32K3XX EMAC fixes to use multicast
Fix compile warning when ioctl is not enabled

## Impact
K3 emac driver

## Testing
CANHUB-K3

