### PR TITLE
sched/irq: optimizing IRQMONITOR, move up_perf_convert to irq_procfs

### DIFF
--- a/sched/irq/irq_dispatch.c
+++ b/sched/irq/irq_dispatch.c
@@ -80,19 +80,17 @@
 #  define CALL_VECTOR(ndx, vector, irq, context, arg) \
      do \
        { \
-         struct timespec delta; \
          unsigned long start; \
          unsigned long elapsed; \
          start = up_perf_gettime(); \
          vector(irq, context, arg); \
          elapsed = up_perf_gettime() - start; \
-         up_perf_convert(elapsed, &delta); \
          if (ndx < NUSER_IRQS) \
            { \
              INCR_COUNT(ndx); \
-             if (delta.tv_nsec > g_irqvector[ndx].time) \
+             if (elapsed > g_irqvector[ndx].time) \
                { \
-                 g_irqvector[ndx].time = delta.tv_nsec; \
+                 g_irqvector[ndx].time = elapsed; \
                } \
            } \
          if (CONFIG_SCHED_CRITMONITOR_MAXTIME_IRQ > 0 && \

--- a/sched/irq/irq_procfs.c
+++ b/sched/irq/irq_procfs.c
@@ -143,6 +143,7 @@ static int irq_callback(int irq, FAR struct irq_info_s *info,
 {
   FAR struct irq_file_s *irqfile = (FAR struct irq_file_s *)arg;
   struct irq_info_s copy;
+  struct timespec delta;
   irqstate_t flags;
   clock_t elapsed;
   clock_t now;
@@ -200,6 +201,7 @@ static int irq_callback(int irq, FAR struct irq_info_s *info,
    */
 
   elapsed = now - copy.start;
+  up_perf_convert(copy.time, &delta);
 
 #ifdef CONFIG_HAVE_LONG_LONG
   /* elapsed = <current-time> - <start-time>, units=clock ticks
@@ -241,7 +243,7 @@ static int irq_callback(int irq, FAR struct irq_info_s *info,
                       (unsigned long)((uintptr_t)copy.handler),
                       (unsigned long)((uintptr_t)copy.arg),
                       count, intpart, fracpart,
-                      (unsigned long)copy.time / 1000);
+                      (unsigned long)delta.tv_nsec / 1000);
 
   copysize  = procfs_memcpy(irqfile->line, linesize, irqfile->buffer,
                             irqfile->remaining, &irqfile->offset);


### PR DESCRIPTION
## Summary
optimizing IRQMONITOR, move up_perf_convert to irq_procfs

Move up_perf_convert use-time to reduce interrupt execution time

## Impact

## Testing

