### PR TITLE
stm32h7/rcc: make VOS0 configurable from board.h

### DIFF
--- a/arch/arm/src/stm32h7/stm32h7x7xx_rcc.c
+++ b/arch/arm/src/stm32h7/stm32h7x7xx_rcc.c
@@ -98,6 +98,34 @@
 #  define USE_PLL3
 #endif
 
+/* Over-drive is supported only for Voltage output scale 1 mode.
+ * It is required when SYSCLK frequency is over 400 MHz or it can be forced
+ * to a given state by adding define to the board.h configuration file:
+ *
+ *   #define STM32_VOS_OVERDRIVE 1 - force over-drive enabled,
+ *   #define STM32_VOS_OVERDRIVE 0 - force over-drive disabled,
+ *   #undef STM32_VOS_OVERDRIVE    - autoselect over-drive by logic below
+ *
+ * Boosting the core voltage can be a workaround solution to problems with
+ * poor board signal integration for high-speed digital interfaces like ULPI.
+ * Higher voltage means faster clock signal edges which may be sufficient to
+ * synchronise the high-speed clock and data.
+ */
+
+#ifndef STM32_VOS_OVERDRIVE
+#  if (STM32_PWR_VOS_SCALE == PWR_D3CR_VOS_SCALE_1) &&  \
+      (STM32_SYSCLK_FREQUENCY > 400000000)
+#    define STM32_VOS_OVERDRIVE 1
+#  else
+#    define STM32_VOS_OVERDRIVE 0
+#  endif
+#else
+#  if (STM32_VOS_OVERDRIVE == 1) &&                   \
+      (STM32_PWR_VOS_SCALE != PWR_D3CR_VOS_SCALE_1)
+#    error Over-drive can be selected only when VOS1 is configured
+#  endif
+#endif
+
 /****************************************************************************
  * Private Data
  ****************************************************************************/
@@ -855,30 +883,25 @@ void stm32_stdclockconfig(void)
         {
         }
 
-      /* Over-drive is needed if
-       *  - Voltage output scale 1 mode is selected and SYSCLK frequency is
-       *    over 400 MHz.
-       */
+#if STM32_VOS_OVERDRIVE && (STM32_PWR_VOS_SCALE == PWR_D3CR_VOS_SCALE_1)
+      /* Over-drive support for VOS1 */
 
-      if ((STM32_PWR_VOS_SCALE == PWR_D3CR_VOS_SCALE_1) &&
-           STM32_SYSCLK_FREQUENCY > 400000000)
+      /* Enable System configuration controller clock to Enable ODEN */
+
+      regval = getreg32(STM32_RCC_APB4ENR);
+      regval |= RCC_APB4ENR_SYSCFGEN;
+      putreg32(regval, STM32_RCC_APB4ENR);
+
+      /* Enable Overdrive */
+
+      regval = getreg32(STM32_SYSCFG_PWRCR);
+      regval |= SYSCFG_PWRCR_ODEN;
+      putreg32(regval, STM32_SYSCFG_PWRCR);
+
+      while ((getreg32(STM32_PWR_D3CR) & STM32_PWR_D3CR_VOSRDY) == 0)
         {
-          /* Enable System configuration controller clock to Enable ODEN */
-
-          regval = getreg32(STM32_RCC_APB4ENR);
-          regval |= RCC_APB4ENR_SYSCFGEN;
-          putreg32(regval, STM32_RCC_APB4ENR);
-
-          /* Enable Overdrive to extend the clock frequency up to 480 MHz. */
-
-          regval = getreg32(STM32_SYSCFG_PWRCR);
-          regval |= SYSCFG_PWRCR_ODEN;
-          putreg32(regval, STM32_SYSCFG_PWRCR);
-
-          while ((getreg32(STM32_PWR_D3CR) & STM32_PWR_D3CR_VOSRDY) == 0)
-            {
-            }
         }
+#endif
 
       /* Configure FLASH wait states */
 


### PR DESCRIPTION
## Summary
Follow up to https://github.com/apache/nuttx/pull/8945
It seems that over-drive is not required for ULPI but it can be a workaround solution for boards with poor signal integrity.
Higher core voltage means faster clock signal edges, which may be sufficient to synchronize the high-speed clock and data on poorly designed boards.

## Impact
VOS0 can be selected from board.h even if we aren't using the max frequency

## Testing
STM32H743II with USB3300 ULPI transceiver
