### PR TITLE
sched/wqueue: fix issue about worker can't wake up thread before work_thread running

### DIFF
--- a/sched/wqueue/kwork_thread.c
+++ b/sched/wqueue/kwork_thread.c
@@ -139,13 +139,6 @@ static int work_thread(int argc, FAR char *argv[])
 
   for (; ; )
     {
-      /* Then process queued work.  work_process will not return until: (1)
-       * there is no further work in the work queue, and (2) semaphore is
-       * posted.
-       */
-
-      nxsem_wait_uninterruptible(&wqueue->sem);
-
       /* And check each entry in the work queue.  Since we have disabled
        * interrupts we know:  (1) we will not be suspended unless we do
        * so ourselves, and (2) there will be no changes to the work queue
@@ -182,6 +175,13 @@ static int work_thread(int argc, FAR char *argv[])
           CALL_WORKER(worker, arg);
           flags = enter_critical_section();
         }
+
+      /* Then process queued work.  work_process will not return until: (1)
+       * there is no further work in the work queue, and (2) semaphore is
+       * posted.
+       */
+
+      nxsem_wait_uninterruptible(&wqueue->sem);
     }
 
   leave_critical_section(flags);


### PR DESCRIPTION

## Summary
sched/wqueue: fix issue about worker can't wake up thread before work_thread running_thread running

Problem:
AppBringup task in default priority 240 ->
board_late_initialize() ->
   some driver called work_queue() ->
      nxsem_post(&(wqueue).sem) failed because sem_count is 0

hp work_thread in default priority 224 ->
      nxsem_wait_uninterruptible(&wqueue->sem);

so hp_work_thread can't wake up, worker can't run immediately.

Signed-off-by: dongjiuzhu1 <dongjiuzhu1@xiaomi.com>
## Impact
start work queue at board_late_initialize step.
## Testing
local test
