### PR TITLE
Added missing checks in strdup'ed strings.

### DIFF
--- a/drivers/wireless/gs2200m.c
+++ b/drivers/wireless/gs2200m.c
@@ -3506,6 +3506,12 @@ FAR void *gs2200m_register(FAR const char *devpath,
 
   nxmutex_init(&dev->dev_lock);
 
+  if (!dev->path)
+    {
+      wlerr("Failed to allocate driver path.\n");
+      goto errout;
+    }
+
   ret = gs2200m_initialize(dev, lower);
   if (ret < 0)
     {
@@ -3531,6 +3537,7 @@ FAR void *gs2200m_register(FAR const char *devpath,
 
 errout:
   nxmutex_destroy(&dev->dev_lock);
+  lib_free(dev->path);
   kmm_free(dev);
   return NULL;
 }

--- a/fs/nxffs/nxffs_pack.c
+++ b/fs/nxffs/nxffs_pack.c
@@ -1093,6 +1093,8 @@ nxffs_setupwriter(FAR struct nxffs_volume_s *volume,
           pack->dest.entry.utc    = wrfile->ofile.entry.utc;
           pack->dest.entry.datlen = wrfile->ofile.entry.datlen;
 
+          DEBUGASSERT(pack->dest.entry.name != NULL);
+
           memset(&pack->src, 0, sizeof(struct nxffs_packstream_s));
           memcpy(&pack->src.entry, &wrfile->ofile.entry,
                  sizeof(struct nxffs_entry_s));


### PR DESCRIPTION
## Summary

Inspired by [this](https://github.com/apache/nuttx/pull/9009) I did a quick check on `strdup()`'s that their return string is not checked.

This PR fixes a couple of such cases.

## Impact

Potential bug fix.

## Testing

CI & build test only.
