### PR TITLE
ci/cibuild.sh: upgrade esptool to 4.5.1

### DIFF
--- a/tools/ci/cibuild.sh
+++ b/tools/ci/cibuild.sh
@@ -286,7 +286,7 @@ function python-tools {
     CodeChecker \
     cvt2utf \
     cxxfilt \
-    esptool==3.3.1 \
+    esptool==4.5.1 \
     imgtool==1.9.0 \
     kconfiglib \
     pexpect==4.8.0 \


### PR DESCRIPTION
## Summary

ci/cibuild.sh: upgrade esptool to 4.5.1

## Impact

N/A

## Testing

ci check