### PR TITLE
arch/arm: change up_saveusercontext to assembly code

### DIFF
--- a/arch/arm/include/syscall.h
+++ b/arch/arm/include/syscall.h
@@ -64,13 +64,6 @@
 
 /* Cortex-M system calls ****************************************************/
 
-/* SYS call 0:
- *
- * int up_saveusercontext(void *saveregs);
- */
-
-#define SYS_save_context          (0)
-
 /* SYS call 1:
  *
  * void arm_fullcontextrestore(uint32_t *restoreregs) noreturn_function;

--- a/arch/arm/src/arm/Make.defs
+++ b/arch/arm/src/arm/Make.defs
@@ -31,6 +31,7 @@ CMN_CSRCS += arm_undefinedinsn.c
 
 CMN_ASRCS += arm_cache.S arm_vectoraddrexcptn.S
 CMN_ASRCS += arm_vectors.S arm_vectortab.S
+CMN_ASRCS += arm_saveusercontext.S
 
 ifeq ($(CONFIG_PAGING),y)
   CMN_CSRCS += arm_pginitialize.c arm_checkmapping.c arm_allocpage.c arm_va2pte.c

--- a/arch/arm/src/arm/arm_saveusercontext.S
+++ b/arch/arm/src/arm/arm_saveusercontext.S
@@ -1,0 +1,72 @@
+/****************************************************************************
+ * arch/arm/src/arm/arm_saveusercontext.S
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/irq.h>
+
+	.file	"arm_saveusercontext.S"
+
+	.text
+	.syntax	unified
+	.arm
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_saveusercontext
+ *
+ * Description:
+ *   Save the current context.  Full prototype is:
+ *
+ *   int up_saveusercontext(void *saveregs);
+ *
+ *   R0 = saveregs = pinter saved array
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+	.globl	up_saveusercontext
+	.globl	up_saveusercontext
+	.type	up_saveusercontext, %function
+
+up_saveusercontext:
+
+	/* Save r0~r14, store the return address as PC */
+
+	stmia		r0!, {r0-r14, r14}
+
+	/* Save cpsr */
+
+	mrs		r1, CPSR
+	str		r1, [r0]
+
+	mov		r0, #0
+	bx		lr
+
+	.size	up_saveusercontext, . - up_saveusercontext
+	.end

--- a/arch/arm/src/arm/arm_syscall.c
+++ b/arch/arm/src/arm/arm_syscall.c
@@ -73,26 +73,6 @@ uint32_t *arm_syscall(uint32_t *regs)
 
   switch (cmd)
     {
-      /* R0=SYS_save_context:  This is a save context command:
-       *
-       *   int up_saveusercontext(void *saveregs);
-       *
-       * At this point, the following values are saved in context:
-       *
-       *   R0 = SYS_save_context
-       *   R1 = saveregs
-       *
-       * In this case, we simply need to copy the current registers to the
-       * save register space references in the saved R1 and return.
-       */
-
-      case SYS_save_context:
-        {
-          DEBUGASSERT(regs[REG_R1] != 0);
-          memcpy((uint32_t *)regs[REG_R1], regs, XCPTCONTEXT_SIZE);
-        }
-        break;
-
       /* R0=SYS_restore_context:  Restore task context
        *
        * void arm_fullcontextrestore(uint32_t *restoreregs)

--- a/arch/arm/src/armv6-m/Make.defs
+++ b/arch/arm/src/armv6-m/Make.defs
@@ -22,7 +22,7 @@
 
 include common/Make.defs
 
-CMN_ASRCS += arm_exception.S
+CMN_ASRCS += arm_exception.S arm_saveusercontext.S
 
 CMN_CSRCS += arm_doirq.c arm_hardfault.c arm_initialstate.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_svcall.c

--- a/arch/arm/src/armv6-m/arm_saveusercontext.S
+++ b/arch/arm/src/armv6-m/arm_saveusercontext.S
@@ -1,0 +1,108 @@
+/****************************************************************************
+ * arch/arm/src/armv6-m/arm_saveusercontext.S
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/irq.h>
+
+	.file	"arm_saveusercontext.S"
+
+	.text
+	.syntax	unified
+	.thumb
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_saveusercontext
+ *
+ * Description:
+ *   Save the current context.  Full prototype is:
+ *
+ *   int up_saveusercontext(void *saveregs);
+ *
+ *   R0 = saveregs = pinter saved array
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+	.globl	up_saveusercontext
+	.globl	up_saveusercontext
+	.type	up_saveusercontext, %function
+
+up_saveusercontext:
+
+	/* Save r0~r3 */
+
+	str		r0, [r0, #(4*REG_R0)]
+	str		r1, [r0, #(4*REG_R1)]
+	str		r2, [r0, #(4*REG_R2)]
+	str		r3, [r0, #(4*REG_R3)]
+
+	/* Save r12，r14, pc */
+
+	mov		r1, r12
+	mov		r2, r14
+	str		r1, [r0, #(4*REG_R12)]
+	str		r2, [r0, #(4*REG_R14)]
+	str		r2, [r0, #(4*REG_R15)]
+
+	/* Save xpsr */
+
+	mrs		r1, XPSR
+	str		r1, [r0, #(4*REG_XPSR)]
+
+	/* Save r13, primask, r4~r7 */
+
+	mov		r2, sp
+	mrs		r3, primask
+	stmia		r0!, {r2-r7}
+
+	/* Save r8~r10 */
+
+	mov		r1, r8
+	mov		r2, r9
+	mov		r3, r10
+	stmia		r0!, {r1-r3}
+
+	/* Save r11 and EXC_RETURN */
+
+	mov		r1, r11
+#ifdef CONFIG_BUILD_PROTECTED
+	/* Save EXC_RETURN to 0xffffffff */
+
+	movs		r2, #-1
+	stmia		r0!, {r1-r2}
+#else
+	stmia		r0!, {r1}
+#endif
+
+	movs		r0, #0
+	bx		lr
+
+	.size	up_saveusercontext, . - up_saveusercontext
+	.end

--- a/arch/arm/src/armv6-m/arm_svcall.c
+++ b/arch/arm/src/armv6-m/arm_svcall.c
@@ -152,26 +152,6 @@ int arm_svcall(int irq, void *context, void *arg)
 
   switch (cmd)
     {
-      /* R0=SYS_save_context:  This is a save context command:
-       *
-       *   int up_saveusercontext(void *saveregs);
-       *
-       * At this point, the following values are saved in context:
-       *
-       *   R0 = SYS_save_context
-       *   R1 = saveregs
-       *
-       * In this case, we simply need to copy the current registers to the
-       * save register space references in the saved R1 and return.
-       */
-
-      case SYS_save_context:
-        {
-          DEBUGASSERT(regs[REG_R1] != 0);
-          memcpy((uint32_t *)regs[REG_R1], regs, XCPTCONTEXT_SIZE);
-        }
-        break;
-
       /* R0=SYS_restore_context:  This a restore context command:
        *
        *   void arm_fullcontextrestore(uint32_t *restoreregs)

--- a/arch/arm/src/armv7-a/Make.defs
+++ b/arch/arm/src/armv7-a/Make.defs
@@ -37,6 +37,7 @@ endif
 # Common assembly language files
 
 CMN_ASRCS += arm_cpuhead.S arm_vectoraddrexcptn.S arm_vectors.S
+CMN_ASRCS += arm_saveusercontext.S
 
 # Common C source files
 

--- a/arch/arm/src/armv7-a/arm_saveusercontext.S
+++ b/arch/arm/src/armv7-a/arm_saveusercontext.S
@@ -1,0 +1,97 @@
+/****************************************************************************
+ * arch/arm/src/armv7-a/arm_saveusercontext.S
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/irq.h>
+
+	.file	"arm_saveusercontext.S"
+
+	.text
+	.syntax	unified
+	.arm
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_saveusercontext
+ *
+ * Description:
+ *   Save the current context.  Full prototype is:
+ *
+ *   int up_saveusercontext(void *saveregs);
+ *
+ *   R0 = saveregs = pinter saved array
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+	.globl	up_saveusercontext
+	.globl	up_saveusercontext
+	.type	up_saveusercontext, %function
+
+up_saveusercontext:
+
+	/* Save r0, r1 */
+
+	str		r0, [r0, #(4*REG_R0)]
+	str		r1, [r0, #(4*REG_R1)]
+
+#ifdef CONFIG_ARCH_FPU
+	/* Save fpu */
+
+#  ifdef CONFIG_ARM_DPFPU32
+	vstmia.64	r0!, {d0-d15}
+	vstmia.64	r0!, {d16-d31}
+#  else
+	vstmia		r0!, {s0-s31}
+#  endif
+	/* Save fpscr, r13 and r14 */
+
+	vmrs		r1, fpscr
+	stmia		r0!, {r1, r13, r14}
+#else
+	/* Save r13, r14 */
+
+	stmia		r0!, {r13, r14}
+#endif
+
+	/* Save r2~r12, and store the return address as PC */
+
+	add		r0, r0, #8
+	stmia		r0!, {r2-r12, r14}
+
+	/* Save cpsr */
+
+	mrs		r1, CPSR
+	str		r1, [r0]
+
+	mov		r0, #0
+	bx		lr
+
+	.size	up_saveusercontext, . - up_saveusercontext
+	.end

--- a/arch/arm/src/armv7-a/arm_syscall.c
+++ b/arch/arm/src/armv7-a/arm_syscall.c
@@ -250,25 +250,6 @@ uint32_t *arm_syscall(uint32_t *regs)
         }
         break;
 #endif
-      /* R0=SYS_save_context:  This is a save context command:
-       *
-       *   int up_saveusercontext(void *saveregs);
-       *
-       * At this point, the following values are saved in context:
-       *
-       *   R0 = SYS_save_context
-       *   R1 = saveregs
-       *
-       * In this case, we simply need to copy the current registers to the
-       * save register space references in the saved R1 and return.
-       */
-
-      case SYS_save_context:
-        {
-          DEBUGASSERT(regs[REG_R1] != 0);
-          memcpy((uint32_t *)regs[REG_R1], regs, XCPTCONTEXT_SIZE);
-        }
-        break;
 
       /* R0=SYS_restore_context:  Restore task context
        *

--- a/arch/arm/src/armv7-m/Make.defs
+++ b/arch/arm/src/armv7-m/Make.defs
@@ -22,7 +22,7 @@
 
 include common/Make.defs
 
-CMN_ASRCS += arm_exception.S
+CMN_ASRCS += arm_exception.S arm_saveusercontext.S
 
 CMN_CSRCS += arm_busfault.c arm_cache.c arm_doirq.c
 CMN_CSRCS += arm_hardfault.c arm_initialstate.c arm_itm.c

--- a/arch/arm/src/armv7-m/arm_saveusercontext.S
+++ b/arch/arm/src/armv7-m/arm_saveusercontext.S
@@ -1,0 +1,104 @@
+/****************************************************************************
+ * arch/arm/src/armv7-m/arm_saveusercontext.S
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/irq.h>
+
+	.file	"arm_saveusercontext.S"
+
+	.text
+	.syntax	unified
+	.thumb
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_saveusercontext
+ *
+ * Description:
+ *   Save the current context.  Full prototype is:
+ *
+ *   int up_saveusercontext(void *saveregs);
+ *
+ *   R0 = saveregs = pinter saved array
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+	.globl	up_saveusercontext
+	.globl	up_saveusercontext
+	.type	up_saveusercontext, %function
+
+up_saveusercontext:
+
+	/* Save r0~r3, r12，r14, pc */
+
+	str		r0, [r0, #(4*REG_R0)]
+	str		r1, [r0, #(4*REG_R1)]
+	str		r2, [r0, #(4*REG_R2)]
+	str		r3, [r0, #(4*REG_R3)]
+	str		r12, [r0, #(4*REG_R12)]
+	str		r14, [r0, #(4*REG_R14)]
+	str		r14, [r0, #(4*REG_R15)]
+
+	/* Save xpsr */
+
+	mrs		r1, XPSR
+	str		r1, [r0, #(4*REG_XPSR)]
+
+#ifdef CONFIG_ARCH_FPU
+	add		r1, r0, #(4*REG_S0)
+	vstmia		r1!, {s0-s15}
+	vmrs		r2, fpscr
+	str		r2, [r1]
+#endif
+
+	/* Save r13, primask, r4~r11 */
+
+	mov		r2, sp
+#ifdef CONFIG_ARMV7M_USEBASEPRI
+	mrs		r3, basepri
+#else
+	mrs		r3, primask
+#endif
+	stmia		r0!, {r2-r11}
+
+	/* Save EXC_RETURN to 0xffffffff */
+
+	mov		r1, #-1
+	stmia		r0!, {r1}
+
+#ifdef CONFIG_ARCH_FPU
+	vstmia		r0!, {s16-s31}
+#endif
+
+	mov		r0, #0
+	bx		lr
+
+	.size	up_saveusercontext, . - up_saveusercontext
+	.end

--- a/arch/arm/src/armv7-m/arm_svcall.c
+++ b/arch/arm/src/armv7-m/arm_svcall.c
@@ -159,26 +159,6 @@ int arm_svcall(int irq, void *context, void *arg)
 
   switch (cmd)
     {
-      /* R0=SYS_save_context:  This is a save context command:
-       *
-       *   int up_saveusercontext(void *saveregs);
-       *
-       * At this point, the following values are saved in context:
-       *
-       *   R0 = SYS_save_context
-       *   R1 = saveregs
-       *
-       * In this case, we simply need to copy the current registers to the
-       * save register space references in the saved R1 and return.
-       */
-
-      case SYS_save_context:
-        {
-          DEBUGASSERT(regs[REG_R1] != 0);
-          memcpy((uint32_t *)regs[REG_R1], regs, XCPTCONTEXT_SIZE);
-        }
-        break;
-
       /* R0=SYS_restore_context:  This a restore context command:
        *
        *   void arm_fullcontextrestore(uint32_t *restoreregs)

--- a/arch/arm/src/armv7-r/Make.defs
+++ b/arch/arm/src/armv7-r/Make.defs
@@ -38,6 +38,7 @@ CMN_CSRCS += arm_perf.c cp15_cacheops.c
 # Common C source files
 
 CMN_ASRCS += arm_head.S arm_vectoraddrexcptn.S arm_vectors.S
+CMN_ASRCS += arm_saveusercontext.S
 
 ifeq ($(CONFIG_ARMV7R_HAVE_PTM), y)
   CMN_CSRCS += arm_timer.c

--- a/arch/arm/src/armv7-r/arm_saveusercontext.S
+++ b/arch/arm/src/armv7-r/arm_saveusercontext.S
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm/src/common/arm_saveusercontext.c
+ * arch/arm/src/armv7-r/arm_saveusercontext.S
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -23,8 +23,13 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/irq.h>
 
-#include <arch/syscall.h>
+	.file	"arm_saveusercontext.S"
+
+	.text
+	.syntax	unified
+	.arm
 
 /****************************************************************************
  * Public Functions
@@ -34,17 +39,59 @@
  * Name: up_saveusercontext
  *
  * Description:
- *   Save the current thread context.  Full prototype is:
+ *   Save the current context.  Full prototype is:
  *
- *   int  up_saveusercontext(void *saveregs);
+ *   int up_saveusercontext(void *saveregs);
+ *
+ *   R0 = saveregs = pinter saved array
  *
  * Returned Value:
- *   0: Normal return
- *   1: Context switch return
+ *   None
  *
  ****************************************************************************/
 
-int up_saveusercontext(void *saveregs)
-{
-  return sys_call1(SYS_save_context, (uintptr_t)saveregs);
-}
+	.globl	up_saveusercontext
+	.globl	up_saveusercontext
+	.type	up_saveusercontext, %function
+
+up_saveusercontext:
+
+	/* Save r0, r1 */
+
+	str		r0, [r0, #(4*REG_R0)]
+	str		r1, [r0, #(4*REG_R1)]
+
+#ifdef CONFIG_ARCH_FPU
+	/* Save fpu */
+
+#  ifdef CONFIG_ARM_DPFPU32
+	vstmia.64	r0!, {d0-d15}
+	vstmia.64	r0!, {d16-d31}
+#  else
+	vstmia		r0!, {s0-s31}
+#  endif
+	/* Save fpscr, r13 and r14 */
+
+	vmrs		r1, fpscr
+	stmia		r0!, {r1, r13, r14}
+#else
+	/* Save r13, r14 */
+
+	stmia		r0!, {r13, r14}
+#endif
+
+	/* Save r2~r12, and store the return address as PC */
+
+	add		r0, r0, #8
+	stmia		r0!, {r2-r12, r14}
+
+	/* Save cpsr */
+
+	mrs		r1, CPSR
+	str		r1, [r0]
+
+	mov		r0, #0
+	bx		lr
+
+	.size	up_saveusercontext, . - up_saveusercontext
+	.end

--- a/arch/arm/src/armv7-r/arm_syscall.c
+++ b/arch/arm/src/armv7-r/arm_syscall.c
@@ -246,25 +246,6 @@ uint32_t *arm_syscall(uint32_t *regs)
         }
         break;
 #endif
-      /* R0=SYS_save_context:  This is a save context command:
-       *
-       *   int up_saveusercontext(void *saveregs);
-       *
-       * At this point, the following values are saved in context:
-       *
-       *   R0 = SYS_save_context
-       *   R1 = saveregs
-       *
-       * In this case, we simply need to copy the current registers to the
-       * save register space references in the saved R1 and return.
-       */
-
-      case SYS_save_context:
-        {
-          DEBUGASSERT(regs[REG_R1] != 0);
-          memcpy((uint32_t *)regs[REG_R1], regs, XCPTCONTEXT_SIZE);
-        }
-        break;
 
       /* R0=SYS_restore_context:  Restore task context
        *

--- a/arch/arm/src/armv8-m/Make.defs
+++ b/arch/arm/src/armv8-m/Make.defs
@@ -22,7 +22,7 @@
 
 include common/Make.defs
 
-CMN_ASRCS += arm_exception.S
+CMN_ASRCS += arm_exception.S arm_saveusercontext.S
 
 CMN_CSRCS += arm_busfault.c arm_cache.c arm_doirq.c
 CMN_CSRCS += arm_hardfault.c arm_initialstate.c arm_itm.c

--- a/arch/arm/src/armv8-m/arm_saveusercontext.S
+++ b/arch/arm/src/armv8-m/arm_saveusercontext.S
@@ -1,0 +1,113 @@
+/****************************************************************************
+ * arch/arm/src/armv8-m/arm_saveusercontext.S
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/irq.h>
+
+	.file	"arm_saveusercontext.S"
+
+	.text
+	.syntax	unified
+	.thumb
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_saveusercontext
+ *
+ * Description:
+ *   Save the current context.  Full prototype is:
+ *
+ *   int up_saveusercontext(void *saveregs);
+ *
+ *   R0 = saveregs = pinter saved array
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+	.globl	up_saveusercontext
+	.globl	up_saveusercontext
+	.type	up_saveusercontext, %function
+
+up_saveusercontext:
+
+	/* Save r0~r3, r12，r14, pc */
+
+	str		r0, [r0, #(4*REG_R0)]
+	str		r1, [r0, #(4*REG_R1)]
+	str		r2, [r0, #(4*REG_R2)]
+	str		r3, [r0, #(4*REG_R3)]
+	str		r12, [r0, #(4*REG_R12)]
+	str		r14, [r0, #(4*REG_R14)]
+	str		r14, [r0, #(4*REG_R15)]
+
+	/* Save xpsr */
+
+	mrs		r1, XPSR
+	str		r1, [r0, #(4*REG_XPSR)]
+
+#ifdef CONFIG_ARCH_FPU
+	add		r1, r0, #(4*REG_S0)
+	vstmia		r1!, {s0-s15}
+	vmrs		r2, fpscr
+	str		r2, [r1]
+#endif
+
+	/* Save r13, primask, r4~r11 */
+
+	mov		r2, sp
+#ifdef CONFIG_ARMV7M_USEBASEPRI
+	mrs		r3, basepri
+#else
+	mrs		r3, primask
+#endif
+	stmia		r0!, {r2-r11}
+
+	/* Save EXC_RETURN to 0xffffffff */
+
+	mov		r1, #-1
+	stmia		r0!, {r1}
+
+#ifdef CONFIG_ARCH_FPU
+	vstmia		r0!, {s16-s31}
+#endif
+
+#ifdef CONFIG_ARMV8M_STACKCHECK_HARDWARE
+	mrs		r2, control
+	tst		r2, #0x2
+	ite		eq
+	mrseq		r1, msplim
+	mrsne		r1, psplim
+	str		r1, [r0]
+#endif
+
+	mov		r0, #0
+	bx		lr
+
+	.size	up_saveusercontext, . - up_saveusercontext
+	.end

--- a/arch/arm/src/armv8-m/arm_svcall.c
+++ b/arch/arm/src/armv8-m/arm_svcall.c
@@ -158,26 +158,6 @@ int arm_svcall(int irq, void *context, void *arg)
 
   switch (cmd)
     {
-      /* R0=SYS_save_context:  This is a save context command:
-       *
-       *   int up_saveusercontext(void *saveregs);
-       *
-       * At this point, the following values are saved in context:
-       *
-       *   R0 = SYS_save_context
-       *   R1 = saveregs
-       *
-       * In this case, we simply need to copy the current registers to the
-       * save register space references in the saved R1 and return.
-       */
-
-      case SYS_save_context:
-        {
-          DEBUGASSERT(regs[REG_R1] != 0);
-          memcpy((uint32_t *)regs[REG_R1], regs, XCPTCONTEXT_SIZE);
-        }
-        break;
-
       /* R0=SYS_restore_context:  This a restore context command:
        *
        *   void arm_fullcontextrestore(uint32_t *restoreregs)

--- a/arch/arm/src/common/Make.defs
+++ b/arch/arm/src/common/Make.defs
@@ -24,8 +24,8 @@ CMN_CSRCS += arm_allocateheap.c arm_createstack.c arm_exit.c
 CMN_CSRCS += arm_getintstack.c arm_initialize.c arm_lowputs.c
 CMN_CSRCS += arm_modifyreg8.c arm_modifyreg16.c arm_modifyreg32.c
 CMN_CSRCS += arm_nputs.c arm_releasestack.c arm_registerdump.c
-CMN_CSRCS += arm_stackframe.c arm_saveusercontext.c
-CMN_CSRCS += arm_switchcontext.c arm_usestack.c arm_vfork.c
+CMN_CSRCS += arm_stackframe.c arm_switchcontext.c
+CMN_CSRCS += arm_usestack.c arm_vfork.c
 
 ifneq ($(CONFIG_ALARM_ARCH),y)
   ifneq ($(CONFIG_TIMER_ARCH),y)

--- a/arch/arm/src/tlsr82/tc32/Make.defs
+++ b/arch/arm/src/tlsr82/tc32/Make.defs
@@ -36,9 +36,13 @@ CMN_ASRCS :=
 # Filter-out unnecessary .c files
 
 TC32_CSRCS_FILTER := arm_backtrace_fp.c arm_backtrace_thumb.c
-TC32_CSRCS_FILTER += arm_fullcontextrestore.c
-TC32_CSRCS_FILTER += arm_saveusercontext.c arm_udelay.c
+TC32_CSRCS_FILTER += arm_fullcontextrestore.c arm_udelay.c
 CMN_CSRCS := $(filter-out $(TC32_CSRCS_FILTER), $(CMN_CSRCS))
+
+# Filter-out unnecessary .S files
+
+TC32_ASRCS_FILTER := arm_saveusercontext.S
+CMN_ASRCS := $(filter-out $(TC32_ASRCS_FILTER), $(CMN_ASRCS))
 
 # Common files in arch/arm/src/armv6-m
 

--- a/arch/arm64/src/common/arm64_internal.h
+++ b/arch/arm64/src/common/arm64_internal.h
@@ -254,7 +254,6 @@ void arm64_secondary_start(void);
 
 void arm64_fullcontextrestore(uint64_t *restoreregs) noreturn_function;
 void arm64_switchcontext(uint64_t **saveregs, uint64_t *restoreregs);
-void arm64_context_snapshot(void *savereg);
 
 /* Signal handling **********************************************************/
 

--- a/arch/arm64/src/common/arm64_task_sched.c
+++ b/arch/arm64/src/common/arm64_task_sched.c
@@ -45,44 +45,6 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_saveusercontext
- *
- * Description:
- *   Save the current thread context.  Full prototype is:
- *
- *   int  up_saveusercontext(void *saveregs);
- *
- * Returned Value:
- *   0: Normal return
- *   1: Context switch return
- *
- ****************************************************************************/
-#ifdef CONFIG_BUILD_FLAT
-
-int up_saveusercontext(void *saveregs)
-{
-  irqstate_t flags;
-
-  /* Take a snapshot of the thread context right now */
-
-  flags = enter_critical_section();
-
-  arm64_context_snapshot(saveregs);
-
-  leave_critical_section(flags);
-  return 0;
-}
-
-#else
-
-int up_saveusercontext(void *saveregs)
-{
-  return sys_call1(SYS_save_context, (uintptr_t)saveregs);
-}
-
-#endif
-
-/****************************************************************************
  * Name: arm64_fullcontextrestore
  *
  * Description:

--- a/arch/arm64/src/common/arm64_vectors.S
+++ b/arch/arm64/src/common/arm64_vectors.S
@@ -60,15 +60,15 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Function: arm64_context_snapshot
+ * Function: up_saveusercontext
  *
  * Description:
  *   Take a snapshot of the thread GP registers context
  *   x0 --- pointer to struct regs_context
  *
  ****************************************************************************/
-GTEXT(arm64_context_snapshot)
-SECTION_FUNC(text, arm64_context_snapshot)
+GTEXT(up_saveusercontext)
+SECTION_FUNC(text, up_saveusercontext)
     str    x0, [sp, #-16]!
 
     stp    x0,  x1,  [x0, #8 * REG_X0]


### PR DESCRIPTION
## Summary

gdb will backtrace failure when use C code to save user context, because the stack push operation in C code can disrupt the stack information.

## Impact

debug

## Testing

tools/checkpatch.sh