### PR TITLE
xtensa/esp32: ESP32 not use IMEM in user heap mode

### DIFF
--- a/arch/xtensa/src/esp32/Kconfig
+++ b/arch/xtensa/src/esp32/Kconfig
@@ -787,6 +787,7 @@ config ESP32_IMM_HEAP
 	bool "Reserve part of DRAM as a separate heap"
 	select XTENSA_IMEM_USE_SEPARATE_HEAP
 	default n
+	depends on ESP32_SPIRAM_COMMON_HEAP
 
 config ESP32_RTC_HEAP
 	bool "Use the RTC memory as a separate heap"
@@ -869,7 +870,7 @@ config ESP32_UART0_TXDMA
 	bool "Enable UART0 TX DMA"
 	select ARCH_DMA
 	select UART0_TXDMA
-	select ESP32_IMM_HEAP if ESP32_SPIRAM
+	select ESP32_IMM_HEAP if ESP32_SPIRAM_COMMON_HEAP
 	depends on EXPERIMENTAL
 	---help---
 		Due to a hardware bug on the DMA used by the UART
@@ -936,7 +937,7 @@ config ESP32_UART1_TXDMA
 	bool "Enable UART1 TX DMA"
 	select ARCH_DMA
 	select UART1_TXDMA
-	select ESP32_IMM_HEAP if ESP32_SPIRAM
+	select ESP32_IMM_HEAP if ESP32_SPIRAM_COMMON_HEAP
 	depends on EXPERIMENTAL
 	---help---
 		Due to a hardware bug on the DMA used by the UART
@@ -1003,7 +1004,7 @@ config ESP32_UART2_TXDMA
 	bool "Enable UART2 TX DMA"
 	select ARCH_DMA
 	select UART2_TXDMA
-	select ESP32_IMM_HEAP if ESP32_SPIRAM
+	select ESP32_IMM_HEAP if ESP32_SPIRAM_COMMON_HEAP
 	depends on EXPERIMENTAL
 	---help---
 		Due to a hardware bug on the DMA used by the UART
@@ -1156,14 +1157,14 @@ config ESP32_SPI2_DMA
 	bool "SPI2 use DMA"
 	default y
 	select ARCH_DMA
-	select ESP32_IMM_HEAP if ESP32_SPIRAM
+	select ESP32_IMM_HEAP if ESP32_SPIRAM_COMMON_HEAP
 	depends on ESP32_SPI2
 
 config ESP32_SPI3_DMA
 	bool "SPI3 use DMA"
 	default y
 	select ARCH_DMA
-	select ESP32_IMM_HEAP if ESP32_SPIRAM
+	select ESP32_IMM_HEAP if ESP32_SPIRAM_COMMON_HEAP
 	depends on ESP32_SPI3
 
 config SPI_DMADESC_NUM

--- a/arch/xtensa/src/esp32/esp32_spi.c
+++ b/arch/xtensa/src/esp32/esp32_spi.c
@@ -829,9 +829,9 @@ static void esp32_spi_dma_exchange(struct esp32_spi_priv_s *priv,
   uint32_t regval;
   struct esp32_dmadesc_s *dma_tx_desc;
   struct esp32_dmadesc_s *dma_rx_desc;
-#ifdef CONFIG_XTENSA_IMEM_USE_SEPARATE_HEAP
+#ifdef CONFIG_ESP32_SPIRAM
   uint8_t *alloctp = NULL;
-  uint8_t *allocrp;
+  uint8_t *allocrp = NULL;
 #endif
 
   /* Define these constants outside transfer loop to avoid wasting CPU time
@@ -853,10 +853,15 @@ static void esp32_spi_dma_exchange(struct esp32_spi_priv_s *priv,
 
   /* If the buffer comes from PSRAM, allocate a new one from DRAM */
 
-#ifdef CONFIG_XTENSA_IMEM_USE_SEPARATE_HEAP
+#ifdef CONFIG_ESP32_SPIRAM
   if (esp32_ptr_extram(txbuffer))
     {
+#  ifdef CONFIG_MM_KERNEL_HEAP
+      alloctp = kmm_malloc(total);
+#  elif defined(CONFIG_XTENSA_IMEM_USE_SEPARATE_HEAP)
       alloctp = xtensa_imm_malloc(total);
+#  endif
+
       DEBUGASSERT(alloctp != NULL);
       memcpy(alloctp, txbuffer, total);
       tp = alloctp;
@@ -867,10 +872,15 @@ static void esp32_spi_dma_exchange(struct esp32_spi_priv_s *priv,
       tp = (uint8_t *)txbuffer;
     }
 
-#ifdef CONFIG_XTENSA_IMEM_USE_SEPARATE_HEAP
+#ifdef CONFIG_ESP32_SPIRAM
   if (esp32_ptr_extram(rxbuffer))
     {
+#  ifdef CONFIG_MM_KERNEL_HEAP
+      allocrp = kmm_malloc(total);
+#  elif defined(CONFIG_XTENSA_IMEM_USE_SEPARATE_HEAP)
       allocrp = xtensa_imm_malloc(total);
+#  endif
+
       DEBUGASSERT(allocrp != NULL);
       rp = allocrp;
     }
@@ -938,18 +948,26 @@ static void esp32_spi_dma_exchange(struct esp32_spi_priv_s *priv,
 
   esp32_spi_reset_regbits(spi_slave_reg, SPI_INT_EN_M);
 
-#ifdef CONFIG_XTENSA_IMEM_USE_SEPARATE_HEAP
-  if (esp32_ptr_extram(rxbuffer))
+#ifdef CONFIG_ESP32_SPIRAM
+  if (allocrp)
     {
       memcpy(rxbuffer, allocrp, total);
+#  ifdef CONFIG_MM_KERNEL_HEAP
+      kmm_free(allocrp);
+#  elif defined(CONFIG_XTENSA_IMEM_USE_SEPARATE_HEAP)
       xtensa_imm_free(allocrp);
+#  endif
     }
 #endif
 
-#ifdef CONFIG_XTENSA_IMEM_USE_SEPARATE_HEAP
-  if (esp32_ptr_extram(txbuffer))
+#ifdef CONFIG_ESP32_SPIRAM
+  if (alloctp)
     {
+#  ifdef CONFIG_MM_KERNEL_HEAP
+      kmm_free(alloctp);
+#  elif defined(CONFIG_XTENSA_IMEM_USE_SEPARATE_HEAP)
       xtensa_imm_free(alloctp);
+#  endif
     }
 #endif
 }


### PR DESCRIPTION
## Summary

When users enable `Separated userspace heap`(ESP32_SPIRAM_USER_HEAP), system don't enable separated heap region of SRAM (ESP32_IMM_HEAP -> XTENSA_IMEM_USE_SEPARATE_HEAP), so that users can have a full larger block of heap.

If users still enable `Additional region to kernel heap`(ESP32_SPIRAM_COMMON_HEAP), system enable separated heap region of SRAM (ESP32_IMM_HEAP -> XTENSA_IMEM_USE_SEPARATE_HEAP), so that kernel driver can allocate heap from SRAM.

## Impact

## Testing

