### PR TITLE
sched/addrenv: Miscellaneous clean-up and fixes

### DIFF
--- a/arch/arm/src/common/arm_checkstack.c
+++ b/arch/arm/src/common/arm_checkstack.c
@@ -203,19 +203,16 @@ size_t up_check_tcbstack(struct tcb_s *tcb)
   size_t size;
 
 #ifdef CONFIG_ARCH_ADDRENV
-  bool saved = false;
-
   if (tcb->addrenv_own != NULL)
     {
       addrenv_select(tcb->addrenv_own);
-      saved = true;
     }
 #endif
 
   size = arm_stack_check(tcb->stack_base_ptr, tcb->adj_stack_size);
 
 #ifdef CONFIG_ARCH_ADDRENV
-  if (saved)
+  if (tcb->addrenv_own != NULL)
     {
       addrenv_restore();
     }

--- a/arch/risc-v/src/common/riscv_checkstack.c
+++ b/arch/risc-v/src/common/riscv_checkstack.c
@@ -159,12 +159,9 @@ size_t up_check_tcbstack(struct tcb_s *tcb)
   size_t size;
 
 #ifdef CONFIG_ARCH_ADDRENV
-  bool saved = false;
-
   if (tcb->addrenv_own != NULL)
     {
       addrenv_select(tcb->addrenv_own);
-      saved = true;
     }
 #endif
 
@@ -172,7 +169,7 @@ size_t up_check_tcbstack(struct tcb_s *tcb)
                            tcb->adj_stack_size);
 
 #ifdef CONFIG_ARCH_ADDRENV
-  if (saved)
+  if (tcb->addrenv_own != NULL)
     {
       addrenv_restore();
     }

--- a/binfmt/libnxflat/libnxflat.h
+++ b/binfmt/libnxflat/libnxflat.h
@@ -80,6 +80,25 @@ int nxflat_addrenv_alloc(FAR struct nxflat_loadinfo_s *loadinfo,
 #endif
 
 /****************************************************************************
+ * Name: nxflat_addrenv_restore
+ *
+ * Description:
+ *   Restore the address environment before nxflat_addrenv_select() was
+ *   called..
+ *
+ * Input Parameters:
+ *   loadinfo - Load state information
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_ARCH_ADDRENV
+#  define nxflat_addrenv_restore(l) addrenv_restore()
+#endif
+
+/****************************************************************************
  * Name: nxflat_addrenv_free
  *
  * Description:

--- a/sched/group/group_argvstr.c
+++ b/sched/group/group_argvstr.c
@@ -59,9 +59,6 @@
 size_t group_argvstr(FAR struct tcb_s *tcb, FAR char *args, size_t size)
 {
   size_t n = 0;
-#ifdef CONFIG_ARCH_ADDRENV
-  bool saved = false;
-#endif
 
   /* Perform sanity checks */
 
@@ -77,7 +74,6 @@ size_t group_argvstr(FAR struct tcb_s *tcb, FAR char *args, size_t size)
   if (tcb->addrenv_own != NULL)
     {
       addrenv_select(tcb->addrenv_own);
-      saved = true;
     }
 #endif
 
@@ -100,7 +96,7 @@ size_t group_argvstr(FAR struct tcb_s *tcb, FAR char *args, size_t size)
     }
 
 #ifdef CONFIG_ARCH_ADDRENV
-  if (saved)
+  if (tcb->addrenv_own != NULL)
     {
       addrenv_restore();
     }


### PR DESCRIPTION
## Summary
Tiny misc. fixes to address environment code:
- Remove the temporary "saved" variable when temporarily changing MMU mappings to access another process's memory. The fact that it has an address environment is enough to make the choice
- Restore nxflat_addrenv_restore-macro. It was accidentally lost when the address environment handling was re-factored.

## Impact
Next to nothing
## Testing
icicle:knsh / sabre6-quad:knsh (qemu)
