### PR TITLE
Add audio underrun notice and support it in cxd56 audio driver

### DIFF
--- a/include/nuttx/audio/audio.h
+++ b/include/nuttx/audio/audio.h
@@ -332,6 +332,7 @@
 #define AUDIO_MSG_WAKEUP            9
 #define AUDIO_MSG_COMMAND          10
 #define AUDIO_MSG_SLIENCE          11
+#define AUDIO_MSG_UNDERRUN         12
 #define AUDIO_MSG_USER             64
 
 /* Audio Pipeline Buffer flags */


### PR DESCRIPTION
## Summary

Add Event ID for notify underrun from audio driver.
Fix a bug of freeze audio driver of cxd56 in case of 2nd play.
Add underrun event on audio/cxd56.

## Impact

Just in audio/cxd56 driver.

## Testing

Tested if nxplayer and nxrecorder work well.
