### PR TITLE
Fix Black/Flake8 whitespace around slice disagreement

### DIFF
--- a/.github/linters/setup.cfg
+++ b/.github/linters/setup.cfg
@@ -1,4 +1,5 @@
 [flake8]
+extend-ignore = E203
 ignore = W503,W605
 max-complexity = 27
 max-line-length = 125


### PR DESCRIPTION
## Summary

Fixes https://github.com/apache/nuttx/pull/8992#issuecomment-1508871789

See https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#flake8

In some cases, as determined by PEP 8, Black will enforce an equal amount of whitespace around slice operators. Due to this, Flake8 will raise E203 whitespace before ':' warnings. Since this warning is not PEP 8 compliant, Flake8 should be configured to ignore it via extend-ignore = E203.

## Impact

Fix CI

## Testing

CI