### PR TITLE
Fix the style issue in procfs

### DIFF
--- a/drivers/mtd/mtd_partition.c
+++ b/drivers/mtd/mtd_partition.c
@@ -149,7 +149,7 @@ static int     part_procfs_stat(FAR const char *relpath,
 #if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_PROCFS_EXCLUDE_PARTITIONS)
 static struct mtd_partition_s *g_pfirstpartition = NULL;
 
-const struct procfs_operations g_part_procfsoperations =
+const struct procfs_operations g_part_operations =
 {
   part_procfs_open,       /* open */
   part_procfs_close,      /* close */

--- a/drivers/mtd/mtd_partition.c
+++ b/drivers/mtd/mtd_partition.c
@@ -149,7 +149,7 @@ static int     part_procfs_stat(FAR const char *relpath,
 #if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_PROCFS_EXCLUDE_PARTITIONS)
 static struct mtd_partition_s *g_pfirstpartition = NULL;
 
-const struct procfs_operations part_procfsoperations =
+const struct procfs_operations g_part_procfsoperations =
 {
   part_procfs_open,       /* open */
   part_procfs_close,      /* close */

--- a/drivers/power/pm/pm_procfs.c
+++ b/drivers/power/pm/pm_procfs.c
@@ -123,7 +123,7 @@ static int     pm_stat(FAR const char *relpath, FAR struct stat *buf);
  * with any compiler.
  */
 
-const struct procfs_operations pm_operations =
+const struct procfs_operations g_pm_operations =
 {
   pm_open,       /* open */
   pm_close,      /* close */

--- a/fs/mount/fs_procfs_mount.c
+++ b/fs/mount/fs_procfs_mount.c
@@ -137,7 +137,7 @@ static int     mount_stat(FAR const char *relpath, FAR struct stat *buf);
  * with any compiler.
  */
 
-const struct procfs_operations mount_procfsoperations =
+const struct procfs_operations g_mount_procfsoperations =
 {
   mount_open,          /* open */
   mount_close,         /* close */

--- a/fs/mount/fs_procfs_mount.c
+++ b/fs/mount/fs_procfs_mount.c
@@ -137,7 +137,7 @@ static int     mount_stat(FAR const char *relpath, FAR struct stat *buf);
  * with any compiler.
  */
 
-const struct procfs_operations g_mount_procfsoperations =
+const struct procfs_operations g_mount_operations =
 {
   mount_open,          /* open */
   mount_close,         /* close */

--- a/fs/procfs/Kconfig
+++ b/fs/procfs/Kconfig
@@ -29,29 +29,6 @@ config FS_PROCFS_MAX_TASKS
 
 menu "Exclude individual procfs entries"
 
-config FS_PROCFS_EXCLUDE_PROCESS
-	bool "Exclude process information"
-	default DEFAULT_SMALL
-	---help---
-		Causes the process information to be excluded from the procfs system.
-		This will reduce code space, but then giving access to process info
-		was kinda the whole point of procfs, but hey, whatever.
-
-config FS_PROCFS_EXCLUDE_ENVIRON
-	bool "Exclude environment information"
-	default DEFAULT_SMALL
-	depends on !FS_PROCFS_EXCLUDE_PROCESS
-	---help---
-		Causes the environment variable information to be excluded from the
-		procfs system.  This will reduce code space slightly.
-
-config FS_PROCFS_EXCLUDE_MODULE
-	bool "Exclude module information"
-	depends on MODULE
-	default DEFAULT_SMALL
-	---help---
-		Causes the module information to be excluded from the procfs system.
-
 config FS_PROCFS_EXCLUDE_BLOCKS
 	bool "Exclude fs/blocks information"
 	depends on !DISABLE_MOUNTPOINT
@@ -60,6 +37,53 @@ config FS_PROCFS_EXCLUDE_BLOCKS
 		Causes the fs block usage information to be excluded from the procfs
 		system.  This procfs file provides the text output for the NSH 'df'
 		command.
+
+config FS_PROCFS_EXCLUDE_CPULOAD
+	bool "Exclude CPU load"
+	depends on SCHED_CPULOAD
+	default DEFAULT_SMALL
+
+config FS_PROCFS_EXCLUDE_ENVIRON
+	bool "Exclude environment information"
+	depends on !FS_PROCFS_EXCLUDE_PROCESS
+	default DEFAULT_SMALL
+	---help---
+		Causes the environment variable information to be excluded from the
+		procfs system.  This will reduce code space slightly.
+
+config FS_PROCFS_EXCLUDE_IOBINFO
+	bool "Exclude iobinfo"
+	depends on MM_IOB
+	default DEFAULT_SMALL
+
+config FS_PROCFS_EXCLUDE_PROCESS
+	bool "Exclude process information"
+	default DEFAULT_SMALL
+	---help---
+		Causes the process information to be excluded from the procfs system.
+		This will reduce code space, but then giving access to process info
+		was kinda the whole point of procfs, but hey, whatever.
+
+config FS_PROCFS_INCLUDE_PROGMEM
+	bool "Include prog mem"
+	depends on ARCH_HAVE_PROGMEM && !FS_PROCFS_EXCLUDE_MEMINFO
+	default DEFAULT_SMALL
+
+config FS_PROCFS_EXCLUDE_MEMDUMP
+	bool "Exclude memdump"
+	depends on !FS_PROCFS_EXCLUDE_MEMINFO
+	default DEFAULT_SMALL
+
+config FS_PROCFS_EXCLUDE_MEMINFO
+	bool "Exclude meminfo"
+	default DEFAULT_SMALL
+
+config FS_PROCFS_EXCLUDE_MODULE
+	bool "Exclude module information"
+	depends on MODULE
+	default DEFAULT_SMALL
+	---help---
+		Causes the module information to be excluded from the procfs system.
 
 config FS_PROCFS_EXCLUDE_MOUNT
 	bool "Exclude fs/mount information"
@@ -70,50 +94,10 @@ config FS_PROCFS_EXCLUDE_MOUNT
 		system.  This procfs file provides the text output for the NSH 'mount'
 		command.
 
-config FS_PROCFS_EXCLUDE_USAGE
-	bool "Exclude fs/usage information"
-	depends on !DISABLE_MOUNTPOINT
-	default DEFAULT_SMALL
-	---help---
-		Causes the fs usage information to be excluded from the procfs
-		system.  This procfs file provides the text output for the NSH 'df -h'
-		command.
-
-config FS_PROCFS_EXCLUDE_UPTIME
-	bool "Exclude uptime"
-	default DEFAULT_SMALL
-
-config FS_PROCFS_EXCLUDE_VERSION
-	bool "Exclude version"
-	default DEFAULT_SMALL
-
-config FS_PROCFS_EXCLUDE_CPULOAD
-	bool "Exclude CPU load"
-	default DEFAULT_SMALL
-	depends on SCHED_CPULOAD
-
-config FS_PROCFS_EXCLUDE_MEMINFO
-	bool "Exclude meminfo"
-	default DEFAULT_SMALL
-
-config FS_PROCFS_EXCLUDE_MEMDUMP
-	bool "Exclude memdump"
-	default DEFAULT_SMALL
-
-config FS_PROCFS_INCLUDE_PROGMEM
-	bool "Include prog mem"
-	default DEFAULT_SMALL
-	depends on ARCH_HAVE_PROGMEM && !FS_PROCFS_EXCLUDE_MEMINFO
-
-config FS_PROCFS_EXCLUDE_IOBINFO
-	bool "Exclude iobinfo"
-	depends on MM_IOB
-	default DEFAULT_SMALL
-
 config FS_PROCFS_EXCLUDE_MOUNTS
 	bool "Exclude mounts"
-	default DEFAULT_SMALL
 	depends on !DISABLE_MOUNTPOINT
+	default DEFAULT_SMALL
 
 config FS_PROCFS_EXCLUDE_NET
 	bool "Exclude network"
@@ -138,6 +122,23 @@ config FS_PROCFS_EXCLUDE_SMARTFS
 config FS_PROCFS_EXCLUDE_TCBINFO
 	bool "Exclude tcbinfo procfs"
 	depends on DEBUG_TCBINFO
+	default DEFAULT_SMALL
+
+config FS_PROCFS_EXCLUDE_UPTIME
+	bool "Exclude uptime"
+	default DEFAULT_SMALL
+
+config FS_PROCFS_EXCLUDE_USAGE
+	bool "Exclude fs/usage information"
+	depends on !DISABLE_MOUNTPOINT
+	default DEFAULT_SMALL
+	---help---
+		Causes the fs usage information to be excluded from the procfs
+		system.  This procfs file provides the text output for the NSH 'df -h'
+		command.
+
+config FS_PROCFS_EXCLUDE_VERSION
+	bool "Exclude version"
 	default DEFAULT_SMALL
 
 endmenu # Exclude individual procfs entries

--- a/fs/procfs/Make.defs
+++ b/fs/procfs/Make.defs
@@ -21,13 +21,10 @@
 ifeq ($(CONFIG_FS_PROCFS),y)
 # Files required for procfs file system support
 
-CSRCS += fs_procfs.c fs_procfsutil.c fs_procfsproc.c fs_procfsuptime.c
-CSRCS += fs_procfscpuload.c fs_procfsmeminfo.c fs_procfsiobinfo.c
-CSRCS += fs_procfsversion.c fs_procfstcbinfo.c
-
-ifeq ($(CONFIG_SCHED_CRITMONITOR),y)
-CSRCS += fs_procfscritmon.c
-endif
+CSRCS += fs_procfs.c fs_procfscpuload.c fs_procfscritmon.c
+CSRCS += fs_procfsiobinfo.c fs_procfsmeminfo.c fs_procfsproc.c
+CSRCS += fs_procfstcbinfo.c fs_procfsuptime.c fs_procfsutil.c
+CSRCS += fs_procfsversion.c
 
 # Include procfs build support
 

--- a/fs/procfs/fs_procfs.c
+++ b/fs/procfs/fs_procfs.c
@@ -72,11 +72,11 @@ extern const struct procfs_operations g_tcbinfo_operations;
  * configuration.
  */
 
-extern const struct procfs_operations g_net_procfsoperations;
-extern const struct procfs_operations g_net_procfs_routeoperations;
-extern const struct procfs_operations g_part_procfsoperations;
-extern const struct procfs_operations g_mount_procfsoperations;
-extern const struct procfs_operations g_smartfs_procfsoperations;
+extern const struct procfs_operations g_net_operations;
+extern const struct procfs_operations g_netroute_operations;
+extern const struct procfs_operations g_part_operations;
+extern const struct procfs_operations g_mount_operations;
+extern const struct procfs_operations g_smartfs_operations;
 
 /****************************************************************************
  * Private Types
@@ -91,90 +91,90 @@ static const struct procfs_entry_s g_procfs_entries[] =
 #endif
 {
 #ifndef CONFIG_FS_PROCFS_EXCLUDE_PROCESS
-  { "[0-9]*/**",     &g_proc_operations,            PROCFS_UNKOWN_TYPE },
-  { "[0-9]*",        &g_proc_operations,            PROCFS_DIR_TYPE    },
+  { "[0-9]*/**",    &g_proc_operations,     PROCFS_UNKOWN_TYPE },
+  { "[0-9]*",       &g_proc_operations,     PROCFS_DIR_TYPE    },
 #endif
 
 #if defined(CONFIG_SCHED_CPULOAD) && !defined(CONFIG_FS_PROCFS_EXCLUDE_CPULOAD)
-  { "cpuload",       &g_cpuload_operations,         PROCFS_FILE_TYPE   },
+  { "cpuload",      &g_cpuload_operations,  PROCFS_FILE_TYPE   },
 #endif
 
 #ifdef CONFIG_SCHED_CRITMONITOR
-  { "critmon",       &g_critmon_operations,         PROCFS_FILE_TYPE   },
+  { "critmon",      &g_critmon_operations,  PROCFS_FILE_TYPE   },
 #endif
 
 #ifdef CONFIG_SCHED_IRQMONITOR
-  { "irqs",          &g_irq_operations,             PROCFS_FILE_TYPE   },
+  { "irqs",         &g_irq_operations,      PROCFS_FILE_TYPE   },
 #endif
 
 #ifndef CONFIG_FS_PROCFS_EXCLUDE_MEMINFO
-  { "meminfo",       &g_meminfo_operations,         PROCFS_FILE_TYPE   },
+  { "meminfo",      &g_meminfo_operations,  PROCFS_FILE_TYPE   },
 #  ifndef CONFIG_FS_PROCFS_EXCLUDE_MEMDUMP
-  { "memdump",       &g_memdump_operations,         PROCFS_FILE_TYPE   },
+  { "memdump",      &g_memdump_operations,  PROCFS_FILE_TYPE   },
 #  endif
 #endif
 
 #ifndef CONFIG_FS_PROCFS_EXCLUDE_MEMPOOL
-  { "mempool",       &g_mempool_operations,         PROCFS_FILE_TYPE   },
+  { "mempool",      &g_mempool_operations,  PROCFS_FILE_TYPE   },
 #endif
 
 #if defined(CONFIG_MM_IOB) && !defined(CONFIG_FS_PROCFS_EXCLUDE_IOBINFO)
-  { "iobinfo",       &g_iobinfo_operations,         PROCFS_FILE_TYPE   },
+  { "iobinfo",      &g_iobinfo_operations,  PROCFS_FILE_TYPE   },
 #endif
 
 #if defined(CONFIG_MODULE) && !defined(CONFIG_FS_PROCFS_EXCLUDE_MODULE)
-  { "modules",       &g_module_operations,          PROCFS_FILE_TYPE   },
+  { "modules",      &g_module_operations,   PROCFS_FILE_TYPE   },
 #endif
 
 #ifndef CONFIG_FS_PROCFS_EXCLUDE_BLOCKS
-  { "fs/blocks",     &g_mount_procfsoperations,     PROCFS_FILE_TYPE   },
+  { "fs/blocks",    &g_mount_operations,    PROCFS_FILE_TYPE   },
 #endif
 
 #ifndef CONFIG_FS_PROCFS_EXCLUDE_MOUNT
-  { "fs/mount",      &g_mount_procfsoperations,     PROCFS_FILE_TYPE   },
+  { "fs/mount",     &g_mount_operations,    PROCFS_FILE_TYPE   },
 #endif
 
 #ifndef CONFIG_FS_PROCFS_EXCLUDE_USAGE
-  { "fs/usage",      &g_mount_procfsoperations,     PROCFS_FILE_TYPE   },
+  { "fs/usage",     &g_mount_operations,    PROCFS_FILE_TYPE   },
 #endif
 
 #if defined(CONFIG_FS_SMARTFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_SMARTFS)
-  { "fs/smartfs**",  &g_smartfs_procfsoperations,   PROCFS_UNKOWN_TYPE },
+  { "fs/smartfs**", &g_smartfs_operations,  PROCFS_UNKOWN_TYPE },
 #endif
 
 #if defined(CONFIG_NET) && !defined(CONFIG_FS_PROCFS_EXCLUDE_NET)
-  { "net",           &g_net_procfsoperations,       PROCFS_DIR_TYPE    },
+  { "net",          &g_net_operations,      PROCFS_DIR_TYPE    },
 #  if defined(CONFIG_NET_ROUTE) && !defined(CONFIG_FS_PROCFS_EXCLUDE_ROUTE)
-  { "net/route",     &g_net_procfs_routeoperations, PROCFS_DIR_TYPE    },
-  { "net/route/**",  &g_net_procfs_routeoperations, PROCFS_UNKOWN_TYPE },
+  { "net/route",    &g_netroute_operations, PROCFS_DIR_TYPE    },
+  { "net/route/**", &g_netroute_operations, PROCFS_UNKOWN_TYPE },
 #  endif
-  { "net/**",        &g_net_procfsoperations,       PROCFS_UNKOWN_TYPE },
+  { "net/**",       &g_net_operations,      PROCFS_UNKOWN_TYPE },
 #endif
 
 #if defined(CONFIG_MTD_PARTITION) && !defined(CONFIG_FS_PROCFS_EXCLUDE_PARTITIONS)
-  { "partitions",    &g_part_procfsoperations,      PROCFS_FILE_TYPE   },
+  { "partitions",   &g_part_operations,     PROCFS_FILE_TYPE   },
 #endif
 
 #if defined(CONFIG_PM) && defined(CONFIG_PM_PROCFS)
-  { "pm",            &g_pm_operations,              PROCFS_DIR_TYPE    },
-  { "pm/**",         &g_pm_operations,              PROCFS_UNKOWN_TYPE },
+  { "pm",           &g_pm_operations,       PROCFS_DIR_TYPE    },
+  { "pm/**",        &g_pm_operations,       PROCFS_UNKOWN_TYPE },
 #endif
 
 #ifndef CONFIG_FS_PROCFS_EXCLUDE_PROCESS
-  { "self",          &g_proc_operations,            PROCFS_DIR_TYPE    },
-  { "self/**",       &g_proc_operations,            PROCFS_UNKOWN_TYPE },
+  { "self",         &g_proc_operations,     PROCFS_DIR_TYPE    },
+  { "self/**",      &g_proc_operations,     PROCFS_UNKOWN_TYPE },
 #endif
 
 #if !defined(CONFIG_FS_PROCFS_EXCLUDE_UPTIME)
-  { "uptime",        &g_uptime_operations,          PROCFS_FILE_TYPE   },
+  { "uptime",       &g_uptime_operations,   PROCFS_FILE_TYPE   },
 #endif
 
 #if !defined(CONFIG_FS_PROCFS_EXCLUDE_VERSION)
-  { "version",       &g_version_operations,         PROCFS_FILE_TYPE   },
+  { "version",      &g_version_operations,  PROCFS_FILE_TYPE   },
 #endif
 
 #if defined(CONFIG_DEBUG_TCBINFO) && !defined(CONFIG_FS_PROCFS_EXCLUDE_TCBINFO)
-  { "tcbinfo",       &g_tcbinfo_operations,         PROCFS_FILE_TYPE   },
+  { "tcbinfo",      &g_tcbinfo_operations,  PROCFS_FILE_TYPE   },
 #endif
 };
 

--- a/fs/procfs/fs_procfs.c
+++ b/fs/procfs/fs_procfs.c
@@ -52,19 +52,19 @@
  * External Definitions
  ****************************************************************************/
 
-extern const struct procfs_operations g_proc_operations;
-extern const struct procfs_operations g_pm_operations;
-extern const struct procfs_operations g_irq_operations;
 extern const struct procfs_operations g_cpuload_operations;
 extern const struct procfs_operations g_critmon_operations;
+extern const struct procfs_operations g_iobinfo_operations;
+extern const struct procfs_operations g_irq_operations;
 extern const struct procfs_operations g_meminfo_operations;
 extern const struct procfs_operations g_memdump_operations;
 extern const struct procfs_operations g_mempool_operations;
-extern const struct procfs_operations g_iobinfo_operations;
 extern const struct procfs_operations g_module_operations;
+extern const struct procfs_operations g_pm_operations;
+extern const struct procfs_operations g_proc_operations;
+extern const struct procfs_operations g_tcbinfo_operations;
 extern const struct procfs_operations g_uptime_operations;
 extern const struct procfs_operations g_version_operations;
-extern const struct procfs_operations g_tcbinfo_operations;
 
 /* This is not good.  These are implemented in other sub-systems.  Having to
  * deal with them here is not a good coupling. What is really needed is a
@@ -72,10 +72,10 @@ extern const struct procfs_operations g_tcbinfo_operations;
  * configuration.
  */
 
+extern const struct procfs_operations g_mount_operations;
 extern const struct procfs_operations g_net_operations;
 extern const struct procfs_operations g_netroute_operations;
 extern const struct procfs_operations g_part_operations;
-extern const struct procfs_operations g_mount_operations;
 extern const struct procfs_operations g_smartfs_operations;
 
 /****************************************************************************
@@ -103,29 +103,6 @@ static const struct procfs_entry_s g_procfs_entries[] =
   { "critmon",      &g_critmon_operations,  PROCFS_FILE_TYPE   },
 #endif
 
-#ifdef CONFIG_SCHED_IRQMONITOR
-  { "irqs",         &g_irq_operations,      PROCFS_FILE_TYPE   },
-#endif
-
-#ifndef CONFIG_FS_PROCFS_EXCLUDE_MEMINFO
-  { "meminfo",      &g_meminfo_operations,  PROCFS_FILE_TYPE   },
-#  ifndef CONFIG_FS_PROCFS_EXCLUDE_MEMDUMP
-  { "memdump",      &g_memdump_operations,  PROCFS_FILE_TYPE   },
-#  endif
-#endif
-
-#ifndef CONFIG_FS_PROCFS_EXCLUDE_MEMPOOL
-  { "mempool",      &g_mempool_operations,  PROCFS_FILE_TYPE   },
-#endif
-
-#if defined(CONFIG_MM_IOB) && !defined(CONFIG_FS_PROCFS_EXCLUDE_IOBINFO)
-  { "iobinfo",      &g_iobinfo_operations,  PROCFS_FILE_TYPE   },
-#endif
-
-#if defined(CONFIG_MODULE) && !defined(CONFIG_FS_PROCFS_EXCLUDE_MODULE)
-  { "modules",      &g_module_operations,   PROCFS_FILE_TYPE   },
-#endif
-
 #ifndef CONFIG_FS_PROCFS_EXCLUDE_BLOCKS
   { "fs/blocks",    &g_mount_operations,    PROCFS_FILE_TYPE   },
 #endif
@@ -134,12 +111,35 @@ static const struct procfs_entry_s g_procfs_entries[] =
   { "fs/mount",     &g_mount_operations,    PROCFS_FILE_TYPE   },
 #endif
 
+#if defined(CONFIG_FS_SMARTFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_SMARTFS)
+  { "fs/smartfs**", &g_smartfs_operations,  PROCFS_UNKOWN_TYPE },
+#endif
+
 #ifndef CONFIG_FS_PROCFS_EXCLUDE_USAGE
   { "fs/usage",     &g_mount_operations,    PROCFS_FILE_TYPE   },
 #endif
 
-#if defined(CONFIG_FS_SMARTFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_SMARTFS)
-  { "fs/smartfs**", &g_smartfs_operations,  PROCFS_UNKOWN_TYPE },
+#if defined(CONFIG_MM_IOB) && !defined(CONFIG_FS_PROCFS_EXCLUDE_IOBINFO)
+  { "iobinfo",      &g_iobinfo_operations,  PROCFS_FILE_TYPE   },
+#endif
+
+#ifdef CONFIG_SCHED_IRQMONITOR
+  { "irqs",         &g_irq_operations,      PROCFS_FILE_TYPE   },
+#endif
+
+#ifndef CONFIG_FS_PROCFS_EXCLUDE_MEMINFO
+#  ifndef CONFIG_FS_PROCFS_EXCLUDE_MEMDUMP
+  { "memdump",      &g_memdump_operations,  PROCFS_FILE_TYPE   },
+#  endif
+  { "meminfo",      &g_meminfo_operations,  PROCFS_FILE_TYPE   },
+#endif
+
+#ifndef CONFIG_FS_PROCFS_EXCLUDE_MEMPOOL
+  { "mempool",      &g_mempool_operations,  PROCFS_FILE_TYPE   },
+#endif
+
+#if defined(CONFIG_MODULE) && !defined(CONFIG_FS_PROCFS_EXCLUDE_MODULE)
+  { "modules",      &g_module_operations,   PROCFS_FILE_TYPE   },
 #endif
 
 #if defined(CONFIG_NET) && !defined(CONFIG_FS_PROCFS_EXCLUDE_NET)
@@ -165,16 +165,16 @@ static const struct procfs_entry_s g_procfs_entries[] =
   { "self/**",      &g_proc_operations,     PROCFS_UNKOWN_TYPE },
 #endif
 
+#if defined(CONFIG_DEBUG_TCBINFO) && !defined(CONFIG_FS_PROCFS_EXCLUDE_TCBINFO)
+  { "tcbinfo",      &g_tcbinfo_operations,  PROCFS_FILE_TYPE   },
+#endif
+
 #if !defined(CONFIG_FS_PROCFS_EXCLUDE_UPTIME)
   { "uptime",       &g_uptime_operations,   PROCFS_FILE_TYPE   },
 #endif
 
 #if !defined(CONFIG_FS_PROCFS_EXCLUDE_VERSION)
   { "version",      &g_version_operations,  PROCFS_FILE_TYPE   },
-#endif
-
-#if defined(CONFIG_DEBUG_TCBINFO) && !defined(CONFIG_FS_PROCFS_EXCLUDE_TCBINFO)
-  { "tcbinfo",      &g_tcbinfo_operations,  PROCFS_FILE_TYPE   },
 #endif
 };
 

--- a/fs/procfs/fs_procfs.c
+++ b/fs/procfs/fs_procfs.c
@@ -52,19 +52,19 @@
  * External Definitions
  ****************************************************************************/
 
-extern const struct procfs_operations proc_operations;
-extern const struct procfs_operations pm_operations;
-extern const struct procfs_operations irq_operations;
-extern const struct procfs_operations cpuload_operations;
-extern const struct procfs_operations critmon_operations;
-extern const struct procfs_operations meminfo_operations;
-extern const struct procfs_operations memdump_operations;
-extern const struct procfs_operations mempool_operations;
-extern const struct procfs_operations iobinfo_operations;
-extern const struct procfs_operations module_operations;
-extern const struct procfs_operations uptime_operations;
-extern const struct procfs_operations version_operations;
-extern const struct procfs_operations tcbinfo_operations;
+extern const struct procfs_operations g_proc_operations;
+extern const struct procfs_operations g_pm_operations;
+extern const struct procfs_operations g_irq_operations;
+extern const struct procfs_operations g_cpuload_operations;
+extern const struct procfs_operations g_critmon_operations;
+extern const struct procfs_operations g_meminfo_operations;
+extern const struct procfs_operations g_memdump_operations;
+extern const struct procfs_operations g_mempool_operations;
+extern const struct procfs_operations g_iobinfo_operations;
+extern const struct procfs_operations g_module_operations;
+extern const struct procfs_operations g_uptime_operations;
+extern const struct procfs_operations g_version_operations;
+extern const struct procfs_operations g_tcbinfo_operations;
 
 /* This is not good.  These are implemented in other sub-systems.  Having to
  * deal with them here is not a good coupling. What is really needed is a
@@ -72,11 +72,11 @@ extern const struct procfs_operations tcbinfo_operations;
  * configuration.
  */
 
-extern const struct procfs_operations net_procfsoperations;
-extern const struct procfs_operations net_procfs_routeoperations;
-extern const struct procfs_operations part_procfsoperations;
-extern const struct procfs_operations mount_procfsoperations;
-extern const struct procfs_operations smartfs_procfsoperations;
+extern const struct procfs_operations g_net_procfsoperations;
+extern const struct procfs_operations g_net_procfs_routeoperations;
+extern const struct procfs_operations g_part_procfsoperations;
+extern const struct procfs_operations g_mount_procfsoperations;
+extern const struct procfs_operations g_smartfs_procfsoperations;
 
 /****************************************************************************
  * Private Types
@@ -91,90 +91,90 @@ static const struct procfs_entry_s g_procfs_entries[] =
 #endif
 {
 #ifndef CONFIG_FS_PROCFS_EXCLUDE_PROCESS
-  { "[0-9]*/**",     &proc_operations,            PROCFS_UNKOWN_TYPE },
-  { "[0-9]*",        &proc_operations,            PROCFS_DIR_TYPE    },
+  { "[0-9]*/**",     &g_proc_operations,            PROCFS_UNKOWN_TYPE },
+  { "[0-9]*",        &g_proc_operations,            PROCFS_DIR_TYPE    },
 #endif
 
 #if defined(CONFIG_SCHED_CPULOAD) && !defined(CONFIG_FS_PROCFS_EXCLUDE_CPULOAD)
-  { "cpuload",       &cpuload_operations,         PROCFS_FILE_TYPE   },
+  { "cpuload",       &g_cpuload_operations,         PROCFS_FILE_TYPE   },
 #endif
 
 #ifdef CONFIG_SCHED_CRITMONITOR
-  { "critmon",       &critmon_operations,         PROCFS_FILE_TYPE   },
+  { "critmon",       &g_critmon_operations,         PROCFS_FILE_TYPE   },
 #endif
 
 #ifdef CONFIG_SCHED_IRQMONITOR
-  { "irqs",          &irq_operations,             PROCFS_FILE_TYPE   },
+  { "irqs",          &g_irq_operations,             PROCFS_FILE_TYPE   },
 #endif
 
 #ifndef CONFIG_FS_PROCFS_EXCLUDE_MEMINFO
-  { "meminfo",       &meminfo_operations,         PROCFS_FILE_TYPE   },
+  { "meminfo",       &g_meminfo_operations,         PROCFS_FILE_TYPE   },
 #  ifndef CONFIG_FS_PROCFS_EXCLUDE_MEMDUMP
-  { "memdump",       &memdump_operations,         PROCFS_FILE_TYPE   },
+  { "memdump",       &g_memdump_operations,         PROCFS_FILE_TYPE   },
 #  endif
 #endif
 
 #ifndef CONFIG_FS_PROCFS_EXCLUDE_MEMPOOL
-  { "mempool",       &mempool_operations,         PROCFS_FILE_TYPE   },
+  { "mempool",       &g_mempool_operations,         PROCFS_FILE_TYPE   },
 #endif
 
 #if defined(CONFIG_MM_IOB) && !defined(CONFIG_FS_PROCFS_EXCLUDE_IOBINFO)
-  { "iobinfo",       &iobinfo_operations,         PROCFS_FILE_TYPE   },
+  { "iobinfo",       &g_iobinfo_operations,         PROCFS_FILE_TYPE   },
 #endif
 
 #if defined(CONFIG_MODULE) && !defined(CONFIG_FS_PROCFS_EXCLUDE_MODULE)
-  { "modules",       &module_operations,          PROCFS_FILE_TYPE   },
+  { "modules",       &g_module_operations,          PROCFS_FILE_TYPE   },
 #endif
 
 #ifndef CONFIG_FS_PROCFS_EXCLUDE_BLOCKS
-  { "fs/blocks",     &mount_procfsoperations,     PROCFS_FILE_TYPE   },
+  { "fs/blocks",     &g_mount_procfsoperations,     PROCFS_FILE_TYPE   },
 #endif
 
 #ifndef CONFIG_FS_PROCFS_EXCLUDE_MOUNT
-  { "fs/mount",      &mount_procfsoperations,     PROCFS_FILE_TYPE   },
+  { "fs/mount",      &g_mount_procfsoperations,     PROCFS_FILE_TYPE   },
 #endif
 
 #ifndef CONFIG_FS_PROCFS_EXCLUDE_USAGE
-  { "fs/usage",      &mount_procfsoperations,     PROCFS_FILE_TYPE   },
+  { "fs/usage",      &g_mount_procfsoperations,     PROCFS_FILE_TYPE   },
 #endif
 
 #if defined(CONFIG_FS_SMARTFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_SMARTFS)
-  { "fs/smartfs**",  &smartfs_procfsoperations,   PROCFS_UNKOWN_TYPE },
+  { "fs/smartfs**",  &g_smartfs_procfsoperations,   PROCFS_UNKOWN_TYPE },
 #endif
 
 #if defined(CONFIG_NET) && !defined(CONFIG_FS_PROCFS_EXCLUDE_NET)
-  { "net",           &net_procfsoperations,       PROCFS_DIR_TYPE    },
+  { "net",           &g_net_procfsoperations,       PROCFS_DIR_TYPE    },
 #  if defined(CONFIG_NET_ROUTE) && !defined(CONFIG_FS_PROCFS_EXCLUDE_ROUTE)
-  { "net/route",     &net_procfs_routeoperations, PROCFS_DIR_TYPE    },
-  { "net/route/**",  &net_procfs_routeoperations, PROCFS_UNKOWN_TYPE },
+  { "net/route",     &g_net_procfs_routeoperations, PROCFS_DIR_TYPE    },
+  { "net/route/**",  &g_net_procfs_routeoperations, PROCFS_UNKOWN_TYPE },
 #  endif
-  { "net/**",        &net_procfsoperations,       PROCFS_UNKOWN_TYPE },
+  { "net/**",        &g_net_procfsoperations,       PROCFS_UNKOWN_TYPE },
 #endif
 
 #if defined(CONFIG_MTD_PARTITION) && !defined(CONFIG_FS_PROCFS_EXCLUDE_PARTITIONS)
-  { "partitions",    &part_procfsoperations,      PROCFS_FILE_TYPE   },
+  { "partitions",    &g_part_procfsoperations,      PROCFS_FILE_TYPE   },
 #endif
 
 #if defined(CONFIG_PM) && defined(CONFIG_PM_PROCFS)
-  { "pm",            &pm_operations,              PROCFS_DIR_TYPE    },
-  { "pm/**",         &pm_operations,              PROCFS_UNKOWN_TYPE },
+  { "pm",            &g_pm_operations,              PROCFS_DIR_TYPE    },
+  { "pm/**",         &g_pm_operations,              PROCFS_UNKOWN_TYPE },
 #endif
 
 #ifndef CONFIG_FS_PROCFS_EXCLUDE_PROCESS
-  { "self",          &proc_operations,            PROCFS_DIR_TYPE    },
-  { "self/**",       &proc_operations,            PROCFS_UNKOWN_TYPE },
+  { "self",          &g_proc_operations,            PROCFS_DIR_TYPE    },
+  { "self/**",       &g_proc_operations,            PROCFS_UNKOWN_TYPE },
 #endif
 
 #if !defined(CONFIG_FS_PROCFS_EXCLUDE_UPTIME)
-  { "uptime",        &uptime_operations,          PROCFS_FILE_TYPE   },
+  { "uptime",        &g_uptime_operations,          PROCFS_FILE_TYPE   },
 #endif
 
 #if !defined(CONFIG_FS_PROCFS_EXCLUDE_VERSION)
-  { "version",       &version_operations,         PROCFS_FILE_TYPE   },
+  { "version",       &g_version_operations,         PROCFS_FILE_TYPE   },
 #endif
 
 #if defined(CONFIG_DEBUG_TCBINFO) && !defined(CONFIG_FS_PROCFS_EXCLUDE_TCBINFO)
-  { "tcbinfo",       &tcbinfo_operations,         PROCFS_FILE_TYPE   },
+  { "tcbinfo",       &g_tcbinfo_operations,         PROCFS_FILE_TYPE   },
 #endif
 };
 

--- a/fs/procfs/fs_procfscpuload.c
+++ b/fs/procfs/fs_procfscpuload.c
@@ -94,7 +94,7 @@ static int     cpuload_stat(FAR const char *relpath, FAR struct stat *buf);
  * with any compiler.
  */
 
-const struct procfs_operations cpuload_operations =
+const struct procfs_operations g_cpuload_operations =
 {
   cpuload_open,       /* open */
   cpuload_close,      /* close */

--- a/fs/procfs/fs_procfscritmon.c
+++ b/fs/procfs/fs_procfscritmon.c
@@ -93,7 +93,7 @@ static int     critmon_stat(FAR const char *relpath, FAR struct stat *buf);
  * with any compiler.
  */
 
-const struct procfs_operations critmon_operations =
+const struct procfs_operations g_critmon_operations =
 {
   critmon_open,       /* open */
   critmon_close,      /* close */

--- a/fs/procfs/fs_procfsiobinfo.c
+++ b/fs/procfs/fs_procfsiobinfo.c
@@ -92,7 +92,7 @@ static int     iobinfo_stat(FAR const char *relpath, FAR struct stat *buf);
  * with any compiler.
  */
 
-const struct procfs_operations iobinfo_operations =
+const struct procfs_operations g_iobinfo_operations =
 {
   iobinfo_open,   /* open */
   iobinfo_close,  /* close */

--- a/fs/procfs/fs_procfsmeminfo.c
+++ b/fs/procfs/fs_procfsmeminfo.c
@@ -117,7 +117,7 @@ static int     meminfo_stat(FAR const char *relpath, FAR struct stat *buf);
  * with any compiler.
  */
 
-const struct procfs_operations meminfo_operations =
+const struct procfs_operations g_meminfo_operations =
 {
   meminfo_open,   /* open */
   meminfo_close,  /* close */
@@ -132,7 +132,7 @@ const struct procfs_operations meminfo_operations =
 };
 
 #ifndef CONFIG_FS_PROCFS_EXCLUDE_MEMDUMP
-const struct procfs_operations memdump_operations =
+const struct procfs_operations g_memdump_operations =
 {
   meminfo_open,   /* open */
   meminfo_close,  /* close */

--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -244,7 +244,7 @@ static int     proc_stat(FAR const char *relpath, FAR struct stat *buf);
  * with any compiler.
  */
 
-const struct procfs_operations proc_operations =
+const struct procfs_operations g_proc_operations =
 {
   proc_open,          /* open */
   proc_close,         /* close */

--- a/fs/procfs/fs_procfstcbinfo.c
+++ b/fs/procfs/fs_procfstcbinfo.c
@@ -92,7 +92,7 @@ static int     tcbinfo_stat(FAR const char *relpath, FAR struct stat *buf);
  * with any compiler.
  */
 
-const struct procfs_operations tcbinfo_operations =
+const struct procfs_operations g_tcbinfo_operations =
 {
   tcbinfo_open,       /* open */
   tcbinfo_close,      /* close */

--- a/fs/procfs/fs_procfsuptime.c
+++ b/fs/procfs/fs_procfsuptime.c
@@ -95,7 +95,7 @@ static int     uptime_stat(FAR const char *relpath, FAR struct stat *buf);
  * with any compiler.
  */
 
-const struct procfs_operations uptime_operations =
+const struct procfs_operations g_uptime_operations =
 {
   uptime_open,       /* open */
   uptime_close,      /* close */

--- a/fs/procfs/fs_procfsversion.c
+++ b/fs/procfs/fs_procfsversion.c
@@ -95,7 +95,7 @@ static int     version_stat(FAR const char *relpath, FAR struct stat *buf);
  * with any compiler.
  */
 
-const struct procfs_operations version_operations =
+const struct procfs_operations g_version_operations =
 {
   version_open,       /* open */
   version_close,      /* close */

--- a/fs/smartfs/smartfs_procfs.c
+++ b/fs/smartfs/smartfs_procfs.c
@@ -168,7 +168,7 @@ static const uint8_t g_direntrycount = sizeof(g_direntry) /
  * with any compiler.
  */
 
-const struct procfs_operations g_smartfs_procfsoperations =
+const struct procfs_operations g_smartfs_operations =
 {
   smartfs_open,       /* open */
   smartfs_close,      /* close */
@@ -348,7 +348,7 @@ static int smartfs_open(FAR struct file *filep, FAR const char *relpath,
    */
 
   if (((oflags & O_WRONLY) != 0 || (oflags & O_RDONLY) == 0) &&
-      (g_smartfs_procfsoperations.write == NULL))
+      (g_smartfs_operations.write == NULL))
     {
       ferr("ERROR: Only O_RDONLY supported\n");
       return -EACCES;

--- a/fs/smartfs/smartfs_procfs.c
+++ b/fs/smartfs/smartfs_procfs.c
@@ -168,7 +168,7 @@ static const uint8_t g_direntrycount = sizeof(g_direntry) /
  * with any compiler.
  */
 
-const struct procfs_operations smartfs_procfsoperations =
+const struct procfs_operations g_smartfs_procfsoperations =
 {
   smartfs_open,       /* open */
   smartfs_close,      /* close */
@@ -348,7 +348,7 @@ static int smartfs_open(FAR struct file *filep, FAR const char *relpath,
    */
 
   if (((oflags & O_WRONLY) != 0 || (oflags & O_RDONLY) == 0) &&
-      (smartfs_procfsoperations.write == NULL))
+      (g_smartfs_procfsoperations.write == NULL))
     {
       ferr("ERROR: Only O_RDONLY supported\n");
       return -EACCES;

--- a/mm/mempool/mempool_procfs.c
+++ b/mm/mempool/mempool_procfs.c
@@ -72,7 +72,7 @@ static ssize_t mempool_read(FAR struct file *filep, FAR char *buffer,
  * Public Data
  ****************************************************************************/
 
-const struct procfs_operations mempool_operations =
+const struct procfs_operations g_mempool_operations =
 {
   mempool_open,   /* open */
   mempool_close,  /* close */

--- a/net/procfs/net_procfs.c
+++ b/net/procfs/net_procfs.c
@@ -99,7 +99,7 @@ static int     netprocfs_stat(FAR const char *relpath, FAR struct stat *buf);
  * Private Data
  ****************************************************************************/
 
-extern const struct procfs_operations g_net_procfs_routeoperations;
+extern const struct procfs_operations g_netroute_operations;
 
 /* Netprocfs component mappings */
 
@@ -141,7 +141,7 @@ static const struct netprocfs_entry_s g_net_entries[] =
   {
     DTYPE_DIRECTORY, "route",
     {
-      (FAR void *)&g_net_procfs_routeoperations
+      (FAR void *)&g_netroute_operations
     }
   },
 #endif
@@ -162,7 +162,7 @@ static const struct netprocfs_entry_s g_net_entries[] =
  * with any compiler.
  */
 
-const struct procfs_operations g_net_procfsoperations =
+const struct procfs_operations g_net_operations =
 {
   netprocfs_open,       /* open */
   netprocfs_close,      /* close */
@@ -202,7 +202,7 @@ static int netprocfs_open(FAR struct file *filep, FAR const char *relpath,
    */
 
   if (((oflags & O_WRONLY) != 0 || (oflags & O_RDONLY) == 0) &&
-      (g_net_procfsoperations.write == NULL))
+      (g_net_operations.write == NULL))
     {
       ferr("ERROR: Only O_RDONLY supported\n");
       return -EACCES;

--- a/net/procfs/net_procfs.c
+++ b/net/procfs/net_procfs.c
@@ -99,7 +99,7 @@ static int     netprocfs_stat(FAR const char *relpath, FAR struct stat *buf);
  * Private Data
  ****************************************************************************/
 
-extern const struct procfs_operations net_procfs_routeoperations;
+extern const struct procfs_operations g_net_procfs_routeoperations;
 
 /* Netprocfs component mappings */
 
@@ -141,7 +141,7 @@ static const struct netprocfs_entry_s g_net_entries[] =
   {
     DTYPE_DIRECTORY, "route",
     {
-      (FAR void *)&net_procfs_routeoperations
+      (FAR void *)&g_net_procfs_routeoperations
     }
   },
 #endif
@@ -162,7 +162,7 @@ static const struct netprocfs_entry_s g_net_entries[] =
  * with any compiler.
  */
 
-const struct procfs_operations net_procfsoperations =
+const struct procfs_operations g_net_procfsoperations =
 {
   netprocfs_open,       /* open */
   netprocfs_close,      /* close */
@@ -202,7 +202,7 @@ static int netprocfs_open(FAR struct file *filep, FAR const char *relpath,
    */
 
   if (((oflags & O_WRONLY) != 0 || (oflags & O_RDONLY) == 0) &&
-      (net_procfsoperations.write == NULL))
+      (g_net_procfsoperations.write == NULL))
     {
       ferr("ERROR: Only O_RDONLY supported\n");
       return -EACCES;

--- a/net/procfs/net_procfs_route.c
+++ b/net/procfs/net_procfs_route.c
@@ -175,7 +175,7 @@ static int     route_stat(FAR const char *relpath, FAR struct stat *buf);
  * with any compiler.
  */
 
-const struct procfs_operations net_procfs_routeoperations =
+const struct procfs_operations g_net_procfs_routeoperations =
 {
   route_open,          /* open */
   route_close,         /* close */

--- a/net/procfs/net_procfs_route.c
+++ b/net/procfs/net_procfs_route.c
@@ -175,7 +175,7 @@ static int     route_stat(FAR const char *relpath, FAR struct stat *buf);
  * with any compiler.
  */
 
-const struct procfs_operations g_net_procfs_routeoperations =
+const struct procfs_operations g_netroute_operations =
 {
   route_open,          /* open */
   route_close,         /* close */

--- a/sched/irq/irq_procfs.c
+++ b/sched/irq/irq_procfs.c
@@ -113,7 +113,7 @@ static int     irq_stat(FAR const char *relpath, FAR struct stat *buf);
  * with any compiler.
  */
 
-const struct procfs_operations irq_operations =
+const struct procfs_operations g_irq_operations =
 {
   irq_open,       /* open */
   irq_close,      /* close */

--- a/sched/module/mod_procfs.c
+++ b/sched/module/mod_procfs.c
@@ -100,7 +100,7 @@ static int     modprocfs_stat(FAR const char *relpath, FAR struct stat *buf);
  * with any compiler.
  */
 
-const struct procfs_operations module_operations =
+const struct procfs_operations g_module_operations =
 {
   modprocfs_open,       /* open */
   modprocfs_close,      /* close */


### PR DESCRIPTION
## Summary

- procfs: Add g_ prefix to all procfs_operations 
- procfs: remove procfs_ from procfs_operations variables 
- procfs: Make g_procfs_entries in the alphabetic order 

## Impact

No, code refactor only

## Testing

CI