### PR TITLE
cxd56_power: Add lowerhalf interface to keep power when cold sleep

### DIFF
--- a/boards/arm/cxd56xx/spresense/include/cxd56_power.h
+++ b/boards/arm/cxd56xx/spresense/include/cxd56_power.h
@@ -202,6 +202,26 @@ bool board_xtal_power_monitor(void);
 
 int board_lna_power_control(bool en);
 
+/****************************************************************************
+ * Name: board_set_reset_gpo
+ *
+ * Description:
+ *   Set gpo to off when power off the board.
+ *
+ ****************************************************************************/
+
+int board_set_reset_gpo(int target);
+
+/****************************************************************************
+ * Name: board_unset_reset_gpo
+ *
+ * Description:
+ *   Keep gpo status when power off the board.
+ *
+ ****************************************************************************/
+
+int board_unset_reset_gpo(int target);
+
 #undef EXTERN
 #if defined(__cplusplus)
 }

--- a/boards/arm/cxd56xx/spresense/src/cxd56_power.c
+++ b/boards/arm/cxd56xx/spresense/src/cxd56_power.c
@@ -64,7 +64,7 @@ static struct pm_cpu_freqlock_s g_hv_lock =
   PM_CPUFREQLOCK_INIT(PM_CPUFREQLOCK_TAG('B', 'P', 0),
                       PM_CPUFREQLOCK_FLAG_HV);
 #endif
-static uint8_t g_reset_gpo_targets = 0xFF;
+static uint8_t g_reset_gpo_targets = 0xff;
 
 /****************************************************************************
  * Public Data
@@ -146,7 +146,8 @@ int board_power_setup(int status)
       case PM_BOOT_WDT_REBOOT:
       case PM_BOOT_WDT_RESET:
         /* Power off Hi-Z of GPO switches (except for GPO0)
-         * in first boot-up stage */
+         * in first boot-up stage
+         */
 
         for (pin = 1; pin <= BOARD_GPO_MAX_PIN_NUM; pin++)
           {
@@ -161,6 +162,7 @@ int board_power_setup(int status)
       case PM_BOOT_DEEP_WKUPS:
       case PM_BOOT_DEEP_RTC:
       case PM_BOOT_DEEP_OTHERS:
+
         /* Enable USB after wakeup from deep sleeping */
 
         ret = cxd56_pmic_read(PMIC_REG_CNT_USB2, &val, sizeof(val));
@@ -189,7 +191,7 @@ int board_power_setup(int status)
 
   /* Initialize reset GPO targets (reset all) */
 
-  g_reset_gpo_targets = 0xFF;
+  g_reset_gpo_targets = 0xff;
 
   return 0;
 }


### PR DESCRIPTION
## Summary

Add board interface to keep power when entering/recover sleep. Some driver wants to keep power when entering sleep mode.

## Impact

Just in power/cxd56 driver.

## Testing

Unit test with Spresense board and work well.