### PR TITLE
tools/ci: Skip esp32c6 build untils espressif fix the problem

### DIFF
--- a/tools/ci/testlist/risc-v.dat
+++ b/tools/ci/testlist/risc-v.dat
@@ -1,2 +1,3 @@
 /risc-v
 -,arty_a7:.+
+-/esp32c6:.+


### PR DESCRIPTION
## Summary

see the discussion here: https://github.com/apache/nuttx/pull/9016

## Impact

make ci work again

## Testing

ci