### PR TITLE
esp32c6: fixed ci build issue

### DIFF
--- a/boards/risc-v/esp32c6/common/scripts/legacy_sections.ld
+++ b/boards/risc-v/esp32c6/common/scripts/legacy_sections.ld
@@ -161,6 +161,7 @@ SECTIONS
     *(.irom1.text) /* catch stray ICACHE_RODATA_ATTR */
     *(.gnu.linkonce.r.*)
     *(.rodata1)
+    *(.srodata.*)
     __XT_EXCEPTION_TABLE_ = ABSOLUTE(.);
     *(.xt_except_table)
     *(.gcc_except_table .gcc_except_table.*)


### PR DESCRIPTION
## Summary

fixed ci build issue discussion here: https://github.com/apache/nuttx/pull/9016

## Impact

NA

## Testing

esp32c6-devkit/coremark ci pass