### PR TITLE
[SYSLOG] avoid concurrent modification by other tasks

### DIFF
--- a/drivers/syslog/syslog_write.c
+++ b/drivers/syslog/syslog_write.c
@@ -62,6 +62,13 @@ static ssize_t syslog_default_write(FAR const char *buffer, size_t buflen)
 
   if (up_interrupt_context() || sched_idletask())
     {
+#ifdef CONFIG_SYSLOG_INTBUFFER
+      if (up_interrupt_context())
+        {
+          sched_lock();
+        }
+#endif
+
       for (nwritten = 0; nwritten < buflen; nwritten++)
         {
 #ifdef CONFIG_SYSLOG_INTBUFFER
@@ -85,6 +92,13 @@ static ssize_t syslog_default_write(FAR const char *buffer, size_t buflen)
                 }
             }
         }
+
+#ifdef CONFIG_SYSLOG_INTBUFFER
+      if (up_interrupt_context())
+        {
+          sched_unlock();
+        }
+#endif
     }
   else
     {


### PR DESCRIPTION
## Summary
when syslog write the iob buffer to interrupt buffer, one char a time disable scheduler to switch to other task in non-SMP environment.

## Impact
syslog improvement

## Testing
Test with developing board, no issue found.
