### PR TITLE
net/tcp: Fix clear condition in ofoseg input

### DIFF
--- a/mm/iob/iob_pack.c
+++ b/mm/iob/iob_pack.c
@@ -51,15 +51,11 @@ FAR struct iob_s *iob_pack(FAR struct iob_s *iob)
   unsigned int ncopy;
   unsigned int navail;
 
-  /* Handle special cases */
+  /* Handle special cases, preserve at least one iob. */
 
-  while (iob->io_len <= 0)
+  while (iob->io_len <= 0 && iob->io_flink != NULL)
     {
       iob = iob_free(iob);
-      if (iob == NULL)
-        {
-          return NULL;
-        }
     }
 
   /* Now remember the head of the chain (for the return value) */

--- a/net/tcp/tcp_input.c
+++ b/net/tcp/tcp_input.c
@@ -454,10 +454,11 @@ static void tcp_input_ofosegs(FAR struct net_driver_s *dev,
   /* Trim l3/l4 header to reserve appdata */
 
   dev->d_iob = iob_trimhead(dev->d_iob, len);
-  if (dev->d_iob == NULL)
+  if (dev->d_iob == NULL || dev->d_iob->io_pktlen == 0)
     {
       /* No available data, clear device buffer */
 
+      iob_free_chain(dev->d_iob);
       goto clear;
     }
 


### PR DESCRIPTION
## Summary
Fix clear condition in TCP ofoseg input (when receiving an out-of-ordered ACK)

We have a case that an http server gives out-of-ordered ACKs, and NuttX client makes `ofoseg`s with length 0, trying to rebuild / put them into `ofosegs` array, which is not intended (no available data and should be skipped). This breaks later logic and finally crashed in `tcp_ofoseg_bufsize` (`ofosegs[i].data` is `NULL`, which should never happen in normal logic).

Note:
- `iob_trimhead` won't return `NULL` when it's applying on normal IOB.
  - Keep `dev->d_iob == NULL` to avoid `iob_trimhead` changed.
- `iob_free_chain` will do nothing when applied to `NULL`.

Patch also included:
- mm/iob: Don't return NULL in iob_pack
  - The direct reason which causes `ofosegs[i].data` become `NULL` in `tcp_ofoseg_bufsize` when there are several `ofoseg`s with length 0.

## Impact
TCP Out-of-order segment process, especially when receiving an out-of-ordered ACK.

## Testing
Manually.