### PR TITLE
net/rpmsg: Set family for rpaddr in ns_bind

### DIFF
--- a/net/rpmsg/rpmsg_sockif.c
+++ b/net/rpmsg/rpmsg_sockif.c
@@ -518,6 +518,7 @@ static void rpmsg_socket_ns_bind(FAR struct rpmsg_device *rdev,
       return;
     }
 
+  new->rpaddr.rp_family = AF_RPMSG;
   strlcpy(new->rpaddr.rp_cpu, rpmsg_get_cpuname(rdev),
           sizeof(new->rpaddr.rp_cpu));
   strlcpy(new->rpaddr.rp_name, name + RPMSG_SOCKET_NAME_PREFIX_LEN,


### PR DESCRIPTION
## Summary
The rpmsg addr get from socket accept has rp_family=0, which is not intended, to avoid wrong logic in other place, set the rp_family in ns_bind function.

## Impact
Set rp_family in rpaddr.

## Testing
CI / Manually.
