### PR TITLE
libelf: Support prioritized init and fini arrays.

### DIFF
--- a/binfmt/libelf/gnu-elf.ld
+++ b/binfmt/libelf/gnu-elf.ld
@@ -75,6 +75,7 @@ SECTIONS
       _sctors = . ;
       *(.ctors)       /* Old ABI:  Unallocated */
       *(.init_array)  /* New ABI:  Allocated */
+      *(SORT(.init_array.*))
       _ectors = . ;
     }
 
@@ -83,6 +84,7 @@ SECTIONS
       _sdtors = . ;
       *(.dtors)       /* Old ABI:  Unallocated */
       *(.fini_array)  /* New ABI:  Allocated */
+      *(SORT(.fini_array.*))
       _edtors = . ;
     }
 


### PR DESCRIPTION
## Summary

Add a wildcard operator to `gnu-elf.ld` to ensure all c++ constructors and destruction are included in partially linked application binaries.

## Impact

Statically and globally declared constructors which specify an initialisation priority are correctly called in `crt0`. Unless I'm mistaken, this shouldn't impact applications which don't provide constructors and destructors with this attribute.

## Testing

Tested with `cxxtest` application using LLVM libcxx 15.0.7, GCC 12.2.0 on Litex vexrisc_smp core. 
