### PR TITLE
l2cc: Don't repeat disabling the cache when the cache is already disabled

### DIFF
--- a/arch/arm/src/armv7-a/arm_l2cc_pl310.c
+++ b/arch/arm/src/armv7-a/arm_l2cc_pl310.c
@@ -437,6 +437,12 @@ void l2cc_enable(void)
   /* Invalidate and enable the cache (must be disabled to do this!) */
 
   flags = enter_critical_section();
+
+  if ((getreg32(L2CC_CR) & L2CC_CR_L2CEN) != 0)
+    {
+      l2cc_disable();
+    }
+
   l2cc_invalidate_all();
   putreg32(L2CC_CR_L2CEN, L2CC_CR);
   ARM_DSB();
@@ -520,16 +526,10 @@ void l2cc_sync(void)
 void l2cc_invalidate_all(void)
 {
   irqstate_t flags;
-  uint32_t regval;
 
   /* Invalidate all ways */
 
   flags = enter_critical_section();
-
-  /* Disable the L2 cache while we invalidate it */
-
-  regval = getreg32(L2CC_CR);
-  l2cc_disable();
 
   /* Invalidate all ways by writing the bit mask of ways to be invalidated
    * the Invalidate Way Register (IWR).
@@ -547,9 +547,6 @@ void l2cc_invalidate_all(void)
 
   putreg32(0, L2CC_CSR);
 
-  /* Then re-enable the L2 cache if it was enabled before */
-
-  putreg32(regval, L2CC_CR);
   leave_critical_section(flags);
 }
 

--- a/arch/arm/src/armv7-r/arm_l2cc_pl310.c
+++ b/arch/arm/src/armv7-r/arm_l2cc_pl310.c
@@ -437,6 +437,12 @@ void l2cc_enable(void)
   /* Invalidate and enable the cache (must be disabled to do this!) */
 
   flags = enter_critical_section();
+
+  if ((getreg32(L2CC_CR) & L2CC_CR_L2CEN) != 0)
+    {
+      l2cc_disable();
+    }
+
   l2cc_invalidate_all();
   putreg32(L2CC_CR_L2CEN, L2CC_CR);
   ARM_DSB();
@@ -520,16 +526,10 @@ void l2cc_sync(void)
 void l2cc_invalidate_all(void)
 {
   irqstate_t flags;
-  uint32_t regval;
 
   /* Invalidate all ways */
 
   flags = enter_critical_section();
-
-  /* Disable the L2 cache while we invalidate it */
-
-  regval = getreg32(L2CC_CR);
-  l2cc_disable();
 
   /* Invalidate all ways by writing the bit mask of ways to be invalidated
    * the Invalidate Way Register (IWR).
@@ -547,9 +547,6 @@ void l2cc_invalidate_all(void)
 
   putreg32(0, L2CC_CSR);
 
-  /* Then re-enable the L2 cache if it was enabled before */
-
-  putreg32(regval, L2CC_CR);
   leave_critical_section(flags);
 }
 


### PR DESCRIPTION
## Summary

When l2cc is already in disable state, performing a disable operation again will flush incorrect cache data to memory.
So, when it is found that the L2 cache is in a disabled state during startup, no flash operation is performed. Only when it is necessary to disable the L2 cache, a flush operation is performed.

## Impact

L2 cache

## Testing

sabre-6quad:smp