### PR TITLE
mm/mm_map: Give the mm_map as parameter to the mm_map functions

### DIFF
--- a/fs/mmap/fs_anonmap.c
+++ b/fs/mmap/fs_anonmap.c
@@ -24,6 +24,7 @@
 
 #include <nuttx/config.h>
 #include <nuttx/kmalloc.h>
+#include <nuttx/sched.h>
 #include <assert.h>
 #include <debug.h>
 
@@ -133,7 +134,7 @@ int map_anonymous(FAR struct mm_map_entry_s *entry, bool kernel)
   entry->munmap = unmap_anonymous;
   entry->priv.i = kernel;
 
-  ret = mm_map_add(entry);
+  ret = mm_map_add(get_current_mm(), entry);
   if (ret < 0)
     {
       if (kernel)

--- a/fs/mmap/fs_munmap.c
+++ b/fs/mmap/fs_munmap.c
@@ -47,6 +47,7 @@ static int file_munmap_(FAR void *start, size_t length, bool kernel)
   FAR struct tcb_s *tcb = nxsched_self();
   FAR struct task_group_s *group = tcb->group;
   FAR struct mm_map_entry_s *entry = NULL;
+  FAR struct mm_map_s *mm = get_current_mm();
   int ret = OK;
 
   /* Iterate through all the mappings and call the underlying
@@ -59,7 +60,7 @@ static int file_munmap_(FAR void *start, size_t length, bool kernel)
   ret = mm_map_lock();
   if (ret == OK)
     {
-      while (ret == OK && (entry = mm_map_find(start, length)))
+      while (ret == OK && (entry = mm_map_find(mm, start, length)))
         {
           DEBUGASSERT(entry->munmap);
           ret = entry->munmap(group, entry, start, length);

--- a/fs/mmap/fs_rammap.c
+++ b/fs/mmap/fs_rammap.c
@@ -33,6 +33,7 @@
 
 #include <nuttx/fs/fs.h>
 #include <nuttx/kmalloc.h>
+#include <nuttx/sched.h>
 
 #include "fs_rammap.h"
 
@@ -240,7 +241,7 @@ int rammap(FAR struct file *filep, FAR struct mm_map_entry_s *entry,
   entry->priv.i = kernel;
   entry->munmap = unmap_rammap;
 
-  ret = mm_map_add(entry);
+  ret = mm_map_add(get_current_mm(), entry);
   if (ret < 0)
     {
       goto errout_with_region;

--- a/fs/shm/shmfs.c
+++ b/fs/shm/shmfs.c
@@ -302,7 +302,7 @@ static int shmfs_mmap(FAR struct file *filep,
         {
           entry->munmap = shmfs_munmap;
           entry->priv.p = (FAR void *)filep->f_inode;
-          mm_map_add(entry);
+          mm_map_add(get_current_mm(), entry);
         }
     }
 

--- a/include/nuttx/mm/map.h
+++ b/include/nuttx/mm/map.h
@@ -152,23 +152,6 @@ void mm_map_initialize(FAR struct mm_map_s *mm, bool kernel);
 
 void mm_map_destroy(FAR struct mm_map_s *mm);
 
-/****************************************************************************
- * Name: mm_map_add
- *
- * Description:
- *   Adds a virtual memory area into the list of mappings
- *
- * Input Parameters:
- *   entry - A pointer to mm_map_entry_s, mapping info to be added
- *
- * Returned Value:
- *   OK        Added successfully
- *   -EINVAL:  Invalid attempt to get the semaphore
- *   -EINTR:   The wait was interrupted by the receipt of a signal.
- *   -ENOMEM:  Out of memory
- *
- ****************************************************************************/
-
 #ifdef CONFIG_ARCH_VMA_MAPPING
 
 /****************************************************************************
@@ -209,7 +192,25 @@ void vm_release_region(FAR struct mm_map_s *mm, FAR void *vaddr,
 
 #endif
 
-int mm_map_add(FAR struct mm_map_entry_s *entry);
+/****************************************************************************
+ * Name: mm_map_add
+ *
+ * Description:
+ *   Adds a virtual memory area into the list of mappings
+ *
+ * Input Parameters:
+ *   mm    - A pointer to mm_map_s, which describes the virtual memory area
+ *   entry - A pointer to mm_map_entry_s, mapping info to be added
+ *
+ * Returned Value:
+ *   OK        Added successfully
+ *   -EINVAL:  Invalid attempt to get the semaphore
+ *   -EINTR:   The wait was interrupted by the receipt of a signal.
+ *   -ENOMEM:  Out of memory
+ *
+ ****************************************************************************/
+
+int mm_map_add(FAR struct mm_map_s *mm, FAR struct mm_map_entry_s *entry);
 
 /****************************************************************************
  * Name: mm_map_next
@@ -220,15 +221,16 @@ int mm_map_add(FAR struct mm_map_entry_s *entry);
  *   mapping when the argument "entry" is NULL.
  *
  * Input Parameters:
- *   entry  - Pointer to a single mapping in this task group or NULL to get
- *            the first one
+ *   mm    - A pointer to mm_map_s, which describes the virtual memory area
+ *   entry - Pointer to a single mapping in this task group or NULL to get
+ *           the first one
  *
  * Returned Value:
  *   Pointer to the next mapping
  *
  ****************************************************************************/
 
-FAR struct mm_map_entry_s *mm_map_next(
+FAR struct mm_map_entry_s *mm_map_next(FAR struct mm_map_s *mm,
                            FAR const struct mm_map_entry_s *entry);
 
 /****************************************************************************
@@ -238,15 +240,17 @@ FAR struct mm_map_entry_s *mm_map_next(
  *   Find the first mapping matching address and length
  *
  * Input Parameters:
- *   vaddr   - Start address of the mapped area
- *   length  - Length of the mapping
+ *   mm     - A pointer to mm_map_s, which describes the virtual memory area
+ *   vaddr  - Start address of the mapped area
+ *   length - Length of the mapping
  *
  * Returned Value:
  *   Pointer to the mapping, NULL if not found
  *
  ****************************************************************************/
 
-FAR struct mm_map_entry_s *mm_map_find(FAR const void *vaddr,
+FAR struct mm_map_entry_s *mm_map_find(FAR struct mm_map_s *mm,
+                                       FAR const void *vaddr,
                                        size_t length);
 
 /****************************************************************************

--- a/mm/map/mm_map.c
+++ b/mm/map/mm_map.c
@@ -171,9 +171,8 @@ void mm_map_destroy(FAR struct mm_map_s *mm)
  *
  ****************************************************************************/
 
-int mm_map_add(FAR struct mm_map_entry_s *entry)
+int mm_map_add(FAR struct mm_map_s *mm, FAR struct mm_map_entry_s *entry)
 {
-  FAR struct mm_map_s *mm = get_current_mm();
   FAR struct mm_map_entry_s *new_entry;
   int ret;
 
@@ -214,10 +213,9 @@ int mm_map_add(FAR struct mm_map_entry_s *entry)
  *
  ****************************************************************************/
 
-FAR struct mm_map_entry_s *mm_map_next(
+FAR struct mm_map_entry_s *mm_map_next(FAR struct mm_map_s *mm,
                            FAR const struct mm_map_entry_s *entry)
 {
-  FAR struct mm_map_s *mm = get_current_mm();
   FAR struct mm_map_entry_s *next_entry = NULL;
 
   if (nxrmutex_lock(&mm->mm_map_mutex) == OK)
@@ -246,9 +244,10 @@ FAR struct mm_map_entry_s *mm_map_next(
  *
  ****************************************************************************/
 
-FAR struct mm_map_entry_s *mm_map_find(FAR const void *vaddr, size_t length)
+FAR struct mm_map_entry_s *mm_map_find(FAR struct mm_map_s *mm,
+                                       FAR const void *vaddr,
+                                       size_t length)
 {
-  FAR struct mm_map_s *mm = get_current_mm();
   FAR struct mm_map_entry_s *found_entry = NULL;
 
   if (nxrmutex_lock(&mm->mm_map_mutex) == OK)

--- a/mm/shm/shmat.c
+++ b/mm/shm/shmat.c
@@ -271,7 +271,7 @@ FAR void *shmat(int shmid, FAR const void *shmaddr, int shmflg)
   entry.munmap = munmap_shm;
   entry.priv.i = shmid;
 
-  ret = mm_map_add(&entry);
+  ret = mm_map_add(get_current_mm(), &entry);
   if (ret < 0)
     {
       shmerr("ERROR: mm_map_add() failed\n");

--- a/mm/shm/shmdt.c
+++ b/mm/shm/shmdt.c
@@ -85,7 +85,7 @@ int shmdt(FAR const void *shmaddr)
        * shmaddr. The mapping is matched with just shmaddr == map->vaddr.
        */
 
-      entry = mm_map_find(shmaddr, 1);
+      entry = mm_map_find(get_current_mm(), shmaddr, 1);
       if (entry && entry->vaddr == shmaddr)
         {
           DEBUGASSERT(entry->munmap);


### PR DESCRIPTION
## Summary
This way the mappings can be modified for any vm area, not only the process that is running.

Why? This allows mapping pages to kernel dynamically, this functionality will be presented later.
## Impact
Adds option to modify other mappings besides the current processes mappings
## Testing
icicle:knsh
