### PR TITLE
Add some network-related definitions

### DIFF
--- a/include/net/ethernet.h
+++ b/include/net/ethernet.h
@@ -33,6 +33,10 @@
 
 #define ETHER_ADDR_LEN  6
 
+#define ETHERTYPE_ARP   0x0806 /* Address resolution protocol */
+#define ETHERTYPE_IP    0x0800 /* IP */
+#define ETHERTYPE_IPV6  0x86dd /* IP protocol version 6 */
+
 /****************************************************************************
  * Public Type Definitions
  ****************************************************************************/

--- a/include/net/if.h
+++ b/include/net/if.h
@@ -54,8 +54,10 @@
 #define IFF_POINTOPOINT    (1 << 6)  /* Is point-to-point link */
 #define IFF_NOARP          (1 << 7)  /* ARP is not required for this packet */
 #define IFF_NAT            (1 << 8)  /* NAT is enabled for this interface */
+#define IFF_SLAVE          (1 << 11) /* Slave of a load balancer. */
 #define IFF_MULTICAST      (1 << 12) /* Supports multicast. */
 #define IFF_BROADCAST      (1 << 13) /* Broadcast address valid. */
+#define IFF_DYNAMIC        (1 << 15) /* Dialup device with changing addresses. */
 
 /* Interface flag helpers */
 
@@ -67,6 +69,8 @@
 #define IFF_SET_POINTOPOINT(f) do { (f) |= IFF_POINTOPOINT; } while (0)
 #define IFF_SET_MULTICAST(f)   do { (f) |= IFF_MULTICAST; } while (0)
 #define IFF_SET_BROADCAST(f)   do { (f) |= IFF_BROADCAST; } while (0)
+#define IFF_SET_SLAVE(f)       do { (f) |= IFF_SLAVE; } while (0)
+#define IFF_SET_DYNAMIC(f)     do { (f) |= IFF_DYNAMIC; } while (0)
 
 #define IFF_CLR_UP(f)          do { (f) &= ~IFF_UP; } while (0)
 #define IFF_CLR_RUNNING(f)     do { (f) &= ~IFF_RUNNING; } while (0)
@@ -76,6 +80,8 @@
 #define IFF_CLR_POINTOPOINT(f) do { (f) &= ~IFF_POINTOPOINT; } while (0)
 #define IFF_CLR_MULTICAST(f)   do { (f) &= ~IFF_MULTICAST; } while (0)
 #define IFF_CLR_BROADCAST(f)   do { (f) &= ~IFF_BROADCAST; } while (0)
+#define IFF_CLR_SLAVE(f)       do { (f) &= ~IFF_SLAVE; } while (0)
+#define IFF_CLR_DYNAMIC(f)     do { (f) &= ~IFF_DYNAMIC; } while (0)
 
 #define IFF_IS_UP(f)          (((f) & IFF_UP) != 0)
 #define IFF_IS_RUNNING(f)     (((f) & IFF_RUNNING) != 0)
@@ -85,6 +91,8 @@
 #define IFF_IS_POINTOPOINT(f) (((f) & IFF_POINTOPOINT) != 0)
 #define IFF_IS_MULTICAST(f)   (((f) & IFF_MULTICAST) != 0)
 #define IFF_IS_BROADCAST(f)   (((f) & IFF_BROADCAST) != 0)
+#define IFF_IS_SLAVE(f)       (((f) & IFF_SLAVE) != 0)
+#define IFF_IS_DYNAMIC(f)     (((f) & IFF_DYNAMIC) != 0)
 
 /* We only need to manage the IPv6 bit if both IPv6 and IPv4 are supported.
  * Otherwise, we can save a few bytes by ignoring it.

--- a/include/net/if_arp.h
+++ b/include/net/if_arp.h
@@ -1,0 +1,135 @@
+/****************************************************************************
+ * include/net/if_arp.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_NET_IF_ARP_H
+#define __INCLUDE_NET_IF_ARP_H
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* ARP protocol HARDWARE identifiers. */
+
+#define ARPHRD_NETROM     0             /* from KA9Q: NET/ROM pseudo    */
+#define ARPHRD_ETHER      1             /* Ethernet                     */
+#define ARPHRD_EETHER     2             /* Experimental Ethernet        */
+#define ARPHRD_AX25       3             /* AX.25 Level 2                */
+#define ARPHRD_PRONET     4             /* PROnet token ring            */
+#define ARPHRD_CHAOS      5             /* Chaosnet                     */
+#define ARPHRD_IEEE802    6             /* IEEE 802.2 Ethernet/TR/TB    */
+#define ARPHRD_ARCNET     7             /* ARCnet                       */
+#define ARPHRD_APPLETLK   8             /* APPLEtalk                    */
+#define ARPHRD_DLCI       15            /* Frame Relay DLCI             */
+#define ARPHRD_ATM        19            /* ATM                          */
+#define ARPHRD_METRICOM   23            /* Metricom STRIP (new IANA id) */
+#define ARPHRD_IEEE1394   24            /* IEEE 1394 IPv4 - RFC 2734    */
+#define ARPHRD_EUI64      27            /* EUI-64                       */
+#define ARPHRD_INFINIBAND 32            /* InfiniBand                   */
+
+/* Dummy types for non ARP hardware */
+#define ARPHRD_SLIP     256
+#define ARPHRD_CSLIP    257
+#define ARPHRD_SLIP6    258
+#define ARPHRD_CSLIP6   259
+#define ARPHRD_RSRVD    260             /* Notional KISS type           */
+#define ARPHRD_ADAPT    264
+#define ARPHRD_ROSE     270
+#define ARPHRD_X25      271             /* CCITT X.25                   */
+#define ARPHRD_HWX25    272             /* Boards with X.25 in firmware */
+#define ARPHRD_CAN      280             /* Controller Area Network      */
+#define ARPHRD_PPP      512
+#define ARPHRD_CISCO    513             /* Cisco HDLC                   */
+#define ARPHRD_HDLC     ARPHRD_CISCO
+#define ARPHRD_LAPB     516             /* LAPB                         */
+#define ARPHRD_DDCMP    517             /* Digital's DDCMP protocol     */
+#define ARPHRD_RAWHDLC  518             /* Raw HDLC                     */
+#define ARPHRD_RAWIP    519             /* Raw IP                       */
+#define ARPHRD_TUNNEL   768             /* IPIP tunnel                  */
+#define ARPHRD_TUNNEL6  769             /* IP6IP6 tunnel                */
+#define ARPHRD_FRAD     770             /* Frame Relay Access Device    */
+#define ARPHRD_SKIP     771             /* SKIP vif                     */
+#define ARPHRD_LOOPBACK 772             /* Loopback device              */
+#define ARPHRD_LOCALTLK 773             /* Localtalk device             */
+#define ARPHRD_FDDI     774             /* Fiber Distributed Data Interface */
+#define ARPHRD_BIF      775             /* AP1000 BIF                   */
+#define ARPHRD_SIT      776             /* sit0 device - IPv6-in-IPv4   */
+#define ARPHRD_IPDDP    777             /* IP over DDP tunneller        */
+#define ARPHRD_IPGRE    778             /* GRE over IP                  */
+#define ARPHRD_PIMREG   779             /* PIMSM register interface     */
+#define ARPHRD_HIPPI    780             /* High Performance Parallel Interface */
+#define ARPHRD_ASH      781             /* Nexus 64Mbps Ash             */
+#define ARPHRD_ECONET   782             /* Acorn Econet                 */
+#define ARPHRD_IRDA     783             /* Linux-IrDA                   */
+
+/* ARP works differently on different FC media .. so  */
+
+#define ARPHRD_FCPP     784             /* Point to point fibrechannel  */
+#define ARPHRD_FCAL     785             /* Fibrechannel arbitrated loop */
+#define ARPHRD_FCPL     786             /* Fibrechannel public loop     */
+#define ARPHRD_FCFABRIC 787             /* Fibrechannel fabric          */
+
+/* 787->799 reserved for fibrechannel media types */
+
+#define ARPHRD_IEEE802_TR         800   /* Magic type ident for TR      */
+#define ARPHRD_IEEE80211          801   /* IEEE 802.11                  */
+#define ARPHRD_IEEE80211_PRISM    802   /* IEEE 802.11 + Prism2 header  */
+#define ARPHRD_IEEE80211_RADIOTAP 803   /* IEEE 802.11 + radiotap header */
+#define ARPHRD_IEEE802154         804   /* IEEE 802.15.4 */
+#define ARPHRD_IEEE802154_MONITOR 805   /* IEEE 802.15.4 network monitor */
+
+#define ARPHRD_PHONET      820          /* PhoNet media type            */
+#define ARPHRD_PHONET_PIPE 821          /* PhoNet pipe header           */
+#define ARPHRD_CAIF        822          /* CAIF media type              */
+#define ARPHRD_IP6GRE      823          /* GRE over IPv6                */
+#define ARPHRD_NETLINK     824          /* Netlink header               */
+#define ARPHRD_6LOWPAN     825          /* IPv6 over LoWPAN             */
+#define ARPHRD_VSOCKMON    826          /* Vsock monitor header         */
+
+#define ARPHRD_VOID        0xFFFF       /* Void type, nothing is known  */
+#define ARPHRD_NONE        0xFFFE       /* zero header length           */
+
+/* ARP protocol opcodes. */
+
+#define ARPOP_REQUEST   1               /* ARP request                  */
+#define ARPOP_REPLY     2               /* ARP reply                    */
+#define ARPOP_RREQUEST  3               /* RARP request                 */
+#define ARPOP_RREPLY    4               /* RARP reply                   */
+#define ARPOP_InREQUEST 8               /* InARP request                */
+#define ARPOP_InREPLY   9               /* InARP reply                  */
+#define ARPOP_NAK       10              /* (ATM)ARP NAK                 */
+
+/* See RFC 826 for protocol description.  ARP packets are variable
+ * in size; the arphdr structure defines the fixed-length portion.
+ * Protocol type values are the same as those for 10 Mb/s Ethernet.
+ * It is followed by the variable-sized fields ar_sha, arp_spa,
+ * arp_tha and arp_tpa in that order, according to the lengths
+ * specified.  Field names used correspond to RFC 826.
+ */
+
+struct arphdr
+{
+  unsigned short int ar_hrd;          /* Format of hardware address.  */
+  unsigned short int ar_pro;          /* Format of protocol address.  */
+  unsigned char ar_hln;               /* Length of hardware address.  */
+  unsigned char ar_pln;               /* Length of protocol address.  */
+  unsigned short int ar_op;           /* ARP opcode (command).  */
+};
+
+#endif /* __INCLUDE_NET_IF_ARP_H */

--- a/include/net/route.h
+++ b/include/net/route.h
@@ -28,6 +28,7 @@
 #include <nuttx/config.h>
 
 #include <sys/socket.h>
+#include <netinet/in.h>
 
 #include <nuttx/net/ioctl.h>
 
@@ -55,6 +56,20 @@ struct rtentry
   struct sockaddr_storage rt_genmask; /* Network mask defining the sub-net */
   uint16_t rt_flags;
   FAR char *rt_dev;                   /* Forcing the device at add. */
+};
+
+struct in6_rtmsg
+{
+  struct in6_addr rtmsg_dst;
+  struct in6_addr rtmsg_src;
+  struct in6_addr rtmsg_gateway;
+  uint32_t rtmsg_type;
+  uint16_t rtmsg_dst_len;
+  uint16_t rtmsg_src_len;
+  uint32_t rtmsg_metric;
+  unsigned long int rtmsg_info;
+  uint32_t rtmsg_flags;
+  int rtmsg_ifindex;
 };
 
 /****************************************************************************

--- a/include/netinet/arp.h
+++ b/include/netinet/arp.h
@@ -29,28 +29,13 @@
 
 #include <stdint.h>
 #include <net/if.h>
+#include <net/if_arp.h>
 
 #include <nuttx/fs/ioctl.h>
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
-
-/* ARP protocol HARDWARE identifiers.  Provided as the sa_family member of a
- * struct sockaddr.
- *
- * When sa_family is ARPHRD_ETHER, the 6 byte Ethernet address is provided
- * in the first 6-bytes of the sockaddr sa_data array.
- */
-
-#define ARPHRD_ETHER        1    /* Ethernet */
-#define ARPHRD_PPP          512
-#define ARPHRD_LOOPBACK     772  /* Loopback device    */
-#define ARPHRD_IEEE80211    801  /* IEEE 802.11 */
-#define ARPHRD_IEEE802154   804  /* IEEE 802.15.4 */
-
-#define ARPHRD_VOID         0xFFFF  /* Void type, nothing is known */
-#define ARPHRD_NONE         0xFFFE  /* zero header length */
 
 /* Three ioctls are available on all PF_INET sockets. Each ioctl takes a
  * pointer to a 'struct arpreq' as its parameter.

--- a/include/netinet/icmp6.h
+++ b/include/netinet/icmp6.h
@@ -1,0 +1,364 @@
+/****************************************************************************
+ * include/netinet/icmp6.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef _INCLUDE_NETINET_ICMP6_H
+#define _INCLUDE_NETINET_ICMP6_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <string.h>
+#include <sys/types.h>
+#include <netinet/in.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define ICMP6_FILTER             1
+
+#define ICMP6_FILTER_BLOCK       1
+#define ICMP6_FILTER_PASS        2
+#define ICMP6_FILTER_BLOCKOTHERS 3
+#define ICMP6_FILTER_PASSONLY    4
+
+struct icmp6_filter
+{
+  uint32_t icmp6_filt[8];
+};
+
+struct icmp6_hdr
+{
+  uint8_t     icmp6_type;   /* type field */
+  uint8_t     icmp6_code;   /* code field */
+  uint16_t    icmp6_cksum;  /* checksum field */
+  union
+  {
+    uint32_t  icmp6_un_data32[1]; /* type-specific field */
+    uint16_t  icmp6_un_data16[2]; /* type-specific field */
+    uint8_t   icmp6_un_data8[4];  /* type-specific field */
+  } icmp6_dataun;
+};
+
+#define icmp6_data32    icmp6_dataun.icmp6_un_data32
+#define icmp6_data16    icmp6_dataun.icmp6_un_data16
+#define icmp6_data8     icmp6_dataun.icmp6_un_data8
+#define icmp6_pptr      icmp6_data32[0]  /* parameter prob */
+#define icmp6_mtu       icmp6_data32[0]  /* packet too big */
+#define icmp6_id        icmp6_data16[0]  /* echo request/reply */
+#define icmp6_seq       icmp6_data16[1]  /* echo request/reply */
+#define icmp6_maxdelay  icmp6_data16[0]  /* mcast group membership */
+
+#define ICMP6_DST_UNREACH             1
+#define ICMP6_PACKET_TOO_BIG          2
+#define ICMP6_TIME_EXCEEDED           3
+#define ICMP6_PARAM_PROB              4
+
+#define ICMP6_INFOMSG_MASK            0x80    /* all informational messages */
+
+#define ICMP6_ECHO_REQUEST            128
+#define ICMP6_ECHO_REPLY              129
+#define MLD_LISTENER_QUERY            130
+#define MLD_LISTENER_REPORT           131
+#define MLD_LISTENER_REDUCTION        132
+
+#define ICMP6_DST_UNREACH_NOROUTE     0 /* no route to destination */
+#define ICMP6_DST_UNREACH_ADMIN       1 /* communication with destination */
+                                        /* administratively prohibited */
+#define ICMP6_DST_UNREACH_BEYONDSCOPE 2 /* beyond scope of source address */
+#define ICMP6_DST_UNREACH_ADDR        3 /* address unreachable */
+#define ICMP6_DST_UNREACH_NOPORT      4 /* bad port */
+
+#define ICMP6_TIME_EXCEED_TRANSIT     0 /* Hop Limit == 0 in transit */
+#define ICMP6_TIME_EXCEED_REASSEMBLY  1 /* Reassembly time out */
+
+#define ICMP6_PARAMPROB_HEADER        0 /* erroneous header field */
+#define ICMP6_PARAMPROB_NEXTHEADER    1 /* unrecognized Next Header */
+#define ICMP6_PARAMPROB_OPTION        2 /* unrecognized IPv6 option */
+
+#define ICMP6_FILTER_WILLPASS(type, filterp) \
+  ((((filterp)->icmp6_filt[(type) >> 5]) & (1 << ((type) & 31))) == 0)
+
+#define ICMP6_FILTER_WILLBLOCK(type, filterp) \
+  ((((filterp)->icmp6_filt[(type) >> 5]) & (1 << ((type) & 31))) != 0)
+
+#define ICMP6_FILTER_SETPASS(type, filterp) \
+  ((((filterp)->icmp6_filt[(type) >> 5]) &= ~(1 << ((type) & 31))))
+
+#define ICMP6_FILTER_SETBLOCK(type, filterp) \
+  ((((filterp)->icmp6_filt[(type) >> 5]) |=  (1 << ((type) & 31))))
+
+#define ICMP6_FILTER_SETPASSALL(filterp) \
+  memset(filterp, 0, sizeof (struct icmp6_filter));
+
+#define ICMP6_FILTER_SETBLOCKALL(filterp) \
+  memset(filterp, 0xFF, sizeof (struct icmp6_filter));
+
+#define ND_ROUTER_SOLICIT           133
+#define ND_ROUTER_ADVERT            134
+#define ND_NEIGHBOR_SOLICIT         135
+#define ND_NEIGHBOR_ADVERT          136
+#define ND_REDIRECT                 137
+
+struct nd_router_solicit      /* router solicitation */
+{
+  struct icmp6_hdr nd_rs_hdr;
+
+  /* could be followed by options */
+};
+
+#define nd_rs_type               nd_rs_hdr.icmp6_type
+#define nd_rs_code               nd_rs_hdr.icmp6_code
+#define nd_rs_cksum              nd_rs_hdr.icmp6_cksum
+#define nd_rs_reserved           nd_rs_hdr.icmp6_data32[0]
+
+struct nd_router_advert       /* router advertisement */
+{
+  struct icmp6_hdr nd_ra_hdr;
+  uint32_t nd_ra_reachable;   /* reachable time */
+  uint32_t nd_ra_retransmit;  /* retransmit timer */
+
+  /* could be followed by options */
+};
+
+#define nd_ra_type               nd_ra_hdr.icmp6_type
+#define nd_ra_code               nd_ra_hdr.icmp6_code
+#define nd_ra_cksum              nd_ra_hdr.icmp6_cksum
+#define nd_ra_curhoplimit        nd_ra_hdr.icmp6_data8[0]
+#define nd_ra_flags_reserved     nd_ra_hdr.icmp6_data8[1]
+#define ND_RA_FLAG_MANAGED       0x80
+#define ND_RA_FLAG_OTHER         0x40
+#define ND_RA_FLAG_HOME_AGENT    0x20
+#define nd_ra_router_lifetime    nd_ra_hdr.icmp6_data16[1]
+
+struct nd_neighbor_solicit    /* neighbor solicitation */
+{
+  struct icmp6_hdr nd_ns_hdr;
+  struct in6_addr nd_ns_target; /* target address */
+
+  /* could be followed by options */
+};
+
+#define nd_ns_type               nd_ns_hdr.icmp6_type
+#define nd_ns_code               nd_ns_hdr.icmp6_code
+#define nd_ns_cksum              nd_ns_hdr.icmp6_cksum
+#define nd_ns_reserved           nd_ns_hdr.icmp6_data32[0]
+
+struct nd_neighbor_advert     /* neighbor advertisement */
+{
+  struct icmp6_hdr nd_na_hdr;
+  struct in6_addr nd_na_target; /* target address */
+
+  /* could be followed by options */
+};
+
+#define nd_na_type               nd_na_hdr.icmp6_type
+#define nd_na_code               nd_na_hdr.icmp6_code
+#define nd_na_cksum              nd_na_hdr.icmp6_cksum
+#define nd_na_flags_reserved     nd_na_hdr.icmp6_data32[0]
+#if     __BYTE_ORDER == __BIG_ENDIAN
+#define ND_NA_FLAG_ROUTER        0x80000000
+#define ND_NA_FLAG_SOLICITED     0x40000000
+#define ND_NA_FLAG_OVERRIDE      0x20000000
+#else   /* __BYTE_ORDER == __LITTLE_ENDIAN */
+#define ND_NA_FLAG_ROUTER        0x00000080
+#define ND_NA_FLAG_SOLICITED     0x00000040
+#define ND_NA_FLAG_OVERRIDE      0x00000020
+#endif
+
+struct nd_redirect            /* redirect */
+{
+  struct icmp6_hdr  nd_rd_hdr;
+  struct in6_addr   nd_rd_target; /* target address */
+  struct in6_addr   nd_rd_dst;    /* destination address */
+
+  /* could be followed by options */
+};
+
+#define nd_rd_type               nd_rd_hdr.icmp6_type
+#define nd_rd_code               nd_rd_hdr.icmp6_code
+#define nd_rd_cksum              nd_rd_hdr.icmp6_cksum
+#define nd_rd_reserved           nd_rd_hdr.icmp6_data32[0]
+
+struct nd_opt_hdr             /* Neighbor discovery option header */
+{
+  uint8_t  nd_opt_type;
+  uint8_t  nd_opt_len;        /* in units of 8 octets */
+
+  /* followed by option specific data */
+};
+
+#define ND_OPT_SOURCE_LINKADDR    1
+#define ND_OPT_TARGET_LINKADDR    2
+#define ND_OPT_PREFIX_INFORMATION 3
+#define ND_OPT_REDIRECTED_HEADER  4
+#define ND_OPT_MTU                5
+#define ND_OPT_RTR_ADV_INTERVAL   7
+#define ND_OPT_HOME_AGENT_INFO    8
+
+struct nd_opt_prefix_info     /* prefix information */
+{
+  uint8_t   nd_opt_pi_type;
+  uint8_t   nd_opt_pi_len;
+  uint8_t   nd_opt_pi_prefix_len;
+  uint8_t   nd_opt_pi_flags_reserved;
+  uint32_t  nd_opt_pi_valid_time;
+  uint32_t  nd_opt_pi_preferred_time;
+  uint32_t  nd_opt_pi_reserved2;
+  struct in6_addr  nd_opt_pi_prefix;
+};
+
+#define ND_OPT_PI_FLAG_ONLINK 0x80
+#define ND_OPT_PI_FLAG_AUTO   0x40
+#define ND_OPT_PI_FLAG_RADDR  0x20
+
+struct nd_opt_rd_hdr          /* redirected header */
+{
+  uint8_t   nd_opt_rh_type;
+  uint8_t   nd_opt_rh_len;
+  uint16_t  nd_opt_rh_reserved1;
+  uint32_t  nd_opt_rh_reserved2;
+
+  /* followed by IP header and data */
+};
+
+struct nd_opt_mtu             /* MTU option */
+{
+  uint8_t   nd_opt_mtu_type;
+  uint8_t   nd_opt_mtu_len;
+  uint16_t  nd_opt_mtu_reserved;
+  uint32_t  nd_opt_mtu_mtu;
+};
+
+struct mld_hdr
+{
+  struct icmp6_hdr    mld_icmp6_hdr;
+  struct in6_addr     mld_addr; /* multicast address */
+};
+
+#define mld_type        mld_icmp6_hdr.icmp6_type
+#define mld_code        mld_icmp6_hdr.icmp6_code
+#define mld_cksum       mld_icmp6_hdr.icmp6_cksum
+#define mld_maxdelay    mld_icmp6_hdr.icmp6_data16[0]
+#define mld_reserved    mld_icmp6_hdr.icmp6_data16[1]
+
+#define ICMP6_ROUTER_RENUMBERING    138
+
+struct icmp6_router_renum    /* router renumbering header */
+{
+  struct icmp6_hdr    rr_hdr;
+  uint8_t             rr_segnum;
+  uint8_t             rr_flags;
+  uint16_t            rr_maxdelay;
+  uint32_t            rr_reserved;
+};
+
+#define rr_type         rr_hdr.icmp6_type
+#define rr_code         rr_hdr.icmp6_code
+#define rr_cksum        rr_hdr.icmp6_cksum
+#define rr_seqnum       rr_hdr.icmp6_data32[0]
+
+/* Router renumbering flags */
+#define ICMP6_RR_FLAGS_TEST             0x80
+#define ICMP6_RR_FLAGS_REQRESULT        0x40
+#define ICMP6_RR_FLAGS_FORCEAPPLY       0x20
+#define ICMP6_RR_FLAGS_SPECSITE         0x10
+#define ICMP6_RR_FLAGS_PREVDONE         0x08
+
+struct rr_pco_match    /* match prefix part */
+{
+  uint8_t             rpm_code;
+  uint8_t             rpm_len;
+  uint8_t             rpm_ordinal;
+  uint8_t             rpm_matchlen;
+  uint8_t             rpm_minlen;
+  uint8_t             rpm_maxlen;
+  uint16_t            rpm_reserved;
+  struct in6_addr     rpm_prefix;
+};
+
+/* PCO code values */
+#define RPM_PCO_ADD             1
+#define RPM_PCO_CHANGE          2
+#define RPM_PCO_SETGLOBAL       3
+
+struct rr_pco_use      /* use prefix part */
+{
+  uint8_t             rpu_uselen;
+  uint8_t             rpu_keeplen;
+  uint8_t             rpu_ramask;
+  uint8_t             rpu_raflags;
+  uint32_t            rpu_vltime;
+  uint32_t            rpu_pltime;
+  uint32_t            rpu_flags;
+  struct in6_addr     rpu_prefix;
+};
+
+#define ICMP6_RR_PCOUSE_RAFLAGS_ONLINK  0x20
+#define ICMP6_RR_PCOUSE_RAFLAGS_AUTO    0x10
+
+#if __BYTE_ORDER == __BIG_ENDIAN
+# define ICMP6_RR_PCOUSE_FLAGS_DECRVLTIME 0x80000000
+# define ICMP6_RR_PCOUSE_FLAGS_DECRPLTIME 0x40000000
+#elif __BYTE_ORDER == __LITTLE_ENDIAN
+# define ICMP6_RR_PCOUSE_FLAGS_DECRVLTIME 0x80
+# define ICMP6_RR_PCOUSE_FLAGS_DECRPLTIME 0x40
+#endif
+
+struct rr_result       /* router renumbering result message */
+{
+  uint16_t            rrr_flags;
+  uint8_t             rrr_ordinal;
+  uint8_t             rrr_matchedlen;
+  uint32_t            rrr_ifid;
+  struct in6_addr     rrr_prefix;
+};
+
+#if __BYTE_ORDER == __BIG_ENDIAN
+# define ICMP6_RR_RESULT_FLAGS_OOB       0x0002
+# define ICMP6_RR_RESULT_FLAGS_FORBIDDEN 0x0001
+#elif __BYTE_ORDER == __LITTLE_ENDIAN
+# define ICMP6_RR_RESULT_FLAGS_OOB       0x0200
+# define ICMP6_RR_RESULT_FLAGS_FORBIDDEN 0x0100
+#endif
+
+/* Mobile IPv6 extension: Advertisement Interval.  */
+
+struct nd_opt_adv_interval
+{
+  uint8_t   nd_opt_adv_interval_type;
+  uint8_t   nd_opt_adv_interval_len;
+  uint16_t  nd_opt_adv_interval_reserved;
+  uint32_t  nd_opt_adv_interval_ival;
+};
+
+/* Mobile IPv6 extension: Home Agent Info.  */
+
+struct nd_opt_home_agent_info
+{
+  uint8_t   nd_opt_home_agent_info_type;
+  uint8_t   nd_opt_home_agent_info_len;
+  uint16_t  nd_opt_home_agent_info_reserved;
+  uint16_t  nd_opt_home_agent_info_preference;
+  uint16_t  nd_opt_home_agent_info_lifetime;
+};
+
+#endif /* _INCLUDE_NETINET_ICMP6_H */

--- a/include/netinet/if_ether.h
+++ b/include/netinet/if_ether.h
@@ -1,0 +1,64 @@
+/****************************************************************************
+ * include/netinet/if_ether.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef _INCLUDE_NETINET_IF_ETHER_H
+#define _INCLUDE_NETINET_IF_ETHER_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdint.h>
+#include <net/if_arp.h>
+#include <net/ethernet.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define ETH_ALEN  6    /* Octets in one ethernet addr   */
+
+#define ETH_P_IP  ETHERTYPE_IP
+#define ETH_P_ARP ETHERTYPE_ARP
+
+/**
+ * Ethernet Address Resolution Protocol.
+ *
+ * See RFC 826 for protocol description.  Structure below is adapted
+ * to resolving internet addresses.  Field names used correspond to
+ * RFC 826.
+ */
+
+struct  ether_arp
+{
+  struct  arphdr ea_hdr;          /* fixed-size header */
+  uint8_t arp_sha[ETH_ALEN];      /* sender hardware address */
+  uint8_t arp_spa[4];             /* sender protocol address */
+  uint8_t arp_tha[ETH_ALEN];      /* target hardware address */
+  uint8_t arp_tpa[4];             /* target protocol address */
+};
+
+#define arp_hrd ea_hdr.ar_hrd
+#define arp_pro ea_hdr.ar_pro
+#define arp_hln ea_hdr.ar_hln
+#define arp_pln ea_hdr.ar_pln
+#define arp_op  ea_hdr.ar_op
+
+#endif /* _INCLUDE_NETINET_IF_ETHER_H */

--- a/include/netinet/ip.h
+++ b/include/netinet/ip.h
@@ -32,6 +32,33 @@
  * Public Type Definitions
  ****************************************************************************/
 
+#define IPVERSION 4     /* IP version number */
+#define IPDEFTTL  64    /* default ttl, from RFC 1340 */
+
+struct iphdr
+{
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+  unsigned int ihl:4;
+  unsigned int version:4;
+#elif __BYTE_ORDER == __BIG_ENDIAN
+  unsigned int version:4;
+  unsigned int ihl:4;
+#else
+# error "unknown endian"
+#endif
+  uint8_t tos;
+  uint16_t tot_len;
+  uint16_t id;
+  uint16_t frag_off;
+  uint8_t ttl;
+  uint8_t protocol;
+  uint16_t check;
+  uint32_t saddr;
+  uint32_t daddr;
+
+  /* The options start here. */
+};
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/

--- a/include/netinet/ip6.h
+++ b/include/netinet/ip6.h
@@ -32,6 +32,32 @@
  * Public Type Definitions
  ****************************************************************************/
 
+struct ip6_hdr
+{
+  union
+  {
+    struct ip6_hdrctl
+    {
+      uint32_t ip6_un1_flow;   /* 4 bits version, 8 bits TC, 20 bits flow-ID */
+      uint16_t ip6_un1_plen;   /* payload length */
+      uint8_t  ip6_un1_nxt;    /* next header */
+      uint8_t  ip6_un1_hlim;   /* hop limit */
+    } ip6_un1;
+
+    uint8_t ip6_un2_vfc;       /* 4 bits version, top 4 bits tclass */
+  } ip6_ctlun;
+
+  struct in6_addr ip6_src;      /* source address */
+  struct in6_addr ip6_dst;      /* destination address */
+};
+
+#define ip6_vfc   ip6_ctlun.ip6_un2_vfc
+#define ip6_flow  ip6_ctlun.ip6_un1.ip6_un1_flow
+#define ip6_plen  ip6_ctlun.ip6_un1.ip6_un1_plen
+#define ip6_nxt   ip6_ctlun.ip6_un1.ip6_un1_nxt
+#define ip6_hlim  ip6_ctlun.ip6_un1.ip6_un1_hlim
+#define ip6_hops  ip6_ctlun.ip6_un1.ip6_un1_hlim
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/

--- a/include/netinet/udp.h
+++ b/include/netinet/udp.h
@@ -31,4 +31,27 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+/* UDP header as specified by RFC 768, August 1980. */
+
+struct udphdr
+{
+  union
+  {
+    struct
+    {
+      uint16_t uh_sport;        /* source port */
+      uint16_t uh_dport;        /* destination port */
+      uint16_t uh_ulen;         /* udp length */
+      uint16_t uh_sum;          /* udp checksum */
+    };
+    struct
+    {
+      uint16_t source;
+      uint16_t dest;
+      uint16_t len;
+      uint16_t check;
+    };
+  };
+};
+
 #endif /* __INCLUDE_NETINET_UDP_H */

--- a/include/nuttx/net/ethernet.h
+++ b/include/nuttx/net/ethernet.h
@@ -55,9 +55,9 @@
 
 /* Recognized values of the type bytes in the Ethernet header */
 
-#define ETHTYPE_ARP      0x0806 /* Address resolution protocol */
-#define ETHTYPE_IP       0x0800 /* IP protocol */
-#define ETHTYPE_IP6      0x86dd /* IP protocol version 6 */
+#define ETHTYPE_ARP      ETHERTYPE_ARP  /* Address resolution protocol */
+#define ETHTYPE_IP       ETHERTYPE_IP   /* IP protocol */
+#define ETHTYPE_IP6      ETHERTYPE_IPV6 /* IP protocol version 6 */
 
 /* Tag protocol identifier (TPID) of 0x8100 identifies the frame as an
  * IEEE 802.1Q-tagged frame.  This field is located at the same position as

--- a/net/netlink/netlink_route.c
+++ b/net/netlink/netlink_route.c
@@ -41,6 +41,7 @@
 
 #include "netdev/netdev.h"
 #include "arp/arp.h"
+#include "net/if_arp.h"
 #include "neighbor/neighbor.h"
 #include "route/route.h"
 #include "netlink/netlink.h"
@@ -177,6 +178,44 @@ struct nlroute_info_s
  ****************************************************************************/
 
 #ifndef CONFIG_NETLINK_DISABLE_GETLINK
+
+uint16_t netlink_convert_device_type(uint8_t lltype)
+{
+  switch (lltype)
+    {
+      case NET_LL_ETHERNET:
+        return ARPHRD_ETHER;
+
+      case NET_LL_IEEE80211:
+        return ARPHRD_IEEE80211;
+
+      case NET_LL_LOOPBACK:
+        return ARPHRD_LOOPBACK;
+
+      case NET_LL_SLIP:
+        return ARPHRD_SLIP;
+
+      case NET_LL_TUN:
+      case NET_LL_BLUETOOTH:
+      case NET_LL_PKTRADIO:
+      case NET_LL_MBIM:
+        return ARPHRD_NONE;
+
+      case NET_LL_IEEE802154:
+        return ARPHRD_IEEE802154;
+
+      case NET_LL_CAN:
+        return ARPHRD_CAN;
+
+      case NET_LL_CELL:
+        return ARPHRD_PHONET_PIPE;
+
+      default:
+        nerr("ERROR: invalid lltype %d\n", lltype);
+        return ARPHRD_VOID;
+    }
+}
+
 static FAR struct netlink_response_s *
 netlink_get_device(FAR struct net_driver_s *dev,
                    FAR const struct nlroute_sendto_request_s *req)
@@ -206,7 +245,7 @@ netlink_get_device(FAR struct net_driver_s *dev,
   resp->hdr.nlmsg_pid    = req ? req->hdr.nlmsg_pid : 0;
 
   resp->iface.ifi_family = req ? req->gen.rtgen_family : AF_PACKET;
-  resp->iface.ifi_type   = dev->d_lltype;
+  resp->iface.ifi_type   = netlink_convert_device_type(dev->d_lltype);
 #ifdef CONFIG_NETDEV_IFINDEX
   resp->iface.ifi_index  = dev->d_ifindex;
 #endif


### PR DESCRIPTION
## Summary
We will integrate network management tools in future projects.  In the process of porting the tools, we encounter some situations where the structure is not defined, or the returned data types do not match the expectations.  Refer to the common implementation of other systems and add relevant definitions.
Other patches will be submitted later, replacing some similar structures used in NuttX with common structures. will not replace structures that are specifically aligned with 1 or 2 bytes.
## Impact

## Testing

