### PR TITLE
fs/cromfs: Fix faulty DEBUGASSERT() check

### DIFF
--- a/fs/cromfs/fs_cromfs.c
+++ b/fs/cromfs/fs_cromfs.c
@@ -1153,7 +1153,7 @@ static int cromfs_fstat(FAR const struct file *filep, FAR struct stat *buf)
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv == NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
 
   /* Get the mountpoint inode reference from the file structure and the
    * volume private data from the inode structure


### PR DESCRIPTION
## Summary
The logic being tested is wrong, obviously when accessing file the driver private data has to be valid (open() has been called).
## Impact
Fix crash via incorrect assert logic
## Testing
icicle:pnsh
