### PR TITLE
stm32_eth: Lock the scheduler when reseting the MAC.

### DIFF
--- a/arch/arm/src/stm32/stm32_eth.c
+++ b/arch/arm/src/stm32/stm32_eth.c
@@ -2043,6 +2043,12 @@ static void stm32_interrupt_work(void *arg)
 
       stm32_putreg(ETH_DMAINT_AIS, STM32_ETH_DMASR);
 
+      /* Lock the scheduler, to ensure that the network
+       * will be unlocked before the worker starts.
+       */
+
+      sched_lock();
+
       /* As per the datasheet's recommendation, the MAC
        * needs to be reset for all abnormal events. The
        * scheduled job will take the interface down and
@@ -2057,6 +2063,9 @@ static void stm32_interrupt_work(void *arg)
        */
 
       net_unlock();
+
+      sched_unlock();
+
       return;
     }
 


### PR DESCRIPTION
## Summary

Following the discussion [here](https://github.com/apache/nuttx/pull/8943#discussion_r1164461911), this PR ensures that the Ethernet error handling will be scheduled after the network has been unlocked.

## Impact

Fix potential lock of the network.

## Testing

Tested on custom target based on STM32F427.  
I induced an artificial error with my debugger, and indeed the system recovers without any problem.
No scheduling problems were observed.

