### PR TITLE
bluetooth: Fix the Unexpected ACL flags error

### DIFF
--- a/include/nuttx/wireless/bluetooth/bt_hci.h
+++ b/include/nuttx/wireless/bluetooth/bt_hci.h
@@ -289,9 +289,7 @@ begin_packed_struct struct bt_hci_evt_hdr_s
 
 begin_packed_struct struct bt_hci_acl_hdr_s
 {
-  uint16_t handle          : 12;
-  uint16_t packet_boundary : 2;
-  uint16_t broadcast       : 2;
+  uint16_t handle;
   uint16_t len;
 } end_packed_struct;
 


### PR DESCRIPTION
## Summary
This change fixes a bug that was introduced when a 16 bit handle was changed into a 12 bit bit-field without adapting the rest of the stack.

## Impact

## Testing
There is no easy way right now. This test requires some code changes.
Register some attributes using the bt_gatt_register function and then try reading them using gatttool or btsak.