### PR TITLE
tools/mksymtab: Fix a compilation warning

### DIFF
--- a/tools/mksymtab.c
+++ b/tools/mksymtab.c
@@ -277,7 +277,7 @@ int main(int argc, char **argv, char **envp)
 
       /* Output any conditional compilation */
 
-      cond = (g_parm[COND_INDEX] && strlen(g_parm[COND_INDEX]) > 0);
+      cond = strlen(g_parm[COND_INDEX]) > 0;
       if (cond)
         {
           fprintf(outstream, "%s#if %s\n", nextterm, g_parm[COND_INDEX]);


### PR DESCRIPTION

## Summary

Fix:
```
mksymtab.c: In function ‘main’:
mksymtab.c:280:15: warning: the comparison will always evaluate as ‘true’ for the address of ‘g_parm’ will never be NULL [-Waddress]
  280 |       cond = (g_parm[COND_INDEX] && strlen(g_parm[COND_INDEX]) > 0);
```


## Impact
None
## Testing
CI
