### PR TITLE
tcp_input: drop SYN when no free node in the backlog

### DIFF
--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -1430,7 +1430,7 @@ int tcp_backlogadd(FAR struct tcp_conn_s *conn,
 #endif
 
 /****************************************************************************
- * Name: tcp_backlogavailable
+ * Name: tcp_backlogpending
  *
  * Description:
  *   Called from poll().  Before waiting for a new connection, poll will
@@ -1442,9 +1442,27 @@ int tcp_backlogadd(FAR struct tcp_conn_s *conn,
  ****************************************************************************/
 
 #ifdef CONFIG_NET_TCPBACKLOG
+bool tcp_backlogpending(FAR struct tcp_conn_s *conn);
+#else
+#  define tcp_backlogpending(c) (false)
+#endif
+
+/****************************************************************************
+ * Name: tcp_backlogavailable
+ *
+ * Description:
+ *  Called from tcp_input().  Before alloc a new accept connection, tcp_input
+ *  will call this API to see if there are free node in the backlog.
+ *
+ * Assumptions:
+ *   Called from network socket logic with the network locked
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_TCPBACKLOG
 bool tcp_backlogavailable(FAR struct tcp_conn_s *conn);
 #else
-#  define tcp_backlogavailable(c) (false)
+#  define tcp_backlogavailable(c) (true)
 #endif
 
 /****************************************************************************

--- a/net/tcp/tcp_backlog.c
+++ b/net/tcp/tcp_backlog.c
@@ -252,7 +252,7 @@ int tcp_backlogadd(FAR struct tcp_conn_s *conn,
 }
 
 /****************************************************************************
- * Name: tcp_backlogremove
+ * Name: tcp_backlogpending
  *
  * Description:
  *  Called from poll().  Before waiting for a new connection, poll will
@@ -263,9 +263,26 @@ int tcp_backlogadd(FAR struct tcp_conn_s *conn,
  *
  ****************************************************************************/
 
-bool tcp_backlogavailable(FAR struct tcp_conn_s *conn)
+bool tcp_backlogpending(FAR struct tcp_conn_s *conn)
 {
   return (conn && conn->backlog && !sq_empty(&conn->backlog->bl_pending));
+}
+
+/****************************************************************************
+ * Name: tcp_backlogavailable
+ *
+ * Description:
+ *  Called from tcp_input().  Before alloc a new accept connection, tcp_input
+ *  will call this API to see if there are free node in the backlog.
+ *
+ * Assumptions:
+ *   Called from network socket logic with the network locked
+ *
+ ****************************************************************************/
+
+bool tcp_backlogavailable(FAR struct tcp_conn_s *conn)
+{
+  return (conn && conn->backlog && !sq_empty(&conn->backlog->bl_free));
 }
 
 /****************************************************************************

--- a/net/tcp/tcp_input.c
+++ b/net/tcp/tcp_input.c
@@ -761,6 +761,12 @@ static void tcp_input(FAR struct net_driver_s *dev, uint8_t domain,
       if ((conn = tcp_findlistener(&uaddr, tmp16)) != NULL)
 #endif
         {
+          if (!tcp_backlogavailable(conn))
+            {
+              nerr("ERROR: no free containers for TCP BACKLOG!\n");
+              goto drop;
+            }
+
           /* We matched the incoming packet with a connection in LISTEN.
            * We now need to create a new connection and send a SYNACK in
            * response.

--- a/net/tcp/tcp_netpoll.c
+++ b/net/tcp/tcp_netpoll.c
@@ -288,7 +288,7 @@ int tcp_pollsetup(FAR struct socket *psock, FAR struct pollfd *fds)
 
   /* Check for read data or backlogged connection availability now */
 
-  if (conn->readahead != NULL || tcp_backlogavailable(conn))
+  if (conn->readahead != NULL || tcp_backlogpending(conn))
     {
       /* Normal data may be read without blocking. */
 


### PR DESCRIPTION
It's like a tcp_alloc_accept failure, wait for the client to retransmit TCP_SYN, it will support more backlog connections.

## Summary

## Impact

## Testing

