### PR TITLE
arch/sim: Move up_textheap_xxx to common place

### DIFF
--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -64,7 +64,7 @@ CSRCS  = sim_initialize.c sim_idle.c sim_doirq.c sim_initialstate.c
 CSRCS += sim_createstack.c sim_usestack.c sim_releasestack.c sim_stackframe.c
 CSRCS += sim_exit.c sim_schedulesigaction.c sim_switchcontext.c sim_heap.c
 CSRCS += sim_uart.c sim_copyfullstate.c sim_sigdeliver.c
-CSRCS += sim_registerdump.c sim_saveusercontext.c
+CSRCS += sim_registerdump.c sim_saveusercontext.c sim_textheap.c
 
 ifeq ($(CONFIG_SCHED_BACKTRACE),y)
 CSRCS += sim_backtrace.c

--- a/arch/sim/src/sim/posix/sim_hostmemory.c
+++ b/arch/sim/src/sim/posix/sim_hostmemory.c
@@ -48,122 +48,12 @@
 static atomic_int g_aordblks;
 static atomic_int g_uordblks;
 
-/* Record memory allocated for text sections by sys/queue.h */
-
-struct textheap_s
-{
-  void *p;
-  size_t size;
-  TAILQ_ENTRY(textheap_s) entry;
-};
-
-static TAILQ_HEAD(, textheap_s) g_textheap_list =
-  TAILQ_HEAD_INITIALIZER(g_textheap_list);
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
 extern uint64_t up_irq_save(void);
 extern void up_irq_restore(uint64_t flags);
-
-/****************************************************************************
- * Name: up_textheap_memalign
- *
- * Description:
- *   Allocate memory for text sections with the specified alignment.
- *
- ****************************************************************************/
-
-void *up_textheap_memalign(size_t align, size_t size)
-{
-  uint64_t flags;
-  void *p;
-
-  /* host_allocheap (mmap) returns memory aligned to the page size, which
-   * is always a multiple of the alignment (4/8) for text section. So, we
-   * don't need to do anything here.
-   */
-
-  p = host_allocheap(size);
-
-  flags = up_irq_save();
-
-  /* Record the allocated memory to a global list */
-
-  if (p)
-    {
-      struct textheap_s *node = malloc(sizeof(struct textheap_s));
-      if (node)
-        {
-          node->p = p;
-          node->size = size;
-          TAILQ_INSERT_TAIL(&g_textheap_list, node, entry);
-        }
-    }
-
-  up_irq_restore(flags);
-
-  return p;
-}
-
-/****************************************************************************
- * Name: up_textheap_free
- *
- * Description:
- *   Free memory allocated for text sections.
- *
- ****************************************************************************/
-
-void up_textheap_free(void *p)
-{
-  struct textheap_s *node;
-  uint64_t flags = up_irq_save();
-
-  /* Remove the memory from the global list */
-
-  TAILQ_FOREACH(node, &g_textheap_list, entry)
-    {
-      if (node->p == p)
-        {
-          TAILQ_REMOVE(&g_textheap_list, node, entry);
-          free(node);
-          break;
-        }
-    }
-
-  up_irq_restore(flags);
-  host_freeheap(p);
-}
-
-/****************************************************************************
- * Name: up_textheap_heapmember
- *
- * Description:
- *   Test if memory is from text heap.
- *
- ****************************************************************************/
-
-bool up_textheap_heapmember(void *p)
-{
-  struct textheap_s *node;
-  uint64_t flags = up_irq_save();
-
-  /* Traverse the global list to find the memory */
-
-  TAILQ_FOREACH(node, &g_textheap_list, entry)
-    {
-      if (node->p == p)
-        {
-          up_irq_restore(flags);
-          return true;
-        }
-    }
-
-  up_irq_restore(flags);
-
-  return false;
-}
 
 /****************************************************************************
  * Name: host_allocheap

--- a/arch/sim/src/sim/sim_textheap.c
+++ b/arch/sim/src/sim/sim_textheap.c
@@ -1,0 +1,158 @@
+/****************************************************************************
+ * arch/sim/src/sim/sim_textheap.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/arch.h>
+#include <nuttx/queue.h>
+#include <nuttx/kmalloc.h>
+
+#include "sim_internal.h"
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/* Record memory allocated for text sections by sq_queue_t */
+
+struct textheap_s
+{
+  sq_entry_t entry;
+  void *p;
+  size_t size;
+};
+
+static sq_queue_t g_textheap_list;
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_textheap_memalign
+ *
+ * Description:
+ *   Allocate memory for text sections with the specified alignment.
+ *
+ ****************************************************************************/
+
+void *up_textheap_memalign(size_t align, size_t size)
+{
+  struct textheap_s *node;
+  void *p;
+  irqstate_t flags;
+
+  /* host_allocheap (mmap) returns memory aligned to the page size, which
+   * is always a multiple of the alignment (4/8) for text section. So, we
+   * don't need to do anything here.
+   */
+
+  p = host_allocheap(size);
+
+  flags = up_irq_save();
+
+  if (p)
+    {
+      node = kmm_malloc(sizeof(*node));
+
+      if (node)
+        {
+          node->p = p;
+          node->size = size;
+
+          sq_addlast(&node->entry, &g_textheap_list);
+        }
+      else
+        {
+          host_freeheap(p);
+          p = NULL;
+        }
+    }
+
+  up_irq_restore(flags);
+
+  return p;
+}
+
+/****************************************************************************
+ * Name: up_textheap_free
+ *
+ * Description:
+ *   Free memory allocated for text sections.
+ *
+ ****************************************************************************/
+
+void up_textheap_free(void *p)
+{
+  sq_entry_t *node;
+  struct textheap_s *entry;
+  irqstate_t flags = up_irq_save();
+
+  for (node = sq_peek(&g_textheap_list);
+       node != NULL;
+       node = sq_next(node))
+    {
+      entry = (struct textheap_s *)node;
+
+      if (entry->p == p)
+        {
+          sq_rem(node, &g_textheap_list);
+          host_freeheap(p);
+          kmm_free(entry);
+          break;
+        }
+    }
+
+  up_irq_restore(flags);
+}
+
+/****************************************************************************
+ * Name: up_textheap_heapmember
+ *
+ * Description:
+ *   Test if memory is from text heap.
+ *
+ ****************************************************************************/
+
+bool up_textheap_heapmember(void *p)
+{
+  bool ret = false;
+  sq_entry_t *node;
+  struct textheap_s *entry;
+  irqstate_t flags = up_irq_save();
+
+  for (node = sq_peek(&g_textheap_list);
+       node != NULL;
+       node = sq_next(node))
+    {
+      entry = (struct textheap_s *)node;
+
+      if (entry->p == p)
+        {
+          ret = true;
+          break;
+        }
+    }
+
+  up_irq_restore(flags);
+  return ret;
+}

--- a/arch/sim/src/sim/win/sim_hostmemory.c
+++ b/arch/sim/src/sim/win/sim_hostmemory.c
@@ -41,6 +41,19 @@ void *host_allocheap(size_t sz)
   return _aligned_malloc(sz, 8);
 }
 
+/****************************************************************************
+ * Name: host_freeheap
+ *
+ * Description:
+ *   Free a executable memory block.
+ *
+ ****************************************************************************/
+
+void host_freeheap(void *mem)
+{
+  _aligned_free(mem);
+}
+
 void *host_allocshmem(const char *name, size_t size, int master)
 {
   HANDLE handle;


### PR DESCRIPTION
## Summary
* arch/sim: Move up_textheap_xxx to common place
* arch/sim: Implement up_freeheap for windows

## Impact
sim textheap only
## Testing
sim:elf
