### PR TITLE
ESP32 BLE Bugfix

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_ble_adapter.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_ble_adapter.c
@@ -360,24 +360,24 @@ extern void btdm_deep_sleep_mem_deinit(void);
 extern void btdm_ble_power_down_dma_copy(bool copy);
 extern uint8_t btdm_sleep_clock_sync(void);
 
-extern char _bss_start_btdm;
-extern char _bss_end_btdm;
-extern char _data_start_btdm;
-extern char _data_end_btdm;
-extern uint32_t _data_start_btdm_rom;
-extern uint32_t _data_end_btdm_rom;
+extern uint8_t _bss_start_btdm[];
+extern uint8_t _bss_end_btdm[];
+extern uint8_t _data_start_btdm[];
+extern uint8_t _data_end_btdm[];
+extern const uint32_t _data_start_btdm_rom;
+extern const uint32_t _data_end_btdm_rom;
 
-extern uint32_t _bt_bss_start;
-extern uint32_t _bt_bss_end;
-extern uint32_t _btdm_bss_start;
-extern uint32_t _btdm_bss_end;
-extern uint32_t _bt_data_start;
-extern uint32_t _bt_data_end;
-extern uint32_t _btdm_data_start;
-extern uint32_t _btdm_data_end;
+extern uint8_t _bt_bss_start[];
+extern uint8_t _bt_bss_end[];
+extern uint8_t _btdm_bss_start[];
+extern uint8_t _btdm_bss_end[];
+extern uint8_t _bt_data_start[];
+extern uint8_t _bt_data_end[];
+extern uint8_t _btdm_data_start[];
+extern uint8_t _btdm_data_end[];
 
-extern char _bt_tmp_bss_start;
-extern char _bt_tmp_bss_end;
+extern uint8_t _bt_tmp_bss_start[];
+extern uint8_t _bt_tmp_bss_end[];
 
 /****************************************************************************
  * Private Data

--- a/arch/xtensa/src/esp32/esp32_ble_adapter.c
+++ b/arch/xtensa/src/esp32/esp32_ble_adapter.c
@@ -451,8 +451,8 @@ extern uint8_t _bss_start_btdm[];
 extern uint8_t _bss_end_btdm[];
 extern uint8_t _data_start_btdm[];
 extern uint8_t _data_end_btdm[];
-extern const uint8_t _data_start_btdm_rom[];
-extern const uint8_t _data_end_btdm_rom[];
+extern const uint32_t _data_start_btdm_rom;
+extern const uint32_t _data_end_btdm_rom;
 
 extern uint8_t _bt_bss_start[];
 extern uint8_t _bt_bss_end[];
@@ -2027,11 +2027,11 @@ static void btdm_controller_mem_init(void)
 
   /* initialise .data section */
 
-  memcpy(_data_start_btdm, _data_start_btdm_rom,
+  memcpy(_data_start_btdm, (void *)_data_start_btdm_rom,
          _data_end_btdm - _data_start_btdm);
 
   wlinfo(".data initialise [0x%08x] <== [0x%08x]\n",
-         (uint32_t)_data_start_btdm, (uint32_t)_data_start_btdm_rom);
+         (uint32_t)_data_start_btdm, _data_start_btdm_rom);
 
   /* initial em, .bss section */
 

--- a/arch/xtensa/src/esp32/esp32_ble_adapter.c
+++ b/arch/xtensa/src/esp32/esp32_ble_adapter.c
@@ -884,8 +884,9 @@ static void esp32_ints_on(uint32_t mask)
       bit = 1 << i;
       if (bit & mask)
       {
-        wlinfo("Enabled bit %d\n", i);
-        up_enable_irq(i);
+        int irq = i + XTENSA_IRQ_FIRSTPERIPH;
+        wlinfo("Enabled bit %d\n", irq);
+        up_enable_irq(irq);
       }
     }
 }
@@ -2879,4 +2880,3 @@ void coex_bb_reset_unlock_wrapper(uint32_t restore)
   coex_bb_reset_unlock(restore);
 #endif
 }
-

--- a/net/bluetooth/bluetooth_poll.c
+++ b/net/bluetooth/bluetooth_poll.c
@@ -63,7 +63,7 @@
  ****************************************************************************/
 
 void bluetooth_poll(FAR struct net_driver_s *dev,
-                     FAR struct bluetooth_conn_s *conn)
+                    FAR struct bluetooth_conn_s *conn)
 {
   FAR struct radio_driver_s *radio;
 

--- a/wireless/bluetooth/bt_hcicore.c
+++ b/wireless/bluetooth/bt_hcicore.c
@@ -252,7 +252,6 @@ static void hci_acl(FAR struct bt_buf_s *buf)
     {
       wlerr("ERROR:  ACL data length mismatch (%u != %u)\n",
              buf->len, len);
-      bt_buf_release(buf);
       return;
     }
 
@@ -261,12 +260,10 @@ static void hci_acl(FAR struct bt_buf_s *buf)
     {
       wlerr("ERROR:  Unable to find conn for handle %u\n",
             buf->u.acl.handle);
-      bt_buf_release(buf);
       return;
     }
 
   bt_conn_receive(conn, buf, flags);
-  bt_conn_release(conn);
 }
 
 /* HCI event processing */
@@ -964,8 +961,6 @@ static void hci_event(FAR struct bt_buf_s *buf)
         wlwarn("WARNING:  Unhandled event 0x%02x\n", hdr->evt);
         break;
     }
-
-  bt_buf_release(buf);
 }
 #endif
 
@@ -1075,7 +1070,6 @@ static void hci_rx_work(FAR void *arg)
 
           default:
             wlerr("ERROR:  Unknown buf type %u\n", buf->type);
-            bt_buf_release(buf);
             break;
         }
 #else


### PR DESCRIPTION
## Summary
Make ESP32 BLE mighty again

## Impact
Fix ESP32 BLE operation

## Testing
`esp32-devkitc:ble` with debug assertions enabled
