### PR TITLE
libm/openlibm: add math library openlibm support.

### DIFF
--- a/libs/libm/Kconfig
+++ b/libs/libm/Kconfig
@@ -39,6 +39,12 @@ config LIBM_NEWLIB
 	---help---
 		Math library from Newlib
 
+config LIBM_OPENLIBM
+	bool "Math library from openlibm"
+	depends on !ARCH_MATH_H
+	---help---
+		Math library from openlibm
+
 config LIBM_TOOLCHAIN
 	bool "Math library from toolchain"
 

--- a/libs/libm/Makefile
+++ b/libs/libm/Makefile
@@ -24,6 +24,8 @@ ifeq ($(CONFIG_LIBM),y)
 include libm/Make.defs
 else ifeq ($(CONFIG_LIBM_NEWLIB),y)
 include newlib/Make.defs
+else ifeq ($(CONFIG_LIBM_OPENLIBM),y)
+include openlibm/Make.defs
 endif
 
 BINDIR ?= bin

--- a/libs/libm/openlibm/0001-fix-build-float_t-error-float_t-has-not-been-declare.patch
+++ b/libs/libm/openlibm/0001-fix-build-float_t-error-float_t-has-not-been-declare.patch
@@ -1,0 +1,38 @@
+From 147f2e6962c7624920909c3e4a4ef120e6814a66 Mon Sep 17 00:00:00 2001
+From: yanghuatao <yanghuatao@xiaomi.com>
+Date: Fri, 24 Mar 2023 11:55:02 +0800
+Subject: [PATCH 1/2] fix build float_t error: float_t has not been declared
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+VELAPLATFO-6159
+
+libcxx/cmath:335:9: error: ‘::float_t’ has not been declared
+
+(1)open menuconfig (2)close math.h:build setup->Customize Header Files->math.h (2) select openlibm:Library Rountines->Select math library->Math Library fram openlibm (3)build
+
+Signed-off-by: yanghuatao <yanghuatao@xiaomi.com>
+Change-Id: Iec6dbcebbe4ef15a96bcebb038f0c64ab39c5af7
+---
+ include/openlibm_math.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/openlibm/openlibm/include/openlibm_math.h openlibm/openlibm/include/openlibm_math.h
+index 701ad70..988e80c 100644
+--- a/openlibm/openlibm/include/openlibm_math.h
++++ openlibm/openlibm/include/openlibm_math.h
+@@ -149,8 +149,8 @@ extern const union __nan_un {
+     : __signbitl(x))
+ 
+ //VBS
+-//typedef	__double_t	double_t;
+-//typedef	__float_t	float_t;
++typedef float  float_t;
++typedef double double_t;
+ #endif /* __ISO_C_VISIBLE >= 1999 */
+ 
+ /*
+-- 
+2.39.1
+

--- a/libs/libm/openlibm/0002-add-math.h-and-complex.h-to-openlibm.patch
+++ b/libs/libm/openlibm/0002-add-math.h-and-complex.h-to-openlibm.patch
@@ -1,0 +1,49 @@
+From 8af59fe95d7c878d96752cdc655d70ffbef28514 Mon Sep 17 00:00:00 2001
+From: yanghuatao <yanghuatao@xiaomi.com>
+Date: Sat, 25 Mar 2023 11:05:58 +0800
+Subject: [PATCH 2/2] add math.h and complex.h to openlibm
+
+VELAPLATFO-6159
+
+openlibm do not have math.h and complex.h, so we add them to openlibm
+
+(1)open menuconfig (2)close math.h:build setup->Customize Header Files->math.h (2) select openlibm:Library Rountines->Select math library->Math Library fram openlibm (3)build
+
+Signed-off-by: yanghuatao <yanghuatao@xiaomi.com>
+Change-Id: I0bebef549c3ce7226a190d6a16a347f47014ad0b
+---
+ include/complex.h | 6 ++++++
+ include/math.h    | 6 ++++++
+ 2 files changed, 12 insertions(+)
+ create mode 100644 include/complex.h
+ create mode 100644 include/math.h
+
+diff --git a/openlibm/openlibm/include/complex.h openlibm/openlibm/include/complex.h
+new file mode 100644
+index 0000000..c97e82b
+--- /dev/null
++++ openlibm/openlibm/include/complex.h
+@@ -0,0 +1,6 @@
++#ifndef OPENLIBM_MATH_COMPLEX_H
++#define OPENLIBM_MATH_COMPLEX_H
++
++#include <openlibm_complex.h>
++
++#endif /* OPENLIBM_MATH_COMPLEX_H */
+\ No newline at end of file
+diff --git a/openlibm/openlibm/include/math.h openlibm/openlibm/include/math.h
+new file mode 100644
+index 0000000..0004b77
+--- /dev/null
++++ openlibm/openlibm/include/math.h
+@@ -0,0 +1,6 @@
++#ifndef OPENLIBM_MATH_MATH_H
++#define OPENLIBM_MATH_MATH_H
++
++#include <openlibm_math.h>
++
++#endif /* !OPENLIBM_MATH_MATH_H */
+\ No newline at end of file
+-- 
+2.39.1
+

--- a/libs/libm/openlibm/Make.defs
+++ b/libs/libm/openlibm/Make.defs
@@ -1,0 +1,116 @@
+
+############################################################################
+# libs/libm/openlibm/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+OPENLIBM_VERSION=0.8.1
+
+openlibm-$(OPENLIBM_VERSION).zip:
+	$(call DOWNLOAD,https://github.com/JuliaMath/openlibm/archive/refs/tags,v$(OPENLIBM_VERSION).zip,openlibm.zip)
+
+openlibm/openlibm: openlibm-$(OPENLIBM_VERSION).zip
+	$(Q) unzip -o openlibm.zip
+	$(Q) mv openlibm-$(OPENLIBM_VERSION) openlibm/openlibm
+	$(Q) patch -p0 < openlibm/0001-fix-build-float_t-error-float_t-has-not-been-declare.patch
+	$(Q) patch -p0 < openlibm/0002-add-math.h-and-complex.h-to-openlibm.patch
+
+ifeq ($(wildcard openlibm/openlibm/.git),)
+distclean::
+	$(call DELFILE, openlibm.zip)
+	$(call DELDIR, openlibm/openlibm)
+context:: openlibm/openlibm
+else
+distclean::
+context::
+endif
+
+# OS-specific stuff
+# Get ARCH, it is used to read source code file list form $(ARCH)/Make.files
+ifeq ($(CONFIG_ARCH),sim)
+  ifeq ($(CONFIG_SIM_M32),y)
+    ARCH = i387
+  else ifeq ($(CONFIG_HOST_ARM64),y)
+    ARCH = aarch64
+  else ifeq ($(CONFIG_HOST_ARM),y)
+    ARCH = arm
+  else ifeq ($(CONFIG_HOST_X86),y)
+    ARCH = i387
+  else
+    ARCH = amd64
+  endif
+else ifeq ($(CONFIG_ARCH),risc-v)
+  ARCH = riscv64
+else ifeq ($(CONFIG_ARCH),arm)
+  ARCH = arm
+else ifeq ($(CONFIG_ARCH),arm64)
+  ARCH = arm64
+else ifeq ($(CONFIG_ARCH),x86)
+  ARCH = i387
+else ifeq ($(CONFIG_ARCH),x86_64)
+  ARCH = amd64
+else
+  ARCH = $(CONFIG_ARCH)
+endif
+
+# Get source code lits from Make.files,and append to variable SRCS
+# (1) Override CUR_SRCS to xxx_SRCS(for example src_SRCS etc.), then in xxx/Make.files CUR_SRCS is changed to xxx_SRCS.
+# (2) Include Make.files
+# (3) Get variable xxx_SRCS from Make.files, and append it to variable SRCS
+define INC_template
+  ifneq ($(wildcard $(1)/Make.files),)
+  override CUR_SRCS = $(2)_SRCS
+  include $(1)/Make.files
+  SRCS += $$($(2)_SRCS)
+  endif
+endef
+
+# Determines whether `long double` is the same as `double` on this arch.
+# linux x86_64, for instance, `long double` is 80 bits wide, whereas on macOS aarch64,
+# `long double` is the same as `double`.
+ifneq ($(filter $(ARCH),i387 amd64),) # Add ld80 directory on x86 and x64
+$(eval $(call INC_template,openlibm/openlibm/ld80))
+VPATH += :openlibm/openlibm/ld80
+else ifneq ($(filter $(ARCH),aarch64),) # Add ld128 directory on aarch64
+$(eval $(call INC_template,openlibm/openlibm/ld128))
+VPATH += :openlibm/openlibm/ld128
+endif
+
+$(eval $(call INC_template,openlibm/openlibm/src,src))
+$(eval $(call INC_template,openlibm/openlibm/$(ARCH),$(ARCH)))
+$(eval $(call INC_template,openlibm/openlibm/bsdsrc,bsdsrc))
+
+VPATH += :openlibm/openlibm/src
+VPATH += :openlibm/openlibm/$(ARCH)
+VPATH += :openlibm/openlibm/bsdsrc
+
+CFLAGS += ${INCDIR_PREFIX}openlibm/openlibm
+CFLAGS += ${INCDIR_PREFIX}openlibm/openlibm/$(ARCH)
+CFLAGS += ${INCDIR_PREFIX}openlibm/openlibm/src
+CFLAGS += ${DEFINE_PREFIX}__BSD_VISIBLE
+
+AFLAGS += ${INCDIR_PREFIX}openlibm/openlibm
+AFLAGS += ${INCDIR_PREFIX}openlibm/openlibm/$(ARCH)
+AFLAGS += ${INCDIR_PREFIX}openlibm/openlibm/src
+AFLAGS += ${DEFINE_PREFIX}__BSD_VISIBLE
+
+CSRCS := $(sort $(filter %.c,$(SRCS)))
+ASRCS := $(sort $(filter %.S,$(SRCS)))
+
+# CSRCS and ASRCS have the same name files, we use .S files,so remove them from CSRCS
+CSRCS := $(filter-out $(patsubst %.S,%.c,$(ASRCS)),$(CSRCS))

--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -662,6 +662,11 @@ ifeq ($(CONFIG_LIBM_NEWLIB),y)
   ARCHXXINCLUDES += ${INCSYSDIR_PREFIX}$(TOPDIR)$(DELIM)libs$(DELIM)libm$(DELIM)newlib$(DELIM)include
 endif
 
+ifeq ($(CONFIG_LIBM_OPENLIBM),y)
+  ARCHINCLUDES += ${INCSYSDIR_PREFIX}$(TOPDIR)$(DELIM)libs$(DELIM)libm$(DELIM)openlibm$(DELIM)openlibm$(DELIM)include
+  ARCHXXINCLUDES += ${INCSYSDIR_PREFIX}$(TOPDIR)$(DELIM)libs$(DELIM)libm$(DELIM)openlibm$(DELIM)openlibm$(DELIM)include
+endif
+
 ARCHXXINCLUDES += ${INCSYSDIR_PREFIX}$(TOPDIR)$(DELIM)include
 
 # Convert filepaths to their proper system format (i.e. Windows/Unix)


### PR DESCRIPTION
add math library openlibm support
(1)open menuconfig  (2)close math.h:build setup->Customize Header Files->math.h (3) select openlibm:Library Rountines->Select math library->Math Library fram openlibm (4)build

## Summary

## Impact

## Testing

