### PR TITLE
arch/arm: Resolving warnings for assembly instructions

### DIFF
--- a/arch/arm/src/arm/arm_saveusercontext.S
+++ b/arch/arm/src/arm/arm_saveusercontext.S
@@ -58,7 +58,8 @@ up_saveusercontext:
 
 	/* Save r0~r14, store the return address as PC */
 
-	stmia		r0!, {r0-r14, r14}
+	stmia		r0!, {r0-r14}
+	str		r14, [r0], #4
 
 	/* Save cpsr */
 


### PR DESCRIPTION
## Summary

Fixed warning：
arm/arm_saveusercontext.S:61: Warning: duplicated register (r14) in register list

## Impact

NA

## Testing

CI PASS