### PR TITLE
wireless/bluetooth: Make btuart_lowerhalf_s usable in a USB driver.

### DIFF
--- a/drivers/wireless/bluetooth/bt_uart.c
+++ b/drivers/wireless/bluetooth/bt_uart.c
@@ -227,10 +227,20 @@ int btuart_send(FAR struct bt_driver_s *dev,
 
   if (type == BT_CMD)
     {
+      if (lower->txcmd)
+        {
+          return lower->txcmd(lower, data, len);
+        }
+
       *hdr = H4_CMD;
     }
   else if (type == BT_ACL_OUT)
     {
+      if (lower->txacl)
+        {
+          return lower->txacl(lower, data, len);
+        }
+
       *hdr = H4_ACL;
     }
   else if (type == BT_ISO_OUT)

--- a/include/nuttx/wireless/bluetooth/bt_uart.h
+++ b/include/nuttx/wireless/bluetooth/bt_uart.h
@@ -127,11 +127,19 @@ struct btuart_lowerhalf_s
    *   is insufficient buffer space to hold the Tx frame data.  In that
    *   case the lower half will block until there is sufficient to buffer
    *   the entire outgoing packet.
+   * txcmd() can be used, instead of write(), to send command packets if
+   *   hardware support is available.
+   * txacl() can be used, instead of write(), to send acl data packets if
+   *   hardware support is available.
    */
 
   CODE ssize_t (*read)(FAR const struct btuart_lowerhalf_s *lower,
                        FAR void *buffer, size_t buflen);
   CODE ssize_t (*write)(FAR const struct btuart_lowerhalf_s *lower,
+                        FAR const void *buffer, size_t buflen);
+  CODE ssize_t (*txcmd)(FAR const struct btuart_lowerhalf_s *lower,
+                        FAR const void *buffer, size_t buflen);
+  CODE ssize_t (*txacl)(FAR const struct btuart_lowerhalf_s *lower,
                         FAR const void *buffer, size_t buflen);
 
   /* Flush/drain all buffered RX data */
@@ -142,6 +150,10 @@ struct btuart_lowerhalf_s
 
   CODE int (*ioctl)(FAR const struct btuart_lowerhalf_s *lower,
                     int cmd, unsigned long arg);
+
+  /* Private instance data */
+
+  void *priv;
 };
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
This reuses the btuart lower half in USB drivers. 

## Impact
None expected.

## Testing
Bluetooth on the tiva board with a uart interface still works.