### PR TITLE
stm32_f7/h7_eth: Added error handling for abnormal interrupts.

### DIFF
--- a/arch/arm/src/stm32h7/stm32_ethernet.c
+++ b/arch/arm/src/stm32h7/stm32_ethernet.c
@@ -2230,16 +2230,13 @@ static void stm32_interrupt_work(void *arg)
       stm32_putreg(ETH_DMACSR_NIS, STM32_ETH_DMACSR);
     }
 
-  /* Handle error interrupt only if CONFIG_DEBUG_NET is eanbled */
-
-#ifdef CONFIG_DEBUG_NET
   /* Check if there are pending "abnormal" interrupts */
 
   if ((dmasr & ETH_DMACSR_AIS) != 0)
     {
       /* Just let the user know what happened */
 
-      nerr("ERROR: Abormal event(s): %08x\n", dmasr);
+      nerr("ERROR: Abnormal event(s): %08" PRIx32 "\n", dmasr);
 
       /* Clear all pending abnormal events */
 
@@ -2248,8 +2245,23 @@ static void stm32_interrupt_work(void *arg)
       /* Clear the pending abnormal summary interrupt */
 
       stm32_putreg(ETH_DMACSR_AIS, STM32_ETH_DMACSR);
+
+      /* As per the datasheet's recommendation, the MAC
+       * needs to be reset for all abnormal events. The
+       * scheduled job will take the interface down and
+       * up again.
+       */
+
+      work_queue(ETHWORK, &priv->irqwork, stm32_txtimeout_work, priv, 0);
+
+      /* Interrupts need to remain disabled, no other
+       * processing will take place. After reset
+       * everything will be restored.
+       */
+
+      net_unlock();
+      return;
     }
-#endif
 
   net_unlock();
 


### PR DESCRIPTION
## Summary

In #8943 error handling was added for all abnormal errors of the MAC, for STM32.

This PR copies these changes to STM32F7 & STM32H7 too.

## Impact

STM32 Ethernet operations should be more reliable now.

## Testing

None. I don't have hardware available for this.  
I did extensive testing on STM32F4, but now the changes are blindly copied to the other two families.

I would appreciate feedback on this.