### PR TITLE
tm4c1294-launchpad: Add reboot support.

### DIFF
--- a/boards/arm/tiva/tm4c1294-launchpad/src/Makefile
+++ b/boards/arm/tiva/tm4c1294-launchpad/src/Makefile
@@ -54,4 +54,8 @@ CSRCS += tm4c_hciuart.c
 endif
 endif
 
+ifeq ($(CONFIG_BOARDCTL_RESET),y)
+CSRCS += tm4c_reset.c
+endif
+
 include $(TOPDIR)/boards/Board.mk

--- a/boards/arm/tiva/tm4c1294-launchpad/src/tm4c_reset.c
+++ b/boards/arm/tiva/tm4c1294-launchpad/src/tm4c_reset.c
@@ -48,7 +48,7 @@
  *
  * Returned Value:
  *   If this function returns, then it was not possible to power-off the
- *   board due to some constraints.  The return value int this case is a
+ *   board due to some constraints.  The return value in this case is a
  *   board-specific reason for the failure to shutdown.
  *
  ****************************************************************************/

--- a/boards/arm/tiva/tm4c1294-launchpad/src/tm4c_reset.c
+++ b/boards/arm/tiva/tm4c1294-launchpad/src/tm4c_reset.c
@@ -1,0 +1,62 @@
+/****************************************************************************
+ * boards/arm/tiva/tm4c1294-launchpad/src/tm4c_reset.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/board.h>
+
+#ifdef CONFIG_BOARDCTL_RESET
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_reset
+ *
+ * Description:
+ *   Reset board.  Support for this function is required by board-level
+ *   logic if CONFIG_BOARDCTL_RESET is selected.
+ *
+ * Input Parameters:
+ *   status - Status information provided with the reset event.  This
+ *            meaning of this status information is board-specific.  If not
+ *            used by a board, the value zero may be provided in calls to
+ *            board_reset().
+ *
+ * Returned Value:
+ *   If this function returns, then it was not possible to power-off the
+ *   board due to some constraints.  The return value int this case is a
+ *   board-specific reason for the failure to shutdown.
+ *
+ ****************************************************************************/
+
+int board_reset(int status)
+{
+  up_systemreset();
+  return 0;
+}
+
+#endif /* CONFIG_BOARDCTL_RESET */


### PR DESCRIPTION
## Summary
Copy boards/arm/stm32/stm32f4discovery/src/stm32_reset.c

## Impact
None

## Testing
Reboot command now works.
