### PR TITLE
sem/sem_init: Change sem_xxx -> nxsem_xxx in kernel modules

### DIFF
--- a/arch/arm/src/rtl8720c/amebaz_depend.c
+++ b/arch/arm/src/rtl8720c/amebaz_depend.c
@@ -24,6 +24,7 @@
 
 #include "amebaz_depend.h"
 #include <nuttx/mqueue.h>
+#include <nuttx/semaphore.h>
 #include <nuttx/syslog/syslog.h>
 
 /****************************************************************************
@@ -168,7 +169,7 @@ void rtw_init_sema(void **sema, int init_val)
       return;
     }
 
-  if (sem_init(_sema, 0, init_val))
+  if (nxsem_init(_sema, 0, init_val))
     {
       free(_sema);
       return;
@@ -179,7 +180,7 @@ void rtw_init_sema(void **sema, int init_val)
 
 void rtw_free_sema(void **sema)
 {
-  sem_destroy(*sema);
+  nxsem_destroy(*sema);
   free(*sema);
   *sema = NULL;
 }

--- a/arch/risc-v/src/esp32c3/esp32c3_ble_adapter.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_ble_adapter.c
@@ -44,6 +44,7 @@
 #include <nuttx/kthread.h>
 #include <nuttx/wdog.h>
 #include <nuttx/wqueue.h>
+#include <nuttx/semaphore.h>
 #include <nuttx/sched.h>
 #include <nuttx/signal.h>
 
@@ -780,7 +781,7 @@ static void *semphr_create_wrapper(uint32_t max, uint32_t init)
   bt_sem = kmm_malloc(tmp);
   DEBUGASSERT(bt_sem);
 
-  ret = sem_init(&bt_sem->sem, 0, init);
+  ret = nxsem_init(&bt_sem->sem, 0, init);
   DEBUGASSERT(ret == OK);
 
 #ifdef CONFIG_ESP32C3_SPIFLASH
@@ -807,7 +808,7 @@ static void *semphr_create_wrapper(uint32_t max, uint32_t init)
 static void semphr_delete_wrapper(void *semphr)
 {
   struct bt_sem_s *bt_sem = (struct bt_sem_s *)semphr;
-  sem_destroy(&bt_sem->sem);
+  nxsem_destroy(&bt_sem->sem);
   kmm_free(bt_sem);
 }
 

--- a/arch/xtensa/src/esp32/esp32_ble_adapter.c
+++ b/arch/xtensa/src/esp32/esp32_ble_adapter.c
@@ -1143,7 +1143,7 @@ static void *semphr_create_wrapper(uint32_t max, uint32_t init)
       return NULL;
     }
 
-  ret = sem_init(sem, 0, init);
+  ret = nxsem_init(sem, 0, init);
   if (ret)
     {
       wlerr("ERROR: Failed to initialize sem error=%d\n", ret);
@@ -1171,7 +1171,7 @@ static void *semphr_create_wrapper(uint32_t max, uint32_t init)
 static void semphr_delete_wrapper(void *semphr)
 {
   sem_t *sem = (sem_t *)semphr;
-  sem_destroy(sem);
+  nxsem_destroy(sem);
   kmm_free(sem);
 }
 


### PR DESCRIPTION
## Summary
Use the kernel space api nxsem_xxx when inside the kernel.

## Impact
Everywhere else (besides libc) nxsem_ is used, which I think is correct. sem_xx are userspace APIs which modify the errno variable, and I think using such procedures in the kernel is wrong.
## Testing
CI pass
