### PR TITLE
fs/inode: when searching for nextname skip "/" and "./"

### DIFF
--- a/fs/inode/fs_inodesearch.c
+++ b/fs/inode/fs_inodesearch.c
@@ -559,5 +559,16 @@ FAR const char *inode_nextname(FAR const char *name)
       name++;
     }
 
+  /* Skip single '.' path segment, but not '..' */
+
+  if (*name == '.' && *(name + 1) == '/')
+    {
+      /* If there is a '/' after '.',
+       * continue searching from the next character
+       */
+
+      name = inode_nextname(name);
+    }
+
   return name;
 }


### PR DESCRIPTION
## Summary
fix the problem that stat fails to use the relative path 
An error will be reported if used in the following way: stat("//./bin", &st);

## Impact
fs

## Testing
sim
