### PR TITLE
video/fb: fix pollnotify calling crash in advance

### DIFF
--- a/drivers/video/fb.c
+++ b/drivers/video/fb.c
@@ -803,6 +803,13 @@ void fb_pollnotify(FAR struct fb_vtable_s *vtable)
 
   fb = vtable->priv;
 
+  /* Prevent calling before getting the vtable. */
+
+  if (fb == NULL)
+    {
+      return;
+    }
+
   if (fb->vsyncoffset > 0)
     {
       wd_start(&fb->wdog, fb->vsyncoffset, fb_do_pollnotify, (wdparm_t)fb);


### PR DESCRIPTION
## Summary
When executing `up_fbinitialize`, the driver may turn on the vsync interrupt. If the vsync interrupt calls `fb_pollnotify` before executing `fb->vtable->priv = fb` it will cause null pointer access and crash.

## Impact
None.

## Testing
None.
