### PR TITLE
drivers/spi/spi_bitbang: Add private data on spi_bitbang

### DIFF
--- a/boards/arm/sam34/arduino-due/src/sam_mmcsd.c
+++ b/boards/arm/sam34/arduino-due/src/sam_mmcsd.c
@@ -217,7 +217,7 @@ static struct spi_dev_s *sam_mmcsd_spiinitialize(void)
 
   /* Create the SPI driver instance */
 
-  return spi_create_bitbang(&g_spiops);
+  return spi_create_bitbang(&g_spiops, NULL);
 }
 
 /****************************************************************************

--- a/boards/arm/sam34/arduino-due/src/sam_touchscreen.c
+++ b/boards/arm/sam34/arduino-due/src/sam_touchscreen.c
@@ -313,7 +313,7 @@ static struct spi_dev_s *sam_tsc_spiinitialize(void)
 
   /* Create the SPI driver instance */
 
-  return spi_create_bitbang(&g_spiops);
+  return spi_create_bitbang(&g_spiops, NULL);
 }
 
 /****************************************************************************

--- a/drivers/spi/spi_bitbang.c
+++ b/drivers/spi/spi_bitbang.c
@@ -515,7 +515,8 @@ static int spi_cmddata(FAR struct spi_dev_s *dev, uint32_t devid,
  ****************************************************************************/
 
 FAR struct spi_dev_s *spi_create_bitbang(FAR const struct
-                                         spi_bitbang_ops_s *low)
+                                         spi_bitbang_ops_s *low,
+                                         FAR void *low_priv)
 {
   FAR struct spi_bitbang_s *priv;
 
@@ -535,6 +536,7 @@ FAR struct spi_dev_s *spi_create_bitbang(FAR const struct
 
   priv->dev.ops = &g_spiops;
   priv->low     = low;
+  priv->priv    = low_priv;
 #ifdef CONFIG_SPI_BITBANG_VARWIDTH
   priv->nbits   = 8;
 #endif
@@ -549,6 +551,12 @@ FAR struct spi_dev_s *spi_create_bitbang(FAR const struct
   /* And return the initialized driver structure */
 
   return &priv->dev;
+}
+
+void spi_destroy_bitbang(FAR struct spi_dev_s *dev)
+{
+  DEBUGASSERT(dev);
+  kmm_free(dev);
 }
 
 #endif /* CONFIG_SPI_BITBANG */

--- a/include/nuttx/spi/spi_bitbang.h
+++ b/include/nuttx/spi/spi_bitbang.h
@@ -88,6 +88,7 @@ struct spi_bitbang_s
   uint32_t         holdtime;               /* SCK hold time to achieve requested frequency */
   bitexchange_t    exchange;               /* The select bit exchange function */
   mutex_t          lock;                   /* Supports mutually exclusive access to SPI */
+  FAR void        *priv;                   /* Private data for instance specific */
 #ifdef CONFIG_SPI_BITBANG_VARWIDTH
   uint8_t          nbits;                  /* Number of bits in the transfer */
 #endif
@@ -118,6 +119,7 @@ extern "C"
  *
  * Input Parameters:
  *   low - Low-level, platform specific device operations.
+ *   low_priv - Low-level private data, platform specific data.
  *
  * Returned Value:
  *   On success a non-NULL, initialized SPI driver instance is returned.
@@ -125,7 +127,21 @@ extern "C"
  ****************************************************************************/
 
 FAR struct spi_dev_s *spi_create_bitbang(
-                         FAR const struct spi_bitbang_ops_s *low);
+                         FAR const struct spi_bitbang_ops_s *low,
+                         FAR void *low_priv);
+
+/****************************************************************************
+ * Name:  spi_destroy_bitbang
+ *
+ * Description:
+ *   Destroy an instance of the SPI bit-bang driver.
+ *
+ * Input Parameters:
+ *   dev - device instance, target driver to destroy.
+ *
+ ****************************************************************************/
+
+void spi_destroy_bitbang(FAR struct spi_dev_s *dev);
 
 #undef EXTERN
 #if defined(__cplusplus)


### PR DESCRIPTION
## Summary
Add private data for spi_bitbang low-level driver to add an instance specific private data.
And add spi_destroy_bitbang() to clean up a driver instance.

## Impact
only spi_bitbang

## Testing
local test with spresense board
