### PR TITLE
Fix some error in Windows native build

### DIFF
--- a/arch/arm/src/common/Toolchain.defs
+++ b/arch/arm/src/common/Toolchain.defs
@@ -233,7 +233,7 @@ else
   # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523
 
   ifeq ($(GCCVER),)
-    export GCCVER := $(shell $(CC) --version | grep gcc | sed -r 's/.* ([0-9]+\.[0-9]+).*/\1/')
+    export GCCVER := $(shell $(CC) --version | grep gcc | sed -r "s/.* ([0-9]+\.[0-9]+).*/\1/")
   endif
 
   ifeq ($(GCCVER),12.2)

--- a/tools/Win.mk
+++ b/tools/Win.mk
@@ -571,10 +571,10 @@ pass2dep: context tools\mkdeps$(HOSTEXEEXT)
 # location: https://bitbucket.org/nuttx/tools/downloads/.  See
 # misc\tools\README.txt for additional information.
 
-KCONFIG_ENV = set APPSDIR=$(patsubst "%",%,${CONFIG_APPS_DIR}) & \
-              set EXTERNALDIR=$(EXTERNALDIR) & \
-              set APPSBINDIR=$(patsubst "%",%,${CONFIG_APPS_DIR}) & \
-              set BINDIR=$(patsubst "%",%,${TOPDIR}) &
+KCONFIG_ENV = set APPSDIR=$(patsubst "%",%,${CONFIG_APPS_DIR})& \
+              set EXTERNALDIR=$(EXTERNALDIR)& \
+              set APPSBINDIR=$(patsubst "%",%,${CONFIG_APPS_DIR})& \
+              set BINDIR=$(patsubst "%",%,${TOPDIR})&
 
 config:
 	$(Q) $(MAKE) clean_context


### PR DESCRIPTION
## Summary
1. arm/Toolchain.defs: fix error sed:-e expression 1,character 1:unknown command:" ' " in Windows native build
2. tools/Win.mk: fix error:can't open file ".\NuttX\nuttx /arch/dummy/Kconfig"in Windows native build
## Impact
Windows native build
## Testing
Windows native build:
tools\configure.bat -n stm32f4discovery:nsh
make
