### PR TITLE
sim/usbdev: fix unpaired critical_section()

### DIFF
--- a/arch/sim/src/sim/sim_usbdev.c
+++ b/arch/sim/src/sim/sim_usbdev.c
@@ -692,6 +692,7 @@ static int sim_ep_submit(struct usbdev_ep_s *ep, struct usbdev_req_s *req)
   if (privep->epstate == SIM_EPSTATE_STALLED)
     {
       sim_reqabort(privep, privreq, -EBUSY);
+      leave_critical_section(flags);
       return -EPERM;
     }
 


### PR DESCRIPTION
## Summary

sim/usbdev: fix unpaired critical_section()

## Impact

N/A

## Testing

ci-check