### PR TITLE
wireless/bluetooth: Initialize private bt_driver_s member.

### DIFF
--- a/include/nuttx/wireless/bluetooth/bt_driver.h
+++ b/include/nuttx/wireless/bluetooth/bt_driver.h
@@ -84,9 +84,17 @@ struct bt_driver_s
   CODE int (*ioctl)(FAR struct bt_driver_s *btdev, int cmd,
                     unsigned long arg);
 
-  /* Filled by register function, shouldn't be touched by bt_driver_s */
+  /* For private use by device drivers.
+   * Should NOT be touched by the bluetooth stack.
+   */
 
   FAR void *priv;
+
+  /* Reserved for the bluetooth stack.
+   * Should NOT be touched by drivers.
+   */
+
+  FAR void *bt_net;
 };
 
 /****************************************************************************

--- a/wireless/bluetooth/bt_netdev.c
+++ b/wireless/bluetooth/bt_netdev.c
@@ -1194,7 +1194,7 @@ int bt_netdev_register(FAR struct bt_driver_s *btdev)
 
   /* Get the interface structure associated with this interface number. */
 
-  priv = (FAR struct btnet_driver_s *)
+  btdev->bt_net = priv = (FAR struct btnet_driver_s *)
     kmm_zalloc(sizeof(struct btnet_driver_s));
 
   if (priv == NULL)


### PR DESCRIPTION
## Summary
The priv member is currently unused but should not be null after the bt driver is registered.
## Impact
None
## Testing
Modified code and printed the value of priv. It is not NULL like it used to be.
