### PR TITLE
arch/risc-v: change up_saveusercontext to assembly code

### DIFF
--- a/arch/risc-v/include/syscall.h
+++ b/arch/risc-v/include/syscall.h
@@ -63,8 +63,6 @@
  * therefore, be reserved (0 is not used).
  */
 
-#define SYS_save_context          (0)
-
 /* SYS call 1:
  *
  * void riscv_fullcontextrestore(uintptr_t *restoreregs) noreturn_function;

--- a/arch/risc-v/src/common/Make.defs
+++ b/arch/risc-v/src/common/Make.defs
@@ -24,6 +24,7 @@ endif
 
 # Specify our general Assembly files
 CMN_ASRCS += riscv_vectors.S riscv_exception_common.S riscv_mhartid.S
+CMN_ASRCS += riscv_saveusercontext.S
 
 # Specify C code within the common directory to be included
 CMN_CSRCS += riscv_initialize.c riscv_swint.c riscv_mtimer.c
@@ -32,7 +33,7 @@ CMN_CSRCS += riscv_cpuidlestack.c riscv_doirq.c riscv_exit.c riscv_exception.c
 CMN_CSRCS += riscv_getnewintctx.c riscv_getintstack.c riscv_initialstate.c
 CMN_CSRCS += riscv_idle.c riscv_modifyreg32.c riscv_nputs.c riscv_releasestack.c
 CMN_CSRCS += riscv_registerdump.c riscv_stackframe.c riscv_schedulesigaction.c
-CMN_CSRCS += riscv_sigdeliver.c riscv_switchcontext.c riscv_saveusercontext.c
+CMN_CSRCS += riscv_sigdeliver.c riscv_switchcontext.c
 CMN_CSRCS += riscv_usestack.c riscv_tcbinfo.c
 
 ifneq ($(CONFIG_ALARM_ARCH),y)

--- a/arch/risc-v/src/common/riscv_saveusercontext.S
+++ b/arch/risc-v/src/common/riscv_saveusercontext.S
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/risc-v/src/common/riscv_saveusercontext.c
+ * arch/risc-v/src/common/riscv_saveusercontext.S
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -24,27 +24,42 @@
 
 #include <nuttx/config.h>
 
-#include <arch/syscall.h>
+#include "riscv_macros.S"
 
 /****************************************************************************
- * Public Functions
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Symbols
  ****************************************************************************/
 
 /****************************************************************************
  * Name: up_saveusercontext
  *
  * Description:
- *   Save the current thread context.  Full prototype is:
- *
- *   int  up_saveusercontext(void *saveregs);
- *
- * Returned Value:
- *   0: Normal return
- *   1: Context switch return
+ *   Save the current thread context
  *
  ****************************************************************************/
 
-int up_saveusercontext(void *saveregs)
-{
-  return sys_call1(SYS_save_context, (uintptr_t)saveregs);
-}
+  .section .text
+  .global up_saveusercontext
+  .align  8
+
+up_saveusercontext:
+
+  save_ctx   a0
+
+  csrr       a1, CSR_STATUS
+  REGSTORE   a1, REG_INT_CTX(a0)  /* status */
+
+  REGSTORE   sp, REG_X2(a0)       /* original SP */
+  REGSTORE   x1, REG_EPC(a0)
+
+  riscv_savefpu   a0
+
+  li         a0, 0
+  jr         ra
+
+  .size	up_saveusercontext, . - up_saveusercontext
+  .end

--- a/arch/risc-v/src/common/riscv_swint.c
+++ b/arch/risc-v/src/common/riscv_swint.c
@@ -132,26 +132,6 @@ int riscv_swint(int irq, void *context, void *arg)
 
   switch (regs[REG_A0])
     {
-      /* A0=SYS_save_context:  This is a save context command:
-       *
-       *   int up_saveusercontext(void *saveregs);
-       *
-       * At this point, the following values are saved in context:
-       *
-       *   A0 = SYS_save_context
-       *   A1 = saveregs
-       *
-       * In this case, we simply need to copy the current registers to the
-       * save register space references in the saved A1 and return.
-       */
-
-      case SYS_save_context:
-        {
-          DEBUGASSERT(regs[REG_A1] != 0);
-          riscv_copystate((uintptr_t *)regs[REG_A1], regs);
-        }
-        break;
-
       /* A0=SYS_restore_context: This a restore context command:
        *
        * void


### PR DESCRIPTION
## Summary

minidump will backtrace failure when use C code to save user context, because the stack push operation in C code can disrupt the stack information.

## Impact

Debug

## Testing

bl602