### PR TITLE
arch: Return directly when arch not support interrupt context save

### DIFF
--- a/arch/ceva/src/common/ceva_saveusercontext.c
+++ b/arch/ceva/src/common/ceva_saveusercontext.c
@@ -25,6 +25,8 @@
 #include <nuttx/config.h>
 #include <nuttx/irq.h>
 
+#include <string.h>
+
 #include <arch/syscall.h>
 
 #include "ceva_internal.h"
@@ -50,6 +52,14 @@
 int up_saveusercontext(void *saveregs)
 {
   int ret;
+
+  if (up_interrupt_context())
+    {
+      /* TODO: save interrupt context */
+
+      memset(saveregs, 0x0, XCPTCONTEXT_SIZE);
+      return 0;
+    }
 
   /* Let sys_call1() do all of the work */
 

--- a/arch/mips/src/mips32/mips_saveusercontext.c
+++ b/arch/mips/src/mips32/mips_saveusercontext.c
@@ -23,6 +23,9 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/irq.h>
+
+#include <string.h>
 
 #include <arch/syscall.h>
 
@@ -46,5 +49,13 @@
 
 int up_saveusercontext(void *saveregs)
 {
+  if (up_interrupt_context())
+    {
+      /* TODO: save interrupt context */
+
+      memset(saveregs, 0x0, XCPTCONTEXT_SIZE);
+      return 0;
+    }
+
   return sys_call1(SYS_save_context, (uintptr_t)saveregs);
 }

--- a/arch/misoc/src/lm32/lm32_saveusercontext.c
+++ b/arch/misoc/src/lm32/lm32_saveusercontext.c
@@ -23,6 +23,9 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/irq.h>
+
+#include <string.h>
 
 #include <arch/syscall.h>
 
@@ -46,5 +49,13 @@
 
 int up_saveusercontext(void *saveregs)
 {
+  if (up_interrupt_context())
+    {
+      /* TODO: save interrupt context */
+
+      memset(saveregs, 0x0, XCPTCONTEXT_SIZE);
+      return 0;
+    }
+
   return sys_call1(SYS_save_context, (uintptr_t)saveregs);
 }

--- a/arch/misoc/src/minerva/minerva_saveusercontext.c
+++ b/arch/misoc/src/minerva/minerva_saveusercontext.c
@@ -23,6 +23,9 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/irq.h>
+
+#include <string.h>
 
 #include <arch/syscall.h>
 
@@ -46,5 +49,13 @@
 
 int up_saveusercontext(void *saveregs)
 {
+  if (up_interrupt_context())
+    {
+      /* TODO: save interrupt context */
+
+      memset(saveregs, 0x0, XCPTCONTEXT_SIZE);
+      return 0;
+    }
+
   return sys_call1(SYS_save_context, (uintptr_t)saveregs);
 }

--- a/arch/sparc/src/sparc_v8/sparc_v8_saveusercontext.c
+++ b/arch/sparc/src/sparc_v8/sparc_v8_saveusercontext.c
@@ -23,6 +23,9 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/irq.h>
+
+#include <string.h>
 
 #include <arch/syscall.h>
 
@@ -46,5 +49,13 @@
 
 int up_saveusercontext(void *saveregs)
 {
+  if (up_interrupt_context())
+    {
+      /* TODO: save interrupt context */
+
+      memset(saveregs, 0x0, XCPTCONTEXT_SIZE);
+      return 0;
+    }
+
   return sys_call1(SYS_save_context, (uintptr_t)saveregs);
 }


### PR DESCRIPTION
## Summary

Return directly when arch not support interrupt context save.

## Impact

Debug

## Testing

CI pass