### PR TITLE
net/procfs: Support to show MTU in netdev statistics

### DIFF
--- a/net/netdev/netdev_ioctl.c
+++ b/net/netdev/netdev_ioctl.c
@@ -918,13 +918,13 @@ static int netdev_ifr_ioctl(FAR struct socket *psock, int cmd,
 
       case SIOCGLIFMTU:  /* Get MTU size */
       case SIOCGIFMTU:   /* Get MTU size */
-        req->ifr_mtu = NETDEV_PKTSIZE(dev);
+        req->ifr_mtu = NETDEV_PKTSIZE(dev) - dev->d_llhdrlen;
         break;
       case SIOCSIFMTU:   /* Set MTU size */
         dev = netdev_ifr_dev(req);
         if (dev)
           {
-            NETDEV_PKTSIZE(dev) = req->ifr_mtu;
+            NETDEV_PKTSIZE(dev) = req->ifr_mtu + dev->d_llhdrlen;
           }
         break;
 

--- a/net/procfs/netdev_statistics.c
+++ b/net/procfs/netdev_statistics.c
@@ -248,7 +248,10 @@ static int netprocfs_linklayer(FAR struct netprocfs_file_s *netfile)
     }
 
   len += snprintf(&netfile->line[len], NET_LINELEN - len,
-                  " at %s\n", status);
+                  " at %s", status);
+
+  len += snprintf(&netfile->line[len], NET_LINELEN - len,
+                  " mtu %d\n", (dev->d_pktsize - dev->d_llhdrlen));
   return len;
 }
 


### PR DESCRIPTION
## Summary
Support to show MTU in netdev statistics
## Impact
N/A
## Testing
Usage:
ifconfig (interfacename)
example:
ifconfig eth0
eth0	Link encap:Ethernet HWaddr 42:d3:59:ad:5a:2f at RUNNING mtu 1500
	inet addr:10.0.1.2 DRaddr:10.0.1.1 Mask:255.255.255.0
	inet6 addr: fe80::40d3:59ff:fead:5a2f/64
	inet6 DRaddr: ::/64
