### PR TITLE
Add option for selecting coherent DMA.

### DIFF
--- a/arch/risc-v/src/litex/Kconfig
+++ b/arch/risc-v/src/litex/Kconfig
@@ -11,6 +11,13 @@ config LITEX_SYS_CORE_FREQ_HZ
 	---help---
 		This value should match default frequency of the FPGA fabric system clock.
 
+config LITEX_COHERENT_DMA
+	bool "Litex Coherent DMA"
+	default n
+	---help---
+		Select this option if the soft core was build with coherent DMA. When selected,
+		dcache is considered coherent and not invalidated before DMA transfers.
+
 menu "LITEX Peripheral Support"
 
 # These "hidden" settings determine whether a peripheral option is available

--- a/arch/risc-v/src/litex/litex_sdio.c
+++ b/arch/risc-v/src/litex/litex_sdio.c
@@ -860,7 +860,9 @@ static int litex_recvsetup(struct sdio_dev_s *dev, uint8_t *buffer,
 
   /* flush CPU d-cache */
 
+#ifndef CONFIG_LITEX_COHERENT_DMA
   up_invalidate_dcache_all();
+#endif
 
   putreg32(0, LITEX_SDBLOCK2MEM_DMA_ENABLE);
   putreg32((uintptr_t)buffer >> 32, LITEX_SDBLOCK2MEM_DMA_BASE);
@@ -903,7 +905,9 @@ static int litex_sendsetup(struct sdio_dev_s *dev,
 
   /* flush CPU d-cache */
 
+#ifndef CONFIG_LITEX_COHERENT_DMA
   up_invalidate_dcache_all();
+#endif
 
   putreg32(0, LITEX_SDMEM2BLOCK_DMA_ENABLE);
   putreg32((uintptr_t)buffer >> 32, LITEX_SDMEM2BLOCK_DMA_BASE);


### PR DESCRIPTION
## Summary
Used if the soft core was build with coherent DMA. When selected, dcache is considered coherent and not invalidated before DMA transfers.

## Impact
On certain architectures, when utilising DMA for SD transfers, invalidation of the dcache can cause a kernel panic

## Testing
Configuration tested functional on Arty-A7, risc-v core, Kernel operating in S-mode.
