### PR TITLE
Fix missing instantiation of return value in rwb_mediaremoved.

### DIFF
--- a/drivers/misc/rwbuffer.c
+++ b/drivers/misc/rwbuffer.c
@@ -1182,6 +1182,8 @@ ssize_t rwb_readbytes(FAR struct rwbuffer_s *dev, off_t offset,
 #ifdef CONFIG_DRVR_REMOVABLE
 int rwb_mediaremoved(FAR struct rwbuffer_s *rwb)
 {
+  int ret;
+
 #ifdef CONFIG_DRVR_WRITEBUFFER
   if (rwb->wrmaxblocks > 0)
     {


### PR DESCRIPTION
## Summary
Menuconfig options CONFIG_DRVR_REMOVABLE and CONFIG_DRVR_WRITEBUFFER currently cause compilation errors if enabled due to the return value not being instantiated.

## Impact
Menuconfig options CONFIG_DRVR_REMOVABLE and CONFIG_DRVR_WRITEBUFFER currently unusable

## Testing
Tested OK on Arty-A7 risc-v core.

