### PR TITLE
Add patch for littlefs to use kmm_malloc/free on kernel with MMU. Upgrade to latest littlefs

### DIFF
--- a/fs/littlefs/Make.defs
+++ b/fs/littlefs/Make.defs
@@ -41,7 +41,7 @@ CFLAGS += -DLFS_NAME_MAX=$(CONFIG_FS_LITTLEFS_NAME_MAX)
 CFLAGS += -DLFS_FILE_MAX=$(CONFIG_FS_LITTLEFS_FILE_MAX)
 CFLAGS += -DLFS_ATTR_MAX=$(CONFIG_FS_LITTLEFS_ATTR_MAX)
 
-LITTLEFS_VERSION ?= 2.4.0
+LITTLEFS_VERSION ?= 2.5.1
 LITTLEFS_TARBALL = v$(LITTLEFS_VERSION).tar.gz
 
 $(LITTLEFS_TARBALL):
@@ -50,6 +50,7 @@ $(LITTLEFS_TARBALL):
 .littlefsunpack: $(LITTLEFS_TARBALL)
 	$(Q) tar zxf littlefs/$(LITTLEFS_TARBALL) -C littlefs
 	$(Q) mv littlefs/littlefs-$(LITTLEFS_VERSION) littlefs/littlefs
+	$(Q) git apply littlefs/lfs_util.patch
 	$(Q) touch littlefs/.littlefsunpack
 
 # Download and unpack tarball if no git repo found

--- a/fs/littlefs/lfs_util.patch
+++ b/fs/littlefs/lfs_util.patch
@@ -1,0 +1,28 @@
+--- ./littlefs/littlefs/lfs_util.h	2022-11-11 03:32:30.000000000 +1100
++++ ./littlefs/littlefs/lfs_util.h	2023-04-21 12:25:27.987084276 +1000
+@@ -28,6 +28,7 @@
+
+ #ifndef LFS_NO_MALLOC
+ #include <stdlib.h>
++#include <nuttx/mm/mm.h>
+ #endif
+ #ifndef LFS_NO_ASSERT
+ #include <assert.h>
+@@ -218,7 +219,7 @@
+ // Note, memory must be 64-bit aligned
+ static inline void *lfs_malloc(size_t size) {
+ #ifndef LFS_NO_MALLOC
+-    return malloc(size);
++    return kmm_malloc(size);
+ #else
+     (void)size;
+     return NULL;
+@@ -228,7 +229,7 @@
+ // Deallocate memory, only used if buffers are not provided to littlefs
+ static inline void lfs_free(void *p) {
+ #ifndef LFS_NO_MALLOC
+-    free(p);
++    kmm_free(p);
+ #else
+     (void)p;
+ #endif


### PR DESCRIPTION
## Summary
When running the kernel in S-Mode with MMU and DMA within the SD/eMMC driver, littlefs initially allocates a memory buffer for the block reads in user/virtual address space and passes this to the SD driver for use.  The SD driver allocates this address to use for the DMA transfer, which is not valid.   Altering the SD driver to use it's own preallocated buffer in static memory and then memcpy'ing it into the buffer provided by littlefs is not a viable option, due to the performance hit this incurs.

## Impact
Allows the use of SD DMA transfers with littlefs

## Testing
Tested on Arty-A7 running S-Mode kernel with littlefs onto both SD and eMMC.  Tested with littlefs on RAM disk.
