### PR TITLE
Revert "arch/armv7ar: use robust code sequences for cache maintenance"

### DIFF
--- a/arch/arm/src/armv7-a/arm_cache.c
+++ b/arch/arm/src/armv7-a/arm_cache.c
@@ -216,8 +216,8 @@ size_t up_get_dcache_linesize(void)
 
 void up_invalidate_dcache(uintptr_t start, uintptr_t end)
 {
-  l2cc_invalidate(start, end);
   cp15_invalidate_dcache(start, end);
+  l2cc_invalidate(start, end);
 }
 
 /****************************************************************************
@@ -241,8 +241,8 @@ void up_invalidate_dcache_all(void)
 {
 #ifdef CONFIG_ARCH_L2CACHE
   irqstate_t flags = enter_critical_section();
-  l2cc_invalidate_all();
   cp15_invalidate_dcache_all();
+  l2cc_invalidate_all();
   leave_critical_section(flags);
 #else
   cp15_invalidate_dcache_all();
@@ -338,15 +338,14 @@ void up_flush_dcache(uintptr_t start, uintptr_t end)
 {
   if ((end - start) < cp15_cache_size())
     {
-      cp15_clean_dcache(start, end);
+      cp15_flush_dcache(start, end);
     }
   else
     {
-      cp15_clean_dcache_all();
+      cp15_flush_dcache_all();
     }
 
   l2cc_flush(start, end);
-  cp15_invalidate_dcache(start, end);
 }
 
 /****************************************************************************
@@ -373,9 +372,8 @@ void up_flush_dcache(uintptr_t start, uintptr_t end)
 
 void up_flush_dcache_all(void)
 {
-  cp15_clean_dcache_all();
+  cp15_flush_dcache_all();
   l2cc_flush_all();
-  cp15_invalidate_dcache_all();
 }
 
 /****************************************************************************

--- a/arch/arm/src/armv7-r/arm_cache.c
+++ b/arch/arm/src/armv7-r/arm_cache.c
@@ -216,8 +216,8 @@ size_t up_get_dcache_linesize(void)
 
 void up_invalidate_dcache(uintptr_t start, uintptr_t end)
 {
-  l2cc_invalidate(start, end);
   cp15_invalidate_dcache(start, end);
+  l2cc_invalidate(start, end);
 }
 
 /****************************************************************************
@@ -241,8 +241,8 @@ void up_invalidate_dcache_all(void)
 {
 #ifdef CONFIG_ARCH_L2CACHE
   irqstate_t flags = enter_critical_section();
-  l2cc_invalidate_all();
   cp15_invalidate_dcache_all();
+  l2cc_invalidate_all();
   leave_critical_section(flags);
 #else
   cp15_invalidate_dcache_all();
@@ -338,15 +338,14 @@ void up_flush_dcache(uintptr_t start, uintptr_t end)
 {
   if ((end - start) < cp15_cache_size())
     {
-      cp15_clean_dcache(start, end);
+      cp15_flush_dcache(start, end);
     }
   else
     {
-      cp15_clean_dcache_all();
+      cp15_flush_dcache_all();
     }
 
   l2cc_flush(start, end);
-  cp15_invalidate_dcache(start, end);
 }
 
 /****************************************************************************
@@ -373,9 +372,8 @@ void up_flush_dcache(uintptr_t start, uintptr_t end)
 
 void up_flush_dcache_all(void)
 {
-  cp15_clean_dcache_all();
+  cp15_flush_dcache_all();
   l2cc_flush_all();
-  cp15_invalidate_dcache_all();
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

This reverts commit 69fd539886eb529695557a4b46baccebfa86b82f.
Some board test fail for PR #9047.

## Impact

NA

## Testing

BES board