### PR TITLE
assert: Distinguish between assert and exception

### DIFF
--- a/arch/arm/src/arm/arm_dataabort.c
+++ b/arch/arm/src/arm/arm_dataabort.c
@@ -145,7 +145,7 @@ segfault:
 #endif
   _alert("Data abort. PC: %08x FAR: %08x FSR: %08x\n",
          regs[REG_PC], far, fsr);
-  PANIC();
+  PANIC_WITH_REGS("panic", regs);
 }
 
 #else /* CONFIG_PAGING */
@@ -161,7 +161,7 @@ void arm_dataabort(uint32_t *regs)
   /* Crash -- possibly showing diagnost debug information. */
 
   _alert("Data abort. PC: %08" PRIx32 "\n", regs[REG_PC]);
-  PANIC();
+  PANIC_WITH_REGS("panic", regs);
 }
 
 #endif /* CONFIG_PAGING */

--- a/arch/arm/src/arm/arm_prefetchabort.c
+++ b/arch/arm/src/arm/arm_prefetchabort.c
@@ -125,6 +125,6 @@ void arm_prefetchabort(uint32_t *regs)
 #endif
     {
       _alert("Prefetch abort. PC: %08" PRIx32 "\n", regs[REG_PC]);
-      PANIC();
+      PANIC_WITH_REGS("panic", regs);
     }
 }

--- a/arch/arm/src/arm/arm_undefinedinsn.c
+++ b/arch/arm/src/arm/arm_undefinedinsn.c
@@ -44,5 +44,5 @@ void arm_undefinedinsn(uint32_t *regs)
 {
   _alert("Undefined instruction at 0x%" PRIx32 "\n", regs[REG_PC]);
   CURRENT_REGS = regs;
-  PANIC();
+  PANIC_WITH_REGS("panic", regs);
 }

--- a/arch/arm/src/armv6-m/arm_hardfault.c
+++ b/arch/arm/src/armv6-m/arm_hardfault.c
@@ -120,6 +120,6 @@ int arm_hardfault(int irq, void *context, void *arg)
 
   up_irq_save();
   hfalert("PANIC!!! Hard fault\n");
-  PANIC();
+  PANIC_WITH_REGS("panic", context);
   return OK; /* Won't get here */
 }

--- a/arch/arm/src/armv7-a/arm_dataabort.c
+++ b/arch/arm/src/armv7-a/arm_dataabort.c
@@ -140,7 +140,7 @@ uint32_t *arm_dataabort(uint32_t *regs, uint32_t dfar, uint32_t dfsr)
 segfault:
   _alert("Data abort. PC: %08x DFAR: %08x DFSR: %08x\n",
         regs[REG_PC], dfar, dfsr);
-  PANIC();
+  PANIC_WITH_REGS("panic", regs);
   return regs; /* To keep the compiler happy */
 }
 
@@ -158,7 +158,7 @@ uint32_t *arm_dataabort(uint32_t *regs, uint32_t dfar, uint32_t dfsr)
 
   _alert("Data abort. PC: %08x DFAR: %08x DFSR: %08x\n",
         regs[REG_PC], dfar, dfsr);
-  PANIC();
+  PANIC_WITH_REGS("panic", regs);
   return regs; /* To keep the compiler happy */
 }
 

--- a/arch/arm/src/armv7-a/arm_prefetchabort.c
+++ b/arch/arm/src/armv7-a/arm_prefetchabort.c
@@ -111,7 +111,7 @@ uint32_t *arm_prefetchabort(uint32_t *regs, uint32_t ifar, uint32_t ifsr)
     {
       _alert("Prefetch abort. PC: %08x IFAR: %08x IFSR: %08x\n",
             regs[REG_PC], ifar, ifsr);
-      PANIC();
+      PANIC_WITH_REGS("panic", regs);
     }
 
   return regs;
@@ -131,7 +131,7 @@ uint32_t *arm_prefetchabort(uint32_t *regs, uint32_t ifar, uint32_t ifsr)
 
   _alert("Prefetch abort. PC: %08x IFAR: %08x IFSR: %08x\n",
         regs[REG_PC], ifar, ifsr);
-  PANIC();
+  PANIC_WITH_REGS("panic", regs);
   return regs; /* To keep the compiler happy */
 }
 

--- a/arch/arm/src/armv7-a/arm_undefinedinsn.c
+++ b/arch/arm/src/armv7-a/arm_undefinedinsn.c
@@ -44,6 +44,6 @@ uint32_t *arm_undefinedinsn(uint32_t *regs)
 {
   _alert("Undefined instruction at 0x%x\n", regs[REG_PC]);
   CURRENT_REGS = regs;
-  PANIC();
+  PANIC_WITH_REGS("panic", regs);
   return regs; /* To keep the compiler happy */
 }

--- a/arch/arm/src/armv7-m/arm_busfault.c
+++ b/arch/arm/src/armv7-m/arm_busfault.c
@@ -103,6 +103,6 @@ int arm_busfault(int irq, void *context, void *arg)
     }
 
   up_irq_save();
-  PANIC();
+  PANIC_WITH_REGS("panic", context);
   return OK;
 }

--- a/arch/arm/src/armv7-m/arm_hardfault.c
+++ b/arch/arm/src/armv7-m/arm_hardfault.c
@@ -172,6 +172,6 @@ int arm_hardfault(int irq, void *context, void *arg)
     }
 
   up_irq_save();
-  PANIC();
+  PANIC_WITH_REGS("panic", context);
   return OK;
 }

--- a/arch/arm/src/armv7-m/arm_memfault.c
+++ b/arch/arm/src/armv7-m/arm_memfault.c
@@ -99,6 +99,6 @@ int arm_memfault(int irq, void *context, void *arg)
     }
 
   up_irq_save();
-  PANIC();
+  PANIC_WITH_REGS("panic", context);
   return OK; /* Won't get here */
 }

--- a/arch/arm/src/armv7-m/arm_usagefault.c
+++ b/arch/arm/src/armv7-m/arm_usagefault.c
@@ -111,6 +111,6 @@ int arm_usagefault(int irq, void *context, void *arg)
     }
 
   up_irq_save();
-  PANIC();
+  PANIC_WITH_REGS("panic", context);
   return OK;
 }

--- a/arch/arm/src/armv7-r/arm_dataabort.c
+++ b/arch/arm/src/armv7-r/arm_dataabort.c
@@ -63,6 +63,6 @@ uint32_t *arm_dataabort(uint32_t *regs, uint32_t dfar, uint32_t dfsr)
 
   _alert("Data abort. PC: %08x DFAR: %08x DFSR: %08x\n",
         regs[REG_PC], dfar, dfsr);
-  PANIC();
+  PANIC_WITH_REGS("panic", regs);
   return regs; /* To keep the compiler happy */
 }

--- a/arch/arm/src/armv7-r/arm_prefetchabort.c
+++ b/arch/arm/src/armv7-r/arm_prefetchabort.c
@@ -59,6 +59,6 @@ uint32_t *arm_prefetchabort(uint32_t *regs, uint32_t ifar, uint32_t ifsr)
 
   _alert("Prefetch abort. PC: %08x IFAR: %08x IFSR: %08x\n",
         regs[REG_PC], ifar, ifsr);
-  PANIC();
+  PANIC_WITH_REGS("panic", regs);
   return regs; /* To keep the compiler happy */
 }

--- a/arch/arm/src/armv7-r/arm_undefinedinsn.c
+++ b/arch/arm/src/armv7-r/arm_undefinedinsn.c
@@ -44,6 +44,6 @@ uint32_t *arm_undefinedinsn(uint32_t *regs)
 {
   _alert("Undefined instruction at 0x%x\n", regs[REG_PC]);
   CURRENT_REGS = regs;
-  PANIC();
+  PANIC_WITH_REGS("panic", regs);
   return regs; /* To keep the compiler happy */
 }

--- a/arch/arm/src/armv8-m/arm_busfault.c
+++ b/arch/arm/src/armv8-m/arm_busfault.c
@@ -103,6 +103,6 @@ int arm_busfault(int irq, void *context, void *arg)
     }
 
   up_irq_save();
-  PANIC();
+  PANIC_WITH_REGS("panic", context);
   return OK;
 }

--- a/arch/arm/src/armv8-m/arm_hardfault.c
+++ b/arch/arm/src/armv8-m/arm_hardfault.c
@@ -182,6 +182,6 @@ int arm_hardfault(int irq, void *context, void *arg)
     }
 
   up_irq_save();
-  PANIC();
+  PANIC_WITH_REGS("panic", context);
   return OK;
 }

--- a/arch/arm/src/armv8-m/arm_memfault.c
+++ b/arch/arm/src/armv8-m/arm_memfault.c
@@ -99,6 +99,6 @@ int arm_memfault(int irq, void *context, void *arg)
     }
 
   up_irq_save();
-  PANIC();
+  PANIC_WITH_REGS("panic", context);
   return OK; /* Won't get here */
 }

--- a/arch/arm/src/armv8-m/arm_securefault.c
+++ b/arch/arm/src/armv8-m/arm_securefault.c
@@ -167,7 +167,7 @@ int arm_securefault(int irq, void *context, void *arg)
 #endif
 
   up_irq_save();
-  PANIC();
+  PANIC_WITH_REGS("panic", context);
 
   return OK;
 }

--- a/arch/arm/src/armv8-m/arm_usagefault.c
+++ b/arch/arm/src/armv8-m/arm_usagefault.c
@@ -111,6 +111,6 @@ int arm_usagefault(int irq, void *context, void *arg)
     }
 
   up_irq_save();
-  PANIC();
+  PANIC_WITH_REGS("panic", context);
   return OK;
 }

--- a/arch/arm/src/nrf52/nrf52_sdc.c
+++ b/arch/arm/src/nrf52/nrf52_sdc.c
@@ -323,7 +323,7 @@ static int bt_hci_send(struct bt_driver_s *btdev,
 
 static void sdc_fault_handler(const char *file, const uint32_t line)
 {
-  _assert(file, line, "SoftDevice Controller Fault");
+  __assert(file, line, "SoftDevice Controller Fault");
 }
 
 /****************************************************************************
@@ -332,7 +332,7 @@ static void sdc_fault_handler(const char *file, const uint32_t line)
 
 static void mpsl_assert_handler(const char *const file, const uint32_t line)
 {
-  _assert(file, line, "MPSL assertion failed");
+  __assert(file, line, "MPSL assertion failed");
 }
 
 /****************************************************************************

--- a/arch/arm/src/nrf53/nrf53_sdc.c
+++ b/arch/arm/src/nrf53/nrf53_sdc.c
@@ -323,7 +323,7 @@ static int bt_hci_send(struct bt_driver_s *btdev,
 
 static void sdc_fault_handler(const char *file, const uint32_t line)
 {
-  _assert(file, line, "SoftDevice Controller Fault");
+  __assert(file, line, "SoftDevice Controller Fault");
 }
 
 /****************************************************************************
@@ -332,7 +332,7 @@ static void sdc_fault_handler(const char *file, const uint32_t line)
 
 static void mpsl_assert_handler(const char *const file, const uint32_t line)
 {
-  _assert(file, line, "MPSL assertion failed");
+  __assert(file, line, "MPSL assertion failed");
 }
 
 /****************************************************************************

--- a/arch/arm/src/phy62xx/phy62xx_hardfault.c
+++ b/arch/arm/src/phy62xx/phy62xx_hardfault.c
@@ -124,6 +124,6 @@ int arm_hardfault(int irq, void *context, void *arg)
 
   up_irq_save();
   hfalert("PANIC!!! Hard fault\n");
-  PANIC();
+  PANIC_WITH_REGS("panic", context);
   return OK; /* Won't get here */
 }

--- a/arch/arm64/src/common/arm64_fatal.c
+++ b/arch/arm64/src/common/arm64_fatal.c
@@ -372,5 +372,5 @@ void arm64_fatal_error(unsigned int reason, struct regs_context * reg)
         }
     }
 
-  PANIC();
+  PANIC_WITH_REGS("panic", reg);
 }

--- a/arch/ceva/src/xc5/xc5_hardfault.c
+++ b/arch/ceva/src/xc5/xc5_hardfault.c
@@ -88,6 +88,6 @@ int ceva_hardfault(int irq, void *context, void *arg)
   hfdumpreg4(P_MAPAR, P_MAPSR, UOP_STS, UOP_PAR);
   hfdumpreg1(REG_DBG_GEN);
 
-  PANIC();
+  PANIC_WITH_REGS("panic", context);
   return OK;
 }

--- a/arch/ceva/src/xm6/xm6_hardfault.c
+++ b/arch/ceva/src/xm6/xm6_hardfault.c
@@ -106,6 +106,6 @@ int ceva_hardfault(int irq, void *context, void *arg)
   hfdumpreg4(MAPAR,      MAPSR,         DBG_GEN,     DBG_GEN_2);
   hfdumpreg4(DBG_DUNMPD, HIST_OVERFLOW, DBG_DESC_ID, DBG_QMAN_ID);
 
-  PANIC();
+  PANIC_WITH_REGS("panic", context);
   return OK;
 }

--- a/arch/mips/src/pic32mx/pic32mx_exception.c
+++ b/arch/mips/src/pic32mx/pic32mx_exception.c
@@ -164,6 +164,6 @@ uint32_t *pic32mx_exception(uint32_t *regs)
    */
 
   CURRENT_REGS = regs;
-  PANIC();
+  PANIC_WITH_REGS("panic", regs);
   return regs; /* Won't get here */
 }

--- a/arch/mips/src/pic32mz/pic32mz_exception.c
+++ b/arch/mips/src/pic32mz/pic32mz_exception.c
@@ -163,6 +163,6 @@ uint32_t *pic32mz_exception(uint32_t *regs)
    */
 
   CURRENT_REGS = regs;
-  PANIC();
+  PANIC_WITH_REGS("panic", regs);
   return regs; /* Won't get here */
 }

--- a/arch/risc-v/src/common/riscv_exception.c
+++ b/arch/risc-v/src/common/riscv_exception.c
@@ -82,7 +82,7 @@ int riscv_exception(int mcause, void *regs, void *args)
   _alert("PANIC!!! Exception = %" PRIxREG "\n", cause);
   up_irq_save();
   CURRENT_REGS = regs;
-  PANIC();
+  PANIC_WITH_REGS("panic", regs);
 
   return 0;
 }

--- a/arch/xtensa/src/common/xtensa_assert.c
+++ b/arch/xtensa/src/common/xtensa_assert.c
@@ -81,7 +81,7 @@ void xtensa_panic(int xptcode, uint32_t *regs)
   _alert("Unhandled Exception %d\n", xptcode);
 #endif
 
-  PANIC();  /* Should not return */
+  PANIC_WITH_REGS("panic", regs);  /* Should not return */
   for (; ; );
 }
 
@@ -184,6 +184,6 @@ void xtensa_user_panic(int exccause, uint32_t *regs)
   _alert("User Exception: EXCCAUSE=%04x\n", exccause);
 #endif
 
-  PANIC(); /* Should not return */
+  PANIC_WITH_REGS("user panic", regs); /* Should not return */
   for (; ; );
 }

--- a/arch/z16/src/z16f/z16f_sysexec.c
+++ b/arch/z16/src/z16f/z16f_sysexec.c
@@ -101,5 +101,5 @@ void z16f_sysexec(FAR chipreg_t *regs)
       z16f_reset();
     }
 
-  PANIC();
+  PANIC_WITH_REGS("panic", regs);
 }

--- a/include/assert.h
+++ b/include/assert.h
@@ -48,6 +48,7 @@
 #endif
 
 #define PANIC() __assert(__FILE__, __LINE__, "panic")
+#define PANIC_WITH_REGS(msg, regs) _assert(__FILE__, __LINE__, msg, regs)
 
 #ifdef CONFIG_DEBUG_ASSERTIONS_EXPRESSION
 #  define ASSERT(f)                       \
@@ -152,7 +153,8 @@ extern "C"
  *
  ****************************************************************************/
 
-void _assert(FAR const char *filename, int linenum, FAR const char *msg);
+void _assert(FAR const char *filename, int linenum,
+             FAR const char *msg, FAR void *regs);
 
 /****************************************************************************
  * Name: __assert

--- a/include/sys/syscall_lookup.h
+++ b/include/sys/syscall_lookup.h
@@ -25,7 +25,7 @@
  */
 
 SYSCALL_LOOKUP1(_exit,                     1)
-SYSCALL_LOOKUP(_assert,                    3)
+SYSCALL_LOOKUP(_assert,                    4)
 SYSCALL_LOOKUP(getpid,                     0)
 SYSCALL_LOOKUP(gettid,                     0)
 SYSCALL_LOOKUP(prctl,                      2)

--- a/libs/libc/assert/lib_assert.c
+++ b/libs/libc/assert/lib_assert.c
@@ -33,6 +33,6 @@
 
 void __assert(FAR const char *filename, int linenum, FAR const char *msg)
 {
-  _assert(filename, linenum, msg);
+  _assert(filename, linenum, msg, NULL);
   abort();
 }

--- a/syscall/syscall.csv
+++ b/syscall/syscall.csv
@@ -1,4 +1,4 @@
-"_assert","assert.h","","void","FAR const char *","int","FAR const char *"
+"_assert","assert.h","","void","FAR const char *","int","FAR const char *","FAR void *"
 "_exit","unistd.h","","noreturn","int"
 "accept4","sys/socket.h","defined(CONFIG_NET)","int","int","FAR struct sockaddr *","FAR socklen_t *","int"
 "adjtime","sys/time.h","defined(CONFIG_CLOCK_TIMEKEEPING)","int","FAR const struct timeval *","FAR struct timeval *"


### PR DESCRIPTION
## Summary

CURRENT_REGS may change during assert handling, so pass in the 'regs' parameter at the entry point of _assert.
When an exception occurs, use the passed-in 'regs' parameter directly instead of using CURRENT_REGS.

## Impact

Debug

## Testing

BES board