### PR TITLE
sched: add the CPU bitset to initialize the non-exclusive CPU

### DIFF
--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -358,6 +358,13 @@ config SMP_NCPUS
 		SMP configuration.  However, running the SMP logic in a single CPU
 		configuration is useful during certain testing.
 
+config SMP_DEFAULT_CPUSET
+	hex "Default CPU bit set"
+	default 0xffffffff
+	---help---
+		Set the Default CPU bits. The way to use the unset CPU is to call the
+		sched_setaffinity function to bind a task to the CPU. bit0 means CPU0.
+
 endif # SMP
 
 choice

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -376,7 +376,8 @@ void nx_start(void)
        * the IDLE task.
        */
 
-      g_idletcb[i].cmn.affinity = SCHED_ALL_CPUS;
+      g_idletcb[i].cmn.affinity =
+        (cpu_set_t)(CONFIG_SMP_DEFAULT_CPUSET & SCHED_ALL_CPUS);
 #else
       g_idletcb[i].cmn.flags = (TCB_FLAG_TTYPE_KERNEL |
                                 TCB_FLAG_NONCANCELABLE);


### PR DESCRIPTION
## Summary

Set the Default CPU bits. The way to use the unset CPU is to call the sched_setaffinity function to bind a task to the CPU. bit0 means CPU0.

## Impact

SMP

## Testing

BES board