### PR TITLE
boards/k210: Use 8 byte align in linker script

### DIFF
--- a/boards/risc-v/k210/maix-bit/scripts/ld.script
+++ b/boards/risc-v/k210/maix-bit/scripts/ld.script
@@ -53,33 +53,34 @@ SECTIONS
         _etext = ABSOLUTE(.);
     } > progmem
 
-    .init_section : ALIGN(4) {
+    .init_section : ALIGN(8) {
         _sinit = ABSOLUTE(.);
         KEEP(*(.init_array .init_array.*))
+        . = ALIGN(8);
         _einit = ABSOLUTE(.);
     } > progmem
 
     _eronly = ABSOLUTE(.);
 
-    .data : ALIGN(4) {
+    .data : ALIGN(8) {
         _sdata = ABSOLUTE(.);
         *(.data .data.*)
         *(.sdata .sdata.* .sdata2.*)
         *(.gnu.linkonce.d.*)
         *(.gnu.linkonce.s.*)
         CONSTRUCTORS
-        . = ALIGN(4);
+        . = ALIGN(8);
         _edata = ABSOLUTE(.);
     } > sram AT > progmem
 
-    .bss : ALIGN(4) {
+    .bss : ALIGN(8) {
         _sbss = ABSOLUTE(.);
         *(.bss .bss.*)
         *(.sbss .sbss.*)
         *(.gnu.linkonce.b.*)
         *(.gnu.linkonce.sb.*)
         *(COMMON)
-        . = ALIGN(32);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/risc-v/k210/maix-bit/scripts/user-space.ld
+++ b/boards/risc-v/k210/maix-bit/scripts/user-space.ld
@@ -45,9 +45,10 @@ SECTIONS
         _etext = ABSOLUTE(.);
     } > uflash
 
-    .init_section : {
+    .init_section : ALIGN(8) {
         _sinit = ABSOLUTE(.);
         KEEP(*(.init_array .init_array.*))
+        . = ALIGN(8);
         _einit = ABSOLUTE(.);
     } > uflash
 
@@ -63,7 +64,7 @@ SECTIONS
         *(.sdata .sdata.* .sdata2.*)
         *(.gnu.linkonce.d.*)
         CONSTRUCTORS
-        . = ALIGN(4);
+        . = ALIGN(8);
         _edata = ABSOLUTE(.);
     } > usram AT > uflash
 
@@ -73,7 +74,7 @@ SECTIONS
         *(.sbss .sbss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > usram
 


### PR DESCRIPTION
## Summary
I noticed sometimes once config changed, it will not launch to shell, maybe due to
K210 is a 64-bit platform and without misaligned memory access support.

This patch may fix this problem, it will not introduce new issues at least.
## Impact
k210 only
## Testing
maix-bit:nsh, maix-bit:smp with addtion apps (coremark etc) enabled.
