### PR TITLE
signal: add macro NSIG

### DIFF
--- a/include/signal.h
+++ b/include/signal.h
@@ -51,6 +51,7 @@
 #define SIGRTMIN        (SIGSTDMAX + 1) /* First real time signal */
 #define SIGRTMAX        MAX_SIGNO       /* Last real time signal */
 #define _NSIG           (MAX_SIGNO + 1) /* Biggest signal number + 1 */
+#define NSIG            _NSIG           /* _NSIG variant commonly used */
 
 /* sigset_t is represented as an array of 32-b unsigned integers.
  * _SIGSET_NELEM is the allocated isze of the array


### PR DESCRIPTION
## Summary

In addition to https://github.com/apache/nuttx/pull/8286, add the `NSIG` macro based on `_NSIG` as it's done on [Linux](https://github.com/torvalds/linux/blob/8ad4b6fa0f874ec8ec6e92a90116e3ab43cded6c/arch/sparc/include/uapi/asm/signal.h#L102)

The motivation is to provide it for applications that include `<signal.h>`. Specifically, it's necessary to build https://github.com/apache/nuttx-apps/pull/1651 correctly.

## Impact

New macro definition based on an already defined macro. 

## Testing

NuttX's CI and (rtptools)[https://github.com/apache/nuttx-apps/pull/1651] on SIM.