### PR TITLE
mm: malloc return valid pointer when request 0 size

### DIFF
--- a/mm/mm_heap/mm_calloc.c
+++ b/mm/mm_heap/mm_calloc.c
@@ -42,20 +42,19 @@ FAR void *mm_calloc(FAR struct mm_heap_s *heap, size_t n, size_t elem_size)
 {
   FAR void *ret = NULL;
 
-  /* Verify input parameters */
+  /* Verify input parameters
+   *
+   * elem_size or n is zero treats as valid input.
+   *
+   * Assure that the following multiplication cannot overflow the size_t
+   * type, i.e., that:  SIZE_MAX >= n * elem_size
+   *
+   * Refer to SEI CERT C Coding Standard.
+   */
 
-  if (n > 0 && elem_size > 0)
+  if (elem_size == 0 || n <= (SIZE_MAX / elem_size))
     {
-      /* Assure that the following multiplication cannot overflow the size_t
-       * type, i.e., that:  SIZE_MAX >= n * elem_size
-       *
-       * Refer to SEI CERT C Coding Standard.
-       */
-
-      if (n <= (SIZE_MAX / elem_size))
-        {
-          ret = mm_zalloc(heap, n * elem_size);
-        }
+      ret = mm_zalloc(heap, n * elem_size);
     }
 
   return ret;

--- a/mm/mm_heap/mm_malloc.c
+++ b/mm/mm_heap/mm_malloc.c
@@ -114,13 +114,6 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
 
   free_delaylist(heap);
 
-  /* Ignore zero-length allocations */
-
-  if (size < 1)
-    {
-      return NULL;
-    }
-
 #if CONFIG_MM_HEAP_MEMPOOL_THRESHOLD != 0
   ret = mempool_multiple_alloc(heap->mm_mpool, size);
   if (ret != NULL)

--- a/mm/umm_heap/umm_calloc.c
+++ b/mm/umm_heap/umm_calloc.c
@@ -50,20 +50,19 @@ FAR void *calloc(size_t n, size_t elem_size)
 
   FAR void *ret = NULL;
 
-  /* Verify input parameters */
+  /* Verify input parameters
+   *
+   * elem_size or n is zero treats as valid input.
+   *
+   * Assure that the following multiplication cannot overflow the size_t
+   * type, i.e., that:  SIZE_MAX >= n * elem_size
+   *
+   * Refer to SEI CERT C Coding Standard.
+   */
 
-  if (n > 0 && elem_size > 0)
+  if (elem_size == 0 || n <= (SIZE_MAX / elem_size))
     {
-      /* Assure that the following multiplication cannot overflow the size_t
-       * type, i.e., that:  SIZE_MAX >= n * elem_size
-       *
-       * Refer to SEI CERT C Coding Standard.
-       */
-
-      if (n <= (SIZE_MAX / elem_size))
-        {
-          ret = zalloc(n * elem_size);
-        }
+      ret = zalloc(n * elem_size);
     }
 
   return ret;


### PR DESCRIPTION
If requested space size is 0, the behavior is implementation-defined: the value returned shall be either a null pointer or a unique pointer. Change the behavior to be similar to linux and Android

https://pubs.opengroup.org/onlinepubs/000095399/functions/malloc.html https://pubs.opengroup.org/onlinepubs/000095399/functions/calloc.html

test case: malloc/calloc request size 0 with 10000 times and then free one by one, check with no memory leak.

## Summary
There is a crucial difference between "no data" (yet) and "data of length zero" in many cases.  malloc(0) helps in either case, for example some marshal or serialization code to transfer buffer with  pointer and size.
## Impact

## Testing
sim
