### PR TITLE
include/err: Enforce c linkage for err and warn functions.

### DIFF
--- a/include/err.h
+++ b/include/err.h
@@ -32,6 +32,14 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
 /* Append _func suffix to avoid the penitential symbol collision */
 
 #define warn   warn_func
@@ -66,5 +74,10 @@ void err(int status, FAR const char *fmt, ...) printf_like(2, 3);
 void verr(int status, FAR const char *fmt, va_list ap) printf_like(2, 0);
 void errx(int status, FAR const char *fmt, ...) printf_like(2, 3);
 void verrx(int status, FAR const char *fmt, va_list ap) printf_like(2, 0);
+
+#ifdef __cplusplus
+#undef EXTERN
+}
+#endif
 
 #endif /* __INCLUDE_ERR_H */


### PR DESCRIPTION
## Summary

This change ensures that xx_func names are not mangled by a c++ compiler and can be correctly resolved when loaded at runtime.

## Impact

c++ applications which use `err` can be loaded correctly.

## Testing

The issue without this addition can be reproduced by following:

1) Use the `err` function from a c++ application:

```
diff --git a/examples/helloxx/helloxx_main.cxx b/examples/helloxx/helloxx_main.cxx
index c64891de1..93a38be58 100644
--- a/examples/helloxx/helloxx_main.cxx
+++ b/examples/helloxx/helloxx_main.cxx
@@ -26,6 +26,7 @@
 
 #include <cstdio>
 #include <debug.h>
+#include <err.h>
 
 //***************************************************************************
 // Definitions
@@ -124,6 +125,8 @@ extern "C" int main(int argc, FAR char *argv[])
   g_HelloWorld.HelloWorld();
 #endif
 
+  err(11, "This produces an undefined symbol\n");
+
   delete pHelloWorld;
   return 0;
 }
```

2) Add BINFORMAT debugging and add helloxx application to `rv-virt:knsh32`:
```
diff --git a/boards/risc-v/qemu-rv/rv-virt/configs/knsh32/defconfig b/boards/risc-v/qemu-rv/rv-virt/configs/knsh32/defconfig
index 86d381bd07..f4bdd20da5 100644
--- a/boards/risc-v/qemu-rv/rv-virt/configs/knsh32/defconfig
+++ b/boards/risc-v/qemu-rv/rv-virt/configs/knsh32/defconfig
@@ -44,10 +44,18 @@ CONFIG_ARCH_USE_S_MODE=y
 CONFIG_BOARD_LOOPSPERMSEC=6366
 CONFIG_BUILD_KERNEL=y
 CONFIG_DEV_ZERO=y
+CONFIG_DEBUG_BINFMT=y
+CONFIG_DEBUG_BINFMT_ERROR=y
+CONFIG_DEBUG_ERROR=y
+CONFIG_DEBUG_FEATURES=y
+CONFIG_DEBUG_INFO=y
+CONFIG_DEBUG_WARN=y
 CONFIG_ELF=y
 CONFIG_EXAMPLES_HELLO=m
+CONFIG_EXAMPLES_HELLOXX=m
 CONFIG_FS_HOSTFS=y
 CONFIG_FS_PROCFS=y
+CONFIG_HAVE_CXX=y
 CONFIG_IDLETHREAD_STACKSIZE=3072
 CONFIG_INIT_FILEPATH="/system/bin/init"
 CONFIG_INIT_MOUNT=y
```

Program output when `helloxx` is ran from nsh:
```
...
[    3.347000] elf_symvalue: SHN_UNDEF: Exported symbol "_Z8err_funciPKcz" not found
[    3.348000] elf_relocateadd: Section 2 reloc 77: Failed to get value of symbol[270]: -2
[    3.350000] elf_loadbinary: Failed to bind symbols program binary: -2
[    3.351000] exec_spawn: ERROR: Failed to load program 'helloxx': -2
```

Using objdump `riscv64-unknown-elf-objdump apps/bin/helloxx -x | c++filt | less`
```
SYMBOL TABLE:
...
...
00000000         *UND*  00000000 err_func(int, char const*, ...)
```

With the additions included in the PR, the symbol is no longed undefined with the application building and launching successfully.
