### PR TITLE
libc: Add setbuffer to stdio.

### DIFF
--- a/include/stdio.h
+++ b/include/stdio.h
@@ -171,6 +171,7 @@ void   rewind(FAR FILE *stream);
 
 void   setbuf(FAR FILE *stream, FAR char *buf);
 int    setvbuf(FAR FILE *stream, FAR char *buffer, int mode, size_t size);
+void   setbuffer(FAR FILE *stream, FAR char *buf, size_t size);
 
 int    ungetc(int c, FAR FILE *stream);
 

--- a/libs/libc/stdio/Make.defs
+++ b/libs/libc/stdio/Make.defs
@@ -47,7 +47,7 @@ CSRCS += lib_fputs.c lib_ungetc.c lib_fprintf.c lib_vfprintf.c
 CSRCS += lib_feof.c lib_ferror.c lib_rewind.c lib_clearerr.c
 CSRCS += lib_scanf.c lib_vscanf.c lib_fscanf.c lib_vfscanf.c lib_tmpfile.c
 CSRCS += lib_setbuf.c lib_setvbuf.c lib_libstream.c lib_libfilelock.c
-CSRCS += lib_libgetstreams.c
+CSRCS += lib_libgetstreams.c lib_setbuffer.c
 endif
 
 # Add the stdio directory to the build

--- a/libs/libc/stdio/lib_setbuffer.c
+++ b/libs/libc/stdio/lib_setbuffer.c
@@ -1,0 +1,64 @@
+/****************************************************************************
+ * libs/libc/stdio/lib_setbuffer.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <assert.h>
+#include <errno.h>
+
+#include <nuttx/fs/fs.h>
+
+#include "libc.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: setbuffer()
+ *
+ * Description:
+ *  The setbuffer() function is a wrapper around setvbuf() which
+ *  enables full buffering on a buffer allocated by the caller, assuming
+ *  buffer is not a null pointer.
+ *
+ * Input Parameters:
+ *   stream - the stream to flush
+ *   buffer - The user allocated buffer to use.
+ *            If NULL, buffering is disabled.
+ *   size   - size of the user buffer.
+ *
+ ****************************************************************************/
+
+void setbuffer(FAR FILE *stream, FAR char *buffer, size_t size)
+{
+#ifndef CONFIG_STDIO_DISABLE_BUFFERING
+  setvbuf(stream, buffer, buffer ? _IOFBF : _IONBF, size);
+#endif
+}


### PR DESCRIPTION
## Summary

The setbuffer() function is a wrapper around setvbuf() which enables full buffering on a buffer allocated by the caller, assuming buffer is not a null pointer.

## Impact

Add setbuffer to `stdio.h` namespace.

## Testing

Considering this directly wraps setvbuf, no separate test case has been added to app/testing/ostest for setbuffer.

