### PR TITLE
Remove #warning in the unnecessary places

### DIFF
--- a/drivers/net/dm90x0.c
+++ b/drivers/net/dm90x0.c
@@ -1554,8 +1554,9 @@ static int dm9x_addmac(FAR struct net_driver_s *dev, FAR const uint8_t *mac)
 
   /* Add the MAC address to the hardware multicast routing table */
 
-#warning "Multicast MAC support not implemented"
-  return OK;
+  /* #warning "Multicast MAC support not implemented" */
+
+  return -ENOSYS;
 }
 #endif
 
@@ -1585,8 +1586,9 @@ static int dm9x_rmmac(FAR struct net_driver_s *dev, FAR const uint8_t *mac)
 
   /* Add the MAC address to the hardware multicast routing table */
 
-#warning "Multicast MAC support not implemented"
-  return OK;
+  /* #warning "Multicast MAC support not implemented" */
+
+  return -ENOSYS;
 }
 #endif
 

--- a/drivers/net/enc28j60.c
+++ b/drivers/net/enc28j60.c
@@ -2084,12 +2084,12 @@ static int enc_addmac(struct net_driver_s *dev, FAR const uint8_t *mac)
 
   /* Add the MAC address to the hardware multicast routing table */
 
-#warning "Multicast MAC support not implemented"
+  /* #warning "Multicast MAC support not implemented" */
 
   /* Un-lock the SPI bus */
 
   enc_unlock(priv);
-  return OK;
+  return -ENOSYS;
 }
 #endif
 
@@ -2122,12 +2122,12 @@ static int enc_rmmac(struct net_driver_s *dev, FAR const uint8_t *mac)
 
   /* Add the MAC address to the hardware multicast routing table */
 
-#warning "Multicast MAC support not implemented"
+  /* #warning "Multicast MAC support not implemented" */
 
   /* Un-lock the SPI bus */
 
   enc_unlock(priv);
-  return OK;
+  return -ENOSYS;
 }
 #endif
 

--- a/drivers/net/encx24j600.c
+++ b/drivers/net/encx24j600.c
@@ -2228,12 +2228,12 @@ static int enc_addmac(struct net_driver_s *dev, FAR const uint8_t *mac)
 
   /* Add the MAC address to the hardware multicast routing table */
 
-#warning "Multicast MAC support not implemented"
+  /* #warning "Multicast MAC support not implemented" */
 
   /* Un-lock the SPI bus */
 
   enc_unlock(priv);
-  return OK;
+  return -ENOSYS;
 }
 #endif
 
@@ -2266,12 +2266,12 @@ static int enc_rmmac(struct net_driver_s *dev, FAR const uint8_t *mac)
 
   /* Add the MAC address to the hardware multicast routing table */
 
-#warning "Multicast MAC support not implemented"
+  /* #warning "Multicast MAC support not implemented" */
 
   /* Un-lock the SPI bus */
 
   enc_unlock(priv);
-  return OK;
+  return -ENOSYS;
 }
 #endif
 

--- a/libs/libc/dlfcn/lib_dlclose.c
+++ b/libs/libc/dlfcn/lib_dlclose.c
@@ -246,7 +246,8 @@ int dlclose(FAR void *handle)
    * memory region.
    */
 
-#warning Missing logic
+  /* #warning Missing logic */
+
   return -ENOSYS;
 #endif
 }

--- a/libs/libc/dlfcn/lib_dlopen.c
+++ b/libs/libc/dlfcn/lib_dlopen.c
@@ -297,7 +297,8 @@ static inline FAR void *dlinsert(FAR const char *filename)
 
 static inline FAR void *dlinsert(FAR const char *filename)
 {
-#warning Missing logic
+  /* #warning Missing logic */
+
   return NULL;
 }
 #endif

--- a/libs/libc/dlfcn/lib_dlsym.c
+++ b/libs/libc/dlfcn/lib_dlsym.c
@@ -171,7 +171,8 @@ FAR void *dlsym(FAR void *handle, FAR const char *name)
    * memory region.
    */
 
-#warning Missing logic
+  /* #warning Missing logic */
+
   return NULL;
 #endif
 }

--- a/libs/libc/dlfcn/lib_dlsymtab.c
+++ b/libs/libc/dlfcn/lib_dlsymtab.c
@@ -63,7 +63,8 @@ int dlsymtab(FAR const struct symtab_s *symtab, int nsymbols)
    * memory region.
    */
 
-#warning Missing logic
+  /* #warning Missing logic */
+
   return -ENOSYS;
 
 #else

--- a/libs/libm/libm/arm/armv7-m/arch_fabsf.c
+++ b/libs/libm/libm/arm/armv7-m/arch_fabsf.c
@@ -30,14 +30,10 @@
  ****************************************************************************/
 
 #if (__ARM_ARCH >= 7) && (__ARM_FP >= 4)
-
 float fabsf(float x)
 {
   float result;
   asm volatile ("vabs.f32\t%0, %1" : "=t" (result) : "t" (x));
   return result;
 }
-
-#else
-#  warning fabsf() not built
 #endif

--- a/libs/libm/libm/arm/armv7-m/arch_sqrtf.c
+++ b/libs/libm/libm/arm/armv7-m/arch_sqrtf.c
@@ -30,14 +30,10 @@
  ****************************************************************************/
 
 #if (__ARM_ARCH >= 7) && (__ARM_FP >= 4)
-
 float sqrtf(float x)
 {
   float result;
   asm volatile ("vsqrt.f32\t%0, %1" : "=t" (result) : "t" (x));
   return result;
 }
-
-#else
-#  warning sqrtf() not built
 #endif

--- a/libs/libm/libm/arm/armv8-m/arch_ceil.c
+++ b/libs/libm/libm/arm/armv8-m/arch_ceil.c
@@ -40,14 +40,10 @@
  ****************************************************************************/
 
 #if __ARM_ARCH >= 8 && (__ARM_FP & 0x8) && !defined (__SOFTFP__)
-
 double ceil(double x)
 {
   double result;
   asm volatile("vrintp.f64\t%P0, %P1" : "=w"(result) : "w"(x));
   return result;
 }
-
-#else
-#  warning ceil() not built
 #endif

--- a/libs/libm/libm/arm/armv8-m/arch_ceilf.c
+++ b/libs/libm/libm/arm/armv8-m/arch_ceilf.c
@@ -40,14 +40,10 @@
  ****************************************************************************/
 
 #if __ARM_ARCH >= 8 && !defined (__SOFTFP__)
-
 float ceilf(float x)
 {
   float result;
   asm volatile("vrintp.f32\t%0, %1" : "=t"(result) : "t"(x));
   return result;
 }
-
-#else
-#  warning ceilf() not built
 #endif

--- a/libs/libm/libm/arm/armv8-m/arch_floor.c
+++ b/libs/libm/libm/arm/armv8-m/arch_floor.c
@@ -40,14 +40,10 @@
  ****************************************************************************/
 
 #if __ARM_ARCH >= 8 && (__ARM_FP & 0x8) && !defined (__SOFTFP__)
-
 double floor(double x)
 {
   double result;
   asm volatile ("vrintm.f64\t%P0, %P1" : "=w" (result) : "w" (x));
   return result;
 }
-
-#else
-#  warning floor() not built
 #endif

--- a/libs/libm/libm/arm/armv8-m/arch_floorf.c
+++ b/libs/libm/libm/arm/armv8-m/arch_floorf.c
@@ -40,14 +40,10 @@
  ****************************************************************************/
 
 #if __ARM_ARCH >= 8 && !defined (__SOFTFP__)
-
 float floorf(float x)
 {
   float result;
   asm volatile("vrintm.f32\t%0, %1" : "=t"(result) : "t"(x));
   return result;
 }
-
-#else
-#  warning floorf() not built
 #endif

--- a/libs/libm/libm/arm/armv8-m/arch_nearbyint.c
+++ b/libs/libm/libm/arm/armv8-m/arch_nearbyint.c
@@ -40,14 +40,10 @@
  ****************************************************************************/
 
 #if __ARM_ARCH >= 8 && (__ARM_FP & 0x8) && !defined (__SOFTFP__)
-
 double nearbyint(double x)
 {
   double result;
   asm volatile ("vrintr.f64\t%P0, %P1" : "=w" (result) : "w" (x));
   return result;
 }
-
-#else
-#  warning nearbyint() not built
 #endif

--- a/libs/libm/libm/arm/armv8-m/arch_nearbyintf.c
+++ b/libs/libm/libm/arm/armv8-m/arch_nearbyintf.c
@@ -40,14 +40,10 @@
  ****************************************************************************/
 
 #if __ARM_ARCH >= 8 && !defined (__SOFTFP__)
-
 float nearbyintf(float x)
 {
   float result;
   asm volatile ("vrintr.f32\t%0, %1" : "=t" (result) : "t" (x));
   return result;
 }
-
-#else
-#  warning nearbyintf() not built
 #endif

--- a/libs/libm/libm/arm/armv8-m/arch_rint.c
+++ b/libs/libm/libm/arm/armv8-m/arch_rint.c
@@ -40,14 +40,10 @@
  ****************************************************************************/
 
 #if __ARM_ARCH >= 8 && (__ARM_FP & 0x8) && !defined (__SOFTFP__)
-
 double rint(double x)
 {
   double result;
   asm volatile ("vrintx.f64\t%P0, %P1" : "=w" (result) : "w" (x));
   return result;
 }
-
-#else
-#  warning rint() not built
 #endif

--- a/libs/libm/libm/arm/armv8-m/arch_rintf.c
+++ b/libs/libm/libm/arm/armv8-m/arch_rintf.c
@@ -40,14 +40,10 @@
  ****************************************************************************/
 
 #if __ARM_ARCH >= 8 && !defined (__SOFTFP__)
-
 float rintf(float x)
 {
   float result;
   asm volatile ("vrintx.f32\t%0, %1" : "=t" (result) : "t" (x));
   return result;
 }
-
-#else
-#  warning rintf() not built
 #endif

--- a/libs/libm/libm/arm/armv8-m/arch_round.c
+++ b/libs/libm/libm/arm/armv8-m/arch_round.c
@@ -40,14 +40,10 @@
  ****************************************************************************/
 
 #if __ARM_ARCH >= 8 && (__ARM_FP & 0x8) && !defined (__SOFTFP__)
-
 double round(double x)
 {
   double result;
   asm volatile ("vrinta.f64\t%P0, %P1" : "=w" (result) : "w" (x));
   return result;
 }
-
-#else
-#  warning round() not built
 #endif

--- a/libs/libm/libm/arm/armv8-m/arch_roundf.c
+++ b/libs/libm/libm/arm/armv8-m/arch_roundf.c
@@ -40,14 +40,10 @@
  ****************************************************************************/
 
 #if __ARM_ARCH >= 8 && !defined (__SOFTFP__)
-
 float roundf(float x)
 {
   float result;
   asm volatile ("vrinta.f32\t%0, %1" : "=t" (result) : "t" (x));
   return result;
 }
-
-#else
-#  warning roundf() not built
 #endif

--- a/libs/libm/libm/arm/armv8-m/arch_trunc.c
+++ b/libs/libm/libm/arm/armv8-m/arch_trunc.c
@@ -40,14 +40,10 @@
  ****************************************************************************/
 
 #if __ARM_ARCH >= 8 && (__ARM_FP & 0x8) && !defined (__SOFTFP__)
-
 double trunc(double x)
 {
   double result;
   asm volatile ("vrintz.f64\t%P0, %P1" : "=w" (result) : "w" (x));
   return result;
 }
-
-#else
-#  warning trunc() not built
 #endif

--- a/libs/libm/libm/arm/armv8-m/arch_truncf.c
+++ b/libs/libm/libm/arm/armv8-m/arch_truncf.c
@@ -40,14 +40,10 @@
  ****************************************************************************/
 
 #if __ARM_ARCH >= 8 && !defined (__SOFTFP__)
-
 float truncf(float x)
 {
   float result;
   asm volatile ("vrintz.f32\t%0, %1" : "=t" (result) : "t" (x));
   return result;
 }
-
-#else
-#  warning truncf() not built
 #endif

--- a/libs/libnx/nxmu/nx_cursor.c
+++ b/libs/libnx/nxmu/nx_cursor.c
@@ -206,7 +206,8 @@ int nxcursor_get_position(NXHANDLE hnd, FAR struct nxgl_point_s *pos)
    * be we don't have the definitions exposed to get it.
    */
 
-#warning Missing logic
+  /* #warning Missing logic */
+
   set_errno(ENOSYS);
   return ERROR;
 }

--- a/net/bluetooth/bluetooth_poll.c
+++ b/net/bluetooth/bluetooth_poll.c
@@ -87,7 +87,7 @@ void bluetooth_poll(FAR struct net_driver_s *dev,
        * REVISIT: Need to pass the meta data and the IOB through the callback
        */
 
-#warning Missing logic
+      /* #warning Missing logic */
 
       /* Perform the application callback */
 

--- a/net/bluetooth/bluetooth_recvmsg.c
+++ b/net/bluetooth/bluetooth_recvmsg.c
@@ -225,7 +225,7 @@ static uint16_t bluetooth_recvfrom_eventhandler(FAR struct net_driver_s *dev,
 
   /* Make sure that this is the driver to which the socket is bound. */
 
-#warning Missing logic
+  /* #warning Missing logic */
 
   pstate = pvpriv;
   radio  = (FAR struct radio_driver_s *)dev;

--- a/net/bluetooth/bluetooth_sendmsg.c
+++ b/net/bluetooth/bluetooth_sendmsg.c
@@ -103,7 +103,7 @@ static uint16_t bluetooth_sendto_eventhandler(FAR struct net_driver_s *dev,
 
   /* Make sure that this is the driver to which the socket is connected. */
 
-#warning Missing logic
+  /* #warning Missing logic */
 
   pstate = pvpriv;
   radio  = (FAR struct radio_driver_s *)dev;

--- a/net/can/can_sockif.c
+++ b/net/can/can_sockif.c
@@ -494,7 +494,7 @@ static int can_close(FAR struct socket *psock)
     {
       /* Yes... inform user-space daemon of socket close. */
 
-#warning Missing logic
+      /* #warning Missing logic */
 
       /* Free the connection structure */
 

--- a/net/ieee802154/ieee802154_poll.c
+++ b/net/ieee802154/ieee802154_poll.c
@@ -85,7 +85,7 @@ void ieee802154_poll(FAR struct net_driver_s *dev,
        *  Need to pass the meta data and the IOB through the callback.
        */
 
-#warning Missing logic
+      /* #warning Missing logic */
 
       /* Perform the application callback */
 

--- a/net/ieee802154/ieee802154_recvmsg.c
+++ b/net/ieee802154/ieee802154_recvmsg.c
@@ -225,7 +225,7 @@ static uint16_t
 
   /* Make sure that this is the driver to which the socket is bound. */
 
-#warning Missing logic
+  /* #warning Missing logic */
 
   pstate = pvpriv;
   radio  = (FAR struct radio_driver_s *)dev;

--- a/net/ieee802154/ieee802154_sendmsg.c
+++ b/net/ieee802154/ieee802154_sendmsg.c
@@ -292,7 +292,7 @@ static uint16_t ieee802154_sendto_eventhandler(FAR struct net_driver_s *dev,
 
   /* Make sure that this is the driver to which the socket is connected. */
 
-#warning Missing logic
+  /* #warning Missing logic */
 
   pstate = pvpriv;
   radio  = (FAR struct radio_driver_s *)dev;

--- a/net/inet/ipv4_setsockopt.c
+++ b/net/inet/ipv4_setsockopt.c
@@ -226,7 +226,9 @@ int ipv4_setsockopt(FAR struct socket *psock, int option,
       case IP_MULTICAST_ALL:          /* Modify the delivery policy of
                                        * multicast messages bound to
                                        * INADDR_ANY */
-#warning Missing logic
+
+        /* #warning Missing logic */
+
         nwarn("WARNING: Unimplemented IPv4 option: %d\n", option);
         ret = -ENOSYS;
         break;

--- a/net/local/local_fifo.c
+++ b/net/local/local_fifo.c
@@ -489,7 +489,8 @@ int local_release_halfduplex(FAR struct local_conn_s *conn)
    * would be destroyed.
    */
 
-#  warning Missing logic
+  /* #warning Missing logic */
+
   return OK;
 
 #else

--- a/net/local/local_sendmsg.c
+++ b/net/local/local_sendmsg.c
@@ -215,7 +215,7 @@ static ssize_t local_send(FAR struct socket *psock,
         {
           /* Local UDP packet send */
 
-#warning Missing logic
+          /* #warning Missing logic */
 
           ret = -ENOSYS;
         }

--- a/net/local/local_sockif.c
+++ b/net/local/local_sockif.c
@@ -618,7 +618,7 @@ static int local_connect(FAR struct socket *psock,
         {
           /* Perform the datagram connection logic */
 
-#warning Missing logic
+          /* #warning Missing logic */
 
           return -ENOSYS;
         }

--- a/net/utils/net_chksum.c
+++ b/net/utils/net_chksum.c
@@ -223,10 +223,6 @@ void net_chksum_adjust(FAR uint16_t *chksum,
                        FAR const uint16_t *optr, ssize_t olen,
                        FAR const uint16_t *nptr, ssize_t nlen)
 {
-#ifdef CONFIG_ENDIAN_BIG
-#  warning "Not verified on big-endian yet."
-#endif
-
   int32_t x;
   int32_t oldval;
   int32_t newval;


### PR DESCRIPTION
## Summary

- libm/arm: Remove the compiler specific #warning
- Remove #warning if the code already return the error code or value
- net: Remove some minor #warning since it compiler specific

## Impact

Compiler time warning
Note: the error still report at the runtime

## Testing

CI