### PR TITLE
audio/pcm_decode: fix warnings regarding unused functions and vars

### DIFF
--- a/audio/pcm_decode.c
+++ b/audio/pcm_decode.c
@@ -42,14 +42,6 @@
 #if defined(CONFIG_AUDIO) && defined(CONFIG_AUDIO_FORMAT_PCM)
 
 /****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-/* Configuration ************************************************************/
-
-#define CONFIG_PCM_DEBUG 1 /* For now */
-
-/****************************************************************************
  * Private Types
  ****************************************************************************/
 
@@ -109,7 +101,7 @@ struct pcm_decode_s
 
 /* Helper functions *********************************************************/
 
-#ifdef CONFIG_PCM_DEBUG
+#ifdef CONFIG_DEBUG_AUDIO_INFO
 static void pcm_dump(FAR const struct wav_header_s *wav);
 #else
 #  define pcm_dump(w)
@@ -227,7 +219,7 @@ static void pcm_callback(FAR void *arg, uint16_t reason,
  *
  ****************************************************************************/
 
-#ifdef CONFIG_PCM_DEBUG
+#ifdef CONFIG_DEBUG_AUDIO_INFO
 static void pcm_dump(FAR const struct wav_header_s *wav)
 {
   _info("Wave file header\n");
@@ -259,6 +251,7 @@ static void pcm_dump(FAR const struct wav_header_s *wav)
  *
  ****************************************************************************/
 
+#ifndef CONFIG_AUDIO_FORMAT_RAW
 static uint16_t pcm_leuint16(FAR const uint16_t *ptr)
 {
   FAR const uint8_t *p = (FAR const uint8_t *)ptr;
@@ -293,7 +286,7 @@ static uint32_t pcm_leuint32(FAR const uint32_t *ptr)
  *   Return true if this is a valid WAV file header
  *
  ****************************************************************************/
-#ifndef CONFIG_AUDIO_FORMAT_RAW
+
 static inline bool pcm_validwav(FAR const struct wav_header_s *wav)
 {
   return (wav->hdr.chunkid  == WAV_HDR_CHUNKID  &&
@@ -1039,7 +1032,6 @@ static int pcm_enqueuebuffer(FAR struct audio_lowerhalf_s *dev,
   FAR struct pcm_decode_s *priv = (FAR struct pcm_decode_s *)dev;
   FAR struct audio_lowerhalf_s *lower;
   apb_samp_t bytesleft;
-  ssize_t headersize;
   int ret;
 
   DEBUGASSERT(priv);
@@ -1093,7 +1085,8 @@ static int pcm_enqueuebuffer(FAR struct audio_lowerhalf_s *dev,
   /* Parse and verify the candidate PCM WAV file header */
 
 #ifndef CONFIG_AUDIO_FORMAT_RAW
-  headersize = pcm_parsewav(priv, &apb->samp[apb->curbyte], bytesleft);
+  ssize_t headersize = pcm_parsewav(priv, &apb->samp[apb->curbyte],
+                                    bytesleft);
   if (headersize > 0)
     {
       struct audio_caps_s caps;


### PR DESCRIPTION
## Summary

Fix warnings regarding unused functions and vars:

* `pcm_dump` available if 'CONFIG_DEBUG_AUDIO_INFO' is set instead of using the 'CONFIG_PCM_DEBUG'.
* `pcm_leuint16` and `pcm_leuint32` available if 'CONFIG_AUDIO_FORMAT_RAW' is not set (once 'pcm_parsewav', which is available under the same condition, use them).
* `headersize` var, from 'pcm_enqueuebuffer' declared only if 'CONFIG_AUDIO_FORMAT_RAW' is not set (as it's used by the code defined by the same condition).

## Impact

Fixing [CI error](https://github.com/apache/nuttx/actions/runs/4856277612/jobs/8659305018?pr=9150#step:7:636) of PR https://github.com/apache/nuttx/pull/9150

## Testing

esp32-lyrat:rtptools from https://github.com/apache/nuttx/pull/9150