### PR TITLE
mtd/nand: Return -EUCLEAN when the bit error happen but fixed by ecc

### DIFF
--- a/drivers/mtd/mtd_nandecc.c
+++ b/drivers/mtd/mtd_nandecc.c
@@ -138,14 +138,19 @@ int nandecc_readpage(FAR struct nand_dev_s *nand, off_t block,
   /* Use the ECC data to verify the page */
 
   ret = hamming_verify256x(data, pagesize, raw->ecc);
-  if (ret && (ret != HAMMING_ERROR_SINGLEBIT))
+  switch (ret)
     {
+      case HAMMING_SUCCESS:
+        return OK;
+
+      case HAMMING_ERROR_SINGLEBIT:
+        return -EUCLEAN;
+
+      default:
       ferr("ERROR: Block=%d page=%d Unrecoverable error: %d\n",
            block, page, ret);
-      return -EIO;
+      return -EBADMSG;
     }
-
-  return OK;
 }
 
 /****************************************************************************

--- a/drivers/mtd/mtd_nandecc.c
+++ b/drivers/mtd/mtd_nandecc.c
@@ -147,7 +147,7 @@ int nandecc_readpage(FAR struct nand_dev_s *nand, off_t block,
         return -EUCLEAN;
 
       default:
-      ferr("ERROR: Block=%d page=%d Unrecoverable error: %d\n",
+      ferr("ERROR: Block=%" PRIdOFF " page=%d Unrecoverable error: %d\n",
            block, page, ret);
       return -EBADMSG;
     }


### PR DESCRIPTION
## Summary

follow how Linux report the correction information from ecc:
http://www.infradead.org/pipermail/linux-mtd/2012-March/040305.html
since this information is very useful to file system(e.g. yaffs, ubi/buifs)
which is specially designed for nand flash.

## Impact

MTD NAND driver

## Testing

internal yaffs