### PR TITLE
libs/libxx: remove redundant code

### DIFF
--- a/libs/libxx/libcxxmini/libxx_new.cxx
+++ b/libs/libxx/libcxxmini/libxx_new.cxx
@@ -48,13 +48,6 @@
 
 FAR void *operator new(std::size_t nbytes)
 {
-  // We have to allocate something
-
-  if (nbytes < 1)
-    {
-      nbytes = 1;
-    }
-
   // Perform the allocation
 
   FAR void *alloc = lib_malloc(nbytes);

--- a/libs/libxx/libcxxmini/libxx_newa.cxx
+++ b/libs/libxx/libcxxmini/libxx_newa.cxx
@@ -56,13 +56,6 @@
 
 FAR void *operator new[](std::size_t nbytes)
 {
-  // We have to allocate something
-
-  if (nbytes < 1)
-    {
-      nbytes = 1;
-    }
-
   // Perform the allocation
 
   FAR void *alloc = lib_malloc(nbytes);


### PR DESCRIPTION
## Summary
As https://github.com/apache/nuttx/pull/9151 merged,  that is no need to deal with zero size in C++ allocator.

The discuss is from https://github.com/apache/nuttx/pull/9143#issuecomment-1529395957
## Impact
None
## Testing
Pass CI. Test new int[0] in sim.
