### PR TITLE
net/can: Remove the unnecessary "ret = OK;" in can_getsockopt

### DIFF
--- a/net/arp/arp_input.c
+++ b/net/arp/arp_input.c
@@ -129,8 +129,8 @@ static int arp_in(FAR struct net_driver_s *dev)
             net_ipv4addr_hdrcopy(arp->ah_sipaddr, &dev->d_ipaddr);
             arp_dump(arp);
 
-            eth->type           = HTONS(ETHTYPE_ARP);
-            dev->d_len          = sizeof(struct arp_hdr_s) + ETH_HDRLEN;
+            eth->type  = HTONS(ETHTYPE_ARP);
+            dev->d_len = sizeof(struct arp_hdr_s) + ETH_HDRLEN;
           }
         break;
 

--- a/net/arp/arp_send.c
+++ b/net/arp/arp_send.c
@@ -54,11 +54,11 @@ static void arp_send_terminate(FAR struct arp_send_s *state, int result)
 {
   /* Don't allow any further call backs. */
 
-  state->snd_sent         = true;
-  state->snd_result       = (int16_t)result;
-  state->snd_cb->flags    = 0;
-  state->snd_cb->priv     = NULL;
-  state->snd_cb->event    = NULL;
+  state->snd_sent      = true;
+  state->snd_result    = (int16_t)result;
+  state->snd_cb->flags = 0;
+  state->snd_cb->priv  = NULL;
+  state->snd_cb->event = NULL;
 
   /* Wake up the waiting thread */
 
@@ -277,8 +277,8 @@ int arp_send(in_addr_t ipaddr)
 
   nxsem_init(&state.snd_sem, 0, 0); /* Doesn't really fail */
 
-  state.snd_retries   = 0;              /* No retries yet */
-  state.snd_ipaddr    = ipaddr;         /* IP address to query */
+  state.snd_retries = 0;            /* No retries yet */
+  state.snd_ipaddr  = ipaddr;       /* IP address to query */
 
   /* Remember the routing device name */
 

--- a/net/bluetooth/bluetooth_conn.c
+++ b/net/bluetooth/bluetooth_conn.c
@@ -190,7 +190,7 @@ void bluetooth_conn_free(FAR struct bluetooth_conn_s *conn)
     {
       /* Remove the frame from the list */
 
-      next                = container->bn_flink;
+      next = container->bn_flink;
       container->bn_flink = NULL;
 
       /* Free the contained frame data (should be only one in chain) */

--- a/net/bluetooth/bluetooth_container.c
+++ b/net/bluetooth/bluetooth_container.c
@@ -134,8 +134,8 @@ FAR struct bluetooth_container_s *bluetooth_container_allocate(void)
   net_lock();
   if (g_free_container != NULL)
     {
-      container         = g_free_container;
-      g_free_container  = container->bn_flink;
+      container        = g_free_container;
+      g_free_container = container->bn_flink;
       pool             = BLUETOOTH_POOL_PREALLOCATED;
       net_unlock();
     }
@@ -143,8 +143,8 @@ FAR struct bluetooth_container_s *bluetooth_container_allocate(void)
     {
       net_unlock();
       container = (FAR struct bluetooth_container_s *)
-        kmm_malloc((sizeof (struct bluetooth_container_s)));
-      pool     = BLUETOOTH_POOL_DYNAMIC;
+        kmm_malloc((sizeof(struct bluetooth_container_s)));
+      pool = BLUETOOTH_POOL_DYNAMIC;
     }
 
   /* We have successfully allocated memory from some source? */

--- a/net/bluetooth/bluetooth_input.c
+++ b/net/bluetooth/bluetooth_input.c
@@ -250,7 +250,7 @@ int bluetooth_input(FAR struct radio_driver_s *radio,
         {
           /* Remove the frame from the list */
 
-          next            = frame->io_flink;
+          next = frame->io_flink;
           frame->io_flink = NULL;
 
           /* Add the frame to the RX queue */

--- a/net/bluetooth/bluetooth_recvmsg.c
+++ b/net/bluetooth/bluetooth_recvmsg.c
@@ -157,7 +157,7 @@ static ssize_t
 
       /* Extract the IOB containing the frame from the container */
 
-      iob               = container->bn_iob;
+      iob = container->bn_iob;
       container->bn_iob = NULL;
       DEBUGASSERT(iob != NULL);
 
@@ -175,8 +175,8 @@ static ssize_t
 
       if (pstate->ir_from != NULL)
         {
-          iaddr             = (FAR struct sockaddr_l2 *)pstate->ir_from;
-          iaddr->l2_family  = AF_BLUETOOTH;
+          iaddr = (FAR struct sockaddr_l2 *)pstate->ir_from;
+          iaddr->l2_family = AF_BLUETOOTH;
           BLUETOOTH_ADDRCOPY(&iaddr->l2_bdaddr, &container->bn_raddr);
           iaddr->l2_cid = container->bn_channel;
         }
@@ -245,10 +245,10 @@ static uint16_t bluetooth_recvfrom_eventhandler(FAR struct net_driver_s *dev,
             {
               /* Don't allow any further call backs. */
 
-              pstate->ir_cb->flags   = 0;
-              pstate->ir_cb->priv    = NULL;
-              pstate->ir_cb->event   = NULL;
-              pstate->ir_result      = ret;
+              pstate->ir_cb->flags = 0;
+              pstate->ir_cb->priv  = NULL;
+              pstate->ir_cb->event = NULL;
+              pstate->ir_result    = ret;
 
               /* indicate that the data has been consumed */
 
@@ -372,9 +372,9 @@ ssize_t bluetooth_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
   state.ir_cb = bluetooth_callback_alloc(&radio->r_dev, conn);
   if (state.ir_cb)
     {
-      state.ir_cb->flags  = (BLUETOOTH_NEWDATA | BLUETOOTH_POLL);
-      state.ir_cb->priv   = (FAR void *)&state;
-      state.ir_cb->event  = bluetooth_recvfrom_eventhandler;
+      state.ir_cb->flags = (BLUETOOTH_NEWDATA | BLUETOOTH_POLL);
+      state.ir_cb->priv  = (FAR void *)&state;
+      state.ir_cb->event = bluetooth_recvfrom_eventhandler;
 
       /* Wait for either the receive to complete or for an error/timeout to
        * occur. NOTES:  (1) net_sem_wait will also terminate if a signal

--- a/net/can/can_getsockopt.c
+++ b/net/can/can_getsockopt.c
@@ -151,13 +151,13 @@ int can_getsockopt(FAR struct socket *psock, int level, int option,
              * to me in this case.
              */
 
-            ret              = -EINVAL;
+            ret = -EINVAL;
           }
         else
           {
-            FAR int32_t *loopback  = (FAR int32_t *)value;
-            *loopback              = conn->loopback;
-            *value_len             = sizeof(conn->loopback);
+            FAR int32_t *loopback = (FAR int32_t *)value;
+            *loopback             = conn->loopback;
+            *value_len            = sizeof(conn->loopback);
           }
         break;
 
@@ -169,7 +169,7 @@ int can_getsockopt(FAR struct socket *psock, int level, int option,
              * to me in this case.
              */
 
-            ret              = -EINVAL;
+            ret = -EINVAL;
           }
         else
           {
@@ -188,7 +188,7 @@ int can_getsockopt(FAR struct socket *psock, int level, int option,
              * to me in this case.
              */
 
-            ret              = -EINVAL;
+            ret = -EINVAL;
           }
         else
           {
@@ -211,7 +211,7 @@ int can_getsockopt(FAR struct socket *psock, int level, int option,
              * to me in this case.
              */
 
-            ret              = -EINVAL;
+            ret = -EINVAL;
           }
         else
           {

--- a/net/can/can_getsockopt.c
+++ b/net/can/can_getsockopt.c
@@ -137,8 +137,6 @@ int can_getsockopt(FAR struct socket *psock, int level, int option,
               {
                 ((struct can_filter *)value)[i] = conn->filters[i];
               }
-
-            ret = OK;
           }
         break;
 
@@ -160,7 +158,6 @@ int can_getsockopt(FAR struct socket *psock, int level, int option,
             FAR int32_t *loopback  = (FAR int32_t *)value;
             *loopback              = conn->loopback;
             *value_len             = sizeof(conn->loopback);
-            ret                    = OK;
           }
         break;
 
@@ -179,7 +176,6 @@ int can_getsockopt(FAR struct socket *psock, int level, int option,
             FAR int32_t *recv_own_msgs = (FAR int32_t *)value;
             *recv_own_msgs             = conn->recv_own_msgs;
             *value_len                 = sizeof(conn->recv_own_msgs);
-            ret                        = OK;
           }
         break;
 
@@ -199,7 +195,6 @@ int can_getsockopt(FAR struct socket *psock, int level, int option,
             FAR int32_t *fd_frames = (FAR int32_t *)value;
             *fd_frames             = conn->fd_frames;
             *value_len             = sizeof(conn->fd_frames);
-            ret                    = OK;
           }
         break;
 #endif
@@ -223,7 +218,6 @@ int can_getsockopt(FAR struct socket *psock, int level, int option,
             FAR int32_t *tx_deadline = (FAR int32_t *)value;
             *tx_deadline             = conn->tx_deadline;
             *value_len               = sizeof(conn->tx_deadline);
-            ret                      = OK;
           }
         break;
 #endif

--- a/net/can/can_recvmsg.c
+++ b/net/can/can_recvmsg.c
@@ -379,9 +379,9 @@ static uint16_t can_recvfrom_eventhandler(FAR struct net_driver_s *dev,
 
           /* Don't allow any further call backs. */
 
-          pstate->pr_cb->flags   = 0;
-          pstate->pr_cb->priv    = NULL;
-          pstate->pr_cb->event   = NULL;
+          pstate->pr_cb->flags = 0;
+          pstate->pr_cb->priv  = NULL;
+          pstate->pr_cb->event = NULL;
 
           /* indicate that the data has been consumed */
 
@@ -545,7 +545,7 @@ ssize_t can_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
 
   /* Get the device driver that will service this transfer */
 
-  dev  = conn->dev;
+  dev = conn->dev;
   if (dev == NULL)
     {
       ret = -ENODEV;
@@ -557,9 +557,9 @@ ssize_t can_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
   state.pr_cb = can_callback_alloc(dev, conn);
   if (state.pr_cb)
     {
-      state.pr_cb->flags  = (CAN_NEWDATA | CAN_POLL);
-      state.pr_cb->priv   = (FAR void *)&state;
-      state.pr_cb->event  = can_recvfrom_eventhandler;
+      state.pr_cb->flags = (CAN_NEWDATA | CAN_POLL);
+      state.pr_cb->priv  = (FAR void *)&state;
+      state.pr_cb->event = can_recvfrom_eventhandler;
 
       /* Wait for either the receive to complete or for an error/timeout to
        * occur. NOTES:  (1) net_sem_wait will also terminate if a signal

--- a/net/can/can_sendmsg.c
+++ b/net/can/can_sendmsg.c
@@ -124,9 +124,9 @@ static uint16_t psock_send_eventhandler(FAR struct net_driver_s *dev,
 
       /* Don't allow any further call backs. */
 
-      pstate->snd_cb->flags    = 0;
-      pstate->snd_cb->priv     = NULL;
-      pstate->snd_cb->event    = NULL;
+      pstate->snd_cb->flags = 0;
+      pstate->snd_cb->priv  = NULL;
+      pstate->snd_cb->event = NULL;
 
       /* Wake up the waiting thread */
 
@@ -223,8 +223,8 @@ ssize_t can_sendmsg(FAR struct socket *psock, FAR struct msghdr *msg,
   memset(&state, 0, sizeof(struct send_s));
   nxsem_init(&state.snd_sem, 0, 0); /* Doesn't really fail */
 
-  state.snd_buflen    = msg->msg_iov->iov_len;  /* bytes to send */
-  state.snd_buffer    = msg->msg_iov->iov_base; /* Buffer to send from */
+  state.snd_buflen = msg->msg_iov->iov_len;  /* bytes to send */
+  state.snd_buffer = msg->msg_iov->iov_base; /* Buffer to send from */
 
 #ifdef CONFIG_NET_CAN_RAW_TX_DEADLINE
   if (msg->msg_controllen > sizeof(struct cmsghdr))
@@ -234,8 +234,8 @@ ssize_t can_sendmsg(FAR struct socket *psock, FAR struct msghdr *msg,
               && cmsg->cmsg_type == CAN_RAW_TX_DEADLINE
               && cmsg->cmsg_len == sizeof(struct timeval))
         {
-          state.pr_msgbuf     = CMSG_DATA(cmsg); /* Buffer to cmsg data */
-          state.pr_msglen     = cmsg->cmsg_len;  /* len of cmsg data */
+          state.pr_msgbuf = CMSG_DATA(cmsg); /* Buffer to cmsg data */
+          state.pr_msglen = cmsg->cmsg_len;  /* len of cmsg data */
         }
     }
 #endif

--- a/net/can/can_sockif.c
+++ b/net/can/can_sockif.c
@@ -388,18 +388,18 @@ static int can_poll_local(FAR struct socket *psock, FAR struct pollfd *fds,
 
       /* Initialize the poll info container */
 
-      info->psock  = psock;
-      info->fds    = fds;
-      info->cb     = cb;
+      info->psock = psock;
+      info->fds   = fds;
+      info->cb    = cb;
 
       /* Initialize the callback structure.  Save the reference to the info
        * structure as callback private data so that it will be available
        * during callback processing.
        */
 
-      cb->flags    = NETDEV_DOWN;
-      cb->priv     = (FAR void *)info;
-      cb->event    = can_poll_eventhandler;
+      cb->flags   = NETDEV_DOWN;
+      cb->priv    = (FAR void *)info;
+      cb->event   = can_poll_eventhandler;
 
       if ((fds->events & POLLOUT) != 0)
         {


### PR DESCRIPTION
## Summary

and remove the extra space in code

## Impact

code refactor only

## Testing

CI