### PR TITLE
sched: Stop the sched timer when possible to save the power in tickless mode

### DIFF
--- a/sched/sched/sched_timerexpiration.c
+++ b/sched/sched/sched_timerexpiration.c
@@ -46,31 +46,6 @@
 #ifdef CONFIG_SCHED_TICKLESS
 
 /****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-/* In the original design, it was planned that nxsched_reassess_timer() be
- * called whenever there was a change at the head of the ready-to-run
- * list.  That call was intended to establish a new time-slice or to
- * stop an old time-slice timer.  However, it turns out that that
- * solution is too fragile:  The system is too vulnerable at the time
- * that the ready-to-run list is modified in order to muck with timers.
- *
- * The kludge/work-around is simple to keep the timer running all of the
- * time with an interval of no more than the timeslice interval.  If we
- * do this, then there is really no need to do anything when on context
- * switches.
- */
-
-#define KEEP_ALIVE_HACK 1
-
-#if CONFIG_RR_INTERVAL > 0
-#  define KEEP_ALIVE_TICKS MSEC2TICK(CONFIG_RR_INTERVAL)
-#else
-#  define KEEP_ALIVE_TICKS MSEC2TICK(80)
-#endif
-
-/****************************************************************************
  * Public Data
  ****************************************************************************/
 
@@ -271,15 +246,6 @@ static uint32_t nxsched_cpu_scheduler(int cpu, uint32_t ticks,
     }
 
   /* Returning zero means that there is no interesting event to be timed */
-
-#ifdef KEEP_ALIVE_HACK
-  if (ret == 0)
-    {
-      /* Apply the keep alive hack */
-
-      return KEEP_ALIVE_TICKS;
-    }
-#endif
 
   return ret;
 }


### PR DESCRIPTION
## Summary

Remove KEEP_ALIVE_HACK to avoid waking up the device periodly. The workaround it's added by:
```
    commit 6546fa39c7a292e919d1ea396d67bea8242f2c4b
    Author: Gregory Nutt <gnutt@nuttx.org>
    Date:   Tue Aug 12 11:12:00 2014 -0600

    Tickless Stuff:  Back out the risky timer operations when the ready-to-run
    list is modified. That is unsafe.  An ugly workaround is just to keep an
    interval timer going all of the time with a minimum duration equal to the
    timeslice interval.
```
But look like it doesn't needed anymore.

## Impact

tickless with round robin

## Testing

internal test