### PR TITLE
boards/nucleo-f429zi: update CONFIG define to keep up with the CONFIG in arch/stm32

### DIFF
--- a/boards/arm/stm32/nucleo-f429zi/src/Make.defs
+++ b/boards/arm/stm32/nucleo-f429zi/src/Make.defs
@@ -56,11 +56,11 @@ ifeq ($(CONFIG_MMCSD),y)
 CSRCS += stm32_sdio.c
 endif
 
-ifeq ($(CONFIG_STM32F4_OTGFS),y)
+ifeq ($(CONFIG_STM32_OTGFS),y)
 CSRCS += stm32_usb.c
 endif
 
-ifeq ($(CONFIG_STM32F4_BBSRAM),y)
+ifeq ($(CONFIG_STM32_BBSRAM),y)
 CSRCS += stm32_bbsram.c
 endif
 

--- a/boards/arm/stm32/nucleo-f429zi/src/nucleo-144.h
+++ b/boards/arm/stm32/nucleo-f429zi/src/nucleo-144.h
@@ -98,7 +98,7 @@
 #define GPIO_SPI3_CS2  (GPIO_SPI_CS | GPIO_PORTG | GPIO_PIN6)
 #define GPIO_SPI3_CS3  (GPIO_SPI_CS | GPIO_PORTG | GPIO_PIN7)
 
-#if defined(CONFIG_STM32F4_SDMMC1) || defined(CONFIG_STM32F4_SDMMC2)
+#if defined(CONFIG_STM32_SDMMC1) || defined(CONFIG_STM32_SDMMC2)
 # define HAVE_SDIO
 #endif
 
@@ -109,7 +109,7 @@
 #define SDIO_SLOTNO 0  /* Only one slot */
 
 #ifdef HAVE_SDIO
-#  if defined(CONFIG_STM32F4_SDMMC1)
+#  if defined(CONFIG_STM32_SDMMC1)
 #    define GPIO_SDMMC1_NCD (GPIO_INPUT|GPIO_FLOAT|GPIO_EXTI | GPIO_PORTC | GPIO_PIN6)
 #  endif
 
@@ -229,7 +229,7 @@ int stm32_sdio_initialize(void);
  *
  ****************************************************************************/
 
-#ifdef CONFIG_STM32F4_OTGFS
+#ifdef CONFIG_STM32_OTGFS
 void stm32_usbinitialize(void);
 #endif
 
@@ -261,7 +261,7 @@ int stm32_adc_setup(void);
  * Name: stm32_bbsram_int
  ****************************************************************************/
 
-#ifdef CONFIG_STM32F4_BBSRAM
+#ifdef CONFIG_STM32_BBSRAM
 int stm32_bbsram_int(void);
 #endif
 

--- a/boards/arm/stm32/nucleo-f429zi/src/stm32_adc.c
+++ b/boards/arm/stm32/nucleo-f429zi/src/stm32_adc.c
@@ -47,19 +47,19 @@
 /* Up to 3 ADC interfaces are supported */
 
 #if STM32F4_NADC < 3
-#  undef CONFIG_STM32F4_ADC3
+#  undef CONFIG_STM32_ADC3
 #endif
 
 #if STM32F4_NADC < 2
-#  undef CONFIG_STM32F4_ADC2
+#  undef CONFIG_STM32_ADC2
 #endif
 
 #if STM32F4_NADC < 1
-#  undef CONFIG_STM32F4_ADC1
+#  undef CONFIG_STM32_ADC1
 #endif
 
-#if defined(CONFIG_STM32F4_ADC1) || defined(CONFIG_STM32F4_ADC2) || defined(CONFIG_STM32F4_ADC3)
-#ifndef CONFIG_STM32F4_ADC1
+#if defined(CONFIG_STM32_ADC1) || defined(CONFIG_STM32_ADC2) || defined(CONFIG_STM32_ADC3)
+#ifndef CONFIG_STM32_ADC1
 #  warning "Channel information only available for ADC1"
 #endif
 
@@ -76,7 +76,7 @@
  * {1,  2,  3, 4,  5,  6, 7,  8,  9, 10, 11, 12, 13, 15};
  */
 
-#ifdef CONFIG_STM32F4_ADC1
+#ifdef CONFIG_STM32_ADC1
 static const uint8_t  g_chanlist[ADC1_NCHANNELS] =
     {
         3
@@ -114,7 +114,7 @@ static const uint32_t g_pinlist[ADC1_NCHANNELS] =
 
 int stm32_adc_setup(void)
 {
-#ifdef CONFIG_STM32F4_ADC1
+#ifdef CONFIG_STM32_ADC1
   static bool initialized = false;
   struct adc_dev_s *adc;
   int ret;
@@ -163,5 +163,5 @@ int stm32_adc_setup(void)
 #endif
 }
 
-#endif /* CONFIG_STM32F4_ADC1 || CONFIG_STM32F4_ADC2 || CONFIG_STM32F4_ADC3 */
+#endif /* CONFIG_STM32_ADC1 || CONFIG_STM32_ADC2 || CONFIG_STM32_ADC3 */
 #endif /* CONFIG_ADC */

--- a/boards/arm/stm32/nucleo-f429zi/src/stm32_appinitialize.c
+++ b/boards/arm/stm32/nucleo-f429zi/src/stm32_appinitialize.c
@@ -121,7 +121,7 @@ int board_app_initialize(uintptr_t arg)
     }
 #endif
 
-#ifdef CONFIG_STM32F4_BBSRAM
+#ifdef CONFIG_STM32_BBSRAM
   /* Initialize battery-backed RAM */
 
   stm32_bbsram_int();

--- a/boards/arm/stm32/nucleo-f429zi/src/stm32_bbsram.c
+++ b/boards/arm/stm32/nucleo-f429zi/src/stm32_bbsram.c
@@ -45,7 +45,7 @@
 
 #include "nucleo-144.h"
 
-#ifdef CONFIG_STM32F4_BBSRAM
+#ifdef CONFIG_STM32_BBSRAM
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -306,7 +306,7 @@ static int hardfault_get_desc(struct bbsramd_s *desc)
  * Name: copy_reverse
  ****************************************************************************/
 
-#if defined(CONFIG_STM32F4_SAVE_CRASHDUMP)
+#if defined(CONFIG_STM32_SAVE_CRASHDUMP)
 static void copy_reverse(stack_word_t *dest, stack_word_t *src, int size)
 {
   while (size--)
@@ -314,7 +314,7 @@ static void copy_reverse(stack_word_t *dest, stack_word_t *src, int size)
       *dest++ = *src--;
     }
 }
-#endif /* CONFIG_STM32F4_SAVE_CRASHDUMP */
+#endif /* CONFIG_STM32_SAVE_CRASHDUMP */
 
 /****************************************************************************
  * Public Functions
@@ -326,7 +326,7 @@ static void copy_reverse(stack_word_t *dest, stack_word_t *src, int size)
 
 int stm32_bbsram_int(void)
 {
-  int filesizes[CONFIG_STM32F4_BBSRAM_FILES + 1] = BSRAM_FILE_SIZES;
+  int filesizes[CONFIG_STM32_BBSRAM_FILES + 1] = BSRAM_FILE_SIZES;
   char buf[HEADER_TIME_FMT_LEN + 1];
   struct bbsramd_s desc;
   int rv;
@@ -338,7 +338,7 @@ int stm32_bbsram_int(void)
 
   stm32_bbsraminitialize(BBSRAM_PATH, filesizes);
 
-#if defined(CONFIG_STM32F4_SAVE_CRASHDUMP)
+#if defined(CONFIG_STM32_SAVE_CRASHDUMP)
   /* Panic Logging in Battery Backed Up Files
    * Do we have an hard fault in BBSRAM?
    */
@@ -369,7 +369,7 @@ int stm32_bbsram_int(void)
                  "[%s] (%d)\n", HARDFAULT_PATH, rv);
         }
     }
-#endif /* CONFIG_STM32F4_SAVE_CRASHDUMP */
+#endif /* CONFIG_STM32_SAVE_CRASHDUMP */
 
   return rv;
 }
@@ -378,7 +378,7 @@ int stm32_bbsram_int(void)
  * Name: board_crashdump
  ****************************************************************************/
 
-#if defined(CONFIG_STM32F4_SAVE_CRASHDUMP)
+#if defined(CONFIG_STM32_SAVE_CRASHDUMP)
 void board_crashdump(uintptr_t sp, struct tcb_s *tcb,
                      const char *filename, int lineno,
                      const char *msg)
@@ -521,6 +521,6 @@ void board_crashdump(uintptr_t sp, struct tcb_s *tcb,
       arm_lowputc('!');
     }
 }
-#endif /* CONFIG_STM32F4_SAVE_CRASHDUMP */
+#endif /* CONFIG_STM32_SAVE_CRASHDUMP */
 
 #endif /* CONFIG_STM32_BBSRAM */

--- a/boards/arm/stm32/nucleo-f429zi/src/stm32_boot.c
+++ b/boards/arm/stm32/nucleo-f429zi/src/stm32_boot.c
@@ -55,7 +55,7 @@ void stm32_boardinitialize(void)
   board_autoled_initialize();
 #endif
 
-#if defined(CONFIG_STM32F4_OTGFS) || defined(CONFIG_STM32F4_HOST)
+#if defined(CONFIG_STM32_OTGFS) || defined(CONFIG_STM32_HOST)
   stm32_usbinitialize();
 #endif
 

--- a/boards/arm/stm32/nucleo-f429zi/src/stm32_pwm.c
+++ b/boards/arm/stm32/nucleo-f429zi/src/stm32_pwm.c
@@ -71,7 +71,7 @@ int stm32_pwm_setup(void)
     {
       /* Call stm32_pwminitialize() to get an instance of the PWM interface */
 
-#if defined(CONFIG_STM32F4_TIM1_PWM)
+#if defined(CONFIG_STM32_TIM1_PWM)
       pwm = stm32_pwminitialize(1);
       if (!pwm)
         {
@@ -87,7 +87,7 @@ int stm32_pwm_setup(void)
         }
 #endif
 
-#if defined(CONFIG_STM32F4_TIM2_PWM)
+#if defined(CONFIG_STM32_TIM2_PWM)
       pwm = stm32_pwminitialize(2);
       if (!pwm)
         {
@@ -103,7 +103,7 @@ int stm32_pwm_setup(void)
         }
 #endif
 
-#if defined(CONFIG_STM32F4_TIM3_PWM)
+#if defined(CONFIG_STM32_TIM3_PWM)
       pwm = stm32_pwminitialize(3);
       if (!pwm)
         {
@@ -119,7 +119,7 @@ int stm32_pwm_setup(void)
         }
 #endif
 
-#if defined(CONFIG_STM32F4_TIM4_PWM)
+#if defined(CONFIG_STM32_TIM4_PWM)
       pwm = stm32_pwminitialize(4);
       if (!pwm)
         {

--- a/boards/arm/stm32/nucleo-f429zi/src/stm32_spi.c
+++ b/boards/arm/stm32/nucleo-f429zi/src/stm32_spi.c
@@ -93,7 +93,7 @@
  * Private Data
  ****************************************************************************/
 
-#if defined(CONFIG_STM32F4_SPI1)
+#if defined(CONFIG_STM32_SPI1)
 static const uint32_t g_spi1gpio[] =
 {
 #if defined(GPIO_SPI1_CS0)
@@ -119,7 +119,7 @@ static const uint32_t g_spi1gpio[] =
 };
 #endif
 
-#if defined(CONFIG_STM32F4_SPI2)
+#if defined(CONFIG_STM32_SPI2)
 static const uint32_t g_spi2gpio[] =
 {
 #if defined(GPIO_SPI2_CS0)
@@ -145,7 +145,7 @@ static const uint32_t g_spi2gpio[] =
 };
 #endif
 
-#if defined(CONFIG_STM32F4_SPI3)
+#if defined(CONFIG_STM32_SPI3)
 static const uint32_t g_spi3gpio[] =
 {
 #if defined(GPIO_SPI3_CS0)
@@ -172,13 +172,13 @@ static const uint32_t g_spi3gpio[] =
 #endif
 
 #if defined(CONFIG_NUCLEO_SPI_TEST)
-#  if defined(CONFIG_STM32F4_SPI1)
+#  if defined(CONFIG_STM32_SPI1)
 struct spi_dev_s *spi1;
 #  endif
-#  if defined(CONFIG_STM32F4_SPI2)
+#  if defined(CONFIG_STM32_SPI2)
 struct spi_dev_s *spi2;
 #  endif
-#  if defined(CONFIG_STM32F4_SPI3)
+#  if defined(CONFIG_STM32_SPI3)
 struct spi_dev_s *spi3;
 #  endif
 #endif
@@ -199,7 +199,7 @@ void weak_function stm32_spidev_initialize(void)
 {
   /* Configure SPI CS GPIO for output */
 
-#if defined(CONFIG_STM32F4_SPI1)
+#if defined(CONFIG_STM32_SPI1)
   for (int i = 0; i < nitems(g_spi1gpio); i++)
     {
       if (g_spi1gpio[i] != 0)
@@ -209,7 +209,7 @@ void weak_function stm32_spidev_initialize(void)
     }
 #endif
 
-#if defined(CONFIG_STM32F4_SPI2)
+#if defined(CONFIG_STM32_SPI2)
   for (int i = 0; i < nitems(g_spi2gpio); i++)
     {
       if (g_spi2gpio[i] != 0)
@@ -219,7 +219,7 @@ void weak_function stm32_spidev_initialize(void)
     }
 #endif
 
-#if defined(CONFIG_STM32F4_SPI3)
+#if defined(CONFIG_STM32_SPI3)
   for (int i = 0; i < nitems(g_spi3gpio); i++)
     {
       if (g_spi3gpio[i] != 0)
@@ -257,7 +257,7 @@ void weak_function stm32_spidev_initialize(void)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_STM32F4_SPI1
+#ifdef CONFIG_STM32_SPI1
 void stm32_spi1select(struct spi_dev_s *dev,
                       uint32_t devid, bool selected)
 {
@@ -278,7 +278,7 @@ uint8_t stm32_spi1status(struct spi_dev_s *dev, uint32_t devid)
 }
 #endif
 
-#ifdef CONFIG_STM32F4_SPI2
+#ifdef CONFIG_STM32_SPI2
 void stm32_spi2select(struct spi_dev_s *dev,
                       uint32_t devid, bool selected)
 {
@@ -299,7 +299,7 @@ uint8_t stm32_spi2status(struct spi_dev_s *dev, uint32_t devid)
 }
 #endif
 
-#ifdef CONFIG_STM32F4_SPI3
+#ifdef CONFIG_STM32_SPI3
 void stm32_spi3select(struct spi_dev_s *dev,
                       uint32_t devid, bool selected)
 {
@@ -320,7 +320,7 @@ uint8_t stm32_spi3status(struct spi_dev_s *dev, uint32_t devid)
 }
 #endif
 
-#ifdef CONFIG_STM32F4_SPI4
+#ifdef CONFIG_STM32_SPI4
 void stm32_spi4select(struct spi_dev_s *dev,
                       uint32_t devid, bool selected)
 {
@@ -334,7 +334,7 @@ uint8_t stm32_spi4status(struct spi_dev_s *dev, uint32_t devid)
 }
 #endif
 
-#ifdef CONFIG_STM32F4_SPI5
+#ifdef CONFIG_STM32_SPI5
 void stm32_spi5select(struct spi_dev_s *dev,
                       uint32_t devid, bool selected)
 {
@@ -348,7 +348,7 @@ uint8_t stm32_spi5status(struct spi_dev_s *dev, uint32_t devid)
 }
 #endif
 
-#ifdef CONFIG_STM32F4_SPI6
+#ifdef CONFIG_STM32_SPI6
 void stm32_spi6select(struct spi_dev_s *dev,
                       uint32_t devid, bool selected)
 {
@@ -386,42 +386,42 @@ uint8_t stm32_spi6status(struct spi_dev_s *dev, uint32_t devid)
  ****************************************************************************/
 
 #ifdef CONFIG_SPI_CMDDATA
-#ifdef CONFIG_STM32F4_SPI1
+#ifdef CONFIG_STM32_SPI1
 int stm32_spi1cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
 {
   return -ENODEV;
 }
 #endif
 
-#ifdef CONFIG_STM32F4_SPI2
+#ifdef CONFIG_STM32_SPI2
 int stm32_spi2cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
 {
   return -ENODEV;
 }
 #endif
 
-#ifdef CONFIG_STM32F4_SPI3
+#ifdef CONFIG_STM32_SPI3
 int stm32_spi3cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
 {
   return -ENODEV;
 }
 #endif
 
-#ifdef CONFIG_STM32F4_SPI4
+#ifdef CONFIG_STM32_SPI4
 int stm32_spi4cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
 {
   return -ENODEV;
 }
 #endif
 
-#ifdef CONFIG_STM32F4_SPI5
+#ifdef CONFIG_STM32_SPI5
 int stm32_spi5cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
 {
   return -ENODEV;
 }
 #endif
 
-#ifdef CONFIG_STM32F4_SPI6
+#ifdef CONFIG_STM32_SPI6
 int stm32_spi6cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
 {
   return -ENODEV;

--- a/boards/arm/stm32/nucleo-f429zi/src/stm32_usb.c
+++ b/boards/arm/stm32/nucleo-f429zi/src/stm32_usb.c
@@ -43,7 +43,7 @@
 #include "stm32_otg.h"
 #include "nucleo-144.h"
 
-#ifdef CONFIG_STM32F4_OTGFS
+#ifdef CONFIG_STM32_OTGFS
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -136,7 +136,7 @@ void stm32_usbinitialize(void)
    * Power On, and Overcurrent GPIOs
    */
 
-#ifdef CONFIG_STM32F4_OTGFS
+#ifdef CONFIG_STM32_OTGFS
   stm32_configgpio(GPIO_OTGFS_VBUS);
   stm32_configgpio(GPIO_OTGFS_PWRON);
   stm32_configgpio(GPIO_OTGFS_OVER);


### PR DESCRIPTION
## Summary
The kconfig item in arch/arm/stm32 is CONFIG_STM32_XXX , but when the config definition was used in nucleo-f429zi it was supposed to be CONFIG_STM32F4_XXX at present, it should be update to keep up with the kconfig in arch/arm/stm32.
## Impact
boards/nucleo-f429zi
## Testing
ci build
