### PR TITLE
wireless/bluetooth: Support removable bluetooth modules.

### DIFF
--- a/include/nuttx/wireless/bluetooth/bt_driver.h
+++ b/include/nuttx/wireless/bluetooth/bt_driver.h
@@ -119,4 +119,21 @@ struct bt_driver_s
 
 int bt_netdev_register(FAR struct bt_driver_s *btdev);
 
+/****************************************************************************
+ * Name: bt_netdev_unregister
+ *
+ * Description:
+ *   Unregister a network driver registered by bt_netdev_register.
+ *
+ * Input Parameters:
+ *   btdev - An instance of the low-level driver interface structure.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success.  Otherwise a negated errno value is
+ *   returned to indicate the nature of the failure.
+ *
+ ****************************************************************************/
+
+int bt_netdev_unregister(FAR struct bt_driver_s *btdev);
+
 #endif /* __INCLUDE_NUTTX_WIRELESS_BLUETOOTH_BT_DRIVER_H */

--- a/wireless/bluetooth/bt_att.c
+++ b/wireless/bluetooth/bt_att.c
@@ -1846,6 +1846,8 @@ void bt_att_initialize(void)
     .disconnected = bt_att_disconnected,
   };
 
+  memset(g_bt_att_pool, 0, sizeof(g_bt_att_pool));
+
   bt_l2cap_chan_register(&chan);
 }
 

--- a/wireless/bluetooth/bt_conn.c
+++ b/wireless/bluetooth/bt_conn.c
@@ -1078,3 +1078,22 @@ int bt_conn_le_conn_update(FAR struct bt_conn_s *conn, uint16_t min,
 
   return bt_hci_cmd_send(BT_HCI_OP_LE_CONN_UPDATE, buf);
 }
+
+/****************************************************************************
+ * Name: bt_conn_initialize
+ *
+ * Description:
+ *   Initialize this module's private data.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void bt_conn_initialize(void)
+{
+  memset(g_conns, 0, sizeof(g_conns));
+}

--- a/wireless/bluetooth/bt_conn.h
+++ b/wireless/bluetooth/bt_conn.h
@@ -416,4 +416,6 @@ int bt_conn_le_conn_update(FAR struct bt_conn_s *conn, uint16_t min,
                            uint16_t max, uint16_t latency,
                            uint16_t timeout);
 
+void bt_conn_initialize(void);
+
 #endif /* __WIRELESS_BLUETOOTH_BT_CONN_H */

--- a/wireless/bluetooth/bt_hcicore.h
+++ b/wireless/bluetooth/bt_hcicore.h
@@ -100,6 +100,10 @@ struct bt_dev_s
   sem_t le_pkts_sem;
 #endif
 
+  /* TX thread status */
+
+  int tx_status;
+
   /* Number of commands controller can accept */
 
   uint8_t ncmd;
@@ -254,6 +258,19 @@ struct bt_eir_s; /* Forward reference */
  ****************************************************************************/
 
 int bt_initialize(void);
+
+/****************************************************************************
+ * Name: bt_deinitialize
+ *
+ * Description:
+ *   Deinitialize Bluetooth.
+ *
+ * Returned Value:
+ *    Zero on success or (negative) error code otherwise.
+ *
+ ****************************************************************************/
+
+int bt_deinitialize(void);
 
 /****************************************************************************
  * Name: bt_driver_register

--- a/wireless/bluetooth/bt_l2cap.c
+++ b/wireless/bluetooth/bt_l2cap.c
@@ -454,6 +454,10 @@ int bt_l2cap_init(void)
     .receive = le_sig,
   };
 
+  g_channels = NULL;
+  g_default = NULL;
+
+  bt_conn_initialize();
   bt_att_initialize();
 
   ret = bt_smp_initialize();

--- a/wireless/bluetooth/bt_smp.c
+++ b/wireless/bluetooth/bt_smp.c
@@ -1584,6 +1584,8 @@ int bt_smp_initialize(void)
     .encrypt_change = bt_smp_encrypt_change,
   };
 
+  memset(g_smp_pool, 0, sizeof(g_smp_pool));
+
   bt_l2cap_chan_register(&chan);
 
   return smp_self_test();


### PR DESCRIPTION
## Summary

This bluetooth stack remains in an inconsistent state when the bluetooth HCI module is removed. This change adds a bt_netdev_unregister function that can be used to clean up after a module is removed. Some global variables are also set to their default values.

## Impact

## Testing
Some out-of-tree code was used for testing.
1) Confirmed that BT was still functional on the  tm4c1294-launchpad with CC2564 module attached. 
2) "Bluetooth Hotplugging" was tested on sama5d3-xplained using an out-of-tree USB BT HCI driver. The USB driver calls bt_netdev_unregister when the USB BT dongle is unplugged.  Without rebooting, the linux gatttool is able to connect to NuttX BT when the USB BT dongle is plugged in again. By adding some debug printfs to bt_buf.c, I was able to confirm that all buffers, allocated during insertion, are released when the dongle is unplugged.