### PR TITLE
ethernet: add ETHERTYPE define

### DIFF
--- a/include/net/ethernet.h
+++ b/include/net/ethernet.h
@@ -33,6 +33,19 @@
 
 #define ETHER_ADDR_LEN  6
 
+/* Ethernet protocol ID's */
+#define ETHERTYPE_PUP      0x0200    /* Xerox PUP */
+#define ETHERTYPE_SPRITE   0x0500    /* Sprite */
+#define ETHERTYPE_IP       0x0800    /* IP */
+#define ETHERTYPE_ARP      0x0806    /* Address resolution */
+#define ETHERTYPE_REVARP   0x8035    /* Reverse ARP */
+#define ETHERTYPE_AT       0x809B    /* AppleTalk protocol */
+#define ETHERTYPE_AARP     0x80F3    /* AppleTalk ARP */
+#define ETHERTYPE_VLAN     0x8100    /* IEEE 802.1Q VLAN tagging */
+#define ETHERTYPE_IPX      0x8137    /* IPX */
+#define ETHERTYPE_IPV6     0x86dd    /* IP protocol version 6 */
+#define ETHERTYPE_LOOPBACK 0x9000    /* used to test interfaces */
+
 /****************************************************************************
  * Public Type Definitions
  ****************************************************************************/

--- a/include/nuttx/net/ethernet.h
+++ b/include/nuttx/net/ethernet.h
@@ -55,9 +55,9 @@
 
 /* Recognized values of the type bytes in the Ethernet header */
 
-#define ETHTYPE_ARP      0x0806 /* Address resolution protocol */
-#define ETHTYPE_IP       0x0800 /* IP protocol */
-#define ETHTYPE_IP6      0x86dd /* IP protocol version 6 */
+#define ETHTYPE_ARP      ETHERTYPE_ARP  /* Address resolution protocol */
+#define ETHTYPE_IP       ETHERTYPE_IP   /* IP protocol */
+#define ETHTYPE_IP6      ETHERTYPE_IPV6 /* IP protocol version 6 */
 
 /* Tag protocol identifier (TPID) of 0x8100 identifies the frame as an
  * IEEE 802.1Q-tagged frame.  This field is located at the same position as
@@ -65,7 +65,7 @@
  * distinguish the frame from untagged frames.
  */
 
-#define TPID_8021QVLAN   0x8100
+#define TPID_8021QVLAN   ETHERTYPE_VLAN
 
 /* These are some of the types associated with QVLAN tagged
  * Ethernet packets.


### PR DESCRIPTION
## Summary
We will integrate network management tools in future projects. In the process of porting the tools, we encounter some situations where the structure is not defined, or the returned data types do not match the expectations. Refer to the common implementation of other systems and add relevant definitions.

## Impact

## Testing
sim:local
