### PR TITLE
route: add struct in6_rtmsg definition

### DIFF
--- a/include/net/route.h
+++ b/include/net/route.h
@@ -28,6 +28,7 @@
 #include <nuttx/config.h>
 
 #include <sys/socket.h>
+#include <netinet/in.h>
 
 #include <nuttx/net/ioctl.h>
 
@@ -55,6 +56,20 @@ struct rtentry
   struct sockaddr_storage rt_genmask; /* Network mask defining the sub-net */
   uint16_t rt_flags;
   FAR char *rt_dev;                   /* Forcing the device at add. */
+};
+
+struct in6_rtmsg
+{
+  struct in6_addr rtmsg_dst;
+  struct in6_addr rtmsg_src;
+  struct in6_addr rtmsg_gateway;
+  uint32_t rtmsg_type;
+  uint16_t rtmsg_dst_len;
+  uint16_t rtmsg_src_len;
+  uint32_t rtmsg_metric;
+  unsigned long int rtmsg_info;
+  uint32_t rtmsg_flags;
+  int rtmsg_ifindex;
 };
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
We will integrate network management tools in future projects. In the process of porting the tools, we encounter some situations where the structure is not defined, or the returned data types do not match the expectations. Refer to the common implementation of other systems and add relevant definitions.

## Impact

## Testing
sim:local