### PR TITLE
syslog: add syslog option definition

### DIFF
--- a/include/syslog.h
+++ b/include/syslog.h
@@ -52,6 +52,13 @@
  *   LOG_PID      - Include PID with each message.
  */
 
+#define LOG_PID         0x01    /* log the pid with each message */
+#define LOG_CONS        0x02    /* log on the console if errors in sending */
+#define LOG_ODELAY      0x04    /* delay open until first syslog() (default) */
+#define LOG_NDELAY      0x08    /* don't delay open */
+#define LOG_NOWAIT      0x10    /* don't wait for console forks: DEPRECATED */
+#define LOG_PERROR      0x20    /* log to stderr as well */
+
 /* Note: openlog() is not currently supported */
 
 /* The facility argument is used to specify what type of program is logging
@@ -162,9 +169,8 @@ extern "C"
  *
  ****************************************************************************/
 
-#if 0 /* Not supported */
-void openlog(FAR const char *ident, int option, int facility);
-#endif
+/* Not supported */
+#define openlog(i, o, f) {(void)(i); (void)(o); (void)(f);}
 
 /****************************************************************************
  * Name: closelog
@@ -176,9 +182,8 @@ void openlog(FAR const char *ident, int option, int facility);
  *
  ****************************************************************************/
 
-#if 0 /* Not supported */
-void closelog(void);
-#endif
+/* Not supported */
+#define closelog()
 
 /****************************************************************************
  * Name: syslog and vsyslog


### PR DESCRIPTION
## Summary
We will integrate network management tools in future projects. In the process of porting the tools, we encounter some situations where the structure is not defined, or the returned data types do not match the expectations. Refer to the common implementation of other systems and add relevant definitions.
## Impact

## Testing
sim:local