### PR TITLE
if: add net device type

### DIFF
--- a/include/net/if.h
+++ b/include/net/if.h
@@ -54,8 +54,10 @@
 #define IFF_POINTOPOINT    (1 << 6)  /* Is point-to-point link */
 #define IFF_NOARP          (1 << 7)  /* ARP is not required for this packet */
 #define IFF_NAT            (1 << 8)  /* NAT is enabled for this interface */
+#define IFF_SLAVE          (1 << 11) /* Slave of a load balancer. */
 #define IFF_MULTICAST      (1 << 12) /* Supports multicast. */
 #define IFF_BROADCAST      (1 << 13) /* Broadcast address valid. */
+#define IFF_DYNAMIC        (1 << 15) /* Dialup device with changing addresses. */
 
 /* Interface flag helpers */
 
@@ -67,6 +69,8 @@
 #define IFF_SET_POINTOPOINT(f) do { (f) |= IFF_POINTOPOINT; } while (0)
 #define IFF_SET_MULTICAST(f)   do { (f) |= IFF_MULTICAST; } while (0)
 #define IFF_SET_BROADCAST(f)   do { (f) |= IFF_BROADCAST; } while (0)
+#define IFF_SET_SLAVE(f)       do { (f) |= IFF_SLAVE; } while (0)
+#define IFF_SET_DYNAMIC(f)     do { (f) |= IFF_DYNAMIC; } while (0)
 
 #define IFF_CLR_UP(f)          do { (f) &= ~IFF_UP; } while (0)
 #define IFF_CLR_RUNNING(f)     do { (f) &= ~IFF_RUNNING; } while (0)
@@ -76,6 +80,8 @@
 #define IFF_CLR_POINTOPOINT(f) do { (f) &= ~IFF_POINTOPOINT; } while (0)
 #define IFF_CLR_MULTICAST(f)   do { (f) &= ~IFF_MULTICAST; } while (0)
 #define IFF_CLR_BROADCAST(f)   do { (f) &= ~IFF_BROADCAST; } while (0)
+#define IFF_CLR_SLAVE(f)       do { (f) &= ~IFF_SLAVE; } while (0)
+#define IFF_CLR_DYNAMIC(f)     do { (f) &= ~IFF_DYNAMIC; } while (0)
 
 #define IFF_IS_UP(f)          (((f) & IFF_UP) != 0)
 #define IFF_IS_RUNNING(f)     (((f) & IFF_RUNNING) != 0)
@@ -85,6 +91,8 @@
 #define IFF_IS_POINTOPOINT(f) (((f) & IFF_POINTOPOINT) != 0)
 #define IFF_IS_MULTICAST(f)   (((f) & IFF_MULTICAST) != 0)
 #define IFF_IS_BROADCAST(f)   (((f) & IFF_BROADCAST) != 0)
+#define IFF_IS_SLAVE(f)       (((f) & IFF_SLAVE) != 0)
+#define IFF_IS_DYNAMIC(f)     (((f) & IFF_DYNAMIC) != 0)
 
 /* We only need to manage the IPv6 bit if both IPv6 and IPv4 are supported.
  * Otherwise, we can save a few bytes by ignoring it.


### PR DESCRIPTION
## Summary
We will integrate network management tools in future projects. In the process of porting the tools, we encounter some situations where the structure is not defined, or the returned data types do not match the expectations. Refer to the common implementation of other systems and add relevant definitions.
## Impact

## Testing
sim:local