### PR TITLE
sim/lsan: disable fast-unwind by default

### DIFF
--- a/arch/sim/src/sim/sim_head.c
+++ b/arch/sim/src/sim/sim_head.c
@@ -98,6 +98,36 @@ static void allsyms_relocate(void)
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: __lsan_default_options
+ *
+ * Description:
+ *   This function may be optionally provided by user and should return
+ *   a string containing leak sanitizer runtime options.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_SIM_ASAN
+const char *__lsan_default_options(void)
+{
+  /* The fast-unwind implementation of leak-sanitizer will obtain the
+   * current stack top/bottom and frame address(Stack Pointer) for
+   * backtrace calculation:
+   *
+   * https://github.com/gcc-mirror/gcc/blob/releases/gcc-13/libsanitizer/
+   *   lsan/lsan.cpp#L39-L42
+   *
+   * Since the scheduling mechanism of NuttX sim is coroutine
+   * (setjmp/longjmp), if the Stack Pointer is switched, the fast-unwind
+   * will unable to get the available address, so the memory leaks on the
+   * system/application side that cannot be caught normally. This PR will
+   * disable fast-unwind by default to avoid unwind failure.
+   */
+
+  return "fast_unwind_on_malloc=0";
+}
+#endif
+
+/****************************************************************************
  * Name: main
  *
  * Description:


### PR DESCRIPTION
## Summary

sim/lsan: disable fast-unwind by default

The fast-unwind implementation of leak-sanitizer will obtain the
current stack top/bottom and frame address(Stack Pointer) for
backtrace calculation:

https://github.com/gcc-mirror/gcc/blob/releases/gcc-13/libsanitizer/lsan/lsan.cpp#L39-L42

Since the scheduling mechanism of NuttX sim is coroutine
(setjmp/longjmp), if the Stack Pointer is switched, the fast-unwind
will unable to get the available address, so the memory leaks on the
system/application side that cannot be caught normally. This PR will
disable fast-unwind by default to avoid unwind failure.

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

CONFIG_SIM_ASAN

## Testing

1. memory leak on test code:
```bash
diff --git a/examples/hello/hello_main.c b/examples/hello/hello_main.c
index 2cd6cb400..db58031f0 100644
--- a/examples/hello/hello_main.c
+++ b/examples/hello/hello_main.c
@@ -35,6 +35,7 @@
 
 int main(int argc, FAR char *argv[])
 {
+  malloc(100);
   printf("Hello, World!!\n");
   return 0;
 }
```

2. Detected by leak-sanitizer:
```bash
$ ./nuttx 
==2283059==WARNING: ASan is ignoring requested __asan_handle_no_return: stack type: default top: 0x7fffeeb1b000; bottom 0x631000023000; size: 0x1cefeeaf8000 (31816827240448)
False positive error reports may follow
For details see https://github.com/google/sanitizers/issues/189

NuttShell (NSH) NuttX-10.4.0
nsh> hello
Hello, World!!
nsh> poweroff

=================================================================
==2283059==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 100 byte(s) in 1 object(s) allocated from:
    #0 0x7fcadf13d93c in __interceptor_posix_memalign ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:226
    #1 0x5601710b789d in host_memalign sim/posix/sim_hostmemory.c:180
    #2 0x5601710b7e44 in host_realloc sim/posix/sim_hostmemory.c:227
    #3 0x560170fd5324 in mm_realloc sim/sim_heap.c:262
    #4 0x560170fd528c in mm_malloc sim/sim_heap.c:194
    #5 0x560170fd2974 in malloc umm_heap/umm_malloc.c:62
    #6 0x56017106a5d9 in hello_main /home/archer/code/nuttx/n10/apps/examples/hello/hello_main.c:38
    #7 0x560170fc82da in nxtask_startup sched/task_startup.c:70
    #8 0x560170fa6c15 in nxtask_start task/task_start.c:134

SUMMARY: AddressSanitizer: 100 byte(s) leaked in 1 allocation(s).
```