### PR TITLE
tcp_monitor: start_monitor return OK when connect closed by peer

### DIFF
--- a/net/tcp/tcp_monitor.c
+++ b/net/tcp/tcp_monitor.c
@@ -271,6 +271,18 @@ int tcp_start_monitor(FAR struct socket *psock)
 
       tcp_shutdown_monitor(conn, TCP_CLOSE);
 
+      /* If the peer close the connection before we call accept,
+       * in order to allow user to read the readahead data,
+       * return OK.
+       */
+
+      if (conn->tcpstateflags == TCP_CLOSED ||
+          conn->tcpstateflags == TCP_LAST_ACK)
+        {
+          net_unlock();
+          return OK;
+        }
+
       /* And return -ENOTCONN to indicate the monitor was not started
        * because the socket was already disconnected.
        */


### PR DESCRIPTION
## Summary
If TCP_FIN is received before the user calls accept, the later accept will report an error, then the previously received data cannot be read.

operation flow:
tcp_server_listen -> tcp_client_connect -> tcp_client_send -> tcp_client_close -> tcp_server_accept(fix this error) -> tcp_server_recv
## Impact

## Testing
sim:local
