### PR TITLE
arch/sim: do not free memory of zero-length reallocation

### DIFF
--- a/arch/sim/src/sim/posix/sim_hostmemory.c
+++ b/arch/sim/src/sim/posix/sim_hostmemory.c
@@ -217,12 +217,7 @@ void *host_realloc(void *oldmem, size_t size)
   size_t oldsize;
   void *mem;
 
-  if (size == 0)
-    {
-      host_free(oldmem);
-      return NULL;
-    }
-  else if (oldmem == NULL)
+  if (oldmem == NULL)
     {
       return host_memalign(sizeof(void *), size);
     }


### PR DESCRIPTION

## Summary
Follow the change: https://github.com/apache/nuttx/pull/9151, if MM_CUSTOMIZE_MANAGER is enabled, heap manager allocator in host is used, for example in sim:asan build.

malloc and related allocation APIs will fall back to host_realloc. Do not free memory of zero-length reallocation, so memory allocations return valid pointer when request zero size in all sim build.

call stack:
    malloc()              (mm/umm_heap/umm_malloc.c)
    mm_malloc()      (arch/sim/src/sim/sim_heap.c)
    mm_realloc()      (arch/sim/src/sim/sim_heap.c)
    host_realloc()     (arch/sim/src/sim/posix/sim_hostmemory.c)
    host_memalign()  (arch/sim/src/sim/posix/sim_hostmemory.c)

## Impact
Improve POSIX compliance of malloc in sim:asan related build.

## Testing
passing CI. 
