### PR TITLE
libc/armv8-m: fix build break if MVE is disabled

### DIFF
--- a/libs/libc/machine/arm/armv8-m/gnu/arch_memcpy.S
+++ b/libs/libc/machine/arm/armv8-m/gnu/arch_memcpy.S
@@ -29,7 +29,6 @@
  *
  ****************************************************************************/
 
-#ifndef __ARM_FEATURE_MVE
 /* This memcpy routine is optimised for Cortex-M3/M4 cores with/without
    unaligned access.
 
@@ -50,7 +49,10 @@
      __OPT_BIG_BLOCK_SIZE: Size of big block in words.  Default to 64.
      __OPT_MID_BLOCK_SIZE: Size of big block in words.  Default to 16.
  */
+
 #include "arm_asm.h"
+
+#ifndef __ARM_FEATURE_MVE
 
 #ifndef __OPT_BIG_BLOCK_SIZE
 #define __OPT_BIG_BLOCK_SIZE (4 * 16)


### PR DESCRIPTION
## Summary

libc/armv8-m: fix build break if MVE is disabled

```
machine/arm/armv8-m/gnu/arch_memcpy.S: Assembler messages:
machine/arm/armv8-m/gnu/arch_memcpy.S:105: Error: bad instruction `prologue push_ip=HAVE_PAC_LEAF'
machine/arm/armv8-m/gnu/arch_memcpy.S:121: Error: bad instruction `epilogue push_ip=HAVE_PAC_LEAF'
make[1]: *** [Makefile:143: bin/arch_memcpy.o] Error
```

## Impact

N/A

## Testing

armv8-m