### PR TITLE
net/udp: Remove wrong check in udp_readahead

### DIFF
--- a/net/udp/udp_recvfrom.c
+++ b/net/udp/udp_recvfrom.c
@@ -170,8 +170,6 @@ static inline void udp_readahead(struct udp_recvfrom_s *pstate)
       FAR void *srcaddr;
       uint8_t ifindex;
 
-      DEBUGASSERT(iob->io_pktlen > 0);
-
       /* Unflatten saved connection information */
 
 #ifdef CONFIG_NETDEV_IFINDEX


### PR DESCRIPTION
## Summary
- Before IOB offload, `srcaddr` / `src_addr_size` / `ifindex` are written into IOB by `iob_trycopyin`, so `io_pktlen > 0` is always true, this check is correct at that time. (It won't fail with zero-length UDP datagram.)
- After IOB offload, `srcaddr` / `src_addr_size` / `ifindex` are written into offset 0, without increasing `io_pktlen`. So this check will fail with zero-length UDP datagram now.
- We need to support zero-length UDP datagram and this check is unnecessary at this point.
  - https://stackoverflow.com/questions/5307031/how-to-detect-receipt-of-a-0-length-udp-datagram
  - https://github.com/apache/nuttx/blob/nuttx-12.1.0/net/udp/udp_callback.c#L214

## Impact

## Testing

