### PR TITLE
tools/nuttx-gdbinit: improve experience of gdb backend scripts 

### DIFF
--- a/tools/nuttx-gdbinit
+++ b/tools/nuttx-gdbinit
@@ -59,8 +59,7 @@ define _examine_target
   if ($_target_examined == 0x0)
     _examine_arch
 
-    set $_tcb0 = g_pidhash[0]
-    set $_xcp_nregs = sizeof($_tcb0->xcp.regs) / sizeof($_tcb0->xcp.regs[0])
+    set $_xcp_nregs = sizeof(g_last_regs) / sizeof(void *)
     set $_target_has_fpu = 0
 
     if ($_streq($_target_arch, "armv7e-m") == 1)

--- a/tools/nuttx-gdbinit
+++ b/tools/nuttx-gdbinit
@@ -80,9 +80,6 @@ define _examine_target
 
     set $_target_max_tasks = g_npidhash
 
-    python if (type(gdb.lookup_global_symbol("up_check_tcbstack")) is gdb.Symbol) : \
-    gdb.execute("set $_target_has_stack_coloration = 1")
-
     printf "target examined\n"
     python print("_target_arch.name=" + _target_arch.name())
 
@@ -104,15 +101,9 @@ define _print_thread
     printf "  "
   end
 
-  if ($_target_has_stack_coloration)
-    set $stack_used = up_check_tcbstack($tcb)
-  else
-    set $stack_used = 0
-  end
-
-  printf "%d Thread 0x%x  (Name: %s, State: %s, Priority: %d, Stack: %d/%d) PC: 0x%x in ", \
+  printf "%d Thread 0x%x  (Name: %s, State: %s, Priority: %d, Stack: %d) PC: 0x%x in ", \
   $tcb->pid, $tcb, $tcb->name, g_statenames[$tcb->task_state], $tcb->sched_priority, \
-  $stack_used, $tcb->adj_stack_size, $tcb->xcp.regs[$_pc_reg_idx]
+  $tcb->adj_stack_size, $tcb->xcp.regs[$_pc_reg_idx]
   python _symbol = gdb.execute("info symbol $tcb->xcp.regs[$_pc_reg_idx]", to_string=True); \
   print(_symbol.split()[0] + "()")
 end

--- a/tools/nuttx-gdbinit
+++ b/tools/nuttx-gdbinit
@@ -20,7 +20,7 @@
 
 # NOTE: you need to use gdb configured '--with-python'
 # usage: gdb -ix=./tools/nuttx-gdbinit nuttx
-# new commands: info_nxthreads, nxthread pid, nxcontinue, nxthread_all_bt
+# new commands: nxthread pid, nxthread_all_bt
 
 # Do not stop with SIGUSR1 which is used for the NuttX sim SMP
 handle SIGUSR1 "nostop" "pass" "noprint"
@@ -78,24 +78,23 @@ define _examine_target
     python if (type(gdb.lookup_global_symbol("g_assignedtasks")) is gdb.Symbol) : \
     gdb.execute("set $_target_has_smp = 1")
 
-    set $_target_max_tasks = g_npidhash
-
-    printf "target examined\n"
-    python print("_target_arch.name=" + _target_arch.name())
-
-    # NOTE: i386:x86-64 (qemu) does not work
-    #printf "$_target_arch : %s\n", $_target_arch
-
-    printf "$_target_has_fpu : %d\n", $_target_has_fpu
-    printf "$_target_has_smp : %d\n", $_target_has_smp
     set $_target_examined = 1
+  end
+end
+
+define _running_task
+  if ($_target_has_smp == 0)
+    set $rtcb = (struct tcb_s *)g_readytorun->head
+  else
+    set $rtcb = (struct tcb_s *)g_assignedtasks[up_cpu_index()]->head
   end
 end
 
 define _print_thread
   set $tcb = (struct tcb_s *)$arg0
+  _running_task
 
-  if ($tcb == $_current_tcb)
+  if ($tcb == $rtcb)
     printf "* "
   else
     printf "  "
@@ -137,21 +136,13 @@ define _save_current_tcb
   _examine_target
 
   if ($_current_tcb == 0)
-    if ($_target_has_smp == 0)
-      set $tcb = (struct tcb_s *)g_readytorun->head
-      _save_tcb $tcb
-    else
-      set $cpu = up_cpu_index()
-      set $tcb = (struct tcb_s *)g_assignedtasks[$cpu]->head
-      _save_tcb $tcb
-    end
-    printf "saved current_tcb (pid=%d)\n", $tcb->pid
-    set $_current_tcb = $tcb
+    _running_task
+    _save_tcb $rtcb
+    set $_current_tcb = $rtcb
   end
 end
 
 define _switch_tcb
-  _examine_target
   _save_current_tcb
 
   # set the current frame to the newest before switching
@@ -406,36 +397,31 @@ define _switch_tcb_simx86
 end
 
 define _restore_current_tcb
-  # TODO: SMP
-  set $tcb = g_readytorun->head
-  _switch_tcb $tcb
+  _examine_target
+  _running_task
+  _switch_tcb $rtcb
   set $_current_tcb = 0x0
 end
 
 define nxthread
-  _examine_target
-  _save_current_tcb
-  set $hash = ($arg0 & ($_target_max_tasks - 1))
+  set $hash = ($arg0 & (g_npidhash - 1))
   set $tcb = g_pidhash[$hash]
   if ($tcb != 0x0)
+    _switch_tcb $tcb
     _print_thread $tcb
-    if ($argc == 1)
-      _switch_tcb $tcb
-    end
     if ($argc == 2)
       if ($arg1 == 1)
-	_switch_tcb $tcb
-	where
+        _switch_tcb $tcb
+        where
       end
     end
   end
-  _restore_current_tcb
 end
 
 define nxthread_all_bt
   _save_current_tcb
   set $i = 0
-  while ($i < $_target_max_tasks)
+  while ($i < g_npidhash)
     # 1: backtrace
     nxthread $i 1
     set $i = $i + 1
@@ -443,10 +429,10 @@ define nxthread_all_bt
   _restore_current_tcb
 end
 
-define info_nxthreads
+define info threads
   _save_current_tcb
   set $i = 0
-  while ($i < $_target_max_tasks)
+  while ($i < g_npidhash)
     # dummy : 0 0
     nxthread $i 0 0
     set $i = $i + 1
@@ -454,8 +440,19 @@ define info_nxthreads
   _restore_current_tcb
 end
 
-define nxcontinue
-  printf "nxcontinue\n"
+define c
   _restore_current_tcb
   continue
+end
+
+define thread
+  _save_current_tcb
+  if ($argc == 0)
+    _running_task
+    set $pid = $rtcb->pid
+  else
+    set $pid = $arg0
+  end
+
+  nxthread $pid
 end


### PR DESCRIPTION
## Summary

1. tools/nuttx-gdbinit: improve experience of gdb backend scripts

Redefine built-in command (info thread/thread/c) to compatible with developer habits

Test board:
```bash
./tools/configure.sh -E lm3s6965-ek:qemu-flat
```
1> start qemu:
```bash
qemu-system-arm   -M lm3s6965evb   -device loader,file=nuttx   -serial mon:stdio   -nographic  -s
```
2> gdb attach:
```bash
gdb-multiarch -ix tools/nuttx-gdbinit nuttx -ex "target extended-remote localhost:1234"
```
3> show thread info and callstack:

```bash
| (gdb) info thread
| * 0 Thread 0x20001548  (Name: Idle Task, State: Running, Priority: 0, Stack: 1000) PC: 0x9eee in up_idle()
|   1 Thread 0x20005058  (Name: hpwork, State: Waiting,Semaphore, Priority: 224, Stack: 1992) PC: 0xa124 in up_switch_context()
|   2 Thread 0x20005c20  (Name: nsh_main, State: Waiting,Semaphore, Priority: 100, Stack: 2000) PC: 0xa124 in up_switch_context()
|   3 Thread 0x20006b30  (Name: NTP daemon, State: Waiting,Semaphore, Priority: 100, Stack: 1952) PC: 0xa124 in up_switch_context()
|   4 Thread 0x200086f0  (Name: telnetd, State: Waiting,Semaphore, Priority: 100, Stack: 2008) PC: 0xa124 in up_switch_context()
| (gdb) bt
| #0  0x00009eee in up_idle () at chip/common/tiva_idle.c:62
| #1  0x00003dd2 in nx_start () at init/nx_start.c:698
| #2  0x00000190 in __start () at chip/common/lmxx_tm4c_start.c:177
| (gdb) thread 4
|   4 Thread 0x200086f0  (Name: telnetd, State: Waiting,Semaphore, Priority: 100, Stack: 2008) PC: 0xa124 in up_switch_context()
| (gdb) bt
| #0  up_switch_context (tcb=0x20001548 <g_idletcb>, rtcb=rtcb@entry=0x200086f0) at common/arm_switchcontext.c:95
| #1  0x0000453a in nxsem_wait (sem=sem@entry=0x2000916c) at semaphore/sem_wait.c:176
| #2  0x0000197e in _net_timedwait (sem=sem@entry=0x2000916c, interruptible=interruptible@entry=true, timeout=timeout@entry=4294967295) at utils/net_lock.c:101
| #3  0x0000198e in net_sem_timedwait (sem=sem@entry=0x2000916c, timeout=timeout@entry=4294967295) at utils/net_lock.c:242
| #4  0x00001996 in net_sem_wait (sem=sem@entry=0x2000916c) at utils/net_lock.c:330
| #5  0x00025f84 in psock_tcp_accept (psock=<optimized out>, addr=<optimized out>, addrlen=<optimized out>, newconn=newconn@entry=0x2000956c) at tcp/tcp_accept.c:274
| #6  0x00025432 in inet_accept (psock=<optimized out>, addr=<optimized out>, addrlen=<optimized out>, newsock=0x20009568, flags=0) at inet/inet_sockif.c:1443
| #7  0x00027a10 in psock_accept (psock=0x200044b8, addr=addr@entry=0x2000921c, addrlen=addrlen@entry=0x2000920c, newsock=newsock@entry=0x20009568, flags=flags@entry=0) at socket/accept.c:149
| #8  0x00027a8c in accept4 (sockfd=sockfd@entry=3, addr=addr@entry=0x2000921c, addrlen=addrlen@entry=0x2000920c, flags=flags@entry=0) at socket/accept.c:280
| #9  0x0002a256 in accept (sockfd=sockfd@entry=3, addr=addr@entry=0x2000921c, addrlen=addrlen@entry=0x2000920c) at net/lib_accept.c:50
| #10 0x0001efaa in telnetd_daemon (config=config@entry=0x20009290) at telnetd_daemon.c:200
| #11 0x0001e508 in telnetd_main (argc=1, argv=0x20008af8) at telnetd.c:98
| #12 0x00008486 in nxtask_startup (entrypt=0x1e4bd <telnetd_main>, entrypt@entry=0x1 <up_putc>, argc=1, argv=0x20008af8) at sched/task_startup.c:70
| #13 0x000056d2 in nxtask_start () at task/task_start.c:134
| #14 0x00000000 in ?? ()
| (gdb) c
```

Signed-off-by: chao an <anchao@xiaomi.com>


2. tools/nuttx-gdbinit: remove unsafed function call from script

Some time nuttx will receive SIGSEGV while executing the function:

```bash
| Thread 1 "nuttx" received signal SIGSEGV, Segmentation fault.
| 0xf7bab4a0 in __sanitizer::common_flags_dont_use () from /lib/i386-linux-gnu/libasan.so.6
| The program being debugged was signaled while in a function called from GDB.
| GDB has restored the context to what it was before the call.
| Evaluation of the expression containing the function
| (up_check_tcbstack) will be abandoned.
```

Signed-off-by: chao an <anchao@xiaomi.com>


3. tools/nuttx-gdbinit: correct xcp context size

Fix issue: https://github.com/apache/nuttx/issues/8616

Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

./tools/configure.sh -E lm3s6965-ek:qemu-flat