### PR TITLE
pthread: fixed pthread incorrect return values

### DIFF
--- a/libs/libc/pthread/pthread_once.c
+++ b/libs/libc/pthread/pthread_once.c
@@ -25,6 +25,7 @@
 #include <nuttx/config.h>
 
 #include <assert.h>
+#include <errno.h>
 #include <stdbool.h>
 #include <pthread.h>
 #include <sched.h>
@@ -65,8 +66,10 @@ int pthread_once(FAR pthread_once_t *once_control,
 {
   /* Sanity checks */
 
-  DEBUGASSERT(once_control != NULL);
-  DEBUGASSERT(init_routine != NULL);
+  if (once_control == NULL || init_routine == NULL)
+    {
+      return EINVAL;
+    }
 
   /* Prohibit pre-emption while we test and set the once_control. */
 

--- a/libs/libc/sched/task_setcanceltype.c
+++ b/libs/libc/sched/task_setcanceltype.c
@@ -55,5 +55,5 @@ int task_setcanceltype(int type, FAR int *oldtype)
 
   /* Check the requested cancellation type */
 
-  return (type == TASK_CANCEL_ASYNCHRONOUS) ? OK : ENOSYS;
+  return (type == TASK_CANCEL_ASYNCHRONOUS) ? OK : EINVAL;
 }

--- a/sched/pthread/pthread_detach.c
+++ b/sched/pthread/pthread_detach.c
@@ -76,8 +76,23 @@ int pthread_detach(pthread_t thread)
   pjoin = pthread_findjoininfo(group, (pid_t)thread);
   if (!pjoin)
     {
+      FAR struct tcb_s *tcb = nxsched_get_tcb((pid_t)thread);
+
       serr("ERROR: Could not find thread entry\n");
-      ret = EINVAL;
+
+      if (tcb == NULL)
+        {
+          ret = ESRCH;
+        }
+
+      /* The thread is still active but has no join info.  In that
+       * case, it must be a task and not a pthread.
+       */
+
+      else
+        {
+          ret = EINVAL;
+        }
     }
   else
     {


### PR DESCRIPTION
## Summary

1. Return ESRCH when thread not found at pthread_detach.

[https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_detach.html](https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_detach.html)

```
If an implementation detects that the value specified by the thread argument to pthread_detach() does not refer to a joinable thread, it is recommended that the function should fail and report an [EINVAL] error.

If an implementation detects use of a thread ID after the end of its lifetime, it is recommended that the function should fail and report an [ESRCH] error.
```

2. Return EINVAL when input parameter incorrect at pthread_once.

[https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_once.html](https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_once.html)

```
If an implementation detects that the value specified by the once_control argument to pthread_once() does not refer to a pthread_once_t object initialized by PTHREAD_ONCE_INIT, it is recommended that the function should fail and report an [EINVAL] error
```

3. Return EINVAL when type incorrect at task_setcanceltype.

[https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_setcancelstate.html](https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_setcancelstate.html)

```
The pthread_setcancelstate() function may fail if:

[EINVAL]
The specified state is not PTHREAD_CANCEL_ENABLE or PTHREAD_CANCEL_DISABLE.
The pthread_setcanceltype() function may fail if:

[EINVAL]
The specified type is not PTHREAD_CANCEL_DEFERRED or PTHREAD_CANCEL_ASYNCHRONOUS.
```


## Impact

pthread

## Testing

liteos pthread test case