### PR TITLE
system/signal: in interrupting the context, regs modify logic error

### DIFF
--- a/arch/arm64/src/common/arm64_schedulesigaction.c
+++ b/arch/arm64/src/common/arm64_schedulesigaction.c
@@ -46,9 +46,15 @@
  * Public Functions
  ****************************************************************************/
 
-void arm64_init_signal_process(struct tcb_s *tcb)
+void arm64_init_signal_process(struct tcb_s *tcb, struct regs_context *regs)
 {
-  struct regs_context  *pctx = (struct regs_context *)tcb->xcp.regs;
+/****************************************************************************
+ * if regs != NULL We are interrupting the context,
+ * we should modify the regs
+ ****************************************************************************/
+
+  struct regs_context  *pctx = (regs != NULL) ? regs :
+  (struct regs_context *)tcb->xcp.regs;
   struct regs_context  *psigctx;
   char   *stack_ptr = (char *)pctx->sp_elx;
 
@@ -162,11 +168,12 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
               /* create signal process context */
 
-              tcb->xcp.saved_reg = tcb->xcp.regs;
+              tcb->xcp.saved_reg = (uint64_t *)CURRENT_REGS;
 #ifdef CONFIG_ARCH_FPU
               tcb->xcp.saved_fpu_regs = tcb->xcp.fpu_regs;
 #endif
-              arm64_init_signal_process(tcb);
+              arm64_init_signal_process(tcb,
+              (struct regs_context *)CURRENT_REGS);
 
               /* trigger switch to signal process */
 
@@ -193,7 +200,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
           /* create signal process context */
 
           tcb->xcp.saved_reg = tcb->xcp.regs;
-          arm64_init_signal_process(tcb);
+          arm64_init_signal_process(tcb, NULL);
         }
     }
 }
@@ -276,7 +283,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                   /* create signal process context */
 
                   tcb->xcp.saved_reg = tcb->xcp.regs;
-                  arm64_init_signal_process(tcb);
+                  arm64_init_signal_process(tcb, NULL);
                 }
               else
                 {
@@ -292,11 +299,12 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
                   /* create signal process context */
 
-                  tcb->xcp.saved_reg = tcb->xcp.regs;
+                  tcb->xcp.saved_reg = (uint64_t *)CURRENT_REGS;
 #ifdef CONFIG_ARCH_FPU
                   tcb->xcp.saved_fpu_regs = tcb->xcp.fpu_regs;
 #endif
-                  arm64_init_signal_process(tcb);
+                  arm64_init_signal_process(tcb,
+                  (struct regs_context *)CURRENT_REGS);
 
                   /* trigger switch to signal process */
 
@@ -347,7 +355,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
           /* create signal process context */
 
-          arm64_init_signal_process(tcb);
+          arm64_init_signal_process(tcb, NULL);
 
           /* Increment the IRQ lock count so that when the task is restarted,
            * it will hold the IRQ spinlock.


### PR DESCRIPTION
## Summary
In the interrupt context, we should first save the interrupt context and modify the interrupt register to execute the signal processing program immediately after exiting the current interrupt

## Impact
none
## Testing
ostest
