### PR TITLE
sched/signal: fix the issue of asynchronous signal processing

### DIFF
--- a/arch/arm/src/armv6-m/arm_sigdeliver.c
+++ b/arch/arm/src/armv6-m/arm_sigdeliver.c
@@ -71,14 +71,15 @@ void arm_sigdeliver(void)
         rtcb, rtcb->xcp.sigdeliver, rtcb->sigpendactionq.head);
   DEBUGASSERT(rtcb->xcp.sigdeliver != NULL);
 
+retry:
 #ifdef CONFIG_SMP
   /* In the SMP case, up_schedule_sigaction(0) will have incremented
    * 'irqcount' in order to force us into a critical section.  Save the
    * pre-incremented irqcount.
    */
 
-  saved_irqcount = rtcb->irqcount - 1;
-  DEBUGASSERT(saved_irqcount >= 0);
+  saved_irqcount = rtcb->irqcount;
+  DEBUGASSERT(saved_irqcount >= 1);
 
   /* Now we need call leave_critical_section() repeatedly to get the irqcount
    * to zero, freeing all global spinlocks that enforce the critical section.
@@ -129,6 +130,12 @@ void arm_sigdeliver(void)
   up_irq_save();
 #endif
 
+  if (!sq_empty(&rtcb->sigpendactionq) &&
+      (rtcb->flags & TCB_FLAG_SIGNAL_ACTION) == 0)
+    {
+      goto retry;
+    }
+
   /* Modify the saved return state with the actual saved values in the
    * TCB.  This depends on the fact that nested signal handling is
    * not supported.  Therefore, these values will persist throughout the
@@ -146,5 +153,8 @@ void arm_sigdeliver(void)
    */
 
   board_autoled_off(LED_SIGNAL);
+#ifdef CONFIG_SMP
+  rtcb->irqcount--;
+#endif
   arm_fullcontextrestore(regs);
 }

--- a/arch/arm/src/armv7-a/arm_sigdeliver.c
+++ b/arch/arm/src/armv7-a/arm_sigdeliver.c
@@ -71,14 +71,15 @@ void arm_sigdeliver(void)
         rtcb, rtcb->xcp.sigdeliver, rtcb->sigpendactionq.head);
   DEBUGASSERT(rtcb->xcp.sigdeliver != NULL);
 
+retry:
 #ifdef CONFIG_SMP
   /* In the SMP case, up_schedule_sigaction(0) will have incremented
    * 'irqcount' in order to force us into a critical section.  Save the
    * pre-incremented irqcount.
    */
 
-  saved_irqcount = rtcb->irqcount - 1;
-  DEBUGASSERT(saved_irqcount >= 0);
+  saved_irqcount = rtcb->irqcount;
+  DEBUGASSERT(saved_irqcount >= 1);
 
   /* Now we need call leave_critical_section() repeatedly to get the irqcount
    * to zero, freeing all global spinlocks that enforce the critical section.
@@ -129,6 +130,12 @@ void arm_sigdeliver(void)
   up_irq_save();
 #endif
 
+  if (!sq_empty(&rtcb->sigpendactionq) &&
+      (rtcb->flags & TCB_FLAG_SIGNAL_ACTION) == 0)
+    {
+      goto retry;
+    }
+
   /* Modify the saved return state with the actual saved values in the
    * TCB.  This depends on the fact that nested signal handling is
    * not supported.  Therefore, these values will persist throughout the
@@ -144,5 +151,8 @@ void arm_sigdeliver(void)
   /* Then restore the correct state for this thread of execution. */
 
   board_autoled_off(LED_SIGNAL);
+#ifdef CONFIG_SMP
+  rtcb->irqcount--;
+#endif
   arm_fullcontextrestore(regs);
 }

--- a/arch/arm/src/armv7-m/arm_sigdeliver.c
+++ b/arch/arm/src/armv7-m/arm_sigdeliver.c
@@ -71,14 +71,15 @@ void arm_sigdeliver(void)
         rtcb, rtcb->xcp.sigdeliver, rtcb->sigpendactionq.head);
   DEBUGASSERT(rtcb->xcp.sigdeliver != NULL);
 
+retry:
 #ifdef CONFIG_SMP
   /* In the SMP case, up_schedule_sigaction(0) will have incremented
    * 'irqcount' in order to force us into a critical section.  Save the
    * pre-incremented irqcount.
    */
 
-  saved_irqcount = rtcb->irqcount - 1;
-  DEBUGASSERT(saved_irqcount >= 0);
+  saved_irqcount = rtcb->irqcount;
+  DEBUGASSERT(saved_irqcount >= 1);
 
   /* Now we need call leave_critical_section() repeatedly to get the irqcount
    * to zero, freeing all global spinlocks that enforce the critical section.
@@ -133,6 +134,12 @@ void arm_sigdeliver(void)
   up_irq_save();
 #endif
 
+  if (!sq_empty(&rtcb->sigpendactionq) &&
+      (rtcb->flags & TCB_FLAG_SIGNAL_ACTION) == 0)
+    {
+      goto retry;
+    }
+
   /* Modify the saved return state with the actual saved values in the
    * TCB.  This depends on the fact that nested signal handling is
    * not supported.  Therefore, these values will persist throughout the
@@ -150,5 +157,8 @@ void arm_sigdeliver(void)
    */
 
   board_autoled_off(LED_SIGNAL);
+#ifdef CONFIG_SMP
+  rtcb->irqcount--;
+#endif
   arm_fullcontextrestore(regs);
 }

--- a/arch/arm/src/armv7-r/arm_sigdeliver.c
+++ b/arch/arm/src/armv7-r/arm_sigdeliver.c
@@ -71,14 +71,15 @@ void arm_sigdeliver(void)
         rtcb, rtcb->xcp.sigdeliver, rtcb->sigpendactionq.head);
   DEBUGASSERT(rtcb->xcp.sigdeliver != NULL);
 
+retry:
 #ifdef CONFIG_SMP
   /* In the SMP case, up_schedule_sigaction(0) will have incremented
    * 'irqcount' in order to force us into a critical section.  Save the
    * pre-incremented irqcount.
    */
 
-  saved_irqcount = rtcb->irqcount - 1;
-  DEBUGASSERT(saved_irqcount >= 0);
+  saved_irqcount = rtcb->irqcount;
+  DEBUGASSERT(saved_irqcount >= 1);
 
   /* Now we need call leave_critical_section() repeatedly to get the irqcount
    * to zero, freeing all global spinlocks that enforce the critical section.
@@ -126,6 +127,12 @@ void arm_sigdeliver(void)
   up_irq_save();
 #endif
 
+  if (!sq_empty(&rtcb->sigpendactionq) &&
+      (rtcb->flags & TCB_FLAG_SIGNAL_ACTION) == 0)
+    {
+      goto retry;
+    }
+
   /* Modify the saved return state with the actual saved values in the
    * TCB.  This depends on the fact that nested signal handling is
    * not supported.  Therefore, these values will persist throughout the
@@ -141,5 +148,8 @@ void arm_sigdeliver(void)
   /* Then restore the correct state for this thread of execution. */
 
   board_autoled_off(LED_SIGNAL);
+#ifdef CONFIG_SMP
+  rtcb->irqcount--;
+#endif
   arm_fullcontextrestore(regs);
 }

--- a/arch/arm/src/armv8-m/arm_sigdeliver.c
+++ b/arch/arm/src/armv8-m/arm_sigdeliver.c
@@ -71,14 +71,15 @@ void arm_sigdeliver(void)
         rtcb, rtcb->xcp.sigdeliver, rtcb->sigpendactionq.head);
   DEBUGASSERT(rtcb->xcp.sigdeliver != NULL);
 
+retry:
 #ifdef CONFIG_SMP
   /* In the SMP case, up_schedule_sigaction(0) will have incremented
    * 'irqcount' in order to force us into a critical section.  Save the
    * pre-incremented irqcount.
    */
 
-  saved_irqcount = rtcb->irqcount - 1;
-  DEBUGASSERT(saved_irqcount >= 0);
+  saved_irqcount = rtcb->irqcount;
+  DEBUGASSERT(saved_irqcount >= 1);
 
   /* Now we need call leave_critical_section() repeatedly to get the irqcount
    * to zero, freeing all global spinlocks that enforce the critical section.
@@ -133,6 +134,12 @@ void arm_sigdeliver(void)
   up_irq_save();
 #endif
 
+  if (!sq_empty(&rtcb->sigpendactionq) &&
+      (rtcb->flags & TCB_FLAG_SIGNAL_ACTION) == 0)
+    {
+      goto retry;
+    }
+
   /* Modify the saved return state with the actual saved values in the
    * TCB.  This depends on the fact that nested signal handling is
    * not supported.  Therefore, these values will persist throughout the
@@ -150,5 +157,8 @@ void arm_sigdeliver(void)
    */
 
   board_autoled_off(LED_SIGNAL);
+#ifdef CONFIG_SMP
+  rtcb->irqcount--;
+#endif
   arm_fullcontextrestore(regs);
 }

--- a/arch/arm64/src/common/arm64_sigdeliver.c
+++ b/arch/arm64/src/common/arm64_sigdeliver.c
@@ -77,14 +77,15 @@ void arm64_sigdeliver(void)
         rtcb, rtcb->xcp.sigdeliver, rtcb->sigpendactionq.head);
   DEBUGASSERT(rtcb->xcp.sigdeliver != NULL);
 
+retry:
 #ifdef CONFIG_SMP
   /* In the SMP case, up_schedule_sigaction(0) will have incremented
    * 'irqcount' in order to force us into a critical section.  Save the
    * pre-incremented irqcount.
    */
 
-  saved_irqcount = rtcb->irqcount - 1;
-  DEBUGASSERT(saved_irqcount >= 0);
+  saved_irqcount = rtcb->irqcount;
+  DEBUGASSERT(saved_irqcount >= 1);
 
   /* Now we need call leave_critical_section() repeatedly to get the irqcount
    * to zero, freeing all global spinlocks that enforce the critical section.
@@ -135,6 +136,12 @@ void arm64_sigdeliver(void)
   up_irq_save();
 #endif
 
+  if (!sq_empty(&rtcb->sigpendactionq) &&
+      (rtcb->flags & TCB_FLAG_SIGNAL_ACTION) == 0)
+    {
+      goto retry;
+    }
+
   /* Modify the saved return state with the actual saved values in the
    * TCB.  This depends on the fact that nested signal handling is
    * not supported.  Therefore, these values will persist throughout the
@@ -155,5 +162,8 @@ void arm64_sigdeliver(void)
 
   /* Then restore the correct state for this thread of execution. */
 
+#ifdef CONFIG_SMP
+  rtcb->irqcount--;
+#endif
   arm64_fullcontextrestore(rtcb->xcp.regs);
 }

--- a/arch/risc-v/src/common/riscv_sigdeliver.c
+++ b/arch/risc-v/src/common/riscv_sigdeliver.c
@@ -72,14 +72,15 @@ void riscv_sigdeliver(void)
         rtcb, rtcb->xcp.sigdeliver, rtcb->sigpendactionq.head);
   DEBUGASSERT(rtcb->xcp.sigdeliver != NULL);
 
+retry:
 #ifdef CONFIG_SMP
   /* In the SMP case, up_schedule_sigaction(0) will have incremented
    * 'irqcount' in order to force us into a critical section.  Save the
    * pre-incremented irqcount.
    */
 
-  saved_irqcount = rtcb->irqcount - 1;
-  DEBUGASSERT(saved_irqcount >= 0);
+  saved_irqcount = rtcb->irqcount;
+  DEBUGASSERT(saved_irqcount >= 1);
 
   /* Now we need call leave_critical_section() repeatedly to get the irqcount
    * to zero, freeing all global spinlocks that enforce the critical section.
@@ -128,6 +129,12 @@ void riscv_sigdeliver(void)
   up_irq_save();
 #endif
 
+  if (!sq_empty(&rtcb->sigpendactionq) &&
+      (rtcb->flags & TCB_FLAG_SIGNAL_ACTION) == 0)
+    {
+      goto retry;
+    }
+
   /* Modify the saved return state with the actual saved values in the
    * TCB.  This depends on the fact that nested signal handling is
    * not supported.  Therefore, these values will persist throughout the
@@ -145,5 +152,8 @@ void riscv_sigdeliver(void)
    */
 
   board_autoled_off(LED_SIGNAL);
+#ifdef CONFIG_SMP
+  rtcb->irqcount--;
+#endif
   riscv_fullcontextrestore(regs);
 }

--- a/arch/xtensa/src/common/xtensa_sigdeliver.c
+++ b/arch/xtensa/src/common/xtensa_sigdeliver.c
@@ -71,14 +71,15 @@ void xtensa_sig_deliver(void)
         rtcb, rtcb->xcp.sigdeliver, rtcb->sigpendactionq.head);
   DEBUGASSERT(rtcb->xcp.sigdeliver != NULL);
 
+retry:
 #ifdef CONFIG_SMP
   /* In the SMP case, up_schedule_sigaction(0) will have incremented
    * 'irqcount' in order to force us into a critical section.  Save the
    * pre-incremented irqcount.
    */
 
-  saved_irqcount = rtcb->irqcount - 1;
-  DEBUGASSERT(saved_irqcount >= 0);
+  saved_irqcount = rtcb->irqcount;
+  DEBUGASSERT(saved_irqcount >= 1);
 
   /* Now we need to call leave_critical_section() repeatedly to get the
    * irqcount to zero, freeing all global spinlocks that enforce the critical
@@ -127,6 +128,12 @@ void xtensa_sig_deliver(void)
   up_irq_save();
 #endif
 
+  if (!sq_empty(&rtcb->sigpendactionq) &&
+      (rtcb->flags & TCB_FLAG_SIGNAL_ACTION) == 0)
+    {
+      goto retry;
+    }
+
   /* Modify the saved return state with the actual saved values in the
    * TCB.  This depends on the fact that nested signal handling is
    * not supported.  Therefore, these values will persist throughout the
@@ -143,5 +150,8 @@ void xtensa_sig_deliver(void)
    */
 
   board_autoled_off(LED_SIGNAL);
+#ifdef CONFIG_SMP
+  rtcb->irqcount--;
+#endif
   xtensa_context_restore(regs);
 }


### PR DESCRIPTION
## Summary
in SMP, signal processing cannot be nested, we use xcp.sigdeliver to identify whether there is currently a signal being processed, but this state does not match the actual situation One possible scenario is that signal processing has already been completed, but an interrupt occurs, resulting in xcp.sigdeliver not being correctly set to NULL, At this point, a new signal arrives, which can only be placed in the queue and cannot be processed immediately Our solution is that signal processing and signal complete status are set in the same critical section, which can ensure status synchronization

## Impact
none

## Testing
ostest

