### PR TITLE
boards/arm/tiva: mpu6050 driver binding to TM4C1294

### DIFF
--- a/arch/arm/src/tiva/common/tiva_i2c.c
+++ b/arch/arm/src/tiva/common/tiva_i2c.c
@@ -973,7 +973,8 @@ static void tiva_i2c_tracedump(struct tiva_i2c_priv_s *priv)
     {
       trace = &priv->trace[i];
       syslog(LOG_DEBUG,
-             "%2d. STATUS: %08x COUNT: %3d EVENT: %2d PARM: %08x TIME: %d\n",
+             "%2d. STATUS: %08lx COUNT: %3ld EVENT: %2d PARM: %08lx "
+             "TIME: %ld\n",
              i + 1, trace->status, trace->count,  trace->event, trace->parm,
              trace->time - priv->ttime);
     }

--- a/boards/arm/tiva/tm4c1294-launchpad/src/tm4c_bringup.c
+++ b/boards/arm/tiva/tm4c1294-launchpad/src/tm4c_bringup.c
@@ -30,6 +30,7 @@
 
 #include <nuttx/i2c/i2c_master.h>
 #include <nuttx/sensors/bmi160.h>
+#include <nuttx/sensors/mpu60x0.h>
 #include <nuttx/sensors/qencoder.h>
 #include <arch/board/board.h>
 #include <nuttx/fs/fs.h>
@@ -186,6 +187,58 @@ static int tm4c_bmi160_setup(int bus)
   if (ret < 0)
     {
       syslog(LOG_ERR, "Error registering BMI160\n");
+    }
+
+  return ret;
+}
+#endif
+
+/****************************************************************************
+ * Name: tm4c_mpu60x0_setup
+ *
+ * Description:
+ *   Initialize and register the Invensense MPU60x0 sensor.
+ *
+ * Input Parameters:
+ *   bus - A number identifying the I2C bus.
+ *
+ * Returned Value:
+ *   On success, zero (OK) is returned. On failure, a negated errno value
+ *   is returned to indicate the nature of the failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_SENSORS_MPU60X0
+static int tm4c_mpu60x0_setup(int bus)
+{
+  int ret;
+  struct i2c_master_s *i2c;
+  struct mpu_config_s *mpu_config;
+
+  /* Initialize i2c device */
+
+  i2c = tiva_i2cbus_initialize(bus);
+  if (!i2c)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to initialize i2c%d.\n", bus);
+      return -ENODEV;
+    }
+
+  mpu_config = kmm_zalloc(sizeof(struct mpu_config_s));
+  if (mpu_config == NULL)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to allocate mpu60x0 driver\n");
+      return -ENOMEM;
+    }
+    else
+    {
+      mpu_config->i2c = i2c;
+      mpu_config->addr = 0x68;
+      ret = mpu60x0_register("/dev/imu0", mpu_config);
+      if (ret < 0)
+        {
+          syslog(LOG_ERR, "Error registering MPU60X0\n");
+        }
     }
 
   return ret;
@@ -364,6 +417,14 @@ int tm4c_bringup(void)
       syslog(LOG_ERR, "ERROR: BMI160 on 2 failed %d\n", ret);
     }
 #endif
+#endif
+
+#ifdef CONFIG_SENSORS_MPU60X0
+  ret = tm4c_mpu60x0_setup(0);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: MPU60X0 on I2C0 failed %d\n", ret);
+    }
 #endif
 
 #ifdef CONFIG_FS_PROCFS


### PR DESCRIPTION
## Summary
This is a board I'm currently using and it is has only one sensor in its bring up sequence.
This commit adds the MPU6050 driver allocation and also fixes a simple linter error found.

## Impact
One more function to the tm4c_bringup.c file.

## Testing
Tested on the MPU6050 IMU. No issues were found.
