### PR TITLE
libc/qsort: fix invalid-pointer-pair if enable detect_invalid_pointer_pairs=2

### DIFF
--- a/libs/libc/stdlib/lib_qsort.c
+++ b/libs/libc/stdlib/lib_qsort.c
@@ -67,8 +67,8 @@
   }
 
 #define SWAPINIT(a, width) \
-  swaptype = ((FAR char *)a - (FAR char *)0) % sizeof(long) || \
-  width % sizeof(long) ? 2 : width == sizeof(long)? 0 : 1;
+  swaptype = (uintptr_t)a % sizeof(long) || \
+  width % sizeof(long) ? 2 : width == sizeof(long) ? 0 : 1;
 
 #define swap(a, b) \
   if (swaptype == 0) \


### PR DESCRIPTION
## Summary


libc/qsort: fix invalid-pointer-pair if enable detect_invalid_pointer_pairs=2


```bash
================================================================= ==2920138==ERROR: AddressSanitizer: invalid-pointer-pair: 0x603000000130 0x000000000000
    #0 0x5602d3c6a89d in qsort stdlib/lib_qsort.c:180
    #1 0x5602d3c28928 in romfs_cachenode romfs/fs_romfsutil.c:503
    #2 0x5602d3c2854d in romfs_cachenode romfs/fs_romfsutil.c:486
    #3 0x5602d3c2b056 in romfs_fsconfigure romfs/fs_romfsutil.c:777
    #4 0x5602d3c24856 in romfs_bind romfs/fs_romfs.c:1111
    #5 0x5602d3bf5179 in nx_mount mount/fs_mount.c:427
    #6 0x5602d3bf5796 in mount mount/fs_mount.c:539
    #7 0x5602d3bc1154 in nsh_romfsetc apps/nshlib/nsh_romfsetc.c:110
    #8 0x5602d3b8f38d in nsh_initialize apps/nshlib/nsh_init.c:127
    #9 0x5602d3b8f2b7 in nsh_main apps/system/nsh/nsh_main.c:69
    #10 0x5602d3b7a3a6 in nxtask_startup sched/task_startup.c:70
    #11 0x5602d3b5de89 in nxtask_start task/task_start.c:134

0x603000000130 is located 0 bytes inside of 32-byte region [0x603000000130,0x603000000150) allocated by thread T0 here:
    #0 0x7fcdac74793c in __interceptor_posix_memalign ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:226
    #1 0x5602d3c9024e in host_memalign sim/posix/sim_hostmemory.c:180
    #2 0x5602d3c907d2 in host_realloc sim/posix/sim_hostmemory.c:222
    #3 0x5602d3b8aaff in mm_realloc sim/sim_heap.c:262
    #4 0x5602d3b87a6a in realloc umm_heap/umm_realloc.c:91
    #5 0x5602d3c280c4 in romfs_cachenode romfs/fs_romfsutil.c:466
    #6 0x5602d3c2854d in romfs_cachenode romfs/fs_romfsutil.c:486
    #7 0x5602d3c2b056 in romfs_fsconfigure romfs/fs_romfsutil.c:777
    #8 0x5602d3c24856 in romfs_bind romfs/fs_romfs.c:1111
    #9 0x5602d3bf5179 in nx_mount mount/fs_mount.c:427
    #10 0x5602d3bf5796 in mount mount/fs_mount.c:539
    #11 0x5602d3bc1154 in nsh_romfsetc apps/nshlib/nsh_romfsetc.c:110
    #12 0x5602d3b8f38d in nsh_initialize apps/nshlib/nsh_init.c:127
    #13 0x5602d3b8f2b7 in nsh_main apps/system/nsh/nsh_main.c:69
    #14 0x5602d3b7a3a6 in nxtask_startup sched/task_startup.c:70
    #15 0x5602d3b5de89 in nxtask_start task/task_start.c:134

Address 0x000000000000 is a wild pointer.
SUMMARY: AddressSanitizer: invalid-pointer-pair stdlib/lib_qsort.c:180 in qsort ==2920138==ABORTING
Aborted (core dumped)
```

## Impact

N/A

## Testing

asan