### PR TITLE
tools/nuttx-gdbinit/armv7-a: reorder and synchronization registers of save/restore

### DIFF
--- a/tools/nuttx-gdbinit
+++ b/tools/nuttx-gdbinit
@@ -177,46 +177,46 @@ end
 # see nuttx/arch/arm/include/armv7-a/irq.h
 define _save_tcb_armv7-a
   set $tcb = (struct tcb_s *)$arg0
-  set $tcb.xcp.regs[0] = $r0
-  set $tcb.xcp.regs[1] = $r1
-  set $tcb.xcp.regs[2] = $r2
-  set $tcb.xcp.regs[3] = $r3
-  set $tcb.xcp.regs[4] = $r4
-  set $tcb.xcp.regs[5] = $r5
-  set $tcb.xcp.regs[6] = $r6
-  set $tcb.xcp.regs[7] = $r7
-  set $tcb.xcp.regs[8] = $r8
-  set $tcb.xcp.regs[9] = $r9
-  set $tcb.xcp.regs[10] = $r10
-  set $tcb.xcp.regs[11] = $r11
-  set $tcb.xcp.regs[12] = $r12
-  set $tcb.xcp.regs[13] = $r13
-  set $tcb.xcp.regs[14] = $r14
+  set $tcb.xcp.regs[0] = $r13
+  set $tcb.xcp.regs[1] = $r14
+  set $tcb.xcp.regs[2] = $r0
+  set $tcb.xcp.regs[3] = $r1
+  set $tcb.xcp.regs[4] = $r2
+  set $tcb.xcp.regs[5] = $r3
+  set $tcb.xcp.regs[6] = $r4
+  set $tcb.xcp.regs[7] = $r5
+  set $tcb.xcp.regs[8] = $r6
+  set $tcb.xcp.regs[9] = $r7
+  set $tcb.xcp.regs[10] = $r8
+  set $tcb.xcp.regs[11] = $r9
+  set $tcb.xcp.regs[12] = $r10
+  set $tcb.xcp.regs[13] = $r11
+  set $tcb.xcp.regs[14] = $r12
   set $tcb.xcp.regs[15] = $r15
-  # TODO: xPSR
+  set $tcb.xcp.regs[16] = $cpsr
 
   set $_pc_reg_idx = 15
 end
 
 define _switch_tcb_armv7-a
   set $tcb = (struct tcb_s *)$arg0
-  set $r0 = $tcb.xcp.regs[0]
-  set $r1 = $tcb.xcp.regs[1]
-  set $r2 = $tcb.xcp.regs[2]
-  set $r3 = $tcb.xcp.regs[3]
-  set $r4 = $tcb.xcp.regs[4]
-  set $r5 = $tcb.xcp.regs[5]
-  set $r6 = $tcb.xcp.regs[6]
-  set $r7 = $tcb.xcp.regs[7]
-  set $r8 = $tcb.xcp.regs[8]
-  set $r9 = $tcb.xcp.regs[9]
-  set $r10 = $tcb.xcp.regs[10]
-  set $r11 = $tcb.xcp.regs[11]
-  set $r12 = $tcb.xcp.regs[12]
-  set $r13 = $tcb.xcp.regs[13]
-  set $r14 = $tcb.xcp.regs[14]
+  set $r13 = $tcb.xcp.regs[0]
+  set $r14 = $tcb.xcp.regs[1]
+  set $r0 = $tcb.xcp.regs[2]
+  set $r1 = $tcb.xcp.regs[3]
+  set $r2 = $tcb.xcp.regs[4]
+  set $r3 = $tcb.xcp.regs[5]
+  set $r4 = $tcb.xcp.regs[6]
+  set $r5 = $tcb.xcp.regs[7]
+  set $r6 = $tcb.xcp.regs[8]
+  set $r7 = $tcb.xcp.regs[9]
+  set $r8 = $tcb.xcp.regs[10]
+  set $r9 = $tcb.xcp.regs[11]
+  set $r10 = $tcb.xcp.regs[12]
+  set $r11 = $tcb.xcp.regs[13]
+  set $r12 = $tcb.xcp.regs[14]
   set $r15 = $tcb.xcp.regs[15]
-  # TODO: xPSR
+  set $cpsr = $tcb.xcp.regs[16]
 end
 
 # see nuttx/arch/arm/include/armv7-m/irq_cmnvector.h


### PR DESCRIPTION
## Summary

tools/nuttx-gdbinit/armv7-a: reorder and synchronization registers of save/restore

The order of the registers was changed by the following commit:

```
---------------------------------
| armv7-a/r: modify regs index to improve exception performance
|
| Signed-off-by: zhangyuan21 <zhangyuan21@xiaomi.com>

```
Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

qemu cortex-a7