### PR TITLE
tools/Unix: treat kconfig warning as failure 

### DIFF
--- a/drivers/syslog/Kconfig
+++ b/drivers/syslog/Kconfig
@@ -277,7 +277,7 @@ config SYSLOG_RPMSG_WORK_DELAY
 
 config SYSLOG_RPMSG_CHARDEV
 	bool "SYSLOG rpmsg character device"
-	default !SYSLOG_RPMSG_WORK_DELAY
+	default SYSLOG_RPMSG_WORK_DELAY != 0
 
 endif # SYSLOG_RPMSG
 

--- a/tools/Unix.mk
+++ b/tools/Unix.mk
@@ -624,7 +624,14 @@ define kconfig_tweak_disable
 	kconfig-tweak --file $1 -u $2
 endef
 else
-  PURGE_MODULE_WARNING  = 2> >(grep -v "warning: the 'modules' option is not supported")
+  KCONFIG_WARNING       = if [ -s kwarning ]; \
+                            then rm kwarning; \
+                              exit 1; \
+                            else \
+                              rm kwarning; \
+                          fi
+  MODULE_WARNING        = "warning: the 'modules' option is not supported"
+  PURGE_MODULE_WARNING  = 2> >(grep -v ${MODULE_WARNING} | tee kwarning) && ${KCONFIG_WARNING}
   KCONFIG_OLDCONFIG     = oldconfig ${PURGE_MODULE_WARNING}
   KCONFIG_OLDDEFCONFIG  = olddefconfig ${PURGE_MODULE_WARNING}
   KCONFIG_MENUCONFIG    = menuconfig ${PURGE_MODULE_WARNING}


### PR DESCRIPTION
## Summary

tools/Unix: treat kconfig warning as failure 

The syntax check of kconfiglib is stricter than kconfig-frontends,
but the warnings of kconfiglib are not catched by Makefile. Since kconfiglib
is implemented by python, the return value of the shell is always zero($?),
In this PR, I redirected the relevant standard errors to the file to check
whether the kconfig warning is occurred


## Impact

N/A

## Testing

ci-check