### PR TITLE
udp: change PKTINFO flag to socket_conn_s struct

### DIFF
--- a/include/netinet/in.h
+++ b/include/netinet/in.h
@@ -126,10 +126,10 @@
 #define IPV6_UNICAST_HOPS     (__SO_PROTOCOL + 6)  /* Unicast hop limit */
 #define IPV6_V6ONLY           (__SO_PROTOCOL + 7)  /* Restrict AF_INET6 socket
                                                     * to IPv6 communications only */
-#define IPV6_PKTINFO          (__SO_PROTOCOL + 8)  /* Get some information about
+#define IPV6_PKTINFO          (__SO_PROTOCOL + 8)  /* Information about the
+                                                    * incoming packet */
+#define IPV6_RECVPKTINFO      (__SO_PROTOCOL + 9)  /* Receive the information about
                                                     * the incoming packet */
-#define IPV6_RECVPKTINFO      (__SO_PROTOCOL + 9)  /* It functions just same as
-                                                    * IPV6_PKTINFO for now */
 #define IPV6_TCLASS           (__SO_PROTOCOL + 10) /* Access the Traffic Class
                                                     * field */
 

--- a/include/nuttx/net/net.h
+++ b/include/nuttx/net/net.h
@@ -117,7 +117,7 @@ enum net_lltype_e
 
 /* This defines a bitmap big enough for one bit for each socket option */
 
-typedef uint16_t sockopt_t;
+typedef uint32_t sockopt_t;
 
 /* This defines the storage size of a timeout value.  This effects only
  * range of supported timeout values.  With an LSB in seciseconds, the

--- a/net/inet/ipv6_setsockopt.c
+++ b/net/inet/ipv6_setsockopt.c
@@ -34,9 +34,9 @@
 
 #include "mld/mld.h"
 #include "inet/inet.h"
-#include "udp/udp.h"
+#include "socket/socket.h"
 
-#ifdef CONFIG_NET_IPv6
+#if defined(CONFIG_NET_IPv6) && defined(CONFIG_NET_SOCKOPTS)
 
 /****************************************************************************
  * Public Functions
@@ -127,15 +127,12 @@ int ipv6_setsockopt(FAR struct socket *psock, int option,
         ret = -ENOSYS;
         break;
 
-#ifdef NET_UDP_HAVE_STACK
-      case IPV6_PKTINFO:
       case IPV6_RECVPKTINFO:
         {
-          FAR struct udp_conn_s *conn;
+          FAR struct socket_conn_s *conn;
           int enable;
 
-          if (psock->s_type != SOCK_DGRAM ||
-              value == NULL || value_len == 0)
+          if (value == NULL || value_len == 0)
             {
               ret = -EINVAL;
               break;
@@ -143,20 +140,19 @@ int ipv6_setsockopt(FAR struct socket *psock, int option,
 
           enable = (value_len >= sizeof(int)) ?
             *(FAR int *)value : (int)*(FAR unsigned char *)value;
-          conn = (FAR struct udp_conn_s *)psock->s_conn;
+          conn = psock->s_conn;
           if (enable)
             {
-              conn->flags |= _UDP_FLAG_PKTINFO;
+              _SO_SETOPT(conn->s_options, option);
             }
           else
             {
-              conn->flags &= ~_UDP_FLAG_PKTINFO;
+              _SO_CLROPT(conn->s_options, option);
             }
 
           ret = OK;
         }
         break;
-#endif
 
       case IPV6_TCLASS:
         {

--- a/net/udp/udp.h
+++ b/net/udp/udp.h
@@ -70,7 +70,6 @@
 /* Definitions for the UDP connection struct flag field */
 
 #define _UDP_FLAG_CONNECTMODE (1 << 0) /* Bit 0:  UDP connection-mode */
-#define _UDP_FLAG_PKTINFO     (1 << 1) /* Bit 1:  UDP PKTINFO */
 
 #define _UDP_ISCONNECTMODE(f) (((f) & _UDP_FLAG_CONNECTMODE) != 0)
 

--- a/net/udp/udp_recvfrom.c
+++ b/net/udp/udp_recvfrom.c
@@ -62,19 +62,16 @@ struct udp_recvfrom_s
  * Private Functions
  ****************************************************************************/
 
+#ifdef CONFIG_NET_SOCKOPTS
 static void udp_recvpktinfo(FAR struct udp_recvfrom_s *pstate,
                             FAR void *srcaddr, uint8_t ifindex)
 {
   FAR struct msghdr     *msg  = pstate->ir_msg;
   FAR struct udp_conn_s *conn = pstate->ir_conn;
 
-  if (!(conn->flags & _UDP_FLAG_PKTINFO))
-    {
-      return;
-    }
-
 #ifdef CONFIG_NET_IPv4
-  if (conn->domain == PF_INET)
+  if (conn->domain == PF_INET &&
+      _SO_GETOPT(conn->sconn.s_options, IP_PKTINFO))
     {
       FAR struct sockaddr_in *infrom = srcaddr;
       FAR struct in_pktinfo   pktinfo;
@@ -88,7 +85,8 @@ static void udp_recvpktinfo(FAR struct udp_recvfrom_s *pstate,
 #endif
 
 #ifdef CONFIG_NET_IPv6
-  if (conn->domain == PF_INET6)
+  if (conn->domain == PF_INET6 &&
+      _SO_GETOPT(conn->sconn.s_options, IPV6_RECVPKTINFO))
     {
       FAR struct sockaddr_in6 *infrom = srcaddr;
       FAR struct in6_pktinfo   pktinfo;
@@ -101,6 +99,9 @@ static void udp_recvpktinfo(FAR struct udp_recvfrom_s *pstate,
     }
 #endif
 }
+#else
+#define udp_recvpktinfo(p, s, i) {(void)(p); (void)(s); (void)(i);}
+#endif
 
 /****************************************************************************
  * Name: udp_recvfrom_newdata
@@ -175,7 +176,7 @@ static inline void udp_readahead(struct udp_recvfrom_s *pstate)
 #ifdef CONFIG_NETDEV_IFINDEX
       ifindex = iob->io_data[offset++];
 #else
-      ifindex = 0;
+      ifindex = 1;
 #endif
       src_addr_size = iob->io_data[offset++];
       srcaddr = &iob->io_data[offset];
@@ -320,7 +321,7 @@ static inline void udp_sender(FAR struct net_driver_s *dev,
 #ifdef CONFIG_NETDEV_IFINDEX
   udp_recvpktinfo(pstate, srcaddr, dev->d_ifindex);
 #else
-  udp_recvpktinfo(pstate, srcaddr, 0);
+  udp_recvpktinfo(pstate, srcaddr, 1);
 #endif
 }
 


### PR DESCRIPTION
## Summary
move the IPPROTO_IP/IPPROTO_IPV6 flag into the socket_conn_s structure to make it more than just control udp.

## Impact

## Testing
sim:local
