### PR TITLE
arch/arm/sama5: Fix OHCI SchedulingOverrun interrupt storm.

### DIFF
--- a/arch/arm/src/sama5/sam_ohci.c
+++ b/arch/arm/src/sama5/sam_ohci.c
@@ -1330,6 +1330,8 @@ static inline int sam_reminted(struct sam_ed_s *ed)
            */
 
           prev->hw.nexted = ed->hw.nexted;
+          up_clean_dcache((uintptr_t)prev,
+                          (uintptr_t)prev + sizeof(struct ohci_ed_s));
         }
 
 #ifdef CONFIG_USBHOST_TRACE


### PR DESCRIPTION
## Summary

The following message is printed continuously and the nsh shell is unusable on sama5d3-xplained.
"OHCI ERROR: Unhandled interrupts pending: 000001". This happens when a keyboard is removed and reinserted on port3 (lower port) while a bluetooth dongle is in port2.

## Impact
Less OHCI bugs on sama5

## Testing
There are probably many ways to trigger this bug. 
Unplugging a USB keyboard and quickly reinserting it causes the message (see above) to be printed forever. NuttX has to start with both the keyboard and BT dongle plugged in.
