### PR TITLE
arch/arm/src/common/tiva_i2c.c: Fix i2c message buffer error

### DIFF
--- a/arch/arm/src/tiva/common/tiva_i2c.c
+++ b/arch/arm/src/tiva/common/tiva_i2c.c
@@ -1284,6 +1284,7 @@ static int tiva_i2c_process(struct tiva_i2c_priv_s *priv, uint32_t status)
                            * change
                            */
 
+                          priv->mptr = priv->msgv->buffer;
                           tiva_i2c_nextxfr(priv, 0);
                         }
                       else


### PR DESCRIPTION
## Summary
This same issue (#5003) happened to me. I went all in and maybe found a solution.

When a single I2C message struct with multiple messages in the buffer is written, the process works fine.
When two I2C messages structs are sent, each with a single message in the buffer, the write process fails.

The snippet below is extracted from the bmp280_putreg8 function of the bmp280.c. The txbuffer has 2 values: one for address and one for value. Both are sent in the same i2c_msg_s struct, as can be seen by the 3rd argument on I2C_TRANSFER. **This driver works fine.**
```
  struct i2c_msg_s msg[2];
  uint8_t txbuffer[2];
  int ret;

  txbuffer[0] = regaddr;
  txbuffer[1] = regval;
  [....]
  msg[0].buffer    = txbuffer;
  msg[0].length    = 2;

  ret = I2C_TRANSFER(priv->i2c, msg, 1);
```

The next snippet is from the __mpu_write_reg_i2c function of the mpu60x0.c. It has one i2c_msg_s struct for the address and one for the data. That's two messages for the I2C_TRANSFER. **This driver does not work.**
```
  struct i2c_msg_s msg[2];
  [....]
  msg[0].buffer    = &reg_addr;
  msg[0].length    = 1;
  msg[1].flags     = I2C_M_NOSTART;
  [....]
  msg[1].buffer    = (FAR uint8_t *)buf;
  msg[1].length    = len;
  ret = I2C_TRANSFER(dev->config.i2c, msg, 2);
```

The Tiva driver on tiva_i2c.c understands the single message struct just fine. It does not accept it gracefully when two strucs are received. The reason is that the data inserted in the I2C data register corresponds to:
`dr = (uint32_t)*priv->mptr++;
`
where priv->mptr++ only works if the next data to be sent is the next value in the message buffer. When using
the MPU6050, the driver sends two structs which is not taken into consideration by tiva_i2c.c. The result is that the some values written are pure garbage.

It's important to mention that **the same problem occurs when using the I2C Tool (i2c set)** and it is easy to reproduce. I think that the fact it fails on the I2C tool shows that its not a MPU6050 driver fault. Here's an example:

```
nsh> i2c set -b 0 -a 0x68 -r 0x6b 0x1
[   42.510000] i2cdrvr_ioctl: cmd=2101 arg=20009ee0
[   42.510000] tiva_i2c_transfer: I2C0: msgc=2
[   42.520000] tiva_i2c_setclock: I2C0: frequency: 400000
[   42.520000] tiva_i2c_putreg: 40020000<-000000d0
[   42.520000] tiva_i2c_putreg: 40020008<-0000006b  ---> I2C Data register received 0x6b (correct)
[   42.530000] tiva_i2c_putreg: 40020004<-00000003
[   42.530000] tiva_i2c_putreg: 40020010<-00000001
[   42.540000] tiva_i2c_getreg: 40020018->00000001
[   42.540000] tiva_i2c_putreg: 4002001c<-00000001
[   42.540000] tiva_i2c_getreg: 40020018->00000000
[   42.540000] tiva_i2c_getreg: 40020004->00000040
[   42.540000] tiva_i2c_getreg: 40020008->00000040  ---> I2C Data register received 0x40 (wrong, should be 0x1)
[   42.540000] tiva_i2c_putreg: 40020008<-000000a0
[   42.540000] tiva_i2c_putreg: 40020004<-00000005
[   42.550000] tiva_i2c_getreg: 40020018->00000001
[   42.550000] tiva_i2c_putreg: 4002001c<-00000001
[   42.550000] tiva_i2c_getreg: 40020018->00000000
[   42.550000] tiva_i2c_getreg: 40020004->00000020
[   42.550000] tiva_i2c_getreg: 40020008->00000040
[   42.550000] tiva_i2c_putreg: 40020010<-00000000
[   42.560000] tiva_i2c_checkreg: ...[Repeats 1 times]...
[   42.560000] tiva_i2c_getreg: 40020004->00000020
WROTE Bus: 0 Addr: 68 Subaddr: 6b Value: 01              ---> Should have written 0x1
```

A read from the same register shows the value 0x40.
```
nsh> i2c get -r 0x6b 1
[....]
READ Bus: 0 Addr: 68 Subaddr: 6b Value: 40
```

My solution was to update the current message buffer with data of the current priv->msgv in the write process.

## Impact
Solves the issue of wrong values written to I2C devices, using the Tiva boards. This is mostly noted when using 'i2c set' of the I2C Tool and when using the MPU6050, which would always write the correct register but garbage data.

## Testing
The solution commited here was tested on the BMP280 and MPU6050. However some feedback on this would be appreciated, since I'm not sure if the fix broke something else. Any recommendations are appreciated.


TL;DR: tiva_i2c.c did not seem to update the current message buffer before putting the data in the I2C data register. This wall of text was necessary to show the debug process.
