### PR TITLE
Fix stm32f0l0g0 GPIO definitions

### DIFF
--- a/arch/arm/include/stm32f0l0g0/chip.h
+++ b/arch/arm/include/stm32f0l0g0/chip.h
@@ -50,7 +50,7 @@
 #  define STM32_NDAC            0  /* One DAC channel */
 #  define STM32_NCOMP           0  /* Two Analog Comparators */
 #  define STM32_NCAP            0  /* Capacitive sensing channels (14 on UFQFPN32)) */
-#  define STM32_NPORTS          5  /* Six GPIO ports, GPIOA-F */
+#  define STM32_NPORTS          5  /* Five GPIO ports, GPIOA-D, F */
 
 #elif defined(CONFIG_ARCH_CHIP_STM32F051R8)
 
@@ -244,7 +244,7 @@
 #  define STM32_NCRC            1  /* No CRC module */
 #  define STM32_NRNG            0  /* No Random number generator (RNG) */
 #  define STM32_NCAP            0  /* No Capacitive sensing channels */
-#  define STM32_NPORTS          5  /* Five GPIO ports, GPIOA-D, F */
+#  define STM32_NPORTS          6  /* Six GPIO ports, GPIOA-F */
 
 #elif defined(CONFIG_ARCH_CHIP_STM32G071EB)   || defined(CONFIG_ARCH_CHIP_STM32G071G8)   || \
       defined(CONFIG_ARCH_CHIP_STM32G071GB)   || defined(CONFIG_ARCH_CHIP_STM32G071G8XN) || \
@@ -277,7 +277,7 @@
 #  define STM32_NCRC            0  /* No CRC module */
 #  define STM32_NRNG            0  /* No Random number generator (RNG) */
 #  define STM32_NCAP            0  /* No Capacitive sensing channels */
-#  define STM32_NPORTS          6  /* Six GPIO ports, GPIOA-E, H */
+#  define STM32_NPORTS          6  /* Six GPIO ports, GPIOA-F */
 
 /* STM32L EnergyLite Line ***************************************************/
 

--- a/arch/arm/src/stm32f0l0g0/hardware/stm32g0_memorymap.h
+++ b/arch/arm/src/stm32f0l0g0/hardware/stm32g0_memorymap.h
@@ -112,6 +112,7 @@
 #define STM32_GPIOB_BASE     0x50000400     /* 0x50000400-0x500007ff: GPIO Port B */
 #define STM32_GPIOC_BASE     0x50000800     /* 0x50000800-0x50000bff: GPIO Port C */
 #define STM32_GPIOD_BASE     0X50000C00     /* 0x50000c00-0x50000fff: GPIO Port D */
+#define STM32_GPIOE_BASE     0X50001000     /* 0x50001000-0x500013ff: GPIO Port E */
 #define STM32_GPIOF_BASE     0x50001400     /* 0x50001400-0x500017ff: GPIO Port F */
 
 /* Cortex-M4 Base Addresses *************************************************/

--- a/arch/arm/src/stm32f0l0g0/stm32_gpio.h
+++ b/arch/arm/src/stm32f0l0g0/stm32_gpio.h
@@ -186,8 +186,16 @@
 #  define GPIO_PORTB                  (1 << GPIO_PORT_SHIFT)     /*   GPIOB */
 #  define GPIO_PORTC                  (2 << GPIO_PORT_SHIFT)     /*   GPIOC */
 #  define GPIO_PORTD                  (3 << GPIO_PORT_SHIFT)     /*   GPIOD */
+#if defined (CONFIG_STM32F0L0G0_STM32F03X)
+#  define GPIO_PORTF                  (4 << GPIO_PORT_SHIFT)     /*   GPIOF */
+#else
 #  define GPIO_PORTE                  (4 << GPIO_PORT_SHIFT)     /*   GPIOE */
+#if defined (CONFIG_ARCH_CHIP_STM32L0)
+#  define GPIO_PORTH                  (5 << GPIO_PORT_SHIFT)     /*   GPIOH */
+#else
 #  define GPIO_PORTF                  (5 << GPIO_PORT_SHIFT)     /*   GPIOF */
+#endif
+#endif
 
 /* This identifies the bit in the port:
  *


### PR DESCRIPTION
## Summary

Fix definitions for GPIOs in stm32f0l0g0 series.

## Impact

Some chips in stm32f0l0g0 series cannot use specific GPIO ports that they have.

## Testing