### PR TITLE
driver/serial/pty.c fix update local flags for the pty device attribute

### DIFF
--- a/drivers/serial/pty.c
+++ b/drivers/serial/pty.c
@@ -714,6 +714,7 @@ static int pty_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
           dev->pd_iflag = termiosp->c_iflag;
           dev->pd_oflag = termiosp->c_oflag;
+          dev->pd_lflag = termiosp->c_lflag;
           ret = OK;
         }
         break;


### PR DESCRIPTION
## Summary

Version 12.1.0 introduces an `ECHO` attribute for pty which is recorded in the local flags. Hence, we also need to update the local flags as well if we are about to set the terminal attribute.

## Impact

Without updating the local flag, any changing of the local flags won't take effect. For example, the user can't prevent the slave device from echoing back data to the master device.

## Testing

