### PR TITLE
in.h: add SOL_IPV6 protocol-level socket options IPV6_RECVHOPLIMIT

### DIFF
--- a/include/netinet/in.h
+++ b/include/netinet/in.h
@@ -132,6 +132,8 @@
                                                     * the incoming packet */
 #define IPV6_TCLASS           (__SO_PROTOCOL + 10) /* Access the Traffic Class
                                                     * field */
+#define IPV6_RECVHOPLIMIT     (__SO_PROTOCOL + 11) /* Access the hop limit field */
+#define IPV6_HOPLIMIT         (__SO_PROTOCOL + 12) /* Hop limit */
 
 /* Values used with SIOCSIFMCFILTER and SIOCGIFMCFILTER ioctl's */
 

--- a/net/icmpv6/icmpv6.h
+++ b/net/icmpv6/icmpv6.h
@@ -651,7 +651,7 @@ ssize_t icmpv6_sendmsg(FAR struct socket *psock, FAR struct msghdr *msg,
  * Description:
  *   Implements the socket recvfrom interface for the case of the AF_INET
  *   data gram socket with the IPPROTO_ICMP6 protocol.  icmpv6_recvmsg()
- *   receives ICMPv6 ECHO replies for the a socket.
+ *   receives ICMPv6 message for the a socket.
  *
  *   If msg_name is not NULL, and the underlying protocol provides the source
  *   address, this source address is filled in. The argument 'msg_namelen' is

--- a/net/icmpv6/icmpv6_input.c
+++ b/net/icmpv6/icmpv6_input.c
@@ -111,6 +111,7 @@ static uint16_t icmpv6_datahandler(FAR struct net_driver_s *dev,
   FAR struct ipv6_hdr_s *ipv6;
   struct sockaddr_in6 inaddr;
   FAR struct iob_s *iob;
+  unsigned int offset;
   uint16_t buflen;
   int ret;
 
@@ -132,8 +133,11 @@ static uint16_t icmpv6_datahandler(FAR struct net_driver_s *dev,
    */
 
   memcpy(iob->io_data, &inaddr, sizeof(struct sockaddr_in6));
+  offset = sizeof(struct sockaddr_in6);
 
-  iob_reserve(iob, sizeof(struct sockaddr_in6));
+  iob->io_data[offset++] = ipv6->ttl;
+
+  iob_reserve(iob, offset);
 
   /* Copy the ICMPv6 message into the I/O buffer chain (without waiting) */
 

--- a/net/inet/ipv6_setsockopt.c
+++ b/net/inet/ipv6_setsockopt.c
@@ -128,6 +128,7 @@ int ipv6_setsockopt(FAR struct socket *psock, int option,
         break;
 
       case IPV6_RECVPKTINFO:
+      case IPV6_RECVHOPLIMIT:
         {
           FAR struct socket_conn_s *conn;
           int enable;


### PR DESCRIPTION
## Summary
added IPV6_RECVHOPLIMIT support so that fd of SOCK_RAW ICMPV6 can obtain ttl information, some network related tools use this feature.

## Impact

## Testing
sim:local
