### PR TITLE
tools/refresh.sh: Add option to refresh all archs or all chips

### DIFF
--- a/tools/refresh.sh
+++ b/tools/refresh.sh
@@ -68,10 +68,16 @@ while [ ! -z "$1" ]; do
     echo "  --help"
     echo "     Show this help message and exit"
     echo "  <board>"
-    echo "     The board directory under nuttx/boards"
+    echo "     The board directory under nuttx/boards/arch/chip/"
     echo "  <config>"
-    echo "     The board configuration directory under nuttx/boards/<board>/configs"
-    echo "  Note: all configuration is refreshed if <board>:<config> equals all."
+    echo "     The board configuration directory under nuttx/boards/arch/chip/<board>/configs"
+    echo "  <archname>"
+    echo "     The architecture directory under nuttx/boards/"
+    echo "  <chipname>"
+    echo "     The chip family directory under nuttx/boards/<arch>/"
+    echo "  Note1: all configuration is refreshed if <board>:<config> equals all."
+    echo "  Note2: all configuration of arch XYZ is refreshed if \"arch:<namearch>\" is passed"
+    echo "  Note3: all configuration of chip XYZ is refreshed if \"chip:<chipname>\" is passed"
     exit 0
     ;;
   * )
@@ -106,7 +112,22 @@ if [ -z "${CONFIGS}" ]; then
 fi
 
 if [ "X${CONFIGS}" == "Xall" ]; then
+  echo "Normalizing all boards!"
   CONFIGS=`find boards -name defconfig | cut -d'/' -f4,6`
+else
+  if [[ "X${CONFIGS}" == "Xarch:"* ]]; then
+    IFS=: read -r atype archname <<< "${CONFIGS}"
+    ARCH=$archname
+    echo "Normalizing all boards in arch: ${ARCH} !"
+    CONFIGS=`find boards/${ARCH} -name defconfig | cut -d'/' -f4,6`
+  else
+    if [[ "X${CONFIGS}" == "Xchip:"* ]]; then
+      IFS=: read -r atype chipname <<< "${CONFIGS}"
+      CHIP=$chipname
+      echo "Normalizing all boards in chip: ${CHIP} !"
+      CONFIGS=`find boards/*/${CHIP} -name defconfig | cut -d'/' -f4,6`
+    fi
+  fi
 fi
 
 for CONFIG in ${CONFIGS}; do


### PR DESCRIPTION
## Summary
Currently when we modify some Kconfig related to some chip or some architecture we need to run refresh.sh to all boards that is too slow (more than one hour to finish).

This patch modify the script to update only the boards configs of an specific chip or only the boards of an specific architecture.

Examples:

$ ./tools/refresh.sh --silent --defaults arch renesas
  Normalize us7032evb1/ostest
  Normalize us7032evb1/nsh
  Normalize skp16c26/ostest
  Normalize rx65n-rsk2mb/netnsh
  Normalize rx65n-rsk2mb/ipv6
  Normalize rx65n-rsk2mb/nsh
  Normalize rx65n-rsk1mb/netnsh
  Normalize rx65n-rsk1mb/nsh
  Normalize rx65n-grrose/netnsh
  Normalize rx65n-grrose/ipv6
  Normalize rx65n-grrose/nsh
  Normalize rx65n/nsh

It updates the boards from all 'renesas' architecture (m9c, rx65n, sh1)

$ ./tools/refresh.sh --silent --defaults chip rx65n
  Normalize rx65n-rsk2mb/netnsh
  Normalize rx65n-rsk2mb/ipv6
  Normalize rx65n-rsk2mb/nsh
  Normalize rx65n-rsk1mb/netnsh
  Normalize rx65n-rsk1mb/nsh
  Normalize rx65n-grrose/netnsh
  Normalize rx65n-grrose/ipv6
  Normalize rx65n-grrose/nsh
  Normalize rx65n/nsh

It updates all the boards from renesas chip 'rx65n' family

## Impact
Now we don't need to wait hours the get update done for some board architecture or board chip family.

## Testing
Basic test using sim, and other boards
