### PR TITLE
net/net_cmsg.c: Fix warning about using void* arithmetics

### DIFF
--- a/net/utils/net_cmsg.c
+++ b/net/utils/net_cmsg.c
@@ -79,7 +79,7 @@ FAR void *cmsg_append(FAR struct msghdr *msg, int level, int type,
       memcpy(cmsgdata, value, value_len);
     }
 
-  msg->msg_control    += cmsgspace;
+  msg->msg_control     = (char *)msg->msg_control + cmsgspace;
   msg->msg_controllen -= cmsgspace;
 
   return cmsgdata;


### PR DESCRIPTION
## Summary
utils/net_cmsg.c: In function 'cmsg_append':
utils/net_cmsg.c:82:23: error: pointer of type 'void *' used in arithmetic [-Werror=pointer-arith]
   82 |   msg->msg_control    += cmsgspace;
      |                       ^~
cc1: all warnings being treated as errors

Using void pointers in arithmetic operations is a GCC extension, it is not supported by the standard. Because what is the size of a void ?
## Impact
Fixes build error with -Werror -Wall -Wextra
## Testing
CI passes
