### PR TITLE
xtensa/esp32: Fix himem driver crash in SMP mode

### DIFF
--- a/arch/xtensa/src/esp32/esp32_spiram.c
+++ b/arch/xtensa/src/esp32/esp32_spiram.c
@@ -34,6 +34,7 @@
 #include <sys/param.h>
 #include <nuttx/config.h>
 #include <nuttx/spinlock.h>
+#include <nuttx/init.h>
 
 #include "esp32_spiram.h"
 #include "esp32_spicache.h"
@@ -85,7 +86,9 @@ unsigned int IRAM_ATTR cache_sram_mmu_set(int cpu_no, int pid,
   uint32_t regval;
   uint32_t statecpu0;
 #ifdef CONFIG_SMP
+  int cpu_to_stop = 0;
   uint32_t statecpu1;
+  bool smp_start = OSINIT_OS_READY();
 #endif
   unsigned int i;
   unsigned int shift;
@@ -168,13 +171,23 @@ unsigned int IRAM_ATTR cache_sram_mmu_set(int cpu_no, int pid,
    * the flash guards to make sure the cache is disabled.
    */
 
-  flags = spin_lock_irqsave(NULL);
-
-  spi_disable_cache(0, &statecpu0);
+  flags = enter_critical_section();
 
 #ifdef CONFIG_SMP
+  /* The other CPU might be accessing the cache at the same time, just by
+   * using variables in external RAM.
+   */
+
+  if (smp_start)
+    {
+      cpu_to_stop = up_cpu_index() == 1 ? 0 : 1;
+      up_cpu_pause(cpu_to_stop);
+    }
+
   spi_disable_cache(1, &statecpu1);
 #endif
+
+  spi_disable_cache(0, &statecpu0);
 
   /* mmu change */
 
@@ -203,9 +216,14 @@ unsigned int IRAM_ATTR cache_sram_mmu_set(int cpu_no, int pid,
   spi_enable_cache(0, statecpu0);
 #ifdef CONFIG_SMP
   spi_enable_cache(1, statecpu1);
+
+  if (smp_start)
+    {
+      up_cpu_resume(cpu_to_stop);
+    }
 #endif
 
-  spin_unlock_irqrestore(NULL, flags);
+  leave_critical_section(flags);
   return 0;
 }
 


### PR DESCRIPTION
## Summary

Fix himem driver crash in SMP mode.

The thing is, the other CPU might be accessing the cache at the same time, just by using variables in external RAM. So it is using a "resource" for which there is no spinlock.
The point is to prevent any access to cache from another CPU while the first CPU is modifying the MMU table. This can be done either by suspending the other CPU, or by preempting the tasks which run on another CPU and making sure that only code from internal RAM is executed.

## Impact

## Testing

