### PR TITLE
net: remove conn-related casts

### DIFF
--- a/net/bluetooth/bluetooth_recvmsg.c
+++ b/net/bluetooth/bluetooth_recvmsg.c
@@ -308,8 +308,7 @@ ssize_t bluetooth_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
   size_t len = msg->msg_iov->iov_len;
   FAR struct sockaddr *from = msg->msg_name;
   FAR socklen_t *fromlen = &msg->msg_namelen;
-  FAR struct bluetooth_conn_s *conn =
-    (FAR struct bluetooth_conn_s *)psock->s_conn;
+  FAR struct bluetooth_conn_s *conn = psock->s_conn;
   FAR struct radio_driver_s *radio;
   struct bluetooth_recvfrom_s state;
   ssize_t ret;

--- a/net/bluetooth/bluetooth_sendmsg.c
+++ b/net/bluetooth/bluetooth_sendmsg.c
@@ -254,7 +254,7 @@ static ssize_t bluetooth_sendto(FAR struct socket *psock,
       return -EBADF;
     }
 
-  conn = (FAR struct bluetooth_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
 
   /* Verify that the address is large enough to be a valid PF_BLUETOOTH
    * address.
@@ -416,7 +416,7 @@ static ssize_t bluetooth_l2cap_send(FAR struct socket *psock,
   FAR struct bluetooth_conn_s *conn;
   ssize_t ret;
 
-  conn = (FAR struct bluetooth_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
   DEBUGASSERT(conn != NULL);
 
   if (!_SS_ISCONNECTED(conn->bc_conn.s_flags))

--- a/net/bluetooth/bluetooth_sockif.c
+++ b/net/bluetooth/bluetooth_sockif.c
@@ -211,7 +211,7 @@ static void bluetooth_addref(FAR struct socket *psock)
   DEBUGASSERT(psock != NULL && psock->s_conn != NULL &&
               (psock->s_type == SOCK_RAW || psock->s_type == SOCK_CTRL));
 
-  conn = (FAR struct bluetooth_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
   DEBUGASSERT(conn->bc_crefs > 0 && conn->bc_crefs < 255);
   conn->bc_crefs++;
 }
@@ -251,7 +251,7 @@ static int bluetooth_connect(FAR struct socket *psock,
   int ret = OK;
 
   DEBUGASSERT(psock != NULL || addr != NULL);
-  conn = (FAR struct bluetooth_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
   DEBUGASSERT(conn != NULL);
 
   /* Verify the address family */
@@ -395,7 +395,7 @@ static int bluetooth_l2cap_bind(FAR struct socket *psock,
       return -EBADF;
     }
 
-  conn = (FAR struct bluetooth_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
 
   /* Verify that the socket is not already bound. */
 
@@ -468,7 +468,7 @@ static int bluetooth_hci_bind(FAR struct socket *psock,
       return -EBADF;
     }
 
-  conn = (FAR struct bluetooth_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
 
   /* Verify that the socket is not already bound. */
 
@@ -523,7 +523,7 @@ static int bluetooth_getsockname(FAR struct socket *psock,
 
   DEBUGASSERT(psock != NULL && addr != NULL && addrlen != NULL);
 
-  conn = (FAR struct bluetooth_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
   DEBUGASSERT(conn != NULL);
 
   /* Create a copy of the full address on the stack */
@@ -590,7 +590,7 @@ static int bluetooth_getpeername(FAR struct socket *psock,
       return -EPFNOSUPPORT;
     }
 
-  conn = (FAR struct bluetooth_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
   DEBUGASSERT(conn != NULL);
 
   /* Create a copy of the full address on the stack */

--- a/net/can/can_getsockopt.c
+++ b/net/can/can_getsockopt.c
@@ -82,7 +82,7 @@ int can_getsockopt(FAR struct socket *psock, int level, int option,
 
   DEBUGASSERT(psock != NULL && value != NULL && value_len != NULL &&
               psock->s_conn != NULL);
-  conn = (FAR struct can_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
 
 #ifdef CONFIG_NET_TIMESTAMP
   if (level == SOL_SOCKET && option == SO_TIMESTAMP)

--- a/net/can/can_recvmsg.c
+++ b/net/can/can_recvmsg.c
@@ -472,7 +472,7 @@ ssize_t can_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
 
   DEBUGASSERT(psock != NULL && psock->s_conn != NULL);
 
-  conn = (FAR struct can_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
 
   if (psock->s_type != SOCK_RAW)
     {

--- a/net/can/can_sendmsg.c
+++ b/net/can/can_sendmsg.c
@@ -185,7 +185,7 @@ ssize_t can_sendmsg(FAR struct socket *psock, FAR struct msghdr *msg,
       return -EDESTADDRREQ;
     }
 
-  conn = (FAR struct can_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
 
   /* Get the device driver that will service this transfer */
 

--- a/net/can/can_setsockopt.c
+++ b/net/can/can_setsockopt.c
@@ -80,7 +80,7 @@ int can_setsockopt(FAR struct socket *psock, int level, int option,
   DEBUGASSERT(psock != NULL && psock->s_conn != NULL);
   DEBUGASSERT(value_len == 0 || value != NULL);
 
-  conn = (FAR struct can_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
 
 #ifdef CONFIG_NET_TIMESTAMP
 

--- a/net/can/can_sockif.c
+++ b/net/can/can_sockif.c
@@ -318,7 +318,7 @@ static int can_bind(FAR struct socket *psock,
   /* Save the address information in the connection structure */
 
   canaddr = (FAR struct sockaddr_can *)addr;
-  conn    = (FAR struct can_conn_s *)psock->s_conn;
+  conn    = psock->s_conn;
 
   /* Bind CAN device to socket */
 
@@ -366,7 +366,7 @@ static int can_poll_local(FAR struct socket *psock, FAR struct pollfd *fds,
   int ret = OK;
 
   DEBUGASSERT(psock != NULL && psock->s_conn != NULL);
-  conn = (FAR struct can_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
   info = conn->pollinfo;
 
   /* FIXME add NETDEV_DOWN support */

--- a/net/ieee802154/ieee802154_recvmsg.c
+++ b/net/ieee802154/ieee802154_recvmsg.c
@@ -308,8 +308,7 @@ ssize_t ieee802154_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
   size_t len = msg->msg_iov->iov_len;
   FAR struct sockaddr *from = msg->msg_name;
   FAR socklen_t *fromlen = &msg->msg_namelen;
-  FAR struct ieee802154_conn_s *conn =
-    (FAR struct ieee802154_conn_s *)psock->s_conn;
+  FAR struct ieee802154_conn_s *conn = psock->s_conn;
   FAR struct radio_driver_s *radio;
   struct ieee802154_recvfrom_s state;
   ssize_t ret;

--- a/net/ieee802154/ieee802154_sendmsg.c
+++ b/net/ieee802154/ieee802154_sendmsg.c
@@ -178,7 +178,7 @@ static void ieee802154_meta_data(FAR struct radio_driver_s *radio,
   psock    = pstate->is_sock;
   DEBUGASSERT(psock->s_conn != NULL);
 
-  conn     = (FAR struct ieee802154_conn_s *)psock->s_conn;
+  conn     = psock->s_conn;
   srcaddr  = &conn->laddr;
   destaddr = &pstate->is_destaddr;
 
@@ -443,7 +443,7 @@ static ssize_t ieee802154_sendto(FAR struct socket *psock,
       return -EDESTADDRREQ;
     }
 
-  conn = (FAR struct ieee802154_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
 
   /* Verify that the address is large enough to be a valid PF_IEEE802154
    * address.
@@ -566,7 +566,7 @@ static ssize_t ieee802154_send(FAR struct socket *psock, FAR const void *buf,
   ssize_t ret;
 
   DEBUGASSERT(psock != NULL || buf != NULL);
-  conn = (FAR struct ieee802154_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
   DEBUGASSERT(conn != NULL);
 
   /* Only SOCK_DGRAM is supported (because the MAC header is stripped) */

--- a/net/ieee802154/ieee802154_sockif.c
+++ b/net/ieee802154/ieee802154_sockif.c
@@ -202,7 +202,7 @@ static void ieee802154_addref(FAR struct socket *psock)
   DEBUGASSERT(psock != NULL && psock->s_conn != NULL &&
               (psock->s_type == SOCK_DGRAM || psock->s_type == SOCK_CTRL));
 
-  conn = (FAR struct ieee802154_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
   DEBUGASSERT(conn->crefs > 0 && conn->crefs < 255);
   conn->crefs++;
 }
@@ -248,7 +248,7 @@ static int ieee802154_connect(FAR struct socket *psock,
   int ret = OK;
 
   DEBUGASSERT(psock != NULL || addr != NULL);
-  conn = (FAR struct ieee802154_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
   DEBUGASSERT(conn != NULL);
 
   /* Verify the address family */
@@ -315,7 +315,7 @@ static int ieee802154_bind(FAR struct socket *psock,
       return -EBADF;
     }
 
-  conn = (FAR struct ieee802154_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
 
   /* Bind a PF_IEEE802154 socket to an network device. */
 
@@ -402,7 +402,7 @@ static int ieee802154_getsockname(FAR struct socket *psock,
 
   DEBUGASSERT(psock != NULL && addr != NULL && addrlen != NULL);
 
-  conn = (FAR struct ieee802154_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
   DEBUGASSERT(conn != NULL);
 
   /* Create a copy of the full address on the stack */
@@ -464,7 +464,7 @@ static int ieee802154_getpeername(FAR struct socket *psock,
 
   DEBUGASSERT(psock != NULL && addr != NULL && addrlen != NULL);
 
-  conn = (FAR struct ieee802154_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
   DEBUGASSERT(conn != NULL);
 
   /* Create a copy of the full address on the stack */

--- a/net/inet/inet_sockif.c
+++ b/net/inet/inet_sockif.c
@@ -1127,7 +1127,7 @@ int inet_listen(FAR struct socket *psock, int backlog)
 
 #ifdef CONFIG_NET_TCP
 #ifdef NET_TCP_HAVE_STACK
-  conn = (FAR struct tcp_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
 
   if (conn->lport <= 0)
     {
@@ -1284,7 +1284,7 @@ static int inet_connect(FAR struct socket *psock,
 
           /* Perform the connect/disconnect operation */
 
-          conn = (FAR struct udp_conn_s *)psock->s_conn;
+          conn = psock->s_conn;
 #if defined(CONFIG_NET_IPv4) && defined(CONFIG_NET_IPv6)
           if (conn->domain != addr->sa_family)
             {

--- a/net/inet/ipv4_getpeername.c
+++ b/net/inet/ipv4_getpeername.c
@@ -100,8 +100,7 @@ int ipv4_getpeername(FAR struct socket *psock, FAR struct sockaddr *addr,
 #ifdef NET_TCP_HAVE_STACK
       case SOCK_STREAM:
         {
-          FAR struct tcp_conn_s *tcp_conn =
-            (FAR struct tcp_conn_s *)psock->s_conn;
+          FAR struct tcp_conn_s *tcp_conn = psock->s_conn;
 
           outaddr->sin_port = tcp_conn->rport; /* Already in network byte order */
           ripaddr           = tcp_conn->u.ipv4.raddr;
@@ -112,8 +111,7 @@ int ipv4_getpeername(FAR struct socket *psock, FAR struct sockaddr *addr,
 #ifdef NET_UDP_HAVE_STACK
       case SOCK_DGRAM:
         {
-          FAR struct udp_conn_s *udp_conn =
-            (FAR struct udp_conn_s *)psock->s_conn;
+          FAR struct udp_conn_s *udp_conn = psock->s_conn;
 
           outaddr->sin_port = udp_conn->rport; /* Already in network byte order */
           ripaddr           = udp_conn->u.ipv4.raddr;

--- a/net/inet/ipv4_getsockname.c
+++ b/net/inet/ipv4_getsockname.c
@@ -93,8 +93,7 @@ int ipv4_getsockname(FAR struct socket *psock, FAR struct sockaddr *addr,
 #ifdef NET_TCP_HAVE_STACK
       case SOCK_STREAM:
         {
-          FAR struct tcp_conn_s *tcp_conn =
-                                (FAR struct tcp_conn_s *)psock->s_conn;
+          FAR struct tcp_conn_s *tcp_conn = psock->s_conn;
 
           outaddr->sin_port = tcp_conn->lport; /* Already in network byte order */
           lipaddr           = tcp_conn->u.ipv4.laddr;
@@ -106,8 +105,7 @@ int ipv4_getsockname(FAR struct socket *psock, FAR struct sockaddr *addr,
 #ifdef NET_UDP_HAVE_STACK
       case SOCK_DGRAM:
         {
-          FAR struct udp_conn_s *udp_conn =
-                                (FAR struct udp_conn_s *)psock->s_conn;
+          FAR struct udp_conn_s *udp_conn = psock->s_conn;
 
           outaddr->sin_port = udp_conn->lport; /* Already in network byte order */
           lipaddr           = udp_conn->u.ipv4.laddr;

--- a/net/inet/ipv4_getsockopt.c
+++ b/net/inet/ipv4_getsockopt.c
@@ -86,8 +86,7 @@ int ipv4_getsockopt(FAR struct socket *psock, int option,
 
       case IP_TOS:
         {
-          FAR struct socket_conn_s *conn =
-                           (FAR struct socket_conn_s *)psock->s_conn;
+          FAR struct socket_conn_s *conn = psock->s_conn;
 
           *(FAR uint8_t *)value = conn->s_tos;
           *value_len = 1;

--- a/net/inet/ipv4_setsockopt.c
+++ b/net/inet/ipv4_setsockopt.c
@@ -199,7 +199,7 @@ int ipv4_setsockopt(FAR struct socket *psock, int option,
             }
           else
             {
-              conn = (FAR struct udp_conn_s *)psock->s_conn;
+              conn = psock->s_conn;
               conn->ttl = ttl;
               ret = OK;
             }
@@ -247,7 +247,7 @@ int ipv4_setsockopt(FAR struct socket *psock, int option,
           enable = (value_len >= sizeof(int)) ?
             *(FAR int *)value : (int)*(FAR unsigned char *)value;
 
-          conn = (FAR struct socket_conn_s *)psock->s_conn;
+          conn = psock->s_conn;
           if (enable)
             {
               _SO_SETOPT(conn->s_options, option);
@@ -263,8 +263,7 @@ int ipv4_setsockopt(FAR struct socket *psock, int option,
 
       case IP_TOS:
         {
-          FAR struct socket_conn_s *conn =
-                           (FAR struct socket_conn_s *)psock->s_conn;
+          FAR struct socket_conn_s *conn = psock->s_conn;
           int tos;
 
           tos = (value_len >= sizeof(int)) ?

--- a/net/inet/ipv6_getpeername.c
+++ b/net/inet/ipv6_getpeername.c
@@ -99,8 +99,7 @@ int ipv6_getpeername(FAR struct socket *psock, FAR struct sockaddr *addr,
 #ifdef NET_TCP_HAVE_STACK
       case SOCK_STREAM:
         {
-          FAR struct tcp_conn_s *tcp_conn =
-            (FAR struct tcp_conn_s *)psock->s_conn;
+          FAR struct tcp_conn_s *tcp_conn = psock->s_conn;
 
           outaddr->sin6_port = tcp_conn->lport; /* Already in network byte order */
           ripaddr            = &tcp_conn->u.ipv6.raddr;
@@ -111,8 +110,7 @@ int ipv6_getpeername(FAR struct socket *psock, FAR struct sockaddr *addr,
 #ifdef NET_UDP_HAVE_STACK
       case SOCK_DGRAM:
         {
-          FAR struct udp_conn_s *udp_conn =
-            (FAR struct udp_conn_s *)psock->s_conn;
+          FAR struct udp_conn_s *udp_conn = psock->s_conn;
 
           outaddr->sin6_port = udp_conn->lport; /* Already in network byte order */
           ripaddr            = &udp_conn->u.ipv6.raddr;

--- a/net/inet/ipv6_getsockname.c
+++ b/net/inet/ipv6_getsockname.c
@@ -92,8 +92,7 @@ int ipv6_getsockname(FAR struct socket *psock, FAR struct sockaddr *addr,
 #ifdef NET_TCP_HAVE_STACK
       case SOCK_STREAM:
         {
-          FAR struct tcp_conn_s *tcp_conn =
-                                (FAR struct tcp_conn_s *)psock->s_conn;
+          FAR struct tcp_conn_s *tcp_conn = psock->s_conn;
 
           outaddr->sin6_port = tcp_conn->lport; /* Already in network byte order */
           lipaddr            = &tcp_conn->u.ipv6.laddr;
@@ -105,8 +104,7 @@ int ipv6_getsockname(FAR struct socket *psock, FAR struct sockaddr *addr,
 #ifdef NET_UDP_HAVE_STACK
       case SOCK_DGRAM:
         {
-          FAR struct udp_conn_s *udp_conn =
-                                (FAR struct udp_conn_s *)psock->s_conn;
+          FAR struct udp_conn_s *udp_conn = psock->s_conn;
 
           outaddr->sin6_port = udp_conn->lport; /* Already in network byte order */
           lipaddr            = &udp_conn->u.ipv6.laddr;

--- a/net/inet/ipv6_getsockopt.c
+++ b/net/inet/ipv6_getsockopt.c
@@ -77,8 +77,7 @@ int ipv6_getsockopt(FAR struct socket *psock, int option,
     {
       case IPV6_TCLASS:
         {
-          FAR struct socket_conn_s *conn =
-                           (FAR struct socket_conn_s *)psock->s_conn;
+          FAR struct socket_conn_s *conn = psock->s_conn;
 
           *(FAR uint8_t *)value = conn->s_tclass;
           *value_len = 1;

--- a/net/inet/ipv6_setsockopt.c
+++ b/net/inet/ipv6_setsockopt.c
@@ -156,8 +156,7 @@ int ipv6_setsockopt(FAR struct socket *psock, int option,
 
       case IPV6_TCLASS:
         {
-          FAR struct socket_conn_s *conn =
-                           (FAR struct socket_conn_s *)psock->s_conn;
+          FAR struct socket_conn_s *conn = psock->s_conn;
           int tclass;
 
           tclass = (value_len >= sizeof(int)) ?

--- a/net/local/local_accept.c
+++ b/net/local/local_accept.c
@@ -122,7 +122,7 @@ int local_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
    * address
    */
 
-  server = (FAR struct local_conn_s *)psock->s_conn;
+  server = psock->s_conn;
 
   if (server->lc_proto != SOCK_STREAM ||
       server->lc_state != LOCAL_STATE_LISTENING ||

--- a/net/local/local_bind.c
+++ b/net/local/local_bind.c
@@ -61,7 +61,7 @@ int psock_local_bind(FAR struct socket *psock,
       return -EINVAL;
     }
 
-  conn = (FAR struct local_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
 
   /* Save the address family */
 

--- a/net/local/local_connect.c
+++ b/net/local/local_connect.c
@@ -246,7 +246,7 @@ int psock_local_connect(FAR struct socket *psock,
   int ret;
 
   DEBUGASSERT(psock && psock->s_conn);
-  client = (FAR struct local_conn_s *)psock->s_conn;
+  client = psock->s_conn;
 
   if (client->lc_state == LOCAL_STATE_ACCEPT ||
       client->lc_state == LOCAL_STATE_CONNECTED)

--- a/net/local/local_listen.c
+++ b/net/local/local_listen.c
@@ -81,7 +81,7 @@ int local_listen(FAR struct socket *psock, int backlog)
 
   net_lock();
 
-  server = (FAR struct local_conn_s *)psock->s_conn;
+  server = psock->s_conn;
 
   /* Some sanity checks */
 

--- a/net/local/local_netpoll.c
+++ b/net/local/local_netpoll.c
@@ -160,7 +160,7 @@ int local_pollsetup(FAR struct socket *psock, FAR struct pollfd *fds)
   FAR struct local_conn_s *conn;
   int ret = -ENOSYS;
 
-  conn = (FAR struct local_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
 
   if (conn->lc_proto == SOCK_DGRAM)
     {
@@ -314,7 +314,7 @@ int local_pollteardown(FAR struct socket *psock, FAR struct pollfd *fds)
   FAR struct local_conn_s *conn;
   int ret = OK;
 
-  conn = (FAR struct local_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
 
   if (conn->lc_proto == SOCK_DGRAM)
     {

--- a/net/local/local_recvmsg.c
+++ b/net/local/local_recvmsg.c
@@ -58,7 +58,7 @@
 static int psock_fifo_read(FAR struct socket *psock, FAR void *buf,
                            FAR size_t *readlen, bool once)
 {
-  FAR struct local_conn_s *conn = (FAR struct local_conn_s *)psock->s_conn;
+  FAR struct local_conn_s *conn = psock->s_conn;
   int ret;
 
   ret = local_fifo_read(&conn->lc_infile, buf, readlen, once);
@@ -206,7 +206,7 @@ psock_stream_recvfrom(FAR struct socket *psock, FAR void *buf, size_t len,
                       int flags, FAR struct sockaddr *from,
                       FAR socklen_t *fromlen)
 {
-  FAR struct local_conn_s *conn = (FAR struct local_conn_s *)psock->s_conn;
+  FAR struct local_conn_s *conn = psock->s_conn;
   size_t readlen = len;
   int ret;
 
@@ -274,7 +274,7 @@ psock_dgram_recvfrom(FAR struct socket *psock, FAR void *buf, size_t len,
                      int flags, FAR struct sockaddr *from,
                      FAR socklen_t *fromlen)
 {
-  FAR struct local_conn_s *conn = (FAR struct local_conn_s *)psock->s_conn;
+  FAR struct local_conn_s *conn = psock->s_conn;
   uint16_t pktlen;
   size_t readlen;
   int ret;

--- a/net/local/local_sendmsg.c
+++ b/net/local/local_sendmsg.c
@@ -176,7 +176,7 @@ static ssize_t local_send(FAR struct socket *psock,
           /* Local TCP packet send */
 
           DEBUGASSERT(psock && psock->s_conn && buf);
-          peer = (FAR struct local_conn_s *)psock->s_conn;
+          peer = psock->s_conn;
 
           /* Verify that this is a connected peer socket and that it has
            * opened the outgoing FIFO for write-only access.
@@ -268,7 +268,7 @@ static ssize_t local_sendto(FAR struct socket *psock,
                             socklen_t tolen)
 {
 #ifdef CONFIG_NET_LOCAL_DGRAM
-  FAR struct local_conn_s *conn = (FAR struct local_conn_s *)psock->s_conn;
+  FAR struct local_conn_s *conn = psock->s_conn;
   FAR struct sockaddr_un *unaddr = (FAR struct sockaddr_un *)to;
   ssize_t ret;
 

--- a/net/local/local_sockif.c
+++ b/net/local/local_sockif.c
@@ -379,7 +379,7 @@ static int local_getsockname(FAR struct socket *psock,
       return OK;
     }
 
-  conn = (FAR struct local_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
 
   /* Save the address family */
 
@@ -751,7 +751,7 @@ static int local_ioctl(FAR struct socket *psock, int cmd, unsigned long arg)
   FAR struct local_conn_s *conn;
   int ret = OK;
 
-  conn = (FAR struct local_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
 
   switch (cmd)
     {

--- a/net/netlink/netlink_sockif.c
+++ b/net/netlink/netlink_sockif.c
@@ -253,7 +253,7 @@ static int netlink_bind(FAR struct socket *psock,
   /* Save the address information in the connection structure */
 
   nladdr = (FAR struct sockaddr_nl *)addr;
-  conn   = (FAR struct netlink_conn_s *)psock->s_conn;
+  conn   = psock->s_conn;
 
   conn->pid    = nladdr->nl_pid ? nladdr->nl_pid : nxsched_gettid();
   conn->groups = nladdr->nl_groups;
@@ -293,7 +293,7 @@ static int netlink_getsockname(FAR struct socket *psock,
   DEBUGASSERT(psock != NULL && psock->s_conn != NULL && addr != NULL &&
               addrlen != NULL && *addrlen >= sizeof(struct sockaddr_nl));
 
-  conn = (FAR struct netlink_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
 
   /* Return the address information in the address structure */
 
@@ -346,7 +346,7 @@ static int netlink_getpeername(FAR struct socket *psock,
   DEBUGASSERT(psock != NULL && psock->s_conn != NULL && addr != NULL &&
               addrlen != NULL && *addrlen >= sizeof(struct sockaddr_nl));
 
-  conn = (FAR struct netlink_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
 
   /* Return the address information in the address structure */
 
@@ -392,7 +392,7 @@ static int netlink_connect(FAR struct socket *psock,
   /* Save the address information in the connection structure */
 
   nladdr = (FAR struct sockaddr_nl *)addr;
-  conn   = (FAR struct netlink_conn_s *)psock->s_conn;
+  conn   = psock->s_conn;
 
   conn->dst_pid    = nladdr->nl_pid;
   conn->dst_groups = nladdr->nl_groups;
@@ -476,7 +476,7 @@ static int netlink_poll(FAR struct socket *psock, FAR struct pollfd *fds,
   int ret = OK;
 
   DEBUGASSERT(psock != NULL && psock->s_conn != NULL);
-  conn = (FAR struct netlink_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
 
   /* Check if we are setting up or tearing down the poll */
 
@@ -595,7 +595,7 @@ static ssize_t netlink_sendmsg(FAR struct socket *psock,
 
   /* Get the underlying connection structure */
 
-  conn = (FAR struct netlink_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
   if (to == NULL)
     {
       /* netlink_send() */

--- a/net/pkt/pkt_recvmsg.c
+++ b/net/pkt/pkt_recvmsg.c
@@ -394,7 +394,7 @@ ssize_t pkt_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
   size_t len = msg->msg_iov->iov_len;
   FAR struct sockaddr *from = msg->msg_name;
   FAR socklen_t *fromlen = &msg->msg_namelen;
-  FAR struct pkt_conn_s *conn = (FAR struct pkt_conn_s *)psock->s_conn;
+  FAR struct pkt_conn_s *conn = psock->s_conn;
   FAR struct net_driver_s *dev;
   struct pkt_recvfrom_s state;
   ssize_t ret;

--- a/net/pkt/pkt_sendmsg.c
+++ b/net/pkt/pkt_sendmsg.c
@@ -201,7 +201,7 @@ ssize_t pkt_sendmsg(FAR struct socket *psock, FAR struct msghdr *msg,
 
   /* Get the device driver that will service this transfer */
 
-  dev = pkt_find_device((FAR struct pkt_conn_s *)psock->s_conn);
+  dev = pkt_find_device(psock->s_conn);
   if (dev == NULL)
     {
       return -ENODEV;
@@ -223,7 +223,7 @@ ssize_t pkt_sendmsg(FAR struct socket *psock, FAR struct msghdr *msg,
 
   if (len > 0)
     {
-      FAR struct pkt_conn_s *conn = (FAR struct pkt_conn_s *)psock->s_conn;
+      FAR struct pkt_conn_s *conn = psock->s_conn;
 
       /* Allocate resource to receive a callback */
 

--- a/net/pkt/pkt_sockif.c
+++ b/net/pkt/pkt_sockif.c
@@ -236,7 +236,7 @@ static int pkt_bind(FAR struct socket *psock,
 
   if (psock->s_type == SOCK_RAW || psock->s_type == SOCK_CTRL)
     {
-      FAR struct pkt_conn_s *conn = (FAR struct pkt_conn_s *)psock->s_conn;
+      FAR struct pkt_conn_s *conn = psock->s_conn;
       FAR struct net_driver_s *dev;
 
       /* Look at the addr and identify the network interface */

--- a/net/sixlowpan/sixlowpan_tcpsend.c
+++ b/net/sixlowpan/sixlowpan_tcpsend.c
@@ -731,7 +731,7 @@ ssize_t psock_6lowpan_tcp_send(FAR struct socket *psock, FAR const void *buf,
 
   /* Get the underlying TCP connection structure */
 
-  conn = (FAR struct tcp_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
 
   /* Make sure that this is a connected TCP socket */
 

--- a/net/sixlowpan/sixlowpan_udpsend.c
+++ b/net/sixlowpan/sixlowpan_udpsend.c
@@ -186,7 +186,7 @@ ssize_t psock_6lowpan_udp_sendto(FAR struct socket *psock,
 
   /* Get the underlying UDP "connection" structure */
 
-  conn = (FAR struct udp_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
   DEBUGASSERT(conn != NULL);
 
   /* Route outgoing message to the correct device */
@@ -351,7 +351,7 @@ ssize_t psock_6lowpan_udp_send(FAR struct socket *psock, FAR const void *buf,
 
   /* Get the underlying UDP "connection" structure */
 
-  conn = (FAR struct udp_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
 
   /* Was the UDP socket connected via connect()? */
 

--- a/net/socket/net_fstat.c
+++ b/net/socket/net_fstat.c
@@ -108,8 +108,7 @@ int psock_fstat(FAR struct socket *psock, FAR struct stat *buf)
 #if defined(NET_TCP_HAVE_STACK)
        case SOCK_STREAM:
          {
-           FAR struct tcp_conn_s *tcp_conn =
-                       (FAR struct tcp_conn_s *)psock->s_conn;
+           FAR struct tcp_conn_s *tcp_conn = psock->s_conn;
 
            /* For TCP, the MSS is a dynamic value that maintained in the
             * connection structure.
@@ -123,8 +122,7 @@ int psock_fstat(FAR struct socket *psock, FAR struct stat *buf)
 #if defined(NET_UDP_HAVE_STACK)
        case SOCK_DGRAM:
          {
-           FAR struct udp_conn_s *udp_conn =
-                                   (FAR struct udp_conn_s *)psock->s_conn;
+           FAR struct udp_conn_s *udp_conn = psock->s_conn;
            FAR struct net_driver_s *dev;
            uint16_t iplen;
 

--- a/net/tcp/tcp_accept.c
+++ b/net/tcp/tcp_accept.c
@@ -223,7 +223,7 @@ int psock_tcp_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
    * this listener.
    */
 
-  conn = (FAR struct tcp_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
 
 #ifdef CONFIG_NET_TCPBACKLOG
   state.acpt_newconn = tcp_backlogremove(conn);

--- a/net/tcp/tcp_close.c
+++ b/net/tcp/tcp_close.c
@@ -217,7 +217,7 @@ static inline int tcp_close_disconnect(FAR struct socket *psock)
 
   net_lock();
 
-  conn = (FAR struct tcp_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
   DEBUGASSERT(conn != NULL);
 
   /* Discard our reference to the connection */

--- a/net/tcp/tcp_getsockopt.c
+++ b/net/tcp/tcp_getsockopt.c
@@ -87,7 +87,7 @@ int tcp_getsockopt(FAR struct socket *psock, int option,
 
   DEBUGASSERT(psock != NULL && value != NULL && value_len != NULL &&
               psock->s_conn != NULL);
-  conn = (FAR struct tcp_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
 
   /* All of the TCP protocol options apply only TCP sockets.  The sockets
    * do not have to be connected.. that might occur later with the KeepAlive

--- a/net/tcp/tcp_monitor.c
+++ b/net/tcp/tcp_monitor.c
@@ -147,8 +147,7 @@ static uint16_t tcp_monitor_event(FAR struct net_driver_s *dev,
       else if ((flags & TCP_CONNECTED) != 0)
         {
 #if 0 /* REVISIT: Assertion fires.  Why? */
-          FAR struct tcp_conn_s *conn =
-            (FAR struct tcp_conn_s *)psock->s_conn;
+          FAR struct tcp_conn_s *conn = psock->s_conn;
 
           /* Make sure that this is the device bound to the connection */
 
@@ -250,7 +249,7 @@ int tcp_start_monitor(FAR struct socket *psock)
   bool nonblock_conn;
 
   DEBUGASSERT(psock != NULL && psock->s_conn != NULL);
-  conn = (FAR struct tcp_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
 
   net_lock();
 

--- a/net/tcp/tcp_recvfrom.c
+++ b/net/tcp/tcp_recvfrom.c
@@ -606,7 +606,7 @@ ssize_t psock_tcp_recvfrom(FAR struct socket *psock, FAR struct msghdr *msg,
 
   net_lock();
 
-  conn = (FAR struct tcp_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
 
   /* Initialize the state structure.  This is done with the network locked
    * because we don't want anything to happen until we are ready.

--- a/net/tcp/tcp_send_buffered.c
+++ b/net/tcp/tcp_send_buffered.c
@@ -1231,7 +1231,7 @@ ssize_t psock_tcp_send(FAR struct socket *psock, FAR const void *buf,
       goto errout;
     }
 
-  conn = (FAR struct tcp_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
 
   if (!_SS_ISCONNECTED(conn->sconn.s_flags))
     {

--- a/net/tcp/tcp_send_unbuffered.c
+++ b/net/tcp/tcp_send_unbuffered.c
@@ -485,7 +485,7 @@ ssize_t psock_tcp_send(FAR struct socket *psock,
       goto errout;
     }
 
-  conn = (FAR struct tcp_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
 
   /* Check early if this is an un-connected socket, if so, then
    * return -ENOTCONN. Note, we will have to check this again, as we can't

--- a/net/tcp/tcp_setsockopt.c
+++ b/net/tcp/tcp_setsockopt.c
@@ -76,7 +76,7 @@ int tcp_setsockopt(FAR struct socket *psock, int option,
   int ret = OK;
 
   DEBUGASSERT(psock != NULL && value != NULL && psock->s_conn != NULL);
-  conn = (FAR struct tcp_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
 
   /* All of the TCP protocol options apply only TCP sockets.  The sockets
    * do not have to be connected.. that might occur later with the KeepAlive

--- a/net/tcp/tcp_shutdown.c
+++ b/net/tcp/tcp_shutdown.c
@@ -105,7 +105,7 @@ static inline int tcp_send_fin(FAR struct socket *psock)
 
   net_lock();
 
-  conn = (FAR struct tcp_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
   DEBUGASSERT(conn != NULL);
 
   if ((conn->tcpstateflags == TCP_ESTABLISHED ||

--- a/net/tcp/tcp_txdrain.c
+++ b/net/tcp/tcp_txdrain.c
@@ -95,7 +95,7 @@ int tcp_txdrain(FAR struct socket *psock, unsigned int timeout)
   DEBUGASSERT(psock != NULL && psock->s_conn != NULL);
   DEBUGASSERT(psock->s_type == SOCK_STREAM);
 
-  conn = (FAR struct tcp_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
 
   /* Initialize the wait semaphore */
 

--- a/net/udp/udp_close.c
+++ b/net/udp/udp_close.c
@@ -67,7 +67,7 @@ int udp_close(FAR struct socket *psock)
 
   net_lock();
 
-  conn = (FAR struct udp_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
   DEBUGASSERT(conn != NULL);
 
 #ifdef CONFIG_NET_SOLINGER

--- a/net/udp/udp_recvfrom.c
+++ b/net/udp/udp_recvfrom.c
@@ -546,7 +546,7 @@ static ssize_t udp_recvfrom_result(int result, struct udp_recvfrom_s *pstate)
 ssize_t psock_udp_recvfrom(FAR struct socket *psock, FAR struct msghdr *msg,
                            int flags)
 {
-  FAR struct udp_conn_s *conn = (FAR struct udp_conn_s *)psock->s_conn;
+  FAR struct udp_conn_s *conn = psock->s_conn;
   FAR struct net_driver_s *dev;
   struct udp_recvfrom_s state;
   int ret;

--- a/net/udp/udp_txdrain.c
+++ b/net/udp/udp_txdrain.c
@@ -95,7 +95,7 @@ int udp_txdrain(FAR struct socket *psock, unsigned int timeout)
   DEBUGASSERT(psock != NULL && psock->s_conn != NULL);
   DEBUGASSERT(psock->s_type == SOCK_DGRAM);
 
-  conn = (FAR struct udp_conn_s *)psock->s_conn;
+  conn = psock->s_conn;
 
   /* Initialize the wait semaphore */
 


### PR DESCRIPTION
## Summary
redundant casts for psock are removed

## Impact

## Testing
sim:local
