### PR TITLE
net/local: fix blocking local sockets

### DIFF
--- a/net/local/local_fifo.c
+++ b/net/local/local_fifo.c
@@ -275,10 +275,9 @@ static int local_rx_open(FAR struct local_conn_s *conn, FAR const char *path,
 static int local_tx_open(FAR struct local_conn_s *conn, FAR const char *path,
                          bool nonblock)
 {
-  int oflags = nonblock ? O_WRONLY | O_NONBLOCK : O_WRONLY;
   int ret;
 
-  ret = file_open(&conn->lc_outfile, path, oflags);
+  ret = file_open(&conn->lc_outfile, path, O_WRONLY | O_NONBLOCK);
   if (ret < 0)
     {
       nerr("ERROR: Failed on open %s for writing: %d\n",
@@ -293,6 +292,17 @@ static int local_tx_open(FAR struct local_conn_s *conn, FAR const char *path,
        */
 
       return ret == -ENOENT ? -EFAULT : ret;
+    }
+
+  /* Clear O_NONBLOCK if it's meant to be blocking */
+
+  if (nonblock == false)
+    {
+      ret = file_fcntl(&conn->lc_outfile, F_SETFL, O_WRONLY);
+      if (ret < 0)
+        {
+          return ret;
+        }
     }
 
   return OK;


### PR DESCRIPTION
## Summary

As pointed out by https://github.com/apache/nuttx/issues/9241, PR https://github.com/apache/nuttx/pull/8985 made pipes and named pipes block when opening for `O_WRONLY` or `O_RDONLY`. Local sockets, however, require `local_open_client_tx` to be non-blocking to enable the server side to prevent the server side from blocking. If set otherwise, it would deadly block. This commit sets the FIFO as non-blocking temporarily, open the TX side and, if originally blocking - restores it to that state.

## Impact

Fixes https://github.com/apache/nuttx/issues/9241 and allow using local sockets.

## Testing

`sim:citest` (`pipe`) + `sim:ustream` + `sim:dgram`