### PR TITLE
rtc: Fix compiler warning in driver initialization.

### DIFF
--- a/drivers/timers/rtc.c
+++ b/drivers/timers/rtc.c
@@ -819,7 +819,7 @@ static int rtc_unlink(FAR struct inode *inode)
 int rtc_initialize(int minor, FAR struct rtc_lowerhalf_s *lower)
 {
   FAR struct rtc_upperhalf_s *upper;
-  char devpath[16];
+  char devpath[20];
   int ret;
 
   DEBUGASSERT(lower && lower->ops && minor >= 0 && minor < 1000);
@@ -844,11 +844,11 @@ int rtc_initialize(int minor, FAR struct rtc_lowerhalf_s *lower)
   upper->unlinked = false;  /* Driver is not  unlinked */
 #endif
 
-  /* Create the driver name.  There is space for the a minor number up to  6
+  /* Create the driver name.  There is space for the a minor number up to 10
    * characters
    */
 
-  snprintf(devpath, 16, "/dev/rtc%d", minor);
+  snprintf(devpath, sizeof(devpath), "/dev/rtc%d", minor);
 
   /* And, finally, register the new RTC driver */
 


### PR DESCRIPTION
## Summary

The RTC driver causes the following warning:

```
timers/rtc.c: In function ‘rtc_initialize’:
timers/rtc.c:851:34: warning: ‘%d’ directive output may be truncated writing between 1 and 11 bytes into a region of size 8 [-Wformat-truncation=]
  851 |   snprintf(devpath, 16, "/dev/rtc%d", minor);
      |                                  ^~
timers/rtc.c:851:25: note: directive argument in the range [-2147483648, 999]
  851 |   snprintf(devpath, 16, "/dev/rtc%d", minor);
      |                         ^~~~~~~~~~~~
timers/rtc.c:851:3: note: ‘snprintf’ output between 10 and 20 bytes into a destination of size 16
  851 |   snprintf(devpath, 16, "/dev/rtc%d", minor);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```

This PR fixes this warning.  
The `devpath` is slightly enlarged, to ensure that all possible numbers can be reliably printed.

## Impact

Practically none.

The buffer is enlarged by just 4 bytes, but it is also located in the stack. So it shouldn't have any actual impact on any practical application.

## Testing

Build test only.