### PR TITLE
esp32xx: Workaround to avoid printing serial trash character

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_lowputc.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_lowputc.c
@@ -766,6 +766,12 @@ void esp32c3_lowputc_config_pins(const struct esp32c3_uart_s *priv)
 {
   /* Configure the pins */
 
+  /* Keep TX pin in high level to avoid "?" trash character
+   * This "?" is the Unicode replacement character (U+FFFD)
+   */
+
+  esp32c3_gpiowrite(priv->txpin, true);
+
   esp32c3_gpio_matrix_out(priv->txpin, priv->txsig, 0, 0);
   esp32c3_configgpio(priv->txpin, OUTPUT_FUNCTION_1);
 

--- a/arch/xtensa/src/esp32/esp32_serial.c
+++ b/arch/xtensa/src/esp32/esp32_serial.c
@@ -1885,6 +1885,11 @@ static void esp32_config_pins(struct esp32_dev_s *priv)
    * But only one GPIO pad can connect with input signal
    */
 
+  /* Keep TX pin in high level to avoid "?" trash character
+   * This "?" is the Unicode replacement character (U+FFFD)
+   */
+
+  esp32_gpiowrite(priv->config->txpin, true);
   esp32_configgpio(priv->config->txpin, OUTPUT_FUNCTION_3);
   esp32_gpio_matrix_out(priv->config->txpin, priv->config->txsig, 0, 0);
 

--- a/arch/xtensa/src/esp32s2/esp32s2_lowputc.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_lowputc.c
@@ -683,6 +683,12 @@ void esp32s2_lowputc_config_pins(const struct esp32s2_uart_s *priv)
 {
   /* Configure the pins */
 
+  /* Keep TX pin in high level to avoid "?" trash character
+   * This "?" is the Unicode replacement character (U+FFFD)
+   */
+
+  esp32s2_gpiowrite(priv->txpin, true);
+
   /* Route UART TX signal to the selected TX pin */
 
   esp32s2_gpio_matrix_out(priv->txpin, priv->txsig, 0, 0);

--- a/arch/xtensa/src/esp32s3/esp32s3_lowputc.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_lowputc.c
@@ -795,6 +795,12 @@ void esp32s3_lowputc_config_pins(const struct esp32s3_uart_s *priv)
 {
   /* Configure the pins */
 
+  /* Keep TX pin in high level to avoid "?" trash character
+   * This "?" is the Unicode replacement character (U+FFFD)
+   */
+
+  esp32s3_gpiowrite(priv->txpin, true);
+
   if (uart_is_iomux(priv))
     {
       esp32s3_configgpio(priv->txpin, OUTPUT_FUNCTION_1);


### PR DESCRIPTION
## Summary
During the serial reconfiguration from bootloader to the NuttX a trash character "?" (Unicode replacement U+FFFD) was printed in the screen.

This fix was discovered by Sylvio Alves from Espressif!
## Impact
It will avoid to annoying some users
## Testing
ESPxx
