### PR TITLE
net: move ttl field into socket_conn_s struct

### DIFF
--- a/include/nuttx/net/net.h
+++ b/include/nuttx/net/net.h
@@ -228,6 +228,9 @@ struct socket_conn_s
 
   uint8_t       s_tos;       /* IPv4 Type of Service */
 #define s_tclass s_tos       /* IPv6 traffic class defination */
+#if defined(CONFIG_NET_IPv4) || defined(CONFIG_NET_IPv6)
+  uint8_t       ttl;         /* Default time-to-live */
+#endif
 
   /* Connection-specific content may follow */
 };

--- a/net/inet/ipv4_setsockopt.c
+++ b/net/inet/ipv4_setsockopt.c
@@ -37,7 +37,6 @@
 #include "netfilter/iptables.h"
 #include "igmp/igmp.h"
 #include "inet/inet.h"
-#include "udp/udp.h"
 #include "socket/socket.h"
 
 #if defined(CONFIG_NET_IPv4) && defined(CONFIG_NET_SOCKOPTS)
@@ -180,11 +179,9 @@ int ipv4_setsockopt(FAR struct socket *psock, int option,
       case IP_MULTICAST_TTL:          /* Set/read the time-to-live value of
                                        * outgoing multicast packets */
         {
-          FAR struct udp_conn_s *conn;
-          int ttl;
+          FAR struct socket_conn_s *conn;
 
-          if (psock->s_type != SOCK_DGRAM ||
-              value == NULL || value_len == 0)
+          if (value == NULL || value_len == 0)
             {
               ret = -EINVAL;
               break;

--- a/net/sixlowpan/sixlowpan_udpsend.c
+++ b/net/sixlowpan/sixlowpan_udpsend.c
@@ -227,7 +227,7 @@ ssize_t psock_6lowpan_udp_sendto(FAR struct socket *psock,
   ipv6udp.ipv6.tcf    = 0x00;
   ipv6udp.ipv6.flow   = 0x00;
   ipv6udp.ipv6.proto  = IP_PROTO_UDP;
-  ipv6udp.ipv6.ttl    = conn->ttl;
+  ipv6udp.ipv6.ttl    = conn->sconn.ttl;
 
   /* The IPv6 header length field does not include the size of IPv6 IP
    * header.

--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -737,6 +737,7 @@ FAR struct tcp_conn_s *tcp_alloc(uint8_t domain)
   if (conn)
     {
       memset(conn, 0, sizeof(struct tcp_conn_s));
+      conn->sconn.ttl     = IP_TTL_DEFAULT;
       conn->tcpstateflags = TCP_ALLOCATED;
 #if defined(CONFIG_NET_IPv4) && defined(CONFIG_NET_IPv6)
       conn->domain        = domain;
@@ -1116,6 +1117,7 @@ FAR struct tcp_conn_s *tcp_alloc_accept(FAR struct net_driver_s *dev,
 #endif
 
       conn->sconn.s_tos      = listener->sconn.s_tos;
+      conn->sconn.ttl        = listener->sconn.ttl;
 #if CONFIG_NET_RECV_BUFSIZE > 0
       conn->rcv_bufs         = listener->rcv_bufs;
 #endif

--- a/net/tcp/tcp_send.c
+++ b/net/tcp/tcp_send.c
@@ -182,7 +182,7 @@ static void tcp_sendcommon(FAR struct net_driver_s *dev,
       ninfo("do IPv6 IP header build!\n");
       ipv6_build_header(IPv6BUF, dev->d_len - IPv6_HDRLEN,
                         IP_PROTO_TCP, dev->d_ipv6addr, conn->u.ipv6.raddr,
-                        IP_TTL_DEFAULT, conn->sconn.s_tclass);
+                        conn->sconn.ttl, conn->sconn.s_tclass);
 
       /* Calculate TCP checksum. */
 
@@ -202,7 +202,7 @@ static void tcp_sendcommon(FAR struct net_driver_s *dev,
       ninfo("do IPv4 IP header build!\n");
       ipv4_build_header(IPv4BUF, dev->d_len, IP_PROTO_TCP,
                         &dev->d_ipaddr, &conn->u.ipv4.raddr,
-                        IP_TTL_DEFAULT, conn->sconn.s_tos, NULL);
+                        conn->sconn.ttl, conn->sconn.s_tos, NULL);
 
       /* Calculate TCP checksum. */
 
@@ -477,8 +477,8 @@ void tcp_reset(FAR struct net_driver_s *dev, FAR struct tcp_conn_s *conn)
 
       ipv6_build_header(ipv6, dev->d_len - IPv6_HDRLEN,
                         IP_PROTO_TCP, dev->d_ipv6addr, ipv6->srcipaddr,
-                        IP_TTL_DEFAULT, conn ? conn->sconn.s_tclass : 0);
-
+                        conn ? conn->sconn.ttl : IP_TTL_DEFAULT,
+                        conn ? conn->sconn.s_tos : 0);
       tcp->tcpchksum = 0;
       tcp->tcpchksum = ~tcp_ipv6_chksum(dev);
     }
@@ -493,7 +493,8 @@ void tcp_reset(FAR struct net_driver_s *dev, FAR struct tcp_conn_s *conn)
 
       ipv4_build_header(IPv4BUF, dev->d_len, IP_PROTO_TCP,
                         &dev->d_ipaddr, (FAR in_addr_t *)ipv4->srcipaddr,
-                        IP_TTL_DEFAULT, conn ? conn->sconn.s_tos : 0, NULL);
+                        conn ? conn->sconn.ttl : IP_TTL_DEFAULT,
+                        conn ? conn->sconn.s_tos : 0, NULL);
 
       tcp->tcpchksum = 0;
       tcp->tcpchksum = ~tcp_ipv4_chksum(dev);

--- a/net/udp/udp.h
+++ b/net/udp/udp.h
@@ -115,7 +115,6 @@ struct udp_conn_s
   uint16_t rport;         /* Remote port number (network byte order) */
   uint8_t  flags;         /* See _UDP_FLAG_* definitions */
   uint8_t  domain;        /* IP domain: PF_INET or PF_INET6 */
-  uint8_t  ttl;           /* Default time-to-live */
   uint8_t  crefs;         /* Reference counts on this instance */
 
 #if CONFIG_NET_RECV_BUFSIZE > 0

--- a/net/udp/udp_conn.c
+++ b/net/udp/udp_conn.c
@@ -636,17 +636,17 @@ FAR struct udp_conn_s *udp_alloc(uint8_t domain)
     {
       /* Make sure that the connection is marked as uninitialized */
 
-      conn->flags   = 0;
+      conn->sconn.ttl = IP_TTL_DEFAULT;
+      conn->flags     = 0;
 #if defined(CONFIG_NET_IPv4) && defined(CONFIG_NET_IPv6)
-      conn->domain  = domain;
+      conn->domain    = domain;
 #endif
-      conn->lport   = 0;
-      conn->ttl     = IP_TTL_DEFAULT;
+      conn->lport     = 0;
 #if CONFIG_NET_RECV_BUFSIZE > 0
-      conn->rcvbufs = CONFIG_NET_RECV_BUFSIZE;
+      conn->rcvbufs   = CONFIG_NET_RECV_BUFSIZE;
 #endif
 #if CONFIG_NET_SEND_BUFSIZE > 0
-      conn->sndbufs = CONFIG_NET_SEND_BUFSIZE;
+      conn->sndbufs   = CONFIG_NET_SEND_BUFSIZE;
 
       nxsem_init(&conn->sndsem, 0, 0);
 #endif

--- a/net/udp/udp_send.c
+++ b/net/udp/udp_send.c
@@ -123,7 +123,7 @@ void udp_send(FAR struct net_driver_s *dev, FAR struct udp_conn_s *conn)
           dev->d_len        = dev->d_sndlen + IPv4UDP_HDRLEN;
 
           ipv4_build_header(IPv4BUF, dev->d_len, IP_PROTO_UDP,
-                            &dev->d_ipaddr, &raddr, IP_TTL_DEFAULT,
+                            &dev->d_ipaddr, &raddr, conn->sconn.ttl,
                             conn->sconn.s_tos, NULL);
 
 #ifdef CONFIG_NET_STATISTICS
@@ -149,8 +149,8 @@ void udp_send(FAR struct net_driver_s *dev, FAR struct udp_conn_s *conn)
           dev->d_len        = dev->d_sndlen + UDP_HDRLEN;
 
           ipv6_build_header(IPv6BUF, dev->d_len, IP_PROTO_UDP,
-                            dev->d_ipv6addr, conn->u.ipv6.raddr, conn->ttl,
-                            conn->sconn.s_tclass);
+                            dev->d_ipv6addr, conn->u.ipv6.raddr,
+                            conn->sconn.ttl, conn->sconn.s_tclass);
 
           /* The total length to send is the size of the application data
            * plus the IPv6 and UDP headers (and, eventually, the link layer


### PR DESCRIPTION
## Summary
move ttl filed from udp_conn_s to socket_conn_s structure to make it more than just control udp.

## Impact

## Testing
sim:local
