### PR TITLE
w25qxxxjv: fix STATUS2_QE_ENABLED bitfield write

### DIFF
--- a/drivers/mtd/w25qxxxjv.c
+++ b/drivers/mtd/w25qxxxjv.c
@@ -616,7 +616,7 @@ static void w25qxxxjv_quad_enable(FAR struct w25qxxxjv_dev_s *priv)
       w25qxxxjv_write_enable(priv);
 
       priv->cmdbuf[0] &= ~STATUS2_QE_MASK;
-      priv->cmdbuf[1] |= STATUS2_QE_ENABLED;
+      priv->cmdbuf[0] |= STATUS2_QE_ENABLED;
 
       w25qxxxjv_command_write(priv->qspi, W25QXXXJV_WRITE_STATUS_2,
                               (FAR const void *)priv->cmdbuf, 1);


### PR DESCRIPTION
## Summary
W25QXXXJV_WRITE_STATUS_2 register uses just first byte therefore all operations has to be done in priv->cmdbuf[0]. Previous priv->cmdbuf[1] caused QuadSPI mode not being enabled.

## Impact
W25Q flash now enables Quad mode.

## Testing
Tested on W25Q01JV flash and SAM E70 based board. 
