### PR TITLE
modify type of numbytes in audio_buf_desc_s from uint16_t to apb_samp_t

### DIFF
--- a/include/nuttx/audio/audio.h
+++ b/include/nuttx/audio/audio.h
@@ -484,7 +484,7 @@ struct audio_buf_desc_s
 #ifdef CONFIG_AUDIO_MULTI_SESSION
   FAR void            *session;           /* Associated channel */
 #endif
-  uint16_t            numbytes;           /* Number of bytes to allocate */
+  apb_samp_t          numbytes;           /* Number of bytes to allocate */
   union
   {
     FAR struct ap_buffer_s  *buffer;     /* Buffer to free / enqueue */


### PR DESCRIPTION
## Summary

## Impact

## Testing

