### PR TITLE
Fix some warnings in STM32H7 IWDG

### DIFF
--- a/arch/arm/src/stm32h7/stm32_iwdg.c
+++ b/arch/arm/src/stm32h7/stm32_iwdg.c
@@ -315,8 +315,8 @@ static int stm32_start(struct watchdog_lowerhalf_s *lower)
   struct stm32_lowerhalf_s *priv = (struct stm32_lowerhalf_s *)lower;
   irqstate_t flags;
 
-  wdinfo("Entry: started=%d\n");
   DEBUGASSERT(priv);
+  wdinfo("Entry: started=%d\n", priv->started);
 
   /* Have we already been started? */
 
@@ -462,9 +462,9 @@ static int stm32_getstatus(struct watchdog_lowerhalf_s *lower,
   status->timeleft = priv->timeout - elapsed;
 
   wdinfo("Status     :\n");
-  wdinfo("  flags    : %08x\n", status->flags);
-  wdinfo("  timeout  : %d\n", status->timeout);
-  wdinfo("  timeleft : %d\n", status->timeleft);
+  wdinfo("  flags    : %08"PRIx32"\n", status->flags);
+  wdinfo("  timeout  : %"PRIu32"\n", status->timeout);
+  wdinfo("  timeleft : %"PRIu32"\n", status->timeleft);
   return OK;
 }
 
@@ -493,14 +493,14 @@ static int stm32_settimeout(struct watchdog_lowerhalf_s *lower,
   int prescaler;
   int shift;
 
-  wdinfo("Entry: timeout=%d\n", timeout);
+  wdinfo("Entry: timeout=%"PRIu32"\n", timeout);
   DEBUGASSERT(priv);
 
   /* Can this timeout be represented? */
 
   if (timeout < 1 || timeout > IWDG_MAXTIMEOUT)
     {
-      wderr("ERROR: Cannot represent timeout=%d > %d\n",
+      wderr("ERROR: Cannot represent timeout=%"PRIu32" > %d\n",
             timeout, IWDG_MAXTIMEOUT);
       return -ERANGE;
     }
@@ -608,7 +608,7 @@ static int stm32_settimeout(struct watchdog_lowerhalf_s *lower,
     }
 #endif
 
-  wdinfo("prescaler=%d fiwdg=%d reload=%d\n", prescaler, fiwdg, reload);
+  wdinfo("prescaler=%d fiwdg=%"PRIu32" reload=%"PRIu64"\n", prescaler, fiwdg, reload);
 
   return OK;
 }
@@ -639,7 +639,7 @@ void stm32_iwdginitialize(const char *devpath, uint32_t lsifreq)
 {
   struct stm32_lowerhalf_s *priv = &g_wdgdev;
 
-  wdinfo("Entry: devpath=%s lsifreq=%d\n", devpath, lsifreq);
+  wdinfo("Entry: devpath=%s lsifreq=%"PRIu32"\n", devpath, lsifreq);
 
   /* NOTE we assume that clocking to the IWDG has already been provided by
    * the RCC initialization logic.
@@ -659,7 +659,7 @@ void stm32_iwdginitialize(const char *devpath, uint32_t lsifreq)
    */
 
   stm32_rcc_enablelsi();
-  wdinfo("RCC CSR: %08x\n", getreg32(STM32_RCC_CSR));
+  wdinfo("RCC CSR: %08"PRIx32"\n", getreg32(STM32_RCC_CSR));
 
   /* Select an arbitrary initial timeout value.  But don't start the watchdog
    * yet. NOTE: If the "Hardware watchdog" feature is enabled through the

--- a/boards/arm/stm32h7/nucleo-h743zi2/src/stm32_wdt.c
+++ b/boards/arm/stm32h7/nucleo-h743zi2/src/stm32_wdt.c
@@ -1,0 +1,160 @@
+/****************************************************************************
+ * boards/arm/stm32h7/nucleo-h743zi2/src/stm32_wdt.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <sys/types.h>
+#include <sys/ioctl.h>
+
+#include <errno.h>
+#include <debug.h>
+#include <sched.h>
+#include <stdio.h>
+#include <fcntl.h>
+
+#include <nuttx/signal.h>
+#include <nuttx/fs/fs.h>
+#include <nuttx/timers/watchdog.h>
+#include <arch/board/board.h>
+
+#include <nuttx/kthread.h>
+#include <nuttx/clock.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/* Watchdog daemon thread */
+
+#if defined(CONFIG_H743ZI2_WDG_THREAD)
+
+static int wdog_daemon(int argc, char *argv[])
+{
+  struct file filestruct;
+  int ret;
+
+  /* Open watchdog device */
+
+  ret = file_open(&filestruct, CONFIG_WATCHDOG_DEVPATH, O_RDONLY);
+  if (ret < 0)
+    {
+      wderr("ERROR: open %s failed: %d\n", CONFIG_WATCHDOG_DEVPATH, ret);
+      return ret;
+    }
+
+  /* Start watchdog timer */
+
+  ret = file_ioctl(&filestruct, WDIOC_START, 0);
+  if (ret < 0)
+    {
+      wderr("ERROR: file_ioctl(WDIOC_START) failed: %d\n", ret);
+      goto exit_close_dev;
+    }
+
+  while (1)
+    {
+      nxsig_usleep((CONFIG_H743ZI2_WDG_THREAD_INTERVAL)*1000);
+
+      /* Send keep alive ioctl */
+
+      ret = file_ioctl(&filestruct, WDIOC_KEEPALIVE, 0);
+      if (ret < 0)
+        {
+          wderr("ERROR: file_ioctl(WDIOC_KEEPALIVE) failed: %d\n", ret);
+          break;
+        }
+    }
+
+exit_close_dev:
+
+  /* Close watchdog device and exit. */
+
+  file_close(&filestruct);
+  return ret;
+}
+
+#endif /* CONFIG_H743ZI2_WDG_THREAD */
+
+/****************************************************************************
+ * Name: stm32_watchdog_initialize()
+ *
+ * Description:
+ *   Perform architecture-specific initialization of the Watchdog hardware.
+ *   This interface must be provided by all configurations using
+ *   apps/examples/watchdog
+ *
+ ****************************************************************************/
+
+int stm32_watchdog_initialize(void)
+{
+  struct file filestruct;
+  int ret = 0;
+
+  /* Open the watchdog device */
+
+  ret = file_open(&filestruct, CONFIG_WATCHDOG_DEVPATH, O_RDONLY);
+  if (ret < 0)
+    {
+      wderr("ERROR: open %s failed: %d\n", CONFIG_WATCHDOG_DEVPATH, ret);
+      return ret;
+    }
+
+  /* Set the watchdog timeout */
+
+#ifdef CONFIG_H743ZI2_IWDG
+  wdinfo("Timeout = %d.\n", CONFIG_H743ZI2_IWDG_TIMEOUT);
+  ret = file_ioctl(&filestruct, WDIOC_SETTIMEOUT,
+                   (unsigned long)CONFIG_H743ZI2_IWDG_TIMEOUT);
+#else
+# error "No watchdog configured"
+#endif
+
+  /* Close watchdog as it is not needed here anymore */
+
+  file_close(&filestruct);
+
+  if (ret < 0)
+    {
+      wderr("ERROR: watchdog configuration failed: %d\n", ret);
+      return ret;
+    }
+
+#if defined(CONFIG_H743ZI2_WDG_THREAD)
+
+  /* Spawn wdog daemon thread */
+
+  int taskid = kthread_create(CONFIG_H743ZI2_WDG_THREAD_NAME,
+                              CONFIG_H743ZI2_WDG_THREAD_PRIORITY,
+                              CONFIG_H743ZI2_WDG_THREAD_STACKSIZE,
+                              wdog_daemon, NULL);
+
+  if (taskid <= 0)
+    {
+      wderr("ERROR: cannot spawn wdog_daemon thread\n");
+      return ERROR;
+    }
+
+#endif /* CONFIG_H743ZI2_WDG_THREAD */
+
+  return OK;
+}


### PR DESCRIPTION
## Summary
Compiling STM32H7 IWDG showed some format warnings in debug outputs.

## Impact
*Build output has less warnings

## Testing
* no checkpatch output
* Local build successful