### PR TITLE
usbhost: Make unplugging hubs more reliable.

### DIFF
--- a/drivers/usbhost/usbhost_hub.c
+++ b/drivers/usbhost/usbhost_hub.c
@@ -1095,10 +1095,6 @@ static void usbhost_disconnect_event(FAR void *arg)
 
   work_cancel(LPWORK, &priv->work);
 
-  /* Disable power to all downstream ports */
-
-  usbhost_hubpwr(priv, hport, false);
-
   /* Free the allocated control request */
 
   DRVR_FREE(hport->drvr, (FAR uint8_t *)priv->ctrlreq);


### PR DESCRIPTION
## Summary

This change ensures that a child hub is freed before its parent when both are unplugged at the same time.

## Impact

## Testing
BOARD<-- hubA <-- hubB <-- hubC
1) Start with 3 daisy chained hubs plugged into the board.
2) Disconnect hubB from  hubA.
3) This caused a crash before I made this change.


