### PR TITLE
net/rpmsg: initialize semaphore count before wait

### DIFF
--- a/net/rpmsg/rpmsg_sockif.c
+++ b/net/rpmsg/rpmsg_sockif.c
@@ -342,7 +342,7 @@ static int rpmsg_socket_ept_cb(FAR struct rpmsg_endpoint *ept,
                 }
 
               conn->recvdata = NULL;
-              nxsem_post(&conn->recvsem);
+              rpmsg_socket_post(&conn->recvsem);
             }
 
           if (len > 0)
@@ -1249,6 +1249,7 @@ static ssize_t rpmsg_socket_recvmsg(FAR struct socket *psock,
   conn->recvdata = buf;
   conn->recvlen  = len;
 
+  nxsem_reset(&conn->recvsem, 0);
   nxmutex_unlock(&conn->recvlock);
 
   ret = net_sem_timedwait(&conn->recvsem,


### PR DESCRIPTION
## Summary


net/rpmsg: initialize semaphore count before wait

recvmsg() will incorrectly return 0 if the count of sema before waiting is greater than 0,
This commit will reinitialize the sema count before waiting:

```bash
1181 static ssize_t rpmsg_socket_recvmsg(FAR struct socket *psock,
1182                                     FAR struct msghdr *msg, int flags)
1183 {
...
1255   ret = net_sem_timedwait(&conn->recvsem,
1256                       _SO_TIMEOUT(conn->sconn.s_rcvtimeo)); // recvsem.sem_count == 1; return 0
...
1264   if (!conn->recvdata)              // recvdata not consumed; goto else
1265     {
1266       ret = conn->recvlen;
1267     }
1268   else
1269     {
1270       conn->recvdata = NULL;
1271     }
...
1282   return ret;                        // BUGON! incorrectly return 0 to user
1283 }

```
Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

rpmsg test