### PR TITLE
sim/posix/backtrace: process host backtrace with critical section

### DIFF
--- a/arch/sim/src/sim/posix/sim_hostmisc.c
+++ b/arch/sim/src/sim/posix/sim_hostmisc.c
@@ -94,7 +94,13 @@ int host_backtrace(void** array, int size)
 #ifdef CONFIG_WINDOWS_CYGWIN
   return 0;
 #else
-  return backtrace(array, size);
+  uint64_t flags = up_irq_save();
+  int ret;
+
+  ret = backtrace(array, size);
+
+  up_irq_restore(flags);
+  return ret;
 #endif
 }
 

--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -536,6 +536,12 @@ static const char *g_white_content_list[] =
   "idProduct",
 
   /* Ref:
+   * sim/posix/sim_hostmisc.c
+   */
+
+  "_NSGetExecutablePath",
+
+  /* Ref:
    * arch/arm/src/nrf52/sdc/nrf.h
    * arch/arm/src/nrf53/sdc/nrf.h
    */


### PR DESCRIPTION
## Summary

sim/posix/backtrace: process host backtrace with critical section

backtrace() is not a signal safe

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

enable CONFIG_MM_BACKTRACE