### PR TITLE
net/udp: Populate the udp connection structure with the address family.

### DIFF
--- a/net/udp/udp_conn.c
+++ b/net/udp/udp_conn.c
@@ -807,6 +807,7 @@ int udp_bind(FAR struct udp_conn_s *conn, FAR const struct sockaddr *addr)
   uint16_t portno;
   int ret;
 
+  conn->domain = addr->sa_family == AF_INET ? PF_INET : PF_INET6;
 #ifdef CONFIG_NET_IPv4
 #ifdef CONFIG_NET_IPv6
   if (conn->domain == PF_INET)


### PR DESCRIPTION
## Summary

The udp connection structure contains the field, "domain", which defines which address family it belongs to. Prior to this change, this field was not populated correctly, and was read as zero in subsequent udp packet processing. As a result, packet information was not processed in udp_recvpktinfo, as expected when the appropriate socket option was enabled.

## Impact

Further processing of UDP packets, i.e in `udp_recvpktinfo`, can correctly read the address domain and provide appropriate actions.

## Testing

In our application:
 - We are now able to fetch using `in6_pktinfo` using `recvmsg`. Previously this wasn't possible if only the IPV6 stack was enabled. When both IPV4 and IPV6 was enabled, this wasn't an issue.

In NuttX:
 - Using syslog messages to log the value of the `udp_conn_s::domain` field.
