### PR TITLE
net: Add the check that socket domain is equal to bound address type, when do bind.

### DIFF
--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -1193,6 +1193,15 @@ FAR struct tcp_conn_s *tcp_alloc_accept(FAR struct net_driver_s *dev,
 
 int tcp_bind(FAR struct tcp_conn_s *conn, FAR const struct sockaddr *addr)
 {
+#if defined(CONFIG_NET_IPv4) && defined(CONFIG_NET_IPv6)
+  if (conn->domain != addr->sa_family)
+    {
+      nerr("ERROR: Invalid address type: %d != %d\n", conn->domain,
+           addr->sa_family);
+      return -EINVAL;
+    }
+#endif
+
 #ifdef CONFIG_NET_IPv4
 #ifdef CONFIG_NET_IPv6
   if (conn->domain == PF_INET)

--- a/net/udp/udp_conn.c
+++ b/net/udp/udp_conn.c
@@ -807,6 +807,15 @@ int udp_bind(FAR struct udp_conn_s *conn, FAR const struct sockaddr *addr)
   uint16_t portno;
   int ret;
 
+#if defined(CONFIG_NET_IPv4) && defined(CONFIG_NET_IPv6)
+  if (conn->domain != addr->sa_family)
+    {
+      nerr("ERROR: Invalid address type: %d != %d\n", conn->domain,
+           addr->sa_family);
+      return -EINVAL;
+    }
+#endif
+
 #ifdef CONFIG_NET_IPv4
 #ifdef CONFIG_NET_IPv6
   if (conn->domain == PF_INET)


### PR DESCRIPTION
## Summary
When bind the sockaddr, Check conn->domain and addr->sa_family. If they aren't equal, return an error early.
 which can avoid the problem of stack buffer overflow.

## Impact
Avoid an exception caused by using the bad address on binding.

## Testing
When the socket of type AF_INET4, if the sockaddr of type AF_INET6 are used, the bind interface returns an error and does not cause any other exception.
