### PR TITLE
arch: Save sigdeliver into xcp in the case of signal self delevery

### DIFF
--- a/arch/arm/src/arm/arm_initialstate.c
+++ b/arch/arm/src/arm/arm_initialstate.c
@@ -92,12 +92,12 @@ void up_initial_state(struct tcb_s *tcb)
 
   /* Save the initial stack pointer */
 
-  xcp->regs[REG_SP] = (uint32_t)tcb->stack_base_ptr +
-                                tcb->adj_stack_size;
+  xcp->regs[REG_SP]      = (uint32_t)tcb->stack_base_ptr +
+                                     tcb->adj_stack_size;
 
   /* Save the task entry point */
 
-  xcp->regs[REG_PC] = (uint32_t)tcb->start;
+  xcp->regs[REG_PC]      = (uint32_t)tcb->start;
 
   /* If this task is running PIC, then set the PIC base register to the
    * address of the allocated D-Space region.

--- a/arch/arm/src/arm/arm_schedulesigaction.c
+++ b/arch/arm/src/arm/arm_schedulesigaction.c
@@ -83,6 +83,8 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   if (!tcb->xcp.sigdeliver)
     {
+      tcb->xcp.sigdeliver = sigdeliver;
+
       /* First, handle some special cases when the signal is
        * being delivered to the currently executing task.
        */
@@ -100,6 +102,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
               /* In this case just deliver the signal now. */
 
               sigdeliver(tcb);
+              tcb->xcp.sigdeliver = NULL;
             }
 
           /* CASE 2:  We are in an interrupt handler AND the
@@ -121,8 +124,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * the signals have been delivered.
                */
 
-              tcb->xcp.sigdeliver     = sigdeliver;
-
               /* And make sure that the saved context in the TCB
                * is the same as the interrupt return context.
                */
@@ -136,12 +137,12 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
               CURRENT_REGS            = (void *)
                                         ((uint32_t)CURRENT_REGS -
-                                         (uint32_t)XCPTCONTEXT_SIZE);
+                                                   XCPTCONTEXT_SIZE);
               memcpy((uint32_t *)CURRENT_REGS, tcb->xcp.saved_regs,
                      XCPTCONTEXT_SIZE);
 
               CURRENT_REGS[REG_SP]    = (uint32_t)CURRENT_REGS +
-                                        (uint32_t)XCPTCONTEXT_SIZE;
+                                                  XCPTCONTEXT_SIZE;
 
               /* Then set up to vector to the trampoline with interrupts
                * disabled
@@ -168,8 +169,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * the signals have been delivered.
            */
 
-          tcb->xcp.sigdeliver      = sigdeliver;
-
           /* Save the current register context location */
 
           tcb->xcp.saved_regs      = tcb->xcp.regs;
@@ -181,11 +180,11 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
           tcb->xcp.regs            = (void *)
                                      ((uint32_t)tcb->xcp.regs -
-                                      (uint32_t)XCPTCONTEXT_SIZE);
+                                                XCPTCONTEXT_SIZE);
           memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
 
           tcb->xcp.regs[REG_SP]    = (uint32_t)tcb->xcp.regs +
-                                     (uint32_t)XCPTCONTEXT_SIZE;
+                                               XCPTCONTEXT_SIZE;
 
           /* Then set up to vector to the trampoline with interrupts
            * disabled

--- a/arch/arm/src/armv6-m/arm_schedulesigaction.c
+++ b/arch/arm/src/armv6-m/arm_schedulesigaction.c
@@ -88,6 +88,8 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   if (tcb->xcp.sigdeliver == NULL)
     {
+      tcb->xcp.sigdeliver = sigdeliver;
+
       /* First, handle some special cases when the signal is being delivered
        * to the currently executing task.
        */
@@ -107,6 +109,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                */
 
               sigdeliver(tcb);
+              tcb->xcp.sigdeliver = NULL;
             }
 
           /* CASE 2:  We are in an interrupt handler AND the interrupted
@@ -123,8 +126,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * delivered.
                */
 
-              tcb->xcp.sigdeliver          = (void *)sigdeliver;
-
               /* And make sure that the saved context in the TCB is the same
                * as the interrupt return context.
                */
@@ -138,12 +139,12 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
               CURRENT_REGS                 = (void *)
                                              ((uint32_t)CURRENT_REGS -
-                                              (uint32_t)XCPTCONTEXT_SIZE);
+                                                        XCPTCONTEXT_SIZE);
               memcpy((uint32_t *)CURRENT_REGS, tcb->xcp.saved_regs,
                      XCPTCONTEXT_SIZE);
 
               CURRENT_REGS[REG_SP]         = (uint32_t)CURRENT_REGS +
-                                             (uint32_t)XCPTCONTEXT_SIZE;
+                                                       XCPTCONTEXT_SIZE;
 
               /* Then set up to vector to the trampoline with interrupts
                * disabled.  The kernel-space trampoline must run in
@@ -172,8 +173,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * by the signal trampoline after the signal has been delivered.
            */
 
-          tcb->xcp.sigdeliver        = (void *)sigdeliver;
-
           /* Save the current register context location */
 
           tcb->xcp.saved_regs        = tcb->xcp.regs;
@@ -185,11 +184,11 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
           tcb->xcp.regs              = (void *)
                                        ((uint32_t)tcb->xcp.regs -
-                                        (uint32_t)XCPTCONTEXT_SIZE);
+                                                  XCPTCONTEXT_SIZE);
           memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
 
           tcb->xcp.regs[REG_SP]      = (uint32_t)tcb->xcp.regs +
-                                       (uint32_t)XCPTCONTEXT_SIZE;
+                                                 XCPTCONTEXT_SIZE;
 
           /* Then set up to vector to the trampoline with interrupts
            * disabled.  We must already be in privileged thread mode to be
@@ -219,6 +218,8 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   if (!tcb->xcp.sigdeliver)
     {
+      tcb->xcp.sigdeliver = sigdeliver;
+
       /* First, handle some special cases when the signal is being delivered
        * to task that is currently executing on any CPU.
        */
@@ -241,6 +242,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                */
 
               sigdeliver(tcb);
+              tcb->xcp.sigdeliver = NULL;
             }
 
           /* CASE 2:  The task that needs to receive the signal is running.
@@ -276,8 +278,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                    * been delivered.
                    */
 
-                  tcb->xcp.sigdeliver        = (void *)sigdeliver;
-
                   /* Save the current register context location */
 
                   tcb->xcp.saved_regs        = tcb->xcp.regs;
@@ -289,12 +289,12 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
                   tcb->xcp.regs              = (void *)
                                                ((uint32_t)tcb->xcp.regs -
-                                                (uint32_t)XCPTCONTEXT_SIZE);
+                                                          XCPTCONTEXT_SIZE);
                   memcpy(tcb->xcp.regs, tcb->xcp.saved_regs,
                          XCPTCONTEXT_SIZE);
 
                   tcb->xcp.regs[REG_SP]      = (uint32_t)tcb->xcp.regs +
-                                               (uint32_t)XCPTCONTEXT_SIZE;
+                                                         XCPTCONTEXT_SIZE;
 
                   /* Then set up vector to the trampoline with interrupts
                    * disabled.  We must already be in privileged thread mode
@@ -318,8 +318,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                    * signal has been delivered.
                    */
 
-                  tcb->xcp.sigdeliver       = (void *)sigdeliver;
-
                   /* And make sure that the saved context in the TCB is the
                    * same as the interrupt return context.
                    */
@@ -333,12 +331,12 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
                   CURRENT_REGS              = (void *)
                                               ((uint32_t)CURRENT_REGS -
-                                               (uint32_t)XCPTCONTEXT_SIZE);
+                                                         XCPTCONTEXT_SIZE);
                   memcpy((uint32_t *)CURRENT_REGS, tcb->xcp.saved_regs,
                          XCPTCONTEXT_SIZE);
 
                   CURRENT_REGS[REG_SP]      = (uint32_t)CURRENT_REGS +
-                                              (uint32_t)XCPTCONTEXT_SIZE;
+                                                        XCPTCONTEXT_SIZE;
 
                   /* Then set up vector to the trampoline with interrupts
                    * disabled.  The kernel-space trampoline must run in
@@ -388,8 +386,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * by the signal trampoline after the signal has been delivered.
            */
 
-          tcb->xcp.sigdeliver        = (void *)sigdeliver;
-
           /* Save the current register context location */
 
           tcb->xcp.saved_regs        = tcb->xcp.regs;
@@ -401,11 +397,11 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
           tcb->xcp.regs              = (void *)
                                        ((uint32_t)tcb->xcp.regs -
-                                        (uint32_t)XCPTCONTEXT_SIZE);
+                                                  XCPTCONTEXT_SIZE);
           memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
 
           tcb->xcp.regs[REG_SP]      = (uint32_t)tcb->xcp.regs +
-                                       (uint32_t)XCPTCONTEXT_SIZE;
+                                                 XCPTCONTEXT_SIZE;
 
           /* Increment the IRQ lock count so that when the task is restarted,
            * it will hold the IRQ spinlock.

--- a/arch/arm/src/armv7-a/arm_schedulesigaction.c
+++ b/arch/arm/src/armv7-a/arm_schedulesigaction.c
@@ -86,6 +86,8 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   if (!tcb->xcp.sigdeliver)
     {
+      tcb->xcp.sigdeliver = sigdeliver;
+
       /* First, handle some special cases when the signal is being delivered
        * to task that is currently executing on this CPU.
        */
@@ -105,6 +107,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                */
 
               sigdeliver(tcb);
+              tcb->xcp.sigdeliver = NULL;
             }
 
           /* CASE 2:  We are in an interrupt handler AND the interrupted
@@ -126,8 +129,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * the signals have been delivered.
                */
 
-              tcb->xcp.sigdeliver     = sigdeliver;
-
               /* And make sure that the saved context in the TCB is the same
                * as the interrupt return context.
                */
@@ -141,12 +142,12 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
               CURRENT_REGS            = (void *)
                                         ((uint32_t)CURRENT_REGS -
-                                         (uint32_t)XCPTCONTEXT_SIZE);
+                                                   XCPTCONTEXT_SIZE);
               memcpy((uint32_t *)CURRENT_REGS, tcb->xcp.saved_regs,
                      XCPTCONTEXT_SIZE);
 
               CURRENT_REGS[REG_SP]    = (uint32_t)CURRENT_REGS +
-                                        (uint32_t)XCPTCONTEXT_SIZE;
+                                                  XCPTCONTEXT_SIZE;
 
               /* Then set up to vector to the trampoline with interrupts
                * disabled
@@ -173,8 +174,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * have been delivered.
            */
 
-          tcb->xcp.sigdeliver      = sigdeliver;
-
           /* Save the current register context location */
 
           tcb->xcp.saved_regs      = tcb->xcp.regs;
@@ -186,11 +185,11 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
           tcb->xcp.regs            = (void *)
                                      ((uint32_t)tcb->xcp.regs -
-                                      (uint32_t)XCPTCONTEXT_SIZE);
+                                                XCPTCONTEXT_SIZE);
           memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
 
           tcb->xcp.regs[REG_SP]    = (uint32_t)tcb->xcp.regs +
-                                     (uint32_t)XCPTCONTEXT_SIZE;
+                                               XCPTCONTEXT_SIZE;
 
           /* Then set up to vector to the trampoline with interrupts
            * disabled
@@ -218,6 +217,8 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   if (!tcb->xcp.sigdeliver)
     {
+      tcb->xcp.sigdeliver = sigdeliver;
+
       /* First, handle some special cases when the signal is being delivered
        * to task that is currently executing on any CPU.
        */
@@ -240,6 +241,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                */
 
               sigdeliver(tcb);
+              tcb->xcp.sigdeliver = NULL;
             }
 
           /* CASE 2:  The task that needs to receive the signal is running.
@@ -275,8 +277,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                    * been delivered.
                    */
 
-                  tcb->xcp.sigdeliver      = sigdeliver;
-
                   /* Save the current register context location */
 
                   tcb->xcp.saved_regs      = tcb->xcp.regs;
@@ -288,12 +288,12 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
                   tcb->xcp.regs            = (void *)
                                              ((uint32_t)tcb->xcp.regs -
-                                              (uint32_t)XCPTCONTEXT_SIZE);
+                                                        XCPTCONTEXT_SIZE);
                   memcpy(tcb->xcp.regs, tcb->xcp.saved_regs,
                          XCPTCONTEXT_SIZE);
 
                   tcb->xcp.regs[REG_SP]    = (uint32_t)tcb->xcp.regs +
-                                             (uint32_t)XCPTCONTEXT_SIZE;
+                                                       XCPTCONTEXT_SIZE;
 
                   /* Then set up to vector to the trampoline with interrupts
                    * disabled
@@ -316,8 +316,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                    * has been delivered.
                    */
 
-                  tcb->xcp.sigdeliver     = (void *)sigdeliver;
-
                   /* And make sure that the saved context in the TCB is the
                    * same as the interrupt return context.
                    */
@@ -331,12 +329,12 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
                   CURRENT_REGS            = (void *)
                                             ((uint32_t)CURRENT_REGS -
-                                             (uint32_t)XCPTCONTEXT_SIZE);
+                                                       XCPTCONTEXT_SIZE);
                   memcpy((uint32_t *)CURRENT_REGS, tcb->xcp.saved_regs,
                          XCPTCONTEXT_SIZE);
 
                   CURRENT_REGS[REG_SP]    = (uint32_t)CURRENT_REGS +
-                                            (uint32_t)XCPTCONTEXT_SIZE;
+                                                      XCPTCONTEXT_SIZE;
 
                   /* Then set up vector to the trampoline with interrupts
                    * disabled.  The kernel-space trampoline must run in
@@ -386,8 +384,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * have been delivered.
            */
 
-          tcb->xcp.sigdeliver      = sigdeliver;
-
           /* Save the current register context location */
 
           tcb->xcp.saved_regs      = tcb->xcp.regs;
@@ -399,11 +395,11 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
           tcb->xcp.regs            = (void *)
                                      ((uint32_t)tcb->xcp.regs -
-                                      (uint32_t)XCPTCONTEXT_SIZE);
+                                                XCPTCONTEXT_SIZE);
           memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
 
           tcb->xcp.regs[REG_SP]    = (uint32_t)tcb->xcp.regs +
-                                     (uint32_t)XCPTCONTEXT_SIZE;
+                                               XCPTCONTEXT_SIZE;
 
           /* Increment the IRQ lock count so that when the task is restarted,
            * it will hold the IRQ spinlock.

--- a/arch/arm/src/armv7-m/arm_initialstate.c
+++ b/arch/arm/src/armv7-m/arm_initialstate.c
@@ -145,7 +145,7 @@ void up_initial_state(struct tcb_s *tcb)
   xcp->regs[REG_EXC_RETURN] = EXC_RETURN_PRIVTHR;
 
 #ifdef CONFIG_ARCH_FPU
-  xcp->regs[REG_FPSCR] = 0;      /* REVISIT: Initial FPSCR should be configurable */
+  xcp->regs[REG_FPSCR]   = 0; /* REVISIT: Initial FPSCR should be configurable */
 #endif /* CONFIG_ARCH_FPU */
 
   /* Enable or disable interrupts, based on user configuration */

--- a/arch/arm/src/armv7-m/arm_schedulesigaction.c
+++ b/arch/arm/src/armv7-m/arm_schedulesigaction.c
@@ -89,6 +89,8 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   if (tcb->xcp.sigdeliver == NULL)
     {
+      tcb->xcp.sigdeliver = sigdeliver;
+
       /* First, handle some special cases when the signal is being delivered
        * to the currently executing task.
        */
@@ -108,6 +110,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                */
 
               sigdeliver(tcb);
+              tcb->xcp.sigdeliver = NULL;
             }
 
           /* CASE 2:  We are in an interrupt handler AND the interrupted
@@ -124,8 +127,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * delivered.
                */
 
-              tcb->xcp.sigdeliver          = (void *)sigdeliver;
-
               /* And make sure that the saved context in the TCB is the same
                * as the interrupt return context.
                */
@@ -139,12 +140,12 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
               CURRENT_REGS                 = (void *)
                                              ((uint32_t)CURRENT_REGS -
-                                              (uint32_t)XCPTCONTEXT_SIZE);
+                                                        XCPTCONTEXT_SIZE);
               memcpy((uint32_t *)CURRENT_REGS, tcb->xcp.saved_regs,
                      XCPTCONTEXT_SIZE);
 
               CURRENT_REGS[REG_SP]         = (uint32_t)CURRENT_REGS +
-                                             (uint32_t)XCPTCONTEXT_SIZE;
+                                                       XCPTCONTEXT_SIZE;
 
               /* Then set up to vector to the trampoline with interrupts
                * disabled.  The kernel-space trampoline must run in
@@ -177,8 +178,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * by the signal trampoline after the signal has been delivered.
            */
 
-          tcb->xcp.sigdeliver        = (void *)sigdeliver;
-
           /* Save the current register context location */
 
           tcb->xcp.saved_regs        = tcb->xcp.regs;
@@ -190,11 +189,11 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
           tcb->xcp.regs              = (void *)
                                        ((uint32_t)tcb->xcp.regs -
-                                        (uint32_t)XCPTCONTEXT_SIZE);
+                                                  XCPTCONTEXT_SIZE);
           memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
 
           tcb->xcp.regs[REG_SP]      = (uint32_t)tcb->xcp.regs +
-                                       (uint32_t)XCPTCONTEXT_SIZE;
+                                                 XCPTCONTEXT_SIZE;
 
           /* Then set up to vector to the trampoline with interrupts
            * disabled.  We must already be in privileged thread mode to be
@@ -228,6 +227,8 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   if (!tcb->xcp.sigdeliver)
     {
+      tcb->xcp.sigdeliver = sigdeliver;
+
       /* First, handle some special cases when the signal is being delivered
        * to task that is currently executing on any CPU.
        */
@@ -250,6 +251,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                */
 
               sigdeliver(tcb);
+              tcb->xcp.sigdeliver = NULL;
             }
 
           /* CASE 2:  The task that needs to receive the signal is running.
@@ -285,8 +287,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                    * been delivered.
                    */
 
-                  tcb->xcp.sigdeliver        = (void *)sigdeliver;
-
                   /* Save the current register context location */
 
                   tcb->xcp.saved_regs        = tcb->xcp.regs;
@@ -298,12 +298,12 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
                   tcb->xcp.regs              = (void *)
                                                ((uint32_t)tcb->xcp.regs -
-                                                (uint32_t)XCPTCONTEXT_SIZE);
+                                                          XCPTCONTEXT_SIZE);
                   memcpy(tcb->xcp.regs, tcb->xcp.saved_regs,
                          XCPTCONTEXT_SIZE);
 
                   tcb->xcp.regs[REG_SP]      = (uint32_t)tcb->xcp.regs +
-                                               (uint32_t)XCPTCONTEXT_SIZE;
+                                                         XCPTCONTEXT_SIZE;
 
                   /* Then set up vector to the trampoline with interrupts
                    * disabled.  We must already be in privileged thread mode
@@ -331,8 +331,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                    * signal has been delivered.
                    */
 
-                  tcb->xcp.sigdeliver       = (void *)sigdeliver;
-
                   /* And make sure that the saved context in the TCB is the
                    * same as the interrupt return context.
                    */
@@ -346,12 +344,12 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
                   CURRENT_REGS              = (void *)
                                               ((uint32_t)CURRENT_REGS -
-                                               (uint32_t)XCPTCONTEXT_SIZE);
+                                                         XCPTCONTEXT_SIZE);
                   memcpy((uint32_t *)CURRENT_REGS, tcb->xcp.saved_regs,
                          XCPTCONTEXT_SIZE);
 
                   CURRENT_REGS[REG_SP]      = (uint32_t)CURRENT_REGS +
-                                              (uint32_t)XCPTCONTEXT_SIZE;
+                                                        XCPTCONTEXT_SIZE;
 
                   /* Then set up vector to the trampoline with interrupts
                    * disabled.  The kernel-space trampoline must run in
@@ -405,8 +403,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * by the signal trampoline after the signal has been delivered.
            */
 
-          tcb->xcp.sigdeliver        = (void *)sigdeliver;
-
           /* Save the current register context location */
 
           tcb->xcp.saved_regs        = tcb->xcp.regs;
@@ -418,11 +414,11 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
           tcb->xcp.regs              = (void *)
                                        ((uint32_t)tcb->xcp.regs -
-                                        (uint32_t)XCPTCONTEXT_SIZE);
+                                                  XCPTCONTEXT_SIZE);
           memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
 
           tcb->xcp.regs[REG_SP]      = (uint32_t)tcb->xcp.regs +
-                                       (uint32_t)XCPTCONTEXT_SIZE;
+                                                 XCPTCONTEXT_SIZE;
 
           /* Increment the IRQ lock count so that when the task is restarted,
            * it will hold the IRQ spinlock.

--- a/arch/arm/src/armv7-r/arm_schedulesigaction.c
+++ b/arch/arm/src/armv7-r/arm_schedulesigaction.c
@@ -84,6 +84,8 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   if (!tcb->xcp.sigdeliver)
     {
+      tcb->xcp.sigdeliver = sigdeliver;
+
       /* First, handle some special cases when the signal is being delivered
        * to the currently executing task.
        */
@@ -101,6 +103,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
               /* In this case just deliver the signal now. */
 
               sigdeliver(tcb);
+              tcb->xcp.sigdeliver = NULL;
             }
 
           /* CASE 2:  We are in an interrupt handler AND the interrupted
@@ -122,8 +125,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * the signals have been delivered.
                */
 
-              tcb->xcp.sigdeliver       = sigdeliver;
-
               /* And make sure that the saved context in the TCB is the same
                * as the interrupt return context.
                */
@@ -135,28 +136,28 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * delivered.
                */
 
-              CURRENT_REGS              = (void *)
-                                          ((uint32_t)CURRENT_REGS -
-                                           (uint32_t)XCPTCONTEXT_SIZE);
+              CURRENT_REGS           = (void *)
+                                       ((uint32_t)CURRENT_REGS -
+                                                  XCPTCONTEXT_SIZE);
               memcpy((uint32_t *)CURRENT_REGS, tcb->xcp.saved_regs,
                      XCPTCONTEXT_SIZE);
 
-              CURRENT_REGS[REG_SP]      = (uint32_t)CURRENT_REGS +
-                                          (uint32_t)XCPTCONTEXT_SIZE;
+              CURRENT_REGS[REG_SP]   = (uint32_t)CURRENT_REGS +
+                                                 XCPTCONTEXT_SIZE;
 
               /* Then set up to vector to the trampoline with interrupts
                * disabled
                */
 
-              CURRENT_REGS[REG_PC]      = (uint32_t)arm_sigdeliver;
-              CURRENT_REGS[REG_CPSR]    = (PSR_MODE_SYS | PSR_I_BIT |
-                                           PSR_F_BIT);
+              CURRENT_REGS[REG_PC]   = (uint32_t)arm_sigdeliver;
+              CURRENT_REGS[REG_CPSR] = (PSR_MODE_SYS | PSR_I_BIT |
+                                        PSR_F_BIT);
 #ifdef CONFIG_ARM_THUMB
-              CURRENT_REGS[REG_CPSR]   |= PSR_T_BIT;
+              CURRENT_REGS[REG_CPSR] |= PSR_T_BIT;
 #endif
 
 #ifdef CONFIG_ENDIAN_BIG
-              CURRENT_REGS[REG_CPSR]   |= PSR_E_BIT;
+              CURRENT_REGS[REG_CPSR] |= PSR_E_BIT;
 #endif
             }
         }
@@ -173,8 +174,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * have been delivered.
            */
 
-          tcb->xcp.sigdeliver        = sigdeliver;
-
           /* Save the current register context location */
 
           tcb->xcp.saved_regs        = tcb->xcp.regs;
@@ -186,11 +185,11 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
           tcb->xcp.regs              = (void *)
                                        ((uint32_t)tcb->xcp.regs -
-                                        (uint32_t)XCPTCONTEXT_SIZE);
+                                                  XCPTCONTEXT_SIZE);
           memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
 
           tcb->xcp.regs[REG_SP]      = (uint32_t)tcb->xcp.regs +
-                                       (uint32_t)XCPTCONTEXT_SIZE;
+                                                 XCPTCONTEXT_SIZE;
 
           /* Then set up to vector to the trampoline with interrupts
            * disabled
@@ -221,6 +220,8 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   if (!tcb->xcp.sigdeliver)
     {
+      tcb->xcp.sigdeliver = sigdeliver;
+
       /* First, handle some special cases when the signal is being delivered
        * to task that is currently executing on any CPU.
        */
@@ -243,6 +244,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                */
 
               sigdeliver(tcb);
+              tcb->xcp.sigdeliver = NULL;
             }
 
           /* CASE 2:  The task that needs to receive the signal is running.
@@ -278,8 +280,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                    * been delivered.
                    */
 
-                  tcb->xcp.sigdeliver      = sigdeliver;
-
                   /* Save the current register context location */
 
                   tcb->xcp.saved_regs      = tcb->xcp.regs;
@@ -291,12 +291,12 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
                   tcb->xcp.regs            = (void *)
                                              ((uint32_t)tcb->xcp.regs -
-                                              (uint32_t)XCPTCONTEXT_SIZE);
+                                                        XCPTCONTEXT_SIZE);
                   memcpy(tcb->xcp.regs, tcb->xcp.saved_regs,
                          XCPTCONTEXT_SIZE);
 
                   tcb->xcp.regs[REG_SP]    = (uint32_t)tcb->xcp.regs +
-                                             (uint32_t)XCPTCONTEXT_SIZE;
+                                                       XCPTCONTEXT_SIZE;
 
                   /* Then set up to vector to the trampoline with interrupts
                    * disabled
@@ -319,8 +319,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                    * has been delivered.
                    */
 
-                  tcb->xcp.sigdeliver     = (void *)sigdeliver;
-
                   /* And make sure that the saved context in the TCB is the
                    * same as the interrupt return context.
                    */
@@ -334,12 +332,12 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
                   CURRENT_REGS            = (void *)
                                             ((uint32_t)CURRENT_REGS -
-                                             (uint32_t)XCPTCONTEXT_SIZE);
+                                                       XCPTCONTEXT_SIZE);
                   memcpy((uint32_t *)CURRENT_REGS, tcb->xcp.saved_regs,
                          XCPTCONTEXT_SIZE);
 
                   CURRENT_REGS[REG_SP]    = (uint32_t)CURRENT_REGS +
-                                            (uint32_t)XCPTCONTEXT_SIZE;
+                                                      XCPTCONTEXT_SIZE;
 
                   /* Then set up vector to the trampoline with interrupts
                    * disabled.  The kernel-space trampoline must run in
@@ -389,8 +387,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * have been delivered.
            */
 
-          tcb->xcp.sigdeliver      = sigdeliver;
-
           /* Save the current register context location */
 
           tcb->xcp.saved_regs      = tcb->xcp.regs;
@@ -402,11 +398,11 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
           tcb->xcp.regs            = (void *)
                                      ((uint32_t)tcb->xcp.regs -
-                                      (uint32_t)XCPTCONTEXT_SIZE);
+                                                XCPTCONTEXT_SIZE);
           memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
 
           tcb->xcp.regs[REG_SP]    = (uint32_t)tcb->xcp.regs +
-                                     (uint32_t)XCPTCONTEXT_SIZE;
+                                               XCPTCONTEXT_SIZE;
 
           /* Increment the IRQ lock count so that when the task is restarted,
            * it will hold the IRQ spinlock.

--- a/arch/arm/src/armv8-m/arm_initialstate.c
+++ b/arch/arm/src/armv8-m/arm_initialstate.c
@@ -151,7 +151,7 @@ void up_initial_state(struct tcb_s *tcb)
   xcp->regs[REG_EXC_RETURN] = EXC_RETURN_PRIVTHR;
 
 #ifdef CONFIG_ARCH_FPU
-  xcp->regs[REG_FPSCR] |= ARMV8M_FPSCR_LTPSIZE_NONE;
+  xcp->regs[REG_FPSCR]  |= ARMV8M_FPSCR_LTPSIZE_NONE;
 #endif /* CONFIG_ARCH_FPU */
 
   /* Enable or disable interrupts, based on user configuration */

--- a/arch/arm/src/armv8-m/arm_schedulesigaction.c
+++ b/arch/arm/src/armv8-m/arm_schedulesigaction.c
@@ -89,6 +89,8 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   if (tcb->xcp.sigdeliver == NULL)
     {
+      tcb->xcp.sigdeliver = sigdeliver;
+
       /* First, handle some special cases when the signal is being delivered
        * to the currently executing task.
        */
@@ -108,6 +110,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                */
 
               sigdeliver(tcb);
+              tcb->xcp.sigdeliver = NULL;
             }
 
           /* CASE 2:  We are in an interrupt handler AND the interrupted
@@ -124,8 +127,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * delivered.
                */
 
-              tcb->xcp.sigdeliver          = (void *)sigdeliver;
-
               /* And make sure that the saved context in the TCB is the same
                * as the interrupt return context.
                */
@@ -139,12 +140,12 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
               CURRENT_REGS                 = (void *)
                                              ((uint32_t)CURRENT_REGS -
-                                              (uint32_t)XCPTCONTEXT_SIZE);
+                                                        XCPTCONTEXT_SIZE);
               memcpy((uint32_t *)CURRENT_REGS, tcb->xcp.saved_regs,
                      XCPTCONTEXT_SIZE);
 
               CURRENT_REGS[REG_SP]         = (uint32_t)CURRENT_REGS +
-                                             (uint32_t)XCPTCONTEXT_SIZE;
+                                                       XCPTCONTEXT_SIZE;
 
               /* Then set up to vector to the trampoline with interrupts
                * disabled.  The kernel-space trampoline must run in
@@ -177,8 +178,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * by the signal trampoline after the signal has been delivered.
            */
 
-          tcb->xcp.sigdeliver        = (void *)sigdeliver;
-
           /* Save the current register context location */
 
           tcb->xcp.saved_regs        = tcb->xcp.regs;
@@ -190,11 +189,11 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
           tcb->xcp.regs              = (void *)
                                        ((uint32_t)tcb->xcp.regs -
-                                        (uint32_t)XCPTCONTEXT_SIZE);
+                                                  XCPTCONTEXT_SIZE);
           memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
 
           tcb->xcp.regs[REG_SP]      = (uint32_t)tcb->xcp.regs +
-                                       (uint32_t)XCPTCONTEXT_SIZE;
+                                                 XCPTCONTEXT_SIZE;
 
           /* Then set up to vector to the trampoline with interrupts
            * disabled.  We must already be in privileged thread mode to be
@@ -228,6 +227,8 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   if (!tcb->xcp.sigdeliver)
     {
+      tcb->xcp.sigdeliver = sigdeliver;
+
       /* First, handle some special cases when the signal is being delivered
        * to task that is currently executing on any CPU.
        */
@@ -250,6 +251,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                */
 
               sigdeliver(tcb);
+              tcb->xcp.sigdeliver = NULL;
             }
 
           /* CASE 2:  The task that needs to receive the signal is running.
@@ -285,8 +287,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                    * been delivered.
                    */
 
-                  tcb->xcp.sigdeliver        = (void *)sigdeliver;
-
                   /* Save the current register context location */
 
                   tcb->xcp.saved_regs        = tcb->xcp.regs;
@@ -298,12 +298,12 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
                   tcb->xcp.regs              = (void *)
                                                ((uint32_t)tcb->xcp.regs -
-                                                (uint32_t)XCPTCONTEXT_SIZE);
+                                                          XCPTCONTEXT_SIZE);
                   memcpy(tcb->xcp.regs, tcb->xcp.saved_regs,
                          XCPTCONTEXT_SIZE);
 
                   tcb->xcp.regs[REG_SP]      = (uint32_t)tcb->xcp.regs +
-                                               (uint32_t)XCPTCONTEXT_SIZE;
+                                                         XCPTCONTEXT_SIZE;
 
                   /* Then set up vector to the trampoline with interrupts
                    * disabled.  We must already be in privileged thread mode
@@ -331,8 +331,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                    * signal has been delivered.
                    */
 
-                  tcb->xcp.sigdeliver       = (void *)sigdeliver;
-
                   /* And make sure that the saved context in the TCB is the
                    * same as the interrupt return context.
                    */
@@ -346,12 +344,12 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
                   CURRENT_REGS              = (void *)
                                               ((uint32_t)CURRENT_REGS -
-                                               (uint32_t)XCPTCONTEXT_SIZE);
+                                                         XCPTCONTEXT_SIZE);
                   memcpy((uint32_t *)CURRENT_REGS, tcb->xcp.saved_regs,
                          XCPTCONTEXT_SIZE);
 
                   CURRENT_REGS[REG_SP]      = (uint32_t)CURRENT_REGS +
-                                              (uint32_t)XCPTCONTEXT_SIZE;
+                                                        XCPTCONTEXT_SIZE;
 
                   /* Then set up vector to the trampoline with interrupts
                    * disabled.  The kernel-space trampoline must run in
@@ -409,8 +407,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * by the signal trampoline after the signal has been delivered.
            */
 
-          tcb->xcp.sigdeliver        = (void *)sigdeliver;
-
           /* Save the current register context location */
 
           tcb->xcp.saved_regs        = tcb->xcp.regs;
@@ -422,11 +418,11 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
           tcb->xcp.regs              = (void *)
                                        ((uint32_t)tcb->xcp.regs -
-                                        (uint32_t)XCPTCONTEXT_SIZE);
+                                                  XCPTCONTEXT_SIZE);
           memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
 
           tcb->xcp.regs[REG_SP]      = (uint32_t)tcb->xcp.regs +
-                                       (uint32_t)XCPTCONTEXT_SIZE;
+                                                 XCPTCONTEXT_SIZE;
 
           /* Increment the IRQ lock count so that when the task is restarted,
            * it will hold the IRQ spinlock.

--- a/arch/arm/src/cxd56xx/cxd56_cpustart.c
+++ b/arch/arm/src/cxd56xx/cxd56_cpustart.c
@@ -178,7 +178,7 @@ int up_cpu_start(int cpu)
   /* Copy initial stack and reset vector for APP_DSP */
 
   putreg32((uint32_t)tcb->stack_base_ptr +
-           tcb->adj_stack_size, VECTOR_ISTACK);
+                     tcb->adj_stack_size, VECTOR_ISTACK);
   putreg32((uint32_t)appdsp_boot, VECTOR_RESETV);
 
   spin_lock(&g_appdsp_boot);

--- a/arch/arm/src/lc823450/lc823450_cpustart.c
+++ b/arch/arm/src/lc823450/lc823450_cpustart.c
@@ -166,7 +166,7 @@ int up_cpu_start(int cpu)
   backup[0] = getreg32(CPU1_VECTOR_ISTACK);
   backup[1] = getreg32(CPU1_VECTOR_RESETV);
   putreg32((uint32_t)tcb->stack_base_ptr +
-           tcb->adj_stack_size, CPU1_VECTOR_ISTACK);
+                     tcb->adj_stack_size, CPU1_VECTOR_ISTACK);
   putreg32((uint32_t)cpu1_boot, CPU1_VECTOR_RESETV);
 
   spin_lock(&g_cpu_wait[0]);

--- a/arch/arm/src/sam34/sam4cm_cpustart.c
+++ b/arch/arm/src/sam34/sam4cm_cpustart.c
@@ -204,7 +204,7 @@ int up_cpu_start(int cpu)
   /* Copy initial vectors for CPU1 */
 
   putreg32((uint32_t)tcb->stack_base_ptr +
-           tcb->adj_stack_size, CPU1_VECTOR_ISTACK);
+                     tcb->adj_stack_size, CPU1_VECTOR_ISTACK);
   putreg32((uint32_t)cpu1_boot, CPU1_VECTOR_RESETV);
 
   spin_lock(&g_cpu1_boot);

--- a/arch/arm/src/tlsr82/tc32/tc32_schedulesigaction.c
+++ b/arch/arm/src/tlsr82/tc32/tc32_schedulesigaction.c
@@ -83,6 +83,8 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   if (!tcb->xcp.sigdeliver)
     {
+      tcb->xcp.sigdeliver = sigdeliver;
+
       /* First, handle some special cases when the signal is
        * being delivered to the currently executing task.
        */
@@ -100,6 +102,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
               /* In this case just deliver the signal now. */
 
               sigdeliver(tcb);
+              tcb->xcp.sigdeliver = NULL;
             }
 
           /* CASE 2:  We are in an interrupt handler AND the
@@ -121,8 +124,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * the signals have been delivered.
                */
 
-              tcb->xcp.sigdeliver    = sigdeliver;
-
               /* And make sure that the saved context in the TCB
                * is the same as the interrupt return context.
                */
@@ -135,12 +136,12 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                */
 
               CURRENT_REGS           = (void *)((uint32_t)CURRENT_REGS -
-                                       (uint32_t)XCPTCONTEXT_SIZE);
+                                                          XCPTCONTEXT_SIZE);
               memcpy((uint32_t *)CURRENT_REGS, tcb->xcp.saved_regs,
                      XCPTCONTEXT_SIZE);
 
               CURRENT_REGS[REG_SP]   = (uint32_t)CURRENT_REGS +
-                                       (uint32_t)XCPTCONTEXT_SIZE;
+                                                 XCPTCONTEXT_SIZE;
 
               /* Then set up to vector to the trampoline with interrupts
                * disabled
@@ -165,8 +166,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * the signals have been delivered.
            */
 
-          tcb->xcp.sigdeliver     = sigdeliver;
-
           /* Save the current register context location */
 
           tcb->xcp.saved_regs     = tcb->xcp.regs;
@@ -177,11 +176,11 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            */
 
           tcb->xcp.regs           = (void *)((uint32_t)tcb->xcp.regs -
-                                    (uint32_t)XCPTCONTEXT_SIZE);
+                                                       XCPTCONTEXT_SIZE);
           memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
 
           tcb->xcp.regs[REG_SP]   = (uint32_t)tcb->xcp.regs +
-                                    (uint32_t)XCPTCONTEXT_SIZE;
+                                              XCPTCONTEXT_SIZE;
 
           /* Then set up to vector to the trampoline with interrupts
            * disabled

--- a/arch/arm64/src/common/arm64_backtrace.c
+++ b/arch/arm64/src/common/arm64_backtrace.c
@@ -145,10 +145,10 @@ int up_backtrace(struct tcb_s *tcb,
             {
               p_regs = (struct regs_context *)CURRENT_REGS;
               ret += backtrace(rtcb->stack_base_ptr,
-                 rtcb->stack_base_ptr + rtcb->adj_stack_size,
-                 (void *)p_regs->regs[REG_X29],
-                 (void *)p_regs->elr,
-                 &buffer[ret], size - ret, &skip);
+                               rtcb->stack_base_ptr + rtcb->adj_stack_size,
+                               (void *)p_regs->regs[REG_X29],
+                               (void *)p_regs->elr,
+                               &buffer[ret], size - ret, &skip);
             }
         }
       else
@@ -165,10 +165,10 @@ int up_backtrace(struct tcb_s *tcb,
       p_regs = (struct regs_context *)CURRENT_REGS;
 
       ret = backtrace(tcb->stack_base_ptr,
-            tcb->stack_base_ptr + tcb->adj_stack_size,
-            (void *)p_regs->regs[REG_X29],
-            (void *)p_regs->elr,
-            buffer, size, &skip);
+                      tcb->stack_base_ptr + tcb->adj_stack_size,
+                      (void *)p_regs->regs[REG_X29],
+                      (void *)p_regs->elr,
+                      buffer, size, &skip);
 
       leave_critical_section(flags);
     }

--- a/arch/arm64/src/common/arm64_initialstate.c
+++ b/arch/arm64/src/common/arm64_initialstate.c
@@ -56,12 +56,12 @@
 
 void arm64_new_task(struct tcb_s * tcb)
 {
-  char  *stack_ptr = tcb->stack_base_ptr + tcb->adj_stack_size;
-  struct regs_context  * pinitctx;
+  char *stack_ptr = tcb->stack_base_ptr + tcb->adj_stack_size;
+  struct regs_context *pinitctx;
 
 #ifdef CONFIG_ARCH_FPU
-  struct fpu_reg      * pfpuctx;
-  pfpuctx      = STACK_PTR_TO_FRAME(struct fpu_reg, stack_ptr);
+  struct fpu_reg *pfpuctx;
+  pfpuctx = STACK_PTR_TO_FRAME(struct fpu_reg, stack_ptr);
   tcb->xcp.fpu_regs   = (uint64_t *)pfpuctx;
 
   /* set fpu context */
@@ -70,25 +70,25 @@ void arm64_new_task(struct tcb_s * tcb)
   stack_ptr  = (char *)pfpuctx;
 #endif
 
-  pinitctx      = STACK_PTR_TO_FRAME(struct regs_context, stack_ptr);
+  pinitctx = STACK_PTR_TO_FRAME(struct regs_context, stack_ptr);
   memset(pinitctx, 0, sizeof(struct regs_context));
-  pinitctx->elr          = (uint64_t)tcb->start;
+  pinitctx->elr       = (uint64_t)tcb->start;
 
   /* Keep using SP_EL1 */
 
-  pinitctx->spsr         = SPSR_MODE_EL1H;
+  pinitctx->spsr      = SPSR_MODE_EL1H;
 
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
   pinitctx->spsr       |= (DAIF_IRQ_BIT | DAIF_FIQ_BIT);
 #endif /* CONFIG_SUPPRESS_INTERRUPTS */
 
-  pinitctx->sp_elx       = (uint64_t)pinitctx;
-  pinitctx->sp_el0       = (uint64_t)pinitctx;
-  pinitctx->exe_depth    = 0;
-  pinitctx->tpidr_el0    = (uint64_t)tcb;
-  pinitctx->tpidr_el1    = (uint64_t)tcb;
+  pinitctx->sp_elx    = (uint64_t)pinitctx;
+  pinitctx->sp_el0    = (uint64_t)pinitctx;
+  pinitctx->exe_depth = 0;
+  pinitctx->tpidr_el0 = (uint64_t)tcb;
+  pinitctx->tpidr_el1 = (uint64_t)tcb;
 
-  tcb->xcp.regs          = (uint64_t *)pinitctx;
+  tcb->xcp.regs       = (uint64_t *)pinitctx;
 }
 
 /****************************************************************************
@@ -115,12 +115,12 @@ void up_initial_state(struct tcb_s *tcb)
     {
       /* Initialize the idle thread stack */
 #ifdef CONFIG_SMP
-      tcb->stack_alloc_ptr  = (void *)(g_cpu_idlestackalloc[0]);
+      tcb->stack_alloc_ptr = (void *)(g_cpu_idlestackalloc[0]);
 #else
-      tcb->stack_alloc_ptr  = (void *)(g_idle_stack);
+      tcb->stack_alloc_ptr = (void *)(g_idle_stack);
 #endif
-      tcb->stack_base_ptr   = tcb->stack_alloc_ptr;
-      tcb->adj_stack_size   = CONFIG_IDLETHREAD_STACKSIZE;
+      tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+      tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
 
 #ifdef CONFIG_ARCH_FPU
       /* set fpu context */

--- a/arch/arm64/src/common/arm64_schedulesigaction.c
+++ b/arch/arm64/src/common/arm64_schedulesigaction.c
@@ -126,6 +126,8 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   if (!tcb->xcp.sigdeliver)
     {
+      tcb->xcp.sigdeliver = sigdeliver;
+
       /* First, handle some special cases when the signal is being delivered
        * to task that is currently executing on this CPU.
        */
@@ -143,6 +145,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                */
 
               sigdeliver(tcb);
+              tcb->xcp.sigdeliver = NULL;
             }
 
           /* CASE 2:  We are in an interrupt handler AND the interrupted
@@ -163,8 +166,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * These will be restored by the signal trampoline after
                * the signals have been delivered.
                */
-
-              tcb->xcp.sigdeliver     = sigdeliver;
 
               /* create signal process context */
 
@@ -193,7 +194,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * have been delivered.
            */
 
-          tcb->xcp.sigdeliver      = sigdeliver;
 #ifdef CONFIG_ARCH_FPU
           tcb->xcp.saved_fpu_regs = tcb->xcp.fpu_regs;
 #endif
@@ -218,6 +218,8 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   if (!tcb->xcp.sigdeliver)
     {
+      tcb->xcp.sigdeliver = sigdeliver;
+
       /* First, handle some special cases when the signal is being delivered
        * to task that is currently executing on any CPU.
        */
@@ -240,6 +242,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                */
 
               sigdeliver(tcb);
+              tcb->xcp.sigdeliver = NULL;
             }
 
           /* CASE 2:  The task that needs to receive the signal is running.
@@ -275,8 +278,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                    * been delivered.
                    */
 
-                  tcb->xcp.sigdeliver      = sigdeliver;
-
 #ifdef CONFIG_ARCH_FPU
                   tcb->xcp.saved_fpu_regs = tcb->xcp.fpu_regs;
 #endif
@@ -294,8 +295,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                    * be restored by the signal trampoline after the signal
                    * has been delivered.
                    */
-
-                  tcb->xcp.sigdeliver      = (void *)sigdeliver;
 
                   /* create signal process context */
 
@@ -345,8 +344,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * will be restored by the signal trampoline after the signals
            * have been delivered.
            */
-
-          tcb->xcp.sigdeliver      = sigdeliver;
 
 #ifdef CONFIG_ARCH_FPU
           tcb->xcp.saved_fpu_regs = tcb->xcp.fpu_regs;

--- a/arch/avr/src/avr/avr_checkstack.c
+++ b/arch/avr/src/avr/avr_checkstack.c
@@ -145,7 +145,7 @@ size_t avr_stack_check(uintptr_t alloc, size_t size)
 size_t up_check_tcbstack(FAR struct tcb_s *tcb)
 {
   return avr_stack_check((uintptr_t)tcb->stack_base_ptr,
-                         tcb->adj_stack_size);
+                                    tcb->adj_stack_size);
 }
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 3

--- a/arch/avr/src/avr/avr_initialstate.c
+++ b/arch/avr/src/avr/avr_initialstate.c
@@ -89,27 +89,27 @@ void up_initial_state(struct tcb_s *tcb)
 
   /* Set the initial stack pointer to the top of the allocated stack */
 
-  sp                   = (uintptr_t)tcb->stack_base_ptr +
-                                    tcb->adj_stack_size;
-  xcp->regs[REG_SPH]   = (uint8_t)(sp >> 8);
-  xcp->regs[REG_SPL]   = (uint8_t)(sp & 0xff);
+  sp                  = (uintptr_t)tcb->stack_base_ptr +
+                                   tcb->adj_stack_size;
+  xcp->regs[REG_SPH]  = (uint8_t)(sp >> 8);
+  xcp->regs[REG_SPL]  = (uint8_t)(sp & 0xff);
 
   /* Save the task entry point */
 
 #if !defined(REG_PC2)
-  xcp->regs[REG_PC0]   = (uint8_t)((uintptr_t)tcb->start >> 8);
-  xcp->regs[REG_PC1]   = (uint8_t)((uintptr_t)tcb->start & 0xff);
+  xcp->regs[REG_PC0]  = (uint8_t)((uintptr_t)tcb->start >> 8);
+  xcp->regs[REG_PC1]  = (uint8_t)((uintptr_t)tcb->start & 0xff);
 #else
-  xcp->regs[REG_PC0]   = (uint8_t)((uint32_t)(uintptr_t)tcb->start >> 16);
-  xcp->regs[REG_PC1]   = (uint8_t)((uintptr_t)tcb->start >> 8);
-  xcp->regs[REG_PC2]   = (uint8_t)((uintptr_t)tcb->start & 0xff);
+  xcp->regs[REG_PC0]  = (uint8_t)((uint32_t)(uintptr_t)tcb->start >> 16);
+  xcp->regs[REG_PC1]  = (uint8_t)((uintptr_t)tcb->start >> 8);
+  xcp->regs[REG_PC2]  = (uint8_t)((uintptr_t)tcb->start & 0xff);
 #endif
 
   /* Enable or disable interrupts, based on user configuration */
 
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
-  xcp->regs[REG_SREG]  = getsreg() & ~(1 << SREG_I);
+  xcp->regs[REG_SREG] = getsreg() & ~(1 << SREG_I);
 #else
-  xcp->regs[REG_SREG]  = getsreg() | (1 << SREG_I);
+  xcp->regs[REG_SREG] = getsreg() | (1 << SREG_I);
 #endif
 }

--- a/arch/avr/src/avr/avr_schedulesigaction.c
+++ b/arch/avr/src/avr/avr_schedulesigaction.c
@@ -85,6 +85,8 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   if (!tcb->xcp.sigdeliver)
     {
+      tcb->xcp.sigdeliver = sigdeliver;
+
       /* First, handle some special cases when the signal is
        * being delivered to the currently executing task.
        */
@@ -103,6 +105,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
               /* In this case just deliver the signal now. */
 
               sigdeliver(tcb);
+              tcb->xcp.sigdeliver = NULL;
             }
 
           /* CASE 2:  We are in an interrupt handler AND the
@@ -124,13 +127,12 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * trampoline after the signal(s) have been delivered.
                */
 
-              tcb->xcp.sigdeliver   = sigdeliver;
-              tcb->xcp.saved_pc0    = g_current_regs[REG_PC0];
-              tcb->xcp.saved_pc1    = g_current_regs[REG_PC1];
+              tcb->xcp.saved_pc0      = g_current_regs[REG_PC0];
+              tcb->xcp.saved_pc1      = g_current_regs[REG_PC1];
 #if defined(REG_PC2)
-              tcb->xcp.saved_pc2    = g_current_regs[REG_PC2];
+              tcb->xcp.saved_pc2      = g_current_regs[REG_PC2];
 #endif
-              tcb->xcp.saved_sreg   = g_current_regs[REG_SREG];
+              tcb->xcp.saved_sreg     = g_current_regs[REG_SREG];
 
               /* Then set up to vector to the trampoline with interrupts
                * disabled
@@ -167,28 +169,27 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * the signals have been delivered.
            */
 
-          tcb->xcp.sigdeliver       = sigdeliver;
-          tcb->xcp.saved_pc0        = tcb->xcp.regs[REG_PC0];
-          tcb->xcp.saved_pc1        = tcb->xcp.regs[REG_PC1];
+          tcb->xcp.saved_pc0     = tcb->xcp.regs[REG_PC0];
+          tcb->xcp.saved_pc1     = tcb->xcp.regs[REG_PC1];
 #if defined(REG_PC2)
-          tcb->xcp.saved_pc2        = tcb->xcp.regs[REG_PC2];
+          tcb->xcp.saved_pc2     = tcb->xcp.regs[REG_PC2];
 #endif
-          tcb->xcp.saved_sreg       = tcb->xcp.regs[REG_SREG];
+          tcb->xcp.saved_sreg    = tcb->xcp.regs[REG_SREG];
 
           /* Then set up to vector to the trampoline with interrupts
            * disabled
            */
 
 #if !defined(REG_PC2)
-          tcb->xcp.regs[REG_PC0]    = (uint16_t)reg_ptr >> 8;
-          tcb->xcp.regs[REG_PC1]    = (uint16_t)reg_ptr & 0xff;
+          tcb->xcp.regs[REG_PC0] = (uint16_t)reg_ptr >> 8;
+          tcb->xcp.regs[REG_PC1] = (uint16_t)reg_ptr & 0xff;
 #else
-          tcb->xcp.regs[REG_PC0]    = (uint32_t)reg_ptr >> 16;
-          tcb->xcp.regs[REG_PC1]    = (uint32_t)reg_ptr >> 8;
-          tcb->xcp.regs[REG_PC2]    = (uint32_t)reg_ptr & 0xff;
+          tcb->xcp.regs[REG_PC0] = (uint32_t)reg_ptr >> 16;
+          tcb->xcp.regs[REG_PC1] = (uint32_t)reg_ptr >> 8;
+          tcb->xcp.regs[REG_PC2] = (uint32_t)reg_ptr & 0xff;
 
 #endif
-          tcb->xcp.regs[REG_SREG]  &= ~(1 << SREG_I);
+          tcb->xcp.regs[REG_SREG] &= ~(1 << SREG_I);
         }
     }
 }

--- a/arch/avr/src/avr32/avr_initialstate.c
+++ b/arch/avr/src/avr32/avr_initialstate.c
@@ -99,12 +99,12 @@ void up_initial_state(struct tcb_s *tcb)
 
   /* Set the initial stack pointer to the top of the allocated stack */
 
-  xcp->regs[REG_SP]      = (uint32_t)tcb->stack_base_ptr +
-                                     tcb->adj_stack_size;
+  xcp->regs[REG_SP] = (uint32_t)tcb->stack_base_ptr +
+                                tcb->adj_stack_size;
 
   /* Save the task entry point */
 
-  xcp->regs[REG_PC]      = (uint32_t)tcb->start;
+  xcp->regs[REG_PC] = (uint32_t)tcb->start;
 
   /* Set supervisor- or user-mode, depending on how NuttX is configured and
    * what kind of thread is being started.  Disable FIQs in any event
@@ -120,8 +120,8 @@ void up_initial_state(struct tcb_s *tcb)
   /* Enable or disable interrupts, based on user configuration */
 
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
-  xcp->regs[REG_SR]    = avr32_sr() | AVR32_SR_GM_MASK;
+  xcp->regs[REG_SR] = avr32_sr() | AVR32_SR_GM_MASK;
 #else
-  xcp->regs[REG_SR]    = avr32_sr() & ~AVR32_SR_GM_MASK;
+  xcp->regs[REG_SR] = avr32_sr() & ~AVR32_SR_GM_MASK;
 #endif
 }

--- a/arch/ceva/src/common/ceva_schedulesigaction.c
+++ b/arch/ceva/src/common/ceva_schedulesigaction.c
@@ -81,6 +81,8 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   if (tcb->xcp.sigdeliver == NULL)
     {
+      tcb->xcp.sigdeliver = sigdeliver;
+
       /* First, handle some special cases when the signal is being delivered
        * to task that is currently executing on any CPU.
        */
@@ -105,6 +107,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
               /* In this case just deliver the signal now. */
 
               sigdeliver(tcb);
+              tcb->xcp.sigdeliver = NULL;
             }
 
           /* CASE 2:  The task that needs to receive the signal is running.
@@ -141,7 +144,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
               /* Save the current register context location */
 
               tcb->xcp.saved_regs = g_current_regs[cpu];
-              tcb->xcp.sigdeliver = (void *)sigdeliver;
 
               /* Duplicate the register context.  These will be
                * restored by the signal trampoline after the signal has been
@@ -149,8 +151,8 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                */
 
               g_current_regs[cpu] -= XCPTCONTEXT_REGS;
-              memcpy(g_current_regs[cpu], g_current_regs[cpu]
-                    + XCPTCONTEXT_REGS, XCPTCONTEXT_SIZE);
+              memcpy(g_current_regs[cpu], g_current_regs[cpu] +
+                     XCPTCONTEXT_REGS, XCPTCONTEXT_SIZE);
 
               g_current_regs[cpu][REG_SP]  = (uint32_t)g_current_regs[cpu];
 
@@ -186,15 +188,14 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
           /* Save the current register context location */
 
           tcb->xcp.saved_regs = tcb->xcp.regs;
-          tcb->xcp.sigdeliver = (void *)sigdeliver;
 
           /* Duplicate the register context.  These will be restored
            * by the signal trampoline after the signal has been delivered.
            */
 
           tcb->xcp.regs -= XCPTCONTEXT_REGS;
-          memcpy(tcb->xcp.regs, tcb->xcp.regs
-                + XCPTCONTEXT_REGS, XCPTCONTEXT_SIZE);
+          memcpy(tcb->xcp.regs, tcb->xcp.regs +
+                 XCPTCONTEXT_REGS, XCPTCONTEXT_SIZE);
 
           tcb->xcp.regs[REG_SP]  = (uint32_t)tcb->xcp.regs;
 

--- a/arch/hc/src/m9s12/m9s12_initialstate.c
+++ b/arch/hc/src/m9s12/m9s12_initialstate.c
@@ -85,20 +85,20 @@ void up_initial_state(struct tcb_s *tcb)
 
   /* Save the initial stack pointer */
 
-  sp                      = (uintptr_t)tcb->stack_base_ptr +
-                                       tcb->adj_stack_size;
-  xcp->regs[REG_SPH]      = sp >> 8;
-  xcp->regs[REG_SPL]      = sp & 0xff;
+  sp                   = (uintptr_t)tcb->stack_base_ptr +
+                                    tcb->adj_stack_size;
+  xcp->regs[REG_SPH]   = sp >> 8;
+  xcp->regs[REG_SPL]   = sp & 0xff;
 
   /* Save the task entry point */
 
-  xcp->regs[REG_PCH]      = (uint16_t)tcb->start >> 8;
-  xcp->regs[REG_PCL]      = (uint16_t)tcb->start & 0xff;
+  xcp->regs[REG_PCH]   = (uint16_t)tcb->start >> 8;
+  xcp->regs[REG_PCL]   = (uint16_t)tcb->start & 0xff;
 
 #ifndef CONFIG_HCS12_NONBANKED
   /* Can only directly start in PPAGE 0x30 */
 
-  xcp->regs[REG_PPAGE]    = 0x30;
+  xcp->regs[REG_PPAGE] = 0x30;
 #endif
 
   /* Condition code register:
@@ -116,10 +116,10 @@ void up_initial_state(struct tcb_s *tcb)
 # ifdef CONFIG_SUPPRESS_INTERRUPTS
   /* Disable STOP, Mask I- and Z- interrupts */
 
-  xcp->regs[REG_CCR]      = HCS12_CCR_S | HCS12_CCR_X | HCS12_CCR_I;
+  xcp->regs[REG_CCR]   = HCS12_CCR_S | HCS12_CCR_X | HCS12_CCR_I;
 # else
   /* Disable STOP, Enable I- and Z-interrupts */
 
-  xcp->regs[REG_CCR]      = HCS12_CCR_S;
+  xcp->regs[REG_CCR]   = HCS12_CCR_S;
 # endif
 }

--- a/arch/mips/src/mips32/mips_initialstate.c
+++ b/arch/mips/src/mips32/mips_initialstate.c
@@ -92,12 +92,12 @@ void up_initial_state(struct tcb_s *tcb)
    * only the start function would do that and we have control over that one.
    */
 
-  xcp->regs[REG_SP]      = (uint32_t)tcb->stack_base_ptr +
-                                     tcb->adj_stack_size;
+  xcp->regs[REG_SP] = (uint32_t)tcb->stack_base_ptr +
+                                tcb->adj_stack_size;
 
   /* Save the task entry point */
 
-  xcp->regs[REG_EPC]     = (uint32_t)tcb->start;
+  xcp->regs[REG_EPC] = (uint32_t)tcb->start;
 
   /* If this task is running PIC, then set the PIC base register to the
    * address of the allocated D-Space region.

--- a/arch/mips/src/mips32/mips_schedulesigaction.c
+++ b/arch/mips/src/mips32/mips_schedulesigaction.c
@@ -86,6 +86,8 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   if (!tcb->xcp.sigdeliver)
     {
+      tcb->xcp.sigdeliver = sigdeliver;
+
       /* First, handle some special cases when the signal is
        * being delivered to the currently executing task.
        */
@@ -104,6 +106,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
               /* In this case just deliver the signal now. */
 
               sigdeliver(tcb);
+              tcb->xcp.sigdeliver = NULL;
             }
 
           /* CASE 2:  We are in an interrupt handler AND the
@@ -125,7 +128,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * been delivered.
                */
 
-              tcb->xcp.sigdeliver       = sigdeliver;
               tcb->xcp.saved_epc        = CURRENT_REGS[REG_EPC];
               tcb->xcp.saved_status     = CURRENT_REGS[REG_STATUS];
 
@@ -133,11 +135,11 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * disabled
                */
 
-              CURRENT_REGS[REG_EPC]      = (uint32_t)mips_sigdeliver;
-              status                     = CURRENT_REGS[REG_STATUS];
-              status                    &= ~CP0_STATUS_INT_MASK;
-              status                    |= CP0_STATUS_INT_SW0;
-              CURRENT_REGS[REG_STATUS]   = status;
+              CURRENT_REGS[REG_EPC]     = (uint32_t)mips_sigdeliver;
+              status                    = CURRENT_REGS[REG_STATUS];
+              status                   &= ~CP0_STATUS_INT_MASK;
+              status                   |= CP0_STATUS_INT_SW0;
+              CURRENT_REGS[REG_STATUS]  = status;
 
               /* And make sure that the saved context in the TCB
                * is the same as the interrupt return context.
@@ -165,9 +167,8 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * been delivered.
            */
 
-          tcb->xcp.sigdeliver       = sigdeliver;
-          tcb->xcp.saved_epc        = tcb->xcp.regs[REG_EPC];
-          tcb->xcp.saved_status     = tcb->xcp.regs[REG_STATUS];
+          tcb->xcp.saved_epc         = tcb->xcp.regs[REG_EPC];
+          tcb->xcp.saved_status      = tcb->xcp.regs[REG_STATUS];
 
           /* Then set up to vector to the trampoline with interrupts
            * disabled

--- a/arch/misoc/src/minerva/minerva_schedulesigaction.c
+++ b/arch/misoc/src/minerva/minerva_schedulesigaction.c
@@ -84,6 +84,8 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   if (!tcb->xcp.sigdeliver)
     {
+      tcb->xcp.sigdeliver = sigdeliver;
+
       /* First, handle some special cases when the signal is being delivered
        * to the currently executing task.
        */
@@ -101,6 +103,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
               /* In this case just deliver the signal now. */
 
               sigdeliver(tcb);
+              tcb->xcp.sigdeliver = NULL;
             }
 
           /* CASE 2: We are in an interrupt handler AND the interrupted task
@@ -122,7 +125,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * been delivered.
                */
 
-              tcb->xcp.sigdeliver = sigdeliver;
               tcb->xcp.saved_epc = g_current_regs[REG_CSR_MEPC];
 
               /* Then set up to vector to the trampoline with interrupts
@@ -157,7 +159,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * delivered.
            */
 
-          tcb->xcp.sigdeliver = sigdeliver;
           tcb->xcp.saved_epc = tcb->xcp.regs[REG_CSR_MEPC];
           tcb->xcp.saved_int_ctx = tcb->xcp.regs[REG_CSR_MSTATUS];
 

--- a/arch/or1k/src/common/or1k_checkstack.c
+++ b/arch/or1k/src/common/or1k_checkstack.c
@@ -116,7 +116,7 @@ size_t or1k_stack_check(uintptr_t alloc, size_t size)
 size_t up_check_tcbstack(struct tcb_s *tcb)
 {
   return or1k_stack_check((uintptr_t)tcb->stack_base_ptr,
-                          tcb->adj_stack_size);
+                                     tcb->adj_stack_size);
 }
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 3

--- a/arch/or1k/src/common/or1k_initialstate.c
+++ b/arch/or1k/src/common/or1k_initialstate.c
@@ -95,12 +95,12 @@ void up_initial_state(struct tcb_s *tcb)
 
   memset(xcp, 0, sizeof(struct xcptcontext));
 
-  xcp->regs[REG_R1]      = (uint32_t)tcb->stack_base_ptr +
-                                     tcb->adj_stack_size;
-  xcp->regs[REG_PC]      = (uint32_t)tcb->start;
+  xcp->regs[REG_R1] = (uint32_t)tcb->stack_base_ptr +
+                                tcb->adj_stack_size;
+  xcp->regs[REG_PC] = (uint32_t)tcb->start;
 
   mfspr(SPR_SYS_SR, sr);
-  xcp->regs[REG_SR]      = sr;
+  xcp->regs[REG_SR] = sr;
 
 #ifdef CONFIG_NXFLAT
   /* Make certain that bit 0 is set in the main entry address.  This is

--- a/arch/or1k/src/common/or1k_schedulesigaction.c
+++ b/arch/or1k/src/common/or1k_schedulesigaction.c
@@ -82,6 +82,8 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   if (!tcb->xcp.sigdeliver)
     {
+      tcb->xcp.sigdeliver = sigdeliver;
+
       /* First, handle some special cases when the signal is
        * being delivered to the currently executing task.
        */
@@ -99,6 +101,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
               /* In this case just deliver the signal now. */
 
               sigdeliver(tcb);
+              tcb->xcp.sigdeliver = NULL;
             }
 
           /* CASE 2:  We are in an interrupt handler AND the
@@ -120,18 +123,17 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * the signals have been delivered.
                */
 
-              tcb->xcp.sigdeliver       = sigdeliver;
-              /* tcb->xcp.saved_pc         = CURRENT_REGS[REG_PC];
-               * tcb->xcp.saved_cpsr       = CURRENT_REGS[REG_CPSR];
+              /* tcb->xcp.saved_pc      = CURRENT_REGS[REG_PC];
+               * tcb->xcp.saved_cpsr    = CURRENT_REGS[REG_CPSR];
                */
 
               /* Then set up to vector to the trampoline with interrupts
                * disabled
                */
 
-              /* CURRENT_REGS[REG_PC]      = (uint32_t)or1k_sigdeliver;
-               * CURRENT_REGS[REG_CPSR]    = SVC_MODE | PSR_I_BIT |
-               *                             PSR_F_BIT;
+              /* CURRENT_REGS[REG_PC]   = (uint32_t)or1k_sigdeliver;
+               * CURRENT_REGS[REG_CPSR] = SVC_MODE | PSR_I_BIT |
+               *                          PSR_F_BIT;
                */
 
               /* And make sure that the saved context in the TCB
@@ -155,17 +157,16 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * the signals have been delivered.
            */
 
-          tcb->xcp.sigdeliver       = sigdeliver;
-          tcb->xcp.saved_pc         = tcb->xcp.regs[REG_PC];
+          tcb->xcp.saved_pc          = tcb->xcp.regs[REG_PC];
 
-          /* tcb->xcp.saved_cpsr       = tcb->xcp.regs[REG_CPSR]; */
+          /* tcb->xcp.saved_cpsr     = tcb->xcp.regs[REG_CPSR]; */
 
           /* Then set up to vector to the trampoline with interrupts
            * disabled
            */
 
-          /* tcb->xcp.regs[REG_PC]      = (uint32_t)or1k_sigdeliver;
-           * tcb->xcp.regs[REG_CPSR]    = SVC_MODE | PSR_I_BIT | PSR_F_BIT;
+          /* tcb->xcp.regs[REG_PC]   = (uint32_t)or1k_sigdeliver;
+           * tcb->xcp.regs[REG_CPSR] = SVC_MODE | PSR_I_BIT | PSR_F_BIT;
            */
         }
     }

--- a/arch/renesas/src/rx65n/rx65n_schedulesigaction.c
+++ b/arch/renesas/src/rx65n/rx65n_schedulesigaction.c
@@ -82,6 +82,8 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   if (!tcb->xcp.sigdeliver)
     {
+      tcb->xcp.sigdeliver = sigdeliver;
+
       /* First, handle some special cases when the signal is
        * being delivered to the currently executing task.
        */
@@ -99,6 +101,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
               /* In this case just deliver the signal now. */
 
               sigdeliver(tcb);
+              tcb->xcp.sigdeliver = NULL;
             }
 
           /* CASE 2:  We are in an interrupt handler AND the
@@ -114,16 +117,15 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * the signals have been delivered.
                */
 
-              tcb->xcp.sigdeliver   = sigdeliver;
-              tcb->xcp.saved_pc     = g_current_regs[REG_PC];
-              tcb->xcp.saved_sr     = g_current_regs[REG_PSW];
+              tcb->xcp.saved_pc        = g_current_regs[REG_PC];
+              tcb->xcp.saved_sr        = g_current_regs[REG_PSW];
 
               /* Then set up to vector to the trampoline with interrupts
                * disabled
                */
 
-              g_current_regs[REG_PC]  = (uint32_t)renesas_sigdeliver;
-              g_current_regs[REG_PSW] |=  0x00030000;
+              g_current_regs[REG_PC]   = (uint32_t)renesas_sigdeliver;
+              g_current_regs[REG_PSW] |= 0x00030000;
 
               /* And make sure that the saved context in the TCB
                * is the same as the interrupt return context.
@@ -146,16 +148,15 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * the signals have been delivered.
            */
 
-          tcb->xcp.sigdeliver    = sigdeliver;
-          tcb->xcp.saved_pc      = tcb->xcp.regs[REG_PC];
-          tcb->xcp.saved_sr      = tcb->xcp.regs[REG_PSW];
+          tcb->xcp.saved_pc       = tcb->xcp.regs[REG_PC];
+          tcb->xcp.saved_sr       = tcb->xcp.regs[REG_PSW];
 
           /* Then set up to vector to the trampoline with interrupts
            * disabled
            */
 
-          tcb->xcp.regs[REG_PC]  = (uint32_t)renesas_sigdeliver;
-          tcb->xcp.regs[REG_PSW]  |=  0x00030000;
+          tcb->xcp.regs[REG_PC]   = (uint32_t)renesas_sigdeliver;
+          tcb->xcp.regs[REG_PSW] |= 0x00030000;
         }
     }
 }

--- a/arch/renesas/src/sh1/sh1_schedulesigaction.c
+++ b/arch/renesas/src/sh1/sh1_schedulesigaction.c
@@ -82,6 +82,8 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   if (!tcb->xcp.sigdeliver)
     {
+      tcb->xcp.sigdeliver = sigdeliver;
+
       /* First, handle some special cases when the signal is
        * being delivered to the currently executing task.
        */
@@ -99,6 +101,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
               /* In this case just deliver the signal now. */
 
               sigdeliver(tcb);
+              tcb->xcp.sigdeliver = NULL;
             }
 
           /* CASE 2:  We are in an interrupt handler AND the
@@ -114,9 +117,8 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * the signals have been delivered.
                */
 
-              tcb->xcp.sigdeliver   = sigdeliver;
-              tcb->xcp.saved_pc     = g_current_regs[REG_PC];
-              tcb->xcp.saved_sr     = g_current_regs[REG_SR];
+              tcb->xcp.saved_pc       = g_current_regs[REG_PC];
+              tcb->xcp.saved_sr       = g_current_regs[REG_SR];
 
               /* Then set up to vector to the trampoline with interrupts
                * disabled
@@ -146,7 +148,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * the signals have been delivered.
            */
 
-          tcb->xcp.sigdeliver    = sigdeliver;
           tcb->xcp.saved_pc      = tcb->xcp.regs[REG_PC];
           tcb->xcp.saved_sr      = tcb->xcp.regs[REG_SR];
 

--- a/arch/risc-v/src/common/riscv_checkstack.c
+++ b/arch/risc-v/src/common/riscv_checkstack.c
@@ -168,7 +168,7 @@ size_t up_check_tcbstack(struct tcb_s *tcb)
 #endif
 
   size = riscv_stack_check((uintptr_t)tcb->stack_base_ptr,
-                           tcb->adj_stack_size);
+                                      tcb->adj_stack_size);
 
 #ifdef CONFIG_ARCH_ADDRENV
   if (tcb->addrenv_own != NULL)

--- a/arch/sim/src/sim/sim_checkstack.c
+++ b/arch/sim/src/sim/sim_checkstack.c
@@ -155,5 +155,5 @@ size_t sim_stack_check(void *alloc, size_t size)
 size_t up_check_tcbstack(struct tcb_s *tcb)
 {
   return sim_stack_check((void *)(uintptr_t)tcb->stack_base_ptr,
-                         tcb->adj_stack_size);
+                                            tcb->adj_stack_size);
 }

--- a/arch/sim/src/sim/sim_schedulesigaction.c
+++ b/arch/sim/src/sim/sim_schedulesigaction.c
@@ -83,13 +83,14 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   flags = enter_critical_section();
 
-  if (tcb == this_task())
-    {
-      sigdeliver(tcb);
-    }
-  else
+  if (tcb->xcp.sigdeliver == NULL)
     {
       tcb->xcp.sigdeliver = sigdeliver;
+      if (tcb == this_task())
+        {
+          sigdeliver(tcb);
+          tcb->xcp.sigdeliver = NULL;
+        }
     }
 
   leave_critical_section(flags);

--- a/arch/sparc/src/sparc_v8/sparc_v8_doirq.c
+++ b/arch/sparc/src/sparc_v8/sparc_v8_doirq.c
@@ -110,7 +110,7 @@ uint32_t *sparc_doirq(int irq, uint32_t *regs)
    */
 
   regs = (uint32_t *)((uint32_t)CURRENT_REGS -
-                       CPU_MINIMUM_STACK_FRAME_SIZE);
+                                CPU_MINIMUM_STACK_FRAME_SIZE);
 
   /* Restore the cpu lock */
 

--- a/arch/sparc/src/sparc_v8/sparc_v8_initialstate.c
+++ b/arch/sparc/src/sparc_v8/sparc_v8_initialstate.c
@@ -91,13 +91,13 @@ void up_initial_state(struct tcb_s *tcb)
 
   /* Set the initial stack pointer to the "base" of the allocated stack */
 
-  xcp->regs[REG_I6]      = (uint32_t)tcb->stack_base_ptr +
-                                     tcb->adj_stack_size;
+  xcp->regs[REG_I6]  = (uint32_t)tcb->stack_base_ptr +
+                                 tcb->adj_stack_size;
 
   /* Save the task entry point */
 
-  xcp->regs[REG_PC]      = (uint32_t)(tcb->start);
-  xcp->regs[REG_NPC]     = (uint32_t)(tcb->start + 4);
+  xcp->regs[REG_PC]  = (uint32_t)(tcb->start);
+  xcp->regs[REG_NPC] = (uint32_t)(tcb->start + 4);
 
   /* Set supervisor- or user-mode, depending on how NuttX is configured and
    * what kind of thread is being started.  Disable FIQs in any event

--- a/arch/sparc/src/sparc_v8/sparc_v8_schedulesigaction.c
+++ b/arch/sparc/src/sparc_v8/sparc_v8_schedulesigaction.c
@@ -86,6 +86,8 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   if (!tcb->xcp.sigdeliver)
     {
+      tcb->xcp.sigdeliver = sigdeliver;
+
       /* First, handle some special cases when the signal is
        * being delivered to the currently executing task.
        */
@@ -103,6 +105,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
               /* In this case just deliver the signal now. */
 
               sigdeliver(tcb);
+              tcb->xcp.sigdeliver = NULL;
             }
 
           /* CASE 2:  We are in an interrupt handler AND the
@@ -124,7 +127,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * trampoline after the signal(s) have been delivered.
                */
 
-              tcb->xcp.sigdeliver   = sigdeliver;
               tcb->xcp.saved_pc     = CURRENT_REGS[REG_PC];
               tcb->xcp.saved_npc    = CURRENT_REGS[REG_NPC];
               tcb->xcp.saved_status = CURRENT_REGS[REG_PSR];
@@ -158,7 +160,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * the signals have been delivered.
            */
 
-          tcb->xcp.sigdeliver       = sigdeliver;
           tcb->xcp.saved_pc         = tcb->xcp.regs[REG_PC];
           tcb->xcp.saved_npc        = tcb->xcp.regs[REG_NPC];
           tcb->xcp.saved_status     = tcb->xcp.regs[REG_PSR];
@@ -194,6 +195,8 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   if (!tcb->xcp.sigdeliver)
     {
+      tcb->xcp.sigdeliver = sigdeliver;
+
       /* First, handle some special cases when the signal is being delivered
        * to task that is currently executing on any CPU.
        */
@@ -216,6 +219,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                */
 
               sigdeliver(tcb);
+              tcb->xcp.sigdeliver = NULL;
             }
 
           /* CASE 2:  The task that needs to receive the signal is running.
@@ -251,19 +255,18 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                    * been delivered.
                    */
 
-                  tcb->xcp.sigdeliver       = (void *)sigdeliver;
-                  tcb->xcp.saved_pc         = tcb->xcp.regs[REG_PC];
-                  tcb->xcp.saved_npc        = tcb->xcp.regs[REG_NPC];
-                  tcb->xcp.saved_status     = tcb->xcp.regs[REG_PSR];
+                  tcb->xcp.saved_pc     = tcb->xcp.regs[REG_PC];
+                  tcb->xcp.saved_npc    = tcb->xcp.regs[REG_NPC];
+                  tcb->xcp.saved_status = tcb->xcp.regs[REG_PSR];
 
                   /* Then set up vector to the trampoline with interrupts
                    * disabled.  We must already be in privileged thread mode
                    * to be here.
                    */
 
-                  tcb->xcp.regs[REG_PC]     = (uint32_t)sparc_sigdeliver;
-                  tcb->xcp.regs[REG_NPC]    = (uint32_t)sparc_sigdeliver + 4;
-                  tcb->xcp.regs[REG_PSR]    |= SPARC_PSR_ET_MASK;
+                  tcb->xcp.regs[REG_PC]  = (uint32_t)sparc_sigdeliver;
+                  tcb->xcp.regs[REG_NPC] = (uint32_t)sparc_sigdeliver + 4;
+                  tcb->xcp.regs[REG_PSR] |= SPARC_PSR_ET_MASK;
                 }
               else
                 {
@@ -274,7 +277,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                    * trampoline after the signal(s) have been delivered.
                    */
 
-                  tcb->xcp.sigdeliver   = (void *)sigdeliver;
                   tcb->xcp.saved_pc     = CURRENT_REGS[REG_PC];
                   tcb->xcp.saved_npc    = CURRENT_REGS[REG_NPC];
                   tcb->xcp.saved_status = CURRENT_REGS[REG_PSR];
@@ -330,7 +332,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * trampoline after the signal(s) have been delivered.
            */
 
-          tcb->xcp.sigdeliver       = (void *)sigdeliver;
           tcb->xcp.saved_pc     = CURRENT_REGS[REG_PC];
           tcb->xcp.saved_npc    = CURRENT_REGS[REG_NPC];
           tcb->xcp.saved_status = CURRENT_REGS[REG_PSR];
@@ -347,9 +348,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * here.
            */
 
-          tcb->xcp.regs[REG_PC]     = (uint32_t)sparc_sigdeliver;
-          tcb->xcp.regs[REG_NPC]    = (uint32_t)sparc_sigdeliver + 4;
-          tcb->xcp.regs[REG_PSR]    |= SPARC_PSR_ET_MASK;
+          tcb->xcp.regs[REG_PC]  = (uint32_t)sparc_sigdeliver;
+          tcb->xcp.regs[REG_NPC] = (uint32_t)sparc_sigdeliver + 4;
+          tcb->xcp.regs[REG_PSR] |= SPARC_PSR_ET_MASK;
         }
     }
 

--- a/arch/x86/src/i486/i486_initialstate.c
+++ b/arch/x86/src/i486/i486_initialstate.c
@@ -87,20 +87,20 @@ void up_initial_state(struct tcb_s *tcb)
    * that depends on if a priority change is required or not.
    */
 
-  xcp->regs[REG_SP]      = (uint32_t)tcb->stack_base_ptr +
-                                     tcb->adj_stack_size;
+  xcp->regs[REG_SP]     = (uint32_t)tcb->stack_base_ptr +
+                                    tcb->adj_stack_size;
 
   /* Save the task entry point */
 
-  xcp->regs[REG_EIP]     = (uint32_t)tcb->start;
+  xcp->regs[REG_EIP]    = (uint32_t)tcb->start;
 
   /* Set up the segment registers... assume the same segment as the caller.
    * That is not a good assumption in the long run.
    */
 
-  xcp->regs[REG_DS]      = up_getds();
-  xcp->regs[REG_CS]      = up_getcs();
-  xcp->regs[REG_SS]      = up_getss();
+  xcp->regs[REG_DS]     = up_getds();
+  xcp->regs[REG_CS]     = up_getcs();
+  xcp->regs[REG_SS]     = up_getss();
 
   /* Set supervisor- or user-mode, depending on how NuttX is configured and
    * what kind of thread is being started.  Disable FIQs in any event
@@ -118,6 +118,6 @@ void up_initial_state(struct tcb_s *tcb)
    */
 
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
-  xcp->regs[REG_EFLAGS]  = X86_FLAGS_IF;
+  xcp->regs[REG_EFLAGS] = X86_FLAGS_IF;
 #endif
 }

--- a/arch/x86_64/src/intel64/intel64_initialstate.c
+++ b/arch/x86_64/src/intel64/intel64_initialstate.c
@@ -85,40 +85,40 @@ void up_initial_state(struct tcb_s *tcb)
 
   /* set the FCW to 1f80 */
 
-  xcp->regs[1]      = (uint64_t)0x0000037f00000000;
+  xcp->regs[1]          = (uint64_t)0x0000037f00000000;
 
   /* set the MXCSR to 1f80 */
 
-  xcp->regs[3]      = (uint64_t)0x0000000000001f80;
+  xcp->regs[3]          = (uint64_t)0x0000000000001f80;
 
   /* Save the initial stack pointer... the value of the stackpointer before
    * the "interrupt occurs."
    */
 
-  xcp->regs[REG_RSP]      = (uint64_t)tcb->stack_base_ptr +
-                                      tcb->adj_stack_size;
-  xcp->regs[REG_RBP]      = (uint64_t)tcb->stack_base_ptr +
-                                      tcb->adj_stack_size;
+  xcp->regs[REG_RSP]    = (uint64_t)tcb->stack_base_ptr +
+                                    tcb->adj_stack_size;
+  xcp->regs[REG_RBP]    = (uint64_t)tcb->stack_base_ptr +
+                                    tcb->adj_stack_size;
 
   /* Save the task entry point */
 
-  xcp->regs[REG_RIP]     = (uint64_t)tcb->start;
+  xcp->regs[REG_RIP]    = (uint64_t)tcb->start;
 
   /* Set up the segment registers... assume the same segment as the caller.
    * That is not a good assumption in the long run.
    */
 
-  xcp->regs[REG_DS]      = up_getds();
-  xcp->regs[REG_CS]      = up_getcs();
-  xcp->regs[REG_SS]      = up_getss();
-  xcp->regs[REG_ES]      = up_getes();
+  xcp->regs[REG_DS]     = up_getds();
+  xcp->regs[REG_CS]     = up_getcs();
+  xcp->regs[REG_SS]     = up_getss();
+  xcp->regs[REG_ES]     = up_getes();
 
   /* Aux GS and FS are set to be 0 */
 
   /* used by some libc for TLS and segment reference */
 
-  xcp->regs[REG_GS]      = 0;
-  xcp->regs[REG_FS]      = 0;
+  xcp->regs[REG_GS]     = 0;
+  xcp->regs[REG_FS]     = 0;
 
   /* Set supervisor- or user-mode, depending on how NuttX is configured and
    * what kind of thread is being started.  Disable FIQs in any event
@@ -136,7 +136,7 @@ void up_initial_state(struct tcb_s *tcb)
    */
 
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
-  xcp->regs[REG_RFLAGS]  = X86_64_RFLAGS_IF;
+  xcp->regs[REG_RFLAGS] = X86_64_RFLAGS_IF;
 #endif
 }
 

--- a/arch/xtensa/src/common/xtensa_checkstack.c
+++ b/arch/xtensa/src/common/xtensa_checkstack.c
@@ -159,7 +159,7 @@ size_t xtensa_stack_check(uintptr_t alloc, size_t size)
 size_t up_check_tcbstack(struct tcb_s *tcb)
 {
   return xtensa_stack_check((uintptr_t)tcb->stack_base_ptr,
-                            tcb->adj_stack_size);
+                                       tcb->adj_stack_size);
 }
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 15

--- a/arch/xtensa/src/common/xtensa_initialstate.c
+++ b/arch/xtensa/src/common/xtensa_initialstate.c
@@ -93,19 +93,19 @@ void up_initial_state(struct tcb_s *tcb)
 
   /* Set initial values of registers */
 
-  xcp->regs[REG_PC]   = (uint32_t)tcb->start;           /* Task entrypoint                */
-  xcp->regs[REG_A0]   = 0;                              /* To terminate GDB backtrace     */
-  xcp->regs[REG_A1]   = (uint32_t)tcb->stack_base_ptr + /* Physical top of stack frame    */
-                                  tcb->adj_stack_size;
+  xcp->regs[REG_PC] = (uint32_t)tcb->start;           /* Task entrypoint                */
+  xcp->regs[REG_A0] = 0;                              /* To terminate GDB backtrace     */
+  xcp->regs[REG_A1] = (uint32_t)tcb->stack_base_ptr + /* Physical top of stack frame    */
+                                tcb->adj_stack_size;
 
   /* Set initial PS to int level 0, user mode. */
 
 #ifdef __XTENSA_CALL0_ABI__
-  xcp->regs[REG_PS]   = PS_UM;
+  xcp->regs[REG_PS] = PS_UM;
 
 #else
   /* For windowed ABI set WOE and CALLINC (pretend task was 'call4'd). */
 
-  xcp->regs[REG_PS]   = PS_UM | PS_WOE | PS_CALLINC(1);
+  xcp->regs[REG_PS] = PS_UM | PS_WOE | PS_CALLINC(1);
 #endif
 }

--- a/arch/xtensa/src/esp32/esp32_cpustart.c
+++ b/arch/xtensa/src/esp32/esp32_cpustart.c
@@ -119,7 +119,7 @@ void IRAM_ATTR xtensa_appcpu_start(void)
    */
 
   sp = (uint32_t)tcb->stack_base_ptr + tcb->adj_stack_size -
-       XCPTCONTEXT_SIZE;
+                 XCPTCONTEXT_SIZE;
   __asm__ __volatile__("mov sp, %0\n" : : "r"(sp));
 
   sinfo("CPU%d Started\n", up_cpu_index());

--- a/arch/xtensa/src/esp32s3/esp32s3_cpustart.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_cpustart.c
@@ -116,7 +116,7 @@ void xtensa_appcpu_start(void)
    */
 
   sp = (uint32_t)tcb->stack_base_ptr + tcb->adj_stack_size -
-       XCPTCONTEXT_SIZE;
+                 XCPTCONTEXT_SIZE;
   __asm__ __volatile__("mov sp, %0\n" : : "r"(sp));
 
   sinfo("CPU%d Started\n", up_cpu_index());

--- a/arch/z16/src/common/z16_schedulesigaction.c
+++ b/arch/z16/src/common/z16_schedulesigaction.c
@@ -82,6 +82,8 @@ void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   if (!tcb->xcp.sigdeliver)
     {
+      tcb->xcp.sigdeliver = sigdeliver;
+
       /* First, handle some special cases when the signal is
        * being delivered to the currently executing task.
        */
@@ -99,6 +101,7 @@ void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver)
               /* In this case just deliver the signal now. */
 
               sigdeliver(tcb);
+              tcb->xcp.sigdeliver = NULL;
             }
 
           /* CASE 2:  We are in an interrupt handler AND the interrupted
@@ -117,7 +120,6 @@ void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * been delivered.
                */
 
-              tcb->xcp.sigdeliver       = sigdeliver;
               tcb->xcp.saved_pc         = *current_pc;
               tcb->xcp.saved_i          = g_current_regs[REG_FLAGS];
 
@@ -150,7 +152,6 @@ void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * the signals have been delivered.
            */
 
-          tcb->xcp.sigdeliver      = sigdeliver;
           tcb->xcp.saved_pc        = *saved_pc;
           tcb->xcp.saved_i         = tcb->xcp.regs[REG_FLAGS];
 

--- a/arch/z80/src/ez80/ez80_schedulesigaction.c
+++ b/arch/z80/src/ez80/ez80_schedulesigaction.c
@@ -50,14 +50,13 @@ static void ez80_sigsetup(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver,
    * the signal trampoline after the signals have been delivered.
    */
 
-  tcb->xcp.sigdeliver    = sigdeliver;
-  tcb->xcp.saved_pc      = regs[XCPT_PC];
-  tcb->xcp.saved_i       = regs[XCPT_I];
+  tcb->xcp.saved_pc = regs[XCPT_PC];
+  tcb->xcp.saved_i  = regs[XCPT_I];
 
   /* Then set up to vector to the trampoline with interrupts disabled */
 
-  regs[XCPT_PC]  = (chipreg_t)z80_sigdeliver;
-  regs[XCPT_I]   = 0;
+  regs[XCPT_PC] = (chipreg_t)z80_sigdeliver;
+  regs[XCPT_I]  = 0;
 }
 
 /****************************************************************************
@@ -108,6 +107,8 @@ void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   if (tcb->xcp.sigdeliver == NULL)
     {
+      tcb->xcp.sigdeliver = sigdeliver;
+
       /* First, handle some special cases when the signal is being delivered
        * to the currently executing task.
        */
@@ -123,6 +124,7 @@ void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver)
               /* In this case just deliver the signal now. */
 
               sigdeliver(tcb);
+              tcb->xcp.sigdeliver = NULL;
             }
 
           /* CASE 2:  We are in an interrupt handler AND the interrupted task

--- a/arch/z80/src/z180/z180_schedulesigaction.c
+++ b/arch/z80/src/z180/z180_schedulesigaction.c
@@ -53,14 +53,13 @@ static void z180_sigsetup(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver,
    * the signal trampoline after the signals have been delivered.
    */
 
-  tcb->xcp.sigdeliver    = sigdeliver;
-  tcb->xcp.saved_pc      = regs[XCPT_PC];
-  tcb->xcp.saved_i       = regs[XCPT_I];
+  tcb->xcp.saved_pc = regs[XCPT_PC];
+  tcb->xcp.saved_i  = regs[XCPT_I];
 
   /* Then set up to vector to the trampoline with interrupts disabled */
 
-  regs[XCPT_PC]  = (chipreg_t)z80_sigdeliver;
-  regs[XCPT_I]   = 0;
+  regs[XCPT_PC] = (chipreg_t)z80_sigdeliver;
+  regs[XCPT_I]  = 0;
 }
 
 /****************************************************************************
@@ -111,6 +110,8 @@ void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   if (tcb->xcp.sigdeliver == NULL)
     {
+      tcb->xcp.sigdeliver = sigdeliver;
+
       /* First, handle some special cases when the signal is being delivered
        * to the currently executing task.
        */
@@ -126,6 +127,7 @@ void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver)
               /* In this case just deliver the signal now. */
 
               sigdeliver(tcb);
+              tcb->xcp.sigdeliver = NULL;
             }
 
           /* CASE 2:  We are in an interrupt handler AND the interrupted task

--- a/arch/z80/src/z8/z8_schedulesigaction.c
+++ b/arch/z80/src/z8/z8_schedulesigaction.c
@@ -50,14 +50,13 @@ static void z8_sigsetup(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver,
    * the signal trampoline after the signals have been delivered.
    */
 
-  tcb->xcp.sigdeliver    = sigdeliver;
-  tcb->xcp.saved_pc      = regs[XCPT_PC];
-  tcb->xcp.saved_irqctl  = regs[XCPT_IRQCTL];
+  tcb->xcp.saved_pc     = regs[XCPT_PC];
+  tcb->xcp.saved_irqctl = regs[XCPT_IRQCTL];
 
   /* Then set up to vector to the trampoline with interrupts disabled */
 
-  regs[XCPT_PC]          = (chipreg_t)z80_sigdeliver;
-  regs[XCPT_IRQCTL]      = 0;
+  regs[XCPT_PC]         = (chipreg_t)z80_sigdeliver;
+  regs[XCPT_IRQCTL]     = 0;
 }
 
 /****************************************************************************
@@ -108,6 +107,8 @@ void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   if (tcb->xcp.sigdeliver == NULL)
     {
+      tcb->xcp.sigdeliver = sigdeliver;
+
       /* First, handle some special cases when the signal is being delivered
        * to the currently executing task.
        */
@@ -123,6 +124,7 @@ void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver)
               /* In this case just deliver the signal now. */
 
               sigdeliver(tcb);
+              tcb->xcp.sigdeliver = NULL;
             }
 
           /* CASE 2:  We are in an interrupt handler AND the interrupted task

--- a/arch/z80/src/z80/z80_schedulesigaction.c
+++ b/arch/z80/src/z80/z80_schedulesigaction.c
@@ -51,14 +51,13 @@ static void z80_sigsetup(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver,
    * the signal trampoline after the signals have been delivered.
    */
 
-  tcb->xcp.sigdeliver    = sigdeliver;
-  tcb->xcp.saved_pc      = regs[XCPT_PC];
-  tcb->xcp.saved_i       = regs[XCPT_I];
+  tcb->xcp.saved_pc = regs[XCPT_PC];
+  tcb->xcp.saved_i  = regs[XCPT_I];
 
   /* Then set up to vector to the trampoline with interrupts disabled */
 
-  regs[XCPT_PC]          = (chipreg_t)z80_sigdeliver;
-  regs[XCPT_I]           = 0;
+  regs[XCPT_PC]     = (chipreg_t)z80_sigdeliver;
+  regs[XCPT_I]      = 0;
 }
 
 /****************************************************************************
@@ -109,6 +108,8 @@ void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   if (tcb->xcp.sigdeliver == NULL)
     {
+      tcb->xcp.sigdeliver = sigdeliver;
+
       /* First, handle some special cases when the signal is being delivered
        * to the currently executing task.
        */
@@ -124,6 +125,7 @@ void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver)
               /* In this case just deliver the signal now. */
 
               sigdeliver(tcb);
+              tcb->xcp.sigdeliver = NULL;
             }
 
           /* CASE 2:  We are in an interrupt handler AND the interrupted task

--- a/sched/task/task_vfork.c
+++ b/sched/task/task_vfork.c
@@ -169,7 +169,7 @@ FAR struct task_tcb_s *nxtask_setup_vfork(start_t retaddr)
   /* Allocate the stack for the TCB */
 
   stack_size = (uintptr_t)ptcb->stack_base_ptr -
-      (uintptr_t)ptcb->stack_alloc_ptr + ptcb->adj_stack_size;
+               (uintptr_t)ptcb->stack_alloc_ptr + ptcb->adj_stack_size;
 
   ret = up_create_stack(&child->cmn, stack_size, ttype);
   if (ret < OK)


### PR DESCRIPTION
## Summary

to avoid the infinite recusive dispatch:
```
#0  myhandler (signo=27, info=0xf3e38b9c, context=0x0) at ltp/testcases/open_posix_testsuite/conformance/interfaces/sigqueue/7-1.c:39
#1  0x58f1c39e in nxsig_deliver (stcb=0xf4e20f40) at signal/sig_deliver.c:167
#2  0x58fa0664 in up_schedule_sigaction (tcb=0xf4e20f40, sigdeliver=0x58f1bab5 <nxsig_deliver>) at sim/sim_schedulesigaction.c:88
#3  0x58f19907 in nxsig_queue_action (stcb=0xf4e20f40, info=0xf4049334) at signal/sig_dispatch.c:115
#4  0x58f1b089 in nxsig_tcbdispatch (stcb=0xf4e20f40, info=0xf4049334) at signal/sig_dispatch.c:435
#5  0x58f31853 in nxsig_unmask_pendingsignal () at signal/sig_unmaskpendingsignal.c:104
#6  0x58f1ca09 in nxsig_deliver (stcb=0xf4e20f40) at signal/sig_deliver.c:199
#7  0x58fa0664 in up_schedule_sigaction (tcb=0xf4e20f40, sigdeliver=0x58f1bab5 <nxsig_deliver>) at sim/sim_schedulesigaction.c:88
#8  0x58f19907 in nxsig_queue_action (stcb=0xf4e20f40, info=0xf4049304) at signal/sig_dispatch.c:115
#9  0x58f1b089 in nxsig_tcbdispatch (stcb=0xf4e20f40, info=0xf4049304) at signal/sig_dispatch.c:435
#10 0x58f31853 in nxsig_unmask_pendingsignal () at signal/sig_unmaskpendingsignal.c:104
#11 0x58f1ca09 in nxsig_deliver (stcb=0xf4e20f40) at signal/sig_deliver.c:199
#12 0x58fa0664 in up_schedule_sigaction (tcb=0xf4e20f40, sigdeliver=0x58f1bab5 <nxsig_deliver>) at sim/sim_schedulesigaction.c:88
#13 0x58f19907 in nxsig_queue_action (stcb=0xf4e20f40, info=0xf40492d4) at signal/sig_dispatch.c:115
#14 0x58f1b089 in nxsig_tcbdispatch (stcb=0xf4e20f40, info=0xf40492d4) at signal/sig_dispatch.c:435
#15 0x58f31853 in nxsig_unmask_pendingsignal () at signal/sig_unmaskpendingsignal.c:104
#16 0x58f1ca09 in nxsig_deliver (stcb=0xf4e20f40) at signal/sig_deliver.c:199
#17 0x58fa0664 in up_schedule_sigaction (tcb=0xf4e20f40, sigdeliver=0x58f1bab5 <nxsig_deliver>) at sim/sim_schedulesigaction.c:88
#18 0x58f19907 in nxsig_queue_action (stcb=0xf4e20f40, info=0xf40492a4) at signal/sig_dispatch.c:115
#19 0x58f1b089 in nxsig_tcbdispatch (stcb=0xf4e20f40, info=0xf40492a4) at signal/sig_dispatch.c:435
#20 0x58f31853 in nxsig_unmask_pendingsignal () at signal/sig_unmaskpendingsignal.c:104
#21 0x58f1ca09 in nxsig_deliver (stcb=0xf4e20f40) at signal/sig_deliver.c:199
#22 0x58fa0664 in up_schedule_sigaction (tcb=0xf4e20f40, sigdeliver=0x58f1bab5 <nxsig_deliver>) at sim/sim_schedulesigaction.c:88
#23 0x58f19907 in nxsig_queue_action (stcb=0xf4e20f40, info=0xf4049274) at signal/sig_dispatch.c:115
#24 0x58f1b089 in nxsig_tcbdispatch (stcb=0xf4e20f40, info=0xf4049274) at signal/sig_dispatch.c:435
#25 0x58f31853 in nxsig_unmask_pendingsignal () at signal/sig_unmaskpendingsignal.c:104
#26 0x58f1ca09 in nxsig_deliver (stcb=0xf4e20f40) at signal/sig_deliver.c:199
#27 0x58fa0664 in up_schedule_sigaction (tcb=0xf4e20f40, sigdeliver=0x58f1bab5 <nxsig_deliver>) at sim/sim_schedulesigaction.c:88
#28 0x58f19907 in nxsig_queue_action (stcb=0xf4e20f40, info=0xf4049244) at signal/sig_dispatch.c:115
#29 0x58f1b089 in nxsig_tcbdispatch (stcb=0xf4e20f40, info=0xf4049244) at signal/sig_dispatch.c:435
#30 0x58f31853 in nxsig_unmask_pendingsignal () at signal/sig_unmaskpendingsignal.c:104
#31 0x58f1ca09 in nxsig_deliver (stcb=0xf4e20f40) at signal/sig_deliver.c:199
```

## Impact

signal send to self

## Testing

https://github.com/linux-test-project/ltp/blob/master/testcases/open_posix_testsuite/conformance/interfaces/sigqueue/7-1.c