### PR TITLE
Signal must be masked when it is delivered to a signal handler

### DIFF
--- a/sched/signal/sig_deliver.c
+++ b/sched/signal/sig_deliver.c
@@ -117,6 +117,7 @@ void nxsig_deliver(FAR struct tcb_s *stcb)
 
       savesigprocmask   = stcb->sigprocmask;
       sigorset(&newsigprocmask, &savesigprocmask, &sigq->mask);
+      nxsig_addset(&newsigprocmask, sigq->info.si_signo);
       stcb->sigprocmask = newsigprocmask;
 
 #ifndef CONFIG_BUILD_FLAT


### PR DESCRIPTION
## Summary

Signal must be masked when it is delivered to a signal handler per:

> https://pubs.opengroup.org/onlinepubs/007904875/functions/sigaction.html:
> 
> When a signal is caught by a signal-catching function installed by sigaction(), a new signal mask is calculated and installed for the duration of the signal-catching function (or until a call to either sigprocmask() or sigsuspend() is made). This mask is formed by taking the union of the current signal mask and the value of the sa_mask for the signal being delivered [XSI] [Option Start] unless SA_NODEFER or SA_RESETHAND is set, [Option End] and then including the signal being delivered. If and when the user's signal handler returns normally, the original signal mask is restored.

Any action queued for that signal while the signal is masked should be deferred. It should go into the group pending signal list and should not be processed until until the signal is unmasked (which should occur when the signal handler returns).

See Issue #9298

## Impact

- Follows POSIX more closely
-  Probably has little effect because sa_mask typically does mask the signal explicitly
-  Probably does not effect re-entrancy of the signal handler because that is protected by other means.

## Testing

sim:ostest
