### PR TITLE
drivers/serial/pty.c: Fix coverity issue

### DIFF
--- a/drivers/serial/pty.c
+++ b/drivers/serial/pty.c
@@ -471,7 +471,7 @@ static ssize_t pty_read(FAR struct file *filep, FAR char *buffer, size_t len)
       ntotal = file_read(&dev->pd_src, buffer, len);
     }
 
-  if (dev->pd_lflag & ECHO)
+  if ((dev->pd_lflag & ECHO) && (ntotal > 0))
     {
       pty_write(filep, buffer, ntotal);
     }


### PR DESCRIPTION


## Summary
Coverity report that `ntotal` may be a negative value.
## Impact
Minor
## Testing
sim and CI
