### PR TITLE
Fix windows compile errors because of double quotes in config

### DIFF
--- a/tools/Win.mk
+++ b/tools/Win.mk
@@ -52,6 +52,8 @@ ARCH_INC = $(ARCH_DIR)\include
 
 ifeq ($(CONFIG_APPS_DIR),)
 CONFIG_APPS_DIR = ..\apps
+else
+CONFIG_APPS_DIR := $(patsubst "%",%,$(CONFIG_APPS_DIR))
 endif
 APPDIR := $(realpath ${shell if exist "$(CONFIG_APPS_DIR)\Makefile" echo $(CONFIG_APPS_DIR)})
 


### PR DESCRIPTION
The "CONFIG_APPS_DIR" generated in .config has double quotes and is not recognized as a path by most make systems. This commits removes these double quotes to make the compile successfully.

## Summary
The "CONFIG_APPS_DIR" generated in .config has double quotes.
For example, by default "CONFIG_APPS_DIR" is:
CONFIG_APPS_DIR="../apps"
And thus when the make system expands "$(CONFIG_APPS_DIR)\Makefile", it will expand as
"../apps"\Makefile
And this path is not recognized by most make systems in windows (The make.exe in GnuWin32 recognizes this kind of path, but this program is quite out dated and tend to have other problems) and will result the APPDIR to be empty and thus the whole apps directory will not be built.

## Impact
* The build system when "CONFIG_WINDOWS_NATIVE=y" is defined.

## Testing
* sim:ostest
* s32k144evb
