### PR TITLE
arch/armv8-m: add ARMV8M_TRUSTZONE_HYBRID feature

### DIFF
--- a/arch/arm/src/armv8-m/Kconfig
+++ b/arch/arm/src/armv8-m/Kconfig
@@ -153,3 +153,19 @@ config ARMV8M_SYSTICK
 	depends on TIMER
 	---help---
 		Enable SysTick timer driver.
+
+config ARMV8M_TRUSTZONE_HYBRID
+	bool "Hybrid with secure and non-secure."
+	default n
+	depends on SMP
+	---help---
+		Enable the hybrid with secure and non-secure domain.
+		In SMP mode, you can enable this configuration when one
+		core supports secure and the other does not.
+
+config ARMV8M_TRUSTZONE_CPU_BITMASK
+	hex "Security support bitmap for multicore."
+	depends on ARMV8M_TRUSTZONE_HYBRID
+	default 0
+	---help---
+		Set Security bitmap for multicore, bit 0 means core 0.

--- a/arch/arm/src/armv8-m/arm_doirq.c
+++ b/arch/arm/src/armv8-m/arm_doirq.c
@@ -33,6 +33,7 @@
 #include <arch/board/board.h>
 
 #include "arm_internal.h"
+#include "exc_return.h"
 
 /****************************************************************************
  * Public Functions
@@ -92,5 +93,19 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 #endif
 
   board_autoled_off(LED_INIRQ);
+
+#ifdef CONFIG_ARMV8M_TRUSTZONE_HYBRID
+  if (((1 << up_cpu_index()) & CONFIG_ARMV8M_TRUSTZONE_CPU_BITMASK) == 0)
+    {
+      regs[REG_EXC_RETURN] &=
+        ~(EXC_RETURN_EXC_SECURE | EXC_RETURN_SECURE_STACK);
+    }
+  else
+    {
+      regs[REG_EXC_RETURN] |=
+        (EXC_RETURN_EXC_SECURE | EXC_RETURN_SECURE_STACK);
+    }
+#endif
+
   return regs;
 }


### PR DESCRIPTION
## Summary

Some chips only have one core that supports secure in smp mode, so need change EXC_RETURN to non-secure when switching to a core that does not support secure.

## Impact

armv8m SMP

## Testing

bes chip