### PR TITLE
arch/xtensa: only cmp fpu coprocessor for fpu test

### DIFF
--- a/arch/xtensa/src/common/xtensa_fpucmp.c
+++ b/arch/xtensa/src/common/xtensa_fpucmp.c
@@ -38,6 +38,7 @@
  * Private Data
  ****************************************************************************/
 
+#ifdef XCHAL_CP_ID_FPU
 static uint32_t g_coproc_sa_offsets[] =
 {
   XTENSA_CP0_SA, XTENSA_CP1_SA, XTENSA_CP2_SA, XTENSA_CP3_SA,
@@ -49,6 +50,7 @@ static uint32_t g_coproc_sa_sizes[] =
   XCHAL_CP0_SA_SIZE, XCHAL_CP1_SA_SIZE, XCHAL_CP2_SA_SIZE, XCHAL_CP3_SA_SIZE,
   XCHAL_CP4_SA_SIZE, XCHAL_CP5_SA_SIZE, XCHAL_CP6_SA_SIZE, XCHAL_CP7_SA_SIZE
 };
+#endif
 
 /****************************************************************************
  * Public Functions
@@ -72,6 +74,7 @@ static uint32_t g_coproc_sa_sizes[] =
 
 bool up_fpucmp(const void *saveregs1, const void *saveregs2)
 {
+#ifdef XCHAL_CP_ID_FPU
   const uint32_t *regs1 = saveregs1;
   const uint32_t *regs2 = saveregs2;
   uint32_t cpenable = xtensa_get_cpenable();
@@ -84,13 +87,21 @@ bool up_fpucmp(const void *saveregs1, const void *saveregs2)
       uint32_t reg_offset;
 
       ndx += i;
-      reg_offset = g_coproc_sa_offsets[ndx - 1] / 4;
-      ret = memcmp(&regs1[COMMON_CTX_REGS + reg_offset],
-                   &regs2[COMMON_CTX_REGS + reg_offset],
-                   g_coproc_sa_sizes[ndx - 1]) == 0;
+      if ((ndx - 1) == XCHAL_CP_ID_FPU)
+        {
+          reg_offset = g_coproc_sa_offsets[ndx - 1] / 4;
+          ret = memcmp(&regs1[COMMON_CTX_REGS + reg_offset],
+                       &regs2[COMMON_CTX_REGS + reg_offset],
+                       g_coproc_sa_sizes[ndx - 1]) == 0;
+          break;
+        }
+
       cpenable >>= i;
     }
 
   return ret;
+#else
+  return true;
+#endif
 }
 #endif /* CONFIG_ARCH_FPU */


### PR DESCRIPTION
## Summary

If the chip does not have a separate FPU coprocessor, the FPU test will fail.
So only  check the separate FPU coprocessor for FPU test. 

## Impact

FPU test

## Testing

bes1600: ostest pass