### PR TITLE
elf/coredump: correct register offset after xcp.regs update

### DIFF
--- a/binfmt/libelf/libelf_coredump.c
+++ b/binfmt/libelf/libelf_coredump.c
@@ -246,8 +246,20 @@ static void elf_emit_note_info(FAR struct elf_dumpinfo_s *cinfo)
 
       for (j = 0; j < nitems(status.pr_regs); j++)
         {
-          status.pr_regs[j] = *(uintptr_t *)((uint8_t *)tcb +
-                                             g_tcbinfo.reg_off.p[j]);
+          if (tcb->xcp.regs == NULL)
+            {
+              continue;
+            }
+
+          if (g_tcbinfo.reg_off.p[j] == UINT16_MAX)
+            {
+              status.pr_regs[j] = 0;
+            }
+          else
+            {
+              status.pr_regs[j] = *(uintptr_t *)((uint8_t *)tcb->xcp.regs +
+                                                 g_tcbinfo.reg_off.p[j]);
+            }
         }
 
       elf_emit(cinfo, &status, sizeof(status));


### PR DESCRIPTION
## Summary

elf/coredump: correct register offset after xcp.regs update

The offset should be calculated from pointer xcp.regs

## Impact

N/A

## Testing

sabre-6quad/smp   lm3s6965-ek/qemu-flat