### PR TITLE
Documentation: Improve "High Performance, Zero Latency Interrupts"

### DIFF
--- a/Documentation/guides/index.rst
+++ b/Documentation/guides/index.rst
@@ -16,3 +16,4 @@ Guides
   pysimcoder.rst
   customboards.rst
   customapps.rst
+  zerolatencyinterrupts.rst


### PR DESCRIPTION
## Summary

Fix reStructuredText mistakes I made in PR #9302.
Add a paragraph about jitter.
Fix some minor typos.
Add zerolatencyinterrupts.rst to the TOC so that it will actually show up at https://nuttx.apache.org/docs/latest/guides/index.html

## Impact

Improves our documentation!

## Testing

Viewed in GitHub.