### PR TITLE
fb_driver: add fb_open and fb_close

### DIFF
--- a/include/nuttx/video/fb.h
+++ b/include/nuttx/video/fb.h
@@ -673,6 +673,11 @@ struct fb_vtable_s
   int (*getplaneinfo)(FAR struct fb_vtable_s *vtable, int planeno,
                       FAR struct fb_planeinfo_s *pinfo);
 
+  /* open/close window. */
+
+  int (*open)(FAR struct fb_vtable_s *vtable);
+  int (*close)(FAR struct fb_vtable_s *vtable);
+
 #ifdef CONFIG_FB_CMAP
   /* The following are provided only if the video hardware supports RGB
    * color mapping


### PR DESCRIPTION
## Summary
Add fb_open() and fb_close().  We hope that when the emulator starts, the window will not be opened by default, and the window will be opened when the user opens /dev/fb, and the window will be closed when the user closes /dev/fb.

## Impact
None.

## Testing
fb example.
