### PR TITLE
vnc_server: set touch.maxpoint to 1 for circbuf_init

### DIFF
--- a/drivers/video/vnc/vnc_server.c
+++ b/drivers/video/vnc/vnc_server.c
@@ -125,6 +125,10 @@ static void vnc_reset_session(FAR struct vnc_session_s *session,
   session->nwhupd  = 0;
   session->change  = true;
 
+#ifdef CONFIG_VNCSERVER_TOUCH
+  session->touch.maxpoint = 1;
+#endif
+
   /* Careful not to disturb the keyboard/mouse callouts set by
    * vnc_fbinitialize().  Client related data left in garbage state.
    */


### PR DESCRIPTION
## Summary
Set touch.maxpoint to 1 in vnc_server.c for circbuf_init，otherwise touch_event will circbuf_overwrite a wrong value.
## Impact
VNC touch event
## Testing
VNC server run lvgldemo，and test touch event

