### PR TITLE
arch/arm64: .bss initialization using assembly language

### DIFF
--- a/arch/arm64/src/common/arm64_boot.c
+++ b/arch/arm64/src/common/arm64_boot.c
@@ -174,24 +174,8 @@ void arm64_boot_el1_init(void)
   ARM64_ISB();
 }
 
-/* These simple memset alternatives are necessary
- * as the function at libc is depend on the MMU
- * to be active.
- */
-
-static void boot_early_memset(void *dst, int c, size_t n)
-{
-  uint8_t *d = dst;
-
-  while (n--)
-    {
-      *d++ = c;
-    }
-}
-
 void arm64_boot_primary_c_routine(void)
 {
-  boot_early_memset(_START_BSS, 0, _END_BSS - _START_BSS);
   arm64_chip_boot();
   up_perf_init(NULL);
   nx_start();

--- a/arch/arm64/src/common/arm64_head.S
+++ b/arch/arm64/src/common/arm64_head.S
@@ -212,6 +212,8 @@ primary_core:
     bl    arm64_earlyprintinit
 #endif
 
+    bl    arm64_data_initialize
+
     PRINT(primary_boot, "- Ready to Boot Primary CPU\r\n")
 
 cpu_boot:
@@ -351,3 +353,38 @@ boot_stage_puts:
 .type boot_low_puts, %function;
 
 #endif /* !CONFIG_ARCH_EARLY_PRINT */
+
+/***************************************************************************
+ * Name: arm64_data_initialize
+ ***************************************************************************/
+
+    .type   arm64_data_initialize, #function
+
+arm64_data_initialize:
+
+    /* Zero BSS */
+
+    adr     x0, .Linitparms
+    ldp     x1, x2, [x0], #8
+
+    mov     x0, #0
+1:
+    cmp     x1, x2
+    bge     2f
+    str     x0, [x1], #8
+    b       1b
+2:
+    ret
+    .size   arm64_data_initialize, . - arm64_data_initialize
+
+/***************************************************************************
+ * Text-section constants
+ ***************************************************************************/
+
+    .data
+    .align  8
+    .type   .Linitparms, %object
+.Linitparms:
+    .quad   _sbss
+    .quad   _ebss
+    .size   .Linitparms, . -.Linitparms

--- a/boards/arm64/a64/pinephone/scripts/dramboot.ld
+++ b/boards/arm64/a64/pinephone/scripts/dramboot.ld
@@ -87,9 +87,10 @@ SECTIONS
   _edata = .; /* End+1 of .data */
 
   .bss : {                     /* BSS */
+       . = ALIGN(8);
        _sbss = .;
        *(.bss)
-       . = ALIGN(1 << 3);
+       . = ALIGN(8);
   } :text
   . = ALIGN(4096);
   _ebss = .;

--- a/boards/arm64/fvp-v8r/fvp-armv8r/scripts/dramboot.ld
+++ b/boards/arm64/fvp-v8r/fvp-armv8r/scripts/dramboot.ld
@@ -87,9 +87,10 @@ SECTIONS
   _edata = .; /* End+1 of .data */
 
   .bss : {                     /* BSS */
+       . = ALIGN(8);
        _sbss = .;
        *(.bss)
-       . = ALIGN(1 << 3);
+       . = ALIGN(8);
   } :text
   . = ALIGN(4096);
   _ebss = .;

--- a/boards/arm64/qemu/qemu-armv8a/scripts/dramboot.ld
+++ b/boards/arm64/qemu/qemu-armv8a/scripts/dramboot.ld
@@ -87,9 +87,10 @@ SECTIONS
   _edata = .; /* End+1 of .data */
 
   .bss : {                     /* BSS */
+       . = ALIGN(8);
        _sbss = .;
        *(.bss)
-       . = ALIGN(1 << 3);
+       . = ALIGN(8);
   } :text
   . = ALIGN(4096);
   _ebss = .;


### PR DESCRIPTION
## Summary

The compiler will optimize boot_early_memset to memset, but memset in libc cannot be used before MMU is enabled. Therefore, assembly language is used to implement the initialization of bss to avoid this problem.

## Impact

arm64 boot

## Testing

fvp-v8r and qemu-armv8a ostest