### PR TITLE
arch/arm64: Each core initializes its own idle stack in SMP

### DIFF
--- a/arch/arm64/src/common/arm64_cpustart.c
+++ b/arch/arm64/src/common/arm64_cpustart.c
@@ -222,15 +222,6 @@ int up_cpu_start(int cpu)
   sched_note_cpu_start(this_task(), cpu);
 #endif
 
-#ifdef CONFIG_STACK_COLORATION
-  /* If stack debug is enabled, then fill the stack with a
-   * recognizable value that we can use later to test for high
-   * water marks.
-   */
-
-  arm64_stack_color(g_cpu_idlestackalloc[cpu], SMP_STACK_SIZE);
-#endif
-
   cpu_boot_params.cpu_ready_flag = 0;
   arm64_start_cpu(cpu, (char *)g_cpu_idlestackalloc[cpu], SMP_STACK_SIZE,
                   arm64_smp_init_top);

--- a/arch/arm64/src/common/arm64_head.S
+++ b/arch/arm64/src/common/arm64_head.S
@@ -26,6 +26,7 @@
 #include <nuttx/config.h>
 
 #include "arm64_arch.h"
+#include "arm64_internal.h"
 #include "arm64_macro.inc"
 
 /****************************************************************************
@@ -153,7 +154,22 @@ real_start:
     /* we can now load our stack pointer value and move on */
 
     ldr    x24, [x0, #BOOT_PARAM_SP]
-    add    x24, x24, #(CONFIG_IDLETHREAD_STACKSIZE)
+
+#  ifdef CONFIG_STACK_COLORATION
+    /* Write a known value to the IDLE thread stack to support stack
+     * monitoring logic
+     */
+
+    ldr    w1, =SMP_STACK_WORDS
+    ldr    w2, =STACK_COLOR
+
+.loop:
+    sub    w1, w1, #1
+    str    w2, [x24], #4
+    cmp    w1, #0
+    bne    .loop
+#  endif
+
     ldr    x25, =arm64_boot_secondary_c_routine
     bl     __reset_prep_c
 

--- a/arch/arm64/src/common/arm64_internal.h
+++ b/arch/arm64/src/common/arm64_internal.h
@@ -91,6 +91,25 @@
 #define STACK_COLOR    0xdeaddead
 #define HEAP_COLOR     'h'
 
+/* AArch64 the stack-pointer must be 128-bit aligned */
+
+#define STACK_ALIGNMENT     16
+
+/* Stack alignment macros */
+
+#define STACK_ALIGN_MASK    (STACK_ALIGNMENT - 1)
+#define STACK_ALIGN_DOWN(a) ((a) & ~STACK_ALIGN_MASK)
+#define STACK_ALIGN_UP(a)   (((a) + STACK_ALIGN_MASK) & ~STACK_ALIGN_MASK)
+
+#ifdef CONFIG_SMP
+/* The size of interrupt and idle stack.  This is the configured
+ * value aligned the 8-bytes as required by the ARM EABI.
+ */
+
+#  define SMP_STACK_SIZE    STACK_ALIGN_UP(CONFIG_IDLETHREAD_STACKSIZE)
+#  define SMP_STACK_WORDS   (SMP_STACK_SIZE >> 2)
+#endif
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/
@@ -112,16 +131,6 @@ extern "C"
 #define EXTERN extern
 #endif
 
-/* AArch64 the stack-pointer must be 128-bit aligned */
-
-#define STACK_ALIGNMENT     16
-
-/* Stack alignment macros */
-
-#define STACK_ALIGN_MASK    (STACK_ALIGNMENT - 1)
-#define STACK_ALIGN_DOWN(a) ((a) & ~STACK_ALIGN_MASK)
-#define STACK_ALIGN_UP(a)   (((a) + STACK_ALIGN_MASK) & ~STACK_ALIGN_MASK)
-
 #define INIT_STACK_DEFINE(sym, size) \
     char locate_data(".initstack") \
      aligned_data(STACK_ALIGNMENT) sym[size]
@@ -142,12 +151,6 @@ extern "C"
 #define INTSTACK_SIZE        (CONFIG_ARCH_INTERRUPTSTACK & ~STACK_ALIGN_MASK)
 
 #ifdef CONFIG_SMP
-
-/* The size of interrupt and idle stack.  This is the configured
- * value aligned the 8-bytes as required by the ARM EABI.
- */
-
-#define SMP_STACK_SIZE       STACK_ALIGN_UP(CONFIG_IDLETHREAD_STACKSIZE)
 
 INIT_STACK_ARRAY_DEFINE_EXTERN(g_cpu_idlestackalloc, CONFIG_SMP_NCPUS,
                           SMP_STACK_SIZE);


### PR DESCRIPTION
## Summary

When the MMU/MPU of core0 is enabled while those of other cores are not, it is unsafe to operate the idle stack simultaneously. The idle stack of other cores will be flushed by the contents in the cache of core0, therefore it is necessary to initialize the idle stack and let each core handle it on its own.

## Impact

ARM64 SMP boot

## Testing

fvp-v8r:nsh_smp and qemu-armv8a:nsh_smp ostest