### PR TITLE
tools/mkallsyms: add exception handle

### DIFF
--- a/tools/mkallsyms.py
+++ b/tools/mkallsyms.py
@@ -99,8 +99,11 @@ class SymbolTables(object):
         symtable = self.get_symtable()
         for nsym, symbol in enumerate(symtable.iter_symbols()):
             if self.symbol_filter(symbol) is not None:
-                symbol_name = cxxfilt.demangle(symbol.name)
-                func_name = re.sub(r"\(.*$", "", symbol_name)
+                try:
+                    symbol_name = cxxfilt.demangle(symbol.name)
+                    func_name = re.sub(r"\(.*$", "", symbol_name)
+                except cxxfilt.InvalidName:
+                    symbol_name = symbol.name
                 self.symbol_list.append((symbol["st_value"] & ~0x01, func_name))
         self.symbol_list = sorted(self.symbol_list, key=lambda item: item[0])
 


### PR DESCRIPTION
## Summary
Parsing of some C++ complex declarations may fail.
Use the original symbol name directly on failure

## Impact

## Testing

