### PR TITLE
arch/arm/src: Fix Kconfig style and texts

### DIFF
--- a/arch/arm/src/gd32f4/Kconfig
+++ b/arch/arm/src/gd32f4/Kconfig
@@ -895,11 +895,11 @@ config GD32F4_TIMER0_CH3MODE
 		which drives CH3_O and CH3_ON.
 
 config GD32F4_TIMER0_CH3O
-	bool "TIMER0 Channel 2 Output"
+	bool "TIMER0 Channel 3 Output"
 	default n
-	depends on GD32F4_TIMER0_CHANNEL2
+	depends on GD32F4_TIMER0_CHANNEL3
 	---help---
-		Enables channel 2 output.
+		Enables channel 3 output.
 
 config GD32F4_TIMER0_CH3ON
 	bool "TIMER0 Channel 3 Complementary Output"
@@ -2089,7 +2089,7 @@ menu "RTC Configuration"
 config GD32F4_RTC_MAGIC_REG
 	int "BKP register"
 	default 0
-	range  0 19
+	range 0 19
 	depends on !GD32F4_HAVE_RTC_COUNTER
 	---help---
 		The BKP register used to store/check the Magic value to determine if

--- a/arch/arm/src/imxrt/Kconfig
+++ b/arch/arm/src/imxrt/Kconfig
@@ -2655,7 +2655,7 @@ menu "RTC Configuration"
 config IMXRT_RTC_MAGIC_REG
 	int "RTC SNVS GPR"
 	default 0
-	range  0 3
+	range 0 3
 	---help---
 		The BKP register used to store/check the Magic value to determine if
 		RTC is already setup

--- a/arch/arm/src/stm32f7/Kconfig
+++ b/arch/arm/src/stm32f7/Kconfig
@@ -2589,7 +2589,7 @@ menu "RTC Configuration"
 config STM32F7_RTC_MAGIC_REG
 	int "BKP register"
 	default 0
-	range  0 31
+	range 0 31
 	---help---
 		The BKP register used to store/check the Magic value to determine if
 		RTC is already setup

--- a/arch/arm/src/stm32h7/Kconfig
+++ b/arch/arm/src/stm32h7/Kconfig
@@ -1744,7 +1744,7 @@ menu "RTC Configuration"
 config STM32H7_RTC_MAGIC_REG
 	int "BKP register"
 	default 0
-	range  0 31
+	range 0 31
 	---help---
 		The BKP register used to store/check the Magic value to determine if
 		RTC is already setup

--- a/arch/arm/src/stm32l4/Kconfig
+++ b/arch/arm/src/stm32l4/Kconfig
@@ -1864,7 +1864,7 @@ menu "RTC Configuration"
 config STM32L4_RTC_MAGIC_REG
 	int "BKP register"
 	default 0
-	range  0 31
+	range 0 31
 	---help---
 		The BKP register used to store/check the Magic value to determine if
 		RTC is already setup

--- a/arch/arm/src/stm32l5/Kconfig
+++ b/arch/arm/src/stm32l5/Kconfig
@@ -393,7 +393,7 @@ menu "RTC Configuration"
 config STM32L5_RTC_MAGIC_REG
 	int "BKP register"
 	default 0
-	range  0 31
+	range 0 31
 	---help---
 		The BKP register used to store/check the Magic value to determine if
 		RTC is already setup

--- a/arch/arm/src/stm32u5/Kconfig
+++ b/arch/arm/src/stm32u5/Kconfig
@@ -625,7 +625,7 @@ menu "RTC Configuration"
 config STM32U5_RTC_MAGIC_REG
 	int "BKP register"
 	default 0
-	range  0 31
+	range 0 31
 	---help---
 		The BKP register used to store/check the Magic value to determine if
 		RTC is already setup

--- a/arch/arm/src/stm32wb/Kconfig
+++ b/arch/arm/src/stm32wb/Kconfig
@@ -650,7 +650,7 @@ menu "RTC Configuration"
 config STM32WB_RTC_MAGIC_REG
 	int "BKP register"
 	default 0
-	range  0 31
+	range 0 31
 	---help---
 		The BKP register used to store/check the Magic value to determine if
 		RTC is already setup


### PR DESCRIPTION
## Summary
correct  config GD32F4_TIMER0_CH3O ( GD32F4_TIMER0_CHANNEL2 -> GD32F4_TIMER0_CHANNEL3 )
fix texts
Remove spaces from Kconfig files
## Impact
none
## Testing

