### PR TITLE
GD25 Flash memory - performance enhancements

### DIFF
--- a/drivers/mtd/Kconfig
+++ b/drivers/mtd/Kconfig
@@ -1165,6 +1165,38 @@ config GD25_SLOWREAD
 	bool
 	default n
 
+config GD25_START_DELAY
+	int "GD25 startdelay"
+	---help---
+		The delay between CS active and first CLK. In ns.
+	depends on SPI_DELAY_CONTROL
+	range 0 1000000
+	default 5000
+
+config GD25_STOP_DELAY
+	int "GD25 stopdelay"
+	---help---
+		The delay between last CLK and CS inactive. In ns.
+	depends on SPI_DELAY_CONTROL
+	range 0 1000000
+	default 5000
+
+config GD25_CS_DELAY
+	int "GD25 csdelay"
+	---help---
+		The delay between CS inactive and CS active again. In ns.
+	depends on SPI_DELAY_CONTROL
+	range 0 1000000
+	default 5000
+
+config GD25_IFDELAY
+	int "GD25 ifdelay"
+	---help---
+		The delay between frames. In ns.
+	depends on SPI_DELAY_CONTROL
+	range 0 1000000
+	default 5000
+
 endif # MTD_GD25
 
 config MTD_GD5F

--- a/drivers/mtd/gd25.c
+++ b/drivers/mtd/gd25.c
@@ -230,6 +230,10 @@ static void gd25_lock(FAR struct spi_dev_s *spi)
   SPI_SETBITS(spi, 8);
   SPI_HWFEATURES(spi, 0);
   SPI_SETFREQUENCY(spi, CONFIG_GD25_SPIFREQUENCY);
+#ifdef CONFIG_SPI_DELAY_CONTROL
+  SPI_SETDELAY(spi, CONFIG_GD25_START_DELAY, CONFIG_GD25_STOP_DELAY,
+                    CONFIG_GD25_CS_DELAY, CONFIG_GD25_IFDELAY);
+#endif
 }
 
 /***************************************************************************


### PR DESCRIPTION
## Summary

Adds a call to the SETDELAY macro to allow optimised chip select delays, but only if CONFIG_SET_DELAY_CONTROL is enabled, and only if the 4 parameters have actually been set from Kconfig.

## Impact
The #ifdef checks should make this change benign.

## Testing
Custom board with SAMA5D27C-D1G with 256M GD25 memory. On this board the dd of a file from the flash to /dev/null improved from 37 KB/s (using the SAMA5D2 default delays) to 82KB/s. (Went to 700KB/s using DMA however)

