### PR TITLE
arch/all: in smp pthread_cancel occasionally deadlock except for arm64 

### DIFF
--- a/arch/arm/src/armv7-a/arm_cpupause.c
+++ b/arch/arm/src/armv7-a/arm_cpupause.c
@@ -58,6 +58,7 @@
 
 static volatile spinlock_t g_cpu_wait[CONFIG_SMP_NCPUS];
 static volatile spinlock_t g_cpu_paused[CONFIG_SMP_NCPUS];
+static volatile spinlock_t g_cpu_resumed[CONFIG_SMP_NCPUS];
 
 /****************************************************************************
  * Public Functions
@@ -136,6 +137,10 @@ int up_cpu_paused(int cpu)
 
   spin_unlock(&g_cpu_paused[cpu]);
 
+  /* Ensure the CPU has been resumed to avoid causing a deadlock */
+
+  spin_lock(&g_cpu_resumed[cpu]);
+
   /* Wait for the spinlock to be released.  The requesting CPU will release
    * the spinlock when the CPU is resumed.
    */
@@ -164,6 +169,7 @@ int up_cpu_paused(int cpu)
 
   arm_restorestate(tcb->xcp.regs);
   spin_unlock(&g_cpu_wait[cpu]);
+  spin_unlock(&g_cpu_resumed[cpu]);
 
   return OK;
 }
@@ -320,6 +326,13 @@ int up_cpu_resume(int cpu)
               !spin_islocked(&g_cpu_paused[cpu]));
 
   spin_unlock(&g_cpu_wait[cpu]);
+
+  /* Ensure the CPU has been resumed to avoid causing a deadlock */
+
+  spin_lock(&g_cpu_resumed[cpu]);
+
+  spin_unlock(&g_cpu_resumed[cpu]);
+
   return OK;
 }
 

--- a/arch/arm/src/armv7-r/arm_cpupause.c
+++ b/arch/arm/src/armv7-r/arm_cpupause.c
@@ -58,6 +58,7 @@
 
 static volatile spinlock_t g_cpu_wait[CONFIG_SMP_NCPUS];
 static volatile spinlock_t g_cpu_paused[CONFIG_SMP_NCPUS];
+static volatile spinlock_t g_cpu_resumed[CONFIG_SMP_NCPUS];
 
 /****************************************************************************
  * Public Functions
@@ -136,6 +137,10 @@ int up_cpu_paused(int cpu)
 
   spin_unlock(&g_cpu_paused[cpu]);
 
+  /* Ensure the CPU has been resumed to avoid causing a deadlock */
+
+  spin_lock(&g_cpu_resumed[cpu]);
+
   /* Wait for the spinlock to be released.  The requesting CPU will release
    * the spinlock when the CPU is resumed.
    */
@@ -164,6 +169,7 @@ int up_cpu_paused(int cpu)
 
   arm_restorestate(tcb->xcp.regs);
   spin_unlock(&g_cpu_wait[cpu]);
+  spin_unlock(&g_cpu_resumed[cpu]);
 
   return OK;
 }
@@ -320,6 +326,13 @@ int up_cpu_resume(int cpu)
               !spin_islocked(&g_cpu_paused[cpu]));
 
   spin_unlock(&g_cpu_wait[cpu]);
+
+  /* Ensure the CPU has been resumed to avoid causing a deadlock */
+
+  spin_lock(&g_cpu_resumed[cpu]);
+
+  spin_unlock(&g_cpu_resumed[cpu]);
+
   return OK;
 }
 

--- a/arch/arm/src/lc823450/lc823450_cpupause.c
+++ b/arch/arm/src/lc823450/lc823450_cpupause.c
@@ -68,6 +68,7 @@
 
 volatile spinlock_t g_cpu_wait[CONFIG_SMP_NCPUS];
 volatile spinlock_t g_cpu_paused[CONFIG_SMP_NCPUS];
+volatile spinlock_t g_cpu_resumed[CONFIG_SMP_NCPUS];
 
 /****************************************************************************
  * Public Functions
@@ -143,6 +144,11 @@ int up_cpu_paused(int cpu)
   /* Wait for the spinlock to be released */
 
   spin_unlock(&g_cpu_paused[cpu]);
+
+  /* Ensure the CPU has been resumed to avoid causing a deadlock */
+
+  spin_lock(&g_cpu_resumed[cpu]);
+
   spin_lock(&g_cpu_wait[cpu]);
 
   /* Restore the exception context of the tcb at the (new) head of the
@@ -168,6 +174,8 @@ int up_cpu_paused(int cpu)
   arm_restorestate(tcb->xcp.regs);
 
   spin_unlock(&g_cpu_wait[cpu]);
+
+  spin_unlock(&g_cpu_resumed[cpu]);
 
   return OK;
 }
@@ -342,6 +350,12 @@ int up_cpu_resume(int cpu)
               !spin_islocked(&g_cpu_paused[cpu]));
 
   spin_unlock(&g_cpu_wait[cpu]);
+
+  /* Ensure the CPU has been resumed to avoid causing a deadlock */
+
+  spin_lock(&g_cpu_resumed[cpu]);
+
+  spin_unlock(&g_cpu_resumed[cpu]);
 
   return 0;
 }

--- a/arch/arm/src/rp2040/rp2040_cpupause.c
+++ b/arch/arm/src/rp2040/rp2040_cpupause.c
@@ -70,6 +70,7 @@
 
 static volatile spinlock_t g_cpu_wait[CONFIG_SMP_NCPUS];
 static volatile spinlock_t g_cpu_paused[CONFIG_SMP_NCPUS];
+static volatile spinlock_t g_cpu_resumed[CONFIG_SMP_NCPUS];
 
 /****************************************************************************
  * Name: rp2040_handle_irqreq
@@ -183,6 +184,11 @@ int up_cpu_paused(int cpu)
   /* Wait for the spinlock to be released */
 
   spin_unlock(&g_cpu_paused[cpu]);
+
+  /* Ensure the CPU has been resumed to avoid causing a deadlock */
+
+  spin_lock(&g_cpu_resumed[cpu]);
+
   spin_lock(&g_cpu_wait[cpu]);
 
   /* Restore the exception context of the tcb at the (new) head of the
@@ -207,6 +213,7 @@ int up_cpu_paused(int cpu)
 
   arm_restorestate(tcb->xcp.regs);
   spin_unlock(&g_cpu_wait[cpu]);
+  spin_unlock(&g_cpu_resumed[cpu]);
 
   return OK;
 }
@@ -393,6 +400,12 @@ int up_cpu_resume(int cpu)
               !spin_islocked(&g_cpu_paused[cpu]));
 
   spin_unlock(&g_cpu_wait[cpu]);
+
+  /* Ensure the CPU has been resumed to avoid causing a deadlock */
+
+  spin_lock(&g_cpu_resumed[cpu]);
+
+  spin_unlock(&g_cpu_resumed[cpu]);
   return 0;
 }
 
@@ -432,6 +445,12 @@ void rp2040_send_irqreq(int irqreq)
   /* Finally unlock the spinlock to proceed the handler */
 
   spin_unlock(&g_cpu_wait[0]);
+
+  /* Ensure the CPU has been resumed to avoid causing a deadlock */
+
+  spin_lock(&g_cpu_resumed[0]);
+
+  spin_unlock(&g_cpu_resumed[0]);
 }
 
 #endif /* CONFIG_SMP */

--- a/arch/risc-v/src/common/riscv_cpupause.c
+++ b/arch/risc-v/src/common/riscv_cpupause.c
@@ -58,6 +58,7 @@
 
 volatile spinlock_t g_cpu_wait[CONFIG_SMP_NCPUS];
 volatile spinlock_t g_cpu_paused[CONFIG_SMP_NCPUS];
+volatile spinlock_t g_cpu_resumed[CONFIG_SMP_NCPUS];
 
 /****************************************************************************
  * Public Functions
@@ -133,6 +134,11 @@ int up_cpu_paused(int cpu)
   /* Wait for the spinlock to be released */
 
   spin_unlock(&g_cpu_paused[cpu]);
+
+  /* Ensure the CPU has been resumed to avoid causing a deadlock */
+
+  spin_lock(&g_cpu_resumed[cpu]);
+
   spin_lock(&g_cpu_wait[cpu]);
 
   /* Restore the exception context of the tcb at the (new) head of the
@@ -158,6 +164,7 @@ int up_cpu_paused(int cpu)
   riscv_restorestate(tcb->xcp.regs);
 
   spin_unlock(&g_cpu_wait[cpu]);
+  spin_unlock(&g_cpu_resumed[cpu]);
 
   return OK;
 }
@@ -316,6 +323,12 @@ int up_cpu_resume(int cpu)
               !spin_islocked(&g_cpu_paused[cpu]));
 
   spin_unlock(&g_cpu_wait[cpu]);
+
+  /* Ensure the CPU has been resumed to avoid causing a deadlock */
+
+  spin_lock(&g_cpu_resumed[cpu]);
+
+  spin_unlock(&g_cpu_resumed[cpu]);
 
   return 0;
 }

--- a/arch/sim/src/sim/sim_smpsignal.c
+++ b/arch/sim/src/sim/sim_smpsignal.c
@@ -49,6 +49,7 @@
 
 static volatile spinlock_t g_cpu_wait[CONFIG_SMP_NCPUS];
 static volatile spinlock_t g_cpu_paused[CONFIG_SMP_NCPUS];
+static volatile spinlock_t g_cpu_resumed[CONFIG_SMP_NCPUS];
 
 /****************************************************************************
  * Private Functions
@@ -176,6 +177,11 @@ int up_cpu_paused(int cpu)
   /* Wait for the spinlock to be released */
 
   spin_unlock(&g_cpu_paused[cpu]);
+
+  /* Ensure the CPU has been resumed to avoid causing a deadlock */
+
+  spin_lock(&g_cpu_resumed[cpu]);
+
   spin_lock(&g_cpu_wait[cpu]);
 
   /* Restore the exception context of the tcb at the (new) head of the
@@ -209,6 +215,7 @@ int up_cpu_paused(int cpu)
 
   sim_restorestate(tcb->xcp.regs);
   spin_unlock(&g_cpu_wait[cpu]);
+  spin_unlock(&g_cpu_resumed[cpu]);
 
   return OK;
 }
@@ -394,5 +401,12 @@ int up_cpu_resume(int cpu)
               !spin_islocked(&g_cpu_paused[cpu]));
 
   spin_unlock(&g_cpu_wait[cpu]);
+
+  /* Ensure the CPU has been resumed to avoid causing a deadlock */
+
+  spin_lock(&g_cpu_resumed[cpu]);
+
+  spin_unlock(&g_cpu_resumed[cpu]);
+
   return OK;
 }

--- a/arch/sparc/src/s698pm/s698pm_cpupause.c
+++ b/arch/sparc/src/s698pm/s698pm_cpupause.c
@@ -58,6 +58,7 @@
 
 volatile spinlock_t g_cpu_wait[CONFIG_SMP_NCPUS];
 volatile spinlock_t g_cpu_paused[CONFIG_SMP_NCPUS];
+volatile spinlock_t g_cpu_resumed[CONFIG_SMP_NCPUS];
 
 /****************************************************************************
  * Public Functions
@@ -133,6 +134,11 @@ int up_cpu_paused(int cpu)
   /* Wait for the spinlock to be released */
 
   spin_unlock(&g_cpu_paused[cpu]);
+
+  /* Ensure the CPU has been resumed to avoid causing a deadlock */
+
+  spin_lock(&g_cpu_resumed[cpu]);
+
   spin_lock(&g_cpu_wait[cpu]);
 
   /* Restore the exception context of the tcb at the (new) head of the
@@ -158,6 +164,7 @@ int up_cpu_paused(int cpu)
   sparc_restorestate(tcb->xcp.regs);
 
   spin_unlock(&g_cpu_wait[cpu]);
+  spin_unlock(&g_cpu_resumed[cpu]);
 
   return OK;
 }
@@ -319,6 +326,12 @@ int up_cpu_resume(int cpu)
               !spin_islocked(&g_cpu_paused[cpu]));
 
   spin_unlock(&g_cpu_wait[cpu]);
+
+  /* Ensure the CPU has been resumed to avoid causing a deadlock */
+
+  spin_lock(&g_cpu_resumed[cpu]);
+
+  spin_unlock(&g_cpu_resumed[cpu]);
 
   return 0;
 }

--- a/arch/xtensa/src/common/xtensa_cpupause.c
+++ b/arch/xtensa/src/common/xtensa_cpupause.c
@@ -43,6 +43,7 @@
 
 static spinlock_t g_cpu_wait[CONFIG_SMP_NCPUS];
 static spinlock_t g_cpu_paused[CONFIG_SMP_NCPUS];
+static spinlock_t g_cpu_resumed[CONFIG_SMP_NCPUS];
 
 /****************************************************************************
  * Public Functions
@@ -118,6 +119,11 @@ int up_cpu_paused(int cpu)
   /* Wait for the spinlock to be released */
 
   spin_unlock(&g_cpu_paused[cpu]);
+
+  /* Ensure the CPU has been resumed to avoid causing a deadlock */
+
+  spin_lock(&g_cpu_resumed[cpu]);
+
   spin_lock(&g_cpu_wait[cpu]);
 
   /* Restore the exception context of the tcb at the (new) head of the
@@ -143,6 +149,8 @@ int up_cpu_paused(int cpu)
   xtensa_restorestate(tcb->xcp.regs);
 
   spin_unlock(&g_cpu_wait[cpu]);
+  spin_unlock(&g_cpu_resumed[cpu]);
+
   return OK;
 }
 
@@ -307,6 +315,13 @@ int up_cpu_resume(int cpu)
               !spin_islocked(&g_cpu_paused[cpu]));
 
   spin_unlock(&g_cpu_wait[cpu]);
+
+  /* Ensure the CPU has been resumed to avoid causing a deadlock */
+
+  spin_lock(&g_cpu_resumed[cpu]);
+
+  spin_unlock(&g_cpu_resumed[cpu]);
+
   return OK;
 }
 


### PR DESCRIPTION
## Summary
In smp when cpu0 calls up_cpu_resume to release the cpu1 lock, another locked cpu1 did not execute immediately, and soon cpu0 called up_cpu_resume again, now cpu1 unable to respond to the interrupt at this time, resulting in a deadlock. Our solution is to restore cpu1 execution from asynchronous to synchronous to ensure that cpu1 is restored.

## Impact
none

## Testing
ostest

