### PR TITLE
docs: Fix sphinx warnings listed in issue #9306

### DIFF
--- a/Documentation/components/drivers/special/framebuffer.rst
+++ b/Documentation/components/drivers/special/framebuffer.rst
@@ -68,7 +68,7 @@ Examples
 
 Examples apply to specific cases of the :ref:`genericlcdfb`:
 
-.. _ttgotdisplayesp32:
+.. _ttgotdisplayesp32_fb:
 
 TTGO T-Display ESP32 board
 ---------------------------
@@ -109,7 +109,7 @@ NuttX Simulator
 
 By selecting the ``sim:lvgl_fb`` config, the ``lvgldemo`` example will be built with the framebuffer driver.
 
-* ``boards/sim/sim/sim/src/sim_bringup.c`` registers the framebuffer driver the same way :ref:`ttgotdisplayesp32`;
+* ``boards/sim/sim/sim/src/sim_bringup.c`` registers the framebuffer driver the same way :ref:`ttgotdisplayesp32_fb`;
 * ``arch/sim/src/sim/up_framebuffer.c`` and ``arch/sim/src/sim/up_x11framebuffer.c`` will be built as ``CONFIG_SIM_FRAMEBUFFER = y`` and ``CONFIG_SIM_X11FB = y`` are set, respectively;
 
    * ``up_framebuffer.c`` provides ``up_fbinitialize`` and,

--- a/Documentation/components/drivers/special/lcd.rst
+++ b/Documentation/components/drivers/special/lcd.rst
@@ -46,7 +46,7 @@ Examples
 
 Examples apply to specific cases of the :ref:`genericlcdlcd`:
 
-.. _ttgotdisplayesp32:
+.. _ttgotdisplayesp32_lcd:
 
 TTGO T-Display ESP32 board
 ---------------------------
@@ -94,7 +94,7 @@ NuttX Simulator
 
 By selecting the ``sim:lvgl_lcd`` config, the ``lvgldemo`` example will be built with the LCD character interface.
 
-* ``boards/sim/sim/sim/src/sim_bringup.c`` registers the framebuffer driver the same way :ref:`ttgotdisplayesp32`;
+* ``boards/sim/sim/sim/src/sim_bringup.c`` registers the lcd driver the same way :ref:`ttgotdisplayesp32_lcd`;
 * ``arch/sim/src/sim/up_lcd.c`` and ``arch/sim/src/sim/up_x11framebuffer.c`` will be built as ``CONFIG_SIM_LCDDRIVER = y`` and ``CONFIG_SIM_X11FB = y`` are set, respectively;
 
    * ``up_lcd.c`` provides ``board_lcd_initialize`` and ``board_lcd_getdev``:

--- a/Documentation/guides/zerolatencyinterrupts.rst
+++ b/Documentation/guides/zerolatencyinterrupts.rst
@@ -115,7 +115,7 @@ Nested Interrupt Handling
 =========================
 
 Some general notes about nested interrupt handling are provided in
-:doc:`<nestedinterrupts.rst>`. In this case, handling the nested custom
+:doc:`nestedinterrupts`. In this case, handling the nested custom
 interrupt is simpler because the generic interrupt handler is not
 re-entered. Rather, the generic interrupt handler must simply be made to
 co-exist with the custom interrupt interrupt handler.

--- a/Documentation/platforms/sim/sim/boards/sim/index.rst
+++ b/Documentation/platforms/sim/sim/boards/sim/index.rst
@@ -366,8 +366,8 @@ BASIC
   There is also a test suite for the interpreter that can be found at
   apps/examples/bastest.
 
-  Configuration
-  -------------
+Configuration
+-------------
   Below are the recommended configuration changes to use BAS with the
   stm32f4discovery/nsh configuration:
 
@@ -390,8 +390,8 @@ BASIC
      CONFIG_EXAMPLES_BASTEST_DEVMINOR=6
      CONFIG_EXAMPLES_BASTEST_DEVPATH="/dev/ram6"
 
-  Usage
-  -----
+Usage
+-----
   This setup will initialize the BASIC test (optional):  This will mount a
   ROMFS file system at /mnt/romfs that contains the BASIC test files::
 
@@ -1487,40 +1487,50 @@ This is a configuration for WebAssembly sample.
 
 1. Compile Toolchain
 
-   1. Download WASI sdk and export the WASI_SDK_PATH path::
+   1. Download WASI sdk and export the WASI_SDK_PATH path
 
-      $ wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-19/wasi-sdk-19.0-linux.tar.gz
-      $ tar xf wasi-sdk-19.0-linux.tar.gz
-      Put wasi-sdk-19.0 to your host WASI_SDK_PATH environment variable, like:
-      $ export WASI_SDK_PATH=`pwd`/wasi-sdk-19.0
+    .. code-block:: console
 
-   2. Download Wamr "wamrc" AOT compiler and export to the PATH::
+      wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-19/wasi-sdk-19.0-linux.tar.gz
+      tar xf wasi-sdk-19.0-linux.tar.gz
+      # Put wasi-sdk-19.0 to your host WASI_SDK_PATH environment variable, like:
+      export WASI_SDK_PATH=`pwd`/wasi-sdk-19.0
 
-      $ mkdir wamrc
-      $ wget https://github.com/bytecodealliance/wasm-micro-runtime/releases/download/WAMR-1.1.2/wamrc-1.1.2-x86_64-ubuntu-20.04.tar.gz
-      $ tar xf wamrc-1.1.2-x86_64-ubuntu-20.04.tar.gz
-      $ export PATH=$PATH:$PWD
+   2. Download Wamr "wamrc" AOT compiler and export to the PATH
+
+    .. code-block:: console
+
+      mkdir wamrc
+      wget https://github.com/bytecodealliance/wasm-micro-runtime/releases/download/WAMR-1.1.2/wamrc-1.1.2-x86_64-ubuntu-20.04.tar.gz
+      tar xf wamrc-1.1.2-x86_64-ubuntu-20.04.tar.gz
+      export PATH=$PATH:$PWD
 
 2. Configuring and running
 
-   1. Configuring sim/wamr and compile::
+   1. Configuring sim/wamr and compile
 
-          nuttx$ ./tools/configure.sh  sim/wamr
-          nuttx$ make
+    .. code-block:: console
+
+          ./tools/configure.sh  sim/wamr
+          make
           ...
           Wamrc Generate AoT: /home/archer/code/nuttx/n5/apps/wasm/hello.aot
           Wamrc Generate AoT: /home/archer/code/nuttx/n5/apps/wasm/coremark.aot
           LD:  nuttx
 
-   2. Copy the generated wasm file(Interpreter/AoT)::
+   2. Copy the generated wasm file(Interpreter/AoT)
 
-          nuttx$ cp ../apps/wasm/hello.aot .
-          nuttx$ cp ../apps/wasm/hello.wasm .
-          nuttx$ cp ../apps/wasm/coremark.wasm .
+    .. code-block:: console
 
-   3. Run iwasm::
+      cp ../apps/wasm/hello.aot .
+      cp ../apps/wasm/hello.wasm .
+      cp ../apps/wasm/coremark.wasm .
 
-          nuttx$ ./nuttx
+   3. Run iwasm
+
+    .. code-block:: console
+
+          ./nuttx
           NuttShell (NSH) NuttX-10.4.0
           nsh> iwasm /data/hello.wasm
           Hello, World!!
@@ -1566,12 +1576,12 @@ This is a configuration with sim usbdev support.
 
   sim:usbdev contains two different sets of composite devices::
 
-  conn0: adb & rndis
-  conn1: cdcacm & cdcecm
+    conn0: adb & rndis
+    conn1: cdcacm & cdcecm
 
   You can use the sim:usbdev configuration::
 
-  ./tools/configure.sh sim:usbdev
+    ./tools/configure.sh sim:usbdev
 
 3. How to run
 

--- a/Documentation/platforms/xtensa/esp32s2/boards/esp32s2-kaluga-1/index.rst
+++ b/Documentation/platforms/xtensa/esp32s2/boards/esp32s2-kaluga-1/index.rst
@@ -204,7 +204,7 @@ This will create a temporary folder in ``apps/examples/romfs/testdir``. Move
 a PCM-encoded (``.wav``) audio file with 16 or 24 bits/sample (sampled at 16~48kHz)
 to this folder.
 
-.. note:: You can use :download:`this 440 Hz sinusoidal tone <tone.wav>`.
+.. note:: You can use :download:`this 440 Hz sinusoidal tone <../esp32s2-saola-1/tone.wav>`.
    The audio file should be located at ``apps/examples/romfs/testdir/tone.wav``
 
 Build the project again and flash it (make sure not to clean it, just build)

--- a/Documentation/reference/os/index.rst
+++ b/Documentation/reference/os/index.rst
@@ -18,6 +18,7 @@ in other header files.
   led.rst
   mutex.rst
   nat.rst
+  newreno.rst
   notifier.rst
   nuttx.rst
   paging.rst


### PR DESCRIPTION
## Summary

Fixes these errors:
```
 /home/bashton/nuttx-wrk/nuttx/Documentation/components/drivers/special/lcd.rst:52: WARNING: duplicate label ttgotdisplayesp32, other instance in /home/bashton/nuttx-wrk/nuttx/Documentation/components/drivers/special/framebuffer.rst
 /home/bashton/nuttx-wrk/nuttx/Documentation/platforms/sim/sim/boards/sim/index.rst:370: CRITICAL: Unexpected section title.
 /home/bashton/nuttx-wrk/nuttx/Documentation/platforms/sim/sim/boards/sim/index.rst:394: CRITICAL: Unexpected section title.
 /home/bashton/nuttx-wrk/nuttx/Documentation/platforms/sim/sim/boards/sim/index.rst:1494: ERROR: Inconsistent literal block quoting.
 /home/bashton/nuttx-wrk/nuttx/Documentation/platforms/sim/sim/boards/sim/index.rst:1569: WARNING: Literal block expected; none found.
 /home/bashton/nuttx-wrk/nuttx/Documentation/platforms/xtensa/esp32s2/boards/esp32s2-kaluga-1/index.rst:207: WARNING: download file not readable: /home/bashton/nuttx-wrk/nuttx/Documentation/platforms/xtensa/esp32s2/boards/esp32s2-kaluga-1/tone.wav
 checking consistency... /home/bashton/nuttx-wrk/nuttx/Documentation/reference/os/newreno.rst: WARNING: document isn't included in any toctree
 /home/bashton/nuttx-wrk/nuttx/Documentation/guides/zerolatencyinterrupts.rst:117: WARNING: unknown document: <nestedinterrupts.rst>
```
## Testing
In master we see this build output
```
❯ make html
Removing everything under '_build'...
Running Sphinx v4.5.0
making output directory... done
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 196 source files that are out of date
updating environment: [new config] 196 added, 0 changed, 0 removed
reading sources... [100%] reference/os/smp .. substitutions                                                                                   
waiting for workers...
/home/bashton/nuttx-wrk/nuttx/Documentation/components/drivers/special/lcd.rst:52: WARNING: duplicate label ttgotdisplayesp32, other instance in /home/bashton/nuttx-wrk/nuttx/Documentation/components/drivers/special/framebuffer.rst
/home/bashton/nuttx-wrk/nuttx/Documentation/platforms/sim/sim/boards/sim/index.rst:370: CRITICAL: Unexpected section title.

Configuration
-------------
/home/bashton/nuttx-wrk/nuttx/Documentation/platforms/sim/sim/boards/sim/index.rst:394: CRITICAL: Unexpected section title.

Usage
-----
/home/bashton/nuttx-wrk/nuttx/Documentation/platforms/sim/sim/boards/sim/index.rst:1494: ERROR: Inconsistent literal block quoting.
/home/bashton/nuttx-wrk/nuttx/Documentation/platforms/sim/sim/boards/sim/index.rst:1569: WARNING: Literal block expected; none found.
/home/bashton/nuttx-wrk/nuttx/Documentation/platforms/xtensa/esp32s2/boards/esp32s2-kaluga-1/index.rst:207: WARNING: download file not readable: /home/bashton/nuttx-wrk/nuttx/Documentation/platforms/xtensa/esp32s2/boards/esp32s2-kaluga-1/tone.wav
/home/bashton/nuttx-wrk/nuttx/Documentation/reference/user/structures.rst:111: WARNING: Duplicate C declaration, also defined at reference/user/07_signals:179.
Declaration is '.. c:struct:: sigaction'.
/home/bashton/nuttx-wrk/nuttx/Documentation/reference/user/structures.rst:111: WARNING: Duplicate C declaration, also defined at reference/user/07_signals:179.
Declaration is '.. c:function:: int sigaction(int signo, const struct sigaction *act, struct sigaction *oact);'.
looking for now-outdated files... none found
pickling environment... done
checking consistency... /home/bashton/nuttx-wrk/nuttx/Documentation/reference/os/newreno.rst: WARNING: document isn't included in any toctree
done
preparing documents... done
/home/bashton/nuttx-wrk/nuttx/Documentation/guides/zerolatencyinterrupts.rst:117: WARNING: unknown document: <nestedinterrupts.rst>           
writing output... [100%] reference/os/smp .. substitutions                                                                                    
waiting for workers...
generating indices... genindex done
writing additional pages... search done
copying images... [100%] _static/images/menuconfig-debug.png                                                                                  
copying downloadable files... [100%] platforms/xtensa/esp32s2/boards/esp32s2-saola-1/tone.wav                                                 
copying static files... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 10 warnings.

The HTML pages are in _build/html.
```
With these changes we see

```
❯ make html
Removing everything under '_build'...
Running Sphinx v4.5.0
making output directory... done
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 196 source files that are out of date
updating environment: [new config] 196 added, 0 changed, 0 removed
reading sources... [100%] reference/os/smp .. substitutions                                                                                   
waiting for workers...
/home/bashton/nuttx-wrk/nuttx/Documentation/reference/user/structures.rst:111: WARNING: Duplicate C declaration, also defined at reference/user/07_signals:179.
Declaration is '.. c:struct:: sigaction'.
/home/bashton/nuttx-wrk/nuttx/Documentation/reference/user/structures.rst:111: WARNING: Duplicate C declaration, also defined at reference/user/07_signals:179.
Declaration is '.. c:function:: int sigaction(int signo, const struct sigaction *act, struct sigaction *oact);'.
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] reference/os/smp .. substitutions                                                                                    
waiting for workers...
generating indices... genindex done
writing additional pages... search done
copying images... [100%] _static/images/menuconfig-debug.png                                                                                  
copying downloadable files... [100%] platforms/xtensa/esp32s2/boards/esp32s2-saola-1/tone.wav                                                 
copying static files... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 2 warnings.

The HTML pages are in _build/html.
```
`WARNING: Duplicate C declaration,` is expected and tracked as an upstream sphinx bug.
