### PR TITLE
kinetis s32k1 s32k3:edma {s|d}last needs to be total xfer size

### DIFF
--- a/arch/arm/src/kinetis/kinetis_edma.c
+++ b/arch/arm/src/kinetis/kinetis_edma.c
@@ -364,7 +364,9 @@ static inline void kinetis_tcd_configure(struct kinetis_edmatcd_s *tcd,
   tcd->attr     = EDMA_TCD_ATTR_SSIZE(config->ssize) |  /* Transfer Attributes */
                   EDMA_TCD_ATTR_DSIZE(config->dsize);
   tcd->nbytes   = config->nbytes;
-  tcd->slast    = config->flags & EDMA_CONFIG_LOOPSRC ? -config->iter : 0;
+  tcd->slast    = config->flags & EDMA_CONFIG_LOOPSRC ?
+                                  -(config->iter * config->nbytes) : 0;
+
   tcd->daddr    = config->daddr;
   tcd->doff     = config->doff;
   tcd->citer    = config->iter & EDMA_TCD_CITER_CITER_MASK;
@@ -373,7 +375,8 @@ static inline void kinetis_tcd_configure(struct kinetis_edmatcd_s *tcd,
                                   0 : EDMA_TCD_CSR_DREQ;
   tcd->csr     |= config->flags & EDMA_CONFIG_INTHALF ?
                                   EDMA_TCD_CSR_INTHALF : 0;
-  tcd->dlastsga = config->flags & EDMA_CONFIG_LOOPDEST ? -config->iter : 0;
+  tcd->dlastsga = config->flags & EDMA_CONFIG_LOOPDEST ?
+                                  -(config->iter * config->nbytes) : 0;
 
   /* And special case flags */
 

--- a/arch/arm/src/s32k1xx/s32k1xx_edma.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_edma.c
@@ -362,7 +362,8 @@ static inline void s32k1xx_tcd_configure(struct s32k1xx_edmatcd_s *tcd,
   tcd->attr     = EDMA_TCD_ATTR_SSIZE(config->ssize) |  /* Transfer Attributes */
                   EDMA_TCD_ATTR_DSIZE(config->dsize);
   tcd->nbytes   = config->nbytes;
-  tcd->slast    = config->flags & EDMA_CONFIG_LOOPSRC ?  -config->iter : 0;
+  tcd->slast    = config->flags & EDMA_CONFIG_LOOPSRC ?
+                                  -(config->iter * config->nbytes) : 0;
   tcd->daddr    = config->daddr;
   tcd->doff     = config->doff;
   tcd->citer    = config->iter & EDMA_TCD_CITER_CITER_MASK;
@@ -371,7 +372,8 @@ static inline void s32k1xx_tcd_configure(struct s32k1xx_edmatcd_s *tcd,
                                   0 : EDMA_TCD_CSR_DREQ;
   tcd->csr      |= config->flags & EDMA_CONFIG_INTHALF ?
                                   EDMA_TCD_CSR_INTHALF : 0;
-  tcd->dlastsga = config->flags & EDMA_CONFIG_LOOPDEST ?  -config->iter : 0;
+  tcd->dlastsga = config->flags & EDMA_CONFIG_LOOPDEST ?
+                                  -(config->iter * config->nbytes) : 0;
 
   /* And special case flags */
 

--- a/arch/arm/src/s32k3xx/s32k3xx_edma.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_edma.c
@@ -616,7 +616,9 @@ static inline void s32k3xx_tcd_configure(struct s32k3xx_edmatcd_s *tcd,
                    EDMA_TCD_ATTR_DMOD(config->dmod);
 #endif
   tcd->nbytes   = config->nbytes;
-  tcd->slast    = config->flags & EDMA_CONFIG_LOOPSRC ? -config->iter : 0;
+  tcd->slast    = config->flags & EDMA_CONFIG_LOOPSRC ?
+                                  -(config->iter * config->nbytes) : 0;
+
   tcd->daddr    = config->daddr;
   tcd->doff     = config->doff;
   tcd->citer    = config->iter & EDMA_TCD_CITER_MASK;
@@ -625,7 +627,8 @@ static inline void s32k3xx_tcd_configure(struct s32k3xx_edmatcd_s *tcd,
                                   0 : EDMA_TCD_CSR_DREQ;
   tcd->csr     |= config->flags & EDMA_CONFIG_INTHALF ?
                                   EDMA_TCD_CSR_INTHALF : 0;
-  tcd->dlastsga = config->flags & EDMA_CONFIG_LOOPDEST ? -config->iter : 0;
+  tcd->dlastsga = config->flags & EDMA_CONFIG_LOOPDEST ?
+                                  -(config->iter * config->nbytes) : 0;
 
 #ifdef CONFIG_S32K3XX_DTCM_HEAP
   /* Remap address to backdoor address for eDMA */


### PR DESCRIPTION
## Summary

As reported in https://github.com/apache/nuttx/pull/9324 for the imxrt

The edma  slast and dlast calculation needs to be total xfer size

 ## Impact

DMA with TCDn_CITER or  TCDn_BITER not set to 1 would not reset the {s|d}last to the correct location.

## Testing

Inspection

