### PR TITLE
arch/arm/src/nrf53/Kconfig: Fix config I2C3 Master

### DIFF
--- a/arch/arm/src/nrf53/Kconfig
+++ b/arch/arm/src/nrf53/Kconfig
@@ -151,7 +151,7 @@ config NRF53_I2C2_MASTER
 	depends on NRF53_HAVE_I2C123
 	select NRF53_I2C_MASTER
 
-config NRF53_I2C2_MASTER
+config NRF53_I2C3_MASTER
 	bool "I2C3 Master"
 	default n
 	depends on NRF53_HAVE_I2C123


### PR DESCRIPTION
## Summary
correct config NRF53_I2C3_MASTER ( NRF53_I2C2_MASTER -> NRF53_I2C3_MASTER )
## Impact
none
## Testing

