### PR TITLE
arch/arm/samv7: remove alignment check that is not needed

### DIFF
--- a/arch/arm/src/samv7/sam_qspi.c
+++ b/arch/arm/src/samv7/sam_qspi.c
@@ -1398,7 +1398,6 @@ static int qspi_command(struct qspi_dev_s *dev,
   if (QSPICMD_ISDATA(cmdinfo->flags))
     {
       DEBUGASSERT(cmdinfo->buffer != NULL && cmdinfo->buflen > 0);
-      DEBUGASSERT(IS_ALIGNED(cmdinfo->buffer));
 
       /* Write Instruction Frame Register:
        *


### PR DESCRIPTION
## Summary
SAMv7 QSPI peripheral does not copy-in/out directly into/from user provided buffer, but use a dedicated memory that is interfaces using byte copy. The QSPI command buffer can point to memory with any alignment

## Impact
Fix regression after https://github.com/apache/nuttx/pull/9309 for SAMv7, but STM32 based boards should be checked.
Anyway the alignment should be handled by QSPI driver and not on upper (MTD) layer (at least not for data buffer transactions like sending a command).

## Testing
Pass CI