### PR TITLE
stream/syslog: use internal buffer to decoupling syslog with iob 

### DIFF
--- a/drivers/syslog/Kconfig
+++ b/drivers/syslog/Kconfig
@@ -72,7 +72,6 @@ endif
 config SYSLOG_BUFFER
 	bool "Use buffered output"
 	default n
-	select MM_IOB
 	---help---
 		Enables an buffering logic that will be used to serialize debug
 		output from concurrent tasks. This enables allocation of one buffer
@@ -81,6 +80,16 @@ config SYSLOG_BUFFER
 		The use of SYSLOG buffering is optional.  If not enabled, however,
 		then the output from multiple tasks that attempt to generate SYSLOG
 		output may be interleaved and difficult to read.
+
+if SYSLOG_BUFFER
+
+config SYSLOG_BUFSIZE
+	int "Syslog buffer size"
+	default 64
+	---help---
+		The size of the syslog buffer in bytes.
+
+endif
 
 config SYSLOG_INTBUFFER
 	bool "Use interrupt buffer"

--- a/include/nuttx/streams.h
+++ b/include/nuttx/streams.h
@@ -236,8 +236,15 @@ struct lib_syslogstream_s
 {
   struct lib_outstream_s public;
 #ifdef CONFIG_SYSLOG_BUFFER
+#  ifdef CONFIG_MM_IOB
   FAR struct iob_s *iob;
+#  else
+  char buffer[CONFIG_SYSLOG_BUFSIZE];
+#  endif
 #endif
+  FAR char *base;
+  int size;
+  int offset;
   int last_ch;
 };
 


### PR DESCRIPTION
## Summary

stream/syslog: use internal buffer to decoupling syslog with iob

Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

ci-check