### PR TITLE
stream/hexdump: add hexdump stream to dump binary to syslog 

### DIFF
--- a/drivers/note/notesnap_driver.c
+++ b/drivers/note/notesnap_driver.c
@@ -434,8 +434,8 @@ void notesnap_dump_with_stream(FAR struct lib_outstream_s *stream)
 
 void notesnap_dump(void)
 {
-  struct lib_syslogstream_s stream;
-  lib_syslogstream_open(&stream);
+  struct lib_syslograwstream_s stream;
+  lib_syslograwstream_open(&stream);
   notesnap_dump_with_stream(&stream.public);
-  lib_syslogstream_close(stream);
+  lib_syslograwstream_close(stream);
 }

--- a/drivers/syslog/vsyslog.c
+++ b/drivers/syslog/vsyslog.c
@@ -80,7 +80,7 @@ static FAR const char * const g_priority_str[] =
 
 int nx_vsyslog(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
 {
-  struct lib_syslogstream_s stream;
+  struct lib_syslograwstream_s stream;
   int ret;
 #if CONFIG_TASK_NAME_SIZE > 0 && defined(CONFIG_SYSLOG_PROCESS_NAME)
   FAR struct tcb_s *tcb = nxsched_get_tcb(nxsched_gettid());
@@ -100,7 +100,7 @@ int nx_vsyslog(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
    * do the work.
    */
 
-  lib_syslogstream_open(&stream);
+  lib_syslograwstream_open(&stream);
 
 #ifdef CONFIG_SYSLOG_TIMESTAMP
   ts.tv_sec = 0;
@@ -263,6 +263,6 @@ int nx_vsyslog(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
 
   /* Flush and destroy the syslog stream buffer */
 
-  lib_syslogstream_close(&stream);
+  lib_syslograwstream_close(&stream);
   return ret;
 }

--- a/include/nuttx/streams.h
+++ b/include/nuttx/streams.h
@@ -232,7 +232,7 @@ struct lib_bufferedoutstream_s
 
 struct iob_s;  /* Forward reference */
 
-struct lib_syslogstream_s
+struct lib_syslograwstream_s
 {
   struct lib_outstream_s public;
 #ifdef CONFIG_SYSLOG_BUFFER
@@ -459,7 +459,7 @@ void lib_nullinstream(FAR struct lib_instream_s *nullinstream);
 void lib_nulloutstream(FAR struct lib_outstream_s *nulloutstream);
 
 /****************************************************************************
- * Name: lib_syslogstream_open
+ * Name: lib_syslograwstream_open
  *
  * Description:
  *   Initializes a stream for use with the configured syslog interface.
@@ -467,24 +467,24 @@ void lib_nulloutstream(FAR struct lib_outstream_s *nulloutstream);
  *
  * Input Parameters:
  *   stream - User allocated, uninitialized instance of struct
- *            lib_syslogstream_s to be initialized.
+ *            lib_syslograwstream_s to be initialized.
  *
  * Returned Value:
  *   None (User allocated instance initialized).
  *
  ****************************************************************************/
 
-void lib_syslogstream_open(FAR struct lib_syslogstream_s *stream);
+void lib_syslograwstream_open(FAR struct lib_syslograwstream_s *stream);
 
 /****************************************************************************
- * Name: lib_syslogstream_close
+ * Name: lib_syslograwstream_close
  *
  * Description:
  *   Free resources held by the syslog stream.
  *
  * Input Parameters:
  *   stream - User allocated, uninitialized instance of struct
- *            lib_syslogstream_s to be initialized.
+ *            lib_syslograwstream_s to be initialized.
  *
  * Returned Value:
  *   None (Resources freed).
@@ -492,9 +492,9 @@ void lib_syslogstream_open(FAR struct lib_syslogstream_s *stream);
  ****************************************************************************/
 
 #ifdef CONFIG_SYSLOG_BUFFER
-void lib_syslogstream_close(FAR struct lib_syslogstream_s *stream);
+void lib_syslograwstream_close(FAR struct lib_syslograwstream_s *stream);
 #else
-#  define lib_syslogstream_close(s)
+#  define lib_syslograwstream_close(s)
 #endif
 
 /****************************************************************************

--- a/include/nuttx/streams.h
+++ b/include/nuttx/streams.h
@@ -225,6 +225,14 @@ struct lib_bufferedoutstream_s
   char                        buffer[CONFIG_STREAM_OUT_BUFFER_SIZE];
 };
 
+struct lib_hexdumpstream_s
+{
+  struct lib_outstream_s      public;
+  FAR struct lib_outstream_s *backend;
+  int                         pending;
+  char                        buffer[CONFIG_STREAM_HEXDUMP_BUFFER_SIZE + 1];
+};
+
 /* This is a special stream that does buffered character I/O.  NOTE that is
  * CONFIG_SYSLOG_BUFFER is not defined, it is the same as struct
  * lib_outstream_s
@@ -412,6 +420,25 @@ void lib_rawsostream(FAR struct lib_rawsostream_s *outstream, int fd);
 
 void lib_bufferedoutstream(FAR struct lib_bufferedoutstream_s *outstream,
                            FAR struct lib_outstream_s *backend);
+
+/****************************************************************************
+ * Name: lib_hexdumpstream
+ *
+ * Description:
+ *   Convert binary stream to hex and redirect to syslog
+ *
+ * Input Parameters:
+ *   stream    - User allocated, uninitialized instance of struct
+ *               lib_bufferedoutstream_s to be initialized.
+ *   backend   - Stream backend port.
+ *
+ * Returned Value:
+ *   None (User allocated instance initialized).
+ *
+ ****************************************************************************/
+
+void lib_hexdumpstream(FAR struct lib_hexdumpstream_s *stream,
+                       FAR struct lib_outstream_s *backend);
 
 /****************************************************************************
  * Name: lib_lowoutstream

--- a/include/nuttx/streams.h
+++ b/include/nuttx/streams.h
@@ -230,6 +230,12 @@ struct lib_bufferedoutstream_s
  * lib_outstream_s
  */
 
+struct lib_syslogstream_s
+{
+  struct lib_outstream_s public;
+  int priority;
+};
+
 struct iob_s;  /* Forward reference */
 
 struct lib_syslograwstream_s
@@ -457,6 +463,24 @@ void lib_lowoutstream(FAR struct lib_outstream_s *lowoutstream);
 void lib_zeroinstream(FAR struct lib_instream_s *zeroinstream);
 void lib_nullinstream(FAR struct lib_instream_s *nullinstream);
 void lib_nulloutstream(FAR struct lib_outstream_s *nulloutstream);
+
+/****************************************************************************
+ * Name: lib_syslogstream
+ *
+ * Description:
+ *   Initializes syslog stream
+ *
+ * Input Parameters:
+ *   stream   - User allocated, uninitialized instance of struct
+ *              lib_syslogstream_s to be initialized.
+ *   priority - log priority.
+ *
+ * Returned Value:
+ *   None (User allocated instance initialized).
+ *
+ ****************************************************************************/
+
+void lib_syslogstream(FAR struct lib_syslogstream_s *stream, int priority);
 
 /****************************************************************************
  * Name: lib_syslograwstream_open

--- a/libs/libc/stream/Kconfig
+++ b/libs/libc/stream/Kconfig
@@ -25,4 +25,8 @@ config STREAM_OUT_BUFFER_SIZE
 	int "Output stream buffer size"
 	default 64
 
+config STREAM_HEXDUMP_BUFFER_SIZE
+	int "Output hexdump stream buffer size"
+	default 128
+
 endmenu # Locale Support

--- a/libs/libc/stream/Make.defs
+++ b/libs/libc/stream/Make.defs
@@ -27,6 +27,7 @@ CSRCS += lib_rawoutstream.c lib_rawsistream.c lib_rawsostream.c
 CSRCS += lib_zeroinstream.c lib_nullinstream.c lib_nulloutstream.c
 CSRCS += lib_mtdoutstream.c lib_libnoflush.c lib_libsnoflush.c
 CSRCS += lib_syslogstream.c lib_syslograwstream.c lib_bufferedoutstream.c
+CSRCS += lib_hexdumpstream.c
 
 # The remaining sources files depend upon C streams
 

--- a/libs/libc/stream/Make.defs
+++ b/libs/libc/stream/Make.defs
@@ -26,7 +26,7 @@ CSRCS += lib_memsostream.c lib_lowoutstream.c lib_rawinstream.c
 CSRCS += lib_rawoutstream.c lib_rawsistream.c lib_rawsostream.c
 CSRCS += lib_zeroinstream.c lib_nullinstream.c lib_nulloutstream.c
 CSRCS += lib_mtdoutstream.c lib_libnoflush.c lib_libsnoflush.c
-CSRCS += lib_syslograwstream.c lib_bufferedoutstream.c
+CSRCS += lib_syslogstream.c lib_syslograwstream.c lib_bufferedoutstream.c
 
 # The remaining sources files depend upon C streams
 

--- a/libs/libc/stream/Make.defs
+++ b/libs/libc/stream/Make.defs
@@ -26,7 +26,7 @@ CSRCS += lib_memsostream.c lib_lowoutstream.c lib_rawinstream.c
 CSRCS += lib_rawoutstream.c lib_rawsistream.c lib_rawsostream.c
 CSRCS += lib_zeroinstream.c lib_nullinstream.c lib_nulloutstream.c
 CSRCS += lib_mtdoutstream.c lib_libnoflush.c lib_libsnoflush.c
-CSRCS += lib_syslogstream.c lib_bufferedoutstream.c
+CSRCS += lib_syslograwstream.c lib_bufferedoutstream.c
 
 # The remaining sources files depend upon C streams
 

--- a/libs/libc/stream/lib_hexdumpstream.c
+++ b/libs/libc/stream/lib_hexdumpstream.c
@@ -1,0 +1,182 @@
+/****************************************************************************
+ * libs/libc/stream/lib_hexdumpstream.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/compiler.h>
+#include <nuttx/streams.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: nibble2hex
+ *
+ * Description:
+ *  Convert a binary nibble to a hexadecimal character.
+ *
+ ****************************************************************************/
+
+static char nibble2hex(unsigned char nibble)
+{
+  if (nibble < 10)
+    {
+      return '0' + nibble;
+    }
+  else
+    {
+      return 'A' + nibble - 10;
+    }
+}
+
+/****************************************************************************
+ * Name: bin2hex
+ ****************************************************************************/
+
+static size_t bin2hex(FAR const uint8_t *buf, size_t buflen,
+                      FAR char *hex, size_t hexlen)
+{
+  size_t i;
+
+  if (buflen > hexlen)
+    {
+      buflen = hexlen;
+    }
+
+  for (i = 0; i < buflen; i++)
+    {
+      hex[2 * i]     = nibble2hex(buf[i] >> 4);
+      hex[2 * i + 1] = nibble2hex(buf[i] & 0xf);
+    }
+
+  return buflen;
+}
+
+/****************************************************************************
+ * Name: hexdumpstream_flush
+ ****************************************************************************/
+
+static int hexdumpstream_flush(FAR struct lib_outstream_s *this)
+{
+  FAR struct lib_hexdumpstream_s *rthis = (FAR void *)this;
+
+  if (rthis->pending > 0)
+    {
+      rthis->buffer[rthis->pending] = '\n';
+      lib_stream_puts(rthis->backend, rthis->buffer, rthis->pending + 1);
+      rthis->pending = 0;
+    }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: hexdumpstream_putc
+ ****************************************************************************/
+
+static void hexdumpstream_putc(FAR struct lib_outstream_s *this, int ch)
+{
+  FAR struct lib_hexdumpstream_s *rthis = (FAR void *)this;
+  int outlen = CONFIG_STREAM_HEXDUMP_BUFFER_SIZE;
+  const uint8_t byte = ch;
+
+  bin2hex(&byte, 1, rthis->buffer + rthis->pending,
+          (outlen - rthis->pending) / 2);
+
+  rthis->pending += 2;
+
+  if (rthis->pending == outlen)
+    {
+      hexdumpstream_flush(this);
+    }
+}
+
+/****************************************************************************
+ * Name: hexdumpstream_puts
+ ****************************************************************************/
+
+static int hexdumpstream_puts(FAR struct lib_outstream_s *this,
+                           FAR const void *buf, int len)
+{
+  FAR struct lib_hexdumpstream_s *rthis = (FAR void *)this;
+  const unsigned char *p = buf;
+  int outlen = CONFIG_STREAM_HEXDUMP_BUFFER_SIZE;
+  int line = outlen / 2;
+  int remain = len;
+  int ret;
+
+  while (remain > 0)
+    {
+      ret = remain > line ? line : remain;
+      ret = bin2hex(p, ret, rthis->buffer + rthis->pending,
+                    (outlen - rthis->pending) / 2);
+
+      p              += ret;
+      remain         -= ret;
+      rthis->pending += ret * 2;
+
+      if (rthis->pending == outlen)
+        {
+          hexdumpstream_flush(this);
+        }
+    }
+
+  this->nput += len;
+
+  return len;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: lib_hexdumpstream
+ *
+ * Description:
+ *   Convert binary stream to hex and redirect to syslog
+ *
+ * Input Parameters:
+ *   stream    - User allocated, uninitialized instance of struct
+ *               lib_bufferedoutstream_s to be initialized.
+ *   backend   - Stream backend port.
+ *
+ * Returned Value:
+ *   None (User allocated instance initialized).
+ *
+ ****************************************************************************/
+
+void lib_hexdumpstream(FAR struct lib_hexdumpstream_s *stream,
+                       FAR struct lib_outstream_s *backend)
+{
+  struct lib_outstream_s *public = &stream->public;
+
+  public->putc    = hexdumpstream_putc;
+  public->puts    = hexdumpstream_puts;
+  public->flush   = hexdumpstream_flush;
+  public->nput    = 0;
+
+  stream->pending  = 0;
+  stream->backend  = backend;
+}

--- a/libs/libc/stream/lib_syslograwstream.c
+++ b/libs/libc/stream/lib_syslograwstream.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * libs/libc/stream/lib_syslogstream.c
+ * libs/libc/stream/lib_syslograwstream.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -36,12 +36,12 @@
 
 #ifdef CONFIG_SYSLOG_BUFFER
 /****************************************************************************
- * Name: syslogstream_flush
+ * Name: syslograwstream_flush
  ****************************************************************************/
 
-static int syslogstream_flush(FAR struct lib_outstream_s *ostream)
+static int syslograwstream_flush(FAR struct lib_outstream_s *ostream)
 {
-  FAR struct lib_syslogstream_s *stream = (FAR void *)ostream;
+  FAR struct lib_syslograwstream_s *stream = (FAR void *)ostream;
   int ret = OK;
 
   DEBUGASSERT(stream != NULL);
@@ -72,11 +72,11 @@ static int syslogstream_flush(FAR struct lib_outstream_s *ostream)
 }
 
 /****************************************************************************
- * Name: syslogstream_addchar
+ * Name: syslograwstream_addchar
  ****************************************************************************/
 
-static void syslogstream_addchar(FAR struct lib_syslogstream_s *stream,
-                                 int ch)
+static void syslograwstream_addchar(FAR struct lib_syslograwstream_s *stream,
+                                    int ch)
 {
   /* Add the incoming character to the buffer */
 
@@ -93,16 +93,17 @@ static void syslogstream_addchar(FAR struct lib_syslogstream_s *stream,
     {
       /* Yes.. then flush the buffer */
 
-      syslogstream_flush(&stream->public);
+      syslograwstream_flush(&stream->public);
     }
 }
 
 /****************************************************************************
- * Name: syslogstream_addstring
+ * Name: syslograwstream_addstring
  ****************************************************************************/
 
-static int syslogstream_addstring(FAR struct lib_syslogstream_s *stream,
-                                  FAR const char *buff, int len)
+static int
+syslograwstream_addstring(FAR struct lib_syslograwstream_s *stream,
+                          FAR const char *buff, int len)
 {
   int ret = 0;
 
@@ -120,7 +121,7 @@ static int syslogstream_addstring(FAR struct lib_syslogstream_s *stream,
         {
           /* Yes.. then flush the buffer */
 
-          syslogstream_flush(&stream->public);
+          syslograwstream_flush(&stream->public);
         }
     }
   while (ret < len);
@@ -133,13 +134,13 @@ static int syslogstream_addstring(FAR struct lib_syslogstream_s *stream,
 #endif
 
 /****************************************************************************
- * Name: syslogstream_putc
+ * Name: syslograwstream_putc
  ****************************************************************************/
 
-static void syslogstream_putc(FAR struct lib_outstream_s *this, int ch)
+static void syslograwstream_putc(FAR struct lib_outstream_s *this, int ch)
 {
-  FAR struct lib_syslogstream_s *stream =
-                                      (FAR struct lib_syslogstream_s *)this;
+  FAR struct lib_syslograwstream_s *stream =
+                                    (FAR struct lib_syslograwstream_s *)this;
 
   DEBUGASSERT(stream != NULL);
   stream->last_ch = ch;
@@ -155,7 +156,7 @@ static void syslogstream_putc(FAR struct lib_outstream_s *this, int ch)
         {
           /* Add the incoming character to the buffer */
 
-          syslogstream_addchar(stream, ch);
+          syslograwstream_addchar(stream, ch);
         }
       else
 #  endif
@@ -189,11 +190,11 @@ static void syslogstream_putc(FAR struct lib_outstream_s *this, int ch)
     }
 }
 
-static int syslogstream_puts(FAR struct lib_outstream_s *this,
-                             FAR const void *buff, int len)
+static int syslograwstream_puts(FAR struct lib_outstream_s *this,
+                                FAR const void *buff, int len)
 {
-  FAR struct lib_syslogstream_s *stream =
-                                      (FAR struct lib_syslogstream_s *)this;
+  FAR struct lib_syslograwstream_s *stream =
+                                    (FAR struct lib_syslograwstream_s *)this;
   int ret;
 
   DEBUGASSERT(stream != NULL);
@@ -212,7 +213,7 @@ static int syslogstream_puts(FAR struct lib_outstream_s *this,
     {
       /* Add the incoming string to the buffer */
 
-      ret = syslogstream_addstring(stream, buff, len);
+      ret = syslograwstream_addstring(stream, buff, len);
     }
   else
 #endif
@@ -250,7 +251,7 @@ static int syslogstream_puts(FAR struct lib_outstream_s *this,
  ****************************************************************************/
 
 /****************************************************************************
- * Name: lib_syslogstream_open
+ * Name: lib_syslograwstream_open
  *
  * Description:
  *   Initializes a stream for use with the configured syslog interface.
@@ -258,25 +259,25 @@ static int syslogstream_puts(FAR struct lib_outstream_s *this,
  *
  * Input Parameters:
  *   stream - User allocated, uninitialized instance of struct
- *            lib_syslogstream_s to be initialized.
+ *            lib_syslograwstream_s to be initialized.
  *
  * Returned Value:
  *   None (User allocated instance initialized).
  *
  ****************************************************************************/
 
-void lib_syslogstream_open(FAR struct lib_syslogstream_s *stream)
+void lib_syslograwstream_open(FAR struct lib_syslograwstream_s *stream)
 {
   DEBUGASSERT(stream != NULL);
 
   /* Initialize the common fields */
 
-  stream->public.putc  = syslogstream_putc;
-  stream->public.puts  = syslogstream_puts;
+  stream->public.putc  = syslograwstream_putc;
+  stream->public.puts  = syslograwstream_puts;
   stream->public.nput  = 0;
 
 #ifdef CONFIG_SYSLOG_BUFFER
-  stream->public.flush = syslogstream_flush;
+  stream->public.flush = syslograwstream_flush;
 
   /* Allocate an IOB */
 
@@ -298,14 +299,14 @@ void lib_syslogstream_open(FAR struct lib_syslogstream_s *stream)
 }
 
 /****************************************************************************
- * Name: lib_syslogstream_close
+ * Name: lib_syslograwstream_close
  *
  * Description:
  *   Free resources held by the syslog stream.
  *
  * Input Parameters:
  *   stream - User allocated, uninitialized instance of struct
- *            lib_syslogstream_s to be initialized.
+ *            lib_syslograwstream_s to be initialized.
  *
  * Returned Value:
  *   None (Resources freed).
@@ -313,7 +314,7 @@ void lib_syslogstream_open(FAR struct lib_syslogstream_s *stream)
  ****************************************************************************/
 
 #ifdef CONFIG_SYSLOG_BUFFER
-void lib_syslogstream_close(FAR struct lib_syslogstream_s *stream)
+void lib_syslograwstream_close(FAR struct lib_syslograwstream_s *stream)
 {
   DEBUGASSERT(stream != NULL);
 
@@ -324,7 +325,7 @@ void lib_syslogstream_close(FAR struct lib_syslogstream_s *stream)
     {
       /* Flush the output buffered in the IOB */
 
-      syslogstream_flush(&stream->public);
+      syslograwstream_flush(&stream->public);
 
       /* Free the IOB */
 
@@ -332,7 +333,7 @@ void lib_syslogstream_close(FAR struct lib_syslogstream_s *stream)
       stream->iob = NULL;
     }
 #  else
-  syslogstream_flush(&stream->public);
+  syslograwstream_flush(&stream->public);
 #  endif
 }
 #endif

--- a/libs/libc/stream/lib_syslogstream.c
+++ b/libs/libc/stream/lib_syslogstream.c
@@ -1,0 +1,97 @@
+/****************************************************************************
+ * libs/libc/stream/lib_syslogstream.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <assert.h>
+#include <errno.h>
+#include <stddef.h>
+#include <syslog.h>
+
+#include <nuttx/streams.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: syslogstream_putc
+ ****************************************************************************/
+
+static void syslogstream_putc(FAR struct lib_outstream_s *this, int ch)
+{
+  FAR struct lib_syslogstream_s *stream =
+                                       (FAR struct lib_syslogstream_s *)this;
+
+  DEBUGASSERT(stream != NULL);
+  syslog(stream->priority, "%c", ch);
+  stream->public.nput++;
+}
+
+static int syslogstream_puts(FAR struct lib_outstream_s *this,
+                             FAR const void *buff, int len)
+{
+  FAR struct lib_syslogstream_s *stream =
+                                       (FAR struct lib_syslogstream_s *)this;
+
+  DEBUGASSERT(stream != NULL);
+  if (len <= 0)
+    {
+      return 0;
+    }
+
+  syslog(stream->priority, "%.*s", len, (FAR const char *)buff);
+  return len;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: lib_syslogstream
+ *
+ * Description:
+ *   Initializes syslog stream
+ *
+ * Input Parameters:
+ *   stream   - User allocated, uninitialized instance of struct
+ *              lib_syslogstream_s to be initialized.
+ *   priority - log priority.
+ *
+ * Returned Value:
+ *   None (User allocated instance initialized).
+ *
+ ****************************************************************************/
+
+void lib_syslogstream(FAR struct lib_syslogstream_s *stream, int priority)
+{
+  DEBUGASSERT(stream != NULL);
+
+  /* Initialize the common fields */
+
+  stream->public.nput  = 0;
+  stream->public.putc  = syslogstream_putc;
+  stream->public.puts  = syslogstream_puts;
+  stream->public.flush = lib_noflush;
+  stream->priority     = priority;
+}

--- a/libs/libc/stream/lib_syslogstream.c
+++ b/libs/libc/stream/lib_syslogstream.c
@@ -70,13 +70,11 @@ static int syslogstream_flush(FAR struct lib_outstream_s *ostream)
   stream->offset = 0;
   return ret;
 }
-#endif
 
 /****************************************************************************
  * Name: syslogstream_addchar
  ****************************************************************************/
 
-#ifdef CONFIG_SYSLOG_BUFFER
 static void syslogstream_addchar(FAR struct lib_syslogstream_s *stream,
                                  int ch)
 {


### PR DESCRIPTION

![Screenshot from 2023-05-24 14-38-21](https://github.com/apache/nuttx/assets/758493/14634408-70fa-4763-baef-7c6608916a4c)


## Summary

stream/hexdump: add hexdump stream to dump binary to syslog 

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

ci-check