### PR TITLE
mm/kmm_map: Add support to dynamically map pages into kernel virtual …

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -549,6 +549,13 @@ config ARCH_SHM_VBASE
 	---help---
 		The virtual address of the beginning of the shared memory region.
 
+config ARCH_KMAP_VBASE
+	hex "Kernel dynamic virtual mappings base"
+	depends on ARCH_VMA_MAPPING
+	---help---
+		The virtual address of the beginning of the kernel dynamic mapping
+		region.
+
 config ARCH_TEXT_NPAGES
 	int "Max .text pages"
 	default 1
@@ -595,6 +602,18 @@ config ARCH_SHM_NPAGES
 	---help---
 		The maximum number of pages that can allocated per region for the shared memory
 		region. Default is 1.
+
+		The size of the virtual shared memory address space is then
+		determined by the product of the maximum number of regions, the
+		maximum number of pages per region, and the configured size of
+		each page.
+
+config ARCH_KMAP_NPAGES
+	int "Max kernel dynamic mapping pages"
+	default 1
+	---help---
+		The maximum amount of pages that a kernel can use for dynamically
+		mapping physical pages to itself.
 
 		The size of the virtual shared memory address space is then
 		determined by the product of the maximum number of regions, the

--- a/arch/risc-v/src/common/Make.defs
+++ b/arch/risc-v/src/common/Make.defs
@@ -102,5 +102,5 @@ endif
 
 ifeq ($(CONFIG_ARCH_ADDRENV),y)
 CMN_CSRCS += riscv_addrenv.c riscv_pgalloc.c riscv_addrenv_perms.c
-CMN_CSRCS += riscv_addrenv_utils.c riscv_addrenv_shm.c
+CMN_CSRCS += riscv_addrenv_utils.c riscv_addrenv_shm.c riscv_addrenv_pgmap.c
 endif

--- a/arch/risc-v/src/common/addrenv.h
+++ b/arch/risc-v/src/common/addrenv.h
@@ -52,6 +52,14 @@
 #  define ARCH_ADDRENV_VBASE    (CONFIG_ARCH_DATA_VBASE)
 #endif
 
+/* Maximum user address environment size */
+
+#define ARCH_ADDRENV_MAX_SIZE   (0x40000000)
+
+/* User address environment end */
+
+#define ARCH_ADDRENV_VEND       (ARCH_ADDRENV_VBASE + ARCH_ADDRENV_MAX_SIZE)
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/

--- a/arch/risc-v/src/common/addrenv.h
+++ b/arch/risc-v/src/common/addrenv.h
@@ -44,6 +44,14 @@
 #  define ARCH_KERNEL_STACKSIZE STACK_ALIGN_UP(CONFIG_ARCH_KERNEL_STACKSIZE)
 #endif
 
+/* Base address for address environment */
+
+#if CONFIG_ARCH_TEXT_VBASE != 0
+#  define ARCH_ADDRENV_VBASE    (CONFIG_ARCH_TEXT_VBASE)
+#else
+#  define ARCH_ADDRENV_VBASE    (CONFIG_ARCH_DATA_VBASE)
+#endif
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/

--- a/arch/risc-v/src/common/pgalloc.h
+++ b/arch/risc-v/src/common/pgalloc.h
@@ -95,7 +95,7 @@ static inline bool riscv_uservaddr(uintptr_t vaddr)
    * heap, or stack regions.
    */
 
-  return vaddr >= ARCH_ADDRENV_VBASE;
+  return vaddr >= ARCH_ADDRENV_VBASE && vaddr < ARCH_ADDRENV_VEND;
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/common/pgalloc.h
+++ b/arch/risc-v/src/common/pgalloc.h
@@ -32,6 +32,8 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "addrenv.h"
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -77,6 +79,24 @@ static inline uintptr_t riscv_pgvaddr(uintptr_t paddr)
   return 0;
 }
 #endif /* CONFIG_ARCH_PGPOOL_MAPPING */
+
+/****************************************************************************
+ * Name: riscv_uservaddr
+ *
+ * Description:
+ *   Return true if the virtual address, vaddr, lies in the user address
+ *   space.
+ *
+ ****************************************************************************/
+
+static inline bool riscv_uservaddr(uintptr_t vaddr)
+{
+  /* Check if this address is within the range of the virtualized .bss/.data,
+   * heap, or stack regions.
+   */
+
+  return vaddr >= ARCH_ADDRENV_VBASE;
+}
 
 /****************************************************************************
  * Name: riscv_pgwipe

--- a/arch/risc-v/src/common/riscv_addrenv.c
+++ b/arch/risc-v/src/common/riscv_addrenv.c
@@ -68,6 +68,7 @@
 
 #include <arch/barriers.h>
 
+#include "addrenv.h"
 #include "pgalloc.h"
 #include "riscv_mmu.h"
 
@@ -85,17 +86,9 @@
 
 #define ENTRIES_PER_PGT     (RV_MMU_PAGE_ENTRIES)
 
-/* Base address for address environment */
-
-#if CONFIG_ARCH_TEXT_VBASE != 0
-#  define ADDRENV_VBASE       (CONFIG_ARCH_TEXT_VBASE)
-#else
-#  define ADDRENV_VBASE       (CONFIG_ARCH_DATA_VBASE)
-#endif
-
 /* Make sure the address environment virtual address boundary is valid */
 
-static_assert((ADDRENV_VBASE & RV_MMU_SECTION_ALIGN) == 0,
+static_assert((ARCH_ADDRENV_VBASE & RV_MMU_SECTION_ALIGN) == 0,
               "Addrenv start address is not aligned to section boundary");
 
 /****************************************************************************
@@ -382,7 +375,7 @@ int up_addrenv_create(size_t textsize, size_t datasize, size_t heapsize,
   uintptr_t heapbase;
 
   DEBUGASSERT(addrenv);
-  DEBUGASSERT(MM_ISALIGNED(ADDRENV_VBASE));
+  DEBUGASSERT(MM_ISALIGNED(ARCH_ADDRENV_VBASE));
 
   /* Make sure the address environment is wiped before doing anything */
 
@@ -417,7 +410,7 @@ int up_addrenv_create(size_t textsize, size_t datasize, size_t heapsize,
   database = resvbase + MM_PGALIGNUP(resvsize);
   heapbase = CONFIG_ARCH_HEAP_VBASE;
 #else
-  resvbase = ADDRENV_VBASE;
+  resvbase = ARCH_ADDRENV_VBASE;
   resvsize = ARCH_DATA_RESERVE_SIZE;
   textbase = resvbase + MM_PGALIGNUP(resvsize);
   database = textbase + MM_PGALIGNUP(textsize);
@@ -532,7 +525,7 @@ int up_addrenv_destroy(arch_addrenv_t *addrenv)
 
   /* Things start from the beginning of the user virtual memory */
 
-  vaddr  = ADDRENV_VBASE;
+  vaddr  = ARCH_ADDRENV_VBASE;
   pgsize = mmu_get_region_size(ARCH_SPGTS);
 
   /* First destroy the allocated memory and the final level page table */

--- a/arch/risc-v/src/common/riscv_addrenv_pgmap.c
+++ b/arch/risc-v/src/common/riscv_addrenv_pgmap.c
@@ -1,0 +1,239 @@
+/****************************************************************************
+ * arch/risc-v/src/common/riscv_addrenv_pgmap.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/addrenv.h>
+#include <nuttx/irq.h>
+#include <nuttx/pgalloc.h>
+#include <nuttx/sched.h>
+
+#include <arch/barriers.h>
+
+#include <sys/mman.h>
+
+#include "pgalloc.h"
+#include "riscv_mmu.h"
+
+#ifdef CONFIG_BUILD_KERNEL
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_addrenv_find_page
+ *
+ * Description:
+ *   Find physical page mapped to user virtual address from the address
+ *   environment page directory.
+ *
+ * Input Parameters:
+ *   addrenv - The user address environment.
+ *   vaddr   - The user virtual address
+ *
+ * Returned Value:
+ *   Page physical address on success; NULL on failure.
+ *
+ ****************************************************************************/
+
+uintptr_t up_addrenv_find_page(FAR arch_addrenv_t *addrenv, uintptr_t vaddr)
+{
+  uintptr_t pgdir;
+  uintptr_t lnvaddr;
+  uintptr_t paddr;
+  uint32_t  ptlevel;
+
+  /* If vaddr is not user space, get out */
+
+  if (!riscv_uservaddr(vaddr))
+    {
+      return 0;
+    }
+
+  /* Get the kernel addressable virtual address of the page directory root */
+
+  pgdir = riscv_pgvaddr(mmu_satp_to_paddr(addrenv->satp));
+  if (!pgdir)
+    {
+      return 0;
+    }
+
+  /* Make table walk to find the page */
+
+  for (ptlevel = 1, lnvaddr = pgdir; ptlevel < RV_MMU_PT_LEVELS; ptlevel++)
+    {
+      paddr = mmu_pte_to_paddr(mmu_ln_getentry(ptlevel, lnvaddr, vaddr));
+      lnvaddr = riscv_pgvaddr(paddr);
+      if (!lnvaddr)
+        {
+          return 0;
+        }
+    }
+
+  /* Got it, now convert it to physical page */
+
+  paddr = mmu_ln_getentry(ptlevel, lnvaddr, vaddr);
+  paddr = mmu_pte_to_paddr(paddr);
+
+  return paddr;
+}
+
+/****************************************************************************
+ * Name: up_addrenv_page_vaddr
+ *
+ * Description:
+ *   Find the kernel virtual address associated with physical page.
+ *
+ * Input Parameters:
+ *   page - The page physical address.
+ *
+ * Returned Value:
+ *   Page kernel virtual address on success; NULL on failure.
+ *
+ ****************************************************************************/
+
+uintptr_t up_addrenv_page_vaddr(uintptr_t page)
+{
+  return riscv_pgvaddr(page);
+}
+
+/****************************************************************************
+ * Name: up_addrenv_user_vaddr
+ *
+ * Description:
+ *   Check if a virtual address is in user virtual address space.
+ *
+ * Input Parameters:
+ *   vaddr - The virtual address.
+ *
+ * Returned Value:
+ *   True if it is; false if it's not
+ *
+ ****************************************************************************/
+
+bool up_addrenv_user_vaddr(uintptr_t vaddr)
+{
+  return riscv_uservaddr(vaddr);
+}
+
+#ifdef CONFIG_MM_KMAP
+
+/****************************************************************************
+ * Name: up_addrenv_kmap_pages
+ *
+ * Description:
+ *   Map physical pages into a continuous virtual memory block.
+ *
+ * Input Parameters:
+ *   pages - A pointer to the first element in a array of physical address,
+ *     each corresponding to one page of memory.
+ *   npages - The number of pages in the list of physical pages to be mapped.
+ *   vaddr - The virtual address corresponding to the beginning of the
+ *     (continuous) virtual address region.
+ *   prot - Access right flags.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; a negated errno value is returned
+ *   on failure.
+ *
+ ****************************************************************************/
+
+int up_addrenv_kmap_pages(void **pages, unsigned int npages, uintptr_t vaddr,
+                          int prot)
+{
+  struct tcb_s          *tcb     = nxsched_self();
+  struct arch_addrenv_s *addrenv = &tcb->addrenv_own->addrenv;
+  int mask                       = 0;
+
+  /* Sanity checks */
+
+  DEBUGASSERT(tcb && tcb->addrenv_own);
+  DEBUGASSERT(pages != NULL && npages > 0);
+  DEBUGASSERT(vaddr >= CONFIG_ARCH_KMAP_VBASE && vaddr < ARCH_KMAP_VEND);
+  DEBUGASSERT(MM_ISALIGNED(vaddr));
+
+  /* Convert access right flags to MMU flags */
+
+  if (prot & PROT_READ)
+    {
+      mask |= PTE_R;
+    }
+
+  if (prot & PROT_WRITE)
+    {
+      mask |= PTE_W;
+    }
+
+  if (prot & PROT_EXEC)
+    {
+      mask |= PTE_X;
+    }
+
+  /* This is a kernel (global) mapping */
+
+  mask |= PTE_G;
+
+  /* Let riscv_map_pages do the work */
+
+  return riscv_map_pages(addrenv, (uintptr_t *)pages, npages, vaddr, mask);
+}
+
+/****************************************************************************
+ * Name: riscv_unmap_pages
+ *
+ * Description:
+ *   Unmap a previously mapped virtual memory region.
+ *
+ * Input Parameters:
+ *   vaddr - The virtual address corresponding to the beginning of the
+ *     (continuous) virtual address region.
+ *   npages - The number of pages to be unmapped
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; a negated errno value is returned
+ *   on failure.
+ *
+ ****************************************************************************/
+
+int up_addrenv_kunmap_pages(uintptr_t vaddr, unsigned int npages)
+{
+  struct tcb_s          *tcb     = nxsched_self();
+  struct arch_addrenv_s *addrenv = &tcb->addrenv_own->addrenv;
+
+  /* Sanity checks */
+
+  DEBUGASSERT(tcb && tcb->addrenv_own);
+  DEBUGASSERT(npages > 0);
+  DEBUGASSERT(vaddr >= CONFIG_ARCH_KMAP_VBASE && vaddr < ARCH_KMAP_VEND);
+  DEBUGASSERT(MM_ISALIGNED(vaddr));
+
+  /* Let riscv_unmap_pages do the work */
+
+  return riscv_unmap_pages(addrenv, vaddr, npages);
+}
+
+#endif /* CONFIG_MM_KMAP */
+#endif /* CONFIG_BUILD_KERNEL */

--- a/arch/risc-v/src/common/riscv_mmu.h
+++ b/arch/risc-v/src/common/riscv_mmu.h
@@ -308,10 +308,29 @@ static inline uintptr_t mmu_pte_to_paddr(uintptr_t pte)
 }
 
 /****************************************************************************
+ * Name: mmu_satp_to_paddr
+ *
+ * Description:
+ *   Extract physical address from SATP
+ *
+ * Returned Value:
+ *   Physical address from SATP value
+ *
+ ****************************************************************************/
+
+static inline uintptr_t mmu_satp_to_paddr(uintptr_t satp)
+{
+  uintptr_t ppn;
+  ppn = satp;
+  ppn = ((ppn >> SATP_PPN_SHIFT) & SATP_PPN_MASK);
+  return SATP_PPN_TO_ADDR(ppn);
+}
+
+/****************************************************************************
  * Name: mmu_get_satp_pgbase
  *
  * Description:
- *   Utility function to read the base page table physical address
+ *   Utility function to read the current base page table physical address
  *
  * Returned Value:
  *   Physical address of the current base page table
@@ -320,10 +339,7 @@ static inline uintptr_t mmu_pte_to_paddr(uintptr_t pte)
 
 static inline uintptr_t mmu_get_satp_pgbase(void)
 {
-  uintptr_t ppn;
-  ppn = mmu_read_satp();
-  ppn = ((ppn >> SATP_PPN_SHIFT) & SATP_PPN_MASK);
-  return SATP_PPN_TO_ADDR(ppn);
+  return mmu_satp_to_paddr(mmu_read_satp());
 }
 
 /****************************************************************************

--- a/include/nuttx/addrenv.h
+++ b/include/nuttx/addrenv.h
@@ -201,6 +201,23 @@
 #  define ARCH_SCRATCH_VBASE   __ARCH_SHM_VBASE
 #endif
 
+#ifdef CONFIG_MM_KMAP
+#  ifndef CONFIG_ARCH_KMAP_VBASE
+#    error CONFIG_ARCH_KMAP_VBASE not defined
+#  endif
+
+#  if (CONFIG_ARCH_KMAP_VBASE & CONFIG_MM_MASK) != 0
+#    error CONFIG_ARCH_KMAP_VBASE not aligned to page boundary
+#  endif
+
+#  ifndef CONFIG_ARCH_KMAP_NPAGES
+#    error CONFIG_ARCH_KMAP_NPAGES not defined
+#  endif
+
+#  define ARCH_KMAP_SIZE       (CONFIG_ARCH_KMAP_NPAGES * CONFIG_MM_PGSIZE)
+#  define ARCH_KMAP_VEND       (CONFIG_ARCH_KMAP_VBASE + ARCH_KMAP_SIZE - 1)
+#endif
+
 /* There is no need to use the scratch memory region if the page pool memory
  * is statically mapped.
  */

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -1254,6 +1254,108 @@ int up_addrenv_kstackfree(FAR struct tcb_s *tcb);
 #endif
 
 /****************************************************************************
+ * Name: up_addrenv_find_page
+ *
+ * Description:
+ *   Find physical page mapped to user virtual address from the address
+ *   environment page directory.
+ *
+ * Input Parameters:
+ *   addrenv - The user address environment.
+ *   vaddr   - The user virtual address
+ *
+ * Returned Value:
+ *   Page physical address on success; NULL on failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_ARCH_ADDRENV
+uintptr_t up_addrenv_find_page(FAR arch_addrenv_t *addrenv, uintptr_t vaddr);
+#endif
+
+/****************************************************************************
+ * Name: up_addrenv_page_vaddr
+ *
+ * Description:
+ *   Find the kernel virtual address associated with physical page.
+ *
+ * Input Parameters:
+ *   page - The page physical address.
+ *
+ * Returned Value:
+ *   Page kernel virtual address on success; NULL on failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_ARCH_ADDRENV
+uintptr_t up_addrenv_page_vaddr(uintptr_t page);
+#endif
+
+/****************************************************************************
+ * Name: up_addrenv_user_vaddr
+ *
+ * Description:
+ *   Check if a virtual address is in user virtual address space.
+ *
+ * Input Parameters:
+ *   vaddr - The virtual address.
+ *
+ * Returned Value:
+ *   True if it is; false if it's not
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_ARCH_ADDRENV
+bool up_addrenv_user_vaddr(uintptr_t vaddr);
+#endif
+
+/****************************************************************************
+ * Name: up_addrenv_kmap_pages
+ *
+ * Description:
+ *   Map physical pages into a continuous virtual memory block.
+ *
+ * Input Parameters:
+ *   pages - A pointer to the first element in a array of physical address,
+ *     each corresponding to one page of memory.
+ *   npages - The number of pages in the list of physical pages to be mapped.
+ *   vaddr - The virtual address corresponding to the beginning of the
+ *     (continuous) virtual address region.
+ *   prot - Access right flags.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; a negated errno value is returned
+ *   on failure.
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_MM_KMAP)
+int up_addrenv_kmap_pages(FAR void **pages, unsigned int npages,
+                          uintptr_t vaddr, int prot);
+#endif
+
+/****************************************************************************
+ * Name: riscv_unmap_pages
+ *
+ * Description:
+ *   Unmap a previously mapped virtual memory region.
+ *
+ * Input Parameters:
+ *   vaddr - The virtual address corresponding to the beginning of the
+ *     (continuous) virtual address region.
+ *   npages - The number of pages to be unmapped
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; a negated errno value is returned
+ *   on failure.
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_MM_KMAP)
+int up_addrenv_kunmap_pages(uintptr_t vaddr, unsigned int npages);
+#endif
+
+/****************************************************************************
  * Name: up_addrenv_pa_to_va
  *
  * Description:

--- a/include/nuttx/mm/kmap.h
+++ b/include/nuttx/mm/kmap.h
@@ -1,0 +1,109 @@
+/****************************************************************************
+ * include/nuttx/mm/kmap.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_NUTTX_MM_KMAP_H_
+#define __INCLUDE_NUTTX_MM_KMAP_H_
+
+/****************************************************************************
+ * Name: kmm_map_initialize
+ *
+ * Description:
+ *   Initialize the kernel dynamic mapping module.
+ *
+ * Input Parameters:
+ *   None.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void kmm_map_initialize(void);
+
+/****************************************************************************
+ * Name: kmm_map_pages
+ *
+ * Description:
+ *   Map pages into kernel virtual memory.
+ *
+ * Input Parameters:
+ *   pages  - Pointer to buffer that contains the physical page addresses.
+ *   npages - Amount of pages.
+ *   prot   - Access right flags.
+ *
+ * Returned Value:
+ *   Pointer to the mapped virtual memory on success; NULL on failure
+ *
+ ****************************************************************************/
+
+FAR void *kmm_map(FAR void **pages, size_t npages, int prot);
+
+/****************************************************************************
+ * Name: kmm_unmap
+ *
+ * Description:
+ *   Unmap a previously allocated kernel virtual memory area.
+ *
+ * Input Parameters:
+ *   kaddr - The kernel virtual address where the mapping begins.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void kmm_unmap(FAR void *kaddr);
+
+/****************************************************************************
+ * Name: kmm_user_map
+ *
+ * Description:
+ *   Map a region of user memory (physical pages) for kernel use through
+ *   a continuous virtual memory area.
+ *
+ * Input Parameters:
+ *   uaddr - The user virtual address where mapping begins.
+ *   size  - Size of the region.
+ *
+ * Returned Value:
+ *   Pointer to the virtual memory area, or NULL if out of memory.
+ *
+ ****************************************************************************/
+
+FAR void *kmm_user_map(FAR void *uaddr, size_t size);
+
+/****************************************************************************
+ * Name: kmm_map_user_page
+ *
+ * Description:
+ *   Map a single physical page into kernel virtual memory. Typically just
+ *   returns the kernel addressable page pool virtual address.
+ *
+ * Input Parameters:
+ *   uaddr - The virtual address of the user page.
+ *
+ * Returned Value:
+ *   Pointer to the new address environment, or NULL if out of memory.
+ *
+ ****************************************************************************/
+
+FAR void *kmm_map_user_page(FAR void *uaddr);
+
+#endif /* __INCLUDE_NUTTX_MM_KMAP_H_ */

--- a/mm/Kconfig
+++ b/mm/Kconfig
@@ -189,6 +189,16 @@ config MM_SHM
 		Build in support for the shared memory interfaces shmget(), shmat(),
 		shmctl(), and shmdt().
 
+config MM_KMAP
+	bool "Support for dynamic kernel virtual mappings"
+	default n
+	depends on MM_PGALLOC && BUILD_KERNEL
+	select ARCH_VMA_MAPPING
+	---help---
+		Build support for dynamically mapping pages from the page pool into
+		kernel virtual memory. This includes pages that are already mapped
+		for user.
+
 config MM_HEAP_MEMPOOL_THRESHOLD
 	int "The size of threshold to avoid using multiple mempool in heap"
 	default 0

--- a/mm/Makefile
+++ b/mm/Makefile
@@ -34,6 +34,7 @@ include kasan/Make.defs
 include ubsan/Make.defs
 include tlsf/Make.defs
 include map/Make.defs
+include kmap/Make.defs
 
 BINDIR ?= bin
 

--- a/mm/kmap/Make.defs
+++ b/mm/kmap/Make.defs
@@ -1,0 +1,32 @@
+############################################################################
+# mm/kmap/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifeq ($(CONFIG_MM_KMAP),y)
+
+# Kernel virtual mapping support
+
+CSRCS += kmm_map.c
+
+# Add the shared memory directory to the build
+
+DEPPATH += --dep-path kmap
+VPATH += :kmap
+
+endif

--- a/mm/kmap/kmm_map.c
+++ b/mm/kmap/kmm_map.c
@@ -1,0 +1,466 @@
+/****************************************************************************
+ * mm/kmap/kmm_map.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+#include <stddef.h>
+
+#include <nuttx/addrenv.h>
+#include <nuttx/arch.h>
+#include <nuttx/compiler.h>
+#include <nuttx/kmalloc.h>
+#include <nuttx/mm/gran.h>
+#include <nuttx/mm/map.h>
+#include <nuttx/pgalloc.h>
+#include <nuttx/sched.h>
+
+#include <sys/mman.h>
+
+#if defined(CONFIG_BUILD_KERNEL)
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static GRAN_HANDLE     g_kmm_map_vpages;
+static struct mm_map_s g_kmm_map;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: get_user_pages
+ *
+ * Description:
+ *   Get the physical pages mapped to a user virtual memory region.
+ *
+ * Input Parameters:
+ *   pages  - Pointer to buffer where the page addresses are recorded.
+ *   npages - Amount of pages.
+ *   vaddr  - Start address of the user virtual memory region.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; a negated errno value is returned
+ *   on failure.
+ *
+ ****************************************************************************/
+
+static int get_user_pages(FAR void **pages, size_t npages, uintptr_t vaddr)
+{
+  FAR struct tcb_s *tcb = nxsched_self();
+  uintptr_t         page;
+  int               i;
+
+  /* Find the pages associated with the user virtual address space */
+
+  for (i = 0; i < npages; i++, vaddr += MM_PGSIZE)
+    {
+      page = up_addrenv_find_page(&tcb->addrenv_own->addrenv, vaddr);
+      if (!page)
+        {
+          /* Something went wrong, get out */
+
+          return -EINVAL;
+        }
+
+      pages[i] = (FAR void *)page;
+    }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: map_pages
+ *
+ * Description:
+ *   Map pages into kernel virtual memory.
+ *
+ * Input Parameters:
+ *   pages  - Pointer to buffer that contains the physical page addresses.
+ *   npages - Amount of pages.
+ *   prot   - Access right flags.
+ *
+ * Returned Value:
+ *   Pointer to the mapped virtual memory on success; NULL on failure
+ *
+ ****************************************************************************/
+
+static void *map_pages(FAR void **pages, size_t npages, int prot)
+{
+  struct mm_map_entry_s entry;
+  FAR void             *vaddr;
+  size_t                size;
+  int                   ret;
+
+  /* The region size is full pages */
+
+  size = npages << MM_PGSHIFT;
+
+  /* Find a virtual memory area that fits */
+
+  vaddr = gran_alloc(&g_kmm_map_vpages, size);
+  if (!vaddr)
+    {
+      return NULL;
+    }
+
+  /* Map the pages into the kernel page directory */
+
+  ret = up_addrenv_kmap_pages(pages, npages, (uintptr_t)vaddr, prot);
+  if (ret < 0)
+    {
+      goto errout_with_vaddr;
+    }
+
+  entry.vaddr = vaddr;
+  entry.length = size;
+  entry.offset = 0;
+  entry.munmap = NULL;
+
+  ret = mm_map_add(&g_kmm_map, &entry);
+  if (ret < 0)
+    {
+      goto errout_with_pgmap;
+    }
+
+  return vaddr;
+
+errout_with_pgmap:
+  up_addrenv_kunmap_pages((uintptr_t)vaddr, npages);
+errout_with_vaddr:
+  gran_free(&g_kmm_map_vpages, vaddr, size);
+  return NULL;
+}
+
+/****************************************************************************
+ * Name: map_single_user_page
+ *
+ * Description:
+ *   Map a single user page into kernel memory.
+ *
+ * Input Parameters:
+ *   pages  - Pointer to buffer that contains the physical page addresses.
+ *   npages - Amount of pages.
+ *   prot   - Access right flags.
+ *
+ * Returned Value:
+ *   Pointer to the mapped virtual memory on success; NULL on failure
+ *
+ ****************************************************************************/
+
+static void *map_single_user_page(uintptr_t vaddr)
+{
+  FAR struct tcb_s *tcb = nxsched_self();
+  uintptr_t         page;
+
+  /* Find the page associated with this virtual address */
+
+  page = up_addrenv_find_page(&tcb->addrenv_own->addrenv, vaddr);
+  if (!page)
+    {
+      return NULL;
+    }
+
+  vaddr = up_addrenv_page_vaddr(page);
+  return (FAR void *)vaddr;
+}
+
+/****************************************************************************
+ * Name: kmm_map_lock
+ *
+ * Description:
+ *   Get exclusive access to the kernel mm_map
+ *
+ ****************************************************************************/
+
+static int kmm_map_lock(void)
+{
+  return nxrmutex_lock(&g_kmm_map.mm_map_mutex);
+}
+
+/****************************************************************************
+ * Name: kmm_map_unlock
+ *
+ * Description:
+ *   Relinquish exclusive access to the kernel mm_map
+ *
+ ****************************************************************************/
+
+static void kmm_map_unlock(void)
+{
+  DEBUGVERIFY(nxrmutex_unlock(&g_kmm_map.mm_map_mutex));
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: kmm_map_initialize
+ *
+ * Description:
+ *   Initialize the kernel dynamic mapping module.
+ *
+ * Input Parameters:
+ *   None.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void kmm_map_initialize(void)
+{
+  g_kmm_map_vpages = gran_initialize((FAR void *)CONFIG_ARCH_KMAP_VBASE,
+                                     CONFIG_ARCH_KMAP_NPAGES << MM_PGSHIFT,
+                                     MM_PGSHIFT, MM_PGSHIFT);
+  DEBUGVERIFY(g_kmm_map_vpages);
+  mm_map_initialize(&g_kmm_map, true);
+}
+
+/****************************************************************************
+ * Name: kmm_map_pages
+ *
+ * Description:
+ *   Map pages into kernel virtual memory.
+ *
+ * Input Parameters:
+ *   pages  - Pointer to buffer that contains the physical page addresses.
+ *   npages - Amount of pages.
+ *   prot   - Access right flags.
+ *
+ * Returned Value:
+ *   Pointer to the mapped virtual memory on success; NULL on failure
+ *
+ ****************************************************************************/
+
+FAR void *kmm_map(FAR void **pages, size_t npages, int prot)
+{
+  uintptr_t vaddr;
+
+  if (!pages || !npages || npages > CONFIG_ARCH_KMAP_NPAGES)
+    {
+      return NULL;
+    }
+
+  /* Attempt to map the pages */
+
+  vaddr = (uintptr_t)map_pages(pages, npages, prot);
+  if (!vaddr)
+    {
+      return NULL;
+    }
+
+  return (FAR void *)(vaddr);
+}
+
+/****************************************************************************
+ * Name: kmm_unmap
+ *
+ * Description:
+ *   Unmap a previously allocated kernel virtual memory area.
+ *
+ * Input Parameters:
+ *   kaddr - The kernel virtual address where the mapping begins.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void kmm_unmap(FAR void *kaddr)
+{
+  FAR struct mm_map_entry_s *entry;
+  unsigned int               npages;
+  int                        ret;
+
+  /* Lock the mapping list when we fiddle around with it */
+
+  ret = kmm_map_lock();
+  if (ret == OK)
+    {
+      /* Find the entry, it is OK if none found */
+
+      entry = mm_map_find(get_current_mm(), kaddr, 1);
+      if (entry)
+        {
+          npages = MM_NPAGES(entry->length);
+
+          /* Remove the mappings from the page directory */
+
+          up_addrenv_kunmap_pages((uintptr_t)entry->vaddr, npages);
+
+          /* Release the virtual memory area for use */
+
+          gran_free(&g_kmm_map_vpages, entry->vaddr, entry->length);
+
+          /* Remove the mapping from the kernel mapping list */
+
+          mm_map_remove(&g_kmm_map, entry);
+        }
+
+      kmm_map_unlock();
+    }
+}
+
+/****************************************************************************
+ * Name: kmm_user_map
+ *
+ * Description:
+ *   Map a region of user memory (physical pages) for kernel use through
+ *   a continuous virtual memory area.
+ *
+ * Input Parameters:
+ *   uaddr - The user virtual address where mapping begins.
+ *   size  - Size of the region.
+ *
+ * Returned Value:
+ *   Pointer to the virtual memory area, or NULL if out of memory.
+ *
+ ****************************************************************************/
+
+FAR void *kmm_user_map(FAR void *uaddr, size_t size)
+{
+  FAR void *pages;
+  uintptr_t vaddr;
+  uintptr_t offset;
+  size_t    npages;
+  int       ret;
+
+  /* Find the kernel addressable virtual address, or map the user memory */
+
+  vaddr = (uintptr_t)uaddr;
+
+  /* If the memory is not user memory, get out */
+
+  if (!up_addrenv_user_vaddr(vaddr))
+    {
+      /* Not user memory, get out */
+
+      return uaddr;
+    }
+
+  /* How many pages (including partial) does the space encompass ? */
+
+  offset = vaddr & MM_PGMASK;
+  vaddr  = MM_PGALIGNDOWN(vaddr);
+  npages = MM_NPAGES(offset + size);
+
+  /* Does the area fit in 1 page, including page boundary crossings ? */
+
+  if (npages == 1)
+    {
+      /* Yes, can simply return the kernel addressable virtual address */
+
+      vaddr = (uintptr_t)map_single_user_page(vaddr);
+      return (FAR void *)(vaddr + offset);
+    }
+
+  /* No, the area must be mapped into kernel virtual address space */
+
+  pages = kmm_zalloc(npages * sizeof(void *));
+  if (!pages)
+    {
+      return NULL;
+    }
+
+  /* Fetch the physical pages for the user virtual address range */
+
+  ret = get_user_pages(&pages, npages, vaddr);
+  if (ret < 0)
+    {
+      goto errout_with_pages;
+    }
+
+  /* Map the physical pages to kernel memory */
+
+  vaddr = (uintptr_t)map_pages(&pages, npages, PROT_READ | PROT_WRITE);
+  if (!vaddr)
+    {
+      goto errout_with_pages;
+    }
+
+  /* Ok, we have a virtual memory area, add the offset back */
+
+  return (FAR void *)(vaddr + offset);
+
+errout_with_pages:
+  kmm_free(pages);
+  return NULL;
+}
+
+/****************************************************************************
+ * Name: kmm_map_user_page
+ *
+ * Description:
+ *   Map a single physical page into kernel virtual memory. Typically just
+ *   returns the kernel addressable page pool virtual address.
+ *
+ * Input Parameters:
+ *   uaddr - The virtual address of the user page.
+ *
+ * Returned Value:
+ *   Pointer to the new address environment, or NULL if out of memory.
+ *
+ ****************************************************************************/
+
+FAR void *kmm_map_user_page(FAR void *uaddr)
+{
+  uintptr_t vaddr;
+  uintptr_t offset;
+
+  /* Find the kernel addressable virtual address, or map the user memory */
+
+  vaddr = (uintptr_t)uaddr;
+
+  /* If the memory is not user memory, get out */
+
+  if (!up_addrenv_user_vaddr(vaddr))
+    {
+      /* Not user memory, get out */
+
+      return uaddr;
+    }
+
+  /* Record the offset and add it back later */
+
+  offset = vaddr & MM_PGMASK;
+  vaddr = MM_PGALIGNDOWN(vaddr);
+
+  vaddr = (uintptr_t)map_single_user_page(vaddr);
+  if (!vaddr)
+    {
+      return NULL;
+    }
+
+  return (FAR void *)(vaddr + offset);
+}
+
+#endif

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -36,6 +36,7 @@
 #include <nuttx/fs/fs.h>
 #include <nuttx/net/net.h>
 #include <nuttx/mm/iob.h>
+#include <nuttx/mm/kmap.h>
 #include <nuttx/mm/mm.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/pgalloc.h>
@@ -470,6 +471,12 @@ void nx_start(void)
       mm_pginitialize(heap_start, heap_size);
 #endif
     }
+#endif
+
+#ifdef CONFIG_MM_KMAP
+  /* Initialize the kernel dynamic mapping module */
+
+  kmm_map_initialize();
 #endif
 
 #ifdef CONFIG_ARCH_HAVE_EXTRA_HEAPS


### PR DESCRIPTION
…memory

## Summary
This adds functionality to map pages dynamically into kernel virtual memory. This allows implementing I/O remap for example, which is a useful (future) feature.

Now, the first target is to support mapping user pages for the kernel.

Why? There are some userspace structures that might be needed when the userspace process is not running. Semaphores are one such example. Signals and the WDT timeout both need access to the user semaphore to work properly. Even though for this only obtaining the kernel addressable page pool virtual address is needed, for completeness a procedure is provided to map several pages.

NOTE: ARM target does not implement support yet, I'm not sure how to implement it.
## Impact
Add new feature for CONFIG_BUILD_KERNEL, nothing else is affected
## Testing
icicle:knsh
