### PR TITLE
net/socket: Fix send() / recv() in BUILD_KERNEL

### DIFF
--- a/net/socket/send.c
+++ b/net/socket/send.c
@@ -156,30 +156,7 @@ ssize_t psock_send(FAR struct socket *psock, FAR const void *buf, size_t len,
 
 ssize_t send(int sockfd, FAR const void *buf, size_t len, int flags)
 {
-  FAR struct socket *psock;
-  ssize_t ret;
+  /* send is a cancellation point, but that can all be handled by sendto */
 
-  /* send() is a cancellation point */
-
-  enter_cancellation_point();
-
-  /* Get the underlying socket structure */
-
-  ret = sockfd_socket(sockfd, &psock);
-
-  /* And let psock_send do all of the work */
-
-  if (ret == OK)
-    {
-      ret = psock_send(psock, buf, len, flags);
-    }
-
-  if (ret < 0)
-    {
-      set_errno(-ret);
-      ret = ERROR;
-    }
-
-  leave_cancellation_point();
-  return ret;
+  return sendto(sockfd, buf, len, flags, NULL, 0);
 }

--- a/net/socket/sendto.c
+++ b/net/socket/sendto.c
@@ -27,11 +27,13 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <stdint.h>
+#include <string.h>
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
 
 #include <nuttx/cancelpt.h>
+#include <nuttx/kmalloc.h>
 #include <nuttx/net/net.h>
 
 #include "socket/socket.h"
@@ -198,10 +200,38 @@ ssize_t sendto(int sockfd, FAR const void *buf, size_t len, int flags,
 {
   FAR struct socket *psock;
   ssize_t ret;
+#ifdef CONFIG_BUILD_KERNEL
+  struct sockaddr_storage kaddr;
+  FAR void *kbuf;
+#endif
 
   /* sendto() is a cancellation point */
 
   enter_cancellation_point();
+
+#ifdef CONFIG_BUILD_KERNEL
+  /* Allocate memory and copy user buffer to kernel */
+
+  kbuf = kmm_malloc(len);
+  if (!kbuf)
+    {
+      /* Out of memory */
+
+      ret = -ENOMEM;
+      goto errout_with_cancelpt;
+    }
+
+  memcpy(kbuf, buf, len);
+  buf = kbuf;
+
+  /* Copy the address data to kernel */
+
+  if (to)
+    {
+      memcpy(&kaddr, to, tolen);
+      to = (FAR const struct sockaddr *)&kaddr;
+    }
+#endif
 
   /* Get the underlying socket structure */
 
@@ -214,12 +244,19 @@ ssize_t sendto(int sockfd, FAR const void *buf, size_t len, int flags,
       ret = psock_sendto(psock, buf, len, flags, to, tolen);
     }
 
+#ifdef CONFIG_BUILD_KERNEL
+  kmm_free(kbuf);
+
+errout_with_cancelpt:
+#endif
+
+  leave_cancellation_point();
+
   if (ret < 0)
     {
       set_errno(-ret);
       ret = ERROR;
     }
 
-  leave_cancellation_point();
   return ret;
 }


### PR DESCRIPTION
## Summary
The send() and recv() functions take in user data (as pointers) and these were passed -as is- to the underlying logic, which will fail miserably if the data is used in e.g. devif_poll().

Why? Because the callback comes directly from driver logic and at that point the wrong mappings are almost certainly active -> crash due to page fault. This fixes this behavior.
## Impact
Fix page fault issue with socket:send() / recv().
## Testing
icicle:knsh
