### PR TITLE
nuttx/audio: add channels range

### DIFF
--- a/audio/audio_comp.c
+++ b/audio/audio_comp.c
@@ -176,6 +176,8 @@ static int audio_comp_getcaps(FAR struct audio_lowerhalf_s *dev, int type,
   FAR struct audio_comp_priv_s *priv = (FAR struct audio_comp_priv_s *)dev;
   FAR struct audio_lowerhalf_s **lower = priv->lower;
   int ret = -ENOTTY;
+  int max = UINT8_MAX;
+  int min = 0;
   int i;
 
   caps->ac_channels   = UINT8_MAX;
@@ -200,15 +202,22 @@ static int audio_comp_getcaps(FAR struct audio_lowerhalf_s *dev, int type,
               break;
             }
 
-          if (caps->ac_channels > dup.ac_channels)
+          if (max > (dup.ac_channels & 0x0f))
             {
-              caps->ac_channels = dup.ac_channels;
+              max = dup.ac_channels & 0x0f;
+            }
+
+          if (min < (dup.ac_channels & 0xf0))
+            {
+              min = dup.ac_channels & 0xf0;
             }
 
           caps->ac_format.hw   &= dup.ac_format.hw;
           caps->ac_controls.w  &= dup.ac_controls.w;
         }
     }
+
+  caps->ac_channels = max | min;
 
   return ret;
 }

--- a/include/nuttx/audio/audio.h
+++ b/include/nuttx/audio/audio.h
@@ -362,7 +362,8 @@ struct audio_caps_s
   uint8_t ac_len;           /* Length of the structure */
   uint8_t ac_type;          /* Capabilities (device) type */
   uint8_t ac_subtype;       /* Capabilities sub-type, if needed */
-  uint8_t ac_channels;      /* Number of channels (1, 2, 3, ... 8) */
+  uint8_t ac_channels;      /* Number of channels (1, 2, 3, ... 15) upper 4 bits for minimum channels,
+                             * lower 4 bits for maximum channels */
   uint8_t ac_chmap;         /* Channel map, each ch for each bit,
                              * zero means don't care */
   uint8_t reserved;         /* Reserved for future use */


### PR DESCRIPTION
## Summary

use the upper 4bits in ac_channels to indicate the minimum channels.

## Impact

new functionality

## Testing

internal device