### PR TITLE
fs_poll: Fix wrong return value in CONFIG_BUILD_KERNEL

### DIFF
--- a/fs/vfs/fs_poll.c
+++ b/fs/vfs/fs_poll.c
@@ -393,7 +393,7 @@ int poll(FAR struct pollfd *fds, nfds_t nfds, int timeout)
     {
       /* Out of memory */
 
-      ret = ENOMEM;
+      ret = -ENOMEM;
       goto out_with_cancelpt;
     }
 


### PR DESCRIPTION
## Summary
The exit condition below does not work:

  if (ret < 0)
    {
      set_errno(-ret);
      return ERROR;
    }
  else
    {
      return count;
    }
## Impact
Fix wrong return value in fs_poll, CONFIG_BUILD_KERNEL=y
## Testing
None
