### PR TITLE
arch/nrf52: add an option to configure QSPI sampling delay for RX data

### DIFF
--- a/arch/arm/src/nrf52/Kconfig
+++ b/arch/arm/src/nrf52/Kconfig
@@ -661,6 +661,21 @@ config NRF52_I2C_MASTER_COPY_BUF_SIZE
 
 endmenu
 
+menu "QSPI Configuration"
+
+if NRF52_QSPI
+
+config NRF52_QSPI_RXDELAY
+	int "QSPI RX delay"
+	default 2
+	range 0 7
+	---help---
+		The input serial data sampling delay.
+
+endif # NRF52_QSPI
+
+endmenu # QSPI Configuration
+
 menu "USBDEV Configuration"
 
 endmenu # USBDEV Configuration

--- a/arch/arm/src/nrf52/nrf52_qspi.c
+++ b/arch/arm/src/nrf52/nrf52_qspi.c
@@ -835,6 +835,11 @@ static int nrf52_qspi_hw_initialize(struct nrf52_qspidev_s *priv)
   regval |= QSPI_IFCONFIG0_PPSIZE_512;
   nrf52_qspi_putreg(priv, NRF52_QSPI_IFCONFIG0_OFFSET, regval);
 
+  /* Configure RX delay */
+
+  nrf52_qspi_putreg(priv, NRF52_QSPI_IFTIMING_OFFSET,
+                    QSPI_IFTIMING_RXDELAY(CONFIG_NRF52_QSPI_RXDELAY));
+
   /* Enable READY interrupt */
 
   nrf52_qspi_putreg(priv, NRF52_QSPI_INTENSET_OFFSET, QSPI_INT_READY);


### PR DESCRIPTION
## Summary
arch/nrf52: add an option to configure QSPI sampling delay for RX data
The default RX delay value may not be suitable for high QSPI frequencies

## Impact

## Testing
CI
