### PR TITLE
vnc server: Fix that vnc_updater thread exited caused by readed a null data

### DIFF
--- a/drivers/video/vnc/vnc_updater.c
+++ b/drivers/video/vnc/vnc_updater.c
@@ -386,7 +386,10 @@ static FAR void *vnc_updater(FAR void *arg)
           break;
         }
 
-      DEBUGASSERT(srcrect != NULL);
+      if (srcrect == NULL)
+        {
+          continue;
+        }
 
       updinfo("Dequeued {(%d, %d),(%d, %d)}\n",
               srcrect->rect.x, srcrect->rect.y,


### PR DESCRIPTION
## Summary
When updating the full-screen data, sq_init() will clear the updqueue and add just one new full-screen data to the updqueue. So when the vnc_updater thread is awakened, it may read a null data due to multiple reading, leading to vnc_updater thread exited , which is not expected.

## Impact
None.

## Testing
Run lvgldemo by vnc server.
