### PR TITLE
binfmt/elf: Support loading fully linked executables.

### DIFF
--- a/binfmt/libelf/libelf_verify.c
+++ b/binfmt/libelf/libelf_verify.c
@@ -89,9 +89,10 @@ int elf_verifyheader(FAR const Elf_Ehdr *ehdr)
 
   /* Verify that this is a relocatable file */
 
-  if (ehdr->e_type != ET_REL)
+  if ((ehdr->e_type != ET_REL) && (ehdr->e_type != ET_EXEC))
     {
-      berr("Not a relocatable file: e_type=%d\n", ehdr->e_type);
+      berr("Not a relocatable or executable file: e_type=%d\n",
+                                        ehdr->e_type);
       return -EINVAL;
     }
 


### PR DESCRIPTION
## Summary

The following changes make it possible for Nuttx to load binaries in ELF format which are fully linked.

The change does not include the necessary modifications to produce such binaries. In order to build an applicable binary:
 - The userspace applications linker script (`gnu-elf.ld`) needs to modified so the data and text section origin's match those setup by the address environment.
 - The makefile used, in `apps/import/Make.defs` needs to remove the `-r` LDELFFLAG.

## Impact

 - No measurable impact on existing application which load relocatable ELFs.
 - Massive improvement in launch time when loading fully linked ELFs, as there's no longer any need to process relocations. 
 
## Testing

Using existing configurations and relocatable ELFs:
 - sim:elf
 - rv-virt:knsh32

Using fully linked ELFs requires modifications as outlined above. For testing on rv-virt:knsh32:

Changes to Nuttx:
```diff
diff --git a/binfmt/libelf/gnu-elf.ld b/binfmt/libelf/gnu-elf.ld
index 81928663ee..9b03039e3f 100644
--- a/binfmt/libelf/gnu-elf.ld
+++ b/binfmt/libelf/gnu-elf.ld
@@ -20,7 +20,8 @@
 
 SECTIONS
 {
-  .text 0x00000000 :
+  . = 0xC0000000;
+  .text :
     {
       _stext = . ;
       *(.text)
@@ -51,6 +52,7 @@ SECTIONS
       _erodata = . ;
     }
 
+  . = 0xC0401000;
   .data :
     {
       _sdata = . ;
diff --git a/boards/risc-v/qemu-rv/rv-virt/scripts/Make.defs b/boards/risc-v/qemu-rv/rv-virt/scripts/Make.defs
index ab13f19b9c..4511054841 100644
--- a/boards/risc-v/qemu-rv/rv-virt/scripts/Make.defs
+++ b/boards/risc-v/qemu-rv/rv-virt/scripts/Make.defs
@@ -57,5 +57,5 @@ else
   LDELFFLAGS = --oformat elf64-littleriscv
 endif
 
-LDELFFLAGS += -r -e main
+LDELFFLAGS += -e main
 LDELFFLAGS += -T $(call CONVERT_PATH,$(TOPDIR)/binfmt/libelf/gnu-elf.ld)

```

Changes to apps:
```diff
diff --git a/import/Make.defs b/import/Make.defs
index b8377f79a..b97b260a2 100644
--- a/import/Make.defs
+++ b/import/Make.defs
@@ -90,5 +90,5 @@ endif
 
 # ELF module definitions
 
-LDELFFLAGS += -r -e _start -Bstatic
+LDELFFLAGS += -s -e _start -Bstatic
 LDELFFLAGS += $(addprefix -T,$(call CONVERT_PATH,$(TOPDIR)/scripts/gnu-elf.ld))
```

As can be seen, the required changes are board, and configuration specific. It may be possible to provide the infrastructure in NuttX (and apps) to build fully-linked applications, picking up the necessary configuration values from the board's directory. However, this would be quite a large change, and may need to be addressed separately.

For our current application I'm building NuttX native applications as relocatables and our custom applications  fully linked against Nuttx export with a custom Makefile and linker script. Loading both ELF types simultaneously works without issues.

