### PR TITLE
SLIP: Switch to poll based design

### DIFF
--- a/net/Kconfig
+++ b/net/Kconfig
@@ -192,6 +192,7 @@ menuconfig NET_MBIM
 menuconfig NET_SLIP
 	bool "SLIP support"
 	select ARCH_HAVE_NETDEV_STATISTICS
+	depends on NET_IPv4
 	default n
 	---help---
 		Enables building of the SLIP driver. SLIP requires
@@ -220,21 +221,6 @@ config NET_SLIP_NINTERFACES
 		Selects the number of physical SLIP
 		interfaces to support.
 		Default: 1
-
-config NET_SLIP_STACKSIZE
-	int "SLIP per-thread stack size"
-	default DEFAULT_TASK_STACKSIZE
-	---help---
-		Select the stack size of the SLIP RX and TX tasks.
-
-		SLIP starts two dedicated threads per interface
-		to handle network events, enabling high performance.
-
-config NET_SLIP_DEFPRIO
-	int "SLIP threads priority"
-	default 128
-	---help---
-		The priority of the SLIP RX and TX tasks. Default: 128
 
 endif # NET_SLIP
 


### PR DESCRIPTION
## Summary

This is a refactored version of the SLIP network driver.  Updates include:

1. The original design started two kernel threads per SLIP device. The refactored version uses file_poll to essentially be driven by the UART RX and TX interrupts and pushes work to the low priority work queue.

2. The SLIP byte un-/stuffing is more efficient now, using memcpy instead of handling each byte individually.

3. The switch of the old SLIP driver to IOBs caused buffer overwrites if packets were sent that would not fit into a single IOB.  This is fixed now.

## Impact

Changes are contained to the SLIP network driver.  This fix is reducing latency, improving throughput and is more resource efficient.

## Testing

Working fine for me with LwM2M, Telnet, and iperf