### PR TITLE
Rename touchscreen ioctls for clarity

### DIFF
--- a/drivers/input/tsc2007.c
+++ b/drivers/input/tsc2007.c
@@ -1026,7 +1026,7 @@ static int tsc2007_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
   switch (cmd)
     {
-      case TSIOC_SETCALIB:  /* arg: Pointer to int calibration value */
+      case TSIOC_SETXRCAL:  /* arg: Pointer to int calibration value */
         {
           FAR int *ptr = (FAR int *)((uintptr_t)arg);
           DEBUGASSERT(priv->config != NULL && ptr != NULL);
@@ -1034,7 +1034,7 @@ static int tsc2007_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         }
         break;
 
-      case TSIOC_GETCALIB:  /* arg: Pointer to int calibration value */
+      case TSIOC_GETXRCAL:  /* arg: Pointer to int calibration value */
         {
           FAR int *ptr = (FAR int *)((uintptr_t)arg);
           DEBUGASSERT(priv->config != NULL && ptr != NULL);

--- a/include/nuttx/input/touchscreen.h
+++ b/include/nuttx/input/touchscreen.h
@@ -50,10 +50,10 @@
 
 /* Common TSC IOCTL commands */
 
-#define TSIOC_SETCALIB       _TSIOC(0x0001) /* arg: Pointer to
+#define TSIOC_SETXRCAL       _TSIOC(0x0001) /* arg: Pointer to
                                              * int Xplate R calibration value
                                              */
-#define TSIOC_GETCALIB       _TSIOC(0x0002) /* arg: Pointer to
+#define TSIOC_GETXRCAL       _TSIOC(0x0002) /* arg: Pointer to
                                              * int Xplate R calibration value
                                              */
 #define TSIOC_SETFREQUENCY   _TSIOC(0x0003) /* arg: Pointer to


### PR DESCRIPTION
## Summary
As per comment in [this](https://github.com/apache/nuttx/pull/9377) PR, renames 2x ioctl for clarity

The 2 changed are TSIOC_SETCALIB and TSIOC_GETCALIB


## Impact
None, unless any out-of-tree boards or drivers use the 2 ioctls

## Testing
None

