### PR TITLE
tools: Add way to get current defconfig name on runtime

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -244,6 +244,15 @@ config APPS_DIR
 		example, to include makefile fragments (e.g., .config or Make.defs)
 		or to set up include file paths.
 
+config BASE_DEFCONFIG
+		string "Base Configuration"
+		default ""
+		---help---
+			This will be automatically be updated by the configuration
+			script. This is the base configuration file that was used to create the
+			current configuration. It is useful for getting the current configuration
+			on runtime.
+
 config BUILD_LOADABLE
 	bool
 	option modules

--- a/tools/configure.sh
+++ b/tools/configure.sh
@@ -176,6 +176,7 @@ fi
 
 src_config=${configpath}/defconfig
 dest_config="${TOPDIR}/.config"
+original_config="${TOPDIR}/.config.orig"
 backup_config="${TOPDIR}/defconfig"
 
 if [ ! -r ${src_config} ]; then
@@ -303,7 +304,17 @@ if [ "X${defappdir}" = "Xy" ]; then
   fi
 fi
 
+# Update the CONFIG_BASE_DEFCONFIG setting
+
+posboardconfig=`echo "${boardconfig}" | sed -e 's/\\\\/\\//g'`
+echo "CONFIG_BASE_DEFCONFIG=\"$posboardconfig\"" >> "${dest_config}"
+
 # The saved defconfig files are all in compressed format and must be
 # reconstitued before they can be used.
 
 ${TOPDIR}/tools/sethost.sh $host $*
+
+# Save the original configuration file without CONFIG_BASE_DEFCONFIG
+# for later comparison
+
+grep -v "CONFIG_BASE_DEFCONFIG" "${dest_config}" > "${original_config}"


### PR DESCRIPTION
## Summary

This commit aims to provide a way to get the current applied defconfig on runtime by providing CONFIG_BASE_DEFCONFIG that is updated when the configure and build scripts are run.

## Impact

Slight modifications to the configure and build scripts. Shouldn't break anything on any platform.

## Testing

Tested on ESP32-DevKitC using a modified version of Nxdiag.