### PR TITLE
arch/{nrf52|nrf53}/usbd: fix IN endpoint completion logic

### DIFF
--- a/arch/arm/src/nrf52/nrf52_usbd.c
+++ b/arch/arm/src/nrf52/nrf52_usbd.c
@@ -1143,7 +1143,9 @@ static void nrf52_epin_request(struct nrf52_usbdev_s *priv,
       privreq->req.xfrd += nbytes;
     }
 
-  else if (privreq->req.xfrd >= privreq->req.len)
+  /* Has all the request data been sent? */
+
+  if (privreq->req.xfrd >= privreq->req.len)
     {
       usbtrace(TRACE_COMPLETE(privep->epphy), privreq->req.xfrd);
 

--- a/arch/arm/src/nrf53/nrf53_usbd.c
+++ b/arch/arm/src/nrf53/nrf53_usbd.c
@@ -1143,7 +1143,9 @@ static void nrf53_epin_request(struct nrf53_usbdev_s *priv,
       privreq->req.xfrd += nbytes;
     }
 
-  else if (privreq->req.xfrd >= privreq->req.len)
+  /* Has all the request data been sent? */
+
+  if (privreq->req.xfrd >= privreq->req.len)
     {
       usbtrace(TRACE_COMPLETE(privep->epphy), privreq->req.xfrd);
 


### PR DESCRIPTION

## Summary

- arch/{nrf52|nrf53}/usbd: fix IN endpoint completion logic

    Confirmation of the IN request must be done immediately after all data has been transferred,
    otherwise sending data when more than one request has been added to the queue will
    not work properly.


## Impact
Console over USB works correctly now.

## Testing
usbnsh on nrf52840
