### PR TITLE
openamp: virtio.h add version field in device id table struct

### DIFF
--- a/openamp/0019-virtio.h-add-version-in-device-id-table.patch
+++ b/openamp/0019-virtio.h-add-version-in-device-id-table.patch
@@ -1,0 +1,28 @@
+From 8d69eb3524fd57753ab849ed790777f073242276 Mon Sep 17 00:00:00 2001
+From: wangbowen6 <wangbowen6@xiaomi.com>
+Date: Thu, 25 May 2023 21:01:17 +0800
+Subject: [PATCH] virtio.h: add version in device id table
+
+support the leagcy mmio transport (version 1)
+
+Change-Id: I194c587754668d28cb7be4dc1b58fa5ce1393414
+Signed-off-by: wangbowen6 <wangbowen6@xiaomi.com>
+---
+ lib/include/openamp/virtio.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/lib/include/openamp/virtio.h open-amp/lib/include/openamp/virtio.h
+index fb68c19..6ef1746 100644
+--- a/lib/include/openamp/virtio.h
++++ open-amp/lib/include/openamp/virtio.h
+@@ -82,6 +82,7 @@ __deprecated static inline int deprecated_virtio_dev_slave(void)
+ struct virtio_device_id {
+ 	uint32_t device;
+ 	uint32_t vendor;
++	uint32_t version;
+ };
+ 
+ /*
+-- 
+2.25.1
+

--- a/openamp/open-amp.defs
+++ b/openamp/open-amp.defs
@@ -53,6 +53,7 @@ open-amp.zip:
 	$(Q) patch -p0 < 0016-openamp-add-new-API-rpmsg_virtio_get_rxbuffer_size.patch
 	$(Q) patch -p0 < 0017-virtio-follow-virtio-1.2-spec-add-more-virtio-status.patch
 	$(Q) patch -p0 < 0018-virtio-decoupling-the-transport-layer-and-virtio-dev.patch
+	$(Q) patch -p0 < 0019-virtio.h-add-version-in-device-id-table.patch
 
 
 


### PR DESCRIPTION
## Summary
Add new patch 0019, this patch is used to support the legacy virtio mmio trasport.

This PR is need by https://github.com/apache/nuttx/pull/9297

## Impact
New feature

## Testing
1. Test this PR alone using sim:rpserver and sim:rpproxy;
2. Test with https://github.com/apache/nuttx/pull/9297 using qemu 2.12.0 and qemu 7.2.0;

