### PR TITLE
fix compile warnings caused by incorrect variable format in print

### DIFF
--- a/drivers/mtd/w25qxxxjv.c
+++ b/drivers/mtd/w25qxxxjv.c
@@ -1531,7 +1531,7 @@ static int w25qxxxjv_ioctl(FAR struct mtd_dev_s *dev, int cmd,
 #endif
               ret               = OK;
 
-              finfo("blocksize: %" PRIu16 " erasesize: %" PRIu32
+              finfo("blocksize: %" PRIu32 " erasesize: %" PRIu32
                     " neraseblocks: %" PRIu32 "\n",
                     geo->blocksize, geo->erasesize, geo->neraseblocks);
             }

--- a/fs/partition/fs_mbr.c
+++ b/fs/partition/fs_mbr.c
@@ -25,6 +25,7 @@
 #include <debug.h>
 #include <endian.h>
 #include <string.h>
+#include <inttypes.h>
 
 #include <nuttx/kmalloc.h>
 
@@ -169,7 +170,7 @@ int parse_mbr_partition(FAR struct partition_state_s *state,
 
           if (buffer[0x1fe] != 0x55 || buffer[0x1ff] != 0xaa)
             {
-              ferr("block %x doesn't contain an EBR signature\n",
+              ferr("block %" PRIu32 " doesn't contain an EBR signature\n",
                    ebr_block);
               ret = -EINVAL;
               goto out;


### PR DESCRIPTION
## Summary

Just fix of two compile warnings in finfo and ferr print functions.

## Testing

Build pass.

