### PR TITLE
DIR/Complementary PWM possible on PE08 and PE10

### DIFF
--- a/boards/arm/stm32f7/nucleo-144/src/nucleo-144.h
+++ b/boards/arm/stm32f7/nucleo-144/src/nucleo-144.h
@@ -151,8 +151,10 @@
 /* GPIO pins used by the GPIO Subsystem */
 
 #define BOARD_NGPIOIN     4   /* Amount of GPIO Input pins */
-#ifdef CONFIG_STM32F7_TIM1_CH1NOUT
+#if defined(CONFIG_STM32F7_TIM1_CH1NOUT) && defined (CONFIG_STM32F7_TIM1_CH2NOUT)
 #define BOARD_NGPIOOUT    8   /* Amount of GPIO Output pins */
+#elif defined(CONFIG_STM32F7_TIM1_CH1NOUT) || defined (CONFIG_STM32F7_TIM1_CH2NOUT)
+#define BOARD_NGPIOOUT    9   /* Amount of GPIO Output pins */
 #else
 #define BOARD_NGPIOOUT    10   /* Amount of GPIO Output pins */
 #endif
@@ -175,9 +177,11 @@
                                 GPIO_OUTPUT_SET | GPIO_PORTA |GPIO_PIN5)
 #define GPIO_OUT5         (GPIO_OUTPUT | GPIO_SPEED_50MHz | \
                                 GPIO_OUTPUT_SET | GPIO_PORTF | GPIO_PIN12)
-#ifndef CONFIG_STM32F7_TIM1_CH1NOUT
+#if !defined(CONFIG_STM32F7_TIM1_CH1NOUT)
 #define GPIO_OUT6         (GPIO_OUTPUT | GPIO_SPEED_50MHz | \
                                 GPIO_OUTPUT_SET | GPIO_PORTE | GPIO_PIN8)
+#endif
+#if !defined(CONFIG_STM32F7_TIM1_CH2NOUT)
 #define GPIO_OUT7         (GPIO_OUTPUT | GPIO_SPEED_50MHz | \
                                 GPIO_OUTPUT_SET | GPIO_PORTE | GPIO_PIN10)
 #endif

--- a/boards/arm/stm32f7/nucleo-144/src/stm32_gpio.c
+++ b/boards/arm/stm32f7/nucleo-144/src/stm32_gpio.c
@@ -123,8 +123,10 @@ static const uint32_t g_gpiooutputs[BOARD_NGPIOOUT] =
   GPIO_OUT3,
   GPIO_OUT4,
   GPIO_OUT5,
-#ifndef CONFIG_STM32F7_TIM1_CH1NOUT
+#if !defined(CONFIG_STM32F7_TIM1_CH1NOUT)
   GPIO_OUT6,
+#endif
+#if !defined(CONFIG_STM32F7_TIM1_CH2NOUT)  
   GPIO_OUT7,
 #endif
 };


### PR DESCRIPTION
## Summary
The 2 pins on PE08 and PE10 can be used as complementary PWM or as direction pin

## Impact
board/arm/stm32f7/nucleo-144/src/nucle0-144.h
board/arm/stm32f7/nucleo-144/src/stm32f7_gpio.c

## Testing
Tested on the nucleo-F746ZG board