### PR TITLE
mm: Correct the callsite of mm_mallinfo 

### DIFF
--- a/arch/arm/src/rtl8720c/amebaz_depend.h
+++ b/arch/arm/src/rtl8720c/amebaz_depend.h
@@ -30,7 +30,6 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
-#include <malloc.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/arch/risc-v/src/esp32c3/esp32c3_bignum.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_bignum.c
@@ -28,7 +28,6 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <malloc.h>
 #include <limits.h>
 #include <assert.h>
 #include <stdlib.h>

--- a/arch/risc-v/src/esp32c3/esp32c3_rtcheap.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_rtcheap.c
@@ -26,7 +26,6 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/mm/mm.h>
-#include <malloc.h>
 
 #include "esp32c3_rtcheap.h"
 

--- a/arch/risc-v/src/esp32c3/esp32c3_rtcheap.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_rtcheap.c
@@ -177,7 +177,7 @@ bool esp32c3_rtcheap_heapmember(void *mem)
  *
  ****************************************************************************/
 
-int esp32c3_rtcheap_mallinfo(struct mallinfo *info)
+struct mallinfo esp32c3_rtcheap_mallinfo(void)
 {
-  return mm_mallinfo(g_rtcheap, info);
+  return mm_mallinfo(g_rtcheap);
 }

--- a/arch/risc-v/src/esp32c3/esp32c3_rtcheap.h
+++ b/arch/risc-v/src/esp32c3/esp32c3_rtcheap.h
@@ -136,7 +136,7 @@ bool esp32c3_rtcheap_heapmember(void *mem);
  *
  ****************************************************************************/
 
-int esp32c3_rtcheap_mallinfo(struct mallinfo *info);
+struct mallinfo esp32c3_rtcheap_mallinfo(void);
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/arch/sim/src/sim/sim_heap.c
+++ b/arch/sim/src/sim/sim_heap.c
@@ -26,7 +26,6 @@
 
 #include <assert.h>
 #include <string.h>
-#include <malloc.h>
 #include <stdbool.h>
 
 #include <nuttx/arch.h>

--- a/arch/sim/src/sim/win/sim_wpcap.c
+++ b/arch/sim/src/sim/win/sim_wpcap.c
@@ -68,7 +68,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <syslog.h>
-#include <malloc.h>
 
 #include "sim_internal.h"
 

--- a/arch/xtensa/src/esp32/esp32_imm.c
+++ b/arch/xtensa/src/esp32/esp32_imm.c
@@ -26,7 +26,6 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/mm/mm.h>
-#include <malloc.h>
 #include <arch/esp32/memory_layout.h>
 
 #include "xtensa.h"

--- a/arch/xtensa/src/esp32/esp32_imm.c
+++ b/arch/xtensa/src/esp32/esp32_imm.c
@@ -176,7 +176,7 @@ bool xtensa_imm_heapmember(void *mem)
  *
  ****************************************************************************/
 
-struct mallinfo xtensa_imm_mallinfo()
+struct mallinfo xtensa_imm_mallinfo(void)
 {
   return mm_mallinfo(g_iheap);
 }

--- a/arch/xtensa/src/esp32/esp32_iramheap.c
+++ b/arch/xtensa/src/esp32/esp32_iramheap.c
@@ -26,7 +26,6 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/mm/mm.h>
-#include <malloc.h>
 
 #include "esp32_iramheap.h"
 

--- a/arch/xtensa/src/esp32/esp32_rtcheap.c
+++ b/arch/xtensa/src/esp32/esp32_rtcheap.c
@@ -26,7 +26,6 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/mm/mm.h>
-#include <malloc.h>
 
 #include "esp32_rtcheap.h"
 

--- a/arch/xtensa/src/esp32s3/esp32s3_rtcheap.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_rtcheap.c
@@ -26,7 +26,6 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/mm/mm.h>
-#include <malloc.h>
 
 #include "esp32s3_rtcheap.h"
 

--- a/arch/xtensa/src/esp32s3/esp32s3_rtcheap.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_rtcheap.c
@@ -188,7 +188,7 @@ bool esp32s3_rtcheap_heapmember(void *mem)
  *
  ****************************************************************************/
 
-int esp32s3_rtcheap_mallinfo(struct mallinfo *info)
+struct mallinfo esp32s3_rtcheap_mallinfo(void)
 {
-  return mm_mallinfo(g_rtcheap, info);
+  return mm_mallinfo(g_rtcheap);
 }

--- a/arch/xtensa/src/esp32s3/esp32s3_rtcheap.h
+++ b/arch/xtensa/src/esp32s3/esp32s3_rtcheap.h
@@ -139,7 +139,7 @@ bool esp32s3_rtcheap_heapmember(void *mem);
  *
  ****************************************************************************/
 
-int esp32s3_rtcheap_mallinfo(struct mallinfo *info);
+struct mallinfo esp32s3_rtcheap_mallinfo(void);
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/include/nuttx/kmalloc.h
+++ b/include/nuttx/kmalloc.h
@@ -28,7 +28,6 @@
 #include <nuttx/config.h>
 
 #include <sys/types.h>
-#include <malloc.h>
 #include <stdbool.h>
 #include <stdlib.h>
 

--- a/include/nuttx/mm/mempool.h
+++ b/include/nuttx/mm/mempool.h
@@ -138,8 +138,6 @@ struct mempoolinfo_s
   unsigned long nwaiter;  /* This is the number of waiter for mempool */
 };
 
-#define mempoolinfo_task mallinfo_task
-
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
@@ -268,7 +266,7 @@ int mempool_deinit(FAR struct mempool_s *pool);
  *   Statistics of memory information based on dump.
  ****************************************************************************/
 
-struct mempoolinfo_task
+struct mallinfo_task
 mempool_info_task(FAR struct mempool_s *pool,
                   FAR const struct mm_memdump_s *dump);
 
@@ -518,7 +516,7 @@ mempool_multiple_mallinfo(FAR struct mempool_multiple_s *mpool);
  *    Statistics of memory information based on dump.
  ****************************************************************************/
 
-struct mempoolinfo_task
+struct mallinfo_task
 mempool_multiple_info_task(FAR struct mempool_multiple_s *mpool,
                            FAR const struct mm_memdump_s *dump);
 

--- a/include/nuttx/mm/mm.h
+++ b/include/nuttx/mm/mm.h
@@ -29,6 +29,7 @@
 
 #include <sys/types.h>
 #include <stdbool.h>
+#include <malloc.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -108,7 +109,6 @@
  ****************************************************************************/
 
 struct mm_heap_s; /* Forward reference */
-struct mm_memdump_s;
 
 /****************************************************************************
  * Public Data
@@ -314,9 +314,7 @@ void kmm_extend(FAR void *mem, size_t size, int region);
 
 /* Functions contained in mm_mallinfo.c *************************************/
 
-struct mallinfo; /* Forward reference */
 struct mallinfo mm_mallinfo(FAR struct mm_heap_s *heap);
-struct mallinfo_task; /* Forward reference */
 struct mallinfo_task mm_mallinfo_task(FAR struct mm_heap_s *heap,
                                       FAR const struct mm_memdump_s *dump);
 

--- a/mm/kmm_heap/kmm_mallinfo.c
+++ b/mm/kmm_heap/kmm_mallinfo.c
@@ -24,8 +24,6 @@
 
 #include <nuttx/config.h>
 
-#include <malloc.h>
-
 #include <nuttx/mm/mm.h>
 
 #ifdef CONFIG_MM_KERNEL_HEAP

--- a/mm/mempool/mempool.c
+++ b/mm/mempool/mempool.c
@@ -390,12 +390,12 @@ int mempool_info(FAR struct mempool_s *pool, FAR struct mempoolinfo_s *info)
  * Name: mempool_info_task
  ****************************************************************************/
 
-struct mempoolinfo_task
+struct mallinfo_task
 mempool_info_task(FAR struct mempool_s *pool,
                   FAR const struct mm_memdump_s *dump)
 {
   irqstate_t flags = spin_lock_irqsave(&pool->lock);
-  struct mempoolinfo_task info =
+  struct mallinfo_task info =
     {
       0, 0
     };

--- a/mm/mempool/mempool_multiple.c
+++ b/mm/mempool/mempool_multiple.c
@@ -766,13 +766,13 @@ mempool_multiple_mallinfo(FAR struct mempool_multiple_s *mpool)
  * Name: mempool_multiple_info_task
  ****************************************************************************/
 
-struct mempoolinfo_task
+struct mallinfo_task
 mempool_multiple_info_task(FAR struct mempool_multiple_s *mpool,
                            FAR const struct mm_memdump_s *dump)
 {
   int i;
-  struct mempoolinfo_task info;
-  struct mempoolinfo_task ret =
+  struct mallinfo_task info;
+  struct mallinfo_task ret =
     {
       0, 0
     };

--- a/mm/mm_heap/mm_mallinfo.c
+++ b/mm/mm_heap/mm_mallinfo.c
@@ -24,7 +24,6 @@
 
 #include <nuttx/config.h>
 
-#include <malloc.h>
 #include <assert.h>
 #include <debug.h>
 

--- a/mm/mm_heap/mm_malloc.c
+++ b/mm/mm_heap/mm_malloc.c
@@ -27,7 +27,6 @@
 #include <assert.h>
 #include <debug.h>
 #include <string.h>
-#include <malloc.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/mm/mm.h>

--- a/mm/mm_heap/mm_memdump.c
+++ b/mm/mm_heap/mm_memdump.c
@@ -25,7 +25,6 @@
 #include <nuttx/config.h>
 
 #include <stdio.h>
-#include <malloc.h>
 #include <assert.h>
 #include <debug.h>
 

--- a/mm/tlsf/mm_tlsf.c
+++ b/mm/tlsf/mm_tlsf.c
@@ -29,7 +29,6 @@
 #include <assert.h>
 #include <debug.h>
 #include <execinfo.h>
-#include <malloc.h>
 #include <sched.h>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
## Summary

forget to update in https://github.com/apache/nuttx/pull/9488, and:

- mm: include malloc.h in mm/mm.h 
- mm: Remove mempoolinfo_task macro and use mallinfo_task directly 

## Impact

No real functionality change

## Testing

sim:kasan