### PR TITLE
boards/samv7/common: add type member to mtd_partition_s structure

### DIFF
--- a/boards/arm/samv7/common/include/board_progmem.h
+++ b/boards/arm/samv7/common/include/board_progmem.h
@@ -39,6 +39,10 @@ struct mtd_partition_s
 {
   size_t            offset;    /* Partition offset from the beginning of MTD */
   size_t            size;      /* Partition size in bytes */
+  uint8_t           type;      /* Optional if more devices types (block
+                                * character, smartfs) have to be distinguish
+                                * in board related code.
+                                */
   const char       *devpath;   /* Partition device path */
   struct mtd_dev_s *mtd;       /* Pointer to allocated MTD partition */
 };


### PR DESCRIPTION
## Summary
Board related code may use different mounts for MTD device (block character for one, SmartFS for another) if required by the board. Additional type member was therefore added to mtd_partition_s structure in order to support this.

## Impact
SAMv7 boards only.

## Testing
Tested on custom samv7 board.

