### PR TITLE
Support when malloc failed dump mempool info

### DIFF
--- a/include/nuttx/mm/mempool.h
+++ b/include/nuttx/mm/mempool.h
@@ -61,6 +61,9 @@ typedef CODE FAR void *(*mempool_multiple_alloc_t)(FAR void *arg,
                                                    size_t size);
 typedef CODE void (*mempool_multiple_free_t)(FAR void *arg, FAR void *addr);
 
+typedef CODE void (mempool_multiple_foreach_t)(FAR struct mempool_s *pool,
+                                               FAR void *arg);
+
 #if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_MEMPOOL)
 struct mempool_procfs_entry_s
 {
@@ -481,12 +484,14 @@ void mempool_multiple_memdump(FAR struct mempool_multiple_s *mpool,
 void mempool_multiple_deinit(FAR struct mempool_multiple_s *mpool);
 
 /****************************************************************************
-  * Name: mempool_multiple_info
+ * Name: mempool_multiple_foreach
  * Description:
- *   Dump multiple memory pool's info.
+ *   Traverse mempool under multiple pool to execute handle.
  ****************************************************************************/
 
-void mempool_multiple_info(FAR struct mempool_multiple_s *mpool);
+void mempool_multiple_foreach(FAR struct mempool_multiple_s *mpool,
+                              mempool_multiple_foreach_t handle,
+                              FAR void *arg);
 
 /****************************************************************************
  * Name: mempool_multiple_info_task

--- a/mm/mempool/mempool_multiple.c
+++ b/mm/mempool/mempool_multiple.c
@@ -594,23 +594,17 @@ FAR void *mempool_multiple_memalign(FAR struct mempool_multiple_s *mpool,
 }
 
 /****************************************************************************
- * Name: mempool_multiple_info
+ * Name: mempool_multiple_foreach
  ****************************************************************************/
 
-void mempool_multiple_info(FAR struct mempool_multiple_s *mpool)
+void mempool_multiple_foreach(FAR struct mempool_multiple_s *mpool,
+                              mempool_multiple_foreach_t handle,
+                              FAR void *arg)
 {
-  struct mempoolinfo_s minfo;
   size_t i;
-
-  syslog(LOG_INFO, "%11s%9s%9s%9s%9s%9s%9s\n", "bsize", "total", "nused",
-                  "nfree", "nifree", "nwaiter", "nexpend");
   for (i = 0; i < mpool->npools; i++)
     {
-      mempool_info(mpool->pools + i, &minfo);
-      syslog(LOG_INFO, "%9lu%11lu%9lu%9lu%9lu%9lu%9zu\n",
-                       minfo.sizeblks, minfo.arena, minfo.aordblks,
-                       minfo.ordblks, minfo.iordblks,
-                       minfo.nwaiter, mpool->pools->nexpend);
+      handle(mpool->pools + i, arg);
     }
 }
 

--- a/mm/mm_heap/mm_malloc.c
+++ b/mm/mm_heap/mm_malloc.c
@@ -90,6 +90,19 @@ void mm_dump_handler(FAR struct tcb_s *tcb, FAR void *arg)
 }
 #endif
 
+#if CONFIG_MM_HEAP_MEMPOOL_THRESHOLD != 0
+void mm_mempool_dump_handle(FAR struct mempool_s *pool, FAR void *arg)
+{
+  struct mempoolinfo_s info;
+
+  mempool_info(pool, &info);
+  mwarn("%9lu%11lu%9lu%9lu%9lu%9lu%9zu\n",
+        info.sizeblks, info.arena, info.aordblks,
+        info.ordblks, info.iordblks,
+        info.nwaiter, pool->nexpend);
+}
+#endif
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -272,7 +285,10 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
       nxsched_foreach(mm_dump_handler, heap);
 #  endif
 #  if CONFIG_MM_HEAP_MEMPOOL_THRESHOLD != 0
-      mempool_multiple_info(heap->mm_mpool);
+      mwarn("%11s%9s%9s%9s%9s%9s%9s\n", "bsize", "total", "nused",
+            "nfree", "nifree", "nwaiter", "nexpend");
+      mempool_multiple_foreach(heap->mm_mpool,
+                               mm_mempool_dump_handle, NULL);
 #  endif
 
 #endif


### PR DESCRIPTION
## Summary
Replaced the previous implementation method to
maintain unity with the heap dump
## Impact
noting
## Testing
sim:nsh with testing_mm
