### PR TITLE
mm: add invalid pid dump when malloc failed

### DIFF
--- a/include/nuttx/mm/mm.h
+++ b/include/nuttx/mm/mm.h
@@ -98,6 +98,7 @@
 #  endif
 #endif
 
+#define MM_BACKTRACE_INVALID_PID ((pid_t)-4)
 #define MM_BACKTRACE_MEMPOOL_PID ((pid_t)-3)
 #define MM_BACKTRACE_FREE_PID    ((pid_t)-2)
 #define MM_BACKTRACE_ALLOC_PID   ((pid_t)-1)

--- a/mm/mm_heap/mm_mallinfo.c
+++ b/mm/mm_heap/mm_mallinfo.c
@@ -98,16 +98,24 @@ static void mallinfo_task_handler(FAR struct mm_allocnode_s *node,
       DEBUGASSERT(nodesize >= SIZEOF_MM_ALLOCNODE);
 #if CONFIG_MM_BACKTRACE < 0
       if (handle->dump->pid == MM_BACKTRACE_ALLOC_PID)
-#else
-      if ((handle->dump->pid == MM_BACKTRACE_ALLOC_PID ||
-           handle->dump->pid == node->pid) &&
-          node->seqno >= handle->dump->seqmin &&
-          node->seqno <= handle->dump->seqmax)
-#endif
         {
           handle->info->aordblks++;
           handle->info->uordblks += nodesize;
         }
+#else
+      if (handle->dump->pid == MM_BACKTRACE_ALLOC_PID ||
+          handle->dump->pid == node->pid ||
+          (handle->dump->pid == MM_BACKTRACE_INVALID_PID &&
+           nxsched_get_tcb(node->pid) == NULL))
+        {
+          if (node->seqno >= handle->dump->seqmin &&
+              node->seqno <= handle->dump->seqmax)
+            {
+              handle->info->aordblks++;
+              handle->info->uordblks += nodesize;
+            }
+        }
+#endif
     }
   else if (handle->dump->pid == MM_BACKTRACE_FREE_PID)
     {

--- a/mm/mm_heap/mm_malloc.c
+++ b/mm/mm_heap/mm_malloc.c
@@ -81,12 +81,12 @@ void mm_dump_handler(FAR struct tcb_s *tcb, FAR void *arg)
   struct mallinfo_task info;
   struct mm_memdump_s dump;
 
-  dump.pid = tcb->pid;
+  dump.pid = tcb ? tcb->pid : MM_BACKTRACE_INVALID_PID;
   dump.seqmin = 0;
   dump.seqmax = ULONG_MAX;
   info = mm_mallinfo_task(arg, &dump);
   mwarn("pid:%5d, used:%10d, nused:%10d\n",
-        tcb->pid, info.uordblks, info.aordblks);
+        dump.pid, info.uordblks, info.aordblks);
 }
 #endif
 
@@ -270,6 +270,7 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
             minfo.mxordblk, minfo.aordblks, minfo.ordblks);
 #  if CONFIG_MM_BACKTRACE >= 0
       nxsched_foreach(mm_dump_handler, heap);
+      mm_dump_handler(NULL, heap);
 #  endif
 #  if CONFIG_MM_HEAP_MEMPOOL_THRESHOLD != 0
       mempool_multiple_info(heap->mm_mpool);

--- a/mm/tlsf/mm_tlsf.c
+++ b/mm/tlsf/mm_tlsf.c
@@ -294,16 +294,24 @@ static void mallinfo_task_handler(FAR void *ptr, size_t size, int used,
     {
 #if CONFIG_MM_BACKTRACE < 0
       if (handler->dump->pid = MM_BACKTRACE_ALLOC_PID)
-#else
-      if ((handler->dump->pid == MM_BACKTRACE_ALLOC_PID ||
-           handler->dump->pid == dump->pid) &&
-          dump->seqno >= handler->dump->seqmin &&
-          dump->seqno <= handler->dump->seqmax)
-#endif
         {
           handler->info->aordblks++;
           handler->info->uordblks += size;
         }
+#else
+      if (handler->dump->pid == MM_BACKTRACE_ALLOC_PID ||
+          handler->dump->pid == dump->pid ||
+          (handler->dump->pid == MM_BACKTRACE_INVALID_PID &&
+           nxsched_get_tcb(dump->pid) == NULL))
+        {
+          if (dump->seqno >= handler->dump->seqmin &&
+              dump->seqno <= handler->dump->seqmax)
+            {
+              handler->info->aordblks++;
+              handler->info->uordblks += size;
+            }
+        }
+#endif
     }
   else if (handler->dump->pid == MM_BACKTRACE_FREE_PID)
     {


### PR DESCRIPTION
## Summary
We can dump the memory that has exited but
has not been released.
## Impact
when malloc failed
## Testing
sim:nsh with testing_mm

