### PR TITLE
mpfs: add support for CoreI2C fpga driver

### DIFF
--- a/arch/risc-v/src/mpfs/Kconfig
+++ b/arch/risc-v/src/mpfs/Kconfig
@@ -286,11 +286,27 @@ config MPFS_I2C1
 	default n
 
 config MPFS_COREI2C0
-        bool "Core I2C 0"
-        select ARCH_HAVE_I2CRESET
-        default n
+	bool "Core I2C 0"
+	depends on !MPFS_I2C0
+	select ARCH_HAVE_I2CRESET
+	default n
 	---help---
 		Selects the FPGA i2c0 driver.
+
+config MPFS_COREI2C1
+	bool "Core I2C 1"
+	depends on !MPFS_I2C1
+	select ARCH_HAVE_I2CRESET
+	default n
+	---help---
+		Selects the FPGA i2c1 driver.
+
+config MPFS_COREI2C2
+	bool "Core I2C 2"
+	select ARCH_HAVE_I2CRESET
+	default n
+	---help---
+		Selects the FPGA i2c2 driver.
 
 config MPFS_EMMCSD
 	bool "EMMCSD"

--- a/arch/risc-v/src/mpfs/Kconfig
+++ b/arch/risc-v/src/mpfs/Kconfig
@@ -285,6 +285,13 @@ config MPFS_I2C1
 	select ARCH_HAVE_I2CRESET
 	default n
 
+config MPFS_COREI2C0
+        bool "Core I2C 0"
+        select ARCH_HAVE_I2CRESET
+        default n
+	---help---
+		Selects the FPGA i2c0 driver.
+
 config MPFS_EMMCSD
 	bool "EMMCSD"
 	select ARCH_HAVE_SDIO

--- a/arch/risc-v/src/mpfs/hardware/mpfs_i2c.h
+++ b/arch/risc-v/src/mpfs/hardware/mpfs_i2c.h
@@ -43,6 +43,7 @@
 #define MPFS_I2C_CTRL_CR1_MASK        (1 << 1)
 #define MPFS_I2C_CTRL_CR0_MASK        (1 << 0)
 
+#define MPFS_I2C_ST_IDLE              0xF8  /* No activity, I2C bus idle */
 #define MPFS_I2C_ST_RESET_ACTIVATED   0xD0  /* Master reset is activated */
 #define MPFS_I2C_ST_RX_DATA_NACK      0x58  /* Data received, NACK sent */
 #define MPFS_I2C_ST_RX_DATA_ACK       0x50  /* Data received, ACK sent */

--- a/arch/risc-v/src/mpfs/hardware/mpfs_i2c.h
+++ b/arch/risc-v/src/mpfs/hardware/mpfs_i2c.h
@@ -44,6 +44,7 @@
 #define MPFS_I2C_CTRL_CR0_MASK        (1 << 0)
 
 #define MPFS_I2C_ST_IDLE              0xF8  /* No activity, I2C bus idle */
+#define MPFS_I2C_ST_STOP_SENT         0xE0  /* Stop condition has been sent */
 #define MPFS_I2C_ST_RESET_ACTIVATED   0xD0  /* Master reset is activated */
 #define MPFS_I2C_ST_RX_DATA_NACK      0x58  /* Data received, NACK sent */
 #define MPFS_I2C_ST_RX_DATA_ACK       0x50  /* Data received, ACK sent */

--- a/arch/risc-v/src/mpfs/mpfs_i2c.c
+++ b/arch/risc-v/src/mpfs/mpfs_i2c.c
@@ -206,40 +206,6 @@ static int mpfs_i2c_setfrequency(struct mpfs_i2c_priv_s *priv,
  ****************************************************************************/
 
 /****************************************************************************
- * Name: mpfs_disable_interrupts
- *
- * Description:
- *   Disable all interrupts.
- *
- * Returned Value:
- *   primask (current interrupt status)
- *
- ****************************************************************************/
-
-static irqstate_t mpfs_disable_interrupts(void)
-{
-  irqstate_t primask;
-  primask = up_irq_save();
-  return primask;
-}
-
-/****************************************************************************
- * Name: mpfs_restore_interrupts
- *
- * Description:
- *   Restore interrupts.
- *
- * Parameters:
- *   primask       - Earlier stored irqstate
- *
- ****************************************************************************/
-
-static void mpfs_restore_interrupts(irqstate_t primask)
-{
-  up_irq_restore(primask);
-}
-
-/****************************************************************************
  * Name: mpfs_i2c_init
  *
  * Description:
@@ -256,12 +222,8 @@ static void mpfs_restore_interrupts(irqstate_t primask)
 
 static int mpfs_i2c_init(struct mpfs_i2c_priv_s *priv)
 {
-  uint32_t primask;
-
   if (!priv->initialized)
     {
-      primask = mpfs_disable_interrupts();
-
       if (priv->id == 0)
         {
           modifyreg32(MPFS_SYSREG_SOFT_RESET_CR,
@@ -299,8 +261,6 @@ static int mpfs_i2c_init(struct mpfs_i2c_priv_s *priv)
                   MPFS_I2C_CTRL_ENS1_MASK);
 
       priv->initialized = true;
-
-      mpfs_restore_interrupts(primask);
     }
 
   return OK;
@@ -501,6 +461,12 @@ static int mpfs_i2c_irq(int cpuint, void *context, void *arg)
         priv->status = MPFS_I2C_SUCCESS;
         break;
 
+      case MPFS_I2C_ST_IDLE:
+
+        /* No activity, bus idle */
+
+        break;
+
       case MPFS_I2C_ST_RESET_ACTIVATED:
       case MPFS_I2C_ST_BUS_ERROR: /* Bus errors */
       default:
@@ -549,15 +515,8 @@ static int mpfs_i2c_irq(int cpuint, void *context, void *arg)
 
 static void mpfs_i2c_sendstart(struct mpfs_i2c_priv_s *priv)
 {
-  uint32_t primask;
-
-  primask = mpfs_disable_interrupts();
-
-  modifyreg32(MPFS_I2C_CTRL, MPFS_I2C_CTRL_STA_MASK, MPFS_I2C_CTRL_STA_MASK);
-
   up_enable_irq(priv->plic_irq);
-
-  mpfs_restore_interrupts(primask);
+  modifyreg32(MPFS_I2C_CTRL, MPFS_I2C_CTRL_STA_MASK, MPFS_I2C_CTRL_STA_MASK);
 }
 
 static int mpfs_i2c_transfer(struct i2c_master_s *dev,
@@ -677,8 +636,15 @@ static int mpfs_i2c_reset(struct i2c_master_s *dev)
 {
   struct mpfs_i2c_priv_s *priv = (struct mpfs_i2c_priv_s *)dev;
   int ret;
+  irqstate_t flags;
 
   DEBUGASSERT(priv != NULL);
+
+  flags = enter_critical_section();
+
+  /* Disabling I2C interrupts.
+   * NOTE: up_enable_irq() will be called at mpfs_i2c_sendstart()
+   */
 
   up_disable_irq(priv->plic_irq);
 
@@ -687,7 +653,7 @@ static int mpfs_i2c_reset(struct i2c_master_s *dev)
   ret = mpfs_i2c_init(priv);
   if (ret != OK)
     {
-      up_enable_irq(priv->plic_irq);
+      leave_critical_section(flags);
       return ret;
     }
 
@@ -696,7 +662,7 @@ static int mpfs_i2c_reset(struct i2c_master_s *dev)
   priv->rx_size = 0;
   priv->rx_idx  = 0;
 
-  /* up_enable_irq() will be called at mpfs_i2c_sendstart() */
+  leave_critical_section(flags);
 
   return OK;
 }

--- a/boards/risc-v/mpfs/icicle/include/board.h
+++ b/boards/risc-v/mpfs/icicle/include/board.h
@@ -53,6 +53,7 @@
 #define MPFS_MSS_RTC_TOGGLE_CLK      (1000000UL)
 #define MPFS_MSS_AXI_CLK           (300000000UL)
 #define MPFS_MSS_APB_AHB_CLK       (150000000UL)
+#define MPFS_FPGA_PERIPHERAL_CLK    (62500000UL)
 #define MPFS_FPGA_BCLK               (3000000UL)
 
 /* LED definitions **********************************************************/

--- a/boards/risc-v/mpfs/m100pfsevp/include/board.h
+++ b/boards/risc-v/mpfs/m100pfsevp/include/board.h
@@ -58,6 +58,7 @@
 #define MPFS_MSS_RTC_TOGGLE_CLK      (1000000UL)
 #define MPFS_MSS_AXI_CLK           (300000000UL)
 #define MPFS_MSS_APB_AHB_CLK       (150000000UL)
+#define MPFS_FPGA_PERIPHERAL_CLK    (62500000UL)
 #define MPFS_FPGA_BCLK               (3000000UL)
 
 /* LED definitions **********************************************************/


### PR DESCRIPTION
## Summary

This adds support for Microchip's CoreI2C v7.2.  Its register map is the same with MSS I2C, but functions in a little bit different manner; for example, it fires irqs at i2c stop condition, whereas MSS i2c doesn't.

## Impact

Configuration is set so that either FPGA CoreI2C or MSS i2c (default) may be used; not both of them at the same time.

## Testing

Tested with several sensors on multiple buses concurrently. This needs the CoreI2C FPGA sw in place in order for it to function.

