### PR TITLE
net/socket: fix kconfig warning

### DIFF
--- a/net/socket/Kconfig
+++ b/net/socket/Kconfig
@@ -66,7 +66,7 @@ config NET_SOLINGER
 	bool "SO_LINGER socket option"
 	default n
 	depends on NET_TCP_WRITE_BUFFERS || NET_UDP_WRITE_BUFFERS
-	select NET_UDP_NOTIFIER if NET_UDP
+	select NET_UDP_NOTIFIER if NET_UDP && !NET_UDP_NO_STACK
 	---help---
 		Enable or disable support for the SO_LINGER socket option.  Requires
 		write buffer support.


### PR DESCRIPTION
## Summary

net/socket: fix kconfig warning

warning: (NET_SOLINGER) selects NET_UDP_NOTIFIER which has unmet direct dependencies
  (NET && NET_UDP && !NET_UDP_NO_STACK && SCHED_WORKQUEUE)

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

ci-check