### PR TITLE
mempool:Fix seqnumber statistics error in memdump

### DIFF
--- a/mm/mempool/mempool.c
+++ b/mm/mempool/mempool.c
@@ -416,20 +416,15 @@ mempool_info_task(FAR struct mempool_s *pool,
       info.aordblks += count;
       info.uordblks += count * pool->blocksize;
     }
+#if CONFIG_MM_BACKTRACE < 0
   else if (dump->pid == MM_BACKTRACE_ALLOC_PID)
     {
-#if CONFIG_MM_BACKTRACE >= 0
-      size_t count = list_length(&pool->alist);
-#else
       size_t count = pool->nalloc;
-#endif
 
       info.aordblks += count;
       info.uordblks += count * pool->blocksize;
-      info.aordblks -= pool->nexpend;
-      info.uordblks -= pool->totalsize;
     }
-#if CONFIG_MM_BACKTRACE >= 0
+#else
   else
     {
       FAR struct mempool_backtrace_s *buf;
@@ -437,7 +432,7 @@ mempool_info_task(FAR struct mempool_s *pool,
       list_for_every_entry(&pool->alist, buf, struct mempool_backtrace_s,
                            node)
         {
-          if (buf->pid == dump->pid ||
+          if (dump->pid == buf->pid || dump->pid == MM_BACKTRACE_ALLOC_PID ||
               (dump->pid == MM_BACKTRACE_INVALID_PID &&
                nxsched_get_tcb(buf->pid) == NULL))
             {


### PR DESCRIPTION
## Summary
bug fix,The judgment of seqmin and seqmax is ignored
## Impact
memdump
## Testing
sim:nsh with testing_mm & mempoll
