### PR TITLE
mpfs_usb: Add mpfs_vbus_detect

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_usb.h
+++ b/arch/risc-v/src/mpfs/mpfs_usb.h
@@ -63,6 +63,22 @@ extern "C"
 
 void mpfs_usbinitialize(void);
 
+/****************************************************************************
+ * Name: mpfs_vbus_detect
+ *
+ * Description:
+ *   Read the VBUS state from the USB OTG controller.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   true if VBUS is valid; false otherwise
+ *
+ ****************************************************************************/
+
+bool mpfs_vbus_detect(void);
+
 #undef EXTERN
 #if defined(__cplusplus)
 }


### PR DESCRIPTION
## Summary
External function to query vbus status. Reading from the block requires the clock, but if no devices are open -> vbus detect does not work.

This creates a chicken / egg problem, if vbus detect is used to start the usb device.
## Impact
Add way to query VBUS status externally.
## Testing
icicle:nsh
