### PR TITLE
arch/arm/src/tiva: start FPU before GPIO config

### DIFF
--- a/arch/arm/src/tiva/common/lmxx_tm4c_start.c
+++ b/arch/arm/src/tiva/common/lmxx_tm4c_start.c
@@ -108,9 +108,9 @@ void __start(void)
 
   /* Configure the UART so that we can get debug output as soon as possible */
 
+  arm_fpuconfig();
   tiva_clock_configure();
   tiva_lowsetup();
-  arm_fpuconfig();
   showprogress('A');
 
   /* Clear .bss.  We'll do this inline (vs. calling memset) just to be


### PR DESCRIPTION
## Summary
This PR fixes the issue described in https://github.com/apache/nuttx/issues/9327. regarding the board not booting when FPU is enabled and GCC 10 is used (however GCC 9 and 12 worked fine

GCC 9 and 12 works fine. GCC 10 causes the board to not boot when configuring GPIO.
@ldube pointed that GCC needs the FPU up and running before proceeding with the configuration. 

## Impact
None expected.

## Testing
Board successfully booted when compiled with GCC 9.
