### PR TITLE
arch/{nrf52|nrf53}: validate if EasyDMA transfer is possible

### DIFF
--- a/arch/arm/src/nrf52/hardware/nrf52_utils.h
+++ b/arch/arm/src/nrf52/hardware/nrf52_utils.h
@@ -43,6 +43,16 @@
 void nrf52_clrpend(int irq);
 
 /****************************************************************************
+ * Name: nrf52_easydma_valid
+ *
+ * Description:
+ *   Validate if easyDMA transfer is possible.
+ *
+ ****************************************************************************/
+
+bool nrf52_easydma_valid(uint32_t addr);
+
+/****************************************************************************
  * Name: nrf52832_errdata_init
  *
  * Description:

--- a/arch/arm/src/nrf52/nrf52_adc.c
+++ b/arch/arm/src/nrf52/nrf52_adc.c
@@ -40,6 +40,7 @@
 #include "nrf52_adc.h"
 
 #include "hardware/nrf52_saadc.h"
+#include "hardware/nrf52_utils.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -262,6 +263,7 @@ static int nrf52_adc_configure(struct nrf52_adc_s *priv)
   /* Configure ADC buffer */
 
   regval = (uint32_t)&priv->buffer;
+  DEBUGASSERT(nrf52_easydma_valid(regval));
   nrf52_adc_putreg(priv, NRF52_SAADC_PTR_OFFSET, regval);
 
   regval = priv->chan_len;

--- a/arch/arm/src/nrf52/nrf52_i2c.c
+++ b/arch/arm/src/nrf52/nrf52_i2c.c
@@ -39,6 +39,7 @@
 #include "nrf52_i2c.h"
 
 #include "hardware/nrf52_twi.h"
+#include "hardware/nrf52_utils.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -366,6 +367,7 @@ static int nrf52_i2c_transfer(struct i2c_master_s *dev,
           /* Write TXD data pointer */
 
           regval = (uint32_t)priv->ptr;
+          DEBUGASSERT(nrf52_easydma_valid(regval));
           nrf52_i2c_putreg(priv, NRF52_TWIM_TXDPTR_OFFSET, regval);
 
           /* Write number of bytes in TXD buffer */
@@ -419,6 +421,7 @@ static int nrf52_i2c_transfer(struct i2c_master_s *dev,
           /* Write RXD data pointer */
 
           regval = (uint32_t)priv->ptr;
+          DEBUGASSERT(nrf52_easydma_valid(regval));
           nrf52_i2c_putreg(priv, NRF52_TWIM_RXDPTR_OFFSET, regval);
 
           /* Write number of bytes in RXD buffer */

--- a/arch/arm/src/nrf52/nrf52_pwm.c
+++ b/arch/arm/src/nrf52/nrf52_pwm.c
@@ -38,6 +38,7 @@
 #include "nrf52_pwm.h"
 
 #include "hardware/nrf52_pwm.h"
+#include "hardware/nrf52_utils.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -271,6 +272,7 @@ static int nrf52_pwm_configure(struct nrf52_pwm_s *priv)
   /* Configure sequence 0 */
 
   regval = (uint32_t)priv->seq0;
+  DEBUGASSERT(nrf52_easydma_valid(regval));
   nrf52_pwm_putreg(priv, NRF52_PWM_SEQ0PTR_OFFSET, regval);
 
   regval = PWM_SEQ0_LEN;

--- a/arch/arm/src/nrf52/nrf52_radio.c
+++ b/arch/arm/src/nrf52/nrf52_radio.c
@@ -39,6 +39,7 @@
 #include "nrf52_radio.h"
 
 #include "hardware/nrf52_radio.h"
+#include "hardware/nrf52_utils.h"
 
 #warning NRF52 RADIO support is EXPERIMENTAL!
 
@@ -748,6 +749,7 @@ static int nrf52_radio_write(struct nrf52_radio_dev_s *dev,
 
   /* Set packet pointer */
 
+  DEBUGASSERT(nrf52_easydma_valid(&dev->txbuf));
   nrf52_radio_putreg(dev, NRF52_RADIO_PACKETPTR_OFFSET, &dev->txbuf);
 
   /* Set state to TX */
@@ -803,6 +805,7 @@ static int nrf52_radio_read(struct nrf52_radio_dev_s *dev,
 
   /* Set packet pointer */
 
+  DEBUGASSERT(nrf52_easydma_valid(&dev->rxbuf));
   nrf52_radio_putreg(dev, NRF52_RADIO_PACKETPTR_OFFSET, &dev->rxbuf);
 
   /* Set state to RX */

--- a/arch/arm/src/nrf52/nrf52_spi.c
+++ b/arch/arm/src/nrf52/nrf52_spi.c
@@ -42,6 +42,7 @@
 #include "nrf52_spi.h"
 
 #include "hardware/nrf52_spi.h"
+#include "hardware/nrf52_utils.h"
 
 #ifdef CONFIG_NRF52_SPI_MASTER_WORKAROUND_1BYTE_TRANSFER
 #  include "hardware/nrf52_gpiote.h"
@@ -1089,6 +1090,7 @@ static void nrf52_spi_exchange(struct spi_dev_s *dev,
       /* Write RXD data pointer */
 
       regval = (uint32_t)rxbuffer;
+      DEBUGASSERT(nrf52_easydma_valid(regval));
       nrf52_spi_putreg(priv, NRF52_SPIM_RXDPTR_OFFSET, regval);
     }
   else
@@ -1101,6 +1103,7 @@ static void nrf52_spi_exchange(struct spi_dev_s *dev,
       /* Write TXD data pointer */
 
       regval = (uint32_t)txbuffer;
+      DEBUGASSERT(nrf52_easydma_valid(regval));
       nrf52_spi_putreg(priv, NRF52_SPIM_TXDPTR_OFFSET, regval);
     }
   else

--- a/arch/arm/src/nrf52/nrf52_usbd.c
+++ b/arch/arm/src/nrf52/nrf52_usbd.c
@@ -49,6 +49,7 @@
 
 #include "hardware/nrf52_usbd.h"
 #include "hardware/nrf52_power.h"
+#include "hardware/nrf52_utils.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -1023,6 +1024,7 @@ static void nrf52_epin_transfer(struct nrf52_ep_s *privep, uint8_t *buf,
     {
       /* Configure EasyDMA */
 
+      DEBUGASSERT(nrf52_easydma_valid((uint32_t)buf));
       nrf52_putreg((uint32_t)buf, NRF52_USBD_EPIN_PTR(privep->epphy));
       nrf52_putreg(nbytes, NRF52_USBD_EPIN_MAXCNT(privep->epphy));
 
@@ -1071,6 +1073,7 @@ static void nrf52_epout_transfer(struct nrf52_ep_s *privep)
 
   /* Configure EasyDMA */
 
+  DEBUGASSERT(nrf52_easydma_valid((uint32_t)privep->rxbuff));
   nrf52_putreg((uint32_t)privep->rxbuff,
                NRF52_USBD_EPOUT_PTR(privep->epphy));
   nrf52_putreg(nbytes, NRF52_USBD_EPOUT_MAXCNT(privep->epphy));

--- a/arch/arm/src/nrf52/nrf52_utils.c
+++ b/arch/arm/src/nrf52/nrf52_utils.c
@@ -30,6 +30,7 @@
 #include "arm_internal.h"
 #include "nrf52_irq.h"
 #include "hardware/nrf52_utils.h"
+#include "hardware/nrf52_memorymap.h"
 
 /****************************************************************************
  * Public Functions
@@ -64,4 +65,26 @@ void nrf52_clrpend(int irq)
                    NVIC_IRQ32_63_CLRPEND);
         }
     }
+}
+
+/****************************************************************************
+ * Name: nrf52_easydma_valid
+ *
+ * Description:
+ *   Validate if easyDMA transfer is possible.
+ *
+ ****************************************************************************/
+
+bool nrf52_easydma_valid(uint32_t addr)
+{
+#ifdef CONFIG_DEBUG_FEATURES
+  /* EasyDMA cannot access flash memory */
+
+  if (addr >= NRF52_FLASH_BASE && addr < NRF52_SRAM_BASE)
+    {
+      return false;
+    }
+#endif
+
+  return true;
 }

--- a/arch/arm/src/nrf53/hardware/nrf53_utils.h
+++ b/arch/arm/src/nrf53/hardware/nrf53_utils.h
@@ -43,15 +43,14 @@
 void nrf53_clrpend(int irq);
 
 /****************************************************************************
- * Name: nrf53832_errdata_init
+ * Name: nrf53_easydma_valid
  *
  * Description:
- *   ErrData correction for 52832
- *   required for most interrupts.
+ *   Validate if easyDMA transfer is possible.
  *
  ****************************************************************************/
 
-void nrf53832_errdata_init(void);
+bool nrf53_easydma_valid(uint32_t addr);
 
 /****************************************************************************
  * Name: nrf53_task_trigger

--- a/arch/arm/src/nrf53/nrf53_adc.c
+++ b/arch/arm/src/nrf53/nrf53_adc.c
@@ -40,6 +40,7 @@
 #include "nrf53_adc.h"
 
 #include "hardware/nrf53_saadc.h"
+#include "hardware/nrf53_utils.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -262,6 +263,7 @@ static int nrf53_adc_configure(struct nrf53_adc_s *priv)
   /* Configure ADC buffer */
 
   regval = (uint32_t)&priv->buffer;
+  DEBUGASSERT(nrf53_easydma_valid(regval));
   nrf53_adc_putreg(priv, NRF53_SAADC_PTR_OFFSET, regval);
 
   regval = priv->chan_len;

--- a/arch/arm/src/nrf53/nrf53_i2c.c
+++ b/arch/arm/src/nrf53/nrf53_i2c.c
@@ -39,6 +39,7 @@
 #include "nrf53_i2c.h"
 
 #include "hardware/nrf53_twi.h"
+#include "hardware/nrf53_utils.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -416,6 +417,7 @@ static int nrf53_i2c_transfer(struct i2c_master_s *dev,
           /* Write TXD data pointer */
 
           regval = (uint32_t)priv->ptr;
+          DEBUGASSERT(nrf53_easydma_valid(regval));
           nrf53_i2c_putreg(priv, NRF53_TWIM_TXDPTR_OFFSET, regval);
 
           /* Write number of bytes in TXD buffer */
@@ -469,6 +471,7 @@ static int nrf53_i2c_transfer(struct i2c_master_s *dev,
           /* Write RXD data pointer */
 
           regval = (uint32_t)priv->ptr;
+          DEBUGASSERT(nrf53_easydma_valid(regval));
           nrf53_i2c_putreg(priv, NRF53_TWIM_RXDPTR_OFFSET, regval);
 
           /* Write number of bytes in RXD buffer */

--- a/arch/arm/src/nrf53/nrf53_pwm.c
+++ b/arch/arm/src/nrf53/nrf53_pwm.c
@@ -38,6 +38,7 @@
 #include "nrf53_pwm.h"
 
 #include "hardware/nrf53_pwm.h"
+#include "hardware/nrf53_utils.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -249,6 +250,7 @@ static int nrf53_pwm_configure(struct nrf53_pwm_s *priv)
   /* Configure sequence 0 */
 
   regval = (uint32_t)priv->seq0;
+  DEBUGASSERT(nrf53_easydma_valid(regval));
   nrf53_pwm_putreg(priv, NRF53_PWM_SEQ0PTR_OFFSET, regval);
 
   regval = PWM_SEQ0_LEN;

--- a/arch/arm/src/nrf53/nrf53_spi.c
+++ b/arch/arm/src/nrf53/nrf53_spi.c
@@ -42,6 +42,7 @@
 #include "nrf53_spi.h"
 
 #include "hardware/nrf53_spi.h"
+#include "hardware/nrf53_utils.h"
 
 /****************************************************************************
  * Private Types
@@ -1083,6 +1084,7 @@ static void nrf53_spi_exchange(struct spi_dev_s *dev,
       /* Write RXD data pointer */
 
       regval = (uint32_t)rxbuffer;
+      DEBUGASSERT(nrf53_easydma_valid(regval));
       nrf53_spi_putreg(priv, NRF53_SPIM_RXDPTR_OFFSET, regval);
     }
   else
@@ -1095,6 +1097,7 @@ static void nrf53_spi_exchange(struct spi_dev_s *dev,
       /* Write TXD data pointer */
 
       regval = (uint32_t)txbuffer;
+      DEBUGASSERT(nrf53_easydma_valid(regval));
       nrf53_spi_putreg(priv, NRF53_SPIM_TXDPTR_OFFSET, regval);
     }
   else

--- a/arch/arm/src/nrf53/nrf53_usbd.c
+++ b/arch/arm/src/nrf53/nrf53_usbd.c
@@ -49,6 +49,7 @@
 
 #include "hardware/nrf53_usbd.h"
 #include "hardware/nrf53_usbreg.h"
+#include "hardware/nrf53_utils.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -1023,6 +1024,7 @@ static void nrf53_epin_transfer(struct nrf53_ep_s *privep, uint8_t *buf,
     {
       /* Configure EasyDMA */
 
+      DEBUGASSERT(nrf53_easydma_valid((uint32_t)buf));
       nrf53_putreg((uint32_t)buf, NRF53_USBD_EPIN_PTR(privep->epphy));
       nrf53_putreg(nbytes, NRF53_USBD_EPIN_MAXCNT(privep->epphy));
 
@@ -1071,6 +1073,7 @@ static void nrf53_epout_transfer(struct nrf53_ep_s *privep)
 
   /* Configure EasyDMA */
 
+  DEBUGASSERT(nrf53_easydma_valid((uint32_t)privep->rxbuff));
   nrf53_putreg((uint32_t)privep->rxbuff,
                NRF53_USBD_EPOUT_PTR(privep->epphy));
   nrf53_putreg(nbytes, NRF53_USBD_EPOUT_MAXCNT(privep->epphy));

--- a/arch/arm/src/nrf53/nrf53_utils.c
+++ b/arch/arm/src/nrf53/nrf53_utils.c
@@ -30,6 +30,7 @@
 #include "arm_internal.h"
 #include "nrf53_irq.h"
 #include "hardware/nrf53_utils.h"
+#include "hardware/nrf53_memorymap.h"
 
 /****************************************************************************
  * Public Functions
@@ -64,4 +65,26 @@ void nrf53_clrpend(int irq)
                    NVIC_IRQ32_63_CLRPEND);
         }
     }
+}
+
+/****************************************************************************
+ * Name: nrf53_easydma_valid
+ *
+ * Description:
+ *   Validate if easyDMA transfer is possible.
+ *
+ ****************************************************************************/
+
+bool nrf53_easydma_valid(uint32_t addr)
+{
+#ifdef CONFIG_DEBUG_FEATURES
+  /* EasyDMA cannot access flash memory */
+
+  if (addr >= NRF53_FLASH_BASE && addr < NRF53_SRAM_BASE)
+    {
+      return false;
+    }
+#endif
+
+  return true;
 }


### PR DESCRIPTION
## Summary
- arch/{nrf52|nrf53}: validate if EasyDMA transfer is possible
Add an interface that validate if EasyDMA transfer is possible. EasyDMA cannot access flash memory which can cause hard to detect silent bugs. This feature is enabled if CONFIG_DEBUG_FEATURES=y and CONFIG_DEBUG_ASSERTIONS=y.

## Impact
Debug feature

## Testing
thingy53
