### PR TITLE
arch/{nrf52|nrf53}: cosmetic changes in Kconfig

### DIFF
--- a/arch/arm/src/nrf52/Kconfig
+++ b/arch/arm/src/nrf52/Kconfig
@@ -465,6 +465,8 @@ endmenu # GPIO Interrupt Configuration
 
 menu "PWM configuration"
 
+if NRF52_PWM
+
 config NRF52_PWM_MULTICHAN
 	bool "PWM Multiple Output Channels"
 	default n
@@ -612,6 +614,8 @@ config NRF52_PWM3_CHANNEL
 	range 0 3
 
 endif # !NRF52_PWM_MULTICHAN
+
+endif # NRF52_PWM
 
 endmenu # PWM configuration
 

--- a/arch/arm/src/nrf52/Kconfig
+++ b/arch/arm/src/nrf52/Kconfig
@@ -193,14 +193,6 @@ config NRF52_SPI3_MASTER
 	select NRF52_SPI_MASTER
 	depends on NRF52_HAVE_SPI3_MASTER
 
-if NRF52_SPI_MASTER
-
-config NRF52_SPI_MASTER_INTERRUPTS
-	bool "SPI Master interrupts support"
-	default n
-
-endif
-
 config NRF52_GPIOTE
 	bool "GPIOTE (GPIO interrupts)"
 	default n
@@ -679,14 +671,23 @@ endmenu # SAADC Configuration
 
 menu "SPI Configuration"
 
+if NRF52_SPI_MASTER
+
+config NRF52_SPI_MASTER_INTERRUPTS
+	bool "SPI Master interrupts support"
+	default n
+
 config NRF52_SPI_MASTER_WORKAROUND_1BYTE_TRANSFER
 	bool "Master 1 Byte transfer anomaly workaround"
-	depends on NRF52_SPI_MASTER && ARCH_CHIP_NRF52832
+	depends on ARCH_CHIP_NRF52832
 	select NRF52_PPI
 	default y
 	---help---
 		Enable the workaround to fix SPI Master 1 byte transfer bug
 		which occurs in NRF52832 revision 1 and revision 2.
+
+endif # NRF52_SPI_MASTER
+
 endmenu
 
 menu "I2C Master Configuration"

--- a/arch/arm/src/nrf52/Kconfig
+++ b/arch/arm/src/nrf52/Kconfig
@@ -691,6 +691,8 @@ endmenu
 
 menu "I2C Master Configuration"
 
+if NRF52_I2C_MASTER
+
 config NRF52_I2C_MASTER_DISABLE_NOSTART
 	bool "Disable the I2C Master NOSTART flag support"
 	default n
@@ -713,6 +715,8 @@ config NRF52_I2C_MASTER_COPY_BUF_SIZE
 		transfer. This static buffer will be used if the
 		transaction will fit otherwise it will fall back
 		on malloc.
+
+endif # NRF52_I2C_MASTER
 
 endmenu
 

--- a/arch/arm/src/nrf53/Kconfig
+++ b/arch/arm/src/nrf53/Kconfig
@@ -658,6 +658,8 @@ endmenu # GPIO Interrupt Configuration
 
 menu "I2C Master Configuration"
 
+if NRF53_I2C_MASTER
+
 config NRF53_I2C_MASTER_DISABLE_NOSTART
 	bool "Disable the I2C Master NOSTART flag support"
 	default n
@@ -680,6 +682,8 @@ config NRF53_I2C_MASTER_COPY_BUF_SIZE
 		transfer. This static buffer will be used if the
 		transaction will fit otherwise it will fall back
 		on malloc.
+
+endif # NRF53_I2C_MASTER
 
 endmenu
 

--- a/arch/arm/src/nrf53/Kconfig
+++ b/arch/arm/src/nrf53/Kconfig
@@ -447,6 +447,27 @@ config NRF53_PROGMEM
 	---help---
 		Enable support FLASH interfaces as defined in include/nuttx/progmem.h
 
+menu "GPIO Interrupt Configuration"
+
+config NRF53_PER_PIN_INTERRUPTS
+	bool "Per-pin interrupt callbacks"
+	default !DEFAULT_SMALL
+	depends on NRF53_GPIOTE
+	---help---
+		The GPIOTE peripheral supports a limited number of channels which can
+		be set to EVENT mode and thus generate interrupts on pin state changes.
+		Another mechanism offered by the GPIO/GPIOTE peripherals is the PORT
+		event. This event is generated from a signal shared by all pins in
+		the GPIO port.
+
+		This option enables the ability to set per-pin callbacks that will
+		be invoked from the main GPIOTE ISR when a PORT event is generated.
+		As this involves extra storage to store each callback, this option can
+		be disabled to save space. In such case, it is possible to set a callback
+		for the whole PORT event directly.
+
+endmenu # GPIO Interrupt Configuration
+
 menu "PWM configuration"
 
 if NRF53_PWM
@@ -626,27 +647,6 @@ config NRF53_SAADC_LIMITS
 endif # NRF53_SAADC
 
 endmenu # SAADC Configuration
-
-menu "GPIO Interrupt Configuration"
-
-config NRF53_PER_PIN_INTERRUPTS
-	bool "Per-pin interrupt callbacks"
-	default !DEFAULT_SMALL
-	depends on NRF53_GPIOTE
-	---help---
-		The GPIOTE peripheral supports a limited number of channels which can
-		be set to EVENT mode and thus generate interrupts on pin state changes.
-		Another mechanism offered by the GPIO/GPIOTE peripherals is the PORT
-		event. This event is generated from a signal shared by all pins in
-		the GPIO port.
-
-		This option enables the ability to set per-pin callbacks that will
-		be invoked from the main GPIOTE ISR when a PORT event is generated.
-		As this involves extra storage to store each callback, this option can
-		be disabled to save space. In such case, it is possible to set a callback
-		for the whole PORT event directly.
-
-endmenu # GPIO Interrupt Configuration
 
 menu "SPI Configuration"
 

--- a/arch/arm/src/nrf53/Kconfig
+++ b/arch/arm/src/nrf53/Kconfig
@@ -240,14 +240,6 @@ config NRF53_SPI4_MASTER
 
 endif # NRF53_HAVE_SPI1234
 
-if NRF53_SPI_MASTER
-
-config NRF53_SPI_MASTER_INTERRUPTS
-	bool "SPI Master interrupts support"
-	default n
-
-endif
-
 config NRF53_UART0
 	bool "UART0"
 	default n
@@ -655,6 +647,18 @@ config NRF53_PER_PIN_INTERRUPTS
 		for the whole PORT event directly.
 
 endmenu # GPIO Interrupt Configuration
+
+menu "SPI Configuration"
+
+if NRF53_SPI_MASTER
+
+config NRF53_SPI_MASTER_INTERRUPTS
+	bool "SPI Master interrupts support"
+	default n
+
+endif #  NRF53_SPI_MASTER
+
+endmenu
 
 menu "I2C Master Configuration"
 

--- a/arch/arm/src/nrf53/Kconfig
+++ b/arch/arm/src/nrf53/Kconfig
@@ -457,6 +457,8 @@ config NRF53_PROGMEM
 
 menu "PWM configuration"
 
+if NRF53_PWM
+
 config NRF53_PWM_MULTICHAN
 	bool "PWM Multiple Output Channels"
 	default n
@@ -570,6 +572,8 @@ config NRF53_PWM2_CHANNEL
 	range 0 3
 
 endif # !NRF53_PWM_MULTICHAN
+
+endif # NRF53_PWM
 
 endmenu # PWM configuration
 


### PR DESCRIPTION
## Summary

- arch/{nrf52|nrf53}: hide PWM options if PWM not enabled
- arch/{nrf52|nrf53}: hide I2C_MASTER options if I2C_MASTER not enabled
- arch/{nrf52|nrf53}: hide SPI_MASTER options if SPI_MASTER not enabled
- arch/nrf53/Kconfig: move GPIO configuration menu to match nrf52

## Impact
Purely cosmetic changes

## Testing
CI
