### PR TITLE
dirivers: virtio: Fix virtnet_transmit() in virtio-mmio-net.c

### DIFF
--- a/drivers/virtio/virtio-mmio-net.c
+++ b/drivers/virtio/virtio-mmio-net.c
@@ -394,6 +394,14 @@ static int virtnet_transmit(FAR struct virtnet_driver_s *priv)
 
   wd_start(&priv->vnet_txtimeout, VIRTNET_TXTIMEOUT,
            virtnet_txtimeout_expiry, (wdparm_t)priv);
+
+  /* Wait for completion */
+
+  while (priv->txq->avail->idx != priv->txq->used->idx)
+    {
+      virtio_mb();
+    }
+
   return OK;
 }
 


### PR DESCRIPTION
## Summary

- I noticed that the driver sends incorrect packets sometimes.
- This commit fixes this issue.

## Impact

- None

## Testing

- Tested with qemu-7.1
