### PR TITLE
boards/nrf52-feather: fix typo in I2C1 initialization

### DIFF
--- a/boards/arm/nrf52/nrf52-feather/src/nrf52_i2c.c
+++ b/boards/arm/nrf52/nrf52-feather/src/nrf52_i2c.c
@@ -88,7 +88,7 @@ int nrf52_i2ctool(void)
 #endif
 
 #ifdef CONFIG_NRF52_I2C1_MASTER
-  ret = nrf52_i2c_register(0);
+  ret = nrf52_i2c_register(1);
 #endif
   return ret;
 }


### PR DESCRIPTION
## Summary
- boards/nrf52-feather: fix typo in I2C1 initialization

## Impact

## Testing
CI
