### PR TITLE
arch: fvp-v8r: Fix warning when configuring fvp-armv8r:nsh_smp

### DIFF
--- a/arch/arm64/src/fvp-v8r/Kconfig
+++ b/arch/arm64/src/fvp-v8r/Kconfig
@@ -14,7 +14,6 @@ choice
 config ARCH_CHIP_FVP_R82
 	bool "FVP virtual Processor (Cortex-r82)"
 	select ARCH_HAVE_MULTICPU
-	select ARMV8R_HAVE_GICv3
 	select ARCH_SET_VMPIDR_EL2
 
 endchoice # FVP Chip Selection


### PR DESCRIPTION
## Summary

- I noticed that ./tools/configure.sh fvp-armv8r:nsh_smp shows 
 `warning: (ARCH_CHIP_FVP_R52 && ARCH_CHIP_FVP_R82) selects ARMV8R_HAVE_GICv3 which has unmet direct dependencies (ARCH_ARM && ARCH_ARMV8R)`
- I think ARMV8R_HAVE_GICv3 is only used for aarch32.
- This commit fixes this issue.

## Impact

- None

## Testing

- Tested with nsh_smp on FVP
