### PR TITLE
arch/arm64: use adrp instead of adr in bss init code

### DIFF
--- a/arch/arm64/src/common/arm64_head.S
+++ b/arch/arm64/src/common/arm64_head.S
@@ -364,7 +364,8 @@ arm64_data_initialize:
 
     /* Zero BSS */
 
-    adr     x0, .Linitparms
+    adrp    x0, .Linitparms
+    add     x0, x0, .Linitparms
     ldp     x1, x2, [x0], #8
 
     mov     x0, #0


### PR DESCRIPTION
To support address offset larger than 1MB


