### PR TITLE
initial FPU support for ARMv8R AARCH32

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -86,6 +86,7 @@ config ARCH_CHIP_FVP_ARMV8R_AARCH32
 	select ARCH_HAVE_LOWVECTORS
 	select ARCH_HAVE_FETCHADD
 	select ARMV8R_HAVE_DECODEFIQ
+	select ARCH_HAVE_FPU
 	---help---
 		ARM FVP virt platform (ARMv8r)
 

--- a/arch/arm/src/armv8-r/Make.defs
+++ b/arch/arm/src/armv8-r/Make.defs
@@ -45,8 +45,8 @@ CMN_ASRCS += arm_saveusercontext.S
 #   CMN_CSRCS += arm_mpu.c
 # endif
 
-# ifeq ($(CONFIG_ARCH_FPU),y)
-#   CMN_CSRCS += arm_fpucmp.c
-#   CMN_ASRCS += arm_fpuconfig.S
-# endif
+ifeq ($(CONFIG_ARCH_FPU),y)
+  CMN_CSRCS += arm_fpucmp.c
+  CMN_ASRCS += arm_fpuconfig.S
+endif
 

--- a/arch/arm/src/armv8-r/arm_fpucmp.c
+++ b/arch/arm/src/armv8-r/arm_fpucmp.c
@@ -1,0 +1,71 @@
+/****************************************************************************
+ * arch/arm/src/armv8-r/arm_fpucmp.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+#include <string.h>
+#include <nuttx/irq.h>
+
+#include "arm_internal.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifdef CONFIG_ARCH_FPU
+
+#  define FPU_CALLEE_REGS   (16)
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_fpucmp
+ *
+ * Description:
+ *   Compare FPU areas from thread context.
+ *
+ * Input Parameters:
+ *   saveregs1 - Pointer to the saved FPU registers.
+ *   saveregs2 - Pointer to the saved FPU registers.
+ *
+ * Returned Value:
+ *   True if FPU areas compare equal, False otherwise.
+ *
+ ****************************************************************************/
+
+bool up_fpucmp(const void *saveregs1, const void *saveregs2)
+{
+  const uint32_t *regs1 = saveregs1;
+  const uint32_t *regs2 = saveregs2;
+
+  /* Only compare callee-saved registers, caller-saved registers do not
+   * need to be preserved.
+   */
+
+  return memcmp(&regs1[REG_S16], &regs2[REG_S16], 4 * FPU_CALLEE_REGS) == 0;
+}
+#endif /* CONFIG_ARCH_FPU */

--- a/arch/arm/src/armv8-r/arm_fpuconfig.S
+++ b/arch/arm/src/armv8-r/arm_fpuconfig.S
@@ -1,0 +1,87 @@
+/****************************************************************************
+ * arch/arm/src/armv8-r/arm_fpuconfig.S
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include "cp15.h"
+
+#ifdef CONFIG_ARCH_FPU
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Symbols
+ ****************************************************************************/
+
+	.globl	arm_fpuconfig
+	.file	"arm_fpuconfig.S"
+
+/****************************************************************************
+ * Assembly Macros
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+	.text
+	.syntax	unified
+	.arm
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: arm_fpuconfig
+ *
+ * Description:
+ *   Configure the FPU.  Enables access to CP10 and CP11
+ *
+ ****************************************************************************/
+
+	.globl	arm_fpuconfig
+	.type	arm_fpuconfig, %function
+
+arm_fpuconfig:
+
+	/* Enable access to CP10 and CP11 in CP15.CACR */
+
+	mrc		CP15_CPACR(r0)
+	orr		r0, r0, #0xf00000
+	mcr		CP15_CPACR(r0)
+
+	/* Enable access to CP10 and CP11 in CP15.NSACR */
+	/* REVISIT: Do we need to do this? */
+
+	/* Set FPEXC.EN (B30) */
+
+	fmrx		r0, fpexc
+	orr		r0, r0, #0x40000000
+	fmxr		fpexc, r0
+	bx		lr
+	.size	arm_fpuconfig, . - arm_fpuconfig
+#endif
+	.end

--- a/arch/arm/src/armv8-r/arm_head.S
+++ b/arch/arm/src/armv8-r/arm_head.S
@@ -160,7 +160,7 @@ __cpu0_start:
 
 	/* Make sure that IRQs and FIQs are disabled */
 
-	cpsid		if
+	cpsid	if
 
 	/* Set up the stack pointer and clear the frame pointer. */
 
@@ -187,7 +187,7 @@ __cpu0_start:
 	mov		r0, #0
 	mcr		CP15_BPIALL(r0)		/* Invalidate entire branch prediction array */
 	mcr		CP15_ICIALLU(r0)	/* Invalidate I-cache */
-	mov     r0, CP15_CACHE_INVALIDATE
+	mov		r0, CP15_CACHE_INVALIDATE
 	bl		cp15_dcache_op_level
 	isb
 
@@ -196,16 +196,16 @@ __cpu0_start:
 	/* Initialize .bss and .data assumt that RAM that is ready to use. */
 	bl		arm_data_initialize
 
-    /* Platform hook for highest EL */
-    bl      arm_el_init
+	/* Platform hook for highest EL */
+	bl		arm_el_init
 
     /* Move to PL1 SYS with all exceptions masked */
 	mov		r0, #(PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT | PSR_A_BIT)
-    msr		spsr_hyp, r0
+	msr		spsr_hyp, r0
 
-    adr		r0, 1f
-    msr		elr_hyp, r0
-    eret
+	adr		r0, 1f
+	msr		elr_hyp, r0
+	eret
 
 1:
 	/* Set up the stack pointer and clear the frame pointer. */
@@ -217,6 +217,9 @@ __cpu0_start:
 	mcr		CP15_VBAR(r0)
 
 	bl		sctlr_initialize
+#ifdef CONFIG_ARCH_FPU
+	bl		arm_fpuconfig
+#endif
 	bl		arm_boot
 
 	mov		lr, #0				/* LR = return address (none) */
@@ -284,7 +287,7 @@ arm_data_initialize:
 	cmp		r1, r2
 	blt		3b
 
-#ifndef CONFIG_ARMV7R_DCACHE_DISABLE
+#ifndef CONFIG_ARMV8R_DCACHE_DISABLE
 	/* Flush the copied RAM functions into physical RAM so that will
 	 * be available when fetched into the I-Cache.
 	 *


### PR DESCRIPTION
## Summary
Initial support for floating point on ARMv8R AARCH32. Tested using ARM FVP AEMv8R configured like an CortexR52.
I skipped NEON as I am not sure about the compiler flags here.

## Impact

## Testing
`ostest` passed on ARM FVP

