### PR TITLE
mtd: fix a typo

### DIFF
--- a/drivers/mtd/mtd_config_fs.c
+++ b/drivers/mtd/mtd_config_fs.c
@@ -1863,8 +1863,8 @@ static int nvs_next(FAR struct nvs_fs *fs,
       return rc;
     }
 
-  memcpy(pdata->id, key, sizeof(pdata->id));
-  memcpy(pdata->instance, key + sizeof(pdata->id), sizeof(pdata->instance));
+  memcpy(&pdata->id, key, sizeof(pdata->id));
+  memcpy(&pdata->instance, key + sizeof(pdata->id), sizeof(pdata->instance));
 #endif
 
   rc = nvs_flash_rd(fs, (rd_addr & ADDR_BLOCK_MASK) + step_ate.offset +


### PR DESCRIPTION
Eliminate compilation warnings to find this typo

