### PR TITLE
arch/sim: Replace uart_[xmit|recv]chars_dma with uart_dma[txavail|rxfree]

### DIFF
--- a/arch/sim/src/sim/sim_uart.c
+++ b/arch/sim/src/sim/sim_uart.c
@@ -421,19 +421,19 @@ static void tty_work(void *arg)
       return;
     }
 
-  if (priv->txint && host_uart_checkout(dev->isconsole ? 1 : priv->fd))
+  if (priv->txint)
     {
 #ifdef CONFIG_SIM_UART_DMA
-      uart_xmitchars_dma(dev);
+      uart_dmatxavail(dev);
 #else
       uart_xmitchars(dev);
 #endif
     }
 
-  if (priv->rxint && host_uart_checkin(priv->fd))
+  if (priv->rxint)
     {
 #ifdef CONFIG_SIM_UART_DMA
-      uart_recvchars_dma(dev);
+      uart_dmarxfree(dev);
 #else
       uart_recvchars(dev);
 #endif
@@ -511,6 +511,10 @@ static bool tty_rxflowcontrol(struct uart_dev_s *dev,
 
 static void tty_dmatxavail(FAR struct uart_dev_s *dev)
 {
+  if (uart_txready(dev))
+    {
+      uart_xmitchars_dma(dev);
+    }
 }
 
 /****************************************************************************
@@ -557,6 +561,10 @@ static void tty_dmasend(FAR struct uart_dev_s *dev)
 
 static void tty_dmarxfree(FAR struct uart_dev_s *dev)
 {
+  if (uart_rxavailable(dev))
+    {
+      uart_recvchars_dma(dev);
+    }
 }
 
 /****************************************************************************
@@ -730,4 +738,3 @@ int up_putc(int ch)
 #endif
   return 0;
 }
-

--- a/drivers/usbhost/usbhost_cdcacm.c
+++ b/drivers/usbhost/usbhost_cdcacm.c
@@ -425,11 +425,21 @@ static const struct uart_ops_s g_uart_ops =
   usbhost_attach,        /* attach */
   usbhost_detach,        /* detach */
   usbhost_ioctl,         /* ioctl */
-  NULL           ,       /* receive */
+  NULL,                  /* receive */
   usbhost_rxint,         /* rxinit */
   usbhost_rxavailable,   /* rxavailable */
 #ifdef CONFIG_SERIAL_IFLOWCONTROL
   usbhost_rxflowcontrol, /* rxflowcontrol */
+#endif
+#ifdef CONFIG_SERIAL_TXDMA
+  NULL,                  /* dmasend */
+#endif
+#ifdef CONFIG_SERIAL_RXDMA
+  NULL,                  /* dmareceive */
+  NULL,                  /* dmarxfree */
+#endif
+#ifdef CONFIG_SERIAL_TXDMA
+  NULL,                  /* dmatxavail */
 #endif
   NULL,                  /* send */
   usbhost_txint,         /* txinit */


### PR DESCRIPTION
## Summary

to follow the original dma design

## Impact

sim

## Testing

sim:nsh