### PR TITLE
serial/16550: Include nuttx/clk/clk.h

### DIFF
--- a/drivers/serial/uart_16550.c
+++ b/drivers/serial/uart_16550.c
@@ -37,6 +37,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/clk/clk.h>
 #include <nuttx/dma/dma.h>
 #include <nuttx/serial/serial.h>
 #include <nuttx/fs/ioctl.h>


### PR DESCRIPTION
## Summary

to avoid the build break when CONFIG_CLK is enabled

## Impact

16550 serial driver

## Testing

inernal device