### PR TITLE
mm/mempool: Remove nexpend and totalsize from mempool_s

### DIFF
--- a/include/nuttx/mm/mempool.h
+++ b/include/nuttx/mm/mempool.h
@@ -109,8 +109,6 @@ struct mempool_s
 #endif
   spinlock_t lock;      /* The protect lock to mempool */
   sem_t      waitsem;   /* The semaphore of waiter get free block */
-  size_t     nexpend;   /* The number of expend memory for mempool */
-  size_t     totalsize; /* Total size of the expend for mempoll */
 #if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_MEMPOOL)
   struct mempool_procfs_entry_s procfs; /* The entry of procfs */
 #endif

--- a/mm/mempool/mempool.c
+++ b/mm/mempool/mempool.c
@@ -136,8 +136,6 @@ int mempool_init(FAR struct mempool_s *pool, FAR const char *name)
   sq_init(&pool->queue);
   sq_init(&pool->iqueue);
   sq_init(&pool->equeue);
-  pool->nexpend = 0;
-  pool->totalsize = 0;
 
 #if CONFIG_MM_BACKTRACE >= 0
   list_initialize(&pool->alist);
@@ -157,8 +155,6 @@ int mempool_init(FAR struct mempool_s *pool, FAR const char *name)
           return -ENOMEM;
         }
 
-      pool->nexpend++;
-      pool->totalsize += size;
       mempool_add_queue(&pool->iqueue, pool->ibase, ninterrupt, blocksize);
       kasan_poison(pool->ibase, size);
     }
@@ -184,8 +180,6 @@ int mempool_init(FAR struct mempool_s *pool, FAR const char *name)
           return -ENOMEM;
         }
 
-      pool->nexpend++;
-      pool->totalsize += size;
       mempool_add_queue(&pool->queue, base, ninitial, blocksize);
       sq_addlast((FAR sq_entry_t *)(base + ninitial * blocksize),
                   &pool->equeue);
@@ -259,8 +253,6 @@ retry:
                   return NULL;
                 }
 
-              pool->nexpend++;
-              pool->totalsize += size;
               kasan_poison(base, size);
               flags = spin_lock_irqsave(&pool->lock);
               mempool_add_queue(&pool->queue, base, nexpand, blocksize);

--- a/mm/mm_heap/mm_malloc.c
+++ b/mm/mm_heap/mm_malloc.c
@@ -96,10 +96,9 @@ void mm_mempool_dump_handle(FAR struct mempool_s *pool, FAR void *arg)
   struct mempoolinfo_s info;
 
   mempool_info(pool, &info);
-  mwarn("%9lu%11lu%9lu%9lu%9lu%9lu%9zu\n",
+  mwarn("%9lu%11lu%9lu%9lu%9lu%9lu\n",
         info.sizeblks, info.arena, info.aordblks,
-        info.ordblks, info.iordblks,
-        info.nwaiter, pool->nexpend);
+        info.ordblks, info.iordblks, info.nwaiter);
 }
 #endif
 
@@ -292,8 +291,9 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
       mm_dump_handler(NULL, heap);
 #  endif
 #  if CONFIG_MM_HEAP_MEMPOOL_THRESHOLD != 0
-      mwarn("%11s%9s%9s%9s%9s%9s%9s\n", "bsize", "total", "nused",
-            "nfree", "nifree", "nwaiter", "nexpend");
+      mwarn("%11s%9s%9s%9s%9s%9s\n",
+            "bsize", "total", "nused",
+            "nfree", "nifree", "nwaiter");
       mempool_multiple_foreach(heap->mm_mpool,
                                mm_mempool_dump_handle, NULL);
 #  endif


### PR DESCRIPTION
## Summary

forget in the commit(https://github.com/apache/nuttx/pull/9052):
```
commit 781a34da948724093dc16317ab29f68ec9b57df3
Author: anjiahao <anjiahao@xiaomi.com>
Date:   Tue Apr 18 11:18:43 2023 +0800

    memepool:fix memory consumption double counting issue
```

## Impact

remove the unused fields

## Testing

sim:adb