### PR TITLE
kmm/kmm_map: Add missing FAR qualifiers

### DIFF
--- a/arch/risc-v/src/common/riscv_addrenv_pgmap.c
+++ b/arch/risc-v/src/common/riscv_addrenv_pgmap.c
@@ -59,7 +59,7 @@
  *
  ****************************************************************************/
 
-uintptr_t up_addrenv_find_page(FAR arch_addrenv_t *addrenv, uintptr_t vaddr)
+uintptr_t up_addrenv_find_page(arch_addrenv_t *addrenv, uintptr_t vaddr)
 {
   uintptr_t pgdir;
   uintptr_t lnvaddr;

--- a/include/nuttx/mm/kmap.h
+++ b/include/nuttx/mm/kmap.h
@@ -18,8 +18,8 @@
  *
  ****************************************************************************/
 
-#ifndef __INCLUDE_NUTTX_MM_KMAP_H_
-#define __INCLUDE_NUTTX_MM_KMAP_H_
+#ifndef __INCLUDE_NUTTX_MM_KMAP_H
+#define __INCLUDE_NUTTX_MM_KMAP_H
 
 /****************************************************************************
  * Name: kmm_map_initialize
@@ -106,4 +106,4 @@ FAR void *kmm_user_map(FAR void *uaddr, size_t size);
 
 FAR void *kmm_map_user_page(FAR void *uaddr);
 
-#endif /* __INCLUDE_NUTTX_MM_KMAP_H_ */
+#endif /* __INCLUDE_NUTTX_MM_KMAP_H */

--- a/mm/kmap/kmm_map.c
+++ b/mm/kmap/kmm_map.c
@@ -112,7 +112,7 @@ static int get_user_pages(FAR void **pages, size_t npages, uintptr_t vaddr)
  *
  ****************************************************************************/
 
-static void *map_pages(FAR void **pages, size_t npages, int prot)
+static FAR void *map_pages(FAR void **pages, size_t npages, int prot)
 {
   struct mm_map_entry_s entry;
   FAR void             *vaddr;
@@ -175,7 +175,7 @@ errout_with_vaddr:
  *
  ****************************************************************************/
 
-static void *map_single_user_page(uintptr_t vaddr)
+static FAR void *map_single_user_page(uintptr_t vaddr)
 {
   FAR struct tcb_s *tcb = nxsched_self();
   uintptr_t         page;
@@ -385,7 +385,7 @@ FAR void *kmm_user_map(FAR void *uaddr, size_t size)
 
   /* No, the area must be mapped into kernel virtual address space */
 
-  pages = kmm_zalloc(npages * sizeof(void *));
+  pages = kmm_zalloc(npages * sizeof(FAR void *));
   if (!pages)
     {
       return NULL;


### PR DESCRIPTION
## Summary
Add missing FAR qualifiers
## Impact
Fixes kmm_map for targets that need memory banking
## Testing
Cannot do it, don't own such ancient technology
