### PR TITLE
Assert.h revert #5647 cast assert() to void when NDEBUG is defined

### DIFF
--- a/include/assert.h
+++ b/include/assert.h
@@ -100,7 +100,7 @@
  */
 
 #ifdef NDEBUG
-#  define assert(f) ((void)(1 || (f)))
+#  define assert(f) ((void)(1))
 #else
 #  define assert(f) ASSERT(f)
 #endif


### PR DESCRIPTION
## Summary
Fixes #9467 
By casting `assert(f)` directly to `(void)(1)` to maintain compatibility with other libc implementations

## Impact
Minimal, no functionality changes only compilation warnings

## Testing
CI

