### PR TITLE
usrsock/dns: add sanity check before send dns event

### DIFF
--- a/drivers/usrsock/usrsock_rpmsg_server.c
+++ b/drivers/usrsock/usrsock_rpmsg_server.c
@@ -941,6 +941,10 @@ static int usrsock_rpmsg_send_dns_event(FAR void *arg,
   uint32_t len;
 
   dns = rpmsg_get_tx_payload_buffer(ept, &len, true);
+  if (dns == NULL)
+    {
+      return -ENOMEM;
+    }
 
   dns->head.msgid = USRSOCK_RPMSG_DNS_EVENT;
   dns->head.flags = USRSOCK_MESSAGE_FLAG_EVENT;


### PR DESCRIPTION
## Summary

usrsock/dns: add sanity check before send dns event

Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

usrsock test