### PR TITLE
libs/libc: fix build break on kernel mode

### DIFF
--- a/libs/libc/sched/Make.defs
+++ b/libs/libc/sched/Make.defs
@@ -32,13 +32,12 @@ ifeq ($(CONFIG_SMP),y)
 CSRCS += sched_cpucount.c
 endif
 
-ifneq ($(CONFIG_BUILD_KERNEL),y)
-CSRCS += task_startup.c
-
 ifeq ($(CONFIG_SCHED_BACKTRACE),y)
 CSRCS += sched_dumpstack.c sched_backtrace.c
 endif
 
+ifneq ($(CONFIG_BUILD_KERNEL),y)
+CSRCS += task_startup.c
 endif # CONFIG_BUILD_KERNEL
 
 # Add the sched directory to the build

--- a/sched/pthread/pthread_create.c
+++ b/sched/pthread/pthread_create.c
@@ -369,7 +369,8 @@ int nx_pthread_create(pthread_trampoline_t trampoline, FAR pthread_t *thread,
       goto errout_with_tcb;
     }
 
-#if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
+#if defined(CONFIG_ARCH_ADDRENV) && \
+    defined(CONFIG_BUILD_KERNEL) && defined(CONFIG_ARCH_KERNEL_STACK)
   /* Allocate the kernel stack */
 
   ret = up_addrenv_kstackalloc(&ptcb->cmn);


### PR DESCRIPTION
## Summary

libs/libc: fix build break on kernel mode

Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

fix build break if enable CONFIG_SCHED_BACKTRACE on kernel mode