### PR TITLE
risc-v/backtrace: correct stack pointer if enable ARCH_KERNEL_STACK

### DIFF
--- a/arch/risc-v/src/common/riscv_backtrace.c
+++ b/arch/risc-v/src/common/riscv_backtrace.c
@@ -162,20 +162,44 @@ int up_backtrace(struct tcb_s *tcb, void **buffer, int size, int skip)
         }
       else
         {
-          ret = backtrace(rtcb->stack_base_ptr,
-                          rtcb->stack_base_ptr + rtcb->adj_stack_size,
-                          (void *)getfp(), NULL, buffer, size, &skip);
+#ifdef CONFIG_ARCH_KERNEL_STACK
+          if (rtcb->xcp.ustkptr != NULL)
+            {
+              ret = backtrace(rtcb->stack_base_ptr,
+                              rtcb->stack_base_ptr + rtcb->adj_stack_size,
+                              (void *)*(rtcb->xcp.ustkptr + 1), NULL,
+                              buffer, size, &skip);
+            }
+          else
+#endif
+            {
+              ret = backtrace(rtcb->stack_base_ptr,
+                              rtcb->stack_base_ptr + rtcb->adj_stack_size,
+                              (void *)getfp(), NULL, buffer, size, &skip);
+            }
         }
     }
   else
     {
       flags = enter_critical_section();
 
-      ret = backtrace(tcb->stack_base_ptr,
-                      tcb->stack_base_ptr + tcb->adj_stack_size,
-                      (void *)tcb->xcp.regs[REG_FP],
-                      (void *)tcb->xcp.regs[REG_EPC],
-                      buffer, size, &skip);
+#ifdef CONFIG_ARCH_KERNEL_STACK
+      if (tcb->xcp.ustkptr != NULL)
+        {
+          ret = backtrace(tcb->stack_base_ptr,
+                          tcb->stack_base_ptr + tcb->adj_stack_size,
+                          (void *)*(tcb->xcp.ustkptr + 1), NULL,
+                          buffer, size, &skip);
+        }
+      else
+#endif
+        {
+          ret = backtrace(tcb->stack_base_ptr,
+                          tcb->stack_base_ptr + tcb->adj_stack_size,
+                          (void *)tcb->xcp.regs[REG_FP],
+                          (void *)tcb->xcp.regs[REG_EPC],
+                          buffer, size, &skip);
+        }
 
       leave_critical_section(flags);
     }


### PR DESCRIPTION
## Summary

risc-v/backtrace: correct stack pointer if enable ARCH_KERNEL_STACK

## Impact

N/A

## Testing

backtrace test on:
./tools/configure.sh  rv-virt/knetnsh64

```
nsh> dumpstack 5
elf_addrenv_alloc: 134, textalloc: 0xc0000000
[    1.660000] backtrace| 5: 0x00000000c0000a42 0x00000000c0000abe 0x00000000c0000a02 0x000000008000c89a 0x0000000080004d76
```
```
$ riscv64-unknown-elf-addr2line -e bin/dumpstack  0x000000000000a42 0x000000000000abe 0x000000000000a02
/home/archer/code/nuttx/n10/apps/system/dumpstack/dumpstack.c:63 (discriminator 1)
/home/archer/code/nuttx/n10/apps/system/dumpstack/dumpstack.c:92
/home/archer/code/nuttx/n10/incubator-nuttx/arch/risc-v/src/common/crt0.c:191
```



```
riscv64-unknown-elf-addr2line -e nuttx 0x00000000c0000a42 0x00000000c0000abe 0x00000000c0000a02 0x000000008000c89a 0x0000000080004d76
??:0
??:0
??:0
/home/archer/code/nuttx/n10/incubator-nuttx/arch/risc-v/src/common/riscv_task_start.c:71
/home/archer/code/nuttx/n10/incubator-nuttx/sched/task/exit.c:54
```