### PR TITLE
net/icmp: Save poll device in icmp_poll_s

### DIFF
--- a/net/icmp/icmp.h
+++ b/net/icmp/icmp.h
@@ -69,6 +69,7 @@ struct devif_callback_s;         /* Forward reference */
 struct icmp_poll_s
 {
   FAR struct socket *psock;        /* IPPROTO_ICMP socket structure */
+  FAR struct net_driver_s *dev;    /* Needed to free the callback structure */
   FAR struct pollfd *fds;          /* Needed to handle poll events */
   FAR struct devif_callback_s *cb; /* Needed to teardown the poll */
 };

--- a/net/icmp/icmp_netpoll.c
+++ b/net/icmp/icmp_netpoll.c
@@ -181,6 +181,7 @@ int icmp_pollsetup(FAR struct socket *psock, FAR struct pollfd *fds)
   /* Initialize the poll info container */
 
   info->psock = psock;
+  info->dev   = conn->dev;
   info->fds   = fds;
   info->cb    = cb;
 
@@ -272,7 +273,7 @@ int icmp_pollteardown(FAR struct socket *psock, FAR struct pollfd *fds)
     {
       /* Release the callback */
 
-      icmp_callback_free(conn->dev, conn, info->cb);
+      icmp_callback_free(info->dev, conn, info->cb);
 
       /* Release the poll/select data slot */
 


### PR DESCRIPTION
## Summary
ICMP's `conn->dev` is changing in `icmp_sendmsg`, when sending to different address, or when error occurs (like `NETDEV_DOWN`). Then the poll callback cannot be dropped from previous `dev` in `icmp_callback_free`, because the `dev` is wrong.

So add `dev` to `struct icmp_poll_s` just like `struct udp_poll_s`.

## Impact

## Testing
Manually / CI

