### PR TITLE
arch/riscv: Store user context into the kernel stack

### DIFF
--- a/arch/arm/src/armv7-a/arm_initialstate.c
+++ b/arch/arm/src/armv7-a/arm_initialstate.c
@@ -54,6 +54,9 @@ void up_initial_state(struct tcb_s *tcb)
 {
   struct xcptcontext *xcp = &tcb->xcp;
   uint32_t cpsr;
+#ifdef CONFIG_ARCH_KERNEL_STACK
+  uint32_t *kstack = xcp->kstack;
+#endif
 
   /* Initialize the initial exception register context structure */
 
@@ -79,6 +82,10 @@ void up_initial_state(struct tcb_s *tcb)
 
       return;
     }
+
+#ifdef CONFIG_ARCH_KERNEL_STACK
+  xcp->kstack = kstack;
+#endif
 
   /* Initialize the context registers to stack top */
 

--- a/arch/risc-v/include/irq.h
+++ b/arch/risc-v/include/irq.h
@@ -557,6 +557,7 @@ struct xcptcontext
 
   uintptr_t *ustkptr;  /* Saved user stack pointer */
   uintptr_t *kstack;   /* Allocate base of the (aligned) kernel stack */
+  uintptr_t *ktopstk;  /* Top of kernel stack */
   uintptr_t *kstkptr;  /* Saved kernel stack pointer */
 #endif
 #endif

--- a/arch/risc-v/src/common/Make.defs
+++ b/arch/risc-v/src/common/Make.defs
@@ -97,7 +97,7 @@ CMN_CSRCS += riscv_mmu.c
 endif
 
 ifeq ($(CONFIG_ARCH_KERNEL_STACK),y)
-CMN_CSRCS += riscv_addrenv_kstack.c
+CMN_CSRCS += riscv_addrenv_kstack.c riscv_ksp.c
 endif
 
 ifeq ($(CONFIG_ARCH_ADDRENV),y)

--- a/arch/risc-v/src/common/riscv_exception_common.S
+++ b/arch/risc-v/src/common/riscv_exception_common.S
@@ -32,24 +32,22 @@
 
 #include "chip.h"
 
+#include "riscv_percpu.h"
+
 #include "riscv_macros.S"
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* Using address environments currently require that a common interrupt stack
- * is in place. This is needed because during context switch the procedure
- * that swaps the active address environment is dependent on a stack, which
- * must be a 'neutral' stack.
- *
- * Another option would be to use a per-process kernel stack, but full
- * support for this is not yet in place, so use the common IRQ stack instead.
+/* Using address environments requires that the per-process kernel stack is
+ * enabled. Using user stack to run exception and/or kernel code is a very
+ * very bad idea, thus enforce the kernel stack
  */
 
 #ifdef CONFIG_ARCH_ADDRENV
-#  if CONFIG_ARCH_INTERRUPTSTACK == 0 && !defined(CONFIG_ARCH_KERNEL_STACK)
-#    error "IRQ or kernel stack is needed for swapping address environments"
+#  ifndef CONFIG_ARCH_KERNEL_STACK
+#    error "Kernel stack is needed for handling exceptions"
 #  endif
 #endif
 
@@ -78,13 +76,38 @@
 
 exception_common:
 
+#ifdef CONFIG_ARCH_KERNEL_STACK
+  /* Take the kernel stack into use */
+
+  csrrw      a0, CSR_SCRATCH, a0
+  REGSTORE   sp, RISCV_PERCPU_USP(a0)
+  REGLOAD    sp, RISCV_PERCPU_KSP(a0)
+  REGSTORE   x0, RISCV_PERCPU_KSP(a0)
+  bnez       sp, 1f
+
+  /* No kernel stack, exception comes from kernel */
+
+  REGLOAD    sp, RISCV_PERCPU_USP(a0)
+
+1:
+  /* Restore the per-cpu structure */
+
+  csrrw      a0, CSR_SCRATCH, a0
+#endif
+
   addi       sp, sp, -XCPTCONTEXT_SIZE
   save_ctx   sp
 
   csrr       s0, CSR_STATUS
   REGSTORE   s0, REG_INT_CTX(sp)  /* status */
 
+#ifdef CONFIG_ARCH_KERNEL_STACK
+  csrr       s0, CSR_SCRATCH
+  REGLOAD    s0, RISCV_PERCPU_USP(s0)
+#else
   addi       s0, sp, XCPTCONTEXT_SIZE
+#endif
+
   REGSTORE   s0, REG_X2(sp)       /* original SP */
 
   csrr       s0, CSR_EPC
@@ -132,6 +155,22 @@ exception_common:
 
   REGLOAD    s0, REG_INT_CTX(sp)  /* restore sstatus */
   csrw       CSR_STATUS, s0
+
+#ifdef CONFIG_ARCH_KERNEL_STACK
+  /* Returning to userspace ? */
+
+  li         s1, STATUS_PPP
+  and        s0, s0, s1
+  bnez       s0, 1f
+
+  /* Set the next task's kernel stack to the scratch area */
+
+  jal        x1, riscv_current_ksp
+  csrr       s0, CSR_SCRATCH
+  REGSTORE   a0, RISCV_PERCPU_KSP(s0)
+
+1:
+#endif
 
   load_ctx   sp
 

--- a/arch/risc-v/src/common/riscv_initialstate.c
+++ b/arch/risc-v/src/common/riscv_initialstate.c
@@ -56,6 +56,9 @@ void up_initial_state(struct tcb_s *tcb)
 {
   struct xcptcontext *xcp = &tcb->xcp;
   uintptr_t regval;
+#ifdef CONFIG_ARCH_KERNEL_STACK
+  uintptr_t *kstack = xcp->kstack;
+#endif
 
   /* Initialize the initial exception register context structure */
 
@@ -84,6 +87,10 @@ void up_initial_state(struct tcb_s *tcb)
       riscv_set_idleintctx();
       return;
     }
+
+#ifdef CONFIG_ARCH_KERNEL_STACK
+  xcp->kstack = kstack;
+#endif
 
   xcp->regs = (uintptr_t *)(
     (uintptr_t)tcb->stack_base_ptr + tcb->adj_stack_size - XCPTCONTEXT_SIZE);

--- a/arch/risc-v/src/common/riscv_ksp.c
+++ b/arch/risc-v/src/common/riscv_ksp.c
@@ -1,0 +1,36 @@
+/****************************************************************************
+ * arch/risc-v/src/common/riscv_ksp.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdint.h>
+
+#include <nuttx/sched.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+uintptr_t riscv_current_ksp(void)
+{
+  return (uintptr_t)nxsched_self()->xcp.kstkptr;
+}

--- a/arch/risc-v/src/common/riscv_percpu.c
+++ b/arch/risc-v/src/common/riscv_percpu.c
@@ -192,3 +192,35 @@ uintptr_t riscv_percpu_get_irqstack(void)
 
   return ((riscv_percpu_t *)scratch)->irq_stack;
 }
+
+/****************************************************************************
+ * Name: riscv_percpu_set_kstack
+ *
+ * Description:
+ *   Set current kernel stack, so it can be taken quickly into use when a
+ *   trap is taken. Do this whenever a new process moves to running state.
+ *
+ * Input Parameters:
+ *   ksp - Pointer to the kernel stack
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void riscv_percpu_set_kstack(uintptr_t ksp)
+{
+  irqstate_t flags;
+  uintptr_t scratch;
+
+  /* This must be done with interrupts disabled */
+
+  flags   = enter_critical_section();
+  scratch = READ_CSR(CSR_SCRATCH);
+
+  DEBUGASSERT(scratch >= (uintptr_t) &g_percpu &&
+              scratch <  (uintptr_t) &g_percpu + sizeof(g_percpu));
+
+  ((riscv_percpu_t *)scratch)->ksp = ksp;
+  leave_critical_section(flags);
+}

--- a/arch/risc-v/src/common/riscv_percpu.h
+++ b/arch/risc-v/src/common/riscv_percpu.h
@@ -50,6 +50,8 @@
 #define RISCV_PERCPU_LIST       (0 * INT_REG_SIZE)
 #define RISCV_PERCPU_HARTID     (1 * INT_REG_SIZE)
 #define RISCV_PERCPU_IRQSTACK   (2 * INT_REG_SIZE)
+#define RISCV_PERCPU_USP        (3 * INT_REG_SIZE)
+#define RISCV_PERCPU_KSP        (4 * INT_REG_SIZE)
 
 #ifndef __ASSEMBLY__
 
@@ -68,6 +70,8 @@ struct riscv_percpu_s
   struct riscv_percpu_s *next;      /* For sl list linkage */
   uintptr_t              hartid;    /* Hart ID */
   uintptr_t              irq_stack; /* Interrupt stack */
+  uintptr_t              usp;       /* Area to store user sp */
+  uintptr_t              ksp;       /* Area to load kernel sp */
 };
 
 typedef struct riscv_percpu_s riscv_percpu_t;
@@ -115,6 +119,23 @@ uintptr_t riscv_percpu_get_hartid(void);
  ****************************************************************************/
 
 uintptr_t riscv_percpu_get_irqstack(void);
+
+/****************************************************************************
+ * Name: riscv_percpu_set_kstack
+ *
+ * Description:
+ *   Set current kernel stack, so it can be taken quickly into use when a
+ *   trap is taken.
+ *
+ * Input Parameters:
+ *   ksp - Pointer to the kernel stack
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void riscv_percpu_set_kstack(uintptr_t ksp);
 
 #endif /* __ASSEMBLY__ */
 #endif /* __ARCH_RISC_V_SRC_COMMON_RISCV_PERCPU_H */

--- a/arch/risc-v/src/common/supervisor/riscv_syscall.S
+++ b/arch/risc-v/src/common/supervisor/riscv_syscall.S
@@ -146,6 +146,22 @@ sys_call6:
 1:
   csrw       CSR_STATUS, s0
 
+#ifdef CONFIG_ARCH_KERNEL_STACK
+  /* Returning to userspace ? */
+
+  li         s1, STATUS_PPP
+  and        s0, s0, s1
+  bnez       s0, 1f
+
+  /* Set the next task's kernel stack to the scratch area */
+
+  jal        x1, riscv_current_ksp
+  csrr       s0, CSR_SCRATCH
+  REGSTORE   a0, RISCV_PERCPU_KSP(s0)
+
+1:
+#endif
+
   load_ctx   sp
 
   REGLOAD    sp, REG_SP(sp)            /* restore original sp */

--- a/binfmt/binfmt_execmodule.c
+++ b/binfmt/binfmt_execmodule.c
@@ -186,6 +186,17 @@ int exec_module(FAR struct binary_s *binp,
   umm_initialize(vheap, up_addrenv_heapsize(addrenv));
 #endif
 
+#if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_ARCH_KERNEL_STACK)
+  /* Allocate the kernel stack */
+
+  ret = up_addrenv_kstackalloc(&tcb->cmn);
+  if (ret < 0)
+    {
+      berr("ERROR: up_addrenv_kstackalloc() failed: %d\n", ret);
+      goto errout_with_addrenv;
+    }
+#endif
+
   /* Note that tcb->flags are not modified.  0=normal task */
 
   /* tcb->flags |= TCB_FLAG_TTYPE_TASK; */
@@ -228,17 +239,6 @@ int exec_module(FAR struct binary_s *binp,
           goto errout_with_tcbinit;
         }
     }
-
-#if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_ARCH_KERNEL_STACK)
-  /* Allocate the kernel stack */
-
-  ret = up_addrenv_kstackalloc(&tcb->cmn);
-  if (ret < 0)
-    {
-      berr("ERROR: up_addrenv_kstackalloc() failed: %d\n", ret);
-      goto errout_with_tcbinit;
-    }
-#endif
 
 #ifdef CONFIG_PIC
   /* Add the D-Space address as the PIC base address.  By convention, this

--- a/sched/pthread/pthread_create.c
+++ b/sched/pthread/pthread_create.c
@@ -253,6 +253,18 @@ int nx_pthread_create(pthread_trampoline_t trampoline, FAR pthread_t *thread,
       goto errout_with_tcb;
     }
 
+#if defined(CONFIG_ARCH_ADDRENV) && \
+    defined(CONFIG_BUILD_KERNEL) && defined(CONFIG_ARCH_KERNEL_STACK)
+  /* Allocate the kernel stack */
+
+  ret = up_addrenv_kstackalloc(&ptcb->cmn);
+  if (ret < 0)
+    {
+      errcode = ENOMEM;
+      goto errout_with_tcb;
+    }
+#endif
+
   /* Initialize thread local storage */
 
   ret = tls_init_info(&ptcb->cmn);
@@ -368,18 +380,6 @@ int nx_pthread_create(pthread_trampoline_t trampoline, FAR pthread_t *thread,
       errcode = EBUSY;
       goto errout_with_tcb;
     }
-
-#if defined(CONFIG_ARCH_ADDRENV) && \
-    defined(CONFIG_BUILD_KERNEL) && defined(CONFIG_ARCH_KERNEL_STACK)
-  /* Allocate the kernel stack */
-
-  ret = up_addrenv_kstackalloc(&ptcb->cmn);
-  if (ret < 0)
-    {
-      errcode = ENOMEM;
-      goto errout_with_tcb;
-    }
-#endif
 
 #ifdef CONFIG_SMP
   /* pthread_setup_scheduler() will set the affinity mask by inheriting the


### PR DESCRIPTION
## Summary
If a kernel stack exists, use that whenever the user process is in
privileged mode, i.e. running an exception or in system call. Previously
the exception context was stored into the user's stack, which is not ideal.

Why?

1. Because the exception entry status (REG_INT_CTX) is needed by the
   kernel, and this is now in user memory which requires that the correct
   user mappings are active when it is accessed.

2. The user must currently account for the exception stack frame (which
   is BIG) in its own stack allocation. Moving the exception context save
   to the kernel stack offloads this responsibility from the user to the
   kernel, which is IMO the correct behavior.

3. The kernel access to user memory is currently allowed without condition,
   however this is not ideal either. The privileged mode status CSR (MSTATUS/SSTATUS) allows
   blocking access to user memory via the STATUS_SUM-bit, which should be
   disabled by default and only enabled when access to user space is really
   needed. This patch allows implementing such features.

Also had to fix arm_initialstate due to execution ordering: the allocated kstack pointer in xcptcontext is wiped by memset if
it is allocated before call to arm_initialstate.
## Impact
Significant, changes the kernel stack functionality entirely, but affects risc-v targets that define:
CONFIG_ARCH_ADDRENV=y 
CONFIG_ARCH_KERNEL_STACK=y

Others are not affected by this.
## Testing
icicle:knsh
