### PR TITLE
mempool:Allocate a chunk for multiple mempool avoid memory fragmentation

### DIFF
--- a/arch/sim/src/sim/sim_heap.c
+++ b/arch/sim/src/sim/sim_heap.c
@@ -381,11 +381,13 @@ void mm_extend(struct mm_heap_s *heap, void *mem, size_t size,
  *
  ****************************************************************************/
 
-int mm_mallinfo(struct mm_heap_s *heap, struct mallinfo *info)
+struct mallinfo mm_mallinfo(struct mm_heap_s *heap)
 {
-  memset(info, 0, sizeof(struct mallinfo));
-  host_mallinfo(&info->aordblks, &info->uordblks);
-  return 0;
+  struct mallinfo info;
+
+  memset(&info, 0, sizeof(struct mallinfo));
+  host_mallinfo(&info.aordblks, &info.uordblks);
+  return info;
 }
 
 /****************************************************************************

--- a/arch/xtensa/include/arch.h
+++ b/arch/xtensa/include/arch.h
@@ -163,7 +163,7 @@ bool xtensa_imm_heapmember(void *mem);
  *
  ****************************************************************************/
 
-int xtensa_imm_mallinfo(struct mallinfo *info);
+struct mallinfo xtensa_imm_mallinfo(void);
 #endif
 
 #undef EXTERN

--- a/arch/xtensa/src/esp32/esp32_imm.c
+++ b/arch/xtensa/src/esp32/esp32_imm.c
@@ -177,9 +177,9 @@ bool xtensa_imm_heapmember(void *mem)
  *
  ****************************************************************************/
 
-int xtensa_imm_mallinfo(struct mallinfo *info)
+struct mallinfo xtensa_imm_mallinfo()
 {
-  return mm_mallinfo(g_iheap, info);
+  return mm_mallinfo(g_iheap);
 }
 
 #endif /* CONFIG_XTENSA_IMEM_USE_SEPARATE_HEAP */

--- a/arch/xtensa/src/esp32/esp32_iramheap.c
+++ b/arch/xtensa/src/esp32/esp32_iramheap.c
@@ -175,7 +175,7 @@ bool esp32_iramheap_heapmember(void *mem)
  *
  ****************************************************************************/
 
-int esp32_iramheap_mallinfo(struct mallinfo *info)
+struct mallinfo esp32_iramheap_mallinfo(void)
 {
-  return mm_mallinfo(g_iramheap, info);
+  return mm_mallinfo(g_iramheap);
 }

--- a/arch/xtensa/src/esp32/esp32_iramheap.h
+++ b/arch/xtensa/src/esp32/esp32_iramheap.h
@@ -136,7 +136,7 @@ bool esp32_iramheap_heapmember(void *mem);
  *
  ****************************************************************************/
 
-int esp32_iramheap_mallinfo(struct mallinfo *info);
+struct mallinfo esp32_iramheap_mallinfo(void);
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/arch/xtensa/src/esp32/esp32_rtcheap.c
+++ b/arch/xtensa/src/esp32/esp32_rtcheap.c
@@ -185,7 +185,7 @@ bool esp32_rtcheap_heapmember(void *mem)
  *
  ****************************************************************************/
 
-int esp32_rtcheap_mallinfo(struct mallinfo *info)
+struct mallinfo esp32_rtcheap_mallinfo(void)
 {
-  return mm_mallinfo(g_rtcheap, info);
+  return mm_mallinfo(g_rtcheap);
 }

--- a/arch/xtensa/src/esp32/esp32_rtcheap.h
+++ b/arch/xtensa/src/esp32/esp32_rtcheap.h
@@ -139,7 +139,7 @@ bool esp32_rtcheap_heapmember(void *mem);
  *
  ****************************************************************************/
 
-int esp32_rtcheap_mallinfo(struct mallinfo *info);
+struct mallinfo esp32_rtcheap_mallinfo(void);
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/fs/procfs/fs_procfsmeminfo.c
+++ b/fs/procfs/fs_procfsmeminfo.c
@@ -313,7 +313,7 @@ static ssize_t meminfo_read(FAR struct file *filep, FAR char *buffer,
 
           /* Show heap information */
 
-          mm_mallinfo(entry->heap, &minfo);
+          minfo      = mm_mallinfo(entry->heap);
           linesize   = procfs_snprintf(procfile->line, MEMINFO_LINELEN,
                                        "%12s:%11lu%11lu%11lu%11lu%7lu%7lu\n",
                                        entry->name,

--- a/include/nuttx/mm/mempool.h
+++ b/include/nuttx/mm/mempool.h
@@ -60,6 +60,8 @@ typedef CODE FAR void *(*mempool_multiple_alloc_t)(FAR void *arg,
                                                    size_t alignment,
                                                    size_t size);
 typedef CODE void (*mempool_multiple_free_t)(FAR void *arg, FAR void *addr);
+typedef CODE size_t (*mempool_multiple_alloc_size_t)(FAR void *arg,
+                                                     FAR void *addr);
 
 typedef CODE void (mempool_multiple_foreach_t)(FAR struct mempool_s *pool,
                                                FAR void *arg);
@@ -320,6 +322,7 @@ void mempool_procfs_unregister(FAR struct mempool_procfs_entry_s *entry);
  *   poolsize        - The block size array for pools in multiples pool.
  *   npools          - How many pools in multiples pool.
  *   alloc           - The alloc memory function for multiples pool.
+ *   alloc_size      - Get the address size of the alloc function.
  *   free            - The free memory function for multiples pool.
  *   arg             - The alloc & free memory fuctions used arg.
  *   chunksize       - The multiples pool chunk size.
@@ -337,6 +340,7 @@ FAR struct mempool_multiple_s *
 mempool_multiple_init(FAR const char *name,
                       FAR size_t *poolsize, size_t npools,
                       mempool_multiple_alloc_t alloc,
+                      mempool_multiple_alloc_size_t alloc_size,
                       mempool_multiple_free_t free, FAR void *arg,
                       size_t chunksize, size_t expandsize,
                       size_t dict_expendsize);
@@ -491,6 +495,15 @@ void mempool_multiple_deinit(FAR struct mempool_multiple_s *mpool);
 void mempool_multiple_foreach(FAR struct mempool_multiple_s *mpool,
                               mempool_multiple_foreach_t handle,
                               FAR void *arg);
+
+/****************************************************************************
+ * Name: mempool_multiple_mallinfo
+ * Description:
+ *   mallinfo returns a copy of updated current multiples pool information.
+ ****************************************************************************/
+
+struct mallinfo
+mempool_multiple_mallinfo(FAR struct mempool_multiple_s *mpool);
 
 /****************************************************************************
  * Name: mempool_multiple_info_task

--- a/include/nuttx/mm/mempool.h
+++ b/include/nuttx/mm/mempool.h
@@ -322,6 +322,7 @@ void mempool_procfs_unregister(FAR struct mempool_procfs_entry_s *entry);
  *   alloc           - The alloc memory function for multiples pool.
  *   free            - The free memory function for multiples pool.
  *   arg             - The alloc & free memory fuctions used arg.
+ *   chunksize       - The multiples pool chunk size.
  *   expandsize      - The expend mempry for all pools in multiples pool.
  *   dict_expendsize - The expend size for multiple dictnoary.
  * Returned Value:
@@ -336,8 +337,8 @@ FAR struct mempool_multiple_s *
 mempool_multiple_init(FAR const char *name,
                       FAR size_t *poolsize, size_t npools,
                       mempool_multiple_alloc_t alloc,
-                      mempool_multiple_free_t free,
-                      FAR void *arg, size_t expandsize,
+                      mempool_multiple_free_t free, FAR void *arg,
+                      size_t chunksize, size_t expandsize,
                       size_t dict_expendsize);
 
 /****************************************************************************

--- a/include/nuttx/mm/mm.h
+++ b/include/nuttx/mm/mm.h
@@ -315,7 +315,7 @@ void kmm_extend(FAR void *mem, size_t size, int region);
 /* Functions contained in mm_mallinfo.c *************************************/
 
 struct mallinfo; /* Forward reference */
-int mm_mallinfo(FAR struct mm_heap_s *heap, FAR struct mallinfo *info);
+struct mallinfo mm_mallinfo(FAR struct mm_heap_s *heap);
 struct mallinfo_task; /* Forward reference */
 struct mallinfo_task mm_mallinfo_task(FAR struct mm_heap_s *heap,
                                       FAR const struct mm_memdump_s *dump);

--- a/mm/Kconfig
+++ b/mm/Kconfig
@@ -207,7 +207,7 @@ config MM_HEAP_MEMPOOL_THRESHOLD
 		than the threshold, the memory will be requested from the
 		multiple mempool by default.
 
-config MM_HEAP_MEMPOOL_EXPAND
+config MM_HEAP_MEMPOOL_EXPAND_SIZE
 	int "The expand size for each mempool in multiple mempool"
 	default 4096
 	depends on MM_HEAP_MEMPOOL_THRESHOLD != 0
@@ -215,12 +215,19 @@ config MM_HEAP_MEMPOOL_EXPAND
 		This size describes the size of each expansion of each memory
 		pool with insufficient memory in the multi-level memory pool.
 
-config MM_HEAP_MEMPOOL_DICTIONARY_EXPAND
+config MM_HEAP_MEMPOOL_DICTIONARY_EXPAND_SIZE
 	int "The expand size for multiple mempool's dictonary"
-	default MM_HEAP_MEMPOOL_EXPAND
+	default MM_HEAP_MEMPOOL_EXPAND_SIZE
 	depends on MM_HEAP_MEMPOOL_THRESHOLD != 0
 	---help---
 		This size describes the multiple mempool dictonary expend.
+
+config MM_HEAP_MEMPOOL_CHUNK_SIZE
+	int "The multiples pool chunk size"
+	default 0
+	depends on MM_HEAP_MEMPOOL_THRESHOLD != 0
+	---help---
+		This size describes the multiple mempool chunk size.
 
 config FS_PROCFS_EXCLUDE_MEMPOOL
 	bool "Exclude mempool"

--- a/mm/kmm_heap/kmm_mallinfo.c
+++ b/mm/kmm_heap/kmm_mallinfo.c
@@ -45,9 +45,7 @@
 
 struct mallinfo kmm_mallinfo(void)
 {
-  struct mallinfo info;
-  mm_mallinfo(g_kmmheap, &info);
-  return info;
+  return mm_mallinfo(g_kmmheap);
 }
 
 /****************************************************************************

--- a/mm/mempool/mempool_multiple.c
+++ b/mm/mempool/mempool_multiple.c
@@ -63,17 +63,21 @@ struct mpool_chunk_s
 
 struct mempool_multiple_s
 {
-  FAR struct mempool_s    *pools;       /* The memory pool array */
-  size_t                   npools;      /* The number of memory pool array elements */
-  size_t                   expandsize;  /* The number not will use it to init erery
-                                         * pool expandsize
-                                         */
-  size_t                   minpoolsize; /* The number is align for each memory pool */
-  FAR void                *arg;         /* This pointer is used to store the user's
-                                         * private data
-                                         */
-  mempool_multiple_alloc_t alloc;       /* The alloc function for mempool */
-  mempool_multiple_free_t  free;        /* The free function for mempool */
+  FAR struct mempool_s         *pools;       /* The memory pool array */
+  size_t                        npools;      /* The number of memory pool array elements */
+  size_t                        expandsize;  /* The number not will use it to init erery
+                                              * pool expandsize
+                                              */
+  size_t                        minpoolsize; /* The number is align for each memory pool */
+  FAR void                     *arg;         /* This pointer is used to store the user's
+                                              * private data
+                                              */
+  mempool_multiple_alloc_t      alloc;       /* The alloc function for mempool */
+  mempool_multiple_alloc_size_t alloc_size;  /* Get the address size of the
+                                              * alloc function
+                                              */
+  mempool_multiple_free_t       free;        /* The free function for mempool */
+  size_t                        alloced;     /* Total size of alloc */
 
   /* This delta describes the relationship between the block size of each
    * mempool in multiple mempool by user initialized. It is automatically
@@ -82,19 +86,19 @@ struct mempool_multiple_s
    * arithmetic progressions, otherwise it is an increasing progressions.
    */
 
-  size_t                   delta;
+  size_t                        delta;
 
   /* It is used to record the information recorded by the mempool during
    * expansion, and find the mempool by adding an index
    */
 
-  mutex_t                   lock;
-  sq_queue_t                chunk_queue;
-  size_t                    chunk_size;
-  size_t                    dict_used;
-  size_t                    dict_col_num_log2;
-  size_t                    dict_row_num;
-  FAR struct mpool_dict_s **dict;
+  mutex_t                       lock;
+  sq_queue_t                    chunk_queue;
+  size_t                        chunk_size;
+  size_t                        dict_used;
+  size_t                        dict_col_num_log2;
+  size_t                        dict_row_num;
+  FAR struct mpool_dict_s     **dict;
 };
 
 /****************************************************************************
@@ -157,7 +161,13 @@ mempool_multiple_alloc_chunk(FAR struct mempool_multiple_s *mpool,
 
   if (mpool->chunk_size < mpool->expandsize)
     {
-      return mpool->alloc(mpool->arg, align, size);
+      ret = mpool->alloc(mpool->arg, align, size);
+      if (ret)
+        {
+          mpool->alloced += mpool->alloc_size(mpool->arg, ret);
+        }
+
+      return ret;
     }
 
   chunk = (FAR struct mpool_chunk_s *)sq_peek(&mpool->chunk_queue);
@@ -173,6 +183,7 @@ retry:
           return NULL;
         }
 
+      mpool->alloced += mpool->alloc_size(mpool->arg, tmp);
       chunk = (FAR struct mpool_chunk_s *)(tmp + mpool->chunk_size);
       chunk->end = tmp + mpool->chunk_size;
       chunk->start = tmp;
@@ -345,6 +356,7 @@ mempool_multiple_get_dict(FAR struct mempool_multiple_s *mpool,
  *   poolsize        - The block size array for pools in multiples pool.
  *   npools          - How many pools in multiples pool.
  *   alloc           - The alloc memory function for multiples pool.
+ *   alloc_size      - Get the address size of the alloc function.
  *   free            - The free memory function for multiples pool.
  *   arg             - The alloc & free memory fuctions used arg.
  *   chunksize       - The multiples pool chunk size.
@@ -360,6 +372,7 @@ FAR struct mempool_multiple_s *
 mempool_multiple_init(FAR const char *name,
                       FAR size_t *poolsize, size_t npools,
                       mempool_multiple_alloc_t alloc,
+                      mempool_multiple_alloc_size_t alloc_size,
                       mempool_multiple_free_t free, FAR void *arg,
                       size_t chunksize, size_t expandsize,
                       size_t dict_expendsize)
@@ -397,11 +410,13 @@ mempool_multiple_init(FAR const char *name,
       return NULL;
     }
 
+  mpool->alloc_size = alloc_size;
   mpool->expandsize = expandsize;
   mpool->chunk_size = chunksize;
   mpool->alloc = alloc;
   mpool->free = free;
   mpool->arg = arg;
+  mpool->alloced = alloc_size(arg, mpool);
   sq_init(&mpool->chunk_queue);
   pools = mempool_multiple_alloc_chunk(mpool, sizeof(uintptr_t),
                                        npools * sizeof(struct mempool_s));
@@ -701,6 +716,50 @@ void mempool_multiple_foreach(FAR struct mempool_multiple_s *mpool,
     {
       handle(mpool->pools + i, arg);
     }
+}
+
+/****************************************************************************
+ * Name: mempool_multiple_mallinfo
+ ****************************************************************************/
+
+struct mallinfo
+mempool_multiple_mallinfo(FAR struct mempool_multiple_s *mpool)
+{
+  struct mallinfo info;
+  size_t i;
+
+  memset(&info, 0, sizeof(struct mallinfo));
+
+  nxmutex_lock(&mpool->lock);
+  info.arena = mpool->alloced;
+
+  if (mpool->chunk_size >= mpool->expandsize)
+    {
+      FAR struct mpool_chunk_s *chunk;
+
+      chunk = (FAR struct mpool_chunk_s *)sq_peek(&mpool->chunk_queue);
+      info.fordblks += chunk->end - chunk->next;
+    }
+
+  nxmutex_unlock(&mpool->lock);
+
+  for (i = 0; i < mpool->npools; i++)
+    {
+      struct mempoolinfo_s poolinfo;
+
+      mempool_info(mpool->pools + i, &poolinfo);
+      info.fordblks += (poolinfo.ordblks + poolinfo.iordblks)
+                       * poolinfo.sizeblks;
+      info.ordblks += poolinfo.ordblks + poolinfo.iordblks;
+      info.aordblks += poolinfo.aordblks;
+      if (info.mxordblk < poolinfo.sizeblks)
+        {
+          info.mxordblk = poolinfo.sizeblks;
+        }
+    }
+
+  info.uordblks += mpool->alloced - info.fordblks;
+  return info;
 }
 
 /****************************************************************************

--- a/mm/mm_heap/mm_initialize.c
+++ b/mm/mm_heap/mm_initialize.c
@@ -287,10 +287,11 @@ FAR struct mm_heap_s *mm_initialize(FAR const char *name,
     }
 
   heap->mm_mpool = mempool_multiple_init(name, poolsize, MEMPOOL_NPOOLS,
-                                  (mempool_multiple_alloc_t)mempool_memalign,
-                                  (mempool_multiple_free_t)mm_free, heap,
-                                  CONFIG_MM_HEAP_MEMPOOL_EXPAND,
-                                  CONFIG_MM_HEAP_MEMPOOL_DICTIONARY_EXPAND);
+                              (mempool_multiple_alloc_t)mempool_memalign,
+                              (mempool_multiple_free_t)mm_free, heap,
+                              CONFIG_MM_HEAP_MEMPOOL_CHUNK_SIZE,
+                              CONFIG_MM_HEAP_MEMPOOL_EXPAND_SIZE,
+                              CONFIG_MM_HEAP_MEMPOOL_DICTIONARY_EXPAND_SIZE);
 #endif
 
   return heap;

--- a/mm/mm_heap/mm_initialize.c
+++ b/mm/mm_heap/mm_initialize.c
@@ -288,6 +288,7 @@ FAR struct mm_heap_s *mm_initialize(FAR const char *name,
 
   heap->mm_mpool = mempool_multiple_init(name, poolsize, MEMPOOL_NPOOLS,
                               (mempool_multiple_alloc_t)mempool_memalign,
+                              (mempool_multiple_alloc_size_t)mm_malloc_size,
                               (mempool_multiple_free_t)mm_free, heap,
                               CONFIG_MM_HEAP_MEMPOOL_CHUNK_SIZE,
                               CONFIG_MM_HEAP_MEMPOOL_EXPAND_SIZE,

--- a/mm/mm_heap/mm_malloc.c
+++ b/mm/mm_heap/mm_malloc.c
@@ -282,7 +282,7 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
 
       mwarn("WARNING: Allocation failed, size %zu\n", alignsize);
 #ifdef CONFIG_MM_DUMP_ON_FAILURE
-      mm_mallinfo(heap, &minfo);
+      minfo = mm_mallinfo(heap);
       mwarn("Total:%d, used:%d, free:%d, largest:%d, nused:%d, nfree:%d\n",
             minfo.arena, minfo.uordblks, minfo.fordblks,
             minfo.mxordblk, minfo.aordblks, minfo.ordblks);

--- a/mm/tlsf/mm_tlsf.c
+++ b/mm/tlsf/mm_tlsf.c
@@ -844,10 +844,11 @@ FAR struct mm_heap_s *mm_initialize(FAR const char *name,
     }
 
   heap->mm_mpool = mempool_multiple_init(name, poolsize, MEMPOOL_NPOOLS,
-                                  (mempool_multiple_alloc_t)mempool_memalign,
-                                  (mempool_multiple_free_t)mm_free, heap,
-                                  CONFIG_MM_HEAP_MEMPOOL_EXPAND,
-                                  CONFIG_MM_HEAP_MEMPOOL_DICTIONARY_EXPAND);
+                              (mempool_multiple_alloc_t)mempool_memalign,
+                              (mempool_multiple_free_t)mm_free, heap,
+                              CONFIG_MM_HEAP_MEMPOOL_CHUNK_SIZE,
+                              CONFIG_MM_HEAP_MEMPOOL_EXPAND_SIZE,
+                              CONFIG_MM_HEAP_MEMPOOL_DICTIONARY_EXPAND_SIZE);
 #endif
 
   return heap;

--- a/mm/umm_heap/umm_mallinfo.c
+++ b/mm/umm_heap/umm_mallinfo.c
@@ -45,9 +45,7 @@
 
 struct mallinfo mallinfo(void)
 {
-  struct mallinfo info;
-  mm_mallinfo(USR_HEAP, &info);
-  return info;
+  return mm_mallinfo(USR_HEAP);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
Allocate a chunk for multiple mempool avoid memory fragmentation,And calculate the consumption of mempool in the memory statistics
## Impact
mempool
## Testing
sim:nsh with testing_mm
