### PR TITLE
stm32: Removed unused STM32_TICKLESS_SYSTICK Kconfig option.

### DIFF
--- a/arch/arm/src/stm32/Kconfig
+++ b/arch/arm/src/stm32/Kconfig
@@ -3799,13 +3799,6 @@ config STM32_EXTERNAL_RAM
 	---help---
 		In addition to internal SRAM, external RAM may be available through the FSMC/FMC.
 
-config STM32_TICKLESS_SYSTICK
-	bool "Tickless via SysTick"
-	default n
-	depends on SCHED_TICKLESS
-	---help---
-		Use SysTick as Tickless clock.
-
 menu "Timer Configuration"
 	depends on STM32_TIM
 
@@ -3815,7 +3808,6 @@ config STM32_TICKLESS_TIMER
 	int "Tickless hardware timer"
 	default 2
 	range 1 14
-	depends on !STM32_TICKLESS_SYSTICK
 	---help---
 		If the Tickless OS feature is enabled, then one clock must be
 		assigned to provided the timer needed by the OS.


### PR DESCRIPTION
## Summary

The option STM32_TICKLESS_SYSTICK is not used anywhere and the stm32 arch does not have the capability to use systick as a tickless timer.

This PR just removes this dead option.

*Also see [here](https://lists.apache.org/thread/bjg7m2rvo45chym6t3knqfjotzfd8jgx).*

## Impact

Clean-up.

## Testing

N/A.