### PR TITLE
Fixed Kconfig options for obsolete tickless systick options.

### DIFF
--- a/arch/arm/src/gd32f4/Kconfig
+++ b/arch/arm/src/gd32f4/Kconfig
@@ -698,7 +698,6 @@ config GD32F4_TICKLESS_TIMER
 	int "Tickless by hardware timer"
 	default 1
 	range 0 13
-	depends on !GD32F4_TICKLESS_SYSTICK
 	---help---
 		If the Tickless OS feature is enabled, then one clock must be
 		assigned to provided the timer needed by the OS.

--- a/arch/arm/src/stm32wb/Kconfig
+++ b/arch/arm/src/stm32wb/Kconfig
@@ -724,7 +724,6 @@ config STM32WB_TICKLESS_TIMER
 	int "Tickless hardware timer"
 	default 2
 	range 1 17
-	depends on !STM32WB_TICKLESS_SYSTICK
 	---help---
 		If the Tickless OS feature is enabled, then one clock must be
 		assigned to provided the timer needed by the OS.


### PR DESCRIPTION
## Summary

Fixed Kconfig options for the obsolete GD32F4_TICKLESS_SYSTICK & STM32WB_TICKLESS_SYSTICK options.

See [here](https://github.com/apache/nuttx/pull/9491#issuecomment-1580784797).

## Impact

Clean-up.

## Testing

N/A
