### PR TITLE
assert: disable function/line print if DEBUG_ASSERTIONS_FILENAME disabled

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -665,6 +665,15 @@ config DEBUG_ASSERTIONS_EXPRESSION
 		function when it is triggered. This option maybe will take up a lot
 		of space.
 
+config DEBUG_ASSERTIONS_FILENAME
+	bool "Enable Debug Assertions show file name"
+	default !DEFAULT_SMALL
+	depends on DEBUG_ASSERTIONS
+	---help---
+		This option can display the file information of the ASSERT()
+		function when it is enabled. This option maybe will take up a lot
+		of space.
+
 comment "Subsystem Debug Options"
 
 config DEBUG_AUDIO

--- a/arch/arm/src/arm/arm_dataabort.c
+++ b/arch/arm/src/arm/arm_dataabort.c
@@ -143,7 +143,8 @@ void arm_dataabort(uint32_t *regs, uint32_t far, uint32_t fsr)
 
 segfault:
 #endif
-  _alert("Data abort. PC: %08x FAR: %08x FSR: %08x\n",
+  _alert("Data abort. "
+         "PC: %08" PRIx32 " FAR: %08" PRIx32 " FSR: %08" PRIx32 "\n",
          regs[REG_PC], far, fsr);
   PANIC_WITH_REGS("panic", regs);
 }

--- a/arch/risc-v/src/common/riscv_misaligned.c
+++ b/arch/risc-v/src/common/riscv_misaligned.c
@@ -544,7 +544,7 @@ static bool decode_insn(uintptr_t *regs, riscv_insn_ctx_t *ctx)
         break;
 #endif
       default:
-        _alert("Uncompressed: %x\n", insn.insn);
+        _alert("Uncompressed: %lx\n", insn.insn);
         return false;
     }
 

--- a/include/assert.h
+++ b/include/assert.h
@@ -42,20 +42,25 @@
 #undef DEBUGASSERT  /* Like ASSERT, but only if CONFIG_DEBUG_ASSERTIONS is defined */
 #undef DEBUGVERIFY  /* Like VERIFY, but only if CONFIG_DEBUG_ASSERTIONS is defined */
 
-#ifndef CONFIG_HAVE_FILENAME
-#  define __FILE__ 0
-#  define __LINE__ 0
+#if !defined(CONFIG_HAVE_FILENAME) || !defined(CONFIG_DEBUG_ASSERTIONS_FILENAME)
+#  define __ASSERT_FILE__ 0
+#  define __ASSERT_LINE__ 0
+#else
+#  define __ASSERT_FILE__ __FILE__
+#  define __ASSERT_LINE__ __LINE__
 #endif
 
-#define PANIC() __assert(__FILE__, __LINE__, "panic")
-#define PANIC_WITH_REGS(msg, regs) _assert(__FILE__, __LINE__, msg, regs)
+#define PANIC() __assert(__ASSERT_FILE__, __ASSERT_LINE__, "panic")
+#define PANIC_WITH_REGS(msg, regs) _assert(__ASSERT_FILE__, \
+                                           __ASSERT_LINE__, msg, regs)
 
 #ifdef CONFIG_DEBUG_ASSERTIONS_EXPRESSION
 #  define ASSERT(f)                       \
   do                                      \
     {                                     \
       if (predict_false(!(f)))            \
-        __assert(__FILE__, __LINE__, #f); \
+        __assert(__ASSERT_FILE__,         \
+                 __ASSERT_LINE__, #f);    \
     }                                     \
   while (0)
 
@@ -63,7 +68,8 @@
   do                                      \
     {                                     \
       if (predict_false((f) < 0))         \
-        __assert(__FILE__, __LINE__, #f); \
+        __assert(__ASSERT_FILE__,         \
+                 __ASSERT_LINE__, #f);    \
     }                                     \
   while (0)
 #else
@@ -71,7 +77,8 @@
   do                                      \
     {                                     \
       if (predict_false(!(f)))            \
-        __assert(__FILE__, __LINE__, 0);  \
+        __assert(__ASSERT_FILE__,         \
+                 __ASSERT_LINE__, 0);     \
     }                                     \
   while (0)
 
@@ -79,7 +86,8 @@
   do                                      \
     {                                     \
       if (predict_false((f) < 0))         \
-        __assert(__FILE__, __LINE__, 0);  \
+        __assert(__ASSERT_FILE__,         \
+                 __ASSERT_LINE__, 0);     \
     }                                     \
   while (0)
 #endif

--- a/include/debug.h
+++ b/include/debug.h
@@ -78,7 +78,8 @@
  *    really intended only for crash error reporting.
  */
 
-#if !defined(EXTRA_FMT) && !defined(EXTRA_ARG) && defined(CONFIG_HAVE_FUNCTIONNAME)
+#if !defined(EXTRA_FMT) && !defined(EXTRA_ARG) && \
+    defined(CONFIG_HAVE_FUNCTIONNAME) && !defined(CONFIG_DEFAULT_SMALL)
 #  define EXTRA_FMT "%s: "
 #  define EXTRA_ARG ,__FUNCTION__
 #endif


### PR DESCRIPTION

## Summary

assert: disable function/line print if DEBUG_ASSERTIONS_FILENAME disabled

Test on sim/nsh:
(CONFIG_DEBUG_ASSERTIONS=y CONFIG_DEFAULT_SMALL=y)
```bash
   text	   data	    bss	    dec	    hex	filename
 423626	  27152	   4128	 454906	  6f0fa	nuttx     /* before */
 417010	  27152	   4128	 448290	  6d722	nuttx     /* after */
  -6616
```

## Impact

N/A

## Testing

sim/nsh