### PR TITLE
debug: change generate debug symbols default enable

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1904,7 +1904,7 @@ config HEAP_COLORATION
 
 config DEBUG_SYMBOLS
 	bool "Generate Debug Symbols"
-	default n
+	default y
 	---help---
 		Build with debug symbols (needed for use with a debugger).
 


### PR DESCRIPTION
Since this not occupy actual binary size, so default y for debug used.

## Summary

## Impact

## Testing

