### PR TITLE
is25xp: Enable usage of several chips on the same spi bus

### DIFF
--- a/include/nuttx/mtd/mtd.h
+++ b/include/nuttx/mtd/mtd.h
@@ -429,7 +429,8 @@ FAR struct mtd_dev_s *at25_initialize(FAR struct spi_dev_s *dev);
  *
  ****************************************************************************/
 
-FAR struct mtd_dev_s *is25xp_initialize(FAR struct spi_dev_s *dev);
+FAR struct mtd_dev_s *is25xp_initialize(FAR struct spi_dev_s *dev,
+                                        uint16_t spi_devid);
 
 /****************************************************************************
  * Name: m25p_initialize


### PR DESCRIPTION
## Summary
enable use of several is25 devices per bus

## Impact
none expected if you dont use this chip.

## Testing
The github integration tests are useless to check this change
