### PR TITLE
mpfs/mpfs_shead.S: Remove MMU mappings and flush TLB upon boot

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_shead.S
+++ b/arch/risc-v/src/mpfs/mpfs_shead.S
@@ -84,6 +84,11 @@ __start:
   la  gp, __global_pointer$
 .option pop
 
+  /* Remove MMU mappings (if any) and flush TLB */
+
+  csrw satp, zero
+  sfence.vma x0, x0
+
   /* Make sure the writes to CSR stick before continuing */
 
   fence


### PR DESCRIPTION
## Summary
This fixes warm reset crash when trying to access memory via old stale MMU mappings
## Impact
Fix crash after warm reset
## Testing
icicle:knsh
