### PR TITLE
drivers/ptmx: Fix a potential buffer overflow

### DIFF
--- a/drivers/serial/ptmx.c
+++ b/drivers/serial/ptmx.c
@@ -165,7 +165,7 @@ static int ptmx_minor_allocate(void)
 static int ptmx_open(FAR struct file *filep)
 {
   struct file temp;
-  char devname[16];
+  char devname[32];
   int minor;
   int ret;
 
@@ -202,7 +202,7 @@ static int ptmx_open(FAR struct file *filep)
 
   /* Open the master device:  /dev/ptyN, where N=minor */
 
-  snprintf(devname, 16, "/dev/pty%d", minor);
+  snprintf(devname, sizeof(devname), "/dev/pty%d", minor);
   memcpy(&temp, filep, sizeof(temp));
   ret = file_open(filep, devname, O_RDWR);
   DEBUGASSERT(ret >= 0);  /* file_open() should never fail */


### PR DESCRIPTION

## Summary
Fix warning:
```
serial/ptmx.c:205:34: warning: ‘%d’ directive output may be truncated writing between 1 and 10 bytes into a region of size 8 [-Wformat-truncation=]
  205 |   snprintf(devname, 16, "/dev/pty%d", minor);
      |
serial/ptmx.c:205:25: note: directive argument in the range [0, 2147483647]
  205 |   snprintf(devname, 16, "/dev/pty%d", minor);
      |                         ^~~~~~~~~~~~
serial/ptmx.c:205:3: note: ‘snprintf’ output between 10 and 19 bytes into a destination of size 16
  205 |   snprintf(devname, 16, "/dev/pty%d", minor);
```
## Impact
Minor
## Testing
CI and local machine
