### PR TITLE
sdcard: update sdcard detection to avoid 0xff asignment to bool type 

### DIFF
--- a/arch/arm/src/stm32f7/stm32_qspi.c
+++ b/arch/arm/src/stm32f7/stm32_qspi.c
@@ -2034,7 +2034,7 @@ static int qspi_command(struct qspi_dev_s *dev,
 
           qspi_ccrconfig(priv, &xctn, CCR_FMODE_INDWR);
 
-          /* Enable 'Transfer Error' 'FIFO Threshhold' and 'Transfer
+          /* Enable 'Transfer Error' 'FIFO Threshold' and 'Transfer
            * Complete' interrupts.
            */
 
@@ -2059,7 +2059,7 @@ static int qspi_command(struct qspi_dev_s *dev,
 
           qspi_putreg(priv, addrval, STM32_QUADSPI_AR_OFFSET);
 
-          /* Enable 'Transfer Error' 'FIFO Threshhold' and 'Transfer
+          /* Enable 'Transfer Error' 'FIFO Threshold' and 'Transfer
            * Complete' interrupts
            */
 

--- a/arch/arm/src/stm32wb/stm32wb_blehci.c
+++ b/arch/arm/src/stm32wb/stm32wb_blehci.c
@@ -128,7 +128,7 @@ static struct bt_driver_s g_blehci_driver =
   .send         = stm32wb_blehci_driversend
 };
 
-static mutex_t  g_lock = NXMUTEX_INITIALIZER;
+static mutex_t g_lock = NXMUTEX_INITIALIZER;
 struct work_s g_drv_init_work;
 
 /****************************************************************************

--- a/binfmt/elf.c
+++ b/binfmt/elf.c
@@ -262,8 +262,8 @@ static int elf_loadbinary(FAR struct binary_s *binp,
     {
       if (nexports > 0)
         {
-          berr("Cannot bind exported symbols to a "\
-                                    "fully linked executable\n");
+          berr("Cannot bind exported symbols to a "
+               "fully linked executable\n");
           ret = -ENOEXEC;
           goto errout_with_load;
         }
@@ -275,8 +275,8 @@ static int elf_loadbinary(FAR struct binary_s *binp,
 
   else
     {
-        berr("Unexpected elf type %d\n", loadinfo.ehdr.e_type);
-        ret = -ENOEXEC;
+      berr("Unexpected elf type %d\n", loadinfo.ehdr.e_type);
+      ret = -ENOEXEC;
     }
 
   /* Return the load information */

--- a/binfmt/libelf/libelf_verify.c
+++ b/binfmt/libelf/libelf_verify.c
@@ -41,7 +41,7 @@
 
 static const char g_elfmagic[EI_MAGIC_SIZE] =
 {
-    0x7f, 'E', 'L', 'F'
+  0x7f, 'E', 'L', 'F'
 };
 
 /****************************************************************************
@@ -92,7 +92,7 @@ int elf_verifyheader(FAR const Elf_Ehdr *ehdr)
   if ((ehdr->e_type != ET_REL) && (ehdr->e_type != ET_EXEC))
     {
       berr("Not a relocatable or executable file: e_type=%d\n",
-                                        ehdr->e_type);
+           ehdr->e_type);
       return -EINVAL;
     }
 

--- a/boards/arm/gd32f4/gd32f450zk-eval/src/gd32f4xx_sdio.c
+++ b/boards/arm/gd32f4/gd32f450zk-eval/src/gd32f4xx_sdio.c
@@ -57,7 +57,7 @@
 
 static struct sdio_dev_s *g_sdio_dev;
 #ifdef HAVE_NCD
-static bool g_sd_inserted = 0xff; /* Impossible value */
+static bool g_sd_inserted;
 #endif
 
 /****************************************************************************
@@ -104,13 +104,6 @@ int gd32_sdio_initialize(void)
 {
   int ret;
 
-#ifdef HAVE_NCD
-  /* Card detect */
-
-  bool cd_status;
-
-#endif
-
   /* Mount the SDIO-based MMC/SD block driver
    * First, get an instance of the SDIO interface
    */
@@ -140,10 +133,10 @@ int gd32_sdio_initialize(void)
 #ifdef HAVE_NCD
   /* Use SD card detect pin to check if a card is g_sd_inserted */
 
-  cd_status = !gd32_gpio_read(GPIO_SDMMC1_NCD);
-  finfo("Card detect : %d\n", cd_status);
+  g_sd_inserted = !gd32_gpio_read(GPIO_SDMMC1_NCD);
+  finfo("Card detect : %d\n", g_sd_inserted);
 
-  sdio_mediachange(g_sdio_dev, cd_status);
+  sdio_mediachange(g_sdio_dev, g_sd_inserted);
 #else
   /* Assume that the SD card is inserted.  What choice do we have? */
 

--- a/boards/arm/lpc17xx_40xx/lpc4088-quickstart/src/lpc17_40_bringup.c
+++ b/boards/arm/lpc17xx_40xx/lpc4088-quickstart/src/lpc17_40_bringup.c
@@ -151,6 +151,9 @@ static struct usbhost_connection_s *g_usbconn;
 #ifdef NSH_HAVE_MMCSD
 static struct sdio_dev_s *g_sdiodev;
 #endif
+#ifdef NSH_HAVE_MMCSD_CD
+static bool g_sd_inserted;
+#endif
 
 /****************************************************************************
  * Private Functions
@@ -205,14 +208,13 @@ static int nsh_waiter(int argc, char *argv[])
 #ifdef NSH_HAVE_MMCSD_CDINT
 static int nsh_cdinterrupt(int irq, void *context, void *arg)
 {
-  static bool inserted = 0xff; /* Impossible value */
   bool present;
 
   present = !lpc17_40_gpioread(GPIO_SD_CD);
-  if (present != inserted)
+  if (present != g_sd_inserted)
     {
       sdio_mediachange(g_sdiodev, present);
-      inserted = present;
+      g_sd_inserted = present;
     }
 
   return OK;
@@ -275,7 +277,8 @@ static int nsh_sdinitialize(void)
    */
 
 #ifdef NSH_HAVE_MMCSD_CD
-  sdio_mediachange(g_sdiodev, !lpc17_40_gpioread(GPIO_SD_CD));
+  g_sd_inserted = !lpc17_40_gpioread(GPIO_SD_CD);
+  sdio_mediachange(g_sdiodev, g_sd_inserted);
 #else
   sdio_mediachange(g_sdiodev, true);
 #endif

--- a/boards/arm/lpc17xx_40xx/lx_cpu/src/lpc17_40_bringup.c
+++ b/boards/arm/lpc17xx_40xx/lx_cpu/src/lpc17_40_bringup.c
@@ -150,6 +150,9 @@ static struct usbhost_connection_s *g_usbconn;
 #ifdef NSH_HAVE_MMCSD
 static struct sdio_dev_s *g_sdiodev;
 #endif
+#ifdef NSH_HAVE_MMCSD_CD
+static bool g_sd_inserted;
+#endif
 
 /****************************************************************************
  * Private Functions
@@ -204,14 +207,13 @@ static int nsh_waiter(int argc, char *argv[])
 #ifdef NSH_HAVE_MMCSD_CDINT
 static int nsh_cdinterrupt(int irq, void *context, void *arg)
 {
-  static bool inserted = 0xff; /* Impossible value */
   bool present;
 
   present = !lpc17_40_gpioread(GPIO_SD_CD);
-  if (present != inserted)
+  if (present != g_sd_inserted)
     {
       sdio_mediachange(g_sdiodev, present);
-      inserted = present;
+      g_sd_inserted = present;
     }
 
   return OK;
@@ -273,7 +275,8 @@ static int nsh_sdinitialize(void)
    */
 
 #ifdef NSH_HAVE_MMCSD_CD
-  sdio_mediachange(g_sdiodev, !lpc17_40_gpioread(GPIO_SD_CD));
+  g_sd_inserted = !lpc17_40_gpioread(GPIO_SD_CD);
+  sdio_mediachange(g_sdiodev, g_sd_inserted);
 #else
   sdio_mediachange(g_sdiodev, true);
 #endif

--- a/boards/arm/lpc17xx_40xx/lx_cpu/src/lpc17_40_nsh.c
+++ b/boards/arm/lpc17xx_40xx/lx_cpu/src/lpc17_40_nsh.c
@@ -147,6 +147,9 @@ static struct usbhost_connection_s *g_usbconn;
 #ifdef NSH_HAVE_MMCSD
 static struct sdio_dev_s *g_sdiodev;
 #endif
+#ifdef NSH_HAVE_MMCSD_CD
+static bool g_sd_inserted;
+#endif
 
 /****************************************************************************
  * Private Functions
@@ -201,14 +204,13 @@ static int nsh_waiter(int argc, char *argv[])
 #ifdef NSH_HAVE_MMCSD_CDINT
 static int nsh_cdinterrupt(int irq, void *context)
 {
-  static bool inserted = 0xff; /* Impossible value */
   bool present;
 
   present = !lpc17_40_gpioread(GPIO_SD_CD);
-  if (present != inserted)
+  if (present != g_sd_inserted)
     {
       sdio_mediachange(g_sdiodev, present);
-      inserted = present;
+      g_sd_inserted = present;
     }
 
   return OK;
@@ -270,7 +272,8 @@ static int nsh_sdinitialize(void)
    */
 
 #ifdef NSH_HAVE_MMCSD_CD
-  sdio_mediachange(g_sdiodev, !lpc17_40_gpioread(GPIO_SD_CD));
+  g_sd_inserted = !lpc17_40_gpioread(GPIO_SD_CD);
+  sdio_mediachange(g_sdiodev, g_sd_inserted);
 #else
   sdio_mediachange(g_sdiodev, true);
 #endif

--- a/boards/arm/lpc17xx_40xx/open1788/src/lpc17_40_bringup.c
+++ b/boards/arm/lpc17xx_40xx/open1788/src/lpc17_40_bringup.c
@@ -150,6 +150,9 @@ static struct usbhost_connection_s *g_usbconn;
 #ifdef NSH_HAVE_MMCSD
 static struct sdio_dev_s *g_sdiodev;
 #endif
+#ifdef NSH_HAVE_MMCSD_CD
+static bool g_sd_inserted;
+#endif
 
 /****************************************************************************
  * Private Functions
@@ -204,14 +207,13 @@ static int nsh_waiter(int argc, char *argv[])
 #ifdef NSH_HAVE_MMCSD_CDINT
 static int nsh_cdinterrupt(int irq, void *context, void *arg)
 {
-  static bool inserted = 0xff; /* Impossible value */
   bool present;
 
   present = !lpc17_40_gpioread(GPIO_SD_CD);
-  if (present != inserted)
+  if (present != g_sd_inserted)
     {
       sdio_mediachange(g_sdiodev, present);
-      inserted = present;
+      g_sd_inserted = present;
     }
 
   return OK;
@@ -274,7 +276,8 @@ static int nsh_sdinitialize(void)
    */
 
 #ifdef NSH_HAVE_MMCSD_CD
-  sdio_mediachange(g_sdiodev, !lpc17_40_gpioread(GPIO_SD_CD));
+  g_sd_inserted = !lpc17_40_gpioread(GPIO_SD_CD);
+  sdio_mediachange(g_sdiodev, g_sd_inserted);
 #else
   sdio_mediachange(g_sdiodev, true);
 #endif

--- a/boards/arm/stm32/axoloti/src/stm32_sdio.c
+++ b/boards/arm/stm32/axoloti/src/stm32_sdio.c
@@ -54,7 +54,7 @@
 
 static struct sdio_dev_s *g_sdio_dev;
 #ifdef HAVE_NCD
-static bool g_sd_inserted = 0xff;       /* Impossible value */
+static bool g_sd_inserted;
 #endif
 
 /****************************************************************************
@@ -102,8 +102,6 @@ int stm32_sdio_initialize(void)
   int ret;
 
 #ifdef HAVE_NCD
-  bool cd_status;
-
   /* Configure the card detect GPIO */
 
   stm32_configgpio(GPIO_SDIO_NCD);
@@ -112,7 +110,6 @@ int stm32_sdio_initialize(void)
 
   stm32_gpiosetevent(GPIO_SDIO_NCD, true, true, true,
                      stm32_ncd_interrupt, NULL);
-
 #endif
 
   /* Mount the SDIO-based MMC/SD block driver.
@@ -142,9 +139,9 @@ int stm32_sdio_initialize(void)
 #ifdef HAVE_NCD
   /* Use SD card detect pin to check if a card is g_sd_inserted */
 
-  cd_status = !stm32_gpioread(GPIO_SDIO_NCD);
-  finfo("Card detect : %d\n", cd_status);
-  sdio_mediachange(g_sdio_dev, cd_status);
+  g_sd_inserted = !stm32_gpioread(GPIO_SDIO_NCD);
+  finfo("Card detect : %d\n", g_sd_inserted);
+  sdio_mediachange(g_sdio_dev, g_sd_inserted);
 #else
   /* Assume that the SD card is inserted.  What choice do we have? */
 

--- a/boards/arm/stm32/nucleo-f429zi/src/stm32_sdio.c
+++ b/boards/arm/stm32/nucleo-f429zi/src/stm32_sdio.c
@@ -58,7 +58,7 @@
 
 static struct sdio_dev_s *g_sdio_dev;
 #ifdef HAVE_NCD
-static bool g_sd_inserted = 0xff; /* Impossible value */
+static bool g_sd_inserted;
 #endif
 
 /****************************************************************************
@@ -106,10 +106,6 @@ int stm32_sdio_initialize(void)
   int ret;
 
 #ifdef HAVE_NCD
-  /* Card detect */
-
-  bool cd_status;
-
   /* Configure the card detect GPIO */
 
   stm32_configgpio(GPIO_SDMMC1_NCD);
@@ -149,10 +145,10 @@ int stm32_sdio_initialize(void)
 #ifdef HAVE_NCD
   /* Use SD card detect pin to check if a card is g_sd_inserted */
 
-  cd_status = !stm32_gpioread(GPIO_SDMMC1_NCD);
-  finfo("Card detect : %d\n", cd_status);
+  g_sd_inserted = !stm32_gpioread(GPIO_SDMMC1_NCD);
+  finfo("Card detect : %d\n", g_sd_inserted);
 
-  sdio_mediachange(g_sdio_dev, cd_status);
+  sdio_mediachange(g_sdio_dev, g_sd_inserted);
 #else
   /* Assume that the SD card is inserted.  What choice do we have? */
 

--- a/boards/arm/stm32/olimex-stm32-h407/src/stm32_sdio.c
+++ b/boards/arm/stm32/olimex-stm32-h407/src/stm32_sdio.c
@@ -56,7 +56,7 @@
 
 static struct sdio_dev_s *g_sdio_dev;
 #ifdef HAVE_NCD
-static bool g_sd_inserted = 0xff; /* Impossible value */
+static bool g_sd_inserted;
 #endif
 
 /****************************************************************************
@@ -104,10 +104,6 @@ int stm32_sdio_initialize(void)
   int ret;
 
 #ifdef HAVE_NCD
-  /* Card detect */
-
-  bool cd_status;
-
   /* Configure the card detect GPIO */
 
   stm32_configgpio(GPIO_SDIO_NCD);
@@ -147,10 +143,10 @@ int stm32_sdio_initialize(void)
 #ifdef HAVE_NCD
   /* Use SD card detect pin to check if a card is g_sd_inserted */
 
-  cd_status = !stm32_gpioread(GPIO_SDIO_NCD);
-  finfo("Card detect : %d\n", cd_status);
+  g_sd_inserted = !stm32_gpioread(GPIO_SDIO_NCD);
+  finfo("Card detect : %d\n", g_sd_inserted);
 
-  sdio_mediachange(g_sdio_dev, cd_status);
+  sdio_mediachange(g_sdio_dev, g_sd_inserted);
 #else
   /* Assume that the SD card is inserted.  What choice do we have? */
 

--- a/boards/arm/stm32/stm32f4discovery/src/stm32_sdio.c
+++ b/boards/arm/stm32/stm32f4discovery/src/stm32_sdio.c
@@ -56,7 +56,7 @@
 
 static struct sdio_dev_s *g_sdio_dev;
 #ifdef HAVE_NCD
-static bool g_sd_inserted = 0xff; /* Impossible value */
+static bool g_sd_inserted;
 #endif
 
 /****************************************************************************
@@ -104,10 +104,6 @@ int stm32_sdio_initialize(void)
   int ret;
 
 #ifdef HAVE_NCD
-  /* Card detect */
-
-  bool cd_status;
-
   /* Configure the card detect GPIO */
 
   stm32_configgpio(GPIO_SDIO_NCD);
@@ -147,10 +143,10 @@ int stm32_sdio_initialize(void)
 #ifdef HAVE_NCD
   /* Use SD card detect pin to check if a card is g_sd_inserted */
 
-  cd_status = !stm32_gpioread(GPIO_SDIO_NCD);
-  finfo("Card detect : %d\n", cd_status);
+  g_sd_inserted = !stm32_gpioread(GPIO_SDIO_NCD);
+  finfo("Card detect : %d\n", g_sd_inserted);
 
-  sdio_mediachange(g_sdio_dev, cd_status);
+  sdio_mediachange(g_sdio_dev, g_sd_inserted);
 #else
   /* Assume that the SD card is inserted.  What choice do we have? */
 

--- a/boards/arm/stm32f7/nucleo-144/src/stm32_sdio.c
+++ b/boards/arm/stm32f7/nucleo-144/src/stm32_sdio.c
@@ -58,7 +58,7 @@
 
 static struct sdio_dev_s *g_sdio_dev;
 #ifdef HAVE_NCD
-static bool g_sd_inserted = 0xff; /* Impossible value */
+static bool g_sd_inserted;
 #endif
 
 /****************************************************************************
@@ -106,10 +106,6 @@ int stm32_sdio_initialize(void)
   int ret;
 
 #ifdef HAVE_NCD
-  /* Card detect */
-
-  bool cd_status;
-
   /* Configure the card detect GPIO */
 
   stm32_configgpio(GPIO_SDMMC1_NCD);
@@ -149,10 +145,10 @@ int stm32_sdio_initialize(void)
 #ifdef HAVE_NCD
   /* Use SD card detect pin to check if a card is g_sd_inserted */
 
-  cd_status = !stm32_gpioread(GPIO_SDMMC1_NCD);
-  finfo("Card detect : %d\n", cd_status);
+  g_sd_inserted = !stm32_gpioread(GPIO_SDMMC1_NCD);
+  finfo("Card detect : %d\n", g_sd_inserted);
 
-  sdio_mediachange(g_sdio_dev, cd_status);
+  sdio_mediachange(g_sdio_dev, g_sd_inserted);
 #else
   /* Assume that the SD card is inserted.  What choice do we have? */
 

--- a/boards/arm/stm32f7/stm32f746-ws/src/stm32_sdmmc.c
+++ b/boards/arm/stm32f7/stm32f746-ws/src/stm32_sdmmc.c
@@ -54,7 +54,7 @@
 
 static struct sdio_dev_s *g_sdio_dev;
 #ifdef HAVE_NCD
-static bool g_sd_inserted = 0xff; /* Impossible value */
+static bool g_sd_inserted;
 #endif
 
 /****************************************************************************
@@ -102,10 +102,6 @@ int stm32_sdio_initialize(void)
   int ret;
 
 #ifdef HAVE_NCD
-  /* Card detect */
-
-  bool cd_status;
-
   /* Configure the card detect GPIO */
 
   stm32_configgpio(GPIO_SDIO_NCD);
@@ -145,10 +141,10 @@ int stm32_sdio_initialize(void)
 #ifdef HAVE_NCD
   /* Use SD card detect pin to check if a card is g_sd_inserted */
 
-  cd_status = !stm32_gpioread(GPIO_SDIO_NCD);
-  finfo("Card detect : %d\n", cd_status);
+  g_sd_inserted = !stm32_gpioread(GPIO_SDIO_NCD);
+  finfo("Card detect : %d\n", g_sd_inserted);
 
-  sdio_mediachange(g_sdio_dev, cd_status);
+  sdio_mediachange(g_sdio_dev, g_sd_inserted);
 #else
   /* Assume that the SD card is inserted.  What choice do we have? */
 

--- a/boards/arm/stm32f7/stm32f746g-disco/src/stm32_sdmmc.c
+++ b/boards/arm/stm32f7/stm32f746g-disco/src/stm32_sdmmc.c
@@ -55,7 +55,7 @@
 
 static struct sdio_dev_s *g_sdio_dev;
 #ifdef HAVE_NCD
-static bool g_sd_inserted = 0xff; /* Impossible value */
+static bool g_sd_inserted;
 #endif
 
 /****************************************************************************
@@ -103,10 +103,6 @@ int stm32_sdio_initialize(void)
   int ret;
 
 #ifdef HAVE_NCD
-  /* Card detect */
-
-  bool cd_status;
-
   /* Configure the card detect GPIO */
 
   stm32_configgpio(GPIO_SDIO_NCD);
@@ -146,10 +142,10 @@ int stm32_sdio_initialize(void)
 #ifdef HAVE_NCD
   /* Use SD card detect pin to check if a card is g_sd_inserted */
 
-  cd_status = !stm32_gpioread(GPIO_SDIO_NCD);
-  finfo("Card detect : %d\n", cd_status);
+  g_sd_inserted = !stm32_gpioread(GPIO_SDIO_NCD);
+  finfo("Card detect : %d\n", g_sd_inserted);
 
-  sdio_mediachange(g_sdio_dev, cd_status);
+  sdio_mediachange(g_sdio_dev, g_sd_inserted);
 #else
   /* Assume that the SD card is inserted.  What choice do we have? */
 

--- a/boards/arm/stm32h7/stm32h747i-disco/src/stm32_sdmmc.c
+++ b/boards/arm/stm32h7/stm32h747i-disco/src/stm32_sdmmc.c
@@ -55,7 +55,7 @@
 
 static struct sdio_dev_s *g_sdio_dev;
 #ifdef HAVE_NCD
-static bool g_sd_inserted = 0xff; /* Impossible value */
+static bool g_sd_inserted;
 #endif
 
 /****************************************************************************
@@ -103,10 +103,6 @@ int stm32_sdio_initialize(void)
   int ret;
 
 #ifdef HAVE_NCD
-  /* Card detect */
-
-  bool cd_status;
-
   /* Configure the card detect GPIO */
 
   stm32_configgpio(GPIO_SDIO_NCD);
@@ -146,10 +142,10 @@ int stm32_sdio_initialize(void)
 #ifdef HAVE_NCD
   /* Use SD card detect pin to check if a card is g_sd_inserted */
 
-  cd_status = !stm32_gpioread(GPIO_SDIO_NCD);
-  finfo("Card detect : %d\n", cd_status);
+  g_sd_inserted = !stm32_gpioread(GPIO_SDIO_NCD);
+  finfo("Card detect : %d\n", g_sd_inserted);
 
-  sdio_mediachange(g_sdio_dev, cd_status);
+  sdio_mediachange(g_sdio_dev, g_sd_inserted);
 #else
   /* Assume that the SD card is inserted.  What choice do we have? */
 

--- a/boards/arm/stm32l4/nucleo-l496zg/src/stm32_sdio.c
+++ b/boards/arm/stm32l4/nucleo-l496zg/src/stm32_sdio.c
@@ -58,7 +58,7 @@
 
 static struct sdio_dev_s *g_sdio_dev;
 #ifdef HAVE_NCD
-static bool g_sd_inserted = 0xff; /* Impossible value */
+static bool g_sd_inserted;
 #endif
 
 /****************************************************************************
@@ -106,10 +106,6 @@ int stm32l4_sdio_initialize(void)
   int ret;
 
 #ifdef HAVE_NCD
-  /* Card detect */
-
-  bool cd_status;
-
   /* Configure the card detect GPIO */
 
   stm32l4_configgpio(GPIO_SDMMC1_NCD);
@@ -149,10 +145,10 @@ int stm32l4_sdio_initialize(void)
 #ifdef HAVE_NCD
   /* Use SD card detect pin to check if a card is g_sd_inserted */
 
-  cd_status = !stm32l4_gpioread(GPIO_SDMMC1_NCD);
-  finfo("Card detect : %d\n", cd_status);
+  g_sd_inserted = !stm32l4_gpioread(GPIO_SDMMC1_NCD);
+  finfo("Card detect : %d\n", g_sd_inserted);
 
-  sdio_mediachange(g_sdio_dev, cd_status);
+  sdio_mediachange(g_sdio_dev, g_sd_inserted);
 #else
   /* Assume that the SD card is inserted.  What choice do we have? */
 

--- a/include/nuttx/wireless/bluetooth/bt_ioctl.h
+++ b/include/nuttx/wireless/bluetooth/bt_ioctl.h
@@ -450,7 +450,7 @@ struct btreq_s
       bt_addr_le_t btgwr_wrpeer;                 /* IN:  Peer address */
       uint8_t btgwr_wrnbytes;                    /* IN:  Number of bytes to write */
       uint16_t btgwr_wrhandle;                   /* IN:  GATT handle */
-      FAR uint8_t btgwr_wrdata[HCI_GATTWR_DATA]; /* IN:  Data to be written */
+      uint8_t btgwr_wrdata[HCI_GATTWR_DATA];     /* IN:  Data to be written */
       uint8_t btgwr_wrresult;                    /* OUT: The result of the operation */
     } btgwr;
 

--- a/libs/libc/regex/Make.defs
+++ b/libs/libc/regex/Make.defs
@@ -28,3 +28,4 @@ DEPPATH += --dep-path regex
 VPATH += :regex
 
 endif
+

--- a/net/ipfrag/ipfrag.c
+++ b/net/ipfrag/ipfrag.c
@@ -108,27 +108,27 @@ do  \
  * if so, free all resources of this node.
  */
 
-static struct wdog_s  g_wdfragtimeout;
+static struct wdog_s g_wdfragtimeout;
 
 /* Reassembly timeout work */
 
-static struct work_s  g_wkfragtimeout;
+static struct work_s g_wkfragtimeout;
 
 /* Remember the number of I/O buffers currently in reassembly cache */
 
-static uint8_t        g_bufoccupy;
+static uint8_t       g_bufoccupy;
 
 /* Queue header definition, it links all fragments of all NICs by ascending
  * ipid.
  */
 
-static sq_queue_t     g_assemblyhead_ipid;
+static sq_queue_t    g_assemblyhead_ipid;
 
 /* Queue header definition, which connects all fragments of all NICs in order
  * of addition time.
  */
 
-static sq_queue_t     g_assemblyhead_time;
+static sq_queue_t    g_assemblyhead_time;
 
 /****************************************************************************
  * Public Data
@@ -138,7 +138,7 @@ static sq_queue_t     g_assemblyhead_time;
  * at a time.
  */
 
-mutex_t               g_ipfrag_lock = NXMUTEX_INITIALIZER;
+mutex_t              g_ipfrag_lock = NXMUTEX_INITIALIZER;
 
 /****************************************************************************
  * Private Function Prototypes

--- a/net/ipfrag/ipfrag.h
+++ b/net/ipfrag/ipfrag.h
@@ -151,7 +151,7 @@ extern "C"
  * at a time
  */
 
-extern mutex_t               g_ipfrag_lock;
+extern mutex_t g_ipfrag_lock;
 
 /****************************************************************************
  * Public Function Prototypes

--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -422,7 +422,7 @@ static void show_tasks(void)
 #endif
          " PRI POLICY   TYPE    NPX"
          " STATE   EVENT"
-         "      SIGMASK"
+         "      SIGMASK        "
          "  STACKBASE"
          "  STACKSIZE"
 #ifdef CONFIG_STACK_COLORATION

--- a/sched/signal/sig_queue.c
+++ b/sched/signal/sig_queue.c
@@ -74,7 +74,7 @@
  *
  ****************************************************************************/
 
-int nxsig_queue (int pid, int signo, union sigval value)
+int nxsig_queue(int pid, int signo, union sigval value)
 {
 #ifdef CONFIG_SCHED_HAVE_PARENT
   FAR struct tcb_s *rtcb = this_task();
@@ -143,7 +143,7 @@ int nxsig_queue (int pid, int signo, union sigval value)
  *
  ****************************************************************************/
 
-int sigqueue (int pid, int signo, union sigval value)
+int sigqueue(int pid, int signo, union sigval value)
 {
   int ret;
 


### PR DESCRIPTION
## Summary
1. Update sdcard detection to avoid 0xff assignment to bool type
2. Remove extra spaces and align parameters
3. Fix the alignment in task dump printing during assert
4. Remove `FAR` from array type

## Impact
N/A

## Testing
Task dump during assert is not better aligned. Tested on ESP32
Pass CI