### PR TITLE
arch/arm64: Save FPU context when a context switch occurs in SMP mode

### DIFF
--- a/arch/arm64/src/common/arm64_arch.h
+++ b/arch/arm64/src/common/arm64_arch.h
@@ -328,7 +328,6 @@ struct fpu_reg
   __int128 q[32];
   uint32_t fpsr;
   uint32_t fpcr;
-  uint64_t fpu_trap;
 };
 
 #endif

--- a/arch/arm64/src/common/arm64_vectors.S
+++ b/arch/arm64/src/common/arm64_vectors.S
@@ -121,6 +121,14 @@ SECTION_FUNC(text, arm64_context_switch)
     cmp    x1, #0x0
     beq    restore_new
 
+#if defined(CONFIG_ARCH_FPU) && defined(CONFIG_SMP)
+    stp    x0, x1, [sp, #-16]!
+    stp    xzr, x30, [sp, #-16]!
+    bl     arm64_fpu_context_save
+    ldp    xzr, x30, [sp], #16
+    ldp    x0, x1, [sp], #16
+#endif
+
     /* Save the current SP_EL0 */
     mov    x4,  sp
     str    x4, [x1, #8 * REG_SP_ELX]


### PR DESCRIPTION
## Summary

In SMP mode, the fpu owner may switch from core0 to core1, so it is necessary to force saving the FPU context when a context switch occurs.

This PR fixed the crash issue mentioned in #8799.

## Impact

ARM64 FPU

## Testing

qemu-armv8a:nsh_smp enable FPU