### PR TITLE
Assert: Optimizing assert handling

### DIFF
--- a/boards/arm/cxd56xx/common/src/cxd56_crashdump.c
+++ b/boards/arm/cxd56xx/common/src/cxd56_crashdump.c
@@ -100,7 +100,7 @@ static void copy_reverse(stack_word_t *dest, stack_word_t *src, int size)
 
 void board_crashdump(uintptr_t sp, struct tcb_s *tcb,
                      const char *filename, int lineno,
-                     const char *msg)
+                     const char *msg, FAR void *regs)
 {
   fullcontext_t *pdump;
 

--- a/boards/arm/stm32/nucleo-f429zi/src/stm32_bbsram.c
+++ b/boards/arm/stm32/nucleo-f429zi/src/stm32_bbsram.c
@@ -381,7 +381,7 @@ int stm32_bbsram_int(void)
 #if defined(CONFIG_STM32_SAVE_CRASHDUMP)
 void board_crashdump(uintptr_t sp, struct tcb_s *tcb,
                      const char *filename, int lineno,
-                     const char *msg)
+                     const char *msg, FAR void *regs)
 {
   fullcontext_t *pdump = (fullcontext_t *)&g_sdata;
   int rv;

--- a/boards/arm/stm32f7/nucleo-144/src/stm32_bbsram.c
+++ b/boards/arm/stm32f7/nucleo-144/src/stm32_bbsram.c
@@ -381,7 +381,7 @@ int stm32_bbsram_int(void)
 #if defined(CONFIG_STM32F7_SAVE_CRASHDUMP)
 void board_crashdump(uintptr_t sp, struct tcb_s *tcb,
                      const char *filename, int lineno,
-                     const char *msg)
+                     const char *msg, FAR void *regs)
 {
   fullcontext_t *pdump = (fullcontext_t *)&g_sdata;
   int rv;

--- a/boards/renesas/rx65n/rx65n-grrose/src/rx65n_sbram.c
+++ b/boards/renesas/rx65n/rx65n-grrose/src/rx65n_sbram.c
@@ -334,7 +334,7 @@ int rx65n_sbram_int(void)
 #if defined(CONFIG_RX65N_SAVE_CRASHDUMP)
 void board_crashdump(uintptr_t sp, struct tcb_s *tcb,
                      const char *filename, int lineno,
-                     const char *msg)
+                     const char *msg, FAR void *regs)
 {
   struct fullcontext *pdump;
   pdump = (struct fullcontext *)&g_sdata;

--- a/boards/renesas/rx65n/rx65n-rsk2mb/src/rx65n_sbram.c
+++ b/boards/renesas/rx65n/rx65n-rsk2mb/src/rx65n_sbram.c
@@ -332,7 +332,7 @@ int rx65n_sbram_int(void)
 #if defined(CONFIG_RX65N_SAVE_CRASHDUMP)
 void board_crashdump(uintptr_t sp, struct tcb_s *tcb,
                      const char *filename, int lineno,
-                     const char *msg)
+                     const char *msg, FAR void *regs)
 {
   struct fullcontext *pdump;
   pdump = (struct fullcontext *)&g_sdata;

--- a/include/nuttx/board.h
+++ b/include/nuttx/board.h
@@ -805,7 +805,7 @@ int board_button_irq(int id, xcpt_t irqhandler, FAR void *arg);
 struct tcb_s;
 void board_crashdump(uintptr_t sp, FAR struct tcb_s *tcb,
                      FAR const char *filename, int lineno,
-                     FAR const char *msg);
+                     FAR const char *msg, FAR void *regs);
 #endif
 
 /****************************************************************************

--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -601,7 +601,7 @@ void _assert(FAR const char *filename, int linenum,
 #endif
 
 #ifdef CONFIG_BOARD_CRASHDUMP
-      board_crashdump(up_getsp(), rtcb, filename, linenum, msg);
+      board_crashdump(up_getsp(), rtcb, filename, linenum, msg, regs);
 
 #elif defined(CONFIG_BOARD_COREDUMP)
       /* Dump core information */

--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -153,12 +153,12 @@ static void dump_stack(FAR const char *tag, uintptr_t sp,
   uintptr_t top = base + size;
 
   _alert("%s Stack:\n", tag);
-  _alert("sp:     %p\n", (FAR void *)sp);
   _alert("  base: %p\n", (FAR void *)base);
   _alert("  size: %08zu\n", size);
 
   if (!force)
     {
+      _alert("    sp: %p\n", (FAR void *)sp);
       stack_dump(sp, top);
     }
   else
@@ -191,62 +191,50 @@ static void show_stacks(FAR struct tcb_s *rtcb, uintptr_t sp)
   uintptr_t intstack_base = up_get_intstackbase();
   size_t intstack_size = CONFIG_ARCH_INTERRUPTSTACK;
   uintptr_t intstack_top = intstack_base + intstack_size;
+  FAR void *intstack_sp = NULL;
 #endif
 #ifdef CONFIG_ARCH_KERNEL_STACK
   uintptr_t kernelstack_base = (uintptr_t)rtcb->xcp.kstack;
   size_t kernelstack_size = CONFIG_ARCH_KERNEL_STACKSIZE;
   uintptr_t kernelstack_top = kernelstack_base + kernelstack_size;
+  FAR void *kernelstack_sp = NULL;
 #endif
   uintptr_t tcbstack_base = (uintptr_t)rtcb->stack_base_ptr;
   size_t tcbstack_size = (size_t)rtcb->adj_stack_size;
   uintptr_t tcbstack_top = tcbstack_base + tcbstack_size;
+  FAR void *tcbstack_sp = NULL;
+  bool force = false;
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 0
   if (sp >= intstack_base && sp < intstack_top)
     {
-      dump_stack("IRQ", sp,
-                 intstack_base,
-                 intstack_size,
-#ifdef CONFIG_STACK_COLORATION
-                 up_check_intstack(),
-#else
-                 0,
-#endif
-                 false
-                );
+      intstack_sp = (FAR void *)sp;
+      tcbstack_sp = (FAR void *)up_getusrsp(rtcb->xcp.regs);
     }
   else
 #endif
 #ifdef CONFIG_ARCH_KERNEL_STACK
   if (sp >= kernelstack_base && sp < kernelstack_top)
     {
-      dump_stack("Kernel", sp,
-                 kernelstack_base,
-                 kernelstack_size,
-                 0, false
-                );
+      kernelstack_sp = (FAR void *)sp;
     }
   else
 #endif
   if (sp >= tcbstack_base && sp < tcbstack_top)
     {
-      dump_stack("User", sp,
-                 tcbstack_base,
-                 tcbstack_size,
-#ifdef CONFIG_STACK_COLORATION
-                 up_check_tcbstack(rtcb),
-#else
-                 0,
-#endif
-                 false
-                );
+      tcbstack_sp = (FAR void *)sp;
     }
   else
     {
+      force = true;
       _alert("ERROR: Stack pointer is not within the stack\n");
+    }
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 0
-      dump_stack("IRQ", sp,
+  if (intstack_sp != NULL || force)
+    {
+      dump_stack("IRQ",
+                 (uintptr_t)intstack_sp,
                  intstack_base,
                  intstack_size,
 #ifdef CONFIG_STACK_COLORATION
@@ -254,19 +242,27 @@ static void show_stacks(FAR struct tcb_s *rtcb, uintptr_t sp)
 #else
                  0,
 #endif
-                 true
+                 force
                 );
+    }
 #endif
 
 #ifdef CONFIG_ARCH_KERNEL_STACK
-      dump_stack("Kernel", sp,
+  if (kernelstack_sp != NULL || force)
+    {
+      dump_stack("Kernel",
+                 (uintptr_t)kernelstack_sp,
                  kernelstack_base,
                  kernelstack_size,
-                 0, true
+                 0, force
                 );
+    }
 #endif
 
-      dump_stack("User", sp,
+  if (tcbstack_sp != NULL || force)
+    {
+      dump_stack("User",
+                 (uintptr_t)tcbstack_sp,
                  tcbstack_base,
                  tcbstack_size,
 #ifdef CONFIG_STACK_COLORATION
@@ -274,7 +270,7 @@ static void show_stacks(FAR struct tcb_s *rtcb, uintptr_t sp)
 #else
                  0,
 #endif
-                 true
+                 force
                 );
     }
 }

--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -70,7 +70,7 @@
  * Private Data
  ****************************************************************************/
 
-static uint8_t g_last_regs[XCPTCONTEXT_SIZE];
+static uint8_t g_last_regs[XCPTCONTEXT_SIZE] aligned_data(16);
 
 #ifdef CONFIG_BOARD_COREDUMP
 static struct lib_syslogstream_s  g_syslogstream;


### PR DESCRIPTION
## Summary

1. Ensure that g_last_regs is aligned to 16 bytes.
2. Print the stack of last running task when assert in irq context.
3. Add regs parameter to board_crashdump function. 

## Impact

Assert

## Testing

BES Board