### PR TITLE
netdev: remove ASSERT when ifindex is invalid

### DIFF
--- a/net/netdev/netdev_findbyindex.c
+++ b/net/netdev/netdev_findbyindex.c
@@ -61,7 +61,6 @@ FAR struct net_driver_s *netdev_findbyindex(int ifindex)
    * POSIX to mean no interface index.
    */
 
-  DEBUGASSERT(ifindex > 0 && ifindex <= MAX_IFINDEX);
   if (ifindex < 1 || ifindex > MAX_IFINDEX)
     {
       return NULL;


### PR DESCRIPTION
## Summary
There is no control over whether a valid index is input when user use ioctl to get netdev information, so removing this assertion will allow ENODEV to be returned.

## Impact

## Testing
sim:local
