### PR TITLE
sim/posix/sim_hostusrsock: process host network syscall with critical…

### DIFF
--- a/arch/sim/src/sim/sim_usrsock.c
+++ b/arch/sim/src/sim/sim_usrsock.c
@@ -28,6 +28,7 @@
 #include <syslog.h>
 #include <string.h>
 
+#include <nuttx/arch.h>
 #include <nuttx/net/usrsock.h>
 
 #include "sim_hostusrsock.h"
@@ -408,6 +409,7 @@ void usrsock_register(void)
 int usrsock_request(struct iovec *iov, unsigned int iovcnt)
 {
   struct usrsock_request_common_s *common;
+  uint64_t flags;
   int ret;
 
   /* Copy request to buffer */
@@ -424,8 +426,10 @@ int usrsock_request(struct iovec *iov, unsigned int iovcnt)
   if (common->reqid >= 0 &&
       common->reqid < USRSOCK_REQUEST__MAX)
     {
+      flags = up_irq_save();
       ret = g_usrsock_handler[common->reqid](&g_usrsock,
                                               g_usrsock.in, ret);
+      up_irq_restore(flags);
       if (ret < 0)
         {
           syslog(LOG_ERR, "Usrsock request %d failed: %d\n",


### PR DESCRIPTION
… section
## Summary
if config_walltime_signal is enabled, NuttX_sim will receive a lot of signals, the socket api will break and errno will be EINTR, masking irq before calling the host socket api will avoid this problem.

## Impact

## Testing

