### PR TITLE
inet_addr: return INADDR_NONE(-1) when input string is invalid

### DIFF
--- a/libs/libc/net/lib_inetaddr.c
+++ b/libs/libc/net/lib_inetaddr.c
@@ -88,7 +88,7 @@ in_addr_t inet_addr(FAR const char *cp)
   unsigned int b;
   unsigned int c;
   unsigned int d;
-  uint32_t result = 0;
+  uint32_t result = INADDR_NONE;
 
   switch (sscanf(cp, "%u.%u.%u.%u", &a, &b, &c, &d))
     {


### PR DESCRIPTION
## Summary
now:
inet_network("300.10.10.10"); return 0
inet_addr("300.10.10.10"); return 0

glibc and muscle both return INADDR_NONE or -1.
## Impact

## Testing
sim:local
