### PR TITLE
usrsock_rpmsg_server: fix poll recursive when revent POLLHUP or POLLERR

### DIFF
--- a/drivers/usrsock/usrsock_rpmsg_server.c
+++ b/drivers/usrsock/usrsock_rpmsg_server.c
@@ -1096,6 +1096,7 @@ static void usrsock_rpmsg_poll_setup(FAR struct pollfd *pfds,
 static void usrsock_rpmsg_poll_cb(FAR struct pollfd *pfds)
 {
   FAR struct usrsock_rpmsg_s *priv = (FAR struct usrsock_rpmsg_s *)pfds->arg;
+  int oldevents;
   int events = 0;
 
   nxrmutex_lock(&priv->mutex);
@@ -1106,6 +1107,7 @@ static void usrsock_rpmsg_poll_cb(FAR struct pollfd *pfds)
       return;
     }
 
+  oldevents = pfds->events;
   if (pfds->revents & POLLIN)
     {
       events |= USRSOCK_EVENT_RECVFROM_AVAIL;
@@ -1138,9 +1140,13 @@ static void usrsock_rpmsg_poll_cb(FAR struct pollfd *pfds)
         }
     }
 
-  if (events != 0)
+  if (oldevents != pfds->events)
     {
       usrsock_rpmsg_poll_setup(pfds, pfds->events);
+    }
+
+  if (events != 0)
+    {
       usrsock_rpmsg_send_event(priv->epts[pfds->fd], pfds->fd, events);
     }
 


### PR DESCRIPTION
## Summary
the previous patch can not handle the revent is POLLHUP or POLLERR, poll_setup needs to be executed only when the POLLIN or POLLOUT event changes.

## Impact

## Testing
sim:local
