### PR TITLE
fs: move memset to upper lever for statfs and add f_fsid field

### DIFF
--- a/fs/binfs/fs_binfs.c
+++ b/fs/binfs/fs_binfs.c
@@ -449,7 +449,6 @@ static int binfs_statfs(struct inode *mountpt, struct statfs *buf)
 
   /* Fill in the statfs info */
 
-  memset(buf, 0, sizeof(struct statfs));
   buf->f_type    = BINFS_MAGIC;
   buf->f_bsize   = 0;
   buf->f_blocks  = 0;

--- a/fs/cromfs/fs_cromfs.c
+++ b/fs/cromfs/fs_cromfs.c
@@ -1467,7 +1467,6 @@ static int cromfs_statfs(struct inode *mountpt, struct statfs *buf)
 
   /* Fill in the statfs info. */
 
-  memset(buf, 0, sizeof(struct statfs));
   buf->f_type    = CROMFS_MAGIC;
   buf->f_namelen = NAME_MAX;
   buf->f_bsize   = fs->cv_bsize;

--- a/fs/fat/fs_fat32.c
+++ b/fs/fat/fs_fat32.c
@@ -2333,7 +2333,6 @@ static int fat_statfs(FAR struct inode *mountpt, FAR struct statfs *buf)
 
   /* Fill in the statfs info */
 
-  memset(buf, 0, sizeof(struct statfs));
   buf->f_type    = MSDOS_SUPER_MAGIC;
 
   /* We will claim that the optimal transfer size is the size of a cluster

--- a/fs/hostfs/hostfs.c
+++ b/fs/hostfs/hostfs.c
@@ -1161,7 +1161,6 @@ static int hostfs_statfs(FAR struct inode *mountpt, FAR struct statfs *buf)
 
   /* Call the host fs to perform the statfs */
 
-  memset(buf, 0, sizeof(struct statfs));
   ret = host_statfs(fs->fs_root, buf);
   buf->f_type = HOSTFS_MAGIC;
 

--- a/fs/littlefs/lfs_vfs.c
+++ b/fs/littlefs/lfs_vfs.c
@@ -1242,7 +1242,6 @@ static int littlefs_statfs(FAR struct inode *mountpt, FAR struct statfs *buf)
 
   /* Return something for the file system description */
 
-  memset(buf, 0, sizeof(*buf));
   buf->f_type    = LITTLEFS_SUPER_MAGIC;
   buf->f_namelen = LFS_NAME_MAX;
   buf->f_bsize   = fs->cfg.block_size;

--- a/fs/mount/fs_foreachmountpoint.c
+++ b/fs/mount/fs_foreachmountpoint.c
@@ -100,6 +100,7 @@ static int mountpoint_filter(FAR struct inode *node,
 
       /* Get the status of the file system */
 
+      memset(&statbuf, 0, sizeof(struct statfs));
       if (node->u.i_mops->statfs(node, &statbuf) == OK)
         {
           /* And pass the full path and file system status to the handler */

--- a/fs/nxffs/nxffs_stat.c
+++ b/fs/nxffs/nxffs_stat.c
@@ -74,7 +74,6 @@ int nxffs_statfs(FAR struct inode *mountpt, FAR struct statfs *buf)
    * REVISIT: Need f_bfree, f_bavail, f_files, f_ffree calculation
    */
 
-  memset(buf, 0, sizeof(struct statfs));
   buf->f_type    = NXFFS_MAGIC;
   buf->f_bsize   = volume->geo.blocksize;
   buf->f_blocks  = volume->nblocks;

--- a/fs/procfs/fs_procfs.c
+++ b/fs/procfs/fs_procfs.c
@@ -1005,7 +1005,6 @@ static int procfs_statfs(FAR struct inode *mountpt, FAR struct statfs *buf)
 {
   /* Fill in the statfs info */
 
-  memset(buf, 0, sizeof(struct statfs));
   buf->f_type    = PROCFS_MAGIC;
   buf->f_bsize   = 0;
   buf->f_blocks  = 0;

--- a/fs/romfs/fs_romfs.c
+++ b/fs/romfs/fs_romfs.c
@@ -1260,7 +1260,6 @@ static int romfs_statfs(FAR struct inode *mountpt, FAR struct statfs *buf)
 
   /* Fill in the statfs info */
 
-  memset(buf, 0, sizeof(struct statfs));
   buf->f_type    = ROMFS_MAGIC;
 
   /* We will claim that the optimal transfer size is the size of one sector */

--- a/fs/rpmsgfs/rpmsgfs.c
+++ b/fs/rpmsgfs/rpmsgfs.c
@@ -1234,7 +1234,6 @@ static int rpmsgfs_statfs(FAR struct inode *mountpt, FAR struct statfs *buf)
 
   /* Call the host fs to perform the statfs */
 
-  memset(buf, 0, sizeof(struct statfs));
   ret = rpmsgfs_client_statfs(fs->handle, fs->fs_root, buf);
   buf->f_type = RPMSGFS_MAGIC;
 

--- a/fs/smartfs/smartfs_smart.c
+++ b/fs/smartfs/smartfs_smart.c
@@ -1610,7 +1610,6 @@ static int smartfs_statfs(FAR struct inode *mountpt, FAR struct statfs *buf)
 
   /* Implement the logic!! */
 
-  memset(buf, 0, sizeof(struct statfs));
   buf->f_type = SMARTFS_MAGIC;
 
   /* Re-request the low-level format info to update free blocks */

--- a/fs/unionfs/fs_unionfs.c
+++ b/fs/unionfs/fs_unionfs.c
@@ -2045,8 +2045,6 @@ static int unionfs_statfs(FAR struct inode *mountpt, FAR struct statfs *buf)
   DEBUGASSERT(mountpt != NULL && mountpt->i_private != NULL && buf != NULL);
   ui = (FAR struct unionfs_inode_s *)mountpt->i_private;
 
-  memset(buf, 0, sizeof(struct statfs));
-
   /* Get statfs info from file system 1.
    *
    * REVISIT: What would it mean if one file system did not support statfs?
@@ -2064,6 +2062,8 @@ static int unionfs_statfs(FAR struct inode *mountpt, FAR struct statfs *buf)
               um2->um_node->u.i_mops != NULL);
   ops2 = um2->um_node->u.i_mops;
 
+  memset(&buf1, 0, sizeof(struct statfs));
+  memset(&buf2, 0, sizeof(struct statfs));
   if (ops1->statfs != NULL && ops2->statfs != NULL)
     {
       ret = ops1->statfs(um1->um_node, &buf1);

--- a/fs/vfs/fs_fstatfs.c
+++ b/fs/vfs/fs_fstatfs.c
@@ -104,6 +104,7 @@ int fstatfs(int fd, FAR struct statfs *buf)
         {
           /* Perform the statfs() operation */
 
+          memset(buf, 0, sizeof(struct statfs));
           ret = inode->u.i_mops->statfs(inode, buf);
         }
     }

--- a/fs/vfs/fs_statfs.c
+++ b/fs/vfs/fs_statfs.c
@@ -43,7 +43,6 @@
 
 static int statpseudofs(FAR struct inode *inode, FAR struct statfs *buf)
 {
-  memset(buf, 0, sizeof(struct statfs));
   buf->f_type    = PROC_SUPER_MAGIC;
   buf->f_namelen = NAME_MAX;
   return OK;
@@ -113,6 +112,7 @@ int statfs(FAR const char *path, FAR struct statfs *buf)
    * are dealing with.
    */
 
+  memset(buf, 0, sizeof(struct statfs));
 #ifndef CONFIG_DISABLE_MOUNTPOINT
   if (INODE_IS_MOUNTPT(inode))
     {

--- a/include/sys/statfs.h
+++ b/include/sys/statfs.h
@@ -104,6 +104,8 @@
  * Type Definitions
  ****************************************************************************/
 
+typedef struct fsid_s fsid_t;
+
 struct statfs
 {
   uint32_t   f_type;     /* Type of filesystem (see definitions above) */
@@ -114,6 +116,7 @@ struct statfs
   fsblkcnt_t f_bavail;   /* Free blocks avail to non-superuser */
   fsfilcnt_t f_files;    /* Total file nodes in the file system */
   fsfilcnt_t f_ffree;    /* Free file nodes in the file system */
+  fsid_t     f_fsid;     /* Encode device type, not yet in use */
 };
 
 /****************************************************************************

--- a/include/sys/types.h
+++ b/include/sys/types.h
@@ -294,6 +294,11 @@ typedef uint24_t u_int24_t;
 typedef uint64_t u_int64_t;
 #endif
 
+struct fsid_s
+{
+  int val[2];
+};
+
 /* Task entry point */
 
 typedef CODE int (*main_t)(int argc, FAR char *argv[]);

--- a/libs/libc/userfs/lib_userfs.c
+++ b/libs/libc/userfs/lib_userfs.c
@@ -588,6 +588,7 @@ static inline int userfs_statfs_dispatch(FAR struct userfs_info_s *info,
   /* Dispatch the request */
 
   DEBUGASSERT(info->userops != NULL && info->userops->statfs != NULL);
+  memset(&resp.buf, 0, sizeof(struct statfs));
   resp.ret  = info->userops->statfs(info->volinfo, &resp.buf);
 
   /* Send the response */


### PR DESCRIPTION
## Summary
if struct statfs add new members, such as f_fsid, no additional code changes are required. and add f_fsid field for third-party code compile, because NuttX doesn't have the device number, so we're not assigning a valid value here. just memset to zero.

## Impact

## Testing
sim:local
