### PR TITLE
netfilter: add NF_IP_xxx definition

### DIFF
--- a/include/nuttx/net/netfilter/netfilter.h
+++ b/include/nuttx/net/netfilter/netfilter.h
@@ -41,6 +41,15 @@
 #define NF_STOP   5 /* Deprecated, for userspace nf_queue compatibility. */
 #define NF_MAX_VERDICT NF_STOP
 
+/* IP Hooks */
+
+#define NF_IP_PRE_ROUTING  0 /* After promisc drops, checksum checks. */
+#define NF_IP_LOCAL_IN     1 /* If the packet is destined for this box. */
+#define NF_IP_FORWARD      2 /* If the packet is destined for another interface. */
+#define NF_IP_LOCAL_OUT    3 /* Packets coming from a local process. */
+#define NF_IP_POST_ROUTING 4 /* Packets about to hit the wire. */
+#define NF_IP_NUMHOOKS     5
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/


### PR DESCRIPTION
## Summary
In order to support the compilation of third-party library, we encounter some situations where the macro is not defined, refer to the common implementation of other systems and add relevant definitions.

## Impact

## Testing
sim:local
