### PR TITLE
riscv/vfork: Replace jal with call for long jump

### DIFF
--- a/arch/risc-v/src/common/vfork.S
+++ b/arch/risc-v/src/common/vfork.S
@@ -139,7 +139,7 @@ vfork:
   /* Then, call up_vfork(), passing it a pointer to the stack frame */
 
   mv          a0, sp
-  jal         x1, up_vfork
+  call        up_vfork
 
   /* Release the stack frame and return the value returned by up_vfork */
 


### PR DESCRIPTION
## Summary
riscv/vfork: Replace jal with call for long jump

Fix: relocation truncated to fit: R_RISCV_JAL against symbol for 'xxx'
## Impact
riscv vfork only
## Testing
ostest (contains vfork test) on QEMU
