### PR TITLE
pca9555: fix const correctness of pin set parameters

### DIFF
--- a/drivers/ioexpander/pca9555.c
+++ b/drivers/ioexpander/pca9555.c
@@ -71,11 +71,11 @@ static int pca9555_readbuf(FAR struct ioexpander_dev_s *dev, uint8_t pin,
              FAR bool *value);
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int pca9555_multiwritepin(FAR struct ioexpander_dev_s *dev,
-             FAR uint8_t *pins, FAR bool *values, int count);
+             FAR const uint8_t *pins, FAR bool *values, int count);
 static int pca9555_multireadpin(FAR struct ioexpander_dev_s *dev,
-             FAR uint8_t *pins, FAR bool *values, int count);
+             FAR const uint8_t *pins, FAR bool *values, int count);
 static int pca9555_multireadbuf(FAR struct ioexpander_dev_s *dev,
-             FAR uint8_t *pins, FAR bool *values, int count);
+             FAR const uint8_t *pins, FAR bool *values, int count);
 #endif
 #ifdef CONFIG_IOEXPANDER_INT_ENABLE
 static FAR void *pca9555_attach(FAR struct ioexpander_dev_s *dev,
@@ -492,7 +492,7 @@ static int pca9555_readbuf(FAR struct ioexpander_dev_s *dev, uint8_t pin,
  ****************************************************************************/
 
 static int pca9555_getmultibits(FAR struct pca9555_dev_s *pca, uint8_t addr,
-                                FAR uint8_t *pins, FAR bool *values,
+                                FAR const uint8_t *pins, FAR bool *values,
                                 int count)
 {
   uint8_t buf[2];
@@ -554,7 +554,7 @@ static int pca9555_getmultibits(FAR struct pca9555_dev_s *pca, uint8_t addr,
  ****************************************************************************/
 
 static int pca9555_multiwritepin(FAR struct ioexpander_dev_s *dev,
-                                 FAR uint8_t *pins, FAR bool *values,
+                                 FAR const uint8_t *pins, FAR bool *values,
                                  int count)
 {
   FAR struct pca9555_dev_s *pca = (FAR struct pca9555_dev_s *)dev;
@@ -652,7 +652,7 @@ static int pca9555_multiwritepin(FAR struct ioexpander_dev_s *dev,
  ****************************************************************************/
 
 static int pca9555_multireadpin(FAR struct ioexpander_dev_s *dev,
-                                FAR uint8_t *pins, FAR bool *values,
+                                FAR const uint8_t *pins, FAR bool *values,
                                 int count)
 {
   FAR struct pca9555_dev_s *pca = (FAR struct pca9555_dev_s *)dev;
@@ -690,7 +690,7 @@ static int pca9555_multireadpin(FAR struct ioexpander_dev_s *dev,
  ****************************************************************************/
 
 static int pca9555_multireadbuf(FAR struct ioexpander_dev_s *dev,
-                                FAR uint8_t *pins, FAR bool *values,
+                                FAR const uint8_t *pins, FAR bool *values,
                                 int count)
 {
   FAR struct pca9555_dev_s *pca = (FAR struct pca9555_dev_s *)dev;
@@ -747,7 +747,7 @@ static FAR void *pca9555_attach(FAR struct ioexpander_dev_s *dev,
   ret = nxmutex_lock(&pca->lock);
   if (ret < 0)
     {
-      return ret;
+      return NULL;
     }
 
   /* Find and available in entry in the callback table */

--- a/include/nuttx/ioexpander/ioexpander.h
+++ b/include/nuttx/ioexpander/ioexpander.h
@@ -322,13 +322,13 @@ struct ioexpander_ops_s
                           FAR bool *value);
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
   CODE int (*ioe_multiwritepin)(FAR struct ioexpander_dev_s *dev,
-                                FAR uint8_t *pins, FAR bool *values,
+                                FAR const uint8_t *pins, FAR bool *values,
                                 int count);
   CODE int (*ioe_multireadpin)(FAR struct ioexpander_dev_s *dev,
-                               FAR uint8_t *pins, FAR bool *values,
+                               FAR const uint8_t *pins, FAR bool *values,
                                int count);
   CODE int (*ioe_multireadbuf)(FAR struct ioexpander_dev_s *dev,
-                               FAR uint8_t *pins, FAR bool *values,
+                               FAR const uint8_t *pins, FAR bool *values,
                                int count);
 #endif
 #ifdef CONFIG_IOEXPANDER_INT_ENABLE


### PR DESCRIPTION
## Summary
Make sure the pin sets are marked const

## Impact
Less warnings when passing const pin sets to pca9555 functions

## Testing
New code working as expected on our test configs