### PR TITLE
boards: spresense: Fix boards implements for supporting PM System

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_idle.c
+++ b/arch/arm/src/cxd56xx/cxd56_idle.c
@@ -116,11 +116,15 @@ static void up_idlepm(void)
             break;
 
           case PM_STANDBY:
-            cxd56_pmstandby(true);
+
+            /* Not supported yet */
+
             break;
 
           case PM_SLEEP:
-            cxd56_pmsleep();
+
+            /* Not supported yet */
+
             break;
 
           default:

--- a/boards/arm/cxd56xx/common/src/Make.defs
+++ b/boards/arm/cxd56xx/common/src/Make.defs
@@ -178,6 +178,10 @@ ifeq ($(CONFIG_BOARD_USBDEV_SERIALSTR),y)
   CSRCS += cxd56_usbdevserialstr.c
 endif
 
+ifeq ($(CONFIG_PM),y)
+  CSRCS += cxd56_pm.c
+endif
+
 DEPPATH += --dep-path src
 VPATH += :src
 CFLAGS += $(shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)arch$(DELIM)$(CONFIG_ARCH)$(DELIM)src$(DELIM)board$(DELIM)src)

--- a/boards/arm/cxd56xx/common/src/cxd56_pm.c
+++ b/boards/arm/cxd56xx/common/src/cxd56_pm.c
@@ -1,0 +1,56 @@
+/****************************************************************************
+ * boards/arm/cxd56xx/common/src/cxd56_pm.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/power/pm.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: arm_pminitialize
+ *
+ * Description:
+ *   This function is called by MCU-specific logic at power-on reset in
+ *   order to provide one-time initialization the power management subsystem.
+ *   This function must be called *very* early in the initialization sequence
+ *   *before* any other device drivers are initialized (since they may
+ *   attempt to register with the power management subsystem).
+ *
+ * Input Parameters:
+ *   None.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void arm_pminitialize(void)
+{
+  /* Then initialize the NuttX power management subsystem proper */
+
+  pm_initialize();
+}
+

--- a/boards/arm/cxd56xx/spresense/include/board.h
+++ b/boards/arm/cxd56xx/spresense/include/board.h
@@ -216,6 +216,11 @@ enum board_power_device
 #define BOARD_POWEROFF_DEEP (0)
 #define BOARD_POWEROFF_COLD (1)
 
+/* Power domain definitions *************************************************/
+
+#define BOARD_PM_IDLE       (0)
+#define BOARD_PM_APPS       (1)
+
 /* CXD5247 audio control definitions ****************************************/
 
 #define CXD5247_XRST  PIN_SPI3_CS2_X


### PR DESCRIPTION
## Summary

Fix spresense boards code for supporting PM System.

## Impact

Spresense boards only.

## Testing

Spresense boards with LTE.
