### PR TITLE
riscv/barrier: Define more granular memory barriers

### DIFF
--- a/arch/risc-v/include/barriers.h
+++ b/arch/risc-v/include/barriers.h
@@ -21,12 +21,20 @@
 #ifndef __ARCH_RISCV_INCLUDE_BARRIERS_H
 #define __ARCH_RISCV_INCLUDE_BARRIERS_H
 
-/* Common memory barriers:
- * __DMB() is used to synchronize external devices (I/O domain mainly)
- * __ISB() is used to synchronize the instruction and data streams
- */
+/* Common memory barriers (p=predecessor, s=successor) */
 
-#define __DMB()             __asm__ __volatile__ ("fence"   ::: "memory")
-#define __ISB()             __asm__ __volatile__ ("fence.i" ::: "memory")
+#define __FENCE(p, s) __asm__ __volatile__ ("fence "#p", "#s  ::: "memory")
+
+/* __DMB() is used to flush local data caches (memory) */
+
+#define __DMB()       __FENCE(rw, rw)
+
+/* __MB() is a full memory barrier */
+
+#define __MB()        __FENCE(iorw, iorw)
+
+/* __ISB() is used to synchronize the instruction and data streams */
+
+#define __ISB()       __asm__ __volatile__ ("fence.i" ::: "memory")
 
 #endif /* __ARCH_RISCV_INCLUDE_BARRIERS_H */

--- a/arch/risc-v/src/common/riscv_addrenv.c
+++ b/arch/risc-v/src/common/riscv_addrenv.c
@@ -736,10 +736,8 @@ int up_addrenv_select(const arch_addrenv_t *addrenv)
 
 int up_addrenv_coherent(const arch_addrenv_t *addrenv)
 {
-  /* Flush the instruction and data caches */
+  /* Nothing needs to be done */
 
-  __ISB();
-  __DMB();
   return OK;
 }
 

--- a/arch/risc-v/src/common/riscv_mmu.h
+++ b/arch/risc-v/src/common/riscv_mmu.h
@@ -187,7 +187,8 @@ static inline void mmu_write_satp(uintptr_t reg)
     (
       "csrw satp, %0\n"
       "sfence.vma x0, x0\n"
-      "fence\n"
+      "fence rw, rw\n"
+      "fence.i\n"
       :
       : "rK" (reg)
       : "memory"

--- a/arch/risc-v/src/common/riscv_mtimer.c
+++ b/arch/risc-v/src/common/riscv_mtimer.c
@@ -124,7 +124,7 @@ static void riscv_mtimer_set_mtimecmp(struct riscv_mtimer_lowerhalf_s *priv,
 
   /* Make sure it sticks */
 
-  __DMB();
+  __MB();
 }
 #else
 static uint64_t riscv_mtimer_get_mtime(struct riscv_mtimer_lowerhalf_s *priv)

--- a/arch/risc-v/src/common/riscv_percpu.c
+++ b/arch/risc-v/src/common/riscv_percpu.c
@@ -147,7 +147,7 @@ void riscv_percpu_add_hart(uintptr_t hartid)
 
   /* Make sure it sticks */
 
-  __DMB();
+  __MB();
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/mpfs/mpfs_gpio.c
+++ b/arch/risc-v/src/mpfs/mpfs_gpio.c
@@ -100,7 +100,7 @@ static struct gpio_callback_s g_mss_gpio_callbacks[GPIO_BANK0_NUM_PINS +
 static void mpfs_gpio_irq_clear(int bank, int pin)
 {
   putreg32(1 << pin, g_gpio_base[bank] + MPFS_GPIO_INTR_OFFSET);
-  __DMB();
+  __MB();
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/nuttsbi/sbi_mscratch.c
+++ b/arch/risc-v/src/nuttsbi/sbi_mscratch.c
@@ -81,5 +81,5 @@ void sbi_mscratch_assign(uintptr_t hartid)
 
   /* Make sure mscratch is updated before continuing */
 
-  __DMB();
+  __MB();
 }

--- a/arch/risc-v/src/nuttsbi/sbi_mtimer.c
+++ b/arch/risc-v/src/nuttsbi/sbi_mtimer.c
@@ -96,5 +96,5 @@ void sbi_set_mtimecmp(uint64_t value)
 
   /* Make sure it sticks */
 
-  __DMB();
+  __MB();
 }


### PR DESCRIPTION
## Summary
Separate barriers for full (memory + I/O) and local memory (cache) flushing.
## Impact
Allow for more granular fencing
## Testing
icicle:knsh
