### PR TITLE
sched/pthread: Return ESRCH when the task is in the process of exit.

### DIFF
--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -702,6 +702,7 @@ struct pthread_tcb_s
   pthread_trampoline_t trampoline;       /* User-space pthread startup function */
   pthread_addr_t arg;                    /* Startup argument                    */
   FAR void *joininfo;                    /* Detach-able info to support join    */
+  bool join_complete;                    /* Join was completed                  */
 };
 #endif /* !CONFIG_DISABLE_PTHREAD */
 

--- a/sched/pthread/pthread.h
+++ b/sched/pthread/pthread.h
@@ -84,8 +84,8 @@ int pthread_setup_scheduler(FAR struct pthread_tcb_s *tcb, int priority,
 int pthread_completejoin(pid_t pid, FAR void *exit_value);
 void pthread_destroyjoin(FAR struct task_group_s *group,
                          FAR struct join_s *pjoin);
-FAR struct join_s *pthread_findjoininfo(FAR struct task_group_s *group,
-                                        pid_t pid);
+int pthread_findjoininfo(FAR struct task_group_s *group,
+                         pid_t pid, FAR struct join_s **join);
 void pthread_release(FAR struct task_group_s *group);
 
 int pthread_sem_take(FAR sem_t *sem, FAR const struct timespec *abs_timeout);

--- a/sched/pthread/pthread_detach.c
+++ b/sched/pthread/pthread_detach.c
@@ -73,28 +73,8 @@ int pthread_detach(pthread_t thread)
   /* Find the entry associated with this pthread. */
 
   nxmutex_lock(&group->tg_joinlock);
-  pjoin = pthread_findjoininfo(group, (pid_t)thread);
-  if (!pjoin)
-    {
-      FAR struct tcb_s *tcb = nxsched_get_tcb((pid_t)thread);
-
-      serr("ERROR: Could not find thread entry\n");
-
-      if (tcb == NULL)
-        {
-          ret = ESRCH;
-        }
-
-      /* The thread is still active but has no join info.  In that
-       * case, it must be a task and not a pthread.
-       */
-
-      else
-        {
-          ret = EINVAL;
-        }
-    }
-  else
+  ret = pthread_findjoininfo(group, (pid_t)thread, &pjoin);
+  if (ret == OK)
     {
       /* Has the thread already terminated? */
 


### PR DESCRIPTION
## Summary

Resolving the issue with the ltp_interfaces_pthread_join_6_2 test case.

In SMP mode, the pthread may still be in the process of exiting when pthread_join returns, and calling pthread_join again at this time will result in an error. The error code returned should be  ESRCH.

## Impact

pthread join

## Testing

Bes board with ostest and ltp_interfaces_pthread_join_6_2 test case pass