### PR TITLE
netdev/upper: Optimize on quota related operations

### DIFF
--- a/drivers/net/netdev_upperhalf.c
+++ b/drivers/net/netdev_upperhalf.c
@@ -107,23 +107,6 @@ static int quota_fetch_dec(FAR struct netdev_lowerhalf_s *lower,
 }
 
 /****************************************************************************
- * Name: quota_load
- *
- * Description:
- *   Fetch the quota, works like atomic_load.
- *
- ****************************************************************************/
-
-static int quota_load(FAR struct netdev_lowerhalf_s *lower,
-                      enum netpkt_type_e type)
-{
-  irqstate_t flags = spin_lock_irqsave(NULL);
-  int ret = lower->quota[type];
-  spin_unlock_irqrestore(NULL, flags);
-  return ret;
-}
-
-/****************************************************************************
  * Name: netpkt_get
  *
  * Description:
@@ -232,7 +215,7 @@ netdev_upper_alloc(FAR struct netdev_lowerhalf_s *dev)
 
 static inline bool netdev_upper_can_tx(FAR struct netdev_upperhalf_s *upper)
 {
-  return quota_load(upper->lower, NETPKT_TX) > 0;
+  return netdev_lower_quota_load(upper->lower, NETPKT_TX) > 0;
 }
 
 /****************************************************************************
@@ -838,6 +821,27 @@ void netdev_lower_txdone(FAR struct netdev_lowerhalf_s *dev)
 {
   NETDEV_TXDONE(&dev->netdev);
   netdev_upper_queue_work(&dev->netdev);
+}
+
+/****************************************************************************
+ * Name: netdev_lower_quota_load
+ *
+ * Description:
+ *   Fetch the quota, works like atomic_load.
+ *
+ * Input Parameters:
+ *   dev  - The lower half device driver structure
+ *   type - Whether get quota for TX or RX
+ *
+ ****************************************************************************/
+
+int netdev_lower_quota_load(FAR struct netdev_lowerhalf_s *dev,
+                            enum netpkt_type_e type)
+{
+  irqstate_t flags = spin_lock_irqsave(NULL);
+  int ret = dev->quota[type];
+  spin_unlock_irqrestore(NULL, flags);
+  return ret;
 }
 
 /****************************************************************************

--- a/drivers/net/netdev_upperhalf.c
+++ b/drivers/net/netdev_upperhalf.c
@@ -91,19 +91,27 @@ struct netdev_upperhalf_s
 static int quota_fetch_inc(FAR struct netdev_lowerhalf_s *lower,
                            enum netpkt_type_e type)
 {
+#ifndef HAVE_ATOMIC
   irqstate_t flags = spin_lock_irqsave(NULL);
   int ret = lower->quota[type]++;
   spin_unlock_irqrestore(NULL, flags);
   return ret;
+#else
+  return atomic_fetch_add(&lower->quota[type], 1);
+#endif
 }
 
 static int quota_fetch_dec(FAR struct netdev_lowerhalf_s *lower,
                            enum netpkt_type_e type)
 {
+#ifndef HAVE_ATOMIC
   irqstate_t flags = spin_lock_irqsave(NULL);
   int ret = lower->quota[type]--;
   spin_unlock_irqrestore(NULL, flags);
   return ret;
+#else
+  return atomic_fetch_sub(&lower->quota[type], 1);
+#endif
 }
 
 /****************************************************************************
@@ -838,10 +846,14 @@ void netdev_lower_txdone(FAR struct netdev_lowerhalf_s *dev)
 int netdev_lower_quota_load(FAR struct netdev_lowerhalf_s *dev,
                             enum netpkt_type_e type)
 {
+#ifndef HAVE_ATOMIC
   irqstate_t flags = spin_lock_irqsave(NULL);
   int ret = dev->quota[type];
   spin_unlock_irqrestore(NULL, flags);
   return ret;
+#else
+  return atomic_load(&dev->quota[type]);
+#endif
 }
 
 /****************************************************************************

--- a/include/nuttx/net/netdev_lowerhalf.h
+++ b/include/nuttx/net/netdev_lowerhalf.h
@@ -235,6 +235,21 @@ void netdev_lower_rxready(FAR struct netdev_lowerhalf_s *dev);
 void netdev_lower_txdone(FAR struct netdev_lowerhalf_s *dev);
 
 /****************************************************************************
+ * Name: netdev_lower_quota_load
+ *
+ * Description:
+ *   Fetch the quota, use this interface when device is running.
+ *
+ * Input Parameters:
+ *   dev  - The lower half device driver structure
+ *   type - Whether get quota for TX or RX
+ *
+ ****************************************************************************/
+
+int netdev_lower_quota_load(FAR struct netdev_lowerhalf_s *dev,
+                            enum netpkt_type_e type);
+
+/****************************************************************************
  * Name: netpkt_alloc
  *
  * Description:


### PR DESCRIPTION
## Summary
Patches included:
- netdev/upper: Make quota_load public
  - In case some lower-half need to get current quota, like https://github.com/apache/nuttx/pull/9297
- netdev/upper: Use atomic when we have atomic support from compiler
  - Checks whether current compiler supports atomic, and use atomic instead of spin_lock to optimize performance.

## Impact
netdev upper half, currently used on sim only

## Testing
sim and https://github.com/apache/nuttx/pull/9297
