### PR TITLE
Openamp/Kconfig: add cache and debug config for openamp

### DIFF
--- a/openamp/Kconfig
+++ b/openamp/Kconfig
@@ -11,4 +11,11 @@ config OPENAMP
 
 if OPENAMP
 
+config OPENAMP_CACHE
+	bool "Enable OpenAMP Cache support"
+	default n
+	---help---
+		Enable or disable OpenAMP Cache support (VIRTIO_CACHED_BUFFERS and
+		VIRTIO_CACHED_VRINGS)
+
 endif # OPENAMP

--- a/openamp/Kconfig
+++ b/openamp/Kconfig
@@ -18,4 +18,12 @@ config OPENAMP_CACHE
 		Enable or disable OpenAMP Cache support (VIRTIO_CACHED_BUFFERS and
 		VIRTIO_CACHED_VRINGS)
 
+config OPENAMP_RPMSG_DEBUG
+	bool "Enable OpenAMP Rpmsg Debug"
+	default n
+
+config OPENAMP_VQUEUE_DEBUG
+	bool "Enable OpenAMP Virtio Queue Debug"
+	default n
+
 endif # OPENAMP

--- a/openamp/open-amp.defs
+++ b/openamp/open-amp.defs
@@ -20,6 +20,10 @@
 
 ifeq ($(CONFIG_OPENAMP),y)
 
+ifeq ($(CONFIG_OPENAMP_CACHE),y)
+  CFLAGS += -DVIRTIO_CACHED_BUFFERS -DVIRTIO_CACHED_VRINGS
+endif
+
 CSRCS += open-amp/lib/remoteproc/elf_loader.c
 CSRCS += open-amp/lib/remoteproc/remoteproc.c
 CSRCS += open-amp/lib/remoteproc/remoteproc_virtio.c

--- a/openamp/open-amp.defs
+++ b/openamp/open-amp.defs
@@ -24,6 +24,14 @@ ifeq ($(CONFIG_OPENAMP_CACHE),y)
   CFLAGS += -DVIRTIO_CACHED_BUFFERS -DVIRTIO_CACHED_VRINGS
 endif
 
+ifeq ($(CONFIG_OPENAMP_RPMSG_DEBUG),y)
+  CFLAGS += -DRPMSG_DEBUG
+endif
+
+ifeq ($(CONFIG_OPENAMP_VQUEUE_DEBUG),y)
+  CFLAGS += -DVQUEUE_DEBUG
+endif
+
 CSRCS += open-amp/lib/remoteproc/elf_loader.c
 CSRCS += open-amp/lib/remoteproc/remoteproc.c
 CSRCS += open-amp/lib/remoteproc/remoteproc_virtio.c


### PR DESCRIPTION
## Summary
Commit 1:
openamp/Kconfig: add config to enable/disable the cache feature

Commit 2:
openamp: add OPENAMP_DEBUG config to enable/disable openamp debug

## Impact
None

## Testing
Test with bes board.

