### PR TITLE
Rptun: rptun and rptun_dump bug fix

### DIFF
--- a/drivers/rptun/rptun.c
+++ b/drivers/rptun/rptun.c
@@ -1194,6 +1194,8 @@ int rptun_initialize(FAR struct rptun_dev_s *dev)
       goto err_driver;
     }
 
+  nxsem_init(&priv->semtx, 0, 0);
+
 #ifdef CONFIG_RPTUN_WORKQUEUE
   if (RPTUN_IS_AUTOSTART(dev))
     {
@@ -1221,12 +1223,11 @@ int rptun_initialize(FAR struct rptun_dev_s *dev)
   if (ret < 0)
     {
       unregister_driver(name);
+      nxsem_destroy(&priv->semtx);
       nxsem_destroy(&priv->semrx);
       goto err_driver;
     }
 #endif
-
-  nxsem_init(&priv->semtx, 0, 0);
 
   /* Add priv to list */
 


### PR DESCRIPTION
## Summary
Commit 1:
rptun: init the semtx before the thread/workqueue created

If the rptun driver set auto start, the smetx may has been used
in rptun_notify_wait() but not inited.

Commit 2:
rptun_dump: do not acquire the lock when has hold the lock

Otherwise, system will crash again when call rptun_dump_all()
after has acquired the lock.

## Impact
Bug Fix

## Testing
Local test with bes board.

