### PR TITLE
mm: mm leak dump build error fix and memory foreach optimization

### DIFF
--- a/mm/mm_heap/mm_foreach.c
+++ b/mm/mm_heap/mm_foreach.c
@@ -94,6 +94,7 @@ void mm_foreach(FAR struct mm_heap_s *heap, mm_node_handler_t handler,
       minfo("region=%d node=%p heapend=%p\n",
             region, node, heap->mm_heapend[region]);
       DEBUGASSERT(node == heap->mm_heapend[region]);
+      handler(node, arg);
 
       mm_unlock(heap);
     }

--- a/mm/mm_heap/mm_mallinfo.c
+++ b/mm/mm_heap/mm_mallinfo.c
@@ -141,11 +141,6 @@ struct mallinfo mm_mallinfo(FAR struct mm_heap_s *heap)
 #if CONFIG_MM_HEAP_MEMPOOL_THRESHOLD != 0
   struct mallinfo poolinfo;
 #endif
-#if CONFIG_MM_REGIONS > 1
-  int region = heap->mm_nregions;
-#else
-#  define region 1
-#endif
 
   memset(&info, 0, sizeof(info));
   mm_foreach(heap, mallinfo_handler, &info);
@@ -157,15 +152,6 @@ struct mallinfo mm_mallinfo(FAR struct mm_heap_s *heap)
   info.uordblks -= poolinfo.fordblks;
   info.fordblks += poolinfo.fordblks;
 #endif
-
-  /* Account for the heap->mm_heapend[region] node overhead and the
-   * heap->mm_heapstart[region]->preceding:
-   * heap->mm_heapend[region] overhead size     = OVERHEAD_MM_ALLOCNODE
-   * heap->mm_heapstart[region]->preceding size = sizeof(mmsize_t)
-   * and SIZEOF_MM_ALLOCNODE = OVERHEAD_MM_ALLOCNODE + sizeof(mmsize_t).
-   */
-
-  info.uordblks += region * SIZEOF_MM_ALLOCNODE;
 
   DEBUGASSERT((size_t)info.uordblks + info.fordblks == heap->mm_heapsize);
 

--- a/sched/task/task_exithook.c
+++ b/sched/task/task_exithook.c
@@ -409,6 +409,17 @@ static inline void nxtask_exitwakeup(FAR struct tcb_s *tcb, int status)
 
 void nxtask_exithook(FAR struct tcb_s *tcb, int status)
 {
+#ifdef CONFIG_SCHED_DUMP_LEAK
+  struct mm_memdump_s dump =
+  {
+    tcb->pid,
+#  if CONFIG_MM_BACKTRACE >= 0
+    0,
+    ULONG_MAX
+#  endif
+  };
+#endif
+
   /* Under certain conditions, nxtask_exithook() can be called multiple
    * times.  A bit in the TCB was set the first time this function was
    * called.  If that bit is set, then just exit doing nothing more..
@@ -463,11 +474,11 @@ void nxtask_exithook(FAR struct tcb_s *tcb, int status)
 #ifdef CONFIG_SCHED_DUMP_LEAK
   if ((tcb->flags & TCB_FLAG_TTYPE_MASK) == TCB_FLAG_TTYPE_KERNEL)
     {
-      kmm_memdump(tcb->pid);
+      kmm_memdump(&dump);
     }
   else
     {
-      umm_memdump(tcb->pid);
+      umm_memdump(&dump);
     }
 #endif
 


### PR DESCRIPTION
## Summary
Commit 1:
taks_exithook: fix the build error when enable CONFIG_SCHED_DUMP_LEAK

Commit 2:
mm_heap: dump and stat the mm_heapend node also

## Impact
Should be None

## Testing
local test with bes board
