### PR TITLE
rpmsg: add fdsan support for rpmsg dev/mtd/blk

### DIFF
--- a/drivers/mtd/rpmsgmtd.c
+++ b/drivers/mtd/rpmsgmtd.c
@@ -85,7 +85,7 @@ static ssize_t rpmsgmtd_read(FAR struct mtd_dev_s *dev, off_t offset,
 static ssize_t rpmsgmtd_write(FAR struct mtd_dev_s *dev, off_t offset,
                               size_t nbytes, FAR const uint8_t *buffer);
 #endif
-static size_t  rpmsgmtd_ioctl_arglen(int cmd);
+static ssize_t rpmsgmtd_ioctl_arglen(int cmd);
 static int     rpmsgmtd_ioctl(FAR struct mtd_dev_s *dev, int cmd,
                               unsigned long arg);
 
@@ -548,7 +548,7 @@ out:
  *
  ****************************************************************************/
 
-static size_t rpmsgmtd_ioctl_arglen(int cmd)
+static ssize_t rpmsgmtd_ioctl_arglen(int cmd)
 {
   switch (cmd)
     {
@@ -558,7 +558,7 @@ static size_t rpmsgmtd_ioctl_arglen(int cmd)
       case MTDIOC_UNPROTECT:
         return sizeof(struct mtd_protect_s);
       default:
-        return 0;
+        return -ENOTTY;
     }
 }
 
@@ -584,7 +584,7 @@ static int rpmsgmtd_ioctl(FAR struct mtd_dev_s *dev, int cmd,
   FAR struct rpmsgmtd_s *priv = (FAR struct rpmsgmtd_s *)dev;
   FAR struct rpmsgmtd_ioctl_s *msg;
   uint32_t space;
-  size_t arglen;
+  ssize_t arglen;
   size_t msglen;
 
   /* Sanity checks */
@@ -594,6 +594,11 @@ static int rpmsgmtd_ioctl(FAR struct mtd_dev_s *dev, int cmd,
   /* Call our internal routine to perform the ioctl */
 
   arglen = rpmsgmtd_ioctl_arglen(cmd);
+  if (arglen < 0)
+    {
+      return arglen;
+    }
+
   msglen = sizeof(*msg) + arglen - 1;
 
   msg = rpmsgmtd_get_tx_payload_buffer(priv, &space);

--- a/fs/rpmsgfs/rpmsgfs_client.c
+++ b/fs/rpmsgfs/rpmsgfs_client.c
@@ -380,7 +380,7 @@ fail:
   return ret;
 }
 
-static size_t rpmsgfs_ioctl_arglen(int cmd)
+static ssize_t rpmsgfs_ioctl_arglen(int cmd)
 {
   switch (cmd)
     {
@@ -389,7 +389,7 @@ static size_t rpmsgfs_ioctl_arglen(int cmd)
       case FIONREAD:
         return sizeof(int);
       default:
-        return 0;
+        return -ENOTTY;
     }
 }
 
@@ -567,11 +567,16 @@ off_t rpmsgfs_client_lseek(FAR void *handle, int fd,
 int rpmsgfs_client_ioctl(FAR void *handle, int fd,
                          int request, unsigned long arg)
 {
-  size_t arglen = rpmsgfs_ioctl_arglen(request);
+  ssize_t arglen = rpmsgfs_ioctl_arglen(request);
   FAR struct rpmsgfs_s *priv = handle;
   FAR struct rpmsgfs_ioctl_s *msg;
   uint32_t space;
   size_t len;
+
+  if (arglen < 0)
+    {
+      return arglen;
+    }
 
   len = sizeof(*msg) + arglen;
   msg = rpmsgfs_get_tx_payload_buffer(priv, &space);


### PR DESCRIPTION
## Summary
Directly return -ENOTTY in rpmsgxxx_ioctl() when the command is not supported to avoid fdsan command FIOC_SETTAG and FIOC_GETTAG pass to the rpmsg dev/mtd/blk server with CONFIG_FDSAN enabled. 

## Impact
Shoule be none.

## Testing
sim:rpserver/rpproxy
