### PR TITLE
lib_syslograwstream: fix bug when iob alloc failed

### DIFF
--- a/include/nuttx/streams.h
+++ b/include/nuttx/streams.h
@@ -255,10 +255,10 @@ struct lib_syslograwstream_s
 #  else
   char buffer[CONFIG_SYSLOG_BUFSIZE];
 #  endif
-#endif
   FAR char *base;
   int size;
   int offset;
+#endif
   int last_ch;
 };
 

--- a/libs/libc/stream/lib_syslograwstream.c
+++ b/libs/libc/stream/lib_syslograwstream.c
@@ -288,14 +288,19 @@ void lib_syslograwstream_open(FAR struct lib_syslograwstream_s *stream)
       stream->base = (FAR void *)stream->iob->io_data;
       stream->size = sizeof(stream->iob->io_data);
     }
+  else
+    {
+      stream->base = NULL;
+      stream->size = 0;
+    }
 #  else
   stream->base = stream->buffer;
   stream->size = sizeof(stream->buffer);
 #  endif
+  stream->offset = 0;
 #else
   stream->public.flush = lib_noflush;
 #endif
-  stream->offset = 0;
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
Fix a bug in lib_syslograwstream_open() when iob alloc failed. 

## Impact
Should be None.

## Testing
Local test with bes board.
