### PR TITLE
fs: some minor changed about the fs

### DIFF
--- a/fs/romfs/fs_romfs.c
+++ b/fs/romfs/fs_romfs.c
@@ -604,7 +604,6 @@ static int romfs_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
       return OK;
     }
 
-  ferr("ERROR: Invalid cmd: %d\n", cmd);
   return -ENOTTY;
 }
 

--- a/fs/vfs/fs_fsync.c
+++ b/fs/vfs/fs_fsync.c
@@ -64,12 +64,14 @@ int file_fsync(FAR struct file *filep)
   if (inode != NULL)
     {
 #ifndef CONFIG_DISABLE_MOUNTPOINT
-      if (INODE_IS_MOUNTPT(inode) && inode->u.i_mops &&
-          inode->u.i_mops->sync)
+      if (INODE_IS_MOUNTPT(inode))
         {
-          /* Yes, then tell the mountpoint to sync this file */
+          if (inode->u.i_mops && inode->u.i_mops->sync)
+            {
+              /* Yes, then tell the mountpoint to sync this file */
 
-          return inode->u.i_mops->sync(filep);
+              return inode->u.i_mops->sync(filep);
+            }
         }
       else
 #endif


### PR DESCRIPTION
## Summary
Commit1: fs_romfs: avoid the romfs ERROR log when enable FDSAN
Error log:
[    0.003400] [remote] romfs_ioctl: ERROR: Invalid cmd: 783
[    0.003400] [remote] romfs_ioctl: ERROR: Invalid cmd: 782
[    0.003500] [remote] romfs_ioctl: ERROR: Invalid cmd: 783
[    0.003600] [remote] romfs_ioctl: ERROR: Invalid cmd: 782
[    0.042900] [remote] romfs_ioctl: ERROR: Invalid cmd: 783
[    0.043100] [remote] romfs_ioctl: ERROR: Invalid cmd: 782

Commit2: fs_fsync: should not call fs's ioctl when fs not support sync api

## Impact
None

## Testing
Local test with bes board and sim.
