### PR TITLE
stm32 tickless: stop assertion when calling up_timer_gettime

### DIFF
--- a/arch/arm/src/stm32/stm32_tickless.c
+++ b/arch/arm/src/stm32/stm32_tickless.c
@@ -614,7 +614,16 @@ int up_timer_gettime(struct timespec *ts)
   int pending;
   irqstate_t flags;
 
-  DEBUGASSERT(g_tickless.tch && ts);
+  DEBUGASSERT(ts);
+
+  /* Timer not initialized yet, return zero */
+
+  if (g_tickless.tch == 0)
+    {
+      ts->tv_nsec = 0;
+      ts->tv_sec  = 0;
+      return OK;
+    }
 
   /* Temporarily disable the overflow counter.  NOTE that we have to be
    * careful here because  stm32_tc_getpending() will reset the pending
@@ -938,6 +947,7 @@ int up_timer_start(const struct timespec *ts)
   /* Set interval compare value. Rollover is fine,
    * channel will trigger on the next period.
    */
+
 #ifdef HAVE_32BIT_TICKLESS
   DEBUGASSERT(period <= UINT32_MAX);
   g_tickless.period = (uint32_t)(period + count);


### PR DESCRIPTION
## Summary

When `CONFIG_SCHED_TICKLESS` and `CONFIG_SCHED_IRQMONITOR` is enabled...

`up_timer_gettime` is called before `g_tickless` is initialised (within `up_timer_initialize`) which causes an assertion.

Instead of asserting on uninitialised `g_tickless`, simply return 0 instead.

This fix aligns with the stm32f7 implementation.

## Impact
Any stm32 platform with `CONFIG_SCHED_TICKLESS` and `CONFIG_SCHED_IRQMONITOR` enabled.

## Testing
Tested on the stm32f4discovery
