### PR TITLE
compute the heap info more accuracy

### DIFF
--- a/mm/mempool/mempool.c
+++ b/mm/mempool/mempool.c
@@ -163,7 +163,7 @@ int mempool_init(FAR struct mempool_s *pool, FAR const char *name)
       pool->ibase = NULL;
     }
 
-  if (pool->initialsize > sizeof(sq_entry_t))
+  if (pool->initialsize >= blocksize + sizeof(sq_entry_t))
     {
       size_t ninitial = (pool->initialsize - sizeof(sq_entry_t)) / blocksize;
       size_t size = ninitial * blocksize + sizeof(sq_entry_t);
@@ -239,10 +239,11 @@ retry:
         }
       else
         {
+          size_t blocksize = MEMPOOL_REALBLOCKSIZE(pool);
+
           spin_unlock_irqrestore(&pool->lock, flags);
-          if (pool->expandsize > sizeof(sq_entry_t))
+          if (pool->expandsize >= blocksize + sizeof(sq_entry_t))
             {
-              size_t blocksize = MEMPOOL_REALBLOCKSIZE(pool);
               size_t nexpand = (pool->expandsize - sizeof(sq_entry_t)) /
                                blocksize;
               size_t size = nexpand * blocksize + sizeof(sq_entry_t);
@@ -545,14 +546,14 @@ int mempool_deinit(FAR struct mempool_s *pool)
       return -EBUSY;
     }
 
-  if (pool->initialsize > sizeof(sq_entry_t))
+  if (pool->initialsize >= blocksize + sizeof(sq_entry_t))
     {
       count = (pool->initialsize - sizeof(sq_entry_t)) / blocksize;
     }
 
   if (count == 0)
     {
-      if (pool->expandsize > sizeof(sq_entry_t))
+      if (pool->expandsize >= blocksize + sizeof(sq_entry_t))
         {
           count = (pool->expandsize - sizeof(sq_entry_t)) / blocksize;
         }
@@ -566,7 +567,7 @@ int mempool_deinit(FAR struct mempool_s *pool)
     {
       blk = (FAR sq_entry_t *)((FAR char *)blk - count * blocksize);
       pool->free(pool, blk);
-      if (pool->expandsize > sizeof(sq_entry_t))
+      if (pool->expandsize >= blocksize + sizeof(sq_entry_t))
         {
           count = (pool->expandsize - sizeof(sq_entry_t)) / blocksize;
         }

--- a/mm/mm_heap/mm_mallinfo.c
+++ b/mm/mm_heap/mm_mallinfo.c
@@ -145,6 +145,8 @@ struct mallinfo mm_mallinfo(FAR struct mm_heap_s *heap)
   memset(&info, 0, sizeof(info));
   mm_foreach(heap, mallinfo_handler, &info);
   info.arena = heap->mm_heapsize;
+  info.arena += sizeof(struct mm_heap_s);
+  info.uordblks += sizeof(struct mm_heap_s);
 
 #if CONFIG_MM_HEAP_MEMPOOL_THRESHOLD != 0
   poolinfo = mempool_multiple_mallinfo(heap->mm_mpool);
@@ -153,7 +155,7 @@ struct mallinfo mm_mallinfo(FAR struct mm_heap_s *heap)
   info.fordblks += poolinfo.fordblks;
 #endif
 
-  DEBUGASSERT((size_t)info.uordblks + info.fordblks == heap->mm_heapsize);
+  DEBUGASSERT(info.uordblks + info.fordblks == info.arena);
 
   return info;
 }


### PR DESCRIPTION
## Summary

- mm/mempool: Avoid the allocation number of expend block equals zero
- mm/heap: Count mm_heap_s overhead in mm_mallinfo

## Impact

heap info

## Testing

sim:kasan