### PR TITLE
Compute the heap info more accuracy(2)

### DIFF
--- a/binfmt/binfmt_execmodule.c
+++ b/binfmt/binfmt_execmodule.c
@@ -294,7 +294,7 @@ int exec_module(FAR struct binary_s *binp,
     }
 #endif
 
-  return (int)pid;
+  return pid;
 
 errout_with_tcbinit:
 #ifndef CONFIG_BUILD_KERNEL

--- a/fs/procfs/fs_procfs.c
+++ b/fs/procfs/fs_procfs.c
@@ -847,14 +847,14 @@ static int procfs_readdir(FAR struct inode *mountpt,
           FAR struct tcb_s *tcb = nxsched_get_tcb(pid);
           if (!tcb)
             {
-              ferr("ERROR: PID %d is no longer valid\n", (int)pid);
+              ferr("ERROR: PID %d is no longer valid\n", pid);
               return -ENOENT;
             }
 
           /* Save the filename=pid and file type=directory */
 
           entry->d_type = DTYPE_DIRECTORY;
-          procfs_snprintf(entry->d_name, NAME_MAX + 1, "%d", (int)pid);
+          procfs_snprintf(entry->d_name, NAME_MAX + 1, "%d", pid);
 
           /* Set up the next directory entry offset.  NOTE that we could use
            * the standard f_pos instead of our own private index.

--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -1474,7 +1474,7 @@ static int proc_open(FAR struct file *filep, FAR const char *relpath,
   tcb = nxsched_get_tcb(pid);
   if (tcb == NULL)
     {
-      ferr("ERROR: PID %d is no longer valid\n", (int)pid);
+      ferr("ERROR: PID %d is no longer valid\n", pid);
       return -ENOENT;
     }
 
@@ -1561,7 +1561,7 @@ static ssize_t proc_read(FAR struct file *filep, FAR char *buffer,
   tcb = nxsched_get_tcb(procfile->pid);
   if (tcb == NULL)
     {
-      ferr("ERROR: PID %d is not valid\n", (int)procfile->pid);
+      ferr("ERROR: PID %d is not valid\n", procfile->pid);
       return -ENODEV;
     }
 
@@ -1651,7 +1651,7 @@ static ssize_t proc_write(FAR struct file *filep, FAR const char *buffer,
   tcb = nxsched_get_tcb(procfile->pid);
   if (tcb == NULL)
     {
-      ferr("ERROR: PID %d is not valid\n", (int)procfile->pid);
+      ferr("ERROR: PID %d is not valid\n", procfile->pid);
       return -ENODEV;
     }
 
@@ -1780,7 +1780,7 @@ static int proc_opendir(FAR const char *relpath,
   tcb = nxsched_get_tcb(pid);
   if (tcb == NULL)
     {
-      ferr("ERROR: PID %d is not valid\n", (int)pid);
+      ferr("ERROR: PID %d is not valid\n", pid);
       return -ENOENT;
     }
 
@@ -1900,7 +1900,7 @@ static int proc_readdir(FAR struct fs_dirent_s *dir,
       tcb = nxsched_get_tcb(pid);
       if (tcb == NULL)
         {
-          ferr("ERROR: PID %d is no longer valid\n", (int)pid);
+          ferr("ERROR: PID %d is no longer valid\n", pid);
           return -ENOENT;
         }
 
@@ -2018,7 +2018,7 @@ static int proc_stat(const char *relpath, struct stat *buf)
   tcb = nxsched_get_tcb(pid);
   if (tcb == NULL)
     {
-      ferr("ERROR: PID %d is no longer valid\n", (int)pid);
+      ferr("ERROR: PID %d is no longer valid\n", pid);
       return -ENOENT;
     }
 

--- a/include/nuttx/mm/mempool.h
+++ b/include/nuttx/mm/mempool.h
@@ -39,11 +39,11 @@
  ****************************************************************************/
 
 #if CONFIG_MM_BACKTRACE >= 0
-#  define MEMPOOL_REALBLOCKSIZE(pool) (ALIGN_UP(pool->blocksize + \
-                                      sizeof(struct mempool_backtrace_s), \
-                                      pool->blockalign))
+#  define MEMPOOL_REALBLOCKSIZE(pool) (ALIGN_UP((pool)->blocksize + \
+                                       sizeof(struct mempool_backtrace_s), \
+                                       (pool)->blockalign))
 #else
-#  define MEMPOOL_REALBLOCKSIZE(pool) (pool->blocksize)
+#  define MEMPOOL_REALBLOCKSIZE(pool) ((pool)->blocksize)
 #endif
 
 /****************************************************************************

--- a/mm/mempool/mempool.c
+++ b/mm/mempool/mempool.c
@@ -506,7 +506,7 @@ void mempool_memdump(FAR struct mempool_s *pool,
 #  endif
 
               syslog(LOG_INFO, "%6d%12zu%12lu%*p%s\n",
-                     (int)buf->pid, blocksize, buf->seqno,
+                     buf->pid, blocksize, buf->seqno,
                      MM_PTR_FMT_WIDTH, ((FAR char *)buf - blocksize), tmp);
             }
         }

--- a/mm/mempool/mempool.c
+++ b/mm/mempool/mempool.c
@@ -369,6 +369,7 @@ int mempool_info(FAR struct mempool_s *pool, FAR struct mempoolinfo_s *info)
   info->aordblks = pool->nalloc;
 #endif
   info->arena =
+    mempool_queue_lenth(&pool->equeue) * sizeof(sq_entry_t) +
     (info->aordblks + info->ordblks + info->iordblks) * blocksize;
   spin_unlock_irqrestore(&pool->lock, flags);
   info->sizeblks = blocksize;

--- a/mm/mempool/mempool.c
+++ b/mm/mempool/mempool.c
@@ -485,31 +485,29 @@ void mempool_memdump(FAR struct mempool_s *pool,
     {
       FAR struct mempool_backtrace_s *buf;
 
-      list_for_every_entry(&pool->alist, buf, struct mempool_backtrace_s,
-                           node)
+      list_for_every_entry(&pool->alist, buf,
+                           struct mempool_backtrace_s, node)
         {
           if ((dump->pid == PID_MM_ALLOC || dump->pid == buf->pid) &&
               buf->seqno >= dump->seqmin && buf->seqno <= dump->seqmax)
             {
-#  if CONFIG_MM_BACKTRACE > 0
-              int i;
-              FAR const char *format = " %0*p";
-#  endif
-              char bt[CONFIG_MM_BACKTRACE * MM_PTR_FMT_WIDTH + 1];
+              char tmp[CONFIG_MM_BACKTRACE * MM_PTR_FMT_WIDTH + 1] = "";
 
-              bt[0] = '\0';
 #  if CONFIG_MM_BACKTRACE > 0
+              FAR const char *format = " %0*p";
+              int i;
+
               for (i = 0; i < CONFIG_MM_BACKTRACE && buf->backtrace[i]; i++)
                 {
-                  snprintf(bt + i * MM_PTR_FMT_WIDTH,
-                           sizeof(bt) - i * MM_PTR_FMT_WIDTH,
+                  snprintf(tmp + i * MM_PTR_FMT_WIDTH,
+                           sizeof(tmp) - i * MM_PTR_FMT_WIDTH,
                            format, MM_PTR_FMT_WIDTH - 1, buf->backtrace[i]);
                 }
 #  endif
 
               syslog(LOG_INFO, "%6d%12zu%12lu%*p%s\n",
                      (int)buf->pid, blocksize, buf->seqno,
-                     MM_PTR_FMT_WIDTH, ((FAR char *)buf - blocksize), bt);
+                     MM_PTR_FMT_WIDTH, ((FAR char *)buf - blocksize), tmp);
             }
         }
     }

--- a/mm/mm_heap/mm_memdump.c
+++ b/mm/mm_heap/mm_memdump.c
@@ -85,7 +85,7 @@ static void memdump_handler(FAR struct mm_allocnode_s *node, FAR void *arg)
 #  endif
 
           syslog(LOG_INFO, "%6d%12zu%12lu%*p%s\n",
-                 (int)node->pid, nodesize, node->seqno,
+                 node->pid, nodesize, node->seqno,
                  MM_PTR_FMT_WIDTH,
                  ((FAR char *)node + SIZEOF_MM_ALLOCNODE), buf);
 #endif

--- a/mm/mm_heap/mm_memdump.c
+++ b/mm/mm_heap/mm_memdump.c
@@ -70,14 +70,12 @@ static void memdump_handler(FAR struct mm_allocnode_s *node, FAR void *arg)
                  nodesize, MM_PTR_FMT_WIDTH,
                  ((FAR char *)node + SIZEOF_MM_ALLOCNODE));
 #else
-#  if CONFIG_MM_BACKTRACE > 0
-          int i;
-          FAR const char *format = " %0*p";
-#  endif
-          char buf[CONFIG_MM_BACKTRACE * MM_PTR_FMT_WIDTH + 1];
+          char buf[CONFIG_MM_BACKTRACE * MM_PTR_FMT_WIDTH + 1] = "";
 
-          buf[0] = '\0';
 #  if CONFIG_MM_BACKTRACE > 0
+          FAR const char *format = " %0*p";
+          int i;
+
           for (i = 0; i < CONFIG_MM_BACKTRACE && node->backtrace[i]; i++)
             {
               snprintf(buf + i * MM_PTR_FMT_WIDTH,

--- a/mm/tlsf/mm_tlsf.c
+++ b/mm/tlsf/mm_tlsf.c
@@ -415,14 +415,12 @@ static void memdump_handler(FAR void *ptr, size_t size, int used,
 #if CONFIG_MM_BACKTRACE < 0
           syslog(LOG_INFO, "%12zu%*p\n", size, MM_PTR_FMT_WIDTH, ptr);
 #else
-#  if CONFIG_MM_BACKTRACE > 0
-          int i;
-          FAR const char *format = " %0*p";
-#  endif
-          char tmp[CONFIG_MM_BACKTRACE * MM_PTR_FMT_WIDTH + 1];
+          char tmp[CONFIG_MM_BACKTRACE * MM_PTR_FMT_WIDTH + 1] = "";
 
-          tmp[0] = '\0';
 #  if CONFIG_MM_BACKTRACE > 0
+          FAR const char *format = " %0*p";
+          int i;
+
           for (i = 0; i < CONFIG_MM_BACKTRACE && buf->backtrace[i]; i++)
             {
               snprintf(tmp + i * MM_PTR_FMT_WIDTH,

--- a/mm/tlsf/mm_tlsf.c
+++ b/mm/tlsf/mm_tlsf.c
@@ -280,16 +280,9 @@ static void mallinfo_handler(FAR void *ptr, size_t size, int used,
 static void mallinfo_task_handler(FAR void *ptr, size_t size, int used,
                                   FAR void *user)
 {
-#if CONFIG_MM_BACKTRACE >= 0
-  FAR struct memdump_backtrace_s *buf;
-#endif
   FAR struct mm_mallinfo_handler_s *handler = user;
   FAR const struct malltask *task = handler->task;
   FAR struct mallinfo_task *info = handler->info;
-
-#if CONFIG_MM_BACKTRACE >= 0
-  size -= sizeof(struct memdump_backtrace_s);
-  buf = ptr + size;
 
   if (used)
     {
@@ -300,6 +293,9 @@ static void mallinfo_task_handler(FAR void *ptr, size_t size, int used,
           info->uordblks += size;
         }
 #else
+      FAR struct memdump_backtrace_s *buf =
+        ptr + size - sizeof(struct memdump_backtrace_s);
+
       if ((task->pid == PID_MM_ALLOC || task->pid == buf->pid ||
            (task->pid == PID_MM_LEAK && !!nxsched_get_tcb(buf->pid))) &&
           buf->seqno >= task->seqmin && buf->seqno <= task->seqmax)
@@ -314,7 +310,6 @@ static void mallinfo_task_handler(FAR void *ptr, size_t size, int used,
       info->aordblks++;
       info->uordblks += size;
     }
-#endif
 }
 
 /****************************************************************************
@@ -404,18 +399,15 @@ static void memdump_handler(FAR void *ptr, size_t size, int used,
                             FAR void *user)
 {
   FAR const struct mm_memdump_s *dump = user;
-#if CONFIG_MM_BACKTRACE >= 0
-  FAR struct memdump_backtrace_s *buf;
-
-  size -= sizeof(struct memdump_backtrace_s);
-  buf = ptr + size;
-#endif
 
   if (used)
     {
 #if CONFIG_MM_BACKTRACE < 0
       if (dump->pid == PID_MM_ALLOC)
 #else
+      FAR struct memdump_backtrace_s *buf =
+        ptr + size - sizeof(struct memdump_backtrace_s);
+
       if ((dump->pid == PID_MM_ALLOC || dump->pid == buf->pid) &&
           buf->seqno >= dump->seqmin && buf->seqno <= dump->seqmax)
 #endif

--- a/mm/tlsf/mm_tlsf.c
+++ b/mm/tlsf/mm_tlsf.c
@@ -430,7 +430,7 @@ static void memdump_handler(FAR void *ptr, size_t size, int used,
 #  endif
 
          syslog(LOG_INFO, "%6d%12zu%12lu%*p%s\n",
-                (int)buf->pid, size, buf->seqno, MM_PTR_FMT_WIDTH,
+                buf->pid, size, buf->seqno, MM_PTR_FMT_WIDTH,
                 ptr, tmp);
 #endif
         }

--- a/sched/task/task_create.c
+++ b/sched/task/task_create.c
@@ -110,7 +110,7 @@ int nxthread_create(FAR const char *name, uint8_t ttype, int priority,
 
   nxtask_activate(&tcb->cmn);
 
-  return (int)pid;
+  return pid;
 }
 
 /****************************************************************************

--- a/sched/task/task_spawn.c
+++ b/sched/task/task_spawn.c
@@ -129,7 +129,7 @@ static int nxtask_spawn_create(FAR const char *name, int priority,
 
   nxtask_activate(&tcb->cmn);
 
-  return (int)pid;
+  return pid;
 }
 
 /****************************************************************************
@@ -341,7 +341,7 @@ int task_spawn(FAR const char *name, main_t entry,
                           file_actions != NULL ? *file_actions : NULL,
                           attr, argv, envp);
 
-  return ret >= 0 ? (int)pid : ret;
+  return ret >= 0 ? pid : ret;
 }
 
 #endif /* CONFIG_BUILD_KERNEL */


### PR DESCRIPTION
## Summary

Continue the work https://github.com/apache/nuttx/pull/9561

- mm/mempool: Count the backtrace overhead in mempool_[dump|info[_task]] 
- mm/mempool: Count the expend block overhead in mempool_info
- mm/tlfs: Count the backtrace overhead in mm_mallinfo_task
- mm: Simplify memdump_handler logic a little bit
- sched: Remove the unnecessary cast from pid_t to int 

## Impact

Report more accuracy statistics info

## Testing

sim:kasan and sim:adb