### PR TITLE
boards/samv7: add lower level IOCTL handler to sam_gpio_enc driver

### DIFF
--- a/boards/arm/samv7/common/src/sam_gpio_enc.c
+++ b/boards/arm/samv7/common/src/sam_gpio_enc.c
@@ -76,6 +76,8 @@ static int sam_gpio_enc_position(struct qe_lowerhalf_s *lower, int32_t *pos);
 static int sam_gpio_enc_setup(struct qe_lowerhalf_s *lower);
 static int sam_gpio_enc_shutdown(struct qe_lowerhalf_s *lower);
 static int sam_gpio_enc_reset(struct qe_lowerhalf_s *lower);
+static int sam_gpio_enc_ioctl(struct qe_lowerhalf_s *lower, int cmd,
+                              unsigned long arg);
 
 /****************************************************************************
  * Private Data
@@ -88,7 +90,7 @@ static const struct qe_ops_s g_qecallbacks =
   .position  = sam_gpio_enc_position,
   .setposmax = NULL,
   .reset     = sam_gpio_enc_reset,
-  .ioctl     = NULL,
+  .ioctl     = sam_gpio_enc_ioctl,
 };
 
 static struct sam_qeconfig_s sam_gpio_enc_config =
@@ -300,6 +302,14 @@ static int sam_gpio_enc_shutdown(struct qe_lowerhalf_s *lower)
   return OK;
 }
 
+/****************************************************************************
+ * Name: sam_gpio_enc_reset
+ *
+ * Description:
+ *   Reset the position measurement to base position.
+ *
+ ****************************************************************************/
+
 static int sam_gpio_enc_reset(struct qe_lowerhalf_s *lower)
 {
   struct sam_gpio_enc_lowerhalf_s *priv =
@@ -310,6 +320,23 @@ static int sam_gpio_enc_reset(struct qe_lowerhalf_s *lower)
   config->position = config->position_base;
 
   return OK;
+}
+
+/****************************************************************************
+ * Name: sam_gpio_enc_ioctl
+ *
+ * Description:
+ *   This method is called when IOCTL command can not be handled by upper
+ *   half of the driver.
+ *
+ ****************************************************************************/
+
+static int sam_gpio_enc_ioctl(struct qe_lowerhalf_s *lower, int cmd,
+                              unsigned long arg)
+{
+  /* No commands supported. */
+
+  return -ENOTTY;
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
SAMv7 encoder driver with GPIO pins was written without IOCTL support. While this driver does not require any lower level IOCTLs for its functionality the upper layer fails on [assertion](https://github.com/apache/nuttx/blob/master/drivers/sensors/qencoder.c#L355) (during system reboot for example) when unknown command can not be send to lower layer. This commit adds IOCTL handler that always returns -ENOTTY as no commands are supported.

## Impact

SAMv7 only.

## Testing

Custom board with SAMv7 MCU.

