### PR TITLE
tools: Fix CONFIG_BASE_DEFCONFIG generation

### DIFF
--- a/tools/Unix.mk
+++ b/tools/Unix.mk
@@ -250,7 +250,7 @@ tools/mkconfig$(HOSTEXEEXT):
 include/nuttx/config.h: $(TOPDIR)/.config tools/mkconfig$(HOSTEXEEXT)
 	$(Q) grep -v "CONFIG_BASE_DEFCONFIG" "$(TOPDIR)/.config" > "$(TOPDIR)/.config.tmp"
 	$(Q) if ! cmp -s "$(TOPDIR)/.config.tmp" "$(TOPDIR)/.config.orig" ; then \
-		sed -i.bak "/CONFIG_BASE_DEFCONFIG/s/\"$$/-dirty\"/" "$(TOPDIR)/.config"; \
+		sed -i.bak "/CONFIG_BASE_DEFCONFIG/ { /-dirty/! s/\"$$/-dirty\"/ }" "$(TOPDIR)/.config"; \
 	else \
 		sed -i.bak "s/-dirty//g" "$(TOPDIR)/.config"; \
 	fi

--- a/tools/Win.mk
+++ b/tools/Win.mk
@@ -238,7 +238,7 @@ include\nuttx\config.h: $(TOPDIR)\.config tools\mkconfig$(HOSTEXEEXT)
 	$(Q) grep -v "CONFIG_BASE_DEFCONFIG" "$(TOPDIR)\.config" > "$(TOPDIR)\.config.tmp"
 # In-place edit can mess up permissions on Windows
 	$(Q) if ! cmp -s "$(TOPDIR)\.config.tmp" "$(TOPDIR)\.config.orig" ; then \
-		sed "/CONFIG_BASE_DEFCONFIG/s/\"$$/-dirty\"/" "$(TOPDIR)\.config" > "$(TOPDIR)\.config-temp"; \
+		sed "/CONFIG_BASE_DEFCONFIG/ { /-dirty/! s/\"$$/-dirty\"/ }" "$(TOPDIR)\.config" > "$(TOPDIR)\.config-temp"; \
 	else \
 		sed "s/-dirty//g" "$(TOPDIR)\.config" > "$(TOPDIR)\.config-temp"; \
 	fi


### PR DESCRIPTION
## Summary

Currently, there is no check to see if there's already a "dirty" tag on `CONFIG_BASE_DEFCONFIG`.
This MR modifies the sed command to avoid appending multiple "-dirty" at the end of the configuration name.

## Impact

Correct `CONFIG_BASE_DEFCONFIG` generation.

## Testing

Local build using `esp32-devkitc:nsh`.