### PR TITLE
sendfile: Fixed behavior of sendfile when count is set to zero.

### DIFF
--- a/fs/vfs/fs_sendfile.c
+++ b/fs/vfs/fs_sendfile.c
@@ -27,6 +27,7 @@
 #include <sys/sendfile.h>
 #include <stdbool.h>
 #include <errno.h>
+#include <debug.h>
 
 #include <nuttx/kmalloc.h>
 #include <nuttx/net/net.h>
@@ -244,6 +245,12 @@ static ssize_t copyfile(FAR struct file *outfile, FAR struct file *infile,
 ssize_t file_sendfile(FAR struct file *outfile, FAR struct file *infile,
                       off_t *offset, size_t count)
 {
+  if (count == 0)
+    {
+      nwarn("WARNING: sendfile count is zero\n");
+      return 0;
+    }
+
 #ifdef CONFIG_NET_SENDFILE
   /* Check the destination file descriptor:  Is it a (probable) file
    * descriptor?  Check the source file:  Is it a normal file?


### PR DESCRIPTION
## Summary

If `sendfile()` is called with a zero count, it will nevertheless try to send the data.
This is mostly meaningless, it causes waste of resources, and in some cases delays.

For example, in case of just copying a file [unneeded buffers are allocated](https://github.com/apache/nuttx/blob/master/fs/vfs/fs_sendfile.c#L74), or in case of TCP the code waits for (no) data to be transmitted [till the socket timeouts](https://github.com/apache/nuttx/blob/master/net/tcp/tcp_sendfile.c#L527).

This commit adds special handling for this case, allowing `sendfile()` to return immediately zero.  
The new behavior is in line with the Linux variant of `sendfile()`, as tested with [this](https://github.com/fjpanag/code_for_nuttx/blob/main/ftp/ftpc.c) FTP client.

For more information, see the discussion [here](https://lists.apache.org/thread/gls3rr8h4ggbwgk4skq1j0txoyd94jrf).

## Impact

Proper handling of this edge case, without waste of resources, or needless delays.

## Testing

Tested on a custom STM32F4 board, using an FTP client to upload 0 size files.  
Works as expected:
* Returns immediately without delays.
* No network traffic is generated, similarly to Linux systems.
