### PR TITLE
localtime: add tzreset function to force zone file reload

### DIFF
--- a/include/time.h
+++ b/include/time.h
@@ -246,6 +246,7 @@ int nanosleep(FAR const struct timespec *rqtp, FAR struct timespec *rmtp);
 
 #ifdef CONFIG_LIBC_LOCALTIME
 void tzset(void);
+void tzreset(void);
 #endif
 
 #undef EXTERN

--- a/libs/libc/time/lib_localtime.c
+++ b/libs/libc/time/lib_localtime.c
@@ -2801,6 +2801,11 @@ tzname:
   nxrmutex_unlock(&g_lcl_lock);
 }
 
+void tzreset(void)
+{
+  strlcpy(g_lcl_tzname, "", sizeof(g_lcl_tzname));
+}
+
 FAR struct tm *localtime(FAR const time_t *timep)
 {
   tzset();


### PR DESCRIPTION
## Summary
Current implementation discards any updates if current timezone name is the same as new timezone name. This works well if every timezone name is different (`Europe/Prague,` `Mexico/General` etc.) however some application may want to reduce the image size by omitting zoneinfo directory and using just single zoneinfo file instead. Therefore the name of the zone is the same all the time.

This commit adds function `tzreset()` that resets the `g_lcl_tzname` variable keeping the time zone file name and hence forces the `tzset()` function to reload the file on next call.

## Impact

Should not have any impact on current implementations. Just addition of new public function.

## Testing

Tested on custom SAMv7 board.

