### PR TITLE
lib_strftime: Fix %I to avoid printing 00:xx AM/PM

### DIFF
--- a/libs/libc/time/lib_strftime.c
+++ b/libs/libc/time/lib_strftime.c
@@ -267,7 +267,8 @@ size_t strftime(FAR char *s, size_t max, FAR const char *format,
 
            case 'I':
              {
-               len = snprintf(dest, chleft, "%02d", tm->tm_hour % 12);
+               len = snprintf(dest, chleft, "%02d", (tm->tm_hour % 12) != 0 ?
+                                                    (tm->tm_hour % 12) : 12);
              }
              break;
 

--- a/libs/libc/time/lib_strftime.c
+++ b/libs/libc/time/lib_strftime.c
@@ -305,7 +305,8 @@ size_t strftime(FAR char *s, size_t max, FAR const char *format,
 
            case 'l':
              {
-               len = snprintf(dest, chleft, "%2d", tm->tm_hour % 12);
+               len = snprintf(dest, chleft, "%2d", (tm->tm_hour % 12) != 0 ?
+                                                   (tm->tm_hour % 12) : 12);
              }
              break;
 


### PR DESCRIPTION
## Summary
Currently strftime() is printing 00:00 AM and 00:00 PM instead of 12:00 AM and 12:00 PM when using %I.
This commit fixes this issue
## Impact
Users will get time format correct in USA (those Imperialist hehehe)
## Testing
SIM
