### PR TITLE
usrsock_server:fix incomplete received data error

### DIFF
--- a/drivers/usrsock/usrsock_rpmsg_server.c
+++ b/drivers/usrsock/usrsock_rpmsg_server.c
@@ -578,7 +578,6 @@ static int usrsock_rpmsg_recvfrom_handler(FAR struct rpmsg_endpoint *ept,
                                                             false);
               if (!iov[i].iov_base)
                 {
-                  events |= USRSOCK_EVENT_RECVFROM_AVAIL;
                   break;
                 }
 
@@ -607,11 +606,15 @@ static int usrsock_rpmsg_recvfrom_handler(FAR struct rpmsg_endpoint *ept,
               else
                 {
                   iov[i].iov_len = 0;
-                  events |= USRSOCK_EVENT_RECVFROM_AVAIL;
                   break;
                 }
 
               i++;
+            }
+
+          if (usrsock_rpmsg_available(&priv->socks[req->usockid], FIONREAD))
+            {
+              events |= USRSOCK_EVENT_RECVFROM_AVAIL;
             }
         }
     }


### PR DESCRIPTION
## Summary
usrsock received wrong message to stop receiving the data, however there is remaining data that has not been retrieved.
when usrsock receiving data ,  it checks number of bytes available for reading.
if the number is more than zero, setting USRSOCK_EVENT_RECVFROM_AVAIL flag into the event
## Impact
usrsock
## Testing
**Before modification** 
![image](https://github.com/apache/nuttx/assets/129070278/1d5c4dc0-ab4d-459d-ab8b-44780fa86f55)
![image](https://github.com/apache/nuttx/assets/129070278/b757a25f-f1f2-49ce-b990-8e5e21f45ad1)
**After modification** 
![image](https://github.com/apache/nuttx/assets/129070278/8dd04e5f-571a-487a-9920-4e87e2af9596)
![image](https://github.com/apache/nuttx/assets/129070278/52456fc1-13c5-4835-84cb-c0465e7e02fa)

