### PR TITLE
socket/recvfrom: Fix buffer copy direction when using BUILD_KERNEL.

### DIFF
--- a/net/socket/recvfrom.c
+++ b/net/socket/recvfrom.c
@@ -158,6 +158,7 @@ ssize_t recvfrom(int sockfd, FAR void *buf, size_t len, int flags,
   struct sockaddr_storage kaddr;
   FAR struct sockaddr *ufrom;
   FAR void *kbuf;
+  FAR void *ubuf;
 #endif
 
   /* recvfrom() is a cancellation point */
@@ -176,7 +177,7 @@ ssize_t recvfrom(int sockfd, FAR void *buf, size_t len, int flags,
       goto errout_with_cancelpt;
     }
 
-  memcpy(kbuf, buf, len);
+  ubuf = buf;
   buf = kbuf;
 
   /* Copy the address data to kernel, store the original user pointer */
@@ -199,6 +200,7 @@ ssize_t recvfrom(int sockfd, FAR void *buf, size_t len, int flags,
     }
 
 #ifdef CONFIG_BUILD_KERNEL
+  memcpy(ubuf, buf, len);
   kmm_free(kbuf);
 
   /* Copy the address back to user */


### PR DESCRIPTION
## Summary

When using recvfrom, the data should be copied back to the user provided buffer after psock_recvfrom, not before.

## Impact

Data received from psock_recvfrom is returned back to the user.

## Testing

arty_a7:knsh with IPV6 stack and ping6.
