### PR TITLE
arch/risc-v: Enable -msave-restore when CONFIG_DEBUG_FULLOPT is selected

### DIFF
--- a/arch/risc-v/src/common/Toolchain.defs
+++ b/arch/risc-v/src/common/Toolchain.defs
@@ -48,7 +48,7 @@ endif
 ifeq ($(CONFIG_DEBUG_CUSTOMOPT),y)
   ARCHOPTIMIZATION += $(CONFIG_DEBUG_OPTLEVEL)
 else ifeq ($(CONFIG_DEBUG_FULLOPT),y)
-  ARCHOPTIMIZATION += -Os
+  ARCHOPTIMIZATION += -Os -msave-restore
 endif
 
 ifneq ($(CONFIG_DEBUG_NOOPT),y)


### PR DESCRIPTION
## Summary

Do use smaller but slower prologue and epilogue code that uses library function calls.

## Impact

generate smaller image size

## Testing

