### PR TITLE
segger: Change the default value of SEGGER_RTT_MAX_NUM_DOWN_BUFFERS to SEGGER_RTT_MAX_NUM_UP_BUFFERS

### DIFF
--- a/drivers/segger/Kconfig
+++ b/drivers/segger/Kconfig
@@ -47,7 +47,7 @@ config SEGGER_RTT_MAX_NUM_UP_BUFFERS
 
 config SEGGER_RTT_MAX_NUM_DOWN_BUFFERS
 	int "Segger RTT Maximum Number of Down Buffers"
-	default 3
+	default SEGGER_RTT_MAX_NUM_UP_BUFFERS
 	---help---
 		Number of down-buffers (H->T) available on this target
 


### PR DESCRIPTION
## Summary

since the number of down buffers should be equal to the number of up buffers in most cases.

## Impact

minor

## Testing

sim:segger