### PR TITLE
stm32f429i-disco: Register the BUTTON driver

### DIFF
--- a/boards/arm/stm32/stm32f429i-disco/src/stm32_bringup.c
+++ b/boards/arm/stm32/stm32f429i-disco/src/stm32_bringup.c
@@ -66,6 +66,10 @@
 #include "stm32.h"
 #include "stm32f429i-disco.h"
 
+#ifdef CONFIG_INPUT_BUTTONS_LOWER
+#  include <nuttx/input/buttons.h>
+#endif
+
 #ifdef CONFIG_SENSORS_L3GD20
 #include "stm32_l3gd20.h"
 #endif
@@ -344,6 +348,16 @@ int stm32_bringup(void)
       syslog(LOG_ERR, "ERROR: Failed to start USB monitor: %d\n", ret);
     }
 #endif
+
+#ifdef CONFIG_INPUT_BUTTONS_LOWER
+  /* Register the BUTTON driver */
+
+  ret = btn_lower_initialize("/dev/buttons");
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: btn_lower_initialize() failed: %d\n", ret);
+    }
+#endif /* CONFIG_INPUT_BUTTONS_LOWER */
 
 #ifdef CONFIG_INPUT_STMPE811
   /* Initialize the touchscreen */


### PR DESCRIPTION
## Summary

I could be wrong, but I need to apply the following change to get the push button events on the STM32F429I-DISC1 board.

## Testing

Test based on the following defconfig: https://github.com/directfb2/DirectFB2/blob/master/lib/direct/os/nuttx/configs/stm32f429i-disco/defconfig

Use df_input example to get input events: https://github.com/directfb2/DirectFB-examples/blob/master/src/df_input.c
