### PR TITLE
litex/gpio: Fix incorrect  declaration name.

### DIFF
--- a/arch/risc-v/src/litex/litex_gpio.h
+++ b/arch/risc-v/src/litex/litex_gpio.h
@@ -196,9 +196,9 @@ int litex_gpio_irq_config(struct gpio_isr_config_s * config);
  ****************************************************************************/
 
 #ifdef CONFIG_LITEX_GPIO_IRQ
-void litex_irq_disable(int irq);
+void litex_gpio_irq_disable(int irq);
 #else
-#  define litex_irq_disable(irq)
+#  define litex_gpio_irq_disable(irq)
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Summary

Fixes incorrect function declaration name for litex_gpio_disable.

## Impact

Builds without error.

## Testing

arty_a7:nsh
