### PR TITLE
Fix assertion of free a wrong heap

### DIFF
--- a/include/nuttx/lib/lib.h
+++ b/include/nuttx/lib/lib.h
@@ -41,7 +41,7 @@
  * then only the first mode is supported.
  */
 
-#if defined(__KERNEL__)
+#if  !defined(CONFIG_BUILD_FLAT) && defined(__KERNEL__)
 
   /* Domain-specific allocations */
 


### PR DESCRIPTION
## Summary
Fix an assertion issue https://github.com/apache/nuttx/issues/9599.

`lib_malloc` is defined as macro and it will be expanded to `kmm_alloc` if `__KERNEL__` is defined or `malloc` if `__KERNEL__` is not defined.
`lib_free` is defined as macro and it will be expanded to `kmm_free` if `__KERNEL__` is defined or `free` if `__KERNEL__` is not defined.

For `fs`, it is a kernel module and build with `__KERNEL__` defined. so the `lib_free` in this module is `kmm_free` in fact.
For `libc` is is only a library (not belong to kernel), it build without  `__KERNEL__` defined. so `lib_malloc` used in this modue is `malloc` in fact.

Think about a case like this:
in `fs` module, `asprintf` was used to alloc and initialize the memory, and this memory is freed via `lib_free`. This is the case https://github.com/apache/nuttx/issues/9599 addressed. 

The fix use the flag of flat build mode. if under flat mode, the `__KERNEL__` will not be consider. as it is not real kernel or user distinguished under this buils mode

## Impact
Should no

## Testing
The issue https://github.com/apache/nuttx/issues/9599 has been fixed.
