### PR TITLE
arch/arm/stm: Fix duplicate include guard

### DIFF
--- a/arch/arm/src/stm32f7/hardware/stm32f76xx77xx_flash.h
+++ b/arch/arm/src/stm32f7/hardware/stm32f76xx77xx_flash.h
@@ -18,8 +18,8 @@
  *
  ****************************************************************************/
 
-#ifndef __ARCH_ARM_SRC_STM32F7_HARDWARE_STM32F74XX75XX_FLASH_H
-#define __ARCH_ARM_SRC_STM32F7_HARDWARE_STM32F74XX75XX_FLASH_H
+#ifndef __ARCH_ARM_SRC_STM32F7_HARDWARE_STM32F76XX77XX_FLASH_H
+#define __ARCH_ARM_SRC_STM32F7_HARDWARE_STM32F76XX77XX_FLASH_H
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -204,4 +204,4 @@
 #define FLASH_OPTCR1_BOOTADD1_MASK  (0xffff << FLASH_OPTCR1_BOOTADD1_SHIFT)
 #  define FLASH_OPTCR1_BOOTADD1(n)  ((uint32_t)(n) << FLASH_OPTCR1_BOOTADD1_SHIFT)
 
-#endif /* __ARCH_ARM_SRC_STM32F7_HARDWARE_STM32F74XX75XX_FLASH_H */
+#endif /* __ARCH_ARM_SRC_STM32F7_HARDWARE_STM32F76XX77XX_FLASH_H */

--- a/arch/arm/src/stm32l4/hardware/stm32l4xrxx_rcc.h
+++ b/arch/arm/src/stm32l4/hardware/stm32l4xrxx_rcc.h
@@ -18,8 +18,8 @@
  *
  ****************************************************************************/
 
-#ifndef __ARCH_ARM_SRC_STM32L4_HARDWARE_STM32L4X6XX_RCC_H
-#define __ARCH_ARM_SRC_STM32L4_HARDWARE_STM32L4X6XX_RCC_H
+#ifndef __ARCH_ARM_SRC_STM32L4_HARDWARE_STM32L4XRXX_RCC_H
+#define __ARCH_ARM_SRC_STM32L4_HARDWARE_STM32L4XRXX_RCC_H
 
 /****************************************************************************
  * Included Files


### PR DESCRIPTION


## Summary
The following macros
  __ARCH_ARM_SRC_STM32F7_HARDWARE_STM32F74XX75XX_FLASH_H
  __ARCH_ARM_SRC_STM32L4_HARDWARE_STM32L4X6XX_RCC_H
are used in other header files.

Fix by using new macros.

## Impact

## Testing

