### PR TITLE
libs/libc/unistd: add getpgrp function

### DIFF
--- a/include/unistd.h
+++ b/include/unistd.h
@@ -306,6 +306,7 @@ extern "C"
 
 pid_t   vfork(void);
 pid_t   getpid(void);
+pid_t   getpgrp(void);
 pid_t   gettid(void);
 pid_t   getppid(void);
 void    _exit(int status) noreturn_function;

--- a/libs/libc/unistd/Make.defs
+++ b/libs/libc/unistd/Make.defs
@@ -30,7 +30,7 @@ CSRCS += lib_setreuid.c lib_setregid.c lib_getrusage.c lib_utime.c lib_utimes.c
 CSRCS += lib_setrlimit.c lib_getrlimit.c lib_setpriority.c lib_getpriority.c
 CSRCS += lib_futimes.c lib_lutimes.c lib_gethostname.c lib_sethostname.c
 CSRCS += lib_fchownat.c lib_linkat.c lib_readlinkat.c lib_symlinkat.c
-CSRCS += lib_unlinkat.c
+CSRCS += lib_unlinkat.c lib_getpgrp.c
 
 ifneq ($(CONFIG_SCHED_USER_IDENTITY),y)
 CSRCS += lib_setuid.c lib_setgid.c lib_getuid.c lib_getgid.c

--- a/libs/libc/unistd/lib_getpgrp.c
+++ b/libs/libc/unistd/lib_getpgrp.c
@@ -1,0 +1,48 @@
+/****************************************************************************
+ * libs/libc/unistd/lib_getpgrp.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <unistd.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: getpgrp
+ *
+ * Description:
+ *   Get the Process Group ID of the currently executing task.
+ *
+ * Input parameters:
+ *   None
+ *
+ * Returned Value:
+ *   The getpgrp will return current process ID directly
+ *
+ ****************************************************************************/
+
+pid_t getpgrp(void)
+{
+  return getpid();
+}


### PR DESCRIPTION
## Summary
1. the getpgrp function can help to pass the ltp/open_posix_teststuite/killpg related testcases
2. Nuttx do not support process group, so we use getpid to implement this
3. the implementation are referred to: https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpgrp.html

## Impact

## Testing

