### PR TITLE
fs/rpmsgfs: Zero dirs after realloc to avoid stale data

### DIFF
--- a/fs/rpmsgfs/rpmsgfs_server.c
+++ b/fs/rpmsgfs/rpmsgfs_server.c
@@ -285,6 +285,9 @@ static int rpmsgfs_attach_dir(FAR struct rpmsgfs_server_s *priv,
       return -ENOMEM;
     }
 
+  memset(&tmp[priv->dir_nums], 0, sizeof(FAR void *) *
+         CONFIG_NFILE_DESCRIPTORS_PER_BLOCK);
+
   priv->dirs = tmp;
   priv->dir_nums += CONFIG_NFILE_DESCRIPTORS_PER_BLOCK;
 


### PR DESCRIPTION
## Summary

since many places assume the null pointer as an unused entry

## Impact

rpmsgfs

## Testing

internal