### PR TITLE
arch/arm/imxrt: Fix implicit function declaration

### DIFF
--- a/arch/arm/src/imxrt/imxrt_flexcan.c
+++ b/arch/arm/src/imxrt/imxrt_flexcan.c
@@ -46,6 +46,7 @@
 #include "chip.h"
 #include "imxrt_config.h"
 #include "imxrt_flexcan.h"
+#include "imxrt_gpio.h"
 #include "imxrt_periphclks.h"
 #include "hardware/imxrt_flexcan.h"
 #include "hardware/imxrt_pinmux.h"

--- a/arch/arm/src/imxrt/imxrt_flexpwm.c
+++ b/arch/arm/src/imxrt/imxrt_flexpwm.c
@@ -39,6 +39,7 @@
 #include "chip.h"
 #include "imxrt_config.h"
 #include "imxrt_flexpwm.h"
+#include "imxrt_gpio.h"
 #include "imxrt_periphclks.h"
 #include "imxrt_xbar.h"
 #include "hardware/imxrt_flexpwm.h"


### PR DESCRIPTION

## Summary
The function 'imxrt_config_gpio' was implicitly declared. Fix by include the header 'imxrt_gpio.h'.

## Impact

## Testing
```
./tools/configure.sh  teensy-4.x:pikron-bb
```

