### PR TITLE
drivers/sensors/apds9960.c: Fix use after free

### DIFF
--- a/drivers/sensors/apds9960.c
+++ b/drivers/sensors/apds9960.c
@@ -1281,6 +1281,7 @@ int apds9960_register(FAR const char *devpath,
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);
       kmm_free(priv);
+      return ret;
     }
 
   /* Attach to the interrupt */


### PR DESCRIPTION

## Summary
Memory pointed by priv may be used (in line 1289) after it is freed in line 1283.
Fix by adding the missing return statement in error handling.

## Impact

## Testing

