### PR TITLE
drivers/can/can.c: Fix nested loops with same variable

### DIFF
--- a/drivers/can/can.c
+++ b/drivers/can/can.c
@@ -1242,6 +1242,7 @@ int can_receive(FAR struct can_dev_s *dev, FAR struct can_hdr_s *hdr,
   int                      nexttail;
   int                      errcode = -ENOMEM;
   int                      i;
+  int                      j;
   int                      sval;
   int                      ret;
 
@@ -1291,7 +1292,7 @@ int can_receive(FAR struct can_dev_s *dev, FAR struct can_hdr_s *hdr,
               memcpy(&waitmsg->cm_hdr, hdr, sizeof(struct can_hdr_s));
 
               nbytes = can_dlc2bytes(hdr->ch_dlc);
-              for (i = 0, dest = waitmsg->cm_data; i < nbytes; i++)
+              for (j = 0, dest = waitmsg->cm_data; j < nbytes; j++)
                 {
                   *dest++ = *data++;
                 }


### PR DESCRIPTION


## Summary
In this nested loop, the iteration variable is the same for both loops. This is a typo and the inner loop should use a new loop variable.
## Impact

## Testing

