### PR TITLE
risc-v toolchain 12.x compatibility issue.

### DIFF
--- a/arch/risc-v/src/common/Toolchain.defs
+++ b/arch/risc-v/src/common/Toolchain.defs
@@ -150,6 +150,11 @@ ifeq ($(CONFIG_RISCV_TOOLCHAIN),GNU_RVG)
     ARCHRVISAD = d
   endif
 
+  GCC_VERSION = ${shell $(CROSSDEV)gcc --version | grep gcc | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | tail -n 1 | cut -d"." -f1 }
+  ifeq ($(shell expr $(GCC_VERSION) \>= 12), 1)
+    ARCHRVISAZ = _zicsr_zifencei
+  endif
+
   # Detect abi type
 
   ifeq ($(CONFIG_ARCH_RV32),y)
@@ -164,7 +169,7 @@ ifeq ($(CONFIG_RISCV_TOOLCHAIN),GNU_RVG)
 
   # Construct arch flags
 
-  ARCHCPUEXTFLAGS = i$(ARCHRVISAM)$(ARCHRVISAA)$(ARCHRVISAF)$(ARCHRVISAD)$(ARCHRVISAC)
+  ARCHCPUEXTFLAGS = i$(ARCHRVISAM)$(ARCHRVISAA)$(ARCHRVISAF)$(ARCHRVISAD)$(ARCHRVISAC)$(ARCHRVISAZ)
   ARCHCPUFLAGS = -march=$(ARCHTYPE)$(ARCHCPUEXTFLAGS)
 
   # Construct arch abi flags


### PR DESCRIPTION
Reference:https://xpack.github.io/blog/2022/05/18/riscv-none-elf-gcc-v12-1-0-2-released/

RISC-V ISA updates
```
Compared to previous releases, starting from 12.x, the compiler implements the new RISC-V ISA, which introduces an incompatibility issue, and builds might throw error messages like unrecognized opcode csrr.

The reason is that csr read/write (csrr*/csrw*) instructions and fence.i instruction were separated from the I extension, becoming two standalone extensions: Zicsr and Zifencei.

The solution is to add _zicsr and/or _zifencei to the -march option, e.g. -march=rv32imac becomes -march=rv32imac_zicsr_zifencei.
```
## Summary
related #9602 

## Impact
riscv compiler
## Testing
Testing on riscv64-unknown-elf-gcc 12.2.0

