### PR TITLE
mkexport: Allow boards to supply custom gnu-elf.ld.

### DIFF
--- a/tools/mkexport.sh
+++ b/tools/mkexport.sh
@@ -180,9 +180,13 @@ fi
 cp "${TOPDIR}/tools/mkdeps.c" "${EXPORTDIR}/tools/."
 cp "${TOPDIR}/tools/incdir.c" "${EXPORTDIR}/tools/."
 
-# Copy the default linker script
+# Copy the board specific linker if found, or use the default when not.
 
-cp -f "${TOPDIR}/binfmt/libelf/gnu-elf.ld" "${EXPORTDIR}/scripts/."
+if [ -f "${BOARDDIR}/scripts/gnu-elf.ld" ]; then
+  cp -f "${BOARDDIR}/scripts/gnu-elf.ld" "${EXPORTDIR}/scripts/."
+else
+  cp -f "${TOPDIR}/binfmt/libelf/gnu-elf.ld" "${EXPORTDIR}/scripts/."
+fi
 
 # Copy the board config script
 


### PR DESCRIPTION
## Summary

Allows boards to supply their own gnu-elf linker script, used when building Nuttx applications and CONFIG_BUILD_KERNEL.

This is useful when building fully-linked applications (see #9395).

## Impact

Makes it easier to customize Nuttx userspace application link configuration.

## Testing

Using the arty:knsh configuration:

```bash
$ make export -j 16
$ cd ../apps && ./tools/mkimport.sh -z -x ../nuttx/nuttx-export-*.tar.gz
$ diff -q import/scripts/gnu-elf.ld ../nuttx/binfmt/libelf/gnu-elf.ld
```

After placing a custom linker script at `boards/risc-v/litex/arty_ay/scripts/gnu-elf.ld`
```bash
$ make export -j 16
$ cd ../apps && ./tools/mkimport.sh -z -x ../nuttx/nuttx-export-*.tar.gz
$ diff -q import/scripts/gnu-elf.ld ../nuttx/binfmt/libelf/gnu-elf.ld
Files import/scripts/gnu-elf.ld and ../nuttx/binfmt/libelf/gnu-elf.ld differ
```