### PR TITLE
include/sys: Include string.h to silence implicit memset declration.

### DIFF
--- a/include/sys/select.h
+++ b/include/sys/select.h
@@ -30,6 +30,7 @@
 #include <limits.h>
 #include <stdint.h>
 #include <signal.h>
+#include <string.h>
 #include <sys/time.h>
 
 #ifdef CONFIG_FDCHECK


### PR DESCRIPTION
## Summary

This change stops the warning "implicit declaration of function 'memset'" when using the `FD_ZERO` macro.

## Impact

See #9616. Stops implicit declaration of `memset`.

## Testing

As per #9616, I can't reproduce the issue within the Nuttx applications repository. I don't believe the addition would break anything, feedback welcome.
