### PR TITLE
tools/syscall: Resolve compile time warning on address validation.

### DIFF
--- a/tools/mksyscall.c
+++ b/tools/mksyscall.c
@@ -208,7 +208,7 @@ static void generate_proxy(int nfixed, int nparms)
       fprintf(stream, "#include <stdarg.h>\n");
     }
 
-  if (g_parm[HEADER_INDEX] && strlen(g_parm[HEADER_INDEX]) > 0)
+  if (strlen(g_parm[HEADER_INDEX]) > 0)
     {
       fprintf(stream, "#include <%s>\n", g_parm[HEADER_INDEX]);
     }
@@ -429,7 +429,7 @@ static void generate_stub(int nfixed, int nparms)
   fprintf(stream, "#include <nuttx/config.h>\n");
   fprintf(stream, "#include <stdint.h>\n");
 
-  if (g_parm[HEADER_INDEX] && strlen(g_parm[HEADER_INDEX]) > 0)
+  if (strlen(g_parm[HEADER_INDEX]) > 0)
     {
       fprintf(stream, "#include <%s>\n", g_parm[HEADER_INDEX]);
     }
@@ -588,7 +588,7 @@ static void generate_wrapper(int nfixed, int nparms)
       fprintf(stream, "#include <stdarg.h>\n");
     }
 
-  if (g_parm[HEADER_INDEX] && strlen(g_parm[HEADER_INDEX]) > 0)
+  if (strlen(g_parm[HEADER_INDEX]) > 0)
     {
       fprintf(stream, "#include <%s>\n", g_parm[HEADER_INDEX]);
     }


### PR DESCRIPTION

## Summary

The following warning is emitted when building with GCC 12.2.0:

"the comparison will always evaluate as ‘true’ for the address of ‘g_parm’ will never be NULL [-Waddress]"

As g_param is an array of char[]. each member should have an actual address, so the validation in each if statement is not required.

## Impact

Resolves the following warnings when building:
```bash
mksyscall.c: In function ‘generate_proxy’:
mksyscall.c:211:7: warning: the comparison will always evaluate as ‘true’ for the address of ‘g_parm’ will never be NULL [-Waddress]
  211 |   if (g_parm[HEADER_INDEX] && strlen(g_parm[HEADER_INDEX]) > 0)
      |       ^~~~~~
In file included from mksyscall.c:32:
csvparser.h:58:18: note: ‘g_parm’ declared here
   58 | extern csvparm_t g_parm[MAX_FIELDS];
      |                  ^~~~~~
mksyscall.c: In function ‘generate_stub’:
mksyscall.c:432:7: warning: the comparison will always evaluate as ‘true’ for the address of ‘g_parm’ will never be NULL [-Waddress]
  432 |   if (g_parm[HEADER_INDEX] && strlen(g_parm[HEADER_INDEX]) > 0)
      |       ^~~~~~
csvparser.h:58:18: note: ‘g_parm’ declared here
   58 | extern csvparm_t g_parm[MAX_FIELDS];
      |                  ^~~~~~
mksyscall.c: In function ‘generate_wrapper’:
mksyscall.c:591:7: warning: the comparison will always evaluate as ‘true’ for the address of ‘g_parm’ will never be NULL [-Waddress]
  591 |   if (g_parm[HEADER_INDEX] && strlen(g_parm[HEADER_INDEX]) > 0)
      |       ^~~~~~
csvparser.h:58:18: note: ‘g_parm’ declared here
   58 | extern csvparm_t g_parm[MAX_FIELDS];
```


## Testing

Testing with `rv-virt:knsh32`.
