### PR TITLE
compiler/fortify: remove unused label prefix and fix build warning 

### DIFF
--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -111,10 +111,9 @@
                                       while (0)
 
 #    define fortify_va_arg_pack __builtin_va_arg_pack
-#    define fortify_str(s) #s
-#    define fortify_real(p,fn) __typeof__(fn) __real_##fn __asm__(fortify_str(p) #fn)
-#    define fortify_function(fn) fortify_real(__USER_LABEL_PREFIX__, fn); \
-                                 extern __inline__ \
+#    define fortify_real(fn) __typeof__(fn) __real_##fn __asm__(#fn)
+#    define fortify_function(fn) fortify_real(fn); \
+                                 extern __inline__ no_builtin(#fn) \
                                  __attribute__((__always_inline__, \
                                                 __gnu_inline__, __artificial__))
 #  endif


### PR DESCRIPTION


## Summary

compiler/fortify: remove unused label prefix and fix build warning 

```
string/lib_memmove.c:39:1: warning: optimization attribute on 'memmove' follows definition but the attribute doesn't match [-Wattributes]
   39 | {
      | ^
In file included from string/lib_memmove.c:27:
nuttx/include/string.h:177:37: note: previous definition of 'memmove' with type 'void *(void *, const void *, size_t)' {aka 'void *(void *, const void *, unsigned int)'}
  177 | fortify_function(memmove) FAR void *memmove(FAR void *dest,
      |                                     ^~~~~~~
string/lib_memset.c:55:1: warning: optimization attribute on 'memset' follows definition but the attribute doesn't match [-Wattributes]
   55 | {
      | ^
In file included from string/lib_memset.c:30:
nuttx/include/string.h:194:36: note: previous definition of 'memset' with type 'void *(void *, int,  size_t)' {aka 'void *(void *, int,  unsigned int)'}
  194 | fortify_function(memset) FAR void *memset(FAR void *s, int c, size_t n)
      |                                    ^~~~~~
CC:  unistd/lib_sysconf.c string/lib_memcpy.c:43:1: warning: optimization attribute on 'memcpy' follows definition but the attribute doesn't match [-Wattributes]
   43 | {
      | ^
In file included from string/lib_memcpy.c:27:
nuttx/include/string.h:186:36: note: previous definition of 'memcpy' with type 'void *(void *, const void *, size_t)' {aka 'void *(void *, const void *, unsigned int)'}
  186 | fortify_function(memcpy) FAR void *memcpy(FAR void *dest,
      |
```

## Impact

N/A

## Testing

GCC 12