### PR TITLE
net/udp: Populate the udp connection structure with the address family.

### DIFF
--- a/net/udp/udp_conn.c
+++ b/net/udp/udp_conn.c
@@ -638,7 +638,7 @@ FAR struct udp_conn_s *udp_alloc(uint8_t domain)
 
       conn->sconn.ttl = IP_TTL_DEFAULT;
       conn->flags     = 0;
-#if defined(CONFIG_NET_IPv4) && defined(CONFIG_NET_IPv6)
+#if defined(CONFIG_NET_IPv4) || defined(CONFIG_NET_IPv6)
       conn->domain    = domain;
 #endif
       conn->lport     = 0;


### PR DESCRIPTION
## Summary

The udp connection structure contains the field, "domain", which defines which address family it belongs to. Prior to this change, this field was only populated correctly if IPv4 and IPv6 was enabled. As a result, packet information was not processed in udp_recvpktinfo, as expected when the appropriate socket option was enabled.

This PR is actually a reworked version of #9294, which was closed when #9295 was merged. However the additions in #9295 did no solve the current issue.

## Impact

The `conn->domain` field is correctly populated with the address family when only IPv6 is enabled. Further processing of UDP packets, i.e in `udp_recvpktinfo`, can correctly read the address domain and provide appropriate actions.

## Testing

In our application:

We are now able to fetch using in6_pktinfo using recvmsg. Previously this wasn't possible if only the IPV6 stack was enabled. When both IPV4 and IPV6 was enabled, this wasn't an issue.

In NuttX:

Using syslog messages to log the value of the udp_conn_s::domain field.