### PR TITLE
sched: fix pthread_exit crash

### DIFF
--- a/sched/pthread/pthread_completejoin.c
+++ b/sched/pthread/pthread_completejoin.c
@@ -203,7 +203,10 @@ int pthread_completejoin(pid_t pid, FAR void *exit_value)
   if (ret != OK)
     {
       nxmutex_unlock(&group->tg_joinlock);
-      return tcb->flags & TCB_FLAG_DETACHED ? OK : ERROR;
+
+      return ((tcb->flags & TCB_FLAG_DETACHED) ||
+              (tcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_PTHREAD) ?
+              OK : ERROR;
     }
   else
     {

--- a/sched/pthread/pthread_exit.c
+++ b/sched/pthread/pthread_exit.c
@@ -69,7 +69,6 @@ void nx_pthread_exit(FAR void *exit_value)
   sinfo("exit_value=%p\n", exit_value);
 
   DEBUGASSERT(tcb != NULL);
-  DEBUGASSERT((tcb->flags & TCB_FLAG_TTYPE_MASK) == TCB_FLAG_TTYPE_PTHREAD);
 
   /* Block any signal actions that would awaken us while were
    * are performing the JOIN handshake.


### PR DESCRIPTION
A normal user task calls pthread_exit(), will crash at DEBUGASSERT. Cause pthread_exit limit in user pthread task. Also correct return code.

test case:
int main(int argc, FAR char *argv[])
{
  pthread_exit(NULL);
  return 0;
}
nsh> test
nsh> echo $?
nsh> 0

## Summary

## Impact
None

## Testing
sim with debug build
