### PR TITLE
libs/libc/aio: fix aio_read compatible bug

### DIFF
--- a/fs/aio/aio_read.c
+++ b/fs/aio/aio_read.c
@@ -219,6 +219,34 @@ int aio_read(FAR struct aiocb *aiocbp)
 
   DEBUGASSERT(aiocbp);
 
+  if (aiocbp->aio_reqprio < 0)
+    {
+      set_errno(EINVAL);
+      return ERROR;
+    }
+
+  if (aiocbp->aio_fildes < 0)
+    {
+      /* the EBADF should be collected by aio_error(), we need return OK at
+       * here
+       */
+
+      aiocbp->aio_result = -EBADF;
+      return OK;
+    }
+
+  /* for aio_read, the aio_offset should be large or equal than 0 */
+
+  if (aiocbp->aio_offset < 0)
+    {
+      /* the EINVAL should be collected by aio_error(), we need to return OK
+       * here
+       */
+
+      aiocbp->aio_result = -EINVAL;
+      return OK;
+    }
+
   /* The result -EINPROGRESS means that the transfer has not yet completed */
 
   sigwork_init(&aiocbp->aio_sigwork);


### PR DESCRIPTION
## Summary
1. make the aio_read implementation can pass the ltp/open_posix_testsuite/aio_read testcases
2. the modification are referred to https://pubs.opengroup.org/onlinepubs/9699919799/functions/aio_read.html

## Impact

## Testing

