### PR TITLE
Fixes for xmc4700-relax board

### DIFF
--- a/arch/arm/src/xmc4/xmc4_serial.c
+++ b/arch/arm/src/xmc4/xmc4_serial.c
@@ -1147,7 +1147,8 @@ int up_putc(int ch)
 
   arm_lowputc(ch);
   return ch;
-}
 #endif
+}
+
 
 #endif /* HAVE_UART_DEVICE && USE_SERIALDRIVER */

--- a/arch/arm/src/xmc4/xmc4_serial.c
+++ b/arch/arm/src/xmc4/xmc4_serial.c
@@ -1150,5 +1150,4 @@ int up_putc(int ch)
 #endif
 }
 
-
 #endif /* HAVE_UART_DEVICE && USE_SERIALDRIVER */

--- a/arch/arm/src/xmc4/xmc4_spi.c
+++ b/arch/arm/src/xmc4/xmc4_spi.c
@@ -221,7 +221,7 @@ static bool     spi_checkreg(struct xmc4_spidev_s *spi, bool wr,
                              uint32_t value, uint32_t address);
 
 #else
-# define        spi_checkreg(spi, wr, value, address)  (false)
+#  define       spi_checkreg(spi, wr, value, address)  (false)
 #endif
 
 static inline uint32_t spi_getreg(struct xmc4_spidev_s *spi,
@@ -233,7 +233,7 @@ static inline struct xmc4_spidev_s *spi_device(struct xmc4_spics_s *spics);
 #ifdef CONFIG_DEBUG_SPI_INFO
 static void     spi_dumpregs(struct xmc4_spidev_s *spi, const char *msg);
 #else
-# define        spi_dumpregs(spi, msg)
+#  define       spi_dumpregs(spi, msg)
 #endif
 
 static inline void spi_flush(struct xmc4_spidev_s *spi);

--- a/arch/arm/src/xmc4/xmc4_spi.c
+++ b/arch/arm/src/xmc4/xmc4_spi.c
@@ -48,7 +48,6 @@
 #include "xmc4_gpio.h"
 #include "xmc4_spi.h"
 #include "xmc4_usic.h"
-#include "hardware/xmc4_spi.h"
 #include "hardware/xmc4_usic.h"
 #include "hardware/xmc4_pinmux.h"
 
@@ -222,7 +221,7 @@ static bool     spi_checkreg(struct xmc4_spidev_s *spi, bool wr,
                              uint32_t value, uint32_t address);
 
 #else
-#  define       spi_checkreg(spi, wr, value, address)  (false)
+# define        spi_checkreg(spi, wr, value, address)  (false)
 #endif
 
 static inline uint32_t spi_getreg(struct xmc4_spidev_s *spi,
@@ -234,7 +233,7 @@ static inline struct xmc4_spidev_s *spi_device(struct xmc4_spics_s *spics);
 #ifdef CONFIG_DEBUG_SPI_INFO
 static void     spi_dumpregs(struct xmc4_spidev_s *spi, const char *msg);
 #else
-#  define       spi_dumpregs(spi, msg)
+# define        spi_dumpregs(spi, msg)
 #endif
 
 static inline void spi_flush(struct xmc4_spidev_s *spi);

--- a/boards/arm/xmc4/xmc4700-relax/include/board.h
+++ b/boards/arm/xmc4/xmc4700-relax/include/board.h
@@ -311,6 +311,19 @@
 #define GPIO_UART0_RXD    GPIO_U0C0_DX0B
 #define GPIO_UART0_TXD    (GPIO_U0C0_DOUT0_3 | GPIO_PADA1P_STRONGSOFT | GPIO_OUTPUT_SET)
 
+/* USIC2 CH0 is used as SPI4
+ *
+ *  MOSI - P3.8  (UC2C0.DOUT0)
+ *  MISO - P3.7  (UC2C0.DX0C)
+ *  SCLK - P3.9 (UC2C0.SCLKOUT)
+ */
+
+#define BOARD_SPI_DX      USIC_DXC
+#define GPIO_SPI4_MOSI    (GPIO_U2C0_DOUT0_2 | GPIO_PADA2_STRONGMEDIUM)
+#define GPIO_SPI4_MISO    (GPIO_U1C0_DX0C)
+#define GPIO_SPI4_SCLK    (GPIO_U2C0_SCLKOUT_1 | GPIO_PADA2_STRONGMEDIUM)
+
+
 /****************************************************************************
  * Public Data
  ****************************************************************************/

--- a/boards/arm/xmc4/xmc4700-relax/include/board.h
+++ b/boards/arm/xmc4/xmc4700-relax/include/board.h
@@ -320,9 +320,8 @@
 
 #define BOARD_SPI_DX      USIC_DXC
 #define GPIO_SPI4_MOSI    (GPIO_U2C0_DOUT0_2 | GPIO_PADA2_STRONGMEDIUM)
-#define GPIO_SPI4_MISO    (GPIO_U1C0_DX0C)
+#define GPIO_SPI4_MISO    (GPIO_U2C0_DX0C)
 #define GPIO_SPI4_SCLK    (GPIO_U2C0_SCLKOUT_1 | GPIO_PADA2_STRONGMEDIUM)
-
 
 /****************************************************************************
  * Public Data

--- a/boards/arm/xmc4/xmc4700-relax/src/Makefile
+++ b/boards/arm/xmc4/xmc4700-relax/src/Makefile
@@ -32,6 +32,10 @@ else
 CSRCS += xmc4_userleds.c
 endif
 
+ifeq ($(CONFIG_XMC4_USCI_SPI),y)
+CSRCS += xmc4_spi.c
+endif
+
 ifeq ($(CONFIG_BOARDCTL),y)
 CSRCS += xmc4_appinit.c
 endif

--- a/boards/arm/xmc4/xmc4700-relax/src/xmc4700-relax.h
+++ b/boards/arm/xmc4/xmc4700-relax/src/xmc4700-relax.h
@@ -41,12 +41,12 @@
  * LED2 P5.8, Pad type A1+ High output illuminates
  */
 
-#define GPIO_LED1    (GPIO_OUTPUT | GPIO_OUTPUT_PUSHPULL | \
-                      GPIO_PADA1P_STRONGSOFT | GPIO_PINCTRL_SOFTWARE | \
-                      GPIO_OUTPUT_CLEAR | GPIO_PORT5 | GPIO_PIN9)
-#define GPIO_LED2    (GPIO_OUTPUT | GPIO_OUTPUT_PUSHPULL | \
-                      GPIO_PADA1P_STRONGSOFT | GPIO_PINCTRL_SOFTWARE | \
-                      GPIO_OUTPUT_CLEAR | GPIO_PORT5 | GPIO_PIN8)
+#define GPIO_LED1 (GPIO_OUTPUT | GPIO_OUTPUT_PUSHPULL |             \
+                   GPIO_PADA1P_STRONGSOFT | GPIO_PINCTRL_SOFTWARE | \
+                   GPIO_OUTPUT_CLEAR | GPIO_PORT5 | GPIO_PIN9)
+#define GPIO_LED2 (GPIO_OUTPUT | GPIO_OUTPUT_PUSHPULL |             \
+                   GPIO_PADA1P_STRONGSOFT | GPIO_PINCTRL_SOFTWARE | \
+                   GPIO_OUTPUT_CLEAR | GPIO_PORT5 | GPIO_PIN8)
 
 /* BUTTONS
  *
@@ -60,6 +60,12 @@
                       GPIO_PORT15 | GPIO_PIN13)
 #define GPIO_BUTTON2 (GPIO_INPUT | GPIO_PINCTRL_SOFTWARE | \
                       GPIO_PORT15 | GPIO_PIN12)
+
+/* SPIs Chip select */
+
+#define GPIO_CS (GPIO_OUTPUT | GPIO_OUTPUT_PUSHPULL |             \
+                 GPIO_PADA1P_STRONGSOFT | GPIO_PINCTRL_SOFTWARE | \
+                 GPIO_OUTPUT_SET | GPIO_PORT3 | GPIO_PIN10)
 
 /****************************************************************************
  * Public Types

--- a/boards/arm/xmc4/xmc4700-relax/src/xmc4_boot.c
+++ b/boards/arm/xmc4/xmc4700-relax/src/xmc4_boot.c
@@ -50,8 +50,6 @@ void xmc4_board_initialize(void)
   /* Configure on-board LEDs if LED support has been selected. */
 
   board_autoled_initialize();
-#else
-  board_userled_initialize();
 #endif
 
 #ifdef CONFIG_XMC4_USCI_SPI

--- a/boards/arm/xmc4/xmc4700-relax/src/xmc4_boot.c
+++ b/boards/arm/xmc4/xmc4700-relax/src/xmc4_boot.c
@@ -50,6 +50,8 @@ void xmc4_board_initialize(void)
   /* Configure on-board LEDs if LED support has been selected. */
 
   board_autoled_initialize();
+#else
+  board_userled_initialize();
 #endif
 
 #ifdef CONFIG_XMC4_USCI_SPI

--- a/boards/arm/xmc4/xmc4700-relax/src/xmc4_bringup.c
+++ b/boards/arm/xmc4/xmc4700-relax/src/xmc4_bringup.c
@@ -26,8 +26,14 @@
 
 #include <debug.h>
 #include <errno.h>
-#include <nuttx/spi/spi_transfer.h>
 #include <sys/types.h>
+
+#ifdef CONFIG_XMC4_USCI_SPI
+#  include <nuttx/spi/spi_transfer.h>
+#endif
+#ifdef CONFIG_USERLED
+#  include <nuttx/leds/userled.h>
+#endif
 
 /****************************************************************************
  * Public Functions
@@ -50,15 +56,25 @@ int xmc4_bringup(void)
   spi = xmc4_spibus_initialize(4);
 
   if (!spi)
-  {
-    return -ENODEV;
-  }
+    {
+      return -ENODEV;
+    }
 
   ret = spi_register(spi, 0);
   if (ret < 0)
-  {
-    snerr("ERROR: Failed to register driver: %d\n", ret);
-  }
+    {
+      snerr("ERROR: Failed to register driver: %d\n", ret);
+    }
+#endif
+
+#ifdef CONFIG_USERLED
+  /* Register the LED driver */
+
+  ret = userled_lower_initialize("/dev/userleds");
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: userled_lower_initialize() failed: %d\n", ret);
+    }
 #endif
 
   return ret;

--- a/boards/arm/xmc4/xmc4700-relax/src/xmc4_bringup.c
+++ b/boards/arm/xmc4/xmc4700-relax/src/xmc4_bringup.c
@@ -24,8 +24,10 @@
 
 #include <nuttx/config.h>
 
-#include <sys/types.h>
 #include <debug.h>
+#include <errno.h>
+#include <nuttx/spi/spi_transfer.h>
+#include <sys/types.h>
 
 /****************************************************************************
  * Public Functions
@@ -43,12 +45,20 @@ int xmc4_bringup(void)
 {
   int ret = OK;
 
-#ifdef CONFIG_SENSORS_MAX6675
-  ret = xmc4_max6675initialize("/dev/temp0");
+#ifdef CONFIG_XMC4_USCI_SPI
+  struct spi_dev_s *spi;
+  spi = xmc4_spibus_initialize(4);
+
+  if (!spi)
+  {
+    return -ENODEV;
+  }
+
+  ret = spi_register(spi, 0);
   if (ret < 0)
-    {
-      syslog(LOG_ERR, "ERROR:  stm32_max6675initialize failed: %d\n", ret);
-    }
+  {
+    snerr("ERROR: Failed to register driver: %d\n", ret);
+  }
 #endif
 
   return ret;

--- a/boards/arm/xmc4/xmc4700-relax/src/xmc4_spi.c
+++ b/boards/arm/xmc4/xmc4700-relax/src/xmc4_spi.c
@@ -1,0 +1,280 @@
+/****************************************************************************
+ * boards/arm/xmc4/xmc4500-relax/src/xmc4_spi.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <debug.h>
+#include <errno.h>
+#include <stdbool.h>
+
+#include <nuttx/spi/spi.h>
+
+#include "xmc4700-relax.h"
+#include "xmc4_gpio.h"
+#include "xmc4_spi.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: xmc4_spidev_initialize
+ *
+ * Description:
+ *   Called to configure SPI chip select GPIO pins for the FRDM-KL25Z board.
+ *
+ ****************************************************************************/
+
+void weak_function xmc4_spidev_initialize(void)
+{
+  /* Configure SPI0 chip selects */
+
+#ifdef CONFIG_XMC4_SPI0
+#endif
+
+  /* Configure SPI1 chip selects */
+
+#ifdef CONFIG_XMC4_SPI1
+#endif
+
+  /* Configure SPI2 chip selects */
+
+#if defined(CONFIG_XMC4_SPI2)
+#endif
+
+  /* Configure SPI3 chip selects */
+
+#ifdef CONFIG_XMC4_SPI3
+#endif
+
+  /* Configure SPI4 chip selects */
+
+#ifdef CONFIG_XMC4_SPI4
+  xmc4_gpio_config(GPIO_CS);
+#endif
+}
+
+/****************************************************************************
+ * Name:  xmc4_spi[n]select, xmc4_spi[n]status, and xmc4_spi[n]cmddata
+ *
+ * Description:
+ *   These external functions must be provided by board-specific logic.  They
+ *   are implementations of the select, status, and cmddata methods of the
+ *   SPI interface defined by struct spi_ops_s (see include/nuttx/spi/spi.h).
+ *   All other methods including xmc4_spibus_initialize()) are provided by
+ *   common xmc4 logic. To use this common SPI logic on your board:
+ *
+ *   1. Provide logic in xmc4_boardinitialize() to configure SPI chip select
+ *      pins.
+ *   2. Provide xmc4_spi[n]select() and xmc4_spi[n]status() functions
+ *      in your board-specific logic.  These functions will perform chip
+ *      selection and status operations using GPIOs in the way your board
+ *      is configured.
+ *   2. If CONFIG_SPI_CMDDATA is defined in the NuttX configuration, provide
+ *      xmc4_spi[n]cmddata() functions in your board-specific logic.  These
+ *      functions will perform cmd/data selection operations using GPIOs in
+ *      the way your board is configured.
+ *   3. Add a call to xmc4_spibus_initialize() in your low level application
+ *      initialization logic
+ *   4. The handle returned by xmc4_spibus_initialize() may then be used to
+ *      bind the SPI driver to higher level logic (e.g., calling
+ *      mmcsd_spislotinitialize(), for example, will bind the SPI driver to
+ *      the SPI MMC/SD driver).
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: xmc4_spi[n]select
+ *
+ * Description:
+ *   PIO chip select pins may be programmed by the board specific logic in
+ *   one of two different ways.  First, the pins may be programmed as SPI
+ *   peripherals.  In that case, the pins are completely controlled by the
+ *   SPI driver.  This method still needs to be provided, but it may be only
+ *   a stub.
+ *
+ *   An alternative way to program the PIO chip select pins is as a normal
+ *   GPIO output.  In that case, the automatic control of the CS pins is
+ *   bypassed and this function must provide control of the chip select.
+ *   NOTE:  In this case, the GPIO output pin does *not* have to be the
+ *   same as the NPCS pin normal associated with the chip select number.
+ *
+ * Input Parameters:
+ *   devid - Identifies the (logical) device
+ *   selected - TRUE:Select the device, FALSE:De-select the device
+ *
+ * Returned Values:
+ *   None
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_XMC4_SPI0
+void xmc4_spi0select(struct spi_dev_s *dev, uint32_t devid,
+                     bool selected)
+{
+  spiinfo("devid: %d CS: %s\n",
+          (int)devid, selected ? "assert" : "de-assert");
+}
+#endif
+
+#ifdef CONFIG_XMC4_SPI1
+void xmc4_spi1select(struct spi_dev_s *dev, uint32_t devid,
+                     bool selected)
+{
+  spiinfo("devid: %d CS: %s\n",
+          (int)devid, selected ? "assert" : "de-assert");
+}
+#endif
+
+#ifdef CONFIG_XMC4_SPI2
+void xmc4_spi2select(struct spi_dev_s *dev, uint32_t devid,
+                     bool selected)
+{
+  spiinfo("devid: %d CS: %s\n",
+          (int)devid, selected ? "assert" : "de-assert");
+}
+#endif
+
+#ifdef CONFIG_XMC4_SPI3
+void xmc4_spi3select(struct spi_dev_s *dev, uint32_t devid,
+                     bool selected)
+{
+  spiinfo("devid: %d CS: %s\n",
+          (int)devid, selected ? "assert" : "de-assert");
+}
+#endif
+
+#ifdef CONFIG_XMC4_SPI4
+void xmc4_spi4select(struct spi_dev_s *dev, uint32_t devid,
+                     bool selected)
+{
+  spiinfo("devid: %d CS: %s\n",
+          (int)devid, selected ? "assert" : "de-assert");
+
+  xmc4_gpio_write(GPIO_CS, !selected);
+}
+#endif
+
+/****************************************************************************
+ * Name: xmc4_spi[n]status
+ *
+ * Description:
+ *   Return status information associated with the SPI device.
+ *
+ * Input Parameters:
+ *   devid - Identifies the (logical) device
+ *
+ * Returned Values:
+ *   Bit-encoded SPI status (see include/nuttx/spi/spi.h.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_XMC4_SPI0
+uint8_t xmc4_spi0status(struct spi_dev_s *dev, uint32_t devid)
+{
+  return 0;
+}
+#endif
+
+#ifdef CONFIG_XMC4_SPI1
+uint8_t xmc4_spi1status(struct spi_dev_s *dev, uint32_t devid)
+{
+  return 0;
+}
+#endif
+
+#ifdef CONFIG_XMC4_SPI2
+uint8_t xmc4_spi2status(struct spi_dev_s *dev, uint32_t devid)
+{
+  return 0;
+}
+#endif
+
+#ifdef CONFIG_XMC4_SPI3
+uint8_t xmc4_spi3status(struct spi_dev_s *dev, uint32_t devid)
+{
+  return 0;
+}
+#endif
+
+#ifdef CONFIG_XMC4_SPI4
+uint8_t xmc4_spi4status(struct spi_dev_s *dev, uint32_t devid)
+{
+  return 0;
+}
+#endif
+
+/****************************************************************************
+ * Name: xmc4_spi[n]cmddata
+ *
+ * Description:
+ *   Some SPI interfaces, particularly with LCDs, and an auxiliary 9th data
+ *   input that determines where the other 8 data bits represent command or
+ *   data.  These interfaces control that CMD/DATA GPIO output
+ *
+ * Input Parameters:
+ *   devid - Identifies the (logical) device
+ *   cmd - Determines where command or data should be selected.
+ *
+ * Returned Values:
+ *   Bit-encoded SPI status (see include/nuttx/spi/spi.h.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_SPI_CMDDATA
+#ifdef CONFIG_XMC4_SPI0
+int xmc4_spi0cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
+{
+  return 0;
+}
+#endif
+
+#ifdef CONFIG_XMC4_SPI1
+int xmc4_spi1cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
+{
+  return 0;
+}
+#endif
+
+#ifdef CONFIG_XMC4_SPI2
+int xmc4_spi2cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
+{
+  return 0;
+}
+#endif
+
+#ifdef CONFIG_XMC4_SPI3
+int xmc4_spi3cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
+{
+  return 0;
+}
+#endif
+
+#ifdef CONFIG_XMC4_SPI4
+int xmc4_spi4cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
+{
+  return 0;
+}
+#endif
+#endif /* CONFIG_SPI_CMDDATA */

--- a/boards/arm/xmc4/xmc4700-relax/src/xmc4_spi.c
+++ b/boards/arm/xmc4/xmc4700-relax/src/xmc4_spi.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * boards/arm/xmc4/xmc4500-relax/src/xmc4_spi.c
+ * boards/arm/xmc4/xmc4700-relax/src/xmc4_spi.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -42,7 +42,7 @@
  * Name: xmc4_spidev_initialize
  *
  * Description:
- *   Called to configure SPI chip select GPIO pins for the FRDM-KL25Z board.
+ *   Called to configure SPI chip select GPIO pins.
  *
  ****************************************************************************/
 
@@ -186,7 +186,7 @@ void xmc4_spi4select(struct spi_dev_s *dev, uint32_t devid,
  *   devid - Identifies the (logical) device
  *
  * Returned Values:
- *   Bit-encoded SPI status (see include/nuttx/spi/spi.h.
+ *   Bit-encoded SPI status (see include/nuttx/spi/spi.h).
  *
  ****************************************************************************/
 
@@ -238,7 +238,7 @@ uint8_t xmc4_spi4status(struct spi_dev_s *dev, uint32_t devid)
  *   cmd - Determines where command or data should be selected.
  *
  * Returned Values:
- *   Bit-encoded SPI status (see include/nuttx/spi/spi.h.
+ *   Bit-encoded SPI status (see include/nuttx/spi/spi.h).
  *
  ****************************************************************************/
 

--- a/boards/arm/xmc4/xmc4700-relax/src/xmc4_userleds.c
+++ b/boards/arm/xmc4/xmc4700-relax/src/xmc4_userleds.c
@@ -55,11 +55,11 @@ void board_userled(int led, bool ledon)
 {
   gpioconfig_t ledcfg;
 
-  if (led == BOARD_LED1)
+  if (led == BOARD_LED0)
     {
       ledcfg = GPIO_LED1;
     }
-  else if (led == BOARD_LED2)
+  else if (led == BOARD_LED1)
     {
       ledcfg = GPIO_LED2;
     }
@@ -79,9 +79,9 @@ void board_userled_all(uint32_t ledset)
 {
   bool ledon;
 
-  ledon = ((ledset & BOARD_LED1_BIT) != 0);
+  ledon = ((ledset & BOARD_LED0_BIT) != 0);
   xmc4_gpio_write(GPIO_LED1, ledon);
 
-  ledon = ((ledset & BOARD_LED2_BIT) != 0);
+  ledon = ((ledset & BOARD_LED1_BIT) != 0);
   xmc4_gpio_write(GPIO_LED2, ledon);
 }


### PR DESCRIPTION
## Summary
1. Added SPI interface according to the evaluation board doc (https://www.infineon.com/dgdl/Infineon-Board_User_Manual_XMC4700_XMC4800_Relax_Kit_Series-UserManual-v01_04-EN.pdf?fileId=5546d46250cc1fdf01513f8e052d07fc) USIC2 Channel 0.
2. Fix userled driver so that LED1 and LED2 are correctly routed.

## Impact
N/A

## Testing
N/A

