### PR TITLE
arch/arm: move -mthumb option back to ARCHCPUFLAGS

### DIFF
--- a/arch/arm/src/common/Toolchain.defs
+++ b/arch/arm/src/common/Toolchain.defs
@@ -74,23 +74,6 @@ ifeq ($(CONFIG_MM_KASAN_ALL),y)
   ARCHOPTIMIZATION += -fsanitize=kernel-address
 endif
 
-ifeq ($(CONFIG_ARM_THUMB),y)
-  ARCHOPTIMIZATION += -mthumb
-
-  # GCC Manual:
-  # -mthumb
-  # ... If you want to force assembler files to be interpreted as Thumb
-  # code, either add a `.thumb' directive to the source or pass the
-  # -mthumb option directly to the assembler by prefixing it with -Wa.
-
-  ARCHOPTIMIZATION += -Wa,-mthumb
-
-  # Outputs an implicit IT block when there is a conditional instruction
-  # without an enclosing IT block.
-
-  ARCHOPTIMIZATION += -Wa,-mimplicit-it=always
-endif
-
 ifeq ($(CONFIG_UNWINDER_ARM),y)
   ARCHOPTIMIZATION += -funwind-tables -fasynchronous-unwind-tables
 endif
@@ -143,6 +126,23 @@ ifneq ($(TARGET_TOOL),)
 endif
 
 ARCHCPUFLAGS += $(TOOLCHAIN_MARCH) $(TOOLCHAIN_MTUNE) $(TOOLCHAIN_MFLOAT)
+
+ifeq ($(CONFIG_ARM_THUMB),y)
+  ARCHCPUFLAGS += -mthumb
+
+  # GCC Manual:
+  # -mthumb
+  # ... If you want to force assembler files to be interpreted as Thumb
+  # code, either add a `.thumb' directive to the source or pass the
+  # -mthumb option directly to the assembler by prefixing it with -Wa.
+
+  ARCHCPUFLAGS += -Wa,-mthumb
+
+  # Outputs an implicit IT block when there is a conditional instruction
+  # without an enclosing IT block.
+
+  ARCHCPUFLAGS += -Wa,-mimplicit-it=always
+endif
 
 # Clang toolchain
 


### PR DESCRIPTION
## Summary

CONFIG_ARM_TOOLCHAIN_GNU_EABI build got broken when -mthumb option was moved from ARCHCPUFLAGS to ARCHOPTIMIZATION variable:

```
arm-none-eabi-ld: error: .../build/nuttx/nuttx uses VFP register arguments, /usr/lib/gcc/arm-none-eabi/5.4.1/libgcc.a(_fixunsdfdi.o) does not
arm-none-eabi-ld: failed to merge target specific data of file /usr/lib/gcc/arm-none-eabi/5.4.1/libgcc.a(_fixunsdfdi.o)
arm-none-eabi-ld: error: .../build/nuttx/nuttx uses VFP register arguments, /usr/lib/gcc/arm-none-eabi/5.4.1/libgcc.a(_udivmoddi4.o) does not
arm-none-eabi-ld: failed to merge target specific data of file /usr/lib/gcc/arm-none-eabi/5.4.1/libgcc.a(_udivmoddi4.o)

```
Related to #7097.

## Impact

arch/arm

## Testing

./tools/configure.sh -l nucleo-h743zi:nsh