### PR TITLE
libs/libc/aio: fix aio_fsync compatible issue

### DIFF
--- a/fs/aio/aio_fsync.c
+++ b/fs/aio/aio_fsync.c
@@ -191,7 +191,12 @@ int aio_fsync(int op, FAR struct aiocb *aiocbp)
   FAR struct aio_container_s *aioc;
   int ret;
 
-  DEBUGASSERT(op == O_SYNC); /* || op == O_DSYNC */
+  if (op != O_SYNC)
+    {
+      set_errno(EINVAL);
+      return ERROR;
+    }
+
   DEBUGASSERT(aiocbp);
 
   /* The result -EINPROGRESS means that the transfer has not yet completed */


### PR DESCRIPTION
## Summary
1. make the aio_fsync implementation can pass the ltp/open_posix_testsuite/aio_fsync testcases
2. the modification are referred to https://pubs.opengroup.org/onlinepubs/9699919799/functions/aio_fsync.html

## Impact

## Testing

