### PR TITLE
net: Add new interface to tell usrsock available

### DIFF
--- a/include/nuttx/net/ioctl.h
+++ b/include/nuttx/net/ioctl.h
@@ -125,7 +125,7 @@
 
 /* Network socket control ***************************************************/
 
-#define SIOCDENYINETSOCK _SIOC(0x0033) /* Deny network socket. */
+#define SIOCDENYINETSOCK _SIOC(0x003C) /* Deny network socket. */
 
 /* Bridge calls *************************************************************/
 

--- a/net/socket/net_sockif.c
+++ b/net/socket/net_sockif.c
@@ -38,7 +38,6 @@
 #include "pkt/pkt.h"
 #include "bluetooth/bluetooth.h"
 #include "ieee802154/ieee802154.h"
-#include "usrsock/usrsock.h"
 #include "socket/socket.h"
 
 /****************************************************************************
@@ -131,13 +130,6 @@ net_sockif(sa_family_t family, int type, int protocol)
     default:
       nerr("ERROR: Address family unsupported: %d\n", family);
     }
-
-#ifdef CONFIG_NET_USRSOCK
-  if (sockif == NULL)
-    {
-      sockif = &g_usrsock_sockif;
-    }
-#endif
 
   return sockif;
 }

--- a/net/tcp/Kconfig
+++ b/net/tcp/Kconfig
@@ -14,7 +14,7 @@ config NET_TCP
 
 config NET_TCP_NO_STACK
 	bool "Disable TCP/IP Stack"
-	default n
+	default NET_USRSOCK_TCP if NET_USRSOCK
 	select NET_TCP
 	---help---
 		Build without TCP/IP stack even if TCP networking support enabled.

--- a/net/udp/Kconfig
+++ b/net/udp/Kconfig
@@ -15,7 +15,7 @@ config NET_UDP
 
 config NET_UDP_NO_STACK
 	bool "Disable UDP/IP Stack"
-	default n
+	default NET_USRSOCK_UDP if NET_USRSOCK
 	select NET_UDP
 	---help---
 		Build without UDP/IP stack even if UDP networking support enabled.

--- a/net/usrsock/Kconfig
+++ b/net/usrsock/Kconfig
@@ -76,12 +76,10 @@ config NET_USRSOCK_NPOLLWAITERS
 config NET_USRSOCK_UDP
 	bool "User-space daemon provides UDP sockets"
 	default n
-	select NET_UDP_NO_STACK
 
 config NET_USRSOCK_TCP
 	bool "User-space daemon provides TCP sockets"
 	default n
-	select NET_TCP_NO_STACK
 
 config NET_USRSOCK_ICMP
 	bool "User-space daemon provides ICMP sockets"


### PR DESCRIPTION
## Summary

Applications can prohibit Socket for INET by UsrSock by using the
ioctl command of SIOCDENYINETSOCK.

In this modification, we have added an interface to UsrSock that
queries whether or not the creation of Socket for INET is
prohibited.

This allows an application to choose which to use when both
UsrSock and, for example, rndis stacks are enabled.

## Impact

UsrSock daemons

## Testing

Spresense + wifi