### PR TITLE
Fix gpio outputs from being configured as interrupts in stm32f0l0g0 gpio driver

### DIFF
--- a/arch/arm/src/stm32f0l0g0/stm32_gpio.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_gpio.c
@@ -307,7 +307,7 @@ int stm32_configgpio(uint32_t cfgset)
    * Should it configured as an EXTI interrupt?
    */
 
-  if ((cfgset & GPIO_EXTI) != 0)
+  if ((pinmode != GPIO_MODER_OUTPUT) && ((cfgset & GPIO_EXTI) != 0))
     {
       uint32_t regaddr;
       int shift;


### PR DESCRIPTION
## Summary
This PR intends to fix a bug in the gpio driver for smtr32f0l0g0 family.
When configuring gpios as outputs, they are being also configured as interrupts in the EXTICR register.
With the proposed fix this misconfiguration is corrected and outputs as well as interrupts are correctly configured.
## Impact
GPIO outputs are not configured as interrupts, and interrupts are correctly configured.
## Testing

