### PR TITLE
fix locale/lib_iconv.c:538:23: warning: dereference of NULL ‘scd’ [CWE-690] [-Wanalyzer-null-dereference] by -fanalyzer

### DIFF
--- a/libs/libc/locale/lib_iconv.c
+++ b/libs/libc/locale/lib_iconv.c
@@ -529,6 +529,11 @@ size_t iconv(iconv_t cd, FAR char **in, FAR size_t *inb,
           case UCS2:
           case UTF_16:
             {
+              if (scd == NULL)
+                {
+                  goto starved;
+                }
+
               l = 0;
               if (!scd->state)
                 {
@@ -551,6 +556,11 @@ size_t iconv(iconv_t cd, FAR char **in, FAR size_t *inb,
 
           case UTF_32:
             {
+              if (scd == NULL)
+                {
+                  goto starved;
+                }
+
               l = 0;
               if (!scd->state)
                 {
@@ -699,6 +709,11 @@ size_t iconv(iconv_t cd, FAR char **in, FAR size_t *inb,
 
                   switch (128 * (c == '$') + d)
                     {
+                    if (scd == NULL)
+                      {
+                        goto starved;
+                      }
+
                       case 'B':
                         {
                           scd->state = 0;
@@ -731,6 +746,11 @@ size_t iconv(iconv_t cd, FAR char **in, FAR size_t *inb,
                     }
 
                   goto ilseq;
+                }
+
+              if (scd == NULL)
+                {
+                  goto starved;
                 }
 
               switch (scd->state)


### PR DESCRIPTION
## Summary
fix locale/lib_iconv.c:538:23: warning: dereference of NULL ‘scd’ [CWE-690] [-Wanalyzer-null-dereference] by -fanalyzer
```
    CC:  signal/sig_queue.c locale/lib_iconv.c: In function ‘iconv’:
    locale/lib_iconv.c:538:23: warning: dereference of NULL ‘scd’ [CWE-690] [-Wanalyzer-null-dereference]
      538 |               if (!scd->state)
          |                    ~~~^~~~~~~
      ‘iconv’: events 1-5
        |
        |  413 |   x = 0;
        |      |   ~~^~~
        |      |     |
        |      |     (1) ‘scd’ is NULL
        |  414 |   scd = NULL;
        |  415 |   if (((size_t)cd & 1) == 0)
        |      |      ~
        |      |      |
        |      |      (2) following ‘false’ branch...
        |......
        |  421 |   to = extract_to(cd);
        |      |        ~~~~~~~~~~~~~~
        |      |        |
        |      |        (3) ...to here
        |......
        |  428 |   if (in == NULL || *in == NULL || *inb == 0)
        |      |      ~              ~~~
        |      |      |              |
        |      |      |              (5) ...to here
        |      |      (4) following ‘false’ branch (when ‘in’ is non-NULL)...
        |
      ‘iconv’: events 6-8
        |
        |  428 |   if (in == NULL || *in == NULL || *inb == 0)
        |      |       ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
        |      |                  |              |  |
        |      |                  |              |  (7) ...to here
        |      |                  |              (8) following ‘false’ branch...
        |      |                  (6) following ‘false’ branch...
        |
      ‘iconv’: event 9
        |
        |cc1:
        | (9): ...to here
        |
      ‘iconv’: events 10-14
        |
        |  433 |   for (; *inb; *in += l, *inb -= l)
        |      |   ^~~
        |      |   |
        |      |   (10) following ‘true’ branch...
        |  434 |     {
        |  435 |       c = *(FAR unsigned char *)*in;
        |      |            ~~~~~~~~~~~~~~~~~~~~~~~~
        |      |            |
        |      |            (11) ...to here
        |......
        |  438 |       switch (type)
        |      |       ~~~~~~
        |      |       |
        |      |       (12) following ‘case 200:’ branch...
        |......
        |  529 |           case UCS2:
        |      |           ~~~~
        |      |           |
        |      |           (13) ...to here
        |......
        |  538 |               if (!scd->state)
        |      |                    ~~~~~~~~~~
        |      |                       |
        |      |                       (14) dereference of NULL ‘scd’
        |
    locale/lib_iconv.c:565:23: warning: dereference of NULL ‘scd’ [CWE-690] [-Wanalyzer-null-dereference]
      565 |               if (!scd->state)
          |                    ~~~^~~~~~~
      ‘iconv’: events 1-5
        |
        |  413 |   x = 0;
        |      |   ~~^~~
        |      |     |
        |      |     (1) ‘scd’ is NULL
        |  414 |   scd = NULL;
        |  415 |   if (((size_t)cd & 1) == 0)
        |      |      ~
        |      |      |
        |      |      (2) following ‘false’ branch...
        |......
        |  421 |   to = extract_to(cd);
        |      |        ~~~~~~~~~~~~~~
        |      |        |
        |      |        (3) ...to here
        |......
        |  428 |   if (in == NULL || *in == NULL || *inb == 0)
        |      |      ~              ~~~
        |      |      |              |
        |      |      |              (5) ...to here
        |      |      (4) following ‘false’ branch (when ‘in’ is non-NULL)...
        |
      ‘iconv’: events 6-8
        |
        |  428 |   if (in == NULL || *in == NULL || *inb == 0)
        |      |       ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
        |      |                  |              |  |
        |      |                  |              |  (7) ...to here
        |      |                  |              (8) following ‘false’ branch...
        |      |                  (6) following ‘false’ branch...
        |
      ‘iconv’: event 9
        |
        |cc1:
        | (9): ...to here
        |
      ‘iconv’: events 10-14
        |
        |  433 |   for (; *inb; *in += l, *inb -= l)
        |      |   ^~~
        |      |   |
        |      |   (10) following ‘true’ branch...
        |  434 |     {
        |  435 |       c = *(FAR unsigned char *)*in;
        |      |            ~~~~~~~~~~~~~~~~~~~~~~~~
        |      |            |
        |      |            (11) ...to here
        |......
        |  438 |       switch (type)
        |      |       ~~~~~~
        |      |       |
        |      |       (12) following ‘case 202:’ branch...
        |......
        |  557 |           case UTF_32:
        |      |           ~~~~
        |      |           |
        |      |           (13) ...to here
        |......
        |  565 |               if (!scd->state)
        |      |                    ~~~~~~~~~~
        |      |                       |
        |      |                       (14) dereference of NULL ‘scd’
        |
```
Signed-off-by: Junbo Zheng <zhengjunbo1@xiaomi.com>

## Impact
N/A

## Testing
./tools/configure.sh sim:nsh

please ignore the below warning:
```
Warning: /home/runner/work/nuttx/nuttx/nuttx/libs/libc/locale/lib_iconv.c:110:3: warning: #include outside of 'Included Files' section
Warning: /home/runner/work/nuttx/nuttx/nuttx/libs/libc/locale/lib_iconv.c:121:1: warning: #include outside of 'Included Files' section
Warning: /home/runner/work/nuttx/nuttx/nuttx/libs/libc/locale/lib_iconv.c:127:1: warning: #include outside of 'Included Files' section
Warning: /home/runner/work/nuttx/nuttx/nuttx/libs/libc/locale/lib_iconv.c:132:1: warning: #include outside of 'Included Files' section
Warning: /home/runner/work/nuttx/nuttx/nuttx/libs/libc/locale/lib_iconv.c:139:1: warning: #include outside of 'Included Files' section
Warning: /home/runner/work/nuttx/nuttx/nuttx/libs/libc/locale/lib_iconv.c:144:1: warning: #include outside of 'Included Files' section
Warning: /home/runner/work/nuttx/nuttx/nuttx/libs/libc/locale/lib_iconv.c:149:1: warning: #include outside of 'Included Files' section
Warning: /home/runner/work/nuttx/nuttx/nuttx/libs/libc/locale/lib_iconv.c:156:1: warning: #include outside of 'Included Files' section
```
