### PR TITLE
arm64 smp with kvm

### DIFF
--- a/arch/arm64/src/common/arm64_gicv2.c
+++ b/arch/arm64/src/common/arm64_gicv2.c
@@ -1393,6 +1393,26 @@ void arm64_gic_secondary_init(void)
   arm_gic_initialize();
 }
 
+/****************************************************************************
+ * Name: arm64_gic_raise_sgi
+ *
+ * Description:
+ *   Raise software generated interrupt to the target
+ *
+ * Input Parameters
+ *   sgi    - The SGI interrupt ID (0-15)
+ *   cpuset - The set of CPUs to receive the SGI
+ *
+ * Returned Value:
+ *   OK is always returned at present.
+ *
+ ****************************************************************************/
+
+int arm64_gic_raise_sgi(unsigned int sgi, uint16_t cpuset)
+{
+  arm_cpu_sgi(sgi, cpuset);
+  return 0;
+}
 #endif /* CONFIG_SMP */
 
 #endif /* CONFIG_ARM_GIC_VERSION == 2 */

--- a/arch/arm64/src/qemu/Kconfig
+++ b/arch/arm64/src/qemu/Kconfig
@@ -31,6 +31,10 @@ config ARCH_CHIP_QEMU_A72
 
 endchoice # Qemu Chip Selection
 
+config ARCH_CHIP_QEMU_WITH_HV
+	bool "Qemu with hypvervisor (e.g. kvm, hvf)"
+	default n
+
 endmenu # "Qemu Chip Selection"
 
 endif # ARCH_CHIP_QEMU

--- a/arch/arm64/src/qemu/qemu_boot.c
+++ b/arch/arm64/src/qemu/qemu_boot.c
@@ -154,9 +154,10 @@ void arm64_chip_boot(void)
 
   arm64_mmu_init(true);
 
-#if defined(CONFIG_SMP) || defined(CONFIG_ARCH_HAVE_PSCI)
+#if defined(CONFIG_ARCH_CHIP_QEMU_WITH_HV)
+  arm64_psci_init("hvc");
+#elif defined(CONFIG_SMP) || defined(CONFIG_ARCH_HAVE_PSCI)
   arm64_psci_init("smc");
-
 #endif
 
   /* Perform board-specific device initialization. This would include


### PR DESCRIPTION
## Summary

- This PR consists of the following two commits
- commit1: arch: arm64: Fix to access psci with hypervisor
  - I noticed that pcsi version can not be obtained with qemu + kvm.
  - Also, pci_detect hangs with qemu + hvf.
  - This commit fixes this issue by using hvc (hypervisor call).
- commit2: arch: arm64: Add arm64_gic_raise_sgi() for SMP
  - I noticed that arm64_gic_raise_sgi() is not implemented for
      GICv2 which is used for SMP + hypervisor such as qemu + kvm.
  - This commit fixes this issue

## Impact

- None

## Testing

- Tested with qemu-7.1 + kvm (linux) and qemu-7.1 + hvf (macOS)