### PR TITLE
fs: Define __USE_FILE_OFFSET64 when CONFIG_FS_LARGEFILE is enabled

### DIFF
--- a/include/sys/types.h
+++ b/include/sys/types.h
@@ -84,6 +84,7 @@
 #define SCHED_PRIORITY_IDLE      0
 
 #if defined(CONFIG_FS_LARGEFILE)
+#  define __USE_FILE_OFFSET64    1
 #  define fsblkcnt64_t           fsblkcnt_t
 #  define fsfilcnt64_t           fsfilcnt_t
 #  define blkcnt64_t             blkcnt_t


### PR DESCRIPTION
## Summary

follow other OS convention.

## Impact

new macro

## Testing

ci