### PR TITLE
drivers/net: Remove HAVE_ATOMICS and use CONFIG_HAVE_ATOMICS directly

### DIFF
--- a/drivers/net/netdev_upperhalf.c
+++ b/drivers/net/netdev_upperhalf.c
@@ -91,7 +91,7 @@ struct netdev_upperhalf_s
 static int quota_fetch_inc(FAR struct netdev_lowerhalf_s *lower,
                            enum netpkt_type_e type)
 {
-#ifndef HAVE_ATOMICS
+#ifndef CONFIG_HAVE_ATOMICS
   irqstate_t flags = spin_lock_irqsave(&lower->lock);
   int ret = lower->quota[type]++;
   spin_unlock_irqrestore(&lower->lock, flags);
@@ -104,7 +104,7 @@ static int quota_fetch_inc(FAR struct netdev_lowerhalf_s *lower,
 static int quota_fetch_dec(FAR struct netdev_lowerhalf_s *lower,
                            enum netpkt_type_e type)
 {
-#ifndef HAVE_ATOMICS
+#ifndef CONFIG_HAVE_ATOMICS
   irqstate_t flags = spin_lock_irqsave(&lower->lock);
   int ret = lower->quota[type]--;
   spin_unlock_irqrestore(&lower->lock, flags);
@@ -680,7 +680,7 @@ int netdev_lower_register(FAR struct netdev_lowerhalf_s *dev,
       return -ENOMEM;
     }
 
-#ifndef HAVE_ATOMICS
+#ifndef CONFIG_HAVE_ATOMICS
   spin_initialize(&dev->lock, SP_UNLOCKED);
 #endif
   dev->netdev.d_ifup    = netdev_upper_ifup;
@@ -849,7 +849,7 @@ void netdev_lower_txdone(FAR struct netdev_lowerhalf_s *dev)
 int netdev_lower_quota_load(FAR struct netdev_lowerhalf_s *dev,
                             enum netpkt_type_e type)
 {
-#ifndef HAVE_ATOMICS
+#ifndef CONFIG_HAVE_ATOMICS
   irqstate_t flags = spin_lock_irqsave(&dev->lock);
   int ret = dev->quota[type];
   spin_unlock_irqrestore(&dev->lock, flags);

--- a/include/nuttx/net/netdev_lowerhalf.h
+++ b/include/nuttx/net/netdev_lowerhalf.h
@@ -34,13 +34,7 @@
 #include <net/if.h>
 #include <netinet/in.h>
 
-/* Compiler may not have stdatomic.h before C11 or with __STDC_NO_ATOMICS__
- * But we can also get atomic support from libmetal.
- */
-
-#if defined(CONFIG_OPENAMP)
-#  include <metal/atomic.h>
-#elif defined(CONFIG_HAVE_ATOMICS)
+#ifdef CONFIG_HAVE_ATOMICS
 #  include <stdatomic.h>
 #endif
 
@@ -61,10 +55,6 @@
  */
 
 #define NETPKT_BUFLEN   CONFIG_IOB_BUFSIZE
-
-#if defined(CONFIG_OPENAMP) || defined(CONFIG_HAVE_ATOMICS)
-#  define HAVE_ATOMICS
-#endif
 
 /****************************************************************************
  * Public Types
@@ -103,7 +93,7 @@ struct netdev_lowerhalf_s
 
   /* Max # of buffer held by driver */
 
-#ifdef HAVE_ATOMICS
+#ifdef CONFIG_HAVE_ATOMICS
   atomic_int quota[NETPKT_TYPENUM];
 #else
   int quota[NETPKT_TYPENUM];


### PR DESCRIPTION
## Summary

since OpenAMP never support to compile in c89 only mode

## Impact

code refactor only

## Testing

ci