### PR TITLE
arch/nrfxxx: cosmetics in Kconfig

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -274,7 +274,7 @@ config ARCH_CHIP_MOXART
 		MoxART family
 
 config ARCH_CHIP_NRF52
-	bool "Nordic NRF52"
+	bool "Nordic nRF52"
 	select ARCH_CORTEXM4
 	select ARCH_HAVE_TICKLESS
 	select ARMV7M_HAVE_STACKCHECK
@@ -285,25 +285,25 @@ config ARCH_CHIP_NRF52
 	select ARCH_HAVE_PWM_MULTICHAN
 	select ARCH_HAVE_SERIAL_TERMIOS
 	---help---
-		Nordic NRF52 architectures (ARM Cortex-M4).
+		Nordic nRF52 architectures (ARM Cortex-M4).
 
 config ARCH_CHIP_NRF53
-	bool "Nordic NRF53"
+	bool "Nordic nRF53"
 	select ARCH_CORTEXM33
 	select ARCH_HAVE_PWM_MULTICHAN
 	depends on EXPERIMENTAL
 	---help---
-		Nordic NRF53 architectures (ARM dual Cortex-M33).
+		Nordic nRF53 architectures (ARM dual Cortex-M33).
 
 config ARCH_CHIP_NRF91
-	bool "Nordic NRF91"
+	bool "Nordic nRF91"
 	select ARCH_CORTEXM33
 	select ARCH_HAVE_PWM_MULTICHAN
 	select ARCH_HAVE_TRUSTZONE
 	select ARCH_HAVE_TICKLESS
 	depends on EXPERIMENTAL
 	---help---
-		Nordic NRF91 architectures (ARM Cortex-M33 with integrated
+		Nordic nRF91 architectures (ARM Cortex-M33 with integrated
 		LTE-M/NB-IoT modem and GNSS).
 
 config ARCH_CHIP_NUC1XX

--- a/arch/arm/src/nrf52/Kconfig
+++ b/arch/arm/src/nrf52/Kconfig
@@ -3,22 +3,22 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
-comment "NRF52 Configuration Options"
+comment "nRF52 Configuration Options"
 
 choice
-	prompt "NRF52 Chip Selection"
+	prompt "nRF52 Chip Selection"
 	default ARCH_CHIP_NRF52832
 	depends on ARCH_CHIP_NRF52
 
 config ARCH_CHIP_NRF52832
-	bool "NRF52832"
+	bool "nRF52832"
 	select ARCH_FAMILY_NRF52
 	select NRF52_MEM_FLASH_512
 	select NRF52_MEM_RAM_64
 	select NRF52_HAVE_BPROT
 
 config ARCH_CHIP_NRF52833
-	bool "NRF52832"
+	bool "nRF52832"
 	select ARCH_FAMILY_NRF52
 	select NRF52_MEM_FLASH_512
 	select NRF52_MEM_RAM_128
@@ -30,7 +30,7 @@ config ARCH_CHIP_NRF52833
 	select NRF52_HAVE_PWM3
 
 config ARCH_CHIP_NRF52840
-	bool "NRF52840"
+	bool "nRF52840"
 	select ARCH_FAMILY_NRF52
 	select NRF52_MEM_FLASH_1024
 	select NRF52_MEM_RAM_256
@@ -160,7 +160,7 @@ config NRF52_RTC
 	bool
 	default n
 
-menu "NRF52 Peripheral Selection"
+menu "nRF52 Peripheral Selection"
 
 config NRF52_I2C0_MASTER
 	bool "I2C0 Master"
@@ -321,7 +321,7 @@ config NRF52_COMP
 	bool "COMP"
 	default n
 
-endmenu # NRF52 Peripheral Selection
+endmenu # nRF52 Peripheral Selection
 
 menu "Clock Configuration"
 

--- a/arch/arm/src/nrf53/Kconfig
+++ b/arch/arm/src/nrf53/Kconfig
@@ -3,17 +3,17 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
-comment "NRF53 Configuration Options"
+comment "nRF53 Configuration Options"
 
-# NRF53 Families
+# nRF53 Families
 
 choice
-	prompt "NRF53 Chip Selection"
+	prompt "nRF53 Chip Selection"
 	default ARCH_CHIP_NRF5340
 	depends on ARCH_CHIP_NRF53
 
 config ARCH_CHIP_NRF5340
-	bool "NRF5340"
+	bool "nRF5340"
 	select NRF53_CPUAPP_MEM_FLASH_1024
 	select NRF53_CPUAPP_MEM_RAM_512
 	select NRF53_CPUNET_MEM_FLASH_256
@@ -40,19 +40,19 @@ config NRF53_NETCORE
 	default n
 
 choice
-	prompt "NRF5340 Core Selection"
+	prompt "nRF5340 Core Selection"
 	default ARCH_CHIP_NRF5340_CPUAPP
 	depends on ARCH_CHIP_NRF5340
 
 config ARCH_CHIP_NRF5340_CPUAPP
-	bool "NRF53 App core"
+	bool "nRF53 App core"
 	select NRF53_APPCORE
 
 config ARCH_CHIP_NRF5340_CPUNET
-	bool "NRF53 Net core"
+	bool "nRF53 Net core"
 	select NRF53_NETCORE
 
-endchoice # NRF5340 Core Selection
+endchoice # nRF5340 Core Selection
 
 # RAM size for the app core
 
@@ -97,17 +97,17 @@ config NRF53_CPUNET_MEM_FLASH_SIZE
 if NRF53_APPCORE
 
 config NRF53_NET_BOOT
-	bool "NRF53 Net core configuration"
+	bool "nRF53 Net core configuration"
 	default y
 
 if NRF53_NET_BOOT
 
 config NRF53_NET_POWER_ON_BOOT
-	bool "NRF53 Power Net core on App core boot"
+	bool "nRF53 Power Net core on App core boot"
 	default y
 
 config NRF53_NET_GPIO_ALLOW_ALL
-	bool "NRF53 allow all GPIO for Net core"
+	bool "nRF53 allow all GPIO for Net core"
 	default y
 
 endif # NRF53_NET_BOOT
@@ -115,7 +115,7 @@ endif # NRF53_NET_BOOT
 endif # NRF53_APPCORE
 
 config NRF53_ENABLE_APPROTECT
-	bool "NRF53 enable APPROTECT"
+	bool "nRF53 enable APPROTECT"
 	default n
 
 # Peripheral support
@@ -182,7 +182,7 @@ config NRF53_RTC
 	bool
 	default n
 
-menu "NRF53 Peripheral Selection"
+menu "nRF53 Peripheral Selection"
 
 config NRF53_GPIOTE
 	bool "GPIOTE (GPIO interrupts)"
@@ -309,7 +309,7 @@ config NRF53_USBDEV
 	depends on NRF53_HFCLK_XTAL
 	select USBDEV
 
-endmenu # NRF53 Peripheral Selection
+endmenu # nRF53 Peripheral Selection
 
 menu "Clock Configuration"
 

--- a/arch/arm/src/nrf91/Kconfig
+++ b/arch/arm/src/nrf91/Kconfig
@@ -654,19 +654,19 @@ config NRF91_MODEM
 if NRF91_MODEM
 
 config NRF91_MODEM_SHMEM_TX_SIZE
-	hex "NRF91 modem shmem RX size"
+	hex "Modem shmem RX size"
 	default 0x2000
 
 config NRF91_MODEM_SHMEM_RX_SIZE
-	hex "NRF91 modem shmem RX size"
+	hex "Modem shmem RX size"
 	default 0x2000
 
 config NRF91_MODEM_SHMEM_TRACE_SIZE
-	hex "NRF91 modem shmem TRACE size"
+	hex "Modem shmem TRACE size"
 	default 0
 
 config NRF91_MODEM_SHMEM_SIZE
-	hex "NRF91 modem shmem size"
+	hex "Modem shmem size"
 	default 0x44e8
 	---help---
 	  Shared memory size for the modem library must be calculated by user:
@@ -679,11 +679,11 @@ config NRF91_MODEM_SHMEM_SIZE
 	      and can be found in nrf_modem/include/nrf_modem.h file.
 
 config NRF91_MODEM_LOG
-	bool "NRF91 modem with logs"
+	bool "Modem with logs"
 	default n
 
 config NRF91_MODEM_AT
-	bool "NRF91 modem AT interface support"
+	bool "Modem AT interface support"
 	default y
 
 endif # NRF91_MODEM

--- a/arch/arm/src/nrf91/Kconfig
+++ b/arch/arm/src/nrf91/Kconfig
@@ -3,22 +3,22 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
-comment "NRF91 Configuration Options"
+comment "nRF91 Configuration Options"
 
-# NRF91 Families
+# nRF91 Families
 
 choice
-	prompt "NRF91 Chip Selection"
+	prompt "nRF91 Chip Selection"
 	default ARCH_CHIP_NRF9160
 	depends on ARCH_CHIP_NRF91
 
 config ARCH_CHIP_NRF9160
-	bool "NRF9160"
+	bool "nRF9160"
 
 endchoice # NRF91 Chip Selection
 
 config NRF91_ENABLE_APPROTECT
-	bool "NRF91 enable APPROTECT"
+	bool "nRF91 enable APPROTECT"
 	default n
 
 # Peripheral Selection
@@ -66,7 +66,7 @@ config NRF91_SERIAL4
 	bool
 	default n
 
-menu "NRF91 Peripheral Selection"
+menu "nRF91 Peripheral Selection"
 
 config NRF91_GPIOTE
 	bool "GPIOTE (GPIO interrupts)"
@@ -177,7 +177,7 @@ config NRF91_RTC1
 	select NRF91_RTC
 	default n
 
-endmenu # NRF91 Peripheral Selection
+endmenu # nRF91 Peripheral Selection
 
 menu "SPU configuration"
 
@@ -645,7 +645,7 @@ endif # NRF91_I2C_MASTER
 endmenu
 
 config NRF91_MODEM
-	bool "NRF91 modem"
+	bool "nRF91 modem"
 	depends on ALLOW_BSDNORDIC_COMPONENTS && ARCH_TRUSTZONE_NONSECURE
 	select ARCH_IRQPRIO
 	select NRF91_IPC


### PR DESCRIPTION
## Summary

- arch/{nrf52|nrf53|nrf91}: rename NRFxx to nRFxx to be compatible with the manufacturer's nomenclature
Suggested by @acassis in https://github.com/apache/nuttx/pull/9661
- arch/nrf91: simplyfy modem option names

## Impact

## Testing
CI
