### PR TITLE
tools/ci: remove 'brew update' needed for AVR toolchain installation on OSX

### DIFF
--- a/tools/ci/cibuild.sh
+++ b/tools/ci/cibuild.sh
@@ -552,20 +552,6 @@ case ${os} in
     install="arm-gcc-toolchain arm64-gcc-toolchain avr-gcc-toolchain binutils bloaty elf-toolchain gen-romfs gperf kconfig-frontends mips-gcc-toolchain python-tools riscv-gcc-toolchain rust xtensa-esp32-gcc-toolchain u-boot-tools wasi-sdk c-cache"
     mkdir -p "${tools}"/homebrew
     export HOMEBREW_CACHE=${tools}/homebrew
-    # https://github.com/apache/arrow/issues/15025
-    rm -f /usr/local/bin/2to3 || :
-    rm -f /usr/local/bin/idle3 || :
-    rm -f /usr/local/bin/pydoc3 || :
-    rm -f /usr/local/bin/python3 || :
-    rm -f /usr/local/bin/python3-config || :
-    # same for python@3.11
-    rm -f /usr/local/bin/2to3-3.11 || :
-    rm -f /usr/local/bin/idle3.11 || :
-    rm -f /usr/local/bin/pydoc3.11 || :
-    rm -f /usr/local/bin/python3.11 || :
-    rm -f /usr/local/bin/python3.11-config || :
-    # https://github.com/osx-cross/homebrew-avr/issues/205#issuecomment-760637996
-    brew update --quiet
     ;;
   Linux)
     install="arm-clang-toolchain arm-gcc-toolchain arm64-gcc-toolchain avr-gcc-toolchain binutils bloaty clang-tidy gen-romfs gperf kconfig-frontends mips-gcc-toolchain python-tools riscv-gcc-toolchain rust rx-gcc-toolchain sparc-gcc-toolchain xtensa-esp32-gcc-toolchain u-boot-tools wasi-sdk c-cache"


### PR DESCRIPTION
## Summary
Remove 'brew update' introduced by https://github.com/apache/nuttx-testing/pull/88 as it seems to be not longer needed.

## Impact
Make OSX CI build mighty again

## Testing
Pass CI