### PR TITLE
.github/workflows: run MAC OS builds based on macos-13 image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,7 +174,7 @@ jobs:
   macOS:
     permissions:
       contents: none
-    runs-on: macos-12
+    runs-on: macos-13
     needs: Fetch-Source
     strategy:
       matrix:


### PR DESCRIPTION
## Summary
.github/workflows: run MAC OS builds based on macos-13 image

## Impact
Use the latest available version of MAC OS

## Testing
Pass CI