### PR TITLE
errno: Adjust help string for EALREADY and ESTALE

### DIFF
--- a/include/errno.h
+++ b/include/errno.h
@@ -283,11 +283,11 @@
 #define EHOSTUNREACH        113
 #define EHOSTUNREACH_STR    "No route to host"
 #define EALREADY            114
-#define EALREADY_STR        "Socket already connected"
+#define EALREADY_STR        "Operation already in progress"
 #define EINPROGRESS         115
 #define EINPROGRESS_STR     "Operation now in progress"
 #define ESTALE              116
-#define ESTALE_STR          "Stale NFS file handle"
+#define ESTALE_STR          "Stale file handle"
 #define EUCLEAN             117
 #define EUCLEAN_STR         "Structure needs cleaning"
 #define ENOTNAM             118


### PR DESCRIPTION
## Summary
`EALREADY`:
Both Linux(asm-generic/errno.h) and FreeBSD(sys/sys/errno.h) regard it as "Operation already in progress"

`ESTALE`:
Linux specifically removed the "NFS" description, and we may not only use it for NFS https://github.com/torvalds/linux/commit/0ca43435188b9f911c8efcdf10731f726142dda1

The `ECANCELED` and `EOWNERDEAD` also use different strings from Linux's header, but their meanings are same, and NuttX's description are more likely to obey POSIX 1003.1-2008, so not changing them.

## Impact
Help string for error codes (sync with linux).

## Testing

