### PR TITLE
input/touchscreen: Translate raw X/Y data into pixel coordinates

### DIFF
--- a/drivers/input/Kconfig
+++ b/drivers/input/Kconfig
@@ -415,6 +415,22 @@ config STMPE811_SWAPXY
 	---help---
 		Reverse the meaning of X and Y to handle different LCD orientations.
 
+config STMPE811_OFFSETX
+	int "X offset"
+	default 0
+	depends on !STMPE811_TSC_DISABLE
+	---help---
+		Horizontal offset between the left edge of the touchscreen and
+		the left edge of the display area.
+
+config STMPE811_OFFSETY
+	int "Y offset"
+	default 0
+	depends on !STMPE811_TSC_DISABLE
+	---help---
+		Vertical offset between the top edge of the touchscreen and
+		the top edge of the display area.
+
 config STMPE811_THRESHX
 	int "X threshold"
 	default 12

--- a/drivers/input/stmpe811_tsc.c
+++ b/drivers/input/stmpe811_tsc.c
@@ -573,6 +573,38 @@ static int stmpe811_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         }
         break;
 
+      case TSIOC_GETOFFSETX:  /* arg: Pointer to int offsetx config value */
+        {
+          FAR int *ptr = (FAR int *)((uintptr_t)arg);
+          DEBUGASSERT(ptr != NULL);
+          *ptr = CONFIG_STMPE811_OFFSETX;
+        }
+        break;
+
+      case TSIOC_GETOFFSETY:  /* arg: Pointer to int offsety config value */
+        {
+          FAR int *ptr = (FAR int *)((uintptr_t)arg);
+          DEBUGASSERT(ptr != NULL);
+          *ptr = CONFIG_STMPE811_OFFSETY;
+        }
+        break;
+
+      case TSIOC_GETTHRESHX:  /* arg: Pointer to int threshx config value */
+        {
+          FAR int *ptr = (FAR int *)((uintptr_t)arg);
+          DEBUGASSERT(ptr != NULL);
+          *ptr = CONFIG_STMPE811_THRESHX;
+        }
+        break;
+
+      case TSIOC_GETTHRESHY:  /* arg: Pointer to int threshy config value */
+        {
+          FAR int *ptr = (FAR int *)((uintptr_t)arg);
+          DEBUGASSERT(ptr != NULL);
+          *ptr = CONFIG_STMPE811_THRESHY;
+        }
+        break;
+
       default:
         ret = -ENOTTY;
         break;

--- a/include/nuttx/input/touchscreen.h
+++ b/include/nuttx/input/touchscreen.h
@@ -76,6 +76,18 @@
                                              * struct g_tscaldata_s
                                              */
 #define TSIOC_USESCALED      _TSIOC(0x0009) /* arg: bool, yes/no */
+#define TSIOC_GETOFFSETX     _TSIOC(0x000a) /* arg: Pointer to
+                                             * int X offset value
+                                             */
+#define TSIOC_GETOFFSETY     _TSIOC(0x000b) /* arg: Pointer to
+                                             * int Y offset value
+                                             */
+#define TSIOC_GETTHRESHX     _TSIOC(0x000c) /* arg: Pointer to
+                                             * int X threshold value
+                                             */
+#define TSIOC_GETTHRESHY     _TSIOC(0x000d) /* arg: Pointer to
+                                             * int Y threshold value
+                                             */
 
 #define TSC_FIRST            0x0001          /* First common command */
 #define TSC_NCMDS            6               /* Six common commands */


### PR DESCRIPTION
## Summary

When using the generic touchscreen driver interface, the device's X and Y threshold config values ​​may be required to translate the raw touchscreen data into pixel coordinates. It may also be necessary to apply an offset.

ioctl commands can be used to get these device specific config values.

The idea of ​​the proposal is illustrated here with the STMPE811 touchscreen controller available on the STM32F429I-DISC1 board.

## Testing

Test based on the following defconfig: https://github.com/directfb2/DirectFB2/blob/master/lib/direct/os/nuttx/configs/stm32f429i-disco/defconfig

Use the df_input example to move a cross with its pixel coordinates displayed on the touchscreen: https://github.com/directfb2/DirectFB-examples/blob/master/src/df_input.c