### PR TITLE
samv7: fix minor issues with serial DMA

### DIFF
--- a/arch/arm/src/samv7/sam_serial.c
+++ b/arch/arm/src/samv7/sam_serial.c
@@ -1228,6 +1228,8 @@ static int sam_dma_setup(struct uart_dev_s *dev)
        */
 
       priv->rxdmanext = 0;
+      priv->nextcache = 0;
+      priv->buf_idx = 0;
       priv->rxenable = true;
       priv->odd = false;
 

--- a/arch/arm/src/samv7/sam_xdmac.c
+++ b/arch/arm/src/samv7/sam_xdmac.c
@@ -1427,9 +1427,14 @@ static void sam_dmaterminate(struct sam_xdmach_s *xdmach, int result)
   sam_putdmac(xdmac, chanbit, SAM_XDMAC_GD_OFFSET);
   while ((sam_getdmac(xdmac, SAM_XDMAC_GS_OFFSET) & chanbit) != 0);
 
-  /* Free the linklist */
+  /* Free the linklist. Circular buffers do not use link list so any free
+   * operation should be handled in peripheral driver that calls DMA.
+   */
 
-  sam_freelinklist(xdmach);
+  if (!xdmach->circular)
+    {
+      sam_freelinklist(xdmach);
+    }
 
   /* Perform the DMA complete callback */
 


### PR DESCRIPTION
## Summary

Circular buffer does not use DMA linked list therefore function sam_freelinklist() cannot be called as it would fail on assertion (csa
not defined). Peripheral that calls DMA should care of buffer invalidation instead.

Second commit is a small fix that ensures all DMA pointers are correctly reseted during DMA setup (when the driver is opened). Without this there could be rare occurrence of driver pointing to incorrect (invalidate) DMA buffer and thus saving incorrect characters to upper layer.

## Testing
Tested on SAMv7 custom board

