### PR TITLE
fs/mount: correct `df -h` output format

### DIFF
--- a/fs/mount/fs_procfs_mount.c
+++ b/fs/mount/fs_procfs_mount.c
@@ -301,7 +301,7 @@ static int usage_entry(FAR const char *mountpoint,
   if (!info->header)
     {
       mount_sprintf(info,
-        "  Filesystem    Size      Used  Available Mounted on\n");
+        "  Filesystem      Size      Used  Available Mounted on\n");
       info->header = true;
     }
 
@@ -349,7 +349,7 @@ static int usage_entry(FAR const char *mountpoint,
   /* Generate usage list one line at a time */
 
   mount_sprintf(info,
-    "  %-10s %" PRIuOFF "%c %8" PRIuOFF "%c  %8" PRIuOFF "%c %s\n",
+    "  %-10s %8" PRIuOFF "%c %8" PRIuOFF "%c  %8" PRIuOFF "%c %s\n",
     fstype, size, sizelabel, used, usedlabel, free, freelabel, mountpoint);
 
   return (info->totalsize >= info->buflen) ? 1 : 0;


### PR DESCRIPTION
## Summary
fs/mount: correct `df -h` output format

Signed-off-by: Junbo Zheng <zhengjunbo1@xiaomi.com>

## Impact
N/A

## Testing
config: ./tools/configure.sh sim:nsh
correct before
```
nsh> df
  Block    Number
  Size     Blocks       Used   Available Mounted on
     0          0          0           0 /bin
    64          8          8           0 /etc
     0          0          0           0 /proc
   512        985          2         983 /tmp
nsh>
nsh> df -h
  Filesystem    Size      Used  Available Mounted on
  binfs      0B        0B         0B /bin
  romfs      512B      512B         0B /etc
  procfs     0B        0B         0B /proc
  vfat       492K        1K       491K /tmp
nsh>
```
correct after
```
nsh> df
  Block    Number
  Size     Blocks       Used   Available Mounted on
     0          0          0           0 /bin
    64          8          8           0 /etc
     0          0          0           0 /proc
   512        985          2         983 /tmp
nsh> df -h
  Filesystem      Size      Used  Available Mounted on
  binfs             0B        0B         0B /bin
  romfs           512B      512B         0B /etc
  procfs            0B        0B         0B /proc
  vfat            492K        1K       491K /tmp
nsh>
```

config: ./tools/configure.sh ../vendor/sim/boards/miwear/configs/miwear -j16 
correct before
```
nsh>
nsh> df
  Block    Number
  Size     Blocks       Used   Available Mounted on
     0          0          0           0 /bin
  4096  240075962   87644775   152431187 /data
    64       3621       3621           0 /etc
  4096  240075962   87644775   152431187 /font
  4096  240075962   87644775   152431187 /i18n
     0          0          0           0 /proc
  4096  240075962   87644775   152431187 /resource/app
  4096  240075962   87644775   152431187 /resource/misc
  4096  240075962   87644775   152431187 /resource/recovery
  4096  240075962   87644775   152431187 /resource/system
  4096  240075962   87644775   152431187 /system
   512         26         24           2 /tmp
  4096  240075962   87644775   152431187 /vendor
  4096  240075962   87644775   152431187 /watchface
nsh>
nsh> df -h
  Filesystem    Size      Used  Available Mounted on
  binfs      0B        0B         0B /bin
  hostfs     915G      334G       581G /data
  romfs      226K      226K         0B /etc
  hostfs     915G      334G       581G /font
  hostfs     915G      334G       581G /i18n
  procfs     0B        0B         0B /proc
  hostfs     915G      334G       581G /resource/app
  hostfs     915G      334G       581G /resource/misc
  hostfs     915G      334G       581G /resource/recovery
  hostfs     915G      334G       581G /resource/system
  hostfs     915G      334G       581G /system
  tmpfs      13K       12K         1K /tmp
  hostfs     915G      334G       581G /vendor
  hostfs     915G      334G       581G /watchface
```
correct after
```
nsh>
nsh> date
Mon, Jul 03 02:09:53 2023
nsh>
nsh> df
  Block    Number
  Size     Blocks       Used   Available Mounted on
     0          0          0           0 /bin
  4096  240075962   87644776   152431186 /data
    64       3621       3621           0 /etc
  4096  240075962   87644776   152431186 /font
  4096  240075962   87644776   152431186 /i18n
     0          0          0           0 /proc
  4096  240075962   87644776   152431186 /resource/app
  4096  240075962   87644776   152431186 /resource/misc
  4096  240075962   87644776   152431186 /resource/recovery
  4096  240075962   87644776   152431186 /resource/system
  4096  240075962   87644776   152431186 /system
   512         26         24           2 /tmp
  4096  240075962   87644776   152431186 /vendor
  4096  240075962   87644776   152431186 /watchface
nsh>
nsh> df -h
  Filesystem      Size      Used  Available Mounted on
  binfs             0B        0B         0B /bin
  hostfs          915G      334G       581G /data
  romfs           226K      226K         0B /etc
  hostfs          915G      334G       581G /font
  hostfs          915G      334G       581G /i18n
  procfs            0B        0B         0B /proc
  hostfs          915G      334G       581G /resource/app
  hostfs          915G      334G       581G /resource/misc
  hostfs          915G      334G       581G /resource/recovery
  hostfs          915G      334G       581G /resource/system
  hostfs          915G      334G       581G /system
  tmpfs            13K       12K         1K /tmp
  hostfs          915G      334G       581G /vendor
  hostfs          915G      334G       581G /watchface
nsh>
```
