### PR TITLE
arch/sim : Audio driver add AUDIOIOC_GETLATENCY ioctl

### DIFF
--- a/include/nuttx/audio/audio.h
+++ b/include/nuttx/audio/audio.h
@@ -112,6 +112,7 @@
 #define AUDIOIOC_HWRESET            _AUDIOIOC(16)
 #define AUDIOIOC_SETBUFFERINFO      _AUDIOIOC(17)
 #define AUDIOIOC_SETPARAMTER        _AUDIOIOC(18)
+#define AUDIOIOC_GETLATENCY         _AUDIOIOC(19)
 
 /* Audio Device Types *******************************************************/
 


### PR DESCRIPTION
## Summary

add AUDIOIOC_GETLATENCY definition, and add reference code in sim alsa.

## Impact

N/A

## Testing

vela

