### PR TITLE
boards: cxd56xx: Fix system clock to HV mode for video drivers

### DIFF
--- a/boards/arm/cxd56xx/common/src/cxd56_isx012.c
+++ b/boards/arm/cxd56xx/common/src/cxd56_isx012.c
@@ -37,6 +37,7 @@
 #include "cxd56_i2c.h"
 
 #include <arch/board/board.h>
+#include <arch/chip/pm.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -58,6 +59,14 @@
 #define POWER_OFF_TIME              (50 * 1000)  /* ms */
 
 #define POWER_CHECK_RETRY           (10)
+
+/****************************************************************************
+ *  Private Data
+ ****************************************************************************/
+
+static struct pm_cpu_freqlock_s g_hv_lock =
+  PM_CPUFREQLOCK_INIT(PM_CPUFREQLOCK_TAG('I', 'S', 0),
+                      PM_CPUFREQLOCK_FLAG_HV);
 
 /****************************************************************************
  * Public Functions
@@ -163,6 +172,10 @@ struct i2c_master_s *board_isx012_initialize(void)
 {
   _info("Initializing ISX012...\n");
 
+  /* Fix system clock to HV mode */
+
+  up_pm_acquire_freqlock(&g_hv_lock);
+
 #ifdef IMAGER_ALERT
   cxd56_gpio_config(IMAGER_ALERT, true);
 #endif
@@ -183,6 +196,10 @@ int board_isx012_uninitialize(struct i2c_master_s *i2c)
   int ret;
 
   _info("Uninitializing ISX012...\n");
+
+  /* Release system clock */
+
+  up_pm_release_freqlock(&g_hv_lock);
 
   /* Initialize i2c device */
 


### PR DESCRIPTION
## Summary
Fix issue that ISX012 and ISX019 don't work if the dynamic clock control is enabled.

## Impact
Only spresense camera board.

## Testing

