### PR TITLE
Modified rgb led pwm freq from 100 to 200

### DIFF
--- a/drivers/leds/Kconfig
+++ b/drivers/leds/Kconfig
@@ -71,6 +71,13 @@ config RGBLED
 		This selection enables building of the "upper-half" RGB LED driver.
 		See include/nuttx/rgbled.h for further PWM driver information.
 
+config RGBLED_PWM_FREQ
+	int "PWM Frequency (Hz)"
+	depends on RGBLED
+	default 100
+	---help---
+		This controls the frequency of the PWM channel powering each led.
+
 config RGBLED_INVERT
 	bool "Invert RGB LED Output"
 	depends on RGBLED

--- a/drivers/leds/rgbled.c
+++ b/drivers/leds/rgbled.c
@@ -360,7 +360,7 @@ static ssize_t rgbled_write(FAR struct file *filep, FAR const char *buffer,
 
 #ifdef CONFIG_PWM_MULTICHAN
   memset(&pwm, 0, sizeof(struct pwm_info_s));
-  pwm.frequency = 100;
+  pwm.frequency = CONFIG_RGBLED_PWM_FREQ;
 
   i = 0;
   pwm.channels[i].duty = red;
@@ -433,7 +433,7 @@ static ssize_t rgbled_write(FAR struct file *filep, FAR const char *buffer,
       ledb->ops->start(ledb, &pwm);
     }
 #else
-  pwm.frequency = 100;
+  pwm.frequency = CONFIG_RGBLED_PWM_FREQ;
 
   pwm.duty = red;
   ledr->ops->start(ledr, &pwm);


### PR DESCRIPTION
## Summary
I am currently trying to add the RGB driver to an esp32 based board. The LED on the board did not function correctly at the old frequency (that was hard-coded in the driver), 200 being more suitable. The RGB driver support is already added to stm32,  
and I **suppose** 100 was right for that situation, so simply modifying the frequency inside the driver might make it unusable for stm32 or other boards with the driver already implemented. The question is: Is 200 appropriate for any led or is custom configuring necessary?

