### PR TITLE
libc/libvsprintf:fix vsnprintf bug with "%#.0f"

### DIFF
--- a/libs/libc/stdio/lib_libvsprintf.c
+++ b/libs/libc/stdio/lib_libvsprintf.c
@@ -816,11 +816,6 @@ flt_oper:
 
                   if (--n < -prec)
                     {
-                      if ((flags & FL_ALT) != 0 && n == -1)
-                        {
-                          stream_putc('.', stream);
-                        }
-
                       break;
                     }
 
@@ -835,6 +830,11 @@ flt_oper:
                 }
 
               stream_putc(out, stream);
+
+              if ((flags & FL_ALT) != 0 && n == -1)
+                {
+                  stream_putc('.', stream);
+                }
             }
           else
             {


### PR DESCRIPTION
With double value=3.141593 initialized in va_list ap, such code:
   vsnprintf(buffer, sizeof(buffer), "%#.0f", ap);
expected output string: "3."
but real output string: ".3"

## Summary

## Impact

## Testing

