### PR TITLE
arch/armv8-m/nvic.h: add definition for NVIC non-secure registers offset

### DIFF
--- a/arch/arm/src/armv8-m/nvic.h
+++ b/arch/arm/src/armv8-m/nvic.h
@@ -60,7 +60,11 @@
 /* NVIC base address ********************************************************/
 
 #define ARMV8M_NVIC_BASE                0xe000e000
-#define ARMV8M_NVIC_BASE_NS             0xe002e000
+
+/* Non-secure NVIC access */
+
+#define ARMV8M_NS_OFFSET                0x00020000
+#define ARMV8M_NVIC_BASE_NS             (ARMV8M_NVIC_BASE + ARMV8M_NS_OFFSET)
 
 /* NVIC register offsets ****************************************************/
 


### PR DESCRIPTION
## Summary

- arch/armv8-m/nvic.h: add definition for NVIC non-secure registers offset
This will make it easier to use the NVIC non-secure registers using the current NVIC secure registers definitions.

## Impact
For example, setting a vector table for non-secure environment would look like this:
`putreg32(VECTOR_TABLE_NS, (NVIC_VECTAB + ARMV8M_NS_OFFSET));`
## Testing
nrf9160
