### PR TITLE
arch/arm: add support for ARMv8-M Security Extensions

### DIFF
--- a/arch/arm/src/armv8-m/Kconfig
+++ b/arch/arm/src/armv8-m/Kconfig
@@ -169,3 +169,8 @@ config ARMV8M_TRUSTZONE_CPU_BITMASK
 	default 0
 	---help---
 		Set Security bitmap for multicore, bit 0 means core 0.
+
+config ARMV8M_CMSE
+	bool "ARMv8-M Security Extensions"
+	---help---
+		Enable ARMv8-M Security Extensions.

--- a/arch/arm/src/armv8-m/Toolchain.defs
+++ b/arch/arm/src/armv8-m/Toolchain.defs
@@ -188,4 +188,10 @@ ifeq ($(CONFIG_ARMV8M_STACKCHECK),y)
   ARCHOPTIMIZATION += -finstrument-functions -ffixed-r10
 endif
 
+# ARMv8-M Security Extensions
+
+ifeq ($(CONFIG_ARMV8M_CMSE),y)
+  ARCHCPUFLAGS += -mcmse
+endif
+
 include $(TOPDIR)/arch/arm/src/common/Toolchain.defs

--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -472,6 +472,13 @@
 #    define no_builtin(n)
 #  endif
 
+/* CMSE extention */
+
+#  ifdef CONFIG_ARCH_HAVE_TRUSTZONE
+#    define cmse_nonsecure_entry __attribute__((cmse_nonsecure_entry))
+#    define cmse_nonsecure_call __attribute__((cmse_nonsecure_call))
+#  endif
+
 /* SDCC-specific definitions ************************************************/
 
 #elif defined(SDCC) || defined(__SDCC)


### PR DESCRIPTION
## Summary
arch/arm: add support for ARMv8-M Security Extensions

## Impact
We can call to/from non-secure world.

## Testing
nrf9160: secure bootloader (mcuboot + nuttx) booting to non-secure application 