### PR TITLE
sched/clock/clock_getcpuclockid: fix code format, remove space

### DIFF
--- a/sched/clock/clock_gettime.c
+++ b/sched/clock/clock_gettime.c
@@ -171,7 +171,7 @@ int clock_gettime(clockid_t clock_id, struct timespec *tp)
         }
       else
         {
-           tcb = nxsched_get_tcb(pid);
+          tcb = nxsched_get_tcb(pid);
         }
 
       group = tcb->group;


### PR DESCRIPTION
## Summary

## Impact

## Testing

