### PR TITLE
net: Limit max value for Send/Recv bufsize

### DIFF
--- a/net/Kconfig
+++ b/net/Kconfig
@@ -128,17 +128,33 @@ config NET_LL_GUARDSIZE
 		to L3 network layer protocol transparent transmission and forwarding
 
 config NET_RECV_BUFSIZE
-	int "Net Receive buffer size"
+	int "Net Default Receive buffer size"
 	default 0
 	---help---
 		This is the default value for receive buffer size.
 
+config NET_MAX_RECV_BUFSIZE
+	int "Net Max Receive buffer size"
+	depends on NET_RECV_BUFSIZE > 0
+	default 0
+	---help---
+		Limit the max value for receive buffer size to avoid overconsumption.
+		Zero means no limit.
+
 config NET_SEND_BUFSIZE
-	int "Net Send buffer size"
+	int "Net Default Send buffer size"
 	depends on NET_TCP_WRITE_BUFFERS || NET_UDP_WRITE_BUFFERS
 	default 0
 	---help---
 		This is the default value for send buffer size.
+
+config NET_MAX_SEND_BUFSIZE
+	int "Net Max Send buffer size"
+	depends on NET_SEND_BUFSIZE > 0
+	default 0
+	---help---
+		Limit the max value for send buffer size to avoid overconsumption.
+		Zero means no limit.
 
 endmenu # Driver buffer configuration
 

--- a/net/inet/inet_sockif.c
+++ b/net/inet/inet_sockif.c
@@ -929,6 +929,10 @@ static int inet_set_socketlevel_option(FAR struct socket *psock, int option,
               return -EINVAL;
             }
 
+#if CONFIG_NET_MAX_RECV_BUFSIZE > 0
+          buffersize = MIN(buffersize, CONFIG_NET_MAX_RECV_BUFSIZE);
+#endif
+
           net_lock();
 
 #ifdef NET_TCP_HAVE_STACK
@@ -985,6 +989,10 @@ static int inet_set_socketlevel_option(FAR struct socket *psock, int option,
             {
               return -EINVAL;
             }
+
+#if CONFIG_NET_MAX_SEND_BUFSIZE > 0
+          buffersize = MIN(buffersize, CONFIG_NET_MAX_SEND_BUFSIZE);
+#endif
 
           net_lock();
 


### PR DESCRIPTION
## Summary
There're some apps trying to set too large `SO_SNDBUF` and `SO_RCVBUF`, which may use all IOBs in one socket and block all other network traffic.

Note:
Linux silently limits `SO_SNDBUF` to be less than `sysctl_wmem_max` ([code](https://github.com/torvalds/linux/blob/d528014517f2b0531862c02865b9d4c908019dc4/net/core/sock.c#L1151)), so we can also do this limit without returning any error.

## Impact
Limit too large socket bufsize

## Testing
Manually
