### PR TITLE
signal: correct to const pointer for sigorset and sigandset

### DIFF
--- a/include/signal.h
+++ b/include/signal.h
@@ -359,7 +359,8 @@ int  raise(int signo);
 int  sigaction(int signo, FAR const struct sigaction *act,
                FAR struct sigaction *oact);
 int  sigaddset(FAR sigset_t *set, int signo);
-int  sigandset(FAR sigset_t *dest, FAR sigset_t *left, FAR sigset_t *right);
+int  sigandset(FAR sigset_t *dest, FAR const sigset_t *left,
+               FAR const sigset_t *right);
 int  sigdelset(FAR sigset_t *set, int signo);
 int  sigemptyset(FAR sigset_t *set);
 int  sigfillset(FAR sigset_t *set);
@@ -368,7 +369,8 @@ int  sigisemptyset(FAR sigset_t *set);
 int  sigismember(FAR const sigset_t *set, int signo);
 int  sigignore(int signo);
 _sa_handler_t signal(int signo, _sa_handler_t func);
-int  sigorset(FAR sigset_t *dest, FAR sigset_t *left, FAR sigset_t *right);
+int  sigorset(FAR sigset_t *dest, FAR const sigset_t *left,
+              FAR const sigset_t *right);
 int  sigpause(int signo);
 int  sigpending(FAR sigset_t *set);
 int  sigprocmask(int how, FAR const sigset_t *set, FAR sigset_t *oset);

--- a/libs/libc/signal/sig_andset.c
+++ b/libs/libc/signal/sig_andset.c
@@ -53,7 +53,8 @@
  *
  ****************************************************************************/
 
-int sigandset(FAR sigset_t *dest, FAR sigset_t *left, FAR sigset_t *right)
+int sigandset(FAR sigset_t *dest, FAR const sigset_t *left,
+              FAR const sigset_t *right)
 {
   int ndx;
 

--- a/libs/libc/signal/sig_orset.c
+++ b/libs/libc/signal/sig_orset.c
@@ -53,7 +53,8 @@
  *
  ****************************************************************************/
 
-int sigorset(FAR sigset_t *dest, FAR sigset_t *left, FAR sigset_t *right)
+int sigorset(FAR sigset_t *dest, FAR const sigset_t *left,
+             FAR const sigset_t *right)
 {
   int ndx;
 

--- a/sched/signal/sig_procmask.c
+++ b/sched/signal/sig_procmask.c
@@ -119,8 +119,7 @@ int nxsig_procmask(int how, FAR const sigset_t *set, FAR sigset_t *oset)
            */
 
           case SIG_BLOCK:
-            sigorset(&rtcb->sigprocmask, &rtcb->sigprocmask,
-                     (FAR sigset_t *)set);
+            sigorset(&rtcb->sigprocmask, &rtcb->sigprocmask, set);
             break;
 
           /* The resulting set is the intersection of the current set and

--- a/sched/signal/sig_timedwait.c
+++ b/sched/signal/sig_timedwait.c
@@ -261,7 +261,7 @@ int nxsig_timedwait(FAR const sigset_t *set, FAR struct siginfo *info,
    */
 
   intersection = nxsig_pendingset(rtcb);
-  sigandset(&intersection, &intersection, (FAR sigset_t *)set);
+  sigandset(&intersection, &intersection, set);
   if (!sigisemptyset(&intersection))
     {
       /* One or more of the signals in intersections is sufficient to cause


### PR DESCRIPTION
the two GNU functions, should use const input pointer parameter.

https://refspecs.linuxfoundation.org/LSB_1.3.0/gLSB/gLSB/baselib-sigorset.html https://refspecs.linuxfoundation.org/LSB_1.3.0/gLSB/gLSB/baselib-sigandset.html

## Summary

## Impact
None
## Testing
CI pass
