### PR TITLE
libs/libc/pthread: add the implementation of pthread_getcpuclockid

### DIFF
--- a/include/pthread.h
+++ b/include/pthread.h
@@ -721,6 +721,8 @@ int pthread_spin_trylock(FAR pthread_spinlock_t *lock);
 int pthread_spin_unlock(FAR pthread_spinlock_t *lock);
 #endif
 
+int pthread_getcpuclockid(pthread_t thread_id, FAR clockid_t *clock_id);
+
 int pthread_atfork(CODE void (*prepare)(void),
                    CODE void (*parent)(void),
                    CODE void (*child)(void));

--- a/libs/libc/pthread/Make.defs
+++ b/libs/libc/pthread/Make.defs
@@ -56,7 +56,7 @@ CSRCS += pthread_rwlockattr_init.c pthread_rwlockattr_destroy.c
 CSRCS += pthread_rwlockattr_getpshared.c pthread_rwlockattr_setpshared.c
 CSRCS += pthread_rwlock.c pthread_rwlock_rdlock.c pthread_rwlock_wrlock.c
 CSRCS += pthread_setcancelstate.c pthread_setcanceltype.c
-CSRCS += pthread_testcancel.c
+CSRCS += pthread_testcancel.c pthread_getcpuclockid.c
 
 ifeq ($(CONFIG_SMP),y)
 CSRCS += pthread_attr_getaffinity.c pthread_attr_setaffinity.c

--- a/libs/libc/pthread/pthread_getcpuclockid.c
+++ b/libs/libc/pthread/pthread_getcpuclockid.c
@@ -1,0 +1,63 @@
+/****************************************************************************
+ * libs/libc/pthread/pthread_getcpuclockid.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <pthread.h>
+#include <errno.h>
+#include <time.h>
+#include <nuttx/clock.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: pthread_getcpuclockid
+ *
+ * Description:
+ *   The pthread_getcpuclockid() function using to access a thread CPU-time
+ *   clock
+ *
+ * Input Parameters:
+ *   thread_id - The id of the thread to fetch the running time
+ *   clockid - The clockid with type CLOCK_THREAD_CPUTIME_ID that required
+ *
+ * Returned Value:
+ *    Return 0 on success, return error number on error
+ *
+ ****************************************************************************/
+
+int pthread_getcpuclockid(pthread_t thread_id, FAR clockid_t *clockid)
+{
+  if (pthread_kill(thread_id, 0) != 0)
+    {
+      return ESRCH;
+    }
+
+  /* for pthread_getcpuclockid, the clock type are
+   * CLOCK_THREAD_CPUTIME_ID
+   */
+
+  *clockid = (thread_id << CLOCK_SHIFT) | CLOCK_THREAD_CPUTIME_ID;
+  return OK;
+}


### PR DESCRIPTION
## Summary
1. the implementation can pass the ltp/open_posix_testsuite/pthread_getcpuclockid testcases
2. the modification are referred to https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_getcpuclockid.html

## Impact

## Testing

