### PR TITLE
net/local: fix build warning on GCC 12.2.0

### DIFF
--- a/net/local/local_fifo.c
+++ b/net/local/local_fifo.c
@@ -49,7 +49,8 @@
 #define LOCAL_HD_SUFFIX    "HD"  /* Name of the half duplex datagram FIFO */
 #define LOCAL_SUFFIX_LEN   2
 
-#define LOCAL_FULLPATH_LEN (UNIX_PATH_MAX + LOCAL_SUFFIX_LEN)
+#define LOCAL_FULLPATH_LEN (strlen(CONFIG_NET_LOCAL_VFS_PATH) + \
+                            UNIX_PATH_MAX + LOCAL_SUFFIX_LEN + 2)
 
 /****************************************************************************
  * Private Functions
@@ -66,7 +67,8 @@
 static void local_format_name(FAR const char *inpath, FAR char *outpath,
                               FAR const char *suffix, int32_t id)
 {
-  if (strcmp(inpath, CONFIG_NET_LOCAL_VFS_PATH) == 0)
+  if (strncmp(inpath, CONFIG_NET_LOCAL_VFS_PATH,
+              strlen(CONFIG_NET_LOCAL_VFS_PATH)) == 0)
     {
       inpath += strlen(CONFIG_NET_LOCAL_VFS_PATH);
     }


### PR DESCRIPTION

## Summary

net/local: fix build warning on GCC 12.2.0

In file included from local/local_fifo.c:25:
In function ‘local_format_name’,
    inlined from ‘local_hd_name’ at local/local_fifo.c:132:3,
    inlined from ‘local_open_receiver’ at local/local_fifo.c:661:3:
local/local_fifo.c:77:16: warning: ‘%s’ directive output may be truncated writing up to 107 bytes into a region of size 100 [-Wformat-truncation=]
   77 |                CONFIG_NET_LOCAL_VFS_PATH "/%s%s", inpath, suffix);
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~
local/local_fifo.c: In function ‘local_open_receiver’:
local/local_fifo.c:82:44: note: format string is defined here
   82 |                CONFIG_NET_LOCAL_VFS_PATH "/%s%s%" PRIx32,
      |                                            ^~
In function ‘local_format_name’,
    inlined from ‘local_hd_name’ at local/local_fifo.c:132:3,
    inlined from ‘local_open_receiver’ at local/local_fifo.c:661:3:
local/local_fifo.c:76:7: note: ‘snprintf’ output between 12 and 119 bytes into a destination of size 109
   76 |       snprintf(outpath, LOCAL_FULLPATH_LEN - 1,
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   77 |                CONFIG_NET_LOCAL_VFS_PATH "/%s%s", inpath, suffix);
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


## Impact

N/A

## Testing

ci-check