### PR TITLE
{BP-9658} esp32s2: Fix UART1 default pins

### DIFF
--- a/arch/xtensa/src/esp32s2/Kconfig
+++ b/arch/xtensa/src/esp32s2/Kconfig
@@ -602,12 +602,12 @@ if ESP32S2_UART1
 
 config ESP32S2_UART1_TXPIN
 	int "UART1 Tx Pin"
-	default 37
+	default 17
 	range 0 46
 
 config ESP32S2_UART1_RXPIN
 	int "UART1 Rx Pin"
-	default 38
+	default 18
 	range 0 46
 
 config ESP32S2_UART1_RTSPIN


### PR DESCRIPTION
## Summary
The default pins to UART1 should be 17 (TXD) and 18 (RXD).

## Impact
RELEASE

## Testing
NONE
