### PR TITLE
{BP-9700} arch/armv8-m/arm_secure_irq.c: fix writing to the NVIC_AIRCR register

### DIFF
--- a/arch/arm/src/armv8-m/arm_secure_irq.c
+++ b/arch/arm/src/armv8-m/arm_secure_irq.c
@@ -100,8 +100,8 @@ void up_secure_irq_all(bool secure)
 {
   int i;
 
-  modreg32(secure ? 0 : NVIC_AIRCR_BFHFNMINS,
-           NVIC_AIRCR_BFHFNMINS, NVIC_AIRCR);
+  modreg32((secure ? 0 : NVIC_AIRCR_BFHFNMINS) | NVIC_AIRCR_VECTKEY,
+           (NVIC_AIRCR_VECTKEY_MASK | NVIC_AIRCR_BFHFNMINS), NVIC_AIRCR);
 
   modreg32(secure ? NVIC_DEMCR_SDME : 0,
            NVIC_DEMCR_SDME, NVIC_DEMCR);


### PR DESCRIPTION
## Summary
Register key (VECTKEY) must be written, otherwise the write is ignored.

Reference:
https://developer.arm.com/documentation/100235/0004/the-cortex-m33-peripherals/system-control-block/application-interrupt-and-reset-control-register

## Impact
REELASE

## Testing
NONE
