### PR TITLE
{BP-9621} cxd56_dmac, lcd_dev: fix null pointer dereference

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_dmac.c
+++ b/arch/arm/src/cxd56xx/cxd56_dmac.c
@@ -400,6 +400,12 @@ static void _dmac_intc_handler(int ch)
   int itc;
   int err;
 
+  if (dev == NULL)
+    {
+      dmaerr("Cannot get device with channel number %d.\n", ch);
+      return;
+    }
+
   mask = (1u << (ch & 1));
 
   if (is_dmac(2, dev))
@@ -442,8 +448,15 @@ static int intr_handler_admac1(int irq, void *context, void *arg)
 static int intr_handler_idmac(int irq, void *context, void *arg)
 {
   struct dmac_register_map *dev = get_device(2); /* XXX */
-  uint32_t stat = dev->intstatus & 0x1f;
+  uint32_t stat;
   int i;
+
+  if (dev == NULL)
+    {
+      return -ENODEV;
+    }
+
+  stat = dev->intstatus & 0x1f;
 
   for (i = 2; stat; i++, stat >>= 1)
     {

--- a/drivers/lcd/lcd_dev.c
+++ b/drivers/lcd/lcd_dev.c
@@ -315,6 +315,12 @@ int lcddev_register(int devno)
     }
 
   priv->lcd_ptr = board_lcd_getdev(devno);
+  if (!priv->lcd_ptr)
+    {
+      ret = -ENODEV;
+      goto err;
+    }
+
   ret = priv->lcd_ptr->getplaneinfo(priv->lcd_ptr, 0, &priv->planeinfo);
   if (ret < 0)
     {


### PR DESCRIPTION
## Summary
Check return values of following functions for null:
   - board_lcd_getdev
   - get_device

## Impact
RELEASE

## Testing
NONE
