### PR TITLE
{BP-9626} libs/libc/aio: fix aio_error compatible bug

### DIFF
--- a/libs/libc/aio/aio_error.c
+++ b/libs/libc/aio/aio_error.c
@@ -89,6 +89,13 @@ int aio_error(FAR const struct aiocb *aiocbp)
 {
   DEBUGASSERT(aiocbp);
 
+  /* the aio_reqprio field must be large or equal than 0 */
+
+  if (aiocbp->aio_reqprio < 0)
+    {
+      return EINVAL;
+    }
+
   if (aiocbp->aio_result < 0)
     {
       return -aiocbp->aio_result;


### PR DESCRIPTION
## Summary
1. make the aio_error implementation can pass the ltp/open_posix_testsuite/aio_error testcases
2. the modification are referred to https://pubs.opengroup.org/onlinepubs/9699919799/functions/aio_error.html

## Impact
RELEASE

## Testing
NONE
