### PR TITLE
iob_alloc: change sem_post to count++

### DIFF
--- a/mm/iob/iob_alloc.c
+++ b/mm/iob/iob_alloc.c
@@ -148,7 +148,7 @@ static FAR struct iob_s *iob_allocwait(bool throttled, unsigned int timeout)
                * we will have to wait again.
                */
 
-              nxsem_post(sem);
+              sem->semcount++;
               iob = iob_tryalloc(throttled);
             }
 


### PR DESCRIPTION
## Summary
if there are two throttled wait, when iob_free occurs, one of wait will be awakened to execute iob_alloc_committed, but it will fail to execute, sem will be posted at this time, then another wait will be awakened. after the other wait thread is awakened, This step is repeated. the two threads are in the critical_section state and cannot be switched to other threads. then cpu will busy util timeout.
## Impact

## Testing
sim:local and cortex-m33 device
