### PR TITLE
net/if.h: add definitions associated with IF_OPER_

### DIFF
--- a/include/net/if.h
+++ b/include/net/if.h
@@ -126,6 +126,19 @@
 #  define IFF_IS_IPv4(f)   (1)
 #endif
 
+/* RFC 2863 operational status */
+
+enum
+{
+  IF_OPER_UNKNOWN,
+  IF_OPER_NOTPRESENT,
+  IF_OPER_DOWN,
+  IF_OPER_LOWERLAYERDOWN,
+  IF_OPER_TESTING,
+  IF_OPER_DORMANT,
+  IF_OPER_UP,
+};
+
 /****************************************************************************
  * Public Type Definitions
  ****************************************************************************/


### PR DESCRIPTION
## Summary
In order to support the compilation of third-party library, we encounter some situations where the macro is not defined, refer to the common implementation of other systems and add relevant definitions.

## Impact

## Testing
sim:local
