### PR TITLE
libc/libvsprintf: fix vsnprintf bug with "%e"

### DIFF
--- a/libs/libc/stdio/lib_libvsprintf.c
+++ b/libs/libc/stdio/lib_libvsprintf.c
@@ -877,6 +877,12 @@ flt_oper:
 
               stream_putc(ndigs, stream);
               c = __ultoa_invert(exp, (FAR char *)buf, 10) - (FAR char *)buf;
+
+              if (exp >= 0 && exp <= 9)
+                {
+                  stream_putc('0', stream);
+                }
+
               while (c > 0)
                 {
                   stream_putc(buf[c - 1], stream);


### PR DESCRIPTION
For "%e" conversion, the exponent always contains at least two digits. 
That means if the value is zero, the exponent is 00, not 0.

Such as code:
  printf(buffer, sizeof(buffer), "%e", 1.232323232323);
  printf(buffer, sizeof(buffer), "%e", 12.32323232323);
  printf(buffer, sizeof(buffer), "%e", 123.2323232323);

Expected output:
  1.232323e+00
  1.232323e+01
  1.232323e+02

But real output:
  1.232323e+0
  1.232323e+1
  1.232323e+2

## Summary

## Impact

## Testing

