### PR TITLE
cmake/sched/clock: fix build break 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,13 @@ if(NOT DEFINED BOARD_CONFIG)
   message(FATAL_ERROR "Please define configuration with BOARD_CONFIG")
 endif()
 
+find_program(KCONFIGLIB olddefconfig)
+if(NOT KCONFIGLIB)
+  message(
+    FATAL_ERROR "Kconfig environment depends on kconfiglib, Please install:
+  $ pip install kconfiglib")
+endif()
+
 if(EXISTS ${BOARD_CONFIG} AND EXISTS ${BOARD_CONFIG}/defconfig)
   get_filename_component(NUTTX_BOARD_ABS_DIR ${BOARD_CONFIG} ABSOLUTE BASE_DIR
                          ${NUTTX_DIR})

--- a/libs/libc/modlib/CMakeLists.txt
+++ b/libs/libc/modlib/CMakeLists.txt
@@ -20,21 +20,26 @@
 
 if(CONFIG_LIBC_MODLIB)
 
-  target_sources(
-    c
-    PRIVATE modlib_bind.c
-            modlib_depend.c
-            modlib_init.c
-            modlib_iobuffer.c
-            modlib_load.c
-            modlib_loadshdrs.c
-            modlib_read.c
-            modlib_registry.c
-            modlib_sections.c
-            modlib_symbols.c
-            modlib_symtab.c
-            modlib_uninit.c
-            modlib_unload.c
-            modlib_verify.c)
+  list(
+    APPEND
+    SRCS
+    modlib_bind.c
+    modlib_depend.c
+    modlib_init.c
+    modlib_iobuffer.c
+    modlib_load.c
+    modlib_loadhdrs.c
+    modlib_read.c
+    modlib_registry.c
+    modlib_sections.c
+    modlib_symbols.c
+    modlib_symtab.c
+    modlib_uninit.c
+    modlib_unload.c
+    modlib_verify.c)
+
+  list(APPEND SRCS modlib_globals.S)
+
+  target_sources(c PRIVATE ${SRCS})
 
 endif()

--- a/libs/libc/sched/CMakeLists.txt
+++ b/libs/libc/sched/CMakeLists.txt
@@ -18,8 +18,15 @@
 #
 # ##############################################################################
 
-set(SRCS sched_getprioritymax.c sched_getprioritymin.c clock_ticks2time.c
-         clock_time2ticks.c clock_timespec_add.c clock_timespec_subtract.c)
+set(SRCS
+    sched_getprioritymax.c
+    sched_getprioritymin.c
+    clock_ticks2time.c
+    clock_time2ticks.c
+    clock_timespec_add.c
+    clock_timespec_subtract.c
+    clock_getcpuclockid.c
+    clock_getres.c)
 
 if(NOT CONFIG_CANCELLATION_POINTS)
   list(APPEND SRCS task_setcanceltype.c task_testcancel.c)
@@ -29,12 +36,12 @@ if(CONFIG_SMP)
   list(APPEND SRCS sched_cpucount.c)
 endif()
 
+if(CONFIG_SCHED_BACKTRACE)
+  list(APPEND SRCS sched_dumpstack.c sched_backtrace.c)
+endif()
+
 if(NOT CONFIG_BUILD_KERNEL)
   list(APPEND SRCS task_startup.c)
-
-  if(CONFIG_SCHED_BACKTRACE)
-    list(APPEND SRCS sched_dumpstack.c sched_backtrace.c)
-  endif()
 endif()
 
 target_sources(c PRIVATE ${SRCS})

--- a/sched/clock/CMakeLists.txt
+++ b/sched/clock/CMakeLists.txt
@@ -24,16 +24,19 @@ if(CONFIG_CLOCK_TIMEKEEPING)
   list(APPEND SRCS clock_timekeeping.c)
 endif()
 
+if(CONFIG_CLOCK_ADJTIME)
+  list(APPEND SRCS clock_adjtime.c)
+endif()
+
 list(
   APPEND
   SRCS
+  clock.c
   clock_initialize.c
   clock_settime.c
   clock_gettime.c
-  clock_getres.c
   clock_abstime2ticks.c
   clock_systime_ticks.c
-  clock_systime_timespec.c
-  clock.c)
+  clock_systime_timespec.c)
 
 target_sources(sched PRIVATE ${SRCS})


### PR DESCRIPTION
## Summary

cmake/sched/clock: fix build break 

## Impact

N/A

## Testing

cmake -B build -DBOARD_CONFIG=sabre-6quad/smp -GNinja
cmake --build build