### PR TITLE
drivers/spi: add support for qspi hwfeatures

### DIFF
--- a/arch/arm/src/nrf52/nrf52_qspi.c
+++ b/arch/arm/src/nrf52/nrf52_qspi.c
@@ -123,6 +123,9 @@ static const struct qspi_ops_s g_qspi_ops =
   .setfrequency      = nrf52_qspi_setfrequency,
   .setmode           = nrf52_qspi_setmode,
   .setbits           = nrf52_qspi_setbits,
+#ifdef CONFIG_QSPI_HWFEATURES
+  .hwfeatures        = NULL,
+#endif
   .command           = nrf52_qspi_command,
   .memory            = nrf52_qspi_memory,
   .alloc             = nrf52_qspi_alloc,

--- a/arch/arm/src/nrf53/nrf53_qspi.c
+++ b/arch/arm/src/nrf53/nrf53_qspi.c
@@ -133,6 +133,9 @@ static const struct qspi_ops_s g_qspi_ops =
   .setfrequency      = nrf53_qspi_setfrequency,
   .setmode           = nrf53_qspi_setmode,
   .setbits           = nrf53_qspi_setbits,
+#ifdef CONFIG_QSPI_HWFEATURES
+  .hwfeatures        = NULL,
+#endif  
   .command           = nrf53_qspi_command,
   .memory            = nrf53_qspi_memory,
   .alloc             = nrf53_qspi_alloc,

--- a/arch/arm/src/s32k3xx/s32k3xx_qspi.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_qspi.c
@@ -210,6 +210,9 @@ static const struct qspi_ops_s g_qspi0ops =
   .setfrequency      = qspi_setfrequency,
   .setmode           = qspi_setmode,
   .setbits           = qspi_setbits,
+#ifdef CONFIG_QSPI_HWFEATURES
+  .hwfeatures        = NULL,
+#endif
   .command           = qspi_command,
   .memory            = qspi_memory,
   .alloc             = qspi_alloc,

--- a/arch/arm/src/samv7/sam_qspi.c
+++ b/arch/arm/src/samv7/sam_qspi.c
@@ -292,6 +292,9 @@ static const struct qspi_ops_s g_qspi0ops =
   .setfrequency      = qspi_setfrequency,
   .setmode           = qspi_setmode,
   .setbits           = qspi_setbits,
+#ifdef CONFIG_QSPI_HWFEATURES
+  .hwfeatures        = NULL,
+#endif
   .command           = qspi_command,
   .memory            = qspi_memory,
   .alloc             = qspi_alloc,

--- a/arch/arm/src/stm32f7/stm32_qspi.c
+++ b/arch/arm/src/stm32f7/stm32_qspi.c
@@ -325,6 +325,9 @@ static const struct qspi_ops_s g_qspi0ops =
   .setfrequency      = qspi_setfrequency,
   .setmode           = qspi_setmode,
   .setbits           = qspi_setbits,
+#ifdef CONFIG_QSPI_HWFEATURES
+  .hwfeatures        = NULL,
+#endif
   .command           = qspi_command,
   .memory            = qspi_memory,
   .alloc             = qspi_alloc,

--- a/arch/arm/src/stm32h7/stm32_qspi.c
+++ b/arch/arm/src/stm32h7/stm32_qspi.c
@@ -350,6 +350,9 @@ static const struct qspi_ops_s g_qspi0ops =
   .setfrequency      = qspi_setfrequency,
   .setmode           = qspi_setmode,
   .setbits           = qspi_setbits,
+#ifdef CONFIG_QSPI_HWFEATURES
+  .hwfeatures        = NULL,
+#endif
   .command           = qspi_command,
   .memory            = qspi_memory,
   .alloc             = qspi_alloc,

--- a/arch/arm/src/stm32l4/stm32l4_qspi.c
+++ b/arch/arm/src/stm32l4/stm32l4_qspi.c
@@ -323,6 +323,9 @@ static const struct qspi_ops_s g_qspi0ops =
   .setfrequency      = qspi_setfrequency,
   .setmode           = qspi_setmode,
   .setbits           = qspi_setbits,
+#ifdef CONFIG_QSPI_HWFEATURES
+  .hwfeatures        = NULL,
+#endif
   .command           = qspi_command,
   .memory            = qspi_memory,
   .alloc             = qspi_alloc,

--- a/arch/xtensa/src/esp32s3/esp32s3_qspi.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_qspi.c
@@ -289,6 +289,9 @@ static const struct qspi_ops_s esp32s3_spi2_ops =
   .setfrequency = esp32s3_qspi_setfrequency,
   .setmode      = esp32s3_qspi_setmode,
   .setbits      = esp32s3_qspi_setbits,
+#ifdef CONFIG_QSPI_HWFEATURES
+  .hwfeatures   = NULL,
+#endif
   .command      = esp32s3_qspi_command,
   .memory       = esp32s3_qspi_memory,
   .alloc        = esp32s3_qspi_alloc,
@@ -379,6 +382,9 @@ static const struct qspi_ops_s esp32s3_spi3_ops =
   .setfrequency = esp32s3_qspi_setfrequency,
   .setmode      = esp32s3_qspi_setmode,
   .setbits      = esp32s3_qspi_setbits,
+#ifdef CONFIG_QSPI_HWFEATURES
+  .hwfeatures   = NULL,
+#endif
   .command      = esp32s3_qspi_command,
   .memory       = esp32s3_qspi_memory,
   .alloc        = esp32s3_qspi_alloc,

--- a/drivers/spi/Kconfig
+++ b/drivers/spi/Kconfig
@@ -15,6 +15,14 @@ config ARCH_HAVE_SPI_BITORDER
 	bool
 	default n
 
+config ARCH_HAVE_QSPI_BITORDER
+	bool
+	default n
+
+config ARCH_HAVE_QSPI_WORD_REVERSE
+	bool
+	default n
+
 menuconfig SPI
 	bool "SPI Driver Support"
 	default n
@@ -161,6 +169,32 @@ config SPI_BITORDER
 	depends on ARCH_HAVE_SPI_BITORDER
 	---help---
 		Enables capability to select MSB- or LSB-first hardware feature for
+		data transfers.
+
+config QSPI_HWFEATURES
+	bool
+	default n
+	---help---
+		Selected only if a specific H/W feature is selected.  This is
+		basically the OR of any specific hardware feature and enables
+		the QSPI hwfeatures() interface method.
+
+config QSPI_BITORDER
+	bool "QSPI Bit Order Control"
+	default n
+	select QSPI_HWFEATURES
+	depends on ARCH_HAVE_QSPI_BITORDER
+	---help---
+		Enables capability to select MSB- or LSB-first hardware feature for
+		data transfers.
+
+config QSPI_WORD_REVERSE
+	bool "QSPI word reverse Control"
+	default n
+	select QSPI_HWFEATURES
+	depends on ARCH_HAVE_QSPI_WORD_REVERSE
+	---help---
+		Enables capability to word reverse hardware feature for
 		data transfers.
 
 config SPI_DELAY_CONTROL

--- a/drivers/spi/qspi_flash.c
+++ b/drivers/spi/qspi_flash.c
@@ -200,6 +200,9 @@ static const struct qspi_ops_s g_qspiops =
   qspi_flash_setfrequency,      /* setfrequency */
   qspi_flash_setmode,           /* setmode */
   qspi_flash_setbits,           /* setbits */
+#ifdef CONFIG_QSPI_HWFEATURES
+  NULL,                         /* hwfeatures */
+#endif
   qspi_flash_command,           /* command */
   qspi_flash_memory,            /* memory */
   qspi_flash_alloc,             /* alloc */


### PR DESCRIPTION
Support qspi hwfeatures.

## Summary
support qspi hwfeatures, add 'bit order' and 'word reverse' for vendro IC

## Impact
None

## Testing
Daily
