### PR TITLE
openamp/libmetal: Check CONFIG_HAVE_ATOMICS instead of HAVE_STDATOMIC_H in atomic.h

### DIFF
--- a/openamp/libmetal.defs
+++ b/openamp/libmetal.defs
@@ -67,6 +67,8 @@ LIBMETAL_HDRS_SEDEXP := \
 	 s/@PROJECT_SYSTEM_UPPER@/nuttx/g; \
 	 s/@PROJECT_PROCESSOR_UPPER@/$(LIBMETAL_ARCH)/g; \
 	 s/@PROJECT_MACHINE_UPPER@/$(CONFIG_ARCH_CHIP)/g; \
+	 s/cmakedefine HAVE_STDATOMIC_H/include <nuttx\/compiler.h>/g; \
+	 s/defined(HAVE_STDATOMIC_H)/defined(CONFIG_HAVE_ATOMICS)/g; \
 	 s/cmakedefine/undef/g"
 
 ifeq ($(wildcard libmetal/.git),)


### PR DESCRIPTION
## Summary
When we use libmetal with other headers using `stdatomic.h`, we'll get **symbol conflict** if we don't enable `HAVE_STDATOMIC_H` in libmetal.  The best solution might be using cmake to detect headers automatically, but we can't.  Fortunately we have `CONFIG_HAVE_ATOMICS` macro now, which can replace `HAVE_STDATOMIC_H` when we're not using cmake.

Note: 2-Steps to use `CONFIG_HAVE_ATOMICS`
1. Include `nuttx/compiler.h` for `CONFIG_HAVE_ATOMICS` definition
2. Check `CONFIG_HAVE_ATOMICS` instead of `HAVE_STDATOMIC_H`

## Impact
`config.h` and `atomic.h` in libmetal

## Testing
CI

