### PR TITLE
nuttx/toolchain: Add macro _LDBL_EQ_DBL to nuttx/arch/arm64/src/Toolc…

### DIFF
--- a/arch/arm64/src/Toolchain.defs
+++ b/arch/arm64/src/Toolchain.defs
@@ -80,6 +80,11 @@ ifeq ($(CONFIG_MM_UBSAN_TRAP_ON_ERROR),y)
   ARCHOPTIMIZATION += -fsanitize-undefined-trap-on-error
 endif
 
+ifeq ($(CONFIG_ARCH_FPU),y)
+  ARCHCXXFLAGS += -D_LDBL_EQ_DBL
+  ARCHCFLAGS   += -D_LDBL_EQ_DBL
+endif
+
 ARCHCFLAGS += -fno-common
 ARCHCXXFLAGS += -fno-common -nostdinc++
 


### PR DESCRIPTION
…hain.defs

Fix goldfish build toolchain math library error:
/mnt/yang/vela_Goldfish/nuttx/include/libcxx/cmath:454:9: error: 'nexttowardf' has not been declared in '::'
  454 | using ::nexttowardf;
      |         ^~~~~~~~~~~
/mnt/yang/vela_Goldfish/nuttx/include/libcxx/cmath:472:9: error: 'acosl' has not been declared in '::'
  472 | using ::acosl;
      |         ^~~~~
/mnt/yang/vela_Goldfish/nuttx/include/libcxx/cmath:473:9: error: 'asinl' has not been declared in '::'
  473 | using ::asinl;
      |         ^~~~~

## Summary

## Impact

## Testing

