### PR TITLE
libm/libmcs: Fix undefined symbol `fesetround'

### DIFF
--- a/libs/libm/libmcs/Make.defs
+++ b/libs/libm/libmcs/Make.defs
@@ -76,6 +76,7 @@ CSRCS = signgam.c \
         expm1d.c \
         fabsd.c \
         fdimd.c \
+        fenv.c \
         floord.c \
         fmad.c \
         fmaxd.c \


### PR DESCRIPTION
## Summary

```
Fix build error:apps/interpreters/quickjs/quickjs/quickjs.c:11852:(.text.js_ecvt1.constprop.0+0xfc): relocation truncated to fit: R_AARCH64_CALL26 against undefined symbol `fesetround'
```

## Impact

## Testing

ci