### PR TITLE
libs/libc/stdlib: fix strtoul,strtoull bugs when value outside range

### DIFF
--- a/libs/libc/stdlib/lib_strtoul.c
+++ b/libs/libc/stdlib/lib_strtoul.c
@@ -103,6 +103,11 @@ unsigned long strtoul(FAR const char *nptr, FAR char **endptr, int base)
               nptr++;
             }
 
+          while (lib_isbasedigit(*nptr, base, &value))
+            {
+              nptr++;
+            }
+
           if (sign == '-')
             {
               accum = (~accum) + 1;

--- a/libs/libc/stdlib/lib_strtoull.c
+++ b/libs/libc/stdlib/lib_strtoull.c
@@ -107,6 +107,11 @@ unsigned long long strtoull(FAR const char *nptr,
               nptr++;
             }
 
+          while (lib_isbasedigit(*nptr, base, &value))
+            {
+              nptr++;
+            }
+
           if (sign == '-')
             {
               accum = (~accum) + 1;


### PR DESCRIPTION
## Summary

Prototype:
```
  unsigned long strtoul(FAR const char *nptr, FAR char **endptr, int base);
  unsigned long long strtoull(FAR const char *nptr,  FAR char **endptr, int base);
```

If endptr is not NULL, strtoul()/strtoull() should store the address of the first invalid character in *endptr. And if the correct value is outside the range of representable values, {ULONG_MAX} or {ULLONG_MAX} shall be returned and errno set to [ERANGE].

With such code:
  strtoul("34592348345343453453455645765736575865767", &endptr, 10);

It indeed returns ULONG_MAX and sets errno to ERANGE. But after strtoul return, endptr points to "3455645765736575865767", not NULL.

## Impact

## Testing

