### PR TITLE
libc/pthread: remove unsed compare code in pthread_rwlock_init()

### DIFF
--- a/libs/libc/pthread/pthread_rwlock.c
+++ b/libs/libc/pthread/pthread_rwlock.c
@@ -38,11 +38,6 @@ int pthread_rwlock_init(FAR pthread_rwlock_t *lock,
 {
   int err;
 
-  if (attr != NULL)
-    {
-      return ENOSYS;
-    }
-
   lock->num_readers       = 0;
   lock->num_writers       = 0;
   lock->write_in_progress = false;


### PR DESCRIPTION
In nuttx function pthread_rwlock_init param attr is useless, so remove it to make rwlock_init pass rwlock_init/1-1.c and rwlock_init/3-1.c testcases.

## Summary

## Impact

## Testing

