### PR TITLE
sim/posix_test: fix shm_open() return file descriptor associated with FD_CLOEXEC

### DIFF
--- a/fs/shm/shm_open.c
+++ b/fs/shm/shm_open.c
@@ -142,7 +142,7 @@ static int file_shm_open(FAR struct file *shm, FAR const char *name,
   /* Associate the inode with a file structure */
 
   memset(shm, 0, sizeof(*shm));
-  shm->f_oflags = oflags;
+  shm->f_oflags = oflags | O_CLOEXEC | O_NOFOLLOW;
   shm->f_inode = inode;
 
 errout_with_sem:


### PR DESCRIPTION
## Summary

Make the pthread_setspecific pass the shm_open/11-1.c testcases. Function shm_open() should return a file descriptor for the shared memory object associated with FD_CLOEXEC. Reference to https://pubs.opengroup.org/onlinepubs/9699919799/functions/shm_open.html and https://github.com/lattera/glibc/blob/master/sysdeps/posix/shm_open.c#LL38C1-L38C1

## Impact

## Testing

