### PR TITLE
drivers/net: Add wireless ops in upper-half driver

### DIFF
--- a/drivers/net/Kconfig
+++ b/drivers/net/Kconfig
@@ -45,6 +45,13 @@ config NETDEV_WORK_THREAD_PRIORITY
 	---help---
 		The priority of work poll thread in netdev.
 
+config NETDEV_WIRELESS_HANDLER
+	bool "Support wireless handler in upper-half driver"
+	default y
+	depends on NETDEV_IOCTL
+	---help---
+		Enable the wireless handler support in upper-half driver.
+
 comment "General Ethernet MAC Driver Options"
 
 config NET_RPMSG_DRV


### PR DESCRIPTION
## Summary
Take the idea from Linux's `iw_handler` array and esp32c3_wlan's `wlan_ops_s`, and make it a common logic of upper-half driver.

## Impact
Add new logic controlled by Kconfig

## Testing
Used/Tested by sim wifi which may be another pull request some time later.
