### PR TITLE
set CONFIG_PTHREAD_STACK_MIN as DEFAULT_MM_PGSIZE`s default value and

### DIFF
--- a/libs/libc/unistd/lib_sysconf.c
+++ b/libs/libc/unistd/lib_sysconf.c
@@ -33,7 +33,7 @@
 #ifdef CONFIG_MM_PGSIZE
 #  define DEFAULT_MM_PGSIZE CONFIG_MM_PGSIZE
 #else
-#  define DEFAULT_MM_PGSIZE 4096
+#  define DEFAULT_MM_PGSIZE CONFIG_PTHREAD_STACK_MIN
 #endif
 
 /****************************************************************************
@@ -245,6 +245,9 @@ long sysconf(int name)
 
       case _SC_PAGESIZE:
         return DEFAULT_MM_PGSIZE;
+
+      case _SC_THREAD_STACK_MIN:
+        return CONFIG_PTHREAD_STACK_MIN;
 
       default:
 #if 0 /* Assume valid but not implemented for the time being */


### PR DESCRIPTION
## Summary

sysconf add param _SC_THREAD_STACK_MIN deal

make the pthread_exit pass the ltp/open_posix_testsuite/pthread_exit/1-2.c testcase (1) in pthread_exit/1-2.c testcase, if sysconf(_SC_THREAD_STACK_MIN) % sysconf(_SC_PAGESIZE) is not zero, will report error and test failed, so set CONFIG_PTHREAD_STACK_MIN as DEFAULT_MM_PGSIZE`s default value. (2) in function sysconf add param _SC_THREAD_STACK_MIN deal.

## Impact

## Testing

