### PR TITLE
change clockid_t type from uint8_t to int

### DIFF
--- a/include/time.h
+++ b/include/time.h
@@ -113,7 +113,7 @@ typedef uint64_t  time_t;         /* Holds time in seconds */
 #else
 typedef uint32_t  time_t;         /* Holds time in seconds */
 #endif
-typedef uint8_t   clockid_t;      /* Identifies one time base source */
+typedef int       clockid_t;      /* Identifies one time base source */
 typedef FAR void *timer_t;        /* Represents one POSIX timer */
 
 /* struct timespec is the standard representation of time as seconds and


### PR DESCRIPTION
## Summary

make the clock_getres pass the ltp/open_posix_testsuite/clock_getres testcases, posix has no explain about clockid_t type, referrence linux: https://github.com/torvalds/linux/blob/858fd168a95c5b9669aac8db6c14a9aeab446375/include/linux/types.h#L27 and https://github.com/torvalds/linux/blob/858fd168a95c5b9669aac8db6c14a9aeab446375/include/uapi/asm-generic/posix_types.h#L96

## Impact

## Testing

