### PR TITLE
Fix syslog stack usage is too large

### DIFF
--- a/drivers/syslog/vsyslog.c
+++ b/drivers/syslog/vsyslog.c
@@ -150,101 +150,102 @@ int nx_vsyslog(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
     defined(CONFIG_SYSLOG_PRIORITY) || defined(CONFIG_SYSLOG_PREFIX) || \
     defined(CONFIG_SYSLOG_PROCESS_NAME)
 
-  ret = lib_sprintf(&stream.public,
+  ret = lib_sprintf_internal(&stream.public,
 #if defined(CONFIG_SYSLOG_COLOR_OUTPUT)
   /* Reset the terminal style. */
 
-                    "\e[0m"
+                             "\e[0m"
 #endif
 
 #ifdef CONFIG_SYSLOG_TIMESTAMP
 #  if defined(CONFIG_SYSLOG_TIMESTAMP_FORMATTED)
 #    if defined(CONFIG_SYSLOG_TIMESTAMP_FORMAT_MICROSECOND)
-                    "[%s.%06ld] "
+                             "[%s.%06ld] "
 #    else
-                    "[%s] "
+                             "[%s] "
 #    endif
 #  else
-                    "[%5jd.%06ld] "
+                             "[%5jd.%06ld] "
 #  endif
 #endif
 
 #if defined(CONFIG_SMP)
-                    "[CPU%d] "
+                             "[CPU%d] "
 #endif
 
 #if defined(CONFIG_SYSLOG_PROCESSID)
   /* Prepend the Thread ID */
 
-                    "[%2d] "
+                             "[%2d] "
 #endif
 
 #if defined(CONFIG_SYSLOG_COLOR_OUTPUT)
   /* Set the terminal style according to message priority. */
 
-                    "%s"
+                             "%s"
 #endif
 
 #if defined(CONFIG_SYSLOG_PRIORITY)
   /* Prepend the message priority. */
 
-                    "[%6s] "
+                             "[%6s] "
 #endif
 
 #if defined(CONFIG_SYSLOG_PREFIX)
   /* Prepend the prefix, if available */
 
-                    "[%s] "
+                             "[%s] "
 #endif
 #if CONFIG_TASK_NAME_SIZE > 0 && defined(CONFIG_SYSLOG_PROCESS_NAME)
   /* Prepend the thread name */
 
-                    "%s: "
+                             "%s: "
 #endif
 #ifdef CONFIG_SYSLOG_TIMESTAMP
 #  if defined(CONFIG_SYSLOG_TIMESTAMP_FORMATTED)
 #    if defined(CONFIG_SYSLOG_TIMESTAMP_FORMAT_MICROSECOND)
-                    , date_buf, ts.tv_nsec / NSEC_PER_USEC
+                             , date_buf, ts.tv_nsec / NSEC_PER_USEC
 #    else
-                    , date_buf
+                             , date_buf
 #    endif
 #  else
-                    , (uintmax_t)ts.tv_sec, ts.tv_nsec / NSEC_PER_USEC
+                             , (uintmax_t)ts.tv_sec
+                             , ts.tv_nsec / NSEC_PER_USEC
 #  endif
 #endif
 
 #if defined(CONFIG_SMP)
-                    , up_cpu_index()
+                             , up_cpu_index()
 #endif
 
 #if defined(CONFIG_SYSLOG_PROCESSID)
   /* Prepend the Thread ID */
 
-                    , nxsched_gettid()
+                             , nxsched_gettid()
 #endif
 
 #if defined(CONFIG_SYSLOG_COLOR_OUTPUT)
   /* Set the terminal style according to message priority. */
 
-                    , g_priority_color[priority]
+                             , g_priority_color[priority]
 #endif
 
 #if defined(CONFIG_SYSLOG_PRIORITY)
   /* Prepend the message priority. */
 
-                    , g_priority_str[priority]
+                             , g_priority_str[priority]
 #endif
 
 #if defined(CONFIG_SYSLOG_PREFIX)
   /* Prepend the prefix, if available */
 
-                    , CONFIG_SYSLOG_PREFIX_STRING
+                             , CONFIG_SYSLOG_PREFIX_STRING
 #endif
 
 #if CONFIG_TASK_NAME_SIZE > 0 && defined(CONFIG_SYSLOG_PROCESS_NAME)
   /* Prepend the thread name */
 
-                    , tcb != NULL ? tcb->name : "(null)"
+                             , tcb != NULL ? tcb->name : "(null)"
 #endif
                     );
 
@@ -252,7 +253,7 @@ int nx_vsyslog(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
 
   /* Generate the output */
 
-  ret += lib_vsprintf(&stream.public, fmt, *ap);
+  ret += lib_vsprintf_internal(&stream.public, fmt, *ap);
 
   if (stream.last_ch != '\n')
     {

--- a/include/nuttx/streams.h
+++ b/include/nuttx/streams.h
@@ -690,6 +690,31 @@ int lib_sprintf(FAR struct lib_outstream_s *obj,
                 FAR const IPTR char *fmt, ...) printf_like(2, 3);
 
 /****************************************************************************
+ * Name: lib_sprintf_internal
+ *
+ * Description:
+ *   This function does not take numbered arguments in printf.
+ *   Equivalent to lib_sprintf when CONFIG_LIBC_NUMBERED_ARGS is not enabled
+ *
+ ****************************************************************************/
+
+int lib_sprintf_internal(FAR struct lib_outstream_s *obj,
+                         FAR const IPTR char *fmt, ...) printf_like(2, 3);
+
+/****************************************************************************
+ * Name: lib_vsprintf_internal
+ *
+ * Description:
+ *   This function does not take numbered arguments in printf.
+ *   Equivalent to lib_sprintf when CONFIG_LIBC_NUMBERED_ARGS is not enabled
+ *
+ ****************************************************************************/
+
+int lib_vsprintf_internal(FAR struct lib_outstream_s *stream,
+                          FAR const IPTR char *fmt, va_list ap)
+                          printf_like(2, 0);
+
+/****************************************************************************
  * Name: lib_vsprintf
  *
  * Description:

--- a/libs/libc/stdio/lib_libvsprintf.c
+++ b/libs/libc/stdio/lib_libvsprintf.c
@@ -1166,7 +1166,9 @@ str_lpad:
 
                           if (c == 'S')
                             {
-                              sprintf_internal(stream, "+%#tx/%#zx",
+                              total_len +=
+                              sprintf_internal(stream,
+                                               "+%#tx/%#zx",
                                                addr - symbol->sym_value,
                                                symbolsize);
                             }

--- a/libs/libc/stdio/lib_libvsprintf.c
+++ b/libs/libc/stdio/lib_libvsprintf.c
@@ -155,23 +155,6 @@ static int vsprintf_internal(FAR struct lib_outstream_s *stream,
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_ALLSYMS
-static int sprintf_internal(FAR struct lib_outstream_s *stream,
-                            FAR const IPTR char *fmt, ...)
-{
-  va_list ap;
-  int     n;
-
-  /* Then let vsprintf_internal do the real work */
-
-  va_start(ap, fmt);
-  n = vsprintf_internal(stream, NULL, 0, fmt, ap);
-  va_end(ap);
-
-  return n;
-}
-#endif
-
 static int vsprintf_internal(FAR struct lib_outstream_s *stream,
                              FAR struct arg_s *arglist, int numargs,
                              FAR const IPTR char *fmt, va_list ap)
@@ -1167,10 +1150,10 @@ str_lpad:
                           if (c == 'S')
                             {
                               total_len +=
-                              sprintf_internal(stream,
-                                               "+%#tx/%#zx",
-                                               addr - symbol->sym_value,
-                                               symbolsize);
+                              lib_sprintf_internal(stream,
+                                                   "+%#tx/%#zx",
+                                                   addr - symbol->sym_value,
+                                                   symbolsize);
                             }
 
                           continue;
@@ -1381,4 +1364,43 @@ int lib_vsprintf(FAR struct lib_outstream_s *stream,
 #else
   return vsprintf_internal(stream, NULL, 0, fmt, ap);
 #endif
+}
+
+/****************************************************************************
+ * Name: lib_sprintf_internal
+ *
+ * Description:
+ *   This function does not take numbered arguments in printf.
+ *   Equivalent to lib_sprintf when CONFIG_LIBC_NUMBERED_ARGS is not enabled
+ *
+ ****************************************************************************/
+
+int lib_sprintf_internal(FAR struct lib_outstream_s *stream,
+                         FAR const IPTR char *fmt, ...)
+{
+  va_list ap;
+  int     n;
+
+  /* Then let vsprintf_internal do the real work */
+
+  va_start(ap, fmt);
+  n = vsprintf_internal(stream, NULL, 0, fmt, ap);
+  va_end(ap);
+
+  return n;
+}
+
+/****************************************************************************
+ * Name: lib_vsprintf_internal
+ *
+ * Description:
+ *   This function does not take numbered arguments in printf.
+ *   Equivalent to lib_sprintf when CONFIG_LIBC_NUMBERED_ARGS is not enabled
+ *
+ ****************************************************************************/
+
+int lib_vsprintf_internal(FAR struct lib_outstream_s *stream,
+                          FAR const IPTR char *fmt, va_list ap)
+{
+  return vsprintf_internal(stream, NULL, 0, fmt, ap);
 }


### PR DESCRIPTION
## Summary
Using %pV in syslog will lead to nested calls, which will increase the stack consumption

If LIBC_NUMBERED_ARGS is enabled, calling lib_sprintf in syslog will use a few hundred bytes of local variables, but syslog doesn't need it

## Impact

## Testing

