### PR TITLE
syslog: add syslog channel filtering function

### DIFF
--- a/Documentation/components/drivers/special/syslog.rst
+++ b/Documentation/components/drivers/special/syslog.rst
@@ -233,6 +233,23 @@ even further initialization. For example, the file SYSLOG channel
 (described below) cannot be initialized until the necessary file
 systems have been mounted.
 
+SYSLOG Channel Filtering
+-----------------------------
+If you enable the CONFIG_SYSLOG_IOCTL configuration, you can enable
+syslog to open or close the specified channel at runtime.
+
+You can control SYSLOG channels by using the ioctl command in NuttX
+with either the SYSLOGIOC_GETCHANNELS or SYSLOGIOC_SETFILTER.
+
+-  ``SYSLOGIOC_GETCHANNELS``. This command can get a list of all channels
+-  ``SYSLOGIOC_SETFILTER``. This command enables/disables the specified channel.
+
+In nsh, you can view/set the syslog channel status through the setlogmask command.
+
+-  ``setlogmask list``. Print all channel status
+-  ``setlogmask <enable/disable> <channel>``. Enable or disable the
+   specified channel.
+
 Interrupt Level SYSLOG Output
 -----------------------------
 

--- a/drivers/syslog/Kconfig
+++ b/drivers/syslog/Kconfig
@@ -379,4 +379,13 @@ config SYSLOG_CHARDEV
 		byte output with no time-stamping or any other SYSLOG features
 		supported.
 
+config SYSLOG_IOCTL
+	bool "SYSLOG IOCTL support"
+	default n
+	---help---
+		Enables support for the SYSLOG IOCTL command.  This command is used
+		to control the behavior of the SYSLOG device. Currently, the supported
+		commands are SYSLOGIOC_SETFILTER/SYSLOGIOC_GETCHANNELS, which can be
+		used to set the enable status of different channels
+
 endmenu # System logging

--- a/drivers/syslog/syslog_channel.c
+++ b/drivers/syslog/syslog_channel.c
@@ -82,6 +82,10 @@ static const struct syslog_channel_ops_s g_ramlog_channel_ops =
 static struct syslog_channel_s g_ramlog_channel =
 {
   &g_ramlog_channel_ops
+#  ifdef CONFIG_SYSLOG_IOCTL
+  , "ram"
+  , false
+#  endif
 };
 #endif
 
@@ -98,6 +102,10 @@ static const struct syslog_channel_ops_s g_rpmsg_channel_ops =
 static struct syslog_channel_s g_rpmsg_channel =
 {
   &g_rpmsg_channel_ops
+#  ifdef CONFIG_SYSLOG_IOCTL
+  , "rpmsg"
+  , false
+#  endif
 };
 #endif
 
@@ -114,6 +122,10 @@ static const struct syslog_channel_ops_s g_rtt_channel_ops =
 static struct syslog_channel_s g_rtt_channel =
 {
   &g_rtt_channel_ops
+#  ifdef CONFIG_SYSLOG_IOCTL
+  , "rtt"
+  , false
+#  endif
 };
 #endif
 
@@ -129,6 +141,10 @@ static const struct syslog_channel_ops_s g_default_channel_ops =
 static struct syslog_channel_s g_default_channel =
 {
   &g_default_channel_ops
+#  ifdef CONFIG_SYSLOG_IOCTL
+  , "default"
+  , false
+#  endif
 };
 #endif
 
@@ -272,6 +288,14 @@ int syslog_channel(FAR struct syslog_channel_s *channel)
         {
           if (g_syslog_channel[i] == NULL)
             {
+#  ifdef CONFIG_SYSLOG_IOCTL
+              if (channel->sc_name[0] == '\0')
+                {
+                  snprintf(channel->sc_name, sizeof(channel->sc_name),
+                           "channel-%p", channel->sc_ops);
+                }
+#  endif
+
               g_syslog_channel[i] = channel;
               return OK;
             }

--- a/drivers/syslog/syslog_intbuffer.c
+++ b/drivers/syslog/syslog_intbuffer.c
@@ -192,6 +192,13 @@ int syslog_add_intbuffer(int ch)
               break;
             }
 
+#ifdef CONFIG_SYSLOG_IOCTL
+          if (g_syslog_channel[i]->sc_disable)
+            {
+              continue;
+            }
+#endif
+
           /* Select which putc function to use for this flush */
 
           if (g_syslog_channel[i]->sc_ops->sc_force)
@@ -268,6 +275,13 @@ int syslog_flush_intbuffer(bool force)
             {
               break;
             }
+
+#ifdef CONFIG_SYSLOG_IOCTL
+          if (g_syslog_channel[i]->sc_disable)
+            {
+              continue;
+            }
+#endif
 
           /* Select which putc function to use for this flush */
 

--- a/drivers/syslog/syslog_putc.c
+++ b/drivers/syslog/syslog_putc.c
@@ -90,6 +90,13 @@ int syslog_putc(int ch)
                   break;
                 }
 
+#ifdef CONFIG_SYSLOG_IOCTL
+              if (channel->sc_disable)
+                {
+                  continue;
+                }
+#endif
+
               if (channel->sc_ops->sc_force != NULL)
                 {
                   channel->sc_ops->sc_force(channel,  ch);
@@ -122,6 +129,13 @@ int syslog_putc(int ch)
             {
               break;
             }
+
+#ifdef CONFIG_SYSLOG_IOCTL
+          if (channel->sc_disable)
+            {
+              continue;
+            }
+#endif
 
           if (channel->sc_ops->sc_putc != NULL)
             {

--- a/drivers/syslog/syslog_write.c
+++ b/drivers/syslog/syslog_write.c
@@ -82,6 +82,13 @@ static ssize_t syslog_default_write(FAR const char *buffer, size_t buflen)
                   break;
                 }
 
+#ifdef CONFIG_SYSLOG_IOCTL
+              if (channel->sc_disable)
+                {
+                  continue;
+                }
+#endif
+
               if (channel->sc_ops->sc_write_force != NULL)
                 {
                   nwritten =
@@ -108,6 +115,13 @@ static ssize_t syslog_default_write(FAR const char *buffer, size_t buflen)
             {
               break;
             }
+
+#ifdef CONFIG_SYSLOG_IOCTL
+          if (channel->sc_disable)
+            {
+              continue;
+            }
+#endif
 
           if (channel->sc_ops->sc_write != NULL)
             {

--- a/include/nuttx/fs/ioctl.h
+++ b/include/nuttx/fs/ioctl.h
@@ -95,6 +95,7 @@
 #define _VIDIOCBASE     (0x3700) /* Video device ioctl commands */
 #define _CELLIOCBASE    (0x3800) /* Cellular device ioctl commands */
 #define _MIPIDSIBASE    (0x3900) /* Mipidsi device ioctl commands */
+#define _SYSLOGBASE     (0x3c00) /* Syslog device ioctl commands */
 #define _WLIOCBASE      (0x8b00) /* Wireless modules ioctl network commands */
 
 /* boardctl() commands share the same number space */
@@ -638,6 +639,11 @@
 
 #define _MIPIDSIIOCVALID(c)    (_IOC_TYPE(c)==_MIPIDSIBASE)
 #define _MIPIDSIIOC(nr)        _IOC(_MIPIDSIBASE,nr)
+
+/* syslog driver ioctl definitions ******************************************/
+
+#define _SYSLOGVALID(c) (_IOC_TYPE(c)==_SYSLOGBASE)
+#define _SYSLOGIOC(nr)  _IOC(_SYSLOGBASE,nr)
 
 /* Wireless driver network ioctl definitions ********************************/
 

--- a/include/nuttx/syslog/syslog.h
+++ b/include/nuttx/syslog/syslog.h
@@ -79,6 +79,16 @@
 #  endif
 #endif
 
+/* Get a list of syslog channels */
+
+#define SYSLOGIOC_GETCHANNELS _SYSLOGIOC(0x0001)
+
+/* Set syslog channel filter */
+
+#define SYSLOGIOC_SETFILTER _SYSLOGIOC(0x0002)
+
+#define SYSLOG_CHANNEL_NAME_LEN 32
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/
@@ -108,6 +118,12 @@ struct syslog_channel_ops_s
   syslog_close_t sc_close;        /* Channel close callback */
 };
 
+struct syslog_channel_info_s
+{
+  char sc_name[SYSLOG_CHANNEL_NAME_LEN];
+  bool sc_disable;
+};
+
 /* This structure provides the interface to a SYSLOG channel */
 
 struct syslog_channel_s
@@ -117,6 +133,16 @@ struct syslog_channel_s
   FAR const struct syslog_channel_ops_s *sc_ops;
 
   /* Implementation specific logic may follow */
+
+#ifdef CONFIG_SYSLOG_IOCTL
+  /* Syslog channel name */
+
+  char sc_name[SYSLOG_CHANNEL_NAME_LEN];
+
+  /* Syslog channel enable status, true is disable */
+
+  bool sc_disable;
+#endif
 };
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
support to control the opening or closing of the specified channel through the syslogmask command at runtime

## Impact

## Testing

