### PR TITLE
cmake: some fixes for stm32 and support for stm32f7 and stm32h7

### DIFF
--- a/arch/arm/src/stm32/CMakeLists.txt
+++ b/arch/arm/src/stm32/CMakeLists.txt
@@ -32,7 +32,6 @@ list(
   stm32_exti_gpio.c
   stm32_flash.c
   stm32_irq.c
-  stm32_dma.c
   stm32_lowputc.c
   stm32_serial.c
   stm32_spi.c
@@ -44,6 +43,10 @@ list(
   stm32_uid.c
   stm32_capture.c
   stm32_dfumode.c)
+
+if(CONFIG_STM32_DMA)
+  list(APPEND SRCS stm32_dma.c)
+endif()
 
 if(CONFIG_TIMER)
   list(APPEND SRCS stm32_tim_lowerhalf.c)
@@ -67,10 +70,6 @@ if(CONFIG_BUILD_PROTECTED)
   list(APPEND SRCS stm32_userspace.c stm32_mpuinit.c)
 endif()
 
-if(CONFIG_STM32_CCM_PROCFS)
-  list(APPEND SRCS stm32_procfs_ccm.c)
-endif()
-
 if(CONFIG_STM32_HAVE_IP_I2C_V1)
   if(CONFIG_STM32_I2C_ALT)
     list(APPEND SRCS stm32_i2c_alt.c)
@@ -86,6 +85,9 @@ endif()
 if(CONFIG_USBDEV)
   if(CONFIG_STM32_USB)
     list(APPEND SRCS stm32_usbdev.c)
+  endif()
+  if(CONFIG_STM32_USBFS)
+    list(APPEND SRCS stm32_usbfs.c)
   endif()
   if(CONFIG_STM32_OTGFS)
     list(APPEND SRCS stm32_otgfsdev.c)
@@ -142,12 +144,12 @@ if(CONFIG_STM32_RTC)
   endif()
 endif()
 
-if(CONFIG_STM32_ADC)
-  list(APPEND SRCS stm32_adc.c)
-endif()
-
 if(CONFIG_STM32_SDADC)
   list(APPEND SRCS stm32_sdadc.c)
+endif()
+
+if(CONFIG_STM32_ADC)
+  list(APPEND SRCS stm32_adc.c)
 endif()
 
 if(CONFIG_STM32_DAC)
@@ -190,12 +192,34 @@ if(CONFIG_STM32_PWM)
   list(APPEND SRCS stm32_pwm.c)
 endif()
 
+if(CONFIG_STM32_CAP)
+  list(APPEND SRCS stm32_capture_lowerhalf.c)
+endif()
+
 if(CONFIG_SENSORS_QENCODER)
   list(APPEND SRCS stm32_qencoder.c)
 endif()
 
+if(CONFIG_SENSORS_HALL3PHASE)
+  list(APPEND SRCS stm32_hall3ph.c)
+endif()
+
 if(CONFIG_STM32_CAN)
-  list(APPEND SRCS stm32_can.c)
+  if(CONFIG_STM32_CAN_CHARDRIVER)
+    list(APPEND SRCS stm32_can.c)
+  endif()
+  if(CONFIG_STM32_CAN_SOCKET)
+    list(APPEND SRCS stm32_can_sock.c)
+  endif()
+endif()
+
+if(CONFIG_STM32_FDCAN)
+  if(CONFIG_STM32_FDCAN_CHARDRIVER)
+    list(APPEND SRCS stm32_fdcan.c)
+  endif()
+  if(CONFIG_STM32_FDCAN_SOCKET)
+    list(APPEND SRCS stm32_fdcan_sock.c)
+  endif()
 endif()
 
 if(CONFIG_STM32_IWDG)
@@ -214,6 +238,10 @@ if(CONFIG_STM32_AES)
   list(APPEND SRCS stm32_aes.c)
 endif()
 
+if(CONFIG_CRYPTO_CRYPTODEV_HARDWARE)
+  list(APPEND SRCS stm32_crypto.c)
+endif()
+
 if(CONFIG_STM32_BBSRAM)
   list(APPEND SRCS stm32_bbsram.c)
 endif()
@@ -228,6 +256,10 @@ endif()
 
 if(CONFIG_STM32_FOC)
   list(APPEND SRCS stm32_foc.c)
+endif()
+
+if(CONFIG_STM32_CORDIC)
+  list(APPEND SRCS stm32_cordic.c)
 endif()
 
 target_sources(arch PRIVATE ${SRCS})

--- a/arch/arm/src/stm32f7/CMakeLists.txt
+++ b/arch/arm/src/stm32f7/CMakeLists.txt
@@ -1,0 +1,184 @@
+# ##############################################################################
+# arch/arm/src/stm32f7/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS)
+
+list(
+  APPEND
+  SRCS
+  stm32_allocateheap.c
+  stm32_exti_gpio.c
+  stm32_gpio.c
+  stm32_irq.c
+  stm32_lowputc.c
+  stm32_rcc.c
+  stm32_serial.c
+  stm32_start.c
+  stm32_capture.c
+  stm32_uid.c
+  stm32_waste.c
+)
+
+if(CONFIG_STM32F7_TICKLESS_TIMER)
+  list(APPEND SRCS stm32_tickless.c)
+else()
+  list(APPEND SRCS stm32_timerisr.c)
+endif()
+
+if(CONFIG_STM32F7_PROGMEM)
+  list(APPEND SRCS stm32_flash.c)
+endif()
+
+if(CONFIG_BUILD_PROTECTED)
+  list(APPEND SRCS stm32_userspace.c stm32_mpuinit.c)
+endif()
+
+if(CONFIG_ARMV7M_DTCM)
+  list(APPEND SRCS stm32_dtcm.c)
+endif()
+
+if(CONFIG_STM32F7_DMA)
+  list(APPEND SRCS stm32_dma.c)
+endif()
+
+if(CONFIG_PM)
+  list(APPEND SRCS stm32_pmstandby.c stm32_pmstop.c stm32_pmsleep.c)
+  if(NOT CONFIG_ARCH_CUSTOM_PMINIT)
+    list(APPEND SRCS stm32_pminitialize.c)
+  endif()
+endif()
+
+if(CONFIG_STM32F7_PWR)
+  list(APPEND SRCS stm32_pwr.c stm32_exti_pwr.c)
+endif()
+
+if(CONFIG_STM32F7_RTC)
+  list(APPEND SRCS stm32_rtc.c)
+  if(CONFIG_RTC_ALARM)
+    list(APPEND SRCS stm32_exti_alarm.c)
+  endif()
+  if(CONFIG_RTC_PERIODIC)
+    list(APPEND SRCS stm32_exti_wakeup.c)
+  endif()
+  if(CONFIG_RTC_DRIVER)
+    list(APPEND SRCS stm32_rtc_lowerhalf.c)
+  endif()
+endif()
+
+if(CONFIG_STM32F7_IWDG OR CONFIG_STM32F7_RTC_LSICLOCK)
+  list(APPEND SRCS stm32_lsi.c)
+endif()
+
+if(CONFIG_STM32F7_RTC_LSECLOCK)
+  list(APPEND SRCS stm32_lse.c)
+endif()
+
+if(CONFIG_STM32F7_I2C)
+  list(APPEND SRCS stm32_i2c.c)
+endif()
+
+if(CONFIG_STM32F7_SPI)
+  list(APPEND SRCS stm32_spi.c)
+endif()
+
+if(CONFIG_STM32F7_SDMMC)
+  list(APPEND SRCS stm32_sdmmc.c)
+endif()
+
+if(CONFIG_USBDEV)
+  list(APPEND SRCS stm32_otgdev.c)
+endif()
+
+if(CONFIG_USBHOST)
+  list(APPEND SRCS stm32_otghost.c)
+  if(CONFIG_USBHOST_TRACE)
+    list(APPEND SRCS stm32_usbhost.c)
+    elseif(CONFIG_DEBUG_USB)
+      list(APPEND SRCS stm32_usbhost.c)
+    endif()
+endif()
+
+if(CONFIG_STM32F7_TIM)
+  list(APPEND SRCS stm32_tim.c stm32_tim_lowerhalf.c)
+endif()
+
+if(CONFIG_STM32F7_ADC)
+  list(APPEND SRCS stm32_adc.c)
+endif()
+
+if(CONFIG_STM32F7_QUADSPI)
+  list(APPEND SRCS stm32_qspi.c)
+endif()
+
+if(CONFIG_STM32F7_RTC)
+  if(CONFIG_RTC_ALARM)
+    list(APPEND SRCS stm32_exti_alarm.c)
+  endif()
+endif()
+
+if(CONFIG_STM32F7_ETHMAC)
+  list(APPEND SRCS stm32_ethernet.c)
+endif()
+
+if(CONFIG_DEBUG_FEATURES)
+  list(APPEND SRCS stm32_dumpgpio.c)
+endif()
+
+if(CONFIG_STM32F7_BBSRAM)
+  list(APPEND SRCS stm32_bbsram.c)
+endif()
+
+if(CONFIG_STM32F7_RNG)
+  list(APPEND SRCS stm32_rng.c)
+endif()
+
+if(CONFIG_STM32F7_LTDC)
+  list(APPEND SRCS stm32_ltdc.c)
+endif()
+
+if(CONFIG_STM32F7_DMA2D)
+  list(APPEND SRCS stm32_dma2d.c)
+endif()
+
+if(CONFIG_SENSORS_QENCODER)
+  list(APPEND SRCS stm32_qencoder.c)
+endif()
+
+if(CONFIG_STM32F7_CAN_CHARDRIVER)
+  list(APPEND SRCS stm32_can.c)
+endif()
+
+if(CONFIG_STM32F7_CAN_SOCKET)
+  list(APPEND SRCS stm32_can_sock.c)
+endif()
+
+if(CONFIG_STM32F7_SAI)
+  list(APPEND SRCS stm32_sai.c)
+endif()
+
+if(CONFIG_STM32F7_PWM)
+  list(APPEND SRCS stm32_pwm.c)
+endif()
+
+if(CONFIG_STM32F7_FOC)
+  list(APPEND SRCS stm32_foc.c)
+endif()
+
+target_sources(arch PRIVATE ${SRCS})

--- a/arch/arm/src/stm32h7/CMakeLists.txt
+++ b/arch/arm/src/stm32h7/CMakeLists.txt
@@ -1,0 +1,178 @@
+# ##############################################################################
+# arch/arm/src/stm32h7/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS)
+
+list(
+  APPEND
+  SRCS
+  stm32_allocateheap.c
+  stm32_exti_gpio.c
+  stm32_gpio.c
+  stm32_irq.c
+  stm32_start.c
+  stm32_rcc.c
+  stm32_lowputc.c
+  stm32_serial.c
+  stm32_uid.c
+)
+
+if(CONFIG_STM32H7_PROGMEM)
+  list(APPEND SRCS stm32_flash.c)
+endif()
+
+if(CONFIG_SCHED_TICKLESS)
+  list(APPEND SRCS stm32_tickless.c)
+else()
+  list(APPEND SRCS stm32_timerisr.c)
+endif()
+
+if(CONFIG_STM32H7_ONESHOT)
+  list(APPEND SRCS stm32_oneshot.c stm32_oneshot_lowerhalf.c)
+endif()
+
+if(CONFIG_BUILD_PROTECTED)
+  list(APPEND SRCS stm32_userspace.c stm32_mpuinit.c)
+endif()
+
+if(CONFIG_ARMV7M_DTCM)
+  list(APPEND SRCS stm32_dtcm.c)
+endif()
+
+if(CONFIG_STM32H7_ADC)
+  list(APPEND SRCS stm32_adc.c)
+endif()
+
+if(CONFIG_STM32H7_FDCAN)
+  list(APPEND SRCS stm32_fdcan_sock.c)
+endif()
+
+if(CONFIG_STM32H7_BBSRAM)
+  list(APPEND SRCS stm32_bbsram.c)
+endif()
+
+if(CONFIG_STM32H7_DMA)
+  list(APPEND SRCS stm32_dma.c)
+endif()
+
+if(CONFIG_STM32H7_FMC)
+  list(APPEND SRCS stm32_fmc.c)
+endif()
+
+if(CONFIG_STM32H7_IWDG OR CONFIG_STM32H7_RTC_LSICLOCK)
+  list(APPEND SRCS stm32_lsi.c)
+endif()
+
+if(CONFIG_STM32H7_RTC_LSECLOCK)
+  list(APPEND SRCS stm32_lse.c)
+endif()
+
+if(CONFIG_STM32H7_I2C)
+  list(APPEND SRCS stm32_i2c.c)
+endif()
+
+if(CONFIG_STM32H7_PWR)
+  list(APPEND SRCS stm32_pwr.c)
+endif()
+
+if(CONFIG_STM32H7_QUADSPI)
+  list(APPEND SRCS stm32_qspi.c)
+endif()
+
+if(CONFIG_STM32H7_RTC)
+  list(APPEND SRCS stm32_rtc.c)
+  if(CONFIG_RTC_ALARM)
+    list(APPEND SRCS stm32_exti_alarm.c)
+  endif()
+  if(CONFIG_RTC_PERIODIC)
+    list(APPEND SRCS stm32_exti_wakeup.c)
+  endif()
+  if(CONFIG_RTC_DRIVER)
+    list(APPEND SRCS stm32_rtc_lowerhalf.c)
+  endif()
+endif()
+
+if(CONFIG_STM32H7_SPI)
+  list(APPEND SRCS stm32_spi.c)
+endif()
+
+if(CONFIG_SPI_SLAVE)
+  list(APPEND SRCS stm32_spi_slave.c)
+endif()
+
+if(CONFIG_STM32H7_SDMMC)
+  list(APPEND SRCS stm32_sdmmc.c)
+endif()
+
+if(CONFIG_TIMER)
+  list(APPEND SRCS stm32_tim_lowerhalf.c)
+endif()
+
+if(CONFIG_USBDEV)
+  list(APPEND SRCS stm32_otgdev.c)
+endif()
+
+if(CONFIG_USBHOST)
+  list(APPEND SRCS stm32_otghost.c)
+  if(CONFIG_USBHOST_TRACE)
+    list(APPEND SRCS stm32_usbhost.c)
+  else()
+    if(CONFIG_DEBUG_USB)
+      list(APPEND SRCS stm32_usbhost.c)
+    endif()
+  endif()
+endif()
+
+if(CONFIG_STM32H7_TIM)
+  list(APPEND SRCS stm32_tim.c)
+endif()
+
+if(CONFIG_STM32H7_LPTIM)
+  list(APPEND SRCS stm32_lptim.c)
+endif()
+
+if(CONFIG_STM32H7_PWM)
+  list(APPEND SRCS stm32_pwm.c)
+endif()
+
+if(CONFIG_STM32H7_ETHMAC)
+  list(APPEND SRCS stm32_ethernet.c)
+endif()
+
+if(CONFIG_SENSORS_QENCODER)
+  list(APPEND SRCS stm32_qencoder.c)
+endif()
+
+if(CONFIG_PM)
+  list(APPEND SRCS stm32_pmsleep.c stm32_pmstandby.c stm32_pmstop.c)
+  if(NOT CONFIG_ARCH_CUSTOM_PMINIT)
+    list(APPEND SRCS stm32_pminitialize.c)
+  endif()
+endif()
+
+if(CONFIG_STM32H7_IWDG)
+  list(APPEND SRCS stm32_iwdg.c)
+endif()
+
+if(CONFIG_STM32H7_WWDG)
+  list(APPEND SRCS stm32_wwdg.c)
+endif()
+
+target_sources(arch PRIVATE ${SRCS})

--- a/boards/arm/stm32/b-g431b-esc1/CMakeLists.txt
+++ b/boards/arm/stm32/b-g431b-esc1/CMakeLists.txt
@@ -1,0 +1,22 @@
+
+# ##############################################################################
+# boards/arm/stm32/b-g431b-esc1/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32/b-g431b-esc1/src/CMakeLists.txt
+++ b/boards/arm/stm32/b-g431b-esc1/src/CMakeLists.txt
@@ -1,0 +1,53 @@
+############################################################################
+# boards/arm/stm32/b-g431b-esc1/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+
+set(SRCS stm32_boot.c stm32_bringup.c)
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS stm32_autoleds.c)
+else()
+  list(APPEND SRCS stm32_userleds.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS stm32_buttons.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+if(CONFIG_STM32_FOC)
+  list(APPEND SRCS stm32_foc.c)
+endif()
+
+if(CONFIG_STM32_FDCAN)
+if(CONFIG_STM32_FDCAN_CHARDRIVER)
+  list(APPEND SRCS stm32_can.c)
+endif()
+if(CONFIG_STM32_FDCAN_SOCKET)
+  list(APPEND SRCS stm32_cansock.c)
+endif()
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/ld.script")

--- a/boards/arm/stm32/nucleo-f302r8/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-f302r8/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32/nucleo-f302r8/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32/nucleo-f302r8/src/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-f302r8/src/CMakeLists.txt
@@ -1,0 +1,60 @@
+############################################################################
+# boards/arm/stm32/nucleo-f302r8/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+set(SRCS stm32_boot.c stm32_bringup.c)
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS stm32_autoleds.c)
+else()
+  list(APPEND SRCS stm32_userleds.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS stm32_buttons.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+if(CONFIG_PWM)
+  list(APPEND SRCS stm32_pwm.c)
+endif()
+
+if(CONFIG_NUCLEOF302R8_HIGHPRI)
+  list(APPEND SRCS stm32_highpri.c)
+endif()
+
+if(CONFIG_BOARD_STM32_IHM07M1)
+  list(APPEND SRCS stm32_foc_ihm07m1.c)
+endif()
+
+if(CONFIG_STM32_CAN)
+  if(CONFIG_STM32_CAN_CHARDRIVER)
+    list(APPEND SRCS stm32_can.c)
+  endif()
+  if(CONFIG_STM32_CAN_SOCKET)
+    list(APPEND SRCS stm32_cansock.c)
+  endif()
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/ld.script")

--- a/boards/arm/stm32/nucleo-f334r8/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-f334r8/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32/nucleo-f334r8/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32/nucleo-f334r8/src/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-f334r8/src/CMakeLists.txt
@@ -1,0 +1,61 @@
+############################################################################
+# boards/arm/stm32/nucleo-f334r8/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+set(SRCS stm32_boot.c)
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS stm32_autoleds.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+if(CONFIG_ADC)
+  list(APPEND SRCS stm32_adc.c)
+endif()
+
+if(CONFIG_DAC)
+  list(APPEND SRCS stm32_dac.c)
+endif()
+
+if(CONFIG_STM32_HRTIM)
+  list(APPEND SRCS stm32_hrtim.c)
+endif()
+
+if(CONFIG_COMP)
+  list(APPEND SRCS stm32_comp.c)
+endif()
+
+if(CONFIG_OPAMP)
+  list(APPEND SRCS stm32_opamp.c)
+endif()
+
+if(CONFIG_NUCLEOF334R8_HIGHPRI)
+  list(APPEND SRCS stm32_highpri.c)
+endif()
+
+if(CONFIG_NUCLEOF334R8_SPWM)
+  list(APPEND SRCS stm32_spwm.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/ld.script")

--- a/boards/arm/stm32/nucleo-f446re/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-f446re/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32/nucleo-f446re/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32/nucleo-f446re/src/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-f446re/src/CMakeLists.txt
@@ -1,0 +1,81 @@
+############################################################################
+# boards/arm/stm32/nucleo-f446re/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+set(SRCS stm32_boot.c stm32_bringup.c stm32_spi.c)
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS stm32_autoleds.c)
+else()
+  list(APPEND SRCS stm32_userleds.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS stm32_buttons.c)
+endif()
+
+if(CONFIG_LCD_ILI9225)
+  list(APPEND SRCS stm32_ili9225.c)
+endif()
+
+if(NOT CONFIG_STM32_FOC)
+  if(CONFIG_ADC)
+    list(APPEND SRCS stm32_adc.c)
+    if(CONFIG_INPUT_AJOYSTICK)
+      list(APPEND SRCS stm32_ajoystick.c)
+    endif()
+  endif()
+endif()
+
+if(CONFIG_STM32_CAN)
+  if(CONFIG_STM32_CAN_CHARDRIVER)
+    list(APPEND SRCS stm32_can.c)
+  endif()
+  if(CONFIG_STM32_CAN_SOCKET)
+    list(APPEND SRCS stm32_cansock.c)
+  endif()
+endif()
+
+if(CONFIG_STM32_PWM)
+  list(APPEND SRCS stm32_pwm.c)
+endif()
+
+if(CONFIG_DEV_GPIO)
+  list(APPEND SRCS stm32_gpio.c)
+endif()
+
+if(CONFIG_DAC)
+  list(APPEND SRCS stm32_dac.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+if(CONFIG_BOARD_STM32_IHM08M1)
+  list(APPEND SRCS stm32_foc_ihm08m1.c)
+endif()
+
+if(CONFIG_STM32_ROMFS)
+  list(APPEND SRCS stm32_romfs_initialize.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/f446re.ld")

--- a/boards/arm/stm32/nucleo-f446re/src/stm32_bringup.c
+++ b/boards/arm/stm32/nucleo-f446re/src/stm32_bringup.c
@@ -35,7 +35,6 @@
 #include <nuttx/mmcsd.h>
 
 #include <stm32.h>
-#include <stm32_romfs.h>
 
 #include <arch/board/board.h>
 
@@ -55,6 +54,7 @@
 #  include <nuttx/video/fb.h>
 #endif
 
+#include "stm32_romfs.h"
 #include "nucleo-f446re.h"
 
 /****************************************************************************

--- a/boards/arm/stm32f7/nucleo-144/CMakeLists.txt
+++ b/boards/arm/stm32f7/nucleo-144/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32f7/nucleo-144/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32f7/nucleo-144/src/CMakeLists.txt
+++ b/boards/arm/stm32f7/nucleo-144/src/CMakeLists.txt
@@ -1,0 +1,98 @@
+# ##############################################################################
+# boards/arm/stm32f7/nucleo-144/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_bringup.c)
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS stm32_autoleds.c)
+else()
+  list(APPEND SRCS stm32_userleds.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS stm32_buttons.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinitialize.c)
+endif()
+
+if(CONFIG_DEV_GPIO)
+  list(APPEND SRCS stm32_gpio.c)
+endif()
+
+if(CONFIG_SPI)
+  list(APPEND SRCS stm32_spi.c)
+endif()
+
+if(CONFIG_ADC)
+  list(APPEND SRCS stm32_adc.c)
+endif()
+
+if(CONFIG_PWM)
+  list(APPEND SRCS stm32_pwm.c)
+endif()
+
+if(CONFIG_MMCSD)
+  list(APPEND SRCS stm32_sdio.c)
+endif()
+
+if(CONFIG_STM32F7_OTGFS)
+  list(APPEND SRCS stm32_usb.c)
+endif()
+
+if(CONFIG_STM32F7_BBSRAM)
+  list(APPEND SRCS stm32_bbsram.c)
+endif()
+
+if(CONFIG_BOARDCTL_RESET)
+  list(APPEND SRCS stm32_reset.c)
+endif()
+
+if(CONFIG_STM32_ROMFS)
+  list(APPEND SRCS stm32_romfs_initialize.c)
+endif()
+
+if(CONFIG_SENSORS_QENCODER)
+  list(APPEND SRCS stm32_qencoder.c)
+endif()
+
+if(CONFIG_STM32F7_CAN)
+  if(CONFIG_STM32F7_CAN_CHARDRIVER)
+    list(APPEND SRCS stm32_can.c)
+  endif()
+  if(CONFIG_STM32F7_CAN_SOCKET)
+    list(APPEND SRCS stm32_cansock.c)
+  endif()
+endif()
+
+if(CONFIG_USBDEV_COMPOSITE)
+  list(APPEND SRCS stm32_composite.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+if(CONFIG_ARCH_CHIP_STM32F722ZE)
+  set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/f722-flash.ld")
+elseif(CONFIG_ARCH_CHIP_STM32F746ZG)
+  set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/f746-flash.ld")
+elseif(CONFIG_ARCH_CHIP_STM32F767ZI)
+  set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/f767-flash.ld")
+endif()

--- a/boards/arm/stm32f7/steval-eth001v1/CMakeLists.txt
+++ b/boards/arm/stm32f7/steval-eth001v1/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32f7/steval-eth001v1/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32f7/steval-eth001v1/src/CMakeLists.txt
+++ b/boards/arm/stm32f7/steval-eth001v1/src/CMakeLists.txt
@@ -1,0 +1,33 @@
+############################################################################
+# boards/arm/stm32f7/steval-eth001v1/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+set(SRCS stm32_boot.c stm32_bringup.c)
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+if(CONFIG_STM32F7_FOC)
+  list(APPEND SRCS stm32_foc.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash.ld")

--- a/boards/arm/stm32f7/stm32f746-ws/CMakeLists.txt
+++ b/boards/arm/stm32f7/stm32f746-ws/CMakeLists.txt
@@ -1,0 +1,21 @@
+############################################################################
+# boards/arm/stm32f7/stm32f746-ws/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32f7/stm32f746-ws/src/CMakeLists.txt
+++ b/boards/arm/stm32f7/stm32f746-ws/src/CMakeLists.txt
@@ -1,0 +1,37 @@
+############################################################################
+# boards/arm/stm32f7/stm32f746-ws/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+set(SRCS stm32_boot.c stm32_spi.c stm32_dma_alloc.c)
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinitialize.c)
+endif()
+
+if(CONFIG_STM32F7_OTGFS)
+  list(APPEND SRCS stm32_usb.c)
+endif()
+
+if(CONFIG_STM32F7_SDMMC1)
+  list(APPEND SRCS stm32_sdmmc.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash.ld")

--- a/boards/arm/stm32f7/stm32f746g-disco/CMakeLists.txt
+++ b/boards/arm/stm32f7/stm32f746g-disco/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32f7/stm32f746-disco/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32f7/stm32f746g-disco/src/CMakeLists.txt
+++ b/boards/arm/stm32f7/stm32f746g-disco/src/CMakeLists.txt
@@ -1,0 +1,77 @@
+# ##############################################################################
+# boards/arm/stm32f7/stm32f746-disco/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_spi.c stm32_bringup.c)
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS stm32_autoleds.c)
+else()
+  list(APPEND SRCS stm32_userleds.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS  stm32_buttons.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinitialize.c)
+endif()
+
+if(CONFIG_ADC)
+  list(APPEND SRCS stm32_adc.c)
+endif()
+
+if(CONFIG_SPORADIC_INSTRUMENTATION)
+  list(APPEND SRCS stm32_sporadic.c)
+endif()
+
+if(CONFIG_STM32F7_LTDC)
+  list(APPEND SRCS stm32_lcd.c)
+endif()
+
+if(CONFIG_STM32F7_FMC)
+  list(APPEND SRCS stm32_extmem.c)
+endif()
+
+if(CONFIG_INPUT_FT5X06)
+  list(APPEND SRCS stm32_touchscreen.c)
+endif()
+
+if(CONFIG_MTD_N25QXXX)
+  list(APPEND SRCS stm32_n25q.c)
+endif()
+
+if(CONFIG_STM32F7_OTGFS)
+  list(APPEND SRCS stm32_usb.c)
+elseif(CONFIG_STM32F7_OTGFSHS)
+  list(APPEND SRCS stm32_usb.c)
+endif()
+
+if(CONFIG_STM32F7_SDMMC)
+  list(APPEND SRCS stm32_sdmmc.c)
+endif()
+
+if(CONFIG_AUDIO_WM8994)
+  list(APPEND SRCS stm32_wm8994.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash.ld")

--- a/boards/arm/stm32f7/stm32f769i-disco/CMakeLists.txt
+++ b/boards/arm/stm32f7/stm32f769i-disco/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32f7/stm32f769i-disco/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32f7/stm32f769i-disco/src/CMakeLists.txt
+++ b/boards/arm/stm32f7/stm32f769i-disco/src/CMakeLists.txt
@@ -1,0 +1,51 @@
+# ##############################################################################
+# boards/arm/stm32f7/stm32f769i-disco/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_bringup.c stm32_spi.c)
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS stm32_autoleds.c)
+else()
+  list(APPEND SRCS stm32_userleds.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS stm32_buttons.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinitialize.c)
+endif()
+
+if(CONFIG_PWM)
+  list(APPEND SRCS stm32_pwm.c)
+endif()
+
+if(CONFIG_SPORADIC_INSTRUMENTATION)
+  list(APPEND SRCS stm32_sporadic.c)
+endif()
+
+if(CONFIG_STM32F7_FMC)
+  list(APPEND SRCS stm32_extmem.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash.ld")

--- a/boards/arm/stm32f7/stm32f777zit6-meadow/CMakeLists.txt
+++ b/boards/arm/stm32f7/stm32f777zit6-meadow/CMakeLists.txt
@@ -1,0 +1,21 @@
+############################################################################
+# boards/arm/stm32f7/stm32f77zit6-meadow/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32f7/stm32f777zit6-meadow/src/CMakeLists.txt
+++ b/boards/arm/stm32f7/stm32f777zit6-meadow/src/CMakeLists.txt
@@ -1,0 +1,60 @@
+############################################################################
+# boards/arm/stm32f7/stm32f77zit6-meadow/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+set(SRCS stm32_boot.c stm32_bringup.c stm32_spi.c)
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS stm32_autoleds.c)
+else()
+  list(APPEND SRCS stm32_userleds.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS  stm32_buttons.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinitialize.c)
+  if(CONFIG_BOARDCTL_IOCTL)
+    list(APPEND SRCS stm32_ioctl.c)
+  endif()
+endif()
+
+if(CONFIG_PWM)
+  list(APPEND SRCS stm32_pwm.c)
+endif()
+
+if(CONFIG_SPORADIC_INSTRUMENTATION)
+  list(APPEND SRCS stm32_sporadic.c)
+endif()
+
+if(CONFIG_STM32F7_FMC)
+  list(APPEND SRCS stm32_extmem.c)
+endif()
+
+if(CONFIG_STM32F7_OTGFS)
+  list(APPEND SRCS stm32_usb.c)
+elseif(CONFIG_STM32F7_OTGFSHS)
+  list(APPEND SRCS stm32_usb.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash.ld")

--- a/boards/arm/stm32h7/nucleo-h743zi/CMakeLists.txt
+++ b/boards/arm/stm32h7/nucleo-h743zi/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32h7/nucleo-h743zi/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32h7/nucleo-h743zi/src/CMakeLists.txt
+++ b/boards/arm/stm32h7/nucleo-h743zi/src/CMakeLists.txt
@@ -1,0 +1,130 @@
+# ##############################################################################
+# boards/arm/stm32h7/nucleo-h743zi/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_bringup.c)
+
+if(CONFIG_ADC)
+  list(APPEND SRCS stm32_adc.c)
+endif()
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS stm32_autoleds.c)
+else()
+  list(APPEND SRCS stm32_userleds.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS stm32_buttons.c)
+endif()
+
+if(CONFIG_STM32_ROMFS)
+  list(APPEND SRCS stm32_romfs_initialize.c)
+endif()
+
+if(CONFIG_STM32H7_SPI)
+  list(APPEND SRCS stm32_spi.c)
+endif()
+
+if(CONFIG_STM32H7_OTGFS)
+  list(APPEND SRCS stm32_usb.c)
+endif()
+
+if(CONFIG_BOARDCTL_UNIQUEID)
+  list(APPEND SRCS stm32_uid.c)
+endif()
+
+if(CONFIG_SENSORS_LSM6DSL)
+  list(APPEND SRCS stm32_lsm6dsl.c)
+endif()
+
+if(CONFIG_SENSORS_LSM9DS1)
+  list(APPEND SRCS stm32_lsm9ds1.c)
+endif()
+
+if(CONFIG_SENSORS_LSM303AGR)
+  list(APPEND SRCS stm32_lsm303agr.c)
+endif()
+
+if(CONFIG_PCA9635PW)
+  list(APPEND SRCS stm32_pca9635.c)
+endif()
+
+if(CONFIG_LCD_SSD1306)
+  list(APPEND SRCS stm32_ssd1306.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinitialize.c)
+endif()
+
+if(CONFIG_STM32H7_PROGMEM)
+  list(APPEND SRCS stm32_progmem.c)
+endif()
+
+if(CONFIG_WL_NRF24L01)
+  list(APPEND SRCS stm32_nrf24l01.c)
+endif()
+
+if(CONFIG_DEV_GPIO)
+  list(APPEND SRCS stm32_gpio.c)
+endif()
+
+if(CONFIG_PWM)
+  list(APPEND SRCS stm32_pwm.c)
+endif()
+
+if(CONFIG_BOARDCTL_RESET)
+  list(APPEND SRCS stm32_reset.c)
+endif()
+
+if(CONFIG_BOARDCTL_BOOT_IMAGE)
+  list(APPEND SRCS stm32_boot_image.c)
+endif()
+
+if(CONFIG_USBMSC)
+  list(APPEND SRCS stm32_usbmsc.c)
+endif()
+
+if(CONFIG_USBDEV_COMPOSITE)
+  list(APPEND SRCS stm32_composite.c)
+endif()
+
+if(CONFIG_MMCSD)
+  list(APPEND SRCS stm32_mmcsd.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+if(CONFIG_STM32_APP_FORMAT_MCUBOOT)
+  if(CONFIG_MCUBOOT_BOOTLOADER)
+    set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash-mcuboot-loader.ld")
+  else()
+    set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash-mcuboot-app.ld")
+  endif()
+else()
+  set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash.ld")
+endif()
+
+if(NOT CONFIG_BUILD_FLAT)
+  add_subdirectory(${NUTTX_BOARD_DIR}/kernel)
+  set_property(
+    GLOBAL PROPERTY LD_SCRIPT_USER ${NUTTX_BOARD_DIR}/scripts/memory.ld
+    ${NUTTX_BOARD_DIR}/scripts/user-space.ld)
+endif()

--- a/boards/arm/stm32h7/nucleo-h743zi2/CMakeLists.txt
+++ b/boards/arm/stm32h7/nucleo-h743zi2/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32h7/nucleo-h743zi2/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32h7/nucleo-h743zi2/src/CMakeLists.txt
+++ b/boards/arm/stm32h7/nucleo-h743zi2/src/CMakeLists.txt
@@ -1,0 +1,67 @@
+# ##############################################################################
+# boards/arm/stm32h7/nucleo-h743zi2/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_bringup.c)
+
+if(CONFIG_ADC)
+  list(APPEND SRCS stm32_adc.c)
+endif()
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS stm32_autoleds.c)
+else()
+  list(APPEND SRCS stm32_userleds.c)
+endif()
+
+if(CONFIG_STM32H7_OTGFS)
+  list(APPEND SRCS stm32_usb.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinitialize.c)
+endif()
+
+if(CONFIG_DEV_GPIO)
+  list(APPEND SRCS stm32_gpio.c)
+endif()
+
+if(CONFIG_PWM)
+  list(APPEND SRCS stm32_pwm.c)
+endif()
+
+if(CONFIG_SENSORS_QENCODER)
+  list(APPEND SRCS stm32_qencoder.c)
+endif()
+
+if(CONFIG_BOARDCTL_RESET)
+  list(APPEND SRCS stm32_reset.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash.ld")
+
+if(NOT CONFIG_BUILD_FLAT)
+  add_subdirectory(${NUTTX_BOARD_DIR}/kernel)
+  set_property(
+    GLOBAL PROPERTY LD_SCRIPT_USER ${NUTTX_BOARD_DIR}/scripts/memory.ld
+    ${NUTTX_BOARD_DIR}/scripts/user-space.ld)
+endif()
+

--- a/boards/arm/stm32h7/stm32h747i-disco/CMakeLists.txt
+++ b/boards/arm/stm32h7/stm32h747i-disco/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32h7/stm32h747i-disco/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32h7/stm32h747i-disco/src/CMakeLists.txt
+++ b/boards/arm/stm32h7/stm32h747i-disco/src/CMakeLists.txt
@@ -1,0 +1,70 @@
+# ##############################################################################
+# boards/arm/stm32h7/stm32h747i-disco/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_bringup.c)
+
+if(CONFIG_ADC)
+  list(APPEND SRCS stm32_adc.c)
+endif()
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS stm32_autoleds.c)
+else()
+  list(APPEND SRCS stm32_userleds.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS stm32_buttons.c)
+endif()
+
+if(CONFIG_STM32H7_SPI)
+  list(APPEND SRCS stm32_spi.c)
+endif()
+
+if(CONFIG_STM32H7_OTGHS)
+  list(APPEND SRCS stm32_usb.c)
+endif()
+
+if(CONFIG_BOARDCTL_UNIQUEID)
+  list(APPEND SRCS stm32_uid.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinitialize.c)
+endif()
+
+if(CONFIG_STM32H7_SDMMC)
+  list(APPEND SRCS stm32_sdmmc.c)
+endif()
+
+if(CONFIG_FAT_DMAMEMORY)
+  list(APPEND SRCS stm32_dma_alloc.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash.ld")
+
+if(NOT CONFIG_BUILD_FLAT)
+  add_subdirectory(${NUTTX_BOARD_DIR}/kernel)
+  set_property(
+    GLOBAL PROPERTY LD_SCRIPT_USER ${NUTTX_BOARD_DIR}/scripts/memory.ld
+    ${NUTTX_BOARD_DIR}/scripts/user-space.ld)
+endif()


### PR DESCRIPTION
## Summary

- cmake: sync arch/stm32/CMakeLists.txt with Make.defs
- cmake: add support for stm32f7
- cmake: add support for stm32h7
- cmake: convert some stm32 boards

## Impact

## Testing
nucleo-f446re/cansock
nucleo-h743zi/nsh
steval-eth001v1/nsh
