### PR TITLE
drivers/video: use kmm_free(buff) to free memory instead of realloc(b…

### DIFF
--- a/drivers/video/video_framebuff.c
+++ b/drivers/video/video_framebuff.c
@@ -103,18 +103,26 @@ int video_framebuff_realloc_container(video_framebuff_t *fbuf, int sz)
       return OK;
     }
 
-  vbuf = kmm_realloc(fbuf->vbuf_alloced, sizeof(vbuf_container_t) * sz);
-  if (vbuf != NULL)
+  if (sz > 0)
     {
-      memset(vbuf, 0, sizeof(vbuf_container_t) * sz);
+      vbuf = kmm_realloc(fbuf->vbuf_alloced, sizeof(vbuf_container_t) * sz);
+      if (vbuf != NULL)
+        {
+          memset(vbuf, 0, sizeof(vbuf_container_t) * sz);
+          fbuf->vbuf_alloced = vbuf;
+          fbuf->container_size = sz;
+        }
+      else
+        {
+          return -ENOMEM;
+        }
     }
-  else if (sz != 0)
+  else
     {
-      return -ENOMEM;
+      kmm_free(fbuf->vbuf_alloced);
+      fbuf->vbuf_alloced = NULL;
+      fbuf->container_size = 0;
     }
-
-  fbuf->vbuf_alloced = vbuf;
-  fbuf->container_size = sz;
 
   init_buf_chain(fbuf);
   return OK;


### PR DESCRIPTION
drivers/video: use kmm_free(buff) to free memory instead of realloc(buff, 0) which is abandoned
    
ref: https://github.com/apache/nuttx/pull/9151/commits/89d61f4eb4fd60ac88cd6a05b1957babcd4f9150