### PR TITLE
drivers/lcd: add area alignment ioctl for lcd driver

### DIFF
--- a/drivers/lcd/lcd_dev.c
+++ b/drivers/lcd/lcd_dev.c
@@ -272,6 +272,25 @@ static int lcddev_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         *((FAR int *)arg) = priv->lcd_ptr->getframerate(priv->lcd_ptr);
       }
       break;
+    case LCDDEVIO_GETAREAALIGN:
+      {
+        FAR struct lcddev_area_align_s *area_align =
+            (FAR struct lcddev_area_align_s *)arg;
+
+        if (priv->lcd_ptr->getareaalign == NULL)
+          {
+            area_align->row_start_align = 1;
+            area_align->height_align    = 1;
+            area_align->col_start_align = 1;
+            area_align->width_align     = 1;
+            area_align->buf_align       = sizeof(uintptr_t);
+          }
+        else
+          {
+            ret = priv->lcd_ptr->getareaalign(priv->lcd_ptr, area_align);
+          }
+      }
+      break;
     default:
       ret = -EINVAL;
       break;

--- a/include/nuttx/lcd/lcd.h
+++ b/include/nuttx/lcd/lcd.h
@@ -47,6 +47,19 @@
 
 struct lcd_dev_s;
 
+/* Some special LCD drivers require input data to be aligned.
+ * Such as starting row and column, width, height, data address, etc.
+ */
+
+struct lcddev_area_align_s
+{
+  uint16_t row_start_align; /* Start row index alignment */
+  uint16_t height_align;    /* Height alignment */
+  uint16_t col_start_align; /* Start column index alignment */
+  uint16_t width_align;     /* Width alignment */
+  uint16_t buf_align;       /* Buffer addr alignment */
+};
+
 /* This structure describes one color plane.  Some YUV formats may support
  * up to 4 planes (although they probably wouldn't be used on LCD hardware).
  * The framebuffer driver provides the video memory address in its
@@ -246,6 +259,11 @@ struct lcd_dev_s
   /* Get LCD panel frame rate (0: disable refresh) */
 
   int (*getframerate)(struct lcd_dev_s *dev);
+
+  /* Get LCD panel area alignment */
+
+  int (*getareaalign)(FAR struct lcd_dev_s *dev,
+                      FAR struct lcddev_area_align_s *align);
 };
 
 /****************************************************************************

--- a/include/nuttx/lcd/lcd_dev.h
+++ b/include/nuttx/lcd/lcd_dev.h
@@ -50,17 +50,19 @@
 #define LCDDEVIO_SETPLANENO   _LCDIOC(10) /* Arg: int */
 
 #ifdef CONFIG_FB_CMAP
-#define LCDDEVIO_GETCMAP      _LCDIOC(9)  /* Arg: struct fb_cmap_s* */
-#define LCDDEVIO_PUTCMAP      _LCDIOC(10) /* Arg: const struct fb_cmap_s* */
+#define LCDDEVIO_GETCMAP      _LCDIOC(11) /* Arg: struct fb_cmap_s* */
+#define LCDDEVIO_PUTCMAP      _LCDIOC(12) /* Arg: const struct fb_cmap_s* */
 #endif
 
 #ifdef CONFIG_FB_HWCURSOR
-#define LCDDEVIO_GETCURSOR    _LCDIOC(11) /* Arg: struct fb_cursorattrib_s* */
-#define LCDDEVIO_SETCURSOR    _LCDIOC(12) /* Arg: struct fb_setcursor_s* */
+#define LCDDEVIO_GETCURSOR    _LCDIOC(13) /* Arg: struct fb_cursorattrib_s* */
+#define LCDDEVIO_SETCURSOR    _LCDIOC(14) /* Arg: struct fb_setcursor_s* */
 #endif
 
-#define LCDDEVIO_SETFRAMERATE _LCDIOC(13) /* Arg: int */
-#define LCDDEVIO_GETFRAMERATE _LCDIOC(14) /* Arg: int* */
+#define LCDDEVIO_SETFRAMERATE _LCDIOC(15) /* Arg: int */
+#define LCDDEVIO_GETFRAMERATE _LCDIOC(16) /* Arg: int* */
+
+#define LCDDEVIO_GETAREAALIGN _LCDIOC(17) /* Arg: struct lcddev_area_align_s* */
 
 /****************************************************************************
  * Public Data


### PR DESCRIPTION
## Summary

Some special LCD drivers require input data to be aligned,  such as starting row and column, width, height, data address, etc.

So, we need to add a ioctl command to get the align requirement of LCD.

## Impact

LCD drivers

## Testing

