### PR TITLE
libs/libc/getpgid: add getpgid implementation

### DIFF
--- a/include/unistd.h
+++ b/include/unistd.h
@@ -310,6 +310,7 @@ extern "C"
 pid_t   fork(void);
 pid_t   vfork(void);
 pid_t   getpid(void);
+pid_t   getpgid(pid_t pid);
 pid_t   getpgrp(void);
 pid_t   gettid(void);
 pid_t   getppid(void);

--- a/libs/libc/unistd/Make.defs
+++ b/libs/libc/unistd/Make.defs
@@ -30,7 +30,7 @@ CSRCS += lib_setreuid.c lib_setregid.c lib_getrusage.c lib_utime.c lib_utimes.c
 CSRCS += lib_setrlimit.c lib_getrlimit.c lib_setpriority.c lib_getpriority.c
 CSRCS += lib_futimes.c lib_lutimes.c lib_gethostname.c lib_sethostname.c
 CSRCS += lib_fchownat.c lib_linkat.c lib_readlinkat.c lib_symlinkat.c
-CSRCS += lib_unlinkat.c lib_getpgrp.c
+CSRCS += lib_unlinkat.c lib_getpgrp.c lib_getpgid.c
 
 ifneq ($(CONFIG_SCHED_USER_IDENTITY),y)
 CSRCS += lib_setuid.c lib_setgid.c lib_getuid.c lib_getgid.c

--- a/libs/libc/unistd/lib_getpgid.c
+++ b/libs/libc/unistd/lib_getpgid.c
@@ -1,0 +1,73 @@
+/****************************************************************************
+ * libs/libc/unistd/lib_getpgid.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/sched.h>
+#include <nuttx/signal.h>
+
+#include <unistd.h>
+#include <errno.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: getpgid
+ *
+ * Description:
+ *   Get the Process Group ID of the required process id. But since NuttX do
+ *   not support process group, so the process group id are same as process
+ *   id, so this method will return the pid that transferred in directly,
+ *   which is same as getpgrp() method
+ *
+ * Input parameters:
+ *   pid - the process id that required to fetch the process group id
+ *
+ * Returned Value:
+ *   getpgid() shall return a process group ID. Otherwise, it shall return
+ *   (pid_t)-1 and set errno to indicate the error. If the given process id
+ *   are invalid, set errno as EINVAL, if the given process id do not exist,
+ *   set errno as ESRCH
+ *
+ ****************************************************************************/
+
+pid_t getpgid(pid_t pid)
+{
+  if (pid < 0)
+    {
+      set_errno(EINVAL);
+      return INVALID_PROCESS_ID;
+    }
+
+  if (pid == 0)
+    {
+      return getpgrp();
+    }
+  else if (_SIG_KILL(pid, 0) < 0)
+    {
+      return INVALID_PROCESS_ID;
+    }
+
+  return pid;
+}


### PR DESCRIPTION
## Summary
1. the getpgid function can help to pass the ltp/open_posix_testsuite/killpg related testcases
2. NuttX do not support process group, so we use the process id as process group id
3. the implementation are referred to: https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpgid.html

## Impact

## Testing

