### PR TITLE
signal: SIGKILL or SIGSTOP cannot be caught

### DIFF
--- a/include/signal.h
+++ b/include/signal.h
@@ -39,7 +39,6 @@
 
 #define MIN_SIGNO       1               /* Lowest valid signal number */
 #define MAX_SIGNO       63              /* Highest valid signal number */
-#define GOOD_SIGNO(s)   ((((unsigned)(s)) <= MAX_SIGNO))
 
 /* Definitions for "standard" signals */
 
@@ -236,7 +235,10 @@
 #  define SIG_HOLD      ((_sa_handler_t)1)   /* Used only with sigset() */
 #endif
 
-#define tkill(tid, signo)  tgkill((pid_t)-1, tid, signo)
+#define GOOD_SIGNO(s)     (((unsigned)(s)) <= MAX_SIGNO)
+#define UNCAUGHT_SIGNO(s) ((s) == SIGKILL || (s) == SIGSTOP)
+
+#define tkill(tid, signo) tgkill((pid_t)-1, tid, signo)
 
 /****************************************************************************
  * Public Types

--- a/libs/libc/signal/sig_set.c
+++ b/libs/libc/signal/sig_set.c
@@ -101,7 +101,7 @@ _sa_handler_t sigset(int signo, _sa_handler_t func)
   sigset_t set;
   int ret = -EINVAL;
 
-  if (signo == SIGKILL || signo == SIGSTOP || !GOOD_SIGNO(signo))
+  if (!GOOD_SIGNO(signo) || UNCAUGHT_SIGNO(signo))
     {
       goto err;
     }

--- a/libs/libc/signal/sig_signal.c
+++ b/libs/libc/signal/sig_signal.c
@@ -62,7 +62,7 @@ _sa_handler_t signal(int signo, _sa_handler_t func)
   struct sigaction oact;
   int ret = -EINVAL;
 
-  if (!GOOD_SIGNO(signo))
+  if (!GOOD_SIGNO(signo) || UNCAUGHT_SIGNO(signo))
     {
       goto err;
     }

--- a/sched/signal/sig_default.c
+++ b/sched/signal/sig_default.c
@@ -135,7 +135,7 @@ static const struct nxsig_defaction_s g_defactions[] =
   { SIGVTALRM, 0,                nxsig_abnormal_termination },
 #endif
 #ifdef CONFIG_SIG_SIGSTOP_ACTION
-  { SIGCONT,   SIG_FLAG_NOCATCH, nxsig_null_action },
+  { SIGCONT,   0,                nxsig_null_action },
   { SIGSTOP,   SIG_FLAG_NOCATCH, nxsig_stop_task },
   { SIGTSTP,   0,                nxsig_stop_task },
   { SIGTTIN,   0,                nxsig_stop_task },


### PR DESCRIPTION
## Summary
From posix spec, SIGKILL and SIGSTOP cannot be caught, and shall not be added to the signal mask, this restriction shall be enforced by the system. 

SIGCONT can be caught. When SIGCONT is dispatched, resume all members of the task group. So there is nothing do in default action.

https://pubs.opengroup.org/onlinepubs/007904875/functions/sigaction.html
https://pubs.opengroup.org/onlinepubs/007904875/functions/sigset.html

## Impact
None
## Testing
sim LTP sigaction case
