### PR TITLE
arch/arm64: Enable ARCH_FPU for qemu-armv8a:netnsh_smp and netnsh_smp_hv

### DIFF
--- a/boards/arm64/qemu/qemu-armv8a/configs/netnsh_smp/defconfig
+++ b/boards/arm64/qemu/qemu-armv8a/configs/netnsh_smp/defconfig
@@ -5,7 +5,6 @@
 # You can then do "make savedefconfig" to generate a new defconfig file that includes your
 # modifications.
 #
-# CONFIG_ARCH_FPU is not set
 CONFIG_ALLOW_BSD_COMPONENTS=y
 CONFIG_ARCH="arm64"
 CONFIG_ARCH_ARM64=y

--- a/boards/arm64/qemu/qemu-armv8a/configs/netnsh_smp_hv/defconfig
+++ b/boards/arm64/qemu/qemu-armv8a/configs/netnsh_smp_hv/defconfig
@@ -5,7 +5,6 @@
 # You can then do "make savedefconfig" to generate a new defconfig file that includes your
 # modifications.
 #
-# CONFIG_ARCH_FPU is not set
 CONFIG_ALLOW_BSD_COMPONENTS=y
 CONFIG_ARCH="arm64"
 CONFIG_ARCH_ARM64=y


### PR DESCRIPTION
## Summary
When reading https://github.com/apache/nuttx-apps/pull/1793, I found a previous problem https://github.com/apache/nuttx-apps/pull/1454#discussion_r1045718067 now still exist on current master (`inf` in `iperf` bandwidth).

By step-by-step debugging, I found a value of `1000000.0` stored in register `d8` is overwritten as `0` after context switch, then `fdiv` results in `inf` because of divided by `0`. Finally I found that `ARCH_FPU` is not enabled while compiler is using FPU, and may lose values in floating-point registers.

## Impact
`qemu-armv8a:netnsh_smp` and `qemu-armv8a:netnsh_smp_hv`

## Testing
Manually
