### PR TITLE
add refcnt using epoll_create to fix bug when use popen which dup the fd and close at end after epoll_create

### DIFF
--- a/drivers/power/battery/battery_charger.c
+++ b/drivers/power/battery/battery_charger.c
@@ -415,8 +415,8 @@ static int bat_charger_ioctl(FAR struct file *filep, int cmd,
  * Name: bat_charger_poll
  ****************************************************************************/
 
-static ssize_t bat_charger_poll(FAR struct file *filep,
-                                struct pollfd *fds, bool setup)
+static int bat_charger_poll(FAR struct file *filep,
+                            FAR struct pollfd *fds, bool setup)
 {
   FAR struct battery_charger_priv_s *priv = filep->f_priv;
   int ret;

--- a/drivers/power/battery/battery_gauge.c
+++ b/drivers/power/battery/battery_gauge.c
@@ -373,8 +373,8 @@ static int bat_gauge_ioctl(FAR struct file *filep,
  * Name: bat_gauge_poll
  ****************************************************************************/
 
-static ssize_t bat_gauge_poll(FAR struct file *filep,
-                                struct pollfd *fds, bool setup)
+static int bat_gauge_poll(FAR struct file *filep,
+                          FAR struct pollfd *fds, bool setup)
 {
   FAR struct battery_gauge_priv_s *priv = filep->f_priv;
   int ret;

--- a/drivers/power/battery/battery_monitor.c
+++ b/drivers/power/battery/battery_monitor.c
@@ -452,8 +452,8 @@ static int bat_monitor_ioctl(FAR struct file *filep, int cmd,
  * Name: bat_monitor_poll
  ****************************************************************************/
 
-static ssize_t bat_monitor_poll(FAR struct file *filep,
-                                struct pollfd *fds, bool setup)
+static int bat_monitor_poll(FAR struct file *filep,
+                            FAR struct pollfd *fds, bool setup)
 {
   FAR struct battery_monitor_priv_s *priv = filep->f_priv;
   int ret;

--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -848,7 +848,7 @@ static ssize_t uart_read(FAR struct file *filep,
 
               /* Discarding \r ? */
 
-              if ((ch == '\r') & (dev->tc_iflag & IGNCR))
+              if ((ch == '\r') && (dev->tc_iflag & IGNCR))
                 {
                   continue;
                 }

--- a/fs/vfs/fs_epoll.c
+++ b/fs/vfs/fs_epoll.c
@@ -246,6 +246,8 @@ static int epoll_do_create(int size, int flags)
       list_add_tail(&eph->free, &epn[i].node);
     }
 
+  eph->crefs++;
+
   /* Alloc the file descriptor */
 
   fd = file_allocate(&g_epoll_inode, flags, 0, eph, 0, true);

--- a/include/nuttx/power/battery_monitor.h
+++ b/include/nuttx/power/battery_monitor.h
@@ -296,7 +296,7 @@ struct battery_monitor_operations_s
 
   /* Get chip id */
 
-  CODE int (*chipid)(FAR struct battery_charger_dev_s *dev,
+  CODE int (*chipid)(FAR struct battery_monitor_dev_s *dev,
                      FAR unsigned int *value);
 };
 


### PR DESCRIPTION
## Summary

1.use epoll_create create fd
2.use popen exec sh cmd
3.the epoll fd is not vaild,because of the refcnt is 0

## Impact

## Testing

