### PR TITLE
add refcnt using epoll_create to fix bug when use popen which dup the fd and close at end after epoll_create

### DIFF
--- a/fs/vfs/fs_epoll.c
+++ b/fs/vfs/fs_epoll.c
@@ -246,6 +246,8 @@ static int epoll_do_create(int size, int flags)
       list_add_tail(&eph->free, &epn[i].node);
     }
 
+  eph->crefs++;
+
   /* Alloc the file descriptor */
 
   fd = file_allocate(&g_epoll_inode, flags, 0, eph, 0, true);


### PR DESCRIPTION


## Summary
add refcnt using epoll_create to fix bug when use popen which dup the fd and close at end after epoll_create
## Impact

## Testing
1.use epoll_create create fd
2.use popen exec sh cmd
3.the epoll fd is not vaild,because of the refcnt is 0

