### PR TITLE
xtensa_saveusercontext:Leave the context information empty

### DIFF
--- a/arch/xtensa/src/common/xtensa_saveusercontext.c
+++ b/arch/xtensa/src/common/xtensa_saveusercontext.c
@@ -23,6 +23,9 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/irq.h>
+
+#include <string.h>
 
 #include <arch/syscall.h>
 
@@ -46,5 +49,13 @@
 
 int up_saveusercontext(void *saveregs)
 {
+  if (up_interrupt_context())
+    {
+      /* TODO: save interrupt context */
+
+      memset(saveregs, 0x0, XCPTCONTEXT_SIZE);
+      return 0;
+    }
+
   return sys_call1(SYS_save_context, (uintptr_t)saveregs);
 }


### PR DESCRIPTION
## Summary
In the current implementation of other architectures, it is not really implemented to preserve the context, so it is emulated from other architectures to clear the context. If this behavior is not implemented, it will cause the xtensa architecture processor to loop assert in the active assert case

## Impact

## Testing

