### PR TITLE
arm_gicv2: accesses the non-secure copy in non-secure state

### DIFF
--- a/arch/arm/src/armv7-a/arm_gicv2.c
+++ b/arch/arm/src/armv7-a/arm_gicv2.c
@@ -189,7 +189,7 @@ void arm_gic_initialize(void)
 #elif defined(CONFIG_ARCH_TRUSTZONE_NONSECURE)
   /* Clear non-secure state ICCICR bits to be configured below */
 
-  iccicr &= ~(GIC_ICCICRS_EOIMODENS | GIC_ICCICRU_ENABLEGRP1 |
+  iccicr &= ~(GIC_ICCICRU_EOIMODENS | GIC_ICCICRU_ENABLEGRP1 |
               GIC_ICCICRU_FIQBYPDISGRP1 | GIC_ICCICRU_IRQBYPDISGRP1);
 
 #endif
@@ -260,7 +260,7 @@ void arm_gic_initialize(void)
    * NOTE:  Only for processors that operate in non-secure state.
    */
 
-  iccicr |= GIC_ICCICRS_EOIMODENS;
+  iccicr |= GIC_ICCICRU_EOIMODENS;
 
 #  elif defined(CONFIG_ARCH_TRUSTZONE_BOTH)
   /* Set EnableNS=1 to enable the CPU to signal non-secure interrupts.
@@ -268,7 +268,7 @@ void arm_gic_initialize(void)
    * NOTE:  Only for processors that operate in non-secure state.
    */
 
-  iccicr |= GIC_ICCICRU_EOIMODENS;
+  iccicr |= GIC_ICCICRS_EOIMODENS;
 #  endif
 #endif
 

--- a/arch/arm/src/armv7-r/arm_gicv2.c
+++ b/arch/arm/src/armv7-r/arm_gicv2.c
@@ -189,7 +189,7 @@ void arm_gic_initialize(void)
 #elif defined(CONFIG_ARCH_TRUSTZONE_NONSECURE)
   /* Clear non-secure state ICCICR bits to be configured below */
 
-  iccicr &= ~(GIC_ICCICRS_EOIMODENS     |
+  iccicr &= ~(GIC_ICCICRU_EOIMODENS     |
               GIC_ICCICRU_ENABLEGRP1    |
               GIC_ICCICRU_FIQBYPDISGRP1 |
               GIC_ICCICRU_IRQBYPDISGRP1);
@@ -244,7 +244,7 @@ void arm_gic_initialize(void)
    * NOTE:  Only for processors that operate in non-secure state.
    */
 
-  iccicr |= GIC_ICCICRS_EOIMODENS;
+  iccicr |= GIC_ICCICRU_EOIMODENS;
 
 #  elif defined(CONFIG_ARCH_TRUSTZONE_BOTH)
   /* Set EnableNS=1 to enable the CPU to signal non-secure interrupts.
@@ -252,7 +252,7 @@ void arm_gic_initialize(void)
    * NOTE:  Only for processors that operate in non-secure state.
    */
 
-  iccicr |= GIC_ICCICRU_EOIMODENS;
+  iccicr |= GIC_ICCICRS_EOIMODENS;
 #  endif
 #endif
 


### PR DESCRIPTION
## Summary

Fixed the incorrect usage of the iccicr register, accesses the non-secure copy in non-secure state.

## Impact

GICv2

## Testing

BES borad with armv7a