### PR TITLE
arm64: Use the correct cpu id for fpu idle task init

### DIFF
--- a/arch/arm64/src/common/arm64_fpu.c
+++ b/arch/arm64/src/common/arm64_fpu.c
@@ -270,11 +270,16 @@ void arm64_init_fpu(struct tcb_s *tcb)
 {
   if (tcb->pid < CONFIG_SMP_NCPUS)
     {
-      memset(&g_cpu_fpu_ctx[this_cpu()], 0,
+#ifdef CONFIG_SMP
+      int cpu = tcb->cpu;
+#else
+      int cpu = 0;
+#endif
+      memset(&g_cpu_fpu_ctx[cpu], 0,
              sizeof(struct arm64_cpu_fpu_context));
-      g_cpu_fpu_ctx[this_cpu()].idle_thread = tcb;
+      g_cpu_fpu_ctx[cpu].idle_thread = tcb;
 
-      tcb->xcp.fpu_regs = (uint64_t *)&g_idle_thread_fpu[this_cpu()];
+      tcb->xcp.fpu_regs = (uint64_t *)&g_idle_thread_fpu[cpu];
     }
 
   memset(tcb->xcp.fpu_regs, 0, sizeof(struct fpu_reg));


### PR DESCRIPTION
## Summary

Use the correct cpu id for fpu idle task init.

## Impact

ARM64

## Testing

fvp-armv8r:nsh_smp