### PR TITLE
libs: fix visual studio Compiler Error C2036

### DIFF
--- a/include/nuttx/net/netfilter/ip_tables.h
+++ b/include/nuttx/net/netfilter/ip_tables.h
@@ -285,7 +285,7 @@ struct ipt_get_entries
 static inline FAR struct xt_entry_target *
 ipt_get_target(FAR struct ipt_entry *e)
 {
-  return (FAR void *)e + e->target_offset;
+  return (FAR char *)e + e->target_offset;
 }
 
 #endif /* __INCLUDE_NUTTX_NET_NETFILTER_IP_TABLES_H */

--- a/mm/mempool/mempool_multiple.c
+++ b/mm/mempool/mempool_multiple.c
@@ -193,13 +193,13 @@ retry:
     }
 
   ret = (FAR void *)ALIGN_UP(chunk->next, align);
-  if (chunk->end - ret < size)
+  if ((uintptr_t)chunk->end - (uintptr_t)ret < size)
     {
       goto retry;
     }
 
   chunk->used++;
-  chunk->next = ret + size;
+  chunk->next = (FAR char *)ret + size;
   return ret;
 }
 
@@ -738,7 +738,7 @@ mempool_multiple_mallinfo(FAR struct mempool_multiple_s *mpool)
       FAR struct mpool_chunk_s *chunk;
 
       chunk = (FAR struct mpool_chunk_s *)sq_peek(&mpool->chunk_queue);
-      info.fordblks += chunk->end - chunk->next;
+      info.fordblks += (uintptr_t)chunk->end - (uintptr_t)chunk->next;
     }
 
   nxmutex_unlock(&mpool->lock);


### PR DESCRIPTION
## Summary

libs: fix visual studio Compiler Error C2036

D:\code\nuttx\include\nuttx\net\netfilter\ip_tables.h(288,42): error C2036: "void *" : unknown size

Reference:
https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2036?view=msvc-170

## Impact

N/A

## Testing

ci-check