### PR TITLE
cmake/win32: set default LINK_STACKSIZE to avoid stack overflow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -603,6 +603,10 @@ if(NOT CONFIG_ARCH_SIM)
   endif()
 elseif(WIN32)
   target_link_options(nuttx PUBLIC /SAFESEH:NO)
+  math(EXPR LINK_STACKSIZE
+       "${CONFIG_SIM_STACKSIZE_ADJUSTMENT} + ${CONFIG_IDLETHREAD_STACKSIZE}"
+       OUTPUT_FORMAT DECIMAL)
+  target_link_options(nuttx PUBLIC /STACK:${LINK_STACKSIZE},${LINK_STACKSIZE})
   set(nuttx_libs_paths)
   foreach(lib ${nuttx_libs})
     list(APPEND nuttx_libs_paths $<TARGET_FILE:${lib}>)


### PR DESCRIPTION
## Summary

cmake/win32: set default LINK_STACKSIZE to avoid stack overflow


## Impact

N/A

## Testing

cmake 