### PR TITLE
vfork: modify struct vfork_s

### DIFF
--- a/arch/arm/src/common/arm_fork.c
+++ b/arch/arm/src/common/arm_fork.c
@@ -103,8 +103,8 @@ pid_t up_fork(const struct fork_s *context)
         context->r4, context->r5, context->r6, context->r7);
   sinfo("  r8:%08" PRIx32 " r9:%08" PRIx32 " r10:%08" PRIx32 "\n",
         context->r8, context->r9, context->r10);
-  sinfo("  fp:%08" PRIx32 " sp:%08" PRIx32 " lr:%08" PRIx32 "\n",
-        context->fp, context->sp, context->lr);
+  sinfo("  r11:%08" PRIx32 " sp:%08" PRIx32 " lr:%08" PRIx32 "\n",
+        context->r11, context->sp, context->lr);
 
   /* Allocate and initialize a TCB for the child task. */
 
@@ -182,6 +182,7 @@ pid_t up_fork(const struct fork_s *context)
   child->cmn.xcp.regs[REG_R8]  = context->r8;  /* Volatile register r8 */
   child->cmn.xcp.regs[REG_R9]  = context->r9;  /* Volatile register r9 */
   child->cmn.xcp.regs[REG_R10] = context->r10; /* Volatile register r10 */
+  child->cmn.xcp.regs[REG_R11] = context->r11; /* Volatile register r11 */
   child->cmn.xcp.regs[REG_FP]  = newfp;        /* Frame pointer */
   child->cmn.xcp.regs[REG_SP]  = newsp;        /* Stack pointer */
 

--- a/arch/arm/src/common/arm_fork.h
+++ b/arch/arm/src/common/arm_fork.h
@@ -54,17 +54,30 @@ struct fork_s
 {
   /* CPU registers */
 
-  uint32_t r4;   /* Volatile register r4 */
-  uint32_t r5;   /* Volatile register r5 */
-  uint32_t r6;   /* Volatile register r6 */
-  uint32_t r7;   /* Volatile register r7 */
-  uint32_t r8;   /* Volatile register r8 */
-  uint32_t r9;   /* Volatile register r9 */
-  uint32_t r10;  /* Volatile register r10 */
+  uint32_t r4;          /* Volatile register r4 */
+  uint32_t r5;          /* Volatile register r5 */
+  uint32_t r6;          /* Volatile register r6 */
+  union
+    {
+      uint32_t r7;      /* Volatile register r7 */
+#ifdef CONFIG_ARM_THUMB
+      uint32_t fp;      /* Frame pointer */
+#endif
+    };
 
-  uint32_t fp;   /* Frame pointer */
-  uint32_t sp;   /* Stack pointer */
-  uint32_t lr;   /* Return address */
+  uint32_t r8;          /* Volatile register r8 */
+  uint32_t r9;          /* Volatile register r9 */
+  uint32_t r10;         /* Volatile register r10 */
+  union
+    {
+      uint32_t r11;     /* Volatile register r11 */
+#ifndef CONFIG_ARM_THUMB
+      uint32_t fp;      /* Frame pointer */
+#endif
+    };
+
+  uint32_t sp;          /* Stack pointer */
+  uint32_t lr;          /* Return address */
 
   /* Floating point registers (not yet) */
 };

--- a/arch/arm/src/common/gnu/fork.S
+++ b/arch/arm/src/common/gnu/fork.S
@@ -92,8 +92,8 @@ fork:
 	mov		r4, r8			/* Copy high registers to low registers */
 	mov		r5, r9
 	mov		r6, r10
-	mov		r7, fp
-	stmia		r1!, {r4-r7}		/* Save r8-r10 and fp in the structure */
+	mov		r7, r11
+	stmia		r1!, {r4-r7}		/* Save r8-r11 in the structure */
 	mov		r5, lr			/* Copy lr to a low register */
 	stmia		r1!, {r0,r5}		/* Save sp and lr in the structure */
 


### PR DESCRIPTION
## Summary
fp is just an alias of r11, it  not really used for framepointer in t32 mode.

## Impact
vfork

## Testing

