### PR TITLE
assert: check intstack_sp when print last stack in irq context

### DIFF
--- a/arch/renesas/include/irq.h
+++ b/arch/renesas/include/irq.h
@@ -64,6 +64,7 @@ extern "C"
  */
 
 EXTERN volatile uint32_t *g_current_regs;
+#define CURRENT_REGS g_current_regs
 
 /****************************************************************************
  * Public Function Prototypes


### PR DESCRIPTION
## Summary
    1、correct arguement of up_getusrsp
    2、move up_getusrsp to line 247, therefore, tcbstack can be printed
    correctly when sp is not within irq nor within tcbstack.
    3、check tcbstack from up_getusrsp
    4、remove force arguement for dump_stack
## Impact

## Testing

