### PR TITLE
rpmsgblk: get return value from header

### DIFF
--- a/drivers/misc/rpmsgblk.c
+++ b/drivers/misc/rpmsgblk.c
@@ -838,6 +838,7 @@ static int rpmsgblk_geometry_handler(FAR struct rpmsg_endpoint *ept,
       (FAR struct rpmsgblk_cookie_s *)(uintptr_t)header->cookie;
   FAR struct rpmsgblk_geometry_s *rsp = data;
 
+  cookie->result = header->result;
   if (cookie->result >= 0 && rsp->arglen > 0)
     {
       memcpy(cookie->data, rsp->buf, rsp->arglen);
@@ -874,6 +875,7 @@ static int rpmsgblk_ioctl_handler(FAR struct rpmsg_endpoint *ept,
       (FAR struct rpmsgblk_cookie_s *)(uintptr_t)header->cookie;
   FAR struct rpmsgblk_ioctl_s *rsp = data;
 
+  cookie->result = header->result;
   if (cookie->result >= 0 && rsp->arglen > 0)
     {
       memcpy(cookie->data, rsp->buf, rsp->arglen);


### PR DESCRIPTION
## Summary
cookie->result as the return value of rpmsg operations, it should get from remote response.
## Impact

## Testing

