### PR TITLE
arch/sparc/src/bm3823/bm3823.h: Fix the name of the constant BM3823_Is_interrupt_pending

### DIFF
--- a/arch/sparc/src/bm3823/bm3823.h
+++ b/arch/sparc/src/bm3823/bm3823.h
@@ -399,7 +399,7 @@ static __inline__ int bsp_irq_fixup(int irq)
     INTER_REG.Interrupt_Force = (1 << (_source)); \
   } while (0)
 
-#define BM3823_Is_int										   errupt_pending( _source ) \
+#define BM3823_Is_interrupt_pending( _source ) \
   (INTER_REG.Interrupt_Pending & (1 << (_source)))
 
 #define BM3823_Is_interrupt_masked( _source ) \


### PR DESCRIPTION
## Summary
Remove TABs and spaces from the name of the constant BM3823_Is_interrupt_pending
## Impact

## Testing

