### PR TITLE
cmake: support arm libm and more stm32 boards

### DIFF
--- a/boards/arm/stm32/common/src/CMakeLists.txt
+++ b/boards/arm/stm32/common/src/CMakeLists.txt
@@ -124,4 +124,8 @@ if(CONFIG_BOARD_STM32_IHM08M1)
   list(APPEND SRCS stm32_ihm08m1.c)
 endif()
 
+if(CONFIG_BOARD_STM32_IHM16M1)
+  list(APPEND SRCS stm32_ihm16m1.c)
+endif()
+
 target_sources(board PRIVATE ${SRCS})

--- a/boards/arm/stm32/nucleo-f103rb/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-f103rb/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# boards/arm/stm32/b-g431b-esc1/CMakeLists.txt
+# boards/arm/stm32/nucleo-f103rb/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for

--- a/boards/arm/stm32/nucleo-f103rb/src/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-f103rb/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 ############################################################################
-# boards/arm/stm32/b-g431b-esc1/src/CMakeLists.txt
+# boards/arm/stm32/nucleo-f103rb/src/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance with the
 # License.  You may obtain a copy of the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+#  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
@@ -34,17 +34,18 @@ if(CONFIG_BOARDCTL)
   list(APPEND SRCS stm32_appinit.c)
 endif()
 
-if(CONFIG_STM32_FOC)
-  list(APPEND SRCS stm32_foc.c)
+if(NOT CONFIG_STM32_FOC)
+  if(CONFIG_ADC)
+    list(APPEND SRCS stm32_adc.c)
+  endif()
+
+  if(CONFIG_PWM)
+    list(APPEND SRCS stm32_pwm.c)
+  endif()
 endif()
 
-if(CONFIG_STM32_FDCAN)
-  if(CONFIG_STM32_FDCAN_CHARDRIVER)
-    list(APPEND SRCS stm32_can.c)
-  endif()
-  if(CONFIG_STM32_FDCAN_SOCKET)
-    list(APPEND SRCS stm32_cansock.c)
-  endif()
+if(CONFIG_BOARD_STM32_IHM07M1)
+  list(APPEND SRCS stm32_foc_ihm07m1.c)
 endif()
 
 target_sources(board PRIVATE ${SRCS})

--- a/boards/arm/stm32/nucleo-f207zg/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-f207zg/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# boards/arm/stm32/b-g431b-esc1/CMakeLists.txt
+# boards/arm/stm32/nucleo-f207zg/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for

--- a/boards/arm/stm32/nucleo-f207zg/src/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-f207zg/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 ############################################################################
-# boards/arm/stm32/b-g431b-esc1/src/CMakeLists.txt
+# boards/arm/stm32/nucleo-f207zg/src/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance with the
 # License.  You may obtain a copy of the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+#  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
@@ -30,21 +30,20 @@ if(CONFIG_ARCH_BUTTONS)
   list(APPEND SRCS stm32_buttons.c)
 endif()
 
+if(CONFIG_STM32_OTGFS)
+  list(APPEND SRCS stm32_usb.c)
+endif()
+
 if(CONFIG_BOARDCTL)
-  list(APPEND SRCS stm32_appinit.c)
+  list(APPEND SRCS stm32_appinitialize.c)
 endif()
 
-if(CONFIG_STM32_FOC)
-  list(APPEND SRCS stm32_foc.c)
+if(CONFIG_ADC)
+  list(APPEND SRCS stm32_adc.c)
 endif()
 
-if(CONFIG_STM32_FDCAN)
-  if(CONFIG_STM32_FDCAN_CHARDRIVER)
-    list(APPEND SRCS stm32_can.c)
-  endif()
-  if(CONFIG_STM32_FDCAN_SOCKET)
-    list(APPEND SRCS stm32_cansock.c)
-  endif()
+if(CONFIG_PWM)
+  list(APPEND SRCS stm32_pwm.c)
 endif()
 
 target_sources(board PRIVATE ${SRCS})

--- a/boards/arm/stm32/nucleo-f303re/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-f303re/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# boards/arm/stm32/b-g431b-esc1/CMakeLists.txt
+# boards/arm/stm32/nucleo-f303re/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for

--- a/boards/arm/stm32/nucleo-f303re/src/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-f303re/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 ############################################################################
-# boards/arm/stm32/b-g431b-esc1/src/CMakeLists.txt
+# boards/arm/stm32/nucleo-f303re/src/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -18,7 +18,7 @@
 #
 ############################################################################
 
-set(SRCS stm32_boot.c stm32_bringup.c)
+set(SRCS stm32_boot.c)
 
 if(CONFIG_ARCH_LEDS)
   list(APPEND SRCS stm32_autoleds.c)
@@ -31,20 +31,39 @@ if(CONFIG_ARCH_BUTTONS)
 endif()
 
 if(CONFIG_BOARDCTL)
-  list(APPEND SRCS stm32_appinit.c)
+  list(APPEND SRCS stm32_appinitialize.c)
 endif()
 
-if(CONFIG_STM32_FOC)
-  list(APPEND SRCS stm32_foc.c)
+if(CONFIG_ADC)
+  list(APPEND SRCS stm32_adc.c)
 endif()
 
-if(CONFIG_STM32_FDCAN)
-  if(CONFIG_STM32_FDCAN_CHARDRIVER)
-    list(APPEND SRCS stm32_can.c)
-  endif()
-  if(CONFIG_STM32_FDCAN_SOCKET)
-    list(APPEND SRCS stm32_cansock.c)
-  endif()
+if(CONFIG_STM32_CAN_CHARDRIVER)
+  list(APPEND SRCS stm32_can.c)
+endif()
+
+if(CONFIG_DAC)
+  list(APPEND SRCS stm32_dac.c)
+endif()
+
+if(CONFIG_PWM)
+  list(APPEND SRCS stm32_pwm.c)
+endif()
+
+if(CONFIG_SPI)
+  list(APPEND SRCS stm32_spi.c)
+endif()
+
+if(CONFIG_LCD_SSD1351)
+  list(APPEND SRCS stm32_ssd1351.c)
+endif()
+
+if(CONFIG_TIMER)
+  list(APPEND SRCS stm32_timer.c)
+endif()
+
+if(CONFIG_BOARDCTL_UNIQUEID)
+  list(APPEND SRCS stm32_uid.c)
 endif()
 
 target_sources(board PRIVATE ${SRCS})

--- a/boards/arm/stm32/nucleo-f303ze/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-f303ze/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# boards/arm/stm32/b-g431b-esc1/CMakeLists.txt
+# boards/arm/stm32/nucleo-f303ze/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for

--- a/boards/arm/stm32/nucleo-f303ze/src/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-f303ze/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 ############################################################################
-# boards/arm/stm32/b-g431b-esc1/src/CMakeLists.txt
+# boards/arm/stm32/nucleo-f303ze/src/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance with the
 # License.  You may obtain a copy of the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+#  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
@@ -31,20 +31,15 @@ if(CONFIG_ARCH_BUTTONS)
 endif()
 
 if(CONFIG_BOARDCTL)
-  list(APPEND SRCS stm32_appinit.c)
+  list(APPEND SRCS stm32_appinitialize.c)
 endif()
 
-if(CONFIG_STM32_FOC)
-  list(APPEND SRCS stm32_foc.c)
+if(CONFIG_ADC)
+  list(APPEND SRCS stm32_adc.c)
 endif()
 
-if(CONFIG_STM32_FDCAN)
-  if(CONFIG_STM32_FDCAN_CHARDRIVER)
-    list(APPEND SRCS stm32_can.c)
-  endif()
-  if(CONFIG_STM32_FDCAN_SOCKET)
-    list(APPEND SRCS stm32_cansock.c)
-  endif()
+if(CONFIG_LCD_SSD1306)
+  list(APPEND SRCS stm32_lcd.c)
 endif()
 
 target_sources(board PRIVATE ${SRCS})

--- a/boards/arm/stm32/nucleo-f410rb/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-f410rb/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# boards/arm/stm32/b-g431b-esc1/CMakeLists.txt
+# boards/arm/stm32/nucleo-f410rb/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for

--- a/boards/arm/stm32/nucleo-f410rb/src/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-f410rb/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 ############################################################################
-# boards/arm/stm32/b-g431b-esc1/src/CMakeLists.txt
+# boards/arm/stm32/nucleo-f410rb/src/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -30,23 +30,14 @@ if(CONFIG_ARCH_BUTTONS)
   list(APPEND SRCS stm32_buttons.c)
 endif()
 
+if(CONFIG_ADC)
+  list(APPEND SRCS stm32_adc.c)
+endif()
+
 if(CONFIG_BOARDCTL)
   list(APPEND SRCS stm32_appinit.c)
 endif()
 
-if(CONFIG_STM32_FOC)
-  list(APPEND SRCS stm32_foc.c)
-endif()
-
-if(CONFIG_STM32_FDCAN)
-  if(CONFIG_STM32_FDCAN_CHARDRIVER)
-    list(APPEND SRCS stm32_can.c)
-  endif()
-  if(CONFIG_STM32_FDCAN_SOCKET)
-    list(APPEND SRCS stm32_cansock.c)
-  endif()
-endif()
-
 target_sources(board PRIVATE ${SRCS})
 
-set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/ld.script")
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/f410rb.ld")

--- a/boards/arm/stm32/nucleo-f412zg/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-f412zg/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# boards/arm/stm32/b-g431b-esc1/CMakeLists.txt
+# boards/arm/stm32/nucleo-f412zg/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for

--- a/boards/arm/stm32/nucleo-f412zg/src/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-f412zg/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 ############################################################################
-# boards/arm/stm32/b-g431b-esc1/src/CMakeLists.txt
+# boards/arm/stm32/nucleo-f412zg/src/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -22,31 +22,16 @@ set(SRCS stm32_boot.c stm32_bringup.c)
 
 if(CONFIG_ARCH_LEDS)
   list(APPEND SRCS stm32_autoleds.c)
-else()
-  list(APPEND SRCS stm32_userleds.c)
 endif()
 
-if(CONFIG_ARCH_BUTTONS)
-  list(APPEND SRCS stm32_buttons.c)
-endif()
-
-if(CONFIG_BOARDCTL)
+if(CONFIG_NSH_LIBRARY)
   list(APPEND SRCS stm32_appinit.c)
 endif()
 
-if(CONFIG_STM32_FOC)
-  list(APPEND SRCS stm32_foc.c)
-endif()
-
-if(CONFIG_STM32_FDCAN)
-  if(CONFIG_STM32_FDCAN_CHARDRIVER)
-    list(APPEND SRCS stm32_can.c)
-  endif()
-  if(CONFIG_STM32_FDCAN_SOCKET)
-    list(APPEND SRCS stm32_cansock.c)
-  endif()
+if(CONFIG_STM32_OTGFS)
+  list(APPEND SRCS stm32_usb.c)
 endif()
 
 target_sources(board PRIVATE ${SRCS})
 
-set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/ld.script")
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/f412zg.ld")

--- a/boards/arm/stm32/nucleo-f429zi/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-f429zi/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# boards/arm/stm32/b-g431b-esc1/CMakeLists.txt
+# boards/arm/stm32/nucleo-f429zi/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for

--- a/boards/arm/stm32/nucleo-f429zi/src/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-f429zi/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 ############################################################################
-# boards/arm/stm32/b-g431b-esc1/src/CMakeLists.txt
+# boards/arm/stm32/nucleo-f429zi/src/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -18,7 +18,7 @@
 #
 ############################################################################
 
-set(SRCS stm32_boot.c stm32_bringup.c)
+set(SRCS stm32_boot.c)
 
 if(CONFIG_ARCH_LEDS)
   list(APPEND SRCS stm32_autoleds.c)
@@ -31,20 +31,43 @@ if(CONFIG_ARCH_BUTTONS)
 endif()
 
 if(CONFIG_BOARDCTL)
-  list(APPEND SRCS stm32_appinit.c)
+  list(APPEND SRCS stm32_appinitialize.c)
 endif()
 
-if(CONFIG_STM32_FOC)
-  list(APPEND SRCS stm32_foc.c)
+if(CONFIG_DEV_GPIO)
+  list(APPEND SRCS stm32_gpio.c)
 endif()
 
-if(CONFIG_STM32_FDCAN)
-  if(CONFIG_STM32_FDCAN_CHARDRIVER)
-    list(APPEND SRCS stm32_can.c)
-  endif()
-  if(CONFIG_STM32_FDCAN_SOCKET)
-    list(APPEND SRCS stm32_cansock.c)
-  endif()
+if(CONFIG_SPI)
+  list(APPEND SRCS stm32_spi.c)
+endif()
+
+if(CONFIG_ADC)
+  list(APPEND SRCS stm32_adc.c)
+endif()
+
+if(CONFIG_PWM)
+  list(APPEND SRCS stm32_pwm.c)
+endif()
+
+if(CONFIG_MMCSD)
+  list(APPEND SRCS stm32_sdio.c)
+endif()
+
+if(CONFIG_STM32_OTGFS)
+  list(APPEND SRCS stm32_usb.c)
+endif()
+
+if(CONFIG_STM32_BBSRAM)
+  list(APPEND SRCS stm32_bbsram.c)
+endif()
+
+if(CONFIG_BOARDCTL_RESET)
+  list(APPEND SRCS stm32_reset.c)
+endif()
+
+if(CONFIG_STM32_ROMFS)
+  list(APPEND SRCS stm32_romfs_initialize.c)
 endif()
 
 target_sources(board PRIVATE ${SRCS})

--- a/boards/arm/stm32/nucleo-f4x1re/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-f4x1re/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# boards/arm/stm32/b-g431b-esc1/CMakeLists.txt
+# boards/arm/stm32/nucleo-f4x1re/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for

--- a/boards/arm/stm32/nucleo-f4x1re/src/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-f4x1re/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 ############################################################################
-# boards/arm/stm32/b-g431b-esc1/src/CMakeLists.txt
+# boards/arm/stm32/nucleo-f4x1re/src/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -18,7 +18,13 @@
 #
 ############################################################################
 
-set(SRCS stm32_boot.c stm32_bringup.c)
+set(SRCS stm32_boot.c stm32_spi.c stm32_bringup.c)
+
+if(CONFIG_VIDEO_FB)
+  if(CONFIG_LCD_SSD1306)
+    list(APPEND SRCS stm32_lcd_ssd1306.c)
+  endif()
+endif()
 
 if(CONFIG_ARCH_LEDS)
   list(APPEND SRCS stm32_autoleds.c)
@@ -30,23 +36,25 @@ if(CONFIG_ARCH_BUTTONS)
   list(APPEND SRCS stm32_buttons.c)
 endif()
 
+if(CONFIG_ADC)
+  list(APPEND SRCS stm32_adc.c)
+  if(CONFIG_INPUT_AJOYSTICK)
+    list(APPEND SRCS stm32_ajoystick.c)
+  endif()
+endif()
+
+if(CONFIG_CAN_MCP2515)
+  list(APPEND SRCS stm32_mcp2515.c)
+endif()
+
 if(CONFIG_BOARDCTL)
   list(APPEND SRCS stm32_appinit.c)
 endif()
 
-if(CONFIG_STM32_FOC)
-  list(APPEND SRCS stm32_foc.c)
-endif()
-
-if(CONFIG_STM32_FDCAN)
-  if(CONFIG_STM32_FDCAN_CHARDRIVER)
-    list(APPEND SRCS stm32_can.c)
-  endif()
-  if(CONFIG_STM32_FDCAN_SOCKET)
-    list(APPEND SRCS stm32_cansock.c)
-  endif()
-endif()
-
 target_sources(board PRIVATE ${SRCS})
 
-set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/ld.script")
+if(CONFIG_ARCH_CHIP_STM32F401RE)
+  set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/f401re.ld")
+elseif(CONFIG_ARCH_CHIP_STM32F411RE)
+  set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/f411re.ld")
+endif()

--- a/boards/arm/stm32/nucleo-g431kb/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-g431kb/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# boards/arm/stm32/b-g431b-esc1/CMakeLists.txt
+# boards/arm/stm32/nucleo-g431kb/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for

--- a/boards/arm/stm32/nucleo-g431kb/src/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-g431kb/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 ############################################################################
-# boards/arm/stm32/b-g431b-esc1/src/CMakeLists.txt
+# boards/arm/stm32/nucleo-g431kb/src/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -26,25 +26,20 @@ else()
   list(APPEND SRCS stm32_userleds.c)
 endif()
 
-if(CONFIG_ARCH_BUTTONS)
-  list(APPEND SRCS stm32_buttons.c)
+if(CONFIG_PWM)
+  list(APPEND SRCS stm32_pwm.c)
 endif()
 
 if(CONFIG_BOARDCTL)
   list(APPEND SRCS stm32_appinit.c)
 endif()
 
-if(CONFIG_STM32_FOC)
-  list(APPEND SRCS stm32_foc.c)
+if(CONFIG_STM32_COMP)
+  list(APPEND SRCS stm32_comp.c)
 endif()
 
-if(CONFIG_STM32_FDCAN)
-  if(CONFIG_STM32_FDCAN_CHARDRIVER)
-    list(APPEND SRCS stm32_can.c)
-  endif()
-  if(CONFIG_STM32_FDCAN_SOCKET)
-    list(APPEND SRCS stm32_cansock.c)
-  endif()
+if(CONFIG_STM32_DAC)
+  list(APPEND SRCS stm32_dac.c)
 endif()
 
 target_sources(board PRIVATE ${SRCS})

--- a/boards/arm/stm32/nucleo-g431rb/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-g431rb/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# boards/arm/stm32/b-g431b-esc1/CMakeLists.txt
+# boards/arm/stm32/nucleo-g431rb/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for

--- a/boards/arm/stm32/nucleo-g431rb/src/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-g431rb/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 ############################################################################
-# boards/arm/stm32/b-g431b-esc1/src/CMakeLists.txt
+# boards/arm/stm32/nucleo-g431rb/src/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -34,8 +34,22 @@ if(CONFIG_BOARDCTL)
   list(APPEND SRCS stm32_appinit.c)
 endif()
 
-if(CONFIG_STM32_FOC)
-  list(APPEND SRCS stm32_foc.c)
+if(NOT CONFIG_STM32_FOC)
+  if(CONFIG_PWM)
+    list(APPEND SRCS stm32_pwm.c)
+  endif()
+
+  if(CONFIG_ADC)
+    list(APPEND SRCS stm32_adc.c)
+  endif()
+endif()
+
+if(CONFIG_BOARD_STM32_IHM16M1)
+  list(APPEND SRCS stm32_foc_ihm16m1.c)
+endif()
+
+if(CONFIG_MATH_CORDIC)
+  list(APPEND SRCS stm32_cordic.c)
 endif()
 
 if(CONFIG_STM32_FDCAN)

--- a/boards/arm/stm32/nucleo-g474re/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-g474re/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# boards/arm/stm32/b-g431b-esc1/CMakeLists.txt
+# boards/arm/stm32/nucleo-g474re/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for

--- a/boards/arm/stm32/nucleo-g474re/src/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-g474re/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 ############################################################################
-# boards/arm/stm32/b-g431b-esc1/src/CMakeLists.txt
+# boards/arm/stm32/nucleo-g474re/src/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -26,25 +26,12 @@ else()
   list(APPEND SRCS stm32_userleds.c)
 endif()
 
-if(CONFIG_ARCH_BUTTONS)
-  list(APPEND SRCS stm32_buttons.c)
-endif()
-
 if(CONFIG_BOARDCTL)
   list(APPEND SRCS stm32_appinit.c)
 endif()
 
-if(CONFIG_STM32_FOC)
-  list(APPEND SRCS stm32_foc.c)
-endif()
-
-if(CONFIG_STM32_FDCAN)
-  if(CONFIG_STM32_FDCAN_CHARDRIVER)
-    list(APPEND SRCS stm32_can.c)
-  endif()
-  if(CONFIG_STM32_FDCAN_SOCKET)
-    list(APPEND SRCS stm32_cansock.c)
-  endif()
+if(CONFIG_USBDEV)
+    list(APPEND SRCS stm32_usbdev.c)
 endif()
 
 target_sources(board PRIVATE ${SRCS})

--- a/boards/arm/stm32/nucleo-l152re/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-l152re/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# boards/arm/stm32/b-g431b-esc1/CMakeLists.txt
+# boards/arm/stm32/nucleo-l152re/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for

--- a/boards/arm/stm32/nucleo-l152re/src/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-l152re/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 ############################################################################
-# boards/arm/stm32/b-g431b-esc1/src/CMakeLists.txt
+# boards/arm/stm32/nucleo-l152re/src/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance with the
 # License.  You may obtain a copy of the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+#  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
@@ -18,7 +18,7 @@
 #
 ############################################################################
 
-set(SRCS stm32_boot.c stm32_bringup.c)
+set(SRCS stm32_boot.c)
 
 if(CONFIG_ARCH_LEDS)
   list(APPEND SRCS stm32_autoleds.c)
@@ -31,20 +31,19 @@ if(CONFIG_ARCH_BUTTONS)
 endif()
 
 if(CONFIG_BOARDCTL)
-  list(APPEND SRCS stm32_appinit.c)
+  list(APPEND SRCS stm32_appinitialize.c)
 endif()
 
-if(CONFIG_STM32_FOC)
-  list(APPEND SRCS stm32_foc.c)
+if(CONFIG_LCD_ILI9341)
+  list(APPEND SRCS stm32_ili93418b.c)
 endif()
 
-if(CONFIG_STM32_FDCAN)
-  if(CONFIG_STM32_FDCAN_CHARDRIVER)
-    list(APPEND SRCS stm32_can.c)
-  endif()
-  if(CONFIG_STM32_FDCAN_SOCKET)
-    list(APPEND SRCS stm32_cansock.c)
-  endif()
+if(CONFIG_MMCSD_SPI)
+  list(APPEND SRCS stm32_spisd.c)
+endif()
+
+if(CONFIG_STM32_SPI)
+  list(APPEND SRCS stm32_spi.c)
 endif()
 
 target_sources(board PRIVATE ${SRCS})

--- a/libs/libm/CMakeLists.txt
+++ b/libs/libm/CMakeLists.txt
@@ -1,0 +1,20 @@
+# ##############################################################################
+# libs/libm/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+nuttx_add_subdirectory()

--- a/libs/libm/libm/CMakeLists.txt
+++ b/libs/libm/libm/CMakeLists.txt
@@ -18,6 +18,11 @@
 #
 # ##############################################################################
 if(CONFIG_LIBM)
+
+  if(CONFIG_ARCH_ARM)
+    nuttx_add_subdirectory(arm)
+  endif()
+
   # Add the floating point math C files to the build
 
   set(SRCS

--- a/libs/libm/libm/arm/CMakeLists.txt
+++ b/libs/libm/libm/arm/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# libs/libm/libm/arm/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+nuttx_add_subdirectory()

--- a/libs/libm/libm/arm/armv7-m/CMakeLists.txt
+++ b/libs/libm/libm/arm/armv7-m/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# libs/libm/libm/arm/armv7-m/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_ARMV7M_LIBM)
+  set(SRCS)
+
+  if(CONFIG_LIBM_ARCH_FABSF)
+    list(APPEND SRCS arch_fabsf.c)
+  endif()
+
+  if(CONFIG_LIBM_ARCH_SQRTF)
+    list(APPEND SRCS arch_sqrtf.c)
+  endif()
+
+  target_sources(c PRIVATE ${SRCS})
+endif()

--- a/libs/libm/libm/arm/armv8-m/CMakeLists.txt
+++ b/libs/libm/libm/arm/armv8-m/CMakeLists.txt
@@ -1,0 +1,73 @@
+# ##############################################################################
+# libs/libm/libm/arm/armv8-m/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_ARMV8M_LIBM)
+  set(SRCS)
+
+  if(CONFIG_LIBM_ARCH_CEIL)
+    list(APPEND SRCS arch_ceil.c)
+  endif()
+
+  if(CONFIG_LIBM_ARCH_CEILF)
+    list(APPEND SRCS arch_ceilf.c)
+  endif()
+
+  if(CONFIG_LIBM_ARCH_FLOOR)
+    list(APPEND SRCS arch_floor.c)
+  endif()
+
+  if(CONFIG_LIBM_ARCH_FLOORF)
+    list(APPEND SRCS arch_floorf.c)
+  endif()
+
+  if(CONFIG_LIBM_ARCH_NEARBYINT)
+    list(APPEND SRCS arch_nearbyint.c)
+  endif()
+
+  if(CONFIG_LIBM_ARCH_NEARBYINTF)
+    list(APPEND SRCS arch_nearbyintf.c)
+  endif()
+
+  if(CONFIG_LIBM_ARCH_RINTF)
+    list(APPEND SRCS arch_rintf.c)
+  endif()
+
+  if(CONFIG_LIBM_ARCH_ROUNDF)
+    list(APPEND SRCS arch_roundf.c)
+  endif()
+
+  if(CONFIG_LIBM_ARCH_TRUNCF)
+    list(APPEND SRCS arch_truncf.c)
+  endif()
+
+  if(CONFIG_LIBM_ARCH_RINT)
+    list(APPEND SRCS arch_rint.c)
+  endif()
+
+  if(CONFIG_LIBM_ARCH_ROUND)
+    list(APPEND SRCS arch_round.c)
+  endif()
+
+  if(CONFIG_LIBM_ARCH_TRUNC)
+    list(APPEND SRCS arch_trunc.c)
+  endif()
+
+  target_sources(c PRIVATE ${SRCS})
+endif()


### PR DESCRIPTION
## Summary

- cmake: support arm specific libm
- cmake: convert more stm32 boards

## Impact

## Testing
foc examples
