### PR TITLE
st7789: add support for 3 wire interface

### DIFF
--- a/drivers/lcd/Kconfig
+++ b/drivers/lcd/Kconfig
@@ -705,6 +705,14 @@ config LCD_ST7789
 	default n
 
 if LCD_ST7789
+config LCD_ST7789_3WIRE
+	bool "Use 3 wire interface"
+	default n
+	---help---
+		Specifies whether 3 wire or 4 wire (default) interface is
+		used. 3 wire interface drops CMD/DATA pin and uses 9th bit
+		to determine data/command message.
+
 config LCD_ST7789_XRES
 	int "ST7789 X Resolution"
 	default 240


### PR DESCRIPTION
## Summary
3 wire interface for ST7789 LCD controller does not use  CMD/DATA pin to specify whether data or command is send but uses 9th bit of SPI transfer.

This commit adds support for 3 wire interface to ST7789 controller.

## Impact
Adds 3 wire interface, current support not affected.

## Testing
Tested on both 3 wire and 4 wire interface st7789 displays

