### PR TITLE
binfmt: Move elf_allocbuffer to elf_sectname and elf_symname 

### DIFF
--- a/binfmt/libelf/libelf_bind.c
+++ b/binfmt/libelf/libelf_bind.c
@@ -572,17 +572,6 @@ int elf_bind(FAR struct elf_loadinfo_s *loadinfo,
       return ret;
     }
 
-  /* Allocate an I/O buffer.  This buffer is used by elf_symname() to
-   * accumulate the variable length symbol name.
-   */
-
-  ret = elf_allocbuffer(loadinfo);
-  if (ret < 0)
-    {
-      berr("elf_allocbuffer failed: %d\n", ret);
-      return ret;
-    }
-
 #ifdef CONFIG_ARCH_ADDRENV
   /* If CONFIG_ARCH_ADDRENV=y, then the loaded ELF lies in a virtual address
    * space that may not be in place now.  elf_addrenv_select() will

--- a/binfmt/libelf/libelf_ctors.c
+++ b/binfmt/libelf/libelf_ctors.c
@@ -82,17 +82,6 @@ int elf_loadctors(FAR struct elf_loadinfo_s *loadinfo)
 
   DEBUGASSERT(loadinfo->ctors == NULL);
 
-  /* Allocate an I/O buffer if necessary.  This buffer is used by
-   * elf_sectname() to accumulate the variable length symbol name.
-   */
-
-  ret = elf_allocbuffer(loadinfo);
-  if (ret < 0)
-    {
-      berr("elf_allocbuffer failed: %d\n", ret);
-      return -ENOMEM;
-    }
-
   /* Find the index to the section named ".ctors."  NOTE:  On old ABI system,
    * .ctors is the name of the section containing the list of constructors;
    * On newer systems, the similar section is called .init_array.  It is

--- a/binfmt/libelf/libelf_dtors.c
+++ b/binfmt/libelf/libelf_dtors.c
@@ -83,17 +83,6 @@ int elf_loaddtors(FAR struct elf_loadinfo_s *loadinfo)
 
   DEBUGASSERT(loadinfo->dtors == NULL);
 
-  /* Allocate an I/O buffer if necessary.  This buffer is used by
-   * elf_sectname() to accumulate the variable length symbol name.
-   */
-
-  ret = elf_allocbuffer(loadinfo);
-  if (ret < 0)
-    {
-      berr("elf_allocbuffer failed: %d\n", ret);
-      return -ENOMEM;
-    }
-
   /* Find the index to the section named ".dtors."  NOTE:  On old ABI system,
    * .dtors is the name of the section containing the list of destructors;
    * On newer systems, the similar section is called .fini_array.  It is

--- a/binfmt/libelf/libelf_sections.c
+++ b/binfmt/libelf/libelf_sections.c
@@ -82,6 +82,17 @@ static inline int elf_sectname(FAR struct elf_loadinfo_s *loadinfo,
       return -EINVAL;
     }
 
+  /* Allocate an I/O buffer if necessary.  This buffer is used by
+   * elf_sectname() to accumulate the variable length symbol name.
+   */
+
+  ret = elf_allocbuffer(loadinfo);
+  if (ret < 0)
+    {
+      berr("elf_allocbuffer failed: %d\n", ret);
+      return ret;
+    }
+
   /* Get the section name string table section header */
 
   shstr = &loadinfo->shdr[shstrndx];

--- a/binfmt/libelf/libelf_symbols.c
+++ b/binfmt/libelf/libelf_symbols.c
@@ -82,6 +82,17 @@ static int elf_symname(FAR struct elf_loadinfo_s *loadinfo,
       return -ESRCH;
     }
 
+  /* Allocate an I/O buffer.  This buffer is used by elf_symname() to
+   * accumulate the variable length symbol name.
+   */
+
+  ret = elf_allocbuffer(loadinfo);
+  if (ret < 0)
+    {
+      berr("elf_allocbuffer failed: %d\n", ret);
+      return ret;
+    }
+
   offset = loadinfo->shdr[loadinfo->strtabidx].sh_offset + sym->st_name;
 
   /* Loop until we get the entire symbol name into memory */

--- a/libs/libc/modlib/modlib_bind.c
+++ b/libs/libc/modlib/modlib_bind.c
@@ -811,17 +811,6 @@ int modlib_bind(FAR struct module_s *modp,
       return ret;
     }
 
-  /* Allocate an I/O buffer.  This buffer is used by mod_symname() to
-   * accumulate the variable length symbol name.
-   */
-
-  ret = modlib_allocbuffer(loadinfo);
-  if (ret < 0)
-    {
-      berr("ERROR: modlib_allocbuffer failed: %d\n", ret);
-      return -ENOMEM;
-    }
-
   /* Process relocations in every allocated section */
 
   for (i = 1; i < loadinfo->ehdr.e_shnum; i++)

--- a/libs/libc/modlib/modlib_sections.c
+++ b/libs/libc/modlib/modlib_sections.c
@@ -73,6 +73,17 @@ static inline int modlib_sectname(FAR struct mod_loadinfo_s *loadinfo,
       return -EINVAL;
     }
 
+  /* Allocate an I/O buffer.  This buffer is used by modlib_sectname() to
+   * accumulate the variable length symbol name.
+   */
+
+  ret = modlib_allocbuffer(loadinfo);
+  if (ret < 0)
+    {
+      berr("ERROR: modlib_allocbuffer failed: %d\n", ret);
+      return -ENOMEM;
+    }
+
   /* Get the section name string table section header */
 
   shstr = &loadinfo->shdr[shstrndx];

--- a/libs/libc/modlib/modlib_symbols.c
+++ b/libs/libc/modlib/modlib_symbols.c
@@ -109,6 +109,17 @@ static int modlib_symname(FAR struct mod_loadinfo_s *loadinfo,
       return -ESRCH;
     }
 
+  /* Allocate an I/O buffer.  This buffer is used by mod_symname() to
+   * accumulate the variable length symbol name.
+   */
+
+  ret = modlib_allocbuffer(loadinfo);
+  if (ret < 0)
+    {
+      berr("ERROR: modlib_allocbuffer failed: %d\n", ret);
+      return -ENOMEM;
+    }
+
   offset = sh_offset + sym->st_name;
 
   /* Loop until we get the entire symbol name into memory */


### PR DESCRIPTION
## Summary

it's better to allocate the buffer just before really use it.
Do the similar change to modlib too.

## Impact

code refactor

## Testing

CI, please ignore the follow false alarm:
```
Error: /home/runner/work/nuttx/nuttx/nuttx/libs/libc/modlib/modlib_bind.c:64:6: error: Mixed case identifier found
```