### PR TITLE
drivers/segger: Rename serial device from /dev/rttx to /dev/ttyRx

### DIFF
--- a/drivers/segger/note_sysview.c
+++ b/drivers/segger/note_sysview.c
@@ -134,15 +134,15 @@ static void note_sysview_send_taskinfo(FAR struct tcb_s *tcb)
 {
   SEGGER_SYSVIEW_TASKINFO info;
 
-  info.TaskID     = tcb->pid;
+  info.TaskID    = tcb->pid;
 #if CONFIG_TASK_NAME_SIZE > 0
-  info.sName      = tcb->name;
+  info.sName     = tcb->name;
 #else
-  info.sName      = "<noname>";
+  info.sName     = "<noname>";
 #endif
-  info.Prio       = tcb->sched_priority;
-  info.StackBase  = (uintptr_t)tcb->stack_base_ptr;
-  info.StackSize  = tcb->adj_stack_size;
+  info.Prio      = tcb->sched_priority;
+  info.StackBase = (uintptr_t)tcb->stack_base_ptr;
+  info.StackSize = tcb->adj_stack_size;
 
   SEGGER_SYSVIEW_SendTaskInfo(&info);
 }

--- a/drivers/segger/serial_rtt.c
+++ b/drivers/segger/serial_rtt.c
@@ -446,14 +446,14 @@ static void serial_rtt_register(FAR const char *name,
 void serial_rtt_initialize(void)
 {
 #ifdef CONFIG_SERIAL_RTT0
-  serial_rtt_register("/dev/rtt0", &g_serial_rtt0);
+  serial_rtt_register("/dev/ttyR0", &g_serial_rtt0);
 #endif
 
 #ifdef CONFIG_SERIAL_RTT1
-  serial_rtt_register("/dev/rtt1", &g_serial_rtt1);
+  serial_rtt_register("/dev/ttyR1", &g_serial_rtt1);
 #endif
 
 #ifdef CONFIG_SERIAL_RTT2
-  serial_rtt_register("/dev/rtt2", &g_serial_rtt2);
+  serial_rtt_register("/dev/ttyR2", &g_serial_rtt2);
 #endif
 }


### PR DESCRIPTION
## Summary

follow the serial driver naming convention

## Impact

segger serial driver

## Testing

ci