### PR TITLE
net/udp: Change conn->readahead to I/O buffer chain

### DIFF
--- a/net/procfs/net_udp.c
+++ b/net/procfs/net_udp.c
@@ -122,7 +122,7 @@ static ssize_t netprocfs_udpstats(FAR struct netprocfs_file_s *priv,
 #if CONFIG_NET_SEND_BUFSIZE > 0
                       udp_wrbuffer_inqueue_size(conn),
 #endif
-                      iob_get_queue_size(&conn->readahead));
+                      (conn->readahead) ? conn->readahead->io_pktlen : 0);
 
       len += snprintf(buffer + len, buflen - len,
                       " %*s:%-6" PRIu16 " %*s:%-6" PRIu16 "\n",

--- a/net/tcp/Kconfig
+++ b/net/tcp/Kconfig
@@ -266,20 +266,6 @@ config NET_TCP_WRBUFFER_DUMP
 
 endif # NET_TCP_WRITE_BUFFERS
 
-config NET_TCP_RECV_PACK
-	bool "Enable TCP/IP receive data in a continuous poll"
-	default y
-	---help---
-		This option will enable TCP/IP receive data into a continuous iob chain.
-		Fragmentation of network data will intensify iob consumption, if
-		the device receives a message storm of fragmented packets, the iob
-		cache will not be effectively used, this is not allowed on iot devices
-		since the resources of such devices are limited. Of course, this
-		also takes some disadvantages: data needs to be copied.
-		This option will brings some balance on resource-constrained devices,
-		enable this config to reduce the consumption of iob, the received iob
-		buffers will be merged into the contiguous iob chain.
-
 config NET_TCPBACKLOG
 	bool "TCP/IP backlog support"
 	default n

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -289,11 +289,10 @@ struct tcp_conn_s
 
   /* Read-ahead buffering.
    *
-   *   readahead - A singly linked list of type struct iob_s
-   *               where the TCP/IP read-ahead data is retained.
+   *   readahead - An IOB chain where the TCP/IP read-ahead data is retained.
    */
 
-  struct iob_s *readahead;   /* Read-ahead buffering */
+  FAR struct iob_s *readahead;   /* Read-ahead buffering */
 
 #ifdef CONFIG_NET_TCP_OUT_OF_ORDER
 

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -1374,21 +1374,6 @@ uint16_t tcp_datahandler(FAR struct net_driver_s *dev,
                          uint16_t offset);
 
 /****************************************************************************
- * Name: tcp_dataconcat
- *
- * Description:
- *   Concatenate iob_s chain iob2 to iob1, if CONFIG_NET_TCP_RECV_PACK is
- *   endabled, pack all data in the I/O buffer chain.
- *
- * Returned Value:
- *   The number of bytes actually buffered is returned.  This will be either
- *   zero or equal to iob1->io_pktlen.
- *
- ****************************************************************************/
-
-uint16_t tcp_dataconcat(FAR struct iob_s **iob1, FAR struct iob_s **iob2);
-
-/****************************************************************************
  * Name: tcp_backlogcreate
  *
  * Description:

--- a/net/tcp/tcp_input.c
+++ b/net/tcp/tcp_input.c
@@ -315,7 +315,7 @@ static bool tcp_rebuild_ofosegs(FAR struct tcp_conn_s *conn,
 
           else if (ofoseg->left == seg->right)
             {
-              tcp_dataconcat(&seg->data, &ofoseg->data);
+              net_iob_concat(&seg->data, &ofoseg->data);
               seg->right = ofoseg->right;
             }
 
@@ -338,7 +338,7 @@ static bool tcp_rebuild_ofosegs(FAR struct tcp_conn_s *conn,
               ofoseg->data =
                 iob_trimhead(ofoseg->data,
                              TCP_SEQ_SUB(seg->right, ofoseg->left));
-              tcp_dataconcat(&seg->data, &ofoseg->data);
+              net_iob_concat(&seg->data, &ofoseg->data);
               seg->right = ofoseg->right;
             }
         }
@@ -355,7 +355,7 @@ static bool tcp_rebuild_ofosegs(FAR struct tcp_conn_s *conn,
 
           if (ofoseg->right == seg->left)
             {
-              tcp_dataconcat(&ofoseg->data, &seg->data);
+              net_iob_concat(&ofoseg->data, &seg->data);
               seg->data = ofoseg->data;
               seg->left = ofoseg->left;
               ofoseg->data = NULL;
@@ -390,7 +390,7 @@ static bool tcp_rebuild_ofosegs(FAR struct tcp_conn_s *conn,
               ofoseg->data =
                 iob_trimtail(ofoseg->data,
                              ofoseg->right - seg->left);
-              tcp_dataconcat(&ofoseg->data, &seg->data);
+              net_iob_concat(&ofoseg->data, &seg->data);
               seg->data = ofoseg->data;
               seg->left = ofoseg->left;
               ofoseg->data = NULL;

--- a/net/udp/udp.h
+++ b/net/udp/udp.h
@@ -127,11 +127,10 @@ struct udp_conn_s
 
   /* Read-ahead buffering.
    *
-   *   readahead - A singly linked list of type struct iob_qentry_s
-   *               where the UDP/IP read-ahead data is retained.
+   *   readahead - An IOB chain where the UDP/IP read-ahead data is retained.
    */
 
-  struct iob_queue_s readahead;   /* Read-ahead buffering */
+  FAR struct iob_s *readahead;   /* Read-ahead buffering */
 
 #ifdef CONFIG_NET_UDP_WRITE_BUFFERS
   /* Write buffering

--- a/net/udp/udp_conn.c
+++ b/net/udp/udp_conn.c
@@ -691,9 +691,9 @@ void udp_free(FAR struct udp_conn_s *conn)
 
   dq_rem(&conn->sconn.node, &g_active_udp_connections);
 
-  /* Release any read-ahead buffers attached to the connection */
+  /* Release any read-ahead buffers attached to the connection, NULL is ok */
 
-  iob_free_queue(&conn->readahead);
+  iob_free_chain(conn->readahead);
 
 #ifdef CONFIG_NET_UDP_WRITE_BUFFERS
   /* Release any write buffers attached to the connection */

--- a/net/udp/udp_ioctl.c
+++ b/net/udp/udp_ioctl.c
@@ -64,10 +64,12 @@ int udp_ioctl(FAR struct udp_conn_s *conn, int cmd, unsigned long arg)
   switch (cmd)
     {
       case FIONREAD:
-        iob = iob_peek_queue(&conn->readahead);
+        iob = conn->readahead;
         if (iob)
           {
-            *(FAR int *)((uintptr_t)arg) = iob->io_pktlen;
+            uint16_t datalen;
+            iob_copyout((FAR uint8_t *)&datalen, iob, sizeof(datalen), 0);
+            *(FAR int *)((uintptr_t)arg) = datalen;
           }
         else
           {

--- a/net/udp/udp_netpoll.c
+++ b/net/udp/udp_netpoll.c
@@ -208,7 +208,7 @@ int udp_pollsetup(FAR struct socket *psock, FAR struct pollfd *fds)
 
   /* Check for read data availability now */
 
-  if (!IOB_QEMPTY(&conn->readahead))
+  if (conn->readahead != NULL)
     {
       /* Normal data may be read without blocking. */
 

--- a/net/udp/udp_notifier.c
+++ b/net/udp/udp_notifier.c
@@ -76,7 +76,7 @@ int udp_readahead_notifier_setup(worker_t worker,
    * setting up the notification.
    */
 
-  if (conn->readahead.qh_head != NULL)
+  if (conn->readahead != NULL)
     {
       return 0;
     }

--- a/net/utils/CMakeLists.txt
+++ b/net/utils/CMakeLists.txt
@@ -29,7 +29,8 @@ set(SRCS
     net_incr32.c
     net_lock.c
     net_snoop.c
-    net_cmsg.c)
+    net_cmsg.c
+    net_iob_concat.c)
 
 # IPv6 utilities
 

--- a/net/utils/Kconfig
+++ b/net/utils/Kconfig
@@ -28,3 +28,17 @@ config NET_ARCH_CHKSUM
 config NET_SNOOP_BUFSIZE
 	int "Snoop buffer size for interrupt"
 	default 4096
+
+config NET_RECV_PACK
+	bool "Enable TCP/IP receive data in a continuous poll"
+	default y
+	---help---
+		This option will enable TCP/IP receive data into a continuous iob chain.
+		Fragmentation of network data will intensify iob consumption, if
+		the device receives a message storm of fragmented packets, the iob
+		cache will not be effectively used, this is not allowed on iot devices
+		since the resources of such devices are limited. Of course, this
+		also takes some disadvantages: data needs to be copied.
+		This option will brings some balance on resource-constrained devices,
+		enable this config to reduce the consumption of iob, the received iob
+		buffers will be merged into the contiguous iob chain.

--- a/net/utils/Make.defs
+++ b/net/utils/Make.defs
@@ -22,7 +22,7 @@
 
 NET_CSRCS += net_dsec2tick.c net_dsec2timeval.c net_timeval2dsec.c
 NET_CSRCS += net_chksum.c net_ipchksum.c net_incr32.c net_lock.c net_snoop.c
-NET_CSRCS += net_cmsg.c
+NET_CSRCS += net_cmsg.c net_iob_concat.c
 
 # IPv6 utilities
 

--- a/net/utils/net_iob_concat.c
+++ b/net/utils/net_iob_concat.c
@@ -1,0 +1,74 @@
+/****************************************************************************
+ * net/utils/net_iob_concat.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+
+#include <nuttx/mm/iob.h>
+
+#ifdef CONFIG_MM_IOB
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: net_iob_concat
+ *
+ * Description:
+ *   Concatenate iob_s chain iob2 to iob1, if CONFIG_NET_RECV_PACK is
+ *   endabled, pack all data in the I/O buffer chain.
+ *
+ * Returned Value:
+ *   The number of bytes actually buffered is returned.  This will be either
+ *   zero or equal to iob->io_pktlen.
+ *
+ ****************************************************************************/
+
+uint16_t net_iob_concat(FAR struct iob_s **iob1, FAR struct iob_s **iob2)
+{
+  if (*iob1 == NULL)
+    {
+      *iob1 = *iob2;
+    }
+  else
+    {
+      iob_concat(*iob1, *iob2);
+    }
+
+  *iob2 = NULL;
+
+#ifdef CONFIG_NET_RECV_PACK
+  /* Merge an iob chain into a continuous space, thereby reducing iob
+   * consumption.
+   */
+
+  *iob1 = iob_pack(*iob1);
+#endif
+
+  return (*iob1)->io_pktlen;
+}
+
+#endif /* CONFIG_MM_IOB */

--- a/net/utils/utils.h
+++ b/net/utils/utils.h
@@ -193,6 +193,23 @@ void net_ipv6_pref2mask(uint8_t preflen, net_ipv6addr_t mask);
 #endif
 
 /****************************************************************************
+ * Name: net_iob_concat
+ *
+ * Description:
+ *   Concatenate iob_s chain iob2 to iob1, if CONFIG_NET_RECV_PACK is
+ *   endabled, pack all data in the I/O buffer chain.
+ *
+ * Returned Value:
+ *   The number of bytes actually buffered is returned.  This will be either
+ *   zero or equal to iob1->io_pktlen.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_MM_IOB
+uint16_t net_iob_concat(FAR struct iob_s **iob1, FAR struct iob_s **iob2);
+#endif
+
+/****************************************************************************
  * Name: net_chksum_adjust
  *
  * Description:


### PR DESCRIPTION
## Summary
Patches included:
- net: Rename `tcp_dataconcat` to `net_iob_concat`
  - Allow other protocols like UDP to use concat logic. (No logic change)
- net/udp: Change `conn->readahead` to I/O buffer chain
  - When using IOB queue to store `readahead` data, we use one IOB for each UDP packet. Then if the packets are very small, like 10Bytes per packet, we'll use ~1600 IOBs just for 16KB recv buffer size, which is wasteful and dangerous. So change `conn->readahead` to a single IOB chain like TCP.
  - Benefits:
    - Using memory and IOBs more efficiently (small packets are common case in UDP)
  - Side effects:
    - UDP recv buffer size may count the overhead
    - A little bit drop in UDP recv performance (<1%, more seek & copy)

## Impact
UDP receive buffer

## Testing
Manually, on sim and actual product.