### PR TITLE
tools/ci/checkpatch: add cmake style check into ci-check

### DIFF
--- a/tools/checkpatch.sh
+++ b/tools/checkpatch.sh
@@ -58,6 +58,15 @@ is_rust_file() {
   fi
 }
 
+is_cmake_file() {
+  file_name=$(basename $@)
+  if [ "$file_name" == "CMakeLists.txt" ] || [[ "$file_name" =~ "cmake" ]]; then
+    echo 1
+  else
+    echo 0
+  fi
+}
+
 check_file() {
   if [ -x $@ ]; then
     case $@ in
@@ -74,6 +83,16 @@ check_file() {
     if ! command -v rustfmt &> /dev/null; then
       fail=1
     elif ! rustfmt --edition 2021 --check $@ 2>&1; then
+      fail=1
+    fi
+  elif [ "$(is_cmake_file $@)" == "1" ]; then
+    if ! command -v cmake-format &> /dev/null; then
+      echo -e "\ncmake-format not found, run following command to install:"
+      echo "  $ pip install cmake-format"
+      fail=1
+    elif ! cmake-format --check $@ 2>&1; then
+      echo -e "\ncmake-format check failed, run following command to update the style:"
+      echo "  $ cmake-format -o $@ $@"
       fail=1
     fi
   elif ! $TOOLDIR/nxstyle $@ 2>&1; then

--- a/tools/ci/cibuild.sh
+++ b/tools/ci/cibuild.sh
@@ -282,6 +282,7 @@ function python-tools {
   # Force the reinstall of python packages due to issues with GitHub
   # cache restoration.
   pip3 install --force-reinstall \
+    cmake-format \
     CodeChecker \
     cvt2utf \
     cxxfilt \

--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -286,6 +286,7 @@ ENV PIP_NO_CACHE_DIR=0
 # instead of requiring them to be compiled.
 RUN pip3 install setuptools
 RUN pip3 install wheel
+RUN pip3 install cmake-format
 # Install CodeChecker and use it to statically analyze the code.
 RUN pip3 install CodeChecker
 # Install cvt2utf to check for non-UTF characters.


### PR DESCRIPTION
## Summary

tools/ci/checkpatch: add cmake style check into ci-check


## Impact

N/A

## Testing

run checkpatch for cmake file

```
/nuttx$ ./tools/checkpatch.sh -g HEAD~1
ERROR __main__.py:618: Check failed: /home/archer/code/nuttx/n10/nuttx/CMakeLists.txt

cmake-format check failed, run following command to update the style:
  $ cmake-format -o /home/archer/code/nuttx/n10/nuttx/CMakeLists.txt /home/archer/code/nuttx/n10/nuttx/CMakeLists.txt
```
