### PR TITLE
tools/ci: print cmake warning message only once

### DIFF
--- a/tools/checkpatch.sh
+++ b/tools/checkpatch.sh
@@ -25,6 +25,7 @@ range=0
 spell=0
 encoding=0
 message=0
+cmake_warning_once=0
 
 usage() {
   echo "USAGE: ${0} [options] [list|-]"
@@ -87,12 +88,19 @@ check_file() {
     fi
   elif [ "$(is_cmake_file $@)" == "1" ]; then
     if ! command -v cmake-format &> /dev/null; then
-      echo -e "\ncmake-format not found, run following command to install:"
-      echo "  $ pip install cmake-format"
+      if [ $cmake_warning_once == 0 ]; then
+        echo -e "\ncmake-format not found, run following command to install:"
+        echo "  $ pip install cmake-format"
+        cmake_warning_once=1
+      fi
       fail=1
     elif ! cmake-format --check $@ 2>&1; then
-      echo -e "\ncmake-format check failed, run following command to update the style:"
-      echo "  $ cmake-format -o $@ $@"
+      if [ $cmake_warning_once == 0 ]; then
+        echo -e "\ncmake-format check failed, run following command to update the style:"
+        echo -e "  $ cmake-format -o <src> <dst>\n"
+        cmake-format --check $@ 2>&1
+        cmake_warning_once=1
+      fi
       fail=1
     fi
   elif ! $TOOLDIR/nxstyle $@ 2>&1; then

--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -303,6 +303,7 @@ RUN pip3 install pytest==6.2.5
 RUN pip3 install pytest-json==0.4.0
 RUN pip3 install pytest-ordering==0.6
 RUN pip3 install pytest-repeat==0.9.1
+
 # Used to generate symbol table files
 
 RUN mkdir /tools


### PR DESCRIPTION

## Summary

tools/ci: print cmake warning message only once

1. print cmake warning message only once
2. Touch Dockerfile to update the ci-docker


## Impact

N/A

## Testing

**PR to update Docker, Please do not merge this commit directly**