### PR TITLE
ci/check: install format tool before run style check script

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Check Pull Request
         run: |
           echo "::add-matcher::nuttx/.github/nxstyle.json"
+          pip install cmake-format
           cd nuttx
           commits="${{ github.event.pull_request.base.sha }}..HEAD"
           git log --oneline $commits


### PR DESCRIPTION
## Summary


ci/check: install format tool before run style check script

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

ci-check