### PR TITLE
arch/perf: add ARCH_HAVE_PERF_EVENTS to support hardware perf events

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -34,6 +34,7 @@ config ARCH_ARM64
 	select ARCH_HAVE_SYSCALL_HOOKS
 	select ARCH_HAVE_RDWR_MEM_CPU_RUN
 	select ARCH_HAVE_THREAD_LOCAL
+	select ARCH_HAVE_PERF_EVENTS
 	select ONESHOT
 	---help---
 		The ARM64 architectures
@@ -135,6 +136,7 @@ config ARCH_XTENSA
 	select ARCH_HAVE_STDARG_H
 	select ARCH_HAVE_SETJMP if ARCH_TOOLCHAIN_GNU
 	select ARCH_HAVE_SYSCALL_HOOKS
+	select ARCH_HAVE_PERF_EVENTS
 	---help---
 		Cadence® Tensilica® Xtensa® actictures.
 
@@ -465,6 +467,13 @@ config ARCH_HAVE_SYSCALL_HOOKS
 config ARCH_HAVE_BACKTRACE
 	bool
 	default n
+
+config ARCH_HAVE_PERF_EVENTS
+	bool
+	default n
+	---help---
+		Enable hardware performance counter support for perf events. If
+		disabled, perf events will use software events only.
 
 config ARCH_HAVE_BOOTLOADER
 	bool

--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -740,6 +740,7 @@ config ARCH_ARMV7M
 	bool
 	default n
 	select ARCH_HAVE_CPUINFO
+	select ARCH_HAVE_PERF_EVENTS
 
 config ARCH_CORTEXM3
 	bool
@@ -794,6 +795,7 @@ config ARCH_ARMV7A
 	bool
 	default n
 	select ARCH_HAVE_CPUINFO
+	select ARCH_HAVE_PERF_EVENTS
 	select ARM_HAVE_WFE_SEV
 
 config ARCH_CORTEXA5
@@ -843,6 +845,7 @@ config ARCH_ARMV7R
 	bool
 	default n
 	select ARCH_HAVE_CPUINFO
+	select ARCH_HAVE_PERF_EVENTS
 
 config ARCH_CORTEXR4
 	bool
@@ -875,6 +878,7 @@ config ARCH_ARMV8M
 	bool
 	default n
 	select ARCH_HAVE_CPUINFO
+	select ARCH_HAVE_PERF_EVENTS
 
 config ARCH_CORTEXM23
 	bool
@@ -961,6 +965,7 @@ config ARCH_ARMV8R
 	bool
 	default n
 	select ARCH_HAVE_CPUINFO
+	select ARCH_HAVE_PERF_EVENTS
 	select ONESHOT
 	select ALARM_ARCH
 

--- a/arch/risc-v/Kconfig
+++ b/arch/risc-v/Kconfig
@@ -84,6 +84,7 @@ config ARCH_CHIP_ESP32C3
 	select LIBC_ARCH_STRNLEN
 	select ARCH_HAVE_TEXT_HEAP
 	select ARCH_HAVE_BOOTLOADER
+	select ARCH_HAVE_PERF_EVENTS
 	---help---
 		Espressif ESP32-C3 (RV32IMC).
 

--- a/drivers/timers/arch_alarm.c
+++ b/drivers/timers/arch_alarm.c
@@ -356,6 +356,7 @@ int weak_function up_alarm_tick_start(clock_t ticks)
  *   units.
  ****************************************************************************/
 
+#ifndef CONFIG_ARCH_HAVE_PERF_EVENTS
 void weak_function up_perf_init(FAR void *arg)
 {
   UNUSED(arg);
@@ -386,6 +387,7 @@ void weak_function up_perf_convert(unsigned long elapsed,
 {
   timespec_from_usec(ts, elapsed);
 }
+#endif /* CONFIG_ARCH_HAVE_PERF_EVENTS */
 
 /****************************************************************************
  * Name: up_mdelay

--- a/drivers/timers/arch_timer.c
+++ b/drivers/timers/arch_timer.c
@@ -395,6 +395,7 @@ int weak_function up_timer_tick_start(clock_t ticks)
  *   units.
  ****************************************************************************/
 
+#ifndef CONFIG_ARCH_HAVE_PERF_EVENTS
 void weak_function up_perf_init(FAR void *arg)
 {
   UNUSED(arg);
@@ -422,6 +423,7 @@ void weak_function up_perf_convert(unsigned long elapsed,
 {
   timespec_from_usec(ts, elapsed);
 }
+#endif /* CONFIG_ARCH_HAVE_PERF_EVENTS */
 
 /****************************************************************************
  * Name: up_mdelay


### PR DESCRIPTION

## Summary

arch/perf: add ARCH_HAVE_PERF_EVENTS to support hardware perf events

The implementation of up_perf_*() is in a different static library in nuttx:

Hardware: libarch.a
Software: libdrivers.a (weak function)

Since functions with weak attributes cannot be correctly replaced in multiple static libraries, this PR will use macros to replace whether the arch supports hardware perf events


## Impact

N/A

## Testing

cortex-m55