### PR TITLE
nuttx/sim: use workquene instead rptun_loop

### DIFF
--- a/arch/sim/src/sim/sim_initialize.c
+++ b/arch/sim/src/sim/sim_initialize.c
@@ -187,10 +187,6 @@ static int sim_loop_task(int argc, char **argv)
       host_usrsock_loop();
 #endif
 
-#ifdef CONFIG_RPTUN
-      sim_rptun_loop();
-#endif
-
 #ifdef CONFIG_SIM_HCISOCKET
       sim_bthcisock_loop();
 #endif

--- a/arch/sim/src/sim/sim_internal.h
+++ b/arch/sim/src/sim/sim_internal.h
@@ -350,7 +350,6 @@ void sim_netdriver_loop(void);
 
 #ifdef CONFIG_RPTUN
 int sim_rptun_init(const char *shmemname, const char *cpuname, bool master);
-void sim_rptun_loop(void);
 #endif
 
 /* sim_hcisocket.c **********************************************************/


### PR DESCRIPTION
## Summary
use workquene instead rptun_loop

## Impact

## Testing

