### PR TITLE
arch/risc-v/src/mpfs: Add configuration option to enable DDR manual a…

### DIFF
--- a/arch/risc-v/src/mpfs/Kconfig
+++ b/arch/risc-v/src/mpfs/Kconfig
@@ -157,6 +157,12 @@ config MPFS_DDR_TYPE
 	default 3 if MPFS_DDR_TYPE_LPDDR3
 	default 4 if MPFS_DDR_TYPE_LPDDR4
 
+config MPFS_DDR_MANUAL_ADDCMD_TRAINING
+	bool "Use manual addcmd training"
+        default n
+	---help---
+		This adds code for manual addcmd training. To use it also enable bit 1 in TIP_CFG_PARAMS to skip the automatic one
+
 config MPFS_ENABLE_CACHE
 	bool "Enable L2 cache"
 	depends on MPFS_BOOTLOADER

--- a/arch/risc-v/src/mpfs/mpfs_ddr.c
+++ b/arch/risc-v/src/mpfs/mpfs_ddr.c
@@ -254,6 +254,8 @@ static struct mpfs_ddr_priv_s g_mpfs_ddr_priv =
   .bclk_answer          = 0,
 };
 
+#ifdef CONFIG_MPFS_DDR_MANUAL_ADDCMD_TRAINING
+
 static const uint8_t refclk_offsets[][5] =
   {
     {LIBERO_SETTING_REFCLK_DDR3_1333_NUM_OFFSETS,
@@ -308,6 +310,8 @@ static const uint8_t refclk_offsets[][5] =
      LIBERO_SETTING_REFCLK_LPDDR4_1333_OFFSET_2,
      LIBERO_SETTING_REFCLK_LPDDR4_1333_OFFSET_3},
   };
+
+#endif
 
 /****************************************************************************
  * Private Functions
@@ -1560,6 +1564,8 @@ static void mpfs_init_ddrc(void)
            MPFS_DDR_CSR_APB_PHY_HALF_CLK_DLY_ENABLE);
 }
 
+#ifdef CONFIG_MPFS_DDR_MANUAL_ADDCMD_TRAINING
+
 /****************************************************************************
  * Name: mpfs_ddr_manual_addcmd_refclk_offset
  *
@@ -1609,6 +1615,8 @@ static uint8_t mpfs_ddr_manual_addcmd_refclk_offset(
 
   return refclk_offset;
 }
+
+#endif
 
 /****************************************************************************
  * Name: mpfs_get_num_lanes
@@ -2447,6 +2455,8 @@ static uint32_t mpfs_ddr_read_write_fn(struct mpfs_ddr_priv_s *priv,
   return error_cnt;
 }
 
+#ifdef CONFIG_MPFS_DDR_MANUAL_ADDCMD_TRAINING
+
 /****************************************************************************
  * Name: mpfs_ddr_manual_addcmd_training
  *
@@ -2467,6 +2477,13 @@ static void mpfs_ddr_manual_addcmd_training(struct mpfs_ddr_priv_s *priv)
   uint32_t dpc_vals;
   uint32_t j;
   uint32_t i;
+
+  /* If automatic training is enabled, skip this */
+
+  if ((LIBERO_SETTING_TRAINING_SKIP_SETTING & ADDCMD_BIT) == 0)
+    {
+      return;
+    }
 
   /* Apply offset & load the phase */
 
@@ -2974,6 +2991,8 @@ static void mpfs_ddr_manual_addcmd_training(struct mpfs_ddr_priv_s *priv)
 
   putreg32(ca_drv, MPFS_CFG_DDR_SGMII_PHY_RPC1_DRV);
 }
+
+#endif
 
 /****************************************************************************
  * Name: mpfs_ddr_sm_init
@@ -3895,7 +3914,10 @@ static int mpfs_ddr_setup(struct mpfs_ddr_priv_s *priv)
 
   /* DDR_MANUAL_ADDCMD_TRAINING_SW */
 
+#ifdef CONFIG_MPFS_DDR_MANUAL_ADDCMD_TRAINING
   mpfs_ddr_manual_addcmd_training(priv);
+#endif
+
   mpfs_training_start(priv);
 
   /* DDR_TRAINING_IP_SM_START_CHECK */


### PR DESCRIPTION
…ddcmd training

Also switch to automatic one by default, as it saves a lot of flash. The manual training code is left in for now to be able to use it as an option if there are problems with automatic one

## Summary

By default, use the DDR controller's built-in ADDCMD training procedure. The manual procedure which was used before is modified from Microchip's HSS code, and it seems to have some issues on some boards.

Looks like there is no reason to use this huge manual training code, at least on LPDDR4 & DDR4 devices. So change this

## Impact

This fixes boot problems on some of the boards

## Testing

Tested on Aries m100pfs, icicle board and 2 custom designs