### PR TITLE
net/setsockopt: Add IP_TTL support

### DIFF
--- a/net/inet/ipv4_setsockopt.c
+++ b/net/inet/ipv4_setsockopt.c
@@ -179,6 +179,9 @@ int ipv4_setsockopt(FAR struct socket *psock, int option,
 #ifdef NET_UDP_HAVE_STACK
       case IP_MULTICAST_TTL:          /* Set/read the time-to-live value of
                                        * outgoing multicast packets */
+#endif
+      case IP_TTL:                    /* The IP TTL (time to live) of IP
+                                       * packets sent by the network stack */
         {
           FAR struct socket_conn_s *conn;
           int ttl;
@@ -204,7 +207,6 @@ int ipv4_setsockopt(FAR struct socket *psock, int option,
             }
         }
         break;
-#endif
 
       /* The following IPv4 socket options are defined, but not implemented */
 

--- a/net/inet/ipv4_setsockopt.c
+++ b/net/inet/ipv4_setsockopt.c
@@ -38,6 +38,7 @@
 #include "igmp/igmp.h"
 #include "inet/inet.h"
 #include "socket/socket.h"
+#include "udp/udp.h"
 
 #if defined(CONFIG_NET_IPv4) && defined(CONFIG_NET_SOCKOPTS)
 
@@ -180,6 +181,7 @@ int ipv4_setsockopt(FAR struct socket *psock, int option,
                                        * outgoing multicast packets */
         {
           FAR struct socket_conn_s *conn;
+          int ttl;
 
           if (value == NULL || value_len == 0)
             {


### PR DESCRIPTION
## Summary
We have `IPV6_UNICAST_HOPS` and `IPV6_MULTICAST_HOPS` in `ipv6_setsockopt`, but only `IP_MULTICAST_TTL` in `ipv4_setsockopt`. So add `IP_TTL` support.

## Impact
`IP_TTL` / `IP_MULTICAST_TTL` in `ipv4_setsockopt`

## Testing
CI
