### PR TITLE
Fix include/nuttx/hwspinlock/hwspinlock.h:117:3: error: too few arguments to function 'hwspin_unlock'

### DIFF
--- a/include/nuttx/hwspinlock/hwspinlock.h
+++ b/include/nuttx/hwspinlock/hwspinlock.h
@@ -104,15 +104,13 @@ hwspin_lock_irqsave(FAR struct hwspinlock_dev_s *dev,
   return flags;
 }
 
-static inline void hwspin_unlock(FAR struct hwspinlock_dev_s *dev,
-                                 int id, int priority)
+static inline void hwspin_unlock(FAR struct hwspinlock_dev_s *dev, int id)
 {
   dev->ops->unlock(dev, id);
 }
 
 static inline void hwspin_unlock_restore(FAR struct hwspinlock_dev_s *dev,
-                                         int id, int priority,
-                                         irqstate_t flags)
+                                         int id, irqstate_t flags)
 {
   hwspin_unlock(dev, id);
   spin_lock_restore(&dev->lock, flags);


### PR DESCRIPTION
## Summary

## Impact

hwspinlock

## Testing

internal ci