### PR TITLE
hwspinlock: Fix typo error(spin_lock_restore to spin_unlock_irqrestore)

### DIFF
--- a/include/nuttx/hwspinlock/hwspinlock.h
+++ b/include/nuttx/hwspinlock/hwspinlock.h
@@ -113,7 +113,7 @@ static inline void hwspin_unlock_restore(FAR struct hwspinlock_dev_s *dev,
                                          int id, irqstate_t flags)
 {
   hwspin_unlock(dev, id);
-  spin_lock_restore(&dev->lock, flags);
+  spin_unlock_irqrestore(&dev->lock, flags);
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Summary

## Impact

minor

## Testing

ci