### PR TITLE
cmake: port the rest of stm32 boards and format Nordic boards

### DIFF
--- a/boards/arm/nrf52/common/CMakeLists.txt
+++ b/boards/arm/nrf52/common/CMakeLists.txt
@@ -1,22 +1,22 @@
-############################################################################
+# ##############################################################################
 # boards/arm/nrf52/common/CMakeLists.txt
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# License for the specific language governing permissions and limitations under
+# the License.
 #
-############################################################################
+# ##############################################################################
 
 add_subdirectory(src)
 target_include_directories(board PRIVATE include)

--- a/boards/arm/nrf52/common/src/CMakeLists.txt
+++ b/boards/arm/nrf52/common/src/CMakeLists.txt
@@ -1,37 +1,37 @@
-############################################################################
+# ##############################################################################
 # boards/arm/nrf52/common/src/CMakeLists.txt
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# License for the specific language governing permissions and limitations under
+# the License.
 #
-############################################################################
+# ##############################################################################
 
 if(CONFIG_ARCH_BOARD_COMMON)
 
-if(CONFIG_NRF52_TIMER)
-  list(APPEND SRCS nrf52_timer.c)
-endif()
+  if(CONFIG_NRF52_TIMER)
+    list(APPEND SRCS nrf52_timer.c)
+  endif()
 
-if(CONFIG_BOARDCTL_BOOT_IMAGE)
-  list(APPEND SRCS nrf52_boot_image.c)
-endif()
+  if(CONFIG_BOARDCTL_BOOT_IMAGE)
+    list(APPEND SRCS nrf52_boot_image.c)
+  endif()
 
-if(CONFIG_NRF52_PROGMEM)
-  list(APPEND SRCS nrf52_progmem.c)
-endif()
+  if(CONFIG_NRF52_PROGMEM)
+    list(APPEND SRCS nrf52_progmem.c)
+  endif()
 
-target_sources(board PRIVATE ${SRCS})
+  target_sources(board PRIVATE ${SRCS})
 
 endif()

--- a/boards/arm/nrf52/nrf52-feather/src/CMakeLists.txt
+++ b/boards/arm/nrf52/nrf52-feather/src/CMakeLists.txt
@@ -1,22 +1,22 @@
-############################################################################
+# ##############################################################################
 # boards/arm/nrf52/nrf52-feather/src/CMakeLists.txt
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# License for the specific language governing permissions and limitations under
+# the License.
 #
-############################################################################
+# ##############################################################################
 
 set(SRCS nrf52_boot.c nrf52_bringup.c)
 
@@ -37,7 +37,9 @@ endif()
 target_sources(board PRIVATE ${SRCS})
 
 if(CONFIG_ARCH_BOARD_COMMON)
-  set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_COMMON_DIR}/scripts/flash_config.ld")
+  set_property(GLOBAL PROPERTY LD_SCRIPT
+                               "${NUTTX_COMMON_DIR}/scripts/flash_config.ld")
 else()
-  set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash_config.ld")
+  set_property(GLOBAL PROPERTY LD_SCRIPT
+                               "${NUTTX_BOARD_DIR}/scripts/flash_config.ld")
 endif()

--- a/boards/arm/nrf52/nrf52832-dk/src/CMakeLists.txt
+++ b/boards/arm/nrf52/nrf52832-dk/src/CMakeLists.txt
@@ -1,22 +1,22 @@
-############################################################################
+# ##############################################################################
 # boards/arm/nrf52/nrf52832-dk/src/CMakeLists.txt
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# License for the specific language governing permissions and limitations under
+# the License.
 #
-############################################################################
+# ##############################################################################
 
 set(SRCS nrf52_boot.c nrf52_bringup.c)
 
@@ -37,7 +37,9 @@ endif()
 target_sources(board PRIVATE ${SRCS})
 
 if(CONFIG_ARCH_BOARD_COMMON)
-  set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_COMMON_DIR}/scripts/flash_config.ld")
+  set_property(GLOBAL PROPERTY LD_SCRIPT
+                               "${NUTTX_COMMON_DIR}/scripts/flash_config.ld")
 else()
-  set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash_config.ld")
+  set_property(GLOBAL PROPERTY LD_SCRIPT
+                               "${NUTTX_BOARD_DIR}/scripts/flash_config.ld")
 endif()

--- a/boards/arm/nrf52/nrf52832-mdk/src/CMakeLists.txt
+++ b/boards/arm/nrf52/nrf52832-mdk/src/CMakeLists.txt
@@ -1,22 +1,22 @@
-############################################################################
+# ##############################################################################
 # boards/arm/nrf52/nrf52832-mdk/src/CMakeLists.txt
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
 #
-#  http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# License for the specific language governing permissions and limitations under
+# the License.
 #
-############################################################################
+# ##############################################################################
 
 set(SRCS nrf52_boot.c nrf52_bringup.c)
 
@@ -31,7 +31,9 @@ endif()
 target_sources(board PRIVATE ${SRCS})
 
 if(CONFIG_ARCH_BOARD_COMMON)
-  set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_COMMON_DIR}/scripts/flash_config.ld")
+  set_property(GLOBAL PROPERTY LD_SCRIPT
+                               "${NUTTX_COMMON_DIR}/scripts/flash_config.ld")
 else()
-  set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash_config.ld")
+  set_property(GLOBAL PROPERTY LD_SCRIPT
+                               "${NUTTX_BOARD_DIR}/scripts/flash_config.ld")
 endif()

--- a/boards/arm/nrf52/nrf52832-sparkfun/src/CMakeLists.txt
+++ b/boards/arm/nrf52/nrf52832-sparkfun/src/CMakeLists.txt
@@ -1,22 +1,22 @@
-############################################################################
+# ##############################################################################
 # boards/arm/nrf52/nrf52832-sparkfun/src/CMakeLists.txt
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
 #
-#  http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# License for the specific language governing permissions and limitations under
+# the License.
 #
-############################################################################
+# ##############################################################################
 
 set(SRCS nrf52_boot.c nrf52_bringup.c)
 
@@ -31,7 +31,9 @@ endif()
 target_sources(board PRIVATE ${SRCS})
 
 if(CONFIG_ARCH_BOARD_COMMON)
-  set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_COMMON_DIR}/scripts/flash_config.ld")
+  set_property(GLOBAL PROPERTY LD_SCRIPT
+                               "${NUTTX_COMMON_DIR}/scripts/flash_config.ld")
 else()
-  set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash_config.ld")
+  set_property(GLOBAL PROPERTY LD_SCRIPT
+                               "${NUTTX_BOARD_DIR}/scripts/flash_config.ld")
 endif()

--- a/boards/arm/nrf52/nrf52840-dk/src/CMakeLists.txt
+++ b/boards/arm/nrf52/nrf52840-dk/src/CMakeLists.txt
@@ -1,22 +1,22 @@
-############################################################################
+# ##############################################################################
 # boards/arm/nrf52/nrf52840-dk/src/CMakeLists.txt
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# License for the specific language governing permissions and limitations under
+# the License.
 #
-############################################################################
+# ##############################################################################
 
 set(SRCS nrf52_boot.c nrf52_bringup.c)
 
@@ -81,7 +81,9 @@ endif()
 target_sources(board PRIVATE ${SRCS})
 
 if(CONFIG_ARCH_BOARD_COMMON)
-  set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_COMMON_DIR}/scripts/flash_config.ld")
+  set_property(GLOBAL PROPERTY LD_SCRIPT
+                               "${NUTTX_COMMON_DIR}/scripts/flash_config.ld")
 else()
-  set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash_config.ld")
+  set_property(GLOBAL PROPERTY LD_SCRIPT
+                               "${NUTTX_BOARD_DIR}/scripts/flash_config.ld")
 endif()

--- a/boards/arm/nrf52/nrf52840-dongle/src/CMakeLists.txt
+++ b/boards/arm/nrf52/nrf52840-dongle/src/CMakeLists.txt
@@ -1,22 +1,22 @@
-############################################################################
+# ##############################################################################
 # boards/arm/nrf52/nrf52840-dongle/src/CMakeLists.txt
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
 #
-#  http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# License for the specific language governing permissions and limitations under
+# the License.
 #
-############################################################################
+# ##############################################################################
 
 set(SRCS nrf52_boot.c nrf52_bringup.c)
 
@@ -41,7 +41,9 @@ endif()
 target_sources(board PRIVATE ${SRCS})
 
 if(CONFIG_ARCH_BOARD_COMMON)
-  set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_COMMON_DIR}/scripts/flash_config.ld")
+  set_property(GLOBAL PROPERTY LD_SCRIPT
+                               "${NUTTX_COMMON_DIR}/scripts/flash_config.ld")
 else()
-  set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash_config.ld")
+  set_property(GLOBAL PROPERTY LD_SCRIPT
+                               "${NUTTX_BOARD_DIR}/scripts/flash_config.ld")
 endif()

--- a/boards/arm/nrf52/thingy52/src/CMakeLists.txt
+++ b/boards/arm/nrf52/thingy52/src/CMakeLists.txt
@@ -1,22 +1,22 @@
-############################################################################
+# ##############################################################################
 # boards/arm/nrf52/thingy52/src/CMakeLists.txt
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# License for the specific language governing permissions and limitations under
+# the License.
 #
-############################################################################
+# ##############################################################################
 
 set(SRCS nrf52_boot.c nrf52_bringup.c)
 
@@ -35,7 +35,9 @@ endif()
 target_sources(board PRIVATE ${SRCS})
 
 if(CONFIG_ARCH_BOARD_COMMON)
-  set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_COMMON_DIR}/scripts/flash_config.ld")
+  set_property(GLOBAL PROPERTY LD_SCRIPT
+                               "${NUTTX_COMMON_DIR}/scripts/flash_config.ld")
 else()
-  set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash_config.ld")
+  set_property(GLOBAL PROPERTY LD_SCRIPT
+                               "${NUTTX_BOARD_DIR}/scripts/flash_config.ld")
 endif()

--- a/boards/arm/nrf53/common/CMakeLists.txt
+++ b/boards/arm/nrf53/common/CMakeLists.txt
@@ -1,22 +1,22 @@
-############################################################################
+# ##############################################################################
 # boards/arm/nrf53/common/CMakeLists.txt
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# License for the specific language governing permissions and limitations under
+# the License.
 #
-############################################################################
+# ##############################################################################
 
 add_subdirectory(src)
 target_include_directories(board PRIVATE include)

--- a/boards/arm/nrf53/common/src/CMakeLists.txt
+++ b/boards/arm/nrf53/common/src/CMakeLists.txt
@@ -1,37 +1,37 @@
-############################################################################
+# ##############################################################################
 # boards/arm/nrf53/common/src/CMakeLists.txt
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# License for the specific language governing permissions and limitations under
+# the License.
 #
-############################################################################
+# ##############################################################################
 
 if(CONFIG_ARCH_BOARD_COMMON)
 
-if(CONFIG_NRF53_TIMER)
-  list(APPEND SRCS nrf53_timer.c)
-endif()
+  if(CONFIG_NRF53_TIMER)
+    list(APPEND SRCS nrf53_timer.c)
+  endif()
 
-if(CONFIG_BOARDCTL_BOOT_IMAGE)
-  list(APPEND SRCS nrf53_boot_image.c)
-endif()
+  if(CONFIG_BOARDCTL_BOOT_IMAGE)
+    list(APPEND SRCS nrf53_boot_image.c)
+  endif()
 
-if(CONFIG_NRF53_PROGMEM)
-  list(APPEND SRCS nrf53_progmem.c)
-endif()
+  if(CONFIG_NRF53_PROGMEM)
+    list(APPEND SRCS nrf53_progmem.c)
+  endif()
 
-target_sources(board PRIVATE ${SRCS})
+  target_sources(board PRIVATE ${SRCS})
 
 endif()

--- a/boards/arm/nrf53/nrf5340-audio-dk/src/CMakeLists.txt
+++ b/boards/arm/nrf53/nrf5340-audio-dk/src/CMakeLists.txt
@@ -1,22 +1,22 @@
-############################################################################
+# ##############################################################################
 # boards/arm/nrf53/nrf5340-audio-dk/src/CMakeLists.txt
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# License for the specific language governing permissions and limitations under
+# the License.
 #
-############################################################################
+# ##############################################################################
 
 set(SRCS nrf53_boot.c nrf53_bringup.c)
 
@@ -34,14 +34,18 @@ target_sources(board PRIVATE ${SRCS})
 
 if(CONFIG_ARCH_BOARD_COMMON)
   if(CONFIG_ARCH_CHIP_NRF5340_CPUAPP)
-    set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_COMMON_DIR}/scripts/flash_app.ld")
+    set_property(GLOBAL PROPERTY LD_SCRIPT
+                                 "${NUTTX_COMMON_DIR}/scripts/flash_app.ld")
   else()
-    set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_COMMON_DIR}/scripts/flash_net.ld")
+    set_property(GLOBAL PROPERTY LD_SCRIPT
+                                 "${NUTTX_COMMON_DIR}/scripts/flash_net.ld")
   endif()
 else()
   if(CONFIG_ARCH_CHIP_NRF5340_CPUAPP)
-    set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash_app.ld")
+    set_property(GLOBAL PROPERTY LD_SCRIPT
+                                 "${NUTTX_BOARD_DIR}/scripts/flash_app.ld")
   else()
-    set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash_net.ld")
+    set_property(GLOBAL PROPERTY LD_SCRIPT
+                                 "${NUTTX_BOARD_DIR}/scripts/flash_net.ld")
   endif()
 endif()

--- a/boards/arm/nrf53/nrf5340-dk/src/CMakeLists.txt
+++ b/boards/arm/nrf53/nrf5340-dk/src/CMakeLists.txt
@@ -1,22 +1,22 @@
-############################################################################
+# ##############################################################################
 # boards/arm/nrf53/nrf5340-dk/src/CMakeLists.txt
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# License for the specific language governing permissions and limitations under
+# the License.
 #
-############################################################################
+# ##############################################################################
 
 set(SRCS nrf53_boot.c nrf53_bringup.c)
 
@@ -62,14 +62,18 @@ target_sources(board PRIVATE ${SRCS})
 
 if(CONFIG_ARCH_BOARD_COMMON)
   if(CONFIG_ARCH_CHIP_NRF5340_CPUAPP)
-    set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_COMMON_DIR}/scripts/flash_app.ld")
+    set_property(GLOBAL PROPERTY LD_SCRIPT
+                                 "${NUTTX_COMMON_DIR}/scripts/flash_app.ld")
   else()
-    set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_COMMON_DIR}/scripts/flash_net.ld")
+    set_property(GLOBAL PROPERTY LD_SCRIPT
+                                 "${NUTTX_COMMON_DIR}/scripts/flash_net.ld")
   endif()
 else()
   if(CONFIG_ARCH_CHIP_NRF5340_CPUAPP)
-    set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash_app.ld")
+    set_property(GLOBAL PROPERTY LD_SCRIPT
+                                 "${NUTTX_BOARD_DIR}/scripts/flash_app.ld")
   else()
-    set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash_net.ld")
+    set_property(GLOBAL PROPERTY LD_SCRIPT
+                                 "${NUTTX_BOARD_DIR}/scripts/flash_net.ld")
   endif()
 endif()

--- a/boards/arm/nrf53/thingy53/src/CMakeLists.txt
+++ b/boards/arm/nrf53/thingy53/src/CMakeLists.txt
@@ -1,22 +1,22 @@
-############################################################################
+# ##############################################################################
 # boards/arm/nrf53/thingy53/src/CMakeLists.txt
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# License for the specific language governing permissions and limitations under
+# the License.
 #
-############################################################################
+# ##############################################################################
 
 set(SRCS nrf53_boot.c nrf53_bringup.c)
 
@@ -44,14 +44,18 @@ target_sources(board PRIVATE ${SRCS})
 
 if(CONFIG_ARCH_BOARD_COMMON)
   if(CONFIG_ARCH_CHIP_NRF5340_CPUAPP)
-    set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_COMMON_DIR}/scripts/flash_app.ld")
+    set_property(GLOBAL PROPERTY LD_SCRIPT
+                                 "${NUTTX_COMMON_DIR}/scripts/flash_app.ld")
   else()
-    set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_COMMON_DIR}/scripts/flash_net.ld")
+    set_property(GLOBAL PROPERTY LD_SCRIPT
+                                 "${NUTTX_COMMON_DIR}/scripts/flash_net.ld")
   endif()
 else()
   if(CONFIG_ARCH_CHIP_NRF5340_CPUAPP)
-    set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash_app.ld")
+    set_property(GLOBAL PROPERTY LD_SCRIPT
+                                 "${NUTTX_BOARD_DIR}/scripts/flash_app.ld")
   else()
-    set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash_net.ld")
+    set_property(GLOBAL PROPERTY LD_SCRIPT
+                                 "${NUTTX_BOARD_DIR}/scripts/flash_net.ld")
   endif()
 endif()

--- a/boards/arm/nrf91/common/CMakeLists.txt
+++ b/boards/arm/nrf91/common/CMakeLists.txt
@@ -1,22 +1,22 @@
-############################################################################
+# ##############################################################################
 # boards/arm/nrf91/common/CMakeLists.txt
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# License for the specific language governing permissions and limitations under
+# the License.
 #
-############################################################################
+# ##############################################################################
 
 add_subdirectory(src)
 target_include_directories(board PRIVATE include)

--- a/boards/arm/nrf91/common/src/CMakeLists.txt
+++ b/boards/arm/nrf91/common/src/CMakeLists.txt
@@ -1,37 +1,37 @@
-############################################################################
+# ##############################################################################
 # boards/arm/nrf91/common/src/CMakeLists.txt
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# License for the specific language governing permissions and limitations under
+# the License.
 #
-############################################################################
+# ##############################################################################
 
 if(CONFIG_ARCH_BOARD_COMMON)
 
-if(CONFIG_NRF91_TIMER)
-  list(APPEND SRCS nrf91_timer.c)
-endif()
+  if(CONFIG_NRF91_TIMER)
+    list(APPEND SRCS nrf91_timer.c)
+  endif()
 
-if(CONFIG_BOARDCTL_BOOT_IMAGE)
-  list(APPEND SRCS nrf91_boot_image.c)
-endif()
+  if(CONFIG_BOARDCTL_BOOT_IMAGE)
+    list(APPEND SRCS nrf91_boot_image.c)
+  endif()
 
-if(CONFIG_NRF91_PROGMEM)
-  list(APPEND SRCS nrf91_progmem.c)
-endif()
+  if(CONFIG_NRF91_PROGMEM)
+    list(APPEND SRCS nrf91_progmem.c)
+  endif()
 
-target_sources(board PRIVATE ${SRCS})
+  target_sources(board PRIVATE ${SRCS})
 
 endif()

--- a/boards/arm/nrf91/nrf9160-dk/src/CMakeLists.txt
+++ b/boards/arm/nrf91/nrf9160-dk/src/CMakeLists.txt
@@ -1,22 +1,22 @@
-############################################################################
+# ##############################################################################
 # boards/arm/nrf91/nrf9160-dk/src/CMakeLists.txt
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# License for the specific language governing permissions and limitations under
+# the License.
 #
-############################################################################
+# ##############################################################################
 
 set(SRCS nrf91_boot.c nrf91_bringup.c)
 
@@ -37,7 +37,9 @@ endif()
 target_sources(board PRIVATE ${SRCS})
 
 if(CONFIG_ARCH_BOARD_COMMON)
-  set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_COMMON_DIR}/scripts/flash_app.ld")
+  set_property(GLOBAL PROPERTY LD_SCRIPT
+                               "${NUTTX_COMMON_DIR}/scripts/flash_app.ld")
 else()
-  set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash_app.ld")
+  set_property(GLOBAL PROPERTY LD_SCRIPT
+                               "${NUTTX_BOARD_DIR}/scripts/flash_app.ld")
 endif()

--- a/boards/arm/stm32/axoloti/CMakeLists.txt
+++ b/boards/arm/stm32/axoloti/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32/axoloti/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32/axoloti/src/CMakeLists.txt
+++ b/boards/arm/stm32/axoloti/src/CMakeLists.txt
@@ -1,0 +1,55 @@
+# ##############################################################################
+# boards/arm/stm32/axoloti/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_bringup.c)
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+if(CONFIG_STM32_FMC)
+  list(APPEND SRCS stm32_extmem.c)
+endif()
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS stm32_autoleds.c)
+else()
+  list(APPEND SRCS stm32_userleds.c)
+endif()
+
+if(CONFIG_AUDIO_ADAU1961)
+  list(APPEND SRCS stm32_adau1961.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS stm32_buttons.c)
+endif()
+
+if(CONFIG_STM32_SDIO)
+  list(APPEND SRCS stm32_sdio.c)
+endif()
+
+if(CONFIG_USBHOST)
+  list(APPEND SRCS stm32_usbhost.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/ld.script")

--- a/boards/arm/stm32/b-g431b-esc1/src/CMakeLists.txt
+++ b/boards/arm/stm32/b-g431b-esc1/src/CMakeLists.txt
@@ -1,22 +1,22 @@
-############################################################################
+# ##############################################################################
 # boards/arm/stm32/b-g431b-esc1/src/CMakeLists.txt
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# License for the specific language governing permissions and limitations under
+# the License.
 #
-############################################################################
+# ##############################################################################
 
 set(SRCS stm32_boot.c stm32_bringup.c)
 

--- a/boards/arm/stm32/b-g474e-dpow1/CMakeLists.txt
+++ b/boards/arm/stm32/b-g474e-dpow1/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32/b-g474e-dpow1/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32/b-g474e-dpow1/src/CMakeLists.txt
+++ b/boards/arm/stm32/b-g474e-dpow1/src/CMakeLists.txt
@@ -1,0 +1,35 @@
+# ##############################################################################
+# boards/arm/stm32/b-g474e-dpow1/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c)
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS stm32_autoleds.c)
+else()
+  list(APPEND SRCS stm32_userleds.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/ld.script")

--- a/boards/arm/stm32/clicker2-stm32/CMakeLists.txt
+++ b/boards/arm/stm32/clicker2-stm32/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32/clicker2-stm32/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32/clicker2-stm32/src/CMakeLists.txt
+++ b/boards/arm/stm32/clicker2-stm32/src/CMakeLists.txt
@@ -1,0 +1,67 @@
+# ##############################################################################
+# boards/arm/stm32/clicker2-stm32/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_bringup.c stm32_spi.c)
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS stm32_autoleds.c)
+else()
+  list(APPEND SRCS stm32_userleds.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS stm32_buttons.c)
+endif()
+
+if(CONFIG_STM32_OTGFS)
+  list(APPEND SRCS stm32_usb.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+if(CONFIG_IEEE802154_MRF24J40)
+  list(APPEND SRCS stm32_mrf24j40.c)
+endif()
+
+if(CONFIG_IEEE802154_XBEE)
+  list(APPEND SRCS stm32_xbee.c)
+endif()
+
+if(CONFIG_MMCSD_SPI)
+  list(APPEND SRCS stm32_mmcsd.c)
+endif()
+
+if(CONFIG_FS_AUTOMOUNTER)
+  list(APPEND SRCS stm32_automount.c)
+endif()
+
+if(CONFIG_ADC)
+  list(APPEND SRCS stm32_adc.c)
+endif()
+
+if(CONFIG_STM32_CAN_CHARDRIVER)
+  list(APPEND SRCS stm32_can.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash.ld")

--- a/boards/arm/stm32/cloudctrl/CMakeLists.txt
+++ b/boards/arm/stm32/cloudctrl/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32/cloudctrl/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32/cloudctrl/src/CMakeLists.txt
+++ b/boards/arm/stm32/cloudctrl/src/CMakeLists.txt
@@ -1,0 +1,69 @@
+# ##############################################################################
+# boards/arm/stm32/cloudctrl/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_spi.c stm32_chipid.c)
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS stm32_autoleds.c)
+else()
+  list(APPEND SRCS stm32_userleds.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS stm32_buttons.c)
+endif()
+
+if(CONFIG_ARCH_RELAYS)
+  list(APPEND SRCS stm32_relays.c)
+endif()
+
+if(CONFIG_STM32_OTGFS)
+  list(APPEND SRCS stm32_usb.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+if(CONFIG_MTD_W25)
+  list(APPEND SRCS stm32_w25.c)
+endif()
+
+if(CONFIG_USBMSC)
+  list(APPEND SRCS stm32_usbmsc.c)
+endif()
+
+if(CONFIG_ADC)
+  list(APPEND SRCS stm32_adc.c)
+endif()
+
+if(CONFIG_STM32_PHYINIT)
+  list(APPEND SRCS stm32_phyinit.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+if(CONFIG_STM32_DFU)
+  set_property(GLOBAL PROPERTY LD_SCRIPT
+                               "${NUTTX_BOARD_DIR}/scripts/cloudctrl-dfu.ld")
+else()
+  set_property(GLOBAL PROPERTY LD_SCRIPT
+                               "${NUTTX_BOARD_DIR}/scripts/cloudctrl.ld")
+endif()

--- a/boards/arm/stm32/emw3162/CMakeLists.txt
+++ b/boards/arm/stm32/emw3162/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32/emw3162/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32/emw3162/src/CMakeLists.txt
+++ b/boards/arm/stm32/emw3162/src/CMakeLists.txt
@@ -1,0 +1,40 @@
+# ##############################################################################
+# boards/arm/stm32/emw3162/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_bringup.c)
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS stm32_autoleds.c)
+else()
+  list(APPEND SRCS stm32_userleds.c)
+endif()
+
+if(CONFIG_EMW3162_WLAN)
+  list(APPEND SRCS stm32_wlan.c)
+  list(APPEND SRCS stm32_wlan_firmware.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/ld.script")

--- a/boards/arm/stm32/et-stm32-stamp/CMakeLists.txt
+++ b/boards/arm/stm32/et-stm32-stamp/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32/et-stm32-stamp/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32/et-stm32-stamp/src/CMakeLists.txt
+++ b/boards/arm/stm32/et-stm32-stamp/src/CMakeLists.txt
@@ -1,0 +1,41 @@
+# ##############################################################################
+# boards/arm/stm32/et-stm32-stamp/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c)
+
+if(CONFIG_BOARDCTL)
+
+endif()
+
+if(CONFIG_INPUT)
+
+endif()
+
+if(CONFIG_USBMSC)
+
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/ld.script")

--- a/boards/arm/stm32/fire-stm32v2/CMakeLists.txt
+++ b/boards/arm/stm32/fire-stm32v2/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32/fire-stm32v2/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32/fire-stm32v2/src/CMakeLists.txt
+++ b/boards/arm/stm32/fire-stm32v2/src/CMakeLists.txt
@@ -1,0 +1,61 @@
+# ##############################################################################
+# boards/arm/stm32/fire-stm32v2/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_spi.c stm32_usbdev.c stm32_mmcsd.c)
+
+if(CONFIG_STM32_FSMC)
+  list(APPEND SRCS stm32_lcd.c stm32_selectlcd.c)
+endif()
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS stm32_autoleds.c)
+else()
+  list(APPEND SRCS stm32_userleds.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS stm32_buttons.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+if(CONFIG_ENC28J60)
+  list(APPEND SRCS stm32_enc28j60.c)
+endif()
+
+if(CONFIG_MTD_W25)
+  list(APPEND SRCS stm32_w25.c)
+endif()
+
+if(CONFIG_USBMSC)
+  list(APPEND SRCS stm32_usbmsc.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+if(CONFIG_STM32_DFU)
+  set_property(GLOBAL PROPERTY LD_SCRIPT
+                               "${NUTTX_BOARD_DIR}/scripts/fire-stm32v2-dfu.ld")
+else()
+  set_property(GLOBAL PROPERTY LD_SCRIPT
+                               "${NUTTX_BOARD_DIR}/scripts/fire-stm32v2.ld")
+endif()

--- a/boards/arm/stm32/hymini-stm32v/CMakeLists.txt
+++ b/boards/arm/stm32/hymini-stm32v/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32/hymini-stm32v/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32/hymini-stm32v/src/CMakeLists.txt
+++ b/boards/arm/stm32/hymini-stm32v/src/CMakeLists.txt
@@ -1,0 +1,45 @@
+# ##############################################################################
+# boards/arm/stm32/hymini-stm32v/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_leds.c stm32_buttons.c stm32_spi.c stm32_usbdev.c)
+
+if(CONFIG_LCD_SSD1289)
+  list(APPEND SRCS stm32_ssd1289.c)
+else()
+  if(CONFIG_LCD_R61505U)
+    list(APPEND SRCS stm32_r61505u.c)
+  endif()
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+if(CONFIG_INPUT)
+  list(APPEND SRCS stm32_ts.c)
+endif()
+
+if(CONFIG_USBMSC)
+  list(APPEND SRCS stm32_usbmsc.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/ld.script")

--- a/boards/arm/stm32/maple/CMakeLists.txt
+++ b/boards/arm/stm32/maple/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32/maple/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32/maple/src/CMakeLists.txt
+++ b/boards/arm/stm32/maple/src/CMakeLists.txt
@@ -1,0 +1,45 @@
+# ##############################################################################
+# boards/arm/stm32/maple/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_leds.c stm32_usbdev.c stm32_spi.c)
+
+if(CONFIG_NX_LCDDRIVER)
+  list(APPEND SRCS stm32_lcd.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+
+endif()
+
+if(CONFIG_INPUT)
+
+endif()
+
+if(CONFIG_USBMSC)
+
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/ld.script")

--- a/boards/arm/stm32/mikroe-stm32f4/CMakeLists.txt
+++ b/boards/arm/stm32/mikroe-stm32f4/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32/mikroe-stm32f4/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32/mikroe-stm32f4/src/CMakeLists.txt
+++ b/boards/arm/stm32/mikroe-stm32f4/src/CMakeLists.txt
@@ -1,0 +1,69 @@
+# ##############################################################################
+# boards/arm/stm32/mikroe-stm32f4/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_spi.c)
+
+if(CONFIG_ARCH_BOARD_STM32_CUSTOM_CLOCKCONFIG)
+  list(APPEND SRCS stm32_clockconfig.c)
+endif()
+
+if(CONFIG_STM32_OTGFS)
+  list(APPEND SRCS stm32_usb.c)
+endif()
+
+if(CONFIG_PWM)
+  list(APPEND SRCS stm32_pwm.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+if(CONFIG_ARCH_CUSTOM_PMINIT)
+  list(APPEND SRCS stm32_pm.c)
+endif()
+
+if(CONFIG_ARCH_IDLE_CUSTOM)
+  list(APPEND SRCS stm32_idle.c)
+endif()
+
+if(CONFIG_STM32_FSMC)
+  list(APPEND SRCS stm32_extmem.c)
+endif()
+
+if(CONFIG_INPUT)
+  list(APPEND SRCS stm32_touchscreen.c)
+endif()
+
+if(CONFIG_LCD_MIO283QT2)
+  list(APPEND SRCS stm32_mio283qt2.c)
+endif()
+
+if(CONFIG_LCD_MIO283QT9A)
+  list(APPEND SRCS stm32_mio283qt9a.c)
+endif()
+
+if(CONFIG_AUDIO_VS1053)
+  list(APPEND SRCS stm32_vs1053.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/ld.script")

--- a/boards/arm/stm32/nucleo-f103rb/src/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-f103rb/src/CMakeLists.txt
@@ -1,22 +1,22 @@
-############################################################################
+# ##############################################################################
 # boards/arm/stm32/nucleo-f103rb/src/CMakeLists.txt
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
 #
-#  http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# License for the specific language governing permissions and limitations under
+# the License.
 #
-############################################################################
+# ##############################################################################
 
 set(SRCS stm32_boot.c stm32_bringup.c)
 

--- a/boards/arm/stm32/nucleo-f207zg/src/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-f207zg/src/CMakeLists.txt
@@ -1,22 +1,22 @@
-############################################################################
+# ##############################################################################
 # boards/arm/stm32/nucleo-f207zg/src/CMakeLists.txt
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
 #
-#  http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# License for the specific language governing permissions and limitations under
+# the License.
 #
-############################################################################
+# ##############################################################################
 
 set(SRCS stm32_boot.c stm32_bringup.c)
 

--- a/boards/arm/stm32/nucleo-f302r8/src/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-f302r8/src/CMakeLists.txt
@@ -1,22 +1,22 @@
-############################################################################
+# ##############################################################################
 # boards/arm/stm32/nucleo-f302r8/src/CMakeLists.txt
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
 #
-#  http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# License for the specific language governing permissions and limitations under
+# the License.
 #
-############################################################################
+# ##############################################################################
 
 set(SRCS stm32_boot.c stm32_bringup.c)
 

--- a/boards/arm/stm32/nucleo-f303re/src/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-f303re/src/CMakeLists.txt
@@ -1,22 +1,22 @@
-############################################################################
+# ##############################################################################
 # boards/arm/stm32/nucleo-f303re/src/CMakeLists.txt
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# License for the specific language governing permissions and limitations under
+# the License.
 #
-############################################################################
+# ##############################################################################
 
 set(SRCS stm32_boot.c)
 

--- a/boards/arm/stm32/nucleo-f303ze/src/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-f303ze/src/CMakeLists.txt
@@ -1,22 +1,22 @@
-############################################################################
+# ##############################################################################
 # boards/arm/stm32/nucleo-f303ze/src/CMakeLists.txt
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
 #
-#  http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# License for the specific language governing permissions and limitations under
+# the License.
 #
-############################################################################
+# ##############################################################################
 
 set(SRCS stm32_boot.c stm32_bringup.c)
 

--- a/boards/arm/stm32/nucleo-f334r8/src/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-f334r8/src/CMakeLists.txt
@@ -1,22 +1,22 @@
-############################################################################
+# ##############################################################################
 # boards/arm/stm32/nucleo-f334r8/src/CMakeLists.txt
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
 #
-#  http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# License for the specific language governing permissions and limitations under
+# the License.
 #
-############################################################################
+# ##############################################################################
 
 set(SRCS stm32_boot.c)
 

--- a/boards/arm/stm32/nucleo-f410rb/src/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-f410rb/src/CMakeLists.txt
@@ -1,22 +1,22 @@
-############################################################################
+# ##############################################################################
 # boards/arm/stm32/nucleo-f410rb/src/CMakeLists.txt
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# License for the specific language governing permissions and limitations under
+# the License.
 #
-############################################################################
+# ##############################################################################
 
 set(SRCS stm32_boot.c stm32_bringup.c)
 

--- a/boards/arm/stm32/nucleo-f412zg/src/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-f412zg/src/CMakeLists.txt
@@ -1,22 +1,22 @@
-############################################################################
+# ##############################################################################
 # boards/arm/stm32/nucleo-f412zg/src/CMakeLists.txt
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# License for the specific language governing permissions and limitations under
+# the License.
 #
-############################################################################
+# ##############################################################################
 
 set(SRCS stm32_boot.c stm32_bringup.c)
 

--- a/boards/arm/stm32/nucleo-f429zi/src/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-f429zi/src/CMakeLists.txt
@@ -1,22 +1,22 @@
-############################################################################
+# ##############################################################################
 # boards/arm/stm32/nucleo-f429zi/src/CMakeLists.txt
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# License for the specific language governing permissions and limitations under
+# the License.
 #
-############################################################################
+# ##############################################################################
 
 set(SRCS stm32_boot.c)
 

--- a/boards/arm/stm32/nucleo-f446re/src/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-f446re/src/CMakeLists.txt
@@ -1,22 +1,22 @@
-############################################################################
+# ##############################################################################
 # boards/arm/stm32/nucleo-f446re/src/CMakeLists.txt
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# License for the specific language governing permissions and limitations under
+# the License.
 #
-############################################################################
+# ##############################################################################
 
 set(SRCS stm32_boot.c stm32_bringup.c stm32_spi.c)
 

--- a/boards/arm/stm32/nucleo-f4x1re/src/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-f4x1re/src/CMakeLists.txt
@@ -1,22 +1,22 @@
-############################################################################
+# ##############################################################################
 # boards/arm/stm32/nucleo-f4x1re/src/CMakeLists.txt
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# License for the specific language governing permissions and limitations under
+# the License.
 #
-############################################################################
+# ##############################################################################
 
 set(SRCS stm32_boot.c stm32_spi.c stm32_bringup.c)
 

--- a/boards/arm/stm32/nucleo-g431kb/src/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-g431kb/src/CMakeLists.txt
@@ -1,22 +1,22 @@
-############################################################################
+# ##############################################################################
 # boards/arm/stm32/nucleo-g431kb/src/CMakeLists.txt
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# License for the specific language governing permissions and limitations under
+# the License.
 #
-############################################################################
+# ##############################################################################
 
 set(SRCS stm32_boot.c stm32_bringup.c)
 

--- a/boards/arm/stm32/nucleo-g431rb/src/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-g431rb/src/CMakeLists.txt
@@ -1,22 +1,22 @@
-############################################################################
+# ##############################################################################
 # boards/arm/stm32/nucleo-g431rb/src/CMakeLists.txt
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# License for the specific language governing permissions and limitations under
+# the License.
 #
-############################################################################
+# ##############################################################################
 
 set(SRCS stm32_boot.c stm32_bringup.c)
 

--- a/boards/arm/stm32/nucleo-g474re/src/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-g474re/src/CMakeLists.txt
@@ -1,22 +1,22 @@
-############################################################################
+# ##############################################################################
 # boards/arm/stm32/nucleo-g474re/src/CMakeLists.txt
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# License for the specific language governing permissions and limitations under
+# the License.
 #
-############################################################################
+# ##############################################################################
 
 set(SRCS stm32_boot.c stm32_bringup.c)
 
@@ -31,7 +31,7 @@ if(CONFIG_BOARDCTL)
 endif()
 
 if(CONFIG_USBDEV)
-    list(APPEND SRCS stm32_usbdev.c)
+  list(APPEND SRCS stm32_usbdev.c)
 endif()
 
 target_sources(board PRIVATE ${SRCS})

--- a/boards/arm/stm32/nucleo-l152re/src/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-l152re/src/CMakeLists.txt
@@ -1,22 +1,22 @@
-############################################################################
+# ##############################################################################
 # boards/arm/stm32/nucleo-l152re/src/CMakeLists.txt
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
 #
-#  http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# License for the specific language governing permissions and limitations under
+# the License.
 #
-############################################################################
+# ##############################################################################
 
 set(SRCS stm32_boot.c)
 

--- a/boards/arm/stm32/olimex-stm32-e407/CMakeLists.txt
+++ b/boards/arm/stm32/olimex-stm32-e407/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32/olimex-stm32-e407/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32/olimex-stm32-e407/src/CMakeLists.txt
+++ b/boards/arm/stm32/olimex-stm32-e407/src/CMakeLists.txt
@@ -1,0 +1,79 @@
+# ##############################################################################
+# boards/arm/stm32/olimex-stm32-e407/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_bringup.c stm32_spi.c)
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS stm32_autoleds.c)
+else()
+  list(APPEND SRCS stm32_userleds.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS stm32_buttons.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+if(CONFIG_ARCH_IDLE_CUSTOM)
+  list(APPEND SRCS stm32_idle.c)
+endif()
+
+if(CONFIG_STM32_FSMC)
+  list(APPEND SRCS stm32_extmem.c)
+endif()
+
+if(CONFIG_STM32_OTGFS)
+  list(APPEND SRCS stm32_usb.c)
+endif()
+
+if(CONFIG_STM32_OTGHS)
+  list(APPEND SRCS stm32_usb.c)
+endif()
+
+if(CONFIG_ADC)
+  list(APPEND SRCS stm32_adc.c)
+endif()
+
+if(CONFIG_CAN)
+  list(APPEND SRCS stm32_can.c)
+endif()
+
+if(CONFIG_DAC)
+  list(APPEND SRCS stm32_dac.c)
+endif()
+
+if(CONFIG_TIMER)
+  list(APPEND SRCS stm32_timer.c)
+endif()
+
+if(CONFIG_IEEE802154_MRF24J40)
+  list(APPEND SRCS stm32_mrf24j40.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+if(CONFIG_ARCH_CHIP_STM32F407ZE)
+  set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/f407ze.ld")
+else()
+  set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/f407zg.ld")
+endif()

--- a/boards/arm/stm32/olimex-stm32-h405/CMakeLists.txt
+++ b/boards/arm/stm32/olimex-stm32-h405/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32/olimex-stm32-h405/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32/olimex-stm32-h405/src/CMakeLists.txt
+++ b/boards/arm/stm32/olimex-stm32-h405/src/CMakeLists.txt
@@ -1,0 +1,51 @@
+# ##############################################################################
+# boards/arm/stm32/olimex-stm32-h405/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c)
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS stm32_autoleds.c)
+else()
+  list(APPEND SRCS stm32_userleds.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS stm32_buttons.c)
+endif()
+
+if(CONFIG_STM32_OTGFS)
+  list(APPEND SRCS stm32_usb.c)
+endif()
+
+if(CONFIG_NSH_LIBRARY)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+if(CONFIG_ADC)
+  list(APPEND SRCS stm32_adc.c)
+endif()
+
+if(CONFIG_STM32_CAN_CHARDRIVER)
+  list(APPEND SRCS stm32_can.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/ld.script")

--- a/boards/arm/stm32/olimex-stm32-h407/CMakeLists.txt
+++ b/boards/arm/stm32/olimex-stm32-h407/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32/olimex-stm32-h407/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32/olimex-stm32-h407/src/CMakeLists.txt
+++ b/boards/arm/stm32/olimex-stm32-h407/src/CMakeLists.txt
@@ -1,0 +1,67 @@
+# ##############################################################################
+# boards/arm/stm32/olimex-stm32-h407/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_bringup.c)
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS stm32_autoleds.c)
+else()
+  list(APPEND SRCS stm32_userleds.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS stm32_buttons.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+if(CONFIG_ARCH_IDLE_CUSTOM)
+  list(APPEND SRCS stm32_idle.c)
+endif()
+
+if(CONFIG_STM32_FSMC)
+  list(APPEND SRCS stm32_extmem.c)
+endif()
+
+if(CONFIG_STM32_OTGFS)
+  list(APPEND SRCS stm32_usb.c)
+endif()
+
+if(CONFIG_STM32_OTGHS)
+  list(APPEND SRCS stm32_usb.c)
+endif()
+
+if(CONFIG_ADC)
+  list(APPEND SRCS stm32_adc.c)
+endif()
+
+if(CONFIG_STM32_CAN_CHARDRIVER)
+  list(APPEND SRCS stm32_can.c)
+endif()
+
+if(CONFIG_STM32_SDIO)
+  list(APPEND SRCS stm32_sdio.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/ld.script")

--- a/boards/arm/stm32/olimex-stm32-p107/CMakeLists.txt
+++ b/boards/arm/stm32/olimex-stm32-p107/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32/olimex-stm32-p107/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32/olimex-stm32-p107/src/CMakeLists.txt
+++ b/boards/arm/stm32/olimex-stm32-p107/src/CMakeLists.txt
@@ -1,0 +1,37 @@
+# ##############################################################################
+# boards/arm/stm32/olimex-stm32-p107/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_spi.c)
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+if(CONFIG_STM32_CAN_CHARDRIVER)
+  list(APPEND SRCS stm32_can.c)
+endif()
+
+if(CONFIG_ENCX24J600)
+  list(APPEND SRCS stm32_encx24j600.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/ld.script")

--- a/boards/arm/stm32/olimex-stm32-p207/CMakeLists.txt
+++ b/boards/arm/stm32/olimex-stm32-p207/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32/olimex-stm32-p207/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32/olimex-stm32-p207/src/CMakeLists.txt
+++ b/boards/arm/stm32/olimex-stm32-p207/src/CMakeLists.txt
@@ -1,0 +1,51 @@
+# ##############################################################################
+# boards/arm/stm32/olimex-stm32-p207/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c)
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS stm32_autoleds.c)
+else()
+  list(APPEND SRCS stm32_userleds.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS stm32_buttons.c)
+endif()
+
+if(CONFIG_STM32_OTGFS)
+  list(APPEND SRCS stm32_usb.c)
+endif()
+
+if(CONFIG_NSH_LIBRARY)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+if(CONFIG_ADC)
+  list(APPEND SRCS stm32_adc.c)
+endif()
+
+if(CONFIG_STM32_CAN_CHARDRIVER)
+  list(APPEND SRCS stm32_can.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/ld.script")

--- a/boards/arm/stm32/olimex-stm32-p407/CMakeLists.txt
+++ b/boards/arm/stm32/olimex-stm32-p407/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32/olimex-stm32-p407/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32/olimex-stm32-p407/src/CMakeLists.txt
+++ b/boards/arm/stm32/olimex-stm32-p407/src/CMakeLists.txt
@@ -1,0 +1,63 @@
+# ##############################################################################
+# boards/arm/stm32/olimex-stm32-p407/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_bringup.c stm32_spi.c stm32_st7735.c)
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS stm32_autoleds.c)
+else()
+  list(APPEND SRCS stm32_userleds.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS stm32_buttons.c)
+endif()
+
+if(CONFIG_STM32_FSMC)
+  list(APPEND SRCS stm32_sram.c)
+endif()
+
+if(CONFIG_STM32_OTGFS)
+  list(APPEND SRCS stm32_usb.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+if(CONFIG_ADC)
+  list(APPEND SRCS stm32_adc.c)
+endif()
+
+if(CONFIG_STM32_CAN_CHARDRIVER)
+  list(APPEND SRCS stm32_can.c)
+endif()
+
+if(CONFIG_AUDIO_CS4344)
+  list(APPEND SRCS stm32_cs4344.c)
+endif()
+
+if(CONFIG_INPUT_DJOYSTICK)
+  list(APPEND SRCS stm32_djoystick.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash.ld")

--- a/boards/arm/stm32/olimexino-stm32/CMakeLists.txt
+++ b/boards/arm/stm32/olimexino-stm32/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32/olimexino-stm32/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32/olimexino-stm32/src/CMakeLists.txt
+++ b/boards/arm/stm32/olimexino-stm32/src/CMakeLists.txt
@@ -1,0 +1,49 @@
+# ##############################################################################
+# boards/arm/stm32/olimexino-stm32/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_spi.c stm32_leds.c)
+
+if(CONFIG_STM32_CAN_CHARDRIVER)
+  list(APPEND SRCS stm32_can.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+if(CONFIG_USBMSC)
+  list(APPEND SRCS stm32_usbmsc.c)
+endif()
+
+if(CONFIG_USBDEV_COMPOSITE)
+  list(APPEND SRCS stm32_composite.c)
+endif()
+
+if(CONFIG_USBDEV)
+  list(APPEND SRCS stm32_usbdev.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS stm32_buttons.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/ld.script")

--- a/boards/arm/stm32/omnibusf4/CMakeLists.txt
+++ b/boards/arm/stm32/omnibusf4/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32/omnibusf4/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32/omnibusf4/src/CMakeLists.txt
+++ b/boards/arm/stm32/omnibusf4/src/CMakeLists.txt
@@ -1,0 +1,83 @@
+# ##############################################################################
+# boards/arm/stm32/omnibusf4/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_bringup.c stm32_spi.c stm32_userleds.c)
+
+if(CONFIG_SENSORS_MPU60X0)
+  list(APPEND SRCS stm32_mpu6000.c)
+endif()
+
+if(CONFIG_VIDEO_MAX7456)
+  list(APPEND SRCS stm32_max7456.c)
+endif()
+
+if(CONFIG_STM32_OTGFS)
+  list(APPEND SRCS stm32_usb.c)
+endif()
+
+if(CONFIG_NETDEVICES)
+  list(APPEND SRCS stm32_netinit.c)
+endif()
+
+if(CONFIG_PWM)
+  list(APPEND SRCS stm32_pwm.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+  if(CONFIG_BOARDCTL_RESET)
+    list(APPEND SRCS stm32_reset.c)
+  endif()
+  if(CONFIG_BOARDCTL_IOCTL)
+    list(APPEND SRCS stm32_ioctl.c)
+  endif()
+endif()
+
+if(CONFIG_ARCH_CUSTOM_PMINIT)
+  list(APPEND SRCS stm32_pm.c)
+endif()
+
+if(CONFIG_ARCH_IDLE_CUSTOM)
+  list(APPEND SRCS stm32_idle.c)
+endif()
+
+if(CONFIG_TIMER)
+  list(APPEND SRCS stm32_timer.c)
+endif()
+
+if(CONFIG_STM32_ROMFS)
+  list(APPEND SRCS stm32_romfs_initialize.c)
+endif()
+
+if(CONFIG_BOARDCTL_UNIQUEID)
+  list(APPEND SRCS stm32_uid.c)
+endif()
+
+if(CONFIG_USBMSC)
+  list(APPEND SRCS stm32_usbmsc.c)
+endif()
+
+if(CONFIG_MMCSD)
+  list(APPEND SRCS stm32_mmcsd.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/ld.script")

--- a/boards/arm/stm32/photon/CMakeLists.txt
+++ b/boards/arm/stm32/photon/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32/photon/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32/photon/src/CMakeLists.txt
+++ b/boards/arm/stm32/photon/src/CMakeLists.txt
@@ -1,0 +1,70 @@
+# ##############################################################################
+# boards/arm/stm32/photon/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_bringup.c stm32_spi.c)
+
+if(CONFIG_PHOTON_DFU_BOOTLOADER)
+  list(APPEND SRCS dfu_signature.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+if(CONFIG_INPUT_BUTTONS)
+  list(APPEND SRCS stm32_buttons.c)
+endif()
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS stm32_autoleds.c)
+else()
+  list(APPEND SRCS stm32_userleds.c)
+endif()
+
+if(CONFIG_PHOTON_WDG)
+  list(APPEND SRCS stm32_wdt.c)
+endif()
+
+if(CONFIG_PHOTON_WLAN)
+  list(APPEND SRCS stm32_wlan.c)
+  list(APPEND SRCS stm32_wlan_firmware.c)
+endif()
+
+if(CONFIG_STM32_OTGHS)
+  list(APPEND SRCS stm32_usb.c)
+endif()
+
+if(CONFIG_RGBLED)
+  list(APPEND SRCS stm32_rgbled.c)
+endif()
+
+if(CONFIG_USBDEV_COMPOSITE)
+  list(APPEND SRCS stm32_composite.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+if(CONFIG_PHOTON_DFU_BOOTLOADER)
+  set_property(GLOBAL PROPERTY LD_SCRIPT
+                               "${NUTTX_BOARD_DIR}/scripts/photon_dfu.ld")
+else()
+  set_property(GLOBAL PROPERTY LD_SCRIPT
+                               "${NUTTX_BOARD_DIR}/scripts/photon_jtag.ld")
+endif()

--- a/boards/arm/stm32/shenzhou/CMakeLists.txt
+++ b/boards/arm/stm32/shenzhou/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32/shenzhou/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32/shenzhou/src/CMakeLists.txt
+++ b/boards/arm/stm32/shenzhou/src/CMakeLists.txt
@@ -1,0 +1,75 @@
+# ##############################################################################
+# boards/arm/stm32/shenzhou/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_spi.c stm32_mmcsd.c stm32_chipid.c)
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS stm32_autoleds.c)
+else()
+  list(APPEND SRCS stm32_userleds.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS stm32_buttons.c)
+endif()
+
+if(CONFIG_ARCH_RELAYS)
+  list(APPEND SRCS stm32_relays.c)
+endif()
+
+if(CONFIG_STM32_OTGFS)
+  list(APPEND SRCS stm32_usb.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+if(CONFIG_MTD_W25)
+  list(APPEND SRCS stm32_w25.c)
+endif()
+
+if(CONFIG_USBMSC)
+  list(APPEND SRCS stm32_usbmsc.c)
+endif()
+
+if(CONFIG_STM32_CAN_CHARDRIVER)
+  list(APPEND SRCS stm32_can.c)
+endif()
+
+if(CONFIG_ADC)
+  list(APPEND SRCS stm32_adc.c)
+endif()
+
+# NOTE: SSD1289 is not supported on the board
+
+if(CONFIG_LCD_SSD1289)
+  list(APPEND SRCS stm32_ssd1289.c)
+else()
+  list(APPEND SRCS stm32_ili93xx.c)
+endif()
+
+if(CONFIG_INPUT_ADS7843E)
+  list(APPEND SRCS stm32_touchscreen.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/ld.script")

--- a/boards/arm/stm32/stm3210e-eval/CMakeLists.txt
+++ b/boards/arm/stm32/stm3210e-eval/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32/stm3210e-eval/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32/stm3210e-eval/src/CMakeLists.txt
+++ b/boards/arm/stm32/stm3210e-eval/src/CMakeLists.txt
@@ -1,0 +1,72 @@
+# ##############################################################################
+# boards/arm/stm32/stm3210e-eval/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_bringup.c stm32_leds.c stm32_spi.c stm32_usbdev.c)
+
+if(CONFIG_STM32_FSMC)
+  list(APPEND SRCS stm32_lcd.c stm32_extcontext.c stm32_extmem.c
+       stm32_selectnor.c)
+  list(APPEND SRCS stm32_deselectnor.c stm32_selectsram.c stm32_deselectsram.c)
+  list(APPEND SRCS stm32_selectlcd.c stm32_deselectlcd.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+if(CONFIG_ADC)
+  list(APPEND SRCS stm32_adc.c)
+endif()
+
+if(CONFIG_USBMSC)
+  list(APPEND SRCS stm32_usbmsc.c)
+endif()
+
+if(CONFIG_USBDEV_COMPOSITE)
+  list(APPEND SRCS stm32_composite.c)
+endif()
+
+if(CONFIG_STM32_CAN_CHARDRIVER)
+  list(APPEND SRCS stm32_can.c)
+endif()
+
+if(CONFIG_ARCH_CUSTOM_PMINIT)
+  list(APPEND SRCS stm32_pm.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS stm32_buttons.c)
+
+  if(CONFIG_PM_BUTTONS)
+    list(APPEND SRCS stm32_pmbuttons.c)
+  endif()
+endif()
+
+if(CONFIG_INPUT_DJOYSTICK)
+  list(APPEND SRCS stm32_djoystick.c)
+endif()
+
+if(CONFIG_ARCH_IDLE_CUSTOM)
+  list(APPEND SRCS stm32_idle.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/ld.script")

--- a/boards/arm/stm32/stm3220g-eval/CMakeLists.txt
+++ b/boards/arm/stm32/stm3220g-eval/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32/stm3220g-eval/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32/stm3220g-eval/src/CMakeLists.txt
+++ b/boards/arm/stm32/stm3220g-eval/src/CMakeLists.txt
@@ -1,0 +1,71 @@
+# ##############################################################################
+# boards/arm/stm32/stm3220g-eval/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_spi.c)
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS stm32_autoleds.c)
+else()
+  list(APPEND SRCS stm32_userleds.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS stm32_buttons.c)
+endif()
+
+if(CONFIG_STM32_OTGFS)
+  list(APPEND SRCS stm32_usb.c)
+endif()
+
+if(CONFIG_STM32_FSMC)
+  list(
+    APPEND
+    SRCS
+    stm32_lcd.c
+    stm32_selectlcd.c
+    stm32_deselectlcd.c
+    stm32_selectsram.c
+    stm32_deselectsram.c
+    stm32_extmem.c)
+endif()
+
+if(CONFIG_ADC)
+  list(APPEND SRCS stm32_adc.c)
+endif()
+
+if(CONFIG_PWM)
+  list(APPEND SRCS stm32_pwm.c)
+endif()
+
+if(CONFIG_STM32_CAN_CHARDRIVER)
+  list(APPEND SRCS stm32_can.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+if(CONFIG_INPUT_STMPE811)
+  list(APPEND SRCS stm32_stmpe811.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/ld.script")

--- a/boards/arm/stm32/stm3240g-eval/CMakeLists.txt
+++ b/boards/arm/stm32/stm3240g-eval/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32/stm3240g-eval/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32/stm3240g-eval/src/CMakeLists.txt
+++ b/boards/arm/stm32/stm3240g-eval/src/CMakeLists.txt
@@ -1,0 +1,64 @@
+# ##############################################################################
+# boards/arm/stm32/stm3240g-eval/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_bringup.c stm32_spi.c)
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS stm32_autoleds.c)
+else()
+  list(APPEND SRCS stm32_userleds.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS stm32_buttons.c)
+endif()
+
+if(CONFIG_STM32_OTGFS)
+  list(APPEND SRCS stm32_usb.c)
+endif()
+
+if(CONFIG_STM32_FSMC)
+  list(APPEND SRCS stm32_lcd.c stm32_selectlcd.c stm32_deselectlcd.c)
+  list(APPEND SRCS stm32_selectsram.c stm32_deselectsram.c stm32_extmem.c)
+endif()
+
+if(CONFIG_ADC)
+  list(APPEND SRCS stm32_adc.c)
+endif()
+
+if(CONFIG_PWM)
+  list(APPEND SRCS stm32_pwm.c)
+endif()
+
+if(CONFIG_STM32_CAN_CHARDRIVER)
+  list(APPEND SRCS stm32_can.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+if(CONFIG_INPUT_STMPE811)
+  list(APPEND SRCS stm32_stmpe811.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/ld.script")

--- a/boards/arm/stm32/stm32_tiny/CMakeLists.txt
+++ b/boards/arm/stm32/stm32_tiny/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32/stm32_tiny/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32/stm32_tiny/src/CMakeLists.txt
+++ b/boards/arm/stm32/stm32_tiny/src/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# boards/arm/stm32/stm32_tiny/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_leds.c stm32_spi.c stm32_usbdev.c)
+
+if(CONFIG_PWM)
+  list(APPEND SRCS stm32_pwm.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/ld.script")

--- a/boards/arm/stm32/stm32butterfly2/CMakeLists.txt
+++ b/boards/arm/stm32/stm32butterfly2/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32/stm32butterfly2/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32/stm32butterfly2/src/CMakeLists.txt
+++ b/boards/arm/stm32/stm32butterfly2/src/CMakeLists.txt
@@ -1,0 +1,53 @@
+# ##############################################################################
+# boards/arm/stm32/stm32butterfly2/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_leds.c)
+
+if(CONFIG_STM32_ADC)
+  list(APPEND SRCS stm32_adc.c)
+endif()
+
+if(CONFIG_STM32_SPI1)
+  list(APPEND SRCS stm32_spi.c)
+endif()
+
+if(CONFIG_STM32_OTGFS)
+  list(APPEND SRCS stm32_usb.c)
+endif()
+
+if(CONFIG_STM32_USBHOST)
+  list(APPEND SRCS stm32_usbhost.c)
+endif()
+
+if(CONFIG_USBDEV)
+  list(APPEND SRCS stm32_usbdev.c)
+endif()
+
+if(CONFIG_MMCSD)
+  list(APPEND SRCS stm32_mmcsd.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS stm32_buttons.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash.ld")

--- a/boards/arm/stm32/stm32f103-minimum/src/CMakeLists.txt
+++ b/boards/arm/stm32/stm32f103-minimum/src/CMakeLists.txt
@@ -18,136 +18,99 @@
 #
 # ##############################################################################
 
-set(CSRCS)
+set(SRCS stm32_boot.c stm32_bringup.c stm32_spi.c)
 
-list(APPEND CSRCS stm32_boot.c stm32_bringup.c stm32_spi.c)
-
-if("${CONFIG_LIB_BOARDCTL}" STREQUAL "y")
-  list(APPEND CSRCS stm32_appinit.c)
-endif()
-
-if("${CONFIG_ARCH_BUTTONS}" STREQUAL "y")
-  list(APPEND CSRCS stm32_buttons.c)
-endif()
-
-if("${CONFIG_ARCH_LEDS}" STREQUAL "y")
-  list(APPEND CSRCS stm32_autoleds.c)
-else()
-  list(APPEND CSRCS stm32_userleds.c)
-endif()
-
-if("${CONFIG_ADC}" STREQUAL "y")
-  list(APPEND CSRCS stm32_adc.c)
-endif()
-
-if("${CONFIG_DEV_GPIO}" STREQUAL "y")
-  list(APPEND CSRCS stm32_gpio.c)
-endif()
-
-if("${CONFIG_PWM}" STREQUAL "y")
-  list(APPEND CSRCS stm32_pwm.c)
-endif()
-
-if("${CONFIG_SENSORS_ZEROCROSS}" STREQUAL "y")
-  list(APPEND CSRCS stm32_zerocross.c)
-endif()
-
-if("${CONFIG_LEDS_APA102}" STREQUAL "y")
-  list(APPEND CSRCS stm32_apa102.c)
-endif()
-
-if("${CONFIG_SENSORS_BMP180}" STREQUAL "y")
-  list(APPEND CSRCS stm32_bmp180.c)
-endif()
-
-if("${CONFIG_LM75_I2C}" STREQUAL "y")
-  list(APPEND CSRCS stm32_lm75.c)
-endif()
-
-if("${CONFIG_RGBLED}" STREQUAL "y")
-  list(APPEND CSRCS stm32_rgbled.c)
-endif()
-
-if("${CONFIG_MMCSD}" STREQUAL "y")
-  list(APPEND CSRCS stm32_mmcsd.c)
-endif()
-
-if("${CONFIG_MTD_W25}" STREQUAL "y")
-  list(APPEND CSRCS stm32_w25.c)
-endif()
-
-if("${CONFIG_MTD_AT24XX}" STREQUAL "y")
-  if("${CONFIG_STM32_I2C1}" STREQUAL "y")
-    list(APPEND CSRCS stm32_at24.c)
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+  if(CONFIG_BOARDCTL_RESET)
+    list(APPEND SRCS stm32_reset.c)
   endif()
 endif()
 
-if("${CONFIG_AUDIO_TONE}" STREQUAL "y")
-  list(APPEND CSRCS stm32_tone.c)
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS stm32_buttons.c)
 endif()
 
-if("${CONFIG_CAN_MCP2515}" STREQUAL "y")
-  list(APPEND CSRCS stm32_mcp2515.c)
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS stm32_autoleds.c)
+else()
+  list(APPEND SRCS stm32_userleds.c)
 endif()
 
-if("${CONFIG_CL_MFRC522}" STREQUAL "y")
-  list(APPEND CSRCS stm32_mfrc522.c)
+if(CONFIG_ADC)
+  list(APPEND SRCS stm32_adc.c)
 endif()
 
-if("${CONFIG_SENSORS_HCSR04}" STREQUAL "y")
-  list(APPEND CSRCS stm32_hcsr04.c)
+if(CONFIG_DEV_GPIO)
+  list(APPEND SRCS stm32_gpio.c)
 endif()
 
-if("${CONFIG_SENSORS_MAX6675}" STREQUAL "y")
-  list(APPEND CSRCS stm32_max6675.c)
+if(CONFIG_PWM)
+  list(APPEND SRCS stm32_pwm.c)
 endif()
 
-if("${CONFIG_LCD_MAX7219}" STREQUAL "y")
-  list(APPEND CSRCS stm32_max7219.c)
+if(CONFIG_SENSORS_HYT271)
+  list(APPEND SRCS stm32_hyt271.c)
 endif()
 
-if("${CONFIG_INPUT_NUNCHUCK}" STREQUAL "y")
-  list(APPEND CSRCS stm32_nunchuck.c)
+if(CONFIG_SENSORS_DS18B20)
+  list(APPEND SRCS stm32_ds18b20.c)
 endif()
 
-if("${CONFIG_LCD_SSD1306_I2C}" STREQUAL "y")
-  list(APPEND CSRCS stm32_ssd1306.c)
+if(CONFIG_RGBLED)
+  list(APPEND SRCS stm32_rgbled.c)
 endif()
 
-if("${CONFIG_LCD_ST7567}" STREQUAL "y")
-  list(APPEND CSRCS stm32_lcd.c)
+if(CONFIG_MMCSD)
+  list(APPEND SRCS stm32_mmcsd.c)
 endif()
 
-if("${CONFIG_LCD_PCD8544}" STREQUAL "y")
-  list(APPEND CSRCS stm32_pcd8544.c)
+if(CONFIG_MTD_W25)
+  list(APPEND SRCS stm32_w25.c)
 endif()
 
-if("${CONFIG_SENSORS_APDS9960}" STREQUAL "y")
-  list(APPEND CSRCS stm32_apds9960.c)
+if(CONFIG_MTD_AT24XX)
+  if(CONFIG_STM32_I2C1)
+    list(APPEND SRCS stm32_at24.c)
+  endif()
 endif()
 
-if("${CONFIG_SENSORS_QENCODER}" STREQUAL "y")
-  list(APPEND CSRCS stm32_qencoder.c)
+if(CONFIG_CAN_MCP2515)
+  list(APPEND SRCS stm32_mcp2515.c)
 endif()
 
-if("${CONFIG_SENSORS_VEML6070}" STREQUAL "y")
-  list(APPEND CSRCS stm32_veml6070.c)
+if(CONFIG_CL_MFRC522)
+  list(APPEND SRCS stm32_mfrc522.c)
 endif()
 
-if("${CONFIG_WL_NRF24L01}" STREQUAL "y")
-  list(APPEND CSRCS stm32_nrf24l01.c)
+if(CONFIG_LCD_MAX7219)
+  list(APPEND SRCS stm32_max7219.c)
 endif()
 
-if("${CONFIG_USBDEV}" STREQUAL "y")
-  list(APPEND CSRCS stm32_usbdev.c)
+if(CONFIG_INPUT_NUNCHUCK)
+  list(APPEND SRCS stm32_nunchuck.c)
 endif()
 
-if("${CONFIG_USBMSC}" STREQUAL "y")
-  list(APPEND CSRCS stm32_usbmsc.c)
+if(CONFIG_LCD_SSD1306_I2C)
+  list(APPEND SRCS stm32_lcd_ssd1306.c)
 endif()
 
-target_sources(board PRIVATE ${CSRCS})
+if(CONFIG_LCD_ST7567)
+  list(APPEND SRCS stm32_lcd_st7567.c)
+endif()
 
-# Configure linker script TODO: better to place this in boards/CMakeLists.txt?
+if(CONFIG_LCD_PCD8544)
+  list(APPEND SRCS stm32_pcd8544.c)
+endif()
+
+if(CONFIG_USBDEV)
+  list(APPEND SRCS stm32_usbdev.c)
+endif()
+
+if(CONFIG_USBMSC)
+  list(APPEND SRCS stm32_usbmsc.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
 
 set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/ld.script")

--- a/boards/arm/stm32/stm32f334-disco/CMakeLists.txt
+++ b/boards/arm/stm32/stm32f334-disco/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32/stm32f334-disco/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32/stm32f334-disco/src/CMakeLists.txt
+++ b/boards/arm/stm32/stm32f334-disco/src/CMakeLists.txt
@@ -1,0 +1,57 @@
+# ##############################################################################
+# boards/arm/stm32/stm32f334-disco/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c)
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS stm32_autoleds.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+if(CONFIG_STM32_CAN_CHARDRIVER)
+  list(APPEND SRCS stm32_can.c)
+endif()
+
+if(CONFIG_PWM)
+  list(APPEND SRCS stm32_pwm.c)
+endif()
+
+if(CONFIG_SPI)
+  list(APPEND SRCS stm32_spi.c)
+endif()
+
+if(CONFIG_TIMER)
+  list(APPEND SRCS stm32_timer.c)
+endif()
+
+if(CONFIG_DRIVERS_POWERLED)
+  list(APPEND SRCS stm32_powerled.c)
+endif()
+
+if(CONFIG_DRIVERS_SMPS)
+  list(APPEND SRCS stm32_smps.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/ld.script")

--- a/boards/arm/stm32/stm32f3discovery/CMakeLists.txt
+++ b/boards/arm/stm32/stm32f3discovery/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32/stm32f3discovery/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32/stm32f3discovery/src/CMakeLists.txt
+++ b/boards/arm/stm32/stm32f3discovery/src/CMakeLists.txt
@@ -1,0 +1,47 @@
+# ##############################################################################
+# boards/arm/stm32/stm32f3discovery/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_bringup.c stm32_spi.c)
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS stm32_autoleds.c)
+else()
+  list(APPEND SRCS stm32_userleds.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS stm32_buttons.c)
+endif()
+
+if(CONFIG_STM32_USB)
+  list(APPEND SRCS stm32_usb.c)
+endif()
+
+if(CONFIG_PWM)
+  list(APPEND SRCS stm32_pwm.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/ld.script")

--- a/boards/arm/stm32/stm32f411-minimum/CMakeLists.txt
+++ b/boards/arm/stm32/stm32f411-minimum/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32/stm32f411-minimum/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32/stm32f411-minimum/src/CMakeLists.txt
+++ b/boards/arm/stm32/stm32f411-minimum/src/CMakeLists.txt
@@ -1,0 +1,54 @@
+# ##############################################################################
+# boards/arm/stm32/stm32f411-minimum/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_bringup.c)
+
+if(CONFIG_NSH_LIBRARY)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS stm32_autoleds.c)
+endif()
+
+if(CONFIG_SPI)
+  list(APPEND SRCS stm32_spi.c)
+endif()
+
+if(CONFIG_MTD_W25)
+  list(APPEND SRCS stm32_w25.c)
+endif()
+
+if(CONFIG_STM32_OTGFS)
+  list(APPEND SRCS stm32_usb.c)
+endif()
+
+if(CONFIG_USBDEV_COMPOSITE)
+  list(APPEND SRCS stm32_composite.c)
+endif()
+
+if(CONFIG_USBMSC)
+  list(APPEND SRCS stm32_usbmsc.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT
+                             "${NUTTX_BOARD_DIR}/scripts/stm32f411ce.ld")

--- a/boards/arm/stm32/stm32f411e-disco/CMakeLists.txt
+++ b/boards/arm/stm32/stm32f411e-disco/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32/stm32f411e-disco/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32/stm32f411e-disco/src/CMakeLists.txt
+++ b/boards/arm/stm32/stm32f411e-disco/src/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# boards/arm/stm32/stm32f411e-disco/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_bringup.c)
+
+if(CONFIG_NSH_LIBRARY)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+if(CONFIG_STM32_OTGFS)
+  list(APPEND SRCS stm32_usb.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/f411ve.ld")

--- a/boards/arm/stm32/stm32f429i-disco/CMakeLists.txt
+++ b/boards/arm/stm32/stm32f429i-disco/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32/stm32f429i-disco/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32/stm32f429i-disco/src/CMakeLists.txt
+++ b/boards/arm/stm32/stm32f429i-disco/src/CMakeLists.txt
@@ -1,0 +1,77 @@
+# ##############################################################################
+# boards/arm/stm32/stm32f429i-disco/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_bringup.c stm32_spi.c)
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS stm32_autoleds.c)
+else()
+  list(APPEND SRCS stm32_userleds.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS stm32_buttons.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+if(CONFIG_ARCH_IDLE_CUSTOM)
+  list(APPEND SRCS stm32_idle.c)
+endif()
+
+if(CONFIG_STM32_FMC)
+  list(APPEND SRCS stm32_extmem.c)
+endif()
+
+if(CONFIG_STM32_OTGHS)
+  list(APPEND SRCS stm32_usb.c)
+endif()
+
+if(CONFIG_INPUT_STMPE811)
+  list(APPEND SRCS stm32_stmpe811.c)
+endif()
+
+if(CONFIG_STM32F429I_DISCO_ILI9341)
+  list(APPEND SRCS stm32_ili93414ws.c)
+endif()
+
+if(CONFIG_STM32F429I_DISCO_ILI9341_LCDIFACE
+   AND CONFIG_STM32F429I_DISCO_ILI9341_FBIFACE
+   AND CONFIG_STM32_LTDC)
+  list(APPEND SRCS stm32_lcd.c)
+endif()
+
+if(CONFIG_PWM)
+  list(APPEND SRCS stm32_pwm.c)
+endif()
+
+if(CONFIG_ADC)
+  list(APPEND SRCS stm32_adc.c)
+endif()
+
+if(CONFIG_STM32F429I_DISCO_HIGHPRI)
+  list(APPEND SRCS stm32_highpri.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/ld.script")

--- a/boards/arm/stm32/stm32ldiscovery/CMakeLists.txt
+++ b/boards/arm/stm32/stm32ldiscovery/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32/stm32ldiscovery/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32/stm32ldiscovery/src/CMakeLists.txt
+++ b/boards/arm/stm32/stm32ldiscovery/src/CMakeLists.txt
@@ -1,0 +1,53 @@
+# ##############################################################################
+# boards/arm/stm32/stm32ldiscovery/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_bringup.c stm32_spi.c)
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS stm32_autoleds.c)
+else()
+  list(APPEND SRCS stm32_userleds.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS stm32_buttons.c)
+endif()
+
+if(CONFIG_STM32_LCD)
+  list(APPEND SRCS stm32_lcd.c)
+endif()
+
+if(CONFIG_PWM)
+  list(APPEND SRCS stm32_pwm.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+if(CONFIG_ARCH_CHIP_STM32L152RB)
+  set_property(GLOBAL PROPERTY LD_SCRIPT
+                               "${NUTTX_BOARD_DIR}/scripts/stm32l152rb.ld")
+else()
+  set_property(GLOBAL PROPERTY LD_SCRIPT
+                               "${NUTTX_BOARD_DIR}/scripts/stm32l152rc.ld")
+endif()

--- a/boards/arm/stm32/stm32vldiscovery/CMakeLists.txt
+++ b/boards/arm/stm32/stm32vldiscovery/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/stm32/stm32vldiscovery/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32/stm32vldiscovery/src/CMakeLists.txt
+++ b/boards/arm/stm32/stm32vldiscovery/src/CMakeLists.txt
@@ -1,0 +1,30 @@
+# ##############################################################################
+# boards/arm/stm32/stm32vldiscovery/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_bringup.c stm32_leds.c stm32_buttons.c)
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT
+                             "${NUTTX_BOARD_DIR}/scripts/stm32vldiscovery.ld")


### PR DESCRIPTION
## Summary

- cmake: format Nordic boards
- cmake: port more stm32 boards and format already ported stm32 boards

## Impact

## Testing
CI
