### PR TITLE
arch/nrf91: fix for secure env only configurations

### DIFF
--- a/arch/arm/src/nrf91/nrf91_spu.c
+++ b/arch/arm/src/nrf91/nrf91_spu.c
@@ -185,9 +185,11 @@ void nrf91_spu_configure(void)
 
   sau_control(false, true);
 
+#if defined(CONFIG_NRF91_SPU_NONSECURE)
+  /* Make all interrupts non-secure */
+
   up_secure_irq_all(false);
 
-#if defined(CONFIG_NRF91_SPU_NONSECURE)
   /* Peripheral configuration */
 
   nrf91_spu_periph();


### PR DESCRIPTION
## Summary

- arch/nrf91: make all interrupts non-secure only if CONFIG_NRF91_SPU_NONSECURE=y
    this fixes configurations that works only in secure environment (for testing and dev purposes)
## Impact
fix nrf9160-dk/nsh
## Testing
nrf9160-dk/nsh
