### PR TITLE
Revert "drivers/video: Don't need update vbuf_tail in dequeue_vbuf_unsafe

### DIFF
--- a/drivers/video/video_framebuff.c
+++ b/drivers/video/video_framebuff.c
@@ -70,6 +70,11 @@ static inline vbuf_container_t *dequeue_vbuf_unsafe(video_framebuff_t *fbuf)
     }
   else
     {
+      if (fbuf->mode == V4L2_BUF_MODE_RING)
+        {
+          fbuf->vbuf_tail->next = fbuf->vbuf_top->next;
+        }
+
       fbuf->vbuf_top = fbuf->vbuf_top->next;
     }
 


### PR DESCRIPTION
…safe"

This reverts commit e15bccaa7187cf986cfa14597e6b6301c35eb48d.

## Summary

## Impact

## Testing

