### PR TITLE
net/ipfrag:Fixed ref not initializing warning issue

### DIFF
--- a/net/ipfrag/ipv4_frag.c
+++ b/net/ipfrag/ipv4_frag.c
@@ -361,7 +361,7 @@ int32_t ipv4_fragout(FAR struct net_driver_s *dev, uint16_t mtu)
   uint16_t offset = 0;
   uint16_t hdrlen;
   FAR struct iob_s *frag;
-  FAR struct ipv4_hdr_s *ref;
+  FAR struct ipv4_hdr_s *ref = NULL;
   struct iob_queue_s fragq =
     {
       NULL, NULL

--- a/net/ipfrag/ipv6_frag.c
+++ b/net/ipfrag/ipv6_frag.c
@@ -569,7 +569,7 @@ int32_t ipv6_fragout(FAR struct net_driver_s *dev, uint16_t mtu)
   uint16_t hdroff;
   uint16_t hdrtype;
   FAR struct iob_s *frag;
-  FAR struct ipv6_hdr_s *ref;
+  FAR struct ipv6_hdr_s *ref = NULL;
   FAR struct ipv6_fragment_extension_s *fraghdr;
   struct iob_queue_s fragq =
     {


### PR DESCRIPTION
## Summary
Fixed ref not initializing warning issue
CC: libssh/src/auth.c
1ipfrag/ipv4_frag.c: In function 'ipv4_fragout':
ipfrag/ipv4_frag.c:224:7: error: 'ref' may be used uninitialized in this function [-Werror-maybe-uninitialized]
      224 |      lmemcpy(ipv4, ref, iphdrlen);
ipfrag/ipv4_frag.c:364:26: note: 'ref' was declared here
      364 |   FAR struct ipv4_hdr_s *ref;
CC: tls/task initinfo c
## Impact
minor
## Testing

