### PR TITLE
arch: move [enter|leave]_critical_section

### DIFF
--- a/arch/arm/src/armv6-m/arm_schedulesigaction.c
+++ b/arch/arm/src/armv6-m/arm_schedulesigaction.c
@@ -351,13 +351,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 #endif
                 }
 
-              /* Increment the IRQ lock count so that when the task is
-               * restarted, it will hold the IRQ spinlock.
-               */
-
-              DEBUGASSERT(tcb->irqcount < INT16_MAX);
-              tcb->irqcount++;
-
               /* NOTE: If the task runs on another CPU(cpu), adjusting
                * global IRQ controls will be done in the pause handler
                * on the CPU(cpu) by taking a critical section.
@@ -402,13 +395,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
           tcb->xcp.regs[REG_SP]      = (uint32_t)tcb->xcp.regs +
                                                  XCPTCONTEXT_SIZE;
-
-          /* Increment the IRQ lock count so that when the task is restarted,
-           * it will hold the IRQ spinlock.
-           */
-
-          DEBUGASSERT(tcb->irqcount < INT16_MAX);
-          tcb->irqcount++;
 
           /* Then set up to vector to the trampoline with interrupts
            * disabled.  We must already be in privileged thread mode to be

--- a/arch/arm/src/armv6-m/arm_sigdeliver.c
+++ b/arch/arm/src/armv6-m/arm_sigdeliver.c
@@ -63,6 +63,8 @@ void arm_sigdeliver(void)
    */
 
   int16_t saved_irqcount;
+
+  enter_critical_section();
 #endif
 
   board_autoled_on(LED_SIGNAL);
@@ -154,6 +156,10 @@ retry:
 
   board_autoled_off(LED_SIGNAL);
 #ifdef CONFIG_SMP
+  /* We need to keep the IRQ lock until task switching */
+
+  rtcb->irqcount++;
+  leave_critical_section((uint16_t)regs[REG_PRIMASK]);
   rtcb->irqcount--;
 #endif
   arm_fullcontextrestore(regs);

--- a/arch/arm/src/armv7-a/arm_schedulesigaction.c
+++ b/arch/arm/src/armv7-a/arm_schedulesigaction.c
@@ -349,13 +349,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 #endif
                 }
 
-              /* Increment the IRQ lock count so that when the task is
-               * restarted, it will hold the IRQ spinlock.
-               */
-
-              DEBUGASSERT(tcb->irqcount < INT16_MAX);
-              tcb->irqcount++;
-
               /* NOTE: If the task runs on another CPU(cpu), adjusting
                * global IRQ controls will be done in the pause handler
                * on the CPU(cpu) by taking a critical section.
@@ -400,13 +393,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
           tcb->xcp.regs[REG_SP]    = (uint32_t)tcb->xcp.regs +
                                                XCPTCONTEXT_SIZE;
-
-          /* Increment the IRQ lock count so that when the task is restarted,
-           * it will hold the IRQ spinlock.
-           */
-
-          DEBUGASSERT(tcb->irqcount < INT16_MAX);
-          tcb->irqcount++;
 
           /* Then set up to vector to the trampoline with interrupts
            * disabled

--- a/arch/arm/src/armv7-a/arm_sigdeliver.c
+++ b/arch/arm/src/armv7-a/arm_sigdeliver.c
@@ -63,6 +63,8 @@ void arm_sigdeliver(void)
    */
 
   int16_t saved_irqcount;
+
+  enter_critical_section();
 #endif
 
   board_autoled_on(LED_SIGNAL);
@@ -152,6 +154,10 @@ retry:
 
   board_autoled_off(LED_SIGNAL);
 #ifdef CONFIG_SMP
+  /* We need to keep the IRQ lock until task switching */
+
+  rtcb->irqcount++;
+  leave_critical_section(regs[REG_CPSR]);
   rtcb->irqcount--;
 #endif
   arm_fullcontextrestore(regs);

--- a/arch/arm/src/armv7-m/arm_schedulesigaction.c
+++ b/arch/arm/src/armv7-m/arm_schedulesigaction.c
@@ -368,13 +368,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 #endif
                 }
 
-              /* Increment the IRQ lock count so that when the task is
-               * restarted, it will hold the IRQ spinlock.
-               */
-
-              DEBUGASSERT(tcb->irqcount < INT16_MAX);
-              tcb->irqcount++;
-
               /* NOTE: If the task runs on another CPU(cpu), adjusting
                * global IRQ controls will be done in the pause handler
                * on the CPU(cpu) by taking a critical section.
@@ -419,13 +412,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
           tcb->xcp.regs[REG_SP]      = (uint32_t)tcb->xcp.regs +
                                                  XCPTCONTEXT_SIZE;
-
-          /* Increment the IRQ lock count so that when the task is restarted,
-           * it will hold the IRQ spinlock.
-           */
-
-          DEBUGASSERT(tcb->irqcount < INT16_MAX);
-          tcb->irqcount++;
 
           /* Then set up to vector to the trampoline with interrupts
            * disabled.  We must already be in privileged thread mode to be

--- a/arch/arm/src/armv7-m/arm_sigdeliver.c
+++ b/arch/arm/src/armv7-m/arm_sigdeliver.c
@@ -63,6 +63,8 @@ void arm_sigdeliver(void)
    */
 
   int16_t saved_irqcount;
+
+  enter_critical_section();
 #endif
 
   board_autoled_on(LED_SIGNAL);
@@ -158,6 +160,14 @@ retry:
 
   board_autoled_off(LED_SIGNAL);
 #ifdef CONFIG_SMP
+  /* We need to keep the IRQ lock until task switching */
+
+  rtcb->irqcount++;
+#ifdef CONFIG_ARMV7M_USEBASEPRI
+  leave_critical_section((uint8_t)regs[REG_BASEPRI]);
+#else
+  leave_critical_section((uint16_t)regs[REG_PRIMASK]);
+#endif
   rtcb->irqcount--;
 #endif
   arm_fullcontextrestore(regs);

--- a/arch/arm/src/armv7-r/arm_schedulesigaction.c
+++ b/arch/arm/src/armv7-r/arm_schedulesigaction.c
@@ -352,13 +352,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 #endif
                 }
 
-              /* Increment the IRQ lock count so that when the task is
-               * restarted, it will hold the IRQ spinlock.
-               */
-
-              DEBUGASSERT(tcb->irqcount < INT16_MAX);
-              tcb->irqcount++;
-
               /* NOTE: If the task runs on another CPU(cpu), adjusting
                * global IRQ controls will be done in the pause handler
                * on the CPU(cpu) by taking a critical section.
@@ -403,13 +396,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
           tcb->xcp.regs[REG_SP]    = (uint32_t)tcb->xcp.regs +
                                                XCPTCONTEXT_SIZE;
-
-          /* Increment the IRQ lock count so that when the task is restarted,
-           * it will hold the IRQ spinlock.
-           */
-
-          DEBUGASSERT(tcb->irqcount < INT16_MAX);
-          tcb->irqcount++;
 
           /* Then set up to vector to the trampoline with interrupts
            * disabled

--- a/arch/arm/src/armv7-r/arm_sigdeliver.c
+++ b/arch/arm/src/armv7-r/arm_sigdeliver.c
@@ -63,6 +63,8 @@ void arm_sigdeliver(void)
    */
 
   int16_t saved_irqcount;
+
+  enter_critical_section();
 #endif
 
   board_autoled_on(LED_SIGNAL);
@@ -149,6 +151,10 @@ retry:
 
   board_autoled_off(LED_SIGNAL);
 #ifdef CONFIG_SMP
+  /* We need to keep the IRQ lock until task switching */
+
+  rtcb->irqcount++;
+  leave_critical_section(regs[REG_CPSR]);
   rtcb->irqcount--;
 #endif
   arm_fullcontextrestore(regs);

--- a/arch/arm/src/armv8-m/arm_schedulesigaction.c
+++ b/arch/arm/src/armv8-m/arm_schedulesigaction.c
@@ -368,13 +368,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 #endif
                 }
 
-              /* Increment the IRQ lock count so that when the task is
-               * restarted, it will hold the IRQ spinlock.
-               */
-
-              DEBUGASSERT(tcb->irqcount < INT16_MAX);
-              tcb->irqcount++;
-
               /* In an SMP configuration, the interrupt disable logic also
                * involves spinlocks that are configured per the TCB irqcount
                * field.  This is logically equivalent to
@@ -423,13 +416,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
           tcb->xcp.regs[REG_SP]      = (uint32_t)tcb->xcp.regs +
                                                  XCPTCONTEXT_SIZE;
-
-          /* Increment the IRQ lock count so that when the task is restarted,
-           * it will hold the IRQ spinlock.
-           */
-
-          DEBUGASSERT(tcb->irqcount < INT16_MAX);
-          tcb->irqcount++;
 
           /* Then set up to vector to the trampoline with interrupts
            * disabled.  We must already be in privileged thread mode to be

--- a/arch/arm/src/armv8-m/arm_sigdeliver.c
+++ b/arch/arm/src/armv8-m/arm_sigdeliver.c
@@ -63,6 +63,8 @@ void arm_sigdeliver(void)
    */
 
   int16_t saved_irqcount;
+
+  enter_critical_section();
 #endif
 
   board_autoled_on(LED_SIGNAL);
@@ -158,6 +160,14 @@ retry:
 
   board_autoled_off(LED_SIGNAL);
 #ifdef CONFIG_SMP
+  /* We need to keep the IRQ lock until task switching */
+
+  rtcb->irqcount++;
+#ifdef CONFIG_ARMV8M_USEBASEPRI
+  leave_critical_section((uint8_t)regs[REG_BASEPRI]);
+#else
+  leave_critical_section((uint16_t)regs[REG_PRIMASK]);
+#endif
   rtcb->irqcount--;
 #endif
   arm_fullcontextrestore(regs);

--- a/arch/arm64/src/common/arm64_schedulesigaction.c
+++ b/arch/arm64/src/common/arm64_schedulesigaction.c
@@ -310,13 +310,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                   CURRENT_REGS = tcb->xcp.regs;
                 }
 
-              /* Increment the IRQ lock count so that when the task is
-               * restarted, it will hold the IRQ spinlock.
-               */
-
-              DEBUGASSERT(tcb->irqcount < INT16_MAX);
-              tcb->irqcount++;
-
               /* NOTE: If the task runs on another CPU(cpu), adjusting
                * global IRQ controls will be done in the pause handler
                * on the CPU(cpu) by taking a critical section.
@@ -353,13 +346,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
           /* create signal process context */
 
           arm64_init_signal_process(tcb, NULL);
-
-          /* Increment the IRQ lock count so that when the task is restarted,
-           * it will hold the IRQ spinlock.
-           */
-
-          DEBUGASSERT(tcb->irqcount < INT16_MAX);
-          tcb->irqcount++;
         }
     }
 }

--- a/arch/arm64/src/common/arm64_sigdeliver.c
+++ b/arch/arm64/src/common/arm64_sigdeliver.c
@@ -71,6 +71,7 @@ void arm64_sigdeliver(void)
   struct regs_context  *pctx =
                 (struct regs_context *)rtcb->xcp.saved_reg;
   flags = (pctx->spsr & SPSR_DAIF_MASK);
+  enter_critical_section();
 #endif
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
@@ -163,6 +164,10 @@ retry:
   /* Then restore the correct state for this thread of execution. */
 
 #ifdef CONFIG_SMP
+  /* We need to keep the IRQ lock until task switching */
+
+  rtcb->irqcount++;
+  leave_critical_section(flags);
   rtcb->irqcount--;
 #endif
   arm64_fullcontextrestore(rtcb->xcp.regs);

--- a/arch/risc-v/src/common/riscv_schedulesigaction.c
+++ b/arch/risc-v/src/common/riscv_schedulesigaction.c
@@ -359,13 +359,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                   CURRENT_REGS[REG_INT_CTX] = int_ctx;
                 }
 
-              /* Increment the IRQ lock count so that when the task is
-               * restarted, it will hold the IRQ spinlock.
-               */
-
-              DEBUGASSERT(tcb->irqcount < INT16_MAX);
-              tcb->irqcount++;
-
               /* NOTE: If the task runs on another CPU(cpu), adjusting
                * global IRQ controls will be done in the pause handler
                * on the CPU(cpu) by taking a critical section.
@@ -410,13 +403,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
           tcb->xcp.regs[REG_SP]      = (uintptr_t)tcb->xcp.regs +
                                                   XCPTCONTEXT_SIZE;
-
-          /* Increment the IRQ lock count so that when the task is restarted,
-           * it will hold the IRQ spinlock.
-           */
-
-          DEBUGASSERT(tcb->irqcount < INT16_MAX);
-          tcb->irqcount++;
 
           /* Then set up to vector to the trampoline with interrupts
            * disabled.  We must already be in privileged thread mode to be

--- a/arch/risc-v/src/common/riscv_sigdeliver.c
+++ b/arch/risc-v/src/common/riscv_sigdeliver.c
@@ -64,6 +64,8 @@ void riscv_sigdeliver(void)
    */
 
   int16_t saved_irqcount;
+
+  enter_critical_section();
 #endif
 
   board_autoled_on(LED_SIGNAL);
@@ -153,6 +155,10 @@ retry:
 
   board_autoled_off(LED_SIGNAL);
 #ifdef CONFIG_SMP
+  /* We need to keep the IRQ lock until task switching */
+
+  rtcb->irqcount++;
+  leave_critical_section(regs[REG_INT_CTX]);
   rtcb->irqcount--;
 #endif
   riscv_fullcontextrestore(regs);

--- a/arch/sparc/src/sparc_v8/sparc_v8_schedulesigaction.c
+++ b/arch/sparc/src/sparc_v8/sparc_v8_schedulesigaction.c
@@ -297,13 +297,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                   sparc_savestate(tcb->xcp.regs);
                 }
 
-              /* Increment the IRQ lock count so that when the task is
-               * restarted, it will hold the IRQ spinlock.
-               */
-
-              DEBUGASSERT(tcb->irqcount < INT16_MAX);
-              tcb->irqcount++;
-
               /* NOTE: If the task runs on another CPU(cpu), adjusting
                * global IRQ controls will be done in the pause handler
                * on the CPU(cpu) by taking a critical section.
@@ -335,13 +328,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
           tcb->xcp.saved_pc     = CURRENT_REGS[REG_PC];
           tcb->xcp.saved_npc    = CURRENT_REGS[REG_NPC];
           tcb->xcp.saved_status = CURRENT_REGS[REG_PSR];
-
-          /* Increment the IRQ lock count so that when the task is restarted,
-           * it will hold the IRQ spinlock.
-           */
-
-          DEBUGASSERT(tcb->irqcount < INT16_MAX);
-          tcb->irqcount++;
 
           /* Then set up to vector to the trampoline with interrupts
            * disabled.  We must already be in privileged thread mode to be

--- a/arch/sparc/src/sparc_v8/sparc_v8_sigdeliver.c
+++ b/arch/sparc/src/sparc_v8/sparc_v8_sigdeliver.c
@@ -72,6 +72,8 @@ void sparc_sigdeliver(void)
    */
 
   int16_t saved_irqcount;
+
+  enter_critical_section();
 #endif
 
   board_autoled_on(LED_SIGNAL);
@@ -203,6 +205,10 @@ retry:
 
   board_autoled_off(LED_SIGNAL);
 #ifdef CONFIG_SMP
+  /* We need to keep the IRQ lock until task switching */
+
+  rtcb->irqcount++;
+  leave_critical_section((regs[REG_PSR]));
   rtcb->irqcount--;
 #endif
   sparc_fullcontextrestore(regs);

--- a/arch/xtensa/src/common/xtensa_schedsigaction.c
+++ b/arch/xtensa/src/common/xtensa_schedsigaction.c
@@ -391,13 +391,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 #endif
                 }
 
-              /* Increment the IRQ lock count so that when the task is
-               * restarted, it will hold the IRQ spinlock.
-               */
-
-              DEBUGASSERT(tcb->irqcount < INT16_MAX);
-              tcb->irqcount++;
-
               /* NOTE: If the task runs on another CPU(cpu), adjusting
                * global IRQ controls will be done in the pause handler
                * on the CPU(cpu) by taking a critical section.
@@ -441,13 +434,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
           tcb->xcp.regs[REG_A1] = (uint32_t)tcb->xcp.regs +
                                             XCPTCONTEXT_SIZE;
-
-          /* Increment the IRQ lock count so that when the task is restarted,
-           * it will hold the IRQ spinlock.
-           */
-
-          DEBUGASSERT(tcb->irqcount < INT16_MAX);
-          tcb->irqcount++;
 
           /* Then set up to vector to the trampoline with interrupts
            * disabled

--- a/arch/xtensa/src/common/xtensa_sigdeliver.c
+++ b/arch/xtensa/src/common/xtensa_sigdeliver.c
@@ -63,6 +63,8 @@ void xtensa_sig_deliver(void)
    */
 
   int16_t saved_irqcount;
+
+  enter_critical_section();
 #endif
 
   board_autoled_on(LED_SIGNAL);
@@ -151,6 +153,10 @@ retry:
 
   board_autoled_off(LED_SIGNAL);
 #ifdef CONFIG_SMP
+  /* We need to keep the IRQ lock until task switching */
+
+  rtcb->irqcount++;
+  leave_critical_section((regs[REG_PS]));
   rtcb->irqcount--;
 #endif
   xtensa_context_restore(regs);


### PR DESCRIPTION


## Summary
move [enter|leave]_critical_section to the same place for easy to understand and call matching

## Impact
none

## Testing
ostest
