### PR TITLE
binfmt: remove sched_[un]lock

### DIFF
--- a/binfmt/binfmt_loadmodule.c
+++ b/binfmt/binfmt_loadmodule.c
@@ -103,12 +103,6 @@ static int load_absmodule(FAR struct binary_s *bin, FAR const char *filename,
 
   binfo("Loading %s\n", filename);
 
-  /* Disabling pre-emption should be sufficient protection while accessing
-   * the list of registered binary format handlers.
-   */
-
-  sched_lock();
-
   /* Traverse the list of registered binary format handlers.  Stop
    * when either (1) a handler recognized and loads the format, or
    * (2) no handler recognizes the format.
@@ -133,7 +127,6 @@ static int load_absmodule(FAR struct binary_s *bin, FAR const char *filename,
         }
     }
 
-  sched_unlock();
   return ret;
 }
 

--- a/binfmt/binfmt_register.c
+++ b/binfmt/binfmt_register.c
@@ -60,10 +60,8 @@ int register_binfmt(FAR struct binfmt_s *binfmt)
        * handlers
        */
 
-      sched_lock();
       binfmt->next = g_binfmts;
       g_binfmts    = binfmt;
-      sched_unlock();
       return OK;
     }
 

--- a/binfmt/binfmt_unregister.c
+++ b/binfmt/binfmt_unregister.c
@@ -60,12 +60,6 @@ int unregister_binfmt(FAR struct binfmt_s *binfmt)
 
   if (binfmt)
     {
-      /* Disabling pre-emption should be sufficient protection while
-       * accessing the list of registered binary format handlers.
-       */
-
-      sched_lock();
-
       /* Search the list of registered binary format handlers for the
        * one to be unregistered.
        */
@@ -96,8 +90,6 @@ int unregister_binfmt(FAR struct binfmt_s *binfmt)
           binfmt->next = NULL;
           ret = OK;
         }
-
-      sched_unlock();
     }
 
   return ret;


### PR DESCRIPTION
## Summary
In the current usage mode, multiple tasks will not modify g_binfmts simultaneously

## Impact
none

## Testing
ostest

