### PR TITLE
arch: cxd56xx: Fix compile error

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_emmc.c
+++ b/arch/arm/src/cxd56xx/cxd56_emmc.c
@@ -26,6 +26,7 @@
 
 #include <sys/param.h>
 #include <sys/types.h>
+#include <inttypes.h>
 #include <stdint.h>
 #include <string.h>
 #include <assert.h>


### PR DESCRIPTION
## Summary
Add inttypes.h to fix a compile error in cxd56_emmc.c
which is caused by https://github.com/apache/nuttx/pull/9837.

## Impact
None

## Testing
Build pass
