### PR TITLE
driver/audio/cxd56: Support 24bit, 192kHz and 4ch max

### DIFF
--- a/drivers/audio/cxd56.c
+++ b/drivers/audio/cxd56.c
@@ -1983,7 +1983,7 @@ static int cxd56_power_on_analog_output(FAR struct cxd56_dev_s *dev)
 }
 
 static int cxd56_set_mic_gains(uint8_t gain, enum cxd56_mic_type_e mic_dev,
-                                struct cxd56_aca_pwinput_param_s *param)
+                               struct cxd56_aca_pwinput_param_s *param)
 {
   int i;
   uint32_t mic_gain = (gain >= CXD56_MIC_GAIN_MAX) ?  CXD56_MIC_GAIN_MAX :
@@ -2002,13 +2002,13 @@ static int cxd56_set_mic_gains(uint8_t gain, enum cxd56_mic_type_e mic_dev,
     }
 
   if (fw_as_acacontrol(CXD56_ACA_CTL_INIT_AMIC,
-                     (uint32_t)param) != 0)
+                       (uint32_t)param) != 0)
     {
       return -EBUSY;
     }
 
   if (fw_as_acacontrol(CXD56_ACA_CTL_POWER_ON_INPUT,
-                     (uint32_t)param) != 0)
+                       (uint32_t)param) != 0)
     {
       return -EBUSY;
     }
@@ -2805,7 +2805,7 @@ static int cxd56_configure(FAR struct audio_lowerhalf_s *lower,
             audinfo("    Mic gain: %d\n", priv->mic_gain);
 
             if (priv->state != CXD56_DEV_STATE_OFF &&
-                priv->state != CXD56_DEV_STATE_STOPPED )
+                priv->state != CXD56_DEV_STATE_STOPPED)
               {
                 struct cxd56_aca_pwinput_param_s param;
                 if (cxd56_set_mic_gains(priv->mic_gain,
@@ -2854,7 +2854,7 @@ static int cxd56_configure(FAR struct audio_lowerhalf_s *lower,
 
         audinfo("Configured output using %d:\n", priv->dma_handle);
         audinfo("  Channels:    %d\n", priv->channels);
-        audinfo("  Samplerate:  %ld\n", priv->samplerate);
+        audinfo("  Samplerate:  %" PRIu32 "\n", priv->samplerate);
         audinfo("  Bit width:   %d\n", priv->bitwidth);
       }
       break;
@@ -2874,7 +2874,7 @@ static int cxd56_configure(FAR struct audio_lowerhalf_s *lower,
 
         audinfo("Configured input using %d:\n", priv->dma_handle);
         audinfo("  Channels:    %d\n", priv->channels);
-        audinfo("  Samplerate:  %ld\n", priv->samplerate);
+        audinfo("  Samplerate:  %" PRIu32 "\n", priv->samplerate);
         audinfo("  Bit width:   %d\n", priv->bitwidth);
       }
       break;

--- a/drivers/audio/cxd56.h
+++ b/drivers/audio/cxd56.h
@@ -279,13 +279,14 @@ struct cxd56_dev_s
   struct dq_queue_s       down_doneq;       /* Done SRC buffers to be re-used */
 #endif
 
-  uint16_t                samplerate;       /* Sample rate */
+  uint32_t                samplerate;       /* Sample rate */
 #ifndef CONFIG_AUDIO_EXCLUDE_VOLUME
   int16_t                 volume;           /* Output volume {0..63} */
 #endif  /* CONFIG_AUDIO_EXCLUDE_VOLUME */
   uint8_t                 channels;         /* Number of channels (1..8) */
 
   uint16_t                mic_gain;         /* Mic gain */
+  uint16_t                mic_dev;          /* Mic device */
   uint64_t                mic_boot_start;   /* Mic startup wait time */
 
   uint8_t                 bitwidth;         /* Bits per sample (16 or 24) */

--- a/drivers/audio/cxd56_src.c
+++ b/drivers/audio/cxd56_src.c
@@ -427,7 +427,7 @@ int cxd56_src_init(FAR struct cxd56_dev_s *dev,
   snprintf(g_src.mqname, sizeof(g_src.mqname), "/tmp/%X",
            (unsigned int) &g_src);
 
-  audinfo("SRC: Init (rate = %d, channels = %d, width = %d)\n",
+  audinfo("SRC: Init (rate = %ld, channels = %d, width = %d)\n",
           dev->samplerate, g_src.channels, g_src.bytewidth);
 
   m_attr.mq_maxmsg  = 16;

--- a/drivers/audio/cxd56_src.c
+++ b/drivers/audio/cxd56_src.c
@@ -425,9 +425,9 @@ int cxd56_src_init(FAR struct cxd56_dev_s *dev,
   g_src.channels = dev->channels;
   g_src.float_in_offset = 0;
   snprintf(g_src.mqname, sizeof(g_src.mqname), "/tmp/%X",
-           (unsigned int) &g_src);
+           (unsigned int)&g_src);
 
-  audinfo("SRC: Init (rate = %ld, channels = %d, width = %d)\n",
+  audinfo("SRC: Init (rate = %" PRIu32 ", channels = %d, width = %d)\n",
           dev->samplerate, g_src.channels, g_src.bytewidth);
 
   m_attr.mq_maxmsg  = 16;


### PR DESCRIPTION
## Summary

Support CXD56 audio input for 192kHz sampleing rate, 24bit and 4channels.

refs #16249

## Impact

Spresense Audio Functionality only

## Testing

Test if nxplayer and nxrecorder work fine on Spresense board.