### PR TITLE
rpmsgclk: allow client to disable clk of server

### DIFF
--- a/drivers/clk/clk.c
+++ b/drivers/clk/clk.c
@@ -679,7 +679,7 @@ static int __clk_disable(FAR struct clk_s *clk)
         }
     }
 
-  return clk->enable_count + 1;
+  return clk->enable_count;
 }
 
 static void clk_init_parent(FAR struct clk_s *clk)

--- a/drivers/clk/clk_rpmsg.c
+++ b/drivers/clk/clk_rpmsg.c
@@ -902,8 +902,7 @@ FAR struct clk_s *clk_register_rpmsg(FAR const char *name, uint8_t flags)
       return NULL;
     }
 
-  return clk_register(name, NULL, 0, flags | CLK_IS_CRITICAL,
-                      &g_clk_rpmsg_ops, NULL, 0);
+  return clk_register(name, NULL, 0, flags, &g_clk_rpmsg_ops, NULL, 0);
 }
 
 int clk_rpmsg_server_initialize(void)


### PR DESCRIPTION
## Summary
allow client to disable clk of server

## Impact
rpmsgclk

## Testing
internel testing
