### PR TITLE
driver/adc: fill in missing parameters about adc driver

### DIFF
--- a/include/nuttx/analog/adc.h
+++ b/include/nuttx/analog/adc.h
@@ -62,7 +62,7 @@
 #define ADC_RESET(dev)         ((dev)->ad_ops->ao_reset((dev)))
 #define ADC_SETUP(dev)         ((dev)->ad_ops->ao_setup((dev)))
 #define ADC_SHUTDOWN(dev)      ((dev)->ad_ops->ao_shutdown((dev)))
-#define ADC_RXINT(dev)         ((dev)->ad_ops->ao_rxint((dev)))
+#define ADC_RXINT(dev,enable)  ((dev)->ad_ops->ao_rxint((dev),(enable)))
 #define ADC_IOCTL(dev,cmd,arg) ((dev)->ad_ops->ao_ioctl((dev),(cmd),(arg)))
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
driver/adc: fill in missing parameters about adc driver
## Impact
call ADC_RXINT  correctly.
## Testing
daily test
