### PR TITLE
ltp: sigprocmask fix

### DIFF
--- a/sched/pthread/pthread_sigmask.c
+++ b/sched/pthread/pthread_sigmask.c
@@ -64,6 +64,19 @@
 
 int pthread_sigmask(int how, FAR const sigset_t *set, FAR sigset_t *oset)
 {
-  int ret = nxsig_procmask(how, set, oset);
+  sigset_t nset;
+  int ret;
+
+  /* SIGKILL and SIGSTOP should not be added to signal mask */
+
+  if (set != NULL)
+    {
+      nset = *set;
+      nxsig_delset(&nset, SIGKILL);
+      nxsig_delset(&nset, SIGSTOP);
+      set = &nset;
+    }
+
+  ret = nxsig_procmask(how, set, oset);
   return ret < 0 ? -ret : OK;
 }

--- a/sched/signal/sig_procmask.c
+++ b/sched/signal/sig_procmask.c
@@ -187,7 +187,18 @@ int nxsig_procmask(int how, FAR const sigset_t *set, FAR sigset_t *oset)
 
 int sigprocmask(int how, FAR const sigset_t *set, FAR sigset_t *oset)
 {
+  sigset_t nset;
   int ret;
+
+  /* SIGKILL and SIGSTOP should not be added to signal mask */
+
+  if (set != NULL)
+    {
+      nset = *set;
+      nxsig_delset(&nset, SIGKILL);
+      nxsig_delset(&nset, SIGSTOP);
+      set = &nset;
+    }
 
   /* Let nxsig_procmask do all of the work */
 


### PR DESCRIPTION
## Summary
problem: SIGKILL and SIGSTOP should not be added in signal mask;
solution: check before adding signal to signal mask

## Impact
ostest: sigprocmask (under /apps/testing/ostest) will fail, so I change ostest: sigprocmask.c together
## Testing

