### PR TITLE
fs/semaphore: fix sem_open

### DIFF
--- a/fs/semaphore/sem_open.c
+++ b/fs/semaphore/sem_open.c
@@ -103,6 +103,21 @@ FAR sem_t *sem_open(FAR const char *name, int oflags, ...)
 
   DEBUGASSERT(name != NULL);
 
+  if (name[0] == '/')
+    {
+      if (strlen(name) >= PATH_MAX)
+        {
+          set_errno(ENAMETOOLONG);
+          return SEM_FAILED;
+        }
+
+      if (strlen(strrchr(name, '/') + 1) >= NAME_MAX)
+        {
+          set_errno(ENAMETOOLONG);
+          return SEM_FAILED;
+        }
+    }
+
   /* The POSIX specification requires that the "check for the existence
    * of a semaphore and the creation of the semaphore if it does not
    * exist shall be atomic with respect to other processes executing


### PR DESCRIPTION
## Summary
update the logic when the semaphore name length is greater than PATH_MAX or a component length is greater than NAME_MAX.

Follow the POSIX specification in https://pubs.opengroup.org/onlinepubs/9699919799/functions/sem_open.html, update the logic for condition that the semaphore name length is greater than PATH_MAX or a component length is greater than NAME_MAX.

## Impact

## Testing

