### PR TITLE
Add txt partition table parser

### DIFF
--- a/fs/partition/Kconfig
+++ b/fs/partition/Kconfig
@@ -19,6 +19,18 @@ config GPT_PARTITION
 	bool "GPT support"
 	default n
 
+config TXTABLE_PARTITION
+	bool "TXTABLE support"
+	default n
+
+if TXTABLE_PARTITION
+
+config TXTABLE_PARTITION_MAX_NUM
+	int "Max num of TXTABLE partition"
+	default 16
+
+endif
+
 endmenu
 
 endif

--- a/fs/partition/Kconfig
+++ b/fs/partition/Kconfig
@@ -26,8 +26,22 @@ config TXTABLE_PARTITION
 if TXTABLE_PARTITION
 
 config TXTABLE_PARTITION_MAX_NUM
-	int "Max num of TXTABLE partition"
+	int "Max num of TXTABLE partition(s)"
 	default 16
+	---help---
+		Include one pseudo partition named "txtable"
+
+config TXTABLE_DEFAULT_PARTITION
+	int "Enable default txtable"
+	default 0
+	---help---
+		0: Disable
+		1: Enable
+
+config TXTABLE_DEFAULT_PARTITION_PATH
+	string "Path of default txtable in device"
+	default "/etc/txtable.txt"
+	depends on TXTABLE_DEFAULT_PARTITION != 0
 
 endif
 

--- a/fs/partition/Make.defs
+++ b/fs/partition/Make.defs
@@ -36,6 +36,10 @@ ifeq ($(CONFIG_GPT_PARTITION),y)
 CSRCS += fs_gpt.c
 endif
 
+ifeq ($(CONFIG_TXTABLE_PARTITION),y)
+CSRCS += fs_txtable.c
+endif
+
 # Include partition build support
 
 DEPPATH += --dep-path partition

--- a/fs/partition/fs_partition.c
+++ b/fs/partition/fs_partition.c
@@ -74,6 +74,10 @@ static const partition_parser_t g_parser[] =
   parse_mbr_partition,
 #endif
 
+#ifdef CONFIG_TXTABLE_PARTITION
+  parse_txtable_partition,
+#endif
+
   NULL
 };
 

--- a/fs/partition/fs_txtable.c
+++ b/fs/partition/fs_txtable.c
@@ -1,0 +1,171 @@
+/****************************************************************************
+ * fs/partition/fs_txtable.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <string.h>
+#include <stdio.h>
+#include <ctype.h>
+
+#include <nuttx/kmalloc.h>
+
+#include "partition.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define TXTABLE_MAGIC   "TXTABLE0"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: parse_txtable_partition
+ *
+ * Description:
+ *   parse the TXTABLE partition txtable.
+ *
+ * Input Parameters:
+ *   state   - The partition txtable state
+ *   handler - The function to be called for each found partition
+ *   arg     - A caller provided value to return with the handler
+ *
+ * Returned Value:
+ *   A negated errno value is returned on a failure; Otherwise success
+ *
+ ****************************************************************************/
+
+int parse_txtable_partition(FAR struct partition_state_s *state,
+                            partition_handler_t handler,
+                            FAR void *arg)
+{
+  FAR char *save_ptr;
+  FAR char *token;
+  FAR struct partition_s *part;
+  size_t blkpererase;
+  size_t lasteraseblk;
+  int ret = OK;
+  int i;
+  int j;
+
+  /* Allocate memory for table of parsed and raw */
+
+  part = kmm_malloc(CONFIG_TXTABLE_PARTITION_MAX_NUM *
+                    sizeof(struct partition_s) +
+                    state->erasesize);
+  if (part == NULL)
+    {
+      return -ENOMEM;
+    }
+
+  memset(part, 0, CONFIG_TXTABLE_PARTITION_MAX_NUM *
+         sizeof(struct partition_s));
+
+  token = (FAR char *)(part + CONFIG_TXTABLE_PARTITION_MAX_NUM);
+
+  /* TXTABLE locate in the last erase block */
+
+  blkpererase = state->erasesize / state->blocksize;
+  lasteraseblk = state->nblocks - blkpererase;
+
+  ret = read_partition_block(state, token, lasteraseblk, blkpererase);
+  if (ret < 0)
+    {
+      goto out;
+    }
+
+  /* Parsing data of partition table */
+
+  token = strtok_r(token, "\n", &save_ptr);
+  if (strncmp(token, TXTABLE_MAGIC, strlen(TXTABLE_MAGIC)) != 0)
+    {
+      ret = -EFTYPE;
+      goto out;
+    }
+
+  for (i = 0; i < CONFIG_TXTABLE_PARTITION_MAX_NUM; i++)
+    {
+      token = strtok_r(NULL, "\n", &save_ptr);
+      if (token == NULL || !isalnum(token[0]))
+        {
+          break;
+        }
+
+      ret = sscanf(token, "%s %zx %zx",
+                   part[i].name,
+                   &part[i].nblocks,
+                   &part[i].firstblock);
+      if (ret < 0)
+        {
+          goto out;
+        }
+
+      part[i].index       = i;
+      part[i].firstblock /= state->blocksize;
+      part[i].nblocks    /= state->blocksize;
+      part[i].blocksize   = state->blocksize;
+    }
+
+  for (j = 0; j < i; j++)
+    {
+      if (!part[j].firstblock && j > 0)
+        {
+          part[j].firstblock = part[j - 1].firstblock +
+                               part[j - 1].nblocks;
+        }
+
+      if (!part[j].nblocks)
+        {
+          if (j + 1 < i)
+            {
+              if (part[j + 1].firstblock)
+                {
+                  part[j].nblocks = part[j + 1].firstblock -
+                                    part[j].firstblock;
+                }
+            }
+          else
+            {
+              part[j].nblocks = state->nblocks - part[j].firstblock -
+                                blkpererase;
+            }
+        }
+
+      /* Reserved for txtable */
+
+      if (j + 1 == i &&
+          part[j].firstblock + part[j].nblocks > lasteraseblk)
+        {
+          part[j].nblocks = lasteraseblk - part[j].firstblock;
+        }
+
+      /* Notify the caller */
+
+      handler(&part[j], arg);
+    }
+
+out:
+  kmm_free(part);
+  return ret;
+}

--- a/fs/partition/partition.h
+++ b/fs/partition/partition.h
@@ -70,6 +70,12 @@ int parse_mbr_partition(FAR struct partition_state_s *state,
                         FAR void *arg);
 #endif
 
+#ifdef CONFIG_TXTABLE_PARTITION
+int parse_txtable_partition(FAR struct partition_state_s *state,
+                            partition_handler_t handler,
+                            FAR void *arg);
+#endif
+
 #endif /* CONFIG_DISABLE_MOUNTPOINT */
 
 #endif /* __FS_PARTITION_PARTITION_H */


### PR DESCRIPTION
## Summary
A text format partition table stored in last eraseblock.

The 1st line must be "Magic+Version", current is "TXTABLE0".
The 2nd (and belows) is/are partition entry/ies, in format: "%s %zx %zx"(means name, size and offset(byte)(in hex))
Size or offset can be default zero(means zero(only for 1st entry) or caculate), and will be caculated ref to previous and next entries.
The last eraseblock will be registered as pseudo partition named "txtable".

To avoid problems of PTABLE: In case of multiple NuttX binary, partition table maybe out of sync.

And is more eaiser:
1. Text format with simple rules(name + size + offset).
2. Size or offset can be default(caculated refs to previous and next entries).
3. Support backup table(eg. /etc/txtable.txt in ROMFS)

Size / Offset can be automatically calculated, case:
   1. The offset of the first entry is zero, and the offset of other entries is zero: automatic calculation;
   2. The size of the last entry is zero: fill to the end of the entire Flash (keep the last eraseblock); the size of other entries is zero: automatically calculated(next.offset - current.offset);
   3. Typical case 1: The size of all entries is zero (calculated automatically), and the offset is non-zero;
   4. Typical case 2: The size and offset of a certain entry are all zero, but the size and offset of two adjacent entries are all non-zero;

## Impact
Disabled by default.

## Testing
### 1. Both size and offset are zero, and not reserve last eraseblock
**txtable.txt**
```
TXTABLE0
partition1 0x6C000 0x4000 
partition2 0x10000 0x70000 
partition3 0x80000 0x80000 
partition4 0x80000 0x100000 
partition5 0x280000 0x180000 
partition6 0x80000 0 
partition7 0x10000 0x480000 
data 0xb00000 0x500000
```
**Parsed**
Reserved last eraseblock, and gap between partition7 and data is kept.
（name + offset + size:)
```
 > /dev/partition1, 0x4000, 0x6c000 
 > /dev/partition2, 0x70000, 0x10000 
 > /dev/partition3, 0x80000, 0x80000 
 > /dev/partition4, 0x100000, 0x80000 
 > /dev/partition5, 0x180000, 0x280000 
 > /dev/partition6, 0x400000, 0x80000 
 > /dev/partition7, 0x480000, 0x10000 
 > /dev/data, 0x500000, 0xaff000
```
### 2. More than one not set size or offset
**txtable.txt**
```
TXTABLE0
partition1 0x6C000 0x4000 
partition2 0 0x70000 
partition3 0 0x80000 
partition4 0 0x100000 
partition5 0x280000 0x180000 
partition6 0x80000 0 
partition7 0x10000 0x480000 
data 0 0x500000
```
**Parsed**
Size of partition[2,3,4,6] and data are caculated, and gap between partition7 and data is kept.

```
 > /dev/partition1, 0x4000, 0x6c000 
 > /dev/partition2, 0x70000, 0x10000 
 > /dev/partition3, 0x80000, 0x80000 
 > /dev/partition4, 0x100000, 0x80000 
 > /dev/partition5, 0x180000, 0x280000 
 > /dev/partition6, 0x400000, 0x80000 
 > /dev/partition7, 0x480000, 0x10000 
 > /dev/data, 0x500000, 0xaff000
```
### 3. Only one partition entry, and size not spec
**txtable.txt**
```
TXTABLE0
partition1 0x0 0x4000 

```
**Paresd**
The last eraseblock was kept, and size is correct.
```
 > /dev/partition1, 0x4000, 0xffb000 
```
### 4. Blank line && New line delim
**txtable.txt**
New line: CR + LF  /  LF
```
TXTABLE0
partition1 0x6C000 0x4000 
partition2 0 0x70000 
partition3 0 0x80000 
partition4 0 0x100000 
partition5 0x280000 0x180000 
partition6 0x80000 0x400000
partition7 0x10000 0x480000 
data 0 0x500000




```
**Parsed**
Blank lines are ignored, and new line of both "LF" or "CRLF" are parsed.
```
 > /dev/partition1, 0x4000, 0x6c000 
 > /dev/partition2, 0x70000, 0x10000 
 > /dev/partition3, 0x80000, 0x80000 
 > /dev/partition4, 0x100000, 0x80000 
 > /dev/partition5, 0x180000, 0x280000 
 > /dev/partition6, 0x400000, 0x80000 
 > /dev/partition7, 0x480000, 0x10000 
 > /dev/data, 0x500000, 0xaff000
```