### PR TITLE
drivers/mmcsd_sdio: config timout to write one data block

### DIFF
--- a/drivers/mmcsd/Kconfig
+++ b/drivers/mmcsd/Kconfig
@@ -163,6 +163,13 @@ config SDIO_BLOCKSETUP
 		number of blocks.  Others just work on the byte stream.  This option
 		enables the block setup method in the SDIO vtable.
 
+config MMCSD_BLOCK_WDATADELAY
+	int "The wait timeout to write one data block"
+	default 260
+	---help---
+		Some hardware needs to configure this delay to write one data block, because
+		the hardware needs more time for wear leveling and bad block management.
+
 endif
 
 endif # MMCSD

--- a/drivers/mmcsd/mmcsd_sdio.c
+++ b/drivers/mmcsd/mmcsd_sdio.c
@@ -83,7 +83,10 @@
 
 #define MMCSD_SCR_DATADELAY     (100)      /* Wait up to 100MS to get SCR */
 #define MMCSD_BLOCK_RDATADELAY  (100)      /* Wait up to 100MS to get one data block */
-#define MMCSD_BLOCK_WDATADELAY  (260)      /* Wait up to 260MS to write one data block */
+
+/* Wait timeout to write one data block */
+
+#define MMCSD_BLOCK_WDATADELAY  CONFIG_MMCSD_BLOCK_WDATADELAY
 
 #define IS_EMPTY(priv) (priv->type == MMCSD_CARDTYPE_UNKNOWN)
 


### PR DESCRIPTION


## Summary
drivers/mmcsd_sdio: config timout to write one data block

Some hardware needs to config this delay to write one data block, because 
the hardware needs more time to wear leveling and bad block manage.
## Impact

## Testing
local test
