### PR TITLE
binfmt/elf: Support to load ET_EXEC in flat mode

### DIFF
--- a/binfmt/libelf/libelf_addrenv.c
+++ b/binfmt/libelf/libelf_addrenv.c
@@ -137,6 +137,11 @@ errout_with_addrenv:
   addrenv_drop(loadinfo->addrenv, false);
   return ret;
 #else
+  if (loadinfo->ehdr.e_type == ET_EXEC)
+    {
+      return OK;
+    }
+
   /* Allocate memory to hold the ELF image */
 
 #if defined(CONFIG_ARCH_USE_TEXT_HEAP)

--- a/binfmt/libelf/libelf_init.c
+++ b/binfmt/libelf/libelf_init.c
@@ -89,14 +89,6 @@ static inline int elf_filelen(FAR struct elf_loadinfo_s *loadinfo)
       return ret;
     }
 
-  /* Verify that it is a regular file */
-
-  if (!S_ISREG(buf.st_mode))
-    {
-      berr("Not a regular file.  mode: %d\n", buf.st_mode);
-      return -ENOENT;
-    }
-
   /* Return the size of the file in the loadinfo structure */
 
   loadinfo->filelen = buf.st_size;

--- a/binfmt/libelf/libelf_load.c
+++ b/binfmt/libelf/libelf_load.c
@@ -179,6 +179,24 @@ static inline int elf_loadfile(FAR struct elf_loadinfo_s *loadinfo)
           pptr = &text;
         }
 
+      if (*pptr == NULL)
+        {
+          if (shdr->sh_type != SHT_NOBITS)
+            {
+              /* Read the section data from sh_offset to specified region */
+
+              ret = elf_read(loadinfo, (FAR uint8_t *)shdr->sh_addr,
+                             shdr->sh_size, shdr->sh_offset);
+              if (ret < 0)
+                {
+                  berr("ERROR: Failed to read section %d: %d\n", i, ret);
+                  return ret;
+                }
+            }
+
+          continue;
+        }
+
       *pptr = (FAR uint8_t *)_ALIGN_UP((uintptr_t)*pptr, shdr->sh_addralign);
 
       /* SHT_NOBITS indicates that there is no data in the file for the


### PR DESCRIPTION
support read the section data from sh_offset to specified region

