### PR TITLE
libc/pthread: add pthread_attr_set/getscope api

### DIFF
--- a/include/pthread.h
+++ b/include/pthread.h
@@ -187,6 +187,11 @@
 #define _PTHREAD_MFLAGS_INCONSISTENT  (1 << 1) /* Mutex is in an inconsistent state */
 #define _PTHREAD_MFLAGS_NRECOVERABLE  (1 << 2) /* Inconsistent mutex has been unlocked */
 
+/* The contention scope attribute in thread attributes object */
+
+#define PTHREAD_SCOPE_SYSTEM          0
+#define PTHREAD_SCOPE_PROCESS         1
+
 /****************************************************************************
  * Public Type Definitions
  ****************************************************************************/
@@ -487,6 +492,11 @@ int pthread_attr_setstack(FAR pthread_attr_t *attr,
                           FAR void *stackaddr, size_t stacksize);
 int pthread_attr_getstack(FAR const pthread_attr_t *attr,
                           FAR void **stackaddr, FAR size_t *stacksize);
+
+/* Set/get contention scope attribute in thread attributes object */
+
+int pthread_attr_setscope(FAR pthread_attr_t *attr, int scope);
+int pthread_attr_getscope(FAR const pthread_attr_t *attr, FAR int *scope);
 
 /* Set or get the name of a thread */
 

--- a/libs/libc/pthread/Make.defs
+++ b/libs/libc/pthread/Make.defs
@@ -35,6 +35,7 @@ CSRCS += pthread_attr_setstackaddr.c pthread_attr_getstackaddr.c
 CSRCS += pthread_attr_setstacksize.c pthread_attr_getstacksize.c
 CSRCS += pthread_attr_setstack.c pthread_attr_getstack.c
 CSRCS += pthread_attr_setschedparam.c pthread_attr_getschedparam.c
+CSRCS += pthread_attr_setscope.c pthread_attr_getscope.c
 CSRCS += pthread_barrierattr_init.c pthread_barrierattr_destroy.c
 CSRCS += pthread_barrierattr_getpshared.c pthread_barrierattr_setpshared.c
 CSRCS += pthread_barrierinit.c pthread_barrierdestroy.c

--- a/libs/libc/pthread/pthread_attr_getscope.c
+++ b/libs/libc/pthread/pthread_attr_getscope.c
@@ -1,0 +1,53 @@
+/****************************************************************************
+ * libs/libc/pthread/pthread_attr_getscope.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <pthread.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: pthread_attr_getscope
+ *
+ * Description:
+ *   The function returns the contention scope attribute of the thread
+ *   attributes object referred to by attr in the buffer pointed to
+ *   by scope.
+ *
+ * Input Parameters:
+ *   attr  - The pointer to pthread attr.
+ *   scope - The pointer to scope
+ *
+ * Returned Value:
+ *   On success, these functions return 0; on error, they return a nonzero
+ *   error number.
+ *
+ ****************************************************************************/
+
+int pthread_attr_getscope(FAR const pthread_attr_t *attr, FAR int *scope)
+{
+  *scope = PTHREAD_SCOPE_SYSTEM;
+  return 0;
+}

--- a/libs/libc/pthread/pthread_attr_setscope.c
+++ b/libs/libc/pthread/pthread_attr_setscope.c
@@ -1,0 +1,80 @@
+/****************************************************************************
+ * libs/libc/pthread/pthread_attr_setscope.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <pthread.h>
+#include <errno.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: pthread_attr_setscope
+ *
+ * Description:
+ *   The function sets the contention scope attribute of the thread
+ *   attributes object referred to by attr to the value specified in scope.
+ *   The contention scope attributes defines the set of threads against
+ *   which a thread competes for resources such as the CPU.
+ *
+ *   POSIX.1 specifies two possible values for scope:
+ *   PTHREAD_SCOPE_SYSTEM:
+ *     The thread competes for resources with all other threads in all
+ *     processes on the system that are in the same scheduling allocation
+ *     domain (a group of one or  more  processors).
+ *     PTHREAD_SCOPE_SYSTEM threads are scheduled relative to one another
+ *     according to their scheduling policy and priority.
+ *
+ *   PTHREAD_SCOPE_PROCESS
+ *     The thread competes for resources with all other threads in the
+ *     same process that were also created with the PTHREAD_SCOPE_PROCESS
+ *     contention scope. PTHREAD_SCOPE_PROCESS threads are scheduled relative
+ *     to other threads in the process according to their scheduling policy
+ *     and priority. POSIX.1 leaves it unspecified how these threads contend
+ *     with other threads in other process on the system or with other
+ *     threads in the same process that were created with the
+ *     PTHREAD_SCOPE_SYSTEM contention scope.
+ *
+ * Input Parameters:
+ *   attr  - The pointer to pthread attr.
+ *   scope - contention scope.
+ *
+ * Returned Value:
+ *   On success, these functions return 0; on error, they return a nonzero
+ *   error number.
+ *
+ ****************************************************************************/
+
+int pthread_attr_setscope(FAR pthread_attr_t *attr, int scope)
+{
+  switch (scope)
+    {
+      case PTHREAD_SCOPE_SYSTEM:
+        return 0;
+      case PTHREAD_SCOPE_PROCESS:
+        return ENOTSUP;
+      default:
+        return EINVAL;
+    }
+}


### PR DESCRIPTION

## Summary
libc/pthread: add pthread_attr_set/getscope

Refs to https://pubs.opengroup.org/onlinepubs/7908799/xsh/pthread_attr_setscope.html
## Impact
add api pthread_attr_setscope and pthread_attr_getscope
## Testing
local test 
