### PR TITLE
sim/usbdev: fix return value issue

### DIFF
--- a/arch/sim/src/sim/posix/sim_rawgadget.c
+++ b/arch/sim/src/sim/posix/sim_rawgadget.c
@@ -629,6 +629,8 @@ static void *host_raw_ephandle(void *arg)
 
       if (io)
         {
+          int len;
+
           if (entry->halted)
             {
               host_raw_epclearhalt(dev->fd, entry->raw_epid);
@@ -638,8 +640,12 @@ static void *host_raw_ephandle(void *arg)
           io->inner.ep = entry->raw_epid;
           io->inner.flags = 0;
           io->inner.length = USB_RAW_EP_MAX_LEN;
-          io->inner.length = host_raw_epread(dev->fd, &io->inner);
-          USB_RAW_FIFO_PUSH(&entry->fifo);
+          len = host_raw_epread(dev->fd, &io->inner);
+          if (len > 0)
+            {
+              io->inner.length = len;
+              USB_RAW_FIFO_PUSH(&entry->fifo);
+            }
         }
       else
         {

--- a/arch/sim/src/sim/sim_usbdev.c
+++ b/arch/sim/src/sim/sim_usbdev.c
@@ -219,6 +219,55 @@ static const struct usbdev_ops_s g_devops =
   .wakeup      = sim_usbdev_wakeup,
 };
 
+/* Device error strings that may be enabled for more descriptive USB trace
+ * output.
+ */
+
+#ifdef CONFIG_USBDEV_TRACE_STRINGS
+const struct trace_msg_t g_usb_trace_strings_deverror[] =
+{
+  TRACE_STR(SIM_TRACEERR_ALLOCFAIL),
+  TRACE_STR(SIM_TRACEERR_BADCLEARFEATURE),
+  TRACE_STR(SIM_TRACEERR_BADDEVGETSTATUS),
+  TRACE_STR(SIM_TRACEERR_BADEPGETSTATUS),
+  TRACE_STR(SIM_TRACEERR_BADEPNO),
+  TRACE_STR(SIM_TRACEERR_BADEPTYPE),
+  TRACE_STR(SIM_TRACEERR_BADGETCONFIG),
+  TRACE_STR(SIM_TRACEERR_BADGETSETDESC),
+  TRACE_STR(SIM_TRACEERR_BADGETSTATUS),
+  TRACE_STR(SIM_TRACEERR_BADSETADDRESS),
+  TRACE_STR(SIM_TRACEERR_BADSETCONFIG),
+  TRACE_STR(SIM_TRACEERR_BADSETFEATURE),
+  TRACE_STR(SIM_TRACEERR_BINDFAILED),
+  TRACE_STR(SIM_TRACEERR_DISPATCHSTALL),
+  TRACE_STR(SIM_TRACEERR_DRIVER),
+  TRACE_STR(SIM_TRACEERR_DRIVERREGISTERED),
+  TRACE_STR(SIM_TRACEERR_EP0BADCTR),
+  TRACE_STR(SIM_TRACEERR_EP0SETUPSTALLED),
+  TRACE_STR(SIM_TRACEERR_EPBUFFER),
+  TRACE_STR(SIM_TRACEERR_EPDISABLED),
+  TRACE_STR(SIM_TRACEERR_EPOUTNULLPACKET),
+  TRACE_STR(SIM_TRACEERR_EPRESERVE),
+  TRACE_STR(SIM_TRACEERR_INVALIDCTRLREQ),
+  TRACE_STR(SIM_TRACEERR_INVALIDPARMS),
+  TRACE_STR(SIM_TRACEERR_IRQREGISTRATION),
+  TRACE_STR(SIM_TRACEERR_NOTCONFIGURED),
+  TRACE_STR(SIM_TRACEERR_REQABORTED),
+  TRACE_STR_END
+};
+#endif
+
+/* Interrupt event strings that may be enabled for more descriptive USB trace
+ * output.
+ */
+
+#ifdef CONFIG_USBDEV_TRACE_STRINGS
+const struct trace_msg_t g_usb_trace_strings_intdecode[] =
+{
+  TRACE_STR_END
+};
+#endif
+
 /****************************************************************************
  * Private Functions
  ****************************************************************************/


### PR DESCRIPTION
## Summary
1. fix compile break issue when enable USBTRACE.
2. fix return value issue when read failed from sim rawgadget.
## Impact

## Testing
daily test
