### PR TITLE
binfmt/elf: bss section should init to zero

### DIFF
--- a/binfmt/libelf/libelf_load.c
+++ b/binfmt/libelf/libelf_load.c
@@ -194,6 +194,15 @@ static inline int elf_loadfile(FAR struct elf_loadinfo_s *loadinfo)
                 }
             }
 
+          /* If there is no data in an allocated section, then the
+           * allocated section must be cleared.
+           */
+
+          else
+            {
+              memset((FAR uint8_t *)shdr->sh_addr, 0, shdr->sh_size);
+            }
+
           continue;
         }
 


### PR DESCRIPTION
## Summary
bss section should init to zero
## Impact
none
## Testing
none
