### PR TITLE
arch: update g_running_tasks when context switch occurred

### DIFF
--- a/arch/arm/src/armv6-m/arm_doirq.c
+++ b/arch/arm/src/armv6-m/arm_doirq.c
@@ -31,6 +31,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
 #include <arch/board/board.h>
+#include <sched/sched.h>
 
 #include "arm_internal.h"
 
@@ -81,6 +82,13 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
       if (regs != CURRENT_REGS)
         {
+          /* Record the new "running" task when context switch occurred.
+           * g_running_tasks[] is only used by assertion logic for reporting
+           * crashes.
+           */
+
+          g_running_tasks[this_cpu()] = this_task();
+
           restore_critical_section();
           regs = (uint32_t *)CURRENT_REGS;
         }

--- a/arch/arm/src/armv7-a/arm_doirq.c
+++ b/arch/arm/src/armv7-a/arm_doirq.c
@@ -33,6 +33,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
 #include <arch/board/board.h>
+#include <sched/sched.h>
 
 #include "arm_internal.h"
 #include "gic.h"
@@ -70,15 +71,11 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
   irq_dispatch(irq, regs);
 
-#ifdef CONFIG_ARCH_ADDRENV
-  /* Check for a context switch.  If a context switch occurred, then
-   * CURRENT_REGS will have a different value than it did on entry.  If an
-   * interrupt level context switch has occurred, then establish the correct
-   * address environment before returning from the interrupt.
-   */
+  /* Restore the cpu lock */
 
   if (regs != CURRENT_REGS)
     {
+#ifdef CONFIG_ARCH_ADDRENV
       /* Make sure that the address environment for the previously
        * running task is closed down gracefully (data caches dump,
        * MMU flushed) and set up the address environment for the new
@@ -86,13 +83,15 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
        */
 
       addrenv_switch(NULL);
-    }
 #endif
 
-  /* Restore the cpu lock */
+      /* Record the new "running" task when context switch occurred.
+       * g_running_tasks[] is only used by assertion logic for reporting
+       * crashes.
+       */
 
-  if (regs != CURRENT_REGS)
-    {
+      g_running_tasks[this_cpu()] = this_task();
+
       restore_critical_section();
       regs = (uint32_t *)CURRENT_REGS;
     }

--- a/arch/arm/src/armv7-m/arm_doirq.c
+++ b/arch/arm/src/armv7-m/arm_doirq.c
@@ -31,6 +31,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
 #include <arch/board/board.h>
+#include <sched/sched.h>
 
 #include "arm_internal.h"
 
@@ -81,6 +82,13 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
       if (regs != CURRENT_REGS)
         {
+          /* Record the new "running" task when context switch occurred.
+           * g_running_tasks[] is only used by assertion logic for reporting
+           * crashes.
+           */
+
+          g_running_tasks[this_cpu()] = this_task();
+
           restore_critical_section();
           regs = (uint32_t *)CURRENT_REGS;
         }

--- a/arch/arm/src/armv7-r/arm_doirq.c
+++ b/arch/arm/src/armv7-r/arm_doirq.c
@@ -31,6 +31,7 @@
 
 #include <nuttx/board.h>
 #include <arch/board/board.h>
+#include <sched/sched.h>
 
 #include "arm_internal.h"
 
@@ -63,6 +64,13 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
   if (regs != CURRENT_REGS)
     {
+      /* Record the new "running" task when context switch occurred.
+       * g_running_tasks[] is only used by assertion logic for reporting
+       * crashes.
+       */
+
+      g_running_tasks[this_cpu()] = this_task();
+
       restore_critical_section();
       regs = (uint32_t *)CURRENT_REGS;
     }

--- a/arch/arm/src/armv8-m/arm_doirq.c
+++ b/arch/arm/src/armv8-m/arm_doirq.c
@@ -31,6 +31,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
 #include <arch/board/board.h>
+#include <sched/sched.h>
 
 #include "arm_internal.h"
 #include "exc_return.h"
@@ -82,6 +83,13 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
       if (regs != CURRENT_REGS)
         {
+          /* Record the new "running" task when context switch occurred.
+           * g_running_tasks[] is only used by assertion logic for reporting
+           * crashes.
+           */
+
+          g_running_tasks[this_cpu()] = this_task();
+
           restore_critical_section();
           regs = (uint32_t *)CURRENT_REGS;
         }

--- a/arch/arm64/src/common/arm64_doirq.c
+++ b/arch/arm64/src/common/arm64_doirq.c
@@ -92,6 +92,13 @@ uint64_t *arm64_doirq(int irq, uint64_t * regs)
       addrenv_switch(NULL);
 #endif
 
+      /* Record the new "running" task when context switch occurred.
+       * g_running_tasks[] is only used by assertion logic for reporting
+       * crashes.
+       */
+
+      g_running_tasks[this_cpu()] = this_task();
+
       /* Restore the cpu lock */
 
       restore_critical_section();

--- a/arch/avr/src/avr/avr_doirq.c
+++ b/arch/avr/src/avr/avr_doirq.c
@@ -31,6 +31,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
 #include <arch/board/board.h>
+#include <sched/sched.h>
 
 #include "avr_internal.h"
 
@@ -86,6 +87,16 @@ uint8_t *avr_doirq(uint8_t irq, uint8_t *regs)
    * from the input regs, then the lower level will know that a context
    * switch occurred during interrupt processing.
    */
+
+  if (regs != (uint8_t *)g_current_regs)
+    {
+      /* Record the new "running" task when context switch occurred.
+       * g_running_tasks[] is only used by assertion logic for reporting
+       * crashes.
+       */
+
+      g_running_tasks[this_cpu()] = this_task();
+    }
 
   regs = (uint8_t *)g_current_regs;   /* Cast removes volatile attribute */
 

--- a/arch/avr/src/avr32/avr_doirq.c
+++ b/arch/avr/src/avr32/avr_doirq.c
@@ -32,6 +32,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
 #include <arch/board/board.h>
+#include <sched/sched.h>
 
 #include "avr_internal.h"
 
@@ -74,7 +75,6 @@ uint32_t *avr_doirq(int irq, uint32_t *regs)
 
   irq_dispatch(irq, regs);
 
-#if defined(CONFIG_ARCH_FPU) || defined(CONFIG_ARCH_ADDRENV)
   /* Check for a context switch.  If a context switch occurred, then
    * g_current_regs will have a different value than it did on entry.
    * If an interrupt level context switch has occurred, then restore
@@ -99,8 +99,14 @@ uint32_t *avr_doirq(int irq, uint32_t *regs)
 
       addrenv_switch(NULL);
 #endif
+
+      /* Record the new "running" task when context switch occurred.
+       * g_running_tasks[] is only used by assertion logic for reporting
+       * crashes.
+       */
+
+      g_running_tasks[this_cpu()] = this_task();
     }
-#endif
 
   /* If a context switch occurred while processing the interrupt then
    * g_current_regs may have change value.  If we return any value different

--- a/arch/ceva/src/common/ceva_doirq.c
+++ b/arch/ceva/src/common/ceva_doirq.c
@@ -78,6 +78,13 @@ uint32_t *ceva_doirq(int irq, uint32_t *regs)
 
       if (regs != CURRENT_REGS)
         {
+          /* Record the new "running" task when context switch occurred.
+           * g_running_tasks[] is only used by assertion logic for reporting
+           * crashes.
+           */
+
+          g_running_tasks[this_cpu()] = this_task();
+
           restore_critical_section();
           regs = CURRENT_REGS;
         }

--- a/arch/hc/src/common/hc_doirq.c
+++ b/arch/hc/src/common/hc_doirq.c
@@ -32,6 +32,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
 #include <arch/board/board.h>
+#include <sched/sched.h>
 
 #include "hc_internal.h"
 
@@ -74,7 +75,6 @@ uint8_t *hc_doirq(int irq, uint8_t *regs)
 
   irq_dispatch(irq, regs);
 
-#if defined(CONFIG_ARCH_FPU) || defined(CONFIG_ARCH_ADDRENV)
   /* Check for a context switch.  If a context switch occurred, then
    * g_current_regs will have a different value than it did on entry.  If an
    * interrupt level context switch has occurred, then restore the floating
@@ -99,8 +99,14 @@ uint8_t *hc_doirq(int irq, uint8_t *regs)
 
       addrenv_switch(NULL);
 #endif
+
+      /* Record the new "running" task when context switch occurred.
+       * g_running_tasks[] is only used by assertion logic for reporting
+       * crashes.
+       */
+
+      g_running_tasks[this_cpu()] = this_task();
     }
-#endif
 
   /* If a context switch occurred while processing the interrupt then
    * g_current_regs may have change value.  If we return any value different

--- a/arch/mips/src/mips32/mips_doirq.c
+++ b/arch/mips/src/mips32/mips_doirq.c
@@ -32,6 +32,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
 #include <arch/board/board.h>
+#include <sched/sched.h>
 
 #include "mips_internal.h"
 
@@ -80,7 +81,6 @@ uint32_t *mips_doirq(int irq, uint32_t *regs)
 
   irq_dispatch(irq, regs);
 
-#if defined(CONFIG_ARCH_FPU) || defined(CONFIG_ARCH_ADDRENV)
   /* Check for a context switch.  If a context switch occurred, then
    * g_current_regs will have a different value than it did on entry.  If an
    * interrupt level context switch has occurred, then restore the floating
@@ -105,8 +105,14 @@ uint32_t *mips_doirq(int irq, uint32_t *regs)
 
       addrenv_switch(NULL);
 #endif
+
+      /* Record the new "running" task when context switch occurred.
+       * g_running_tasks[] is only used by assertion logic for reporting
+       * crashes.
+       */
+
+      g_running_tasks[this_cpu()] = this_task();
     }
-#endif
 
   /* If a context switch occurred while processing the interrupt then
    * g_current_regs may have change value.  If we return any value different

--- a/arch/misoc/src/minerva/minerva_doirq.c
+++ b/arch/misoc/src/minerva/minerva_doirq.c
@@ -35,6 +35,7 @@
 
 #include <arch/irq.h>
 #include <arch/board/board.h>
+#include <sched/sched.h>
 
 #include "minerva.h"
 
@@ -64,7 +65,6 @@ uint32_t *minerva_doirq(int irq, uint32_t * regs)
 
   irq_dispatch(irq, regs);
 
-#if defined(CONFIG_ARCH_FPU) || defined(CONFIG_ARCH_ADDRENV)
   /* Check for a context switch.  If a context switch occurred, then
    * g_current_regs will have a different value than it did on entry.  If an
    * interrupt level context switch has occurred, then restore the floating
@@ -74,13 +74,13 @@ uint32_t *minerva_doirq(int irq, uint32_t * regs)
 
   if (regs != g_current_regs)
     {
-#  ifdef CONFIG_ARCH_FPU
+#ifdef CONFIG_ARCH_FPU
       /* Restore floating point registers */
 
       up_restorefpu((uint32_t *) g_current_regs);
-#  endif
+#endif
 
-#  ifdef CONFIG_ARCH_ADDRENV
+#ifdef CONFIG_ARCH_ADDRENV
       /* Make sure that the address environment for the previously running
        * task is closed down gracefully (data caches dump, MMU flushed) and
        * set up the address environment for the new thread at the head of
@@ -88,9 +88,15 @@ uint32_t *minerva_doirq(int irq, uint32_t * regs)
        */
 
       addrenv_switch(NULL);
-#  endif
-    }
 #endif
+
+      /* Record the new "running" task when context switch occurred.
+       * g_running_tasks[] is only used by assertion logic for reporting
+       * crashes.
+       */
+
+      g_running_tasks[this_cpu()] = this_task();
+    }
 
   /* If a context switch occurred while processing the interrupt then
    * g_current_regs may have change value.  If we return any value different

--- a/arch/or1k/src/common/or1k_doirq.c
+++ b/arch/or1k/src/common/or1k_doirq.c
@@ -31,6 +31,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
 #include <arch/board/board.h>
+#include <sched/sched.h>
 
 #include "or1k_internal.h"
 
@@ -68,6 +69,16 @@ uint32_t *or1k_doirq(int irq, uint32_t *regs)
    * from the input regs, then the lower level will know that a context
    * switch occurred during interrupt processing.
    */
+
+  if (regs != (uint32_t *)CURRENT_REGS)
+    {
+      /* Record the new "running" task when context switch occurred.
+       * g_running_tasks[] is only used by assertion logic for reporting
+       * crashes.
+       */
+
+      g_running_tasks[this_cpu()] = this_task();
+    }
 
   regs = (uint32_t *)CURRENT_REGS;
 

--- a/arch/renesas/src/common/renesas_doirq.c
+++ b/arch/renesas/src/common/renesas_doirq.c
@@ -31,6 +31,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
 #include <arch/board/board.h>
+#include <sched/sched.h>
 
 #include "renesas_internal.h"
 #include "group/group.h"
@@ -77,7 +78,6 @@ uint32_t *renesas_doirq(int irq, uint32_t * regs)
 
       irq_dispatch(irq, regs);
 
-#if defined(CONFIG_ARCH_FPU) || defined(CONFIG_ARCH_ADDRENV)
       /* Check for a context switch.  If a context switch occurred, then
        * g_current_regs will have a different value than it did on entry.
        * If an interrupt level context switch has occurred, then restore the
@@ -102,9 +102,15 @@ uint32_t *renesas_doirq(int irq, uint32_t * regs)
 
           addrenv_switch(NULL);
 #endif
+
+          /* Record the new "running" task when context switch occurred.
+           * g_running_tasks[] is only used by assertion logic for reporting
+           * crashes.
+           */
+
+          g_running_tasks[this_cpu()] = this_task();
         }
 
-#endif
       /* Get the current value of regs... it may have changed because
        * of a context switch performed during interrupt processing.
        */

--- a/arch/sim/src/sim/CMakeLists.txt
+++ b/arch/sim/src/sim/CMakeLists.txt
@@ -234,6 +234,7 @@ endif()
 target_include_directories(nuttx PRIVATE ${CMAKE_BINARY_DIR}/include/nuttx)
 target_include_directories(nuttx PRIVATE ${CMAKE_CURRENT_LIST_DIR})
 
+target_include_directories(sim_head PUBLIC ${NUTTX_DIR}/sched)
 target_sources(sim_head PUBLIC sim_head.c sim_doirq.c)
 target_sources(arch PRIVATE ${SRCS})
 

--- a/arch/sim/src/sim/sim_doirq.c
+++ b/arch/sim/src/sim/sim_doirq.c
@@ -26,6 +26,7 @@
 
 #include <stdbool.h>
 #include <nuttx/arch.h>
+#include <sched/sched.h>
 
 #include "sim_internal.h"
 
@@ -63,6 +64,16 @@ void *sim_doirq(int irq, void *context)
        * different from the input regs, then the lower level will know that
        * context switch occurred during interrupt processing.
        */
+
+      if (regs != CURRENT_REGS)
+        {
+          /* Record the new "running" task when context switch occurred.
+           * g_running_tasks[] is only used by assertion logic for reporting
+           * crashes.
+           */
+
+          g_running_tasks[this_cpu()] = this_task();
+        }
 
       regs = (void *)CURRENT_REGS;
 

--- a/arch/x86/src/qemu/qemu_handlers.c
+++ b/arch/x86/src/qemu/qemu_handlers.c
@@ -30,6 +30,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
 #include <arch/io.h>
+#include <sched/sched.h>
 
 #include "x86_internal.h"
 
@@ -90,7 +91,6 @@ static uint32_t *common_handler(int irq, uint32_t *regs)
 
   irq_dispatch(irq, regs);
 
-#if defined(CONFIG_ARCH_FPU) || defined(CONFIG_ARCH_ADDRENV)
   /* Check for a context switch.  If a context switch occurred, then
    * g_current_regs will have a different value than it did on entry.  If an
    * interrupt level context switch has occurred, then restore the floating
@@ -115,8 +115,14 @@ static uint32_t *common_handler(int irq, uint32_t *regs)
 
       addrenv_switch(NULL);
 #endif
+
+      /* Record the new "running" task when context switch occurred.
+       * g_running_tasks[] is only used by assertion logic for reporting
+       * crashes.
+       */
+
+      g_running_tasks[this_cpu()] = this_task();
     }
-#endif
 
   /* If a context switch occurred while processing the interrupt then
    * g_current_regs may have change value.  If we return any value different

--- a/arch/x86_64/src/intel64/intel64_handlers.c
+++ b/arch/x86_64/src/intel64/intel64_handlers.c
@@ -77,7 +77,6 @@ static uint64_t *common_handler(int irq, uint64_t *regs)
 
   irq_dispatch(irq, regs);
 
-#if defined(CONFIG_ARCH_FPU) || defined(CONFIG_ARCH_ADDRENV)
   /* Check for a context switch.  If a context switch occurred, then
    * g_current_regs will have a different value than it did on entry.  If an
    * interrupt level context switch has occurred, then restore the floating
@@ -102,8 +101,14 @@ static uint64_t *common_handler(int irq, uint64_t *regs)
 
       addrenv_switch(NULL);
 #endif
+
+      /* Record the new "running" task when context switch occurred.
+       * g_running_tasks[] is only used by assertion logic for reporting
+       * crashes.
+       */
+
+      g_running_tasks[this_cpu()] = this_task();
     }
-#endif
 
   /* If a context switch occurred while processing the interrupt then
    * g_current_regs may have change value.  If we return any value different

--- a/arch/xtensa/src/common/xtensa_irqdispatch.c
+++ b/arch/xtensa/src/common/xtensa_irqdispatch.c
@@ -66,7 +66,6 @@ uint32_t *xtensa_irq_dispatch(int irq, uint32_t *regs)
 
   irq_dispatch(irq, regs);
 
-#if defined(CONFIG_ARCH_ADDRENV)
   /* Check for a context switch.  If a context switch occurred, then
    * CURRENT_REGS will have a different value than it did on entry.
    */
@@ -82,8 +81,14 @@ uint32_t *xtensa_irq_dispatch(int irq, uint32_t *regs)
 
       addrenv_switch(NULL);
 #endif
+
+      /* Record the new "running" task when context switch occurred.
+       * g_running_tasks[] is only used by assertion logic for reporting
+       * crashes.
+       */
+
+      g_running_tasks[this_cpu()] = this_task();
     }
-#endif
 
   /* Restore the cpu lock */
 

--- a/arch/z16/src/common/z16_doirq.c
+++ b/arch/z16/src/common/z16_doirq.c
@@ -30,6 +30,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
 #include <arch/board/board.h>
+#include <sched/sched.h>
 
 #include "chip.h"
 #include "z16_internal.h"
@@ -83,6 +84,16 @@ FAR chipreg_t *z16_doirq(int irq, FAR chipreg_t *regs)
       /* Deliver the IRQ */
 
       irq_dispatch(irq, regs);
+
+      if (regs != g_current_regs)
+        {
+          /* Record the new "running" task when context switch occurred.
+           * g_running_tasks[] is only used by assertion logic for reporting
+           * crashes.
+           */
+
+          g_running_tasks[this_cpu()] = this_task();
+        }
 
       /* Restore the previous value of g_current_regs.  NULL would indicate
        * that we are no longer in an interrupt handler.  It will be non-NULL

--- a/sched/irq/irq_dispatch.c
+++ b/sched/irq/irq_dispatch.c
@@ -182,10 +182,4 @@ void irq_dispatch(int irq, FAR void *context)
       kmm_checkcorruption();
     }
 #endif
-
-  /* Record the new "running" task.  g_running_tasks[] is only used by
-   * assertion logic for reporting crashes.
-   */
-
-  g_running_tasks[this_cpu()] = this_task();
 }


### PR DESCRIPTION
## Summary

When supporting high-priority interrupts, updating the g_running_tasks within a high-priority interrupt may be cause problems. The g_running_tasks should only be updated when it is determined that a task context switch has occurred.

## Impact

assert

## Testing

bes board