### PR TITLE
arm-m: Check the dcache status before enabling dcache

### DIFF
--- a/arch/arm/src/armv7-m/arm_cache.c
+++ b/arch/arm/src/armv7-m/arm_cache.c
@@ -496,6 +496,14 @@ void up_enable_dcache(void)
   uint32_t sets;
   uint32_t ways;
 
+  /* If dcache is already enabled, disable it first. */
+
+  ccr = getreg32(NVIC_CFGCON);
+  if ((ccr & NVIC_CFGCON_DC) != 0)
+    {
+      up_disable_dcache();
+    }
+
   /* Get the characteristics of the D-Cache */
 
   ccsidr = getreg32(NVIC_CCSIDR);

--- a/arch/arm/src/armv8-m/arm_cache.c
+++ b/arch/arm/src/armv8-m/arm_cache.c
@@ -496,6 +496,14 @@ void up_enable_dcache(void)
   uint32_t sets;
   uint32_t ways;
 
+  /* If dcache is already enabled, disable it first. */
+
+  ccr = getreg32(NVIC_CFGCON);
+  if ((ccr & NVIC_CFGCON_DC) != 0)
+    {
+      up_disable_dcache();
+    }
+
   /* Get the characteristics of the D-Cache */
 
   ccsidr = getreg32(NVIC_CCSIDR);


### PR DESCRIPTION
## Summary

If the cache is already enabled before NuttX starts up, enabling the cache in NuttX will cause the cache to be re-invalidated, then resulting in data that is already in the cache being flushed out.

## Impact

Cache enable

## Testing

BES board