### PR TITLE
task_spawnparms: out of loop when ret less than 0

### DIFF
--- a/sched/task/task_spawnparms.c
+++ b/sched/task/task_spawnparms.c
@@ -274,7 +274,7 @@ int spawn_file_actions(FAR struct tcb_s *tcb,
   /* Execute each file action */
 
   for (entry = (FAR struct spawn_general_file_action_s *)actions;
-       entry && ret == OK;
+       entry && ret >= 0;
        entry = entry->flink)
     {
       switch (entry->action)


### PR DESCRIPTION
## Summary

The nxspawn_dup2 function will return a value greater than 0, so the loop should only exit if ret is less than 0.

## Impact

dup2

## Testing

ADB test for sim:usbdev