### PR TITLE
drivers/video: Fix returned errno in error cases

### DIFF
--- a/drivers/video/isx012.c
+++ b/drivers/video/isx012.c
@@ -139,7 +139,7 @@
 #define VALIDATE_VALUE(val, min, max, step) (((val >= min) && \
                                               (val <= max) && \
                                               (((val - min) % step) == 0) ? \
-                                              OK : -EINVAL))
+                                              OK : -ERANGE))
 
 #define ISX012_CHIPID_L (0x0000c460)
 #define ISX012_CHIPID_H (0x00005516)

--- a/drivers/video/isx019.c
+++ b/drivers/video/isx019.c
@@ -3521,7 +3521,7 @@ static int validate_range(int32_t val,
 
   if (!VALIDATE_RANGE(val, range->minimum, range->maximum, range->step))
     {
-      ret = -EINVAL;
+      ret = -ERANGE;
     }
 
   return ret;


### PR DESCRIPTION
## Summary
When the value that is out of range is specified in ioctl(VIDIOC_S_CTRL) and ioctl(VIDIOC_S_EXT_CTRLS), returned value should be not EINVAL but ERANGE.

## Impact
video/isx012 and video/isx019

## Testing
Tested with spresense
