### PR TITLE
drivers/video: Initialize flags member of query control APIs

### DIFF
--- a/drivers/video/video.c
+++ b/drivers/video/video.c
@@ -2157,6 +2157,7 @@ static int video_query_ext_ctrl(FAR struct video_mng_s *vmng,
       attr->maximum       = vmng->video_scence_num - 1;
       attr->step          = 1;
       attr->default_value = 0;
+      attr->flags         = 0;
       strlcpy(attr->name, "Scene Mode", 32);
     }
   else
@@ -2170,6 +2171,7 @@ static int video_query_ext_ctrl(FAR struct video_mng_s *vmng,
         }
 
       attr->type = value.type;
+      attr->flags = 0;
 
       switch (value.type)
         {


### PR DESCRIPTION
## Summary

video driver does not support flags member of ioctl(VIDIOC_QUERYCTRL) and ioctl(VIDIOC_QUERY_EXT_CTRL).
But, ioctl returns with the flags member that has the garbage value. Add initialization of flags member to avoid return of the garbage value.

## Impact
video driver

## Testing
Tested with spresense
