### PR TITLE
arm64_backtrace: use running_task if arch_get_current_tcb return NULL

### DIFF
--- a/arch/arm64/src/common/arm64_backtrace.c
+++ b/arch/arm64/src/common/arm64_backtrace.c
@@ -116,6 +116,11 @@ int up_backtrace(struct tcb_s *tcb,
   irqstate_t flags;
   int ret;
 
+  if (rtcb == NULL)
+    {
+      rtcb = running_task();
+    }
+
   if (size <= 0 || !buffer)
     {
       return 0;


### PR DESCRIPTION
## Summary
In the init phase of the OS, arch_get_current_tcb return NULL. Enable the memory backatrace default will crash in backtrace function.

## Impact
arm64 backtrace

## Testing
qemu_armv8a:netnsh with backtrace and mm default backtrace enable(CONFIG_MM_BACKTRACE_DEFAULT)
