### PR TITLE
watchdog: add CONFIG_WATCHDOG_PANIC_NOTIFIER for panic notifier

### DIFF
--- a/drivers/timers/Kconfig
+++ b/drivers/timers/Kconfig
@@ -392,6 +392,13 @@ config WATCHDOG_MAGIC_V
 	---help---
 		The watchdog can be stopped by writing 'V' to the watchdog's device node
 
+config WATCHDOG_PANIC_NOTIFIER
+	bool "Enable watchdog panic notifier"
+	default n
+	---help---
+		When system PANIC, wdog_notifier() will be callled to disable the watchdog,
+		this is an useful option for debug if you want to keep crash scene.
+
 menuconfig WATCHDOG_AUTOMONITOR
 	bool "Auto-monitor"
 	---help---

--- a/drivers/timers/watchdog.c
+++ b/drivers/timers/watchdog.c
@@ -76,9 +76,11 @@
 
 struct watchdog_upperhalf_s
 {
+#ifdef CONFIG_WATCHDOG_PANIC_NOTIFIER
   /* When a crash occurs, stop the watchdog */
 
   struct notifier_block nb;
+#endif
 #ifdef CONFIG_WATCHDOG_AUTOMONITOR
 #  if defined(CONFIG_WATCHDOG_AUTOMONITOR_BY_ONESHOT)
   FAR struct oneshot_lowerhalf_s *oneshot;
@@ -300,6 +302,7 @@ static void watchdog_automonitor_stop(FAR struct watchdog_upperhalf_s *upper)
 }
 #endif
 
+#ifdef CONFIG_WATCHDOG_PANIC_NOTIFIER
 static int wdog_notifier(FAR struct notifier_block *nb, unsigned long action,
                          FAR void *data)
 {
@@ -317,6 +320,7 @@ static int wdog_notifier(FAR struct notifier_block *nb, unsigned long action,
 
   return 0;
 }
+#endif
 
 /****************************************************************************
  * Name: wdog_open
@@ -778,8 +782,10 @@ FAR void *watchdog_register(FAR const char *path,
   watchdog_automonitor_start(upper);
 #endif
 
+#ifdef CONFIG_WATCHDOG_PANIC_NOTIFIER
   upper->nb.notifier_call = wdog_notifier;
   panic_notifier_chain_register(&upper->nb);
+#endif
 
   return (FAR void *)upper;
 
@@ -835,7 +841,9 @@ void watchdog_unregister(FAR void *handle)
   /* Unregister the watchdog timer device */
 
   unregister_driver(upper->path);
+#ifdef CONFIG_WATCHDOG_PANIC_NOTIFIER
   panic_notifier_chain_unregister(&upper->nb);
+#endif
 
   /* Then free all of the driver resources */
 


### PR DESCRIPTION
## Summary
wdog_notifier() will be called in _assert (panic_notifier_call_chain()) to keep the crash scene as mush as possible, which is useful for debug.

But once disable the watchdog, the hardware watchdog can not reboot the system too. If a crash happened in the _assert (e.g. the tcb sp has been corrupted, system will crash again in tack stack dump), system will crashing forever and can not reboot.

So add a config to disable this feature by default and can be enable if anyone need it.

## Impact
watchdog

## Testing
Internal Project with Dual Cores Cotex-A7 Chip
