### PR TITLE
mm: record more useful backtrace for memory node

### DIFF
--- a/include/execinfo.h
+++ b/include/execinfo.h
@@ -33,20 +33,9 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#if defined(CONFIG_SCHED_BACKTRACE)
-
-/* Store up to SIZE return address of the current back trace in
- * ARRAY and return the exact number of values stored.
- */
-
-#  define backtrace(buffer, size) sched_backtrace(_SCHED_GETTID(), \
-                                                 buffer, size, 0)
-#  define dump_stack()            sched_dumpstack(_SCHED_GETTID())
-
-#else
-#  define backtrace(buffer, size) 0
-#  define dump_stack()
-#endif
+#define backtrace(buffer, size) sched_backtrace(_SCHED_GETTID(), \
+                                                buffer, size, 0)
+#define dump_stack()            sched_dumpstack(_SCHED_GETTID())
 
 /****************************************************************************
  * Public Function Prototypes

--- a/include/sched.h
+++ b/include/sched.h
@@ -267,8 +267,13 @@ bool   sched_idletask(void);
 
 /* Task Backtrace */
 
+#ifdef CONFIG_SCHED_BACKTRACE
 int    sched_backtrace(pid_t tid, FAR void **buffer, int size, int skip);
 void   sched_dumpstack(pid_t tid);
+#else
+#  define sched_backtrace(tid, buffer, size, skip) 0
+#  define sched_dumpstack(tid)
+#endif
 
 #undef EXTERN
 #if defined(__cplusplus)

--- a/mm/Kconfig
+++ b/mm/Kconfig
@@ -228,6 +228,13 @@ config MM_HEAP_MEMPOOL_CHUNK_SIZE
 	---help---
 		This size describes the multiple mempool chunk size.
 
+config MM_HEAP_MEMPOOL_BACKTRACE_SKIP
+	int "The skip depth of backtrace for mempool"
+	default 6
+	depends on MM_HEAP_MEMPOOL_THRESHOLD != 0 && MM_BACKTRACE > 0
+	---help---
+		This number is the skipped backtrace depth for mempool.
+
 config FS_PROCFS_EXCLUDE_MEMPOOL
 	bool "Exclude mempool"
 	default DEFAULT_SMALL
@@ -303,6 +310,11 @@ config MM_BACKTRACE
 		Config the depth of backtrace in memory block by specified this
 		config: disable backtrace by -1, only record pid info by zero and
 		enable record backtrace info by 8(fixed depth).
+
+config MM_BACKTRACE_SKIP
+	int "The skip depth of backtrace"
+	depends on MM_BACKTRACE > 0
+	default 3
 
 config MM_BACKTRACE_DEFAULT
 	bool "Enable the backtrace record by default"

--- a/mm/mempool/mempool.c
+++ b/mm/mempool/mempool.c
@@ -23,7 +23,6 @@
  ****************************************************************************/
 
 #include <assert.h>
-#include <execinfo.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <syslog.h>
@@ -94,7 +93,9 @@ static inline void mempool_add_backtrace(FAR struct mempool_s *pool,
 #  if CONFIG_MM_BACKTRACE > 0
   if (pool->procfs.backtrace)
     {
-      int result = backtrace(buf->backtrace, CONFIG_MM_BACKTRACE);
+      int result = sched_backtrace(buf->pid, buf->backtrace,
+                                   CONFIG_MM_BACKTRACE,
+                                   CONFIG_MM_HEAP_MEMPOOL_BACKTRACE_SKIP);
       if (result < CONFIG_MM_BACKTRACE)
         {
           buf->backtrace[result] = NULL;

--- a/mm/mm_heap/mm.h
+++ b/mm/mm_heap/mm.h
@@ -34,7 +34,6 @@
 #include <nuttx/mm/mempool.h>
 
 #include <assert.h>
-#include <execinfo.h>
 #include <sys/types.h>
 #include <stdbool.h>
 #include <string.h>
@@ -89,7 +88,8 @@
          tcb = nxsched_get_tcb(tmp->pid); \
          if ((heap)->mm_procfs.backtrace || (tcb && tcb->flags & TCB_FLAG_HEAP_DUMP)) \
            { \
-             int n = backtrace(tmp->backtrace, CONFIG_MM_BACKTRACE); \
+             int n = sched_backtrace(tmp->pid, tmp->backtrace, CONFIG_MM_BACKTRACE, \
+                                     CONFIG_MM_BACKTRACE_SKIP); \
              if (n < CONFIG_MM_BACKTRACE) \
                { \
                  tmp->backtrace[n] = NULL; \

--- a/mm/tlsf/mm_tlsf.c
+++ b/mm/tlsf/mm_tlsf.c
@@ -28,7 +28,6 @@
 #include <errno.h>
 #include <assert.h>
 #include <debug.h>
-#include <execinfo.h>
 #include <sched.h>
 #include <stdio.h>
 #include <string.h>
@@ -150,7 +149,9 @@ static void memdump_backtrace(FAR struct mm_heap_s *heap,
   if (heap->mm_procfs.backtrace ||
       (tcb && tcb->flags & TCB_FLAG_HEAP_DUMP))
     {
-      int ret = backtrace(buf->backtrace, CONFIG_MM_BACKTRACE);
+      int ret = sched_backtrace(buf->pid, buf->backtrace,
+                                CONFIG_MM_BACKTRACE,
+                                CONFIG_MM_BACKTRACE_SKIP);
       if (ret < CONFIG_MM_BACKTRACE)
         {
           buf->backtrace[ret] = NULL;


### PR DESCRIPTION
## Summary
Commit 1:
mm: use shced_backtrace and skip the first numbers in mm backatrace

beacause the first numbers backtrace in mm node is same, skip them to
show more useful backtrace.

Signed-off-by: wangbowen6 <wangbowen6@xiaomi.com>

Commit 2:
sched_backtrace: define sched_dumpstack when not enable SCHED_BACKTRACE

Before directly use sched_backtrace() with SCHED_BACKTRACE disable will
lead compile error, this commit avoid this problem by define
sched_backtrace to 0 when CONFIG_SCHED_BACKTRACE not enable.

Signed-off-by: Bowen Wang <wangbowen6@xiaomi.com>

## Impact
mm backtrace

## Testing
local project
