### PR TITLE
arm64: add kasan support for arm64

### DIFF
--- a/arch/arm64/src/Toolchain.defs
+++ b/arch/arm64/src/Toolchain.defs
@@ -80,6 +80,10 @@ ifeq ($(CONFIG_MM_UBSAN_TRAP_ON_ERROR),y)
   ARCHOPTIMIZATION += -fsanitize-undefined-trap-on-error
 endif
 
+ifeq ($(CONFIG_MM_KASAN_ALL),y)
+  ARCHOPTIMIZATION += -fsanitize=kernel-address
+endif
+
 ifeq ($(CONFIG_ARCH_FPU),y)
   ARCHCXXFLAGS += -D_LDBL_EQ_DBL
   ARCHCFLAGS   += -D_LDBL_EQ_DBL


### PR DESCRIPTION
## Summary
Add kasan compiler option in arm64 Toolchain.defs

## Impact
arm64 kasan

## Testing
qemu-armv8a:netnsh with CONFIG_MM_KASAN_ALL enable
