### PR TITLE
mm_heap: mm malloc failed dump and panic only valid for the heap own by OS

### DIFF
--- a/include/nuttx/addrenv.h
+++ b/include/nuttx/addrenv.h
@@ -29,7 +29,6 @@
 
 #ifdef CONFIG_BUILD_KERNEL
 #  include <signal.h>
-#  include <nuttx/mm/mm.h>
 #endif
 
 #include <stdbool.h>
@@ -282,6 +281,8 @@ typedef struct addrenv_s addrenv_t;
 typedef CODE void (*addrenv_sigtramp_t)(_sa_sigaction_t sighand, int signo,
                                         FAR siginfo_t *info,
                                         FAR void *ucontext);
+
+struct mm_heaps_s; /* Forward reference */
 
 /* This structure describes the format of the .bss/.data reserved area */
 

--- a/include/nuttx/mm/mm.h
+++ b/include/nuttx/mm/mm.h
@@ -25,7 +25,9 @@
  * Included Files
  ****************************************************************************/
 
+#include <nuttx/addrenv.h>
 #include <nuttx/config.h>
+#include <nuttx/userspace.h>
 
 #include <sys/types.h>
 #include <stdbool.h>
@@ -100,6 +102,36 @@
 #endif
 
 #define mm_memdump_s malltask
+
+#if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
+/* In the kernel build, there are multiple user heaps; one for each task
+ * group.  In this build configuration, the user heap structure lies
+ * in a reserved region at the beginning of the .bss/.data address
+ * space (CONFIG_ARCH_DATA_VBASE).  The size of that region is given by
+ * ARCH_DATA_RESERVE_SIZE
+ */
+
+#  define USR_HEAP (ARCH_DATA_RESERVE->ar_usrheap)
+
+#elif defined(CONFIG_BUILD_PROTECTED) && defined(__KERNEL__)
+/* In the protected mode, there are two heaps:  A kernel heap and a single
+ * user heap.  Kernel code must obtain the address of the user heap data
+ * structure from the userspace interface.
+ */
+
+#  define USR_HEAP (*USERSPACE->us_heap)
+
+#else
+/* Otherwise, the user heap data structures are in common .bss */
+
+#  define USR_HEAP g_mmheap
+#endif
+
+#ifdef CONFIG_MM_KERNEL_HEAP
+#  define MM_INTERNAL_HEAP(heap) ((heap) == USR_HEAP || (heap) == g_kmmheap)
+#else
+#  define MM_INTERNAL_HEAP(heap) ((heap) == USR_HEAP)
+#endif
 
 /****************************************************************************
  * Public Types

--- a/mm/mm_heap/mm_malloc.c
+++ b/mm/mm_heap/mm_malloc.c
@@ -267,7 +267,7 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
 #endif
     }
 #ifdef CONFIG_DEBUG_MM
-  else
+  else if (MM_INTERNAL_HEAP(heap))
     {
 #ifdef CONFIG_MM_DUMP_ON_FAILURE
       struct mallinfo minfo;

--- a/mm/umm_heap/umm_heap.h
+++ b/mm/umm_heap/umm_heap.h
@@ -27,37 +27,11 @@
 
 #include <nuttx/config.h>
 
-#include <nuttx/addrenv.h>
-#include <nuttx/userspace.h>
 #include <nuttx/mm/mm.h>
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
-
-#if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
-/* In the kernel build, there are multiple user heaps; one for each task
- * group.  In this build configuration, the user heap structure lies
- * in a reserved region at the beginning of the .bss/.data address
- * space (CONFIG_ARCH_DATA_VBASE).  The size of that region is given by
- * ARCH_DATA_RESERVE_SIZE
- */
-
-#  define USR_HEAP (ARCH_DATA_RESERVE->ar_usrheap)
-
-#elif defined(CONFIG_BUILD_PROTECTED) && defined(__KERNEL__)
-/* In the protected mode, there are two heaps:  A kernel heap and a single
- * user heap.  Kernel code must obtain the address of the user heap data
- * structure from the userspace interface.
- */
-
-#  define USR_HEAP (*USERSPACE->us_heap)
-
-#else
-/* Otherwise, the user heap data structures are in common .bss */
-
-#  define USR_HEAP g_mmheap
-#endif
 
 /****************************************************************************
  * Public Function Prototypes


### PR DESCRIPTION
## Summary
When other code use nuttx memory manager by call mm_xx api directly, it better to let other code to control weather dump or panic when malloc failed.

## Impact
memory malloc failed dump

## Testing
local project test
