### PR TITLE
w25.c: enable support for W25QxxxJV NOR flash memories

### DIFF
--- a/drivers/mtd/w25.c
+++ b/drivers/mtd/w25.c
@@ -105,6 +105,7 @@
 #define W25Q_JEDEC_MEMORY_TYPE_A   0x40  /* W25Q memory type */
 #define W25Q_JEDEC_MEMORY_TYPE_B   0x60  /* W25Q memory type */
 #define W25Q_JEDEC_MEMORY_TYPE_C   0x50  /* W25Q memory type */
+#define W25Q_JEDEC_MEMORY_TYPE_D   0x70  /* W25QJV memory type (backward compatible) */
 
 #define W25_JEDEC_CAPACITY_8MBIT   0x14  /* 256x4096  = 8Mbit memory capacity */
 #define W25_JEDEC_CAPACITY_16MBIT  0x15  /* 512x4096  = 16Mbit memory capacity */
@@ -394,7 +395,8 @@ static inline int w25_readid(struct w25_dev_s *priv)
       (memory == W25X_JEDEC_MEMORY_TYPE   ||
        memory == W25Q_JEDEC_MEMORY_TYPE_A ||
        memory == W25Q_JEDEC_MEMORY_TYPE_B ||
-       memory == W25Q_JEDEC_MEMORY_TYPE_C))
+       memory == W25Q_JEDEC_MEMORY_TYPE_C ||
+       memory == W25Q_JEDEC_MEMORY_TYPE_D))
     {
       /* Okay.. is it a FLASH capacity that we understand? If so, save
        * the FLASH capacity.
@@ -420,7 +422,7 @@ static inline int w25_readid(struct w25_dev_s *priv)
            priv->nsectors = NSECTORS_16MBIT;
         }
 
-      /* 32M-bit / M-byte (4,194,304)
+      /* 32M-bit / 4M-byte (4,194,304)
        *
        * W25X32, W25Q32BV, W25Q32DW
        */


### PR DESCRIPTION
## Summary
W25QxxxJV NOR memories are backward compatible with older Winbond´s generations and thus can also be supported here. 

## Impact
This essentially brings the support for generic SPI to W25QxxxJV memories as w25qxxxjv.c file only supports QSPI communication.

## Testing
Tested on W25Q32JV memory.

