### PR TITLE
tools/ci/testrun: increase ostest timeout on CI

### DIFF
--- a/tools/ci/testrun/script/test_os/test_os.py
+++ b/tools/ci/testrun/script/test_os/test_os.py
@@ -7,7 +7,7 @@ do_not_support = ["sabre-6quad", "rv-virt", "rv-virt64", "esp32c3-devkit", "bl60
 
 
 def test_ostest(p):
-    ret = p.sendCommand("ostest", "Exiting with status", 300)
+    ret = p.sendCommand("ostest", "Exiting with status", 330)
     assert ret == 0
 
 


### PR DESCRIPTION
## Summary
Increase `ostest` timeout on CI

## Impact
Allow adding new tests

## Testing
Pass CI
