### PR TITLE
driver/ftl: pass the number of eraseblock for ftl_get_cblock

### DIFF
--- a/drivers/mtd/ftl.c
+++ b/drivers/mtd/ftl.c
@@ -296,7 +296,8 @@ static ssize_t ftl_mtd_bread(FAR struct ftl_struct_s *dev, off_t startblock,
           break;
         }
 
-      count = ftl_get_cblock(dev, starteraseblock, (nblocks + mask) & ~mask);
+      count = ftl_get_cblock(dev, starteraseblock,
+                             (nblocks + mask) / dev->blkper);
       count = MIN(count * dev->blkper, nblocks);
       startphysicalblock = dev->lptable[starteraseblock] *
                            dev->blkper + (startblock & mask);


### PR DESCRIPTION
## Summary
driver/ftl: pass the number of eraseblock for ftl_get_cblock
## Impact
optimize code
## Testing
local test
