### PR TITLE
fix incorrect comments

### DIFF
--- a/boards/arm/cxd56xx/drivers/sensors/bmi160_scu.c
+++ b/boards/arm/cxd56xx/drivers/sensors/bmi160_scu.c
@@ -231,8 +231,8 @@ struct bmi160_dev_s
 {
 #ifdef CONFIG_SENSORS_BMI160_SCU_I2C
   struct i2c_master_s *i2c; /* I2C interface */
-  uint8_t addr;             /* BMP280 I2C address */
-  int freq;                 /* BMP280 Frequency <= 3.4MHz */
+  uint8_t addr;             /* BMI160 I2C address */
+  int freq;                 /* BMI160 Frequency <= 3.4MHz */
   int port;                 /* I2C port */
   struct seq_s *seq;        /* Sequencer */
   int fifoid;               /* Sequencer id */

--- a/drivers/sensors/ak09912.c
+++ b/drivers/sensors/ak09912.c
@@ -190,7 +190,7 @@ static const struct file_operations g_ak09912fops =
  * Name: ak09912_getreg8
  *
  * Description:
- *   Read from an 8-bit BMP280 register
+ *   Read from an 8-bit ak09912 register
  *
  ****************************************************************************/
 
@@ -227,7 +227,7 @@ static uint8_t ak09912_getreg8(FAR struct ak09912_dev_s *priv,
  * Name: ak09912_putreg8
  *
  * Description:
- *   Write to an 8-bit BMP280 register
+ *   Write to an 8-bit ak09912 register
  *
  ****************************************************************************/
 


### PR DESCRIPTION
## Summary
boards/arm/cxd56xx/drivers/sensors/bmi160_scu.c: fix incorrect comments to the Right of Statements.
drivers/sensors/ak09912.c: fix incorrect function description ak09912_putreg8 and ak09912_getreg8
## Impact
none
## Testing

