### PR TITLE
fs/romfs: Fix FIOC_FILEPATH for dup'ed file

### DIFF
--- a/fs/romfs/fs_romfs.c
+++ b/fs/romfs/fs_romfs.c
@@ -160,7 +160,7 @@ static int romfs_open(FAR struct file *filep, FAR const char *relpath,
   struct romfs_nodeinfo_s     nodeinfo;
   FAR struct romfs_mountpt_s *rm;
   FAR struct romfs_file_s    *rf;
-  size_t                      size;
+  size_t                      len;
   int                         ret;
 
   finfo("Open '%s'\n", relpath);
@@ -248,8 +248,8 @@ static int romfs_open(FAR struct file *filep, FAR const char *relpath,
    * file.
    */
 
-  size = strlen(relpath);
-  rf = kmm_zalloc(sizeof(struct romfs_file_s) + size);
+  len = strlen(relpath);
+  rf = kmm_zalloc(sizeof(struct romfs_file_s) + len);
   if (!rf)
     {
       ferr("ERROR: Failed to allocate private data\n");
@@ -263,7 +263,7 @@ static int romfs_open(FAR struct file *filep, FAR const char *relpath,
 
   rf->rf_size = nodeinfo.rn_size;
   rf->rf_type = (uint8_t)(nodeinfo.rn_next & RFNEXT_ALLMODEMASK);
-  strlcpy(rf->rf_path, relpath, size + 1);
+  strlcpy(rf->rf_path, relpath, len + 1);
 
   /* Get the start of the file data */
 
@@ -644,6 +644,7 @@ static int romfs_dup(FAR const struct file *oldp, FAR struct file *newp)
   FAR struct romfs_mountpt_s *rm;
   FAR struct romfs_file_s *oldrf;
   FAR struct romfs_file_s *newrf;
+  size_t len;
   int ret;
 
   finfo("Dup %p->%p\n", oldp, newp);
@@ -684,7 +685,8 @@ static int romfs_dup(FAR const struct file *oldp, FAR struct file *newp)
    * dup'ed file.
    */
 
-  newrf = kmm_malloc(sizeof(struct romfs_file_s));
+  len   = strlen(oldrf->rf_path);
+  newrf = kmm_malloc(sizeof(struct romfs_file_s) + len);
   if (!newrf)
     {
       ferr("ERROR: Failed to allocate private data\n");
@@ -696,6 +698,8 @@ static int romfs_dup(FAR const struct file *oldp, FAR struct file *newp)
 
   newrf->rf_startoffset = oldrf->rf_startoffset;
   newrf->rf_size        = oldrf->rf_size;
+  newrf->rf_type        = oldrf->rf_type;
+  strlcpy(newrf->rf_path, oldrf->rf_path, len + 1);
 
   /* Configure buffering to support access to this file */
 


### PR DESCRIPTION
## Summary
The `FIOC_FILEPATH` ioctl needs `rf->rf_path`, which is not initialized for dup'ed romfs file and cause problems.

## Impact
`romfs_dup`

## Testing
sim, with `fdinfo` which shows `/proc/*/group/fd`