### PR TITLE
ioexpander: add option to register GPIO by name for IOexpander

### DIFF
--- a/include/nuttx/ioexpander/gpio.h
+++ b/include/nuttx/ioexpander/gpio.h
@@ -272,6 +272,32 @@ int gpio_pin_unregister_byname(FAR struct gpio_dev_s *dev,
                                FAR const char *pinname);
 
 /****************************************************************************
+ * Name: gpio_lower_half_byname
+ *
+ * Description:
+ *   Create a GPIO pin device driver instance for an I/O expander pin.
+ *   The I/O expander pin must have already been configured by the caller
+ *   for the particular pintype.
+ *
+ * Input Parameters:
+ *   ioe     - An instance of the I/O expander interface
+ *   pin     - The I/O expander pin number for the driver
+ *   pintype - See enum gpio_pintype_e
+ *   name    - gpio device name
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_GPIO_LOWER_HALF
+struct ioexpander_dev_s;
+int gpio_lower_half_byname(FAR struct ioexpander_dev_s *ioe,
+                           unsigned int pin, enum gpio_pintype_e pintype,
+                           FAR char *name);
+#endif
+
+/****************************************************************************
  * Name: gpio_lower_half
  *
  * Description:


### PR DESCRIPTION
## Summary
Function `gpio_lower_half()` could only use GPIO minor number for pin registration. This adds option to register GPIO pin by name as supported for standard GPIOs without expander.

## Impact
General driver change, could affect BSPs.

## Testing
Tested on SAMv7 with pcf8575 expander

