### PR TITLE
open: Use file mode only when O_CREAT is specified.

### DIFF
--- a/fs/vfs/fs_open.c
+++ b/fs/vfs/fs_open.c
@@ -89,7 +89,7 @@ static int file_vopen(FAR struct file *filep, FAR const char *path,
 
   /* If the file is opened for creation, then get the mode bits */
 
-  if ((oflags & (O_WRONLY | O_CREAT)) != 0)
+  if ((oflags & O_CREAT) != 0)
     {
       mode = va_arg(ap, mode_t);
     }


### PR DESCRIPTION
## Summary

`open()` can be accompanied with a `mode_t mode` variable as varargs.  
This mode must only be used when the file flag `O_CREAT` is used.

NuttX was accessing this variable also when `O_WRONLY` was specified, which is wrong.

More info [here](https://github.com/apache/nuttx/issues/9998).

## Impact

I don't expect any problems with this change, as `mode` is properly initialized [here](https://github.com/apache/nuttx/blob/master/fs/vfs/fs_open.c#L79).

So even if this variable is used somewhere it shouldn't, at least it will not contain garbage as before.

## Testing

Build test and ostest on sim.
