### PR TITLE
Arm64: get_cpu_id according to the correct affinity level

### DIFF
--- a/arch/arm64/include/a64/chip.h
+++ b/arch/arm64/include/a64/chip.h
@@ -54,4 +54,17 @@
 
 #define CONFIG_LOAD_BASE          0x40080000
 
+/****************************************************************************
+ * Assembly Macros
+ ****************************************************************************/
+
+#ifdef __ASSEMBLY__
+
+.macro  get_cpu_id xreg0
+  mrs    \xreg0, mpidr_el1
+  ubfx   \xreg0, \xreg0, #0, #8
+.endm
+
+#endif /* __ASSEMBLY__ */
+
 #endif /* __ARCH_ARM64_INCLUDE_A64_CHIP_H */

--- a/arch/arm64/include/fvp-v8r/chip.h
+++ b/arch/arm64/include/fvp-v8r/chip.h
@@ -27,6 +27,10 @@
 
 #include <nuttx/config.h>
 
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
 /* Number of bytes in @p x kibibytes/mebibytes/gibibytes */
 
 #define KB(x)           ((x) << 10)
@@ -72,5 +76,18 @@
 #define MPID_TO_CLUSTER_ID(mpid)  ((mpid) & ~0xff)
 
 #endif
+
+/****************************************************************************
+ * Assembly Macros
+ ****************************************************************************/
+
+#ifdef __ASSEMBLY__
+
+.macro  get_cpu_id xreg0
+  mrs    \xreg0, mpidr_el1
+  ubfx   \xreg0, \xreg0, #0, #8
+.endm
+
+#endif /* __ASSEMBLY__ */
 
 #endif /* __ARCH_ARM64_INCLUDE_FVP_V8R_CHIP_H */

--- a/arch/arm64/include/qemu/chip.h
+++ b/arch/arm64/include/qemu/chip.h
@@ -27,6 +27,10 @@
 
 #include <nuttx/config.h>
 
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
 /* Number of bytes in @p x kibibytes/mebibytes/gibibytes */
 
 #define KB(x)           ((x) << 10)
@@ -62,5 +66,18 @@
 #define MPID_TO_CLUSTER_ID(mpid)  ((mpid) & ~0xff)
 
 #endif
+
+/****************************************************************************
+ * Assembly Macros
+ ****************************************************************************/
+
+#ifdef __ASSEMBLY__
+
+.macro  get_cpu_id xreg0
+  mrs    \xreg0, mpidr_el1
+  ubfx   \xreg0, \xreg0, #0, #8
+.endm
+
+#endif /* __ASSEMBLY__ */
 
 #endif /* __ARCH_ARM64_INCLUDE_QEMU_CHIP_H */

--- a/arch/arm64/src/common/arm64_arch.h
+++ b/arch/arm64/src/common/arm64_arch.h
@@ -571,6 +571,18 @@ uint64_t arm64_get_mpid(int cpu);
 #  define arm64_get_mpid(cpu) GET_MPIDR()
 #endif /* CONFIG_SMP */
 
+/****************************************************************************
+ * Name: arm64_get_cpuid
+ *
+ * Description:
+ *   The function from mpid to get cpu id
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_SMP
+int arm64_get_cpuid(uint64_t mpid);
+#endif
+
 #endif /* __ASSEMBLY__ */
 
 #endif /* ___ARCH_ARM64_SRC_COMMON_ARM64_ARCH_H */

--- a/arch/arm64/src/common/arm64_cpustart.c
+++ b/arch/arm64/src/common/arm64_cpustart.c
@@ -58,7 +58,7 @@ typedef void (*arm64_cpustart_t)(void *data);
 
 struct arm64_boot_params
 {
-  uint64_t mpid;
+  uint64_t cpuid;
   char *boot_sp;
   arm64_cpustart_t func;
   void *arg;
@@ -69,7 +69,7 @@ struct arm64_boot_params
 volatile struct arm64_boot_params aligned_data(L1_CACHE_BYTES)
 cpu_boot_params =
 {
-  .mpid    = -1,
+  .cpuid   = -1,
   .boot_sp = (char *)g_cpu_idlestackalloc[0],
 };
 
@@ -142,9 +142,9 @@ static void arm64_smp_init_top(void *arg)
 static void arm64_start_cpu(int cpu_num, char *stack, int stack_sz,
                             arm64_cpustart_t fn)
 {
-  uint64_t cpu_mpid;
-
-  cpu_mpid = arm64_get_mpid(cpu_num);
+#ifdef CONFIG_ARCH_HAVE_PSCI
+  uint64_t cpu_mpid = arm64_get_mpid(cpu_num);
+#endif
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION
 
@@ -164,7 +164,7 @@ static void arm64_start_cpu(int cpu_num, char *stack, int stack_sz,
 
   /* store mpid last as this is our synchronization point */
 
-  cpu_boot_params.mpid = cpu_mpid;
+  cpu_boot_params.cpuid = cpu_num;
 
   flush_boot_params();
 

--- a/arch/arm64/src/common/arm64_cpustart.c
+++ b/arch/arm64/src/common/arm64_cpustart.c
@@ -142,9 +142,7 @@ static void arm64_smp_init_top(void *arg)
 static void arm64_start_cpu(int cpu_num, char *stack, int stack_sz,
                             arm64_cpustart_t fn)
 {
-#ifdef CONFIG_ARCH_HAVE_PSCI
   uint64_t cpu_mpid = arm64_get_mpid(cpu_num);
-#endif
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION
 
@@ -164,7 +162,7 @@ static void arm64_start_cpu(int cpu_num, char *stack, int stack_sz,
 
   /* store mpid last as this is our synchronization point */
 
-  cpu_boot_params.cpuid = cpu_num;
+  cpu_boot_params.cpuid = arm64_get_cpuid(cpu_mpid);
 
   flush_boot_params();
 

--- a/arch/arm64/src/common/arm64_head.S
+++ b/arch/arm64/src/common/arm64_head.S
@@ -25,6 +25,7 @@
 
 #include <nuttx/config.h>
 
+#include <arch/chip/chip.h>
 #include "arm64_arch.h"
 #include "arm64_internal.h"
 #include "arm64_macro.inc"

--- a/arch/arm64/src/common/arm64_macro.inc
+++ b/arch/arm64/src/common/arm64_macro.inc
@@ -25,16 +25,6 @@
 #ifndef __ARCH_ARM64_SRC_COMMON_ARM64_MACRO_INC
 #define __ARCH_ARM64_SRC_COMMON_ARM64_MACRO_INC
 
-/*
- * Get CPU id
- */
-
-.macro  get_cpu_id xreg0
-    mrs    \xreg0, mpidr_el1
-    /* FIMXME: aff3 not taken into consideration */
-    ubfx   \xreg0, \xreg0, #0, #24
-.endm
-
 .macro  switch_el, xreg, el3_label, el2_label, el1_label
     mrs    \xreg, CurrentEL
     cmp    \xreg, 0xc

--- a/arch/arm64/src/common/arm64_vectors.S
+++ b/arch/arm64/src/common/arm64_vectors.S
@@ -24,6 +24,7 @@
 
 #include <nuttx/config.h>
 
+#include <arch/chip/chip.h>
 #include "arch/syscall.h"
 #include "arm64_macro.inc"
 #include "arch/irq.h"

--- a/arch/arm64/src/fvp-v8r/fvp_boot.c
+++ b/arch/arm64/src/fvp-v8r/fvp_boot.c
@@ -164,6 +164,19 @@ uint64_t arm64_get_mpid(int cpu)
   return CORE_TO_MPID(cpu, 0);
 }
 
+/****************************************************************************
+ * Name: arm64_get_cpuid
+ *
+ * Description:
+ *   The function from mpid to get cpu id
+ *
+ ****************************************************************************/
+
+int arm64_get_cpuid(uint64_t mpid)
+{
+  return MPID_TO_CORE(mpid, 0);
+}
+
 #endif /* CONFIG_SMP */
 
 /****************************************************************************

--- a/arch/arm64/src/qemu/qemu_boot.c
+++ b/arch/arm64/src/qemu/qemu_boot.c
@@ -121,6 +121,19 @@ uint64_t arm64_get_mpid(int cpu)
   return CORE_TO_MPID(cpu, 0);
 }
 
+/****************************************************************************
+ * Name: arm64_get_cpuid
+ *
+ * Description:
+ *   The function from mpid to get cpu id
+ *
+ ****************************************************************************/
+
+int arm64_get_cpuid(uint64_t mpid)
+{
+  return MPID_TO_CORE(mpid, 0);
+}
+
 #endif /* CONFIG_SMP */
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

Get cpuid according to the correct affinity level and set boot cpuid according to the mpidr.

## Impact

ARM64 SMP

## Testing

fvp-armv8r:nsh_smp and qemu-armv8a:nsh_smp ostest pass