### PR TITLE
Usb: Modify macro errors with COMPOSITE equipment.

### DIFF
--- a/drivers/usbdev/cdcecm.c
+++ b/drivers/usbdev/cdcecm.c
@@ -1661,7 +1661,9 @@ static int cdcecm_bind(FAR struct usbdevclass_driver_s *driver,
 
   uinfo("\n");
 
+#ifndef CONFIG_CDCECM_COMPOSITE
   dev->ep0->priv = self;
+#endif
 
   /* Preallocate control request */
 

--- a/drivers/usbdev/rndis.c
+++ b/drivers/usbdev/rndis.c
@@ -56,7 +56,7 @@
 
 #include "rndis_std.h"
 
-#ifdef CONFIG_USBMSC_COMPOSITE
+#ifdef CONFIG_RNDIS_COMPOSITE
 #  include <nuttx/usb/composite.h>
 #endif
 


### PR DESCRIPTION
## Summary

Fixed incorrect macro definition in rndis and cdcacm class.

## Impact

usb

## Testing

sim:usbdev