### PR TITLE
inet/ipv4_setsockopt.c:Modify IP_ MULTICAST_ TTL setting range

### DIFF
--- a/net/inet/ipv4_setsockopt.c
+++ b/net/inet/ipv4_setsockopt.c
@@ -195,7 +195,7 @@ int ipv4_setsockopt(FAR struct socket *psock, int option,
           ttl = (value_len >= sizeof(int)) ?
             *(FAR int *)value : (int)*(FAR unsigned char *)value;
 
-          if (ttl <= 0 || ttl > 255)
+          if (ttl < 0 || ttl > 255)
             {
               ret = -EINVAL;
             }


### PR DESCRIPTION
## Summary
Modify IP_ MULTICAST_ TTL setting range from 0 to 254
Refer to Linux:
![image](https://github.com/apache/nuttx/assets/129070278/23473a89-40d3-416d-9d40-cb228d09537c)


## Impact
N/A
## Testing

