### PR TITLE
serial/uart_16550: Wait before setting Line Control Register (Synopsys DesignWare 8250)

### DIFF
--- a/drivers/serial/Kconfig-16550
+++ b/drivers/serial/Kconfig-16550
@@ -519,4 +519,13 @@ config 16550_ADDRWIDTH
 		Default: 8
 		Note: 0 means auto detect address size (uintptr_t)
 
+config 16550_WAIT_LCR
+	bool "Wait for UART before setting LCR"
+	default n
+	---help---
+		Before setting the Line Control Register (LCR), wait until UART is
+		not busy.  This is required for Synopsys DesignWare 8250, which
+		will trigger spurious interrupts when setting the LCR without
+		waiting.  Default: n
+
 endif # 16550_UART

--- a/include/nuttx/serial/uart_16550.h
+++ b/include/nuttx/serial/uart_16550.h
@@ -172,18 +172,19 @@
 
 /* Register offsets *********************************************************/
 
-#define UART_RBR_INCR          0 /* (DLAB =0) Receiver Buffer Register */
-#define UART_THR_INCR          0 /* (DLAB =0) Transmit Holding Register */
-#define UART_DLL_INCR          0 /* (DLAB =1) Divisor Latch LSB */
-#define UART_DLM_INCR          1 /* (DLAB =1) Divisor Latch MSB */
-#define UART_IER_INCR          1 /* (DLAB =0) Interrupt Enable Register */
-#define UART_IIR_INCR          2 /* Interrupt ID Register */
-#define UART_FCR_INCR          2 /* FIFO Control Register */
-#define UART_LCR_INCR          3 /* Line Control Register */
-#define UART_MCR_INCR          4 /* Modem Control Register */
-#define UART_LSR_INCR          5 /* Line Status Register */
-#define UART_MSR_INCR          6 /* Modem Status Register */
-#define UART_SCR_INCR          7 /* Scratch Pad Register */
+#define UART_RBR_INCR          0  /* (DLAB =0) Receiver Buffer Register */
+#define UART_THR_INCR          0  /* (DLAB =0) Transmit Holding Register */
+#define UART_DLL_INCR          0  /* (DLAB =1) Divisor Latch LSB */
+#define UART_DLM_INCR          1  /* (DLAB =1) Divisor Latch MSB */
+#define UART_IER_INCR          1  /* (DLAB =0) Interrupt Enable Register */
+#define UART_IIR_INCR          2  /* Interrupt ID Register */
+#define UART_FCR_INCR          2  /* FIFO Control Register */
+#define UART_LCR_INCR          3  /* Line Control Register */
+#define UART_MCR_INCR          4  /* Modem Control Register */
+#define UART_LSR_INCR          5  /* Line Status Register */
+#define UART_MSR_INCR          6  /* Modem Status Register */
+#define UART_SCR_INCR          7  /* Scratch Pad Register */
+#define UART_USR_INCR          31 /* UART Status Register */
 
 #define UART_RBR_OFFSET        (CONFIG_16550_REGINCR*UART_RBR_INCR)
 #define UART_THR_OFFSET        (CONFIG_16550_REGINCR*UART_THR_INCR)
@@ -197,6 +198,7 @@
 #define UART_LSR_OFFSET        (CONFIG_16550_REGINCR*UART_LSR_INCR)
 #define UART_MSR_OFFSET        (CONFIG_16550_REGINCR*UART_MSR_INCR)
 #define UART_SCR_OFFSET        (CONFIG_16550_REGINCR*UART_SCR_INCR)
+#define UART_USR_OFFSET        (CONFIG_16550_REGINCR*UART_USR_INCR)
 
 /* Register bit definitions *************************************************/
 
@@ -297,6 +299,10 @@
 /* SCR Scratch Pad Register */
 
 #define UART_SCR_MASK                (0xff)    /* Bits 0-7: SCR data */
+
+/* USR UART Status Register */
+
+#define UART_USR_BUSY                (1 << 0)  /* Bit 0: UART Busy */
 
 /****************************************************************************
  * Public Types


### PR DESCRIPTION
## Summary

Some UART Controllers (Synopsys DesignWare 8250) will trigger spurious interrupts when the Line Control Register (LCR) is set while the UART is busy. This patch provides the option (16550_WAIT_LCR) to wait for UART until it's not busy, before setting the LCR. (16550_WAIT_LCR is disabled by default)

This patch fixes the spurious UART interrupts for the upcoming port of NuttX to StarFive JH7110 SoC (with Synopsys DesignWare 8250 UART). [The patch is explained here](https://lupyuen.github.io/articles/plic#appendix-fix-the-spurious-uart-interrupts)

### Modified Files

`drivers/serial/uart_16550.c`: If 16550_WAIT_LCR is enabled, wait until UART is not busy before setting LCR

`include/nuttx/serial/uart_16550.h`: Define the UART Status Register (USR) for checking if UART is busy

`drivers/serial/Kconfig-16550`: Added option 16550_WAIT_LCR to 16550 UART Config, disabled by default

## Impact

After applying this patch and enabling 16550_WAIT_LCR, StarFive JH7110 will boot correctly to NSH. (Instead of getting stuck servicing too many spurious UART interrupts)

No impact on existing code, since 16550_WAIT_LCR is disabled by default.

## Testing

We tested this patch with the upcoming port of NuttX for JH7110. For Regression Testing, we tested with QEMU RISC-V (rv-virt:knsh64).

### JH7110 Test

When 16550_WAIT_LCR is Disabled (default), JH7110 will fire spurious UART interrupts and fail to start NSH Shell (because it's too busy servicing interrupts):

- [NuttX Log for UART Wait LCR Disabled](https://gist.github.com/lupyuen/6b5803e2b3697e96233267f6cd89c593)

```
Starting kernel ...
BCnx_start: Entry
uart_register: Registering /dev/console
uart_register: Registering /dev/ttyS0
```

When 16550_WAIT_LCR is Enabled, JH7110 will start NSH Shell correctly:

- [NuttX Log for UART Wait LCR Enabled](https://gist.github.com/lupyuen/9325fee202d38a671cd0eb3cfd35a1db)

```text
Starting kernel ...
BCnx_start: Entry
uart_register: Registering /dev/console
uart_register: Registering /dev/ttyS0
work_start_lowpri: Starting low-priority kernel worker thread(s)
nx_start_application: Starting init task: /system/bin/init
...
NuttShell (NSH) NuttX-12.0.3
nsh>
```

###  Regression Test

We tested with QEMU RISC-V (rv-virt:knsh64):

```bash
tools/configure.sh rv-virt:knsh64
make
qemu-system-riscv64 -semihosting -M virt,aclint=on -cpu rv64 -smp 8 -bios none -kernel nuttx -initrd initrd -nographic
```

NuttX boots correctly with the default setting of 16550_WAIT_LCR (disabled):

- [NuttX Log for QEMU RISC-V](https://gist.github.com/lupyuen/e5df2a1a9a274c87e6280260b732a71d)
