### PR TITLE
net/tcp: Return -EINVAL if bind is called more than once

### DIFF
--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -325,6 +325,12 @@ static inline int tcp_ipv4_bind(FAR struct tcp_conn_s *conn,
 
   net_lock();
 
+  if (conn->lport != 0)
+    {
+      net_unlock();
+      return -EINVAL;
+    }
+
   /* Verify or select a local port (network byte order) */
 
   port = tcp_selectport(PF_INET,
@@ -389,6 +395,12 @@ static inline int tcp_ipv6_bind(FAR struct tcp_conn_s *conn,
   /* Verify or select a local port and address */
 
   net_lock();
+
+  if (conn->lport != 0)
+    {
+      net_unlock();
+      return -EINVAL;
+    }
 
   /* Verify or select a local port (network byte order) */
 


### PR DESCRIPTION
## Summary

from https://pubs.opengroup.org/onlinepubs/009695399/functions/bind.html:
[EINVAL]
The socket is already bound to an address, and the protocol does not support binding to a new address; or the socket has been shut down.

## Impact

## Testing

