### PR TITLE
drivers/video: fix if video node do not exist on host of sim env, video driver init fail

### DIFF
--- a/arch/sim/src/sim/sim_camera.c
+++ b/arch/sim/src/sim/sim_camera.c
@@ -179,7 +179,7 @@ static uint32_t imgdata_fmt_to_v4l2(uint32_t pixelformat)
 
 static bool sim_camera_is_available(struct imgsensor_s *sensor)
 {
-  return host_video_is_available(CONFIG_HOST_VIDEO_DEV_PATH);
+  return true;
 }
 
 static int sim_camera_init(struct imgsensor_s *sensor)


### PR DESCRIPTION
## Summary

avoid blocking no streaming pipeline when user's PC doesn't have camera module.

## Impact

sim:video

## Testing

internal test