### PR TITLE
net/udp:add check of the ip packet length

### DIFF
--- a/net/udp/udp_sendto_buffered.c
+++ b/net/udp/udp_sendto_buffered.c
@@ -541,6 +541,13 @@ ssize_t psock_udp_sendto(FAR struct socket *psock, FAR const void *buf,
   conn = psock->s_conn;
   DEBUGASSERT(conn);
 
+  /* The length of a datagram to be up to 65,535 octets */
+
+  if (len > 65535)
+    {
+      return -EMSGSIZE;
+    }
+
   /* If the UDP socket was previously assigned a remote peer address via
    * connect(), then as with connection-mode socket, sendto() may not be
    * used with a non-NULL destination address.  Normally send() would be


### PR DESCRIPTION
## Summary

Refer to  https://datatracker.ietf.org/doc/html/rfc791#page-2

Total Length:  16 bits
    Total Length is the length of the datagram, measured in octets,
    including internet header and data.  This field allows the length of
    a datagram to be up to 65,535 octets

## Impact

## Testing

