### PR TITLE
arch/sim:add -Ttext-segment to load the image in the fixed address

### DIFF
--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -264,3 +264,10 @@ ifeq ($(CONFIG_SIM_M32),y)
   LDMODULEFLAGS += -melf_i386
   LDELFFLAGS += -melf_i386
 endif
+
+# Let the symbol table link from 0x400000
+# which is more convenient for debugging.
+
+ifeq ($(CONFIG_HOST_MACOS),n)
+  LDFLAGS += -Wl,-Ttext-segment=0x400000
+endif


### PR DESCRIPTION
To make the address returned by backtrace and gdbstub match the symbol stored in elf.

## Summary
Fix the link address of sim in a stable address
## Impact
sim
## Testing
sim64 sim32
