### PR TITLE
net:Resolve udp disconnection, status not synchronized error

### DIFF
--- a/net/inet/inet_sockif.c
+++ b/net/inet/inet_sockif.c
@@ -1239,6 +1239,9 @@ static int inet_connect(FAR struct socket *psock,
       break;
 #endif
 
+    case AF_UNSPEC:
+      break;
+
     default:
       DEBUGPANIC();
       return -EAFNOSUPPORT;
@@ -1294,7 +1297,7 @@ static int inet_connect(FAR struct socket *psock,
 
           conn = psock->s_conn;
 #if defined(CONFIG_NET_IPv4) && defined(CONFIG_NET_IPv6)
-          if (conn->domain != addr->sa_family)
+          if (addr != NULL && conn->domain != addr->sa_family)
             {
               nerr("conn's domain must be the same as addr's family!\n");
               return -EPROTOTYPE;
@@ -1306,12 +1309,14 @@ static int inet_connect(FAR struct socket *psock,
             {
               /* Failed to connect or explicitly disconnected */
 
+              conn->sconn.s_flags &= ~_SF_CONNECTED;
               conn->flags &= ~_UDP_FLAG_CONNECTMODE;
             }
           else
             {
               /* Successfully connected */
 
+              conn->sconn.s_flags |= _SF_CONNECTED;
               conn->flags |= _UDP_FLAG_CONNECTMODE;
             }
 

--- a/net/socket/connect.c
+++ b/net/socket/connect.c
@@ -141,7 +141,7 @@ int psock_connect(FAR struct socket *psock, FAR const struct sockaddr *addr,
     }
 
   ret = psock->s_sockif->si_connect(psock, addr, addrlen);
-  if (ret >= 0)
+  if (ret >= 0 && addr->sa_family != AF_UNSPEC)
     {
       FAR struct socket_conn_s *conn = psock->s_conn;
       conn->s_flags |= _SF_CONNECTED;


### PR DESCRIPTION
## Summary
```
libuvtestcase:
TEST_IMPL(udp_connect) {
#if defined(__PASE__)
  RETURN_SKIP(
      "IBMi PASE's UDP connection can not be disconnected with AF_UNSPEC.");
#endif
  uv_udp_send_t req;
  struct sockaddr_in ext_addr;
  struct sockaddr_in tmp_addr;
  int r;
  int addrlen;

  close_cb_called = 0;
  cl_send_cb_called = 0;
  sv_recv_cb_called = 0;

  ASSERT(0 == uv_ip4_addr("[0.0.0.0](http://0.0.0.0/)", TEST_PORT, &lo_addr));

  r = uv_udp_init(uv_default_loop(), &server);
  ASSERT(r == 0);

  r = uv_udp_bind(&server, (const struct sockaddr*) &lo_addr, 0);
  ASSERT(r == 0);

  r = uv_udp_recv_start(&server, alloc_cb, sv_recv_cb);
  ASSERT(r == 0);

  r = uv_udp_init(uv_default_loop(), &client);
  ASSERT(r == 0);

  buf = uv_buf_init("EXIT", 4);

  /* connect() to INADDR_ANY fails on Windows wih WSAEADDRNOTAVAIL */
  ASSERT_EQ(0, uv_ip4_addr("[0.0.0.0](http://0.0.0.0/)", TEST_PORT, &tmp_addr));
  r = uv_udp_connect(&client, (const struct sockaddr*) &tmp_addr);
  ASSERT_EQ(r, UV_EADDRNOTAVAIL);
  ASSERT_EQ(r, 0);
  r = uv_udp_connect(&client, NULL);
  ASSERT_EQ(r, 0);

  ASSERT(0 == uv_ip4_addr("[8.8.8.8](http://8.8.8.8/)", TEST_PORT, &ext_addr));
  ASSERT(0 == uv_ip4_addr("[127.0.0.1](http://127.0.0.1/)", TEST_PORT, &lo_addr));

  r = uv_udp_connect(&client, (const struct sockaddr*) &lo_addr);
  ASSERT(r == 0);
  r = uv_udp_connect(&client, (const struct sockaddr*) &ext_addr);
  ASSERT(r == UV_EISCONN);

  addrlen = sizeof(tmp_addr);
  r = uv_udp_getpeername(&client, (struct sockaddr*) &tmp_addr, &addrlen);
  ASSERT(r == 0);

  /* To send messages in connected UDP sockets addr must be NULL */
  r = uv_udp_try_send(&client, &buf, 1, (const struct sockaddr*) &lo_addr);
  ASSERT(r == UV_EISCONN);
  r = uv_udp_try_send(&client, &buf, 1, NULL);
  ASSERT(r == 4);
  r = uv_udp_try_send(&client, &buf, 1, (const struct sockaddr*) &ext_addr);
  ASSERT(r == UV_EISCONN);

  r = uv_udp_connect(&client, NULL);
  ASSERT(r == 0);
  r = uv_udp_connect(&client, NULL);
  ASSERT(r == UV_ENOTCONN);

  addrlen = sizeof(tmp_addr);
  r = uv_udp_getpeername(&client, (struct sockaddr*) &tmp_addr, &addrlen);
  ASSERT(r == UV_ENOTCONN);

  /* To send messages in disconnected UDP sockets addr must be set */
  r = uv_udp_try_send(&client, &buf, 1, (const struct sockaddr*) &lo_addr);
  ASSERT(r == 4);
  r = uv_udp_try_send(&client, &buf, 1, NULL);
  ASSERT(r == UV_EDESTADDRREQ);

  r = uv_udp_connect(&client, (const struct sockaddr*) &lo_addr);
  ASSERT(r == 0);
  r = uv_udp_send(&req,
                  &client,
                  &buf,
                  1,
                  (const struct sockaddr*) &lo_addr,
                  cl_send_cb);
  ASSERT(r == UV_EISCONN);
  r = uv_udp_send(&req, &client, &buf, 1, NULL, cl_send_cb);
  ASSERT(r == 0);

  uv_run(uv_default_loop(), UV_RUN_DEFAULT);

  ASSERT(close_cb_called == 2);
  ASSERT(sv_recv_cb_called == 4);
  ASSERT(cl_send_cb_called == 2);

  ASSERT(client.send_queue_size == 0);
  ASSERT(server.send_queue_size == 0);

  MAKE_VALGRIND_HAPPY();
  return 0;
}
```

## Impact

## Testing

libuv testcase
