### PR TITLE
sched/pthread: Don't do cancel when it is already in the exit process

### DIFF
--- a/sched/pthread/pthread_cancel.c
+++ b/sched/pthread/pthread_cancel.c
@@ -65,6 +65,13 @@ int pthread_cancel(pthread_t thread)
       return ESRCH;
     }
 
+  /* Return ESRCH when thread was in exit processing */
+
+  if ((tcb->flags & TCB_FLAG_EXIT_PROCESSING) != 0)
+    {
+      return ESRCH;
+    }
+
   /* Only pthreads should use this interface */
 
   DEBUGASSERT((tcb->flags & TCB_FLAG_TTYPE_MASK) ==

--- a/sched/signal/sig_dispatch.c
+++ b/sched/signal/sig_dispatch.c
@@ -328,6 +328,13 @@ int nxsig_tcbdispatch(FAR struct tcb_s *stcb, siginfo_t *info)
 
   DEBUGASSERT(stcb != NULL && info != NULL);
 
+  /* Return ESRCH when thread was in exit processing */
+
+  if ((stcb->flags & TCB_FLAG_EXIT_PROCESSING) != 0)
+    {
+      return -ESRCH;
+    }
+
   /* Don't actually send a signal for signo 0. */
 
   if (info->si_signo == 0)


### PR DESCRIPTION
## Summary

When the task is already in the exit process,do not execute pthread cancel and return ESRCH.

## Impact

pthread cancel and pthread kill

## Testing

ltp_interfaces_pthread_kill_6_1 test case pass