### PR TITLE
drivers/fb: add fboverlay pandisplay & display area ioctl

### DIFF
--- a/drivers/video/fb.c
+++ b/drivers/video/fb.c
@@ -592,6 +592,17 @@ static int fb_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         }
         break;
 
+      case FBIOSET_DESTAREA:  /* Set destination area on the primary FB */
+        {
+          FAR struct fb_overlayinfo_s *oinfo =
+            (FAR struct fb_overlayinfo_s *)((uintptr_t)arg);
+
+          DEBUGASSERT(oinfo != 0 && fb->vtable != NULL &&
+                      fb->vtable->setdestarea != NULL);
+          ret = fb->vtable->setdestarea(fb->vtable, oinfo);
+        }
+        break;
+
 #ifdef CONFIG_FB_OVERLAY_BLIT
       case FBIOSET_BLIT:  /* Blit operation between video overlays */
         {
@@ -615,6 +626,18 @@ static int fb_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         }
         break;
 #endif
+
+      case FBIOPAN_OVERLAY:
+        {
+          FAR struct fb_overlayinfo_s *oinfo =
+            (FAR struct fb_overlayinfo_s *)((uintptr_t)arg);
+
+          DEBUGASSERT(oinfo != 0 && fb->vtable != NULL &&
+                      fb->vtable->panoverlay != NULL);
+          ret = fb->vtable->panoverlay(fb->vtable, oinfo);
+        }
+        break;
+
 #endif /* CONFIG_FB_OVERLAY */
 
       case FBIOSET_POWER:

--- a/include/nuttx/video/fb.h
+++ b/include/nuttx/video/fb.h
@@ -261,42 +261,52 @@
 #  define FBIOSET_AREA        _FBIOC(0x000f)  /* Set active overlay area
                                                * Argument: read-only struct
                                                *           fb_overlayinfo_s */
+#  define FBIOSET_DESTAREA    _FBIOC(0x0010)  /* Set destination area on
+                                               * primary FB.
+                                               * Argument: read-only struct
+                                               *           fb_overlayinfo_s */
+
 #ifdef CONFIG_FB_OVERLAY_BLIT
-#  define FBIOSET_BLIT        _FBIOC(0x0010)  /* Blit area between overlays
+#  define FBIOSET_BLIT        _FBIOC(0x0011)  /* Blit area between overlays
                                                * Argument: read-only struct
                                                *           fb_overlayblit_s */
-#  define FBIOSET_BLEND       _FBIOC(0x0011)  /* Blend area between overlays
+#  define FBIOSET_BLEND       _FBIOC(0x0012)  /* Blend area between overlays
                                                * Argument: read-only struct
                                                *           fb_overlayblend_s */
 #endif
+
+#define FBIOPAN_OVERLAY       _FBIOC(0x0013)  /* Pan display for overlay
+                                               * Argument: read-only struct
+                                               *           fb_overlayinfo_s */
+
 #endif /* CONFIG_FB_OVERLAY */
 
 /* Specific Controls ********************************************************/
 
-#define FBIOSET_POWER         _FBIOC(0x0012)  /* Set panel power
+#define FBIOSET_POWER         _FBIOC(0x0014)  /* Set panel power
                                                * Argument:             int */
-#define FBIOGET_POWER         _FBIOC(0x0013)  /* Get panel current power
+#define FBIOGET_POWER         _FBIOC(0x0015)  /* Get panel current power
                                                * Argument:            int* */
-#define FBIOSET_FRAMERATE     _FBIOC(0x0014)  /* Set frame rate
+#define FBIOSET_FRAMERATE     _FBIOC(0x0016)  /* Set frame rate
                                                * Argument:             int */
-#define FBIOGET_FRAMERATE     _FBIOC(0x0015)  /* Get frame rate
+#define FBIOGET_FRAMERATE     _FBIOC(0x0017)  /* Get frame rate
                                                * Argument:            int* */
 
-#define FBIOPAN_DISPLAY       _FBIOC(0x0016)  /* Pan display
+#define FBIOPAN_DISPLAY       _FBIOC(0x0018)  /* Pan display
                                                * Argument: read-only struct
                                                *           fb_planeinfo_s* */
 
-#define FBIO_CLEARNOTIFY      _FBIOC(0x0017)  /* Clear notify signal */
+#define FBIO_CLEARNOTIFY      _FBIOC(0x0019)  /* Clear notify signal */
 
-#define FBIOSET_VSYNCOFFSET   _FBIOC(0x0018)  /* Set VSync offset in usec
+#define FBIOSET_VSYNCOFFSET   _FBIOC(0x001a)  /* Set VSync offset in usec
                                                * Argument:             int */
 
 /* Linux Support ************************************************************/
 
-#define FBIOGET_VSCREENINFO   _FBIOC(0x0019)  /* Get video variable info */
+#define FBIOGET_VSCREENINFO   _FBIOC(0x001b)  /* Get video variable info */
                                               /* Argument: writable struct
                                                *           fb_var_screeninfo */
-#define FBIOGET_FSCREENINFO   _FBIOC(0x001a)  /* Get video fix info */
+#define FBIOGET_FSCREENINFO   _FBIOC(0x001c)  /* Get video fix info */
                                               /* Argument: writable struct
                                                *           fb_fix_screeninfo */
 
@@ -536,11 +546,16 @@ struct fb_overlayinfo_s
   fb_coord_t stride;          /* Length of a line in bytes */
   uint8_t    overlay;         /* Overlay number */
   uint8_t    bpp;             /* Bits per pixel */
+  uint32_t   xres_virtual;    /* Virtual Horizontal resolution in pixel columns */
+  uint32_t   yres_virtual;    /* Virtual Vertical resolution in pixel rows */
+  uint32_t   xoffset;         /* Offset from virtual to visible resolution */
+  uint32_t   yoffset;         /* Offset from virtual to visible resolution */
   uint8_t    blank;           /* Blank or unblank */
   uint32_t   chromakey;       /* Chroma key argb8888 formatted */
   uint32_t   color;           /* Color argb8888 formatted */
   struct fb_transp_s transp;  /* Transparency */
   struct fb_area_s sarea;     /* Selected area within the overlay */
+  struct fb_area_s darea;     /* Destination area on the primary FB */
   uint32_t   accl;            /* Supported hardware acceleration */
 };
 
@@ -758,6 +773,13 @@ struct fb_vtable_s
   int (*setarea)(FAR struct fb_vtable_s *vtable,
                  FAR const struct fb_overlayinfo_s *oinfo);
 
+  /* The following allows to set the display area for subsequently overlay
+   * operations.
+   */
+
+  int (*setdestarea)(FAR struct fb_vtable_s *vtable,
+                        FAR const struct fb_overlayinfo_s *oinfo);
+
 #  ifdef CONFIG_FB_OVERLAY_BLIT
   /* The following are provided only if the video hardware supports
    * blit operation between overlays.
@@ -773,6 +795,13 @@ struct fb_vtable_s
   int (*blend)(FAR struct fb_vtable_s *vtable,
                FAR const struct fb_overlayblend_s *blend);
 #  endif
+
+  /* The following allows to pan display for multiple buffers.
+   */
+
+  int (*panoverlay)(FAR struct fb_vtable_s *vtable,
+                           FAR const struct fb_overlayinfo_s *oinfo);
+
 #endif
 
   /* Pan display for multiple buffers. */


### PR DESCRIPTION
1. support doublebuffer swtich for overlay layer
2. Add display area ioctl to scale the active area of the overlay layer to a specific region on the LCD through hardware.

## Summary

## Impact

## Testing

