### PR TITLE
driver/fb: fix that vtable.priv is not freed when fb register failed.

### DIFF
--- a/drivers/video/fb.c
+++ b/drivers/video/fb.c
@@ -1084,8 +1084,6 @@ int fb_register(int display, int plane)
       goto errout_with_fb;
     }
 
-  fb->vtable->priv = fb;
-
   /* Initialize the frame buffer instance. */
 
   DEBUGASSERT(fb->vtable->getvideoinfo != NULL);
@@ -1150,6 +1148,8 @@ int fb_register(int display, int plane)
       gerr("ERROR: register_driver() failed: %d\n", ret);
       goto errout_with_fb;
     }
+
+  fb->vtable->priv = fb;
 
   return OK;
 


### PR DESCRIPTION
## Summary

The vtable.priv is better to be assigned after fb is registered sucessfully.

## Impact

None.

## Testing

Run fb.
