### PR TITLE
net:Add check for address binding

### DIFF
--- a/net/inet/inet.h
+++ b/net/inet/inet.h
@@ -71,6 +71,7 @@ extern "C"
 
 #ifdef CONFIG_NET_IPv6
 EXTERN const net_ipv6addr_t g_ipv6_unspecaddr;       /* An address of all zeroes */
+EXTERN const net_ipv6addr_t g_ipv6_loopback;         /* An address of loopback */
 EXTERN const net_ipv6addr_t g_ipv6_allnodes;         /* All link local nodes */
 
 #if defined(CONFIG_NET_ICMPv6_AUTOCONF) || defined(CONFIG_NET_ICMPv6_ROUTER) || \

--- a/net/inet/inet_globals.c
+++ b/net/inet/inet_globals.c
@@ -47,6 +47,12 @@ const net_ipv6addr_t g_ipv6_unspecaddr =  /* An address of all zeroes */
   0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000
 };
 
+const net_ipv6addr_t g_ipv6_loopback =    /* An address of loopback */
+{
+  0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+  HTONS(0x0001)
+};
+
 /* IPv6 Multi-cast IP addresses.  See RFC 2375 */
 
 const net_ipv6addr_t g_ipv6_allnodes =    /* All link local nodes */

--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -69,6 +69,7 @@
 #include "arp/arp.h"
 #include "icmpv6/icmpv6.h"
 #include "nat/nat.h"
+#include "netdev/netdev.h"
 
 /****************************************************************************
  * Private Data
@@ -320,6 +321,7 @@ static inline int tcp_ipv4_bind(FAR struct tcp_conn_s *conn,
 {
   int port;
   int ret;
+  FAR struct net_driver_s *dev;
 
   /* Verify or select a local port and address */
 
@@ -329,6 +331,29 @@ static inline int tcp_ipv4_bind(FAR struct tcp_conn_s *conn,
     {
       net_unlock();
       return -EINVAL;
+    }
+
+  if (!net_ipv4addr_cmp(addr->sin_addr.s_addr, INADDR_ANY) &&
+    !net_ipv4addr_cmp(addr->sin_addr.s_addr, HTONL(INADDR_LOOPBACK)) &&
+    !net_ipv4addr_cmp(addr->sin_addr.s_addr, INADDR_BROADCAST) &&
+    !IN_MULTICAST(NTOHL(addr->sin_addr.s_addr)))
+    {
+      ret = -EADDRNOTAVAIL;
+
+      for (dev = g_netdevices; dev; dev = dev->flink)
+        {
+          if (net_ipv4addr_cmp(addr->sin_addr.s_addr, dev->d_ipaddr))
+            {
+              ret = 0;
+              break;
+            }
+        }
+
+      if (ret == -EADDRNOTAVAIL)
+        {
+          net_unlock();
+          return ret;
+        }
     }
 
   /* Verify or select a local port (network byte order) */
@@ -391,6 +416,7 @@ static inline int tcp_ipv6_bind(FAR struct tcp_conn_s *conn,
 {
   int port;
   int ret;
+  FAR struct net_driver_s *dev;
 
   /* Verify or select a local port and address */
 
@@ -400,6 +426,33 @@ static inline int tcp_ipv6_bind(FAR struct tcp_conn_s *conn,
     {
       net_unlock();
       return -EINVAL;
+    }
+
+  if (!net_ipv6addr_cmp(addr->sin6_addr.in6_u.u6_addr16,
+                        g_ipv6_unspecaddr) &&
+      !net_ipv6addr_cmp(addr->sin6_addr.in6_u.u6_addr16,
+                        g_ipv6_loopback) &&
+      !net_ipv6addr_cmp(addr->sin6_addr.in6_u.u6_addr16,
+                        g_ipv6_allnodes) &&
+      !net_ipv6addr_cmp(addr->sin6_addr.in6_u.u6_addr16, g_ipv6_allnodes))
+    {
+      ret = -EADDRNOTAVAIL;
+
+      for (dev = g_netdevices; dev; dev = dev->flink)
+        {
+          if (net_ipv6addr_cmp(addr->sin6_addr.in6_u.u6_addr16,
+                              dev->d_ipv6addr))
+            {
+              ret = 0;
+              break;
+            }
+        }
+
+      if (ret == -EADDRNOTAVAIL)
+        {
+          net_unlock();
+          return ret;
+        }
     }
 
   /* Verify or select a local port (network byte order) */


### PR DESCRIPTION
## Summary
libuvtestcase1:
```
TEST_IMPL(tcp_bind_error_addrnotavail_2) {
  struct sockaddr_in addr;
  uv_tcp_t server;
  int r;

  init_called_count();

  ASSERT(0 == uv_ip4_addr("[4.4.4.4](http://4.4.4.4/)", TEST_PORT, &addr));

  r = uv_tcp_init(uv_default_loop(), &server);
  ASSERT(r == 0);
  r = uv_tcp_bind(&server, (const struct sockaddr*) &addr, 0);
  ASSERT(r == UV_EADDRNOTAVAIL);

  uv_close((uv_handle_t*)&server, close_cb);

  uv_run(uv_default_loop(), UV_RUN_DEFAULT);

  ASSERT(close_cb_called == 1);

  MAKE_VALGRIND_HAPPY();
  return 0;
}

libuvtestcase2:
TEST_IMPL(tcp_bind6_error_addrnotavail) {
  struct sockaddr_in6 addr;
  uv_tcp_t server;
  int r;

  close_cb_called = 0;

  if (!can_ipv6())
    RETURN_SKIP("IPv6 not supported");

  ASSERT(0 == uv_ip6_addr("4:4:4:4:4:4:4:4", TEST_PORT, &addr));

  r = uv_tcp_init(uv_default_loop(), &server);
  ASSERT(r == 0);
  r = uv_tcp_bind(&server, (const struct sockaddr*) &addr, 0);
  ASSERT(r == UV_EADDRNOTAVAIL);

  uv_close((uv_handle_t*)&server, close_cb);

  uv_run(uv_default_loop(), UV_RUN_DEFAULT);

  ASSERT(close_cb_called == 1);

  MAKE_VALGRIND_HAPPY();
  return 0;
}
```

## Impact

## Testing
libuv test
