### PR TITLE
LPWORK priority

### DIFF
--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -1669,7 +1669,7 @@ config SCHED_LPNTHREADS
 
 config SCHED_LPWORKPRIORITY
 	int "Low priority worker thread priority"
-	default 100
+	default 90
 	---help---
 		The minimum execution priority of the lower priority worker thread.
 
@@ -1678,7 +1678,7 @@ config SCHED_LPWORKPRIORITY
 		priority, of course, but has the added advantage that it supports
 		"priority inheritance" (if PRIORITY_INHERITANCE is also selected):
 		The priority of the lower priority worker thread can then be
-		adjusted to match the highest priority client.  Default: 100
+		adjusted to match the highest priority client.  Default: 90
 
 		NOTE: This priority inheritance feature is not automatic.  The
 		lower priority worker thread will always a fixed priority unless

--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -555,6 +555,9 @@ void _assert(FAR const char *filename, int linenum,
   FAR struct tcb_s *rtcb = running_task();
   struct utsname name;
   bool fatal = true;
+  int flags;
+
+  flags = enter_critical_section();
 
   /* try to save current context if regs is null */
 
@@ -676,4 +679,6 @@ void _assert(FAR const char *filename, int linenum,
         }
 #endif
     }
+
+  leave_critical_section(flags);
 }


### PR DESCRIPTION
## Summary

    LPWORK: set LPWORK default priority to 90
    
    Because most of app default priority is 100


    assert: thread assert don't interrupt by IRQ


## Impact

lpwork & assert

## Testing

VELA