### PR TITLE
procfsproc:Optimize fd information output format

### DIFF
--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -1203,7 +1203,7 @@ static ssize_t proc_groupfd(FAR struct proc_file_s *procfile,
   totalsize = 0;
 
   linesize   = procfs_snprintf(procfile->line, STATUS_LINELEN,
-                               "\n%-3s %-8s %-8s %-8s %s \n",
+                               "\n%-3s %-9s %-7s %-4s %s \n",
                                "FD", "POS", "OFLAGS", "TYPE", "PATH");
   copysize   = procfs_memcpy(procfile->line, linesize, buffer, remaining,
                              &offset);
@@ -1235,7 +1235,7 @@ static ssize_t proc_groupfd(FAR struct proc_file_s *procfile,
                 }
 
               linesize   = procfs_snprintf(procfile->line, STATUS_LINELEN,
-                                    "%3d %8ld %8d %8x",
+                                    "%-3d %-9ld %-7d %4x",
                                     i * CONFIG_NFILE_DESCRIPTORS_PER_BLOCK +
                                     j, (long)file->f_pos,
                                     INODE_GET_TYPE(file->f_inode),
@@ -1266,7 +1266,7 @@ static ssize_t proc_groupfd(FAR struct proc_file_s *procfile,
 
 #ifdef CONFIG_NET
   linesize   = procfs_snprintf(procfile->line, STATUS_LINELEN,
-                               "\n%-3s %-2s %-3s %s\n",
+                               "\n%-3s %-5s %s %s\n",
                                "SD", "RF", "TYP", "FLAGS");
   copysize   = procfs_memcpy(procfile->line, linesize, buffer, remaining,
                              &offset);
@@ -1295,7 +1295,7 @@ static ssize_t proc_groupfd(FAR struct proc_file_s *procfile,
               FAR struct socket *socket = file->f_priv;
               FAR struct socket_conn_s *conn = socket->s_conn;
               linesize   = procfs_snprintf(procfile->line, STATUS_LINELEN,
-                                    "%3d %3d %02x",
+                                    "%-3d %-5d %02x\n",
                                     i * CONFIG_NFILE_DESCRIPTORS_PER_BLOCK +
                                     j, socket->s_type, conn->s_flags);
               copysize   = procfs_memcpy(procfile->line, linesize, buffer,

--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -1203,8 +1203,8 @@ static ssize_t proc_groupfd(FAR struct proc_file_s *procfile,
   totalsize = 0;
 
   linesize   = procfs_snprintf(procfile->line, STATUS_LINELEN,
-                               "\n%-3s %-8s %-8s %s\n",
-                               "FD", "POS", "OFLAGS", "PATH");
+                               "\n%-3s %-8s %-8s %-8s %s \n",
+                               "FD", "POS", "OFLAGS", "TYPE", "PATH");
   copysize   = procfs_memcpy(procfile->line, linesize, buffer, remaining,
                              &offset);
 
@@ -1235,9 +1235,10 @@ static ssize_t proc_groupfd(FAR struct proc_file_s *procfile,
                 }
 
               linesize   = procfs_snprintf(procfile->line, STATUS_LINELEN,
-                                    "%3d %8ld %8x",
+                                    "%3d %8ld %8d %8x",
                                     i * CONFIG_NFILE_DESCRIPTORS_PER_BLOCK +
                                     j, (long)file->f_pos,
+                                    INODE_GET_TYPE(file->f_inode),
                                     file->f_oflags);
               copysize   = procfs_memcpy(procfile->line, linesize, buffer,
                                          remaining, &offset);


### PR DESCRIPTION
## Summary
Fix the wrong position of information display, integrate the fd information of socket and file
By left-aligned display, the effect is as follows (0, 1, 2 is fd information, 3 is sd information)
    
        FD  OFLAGS  TYPE POS       PATH
        0   3       1    0         /dev/console
        1   3       1    0         /dev/console
        2   3       1    0         /dev/console
        3   65      2
## Impact

## Testing

