### PR TITLE
crypto: not use software algorithm in nuttx crypto by default

### DIFF
--- a/crypto/Kconfig
+++ b/crypto/Kconfig
@@ -40,6 +40,11 @@ config CRYPTO_CRYPTODEV
 	depends on ALLOW_BSD_COMPONENTS
 	default n
 
+config CRYPTO_CRYPTODEV_SOFTWARE
+	bool "cryptodev software support"
+	depends on CRYPTO_CRYPTODEV
+	default n
+
 config CRYPTO_CRYPTODEV_HARDWARE
 	bool "cryptodev hardware support"
 	depends on CRYPTO_CRYPTODEV

--- a/crypto/Makefile
+++ b/crypto/Makefile
@@ -30,7 +30,9 @@ CRYPTO_CSRCS += crypto.c testmngr.c
 
 ifeq ($(CONFIG_CRYPTO_CRYPTODEV),y)
   CRYPTO_CSRCS += cryptodev.c
+ifeq ($(CONFIG_CRYPTO_CRYPTODEV_SOFTWARE),y)
   CRYPTO_CSRCS += cryptosoft.c
+endif
   CRYPTO_CSRCS += xform.c
   CRYPTO_CSRCS += aes.c
   CRYPTO_CSRCS += blf.c

--- a/crypto/cryptodev.c
+++ b/crypto/cryptodev.c
@@ -59,9 +59,13 @@ extern FAR struct cryptocap *crypto_drivers;
 extern int crypto_drivers_num;
 int usercrypto = 1;         /* userland may do crypto requests */
 int userasymcrypto = 1;     /* userland may do asymmetric crypto reqs */
+#ifdef CONFIG_CRYPTO_CRYPTODEV_SOFTWARE
 int cryptodevallowsoft = 1; /* 0 is only use hardware crypto
                              * 1 is use hardware & software crypto
                              */
+#else
+int cryptodevallowsoft = 0;
+#endif
 
 /****************************************************************************
  * Private Types
@@ -887,7 +891,10 @@ int csefree(FAR struct csession *cse)
 void devcrypto_register(void)
 {
   register_driver("/dev/crypto", &g_cryptoops, 0666, NULL);
+
+#ifdef CONFIG_CRYPTO_CRYPTODEV_SOFTWARE
   swcr_init();
+#endif
 
 #ifdef CONFIG_CRYPTO_CRYPTODEV_HARDWARE
   hwcr_init();


### PR DESCRIPTION
(1) software algorithm in nuttx crypto are not very efficient
(2) can reduce image size effectively
Signed-off-by: makejian <makejian@xiaomi.com>