### PR TITLE
sched: add CRITMONITOR time out panic

### DIFF
--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -863,6 +863,20 @@ config SCHED_CRITMONITOR_MAXTIME_WDOG
 
 endif # SCHED_CRITMONITOR
 
+config SCHED_CRITMONITOR_MAXTIME_PANIC
+	bool "Monitor timeout panic"
+	depends on \
+		SCHED_CRITMONITOR_MAXTIME_THREAD > 0 || \
+		SCHED_CRITMONITOR_MAXTIME_WDOG > 0 || \
+		SCHED_CRITMONITOR_MAXTIME_WQUEUE > 0 || \
+		SCHED_CRITMONITOR_MAXTIME_PREEMPTION > 0 || \
+		SCHED_CRITMONITOR_MAXTIME_CSECTION > 0 || \
+		SCHED_CRITMONITOR_MAXTIME_IRQ > 0
+	default n
+	---help---
+		If this option is enabled, a panic will be triggered when
+		IRQ/WQUEUE/PREEMPTION execution time exceeds SCHED_CRITMONITOR_MAXTIME_xxx
+
 config SCHED_CPULOAD
 	bool "Enable CPU load monitoring"
 	default n

--- a/sched/irq/irq_dispatch.c
+++ b/sched/irq/irq_dispatch.c
@@ -96,8 +96,8 @@
          if (CONFIG_SCHED_CRITMONITOR_MAXTIME_IRQ > 0 && \
              elapsed > CONFIG_SCHED_CRITMONITOR_MAXTIME_IRQ) \
            { \
-             serr("IRQ %d(%p), execute time too long %lu\n", \
-                  irq, vector, elapsed); \
+             CRITMONITOR_PANIC("IRQ %d(%p), execute time too long %lu\n", \
+                               irq, vector, elapsed); \
            } \
        } \
      while (0)

--- a/sched/sched/sched.h
+++ b/sched/sched/sched.h
@@ -91,6 +91,18 @@
 #  define TLIST_BLOCKED(t)       __TLIST_HEAD(t)
 #endif
 
+#ifdef CONFIG_SCHED_CRITMONITOR_MAXTIME_PANIC
+#  define CRITMONITOR_PANIC(fmt, ...) \
+          do \
+            { \
+              _alert(fmt, ##__VA_ARGS__); \
+              PANIC(); \
+            } \
+          while(0)
+#else
+#  define CRITMONITOR_PANIC(fmt, ...) _alert(fmt, ##__VA_ARGS__)
+#endif
+
 /****************************************************************************
  * Public Type Definitions
  ****************************************************************************/

--- a/sched/sched/sched_critmonitor.c
+++ b/sched/sched/sched_critmonitor.c
@@ -56,8 +56,8 @@
          if (pid > 0 && \
              elapsed > CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION) \
            { \
-             serr("PID %d hold sched lock too long %"PRIu32"\n", \
-                   pid, elapsed); \
+             CRITMONITOR_PANIC("PID %d hold sched lock too long %"PRIu32"\n", \
+                               pid, elapsed); \
            } \
        } \
      while (0)
@@ -72,8 +72,8 @@
          if (pid > 0 && \
              elapsed > CONFIG_SCHED_CRITMONITOR_MAXTIME_CSECTION) \
            { \
-             serr("PID %d hold critical section too long %"PRIu32"\n", \
-                   pid, elapsed); \
+             CRITMONITOR_PANIC("PID %d hold critical section too long %" \
+                               PRIu32 "\n", pid, elapsed); \
            } \
        } \
      while (0)
@@ -88,8 +88,8 @@
          if (pid > 0 && \
              elapsed > CONFIG_SCHED_CRITMONITOR_MAXTIME_THREAD) \
            { \
-             serr("PID %d execute too long %"PRIu32"\n", \
-                   pid, elapsed); \
+             CRITMONITOR_PANIC("PID %d execute too long %"PRIu32"\n", \
+                               pid, elapsed); \
            } \
        } \
      while (0)

--- a/sched/wdog/wd_start.c
+++ b/sched/wdog/wd_start.c
@@ -59,8 +59,9 @@
          elapsed = up_perf_gettime() - start; \
          if (elapsed > CONFIG_SCHED_CRITMONITOR_MAXTIME_WDOG) \
            { \
-             serr("WDOG %p, %s IRQ, execute too long %lu\n", \
-                   func, up_interrupt_context() ? "IN" : "NOT", elapsed); \
+             CRITMONITOR_PANIC("WDOG %p, %s IRQ, execute too long %lu\n", \
+                               func, up_interrupt_context() ? \
+                               "IN" : "NOT", elapsed); \
            } \
        } \
      while (0)

--- a/sched/wqueue/kwork_thread.c
+++ b/sched/wqueue/kwork_thread.c
@@ -38,6 +38,7 @@
 #include <nuttx/kthread.h>
 #include <nuttx/semaphore.h>
 
+#include "sched/sched.h"
 #include "wqueue/wqueue.h"
 
 #if defined(CONFIG_SCHED_WORKQUEUE)
@@ -61,8 +62,8 @@
          elapsed = up_perf_gettime() - start; \
          if (elapsed > CONFIG_SCHED_CRITMONITOR_MAXTIME_WQUEUE) \
            { \
-             serr("WORKER %p execute too long %lu\n", \
-                   worker, elapsed); \
+             CRITMONITOR_PANIC("WORKER %p execute too long %lu\n", \
+                               worker, elapsed); \
            } \
        } \
      while (0)


### PR DESCRIPTION
## Summary
Actively panic to trigger problems when some key points run for too long

## Impact

## Testing

