### PR TITLE
libc/stdio: changed LIBC_NL_ARGMAX default value to 9

### DIFF
--- a/libs/libc/stdio/Kconfig
+++ b/libs/libc/stdio/Kconfig
@@ -89,7 +89,7 @@ config LIBC_NUMBERED_ARGS
 
 config LIBC_NL_ARGMAX
 	int "Maximum number of numbered arguments for printf"
-	default 16
+	default 9
 	range 9 999999
 	depends on LIBC_NUMBERED_ARGS
 	---help---


### PR DESCRIPTION
## Summary
If LIBC_NL_ARGMAX is too large, the stack usage of printf family functions will increase

## Impact

## Testing

