### PR TITLE
Don't call lib_free in the kernel code

### DIFF
--- a/drivers/crypto/dev_urandom.c
+++ b/drivers/crypto/dev_urandom.c
@@ -37,7 +37,6 @@
 #include <errno.h>
 #include <assert.h>
 
-#include <nuttx/lib/lib.h>
 #include <nuttx/lib/xorshift128.h>
 #include <nuttx/semaphore.h>
 #include <nuttx/fs/fs.h>

--- a/drivers/net/telnet.c
+++ b/drivers/net/telnet.c
@@ -720,7 +720,7 @@ static int telnet_close(FAR struct file *filep)
                 }
             }
 
-          lib_free(devpath);
+          kmm_free(devpath);
         }
 
       for (i = 0; i < CONFIG_TELNET_MAXLCLIENTS; i++)

--- a/drivers/wireless/gs2200m.c
+++ b/drivers/wireless/gs2200m.c
@@ -3542,7 +3542,7 @@ FAR void *gs2200m_register(FAR const char *devpath,
 
 errout:
   nxmutex_destroy(&dev->dev_lock);
-  lib_free(dev->path);
+  kmm_free(dev->path);
   kmm_free(dev);
   return NULL;
 }

--- a/fs/inode/fs_inodesearch.c
+++ b/fs/inode/fs_inodesearch.c
@@ -358,7 +358,7 @@ static int _inode_search(FAR struct inode_search_s *desc)
                                                  name);
                                   if (ret > 0)
                                     {
-                                      lib_free(desc->buffer);
+                                      kmm_free(desc->buffer);
                                       desc->buffer = buffer;
                                       relpath = buffer;
                                       ret = OK;

--- a/fs/inode/inode.h
+++ b/fs/inode/inode.h
@@ -35,7 +35,6 @@
 
 #include <nuttx/kmalloc.h>
 #include <nuttx/fs/fs.h>
-#include <nuttx/lib/lib.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -59,7 +58,7 @@
     { \
       if ((d)->buffer != NULL) \
         { \
-          lib_free((d)->buffer); \
+          kmm_free((d)->buffer); \
           (d)->buffer  = NULL; \
         } \
     } \

--- a/fs/unionfs/fs_unionfs.c
+++ b/fs/unionfs/fs_unionfs.c
@@ -1770,7 +1770,7 @@ static int unionfs_readdir(FAR struct inode *mountpt,
 
                       /* Free the allocated relpath */
 
-                      lib_free(relpath);
+                      kmm_free(relpath);
 
                       /* Check for a duplicate */
 
@@ -1857,7 +1857,7 @@ static int unionfs_readdir(FAR struct inode *mountpt,
 
                   /* Free the allocated relpath */
 
-                  lib_free(relpath);
+                  kmm_free(relpath);
                 }
             }
         }

--- a/fs/vfs/fs_dir.c
+++ b/fs/vfs/fs_dir.c
@@ -449,7 +449,7 @@ static int dir_close(FAR struct file *filep)
   /* Release our references on the contained 'root' inode */
 
   inode_release(inode);
-  lib_free(relpath);
+  kmm_free(relpath);
   return ret;
 }
 

--- a/fs/vfs/fs_fdopen.c
+++ b/fs/vfs/fs_fdopen.c
@@ -33,7 +33,6 @@
 #include <nuttx/kmalloc.h>
 #include <nuttx/semaphore.h>
 #include <nuttx/fs/fs.h>
-#include <nuttx/lib/lib.h>
 #include <nuttx/tls.h>
 
 #include "inode/inode.h"

--- a/fs/vfs/fs_rename.c
+++ b/fs/vfs/fs_rename.c
@@ -245,7 +245,7 @@ errout:
   RELEASE_SEARCH(&newdesc);
   if (subdir != NULL)
     {
-      lib_free(subdir);
+      kmm_free(subdir);
     }
 
   return ret;
@@ -431,7 +431,7 @@ errout_with_newsearch:
   RELEASE_SEARCH(&newdesc);
   if (subdir != NULL)
     {
-      lib_free(subdir);
+      kmm_free(subdir);
     }
 
   return ret;


### PR DESCRIPTION
## Summary

since kernel just allocate memory from kmm_malloc

## Impact

code refactor only since lib_free call kmm_free when is compiled in kernel spacee

## Testing

ci