### PR TITLE
arch/risc-v: Add support for StarFive JH7110 SoC

### DIFF
--- a/arch/risc-v/Kconfig
+++ b/arch/risc-v/Kconfig
@@ -189,6 +189,26 @@ config ARCH_CHIP_HPM6750
 	---help---
 		Hpmicro HPM6750 processor (D45 RISC-V Core with MAC extensions).
 
+config ARCH_CHIP_JH7110
+	bool "StarFive JH7110"
+	select ARCH_RV64
+	select ARCH_RV_ISA_M
+	select ARCH_RV_ISA_A
+	select ARCH_RV_ISA_C
+	select ARCH_HAVE_FPU
+	select ARCH_HAVE_DPFPU
+	select ARCH_HAVE_MULTICPU
+	select ARCH_HAVE_MPU
+	select ARCH_HAVE_MMU
+	select ARCH_MMU_TYPE_SV39
+	select ARCH_HAVE_ADDRENV
+	select ARCH_NEED_ADDRENV_MAPPING
+	select ARCH_HAVE_S_MODE
+	select ONESHOT
+	select ALARM_ARCH
+	---help---
+		StarFive JH7110 SoC.
+
 config ARCH_CHIP_RISCV_CUSTOM
 	bool "Custom RISC-V chip"
 	select ARCH_CHIP_CUSTOM
@@ -238,6 +258,7 @@ config ARCH_CHIP
 	default "rv32m1"	if ARCH_CHIP_RV32M1
 	default "qemu-rv"	if ARCH_CHIP_QEMU_RV
 	default "hpm6750"	if ARCH_CHIP_HPM6750
+	default "jh7110"	if ARCH_CHIP_JH7110
 
 config ARCH_RISCV_INTXCPT_EXTENSIONS
 	bool "RISC-V Integer Context Extensions"
@@ -422,5 +443,8 @@ source "arch/risc-v/src/qemu-rv/Kconfig"
 endif
 if ARCH_CHIP_HPM6750
 source "arch/risc-v/src/hpm6750/Kconfig"
+endif
+if ARCH_CHIP_JH7110
+source "arch/risc-v/src/jh7110/Kconfig"
 endif
 endif

--- a/arch/risc-v/include/jh7110/chip.h
+++ b/arch/risc-v/include/jh7110/chip.h
@@ -1,0 +1,24 @@
+/****************************************************************************
+ * arch/risc-v/include/jh7110/chip.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_RISCV_INCLUDE_JH7110_CHIP_H
+#define __ARCH_RISCV_INCLUDE_JH7110_CHIP_H
+
+#endif /* __ARCH_RISCV_INCLUDE_JH7110_CHIP_H */

--- a/arch/risc-v/include/jh7110/irq.h
+++ b/arch/risc-v/include/jh7110/irq.h
@@ -1,0 +1,36 @@
+/****************************************************************************
+ * arch/risc-v/include/jh7110/irq.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_RISCV_INCLUDE_JH7110_IRQ_H
+#define __ARCH_RISCV_INCLUDE_JH7110_IRQ_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Map RISC-V exception code to NuttX IRQ */
+
+#define NR_IRQS (RISCV_IRQ_SEXT + 127)
+
+#endif /* __ARCH_RISCV_INCLUDE_JH7110_IRQ_H */

--- a/arch/risc-v/src/jh7110/Make.defs
+++ b/arch/risc-v/src/jh7110/Make.defs
@@ -1,0 +1,30 @@
+############################################################################
+# arch/risc-v/src/jh7110/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include common/Make.defs
+
+# Specify our HEAD assembly file.  This will be linked as
+# the first object file, so it will appear at address 0
+HEAD_ASRC = jh7110_head.S
+
+# Specify our C code within this directory to be included
+CHIP_CSRCS  = jh7110_start.c jh7110_irq_dispatch.c jh7110_irq.c
+CHIP_CSRCS += jh7110_timerisr.c jh7110_allocateheap.c
+CHIP_CSRCS += jh7110_mm_init.c jh7110_pgalloc.c

--- a/arch/risc-v/src/jh7110/chip.h
+++ b/arch/risc-v/src/jh7110/chip.h
@@ -1,0 +1,75 @@
+/****************************************************************************
+ * arch/risc-v/src/jh7110/chip.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_RISCV_SRC_JH7110_CHIP_H
+#define __ARCH_RISCV_SRC_JH7110_CHIP_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+/* Include the chip capabilities file */
+
+#include <arch/jh7110/chip.h>
+
+#include "jh7110_memorymap.h"
+
+#include "hardware/jh7110_memorymap.h"
+#include "hardware/jh7110_plic.h"
+
+#include "riscv_internal.h"
+#include "riscv_percpu.h"
+
+/****************************************************************************
+ * Macro Definitions
+ ****************************************************************************/
+
+#ifdef __ASSEMBLY__
+
+/****************************************************************************
+ * Name: setintstack
+ *
+ * Description:
+ *   Set the current stack pointer to the  "top" the correct interrupt stack
+ *   for the current CPU.
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_SMP) && CONFIG_ARCH_INTERRUPTSTACK > 15
+.macro  setintstack tmp0, tmp1
+  riscv_mhartid \tmp0
+  li    \tmp1, STACK_ALIGN_DOWN(CONFIG_ARCH_INTERRUPTSTACK)
+  mul   \tmp1, \tmp0, \tmp1
+  la    \tmp0, g_intstacktop
+  sub   sp, \tmp0, \tmp1
+.endm
+#endif /* CONFIG_SMP && CONFIG_ARCH_INTERRUPTSTACK > 15 */
+
+#if CONFIG_ARCH_INTERRUPTSTACK > 15
+#if !defined(CONFIG_SMP) && defined(CONFIG_ARCH_USE_S_MODE)
+.macro  setintstack tmp0, tmp1
+  csrr    \tmp0, CSR_SCRATCH
+  REGLOAD sp, RISCV_PERCPU_IRQSTACK(\tmp0)
+.endm
+#endif /* !defined(CONFIG_SMP) && defined(CONFIG_ARCH_USE_S_MODE) */
+#endif /* CONFIG_ARCH_INTERRUPTSTACK > 15 */
+
+#endif /* __ASSEMBLY__  */
+#endif /* __ARCH_RISCV_SRC_JH7110_CHIP_H */

--- a/arch/risc-v/src/jh7110/hardware/jh7110_memorymap.h
+++ b/arch/risc-v/src/jh7110/hardware/jh7110_memorymap.h
@@ -1,0 +1,32 @@
+/****************************************************************************
+ * arch/risc-v/src/jh7110/hardware/jh7110_memorymap.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_RISCV_SRC_JH7110_HARDWARE_JH7110_MEMORYMAP_H
+#define __ARCH_RISCV_SRC_JH7110_HARDWARE_JH7110_MEMORYMAP_H
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Register Base Address ****************************************************/
+
+#define JH7110_PLIC_BASE    0x0c000000
+
+#endif /* __ARCH_RISCV_SRC_JH7110_HARDWARE_JH7110_MEMORYMAP_H */

--- a/arch/risc-v/src/jh7110/hardware/jh7110_plic.h
+++ b/arch/risc-v/src/jh7110/hardware/jh7110_plic.h
@@ -1,0 +1,51 @@
+/****************************************************************************
+ * arch/risc-v/src/jh7110/hardware/jh7110_plic.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_RISCV_SRC_JH7110_HARDWARE_JH7110_PLIC_H
+#define __ARCH_RISCV_SRC_JH7110_HARDWARE_JH7110_PLIC_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Interrupt Priority */
+
+#define JH7110_PLIC_PRIORITY  (JH7110_PLIC_BASE + 0x000000)
+
+/* Hart 1 S-Mode Interrupt Enable */
+
+#define JH7110_PLIC_ENABLE1   (JH7110_PLIC_BASE + 0x002100)
+#define JH7110_PLIC_ENABLE2   (JH7110_PLIC_BASE + 0x002104)
+
+/* Hart 1 S-Mode Priority Threshold */
+
+#define JH7110_PLIC_THRESHOLD (JH7110_PLIC_BASE + 0x202000)
+
+/* Hart 1 S-Mode Claim / Complete */
+
+#define JH7110_PLIC_CLAIM     (JH7110_PLIC_BASE + 0x202004)
+
+#endif /* __ARCH_RISCV_SRC_JH7110_HARDWARE_JH7110_PLIC_H */

--- a/arch/risc-v/src/jh7110/jh7110_allocateheap.c
+++ b/arch/risc-v/src/jh7110/jh7110_allocateheap.c
@@ -1,0 +1,85 @@
+/****************************************************************************
+ * arch/risc-v/src/jh7110/jh7110_allocateheap.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/kmalloc.h>
+#include <nuttx/userspace.h>
+#include <nuttx/arch.h>
+#include <arch/board/board_memorymap.h>
+#include "riscv_internal.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define KRAM_END    KSRAM_END
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_allocate_heap
+ *
+ * Description:
+ *   This function will be called to dynamically set aside the heap region.
+ *
+ *   For the kernel build (CONFIG_BUILD_PROTECTED=y) with both kernel- and
+ *   user-space heaps (CONFIG_MM_KERNEL_HEAP=y), this function provides the
+ *   size of the unprotected, user-space heap.
+ *
+ *   If a protected kernel-space heap is provided, the kernel heap must be
+ *   allocated (and protected) by an analogous up_allocate_kheap().
+ *
+ *   The following memory map is assumed for the flat build:
+ *
+ *   .data region.  Size determined at link time.
+ *   .bss  region  Size determined at link time.
+ *   IDLE thread stack.  Size determined by CONFIG_IDLETHREAD_STACKSIZE.
+ *   Heap.  Extends to the end of User SRAM.
+ *
+ *   The following memory map is assumed for the protect build.
+ *   The kernel and user space have it's own dedicated heap space.
+ *
+ *   User .data region         Size determined at link time
+ *   User .bss region          Size determined at link time
+ *   User heap                 Extends to the end of User SRAM
+ *   Kernel .data region       Size determined at link time
+ *   Kernel .bss  region       Size determined at link time
+ *   Kernel IDLE thread stack  Size determined by CONFIG_IDLETHREAD_STACKSIZE
+ *   Kernel heap               Size determined by CONFIG_MM_KERNEL_HEAPSIZE
+ *
+ ****************************************************************************/
+
+void up_allocate_kheap(void **heap_start, size_t *heap_size)
+{
+  /* Return the heap settings */
+
+  *heap_start = (void *)g_idle_topstack;
+  *heap_size = KRAM_END - g_idle_topstack;
+}

--- a/arch/risc-v/src/jh7110/jh7110_head.S
+++ b/arch/risc-v/src/jh7110/jh7110_head.S
@@ -1,0 +1,149 @@
+/****************************************************************************
+ * arch/risc-v/src/jh7110/jh7110_head.S
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <arch/arch.h>
+#include <arch/irq.h>
+
+#include "chip.h"
+#include "riscv_internal.h"
+
+/****************************************************************************
+ * Public Symbols
+ ****************************************************************************/
+
+  /* Exported Symbols */
+
+  .section .text
+  .global __start
+
+__start:
+
+  /* DO NOT MODIFY. Image Header expected by Linux bootloaders.
+   *
+   * This `li` instruction has no meaningful effect except that
+   * its opcode forms the magic "MZ" signature of a PE/COFF file
+   * that is required for UEFI applications.
+   *
+   * Some bootloaders check the magic "MZ" to see if the image is a valid
+   * Linux image. But modifying the bootLoader is unnecessary unless we
+   * need to do a customized secure boot. So we just put "MZ" in the
+   * header to make the bootloader happy.
+   */
+
+  c.li    s4, -13              /* Magic Signature "MZ" (2 bytes) */
+  j       real_start           /* Jump to Kernel Start (2 bytes) */
+  .long   0                    /* Executable Code padded to 8 bytes */
+  .quad   0x200000             /* Image load offset from start of RAM */
+  .quad   _ebss - __start      /* Effective size of kernel image */
+  .quad   0                    /* Kernel flags, little-endian */
+  .long   2                    /* Version of this header */
+  .long   0                    /* Reserved */
+  .quad   0                    /* Reserved */
+  .ascii  "RISCV\x00\x00\x00"  /* Magic number, "RISCV" (8 bytes) */
+  .ascii  "RSC\x05"            /* Magic number 2, "RSC\x05" (4 bytes) */
+  .long   0                    /* Reserved for PE COFF offset */
+
+real_start:
+
+  /* We assume that OpenSBI has passed Hart ID (value 1) in Register a0.
+   * But NuttX expects Hart ID to start at 0, so we subtract 1.
+   */
+
+  addi a0, a0, -1
+
+  /* Set stack pointer to the idle thread stack */
+
+  bnez a0, 1f
+  la   sp, JH7110_IDLESTACK_TOP
+  j    2f
+1:
+
+  /* Load the number of CPUs that the kernel supports */
+
+#ifdef CONFIG_SMP
+  li   t1, CONFIG_SMP_NCPUS
+#else
+  li   t1, 1
+#endif
+
+  /* If a0 (hartid) >= t1 (the number of CPUs), stop here */
+
+  blt  a0, t1, 3f
+  csrw sie, zero
+  wfi
+
+3:
+  /* To get g_cpu_basestack[hartid], must get g_cpu_basestack first */
+
+  la   t0, g_cpu_basestack
+
+  /* Offset = pointer width * hart id */
+
+#ifdef CONFIG_ARCH_RV32
+  slli t1, a0, 2
+#else
+  slli t1, a0, 3
+#endif
+  add  t0, t0, t1
+
+  /* Load idle stack base to sp */
+
+  REGLOAD sp, 0(t0)
+
+  /*
+   * sp (stack top) = sp + idle stack size - XCPTCONTEXT_SIZE
+   *
+   * Note: Reserve some space used by up_initial_state since we are already
+   * running and using the per CPU idle stack.
+   */
+
+  li   t0, STACK_ALIGN_UP(CONFIG_IDLETHREAD_STACKSIZE - XCPTCONTEXT_SIZE)
+  add  sp, sp, t0
+
+2:
+
+  /* Disable all interrupts (i.e. timer, external) in sie */
+
+  csrw	sie, zero
+
+  la   t0, __trap_vec
+  csrw stvec, t0
+
+  /* Jump to jh7110_start */
+
+  jal  x1, jh7110_start
+
+  /* We shouldn't return from _start */
+
+  .global _init
+  .global _fini
+
+_init:
+_fini:
+
+  /* These don't have to do anything since we use init_array/fini_array. */
+
+  ret

--- a/arch/risc-v/src/jh7110/jh7110_irq.c
+++ b/arch/risc-v/src/jh7110/jh7110_irq.c
@@ -1,0 +1,194 @@
+/****************************************************************************
+ * arch/risc-v/src/jh7110/jh7110_irq.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+#include <stdio.h>
+#include <assert.h>
+#include <debug.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/irq.h>
+
+#include "riscv_internal.h"
+#include "chip.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_irqinitialize
+ ****************************************************************************/
+
+void up_irqinitialize(void)
+{
+  /* Disable S-Mode interrupts */
+
+  up_irq_save();
+
+  /* Disable all global interrupts */
+
+  putreg32(0x0, JH7110_PLIC_ENABLE1);
+  putreg32(0x0, JH7110_PLIC_ENABLE2);
+
+  /* Colorize the interrupt stack for debug purposes */
+
+#if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 15
+  size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~15);
+  riscv_stack_color(g_intstackalloc, intstack_size);
+#endif
+
+  /* Set priority for all global interrupts to 1 (lowest) */
+
+  int id;
+
+  for (id = 1; id <= NR_IRQS; id++)
+    {
+      putreg32(1, (uintptr_t)(JH7110_PLIC_PRIORITY + 4 * id));
+    }
+
+  /* Set irq threshold to 0 (permits all global interrupts) */
+
+  putreg32(0, JH7110_PLIC_THRESHOLD);
+
+  /* Attach the common interrupt handler */
+
+  riscv_exception_attach();
+
+#ifdef CONFIG_SMP
+  /* Clear RISCV_IPI for CPU0 */
+
+  putreg32(0, RISCV_IPI);
+
+  up_enable_irq(RISCV_IRQ_SOFT);
+#endif
+
+#ifndef CONFIG_SUPPRESS_INTERRUPTS
+
+  /* And finally, enable interrupts */
+
+  up_irq_enable();
+#endif
+}
+
+/****************************************************************************
+ * Name: up_disable_irq
+ *
+ * Description:
+ *   Disable the IRQ specified by 'irq'
+ *
+ ****************************************************************************/
+
+void up_disable_irq(int irq)
+{
+  int extirq;
+
+  if (irq == RISCV_IRQ_SOFT)
+    {
+      /* Read sstatus & clear software interrupt enable in sie */
+
+      CLEAR_CSR(CSR_IE, IE_SIE);
+    }
+  else if (irq == RISCV_IRQ_TIMER)
+    {
+      /* Read sstatus & clear timer interrupt enable in sie */
+
+      CLEAR_CSR(CSR_IE, IE_TIE);
+    }
+  else if (irq > RISCV_IRQ_EXT)
+    {
+      extirq = irq - RISCV_IRQ_EXT;
+
+      /* Clear enable bit for the irq */
+
+      if (0 <= extirq && extirq <= 63)
+        {
+          modifyreg32(JH7110_PLIC_ENABLE1 + (4 * (extirq / 32)),
+                      1 << (extirq % 32), 0);
+        }
+      else
+        {
+          PANIC();
+        }
+    }
+}
+
+/****************************************************************************
+ * Name: up_enable_irq
+ *
+ * Description:
+ *   Enable the IRQ specified by 'irq'
+ *
+ ****************************************************************************/
+
+void up_enable_irq(int irq)
+{
+  int extirq;
+
+  if (irq == RISCV_IRQ_SOFT)
+    {
+      /* Read sstatus & set software interrupt enable in sie */
+
+      SET_CSR(CSR_IE, IE_SIE);
+    }
+  else if (irq == RISCV_IRQ_TIMER)
+    {
+      /* Read sstatus & set timer interrupt enable in sie */
+
+      SET_CSR(CSR_IE, IE_TIE);
+    }
+  else if (irq > RISCV_IRQ_EXT)
+    {
+      extirq = irq - RISCV_IRQ_EXT;
+
+      /* Set enable bit for the irq */
+
+      if (0 <= extirq && extirq <= 63)
+        {
+          modifyreg32(JH7110_PLIC_ENABLE1 + (4 * (extirq / 32)),
+                      0, 1 << (extirq % 32));
+        }
+      else
+        {
+          PANIC();
+        }
+    }
+}
+
+irqstate_t up_irq_enable(void)
+{
+  irqstate_t oldstat;
+
+  /* Enable external interrupts (sie) */
+
+  SET_CSR(CSR_IE, IE_EIE);
+
+  /* Read and enable global interrupts (sie) in sstatus */
+
+  oldstat = READ_AND_SET_CSR(CSR_STATUS, STATUS_IE);
+
+  return oldstat;
+}

--- a/arch/risc-v/src/jh7110/jh7110_irq_dispatch.c
+++ b/arch/risc-v/src/jh7110/jh7110_irq_dispatch.c
@@ -1,0 +1,84 @@
+/****************************************************************************
+ * arch/risc-v/src/jh7110/jh7110_irq_dispatch.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+#include <assert.h>
+
+#include <nuttx/irq.h>
+#include <nuttx/arch.h>
+#include <sys/types.h>
+
+#include "riscv_internal.h"
+#include "hardware/jh7110_memorymap.h"
+#include "hardware/jh7110_plic.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define RV_IRQ_MASK 59
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * riscv_dispatch_irq
+ ****************************************************************************/
+
+void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
+{
+  int irq = (vector >> RV_IRQ_MASK) | (vector & 0xf);
+
+  /* Firstly, check if the irq is machine external interrupt */
+
+  if (RISCV_IRQ_EXT == irq)
+    {
+      uintptr_t val = getreg32(JH7110_PLIC_CLAIM);
+
+      /* Add the value to nuttx irq which is offset to the mext */
+
+      irq += val;
+    }
+
+  /* EXT means no interrupt */
+
+  if (RISCV_IRQ_EXT != irq)
+    {
+      /* Deliver the IRQ */
+
+      regs = riscv_doirq(irq, regs);
+    }
+
+  if (RISCV_IRQ_EXT <= irq)
+    {
+      /* Then write PLIC_CLAIM to clear pending in PLIC */
+
+      putreg32(irq - RISCV_IRQ_EXT, JH7110_PLIC_CLAIM);
+    }
+
+  return regs;
+}

--- a/arch/risc-v/src/jh7110/jh7110_memorymap.h
+++ b/arch/risc-v/src/jh7110/jh7110_memorymap.h
@@ -1,0 +1,45 @@
+/****************************************************************************
+ * arch/risc-v/src/jh7110/jh7110_memorymap.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_RISCV_SRC_JH7110_JH7110_MEMORYMAP_H
+#define __ARCH_RISCV_SRC_JH7110_JH7110_MEMORYMAP_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include "riscv_common_memorymap.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Idle thread stack starts from _ebss */
+
+#ifndef __ASSEMBLY__
+#define JH7110_IDLESTACK_BASE  (uintptr_t)_ebss
+#else
+#define JH7110_IDLESTACK_BASE  _ebss
+#endif
+
+#define JH7110_IDLESTACK_SIZE (CONFIG_IDLETHREAD_STACKSIZE & ~3)
+#define JH7110_IDLESTACK_TOP  (JH7110_IDLESTACK_BASE + JH7110_IDLESTACK_SIZE)
+
+#endif /* __ARCH_RISCV_SRC_JH7110_JH7110_MEMORYMAP_H */

--- a/arch/risc-v/src/jh7110/jh7110_mm_init.c
+++ b/arch/risc-v/src/jh7110/jh7110_mm_init.c
@@ -1,0 +1,284 @@
+/****************************************************************************
+ * arch/risc-v/src/jh7110/jh7110_mm_init.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/arch.h>
+
+#include <stdint.h>
+#include <assert.h>
+#include <debug.h>
+
+#include <arch/board/board_memorymap.h>
+
+#include "jh7110_memorymap.h"
+
+#include "riscv_internal.h"
+#include "riscv_mmu.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Ramdisk Load Address from U-Boot */
+
+#define RAMDISK_ADDR_R  (0x46100000)
+
+/* Map the whole I/O memory with vaddr = paddr mappings */
+
+#define MMU_IO_BASE     (0x00000000)
+#define MMU_IO_SIZE     (0x40000000)
+
+/* Physical and virtual addresses to page tables (vaddr = paddr mapping) */
+
+#define PGT_L1_PBASE    (uintptr_t)&m_l1_pgtable
+#define PGT_L2_PBASE    (uintptr_t)&m_l2_pgtable
+#define PGT_L3_PBASE    (uintptr_t)&m_l3_pgtable
+#define PGT_L1_VBASE    PGT_L1_PBASE
+#define PGT_L2_VBASE    PGT_L2_PBASE
+#define PGT_L3_VBASE    PGT_L3_PBASE
+
+#define PGT_L1_SIZE     (512)  /* Enough to map 512 GiB */
+#define PGT_L2_SIZE     (512)  /* Enough to map 1 GiB */
+#define PGT_L3_SIZE     (1024) /* Enough to map 4 MiB (2MiB x 2) */
+
+#define SLAB_COUNT      (sizeof(m_l3_pgtable) / RV_MMU_PAGE_SIZE)
+
+#define KMM_PAGE_SIZE   RV_MMU_L3_PAGE_SIZE
+#define KMM_PBASE       PGT_L3_PBASE   
+#define KMM_PBASE_IDX   3   
+#define KMM_SPBASE      PGT_L2_PBASE
+#define KMM_SPBASE_IDX  2
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct pgalloc_slab_s
+{
+  sq_entry_t  *next;
+  void        *memory;
+};
+typedef struct pgalloc_slab_s pgalloc_slab_t;
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/* Kernel mappings simply here, mapping is vaddr=paddr */
+
+static size_t         m_l1_pgtable[PGT_L1_SIZE] locate_data(".pgtables");
+static size_t         m_l2_pgtable[PGT_L2_SIZE] locate_data(".pgtables");
+static size_t         m_l3_pgtable[PGT_L3_SIZE] locate_data(".pgtables");
+
+/* Kernel mappings (L1 base) */
+
+uintptr_t               g_kernel_mappings  = PGT_L1_VBASE;
+uintptr_t               g_kernel_pgt_pbase = PGT_L1_PBASE;
+
+/* L3 page table allocator */
+
+static sq_queue_t       g_free_slabs;
+static pgalloc_slab_t   g_slabs[SLAB_COUNT];
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: slab_init
+ *
+ * Description:
+ *   Initialize slab allocator for L2 or L3 page table entries
+ *
+ * L2 Page table is used for SV32. L3 used for SV39
+ *
+ * Input Parameters:
+ *   start - Beginning of the L2 or L3 page table pool
+ *
+ ****************************************************************************/
+
+static void slab_init(uintptr_t start)
+{
+  int i;
+
+  sq_init(&g_free_slabs);
+
+  for (i = 0; i < SLAB_COUNT; i++)
+    {
+      g_slabs[i].memory = (void *)start;
+      sq_addlast((sq_entry_t *)&g_slabs[i], (sq_queue_t *)&g_free_slabs);
+      start += RV_MMU_PAGE_SIZE;
+    }
+}
+
+/****************************************************************************
+ * Name: slab_alloc
+ *
+ * Description:
+ *   Allocate single slab for L2/L3 page table entry
+ *
+ * L2 Page table is used for SV32. L3 used for SV39
+ *
+ ****************************************************************************/
+
+static uintptr_t slab_alloc(void)
+{
+  pgalloc_slab_t *slab = (pgalloc_slab_t *)sq_remfirst(&g_free_slabs);
+  return slab ? (uintptr_t)slab->memory : 0;
+}
+
+/****************************************************************************
+ * Name: map_region
+ *
+ * Description:
+ *   Map a region of physical memory to the L3 page table
+ *
+ * Input Parameters:
+ *   paddr - Beginning of the physical address mapping
+ *   vaddr - Beginning of the virtual address mapping
+ *   size - Size of the region in bytes
+ *   mmuflags - The MMU flags to use in the mapping
+ *
+ ****************************************************************************/
+
+static void map_region(uintptr_t paddr, uintptr_t vaddr, size_t size,
+                       uint32_t mmuflags)
+{
+  uintptr_t endaddr;
+  uintptr_t pbase;
+  int npages;
+  int i;
+  int j;
+
+  /* How many pages */
+
+  npages = (size + RV_MMU_PAGE_MASK) >> RV_MMU_PAGE_SHIFT;
+  endaddr = vaddr + size;
+
+  for (i = 0; i < npages; i += RV_MMU_PAGE_ENTRIES)
+    {
+      /* See if a mapping exists */
+
+      pbase = mmu_pte_to_paddr(mmu_ln_getentry(KMM_SPBASE_IDX,
+                                               KMM_SPBASE, vaddr));
+      if (!pbase)
+        {
+          /* No, allocate 1 page, this must not fail */
+
+          pbase = slab_alloc();
+          DEBUGASSERT(pbase);
+
+          /* Map it to the new table */
+
+          mmu_ln_setentry(KMM_SPBASE_IDX, KMM_SPBASE, pbase, vaddr,
+                          MMU_UPGT_FLAGS);
+        }
+
+      /* Then add the mappings */
+
+      for (j = 0; j < RV_MMU_PAGE_ENTRIES && vaddr < endaddr; j++)
+        {
+          mmu_ln_setentry(KMM_PBASE_IDX, pbase, paddr, vaddr, mmuflags);
+          paddr += KMM_PAGE_SIZE;
+          vaddr += KMM_PAGE_SIZE;
+        }
+    }
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: jh7110_kernel_mappings
+ *
+ * Description:
+ *  Setup kernel mappings when using CONFIG_BUILD_KERNEL. Sets up the kernel
+ *  MMU mappings.
+ *
+ ****************************************************************************/
+
+void jh7110_kernel_mappings(void)
+{
+  /* Initialize slab allocator for the L2/L3 page tables */
+
+  slab_init(KMM_PBASE);
+
+  /* Begin mapping memory to MMU; note that at this point the MMU is not yet
+   * active, so the page table virtual addresses are actually physical
+   * addresses and so forth. M-mode does not perform translations anyhow, so
+   * this mapping is quite simple to do
+   */
+
+  /* Map I/O region, use enough large page tables for the IO region. */
+
+  binfo("map I/O regions\n");
+  mmu_ln_map_region(1, PGT_L1_VBASE, MMU_IO_BASE, MMU_IO_BASE,
+                    MMU_IO_SIZE, MMU_IO_FLAGS);
+
+  /* Map the kernel text and data for L2/L3 */
+
+  binfo("map kernel text\n");
+  map_region(KFLASH_START, KFLASH_START, KFLASH_SIZE, MMU_KTEXT_FLAGS);
+
+  binfo("map kernel data\n");
+  map_region(KSRAM_START, KSRAM_START, KSRAM_SIZE, MMU_KDATA_FLAGS);
+
+  /* Connect the L1 and L2 page tables for the kernel text and data */
+
+  binfo("connect the L1 and L2 page tables\n");
+  mmu_ln_setentry(1, PGT_L1_VBASE, PGT_L2_PBASE, KFLASH_START, PTE_G);
+
+  /* Map the page pool */
+
+  binfo("map the page pool\n");
+  mmu_ln_map_region(2, PGT_L2_VBASE, PGPOOL_START, PGPOOL_START, PGPOOL_SIZE,
+                    MMU_KDATA_FLAGS);
+}
+
+/****************************************************************************
+ * Name: jh7110_mm_init
+ *
+ * Description:
+ *  Setup kernel mappings when using CONFIG_BUILD_KERNEL. Sets up kernel MMU
+ *  mappings. Function also sets the first address environment (satp value).
+ *
+ ****************************************************************************/
+
+void jh7110_mm_init(void)
+{
+  /* Copy Ramdisk from U-Boot Ramdisk Load Address */
+
+  memcpy((void *)__ramdisk_start, (void *)RAMDISK_ADDR_R,
+         (size_t)__ramdisk_size);
+
+  /* Setup the kernel mappings */
+
+  jh7110_kernel_mappings();
+
+  /* Enable MMU (note: system is still in M-mode) */
+
+  binfo("mmu_enable: satp=%" PRIuPTR "\n", g_kernel_pgt_pbase);
+  mmu_enable(g_kernel_pgt_pbase, 0);
+}

--- a/arch/risc-v/src/jh7110/jh7110_mm_init.h
+++ b/arch/risc-v/src/jh7110/jh7110_mm_init.h
@@ -1,0 +1,58 @@
+/****************************************************************************
+ * arch/risc-v/src/jh7110/jh7110_mm_init.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_RISC_V_SRC_JH7110_JH7110_MM_INIT_H
+#define __ARCH_RISC_V_SRC_JH7110_JH7110_MM_INIT_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include "riscv_mmu.h"
+
+/****************************************************************************
+ * Public Functions Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: jh7110_kernel_mappings
+ *
+ * Description:
+ *  Setup kernel mappings when using CONFIG_BUILD_KERNEL. Sets up the kernel
+ *  MMU mappings.
+ *
+ ****************************************************************************/
+
+void jh7110_kernel_mappings(void);
+
+/****************************************************************************
+ * Name: jh7110_mm_init
+ *
+ * Description:
+ *  Setup kernel mappings when using CONFIG_BUILD_KERNEL. Sets up kernel MMU
+ *  mappings. Function also sets the first address environment (satp value).
+ *
+ ****************************************************************************/
+
+void jh7110_mm_init(void);
+
+#endif /* __ARCH_RISC_V_SRC_JH7110_JH7110_MM_INIT_H */

--- a/arch/risc-v/src/jh7110/jh7110_pgalloc.c
+++ b/arch/risc-v/src/jh7110/jh7110_pgalloc.c
@@ -1,0 +1,53 @@
+/****************************************************************************
+ * arch/risc-v/src/jh7110/jh7110_pgalloc.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/arch.h>
+#include <nuttx/config.h>
+#include <nuttx/pgalloc.h>
+#include <assert.h>
+#include <debug.h>
+#include <arch/board/board_memorymap.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_allocate_pgheap
+ *
+ * Description:
+ *   If there is a page allocator in the configuration, then this function
+ *   must be provided by the platform-specific code.  The OS initialization
+ *   logic will call this function early in the initialization sequence to
+ *   get the page heap information needed to configure the page allocator.
+ *
+ ****************************************************************************/
+
+void up_allocate_pgheap(void **heap_start, size_t *heap_size)
+{
+  DEBUGASSERT(heap_start && heap_size);
+
+  *heap_start = (void *)PGPOOL_START;
+  *heap_size  = (size_t)PGPOOL_SIZE;
+}

--- a/arch/risc-v/src/jh7110/jh7110_start.c
+++ b/arch/risc-v/src/jh7110/jh7110_start.c
@@ -1,0 +1,168 @@
+/****************************************************************************
+ * arch/risc-v/src/jh7110/jh7110_start.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/init.h>
+#include <nuttx/arch.h>
+#include <nuttx/serial/uart_16550.h>
+#include <arch/board/board.h>
+
+#include "riscv_internal.h"
+#include "chip.h"
+#include "jh7110_mm_init.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_FEATURES
+#define showprogress(c) up_putc(c)
+#else
+#define showprogress(c)
+#endif
+
+/****************************************************************************
+ * Extern Function Declarations
+ ****************************************************************************/
+
+extern void __trap_vec(void);
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* NOTE: g_idle_topstack needs to point the top of the idle stack
+ * for CPU0 and this value is used in up_initial_state()
+ */
+
+uintptr_t g_idle_topstack = JH7110_IDLESTACK_TOP;
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: jh7110_clear_bss
+ ****************************************************************************/
+
+void jh7110_clear_bss(void)
+{
+  uint32_t *dest;
+
+  /* Clear .bss.  We'll do this inline (vs. calling memset) just to be
+   * certain that there are no issues with the state of global variables.
+   */
+
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
+    {
+      *dest++ = 0;
+    }
+}
+
+/****************************************************************************
+ * Name: jh7110_start
+ ****************************************************************************/
+
+void jh7110_start_s(int mhartid)
+{
+  /* Configure FPU */
+
+  riscv_fpuconfig();
+
+  if (mhartid > 0)
+    {
+      goto cpux;
+    }
+
+  showprogress('A');
+
+#ifdef USE_EARLYSERIALINIT
+  riscv_earlyserialinit();
+#endif
+
+  showprogress('B');
+
+  /* Do board initialization */
+
+  showprogress('C');
+
+  /* Setup page tables for kernel and enable MMU */
+
+  jh7110_mm_init();
+
+  /* Call nx_start() */
+
+  nx_start();
+
+cpux:
+
+#ifdef CONFIG_SMP
+  riscv_cpu_boot(mhartid);
+#endif
+
+  while (true)
+    {
+      asm("WFI");
+    }
+}
+
+/****************************************************************************
+ * Name: jh7110_start
+ ****************************************************************************/
+
+void jh7110_start(int mhartid)
+{
+  DEBUGASSERT(mhartid == 0); /* Only Hart 0 supported for now */
+
+  if (0 == mhartid)
+    {
+      jh7110_clear_bss();
+
+      /* Initialize the per CPU areas */
+
+      riscv_percpu_add_hart(mhartid);
+    }
+
+  /* Disable MMU */
+
+  WRITE_CSR(satp, 0x0);
+
+  /* Set the trap vector for S-mode */
+
+  WRITE_CSR(stvec, (uintptr_t)__trap_vec);
+
+  /* Start S-mode */
+
+  jh7110_start_s(mhartid);
+}
+
+void riscv_earlyserialinit(void)
+{
+  u16550_earlyserialinit();
+}
+
+void riscv_serialinit(void)
+{
+  u16550_serialinit();
+}

--- a/arch/risc-v/src/jh7110/jh7110_timerisr.c
+++ b/arch/risc-v/src/jh7110/jh7110_timerisr.c
@@ -1,0 +1,106 @@
+/****************************************************************************
+ * arch/risc-v/src/jh7110/jh7110_timerisr.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <assert.h>
+#include <stdint.h>
+#include <time.h>
+#include <debug.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/clock.h>
+#include <nuttx/init.h>
+#include <nuttx/spinlock.h>
+#include <nuttx/timers/arch_alarm.h>
+#include <arch/board/board.h>
+
+#include "riscv_internal.h"
+#include "riscv_mtimer.h"
+#include "riscv_percpu.h"
+#include "hardware/jh7110_memorymap.h"
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static uint32_t g_stimer_pending = false;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: jh7110_ssoft_interrupt
+ *
+ * Description:
+ *   This function is S-mode software interrupt handler to proceed
+ *   the OS timer
+ *
+ ****************************************************************************/
+
+static int jh7110_ssoft_interrupt(int irq, void *context, void *arg)
+{
+  /* Cleaer Supervisor Software Interrupt */
+
+  CLEAR_CSR(sip, SIP_SSIP);
+
+  if (g_stimer_pending)
+    {
+      g_stimer_pending = false;
+
+      /* Proceed the OS timer */
+
+      nxsched_process_timer();
+    }
+#ifdef CONFIG_SMP
+  else
+    {
+      /* We assume IPI has been issued */
+
+      riscv_pause_handler(irq, context, arg);
+    }
+#endif
+
+  return 0;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_timer_initialize
+ *
+ * Description:
+ *   This function is called during start-up to initialize
+ *   the timer interrupt.
+ *
+ ****************************************************************************/
+
+void up_timer_initialize(void)
+{
+  irq_attach(RISCV_IRQ_SSOFT, jh7110_ssoft_interrupt, NULL);
+  up_enable_irq(RISCV_IRQ_SSOFT);
+}


### PR DESCRIPTION
## Summary

This PR adds support for the StarFive JH7110 RISC-V SoC. This will be used by the upcoming port of NuttX for PINE64 Star64 SBC. [The source files are explained in the articles here](https://github.com/lupyuen/nuttx-star64)

### Modified Files in arch/risc-v

`Kconfig`: Added ARCH_CHIP_JH7110 for JH7110 SoC

### New Files in arch/risc-v

`include/jh7110/chip.h`: JH7110 Definitions

`include/jh7110/irq.h`: Support 127 External Interrupts

`src/jh7110/chip.h`: Interrupt Stack Macro

`src/jh7110/jh7110_allocateheap.c`: Kernel Heap

`src/jh7110/jh7110_head.S`: Linux Header and Boot Code

`src/jh7110/jh7110_irq.c`: Configure Interrupts

`src/jh7110/jh7110_irq_dispatch.c`: Dispatch Interrupts

`src/jh7110/jh7110_memorymap.h`: Memory Map

`src/jh7110/jh7110_mm_init.c`, `jh7110_mm_init.h`: Memory Mgmt

`src/jh7110/jh7110_pgalloc.c`: Page Allocator

`src/jh7110/jh7110_start.c`: Startup Code

`src/jh7110/jh7110_timerisr.c`: Timer Interrupt

`src/jh7110/hardware/jh7110_memorymap.h`: PLIC Base Address

`src/jh7110/hardware/jh7110_plic.h`: PLIC Register Addresses

`src/jh7110/Kconfig`: JH7110 Config

`src/jh7110/Make.defs`: Makefile

## Impact

This PR is needed for the upcoming port of NuttX for PINE64 Star64 SBC.

No impact on existing code, since the JH7110 source files are not used by existing code.

## Testing

We tested the JH7110 source files on PINE64 Star64 SBC. NuttX boots correctly to NSH Shell:

- [NuttX Log for Star64 JH7110](https://gist.github.com/lupyuen/427843f1de298e1a916d58c9a37bc7cb)

```text
Starting kernel ...
clk u5_dw_i2c_clk_core already disabled
clk u5_dw_i2c_clk_apb already disabled
BCnx_start: Entry
uart_register: Registering /dev/console
uart_register: Registering /dev/ttyS0
work_start_lowpri: Starting low-priority kernel worker thread(s)
nx_start_application: Starting init task: /system/bin/init
elf_symname: Symbol has no name
elf_symvalue: SHN_UNDEF: Failed to get symbol name: -3
elf_relocateadd: Section 2 reloc 2: Undefined symbol[0] has no name: -3
up_exit: TCB=0x40409890 exiting
nx_start: CPU0: Beginning Idle Loop

NuttShell (NSH) NuttX-12.0.3
nsh> uname -a
posix_spawn: pid=0xc0202978 path=uname file_actions=0xc0202980 attr=0xc0202988 argv=0xc0202a28
exec_spawn: ERROR: Failed to load program 'uname': -2
nxposix_spawn_exec: ERROR: exec failed: 2
NuttX 12.0.3 7a92743-dirty Aug  3 2023 18:06:04 risc-v star64
nsh> free
posix_spawn: pid=0xc0202978 path=free file_actions=0xc0202980 attr=0xc0202988 argv=0xc0202a28
exec_spawn: ERROR: Failed to load program 'free': -2
nxposix_spawn_exec: ERROR: exec failed: 2
                   total       used       free    largest  nused  nfree
        Kmem:    2065400      14600    2050800    2049440     50      3
        Page:   20971520     643072   20328448   20328448
nsh> ls -l
posix_spawn: pid=0xc0202978 path=ls file_actions=0xc0202980 attr=0xc0202988 argv=0xc0202a28
exec_spawn: ERROR: Failed to load program 'ls': -2
nxposix_spawn_exec: ERROR: exec failed: 2
/:
 dr--r--r--       0 dev/
 dr--r--r--       0 proc/
 dr--r--r--       0 system/
nsh>
```

We may ignore the `exec_spawn` messages, they are caused by NSH attempting to load the app binaries from the NuttX Apps Filesystem (initrd), when they are actually built-in NSH Commands.
