### PR TITLE
usb: fixed composite usbdev issue

### DIFF
--- a/drivers/usbdev/adb.c
+++ b/drivers/usbdev/adb.c
@@ -161,6 +161,8 @@ struct usbdev_adb_s
    * EPBULKIN; Read requests will be queued in the EBULKOUT.
    */
 
+  bool registered;                    /* Has register_driver() been called */
+
   struct usbadb_wrreq_s wrreqs[CONFIG_USBADB_NWRREQS];
   struct usbadb_rdreq_s rdreqs[CONFIG_USBADB_NRDREQS];
 
@@ -1599,6 +1601,7 @@ static int usbclass_classobject(int minor,
       goto exit_free_driver;
     }
 
+  alloc->dev.registered = true;
   *classdev = &alloc->drvr;
   return OK;
 
@@ -1625,10 +1628,28 @@ static void usbclass_uninitialize(FAR struct usbdevclass_driver_s *classdev)
     classdev, FAR struct adb_driver_s, drvr);
 
   #warning FIXME Maybe missing logic here
+  if (!alloc->dev.registered)
+    {
+      if (alloc->dev.crefs == 0)
+        {
+#ifdef CONFIG_USBADB_COMPOSITE
+          kmm_free(alloc);
+#endif
+        }
+
+      return;
+    }
 
   unregister_driver(USBADB_CHARDEV_PATH);
 
-  kmm_free(alloc);
+  if (alloc->dev.registered)
+    {
+      alloc->dev.registered = false;
+#ifndef CONFIG_USBADB_COMPOSITE
+      kmm_free(alloc);
+#endif
+      return;
+    }
 }
 
 /****************************************************************************

--- a/drivers/usbdev/cdcacm.c
+++ b/drivers/usbdev/cdcacm.c
@@ -1777,7 +1777,7 @@ static int cdcacm_setup(FAR struct usbdevclass_driver_s *driver,
                        value == CDCACM_DATAALTIFID))
                   {
                     cdcacm_resetconfig(priv);
-                    cdcacm_setconfig(priv, priv->config);
+                    cdcacm_setconfig(priv, CDCACM_CONFIGID);
                     ret = 0;
                   }
               }

--- a/drivers/usbdev/composite.c
+++ b/drivers/usbdev/composite.c
@@ -734,7 +734,12 @@ static int composite_setup(FAR struct usbdevclass_driver_s *driver,
       /* Setup the request */
 
       ctrlreq->len   = MIN(len, ret);
-      ctrlreq->flags = USBDEV_REQFLAGS_NULLPKT;
+
+      /* Only when ret is less than len do zero length packet
+       * need to be sent
+       */
+
+      ctrlreq->flags = ret < len ? USBDEV_REQFLAGS_NULLPKT : 0;
 
       /* And submit the request to the USB controller driver */
 

--- a/drivers/usbdev/composite.c
+++ b/drivers/usbdev/composite.c
@@ -1048,6 +1048,11 @@ void composite_uninitialize(FAR void *handle)
 
   priv = &alloc->dev;
 
+  for (i = 0; i < priv->ndevices; i++)
+    {
+      priv->device[i].compdesc.uninitialize(priv->device[i].dev);
+    }
+
   /* Then unregister and destroy the composite class */
 
   usbdev_unregister(&alloc->drvr.drvr);

--- a/drivers/usbdev/composite.h
+++ b/drivers/usbdev/composite.h
@@ -95,7 +95,7 @@
 #  define COMPOSITE_REMOTEWAKEUP      (0)
 #endif
 
-#define NUM_DEVICES_TO_HANDLE         (4)
+#define NUM_DEVICES_TO_HANDLE         (8)
 
 /* Descriptors **************************************************************/
 

--- a/drivers/usbdev/composite_desc.c
+++ b/drivers/usbdev/composite_desc.c
@@ -56,7 +56,7 @@ static const struct usb_devdesc_s g_devdesc =
     LSBYTE(0x0200),
     MSBYTE(0x0200)
   },
-#ifndef CONFIG_COMPOSITE_IAD
+#ifdef CONFIG_COMPOSITE_IAD
   USB_CLASS_MISC,                               /* classid */
   2,                                            /* subclass */
   1,                                            /* protocol */

--- a/drivers/usbdev/rndis.c
+++ b/drivers/usbdev/rndis.c
@@ -2942,15 +2942,21 @@ static void usbclass_uninitialize(FAR struct usbdevclass_driver_s *classdev)
 {
   FAR struct rndis_driver_s *drvr = (FAR struct rndis_driver_s *)classdev;
   FAR struct rndis_alloc_s *alloc = (FAR struct rndis_alloc_s *)drvr->dev;
-
+  if (!alloc->dev.registered)
+    {
+#ifdef CONFIG_USBADB_COMPOSITE
+      kmm_free(alloc);
+#endif
+      return;
+    }
   if (drvr->dev->registered)
     {
       netdev_unregister(&drvr->dev->netdev);
       drvr->dev->registered = false;
-    }
-  else
-    {
+#ifndef CONFIG_RNDIS_COMPOSITE
       kmm_free(alloc);
+#endif
+      return;
     }
 }
 


### PR DESCRIPTION
## Summary

1. adb: When the adbd task is running, the usb uninstall process will panic in the adbd task, because the memory of the adb driver has been freed.
2. cdcacm: Logic error handled in USB_REQ_SETINTERFACE.
3. composite: fix enumeration error for 192 bytes desc.
4. composite: The maximum number of composite devices supported is changed to 8.
5. composite: In the device descriptor, 0xEF means use of IAD.

## Impact

USB

## Testing

sim:usbdev