### PR TITLE
nuttx/arch:support to obtain host cpuinfo in NSH.

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -118,6 +118,7 @@ config ARCH_SIM
 	select SERIAL_CONSOLE
 	select SERIAL_IFLOWCONTROL
 	select SCHED_HPWORK
+	select ARCH_HAVE_CPUINFO
 	---help---
 		Linux/Cygwin user-mode simulation.
 

--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -63,7 +63,7 @@ AOBJS = $(ASRCS:.S=$(OBJEXT))
 CSRCS  = sim_initialize.c sim_idle.c sim_doirq.c sim_initialstate.c
 CSRCS += sim_createstack.c sim_usestack.c sim_releasestack.c sim_stackframe.c
 CSRCS += sim_exit.c sim_schedulesigaction.c sim_switchcontext.c sim_heap.c
-CSRCS += sim_uart.c sim_copyfullstate.c sim_sigdeliver.c sim_tcbinfo.c
+CSRCS += sim_uart.c sim_copyfullstate.c sim_sigdeliver.c sim_tcbinfo.c sim_cpuinfo.c
 CSRCS += sim_registerdump.c sim_saveusercontext.c sim_textheap.c
 
 ifeq ($(CONFIG_SCHED_BACKTRACE),y)
@@ -97,7 +97,15 @@ ifeq ($(CONFIG_FS_LARGEFILE),y)
   HOSTCFLAGS += -D_FILE_OFFSET_BITS=64
 endif
 
-HOSTSRCS = sim_hostirq.c sim_hostmemory.c sim_hostmisc.c sim_hosttime.c sim_hostuart.c
+HOSTSRCS  = sim_hostirq.c sim_hostmemory.c sim_hostmisc.c sim_hosttime.c sim_hostuart.c
+HOSTSRCS += sim_hostfs.c
+
+hostfs.h: $(TOPDIR)/include/nuttx/fs/hostfs.h
+	@echo "CP:  $<"
+	$(Q) cp $< $@
+
+sim_hostfs.c: hostfs.h
+
 STDLIBS += -lpthread
 ifeq ($(CONFIG_HOST_MACOS),y)
 ifeq ($(CONFIG_HAVE_CXXINITIALIZE),y)
@@ -235,16 +243,6 @@ ifeq ($(CONFIG_SIM_CAMERA_V4L2),y)
   HOSTSRCS += sim_host_v4l2.c
   CSRCS += sim_camera.c
   STDLIBS += -lv4l2
-endif
-
-ifeq ($(CONFIG_SIM_HOSTFS),y)
-  HOSTSRCS += sim_hostfs.c
-
-hostfs.h: $(TOPDIR)/include/nuttx/fs/hostfs.h
-	@echo "CP:  $<"
-	$(Q) cp $< $@
-
-sim_hostfs.c: hostfs.h
 endif
 
 COBJS = $(CSRCS:.c=$(OBJEXT))

--- a/arch/sim/src/sim/CMakeLists.txt
+++ b/arch/sim/src/sim/CMakeLists.txt
@@ -40,6 +40,7 @@ list(
   SRCS
   sim_initialize.c
   sim_idle.c
+  sim_cpuinfo.c
   sim_doirq.c
   sim_initialstate.c
   sim_createstack.c
@@ -222,14 +223,12 @@ if(CONFIG_SIM_USB_HOST)
   endif()
 endif()
 
-if(CONFIG_SIM_HOSTFS)
-  list(APPEND HOSTSRCS sim_hostfs.c)
-  list(APPEND HOST_DEFINITIONS CONFIG_NAME_MAX=${CONFIG_NAME_MAX})
+list(APPEND HOSTSRCS sim_hostfs.c)
+list(APPEND HOST_DEFINITIONS CONFIG_NAME_MAX=${CONFIG_NAME_MAX})
 
-  configure_file(${NUTTX_DIR}/include/nuttx/fs/hostfs.h
-                 ${CMAKE_CURRENT_BINARY_DIR}/hostfs.h COPYONLY)
-  target_include_directories(nuttx PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-endif()
+configure_file(${NUTTX_DIR}/include/nuttx/fs/hostfs.h
+               ${CMAKE_CURRENT_BINARY_DIR}/hostfs.h COPYONLY)
+target_include_directories(nuttx PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 target_include_directories(nuttx PRIVATE ${CMAKE_BINARY_DIR}/include/nuttx)
 target_include_directories(nuttx PRIVATE ${CMAKE_CURRENT_LIST_DIR})

--- a/arch/sim/src/sim/sim_cpuinfo.c
+++ b/arch/sim/src/sim/sim_cpuinfo.c
@@ -1,0 +1,65 @@
+/****************************************************************************
+ * arch/sim/src/sim/sim_cpuinfo.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <nuttx/fs/hostfs.h>
+
+#if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_CPUINFO)
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_show_cpuinfo
+ ****************************************************************************/
+
+ssize_t up_show_cpuinfo(char *buf, size_t buf_size, off_t file_off)
+{
+  int fd;
+  off_t ret;
+
+  fd = host_open("/proc/cpuinfo", O_RDONLY, 0644);
+  if (fd < 0)
+    {
+      return fd;
+    }
+
+  ret = host_lseek(fd, file_off, SEEK_SET);
+  if (ret < 0)
+    {
+      host_close(fd);
+      return ret;
+    }
+
+  file_off = host_read(fd, buf, buf_size);
+
+  host_close(fd);
+
+  return file_off;
+}
+#endif /* CONFIG_FS_PROCFS && !CONFIG_FS_PROCFS_EXCLUDE_CPUINFO */


### PR DESCRIPTION
## Summary

implement up_show_cpuinfo on sim

## Impact

## Testing

