### PR TITLE
nuttx/tls:Setting the candidtate index to null prevents dangling pointers.

### DIFF
--- a/include/nuttx/tls.h
+++ b/include/nuttx/tls.h
@@ -73,38 +73,14 @@ extern "C"
 #define EXTERN extern
 #endif
 
-/* type tls_ndxset_t & tls_dtor_t *******************************************/
+/* type tls_dtor_t **********************************************************/
 
 /* Smallest addressable type that can hold the entire configured number of
  * TLS data indexes.
  */
 
 #if CONFIG_TLS_NELEM > 0
-#  if CONFIG_TLS_NELEM > 64
-#    error Too many TLS elements
-#  elif CONFIG_TLS_NELEM > 32
-     typedef uint64_t tls_ndxset_t;
-#  elif CONFIG_TLS_NELEM > 16
-     typedef uint32_t tls_ndxset_t;
-#  elif CONFIG_TLS_NELEM > 8
-     typedef uint16_t tls_ndxset_t;
-#  else
-     typedef uint8_t tls_ndxset_t;
-#  endif
-#endif
-
-#if CONFIG_TLS_TASK_NELEM > 0
-#  if CONFIG_TLS_TASK_NELEM > 64
-#    error Too many TLS elements
-#  elif CONFIG_TLS_TASK_NELEM > 32
-     typedef uint64_t tls_task_ndxset_t;
-#  elif CONFIG_TLS_TASK_NELEM > 16
-     typedef uint32_t tls_task_ndxset_t;
-#  elif CONFIG_TLS_TASK_NELEM > 8
-     typedef uint16_t tls_task_ndxset_t;
-#  else
-     typedef uint8_t tls_task_ndxset_t;
-#  endif
+typedef CODE void (*tls_dtor_t)(FAR void *);
 #endif
 
 typedef CODE void (*tls_dtor_t)(FAR void *);
@@ -149,7 +125,6 @@ struct task_info_s
   uintptr_t       ta_telem[CONFIG_TLS_TASK_NELEM]; /* Task local storage elements */
 #endif
 #if CONFIG_TLS_NELEM > 0
-  tls_ndxset_t    ta_tlsset;                    /* Set of TLS indexes allocated */
   tls_dtor_t      ta_tlsdtor[CONFIG_TLS_NELEM]; /* List of TLS destructors      */
 #endif
 #ifndef CONFIG_BUILD_KERNEL

--- a/libs/libc/pthread/pthread_keycreate.c
+++ b/libs/libc/pthread/pthread_keycreate.c
@@ -34,6 +34,19 @@
 #if CONFIG_TLS_NELEM > 0
 
 /****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: pthread_destructor
+ ****************************************************************************/
+
+static void pthread_destructor(FAR void *arg)
+{
+  UNUSED(arg);
+}
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -95,13 +108,19 @@ int pthread_key_create(FAR pthread_key_t *key,
     {
       /* Is this candidate index available? */
 
-      tls_ndxset_t mask = (tls_ndxset_t)1 << candidate;
-      if ((info->ta_tlsset & mask) == 0)
+      if (info->ta_tlsdtor[candidate] == NULL)
         {
           /* Yes.. allocate the index and break out of the loop */
 
-          info->ta_tlsset |= mask;
-          info->ta_tlsdtor[candidate] = destructor;
+          if (destructor)
+            {
+              info->ta_tlsdtor[candidate] = destructor;
+            }
+          else
+            {
+              info->ta_tlsdtor[candidate] = pthread_destructor;
+            }
+
           *key = candidate;
           ret = OK;
           break;

--- a/libs/libc/pthread/pthread_keydelete.c
+++ b/libs/libc/pthread/pthread_keydelete.c
@@ -58,7 +58,6 @@
 int pthread_key_delete(pthread_key_t key)
 {
   FAR struct task_info_s *info = task_get_info();
-  tls_ndxset_t mask;
   int ret = EINVAL;
 
   DEBUGASSERT(info != NULL);
@@ -69,12 +68,10 @@ int pthread_key_delete(pthread_key_t key)
        * modification of the group TLS index set.
        */
 
-      mask = (tls_ndxset_t)1 << key;
       ret = nxmutex_lock(&info->ta_lock);
       if (ret == OK)
         {
-          DEBUGASSERT((info->ta_tlsset & mask) != 0);
-          info->ta_tlsset &= ~mask;
+          info->ta_tlsdtor[key] = NULL;
           nxmutex_unlock(&info->ta_lock);
         }
       else

--- a/libs/libc/tls/Kconfig
+++ b/libs/libc/tls/Kconfig
@@ -45,7 +45,7 @@ config TLS_LOG2_MAXSTACK
 config TLS_NELEM
 	int "Number of TLS elements"
 	default 0
-	range 0 64
+	range 0 255
 	---help---
 		The number of unique TLS elements.  These can be accessed with
 		the user library functions tls_get_value() and tls_set_value()
@@ -57,7 +57,7 @@ config TLS_NELEM
 config TLS_TASK_NELEM
 	int "Number of Task Local Storage elements"
 	default 0
-	range 0 64
+	range 0 255
 	---help---
 		The number of unique Task Local Storage elements similar with
 		Thread Local Storage.

--- a/libs/libc/tls/tls_destruct.c
+++ b/libs/libc/tls/tls_destruct.c
@@ -60,7 +60,7 @@ void tls_destruct(void)
   DEBUGASSERT(info != NULL);
   tlsset = info->ta_tlsset;
 
-  for (candidate = 0; candidate < CONFIG_TLS_NELEM; candidate++)
+  for (candidate = CONFIG_TLS_NELEM - 1; candidate >= 0; candidate--)
     {
       /* Is this candidate index available? */
 
@@ -68,6 +68,7 @@ void tls_destruct(void)
       if (tlsset & mask)
         {
           tls_elem_ptr = (FAR void *)tls->tl_elem[candidate];
+          tls->tl_elem[candidate] = 0;
           destructor = info->ta_tlsdtor[candidate];
           if (tls_elem_ptr && destructor)
             {

--- a/libs/libc/tls/tls_destruct.c
+++ b/libs/libc/tls/tls_destruct.c
@@ -68,13 +68,14 @@ void tls_destruct(void)
       if (tlsset & mask)
         {
           tls_elem_ptr = (FAR void *)tls->tl_elem[candidate];
-          tls->tl_elem[candidate] = 0;
           destructor = info->ta_tlsdtor[candidate];
           if (tls_elem_ptr && destructor)
             {
               destructor(tls_elem_ptr);
             }
         }
+
+      tls->tl_elem[candidate] = 0;
     }
 }
 

--- a/libs/libc/tls/tls_destruct.c
+++ b/libs/libc/tls/tls_destruct.c
@@ -54,25 +54,19 @@ void tls_destruct(void)
   FAR struct tls_info_s *tls = tls_get_info();
   FAR void *tls_elem_ptr = NULL;
   tls_dtor_t destructor;
-  tls_ndxset_t tlsset;
   int candidate;
 
   DEBUGASSERT(info != NULL);
-  tlsset = info->ta_tlsset;
 
   for (candidate = CONFIG_TLS_NELEM - 1; candidate >= 0; candidate--)
     {
       /* Is this candidate index available? */
 
-      tls_ndxset_t mask = (tls_ndxset_t)1 << candidate;
-      if (tlsset & mask)
+      tls_elem_ptr = (FAR void *)tls->tl_elem[candidate];
+      destructor = info->ta_tlsdtor[candidate];
+      if (tls_elem_ptr && destructor)
         {
-          tls_elem_ptr = (FAR void *)tls->tl_elem[candidate];
-          destructor = info->ta_tlsdtor[candidate];
-          if (tls_elem_ptr && destructor)
-            {
-              destructor(tls_elem_ptr);
-            }
+          destructor(tls_elem_ptr);
         }
 
       tls->tl_elem[candidate] = 0;

--- a/sched/task/task_tls_alloc.c
+++ b/sched/task/task_tls_alloc.c
@@ -114,12 +114,13 @@ void task_tls_destruct(void)
       if ((g_tlsset & mask) != 0)
         {
           elem = info->ta_telem[candidate];
-          info->ta_telem[candidate] = 0;
           dtor = g_tlsdtor[candidate];
           if (dtor != NULL && elem != 0)
             {
               dtor((void *)elem);
             }
+
+         info->ta_telem[candidate] = 0;
         }
     }
 }

--- a/sched/task/task_tls_alloc.c
+++ b/sched/task/task_tls_alloc.c
@@ -108,12 +108,13 @@ void task_tls_destruct(void)
   tls_dtor_t dtor;
   FAR struct task_info_s *info = task_get_info();
 
-  for (candidate = 0; candidate < CONFIG_TLS_TASK_NELEM; candidate++)
+  for (candidate = CONFIG_TLS_TASK_NELEM - 1; candidate >= 0; candidate--)
     {
       tls_task_ndxset_t mask = (tls_task_ndxset_t)1 << candidate;
       if ((g_tlsset & mask) != 0)
         {
           elem = info->ta_telem[candidate];
+          info->ta_telem[candidate] = 0;
           dtor = g_tlsdtor[candidate];
           if (dtor != NULL && elem != 0)
             {


### PR DESCRIPTION
## Summary

- nuttx/tls: Remove the max key limiatation in task_tls_alloc and pthread_key_create
- nuttx/tls:Setting the candidtate index to null prevents dangling pointers.
- nuttx/tls:Setting the candidtate index to null prevents dangling pointers.

## Impact

tls

## Testing

internal