### PR TITLE
ioexpander: define IOEXPANDER_OPTION_NONGENERIC option

### DIFF
--- a/include/nuttx/ioexpander/ioexpander.h
+++ b/include/nuttx/ioexpander/ioexpander.h
@@ -55,21 +55,27 @@
 
 /* Pin options */
 
-#define IOEXPANDER_OPTION_INVERT   1  /* Set the "active" level for a pin */
-#  define IOEXPANDER_VAL_NORMAL    0  /* Normal, no inversion */
-#  define IOEXPANDER_VAL_INVERT    1  /* Inverted */
+#define IOEXPANDER_OPTION_INVERT      1  /* Set the "active" level for a pin */
+#  define IOEXPANDER_VAL_NORMAL       0  /* Normal, no inversion */
+#  define IOEXPANDER_VAL_INVERT       1  /* Inverted */
 
-#define IOEXPANDER_OPTION_INTCFG   2  /* Configure interrupt for a pin */
-#  define IOEXPANDER_VAL_DISABLE   0  /* 0000 Disable pin  interrupts */
-#  define IOEXPANDER_VAL_LEVEL     1  /* xx01 Interrupt on level (vs. edge) */
-#    define IOEXPANDER_VAL_HIGH    5  /* 0101 Interrupt on high level */
-#    define IOEXPANDER_VAL_LOW     9  /* 1001 Interrupt on low level */
-#  define IOEXPANDER_VAL_EDGE      2  /* xx10 Interrupt on edge (vs. level) */
-#    define IOEXPANDER_VAL_RISING  6  /* 0110 Interrupt on rising edge */
-#    define IOEXPANDER_VAL_FALLING 10 /* 1010 Interrupt on falling edge */
-#    define IOEXPANDER_VAL_BOTH    14 /* 1110 Interrupt on both edges */
+#define IOEXPANDER_OPTION_INTCFG      2  /* Configure interrupt for a pin */
+#  define IOEXPANDER_VAL_DISABLE      0  /* 0000 Disable pin  interrupts */
+#  define IOEXPANDER_VAL_LEVEL        1  /* xx01 Interrupt on level (vs. edge) */
+#    define IOEXPANDER_VAL_HIGH       5  /* 0101 Interrupt on high level */
+#    define IOEXPANDER_VAL_LOW        9  /* 1001 Interrupt on low level */
+#  define IOEXPANDER_VAL_EDGE         2  /* xx10 Interrupt on edge (vs. level) */
+#    define IOEXPANDER_VAL_RISING     6  /* 0110 Interrupt on rising edge */
+#    define IOEXPANDER_VAL_FALLING    10 /* 1010 Interrupt on falling edge */
+#    define IOEXPANDER_VAL_BOTH       14 /* 1110 Interrupt on both edges */
 
-#define IOEXPANDER_OPTION_LEDCFG   3  /* Assign LED number to a pin */
+#define IOEXPANDER_OPTION_LEDCFG      3  /* Assign LED number to a pin */
+#define IOEXPANDER_OPTION_NONGENERIC  4  /* Non generic option interface. Some
+                                          * IO expanders have more advance
+                                          * options for pins and communication.
+                                          * This is used to pass driver dependend
+                                          * structure to expander driver.
+                                          */
 
 /* Access macros ************************************************************/
 


### PR DESCRIPTION
## Summary
This introduces non-generic option interface for IO expanders. Some IO expanders have more advance options for pins and communication. This is used to pass driver dependend structure to expander driver.

## Impact
None for current code
