### PR TITLE
driver/mtdconfig_fs : return -ENOENT when delete non-existed key

### DIFF
--- a/drivers/mtd/mtd_config_fs.c
+++ b/drivers/mtd/mtd_config_fs.c
@@ -1594,7 +1594,7 @@ static ssize_t nvs_write(FAR struct nvs_fs *fs,
 
       if (pdata->len == 0)
         {
-          return 0;
+          return -ENOENT;
         }
     }
 


### PR DESCRIPTION
## Summary

## Impact

## Testing

