### PR TITLE
cmake: enable more stm32 builds in ci

### DIFF
--- a/tools/ci/testlist/arm-08.dat
+++ b/tools/ci/testlist/arm-08.dat
@@ -54,7 +54,7 @@ CMake,nucleo-g431rb:nsh
 CMake,nucleo-g431rb:pwm
 CMake,nucleo-g431rb:qenco
 
-# CMake,nucleo-g474re:nsh
+CMake,nucleo-g474re:nsh
 # CMake,nucleo-g474re:usbserial
 
 # CMake,nucleo-l152re:lcd

--- a/tools/ci/testlist/arm-10.dat
+++ b/tools/ci/testlist/arm-10.dat
@@ -13,3 +13,59 @@
 /arm/stm32/stm32f411e-disco,CONFIG_ARM_TOOLCHAIN_CLANG
 
 /arm/stm32/stm32f429i-disco,CONFIG_ARM_TOOLCHAIN_CLANG
+
+# Boards build by CMake
+
+CMake,stm32_tiny:nsh
+CMake,stm32_tiny:usbnsh
+
+CMake,stm32butterfly2:nsh
+CMake,stm32butterfly2:nshnet
+CMake,stm32butterfly2:nshusbdev
+CMake,stm32butterfly2:nshusbhost
+
+# CMake,stm32f103-minimum:adb
+CMake,stm32f103-minimum:apds9960
+CMake,stm32f103-minimum:audio_tone
+CMake,stm32f103-minimum:buttons
+CMake,stm32f103-minimum:hello
+# CMake,stm32f103-minimum:jlx12864g
+CMake,stm32f103-minimum:lcd1602
+CMake,stm32f103-minimum:mcp2515
+CMake,stm32f103-minimum:nrf24
+CMake,stm32f103-minimum:nsh
+CMake,stm32f103-minimum:pwm
+CMake,stm32f103-minimum:rfid-rc522
+CMake,stm32f103-minimum:rgbled
+# CMake,stm32f103-minimum:sensors
+# CMake,stm32f103-minimum:ssd1306
+CMake,stm32f103-minimum:usbnsh
+CMake,stm32f103-minimum:userled
+CMake,stm32f103-minimum:veml6070
+
+CMake,stm32f334-disco:buckboost
+CMake,stm32f334-disco:nsh
+CMake,stm32f334-disco:powerled
+
+CMake,stm32f3discovery:nsh
+CMake,stm32f3discovery:usbnsh
+
+CMake,stm32f411-minimum:composite
+CMake,stm32f411-minimum:nsh
+CMake,stm32f411-minimum:spifsnsh
+CMake,stm32f411-minimum:usbmsc
+
+CMake,stm32f411e-disco:nsh
+
+CMake,stm32f429i-disco:adc
+CMake,stm32f429i-disco:extflash
+# CMake,stm32f429i-disco:fb
+CMake,stm32f429i-disco:highpri
+# CMake,stm32f429i-disco:lcd
+# CMake,stm32f429i-disco:lvgl
+CMake,stm32f429i-disco:nsh
+# CMake,stm32f429i-disco:nxhello
+# CMake,stm32f429i-disco:nxwm
+# CMake,stm32f429i-disco:ofloader
+CMake,stm32f429i-disco:usbmsc
+CMake,stm32f429i-disco:usbnsh

--- a/tools/ci/testlist/arm-12.dat
+++ b/tools/ci/testlist/arm-12.dat
@@ -4,9 +4,35 @@
 
 # Boards build by CMake
 
+CMake,b-l072z-lrwan1:adc
+CMake,b-l072z-lrwan1:nsh
+#CMake,b-l072z-lrwan1:nxlines_oled
+CMake,b-l072z-lrwan1:sx127x
+
+CMake,nucleo-f072rb:nsh
+
+CMake,nucleo-f091rc:nsh
+CMake,nucleo-f091rc:sx127x
+
+CMake,nucleo-g070rb:nsh
+
+CMake,nucleo-g071rb:nsh
+
+CMake,nucleo-l073rz:nsh
+CMake,nucleo-l073rz:sx127x
+
+CMake,stm32f051-discovery:nsh
+
+CMake,stm32f072-discovery:nsh
+
+CMake,stm32g071b-disco:nsh
+#CMake,stm32g071b-disco:oled
+
+CMake,stm32l0538-disco:nsh
+
 CMake,nucleo-144:f722-can
 CMake,nucleo-144:f722-cansock
-# CMake,nucleo-144:f722-composite
+CMake,nucleo-144:f722-composite
 CMake,nucleo-144:f746-evalos
 CMake,nucleo-144:f746-nsh
 CMake,nucleo-144:f746-pysim
@@ -34,7 +60,7 @@ CMake,stm32f769i-disco:nsh
 CMake,stm32f777zit6-meadow:nsh
 # CMake,stm32f777zit6-meadow:sdram
 
-# CMake,nucleo-h743zi:composite
+CMake,nucleo-h743zi:composite
 # CMake,nucleo-h743zi:elf
 CMake,nucleo-h743zi:mcuboot-app
 CMake,nucleo-h743zi:mcuboot-loader
@@ -43,7 +69,7 @@ CMake,nucleo-h743zi:nsh
 # CMake,nucleo-h743zi:nxlines_oled
 CMake,nucleo-h743zi:otg_fs_host
 CMake,nucleo-h743zi:pwm
-# CMake,nucleo-h743zi:rndis
+CMake,nucleo-h743zi:rndis
 
 # CMake,nucleo-h743zi2:jumbo
 CMake,nucleo-h743zi2:netnsh


### PR DESCRIPTION
## Summary
cmake: enable more stm32 builds in ci

## Impact

## Testing
ci
