### PR TITLE
boards: cxd56xx: Fix duplicate make target

### DIFF
--- a/boards/arm/cxd56xx/common/CMakeLists.txt
+++ b/boards/arm/cxd56xx/common/CMakeLists.txt
@@ -23,11 +23,7 @@ if(CONFIG_ARCH_BOARD_COMMON)
 
   list(APPEND SRCS src/cxd56_boot.c)
 
-  if(CONFIG_AUDIO_CXD56)
-    list(APPEND SRCS src/cxd56_audio.c)
-  endif()
-
-  if(CONFIG_CXD56_AUDIO)
+  if(CONFIG_AUDIO_CXD56 OR CONFIG_CXD56_AUDIO)
     list(APPEND SRCS src/cxd56_audio.c)
   endif()
 

--- a/boards/arm/cxd56xx/common/src/Make.defs
+++ b/boards/arm/cxd56xx/common/src/Make.defs
@@ -24,9 +24,7 @@ CSRCS += cxd56_boot.c
 
 ifeq ($(CONFIG_AUDIO_CXD56),y)
 CSRCS += cxd56_audio.c
-endif
-
-ifeq ($(CONFIG_CXD56_AUDIO),y)
+else ifeq ($(CONFIG_CXD56_AUDIO),y)
 CSRCS += cxd56_audio.c
 endif
 


### PR DESCRIPTION
## Summary
Remove a build warning by target 'cxd56_audio.o' given more than once in the same rule.

## Impact
Only for spresense board.

## Testing

