### PR TITLE
net: Add `FIOC_FILEPATH` ioctl support for tcp/udp/local sockets

### DIFF
--- a/include/nuttx/net/ip.h
+++ b/include/nuttx/net/ip.h
@@ -422,6 +422,33 @@ extern "C"
    (ipv6addr)->s6_addr16[5] == 0xffff)
 
 /****************************************************************************
+ * Macro: net_ip_binding_laddr, net_ip_binding_raddr
+ *
+ * Description:
+ *   Get the laddr/raddr pointer form an ip_binding_u.
+ *
+ * Input Parameters:
+ *   u      - The union of address binding.
+ *   domain - The domain of address.
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_NET_IPv4) && defined(CONFIG_NET_IPv6)
+#  define net_ip_binding_laddr(u, domain) \
+    (((domain) == PF_INET) ? (FAR void *)(&(u)->ipv4.laddr) : \
+                             (FAR void *)(&(u)->ipv6.laddr))
+#  define net_ip_binding_raddr(u, domain) \
+    (((domain) == PF_INET) ? (FAR void *)(&(u)->ipv4.raddr) : \
+                             (FAR void *)(&(u)->ipv6.raddr))
+#elif defined(CONFIG_NET_IPv4)
+#  define net_ip_binding_laddr(u, domain) ((FAR void *)(&(u)->ipv4.laddr))
+#  define net_ip_binding_raddr(u, domain) ((FAR void *)(&(u)->ipv4.raddr))
+#else
+#  define net_ip_binding_laddr(u, domain) ((FAR void *)(&(u)->ipv6.laddr))
+#  define net_ip_binding_raddr(u, domain) ((FAR void *)(&(u)->ipv6.raddr))
+#endif
+
+/****************************************************************************
  * Macro: net_ipv4addr_copy, net_ipv4addr_hdrcopy, net_ipv6addr_copy, and
  *        net_ipv6addr_hdrcopy
  *

--- a/net/local/local_sockif.c
+++ b/net/local/local_sockif.c
@@ -882,6 +882,11 @@ static int local_ioctl(FAR struct socket *psock, int cmd, unsigned long arg)
             ret = -ENOTCONN;
           }
         break;
+      case FIOC_FILEPATH:
+        snprintf((FAR char *)(uintptr_t)arg, PATH_MAX, "local:[%s]",
+                 conn->lc_path);
+        ret = OK;
+        break;
       case BIOC_FLUSH:
         ret = -EINVAL;
         break;

--- a/net/procfs/net_tcp.c
+++ b/net/procfs/net_tcp.c
@@ -60,16 +60,13 @@ static ssize_t netprocfs_tcpstats(FAR struct netprocfs_file_s *priv,
   int addrlen = (domain == PF_INET) ?
                 INET_ADDRSTRLEN : INET6_ADDRSTRLEN;
   FAR struct tcp_conn_s *conn = NULL;
-  char remote[INET6_ADDRSTRLEN + 1];
-  char local[INET6_ADDRSTRLEN + 1];
+  char remote[INET6_ADDRSTRLEN];
+  char local[INET6_ADDRSTRLEN];
   int len = 0;
-  void *laddr;
-  void *raddr;
+  FAR void *laddr;
+  FAR void *raddr;
 
   net_lock();
-
-  local[addrlen] = '\0';
-  remote[addrlen] = '\0';
 
   while ((conn = tcp_nextconn(conn)) != NULL)
     {
@@ -90,25 +87,8 @@ static ssize_t netprocfs_tcpstats(FAR struct netprocfs_file_s *priv,
           break;
         }
 
-#ifdef CONFIG_NET_IPv4
-#  ifdef CONFIG_NET_IPv6
-      if (domain == PF_INET)
-#  endif /* CONFIG_NET_IPv6 */
-        {
-          laddr = &conn->u.ipv4.laddr;
-          raddr = &conn->u.ipv4.raddr;
-        }
-#endif /* CONFIG_NET_IPv4 */
-
-#ifdef CONFIG_NET_IPv6
-#  ifdef CONFIG_NET_IPv4
-      else
-#  endif /* CONFIG_NET_IPv4 */
-        {
-          laddr = &conn->u.ipv6.laddr;
-          raddr = &conn->u.ipv6.raddr;
-        }
-#endif /* CONFIG_NET_IPv6 */
+      laddr = net_ip_binding_laddr(&conn->u, domain);
+      raddr = net_ip_binding_raddr(&conn->u, domain);
 
       len += snprintf(buffer + len, buflen - len,
                       "    %2" PRIu8

--- a/net/procfs/net_udp.c
+++ b/net/procfs/net_udp.c
@@ -60,16 +60,13 @@ static ssize_t netprocfs_udpstats(FAR struct netprocfs_file_s *priv,
   int addrlen = (domain == PF_INET) ?
                 INET_ADDRSTRLEN : INET6_ADDRSTRLEN;
   FAR struct udp_conn_s *conn = NULL;
-  char remote[INET6_ADDRSTRLEN + 1];
-  char local[INET6_ADDRSTRLEN + 1];
+  char remote[INET6_ADDRSTRLEN];
+  char local[INET6_ADDRSTRLEN];
   int len = 0;
-  void *laddr;
-  void *raddr;
+  FAR void *laddr;
+  FAR void *raddr;
 
   net_lock();
-
-  local[addrlen] = '\0';
-  remote[addrlen] = '\0';
 
   while ((conn = udp_nextconn(conn)) != NULL)
     {
@@ -90,25 +87,8 @@ static ssize_t netprocfs_udpstats(FAR struct netprocfs_file_s *priv,
           break;
         }
 
-#ifdef CONFIG_NET_IPv4
-#  ifdef CONFIG_NET_IPv6
-      if (domain == PF_INET)
-#  endif /* CONFIG_NET_IPv6 */
-        {
-          laddr = &conn->u.ipv4.laddr;
-          raddr = &conn->u.ipv4.raddr;
-        }
-#endif /* CONFIG_NET_IPv4 */
-
-#ifdef CONFIG_NET_IPv6
-#  ifdef CONFIG_NET_IPv4
-      else
-#  endif /* CONFIG_NET_IPv4 */
-        {
-          laddr = &conn->u.ipv6.laddr;
-          raddr = &conn->u.ipv6.raddr;
-        }
-#endif /* CONFIG_NET_IPv6 */
+      laddr = net_ip_binding_laddr(&conn->u, domain);
+      raddr = net_ip_binding_raddr(&conn->u, domain);
 
       len += snprintf(buffer + len, buflen - len,
                       "    %2" PRIu8

--- a/net/tcp/tcp_ioctl.c
+++ b/net/tcp/tcp_ioctl.c
@@ -25,6 +25,7 @@
 #include <nuttx/config.h>
 
 #include <stdint.h>
+#include <stdio.h>
 #include <stdbool.h>
 #include <debug.h>
 #include <errno.h>
@@ -36,6 +37,71 @@
 #include <nuttx/net/net.h>
 
 #include "tcp/tcp.h"
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: tcp_path
+ *
+ * Description:
+ *   This function generates tcp status as path.
+ *
+ * Parameters:
+ *   conn     The TCP connection of interest
+ *   buf      The buffer to get the path
+ *   len      The length of the buffer
+ *
+ ****************************************************************************/
+
+static void tcp_path(FAR struct tcp_conn_s *conn, FAR char *buf, size_t len)
+{
+#if defined(CONFIG_NET_IPv4) && defined(CONFIG_NET_IPv6)
+  uint8_t domain = conn->domain;
+#elif defined(CONFIG_NET_IPv4)
+  const uint8_t domain = PF_INET;
+#else
+  const uint8_t domain = PF_INET6;
+#endif
+  char remote[INET6_ADDRSTRLEN];
+  char local[INET6_ADDRSTRLEN];
+  FAR void *laddr = net_ip_binding_laddr(&conn->u, domain);
+  FAR void *raddr = net_ip_binding_raddr(&conn->u, domain);
+
+  snprintf(buf, len, "tcp:["
+           "%s:%" PRIu16 "<->%s:%" PRIu16
+#if CONFIG_NET_SEND_BUFSIZE > 0
+           ", tx %" PRIu32 "/%" PRId32
+#endif
+#if CONFIG_NET_RECV_BUFSIZE > 0
+           ", rx %u/%" PRId32
+#  ifdef CONFIG_NET_TCP_OUT_OF_ORDER
+           " + ofo %d"
+#  endif
+#endif
+           ", st %02" PRIx8
+           ", flg %" PRIx8
+           "]",
+           inet_ntop(domain, laddr, local, sizeof(local)),
+           ntohs(conn->lport),
+           inet_ntop(domain, raddr, remote, sizeof(remote)),
+           ntohs(conn->rport),
+#if CONFIG_NET_SEND_BUFSIZE > 0
+           tcp_wrbuffer_inqueue_size(conn),
+           conn->snd_bufs,
+#endif
+#if CONFIG_NET_RECV_BUFSIZE > 0
+           (conn->readahead) ? conn->readahead->io_pktlen : 0,
+           conn->rcv_bufs,
+#  ifdef CONFIG_NET_TCP_OUT_OF_ORDER
+           tcp_ofoseg_bufsize(conn),
+#  endif
+#endif
+           conn->tcpstateflags,
+           conn->sconn.s_flags
+           );
+}
 
 /****************************************************************************
  * Public Functions
@@ -85,6 +151,10 @@ int tcp_ioctl(FAR struct tcp_conn_s *conn, int cmd, unsigned long arg)
 #else
         *(FAR int *)((uintptr_t)arg) = MIN_TCP_MSS;
 #endif
+        break;
+      case FIOC_FILEPATH:
+        tcp_path(conn, (FAR char *)(uintptr_t)arg, PATH_MAX);
+        ret = OK;
         break;
       default:
         ret = -ENOTTY;


### PR DESCRIPTION
## Summary
Patches included:
- net/procfs: Simplify logic for tcp/udp stats
    1. Take out `net_ip_binding_laddr/raddr` macro
    2. `INET6_ADDRSTRLEN` is long enough for all address buffer and no need to
       add 0 to the end of buffer since `inet_ntop` will do so
- net: Add `FIOC_FILEPATH` ioctl support for tcp/udp/local sockets
    - Example of `/proc/PID/group/fd`, which prints the file path:
    ```
    FD  OFLAGS  TYPE POS       PATH
    0   3       1    0         /dev/console
    1   3       1    0         /dev/console
    2   3       1    0         /dev/console
    3   3       9    0         udp:[0.0.0.0:10197<->114.118.7.163:123, tx 0/16384, rx 0/16384, flg 1]
    4   1027    9    0         tcp:[0.0.0.0:23<->0.0.0.0:0, tx 0/16384, rx 0/16384 + ofo 0, st 01, flg 31]
    5   67      9    0         local:[md:ap]
    ```

## Impact
Mainly: procfs `/proc/PID/group/fd` with tcp/udp/local sockets
Slightly: procfs `/proc/net/tcp` and `/proc/net/udp`

## Testing
Manually
