### PR TITLE
Use lib_free for memory deallocation after strdup or asprintf

### DIFF
--- a/arch/arm/include/cxd56xx/scu.h
+++ b/arch/arm/include/cxd56xx/scu.h
@@ -477,7 +477,7 @@ void seq_setaddress(struct seq_s *seq, uint32_t slave_addr);
  */
 
 int scu_spitransfer(int slavesel, uint16_t *inst, uint32_t nr_insts,
-                         uint8_t *buffer, int len);
+                    uint8_t *buffer, int len);
 
 /* I2C data transfer via sequencer
  *
@@ -497,7 +497,7 @@ int scu_spitransfer(int slavesel, uint16_t *inst, uint32_t nr_insts,
  */
 
 int scu_i2ctransfer(int port, int slave, uint16_t *inst, uint32_t nr_insts,
-                         uint8_t *buffer, int len);
+                    uint8_t *buffer, int len);
 
 /* Initialize SCU
  *

--- a/arch/risc-v/src/esp32c3/esp32c3_libc_stubs.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_libc_stubs.c
@@ -31,9 +31,11 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <stdlib.h>
-#include <signal.h>
 
+#include <nuttx/signal.h>
 #include <nuttx/mutex.h>
+#include <nuttx/lib/lib.h>
+
 #include "rom/esp32c3_libc_stubs.h"
 
 /****************************************************************************
@@ -59,12 +61,12 @@ struct _reent;
 
 int _close_r(struct _reent *r, int fd)
 {
-  return close(fd);
+  return nx_close(fd);
 }
 
 int _fstat_r(struct _reent *r, int fd, struct stat *statbuf)
 {
-  return fstat(fd, statbuf);
+  return nx_fstat(fd, statbuf);
 }
 
 int _getpid_r(struct _reent *r)
@@ -74,11 +76,10 @@ int _getpid_r(struct _reent *r)
 
 int _kill_r(struct _reent *r, int pid, int sig)
 {
-  return kill(pid, sig);
+  return nxsig_kill(pid, sig);
 }
 
-int _link_r(struct _reent *r, const char *oldpath,
-                      const char *newpath)
+int _link_r(struct _reent *r, const char *oldpath, const char *newpath)
 {
   /* TODO */
 
@@ -87,22 +88,20 @@ int _link_r(struct _reent *r, const char *oldpath,
 
 int _lseek_r(struct _reent *r, int fd, int offset, int whence)
 {
-  return lseek(fd, offset, whence);
+  return nx_seek(fd, offset, whence);
 }
 
-int _open_r(struct _reent *r, const char *pathname,
-                      int flags, int mode)
+int _open_r(struct _reent *r, const char *pathname, int flags, int mode)
 {
-  return open(pathname, flags, mode);
+  return nx_open(pathname, flags, mode);
 }
 
 int _read_r(struct _reent *r, int fd, void *buf, int count)
 {
-  return read(fd, buf, count);
+  return nx_read(fd, buf, count);
 }
 
-int _rename_r(struct _reent *r, const char *oldpath,
-                        const char *newpath)
+int _rename_r(struct _reent *r, const char *oldpath, const char *newpath)
 {
   return rename(oldpath, newpath);
 }
@@ -112,13 +111,12 @@ void *_sbrk_r(struct _reent *r, ptrdiff_t increment)
   /* TODO: sbrk is only supported on Kernel mode */
 
   errno = -ENOMEM;
-  return (void *) -1;
+  return (void *)-1;
 }
 
-int _stat_r(struct _reent *r, const char *pathname,
-                      struct stat *statbuf)
+int _stat_r(struct _reent *r, const char *pathname, struct stat *statbuf)
 {
-  return stat(pathname, statbuf);
+  return nx_stat(pathname, statbuf, 1);
 }
 
 clock_t _times_r(struct _reent *r, struct tms *buf)
@@ -128,12 +126,12 @@ clock_t _times_r(struct _reent *r, struct tms *buf)
 
 int _unlink_r(struct _reent *r, const char *pathname)
 {
-  return unlink(pathname);
+  return nx_unlink(pathname);
 }
 
 int _write_r(struct _reent *r, int fd, const void *buf, int count)
 {
-  return write(fd, buf, count);
+  return nx_write(fd, buf, count);
 }
 
 int _gettimeofday_r(struct _reent *r, struct timeval *tv, void *tz)
@@ -143,22 +141,22 @@ int _gettimeofday_r(struct _reent *r, struct timeval *tv, void *tz)
 
 void *_malloc_r(struct _reent *r, size_t size)
 {
-  return malloc(size);
+  return lib_malloc(size);
 }
 
 void *_realloc_r(struct _reent *r, void *ptr, size_t size)
 {
-  return realloc(ptr, size);
+  return lib_realloc(ptr, size);
 }
 
 void *_calloc_r(struct _reent *r, size_t nmemb, size_t size)
 {
-  return calloc(nmemb, size);
+  return lib_calloc(nmemb, size);
 }
 
 void _free_r(struct _reent *r, void *ptr)
 {
-  free(ptr);
+  lib_free(ptr);
 }
 
 void _abort(void)
@@ -237,7 +235,7 @@ struct _reent *__getreent(void)
 {
   /* TODO */
 
-  return (struct _reent *) NULL;
+  return (struct _reent *)NULL;
 }
 
 int _system_r(struct _reent *r, const char *command)
@@ -253,42 +251,42 @@ int _system_r(struct _reent *r, const char *command)
 
 static const struct syscall_stub_table g_stub_table =
 {
-    .__getreent = &__getreent,
-    ._malloc_r = &_malloc_r,
-    ._free_r = &_free_r,
-    ._realloc_r = &_realloc_r,
-    ._calloc_r = &_calloc_r,
-    ._abort = NULL,
-    ._system_r = &_system_r,
-    ._rename_r = &_rename_r,
-    ._times_r = &_times_r,
-    ._gettimeofday_r = &_gettimeofday_r,
-    ._raise_r = &_raise_r,
-    ._unlink_r = &_unlink_r,
-    ._link_r = &_link_r,
-    ._stat_r = &_stat_r,
-    ._fstat_r = &_fstat_r,
-    ._sbrk_r = &_sbrk_r,
-    ._getpid_r = &_getpid_r,
-    ._kill_r = &_kill_r,
-    ._exit_r = NULL,
-    ._close_r = &_close_r,
-    ._open_r = &_open_r,
-    ._write_r = &_write_r,
-    ._lseek_r = &_lseek_r,
-    ._read_r = &_read_r,
-    ._lock_init = &_lock_init,
-    ._lock_init_recursive = &_lock_init_recursive,
-    ._lock_close = &_lock_close,
-    ._lock_close_recursive = &_lock_close_recursive,
-    ._lock_acquire = &_lock_acquire,
-    ._lock_acquire_recursive = &_lock_acquire_recursive,
-    ._lock_try_acquire = &_lock_try_acquire,
-    ._lock_try_acquire_recursive = &_lock_try_acquire_recursive,
-    ._lock_release = &_lock_release,
-    ._lock_release_recursive = &_lock_release_recursive,
-    ._printf_float = NULL,
-    ._scanf_float = NULL,
+  .__getreent = &__getreent,
+  ._malloc_r = &_malloc_r,
+  ._free_r = &_free_r,
+  ._realloc_r = &_realloc_r,
+  ._calloc_r = &_calloc_r,
+  ._abort = &_abort,
+  ._system_r = &_system_r,
+  ._rename_r = &_rename_r,
+  ._times_r = &_times_r,
+  ._gettimeofday_r = &_gettimeofday_r,
+  ._raise_r = &_raise_r,
+  ._unlink_r = &_unlink_r,
+  ._link_r = &_link_r,
+  ._stat_r = &_stat_r,
+  ._fstat_r = &_fstat_r,
+  ._sbrk_r = &_sbrk_r,
+  ._getpid_r = &_getpid_r,
+  ._kill_r = &_kill_r,
+  ._exit_r = NULL,
+  ._close_r = &_close_r,
+  ._open_r = &_open_r,
+  ._write_r = &_write_r,
+  ._lseek_r = &_lseek_r,
+  ._read_r = &_read_r,
+  ._lock_init = &_lock_init,
+  ._lock_init_recursive = &_lock_init_recursive,
+  ._lock_close = &_lock_close,
+  ._lock_close_recursive = &_lock_close_recursive,
+  ._lock_acquire = &_lock_acquire,
+  ._lock_acquire_recursive = &_lock_acquire_recursive,
+  ._lock_try_acquire = &_lock_try_acquire,
+  ._lock_try_acquire_recursive = &_lock_try_acquire_recursive,
+  ._lock_release = &_lock_release,
+  ._lock_release_recursive = &_lock_release_recursive,
+  ._printf_float = NULL,
+  ._scanf_float = NULL
 };
 
 /****************************************************************************

--- a/arch/risc-v/src/espressif/esp_libc_stubs.c
+++ b/arch/risc-v/src/espressif/esp_libc_stubs.c
@@ -26,7 +26,6 @@
 
 #include <assert.h>
 #include <fcntl.h>
-#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/stat.h>
@@ -35,7 +34,9 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <nuttx/signal.h>
 #include <nuttx/mutex.h>
+#include <nuttx/lib/lib.h>
 
 #include "esp_rom_caps.h"
 #include "rom/libc_stubs.h"
@@ -69,22 +70,22 @@ static mutex_t g_nxlock_recursive;
 
 int _close_r(struct _reent *r, int fd)
 {
-  return close(fd);
+  return nx_close(fd);
 }
 
 int _fstat_r(struct _reent *r, int fd, struct stat *statbuf)
 {
-  return fstat(fd, statbuf);
+  return nx_fstat(fd, statbuf);
 }
 
 int _getpid_r(struct _reent *r)
 {
-  return getpid();
+  return nxsched_getpid();
 }
 
 int _kill_r(struct _reent *r, int pid, int sig)
 {
-  return kill(pid, sig);
+  return nxsig_kill(pid, sig);
 }
 
 int _link_r(struct _reent *r, const char *oldpath, const char *newpath)
@@ -96,17 +97,17 @@ int _link_r(struct _reent *r, const char *oldpath, const char *newpath)
 
 int lseek_r(struct _reent *r, int fd, int offset, int whence)
 {
-  return lseek(fd, offset, whence);
+  return nx_seek(fd, offset, whence);
 }
 
 int _open_r(struct _reent *r, const char *pathname, int flags, int mode)
 {
-  return open(pathname, flags, mode);
+  return nx_open(pathname, flags, mode);
 }
 
 int read_r(struct _reent *r, int fd, void *buf, int count)
 {
-  return read(fd, buf, count);
+  return nx_read(fd, buf, count);
 }
 
 int _rename_r(struct _reent *r, const char *oldpath, const char *newpath)
@@ -119,12 +120,12 @@ void *_sbrk_r(struct _reent *r, ptrdiff_t increment)
   /* TODO: sbrk is only supported on Kernel mode */
 
   errno = -ENOMEM;
-  return (void *) -1;
+  return (void *)-1;
 }
 
 int _stat_r(struct _reent *r, const char *pathname, struct stat *statbuf)
 {
-  return stat(pathname, statbuf);
+  return nx_stat(pathname, statbuf, 1);
 }
 
 clock_t _times_r(struct _reent *r, struct tms *buf)
@@ -134,12 +135,12 @@ clock_t _times_r(struct _reent *r, struct tms *buf)
 
 int _unlink_r(struct _reent *r, const char *pathname)
 {
-  return unlink(pathname);
+  return nx_unlink(pathname);
 }
 
 int write_r(struct _reent *r, int fd, const void *buf, int count)
 {
-  return write(fd, buf, count);
+  return nx_write(fd, buf, count);
 }
 
 int _gettimeofday_r(struct _reent *r, struct timeval *tv, void *tz)
@@ -149,22 +150,22 @@ int _gettimeofday_r(struct _reent *r, struct timeval *tv, void *tz)
 
 void *_malloc_r(struct _reent *r, size_t size)
 {
-  return malloc(size);
+  return lib_malloc(size);
 }
 
 void *_realloc_r(struct _reent *r, void *ptr, size_t size)
 {
-  return realloc(ptr, size);
+  return lib_realloc(ptr, size);
 }
 
 void *_calloc_r(struct _reent *r, size_t nmemb, size_t size)
 {
-  return calloc(nmemb, size);
+  return lib_calloc(nmemb, size);
 }
 
 void _free_r(struct _reent *r, void *ptr)
 {
-  free(ptr);
+  lib_free(ptr);
 }
 
 void _abort(void)
@@ -295,7 +296,7 @@ struct _reent *__getreent(void)
 {
   /* TODO */
 
-  return (struct _reent *) NULL;
+  return (struct _reent *)NULL;
 }
 
 int _system_r(struct _reent *r, const char *command)
@@ -408,7 +409,7 @@ void esp_setup_syscall_table(void)
   extern void esp_rom_newlib_init_common_mutexes(_LOCK_T, _LOCK_T);
 
   int magic_val = ROM_MUTEX_MAGIC;
-  _LOCK_T magic_mutex = (_LOCK_T) &magic_val;
+  _LOCK_T magic_mutex = (_LOCK_T)&magic_val;
   esp_rom_newlib_init_common_mutexes(magic_mutex, magic_mutex);
 }
 

--- a/arch/xtensa/src/esp32s2/esp32s2_libc_stubs.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_libc_stubs.c
@@ -24,7 +24,6 @@
 
 #include <assert.h>
 #include <fcntl.h>
-#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/time.h>
@@ -33,7 +32,10 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include <nuttx/signal.h>
 #include <nuttx/mutex.h>
+#include <nuttx/lib/lib.h>
+
 #include "rom/esp32s2_libc_stubs.h"
 
 /****************************************************************************
@@ -59,22 +61,22 @@ struct _reent;
 
 int _close_r(struct _reent *r, int fd)
 {
-  return close(fd);
+  return nx_close(fd);
 }
 
 int _fstat_r(struct _reent *r, int fd, struct stat *statbuf)
 {
-  return fstat(fd, statbuf);
+  return nx_fstat(fd, statbuf);
 }
 
 int _getpid_r(struct _reent *r)
 {
-  return getpid();
+  return nxsched_getpid();
 }
 
 int _kill_r(struct _reent *r, int pid, int sig)
 {
-  return kill(pid, sig);
+  return nxsig_kill(pid, sig);
 }
 
 int _link_r(struct _reent *r, const char *oldpath, const char *newpath)
@@ -86,17 +88,17 @@ int _link_r(struct _reent *r, const char *oldpath, const char *newpath)
 
 int lseek_r(struct _reent *r, int fd, int offset, int whence)
 {
-  return lseek(fd, offset, whence);
+  return nx_seek(fd, offset, whence);
 }
 
 int _open_r(struct _reent *r, const char *pathname, int flags, int mode)
 {
-  return open(pathname, flags, mode);
+  return nx_open(pathname, flags, mode);
 }
 
 int read_r(struct _reent *r, int fd, void *buf, int count)
 {
-  return read(fd, buf, count);
+  return nx_read(fd, buf, count);
 }
 
 int _rename_r(struct _reent *r, const char *oldpath, const char *newpath)
@@ -109,12 +111,12 @@ void *_sbrk_r(struct _reent *r, ptrdiff_t increment)
   /* TODO: sbrk is only supported on Kernel mode */
 
   errno = -ENOMEM;
-  return (void *) -1;
+  return (void *)-1;
 }
 
 int _stat_r(struct _reent *r, const char *pathname, struct stat *statbuf)
 {
-  return stat(pathname, statbuf);
+  return nx_stat(pathname, statbuf, 1);
 }
 
 clock_t _times_r(struct _reent *r, struct tms *buf)
@@ -124,12 +126,12 @@ clock_t _times_r(struct _reent *r, struct tms *buf)
 
 int _unlink_r(struct _reent *r, const char *pathname)
 {
-  return unlink(pathname);
+  return nx_unlink(pathname);
 }
 
 int write_r(struct _reent *r, int fd, const void *buf, int count)
 {
-  return write(fd, buf, count);
+  return nx_write(fd, buf, count);
 }
 
 int _gettimeofday_r(struct _reent *r, struct timeval *tv, void *tz)
@@ -139,22 +141,22 @@ int _gettimeofday_r(struct _reent *r, struct timeval *tv, void *tz)
 
 void *_malloc_r(struct _reent *r, size_t size)
 {
-  return malloc(size);
+  return lib_malloc(size);
 }
 
 void *_realloc_r(struct _reent *r, void *ptr, size_t size)
 {
-  return realloc(ptr, size);
+  return lib_realloc(ptr, size);
 }
 
 void *_calloc_r(struct _reent *r, size_t nmemb, size_t size)
 {
-  return calloc(nmemb, size);
+  return lib_calloc(nmemb, size);
 }
 
 void _free_r(struct _reent *r, void *ptr)
 {
-  free(ptr);
+  lib_free(ptr);
 }
 
 void _abort(void)
@@ -233,7 +235,7 @@ struct _reent *__getreent(void)
 {
   /* TODO */
 
-  return (struct _reent *) NULL;
+  return (struct _reent *)NULL;
 }
 
 int _system_r(struct _reent *r, const char *command)
@@ -323,8 +325,8 @@ void esp_setup_syscall_table(void)
   /* Newlib 3.0.0 is used in ROM, the following lock symbols are defined: */
 
   extern _lock_t __sinit_recursive_mutex;
-  __sinit_recursive_mutex = (_lock_t) &g_nxlock_recursive;
+  __sinit_recursive_mutex = (_lock_t)&g_nxlock_recursive;
 
   extern _lock_t __sfp_recursive_mutex;
-  __sfp_recursive_mutex = (_lock_t) &g_nxlock_recursive;
+  __sfp_recursive_mutex = (_lock_t)&g_nxlock_recursive;
 }

--- a/arch/xtensa/src/esp32s3/esp32s3_libc_stubs.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_libc_stubs.c
@@ -24,7 +24,6 @@
 
 #include <assert.h>
 #include <fcntl.h>
-#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/time.h>
@@ -33,7 +32,10 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include <nuttx/signal.h>
 #include <nuttx/mutex.h>
+#include <nuttx/lib/lib.h>
+
 #include "rom/esp32s3_libc_stubs.h"
 
 /****************************************************************************
@@ -61,26 +63,25 @@ struct _reent;
 
 int _close_r(struct _reent *r, int fd)
 {
-  return close(fd);
+  return nx_close(fd);
 }
 
 int _fstat_r(struct _reent *r, int fd, struct stat *statbuf)
 {
-  return fstat(fd, statbuf);
+  return nx_fstat(fd, statbuf);
 }
 
 int _getpid_r(struct _reent *r)
 {
-  return getpid();
+  return nxsched_getpid();
 }
 
 int _kill_r(struct _reent *r, int pid, int sig)
 {
-  return kill(pid, sig);
+  return nxsig_kill(pid, sig);
 }
 
-int _link_r(struct _reent *r, const char *oldpath,
-                      const char *newpath)
+int _link_r(struct _reent *r, const char *oldpath, const char *newpath)
 {
   /* TODO */
 
@@ -89,22 +90,20 @@ int _link_r(struct _reent *r, const char *oldpath,
 
 int lseek_r(struct _reent *r, int fd, int offset, int whence)
 {
-  return lseek(fd, offset, whence);
+  return nx_seek(fd, offset, whence);
 }
 
-int _open_r(struct _reent *r, const char *pathname,
-                      int flags, int mode)
+int _open_r(struct _reent *r, const char *pathname, int flags, int mode)
 {
-  return open(pathname, flags, mode);
+  return nx_open(pathname, flags, mode);
 }
 
 int read_r(struct _reent *r, int fd, void *buf, int count)
 {
-  return read(fd, buf, count);
+  return nx_read(fd, buf, count);
 }
 
-int _rename_r(struct _reent *r, const char *oldpath,
-                        const char *newpath)
+int _rename_r(struct _reent *r, const char *oldpath, const char *newpath)
 {
   return rename(oldpath, newpath);
 }
@@ -114,13 +113,12 @@ void *_sbrk_r(struct _reent *r, ptrdiff_t increment)
   /* TODO: sbrk is only supported on Kernel mode */
 
   errno = -ENOMEM;
-  return (void *) -1;
+  return (void *)-1;
 }
 
-int _stat_r(struct _reent *r, const char *pathname,
-                      struct stat *statbuf)
+int _stat_r(struct _reent *r, const char *pathname, struct stat *statbuf)
 {
-  return stat(pathname, statbuf);
+  return nx_stat(pathname, statbuf, 1);
 }
 
 clock_t _times_r(struct _reent *r, struct tms *buf)
@@ -130,12 +128,12 @@ clock_t _times_r(struct _reent *r, struct tms *buf)
 
 int _unlink_r(struct _reent *r, const char *pathname)
 {
-  return unlink(pathname);
+  return nx_unlink(pathname);
 }
 
 int write_r(struct _reent *r, int fd, const void *buf, int count)
 {
-  return write(fd, buf, count);
+  return nx_write(fd, buf, count);
 }
 
 int _gettimeofday_r(struct _reent *r, struct timeval *tv, void *tz)
@@ -145,22 +143,22 @@ int _gettimeofday_r(struct _reent *r, struct timeval *tv, void *tz)
 
 void *_malloc_r(struct _reent *r, size_t size)
 {
-  return malloc(size);
+  return lib_malloc(size);
 }
 
 void *_realloc_r(struct _reent *r, void *ptr, size_t size)
 {
-  return realloc(ptr, size);
+  return lib_realloc(ptr, size);
 }
 
 void *_calloc_r(struct _reent *r, size_t nmemb, size_t size)
 {
-  return calloc(nmemb, size);
+  return lib_calloc(nmemb, size);
 }
 
 void _free_r(struct _reent *r, void *ptr)
 {
-  free(ptr);
+  lib_free(ptr);
 }
 
 void _abort(void)
@@ -289,7 +287,7 @@ struct _reent *__getreent(void)
 {
   /* TODO */
 
-  return (struct _reent *) NULL;
+  return (struct _reent *)NULL;
 }
 
 int _system_r(struct _reent *r, const char *command)
@@ -389,6 +387,6 @@ void esp_setup_syscall_table(void)
   extern void esp_rom_newlib_init_common_mutexes(_lock_t, _lock_t);
 
   int magic_val = ROM_MUTEX_MAGIC;
-  _lock_t magic_mutex = (_lock_t) &magic_val;
+  _lock_t magic_mutex = (_lock_t)&magic_val;
   esp_rom_newlib_init_common_mutexes(magic_mutex, magic_mutex);
 }

--- a/drivers/crypto/dev_urandom.c
+++ b/drivers/crypto/dev_urandom.c
@@ -37,6 +37,7 @@
 #include <errno.h>
 #include <assert.h>
 
+#include <nuttx/lib/lib.h>
 #include <nuttx/lib/xorshift128.h>
 #include <nuttx/semaphore.h>
 #include <nuttx/fs/fs.h>

--- a/drivers/efuse/efuse.c
+++ b/drivers/efuse/efuse.c
@@ -35,7 +35,7 @@
 
 #include <nuttx/fs/fs.h>
 #include <nuttx/irq.h>
-#include <nuttx/kmalloc.h>
+#include <nuttx/lib/lib.h>
 #include <nuttx/mutex.h>
 #include <nuttx/efuse/efuse.h>
 
@@ -311,7 +311,7 @@ FAR void *efuse_register(FAR const char *path,
   return (FAR void *)upper;
 
 errout_with_path:
-  kmm_free(upper->path);
+  lib_free(upper->path);
 
 errout_with_upper:
   nxmutex_destroy(&upper->lock);
@@ -356,7 +356,7 @@ void efuse_unregister(FAR void *handle)
 
   /* Then free all of the driver resources */
 
-  kmm_free(upper->path);
+  lib_free(upper->path);
   nxmutex_destroy(&upper->lock);
   kmm_free(upper);
 }

--- a/drivers/modem/u-blox.c
+++ b/drivers/modem/u-blox.c
@@ -50,7 +50,7 @@
 #include <nuttx/fs/fs.h>
 #include <nuttx/fs/ioctl.h>
 #include <nuttx/irq.h>
-#include <nuttx/kmalloc.h>
+#include <nuttx/lib/lib.h>
 #include <nuttx/modem/u-blox.h>
 
 /****************************************************************************
@@ -77,30 +77,30 @@
 
 struct ubxmdm_upper
 {
-  FAR char * path;     /* Registration path */
+  FAR char *path;     /* Registration path */
 
   /* The contained lower-half driver. */
 
-  FAR struct ubxmdm_lower * lower;
+  FAR struct ubxmdm_lower *lower;
 };
 
 /****************************************************************************
  * Private Function Prototypes
  ****************************************************************************/
 
-static ssize_t ubxmdm_read (FAR struct file * filep,
-                            FAR char * buffer,
+static ssize_t ubxmdm_read(FAR struct file *filep,
+                           FAR char *buffer,
+                           size_t buflen);
+static ssize_t ubxmdm_write(FAR struct file *filep,
+                            FAR const char *buffer,
                             size_t buflen);
-static ssize_t ubxmdm_write(FAR struct file * filep,
-                            FAR const char * buffer,
-                            size_t buflen);
-static int     ubxmdm_ioctl(FAR struct file * filep,
+static int     ubxmdm_ioctl(FAR struct file *filep,
                             int cmd,
                             unsigned long arg);
 
-static int     ubxmdm_poll (FAR struct file * filep,
-                            FAR struct pollfd * fds,
-                            bool setup);
+static int     ubxmdm_poll(FAR struct file *filep,
+                           FAR struct pollfd *fds,
+                           bool setup);
 
 /****************************************************************************
  * Private Data
@@ -123,29 +123,29 @@ static const struct file_operations g_ubxmdm_fops =
  * Private Functions
  ****************************************************************************/
 
-static ssize_t ubxmdm_read(FAR struct file * filep,
-                           FAR char * buffer,
+static ssize_t ubxmdm_read(FAR struct file *filep,
+                           FAR char *buffer,
                            size_t len)
 {
   return 0; /* Return EOF */
 }
 
-static ssize_t ubxmdm_write(FAR struct file * filep,
-                            FAR const char * buffer,
+static ssize_t ubxmdm_write(FAR struct file *filep,
+                            FAR const char *buffer,
                             size_t len)
 {
   return len; /* Say that everything was written */
 }
 
-static int ubxmdm_ioctl(FAR struct file * filep,
+static int ubxmdm_ioctl(FAR struct file *filep,
                         int cmd,
                         unsigned long arg)
 {
-  FAR struct inode *         inode = filep->f_inode;
-  FAR struct ubxmdm_upper *  upper;
-  FAR struct ubxmdm_lower *  lower;
-  int                        ret;
-  FAR struct ubxmdm_status * status;
+  FAR struct inode         *inode = filep->f_inode;
+  FAR struct ubxmdm_upper  *upper;
+  FAR struct ubxmdm_lower  *lower;
+  FAR struct ubxmdm_status *status;
+  int                       ret;
 
   m_info("cmd: %d arg: %ld\n", cmd, arg);
   upper = inode->i_private;
@@ -214,7 +214,7 @@ static int ubxmdm_ioctl(FAR struct file * filep,
     case MODEM_IOC_GETSTATUS:
       if (lower->ops->getstatus)
         {
-          status = (FAR struct ubxmdm_status *) ((uintptr_t) arg);
+          status = (FAR struct ubxmdm_status *)((uintptr_t)arg);
           if (status)
             {
               ret = lower->ops->getstatus(lower, status);
@@ -253,8 +253,8 @@ static int ubxmdm_ioctl(FAR struct file * filep,
   return ret;
 }
 
-static int ubxmdm_poll(FAR struct file * filep,
-                       FAR struct pollfd * fds,
+static int ubxmdm_poll(FAR struct file *filep,
+                       FAR struct pollfd *fds,
                        bool setup)
 {
   if (setup)
@@ -269,8 +269,8 @@ static int ubxmdm_poll(FAR struct file * filep,
  * Public Functions
  ****************************************************************************/
 
-FAR void * ubxmdm_register(FAR const char * path,
-                          FAR struct ubxmdm_lower * lower)
+FAR void *ubxmdm_register(FAR const char *path,
+                          FAR struct ubxmdm_lower *lower)
 {
   FAR struct ubxmdm_upper *upper;
   int ret;
@@ -300,10 +300,10 @@ FAR void * ubxmdm_register(FAR const char * path,
       goto errout_with_path;
     }
 
-  return (FAR void *) upper;
+  return (FAR void *)upper;
 
 errout_with_path:
-  kmm_free(upper->path);
+  lib_free(upper->path);
 
 errout_with_upper:
   kmm_free(upper);
@@ -329,6 +329,6 @@ void ubxmdm_unregister(FAR void *handle)
 
   unregister_driver(upper->path);
 
-  kmm_free(upper->path);
+  lib_free(upper->path);
   kmm_free(upper);
 }

--- a/drivers/net/slip.c
+++ b/drivers/net/slip.c
@@ -281,13 +281,15 @@ static void slip_transmit(FAR struct slip_driver_s *self)
 
   if (self->txlen > 0)
     {
+      int i;
+
       /* Transmission of previous packet is still pending.  This might happen
        * in the 'slip_receive' -> 'slip_reply' -> 'slip_transmit' case.  Try
        * to forward pending packet into UART's transmit buffer.  Timeout on
        * packet if not forwarded within a second.
        */
 
-      for (int i = 0; (i < 10) && (self->txsent != self->txlen); )
+      for (i = 0; (i < 10) && (self->txsent != self->txlen); )
         {
           ssz = file_write(&self->tty,
                            &self->txbuf[self->txsent],

--- a/drivers/net/telnet.c
+++ b/drivers/net/telnet.c
@@ -720,7 +720,7 @@ static int telnet_close(FAR struct file *filep)
                 }
             }
 
-          kmm_free(devpath);
+          lib_free(devpath);
         }
 
       for (i = 0; i < CONFIG_TELNET_MAXLCLIENTS; i++)

--- a/drivers/sensors/bme680.c
+++ b/drivers/sensors/bme680.c
@@ -53,35 +53,35 @@
 /* Sub-sensor definitions */
 
 #ifdef CONFIG_BME680_DISABLE_PRESS_MEAS
-#define BME680_TEMP_IDX (0)
+#  define BME680_TEMP_IDX (0)
 #else
-#define BME680_TEMP_IDX (-1)
+#  define BME680_TEMP_IDX (-1)
 #endif
 
 #define BME680_TEMP_IDX_OFF BME680_TEMP_IDX
 
 #ifndef CONFIG_BME680_DISABLE_PRESS_MEAS
-#   define BME680_PRESS_IDX (BME680_TEMP_IDX_OFF + (1))
-#   define BME680_PRESS_IDX_OFF BME680_PRESS_IDX
+#  define BME680_PRESS_IDX (BME680_TEMP_IDX_OFF + (1))
+#  define BME680_PRESS_IDX_OFF BME680_PRESS_IDX
 #else
-#   define BME680_PRESS_IDX (-1)
-#   define BME680_PRESS_IDX_OFF BME680_TEMP_IDX_OFF
+#  define BME680_PRESS_IDX (-1)
+#  define BME680_PRESS_IDX_OFF BME680_TEMP_IDX_OFF
 #endif
 
 #ifndef CONFIG_BME680_DISABLE_HUM_MEAS
-#   define BME680_HUM_IDX (BME680_PRESS_IDX_OFF + (1))
-#   define BME680_HUM_IDX_OFF BME680_HUM_IDX
+#  define BME680_HUM_IDX (BME680_PRESS_IDX_OFF + (1))
+#  define BME680_HUM_IDX_OFF BME680_HUM_IDX
 #else
-#   define BME680_HUM_IDX (-1)
-#   define BME680_HUM_IDX_OFF BME680_PRESS_IDX_OFF
+#  define BME680_HUM_IDX (-1)
+#  define BME680_HUM_IDX_OFF BME680_PRESS_IDX_OFF
 #endif
 
 #ifndef CONFIG_BME680_DISABLE_GAS_MEAS
-#   define BME680_GAS_IDX (BME680_HUM_IDX_OFF + (1))
-#   define BME680_GAS_IDX_OFF BME680_GAS_IDX
+#  define BME680_GAS_IDX (BME680_HUM_IDX_OFF + (1))
+#  define BME680_GAS_IDX_OFF BME680_GAS_IDX
 #else
-#   define BME680_GAS_IDX (-1)
-#   define BME680_GAS_IDX_OFF BME680_HUM_IDX_OFF
+#  define BME680_GAS_IDX (-1)
+#  define BME680_GAS_IDX_OFF BME680_HUM_IDX_OFF
 #endif
 
 #define BME680_SENSORS_COUNT (BME680_GAS_IDX_OFF + (1))
@@ -235,34 +235,36 @@
 /* Possible gas range values */
 
 const uint32_t const_array1_int[16] =
-    {(2147483647), (2147483647), (2147483647), (2147483647),
-     (2147483647), (2126008810), (2147483647), (2130303777),
-     (2147483647), (2147483647), (2143188679), (2136746228),
-     (2147483647), (2126008810), (2147483647), (2147483647)
-    };
+{
+  2147483647, 2147483647, 2147483647, 2147483647,
+  2147483647, 2126008810, 2147483647, 2130303777,
+  2147483647, 2147483647, 2143188679, 2136746228,
+  2147483647, 2126008810, 2147483647, 2147483647
+};
 
 const uint32_t const_array2_int[16] =
-    {(4096000000), (2048000000), (1024000000), (512000000),
-     (255744255), (127110228), (64000000), (32258064), (16016016),
-     (8000000), (4000000), (2000000), (1000000), (500000),
-     (250000), (125000)
-    };
+{
+  4096000000, 2048000000, 1024000000, 512000000,
+  255744255, 127110228, 64000000, 32258064, 16016016,
+  8000000, 4000000, 2000000, 1000000, 500000,
+  250000, 125000
+};
 
 const float const_array1[16] =
-    {1.0, 1.0, 1.0, 1.0, 1.0, 0.99, 1.0,
-     0.992, 1.0, 1.0, 0.998, 0.995, 1.0,
-     0.99, 1.0, 1.0
-    };
+{
+  1.0, 1.0, 1.0, 1.0, 1.0, 0.99, 1.0, 0.992, 1.0, 1.0,
+  0.998, 0.995, 1.0, 0.99, 1.0, 1.0
+};
 
 const float const_array2[16] =
-    {8000000.0, 4000000.0, 2000000.0, 1000000.0,
-     499500.4995, 248262.1648, 125000.0, 63004.03226,
-     31281.28128, 15625.0, 7812.5, 3906.25, 1953.125,
-     976.5625, 488.28125, 244.140625
-    };
+{
+  8000000.0, 4000000.0, 2000000.0, 1000000.0, 499500.4995,
+  248262.1648, 125000.0, 63004.03226, 31281.28128, 15625.0,
+  7812.5, 3906.25, 1953.125, 976.5625, 488.28125, 244.140625
+};
 
 #define CHECK_OS_BOUNDS(type) \
-  (type >= BME680_OS_SKIPPED && type <= BME680_OS_16X)
+  ((type) >= BME680_OS_SKIPPED && (type) <= BME680_OS_16X)
 
 /****************************************************************************
  * Private Type Definitions
@@ -396,36 +398,34 @@ static int bme680_control(FAR struct sensor_lowerhalf_s *lower,
  ****************************************************************************/
 
 static const push_data_func deliver_data[BME680_SENSORS_COUNT] =
-    {
+{
 #ifndef CONFIG_BME680_DISABLE_PRESS_MEAS
-        bme680_push_press_data
+  bme680_push_press_data
 #else
-        bme680_push_temp_data
+  bme680_push_temp_data
 #endif
 
 #ifndef CONFIG_BME680_DISABLE_HUM_MEAS
-        ,
-        bme680_push_hum_data
+  , bme680_push_hum_data
 #endif
 
 #ifndef CONFIG_BME680_DISABLE_GAS_MEAS
-        ,
-        bme680_push_gas_data
+  , bme680_push_gas_data
 #endif
 };
 
 static const struct sensor_ops_s g_sensor_ops =
-    {
-        NULL,             /* open */
-        NULL,             /* close */
-        bme680_activate,  /* activate */
-        NULL,             /* set_interval */
-        NULL,             /* batch */
-        NULL,             /* fetch */
-        NULL,             /* selftest */
-        NULL,             /* set_calibvalue */
-        bme680_calibrate, /* calibrate */
-        bme680_control    /* control */
+{
+  NULL,             /* open */
+  NULL,             /* close */
+  bme680_activate,  /* activate */
+  NULL,             /* set_interval */
+  NULL,             /* batch */
+  NULL,             /* fetch */
+  NULL,             /* selftest */
+  NULL,             /* set_calibvalue */
+  bme680_calibrate, /* calibrate */
+  bme680_control    /* control */
 };
 
 /****************************************************************************
@@ -814,8 +814,7 @@ static int bme680_push_temp_data(FAR struct bme680_dev_s *priv,
   temp_data.timestamp = data->timestamp;
   temp_data.temperature = data->temperature;
 
-  ret = lower.push_event(lower.priv, &temp_data,
-                         sizeof(struct sensor_temp));
+  ret = lower.push_event(lower.priv, &temp_data, sizeof(struct sensor_temp));
 
   if (ret < 0)
     {
@@ -839,8 +838,7 @@ static int bme680_push_hum_data(FAR struct bme680_dev_s *priv,
   hum_data.timestamp = data->timestamp;
   hum_data.humidity = data->humidity;
 
-  ret = lower.push_event(lower.priv, &hum_data,
-                         sizeof(struct sensor_humi));
+  ret = lower.push_event(lower.priv, &hum_data, sizeof(struct sensor_humi));
 
   if (ret < 0)
     {
@@ -864,8 +862,7 @@ static int bme680_push_gas_data(FAR struct bme680_dev_s *priv,
   gas_data.timestamp = data->timestamp;
   gas_data.gas_resistance = data->gas_resistance / 1000.f;
 
-  ret = lower.push_event(lower.priv, &gas_data,
-                         sizeof(struct sensor_gas));
+  ret = lower.push_event(lower.priv, &gas_data, sizeof(struct sensor_gas));
 
   if (ret < 0)
     {
@@ -884,7 +881,7 @@ static int bme680_push_gas_data(FAR struct bme680_dev_s *priv,
  *
  ****************************************************************************/
 
-static uint8_t calc_heater_res(const struct bme680_dev_s *priv)
+static uint8_t calc_heater_res(FAR const struct bme680_dev_s *priv)
 {
   uint8_t res_heat;
   int32_t var1;
@@ -902,7 +899,9 @@ static uint8_t calc_heater_res(const struct bme680_dev_s *priv)
   temp = dev.config.target_temp;
 
   if (temp > 400)
-    temp = 400;
+    {
+      temp = 400;
+    }
 
   amb_temp = dev.config.amb_temp;
 
@@ -926,7 +925,7 @@ static uint8_t calc_heater_res(const struct bme680_dev_s *priv)
  *
  ****************************************************************************/
 
-static uint8_t calc_heater_dur(const struct bme680_dev_s *priv)
+static uint8_t calc_heater_dur(FAR const struct bme680_dev_s *priv)
 {
   uint16_t heat_dur = priv->dev.config.heater_duration;
   uint8_t gas_wait_val;
@@ -946,7 +945,7 @@ static uint8_t calc_heater_dur(const struct bme680_dev_s *priv)
   while (heat_dur > 0x3f)
     {
       heat_dur = heat_dur / 4;
-      factor += 1;
+      factor++;
     }
 
   gas_wait_val = (factor << 6) | heat_dur;
@@ -1073,9 +1072,9 @@ err_out:
 static float bme680_comp_temp(FAR struct bme680_dev_s *priv,
                               uint32_t adc_temp)
 {
-  float var1 = 0;
-  float var2 = 0;
-  float calc_temp = 0;
+  float var1 = 0.0f;
+  float var2 = 0.0f;
+  float calc_temp = 0.0f;
 
   struct bme680_sensor_s dev = priv->dev;
 
@@ -1090,7 +1089,7 @@ static float bme680_comp_temp(FAR struct bme680_dev_s *priv,
 
   /* Compensated temperature data */
 
-  calc_temp = ((priv->dev.calib.t_fine) / 5120.0f);
+  calc_temp = (priv->dev.calib.t_fine) / 5120.0f;
 
   return calc_temp;
 }
@@ -1099,10 +1098,10 @@ static float bme680_comp_temp(FAR struct bme680_dev_s *priv,
 static float bme680_comp_press(FAR struct bme680_dev_s *priv,
                                uint32_t adc_press)
 {
-  float var1 = 0;
-  float var2 = 0;
-  float var3 = 0;
-  float calc_pres = 0;
+  float var1 = 0.0f;
+  float var2 = 0.0f;
+  float var3 = 0.0f;
+  float calc_pres = 0.0f;
 
   struct bme680_sensor_s dev = priv->dev;
 
@@ -1136,11 +1135,11 @@ static float bme680_comp_press(FAR struct bme680_dev_s *priv,
 static float bme680_comp_hum(FAR struct bme680_dev_s *priv,
                              uint16_t adc_hum)
 {
-  float calc_hum = 0;
-  float var1 = 0;
-  float var2 = 0;
-  float var3 = 0;
-  float var4 = 0;
+  float calc_hum = 0.0f;
+  float var1 = 0.0f;
+  float var2 = 0.0f;
+  float var3 = 0.0f;
+  float var4 = 0.0f;
   float temp_comp;
 
   struct bme680_sensor_s dev = priv->dev;
@@ -1163,9 +1162,13 @@ static float bme680_comp_hum(FAR struct bme680_dev_s *priv,
   calc_hum = var2 + ((var3 + (var4 * temp_comp)) * var2 * var2);
 
   if (calc_hum > 100.0f)
-    calc_hum = 100.0f;
+    {
+      calc_hum = 100.0f;
+    }
   else if (calc_hum < 0.0f)
-    calc_hum = 0.0f;
+    {
+      calc_hum = 0.0f;
+    }
 
   return calc_hum;
 }
@@ -1176,7 +1179,7 @@ static float bme680_calc_gas_res(FAR struct bme680_dev_s *priv,
                                  uint16_t adc_gas_res, uint8_t gas_range)
 {
   float calc_gas_res;
-  float var1 = 0;
+  float var1 = 0.0f;
 
   struct bme680_sensor_s dev = priv->dev;
 
@@ -1223,8 +1226,7 @@ static int bme680_read_measurements(FAR struct bme680_dev_s *priv,
 
   uint8_t data_regs[BME680_DATA_LEN];
 
-  ret = bme680_getregs(priv, BME680_DATA_ADDR,
-                       data_regs, BME680_DATA_LEN);
+  ret = bme680_getregs(priv, BME680_DATA_ADDR, data_regs, BME680_DATA_LEN);
 
   if (ret < 0)
     {
@@ -1309,9 +1311,9 @@ static uint16_t bme680_get_tphg_dur(FAR struct bme680_dev_s *priv)
   uint32_t meas_cycles;
   uint16_t duration;
   uint8_t os_to_meas_cycles[6] =
-      {
-        0, 1, 2, 4, 8, 16
-      };
+  {
+    0, 1, 2, 4, 8, 16
+  };
 
   meas_cycles = os_to_meas_cycles[priv->dev.config.temp_os];
 
@@ -1325,17 +1327,17 @@ static uint16_t bme680_get_tphg_dur(FAR struct bme680_dev_s *priv)
 
   /* TPH measurement duration */
 
-  tph_dur = meas_cycles * (1963);
-  tph_dur += (477 * 4); /* TPH switching duration */
+  tph_dur = meas_cycles * 1963;
+  tph_dur += 477 * 4; /* TPH switching duration */
 
 #ifndef CONFIG_BME680_DISABLE_GAS_MEAS
-  tph_dur += (477 * 5); /* Gas measurement duration */
+  tph_dur += 477 * 5; /* Gas measurement duration */
 #endif
 
-  tph_dur += (500);
-  tph_dur /= (1000); /* Convert to ms */
+  tph_dur += 500;
+  tph_dur /= 1000; /* Convert to ms */
 
-  tph_dur += (1); /* Wake up duration of 1ms */
+  tph_dur += 1; /* Wake up duration of 1ms */
 
   duration = (uint16_t)tph_dur;
 
@@ -1349,10 +1351,11 @@ static uint16_t bme680_get_tphg_dur(FAR struct bme680_dev_s *priv)
 }
 
 static int bme680_activate(FAR struct sensor_lowerhalf_s *lower,
-                           FAR struct file *filep,
-                           bool enable)
+                           FAR struct file *filep, bool enable)
 {
   int offset;
+  FAR struct bme680_sensor_s *dev;
+  FAR struct bme680_dev_s *priv;
 
   /* Get offset inside array of lowerhalfs */
 
@@ -1360,38 +1363,35 @@ static int bme680_activate(FAR struct sensor_lowerhalf_s *lower,
     {
       case SENSOR_TYPE_AMBIENT_TEMPERATURE:
         offset = BME680_TEMP_IDX;
-      break;
+        break;
 
       case SENSOR_TYPE_BAROMETER:
         offset = BME680_PRESS_IDX;
-      break;
+        break;
 
       case SENSOR_TYPE_RELATIVE_HUMIDITY:
         offset = BME680_HUM_IDX;
-      break;
+        break;
 
       case SENSOR_TYPE_GAS:
         offset = BME680_GAS_IDX;
-      break;
+        break;
 
       default:
         offset = 0;
-      break;
+        break;
     }
 
-  FAR struct bme680_sensor_s *dev =
-        (FAR struct bme680_sensor_s *)
+  dev = (FAR struct bme680_sensor_s *)
         ((uintptr_t)lower - offset * sizeof(*lower));
 
-  FAR struct bme680_dev_s *priv = container_of(dev,
-                                               FAR struct bme680_dev_s,
-                                               dev);
+  priv = container_of(dev, FAR struct bme680_dev_s, dev);
 
   /* Wake the thread only once (the activate method will be called
    *  multiple times for the bme680 sub-sensors)
    */
 
-  if (priv->enabled == false && enable == true)
+  if (!priv->enabled && enable)
     {
       dev->calibrated = false;
       priv->enabled = enable;
@@ -1409,10 +1409,13 @@ static int bme680_activate(FAR struct sensor_lowerhalf_s *lower,
 }
 
 static int bme680_calibrate(FAR struct sensor_lowerhalf_s *lower,
-                            FAR struct file *filep,
-                            unsigned long arg)
+                            FAR struct file *filep, unsigned long arg)
 {
   int offset;
+  FAR struct bme680_sensor_s *dev;
+  FAR struct bme680_dev_s *priv;
+  FAR struct bme680_config_s *calibval = (FAR struct bme680_config_s *)arg;
+  int ret;
 
   /* Get offset inside array of lowerhalfs */
 
@@ -1420,36 +1423,29 @@ static int bme680_calibrate(FAR struct sensor_lowerhalf_s *lower,
     {
       case SENSOR_TYPE_AMBIENT_TEMPERATURE:
         offset = BME680_TEMP_IDX;
-      break;
+        break;
 
       case SENSOR_TYPE_BAROMETER:
         offset = BME680_PRESS_IDX;
-      break;
+        break;
 
       case SENSOR_TYPE_RELATIVE_HUMIDITY:
         offset = BME680_HUM_IDX;
-      break;
+        break;
 
       case SENSOR_TYPE_GAS:
         offset = BME680_GAS_IDX;
-      break;
+        break;
 
       default:
         offset = 0;
-      break;
+        break;
     }
 
-  FAR struct bme680_sensor_s *dev =
-        (FAR struct bme680_sensor_s *)
+  dev = (FAR struct bme680_sensor_s *)
         ((uintptr_t)lower - offset * sizeof(*lower));
 
-  FAR struct bme680_dev_s *priv = container_of(dev,
-                                               FAR struct bme680_dev_s,
-                                               dev);
-  FAR struct bme680_config_s *calibval =
-      (FAR struct bme680_config_s *)arg;
-
-  int ret;
+  priv = container_of(dev, FAR struct bme680_dev_s, dev);
 
   /* Sanity checks */
 
@@ -1495,8 +1491,7 @@ static int bme680_calibrate(FAR struct sensor_lowerhalf_s *lower,
 
   /* Update config in priv */
 
-  memcpy(&priv->dev.config, calibval,
-         sizeof(struct bme680_config_s));
+  memcpy(&priv->dev.config, calibval, sizeof(struct bme680_config_s));
 
   ret = bme680_write_config(priv);
 
@@ -1559,7 +1554,9 @@ static int bme680_thread(int argc, char **argv)
 
   while (true)
     {
-      if (priv->enabled == false)
+      int sensor;
+
+      if (!priv->enabled)
         {
           /* Wait for the sensor to be enabled */
 
@@ -1568,7 +1565,7 @@ static int bme680_thread(int argc, char **argv)
 
       /* No measurements are done unless the sensor is calibrated */
 
-      if (priv->dev.calibrated == false)
+      if (!priv->dev.calibrated)
         {
           sninfo("The sensor is not calibrated!\n");
           goto thread_sleep;
@@ -1593,7 +1590,7 @@ static int bme680_thread(int argc, char **argv)
 
       data.timestamp = sensor_get_timestamp();
 
-      for (int sensor = 0; sensor < BME680_SENSORS_COUNT; sensor++)
+      for (sensor = 0; sensor < BME680_SENSORS_COUNT; sensor++)
         {
           deliver_data[sensor](priv, &data);
         }
@@ -1629,6 +1626,7 @@ int bme680_register(int devno, FAR struct i2c_master_s *i2c)
   FAR char *argv[2];
   char arg1[32];
   int ret = OK;
+  int i;
 
   DEBUGASSERT(i2c != NULL);
 
@@ -1675,8 +1673,7 @@ int bme680_register(int devno, FAR struct i2c_master_s *i2c)
   ret = sensor_register(lower, devno);
   if (ret < 0)
     {
-      snerr("ERROR: Failed to register barometer \
-              driver (err = %d)\n",
+      snerr("ERROR: Failed to register barometer driver (err = %d)\n",
             ret);
       goto err_init;
     }
@@ -1690,8 +1687,7 @@ int bme680_register(int devno, FAR struct i2c_master_s *i2c)
   ret = sensor_register(lower, devno);
   if (ret < 0)
     {
-      snerr("ERROR: Failed to register temperature \
-              driver (err = %d)\n",
+      snerr("ERROR: Failed to register temperature driver (err = %d)\n",
             ret);
       goto err_init;
     }
@@ -1707,8 +1703,7 @@ int bme680_register(int devno, FAR struct i2c_master_s *i2c)
   ret = sensor_register(lower, devno);
   if (ret < 0)
     {
-      snerr("ERROR: Failed to register humidity \
-              driver (err = %d)\n",
+      snerr("ERROR: Failed to register humidity driver (err = %d)\n",
             ret);
       goto err_init;
     }
@@ -1724,8 +1719,7 @@ int bme680_register(int devno, FAR struct i2c_master_s *i2c)
   ret = sensor_register(lower, devno);
   if (ret < 0)
     {
-      snerr("ERROR: Failed to register gas \
-              driver (err = %d)\n",
+      snerr("ERROR: Failed to register gas driver (err = %d)\n",
             ret);
       goto err_init;
     }
@@ -1749,7 +1743,7 @@ int bme680_register(int devno, FAR struct i2c_master_s *i2c)
   return OK;
 
 err_register:
-  for (int i = 0; i < BME680_SENSORS_COUNT; i++)
+  for (i = 0; i < BME680_SENSORS_COUNT; i++)
     {
       sensor_unregister(&priv->dev.lower[i], devno);
     }

--- a/drivers/syslog/syslog_device.c
+++ b/drivers/syslog/syslog_device.c
@@ -36,7 +36,7 @@
 #include <assert.h>
 
 #include <nuttx/arch.h>
-#include <nuttx/kmalloc.h>
+#include <nuttx/lib/lib.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/mutex.h>
 #include <nuttx/syslog/syslog.h>
@@ -781,7 +781,7 @@ void syslog_dev_uninitialize(FAR struct syslog_channel_s *channel)
 
   if (syslog_dev->sl_devpath != NULL)
     {
-      kmm_free(syslog_dev->sl_devpath);
+      lib_free(syslog_dev->sl_devpath);
     }
 
   /* Free the channel structure */

--- a/drivers/timers/timer.c
+++ b/drivers/timers/timer.c
@@ -34,7 +34,7 @@
 #include <debug.h>
 
 #include <nuttx/irq.h>
-#include <nuttx/kmalloc.h>
+#include <nuttx/lib/lib.h>
 #include <nuttx/signal.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/mutex.h>
@@ -473,7 +473,7 @@ FAR void *timer_register(FAR const char *path,
   return (FAR void *)upper;
 
 errout_with_path:
-  kmm_free(upper->path);
+  lib_free(upper->path);
 
 errout_with_upper:
   nxmutex_destroy(&upper->lock);
@@ -523,7 +523,7 @@ void timer_unregister(FAR void *handle)
   /* Then free all of the driver resources */
 
   nxmutex_destroy(&upper->lock);
-  kmm_free(upper->path);
+  lib_free(upper->path);
   kmm_free(upper);
 }
 

--- a/drivers/timers/watchdog.c
+++ b/drivers/timers/watchdog.c
@@ -35,7 +35,7 @@
 
 #include <nuttx/fs/fs.h>
 #include <nuttx/irq.h>
-#include <nuttx/kmalloc.h>
+#include <nuttx/lib/lib.h>
 #include <nuttx/panic_notifier.h>
 #include <nuttx/power/pm.h>
 #include <nuttx/mutex.h>
@@ -790,7 +790,7 @@ FAR void *watchdog_register(FAR const char *path,
   return (FAR void *)upper;
 
 errout_with_path:
-  kmm_free(upper->path);
+  lib_free(upper->path);
 
 errout_with_upper:
   nxmutex_destroy(&upper->lock);
@@ -847,7 +847,7 @@ void watchdog_unregister(FAR void *handle)
 
   /* Then free all of the driver resources */
 
-  kmm_free(upper->path);
+  lib_free(upper->path);
   nxmutex_destroy(&upper->lock);
   kmm_free(upper);
 }

--- a/drivers/wireless/gs2200m.c
+++ b/drivers/wireless/gs2200m.c
@@ -3542,7 +3542,7 @@ FAR void *gs2200m_register(FAR const char *devpath,
 
 errout:
   nxmutex_destroy(&dev->dev_lock);
-  kmm_free(dev->path);
+  lib_free(dev->path);
   kmm_free(dev);
   return NULL;
 }

--- a/fs/driver/fs_blockproxy.c
+++ b/fs/driver/fs_blockproxy.c
@@ -36,7 +36,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/kmalloc.h>
+#include <nuttx/lib/lib.h>
 #include <nuttx/drivers/drivers.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/mutex.h>
@@ -197,14 +197,14 @@ int block_proxy(FAR struct file *filep, FAR const char *blkdev, int oflags)
 
   /* Free the allocated character driver name. */
 
-  kmm_free(chardev);
+  lib_free(chardev);
   return OK;
 
 errout_with_bchdev:
   nx_unlink(chardev);
 
 errout_with_chardev:
-  kmm_free(chardev);
+  lib_free(chardev);
   return ret;
 }
 

--- a/fs/driver/fs_mtdproxy.c
+++ b/fs/driver/fs_mtdproxy.c
@@ -33,7 +33,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/kmalloc.h>
+#include <nuttx/lib/lib.h>
 #include <nuttx/mtd/mtd.h>
 #include <nuttx/mutex.h>
 
@@ -187,6 +187,6 @@ int mtd_proxy(FAR const char *mtddev, int mountflags,
 out_with_fltdev:
   nx_unlink(blkdev);
 out_with_blkdev:
-  kmm_free(blkdev);
+  lib_free(blkdev);
   return ret;
 }

--- a/fs/hostfs/hostfs.c
+++ b/fs/hostfs/hostfs.c
@@ -36,7 +36,7 @@
 #include <errno.h>
 #include <debug.h>
 
-#include <nuttx/kmalloc.h>
+#include <nuttx/lib/lib.h>
 #include <nuttx/mutex.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/fs/fat.h>
@@ -1048,7 +1048,7 @@ static int hostfs_bind(FAR struct inode *blkdriver, FAR const void *data,
       ptr = strtok_r(NULL, ",", &saveptr);
     }
 
-  kmm_free(options);
+  lib_free(options);
 
   /* Take the lock for the mount */
 

--- a/fs/inode/fs_inodesearch.c
+++ b/fs/inode/fs_inodesearch.c
@@ -358,7 +358,7 @@ static int _inode_search(FAR struct inode_search_s *desc)
                                                  name);
                                   if (ret > 0)
                                     {
-                                      kmm_free(desc->buffer);
+                                      lib_free(desc->buffer);
                                       desc->buffer = buffer;
                                       relpath = buffer;
                                       ret = OK;

--- a/fs/inode/fs_inodesearch.c
+++ b/fs/inode/fs_inodesearch.c
@@ -67,7 +67,7 @@ FAR struct inode *g_root_inode = NULL;
 
 static int _inode_compare(FAR const char *fname, FAR struct inode *node)
 {
-  char *nname = node->i_name;
+  FAR char *nname = node->i_name;
 
   if (!nname)
     {
@@ -351,7 +351,7 @@ static int _inode_search(FAR struct inode_search_s *desc)
 
                               if (*desc->relpath != '\0')
                                 {
-                                  char *buffer = NULL;
+                                  FAR char *buffer = NULL;
 
                                   ret = asprintf(&buffer,
                                                  "%s/%s", desc->relpath,

--- a/fs/inode/inode.h
+++ b/fs/inode/inode.h
@@ -35,6 +35,7 @@
 
 #include <nuttx/kmalloc.h>
 #include <nuttx/fs/fs.h>
+#include <nuttx/lib/lib.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -58,7 +59,7 @@
     { \
       if ((d)->buffer != NULL) \
         { \
-          kmm_free((d)->buffer); \
+          lib_free((d)->buffer); \
           (d)->buffer  = NULL; \
         } \
     } \

--- a/fs/nxffs/nxffs_inode.c
+++ b/fs/nxffs/nxffs_inode.c
@@ -31,7 +31,7 @@
 #include <debug.h>
 
 #include <nuttx/crc32.h>
-#include <nuttx/kmalloc.h>
+#include <nuttx/lib/lib.h>
 #include <nuttx/mtd/mtd.h>
 
 #include "nxffs.h"
@@ -212,7 +212,7 @@ void nxffs_freeentry(FAR struct nxffs_entry_s *entry)
 {
   if (entry->name)
     {
-      kmm_free(entry->name);
+      lib_free(entry->name);
       entry->name = NULL;
     }
 }

--- a/fs/nxffs/nxffs_open.c
+++ b/fs/nxffs/nxffs_open.c
@@ -33,7 +33,7 @@
 #include <debug.h>
 
 #include <nuttx/crc32.h>
-#include <nuttx/kmalloc.h>
+#include <nuttx/lib/lib.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/mtd/mtd.h>
 
@@ -654,7 +654,7 @@ static inline int nxffs_wropen(FAR struct nxffs_volume_s *volume,
   return OK;
 
 errout_with_name:
-  kmm_free(wrfile->ofile.entry.name);
+  lib_free(wrfile->ofile.entry.name);
 errout_with_ofile:
 #ifndef CONFIG_NXFFS_PREALLOCATED
   kmm_free(wrfile);

--- a/fs/rpmsgfs/rpmsgfs.c
+++ b/fs/rpmsgfs/rpmsgfs.c
@@ -36,7 +36,7 @@
 #include <debug.h>
 #include <limits.h>
 
-#include <nuttx/kmalloc.h>
+#include <nuttx/lib/lib.h>
 #include <nuttx/mutex.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/fs/ioctl.h>
@@ -1108,7 +1108,7 @@ static int rpmsgfs_bind(FAR struct inode *blkdriver, FAR const void *data,
     }
 
   ret = rpmsgfs_client_bind(&fs->handle, cpuname);
-  kmm_free(options);
+  lib_free(options);
   if (ret < 0)
     {
       kmm_free(fs);

--- a/fs/unionfs/fs_unionfs.c
+++ b/fs/unionfs/fs_unionfs.c
@@ -40,7 +40,7 @@
 #include <fixedmath.h>
 #include <debug.h>
 
-#include <nuttx/kmalloc.h>
+#include <nuttx/lib/lib.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/fs/ioctl.h>
 #include <nuttx/mutex.h>
@@ -824,12 +824,12 @@ static void unionfs_destroy(FAR struct unionfs_inode_s *ui)
 
   if (ui->ui_fs[0].um_prefix)
     {
-      kmm_free(ui->ui_fs[0].um_prefix);
+      lib_free(ui->ui_fs[0].um_prefix);
     }
 
   if (ui->ui_fs[1].um_prefix)
     {
-      kmm_free(ui->ui_fs[1].um_prefix);
+      lib_free(ui->ui_fs[1].um_prefix);
     }
 
   /* And finally free the allocated unionfs state structure as well */
@@ -1516,7 +1516,7 @@ static int unionfs_opendir(FAR struct inode *mountpt,
 errout_with_relpath:
   if (udir->fu_relpath != NULL)
     {
-      kmm_free(udir->fu_relpath);
+      lib_free(udir->fu_relpath);
     }
 
 errout_with_lock:
@@ -1968,7 +1968,7 @@ static int unionfs_bind(FAR struct inode *blkdriver, FAR const void *data,
   /* Call unionfs_dobind to do the real work. */
 
   ret = unionfs_dobind(fspath1, prefix1, fspath2, prefix2, handle);
-  kmm_free(dup);
+  lib_free(dup);
 
   return ret;
 }
@@ -2654,7 +2654,7 @@ static int unionfs_dobind(FAR const char *fspath1, FAR const char *prefix1,
 errout_with_prefix1:
   if (ui->ui_fs[0].um_prefix != NULL)
     {
-      kmm_free(ui->ui_fs[0].um_prefix);
+      lib_free(ui->ui_fs[0].um_prefix);
     }
 
 errout_with_fs2:

--- a/fs/unionfs/fs_unionfs.c
+++ b/fs/unionfs/fs_unionfs.c
@@ -1770,7 +1770,7 @@ static int unionfs_readdir(FAR struct inode *mountpt,
 
                       /* Free the allocated relpath */
 
-                      kmm_free(relpath);
+                      lib_free(relpath);
 
                       /* Check for a duplicate */
 
@@ -1857,7 +1857,7 @@ static int unionfs_readdir(FAR struct inode *mountpt,
 
                   /* Free the allocated relpath */
 
-                  kmm_free(relpath);
+                  lib_free(relpath);
                 }
             }
         }

--- a/fs/vfs/fs_dir.c
+++ b/fs/vfs/fs_dir.c
@@ -453,7 +453,7 @@ static int dir_close(FAR struct file *filep)
   /* Release our references on the contained 'root' inode */
 
   inode_release(inode);
-  kmm_free(relpath);
+  lib_free(relpath);
   return ret;
 }
 

--- a/fs/vfs/fs_fdopen.c
+++ b/fs/vfs/fs_fdopen.c
@@ -33,6 +33,7 @@
 #include <nuttx/kmalloc.h>
 #include <nuttx/semaphore.h>
 #include <nuttx/fs/fs.h>
+#include <nuttx/lib/lib.h>
 #include <nuttx/tls.h>
 
 #include "inode/inode.h"

--- a/fs/vfs/fs_rename.c
+++ b/fs/vfs/fs_rename.c
@@ -245,7 +245,7 @@ errout:
   RELEASE_SEARCH(&newdesc);
   if (subdir != NULL)
     {
-      kmm_free(subdir);
+      lib_free(subdir);
     }
 
   return ret;
@@ -431,7 +431,7 @@ errout_with_newsearch:
   RELEASE_SEARCH(&newdesc);
   if (subdir != NULL)
     {
-      kmm_free(subdir);
+      lib_free(subdir);
     }
 
   return ret;

--- a/fs/vfs/fs_rename.c
+++ b/fs/vfs/fs_rename.c
@@ -33,6 +33,7 @@
 #include <errno.h>
 
 #include <nuttx/fs/fs.h>
+#include <nuttx/lib/lib.h>
 
 #include "inode/inode.h"
 
@@ -118,7 +119,7 @@ next_subdir:
 
           if (subdir != NULL)
             {
-              kmm_free(subdir);
+              lib_free(subdir);
               subdir = NULL;
             }
 
@@ -351,7 +352,7 @@ next_subdir:
 
               if (subdir != NULL)
                 {
-                   kmm_free(subdir);
+                   lib_free(subdir);
                    subdir = NULL;
                 }
 

--- a/fs/vfs/fs_symlink.c
+++ b/fs/vfs/fs_symlink.c
@@ -32,7 +32,7 @@
 #include <assert.h>
 #include <errno.h>
 
-#include <nuttx/kmalloc.h>
+#include <nuttx/lib/lib.h>
 #include <nuttx/fs/fs.h>
 
 #include "inode/inode.h"
@@ -143,7 +143,7 @@ int symlink(FAR const char *path1, FAR const char *path2)
       ret = inode_lock();
       if (ret < 0)
         {
-          kmm_free(newpath2);
+          lib_free(newpath2);
           errcode = -ret;
           goto errout_with_search;
         }
@@ -153,7 +153,7 @@ int symlink(FAR const char *path1, FAR const char *path2)
 
       if (ret < 0)
         {
-          kmm_free(newpath2);
+          lib_free(newpath2);
           errcode = -ret;
           goto errout_with_search;
         }

--- a/include/nuttx/lib/lib.h
+++ b/include/nuttx/lib/lib.h
@@ -41,7 +41,7 @@
  * then only the first mode is supported.
  */
 
-#if  !defined(CONFIG_BUILD_FLAT) && defined(__KERNEL__)
+#if !defined(CONFIG_BUILD_FLAT) && defined(__KERNEL__)
 
   /* Domain-specific allocations */
 

--- a/include/nuttx/lib/lib.h
+++ b/include/nuttx/lib/lib.h
@@ -46,6 +46,7 @@
   /* Domain-specific allocations */
 
 #  define lib_malloc(s)       kmm_malloc(s)
+#  define lib_calloc(n,s)     kmm_calloc(n,s)
 #  define lib_malloc_size(p)  kmm_malloc_size(p)
 #  define lib_zalloc(s)       kmm_zalloc(s)
 #  define lib_realloc(p,s)    kmm_realloc(p,s)
@@ -55,6 +56,7 @@
   /* User-accessible allocations */
 
 #  define lib_umalloc(s)      kumm_malloc(s)
+#  define lib_ucalloc(n,s)    kumm_calloc(n,s)
 #  define lib_umalloc_size(p) kumm_malloc_size(p)
 #  define lib_uzalloc(s)      kumm_zalloc(s)
 #  define lib_urealloc(p,s)   kumm_realloc(p,s)
@@ -66,6 +68,7 @@
   /* Domain-specific allocations */
 
 #  define lib_malloc(s)       malloc(s)
+#  define lib_calloc(n,s)     calloc(n,s)
 #  define lib_malloc_size(p)  malloc_size(p)
 #  define lib_zalloc(s)       zalloc(s)
 #  define lib_realloc(p,s)    realloc(p,s)
@@ -75,6 +78,7 @@
   /* User-accessible allocations */
 
 #  define lib_umalloc(s)      malloc(s)
+#  define lib_ucalloc(n,s)    calloc(n,s)
 #  define lib_umalloc_size(p) malloc_size(p)
 #  define lib_uzalloc(s)      zalloc(s)
 #  define lib_urealloc(p,s)   realloc(p,s)

--- a/libs/libc/modlib/modlib_symbols.c
+++ b/libs/libc/modlib/modlib_symbols.c
@@ -484,7 +484,7 @@ int modlib_insertsymtab(FAR struct module_s *modp,
   if (modp->modinfo.exports != NULL)
     {
       bwarn("Module export information already present - replacing");
-      modlib_freesymtab((FAR void *) modp);
+      modlib_freesymtab((FAR void *)modp);
     }
 
   /* Count the "live" symbols */
@@ -513,13 +513,14 @@ int modlib_insertsymtab(FAR struct module_s *modp,
                   ret = modlib_symname(loadinfo, &sym[i], strtab->sh_offset);
                   if (ret < 0)
                     {
-                      lib_free((FAR void *) modp->modinfo.exports);
+                      lib_free((FAR void *)modp->modinfo.exports);
                       modp->modinfo.exports = NULL;
                       return ret;
                     }
 
-                  symbol[j].sym_name = strdup((char *) loadinfo->iobuffer);
-                  symbol[j].sym_value = (FAR const void *) sym[i].st_value;
+                  symbol[j].sym_name =
+                      strdup((FAR char *)loadinfo->iobuffer);
+                  symbol[j].sym_value = (FAR const void *)sym[i].st_value;
                   j++;
                 }
             }
@@ -606,14 +607,15 @@ void *modlib_findglobal(FAR struct module_s *modp,
 void modlib_freesymtab(FAR struct module_s *modp)
 {
   FAR const struct symtab_s *symbol;
+  int i;
 
-  if ((symbol = modp->modinfo.exports))
+  if ((symbol = modp->modinfo.exports) != NULL)
     {
-      for (int i = 0; i < modp->modinfo.nexports; i++)
+      for (i = 0; i < modp->modinfo.nexports; i++)
         {
-          lib_free((FAR void *) symbol[i].sym_name);
+          lib_free((FAR void *)symbol[i].sym_name);
         }
 
-      lib_free((FAR void *) symbol);
+      lib_free((FAR void *)symbol);
     }
 }

--- a/libs/libc/netdb/lib_rexec.c
+++ b/libs/libc/netdb/lib_rexec.c
@@ -31,6 +31,8 @@
 #include <string.h>
 #include <unistd.h>
 
+#include <nuttx/lib/lib.h>
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -162,7 +164,7 @@ int rexec_af(FAR char **ahost, int inport, FAR const char *user,
 conn_out:
   close(sock);
 sock_out:
-  free(*ahost);
+  lib_free(*ahost);
 addr_out:
   freeaddrinfo(res);
   return -1;

--- a/libs/libc/unistd/lib_getpgrp.c
+++ b/libs/libc/unistd/lib_getpgrp.c
@@ -24,6 +24,8 @@
 
 #include <unistd.h>
 
+#include <nuttx/sched.h>
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -44,5 +46,5 @@
 
 pid_t getpgrp(void)
 {
-  return getpid();
+  return _SCHED_GETPID();
 }

--- a/net/procfs/net_procfs.c
+++ b/net/procfs/net_procfs.c
@@ -39,7 +39,7 @@
 
 #include <sys/param.h>
 
-#include <nuttx/kmalloc.h>
+#include <nuttx/lib/lib.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/fs/procfs.h>
 #include <nuttx/net/netdev.h>
@@ -244,7 +244,7 @@ static int netprocfs_open(FAR struct file *filep, FAR const char *relpath,
 
       devname = basename(copy);
       dev     = netdev_findbyname(devname);
-      kmm_free(copy);
+      lib_free(copy);
 
       if (dev == NULL)
         {
@@ -670,7 +670,7 @@ static int netprocfs_stat(FAR const char *relpath, FAR struct stat *buf)
 
       devname = basename(copy);
       dev     = netdev_findbyname(devname);
-      kmm_free(copy);
+      lib_free(copy);
 
       if (dev == NULL)
         {

--- a/sched/environ/env_putenv.c
+++ b/sched/environ/env_putenv.c
@@ -31,7 +31,7 @@
 #include <string.h>
 #include <errno.h>
 
-#include <nuttx/kmalloc.h>
+#include <nuttx/lib/lib.h>
 
 /****************************************************************************
  * Public Functions
@@ -61,8 +61,8 @@
 
 int putenv(FAR const char *string)
 {
-  char *pname;
-  char *pequal;
+  FAR char *pname;
+  FAR char *pequal;
   int ret = OK;
 
   /* Verify that a string was passed */
@@ -91,7 +91,7 @@ int putenv(FAR const char *string)
       ret = setenv(pname, pequal + 1, TRUE);
     }
 
-  kmm_free(pname);
+  lib_free(pname);
   return ret;
 
 errout:

--- a/sched/signal/sig_notification.c
+++ b/sched/signal/sig_notification.c
@@ -104,7 +104,7 @@ int nxsig_notification(pid_t pid, FAR struct sigevent *event,
                        int code, FAR struct sigwork_s *work)
 {
   sinfo("pid=%" PRIu16 " signo=%d code=%d sival_ptr=%p\n",
-         pid, event->sigev_signo, code, event->sigev_value.sival_ptr);
+        pid, event->sigev_signo, code, event->sigev_value.sival_ptr);
 
   /* Notify client via a signal? */
 

--- a/wireless/ieee802154/mac802154_internal.h
+++ b/wireless/ieee802154/mac802154_internal.h
@@ -306,20 +306,20 @@ struct ieee802154_privmac_s
  ****************************************************************************/
 
 int  mac802154_txdesc_alloc(FAR struct ieee802154_privmac_s *priv,
-      FAR struct ieee802154_txdesc_s **txdesc);
+                            FAR struct ieee802154_txdesc_s **txdesc);
 
 void mac802154_setupindirect(FAR struct ieee802154_privmac_s *priv,
-      FAR struct ieee802154_txdesc_s *txdesc);
+                             FAR struct ieee802154_txdesc_s *txdesc);
 
 void mac802154_createdatareq(FAR struct ieee802154_privmac_s *priv,
-      FAR struct ieee802154_addr_s *coordaddr,
-      enum ieee802154_addrmode_e srcmode,
-      FAR struct ieee802154_txdesc_s *txdesc);
+                             FAR struct ieee802154_addr_s *coordaddr,
+                             enum ieee802154_addrmode_e srcmode,
+                             FAR struct ieee802154_txdesc_s *txdesc);
 
 void mac802154_updatebeacon(FAR struct ieee802154_privmac_s *priv);
 
 void mac802154_notify(FAR struct ieee802154_privmac_s *priv,
-      FAR struct ieee802154_primitive_s *primitive);
+                      FAR struct ieee802154_primitive_s *primitive);
 
 /****************************************************************************
  * Helper Macros/Inline Functions
@@ -349,7 +349,8 @@ void mac802154_notify(FAR struct ieee802154_privmac_s *priv,
 #define mac802154_puteaddr(iob, eaddr) \
   do \
     { \
-      for (int index = IEEE802154_EADDRSIZE - 1; index >= 0; index--) \
+      int index; \
+      for (index = IEEE802154_EADDRSIZE - 1; index >= 0; index--) \
         { \
           iob->io_data[iob->io_len++] = eaddr[index]; \
         } \
@@ -380,7 +381,8 @@ void mac802154_notify(FAR struct ieee802154_privmac_s *priv,
 #define mac802154_takeeaddr(iob, eaddr) \
   do \
     { \
-      for (int index = IEEE802154_EADDRSIZE - 1; index >= 0; index--) \
+      int index; \
+      for (index = IEEE802154_EADDRSIZE - 1; index >= 0; index--) \
         { \
           eaddr[index] = iob->io_data[iob->io_offset++]; \
         } \
@@ -542,7 +544,7 @@ mac802154_symtoticks(FAR struct ieee802154_privmac_s *priv, uint32_t symbols)
    */
 
   priv->radio->getattr(priv->radio, IEEE802154_ATTR_PHY_SYMBOL_DURATION,
-                        &attrval);
+                       &attrval);
 
   /* After this step, ret represents microseconds */
 
@@ -555,11 +557,11 @@ mac802154_symtoticks(FAR struct ieee802154_privmac_s *priv, uint32_t symbols)
 
   if (ret % USEC_PER_TICK == 0)
     {
-      ret = ret / USEC_PER_TICK;
+      ret /= USEC_PER_TICK;
     }
   else
     {
-      ret = ret / USEC_PER_TICK;
+      ret /= USEC_PER_TICK;
       ret++;
     }
 
@@ -645,7 +647,7 @@ mac802154_setchannel(FAR struct ieee802154_privmac_s *priv,
                      uint8_t channel)
 {
   priv->radio->setattr(priv->radio, IEEE802154_ATTR_PHY_CHAN,
-                        (FAR const union ieee802154_attr_u *)&channel);
+                       (FAR const union ieee802154_attr_u *)&channel);
 }
 
 static inline void
@@ -653,7 +655,7 @@ mac802154_setchpage(FAR struct ieee802154_privmac_s *priv,
                     uint8_t chpage)
 {
   priv->radio->setattr(priv->radio, IEEE802154_ATTR_PHY_CURRENT_PAGE,
-                        (FAR const union ieee802154_attr_u *)&chpage);
+                       (FAR const union ieee802154_attr_u *)&chpage);
 }
 
 static inline void
@@ -662,7 +664,7 @@ mac802154_setpanid(FAR struct ieee802154_privmac_s *priv,
 {
   IEEE802154_PANIDCOPY(priv->addr.panid, panid);
   priv->radio->setattr(priv->radio, IEEE802154_ATTR_MAC_PANID,
-                        (FAR const union ieee802154_attr_u *)panid);
+                       (FAR const union ieee802154_attr_u *)panid);
 }
 
 static inline void
@@ -671,7 +673,7 @@ mac802154_setsaddr(FAR struct ieee802154_privmac_s *priv,
 {
   IEEE802154_SADDRCOPY(priv->addr.saddr, saddr);
   priv->radio->setattr(priv->radio, IEEE802154_ATTR_MAC_SADDR,
-                        (FAR const union ieee802154_attr_u *)saddr);
+                       (FAR const union ieee802154_attr_u *)saddr);
 }
 
 static inline void
@@ -680,7 +682,7 @@ mac802154_setcoordsaddr(FAR struct ieee802154_privmac_s *priv,
 {
   IEEE802154_SADDRCOPY(priv->pandesc.coordaddr.saddr, saddr);
   priv->radio->setattr(priv->radio, IEEE802154_ATTR_MAC_COORD_SADDR,
-                        (FAR const union ieee802154_attr_u *)saddr);
+                       (FAR const union ieee802154_attr_u *)saddr);
 }
 
 static inline void
@@ -689,7 +691,7 @@ mac802154_setcoordeaddr(FAR struct ieee802154_privmac_s *priv,
 {
   IEEE802154_EADDRCOPY(priv->pandesc.coordaddr.eaddr, eaddr);
   priv->radio->setattr(priv->radio, IEEE802154_ATTR_MAC_COORD_EADDR,
-                        (FAR const union ieee802154_attr_u *)eaddr);
+                       (FAR const union ieee802154_attr_u *)eaddr);
 }
 
 static inline void
@@ -698,9 +700,9 @@ mac802154_setcoordaddr(FAR struct ieee802154_privmac_s *priv,
 {
   memcpy(&priv->pandesc.coordaddr, addr, sizeof(struct ieee802154_addr_s));
   priv->radio->setattr(priv->radio, IEEE802154_ATTR_MAC_COORD_EADDR,
-                        (FAR const union ieee802154_attr_u *)addr->eaddr);
+                       (FAR const union ieee802154_attr_u *)addr->eaddr);
   priv->radio->setattr(priv->radio, IEEE802154_ATTR_MAC_COORD_SADDR,
-                        (FAR const union ieee802154_attr_u *)addr->saddr);
+                       (FAR const union ieee802154_attr_u *)addr->saddr);
 }
 
 static inline void
@@ -717,7 +719,7 @@ mac802154_setrxonidle(FAR struct ieee802154_privmac_s *priv, bool rxonidle)
     }
 
   priv->radio->setattr(priv->radio, IEEE802154_ATTR_MAC_RX_ON_WHEN_IDLE,
-                        (FAR const union ieee802154_attr_u *)&rxonidle);
+                       (FAR const union ieee802154_attr_u *)&rxonidle);
 }
 
 static inline void
@@ -725,7 +727,7 @@ mac802154_setdevmode(FAR struct ieee802154_privmac_s *priv, uint8_t mode)
 {
   priv->devmode = mode;
   priv->radio->setattr(priv->radio, IEEE802154_ATTR_MAC_DEVMODE,
-                        (FAR const union ieee802154_attr_u *)&mode);
+                       (FAR const union ieee802154_attr_u *)&mode);
 }
 
 #endif /* __WIRELESS_IEEE802154__MAC802154_INTERNAL_H */


### PR DESCRIPTION
## Summary
This PR contains next set of the changes:
- use `lib_free` for memory de-allocation after `strdup` or `asprintf`
- use kernel internal API for libc stubs of ESP32
- Style fixes
- Adding missing `FAR` qualifier
- use `_SCHED_GETPID` in `getpgrp()` implementation

## Impact
Should fix assert "Free memory from the wrong heap" with flat mode and user separated heap enabled mode

## Testing
Pass CI
