### PR TITLE
composite: Use the correct USB dual-speed descriptor when enabling IAD

### DIFF
--- a/drivers/usbdev/composite_desc.c
+++ b/drivers/usbdev/composite_desc.c
@@ -162,9 +162,15 @@ static const struct usb_qualdesc_s g_qualdesc =
      LSBYTE(0x0200),
      MSBYTE(0x0200)
   },
+#  ifdef CONFIG_COMPOSITE_IAD
+  USB_CLASS_MISC,                               /* classid */
+  2,                                            /* subclass */
+  1,                                            /* protocol */
+#  else
   USB_CLASS_VENDOR_SPEC,                        /* classid */
   0,                                            /* subclass */
   0,                                            /* protocol */
+#  endif
   CONFIG_COMPOSITE_EP0MAXPACKET,                /* mxpacketsize */
   COMPOSITE_NCONFIGS,                           /* nconfigs */
   0,                                            /* reserved */


### PR DESCRIPTION
## Summary

Use the correct USB dual-speed descriptor when enabling IAD.

## Impact

composite usbdev

## Testing

BES board