### PR TITLE
ci: Fix the openssl installation fail on macOS

### DIFF
--- a/tools/ci/cibuild.sh
+++ b/tools/ci/cibuild.sh
@@ -448,6 +448,7 @@ function u-boot-tools {
   if ! type mkimage &> /dev/null; then
     case ${os} in
       Darwin)
+        rm -f /usr/local/bin/openssl
         brew install u-boot-tools
         ;;
       Linux)


### PR DESCRIPTION
## Summary

report here: https://github.com/apache/nuttx/pull/10107

```
+ brew install u-boot-tools ==> Fetching dependencies for u-boot-tools: openssl@3 ==> Fetching openssl@3
==> Downloading https://ghcr.io/v2/homebrew/core/openssl/3/manifests/3.1.2-1 Already downloaded: /Users/runner/work/nuttx/nuttx/sources/tools/homebrew/downloads/d235bbcbe9c405bfbe837454515b9cb2793542891a2050e5948a94f596e2a51e--openssl@3-3.1.2-1.bottle_manifest.json ==> Downloading https://ghcr.io/v2/homebrew/core/openssl/3/blobs/sha256:2bea791e9eacc59e0a9099065f3229afaf2b68a9b7b3136ec508103985b1176c Already downloaded: /Users/runner/work/nuttx/nuttx/sources/tools/homebrew/downloads/d082c3abe2fd32b11d857fb7111adc0fc02a0b345044c07f2e7db7160f15300e--openssl@3--3.1.2.ventura.bottle.1.tar.gz ==> Fetching u-boot-tools
==> Downloading https://ghcr.io/v2/homebrew/core/u-boot-tools/manifests/2023.07.02 Already downloaded: /Users/runner/work/nuttx/nuttx/sources/tools/homebrew/downloads/5e0a4a2e6eda6e1dc965b8523549685de4c2da7f1c68d8431bbd7c536642bfee--u-boot-tools-2023.07.02.bottle_manifest.json ==> Downloading https://ghcr.io/v2/homebrew/core/u-boot-tools/blobs/sha256:bfd54176e94ffd2ad380ab7cbd25e091afe9338b17343881cd957f5f6c30d5ed Already downloaded: /Users/runner/work/nuttx/nuttx/sources/tools/homebrew/downloads/8ce6e97fdea98c1581ffe5f52ccd876f3cbf373da9a70f889948b5c888528402--u-boot-tools--2023.07.02.ventura.bottle.tar.gz ==> Installing dependencies for u-boot-tools: openssl@3 ==> Installing u-boot-tools dependency: openssl@3
==> Pouring openssl@3--3.1.2.ventura.bottle.1.tar.gz Error: Could not symlink bin/openssl
Target /usr/local/bin/openssl
is a symlink belonging to openssl@1.1. You can unlink it:
  brew unlink openssl@1.1

To force the link and overwrite all conflicting files:
  brew link --overwrite openssl@3

To list all files that would be deleted:
  brew link --overwrite --dry-run openssl@3
```

## Impact

macOS ci

## Testing

ci