### PR TITLE
net/netdev: Simplify handling of `SIOCSIFMTU`

### DIFF
--- a/net/netdev/netdev_ioctl.c
+++ b/net/netdev/netdev_ioctl.c
@@ -927,11 +927,7 @@ static int netdev_ifr_ioctl(FAR struct socket *psock, int cmd,
         req->ifr_mtu = NETDEV_PKTSIZE(dev) - dev->d_llhdrlen;
         break;
       case SIOCSIFMTU:   /* Set MTU size */
-        dev = netdev_ifr_dev(req);
-        if (dev)
-          {
-            NETDEV_PKTSIZE(dev) = req->ifr_mtu + dev->d_llhdrlen;
-          }
+        NETDEV_PKTSIZE(dev) = req->ifr_mtu + dev->d_llhdrlen;
         break;
 
 #ifdef CONFIG_NET_ICMPv6_AUTOCONF


### PR DESCRIPTION
## Summary
The call of `netdev_ifr_dev` is already simplified by commit fd53db56b6

## Impact
`SIOCSIFMTU` case in `netdev_ifr_ioctl`

## Testing
CI && `ifconfig eth0 mtu 1300`