### PR TITLE
drivers/note: Fix missing header file compilation failure

### DIFF
--- a/include/nuttx/note/noteram_driver.h
+++ b/include/nuttx/note/noteram_driver.h
@@ -27,6 +27,8 @@
 
 #include <nuttx/config.h>
 #include <nuttx/fs/ioctl.h>
+
+#include <stdbool.h>
 #include <sys/types.h>
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
/home/baerg/code/NXOS/nuttx/include/nuttx/note/noteram_driver.h:100:61: error: unknown type name ‘bool’
  100 | noteram_initialize(FAR const char *devpath, size_t bufsize, bool overwrite);
      |                                                             ^~~~
/home/baerg/code/NXOS/nuttx/include/nuttx/note/noteram_driver.h:31:1: note: ‘bool’ is defined in header ‘<stdbool.h>’; did you forget to ‘#include <stdbool.h>’?

## Impact

## Testing

