### PR TITLE
arch/arm64: Fixed arm64 backtrace support for other processes

### DIFF
--- a/arch/arm64/src/common/arm64_backtrace.c
+++ b/arch/arm64/src/common/arm64_backtrace.c
@@ -167,7 +167,7 @@ int up_backtrace(struct tcb_s *tcb,
   else
     {
       flags = enter_critical_section();
-      p_regs = (struct regs_context *)CURRENT_REGS;
+      p_regs = (struct regs_context *)tcb->xcp.regs;
 
       ret = backtrace(tcb->stack_base_ptr,
                       tcb->stack_base_ptr + tcb->adj_stack_size,


### PR DESCRIPTION
## Summary
Fixed arm64 backtrace support for other processes
## Impact
arm64 backtrace
## Testing

