### PR TITLE
cmake:enable nxlib cmake build,fix build break

### DIFF
--- a/graphics/CMakeLists.txt
+++ b/graphics/CMakeLists.txt
@@ -20,7 +20,7 @@
 if(CONFIG_NX)
   nuttx_add_kernel_library(graphics)
 
-  target_include_directories(graphics PRIVATE nxmu nxbe)
+  target_include_directories(graphics PRIVATE nxmu nxbe nxterm)
 
   nuttx_add_subdirectory()
 endif()

--- a/graphics/nxglib/CMakeLists.txt
+++ b/graphics/nxglib/CMakeLists.txt
@@ -19,6 +19,7 @@
 # ##############################################################################
 
 nuttx_add_aux_library(nxglib)
+
 set(SRCS)
 
 set(OPERATIONS setpixel fillrectangle getrectangle filltrapezoid moverectangle
@@ -26,8 +27,8 @@ set(OPERATIONS setpixel fillrectangle getrectangle filltrapezoid moverectangle
 set(BPPS
     1
     2
-    8
     4
+    8
     16
     24
     32)
@@ -40,22 +41,29 @@ endif()
 
 foreach(op ${OPERATIONS})
   foreach(bpp ${BPPS})
-    configure_file(${BLITDIR}/nxglib_${op}.c.in nxglib_${op}_${bpp}bpp.c)
-    set_source_files_properties(
-      ${CMAKE_CURRENT_BINARY_DIR}/nxglib_${op}_${bpp}bpp.c
-      PROPERTIES COMPILE_FLAGS -DNXGLIB_BITSPERPIXEL=${bpp})
-    list(APPEND SRCS ${CMAKE_CURRENT_BINARY_DIR}/nxglib_${op}_${bpp}bpp.c)
+    set(BPP_SUFFIX _${bpp}bpp)
+    configure_file(${BLITDIR}/nxglib_${op}.c nxglib_${op}${BPP_SUFFIX}.c
+                   COPYONLY)
+    set(CUSTOM_DEFINES NXGLIB_BITSPERPIXEL=${bpp} NXGLIB_SUFFIX=${BPP_SUFFIX})
+    set_property(
+      SOURCE ${CMAKE_CURRENT_BINARY_DIR}/nxglib_${op}${BPP_SUFFIX}.c
+      APPEND
+      PROPERTY COMPILE_DEFINITIONS ${CUSTOM_DEFINES})
+    list(APPEND SRCS ${CMAKE_CURRENT_BINARY_DIR}/nxglib_${op}${BPP_SUFFIX}.c)
   endforeach()
 endforeach()
 
 if(CONFIG_NX_RAMBACKED)
   foreach(op ${OPERATIONS})
     foreach(bpp ${BPPS})
-      configure_file(pwfb/pwfb_${op}.c.in pwfb_${op}_${bpp}bpp.c)
-      set_source_files_properties(
-        ${CMAKE_CURRENT_BINARY_DIR}/pwfb_${op}_${bpp}bpp.c
-        PROPERTIES COMPILE_FLAGS -DNXGLIB_BITSPERPIXEL=${bpp})
-      list(APPEND SRCS ${CMAKE_CURRENT_BINARY_DIR}/pwfb_${op}_${bpp}bpp.c)
+      set(BPP_SUFFIX _${bpp}bpp)
+      configure_file(pwfb/pwfb_${op}.c pwfb_${op}${BPP_SUFFIX}.c COPYONLY)
+      set(CUSTOM_DEFINES NXGLIB_BITSPERPIXEL=${bpp} NXGLIB_SUFFIX=${BPP_SUFFIX})
+      set_property(
+        SOURCE ${CMAKE_CURRENT_BINARY_DIR}/pwfb_${op}${BPP_SUFFIX}.c
+        APPEND
+        PROPERTY COMPILE_DEFINITIONS ${CUSTOM_DEFINES})
+      list(APPEND SRCS ${CMAKE_CURRENT_BINARY_DIR}/pwfb_${op}${BPP_SUFFIX}.c)
     endforeach()
   endforeach()
 endif()
@@ -66,13 +74,16 @@ if(CONFIG_NX_SWCURSOR)
 
   foreach(op ${CURSOR_OPS})
     foreach(bpp ${CURSOR_BPPS})
-      configure_file(cursor/nxglib_cursor_${op}.c.in
-                     nxglib_cursor_${op}_${bpp}bpp.c)
-      set_source_files_properties(
-        ${CMAKE_CURRENT_BINARY_DIR}/nxglib_cursor_${op}_${bpp}bpp.c
-        PROPERTIES COMPILE_FLAGS -DNXGLIB_BITSPERPIXEL=${bpp})
+      set(BPP_SUFFIX _${bpp}bpp)
+      configure_file(cursor/nxglib_cursor_${op}.c
+                     nxglib_cursor_${op}${BPP_SUFFIX}.c COPYONLY)
+      set(CUSTOM_DEFINES NXGLIB_BITSPERPIXEL=${bpp} NXGLIB_SUFFIX=${BPP_SUFFIX})
+      set_property(
+        SOURCE ${CMAKE_CURRENT_BINARY_DIR}/nxglib_cursor_${op}${BPP_SUFFIX}.c
+        APPEND
+        PROPERTY COMPILE_DEFINITIONS ${CUSTOM_DEFINES})
       list(APPEND SRCS
-           ${CMAKE_CURRENT_BINARY_DIR}/nxglib_cursor_${op}_${bpp}bpp.c)
+           ${CMAKE_CURRENT_BINARY_DIR}/nxglib_cursor_${op}${BPP_SUFFIX}.c)
     endforeach()
   endforeach()
 endif()

--- a/graphics/nxterm/CMakeLists.txt
+++ b/graphics/nxterm/CMakeLists.txt
@@ -41,9 +41,5 @@ if(CONFIG_NXTERM)
     list(APPEND SRCS nxterm_kbdin.c)
   endif()
 
-  if(CONFIG_DEBUG_GRAPHICS)
-    list(APPEND SRCS nxterm_sem.c)
-  endif()
-
   target_sources(graphics PRIVATE ${SRCS})
 endif()

--- a/libs/libnx/nxfonts/CMakeLists.txt
+++ b/libs/libnx/nxfonts/CMakeLists.txt
@@ -18,13 +18,15 @@
 #
 # ##############################################################################
 function(add_font name id)
-  string(REPLACE "-" "_" prefix "g_${name}")
-  configure_file(nxfonts_bitmaps.c.in nxfonts_bitmaps_${name}.c)
+  string(REPLACE "-" "_" prefix "g_${name}_")
+  configure_file(nxfonts_bitmaps.c nxfonts_bitmaps_${name}.c)
   target_sources(nxfonts
                  PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/nxfonts_bitmaps_${name}.c)
-  set_source_files_properties(
-    ${CMAKE_CURRENT_BINARY_DIR}/nxfonts_bitmaps_${name}.c
-    PROPERTIES COMPILE_FLAGS -DNXFONTS_FONTID=${id})
+  set(CUSTOM_DEFINES NXFONTS_FONTID=${id} NXFONTS_PREFIX=${prefix})
+  set_property(
+    SOURCE ${CMAKE_CURRENT_BINARY_DIR}/nxfonts_bitmaps_${name}.c
+    APPEND
+    PROPERTY COMPILE_DEFINITIONS ${CUSTOM_DEFINES})
 endfunction()
 
 if(CONFIG_NXFONTS)
@@ -45,11 +47,14 @@ if(CONFIG_NXFONTS)
       24
       32)
   foreach(bpp ${BPPS})
-    configure_file(nxfonts_convert.c.in nxfonts_convert_${bpp}bpp.c)
-    set_source_files_properties(
-      ${CMAKE_CURRENT_BINARY_DIR}/nxfonts_convert_${bpp}bpp.c
-      PROPERTIES COMPILE_FLAGS -DNXFONTS_BITSPERPIXEL=${bpp})
-    list(APPEND SRCS ${CMAKE_CURRENT_BINARY_DIR}/nxfonts_convert_${bpp}bpp.c)
+    set(BPP_SUFFIX _${bpp}bpp)
+    configure_file(nxfonts_convert.c nxfonts_convert${BPP_SUFFIX}.c)
+    set(CUSTOM_DEFINES NXFONTS_BITSPERPIXEL=${bpp} NXFONTS_SUFFIX=${BPP_SUFFIX})
+    set_property(
+      SOURCE ${CMAKE_CURRENT_BINARY_DIR}/nxfonts_convert${BPP_SUFFIX}.c
+      APPEND
+      PROPERTY COMPILE_DEFINITIONS ${CUSTOM_DEFINES})
+    list(APPEND SRCS ${CMAKE_CURRENT_BINARY_DIR}/nxfonts_convert${BPP_SUFFIX}.c)
   endforeach()
 
   target_sources(nxfonts PRIVATE ${SRCS})

--- a/libs/libnx/nxmu/CMakeLists.txt
+++ b/libs/libnx/nxmu/CMakeLists.txt
@@ -29,7 +29,6 @@ if(CONFIG_NX)
       nx_disconnect.c
       nx_eventhandler.c
       nx_eventnotify.c
-      nxmu_semtake.c
       nx_block.c
       nx_synch.c
       nx_kbdchin.c


### PR DESCRIPTION
## Summary

- [x] refactor graphics and libnx CMakeLists
- [x] fix nx cmake build block

## Impact

## Testing
env:sim
enable  CONFIG_DRIVERS_VIDEO, CONFIG_VIDEO_FB, CONFIG_SIM_FRAMEBUFFER,  CONFIG_NX
