### PR TITLE
net/icmpv6: Fix value of `SIZEOF_ICMPV6_ECHO_xxx_S`

### DIFF
--- a/include/nuttx/net/icmpv6.h
+++ b/include/nuttx/net/icmpv6.h
@@ -269,7 +269,7 @@ struct icmpv6_router_advertise_s
 
 /* This the message format for the ICMPv6 Echo Request message */
 
-struct icmpv6_echo_request_s
+begin_packed_struct struct icmpv6_echo_request_s
 {
   uint8_t  type;             /* Message Type: ICMPv6_ECHO_REQUEST */
   uint8_t  code;             /* Further qualifies the ICMP messages */
@@ -277,14 +277,14 @@ struct icmpv6_echo_request_s
   uint16_t id;               /* Identifier */
   uint16_t seqno;            /* Sequence Number */
   uint8_t  data[1];          /* Data follows */
-};
+} end_packed_struct;
 
 #define SIZEOF_ICMPV6_ECHO_REQUEST_S(n) \
   (sizeof(struct icmpv6_echo_request_s) - 1 + (n))
 
 /* This the message format for the ICMPv6 Echo Reply message */
 
-struct icmpv6_echo_reply_s
+begin_packed_struct struct icmpv6_echo_reply_s
 {
   uint8_t  type;             /* Message Type: ICMPv6_ECHO_REQUEST */
   uint8_t  code;             /* Further qualifies the ICMP messages */
@@ -292,7 +292,7 @@ struct icmpv6_echo_reply_s
   uint16_t id;               /* Identifier */
   uint16_t seqno;            /* Sequence Number */
   uint8_t  data[1];          /* Data follows */
-};
+} end_packed_struct;
 
 #define SIZEOF_ICMPV6_ECHO_REPLY_S(n) \
   (sizeof(struct icmpv6_echo_reply_s) - 1 + (n))


### PR DESCRIPTION
## Summary
The `SIZEOF_ICMPV6_ECHO_REQUEST_S` and `SIZEOF_ICMPV6_ECHO_REPLY_S` macro are intended to be `8+n`, but actually becomes `10-1+n` and causes the packet sent by `ping6` one byte more than expected.

## Impact
`ping6` command

## Testing
`ping6` on sim with wireshark
