### PR TITLE
net: remove [enter|leave]_critical_section and sched_[un]lock

### DIFF
--- a/net/netlink/netlink_sockif.c
+++ b/net/netlink/netlink_sockif.c
@@ -424,7 +424,6 @@ static void netlink_response_available(FAR void *arg)
    * condition?
    */
 
-  sched_lock();
   net_lock();
 
   if (conn->fds != NULL)
@@ -443,7 +442,6 @@ static void netlink_response_available(FAR void *arg)
   conn->fds = NULL;
 
   net_unlock();
-  sched_unlock();
 }
 
 /****************************************************************************

--- a/net/utils/net_lock.c
+++ b/net/utils/net_lock.c
@@ -64,12 +64,8 @@ static int
 _net_timedwait(sem_t *sem, bool interruptible, unsigned int timeout)
 {
   unsigned int count;
-  irqstate_t   flags;
   int          blresult;
   int          ret;
-
-  flags = enter_critical_section(); /* No interrupts */
-  sched_lock();                     /* No context switches */
 
   /* Release the network lock, remembering my count.  net_breaklock will
    * return a negated value if the caller does not hold the network lock.
@@ -113,8 +109,6 @@ _net_timedwait(sem_t *sem, bool interruptible, unsigned int timeout)
       net_restorelock(count);
     }
 
-  sched_unlock();
-  leave_critical_section(flags);
   return ret;
 }
 
@@ -267,12 +261,8 @@ int net_sem_timedwait(sem_t *sem, unsigned int timeout)
 int net_mutex_timedlock(mutex_t *mutex, unsigned int timeout)
 {
   unsigned int count;
-  irqstate_t   flags;
   int          blresult;
   int          ret;
-
-  flags = enter_critical_section(); /* No interrupts */
-  sched_lock();                     /* No context switches */
 
   /* Release the network lock, remembering my count.  net_breaklock will
    * return a negated value if the caller does not hold the network lock.
@@ -300,8 +290,6 @@ int net_mutex_timedlock(mutex_t *mutex, unsigned int timeout)
       net_restorelock(count);
     }
 
-  sched_unlock();
-  leave_critical_section(flags);
   return ret;
 }
 


### PR DESCRIPTION
## Summary
remove [enter|leave]_critical_section and sched_[un]lock

## Impact
none

## Testing
none
