### PR TITLE
binfmt: add enter_critical_section

### DIFF
--- a/binfmt/binfmt_exec.c
+++ b/binfmt/binfmt_exec.c
@@ -77,6 +77,7 @@ int exec_spawn(FAR const char *filename, FAR char * const *argv,
                FAR const posix_spawnattr_t *attr)
 {
   FAR struct binary_s *bin;
+  irqstate_t flags;
   int pid;
   int ret;
 
@@ -126,6 +127,7 @@ int exec_spawn(FAR const char *filename, FAR char * const *argv,
    * handler.
    */
 
+  flags = enter_critical_section();
   sched_lock();
 
   /* Then start the module */
@@ -160,10 +162,12 @@ int exec_spawn(FAR const char *filename, FAR char * const *argv,
 #endif
 
   sched_unlock();
+  leave_critical_section(flags);
   return pid;
 
 errout_with_lock:
   sched_unlock();
+  leave_critical_section(flags);
   unload_module(bin);
 errout_with_bin:
   kmm_free(bin);


### PR DESCRIPTION

## Summary
adding enter_critical_section to ensure non preemption in smp
## Impact
none
## Testing
none
