### PR TITLE
drivers/input: rm sched_[un]lock

### DIFF
--- a/drivers/input/ads7843e.c
+++ b/drivers/input/ads7843e.c
@@ -372,7 +372,6 @@ static int ads7843e_waitsample(FAR struct ads7843e_dev_s *priv,
    * from getting control while we muck with the semaphores.
    */
 
-  sched_lock();
   flags = enter_critical_section();
 
   /* Now release the semaphore that manages mutually exclusive access to
@@ -418,14 +417,6 @@ errout:
    */
 
   leave_critical_section(flags);
-
-  /* Restore pre-emption.  We might get suspended here but that is okay
-   * because we already have our sample.  Note:  this means that if there
-   * were two threads reading from the ADS7843E for some reason, the data
-   * might be read out of order.
-   */
-
-  sched_unlock();
   return ret;
 }
 

--- a/drivers/input/ft5x06.c
+++ b/drivers/input/ft5x06.c
@@ -606,12 +606,6 @@ static ssize_t ft5x06_waitsample(FAR struct ft5x06_dev_s *priv,
 {
   int ret;
 
-  /* Disable pre-emption to prevent other threads from getting control while
-   * we muck with the semaphores.
-   */
-
-  sched_lock();
-
   /* Now release the semaphore that manages mutually exclusive access to
    * the device structure.  This may cause other tasks to become ready to
    * run, but they cannot run yet because pre-emption is disabled.
@@ -659,13 +653,6 @@ static ssize_t ft5x06_waitsample(FAR struct ft5x06_dev_s *priv,
     }
 
 errout:
-  /* Restore pre-emption.  We might get suspended here but that is okay
-   * because we already have our sample.  Note:  this means that if there
-   * were two threads reading from the FT5x06 for some reason, the data
-   * might be read out of order.
-   */
-
-  sched_unlock();
   return ret;
 }
 

--- a/drivers/input/max11802.c
+++ b/drivers/input/max11802.c
@@ -329,7 +329,6 @@ static int max11802_waitsample(FAR struct max11802_dev_s *priv,
    * from getting control while we muck with the semaphores.
    */
 
-  sched_lock();
   flags = enter_critical_section();
 
   /* Now release the semaphore that manages mutually exclusive access to
@@ -375,14 +374,6 @@ errout:
    */
 
   leave_critical_section(flags);
-
-  /* Restore pre-emption.  We might get suspended here but that is okay
-   * because we already have our sample.  Note:  this means that if there
-   * were two threads reading from the MAX11802 for some reason, the data
-   * might be read out of order.
-   */
-
-  sched_unlock();
   return ret;
 }
 

--- a/drivers/input/mxt.c
+++ b/drivers/input/mxt.c
@@ -1264,12 +1264,6 @@ static ssize_t mxt_read(FAR struct file *filep, FAR char *buffer, size_t len)
       return ret;
     }
 
-  /* Locking the scheduler will prevent the worker thread from running
-   * until we finish here.
-   */
-
-  sched_lock();
-
   /* Try to read sample data. */
 
   ret = mxt_checksample(priv);
@@ -1455,7 +1449,6 @@ static ssize_t mxt_read(FAR struct file *filep, FAR char *buffer, size_t len)
   ret = samplesize;
 
 errout:
-  sched_unlock();
   nxmutex_unlock(&priv->devlock);
   return ret;
 }

--- a/drivers/input/stmpe811_tsc.c
+++ b/drivers/input/stmpe811_tsc.c
@@ -239,12 +239,13 @@ static inline int stmpe811_waitsample(FAR struct stmpe811_dev_s *priv,
                                       FAR struct stmpe811_sample_s *sample)
 {
   int ret;
+  irqstate_t flags;
 
   /* Disable pre-emption to prevent the worker thread from running
    * asynchronously.
    */
 
-  sched_lock();
+  flags = enter_critical_section();
 
   /* Now release the semaphore that manages mutually exclusive access to
    * the device structure.  This may cause other tasks to become ready to
@@ -282,13 +283,12 @@ static inline int stmpe811_waitsample(FAR struct stmpe811_dev_s *priv,
   ret = nxmutex_lock(&priv->lock);
 
 errout:
-  /* Restore pre-emption.  We might get suspended here but that is okay
-   * because we already have our sample.  Note:  this means that if there
-   * were two threads reading from the STMPE811 for some reason, the data
-   * might be read out of order.
+  /* Then re-enable interrupts.  We might get interrupt here and there
+   * could be a new sample.  But no new threads will run because we still
+   * have pre-emption disabled.
    */
 
-  sched_unlock();
+  leave_critical_section(flags);
   return ret;
 }
 
@@ -955,6 +955,10 @@ void stmpe811_tscworker(FAR struct stmpe811_dev_s *priv, uint8_t intsta)
 
   pendown = !!(stmpe811_getreg8(priv, STMPE811_TSC_CTRL) & TSC_CTRL_TSC_STA);
 
+  /* Get exclusive access to the driver data structure */
+
+  nxmutex_lock(&priv->lock);
+
   /* Handle the change from pen down to pen up */
 
   if (!pendown)
@@ -1089,6 +1093,7 @@ void stmpe811_tscworker(FAR struct stmpe811_dev_s *priv, uint8_t intsta)
    */
 
 ignored:
+  nxmutex_unlock(&priv->lock);
   if (priv->sample.contact == CONTACT_DOWN ||
       priv->sample.contact == CONTACT_MOVE)
     {


### PR DESCRIPTION
## Summary
rm sched_[un]lock

We use enter_critical_section to protect the read and write of priv structures,
sched_lock is mainly used to prevent active context switching caused by nxsem_post.
We do not actively switch contexts when reading and writing priv structures,
so sched_lock can be removed.

## Impact
none
## Testing
none

