### PR TITLE
Regulator:add new features

### DIFF
--- a/include/nuttx/power/consumer.h
+++ b/include/nuttx/power/consumer.h
@@ -67,6 +67,8 @@ int regulator_disable_deferred(FAR struct regulator_s *regulator, int ms);
 int regulator_set_voltage(FAR struct regulator_s *regulator, int min_uv,
                           int max_uv);
 int regulator_get_voltage(FAR struct regulator_s *regulator);
+int regulator_set_mode(FAR struct regulator_s *regulator,
+                       enum regulator_mode_e mode);
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/include/nuttx/power/regulator.h
+++ b/include/nuttx/power/regulator.h
@@ -74,30 +74,32 @@ struct regulator_ops_s
 
 struct regulator_desc_s
 {
-  const char   *name;             /* Regulator output name */
-  unsigned int id;                /* Numerical id for a given regulator of
-                                   * a device
-                                   */
-  unsigned int n_voltages;        /* Number of discrete voltages */
-  unsigned int vsel_reg;          /* Device register for voltage selection */
-  unsigned int vsel_mask;         /* Register mask, for voltage selection */
-  unsigned int enable_reg;        /* Device register for enable/disable */
-  unsigned int enable_mask;       /* Register mask for enable/disable */
-  unsigned int enable_time;       /* Time for initial enable of regulator */
-  unsigned int ramp_delay;        /* Rate of change for setting new voltage */
-  unsigned int uv_step;           /* Voltage per step if linear mapping_uv */
-  unsigned int min_uv;            /* Minimum acceptable voltage */
-  unsigned int max_uv;            /* Maximum acceptable voltage */
-  unsigned int pulldown;          /* Enable pulldown when disabled */
-  unsigned int pulldown_reg;      /* Device register, for pulldown enable */
-  unsigned int pulldown_mask;     /* Register mask, for pulldown enable */
-  unsigned int apply_uv;          /* If true, the voltage specifed (between)                                  * min_uv and max_uv will be applied during
-                                   * initialisation.
-                                   */
-  unsigned int boot_on;           /* true if this regulator is to be enabled
-                                   * at power up/reset
-                                   */
-  unsigned int always_on;
+  FAR const char *name;             /* Regulator output name */
+  unsigned int   id;                /* Numerical id for a given regulator of
+                                     * a device
+                                     */
+  unsigned int   n_voltages;        /* Number of discrete voltages */
+  unsigned int   vsel_reg;          /* Device register for voltage selection */
+  unsigned int   vsel_mask;         /* Register mask, for voltage selection */
+  unsigned int   enable_reg;        /* Device register for enable/disable */
+  unsigned int   enable_mask;       /* Register mask for enable/disable */
+  unsigned int   enable_time;       /* Time for initial enable of regulator */
+  unsigned int   ramp_delay;        /* Rate of change for setting new voltage */
+  unsigned int   uv_step;           /* Voltage per step if linear mapping_uv */
+  unsigned int   min_uv;            /* Minimum acceptable voltage */
+  unsigned int   max_uv;            /* Maximum acceptable voltage */
+  unsigned int   pulldown;          /* Enable pulldown when disabled */
+  unsigned int   pulldown_reg;      /* Device register, for pulldown enable */
+  unsigned int   pulldown_mask;     /* Register mask, for pulldown enable */
+  unsigned int   apply_uv;          /* If true, the voltage specifed (between)
+                                     * min_uv and max_uv will be applied during
+                                     * initialisation.
+                                     */
+  unsigned int   boot_on;           /* true if this regulator is to be enabled
+                                     * at power up/reset
+                                     */
+  unsigned int   always_on;
+  FAR const char *supply_name;
 };
 
 struct regulator_dev_s
@@ -109,6 +111,7 @@ struct regulator_dev_s
   mutex_t regulator_lock;
   struct list_node list;
   struct list_node consumer_list;
+  FAR struct regulator_s *supply;
 
   FAR void *priv;
 };
@@ -147,7 +150,7 @@ extern "C"
  *
  ****************************************************************************/
 
-struct regulator_dev_s *
+FAR struct regulator_dev_s *
 regulator_register(FAR const struct regulator_desc_s *desc,
                    FAR const struct regulator_ops_s *ops,
                    FAR void *priv);

--- a/include/nuttx/power/regulator.h
+++ b/include/nuttx/power/regulator.h
@@ -97,6 +97,7 @@ struct regulator_desc_s
   unsigned int boot_on;           /* true if this regulator is to be enabled
                                    * at power up/reset
                                    */
+  unsigned int always_on;
 };
 
 struct regulator_dev_s


### PR DESCRIPTION
## Summary
1.support always on
when add always on desc,the regulator is always enabled
2. support link to supply
when add supply desc,the regulator is linked to the parent regulator
    a.if enable the regualtor, the parent regulator is enabled
    b.if disable all child regulator, the parent regualtor is disabled
3.support lp mode and auto pm register
   a.add new intf regulator_set_mode to manual set rehulator lower power mode;
   b.when add auto lp desc,the regulator lp mode is controlled by  pm framework;
4.optimize the lock to support call the interface in idle task by pm

## Impact


## Testing

