### PR TITLE
SAMA5D2 MCAN errors fixed plus clarity improvements

### DIFF
--- a/arch/arm/src/sama5/Kconfig
+++ b/arch/arm/src/sama5/Kconfig
@@ -1809,72 +1809,72 @@ config SAMA5_MCAN0_LOOPBACK
 		Enable the MCAN0 local loopback mode for testing purposes.
 
 config SAMA5_MCAN0_BITRATE
-	int "MCAN0 bitrate"
+	int "MCAN0 nominal bitrate"
 	default 500000
 	---help---
 		MCAN0 bitrate in bits per second.  Required if SAMA5_MCAN0 is defined.
 
 config SAMA5_MCAN0_PROPSEG
-	int "MCAN0 PropSeg"
-	default 2
-	range 1 8
+	int "MCAN0 nominal PropSeg"
+	default 3
+	range 1 256
 	---help---
 		The length of the bit time is Tquanta * (SyncSeg + PropSeg + PhaseSeg1 + PhaseSeg2).
 
 config SAMA5_MCAN0_PHASESEG1
-	int "MCAN0 PhaseSeg1"
-	default 11
-	range 1 255
+	int "MCAN0 nominal PhaseSeg1"
+	default 8
+	range 1 256
 	---help---
 		The length of the bit time is Tquanta * (SyncSeg + PropSeg + PhaseSeg1 + PhaseSeg2).
 		PhaseSeg1+PropSeg must be between 2 and 256
 
 config SAMA5_MCAN0_PHASESEG2
-	int "MCAN0 PhaseSeg2"
-	default 2
+	int "MCAN0 nominal PhaseSeg2"
+	default 4
 	range 1 128
 	---help---
 		The length of the bit time is Tquanta * (SyncSeg + PropSeg + PhaseSeg1 + PhaseSeg2).
 
-config SAMA5_MCAN0_FSJW
-	int "MCAN0 synchronization jump width"
-	default 1
+config SAMA5_MCAN0_SJW
+	int "MCAN0 nominal synchronization jump width"
+	default 7
 	range 1 128
 	---help---
-		The duration of a synchronization jump is Tcan_clk x FSJW.
+		The duration of a synchronization jump is Tcan_clk x SJW.
 
 config SAMA5_MCAN0_FBITRATE
-	int "MCAN0 fast bitrate"
-	default 2000000
+	int "MCAN0 data bitrate"
+	default SAMA5_MCAN0_BITRATE
 	---help---
-		MCAN0 bitrate in bits per second.  Required if SAMA5_MCAN0 is
+		MCAN0 data bitrate in bits per second.  Required if SAMA5_MCAN0 is
 		defined.
 
 config SAMA5_MCAN0_FPROPSEG
-	int "MCAN0 fast PropSeg"
-	default 2
+	int "MCAN0 data PropSeg"
+	default SAMA5_MCAN0_PROPSEG
 	range 1 63
 	---help---
 		The length of the bit time is Tquanta * (SyncSeg + PropSeg + PhaseSeg1 + PhaseSeg2).
 
 config SAMA5_MCAN0_FPHASESEG1
-	int "MCAN0 fast PhaseSeg1"
-	default 4
+	int "MCAN0 data PhaseSeg1"
+	default SAMA5_MCAN0_PHASESEG1
 	range 1 63
 	---help---
 		The length of the bit time is Tquanta * (SyncSeg + PropSeg + PhaseSeg1 + PhaseSeg2).
 
 config SAMA5_MCAN0_FPHASESEG2
-	int "MCAN0 fast PhaseSeg2"
-	default 4
+	int "MCAN0 data PhaseSeg2"
+	default SAMA5_MCAN0_PHASESEG2
 	range 1 63
 	---help---
 		The length of the bit time is Tquanta * (SyncSeg + PropSeg + PhaseSeg1 + PhaseSeg2).
 
-config SAMA5_MCAN0_FFSJW
-	int "MCAN0 fast synchronization jump width"
-	default 2
-	range 1 5
+config SAMA5_MCAN0_FSJW
+	int "MCAN0 data synchronization jump width"
+	default SAMA5_MCAN0_FSJW
+	range 1 8
 	---help---
 		The duration of a synchronization jump is Tcan_clk x FSJW.
 
@@ -2097,9 +2097,9 @@ menu "MCAN1 device driver options"
 
 choice
 	prompt "MCAN1 mode"
-	default SAMA5_MCAN1_ISO11899_1
+	default SAMA5_MCAN1_ISO11898_1
 
-config SAMA5_MCAN1_ISO11899_1
+config SAMA5_MCAN1_ISO11898_1
 	bool "ISO11898-1"
 	---help---
 		Enable ISO11898-1 mode
@@ -2125,72 +2125,72 @@ config SAMA5_MCAN1_LOOPBACK
 		Enable the MCAN1 local loopback mode for testing purposes.
 
 config SAMA5_MCAN1_BITRATE
-	int "MCAN1 bitrate"
+	int "MCAN1 nominal bitrate"
 	default 500000
 	---help---
 		MCAN1 bitrate in bits per second.  Required if SAMA5_MCAN1 is
 		defined.
 
 config SAMA5_MCAN1_PROPSEG
-	int "MCAN1 PropSeg"
-	default 2
-	range 1 63
+	int "MCAN1 nominal PropSeg"
+	default 3
+	range 1 256
 	---help---
 		The length of the bit time is Tquanta * (SyncSeg + PropSeg + PhaseSeg1 + PhaseSeg2).
 
 config SAMA5_MCAN1_PHASESEG1
-	int "MCAN1 PhaseSeg1"
-	default 11
-	range 1 63
+	int "MCAN1 nominal PhaseSeg1"
+	default 8
+	range 1 256
 	---help---
 		The length of the bit time is Tquanta * (SyncSeg + PropSeg + PhaseSeg1 + PhaseSeg2).
 
 config SAMA5_MCAN1_PHASESEG2
-	int "MCAN1 PhaseSeg2"
-	default 2
-	range 1 63
+	int "MCAN1 nominal PhaseSeg2"
+	default 4
+	range 1 128
 	---help---
 		The length of the bit time is Tquanta * (SyncSeg + PropSeg + PhaseSeg1 + PhaseSeg2).
 
-config SAMA5_MCAN1_FSJW
-	int "MCAN1 synchronization jump width"
-	default 1
-	range 1 5
+config SAMA5_MCAN1_SJW
+	int "MCAN1 nominal synchronization jump width"
+	default 7
+	range 1 128
 	---help---
-		The duration of a synchronization jump is Tcan_clk x FSJW.
+		The duration of a synchronization jump is Tcan_clk x SJW.
 
 config SAMA5_MCAN1_FBITRATE
-	int "MCAN1 fast bitrate"
-	default 2000000
+	int "MCAN1 data bitrate"
+	default SAMA5_MCAN1_BITRATE
 	---help---
 		MCAN1 bitrate in bits per second.  Required if SAMA5_MCAN1 is
 		defined.
 
 config SAMA5_MCAN1_FPROPSEG
-	int "MCAN1 fast PropSeg"
-	default 2
+	int "MCAN1 data PropSeg"
+	default SAMA5_MCAN1_PROPSEG
 	range 1 63
 	---help---
 		The length of the bit time is Tquanta * (SyncSeg + PropSeg + PhaseSeg1 + PhaseSeg2).
 
 config SAMA5_MCAN1_FPHASESEG1
-	int "MCAN1 fast PhaseSeg1"
-	default 4
+	int "MCAN1 data PhaseSeg1"
+	default SAMA5_MCAN1_PHASESEG1
 	range 1 63
 	---help---
 		The length of the bit time is Tquanta * (SyncSeg + PropSeg + PhaseSeg1 + PhaseSeg2).
 
 config SAMA5_MCAN1_FPHASESEG2
-	int "MCAN1 fast PhaseSeg2"
-	default 4
+	int "MCAN1 data PhaseSeg2"
+	default SAMA5_MCAN1_PHASESEG2
 	range 1 63
 	---help---
 		The length of the bit time is Tquanta * (SyncSeg + PropSeg + PhaseSeg1 + PhaseSeg2).
 
-config SAMA5_MCAN1_FFSJW
-	int "MCAN1 fast synchronization jump width"
-	default 2
-	range 1 5
+config SAMA5_MCAN1_FSJW
+	int "MCAN1 data synchronization jump width"
+	default SAMA5_MCAN1_FSJW
+	range 1 8
 	---help---
 		The duration of a synchronization jump is Tcan_clk x FSJW.
 

--- a/arch/arm/src/sama5/sam_mcan.c
+++ b/arch/arm/src/sama5/sam_mcan.c
@@ -130,44 +130,40 @@
 
 #ifdef CONFIG_SAMA5_MCAN0
 
-/* Bit timing */
+  /* Bit timing */
 
-#  define MCAN0_TSEG1  (CONFIG_SAMA5_MCAN0_PROPSEG + CONFIG_SAMA5_MCAN0_PHASESEG1 - 1)
-#  define MCAN0_TSEG2  (CONFIG_SAMA5_MCAN0_PHASESEG2 - 1)
-#  define MCAN0_BRP    ((uint32_t)(((float)SAMA5_MCANCLK_FREQUENCY / \
-                       ((float)(MCAN0_TSEG1 + MCAN0_TSEG2 + 3) * \
-                        (float)CONFIG_SAMA5_MCAN0_BITRATE)) - 1))
+#  define MCAN0_NTSEG1  (CONFIG_SAMA5_MCAN0_PROPSEG + CONFIG_SAMA5_MCAN0_PHASESEG1 - 1)
+#  define MCAN0_NTSEG2  (CONFIG_SAMA5_MCAN0_PHASESEG2 - 1)
+#  define MCAN0_NBRP    ((uint32_t)(((float)SAMA5_MCANCLK_FREQUENCY / \
+                         ((float)(MCAN0_NTSEG1 + MCAN0_NTSEG2 + 3) * \
+                          (float)CONFIG_SAMA5_MCAN0_BITRATE)) - 1))
 
-#  define MCAN0_SJW    (CONFIG_SAMA5_MCAN0_FSJW - 1)
+#  define MCAN0_NSJW    (CONFIG_SAMA5_MCAN0_SJW - 1)
 
-/* NB: errata sheet states TSEG1 must not be programmed as 0 */
-
-#  if ((MCAN0_TSEG1 > 256) || (MCAN0_TSEG1 < 2))
+#  if ((MCAN0_NTSEG1 > 255) || (MCAN0_NTSEG1 < 1))
 #    error Invalid MCAN0 TSEG1
 #  endif
-#  if MCAN0_TSEG2 > 128
+#  if MCAN0_NTSEG2 > 127
 #    error Invalid MCAN0 TSEG2
 #  endif
-#  if MCAN0_SJW > 128
+#  if MCAN0_NSJW > 127
 #    error Invalid MCAN0 SJW
 #  endif
 
 #  define MCAN0_FTSEG1 (CONFIG_SAMA5_MCAN0_FPROPSEG + CONFIG_SAMA5_MCAN0_FPHASESEG1 - 1)
 #  define MCAN0_FTSEG2 (CONFIG_SAMA5_MCAN0_FPHASESEG2 - 1)
 #  define MCAN0_FBRP   ((uint32_t)(((float)SAMA5_MCANCLK_FREQUENCY / \
-                       ((float)(MCAN0_FTSEG1 + MCAN0_FTSEG2 + 3) * \
-                        (float)CONFIG_SAMA5_MCAN0_FBITRATE)) - 1))
-#  define MCAN0_FSJW   (CONFIG_SAMA5_MCAN0_FFSJW - 1)
+                        ((float)(MCAN0_FTSEG1 + MCAN0_FTSEG2 + 3) * \
+                         (float)CONFIG_SAMA5_MCAN0_FBITRATE)) - 1))
+#  define MCAN0_FSJW   (CONFIG_SAMA5_MCAN0_FSJW - 1)
 
-/* NB: errata sheet states TSEG1 must not be programmed as 0 */
-
-#  if ((MCAN0_FTSEG1 > 32) || (MCAN0_FTSEG1 < 2))
+#  if ((MCAN0_FTSEG1 > 31) || (MCAN0_FTSEG1 < 1))
 #    error Invalid MCAN0 FTSEG1
 #  endif
-#  if MCAN0_FTSEG2 > 17
+#  if MCAN0_FTSEG2 > 15
 #    error Invalid MCAN0 FTSEG2
 #  endif
-#  if MCAN0_FSJW > 8
+#  if MCAN0_FSJW > 7
 #    error Invalid MCAN0 FSJW
 #  endif
 
@@ -420,41 +416,43 @@
 /* MCAN1 Configuration */
 
 #ifdef CONFIG_SAMA5_MCAN1
+
   /* Bit timing */
 
-#  define MCAN1_TSEG1  (CONFIG_SAMA5_MCAN1_PROPSEG + CONFIG_SAMA5_MCAN1_PHASESEG1)
-#  define MCAN1_TSEG2  CONFIG_SAMA5_MCAN1_PHASESEG2
-#  define MCAN1_BRP    ((uint32_t)(((float)SAMA5_MCANCLK_FREQUENCY / \
-                       ((float)(MCAN1_TSEG1 + MCAN1_TSEG2 + 3) * \
-                        (float)CONFIG_SAMA5_MCAN1_BITRATE)) - 1))
-#  define MCAN1_SJW    (CONFIG_SAMA5_MCAN1_FSJW - 1)
+#  define MCAN1_NTSEG1  (CONFIG_SAMA5_MCAN1_PROPSEG + CONFIG_SAMA5_MCAN1_PHASESEG1 - 1)
+#  define MCAN1_NTSEG2  (CONFIG_SAMA5_MCAN1_PHASESEG2 - 1)
+#  define MCAN1_NBRP    ((uint32_t)(((float)SAMA5_MCANCLK_FREQUENCY / \
+                         ((float)(MCAN1_NTSEG1 + MCAN1_NTSEG2 + 3) * \
+                          (float)CONFIG_SAMA5_MCAN1_BITRATE)) - 1))
 
-#  if MCAN1_TSEG1 > 63
+#  define MCAN1_NSJW    (CONFIG_SAMA5_MCAN1_SJW - 1)
+
+#  if ((MCAN1_NTSEG1 > 255) || (MCAN1_NTSEG1 < 1))
 #    error Invalid MCAN1 TSEG1
 #  endif
-#  if MCAN1_TSEG2 > 15
+#  if MCAN1_NTSEG2 > 127
 #    error Invalid MCAN1 TSEG2
 #  endif
-#  if MCAN1_SJW > 15
+#  if MCAN1_NSJW > 127
 #    error Invalid MCAN1 SJW
 #  endif
 
-#  define MCAN1_FTSEG1 (CONFIG_SAMA5_MCAN1_FPROPSEG + CONFIG_SAMA5_MCAN1_FPHASESEG1)
-#  define MCAN1_FTSEG2 (CONFIG_SAMA5_MCAN1_FPHASESEG2)
+#  define MCAN1_FTSEG1 (CONFIG_SAMA5_MCAN1_FPROPSEG + CONFIG_SAMA5_MCAN1_FPHASESEG1 - 1)
+#  define MCAN1_FTSEG2 (CONFIG_SAMA5_MCAN1_FPHASESEG2 - 1)
 #  define MCAN1_FBRP   ((uint32_t)(((float)SAMA5_MCANCLK_FREQUENCY / \
                        ((float)(MCAN1_FTSEG1 + MCAN1_FTSEG2 + 3) * \
                         (float)CONFIG_SAMA5_MCAN1_FBITRATE)) - 1))
-#  define MCAN1_FSJW   (CONFIG_SAMA5_MCAN1_FFSJW - 1)
+#  define MCAN1_FSJW   (CONFIG_SAMA5_MCAN1_FSJW - 1)
 
-#if MCAN1_FTSEG1 > 15
-#  error Invalid MCAN1 FTSEG1
-#endif
-#if MCAN1_FTSEG2 > 7
-#  error Invalid MCAN1 FTSEG2
-#endif
-#if MCAN1_FSJW > 3
-#  error Invalid MCAN1 FSJW
-#endif
+#  if ((MCAN1_FTSEG1 > 31) || (MCAN1_FTSEG1 < 1))
+#    error Invalid MCAN1 FTSEG1
+#  endif
+#  if MCAN1_FTSEG2 > 15
+#    error Invalid MCAN1 FTSEG2
+#  endif
+#  if MCAN1_FSJW > 7
+#    error Invalid MCAN FSJW
+#  endif
 
 /* MCAN1 RX FIFO0 element size */
 
@@ -1004,10 +1002,10 @@ static const struct sam_config_s g_mcan0const =
   .txpinset         = PIO_CAN0_TX,
   .base             = SAM_MCAN0_VBASE,
   .baud             = CONFIG_SAMA5_MCAN0_BITRATE,
-  .btp              = MCAN_BTP_BRP(MCAN0_BRP) |
-                      MCAN_BTP_TSEG1(MCAN0_TSEG1) |
-                      MCAN_BTP_TSEG2(MCAN0_TSEG2) |
-                      MCAN_BTP_SJW(MCAN0_SJW),
+  .btp              = MCAN_BTP_BRP(MCAN0_NBRP) |
+                      MCAN_BTP_TSEG1(MCAN0_NTSEG1) |
+                      MCAN_BTP_TSEG2(MCAN0_NTSEG2) |
+                      MCAN_BTP_SJW(MCAN0_NSJW),
   .fbtp             = MCAN_FBTP_FBRP(MCAN0_FBRP) |
                       MCAN_FBTP_FTSEG1(MCAN0_FTSEG1) |
                       MCAN_FBTP_FTSEG2(MCAN0_FTSEG2) |
@@ -1095,10 +1093,10 @@ static const struct sam_config_s g_mcan1const =
   .txpinset         = PIO_CAN1_TX,
   .base             = SAM_MCAN1_VBASE,
   .baud             = CONFIG_SAMA5_MCAN1_BITRATE,
-  .btp              = MCAN_BTP_BRP(MCAN1_BRP) |
-                      MCAN_BTP_TSEG1(MCAN1_TSEG1) |
-                      MCAN_BTP_TSEG2(MCAN1_TSEG2) |
-                      MCAN_BTP_SJW(MCAN1_SJW),
+  .btp              = MCAN_BTP_BRP(MCAN1_NBRP) |
+                      MCAN_BTP_TSEG1(MCAN1_NTSEG1) |
+                      MCAN_BTP_TSEG2(MCAN1_NTSEG2) |
+                      MCAN_BTP_SJW(MCAN1_NSJW),
   .fbtp             = MCAN_FBTP_FBRP(MCAN1_FBRP) |
                       MCAN_FBTP_FTSEG1(MCAN1_FTSEG1) |
                       MCAN_FBTP_FTSEG2(MCAN1_FTSEG2) |
@@ -1155,7 +1153,7 @@ static struct sam_mcan_s g_mcan1priv =
 {
   .config           = &g_mcan1const,
   .lock             = NXMUTEX_INITIALIZER,
-  .txfsem           = SEM_INITIALIZER(CONFIG_SAMA5_MCAN0_TXFIFOQ_SIZE),
+  .txfsem           = SEM_INITIALIZER(CONFIG_SAMA5_MCAN1_TXFIFOQ_SIZE),
 };
 
 static struct can_dev_s g_mcan1dev =


### PR DESCRIPTION
## Summary
Errors fixed relating to MCAN1, and to range checking, plus changes to Kconfig and driver code to improve clarity of "data" and "nominal" timing setup to better match the processor datasheet. The #define naming within the driver has been changed to better reflect this too, but the Kconfig names have been retained as-was to avoid problems with any existing builds.

## Impact
None expected

## Testing
Custom board with SAMA5D27C-D1M with 2x MCAN interfaces.

