### PR TITLE
pthread: remove unused temp change sched_priority

### DIFF
--- a/sched/pthread/pthread_create.c
+++ b/sched/pthread/pthread_create.c
@@ -460,24 +460,6 @@ int nx_pthread_create(pthread_trampoline_t trampoline, FAR pthread_t *thread,
 
   pid = ptcb->cmn.pid;
 
-  /* If the priority of the new pthread is lower than the priority of the
-   * parent thread, then starting the pthread could result in both the
-   * parent and the pthread to be blocked.  This is a recipe for priority
-   * inversion issues.
-   *
-   * We avoid this here by boosting the priority of the (inactive) pthread
-   * so it has the same priority as the parent thread.
-   */
-
-  if (ptcb->cmn.sched_priority < parent->sched_priority)
-    {
-      ret = nxsched_set_priority(&ptcb->cmn, parent->sched_priority);
-      if (ret < 0)
-        {
-          ret = -ret;
-        }
-    }
-
   /* Then activate the task */
 
   sched_lock();


### PR DESCRIPTION
## Summary

old:
pthread_create:

init_priority = prio;
if (sched_priority < parent_prio)
    sched_priority = parent_prio;    // don't need

pthread_start:

if (sched_priority > init_priority)
    sched_priority = init_priority

## Impact

pthread_create

## Testing

VELA

