### PR TITLE
Fix error: '%s' directive output may be truncated

### DIFF
--- a/drivers/ioexpander/gpio.c
+++ b/drivers/ioexpander/gpio.c
@@ -593,7 +593,7 @@ int gpio_pin_register(FAR struct gpio_dev_s *dev, int minor)
 int gpio_pin_register_byname(FAR struct gpio_dev_s *dev,
                              FAR const char *pinname)
 {
-  char devname[32];
+  char devname[64];
   int ret;
 
   DEBUGASSERT(dev != NULL && dev->gp_ops != NULL && pinname != NULL);
@@ -691,7 +691,7 @@ int gpio_pin_unregister(FAR struct gpio_dev_s *dev, int minor)
 int gpio_pin_unregister_byname(FAR struct gpio_dev_s *dev,
                                FAR const char *pinname)
 {
-  char devname[32];
+  char devname[64];
 
   snprintf(devname, sizeof(devname), "/dev/%s", pinname);
 


### PR DESCRIPTION
## Summary

writing up to 31 bytes into a region of size 27 [-Werror=format-truncation=]

## Impact

## Testing

ci