### PR TITLE
usb: Fixed memory leak for usb uninitialize process

### DIFF
--- a/drivers/usbdev/adb.c
+++ b/drivers/usbdev/adb.c
@@ -1053,22 +1053,6 @@ static void usbclass_unbind(FAR struct usbdevclass_driver_s *driver,
 
       usbclass_resetconfig(priv);
 
-      /* Free the bulk IN endpoint */
-
-      if (priv->epbulkin)
-        {
-          DEV_FREEEP(dev, priv->epbulkin);
-          priv->epbulkin = NULL;
-        }
-
-      /* Free the bulk OUT endpoint */
-
-      if (priv->epbulkout)
-        {
-          DEV_FREEEP(dev, priv->epbulkout);
-          priv->epbulkout = NULL;
-        }
-
       /* Free write requests that are not in use (which should be all
        * of them
        */
@@ -1093,6 +1077,22 @@ static void usbclass_unbind(FAR struct usbdevclass_driver_s *driver,
             {
               usbdev_freereq(priv->epbulkin, wrcontainer->req);
             }
+        }
+
+      /* Free the bulk IN endpoint */
+
+      if (priv->epbulkin)
+        {
+          DEV_FREEEP(dev, priv->epbulkin);
+          priv->epbulkin = NULL;
+        }
+
+      /* Free the bulk OUT endpoint */
+
+      if (priv->epbulkout)
+        {
+          DEV_FREEEP(dev, priv->epbulkout);
+          priv->epbulkout = NULL;
         }
     }
 }

--- a/drivers/usbdev/cdcacm.c
+++ b/drivers/usbdev/cdcacm.c
@@ -1463,14 +1463,6 @@ static void cdcacm_unbind(FAR struct usbdevclass_driver_s *driver,
       cdcacm_resetconfig(priv);
       up_mdelay(50);
 
-      /* Free the interrupt IN endpoint */
-
-      if (priv->epintin)
-        {
-          DEV_FREEEP(dev, priv->epintin);
-          priv->epintin = NULL;
-        }
-
       /* Free the pre-allocated control request */
 
       if (priv->ctrlreq != NULL)
@@ -1494,14 +1486,6 @@ static void cdcacm_unbind(FAR struct usbdevclass_driver_s *driver,
             }
         }
 
-      /* Free the bulk OUT endpoint */
-
-      if (priv->epbulkout)
-        {
-          DEV_FREEEP(dev, priv->epbulkout);
-          priv->epbulkout = NULL;
-        }
-
       /* Free write requests that are not in use (which should be all
        * of them)
        */
@@ -1521,6 +1505,22 @@ static void cdcacm_unbind(FAR struct usbdevclass_driver_s *driver,
 
       DEBUGASSERT(priv->nwrq == 0);
       leave_critical_section(flags);
+
+      /* Free the interrupt IN endpoint */
+
+      if (priv->epintin)
+        {
+          DEV_FREEEP(dev, priv->epintin);
+          priv->epintin = NULL;
+        }
+
+      /* Free the bulk OUT endpoint */
+
+      if (priv->epbulkout)
+        {
+          DEV_FREEEP(dev, priv->epbulkout);
+          priv->epbulkout = NULL;
+        }
 
       /* Free the bulk IN endpoint */
 

--- a/drivers/usbdev/composite.c
+++ b/drivers/usbdev/composite.c
@@ -531,7 +531,7 @@ static int composite_setup(FAR struct usbdevclass_driver_s *driver,
                       static const uint8_t msft_response[16] =
                       {
                         'M', 0, 'S', 0, 'F', 0, 'T', 0, '1', 0, '0', 0,
-                        '0', 0, 0xff, 0
+                        '0', 0, USB_REQ_GETMSFTOSDESCRIPTOR, 0
                       };
 
                       buf->len = 18;

--- a/drivers/usbdev/pl2303.c
+++ b/drivers/usbdev/pl2303.c
@@ -1479,22 +1479,6 @@ static void usbclass_unbind(FAR struct usbdevclass_driver_s *driver,
       usbclass_resetconfig(priv);
       up_mdelay(50);
 
-      /* Free the interrupt IN endpoint */
-
-      if (priv->epintin)
-        {
-          DEV_FREEEP(dev, priv->epintin);
-          priv->epintin = NULL;
-        }
-
-      /* Free the bulk IN endpoint */
-
-      if (priv->epbulkin)
-        {
-          DEV_FREEEP(dev, priv->epbulkin);
-          priv->epbulkin = NULL;
-        }
-
       /* Free the pre-allocated control request */
 
       if (priv->ctrlreq != NULL)
@@ -1544,6 +1528,22 @@ static void usbclass_unbind(FAR struct usbdevclass_driver_s *driver,
 
       DEBUGASSERT(priv->nwrq == 0);
       leave_critical_section(flags);
+
+      /* Free the interrupt IN endpoint */
+
+      if (priv->epintin)
+        {
+          DEV_FREEEP(dev, priv->epintin);
+          priv->epintin = NULL;
+        }
+
+      /* Free the bulk IN endpoint */
+
+      if (priv->epbulkin)
+        {
+          DEV_FREEEP(dev, priv->epbulkin);
+          priv->epbulkin = NULL;
+        }
     }
 
   /* Clear out all data in the circular buffer */

--- a/drivers/usbdev/rndis.c
+++ b/drivers/usbdev/rndis.c
@@ -2289,22 +2289,6 @@ static void usbclass_unbind(FAR struct usbdevclass_driver_s *driver,
       usbclass_resetconfig(priv);
       up_mdelay(50);
 
-      /* Free the interrupt IN endpoint */
-
-      if (priv->epintin)
-        {
-          DEV_FREEEP(dev, priv->epintin);
-          priv->epintin = NULL;
-        }
-
-      /* Free the bulk IN endpoint */
-
-      if (priv->epbulkin)
-        {
-          DEV_FREEEP(dev, priv->epbulkin);
-          priv->epbulkin = NULL;
-        }
-
       /* Free the pre-allocated control request */
 
       if (priv->ctrlreq != NULL)
@@ -2328,14 +2312,6 @@ static void usbclass_unbind(FAR struct usbdevclass_driver_s *driver,
         usbdev_freereq(priv->epbulkout, priv->rdreq);
       }
 
-      /* Free the bulk OUT endpoint */
-
-      if (priv->epbulkout)
-        {
-          DEV_FREEEP(dev, priv->epbulkout);
-          priv->epbulkout = NULL;
-        }
-
       netdev_unregister(&priv->netdev);
 
       /* Free write requests that are not in use (which should be all
@@ -2354,6 +2330,30 @@ static void usbclass_unbind(FAR struct usbdevclass_driver_s *driver,
         }
 
       leave_critical_section(flags);
+
+      /* Free the interrupt IN endpoint */
+
+      if (priv->epintin)
+        {
+          DEV_FREEEP(dev, priv->epintin);
+          priv->epintin = NULL;
+        }
+
+      /* Free the bulk IN endpoint */
+
+      if (priv->epbulkin)
+        {
+          DEV_FREEEP(dev, priv->epbulkin);
+          priv->epbulkin = NULL;
+        }
+
+      /* Free the bulk OUT endpoint */
+
+      if (priv->epbulkout)
+        {
+          DEV_FREEEP(dev, priv->epbulkout);
+          priv->epbulkout = NULL;
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

1. a memory leak occurred when the usb uninitialize process was executed: 
In usbclass_unbind, DEV_FREEEP is called first, and later usbclass_freereq does not free memory due to ep NULL.
2.  composite devices are not automatically recognized by windows:
Description bMS_VendorCode is incorrectly configured. Change it to USB_REQ_GETMSFTOSDESCRIPTOR(0xee), which is the same as the request processing logic for GET_MS_DESCRIPTOR in the code.

## Impact

USB

## Testing

Test for BES board