### PR TITLE
drivers/input:Fix setting the number of keyboard driver buffers fails

### DIFF
--- a/drivers/input/keyboard_upper.c
+++ b/drivers/input/keyboard_upper.c
@@ -123,7 +123,8 @@ static int keyboard_open(FAR struct file *filep)
 
   /* Initializes the buffer for each open file */
 
-  ret = circbuf_init(&opriv->circ, NULL, upper->nums);
+  ret = circbuf_init(&opriv->circ, NULL,
+                     upper->nums * sizeof(struct keyboard_event_s));
   if (ret < 0)
     {
       kmm_free(opriv);


### PR DESCRIPTION
Buffer nums is not multiplied by the structure size

## Summary

## Impact

## Testing

