### PR TITLE
fix wait after vfork return error

### DIFF
--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -1457,6 +1457,7 @@ void nxsched_get_stateinfo(FAR struct tcb_s *tcb, FAR char *state,
  *   pid - The task ID of the thread to waid for
  *   stat_loc - The location to return the exit status
  *   options - ignored
+ *   release - Wheather release exited child process infomation
  *
  * Returned Value:
  *   If nxsched_waitpid() returns because the status of a child process is
@@ -1485,7 +1486,8 @@ void nxsched_get_stateinfo(FAR struct tcb_s *tcb, FAR char *state,
  ****************************************************************************/
 
 #ifdef CONFIG_SCHED_WAITPID
-pid_t nxsched_waitpid(pid_t pid, FAR int *stat_loc, int options);
+pid_t nxsched_waitpid(pid_t pid, FAR int *stat_loc, int options,
+                      bool release);
 #endif
 
 /****************************************************************************

--- a/libs/libc/unistd/lib_vfork.c
+++ b/libs/libc/unistd/lib_vfork.c
@@ -23,6 +23,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/sched.h>
 
 #include <unistd.h>
 #include <sys/wait.h>
@@ -63,10 +64,11 @@ pid_t vfork(void)
        * until running finished or performing exec
        */
 
-      ret = waitpid(pid, &status, 0);
+      ret = nxsched_waitpid(pid, &status, 0, false);
       if (ret < 0)
         {
-          serr("ERROR: waitpid failed: %d\n", get_errno());
+          set_errno(-ret);
+          serr("ERROR: waitpid failed: %d\n", -ret);
         }
     }
 


### PR DESCRIPTION
## Summary
This change corrects the -ECHILD error in the following situation:

First, in nuttx implement, vfork use waitpid to hang on the parent process, make it continue after child process ended.
https://github.com/apache/nuttx/blob/d98bfc3e49b55ad560907241cbd7e184cf7aac0a/libs/libc/unistd/lib_vfork.c#L66

Second, this waitpid will make sure child process ended and remove the child process info in nxsched_waitpid.
https://github.com/apache/nuttx/blob/d98bfc3e49b55ad560907241cbd7e184cf7aac0a/sched/sched/sched_waitpid.c#L361

In the end, if application call wait will find NO child process info in 
https://github.com/apache/nuttx/blob/d98bfc3e49b55ad560907241cbd7e184cf7aac0a/sched/sched/sched_waitpid.c#L264

In one world, it looks like vfork interface implement not support to wait vforked child process done, because we don't keep the vforked process info after it end(But the use of wait in parent process after vfork is so common).

## Impact

## Testing
sim
