### PR TITLE
usrsock_server: coverity fix for access invalid index

### DIFF
--- a/drivers/usrsock/usrsock_rpmsg_server.c
+++ b/drivers/usrsock/usrsock_rpmsg_server.c
@@ -494,7 +494,7 @@ out:
     }
 
   retr = usrsock_rpmsg_send_ack(ept, events, req->head.xid, ret);
-  if (retr >= 0 && events == 0)
+  if (retr >= 0 && (ret > 0 || ret == -EAGAIN) && events == 0)
     {
       usrsock_rpmsg_poll_setup(&priv->pfds[req->usockid],
                                priv->pfds[req->usockid].events | POLLOUT);


### PR DESCRIPTION

## Summary
req->usockid maybe < 0 or > CONFIG_NET_USRSOCK_RPMSG_SERVER_NSOCKS, if so , priv->pfds[req->usockid] will access invalid memory.

## Impact

## Testing
sim:local
