### PR TITLE
rpmsgdev: support single read/write mode device

### DIFF
--- a/boards/sim/sim/sim/src/sim_bringup.c
+++ b/boards/sim/sim/sim/src/sim_bringup.c
@@ -469,9 +469,9 @@ int sim_bringup(void)
 #endif
 
 #ifdef CONFIG_DEV_RPMSG
-  rpmsgdev_register("server", "/dev/console", "/dev/server-console");
-  rpmsgdev_register("server", "/dev/null", "/dev/server-null");
-  rpmsgdev_register("server", "/dev/ttyUSB0", "/dev/ttyUSB0");
+  rpmsgdev_register("server", "/dev/console", "/dev/server-console", 0);
+  rpmsgdev_register("server", "/dev/null", "/dev/server-null", 0);
+  rpmsgdev_register("server", "/dev/ttyUSB0", "/dev/ttyUSB0", 0);
 #endif
 
 #ifdef CONFIG_BLK_RPMSG

--- a/drivers/misc/rpmsgdev.h
+++ b/drivers/misc/rpmsgdev.h
@@ -39,11 +39,12 @@
 #define RPMSGDEV_OPEN            1
 #define RPMSGDEV_CLOSE           2
 #define RPMSGDEV_READ            3
-#define RPMSGDEV_WRITE           4
-#define RPMSGDEV_LSEEK           5
-#define RPMSGDEV_IOCTL           6
-#define RPMSGDEV_POLL            7
-#define RPMSGDEV_NOTIFY          8
+#define RPMSGDEV_READ_NOFRAG     4
+#define RPMSGDEV_WRITE           5
+#define RPMSGDEV_LSEEK           6
+#define RPMSGDEV_IOCTL           7
+#define RPMSGDEV_POLL            8
+#define RPMSGDEV_NOTIFY          9
 
 /****************************************************************************
  * Public Types

--- a/drivers/misc/rpmsgdev_server.c
+++ b/drivers/misc/rpmsgdev_server.c
@@ -115,13 +115,14 @@ static int  rpmsgdev_ept_cb(FAR struct rpmsg_endpoint *ept,
 
 static const rpmsg_ept_cb g_rpmsgdev_handler[] =
 {
-  [RPMSGDEV_OPEN]  = rpmsgdev_open_handler,
-  [RPMSGDEV_CLOSE] = rpmsgdev_close_handler,
-  [RPMSGDEV_READ]  = rpmsgdev_read_handler,
-  [RPMSGDEV_WRITE] = rpmsgdev_write_handler,
-  [RPMSGDEV_LSEEK] = rpmsgdev_lseek_handler,
-  [RPMSGDEV_IOCTL] = rpmsgdev_ioctl_handler,
-  [RPMSGDEV_POLL]  = rpmsgdev_poll_handler,
+  [RPMSGDEV_OPEN]        = rpmsgdev_open_handler,
+  [RPMSGDEV_CLOSE]       = rpmsgdev_close_handler,
+  [RPMSGDEV_READ]        = rpmsgdev_read_handler,
+  [RPMSGDEV_READ_NOFRAG] = rpmsgdev_read_handler,
+  [RPMSGDEV_WRITE]       = rpmsgdev_write_handler,
+  [RPMSGDEV_LSEEK]       = rpmsgdev_lseek_handler,
+  [RPMSGDEV_IOCTL]       = rpmsgdev_ioctl_handler,
+  [RPMSGDEV_POLL]        = rpmsgdev_poll_handler,
 };
 
 /****************************************************************************
@@ -227,7 +228,7 @@ static int rpmsgdev_read_handler(FAR struct rpmsg_endpoint *ept,
 
       rsp->header.result = ret;
       rpmsg_send_nocopy(ept, rsp, (ret < 0 ? 0 : ret) + sizeof(*rsp) - 1);
-      if (ret <= 0)
+      if (ret <= 0 || msg->header.command == RPMSGDEV_READ_NOFRAG)
         {
           break;
         }

--- a/include/nuttx/drivers/rpmsgdev.h
+++ b/include/nuttx/drivers/rpmsgdev.h
@@ -28,6 +28,13 @@
 #include <nuttx/config.h>
 
 /****************************************************************************
+ * Pre-processor definitions
+ ****************************************************************************/
+
+#define RPMSGDEV_NOFRAG_READ  0x1
+#define RPMSGDEV_NOFRAG_WRITE 0x2
+
+/****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
 
@@ -71,6 +78,9 @@ int rpmsgdev_server_init(void);
  *   localpath  - the device path in local cpu, if NULL, the localpath is
  *                same as the remotepath, provide this argument to supoort
  *                custom device path
+ *   flags      - RPMSGDEV_NOFRAG_READ and RPMSGDEV_NOFRAG_WRITE can be set
+ *                to indicates that the read and write data of the device
+ *                cannot be split or aggregated
  *
  * Returned Values:
  *   OK on success; A negated errno value is returned on any failure.
@@ -79,7 +89,7 @@ int rpmsgdev_server_init(void);
 
 #ifdef CONFIG_DEV_RPMSG
 int rpmsgdev_register(FAR const char *remotecpu, FAR const char *remotepath,
-                      FAR const char *localpath);
+                      FAR const char *localpath, uint32_t flags);
 #endif
 
 #undef EXTERN


### PR DESCRIPTION
## Summary
The default mode for Rpmsgdev is to read/write data as long as possible for caller, this mode does not apply to tun devices, tun devices can read and write only one complete ip packet at a time.
## Impact

## Testing
Cortex-M33
