### PR TITLE
tun: move tun related macro definitions out of CONFIG_NET_TUN

### DIFF
--- a/include/nuttx/net/tun.h
+++ b/include/nuttx/net/tun.h
@@ -46,8 +46,6 @@
 #include <nuttx/config.h>
 #include <nuttx/net/ioctl.h>
 
-#ifdef CONFIG_NET_TUN
-
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -58,6 +56,8 @@
 #define IFF_TAP          0x02
 #define IFF_MASK         0x7f
 #define IFF_NO_PI        0x80
+
+#ifdef CONFIG_NET_TUN
 
 /****************************************************************************
  * Public Type Definitions


### PR DESCRIPTION
## Summary
to support cross-core tun device operations via rpmsgdev

## Impact

## Testing
Arm Cortex-M33
