### PR TITLE
Revert "sim: Fix sim stack smashing problem"

### DIFF
--- a/arch/sim/src/sim/sim_initialstate.c
+++ b/arch/sim/src/sim/sim_initialstate.c
@@ -32,25 +32,7 @@
 
 #include <nuttx/arch.h>
 
-#include "sched/sched.h"
 #include "sim_internal.h"
-
-/****************************************************************************
- * Private Functions
- ****************************************************************************/
-
-static void pre_start(void)
-{
-  struct tcb_s *tcb = this_task();
-
-  /* Enable signal delivery */
-
-  up_irq_restore(0);
-
-  /* Then call the real start function */
-
-  tcb->start();
-}
 
 /****************************************************************************
  * Public Functions
@@ -111,11 +93,7 @@ void up_initial_state(struct tcb_s *tcb)
 #endif
                                    + tcb->adj_stack_size;
 
-  /* Mask the interrupt until switching to the new task */
-
-  memset(&tcb->xcp.regs[JB_FLAG], 0xff, sizeof(xcpt_reg_t) * 2);
-
-  tcb->xcp.regs[JB_PC] = (xcpt_reg_t)pre_start;
+  tcb->xcp.regs[JB_PC] = (xcpt_reg_t)tcb->start;
 
 #ifdef CONFIG_SIM_ASAN
   __asan_unpoison_memory_region(tcb->stack_alloc_ptr, tcb->adj_stack_size);


### PR DESCRIPTION
Reverts apache/nuttx#10128, since data corruption happens with sim:smp.

