### PR TITLE
math api support FFT

### DIFF
--- a/drivers/math/CMakeLists.txt
+++ b/drivers/math/CMakeLists.txt
@@ -18,6 +18,6 @@
 #
 # ##############################################################################
 
-if(CONFIG_MATH_CORDIC)
-  target_sources(drivers PRIVATE cordic.c)
+if(CONFIG_MATH_CORDIC OR CONFIG_MATH_FFT)
+  target_sources(drivers PRIVATE math.c)
 endif()

--- a/drivers/math/Kconfig
+++ b/drivers/math/Kconfig
@@ -25,4 +25,11 @@ endchoice
 
 endif
 
-endmenu # MATH Acceleration Information
+config MATH_FFT
+	bool "MATH FFT support"
+	default n
+	---help---
+		This selection enables building of the "upper-half" FFT driver.
+		See include/nuttx/math/fft.h for further FFT driver information.
+
+endmenu  # MATH Acceleration Information

--- a/drivers/math/Make.defs
+++ b/drivers/math/Make.defs
@@ -21,7 +21,7 @@
 # Include CORDIC support
 
 ifeq ($(CONFIG_MATH_CORDIC),y)
-CSRCS += cordic.c
+CSRCS += math.c
 endif
 
 # Include build support

--- a/drivers/math/Make.defs
+++ b/drivers/math/Make.defs
@@ -18,9 +18,9 @@
 #
 ############################################################################
 
-# Include CORDIC support
+# Include math acceleration support
 
-ifeq ($(CONFIG_MATH_CORDIC),y)
+ifneq ($(CONFIG_MATH_CORDIC)$(CONFIG_MATH_FFT),)
 CSRCS += math.c
 endif
 

--- a/drivers/math/math.c
+++ b/drivers/math/math.c
@@ -139,6 +139,19 @@ static int math_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
           break;
         }
+
+      case MATHIOC_FFT_CALC:
+        {
+          FAR struct fft_calc_s *calc =
+            (FAR struct fft_calc_s *)((uintptr_t)arg);
+
+          if (upper->fft != NULL)
+            {
+              ret = upper->fft->ops->calc(upper->fft, calc);
+            }
+
+          break;
+        }
     }
 
   leave_critical_section(flags);
@@ -198,7 +211,7 @@ errout:
  * Name: cordic_register
  *
  * Description:
- *   Register a CORDIC driver. Deprecated, use math_register instead!
+ *   Register a CORDIC driver.
  *
  ****************************************************************************/
 
@@ -209,6 +222,25 @@ int cordic_register(FAR const char *path,
 
   memset(&config, 0, sizeof(config));
   config.cordic = lower;
+
+  return math_register(path, &config);
+}
+
+/****************************************************************************
+ * Name: fft_register
+ *
+ * Description:
+ *   Register a FFT driver.
+ *
+ ****************************************************************************/
+
+int fft_register(FAR const char *path,
+                    FAR struct fft_lowerhalf_s *lower)
+{
+  struct math_config_s config;
+
+  memset(&config, 0, sizeof(config));
+  config.fft = lower;
 
   return math_register(path, &config);
 }

--- a/include/nuttx/math/fft.h
+++ b/include/nuttx/math/fft.h
@@ -1,0 +1,137 @@
+/****************************************************************************
+ * include/nuttx/math/fft.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_NUTTX_MATH_FFT_H
+#define __INCLUDE_NUTTX_MATH_FFT_H
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/* fft/dct request type definition
+ * FFT, fft for fast fourier transform
+ * DCT, dct for discrete cosine transform
+ * DCT-II, the normally so called DCT
+ * DCT-III, inverse of DCT-II, so called IDCT
+ * DCT-IV, inverse of DCT-IV is itself
+ * see all the formula and more mathmatics trueth in wikipedia:
+ * https://en.wikipedia.org/wiki/Discrete_cosine_transform
+ */
+
+typedef enum
+{
+  MATH_FFT        = 0,  /* FFT */
+  MATH_DCT_TYPE_2 = 1,  /* DCT-II */
+  MATH_DCT_TYPE_3 = 2,  /* DCT-III */
+  MATH_DCT_TYPE_4 = 3,  /* DCT-IV */
+} fft_type;
+
+/* fft calculate request */
+
+struct fft_calc_s
+{
+  fft_type type;
+
+  /* fft/dct bit width
+   * power of 2, range from 8 to 32
+   */
+
+  size_t bitwidth;
+
+  /* input data, address must be 4 bytes aligned */
+
+  FAR const void *input_data;
+
+  /* output data, address must be 4 bytes aligned */
+
+  FAR void *output_data;
+
+  /* FFT Length, power of 2
+   * fft support 16 to 4096
+   * dct support 8 to 256
+   */
+
+  size_t fft_length;
+
+  /* Real flag. true: real fft/dct, false: complex fft/dct. */
+
+  bool real;
+
+  /* Inverse flag. true: ifft/idct, false: fft/dct */
+
+  bool inverse;
+};
+
+/* This structure provides the "lower-half" driver operations available to
+ * the "upper-half" driver.
+ */
+
+struct fft_lowerhalf_s;
+struct fft_ops_s
+{
+  /* FFT calculate request */
+
+  CODE int (*calc)(FAR struct fft_lowerhalf_s *lower,
+                   FAR struct fft_calc_s *calc);
+};
+
+/* This structure provides the publicly visible representation of the
+ * "lower-half" driver state structure.  "lower half" drivers will have an
+ * internal structure definition that will be cast-compatible with this
+ * structure definitions.
+ */
+
+struct fft_lowerhalf_s
+{
+  /* Publicly visible portion of the "lower-half" driver state structure. */
+
+  FAR const struct fft_ops_s *ops;  /* Lower half operations */
+};
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Name: fft_register
+ *
+ * Description:
+ *   Register a FFT driver.
+ *
+ ****************************************************************************/
+
+int fft_register(FAR const char *path,
+                 FAR struct fft_lowerhalf_s *lower);
+
+#undef EXTERN
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* __INCLUDE_NUTTX_MATH_FFT_H */

--- a/include/nuttx/math/math.h
+++ b/include/nuttx/math/math.h
@@ -26,6 +26,7 @@
  ****************************************************************************/
 
 #include <nuttx/math/cordic.h>
+#include <nuttx/math/fft.h>
 
 /****************************************************************************
  * Public Types
@@ -39,6 +40,7 @@
 struct math_config_s
 {
   FAR struct cordic_lowerhalf_s *cordic;
+  FAR struct fft_lowerhalf_s    *fft;
 };
 
 /****************************************************************************

--- a/include/nuttx/math/math.h
+++ b/include/nuttx/math/math.h
@@ -1,0 +1,59 @@
+/****************************************************************************
+ * include/nuttx/math/math.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_NUTTX_MATH_MATH_H
+#define __INCLUDE_NUTTX_MATH_MATH_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/math/cordic.h>
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/* This math config struct provides the all "lower half" of math drivers.
+ * Each will have an internal structure definition that will be
+ * cast-compatible with this structure definitions.
+ */
+
+struct math_config_s
+{
+  FAR struct cordic_lowerhalf_s *cordic;
+};
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: math_register
+ *
+ * Description:
+ *   Register all math related drivers.
+ *
+ ****************************************************************************/
+
+int math_register(FAR const char *path,
+                  FAR const struct math_config_s *config);
+
+#endif /* __INCLUDE_NUTTX_MATH_MATH_H */

--- a/include/nuttx/math/math_ioctl.h
+++ b/include/nuttx/math/math_ioctl.h
@@ -39,5 +39,6 @@
  */
 
 #define MATHIOC_CORDIC_CALC     _MATHIOC(1)
+#define MATHIOC_FFT_CALC        _MATHIOC(2)
 
 #endif /* __INCLUDE_NUTTX_MATH_MATH_IOCTL_H */


### PR DESCRIPTION
## Summary
Support fft in nuttx/math, in general, I add a math.h to support math accelerators, including the existed cordic and new coming fft. And the ability for supporting more.

## Impact
nuttx/math

## Testing
nuttx/math/cordic.h, nuttx/math/fft.h are framework for chips, I implemented and test the framework below.

cordic hardware accelerator tested with stm32g431rb, sf32lb5xx
fft hardware accelerator tested with sf32lb5xx
