### PR TITLE
gdbstub:fix typo

### DIFF
--- a/libs/libc/gdbstub/lib_gdbstub.c
+++ b/libs/libc/gdbstub/lib_gdbstub.c
@@ -596,8 +596,8 @@ static ssize_t gdb_bin2hex(FAR void *buf, size_t buf_len,
  *
  ****************************************************************************/
 
-static int gdb_hex2bin(FAR void *buf, size_t buf_len,
-                       FAR const void *data, size_t data_len)
+static ssize_t gdb_hex2bin(FAR void *buf, size_t buf_len,
+                           FAR const void *data, size_t data_len)
 {
   FAR const char *in = data;
   FAR char *out = buf;
@@ -1220,12 +1220,12 @@ static int gdb_query(FAR struct gdb_state_s *state)
       nxsched_get_stateinfo(tcb, thread_state, sizeof(thread_state));
 #if CONFIG_TASK_NAME_SIZE > 0
       snprintf(thread_info, sizeof(thread_info),
-               "Name: %s, State: %s, Priority: %d, Stack: %d",
+               "Name: %s, State: %s, Priority: %d, Stack: %zu",
                 tcb->name, thread_state, tcb->sched_priority,
                 tcb->adj_stack_size);
 #else
       snprintf(thread_info, sizeof(thread_info),
-               "State: %s, Priority: %d, Stack: %d",
+               "State: %s, Priority: %d, Stack: %zu",
                thread_state, tcb->sched_priority,
                tcb->adj_stack_size);
 #endif
@@ -1557,3 +1557,4 @@ int gdb_process(FAR struct gdb_state_s *state)
 
   return ret;
 }
+


### PR DESCRIPTION
## Summary
gdbstub:fix typo
## Impact
gdbstub
## Testing
```
CC:  umm_heap/umm_zalloc.c gdbstub/lib_gdbstub.c:599:12: error: conflicting types for ‘gdb_hex2bin’; have ‘int(void *, size_t,  const void *, size_t)’ {aka ‘int(void *, long unsigned int,  const void *, long unsigned int)’}
  599 | static int gdb_hex2bin(FAR void *buf, size_t buf_len,
      |            ^~~~~~~~~~~
gdbstub/lib_gdbstub.c:102:16: note: previous declaration of ‘gdb_hex2bin’ with type ‘ssize_t(void *, size_t,  const void *, size_t)’ {aka ‘long int(void *, long unsigned int,  const void *, long unsigned int)’}
  102 | static ssize_t gdb_hex2bin(FAR void *buf, size_t buf_len,
      |                ^~~~~~~~~~~
gdbstub/lib_gdbstub.c: In function ‘gdb_write_memory’:
gdbstub/lib_gdbstub.c:1079:38: warning: passing argument 6 of ‘gdb_put_memory’ from incompatible pointer type [-Wincompatible-pointer-types]
 1079 |                        addr, length, gdb_hex2bin);
      |                                      ^~~~~~~~~~~
      |                                      |
      |                                      int (*)(void *, size_t,  const void *, size_t) {aka int (*)(void *, long unsigned int,  const void *, long unsigned int)}
gdbstub/lib_gdbstub.c:743:49: note: expected ‘gdb_format_func_t’ {aka ‘long int (*)(void *, long unsigned int,  const void *, long unsigned int)’} but argument is of type ‘int (*)(void *, size_t,  const void *, size_t)’ {aka ‘int (*)(void *, long unsigned int,  const void *, long unsigned int)’}
  743 |                               gdb_format_func_t format)
      |                               ~~~~~~~~~~~~~~~~~~^~~~~~
gdbstub/lib_gdbstub.c: In function ‘gdb_query’:
gdbstub/lib_gdbstub.c:1223:60: warning: format ‘%d’ expects argument of type ‘int’, but argument 7 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
 1223 |                "Name: %s, State: %s, Priority: %d, Stack: %d",
      |                                                           ~^
      |                                                            |
      |                                                            int
      |                                                           %ld
 1224 |                 tcb->name, thread_state, tcb->sched_priority,
 1225 |                 tcb->adj_stack_size);
      |                 ~~~~~~~~~~~~~~~~~~~
      |                    |
      |                    size_t {aka long unsigned int}
```
