### PR TITLE
sim: use correct size to avoid buffer overflow

### DIFF
--- a/arch/sim/src/sim/sim_initialstate.c
+++ b/arch/sim/src/sim/sim_initialstate.c
@@ -113,7 +113,7 @@ void up_initial_state(struct tcb_s *tcb)
 
   /* Mask the interrupt until switching to the new task */
 
-  memset(&tcb->xcp.regs[JB_FLAG], 0xff, sizeof(xcpt_reg_t) * 2);
+  memset(&tcb->xcp.regs[JB_FLAG], 0xff, sizeof(uint32_t) * 2);
 
   tcb->xcp.regs[JB_PC] = (xcpt_reg_t)pre_start;
 


### PR DESCRIPTION
## Summary
In last PR #10128, the sizeof xcpt_reg_t is different on 32/64 bit platform. Fix it here
Report by https://github.com/apache/nuttx/pull/10178.

## Impact

## Testing

sim:smp
