### PR TITLE
arm/stm32h7: stm32h7x5: fixed typo on SPI header inclusion

### DIFF
--- a/arch/arm/src/stm32h7/hardware/stm32_spi.h
+++ b/arch/arm/src/stm32h7/hardware/stm32_spi.h
@@ -32,7 +32,7 @@
 #  include "hardware/stm32h7x3xx_spi.h"
 #elif defined(CONFIG_STM32H7_STM32H7B3XX)
 #  include "hardware/stm32h7x3xx_spi.h"
-#elif defined(CONFIG_STM32H7_STM32H7X3XX)
+#elif defined(CONFIG_STM32H7_STM32H7X5XX)
 #  include "hardware/stm32h7x3xx_spi.h"
 #elif defined(CONFIG_STM32H7_STM32H7X7XX)
 #  include "hardware/stm32h7x3xx_spi.h"


### PR DESCRIPTION
## Summary

It was the following compilation error if CONFIG_STM32H7_FMC=y:
`chip/hardware/stm32_spi.h:40:4: error: #error "Unsupported STM32 H7 sub family"`

It is related to #9796.

## Impact

arm/stm32h7 (CONFIG_STM32H7_STM32H7X5XX)

## Testing

./tools/configure.sh -l stm32h745i-disco:nsh (with CONFIG_STM32H7_FMC enabled)