### PR TITLE
sched/semaphore: Remove restriction to use nxsem_trywait from ISR

### DIFF
--- a/sched/semaphore/sem_trywait.c
+++ b/sched/semaphore/sem_trywait.c
@@ -70,10 +70,11 @@ int nxsem_trywait(FAR sem_t *sem)
   irqstate_t flags;
   int ret;
 
-  /* This API should not be called from interrupt handlers & idleloop */
+  /* This API should not be called from the idleloop */
 
-  DEBUGASSERT(sem != NULL && up_interrupt_context() == false);
-  DEBUGASSERT(!OSINIT_IDLELOOP() || !sched_idletask());
+  DEBUGASSERT(sem != NULL);
+  DEBUGASSERT(!OSINIT_IDLELOOP() || !sched_idletask() ||
+              up_interrupt_context());
 
   /* The following operations must be performed with interrupts disabled
    * because sem_post() may be called from an interrupt handler.


### PR DESCRIPTION
## Summary

* sched/semaphore: Remove restriction to use nxsem_trywait from ISR

It could be called from the interrupt handler because `nxsem_trywait` is non-blocking, although not recommended.

## Impact

Enable applications to call this interface (with `CONFIG_DEBUG_ASSERTIONS` enabled) without problems. No impact for current implementations.

## Testing

Internal CI testing + NuttX CI.