### PR TITLE
builtin: support uid/gid config for binfs app

### DIFF
--- a/binfmt/builtin.c
+++ b/binfmt/builtin.c
@@ -106,6 +106,12 @@ static int builtin_loadbinary(FAR struct binary_s *binp,
   binp->entrypt   = builtin->main;
   binp->stacksize = builtin->stacksize;
   binp->priority  = builtin->priority;
+#ifdef CONFIG_SCHED_USER_IDENTITY
+  binp->uid       = builtin->uid;
+  binp->gid       = builtin->gid;
+  binp->mode      = builtin->mode;
+#endif
+
   return OK;
 }
 

--- a/include/nuttx/lib/builtin.h
+++ b/include/nuttx/lib/builtin.h
@@ -40,6 +40,11 @@ struct builtin_s
   int         priority;     /* Use: SCHED_PRIORITY_DEFAULT */
   int         stacksize;    /* Desired stack size */
   main_t      main;         /* Entry point: main(int argc, char *argv[]) */
+#ifdef CONFIG_SCHED_USER_IDENTITY
+  uid_t       uid;          /* File owner user identity */
+  gid_t       gid;          /* File owner group identity */
+  int         mode;         /* File mode added to */
+#endif
 };
 
 /****************************************************************************
@@ -170,6 +175,64 @@ FAR const char *builtin_getname(int index);
  ****************************************************************************/
 
 FAR const struct builtin_s *builtin_for_index(int index);
+
+#ifdef CONFIG_SCHED_USER_IDENTITY
+
+/****************************************************************************
+ * Name: builtin_getuid
+ *
+ * Description:
+ *   Returns file uid of the application at 'index' in the table
+ *   of built-in applications.
+ *
+ * Input Parameters:
+ *   index - From 0 and on ...
+ *
+ * Returned Value:
+ *   Returns valid uid for app if index is valid.
+ *   Otherwise 0 is returned.
+ *
+ ****************************************************************************/
+
+uid_t builtin_getuid(int index);
+
+/****************************************************************************
+ * Name: builtin_getgid
+ *
+ * Description:
+ *   Returns file gid of the application at 'index' in the table
+ *   of built-in applications.
+ *
+ * Input Parameters:
+ *   index - From 0 and on ...
+ *
+ * Returned Value:
+ *   Returns valid gid for app if index is valid.
+ *   Otherwise 0 is returned.
+ *
+ ****************************************************************************/
+
+gid_t builtin_getgid(int index);
+
+/****************************************************************************
+ * Name: builtin_getmode
+ *
+ * Description:
+ *   Returns file mode of the application at 'index' in the table
+ *   of built-in applications.
+ *
+ * Input Parameters:
+ *   index - From 0 and on ...
+ *
+ * Returned Value:
+ *   Returns valid mode for app if index is valid.
+ *   Otherwise 0 is returned.
+ *
+ ****************************************************************************/
+
+int builtin_getmode(int index);
+
+#endif
 
 #undef EXTERN
 #if defined(__cplusplus)

--- a/libs/libc/builtin/Make.defs
+++ b/libs/libc/builtin/Make.defs
@@ -28,6 +28,10 @@ ifeq ($(CONFIG_BUILD_PROTECTED),y)
 CSRCS += lib_builtin_setlist.c
 endif
 
+ifeq ($(CONFIG_SCHED_USER_IDENTITY),y)
+CSRCS += lib_builtin_getuid.c lib_builtin_getgid.c lib_builtin_getmode.c
+endif
+
 # Hook the builtin subdirectory into the build
 
 DEPPATH += --dep-path builtin

--- a/libs/libc/builtin/lib_builtin_getgid.c
+++ b/libs/libc/builtin/lib_builtin_getgid.c
@@ -1,0 +1,63 @@
+/****************************************************************************
+ * libs/libc/builtin/lib_builtin_getgid.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <nuttx/lib/builtin.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: builtin_getgid
+ *
+ * Description:
+ *   Returns file gid of the application at 'index' in the table
+ *   of built-in applications.
+ *
+ * Input Parameters:
+ *   index - From 0 and on ...
+ *
+ * Returned Value:
+ *   Returns valid gid for app if index is valid.
+ *   Otherwise 0 is returned.
+ *
+ ****************************************************************************/
+
+gid_t builtin_getgid(int index)
+{
+  FAR const struct builtin_s *builtin;
+
+  builtin = builtin_for_index(index);
+
+  if (builtin != NULL)
+    {
+      return builtin->gid;
+    }
+
+  /* Return group user identity 'root' with a gid value of 0. */
+
+  return 0;
+}

--- a/libs/libc/builtin/lib_builtin_getmode.c
+++ b/libs/libc/builtin/lib_builtin_getmode.c
@@ -1,0 +1,63 @@
+/****************************************************************************
+ * libs/libc/builtin/lib_builtin_getmode.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <nuttx/lib/builtin.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: builtin_getmode
+ *
+ * Description:
+ *   Returns file mode of the application at 'index' in the table
+ *   of built-in applications.
+ *
+ * Input Parameters:
+ *   index - From 0 and on ...
+ *
+ * Returned Value:
+ *   Returns valid mode for app if index is valid.
+ *   Otherwise 0 is returned.
+ *
+ ****************************************************************************/
+
+int builtin_getmode(int index)
+{
+  FAR const struct builtin_s *builtin;
+
+  builtin = builtin_for_index(index);
+
+  if (builtin != NULL)
+    {
+      return builtin->mode;
+    }
+
+  /* Return the default mode value of 0. */
+
+  return 0;
+}

--- a/libs/libc/builtin/lib_builtin_getuid.c
+++ b/libs/libc/builtin/lib_builtin_getuid.c
@@ -1,0 +1,63 @@
+/****************************************************************************
+ * libs/libc/builtin/lib_builtin_getuid.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <nuttx/lib/builtin.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: builtin_getuid
+ *
+ * Description:
+ *   Returns file uid of the application at 'index' in the table
+ *   of built-in applications.
+ *
+ * Input Parameters:
+ *   index - From 0 and on ...
+ *
+ * Returned Value:
+ *   Returns valid uid for app if index is valid.
+ *   Otherwise 0 is returned.
+ *
+ ****************************************************************************/
+
+uid_t builtin_getuid(int index)
+{
+  FAR const struct builtin_s *builtin;
+
+  builtin = builtin_for_index(index);
+
+  if (builtin != NULL)
+    {
+      return builtin->uid;
+    }
+
+  /* Return user identity 'root' with a uid value of 0. */
+
+  return 0;
+}


### PR DESCRIPTION
Implement I_SUID/I_SGID feature for binfs in the POSIX compliant way. If set-user-ID bit is set in the file permissions, then the effective user ID of process shall be set to UID of the new process image file.

test case:
hello example emulates to set uid and file set-user-ID bit, and call geteuid and getegid API.
UID  = 2000
GID  = 3000
MODE = S_ISUID|S_ISGID

nsh> ls -l /bin/hello
 ---s--s--x    2000    3000       0 hello
nsh> hello
geteuid:2000
getegid:3000

## Summary

## Impact

## Testing
sim & pass CI
