### PR TITLE
arch/armv7-a: Update the macro definition in gic.h 

### DIFF
--- a/arch/arm/src/armv7-a/arm_gicv2.c
+++ b/arch/arm/src/armv7-a/arm_gicv2.c
@@ -145,7 +145,7 @@ void arm_gic_initialize(void)
   /* Registers with 1-bit per interrupt */
 
   putreg32(0x00000000, GIC_ICDISR(0));      /* SGIs and PPIs secure */
-  putreg32(0xf8000000, GIC_ICDICER(0));     /* PPIs disabled */
+  putreg32(0xfe000000, GIC_ICDICER(0));     /* PPIs disabled */
 
   /* Registers with 8-bits per interrupt */
 
@@ -153,7 +153,7 @@ void arm_gic_initialize(void)
   putreg32(0x80808080, GIC_ICDIPR(4));      /* SGI[4:7] priority */
   putreg32(0x80808080, GIC_ICDIPR(8));      /* SGI[8:11] priority */
   putreg32(0x80808080, GIC_ICDIPR(12));     /* SGI[12:15] priority */
-  putreg32(0x80000000, GIC_ICDIPR(24));     /* PPI[0] priority */
+  putreg32(0x80808000, GIC_ICDIPR(24));     /* PPI[0] priority */
   putreg32(0x80808080, GIC_ICDIPR(28));     /* PPI[1:4] priority */
 
   /* Set the binary point register.
@@ -501,10 +501,10 @@ int up_prioritize_irq(int irq, int priority)
        * distributor Interrupt Priority Register (GIC_ICDIPR).
        */
 
-      regaddr  = GIC_ICDIPR(irq);
-      regval   = getreg32(regaddr);
-      regval  &= ~GIC_ICDIPR_ID_MASK(irq);
-      regval  |= GIC_ICDIPR_ID(irq, priority);
+      regaddr = GIC_ICDIPR(irq);
+      regval  = getreg32(regaddr);
+      regval &= ~GIC_ICDIPR_ID_MASK(irq);
+      regval |= GIC_ICDIPR_ID(irq, priority);
       putreg32(regval, regaddr);
 
       arm_gic_dump("Exit up_prioritize_irq", false, irq);

--- a/arch/arm/src/armv7-a/arm_gicv2_dump.c
+++ b/arch/arm/src/armv7-a/arm_gicv2_dump.c
@@ -226,7 +226,7 @@ static inline void arm_gic_dump_distributor(bool all, int irq, int nlines)
       arm_gic_dump4("IPTR", GIC_ICDIPTR(0), nlines);
       arm_gic_dump16("ICFR", GIC_ICDICFR(0), nlines);
       arm_gic_dump32("PPSIR/SPISR", GIC_ICDPPISR, nlines);
-      arm_gic_dump32("NSACR", GIC_ICDNSACR(0), nlines);
+      arm_gic_dump16("NSACR", GIC_ICDNSACR(0), nlines);
       arm_gic_dump8("SCPR/SSPR", GIC_ICDSCPR(0), nlines);
     }
   else

--- a/arch/arm/src/armv7-a/arm_timer.c
+++ b/arch/arm/src/armv7-a/arm_timer.c
@@ -279,8 +279,8 @@ struct oneshot_lowerhalf_s *arm_timer_initialize(unsigned int freq)
   arm_timer_set_ctrl(ctrl);
 
 #if defined(CONFIG_ARCH_TRUSTZONE_SECURE) || defined(CONFIG_ARCH_TRUSTZONE_BOTH)
-  irq_attach(GIC_IRQ_SEPTM, arm_timer_interrupt, lower);
-  up_enable_irq(GIC_IRQ_SEPTM);
+  irq_attach(GIC_IRQ_STM, arm_timer_interrupt, lower);
+  up_enable_irq(GIC_IRQ_STM);
 #else
   irq_attach(GIC_IRQ_PTM, arm_timer_interrupt, lower);
   up_enable_irq(GIC_IRQ_PTM);

--- a/arch/arm/src/armv7-a/gic.h
+++ b/arch/arm/src/armv7-a/gic.h
@@ -188,17 +188,13 @@
 
 /* Non-secure Access Control Registers, optional: 00xe00-0x0efc */
 
-#define GIC_ICDNSACR_OFFSET(n)     (0x0e00 + GIC_OFFSET32(n))
+#define GIC_ICDNSACR_OFFSET(n)     (0x0e00 + GIC_OFFSET16(n))
 
 /* Software Generated Interrupt Register: 0x0f00 */
 
 #define GIC_ICDSGIR_OFFSET         0x0f00    /* Software Generated Interrupt Register */
 
-/* 0x0f0c-0x0f0c: Reserved */
-
-/* Peripheral Identification Registers: 0x0fd0-0xfe8 */
-
-#define GIC_ICDPIDR_OFFSET(n)      (0x0fd0 + ((n) << 2))
+/* 0x0f04-0x0f0c: Reserved */
 
 /* SGI Clear-Pending Registers: 0x0f10-0x0f1c */
 
@@ -212,11 +208,13 @@
 
 /* 0x0fd0-0x0ffc: Implementation defined */
 
+/* Peripheral Identification Registers: 0x0fd0-0xfe8 */
+
+#define GIC_ICDPIDR_OFFSET(n)      (0x0fd0 + ((n) << 2))
+
 /* Component Identification Registers: 0x0ff0-0x0ffc */
 
 #define GIC_ICDCIDR_OFFSET(n)      (0x0ff0 + ((n) << 2))
-
-/* 0x0f04-0x0ffc: Reserved */
 
 /* GIC Register Addresses ***************************************************/
 
@@ -269,9 +267,9 @@
 #define GIC_ICDSPISR(n)            (MPCORE_ICD_VBASE+GIC_ICDSPISR_OFFSET(n))
 #define GIC_ICDNSACR(n)            (MPCORE_ICD_VBASE+GIC_ICDNSACR_OFFSET(n))
 #define GIC_ICDSGIR                (MPCORE_ICD_VBASE+GIC_ICDSGIR_OFFSET)
-#define GIC_ICDPIDR(n)             (MPCORE_ICD_VBASE+GIC_ICDPIDR_OFFSET(n))
 #define GIC_ICDSCPR(n)             (MPCORE_ICD_VBASE+GIC_ICDSCPR_OFFSET(n))
 #define GIC_ICDSSPR(n)             (MPCORE_ICD_VBASE+GIC_ICDSSPR_OFFSET(n))
+#define GIC_ICDPIDR(n)             (MPCORE_ICD_VBASE+GIC_ICDPIDR_OFFSET(n))
 #define GIC_ICDCIDR(n)             (MPCORE_ICD_VBASE+GIC_ICDCIDR_OFFSET(n))
 
 /* GIC Register Bit Definitions *********************************************/
@@ -332,8 +330,8 @@
 #define GIC_ICCBPR_MASK            (7 << GIC_ICCBPR_SHIFT)
 #  define GIC_ICCBPR_1_7           (0 << GIC_ICCBPR_SHIFT) /* Priority bits [7:1] compared for pre-emption */
 #  define GIC_ICCBPR_2_7           (1 << GIC_ICCBPR_SHIFT) /* Priority bits [7:2] compared for pre-emption */
-#  define GIC_ICCBPR_3_7           (2 << GIC_ICCBPR_SHIFT) /* Priority bits [7:2] compared for pre-emption */
-#  define GIC_ICCBPR_4_7           (3 << GIC_ICCBPR_SHIFT) /* Priority bits [7:2] compared for pre-emption */
+#  define GIC_ICCBPR_3_7           (2 << GIC_ICCBPR_SHIFT) /* Priority bits [7:3] compared for pre-emption */
+#  define GIC_ICCBPR_4_7           (3 << GIC_ICCBPR_SHIFT) /* Priority bits [7:4] compared for pre-emption */
 #  define GIC_ICCBPR_5_7           (4 << GIC_ICCBPR_SHIFT) /* Priority bits [7:5] compared for pre-emption */
 #  define GIC_ICCBPR_6_7           (5 << GIC_ICCBPR_SHIFT) /* Priority bits [7:6] compared for pre-emption */
 #  define GIC_ICCBPR_7_7           (6 << GIC_ICCBPR_SHIFT) /* Priority bit [7] compared for pre-emption */
@@ -354,6 +352,7 @@
 
 /* End of Interrupt Register */
 
+#define GIC_ICCEOIR_SPURIOUSNS     (0x3fe)
 #define GIC_ICCEOIR_SPURIOUS       (0x3ff)
 
 #define GIC_ICCEOIR_INTID_SHIFT    (0)       /* Bits 0-9: Interrupt ID */
@@ -367,9 +366,8 @@
 
 /* Running Interrupt Register */
 
-                                             /* Bits 0-3: Reserved */
-#define GIC_ICCRPR_PRIO_SHIFT      (4)       /* Bits 4-7: Priority mask */
-#define GIC_ICCRPR_PRIO_MASK       (15 << GIC_ICCRPR_PRIO_SHIFT)
+#define GIC_ICCRPR_PRIO_SHIFT      (0)       /* Bits 0-7: Priority mask */
+#define GIC_ICCRPR_PRIO_MASK       (0xff << GIC_ICCRPR_PRIO_SHIFT)
 #  define GIC_ICCRPR_PRIO_VALUE(n) ((uint32_t)(n) << GIC_ICCRPR_PRIO_SHIFT)
 
                                              /* Bits 8-31: Reserved */
@@ -385,39 +383,6 @@
 
                                              /* Bits 13-31: Reserved */
 
-/* Aliased Interrupt Acknowledge Register */
-#define GIC_ICCAIAR_
-
-/* Aliased End of Interrupt Register */
-#define GIC_ICCAEOIR_
-
-/* Aliased Highest Priority Pending Interrupt Register */
-#define GIC_ICCAHPIR_
-
-/* Active Priorities Register 1 */
-#define GIC_ICCAPR1_
-
-/* Active Priorities Register 2 */
-#define GIC_ICCAPR2_
-
-/* Active Priorities Register 3 */
-#define GIC_ICCAPR3_
-
-/* Active Priorities Register 4 */
-#define GIC_ICCAPR4_
-
-/* Non-secure Active Priorities Register 1 */
-#define GIC_ICCNSAPR1_
-
-/* Non-secure Active Priorities Register 2 */
-#define GIC_ICCNSAPR2_
-
-/* Non-secure Active Priorities Register 3 */
-#define GIC_ICCNSAPR3_
-
-/* Non-secure Active Priorities Register 4 */
-#define GIC_ICCNSAPR4_
-
 /* CPU Interface Implementer ID Register */
 
 #define GIC_ICCIDR_IMPL_SHIFT      (0)       /* Bits 0-11:  Implementer */
@@ -430,7 +395,13 @@
 #define GIC_ICCIDR_PARTNO_MASK     (0xfff << GIC_ICCIDR_PARTNO_SHIFT)
 
 /* Deactivate Interrupt Register */
-#define GIC_ICCDIR_
+
+#define GIC_ICCDIR_INTID_SHIFT     (0)       /* Bits 0-9: Interrupt ID */
+#define GIC_ICCDIR_INTID_MASK      (0x3ff << GIC_ICCHPIR_INTID_SHIFT)
+#  define GIC_ICCDIR_INTID(n)      ((uint32_t)(n) << GIC_ICCHPIR_INTID_SHIFT)
+#define GIC_ICCDIR_CPUSRC_SHIFT    (10)      /* Bits 10-12: CPU source ID */
+#define GIC_ICCDIR_CPUSRC_MASK     (7 << GIC_ICCHPIR_CPUSRC_SHIFT)
+#  define GIC_ICCDIR_CPUSRC(n)     ((uint32_t)(n) << GIC_ICCHPIR_CPUSRC_SHIFT)
 
 /* Distributor Registers */
 
@@ -461,10 +432,13 @@
 
 #define GIC_ICDIIDR_IMPL_SHIFT      (0)      /* Bits 0-11: Implementer */
 #define GIC_ICDIIDR_IMPL_MASK       (0xfff << GIC_ICDIIDR_IMPL_SHIFT)
-#define GIC_ICDIIDR_REVISION_SHIFT  (12)     /* Bits 12-23: Revision number */
-#define GIC_ICDIIDR_REVISION_MASK   (0xfff << GIC_ICDIIDR_REVISION_SHIFT)
-#define GIC_ICDIIDR_VERSION_SHIFT   (24)     /* Bits 24-31: Iimplementer version */
-#define GIC_ICDIIDR_VERSION_MASK    (0xff << GIC_ICDIIDR_VERSION_SHIFT)
+#define GIC_ICDIIDR_REVISION_SHIFT  (12)     /* Bits 12-15: Revision number */
+#define GIC_ICDIIDR_REVISION_MASK   (0xf << GIC_ICDIIDR_REVISION_SHIFT)
+#define GIC_ICDIIDR_VARIANT_SHIFT   (16)     /* Bits 16-19 Variant number */
+#define GIC_ICDIIDR_VARIANT_MASK    (0xf << GIC_ICDIIDR_VARIANT_SHIFT)
+                                             /* Bits 20-23: Reserved */
+#define GIC_ICDIIDR_PRODUCTID_SHIFT (24)     /* Bits 24-31: Product id */
+#define GIC_ICDIIDR_PRODUCTID_MASK  (0xff << GIC_ICDIIDR_PRODUCTID_SHIFT)
 
 /* Interrupt Security Registers: 0x0080-0x009c */
 
@@ -548,29 +522,31 @@
 
 /* Non-secure Access Control Registers, optional */
 
-#define GIC_ICDNSACR_INT(n)        GIC_MASK32(n)
+#define GIC_ICDNSACR_NONE          0
+#define GIC_ICDNSACR_SET           1
+#define GIC_ICDNSACR_CLEAR         2
+#define GIC_ICDNSACR_ROUTE         3
+
+#define GIC_ICDNSACR_ID_SHIFT(n)   GIC_SHIFT16(n)
+#define GIC_ICDNSACR_ID_MASK(n)    GIC_MASK16(n)
+#  define GIC_ICDNSACR_ID(n,p)     ((uint32_t)(p) << GIC_SHIFT16(n))
 
 /* Software Generated Interrupt Register */
 
 #define GIC_ICDSGIR_INTID_SHIFT       (0)    /* Bits 0-9: Interrupt ID */
 #define GIC_ICDSGIR_INTID_MASK        (0x3ff << GIC_ICDSGIR_INTID_SHIFT)
 #  define GIC_ICDSGIR_INTID(n)        ((uint32_t)(n) << GIC_ICDSGIR_INTID_SHIFT)
-                                             /* Bits 10-15: Reserved */
+                                             /* Bits 10-14: Reserved */
+#define GIC_ICDSGIR_NSATT             (1 << 15)
 #define GIC_ICDSGIR_CPUTARGET_SHIFT   (16)   /* Bits 16-23: CPU target */
 #define GIC_ICDSGIR_CPUTARGET_MASK    (0xff << GIC_ICDSGIR_CPUTARGET_SHIFT)
 #  define GIC_ICDSGIR_CPUTARGET(n)    ((uint32_t)(n) << GIC_ICDSGIR_CPUTARGET_SHIFT)
-                                             /* Bits 26-31: Reserved */
 #define GIC_ICDSGIR_TGTFILTER_SHIFT   (24)   /* Bits 24-25: Target filter */
 #define GIC_ICDSGIR_TGTFILTER_MASK    (3 << GIC_ICDSGIR_TGTFILTER_SHIFT)
 #  define GIC_ICDSGIR_TGTFILTER_LIST  (0 << GIC_ICDSGIR_TGTFILTER_SHIFT) /* Interrupt sent to CPUs CPU target list */
 #  define GIC_ICDSGIR_TGTFILTER_OTHER (1 << GIC_ICDSGIR_TGTFILTER_SHIFT) /* Interrupt is sent to all but requesting CPU */
 #  define GIC_ICDSGIR_TGTFILTER_THIS  (2 << GIC_ICDSGIR_TGTFILTER_SHIFT) /* Interrupt is sent to requesting CPU only */
-
-/* SGI Clear-Pending Registers */
-#define GIC_ICDSCPR_
-
-/* SGI Set-Pending Registers */
-#define GIC_ICDSSPR_
+                                                                         /* Bits 26-31: Reserved */
 
 /* Interrupt IDs ************************************************************/
 
@@ -593,7 +569,7 @@
 /* Each Cortex-A9 processor has private interrupts, ID0-ID15, that can only
  * be triggered by software. These interrupts are aliased so that there is
  * no requirement for a requesting Cortex-A9 processor to determine its own
- * CPU ID when it deals with SGIs. The priority of an SGI depends on the
+ * CPU ID when it deals with SGIs.  The priority of an SGI depends on the
  * value set by the receiving Cortex-A9 processor in the banked SGI priority
  * registers, not the priority set by the sending Cortex-A9 processor.
  *
@@ -601,32 +577,34 @@
  * task management.
  */
 
-#define GIC_IRQ_SGI0              0  /* Software Generated Interrupt (SGI) 0 */
-#define GIC_IRQ_SGI1              1  /* Software Generated Interrupt (SGI) 1 */
-#define GIC_IRQ_SGI2              2  /* Software Generated Interrupt (SGI) 2 */
-#define GIC_IRQ_SGI3              3  /* Software Generated Interrupt (SGI) 3 */
-#define GIC_IRQ_SGI4              4  /* Software Generated Interrupt (SGI) 4 */
-#define GIC_IRQ_SGI5              5  /* Software Generated Interrupt (SGI) 5 */
-#define GIC_IRQ_SGI6              6  /* Software Generated Interrupt (SGI) 6 */
-#define GIC_IRQ_SGI7              7  /* Software Generated Interrupt (SGI) 7 */
-#define GIC_IRQ_SGI8              8  /* Software Generated Interrupt (SGI) 8 */
-#define GIC_IRQ_SGI9              9  /* Software Generated Interrupt (SGI) 9 */
-#define GIC_IRQ_SGI10            10  /* Software Generated Interrupt (SGI) 10 */
-#define GIC_IRQ_SGI11            11  /* Software Generated Interrupt (SGI) 11 */
-#define GIC_IRQ_SGI12            12  /* Software Generated Interrupt (SGI) 12 */
-#define GIC_IRQ_SGI13            13  /* Software Generated Interrupt (SGI) 13 */
-#define GIC_IRQ_SGI14            14  /* Software Generated Interrupt (SGI) 14 */
-#define GIC_IRQ_SGI15            15  /* Software Generated Interrupt (SGI) 15 */
+#define GIC_IRQ_SGI0              0 /* Software Generated Interrupt (SGI) 0 */
+#define GIC_IRQ_SGI1              1 /* Software Generated Interrupt (SGI) 1 */
+#define GIC_IRQ_SGI2              2 /* Software Generated Interrupt (SGI) 2 */
+#define GIC_IRQ_SGI3              3 /* Software Generated Interrupt (SGI) 3 */
+#define GIC_IRQ_SGI4              4 /* Software Generated Interrupt (SGI) 4 */
+#define GIC_IRQ_SGI5              5 /* Software Generated Interrupt (SGI) 5 */
+#define GIC_IRQ_SGI6              6 /* Software Generated Interrupt (SGI) 6 */
+#define GIC_IRQ_SGI7              7 /* Software Generated Interrupt (SGI) 7 */
+#define GIC_IRQ_SGI8              8 /* Software Generated Interrupt (SGI) 8 */
+#define GIC_IRQ_SGI9              9 /* Software Generated Interrupt (SGI) 9 */
+#define GIC_IRQ_SGI10            10 /* Software Generated Interrupt (SGI) 10 */
+#define GIC_IRQ_SGI11            11 /* Software Generated Interrupt (SGI) 11 */
+#define GIC_IRQ_SGI12            12 /* Software Generated Interrupt (SGI) 12 */
+#define GIC_IRQ_SGI13            13 /* Software Generated Interrupt (SGI) 13 */
+#define GIC_IRQ_SGI14            14 /* Software Generated Interrupt (SGI) 14 */
+#define GIC_IRQ_SGI15            15 /* Software Generated Interrupt (SGI) 15 */
 
-#define GIC_IRQ_GTM              27  /* Global Timer (GTM) PPI(0) */
-#define GIC_IRQ_FIQ              28  /* Fast Interrupt Request (nFIQ) PPI(1) */
-#define GIC_IRQ_PTM              29  /* Private Timer (PTM) PPI(2) */
-#define GIC_IRQ_WDT              30  /* Watchdog Timer (WDT) PPI(3) */
-#define GIC_IRQ_IRQ              31  /* Interrupt Request (nIRQ) PPI(4) */
+#define GIC_IRQ_VM               25 /* Virtual Maintenance Interrupt (VM) PPI(6) */
+#define GIC_IRQ_HTM              26 /* Hypervisor Timer (HTM) PPI(5) */
+#define GIC_IRQ_VTM              27 /* Virtual Timer (VTM) PPI(4) */
+#define GIC_IRQ_FIQ              28 /* Fast Interrupt Request (nFIQ) PPI(0) */
+#define GIC_IRQ_STM              29 /* Secure Physical Timer (STM) PPI(1) */
+#define GIC_IRQ_PTM              30 /* Non-secure Physical Timer (PTM) PPI(2) */
+#define GIC_IRQ_IRQ              31 /* Interrupt Request (nIRQ) PPI(3) */
 
 /* Shared Peripheral Interrupts (SPI) follow */
 
-#define GIC_IRQ_SPI              32  /* First SPI interrupt ID */
+#define GIC_IRQ_SPI              32 /* First SPI interrupt ID */
 
 /****************************************************************************
  * Inline Functions
@@ -686,10 +664,10 @@ static inline void arm_cpu_sgi(int sgi, unsigned int cpuset)
   uint32_t regval;
 
 #ifdef CONFIG_SMP
-  regval = GIC_ICDSGIR_INTID(sgi) |  GIC_ICDSGIR_CPUTARGET(cpuset) |
+  regval = GIC_ICDSGIR_INTID(sgi) | GIC_ICDSGIR_CPUTARGET(cpuset) |
            GIC_ICDSGIR_TGTFILTER_LIST;
 #else
-  regval = GIC_ICDSGIR_INTID(sgi) |  GIC_ICDSGIR_CPUTARGET(0) |
+  regval = GIC_ICDSGIR_INTID(sgi) | GIC_ICDSGIR_CPUTARGET(0) |
            GIC_ICDSGIR_TGTFILTER_THIS;
 #endif
 

--- a/arch/arm/src/armv7-r/CMakeLists.txt
+++ b/arch/arm/src/armv7-r/CMakeLists.txt
@@ -47,7 +47,7 @@ list(
   cp15_cacheops.c)
 
 if(NOT CONFIG_ARCH_CHIP STREQUAL tms570)
-  list(APPEND SRCS arm_gicv2.c)
+  list(APPEND SRCS arm_gicv2.c arm_gicv2_dump.c)
 endif()
 
 if(CONFIG_ARMV7R_HAVE_PTM)

--- a/arch/arm/src/armv7-r/Make.defs
+++ b/arch/arm/src/armv7-r/Make.defs
@@ -29,7 +29,8 @@ HEAD_ASRC += arm_vectortab.S
 
 # Common assembly language files
 
-CMN_CSRCS += arm_cache.c arm_cpuinfo.c arm_dataabort.c arm_doirq.c arm_gicv2.c
+CMN_CSRCS += arm_cache.c arm_cpuinfo.c arm_dataabort.c
+CMN_CSRCS += arm_doirq.c arm_gicv2.c arm_gicv2_dump.c
 CMN_CSRCS += arm_initialstate.c arm_prefetchabort.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c
 CMN_CSRCS += arm_syscall.c arm_tcbinfo.c arm_undefinedinsn.c

--- a/arch/arm/src/armv7-r/arm_gicv2_dump.c
+++ b/arch/arm/src/armv7-r/arm_gicv2_dump.c
@@ -1,0 +1,294 @@
+/****************************************************************************
+ * arch/arm/src/armv7-r/arm_gicv2_dump.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+#include <debug.h>
+
+#include "arm_internal.h"
+#include "gic.h"
+
+#if defined(CONFIG_ARMV7R_HAVE_GICv2) && defined(CONFIG_DEBUG_IRQ_INFO)
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: arm_gic_dump_cpu
+ *
+ * Description:
+ *   Dump CPU interface registers.
+ *
+ * Input Parameters:
+ *   all - True: Dump all IRQs; False: Dump only registers for this IRQ
+ *   irq - if all == false, then dump only this IRQ.
+ *   nlines - Number of interrupts to dump if all == true;
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+static inline void arm_gic_dump_cpu(bool all, int irq, int nlines)
+{
+  irqinfo("  CPU Interface Registers:\n");
+  irqinfo("       ICR: %08x    PMR: %08x    BPR: %08x    IAR: %08x\n",
+          getreg32(GIC_ICCICR), getreg32(GIC_ICCPMR),
+          getreg32(GIC_ICCBPR), getreg32(GIC_ICCIAR));
+  irqinfo("       RPR: %08x   HPIR: %08x   ABPR: %08x\n",
+          getreg32(GIC_ICCRPR), getreg32(GIC_ICCHPIR),
+          getreg32(GIC_ICCABPR));
+  irqinfo("      AIAR: %08x  AHPIR: %08x    IDR: %08x\n",
+          getreg32(GIC_ICCAIAR), getreg32(GIC_ICCAHPIR),
+          getreg32(GIC_ICCIDR));
+  irqinfo("      APR1: %08x   APR2: %08x   APR3: %08x   APR4: %08x\n",
+          getreg32(GIC_ICCAPR1), getreg32(GIC_ICCAPR2),
+          getreg32(GIC_ICCAPR3), getreg32(GIC_ICCAPR4));
+  irqinfo("    NSAPR1: %08x NSAPR2: %08x NSAPR3: %08x NSAPR4: %08x\n",
+          getreg32(GIC_ICCNSAPR1), getreg32(GIC_ICCNSAPR2),
+          getreg32(GIC_ICCNSAPR3), getreg32(GIC_ICCNSAPR4));
+}
+
+/****************************************************************************
+ * Name: arm_gic_dumpregs
+ *
+ * Description:
+ *   Dump registers with 4x8-bit per interrupt
+ *
+ * Input Parameters:
+ *   regaddr - First register address
+ *   nlines  - Number of interrupt lines
+ *   incr    - IRQs per 32-bit word
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+static void arm_gic_dumpregs(uintptr_t regaddr, int nlines, int incr)
+{
+  unsigned int i;
+
+  incr <<= 2;
+  for (i = 0; i < nlines; i += incr, regaddr += 16)
+    {
+      irqinfo("         %08x %08x %08x %08x\n",
+              getreg32(regaddr), getreg32(regaddr + 4),
+              getreg32(regaddr + 8), getreg32(regaddr + 12));
+    }
+}
+
+/****************************************************************************
+ * Name: arm_gic_dump4
+ *
+ * Description:
+ *   Dump registers with 4x8-bit per interrupt
+ *
+ * Input Parameters:
+ *   name    - Register name
+ *   regaddr - First register address
+ *   nlines  - Number of interrupt lines
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+static inline void arm_gic_dump4(const char *name, uintptr_t regaddr,
+                                 int nlines)
+{
+  irqinfo("       %s[%08lx]\n", name, (unsigned long)regaddr);
+  arm_gic_dumpregs(regaddr, nlines, 4);
+}
+
+/****************************************************************************
+ * Name: arm_gic_dump8
+ *
+ * Description:
+ *   Dump registers with 8x4-bit per interrupt
+ *
+ * Input Parameters:
+ *   name    - Register name
+ *   regaddr - First register address
+ *   nlines  - Number of interrupt lines
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+static inline void arm_gic_dump8(const char *name, uintptr_t regaddr,
+                                 int nlines)
+{
+  irqinfo("       %s[%08lx]\n", name, (unsigned long)regaddr);
+  arm_gic_dumpregs(regaddr, nlines, 8);
+}
+
+/****************************************************************************
+ * Name: arm_gic_dump16
+ *
+ * Description:
+ *   Dump registers with 16 x 2-bit per interrupt
+ *
+ * Input Parameters:
+ *   name    - Register name
+ *   regaddr - First register address
+ *   nlines  - Number of interrupt lines
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+static inline void arm_gic_dump16(const char *name, uintptr_t regaddr,
+                                  int nlines)
+{
+  irqinfo("       %s[%08lx]\n", name, (unsigned long)regaddr);
+  arm_gic_dumpregs(regaddr, nlines, 16);
+}
+
+/****************************************************************************
+ * Name: arm_gic_dump32
+ *
+ * Description:
+ *   Dump registers with 32 x 1-bit per interrupt
+ *
+ * Input Parameters:
+ *   name    - Register name
+ *   regaddr - First register address
+ *   nlines  - Number of interrupt lines
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+static inline void arm_gic_dump32(const char *name, uintptr_t regaddr,
+                                  int nlines)
+{
+  irqinfo("       %s[%08lx]\n", name, (unsigned long)regaddr);
+  arm_gic_dumpregs(regaddr, nlines, 32);
+}
+
+/****************************************************************************
+ * Name: arm_gic_dump_distributor
+ *
+ * Description:
+ *   Dump distributor interface registers.
+ *
+ * Input Parameters:
+ *   all    - True: Dump all IRQs; False: Dump only registers for this IRQ
+ *   irq    - if all == false, then dump only this IRQ.
+ *   nlines - Number of interrupts to dump if all == true;
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+static inline void arm_gic_dump_distributor(bool all, int irq, int nlines)
+{
+  irqinfo("  Distributor Registers:\n");
+  irqinfo("       DCR: %08x   ICTR: %08x   IIDR: %08x\n",
+          getreg32(GIC_ICDDCR), getreg32(GIC_ICDICTR),
+          getreg32(GIC_ICDIIDR));
+
+  if (all)
+    {
+      arm_gic_dump32("ISR",  GIC_ICDISR(0),  nlines);
+      arm_gic_dump32("ISER/ICER", GIC_ICDISER(0), nlines);
+      arm_gic_dump32("ISPR/ICPR", GIC_ICDISPR(0), nlines);
+      arm_gic_dump32("SAR/CAR", GIC_ICDSAR(0), nlines);
+      arm_gic_dump4("IPR", GIC_ICDIPR(0), nlines);
+      arm_gic_dump4("IPTR", GIC_ICDIPTR(0), nlines);
+      arm_gic_dump16("ICFR", GIC_ICDICFR(0), nlines);
+      arm_gic_dump32("PPSIR/SPISR", GIC_ICDPPISR, nlines);
+      arm_gic_dump16("NSACR", GIC_ICDNSACR(0), nlines);
+      arm_gic_dump8("SCPR/SSPR", GIC_ICDSCPR(0), nlines);
+    }
+  else
+    {
+      irqinfo("       ISR: %08x   ISER: %08x   ISPR: %08x    SAR: %08x\n",
+              getreg32(GIC_ICDISR(irq)), getreg32(GIC_ICDISER(irq)),
+              getreg32(GIC_ICDISPR(irq)), getreg32(GIC_ICDSAR(irq)));
+      irqinfo("       IPR: %08x   IPTR: %08x   ICFR: %08x  SPISR: %08x\n",
+              getreg32(GIC_ICDIPR(irq)), getreg32(GIC_ICDIPTR(irq)),
+              getreg32(GIC_ICDICFR(irq)), getreg32(GIC_ICDSPISR(irq)));
+      irqinfo("     NSACR: %08x   SCPR: %08x\n",
+              getreg32(GIC_ICDNSACR(irq)), getreg32(GIC_ICDSCPR(irq)));
+    }
+
+  irqinfo("       PIDR[%08lx]:\n", (unsigned long)GIC_ICDPIDR(0));
+  irqinfo("         %08x %08x %08x %08x\n",
+          getreg32(GIC_ICDPIDR(0)), getreg32(GIC_ICDPIDR(1)),
+          getreg32(GIC_ICDPIDR(2)), getreg32(GIC_ICDPIDR(3)));
+  irqinfo("         %08x %08x %08x %08x\n",
+          getreg32(GIC_ICDPIDR(4)), getreg32(GIC_ICDPIDR(5)),
+          getreg32(GIC_ICDPIDR(6)));
+  irqinfo("       CIDR[%08lx]:\n", (unsigned long)GIC_ICDCIDR(0));
+  irqinfo("         %08x %08x %08x %08x\n",
+          getreg32(GIC_ICDCIDR(0)), getreg32(GIC_ICDCIDR(1)),
+          getreg32(GIC_ICDCIDR(2)), getreg32(GIC_ICDCIDR(3)));
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: arm_gic_dump
+ *
+ * Description:
+ *   Dump GIC registers to the SYSLOG device
+ *
+ * Input Parameters:
+ *   msg - Message to print with the register data
+ *   all - True: Dump all IRQs; False: Dump only registers for this IRQ
+ *   irq - if all == false, then dump only this IRQ.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void arm_gic_dump(const char *msg, bool all, int irq)
+{
+  unsigned int nlines = arm_gic_nlines();
+
+  if (all)
+    {
+      irqinfo("GIC: %s NLINES=%u\n", msg, nlines);
+    }
+  else
+    {
+      irqinfo("GIC: %s IRQ=%d\n", msg, irq);
+    }
+
+  arm_gic_dump_cpu(all, irq, nlines);
+  arm_gic_dump_distributor(all, irq, nlines);
+}
+
+#endif /* CONFIG_ARMV7R_HAVE_GICv2 && CONFIG_DEBUG_IRQ_INFO */

--- a/arch/arm/src/armv7-r/gic.h
+++ b/arch/arm/src/armv7-r/gic.h
@@ -19,7 +19,7 @@
  ****************************************************************************/
 
 /* Reference:
- *   Cortex??A9 MPCore, Revision: r4p1, Technical Reference Manual, ARM DDI
+ *   Cortex™-A9 MPCore, Revision: r4p1, Technical Reference Manual, ARM DDI
  *   0407I (ID091612).
  *
  *   Includes some removed registers from the r2p2 version as well. ARM DDI
@@ -34,8 +34,14 @@
  ****************************************************************************/
 
 #include "nuttx/config.h"
-#include <stdint.h>
+
+#ifndef __ASSEMBLY__
+#  include <sys/types.h>
+#  include <stdint.h>
+#endif
+
 #include "mpcore.h"
+#include "arm_internal.h"
 
 #ifdef CONFIG_ARMV7R_HAVE_GICv2
 
@@ -47,10 +53,10 @@
 
 /* 1x32 bit field per register */
 
-#define GIC_INDEX1(n)              (n)                   /* 1 field per word */
-#define GIC_OFFSET1(n)             (GIC_INDEX1(n) << 2)  /* 32-bit word offset */
-#define GIC_SHIFT1(n)              (0)                   /* No shift */
-#define GIC_MASK1(n)               (0xffffffff)          /* Whole word */
+#define GIC_INDEX1(n)              (n)                       /* 1 field per word */
+#define GIC_OFFSET1(n)             (GIC_INDEX1(n) << 2)      /* 32-bit word offset */
+#define GIC_SHIFT1(n)              (0)                       /* No shift */
+#define GIC_MASK1(n)               (0xffffffff)              /* Whole word */
 
 /* 2x16 bit field per register */
 
@@ -61,53 +67,69 @@
 
 /* 4x8 bit field per register */
 
-#define GIC_INDEX4(n)              (n >> 2)                /* 4 fields per word */
-#define GIC_OFFSET4(n)             (GIC_INDEX4(n) << 2)    /* 32-bit word offset */
-#define GIC_SHIFT4(n)              (((n) & 3) << 3)        /* Shift 8-bits per field */
-#define GIC_MASK4(n)               (0xff << GIC_SHIFT4(n)) /* 8-bit mask */
+#define GIC_INDEX4(n)              (n >> 2)                  /* 4 fields per word */
+#define GIC_OFFSET4(n)             (GIC_INDEX4(n) << 2)      /* 32-bit word offset */
+#define GIC_SHIFT4(n)              (((n) & 3) << 3)          /* Shift 8-bits per field */
+#define GIC_MASK4(n)               (0xff << GIC_SHIFT4(n))   /* 8-bit mask */
 
 /* 8x4 bit field per register */
 
-#define GIC_INDEX8(n)              (n >> 3)              /* 8 fields per word */
-#define GIC_OFFSET8(n)             (GIC_INDEX8(n) << 2)  /* 32-bit word offset */
-#define GIC_SHIFT8(n)              (((n) & 7) << 2)      /* Shift 4-bits per field */
-#define GIC_MASK8(n)               (15 << GIC_SHIFT8(n)) /* 4-bit mask */
+#define GIC_INDEX8(n)              (n >> 3)                  /* 8 fields per word */
+#define GIC_OFFSET8(n)             (GIC_INDEX8(n) << 2)      /* 32-bit word offset */
+#define GIC_SHIFT8(n)              (((n) & 7) << 2)          /* Shift 4-bits per field */
+#define GIC_MASK8(n)               (15 << GIC_SHIFT8(n))     /* 4-bit mask */
 
 /* 16x2 bit field per register */
 
-#define GIC_INDEX16(n)             (n >> 4)               /* 16 fields per word */
-#define GIC_OFFSET16(n)            (GIC_INDEX16(n) << 2)  /* 32-bit word offset */
-#define GIC_SHIFT16(n)             (((n) & 15) << 1)      /* Shift 2-bits per field */
-#define GIC_MASK16(n)              (3 << GIC_SHIFT16(n))  /* 2-bit mask */
+#define GIC_INDEX16(n)             (n >> 4)                  /* 16 fields per word */
+#define GIC_OFFSET16(n)            (GIC_INDEX16(n) << 2)     /* 32-bit word offset */
+#define GIC_SHIFT16(n)             (((n) & 15) << 1)         /* Shift 2-bits per field */
+#define GIC_MASK16(n)              (3 << GIC_SHIFT16(n))     /* 2-bit mask */
 
 /* 32x1 bit field per register */
 
-#define GIC_INDEX32(n)             (n >> 5)               /* 32 fields per word */
-#define GIC_OFFSET32(n)            (GIC_INDEX32(n) << 2)  /* 32-bit word offset */
-#define GIC_SHIFT32(n)             ((n) & 31)             /* Shift 1-bit per field */
-#define GIC_MASK32(n)              (1U << GIC_SHIFT32(n)) /* 1-bit mask */
+#define GIC_INDEX32(n)             (n >> 5)                  /* 32 fields per word */
+#define GIC_OFFSET32(n)            (GIC_INDEX32(n) << 2)     /* 32-bit word offset */
+#define GIC_SHIFT32(n)             ((n) & 31)                /* Shift 1-bit per field */
+#define GIC_MASK32(n)              (1 << GIC_SHIFT32(n))     /* 1-bit mask */
 
 /* GIC Register Offsets *****************************************************/
 
-/* Interrupt Interface registers */
+/* CPU Interface registers */
 
-#define GIC_ICCICR_OFFSET          0x0000 /* CPU Interface Control Register */
-#define GIC_ICCPMR_OFFSET          0x0004 /* Interrupt Priority Mask Register */
-#define GIC_ICCBPR_OFFSET          0x0008 /* Binary point Register */
-#define GIC_ICCIAR_OFFSET          0x000c /* Interrupt Acknowledge */
-#define GIC_ICCEOIR_OFFSET         0x0010 /* End of interrupt */
-#define GIC_ICCRPR_OFFSET          0x0014 /* Running interrupt */
-#define GIC_ICCHPIR_OFFSET         0x0018 /* Highest pending interrupt */
-#define GIC_ICCABPR_OFFSET         0x001c /* Aliased Non-secure Binary Point Register */
-#define GIC_ICCIDR_OFFSET          0x00fc /* CPU Interface Implementer ID Register */
+#define GIC_ICCICR_OFFSET          0x0000    /* CPU Interface Control Register */
+#define GIC_ICCPMR_OFFSET          0x0004    /* Interrupt Priority Mask Register */
+#define GIC_ICCBPR_OFFSET          0x0008    /* Binary point Register */
+#define GIC_ICCIAR_OFFSET          0x000c    /* Interrupt Acknowledge */
+#define GIC_ICCEOIR_OFFSET         0x0010    /* End of interrupt */
+#define GIC_ICCRPR_OFFSET          0x0014    /* Running interrupt */
+#define GIC_ICCHPIR_OFFSET         0x0018    /* Highest pending interrupt */
+#define GIC_ICCABPR_OFFSET         0x001c    /* Aliased Non-secure Binary Point Register */
+#define GIC_ICCAIAR_OFFSET         0x0020    /* Aliased Interrupt Acknowledge Register */
+#define GIC_ICCAEOIR_OFFSET        0x0024    /* Aliased End of Interrupt Register */
+#define GIC_ICCAHPIR_OFFSET        0x0028    /* Aliased Highest Priority Pending Interrupt Register */
+                                             /* 0x002c-0x003c: Reserved */
+                                             /* 0x0040-0x00cf: Implementation defined */
+#define GIC_ICCAPR1_OFFSET         0x00d0    /* Active Priorities Register 1 */
+#define GIC_ICCAPR2_OFFSET         0x00d4    /* Active Priorities Register 2 */
+#define GIC_ICCAPR3_OFFSET         0x00d8    /* Active Priorities Register 3 */
+#define GIC_ICCAPR4_OFFSET         0x00dc    /* Active Priorities Register 4 */
+#define GIC_ICCNSAPR1_OFFSET       0x00e0    /* Non-secure Active Priorities Register 1 */
+#define GIC_ICCNSAPR2_OFFSET       0x00e4    /* Non-secure Active Priorities Register 2 */
+#define GIC_ICCNSAPR3_OFFSET       0x00e8    /* Non-secure Active Priorities Register 3 */
+#define GIC_ICCNSAPR4_OFFSET       0x00ec    /* Non-secure Active Priorities Register 4 */
+                                             /* 0x00ed-0x00f8: Reserved */
+#define GIC_ICCIDR_OFFSET          0x00fc    /* CPU Interface Implementer ID Register */
+#define GIC_ICCDIR_OFFSET          0x1000    /* Deactivate Interrupt Register */
 
 /* Distributor Registers */
 
-#define GIC_ICDDCR_OFFSET          0x0000 /* Distributor Control Register */
-#define GIC_ICDICTR_OFFSET         0x0004 /* Interrupt Controller Type Register */
-#define GIC_ICDIIDR_OFFSET         0x0008 /* Distributor Implementer ID Register */
-
-/* 0x000c-0x007c: Reserved */
+#define GIC_ICDDCR_OFFSET          0x0000    /* Distributor Control Register */
+#define GIC_ICDICTR_OFFSET         0x0004    /* Interrupt Controller Type Register */
+#define GIC_ICDIIDR_OFFSET         0x0008    /* Distributor Implementer ID Register */
+                                             /* 0x000c-0x001c: Reserved */
+                                             /* 0x0020-0x003c: Implementation defined */
+                                             /* 0x0040-0x007c: Reserved */
 
 /* Interrupt Security Registers: 0x0080-0x009c */
 
@@ -129,11 +151,13 @@
 
 #define GIC_ICDICPR_OFFSET(n)      (0x0280 + GIC_OFFSET32(n))
 
-/* Interrupt Active Bit Registers: 0x0300-0x31c */
+/* GICv2 Interrupt Set-Active Registers: 0x0300-0x31c */
 
-#define GIC_ICDABR_OFFSET(n)       (0x0300 + GIC_OFFSET32(n))
+#define GIC_ICDSAR_OFFSET(n)       (0x0300 + GIC_OFFSET32(n))
 
-/* 0x0380-0x03fc: Reserved */
+/* Interrupt Clear-Active Registers: 0x380-0x3fc */
+
+#define GIC_ICDCAR_OFFSET(n)       (0x0380 + GIC_OFFSET32(n))
 
 /* Interrupt Priority Registers: 0x0400-0x04fc */
 
@@ -151,21 +175,38 @@
 
 #define GIC_ICDICFR_OFFSET(n)      (0x0c00 + GIC_OFFSET16(n))
 
-/* PPI Status Register: 0x0d00 */
+/* 0x0d00-0x0dfc: Implementation defined */
 
-#define GIC_ICDPPISR_OFFSET        0x0d00 /* PPI Status Register */
+/* PPI Status Register: 0x0d00 */
 
 /* SPI Status Registers: 0x0d04-0x0d1c */
 
-#define GIC_ICDSPISR_OFFSET(n)     (0x0d04 + GIC_OFFSET32(n))
+#define GIC_ICDPPISR_OFFSET        0x0d00    /* PPI Status Register */
+#define GIC_ICDSPISR_OFFSET(n)     (0x0d00 + GIC_OFFSET32(n))
 
-/* 0x0d80-0x0efc: Reserved */
+/* 0x0d80-0x0dfc: Reserved */
+
+/* Non-secure Access Control Registers, optional: 00xe00-0x0efc */
+
+#define GIC_ICDNSACR_OFFSET(n)     (0x0e00 + GIC_OFFSET16(n))
 
 /* Software Generated Interrupt Register: 0x0f00 */
 
-#define GIC_ICDSGIR_OFFSET         0x0f00 /* Software Generated Interrupt Register */
+#define GIC_ICDSGIR_OFFSET         0x0f00    /* Software Generated Interrupt Register */
 
-/* 0x0f0c-0x0fcc: Reserved */
+/* 0x0f04-0x0f0c: Reserved */
+
+/* SGI Clear-Pending Registers: 0x0f10-0x0f1c */
+
+#define GIC_ICDSCPR_OFFSET(n)      (0x0f10 + GIC_OFFSET8(n))
+
+/* SGI Set-Pending Registers: 0x0f20-0x0f2c */
+
+#define GIC_ICDSSPR_OFFSET(n)      (0x0f20 + GIC_OFFSET8(n))
+
+/* 0x0f30-0x0fcc: Reserved */
+
+/* 0x0fd0-0x0ffc: Implementation defined */
 
 /* Peripheral Identification Registers: 0x0fd0-0xfe8 */
 
@@ -175,17 +216,15 @@
 
 #define GIC_ICDCIDR_OFFSET(n)      (0x0ff0 + ((n) << 2))
 
-/* 0x0f04-0x0ffc: Reserved */
-
 /* GIC Register Addresses ***************************************************/
 
 /* The Interrupt Controller is a single functional unit that is located in a
- * Cortex-A9 MPCore design. There is one interrupt interface per Cortex-A9
+ * Cortex-A9 MPCore design.  There is one interrupt interface per Cortex-A9
  * processor.  Registers are memory mapped and accessed through a chip-
  * specific private memory spaced (see mpcore.h).
  */
 
-/* Interrupt Interface registers */
+/* CPU Interface registers */
 
 #define GIC_ICCICR                 (MPCORE_ICC_VBASE+GIC_ICCICR_OFFSET)
 #define GIC_ICCPMR                 (MPCORE_ICC_VBASE+GIC_ICCPMR_OFFSET)
@@ -195,7 +234,19 @@
 #define GIC_ICCRPR                 (MPCORE_ICC_VBASE+GIC_ICCRPR_OFFSET)
 #define GIC_ICCHPIR                (MPCORE_ICC_VBASE+GIC_ICCHPIR_OFFSET)
 #define GIC_ICCABPR                (MPCORE_ICC_VBASE+GIC_ICCABPR_OFFSET)
+#define GIC_ICCAIAR                (MPCORE_ICC_VBASE+GIC_ICCAIAR_OFFSET)
+#define GIC_ICCAEOIR               (MPCORE_ICC_VBASE+GIC_ICCAEOIR_OFFSET)
+#define GIC_ICCAHPIR               (MPCORE_ICC_VBASE+GIC_ICCAHPIR_OFFSET)
+#define GIC_ICCAPR1                (MPCORE_ICC_VBASE+GIC_ICCAPR1_OFFSET)
+#define GIC_ICCAPR2                (MPCORE_ICC_VBASE+GIC_ICCAPR2_OFFSET)
+#define GIC_ICCAPR3                (MPCORE_ICC_VBASE+GIC_ICCAPR3_OFFSET)
+#define GIC_ICCAPR4                (MPCORE_ICC_VBASE+GIC_ICCAPR4_OFFSET)
+#define GIC_ICCNSAPR1              (MPCORE_ICC_VBASE+GIC_ICCNSAPR1_OFFSET)
+#define GIC_ICCNSAPR2              (MPCORE_ICC_VBASE+GIC_ICCNSAPR2_OFFSET)
+#define GIC_ICCNSAPR3              (MPCORE_ICC_VBASE+GIC_ICCNSAPR3_OFFSET)
+#define GIC_ICCNSAPR4              (MPCORE_ICC_VBASE+GIC_ICCNSAPR4_OFFSET)
 #define GIC_ICCIDR                 (MPCORE_ICC_VBASE+GIC_ICCIDR_OFFSET)
+#define GIC_ICCDIR                 (MPCORE_ICC_VBASE+GIC_ICCDIR_OFFSET)
 
 /* Distributor Registers */
 
@@ -207,42 +258,40 @@
 #define GIC_ICDICER(n)             (MPCORE_ICD_VBASE+GIC_ICDICER_OFFSET(n))
 #define GIC_ICDISPR(n)             (MPCORE_ICD_VBASE+GIC_ICDISPR_OFFSET(n))
 #define GIC_ICDICPR(n)             (MPCORE_ICD_VBASE+GIC_ICDICPR_OFFSET(n))
-#define GIC_ICDABR(n)              (MPCORE_ICD_VBASE+GIC_ICDABR_OFFSET(n))
+#define GIC_ICDSAR(n)              (MPCORE_ICD_VBASE+GIC_ICDSAR_OFFSET(n))
+#define GIC_ICDCAR(n)              (MPCORE_ICD_VBASE+GIC_ICDCAR_OFFSET(n))
 #define GIC_ICDIPR(n)              (MPCORE_ICD_VBASE+GIC_ICDIPR_OFFSET(n))
 #define GIC_ICDIPTR(n)             (MPCORE_ICD_VBASE+GIC_ICDIPTR_OFFSET(n))
 #define GIC_ICDICFR(n)             (MPCORE_ICD_VBASE+GIC_ICDICFR_OFFSET(n))
 #define GIC_ICDPPISR               (MPCORE_ICD_VBASE+GIC_ICDPPISR_OFFSET)
 #define GIC_ICDSPISR(n)            (MPCORE_ICD_VBASE+GIC_ICDSPISR_OFFSET(n))
+#define GIC_ICDNSACR(n)            (MPCORE_ICD_VBASE+GIC_ICDNSACR_OFFSET(n))
 #define GIC_ICDSGIR                (MPCORE_ICD_VBASE+GIC_ICDSGIR_OFFSET)
+#define GIC_ICDSCPR(n)             (MPCORE_ICD_VBASE+GIC_ICDSCPR_OFFSET(n))
+#define GIC_ICDSSPR(n)             (MPCORE_ICD_VBASE+GIC_ICDSSPR_OFFSET(n))
 #define GIC_ICDPIDR(n)             (MPCORE_ICD_VBASE+GIC_ICDPIDR_OFFSET(n))
 #define GIC_ICDCIDR(n)             (MPCORE_ICD_VBASE+GIC_ICDCIDR_OFFSET(n))
 
 /* GIC Register Bit Definitions *********************************************/
 
-/* Interrupt Interface registers */
+/* CPU Interface registers */
 
 /* CPU Interface Control Register -- without security extensions */
 
-#define GIC_ICCICR_ENABLE          (1 << 0) /* Bit 0:  Enable the CPU interface for this GIC */
-
-/* Bits 1-31: Reserved */
+#define GIC_ICCICR_ENABLE          (1 << 0)  /* Bit 0:  Enable the CPU interface for this GIC */
+                                             /* Bits 1-31: Reserved */
 
 /* CPU Interface Control Register -- with security extensions,
  * non-secure copy
  */
 
-#define GIC_ICCICRU_ENABLEGRP1     (1 << 0) /* Bit 0:  Enable Group 1 interrupts for the CPU */
-
-/* Bits 1-4: Reserved */
-
-#define GIC_ICCICRU_FIQBYPDISGRP1  (1 << 5) /* Bit 5:  FIQ disabled for CPU Group 1 */
-#define GIC_ICCICRU_IRQBYPDISGRP1  (1 << 6) /* Bit 6:  IRQ disabled for CPU Group 1 */
-
-/* Bits 7-8: Reserved */
-
-#define GIC_ICCICRU_EOIMODENS      (1 << 9) /* Bit 9:  Control EIOIR access (non-secure) */
-
-/* Bits 10-31: Reserved */
+#define GIC_ICCICRU_ENABLEGRP1     (1 << 0)  /* Bit 0:  Enable Group 1 interrupts for the CPU */
+                                             /* Bits 1-4: Reserved */
+#define GIC_ICCICRU_FIQBYPDISGRP1  (1 << 5)  /* Bit 5:  FIQ disabled for CPU Group 1*/
+#define GIC_ICCICRU_IRQBYPDISGRP1  (1 << 6)  /* Bit 6:  IRQ disabled for CPU Group 1*/
+                                             /* Bits 7-8: Reserved */
+#define GIC_ICCICRU_EOIMODENS      (1 << 9)  /* Bit 9:  Control EIOIR access (non-secure) */
+                                             /* Bits 10-31: Reserved */
 
 /* CPU Interface Control Register -- with security extensions,
  * secure copy
@@ -259,19 +308,17 @@
 #define GIC_ICCICRS_IRQBYPDISGRP1  (1 << 8)  /* Bit 6:  IRQ disabled for CPU Group 1 */
 #define GIC_ICCICRS_EOIMODES       (1 << 9)  /* Bit 6:  Control EIOIR access (secure) */
 #define GIC_ICCICRS_EOIMODENS      (1 << 10) /* Bit 10: Control EIOIR access (non-secure) */
-
-/* Bits 11-31: Reserved */
+                                             /* Bits 11-31: Reserved */
 
 /* Interrupt Priority Mask Register.  Priority values are 8-bit unsigned
  * binary. A GIC supports a minimum of 16 and a maximum of 256 priority
  * levels.  As a result, PMR settings make sense.
  */
 
-#define GIC_ICCPMR_SHIFT           (0) /* Bits 0-7: Priority mask */
+#define GIC_ICCPMR_SHIFT           (0)       /* Bits 0-7: Priority mask */
 #define GIC_ICCPMR_MASK            (0xff << GIC_ICCPMR_SHIFT)
-#define GIC_ICCPMR_VALUE(n)        ((uint32_t)(n) << GIC_ICCPMR_SHIFT)
-
-/* Bits 8-31: Reserved */
+#  define GIC_ICCPMR_VALUE(n)      ((uint32_t)(n) << GIC_ICCPMR_SHIFT)
+                                             /* Bits 8-31: Reserved */
 
 /* Binary point Register and Aliased Non-secure Binary Point Register.
  * Priority values are 8-bit unsigned binary. A GIC supports a minimum of
@@ -279,107 +326,119 @@
  * point settings make sense.
  */
 
-#define GIC_ICCBPR_SHIFT         (0) /* Bits 0-2: Binary point */
-#define GIC_ICCBPR_MASK          (7 << GIC_ICCBPR_SHIFT)
-#define GIC_ICCBPR_1_7           (0 << GIC_ICCBPR_SHIFT) /* Priority bits [7:1] compared for pre-emption */
-#define GIC_ICCBPR_2_7           (1 << GIC_ICCBPR_SHIFT) /* Priority bits [7:2] compared for pre-emption */
-#define GIC_ICCBPR_3_7           (2 << GIC_ICCBPR_SHIFT) /* Priority bits [7:2] compared for pre-emption */
-#define GIC_ICCBPR_4_7           (3 << GIC_ICCBPR_SHIFT) /* Priority bits [7:2] compared for pre-emption */
-#define GIC_ICCBPR_5_7           (4 << GIC_ICCBPR_SHIFT) /* Priority bits [7:5] compared for pre-emption */
-#define GIC_ICCBPR_6_7           (5 << GIC_ICCBPR_SHIFT) /* Priority bits [7:6] compared for pre-emption */
-#define GIC_ICCBPR_7_7           (6 << GIC_ICCBPR_SHIFT) /* Priority bit [7] compared for pre-emption */
-#define GIC_ICCBPR_NOPREMPT      (7 << GIC_ICCBPR_SHIFT) /* No pre-emption is performed */
+#define GIC_ICCBPR_SHIFT           (0)       /* Bits 0-2: Binary point */
+#define GIC_ICCBPR_MASK            (7 << GIC_ICCBPR_SHIFT)
+#  define GIC_ICCBPR_1_7           (0 << GIC_ICCBPR_SHIFT) /* Priority bits [7:1] compared for pre-emption */
+#  define GIC_ICCBPR_2_7           (1 << GIC_ICCBPR_SHIFT) /* Priority bits [7:2] compared for pre-emption */
+#  define GIC_ICCBPR_3_7           (2 << GIC_ICCBPR_SHIFT) /* Priority bits [7:3] compared for pre-emption */
+#  define GIC_ICCBPR_4_7           (3 << GIC_ICCBPR_SHIFT) /* Priority bits [7:4] compared for pre-emption */
+#  define GIC_ICCBPR_5_7           (4 << GIC_ICCBPR_SHIFT) /* Priority bits [7:5] compared for pre-emption */
+#  define GIC_ICCBPR_6_7           (5 << GIC_ICCBPR_SHIFT) /* Priority bits [7:6] compared for pre-emption */
+#  define GIC_ICCBPR_7_7           (6 << GIC_ICCBPR_SHIFT) /* Priority bit [7] compared for pre-emption */
+#  define GIC_ICCBPR_NOPREMPT      (7 << GIC_ICCBPR_SHIFT) /* No pre-emption is performed */
 
-/* Bits 3-31: Reserved */
+                                             /* Bits 3-31: Reserved */
 
 /* Interrupt Acknowledge Register */
 
-#define GIC_ICCIAR_INTID_SHIFT     (0)  /* Bits 0-9: Interrupt ID */
+#define GIC_ICCIAR_INTID_SHIFT     (0)       /* Bits 0-9: Interrupt ID */
 #define GIC_ICCIAR_INTID_MASK      (0x3ff << GIC_ICCIAR_INTID_SHIFT)
-#define GIC_ICCIAR_INTID(n)        ((uint32_t)(n) << GIC_ICCIAR_INTID_SHIFT)
-#define GIC_ICCIAR_CPUSRC_SHIFT    (10) /* Bits 10-12: CPU source ID */
+#  define GIC_ICCIAR_INTID(n)      ((uint32_t)(n) << GIC_ICCIAR_INTID_SHIFT)
+#define GIC_ICCIAR_CPUSRC_SHIFT    (10)      /* Bits 10-12: CPU source ID */
 #define GIC_ICCIAR_CPUSRC_MASK     (7 << GIC_ICCIAR_CPUSRC_SHIFT)
-#define GIC_ICCIAR_CPUSRC(n)       ((uint32_t)(n) << GIC_ICCIAR_CPUSRC_SHIFT)
+#  define GIC_ICCIAR_CPUSRC(n)     ((uint32_t)(n) << GIC_ICCIAR_CPUSRC_SHIFT)
 
-/* Bits 13-31: Reserved */
+                                             /* Bits 13-31: Reserved */
 
 /* End of Interrupt Register */
 
+#define GIC_ICCEOIR_SPURIOUSNS     (0x3fe)
 #define GIC_ICCEOIR_SPURIOUS       (0x3ff)
 
-#define GIC_ICCEOIR_INTID_SHIFT    (0) /* Bits 0-9: Interrupt ID */
+#define GIC_ICCEOIR_INTID_SHIFT    (0)       /* Bits 0-9: Interrupt ID */
 #define GIC_ICCEOIR_INTID_MASK     (0x3ff << GIC_ICCEOIR_INTID_SHIFT)
-#define GIC_ICCEOIR_INTID(n)       ((uint32_t)(n) << GIC_ICCEOIR_INTID_SHIFT)
-#define GIC_ICCEOIR_CPUSRC_SHIFT   (10) /* Bits 10-12: CPU source ID */
+#  define GIC_ICCEOIR_INTID(n)     ((uint32_t)(n) << GIC_ICCEOIR_INTID_SHIFT)
+#define GIC_ICCEOIR_CPUSRC_SHIFT   (10)      /* Bits 10-12: CPU source ID */
 #define GIC_ICCEOIR_CPUSRC_MASK    (7 << GIC_ICCEOIR_CPUSRC_SHIFT)
-#define GIC_ICCEOIR_CPUSRC(n)      ((uint32_t)(n) << GIC_ICCEOIR_CPUSRC_SHIFT)
+#  define GIC_ICCEOIR_CPUSRC(n)    ((uint32_t)(n) << GIC_ICCEOIR_CPUSRC_SHIFT)
 
-/* Bits 13-31: Reserved */
+                                             /* Bits 13-31: Reserved */
 
 /* Running Interrupt Register */
 
-/* Bits 0-3: Reserved */
+#define GIC_ICCRPR_PRIO_SHIFT      (0)       /* Bits 0-7: Priority mask */
+#define GIC_ICCRPR_PRIO_MASK       (0xff << GIC_ICCRPR_PRIO_SHIFT)
+#  define GIC_ICCRPR_PRIO_VALUE(n) ((uint32_t)(n) << GIC_ICCRPR_PRIO_SHIFT)
 
-#define GIC_ICCRPR_PRIO_SHIFT      (4) /* Bits 4-7: Priority mask */
-#define GIC_ICCRPR_PRIO_MASK       (15 << GIC_ICCRPR_PRIO_SHIFT)
-#define GIC_ICCRPR_PRIO_VALUE(n)   ((uint32_t)(n) << GIC_ICCRPR_PRIO_SHIFT)
-
-/* Bits 8-31: Reserved */
+                                             /* Bits 8-31: Reserved */
 
 /* Highest Pending Interrupt Register */
 
-#define GIC_ICCHPIR_INTID_SHIFT    (0) /* Bits 0-9: Interrupt ID */
+#define GIC_ICCHPIR_INTID_SHIFT    (0)       /* Bits 0-9: Interrupt ID */
 #define GIC_ICCHPIR_INTID_MASK     (0x3ff << GIC_ICCHPIR_INTID_SHIFT)
-#define GIC_ICCHPIR_INTID(n)       ((uint32_t)(n) << GIC_ICCHPIR_INTID_SHIFT)
-#define GIC_ICCHPIR_CPUSRC_SHIFT   (10) /* Bits 10-12: CPU source ID */
+#  define GIC_ICCHPIR_INTID(n)     ((uint32_t)(n) << GIC_ICCHPIR_INTID_SHIFT)
+#define GIC_ICCHPIR_CPUSRC_SHIFT   (10)      /* Bits 10-12: CPU source ID */
 #define GIC_ICCHPIR_CPUSRC_MASK    (7 << GIC_ICCHPIR_CPUSRC_SHIFT)
-#define GIC_ICCHPIR_CPUSRC(n)      ((uint32_t)(n) << GIC_ICCHPIR_CPUSRC_SHIFT)
+#  define GIC_ICCHPIR_CPUSRC(n)    ((uint32_t)(n) << GIC_ICCHPIR_CPUSRC_SHIFT)
 
-/* Bits 13-31: Reserved */
+                                             /* Bits 13-31: Reserved */
 
 /* CPU Interface Implementer ID Register */
 
-#define GIC_ICCIDR_IMPL_SHIFT      (0) /* Bits 0-11:  Implementer */
+#define GIC_ICCIDR_IMPL_SHIFT      (0)       /* Bits 0-11:  Implementer */
 #define GIC_ICCIDR_IMPL_MASK       (0xfff << GIC_ICCIDR_IMPL_SHIFT)
-#define GIC_ICCIDR_REVISION_SHIFT  (12) /* Bits 12-15: Revision number */
+#define GIC_ICCIDR_REVISION_SHIFT  (12)      /* Bits 12-15: Revision number */
 #define GIC_ICCIDR_REVISION_MASK   (15 << GIC_ICCIDR_REVISION_SHIFT)
-#define GIC_ICCIDR_ARCHNO_SHIFT    (16) /* Bits 16-19: Architecture number */
+#define GIC_ICCIDR_ARCHNO_SHIFT    (16)      /* Bits 16-19: Architecture number */
 #define GIC_ICCIDR_ARCHNO_MASK     (15 << GIC_ICCIDR_ARCHNO_SHIFT)
-#define GIC_ICCIDR_PARTNO_SHIFT    (20) /* Bits 20-31: Part number */
+#define GIC_ICCIDR_PARTNO_SHIFT    (20)      /* Bits 20-31: Part number */
 #define GIC_ICCIDR_PARTNO_MASK     (0xfff << GIC_ICCIDR_PARTNO_SHIFT)
+
+/* Deactivate Interrupt Register */
+
+#define GIC_ICCDIR_INTID_SHIFT     (0)       /* Bits 0-9: Interrupt ID */
+#define GIC_ICCDIR_INTID_MASK      (0x3ff << GIC_ICCHPIR_INTID_SHIFT)
+#  define GIC_ICCDIR_INTID(n)      ((uint32_t)(n) << GIC_ICCHPIR_INTID_SHIFT)
+#define GIC_ICCDIR_CPUSRC_SHIFT    (10)      /* Bits 10-12: CPU source ID */
+#define GIC_ICCDIR_CPUSRC_MASK     (7 << GIC_ICCHPIR_CPUSRC_SHIFT)
+#  define GIC_ICCDIR_CPUSRC(n)     ((uint32_t)(n) << GIC_ICCHPIR_CPUSRC_SHIFT)
 
 /* Distributor Registers */
 
-/* Distributor Control Register */
+/* Distributor Control Register -- without security extensions */
 
-#define GIC_ICDDCR_NONSECENAB      (1 << 0) /* Bit 0: Enable distributor for Non-secure interrupts */
-#define GIC_ICDDCR_SECENABLE       (1 << 1) /* Bit 1: Enable distributor for Secure interrupts */
+#define GIC_ICDDCR_ENABLE          (1 << 0)  /* Bit 0: Enable forwarding of interrupts */
+                                             /* Bits 1-31: Reserved */
 
-/* Bits 2-31: Reserved */
+/* Distributor Control Register -- with security extensions */
+
+#define GIC_ICDDCR_ENABLEGRP0      (1 << 0)  /* Bit 0: Enable forwarding of Group 0 interrupts */
+#define GIC_ICDDCR_ENABLEGRP1      (1 << 1)  /* Bit 1: Enable forwarding of Group 1 interrupts */
+                                             /* Bits 2-31: Reserved */
 
 /* Interrupt Controller Type Register */
 
-#define GIC_ICDICTR_ITLINES_SHIFT  (0) /* Bits 0-4: It lines number */
+#define GIC_ICDICTR_ITLINES_SHIFT  (0)       /* Bits 0-4: It lines number */
 #define GIC_ICDICTR_ITLINES_MASK   (0x1f << GIC_ICDICTR_ITLINES_SHIFT)
-#define GIC_ICDICTR_CPUNO_SHIFT    (5) /* Bits 5-7: CPU number */
+#define GIC_ICDICTR_CPUNO_SHIFT    (5)       /* Bits 5-7: CPU number */
 #define GIC_ICDICTR_CPUNO_MASK     (7 << GIC_ICDICTR_CPUNO_SHIFT)
-
-/* Bits 8-9: Reserved */
-
+                                             /* Bits 8-9: Reserved */
 #define GIC_ICDICTR_SECEXTNS       (1 << 10) /* Bit 10: Number of security domains */
 #define GIC_ICDICTR_LSPI_SHIFT     (11)      /* Bits 11-15: Number of Lockable Shared Peripheral Interrupts */
 #define GIC_ICDICTR_LSPI_MASK      (0x1f << GIC_ICDICTR_LSPI_SHIFT)
-
-/* Bits 16-31: Reserved */
+                                             /* Bits 16-31: Reserved */
 
 /* Distributor Implementer ID Register */
 
-#define GIC_ICDIIDR_IMPL_SHIFT      (0)  /* Bits 0-11: Implementer */
+#define GIC_ICDIIDR_IMPL_SHIFT      (0)      /* Bits 0-11: Implementer */
 #define GIC_ICDIIDR_IMPL_MASK       (0xfff << GIC_ICDIIDR_IMPL_SHIFT)
-#define GIC_ICDIIDR_REVISION_SHIFT  (12) /* Bits 12-23: Revision number */
-#define GIC_ICDIIDR_REVISION_MASK   (0xfff << GIC_ICDIIDR_REVISION_SHIFT)
-#define GIC_ICDIIDR_VERSION_SHIFT   (24) /* Bits 24-31: Iimplementer version */
-#define GIC_ICDIIDR_VERSION_MASK    (0xff << GIC_ICDIIDR_VERSION_SHIFT)
+#define GIC_ICDIIDR_REVISION_SHIFT  (12)     /* Bits 12-15: Revision number */
+#define GIC_ICDIIDR_REVISION_MASK   (0xf << GIC_ICDIIDR_REVISION_SHIFT)
+#define GIC_ICDIIDR_VARIANT_SHIFT   (16)     /* Bits 16-19 Variant number */
+#define GIC_ICDIIDR_VARIANT_MASK    (0xf << GIC_ICDIIDR_VARIANT_SHIFT)
+                                             /* Bits 20-23: Reserved */
+#define GIC_ICDIIDR_PRODUCTID_SHIFT (24)     /* Bits 24-31: Product id */
+#define GIC_ICDIIDR_PRODUCTID_MASK  (0xff << GIC_ICDIIDR_PRODUCTID_SHIFT)
 
 /* Interrupt Security Registers: 0x0080-0x009c */
 
@@ -387,37 +446,43 @@
 
 /* Interrupt Set-Enable.
  *
- * NOTE: In the Cortex-A9 MPCore, SGIs are always enabled.
- * The corresponding bits in the ICDISERn are read as one, write ignored
+ * NOTE:
+ * In the Cortex-A9 MPCore, SGIs are always enabled. The corresponding bits
+ * in the ICDISERn are read as one, write ignored
  */
 
-#define GIC_ICDISER_INT(n)          GIC_MASK32(n)
+#define GIC_ICDISER_INT(n)         GIC_MASK32(n)
 
 /* Interrupt Clear-Enable.
  *
- * NOTE: In the Cortex-A9 MPCore, SGIs are always enabled.
- * The corresponding bits in the ICDICERn are read as one, write ignored
+ * NOTE:
+ * In the Cortex-A9 MPCore, SGIs are always enabled. The corresponding bits
+ * in the ICDICERn are read as one, write ignored
  */
 
-#define GIC_ICDICER_INT(n)          GIC_MASK32(n)
+#define GIC_ICDICER_INT(n)         GIC_MASK32(n)
 
 /* Interrupt Set-Pending */
 
-#define GIC_ICDISPR_INT(n)          GIC_MASK32(n)
+#define GIC_ICDISPR_INT(n)         GIC_MASK32(n)
 
 /* Interrupt Clear-Pending */
 
-#define GIC_ICDICPR_INT(n)          GIC_MASK32(n)
+#define GIC_ICDICPR_INT(n)         GIC_MASK32(n)
 
-/* Interrupt Active Bit */
+/* GICv2 Interrupt Set-Active Registers */
 
-#define GIC_ICDABR_INT(n)           GIC_MASK32(n)
+#define GIC_ICDSAR_INT(n)          GIC_MASK32(n)
+
+/* Interrupt Clear-Active Registers */
+
+#define GIC_ICDCAR_INT(n)          GIC_MASK32(n)
 
 /* Interrupt Priority Registers */
 
-#define GIC_ICDIPR_ID_SHIFT(n)      GIC_SHIFT4(n)
-#define GIC_ICDIPR_ID_MASK(n)       GIC_MASK4(n)
-#define GIC_ICDIPR_ID(n, p)         ((uint32_t)(p) << GIC_SHIFT4(n))
+#define GIC_ICDIPR_ID_SHIFT(n)     GIC_SHIFT4(n)
+#define GIC_ICDIPR_ID_MASK(n)      GIC_MASK4(n)
+#  define GIC_ICDIPR_ID(n,p)       ((uint32_t)(p) << GIC_SHIFT4(n))
 
 /* Interrupt Processor Target Registers */
 
@@ -428,51 +493,60 @@
 
 #define GIC_ICDIPTR_ID_SHIFT(n)    GIC_SHIFT4(n)
 #define GIC_ICDIPTR_ID_MASK(n)     GIC_MASK4(n)
-#define GIC_ICDIPTR_ID(n, t)       ((uint32_t)(t) <<GIC_SHIFT4(n))
+#  define GIC_ICDIPTR_ID(n,t)      ((uint32_t)(t) <<GIC_SHIFT4(n))
 
 /* Interrupt Configuration Register */
 
-#define INT_ICDICFR_NN             0 /* Bit n: 0= N-N Model */
-#define INT_ICDICFR_1N             1 /* Bit n: 1= 1-N Model */
-#define INT_ICDICFR_LEVEL          0 /* Bit n+1: 0=Level sensitive */
-#define INT_ICDICFR_EDGE           2 /* Bit n+2: 1=Edge sensitive */
+#define INT_ICDICFR_NN             0         /* Bit n: 0= N-N Model */
+#define INT_ICDICFR_1N             1         /* Bit n: 1= 1-N Model */
+#define INT_ICDICFR_LEVEL          0         /* Bit n+1: 0=Level sensitive */
+#define INT_ICDICFR_EDGE           2         /* Bit n+2: 1=Edge sensitive */
 
 #define GIC_ICDICFR_ID_SHIFT(n)    GIC_SHIFT16(n)
 #define GIC_ICDICFR_ID_MASK(n)     GIC_MASK16(n)
-#define GIC_ICDICFR_ID(n, c)       ((uint32_t)(c) << GIC_SHIFT16(n))
+#  define GIC_ICDICFR_ID(n,c)      ((uint32_t)(c) << GIC_SHIFT16(n))
 
 /* PPI Status Register */
 
-#define GIC_ICDPPISR_PPI(n)      (1 << ((n) + 11)) /* Bits 11-15:  PPI(n) status, n=0-4 */
-#define GIC_ICDPPISR_GTM         (1 << 11)         /* Bit 11:  PPI[0], Global Timer */
-#define GIC_ICDPPISR_NFIQ        (1 << 12)         /* Bit 12:  PPI[1], FIQ, active low */
-#define GIC_ICDPPISR_PTM         (1 << 13)         /* Bit 13:  PPI[2], Private Timer */
-#define GIC_ICDPPISR_PWDT        (1 << 14)         /* Bit 14:  PPI[3], Private Watchdog */
-#define GIC_ICDPPISR_NIRQ        (1 << 15)         /* Bit 15:  PPI[3], IRQ, active low */
+#define GIC_ICDPPISR_PPI(n)        (1 << ((n) + 11)) /* Bits 11-15:  PPI(n) status, n=0-4 */
+
+#  define GIC_ICDPPISR_GTM         (1 << 11) /* Bit 11:  PPI[0], Global Timer */
+#  define GIC_ICDPPISR_NFIQ        (1 << 12) /* Bit 12:  PPI[1], FIQ, active low */
+#  define GIC_ICDPPISR_PTM         (1 << 13) /* Bit 13:  PPI[2], Private Timer */
+#  define GIC_ICDPPISR_PWDT        (1 << 14) /* Bit 14:  PPI[3], Private Watchdog */
+#  define GIC_ICDPPISR_NIRQ        (1 << 15) /* Bit 15:  PPI[3], IRQ, active low */
 
 /* SPI Status Registers */
 
-#define GIC_ICDSPISR_INT(n)         GIC_MASK32(n)
+#define GIC_ICDSPISR_INT(n)        GIC_MASK32(n)
+
+/* Non-secure Access Control Registers, optional */
+
+#define GIC_ICDNSACR_NONE          0
+#define GIC_ICDNSACR_SET           1
+#define GIC_ICDNSACR_CLEAR         2
+#define GIC_ICDNSACR_ROUTE         3
+
+#define GIC_ICDNSACR_ID_SHIFT(n)   GIC_SHIFT16(n)
+#define GIC_ICDNSACR_ID_MASK(n)    GIC_MASK16(n)
+#  define GIC_ICDNSACR_ID(n,p)     ((uint32_t)(p) << GIC_SHIFT16(n))
 
 /* Software Generated Interrupt Register */
 
-#define GIC_ICDSGIR_INTID_SHIFT     (0) /* Bits 0-9: Interrupt ID */
-#define GIC_ICDSGIR_INTID_MASK      (0x3ff << GIC_ICDSGIR_INTID_SHIFT)
-#define GIC_ICDSGIR_INTID(n)        ((uint32_t)(n) << GIC_ICDSGIR_INTID_SHIFT)
-
-/* Bits 10-15: Reserved */
-
-#define GIC_ICDSGIR_CPUTARGET_SHIFT (16) /* Bits 16-23: CPU target */
-#define GIC_ICDSGIR_CPUTARGET_MASK  (0xff << GIC_ICDSGIR_CPUTARGET_SHIFT)
-#define GIC_ICDSGIR_CPUTARGET(n)    ((uint32_t)(n) << GIC_ICDSGIR_CPUTARGET_SHIFT)
-
-/* Bits 26-31: Reserved */
-
-#define GIC_ICDSGIR_TGTFILTER_SHIFT (24) /* Bits 24-25: Target filter */
-#define GIC_ICDSGIR_TGTFILTER_MASK  (3 << GIC_ICDSGIR_TGTFILTER_SHIFT)
-#define GIC_ICDSGIR_TGTFILTER_LIST  (0 << GIC_ICDSGIR_TGTFILTER_SHIFT) /* Interrupt sent to CPUs CPU target list */
-#define GIC_ICDSGIR_TGTFILTER_OTHER (1 << GIC_ICDSGIR_TGTFILTER_SHIFT) /* Interrupt is sent to all but requesting CPU */
-#define GIC_ICDSGIR_TGTFILTER_THIS  (2 << GIC_ICDSGIR_TGTFILTER_SHIFT) /* Interrupt is sent to requesting CPU only */
+#define GIC_ICDSGIR_INTID_SHIFT       (0)    /* Bits 0-9: Interrupt ID */
+#define GIC_ICDSGIR_INTID_MASK        (0x3ff << GIC_ICDSGIR_INTID_SHIFT)
+#  define GIC_ICDSGIR_INTID(n)        ((uint32_t)(n) << GIC_ICDSGIR_INTID_SHIFT)
+                                             /* Bits 10-14: Reserved */
+#define GIC_ICDSGIR_NSATT             (1 << 15)
+#define GIC_ICDSGIR_CPUTARGET_SHIFT   (16)   /* Bits 16-23: CPU target */
+#define GIC_ICDSGIR_CPUTARGET_MASK    (0xff << GIC_ICDSGIR_CPUTARGET_SHIFT)
+#  define GIC_ICDSGIR_CPUTARGET(n)    ((uint32_t)(n) << GIC_ICDSGIR_CPUTARGET_SHIFT)
+#define GIC_ICDSGIR_TGTFILTER_SHIFT   (24)   /* Bits 24-25: Target filter */
+#define GIC_ICDSGIR_TGTFILTER_MASK    (3 << GIC_ICDSGIR_TGTFILTER_SHIFT)
+#  define GIC_ICDSGIR_TGTFILTER_LIST  (0 << GIC_ICDSGIR_TGTFILTER_SHIFT) /* Interrupt sent to CPUs CPU target list */
+#  define GIC_ICDSGIR_TGTFILTER_OTHER (1 << GIC_ICDSGIR_TGTFILTER_SHIFT) /* Interrupt is sent to all but requesting CPU */
+#  define GIC_ICDSGIR_TGTFILTER_THIS  (2 << GIC_ICDSGIR_TGTFILTER_SHIFT) /* Interrupt is sent to requesting CPU only */
+                                                                         /* Bits 26-31: Reserved */
 
 /* Interrupt IDs ************************************************************/
 
@@ -520,11 +594,13 @@
 #define GIC_IRQ_SGI14            14 /* Software Generated Interrupt (SGI) 14 */
 #define GIC_IRQ_SGI15            15 /* Software Generated Interrupt (SGI) 15 */
 
-#define GIC_IRQ_GTM              27 /* Global Timer (GTM) PPI(0) */
-#define GIC_IRQ_FIQ              28 /* Fast Interrupt Request (nFIQ) PPI(1) */
-#define GIC_IRQ_PTM              29 /* Private Timer (PTM) PPI(2) */
-#define GIC_IRQ_WDT              30 /* Watchdog Timer (WDT) PPI(3) */
-#define GIC_IRQ_IRQ              31 /* Interrupt Request (nIRQ) PPI(4) */
+#define GIC_IRQ_VM               25 /* Virtual Maintenance Interrupt (VM) PPI(6) */
+#define GIC_IRQ_HTM              26 /* Hypervisor Timer (HTM) PPI(5) */
+#define GIC_IRQ_VTM              27 /* Virtual Timer (VTM) PPI(4) */
+#define GIC_IRQ_FIQ              28 /* Fast Interrupt Request (nFIQ) PPI(0) */
+#define GIC_IRQ_STM              29 /* Secure Physical Timer (STM) PPI(1) */
+#define GIC_IRQ_PTM              30 /* Non-secure Physical Timer (PTM) PPI(2) */
+#define GIC_IRQ_IRQ              31 /* Interrupt Request (nIRQ) PPI(3) */
 
 /* Shared Peripheral Interrupts (SPI) follow */
 
@@ -588,10 +664,10 @@ static inline void arm_cpu_sgi(int sgi, unsigned int cpuset)
   uint32_t regval;
 
 #ifdef CONFIG_SMP
-  regval = GIC_ICDSGIR_INTID(sgi) |  GIC_ICDSGIR_CPUTARGET(cpuset) |
+  regval = GIC_ICDSGIR_INTID(sgi) | GIC_ICDSGIR_CPUTARGET(cpuset) |
            GIC_ICDSGIR_TGTFILTER_LIST;
 #else
-  regval = GIC_ICDSGIR_INTID(sgi) |  GIC_ICDSGIR_CPUTARGET(0) |
+  regval = GIC_ICDSGIR_INTID(sgi) | GIC_ICDSGIR_CPUTARGET(0) |
            GIC_ICDSGIR_TGTFILTER_THIS;
 #endif
 
@@ -603,11 +679,11 @@ static inline void arm_cpu_sgi(int sgi, unsigned int cpuset)
  ****************************************************************************/
 
 #ifdef __cplusplus
-#define EXTERN extern "C"
+#  define EXTERN extern "C"
 extern "C"
 {
 #else
-#define EXTERN extern
+#  define EXTERN extern
 #endif
 
 /****************************************************************************
@@ -645,6 +721,26 @@ void arm_gic0_initialize(void);
 void arm_gic_initialize(void);
 
 /****************************************************************************
+ * Name: arm_gic_irq_trigger
+ *
+ * Description:
+ *   Set the trigger type for the specificd IRQ source and the current CPU.
+ *
+ *   Since this API is not supported on all architectures, it should be
+ *   avoided in common implementations where possible.
+ *
+ * Input Parameters:
+ *   irq - The interrupt request to modify.
+ *   edge - False: Active HIGH level sensitive, True: Rising edge sensitive
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value is returned on any failure.
+ *
+ ****************************************************************************/
+
+int arm_gic_irq_trigger(int irq, bool edge);
+
+/****************************************************************************
  * Name: arm_decodeirq
  *
  * Description:
@@ -654,7 +750,7 @@ void arm_gic_initialize(void);
  *   the irq number of the interrupt and then to call arm_doirq to dispatch
  *   the interrupt.
  *
- *  Input parameters:
+ *  Input Parameters:
  *   regs - A pointer to the register save area on the stack.
  *
  ****************************************************************************/
@@ -703,6 +799,28 @@ int arm_start_handler(int irq, void *context, void *arg);
 
 #ifdef CONFIG_SMP
 int arm_pause_handler(int irq, void *context, void *arg);
+#endif
+
+/****************************************************************************
+ * Name: arm_gic_dump
+ *
+ * Description:
+ *   Dump GIC registers to the SYSLOG device
+ *
+ * Input Parameters:
+ *   msg - Message to print with the register data
+ *   all - True: Dump all IRQs; False: Dump only registers for this IRQ
+ *   irq - if all == false, then dump only this IRQ.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_IRQ_INFO
+void arm_gic_dump(const char *msg, bool all, int irq);
+#else
+#  define arm_gic_dump(m,a,i)
 #endif
 
 #undef EXTERN

--- a/arch/arm/src/tms570/Make.defs
+++ b/arch/arm/src/tms570/Make.defs
@@ -39,4 +39,4 @@ ifeq ($(CONFIG_TMS570_GIO_IRQ),y)
 CHIP_CSRCS += tms570_gioirq.c
 endif
 
-CMN_CSRCS := $(filter-out arm_gicv2.c, $(CMN_CSRCS))
+CMN_CSRCS := $(filter-out arm_gicv2.c arm_gicv2_dump.c, $(CMN_CSRCS))

--- a/arch/arm64/src/common/arm64_gicv2.c
+++ b/arch/arm64/src/common/arm64_gicv2.c
@@ -194,17 +194,13 @@
 
 /* Non-secure Access Control Registers, optional: 00xe00-0x0efc */
 
-#define GIC_ICDNSACR_OFFSET(n)     (0x0e00 + GIC_OFFSET32(n))
+#define GIC_ICDNSACR_OFFSET(n)     (0x0e00 + GIC_OFFSET16(n))
 
 /* Software Generated Interrupt Register: 0x0f00 */
 
 #define GIC_ICDSGIR_OFFSET         0x0f00    /* Software Generated Interrupt Register */
 
-/* 0x0f0c-0x0f0c: Reserved */
-
-/* Peripheral Identification Registers: 0x0fd0-0xfe8 */
-
-#define GIC_ICDPIDR_OFFSET(n)      (0x0fd0 + ((n) << 2))
+/* 0x0f04-0x0f0c: Reserved */
 
 /* SGI Clear-Pending Registers: 0x0f10-0x0f1c */
 
@@ -218,11 +214,13 @@
 
 /* 0x0fd0-0x0ffc: Implementation defined */
 
+/* Peripheral Identification Registers: 0x0fd0-0xfe8 */
+
+#define GIC_ICDPIDR_OFFSET(n)      (0x0fd0 + ((n) << 2))
+
 /* Component Identification Registers: 0x0ff0-0x0ffc */
 
 #define GIC_ICDCIDR_OFFSET(n)      (0x0ff0 + ((n) << 2))
-
-/* 0x0f04-0x0ffc: Reserved */
 
 /* GIC Register Addresses ***************************************************/
 
@@ -275,9 +273,9 @@
 #define GIC_ICDSPISR(n)            (MPCORE_ICD_VBASE+GIC_ICDSPISR_OFFSET(n))
 #define GIC_ICDNSACR(n)            (MPCORE_ICD_VBASE+GIC_ICDNSACR_OFFSET(n))
 #define GIC_ICDSGIR                (MPCORE_ICD_VBASE+GIC_ICDSGIR_OFFSET)
-#define GIC_ICDPIDR(n)             (MPCORE_ICD_VBASE+GIC_ICDPIDR_OFFSET(n))
 #define GIC_ICDSCPR(n)             (MPCORE_ICD_VBASE+GIC_ICDSCPR_OFFSET(n))
 #define GIC_ICDSSPR(n)             (MPCORE_ICD_VBASE+GIC_ICDSSPR_OFFSET(n))
+#define GIC_ICDPIDR(n)             (MPCORE_ICD_VBASE+GIC_ICDPIDR_OFFSET(n))
 #define GIC_ICDCIDR(n)             (MPCORE_ICD_VBASE+GIC_ICDCIDR_OFFSET(n))
 
 /* GIC Register Bit Definitions *********************************************/
@@ -338,8 +336,8 @@
 #define GIC_ICCBPR_MASK            (7 << GIC_ICCBPR_SHIFT)
 #  define GIC_ICCBPR_1_7           (0 << GIC_ICCBPR_SHIFT) /* Priority bits [7:1] compared for pre-emption */
 #  define GIC_ICCBPR_2_7           (1 << GIC_ICCBPR_SHIFT) /* Priority bits [7:2] compared for pre-emption */
-#  define GIC_ICCBPR_3_7           (2 << GIC_ICCBPR_SHIFT) /* Priority bits [7:2] compared for pre-emption */
-#  define GIC_ICCBPR_4_7           (3 << GIC_ICCBPR_SHIFT) /* Priority bits [7:2] compared for pre-emption */
+#  define GIC_ICCBPR_3_7           (2 << GIC_ICCBPR_SHIFT) /* Priority bits [7:3] compared for pre-emption */
+#  define GIC_ICCBPR_4_7           (3 << GIC_ICCBPR_SHIFT) /* Priority bits [7:4] compared for pre-emption */
 #  define GIC_ICCBPR_5_7           (4 << GIC_ICCBPR_SHIFT) /* Priority bits [7:5] compared for pre-emption */
 #  define GIC_ICCBPR_6_7           (5 << GIC_ICCBPR_SHIFT) /* Priority bits [7:6] compared for pre-emption */
 #  define GIC_ICCBPR_7_7           (6 << GIC_ICCBPR_SHIFT) /* Priority bit [7] compared for pre-emption */
@@ -360,6 +358,7 @@
 
 /* End of Interrupt Register */
 
+#define GIC_ICCEOIR_SPURIOUSNS     (0x3fe)
 #define GIC_ICCEOIR_SPURIOUS       (0x3ff)
 
 #define GIC_ICCEOIR_INTID_SHIFT    (0)       /* Bits 0-9: Interrupt ID */
@@ -373,9 +372,8 @@
 
 /* Running Interrupt Register */
 
-                                             /* Bits 0-3: Reserved */
-#define GIC_ICCRPR_PRIO_SHIFT      (4)       /* Bits 4-7: Priority mask */
-#define GIC_ICCRPR_PRIO_MASK       (15 << GIC_ICCRPR_PRIO_SHIFT)
+#define GIC_ICCRPR_PRIO_SHIFT      (0)       /* Bits 0-7: Priority mask */
+#define GIC_ICCRPR_PRIO_MASK       (0xff << GIC_ICCRPR_PRIO_SHIFT)
 #  define GIC_ICCRPR_PRIO_VALUE(n) ((uint32_t)(n) << GIC_ICCRPR_PRIO_SHIFT)
 
                                              /* Bits 8-31: Reserved */
@@ -391,39 +389,6 @@
 
                                              /* Bits 13-31: Reserved */
 
-/* Aliased Interrupt Acknowledge Register */
-#define GIC_ICCAIAR_
-
-/* Aliased End of Interrupt Register */
-#define GIC_ICCAEOIR_
-
-/* Aliased Highest Priority Pending Interrupt Register */
-#define GIC_ICCAHPIR_
-
-/* Active Priorities Register 1 */
-#define GIC_ICCAPR1_
-
-/* Active Priorities Register 2 */
-#define GIC_ICCAPR2_
-
-/* Active Priorities Register 3 */
-#define GIC_ICCAPR3_
-
-/* Active Priorities Register 4 */
-#define GIC_ICCAPR4_
-
-/* Non-secure Active Priorities Register 1 */
-#define GIC_ICCNSAPR1_
-
-/* Non-secure Active Priorities Register 2 */
-#define GIC_ICCNSAPR2_
-
-/* Non-secure Active Priorities Register 3 */
-#define GIC_ICCNSAPR3_
-
-/* Non-secure Active Priorities Register 4 */
-#define GIC_ICCNSAPR4_
-
 /* CPU Interface Implementer ID Register */
 
 #define GIC_ICCIDR_IMPL_SHIFT      (0)       /* Bits 0-11:  Implementer */
@@ -436,7 +401,13 @@
 #define GIC_ICCIDR_PARTNO_MASK     (0xfff << GIC_ICCIDR_PARTNO_SHIFT)
 
 /* Deactivate Interrupt Register */
-#define GIC_ICCDIR_
+
+#define GIC_ICCDIR_INTID_SHIFT     (0)       /* Bits 0-9: Interrupt ID */
+#define GIC_ICCDIR_INTID_MASK      (0x3ff << GIC_ICCHPIR_INTID_SHIFT)
+#  define GIC_ICCDIR_INTID(n)      ((uint32_t)(n) << GIC_ICCHPIR_INTID_SHIFT)
+#define GIC_ICCDIR_CPUSRC_SHIFT    (10)      /* Bits 10-12: CPU source ID */
+#define GIC_ICCDIR_CPUSRC_MASK     (7 << GIC_ICCHPIR_CPUSRC_SHIFT)
+#  define GIC_ICCDIR_CPUSRC(n)     ((uint32_t)(n) << GIC_ICCHPIR_CPUSRC_SHIFT)
 
 /* Distributor Registers */
 
@@ -467,10 +438,13 @@
 
 #define GIC_ICDIIDR_IMPL_SHIFT      (0)      /* Bits 0-11: Implementer */
 #define GIC_ICDIIDR_IMPL_MASK       (0xfff << GIC_ICDIIDR_IMPL_SHIFT)
-#define GIC_ICDIIDR_REVISION_SHIFT  (12)     /* Bits 12-23: Revision number */
-#define GIC_ICDIIDR_REVISION_MASK   (0xfff << GIC_ICDIIDR_REVISION_SHIFT)
-#define GIC_ICDIIDR_VERSION_SHIFT   (24)     /* Bits 24-31: Iimplementer version */
-#define GIC_ICDIIDR_VERSION_MASK    (0xff << GIC_ICDIIDR_VERSION_SHIFT)
+#define GIC_ICDIIDR_REVISION_SHIFT  (12)     /* Bits 12-15: Revision number */
+#define GIC_ICDIIDR_REVISION_MASK   (0xf << GIC_ICDIIDR_REVISION_SHIFT)
+#define GIC_ICDIIDR_VARIANT_SHIFT   (16)     /* Bits 16-19 Variant number */
+#define GIC_ICDIIDR_VARIANT_MASK    (0xf << GIC_ICDIIDR_VARIANT_SHIFT)
+                                             /* Bits 20-23: Reserved */
+#define GIC_ICDIIDR_PRODUCTID_SHIFT (24)     /* Bits 24-31: Product id */
+#define GIC_ICDIIDR_PRODUCTID_MASK  (0xff << GIC_ICDIIDR_PRODUCTID_SHIFT)
 
 /* Interrupt Security Registers: 0x0080-0x009c */
 
@@ -554,32 +528,35 @@
 
 /* Non-secure Access Control Registers, optional */
 
-#define GIC_ICDNSACR_INT(n)        GIC_MASK32(n)
+#define GIC_ICDNSACR_NONE          0
+#define GIC_ICDNSACR_SET           1
+#define GIC_ICDNSACR_CLEAR         2
+#define GIC_ICDNSACR_ROUTE         3
+
+#define GIC_ICDNSACR_ID_SHIFT(n)   GIC_SHIFT16(n)
+#define GIC_ICDNSACR_ID_MASK(n)    GIC_MASK16(n)
+#  define GIC_ICDNSACR_ID(n,p)     ((uint32_t)(p) << GIC_SHIFT16(n))
 
 /* Software Generated Interrupt Register */
 
 #define GIC_ICDSGIR_INTID_SHIFT       (0)    /* Bits 0-9: Interrupt ID */
 #define GIC_ICDSGIR_INTID_MASK        (0x3ff << GIC_ICDSGIR_INTID_SHIFT)
 #  define GIC_ICDSGIR_INTID(n)        ((uint32_t)(n) << GIC_ICDSGIR_INTID_SHIFT)
-                                             /* Bits 10-15: Reserved */
+                                             /* Bits 10-14: Reserved */
+#define GIC_ICDSGIR_NSATT             (1 << 15)
 #define GIC_ICDSGIR_CPUTARGET_SHIFT   (16)   /* Bits 16-23: CPU target */
 #define GIC_ICDSGIR_CPUTARGET_MASK    (0xff << GIC_ICDSGIR_CPUTARGET_SHIFT)
 #  define GIC_ICDSGIR_CPUTARGET(n)    ((uint32_t)(n) << GIC_ICDSGIR_CPUTARGET_SHIFT)
-                                             /* Bits 26-31: Reserved */
 #define GIC_ICDSGIR_TGTFILTER_SHIFT   (24)   /* Bits 24-25: Target filter */
 #define GIC_ICDSGIR_TGTFILTER_MASK    (3 << GIC_ICDSGIR_TGTFILTER_SHIFT)
 #  define GIC_ICDSGIR_TGTFILTER_LIST  (0 << GIC_ICDSGIR_TGTFILTER_SHIFT) /* Interrupt sent to CPUs CPU target list */
 #  define GIC_ICDSGIR_TGTFILTER_OTHER (1 << GIC_ICDSGIR_TGTFILTER_SHIFT) /* Interrupt is sent to all but requesting CPU */
 #  define GIC_ICDSGIR_TGTFILTER_THIS  (2 << GIC_ICDSGIR_TGTFILTER_SHIFT) /* Interrupt is sent to requesting CPU only */
-
-/* SGI Clear-Pending Registers */
-#define GIC_ICDSCPR_
-
-/* SGI Set-Pending Registers */
-#define GIC_ICDSSPR_
+                                                                         /* Bits 26-31: Reserved */
 
 /* Peripheral ID2 Register */
-#define GIC_ICPIDR2 (6)
+
+#define GIC_ICPIDR2                   (6)
 
 /* Interrupt IDs ************************************************************/
 
@@ -597,9 +574,47 @@
  * sources.
  */
 
-/* Shared Peripheral Interrupts (SPI) */
+/* Private Peripheral Interrupts (PPI) **************************************/
 
-#define GIC_IRQ_SPI              32  /* First SPI interrupt ID */
+/* Each Cortex-A9 processor has private interrupts, ID0-ID15, that can only
+ * be triggered by software. These interrupts are aliased so that there is
+ * no requirement for a requesting Cortex-A9 processor to determine its own
+ * CPU ID when it deals with SGIs.  The priority of an SGI depends on the
+ * value set by the receiving Cortex-A9 processor in the banked SGI priority
+ * registers, not the priority set by the sending Cortex-A9 processor.
+ *
+ * NOTE: If CONFIG_SMP is enabled then SGI1 and SGI2 are used for inter-CPU
+ * task management.
+ */
+
+#define GIC_IRQ_SGI0              0 /* Software Generated Interrupt (SGI) 0 */
+#define GIC_IRQ_SGI1              1 /* Software Generated Interrupt (SGI) 1 */
+#define GIC_IRQ_SGI2              2 /* Software Generated Interrupt (SGI) 2 */
+#define GIC_IRQ_SGI3              3 /* Software Generated Interrupt (SGI) 3 */
+#define GIC_IRQ_SGI4              4 /* Software Generated Interrupt (SGI) 4 */
+#define GIC_IRQ_SGI5              5 /* Software Generated Interrupt (SGI) 5 */
+#define GIC_IRQ_SGI6              6 /* Software Generated Interrupt (SGI) 6 */
+#define GIC_IRQ_SGI7              7 /* Software Generated Interrupt (SGI) 7 */
+#define GIC_IRQ_SGI8              8 /* Software Generated Interrupt (SGI) 8 */
+#define GIC_IRQ_SGI9              9 /* Software Generated Interrupt (SGI) 9 */
+#define GIC_IRQ_SGI10            10 /* Software Generated Interrupt (SGI) 10 */
+#define GIC_IRQ_SGI11            11 /* Software Generated Interrupt (SGI) 11 */
+#define GIC_IRQ_SGI12            12 /* Software Generated Interrupt (SGI) 12 */
+#define GIC_IRQ_SGI13            13 /* Software Generated Interrupt (SGI) 13 */
+#define GIC_IRQ_SGI14            14 /* Software Generated Interrupt (SGI) 14 */
+#define GIC_IRQ_SGI15            15 /* Software Generated Interrupt (SGI) 15 */
+
+#define GIC_IRQ_VM               25 /* Virtual Maintenance Interrupt (VM) PPI(6) */
+#define GIC_IRQ_HTM              26 /* Hypervisor Timer (HTM) PPI(5) */
+#define GIC_IRQ_VTM              27 /* Virtual Timer (VTM) PPI(4) */
+#define GIC_IRQ_FIQ              28 /* Fast Interrupt Request (nFIQ) PPI(0) */
+#define GIC_IRQ_STM              29 /* Secure Physical Timer (STM) PPI(1) */
+#define GIC_IRQ_PTM              30 /* Non-secure Physical Timer (PTM) PPI(2) */
+#define GIC_IRQ_IRQ              31 /* Interrupt Request (nIRQ) PPI(3) */
+
+/* Shared Peripheral Interrupts (SPI) follow */
+
+#define GIC_IRQ_SPI              32 /* First SPI interrupt ID */
 
 /****************************************************************************
  * Private Functions
@@ -657,10 +672,10 @@ static inline void arm_cpu_sgi(int sgi, unsigned int cpuset)
   uint32_t regval;
 
 #ifdef CONFIG_SMP
-  regval = GIC_ICDSGIR_INTID(sgi) |  GIC_ICDSGIR_CPUTARGET(cpuset) |
+  regval = GIC_ICDSGIR_INTID(sgi) | GIC_ICDSGIR_CPUTARGET(cpuset) |
            GIC_ICDSGIR_TGTFILTER_LIST;
 #else
-  regval = GIC_ICDSGIR_INTID(sgi) |  GIC_ICDSGIR_CPUTARGET(0) |
+  regval = GIC_ICDSGIR_INTID(sgi) | GIC_ICDSGIR_CPUTARGET(0) |
            GIC_ICDSGIR_TGTFILTER_THIS;
 #endif
 
@@ -852,7 +867,7 @@ static void arm_gic_initialize(void)
   /* Registers with 1-bit per interrupt */
 
   putreg32(0x00000000, GIC_ICDISR(0));      /* SGIs and PPIs secure */
-  putreg32(0xf8000000, GIC_ICDICER(0));     /* PPIs disabled */
+  putreg32(0xfe000000, GIC_ICDICER(0));     /* PPIs disabled */
 
   /* Registers with 8-bits per interrupt */
 
@@ -860,7 +875,7 @@ static void arm_gic_initialize(void)
   putreg32(0x80808080, GIC_ICDIPR(4));      /* SGI[4:7] priority */
   putreg32(0x80808080, GIC_ICDIPR(8));      /* SGI[8:11] priority */
   putreg32(0x80808080, GIC_ICDIPR(12));     /* SGI[12:15] priority */
-  putreg32(0x80000000, GIC_ICDIPR(24));     /* PPI[0] priority */
+  putreg32(0x80808000, GIC_ICDIPR(24));     /* PPI[0] priority */
   putreg32(0x80808080, GIC_ICDIPR(28));     /* PPI[1:4] priority */
 
   /* Set the binary point register.
@@ -896,7 +911,7 @@ static void arm_gic_initialize(void)
 #elif defined(CONFIG_ARCH_TRUSTZONE_NONSECURE)
   /* Clear non-secure state ICCICR bits to be configured below */
 
-  iccicr &= ~(GIC_ICCICRS_EOIMODENS | GIC_ICCICRU_ENABLEGRP1 |
+  iccicr &= ~(GIC_ICCICRU_EOIMODENS | GIC_ICCICRU_ENABLEGRP1 |
               GIC_ICCICRU_FIQBYPDISGRP1 | GIC_ICCICRU_IRQBYPDISGRP1);
 
 #endif
@@ -967,7 +982,7 @@ static void arm_gic_initialize(void)
    * NOTE:  Only for processors that operate in non-secure state.
    */
 
-  iccicr |= GIC_ICCICRS_EOIMODENS;
+  iccicr |= GIC_ICCICRU_EOIMODENS;
 
 #  elif defined(CONFIG_ARCH_TRUSTZONE_BOTH)
   /* Set EnableNS=1 to enable the CPU to signal non-secure interrupts.
@@ -975,7 +990,7 @@ static void arm_gic_initialize(void)
    * NOTE:  Only for processors that operate in non-secure state.
    */
 
-  iccicr |= GIC_ICCICRU_EOIMODENS;
+  iccicr |= GIC_ICCICRS_EOIMODENS;
 #  endif
 #endif
 
@@ -1072,7 +1087,7 @@ static void arm_gic_initialize(void)
  *
  ****************************************************************************/
 
-uint64_t * arm64_decodeirq(uint64_t * regs)
+uint64_t *arm64_decodeirq(uint64_t * regs)
 {
   uint32_t regval;
   int irq;
@@ -1207,10 +1222,10 @@ int up_prioritize_irq(int irq, int priority)
        * distributor Interrupt Priority Register (GIC_ICDIPR).
        */
 
-      regaddr  = GIC_ICDIPR(irq);
-      regval   = getreg32(regaddr);
-      regval  &= ~GIC_ICDIPR_ID_MASK(irq);
-      regval  |= GIC_ICDIPR_ID(irq, priority);
+      regaddr = GIC_ICDIPR(irq);
+      regval  = getreg32(regaddr);
+      regval &= ~GIC_ICDIPR_ID_MASK(irq);
+      regval |= GIC_ICDIPR_ID(irq, priority);
       putreg32(regval, regaddr);
 
       return OK;


### PR DESCRIPTION
## Summary

from https://developer.arm.com/documentation/ihi0048/b.
and Sync armv7r gic/timer with armv7-a 

## Impact

## Testing

internal