### PR TITLE
Changed NRF52 USB initialization to check for power via USBREGSTATUS …

### DIFF
--- a/arch/arm/src/nrf52/nrf52_usbd.c
+++ b/arch/arm/src/nrf52/nrf52_usbd.c
@@ -3052,9 +3052,8 @@ static void nrf52_hwinitialize(struct nrf52_usbdev_s *priv)
 {
   /* Wait for VBUS */
 
-  /* TODO: connect to POWER USB events */
-
-  while (getreg32(NRF52_POWER_EVENTS_USBDETECTED) == 0);
+  while ((getreg32(NRF52_POWER_USBREGSTATUS) &
+          NRF52_POWER_USBREGSTATUS_VBUSDETECT) == 0) ;
 
   /* Errata [187] USBD: USB cannot be enabled */
 


### PR DESCRIPTION
…instead of waiting for interrupt, in case we've been launched from a bootloader.

## Summary

Bug fix.

## Impact

Bug fix.

## Testing

Run on Arduino Nano 33 BLE.
