### PR TITLE
Fixed NRF52 I2C register naming.

### DIFF
--- a/arch/arm/src/nrf52/hardware/nrf52_twi.h
+++ b/arch/arm/src/nrf52/hardware/nrf52_twi.h
@@ -60,9 +60,9 @@
 #define NRF52_TWIM_RXDAMOUNT_OFFSET         0x053c /* Number of bytes transferred in the last RXD transaction */
 #define NRF52_TWIM_RXDLIST_OFFSET           0x0540 /* RX EasyDMA list type */
 #define NRF52_TWIM_TXDPTR_OFFSET            0x0544 /* TXD Data pointer */
-#define NRF52_TWIM_TXMAXCNT_OFFSET          0x0548 /* Maximum number of bytes in TXD buffer */
-#define NRF52_TWIM_TXAMOUNT_OFFSET          0x054c /* Number of bytes transferred in the last TXD transaction */
-#define NRF52_TWIM_TXLIST_OFFSET            0x0550 /* TX EasyDMA list type */
+#define NRF52_TWIM_TXDMAXCNT_OFFSET         0x0548 /* Maximum number of bytes in TXD buffer */
+#define NRF52_TWIM_TXDAMOUNT_OFFSET         0x054c /* Number of bytes transferred in the last TXD transaction */
+#define NRF52_TWIM_TXDLIST_OFFSET           0x0550 /* TX EasyDMA list type */
 #define NRF52_TWIM_ADDRESS_OFFSET           0x0588 /* TWIM address */
 
 /* Register offsets for TWI slave (TWIS) ************************************/

--- a/arch/arm/src/nrf52/nrf52_i2c.c
+++ b/arch/arm/src/nrf52/nrf52_i2c.c
@@ -23,6 +23,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/signal.h>
 
 #include <assert.h>
 #include <errno.h>
@@ -373,7 +374,7 @@ static int nrf52_i2c_transfer(struct i2c_master_s *dev,
           /* Write number of bytes in TXD buffer */
 
           regval = priv->dcnt;
-          nrf52_i2c_putreg(priv, NRF52_TWIM_TXMAXCNT_OFFSET, regval);
+          nrf52_i2c_putreg(priv, NRF52_TWIM_TXDMAXCNT_OFFSET, regval);
 
           /* Start TX sequence */
 


### PR DESCRIPTION
## Summary

Several register names were not quite correct.

## Impact

No functional change.

## Testing

Tested on Arduino Nano 33 BLE board.
