### PR TITLE
Added config setting for NRF52 I2C timing bug workaround.

### DIFF
--- a/arch/arm/src/nrf52/Kconfig
+++ b/arch/arm/src/nrf52/Kconfig
@@ -717,6 +717,14 @@ config NRF52_I2C_MASTER_COPY_BUF_SIZE
 		transaction will fit otherwise it will fall back
 		on malloc.
 
+config NRF52_I2C_MASTER_WORKAROUND_400KBPS_TIMING
+	bool "Master 400Kbps timing anomaly workaround"
+	depends on ARCH_CHIP_NRF52840
+	default y
+	---help---
+		Enable the workaround to fix I2C Master 400Kbps timing bug
+		which occurs in all NRF52840 revisions to date.
+
 endif # NRF52_I2C_MASTER
 
 endmenu

--- a/arch/arm/src/nrf52/hardware/nrf52_twi.h
+++ b/arch/arm/src/nrf52/hardware/nrf52_twi.h
@@ -154,7 +154,11 @@
 
 #define TWIM_FREQUENCY_100KBPS              (0x01980000) /* 100 kbps */
 #define TWIM_FREQUENCY_250KBPS              (0x04000000) /* 250 kbps */
+#ifdef NRF52_I2C_MASTER_WORKAROUND_400KBPS_TIMING
+#define TWIM_FREQUENCY_400KBPS              (0x06200000) /* 400 kbps */
+#else
 #define TWIM_FREQUENCY_400KBPS              (0x06400000) /* 400 kbps */
+#endif
 
 /* RXDMAXCNT Register */
 


### PR DESCRIPTION
## Summary

Added config option to enable timing bug workaround for NRF52 I2C. Erratum details at:

https://infocenter.nordicsemi.com/index.jsp?topic=%2Fstruct_nrf52%2Fstruct%2Fnrf52840_errata.html

[219] TWIM: I2C timing spec is violated at 400 kHz

## Impact

Very sensitive I2C devices may fail to respond without this change.

## Testing

Tested on Arduino Nano 33 BLE board.