### PR TITLE
Port recent changes in nrf52 to other Nordic chips

### DIFF
--- a/arch/arm/src/nrf52/hardware/nrf52_twi.h
+++ b/arch/arm/src/nrf52/hardware/nrf52_twi.h
@@ -154,10 +154,10 @@
 
 #define TWIM_FREQUENCY_100KBPS              (0x01980000) /* 100 kbps */
 #define TWIM_FREQUENCY_250KBPS              (0x04000000) /* 250 kbps */
-#ifdef NRF52_I2C_MASTER_WORKAROUND_400KBPS_TIMING
-#define TWIM_FREQUENCY_400KBPS              (0x06200000) /* 400 kbps */
+#ifdef CONFIG_NRF52_I2C_MASTER_WORKAROUND_400KBPS_TIMING
+#  define TWIM_FREQUENCY_400KBPS            (0x06200000) /* 390 kbps */
 #else
-#define TWIM_FREQUENCY_400KBPS              (0x06400000) /* 400 kbps */
+#  define TWIM_FREQUENCY_400KBPS            (0x06400000) /* 400 kbps */
 #endif
 
 /* RXDMAXCNT Register */

--- a/arch/arm/src/nrf52/nrf52_i2c.c
+++ b/arch/arm/src/nrf52/nrf52_i2c.c
@@ -23,7 +23,6 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
-#include <nuttx/signal.h>
 
 #include <assert.h>
 #include <errno.h>

--- a/arch/arm/src/nrf53/Kconfig
+++ b/arch/arm/src/nrf53/Kconfig
@@ -687,6 +687,13 @@ config NRF53_I2C_MASTER_COPY_BUF_SIZE
 		transaction will fit otherwise it will fall back
 		on malloc.
 
+config NRF53_I2C_MASTER_WORKAROUND_400KBPS_TIMING
+	bool "Master 400Kbps timing anomaly workaround"
+	default y
+	---help---
+		Enable the workaround to fix I2C Master 400Kbps timing bug
+		which occurs in all NRF5340 revisions to date.
+
 endif # NRF53_I2C_MASTER
 
 endmenu

--- a/arch/arm/src/nrf53/hardware/nrf53_twi.h
+++ b/arch/arm/src/nrf53/hardware/nrf53_twi.h
@@ -62,9 +62,9 @@
 #define NRF53_TWIM_RXDAMOUNT_OFFSET         0x053c /* Number of bytes transferred in the last RXD transaction */
 #define NRF53_TWIM_RXDLIST_OFFSET           0x0540 /* RX EasyDMA list type */
 #define NRF53_TWIM_TXDPTR_OFFSET            0x0544 /* TXD Data pointer */
-#define NRF53_TWIM_TXMAXCNT_OFFSET          0x0548 /* Maximum number of bytes in TXD buffer */
-#define NRF53_TWIM_TXAMOUNT_OFFSET          0x054c /* Number of bytes transferred in the last TXD transaction */
-#define NRF53_TWIM_TXLIST_OFFSET            0x0550 /* TX EasyDMA list type */
+#define NRF53_TWIM_TXDMAXCNT_OFFSET         0x0548 /* Maximum number of bytes in TXD buffer */
+#define NRF53_TWIM_TXDAMOUNT_OFFSET         0x054c /* Number of bytes transferred in the last TXD transaction */
+#define NRF53_TWIM_TXDLIST_OFFSET           0x0550 /* TX EasyDMA list type */
 #define NRF53_TWIM_ADDRESS_OFFSET           0x0588 /* TWIM address */
 
 /* Register offsets for TWI slave (TWIS) ************************************/
@@ -94,9 +94,9 @@
 #define NRF53_TWIS_RXDAMOUNT_OFFSET         0x053c /* Number of bytes transferred in the last RXD transaction */
 #define NRF53_TWIS_RXDLIST_OFFSET           0x0540 /* RX EasyDMA list type */
 #define NRF53_TWIS_TXDPTR_OFFSET            0x0544 /* TXD Data pointer */
-#define NRF53_TWIS_TXMAXCNT_OFFSET          0x0548 /* Maximum number of bytes in TXD buffer */
-#define NRF53_TWIS_TXAMOUNT_OFFSET          0x054c /* Number of bytes transferred in the last TXD transaction */
-#define NRF53_TWIS_TXLIST_OFFSET            0x0550 /* TX EasyDMA list type */
+#define NRF53_TWIS_TXDMAXCNT_OFFSET         0x0548 /* Maximum number of bytes in TXD buffer */
+#define NRF53_TWIS_TXDAMOUNT_OFFSET         0x054c /* Number of bytes transferred in the last TXD transaction */
+#define NRF53_TWIS_TXDLIST_OFFSET           0x0550 /* TX EasyDMA list type */
 #define NRF53_TWIS_ADDRESS0_OFFSET          0x0588 /* TWIS address 0 */
 #define NRF53_TWIS_ADDRESS1_OFFSET          0x058c /* TWIS address 1 */
 #define NRF53_TWIS_CONFIG_OFFSET            0x0594 /* Configuration register for the address match mechanism */

--- a/arch/arm/src/nrf53/hardware/nrf53_twi.h
+++ b/arch/arm/src/nrf53/hardware/nrf53_twi.h
@@ -156,7 +156,11 @@
 
 #define TWIM_FREQUENCY_100KBPS              (0x01980000) /* 100 kbps */
 #define TWIM_FREQUENCY_250KBPS              (0x04000000) /* 250 kbps */
-#define TWIM_FREQUENCY_400KBPS              (0x06400000) /* 400 kbps */
+#ifdef CONFIG_NRF53_I2C_MASTER_WORKAROUND_400KBPS_TIMING
+#  define TWIM_FREQUENCY_400KBPS            (0x06200000) /* 390 kbps */
+#else
+#  define TWIM_FREQUENCY_400KBPS            (0x06400000) /* 400 kbps */
+#endif
 #define TWIM_FREQUENCY_1000KBPS             (0x0ff00000) /* 1000 kbps */
 
 /* RXDMAXCNT Register */

--- a/arch/arm/src/nrf53/nrf53_i2c.c
+++ b/arch/arm/src/nrf53/nrf53_i2c.c
@@ -423,7 +423,7 @@ static int nrf53_i2c_transfer(struct i2c_master_s *dev,
           /* Write number of bytes in TXD buffer */
 
           regval = priv->dcnt;
-          nrf53_i2c_putreg(priv, NRF53_TWIM_TXMAXCNT_OFFSET, regval);
+          nrf53_i2c_putreg(priv, NRF53_TWIM_TXDMAXCNT_OFFSET, regval);
 
           /* Start TX sequence */
 

--- a/arch/arm/src/nrf53/nrf53_usbd.c
+++ b/arch/arm/src/nrf53/nrf53_usbd.c
@@ -3052,9 +3052,8 @@ static void nrf53_hwinitialize(struct nrf53_usbdev_s *priv)
 {
   /* Wait for VBUS */
 
-  /* TODO: connect to POWER USB events */
-
-  while (getreg32(NRF53_USBREG_EVENTS_USBDETECTED) == 0);
+  while ((getreg32(NRF53_USBREG_USBREGSTATUS) &
+          USBREG_USBREGSTATUS_VBUSDETECT) == 0);
 
   /* Enable the USB controller */
 

--- a/arch/arm/src/nrf91/hardware/nrf91_twi.h
+++ b/arch/arm/src/nrf91/hardware/nrf91_twi.h
@@ -62,9 +62,9 @@
 #define NRF91_TWIM_RXDAMOUNT_OFFSET         0x053c /* Number of bytes transferred in the last RXD transaction */
 #define NRF91_TWIM_RXDLIST_OFFSET           0x0540 /* RX EasyDMA list type */
 #define NRF91_TWIM_TXDPTR_OFFSET            0x0544 /* TXD Data pointer */
-#define NRF91_TWIM_TXMAXCNT_OFFSET          0x0548 /* Maximum number of bytes in TXD buffer */
-#define NRF91_TWIM_TXAMOUNT_OFFSET          0x054c /* Number of bytes transferred in the last TXD transaction */
-#define NRF91_TWIM_TXLIST_OFFSET            0x0550 /* TX EasyDMA list type */
+#define NRF91_TWIM_TXDMAXCNT_OFFSET         0x0548 /* Maximum number of bytes in TXD buffer */
+#define NRF91_TWIM_TXDAMOUNT_OFFSET         0x054c /* Number of bytes transferred in the last TXD transaction */
+#define NRF91_TWIM_TXDLIST_OFFSET           0x0550 /* TX EasyDMA list type */
 #define NRF91_TWIM_ADDRESS_OFFSET           0x0588 /* TWIM address */
 
 /* Register offsets for TWI slave (TWIS) ************************************/
@@ -94,9 +94,9 @@
 #define NRF91_TWIS_RXDAMOUNT_OFFSET         0x053c /* Number of bytes transferred in the last RXD transaction */
 #define NRF91_TWIS_RXDLIST_OFFSET           0x0540 /* RX EasyDMA list type */
 #define NRF91_TWIS_TXDPTR_OFFSET            0x0544 /* TXD Data pointer */
-#define NRF91_TWIS_TXMAXCNT_OFFSET          0x0548 /* Maximum number of bytes in TXD buffer */
-#define NRF91_TWIS_TXAMOUNT_OFFSET          0x054c /* Number of bytes transferred in the last TXD transaction */
-#define NRF91_TWIS_TXLIST_OFFSET            0x0550 /* TX EasyDMA list type */
+#define NRF91_TWIS_TXDMAXCNT_OFFSET         0x0548 /* Maximum number of bytes in TXD buffer */
+#define NRF91_TWIS_TXDAMOUNT_OFFSET         0x054c /* Number of bytes transferred in the last TXD transaction */
+#define NRF91_TWIS_TXDLIST_OFFSET           0x0550 /* TX EasyDMA list type */
 #define NRF91_TWIS_ADDRESS0_OFFSET          0x0588 /* TWIS address 0 */
 #define NRF91_TWIS_ADDRESS1_OFFSET          0x058c /* TWIS address 1 */
 #define NRF91_TWIS_CONFIG_OFFSET            0x0594 /* Configuration register for the address match mechanism */

--- a/arch/arm/src/nrf91/nrf91_i2c.c
+++ b/arch/arm/src/nrf91/nrf91_i2c.c
@@ -423,7 +423,7 @@ static int nrf91_i2c_transfer(struct i2c_master_s *dev,
           /* Write number of bytes in TXD buffer */
 
           regval = priv->dcnt;
-          nrf91_i2c_putreg(priv, NRF91_TWIM_TXMAXCNT_OFFSET, regval);
+          nrf91_i2c_putreg(priv, NRF91_TWIM_TXDMAXCNT_OFFSET, regval);
 
           /* Start TX sequence */
 


### PR DESCRIPTION
## Summary

- arch/nrf52/nrf52_i2c.c: remove unnecessary include introduced in cc99d94cfd
- arch/nrf52/nrf52_twi.h: fix condition
- arch/nrf53: port d7aea88727 change from nrf52
- arch/{nrf53|nrf91}: port cc99d94cfd change from nrf52
- arch/nrf53: port 6e8f25ba3b change from nrf52

## Impact

## Testing
CI
