### PR TITLE
crypto: Remove CRYPTO_SW_AES and CRYPTO_BLAKE2S

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -26,19 +26,38 @@ if(CONFIG_CRYPTO)
 
   if(CONFIG_CRYPTO_CRYPTODEV)
     list(APPEND SRCS cryptodev.c)
+    if(CONFIG_CRYPTO_CRYPTODEV_SOFTWARE)
+      list(APPEND SRCS cryptosoft.c)
+      list(APPEND SRCS xform.c)
+    endif()
   endif()
 
-  # Software AES library
+  # Software crypto library
 
   if(CONFIG_CRYPTO_SW_AES)
     list(APPEND SRCS aes.c)
   endif()
-
-  # BLAKE2s hash algorithm
-
-  if(CONFIG_CRYPTO_BLAKE2S)
-    list(APPEND SRCS blake2s.c)
-  endif()
+  list(APPEND SRCS blake2s.c)
+  list(APPEND SRCS blf.c)
+  list(APPEND SRCS cast.c)
+  list(APPEND SRCS chachapoly.c)
+  list(APPEND SRCS ecb_enc.c)
+  list(APPEND SRCS ecb3_enc.c)
+  list(APPEND SRCS set_key.c)
+  list(APPEND SRCS md5.c)
+  list(APPEND SRCS poly1305.c)
+  list(APPEND SRCS rijndael.c)
+  list(APPEND SRCS rmd160.c)
+  list(APPEND SRCS sha1.c)
+  list(APPEND SRCS sha2.c)
+  list(APPEND SRCS gmac.c)
+  list(APPEND SRCS cmac.c)
+  list(APPEND SRCS hmac.c)
+  list(APPEND SRCS idgen.c)
+  list(APPEND SRCS key_wrap.c)
+  list(APPEND SRCS siphash.c)
+  list(APPEND SRCS hmac_buff.c)
+  list(APPEND SRCS curve25519.c)
 
   # Entropy pool random number generator
 

--- a/crypto/Kconfig
+++ b/crypto/Kconfig
@@ -62,16 +62,9 @@ config CRYPTO_SW_AES
 		implementations.  This needs to support up_aesinitialize() and
 		aes_cypher() per include/nuttx/crypto/crypto.h.
 
-config CRYPTO_BLAKE2S
-	bool "BLAKE2s hash algorithm"
-	default n
-	---help---
-		Enable the BLAKE2s hash algorithm
-
 config CRYPTO_RANDOM_POOL
 	bool "Entropy pool and strong randon number generator"
 	default n
-	select CRYPTO_BLAKE2S
 	---help---
 		Entropy pool gathers environmental noise from device drivers,
 		user-space, etc., and returns good random numbers, suitable

--- a/crypto/Makefile
+++ b/crypto/Makefile
@@ -32,36 +32,36 @@ ifeq ($(CONFIG_CRYPTO_CRYPTODEV),y)
   CRYPTO_CSRCS += cryptodev.c
 ifeq ($(CONFIG_CRYPTO_CRYPTODEV_SOFTWARE),y)
   CRYPTO_CSRCS += cryptosoft.c
-endif
   CRYPTO_CSRCS += xform.c
+endif
+endif
+
+# Software crypto algorithm
+
+ifeq ($(CONFIG_CRYPTO_SW_AES),y)
   CRYPTO_CSRCS += aes.c
-  CRYPTO_CSRCS += blf.c
-  CRYPTO_CSRCS += cast.c
-  CRYPTO_CSRCS += chachapoly.c
-  CRYPTO_CSRCS += ecb_enc.c
-  CRYPTO_CSRCS += ecb3_enc.c
-  CRYPTO_CSRCS += set_key.c
-  CRYPTO_CSRCS += md5.c
-  CRYPTO_CSRCS += poly1305.c
-  CRYPTO_CSRCS += rijndael.c
-  CRYPTO_CSRCS += rmd160.c
-  CRYPTO_CSRCS += sha1.c
-  CRYPTO_CSRCS += sha2.c
-  CRYPTO_CSRCS += gmac.c
-  CRYPTO_CSRCS += cmac.c
-  CRYPTO_CSRCS += hmac.c
-  CRYPTO_CSRCS += idgen.c
-  CRYPTO_CSRCS += key_wrap.c
-  CRYPTO_CSRCS += siphash.c
-  CRYPTO_CSRCS += hmac_buff.c
-  CRYPTO_CSRCS += curve25519.c
 endif
-
-# BLAKE2s hash algorithm
-
-ifeq ($(CONFIG_CRYPTO_BLAKE2S),y)
-  CRYPTO_CSRCS += blake2s.c
-endif
+CRYPTO_CSRCS += blake2s.c
+CRYPTO_CSRCS += blf.c
+CRYPTO_CSRCS += cast.c
+CRYPTO_CSRCS += chachapoly.c
+CRYPTO_CSRCS += ecb_enc.c
+CRYPTO_CSRCS += ecb3_enc.c
+CRYPTO_CSRCS += set_key.c
+CRYPTO_CSRCS += md5.c
+CRYPTO_CSRCS += poly1305.c
+CRYPTO_CSRCS += rijndael.c
+CRYPTO_CSRCS += rmd160.c
+CRYPTO_CSRCS += sha1.c
+CRYPTO_CSRCS += sha2.c
+CRYPTO_CSRCS += gmac.c
+CRYPTO_CSRCS += cmac.c
+CRYPTO_CSRCS += hmac.c
+CRYPTO_CSRCS += idgen.c
+CRYPTO_CSRCS += key_wrap.c
+CRYPTO_CSRCS += siphash.c
+CRYPTO_CSRCS += hmac_buff.c
+CRYPTO_CSRCS += curve25519.c
 
 # Entropy pool random number generator
 


### PR DESCRIPTION
## Summary

since it's simpler to let linker remove the unused functions from the final image

## Impact

crypto

## Testing

ci