### PR TITLE
net/tcp: Fix the sack byte aligment error.

### DIFF
--- a/net/tcp/tcp_send_buffered.c
+++ b/net/tcp/tcp_send_buffered.c
@@ -373,8 +373,10 @@ static int parse_sack(FAR struct tcp_conn_s *conn, FAR struct tcp_hdr_s *tcp,
 
           for (i = 0; i < nsack; i++)
             {
-              segs[i].left = tcp_getsequence((uint8_t *)&sacks[i].left);
-              segs[i].right = tcp_getsequence((uint8_t *)&sacks[i].right);
+              /* Use the pointer to avoid the error of 4 byte alignment. */
+
+              segs[i].left = tcp_getsequence((uint8_t *)&sacks[i]);
+              segs[i].right = tcp_getsequence((uint8_t *)&sacks[i] + 4);
             }
 
           tcp_reorder_ofosegs(nsack, segs);


### PR DESCRIPTION


## Summary
Fix the sack byte aligment error when parsing the sack options from input tcp headers.
The error log is as follows:
  tcp/tcp_send_buffered.c:376:57: runtime error: member access within misaligned  address 0x10075942 for type 'struct tcp_sack_s', which requires 4 byte alignment

## Impact
Parsing the sack options form input tcp headers does not generate the 4 bytes alignment error.
## Testing
In the sim environment, both nuttx sim enable the sack function. Using the iperf tool to stream, does not generate the sack 4 bytes alignment error as described above.
