### PR TITLE
net/local: Fix the error return length when read the bigger packet.

### DIFF
--- a/net/local/local_recvmsg.c
+++ b/net/local/local_recvmsg.c
@@ -398,7 +398,6 @@ psock_dgram_recvfrom(FAR struct socket *psock, FAR void *buf, size_t len,
 
           DEBUGASSERT(tmplen <= remaining);
           remaining -= tmplen;
-          readlen += tmplen;
         }
       while (remaining > 0);
     }


### PR DESCRIPTION
## Summary
Fix the error return length when read the bigger packet.
## Impact
  Write a bigger packet and read the packet using a smaller buffer.
  The return length of read should be the length of smaller buffer.
## Testing
  - We use the local udp socketpair to create the socket vectors.
  - Write the bigger packet (128 bytes) to the socket[0], 
  - then read the packet from the socket[1] using the smaller buffer,
    the buffer lenght is 50 bytes.
  - The returned lenght of read should be 50. 
