### PR TITLE
net/local: Return an error when write the too big packet.

### DIFF
--- a/net/local/local_sendpacket.c
+++ b/net/local/local_sendpacket.c
@@ -130,6 +130,12 @@ int local_send_packet(FAR struct file *filep, FAR const struct iovec *buf,
           len16 += iov->iov_len;
         }
 
+      if (len16 > CONFIG_DEV_FIFO_SIZE - sizeof(uint16_t))
+        {
+          nerr("ERROR: Packet is too big: %d\n", len16);
+          return -EMSGSIZE;
+        }
+
       ret = local_fifo_write(filep, (FAR const uint8_t *)&len16,
                              sizeof(uint16_t));
       if (ret != sizeof(uint16_t))


### PR DESCRIPTION

## Summary
When using the local udp socketpair, write a too big packet to the socket.
An appropriate errno (EMSGSIZE) should be returned. 
## Impact
  Write a packet, the length is bigger than CONFIG_DEV_FIFO_SIZE.
  The return value should be -1, and the errno is EMSGSIZE.
## Testing
  When write a bigger (CONFIG_DEV_FIFO_SIZE) packet to a socket create by local udp socketpair.
  The write should return -1 with the errno EMSGSIZE.
