### PR TITLE
arch/stm32h7: use correct name for bit 2 in STM32_PWR_CR3 register

### DIFF
--- a/arch/arm/src/stm32h7/hardware/stm32h7x3xx_pwr.h
+++ b/arch/arm/src/stm32h7/hardware/stm32h7x3xx_pwr.h
@@ -129,8 +129,9 @@
 
 #define STM32_PWR_CR3_BYPASS                (1 << 0)  /* Bit 0: Power management unit bypass */
 #define STM32_PWR_CR3_LDOEN                 (1 << 1)  /* Bit 1: Low drop-out regulator enable */
-#define STM32_PWR_CR3_LDOESCUEN             (1 << 2)  /* Bit 2: Supply configuration update enable */
+#define STM32_PWR_CR3_SCUEN                 (1 << 2)  /* Bit 2: Supply configuration update enable */
 #ifdef CONFIG_STM32H7_HAVE_SMPS
+#define STM32_PWR_CR3_SDEN                  (1 << 2)  /* Bit 2: SMPS step-down converter enable */
 #define STM32_PWR_CR3_SMPSEXTHP             (1 << 3)  /* Bit 3: SMPS step-down converter external power delivery selection */
 #define STM32_PWR_CR3_SMPSLEVEL_SHIFT       (4)       /* BitS 4-5: SMPS step-down converter voltage output level selection */
 #  define STM32_PWR_CR3_SMPSLEVEL_MASK      (3 << STM32_PWR_CR3_SMPSLEVEL_SHIFT)

--- a/arch/arm/src/stm32h7/stm32h7x3xx_rcc.c
+++ b/arch/arm/src/stm32h7/stm32h7x3xx_rcc.c
@@ -876,11 +876,11 @@ void stm32_stdclockconfig(void)
       regval = getreg32(STM32_PWR_CR3);
       regval &= ~(STM32_PWR_CR3_BYPASS | STM32_PWR_CR3_LDOEN |
           STM32_PWR_CR3_SMPSEXTHP | STM32_PWR_CR3_SMPSLEVEL_MASK);
-      regval |= STM32_PWR_CR3_LDOESCUEN;
+      regval |= STM32_PWR_CR3_SCUEN;
       putreg32(regval, STM32_PWR_CR3);
 #else
       regval = getreg32(STM32_PWR_CR3);
-      regval |= STM32_PWR_CR3_LDOEN | STM32_PWR_CR3_LDOESCUEN;
+      regval |= STM32_PWR_CR3_LDOEN | STM32_PWR_CR3_SCUEN;
       putreg32(regval, STM32_PWR_CR3);
 #endif
 

--- a/arch/arm/src/stm32h7/stm32h7x7xx_rcc.c
+++ b/arch/arm/src/stm32h7/stm32h7x7xx_rcc.c
@@ -858,11 +858,11 @@ void stm32_stdclockconfig(void)
       regval = getreg32(STM32_PWR_CR3);
       regval &= ~(STM32_PWR_CR3_BYPASS | STM32_PWR_CR3_LDOEN |
           STM32_PWR_CR3_SMPSEXTHP | STM32_PWR_CR3_SMPSLEVEL_MASK);
-      regval |= STM32_PWR_CR3_LDOESCUEN;
+      regval |= STM32_PWR_CR3_SCUEN;
       putreg32(regval, STM32_PWR_CR3);
 #else
       regval = getreg32(STM32_PWR_CR3);
-      regval |= STM32_PWR_CR3_LDOEN | STM32_PWR_CR3_LDOESCUEN;
+      regval |= STM32_PWR_CR3_LDOEN | STM32_PWR_CR3_SCUEN;
       putreg32(regval, STM32_PWR_CR3);
 #endif
 


### PR DESCRIPTION
## Summary
arch/stm32h7: use correct name for bit 2 in STM32_PWR_CR3 register

## Impact

## Testing
ci
