### PR TITLE
net: Add `FIOC_FILEPATH` ioctl support for ICMP(v6)/RPMsg/Usrsock sockets

### DIFF
--- a/net/icmp/icmp_ioctl.c
+++ b/net/icmp/icmp_ioctl.c
@@ -25,6 +25,7 @@
 #include <nuttx/config.h>
 
 #include <stdint.h>
+#include <stdio.h>
 #include <stdbool.h>
 #include <debug.h>
 #include <errno.h>
@@ -76,6 +77,12 @@ int icmp_ioctl(FAR struct socket *psock, int cmd, unsigned long arg)
         break;
       case FIONSPACE:
         *(FAR int *)((uintptr_t)arg) = MIN_UDP_MSS;
+        break;
+      case FIOC_FILEPATH:
+        snprintf((FAR char *)(uintptr_t)arg, PATH_MAX,
+                 "icmp:[dev %s, id %" PRIu16 ", flg %" PRIx8 "]",
+                 conn->dev ? conn->dev->d_ifname : "NULL",
+                 NTOHS(conn->id), conn->sconn.s_flags);
         break;
       default:
         ret = -ENOTTY;

--- a/net/icmpv6/icmpv6_ioctl.c
+++ b/net/icmpv6/icmpv6_ioctl.c
@@ -25,6 +25,7 @@
 #include <nuttx/config.h>
 
 #include <stdint.h>
+#include <stdio.h>
 #include <stdbool.h>
 #include <debug.h>
 #include <errno.h>
@@ -76,6 +77,12 @@ int icmpv6_ioctl(FAR struct socket *psock, int cmd, unsigned long arg)
         break;
       case FIONSPACE:
         *(FAR int *)((uintptr_t)arg) = MIN_UDP_MSS;
+        break;
+      case FIOC_FILEPATH:
+        snprintf((FAR char *)(uintptr_t)arg, PATH_MAX,
+                 "icmp6:[dev %s, id %" PRIu16 ", flg %" PRIx8 "]",
+                 conn->dev ? conn->dev->d_ifname : "NULL",
+                 NTOHS(conn->id), conn->sconn.s_flags);
         break;
       default:
         ret = -ENOTTY;

--- a/net/local/local_sockif.c
+++ b/net/local/local_sockif.c
@@ -885,7 +885,6 @@ static int local_ioctl(FAR struct socket *psock, int cmd, unsigned long arg)
       case FIOC_FILEPATH:
         snprintf((FAR char *)(uintptr_t)arg, PATH_MAX, "local:[%s]",
                  conn->lc_path);
-        ret = OK;
         break;
       case BIOC_FLUSH:
         ret = -EINVAL;

--- a/net/netdev/netdev_ioctl.c
+++ b/net/netdev/netdev_ioctl.c
@@ -1591,6 +1591,9 @@ ssize_t net_ioctl_arglen(int cmd)
       case FIONREAD:
         return sizeof(int);
 
+      case FIOC_FILEPATH:
+        return PATH_MAX;
+
       case SIOCGIFCONF:
         return sizeof(struct ifconf);
 

--- a/net/netdev/netdev_ioctl.c
+++ b/net/netdev/netdev_ioctl.c
@@ -27,10 +27,11 @@
 #include <sys/socket.h>
 #include <sys/ioctl.h>
 
-#include <string.h>
 #include <assert.h>
-#include <errno.h>
 #include <debug.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
 
 #include <nuttx/net/net.h>
 #include <nuttx/net/ip.h>
@@ -1536,7 +1537,18 @@ static int netdev_ioctl(FAR struct socket *psock, int cmd,
 
         break;
 
-      default:
+      case FIOC_FILEPATH:
+        if (ret == -ENOTTY)
+          {
+            snprintf((FAR char *)(uintptr_t)arg, PATH_MAX, "socket:["
+                     "domain %" PRIu8 ", type %" PRIu8 ", proto %" PRIu8 "]",
+                     psock->s_domain, psock->s_type, psock->s_proto);
+            ret = OK;
+          }
+
+        break;
+
+    default:
         break;
     }
 

--- a/net/rpmsg/rpmsg_sockif.c
+++ b/net/rpmsg/rpmsg_sockif.c
@@ -1346,6 +1346,25 @@ static int rpmsg_socket_close(FAR struct socket *psock)
   return 0;
 }
 
+static void rpmsg_socket_path(FAR struct rpmsg_socket_conn_s *conn,
+                              FAR char *buf, size_t len)
+{
+  if (conn->backlog) /* Server */
+    {
+      snprintf(buf, len,
+               "rpmsg:[%s:[%s%s]<->%s]",
+               CONFIG_RPTUN_LOCAL_CPUNAME, conn->rpaddr.rp_name,
+               conn->nameid, conn->rpaddr.rp_cpu);
+    }
+  else /* Client */
+    {
+      snprintf(buf, len,
+               "rpmsg:[%s<->%s:[%s%s]]",
+               CONFIG_RPTUN_LOCAL_CPUNAME, conn->rpaddr.rp_cpu,
+               conn->rpaddr.rp_name, conn->nameid);
+    }
+}
+
 static int rpmsg_socket_ioctl(FAR struct socket *psock,
                               int cmd, unsigned long arg)
 {
@@ -1360,6 +1379,10 @@ static int rpmsg_socket_ioctl(FAR struct socket *psock,
 
       case FIONSPACE:
         *(FAR int *)((uintptr_t)arg) = rpmsg_socket_get_space(conn);
+        break;
+
+      case FIOC_FILEPATH:
+        rpmsg_socket_path(conn, (FAR char *)(uintptr_t)arg, PATH_MAX);
         break;
 
       default:

--- a/net/tcp/tcp_ioctl.c
+++ b/net/tcp/tcp_ioctl.c
@@ -154,7 +154,6 @@ int tcp_ioctl(FAR struct tcp_conn_s *conn, int cmd, unsigned long arg)
         break;
       case FIOC_FILEPATH:
         tcp_path(conn, (FAR char *)(uintptr_t)arg, PATH_MAX);
-        ret = OK;
         break;
       default:
         ret = -ENOTTY;

--- a/net/udp/udp_ioctl.c
+++ b/net/udp/udp_ioctl.c
@@ -149,7 +149,6 @@ int udp_ioctl(FAR struct udp_conn_s *conn, int cmd, unsigned long arg)
         break;
       case FIOC_FILEPATH:
         udp_path(conn, (FAR char *)(uintptr_t)arg, PATH_MAX);
-        ret = OK;
         break;
       default:
         ret = -ENOTTY;


### PR DESCRIPTION
## Summary
Example of /proc/PID/group/fd in this case:

```
FD  OFLAGS  TYPE POS       PATH
3   3       9    0         icmp:[dev eth0, id 1, flg 1]
4   3       9    0         icmp6:[dev eth0, id 2, flg 1]
5   3       9    0         rpmsg:[ap:[test:0]<->remote] # server side
5   3       9    0         rpmsg:[remote<->ap:[test:0]] # client side
6   67      9    0         socket:[domain 16, type 2, proto 0] # sockets without FIOC_FILEPATH support
```

## Impact
procfs `/proc/PID/group/fd` with icmp/rpmsg sockets and ioctl `FIOC_FILEPATH` for usrsock sockets.

## Testing
Manually (`fdinfo` command)
