### PR TITLE
net/local:Add peek support for pipe and MSG_PEEK support for local so…

### DIFF
--- a/drivers/pipes/pipe_common.c
+++ b/drivers/pipes/pipe_common.c
@@ -838,6 +838,16 @@ int pipecommon_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         }
         break;
 
+      case PIPEIOC_PEEK:
+        {
+          FAR struct pipe_peek_s *peek = (FAR struct pipe_peek_s *)arg;
+
+          DEBUGASSERT(peek && peek->buf);
+
+          ret = circbuf_peek(&dev->d_buffer, peek->buf, peek->size);
+        }
+        break;
+
       case FIONWRITE:  /* Number of bytes waiting in send queue */
       case FIONREAD:   /* Number of bytes available for reading */
         {

--- a/include/nuttx/fs/ioctl.h
+++ b/include/nuttx/fs/ioctl.h
@@ -26,6 +26,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <sys/types.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -447,6 +448,10 @@
                                                *     threshold.
                                                * OUT: None */
 
+#define PIPEIOC_PEEK        _PIPEIOC(0x0004)  /* Pipe peek interface
+                                               * IN: pipe_peek_s
+                                               * OUT: Length of data */
+
 /* RTC driver ioctl definitions *********************************************/
 
 /* (see nuttx/include/rtc.h */
@@ -660,6 +665,12 @@
 /****************************************************************************
  * Public Type Definitions
  ****************************************************************************/
+
+struct pipe_peek_s
+{
+  FAR void *buf;
+  size_t size;
+};
 
 /****************************************************************************
  * Public Data

--- a/net/local/local.h
+++ b/net/local/local.h
@@ -122,6 +122,10 @@ struct local_conn_s
   char lc_path[UNIX_PATH_MAX];   /* Path assigned by bind() */
   int32_t lc_instance_id;        /* Connection instance ID for stream
                                   * server<->client connection pair */
+#ifdef CONFIG_NET_LOCAL_DGRAM
+  uint16_t pktlen;                 /* Read-ahead packet length */
+#endif /* CONFIG_NET_LOCAL_DGRAM */
+
   FAR struct local_conn_s *
                         lc_peer; /* Peer connection instance */
 #ifdef CONFIG_NET_LOCAL_SCM


### PR DESCRIPTION
## Summary
    net/local:Add peek support for pipe and MSG_PEEK support for local socket
    
    fifo peek example:
    struct pipe_peek_s peek_buf;
    peek_buf.len = len;
    peek_buf.data = buf;
    ret = file_ioctl(filep, PIPEIOC_PEEK,(unsigned long)((uintptr_t)&peek_buf));
## Impact
minor
## Testing

