### PR TITLE
Fix: s32k1 s32k3 kinetis: add propseg to ctrl1 timing mask

### DIFF
--- a/arch/arm/src/kinetis/hardware/kinetis_flexcan.h
+++ b/arch/arm/src/kinetis/hardware/kinetis_flexcan.h
@@ -149,9 +149,9 @@
 
 /* Control 1 Register */
 
-#define CAN_CTRL1_ROPSEG_SHIFT     (0)       /* Bits 0-2: Propagation Segment */
-#define CAN_CTRL1_ROPSEG_MASK      (7 << CAN_CTRL1_ROPSEG_SHIFT)
-#define CAN_CTRL1_PROPSEG(x)       (((uint32_t)(((uint32_t)(x)) << 0)) & 0x7)
+#define CAN_CTRL1_PROSEG_SHIFT     (0)       /* Bits 0-2: Propagation Segment */
+#define CAN_CTRL1_PROSEG_MASK      (7 << CAN_CTRL1_PROSEG_SHIFT)
+#define CAN_CTRL1_PROPSEG(x)       (((uint32_t)(((uint32_t)(x)) << CAN_CTRL1_PROPSEG_SHIFT)) & CAN_CTRL1_PROSEG_MASK)
 #define CAN_CTRL1_LOM              (1 << 3)  /* Bit 3:  Listen-Only Mode */
 #define CAN_CTRL1_LBUF             (1 << 4)  /* Bit 4:  Lowest Buffer Transmitted First */
 #define CAN_CTRL1_TSYN             (1 << 5)  /* Bit 5:  Timer Sync */
@@ -164,7 +164,8 @@
 #define CAN_CTRL1_CLKSRC           (1 << 13) /* Bit 13: CAN Engine Clock Source */
 #define CAN_CTRL1_ERRMSK           (1 << 14) /* Bit 14: Error Mask */
 #define CAN_CTRL1_BOFFMSK          (1 << 15) /* Bit 15: Bus Off Mask */
-#define CAN_CTRL1_TIMINGMSK        (0xFFFF << 16)
+#define CAN_CTRL1_TIMINGMSK        ((0xFFFF << 16) |  CAN_CTRL1_PROSEG_MASK)
+                                             /* Bitmask for propseg, pseg1/2, rjw & presdiv */
                                              /* Bits 16-31: Timing Mask */
 #define CAN_CTRL1_PSEG2_SHIFT      (16)      /* Bits 16-18: Phase Segment 2 */
 #define CAN_CTRL1_PSEG2_MASK       (7 << CAN_CTRL1_PSEG2_SHIFT)

--- a/arch/arm/src/s32k1xx/hardware/s32k1xx_flexcan.h
+++ b/arch/arm/src/s32k1xx/hardware/s32k1xx_flexcan.h
@@ -360,7 +360,9 @@
 
 /* Control 1 Register */
 
-#define CAN_CTRL1_PROPSEG(x)          (((uint32_t)(((uint32_t)(x)) << 0)) & 0x7)
+#define CAN_CTRL1_PROSEG_SHIFT        (0)       /* Bits 0-2: Propagation Segment */
+#define CAN_CTRL1_PROSEG_MASK         (7 << CAN_CTRL1_PROSEG_SHIFT)
+#define CAN_CTRL1_PROPSEG(x)          (((uint32_t)(((uint32_t)(x)) << CAN_CTRL1_PROSEG_SHIFT)) & CAN_CTRL1_PROSEG_MASK)
 #define CAN_CTRL1_LOM                 (1 << 3)  /* Bit 3:  Listen-Only Mode */
 #define CAN_CTRL1_LBUF                (1 << 4)  /* Bit 4:  Lowest Buffer Transmitted First */
 #define CAN_CTRL1_TSYN                (1 << 5)  /* Bit 5:  Timer Sync */
@@ -373,7 +375,8 @@
 #define CAN_CTRL1_CLKSRC              (1 << 13) /* Bit 13: CAN Engine Clock Source */
 #define CAN_CTRL1_ERRMSK              (1 << 14) /* Bit 14: Error Mask */
 #define CAN_CTRL1_BOFFMSK             (1 << 15) /* Bit 15: Bus Off Mask */
-#define CAN_CTRL1_TIMINGMSK           (0xFFFF << 16)
+#define CAN_CTRL1_TIMINGMSK           ((0xFFFF << 16) | CAN_CTRL1_PROSEG_MASK)
+                                                /* Bitmask for propseg, pseg1/2, rjw & presdiv */
 #define CAN_CTRL1_PSEG2(x)            (((uint32_t)(((uint32_t)(x)) << 16)) & 0x70000)
 #define CAN_CTRL1_PSEG1(x)            (((uint32_t)(((uint32_t)(x)) << 19)) & 0x380000)
 #define CAN_CTRL1_RJW(x)              (((uint32_t)(((uint32_t)(x)) << 22)) & 0xC00000)

--- a/arch/arm/src/s32k3xx/hardware/s32k3xx_flexcan.h
+++ b/arch/arm/src/s32k3xx/hardware/s32k3xx_flexcan.h
@@ -2669,7 +2669,8 @@
                                                 /* Bit 13: Reserved */
 #define CAN_CTRL1_ERRMSK              (1 << 14) /* Bit 14: Error Interrupt Mask (ERRMSK) */
 #define CAN_CTRL1_BOFFMSK             (1 << 15) /* Bit 15: Bus Off Interrupt Mask (BOFFMSK) */
-#define CAN_CTRL1_TIMINGMSK           (0xffff << 16)
+#define CAN_CTRL1_TIMINGMSK           ((0xffff << 16) | CAN_CTRL1_PROPSEG_MASK)
+                                                /* Bitmask for propseg, pseg1/2, rjw & presdiv */
 #define CAN_CTRL1_PSEG2_SHIFT         (16)      /* Bits 16-18: Phase Segment 2 (PSEG2) */
 #define CAN_CTRL1_PSEG2_MASK          (0x07 << CAN_CTRL1_PSEG2_SHIFT)
 #define CAN_CTRL1_PSEG2(x)            (((x) << CAN_CTRL1_PSEG2_SHIFT) & CAN_CTRL1_PSEG2_MASK)


### PR DESCRIPTION
## Summary
The timing mask for the can's ctrl1 register excludes the propagation segment bits. This results in incorrect timing when configuring bitrate at runtime with SIOCSCANBITRATE when the bitrate to timeseg algorithm selects a different propseg value.

## Impact
Incorrect can timing configuration when moving between rates at runtime. 

## Testing
s32k1xx HW testing: moving between several speeds both in listen only and while actively participating on the network.
