### PR TITLE
fixing esp_semphr_take in esp wifi

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_wifi_adapter.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_wifi_adapter.c
@@ -1192,14 +1192,14 @@ static void esp_semphr_delete(void *semphr)
  *
  * Input Parameters:
  *   semphr - Semaphore data pointer
- *   ticks  - Wait system ticks
+ *   block_time_ms  - Wait time
  *
  * Returned Value:
  *   True if success or false if fail
  *
  ****************************************************************************/
 
-static int32_t esp_semphr_take(void *semphr, uint32_t ticks)
+static int32_t esp_semphr_take(void *semphr, uint32_t block_time_ms)
 {
   int ret;
   sem_t *sem = (sem_t *)semphr;
@@ -1214,7 +1214,7 @@ static int32_t esp_semphr_take(void *semphr, uint32_t ticks)
     }
   else
     {
-      ret = nxsem_tickwait(sem, ticks);
+      ret = nxsem_tickwait(sem, MSEC2TICK(block_time_ms));
       if (ret)
         {
           wlerr("ERROR: Failed to wait sem in %lu ticks\n", ticks);

--- a/arch/xtensa/src/esp32/esp32_wifi_adapter.c
+++ b/arch/xtensa/src/esp32/esp32_wifi_adapter.c
@@ -1114,14 +1114,14 @@ static void esp_semphr_delete(void *semphr)
  *
  * Input Parameters:
  *   semphr - Semaphore data pointer
- *   ticks  - Wait system ticks
+ *   block_time_ms  - Wait time
  *
  * Returned Value:
  *   True if success or false if fail
  *
  ****************************************************************************/
 
-static int32_t esp_semphr_take(void *semphr, uint32_t ticks)
+static int32_t esp_semphr_take(void *semphr, uint32_t block_time_ms)
 {
   int ret;
   sem_t *sem = (sem_t *)semphr;
@@ -1136,7 +1136,7 @@ static int32_t esp_semphr_take(void *semphr, uint32_t ticks)
     }
   else
     {
-      ret = nxsem_tickwait(sem, ticks);
+      ret = nxsem_tickwait(sem, MSEC2TICK(block_time_ms));
       if (ret)
         {
           wlerr("Failed to wait sem in %d ticks\n", ticks);

--- a/arch/xtensa/src/esp32s3/esp32s3_wifi_adapter.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_wifi_adapter.c
@@ -1088,14 +1088,14 @@ static void esp_semphr_delete(void *semphr)
  *
  * Input Parameters:
  *   semphr - Semaphore data pointer
- *   ticks  - Wait system ticks
+ *   block_time_ms  - Wait time
  *
  * Returned Value:
  *   True if success or false if fail
  *
  ****************************************************************************/
 
-static int32_t esp_semphr_take(void *semphr, uint32_t ticks)
+static int32_t esp_semphr_take(void *semphr, uint32_t block_time_ms)
 {
   int ret;
   sem_t *sem = (sem_t *)semphr;
@@ -1110,7 +1110,7 @@ static int32_t esp_semphr_take(void *semphr, uint32_t ticks)
     }
   else
     {
-      ret = nxsem_tickwait(sem, ticks);
+      ret = nxsem_tickwait(sem, MSEC2TICK(block_time_ms));
       if (ret)
         {
           wlerr("Failed to wait sem in %d ticks\n", ticks);


### PR DESCRIPTION
## Summary

The parameter in esp_semphr_take should be actually milliseconds rather than ticks.

## Impact

No impact expected.

## Testing

