### PR TITLE
usbdev: clear configid after class disconnect

### DIFF
--- a/drivers/usbdev/composite.c
+++ b/drivers/usbdev/composite.c
@@ -746,13 +746,13 @@ static void composite_disconnect(FAR struct usbdevclass_driver_s *driver,
    */
 
   flags = enter_critical_section();
-  priv->config = COMPOSITE_CONFIGIDNONE;
 
   for (i = 0; i < priv->ndevices; i++)
     {
       CLASS_DISCONNECT(priv->device[i].dev, dev);
     }
 
+  priv->config = COMPOSITE_CONFIGIDNONE;
   leave_critical_section(flags);
 
   /* Perform the soft connect function so that we will we can be


### PR DESCRIPTION
## Summary

In class disconnect, resetconfig will be performed based on configid, so configid should be cleared after disconnect.

## Impact

composite usbdev

## Testing

sim:usbdev
