### PR TITLE
arch/arm: Fix arm_backtrace_unwind.c -Wmaybe-uninitialized

### DIFF
--- a/arch/arm/src/common/arm_backtrace_unwind.c
+++ b/arch/arm/src/common/arm_backtrace_unwind.c
@@ -431,6 +431,7 @@ int unwind_frame(struct unwind_frame_s *frame)
   ctrl.vrs[LR] = frame->lr;
   ctrl.vrs[PC] = 0;
   ctrl.stack_top = frame->stack_top;
+  ctrl.lr_addr = NULL;
 
   if (frame->pc == prel31_to_addr(&entry->fnoffset))
     {


### PR DESCRIPTION
## Summary

common/arm_backtrace_unwind.c:528:18: warning: 'ctrl.lr_addr' may be used uninitialized in this function [-Wmaybe-uninitialized]

## Impact

fix warning

## Testing

ci