### PR TITLE
rpmsgdev: add tun device ioctl support

### DIFF
--- a/drivers/misc/rpmsgdev.c
+++ b/drivers/misc/rpmsgdev.c
@@ -32,6 +32,7 @@
 #include <poll.h>
 #include <limits.h>
 #include <debug.h>
+#include <net/if.h>
 
 #include <nuttx/kmalloc.h>
 #include <nuttx/fs/fs.h>
@@ -39,6 +40,7 @@
 #include <nuttx/video/fb.h>
 #include <nuttx/mutex.h>
 #include <nuttx/rptun/openamp.h>
+#include <nuttx/net/ioctl.h>
 #include <nuttx/drivers/rpmsgdev.h>
 
 #include "rpmsgdev.h"
@@ -639,6 +641,9 @@ static ssize_t rpmsgdev_ioctl_arglen(int cmd)
       case FBIOSET_POWER:
       case FBIOGET_POWER:
         return sizeof(int);
+      case TUNSETIFF:
+      case TUNGETIFF:
+        return sizeof(struct ifreq);
       default:
         return -ENOTTY;
     }


### PR DESCRIPTION
## Summary
In a multi-core heterogeneous architecture, tun device nodes of protocol stack core can be accessed by other cores through ioctl
## Impact

## Testing
Arm Cortex-M33