### PR TITLE
fs_fsync.c:Fix unknown command message in non-block device situations

### DIFF
--- a/fs/vfs/fs_fsync.c
+++ b/fs/vfs/fs_fsync.c
@@ -75,7 +75,8 @@ int file_fsync(FAR struct file *filep)
         }
       else
 #endif
-      if (inode->u.i_ops && inode->u.i_ops->ioctl)
+      if ((INODE_IS_BLOCK(inode) || INODE_IS_MTD(inode)) &&
+          inode->u.i_ops && inode->u.i_ops->ioctl)
         {
           ret = inode->u.i_ops->ioctl(filep, BIOC_FLUSH, 0);
           return ret >= 0 ? 0 : ret;


### PR DESCRIPTION
## Summary
This command is called only if the device is a block device or mtd device.
## Impact

## Testing

