### PR TITLE
hostfs:support SEEK_CUR

### DIFF
--- a/arch/arm/src/common/arm_hostfs.c
+++ b/arch/arm/src/common/arm_hostfs.c
@@ -185,7 +185,7 @@ ssize_t host_write(int fd, const void *buf, size_t count)
   return ret < 0 ? ret : count - ret;
 }
 
-off_t host_lseek(int fd, off_t offset, int whence)
+off_t host_lseek(int fd, off_t pos, off_t offset, int whence)
 {
   off_t ret = -ENOSYS;
 
@@ -197,6 +197,11 @@ off_t host_lseek(int fd, off_t offset, int whence)
           offset += ret;
           whence = SEEK_SET;
         }
+    }
+  else if (whence == SEEK_CUR)
+    {
+      offset += pos;
+      whence = SEEK_SET;
     }
 
   if (whence == SEEK_SET)

--- a/arch/arm64/src/common/arm64_hostfs.c
+++ b/arch/arm64/src/common/arm64_hostfs.c
@@ -185,7 +185,7 @@ ssize_t host_write(int fd, const void *buf, size_t count)
   return ret < 0 ? ret : count - ret;
 }
 
-off_t host_lseek(int fd, off_t offset, int whence)
+off_t host_lseek(int fd, off_t pos, off_t offset, int whence)
 {
   off_t ret = -ENOSYS;
 
@@ -197,6 +197,11 @@ off_t host_lseek(int fd, off_t offset, int whence)
           offset += ret;
           whence = SEEK_SET;
         }
+    }
+  else if (whence == SEEK_CUR)
+    {
+      offset += pos;
+      whence = SEEK_SET;
     }
 
   if (whence == SEEK_SET)

--- a/arch/risc-v/src/common/riscv_hostfs.c
+++ b/arch/risc-v/src/common/riscv_hostfs.c
@@ -185,7 +185,7 @@ ssize_t host_write(int fd, const void *buf, size_t count)
   return ret < 0 ? ret : count - ret;
 }
 
-off_t host_lseek(int fd, off_t offset, int whence)
+off_t host_lseek(int fd, off_t pos, off_t offset, int whence)
 {
   off_t ret = -ENOSYS;
 
@@ -197,6 +197,11 @@ off_t host_lseek(int fd, off_t offset, int whence)
           offset += ret;
           whence = SEEK_SET;
         }
+    }
+  else if (whence == SEEK_CUR)
+    {
+      offset += pos;
+      whence = SEEK_SET;
     }
 
   if (whence == SEEK_SET)

--- a/arch/sim/src/sim/posix/sim_hostfs.c
+++ b/arch/sim/src/sim/posix/sim_hostfs.c
@@ -255,7 +255,8 @@ nuttx_ssize_t host_write(int fd, const void *buf, nuttx_size_t count)
  * Name: host_lseek
  ****************************************************************************/
 
-nuttx_off_t host_lseek(int fd, nuttx_off_t offset, int whence)
+nuttx_off_t host_lseek(int fd, nuttx_off_t pos, nuttx_off_t offset,
+                       int whence)
 {
   /* Just call the lseek routine */
 

--- a/arch/sim/src/sim/sim_cpuinfo.c
+++ b/arch/sim/src/sim/sim_cpuinfo.c
@@ -49,7 +49,7 @@ ssize_t up_show_cpuinfo(char *buf, size_t buf_size, off_t file_off)
       return fd;
     }
 
-  ret = host_lseek(fd, file_off, SEEK_SET);
+  ret = host_lseek(fd, 0, file_off, SEEK_SET);
   if (ret < 0)
     {
       host_close(fd);

--- a/arch/sim/src/sim/win/sim_hostfs.c
+++ b/arch/sim/src/sim/win/sim_hostfs.c
@@ -200,7 +200,8 @@ nuttx_ssize_t host_write(int fd, const void *buf, nuttx_size_t count)
  * Name: host_lseek
  ****************************************************************************/
 
-nuttx_off_t host_lseek(int fd, nuttx_off_t offset, int whence)
+nuttx_off_t host_lseek(int fd, nuttx_off_t pos, nuttx_off_t offset,
+                       int whence)
 {
   /* Just call the lseek routine */
 

--- a/arch/xtensa/src/common/xtensa_hostfs.c
+++ b/arch/xtensa/src/common/xtensa_hostfs.c
@@ -126,7 +126,7 @@ ssize_t host_write(int fd, const void *buf, size_t count)
   return host_call(SIMCALL_SYS_WRITE, fd, (int)buf, count);
 }
 
-off_t host_lseek(int fd, off_t offset, int whence)
+off_t host_lseek(int fd, off_t pos, off_t offset, int whence)
 {
   return host_call(SIMCALL_SYS_LSEEK, fd, offset, whence);
 }
@@ -155,9 +155,9 @@ int host_fstat(int fd, struct stat *buf)
    *    hostfs_lock provides enough serialization.
    */
 
-  off_t saved_off = host_lseek(fd, 0, SEEK_CUR);
-  off_t size = host_lseek(fd, 0, SEEK_END);
-  host_lseek(fd, saved_off, SEEK_SET);
+  off_t saved_off = host_lseek(fd, 0, 0, SEEK_CUR);
+  off_t size = host_lseek(fd, 0, 0, SEEK_END);
+  host_lseek(fd, 0, saved_off, SEEK_SET);
 
   memset(buf, 0, sizeof(*buf));
   buf->st_mode = S_IFREG | 0777;

--- a/fs/hostfs/hostfs.c
+++ b/fs/hostfs/hostfs.c
@@ -296,7 +296,7 @@ static int hostfs_open(FAR struct file *filep, FAR const char *relpath,
 
   if ((oflags & (O_APPEND | O_WRONLY)) == (O_APPEND | O_WRONLY))
     {
-      ret = host_lseek(hf->fd, 0, SEEK_END);
+      ret = host_lseek(hf->fd, 0, 0, SEEK_END);
       if (ret >= 0)
         {
           filep->f_pos = ret;
@@ -557,7 +557,7 @@ static off_t hostfs_seek(FAR struct file *filep, off_t offset, int whence)
 
   /* Call our internal routine to perform the seek */
 
-  ret = host_lseek(hf->fd, offset, whence);
+  ret = host_lseek(hf->fd, filep->f_pos, offset, whence);
   if (ret >= 0)
     {
       filep->f_pos = ret;

--- a/include/nuttx/fs/hostfs.h
+++ b/include/nuttx/fs/hostfs.h
@@ -186,7 +186,8 @@ int           host_open(const char *pathname, int flags, nuttx_mode_t mode);
 int           host_close(int fd);
 nuttx_ssize_t host_read(int fd, void *buf, nuttx_size_t count);
 nuttx_ssize_t host_write(int fd, const void *buf, nuttx_size_t count);
-nuttx_off_t   host_lseek(int fd, nuttx_off_t offset, int whence);
+nuttx_off_t   host_lseek(int fd, nuttx_off_t pos, nuttx_off_t offset,
+                         int whence);
 int           host_ioctl(int fd, int request, unsigned long arg);
 void          host_sync(int fd);
 int           host_dup(int fd);
@@ -211,7 +212,7 @@ int           host_open(const char *pathname, int flags, int mode);
 int           host_close(int fd);
 ssize_t       host_read(int fd, void *buf, size_t count);
 ssize_t       host_write(int fd, const void *buf, size_t count);
-off_t         host_lseek(int fd, off_t offset, int whence);
+off_t         host_lseek(int fd, off_t pos, off_t offset, int whence);
 int           host_ioctl(int fd, int request, unsigned long arg);
 void          host_sync(int fd);
 int           host_dup(int fd);


### PR DESCRIPTION
## Summary
Fix the bug that calling "fseek(fin, 0, SEEK_SET)" causes ENOSYS error under some simulator configurations.
## Impact

## Testing

