### PR TITLE
ftl: fix ftl_flush will read/erase beyond the end of the partition

### DIFF
--- a/drivers/misc/rwbuffer.c
+++ b/drivers/misc/rwbuffer.c
@@ -144,6 +144,16 @@ static void rwb_wrflush(FAR struct rwbuffer_s *rwb)
       finfo("Flushing: blockstart=0x%08lx nblocks=%d from buffer=%p\n",
             (long)rwb->wrblockstart, rwb->wrnblocks, rwb->wrbuffer);
 
+      padblocks = rwb->wrblockstart % rwb->wralignblocks;
+      if (padblocks)
+        {
+          memmove(rwb->wrbuffer + padblocks * rwb->blocksize,
+                  rwb->wrbuffer, rwb->wrnblocks * rwb->blocksize);
+          rwb->wrblockstart -= padblocks;
+          rwb->wrnblocks += padblocks;
+          rwb_read_(rwb, rwb->wrblockstart, padblocks, rwb->wrbuffer);
+        }
+
       padblocks = rwb->wrnblocks % rwb->wralignblocks;
       if (padblocks)
         {


### PR DESCRIPTION
## Summary
the  padblock code not aligned with physical alignment
## Impact
it will read/write beyond the end of the partition when the block  is near the end of partition
## Testing

