### PR TITLE
drivers/pty: Support get and set local mode of pty

### DIFF
--- a/drivers/serial/pty.c
+++ b/drivers/serial/pty.c
@@ -757,7 +757,7 @@ static int pty_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
           termiosp->c_iflag = dev->pd_iflag;
           termiosp->c_oflag = dev->pd_oflag;
-          termiosp->c_lflag = 0;
+          termiosp->c_lflag = dev->pd_lflag;
           ret = OK;
         }
         break;


### PR DESCRIPTION
## Summary
add support to get and set local mode of pty. this patch is supplement to 64b51bbbf7e9434a6c789cfbdaa5e744f898bf0c

## Impact

## Testing

