### PR TITLE
sched: add the startup process tracepoint

### DIFF
--- a/drivers/drivers_initialize.c
+++ b/drivers/drivers_initialize.c
@@ -43,6 +43,7 @@
 #include <nuttx/serial/pty.h>
 #include <nuttx/syslog/syslog.h>
 #include <nuttx/syslog/syslog_console.h>
+#include <nuttx/trace.h>
 #include <nuttx/usrsock/usrsock_rpmsg.h>
 #include <nuttx/virtio/virtio.h>
 
@@ -65,6 +66,8 @@
 
 void drivers_initialize(void)
 {
+  drivers_trace_begin();
+
   /* Register devices */
 
   syslog_initialize();
@@ -208,4 +211,6 @@ void drivers_initialize(void)
 #ifdef CONFIG_DRIVERS_VIRTIO
   virtio_register_drivers();
 #endif
+
+  drivers_trace_end();
 }

--- a/fs/fs_initialize.c
+++ b/fs/fs_initialize.c
@@ -24,6 +24,7 @@
 
 #include <nuttx/config.h>
 #include <nuttx/reboot_notifier.h>
+#include <nuttx/trace.h>
 
 #include "rpmsgfs/rpmsgfs.h"
 #include "inode/inode.h"
@@ -76,6 +77,8 @@ static struct notifier_block g_sync_nb =
 
 void fs_initialize(void)
 {
+  fs_trace_begin();
+
   /* Initial inode, file, and VFS data structures */
 
   inode_initialize();
@@ -92,4 +95,5 @@ void fs_initialize(void)
 #endif
 
   register_reboot_notifier(&g_sync_nb);
+  fs_trace_end();
 }

--- a/sched/clock/clock_initialize.c
+++ b/sched/clock/clock_initialize.c
@@ -36,6 +36,7 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/clock.h>
+#include <nuttx/trace.h>
 
 #include "clock/clock.h"
 #ifdef CONFIG_CLOCK_TIMEKEEPING
@@ -206,6 +207,8 @@ static void clock_inittime(FAR const struct timespec *tp)
 
 void clock_initialize(void)
 {
+  sched_trace_begin();
+
 #if !defined(CONFIG_SUPPRESS_INTERRUPTS) && \
     !defined(CONFIG_SUPPRESS_TIMER_INTS) && \
     !defined(CONFIG_SYSTEMTICK_EXTCLK)
@@ -233,6 +236,8 @@ void clock_initialize(void)
 #endif
 
 #endif
+
+  sched_trace_end();
 }
 
 /****************************************************************************

--- a/sched/group/group_setupidlefiles.c
+++ b/sched/group/group_setupidlefiles.c
@@ -34,6 +34,7 @@
 
 #include <nuttx/fs/fs.h>
 #include <nuttx/net/net.h>
+#include <nuttx/trace.h>
 
 #include "group/group.h"
 
@@ -58,10 +59,12 @@
 
 int group_setupidlefiles(FAR struct task_tcb_s *tcb)
 {
+  int ret = OK;
 #if defined(CONFIG_DEV_CONSOLE) || defined(CONFIG_DEV_NULL)
   int fd;
 #endif
 
+  sched_trace_begin();
   DEBUGASSERT(tcb->cmn.group != NULL);
 
   /* Open stdin, dup to get stdout and stderr. This should always
@@ -98,6 +101,7 @@ int group_setupidlefiles(FAR struct task_tcb_s *tcb)
           serr("ERROR: Failed to open stdin: %d\n", fd);
         }
 
+      sched_trace_end();
       return -ENFILE;
     }
 #else
@@ -114,8 +118,8 @@ int group_setupidlefiles(FAR struct task_tcb_s *tcb)
   /* Allocate file/socket streams for the TCB */
 
 #ifdef CONFIG_FILE_STREAM
-  return group_setupstreams(tcb);
-#else
-  return OK;
+  ret = group_setupstreams(tcb);
 #endif
+  sched_trace_end();
+  return ret;
 }

--- a/sched/group/group_setuptaskfiles.c
+++ b/sched/group/group_setuptaskfiles.c
@@ -28,6 +28,7 @@
 #include <assert.h>
 
 #include <nuttx/fs/fs.h>
+#include <nuttx/trace.h>
 
 #include "sched/sched.h"
 #include "group/group.h"
@@ -57,11 +58,12 @@
 int group_setuptaskfiles(FAR struct task_tcb_s *tcb)
 {
   FAR struct task_group_s *group = tcb->cmn.group;
+  int ret = OK;
 #ifndef CONFIG_FDCLONE_DISABLE
   FAR struct tcb_s *rtcb = this_task();
-  int ret;
 #endif
 
+  sched_trace_begin();
   DEBUGASSERT(group);
 #ifndef CONFIG_DISABLE_PTHREAD
   DEBUGASSERT((tcb->cmn.flags & TCB_FLAG_TTYPE_MASK) !=
@@ -76,6 +78,7 @@ int group_setuptaskfiles(FAR struct task_tcb_s *tcb)
   ret = files_duplist(&rtcb->group->tg_filelist, &group->tg_filelist);
   if (ret < 0)
     {
+      sched_trace_end();
       return ret;
     }
 #endif
@@ -83,8 +86,9 @@ int group_setuptaskfiles(FAR struct task_tcb_s *tcb)
   /* Allocate file/socket streams for the new TCB */
 
 #ifdef CONFIG_FILE_STREAM
-  return group_setupstreams(tcb);
-#else
-  return OK;
+  ret = group_setupstreams(tcb);
 #endif
+
+  sched_trace_end();
+  return ret;
 }

--- a/sched/init/nx_bringup.c
+++ b/sched/init/nx_bringup.c
@@ -35,6 +35,7 @@
 #include <nuttx/fs/fs.h>
 #include <nuttx/init.h>
 #include <nuttx/symtab.h>
+#include <nuttx/trace.h>
 #include <nuttx/wqueue.h>
 #include <nuttx/kthread.h>
 #include <nuttx/userspace.h>
@@ -406,6 +407,8 @@ static inline void nx_create_initthread(void)
 
 int nx_bringup(void)
 {
+  sched_trace_begin();
+
 #ifndef CONFIG_DISABLE_ENVIRON
   /* Setup up the initial environment for the idle task.  At present, this
    * may consist of only the initial PATH variable and/or and init library
@@ -454,5 +457,6 @@ int nx_bringup(void)
   clearenv();
 #endif
 
+  sched_trace_end();
   return OK;
 }

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -41,6 +41,7 @@
 #include <nuttx/kmalloc.h>
 #include <nuttx/pgalloc.h>
 #include <nuttx/sched_note.h>
+#include <nuttx/trace.h>
 #include <nuttx/binfmt/binfmt.h>
 #include <nuttx/drivers/drivers.h>
 #include <nuttx/init.h>
@@ -322,6 +323,8 @@ void nx_start(void)
   g_nx_initstate = OSINIT_BOOT;
 
   /* Initialize RTOS Data ***************************************************/
+
+  sched_trace_begin();
 
   /* Initialize the IDLE task TCB *******************************************/
 
@@ -691,6 +694,7 @@ void nx_start(void)
 
   /* Let other threads have access to the memory manager */
 
+  sched_trace_end();
   sched_unlock();
 
   /* The IDLE Loop **********************************************************/

--- a/sched/irq/irq_initialize.c
+++ b/sched/irq/irq_initialize.c
@@ -25,6 +25,7 @@
 #include <nuttx/config.h>
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
+#include <nuttx/trace.h>
 
 #include "irq/irq.h"
 
@@ -68,6 +69,8 @@ void irq_initialize(void)
 {
   int i;
 
+  sched_trace_begin();
+
   /* Point all interrupt vectors to the unexpected interrupt */
 
   for (i = 0; i < TAB_SIZE; i++)
@@ -82,4 +85,5 @@ void irq_initialize(void)
 #endif
 
   up_irqinitialize();
+  sched_trace_end();
 }

--- a/sched/mqueue/mq_initialize.c
+++ b/sched/mqueue/mq_initialize.c
@@ -26,6 +26,7 @@
 
 #include <stdint.h>
 #include <nuttx/kmalloc.h>
+#include <nuttx/trace.h>
 
 #include "mqueue/mqueue.h"
 
@@ -108,6 +109,8 @@ mq_msgblockalloc(FAR struct list_node *list, uint16_t nmsgs,
 
 void nxmq_initialize(void)
 {
+  sched_trace_begin();
+
   /* Allocate a block of messages for general use */
 
   mq_msgblockalloc(&g_msgfree, CONFIG_PREALLOC_MQ_MSGS,
@@ -119,4 +122,6 @@ void nxmq_initialize(void)
 
   mq_msgblockalloc(&g_msgfreeirq, CONFIG_PREALLOC_MQ_IRQ_MSGS,
                    MQ_ALLOC_IRQ);
+
+  sched_trace_end();
 }

--- a/sched/semaphore/sem_initialize.c
+++ b/sched/semaphore/sem_initialize.c
@@ -23,6 +23,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/trace.h>
 
 #include "semaphore/semaphore.h"
 
@@ -54,9 +55,12 @@
 
 void nxsem_initialize(void)
 {
+  sched_trace_begin();
+
   /* Initialize holder structures needed to support priority inheritance */
 
   nxsem_initialize_holders();
+  sched_trace_end();
 }
 
 #endif /* CONFIG_PRIORITY_INHERITANCE */

--- a/sched/signal/sig_initialize.c
+++ b/sched/signal/sig_initialize.c
@@ -29,6 +29,7 @@
 
 #include <nuttx/kmalloc.h>
 #include <nuttx/queue.h>
+#include <nuttx/trace.h>
 
 #include "signal/signal.h"
 
@@ -190,6 +191,8 @@ static sigpendq_t *nxsig_alloc_pendingsignalblock(sq_queue_t *siglist,
 
 void nxsig_initialize(void)
 {
+  sched_trace_begin();
+
   /* Initialize free lists */
 
   sq_init(&g_sigfreeaction);
@@ -223,4 +226,5 @@ void nxsig_initialize(void)
                                    CONFIG_SIG_PREALLOC_IRQ_ACTIONS,
                                    SIG_ALLOC_IRQ);
   DEBUGASSERT(g_sigpendingirqsignalalloc != NULL);
+  sched_trace_end();
 }

--- a/sched/task/task_init.c
+++ b/sched/task/task_init.c
@@ -33,6 +33,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/queue.h>
 #include <nuttx/sched.h>
+#include <nuttx/trace.h>
 
 #include "sched/sched.h"
 #include "environ/environ.h"
@@ -90,6 +91,8 @@ int nxtask_init(FAR struct task_tcb_s *tcb, const char *name, int priority,
   uint8_t ttype = tcb->cmn.flags & TCB_FLAG_TTYPE_MASK;
   int ret;
 
+  sched_trace_begin();
+
 #ifndef CONFIG_DISABLE_PTHREAD
   /* Only tasks and kernel threads can be initialized in this way */
 
@@ -110,6 +113,7 @@ int nxtask_init(FAR struct task_tcb_s *tcb, const char *name, int priority,
   ret = group_allocate(tcb, tcb->cmn.flags);
   if (ret < 0)
     {
+      sched_trace_end();
       return ret;
     }
 
@@ -175,6 +179,7 @@ int nxtask_init(FAR struct task_tcb_s *tcb, const char *name, int priority,
   /* Now we have enough in place that we can join the group */
 
   group_initialize(tcb);
+  sched_trace_end();
   return ret;
 
 errout_with_group:
@@ -200,6 +205,7 @@ errout_with_group:
 
   group_leave(&tcb->cmn);
 
+  sched_trace_end();
   return ret;
 }
 

--- a/sched/timer/timer_initialize.c
+++ b/sched/timer/timer_initialize.c
@@ -31,6 +31,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/queue.h>
+#include <nuttx/trace.h>
 
 #include "timer/timer.h"
 
@@ -83,6 +84,8 @@ volatile sq_queue_t g_alloctimers;
 
 void timer_initialize(void)
 {
+  sched_trace_begin();
+
 #if CONFIG_PREALLOC_TIMERS > 0
   int i;
 
@@ -101,6 +104,7 @@ void timer_initialize(void)
   /* Initialize the list of allocated timers */
 
   sq_init((FAR sq_queue_t *)&g_alloctimers);
+  sched_trace_end();
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
Add the startup process tracepoint

After enabling config_trace configuration, you can directly see the startup time
![image](https://github.com/apache/nuttx/assets/33870028/6cb57079-e2a2-4144-b325-a4bbc031a4f2)

## Impact

## Testing

