### PR TITLE
boards/arduino-nano-33ble{-rev2}: use bool for leds state

### DIFF
--- a/boards/arm/nrf52/arduino-nano-33ble-rev2/src/nrf52_autoleds.c
+++ b/boards/arm/nrf52/arduino-nano-33ble-rev2/src/nrf52_autoleds.c
@@ -48,14 +48,14 @@ static const uint32_t g_ledcfg[BOARD_NLEDS] =
   GPIO_LED5
 };
 
-static const uint32_t g_ledoff[BOARD_NLEDS] =
+static const bool g_ledoff[BOARD_NLEDS] =
 {
-  0, 0, 1, 1, 1
+  false, false, true, true, true
 };
 
-static const uint32_t g_ledon[BOARD_NLEDS] =
+static const bool g_ledon[BOARD_NLEDS] =
 {
-  1, 1, 0, 0, 0
+  true, true, false, false, false
 };
 
 /****************************************************************************

--- a/boards/arm/nrf52/arduino-nano-33ble-rev2/src/nrf52_userleds.c
+++ b/boards/arm/nrf52/arduino-nano-33ble-rev2/src/nrf52_userleds.c
@@ -62,14 +62,14 @@ static const uint32_t g_ledcfg[BOARD_NLEDS] =
   GPIO_LED5
 };
 
-static const uint32_t g_ledoff[BOARD_NLEDS] =
+static const bool g_ledoff[BOARD_NLEDS] =
 {
-  0, 0, 1, 1, 1
+  false, false, true, true, true
 };
 
-static const uint32_t g_ledon[BOARD_NLEDS] =
+static const bool g_ledon[BOARD_NLEDS] =
 {
-  1, 1, 0, 0, 0
+  true, true, false, false, false
 };
 
 /****************************************************************************

--- a/boards/arm/nrf52/arduino-nano-33ble/src/nrf52_autoleds.c
+++ b/boards/arm/nrf52/arduino-nano-33ble/src/nrf52_autoleds.c
@@ -48,14 +48,14 @@ static const uint32_t g_ledcfg[BOARD_NLEDS] =
   GPIO_LED5
 };
 
-static const uint32_t g_ledoff[BOARD_NLEDS] =
+static const bool g_ledoff[BOARD_NLEDS] =
 {
-  0, 0, 1, 1, 1
+  false, false, true, true, true
 };
 
-static const uint32_t g_ledon[BOARD_NLEDS] =
+static const bool g_ledon[BOARD_NLEDS] =
 {
-  1, 1, 0, 0, 0
+  true, true, false, false, false
 };
 
 /****************************************************************************

--- a/boards/arm/nrf52/arduino-nano-33ble/src/nrf52_userleds.c
+++ b/boards/arm/nrf52/arduino-nano-33ble/src/nrf52_userleds.c
@@ -62,14 +62,14 @@ static const uint32_t g_ledcfg[BOARD_NLEDS] =
   GPIO_LED5
 };
 
-static const uint32_t g_ledoff[BOARD_NLEDS] =
+static const bool g_ledoff[BOARD_NLEDS] =
 {
-  0, 0, 1, 1, 1
+  false, false, true, true, true
 };
 
-static const uint32_t g_ledon[BOARD_NLEDS] =
+static const bool g_ledon[BOARD_NLEDS] =
 {
-  1, 1, 0, 0, 0
+  true, true, false, false, false
 };
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
boards/arduino-nano-33ble{-rev2}: use bool for leds state

Cosmetic changes suggested by @pkarashchenko https://github.com/apache/nuttx/pull/10217#discussion_r1293893916

## Impact
cosmetics

## Testing
CI
