### PR TITLE
icmp: add SOCK_RAW type support

### DIFF
--- a/include/nuttx/net/icmp.h
+++ b/include/nuttx/net/icmp.h
@@ -119,6 +119,8 @@
 #define ICMP_EXC_TTL                 0    /* TTL count exceeded */
 #define ICMP_EXC_FRAGTIME            1    /* Fragment Reassembly time exceeded */
 
+#define ICMP_FILTER                  1
+
 /****************************************************************************
  * Public Type Definitions
  ****************************************************************************/

--- a/net/icmp/icmp_conn.c
+++ b/net/icmp/icmp_conn.c
@@ -281,12 +281,46 @@ FAR struct icmp_conn_s *icmp_findconn(FAR struct net_driver_s *dev,
 
   for (conn = icmp_nextconn(NULL); conn != NULL; conn = icmp_nextconn(conn))
     {
-      if (conn->id == id && conn->dev == dev && conn->nreqs > 0)
+      if (conn->id == id && conn->dev == dev)
         {
           return conn;
         }
     }
 
   return conn;
+}
+
+/****************************************************************************
+ * Name: icmp_foreach
+ *
+ * Description:
+ *   Enumerate each ICMP connection structure. This function will terminate
+ *   when either (1) all connection have been enumerated or (2) when a
+ *   callback returns any non-zero value.
+ *
+ * Assumptions:
+ *   This function is called from network logic at with the network locked.
+ *
+ ****************************************************************************/
+
+int icmp_foreach(icmp_callback_t callback, FAR void *arg)
+{
+  FAR struct icmp_conn_s *conn;
+  int ret = 0;
+
+  if (callback != NULL)
+    {
+      for (conn = icmp_nextconn(NULL); conn != NULL;
+           conn = icmp_nextconn(conn))
+        {
+          ret = callback(conn, arg);
+          if (ret != 0)
+            {
+              break;
+            }
+        }
+    }
+
+  return ret;
 }
 #endif /* CONFIG_NET_ICMP */

--- a/net/icmp/icmp_recvmsg.c
+++ b/net/icmp/icmp_recvmsg.c
@@ -40,12 +40,6 @@
 #ifdef CONFIG_NET_ICMP_SOCKET
 
 /****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-#define ICMPSIZE ((dev)->d_len - IPv4_HDRLEN)
-
-/****************************************************************************
  * Private Types
  ****************************************************************************/
 
@@ -94,9 +88,7 @@ static uint16_t recvfrom_eventhandler(FAR struct net_driver_s *dev,
 {
   FAR struct icmp_recvfrom_s *pstate = pvpriv;
   FAR struct socket *psock;
-  FAR struct icmp_conn_s *conn;
   FAR struct ipv4_hdr_s *ipv4;
-  FAR struct icmp_hdr_s *icmp;
 
   ninfo("flags: %04x\n", flags);
 
@@ -111,42 +103,32 @@ static uint16_t recvfrom_eventhandler(FAR struct net_driver_s *dev,
           goto end_wait;
         }
 
-      /* Is this a response on the same device that we sent the request out
-       * on?
-       */
-
       psock = pstate->recv_sock;
       DEBUGASSERT(psock != NULL && psock->s_conn != NULL);
-      conn  = psock->s_conn;
-      if (dev != conn->dev)
-        {
-          ninfo("Wrong device\n");
-          return flags;
-        }
 
       /* Check if we have just received a ICMP ECHO reply. */
 
       if ((flags & ICMP_NEWDATA) != 0)    /* No incoming data */
         {
           unsigned int recvsize;
-
-          /* Check if it is for us */
-
-          icmp = IPBUF(IPv4_HDRLEN);
-          if (conn->id != icmp->id)
-            {
-              ninfo("Wrong ID: %u vs %u\n", icmp->id, conn->id);
-              return flags;
-            }
+          unsigned int offset = 0;
 
           ninfo("Received ICMP reply\n");
+          ipv4 = IPv4BUF;
 
-          /* What should we do if the received reply is larger that the
+          /* What should we do if the received message is larger that the
            * buffer that the caller of sendto provided?  Truncate?  Error
            * out?
            */
 
-          recvsize = ICMPSIZE;
+          if (psock->s_type != SOCK_RAW)
+            {
+              /* Skip L3 header when not SOCK_RAW */
+
+              offset = (ipv4->vhl & IPv4_HLMASK) << 2;
+            }
+
+          recvsize = dev->d_len - offset;
           if (recvsize > pstate->recv_buflen)
             {
               recvsize = pstate->recv_buflen;
@@ -154,7 +136,7 @@ static uint16_t recvfrom_eventhandler(FAR struct net_driver_s *dev,
 
           /* Copy the ICMP ECHO reply to the user provided buffer */
 
-          memcpy(pstate->recv_buf, IPBUF(IPv4_HDRLEN), recvsize);
+          memcpy(pstate->recv_buf, IPBUF(offset), recvsize);
 
           /* Return the size of the returned data */
 
@@ -163,17 +145,7 @@ static uint16_t recvfrom_eventhandler(FAR struct net_driver_s *dev,
 
           /* Return the IPv4 address of the sender from the IPv4 header */
 
-          ipv4 = IPv4BUF;
           net_ipv4addr_hdrcopy(&pstate->recv_from, ipv4->srcipaddr);
-
-          /* Decrement the count of outstanding requests.  I suppose this
-           * could have already been decremented of there were multiple
-           * threads calling sendto() or recvfrom().  If there finds, we
-           * may have to beef up the design.
-           */
-
-          DEBUGASSERT(conn->nreqs > 0);
-          conn->nreqs--;
 
           /* Indicate that the data has been consumed */
 
@@ -225,7 +197,7 @@ end_wait:
 static inline ssize_t icmp_readahead(FAR struct icmp_conn_s *conn,
                                      FAR void *buf, size_t buflen,
                                      FAR struct sockaddr_in *from,
-                                     FAR socklen_t *fromlen)
+                                     FAR socklen_t *fromlen, bool raw)
 {
   FAR struct iob_s *iob;
   ssize_t ret = -ENODATA;
@@ -236,6 +208,8 @@ static inline ssize_t icmp_readahead(FAR struct icmp_conn_s *conn,
 
   if ((iob = iob_peek_queue(&conn->readahead)) != NULL)
     {
+      unsigned int offset = 0;
+
       DEBUGASSERT(iob->io_pktlen > 0);
 
       /* Then get address */
@@ -247,7 +221,17 @@ static inline ssize_t icmp_readahead(FAR struct icmp_conn_s *conn,
 
       /* Copy to user */
 
-      ret = (ssize_t)iob_copyout(buf, iob, buflen, 0);
+      if (!raw)
+        {
+          FAR struct ipv4_hdr_s *ipv4 =
+                                 (FAR struct ipv4_hdr_s *)IOB_DATA(iob);
+
+          /* Skip L3 header when not SOCK_RAW */
+
+          offset = (ipv4->vhl & IPv4_HLMASK) << 2;
+        }
+
+      ret = (ssize_t)iob_copyout(buf, iob, buflen, offset);
 
       ninfo("Received %ld bytes (of %u)\n", (long)ret, iob->io_pktlen);
 
@@ -305,7 +289,7 @@ ssize_t icmp_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
   FAR socklen_t *fromlen = &msg->msg_namelen;
   FAR struct sockaddr_in *inaddr;
   FAR struct icmp_conn_s *conn;
-  FAR struct net_driver_s *dev;
+  FAR struct net_driver_s *dev = NULL;
   struct icmp_recvfrom_s state;
   ssize_t ret;
 
@@ -332,25 +316,18 @@ ssize_t icmp_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
 
   net_lock();
 
-  /* We cannot receive a response from a device until a request has been
-   * sent to the devivce.
-   */
-
   conn = psock->s_conn;
-  if (conn->nreqs < 1)
+  if (psock->s_type != SOCK_RAW)
     {
-      ret = -EPROTO;
-      goto errout;
-    }
+      /* Get the device that was used to send the ICMP request. */
 
-  /* Get the device that was used to send the ICMP request. */
-
-  dev = conn->dev;
-  DEBUGASSERT(dev != NULL);
-  if (dev == NULL)
-    {
-      ret = -EPROTO;
-      goto errout;
+      dev = conn->dev;
+      DEBUGASSERT(dev != NULL);
+      if (dev == NULL)
+        {
+          ret = -EPROTO;
+          goto errout;
+        }
     }
 
   /* Check if there is buffered read-ahead data for this socket.  We may have
@@ -359,8 +336,8 @@ ssize_t icmp_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
 
   if (!IOB_QEMPTY(&conn->readahead))
     {
-      ret = icmp_readahead(conn, buf, len,
-                           (FAR struct sockaddr_in *)from, fromlen);
+      ret = icmp_readahead(conn, buf, len, (FAR struct sockaddr_in *)from,
+                           fromlen, psock->s_type == SOCK_RAW);
     }
   else if (_SS_ISNONBLOCK(conn->sconn.s_flags) ||
            (flags & MSG_DONTWAIT) != 0)
@@ -434,11 +411,10 @@ ssize_t icmp_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
        */
 
 errout:
-      if (conn->nreqs < 1)
+      if (ret < 0)
         {
-          conn->id    = 0;
-          conn->nreqs = 0;
-          conn->dev   = NULL;
+          conn->id  = 0;
+          conn->dev = NULL;
 
           iob_free_queue(&conn->readahead);
         }

--- a/net/icmp/icmp_sendmsg.c
+++ b/net/icmp/icmp_sendmsg.c
@@ -339,12 +339,11 @@ ssize_t icmp_sendmsg(FAR struct socket *psock, FAR struct msghdr *msg,
    */
 
   icmp = (FAR struct icmp_hdr_s *)buf;
-  if (icmp->type != ICMP_ECHO_REQUEST || icmp->id != conn->id ||
-      dev != conn->dev)
+  if (psock->s_type != SOCK_RAW && (icmp->type != ICMP_ECHO_REQUEST ||
+      icmp->id != conn->id || dev != conn->dev))
     {
-      conn->id    = 0;
-      conn->nreqs = 0;
-      conn->dev   = NULL;
+      conn->id  = 0;
+      conn->dev = NULL;
 
       iob_free_queue(&conn->readahead);
     }
@@ -379,19 +378,18 @@ ssize_t icmp_sendmsg(FAR struct socket *psock, FAR struct msghdr *msg,
   state.snd_cb = icmp_callback_alloc(dev, conn);
   if (state.snd_cb != NULL)
     {
-      state.snd_cb->flags   = (ICMP_POLL | NETDEV_DOWN);
-      state.snd_cb->priv    = (FAR void *)&state;
-      state.snd_cb->event   = sendto_eventhandler;
+      state.snd_cb->flags = (ICMP_POLL | NETDEV_DOWN);
+      state.snd_cb->priv  = (FAR void *)&state;
+      state.snd_cb->event = sendto_eventhandler;
 
       /* Setup to receive ICMP ECHO replies */
 
-      if (icmp->type == ICMP_ECHO_REQUEST)
+      if (psock->s_type != SOCK_RAW && icmp->type == ICMP_ECHO_REQUEST)
         {
-          conn->id    = icmp->id;
-          conn->nreqs = 1;
+          conn->id = icmp->id;
         }
 
-        conn->dev     = dev;
+        conn->dev = dev;
 
       /* Notify the device driver of the availability of TX data */
 
@@ -452,9 +450,8 @@ ssize_t icmp_sendmsg(FAR struct socket *psock, FAR struct msghdr *msg,
   return len;
 
 errout:
-  conn->id    = 0;
-  conn->nreqs = 0;
-  conn->dev   = NULL;
+  conn->id  = 0;
+  conn->dev = NULL;
 
   iob_free_queue(&conn->readahead);
   return ret;

--- a/net/inet/inet_sockif.c
+++ b/net/inet/inet_sockif.c
@@ -2441,8 +2441,8 @@ inet_sockif(sa_family_t family, int type, int protocol)
 #if defined(HAVE_PFINET_SOCKETS) && defined(CONFIG_NET_ICMP_SOCKET)
   /* PF_INET, ICMP data gram sockets are a special case of raw sockets */
 
-  if (family == PF_INET && (type == SOCK_DGRAM || type == SOCK_CTRL) &&
-      protocol == IPPROTO_ICMP)
+  if (family == PF_INET && (type == SOCK_DGRAM || type == SOCK_CTRL ||
+      type == SOCK_RAW) && protocol == IPPROTO_ICMP)
     {
       return &g_icmp_sockif;
     }


### PR DESCRIPTION
## Summary
Since ICMPv6 has added SOCK_RAW, a SOCK_RAW related implementation has also been added for ICMP.
## Impact

## Testing
sim:local
