### PR TITLE
Cordic api modify

### DIFF
--- a/include/nuttx/math/cordic.h
+++ b/include/nuttx/math/cordic.h
@@ -48,11 +48,9 @@
  * Public Types
  ****************************************************************************/
 
-#ifdef CONFIG_MATH_CORDIC_USE_Q31
 /* q1.31 as int32_t */
 
 typedef int32_t cordic_num_t;
-#endif
 
 /* CORDIC functions */
 

--- a/include/nuttx/math/cordic.h
+++ b/include/nuttx/math/cordic.h
@@ -117,6 +117,8 @@ struct cordic_calc_s
   /* CORDIC request configuration */
 
   uint8_t func;                 /* CORDIC function */
+  int8_t  input_scale;
+  int8_t  output_scale;
   bool    res2_incl;            /* Include secondary result if available */
 
   /* Input data */


### PR DESCRIPTION
## Summary
small changes below
1. add scale in cordic api, because some hardware accelerator has scale parameter in cordic funtions. 
2. remove CONFIG_MATH_CORDIC_USE_Q31 for cordic_num_t, it's redundant, especially if you open CONFIG_MATH_CORDIC and not open for CONFIG_MATH_CORDIC_USE_Q31, the compile will fail.

## Impact
include/nuttx/math

## Testing

