### PR TITLE
mempool:Use default alignment inside of blockalign

### DIFF
--- a/include/nuttx/mm/mempool.h
+++ b/include/nuttx/mm/mempool.h
@@ -38,10 +38,16 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+#if CONFIG_MM_DFAULT_ALIGNMENT == 0
+#  define MEMPOOL_ALIGN       (2 * sizeof(uintptr_t))
+#else
+#  define MEMPOOL_ALIGN       CONFIG_MM_DFAULT_ALIGNMENT
+#endif
+
 #if CONFIG_MM_BACKTRACE >= 0
 #  define MEMPOOL_REALBLOCKSIZE(pool) (ALIGN_UP((pool)->blocksize + \
                                        sizeof(struct mempool_backtrace_s), \
-                                       (pool)->blockalign))
+                                       MEMPOOL_ALIGN))
 #else
 #  define MEMPOOL_REALBLOCKSIZE(pool) ((pool)->blocksize)
 #endif
@@ -87,9 +93,6 @@ struct mempool_procfs_entry_s
 struct mempool_s
 {
   size_t     blocksize;     /* The size for every block in mempool */
-#if CONFIG_MM_BACKTRACE >= 0
-  size_t     blockalign;    /* The alignment of the blocksize */
-#endif
   size_t     initialsize;   /* The initialize size in normal mempool */
   size_t     interruptsize; /* The initialize size in interrupt mempool */
   size_t     expandsize;    /* The size of expand block every time for mempool */

--- a/mm/mempool/mempool_multiple.c
+++ b/mm/mempool/mempool_multiple.c
@@ -439,9 +439,6 @@ mempool_multiple_init(FAR const char *name,
       pools[i].priv = mpool;
       pools[i].alloc = mempool_multiple_alloc_callback;
       pools[i].free = mempool_multiple_free_callback;
-#if CONFIG_MM_BACKTRACE >= 0
-      pools[i].blockalign = mpool->minpoolsize;
-#endif
       ret = mempool_init(pools + i, name);
       if (ret < 0)
         {


### PR DESCRIPTION
## Summary
mempool:Use default alignment inside of blockalign
## Impact
mempool
## Testing
sim:nsh with `mm`