### PR TITLE
move task tls destruct to before _exit

### DIFF
--- a/libs/libc/stdlib/lib_exit.c
+++ b/libs/libc/stdlib/lib_exit.c
@@ -108,6 +108,10 @@ void exit(int status)
 
   atexit_call_exitfuncs(status, false);
 
+#if defined(CONFIG_TLS_TASK_NELEM) && CONFIG_TLS_TASK_NELEM > 0
+  task_tls_destruct();
+#endif
+
 #ifdef CONFIG_FILE_STREAM
   /* Flush all streams */
 

--- a/sched/group/group_leave.c
+++ b/sched/group/group_leave.c
@@ -128,10 +128,6 @@ static void group_remove(FAR struct task_group_s *group)
 
 static inline void group_release(FAR struct task_group_s *group)
 {
-#if defined(CONFIG_TLS_TASK_NELEM) && CONFIG_TLS_TASK_NELEM > 0
-  task_tls_destruct();
-#endif
-
   task_uninit_info(group);
 
 #if defined(CONFIG_SCHED_HAVE_PARENT) && defined(CONFIG_SCHED_CHILD_STATUS)


### PR DESCRIPTION
## Summary
Destroy task tls before _exit will be more reasonable.

#### Reason
There is an application model in our system, which is one main thread and some pool threads in one task.
These threads  are waiting for some work to do all the time.

This is currently exit sequence:
```
exit
  _exit                     
     group_kill_children   // kill threads in the task
     nxtask_exithook       // 
       group_leave         // call group_release after all of the members left the group
```       
The problem here is that all threads is killed by signal, which will lead to some resource hold by these threads is not released.
We can name this `task_tls_destruct()` is called **passively** to release task TLS.

What I'm trying to do is using the `task_tls_destruct()` to **actively** do something to cooperatively terminate all threads, like wake them up and give them a finishing flag, to ask them to exit their threadloop.

This is why I need to bring `task_tls_destruct()` to before `_exit`.

## Impact

task tls

## Testing

depends on https://github.com/apache/nuttx/pull/10320