### PR TITLE
getifaddrs: set sin6_scope_id when IPv6 enable

### DIFF
--- a/libs/libc/net/lib_getifaddrs.c
+++ b/libs/libc/net/lib_getifaddrs.c
@@ -25,6 +25,7 @@
 #include <errno.h>
 #include <ifaddrs.h>
 #include <net/if.h>
+#include <netinet/in.h>
 #include <sys/ioctl.h>
 #include <string.h>
 #include <unistd.h>
@@ -233,6 +234,7 @@ int getifaddrs(FAR struct ifaddrs **addrs)
 
           myaddrs->addrs.ifa_addr = (FAR struct sockaddr *)&myaddrs->addr;
           memcpy(&myaddrs->addr, &req.lifr_addr, sizeof(req.lifr_addr));
+          ((struct sockaddr_in6 *)&myaddrs->addr)->sin6_scope_id = i;
 
           if (ioctl(sockfd, SIOCGLIFNETMASK, (unsigned long)&req) >= 0)
             {


### PR DESCRIPTION
## Summary
ifindex is also returned when obtain NIC information through getifaddrs.

## Impact

## Testing
sim:local
