### PR TITLE
vfs:add nxsched_foreach to sched_lock avoid crash

### DIFF
--- a/sched/sched/sched_foreach.c
+++ b/sched/sched/sched_foreach.c
@@ -63,6 +63,7 @@ void nxsched_foreach(nxsched_foreach_t handler, FAR void *arg)
   /* Visit each active task */
 
   flags = enter_critical_section();
+  sched_lock();
   for (ndx = 0; ndx < g_npidhash; ndx++)
     {
       /* This test and the function call must be atomic */
@@ -73,5 +74,6 @@ void nxsched_foreach(nxsched_foreach_t handler, FAR void *arg)
         }
     }
 
+  sched_unlock();
   leave_critical_section(flags);
 }


### PR DESCRIPTION
## Summary
vfs:add sched_lock to sync avoid crash
If scheduling occurs in file_fsync,
fl_lock may be released, and an error may
occur when calling nxmutex_unlock

## Impact
call nxsched_foreach

## Testing
sim:nsh
