### PR TITLE
arm64: remove unnecessary trace interface

### DIFF
--- a/arch/arm64/src/common/arm64_vectors.S
+++ b/arch/arm64/src/common/arm64_vectors.S
@@ -162,12 +162,6 @@ restore_new:
     ldr    x4, [x0, #8 * REG_SP_ELX]
     sub    sp, x4, #8 * XCPTCONTEXT_GP_REGS
 
-#ifdef CONFIG_SCHED_INSTRUMENTATION_SWITCH
-    stp    xzr, x30, [sp, #-16]!
-    bl     arm64_trace_context_switch
-    ldp    xzr, x30, [sp], #16
-#endif
-
 #ifdef CONFIG_ARCH_FPU
     stp    xzr, x30, [sp, #-16]!
     bl     arm64_fpu_context_restore


### PR DESCRIPTION
## Summary
    this is an old implementation for ARM64 trace, but will fail
    compile when CONFIG_SCHED_INSTRUMENTATION_SWITCH is enabled.
    Remove it, since it will never be used for trace framework.

## Impact
None

## Testing
PASS
