### PR TITLE
local_recvmsg: do not print error message when errno is EAGAIN

### DIFF
--- a/net/local/local_recvmsg.c
+++ b/net/local/local_recvmsg.c
@@ -108,7 +108,15 @@ static int psock_fifo_read(FAR struct socket *psock, FAR void *buf,
         }
       else
         {
-          nerr("ERROR: Failed to read packet: %d\n", ret);
+          if (ret == -EAGAIN)
+            {
+              nwarn("WARNING: Failed to read packet: %d\n", ret);
+            }
+          else
+            {
+              nerr("ERROR: Failed to read packet: %d\n", ret);
+            }
+
           return ret;
         }
     }


### PR DESCRIPTION
## Summary
Some programs use EAGAIN to determine whether all data has been read, so cancel the error print when the error code is EAGAIN.
## Impact

## Testing
sim:local
