### PR TITLE
netdev_carrier: clear ip address when carrier off

### DIFF
--- a/net/netdev/netdev_carrier.c
+++ b/net/netdev/netdev_carrier.c
@@ -104,6 +104,18 @@ int netdev_carrier_off(FAR struct net_driver_s *dev)
       devif_dev_event(dev, NETDEV_DOWN);
       arp_cleanup(dev);
 
+#ifdef CONFIG_NET_IPv4
+      dev->d_ipaddr  = INADDR_ANY;
+      dev->d_draddr  = INADDR_ANY;
+      dev->d_netmask = INADDR_ANY;
+#endif
+
+#ifdef CONFIG_NET_IPv6
+      net_ipv6addr_copy(&dev->d_ipv6addr, &in6addr_any);
+      net_ipv6addr_copy(&dev->d_ipv6draddr, &in6addr_any);
+      net_ipv6addr_copy(&dev->d_ipv6netmask, &in6addr_any);
+#endif
+
       return OK;
     }
 


### PR DESCRIPTION

## Summary
Some dhcp servers respond to a dhcp offer only when they receive a dhcp discovery message that belongs to their own network segment or address 0. therefore, clear the original ip address when disconnected from the ap or ifdown.

## Impact

## Testing
ARM Cortex-M33
