### PR TITLE
include: move clockid_t and time[r]_t define to sys/types.h

### DIFF
--- a/include/sys/types.h
+++ b/include/sys/types.h
@@ -242,9 +242,13 @@ typedef uint16_t     sa_family_t;
 
 #ifdef CONFIG_SYSTEM_TIME64
 typedef uint64_t     clock_t;
+typedef int64_t      time_t;         /* Holds time in seconds */
 #else
 typedef uint32_t     clock_t;
+typedef uint32_t     time_t;         /* Holds time in seconds */
 #endif
+typedef int          clockid_t;      /* Identifies one time base source */
+typedef FAR void    *timer_t;        /* Represents one POSIX timer */
 
 /* The type useconds_t shall be an unsigned integer type capable of storing
  * values at least in the range [0, 1000000]. The type suseconds_t shall be

--- a/include/time.h
+++ b/include/time.h
@@ -106,16 +106,6 @@
  * Public Types
  ****************************************************************************/
 
-/* Scalar types */
-
-#ifdef CONFIG_SYSTEM_TIME64
-typedef uint64_t  time_t;         /* Holds time in seconds */
-#else
-typedef uint32_t  time_t;         /* Holds time in seconds */
-#endif
-typedef int       clockid_t;      /* Identifies one time base source */
-typedef FAR void *timer_t;        /* Represents one POSIX timer */
-
 /* struct timespec is the standard representation of time as seconds and
  * nanoseconds.
  */


### PR DESCRIPTION
POSIX Standard: Primitive System Data Types
https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_types.h.html

## Summary
fix LTP buildonly case
## Impact


## Testing
pass CI
