### PR TITLE
Fix the bug that localsocket fails to send in CONFIG_NET_LOCAL_DGRAM …

### DIFF
--- a/net/local/local_fifo.c
+++ b/net/local/local_fifo.c
@@ -152,12 +152,11 @@ static bool local_fifo_exists(FAR const char *path)
       return false;
     }
 
-  /* FIFOs are character devices in NuttX.  Return true if what we found
-   * is a FIFO.  What if it is something else?  In that case, we will
-   * return false and mkfifo() will fail.
+  /* Return true if what we found is a FIFO. What if it is something else?
+   * In that case, we will return false and mkfifo() will fail.
    */
 
-  return (bool)S_ISCHR(buf.st_mode);
+  return (bool)S_ISFIFO(buf.st_mode);
 }
 
 /****************************************************************************


### PR DESCRIPTION
 ## Summary
Fix the bug that localsocket fails to send in CONFIG_NET_LOCAL_DGRAM mode because fs adds pipe check (commit 9e06c3e)
## Impact
minor
## Testing

