### PR TITLE
net/tcp:Added tcp zero window probe timer support

### DIFF
--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -126,6 +126,9 @@
 
 #define TCP_FAST_RETRANSMISSION_THRESH 3
 
+#define TCP_RTO_MAX 240 /* 120s,The unit is half a second */
+#define TCP_RTO_MIN 1   /* 0.5s */
+
 /****************************************************************************
  * Public Type Definitions
  ****************************************************************************/
@@ -355,6 +358,7 @@ struct tcp_conn_s
 #if defined(CONFIG_NET_SENDFILE) && defined(CONFIG_NET_TCP_WRITE_BUFFERS)
   bool       sendfile;    /* True if sendfile operation is in progress */
 #endif
+  bool       zero_probe;   /* TCP zero window probe timer */
 
   /* connevents is a list of callbacks for each socket the uses this
    * connection (there can be more that one in the event that the the socket
@@ -760,7 +764,7 @@ void tcp_stop_monitor(FAR struct tcp_conn_s *conn, uint16_t flags);
  * Input Parameters:
  *   conn  - The TCP connection of interest
  *   cb    - devif callback structure
- *   flags - Set of connection events events
+ *   flags - Set of connection events
  *
  * Returned Value:
  *   None
@@ -2303,6 +2307,27 @@ void tcp_cc_recv_ack(FAR struct tcp_conn_s *conn, FAR struct tcp_hdr_s *tcp);
 #ifdef __cplusplus
 }
 #endif
+
+/****************************************************************************
+ * Name: tcp_set_zero_probe
+ *
+ * Description:
+ *   Update the TCP probe timer for the provided TCP connection,
+ *   The timeout is accurate
+ *
+ * Input Parameters:
+ *   conn    - The TCP "connection" to poll for TX data
+ *   flags   - Set of connection events
+ *
+ * Returned Value:
+ *   None
+ *
+ * Assumptions:
+ *   conn is not NULL.
+ *
+ ****************************************************************************/
+
+void tcp_set_zero_probe(FAR struct tcp_conn_s *conn, uint16_t flags);
 
 #endif /* !CONFIG_NET_TCP_NO_STACK */
 #endif /* CONFIG_NET_TCP */

--- a/net/tcp/tcp_input.c
+++ b/net/tcp/tcp_input.c
@@ -634,6 +634,40 @@ static void tcp_parse_option(FAR struct net_driver_s *dev,
 }
 
 /****************************************************************************
+ * Name: tcp_clear_zero_probe
+ *
+ * Description:
+ *   clear the TCP zero window probe
+ *
+ * Input Parameters:
+ *   conn   - The TCP connection of interest
+ *   tcp    - Header of TCP structure
+ *
+ * Returned Value:
+ *   None
+ *
+ * Assumptions:
+ *   The network is locked.
+ *
+ ****************************************************************************/
+
+static void tcp_clear_zero_probe(FAR struct tcp_conn_s *conn,
+                                 FAR struct tcp_hdr_s *tcp)
+{
+  /* If the receive window is not 0,
+   * the zero window probe timer needs to be cleared
+   */
+
+  if ((tcp->wnd[0] || tcp->wnd[1]) && conn->zero_probe &&
+      (tcp->flags & TCP_ACK) != 0)
+    {
+      conn->zero_probe = false;
+      conn->nrtx = 0;
+      conn->timer = 0;
+    }
+}
+
+/****************************************************************************
  * Name: tcp_input
  *
  * Description:
@@ -1154,6 +1188,8 @@ found:
 
       tcp_update_retrantimer(conn, conn->rto);
     }
+
+  tcp_clear_zero_probe(conn, tcp);
 
   /* Update the connection's window size */
 

--- a/net/tcp/tcp_send_buffered.c
+++ b/net/tcp/tcp_send_buffered.c
@@ -1119,6 +1119,10 @@ static uint16_t psock_send_eventhandler(FAR struct net_driver_s *dev,
           flags &= ~TCP_POLL;
         }
     }
+  else
+    {
+      tcp_set_zero_probe(conn, flags);
+    }
 
   /* Continue waiting */
 


### PR DESCRIPTION
## Summary
net/tcp:Added tcp zero window probe timer support
https://www.rfc-editor.org/rfc/rfc1122#page-92
## Impact
minor
## Testing

