### PR TITLE
sched/smp: flush dcache before start other cpus

### DIFF
--- a/sched/init/nx_smpstart.c
+++ b/sched/init/nx_smpstart.c
@@ -111,6 +111,10 @@ int nx_smp_start(void)
   int ret;
   int cpu;
 
+  /* Flush dcache before start other CPUs. */
+
+  up_flush_dcache_all();
+
   /* Start all of the other CPUs.  CPU0 is already running. */
 
   for (cpu = 1; cpu < CONFIG_SMP_NCPUS; cpu++)


### PR DESCRIPTION
## Summary

core0 may write the data used by other cpu, this will cause cache inconsistency. so need fulsh dcache before start other cpus.

## Impact

smp

## Testing

fvp-armv8r:nsh_smp boot