### PR TITLE
fixed the unused variable caused warnning in lib_gethostbyaddrr

### DIFF
--- a/libs/libc/netdb/lib_gethostbyaddrr.c
+++ b/libs/libc/netdb/lib_gethostbyaddrr.c
@@ -201,7 +201,9 @@ static int lib_localhost(FAR const void *addr, socklen_t len, int type,
 
   return 1;
 
+#if defined(CONFIG_NET_IPv4) || defined(CONFIG_NET_IPv6)
 out_copyname:
+#endif
 
   /* And copy localhost host name */
 

--- a/libs/libc/netdb/lib_gethostentbynamer.c
+++ b/libs/libc/netdb/lib_gethostentbynamer.c
@@ -228,7 +228,10 @@ static int lib_localhost(FAR const char *name, FAR struct hostent_s *host,
   FAR struct hostent_info_s *info;
   FAR char *dest;
   int namelen;
+
+#if defined(CONFIG_NET_IPv4) || defined(CONFIG_NET_IPv6)
   int i = 0;
+#endif
 
   if (strcmp(name, g_lo_hostname) == 0)
     {


### PR DESCRIPTION
## Summary
   lib_gethostbyaddrr.c: warning: label 'out_copyname' defined but not used [-Wunused-label] 204 | out_copyname:

## Impact

## Testing

