### PR TITLE
sigqueue: add signal type judgment logic

### DIFF
--- a/sched/signal/sig_dispatch.c
+++ b/sched/signal/sig_dispatch.c
@@ -193,12 +193,19 @@ static FAR sigpendq_t *nxsig_alloc_pendingsignal(void)
  ****************************************************************************/
 
 static FAR sigpendq_t *
-  nxsig_find_pendingsignal(FAR struct task_group_s *group, int signo)
+nxsig_find_pendingsignal(FAR struct task_group_s *group, int signo)
 {
   FAR sigpendq_t *sigpend = NULL;
   irqstate_t flags;
 
   DEBUGASSERT(group != NULL);
+
+  /* Determining whether a signal is reliable or unreliable */
+
+  if (SIGRTMIN <= signo && signo <= SIGRTMAX)
+    {
+      return sigpend;
+    }
 
   /* Pending signals can be added from interrupt level. */
 


### PR DESCRIPTION
## Summary

To determine whether a signal is real-time signal or standard signal, the POSIX standard https://www.man7.org/linux/man-pages/man7/signal.7.html defines a real-time signal between SIGRTMIN  and SIGRTMAX , which can store multiple copies, otherwise only one can be retained.

## Impact

## Testing

sim:ostest