### PR TITLE
net/tcp: Fix unreadable error when doing poll operation on tcp socket.

### DIFF
--- a/net/tcp/tcp_netpoll.c
+++ b/net/tcp/tcp_netpoll.c
@@ -219,7 +219,8 @@ int tcp_pollsetup(FAR struct socket *psock, FAR struct pollfd *fds)
 
   /* Non-blocking connection ? */
 
-  nonblock_conn = (conn->tcpstateflags == TCP_SYN_SENT &&
+  nonblock_conn = ((conn->tcpstateflags == TCP_ALLOCATED ||
+                    conn->tcpstateflags == TCP_SYN_SENT) &&
                    _SS_ISNONBLOCK(conn->sconn.s_flags));
 
   /* Find a container to hold the poll information */


### PR DESCRIPTION

## Summary
When do poll operation and the tcp connection state is TCP_ALLOCATED, eventset(POLLERR|POLLHUP) is return, causing the libuv poll_multiple_handles to fail. So we add the condition of TCP_ALLOCATED on calculating the `nonblock_conn`.
## Impact
If a tcp connection is in the TCP_ALLOCATED state and nonblocking, we can do poll operation on it.
## Testing
Use the libuv test case ` uv_run_tests poll_multiple_handles`.
