### PR TITLE
tools/refresh.sh: Add option to refresh  custom board

### DIFF
--- a/tools/refresh.sh
+++ b/tools/refresh.sh
@@ -18,6 +18,7 @@
 #
 
 WD=`test -d ${0%/*} && cd ${0%/*}; pwd`
+CWD=`pwd`
 
 USAGE="USAGE: $0 [options] <board>:<config>+"
 ADVICE="Try '$0 --help' for more information"
@@ -150,7 +151,18 @@ for CONFIG in ${CONFIGS}; do
     BOARDSUBDIR=`echo ${CONFIG} | cut -d':' -f1`
   fi
 
-  BOARDDIR=boards/*/*/$BOARDSUBDIR
+  BOARDDIR=${CONFIG}
+  if [ ! -d $BOARDDIR ]; then
+    BOARDDIR="${CWD}/${BOARDDIR}"
+  fi
+
+  if [ -d $BOARDDIR ]; then
+    CONFIGSUBDIR=`basename ${CONFIG}`
+    BOARDDIR=$(dirname `dirname ${BOARDDIR}`)
+  else
+    BOARDDIR=boards/*/*/$BOARDSUBDIR
+  fi
+
   SCRIPTSDIR=$BOARDDIR/scripts
   MAKEDEFS1=$SCRIPTSDIR/Make.defs
 


### PR DESCRIPTION
## Summary

This patch modify the script to update only the boards configs of an specific chip or only the boards of an specific architecture.

Examples:

refresh.sh add custom board verify
custom board:
```
./tools/refresh.sh --silent /xxx/xxx/configs/ap
./tools/refresh.sh --silent ../../xxx/configs/ap
```

## Impact

refresh.sh

## Testing

ci