### PR TITLE
libc/gpsutils: merged into one target to fix issue of parallel compile

### DIFF
--- a/libs/libc/gpsutils/Make.defs
+++ b/libs/libc/gpsutils/Make.defs
@@ -31,25 +31,24 @@ $(MINMEA_UNPACKNAME):
 	$(Q) mkdir $(MINMEA_UNPACKNAME)
 	$(Q) unzip -o -j $(MINMEA_VERSION).zip -d $(MINMEA_UNPACKNAME)
 	$(call DELFILE, $(MINMEA_VERSION).zip)
+	$(Q) mkdir -p $(TOPDIR)$(DELIM)include$(DELIM)minmea$(DELIM)
+	$(Q) cp gpsutils/minmea/minmea.h $(TOPDIR)$(DELIM)include$(DELIM)minmea$(DELIM)
 
 # Files
 
 CSRCS  += minmea.c
 CFLAGS += -std=c99
 
-.header:
-	$(shell mkdir -p $(TOPDIR)$(DELIM)include$(DELIM)minmea$(DELIM))
-	$(shell cp gpsutils/minmea/minmea.h $(TOPDIR)$(DELIM)include$(DELIM)minmea$(DELIM))
-
 clean::
 	$(call DELFILE, $(OBJS))
 
 # Download and unpack tarball if no git repo found
 ifeq ($(wildcard $(MINMEA_UNPACKNAME)/.git),)
-context:: $(MINMEA_UNPACKNAME) .header
+context:: $(MINMEA_UNPACKNAME)
 
 distclean::
 	$(call DELDIR, $(MINMEA_UNPACKNAME))
+	$(call DELDIR, $(TOPDIR)$(DELIM)include$(DELIM)minmea$(DELIM))
 else
 context:: .header
 endif


### PR DESCRIPTION


## Summary
libc/gpsutils: merged into one target to fix the issue of parallel compilation

Because multiple dependencies behind the context are compiled in parallel, if they have dependencies on each other, it will cause compilation errors.

This PR is realted to https://github.com/apache/nuttx-apps/pull/1867
## Impact

## Testing
./tools/configure.sh lilygo_tbeam_lora_gps/gps &&  make -j8
