### PR TITLE
libs/ctype/toupper_l: Implement function toupper_l instead of macro

### DIFF
--- a/include/ctype.h
+++ b/include/ctype.h
@@ -31,26 +31,7 @@
  ****************************************************************************/
 
 #include <nuttx/compiler.h>
-
-/****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-#define isalnum_l(c, l)  isalnum(c)
-#define isalpha_l(c, l)  isalpha(c)
-#define isascii_l(c, l)  isascii(c)
-#define isblank_l(c, l)  isblank(c)
-#define iscntrl_l(c, l)  iscntrl(c)
-#define isdigit_l(c, l)  isdigit(c)
-#define isgraph_l(c, l)  isgraph(c)
-#define islower_l(c, l)  islower(c)
-#define isprint_l(c, l)  isprint(c)
-#define ispunct_l(c, l)  ispunct(c)
-#define isspace_l(c, l)  isspace(c)
-#define isupper_l(c, l)  isupper(c)
-#define isxdigit_l(c, l) isxdigit(c)
-#define tolower_l(c, l)  tolower(c)
-#define toupper_l(c, l)  toupper(c)
+#include <langinfo.h>
 
 /****************************************************************************
  * Inline Functions
@@ -80,8 +61,14 @@ static inline int isspace(int c)
   return c == ' ' || c == '\t' || c == '\n' || c == '\r' ||
          c == '\f' || c == '\v';
 }
+
+static inline int isspace_l(int c, locale_t locale)
+{
+  return isspace(c);
+}
 #else
 int isspace(int c);
+int isspace_l(int c, locale_t locale);
 #endif
 
 /****************************************************************************
@@ -98,8 +85,14 @@ static inline int isascii(int c)
 {
   return c >= 0 && c <= 0x7f;
 }
+
+static inline int isascii_l(int c, locale_t locale)
+{
+  return isascii(c);
+}
 #else
 int isascii(int c);
+int isascii_l(int c, locale_t locale);
 #endif
 
 /****************************************************************************
@@ -115,8 +108,14 @@ static inline int isprint(int c)
 {
   return c >= 0x20 && c < 0x7f;
 }
+
+static inline int isprint_l(int c, locale_t locale)
+{
+  return isprint(c);
+}
 #else
 int isprint(int c);
+int isprint_l(int c, locale_t locale);
 #endif
 
 /****************************************************************************
@@ -132,8 +131,14 @@ static inline int isgraph(int c)
 {
   return c > 0x20 && c < 0x7f;
 }
+
+static inline int isgraph_l(int c, locale_t locale)
+{
+  return isgraph(c);
+}
 #else
 int isgraph(int c);
+int isgraph_l(int c, locale_t locale);
 #endif
 
 /****************************************************************************
@@ -149,8 +154,14 @@ static inline int iscntrl(int c)
 {
   return c < 0x20 || c == 0x7f;
 }
+
+static inline int iscntrl_l(int c, locale_t locale)
+{
+  return iscntrl(c);
+}
 #else
 int iscntrl(int c);
+int iscntrl_l(int c, locale_t locale);
 #endif
 
 /****************************************************************************
@@ -166,8 +177,14 @@ static inline int islower(int c)
 {
   return c >= 'a' && c <= 'z';
 }
+
+static inline int islower_l(int c, locale_t locale)
+{
+  return islower(c);
+}
 #else
 int islower(int c);
+int islower_l(int c, locale_t locale);
 #endif
 
 /****************************************************************************
@@ -183,8 +200,14 @@ static inline int isupper(int c)
 {
   return c >= 'A' && c <= 'Z';
 }
+
+static inline int isupper_l(int c, locale_t locale)
+{
+  return isupper(c);
+}
 #else
 int isupper(int c);
+int isupper_l(int c, locale_t locale);
 #endif
 
 /****************************************************************************
@@ -200,8 +223,14 @@ static inline int isalpha(int c)
 {
   return islower(c) || isupper(c);
 }
+
+static inline int isalpha_l(int c, locale_t locale)
+{
+  return isalpha(c);
+}
 #else
 int isalpha(int c);
+int isalpha_l(int c, locale_t locale);
 #endif
 
 /****************************************************************************
@@ -217,8 +246,14 @@ static inline int isblank(int c)
 {
   return c == ' ' || c == '\t';
 }
+
+static inline int isblank_l(int c, locale_t locale)
+{
+  return isblank(c);
+}
 #else
 int isblank(int c);
+int isblank_l(int c, locale_t locale);
 #endif
 
 /****************************************************************************
@@ -234,8 +269,14 @@ static inline int isdigit(int c)
 {
   return c >= '0' && c <= '9';
 }
+
+static inline int isdigit_l(int c, locale_t locale)
+{
+  return isdigit(c);
+}
 #else
 int isdigit(int c);
+int isdigit_l(int c, locale_t locale);
 #endif
 
 /****************************************************************************
@@ -251,8 +292,14 @@ static inline int isalnum(int c)
 {
   return isalpha(c) || isdigit(c);
 }
+
+static inline int isalnum_l(int c, locale_t locale)
+{
+  return isalnum(c);
+}
 #else
 int isalnum(int c);
+int isalnum_l(int c, locale_t locale);
 #endif
 
 /****************************************************************************
@@ -269,8 +316,14 @@ static inline int ispunct(int c)
 {
   return isgraph(c) && !isalnum(c);
 }
+
+static inline int ispunct_l(int c, locale_t locale)
+{
+  return ispunct(c);
+}
 #else
 int ispunct(int c);
+int ispunct_l(int c, locale_t locale);
 #endif
 
 /****************************************************************************
@@ -288,8 +341,14 @@ static inline int isxdigit(int c)
          (c >= 'a' && c <= 'f') ||
          (c >= 'A' && c <= 'F');
 }
+
+static inline int isxdigit_l(int c, locale_t locale)
+{
+  return isxdigit(c);
+}
 #else
 int isxdigit(int c);
+int isxdigit_l(int c, locale_t locale);
 #endif
 
 /****************************************************************************
@@ -305,8 +364,14 @@ static inline int toupper(int c)
 {
   return (c >= 'a' && c <= 'z') ? c - 'a' + 'A' : c;
 }
+
+static inline int toupper_l(int c, locale_t locale)
+{
+  return toupper(c);
+}
 #else
 int toupper(int c);
+int toupper_l(int c, locale_t locale);
 #endif
 
 /****************************************************************************
@@ -322,8 +387,14 @@ static inline int tolower(int c)
 {
   return (c >= 'A' && c <= 'Z') ? (c - 'A' + 'a') : c;
 }
+
+static inline int tolower_l(int c, locale_t locale)
+{
+  return tolower(c);
+}
 #else
 int tolower(int c);
+int tolower_l(int c, locale_t locale);
 #endif
 
 #undef EXTERN

--- a/libs/libc/ctype/lib_isalnum.c
+++ b/libs/libc/ctype/lib_isalnum.c
@@ -32,3 +32,8 @@ int isalnum(int c)
 {
   return isalpha(c) || isdigit(c);
 }
+
+int isalnum_l(int c, locale_t locale)
+{
+  return isalnum(c);
+}

--- a/libs/libc/ctype/lib_isalpha.c
+++ b/libs/libc/ctype/lib_isalpha.c
@@ -32,3 +32,8 @@ int isalpha(int c)
 {
   return islower(c) || isupper(c);
 }
+
+int isalpha_l(int c, locale_t locale)
+{
+  return isalpha(c);
+}

--- a/libs/libc/ctype/lib_isascii.c
+++ b/libs/libc/ctype/lib_isascii.c
@@ -32,3 +32,8 @@ int isascii(int c)
 {
   return c >= 0 && c <= 0x7f;
 }
+
+int isascii_l(int c, locale_t locale)
+{
+  return isascii(c);
+}

--- a/libs/libc/ctype/lib_isblank.c
+++ b/libs/libc/ctype/lib_isblank.c
@@ -32,3 +32,8 @@ int isblank(int c)
 {
   return c == ' ' || c == '\t';
 }
+
+int isblank_l(int c, locale_t locale)
+{
+  return isblank(c);
+}

--- a/libs/libc/ctype/lib_iscntrl.c
+++ b/libs/libc/ctype/lib_iscntrl.c
@@ -32,3 +32,8 @@ int iscntrl(int c)
 {
   return c < 0x20 || c == 0x7f;
 }
+
+int iscntrl_l(int c, locale_t locale)
+{
+  return iscntrl(c);
+}

--- a/libs/libc/ctype/lib_isdigit.c
+++ b/libs/libc/ctype/lib_isdigit.c
@@ -32,3 +32,8 @@ int isdigit(int c)
 {
   return c >= '0' && c <= '9';
 }
+
+int isdigit_l(int c, locale_t locale)
+{
+  return isdigit(c);
+}

--- a/libs/libc/ctype/lib_isgraph.c
+++ b/libs/libc/ctype/lib_isgraph.c
@@ -32,3 +32,8 @@ int isgraph(int c)
 {
   return c > 0x20 && c < 0x7f;
 }
+
+int isgraph_l(int c, locale_t locale)
+{
+  return isgraph(c);
+}

--- a/libs/libc/ctype/lib_islower.c
+++ b/libs/libc/ctype/lib_islower.c
@@ -32,3 +32,8 @@ int islower(int c)
 {
   return c >= 'a' && c <= 'z';
 }
+
+int islower_l(int c, locale_t locale)
+{
+  return islower(c);
+}

--- a/libs/libc/ctype/lib_isprint.c
+++ b/libs/libc/ctype/lib_isprint.c
@@ -32,3 +32,8 @@ int isprint(int c)
 {
   return c >= 0x20 && c < 0x7f;
 }
+
+int isprint_l(int c, locale_t locale)
+{
+  return isprint(c);
+}

--- a/libs/libc/ctype/lib_ispunct.c
+++ b/libs/libc/ctype/lib_ispunct.c
@@ -32,3 +32,8 @@ int ispunct(int c)
 {
   return isgraph(c) && !isalnum(c);
 }
+
+int ispunct_l(int c, locale_t locale)
+{
+  return ispunct(c);
+}

--- a/libs/libc/ctype/lib_isspace.c
+++ b/libs/libc/ctype/lib_isspace.c
@@ -33,3 +33,8 @@ int isspace(int c)
   return c == ' ' || c == '\t' || c == '\n' || c == '\r' ||
          c == '\f' || c == '\v';
 }
+
+int isspace_l(int c, locale_t locale)
+{
+  return isspace(c);
+}

--- a/libs/libc/ctype/lib_isupper.c
+++ b/libs/libc/ctype/lib_isupper.c
@@ -32,3 +32,8 @@ int isupper(int c)
 {
   return c >= 'A' && c <= 'Z';
 }
+
+int isupper_l(int c, locale_t locale)
+{
+  return isupper(c);
+}

--- a/libs/libc/ctype/lib_isxdigit.c
+++ b/libs/libc/ctype/lib_isxdigit.c
@@ -34,3 +34,8 @@ int isxdigit(int c)
          (c >= 'a' && c <= 'f') ||
          (c >= 'A' && c <= 'F');
 }
+
+int isxdigit_l(int c, locale_t locale)
+{
+  return isxdigit(c);
+}

--- a/libs/libc/ctype/lib_tolower.c
+++ b/libs/libc/ctype/lib_tolower.c
@@ -32,3 +32,8 @@ int tolower(int c)
 {
   return (c >= 'A' && c <= 'Z') ? (c - 'A' + 'a') : c;
 }
+
+int tolower_l(int c, locale_t locale)
+{
+  return tolower(c);
+}

--- a/libs/libc/ctype/lib_toupper.c
+++ b/libs/libc/ctype/lib_toupper.c
@@ -32,3 +32,9 @@ int toupper(int c)
 {
   return (c >= 'a' && c <= 'z') ? c - 'a' + 'A' : c;
 }
+
+int toupper_l(int c, locale_t locale)
+{
+  return toupper(c);
+}
+


### PR DESCRIPTION

## Summary
libs/ctype/toupper_l: Implement function toupper_l instead of macro.
Use functions instead of macros to solve recursive execution problems
toupper_l will be replaced by toupper, resulting in infinite recursion, so implement toupper_l

crash stack:
```
0  std::__1::ctype_byname<char>::do_toupper (this=0xf3888120, c=49 '1') at libcxx/src/locale.cpp:1231 
1  0x005b8188 in std::__1::ctype<char>::toupper (__c=49 '1', this=0xf3888120) at nuttx/include/libcxx/__locale:667 
2  std::__1::ctype_byname<char>::do_toupper (this=0xf3888120, c=49 '1') at libcxx/src/locale.cpp:1231 
3  0x005b8188 in std::__1::ctype<char>::toupper (__c=49 '1', this=0xf3888120) at nuttx/include/libcxx/__locale:667 
4  std::__1::ctype_byname<char>::do_toupper (this=0xf3888120, c=49 '1') at libcxx/src/locale.cpp:1231 
5  0x0064cfc9 in std::__1::ctype<char>::toupper (__c=49 '1', this=0xf3888120) at nuttx/include/libcxx/__locale:667 
6  std::__1::__scan_keyword<char*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*, std::__1::ctype<char> > (__b=@0xf38871a0: 0xf3887220 "11:55:59 PM",
   __e=0xf388722b "", __kb=0xf2c03990, __ke=0xf2c03a38, __ct=..., __err=@0xf38871b0: 0, __case_sensitive=false) at nuttx/include/libcxx/locale:299
7  0x005cb0ed in std::__1::__time_get_storage<char>::__analyze (this=0xf2c0398c, fmt=114 'r', ct=...) at libcxx/src/locale.cpp:4998 
8  0x005cf888 in std::__1::__time_get_storage<char>::init (this=0xf2c0398c, ct=...) at libcxx/src/locale.cpp:5295 
9  0x005d4d0f in std::__1::__time_get_storage<char>::__time_get_storage (this=0xf2c0398c, __nm=...) at libcxx/src/locale.cpp:5399 
10 0x005b15c8 in std::__1::time_get_byname<char, std::__1::istreambuf_iterator<char, std::__1::char_traits<char> > >::time_get_byname (__refs=0, __nm=..., this=0xf2c03980)
   at nuttx/include/libcxx/locale:2446
11 std::__1::locale::__imp::__imp (this=0xf2803970, name=..., refs=0) at libcxx/src/locale.cpp:268 
12 0x005b333e in std::__1::locale::locale (this=0xf3888f00, name=0x6ca340 "C") at libcxx/src/locale.cpp:562 
13 0x0058313b in helloxx_main (argc=1, argv=0xf3878810) at helloxx_main.cxx:112 
14 0x0048471a in nxtask_startup (entrypt=0x5830a0 <helloxx_main(int, char**)>, argc=1, argv=0xf3878810) at sched/task_startup.c:70 15 0x00431bcd in nxtask_start () at task/task_start.c:134 16 0x0048f643 in pre_start () at sim/sim_initialstate.c:52 17 0x00000000 in ?? ()
```
## Impact

## Testing
test code:
```
extern "C" int main(int argc, FAR char *argv[])
{
  std::locale loc {"C"};
  return 0;
}
```
