### PR TITLE
drivers/virtio-net: Add support to offload small IOBs

### DIFF
--- a/drivers/net/netdev_upperhalf.c
+++ b/drivers/net/netdev_upperhalf.c
@@ -1290,12 +1290,17 @@ FAR uint8_t *netpkt_getbase(FAR netpkt_t *pkt)
  *   pkt    - The net packet
  *   len    - The length of data in netpkt
  *
+ * Returned Value:
+ *   The new effective data length, or a negated errno value on error.
+ *
  ****************************************************************************/
 
-void netpkt_setdatalen(FAR struct netdev_lowerhalf_s *dev,
-                       FAR netpkt_t *pkt, unsigned int len)
+int netpkt_setdatalen(FAR struct netdev_lowerhalf_s *dev,
+                      FAR netpkt_t *pkt, unsigned int len)
 {
-  iob_update_pktlen(pkt, len - NET_LL_HDRLEN(&dev->netdev));
+  uint8_t llhdrlen = NET_LL_HDRLEN(&dev->netdev);
+  int ret = iob_update_pktlen(pkt, len - llhdrlen, false);
+  return ret >= 0 ? ret + llhdrlen : ret;
 }
 
 /****************************************************************************

--- a/drivers/net/netdev_upperhalf.c
+++ b/drivers/net/netdev_upperhalf.c
@@ -1359,3 +1359,42 @@ bool netpkt_is_fragmented(FAR netpkt_t *pkt)
 {
   return pkt->io_flink != NULL;
 }
+
+/****************************************************************************
+ * Name: netpkt_to_iov
+ *
+ * Description:
+ *   Write each piece of data/len into iov array.
+ *
+ * Input Parameters:
+ *   dev    - The lower half device driver structure
+ *   pkt    - The net packet
+ *   iov    - The iov array to write
+ *   iovcnt - The number of elements in the iov array
+ *
+ * Returned Value:
+ *   The actual written count of iov entries.
+ *
+ ****************************************************************************/
+
+int netpkt_to_iov(FAR struct netdev_lowerhalf_s *dev, FAR netpkt_t *pkt,
+                  FAR struct iovec *iov, int iovcnt)
+{
+  int i;
+
+  for (i = 0; pkt != NULL && i < iovcnt; pkt = pkt->io_flink, i++)
+    {
+      if (i == 0)
+        {
+          iov[i].iov_base = IOB_DATA(pkt) - NET_LL_HDRLEN(&dev->netdev);
+          iov[i].iov_len  = pkt->io_len   + NET_LL_HDRLEN(&dev->netdev);
+        }
+      else
+        {
+          iov[i].iov_base = IOB_DATA(pkt);
+          iov[i].iov_len  = pkt->io_len;
+        }
+    }
+
+  return i;
+}

--- a/include/nuttx/mm/iob.h
+++ b/include/nuttx/mm/iob.h
@@ -571,14 +571,16 @@ void iob_reserve(FAR struct iob_s *iob, unsigned int reserved);
  *
  * Description:
  *   This function will update packet length of the iob, it will be
- *   trimmed if the length of the iob chain is greater than the current
- *   length.
- *   This function will not grow the iob link, any grow operation should
- *   be implemented through iob_copyin()/iob_trycopyin().
+ *   trimmed if the current length of the iob chain is greater than the
+ *   new length, and will be grown if less than new length.
+ *
+ * Returned Value:
+ *   The new effective iob packet length, or a negated errno value on error.
  *
  ****************************************************************************/
 
-void iob_update_pktlen(FAR struct iob_s *iob, unsigned int pktlen);
+int iob_update_pktlen(FAR struct iob_s *iob, unsigned int pktlen,
+                      bool throttled);
 
 /****************************************************************************
  * Name: iob_count

--- a/include/nuttx/net/netdev_lowerhalf.h
+++ b/include/nuttx/net/netdev_lowerhalf.h
@@ -47,12 +47,25 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* | <-------------- NETPKT_BUFLEN ---------------> |
+/* Layout for net packet:
+ *
+ * | <-------------- NETPKT_BUFLEN ---------------> |
  * +---------------------+-------------------+------+      +-------------+
  * | reserved for driver |       data        | free | ---> | next netpkt |
  * +---------------------+-------------------+------+      +-------------+
  * |                     | <--- datalen ---> |
  * ^base                 ^data
+ */
+
+/* Layout for linked net packet, you can get list of (data, len) by
+ * netpkt_to_iov() interface:
+ *
+ *            | <----------- datalen = sum(len) ------------> |
+ * +----------+-----------+     +-----------+     +-----------+------+
+ * | reserved |   data    | --> |   data    | --> |   data    | free |
+ * +----------+-----------+     +-----------+     +-----------+------+
+ * |          | <- len -> |     | <- len -> |     | <- len -> |
+ * ^base      ^data             ^data             ^data
  */
 
 #define NETPKT_BUFLEN   CONFIG_IOB_BUFSIZE
@@ -477,5 +490,25 @@ void netpkt_reset_reserved(FAR struct netdev_lowerhalf_s *dev,
  ****************************************************************************/
 
 bool netpkt_is_fragmented(FAR netpkt_t *pkt);
+
+/****************************************************************************
+ * Name: netpkt_to_iov
+ *
+ * Description:
+ *   Write each piece of data/len into iov array.
+ *
+ * Input Parameters:
+ *   dev    - The lower half device driver structure
+ *   pkt    - The net packet
+ *   iov    - The iov array to write
+ *   iovcnt - The number of elements in the iov array
+ *
+ * Returned Value:
+ *   The actual written count of iov entries.
+ *
+ ****************************************************************************/
+
+int netpkt_to_iov(FAR struct netdev_lowerhalf_s *dev, FAR netpkt_t *pkt,
+                  FAR struct iovec *iov, int iovcnt);
 
 #endif /* __INCLUDE_NUTTX_NET_NETDEV_LOWERHALF_H */

--- a/include/nuttx/net/netdev_lowerhalf.h
+++ b/include/nuttx/net/netdev_lowerhalf.h
@@ -422,10 +422,13 @@ FAR uint8_t *netpkt_getbase(FAR netpkt_t *pkt);
  *   pkt    - The net packet
  *   len    - The length of data in netpkt
  *
+ * Returned Value:
+ *   The new effective data length, or a negated errno value on error.
+ *
  ****************************************************************************/
 
-void netpkt_setdatalen(FAR struct netdev_lowerhalf_s *dev,
-                       FAR netpkt_t *pkt, unsigned int len);
+int netpkt_setdatalen(FAR struct netdev_lowerhalf_s *dev,
+                      FAR netpkt_t *pkt, unsigned int len);
 
 /****************************************************************************
  * Name: netpkt_getdatalen

--- a/net/arp/arp_format.c
+++ b/net/arp/arp_format.c
@@ -109,7 +109,7 @@ void arp_format(FAR struct net_driver_s *dev, in_addr_t ipaddr)
 
   /* Update device buffer length */
 
-  iob_update_pktlen(dev->d_iob, sizeof(struct arp_hdr_s));
+  iob_update_pktlen(dev->d_iob, sizeof(struct arp_hdr_s), false);
 }
 
 #endif /* CONFIG_NET_ARP */

--- a/net/devif/devif_filesend.c
+++ b/net/devif/devif_filesend.c
@@ -92,7 +92,7 @@ int devif_file_send(FAR struct net_driver_s *dev, FAR struct file *file,
       goto errout;
     }
 
-  iob_update_pktlen(dev->d_iob, target_offset);
+  iob_update_pktlen(dev->d_iob, target_offset, false);
 
   ret = file_seek(file, offset, SEEK_SET);
   if (ret < 0)
@@ -142,7 +142,7 @@ int devif_file_send(FAR struct net_driver_s *dev, FAR struct file *file,
         }
     }
 
-  iob_update_pktlen(dev->d_iob, target_offset + len);
+  iob_update_pktlen(dev->d_iob, target_offset + len, false);
 
   dev->d_sndlen = len;
   return len;

--- a/net/devif/devif_poll.c
+++ b/net/devif/devif_poll.c
@@ -704,7 +704,7 @@ static int devif_poll_ipfrag(FAR struct net_driver_s *dev,
 
   if (!bstop && reused)
     {
-      iob_update_pktlen(dev->d_iob, 0);
+      iob_update_pktlen(dev->d_iob, 0, false);
       netdev_iob_prepare(dev, true, 0);
     }
 

--- a/net/devif/devif_send.c
+++ b/net/devif/devif_send.c
@@ -102,7 +102,7 @@ int devif_send(FAR struct net_driver_s *dev, FAR const void *buf,
 
   /* Prepare device buffer before poll callback */
 
-  iob_update_pktlen(dev->d_iob, offset);
+  iob_update_pktlen(dev->d_iob, offset, false);
 
   ret = iob_trycopyin(dev->d_iob, buf, len, offset, false);
   if (ret != len)

--- a/net/devif/ipv4_input.c
+++ b/net/devif/ipv4_input.c
@@ -207,7 +207,7 @@ static int ipv4_in(FAR struct net_driver_s *dev)
   totlen = (ipv4->len[0] << 8) + ipv4->len[1];
   if (totlen < dev->d_len)
     {
-      iob_update_pktlen(dev->d_iob, totlen);
+      iob_update_pktlen(dev->d_iob, totlen, false);
       dev->d_len = totlen;
     }
   else if (totlen > dev->d_len)

--- a/net/devif/ipv6_input.c
+++ b/net/devif/ipv6_input.c
@@ -256,7 +256,7 @@ static int ipv6_in(FAR struct net_driver_s *dev)
 
   if (paylen < dev->d_len)
     {
-      iob_update_pktlen(dev->d_iob, paylen);
+      iob_update_pktlen(dev->d_iob, paylen, false);
       dev->d_len = paylen;
     }
   else if (paylen > dev->d_len)

--- a/net/icmp/icmp_reply.c
+++ b/net/icmp/icmp_reply.c
@@ -133,7 +133,7 @@ void icmp_reply(FAR struct net_driver_s *dev, int type, int code)
 
       /* Skip icmp header from iob */
 
-      iob_update_pktlen(dev->d_iob, datalen + ipicmplen);
+      iob_update_pktlen(dev->d_iob, datalen + ipicmplen, false);
     }
   else
     {
@@ -167,8 +167,9 @@ void icmp_reply(FAR struct net_driver_s *dev, int type, int code)
 
       /* Skip icmp header from iob */
 
-      iob_update_pktlen(dev->d_iob, dev->d_iob->io_pktlen +
-                                    sizeof(struct icmp_hdr_s));
+      iob_update_pktlen(dev->d_iob,
+                        dev->d_iob->io_pktlen + sizeof(struct icmp_hdr_s),
+                        false);
 
       /* Concat new icmp packet before original datagram */
 

--- a/net/icmpv6/icmpv6_advertise.c
+++ b/net/icmpv6/icmpv6_advertise.c
@@ -105,7 +105,7 @@ void icmpv6_advertise(FAR struct net_driver_s *dev,
 
   /* Update device buffer length */
 
-  iob_update_pktlen(dev->d_iob, IPv6_HDRLEN + l3size);
+  iob_update_pktlen(dev->d_iob, IPv6_HDRLEN + l3size, false);
 
   /* Calculate the checksum over both the ICMP header and payload */
 

--- a/net/icmpv6/icmpv6_radvertise.c
+++ b/net/icmpv6/icmpv6_radvertise.c
@@ -282,7 +282,7 @@ void icmpv6_radvertise(FAR struct net_driver_s *dev)
 
   /* Update device buffer length */
 
-  iob_update_pktlen(dev->d_iob, IPv6_HDRLEN + l3size);
+  iob_update_pktlen(dev->d_iob, IPv6_HDRLEN + l3size, false);
 
   /* Calculate the checksum over both the ICMP header and payload */
 

--- a/net/icmpv6/icmpv6_reply.c
+++ b/net/icmpv6/icmpv6_reply.c
@@ -122,7 +122,7 @@ void icmpv6_reply(FAR struct net_driver_s *dev, int type, int code, int data)
 
       /* Skip icmp header from iob */
 
-      iob_update_pktlen(dev->d_iob, datalen + ipicmplen);
+      iob_update_pktlen(dev->d_iob, datalen + ipicmplen, false);
     }
   else
     {
@@ -156,8 +156,9 @@ void icmpv6_reply(FAR struct net_driver_s *dev, int type, int code, int data)
 
       /* Skip icmp header from iob */
 
-      iob_update_pktlen(dev->d_iob, dev->d_iob->io_pktlen +
-                                    sizeof(struct icmpv6_hdr_s));
+      iob_update_pktlen(dev->d_iob,
+                        dev->d_iob->io_pktlen + sizeof(struct icmpv6_hdr_s),
+                        false);
 
       /* Concat new icmp packet before original datagram */
 

--- a/net/icmpv6/icmpv6_rsolicit.c
+++ b/net/icmpv6/icmpv6_rsolicit.c
@@ -99,7 +99,7 @@ void icmpv6_rsolicit(FAR struct net_driver_s *dev)
 
   /* Update device buffer length */
 
-  iob_update_pktlen(dev->d_iob, IPv6_HDRLEN + l3size);
+  iob_update_pktlen(dev->d_iob, IPv6_HDRLEN + l3size, false);
 
   /* Calculate the checksum over both the ICMP header and payload */
 

--- a/net/icmpv6/icmpv6_solicit.c
+++ b/net/icmpv6/icmpv6_solicit.c
@@ -122,7 +122,7 @@ void icmpv6_solicit(FAR struct net_driver_s *dev,
 
   /* Update device buffer length */
 
-  iob_update_pktlen(dev->d_iob, IPv6_HDRLEN + l3size);
+  iob_update_pktlen(dev->d_iob, IPv6_HDRLEN + l3size, false);
 
   /* Calculate the checksum over both the ICMP header and payload */
 

--- a/net/igmp/igmp_send.c
+++ b/net/igmp/igmp_send.c
@@ -129,7 +129,7 @@ void igmp_send(FAR struct net_driver_s *dev, FAR struct igmp_group_s *group,
 
   /* Update device buffer length */
 
-  iob_update_pktlen(dev->d_iob, dev->d_len);
+  iob_update_pktlen(dev->d_iob, dev->d_len, false);
 
   /* The total size of the data is the size of the IGMP header */
 

--- a/net/mld/mld_send.c
+++ b/net/mld/mld_send.c
@@ -168,7 +168,7 @@ void mld_send(FAR struct net_driver_s *dev, FAR struct mld_group_s *group,
 
   /* Update device buffer length */
 
-  iob_update_pktlen(dev->d_iob, dev->d_len);
+  iob_update_pktlen(dev->d_iob, dev->d_len, false);
 
   /* Select the IPv6 destination address.
    * This varies with the type of message being sent:

--- a/net/tcp/tcp_send.c
+++ b/net/tcp/tcp_send.c
@@ -170,7 +170,7 @@ static void tcp_sendcommon(FAR struct net_driver_s *dev,
 
   /* Update device buffer length before setup the IP header */
 
-  iob_update_pktlen(dev->d_iob, dev->d_len);
+  iob_update_pktlen(dev->d_iob, dev->d_len, false);
 
   /* Calculate chk & build L3 header */
 
@@ -464,7 +464,7 @@ void tcp_reset(FAR struct net_driver_s *dev, FAR struct tcp_conn_s *conn)
 
   /* Update device buffer length before setup the IP header */
 
-  iob_update_pktlen(dev->d_iob, dev->d_len);
+  iob_update_pktlen(dev->d_iob, dev->d_len, false);
 
   /* Calculate chk & build L3 header */
 

--- a/net/udp/udp_send.c
+++ b/net/udp/udp_send.c
@@ -174,7 +174,7 @@ void udp_send(FAR struct net_driver_s *dev, FAR struct udp_conn_s *conn)
 
       /* Update the device buffer length */
 
-      iob_update_pktlen(dev->d_iob, dev->d_len);
+      iob_update_pktlen(dev->d_iob, dev->d_len, false);
 
 #ifdef CONFIG_NET_UDP_CHECKSUMS
       /* Calculate UDP checksum. */

--- a/net/udp/udp_sendto_buffered.c
+++ b/net/udp/udp_sendto_buffered.c
@@ -790,7 +790,7 @@ ssize_t psock_udp_sendto(FAR struct socket *psock, FAR const void *buf,
       udpiplen = udpip_hdrsize(conn);
 
       iob_reserve(wrb->wb_iob, CONFIG_NET_LL_GUARDSIZE);
-      iob_update_pktlen(wrb->wb_iob, udpiplen);
+      iob_update_pktlen(wrb->wb_iob, udpiplen, false);
 
       /* Copy the user data into the write buffer.  We cannot wait for
        * buffer space if the socket was opened non-blocking.


### PR DESCRIPTION
## Summary
#### TCP receive tested with different `IOB_BUFSIZE` (1534Byte is current config):
|             | 256B vs 1534B | 512B vs 1534B | 768B vs 1534B |
| :---------: | :-----------: | :-----------: | :-----------: |
|     Non-SMP |     ~85%      |     ~93%      |     ~96%      |
|  armv8a-SMP |     ~66%      |     ~84%      |     ~92%      |
| rv32/64-SMP |     ~52%      |     ~72%      |     ~83%      |

It seems we still get performance penalty on smaller IOBs, and may be affected more under SMP mode. It may be caused by critical sections in IOB operations.

#### Patches included:
- drivers/virtio-net: Add support to offload small IOBs
- netdev/upper: Add `netpkt_to_iov()` interface
  - Some driver like virtio-net can offload fragmented IOBs, so an interface to support this feature is needed.
- mm/iob: Add support for increasing length in `iob_update_pktlen`
- drivers/virtio-net: Support different `LL_GUARDSIZE`
  - Previously, the `CONFIG_NET_LL_GUARDSIZE` is fixed to 32 (64-Bit) or 28 (32-Bit), it's a little bit tricky. Now add support to any value greater than minimal size.

## Impact
virtio-net

## Testing
Manually with iperf, CI

