### PR TITLE
risc-v/mpfs: mpfs_usb: fix tx fifo size setup

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_usb.c
+++ b/arch/risc-v/src/mpfs/mpfs_usb.c
@@ -1339,7 +1339,7 @@ static int mpfs_ep_configure_internal(struct mpfs_ep_s *privep,
                        TXCSRL_REG_EPN_STALL_SENT_MASK,
                         0);
 
-      mpfs_ep_set_fifo_size(epno, 0, maxpacket);
+      mpfs_ep_set_fifo_size(epno, dirin, maxpacket);
 
       /* Give EP0 64 bytes (8*8) and configure 512 bytes for TX fifo.
        * This is a pointer to internal RAM where the data should be


### PR DESCRIPTION
Currently TX_FIFO_SIZE is not altered in mpfs_ep_set_fifo_size(), but all paths (RX and TX) change MPFS_USB_RX_FIFO_SIZE only. Fix the TX_FIFO_SIZE setup.

## Summary

The system would like to change MPFS_USB_RX_FIFO_SIZE and MPFS_USB_TX_FIFO_SIZE, but unfortunately in both cases end up modifying the MPFS_USB_RX_FIFO_SIZE only.

## Impact

MPFS USB, no notifiable differences

## Testing

Flashing images with the patch.
