### PR TITLE
boards: Fix QEMU_VIRTIO_MMIO_NUM

### DIFF
--- a/boards/arm/qemu/qemu-armv7a/src/qemu_bringup.c
+++ b/boards/arm/qemu/qemu-armv7a/src/qemu_bringup.c
@@ -39,7 +39,7 @@
 #define QEMU_VIRTIO_MMIO_BASE    0x0a000000
 #define QEMU_VIRTIO_MMIO_REGSIZE 0x200
 #define QEMU_VIRTIO_MMIO_IRQ     48
-#define QEMU_VIRTIO_MMIO_NUM     4
+#define QEMU_VIRTIO_MMIO_NUM     32
 
 /****************************************************************************
  * Private Functions

--- a/boards/arm64/qemu/qemu-armv8a/src/qemu_bringup.c
+++ b/boards/arm64/qemu/qemu-armv8a/src/qemu_bringup.c
@@ -39,7 +39,7 @@
 #define QEMU_VIRTIO_MMIO_BASE    0x0a000000
 #define QEMU_VIRTIO_MMIO_REGSIZE 0x200
 #define QEMU_VIRTIO_MMIO_IRQ     48
-#define QEMU_VIRTIO_MMIO_NUM     4
+#define QEMU_VIRTIO_MMIO_NUM     32
 
 /****************************************************************************
  * Private Functions

--- a/boards/risc-v/qemu-rv/rv-virt/src/qemu_rv_appinit.c
+++ b/boards/risc-v/qemu-rv/rv-virt/src/qemu_rv_appinit.c
@@ -45,7 +45,7 @@
 #else
 #  define QEMU_VIRTIO_MMIO_IRQ   28
 #endif
-#define QEMU_VIRTIO_MMIO_NUM     4
+#define QEMU_VIRTIO_MMIO_NUM     8
 
 /****************************************************************************
  * Private Functions


### PR DESCRIPTION
## Summary

- I noticed that device discovery for virtio-mmio devices does not work without bus=virtio-mmio-bus.x option. 
- Without this option, qemu assigns the virtio device into the virtio-mmio space in reverse order automatically.
- To fix this issue, we must specify the correct numbers for the target machines. (i.e. arm32/64->32, rv32/64->8)

## Impact

- None

## Testing

- Tested with qemu-7.2.4
