### PR TITLE
riscv/riscv_addrenv.c: Allocate heap for default task stacksize

### DIFF
--- a/arch/risc-v/src/common/riscv_addrenv.c
+++ b/arch/risc-v/src/common/riscv_addrenv.c
@@ -419,7 +419,7 @@ int up_addrenv_create(size_t textsize, size_t datasize, size_t heapsize,
 
   /* Allocate 1 extra page for heap, temporary fix for #5811 */
 
-  heapsize = heapsize + MM_PGALIGNUP(1);
+  heapsize = heapsize + MM_PGALIGNUP(CONFIG_DEFAULT_TASK_STACKSIZE);
 
   /* Map the reserved area */
 


### PR DESCRIPTION
## Summary
1 page might not be enough, if the task has a bigger stack. Best effort is to allocate the default amount, however this won't work will all tasks either. See issue #5811 for more details.
## Impact
Fixes system crash when not enough heap is allocated for new task's stack. Only affects builds with CONFIG_BUILD_KERNEL.
## Testing
Target with processes whose stack size is > 1 page (4K)
