### PR TITLE
Revert "ci/Dockerfile: Update riscv toolchain to gcc13.2.0"

### DIFF
--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -167,10 +167,10 @@ RUN cd /tools/renesas-tools/build/gcc && \
 # Build image for tool required by RISCV builds
 ###############################################################################
 FROM nuttx-toolchain-base AS nuttx-toolchain-riscv
-# Download the latest RISCV GCC toolchain prebuilt by Embecosm
-RUN mkdir riscv32-unknown-elf-gcc && \
-  curl -s -L "https://buildbot.embecosm.com/job/riscv32-gcc-ubuntu2204-release/10/artifact/riscv32-embecosm-ubuntu2204-gcc13.2.0.tar.gz" \
-  | tar -C riscv32-unknown-elf-gcc --strip-components 1 -xz
+# Download the latest RISCV GCC toolchain prebuilt by SiFive
+RUN mkdir riscv64-unknown-elf-gcc && \
+  curl -s -L "https://static.dev.sifive.com/dev-tools/freedom-tools/v2020.12/riscv64-unknown-elf-toolchain-10.2.0-2020.12.8-x86_64-linux-ubuntu14.tar.gz" \
+  | tar -C riscv64-unknown-elf-gcc --strip-components 1 -xz
 
 ###############################################################################
 # Build image for tool required by SPARC builds
@@ -349,8 +349,8 @@ COPY --from=nuttx-toolchain-renesas /tools/renesas-toolchain/rx-elf-gcc/ renesas
 ENV PATH="/tools/renesas-toolchain/rx-elf-gcc/bin:$PATH"
 
 # RISCV toolchain
-COPY --from=nuttx-toolchain-riscv /tools/riscv32-unknown-elf-gcc/ riscv32-unknown-elf-gcc/
-ENV PATH="/tools/riscv32-unknown-elf-gcc/bin:$PATH"
+COPY --from=nuttx-toolchain-riscv /tools/riscv64-unknown-elf-gcc/ riscv64-unknown-elf-gcc/
+ENV PATH="/tools/riscv64-unknown-elf-gcc/bin:$PATH"
 
 # SPARC toolchain
 COPY --from=nuttx-toolchain-sparc /tools/sparc-gaisler-elf-gcc/ sparc-gaisler-elf-gcc/
@@ -392,8 +392,8 @@ RUN mkdir -p /tools/ccache/bin && \
   ln -sf `which ccache` /tools/ccache/bin/g++ && \
   ln -sf `which ccache` /tools/ccache/bin/p32-gcc && \
   ln -sf `which ccache` /tools/ccache/bin/rx-elf-gcc && \
-  ln -sf `which ccache` /tools/ccache/bin/riscv32-unknown-elf-gcc && \
-  ln -sf `which ccache` /tools/ccache/bin/riscv32-unknown-elf-g++ && \
+  ln -sf `which ccache` /tools/ccache/bin/riscv64-unknown-elf-gcc && \
+  ln -sf `which ccache` /tools/ccache/bin/riscv64-unknown-elf-g++ && \
   ln -sf `which ccache` /tools/ccache/bin/sparc-gaisler-elf-gcc && \
   ln -sf `which ccache` /tools/ccache/bin/sparc-gaisler-elf-g++ && \
   ln -sf `which ccache` /tools/ccache/bin/xtensa-esp32-elf-gcc && \


### PR DESCRIPTION
Reverts apache/nuttx#10306 since some target fail to build here: https://github.com/apache/nuttx/pull/10345.