### PR TITLE
github: Skip the build if the change is under tools/ci/docker/linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ on:
   pull_request:
     paths-ignore:
       - 'Documentation/**'
+      - 'tools/ci/docker/linux/**'
   push:
     paths-ignore:
       - 'Documentation/**'


### PR DESCRIPTION
## Summary

don't need waste time to build the source code if the patch only changes dockerfile.

## Impact

ci

## Testing

ci