### PR TITLE
Toolchain: strict GCC version check from GCC-12.2 to GCC-12

### DIFF
--- a/arch/arm/src/common/Toolchain.defs
+++ b/arch/arm/src/common/Toolchain.defs
@@ -244,15 +244,15 @@ else
     endif
   endif
 
-  # Workaround to skip -Warray-bounds check due to bug of GCC-12.2:
+  # Workaround to skip -Warray-bounds check due to bug of GCC-12:
   # Wrong warning array subscript [0] is outside array bounds:
   # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523
 
   ifeq ($(GCCVER),)
-    export GCCVER := $(shell $(CC) --version | grep gcc | sed -r "s/.* ([0-9]+\.[0-9]+).*/\1/")
+    export GCCVER := $(shell $(CC) --version | grep gcc | sed -r "s/.* ([0-9]+\.[0-9]+).*/\1/" | cut -d'.' -f1)
   endif
 
-  ifeq ($(GCCVER),12.2)
+  ifeq ($(GCCVER),12)
     ARCHOPTIMIZATION += --param=min-pagesize=0
     ifeq ($(CONFIG_ARCH_RAMFUNCS),y)
       LDFLAGS += --no-warn-rwx-segments

--- a/arch/xtensa/src/esp32/Make.defs
+++ b/arch/xtensa/src/esp32/Make.defs
@@ -236,9 +236,9 @@ CHIP_CSRCS += esp32_wlan.c esp32_wifi_utils.c esp32_wifi_adapter.c
 EXTRA_LIBS += -lcore -lnet80211 -lpp -lsmartconfig -lespnow -lwpa_supplicant
 
 ifeq ($(GCCVER),)
-  export GCCVER := $(shell $(CC) --version | grep gcc | sed -r 's/.* ([0-9]+\.[0-9]+).*/\1/')
+  export GCCVER := $(shell $(CC) --version | grep gcc | sed -r 's/.* ([0-9]+\.[0-9]+).*/\1/' | cut -d'.' -f1)
 endif
-ifeq ($(GCCVER),12.2)
+ifeq ($(GCCVER),12)
   chip/esp32_wifi_adapter.c_CFLAGS += -Wno-maybe-uninitialized
 endif
 endif

--- a/libs/libxx/libcxx.defs
+++ b/libs/libxx/libcxx.defs
@@ -71,7 +71,7 @@ libcxx/src/locale.cpp_CXXFLAGS += -Wno-shadow
 libcxx/src/filesystem/directory_iterator.cpp_CXXFLAGS += -Wno-shadow
 libcxx/src/filesystem/operations.cpp_CXXFLAGS += -Wno-shadow
 
-# Workaround the following warning with "GCC 12.2"
+# Workaround the following warning with "GCC 12"
 #
 # ...
 # include/libcxx/string:2156:35: warning: '__temp' may be used uninitialized [-Wmaybe-uninitialized]
@@ -85,10 +85,10 @@ libcxx/src/filesystem/operations.cpp_CXXFLAGS += -Wno-shadow
 #       |                                ^~~~~~
 
 ifeq ($(GCCVER),)
-  export GCCVER = $(shell $(CXX) --version | grep g++ | sed -r 's/.* ([0-9]+\.[0-9]+).*/\1/')
+  export GCCVER = $(shell $(CXX) --version | grep g++ | sed -r 's/.* ([0-9]+\.[0-9]+).*/\1/' | cut -d'.' -f1)
 endif
 
-ifeq ($(GCCVER),12.2)
+ifeq ($(GCCVER),12)
   libcxx/src/filesystem/operations.cpp_CXXFLAGS += -Wno-maybe-uninitialized
 endif
 


### PR DESCRIPTION

## Summary

Toolchain: strict GCC version check from GCC-12.2 to GCC-12

Toolchain related detection errors are still not resolved on GCC-12.3


## Impact

N/A fix ci break

## Testing

ci check