### PR TITLE
cmake:replace custom_patch_target with PATCH_COMMAND

### DIFF
--- a/libs/libxx/libcxxabi.cmake
+++ b/libs/libxx/libcxxabi.cmake
@@ -39,6 +39,9 @@ if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/libcxxabi)
         ""
         TEST_COMMAND
         ""
+    PATCH_COMMAND
+      patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
+      ${CMAKE_CURRENT_LIST_DIR}/0001-libc-abi-avoid-the-waring-__EXCEPTIONS-is-not-define.patch
     DOWNLOAD_NO_PROGRESS true
     TIMEOUT 30)
 
@@ -47,19 +50,6 @@ if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/libcxxabi)
   if(NOT libcxxabi_POPULATED)
     FetchContent_Populate(libcxxabi)
   endif()
-endif()
-
-add_custom_target(libcxxabi_patch)
-
-if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/libcxxabi/.libcxxabi_patch)
-  add_custom_command(
-    TARGET libcxxabi_patch
-    PRE_BUILD
-    COMMAND touch ${CMAKE_CURRENT_LIST_DIR}/libcxxabi/.libcxxabi_patch
-    COMMAND
-      patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
-      ${CMAKE_CURRENT_LIST_DIR}/0001-libc-abi-avoid-the-waring-__EXCEPTIONS-is-not-define.patch
-      > /dev/null || (exit 0) DEPENDS libcxxabi)
 endif()
 
 nuttx_add_system_library(libcxxabi)
@@ -112,5 +102,3 @@ foreach(src ${SRCS})
 endforeach()
 
 target_sources(libcxxabi PRIVATE ${TARGET_SRCS})
-
-add_dependencies(libcxxabi libcxxabi_patch)

--- a/openamp/open-amp.cmake
+++ b/openamp/open-amp.cmake
@@ -17,7 +17,7 @@
 # the License.
 #
 # ##############################################################################
-if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/open-amp/.git)
+if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/open-amp)
   FetchContent_Declare(
     open-amp
     DOWNLOAD_NAME "libopen-amp-v${OPENAMP_VERSION}.zip"
@@ -35,6 +35,45 @@ if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/open-amp/.git)
         ""
         TEST_COMMAND
         ""
+    PATCH_COMMAND
+      patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
+      ${CMAKE_CURRENT_LIST_DIR}/0001-ns-acknowledge-the-received-creation-message.patch
+      && patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
+      ${CMAKE_CURRENT_LIST_DIR}/0002-Negotiate-individual-buffer-size-dynamically.patch
+      && patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
+      ${CMAKE_CURRENT_LIST_DIR}/0003-rpmsg-wait-endpoint-ready-in-rpmsg_send-and-rpmsg_se.patch
+      && patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
+      ${CMAKE_CURRENT_LIST_DIR}/0004-openamp-add-new-ops-notify_wait-support.patch
+      && patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
+      ${CMAKE_CURRENT_LIST_DIR}/0005-rpmsg_virtio-don-t-need-check-status-when-get_tx_pay.patch
+      && patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
+      ${CMAKE_CURRENT_LIST_DIR}/0006-rpmsg-notify-the-user-when-the-remote-address-is-rec.patch
+      && patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
+      ${CMAKE_CURRENT_LIST_DIR}/0007-openamp-avoid-double-calling-ns_bound-when-each-othe.patch
+      && patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
+      ${CMAKE_CURRENT_LIST_DIR}/0008-remoteproc-make-all-elf_-functions-static-except-elf.patch
+      && patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
+      ${CMAKE_CURRENT_LIST_DIR}/0009-Fix-warn-declaration-of-vring_rsc-shadows-a-previous.patch
+      && patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
+      ${CMAKE_CURRENT_LIST_DIR}/0010-rptun-fix-rptun-don-t-wait-issue-when-get-tx-patyloa.patch
+      && patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
+      ${CMAKE_CURRENT_LIST_DIR}/0011-rpmsg-fix-rpmsg_virtio_get_tx_buffer-no-idx-return.patch
+      && patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
+      ${CMAKE_CURRENT_LIST_DIR}/0012-rpmsg-add-new-API-rpdev_release_tx-rx_buffer.patch
+      && patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
+      ${CMAKE_CURRENT_LIST_DIR}/0013-openamp-add-error-log-when-ept-cb-return-error.patch
+      && patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
+      ${CMAKE_CURRENT_LIST_DIR}/0014-rpmsg-add-cache-flash-when-hold-rx-buffer.patch
+      && patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
+      ${CMAKE_CURRENT_LIST_DIR}/0015-rpmsg-do-cache_invalidate-when-real-data-returned.patch
+      && patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
+      ${CMAKE_CURRENT_LIST_DIR}/0016-openamp-add-new-API-rpmsg_virtio_get_rxbuffer_size.patch
+      && patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
+      ${CMAKE_CURRENT_LIST_DIR}/0017-virtio-follow-virtio-1.2-spec-add-more-virtio-status.patch
+      && patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
+      ${CMAKE_CURRENT_LIST_DIR}/0018-virtio-decoupling-the-transport-layer-and-virtio-dev.patch
+      && patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
+      ${CMAKE_CURRENT_LIST_DIR}/0019-virtio.h-add-version-in-device-id-table.patch
     DOWNLOAD_NO_PROGRESS true
     TIMEOUT 30)
 
@@ -43,105 +82,20 @@ if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/open-amp/.git)
   if(NOT open-amp_POPULATED)
     FetchContent_Populate(open-amp)
   endif()
-
-  if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/.openamp_patch)
-    add_custom_command(
-      OUTPUT ${CMAKE_CURRENT_LIST_DIR}/.openamp_patch
-      COMMAND touch ${CMAKE_CURRENT_LIST_DIR}/.openamp_patch
-      COMMAND
-        patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
-        ${CMAKE_CURRENT_LIST_DIR}/0001-ns-acknowledge-the-received-creation-message.patch
-        > /dev/null || (exit 0)
-      COMMAND
-        patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
-        ${CMAKE_CURRENT_LIST_DIR}/0002-Negotiate-individual-buffer-size-dynamically.patch
-        > /dev/null || (exit 0)
-      COMMAND
-        patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
-        ${CMAKE_CURRENT_LIST_DIR}/0003-rpmsg-wait-endpoint-ready-in-rpmsg_send-and-rpmsg_se.patch
-        > /dev/null || (exit 0)
-      COMMAND
-        patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
-        ${CMAKE_CURRENT_LIST_DIR}/0004-openamp-add-new-ops-notify_wait-support.patch
-        > /dev/null || (exit 0)
-      COMMAND
-        patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
-        ${CMAKE_CURRENT_LIST_DIR}/0005-rpmsg_virtio-don-t-need-check-status-when-get_tx_pay.patch
-        > /dev/null || (exit 0)
-      COMMAND
-        patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
-        ${CMAKE_CURRENT_LIST_DIR}/0006-rpmsg-notify-the-user-when-the-remote-address-is-rec.patch
-        > /dev/null || (exit 0)
-      COMMAND
-        patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
-        ${CMAKE_CURRENT_LIST_DIR}/0007-openamp-avoid-double-calling-ns_bound-when-each-othe.patch
-        > /dev/null || (exit 0)
-      COMMAND
-        patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
-        ${CMAKE_CURRENT_LIST_DIR}/0008-remoteproc-make-all-elf_-functions-static-except-elf.patch >
-        /dev/null || (exit 0)
-      COMMAND
-        patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
-        ${CMAKE_CURRENT_LIST_DIR}/0009-Fix-warn-declaration-of-vring_rsc-shadows-a-previous.patch
-        > /dev/null || (exit 0)
-      COMMAND
-        patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
-        ${CMAKE_CURRENT_LIST_DIR}/0010-rptun-fix-rptun-don-t-wait-issue-when-get-tx-patyloa.patch
-        > /dev/null || (exit 0)
-      COMMAND
-        patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
-        ${CMAKE_CURRENT_LIST_DIR}/0011-rpmsg-fix-rpmsg_virtio_get_tx_buffer-no-idx-return.patch
-        > /dev/null || (exit 0)
-      COMMAND
-        patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
-        ${CMAKE_CURRENT_LIST_DIR}/0012-rpmsg-add-new-API-rpdev_release_tx-rx_buffer.patch
-        > /dev/null || (exit 0)
-      COMMAND
-        patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
-        ${CMAKE_CURRENT_LIST_DIR}/0013-openamp-add-error-log-when-ept-cb-return-error.patch
-        > /dev/null || (exit 0)
-      COMMAND
-        patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
-        ${CMAKE_CURRENT_LIST_DIR}/0014-rpmsg-add-cache-flash-when-hold-rx-buffer.patch
-        > /dev/null || (exit 0)
-      COMMAND
-        patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
-        ${CMAKE_CURRENT_LIST_DIR}/0015-rpmsg-do-cache_invalidate-when-real-data-returned.patch
-        > /dev/null || (exit 0)
-      COMMAND
-        patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
-        ${CMAKE_CURRENT_LIST_DIR}/0016-openamp-add-new-API-rpmsg_virtio_get_rxbuffer_size.patch
-        > /dev/null || (exit 0)
-      COMMAND
-        patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
-        ${CMAKE_CURRENT_LIST_DIR}/0017-virtio-follow-virtio-1.2-spec-add-more-virtio-status.patch
-        > /dev/null || (exit 0)
-      COMMAND
-        patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
-        ${CMAKE_CURRENT_LIST_DIR}/0018-virtio-decoupling-the-transport-layer-and-virtio-dev.patch
-        > /dev/null || (exit 0)
-      COMMAND
-        patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
-        ${CMAKE_CURRENT_LIST_DIR}/0019-virtio.h-add-version-in-device-id-table.patch
-        > /dev/null || (exit 0)
-      DEPENDS open-amp)
-    add_custom_target(openamp_patch
-                      DEPENDS ${CMAKE_CURRENT_LIST_DIR}/.openamp_patch)
-  endif()
 endif()
 
 nuttx_add_kernel_library(openamp)
 
-if (CONFIG_OPENAMP_CACHE)
+if(CONFIG_OPENAMP_CACHE)
   target_compile_options(openamp PRIVATE -DVIRTIO_CACHED_BUFFERS)
   target_compile_options(openamp PRIVATE -DVIRTIO_CACHED_VRINGS)
 endif()
 
-if (CONFIG_OPENAMP_RPMSG_DEBUG)
+if(CONFIG_OPENAMP_RPMSG_DEBUG)
   target_compile_options(openamp PRIVATE -DRPMSG_DEBUG)
 endif()
 
-if (CONFIG_OPENAMP_VQUEUE_DEBUG)
+if(CONFIG_OPENAMP_VQUEUE_DEBUG)
   target_compile_options(openamp PRIVATE -DVQUEUE_DEBUG)
 endif()
 
@@ -155,7 +109,3 @@ target_sources(
           open-amp/lib/rpmsg/rpmsg_virtio.c
           open-amp/lib/virtio/virtio.c
           open-amp/lib/virtio/virtqueue.c)
-
-if(TARGET openamp_patch)
-  add_dependencies(openamp openamp_patch)
-endif()


### PR DESCRIPTION
## Summary
> this patch is a part of this  issue https://github.com/apache/nuttx/issues/10241
- delete the .git condition that cause duplication of fetching stage.
- replace custom_patch_target with PATCH_COMMAND.
- remove custom_patch_target dependencies.

related to:https://github.com/apache/nuttx-apps/pull/1993
## Impact

## Testing
fetch for the first time and compile repeated
