### PR TITLE
rpmsg/rpmsg_sockif.c: Fix printf format for u64 type

### DIFF
--- a/net/rpmsg/rpmsg_sockif.c
+++ b/net/rpmsg/rpmsg_sockif.c
@@ -607,7 +607,8 @@ static int rpmsg_socket_setaddr(FAR struct rpmsg_socket_conn_s *conn,
 
   if (suffix)
     {
-      snprintf(conn->nameid, sizeof(conn->nameid), ":%llx", g_rpmsg_id++);
+      snprintf(conn->nameid, sizeof(conn->nameid), ":%" PRIx64,
+               g_rpmsg_id++);
     }
   else
     {


### PR DESCRIPTION
## Summary
Use PRIx64 which defines the width correctly regardless or architecture.

Fixes build error:
rpmsg/rpmsg_sockif.c:610:57: error: format '%llx' expects argument of type 'long long unsigned int', but argument 4 has type 'uint64_t' {aka 'long unsigned int'} [-Werror=format=]
  610 |       snprintf(conn->nameid, sizeof(conn->nameid), ":%llx", g_rpmsg_id++);
      |                                                      ~~~^   ~~~~~~~~~~~~
      |                                                         |             |
      |                                                         |             uint64_t {aka long unsigned int}
      |                                                         long long unsigned int
      |                                                      %lx

## Impact
Fix sprintf format to work when u64 is defined as unsigned long
## Testing
Build pass
