### PR TITLE
pwm: fix incorrect documentation for PWMIOC_SETCHARACTERISTICS IOCTL

### DIFF
--- a/drivers/timers/pwm.c
+++ b/drivers/timers/pwm.c
@@ -437,9 +437,7 @@ static int pwm_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   switch (cmd)
     {
       /* PWMIOC_SETCHARACTERISTICS - Set the characteristics of the next
-       *   pulsed output.  This command will neither start nor stop the
-       *   pulsed output.  It will either setup the configuration that will
-       *   be used when the output is started; or it will change the
+       *   pulsed output and start the pulsed output. It will change the
        *   characteristics of the pulsed output on the fly if the timer is
        *   already started.
        *

--- a/include/nuttx/timers/pwm.h
+++ b/include/nuttx/timers/pwm.h
@@ -79,12 +79,10 @@
  * interface, the majority of the functionality is implemented in driver
  * ioctl calls.  The PWM ioctl commands are listed below:
  *
- * PWMIOC_SETCHARACTERISTICS - Set the characteristics of the next pulsed
- *  output.  This command will neither start nor stop the pulsed output.
- *  It will either setup the configuration that will be used when the
- *  output is started; or it will change the characteristics of the pulsed
- *  output on the fly if the timer is already started.  This command will
- *  set the PWM characteristics and return immediately.
+ * PWMIOC_SETCHARACTERISTICS - Set the characteristics of the next
+ *  pulsed output and start the pulsed output. It will change the
+ *  characteristics of the pulsed output on the fly if the timer is
+ *  already started.
  *
  *  ioctl argument: A read-only reference to struct pwm_info_s that provides
  *  the characteristics of the pulsed output.


### PR DESCRIPTION
## Summary
Documentation for PWMIOC_SETCHARACTERISTICS ioctl command mentioned that this command will neither start nor stop the pulsed output. This however is incorrect as PWMIOC_SETCHARACTERISTICS command leads to pwm_start() function which starts the pulsed output.

While this might not be the correct behaviour (I would probably welcome the option to set PWM characteristics without starting the pulsed output) it is the way the PWM driver is coded for many architectures. Future enhancement might be to add function pwm_setchar() for example to just set characteristics without starting the PWM output. This would require quite a lot of work as we would have to change every PWM driver.

## Impact
Just comments.