### PR TITLE
debug: Let boards define custom debug configuration.

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -601,6 +601,11 @@ config ARCH_CHIP_DEBUG_H
 	---help---
 		The debug.h under include/arch/chip contains architecture dependent debugging primitives
 
+config ARCH_BOARD_DEBUG_H
+	bool "board debug.h"
+	---help---
+		The debug.h under include/arch/board contains board dependent debugging primitives
+
 endchoice # debug.h selection
 
 endmenu # Customize Header Files

--- a/include/debug.h
+++ b/include/debug.h
@@ -34,6 +34,9 @@
 #ifdef CONFIG_ARCH_CHIP_DEBUG_H
 #  include <arch/chip/debug.h>
 #endif
+#ifdef CONFIG_ARCH_BOARD_DEBUG_H
+#  include <arch/board/debug.h>
+#endif
 
 #include <syslog.h>
 #include <sys/uio.h>


### PR DESCRIPTION
## Summary

Allows the debug behavior to be specified as part of the board, architecture or chip configuration. This is useful when using out-of tree custom board configurations.

## Impact

Customise debug behaviour for boards.

## Testing

Enable `CONFIG_ARCH_BOARD_DEBUG_H` and add `debug.h` to custom boards directory.
