### PR TITLE
boards: cxd56xx: Fix charger and gauge initialize functions

### DIFF
--- a/boards/arm/cxd56xx/spresense/src/cxd56_charger.c
+++ b/boards/arm/cxd56xx/spresense/src/cxd56_charger.c
@@ -46,8 +46,7 @@ static int g_chargerinitialized = 0;
  * Public Functions
  ****************************************************************************/
 
-int board_charger_initialize(const char *devpath,
-                             int16_t *gaugemeter)
+int board_charger_initialize(const char *devpath)
 {
   int ret;
 

--- a/boards/arm/cxd56xx/spresense/src/cxd56_gauge.c
+++ b/boards/arm/cxd56xx/spresense/src/cxd56_gauge.c
@@ -46,7 +46,7 @@ static int g_gaugeinitialized = 0;
  *
  ****************************************************************************/
 
-int board_gauge_initialize(const char *devpath, int16_t *gaugemeter)
+int board_gauge_initialize(const char *devpath)
 {
   int ret;
 


### PR DESCRIPTION
## Summary
Fix the function definitions to match the prototype declarations.

## Impact
Only spresense board.

## Testing

