### PR TITLE
net/xx/wrbuffer: Do not use SEM_INITIALIZER for buffers

### DIFF
--- a/net/tcp/tcp_wrbuffer.c
+++ b/net/tcp/tcp_wrbuffer.c
@@ -73,10 +73,7 @@ struct wrbuffer_s
 
 /* This is the state of the global write buffer resource */
 
-static struct wrbuffer_s g_wrbuffer =
-{
-  SEM_INITIALIZER(CONFIG_NET_TCP_NWRBCHAINS),
-};
+static struct wrbuffer_s g_wrbuffer;
 
 /****************************************************************************
  * Public Functions
@@ -96,6 +93,10 @@ static struct wrbuffer_s g_wrbuffer =
 void tcp_wrbuffer_initialize(void)
 {
   int i;
+
+  sq_init(&g_wrbuffer.freebuffers);
+
+  nxsem_init(&g_wrbuffer.sem, 0, CONFIG_NET_TCP_NWRBCHAINS);
 
   for (i = 0; i < CONFIG_NET_TCP_NWRBCHAINS; i++)
     {

--- a/net/udp/udp_wrbuffer.c
+++ b/net/udp/udp_wrbuffer.c
@@ -72,10 +72,7 @@ struct wrbuffer_s
 
 /* This is the state of the global write buffer resource */
 
-static struct wrbuffer_s g_wrbuffer =
-{
-  SEM_INITIALIZER(CONFIG_NET_UDP_NWRBCHAINS)
-};
+static struct wrbuffer_s g_wrbuffer;
 
 /****************************************************************************
  * Public Functions
@@ -97,6 +94,8 @@ void udp_wrbuffer_initialize(void)
   int i;
 
   sq_init(&g_wrbuffer.freebuffers);
+
+  nxsem_init(&g_wrbuffer.sem, 0, CONFIG_NET_UDP_NWRBCHAINS);
 
   for (i = 0; i < CONFIG_NET_UDP_NWRBCHAINS; i++)
     {


### PR DESCRIPTION
## Summary
Using the macro places the buffers into .data section which means they will consume the full buffer size of flash / read only memory as well.

Place the buffers into .bss to avoid this case.

## Impact
Free up read only memory from .data section

## Testing
Build pass
