### PR TITLE
pwm: add option to set channel polarity with IOCTL

### DIFF
--- a/include/nuttx/timers/pwm.h
+++ b/include/nuttx/timers/pwm.h
@@ -114,6 +114,17 @@
 #define PWMIOC_START              _PWMIOC(3)
 #define PWMIOC_STOP               _PWMIOC(4)
 
+/* PWM channel polarity *****************************************************/
+
+/* These are helper definitions for setting PWM channel output polarity to
+ * logical low or high level. The pulsed output should start with this
+ * logical value and should return to it when the output is disabled.
+ */
+
+#define PWM_CPOL_NDEF             0   /* Not defined, default value by arch driver should be used */
+#define PWM_CPOL_LOW              1   /* Logical zero */
+#define PWM_CPOL_HIGH             2   /* Logical one */
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/
@@ -134,6 +145,7 @@ struct pwm_chan_s
   ub16_t dead_time_a;
   ub16_t dead_time_b;
 #endif
+  uint8_t cpol;
   int8_t channel;
 };
 #endif
@@ -161,6 +173,7 @@ struct pwm_info_s
   uint32_t           count;     /* The number of pulse to generate.  0 means to
                                  * generate an indefinite number of pulses */
 #  endif
+  uint8_t cpol;                 /* Channel polarity */
 #endif /* CONFIG_PWM_MULTICHAN */
 
   FAR void           *arg;      /* User provided argument to be used in the


### PR DESCRIPTION
## Summary
Many PWM drivers can set channel output polarity (logical low or high) in idle state. This is usually set with a dedicated
channel control register. This commit adds field `cpol` to `pwm_info_s` structure that allows the user to pass the information
of desired polarity to architecture layer from application layer. Already implemented PWMIOC_SETCHARACTERISTICS ioctl is
used for the change.

Possibility of polarity change is added to samv7 driver.

## Impact
None for current drivers as the functionality is not implemented there..

## Testing
Tested on SAMv7 mcu.

