### PR TITLE
esp32: Fix build warning

### DIFF
--- a/arch/xtensa/src/esp32/esp32_spi.c
+++ b/arch/xtensa/src/esp32/esp32_spi.c
@@ -41,6 +41,7 @@
 #include <nuttx/clock.h>
 #include <nuttx/mutex.h>
 #include <nuttx/semaphore.h>
+#include <nuttx/kmalloc.h>
 #include <nuttx/spi/spi.h>
 
 #include <arch/board/board.h>

--- a/arch/xtensa/src/esp32/esp32_wlan.c
+++ b/arch/xtensa/src/esp32/esp32_wlan.c
@@ -1516,7 +1516,7 @@ static int wlan_ioctl(struct net_driver_s *dev,
             ret = ops->disconnect();
             if (ret < 0)
               {
-                nerr("ERROR: Failed to connect\n");
+                nerr("ERROR: Failed to disconnect\n");
                 break;
               }
           }


### PR DESCRIPTION
## Summary
1. Fix below build warning:
```
CC:  chip/esp32_spi.c chip/esp32_spi.c: In function 'esp32_spi_dma_exchange':
chip/esp32_spi.c:861:17: warning: implicit declaration of function 'kmm_malloc'; did you mean 'iob_alloc'? [-Wimplicit-function-declaration]
       alloctp = kmm_malloc(total);
                 ^~~~~~~~~~
                 iob_alloc
chip/esp32_spi.c:861:15: warning: assignment to 'uint8_t *' {aka 'unsigned char *'} from 'int' makes pointer from integer without a cast [-Wint-conversion]
       alloctp = kmm_malloc(total);
               ^
chip/esp32_spi.c:880:15: warning: assignment to 'uint8_t *' {aka 'unsigned char *'} from 'int' makes pointer from integer without a cast [-Wint-conversion]
       allocrp = kmm_malloc(total);
               ^
chip/esp32_spi.c:957:7: warning: implicit declaration of function 'kmm_free'; did you mean 'iob_free'? [-Wimplicit-function-declaration]
       kmm_free(allocrp);
       ^~~~~~~~
       iob_free
```

2. Fixed an incorrect log output.

## Impact
No

## Testing
Pass the build
