### PR TITLE
sensors: Move SCU-specific sensors into spresense board

### DIFF
--- a/boards/arm/cxd56xx/common/src/cxd56_ak09912_scu.c
+++ b/boards/arm/cxd56xx/common/src/cxd56_ak09912_scu.c
@@ -31,6 +31,7 @@
 #include <nuttx/board.h>
 
 #include <nuttx/sensors/ak09912.h>
+#include <arch/board/cxd56_ak09912.h>
 #include "cxd56_i2c.h"
 
 #include <arch/chip/scu.h>
@@ -79,7 +80,7 @@ int board_ak09912_initialize(const char *devpath, int bus)
     {
       /* register device at I2C bus */
 
-      ret = ak09912_register(devpath, i, i2c, bus);
+      ret = ak09912_scu_register(devpath, i, i2c, bus);
       if (ret < 0)
         {
           snerr("Error registering AK09912.\n");

--- a/boards/arm/cxd56xx/common/src/cxd56_bmi160_scu.c
+++ b/boards/arm/cxd56xx/common/src/cxd56_bmi160_scu.c
@@ -31,6 +31,7 @@
 #include <nuttx/board.h>
 #include <nuttx/spi/spi.h>
 #include <nuttx/sensors/bmi160.h>
+#include <arch/board/cxd56_bmi160.h>
 #include <arch/chip/scu.h>
 
 #if defined(CONFIG_SENSORS_BMI160_SCU_SPI)

--- a/boards/arm/cxd56xx/common/src/cxd56_bmp280_scu.c
+++ b/boards/arm/cxd56xx/common/src/cxd56_bmp280_scu.c
@@ -31,6 +31,7 @@
 #include <nuttx/board.h>
 
 #include <nuttx/sensors/bmp280.h>
+#include <arch/board/cxd56_bmp280.h>
 #include <arch/chip/scu.h>
 
 #include "cxd56_i2c.h"

--- a/boards/arm/cxd56xx/drivers/sensors/ak09912_scu.c
+++ b/boards/arm/cxd56xx/drivers/sensors/ak09912_scu.c
@@ -511,23 +511,25 @@ int ak09912_init(struct i2c_master_s *i2c, int port)
 }
 
 /****************************************************************************
- * Name: ak09912_register
+ * Name: ak09912_scu_register
  *
  * Description:
  *   Register the AK09912 character device as 'devpath'
  *
  * Input Parameters:
  *   devpath - The full path to the driver to register. E.g., "/dev/mag"
+ *   minor   - The number of sequencer
  *   i2c     - An instance of the I2C interface to use to communicate with
  *             AK09912
+ *   port    - I2C port number
  *
  * Returned Value:
  *   Zero (OK) on success; a negated errno value on failure.
  *
  ****************************************************************************/
 
-int ak09912_register(const char *devpath, int minor,
-                     struct i2c_master_s *i2c, int port)
+int ak09912_scu_register(const char *devpath, int minor,
+                         struct i2c_master_s *i2c, int port)
 {
   struct ak09912_dev_s *priv;
   char path[16];

--- a/boards/arm/cxd56xx/spresense/include/cxd56_ak09912.h
+++ b/boards/arm/cxd56xx/spresense/include/cxd56_ak09912.h
@@ -26,17 +26,9 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
-
-/****************************************************************************
- * Public Types
- ****************************************************************************/
+#include <nuttx/i2c/i2c_master.h>
 
 #ifndef __ASSEMBLY__
-
-/****************************************************************************
- * Public Data
- ****************************************************************************/
-
 #undef EXTERN
 #if defined(__cplusplus)
 #define EXTERN extern "C"
@@ -61,6 +53,48 @@ extern "C"
 #if defined (CONFIG_SENSORS_AK09912) || defined (CONFIG_SENSORS_AK09912_SCU)
 int board_ak09912_initialize(const char *devpath, int bus);
 #endif
+
+#ifdef CONFIG_SENSORS_AK09912_SCU
+/****************************************************************************
+ * Name: ak09912_init
+ *
+ * Description:
+ *   Initialize AK09912 magnetometer device
+ *
+ * Input Parameters:
+ *   i2c     - An instance of the I2C interface to use to communicate with
+ *             AK09912
+ *   port    - I2C port number
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int ak09912_init(FAR struct i2c_master_s *i2c, int port);
+
+/****************************************************************************
+ * Name: ak09912_scu_register
+ *
+ * Description:
+ *   Register the AK09912 character device as 'devpath'
+ *
+ * Input Parameters:
+ *   devpath - The full path to the driver to register. E.g., "/dev/mag0"
+ *   minor   - The number of sequencer
+ *   i2c     - An instance of the I2C interface to use to communicate with
+ *             AK09912
+ *   port    - I2C port number
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int ak09912_scu_register(const char *devpath, int minor,
+                         struct i2c_master_s *i2c, int port);
+
+#endif /* CONFIG_SENSORS_AK09912_SCU */
 
 #undef EXTERN
 #if defined(__cplusplus)

--- a/boards/arm/cxd56xx/spresense/include/cxd56_bmi160.h
+++ b/boards/arm/cxd56xx/spresense/include/cxd56_bmi160.h
@@ -60,6 +60,83 @@ extern "C"
 
 int board_bmi160_initialize(int bus);
 
+#ifdef CONFIG_SENSORS_BMI160_SCU
+/****************************************************************************
+ * Name: bmi160_init
+ *
+ * Description:
+ *   Initialize BMI160 accelerometer/gyro device
+ *
+ * Input Parameters:
+ *   dev     - An instance of the SPI or I2C interface to use to communicate
+ *             with BMI160
+ *   port    - I2C port number
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_SENSORS_BMI160_I2C
+int bmi160_init(FAR struct i2c_master_s *dev, int port);
+#else /* CONFIG_SENSORS_BMI160_SPI */
+int bmi160_init(struct spi_dev_s *dev);
+#endif
+
+/****************************************************************************
+ * Name: bmi160gyro_register
+ *
+ * Description:
+ *   Register the BMI160 gyro character device as 'devpath'
+ *
+ * Input Parameters:
+ *   devpath - The full path to the driver to register. E.g., "/dev/gyro"
+ *   minor   - The number of sequencer
+ *   dev     - An instance of the SPI or I2C interface to use to communicate
+ *             with BMI160
+ *   port    - I2C port number
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_SENSORS_BMI160_I2C
+int bmi160gyro_register(const char *devpath, int minor,
+                        struct i2c_master_s *dev, int port);
+#else /* CONFIG_SENSORS_BMI160_SPI */
+int bmi160gyro_register(const char *devpath, int minor,
+                        struct spi_dev_s *dev);
+#endif
+
+/****************************************************************************
+ * Name: bmi160accel_register
+ *
+ * Description:
+ *   Register the BMI160 accelerometer character device as 'devpath'
+ *
+ * Input Parameters:
+ *   devpath - The full path to the driver to register. E.g., "/dev/accel"
+ *   minor   - The number of sequencer
+ *   dev     - An instance of the SPI or I2C interface to use to communicate
+ *             with BMI160
+ *   port    - I2C port number
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_SENSORS_BMI160_I2C
+int bmi160accel_register(const char *devpath, int minor,
+                         struct i2c_master_s *dev, int port);
+#else /* CONFIG_SENSORS_BMI160_SPI */
+int bmi160accel_register(const char *devpath, int minor,
+                         struct spi_dev_s *dev);
+#endif
+
+#endif /* CONFIG_SENSORS_BMI160_SCU */
+
 #undef EXTERN
 #if defined(__cplusplus)
 }

--- a/boards/arm/cxd56xx/spresense/include/cxd56_bmp280.h
+++ b/boards/arm/cxd56xx/spresense/include/cxd56_bmp280.h
@@ -26,6 +26,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/i2c/i2c_master.h>
 
 /****************************************************************************
  * Public Types
@@ -60,6 +61,69 @@ extern "C"
 
 #if defined(CONFIG_SENSORS_BMP280) || defined(CONFIG_SENSORS_BMP280_SCU)
 int board_bmp280_initialize(int bus);
+#endif
+
+#ifdef CONFIG_SENSORS_BMP280_SCU
+/****************************************************************************
+ * Name: bmp280_init
+ *
+ * Description:
+ *   Initialize BMP280 pressure device
+ *
+ * Input Parameters:
+ *   i2c     - An instance of the I2C interface to use to communicate with
+ *             BMP280
+ *   port    - I2C port number
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int bmp280_init(struct i2c_master_s *i2c, int port);
+
+/****************************************************************************
+ * Name: bmp280press_register
+ *
+ * Description:
+ *   Register the BMP280 pressure sensor character device as 'devpath'
+ *
+ * Input Parameters:
+ *   devpath - The base path to the driver to register. E.g., "/dev/press0"
+ *   minor   - The number of sequencer
+ *   i2c     - An instance of the I2C interface to use to communicate with
+ *             BMP280
+ *   port    - I2C port number
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int bmp280press_register(const char *devpath, int minor,
+                         struct i2c_master_s *i2c, int port);
+
+/****************************************************************************
+ * Name: bmp280temp_register
+ *
+ * Description:
+ *   Register the BMP280 temperature sensor character device as 'devpath'
+ *
+ * Input Parameters:
+ *   devpath - The base path to the driver to register. E.g., "/dev/temp"
+ *   minor   - The number of sequencer
+ *   i2c     - An instance of the I2C interface to use to communicate with
+ *             BMP280
+ *   port    - I2C port number
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int bmp280temp_register(const char *devpath, int minor,
+                        struct i2c_master_s *i2c, int port);
+
 #endif
 
 #undef EXTERN

--- a/include/nuttx/sensors/ak09912.h
+++ b/include/nuttx/sensors/ak09912.h
@@ -83,25 +83,6 @@ struct ak09912_sensadj_s
   uint8_t z;
 };
 
-#ifdef CONFIG_SENSORS_AK09912_SCU
-/****************************************************************************
- * Name: ak09912_init
- *
- * Description:
- *   Initialize AK09912 magnetometer device
- *
- * Input Parameters:
- *   i2c     - An instance of the I2C interface to use to communicate with
- *             AK09912
- *
- * Returned Value:
- *   Zero (OK) on success; a negated errno value on failure.
- *
- ****************************************************************************/
-
-int ak09912_init(FAR struct i2c_master_s *i2c, int port);
-#endif
-
 /****************************************************************************
  * Name: ak09912_register
  *
@@ -117,12 +98,8 @@ int ak09912_init(FAR struct i2c_master_s *i2c, int port);
  *   Zero (OK) on success; a negated errno value on failure.
  *
  ****************************************************************************/
-#ifdef CONFIG_SENSORS_AK09912_SCU
-int ak09912_register(FAR const char *devpath, int minor,
-                     FAR struct i2c_master_s *i2c, int port);
-#else
+
 int ak09912_register(FAR const char *devpath, FAR struct i2c_master_s *i2c);
-#endif
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/include/nuttx/sensors/bmi160.h
+++ b/include/nuttx/sensors/bmi160.h
@@ -131,30 +131,10 @@ extern "C"
  *
  ****************************************************************************/
 
-#ifndef CONFIG_SENSORS_BMI160_SCU
-
-#  ifdef CONFIG_SENSORS_BMI160_I2C
+#ifdef CONFIG_SENSORS_BMI160_I2C
 int bmi160_register(FAR const char *devpath, FAR struct i2c_master_s *dev);
-#  else /* CONFIG_BMI160_SPI */
+#else /* CONFIG_BMI160_SPI */
 int bmi160_register(FAR const char *devpath, FAR struct spi_dev_s *dev);
-#  endif
-
-#else /* CONFIG_SENSORS_BMI160_SCU */
-
-#  ifdef CONFIG_SENSORS_BMI160_I2C
-int bmi160_init(FAR struct i2c_master_s *dev, int port);
-int bmi160gyro_register(FAR const char *devpath, int minor,
-                        FAR struct i2c_master_s *dev, int port);
-int bmi160accel_register(FAR const char *devpath, int minor,
-                         FAR struct i2c_master_s *dev, int port);
-#  else /* CONFIG_SENSORS_BMI160_SPI */
-int bmi160_init(FAR struct spi_dev_s *dev);
-int bmi160gyro_register(FAR const char *devpath, int minor,
-                        FAR struct spi_dev_s *dev);
-int bmi160accel_register(FAR const char *devpath, int minor,
-                         FAR struct spi_dev_s *dev);
-#  endif
-
 #endif
 
 #undef EXTERN

--- a/include/nuttx/sensors/bmp280.h
+++ b/include/nuttx/sensors/bmp280.h
@@ -135,25 +135,6 @@ struct bmp280_meas_s
   uint8_t   xlsb;   /* meas value XLSB */
 };
 
-#ifdef CONFIG_SENSORS_BMP280_SCU
-/****************************************************************************
- * Name: bmp280_init
- *
- * Description:
- *   Initialize BMP280 pressure device
- *
- * Input Parameters:
- *   i2c     - An instance of the I2C interface to use to communicate with
- *             BMP280
- *
- * Returned Value:
- *   Zero (OK) on success; a negated errno value on failure.
- *
- ****************************************************************************/
-
-int bmp280_init(FAR struct i2c_master_s *i2c, int port);
-#endif
-
 /****************************************************************************
  * Name: bmp280_register
  *
@@ -170,14 +151,7 @@ int bmp280_init(FAR struct i2c_master_s *i2c, int port);
  *
  ****************************************************************************/
 
-#ifdef CONFIG_SENSORS_BMP280_SCU
-int bmp280press_register(FAR const char *devpath, int minor,
-                         FAR struct i2c_master_s *i2c, int port);
-int bmp280temp_register(FAR const char *devpath, int minor,
-                        FAR struct i2c_master_s *i2c, int port);
-#else
 int bmp280_register(int devno, FAR struct i2c_master_s *i2c);
-#endif
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/include/nuttx/sensors/fxos8700cq.h
+++ b/include/nuttx/sensors/fxos8700cq.h
@@ -96,20 +96,8 @@ extern "C"
  *
  ****************************************************************************/
 
-#ifndef CONFIG_SENSORS_FXOS8700CQ_SCU
-
 int fxos8700cq_register(FAR const char *devpath,
                         FAR struct i2c_master_s *dev);
-
-#else /* CONFIG_SENSORS_FXOS8700CQ_SCU */
-
-int fxos8700cq_init(FAR struct i2c_master_s *dev, int port);
-int fxos8700cqgyro_register(FAR const char *devpath, int minor,
-                        FAR struct i2c_master_s *dev, int port);
-int fxos8700cqaccel_register(FAR const char *devpath, int minor,
-                         FAR struct i2c_master_s *dev, int port);
-
-#endif
 
 #undef EXTERN
 #ifdef __cplusplus


### PR DESCRIPTION
## Summary
Move SCU-specific sensors into spresense board to improve modularity.
Issue: https://github.com/apache/nuttx/issues/10240

## Impact
Spresense board.

## Testing
Build and work bmi160, bmp280 and ak09912 sensors.
