### PR TITLE
tcp_send_buffered: change Not connected message level from error to warning

### DIFF
--- a/net/tcp/tcp_send_buffered.c
+++ b/net/tcp/tcp_send_buffered.c
@@ -1663,7 +1663,7 @@ int psock_tcp_cansend(FAR struct tcp_conn_s *conn)
 
   if (!_SS_ISCONNECTED(conn->sconn.s_flags))
     {
-      nerr("ERROR: Not connected\n");
+      nwarn("WARNING: Not connected\n");
       return -ENOTCONN;
     }
 


### PR DESCRIPTION
## Summary
Non-blocking sockets are almost never in the connected state when app try to get result of connect success through poll, to avoid confusion because of this error print, so downgrade the print level to warning.
## Impact

## Testing
sim:local
