### PR TITLE
Revert commit 35602cc2effe923e8c9b635bfc5f11cea36f7ccb(fs_fsync.c:Fix unknown command message in non-block device situations)

### DIFF
--- a/fs/vfs/fs_fsync.c
+++ b/fs/vfs/fs_fsync.c
@@ -75,8 +75,7 @@ int file_fsync(FAR struct file *filep)
         }
       else
 #endif
-      if ((INODE_IS_BLOCK(inode) || INODE_IS_MTD(inode)) &&
-          inode->u.i_ops && inode->u.i_ops->ioctl)
+      if (inode->u.i_ops && inode->u.i_ops->ioctl)
         {
           ret = inode->u.i_ops->ioctl(filep, BIOC_FLUSH, 0);
           return ret >= 0 ? 0 : ret;


### PR DESCRIPTION
Reason for revert: when block device enable bch proxy, it works like a char device, so fsync calling would be failed here

