### PR TITLE
libs/libc: Breakdown LIBC_BUILD_STRING into specific string operation…

### DIFF
--- a/libs/libc/libc.h
+++ b/libs/libc/libc.h
@@ -56,9 +56,123 @@
 #define LIB_BUFLEN_UNKNOWN INT_MAX
 
 #if defined(CONFIG_BUILD_FLAT) || \
-    ((!defined(CONFIG_LIBC_PREVENT_STRING_USER) && !defined(__KERNEL__))  || \
-     (!defined(CONFIG_LIBC_PREVENT_STRING_KERNEL) && defined(__KERNEL__)))
-#  define LIBC_BUILD_STRING
+    ((!defined(CONFIG_LIBC_PREVENT_MEMCHR_USER) && !defined(__KERNEL__))  || \
+     (!defined(CONFIG_LIBC_PREVENT_MEMCHR_KERNEL) && defined(__KERNEL__)))
+#  define LIBC_BUILD_MEMCHR
+#endif
+
+#if defined(CONFIG_BUILD_FLAT) || \
+    ((!defined(CONFIG_LIBC_PREVENT_MEMCMP_USER) && !defined(__KERNEL__))  || \
+     (!defined(CONFIG_LIBC_PREVENT_MEMCMP_KERNEL) && defined(__KERNEL__)))
+#  define LIBC_BUILD_MEMCMP
+#endif
+
+#if defined(CONFIG_BUILD_FLAT) || \
+    ((!defined(CONFIG_LIBC_PREVENT_MEMCPY_USER) && !defined(__KERNEL__))  || \
+     (!defined(CONFIG_LIBC_PREVENT_MEMCPY_KERNEL) && defined(__KERNEL__)))
+#  define LIBC_BUILD_MEMCPY
+#endif
+
+#if defined(CONFIG_BUILD_FLAT) || \
+    ((!defined(CONFIG_LIBC_PREVENT_MEMMOVE_USER) && !defined(__KERNEL__))  || \
+     (!defined(CONFIG_LIBC_PREVENT_MEMMOVE_KERNEL) && defined(__KERNEL__)))
+#  define LIBC_BUILD_MEMMOVE
+#endif
+
+#if defined(CONFIG_BUILD_FLAT) || \
+    ((!defined(CONFIG_LIBC_PREVENT_MEMSET_USER) && !defined(__KERNEL__))  || \
+     (!defined(CONFIG_LIBC_PREVENT_MEMSET_KERNEL) && defined(__KERNEL__)))
+#  define LIBC_BUILD_MEMSET
+#endif
+
+#if defined(CONFIG_BUILD_FLAT) || \
+    ((!defined(CONFIG_LIBC_PREVENT_STRCAT_USER) && !defined(__KERNEL__))  || \
+     (!defined(CONFIG_LIBC_PREVENT_STRCAT_KERNEL) && defined(__KERNEL__)))
+#  define LIBC_BUILD_STRCAT
+#endif
+
+#if defined(CONFIG_BUILD_FLAT) || \
+    ((!defined(CONFIG_LIBC_PREVENT_STRCASECMP_USER) && !defined(__KERNEL__))  || \
+     (!defined(CONFIG_LIBC_PREVENT_STRCASECMP_KERNEL) && defined(__KERNEL__)))
+#  define LIBC_BUILD_STRCASECMP
+#endif
+
+#if defined(CONFIG_BUILD_FLAT) || \
+    ((!defined(CONFIG_LIBC_PREVENT_STRCHR_USER) && !defined(__KERNEL__))  || \
+     (!defined(CONFIG_LIBC_PREVENT_STRCHR_KERNEL) && defined(__KERNEL__)))
+#  define LIBC_BUILD_STRCHR
+#endif
+
+#if defined(CONFIG_BUILD_FLAT) || \
+    ((!defined(CONFIG_LIBC_PREVENT_STRCHRNUL_USER) && !defined(__KERNEL__))  || \
+     (!defined(CONFIG_LIBC_PREVENT_STRCHRNUL_KERNEL) && defined(__KERNEL__)))
+#  define LIBC_BUILD_STRCHRNUL
+#endif
+
+#if defined(CONFIG_BUILD_FLAT) || \
+    ((!defined(CONFIG_LIBC_PREVENT_STRCMP_USER) && !defined(__KERNEL__))  || \
+     (!defined(CONFIG_LIBC_PREVENT_STRCMP_KERNEL) && defined(__KERNEL__)))
+#  define LIBC_BUILD_STRCMP
+#endif
+
+#if defined(CONFIG_BUILD_FLAT) || \
+    ((!defined(CONFIG_LIBC_PREVENT_STRCPY_USER) && !defined(__KERNEL__))  || \
+     (!defined(CONFIG_LIBC_PREVENT_STRCPY_KERNEL) && defined(__KERNEL__)))
+#  define LIBC_BUILD_STRCPY
+#endif
+
+#if defined(CONFIG_BUILD_FLAT) || \
+    ((!defined(CONFIG_LIBC_PREVENT_STRLCAT_USER) && !defined(__KERNEL__))  || \
+     (!defined(CONFIG_LIBC_PREVENT_STRLCAT_KERNEL) && defined(__KERNEL__)))
+#  define LIBC_BUILD_STRLCAT
+#endif
+
+#if defined(CONFIG_BUILD_FLAT) || \
+    ((!defined(CONFIG_LIBC_PREVENT_STRLEN_USER) && !defined(__KERNEL__))  || \
+     (!defined(CONFIG_LIBC_PREVENT_STRLEN_KERNEL) && defined(__KERNEL__)))
+#  define LIBC_BUILD_STRLEN
+#endif
+
+#if defined(CONFIG_BUILD_FLAT) || \
+    ((!defined(CONFIG_LIBC_PREVENT_STRLCPY_USER) && !defined(__KERNEL__))  || \
+     (!defined(CONFIG_LIBC_PREVENT_STRLCPY_KERNEL) && defined(__KERNEL__)))
+#  define LIBC_BUILD_STRLCPY
+#endif
+
+#if defined(CONFIG_BUILD_FLAT) || \
+    ((!defined(CONFIG_LIBC_PREVENT_STRNCASECMP_USER) && !defined(__KERNEL__))  || \
+     (!defined(CONFIG_LIBC_PREVENT_STRNCASECMP_KERNEL) && defined(__KERNEL__)))
+#  define LIBC_BUILD_STRNCASECMP
+#endif
+
+#if defined(CONFIG_BUILD_FLAT) || \
+    ((!defined(CONFIG_LIBC_PREVENT_STRNCAT_USER) && !defined(__KERNEL__))  || \
+     (!defined(CONFIG_LIBC_PREVENT_STRNCAT_KERNEL) && defined(__KERNEL__)))
+#  define LIBC_BUILD_STRNCAT
+#endif
+
+#if defined(CONFIG_BUILD_FLAT) || \
+    ((!defined(CONFIG_LIBC_PREVENT_STRNLEN_USER) && !defined(__KERNEL__))  || \
+     (!defined(CONFIG_LIBC_PREVENT_STRNLEN_KERNEL) && defined(__KERNEL__)))
+#  define LIBC_BUILD_STRNLEN
+#endif
+
+#if defined(CONFIG_BUILD_FLAT) || \
+    ((!defined(CONFIG_LIBC_PREVENT_STRNCMP_USER) && !defined(__KERNEL__))  || \
+     (!defined(CONFIG_LIBC_PREVENT_STRNCMP_KERNEL) && defined(__KERNEL__)))
+#  define LIBC_BUILD_STRNCMP
+#endif
+
+#if defined(CONFIG_BUILD_FLAT) || \
+    ((!defined(CONFIG_LIBC_PREVENT_STRNCPY_USER) && !defined(__KERNEL__))  || \
+     (!defined(CONFIG_LIBC_PREVENT_STRNCPY_KERNEL) && defined(__KERNEL__)))
+#  define LIBC_BUILD_STRNCPY
+#endif
+
+#if defined(CONFIG_BUILD_FLAT) || \
+    ((!defined(CONFIG_LIBC_PREVENT_STRRCHR_USER) && !defined(__KERNEL__))  || \
+     (!defined(CONFIG_LIBC_PREVENT_STRRCHR_KERNEL) && defined(__KERNEL__)))
+#  define LIBC_BUILD_STRRCHR
 #endif
 
 /****************************************************************************

--- a/libs/libc/machine/Kconfig
+++ b/libs/libc/machine/Kconfig
@@ -140,9 +140,448 @@ config LIBC_ARCH_ELF_64BIT
 config LIBC_PREVENT_STRING_KERNEL
 	bool
 	default n
+	select LIBC_PREVENT_MEMCHR_KERNEL
+	select LIBC_PREVENT_MEMCMP_KERNEL
+	select LIBC_PREVENT_MEMCPY_KERNEL
+	select LIBC_PREVENT_MEMMOVE_KERNEL
+	select LIBC_PREVENT_MEMSET_KERNEL
+	select LIBC_PREVENT_STRCAT_KERNEL
+	select LIBC_PREVENT_STRCASECMP_KERNEL
+	select LIBC_PREVENT_STRCHR_KERNEL
+	select LIBC_PREVENT_STRCHRNUL_KERNEL
+	select LIBC_PREVENT_STRCMP_KERNEL
+	select LIBC_PREVENT_STRCPY_KERNEL
+	select LIBC_PREVENT_STRLCAT_KERNEL
+	select LIBC_PREVENT_STRLEN_KERNEL
+	select LIBC_PREVENT_STRLCPY_KERNEL
+	select LIBC_PREVENT_STRNCASECMP_KERNEL
+	select LIBC_PREVENT_STRNCAT_KERNEL
+	select LIBC_PREVENT_STRNLEN_KERNEL
+	select LIBC_PREVENT_STRNCMP_KERNEL
+	select LIBC_PREVENT_STRNCPY_KERNEL
+	select LIBC_PREVENT_STRRCHR_KERNEL
+
+config LIBC_PREVENT_STRING_USER
+	bool
+	default n
+	select LIBC_PREVENT_MEMCHR_USER
+	select LIBC_PREVENT_MEMCMP_USER
+	select LIBC_PREVENT_MEMCPY_USER
+	select LIBC_PREVENT_MEMMOVE_USER
+	select LIBC_PREVENT_MEMSET_USER
+	select LIBC_PREVENT_STRCAT_USER
+	select LIBC_PREVENT_STRCASECMP_USER
+	select LIBC_PREVENT_STRCHR_USER
+	select LIBC_PREVENT_STRCHRNUL_USER
+	select LIBC_PREVENT_STRCMP_USER
+	select LIBC_PREVENT_STRCPY_USER
+	select LIBC_PREVENT_STRLCAT_USER
+	select LIBC_PREVENT_STRLEN_USER
+	select LIBC_PREVENT_STRLCPY_USER
+	select LIBC_PREVENT_STRNCASECMP_USER
+	select LIBC_PREVENT_STRNCAT_USER
+	select LIBC_PREVENT_STRNLEN_USER
+	select LIBC_PREVENT_STRNCMP_USER
+	select LIBC_PREVENT_STRNCPY_USER
+	select LIBC_PREVENT_STRRCHR_USER
+
+config LIBC_PREVENT_MEMCHR_KERNEL
+	bool
+	default n
 	---help---
-		Prevent any implementation of the libc from being built and linked
-		in the kernel, including NuttX's software-defined version of the libc
+		Prevent any implementation of the libc memchr from being built and linked
+		in the kernel, including NuttX's software-defined version of the libc memchr
+		or any other architecture-specific version of it. The ROM-defined
+		version should be linked instead. This option is particularly useful
+		when it's required that the ROM-defined libc memchr to be used by the kernel
+		(for accessing some driver resource, for instance) but the userspace
+		is forbidden to use the same ROM-defined versions. In this case,
+		NuttX's software-defined version of the libc memchr or arch-specific
+		assembly version is built instead.
+
+config LIBC_PREVENT_MEMCHR_USER
+	bool
+	default n
+	---help---
+		Prevent any implementation of the libc memchr from being built and linked
+		in the userspace, including NuttX's software-defined version of the
+		libc memchr or any other architecture-specific version of it. A ROM-defined
+		version of the libc memchr may be linked to the userspace by the linker.
+
+config LIBC_PREVENT_MEMCMP_KERNEL
+	bool
+	default n
+	---help---
+		Prevent any implementation of the libc memcmp from being built and linked
+		in the kernel, including NuttX's software-defined version of the libc memcmp
+		or any other architecture-specific version of it. The ROM-defined
+		version should be linked instead. This option is particularly useful
+		when it's required that the ROM-defined libc to be used by the kernel
+		(for accessing some driver resource, for instance) but the userspace
+		is forbidden to use the same ROM-defined versions. In this case,
+		NuttX's software-defined version of the libc memcmp or arch-specific
+		assembly version is built instead.
+
+config LIBC_PREVENT_MEMCMP_USER
+	bool
+	default n
+	---help---
+		Prevent any implementation of the libc memcmp from being built and linked
+		in the userspace, including NuttX's software-defined version of the
+		libc memcmp or any other architecture-specific version of it. A ROM-defined
+		version of the libc memcmp may be linked to the userspace by the linker.
+
+config LIBC_PREVENT_MEMCPY_KERNEL
+	bool
+	default n
+	---help---
+		Prevent any implementation of the libc memcpy from being built and linked
+		in the kernel, including NuttX's software-defined version of the libc memcpy
+		or any other architecture-specific version of it. The ROM-defined
+		version should be linked instead. This option is particularly useful
+		when it's required that the ROM-defined libc memcpy to be used by the kernel
+		(for accessing some driver resource, for instance) but the userspace
+		is forbidden to use the same ROM-defined versions. In this case,
+		NuttX's software-defined version of the libc memcpy or arch-specific
+		assembly version is built instead.
+
+config LIBC_PREVENT_MEMCPY_USER
+	bool
+	default n
+	---help---
+		Prevent any implementation of the libc memcpy from being built and linked
+		in the userspace, including NuttX's software-defined version of the
+		libc memcpy or any other architecture-specific version of it. A ROM-defined
+		version of the libc memcpy may be linked to the userspace by the linker.
+
+config LIBC_PREVENT_MEMMOVE_KERNEL
+	bool
+	default n
+	---help---
+		Prevent any implementation of the libc memmove from being built and linked
+		in the kernel, including NuttX's software-defined version of the libc memmove
+		or any other architecture-specific version of it. The ROM-defined
+		version should be linked instead. This option is particularly useful
+		when it's required that the ROM-defined libc memmove to be used by the kernel
+		(for accessing some driver resource, for instance) but the userspace
+		is forbidden to use the same ROM-defined versions. In this case,
+		NuttX's software-defined version of the libc memmove or arch-specific
+		assembly version is built instead.
+
+config LIBC_PREVENT_MEMMOVE_USER
+	bool
+	default n
+	---help---
+		Prevent any implementation of the libc memmove from being built and linked
+		in the userspace, including NuttX's software-defined version of the
+		libc memmove or any other architecture-specific version of it. A ROM-defined
+		version of the libc memmove may be linked to the userspace by the linker.
+
+config LIBC_PREVENT_MEMSET_KERNEL
+	bool
+	default n
+	---help---
+		Prevent any implementation of the libc memset from being built and linked
+		in the kernel, including NuttX's software-defined version of the libc memset
+		or any other architecture-specific version of it. The ROM-defined
+		version should be linked instead. This option is particularly useful
+		when it's required that the ROM-defined libc to be used by the kernel
+		(for accessing some driver resource, for instance) but the userspace
+		is forbidden to use the same ROM-defined versions. In this case,
+		NuttX's software-defined version of the libc memset or arch-specific
+		assembly version is built instead.
+
+config LIBC_PREVENT_MEMSET_USER
+	bool
+	default n
+	---help---
+		Prevent any implementation of the libc memset from being built and linked
+		in the userspace, including NuttX's software-defined version of the
+		libc memset or any other architecture-specific version of it. A ROM-defined
+		version of the libc memset may be linked to the userspace by the linker.
+
+config LIBC_PREVENT_STRCAT_KERNEL
+	bool
+	default n
+	---help---
+		Prevent any implementation of the libc strcat from being built and linked
+		in the kernel, including NuttX's software-defined version of the libc strcat
+		or any other architecture-specific version of it. The ROM-defined
+		version should be linked instead. This option is particularly useful
+		when it's required that the ROM-defined libc strcat to be used by the kernel
+		(for accessing some driver resource, for instance) but the userspace
+		is forbidden to use the same ROM-defined versions. In this case,
+		NuttX's software-defined version of the libc strcat or arch-specific
+		assembly version is built instead.
+
+config LIBC_PREVENT_STRCAT_USER
+	bool
+	default n
+	---help---
+		Prevent any implementation of the libc strcat from being built and linked
+		in the userspace, including NuttX's software-defined version of the
+		libc strcat or any other architecture-specific version of it. A ROM-defined
+		version of the libc strcat may be linked to the userspace by the linker.
+
+config LIBC_PREVENT_STRCASECMP_KERNEL
+	bool
+	default n
+	---help---
+		Prevent any implementation of the libc strcasecmp from being built and linked
+		in the kernel, including NuttX's software-defined version of the libc strcasecmp
+		or any other architecture-specific version of it. The ROM-defined
+		version should be linked instead. This option is particularly useful
+		when it's required that the ROM-defined libc strcasecmp to be used by the kernel
+		(for accessing some driver resource, for instance) but the userspace
+		is forbidden to use the same ROM-defined versions. In this case,
+		NuttX's software-defined version of the libc strcasecmp or arch-specific
+		assembly version is built instead.
+
+config LIBC_PREVENT_STRCASECMP_USER
+	bool
+	default n
+	---help---
+		Prevent any implementation of the libc strcasecmp from being built and linked
+		in the userspace, including NuttX's software-defined version of the
+		libc strcasecmp or any other architecture-specific version of it. A ROM-defined
+		version of the libc strcasecmp may be linked to the userspace by the linker.
+
+config LIBC_PREVENT_STRCHR_KERNEL
+	bool
+	default n
+	---help---
+		Prevent any implementation of the libc strchr from being built and linked
+		in the kernel, including NuttX's software-defined version of the libc strchr
+		or any other architecture-specific version of it. The ROM-defined
+		version should be linked instead. This option is particularly useful
+		when it's required that the ROM-defined libc to be used by the kernel
+		(for accessing some driver resource, for instance) but the userspace
+		is forbidden to use the same ROM-defined versions. In this case,
+		NuttX's software-defined version of the libc strchr or arch-specific
+		assembly version is built instead.
+
+config LIBC_PREVENT_STRCHR_USER
+	bool
+	default n
+	---help---
+		Prevent any implementation of the libc strchr from being built and linked
+		in the userspace, including NuttX's software-defined version of the
+		libc strchr or any other architecture-specific version of it. A ROM-defined
+		version of the libc strchr may be linked to the userspace by the linker.
+
+config LIBC_PREVENT_STRCHRNUL_KERNEL
+	bool
+	default n
+	---help---
+		Prevent any implementation of the libc strchrnul from being built and linked
+		in the kernel, including NuttX's software-defined version of the libc strchrnul
+		or any other architecture-specific version of it. The ROM-defined
+		version should be linked instead. This option is particularly useful
+		when it's required that the ROM-defined libc strchrnul to be used by the kernel
+		(for accessing some driver resource, for instance) but the userspace
+		is forbidden to use the same ROM-defined versions. In this case,
+		NuttX's software-defined version of the libc strchrnul or arch-specific
+		assembly version is built instead.
+
+config LIBC_PREVENT_STRCHRNUL_USER
+	bool
+	default n
+	---help---
+		Prevent any implementation of the libc strchrnul from being built and linked
+		in the userspace, including NuttX's software-defined version of the
+		libc strchrnul or any other architecture-specific version of it. A ROM-defined
+		version of the libc strchrnul may be linked to the userspace by the linker.
+
+config LIBC_PREVENT_STRCMP_KERNEL
+	bool
+	default n
+	---help---
+		Prevent any implementation of the libc strcmp from being built and linked
+		in the kernel, including NuttX's software-defined version of the libc strcmp
+		or any other architecture-specific version of it. The ROM-defined
+		version should be linked instead. This option is particularly useful
+		when it's required that the ROM-defined libc strcmp to be used by the kernel
+		(for accessing some driver resource, for instance) but the userspace
+		is forbidden to use the same ROM-defined versions. In this case,
+		NuttX's software-defined version of the libc strcmp or arch-specific
+		assembly version is built instead.
+
+config LIBC_PREVENT_STRCMP_USER
+	bool
+	default n
+	---help---
+		Prevent any implementation of the libc strcmp from being built and linked
+		in the userspace, including NuttX's software-defined version of the
+		libc strcmp or any other architecture-specific version of it. A ROM-defined
+		version of the libc strcmp may be linked to the userspace by the linker.
+
+config LIBC_PREVENT_STRCPY_KERNEL
+	bool
+	default n
+	---help---
+		Prevent any implementation of the libc strcpy from being built and linked
+		in the kernel, including NuttX's software-defined version of the libc strcpy
+		or any other architecture-specific version of it. The ROM-defined
+		version should be linked instead. This option is particularly useful
+		when it's required that the ROM-defined libc strcpy to be used by the kernel
+		(for accessing some driver resource, for instance) but the userspace
+		is forbidden to use the same ROM-defined versions. In this case,
+		NuttX's software-defined version of the libc strcpy or arch-specific
+		assembly version is built instead.
+
+config LIBC_PREVENT_STRCPY_USER
+	bool
+	default n
+	---help---
+		Prevent any implementation of the libc strcpy from being built and linked
+		in the userspace, including NuttX's software-defined version of the
+		libc strcpy or any other architecture-specific version of it. A ROM-defined
+		version of the libc strcpy may be linked to the userspace by the linker.
+
+config LIBC_PREVENT_STRLCAT_KERNEL
+	bool
+	default n
+	---help---
+		Prevent any implementation of the libc strlcat from being built and linked
+		in the kernel, including NuttX's software-defined version of the libc strlcat
+		or any other architecture-specific version of it. The ROM-defined
+		version should be linked instead. This option is particularly useful
+		when it's required that the ROM-defined libc strlcat to be used by the kernel
+		(for accessing some driver resource, for instance) but the userspace
+		is forbidden to use the same ROM-defined versions. In this case,
+		NuttX's software-defined version of the libc strlcat or arch-specific
+		assembly version is built instead.
+
+config LIBC_PREVENT_STRLCAT_USER
+	bool
+	default n
+	---help---
+		Prevent any implementation of the libc strlcat from being built and linked
+		in the userspace, including NuttX's software-defined version of the
+		libc strlcat or any other architecture-specific version of it. A ROM-defined
+		version of the libc strlcat may be linked to the userspace by the linker.
+
+config LIBC_PREVENT_STRLEN_KERNEL
+	bool
+	default n
+	---help---
+		Prevent any implementation of the libc strlen from being built and linked
+		in the kernel, including NuttX's software-defined version of the libc strlen
+		or any other architecture-specific version of it. The ROM-defined
+		version should be linked instead. This option is particularly useful
+		when it's required that the ROM-defined libc strlen to be used by the kernel
+		(for accessing some driver resource, for instance) but the userspace
+		is forbidden to use the same ROM-defined versions. In this case,
+		NuttX's software-defined version of the libc strlen or arch-specific
+		assembly version is built instead.
+
+config LIBC_PREVENT_STRLEN_USER
+	bool
+	default n
+	---help---
+		Prevent any implementation of the libc strlen from being built and linked
+		in the userspace, including NuttX's software-defined version of the
+		libc strlen or any other architecture-specific version of it. A ROM-defined
+		version of the libc strlen may be linked to the userspace by the linker.
+
+config LIBC_PREVENT_STRLCPY_KERNEL
+	bool
+	default n
+	---help---
+		Prevent any implementation of the libc strlcpy from being built and linked
+		in the kernel, including NuttX's software-defined version of the libc strlcpy
+		or any other architecture-specific version of it. The ROM-defined
+		version should be linked instead. This option is particularly useful
+		when it's required that the ROM-defined libc strlcpy to be used by the kernel
+		(for accessing some driver resource, for instance) but the userspace
+		is forbidden to use the same ROM-defined versions. In this case,
+		NuttX's software-defined version of the libc strlcpy or arch-specific
+		assembly version is built instead.
+
+config LIBC_PREVENT_STRLCPY_USER
+	bool
+	default n
+	---help---
+		Prevent any implementation of the libc strlcpy from being built and linked
+		in the userspace, including NuttX's software-defined version of the
+		libc strlcpy or any other architecture-specific version of it. A ROM-defined
+		version of the libc strlcpy may be linked to the userspace by the linker.
+
+config LIBC_PREVENT_STRNCASECMP_KERNEL
+	bool
+	default n
+	---help---
+		Prevent any implementation of the libc strncasecmp from being built and linked
+		in the kernel, including NuttX's software-defined version of the libc strncasecmp
+		or any other architecture-specific version of it. The ROM-defined
+		version should be linked instead. This option is particularly useful
+		when it's required that the ROM-defined libc strncasecmp to be used by the kernel
+		(for accessing some driver resource, for instance) but the userspace
+		is forbidden to use the same ROM-defined versions. In this case,
+		NuttX's software-defined version of the libc strncasecmp or arch-specific
+		assembly version is built instead.
+
+config LIBC_PREVENT_STRNCASECMP_USER
+	bool
+	default n
+	---help---
+		Prevent any implementation of the libc strncasecmp from being built and linked
+		in the userspace, including NuttX's software-defined version of the
+		libc strncasecmp or any other architecture-specific version of it. A ROM-defined
+		version of the libc strncasecmp may be linked to the userspace by the linker.
+
+config LIBC_PREVENT_STRNCAT_KERNEL
+	bool
+	default n
+	---help---
+		Prevent any implementation of the libc strncat from being built and linked
+		in the kernel, including NuttX's software-defined version of the libc strncat
+		or any other architecture-specific version of it. The ROM-defined
+		version should be linked instead. This option is particularly useful
+		when it's required that the ROM-defined libc strncat to be used by the kernel
+		(for accessing some driver resource, for instance) but the userspace
+		is forbidden to use the same ROM-defined versions. In this case,
+		NuttX's software-defined version of the libc strncat or arch-specific
+		assembly version is built instead.
+
+config LIBC_PREVENT_STRNCAT_USER
+	bool
+	default n
+	---help---
+		Prevent any implementation of the libc strncat from being built and linked
+		in the userspace, including NuttX's software-defined version of the
+		libc strncat or any other architecture-specific version of it. A ROM-defined
+		version of the libc strncat may be linked to the userspace by the linker.
+
+config LIBC_PREVENT_STRNLEN_KERNEL
+	bool
+	default n
+	---help---
+		Prevent any implementation of the libc strnlen from being built and linked
+		in the kernel, including NuttX's software-defined version of the libc strnlen
+		or any other architecture-specific version of it. The ROM-defined
+		version should be linked instead. This option is particularly useful
+		when it's required that the ROM-defined libc strnlen to be used by the kernel
+		(for accessing some driver resource, for instance) but the userspace
+		is forbidden to use the same ROM-defined versions. In this case,
+		NuttX's software-defined version of the libc strnlen or arch-specific
+		assembly version is built instead.
+
+config LIBC_PREVENT_STRNLEN_USER
+	bool
+	default n
+	---help---
+		Prevent any implementation of the libc strnlen from being built and linked
+		in the userspace, including NuttX's software-defined version of the
+		libc strnlen or any other architecture-specific version of it. A ROM-defined
+		version of the libc strnlen may be linked to the userspace by the linker.
+
+config LIBC_PREVENT_STRNCMP_KERNEL
+	bool
+	default n
+	---help---
+		Prevent any implementation of the libc strncmp from being built and linked
+		in the kernel, including NuttX's software-defined version of the libc strncmp
 		or any other architecture-specific version of it. The ROM-defined
 		version should be linked instead. This option is particularly useful
 		when it's required that the ROM-defined libc to be used by the kernel
@@ -151,15 +590,60 @@ config LIBC_PREVENT_STRING_KERNEL
 		NuttX's software-defined version of the libc or arch-specific
 		assembly version is built instead.
 
-config LIBC_PREVENT_STRING_USER
+config LIBC_PREVENT_STRNCMP_USER
 	bool
 	default n
 	---help---
-		Prevent any implementation of the libc from being built and linked
+		Prevent any implementation of the libc strncmp from being built and linked
 		in the userspace, including NuttX's software-defined version of the
-		libc or any other architecture-specific version of it. A ROM-defined
-		version of the libc may be linked to the userspace by the linker.
+		libc strncmp or any other architecture-specific version of it. A ROM-defined
+		version of the libc strncmp may be linked to the userspace by the linker.
 
+config LIBC_PREVENT_STRNCPY_KERNEL
+	bool
+	default n
+	---help---
+		Prevent any implementation of the libc strncpy from being built and linked
+		in the kernel, including NuttX's software-defined version of the libc strncpy
+		or any other architecture-specific version of it. The ROM-defined
+		version should be linked instead. This option is particularly useful
+		when it's required that the ROM-defined libc strncpy to be used by the kernel
+		(for accessing some driver resource, for instance) but the userspace
+		is forbidden to use the same ROM-defined versions. In this case,
+		NuttX's software-defined version of the libc strncpy or arch-specific
+		assembly version is built instead.
+
+config LIBC_PREVENT_STRNCPY_USER
+	bool
+	default n
+	---help---
+		Prevent any implementation of the libc strncpy from being built and linked
+		in the userspace, including NuttX's software-defined version of the
+		libc strncpy or any other architecture-specific version of it. A ROM-defined
+		version of the libc strncpy may be linked to the userspace by the linker.
+
+config LIBC_PREVENT_STRRCHR_KERNEL
+	bool
+	default n
+	---help---
+		Prevent any implementation of the libc strrchr from being built and linked
+		in the kernel, including NuttX's software-defined version of the libc strrchr
+		or any other architecture-specific version of it. The ROM-defined
+		version should be linked instead. This option is particularly useful
+		when it's required that the ROM-defined libc strrchr to be used by the kernel
+		(for accessing some driver resource, for instance) but the userspace
+		is forbidden to use the same ROM-defined versions. In this case,
+		NuttX's software-defined version of the libc strrchr or arch-specific
+		assembly version is built instead.
+
+config LIBC_PREVENT_STRRCHR_USER
+	bool
+	default n
+	---help---
+		Prevent any implementation of the libc strrchr from being built and linked
+		in the userspace, including NuttX's software-defined version of the
+		libc strrchr or any other architecture-specific version of it. A ROM-defined
+		version of the libc strrchr may be linked to the userspace by the linker.
 
 # One or more the of above may be selected by architecture specific logic
 

--- a/libs/libc/machine/arm/armv7-a/gnu/arch_memchr.S
+++ b/libs/libc/machine/arm/armv7-a/gnu/arch_memchr.S
@@ -68,7 +68,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_MEMCHR
 
 @ 2011-02-07 david.gilbert@linaro.org
 @    Extracted from local git a5b438d861

--- a/libs/libc/machine/arm/armv7-a/gnu/arch_memcpy.S
+++ b/libs/libc/machine/arm/armv7-a/gnu/arch_memcpy.S
@@ -35,7 +35,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_MEMCPY
 
 /*
  * This memcpy routine is optimised for Cortex-A15 cores and takes advantage

--- a/libs/libc/machine/arm/armv7-a/gnu/arch_memmove.S
+++ b/libs/libc/machine/arm/armv7-a/gnu/arch_memmove.S
@@ -31,7 +31,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_MEMMOVE
 
 	.thumb
 	.syntax unified

--- a/libs/libc/machine/arm/armv7-a/gnu/arch_memset.S
+++ b/libs/libc/machine/arm/armv7-a/gnu/arch_memset.S
@@ -31,7 +31,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_MEMSET
 
 	.arm
 	.syntax unified

--- a/libs/libc/machine/arm/armv7-a/gnu/arch_strcmp.S
+++ b/libs/libc/machine/arm/armv7-a/gnu/arch_strcmp.S
@@ -32,7 +32,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_STRCMP
 
 #ifdef __ARMEB__
 #define SHFT2LSB lsl

--- a/libs/libc/machine/arm/armv7-a/gnu/arch_strlen.S
+++ b/libs/libc/machine/arm/armv7-a/gnu/arch_strlen.S
@@ -64,7 +64,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_STRLEN
 
 #include "acle-compat.h"
 

--- a/libs/libc/machine/arm/armv7-m/gnu/arch_memchr.S
+++ b/libs/libc/machine/arm/armv7-m/gnu/arch_memchr.S
@@ -68,7 +68,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_MEMCHR
 
 @ 2011-02-07 david.gilbert@linaro.org
 @    Extracted from local git a5b438d861

--- a/libs/libc/machine/arm/armv7-m/gnu/arch_memcpy.S
+++ b/libs/libc/machine/arm/armv7-m/gnu/arch_memcpy.S
@@ -31,7 +31,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_MEMCPY
 
 /* This memcpy routine is optimised for Cortex-M3/M4 cores with/without
    unaligned access.

--- a/libs/libc/machine/arm/armv7-m/gnu/arch_memmove.S
+++ b/libs/libc/machine/arm/armv7-m/gnu/arch_memmove.S
@@ -31,7 +31,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_MEMMOVE
 
 	.thumb
 	.syntax unified

--- a/libs/libc/machine/arm/armv7-m/gnu/arch_memset.S
+++ b/libs/libc/machine/arm/armv7-m/gnu/arch_memset.S
@@ -31,7 +31,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_MEMSET
 
 	.thumb
 	.syntax unified

--- a/libs/libc/machine/arm/armv7-m/gnu/arch_strcmp.S
+++ b/libs/libc/machine/arm/armv7-m/gnu/arch_strcmp.S
@@ -31,7 +31,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_STRCMP
 
 /* Very similar to the generic code, but uses Thumb2 as implemented
    in ARMv7-M.  */

--- a/libs/libc/machine/arm/armv7-m/gnu/arch_strcpy.S
+++ b/libs/libc/machine/arm/armv7-m/gnu/arch_strcpy.S
@@ -20,7 +20,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_STRCPY
 
 /* This strcpy borrowed some ideas from arch_strcmp.S(). */
 

--- a/libs/libc/machine/arm/armv7-m/gnu/arch_strlen.S
+++ b/libs/libc/machine/arm/armv7-m/gnu/arch_strlen.S
@@ -64,7 +64,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_STRLEN
 
 #include "acle-compat.h"
 

--- a/libs/libc/machine/arm/armv7-r/gnu/arch_memchr.S
+++ b/libs/libc/machine/arm/armv7-r/gnu/arch_memchr.S
@@ -68,7 +68,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_MEMCHR
 
 @ 2011-02-07 david.gilbert@linaro.org
 @    Extracted from local git a5b438d861

--- a/libs/libc/machine/arm/armv7-r/gnu/arch_memcpy.S
+++ b/libs/libc/machine/arm/armv7-r/gnu/arch_memcpy.S
@@ -35,7 +35,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_MEMCPY
 
 /*
  * This memcpy routine is optimised for Cortex-A15 cores and takes advantage

--- a/libs/libc/machine/arm/armv7-r/gnu/arch_memmove.S
+++ b/libs/libc/machine/arm/armv7-r/gnu/arch_memmove.S
@@ -31,7 +31,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_MEMMOVE
 
 	.thumb
 	.syntax unified

--- a/libs/libc/machine/arm/armv7-r/gnu/arch_memset.S
+++ b/libs/libc/machine/arm/armv7-r/gnu/arch_memset.S
@@ -31,7 +31,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_MEMSET
 
 	.arm
 	.syntax unified

--- a/libs/libc/machine/arm/armv7-r/gnu/arch_strcmp.S
+++ b/libs/libc/machine/arm/armv7-r/gnu/arch_strcmp.S
@@ -32,7 +32,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_STRCMP
 
 #ifdef __ARMEB__
 #define SHFT2LSB lsl

--- a/libs/libc/machine/arm/armv7-r/gnu/arch_strlen.S
+++ b/libs/libc/machine/arm/armv7-r/gnu/arch_strlen.S
@@ -64,7 +64,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_STRLEN
 
 #include "acle-compat.h"
 

--- a/libs/libc/machine/arm/armv8-m/gnu/arch_memchr.S
+++ b/libs/libc/machine/arm/armv8-m/gnu/arch_memchr.S
@@ -68,7 +68,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_MEMCHR
 
 @ 2011-02-07 david.gilbert@linaro.org
 @    Extracted from local git a5b438d861

--- a/libs/libc/machine/arm/armv8-m/gnu/arch_memcpy.S
+++ b/libs/libc/machine/arm/armv8-m/gnu/arch_memcpy.S
@@ -31,7 +31,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_MEMCPY
 
 #ifndef __ARM_FEATURE_MVE
 /* This memcpy routine is optimised for Cortex-M3/M4 cores with/without

--- a/libs/libc/machine/arm/armv8-m/gnu/arch_memmove.S
+++ b/libs/libc/machine/arm/armv8-m/gnu/arch_memmove.S
@@ -31,7 +31,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_MEMMOVE
 
 	.thumb
 	.syntax unified

--- a/libs/libc/machine/arm/armv8-m/gnu/arch_memset.S
+++ b/libs/libc/machine/arm/armv8-m/gnu/arch_memset.S
@@ -57,7 +57,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_MEMSET
 
 	.thumb
 	.syntax unified

--- a/libs/libc/machine/arm/armv8-m/gnu/arch_strcmp.S
+++ b/libs/libc/machine/arm/armv8-m/gnu/arch_strcmp.S
@@ -31,7 +31,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_STRCMP
 
 #ifdef __ARM_BIG_ENDIAN
 #define S2LO lsl

--- a/libs/libc/machine/arm/armv8-m/gnu/arch_strlen.S
+++ b/libs/libc/machine/arm/armv8-m/gnu/arch_strlen.S
@@ -64,7 +64,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_STRLEN
 
 	.macro def_fn f p2align=0
 	.text

--- a/libs/libc/machine/arm64/gnu/arch_memchr.S
+++ b/libs/libc/machine/arm64/gnu/arch_memchr.S
@@ -31,7 +31,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_MEMCHR
 
 /* Assumptions:
  *

--- a/libs/libc/machine/arm64/gnu/arch_memcmp.S
+++ b/libs/libc/machine/arm64/gnu/arch_memcmp.S
@@ -61,7 +61,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_MEMCMP
 
 /* Assumptions:
  *

--- a/libs/libc/machine/arm64/gnu/arch_memcpy.S
+++ b/libs/libc/machine/arm64/gnu/arch_memcpy.S
@@ -61,7 +61,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_MEMCPY
 
 /* Assumptions:
  *

--- a/libs/libc/machine/arm64/gnu/arch_memmove.S
+++ b/libs/libc/machine/arm64/gnu/arch_memmove.S
@@ -61,7 +61,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_MEMMOVE
 
 /* Assumptions:
  *

--- a/libs/libc/machine/arm64/gnu/arch_memset.S
+++ b/libs/libc/machine/arm64/gnu/arch_memset.S
@@ -61,7 +61,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_MEMSET
 
 /* Assumptions:
  *

--- a/libs/libc/machine/arm64/gnu/arch_strchr.S
+++ b/libs/libc/machine/arm64/gnu/arch_strchr.S
@@ -31,7 +31,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_STRCHR
 
 /* Assumptions:
  *

--- a/libs/libc/machine/arm64/gnu/arch_strchrnul.S
+++ b/libs/libc/machine/arm64/gnu/arch_strchrnul.S
@@ -31,7 +31,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_STRCHRNUL
 
 /* Assumptions:
  *

--- a/libs/libc/machine/arm64/gnu/arch_strcmp.S
+++ b/libs/libc/machine/arm64/gnu/arch_strcmp.S
@@ -35,7 +35,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_STRCMP
 
 /* Assumptions:
  *

--- a/libs/libc/machine/arm64/gnu/arch_strcpy.S
+++ b/libs/libc/machine/arm64/gnu/arch_strcpy.S
@@ -31,7 +31,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_STRCPY
 
 /* Assumptions:
  *

--- a/libs/libc/machine/arm64/gnu/arch_strlen.S
+++ b/libs/libc/machine/arm64/gnu/arch_strlen.S
@@ -35,7 +35,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_STRLEN
 
 /* Assumptions:
  *

--- a/libs/libc/machine/arm64/gnu/arch_strncmp.S
+++ b/libs/libc/machine/arm64/gnu/arch_strncmp.S
@@ -35,7 +35,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_STRNCMP
 
 /* Assumptions:
  *

--- a/libs/libc/machine/arm64/gnu/arch_strnlen.S
+++ b/libs/libc/machine/arm64/gnu/arch_strnlen.S
@@ -35,7 +35,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_STRNLEN
 
 /* Assumptions:
  *

--- a/libs/libc/machine/arm64/gnu/arch_strrchr.S
+++ b/libs/libc/machine/arm64/gnu/arch_strrchr.S
@@ -31,7 +31,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_STRRCHR
 
 /* Assumptions:
  *

--- a/libs/libc/machine/risc-v/gnu/arch_memcpy.S
+++ b/libs/libc/machine/risc-v/gnu/arch_memcpy.S
@@ -24,7 +24,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_MEMCPY
 
 /************************************************************************************
  * Public Symbols

--- a/libs/libc/machine/risc-v/gnu/arch_memset.S
+++ b/libs/libc/machine/risc-v/gnu/arch_memset.S
@@ -15,7 +15,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_MEMSET
 
 .text
 .global memset

--- a/libs/libc/machine/risc-v/gnu/arch_strcmp.S
+++ b/libs/libc/machine/risc-v/gnu/arch_strcmp.S
@@ -15,7 +15,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_STRCMP
 
 #include "asm.h"
 

--- a/libs/libc/machine/xtensa/arch_memcpy.S
+++ b/libs/libc/machine/xtensa/arch_memcpy.S
@@ -29,7 +29,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_MEMCPY
 
 /****************************************************************************
  * Pre-processor Macros

--- a/libs/libc/machine/xtensa/arch_memmove.S
+++ b/libs/libc/machine/xtensa/arch_memmove.S
@@ -29,7 +29,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_MEMMOVE
 
 /****************************************************************************
  * Pre-processor Macros

--- a/libs/libc/machine/xtensa/arch_memset.S
+++ b/libs/libc/machine/xtensa/arch_memset.S
@@ -29,7 +29,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_MEMSET
 
 /****************************************************************************
  * Public Functions

--- a/libs/libc/machine/xtensa/arch_strcmp.S
+++ b/libs/libc/machine/xtensa/arch_strcmp.S
@@ -29,7 +29,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_STRCMP
 
 /****************************************************************************
  * Pre-processor Macros

--- a/libs/libc/machine/xtensa/arch_strcpy.S
+++ b/libs/libc/machine/xtensa/arch_strcpy.S
@@ -29,7 +29,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_STRCPY
 
 /****************************************************************************
  * Public Functions

--- a/libs/libc/machine/xtensa/arch_strlen.S
+++ b/libs/libc/machine/xtensa/arch_strlen.S
@@ -29,7 +29,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_STRLEN
 
 /****************************************************************************
  * Public Functions

--- a/libs/libc/machine/xtensa/arch_strncpy.S
+++ b/libs/libc/machine/xtensa/arch_strncpy.S
@@ -29,7 +29,7 @@
 
 #include "libc.h"
 
-#ifdef LIBC_BUILD_STRING
+#ifdef LIBC_BUILD_STRNCPY
 
 /****************************************************************************
  * Public Functions

--- a/libs/libc/string/lib_memchr.c
+++ b/libs/libc/string/lib_memchr.c
@@ -46,7 +46,7 @@
  *
  ****************************************************************************/
 
-#if !defined(CONFIG_LIBC_ARCH_MEMCHR) && defined(LIBC_BUILD_STRING)
+#if !defined(CONFIG_LIBC_ARCH_MEMCHR) && defined(LIBC_BUILD_MEMCHR)
 #undef memchr /* See mm/README.txt */
 FAR void *memchr(FAR const void *s, int c, size_t n)
 {

--- a/libs/libc/string/lib_memcmp.c
+++ b/libs/libc/string/lib_memcmp.c
@@ -32,7 +32,7 @@
  * Public Functions
  ****************************************************************************/
 
-#if !defined(CONFIG_LIBC_ARCH_MEMCMP) && defined(LIBC_BUILD_STRING)
+#if !defined(CONFIG_LIBC_ARCH_MEMCMP) && defined(LIBC_BUILD_MEMCMP)
 #undef memcmp /* See mm/README.txt */
 no_builtin("memcmp")
 int memcmp(FAR const void *s1, FAR const void *s2, size_t n)

--- a/libs/libc/string/lib_memcpy.c
+++ b/libs/libc/string/lib_memcpy.c
@@ -36,7 +36,7 @@
  * Name: memcpy
  ****************************************************************************/
 
-#if !defined(CONFIG_LIBC_ARCH_MEMCPY) && defined(LIBC_BUILD_STRING)
+#if !defined(CONFIG_LIBC_ARCH_MEMCPY) && defined(LIBC_BUILD_MEMCPY)
 #undef memcpy /* See mm/README.txt */
 no_builtin("memcpy")
 FAR void *memcpy(FAR void *dest, FAR const void *src, size_t n)

--- a/libs/libc/string/lib_memmove.c
+++ b/libs/libc/string/lib_memmove.c
@@ -32,7 +32,7 @@
  * Public Functions
  ****************************************************************************/
 
-#if !defined(CONFIG_LIBC_ARCH_MEMMOVE) && defined(LIBC_BUILD_STRING)
+#if !defined(CONFIG_LIBC_ARCH_MEMMOVE) && defined(LIBC_BUILD_MEMMOVE)
 #undef memmove /* See mm/README.txt */
 no_builtin("memmove")
 FAR void *memmove(FAR void *dest, FAR const void *src, size_t count)

--- a/libs/libc/string/lib_memset.c
+++ b/libs/libc/string/lib_memset.c
@@ -48,7 +48,7 @@
  * Public Functions
  ****************************************************************************/
 
-#if !defined(CONFIG_LIBC_ARCH_MEMSET) && defined(LIBC_BUILD_STRING)
+#if !defined(CONFIG_LIBC_ARCH_MEMSET) && defined(LIBC_BUILD_MEMSET)
 #undef memset /* See mm/README.txt */
 no_builtin("memset")
 FAR void *memset(FAR void *s, int c, size_t n)

--- a/libs/libc/string/lib_strcasecmp.c
+++ b/libs/libc/string/lib_strcasecmp.c
@@ -33,7 +33,7 @@
  * Public Functions
  ****************************************************************************/
 
-#if !defined(CONFIG_LIBC_ARCH_STRCASECMP) && defined(LIBC_BUILD_STRING)
+#if !defined(CONFIG_LIBC_ARCH_STRCASECMP) && defined(LIBC_BUILD_STRCASECMP)
 #undef strcasecmp /* See mm/README.txt */
 int strcasecmp(FAR const char *cs, FAR const char *ct)
 {

--- a/libs/libc/string/lib_strcat.c
+++ b/libs/libc/string/lib_strcat.c
@@ -32,7 +32,7 @@
  * Public Functions
  ****************************************************************************/
 
-#if !defined(CONFIG_LIBC_ARCH_STRCAT) && defined(LIBC_BUILD_STRING)
+#if !defined(CONFIG_LIBC_ARCH_STRCAT) && defined(LIBC_BUILD_STRCAT)
 #undef strcat /* See mm/README.txt */
 FAR char *strcat(FAR char *dest, FAR const char *src)
 {

--- a/libs/libc/string/lib_strchr.c
+++ b/libs/libc/string/lib_strchr.c
@@ -46,7 +46,7 @@
  *
  ****************************************************************************/
 
-#if !defined(CONFIG_LIBC_ARCH_STRCHR) && defined(LIBC_BUILD_STRING)
+#if !defined(CONFIG_LIBC_ARCH_STRCHR) && defined(LIBC_BUILD_STRCHR)
 #undef strchr /* See mm/README.txt */
 FAR char *strchr(FAR const char *s, int c)
 {

--- a/libs/libc/string/lib_strchrnul.c
+++ b/libs/libc/string/lib_strchrnul.c
@@ -46,7 +46,7 @@
  *
  ****************************************************************************/
 
-#if !defined(CONFIG_LIBC_ARCH_STRCHRNUL) && defined(LIBC_BUILD_STRING)
+#if !defined(CONFIG_LIBC_ARCH_STRCHRNUL) && defined(LIBC_BUILD_STRCHRNUL)
 #undef strchrnul /* See mm/README.txt */
 FAR char *strchrnul(FAR const char *s, int c)
 {

--- a/libs/libc/string/lib_strcmp.c
+++ b/libs/libc/string/lib_strcmp.c
@@ -32,7 +32,7 @@
  * Public Functions
  ****************************************************************************/
 
-#if !defined(CONFIG_LIBC_ARCH_STRCMP) && defined(LIBC_BUILD_STRING)
+#if !defined(CONFIG_LIBC_ARCH_STRCMP) && defined(LIBC_BUILD_STRCMP)
 #undef strcmp /* See mm/README.txt */
 int strcmp(FAR const char *cs, FAR const char *ct)
 {

--- a/libs/libc/string/lib_strcpy.c
+++ b/libs/libc/string/lib_strcpy.c
@@ -44,7 +44,7 @@
  *
  ****************************************************************************/
 
-#if !defined(CONFIG_LIBC_ARCH_STRCPY) && defined(LIBC_BUILD_STRING)
+#if !defined(CONFIG_LIBC_ARCH_STRCPY) && defined(LIBC_BUILD_STRCPY)
 #undef strcpy /* See mm/README.txt */
 FAR char *strcpy(FAR char *dest, FAR const char *src)
 {

--- a/libs/libc/string/lib_strlcat.c
+++ b/libs/libc/string/lib_strlcat.c
@@ -46,7 +46,7 @@
  *
  ****************************************************************************/
 
-#if !defined(CONFIG_LIBC_ARCH_STRLCAT) && defined(LIBC_BUILD_STRING)
+#if !defined(CONFIG_LIBC_ARCH_STRLCAT) && defined(LIBC_BUILD_STRLCAT)
 #undef strlcat /* See mm/README.txt */
 size_t strlcat(FAR char *dst, FAR const char *src, size_t dsize)
 {

--- a/libs/libc/string/lib_strlcpy.c
+++ b/libs/libc/string/lib_strlcpy.c
@@ -45,7 +45,7 @@
  *
  ****************************************************************************/
 
-#if !defined(CONFIG_LIBC_ARCH_STRLCPY) && defined(LIBC_BUILD_STRING)
+#if !defined(CONFIG_LIBC_ARCH_STRLCPY) && defined(LIBC_BUILD_STRLCPY)
 #undef strlcpy /* See mm/README.txt */
 size_t strlcpy(FAR char *dst, FAR const char *src, size_t dsize)
 {

--- a/libs/libc/string/lib_strlen.c
+++ b/libs/libc/string/lib_strlen.c
@@ -32,7 +32,7 @@
  * Public Functions
  ****************************************************************************/
 
-#if !defined(CONFIG_LIBC_ARCH_STRLEN) && defined(LIBC_BUILD_STRING)
+#if !defined(CONFIG_LIBC_ARCH_STRLEN) && defined(LIBC_BUILD_STRLEN)
 #undef strlen /* See mm/README.txt */
 size_t strlen(FAR const char *s)
 {

--- a/libs/libc/string/lib_strncasecmp.c
+++ b/libs/libc/string/lib_strncasecmp.c
@@ -34,7 +34,7 @@
  * Public Functions
  ****************************************************************************/
 
-#if !defined(CONFIG_LIBC_ARCH_STRNCASECMP) && defined(LIBC_BUILD_STRING)
+#if !defined(CONFIG_LIBC_ARCH_STRNCASECMP) && defined(LIBC_BUILD_STRNCASECMP)
 #undef strncasecmp /* See mm/README.txt */
 int strncasecmp(FAR const char *cs, FAR const char *ct, size_t nb)
 {

--- a/libs/libc/string/lib_strncat.c
+++ b/libs/libc/string/lib_strncat.c
@@ -32,7 +32,7 @@
  * Public Functions
  ****************************************************************************/
 
-#if !defined(CONFIG_LIBC_ARCH_STRNCAT) && defined(LIBC_BUILD_STRING)
+#if !defined(CONFIG_LIBC_ARCH_STRNCAT) && defined(LIBC_BUILD_STRNCAT)
 #undef strncat /* See mm/README.txt */
 FAR char *strncat(FAR char *dest, FAR const char *src, size_t n)
 {

--- a/libs/libc/string/lib_strncmp.c
+++ b/libs/libc/string/lib_strncmp.c
@@ -32,7 +32,7 @@
  * Public Functions
  ****************************************************************************/
 
-#if !defined(CONFIG_LIBC_ARCH_STRNCMP) && defined(LIBC_BUILD_STRING)
+#if !defined(CONFIG_LIBC_ARCH_STRNCMP) && defined(LIBC_BUILD_STRNCMP)
 #undef strncmp /* See mm/README.txt */
 int strncmp(FAR const char *cs, FAR const char *ct, size_t nb)
 {

--- a/libs/libc/string/lib_strncpy.c
+++ b/libs/libc/string/lib_strncpy.c
@@ -53,7 +53,7 @@
  *
  ****************************************************************************/
 
-#if !defined(CONFIG_LIBC_ARCH_STRNCPY) && defined(LIBC_BUILD_STRING)
+#if !defined(CONFIG_LIBC_ARCH_STRNCPY) && defined(LIBC_BUILD_STRNCPY)
 #undef strncpy /* See mm/README.txt */
 FAR char *strncpy(FAR char *dest, FAR const char *src, size_t n)
 {

--- a/libs/libc/string/lib_strnlen.c
+++ b/libs/libc/string/lib_strnlen.c
@@ -32,7 +32,7 @@
  * Public Functions
  ****************************************************************************/
 
-#if !defined(CONFIG_LIBC_ARCH_STRNLEN) && defined(LIBC_BUILD_STRING)
+#if !defined(CONFIG_LIBC_ARCH_STRNLEN) && defined(LIBC_BUILD_STRNLEN)
 #undef strnlen /* See mm/README.txt */
 size_t strnlen(FAR const char *s, size_t maxlen)
 {

--- a/libs/libc/string/lib_strrchr.c
+++ b/libs/libc/string/lib_strrchr.c
@@ -36,7 +36,7 @@
  * occurrence of the character c in the string s.
  */
 
-#if !defined(CONFIG_LIBC_ARCH_STRRCHR) && defined(LIBC_BUILD_STRING)
+#if !defined(CONFIG_LIBC_ARCH_STRRCHR) && defined(LIBC_BUILD_STRRCHR)
 #undef strrchr /* See mm/README.txt */
 FAR char *strrchr(FAR const char *s, int c)
 {

--- a/libs/libc/string/lib_vikmemcpy.c
+++ b/libs/libc/string/lib_vikmemcpy.c
@@ -64,7 +64,7 @@
 
 #include "libc.h"
 
-#if !defined(CONFIG_LIBC_ARCH_MEMCPY) && defined(LIBC_BUILD_STRING)
+#if !defined(CONFIG_LIBC_ARCH_MEMCPY) && defined(LIBC_BUILD_MEMCPY)
 
 /****************************************************************************
  * Pre-processor Definitions


### PR DESCRIPTION
## Summary

Provide a way to only customize specific string operations, such as for memcpy with the DMA capability by ROM.

## Impact

## Testing

