### PR TITLE
net/local: fix visual studio Compiler Error C2057

### DIFF
--- a/net/local/local_fifo.c
+++ b/net/local/local_fifo.c
@@ -49,7 +49,7 @@
 #define LOCAL_HD_SUFFIX    "HD"  /* Name of the half duplex datagram FIFO */
 #define LOCAL_SUFFIX_LEN   2
 
-#define LOCAL_FULLPATH_LEN (strlen(CONFIG_NET_LOCAL_VFS_PATH) + \
+#define LOCAL_FULLPATH_LEN (sizeof(CONFIG_NET_LOCAL_VFS_PATH) + \
                             UNIX_PATH_MAX + LOCAL_SUFFIX_LEN + 2)
 
 /****************************************************************************


### PR DESCRIPTION

## Summary

net/local: fix visual studio Compiler Error C2057

expected constant expression
The context requires a constant expression, an expression whose value is known at compile time.
The compiler must know the size of a type at compile time in order to allocate space for an instance of that type.

Reference:
https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2057?view=msvc-170
Signed-off-by: chao an <anchao@xiaomi.com>



## Impact

N/A

## Testing

visual studio 2023 + cmake