### PR TITLE
change the default NETDB_DNSCLIENT_MAXRESPONSE to the standard length

### DIFF
--- a/libs/libc/netdb/Kconfig
+++ b/libs/libc/netdb/Kconfig
@@ -116,7 +116,7 @@ config NETDB_DNSCLIENT_LIFESEC
 
 config NETDB_DNSCLIENT_MAXRESPONSE
 	int "Max response size"
-	default NETDB_BUFSIZE
+	default 512
 	---help---
 		This setting determines the maximum size of response message that
 		can be received by the DNS resolver.  The default used to be 96,


### PR DESCRIPTION
## Summary
change the default NETDB_DNSCLIENT_MAXRESPONSE to the standard length
the size of the dns response buffer
https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-respsize-12
## Impact
minor
## Testing

