### PR TITLE
assert: Fix the printing alignment of interrupt stack during assert

### DIFF
--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -442,7 +442,7 @@ static void dump_tasks(void)
          " --- --------"
          " ------- ---"
          " ------- ----------"
-         " --------"
+         " ----------------"
          " %p"
          "   %7u"
 #  ifdef CONFIG_STACK_COLORATION


### PR DESCRIPTION
## Summary
Fix the printing alignment of interrupt stack during assert.

before:
```
dump_tasks:    PID GROUP PRI POLICY   TYPE    NPX STATE   EVENT      SIGMASK          STACKBASE  STACKSIZE      USED   FILLED    COMMAND
dump_tasks:   ----   --- --- -------- ------- --- ------- ---------- -------- 0x2d04ea28      2048       608    29.6%    irq
dump_task:       0     0   0 FIFO     Kthread N-- Ready              0000000000000000 0x2d052af0      1016       520    51.1%    Idle_Task
dump_task:       1     1 224 RR       Kthread --- Waiting Semaphore  0000000000000000 0x2d054018      2008       304    15.1%    hpwork 0x2d050818
```
after:
```
dump_tasks:    PID GROUP PRI POLICY   TYPE    NPX STATE   EVENT      SIGMASK          STACKBASE  STACKSIZE      USED   FILLED    COMMAND
dump_tasks:   ----   --- --- -------- ------- --- ------- ---------- ---------------- 0x2d04ea38      2048       608    29.6%    irq
dump_task:       0     0   0 FIFO     Kthread N-- Ready              0000000000000000 0x2d052af0      1016       520    51.1%    Idle_Task
dump_task:       1     1 224 RR       Kthread --- Waiting Semaphore  0000000000000000 0x2d054018      2008       304    15.1%    hpwork 0x2d050828
```
## Impact
None

## Testing

