### PR TITLE
mm/alloc: remove all unnecessary cast for alloc

### DIFF
--- a/Documentation/contributing/coding_style.rst
+++ b/Documentation/contributing/coding_style.rst
@@ -164,9 +164,9 @@ may be used in the file provided that it is used consistently.
       int short_name2;   /* This is a very long comment describing subtle aspects of the short_name2 field */
     };
 
-    struct some_medium_name_s *ptr = (struct some_medium_name_s *)malloc(sizeof(some_medium_name_s);
+    struct some_medium_name_s *ptr = malloc(sizeof(some_medium_name_s);
 
-    struct some_long_struct_name_s *ptr = (struct some_long_struct_name_s *)malloc(sizeof(some_long_struct_name_s);
+    struct some_long_struct_name_s *ptr = malloc(sizeof(some_long_struct_name_s);
 
     ret = some_function_with_many parameters(long_parameter_name_1, long_parameter_name_2, long_parameter_name_3, long_parameter_name_4, long_parameter_name_5, long_parameter_name_6, long_parameter_name_7, long_parameter_name_8);
 
@@ -195,15 +195,11 @@ may be used in the file provided that it is used consistently.
                           * aspects of the short_name2 field. */
     };
 
-    FAR struct some_medium_name_s *ptr = (FAR struct some_medium_name_s *)
-      malloc(sizeof(some_medium_name_s);
+    FAR struct some_medium_name_s *ptr = malloc(sizeof(some_medium_name_s);
 
-    FAR struct some_medium_name_s *ptr =
-      (FAR struct some_medium_name_s *)malloc(sizeof(some_medium_name_s);
+    FAR struct some_medium_name_s *ptr = malloc(sizeof(some_medium_name_s);
 
-    FAR struct some_long_struct_name_s *ptr =
-      (FAR struct some_long_struct_name_s *)
-        malloc(sizeof(some_long_struct_name_s);
+    FAR struct some_long_struct_name_s *ptr = malloc(sizeof(some_long_struct_name_s);
 
     ret = some_function_with_many parameters(long_parameter_name_1,
                                              long_parameter_name_2,
@@ -2279,7 +2275,7 @@ Use of ``goto``
            goto errout;
          }
        ...
-       ptr = (FAR struct some_struct_s *)malloc(sizeof(struct some_struct_s));
+       ptr = malloc(sizeof(struct some_struct_s));
        if (!ptr)
          {
            ret = -ENOMEM;

--- a/arch/arm/src/armv7-a/arm_addrenv_kstack.c
+++ b/arch/arm/src/armv7-a/arm_addrenv_kstack.c
@@ -136,7 +136,7 @@ int up_addrenv_kstackalloc(struct tcb_s *tcb)
 
   /* Allocate the kernel stack */
 
-  tcb->xcp.kstack = (uint32_t *)kmm_memalign(8, ARCH_KERNEL_STACKSIZE);
+  tcb->xcp.kstack = kmm_memalign(8, ARCH_KERNEL_STACKSIZE);
   if (!tcb->xcp.kstack)
     {
       berr("ERROR: Failed to allocate the kernel stack\n");

--- a/arch/arm/src/cxd56xx/cxd56_dmac.c
+++ b/arch/arm/src/cxd56xx/cxd56_dmac.c
@@ -812,7 +812,7 @@ DMA_HANDLE cxd56_dmachannel(int ch, ssize_t maxsize)
       n++;
     }
 
-  dmach->list = (dmac_lli_t *)kmm_malloc(n * sizeof(dmac_lli_t));
+  dmach->list = kmm_malloc(n * sizeof(dmac_lli_t));
   if (dmach->list == NULL)
     {
       dmainfo("Failed to kmm_malloc\n");

--- a/arch/arm/src/cxd56xx/cxd56_emmc.c
+++ b/arch/arm/src/cxd56xx/cxd56_emmc.c
@@ -950,7 +950,7 @@ int cxd56_emmcinitialize(void)
       return -EIO;
     }
 
-  buf = (uint8_t *)kmm_malloc(SECTOR_SIZE);
+  buf = kmm_malloc(SECTOR_SIZE);
   if (buf)
     {
       putreg32(SECTOR_SIZE, EMMC_BYTCNT);

--- a/arch/arm/src/cxd56xx/cxd56_geofence.c
+++ b/arch/arm/src/cxd56xx/cxd56_geofence.c
@@ -631,8 +631,7 @@ static int cxd56_geofence_register(const char *devpath)
   struct cxd56_geofence_dev_s *priv;
   int                          ret;
 
-  priv = (struct cxd56_geofence_dev_s *)kmm_zalloc(
-    sizeof(struct cxd56_geofence_dev_s));
+  priv = kmm_zalloc(sizeof(struct cxd56_geofence_dev_s));
   if (!priv)
     {
       gnsserr("Failed to allocate instance\n");

--- a/arch/arm/src/cxd56xx/cxd56_gnss.c
+++ b/arch/arm/src/cxd56xx/cxd56_gnss.c
@@ -907,7 +907,7 @@ static int cxd56_gnss_save_backup_data(struct file *filep,
   int         n = 0;
   int32_t     offset = 0;
 
-  buf = (char *)kmm_malloc(CONFIG_CXD56_GNSS_BACKUP_BUFFER_SIZE);
+  buf = kmm_malloc(CONFIG_CXD56_GNSS_BACKUP_BUFFER_SIZE);
   if (buf == NULL)
     {
       return -ENOMEM;
@@ -1054,7 +1054,7 @@ static int cxd56_gnss_check_cep_data(struct file *filep, unsigned long arg)
 
   if (g_ceplen > 0)
     {
-      g_cepdata = (char *)kmm_malloc(g_ceplen);
+      g_cepdata = kmm_malloc(g_ceplen);
     }
 
   if (!g_cepdata)
@@ -2267,7 +2267,7 @@ cxd56_gnss_read_cep_file(struct file *fp, int32_t offset,
       goto err0;
     }
 
-  buf = (char *)kmm_malloc(len);
+  buf = kmm_malloc(len);
   if (buf == NULL)
     {
       ret = -ENOMEM;
@@ -2326,7 +2326,7 @@ static void cxd56_gnss_read_backup_file(int *retval)
   size_t      n;
   int         ret = 0;
 
-  buf = (char *)kmm_malloc(CONFIG_CXD56_GNSS_BACKUP_BUFFER_SIZE);
+  buf = kmm_malloc(CONFIG_CXD56_GNSS_BACKUP_BUFFER_SIZE);
   if (buf == NULL)
     {
       ret = -ENOMEM;
@@ -3131,8 +3131,7 @@ static int cxd56_gnss_register(const char *devpath)
     }
   };
 
-  priv = (struct cxd56_gnss_dev_s *)kmm_zalloc(
-    sizeof(struct cxd56_gnss_dev_s));
+  priv = kmm_zalloc(sizeof(struct cxd56_gnss_dev_s));
   if (!priv)
     {
       gnsserr("Failed to allocate instance\n");

--- a/arch/arm/src/cxd56xx/cxd56_hostif.c
+++ b/arch/arm/src/cxd56xx/cxd56_hostif.c
@@ -392,8 +392,7 @@ static int hif_initialize(struct hostif_buff_s *buffer)
 
   /* Setup driver structure */
 
-  drv->dev =
-    (struct cxd56_hifdev_s *)kmm_malloc(sizeof(struct cxd56_hifdev_s) * num);
+  drv->dev = kmm_malloc(sizeof(struct cxd56_hifdev_s) * num);
   if (drv->dev == NULL)
     {
       hiferr("ERROR: hostif allocation failed\n");

--- a/arch/arm/src/cxd56xx/cxd56_icc.c
+++ b/arch/arm/src/cxd56xx/cxd56_icc.c
@@ -339,7 +339,7 @@ static struct iccdev_s *icc_devnew(void)
   struct iccdev_s *priv;
   int i;
 
-  priv = (struct iccdev_s *)kmm_malloc(sizeof(struct iccdev_s));
+  priv = kmm_malloc(sizeof(struct iccdev_s));
   if (!priv)
     {
       return NULL;

--- a/arch/arm/src/cxd56xx/cxd56_nxaudio.c
+++ b/arch/arm/src/cxd56xx/cxd56_nxaudio.c
@@ -3783,7 +3783,7 @@ struct audio_lowerhalf_s *cxd56_initialize(
   FAR struct cxd56_dev_s *priv;
 
   audinfo("cxd56_initialize\n");
-  priv = (FAR struct cxd56_dev_s *)kmm_zalloc(sizeof(struct cxd56_dev_s));
+  priv = kmm_zalloc(sizeof(struct cxd56_dev_s));
   if (priv)
     {
       priv->dev.ops = &g_audioops;

--- a/arch/arm/src/cxd56xx/cxd56_powermgr.c
+++ b/arch/arm/src/cxd56xx/cxd56_powermgr.c
@@ -483,7 +483,7 @@ void *cxd56_pm_register_callback(uint32_t target,
 
   nxmutex_lock(&g_regcblock);
 
-  entry = (struct pm_cbentry_s *)kmm_malloc(sizeof(struct pm_cbentry_s));
+  entry = kmm_malloc(sizeof(struct pm_cbentry_s));
   if (entry == NULL)
     {
       nxmutex_unlock(&g_regcblock);

--- a/arch/arm/src/cxd56xx/cxd56_scu.c
+++ b/arch/arm/src/cxd56xx/cxd56_scu.c
@@ -1778,7 +1778,7 @@ static struct seq_s *seq_new(void)
 
   leave_critical_section(flags);
 
-  seq = (struct seq_s *)kmm_zalloc(sizeof(struct seq_s));
+  seq = kmm_zalloc(sizeof(struct seq_s));
   if (!seq)
     {
       seq_free(sid);
@@ -1818,7 +1818,7 @@ static struct seq_s *deci_new(void)
 
   leave_critical_section(flags);
 
-  deci = (struct decimator_s *)kmm_zalloc(sizeof(struct decimator_s));
+  deci = kmm_zalloc(sizeof(struct decimator_s));
   if (!deci)
     {
       deci_free(sid);
@@ -1873,7 +1873,7 @@ static int seq_fifoinit(struct seq_s *seq, int fifoid, uint16_t fsize)
         }
     }
 
-  fifo = (struct scufifo_s *)kmm_zalloc(sizeof(struct scufifo_s));
+  fifo = kmm_zalloc(sizeof(struct scufifo_s));
   if (!fifo)
     {
       return -ENOMEM;

--- a/arch/arm/src/cxd56xx/cxd56_sfc.c
+++ b/arch/arm/src/cxd56xx/cxd56_sfc.c
@@ -274,7 +274,7 @@ struct mtd_dev_s *cxd56_sfc_initialize(void)
 
   /* Allocate a buffer for the erase block cache */
 
-  priv->cache = (uint8_t *)kmm_malloc(SPIFI_BLKSIZE);
+  priv->cache = kmm_malloc(SPIFI_BLKSIZE);
   if (!priv->cache)
     {
       /* Allocation failed! */

--- a/arch/arm/src/cxd56xx/cxd56_textheap.c
+++ b/arch/arm/src/cxd56xx/cxd56_textheap.c
@@ -49,8 +49,7 @@
 
 void *up_textheap_memalign(size_t align, size_t size)
 {
-  void *ret;
-  ret = (void *)kmm_malloc(size);
+  void *ret = kmm_malloc(size);
 
 #ifdef CONFIG_CXD56_USE_SYSBUS
   if (ret)

--- a/arch/arm/src/cxd56xx/cxd56_usbdev.c
+++ b/arch/arm/src/cxd56xx/cxd56_usbdev.c
@@ -2294,7 +2294,7 @@ static struct usbdev_req_s *cxd56_epallocreq(struct usbdev_ep_s *ep)
 #endif
   usbtrace(TRACE_EPALLOCREQ, ((struct cxd56_ep_s *)ep)->epphy);
 
-  privreq = (struct cxd56_req_s *)kmm_malloc(sizeof(struct cxd56_req_s));
+  privreq = kmm_malloc(sizeof(struct cxd56_req_s));
   if (!privreq)
     {
       usbtrace(TRACE_DEVERROR(CXD56_TRACEERR_ALLOCFAIL), 0);
@@ -2590,8 +2590,7 @@ static int cxd56_allocepbuffer(struct cxd56_ep_s *privep)
   DEBUGASSERT(!privep->desc && !privep->buffer);
   DEBUGASSERT(privep->epphy); /* Do not use for EP0 */
 
-  privep->desc =
-    (struct cxd56_data_desc_s *)kmm_malloc(sizeof(struct cxd56_data_desc_s));
+  privep->desc = kmm_malloc(sizeof(struct cxd56_data_desc_s));
   if (!privep->desc)
     {
       return -1;
@@ -3394,8 +3393,7 @@ static int cxd56_usbdev_open(struct file *filep, const char *relpath,
 
   /* Allocate the open file structure */
 
-  priv = (struct cxd56_usbdev_file_s *)kmm_zalloc(
-    sizeof(struct cxd56_usbdev_file_s));
+  priv = kmm_zalloc(sizeof(struct cxd56_usbdev_file_s));
   if (!priv)
     {
       uerr("ERROR: Failed to allocate file attributes\n");
@@ -3489,8 +3487,7 @@ static int cxd56_usbdev_dup(const struct file *oldp,
 
   /* Allocate a new container to hold the task and attribute selection */
 
-  newattr = (struct cxd56_usbdev_file_s *)kmm_malloc(
-    sizeof(struct cxd56_usbdev_file_s));
+  newattr = kmm_malloc(sizeof(struct cxd56_usbdev_file_s));
   if (!newattr)
     {
       uerr("ERROR: Failed to allocate file attributes\n");

--- a/arch/arm/src/dm320/dm320_framebuffer.c
+++ b/arch/arm/src/dm320/dm320_framebuffer.c
@@ -677,10 +677,10 @@ static int dm320_allocvideomemory(void)
 {
 #ifndef CONFIG_DM320_VID0_DISABLE
 #ifndef CONFIG_DM320_DISABLE_PINGPONG
-  g_vid0base   = (void *)kmm_malloc(2 * DM320_VID0_FBLEN);
+  g_vid0base   = kmm_malloc(2 * DM320_VID0_FBLEN);
   g_vid0ppbase = (char *)g_vid0base + DM320_VID0_FBLEN;
 #else
-  g_vid0base   = (void *)kmm_malloc(DM320_VID0_FBLEN);
+  g_vid0base   = kmm_malloc(DM320_VID0_FBLEN);
 #endif
   if (!g_vid0base)
     {
@@ -689,7 +689,7 @@ static int dm320_allocvideomemory(void)
 #endif
 
 #ifndef CONFIG_DM320_VID1_DISABLE
-  g_vid1base = (void *)kmm_malloc(DM320_VID1_FBLEN);
+  g_vid1base = kmm_malloc(DM320_VID1_FBLEN);
   if (!g_vid1base)
     {
       goto errout;
@@ -697,7 +697,7 @@ static int dm320_allocvideomemory(void)
 #endif
 
 #ifndef CONFIG_DM320_OSD0_DISABLE
-  g_osd0base = (void *)kmm_malloc(DM320_OSD0_FBLEN);
+  g_osd0base = kmm_malloc(DM320_OSD0_FBLEN);
   if (!g_osd0base)
     {
       goto errout;
@@ -705,7 +705,7 @@ static int dm320_allocvideomemory(void)
 #endif
 
 #ifndef CONFIG_DM320_OSD1_DISABLE
-  g_osd1base = (void *)kmm_malloc(DM320_OSD1_FBLEN);
+  g_osd1base = kmm_malloc(DM320_OSD1_FBLEN);
   if (!g_osd1base)
     {
       goto errout;

--- a/arch/arm/src/dm320/dm320_usbdev.c
+++ b/arch/arm/src/dm320/dm320_usbdev.c
@@ -2025,7 +2025,7 @@ static struct usbdev_req_s *dm320_epallocreq(struct usbdev_ep_s *ep)
 
   usbtrace(TRACE_EPALLOCREQ, ((struct dm320_ep_s *)ep)->epphy);
 
-  privreq = (struct dm320_req_s *)kmm_malloc(sizeof(struct dm320_req_s));
+  privreq = kmm_malloc(sizeof(struct dm320_req_s));
   if (!privreq)
     {
       usbtrace(TRACE_DEVERROR(DM320_TRACEERR_ALLOCFAIL), 0);

--- a/arch/arm/src/efm32/efm32_usbdev.c
+++ b/arch/arm/src/efm32/efm32_usbdev.c
@@ -4328,7 +4328,7 @@ static struct usbdev_req_s *efm32_ep_allocreq(struct usbdev_ep_s *ep)
 
   usbtrace(TRACE_EPALLOCREQ, ((struct efm32_ep_s *)ep)->epphy);
 
-  privreq = (struct efm32_req_s *)kmm_malloc(sizeof(struct efm32_req_s));
+  privreq = kmm_malloc(sizeof(struct efm32_req_s));
   if (!privreq)
     {
       usbtrace(TRACE_DEVERROR(EFM32_TRACEERR_ALLOCFAIL), 0);

--- a/arch/arm/src/efm32/efm32_usbhost.c
+++ b/arch/arm/src/efm32/efm32_usbhost.c
@@ -4277,7 +4277,7 @@ static int efm32_alloc(struct usbhost_driver_s *drvr,
 
   /* There is no special memory requirement for the EFM32. */
 
-  alloc = (uint8_t *)kmm_malloc(CONFIG_EFM32_OTGFS_DESCSIZE);
+  alloc = kmm_malloc(CONFIG_EFM32_OTGFS_DESCSIZE);
   if (!alloc)
     {
       return -ENOMEM;
@@ -4361,7 +4361,7 @@ static int efm32_ioalloc(struct usbhost_driver_s *drvr,
 
   /* There is no special memory requirement */
 
-  alloc = (uint8_t *)kmm_malloc(buflen);
+  alloc = kmm_malloc(buflen);
   if (!alloc)
     {
       return -ENOMEM;

--- a/arch/arm/src/imxrt/imxrt_ehci.c
+++ b/arch/arm/src/imxrt/imxrt_ehci.c
@@ -3955,8 +3955,7 @@ static int imxrt_epalloc(struct usbhost_driver_s *drvr,
 
   /* Allocate a endpoint information structure */
 
-  epinfo = (struct imxrt_epinfo_s *)
-    kmm_zalloc(sizeof(struct imxrt_epinfo_s));
+  epinfo = kmm_zalloc(sizeof(struct imxrt_epinfo_s));
   if (!epinfo)
     {
       usbhost_trace1(EHCI_TRACE1_EPALLOC_FAILED, 0);
@@ -4067,8 +4066,7 @@ static int imxrt_alloc(struct usbhost_driver_s *drvr,
    * multiple of the cache line size in length.
    */
 
-  *buffer = (uint8_t *)kmm_memalign(ARMV7M_DCACHE_LINESIZE,
-                                    IMXRT_EHCI_BUFSIZE);
+  *buffer = kmm_memalign(ARMV7M_DCACHE_LINESIZE, IMXRT_EHCI_BUFSIZE);
   if (*buffer)
     {
       *maxlen = IMXRT_EHCI_BUFSIZE;
@@ -4155,7 +4153,7 @@ static int imxrt_ioalloc(struct usbhost_driver_s *drvr,
    */
 
   buflen  = (buflen + DCACHE_LINEMASK) & ~DCACHE_LINEMASK;
-  *buffer = (uint8_t *)kumm_memalign(ARMV7M_DCACHE_LINESIZE, buflen);
+  *buffer = kumm_memalign(ARMV7M_DCACHE_LINESIZE, buflen);
   return *buffer ? OK : -ENOMEM;
 }
 
@@ -5058,10 +5056,8 @@ struct usbhost_connection_s *imxrt_ehci_initialize(int controller)
 #  ifndef CONFIG_IMXRT_EHCI_PREALLOCATE
   /* Allocate a pool of free Queue Head (QH) structures */
 
-  g_qhpool =
-    (struct imxrt_qh_s *)kmm_memalign(32,
-                                      CONFIG_IMXRT_EHCI_NQHS *
-                                      sizeof(struct imxrt_qh_s));
+  g_qhpool = kmm_memalign(32, CONFIG_IMXRT_EHCI_NQHS *
+                              sizeof(struct imxrt_qh_s));
   if (!g_qhpool)
     {
       usbhost_trace1(EHCI_TRACE1_QHPOOLALLOC_FAILED, 0);
@@ -5081,10 +5077,8 @@ struct usbhost_connection_s *imxrt_ehci_initialize(int controller)
 #  ifndef CONFIG_IMXRT_EHCI_PREALLOCATE
   /* Allocate a pool of free Transfer Descriptor (qTD) structures */
 
-  g_qtdpool =
-    (struct imxrt_qtd_s *)kmm_memalign(32,
-                                       CONFIG_IMXRT_EHCI_NQTDS *
-                                       sizeof(struct imxrt_qtd_s));
+  g_qtdpool = kmm_memalign(32, CONFIG_IMXRT_EHCI_NQTDS *
+                               sizeof(struct imxrt_qtd_s));
   if (!g_qtdpool)
     {
       usbhost_trace1(EHCI_TRACE1_QTDPOOLALLOC_FAILED, 0);
@@ -5096,8 +5090,7 @@ struct usbhost_connection_s *imxrt_ehci_initialize(int controller)
 #  if !defined(CONFIG_IMXRT_EHCI_PREALLOCATE) && !defined(CONFIG_USBHOST_INT_DISABLE)
   /* Allocate the periodic framelist */
 
-  g_framelist = (uint32_t *)
-    kmm_memalign(4096, FRAME_LIST_SIZE * sizeof(uint32_t));
+  g_framelist = kmm_memalign(4096, FRAME_LIST_SIZE * sizeof(uint32_t));
   if (!g_framelist)
     {
       usbhost_trace1(EHCI_TRACE1_PERFLALLOC_FAILED, 0);

--- a/arch/arm/src/imxrt/imxrt_usbdev.c
+++ b/arch/arm/src/imxrt/imxrt_usbdev.c
@@ -2281,7 +2281,7 @@ static struct usbdev_req_s *imxrt_epallocreq(struct usbdev_ep_s *ep)
 
   usbtrace(TRACE_EPALLOCREQ, ((struct imxrt_ep_s *)ep)->epphy);
 
-  privreq = (struct imxrt_req_s *)kmm_malloc(sizeof(struct imxrt_req_s));
+  privreq = kmm_malloc(sizeof(struct imxrt_req_s));
   if (!privreq)
     {
       usbtrace(TRACE_DEVERROR(IMXRT_TRACEERR_ALLOCFAIL), 0);

--- a/arch/arm/src/kinetis/kinetis_usbdev.c
+++ b/arch/arm/src/kinetis/kinetis_usbdev.c
@@ -3563,7 +3563,7 @@ static struct usbdev_req_s *khci_epallocreq(struct usbdev_ep_s *ep)
 
   usbtrace(TRACE_EPALLOCREQ, USB_EPNO(ep->eplog));
 
-  privreq = (struct khci_req_s *)kmm_malloc(sizeof(struct khci_req_s));
+  privreq = kmm_malloc(sizeof(struct khci_req_s));
   if (!privreq)
     {
       usbtrace(TRACE_DEVERROR(KHCI_TRACEERR_ALLOCFAIL), 0);

--- a/arch/arm/src/kinetis/kinetis_usbhshost.c
+++ b/arch/arm/src/kinetis/kinetis_usbhshost.c
@@ -4024,8 +4024,7 @@ static int kinetis_epalloc(struct usbhost_driver_s *drvr,
 
   /* Allocate a endpoint information structure */
 
-  epinfo = (struct kinetis_epinfo_s *)
-    kmm_zalloc(sizeof(struct kinetis_epinfo_s));
+  epinfo = kmm_zalloc(sizeof(struct kinetis_epinfo_s));
   if (!epinfo)
     {
       usbhost_trace1(EHCI_TRACE1_EPALLOC_FAILED, 0);
@@ -4136,8 +4135,7 @@ static int kinetis_alloc(struct usbhost_driver_s *drvr,
    * multiple of the cache line size in length.
    */
 
-  *buffer = (uint8_t *)kmm_memalign(ARMV7M_DCACHE_LINESIZE,
-                                    KINETIS_EHCI_BUFSIZE);
+  *buffer = kmm_memalign(ARMV7M_DCACHE_LINESIZE, KINETIS_EHCI_BUFSIZE);
   if (*buffer)
     {
       *maxlen = KINETIS_EHCI_BUFSIZE;
@@ -4225,7 +4223,7 @@ static int kinetis_ioalloc(struct usbhost_driver_s *drvr,
    */
 
   buflen  = (buflen + DCACHE_LINEMASK) & ~DCACHE_LINEMASK;
-  *buffer = (uint8_t *)kumm_memalign(ARMV7M_DCACHE_LINESIZE, buflen);
+  *buffer = kumm_memalign(ARMV7M_DCACHE_LINESIZE, buflen);
   return *buffer ? OK : -ENOMEM;
 }
 
@@ -5128,10 +5126,8 @@ struct usbhost_connection_s *kinetis_ehci_initialize(int controller)
 #  ifndef CONFIG_KINETIS_EHCI_PREALLOCATE
   /* Allocate a pool of free Queue Head (QH) structures */
 
-  g_qhpool =
-    (struct kinetis_qh_s *)kmm_memalign(32,
-                                      CONFIG_KINETIS_EHCI_NQHS *
-                                      sizeof(struct kinetis_qh_s));
+  g_qhpool = kmm_memalign(32, CONFIG_KINETIS_EHCI_NQHS *
+                              sizeof(struct kinetis_qh_s));
   if (!g_qhpool)
     {
       usbhost_trace1(EHCI_TRACE1_QHPOOLALLOC_FAILED, 0);
@@ -5151,10 +5147,8 @@ struct usbhost_connection_s *kinetis_ehci_initialize(int controller)
 #  ifndef CONFIG_KINETIS_EHCI_PREALLOCATE
   /* Allocate a pool of free Transfer Descriptor (qTD) structures */
 
-  g_qtdpool =
-    (struct kinetis_qtd_s *)kmm_memalign(32,
-                                       CONFIG_KINETIS_EHCI_NQTDS *
-                                       sizeof(struct kinetis_qtd_s));
+  g_qtdpool = kmm_memalign(32, CONFIG_KINETIS_EHCI_NQTDS *
+                               sizeof(struct kinetis_qtd_s));
   if (!g_qtdpool)
     {
       usbhost_trace1(EHCI_TRACE1_QTDPOOLALLOC_FAILED, 0);
@@ -5166,8 +5160,7 @@ struct usbhost_connection_s *kinetis_ehci_initialize(int controller)
 #  if !defined(CONFIG_KINETIS_EHCI_PREALLOCATE) && !defined(CONFIG_USBHOST_INT_DISABLE)
   /* Allocate the periodic framelist */
 
-  g_framelist = (uint32_t *)
-    kmm_memalign(4096, FRAME_LIST_SIZE * sizeof(uint32_t));
+  g_framelist = kmm_memalign(4096, FRAME_LIST_SIZE * sizeof(uint32_t));
   if (!g_framelist)
     {
       usbhost_trace1(EHCI_TRACE1_PERFLALLOC_FAILED, 0);

--- a/arch/arm/src/lc823450/lc823450_i2s.c
+++ b/arch/arm/src/lc823450/lc823450_i2s.c
@@ -1010,7 +1010,7 @@ struct i2s_dev_s *lc823450_i2sdev_initialize(void)
    * chip select structures.
    */
 
-  priv = (struct lc823450_i2s_s *)kmm_zalloc(sizeof(struct lc823450_i2s_s));
+  priv = kmm_zalloc(sizeof(struct lc823450_i2s_s));
   if (!priv)
     {
       i2serr("ERROR: Failed to allocate a chip select structure\n");

--- a/arch/arm/src/lc823450/lc823450_mmcl.c
+++ b/arch/arm/src/lc823450/lc823450_mmcl.c
@@ -249,7 +249,7 @@ static struct mmcl_dev_s *mmcl_allocdev(int number,
 
   /* Allocate a MMCL device structure */
 
-  dev = (struct mmcl_dev_s *)kmm_malloc(sizeof(struct mmcl_dev_s));
+  dev = kmm_malloc(sizeof(struct mmcl_dev_s));
   if (dev)
     {
       /* Initialize the MMCL device structure */

--- a/arch/arm/src/lc823450/lc823450_procfs_dvfs.c
+++ b/arch/arm/src/lc823450/lc823450_procfs_dvfs.c
@@ -131,7 +131,7 @@ static int dvfs_open(struct file *filep, const char *relpath,
 
   /* Allocate a container to hold the task and attribute selection */
 
-  priv = (struct dvfs_file_s *)kmm_zalloc(sizeof(struct dvfs_file_s));
+  priv = kmm_zalloc(sizeof(struct dvfs_file_s));
   if (!priv)
     {
       ferr("ERROR: Failed to allocate file attributes\n");
@@ -314,7 +314,7 @@ static int dvfs_dup(const struct file *oldp, struct file *newp)
 
   /* Allocate a new container to hold the task and attribute selection */
 
-  newpriv = (struct dvfs_file_s *)kmm_zalloc(sizeof(struct dvfs_file_s));
+  newpriv = kmm_zalloc(sizeof(struct dvfs_file_s));
   if (!newpriv)
     {
       ferr("ERROR: Failed to allocate file attributes\n");

--- a/arch/arm/src/lpc31xx/lpc31_ehci.c
+++ b/arch/arm/src/lpc31xx/lpc31_ehci.c
@@ -4175,7 +4175,7 @@ static int lpc31_ioalloc(struct usbhost_driver_s *drvr,
    */
 
   buflen  = (buflen + DCACHE_LINEMASK) & ~DCACHE_LINEMASK;
-  *buffer = (uint8_t *)kumm_memalign(ARM_DCACHE_LINESIZE, buflen);
+  *buffer = kumm_memalign(ARM_DCACHE_LINESIZE, buflen);
   return *buffer ? OK : -ENOMEM;
 }
 

--- a/arch/arm/src/lpc31xx/lpc31_usbdev.c
+++ b/arch/arm/src/lpc31xx/lpc31_usbdev.c
@@ -2136,7 +2136,7 @@ static struct usbdev_req_s *lpc31_epallocreq(struct usbdev_ep_s *ep)
 
   usbtrace(TRACE_EPALLOCREQ, ((struct lpc31_ep_s *)ep)->epphy);
 
-  privreq = (struct lpc31_req_s *)kmm_malloc(sizeof(struct lpc31_req_s));
+  privreq = kmm_malloc(sizeof(struct lpc31_req_s));
   if (!privreq)
     {
       usbtrace(TRACE_DEVERROR(LPC31_TRACEERR_ALLOCFAIL), 0);

--- a/arch/arm/src/lpc43xx/lpc43_ehci.c
+++ b/arch/arm/src/lpc43xx/lpc43_ehci.c
@@ -3920,7 +3920,7 @@ static int lpc43_alloc(struct usbhost_driver_s *drvr,
 
   /* There is no special requirements for transfer/descriptor buffers. */
 
-  *buffer = (uint8_t *)kmm_malloc(CONFIG_LPC43_EHCI_BUFSIZE);
+  *buffer = kmm_malloc(CONFIG_LPC43_EHCI_BUFSIZE);
   if (*buffer)
     {
       *maxlen = CONFIG_LPC43_EHCI_BUFSIZE;
@@ -4005,7 +4005,7 @@ static int lpc43_ioalloc(struct usbhost_driver_s *drvr,
    * buffering).
    */
 
-  *buffer = (uint8_t *)kumm_malloc(buflen);
+  *buffer = kumm_malloc(buflen);
   return *buffer ? OK : -ENOMEM;
 }
 

--- a/arch/arm/src/lpc43xx/lpc43_spifi.c
+++ b/arch/arm/src/lpc43xx/lpc43_spifi.c
@@ -1238,7 +1238,7 @@ struct mtd_dev_s *lpc43_spifi_initialize(void)
 
   /* Allocate a buffer for the erase block cache */
 
-  priv->cache = (uint8_t *)kmm_malloc(SPIFI_BLKSIZE);
+  priv->cache = kmm_malloc(SPIFI_BLKSIZE);
   if (!priv->cache)
     {
       /* Allocation failed!

--- a/arch/arm/src/lpc43xx/lpc43_usb0dev.c
+++ b/arch/arm/src/lpc43xx/lpc43_usb0dev.c
@@ -2180,7 +2180,7 @@ usbdev_req_s *lpc43_epallocreq(struct usbdev_ep_s *ep)
 
   usbtrace(TRACE_EPALLOCREQ, ((struct lpc43_ep_s *)ep)->epphy);
 
-  privreq = (struct lpc43_req_s *)kmm_malloc(sizeof(struct lpc43_req_s));
+  privreq = kmm_malloc(sizeof(struct lpc43_req_s));
   if (!privreq)
     {
       usbtrace(TRACE_DEVERROR(LPC43_TRACEERR_ALLOCFAIL), 0);

--- a/arch/arm/src/nrf52/nrf52_usbd.c
+++ b/arch/arm/src/nrf52/nrf52_usbd.c
@@ -2422,7 +2422,7 @@ static struct usbdev_req_s *nrf52_ep_allocreq(struct usbdev_ep_s *ep)
 
   usbtrace(TRACE_EPALLOCREQ, ((struct nrf52_ep_s *)ep)->epphy);
 
-  privreq = (struct nrf52_req_s *)kmm_malloc(sizeof(struct nrf52_req_s));
+  privreq = kmm_malloc(sizeof(struct nrf52_req_s));
   if (!privreq)
     {
       usbtrace(TRACE_DEVERROR(NRF52_TRACEERR_ALLOCFAIL), 0);

--- a/arch/arm/src/nrf53/nrf53_usbd.c
+++ b/arch/arm/src/nrf53/nrf53_usbd.c
@@ -2422,7 +2422,7 @@ static struct usbdev_req_s *nrf53_ep_allocreq(struct usbdev_ep_s *ep)
 
   usbtrace(TRACE_EPALLOCREQ, ((struct nrf53_ep_s *)ep)->epphy);
 
-  privreq = (struct nrf53_req_s *)kmm_malloc(sizeof(struct nrf53_req_s));
+  privreq = kmm_malloc(sizeof(struct nrf53_req_s));
   if (!privreq)
     {
       usbtrace(TRACE_DEVERROR(NRF53_TRACEERR_ALLOCFAIL), 0);

--- a/arch/arm/src/rp2040/rp2040_i2s.c
+++ b/arch/arm/src/rp2040/rp2040_i2s.c
@@ -1291,7 +1291,7 @@ struct i2s_dev_s *rp2040_i2sbus_initialize(int port)
 
   i2sinfo("port: %d\n", port);
 
-  priv = (struct rp2040_i2s_s *)kmm_zalloc(sizeof(struct rp2040_i2s_s));
+  priv = kmm_zalloc(sizeof(struct rp2040_i2s_s));
   if (!priv)
     {
       i2serr("ERROR: Failed to allocate a chip select structure\n");

--- a/arch/arm/src/rtl8720c/amebaz_driver.c
+++ b/arch/arm/src/rtl8720c/amebaz_driver.c
@@ -1080,7 +1080,7 @@ static struct amebaz_dev_s *amebaz_allocate_device(int devnum)
 {
   struct amebaz_dev_s *priv;
 
-  priv = (struct amebaz_dev_s *)kmm_zalloc(sizeof(*priv));
+  priv = kmm_zalloc(sizeof(*priv));
   if (!priv)
     {
       return NULL;

--- a/arch/arm/src/s32k1xx/s32k1xx_eeeprom.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_eeeprom.c
@@ -392,7 +392,7 @@ int s32k1xx_eeeprom_register(int minor, uint32_t size)
 
   /* Allocate a eeeprom device structure */
 
-  dev = (struct eeed_struct_s *)kmm_zalloc(sizeof(struct eeed_struct_s));
+  dev = kmm_zalloc(sizeof(struct eeed_struct_s));
   if (dev)
     {
       /* Initialize the eeeprom device structure */

--- a/arch/arm/src/sam34/sam_emac.c
+++ b/arch/arm/src/sam34/sam_emac.c
@@ -598,7 +598,7 @@ static int sam_buffer_initialize(struct sam_emac_s *priv)
   /* Allocate buffers */
 
   allocsize = CONFIG_SAM34_EMAC_NTXBUFFERS * sizeof(struct emac_txdesc_s);
-  priv->txdesc = (struct emac_txdesc_s *)kmm_memalign(8, allocsize);
+  priv->txdesc = kmm_memalign(8, allocsize);
   if (!priv->txdesc)
     {
       nerr("ERROR: Failed to allocate TX descriptors\n");
@@ -608,7 +608,7 @@ static int sam_buffer_initialize(struct sam_emac_s *priv)
   memset(priv->txdesc, 0, allocsize);
 
   allocsize = CONFIG_SAM34_EMAC_NRXBUFFERS * sizeof(struct emac_rxdesc_s);
-  priv->rxdesc = (struct emac_rxdesc_s *)kmm_memalign(8, allocsize);
+  priv->rxdesc = kmm_memalign(8, allocsize);
   if (!priv->rxdesc)
     {
       nerr("ERROR: Failed to allocate RX descriptors\n");
@@ -619,7 +619,7 @@ static int sam_buffer_initialize(struct sam_emac_s *priv)
   memset(priv->rxdesc, 0, allocsize);
 
   allocsize = CONFIG_SAM34_EMAC_NTXBUFFERS * EMAC_TX_UNITSIZE;
-  priv->txbuffer = (uint8_t *)kmm_memalign(8, allocsize);
+  priv->txbuffer = kmm_memalign(8, allocsize);
   if (!priv->txbuffer)
     {
       nerr("ERROR: Failed to allocate TX buffer\n");
@@ -628,7 +628,7 @@ static int sam_buffer_initialize(struct sam_emac_s *priv)
     }
 
   allocsize = CONFIG_SAM34_EMAC_NRXBUFFERS * EMAC_RX_UNITSIZE;
-  priv->rxbuffer = (uint8_t *)kmm_memalign(8, allocsize);
+  priv->rxbuffer = kmm_memalign(8, allocsize);
   if (!priv->rxbuffer)
     {
       nerr("ERROR: Failed to allocate RX buffer\n");

--- a/arch/arm/src/sam34/sam_spi.c
+++ b/arch/arm/src/sam34/sam_spi.c
@@ -1730,7 +1730,7 @@ struct spi_dev_s *sam_spibus_initialize(int port)
    * chip select structures.
    */
 
-  spics = (struct sam_spics_s *)kmm_zalloc(sizeof(struct sam_spics_s));
+  spics = kmm_zalloc(sizeof(struct sam_spics_s));
   if (!spics)
     {
       spierr("ERROR: Failed to allocate a chip select structure\n");

--- a/arch/arm/src/sam34/sam_udp.c
+++ b/arch/arm/src/sam34/sam_udp.c
@@ -3047,7 +3047,7 @@ static struct usbdev_req_s *sam_ep_allocreq(struct usbdev_ep_s *ep)
 
   usbtrace(TRACE_EPALLOCREQ, USB_EPNO(ep->eplog));
 
-  privreq = (struct sam_req_s *)kmm_malloc(sizeof(struct sam_req_s));
+  privreq = kmm_malloc(sizeof(struct sam_req_s));
   if (!privreq)
     {
       usbtrace(TRACE_DEVERROR(SAM_TRACEERR_ALLOCFAIL), 0);

--- a/arch/arm/src/sama5/sam_ehci.c
+++ b/arch/arm/src/sama5/sam_ehci.c
@@ -3739,7 +3739,7 @@ static int sam_epalloc(struct usbhost_driver_s *drvr,
 
   /* Allocate a endpoint information structure */
 
-  epinfo = (struct sam_epinfo_s *)kmm_zalloc(sizeof(struct sam_epinfo_s));
+  epinfo = kmm_zalloc(sizeof(struct sam_epinfo_s));
   if (!epinfo)
     {
       usbhost_trace1(EHCI_TRACE1_EPALLOC_FAILED, 0);
@@ -3963,7 +3963,7 @@ static int sam_ioalloc(struct usbhost_driver_s *drvr,
    */
 
   buflen  = (buflen + DCACHE_LINEMASK) & ~DCACHE_LINEMASK;
-  *buffer = (uint8_t *)kumm_memalign(ARMV7A_DCACHE_LINESIZE, buflen);
+  *buffer = kumm_memalign(ARMV7A_DCACHE_LINESIZE, buflen);
   return *buffer ? OK : -ENOMEM;
 }
 

--- a/arch/arm/src/sama5/sam_emaca.c
+++ b/arch/arm/src/sama5/sam_emaca.c
@@ -628,7 +628,7 @@ static int sam_buffer_initialize(struct sam_emac_s *priv)
   /* Allocate buffers */
 
   allocsize = CONFIG_SAMA5_EMAC_NTXBUFFERS * sizeof(struct emac_txdesc_s);
-  priv->txdesc = (struct emac_txdesc_s *)kmm_memalign(8, allocsize);
+  priv->txdesc = kmm_memalign(8, allocsize);
   if (!priv->txdesc)
     {
       nerr("ERROR: Failed to allocate TX descriptors\n");
@@ -638,7 +638,7 @@ static int sam_buffer_initialize(struct sam_emac_s *priv)
   memset(priv->txdesc, 0, allocsize);
 
   allocsize = CONFIG_SAMA5_EMAC_NRXBUFFERS * sizeof(struct emac_rxdesc_s);
-  priv->rxdesc = (struct emac_rxdesc_s *)kmm_memalign(8, allocsize);
+  priv->rxdesc = kmm_memalign(8, allocsize);
   if (!priv->rxdesc)
     {
       nerr("ERROR: Failed to allocate RX descriptors\n");
@@ -649,7 +649,7 @@ static int sam_buffer_initialize(struct sam_emac_s *priv)
   memset(priv->rxdesc, 0, allocsize);
 
   allocsize = CONFIG_SAMA5_EMAC_NTXBUFFERS * EMAC_TX_UNITSIZE;
-  priv->txbuffer = (uint8_t *)kmm_memalign(8, allocsize);
+  priv->txbuffer = kmm_memalign(8, allocsize);
   if (!priv->txbuffer)
     {
       nerr("ERROR: Failed to allocate TX buffer\n");
@@ -658,7 +658,7 @@ static int sam_buffer_initialize(struct sam_emac_s *priv)
     }
 
   allocsize = CONFIG_SAMA5_EMAC_NRXBUFFERS * EMAC_RX_UNITSIZE;
-  priv->rxbuffer = (uint8_t *)kmm_memalign(8, allocsize);
+  priv->rxbuffer = kmm_memalign(8, allocsize);
   if (!priv->rxbuffer)
     {
       nerr("ERROR: Failed to allocate RX buffer\n");

--- a/arch/arm/src/sama5/sam_emacb.c
+++ b/arch/arm/src/sama5/sam_emacb.c
@@ -941,7 +941,7 @@ static int sam_buffer_initialize(struct sam_emac_s *priv)
   /* Allocate buffers */
 
   allocsize = priv->attr->ntxbuffers * sizeof(struct emac_txdesc_s);
-  priv->txdesc = (struct emac_txdesc_s *)kmm_memalign(8, allocsize);
+  priv->txdesc = kmm_memalign(8, allocsize);
   if (!priv->txdesc)
     {
       nerr("ERROR: Failed to allocate TX descriptors\n");
@@ -951,7 +951,7 @@ static int sam_buffer_initialize(struct sam_emac_s *priv)
   memset(priv->txdesc, 0, allocsize);
 
   allocsize = priv->attr->nrxbuffers * sizeof(struct emac_rxdesc_s);
-  priv->rxdesc = (struct emac_rxdesc_s *)kmm_memalign(8, allocsize);
+  priv->rxdesc = kmm_memalign(8, allocsize);
   if (!priv->rxdesc)
     {
       nerr("ERROR: Failed to allocate RX descriptors\n");
@@ -962,7 +962,7 @@ static int sam_buffer_initialize(struct sam_emac_s *priv)
   memset(priv->rxdesc, 0, allocsize);
 
   allocsize = priv->attr->ntxbuffers * EMAC_TX_UNITSIZE;
-  priv->txbuffer = (uint8_t *)kmm_memalign(8, allocsize);
+  priv->txbuffer = kmm_memalign(8, allocsize);
   if (!priv->txbuffer)
     {
       nerr("ERROR: Failed to allocate TX buffer\n");
@@ -971,7 +971,7 @@ static int sam_buffer_initialize(struct sam_emac_s *priv)
     }
 
   allocsize = priv->attr->nrxbuffers * EMAC_RX_UNITSIZE;
-  priv->rxbuffer = (uint8_t *)kmm_memalign(8, allocsize);
+  priv->rxbuffer = kmm_memalign(8, allocsize);
   if (!priv->rxbuffer)
     {
       nerr("ERROR: Failed to allocate RX buffer\n");

--- a/arch/arm/src/sama5/sam_flexcom_spi.c
+++ b/arch/arm/src/sama5/sam_flexcom_spi.c
@@ -1857,8 +1857,7 @@ struct spi_dev_s *sam_flex_spibus_initialize(int port)
    * chip select structures.
    */
 
-  flex_spics = (struct sam_flex_spics_s *)kmm_zalloc(
-                sizeof(struct sam_flex_spics_s));
+  flex_spics = kmm_zalloc(sizeof(struct sam_flex_spics_s));
   if (!flex_spics)
     {
       spierr("ERROR: Failed to allocate a flexcom chip select structure\n");

--- a/arch/arm/src/sama5/sam_gmac.c
+++ b/arch/arm/src/sama5/sam_gmac.c
@@ -560,7 +560,7 @@ static int sam_buffer_initialize(struct sam_gmac_s *priv)
   /* Allocate buffers */
 
   allocsize = CONFIG_SAMA5_GMAC_NTXBUFFERS * sizeof(struct gmac_txdesc_s);
-  priv->txdesc = (struct gmac_txdesc_s *)kmm_memalign(8, allocsize);
+  priv->txdesc = kmm_memalign(8, allocsize);
   if (!priv->txdesc)
     {
       nerr("ERROR: Failed to allocate TX descriptors\n");
@@ -570,7 +570,7 @@ static int sam_buffer_initialize(struct sam_gmac_s *priv)
   memset(priv->txdesc, 0, allocsize);
 
   allocsize = CONFIG_SAMA5_GMAC_NRXBUFFERS * sizeof(struct gmac_rxdesc_s);
-  priv->rxdesc = (struct gmac_rxdesc_s *)kmm_memalign(8, allocsize);
+  priv->rxdesc = kmm_memalign(8, allocsize);
   if (!priv->rxdesc)
     {
       nerr("ERROR: Failed to allocate RX descriptors\n");
@@ -581,7 +581,7 @@ static int sam_buffer_initialize(struct sam_gmac_s *priv)
   memset(priv->rxdesc, 0, allocsize);
 
   allocsize = CONFIG_SAMA5_GMAC_NTXBUFFERS * GMAC_TX_UNITSIZE;
-  priv->txbuffer = (uint8_t *)kmm_memalign(8, allocsize);
+  priv->txbuffer = kmm_memalign(8, allocsize);
   if (!priv->txbuffer)
     {
       nerr("ERROR: Failed to allocate TX buffer\n");
@@ -590,7 +590,7 @@ static int sam_buffer_initialize(struct sam_gmac_s *priv)
     }
 
   allocsize = CONFIG_SAMA5_GMAC_NRXBUFFERS * GMAC_RX_UNITSIZE;
-  priv->rxbuffer = (uint8_t *)kmm_memalign(8, allocsize);
+  priv->rxbuffer = kmm_memalign(8, allocsize);
   if (!priv->rxbuffer)
     {
       nerr("ERROR: Failed to allocate RX buffer\n");

--- a/arch/arm/src/sama5/sam_ohci.c
+++ b/arch/arm/src/sama5/sam_ohci.c
@@ -2672,7 +2672,7 @@ static int sam_epalloc(struct usbhost_driver_s *drvr,
 
   /* Allocate a container for the endpoint data */
 
-  eplist = (struct sam_eplist_s *)kmm_zalloc(sizeof(struct sam_eplist_s));
+  eplist = kmm_zalloc(sizeof(struct sam_eplist_s));
   if (!eplist)
     {
       usbhost_trace1(OHCI_TRACE1_EPLISTALLOC_FAILED, 0);

--- a/arch/arm/src/sama5/sam_spi.c
+++ b/arch/arm/src/sama5/sam_spi.c
@@ -1831,7 +1831,7 @@ struct spi_dev_s *sam_spibus_initialize(int port)
    * chip select structures.
    */
 
-  spics = (struct sam_spics_s *)kmm_zalloc(sizeof(struct sam_spics_s));
+  spics = kmm_zalloc(sizeof(struct sam_spics_s));
   if (!spics)
     {
       spierr("ERROR: Failed to allocate a chip select structure\n");

--- a/arch/arm/src/sama5/sam_ssc.c
+++ b/arch/arm/src/sama5/sam_ssc.c
@@ -3336,7 +3336,7 @@ struct i2s_dev_s *sam_ssc_initialize(int port)
    * chip select structures.
    */
 
-  priv = (struct sam_ssc_s *)kmm_zalloc(sizeof(struct sam_ssc_s));
+  priv = kmm_zalloc(sizeof(struct sam_ssc_s));
   if (!priv)
     {
       i2serr("ERROR: Failed to allocate a chip select structure\n");

--- a/arch/arm/src/sama5/sam_udphs.c
+++ b/arch/arm/src/sama5/sam_udphs.c
@@ -3518,7 +3518,7 @@ static struct usbdev_req_s *sam_ep_allocreq(struct usbdev_ep_s *ep)
 #endif
   usbtrace(TRACE_EPALLOCREQ, USB_EPNO(ep->eplog));
 
-  privreq = (struct sam_req_s *)kmm_malloc(sizeof(struct sam_req_s));
+  privreq = kmm_malloc(sizeof(struct sam_req_s));
   if (!privreq)
     {
       usbtrace(TRACE_DEVERROR(SAM_TRACEERR_ALLOCFAIL), 0);

--- a/arch/arm/src/samd2l2/sam_adc.c
+++ b/arch/arm/src/samd2l2/sam_adc.c
@@ -469,7 +469,7 @@ struct adc_dev_s *sam_adcinitialize(int genclk)
   g_sam_adc_dev.ad_ops = &sam_adc_ops;
 
   priv->num_channels = BOARD_ADC_NUM_CHANNELS;
-  priv->channels = (int *)kmm_malloc(priv->num_channels * sizeof(int));
+  priv->channels = kmm_malloc(priv->num_channels * sizeof(int));
 
 #if BOARD_ADC_REF == ADC_REFCTRL_REFSEL_VREFA
   sam_configport(PORT_ADC_VREFA);

--- a/arch/arm/src/samd2l2/sam_usb.c
+++ b/arch/arm/src/samd2l2/sam_usb.c
@@ -1644,7 +1644,7 @@ static struct usbdev_req_s *sam_ep_allocreq(struct usbdev_ep_s *ep)
 
   usbtrace(TRACE_EPALLOCREQ, USB_EPNO(ep->eplog));
 
-  privreq = (struct sam_req_s *)kmm_malloc(sizeof(struct sam_req_s));
+  privreq = kmm_malloc(sizeof(struct sam_req_s));
   if (!privreq)
     {
       usbtrace(TRACE_DEVERROR(SAM_TRACEERR_ALLOCFAIL), 0);

--- a/arch/arm/src/samd5e5/sam_gmac.c
+++ b/arch/arm/src/samd5e5/sam_gmac.c
@@ -557,7 +557,7 @@ static int sam_buffer_initialize(struct sam_gmac_s *priv)
   /* Allocate buffers */
 
   allocsize = CONFIG_SAMD5E5_GMAC_NTXBUFFERS * sizeof(struct gmac_txdesc_s);
-  priv->txdesc = (struct gmac_txdesc_s *)kmm_memalign(8, allocsize);
+  priv->txdesc = kmm_memalign(8, allocsize);
   if (!priv->txdesc)
     {
       nerr("ERROR: Failed to allocate TX descriptors\n");
@@ -567,7 +567,7 @@ static int sam_buffer_initialize(struct sam_gmac_s *priv)
   memset(priv->txdesc, 0, allocsize);
 
   allocsize = CONFIG_SAMD5E5_GMAC_NRXBUFFERS * sizeof(struct gmac_rxdesc_s);
-  priv->rxdesc = (struct gmac_rxdesc_s *)kmm_memalign(8, allocsize);
+  priv->rxdesc = kmm_memalign(8, allocsize);
   if (!priv->rxdesc)
     {
       nerr("ERROR: Failed to allocate RX descriptors\n");
@@ -578,7 +578,7 @@ static int sam_buffer_initialize(struct sam_gmac_s *priv)
   memset(priv->rxdesc, 0, allocsize);
 
   allocsize = CONFIG_SAMD5E5_GMAC_NTXBUFFERS * GMAC_TX_UNITSIZE;
-  priv->txbuffer = (uint8_t *)kmm_memalign(8, allocsize);
+  priv->txbuffer = kmm_memalign(8, allocsize);
   if (!priv->txbuffer)
     {
       nerr("ERROR: Failed to allocate TX buffer\n");
@@ -587,7 +587,7 @@ static int sam_buffer_initialize(struct sam_gmac_s *priv)
     }
 
   allocsize = CONFIG_SAMD5E5_GMAC_NRXBUFFERS * GMAC_RX_UNITSIZE;
-  priv->rxbuffer = (uint8_t *)kmm_memalign(8, allocsize);
+  priv->rxbuffer = kmm_memalign(8, allocsize);
   if (!priv->rxbuffer)
     {
       nerr("ERROR: Failed to allocate RX buffer\n");

--- a/arch/arm/src/samd5e5/sam_usb.c
+++ b/arch/arm/src/samd5e5/sam_usb.c
@@ -2316,7 +2316,7 @@ static struct usbdev_req_s *sam_ep_allocreq(struct usbdev_ep_s *ep)
 
   usbtrace(TRACE_EPALLOCREQ, USB_EPNO(ep->eplog));
 
-  privreq = (struct sam_req_s *)kmm_zalloc(sizeof(struct sam_req_s));
+  privreq = kmm_zalloc(sizeof(struct sam_req_s));
   if (!privreq)
     {
       usbtrace(TRACE_DEVERROR(SAM_TRACEERR_ALLOCFAIL), 0);
@@ -7138,7 +7138,7 @@ static int sam_alloc(struct usbhost_driver_s *drvr,
 
   /* There is no special memory requirement for the SAM. */
 
-  alloc = (uint8_t *)kmm_malloc(CONFIG_SAM_DESCSIZE);
+  alloc = kmm_malloc(CONFIG_SAM_DESCSIZE);
   if (!alloc)
     {
       return -ENOMEM;
@@ -7225,7 +7225,7 @@ static int sam_ioalloc(struct usbhost_driver_s *drvr,
 
   /* There is no special memory requirement */
 
-  alloc = (uint8_t *)kmm_malloc(buflen);
+  alloc = kmm_malloc(buflen);
   if (!alloc)
     {
       return -ENOMEM;

--- a/arch/arm/src/samv7/sam_emac.c
+++ b/arch/arm/src/samv7/sam_emac.c
@@ -1141,7 +1141,7 @@ static int sam_buffer_allocate(struct sam_emac_s *priv)
   priv->xfrq[0].nrxbuffers = priv->attr->nrxbuffers;
 
   allocsize = priv->attr->ntxbuffers * EMAC_TX_UNITSIZE;
-  priv->xfrq[0].txbuffer = (uint8_t *)kmm_memalign(EMAC_ALIGN, allocsize);
+  priv->xfrq[0].txbuffer = kmm_memalign(EMAC_ALIGN, allocsize);
   if (!priv->xfrq[0].txbuffer)
     {
       nerr("ERROR: Failed to allocate TX buffer\n");
@@ -1152,7 +1152,7 @@ static int sam_buffer_allocate(struct sam_emac_s *priv)
   priv->xfrq[0].txbufsize = EMAC_TX_UNITSIZE;
 
   allocsize = priv->attr->nrxbuffers * EMAC_RX_UNITSIZE;
-  priv->xfrq[0].rxbuffer = (uint8_t *)kmm_memalign(EMAC_ALIGN, allocsize);
+  priv->xfrq[0].rxbuffer = kmm_memalign(EMAC_ALIGN, allocsize);
   if (!priv->xfrq[0].rxbuffer)
     {
       nerr("ERROR: Failed to allocate RX buffer\n");
@@ -1188,7 +1188,7 @@ static int sam_buffer_allocate(struct sam_emac_s *priv)
   priv->xfrq[1].nrxbuffers = DUMMY_NBUFFERS;
 
   allocsize = DUMMY_NBUFFERS * DUMMY_BUFSIZE;
-  priv->xfrq[1].txbuffer = (uint8_t *)kmm_memalign(EMAC_ALIGN, allocsize);
+  priv->xfrq[1].txbuffer = kmm_memalign(EMAC_ALIGN, allocsize);
   if (!priv->xfrq[1].txbuffer)
     {
       nerr("ERROR: Failed to allocate TX buffer\n");
@@ -1199,7 +1199,7 @@ static int sam_buffer_allocate(struct sam_emac_s *priv)
   priv->xfrq[1].txbufsize = DUMMY_BUFSIZE;
 
   allocsize = DUMMY_NBUFFERS * DUMMY_BUFSIZE;
-  priv->xfrq[1].rxbuffer = (uint8_t *)kmm_memalign(EMAC_ALIGN, allocsize);
+  priv->xfrq[1].rxbuffer = kmm_memalign(EMAC_ALIGN, allocsize);
   if (!priv->xfrq[1].rxbuffer)
     {
       nerr("ERROR: Failed to allocate RX buffer\n");

--- a/arch/arm/src/samv7/sam_qspi_spi.c
+++ b/arch/arm/src/samv7/sam_qspi_spi.c
@@ -775,7 +775,7 @@ struct spi_dev_s *sam_qspi_spi_initialize(int intf)
 
   /* Allocate a new state structure for this chip select. */
 
-  spics = (struct sam_spics_s *)kmm_zalloc(sizeof(struct sam_spics_s));
+  spics = kmm_zalloc(sizeof(struct sam_spics_s));
   if (!spics)
     {
       spierr("ERROR: Failed to allocate a chip select structure\n");

--- a/arch/arm/src/samv7/sam_spi.c
+++ b/arch/arm/src/samv7/sam_spi.c
@@ -2020,7 +2020,7 @@ struct spi_dev_s *sam_spibus_initialize(int port)
    * chip select structures.
    */
 
-  spics = (struct sam_spics_s *)kmm_zalloc(sizeof(struct sam_spics_s));
+  spics = kmm_zalloc(sizeof(struct sam_spics_s));
   if (!spics)
     {
       spierr("ERROR: Failed to allocate a chip select structure\n");

--- a/arch/arm/src/samv7/sam_ssc.c
+++ b/arch/arm/src/samv7/sam_ssc.c
@@ -3318,7 +3318,7 @@ struct i2s_dev_s *sam_ssc_initialize(int port)
    * chip select structures.
    */
 
-  priv = (struct sam_ssc_s *)kmm_zalloc(sizeof(struct sam_ssc_s));
+  priv = kmm_zalloc(sizeof(struct sam_ssc_s));
   if (!priv)
     {
       i2serr("ERROR: Failed to allocate a chip select structure\n");

--- a/arch/arm/src/samv7/sam_usbdevhs.c
+++ b/arch/arm/src/samv7/sam_usbdevhs.c
@@ -3928,7 +3928,7 @@ static struct usbdev_req_s *sam_ep_allocreq(struct usbdev_ep_s *ep)
   DEBUGASSERT(ep != NULL);
   usbtrace(TRACE_EPALLOCREQ, USB_EPNO(ep->eplog));
 
-  privreq = (struct sam_req_s *)kmm_malloc(sizeof(struct sam_req_s));
+  privreq = kmm_malloc(sizeof(struct sam_req_s));
   if (!privreq)
     {
       usbtrace(TRACE_DEVERROR(SAM_TRACEERR_ALLOCFAIL), 0);

--- a/arch/arm/src/stm32/stm32_i2s.c
+++ b/arch/arm/src/stm32/stm32_i2s.c
@@ -2533,7 +2533,7 @@ struct i2s_dev_s *stm32_i2sbus_initialize(int port)
    * chip select structures.
    */
 
-  priv = (struct stm32_i2s_s *)kmm_zalloc(sizeof(struct stm32_i2s_s));
+  priv = kmm_zalloc(sizeof(struct stm32_i2s_s));
   if (!priv)
     {
       i2serr("ERROR: Failed to allocate a chip select structure\n");

--- a/arch/arm/src/stm32/stm32_otgfsdev.c
+++ b/arch/arm/src/stm32/stm32_otgfsdev.c
@@ -4412,7 +4412,7 @@ static struct usbdev_req_s *stm32_ep_allocreq(struct usbdev_ep_s *ep)
 
   usbtrace(TRACE_EPALLOCREQ, ((struct stm32_ep_s *)ep)->epphy);
 
-  privreq = (struct stm32_req_s *)kmm_malloc(sizeof(struct stm32_req_s));
+  privreq = kmm_malloc(sizeof(struct stm32_req_s));
   if (!privreq)
     {
       usbtrace(TRACE_DEVERROR(STM32_TRACEERR_ALLOCFAIL), 0);

--- a/arch/arm/src/stm32/stm32_otgfshost.c
+++ b/arch/arm/src/stm32/stm32_otgfshost.c
@@ -4267,7 +4267,7 @@ static int stm32_alloc(struct usbhost_driver_s *drvr,
 
   /* There is no special memory requirement for the STM32. */
 
-  alloc = (uint8_t *)kmm_malloc(CONFIG_STM32_OTGFS_DESCSIZE);
+  alloc = kmm_malloc(CONFIG_STM32_OTGFS_DESCSIZE);
   if (!alloc)
     {
       return -ENOMEM;
@@ -4351,7 +4351,7 @@ static int stm32_ioalloc(struct usbhost_driver_s *drvr,
 
   /* There is no special memory requirement */
 
-  alloc = (uint8_t *)kmm_malloc(buflen);
+  alloc = kmm_malloc(buflen);
   if (!alloc)
     {
       return -ENOMEM;

--- a/arch/arm/src/stm32/stm32_otghsdev.c
+++ b/arch/arm/src/stm32/stm32_otghsdev.c
@@ -4317,7 +4317,7 @@ static struct usbdev_req_s *stm32_ep_allocreq(struct usbdev_ep_s *ep)
 
   usbtrace(TRACE_EPALLOCREQ, ((struct stm32_ep_s *)ep)->epphy);
 
-  privreq = (struct stm32_req_s *)kmm_malloc(sizeof(struct stm32_req_s));
+  privreq = kmm_malloc(sizeof(struct stm32_req_s));
   if (!privreq)
     {
       usbtrace(TRACE_DEVERROR(STM32_TRACEERR_ALLOCFAIL), 0);

--- a/arch/arm/src/stm32/stm32_otghshost.c
+++ b/arch/arm/src/stm32/stm32_otghshost.c
@@ -4268,7 +4268,7 @@ static int stm32_alloc(struct usbhost_driver_s *drvr,
 
   /* There is no special memory requirement for the STM32. */
 
-  alloc = (uint8_t *)kmm_malloc(CONFIG_STM32_OTGHS_DESCSIZE);
+  alloc = kmm_malloc(CONFIG_STM32_OTGHS_DESCSIZE);
   if (!alloc)
     {
       return -ENOMEM;
@@ -4352,7 +4352,7 @@ static int stm32_ioalloc(struct usbhost_driver_s *drvr,
 
   /* There is no special memory requirement */
 
-  alloc = (uint8_t *)kmm_malloc(buflen);
+  alloc = kmm_malloc(buflen);
   if (!alloc)
     {
       return -ENOMEM;

--- a/arch/arm/src/stm32/stm32_usbdev.c
+++ b/arch/arm/src/stm32/stm32_usbdev.c
@@ -2997,7 +2997,7 @@ static struct usbdev_req_s *stm32_epallocreq(struct usbdev_ep_s *ep)
 #endif
   usbtrace(TRACE_EPALLOCREQ, USB_EPNO(ep->eplog));
 
-  privreq = (struct stm32_req_s *)kmm_malloc(sizeof(struct stm32_req_s));
+  privreq = kmm_malloc(sizeof(struct stm32_req_s));
   if (!privreq)
     {
       usbtrace(TRACE_DEVERROR(STM32_TRACEERR_ALLOCFAIL), 0);

--- a/arch/arm/src/stm32/stm32_usbfs.c
+++ b/arch/arm/src/stm32/stm32_usbfs.c
@@ -2973,7 +2973,7 @@ static struct usbdev_req_s *stm32_epallocreq(struct usbdev_ep_s *ep)
 #endif
   usbtrace(TRACE_EPALLOCREQ, USB_EPNO(ep->eplog));
 
-  privreq = (struct stm32_req_s *)kmm_malloc(sizeof(struct stm32_req_s));
+  privreq = kmm_malloc(sizeof(struct stm32_req_s));
   if (!privreq)
     {
       usbtrace(TRACE_DEVERROR(STM32_TRACEERR_ALLOCFAIL), 0);

--- a/arch/arm/src/stm32f0l0g0/stm32_usbdev.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_usbdev.c
@@ -2921,7 +2921,7 @@ static struct usbdev_req_s *stm32_epallocreq(struct usbdev_ep_s *ep)
 #endif
   usbtrace(TRACE_EPALLOCREQ, USB_EPNO(ep->eplog));
 
-  privreq = (struct stm32_req_s *)kmm_malloc(sizeof(struct stm32_req_s));
+  privreq = kmm_malloc(sizeof(struct stm32_req_s));
   if (!privreq)
     {
       usbtrace(TRACE_DEVERROR(STM32_TRACEERR_ALLOCFAIL), 0);

--- a/arch/arm/src/stm32f7/stm32_otgdev.c
+++ b/arch/arm/src/stm32f7/stm32_otgdev.c
@@ -4434,7 +4434,7 @@ static struct usbdev_req_s *stm32_ep_allocreq(struct usbdev_ep_s *ep)
 
   usbtrace(TRACE_EPALLOCREQ, ((struct stm32_ep_s *)ep)->epphy);
 
-  privreq = (struct stm32_req_s *)kmm_malloc(sizeof(struct stm32_req_s));
+  privreq = kmm_malloc(sizeof(struct stm32_req_s));
   if (!privreq)
     {
       usbtrace(TRACE_DEVERROR(STM32_TRACEERR_ALLOCFAIL), 0);

--- a/arch/arm/src/stm32f7/stm32_otghost.c
+++ b/arch/arm/src/stm32f7/stm32_otghost.c
@@ -4243,7 +4243,7 @@ static int stm32_alloc(struct usbhost_driver_s *drvr,
 
   /* There is no special memory requirement for the STM32. */
 
-  alloc = (uint8_t *)kmm_malloc(CONFIG_STM32F7_OTG_DESCSIZE);
+  alloc = kmm_malloc(CONFIG_STM32F7_OTG_DESCSIZE);
   if (!alloc)
     {
       return -ENOMEM;
@@ -4327,7 +4327,7 @@ static int stm32_ioalloc(struct usbhost_driver_s *drvr,
 
   /* There is no special memory requirement */
 
-  alloc = (uint8_t *)kmm_malloc(buflen);
+  alloc = kmm_malloc(buflen);
   if (!alloc)
     {
       return -ENOMEM;

--- a/arch/arm/src/stm32h7/stm32_otgdev.c
+++ b/arch/arm/src/stm32h7/stm32_otgdev.c
@@ -4373,7 +4373,7 @@ static struct usbdev_req_s *stm32_ep_allocreq(struct usbdev_ep_s *ep)
 
   usbtrace(TRACE_EPALLOCREQ, ((struct stm32_ep_s *)ep)->epphy);
 
-  privreq = (struct stm32_req_s *)kmm_malloc(sizeof(struct stm32_req_s));
+  privreq = kmm_malloc(sizeof(struct stm32_req_s));
   if (!privreq)
     {
       usbtrace(TRACE_DEVERROR(STM32_TRACEERR_ALLOCFAIL), 0);

--- a/arch/arm/src/stm32h7/stm32_otghost.c
+++ b/arch/arm/src/stm32h7/stm32_otghost.c
@@ -4272,7 +4272,7 @@ static int stm32_alloc(struct usbhost_driver_s *drvr,
 
   /* There is no special memory requirement for the STM32. */
 
-  alloc = (uint8_t *)kmm_malloc(CONFIG_STM32H7_OTG_DESCSIZE);
+  alloc = kmm_malloc(CONFIG_STM32H7_OTG_DESCSIZE);
   if (!alloc)
     {
       return -ENOMEM;
@@ -4356,7 +4356,7 @@ static int stm32_ioalloc(struct usbhost_driver_s *drvr,
 
   /* There is no special memory requirement */
 
-  alloc = (uint8_t *)kmm_malloc(buflen);
+  alloc = kmm_malloc(buflen);
   if (!alloc)
     {
       return -ENOMEM;

--- a/arch/arm/src/stm32l4/stm32l4_otgfshost.c
+++ b/arch/arm/src/stm32l4/stm32l4_otgfshost.c
@@ -4272,7 +4272,7 @@ static int stm32l4_alloc(struct usbhost_driver_s *drvr,
 
   /* There is no special memory requirement for the STM32. */
 
-  alloc = (uint8_t *)kmm_malloc(CONFIG_STM32L4_OTGFS_DESCSIZE);
+  alloc = kmm_malloc(CONFIG_STM32L4_OTGFS_DESCSIZE);
   if (!alloc)
     {
       return -ENOMEM;
@@ -4359,7 +4359,7 @@ static int stm32l4_ioalloc(struct usbhost_driver_s *drvr,
 
   /* There is no special memory requirement */
 
-  alloc = (uint8_t *)kmm_malloc(buflen);
+  alloc = kmm_malloc(buflen);
   if (!alloc)
     {
       return -ENOMEM;

--- a/arch/arm/src/stm32l4/stm32l4_usbdev.c
+++ b/arch/arm/src/stm32l4/stm32l4_usbdev.c
@@ -2956,7 +2956,7 @@ static struct usbdev_req_s *stm32l4_epallocreq(struct usbdev_ep_s *ep)
 
   usbtrace(TRACE_EPALLOCREQ, USB_EPNO(ep->eplog));
 
-  privreq = (struct stm32l4_req_s *)kmm_malloc(sizeof(struct stm32l4_req_s));
+  privreq = kmm_malloc(sizeof(struct stm32l4_req_s));
   if (!privreq)
     {
       usbtrace(TRACE_DEVERROR(STM32L4_TRACEERR_ALLOCFAIL), 0);

--- a/arch/arm/src/xmc4/xmc4_spi.c
+++ b/arch/arm/src/xmc4/xmc4_spi.c
@@ -1793,7 +1793,7 @@ struct spi_dev_s *xmc4_spibus_initialize(int channel)
    * chip select structures.
    */
 
-  spics = (struct xmc4_spics_s *)kmm_zalloc(sizeof(struct xmc4_spics_s));
+  spics = kmm_zalloc(sizeof(struct xmc4_spics_s));
   if (!spics)
     {
       spierr("ERROR: Failed to allocate a chip select structure\n");

--- a/arch/arm64/src/common/arm64_fpu.c
+++ b/arch/arm64/src/common/arm64_fpu.c
@@ -171,8 +171,7 @@ static int arm64_fpu_procfs_open(struct file *filep, const char *relpath,
 
   /* Allocate the open file structure */
 
-  priv = (struct arm64_fpu_procfs_file_s *)kmm_zalloc(
-    sizeof(struct arm64_fpu_procfs_file_s));
+  priv = kmm_zalloc(sizeof(struct arm64_fpu_procfs_file_s));
   if (priv == NULL)
     {
       uerr("ERROR: Failed to allocate file attributes\n");

--- a/arch/avr/src/at90usb/at90usb_usbdev.c
+++ b/arch/avr/src/at90usb/at90usb_usbdev.c
@@ -2325,7 +2325,7 @@ static FAR struct usbdev_req_s *avr_epallocreq(FAR struct usbdev_ep_s *ep)
 
   usbtrace(TRACE_EPALLOCREQ, ((FAR struct avr_ep_s *)ep)->ep.eplog);
 
-  privreq = (FAR struct avr_req_s *)kmm_malloc(sizeof(struct avr_req_s));
+  privreq = kmm_malloc(sizeof(struct avr_req_s));
   if (!privreq)
     {
       usbtrace(TRACE_DEVERROR(AVR_TRACEERR_ALLOCFAIL), 0);

--- a/arch/mips/src/pic32mx/pic32mx_usbdev.c
+++ b/arch/mips/src/pic32mx/pic32mx_usbdev.c
@@ -3365,7 +3365,7 @@ static struct usbdev_req_s *pic32mx_epallocreq(struct usbdev_ep_s *ep)
 
   usbtrace(TRACE_EPALLOCREQ, USB_EPNO(ep->eplog));
 
-  privreq = (struct pic32mx_req_s *)kmm_malloc(sizeof(struct pic32mx_req_s));
+  privreq = kmm_malloc(sizeof(struct pic32mx_req_s));
   if (!privreq)
     {
       usbtrace(TRACE_DEVERROR(PIC32MX_TRACEERR_ALLOCFAIL), 0);

--- a/arch/renesas/src/rx65n/rx65n_usbdev.c
+++ b/arch/renesas/src/rx65n/rx65n_usbdev.c
@@ -3025,7 +3025,7 @@ static struct usbdev_req_s *rx65n_epallocreq(struct usbdev_ep_s *ep)
 #endif
   usbtrace(TRACE_EPALLOCREQ, USB_EPNO(ep->eplog));
 
-  privreq = (struct rx65n_req_s *)kmm_malloc(sizeof(struct rx65n_req_s));
+  privreq = kmm_malloc(sizeof(struct rx65n_req_s));
   if (!privreq)
     {
       usbtrace(TRACE_DEVERROR(RX65N_TRACEERR_ALLOCFAIL), 0);

--- a/arch/renesas/src/rx65n/rx65n_usbhost.c
+++ b/arch/renesas/src/rx65n/rx65n_usbhost.c
@@ -6980,7 +6980,7 @@ static int rx65n_usbhost_ioalloc(struct usbhost_driver_s *drvr,
 
   /* There is no special memory requirement */
 
-  alloc = (uint8_t *)kmm_malloc(buflen);
+  alloc = kmm_malloc(buflen);
   if (!alloc)
     {
       return -ENOMEM;

--- a/arch/risc-v/src/bl602/bl602_oneshot_lowerhalf.c
+++ b/arch/risc-v/src/bl602/bl602_oneshot_lowerhalf.c
@@ -366,9 +366,7 @@ struct oneshot_lowerhalf_s *oneshot_initialize(int      chan,
 
   /* Allocate an instance of the lower half driver */
 
-  priv = (struct bl602_oneshot_lowerhalf_s *)kmm_zalloc(
-    sizeof(struct bl602_oneshot_lowerhalf_s));
-
+  priv = kmm_zalloc(sizeof(struct bl602_oneshot_lowerhalf_s));
   if (priv == NULL)
     {
       tmrerr("ERROR: Failed to initialized state structure\n");

--- a/arch/risc-v/src/bl602/bl602_os_hal.c
+++ b/arch/risc-v/src/bl602/bl602_os_hal.c
@@ -688,8 +688,7 @@ void *bl_os_mq_creat(uint32_t queue_len, uint32_t item_size)
   struct mq_adpt *mq_adpt;
   int ret;
 
-  mq_adpt = (struct mq_adpt *)kmm_malloc(sizeof(struct mq_adpt));
-
+  mq_adpt = kmm_malloc(sizeof(struct mq_adpt));
   if (!mq_adpt)
     {
       wlerr("ERROR: Failed to kmm_malloc\n");
@@ -931,10 +930,7 @@ static void bl_os_timer_callback(wdparm_t arg)
 
 void *bl_os_timer_create(void *func, void *argv)
 {
-  struct timer_adpt *timer;
-
-  timer = (struct timer_adpt *)kmm_malloc(sizeof(struct timer_adpt));
-
+  struct timer_adpt *timer = kmm_malloc(sizeof(struct timer_adpt));
   if (!timer)
     {
       assert(0);
@@ -1067,9 +1063,7 @@ int bl_os_timer_start_periodic(void *timerid, long t_sec, long t_nsec)
 
 void *bl_os_workqueue_create(void)
 {
-  struct work_s *work = NULL;
-  work = (struct work_s *)kmm_calloc(1, sizeof(struct work_s));
-
+  struct work_s *work = kmm_calloc(1, sizeof(struct work_s));
   if (!work)
     {
       assert(0);
@@ -1215,7 +1209,7 @@ void bl_os_irq_attach(int32_t n, void *f, void *arg)
 
   wlinfo("INFO: n=%ld f=%p arg=%p\n", n, f, arg);
 
-  adapter = (struct irq_adpt *)kmm_malloc(sizeof(struct irq_adpt));
+  adapter = kmm_malloc(sizeof(struct irq_adpt));
 
   if (!adapter)
     {
@@ -1286,7 +1280,7 @@ void *bl_os_mutex_create(void)
   int tmp;
 
   tmp = sizeof(mutex_t);
-  mutex = (mutex_t *)kmm_malloc(tmp);
+  mutex = kmm_malloc(tmp);
   if (!mutex)
     {
       wlerr("ERROR: Failed to alloc %d memory\n", tmp);
@@ -1404,7 +1398,7 @@ void *bl_os_sem_create(uint32_t init)
   int tmp;
 
   tmp = sizeof(sem_t);
-  sem = (sem_t *)kmm_malloc(tmp);
+  sem = kmm_malloc(tmp);
   if (!sem)
     {
       wlerr("ERROR: Failed to alloc %d memory\n", tmp);

--- a/arch/risc-v/src/common/riscv_addrenv_kstack.c
+++ b/arch/risc-v/src/common/riscv_addrenv_kstack.c
@@ -65,8 +65,7 @@ int up_addrenv_kstackalloc(struct tcb_s *tcb)
 
   /* Allocate the kernel stack */
 
-  tcb->xcp.kstack = (uintptr_t *)kmm_memalign(STACK_ALIGNMENT,
-                                              ARCH_KERNEL_STACKSIZE);
+  tcb->xcp.kstack = kmm_memalign(STACK_ALIGNMENT, ARCH_KERNEL_STACKSIZE);
   if (!tcb->xcp.kstack)
     {
       berr("ERROR: Failed to allocate the kernel stack\n");

--- a/arch/risc-v/src/esp32c3/esp32c3_bignum.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_bignum.c
@@ -1296,7 +1296,7 @@ int esp32c3_mpi_grow(struct esp32c3_mpi_s *X, size_t nblimbs)
 
   if (X->n < nblimbs)
     {
-      if ((p = (uint32_t *)calloc(nblimbs, CIL)) == NULL)
+      if ((p = calloc(nblimbs, CIL)) == NULL)
         {
           return ESP32C3_ERR_MPI_ALLOC_FAILED;
         }
@@ -1365,7 +1365,7 @@ int esp32c3_mpi_shrink(struct esp32c3_mpi_s *X, size_t nblimbs)
       i = nblimbs;
     }
 
-  if ((p = (uint32_t *)calloc(i, CIL)) == NULL)
+  if ((p = calloc(i, CIL)) == NULL)
     {
       return ESP32C3_ERR_MPI_ALLOC_FAILED;
     }

--- a/arch/risc-v/src/esp32c3/esp32c3_oneshot_lowerhalf.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_oneshot_lowerhalf.c
@@ -348,9 +348,7 @@ struct oneshot_lowerhalf_s *oneshot_initialize(int chan,
 
   /* Allocate an instance of the lower half driver */
 
-  priv = (struct esp32c3_oneshot_lowerhalf_s *)kmm_zalloc(
-          sizeof(struct esp32c3_oneshot_lowerhalf_s));
-
+  priv = kmm_zalloc(sizeof(struct esp32c3_oneshot_lowerhalf_s));
   if (priv == NULL)
     {
       tmrerr("ERROR: Failed to initialize oneshot state structure\n");

--- a/arch/risc-v/src/esp32c3/esp32c3_rt_timer.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_rt_timer.c
@@ -516,7 +516,7 @@ int rt_timer_create(const struct rt_timer_args_s *args,
 {
   struct rt_timer_s *timer;
 
-  timer = (struct rt_timer_s *)kmm_malloc(sizeof(*timer));
+  timer = kmm_malloc(sizeof(*timer));
   if (!timer)
     {
       tmrerr("ERROR: Failed to allocate %d bytes\n", sizeof(*timer));

--- a/arch/risc-v/src/espressif/esp_hr_timer.c
+++ b/arch/risc-v/src/espressif/esp_hr_timer.c
@@ -315,7 +315,7 @@ int esp_hr_timer_create(const struct esp_hr_timer_args_s *args,
 {
   struct esp_hr_timer_s *timer;
 
-  timer = (struct esp_hr_timer_s *)kmm_malloc(sizeof(*timer));
+  timer = kmm_malloc(sizeof(*timer));
   if (timer == NULL)
     {
       tmrerr("Failed to allocate %d bytes\n", sizeof(*timer));

--- a/arch/risc-v/src/mpfs/mpfs_ethernet.c
+++ b/arch/risc-v/src/mpfs/mpfs_ethernet.c
@@ -2708,7 +2708,7 @@ static int mpfs_buffer_initialize(struct mpfs_ethmac_s *priv,
   memset(priv->queue[queue].rx_desc_tab, 0, allocsize);
 
   allocsize = CONFIG_MPFS_ETHMAC_NTXBUFFERS * GMAC_TX_UNITSIZE;
-  priv->queue[queue].txbuffer = (uint8_t *)kmm_memalign(8, allocsize);
+  priv->queue[queue].txbuffer = kmm_memalign(8, allocsize);
   if (priv->queue[queue].txbuffer == NULL)
     {
       nerr("ERROR: Failed to allocate TX buffer\n");
@@ -2717,7 +2717,7 @@ static int mpfs_buffer_initialize(struct mpfs_ethmac_s *priv,
     }
 
   allocsize = CONFIG_MPFS_ETHMAC_NRXBUFFERS * GMAC_RX_UNITSIZE;
-  priv->queue[queue].rxbuffer = (uint8_t *)kmm_memalign(8, allocsize);
+  priv->queue[queue].rxbuffer = kmm_memalign(8, allocsize);
   if (priv->queue[queue].rxbuffer == NULL)
     {
       nerr("ERROR: Failed to allocate RX buffer\n");

--- a/arch/risc-v/src/mpfs/mpfs_usb.c
+++ b/arch/risc-v/src/mpfs/mpfs_usb.c
@@ -1660,7 +1660,7 @@ static struct usbdev_req_s *mpfs_ep_allocreq(struct usbdev_ep_s *ep)
 {
   struct mpfs_req_s *privreq;
 
-  privreq = (struct mpfs_req_s *)kmm_malloc(sizeof(struct mpfs_req_s));
+  privreq = kmm_malloc(sizeof(struct mpfs_req_s));
   if (privreq == NULL)
     {
       usbtrace(TRACE_DEVERROR(MPFS_TRACEERR_ALLOCFAIL), 0);

--- a/arch/risc-v/src/rv32m1/rv32m1_gpio.c
+++ b/arch/risc-v/src/rv32m1/rv32m1_gpio.c
@@ -661,7 +661,7 @@ int rv32m1_gpio_irqattach(uint32_t cfgset, xcpt_t isr, void *arg)
       e = sq_next(e);
     }
 
-  priv = (struct rv32m1_isr_s *)kmm_malloc(sizeof(*priv));
+  priv = kmm_malloc(sizeof(*priv));
   if (priv)
     {
       /* If it is the first time to attach an isr, the generic gpio

--- a/arch/sim/src/sim/posix/sim_linuxi2c.c
+++ b/arch/sim/src/sim/posix/sim_linuxi2c.c
@@ -269,7 +269,7 @@ struct i2c_master_s *sim_i2cbus_initialize(int bus)
   struct linux_i2cbus_master_s *priv;
   char filename[20];
 
-  priv = (struct linux_i2cbus_master_s *)malloc(sizeof(*priv));
+  priv = malloc(sizeof(*priv));
   if (priv == NULL)
     {
       ERROR("Failed to allocate private i2c master driver");

--- a/arch/sim/src/sim/posix/sim_linuxspi.c
+++ b/arch/sim/src/sim/posix/sim_linuxspi.c
@@ -702,7 +702,7 @@ struct spi_dev_s *sim_spi_initialize(const char *filename)
 {
   struct linux_spi_dev_s *priv;
 
-  priv = (struct linux_spi_dev_s *)malloc(sizeof(*priv));
+  priv = malloc(sizeof(*priv));
   if (priv == NULL)
     {
       ERROR("Failed to allocate private spi master driver");

--- a/arch/sim/src/sim/posix/sim_rawgadget.c
+++ b/arch/sim/src/sim/posix/sim_rawgadget.c
@@ -231,7 +231,7 @@ static void host_raw_fifocreate(struct usb_raw_fifo_s *fifo,
   fifo->read = 0;
   fifo->elem_size = elem_size;
   fifo->elem_num = elem_num;
-  fifo->elems = (uint8_t *)malloc(elem_size * elem_num);
+  fifo->elems = malloc(elem_size * elem_num);
 }
 
 static void host_raw_fifodelete(struct usb_raw_fifo_s *fifo)

--- a/arch/sim/src/sim/posix/sim_x11framebuffer.c
+++ b/arch/sim/src/sim/posix/sim_x11framebuffer.c
@@ -322,7 +322,7 @@ shmerror:
 #endif
       b_useshm = 0;
 
-      g_framebuffer = (unsigned char *)malloc(fblen);
+      g_framebuffer = malloc(fblen);
 
       g_image = XCreateImage(display, DefaultVisual(display, g_screen),
                              depth, ZPixmap, 0, (char *)g_framebuffer,

--- a/arch/sim/src/sim/sim_deviceimage.c
+++ b/arch/sim/src/sim/sim_deviceimage.c
@@ -296,7 +296,7 @@ char *sim_deviceimage(void)
    * reallocate this a few times to get the size right.
    */
 
-  pbuffer = (char *)kmm_malloc(bufsize);
+  pbuffer = kmm_malloc(bufsize);
 
   /* Set up the input buffer */
 

--- a/arch/sim/src/sim/sim_hcisocket.c
+++ b/arch/sim/src/sim/sim_hcisocket.c
@@ -180,7 +180,7 @@ static struct bthcisock_s *bthcisock_alloc(int dev_id)
   struct bthcisock_s *dev;
   struct bt_driver_s *drv;
 
-  dev = (struct bthcisock_s *)kmm_zalloc(sizeof(*dev));
+  dev = kmm_zalloc(sizeof(*dev));
   if (dev == NULL)
     {
       return NULL;

--- a/arch/sim/src/sim/sim_usbdev.c
+++ b/arch/sim/src/sim/sim_usbdev.c
@@ -660,7 +660,7 @@ static struct usbdev_req_s *sim_ep_allocreq(struct usbdev_ep_s *ep)
 
   usbtrace(TRACE_EPALLOCREQ, USB_EPNO(ep->eplog));
 
-  privreq = (struct sim_req_s *)kmm_malloc(sizeof(struct sim_req_s));
+  privreq = kmm_malloc(sizeof(struct sim_req_s));
   if (!privreq)
     {
       usbtrace(TRACE_DEVERROR(SIM_TRACEERR_ALLOCFAIL), 0);

--- a/arch/sim/src/sim/sim_usbhost.c
+++ b/arch/sim/src/sim/sim_usbhost.c
@@ -386,7 +386,7 @@ static int sim_usbhost_epalloc(FAR struct usbhost_driver_s *drvr,
 
   /* Allocate a endpoint information structure */
 
-  epinfo = (struct sim_epinfo_s *)kmm_zalloc(sizeof(struct sim_epinfo_s));
+  epinfo = kmm_zalloc(sizeof(struct sim_epinfo_s));
   if (!epinfo)
     {
       return -ENOMEM;
@@ -443,7 +443,7 @@ static int sim_usbhost_alloc(FAR struct usbhost_driver_s *drvr,
 {
   DEBUGASSERT(drvr && buffer && maxlen);
 
-  *buffer = (uint8_t *)kmm_malloc(SIM_USBHOST_BUFSIZE);
+  *buffer = kmm_malloc(SIM_USBHOST_BUFSIZE);
   if (*buffer)
     {
       *maxlen = SIM_USBHOST_BUFSIZE;
@@ -475,7 +475,7 @@ static int sim_usbhost_ioalloc(FAR struct usbhost_driver_s *drvr,
 {
   DEBUGASSERT(drvr && buffer && buflen > 0);
 
-  *buffer = (uint8_t *)kumm_malloc(buflen);
+  *buffer = kumm_malloc(buflen);
   return *buffer ? OK : -ENOMEM;
 }
 

--- a/arch/xtensa/src/common/xtensa_oneshot.c
+++ b/arch/xtensa/src/common/xtensa_oneshot.c
@@ -182,8 +182,7 @@ static int xtensa_oneshot_interrupt(int irq, void *context, void *arg)
 struct oneshot_lowerhalf_s *
 xtensa_oneshot_initialize(uint32_t irq, uint32_t freq)
 {
-  struct xoneshot_lowerhalf_s *lower =
-      (struct xoneshot_lowerhalf_s *)kmm_zalloc(sizeof(*lower));
+  struct xoneshot_lowerhalf_s *lower = kmm_zalloc(sizeof(*lower));
 
   if (lower == NULL)
     {

--- a/arch/xtensa/src/esp32/esp32_himem_chardev.c
+++ b/arch/xtensa/src/esp32/esp32_himem_chardev.c
@@ -70,9 +70,9 @@ static struct file *g_mapped_filep; /* for multi device */
 
 static int himem_chardev_open(struct file *filep)
 {
-  struct himem_chardev_priv_s *priv;
+  struct himem_chardev_priv_s *priv =
+    kmm_malloc(sizeof(struct himem_chardev_priv_s));
 
-  priv = kmm_malloc(sizeof(struct himem_chardev_priv_s));
   if (priv == NULL)
     {
        merr("Failed to malloc.\n");
@@ -296,8 +296,8 @@ int himem_chardev_exit(void)
 int himem_chardev_register(char *name, size_t size)
 {
   int ret = 0;
-  struct himem_chardev_s *dev;
-  dev = (struct himem_chardev_s *)kmm_malloc(sizeof(struct himem_chardev_s));
+  struct himem_chardev_s *dev =
+    kmm_malloc(sizeof(struct himem_chardev_s));
   if (dev == NULL)
     {
       merr("Failed to malloc.\n");

--- a/arch/xtensa/src/esp32/esp32_oneshot_lowerhalf.c
+++ b/arch/xtensa/src/esp32/esp32_oneshot_lowerhalf.c
@@ -348,9 +348,7 @@ struct oneshot_lowerhalf_s *oneshot_initialize(int chan,
 
   /* Allocate an instance of the lower half driver */
 
-  priv = (struct esp32_oneshot_lowerhalf_s *)kmm_zalloc(
-          sizeof(struct esp32_oneshot_lowerhalf_s));
-
+  priv = kmm_zalloc(sizeof(struct esp32_oneshot_lowerhalf_s));
   if (priv == NULL)
     {
       tmrerr("ERROR: Failed to initialize oneshot state structure\n");

--- a/arch/xtensa/src/esp32/esp32_rmt.c
+++ b/arch/xtensa/src/esp32/esp32_rmt.c
@@ -358,11 +358,8 @@ struct rmt_dev_s *esp32_rmtinitialize(void)
   rmt_reset(rmtdev);
   rmt_setup(rmtdev);
 
-  rmtdev->channels = kmm_zalloc(
-    sizeof(struct rmt_dev_channel_s)*
-    RMT_NUMBER_OF_CHANNELS
-  );
-
+  rmtdev->channels = kmm_zalloc(sizeof(struct rmt_dev_channel_s) *
+                                RMT_NUMBER_OF_CHANNELS);
   if (!rmtdev->channels)
     {
       rmterr("Failed to allocate memory for RMT Channels");

--- a/arch/xtensa/src/esp32/esp32_rt_timer.c
+++ b/arch/xtensa/src/esp32/esp32_rt_timer.c
@@ -477,7 +477,7 @@ int rt_timer_create(const struct rt_timer_args_s *args,
 {
   struct rt_timer_s *timer;
 
-  timer = (struct rt_timer_s *)kmm_malloc(sizeof(*timer));
+  timer = kmm_malloc(sizeof(*timer));
   if (!timer)
     {
       tmrerr("ERROR: Failed to allocate %d bytes\n", sizeof(*timer));

--- a/arch/xtensa/src/esp32/esp32_touch.c
+++ b/arch/xtensa/src/esp32/esp32_touch.c
@@ -232,7 +232,7 @@ static void touch_init(void)
 {
   if (touch_mux == NULL)
     {
-      touch_mux = (mutex_t *) kmm_zalloc(sizeof(mutex_t));
+      touch_mux = kmm_zalloc(sizeof(mutex_t));
 
       if (touch_mux == NULL)
         {

--- a/arch/xtensa/src/esp32/esp32_wireless.c
+++ b/arch/xtensa/src/esp32/esp32_wireless.c
@@ -619,7 +619,7 @@ static int phy_update_init_data(phy_init_data_type_t init_data_type)
   int ret;
   size_t length = sizeof(phy_init_magic_pre) +
       sizeof(esp_phy_init_data_t) + sizeof(phy_init_magic_post);
-  uint8_t *init_data_store = (uint8_t *)kmm_malloc(length);
+  uint8_t *init_data_store = kmm_malloc(length);
   if (init_data_store == NULL)
     {
       wlerr("ERROR: Failed to allocate memory for updated country code "
@@ -710,7 +710,7 @@ const esp_phy_init_data_t *esp_phy_get_init_data(void)
   int ret;
   size_t length = sizeof(phy_init_magic_pre) +
           sizeof(esp_phy_init_data_t) + sizeof(phy_init_magic_post);
-  uint8_t *init_data_store = (uint8_t *)kmm_malloc(length);
+  uint8_t *init_data_store = kmm_malloc(length);
   if (init_data_store == NULL)
     {
       wlerr("ERROR: Failed to allocate memory for PHY init data\n");

--- a/arch/xtensa/src/esp32/esp32_wlan.c
+++ b/arch/xtensa/src/esp32/esp32_wlan.c
@@ -416,8 +416,7 @@ static inline struct wlan_pktbuf *wlan_alloc_buffer(struct wlan_priv_s *priv)
       return NULL;
     }
 
-  pktbuf = (struct wlan_pktbuf *)kmm_malloc(
-            sizeof(struct wlan_pktbuf) + WLAN_BUF_SIZE);
+  pktbuf = kmm_malloc(sizeof(struct wlan_pktbuf) + WLAN_BUF_SIZE);
 #else
   sq_entry_t *entry;
   irqstate_t flags = spin_lock_irqsave(&priv->lock);

--- a/arch/xtensa/src/esp32s2/esp32s2_i2s.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_i2s.c
@@ -735,7 +735,7 @@ static int i2s_txdma_setup(struct esp32s2_i2s_s *priv,
    * carried from the last upper half audio buffer.
    */
 
-  bfcontainer->buf = (uint8_t *)calloc(bfcontainer->nbytes, 1);
+  bfcontainer->buf = calloc(bfcontainer->nbytes, 1);
 
   data_copied = 0;
   buf = bfcontainer->buf;

--- a/arch/xtensa/src/esp32s2/esp32s2_oneshot_lowerhalf.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_oneshot_lowerhalf.c
@@ -348,9 +348,7 @@ struct oneshot_lowerhalf_s *oneshot_initialize(int chan,
 
   /* Allocate an instance of the lower half driver */
 
-  priv = (struct esp32s2_oneshot_lowerhalf_s *)kmm_zalloc(
-          sizeof(struct esp32s2_oneshot_lowerhalf_s));
-
+  priv = kmm_zalloc(sizeof(struct esp32s2_oneshot_lowerhalf_s));
   if (priv == NULL)
     {
       tmrerr("ERROR: Failed to initialize oneshot state structure\n");

--- a/arch/xtensa/src/esp32s2/esp32s2_rt_timer.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_rt_timer.c
@@ -527,7 +527,7 @@ int rt_timer_create(const struct rt_timer_args_s *args,
 {
   struct rt_timer_s *timer;
 
-  timer = (struct rt_timer_s *)kmm_malloc(sizeof(*timer));
+  timer = kmm_malloc(sizeof(*timer));
   if (!timer)
     {
       tmrerr("ERROR: Failed to allocate %d bytes\n", sizeof(*timer));

--- a/arch/xtensa/src/esp32s2/esp32s2_touch.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_touch.c
@@ -254,7 +254,7 @@ static void touch_init(struct touch_config_s *config)
       return;
     }
 
-  touch_mux = (mutex_t *) kmm_zalloc(sizeof(mutex_t));
+  touch_mux = kmm_zalloc(sizeof(mutex_t));
 
   if (touch_mux == NULL)
     {

--- a/arch/xtensa/src/esp32s3/esp32s3_ble_adapter.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_ble_adapter.c
@@ -2207,7 +2207,7 @@ int esp32s3_bt_controller_init(void)
 
   btdm_controller_mem_init();
 
-  osi_funcs_p = (struct osi_funcs_s *)kmm_malloc(sizeof(struct osi_funcs_s));
+  osi_funcs_p = kmm_malloc(sizeof(struct osi_funcs_s));
   if (osi_funcs_p == NULL)
     {
       return -ENOMEM;

--- a/arch/xtensa/src/esp32s3/esp32s3_oneshot_lowerhalf.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_oneshot_lowerhalf.c
@@ -344,9 +344,7 @@ struct oneshot_lowerhalf_s *oneshot_initialize(int chan, uint16_t resolution)
 
   /* Allocate an instance of the lower-half driver */
 
-  priv = (struct esp32s3_oneshot_lowerhalf_s *)kmm_zalloc(
-          sizeof(struct esp32s3_oneshot_lowerhalf_s));
-
+  priv = kmm_zalloc(sizeof(struct esp32s3_oneshot_lowerhalf_s));
   if (priv == NULL)
     {
       tmrerr("Failed to allocate oneshot state structure\n");

--- a/arch/xtensa/src/esp32s3/esp32s3_otg_device.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_otg_device.c
@@ -4381,7 +4381,7 @@ static struct usbdev_req_s *esp32s3_ep_allocreq(struct usbdev_ep_s *ep)
 
   usbtrace(TRACE_EPALLOCREQ, ((struct esp32s3_ep_s *)ep)->epphy);
 
-  privreq = (struct esp32s3_req_s *)kmm_zalloc(sizeof(struct esp32s3_req_s));
+  privreq = kmm_zalloc(sizeof(struct esp32s3_req_s));
   if (!privreq)
     {
       usbtrace(TRACE_DEVERROR(ESP32S3_TRACEERR_ALLOCFAIL), 0);

--- a/arch/xtensa/src/esp32s3/esp32s3_rt_timer.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_rt_timer.c
@@ -716,7 +716,7 @@ int esp32s3_rt_timer_create(const struct rt_timer_args_s *args,
   DEBUGASSERT(args != NULL);
   DEBUGASSERT(args->callback != NULL);
 
-  timer = (struct rt_timer_s *)kmm_malloc(sizeof(*timer));
+  timer = kmm_malloc(sizeof(*timer));
   if (timer == NULL)
     {
       tmrerr("ERROR: Failed to allocate %d bytes\n", sizeof(*timer));

--- a/arch/xtensa/src/esp32s3/esp32s3_touch.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_touch.c
@@ -205,7 +205,7 @@ static void touch_init(struct touch_config_s *config)
       return;
     }
 
-  touch_mux = (mutex_t *) kmm_zalloc(sizeof(mutex_t));
+  touch_mux = kmm_zalloc(sizeof(mutex_t));
 
   if (touch_mux == NULL)
     {

--- a/arch/z80/src/z8/z8_i2c.c
+++ b/arch/z80/src/z8/z8_i2c.c
@@ -638,7 +638,7 @@ FAR struct i2c_master_s *z8_i2cbus_initialize(int port)
 
   /* Now, allocate an I2C instance for this caller */
 
-  i2c = (FAR struct z8_i2cdev_s *)kmm_zalloc(sizeof(FAR struct z8_i2cdev_s));
+  i2c = kmm_zalloc(sizeof(struct z8_i2cdev_s));
   if (i2c)
     {
       /* Initialize the allocated instance */

--- a/audio/audio.c
+++ b/audio/audio.c
@@ -930,8 +930,7 @@ int audio_register(FAR const char *name, FAR struct audio_lowerhalf_s *dev)
 
   /* Allocate the upper-half data structure */
 
-  upper = (FAR struct audio_upperhalf_s *)kmm_zalloc(
-                                           sizeof(struct audio_upperhalf_s));
+  upper = kmm_zalloc(sizeof(struct audio_upperhalf_s));
   if (!upper)
     {
       auderr("ERROR: Allocation failed\n");

--- a/audio/pcm_decode.c
+++ b/audio/pcm_decode.c
@@ -1388,7 +1388,7 @@ FAR struct audio_lowerhalf_s *
 
   /* Allocate an instance of our private data structure */
 
-  priv = (FAR struct pcm_decode_s *)kmm_zalloc(sizeof(struct pcm_decode_s));
+  priv = kmm_zalloc(sizeof(struct pcm_decode_s));
   if (!priv)
     {
       auderr("ERROR: Failed to allocate driver structure\n");

--- a/binfmt/binfmt_copyargv.c
+++ b/binfmt/binfmt_copyargv.c
@@ -108,7 +108,7 @@ int binfmt_copyargv(FAR char * const **copy, FAR char * const *argv)
       if (argsize > 0)
         {
           argvsize = (nargs + 1) * sizeof(FAR char *);
-          ptr      = (FAR char *)kmm_malloc(argvsize + argsize);
+          ptr      = kmm_malloc(argvsize + argsize);
           if (!ptr)
             {
               berr("ERROR: Failed to allocate the argument buffer\n");

--- a/binfmt/binfmt_exec.c
+++ b/binfmt/binfmt_exec.c
@@ -83,7 +83,7 @@ int exec_spawn(FAR const char *filename, FAR char * const *argv,
 
   /* Allocate the load information */
 
-  bin = (FAR struct binary_s *)kmm_zalloc(sizeof(struct binary_s));
+  bin = kmm_zalloc(sizeof(struct binary_s));
   if (!bin)
     {
       berr("ERROR: Failed to allocate binary_s\n");

--- a/binfmt/binfmt_execmodule.c
+++ b/binfmt/binfmt_execmodule.c
@@ -140,7 +140,7 @@ int exec_module(FAR struct binary_s *binp,
 
   /* Allocate a TCB for the new task. */
 
-  tcb = (FAR struct task_tcb_s *)kmm_zalloc(sizeof(struct task_tcb_s));
+  tcb = kmm_zalloc(sizeof(struct task_tcb_s));
   if (!tcb)
     {
       return -ENOMEM;

--- a/binfmt/libelf/libelf_ctors.c
+++ b/binfmt/libelf/libelf_ctors.c
@@ -138,7 +138,7 @@ int elf_loadctors(FAR struct elf_loadinfo_s *loadinfo)
         {
           /* Allocate memory to hold a copy of the .ctor section */
 
-          loadinfo->ctoralloc = (binfmt_ctor_t *)kumm_malloc(ctorsize);
+          loadinfo->ctoralloc = kumm_malloc(ctorsize);
           if (!loadinfo->ctoralloc)
             {
               berr("Failed to allocate memory for .ctors\n");

--- a/binfmt/libelf/libelf_dtors.c
+++ b/binfmt/libelf/libelf_dtors.c
@@ -139,7 +139,7 @@ int elf_loaddtors(FAR struct elf_loadinfo_s *loadinfo)
         {
           /* Allocate memory to hold a copy of the .dtor section */
 
-          loadinfo->dtoralloc = (binfmt_dtor_t *)kumm_malloc(dtorsize);
+          loadinfo->dtoralloc = kumm_malloc(dtorsize);
           if (!loadinfo->dtoralloc)
             {
               berr("Failed to allocate memory for .dtors\n");

--- a/binfmt/libelf/libelf_iobuffer.c
+++ b/binfmt/libelf/libelf_iobuffer.c
@@ -69,7 +69,7 @@ int elf_allocbuffer(FAR struct elf_loadinfo_s *loadinfo)
     {
       /* No.. allocate one now */
 
-      loadinfo->iobuffer = (FAR uint8_t *)kmm_malloc(CONFIG_ELF_BUFFERSIZE);
+      loadinfo->iobuffer = kmm_malloc(CONFIG_ELF_BUFFERSIZE);
       if (!loadinfo->iobuffer)
         {
           berr("Failed to allocate an I/O buffer\n");

--- a/binfmt/libelf/libelf_sections.c
+++ b/binfmt/libelf/libelf_sections.c
@@ -204,7 +204,7 @@ int elf_loadshdrs(FAR struct elf_loadinfo_s *loadinfo)
 
   /* Allocate memory to hold a working copy of the sector header table */
 
-  loadinfo->shdr = (FAR FAR Elf_Shdr *)kmm_malloc(shdrsize);
+  loadinfo->shdr = kmm_malloc(shdrsize);
   if (!loadinfo->shdr)
     {
       berr("Failed to allocate the section header table. Size: %zu\n",

--- a/binfmt/libnxflat/libnxflat_addrenv.c
+++ b/binfmt/libnxflat/libnxflat_addrenv.c
@@ -81,7 +81,7 @@ int nxflat_addrenv_alloc(FAR struct nxflat_loadinfo_s *loadinfo,
 
   /* Allocate the struct dspace_s container for the D-Space allocation */
 
-  dspace = (FAR struct dspace_s *)kmm_malloc(sizeof(struct dspace_s));
+  dspace = kmm_malloc(sizeof(struct dspace_s));
   if (dspace == 0)
     {
       berr("ERROR: Failed to allocate DSpace\n");
@@ -163,7 +163,7 @@ errout_with_dspace:
 #else
   /* Allocate (and zero) memory to hold the ELF image */
 
-  dspace->region = (FAR uint8_t *)kumm_zalloc(envsize);
+  dspace->region = kumm_zalloc(envsize);
   if (!dspace->region)
     {
       kmm_free(dspace);

--- a/boards/arm/cxd56xx/drivers/sensors/bmi160_scu.c
+++ b/boards/arm/cxd56xx/drivers/sensors/bmi160_scu.c
@@ -804,7 +804,7 @@ static int bmi160_devregister(const char *devpath,
   char path[12];
   int ret;
 
-  priv = (struct bmi160_dev_s *)kmm_malloc(sizeof(struct bmi160_dev_s));
+  priv = kmm_malloc(sizeof(struct bmi160_dev_s));
   if (!priv)
     {
       snerr("Failed to allocate instance\n");

--- a/boards/arm/cxd56xx/drivers/sensors/bmp280_scu.c
+++ b/boards/arm/cxd56xx/drivers/sensors/bmp280_scu.c
@@ -912,7 +912,7 @@ int bmp280press_register(const char *devpath, int minor,
   char path[12];
   int ret;
 
-  priv = (struct bmp280_dev_s *)kmm_malloc(sizeof(struct bmp280_dev_s));
+  priv = kmm_malloc(sizeof(struct bmp280_dev_s));
   if (!priv)
     {
       snerr("Failed to allocate instance\n");
@@ -963,7 +963,7 @@ int bmp280temp_register(const char *devpath, int minor,
   char path[12];
   int ret;
 
-  priv = (struct bmp280_dev_s *)kmm_malloc(sizeof(struct bmp280_dev_s));
+  priv = kmm_malloc(sizeof(struct bmp280_dev_s));
   if (!priv)
     {
       snerr("Failed to allocate instance\n");

--- a/boards/arm/cxd56xx/drivers/sensors/kx022_scu.c
+++ b/boards/arm/cxd56xx/drivers/sensors/kx022_scu.c
@@ -492,7 +492,7 @@ int kx022_register(const char *devpath, int minor,
 
   /* Initialize the KX022 device structure */
 
-  priv = (struct kx022_dev_s *)kmm_malloc(sizeof(struct kx022_dev_s));
+  priv = kmm_malloc(sizeof(struct kx022_dev_s));
   if (!priv)
     {
       snerr("Failed to allocate instance\n");

--- a/boards/arm/gd32f4/gd32f450zk-eval/src/gd32f4xx_at24.c
+++ b/boards/arm/gd32f4/gd32f450zk-eval/src/gd32f4xx_at24.c
@@ -118,7 +118,7 @@ int gd32_at24_wr_test(int minor)
       return (int)nblocks;
     }
 
-  read_buf = (uint8_t *)kmm_malloc(BUFFSIZE);
+  read_buf = kmm_malloc(BUFFSIZE);
 
   /* Read the data write before */
 

--- a/boards/arm/gd32f4/gd32f450zk-eval/src/gd32f4xx_bringup.c
+++ b/boards/arm/gd32f4/gd32f450zk-eval/src/gd32f4xx_bringup.c
@@ -81,7 +81,7 @@ int gd32_bringup(void)
 #ifdef CONFIG_RAMMTD
   /* Create a RAM MTD device if configured */
 
-  ramstart = (uint8_t *)kmm_malloc(64 * 1024);
+  ramstart = kmm_malloc(64 * 1024);
   if (ramstart == NULL)
     {
       syslog(LOG_ERR, "ERROR: Allocation for RAM MTD failed\n");

--- a/boards/arm/gd32f4/gd32f470zk-eval/src/gd32f4xx_at24.c
+++ b/boards/arm/gd32f4/gd32f470zk-eval/src/gd32f4xx_at24.c
@@ -118,7 +118,7 @@ int gd32_at24_wr_test(int minor)
       return (int)nblocks;
     }
 
-  read_buf = (uint8_t *)kmm_malloc(BUFFSIZE);
+  read_buf = kmm_malloc(BUFFSIZE);
 
   /* Read the data write before */
 

--- a/boards/arm/gd32f4/gd32f470zk-eval/src/gd32f4xx_bringup.c
+++ b/boards/arm/gd32f4/gd32f470zk-eval/src/gd32f4xx_bringup.c
@@ -81,7 +81,7 @@ int gd32_bringup(void)
 #ifdef CONFIG_RAMMTD
   /* Create a RAM MTD device if configured */
 
-  ramstart = (uint8_t *)kmm_malloc(64 * 1024);
+  ramstart = kmm_malloc(64 * 1024);
   if (ramstart == NULL)
     {
       syslog(LOG_ERR, "ERROR: Allocation for RAM MTD failed\n");

--- a/boards/arm/s32k1xx/rddrone-bms772/src/s32k1xx_smbus_sbd.c
+++ b/boards/arm/s32k1xx/rddrone-bms772/src/s32k1xx_smbus_sbd.c
@@ -770,9 +770,7 @@ int smbus_sbd_initialize(int minor, struct i2c_slave_s *i2c_slave_dev)
 
   /* Allocate an SMBus Smart Battery Data slave device structure */
 
-  smbus_sbd_dev =
-    (struct smbus_sbd_dev_s *)kmm_zalloc(sizeof(struct smbus_sbd_dev_s));
-
+  smbus_sbd_dev = kmm_zalloc(sizeof(struct smbus_sbd_dev_s));
   if (smbus_sbd_dev == NULL)
     {
       leave_critical_section(flags);
@@ -801,9 +799,7 @@ int smbus_sbd_initialize(int minor, struct i2c_slave_s *i2c_slave_dev)
 
   /* Allocate the SMBus Smart Battery Data slave data structure */
 
-  smbus_sbd_dev->data =
-    (struct smbus_sbd_data_s *)kmm_zalloc(sizeof(struct smbus_sbd_data_s));
-
+  smbus_sbd_dev->data = kmm_zalloc(sizeof(struct smbus_sbd_data_s));
   if (smbus_sbd_dev->data == NULL)
     {
       leave_critical_section(flags);

--- a/boards/arm/stm32/mikroe-stm32f4/src/stm32_appinit.c
+++ b/boards/arm/stm32/mikroe-stm32f4/src/stm32_appinit.c
@@ -291,7 +291,7 @@ int board_app_initialize(uintptr_t arg)
 #if defined(CONFIG_RAMMTD) && defined(CONFIG_MIKROE_RAMMTD)
     {
       uint8_t *start =
-          (uint8_t *) kmm_malloc(CONFIG_MIKROE_RAMMTD_SIZE * 1024);
+          kmm_malloc(CONFIG_MIKROE_RAMMTD_SIZE * 1024);
       mtd = rammtd_initialize(start, CONFIG_MIKROE_RAMMTD_SIZE * 1024);
       mtd->ioctl(mtd, MTDIOC_BULKERASE, 0);
 

--- a/boards/arm/stm32/mikroe-stm32f4/src/stm32_touchscreen.c
+++ b/boards/arm/stm32/mikroe-stm32f4/src/stm32_touchscreen.c
@@ -1486,7 +1486,7 @@ int stm32_tsc_setup(int minor)
 #ifndef CONFIG_TOUCHSCREEN_MULTIPLE
   priv = &g_touchscreen;
 #else
-  priv = (struct tc_dev_s *)kmm_malloc(sizeof(struct tc_dev_s));
+  priv = kmm_malloc(sizeof(struct tc_dev_s));
   if (!priv)
     {
       ierr("ERROR: kmm_malloc(%d) failed\n", sizeof(struct tc_dev_s));

--- a/boards/arm/stm32/stm32f429i-disco/src/stm32_bringup.c
+++ b/boards/arm/stm32/stm32f429i-disco/src/stm32_bringup.c
@@ -327,7 +327,7 @@ int stm32_bringup(void)
 
     {
       uint8_t *start =
-          (uint8_t *) kmm_malloc(CONFIG_STM32F429I_DISCO_RAMMTD_SIZE * 1024);
+          kmm_malloc(CONFIG_STM32F429I_DISCO_RAMMTD_SIZE * 1024);
       mtd = rammtd_initialize(start,
                               CONFIG_STM32F429I_DISCO_RAMMTD_SIZE * 1024);
       mtd->ioctl(mtd, MTDIOC_BULKERASE, 0);

--- a/boards/arm/stm32h7/nucleo-h743zi2/src/stm32_bringup.c
+++ b/boards/arm/stm32h7/nucleo-h743zi2/src/stm32_bringup.c
@@ -99,7 +99,7 @@ int stm32_bringup(void)
 #ifdef CONFIG_RAMMTD
   /* Create a RAM MTD device if configured */
 
-  ramstart = (uint8_t *)kmm_malloc(128 * 1024);
+  ramstart = kmm_malloc(128 * 1024);
   if (ramstart == NULL)
     {
       syslog(LOG_ERR, "ERROR: Allocation for RAM MTD failed\n");

--- a/boards/arm/stm32h7/stm32h745i-disco/src/stm32_bringup.c
+++ b/boards/arm/stm32h7/stm32h745i-disco/src/stm32_bringup.c
@@ -147,7 +147,7 @@ int stm32_bringup(void)
 #ifdef CONFIG_RAMMTD
   /* Create a RAM MTD device if configured */
 
-  ramstart = (FAR uint8_t *)kmm_malloc(128 * 1024);
+  ramstart = kmm_malloc(128 * 1024);
   if (ramstart == NULL)
     {
       syslog(LOG_ERR, "ERROR: Allocation for RAM MTD failed\n");

--- a/boards/mips/pic32mx/pic32mx7mmb/src/pic32_touchscreen.c
+++ b/boards/mips/pic32mx/pic32mx7mmb/src/pic32_touchscreen.c
@@ -1350,7 +1350,7 @@ int pic32mx_tsc_setup(int minor)
 #ifndef CONFIG_TOUCHSCREEN_MULTIPLE
   priv = &g_touchscreen;
 #else
-  priv = (struct tc_dev_s *)kmm_malloc(sizeof(struct tc_dev_s));
+  priv = kmm_malloc(sizeof(struct tc_dev_s));
   if (!priv)
     {
       ierr("ERROR: kmm_malloc(%d) failed\n", sizeof(struct tc_dev_s));

--- a/boards/risc-v/bl602/bl602evb/src/bl602_bringup.c
+++ b/boards/risc-v/bl602/bl602evb/src/bl602_bringup.c
@@ -293,7 +293,7 @@ static struct bthci_s *bthci_alloc(void)
   struct bthci_s *dev;
   struct bt_driver_s *drv;
 
-  dev = (struct bthci_s *)kmm_zalloc(sizeof(*dev));
+  dev = kmm_zalloc(sizeof(*dev));
   if (dev == NULL)
     {
       return NULL;

--- a/boards/sim/sim/sim/src/sim_bringup.c
+++ b/boards/sim/sim/sim/src/sim_bringup.c
@@ -159,7 +159,7 @@ int sim_bringup(void)
 #ifdef CONFIG_RAMMTD
   /* Create a RAM MTD device if configured */
 
-  ramstart = (uint8_t *)kmm_malloc(128 * 1024);
+  ramstart = kmm_malloc(128 * 1024);
   if (ramstart == NULL)
     {
       syslog(LOG_ERR, "ERROR: Allocation for RAM MTD failed\n");
@@ -240,7 +240,7 @@ int sim_bringup(void)
 #endif
 
 #if !defined(CONFIG_DISABLE_MOUNTPOINT) && defined(CONFIG_BLK_RPMSG_SERVER)
-  ramdiskstart = (uint8_t *)kmm_malloc(512 * 2048);
+  ramdiskstart = kmm_malloc(512 * 2048);
   ret = ramdisk_register(1, ramdiskstart, 2048, 512,
                          RDFLAG_WRENABLED | RDFLAG_FUNLINK);
   if (ret < 0)

--- a/boards/sparc/bm3803/xx3803/src/bm3803_am29lv.c
+++ b/boards/sparc/bm3803/xx3803/src/bm3803_am29lv.c
@@ -146,7 +146,7 @@ int bm3803_am29lv_initialize(int minor)
   /* Create a RAM MTD device if configured */
 
 #if defined(CONFIG_RAMMTD) && defined(CONFIG_XX3803_RAMMTD)
-  uint8_t *start = (uint8_t *)kmm_malloc(CONFIG_XX3803_RAMMTD_SIZE * 1024);
+  uint8_t *start = kmm_malloc(CONFIG_XX3803_RAMMTD_SIZE * 1024);
   mtd = rammtd_initialize(start, CONFIG_XX3803_RAMMTD_SIZE * 1024);
   mtd->ioctl(mtd, MTDIOC_BULKERASE, 0);
 #endif /* CONFIG_RAMMTD && CONFIG_XX3803_RAMMTD */

--- a/boards/sparc/bm3823/xx3823/src/bm3823_am29lv.c
+++ b/boards/sparc/bm3823/xx3823/src/bm3823_am29lv.c
@@ -102,7 +102,7 @@ int bm3823_am29lv_initialize(int minor)
 
 #if defined(CONFIG_RAMMTD) && defined(CONFIG_XX3823_RAMMTD)
 
-  uint8_t *start = (uint8_t *)kmm_malloc(CONFIG_XX3823_RAMMTD_SIZE * 1024);
+  uint8_t *start = kmm_malloc(CONFIG_XX3823_RAMMTD_SIZE * 1024);
   mtd = rammtd_initialize(start, CONFIG_XX3823_RAMMTD_SIZE * 1024);
   mtd->ioctl(mtd, MTDIOC_BULKERASE, 0);
 

--- a/drivers/analog/ads1242.c
+++ b/drivers/analog/ads1242.c
@@ -584,8 +584,7 @@ int ads1242_register(FAR const char *devpath, FAR struct spi_dev_s *spi,
 
   /* Initialize the ADS1242 device structure */
 
-  priv =
-    (FAR struct ads1242_dev_s *)kmm_malloc(sizeof(struct ads1242_dev_s));
+  priv = kmm_malloc(sizeof(struct ads1242_dev_s));
   if (priv == NULL)
     {
        _err("ERROR: Failed to allocate instance\n");

--- a/drivers/analog/dac7554.c
+++ b/drivers/analog/dac7554.c
@@ -245,12 +245,11 @@ FAR struct dac_dev_s *dac7554_initialize(FAR struct spi_dev_s *spi,
 
   /* Initialize the DAC7554 device structure */
 
-  priv =
-    (FAR struct dac7554_dev_s *)kmm_malloc(sizeof(struct dac7554_dev_s));
+  priv = kmm_malloc(sizeof(struct dac7554_dev_s));
   priv->spi = spi;
   priv->spidev = spidev;
 
-  g_dacdev = (FAR struct dac_dev_s *)kmm_malloc(sizeof(struct dac_dev_s));
+  g_dacdev = kmm_malloc(sizeof(struct dac_dev_s));
   g_dacdev->ad_ops = &g_dacops;
   g_dacdev->ad_priv = priv;
 

--- a/drivers/analog/ltc1867l.c
+++ b/drivers/analog/ltc1867l.c
@@ -318,8 +318,7 @@ int ltc1867l_register(FAR const char *devpath, FAR struct spi_dev_s *spi,
 
   /* Initialize the LTC1867L device structure */
 
-  adcpriv =
-    (FAR struct ltc1867l_dev_s *)kmm_malloc(sizeof(struct ltc1867l_dev_s));
+  adcpriv = kmm_malloc(sizeof(struct ltc1867l_dev_s));
   if (adcpriv == NULL)
     {
       aerr("ERROR: Failed to allocate ltc1867l_dev_s instance\n");
@@ -333,7 +332,7 @@ int ltc1867l_register(FAR const char *devpath, FAR struct spi_dev_s *spi,
 
   nxmutex_init(&adcpriv->lock);
 
-  adcdev = (FAR struct adc_dev_s *)kmm_malloc(sizeof(struct adc_dev_s));
+  adcdev = kmm_malloc(sizeof(struct adc_dev_s));
   if (adcdev == NULL)
     {
       aerr("ERROR: Failed to allocate adc_dev_s instance\n");

--- a/drivers/audio/audio_null.c
+++ b/drivers/audio/audio_null.c
@@ -865,7 +865,7 @@ FAR struct audio_lowerhalf_s *audio_null_initialize(void)
 
   /* Allocate the null audio device structure */
 
-  priv = (FAR struct null_dev_s *)kmm_zalloc(sizeof(struct null_dev_s));
+  priv = kmm_zalloc(sizeof(struct null_dev_s));
   if (priv)
     {
       /* Initialize the null audio device structure.

--- a/drivers/audio/cs4344.c
+++ b/drivers/audio/cs4344.c
@@ -1458,7 +1458,7 @@ FAR struct audio_lowerhalf_s *cs4344_initialize(FAR struct i2s_dev_s *i2s)
 
   /* Allocate a CS4344 device structure */
 
-  priv = (FAR struct cs4344_dev_s *)kmm_zalloc(sizeof(struct cs4344_dev_s));
+  priv = kmm_zalloc(sizeof(struct cs4344_dev_s));
   if (priv)
     {
       /* Initialize the CS4344 device structure.  Since we used kmm_zalloc,

--- a/drivers/audio/es8311.c
+++ b/drivers/audio/es8311.c
@@ -2230,7 +2230,7 @@ FAR struct audio_lowerhalf_s *
 
   /* Allocate a ES8311 device structure */
 
-  priv = (FAR struct es8311_dev_s *)kmm_zalloc(sizeof(struct es8311_dev_s));
+  priv = kmm_zalloc(sizeof(struct es8311_dev_s));
 
   if (priv)
     {

--- a/drivers/audio/es8388.c
+++ b/drivers/audio/es8388.c
@@ -2534,7 +2534,7 @@ FAR struct audio_lowerhalf_s *
 
   /* Allocate a ES8388 device structure */
 
-  priv = (FAR struct es8388_dev_s *)kmm_zalloc(sizeof(struct es8388_dev_s));
+  priv = kmm_zalloc(sizeof(struct es8388_dev_s));
 
   if (priv)
     {

--- a/drivers/audio/tone.c
+++ b/drivers/audio/tone.c
@@ -939,10 +939,7 @@ int tone_register(FAR const char *path, FAR struct pwm_lowerhalf_s *tone,
 
   /* Allocate the upper-half data structure */
 
-  upper =
-    (FAR struct tone_upperhalf_s *)kmm_zalloc(
-                              sizeof(struct tone_upperhalf_s));
-
+  upper = kmm_zalloc(sizeof(struct tone_upperhalf_s));
   if (!upper)
     {
       auderr("ERROR: Allocation failed\n");

--- a/drivers/audio/vs1053.c
+++ b/drivers/audio/vs1053.c
@@ -1857,7 +1857,7 @@ struct audio_lowerhalf_s *vs1053_initialize(FAR struct spi_dev_s *spi,
 
   /* Allocate a VS1053 device structure */
 
-  dev = (struct vs1053_struct_s *)kmm_zalloc(sizeof(struct vs1053_struct_s));
+  dev = kmm_zalloc(sizeof(struct vs1053_struct_s));
   if (dev)
     {
       /* Initialize the VS1053 device structure */

--- a/drivers/audio/wm8776.c
+++ b/drivers/audio/wm8776.c
@@ -1310,7 +1310,7 @@ FAR struct audio_lowerhalf_s *
 
   /* Allocate a WM8776 device structure */
 
-  priv = (FAR struct wm8776_dev_s *)kmm_zalloc(sizeof(struct wm8776_dev_s));
+  priv = kmm_zalloc(sizeof(struct wm8776_dev_s));
 
   if (priv)
     {

--- a/drivers/audio/wm8904.c
+++ b/drivers/audio/wm8904.c
@@ -2534,7 +2534,7 @@ FAR struct audio_lowerhalf_s *
 
   /* Allocate a WM8904 device structure */
 
-  priv = (FAR struct wm8904_dev_s *)kmm_zalloc(sizeof(struct wm8904_dev_s));
+  priv = kmm_zalloc(sizeof(struct wm8904_dev_s));
   if (priv)
     {
       /* Initialize the WM8904 device structure.  Since we used kmm_zalloc,

--- a/drivers/audio/wm8994.c
+++ b/drivers/audio/wm8994.c
@@ -2782,7 +2782,7 @@ FAR struct audio_lowerhalf_s *
 
   /* Allocate a WM8994 device structure */
 
-  priv = (FAR struct wm8994_dev_s *)kmm_zalloc(sizeof(struct wm8994_dev_s));
+  priv = kmm_zalloc(sizeof(struct wm8994_dev_s));
   if (priv)
     {
       /* Initialize the WM8994 device structure.  Since we used kmm_zalloc,

--- a/drivers/bch/bchlib_setup.c
+++ b/drivers/bch/bchlib_setup.c
@@ -63,7 +63,7 @@ int bchlib_setup(const char *blkdev, bool readonly, FAR void **handle)
 
   /* Allocate the BCH state structure */
 
-  bch = (FAR struct bchlib_s *)kmm_zalloc(sizeof(struct bchlib_s));
+  bch = kmm_zalloc(sizeof(struct bchlib_s));
   if (!bch)
     {
       ferr("ERROR: Failed to allocate BCH structure\n");

--- a/drivers/can/mcp2515.c
+++ b/drivers/can/mcp2515.c
@@ -2586,7 +2586,7 @@ FAR struct can_dev_s *mcp2515_initialize(
 
   /* Allocate a CAN Device structure */
 
-  dev = (FAR struct can_dev_s *)kmm_zalloc(sizeof(struct can_dev_s));
+  dev = kmm_zalloc(sizeof(struct can_dev_s));
   if (dev == NULL)
     {
       canerr("ERROR: Failed to allocate instance of can_dev_s!\n");

--- a/drivers/contactless/mfrc522.c
+++ b/drivers/contactless/mfrc522.c
@@ -1628,7 +1628,7 @@ int mfrc522_register(FAR const char *devpath, FAR struct spi_dev_s *spi)
 
   /* Initialize the MFRC522 device structure */
 
-  dev = (FAR struct mfrc522_dev_s *)kmm_malloc(sizeof(struct mfrc522_dev_s));
+  dev = kmm_malloc(sizeof(struct mfrc522_dev_s));
   if (!dev)
     {
       ctlserr("ERROR: Failed to allocate instance\n");

--- a/drivers/contactless/pn532.c
+++ b/drivers/contactless/pn532.c
@@ -1116,7 +1116,7 @@ int pn532_register(FAR const char *devpath, FAR struct spi_dev_s *spi,
 
   /* Initialize the PN532 device structure */
 
-  dev = (FAR struct pn532_dev_s *)kmm_malloc(sizeof(struct pn532_dev_s));
+  dev = kmm_malloc(sizeof(struct pn532_dev_s));
   if (!dev)
     {
       ctlserr("ERROR: Failed to allocate instance\n");

--- a/drivers/i2c/i2c_bitbang.c
+++ b/drivers/i2c/i2c_bitbang.c
@@ -379,7 +379,7 @@ FAR struct i2c_master_s *i2c_bitbang_initialize(
 
   DEBUGASSERT(lower && lower->ops);
 
-  dev = (FAR struct i2c_bitbang_dev_s *)kmm_zalloc(sizeof(*dev));
+  dev = kmm_zalloc(sizeof(*dev));
 
   if (!dev)
     {

--- a/drivers/i2c/i2c_driver.c
+++ b/drivers/i2c/i2c_driver.c
@@ -373,7 +373,7 @@ int i2c_register(FAR struct i2c_master_s *i2c, int bus)
 
   /* Allocate a I2C character device structure */
 
-  priv = (FAR struct i2c_driver_s *)kmm_zalloc(sizeof(struct i2c_driver_s));
+  priv = kmm_zalloc(sizeof(struct i2c_driver_s));
   if (priv)
     {
       /* Initialize the I2C character device structure */

--- a/drivers/i2s/i2schar.c
+++ b/drivers/i2s/i2schar.c
@@ -409,7 +409,7 @@ int i2schar_register(FAR struct i2s_dev_s *i2s, int minor)
   /* Allocate a I2S character device structure */
 
   size_t dev_size = sizeof(struct i2schar_dev_s);
-  priv = (FAR struct i2schar_dev_s *)kmm_zalloc(dev_size);
+  priv = kmm_zalloc(dev_size);
   if (priv)
     {
       /* Initialize the I2S character device structure */

--- a/drivers/input/ajoystick.c
+++ b/drivers/input/ajoystick.c
@@ -303,7 +303,7 @@ static int ajoy_open(FAR struct file *filep)
 
   /* Allocate a new open structure */
 
-  opriv = (FAR struct ajoy_open_s *)kmm_zalloc(sizeof(struct ajoy_open_s));
+  opriv = kmm_zalloc(sizeof(struct ajoy_open_s));
   if (!opriv)
     {
       ierr("ERROR: Failed to allocate open structure\n");

--- a/drivers/input/button_upper.c
+++ b/drivers/input/button_upper.c
@@ -315,7 +315,7 @@ static int btn_open(FAR struct file *filep)
 
   /* Allocate a new open structure */
 
-  opriv = (FAR struct btn_open_s *)kmm_zalloc(sizeof(struct btn_open_s));
+  opriv = kmm_zalloc(sizeof(struct btn_open_s));
   if (!opriv)
     {
       ierr("ERROR: Failed to allocate open structure\n");

--- a/drivers/input/djoystick.c
+++ b/drivers/input/djoystick.c
@@ -303,7 +303,7 @@ static int djoy_open(FAR struct file *filep)
 
   /* Allocate a new open structure */
 
-  opriv = (FAR struct djoy_open_s *)kmm_zalloc(sizeof(struct djoy_open_s));
+  opriv = kmm_zalloc(sizeof(struct djoy_open_s));
   if (!opriv)
     {
       ierr("ERROR: Failed to allocate open structure\n");

--- a/drivers/input/ft5x06.c
+++ b/drivers/input/ft5x06.c
@@ -1092,7 +1092,7 @@ int ft5x06_register(FAR struct i2c_master_s *i2c,
 
   /* Create and initialize a FT5x06 device driver instance */
 
-  priv = (FAR struct ft5x06_dev_s *)kmm_zalloc(sizeof(struct ft5x06_dev_s));
+  priv = kmm_zalloc(sizeof(struct ft5x06_dev_s));
   if (!priv)
     {
       ierr("ERROR: kmm_zalloc(%d) failed\n", sizeof(struct ft5x06_dev_s));

--- a/drivers/input/mxt.c
+++ b/drivers/input/mxt.c
@@ -1834,7 +1834,7 @@ int mxt_register(FAR struct i2c_master_s *i2c,
 
   /* Create and initialize a maXTouch device driver instance */
 
-  priv = (FAR struct mxt_dev_s *)kmm_zalloc(sizeof(struct mxt_dev_s));
+  priv = kmm_zalloc(sizeof(struct mxt_dev_s));
   if (priv == NULL)
     {
       ierr("ERROR: Failed allocate device structure\n");

--- a/drivers/input/spq10kbd.c
+++ b/drivers/input/spq10kbd.c
@@ -973,8 +973,7 @@ int spq10kbd_register(FAR struct i2c_master_s *i2c,
   DEBUGASSERT(config->attach != NULL && config->enable != NULL &&
               config->clear  != NULL);
 
-  priv = (FAR struct spq10kbd_dev_s *)kmm_zalloc(
-    sizeof(struct spq10kbd_dev_s));
+  priv = kmm_zalloc(sizeof(struct spq10kbd_dev_s));
   if (!priv)
     {
       ierr("ERROR: kmm_zalloc(%d) failed\n", sizeof(struct spq10kbd_dev_s));

--- a/drivers/input/stmpe811_base.c
+++ b/drivers/input/stmpe811_base.c
@@ -266,8 +266,7 @@ STMPE811_HANDLE stmpe811_instantiate(FAR struct i2c_master_s *dev,
   /* Allocate the device state structure */
 
 #ifdef CONFIG_STMPE811_MULTIPLE
-  priv = (FAR struct stmpe811_dev_s *)kmm_zalloc(
-    sizeof(struct stmpe811_dev_s));
+  priv = kmm_zalloc(sizeof(struct stmpe811_dev_s));
   if (!priv)
     {
       return NULL;

--- a/drivers/ioexpander/gpio_lower_half.c
+++ b/drivers/ioexpander/gpio_lower_half.c
@@ -394,7 +394,7 @@ gpio_lower_half_internal(FAR struct ioexpander_dev_s *ioe,
 
   /* Allocate an new instance of the GPIO lower half driver */
 
-  priv = (FAR struct gplh_dev_s *)kmm_zalloc(sizeof(struct gplh_dev_s));
+  priv = kmm_zalloc(sizeof(struct gplh_dev_s));
   if (priv == NULL)
     {
       gpioerr("ERROR: Failed to allocate driver state %d\n", -ENOMEM);

--- a/drivers/ioexpander/pca9538.c
+++ b/drivers/ioexpander/pca9538.c
@@ -908,8 +908,7 @@ FAR struct ioexpander_dev_s *pca9538_initialize
 #ifdef CONFIG_PCA9538_MULTIPLE
   /* Allocate the device state structure */
 
-  pcadev = (FAR struct pca9538_dev_s *)kmm_zalloc
-                                            (sizeof(struct pca9538_dev_s));
+  pcadev = kmm_zalloc(sizeof(struct pca9538_dev_s));
   if (!pcadev)
     {
       return NULL;

--- a/drivers/ioexpander/skeleton.c
+++ b/drivers/ioexpander/skeleton.c
@@ -780,7 +780,7 @@ FAR struct ioexpander_dev_s *skel_initialize(void)
 #ifdef CONFIG_skeleton_MULTIPLE
   /* Allocate the device state structure */
 
-  priv = (FAR struct skel_dev_s *)kmm_zalloc(sizeof(struct skel_dev_s));
+  priv = kmm_zalloc(sizeof(struct skel_dev_s));
   if (!priv)
     {
       gpioerr("ERROR: Failed to allocate driver instance\n");

--- a/drivers/ioexpander/tca64xx.c
+++ b/drivers/ioexpander/tca64xx.c
@@ -1353,7 +1353,7 @@ FAR struct ioexpander_dev_s *tca64_initialize(FAR struct i2c_master_s *i2c,
 #ifdef CONFIG_TCA64XX_MULTIPLE
   /* Allocate the device state structure */
 
-  priv = (FAR struct tca64_dev_s *)kmm_zalloc(sizeof(struct tca64_dev_s));
+  priv = kmm_zalloc(sizeof(struct tca64_dev_s));
   if (!priv)
     {
       gpioerr("ERROR: Failed to allocate driver instance\n");

--- a/drivers/lcd/ft80x.c
+++ b/drivers/lcd/ft80x.c
@@ -1512,7 +1512,7 @@ int ft80x_register(FAR struct i2c_master_s *i2c,
 
   /* Allocate the driver state structure */
 
-  priv = (FAR struct ft80x_dev_s *)kmm_zalloc(sizeof(struct ft80x_dev_s));
+  priv = kmm_zalloc(sizeof(struct ft80x_dev_s));
   if (priv == NULL)
     {
       lcderr("ERROR: Failed to allocate state structure\n");

--- a/drivers/lcd/ht16k33_14seg.c
+++ b/drivers/lcd/ht16k33_14seg.c
@@ -403,7 +403,7 @@ static void lcd_scroll_up(FAR struct ht16k33_dev_s *priv)
   int currow;
   int curcol;
 
-  data = (FAR uint8_t *)kmm_malloc(HT16K33_MAX_COL);
+  data = kmm_malloc(HT16K33_MAX_COL);
   if (NULL == data)
     {
       lcdinfo("Failed to allocate buffer in lcd_scroll_up()\n");

--- a/drivers/lcd/lcd_dev.c
+++ b/drivers/lcd/lcd_dev.c
@@ -336,7 +336,7 @@ int lcddev_register(int devno)
 
   /* Allocate a new lcd_dev driver instance */
 
-  priv = (FAR struct lcddev_dev_s *)kmm_zalloc(sizeof(struct lcddev_dev_s));
+  priv = kmm_zalloc(sizeof(struct lcddev_dev_s));
 
   if (!priv)
     {

--- a/drivers/lcd/lcd_framebuffer.c
+++ b/drivers/lcd/lcd_framebuffer.c
@@ -557,7 +557,7 @@ int up_fbinitialize(int display)
 
   /* Allocate the framebuffer state structure */
 
-  priv = (FAR struct lcdfb_dev_s *)kmm_zalloc(sizeof(struct lcdfb_dev_s));
+  priv = kmm_zalloc(sizeof(struct lcdfb_dev_s));
   if (priv == NULL)
     {
       lcderr("ERROR: Failed to allocate state structure\n");
@@ -641,7 +641,7 @@ int up_fbinitialize(int display)
   priv->stride = ((size_t)priv->xres * priv->pinfo.bpp + 7) >> 3;
   priv->fblen  = priv->stride * priv->yres;
 
-  priv->fbmem  = (FAR uint8_t *)kmm_zalloc(priv->fblen);
+  priv->fbmem  = kmm_zalloc(priv->fblen);
   if (priv->fbmem == NULL)
     {
       lcderr("ERROR: Failed to allocate frame buffer memory\n");

--- a/drivers/lcd/pcf8574_lcd_backpack.c
+++ b/drivers/lcd/pcf8574_lcd_backpack.c
@@ -678,7 +678,7 @@ static void lcd_scroll_up(FAR struct pcf8574_lcd_dev_s *priv)
   int nrow;
   int ncol;
 
-  data = (FAR uint8_t *)kmm_malloc(priv->cfg.cols);
+  data = kmm_malloc(priv->cfg.cols);
   if (NULL == data)
     {
       lcdinfo("Failed to allocate buffer in lcd_scroll_up()\n");

--- a/drivers/lcd/st7032.c
+++ b/drivers/lcd/st7032.c
@@ -330,7 +330,7 @@ static void lcd_scroll_up(FAR struct st7032_dev_s *priv)
   int currow;
   int curcol;
 
-  data = (FAR uint8_t *)kmm_malloc(ST7032_MAX_COL);
+  data = kmm_malloc(ST7032_MAX_COL);
   if (NULL == data)
     {
       lcdinfo("Failed to allocate buffer in lcd_scroll_up()\n");
@@ -996,7 +996,7 @@ int st7032_register(FAR const char *devpath, FAR struct i2c_master_s *i2c)
 
   /* Initialize the ST7032 device structure */
 
-  priv = (FAR struct st7032_dev_s *)kmm_malloc(sizeof(struct st7032_dev_s));
+  priv = kmm_malloc(sizeof(struct st7032_dev_s));
   if (!priv)
     {
       snerr("ERROR: Failed to allocate instance\n");

--- a/drivers/lcd/tda19988.c
+++ b/drivers/lcd/tda19988.c
@@ -721,8 +721,8 @@ static int tda19988_fetch_edid(struct tda1988_dev_s *priv)
       unsigned int edid_len;
       int i;
 
-      edid_len =  EDID_LENGTH * (blocks + 1);
-      edid     = (FAR void *)kmm_realloc(priv->edid, edid_len);
+      edid_len = EDID_LENGTH * (blocks + 1);
+      edid     = kmm_realloc(priv->edid, edid_len);
 
       if (edid == NULL)
         {
@@ -1639,8 +1639,7 @@ TDA19988_HANDLE tda19988_register(FAR const char *devpath,
 
   /* Allocate an instance of the TDA19988 driver */
 
-  priv = (FAR struct tda1988_dev_s *)
-    kmm_zalloc(sizeof(struct tda1988_dev_s));
+  priv = kmm_zalloc(sizeof(struct tda1988_dev_s));
   if (priv == NULL)
     {
       lcderr("ERROR: Failed to allocate device structure\n");
@@ -1649,7 +1648,7 @@ TDA19988_HANDLE tda19988_register(FAR const char *devpath,
 
   /* Assume a single block in EDID */
 
-  priv->edid = (FAR uint8_t *)kmm_malloc(EDID_LENGTH);
+  priv->edid = kmm_malloc(EDID_LENGTH);
   if (priv->edid == NULL)
     {
       lcderr("ERROR: Failed to allocate EDID\n");

--- a/drivers/leds/apa102.c
+++ b/drivers/leds/apa102.c
@@ -232,7 +232,7 @@ int apa102_register(FAR const char *devpath, FAR struct spi_dev_s *spi)
 
   /* Initialize the APA102 device structure */
 
-  priv = (FAR struct apa102_dev_s *)kmm_malloc(sizeof(struct apa102_dev_s));
+  priv = kmm_malloc(sizeof(struct apa102_dev_s));
   if (!priv)
     {
       snerr("ERROR: Failed to allocate instance\n");

--- a/drivers/leds/lp503x.c
+++ b/drivers/leds/lp503x.c
@@ -916,6 +916,7 @@ static int lp503x_ioctl(struct file *filep, int cmd,
 int lp503x_register(const char *devpath, struct i2c_master_s *i2c,
                     uint8_t const lp503x_i2c_addr, int const i2c_frequency)
 {
+  struct lp503x_dev_s *priv;
   int ret;
 
   /* Sanity check */
@@ -924,9 +925,7 @@ int lp503x_register(const char *devpath, struct i2c_master_s *i2c,
 
   /* Initialize the LP503X device structure */
 
-  struct lp503x_dev_s *priv =
-         (struct lp503x_dev_s *)kmm_malloc(sizeof(struct lp503x_dev_s));
-
+  priv = kmm_malloc(sizeof(struct lp503x_dev_s));
   if (priv == NULL)
     {
       lederr("ERROR: Failed to allocate instance of lp503x_dev_s\n");

--- a/drivers/leds/ncp5623c.c
+++ b/drivers/leds/ncp5623c.c
@@ -262,15 +262,15 @@ static int ncp5623c_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 int ncp5623c_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
                       uint8_t const ncp5623c_i2c_addr)
 {
+  FAR struct ncp5623c_dev_s *priv;
+
   /* Sanity check */
 
   DEBUGASSERT(i2c != NULL);
 
   /* Initialize the NCP5623C device structure */
 
-  FAR struct ncp5623c_dev_s *priv =
-    (FAR struct ncp5623c_dev_s *)kmm_malloc(sizeof(struct ncp5623c_dev_s));
-
+  priv = kmm_malloc(sizeof(struct ncp5623c_dev_s));
   if (priv == NULL)
     {
       lcderr("ERROR: Failed to allocate instance of ncp5623c_dev_s\n");

--- a/drivers/leds/pca9635pw.c
+++ b/drivers/leds/pca9635pw.c
@@ -341,7 +341,7 @@ int pca9635pw_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
   /* Initialize the PCA9635PW device structure */
 
   FAR struct pca9635pw_dev_s *priv =
-    (FAR struct pca9635pw_dev_s *)kmm_malloc(sizeof(struct pca9635pw_dev_s));
+    kmm_malloc(sizeof(struct pca9635pw_dev_s));
 
   if (priv == NULL)
     {

--- a/drivers/leds/ws2812.c
+++ b/drivers/leds/ws2812.c
@@ -657,7 +657,7 @@ int ws2812_leds_register(FAR const char *devpath, FAR struct spi_dev_s *spi,
 
   /* Initialize the WS2812 device structure */
 
-  priv = (FAR struct ws2812_dev_s *)kmm_malloc(sizeof(struct ws2812_dev_s));
+  priv = kmm_malloc(sizeof(struct ws2812_dev_s));
   if (!priv)
     {
       lederr("ERROR: Failed to allocate instance\n");
@@ -665,7 +665,7 @@ int ws2812_leds_register(FAR const char *devpath, FAR struct spi_dev_s *spi,
     }
 
   priv->nleds  = nleds;
-  priv->tx_buf = (FAR uint8_t *)kmm_zalloc(TXBUFF_SIZE(priv->nleds));
+  priv->tx_buf = kmm_zalloc(TXBUFF_SIZE(priv->nleds));
   if (!priv->tx_buf)
     {
       lederr("ERROR: Failed to allocate tx buffer\n");

--- a/drivers/misc/mkrd.c
+++ b/drivers/misc/mkrd.c
@@ -65,7 +65,7 @@ int mkrd(int minor, uint32_t nsectors, uint16_t sectsize, uint8_t rdflags)
 
   /* Allocate the memory backing up the ramdisk from the kernel heap */
 
-  buffer = (FAR uint8_t *)kmm_malloc(sectsize * nsectors);
+  buffer = kmm_malloc(sectsize * nsectors);
   if (buffer == NULL)
     {
       ferr("ERROR: kmm_malloc() failed, enable DEBUG_MM for more info!\n");

--- a/drivers/misc/ramdisk.c
+++ b/drivers/misc/ramdisk.c
@@ -435,7 +435,7 @@ int ramdisk_register(int minor, FAR uint8_t *buffer, uint32_t nsectors,
 
   /* Allocate a ramdisk device structure */
 
-  dev = (struct rd_struct_s *)kmm_zalloc(sizeof(struct rd_struct_s));
+  dev = kmm_zalloc(sizeof(struct rd_struct_s));
   if (dev)
     {
       /* Initialize the ramdisk device structure */

--- a/drivers/misc/rpmsgdev.c
+++ b/drivers/misc/rpmsgdev.c
@@ -207,7 +207,7 @@ static int rpmsgdev_open(FAR struct file *filep)
   dev = filep->f_inode->i_private;
   DEBUGASSERT(dev != NULL);
 
-  priv = (FAR struct rpmsgdev_priv_s *)kmm_zalloc(sizeof(*priv));
+  priv = kmm_zalloc(sizeof(*priv));
   if (priv == NULL)
     {
       return -ENOMEM;

--- a/drivers/mtd/at24xx.c
+++ b/drivers/mtd/at24xx.c
@@ -698,7 +698,7 @@ FAR struct mtd_dev_s *at24c_initialize(FAR struct i2c_master_s *dev)
    * have to be extended to handle multiple FLASH parts on the same I2C bus.
    */
 
-  priv = (FAR struct at24c_dev_s *)kmm_zalloc(sizeof(struct at24c_dev_s));
+  priv = kmm_zalloc(sizeof(struct at24c_dev_s));
   if (priv == NULL)
     {
       ferr("ERROR: Failed to allocate device structure\n");

--- a/drivers/mtd/at25.c
+++ b/drivers/mtd/at25.c
@@ -704,7 +704,7 @@ FAR struct mtd_dev_s *at25_initialize(FAR struct spi_dev_s *dev)
    * have to be extended to handle multiple FLASH parts on the same SPI bus.
    */
 
-  priv = (FAR struct at25_dev_s *)kmm_zalloc(sizeof(struct at25_dev_s));
+  priv = kmm_zalloc(sizeof(struct at25_dev_s));
   if (priv)
     {
       /* Initialize the allocated structure (unsupported methods were

--- a/drivers/mtd/at45db.c
+++ b/drivers/mtd/at45db.c
@@ -877,7 +877,7 @@ FAR struct mtd_dev_s *at45db_initialize(FAR struct spi_dev_s *spi)
    * have to be extended to handle multiple FLASH parts on the same SPI bus.
    */
 
-  priv = (FAR struct at45db_dev_s *)kmm_zalloc(sizeof(struct at45db_dev_s));
+  priv = kmm_zalloc(sizeof(struct at45db_dev_s));
   if (priv)
     {
       /* Initialize the allocated structure. (unsupported methods were

--- a/drivers/mtd/filemtd.c
+++ b/drivers/mtd/filemtd.c
@@ -740,7 +740,7 @@ FAR struct mtd_dev_s *filemtd_initialize(FAR const char *path, size_t offset,
 
   /* Create an instance of the FILE MTD device state structure */
 
-  priv = (FAR struct file_dev_s *)kmm_zalloc(sizeof(struct file_dev_s));
+  priv = kmm_zalloc(sizeof(struct file_dev_s));
   if (!priv)
     {
       ferr("ERROR: Failed to allocate the FILE MTD state structure\n");

--- a/drivers/mtd/ftl.c
+++ b/drivers/mtd/ftl.c
@@ -465,7 +465,7 @@ static int ftl_alloc_eblock(FAR struct ftl_struct_s *dev)
     {
       /* Allocate one, in-memory erase block buffer */
 
-      dev->eblock = (FAR uint8_t *)kmm_malloc(dev->geo.erasesize);
+      dev->eblock = kmm_malloc(dev->geo.erasesize);
     }
 
   return dev->eblock != NULL ? OK : -ENOMEM;
@@ -809,7 +809,7 @@ int ftl_initialize_by_path(FAR const char *path, FAR struct mtd_dev_s *mtd)
 
   /* Allocate a FTL device structure */
 
-  dev = (FAR struct ftl_struct_s *)kmm_zalloc(sizeof(struct ftl_struct_s));
+  dev = kmm_zalloc(sizeof(struct ftl_struct_s));
   if (dev)
     {
       /* Initialize the FTL device structure */

--- a/drivers/mtd/gd25.c
+++ b/drivers/mtd/gd25.c
@@ -1031,7 +1031,7 @@ FAR struct mtd_dev_s *gd25_initialize(FAR struct spi_dev_s *spi,
   FAR struct gd25_dev_s *priv;
   int ret;
 
-  priv = (FAR struct gd25_dev_s *)kmm_zalloc(sizeof(struct gd25_dev_s));
+  priv = kmm_zalloc(sizeof(struct gd25_dev_s));
   if (priv)
     {
       /* Initialize the allocated structure (unsupported methods were

--- a/drivers/mtd/gd5f.c
+++ b/drivers/mtd/gd5f.c
@@ -889,7 +889,7 @@ FAR struct mtd_dev_s *gd5f_initialize(FAR struct spi_dev_s *dev,
 
   finfo("dev: %p\n", dev);
 
-  priv = (FAR struct gd5f_dev_s *)kmm_zalloc(sizeof(struct gd5f_dev_s));
+  priv = kmm_zalloc(sizeof(struct gd5f_dev_s));
   if (priv)
     {
       /* Initialize the allocated structure. (unsupported methods were

--- a/drivers/mtd/is25xp.c
+++ b/drivers/mtd/is25xp.c
@@ -1098,7 +1098,7 @@ FAR struct mtd_dev_s *is25xp_initialize(FAR struct spi_dev_s *dev,
    * The current implementation handles several FLASH part per SPI bus.
    */
 
-  priv = (FAR struct is25xp_dev_s *)kmm_zalloc(sizeof(struct is25xp_dev_s));
+  priv = kmm_zalloc(sizeof(struct is25xp_dev_s));
   if (priv)
     {
       /* Initialize the allocated structure. (unsupported methods were

--- a/drivers/mtd/m25px.c
+++ b/drivers/mtd/m25px.c
@@ -1158,7 +1158,7 @@ FAR struct mtd_dev_s *m25p_initialize(FAR struct spi_dev_s *dev)
    * have to be extended to handle multiple FLASH parts on the same SPI bus.
    */
 
-  priv = (FAR struct m25p_dev_s *)kmm_zalloc(sizeof(struct m25p_dev_s));
+  priv = kmm_zalloc(sizeof(struct m25p_dev_s));
   if (priv)
     {
       /* Initialize the allocated structure. (unsupported methods were

--- a/drivers/mtd/mtd_config.c
+++ b/drivers/mtd/mtd_config.c
@@ -572,7 +572,7 @@ static off_t mtdconfig_ramconsolidate(FAR struct mtdconfig_struct_s *dev)
 
   /* Allocate a consolidation buffer */
 
-  pbuf = (FAR uint8_t *)kmm_malloc(dev->erasesize);
+  pbuf = kmm_malloc(dev->erasesize);
   if (pbuf == NULL)
     {
       /* Unable to allocate buffer, can't consolidate! */
@@ -772,7 +772,7 @@ static off_t  mtdconfig_consolidate(FAR struct mtdconfig_struct_s *dev)
 
   /* Allocate a small buffer for moving data */
 
-  pbuf = (FAR uint8_t *)kmm_malloc(dev->blocksize);
+  pbuf = kmm_malloc(dev->blocksize);
   if (pbuf == NULL)
     {
       return 0;
@@ -1164,7 +1164,7 @@ static int mtdconfig_setconfig(FAR struct mtdconfig_struct_s *dev,
 
   /* Allocate a temp block buffer */
 
-  dev->buffer = (FAR uint8_t *)kmm_malloc(dev->blocksize);
+  dev->buffer = kmm_malloc(dev->blocksize);
   if (dev->buffer == NULL)
     {
       return -ENOMEM;
@@ -1392,7 +1392,7 @@ static int mtdconfig_getconfig(FAR struct mtdconfig_struct_s *dev,
 
   /* Allocate a temp block buffer */
 
-  dev->buffer = (FAR uint8_t *)kmm_malloc(dev->blocksize);
+  dev->buffer = kmm_malloc(dev->blocksize);
   if (dev->buffer == NULL)
     {
       return -ENOMEM;
@@ -1463,7 +1463,7 @@ static int mtdconfig_deleteconfig(FAR struct mtdconfig_struct_s *dev,
 
   /* Allocate a temp block buffer */
 
-  dev->buffer = (FAR uint8_t *)kmm_malloc(dev->blocksize);
+  dev->buffer = kmm_malloc(dev->blocksize);
   if (dev->buffer == NULL)
     {
       return -ENOMEM;
@@ -1511,7 +1511,7 @@ static int mtdconfig_firstconfig(FAR struct mtdconfig_struct_s *dev,
 
   /* Allocate a temp block buffer */
 
-  dev->buffer = (FAR uint8_t *)kmm_malloc(dev->blocksize);
+  dev->buffer = kmm_malloc(dev->blocksize);
   if (dev->buffer == NULL)
     {
       return -ENOMEM;
@@ -1579,7 +1579,7 @@ static int mtdconfig_nextconfig(FAR struct mtdconfig_struct_s *dev,
 
   /* Allocate a temp block buffer */
 
-  dev->buffer = (FAR uint8_t *)kmm_malloc(dev->blocksize);
+  dev->buffer = kmm_malloc(dev->blocksize);
   if (dev->buffer == NULL)
     {
       return -ENOMEM;

--- a/drivers/mtd/mtd_config_fs.c
+++ b/drivers/mtd/mtd_config_fs.c
@@ -2013,7 +2013,7 @@ int mtdconfig_register_by_path(FAR struct mtd_dev_s *mtd,
   int ret;
   FAR struct nvs_fs *fs;
 
-  fs = (FAR struct nvs_fs *)kmm_malloc(sizeof(struct nvs_fs));
+  fs = kmm_malloc(sizeof(struct nvs_fs));
   if (fs == NULL)
     {
       return -ENOMEM;

--- a/drivers/mtd/mtd_nand.c
+++ b/drivers/mtd/mtd_nand.c
@@ -908,7 +908,7 @@ FAR struct mtd_dev_s *nand_raw_initialize(FAR struct nand_raw_s *raw)
 
   /* Allocate an NAND MTD device structure */
 
-  nand = (FAR struct nand_dev_s *)kmm_zalloc(sizeof(struct nand_dev_s));
+  nand = kmm_zalloc(sizeof(struct nand_dev_s));
   if (!nand)
     {
       ferr("ERROR: Failed to allocate the NAND MTD device structure\n");

--- a/drivers/mtd/mx25lx.c
+++ b/drivers/mtd/mx25lx.c
@@ -1161,7 +1161,7 @@ FAR struct mtd_dev_s *mx25l_initialize_spi(FAR struct spi_dev_s *dev)
    * have to be extended to handle multiple FLASH parts on the same SPI bus.
    */
 
-  priv = (FAR struct mx25l_dev_s *)kmm_zalloc(sizeof(struct mx25l_dev_s));
+  priv = kmm_zalloc(sizeof(struct mx25l_dev_s));
   if (priv)
     {
       /* Initialize the allocated structure. (unsupported methods were
@@ -1198,7 +1198,7 @@ FAR struct mtd_dev_s *mx25l_initialize_spi(FAR struct spi_dev_s *dev)
 #ifdef CONFIG_MX25L_SECTOR512        /* Simulate a 512 byte sector */
           /* Allocate a buffer for the erase block cache */
 
-          priv->sector = (FAR uint8_t *)kmm_malloc(1 << priv->sectorshift);
+          priv->sector = kmm_malloc(1 << priv->sectorshift);
           if (!priv->sector)
             {
               /* Allocation failed! Discard all of that work we just did and

--- a/drivers/mtd/mx25rxx.c
+++ b/drivers/mtd/mx25rxx.c
@@ -1113,7 +1113,7 @@ FAR struct mtd_dev_s *mx25rxx_initialize(FAR struct qspi_dev_s *qspi,
    * bus.
    */
 
-  dev = (FAR struct mx25rxx_dev_s *)kmm_zalloc(sizeof(*dev));
+  dev = kmm_zalloc(sizeof(*dev));
 
   if (dev == NULL)
     {

--- a/drivers/mtd/mx35.c
+++ b/drivers/mtd/mx35.c
@@ -941,7 +941,7 @@ FAR struct mtd_dev_s *mx35_initialize(FAR struct spi_dev_s *dev)
    * have to be extended to handle multiple FLASH parts on the same SPI bus.
    */
 
-  priv = (FAR struct mx35_dev_s *)kmm_zalloc(sizeof(struct mx35_dev_s));
+  priv = kmm_zalloc(sizeof(struct mx35_dev_s));
   if (priv)
     {
       /* Initialize the allocated structure. (unsupported methods were

--- a/drivers/mtd/nullmtd.c
+++ b/drivers/mtd/nullmtd.c
@@ -355,7 +355,7 @@ FAR struct mtd_dev_s *nullmtd_initialize(size_t mtdlen, int16_t sectsize,
 
   /* Create an instance of the RAM MTD device state structure */
 
-  priv = (FAR struct null_dev_s *)kmm_zalloc(sizeof(struct null_dev_s));
+  priv = kmm_zalloc(sizeof(struct null_dev_s));
   if (!priv)
     {
       ferr("ERROR: Failed to allocate the RAM MTD state structure\n");

--- a/drivers/mtd/rammtd.c
+++ b/drivers/mtd/rammtd.c
@@ -481,7 +481,7 @@ FAR struct mtd_dev_s *rammtd_initialize(FAR uint8_t *start, size_t size)
 
   /* Create an instance of the RAM MTD device state structure */
 
-  priv = (FAR struct ram_dev_s *)kmm_zalloc(sizeof(struct ram_dev_s));
+  priv = kmm_zalloc(sizeof(struct ram_dev_s));
   if (!priv)
     {
       ferr("ERROR: Failed to allocate the RAM MTD state structure\n");

--- a/drivers/mtd/s25fl1.c
+++ b/drivers/mtd/s25fl1.c
@@ -1553,7 +1553,7 @@ FAR struct mtd_dev_s *s25fl1_initialize(FAR struct qspi_dev_s *qspi,
    * bus.
    */
 
-  priv = (FAR struct s25fl1_dev_s *)kmm_zalloc(sizeof(struct s25fl1_dev_s));
+  priv = kmm_zalloc(sizeof(struct s25fl1_dev_s));
   if (priv)
     {
       /* Initialize the allocated structure (unsupported methods were

--- a/drivers/mtd/sector512.c
+++ b/drivers/mtd/sector512.c
@@ -642,7 +642,7 @@ FAR struct mtd_dev_s *s512_initialize(FAR struct mtd_dev_s *mtd)
    * have to be extended to handle multiple FLASH parts on the same SPI bus.
    */
 
-  priv = (FAR struct s512_dev_s *)kmm_zalloc(sizeof(struct s512_dev_s));
+  priv = kmm_zalloc(sizeof(struct s512_dev_s));
   if (priv)
     {
       /* Initialize the allocated structure. (unsupported methods/fields
@@ -664,7 +664,7 @@ FAR struct mtd_dev_s *s512_initialize(FAR struct mtd_dev_s *mtd)
 
       /* Allocate a buffer for the erase block cache */
 
-      priv->eblock = (FAR uint8_t *)kmm_malloc(priv->eblocksize);
+      priv->eblock = kmm_malloc(priv->eblocksize);
       if (!priv->eblock)
         {
           /* Allocation failed! Discard all of that work we just did and

--- a/drivers/mtd/smart.c
+++ b/drivers/mtd/smart.c
@@ -5695,7 +5695,7 @@ static int smart_fsck_file(FAR struct smart_struct_s *dev,
   /* Allocate a bitmap table for sectors this file is using */
 
   mapsize = (dev->totalsectors + 7) / 8;
-  usedmap = (FAR uint8_t *)kmm_zalloc(mapsize);
+  usedmap = kmm_zalloc(mapsize);
   if (!usedmap)
     {
       ferr("ERROR: Out of memory used map\n");
@@ -5827,7 +5827,7 @@ static int smart_fsck_directory(FAR struct smart_struct_s *dev,
 
   /* Allocate sector buffer for Directory entry */
 
-  rwbuffer = (uint8_t *)kmm_malloc(dev->sectorsize);
+  rwbuffer = kmm_malloc(dev->sectorsize);
   if (!rwbuffer)
     {
       ferr("ERROR: Out of memory sector buffer\n");
@@ -6069,7 +6069,7 @@ static int smart_fsck(FAR struct smart_struct_s *dev)
   /* Allocate a bitmap table for filesystem check */
 
   mapsize = (dev->totalsectors + 7) / 8;
-  checkmap = (FAR uint8_t *)kmm_zalloc(mapsize);
+  checkmap = kmm_zalloc(mapsize);
   if (!checkmap)
     {
       ferr("ERROR: Out of memory fsck map\n");

--- a/drivers/mtd/sst25.c
+++ b/drivers/mtd/sst25.c
@@ -1274,7 +1274,7 @@ FAR struct mtd_dev_s *sst25_initialize(FAR struct spi_dev_s *dev)
    * have to be extended to handle multiple FLASH parts on the same SPI bus.
    */
 
-  priv = (FAR struct sst25_dev_s *)kmm_zalloc(sizeof(struct sst25_dev_s));
+  priv = kmm_zalloc(sizeof(struct sst25_dev_s));
   if (priv)
     {
       /* Initialize the allocated structure. (unsupported methods were
@@ -1319,7 +1319,7 @@ FAR struct mtd_dev_s *sst25_initialize(FAR struct spi_dev_s *dev)
 #ifdef CONFIG_SST25_SECTOR512        /* Simulate a 512 byte sector */
           /* Allocate a buffer for the erase block cache */
 
-          priv->sector = (FAR uint8_t *)kmm_malloc(1 << priv->sectorshift);
+          priv->sector = kmm_malloc(1 << priv->sectorshift);
           if (!priv->sector)
             {
               /* Allocation failed! Discard all of that work we just did and

--- a/drivers/mtd/sst26.c
+++ b/drivers/mtd/sst26.c
@@ -965,7 +965,7 @@ FAR struct mtd_dev_s *sst26_initialize_spi(FAR struct spi_dev_s *dev,
    * have to be extended to handle multiple FLASH parts on the same SPI bus.
    */
 
-  priv = (FAR struct sst26_dev_s *)kmm_zalloc(sizeof(struct sst26_dev_s));
+  priv = kmm_zalloc(sizeof(struct sst26_dev_s));
   if (priv)
     {
       /* Initialize the allocated structure. (unsupported methods were

--- a/drivers/mtd/w25.c
+++ b/drivers/mtd/w25.c
@@ -1405,7 +1405,7 @@ FAR struct mtd_dev_s *w25_initialize(FAR struct spi_dev_s *spi)
    * have to be extended to handle multiple FLASH parts on the same SPI bus.
    */
 
-  priv = (FAR struct w25_dev_s *)kmm_zalloc(sizeof(struct w25_dev_s));
+  priv = kmm_zalloc(sizeof(struct w25_dev_s));
   if (priv)
     {
       /* Initialize the allocated structure (unsupported methods were
@@ -1453,7 +1453,7 @@ FAR struct mtd_dev_s *w25_initialize(FAR struct spi_dev_s *spi)
 #ifdef CONFIG_W25_SECTOR512        /* Simulate a 512 byte sector */
           /* Allocate a buffer for the erase block cache */
 
-          priv->sector = (FAR uint8_t *)kmm_malloc(W25_SECTOR_SIZE);
+          priv->sector = kmm_malloc(W25_SECTOR_SIZE);
           if (!priv->sector)
             {
               /* Discard all of that work we just did and return NULL */

--- a/drivers/net/telnet.c
+++ b/drivers/net/telnet.c
@@ -905,7 +905,7 @@ static int telnet_session(FAR struct telnet_session_s *session)
 
   /* Allocate instance data for this driver */
 
-  priv = (FAR struct telnet_dev_s *)kmm_zalloc(sizeof(struct telnet_dev_s));
+  priv = kmm_zalloc(sizeof(struct telnet_dev_s));
   if (!priv)
     {
       nerr("ERROR: Failed to allocate the driver data structure\n");

--- a/drivers/note/noteram_driver.c
+++ b/drivers/note/noteram_driver.c
@@ -1112,7 +1112,7 @@ noteram_initialize(FAR const char *devpath, size_t bufsize, bool overwrite)
   FAR struct noteram_driver_s *drv;
   int ret;
 
-  drv = (FAR struct noteram_driver_s *)kmm_malloc(sizeof(*drv) + bufsize);
+  drv = kmm_malloc(sizeof(*drv) + bufsize);
   if (drv == NULL)
     {
       return NULL;

--- a/drivers/pipes/pipe_common.c
+++ b/drivers/pipes/pipe_common.c
@@ -94,7 +94,7 @@ FAR struct pipe_dev_s *pipecommon_allocdev(size_t bufsize)
 
   /* Allocate a private structure to manage the pipe */
 
-  dev = (FAR struct pipe_dev_s *)kmm_malloc(sizeof(struct pipe_dev_s));
+  dev = kmm_malloc(sizeof(struct pipe_dev_s));
   if (dev)
     {
       /* Initialize the private structure */

--- a/drivers/power/battery/axp202.c
+++ b/drivers/power/battery/axp202.c
@@ -675,7 +675,7 @@ axp202_initialize(FAR struct i2c_master_s *i2c, uint8_t addr,
 
   /* Initialize the axp202 device structure */
 
-  priv = (FAR struct axp202_dev_s *)kmm_zalloc(sizeof(struct axp202_dev_s));
+  priv = kmm_zalloc(sizeof(struct axp202_dev_s));
 
   if (priv)
     {

--- a/drivers/power/battery/bq27426.c
+++ b/drivers/power/battery/bq27426.c
@@ -419,8 +419,7 @@ FAR struct battery_gauge_dev_s *bq27426_initialize(
 
   /* Initialize the bq27426 device structure */
 
-  priv = (FAR struct bq27426_dev_s *)kmm_zalloc(sizeof(
-                                                      struct bq27426_dev_s));
+  priv = kmm_zalloc(sizeof(struct bq27426_dev_s));
   if (priv)
     {
       /* Initialize the bq27426 device structure */

--- a/drivers/power/pm/pm_procfs.c
+++ b/drivers/power/pm/pm_procfs.c
@@ -183,7 +183,7 @@ static int pm_open(FAR struct file *filep, FAR const char *relpath,
 
   /* Allocate a container to hold the file attributes */
 
-  pmfile = (FAR struct pm_file_s *)kmm_zalloc(sizeof(struct pm_file_s));
+  pmfile = kmm_zalloc(sizeof(struct pm_file_s));
   if (!pmfile)
     {
       ferr("ERROR: Failed to allocate file attributes\n");
@@ -414,7 +414,7 @@ static int pm_dup(FAR const struct file *oldp, FAR struct file *newp)
 
   /* Allocate a new container to hold the task and attribute selection */
 
-  newattr = (FAR struct pm_file_s *)kmm_malloc(sizeof(struct pm_file_s));
+  newattr = kmm_malloc(sizeof(struct pm_file_s));
   if (!newattr)
     {
       ferr("ERROR: Failed to allocate file attributes\n");

--- a/drivers/segger/stream_rtt.c
+++ b/drivers/segger/stream_rtt.c
@@ -124,7 +124,7 @@ void lib_rttoutstream_open(FAR struct lib_rttoutstream_s *stream,
   if (channel)
     {
       bufsize = bufsize ? bufsize : BUFFER_SIZE_UP;
-      stream->buffer = (FAR char *)kmm_malloc(bufsize);
+      stream->buffer = kmm_malloc(bufsize);
       DEBUGASSERT(stream->buffer);
       snprintf(stream->name, sizeof(stream->name), "rtt%d", channel);
       SEGGER_RTT_ConfigUpBuffer(channel, stream->name, stream->buffer,
@@ -172,7 +172,7 @@ void lib_rttinstream_open(FAR struct lib_rttinstream_s *stream,
   if (channel)
     {
       bufsize = bufsize ? bufsize : BUFFER_SIZE_DOWN;
-      stream->buffer = (FAR char *)kmm_malloc(bufsize);
+      stream->buffer = kmm_malloc(bufsize);
       DEBUGASSERT(stream->buffer);
       snprintf(stream->name, sizeof(stream->name), "rtt%d", channel);
       SEGGER_RTT_ConfigDownBuffer(channel, stream->name, stream->buffer,

--- a/drivers/sensors/aht10.c
+++ b/drivers/sensors/aht10.c
@@ -592,7 +592,7 @@ int aht10_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Initialize the device structure */
 
-  priv = (FAR struct aht10_dev_s *)kmm_zalloc(sizeof(struct aht10_dev_s));
+  priv = kmm_zalloc(sizeof(struct aht10_dev_s));
   if (priv == NULL)
     {
       snerr("ERROR: Failed to allocate instance\n");

--- a/drivers/sensors/apds9922.c
+++ b/drivers/sensors/apds9922.c
@@ -1883,7 +1883,7 @@ static int apds9922_i2c_write(FAR struct apds9922_dev_s *priv,
   irqstate_t          flags;
   uint8_t             *buffer;
 
-  buffer = (uint8_t *)kmm_malloc((len + 1) * sizeof(uint8_t));
+  buffer = kmm_malloc((len + 1) * sizeof(uint8_t));
   if (!buffer)
     {
       snerr("ERROR: Failed to create i2c  write buffer space\n");

--- a/drivers/sensors/apds9960.c
+++ b/drivers/sensors/apds9960.c
@@ -1194,13 +1194,12 @@ static ssize_t apds9960_write(FAR struct file *filep,
 int apds9960_register(FAR const char *devpath,
                       FAR struct apds9960_config_s *config)
 {
+  FAR struct apds9960_dev_s *priv;
   int ret;
 
   /* Initialize the APDS9960 device structure */
 
-  FAR struct apds9960_dev_s *priv =
-    (FAR struct apds9960_dev_s *)kmm_zalloc(sizeof(struct apds9960_dev_s));
-
+  priv = kmm_zalloc(sizeof(struct apds9960_dev_s));
   if (priv == NULL)
     {
       snerr("ERROR: Failed to allocate instance\n");

--- a/drivers/sensors/as5048a.c
+++ b/drivers/sensors/as5048a.c
@@ -615,7 +615,7 @@ FAR struct qe_lowerhalf_s *as5048a_initialize(FAR struct spi_dev_s *spi,
 
   /* Initialize the device's structure */
 
-  priv = (FAR struct as5048a_dev_s *)kmm_malloc(sizeof(*priv));
+  priv = kmm_malloc(sizeof(*priv));
   if (priv == NULL)
     {
       snerr("ERROR: Failed to allocate instance\n");

--- a/drivers/sensors/as5048b.c
+++ b/drivers/sensors/as5048b.c
@@ -602,7 +602,7 @@ FAR struct qe_lowerhalf_s *as5048b_initialize(FAR struct i2c_master_s *i2c,
 
   /* Initialize the device's structure */
 
-  priv = (FAR struct as5048b_dev_s *)kmm_malloc(sizeof(*priv));
+  priv = kmm_malloc(sizeof(*priv));
   if (priv == NULL)
     {
       snerr("ERROR: Failed to allocate instance\n");

--- a/drivers/sensors/as726x.c
+++ b/drivers/sensors/as726x.c
@@ -387,6 +387,7 @@ static ssize_t as726x_write(FAR struct file *filep,
 
 int as726x_register(FAR const char *devpath, FAR struct i2c_master_s *i2c)
 {
+  FAR struct as726x_dev_s *priv;
   uint8_t _sensor_version;
   uint8_t value;
   int ret;
@@ -397,9 +398,7 @@ int as726x_register(FAR const char *devpath, FAR struct i2c_master_s *i2c)
 
   /* Initialize the AS726X device structure */
 
-  FAR struct as726x_dev_s *priv =
-    (FAR struct as726x_dev_s *)kmm_malloc(sizeof(struct as726x_dev_s));
-
+  priv = kmm_malloc(sizeof(struct as726x_dev_s));
   if (priv == NULL)
     {
       snerr("ERROR: Failed to allocate instance\n");

--- a/drivers/sensors/bh1750fvi.c
+++ b/drivers/sensors/bh1750fvi.c
@@ -363,6 +363,7 @@ static int bh1750fvi_ioctl(FAR struct file *filep, int cmd,
 int bh1750fvi_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
                        uint8_t addr)
 {
+  FAR struct bh1750fvi_dev_s *priv;
   int ret;
 
   /* Sanity check */
@@ -371,9 +372,7 @@ int bh1750fvi_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Initialize the BH1750FVI device structure */
 
-  FAR struct bh1750fvi_dev_s *priv =
-    (FAR struct bh1750fvi_dev_s *)kmm_malloc(sizeof(struct bh1750fvi_dev_s));
-
+  priv = kmm_malloc(sizeof(struct bh1750fvi_dev_s));
   if (priv == NULL)
     {
       snerr("ERROR: Failed to allocate instance\n");

--- a/drivers/sensors/bme680.c
+++ b/drivers/sensors/bme680.c
@@ -1632,7 +1632,7 @@ int bme680_register(int devno, FAR struct i2c_master_s *i2c)
 
   /* Initialize the BME680 device structure */
 
-  priv = (FAR struct bme680_dev_s *)kmm_zalloc(sizeof(struct bme680_dev_s));
+  priv = kmm_zalloc(sizeof(struct bme680_dev_s));
   if (priv == NULL)
     {
       snerr("ERROR: Failed to allocate instance (err = %d)\n", ret);

--- a/drivers/sensors/bmg160.c
+++ b/drivers/sensors/bmg160.c
@@ -510,7 +510,7 @@ int bmg160_register(FAR const char *devpath, FAR struct spi_dev_s *spi,
 
   /* Initialize the BMG160 device structure */
 
-  priv = (FAR struct bmg160_dev_s *)kmm_malloc(sizeof(struct bmg160_dev_s));
+  priv = kmm_malloc(sizeof(struct bmg160_dev_s));
   if (priv == NULL)
     {
       snerr("ERROR: Failed to allocate instance\n");

--- a/drivers/sensors/bmi160.c
+++ b/drivers/sensors/bmi160.c
@@ -738,7 +738,7 @@ int bmi160_register(FAR const char *devpath, FAR struct spi_dev_s *dev)
   FAR struct bmi160_dev_s *priv;
   int ret;
 
-  priv = (FAR struct bmi160_dev_s *)kmm_malloc(sizeof(struct bmi160_dev_s));
+  priv = kmm_malloc(sizeof(struct bmi160_dev_s));
   if (!priv)
     {
       snerr("Failed to allocate instance\n");

--- a/drivers/sensors/bmi270.c
+++ b/drivers/sensors/bmi270.c
@@ -1440,7 +1440,7 @@ int bmi270_register(FAR const char *devpath, FAR struct spi_dev_s *dev)
   FAR struct bmi270_dev_s *priv;
   int ret;
 
-  priv = (FAR struct bmi270_dev_s *)kmm_malloc(sizeof(struct bmi270_dev_s));
+  priv = kmm_malloc(sizeof(struct bmi270_dev_s));
   if (!priv)
     {
       snerr("Failed to allocate instance\n");

--- a/drivers/sensors/bmp180.c
+++ b/drivers/sensors/bmp180.c
@@ -560,7 +560,7 @@ int bmp180_register(FAR const char *devpath, FAR struct i2c_master_s *i2c)
 
   /* Initialize the BMP180 device structure */
 
-  priv = (FAR struct bmp180_dev_s *)kmm_malloc(sizeof(struct bmp180_dev_s));
+  priv = kmm_malloc(sizeof(struct bmp180_dev_s));
   if (!priv)
     {
       snerr("ERROR: Failed to allocate instance\n");

--- a/drivers/sensors/bmp280.c
+++ b/drivers/sensors/bmp280.c
@@ -687,7 +687,7 @@ int bmp280_register(int devno, FAR struct i2c_master_s *i2c)
 
   /* Initialize the BMP280 device structure */
 
-  priv = (FAR struct bmp280_dev_s *)kmm_zalloc(sizeof(struct bmp280_dev_s));
+  priv = kmm_zalloc(sizeof(struct bmp280_dev_s));
   if (!priv)
     {
       snerr("Failed to allocate instance\n");

--- a/drivers/sensors/dhtxx.c
+++ b/drivers/sensors/dhtxx.c
@@ -545,7 +545,7 @@ int dhtxx_register(FAR const char *devpath,
 
   /* Initialize the Dhtxx device structure */
 
-  priv = (FAR struct dhtxx_dev_s *)kmm_malloc(sizeof(struct dhtxx_dev_s));
+  priv = kmm_malloc(sizeof(struct dhtxx_dev_s));
   if (priv == NULL)
     {
       snerr("ERROR: Failed to allocate instance\n");

--- a/drivers/sensors/hc_sr04.c
+++ b/drivers/sensors/hc_sr04.c
@@ -406,7 +406,7 @@ int hcsr04_register(FAR const char *devpath,
   int ret = 0;
   FAR struct hcsr04_dev_s *priv;
 
-  priv = (struct hcsr04_dev_s *)kmm_zalloc(sizeof(struct hcsr04_dev_s));
+  priv = kmm_zalloc(sizeof(struct hcsr04_dev_s));
 
   if (!priv)
     {

--- a/drivers/sensors/hdc1008.c
+++ b/drivers/sensors/hdc1008.c
@@ -944,7 +944,7 @@ int hdc1008_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
   /* Initialize the driver structure */
 
   priv =
-    (FAR struct hdc1008_dev_s *)kmm_zalloc(sizeof(struct hdc1008_dev_s));
+    kmm_zalloc(sizeof(struct hdc1008_dev_s));
 
   if (priv == NULL)
     {

--- a/drivers/sensors/hts221.c
+++ b/drivers/sensors/hts221.c
@@ -1157,7 +1157,7 @@ int hts221_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
   int ret = 0;
   FAR struct hts221_dev_s *priv;
 
-  priv = (struct hts221_dev_s *)kmm_zalloc(sizeof(struct hts221_dev_s));
+  priv = kmm_zalloc(sizeof(struct hts221_dev_s));
 
   if (!priv)
     {

--- a/drivers/sensors/ina219.c
+++ b/drivers/sensors/ina219.c
@@ -364,7 +364,7 @@ int ina219_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Initialize the ina219 device structure */
 
-  priv = (FAR struct ina219_dev_s *)kmm_malloc(sizeof(struct ina219_dev_s));
+  priv = kmm_malloc(sizeof(struct ina219_dev_s));
   if (priv == NULL)
     {
       snerr("ERROR: Failed to allocate instance\n");

--- a/drivers/sensors/ina226.c
+++ b/drivers/sensors/ina226.c
@@ -344,7 +344,7 @@ int ina226_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Initialize the ina226 device structure */
 
-  priv = (FAR struct ina226_dev_s *)kmm_malloc(sizeof(struct ina226_dev_s));
+  priv = kmm_malloc(sizeof(struct ina226_dev_s));
   if (priv == NULL)
     {
       snerr("ERROR: Failed to allocate instance\n");

--- a/drivers/sensors/kxtj9.c
+++ b/drivers/sensors/kxtj9.c
@@ -614,7 +614,7 @@ int kxtj9_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Initialize the device's structure */
 
-  priv = (FAR struct kxtj9_dev_s *)kmm_zalloc(sizeof(struct kxtj9_dev_s));
+  priv = kmm_zalloc(sizeof(struct kxtj9_dev_s));
   if (priv == NULL)
     {
       snerr("ERROR: Failed to allocate driver instance\n");

--- a/drivers/sensors/l3gd20.c
+++ b/drivers/sensors/l3gd20.c
@@ -545,7 +545,7 @@ int l3gd20_register(int devno, FAR struct spi_dev_s *spi,
 
   /* Initialize the L3GD20 device structure */
 
-  priv = (FAR struct l3gd20_dev_s *)kmm_malloc(sizeof(struct l3gd20_dev_s));
+  priv = kmm_malloc(sizeof(struct l3gd20_dev_s));
   if (priv == NULL)
     {
       snerr("ERROR: Failed to allocate instance\n");

--- a/drivers/sensors/lis2dh.c
+++ b/drivers/sensors/lis2dh.c
@@ -2008,7 +2008,7 @@ int lis2dh_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   DEBUGASSERT(devpath != NULL && i2c != NULL && config != NULL);
 
-  priv = (FAR struct lis2dh_dev_s *)kmm_zalloc(sizeof(struct lis2dh_dev_s));
+  priv = kmm_zalloc(sizeof(struct lis2dh_dev_s));
   if (!priv)
     {
       lis2dh_dbg("lis2dh: Failed to allocate instance\n");

--- a/drivers/sensors/lis3dh.c
+++ b/drivers/sensors/lis3dh.c
@@ -948,7 +948,7 @@ int lis3dh_register(FAR const char *devpath, FAR struct spi_dev_s *spi,
 
   /* Initialize the LIS3DH device structure */
 
-  priv = (FAR struct lis3dh_dev_s *)kmm_malloc(sizeof(struct lis3dh_dev_s));
+  priv = kmm_malloc(sizeof(struct lis3dh_dev_s));
   if (priv == NULL)
     {
       snerr("ERROR: Failed to allocate instance\n");

--- a/drivers/sensors/lis3dsh.c
+++ b/drivers/sensors/lis3dsh.c
@@ -522,7 +522,7 @@ int lis3dsh_register(FAR const char *devpath, FAR struct spi_dev_s *spi,
   /* Initialize the LIS3DSH device structure */
 
   priv =
-      (FAR struct lis3dsh_dev_s *)kmm_malloc(sizeof(struct lis3dsh_dev_s));
+      kmm_malloc(sizeof(struct lis3dsh_dev_s));
   if (priv == NULL)
     {
       snerr("ERROR: Failed to allocate instance\n");

--- a/drivers/sensors/lm75.c
+++ b/drivers/sensors/lm75.c
@@ -547,7 +547,7 @@ int lm75_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Initialize the LM-75 device structure */
 
-  priv = (FAR struct lm75_dev_s *)kmm_malloc(sizeof(struct lm75_dev_s));
+  priv = kmm_malloc(sizeof(struct lm75_dev_s));
   if (priv == NULL)
     {
       snerr("ERROR: Failed to allocate instance\n");

--- a/drivers/sensors/lm92.c
+++ b/drivers/sensors/lm92.c
@@ -628,7 +628,7 @@ int lm92_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Initialize the LM92 device structure */
 
-  priv = (FAR struct lm92_dev_s *)kmm_malloc(sizeof(struct lm92_dev_s));
+  priv = kmm_malloc(sizeof(struct lm92_dev_s));
   if (priv == NULL)
     {
       snerr("ERROR: Failed to allocate instance\n");

--- a/drivers/sensors/lps25h.c
+++ b/drivers/sensors/lps25h.c
@@ -739,7 +739,7 @@ int lps25h_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
   int ret = 0;
   FAR struct lps25h_dev_s *dev;
 
-  dev = (struct lps25h_dev_s *)kmm_zalloc(sizeof(struct lps25h_dev_s));
+  dev = kmm_zalloc(sizeof(struct lps25h_dev_s));
   if (!dev)
     {
       lps25h_dbg("Memory cannot be allocated for LPS25H sensor\n");

--- a/drivers/sensors/lsm303agr.c
+++ b/drivers/sensors/lsm303agr.c
@@ -1168,7 +1168,7 @@ static int lsm303agr_register(FAR const char *devpath,
 
   /* Initialize the device's structure */
 
-  priv = (FAR struct lsm303agr_dev_s *)kmm_malloc(sizeof(*priv));
+  priv = kmm_malloc(sizeof(*priv));
   if (priv == NULL)
     {
       snerr("ERROR: Failed to allocate instance\n");

--- a/drivers/sensors/lsm330_spi.c
+++ b/drivers/sensors/lsm330_spi.c
@@ -1320,7 +1320,7 @@ int lsm330_register(FAR const char *devpath_acl,
 
   /* Initialize the LSM330 accelerometer device structure. */
 
-  priv = (FAR struct lsm330_dev_s *)kmm_malloc(sizeof(struct lsm330_dev_s));
+  priv = kmm_malloc(sizeof(struct lsm330_dev_s));
   if (priv == NULL)
     {
       snerr("ERROR: Failed to allocate accelerometer instance\n");
@@ -1363,7 +1363,7 @@ int lsm330_register(FAR const char *devpath_acl,
 
   /* Initialize the LSM330 gyroscope device structure. */
 
-  priv = (FAR struct lsm330_dev_s *)kmm_malloc(sizeof(struct lsm330_dev_s));
+  priv = kmm_malloc(sizeof(struct lsm330_dev_s));
   if (priv == NULL)
     {
       snerr("ERROR: Failed to allocate gyroscope instance\n");

--- a/drivers/sensors/lsm6dsl.c
+++ b/drivers/sensors/lsm6dsl.c
@@ -1180,7 +1180,7 @@ static int lsm6dsl_register(FAR const char *devpath,
 
   /* Initialize the device's structure */
 
-  priv = (FAR struct lsm6dsl_dev_s *)kmm_malloc(sizeof(*priv));
+  priv = kmm_malloc(sizeof(*priv));
   if (priv == NULL)
     {
       snerr("ERROR: Failed to allocate instance\n");

--- a/drivers/sensors/lsm9ds1.c
+++ b/drivers/sensors/lsm9ds1.c
@@ -1425,7 +1425,7 @@ static int lsm9ds1_register(FAR const char *devpath,
 
   /* Initialize the device's structure */
 
-  priv = (FAR struct lsm9ds1_dev_s *)kmm_malloc(sizeof(*priv));
+  priv = kmm_malloc(sizeof(*priv));
   if (priv == NULL)
     {
       snerr("ERROR: Failed to allocate instance\n");

--- a/drivers/sensors/ltr308.c
+++ b/drivers/sensors/ltr308.c
@@ -592,7 +592,7 @@ int ltr308_register(int devno, FAR struct i2c_master_s *i2c)
 
   /* Initialize the LTR308 device structure */
 
-  priv = (FAR struct ltr308_dev_s *)kmm_zalloc(sizeof(struct ltr308_dev_s));
+  priv = kmm_zalloc(sizeof(struct ltr308_dev_s));
   if (priv == NULL)
     {
       snerr("ERROR: Failed to allocate instance (err = %d)\n", ret);

--- a/drivers/sensors/mb7040.c
+++ b/drivers/sensors/mb7040.c
@@ -333,7 +333,7 @@ int mb7040_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Initialize the device's structure */
 
-  priv = (FAR struct mb7040_dev_s *)kmm_malloc(sizeof(*priv));
+  priv = kmm_malloc(sizeof(*priv));
   if (priv == NULL)
     {
       snerr("ERROR: Failed to allocate instance\n");

--- a/drivers/sensors/mcp9844.c
+++ b/drivers/sensors/mcp9844.c
@@ -355,15 +355,15 @@ static int mcp9844_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 int mcp9844_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
                      uint8_t addr)
 {
+  FAR struct mcp9844_dev_s *priv;
+
   /* Sanity check */
 
   DEBUGASSERT(i2c != NULL);
 
   /* Initialize the MCP9844 device structure */
 
-  FAR struct mcp9844_dev_s *priv =
-    (FAR struct mcp9844_dev_s *)kmm_malloc(sizeof(struct mcp9844_dev_s));
-
+  priv = kmm_malloc(sizeof(struct mcp9844_dev_s));
   if (priv == NULL)
     {
       snerr("ERROR: Failed to allocate instance\n");

--- a/drivers/sensors/mlx90614.c
+++ b/drivers/sensors/mlx90614.c
@@ -403,7 +403,7 @@ int mlx90614_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
   /* Initialize the MLX90614 device structure */
 
   FAR struct mlx90614_dev_s *priv =
-    (FAR struct mlx90614_dev_s *)kmm_malloc(sizeof(struct mlx90614_dev_s));
+    kmm_malloc(sizeof(struct mlx90614_dev_s));
 
   if (priv == NULL)
     {

--- a/drivers/sensors/mpu60x0.c
+++ b/drivers/sensors/mpu60x0.c
@@ -1145,7 +1145,7 @@ int mpu60x0_register(FAR const char *path, FAR struct mpu_config_s *config)
 
   /* Initialize the device structure. */
 
-  priv = (FAR struct mpu_dev_s *)kmm_malloc(sizeof(struct mpu_dev_s));
+  priv = kmm_malloc(sizeof(struct mpu_dev_s));
   if (priv == NULL)
     {
       snerr("ERROR: Failed to allocate mpu60x0 device instance\n");

--- a/drivers/sensors/mpu9250.c
+++ b/drivers/sensors/mpu9250.c
@@ -1938,7 +1938,7 @@ int mpu9250_register(int devno, FAR struct mpu9250_config_s *config)
 
   /* Initialize the device structure. */
 
-  dev = (FAR struct mpu9250_dev_s *)kmm_malloc(sizeof(struct mpu9250_dev_s));
+  dev = kmm_malloc(sizeof(struct mpu9250_dev_s));
   if (dev == NULL)
     {
       snerr("ERROR: Failed to allocate mpu9250 device instance\n");

--- a/drivers/sensors/ms5611.c
+++ b/drivers/sensors/ms5611.c
@@ -645,7 +645,7 @@ int ms5611_register(FAR struct i2c_master_s *i2c, int devno, uint8_t addr)
 
   /* Initialize the MS5611 device structure */
 
-  priv = (FAR struct ms5611_dev_s *)kmm_zalloc(sizeof(struct ms5611_dev_s));
+  priv = kmm_zalloc(sizeof(struct ms5611_dev_s));
   if (priv == NULL)
     {
       snerr("Failed to allocate instance\n");

--- a/drivers/sensors/ms58xx.c
+++ b/drivers/sensors/ms58xx.c
@@ -912,7 +912,7 @@ int ms58xx_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Initialize the device's structure */
 
-  priv = (FAR struct ms58xx_dev_s *)kmm_malloc(sizeof(*priv));
+  priv = kmm_malloc(sizeof(*priv));
   if (priv == NULL)
     {
       snerr("ERROR: Failed to allocate instance\n");

--- a/drivers/sensors/msa301.c
+++ b/drivers/sensors/msa301.c
@@ -658,7 +658,7 @@ static int msa301_register(FAR const char *devpath,
 
   /* Initialize the device's structure */
 
-  priv = (FAR struct msa301_dev_s *)kmm_malloc(sizeof(*priv));
+  priv = kmm_malloc(sizeof(*priv));
   if (priv == NULL)
     {
       snerr("ERROR: Failed to allocate instance\n");

--- a/drivers/sensors/scd30.c
+++ b/drivers/sensors/scd30.c
@@ -1047,7 +1047,7 @@ int scd30_register_i2c(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Initialize the device structure */
 
-  priv = (FAR struct scd30_dev_s *)kmm_zalloc(sizeof(struct scd30_dev_s));
+  priv = kmm_zalloc(sizeof(struct scd30_dev_s));
   if (priv == NULL)
     {
       scd30_dbg("ERROR: Failed to allocate instance\n");

--- a/drivers/sensors/scd41.c
+++ b/drivers/sensors/scd41.c
@@ -1000,7 +1000,7 @@ int scd41_register_i2c(FAR const char *devpath, FAR struct i2c_master_s *i2c)
 
   /* Initialize the device structure */
 
-  priv = (FAR struct scd41_dev_s *)kmm_zalloc(sizeof(struct scd41_dev_s));
+  priv = kmm_zalloc(sizeof(struct scd41_dev_s));
   if (priv == NULL)
     {
       scd41_dbg("ERROR: Failed to allocate instance\n");

--- a/drivers/sensors/sgp30.c
+++ b/drivers/sensors/sgp30.c
@@ -1053,7 +1053,7 @@ int sgp30_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Initialize the device structure */
 
-  priv = (FAR struct sgp30_dev_s *)kmm_zalloc(sizeof(struct sgp30_dev_s));
+  priv = kmm_zalloc(sizeof(struct sgp30_dev_s));
   if (priv == NULL)
     {
       sgp30_dbg("ERROR: Failed to allocate instance\n");

--- a/drivers/sensors/sht21.c
+++ b/drivers/sensors/sht21.c
@@ -654,7 +654,7 @@ int sht21_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Initialize the device structure */
 
-  priv = (FAR struct sht21_dev_s *)kmm_zalloc(sizeof(struct sht21_dev_s));
+  priv = kmm_zalloc(sizeof(struct sht21_dev_s));
   if (priv == NULL)
     {
       snerr("ERROR: Failed to allocate instance\n");

--- a/drivers/sensors/sht3x.c
+++ b/drivers/sensors/sht3x.c
@@ -671,7 +671,7 @@ int sht3x_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Initialize the device structure */
 
-  priv = (FAR struct sht3x_dev_s *)kmm_zalloc(sizeof(struct sht3x_dev_s));
+  priv = kmm_zalloc(sizeof(struct sht3x_dev_s));
   if (priv == NULL)
     {
       snerr("ERROR: Failed to allocate instance\n");

--- a/drivers/sensors/sps30.c
+++ b/drivers/sensors/sps30.c
@@ -1065,7 +1065,7 @@ int sps30_register_i2c(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Initialize the device structure */
 
-  priv = (FAR struct sps30_dev_s *)kmm_zalloc(sizeof(struct sps30_dev_s));
+  priv = kmm_zalloc(sizeof(struct sps30_dev_s));
   if (priv == NULL)
     {
       sps30_dbg("ERROR: Failed to allocate instance\n");

--- a/drivers/sensors/t67xx.c
+++ b/drivers/sensors/t67xx.c
@@ -707,7 +707,7 @@ int t67xx_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Initialize the t67xx device structure. */
 
-  priv = (FAR struct t67xx_dev_s *)kmm_malloc(sizeof(struct t67xx_dev_s));
+  priv = kmm_malloc(sizeof(struct t67xx_dev_s));
   if (priv == NULL)
     {
       snerr("ERROR: Failed to allocate instance\n");

--- a/drivers/sensors/veml6070.c
+++ b/drivers/sensors/veml6070.c
@@ -265,6 +265,7 @@ static ssize_t veml6070_write(FAR struct file *filep,
 int veml6070_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
                        uint8_t addr)
 {
+  FAR struct veml6070_dev_s *priv;
   int ret;
 
   /* Sanity check */
@@ -273,9 +274,7 @@ int veml6070_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Initialize the VEML6070 device structure */
 
-  FAR struct veml6070_dev_s *priv =
-    (FAR struct veml6070_dev_s *)kmm_malloc(sizeof(struct veml6070_dev_s));
-
+  priv = kmm_malloc(sizeof(struct veml6070_dev_s));
   if (priv == NULL)
     {
       snerr("ERROR: Failed to allocate instance\n");

--- a/drivers/sensors/vl53l1x.c
+++ b/drivers/sensors/vl53l1x.c
@@ -1121,8 +1121,7 @@ int vl53l1x_register(FAR const char *devpath, FAR struct i2c_master_s *i2c)
 
   /* Initialize the vl53l1x device structure */
 
-  priv = (FAR struct vl53l1x_dev_s *)kmm_malloc(
-    sizeof(struct vl53l1x_dev_s));
+  priv = kmm_malloc(sizeof(struct vl53l1x_dev_s));
   if (!priv)
     {
       snerr("ERROR: Failed to allocate instance\n");

--- a/drivers/sensors/zerocross.c
+++ b/drivers/sensors/zerocross.c
@@ -215,7 +215,7 @@ static int zc_open(FAR struct file *filep)
 
   /* Allocate a new open structure */
 
-  opriv = (FAR struct zc_open_s *)kmm_zalloc(sizeof(struct zc_open_s));
+  opriv = kmm_zalloc(sizeof(struct zc_open_s));
   if (!opriv)
     {
       snerr("ERROR: Failed to allocate open structure\n");

--- a/drivers/serial/uart_bth5.c
+++ b/drivers/serial/uart_bth5.c
@@ -1237,7 +1237,7 @@ uart_bth5_register(FAR const char *path, FAR struct bt_driver_s *drv)
   FAR struct uart_bth5_s *dev;
   int ret;
 
-  dev = (FAR struct uart_bth5_s *)kmm_zalloc(sizeof(struct uart_bth5_s));
+  dev = kmm_zalloc(sizeof(struct uart_bth5_s));
   if (dev == NULL)
     {
       return -ENOMEM;

--- a/drivers/spi/spi_driver.c
+++ b/drivers/spi/spi_driver.c
@@ -358,7 +358,7 @@ int spi_register(FAR struct spi_dev_s *spi, int bus)
 
   /* Allocate a SPI character device structure */
 
-  priv = (FAR struct spi_driver_s *)kmm_zalloc(sizeof(struct spi_driver_s));
+  priv = kmm_zalloc(sizeof(struct spi_driver_s));
   if (priv)
     {
       /* Initialize the SPI character device structure */

--- a/drivers/syslog/ramlog.c
+++ b/drivers/syslog/ramlog.c
@@ -796,7 +796,7 @@ int ramlog_register(FAR const char *devpath, FAR char *buffer, size_t buflen)
 
   /* Allocate a RAM logging device structure */
 
-  priv = (struct ramlog_dev_s *)kmm_zalloc(sizeof(struct ramlog_dev_s));
+  priv = kmm_zalloc(sizeof(struct ramlog_dev_s));
   if (priv != NULL)
     {
       /* Initialize the non-zero values in the RAM logging device structure */

--- a/drivers/timers/pl031.c
+++ b/drivers/timers/pl031.c
@@ -273,7 +273,7 @@ pl031_setrelative(FAR struct rtc_lowerhalf_s *lower,
 FAR struct rtc_lowerhalf_s *pl031_initialize(uintptr_t base, int irq)
 {
   FAR struct pl031_lowerhalf_s *rtc_lowerhalf =
-     (FAR struct pl031_lowerhalf_s *)kmm_zalloc(sizeof(*rtc_lowerhalf));
+     kmm_zalloc(sizeof(*rtc_lowerhalf));
 
   rtc_lowerhalf->ops = &g_rtc_ops;
   rtc_lowerhalf->base = base;

--- a/drivers/usbdev/usbmsc.c
+++ b/drivers/usbdev/usbmsc.c
@@ -1261,8 +1261,7 @@ int usbmsc_configure(unsigned int nluns, void **handle)
 
   /* Allocate the structures needed */
 
-  alloc = (FAR struct usbmsc_alloc_s *)
-    kmm_malloc(sizeof(struct usbmsc_alloc_s));
+  alloc = kmm_malloc(sizeof(struct usbmsc_alloc_s));
   if (!alloc)
     {
       usbtrace(TRACE_CLSERROR(USBMSC_TRACEERR_ALLOCDEVSTRUCT), 0);
@@ -1285,9 +1284,7 @@ int usbmsc_configure(unsigned int nluns, void **handle)
 
   /* Allocate the LUN table */
 
-  priv->luntab = (FAR struct usbmsc_lun_s *)
-    kmm_malloc(priv->nluns*sizeof(struct usbmsc_lun_s));
-
+  priv->luntab = kmm_malloc(priv->nluns*sizeof(struct usbmsc_lun_s));
   if (!priv->luntab)
     {
       ret = -ENOMEM;
@@ -1456,10 +1453,10 @@ int usbmsc_bindlun(FAR void *handle, FAR const char *drvrpath,
   if (!priv->iobuffer)
     {
 #ifdef CONFIG_USBMSC_WRMULTIPLE
-      priv->iobuffer = (FAR uint8_t *)kmm_malloc(geo.geo_sectorsize *
-                                                 CONFIG_USBMSC_NWRREQS);
+      priv->iobuffer = kmm_malloc(geo.geo_sectorsize *
+                                  CONFIG_USBMSC_NWRREQS);
 #else
-      priv->iobuffer = (FAR uint8_t *)kmm_malloc(geo.geo_sectorsize);
+      priv->iobuffer = kmm_malloc(geo.geo_sectorsize);
 #endif
       if (!priv->iobuffer)
         {
@@ -1478,7 +1475,7 @@ int usbmsc_bindlun(FAR void *handle, FAR const char *drvrpath,
     {
       FAR void *tmp;
 
-      tmp = (FAR void *)kmm_realloc(priv->iobuffer, geo.geo_sectorsize);
+      tmp = kmm_realloc(priv->iobuffer, geo.geo_sectorsize);
       if (!tmp)
         {
           usbtrace(TRACE_CLSERROR(USBMSC_TRACEERR_REALLOCIOBUFFER),

--- a/drivers/usbhost/usbhost_cdcmbim.c
+++ b/drivers/usbhost/usbhost_cdcmbim.c
@@ -629,8 +629,7 @@ static inline FAR struct usbhost_cdcmbim_s *usbhost_allocclass(void)
   FAR struct usbhost_cdcmbim_s *priv;
 
   DEBUGASSERT(!up_interrupt_context());
-  priv = (FAR struct usbhost_cdcmbim_s *)kmm_malloc(
-                                         sizeof(struct usbhost_cdcmbim_s));
+  priv = kmm_malloc(sizeof(struct usbhost_cdcmbim_s));
   uinfo("Allocated: %p\n", priv);
   return priv;
 }

--- a/drivers/usbhost/usbhost_composite.c
+++ b/drivers/usbhost/usbhost_composite.c
@@ -773,7 +773,7 @@ int usbhost_composite(FAR struct usbhost_hubport_s *hport,
    * configuration descriptor for each member class.
    */
 
-  cfgbuffer = (FAR uint8_t *)kmm_malloc(CUSTOM_CONFIG_BUFSIZE);
+  cfgbuffer = kmm_malloc(CUSTOM_CONFIG_BUFSIZE);
   if (cfgbuffer == NULL)
     {
       uerr("ERROR: Failed to allocate configuration buffer");

--- a/drivers/usbhost/usbhost_max3421e.c
+++ b/drivers/usbhost/usbhost_max3421e.c
@@ -3781,7 +3781,7 @@ static int max3421e_alloc(FAR struct usbhost_driver_s *drvr,
 
   /* There is no special memory requirement for the MAX3421E. */
 
-  alloc = (FAR uint8_t *)kmm_malloc(CONFIG_MAX3421E_DESCSIZE);
+  alloc = kmm_malloc(CONFIG_MAX3421E_DESCSIZE);
   if (!alloc)
     {
       return -ENOMEM;
@@ -3866,7 +3866,7 @@ static int max3421e_ioalloc(FAR struct usbhost_driver_s *drvr,
 
   /* There is no special memory requirement */
 
-  alloc = (FAR uint8_t *)kmm_malloc(buflen);
+  alloc = kmm_malloc(buflen);
   if (!alloc)
     {
       return -ENOMEM;

--- a/drivers/video/fb.c
+++ b/drivers/video/fb.c
@@ -1066,7 +1066,7 @@ int fb_register(int display, int plane)
 
   /* Allocate a framebuffer state instance */
 
-  fb = (FAR struct fb_chardev_s *)kmm_zalloc(sizeof(struct fb_chardev_s));
+  fb = kmm_zalloc(sizeof(struct fb_chardev_s));
   if (fb == NULL)
     {
       return -ENOMEM;

--- a/drivers/video/max7456.c
+++ b/drivers/video/max7456.c
@@ -1603,7 +1603,7 @@ int max7456_register(FAR const char *path, FAR struct mx7_config_s *config)
 
   /* Initialize the device structure. */
 
-  dev = (FAR struct mx7_dev_s *)kmm_malloc(sizeof(struct mx7_dev_s));
+  dev = kmm_malloc(sizeof(struct mx7_dev_s));
   if (dev == NULL)
     {
       return -ENOMEM;

--- a/drivers/video/video.c
+++ b/drivers/video/video.c
@@ -833,8 +833,7 @@ static int initialize_scene_parameter(FAR video_mng_t *vmng,
                                       enum v4l2_scene_mode mode,
                                       video_scene_params_t **vsp)
 {
-  video_scene_params_t *sp =
-    (FAR video_scene_params_t *)kmm_malloc(sizeof(video_scene_params_t));
+  FAR video_scene_params_t *sp = kmm_malloc(sizeof(video_scene_params_t));
   if (!sp)
     {
       return -ENOMEM;
@@ -3438,7 +3437,7 @@ int video_register(FAR const char *devpath,
 
   /* Initialize video device structure */
 
-  priv = (FAR video_mng_t *)kmm_zalloc(sizeof(video_mng_t));
+  priv = kmm_zalloc(sizeof(video_mng_t));
   if (priv == NULL)
     {
       verr("Failed to allocate instance\n");
@@ -3454,7 +3453,7 @@ int video_register(FAR const char *devpath,
 
   /* Save device path */
 
-  priv->devpath = (FAR char *)kmm_malloc(allocsize + 1);
+  priv->devpath = kmm_malloc(allocsize + 1);
   if (priv->devpath == NULL)
     {
       kmm_free(priv);

--- a/drivers/video/vnc/vnc_server.c
+++ b/drivers/video/vnc/vnc_server.c
@@ -260,7 +260,7 @@ int vnc_server(int argc, FAR char *argv[])
    * the KMM allocator will align memory to 32-bits or better.
    */
 
-  fb = (FAR uint8_t *)kmm_zalloc(RFB_SIZE);
+  fb = kmm_zalloc(RFB_SIZE);
   if (fb == NULL)
     {
       gerr("ERROR: Failed to allocate framebuffer memory: %lu KB\n",

--- a/drivers/wireless/bluetooth/bt_bridge.c
+++ b/drivers/wireless/bluetooth/bt_bridge.c
@@ -589,7 +589,7 @@ int bt_bridge_register(FAR struct bt_driver_s *hcidrv,
       return -EINVAL;
     }
 
-  bridge = (FAR struct bt_bridge_s *)kmm_zalloc(sizeof(struct bt_bridge_s));
+  bridge = kmm_zalloc(sizeof(struct bt_bridge_s));
   if (!bridge)
     {
       return -ENOMEM;

--- a/drivers/wireless/gs2200m.c
+++ b/drivers/wireless/gs2200m.c
@@ -1099,7 +1099,7 @@ static void _parse_pkt_in_s1(FAR struct pkt_ctx_s *pkt_ctx,
   ASSERT(pkt_ctx->ptr > pkt_ctx->head);
   msize = pkt_ctx->ptr - pkt_ctx->head;
 
-  msg = (FAR char *)kmm_calloc(msize + 1, 1);
+  msg = kmm_calloc(msize + 1, 1);
   ASSERT(msg);
 
   memcpy(msg, pkt_ctx->head, msize);
@@ -1373,7 +1373,7 @@ static void _dup_pkt_dat_and_notify(FAR struct gs2200m_dev_s *dev,
 
   /* Allocate a new pkt_dat */
 
-  pkt_dat = (FAR struct pkt_dat_s *)kmm_malloc(sizeof(struct pkt_dat_s));
+  pkt_dat = kmm_malloc(sizeof(struct pkt_dat_s));
   ASSERT(pkt_dat);
 
   /* Copy pkt_dat0 to pkt_dat */
@@ -1382,7 +1382,7 @@ static void _dup_pkt_dat_and_notify(FAR struct gs2200m_dev_s *dev,
 
   /* Allocate bulk data and copy */
 
-  pkt_dat->data = (FAR uint8_t *)kmm_malloc(pkt_dat0->len);
+  pkt_dat->data = kmm_malloc(pkt_dat0->len);
   ASSERT(pkt_dat->data);
   memcpy(pkt_dat->data, pkt_dat0->data, pkt_dat0->len);
 
@@ -1418,7 +1418,7 @@ static enum pkt_type_e gs2200m_recv_pkt(FAR struct gs2200m_dev_s *dev,
   uint16_t len;
   FAR uint8_t *p;
 
-  p = (FAR uint8_t *)kmm_calloc(MAX_PKT_LEN, 1);
+  p = kmm_calloc(MAX_PKT_LEN, 1);
   ASSERT(p);
 
   s = gs2200m_hal_read(dev, p, &len);
@@ -3195,7 +3195,7 @@ repeat:
 
   /* Allocate a new pkt_dat and initialize it */
 
-  pkt_dat = (FAR struct pkt_dat_s *)kmm_malloc(sizeof(struct pkt_dat_s));
+  pkt_dat = kmm_malloc(sizeof(struct pkt_dat_s));
   ASSERT(NULL != pkt_dat);
 
   memset(pkt_dat, 0, sizeof(struct pkt_dat_s));
@@ -3488,7 +3488,7 @@ FAR void *gs2200m_register(FAR const char *devpath,
   int size;
 
   size = sizeof(struct gs2200m_dev_s);
-  dev = (FAR struct gs2200m_dev_s *)kmm_malloc(size);
+  dev = kmm_malloc(size);
   if (!dev)
     {
       wlerr("Failed to allocate instance.\n");

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_core.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_core.c
@@ -256,7 +256,7 @@ int bcmf_upload_file(FAR bcmf_interface_dev_t *ibus, uint32_t address,
 
   /* Allocate an I/O buffer */
 
-  buf = (FAR uint8_t *)kmm_malloc(BCMF_UPLOAD_TRANSFER_SIZE);
+  buf = kmm_malloc(BCMF_UPLOAD_TRANSFER_SIZE);
   if (buf == NULL)
     {
       wlerr("ERROR: Failed allocate an I/O buffer\n");
@@ -361,7 +361,7 @@ int bcmf_upload_nvram(FAR bcmf_interface_dev_t *ibus)
 
   stat.st_size = (stat.st_size + 63) & (~63);
 
-  buf = (FAR uint8_t *)kmm_malloc(stat.st_size);
+  buf = kmm_malloc(stat.st_size);
   if (buf == NULL)
     {
       goto out;

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c
@@ -1136,7 +1136,7 @@ FAR struct bcmf_dev_s *bcmf_allocate_device(void)
 
   /* Allocate a bcmf device structure */
 
-  priv = (FAR struct bcmf_dev_s *)kmm_malloc(sizeof(*priv));
+  priv = kmm_malloc(sizeof(*priv));
   if (!priv)
     {
       return NULL;

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_gspi.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_gspi.c
@@ -794,7 +794,7 @@ static int bcmf_bus_gspi_initialize(FAR struct bcmf_dev_s *priv,
 
   /* Allocate gSPI bus structure */
 
-  gbus = (FAR bcmf_gspi_dev_t *)kmm_zalloc(sizeof(*gbus));
+  gbus = kmm_zalloc(sizeof(*gbus));
 
   if (!gspi)
     {

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_sdio.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_sdio.c
@@ -651,7 +651,7 @@ static int bcmf_bus_sdio_initialize(FAR struct bcmf_dev_s *priv,
 
   /* Allocate sdio bus structure */
 
-  sbus = (FAR struct bcmf_sdio_dev_s *)kmm_malloc(sizeof(*sbus));
+  sbus = kmm_malloc(sizeof(*sbus));
   if (!sbus)
     {
       return -ENOMEM;

--- a/drivers/wireless/ieee802154/xbee/xbee.c
+++ b/drivers/wireless/ieee802154/xbee/xbee.c
@@ -1217,7 +1217,7 @@ XBEEHANDLE xbee_init(FAR struct spi_dev_s *spi,
 
   /* Allocate object */
 
-  priv = (FAR struct xbee_priv_s *) kmm_zalloc(sizeof(struct xbee_priv_s));
+  priv = kmm_zalloc(sizeof(struct xbee_priv_s));
   if (priv == NULL)
     {
       wlinfo("Failed allocation xbee_priv_s structure\n");

--- a/fs/cromfs/fs_cromfs.c
+++ b/fs/cromfs/fs_cromfs.c
@@ -780,7 +780,7 @@ static int cromfs_open(FAR struct file *filep, FAR const char *relpath,
    * file.
    */
 
-  ff = (FAR struct cromfs_file_s *)kmm_zalloc(sizeof(struct cromfs_file_s));
+  ff = kmm_zalloc(sizeof(struct cromfs_file_s));
   if (ff == NULL)
     {
       return -ENOMEM;
@@ -788,7 +788,7 @@ static int cromfs_open(FAR struct file *filep, FAR const char *relpath,
 
   /* Create a file buffer to support partial sector accesses */
 
-  ff->ff_buffer = (FAR uint8_t *)kmm_malloc(fs->cv_bsize);
+  ff->ff_buffer = kmm_malloc(fs->cv_bsize);
   if (!ff->ff_buffer)
     {
       kmm_free(ff);
@@ -1117,7 +1117,7 @@ static int cromfs_dup(FAR const struct file *oldp, FAR struct file *newp)
 
   /* Create a file buffer to support partial sector accesses */
 
-  newff->ff_buffer = (FAR uint8_t *)kmm_malloc(fs->cv_bsize);
+  newff->ff_buffer = kmm_malloc(fs->cv_bsize);
   if (newff->ff_buffer == NULL)
     {
       kmm_free(newff);

--- a/fs/fat/fs_fat32.c
+++ b/fs/fat/fs_fat32.c
@@ -313,7 +313,7 @@ static int fat_open(FAR struct file *filep, FAR const char *relpath,
    * file.
    */
 
-  ff = (FAR struct fat_file_s *)kmm_zalloc(sizeof(struct fat_file_s));
+  ff = kmm_zalloc(sizeof(struct fat_file_s));
   if (!ff)
     {
       ret = -ENOMEM;
@@ -1498,7 +1498,7 @@ static int fat_dup(FAR const struct file *oldp, FAR struct file *newp)
    * dup'ed file.
    */
 
-  newff = (FAR struct fat_file_s *)kmm_malloc(sizeof(struct fat_file_s));
+  newff = kmm_malloc(sizeof(struct fat_file_s));
   if (!newff)
     {
       ret = -ENOMEM;
@@ -2179,7 +2179,7 @@ static int fat_bind(FAR struct inode *blkdriver, FAR const void *data,
 
   /* Create an instance of the mountpt state structure */
 
-  fs = (struct fat_mountpt_s *)kmm_zalloc(sizeof(struct fat_mountpt_s));
+  fs = kmm_zalloc(sizeof(struct fat_mountpt_s));
   if (!fs)
     {
       return -ENOMEM;

--- a/fs/hostfs/hostfs.c
+++ b/fs/hostfs/hostfs.c
@@ -268,7 +268,7 @@ static int hostfs_open(FAR struct file *filep, FAR const char *relpath,
 
   /* Allocate memory for the open file */
 
-  hf = (struct hostfs_ofile_s *) kmm_malloc(sizeof *hf);
+  hf = kmm_malloc(sizeof *hf);
   if (hf == NULL)
     {
       ret = -ENOMEM;

--- a/fs/inode/fs_foreachinode.c
+++ b/fs/inode/fs_foreachinode.c
@@ -170,7 +170,7 @@ int foreach_inode(foreach_inode_t handler, FAR void *arg)
 
   /* Allocate the mountpoint info structure */
 
-  info = (FAR struct inode_path_s *)kmm_malloc(sizeof(struct inode_path_s));
+  info = kmm_malloc(sizeof(struct inode_path_s));
   if (!info)
     {
       return -ENOMEM;

--- a/fs/inode/fs_inodereserve.c
+++ b/fs/inode/fs_inodereserve.c
@@ -81,7 +81,7 @@ static FAR struct inode *inode_alloc(FAR const char *name, mode_t mode)
   int namelen;
 
   namelen = inode_namelen(name);
-  node    = (FAR struct inode *)kmm_zalloc(FSNODE_SIZE(namelen));
+  node    = kmm_zalloc(FSNODE_SIZE(namelen));
   if (node)
     {
       node->i_ino   = g_ino++;

--- a/fs/mount/fs_automount.c
+++ b/fs/mount/fs_automount.c
@@ -213,8 +213,7 @@ static int automount_open(FAR struct file *filep)
 
   /* Allocate a new open structure */
 
-  opriv = (FAR struct automounter_open_s *)kmm_zalloc(
-      sizeof(struct automounter_open_s));
+  opriv = kmm_zalloc(sizeof(struct automounter_open_s));
   if (opriv == NULL)
     {
       ferr("ERROR: Failed to allocate open structure\n");
@@ -819,9 +818,7 @@ FAR void *automount_initialize(FAR const struct automount_lower_s *lower)
 
   /* Allocate an auto-mounter state structure */
 
-  priv = (FAR struct automounter_state_s *)
-    kmm_zalloc(sizeof(struct automounter_state_s));
-
+  priv = kmm_zalloc(sizeof(struct automounter_state_s));
   if (priv == NULL)
     {
       ferr("ERROR: Failed to allocate state structure\n");

--- a/fs/nfs/nfs_vfsops.c
+++ b/fs/nfs/nfs_vfsops.c
@@ -664,7 +664,7 @@ static int nfs_open(FAR struct file *filep, FAR const char *relpath,
 
   /* Pre-allocate the file private data to describe the opened file. */
 
-  np = (FAR struct nfsnode *)kmm_zalloc(sizeof(struct nfsnode));
+  np = kmm_zalloc(sizeof(struct nfsnode));
   if (!np)
     {
       ferr("ERROR: Failed to allocate private data\n");
@@ -2078,7 +2078,7 @@ static int nfs_bind(FAR struct inode *blkdriver, FAR const void *data,
 
   /* Create an instance of the mountpt state structure */
 
-  nmp = (FAR struct nfsmount *)kmm_zalloc(SIZEOF_nfsmount(buflen));
+  nmp = kmm_zalloc(SIZEOF_nfsmount(buflen));
   if (!nmp)
     {
       ferr("ERROR: Failed to allocate mountpoint structure\n");
@@ -2118,7 +2118,7 @@ static int nfs_bind(FAR struct inode *blkdriver, FAR const void *data,
 
   /* Create an instance of the rpc state structure */
 
-  rpc = (FAR struct rpcclnt *)kmm_zalloc(sizeof(struct rpcclnt));
+  rpc = kmm_zalloc(sizeof(struct rpcclnt));
   if (!rpc)
     {
       ferr("ERROR: Failed to allocate rpc structure\n");

--- a/fs/nxffs/nxffs_dump.c
+++ b/fs/nxffs/nxffs_dump.c
@@ -441,7 +441,7 @@ int nxffs_dump(FAR struct mtd_dev_s *mtd, bool verbose)
 
   /* Allocate a buffer to hold one block */
 
-  blkinfo.buffer = (FAR uint8_t *)kmm_malloc(blkinfo.geo.blocksize);
+  blkinfo.buffer = kmm_malloc(blkinfo.geo.blocksize);
   if (!blkinfo.buffer)
     {
       ferr("ERROR: Failed to allocate block cache\n");

--- a/fs/nxffs/nxffs_initialize.c
+++ b/fs/nxffs/nxffs_initialize.c
@@ -190,7 +190,7 @@ int nxffs_initialize(FAR struct mtd_dev_s *mtd)
 
   /* Allocate one I/O block buffer to general files system access */
 
-  volume->cache = (FAR uint8_t *)kmm_malloc(volume->geo.blocksize);
+  volume->cache = kmm_malloc(volume->geo.blocksize);
   if (!volume->cache)
     {
       ferr("ERROR: Failed to allocate an erase block buffer\n");
@@ -203,7 +203,7 @@ int nxffs_initialize(FAR struct mtd_dev_s *mtd)
    * is not needed often, but is best to have pre-allocated and in-place.
    */
 
-  volume->pack = (FAR uint8_t *)kmm_malloc(volume->geo.erasesize);
+  volume->pack = kmm_malloc(volume->geo.erasesize);
   if (!volume->pack)
     {
       ferr("ERROR: Failed to allocate an I/O block buffer\n");

--- a/fs/nxffs/nxffs_inode.c
+++ b/fs/nxffs/nxffs_inode.c
@@ -108,7 +108,7 @@ static int nxffs_rdentry(FAR struct nxffs_volume_s *volume, off_t offset,
   /* Allocate memory to hold the variable-length file name */
 
   namlen = inode.namlen;
-  entry->name = (FAR char *)kmm_malloc(namlen + 1);
+  entry->name = kmm_malloc(namlen + 1);
   if (!entry->name)
     {
       ferr("ERROR: Failed to allocate name, namlen: %d\n", namlen);

--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -1640,7 +1640,7 @@ static int proc_dup(FAR const struct file *oldp, FAR struct file *newp)
 
   /* Allocate a new container to hold the task and node selection */
 
-  newfile = (FAR struct proc_file_s *)kmm_malloc(sizeof(struct proc_file_s));
+  newfile = kmm_malloc(sizeof(struct proc_file_s));
   if (newfile == NULL)
     {
       ferr("ERROR: Failed to allocate file container\n");
@@ -1733,7 +1733,7 @@ static int proc_opendir(FAR const char *relpath,
    * non-zero entries will need be initialized.
    */
 
-  procdir = (FAR struct proc_dir_s *)kmm_zalloc(sizeof(struct proc_dir_s));
+  procdir = kmm_zalloc(sizeof(struct proc_dir_s));
   if (procdir == NULL)
     {
       ferr("ERROR: Failed to allocate the directory structure\n");

--- a/fs/procfs/fs_skeleton.c
+++ b/fs/procfs/fs_skeleton.c
@@ -173,7 +173,7 @@ static int skel_open(FAR struct file *filep, FAR const char *relpath,
 
   /* Allocate the open file structure */
 
-  priv = (FAR struct skel_file_s *)kmm_zalloc(sizeof(struct skel_file_s));
+  priv = kmm_zalloc(sizeof(struct skel_file_s));
   if (!priv)
     {
       ferr("ERROR: Failed to allocate file attributes\n");
@@ -312,7 +312,7 @@ static int skel_dup(FAR const struct file *oldp, FAR struct file *newp)
 
   /* Allocate a new container to hold the task and attribute selection */
 
-  newpriv = (FAR struct skel_file_s *)kmm_zalloc(sizeof(struct skel_file_s));
+  newpriv = kmm_zalloc(sizeof(struct skel_file_s));
   if (!newpriv)
     {
       ferr("ERROR: Failed to allocate file attributes\n");

--- a/fs/rpmsgfs/rpmsgfs.c
+++ b/fs/rpmsgfs/rpmsgfs.c
@@ -302,7 +302,7 @@ static int rpmsgfs_open(FAR struct file *filep, FAR const char *relpath,
 
   /* Allocate memory for the open file */
 
-  hf = (struct rpmsgfs_ofile_s *) kmm_malloc(sizeof *hf);
+  hf = kmm_malloc(sizeof *hf);
   if (hf == NULL)
     {
       ret = -ENOMEM;

--- a/fs/smartfs/smartfs_smart.c
+++ b/fs/smartfs/smartfs_smart.c
@@ -209,7 +209,7 @@ static int smartfs_open(FAR struct file *filep, FAR const char *relpath,
 
   /* Locate the directory entry for this path */
 
-  sf = (FAR struct smartfs_ofile_s *)kmm_malloc(sizeof *sf);
+  sf = kmm_malloc(sizeof *sf);
   if (sf == NULL)
     {
       ret = -ENOMEM;
@@ -219,7 +219,7 @@ static int smartfs_open(FAR struct file *filep, FAR const char *relpath,
   /* Allocate a sector buffer if CRC enabled in the MTD layer */
 
 #ifdef CONFIG_SMARTFS_USE_SECTOR_BUFFER
-  sf->buffer = (FAR uint8_t *)kmm_malloc(fs->fs_llformat.availbytes);
+  sf->buffer = kmm_malloc(fs->fs_llformat.availbytes);
   if (sf->buffer == NULL)
     {
       /* Error ... no memory */

--- a/fs/smartfs/smartfs_utils.c
+++ b/fs/smartfs/smartfs_utils.c
@@ -242,8 +242,8 @@ int smartfs_mount(struct smartfs_mountpt_s *fs, bool writeable)
 
   if (nextfs == NULL)
     {
-      fs->fs_rwbuffer = (char *) kmm_malloc(fs->fs_llformat.availbytes);
-      fs->fs_workbuffer = (char *) kmm_malloc(WORKBUFFER_SIZE);
+      fs->fs_rwbuffer = kmm_malloc(fs->fs_llformat.availbytes);
+      fs->fs_workbuffer = kmm_malloc(WORKBUFFER_SIZE);
     }
 
   /* Now add ourselves to the linked list of SMART mounts */
@@ -266,8 +266,8 @@ int smartfs_mount(struct smartfs_mountpt_s *fs, bool writeable)
   g_mounthead = fs;
 #endif
 
-  fs->fs_rwbuffer = (char *) kmm_malloc(fs->fs_llformat.availbytes);
-  fs->fs_workbuffer = (char *) kmm_malloc(WORKBUFFER_SIZE);
+  fs->fs_rwbuffer = kmm_malloc(fs->fs_llformat.availbytes);
+  fs->fs_workbuffer = kmm_malloc(WORKBUFFER_SIZE);
   fs->fs_rootsector = SMARTFS_ROOT_DIR_SECTOR;
 
 #endif /* CONFIG_SMARTFS_MULTI_ROOT_DIRS */
@@ -1077,7 +1077,7 @@ int smartfs_createentry(FAR struct smartfs_mountpt_s *fs,
   direntry->datlen = 0;
   if (direntry->name == NULL)
     {
-      direntry->name = (FAR char *)kmm_malloc(fs->fs_llformat.namesize + 1);
+      direntry->name = kmm_malloc(fs->fs_llformat.namesize + 1);
     }
 
   memset(direntry->name, 0, fs->fs_llformat.namesize + 1);
@@ -1913,7 +1913,7 @@ int smartfs_extendfile(FAR struct smartfs_mountpt_s *fs,
    * will, unfortunately, need to allocate one.
    */
 
-  buffer = (FAR uint8_t *)kmm_malloc(SMARTFS_TRUNCBUFFER_SIZE);
+  buffer = kmm_malloc(SMARTFS_TRUNCBUFFER_SIZE);
   if (buffer == NULL)
     {
       return -ENOMEM;

--- a/fs/spiffs/src/spiffs_vfs.c
+++ b/fs/spiffs/src/spiffs_vfs.c
@@ -1382,7 +1382,7 @@ static int spiffs_bind(FAR struct inode *mtdinode, FAR const void *data,
 
   /* Create an instance of the SPIFFS file system */
 
-  fs = (FAR struct spiffs_s *)kmm_zalloc(sizeof(struct spiffs_s));
+  fs = kmm_zalloc(sizeof(struct spiffs_s));
   if (fs == NULL)
     {
       ferr("ERROR: Failed to allocate volume structure\n");
@@ -1424,7 +1424,7 @@ static int spiffs_bind(FAR struct inode *mtdinode, FAR const void *data,
   /* Allocate the cache */
 
   fs->cache_size = cache_size;
-  fs->cache      = (FAR void *)kmm_malloc(cache_size);
+  fs->cache      = kmm_malloc(cache_size);
 
   if (fs->cache == NULL)
     {
@@ -1445,7 +1445,7 @@ static int spiffs_bind(FAR struct inode *mtdinode, FAR const void *data,
    */
 
   work_size = 3 * SPIFFS_GEO_PAGE_SIZE(fs);
-  work      = (FAR uint8_t *)kmm_malloc(work_size);
+  work      = kmm_malloc(work_size);
 
   if (work == NULL)
     {

--- a/fs/tmpfs/fs_tmpfs.c
+++ b/fs/tmpfs/fs_tmpfs.c
@@ -533,7 +533,7 @@ static FAR struct tmpfs_file_s *tmpfs_alloc_file(void)
 
   /* Create a new zero length file object */
 
-  tfo = (FAR struct tmpfs_file_s *)kmm_malloc(sizeof(*tfo));
+  tfo = kmm_malloc(sizeof(*tfo));
   if (tfo == NULL)
     {
       return NULL;
@@ -683,7 +683,7 @@ static FAR struct tmpfs_directory_s *tmpfs_alloc_directory(void)
 
   /* Create a new zero length directory object */
 
-  tdo = (FAR struct tmpfs_directory_s *)kmm_malloc(sizeof(*tdo));
+  tdo = kmm_malloc(sizeof(*tdo));
   if (tdo == NULL)
     {
       return NULL;
@@ -2054,7 +2054,7 @@ static int tmpfs_bind(FAR struct inode *blkdriver, FAR const void *data,
 
   /* Create an instance of the tmpfs file system */
 
-  fs = (FAR struct tmpfs_s *)kmm_zalloc(sizeof(struct tmpfs_s));
+  fs = kmm_zalloc(sizeof(struct tmpfs_s));
   if (fs == NULL)
     {
       return -ENOMEM;

--- a/graphics/nxbe/nxbe_colormap.c
+++ b/graphics/nxbe/nxbe_colormap.c
@@ -69,7 +69,7 @@ int nxbe_colormap(FAR NX_DRIVERTYPE *dev)
    */
 
   size  = 3 * CONFIG_NX_NCOLORS * sizeof(uint8_t);
-  alloc = (FAR uint8_t *)kmm_malloc(size);
+  alloc = kmm_malloc(size);
   if (alloc == NULL)
     {
       return -ENOMEM;

--- a/graphics/nxbe/nxbe_setsize.c
+++ b/graphics/nxbe/nxbe_setsize.c
@@ -129,7 +129,7 @@ static void nxbe_realloc(FAR struct nxbe_window_s *wnd,
 #else
       /* Re-allocate memory from the user space heap. */
 
-      newfb = (FAR nxgl_mxpixel_t *)kumm_malloc(newfbsize);
+      newfb = kumm_malloc(newfbsize);
       if (newfb == NULL)
         {
           /* Fall back to no RAM back up */

--- a/graphics/nxmu/nxmu_kbdin.c
+++ b/graphics/nxmu/nxmu_kbdin.c
@@ -61,7 +61,7 @@ void nxmu_kbdin(FAR struct nxmu_state_s *nxmu, uint8_t nch, FAR uint8_t *ch)
    */
 
   size   = sizeof(struct nxclimsg_kbdin_s) + nch - 1;
-  outmsg = (FAR struct nxclimsg_kbdin_s *)kmm_malloc(size);
+  outmsg = kmm_malloc(size);
   if (outmsg)
     {
       /* Give the keypad input only to the top child */

--- a/graphics/nxmu/nxmu_openwindow.c
+++ b/graphics/nxmu/nxmu_openwindow.c
@@ -132,7 +132,7 @@ void nxmu_openwindow(FAR struct nxbe_state_s *be,
        *      levels.
        */
 
-      wnd->fbmem = (FAR nxgl_mxpixel_t *)kumm_malloc(fbsize);
+      wnd->fbmem = kumm_malloc(fbsize);
       if (wnd->fbmem == NULL)
         {
           /* Fall back to no RAM back up */

--- a/mm/mm_gran/mm_graninit.c
+++ b/mm/mm_gran/mm_graninit.c
@@ -126,7 +126,7 @@ GRAN_HANDLE gran_initialize(FAR void *heapstart, size_t heapsize,
    * correct size.
    */
 
-  priv = (FAR struct gran_s *)kmm_zalloc(SIZEOF_GRAN_S(ngranules));
+  priv = kmm_zalloc(SIZEOF_GRAN_S(ngranules));
   if (priv)
     {
       /* Initialize non-zero elements of the granules heap info structure */

--- a/net/igmp/igmp_group.c
+++ b/net/igmp/igmp_group.c
@@ -110,7 +110,7 @@ FAR struct igmp_group_s *igmp_grpalloc(FAR struct net_driver_s *dev,
   FAR struct igmp_group_s *group;
 
   ninfo("addr: %08" PRIx32 " dev: %p\n", (uint32_t)*addr, dev);
-  group = (FAR struct igmp_group_s *)kmm_zalloc(sizeof(struct igmp_group_s));
+  group = kmm_zalloc(sizeof(struct igmp_group_s));
 
   grpinfo("group: %p\n", group);
 

--- a/net/local/local_conn.c
+++ b/net/local/local_conn.c
@@ -109,7 +109,7 @@ FAR struct local_conn_s *local_peerconn(FAR struct local_conn_s *conn)
 FAR struct local_conn_s *local_alloc(void)
 {
   FAR struct local_conn_s *conn =
-    (FAR struct local_conn_s *)kmm_zalloc(sizeof(struct local_conn_s));
+    kmm_zalloc(sizeof(struct local_conn_s));
 
   if (conn != NULL)
     {

--- a/net/local/local_sendmsg.c
+++ b/net/local/local_sendmsg.c
@@ -105,7 +105,7 @@ static int local_sendctl(FAR struct local_conn_s *conn,
               goto fail;
             }
 
-          filep2 = (FAR struct file *)kmm_zalloc(sizeof(*filep2));
+          filep2 = kmm_zalloc(sizeof(*filep2));
           if (!filep2)
             {
               ret = -ENOMEM;

--- a/net/mld/mld_group.c
+++ b/net/mld/mld_group.c
@@ -103,7 +103,7 @@ FAR struct mld_group_s *mld_grpalloc(FAR struct net_driver_s *dev,
   FAR struct mld_group_s *group;
 
   mldinfo("addr: %08x dev: %p\n", *addr, dev);
-  group = (FAR struct mld_group_s *)kmm_zalloc(sizeof(struct mld_group_s));
+  group = kmm_zalloc(sizeof(struct mld_group_s));
 
   mldinfo("group: %p\n", group);
 

--- a/net/nat/ipv4_nat_entry.c
+++ b/net/nat/ipv4_nat_entry.c
@@ -307,7 +307,7 @@ ipv4_nat_entry_create(uint8_t protocol,
                       in_addr_t local_ip, uint16_t local_port)
 {
   FAR struct ipv4_nat_entry *entry =
-      (FAR struct ipv4_nat_entry *)kmm_malloc(sizeof(struct ipv4_nat_entry));
+      kmm_malloc(sizeof(struct ipv4_nat_entry));
   if (entry == NULL)
     {
       nwarn("WARNING: Failed to allocate IPv4 NAT entry\n");

--- a/net/netlink/netlink_route.c
+++ b/net/netlink/netlink_route.c
@@ -585,7 +585,7 @@ static int netlink_get_arptable(NETLINK_HANDLE handle,
   rspsize   = SIZEOF_NLROUTE_RECVFROM_RESPONSE_S(tabsize);
   allocsize = SIZEOF_NLROUTE_RECVFROM_RSPLIST_S(tabsize);
 
-  entry = (FAR struct getneigh_recvfrom_rsplist_s *)kmm_zalloc(allocsize);
+  entry = kmm_zalloc(allocsize);
   if (entry == NULL)
     {
       nerr("ERROR: Failed to allocate response buffer.\n");
@@ -668,7 +668,7 @@ static int netlink_get_nbtable(NETLINK_HANDLE handle,
   rspsize   = SIZEOF_NLROUTE_RECVFROM_RESPONSE_S(tabsize);
   allocsize = SIZEOF_NLROUTE_RECVFROM_RSPLIST_S(tabsize);
 
-  entry = (FAR struct getneigh_recvfrom_rsplist_s *)kmm_zalloc(allocsize);
+  entry = kmm_zalloc(allocsize);
   if (entry == NULL)
     {
       nerr("ERROR: Failed to allocate response buffer.\n");

--- a/net/tcp/tcp_backlog.c
+++ b/net/tcp/tcp_backlog.c
@@ -97,7 +97,7 @@ int tcp_backlogcreate(FAR struct tcp_conn_s *conn, int nblg)
 
       /* Then allocate that much */
 
-      bls = (FAR struct tcp_backlog_s *)kmm_zalloc(size);
+      bls = kmm_zalloc(size);
       if (!bls)
         {
           nerr("ERROR: Failed to allocate backlog\n");

--- a/sched/addrenv/addrenv.c
+++ b/sched/addrenv/addrenv.c
@@ -219,7 +219,7 @@ FAR struct addrenv_s *addrenv_allocate(void)
 {
   FAR struct addrenv_s *addrenv;
 
-  addrenv = (FAR struct addrenv_s *)kmm_zalloc(sizeof(struct addrenv_s));
+  addrenv = kmm_zalloc(sizeof(struct addrenv_s));
   if (addrenv)
     {
       /* Take reference so this won't get freed */

--- a/sched/group/group_create.c
+++ b/sched/group/group_create.c
@@ -135,7 +135,7 @@ int group_allocate(FAR struct task_tcb_s *tcb, uint8_t ttype)
 
   /* Allocate the group structure and assign it to the TCB */
 
-  group = (FAR struct task_group_s *)kmm_zalloc(sizeof(struct task_group_s));
+  group = kmm_zalloc(sizeof(struct task_group_s));
   if (!group)
     {
       return -ENOMEM;

--- a/sched/group/group_join.c
+++ b/sched/group/group_join.c
@@ -92,7 +92,7 @@ static inline int group_addmember(FAR struct task_group_s *group, pid_t pid)
           newmax = UINT8_MAX;
         }
 
-      newmembers = (FAR pid_t *)kmm_malloc(sizeof(pid_t) * newmax);
+      newmembers = kmm_malloc(sizeof(pid_t) * newmax);
 
       if (!newmembers)
         {

--- a/sched/irq/irq_procfs.c
+++ b/sched/irq/irq_procfs.c
@@ -289,7 +289,7 @@ static int irq_open(FAR struct file *filep, FAR const char *relpath,
 
   /* Allocate a container to hold the file attributes */
 
-  irqfile = (FAR struct irq_file_s *)kmm_zalloc(sizeof(struct irq_file_s));
+  irqfile = kmm_zalloc(sizeof(struct irq_file_s));
   if (!irqfile)
     {
       ferr("ERROR: Failed to allocate file attributes\n");
@@ -391,7 +391,7 @@ static int irq_dup(FAR const struct file *oldp, FAR struct file *newp)
 
   /* Allocate a new container to hold the task and attribute selection */
 
-  newattr = (FAR struct irq_file_s *)kmm_malloc(sizeof(struct irq_file_s));
+  newattr = kmm_malloc(sizeof(struct irq_file_s));
   if (!newattr)
     {
       ferr("ERROR: Failed to allocate file attributes\n");

--- a/sched/module/mod_insmod.c
+++ b/sched/module/mod_insmod.c
@@ -184,7 +184,7 @@ FAR void *insmod(FAR const char *filename, FAR const char *modname)
 
   /* Allocate a module registry entry to hold the module data */
 
-  modp = (FAR struct module_s *)kmm_zalloc(sizeof(struct module_s));
+  modp = kmm_zalloc(sizeof(struct module_s));
   if (modp == NULL)
     {
       berr("Failed to allocate struct module_s\n");

--- a/sched/mqueue/msginternal.c
+++ b/sched/mqueue/msginternal.c
@@ -107,8 +107,7 @@ void nxmsg_initialize(void)
 {
   FAR struct msgbuf_s *msg;
 
-  msg = (FAR struct msgbuf_s *)kmm_malloc(sizeof(*msg) *
-                                          CONFIG_PREALLOC_MQ_MSGS);
+  msg = kmm_malloc(sizeof(*msg) * CONFIG_PREALLOC_MQ_MSGS);
   if (msg)
     {
       int i;

--- a/sched/pthread/pthread_findjoininfo.c
+++ b/sched/pthread/pthread_findjoininfo.c
@@ -60,7 +60,7 @@ int pthread_createjoininfo(FAR struct pthread_tcb_s *ptcb,
 {
   /* Allocate a detachable structure to support pthread_join logic */
 
-  *pjoin = (FAR struct join_s *)kmm_zalloc(sizeof(struct join_s));
+  *pjoin = kmm_zalloc(sizeof(struct join_s));
   if (*pjoin == NULL)
     {
       serr("ERROR: Failed to allocate join\n");

--- a/sched/sched/sched_sporadic.c
+++ b/sched/sched/sched_sporadic.c
@@ -777,7 +777,7 @@ int nxsched_initialize_sporadic(FAR struct tcb_s *tcb)
    * sporadic scheduling parameters and state data.
    */
 
-  sporadic = (FAR struct sporadic_s *)kmm_zalloc(sizeof(struct sporadic_s));
+  sporadic = kmm_zalloc(sizeof(struct sporadic_s));
   if (sporadic == NULL)
     {
       serr("ERROR: Failed to allocate sporadic data structure\n");

--- a/sched/signal/sig_allocpendingsigaction.c
+++ b/sched/signal/sig_allocpendingsigaction.c
@@ -85,7 +85,7 @@ FAR sigq_t *nxsig_alloc_pendingsigaction(void)
         {
           /* No...Try the resource pool */
 
-          sigq = (FAR sigq_t *)kmm_malloc((sizeof (sigq_t)));
+          sigq = kmm_malloc(sizeof(sigq_t));
 
           /* Check if we got an allocated message */
 

--- a/sched/signal/sig_dispatch.c
+++ b/sched/signal/sig_dispatch.c
@@ -170,7 +170,7 @@ static FAR sigpendq_t *nxsig_alloc_pendingsignal(void)
         {
           /* No... Allocate the pending signal */
 
-          sigpend = (FAR sigpendq_t *)kmm_malloc((sizeof (sigpendq_t)));
+          sigpend = kmm_malloc(sizeof(sigpendq_t));
 
           /* Check if we got an allocated message */
 

--- a/sched/signal/sig_initialize.c
+++ b/sched/signal/sig_initialize.c
@@ -128,7 +128,7 @@ static FAR sigq_t *nxsig_alloc_block(sq_queue_t *siglist, uint16_t nsigs,
 
   /* Allocate a block of pending signal actions. */
 
-  sigqalloc = (FAR sigq_t *)kmm_malloc((sizeof(sigq_t)) * nsigs);
+  sigqalloc = kmm_malloc(sizeof(sigq_t) * nsigs);
   if (sigqalloc != NULL)
     {
       sigq = sigqalloc;
@@ -161,9 +161,7 @@ static sigpendq_t *nxsig_alloc_pendingsignalblock(sq_queue_t *siglist,
 
   /* Allocate a block of pending signal structures  */
 
-  sigpendalloc =
-    (FAR sigpendq_t *)kmm_malloc((sizeof(sigpendq_t)) * nsigs);
-
+  sigpendalloc = kmm_malloc(sizeof(sigpendq_t) * nsigs);
   if (sigpendalloc != NULL)
     {
       sigpend = sigpendalloc;

--- a/sched/task/task_create.c
+++ b/sched/task/task_create.c
@@ -81,7 +81,7 @@ int nxthread_create(FAR const char *name, uint8_t ttype, int priority,
 
   /* Allocate a TCB for the new task. */
 
-  tcb = (FAR struct task_tcb_s *)kmm_zalloc(sizeof(struct task_tcb_s));
+  tcb = kmm_zalloc(sizeof(struct task_tcb_s));
   if (!tcb)
     {
       serr("ERROR: Failed to allocate TCB\n");

--- a/sched/task/task_fork.c
+++ b/sched/task/task_fork.c
@@ -134,7 +134,7 @@ FAR struct task_tcb_s *nxtask_setup_fork(start_t retaddr)
 
   /* Allocate a TCB for the child task. */
 
-  child = (FAR struct task_tcb_s *)kmm_zalloc(sizeof(struct task_tcb_s));
+  child = kmm_zalloc(sizeof(struct task_tcb_s));
   if (!child)
     {
       serr("ERROR: Failed to allocate TCB\n");

--- a/sched/task/task_spawn.c
+++ b/sched/task/task_spawn.c
@@ -88,7 +88,7 @@ static int nxtask_spawn_create(FAR const char *name, int priority,
 
   /* Allocate a TCB for the new task. */
 
-  tcb = (FAR struct task_tcb_s *)kmm_zalloc(sizeof(struct task_tcb_s));
+  tcb = kmm_zalloc(sizeof(struct task_tcb_s));
   if (tcb == NULL)
     {
       serr("ERROR: Failed to allocate TCB\n");

--- a/tools/cfgparser.c
+++ b/tools/cfgparser.c
@@ -225,7 +225,7 @@ void parse_file(FILE *stream, struct variable_s **list)
                * variable name and the value.
                */
 
-              curr = (struct variable_s *)malloc(sizeof(struct variable_s) +
+              curr = malloc(sizeof(struct variable_s) +
                                           varlen + vallen - 1);
               if (curr)
                 {

--- a/tools/cxd56/clefia.c
+++ b/tools/cxd56/clefia.c
@@ -391,7 +391,7 @@ struct cipher *cipher_init(uint8_t * key, uint8_t * iv)
 {
   struct cipher *c;
 
-  c = (struct cipher *)malloc(sizeof(*c));
+  c = malloc(sizeof(*c));
   if (!c)
     {
       return NULL;

--- a/tools/cxd56/mkspk.c
+++ b/tools/cxd56/mkspk.c
@@ -156,7 +156,7 @@ static struct elf_file *load_elf(const char *filename)
       return NULL;
     }
 
-  ef = (struct elf_file *)malloc(sizeof(*ef));
+  ef = malloc(sizeof(*ef));
   if (!ef)
     {
       return NULL;
@@ -166,7 +166,7 @@ static struct elf_file *load_elf(const char *filename)
   fsize = (size_t) ftell(fp);
   fseek(fp, pos, SEEK_SET);
 
-  buf = (char *)malloc(fsize);
+  buf = malloc(fsize);
   if (!buf)
     {
       return NULL;
@@ -254,7 +254,7 @@ static void *create_image(struct elf_file *elf, int core, char *savename,
 
   imgsize = sizeof(*header) + snlen + (nphs * 16) + psize;
 
-  img = (char *)malloc(imgsize + 32);
+  img = malloc(imgsize + 32);
   if (!img)
     {
       return NULL;

--- a/tools/incdir.c
+++ b/tools/incdir.c
@@ -381,7 +381,7 @@ int main(int argc, char **argv, char **envp)
           ssize_t bufsize;
 
           bufsize = cygwin_conv_path(CCP_POSIX_TO_WIN_A, dirname, NULL, 0);
-          convpath = (char *)malloc(bufsize);
+          convpath = malloc(bufsize);
           if (convpath == NULL)
             {
               fprintf(stderr, "ERROR:  Failed to allocate buffer.\n");
@@ -461,7 +461,7 @@ int main(int argc, char **argv, char **envp)
       segsize   = ret;
       respsize += (response == NULL) ? segsize + 1 : segsize;
 
-      response = (char *)malloc(respsize);
+      response = malloc(respsize);
       if (response == NULL)
         {
           fprintf(stderr, "ERROR: Failed to allocate response.\n");

--- a/tools/mkdeps.c
+++ b/tools/mkdeps.c
@@ -212,7 +212,7 @@ static void append(char **base, const char *str)
     {
       alloclen = strlen(oldbase) + strlen(str) +
         sizeof((char) ' ') + sizeof((char) '\0');
-      newbase = (char *)malloc(alloclen);
+      newbase = malloc(alloclen);
       if (!newbase)
         {
           fprintf(stderr, "ERROR: Failed to allocate %d bytes\n", alloclen);

--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -448,6 +448,7 @@ static const char *g_white_content_list[] =
   "XColor",
   "AsyncBoth",
   "CurrentTime",
+  "XUnmapWindow",
 
   /* Ref:
    * sim/posix/sim_deviceimage.c


### PR DESCRIPTION
## Summary

mm/alloc: remove all unnecessary cast for alloc

Fix the minor style issue and remove unnecessary cast

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

ci-check