### PR TITLE
fs/inode: remove all unnecessary check for filep/inode

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_emmc.c
+++ b/arch/arm/src/cxd56xx/cxd56_emmc.c
@@ -823,7 +823,7 @@ static int cxd56_emmc_open(struct inode *inode)
   struct cxd56_emmc_state_s *priv;
   int ret;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (struct cxd56_emmc_state_s *)inode->i_private;
 
   /* Just increment the reference count on the driver */
@@ -844,7 +844,7 @@ static int cxd56_emmc_close(struct inode *inode)
   struct cxd56_emmc_state_s *priv;
   int ret;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (struct cxd56_emmc_state_s *)inode->i_private;
 
   /* Decrement the reference count on the block driver */
@@ -868,7 +868,7 @@ static ssize_t cxd56_emmc_read(struct inode *inode,
   struct cxd56_emmc_state_s *priv;
   int ret;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (struct cxd56_emmc_state_s *)inode->i_private;
 
   finfo("Read sector %" PRIuOFF " (%u sectors) to %p\n",
@@ -893,7 +893,7 @@ static ssize_t cxd56_emmc_write(struct inode *inode,
   struct cxd56_emmc_state_s *priv;
   int ret;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (struct cxd56_emmc_state_s *)inode->i_private;
 
   finfo("Write %p to sector %" PRIu32 " (%u sectors)\n", buffer,
@@ -915,7 +915,7 @@ static int cxd56_emmc_geometry(struct inode *inode,
 {
   struct cxd56_emmc_state_s *priv;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (struct cxd56_emmc_state_s *)inode->i_private;
 
   memset(geometry, 0, sizeof(*geometry));

--- a/arch/arm/src/cxd56xx/cxd56_hostif.c
+++ b/arch/arm/src/cxd56xx/cxd56_hostif.c
@@ -198,7 +198,6 @@ static int hif_open(struct file *filep)
   struct inode *inode;
   struct cxd56_hifdev_s *priv;
 
-  DEBUGASSERT(filep && filep->f_inode);
   inode = filep->f_inode;
 
   priv = (struct cxd56_hifdev_s *)inode->i_private;
@@ -253,7 +252,6 @@ static int hif_close(struct file *filep)
   struct inode *inode;
   struct cxd56_hifdev_s *priv;
 
-  DEBUGASSERT(filep && filep->f_inode);
   inode = filep->f_inode;
 
   priv = (struct cxd56_hifdev_s *)inode->i_private;
@@ -281,7 +279,6 @@ static ssize_t hif_read(struct file *filep, char *buffer, size_t len)
   struct cxd56_hifdev_s *priv;
   int ret;
 
-  DEBUGASSERT(filep && filep->f_inode);
   inode = filep->f_inode;
 
   priv = (struct cxd56_hifdev_s *)inode->i_private;
@@ -313,7 +310,6 @@ static ssize_t hif_write(struct file *filep,
   struct cxd56_hifdev_s *priv;
   int ret;
 
-  DEBUGASSERT(filep && filep->f_inode);
   inode = filep->f_inode;
 
   priv = (struct cxd56_hifdev_s *)inode->i_private;

--- a/arch/arm/src/cxd56xx/cxd56_powermgr_procfs.c
+++ b/arch/arm/src/cxd56xx/cxd56_powermgr_procfs.c
@@ -553,7 +553,7 @@ static ssize_t cxd56_powermgr_procfs_read(struct file *filep,
   pminfo("READ buffer=%p buflen=%lu len=%lu\n", buffer,
          (unsigned long)buflen, g_powermg_procfs_len);
 
-  DEBUGASSERT(filep && filep->f_priv);
+  DEBUGASSERT(filep->f_priv);
 
   priv = (struct cxd56_powermgr_procfs_file_s *)filep->f_priv;
 

--- a/arch/arm/src/efm32/efm32_leserial.c
+++ b/arch/arm/src/efm32/efm32_leserial.c
@@ -534,7 +534,6 @@ static int efm32_ioctl(struct file *filep, int cmd, unsigned long arg)
   struct efm32_leuart_s *priv;
   int ret = OK;
 
-  DEBUGASSERT(filep, filep->f_inode);
   inode = filep->f_inode;
   dev   = inode->i_private;
 

--- a/arch/arm/src/efm32/efm32_serial.c
+++ b/arch/arm/src/efm32/efm32_serial.c
@@ -804,9 +804,6 @@ static int efm32_ioctl(struct file *filep, int cmd, unsigned long arg)
 
   int ret = OK;
 
-  DEBUGASSERT(filep);
-  DEBUGASSERT(filep->f_inode);
-
   inode = filep->f_inode;
   dev   = inode->i_private;
 

--- a/arch/arm/src/kinetis/kinetis_lpserial.c
+++ b/arch/arm/src/kinetis/kinetis_lpserial.c
@@ -1114,7 +1114,6 @@ static int kinetis_ioctl(struct file *filep, int cmd, unsigned long arg)
 
 #if defined(CONFIG_SERIAL_TERMIOS) || defined(CONFIG_SERIAL_TIOCSERGSTRUCT) || \
     defined(CONFIG_KINETIS_SERIALBRK_BSDCOMPAT)
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode = filep->f_inode;
   dev   = inode->i_private;
   DEBUGASSERT(dev != NULL && dev->priv != NULL);

--- a/arch/arm/src/kinetis/kinetis_serial.c
+++ b/arch/arm/src/kinetis/kinetis_serial.c
@@ -1277,7 +1277,6 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
   struct up_dev_s   *priv;
   int                ret   = OK;
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode = filep->f_inode;
   dev   = inode->i_private;
   DEBUGASSERT(dev != NULL && dev->priv != NULL);

--- a/arch/arm/src/kl/kl_serial.c
+++ b/arch/arm/src/kl/kl_serial.c
@@ -586,7 +586,6 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
   struct up_dev_s   *priv;
   int                ret = OK;
 
-  DEBUGASSERT(filep, filep->f_inode);
   inode = filep->f_inode;
   dev   = inode->i_private;
 

--- a/arch/arm/src/lc823450/lc823450_mmcl.c
+++ b/arch/arm/src/lc823450/lc823450_mmcl.c
@@ -131,7 +131,7 @@ static ssize_t mmcl_read(struct inode *inode, unsigned char *buffer,
 
   finfo("sector: %" PRIuOFF " nsectors: %u\n", start_sector, nsectors);
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (struct mmcl_dev_s *)inode->i_private;
 
   nread = MTD_BREAD(dev->mtd, start_sector, nsectors, buffer);
@@ -161,7 +161,7 @@ static ssize_t mmcl_write(struct inode *inode,
 
   finfo("sector: %" PRIuOFF " nsectors: %u\n", start_sector, nsectors);
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (struct mmcl_dev_s *)inode->i_private;
 
   nwrite = MTD_BWRITE(dev->mtd, start_sector, nsectors, buffer);
@@ -188,7 +188,6 @@ static int mmcl_geometry(struct inode *inode, struct geometry *geometry)
 
   finfo("Entry\n");
 
-  DEBUGASSERT(inode);
   if (geometry)
     {
       dev = (struct mmcl_dev_s *)inode->i_private;
@@ -226,7 +225,7 @@ static int mmcl_ioctl(struct inode *inode, int cmd, unsigned long arg)
   int ret;
   finfo("Entry\n");
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (struct mmcl_dev_s *)inode->i_private;
 
   ret = MTD_IOCTL(dev->mtd, cmd, arg);

--- a/arch/arm/src/lpc54xx/lpc54_serial.c
+++ b/arch/arm/src/lpc54xx/lpc54_serial.c
@@ -1128,7 +1128,6 @@ static int lpc54_ioctl(struct file *filep, int cmd, unsigned long arg)
   struct lpc54_dev_s   *priv;
   int                   ret = OK;
 
-  DEBUGASSERT(filep, filep->f_inode);
   inode = filep->f_inode;
   dev   = inode->i_private;
 

--- a/arch/arm/src/max326xx/max32660/max32660_serial.c
+++ b/arch/arm/src/max326xx/max32660/max32660_serial.c
@@ -563,7 +563,6 @@ static int max326_ioctl(struct file *filep, int cmd, unsigned long arg)
   struct max326_dev_s *priv;
   int ret = OK;
 
-  DEBUGASSERT(filep, filep->f_inode);
   inode = filep->f_inode;
   dev   = inode->i_private;
 

--- a/arch/arm/src/phy62xx/phyplus_stub.c
+++ b/arch/arm/src/phy62xx/phyplus_stub.c
@@ -608,7 +608,6 @@ static ssize_t phyplus_stub_write(struct file *filep,
 
   int ret = 0;
   static int cmd_pos = 0;
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private != NULL);
 
@@ -696,7 +695,6 @@ static int phyplus_stub_ioctl(struct file *filep, int cmd,
        * int j = 0;
        */
 
-    DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
     inode = filep->f_inode;
     DEBUGASSERT(inode->i_private != NULL);
 

--- a/arch/arm/src/s32k1xx/s32k1xx_eeeprom.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_eeeprom.c
@@ -156,7 +156,7 @@ static int eeed_open(struct inode *inode)
 {
   struct eeed_struct_s *dev;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (struct eeed_struct_s *)inode->i_private;
 
   /* Increment the open reference count */
@@ -181,7 +181,7 @@ static int eeed_close(struct inode *inode)
 {
   struct eeed_struct_s *dev;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (struct eeed_struct_s *)inode->i_private;
 
   /* Increment the open reference count */
@@ -206,7 +206,7 @@ static ssize_t eeed_read(struct inode *inode, unsigned char *buffer,
 {
   struct eeed_struct_s *dev;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (struct eeed_struct_s *)inode->i_private;
 
   finfo("sector: %" PRIu64 " nsectors: %u sectorsize: %d\n",
@@ -243,7 +243,7 @@ static ssize_t eeed_write(struct inode *inode,
 {
   struct eeed_struct_s *dev;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (struct eeed_struct_s *)inode->i_private;
 
   finfo("sector: %" PRIu64 " nsectors: %u sectorsize: %d\n",
@@ -288,7 +288,6 @@ static int eeed_geometry(struct inode *inode, struct geometry *geometry)
 
   finfo("Entry\n");
 
-  DEBUGASSERT(inode);
   if (geometry)
     {
       dev = (struct eeed_struct_s *)inode->i_private;
@@ -329,7 +328,7 @@ static int eeed_ioctl(struct inode *inode, int cmd, unsigned long arg)
 
   /* Only one ioctl command is supported */
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   if (cmd == BIOC_XIPBASE && ppv)
     {
       dev  = (struct eeed_struct_s *)inode->i_private;
@@ -355,7 +354,7 @@ static int eeed_unlink(struct inode *inode)
 {
   struct eeed_struct_s *dev;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (struct eeed_struct_s *)inode->i_private;
 
   /* And free the block driver itself */

--- a/arch/arm/src/sama5/sam_tsd.c
+++ b/arch/arm/src/sama5/sam_tsd.c
@@ -970,10 +970,9 @@ static ssize_t sam_tsd_read(struct file *filep, char *buffer, size_t len)
   int ret;
 
   iinfo("buffer:%p len:%d\n", buffer, len);
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (struct sam_tsd_s *)inode->i_private;
 
   /* Verify that the caller has provided a buffer large enough to receive
@@ -1105,10 +1104,9 @@ static int sam_tsd_ioctl(struct file *filep, int cmd, unsigned long arg)
   int regval;
 
   iinfo("cmd: %d arg: %ld\n", cmd, arg);
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (struct sam_tsd_s *)inode->i_private;
 
   /* Get exclusive access to the driver data structure */
@@ -1164,10 +1162,10 @@ static int sam_tsd_poll(struct file *filep, struct pollfd *fds, bool setup)
   int i;
 
   iinfo("setup: %d\n", (int)setup);
-  DEBUGASSERT(filep && fds);
+  DEBUGASSERT(fds);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (struct sam_tsd_s *)inode->i_private;
 
   /* Get exclusive access to the ADC hardware */

--- a/arch/arm/src/stm32/stm32_bbsram.c
+++ b/arch/arm/src/stm32/stm32_bbsram.c
@@ -254,7 +254,7 @@ static int stm32_bbsram_open(struct file *filep)
   struct stm32_bbsram_s *bbr;
   int ret;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   bbr = (struct stm32_bbsram_s *)inode->i_private;
 
   /* Increment the reference count */
@@ -309,7 +309,7 @@ static int stm32_bbsram_close(struct file *filep)
   struct stm32_bbsram_s *bbr;
   int ret = OK;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   bbr = (struct stm32_bbsram_s *)inode->i_private;
 
   ret = nxmutex_lock(&bbr->lock);
@@ -357,7 +357,7 @@ static off_t stm32_bbsram_seek(struct file *filep, off_t offset,
   off_t newpos;
   int ret;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   bbr = (struct stm32_bbsram_s *)inode->i_private;
 
   ret = nxmutex_lock(&bbr->lock);
@@ -427,7 +427,7 @@ static ssize_t stm32_bbsram_read(struct file *filep, char *buffer,
   struct stm32_bbsram_s *bbr;
   int ret;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   bbr = (struct stm32_bbsram_s *)inode->i_private;
 
   ret = nxmutex_lock(&bbr->lock);
@@ -473,7 +473,7 @@ static ssize_t stm32_bbsram_write(struct file *filep,
   struct stm32_bbsram_s *bbr;
   int ret = -EFBIG;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   bbr = (struct stm32_bbsram_s *)inode->i_private;
 
   /* Forbid writes past the end of the device */
@@ -537,7 +537,7 @@ static int stm32_bbsram_ioctl(struct file *filep, int cmd,
   struct stm32_bbsram_s *bbr;
   int ret = -ENOTTY;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   bbr = (struct stm32_bbsram_s *)inode->i_private;
 
   if (cmd == STM32_BBSRAM_GETDESC_IOCTL)
@@ -590,7 +590,7 @@ static int stm32_bbsram_unlink(struct inode *inode)
   struct stm32_bbsram_s *bbr;
   int ret;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   bbr = (struct stm32_bbsram_s *)inode->i_private;
 
   ret = nxmutex_lock(&bbr->lock);

--- a/arch/arm/src/stm32f7/stm32_bbsram.c
+++ b/arch/arm/src/stm32f7/stm32_bbsram.c
@@ -254,7 +254,7 @@ static int stm32_bbsram_open(struct file *filep)
   struct stm32_bbsram_s *bbr;
   int ret;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   bbr = (struct stm32_bbsram_s *)inode->i_private;
 
   /* Increment the reference count */
@@ -309,7 +309,7 @@ static int stm32_bbsram_close(struct file *filep)
   struct stm32_bbsram_s *bbr;
   int ret = OK;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   bbr = (struct stm32_bbsram_s *)inode->i_private;
 
   ret = nxmutex_lock(&bbr->lock);
@@ -357,7 +357,7 @@ static off_t stm32_bbsram_seek(struct file *filep, off_t offset,
   off_t newpos;
   int ret;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   bbr = (struct stm32_bbsram_s *)inode->i_private;
 
   ret = nxmutex_lock(&bbr->lock);
@@ -427,7 +427,7 @@ static ssize_t stm32_bbsram_read(struct file *filep, char *buffer,
   struct stm32_bbsram_s *bbr;
   int ret;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   bbr = (struct stm32_bbsram_s *)inode->i_private;
 
   ret = nxmutex_lock(&bbr->lock);
@@ -473,7 +473,7 @@ static ssize_t stm32_bbsram_write(struct file *filep,
   struct stm32_bbsram_s *bbr;
   int ret = -EFBIG;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   bbr = (struct stm32_bbsram_s *)inode->i_private;
 
   /* Forbid writes past the end of the device */
@@ -537,7 +537,7 @@ static int stm32_bbsram_ioctl(struct file *filep, int cmd,
   struct stm32_bbsram_s *bbr;
   int ret = -ENOTTY;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   bbr = (struct stm32_bbsram_s *)inode->i_private;
 
   if (cmd == STM32F7_BBSRAM_GETDESC_IOCTL)
@@ -590,7 +590,7 @@ static int stm32_bbsram_unlink(struct inode *inode)
   struct stm32_bbsram_s *bbr;
   int ret;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   bbr = (struct stm32_bbsram_s *)inode->i_private;
 
   ret = nxmutex_lock(&bbr->lock);

--- a/arch/arm/src/stm32h7/stm32_bbsram.c
+++ b/arch/arm/src/stm32h7/stm32_bbsram.c
@@ -300,7 +300,7 @@ static int stm32_bbsram_open(struct file *filep)
   struct stm32_bbsram_s *bbr;
   int ret;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   bbr = (struct stm32_bbsram_s *)inode->i_private;
 
   /* Increment the reference count */
@@ -355,7 +355,7 @@ static int stm32_bbsram_close(struct file *filep)
   struct stm32_bbsram_s *bbr;
   int ret = OK;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   bbr = (struct stm32_bbsram_s *)inode->i_private;
 
   ret = nxmutex_lock(&bbr->lock);
@@ -403,7 +403,7 @@ static off_t stm32_bbsram_seek(struct file *filep, off_t offset,
   off_t newpos;
   int ret;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   bbr = (struct stm32_bbsram_s *)inode->i_private;
 
   ret = nxmutex_lock(&bbr->lock);
@@ -473,7 +473,7 @@ static ssize_t stm32_bbsram_read(struct file *filep, char *buffer,
   struct stm32_bbsram_s *bbr;
   int ret;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   bbr = (struct stm32_bbsram_s *)inode->i_private;
 
   ret = nxmutex_lock(&bbr->lock);
@@ -520,7 +520,7 @@ static ssize_t stm32_bbsram_write(struct file *filep,
   struct stm32_bbsram_s *bbr;
   int ret = -EFBIG;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   bbr = (struct stm32_bbsram_s *)inode->i_private;
 
   /* Forbid writes past the end of the device */
@@ -584,7 +584,7 @@ static int stm32_bbsram_ioctl(struct file *filep, int cmd,
   struct stm32_bbsram_s *bbr;
   int ret = -ENOTTY;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   bbr = (struct stm32_bbsram_s *)inode->i_private;
 
   if (cmd == STM32H7_BBSRAM_GETDESC_IOCTL)
@@ -637,7 +637,7 @@ static int stm32_bbsram_unlink(struct inode *inode)
   struct stm32_bbsram_s *bbr;
   int ret;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   bbr = (struct stm32_bbsram_s *)inode->i_private;
 
   ret = nxmutex_lock(&bbr->lock);

--- a/arch/arm/src/xmc4/xmc4_serial.c
+++ b/arch/arm/src/xmc4/xmc4_serial.c
@@ -802,7 +802,6 @@ static int xmc4_ioctl(struct file *filep, int cmd, unsigned long arg)
   struct xmc4_dev_s   *priv;
   int                ret = OK;
 
-  DEBUGASSERT(filep, filep->f_inode);
   inode = filep->f_inode;
   dev   = inode->i_private;
 

--- a/arch/avr/src/at32uc3/at32uc3_serial.c
+++ b/arch/avr/src/at32uc3/at32uc3_serial.c
@@ -491,7 +491,6 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
   struct up_dev_s   *priv;
   int                ret = OK;
 
-  DEBUGASSERT(filep, filep->f_inode);
   inode = filep->f_inode;
   dev   = inode->i_private;
 

--- a/arch/mips/src/pic32mx/pic32mx_serial.c
+++ b/arch/mips/src/pic32mx/pic32mx_serial.c
@@ -564,7 +564,6 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
   struct up_dev_s   *priv;
   int                ret = OK;
 
-  DEBUGASSERT(filep, filep->f_inode);
   inode = filep->f_inode;
   dev   = inode->i_private;
 

--- a/arch/renesas/src/rx65n/rx65n_sbram.c
+++ b/arch/renesas/src/rx65n/rx65n_sbram.c
@@ -206,7 +206,7 @@ static int rx65n_sbram_open(struct file *filep)
   struct inode *inode = filep->f_inode;
   struct rx65n_sbram_s *bbr;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   bbr = (struct rx65n_sbram_s *)inode->i_private;
 
   /* Increment the reference count */
@@ -257,7 +257,7 @@ static int rx65n_sbram_close(struct file *filep)
   struct rx65n_sbram_s *bbr;
   int ret = OK;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   bbr = (struct rx65n_sbram_s *)inode->i_private;
 
   nxmutex_lock(&bbr->lock);
@@ -299,7 +299,7 @@ static off_t rx65n_sbram_seek(struct file *filep, off_t offset,
   off_t newpos;
   int ret;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   bbr = (struct rx65n_sbram_s *)inode->i_private;
 
   nxmutex_lock(&bbr->lock);
@@ -368,7 +368,7 @@ static ssize_t rx65n_sbram_read(struct file *filep, char *buffer,
   struct inode *inode = filep->f_inode;
   struct rx65n_sbram_s *bbr;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   bbr = (struct rx65n_sbram_s *)inode->i_private;
 
   nxmutex_lock(&bbr->lock);
@@ -410,7 +410,7 @@ static ssize_t rx65n_sbram_write(struct file *filep, const char *buffer,
   struct rx65n_sbram_s *bbr;
   int ret = -EFBIG;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   bbr = (struct rx65n_sbram_s *)inode->i_private;
 
   /* Forbid writes past the end of the device */
@@ -466,7 +466,7 @@ static int rx65n_sbram_ioctl(struct file *filep, int cmd, unsigned long arg)
   struct rx65n_sbram_s *bbr;
   int ret = -ENOTTY;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   bbr = (struct rx65n_sbram_s *)inode->i_private;
 
   if (cmd == RX65N_SBRAM_GETDESC_IOCTL)
@@ -513,7 +513,7 @@ static int rx65n_sbram_unlink(struct inode *inode)
 {
   struct rx65n_sbram_s *bbr;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   bbr = (struct rx65n_sbram_s *)inode->i_private;
 
   nxmutex_lock(&bbr->lock);

--- a/arch/sparc/src/bm3803/bm3803-serial.c
+++ b/arch/sparc/src/bm3803/bm3803-serial.c
@@ -576,7 +576,6 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
   struct up_dev_s   *priv;
   int                ret = OK;
 
-  DEBUGASSERT(filep, filep->f_inode);
   inode = filep->f_inode;
   dev   = inode->i_private;
 

--- a/arch/sparc/src/bm3823/bm3823-serial.c
+++ b/arch/sparc/src/bm3823/bm3823-serial.c
@@ -572,7 +572,6 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
   struct up_dev_s   *priv;
   int                ret = OK;
 
-  DEBUGASSERT(filep, filep->f_inode);
   inode = filep->f_inode;
   dev   = inode->i_private;
 

--- a/arch/sparc/src/s698pm/s698pm-serial.c
+++ b/arch/sparc/src/s698pm/s698pm-serial.c
@@ -638,7 +638,6 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
   struct up_dev_s   *priv;
   int                ret = OK;
 
-  DEBUGASSERT(filep, filep->f_inode);
   inode = filep->f_inode;
   dev   = inode->i_private;
 

--- a/boards/arm/s32k1xx/rddrone-bms772/src/s32k1xx_smbus_sbd.c
+++ b/boards/arm/s32k1xx/rddrone-bms772/src/s32k1xx_smbus_sbd.c
@@ -126,7 +126,7 @@ static int smbus_sbd_open(struct file *filep)
 
   /* Retrieve the smbus_sbd_dev_s struct */
 
-  DEBUGASSERT(filep && filep->f_inode && filep->f_inode->i_private);
+  DEBUGASSERT(filep->f_inode->i_private);
   dev = (struct smbus_sbd_dev_s *)filep->f_inode->i_private;
 
   /* Increase the open reference count */
@@ -158,7 +158,7 @@ static int smbus_sbd_close(struct file *filep)
 
   /* Retrieve the smbus_sbd_dev_s struct */
 
-  DEBUGASSERT(filep && filep->f_inode && filep->f_inode->i_private);
+  DEBUGASSERT(filep->f_inode->i_private);
   dev = (struct smbus_sbd_dev_s *)filep->f_inode->i_private;
 
   /* Decrease the open reference count */
@@ -222,7 +222,7 @@ static ssize_t smbus_sbd_read(struct file *filep, char *buffer,
    * Battery Data slave driver.
    */
 
-  DEBUGASSERT(filep && filep->f_inode && filep->f_inode->i_private);
+  DEBUGASSERT(filep->f_inode->i_private);
   dev = (struct smbus_sbd_dev_s *)filep->f_inode->i_private;
 
   DEBUGASSERT(buffer);
@@ -320,7 +320,7 @@ static ssize_t smbus_sbd_write(struct file *filep, const char *buffer,
    * Battery Data slave driver.
    */
 
-  DEBUGASSERT(filep && filep->f_inode && filep->f_inode->i_private);
+  DEBUGASSERT(filep->f_inode->i_private);
   dev = (struct smbus_sbd_dev_s *)filep->f_inode->i_private;
 
   DEBUGASSERT(buffer);

--- a/boards/arm/stm32/mikroe-stm32f4/src/stm32_touchscreen.c
+++ b/boards/arm/stm32/mikroe-stm32f4/src/stm32_touchscreen.c
@@ -1095,10 +1095,9 @@ static int tc_open(struct file *filep)
   uint8_t          tmp;
   int              ret;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (struct tc_dev_s *)inode->i_private;
 
   /* Get exclusive access to the driver data structure */
@@ -1147,10 +1146,9 @@ static int tc_close(struct file *filep)
   struct tc_dev_s *priv;
   int              ret;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (struct tc_dev_s *)inode->i_private;
 
   /* Get exclusive access to the driver data structure */
@@ -1188,10 +1186,9 @@ static ssize_t tc_read(struct file *filep, char *buffer, size_t len)
   struct tc_sample_s    sample;
   int                   ret;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (struct tc_dev_s *)inode->i_private;
 
   /* Verify that the caller has provided a buffer large enough to receive
@@ -1312,10 +1309,9 @@ static int tc_ioctl(struct file *filep, int cmd, unsigned long arg)
   int ret;
 
   iinfo("cmd: %d arg: %ld\n", cmd, arg);
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (struct tc_dev_s *)inode->i_private;
 
   /* Get exclusive access to the driver data structure */
@@ -1354,10 +1350,10 @@ static int tc_poll(struct file *filep, struct pollfd *fds, bool setup)
   int              i;
 
   iinfo("setup: %d\n", (int)setup);
-  DEBUGASSERT(filep && fds);
+  DEBUGASSERT(fds);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (struct tc_dev_s *)inode->i_private;
 
   /* Are we setting up the poll?  Or tearing it down? */

--- a/boards/mips/pic32mx/pic32mx7mmb/src/pic32_touchscreen.c
+++ b/boards/mips/pic32mx/pic32mx7mmb/src/pic32_touchscreen.c
@@ -972,10 +972,9 @@ static int tc_open(struct file *filep)
   uint8_t          tmp;
   int              ret;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (struct tc_dev_s *)inode->i_private;
 
   /* Get exclusive access to the driver data structure */
@@ -1024,10 +1023,9 @@ static int tc_close(struct file *filep)
   struct tc_dev_s *priv;
   int              ret;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (struct tc_dev_s *)inode->i_private;
 
   /* Get exclusive access to the driver data structure */
@@ -1065,10 +1063,9 @@ static ssize_t tc_read(struct file *filep, char *buffer, size_t len)
   struct tc_sample_s    sample;
   int                   ret;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (struct tc_dev_s *)inode->i_private;
 
   /* Verify that the caller has provided a buffer large enough to receive
@@ -1189,10 +1186,9 @@ static int tc_ioctl(struct file *filep, int cmd, unsigned long arg)
   int              ret;
 
   iinfo("cmd: %d arg: %ld\n", cmd, arg);
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (struct tc_dev_s *)inode->i_private;
 
   /* Get exclusive access to the driver data structure */
@@ -1231,10 +1227,10 @@ static int tc_poll(struct file *filep, struct pollfd *fds, bool setup)
   int              i;
 
   iinfo("setup: %d\n", (int)setup);
-  DEBUGASSERT(filep && fds);
+  DEBUGASSERT(fds);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (struct tc_dev_s *)inode->i_private;
 
   /* Are we setting up the poll?  Or tearing it down? */

--- a/drivers/bch/bchdev_driver.c
+++ b/drivers/bch/bchdev_driver.c
@@ -118,7 +118,7 @@ static int bch_open(FAR struct file *filep)
   FAR struct bchlib_s *bch;
   int ret = OK;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   bch = (FAR struct bchlib_s *)inode->i_private;
 
   /* Increment the reference count */
@@ -155,7 +155,7 @@ static int bch_close(FAR struct file *filep)
   FAR struct bchlib_s *bch;
   int ret = OK;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   bch = (FAR struct bchlib_s *)inode->i_private;
 
   /* Get exclusive access */
@@ -223,7 +223,7 @@ static off_t bch_seek(FAR struct file *filep, off_t offset, int whence)
   off_t newpos;
   off_t ret;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
 
   bch = (FAR struct bchlib_s *)inode->i_private;
   ret = nxmutex_lock(&bch->lock);
@@ -294,7 +294,7 @@ static ssize_t bch_read(FAR struct file *filep, FAR char *buffer, size_t len)
   FAR struct bchlib_s *bch;
   ssize_t ret;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   bch = (FAR struct bchlib_s *)inode->i_private;
 
   ret = nxmutex_lock(&bch->lock);
@@ -324,7 +324,7 @@ static ssize_t bch_write(FAR struct file *filep, FAR const char *buffer,
   FAR struct bchlib_s *bch;
   ssize_t ret = -EACCES;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   bch = (FAR struct bchlib_s *)inode->i_private;
 
   if (!bch->readonly)
@@ -361,7 +361,7 @@ static int bch_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   FAR struct bchlib_s *bch;
   int ret = -ENOTTY;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   bch = (FAR struct bchlib_s *)inode->i_private;
 
   /* Process the call according to the command */
@@ -473,7 +473,7 @@ static int bch_unlink(FAR struct inode *inode)
   FAR struct bchlib_s *bch;
   int ret = OK;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   bch = (FAR struct bchlib_s *)inode->i_private;
 
   /* Get exclusive access to the BCH device */

--- a/drivers/contactless/mfrc522.c
+++ b/drivers/contactless/mfrc522.c
@@ -1414,10 +1414,9 @@ static int mfrc522_open(FAR struct file *filep)
   FAR struct inode *inode;
   FAR struct mfrc522_dev_s *dev;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = inode->i_private;
 
   mfrc522_configspi(dev->spi);
@@ -1443,10 +1442,9 @@ static int mfrc522_close(FAR struct file *filep)
   FAR struct inode *inode;
   FAR struct mfrc522_dev_s *dev;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = inode->i_private;
 
   dev->state = MFRC522_STATE_NOT_INIT;
@@ -1472,10 +1470,9 @@ static ssize_t mfrc522_read(FAR struct file *filep, FAR char *buffer,
   FAR struct mfrc522_dev_s *dev;
   FAR struct picc_uid_s uid;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = inode->i_private;
 
   /* Is a card near? */
@@ -1516,10 +1513,9 @@ static ssize_t mfrc522_write(FAR struct file *filep, FAR const char *buffer,
   FAR struct inode *inode;
   FAR struct mfrc522_dev_s *dev;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = inode->i_private;
 
   UNUSED(dev);
@@ -1537,10 +1533,9 @@ static int mfrc522_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   FAR struct mfrc522_dev_s *dev;
   int ret = OK;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = inode->i_private;
 
   switch (cmd)

--- a/drivers/contactless/pn532.c
+++ b/drivers/contactless/pn532.c
@@ -850,10 +850,9 @@ static int _open(FAR struct file *filep)
   FAR struct inode *inode;
   FAR struct pn532_dev_s *dev;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = inode->i_private;
 
   pn532_configspi(dev->spi);
@@ -881,10 +880,9 @@ static int _close(FAR struct file *filep)
   FAR struct inode *inode;
   FAR struct pn532_dev_s *dev;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = inode->i_private;
 
   dev->config->reset(0);
@@ -918,10 +916,9 @@ static ssize_t _read(FAR struct file *filep, FAR char *buffer, size_t buflen)
   FAR struct inode *inode;
   FAR struct pn532_dev_s *dev;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = inode->i_private;
 
   uint32_t id = pn532_read_passive_target_id(dev, PN532_MIFARE_ISO14443A);
@@ -946,10 +943,9 @@ static ssize_t _write(FAR struct file *filep, FAR const char *buffer,
   FAR struct inode *inode;
   FAR struct pn532_dev_s *dev;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = inode->i_private;
 
   UNUSED(dev);
@@ -967,10 +963,9 @@ static int _ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   FAR struct pn532_dev_s *dev;
   int ret = OK;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = inode->i_private;
 
   switch (cmd)

--- a/drivers/eeprom/i2c_xx24xx.c
+++ b/drivers/eeprom/i2c_xx24xx.c
@@ -345,7 +345,7 @@ static int ee24xx_open(FAR struct file *filep)
   FAR struct ee24xx_dev_s *eedev;
   int ret = OK;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   eedev = (FAR struct ee24xx_dev_s *)inode->i_private;
 
   ret = nxmutex_lock(&eedev->lock);
@@ -382,7 +382,7 @@ static int ee24xx_close(FAR struct file *filep)
   FAR struct ee24xx_dev_s *eedev;
   int ret = OK;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   eedev = (FAR struct ee24xx_dev_s *)inode->i_private;
 
   ret = nxmutex_lock(&eedev->lock);
@@ -422,7 +422,7 @@ static off_t ee24xx_seek(FAR struct file *filep, off_t offset, int whence)
   int                     ret;
   FAR struct inode        *inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   eedev = (FAR struct ee24xx_dev_s *)inode->i_private;
 
   ret = nxmutex_lock(&eedev->lock);
@@ -498,7 +498,7 @@ static ssize_t ee24xx_read(FAR struct file *filep, FAR char *buffer,
   uint32_t                 addr_hi;
   int                      ret;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   eedev = (FAR struct ee24xx_dev_s *)inode->i_private;
 
   ret = nxmutex_lock(&eedev->lock);
@@ -577,7 +577,7 @@ static ssize_t at24cs_read_uuid(FAR struct file *filep, FAR char *buffer,
   uint8_t                  regindx;
   int                      ret;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   eedev = (FAR struct ee24xx_dev_s *)inode->i_private;
 
   ret = nxmutex_lock(&eedev->lock);
@@ -653,7 +653,7 @@ static ssize_t ee24xx_write(FAR struct file *filep, FAR const char *buffer,
   int                      ret   = -EACCES;
   int                      savelen;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   eedev = (FAR struct ee24xx_dev_s *)inode->i_private;
 
   if (eedev->readonly)
@@ -779,7 +779,7 @@ static int ee24xx_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   FAR struct inode        *inode = filep->f_inode;
   int                      ret   = 0;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   eedev = (FAR struct ee24xx_dev_s *)inode->i_private;
   UNUSED(eedev);
 

--- a/drivers/eeprom/spi_xx25xx.c
+++ b/drivers/eeprom/spi_xx25xx.c
@@ -467,7 +467,7 @@ static int ee25xx_open(FAR struct file *filep)
   FAR struct ee25xx_dev_s *eedev;
   int ret = OK;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   eedev = (FAR struct ee25xx_dev_s *)inode->i_private;
 
   ret = nxmutex_lock(&eedev->lock);
@@ -504,7 +504,7 @@ static int ee25xx_close(FAR struct file *filep)
   FAR struct ee25xx_dev_s *eedev;
   int ret = OK;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   eedev = (FAR struct ee25xx_dev_s *)inode->i_private;
 
   ret = nxmutex_lock(&eedev->lock);
@@ -544,7 +544,7 @@ static off_t ee25xx_seek(FAR struct file *filep, off_t offset, int whence)
   int                     ret;
   FAR struct inode        *inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   eedev = (FAR struct ee25xx_dev_s *)inode->i_private;
 
   ret = nxmutex_lock(&eedev->lock);
@@ -616,7 +616,7 @@ static ssize_t ee25xx_read(FAR struct file *filep, FAR char *buffer,
   FAR struct inode        *inode = filep->f_inode;
   int ret;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   eedev = (FAR struct ee25xx_dev_s *)inode->i_private;
 
   ret = nxmutex_lock(&eedev->lock);
@@ -668,7 +668,7 @@ static ssize_t ee25xx_write(FAR struct file *filep, FAR const char *buffer,
   FAR struct inode        *inode = filep->f_inode;
   int                     ret    = -EACCES;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   eedev = (FAR struct ee25xx_dev_s *)inode->i_private;
 
   if (eedev->readonly)
@@ -765,7 +765,7 @@ static int ee25xx_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   FAR struct inode        *inode = filep->f_inode;
   int                     ret    = 0;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   eedev = (FAR struct ee25xx_dev_s *)inode->i_private;
   UNUSED(eedev);
 

--- a/drivers/i2c/i2c_driver.c
+++ b/drivers/i2c/i2c_driver.c
@@ -124,7 +124,6 @@ static int i2cdrvr_open(FAR struct file *filep)
 
   /* Get our private data structure */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode = filep->f_inode;
 
   priv = (FAR struct i2c_driver_s *)inode->i_private;
@@ -161,7 +160,6 @@ static int i2cdrvr_close(FAR struct file *filep)
 
   /* Get our private data structure */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode = filep->f_inode;
 
   priv = (FAR struct i2c_driver_s *)inode->i_private;
@@ -231,7 +229,6 @@ static int i2cdrvr_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
   /* Get our private data structure */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode = filep->f_inode;
 
   priv = (FAR struct i2c_driver_s *)inode->i_private;
@@ -308,7 +305,7 @@ static int i2cdrvr_unlink(FAR struct inode *inode)
 
   /* Get our private data structure */
 
-  DEBUGASSERT(inode != NULL && inode->i_private != NULL);
+  DEBUGASSERT(inode->i_private != NULL);
   priv = (FAR struct i2c_driver_s *)inode->i_private;
 
   /* Get exclusive access to the I2C driver state structure */

--- a/drivers/i2s/i2schar.c
+++ b/drivers/i2s/i2schar.c
@@ -217,10 +217,9 @@ static ssize_t i2schar_read(FAR struct file *filep, FAR char *buffer,
 
   /* Get our private data structure */
 
-  DEBUGASSERT(filep != NULL && buffer != NULL);
+  DEBUGASSERT(buffer != NULL);
 
   inode = filep->f_inode;
-  DEBUGASSERT(inode != NULL);
 
   priv = (FAR struct i2schar_dev_s *)inode->i_private;
   DEBUGASSERT(priv != NULL);
@@ -290,10 +289,9 @@ static ssize_t i2schar_write(FAR struct file *filep, FAR const char *buffer,
 
   /* Get our private data structure */
 
-  DEBUGASSERT(filep && buffer);
+  DEBUGASSERT(buffer);
 
   inode = filep->f_inode;
-  DEBUGASSERT(inode);
 
   priv = (FAR struct i2schar_dev_s *)inode->i_private;
   DEBUGASSERT(priv);
@@ -358,10 +356,7 @@ static int i2schar_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
   /* Get our private data structure */
 
-  DEBUGASSERT(filep != NULL);
-
   inode = filep->f_inode;
-  DEBUGASSERT(inode != NULL);
 
   priv = (FAR struct i2schar_dev_s *)inode->i_private;
   DEBUGASSERT(priv != NULL && priv->i2s && priv->i2s->ops);

--- a/drivers/input/ads7843e.c
+++ b/drivers/input/ads7843e.c
@@ -713,10 +713,9 @@ static int ads7843e_open(FAR struct file *filep)
 
   iinfo("Opening\n");
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (FAR struct ads7843e_dev_s *)inode->i_private;
 
   /* Get exclusive access to the driver data structure */
@@ -767,10 +766,9 @@ static int ads7843e_close(FAR struct file *filep)
   int                       ret;
 
   iinfo("Closing\n");
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (FAR struct ads7843e_dev_s *)inode->i_private;
 
   /* Get exclusive access to the driver data structure */
@@ -811,10 +809,9 @@ static ssize_t ads7843e_read(FAR struct file *filep, FAR char *buffer,
   int                        ret;
 
   iinfo("buffer:%p len:%d\n", buffer, len);
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (FAR struct ads7843e_dev_s *)inode->i_private;
 
   /* Verify that the caller has provided a buffer large enough to receive
@@ -938,10 +935,9 @@ static int ads7843e_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   int                       ret;
 
   iinfo("cmd: %d arg: %ld\n", cmd, arg);
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (FAR struct ads7843e_dev_s *)inode->i_private;
 
   /* Get exclusive access to the driver data structure */
@@ -994,10 +990,10 @@ static int ads7843e_poll(FAR struct file *filep, FAR struct pollfd *fds,
   int i;
 
   iinfo("setup: %d\n", (int)setup);
-  DEBUGASSERT(filep && fds);
+  DEBUGASSERT(fds);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (FAR struct ads7843e_dev_s *)inode->i_private;
 
   /* Are we setting up the poll?  Or tearing it down? */

--- a/drivers/input/ajoystick.c
+++ b/drivers/input/ajoystick.c
@@ -297,7 +297,6 @@ static int ajoy_open(FAR struct file *filep)
   ajoy_buttonset_t supported;
   irqstate_t flags;
 
-  DEBUGASSERT(filep && filep->f_inode);
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private);
   priv = (FAR struct ajoy_upperhalf_s *)inode->i_private;
@@ -352,7 +351,7 @@ static int ajoy_close(FAR struct file *filep)
   FAR struct ajoy_open_s *prev;
   irqstate_t flags;
 
-  DEBUGASSERT(filep && filep->f_priv && filep->f_inode);
+  DEBUGASSERT(filep->f_priv);
   opriv = filep->f_priv;
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private);
@@ -415,7 +414,6 @@ static ssize_t ajoy_read(FAR struct file *filep, FAR char *buffer,
   irqstate_t flags;
   int ret;
 
-  DEBUGASSERT(filep && filep->f_inode);
   opriv = filep->f_priv;
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private);
@@ -465,7 +463,7 @@ static int ajoy_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   irqstate_t flags;
   int ret;
 
-  DEBUGASSERT(filep && filep->f_priv && filep->f_inode);
+  DEBUGASSERT(filep->f_priv);
   opriv = filep->f_priv;
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private);
@@ -590,7 +588,7 @@ static int ajoy_poll(FAR struct file *filep, FAR struct pollfd *fds,
   int ret = OK;
   int i;
 
-  DEBUGASSERT(filep && filep->f_priv && filep->f_inode);
+  DEBUGASSERT(filep->f_priv);
   opriv = filep->f_priv;
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private);

--- a/drivers/input/button_upper.c
+++ b/drivers/input/button_upper.c
@@ -309,7 +309,6 @@ static int btn_open(FAR struct file *filep)
   btn_buttonset_t supported;
   irqstate_t flags;
 
-  DEBUGASSERT(filep && filep->f_inode);
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private);
   priv = (FAR struct btn_upperhalf_s *)inode->i_private;
@@ -364,7 +363,7 @@ static int btn_close(FAR struct file *filep)
   FAR struct btn_open_s *prev;
   irqstate_t flags;
 
-  DEBUGASSERT(filep && filep->f_priv && filep->f_inode);
+  DEBUGASSERT(filep->f_priv);
   opriv = filep->f_priv;
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private);
@@ -432,7 +431,6 @@ static ssize_t btn_read(FAR struct file *filep, FAR char *buffer,
   FAR const struct btn_lowerhalf_s *lower;
   irqstate_t flags;
 
-  DEBUGASSERT(filep && filep->f_inode);
   opriv = filep->f_priv;
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private);
@@ -478,7 +476,6 @@ static ssize_t btn_write(FAR struct file *filep, FAR const char *buffer,
   irqstate_t flags;
   int ret;
 
-  DEBUGASSERT(filep && filep->f_inode);
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private);
   priv  = (FAR struct btn_upperhalf_s *)inode->i_private;
@@ -529,7 +526,7 @@ static int btn_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   irqstate_t flags;
   int ret = OK;
 
-  DEBUGASSERT(filep && filep->f_priv && filep->f_inode);
+  DEBUGASSERT(filep->f_priv);
   opriv = filep->f_priv;
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private);
@@ -656,7 +653,7 @@ static int btn_poll(FAR struct file *filep, FAR struct pollfd *fds,
   int ret = OK;
   int i;
 
-  DEBUGASSERT(filep && filep->f_priv && filep->f_inode);
+  DEBUGASSERT(filep->f_priv);
   opriv = filep->f_priv;
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private);

--- a/drivers/input/cypress_mbr3108.c
+++ b/drivers/input/cypress_mbr3108.c
@@ -736,10 +736,9 @@ static ssize_t mbr3108_read(FAR struct file *filep, FAR char *buffer,
   irqstate_t flags;
   int ret;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = inode->i_private;
 
   ret = nxmutex_lock(&priv->devlock);
@@ -783,10 +782,9 @@ static ssize_t mbr3108_write(FAR struct file *filep, FAR const char *buffer,
   enum mbr3108_cmd_e type;
   int ret;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = inode->i_private;
 
   if (buflen < sizeof(enum mbr3108_cmd_e))
@@ -864,10 +862,9 @@ static int mbr3108_open(FAR struct file *filep)
   unsigned int use_count;
   int ret;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = inode->i_private;
 
   ret = nxmutex_lock(&priv->devlock);
@@ -938,10 +935,9 @@ static int mbr3108_close(FAR struct file *filep)
   int use_count;
   int ret;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = inode->i_private;
 
   ret = nxmutex_lock(&priv->devlock);
@@ -988,10 +984,10 @@ static int mbr3108_poll(FAR struct file *filep, FAR struct pollfd *fds,
   int ret = 0;
   int i;
 
-  DEBUGASSERT(filep && fds);
+  DEBUGASSERT(fds);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (FAR struct mbr3108_dev_s *)inode->i_private;
 
   ret = nxmutex_lock(&priv->devlock);

--- a/drivers/input/djoystick.c
+++ b/drivers/input/djoystick.c
@@ -297,7 +297,6 @@ static int djoy_open(FAR struct file *filep)
   djoy_buttonset_t supported;
   irqstate_t flags;
 
-  DEBUGASSERT(filep && filep->f_inode);
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private);
   priv = (FAR struct djoy_upperhalf_s *)inode->i_private;
@@ -352,7 +351,7 @@ static int djoy_close(FAR struct file *filep)
   FAR struct djoy_open_s *prev;
   irqstate_t flags;
 
-  DEBUGASSERT(filep && filep->f_priv && filep->f_inode);
+  DEBUGASSERT(filep->f_priv);
   opriv = filep->f_priv;
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private);
@@ -415,7 +414,6 @@ static ssize_t djoy_read(FAR struct file *filep, FAR char *buffer,
   irqstate_t flags;
   int ret;
 
-  DEBUGASSERT(filep && filep->f_inode);
   opriv = filep->f_priv;
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private);
@@ -461,7 +459,7 @@ static int djoy_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   irqstate_t flags;
   int ret;
 
-  DEBUGASSERT(filep && filep->f_priv && filep->f_inode);
+  DEBUGASSERT(filep->f_priv);
   opriv = filep->f_priv;
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private);
@@ -586,7 +584,7 @@ static int djoy_poll(FAR struct file *filep, FAR struct pollfd *fds,
   int ret = OK;
   int i;
 
-  DEBUGASSERT(filep && filep->f_priv && filep->f_inode);
+  DEBUGASSERT(filep->f_priv);
   opriv = filep->f_priv;
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private);

--- a/drivers/input/ft5x06.c
+++ b/drivers/input/ft5x06.c
@@ -732,10 +732,9 @@ static int ft5x06_open(FAR struct file *filep)
   uint8_t tmp;
   int ret;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (FAR struct ft5x06_dev_s *)inode->i_private;
 
   /* Get exclusive access to the driver data structure */
@@ -791,10 +790,9 @@ static int ft5x06_close(FAR struct file *filep)
   FAR struct ft5x06_dev_s *priv;
   int ret;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (FAR struct ft5x06_dev_s *)inode->i_private;
 
   /* Get exclusive access to the driver data structure */
@@ -839,10 +837,9 @@ static ssize_t ft5x06_read(FAR struct file *filep, FAR char *buffer,
   FAR struct ft5x06_dev_s *priv;
   int ret;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (FAR struct ft5x06_dev_s *)inode->i_private;
 
   /* Verify that the caller has provided a buffer large enough to receive
@@ -912,10 +909,9 @@ static int ft5x06_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   int                      ret;
 
   iinfo("cmd: %d arg: %ld\n", cmd, arg);
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (FAR struct ft5x06_dev_s *)inode->i_private;
 
   /* Get exclusive access to the driver data structure */
@@ -969,10 +965,10 @@ static int ft5x06_poll(FAR struct file *filep, FAR struct pollfd *fds,
   int                      i;
 
   iinfo("setup: %d\n", (int)setup);
-  DEBUGASSERT(filep && fds);
+  DEBUGASSERT(fds);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (FAR struct ft5x06_dev_s *)inode->i_private;
 
   /* Are we setting up the poll?  Or tearing it down? */

--- a/drivers/input/gt9xx.c
+++ b/drivers/input/gt9xx.c
@@ -488,9 +488,8 @@ static ssize_t gt9xx_read(FAR struct file *filep, FAR char *buffer,
 
   /* Get the Touch Panel Device */
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = inode->i_private;
 
   /* Begin Mutex: Lock to prevent concurrent reads */
@@ -606,9 +605,8 @@ static int gt9xx_open(FAR struct file *filep)
   /* Get the Touch Panel Device */
 
   iinfo("\n");
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = inode->i_private;
 
   /* Begin Mutex: Lock to prevent concurrent update to Reference Count */
@@ -692,9 +690,8 @@ static int gt9xx_close(FAR struct file *filep)
   /* Get the Touch Panel Device */
 
   iinfo("\n");
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = inode->i_private;
 
   /* Begin Mutex: Lock to prevent concurrent update to Reference Count */
@@ -762,9 +759,9 @@ static int gt9xx_poll(FAR struct file *filep, FAR struct pollfd *fds,
   /* Get the Touch Panel Device */
 
   iinfo("setup=%d\n", setup);
-  DEBUGASSERT(filep && fds);
+  DEBUGASSERT(fds);
   inode = filep->f_inode;
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (FAR struct gt9xx_dev_s *)inode->i_private;
 
   /* Begin Mutex: Lock to prevent concurrent update to Poll Waiters */

--- a/drivers/input/max11802.c
+++ b/drivers/input/max11802.c
@@ -706,10 +706,9 @@ static int max11802_open(FAR struct file *filep)
 
   iinfo("Opening\n");
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (FAR struct max11802_dev_s *)inode->i_private;
 
   /* Get exclusive access to the driver data structure */
@@ -760,10 +759,9 @@ static int max11802_close(FAR struct file *filep)
   int                       ret;
 
   iinfo("Closing\n");
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (FAR struct max11802_dev_s *)inode->i_private;
 
   /* Get exclusive access to the driver data structure */
@@ -804,10 +802,9 @@ static ssize_t max11802_read(FAR struct file *filep, FAR char *buffer,
   int                        ret;
 
   iinfo("buffer:%p len:%d\n", buffer, len);
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (FAR struct max11802_dev_s *)inode->i_private;
 
   /* Verify that the caller has provided a buffer large enough to receive
@@ -931,10 +928,9 @@ static int max11802_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   int                       ret;
 
   iinfo("cmd: %d arg: %ld\n", cmd, arg);
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (FAR struct max11802_dev_s *)inode->i_private;
 
   /* Get exclusive access to the driver data structure */
@@ -987,10 +983,10 @@ static int max11802_poll(FAR struct file *filep, FAR struct pollfd *fds,
   int i;
 
   iinfo("setup: %d\n", (int)setup);
-  DEBUGASSERT(filep && fds);
+  DEBUGASSERT(fds);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (FAR struct max11802_dev_s *)inode->i_private;
 
   /* Are we setting up the poll?  Or tearing it down? */

--- a/drivers/input/mxt.c
+++ b/drivers/input/mxt.c
@@ -1104,10 +1104,9 @@ static int mxt_open(FAR struct file *filep)
   uint8_t tmp;
   int ret;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (FAR struct mxt_dev_s *)inode->i_private;
 
   /* Get exclusive access to the driver data structure */
@@ -1182,10 +1181,9 @@ static int mxt_close(FAR struct file *filep)
   FAR struct mxt_dev_s *priv;
   int ret;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (FAR struct mxt_dev_s *)inode->i_private;
 
   /* Get exclusive access to the driver data structure */
@@ -1237,10 +1235,9 @@ static ssize_t mxt_read(FAR struct file *filep, FAR char *buffer, size_t len)
   int i;
   int j;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (FAR struct mxt_dev_s *)inode->i_private;
 
   /* Verify that the caller has provided a buffer large enough to receive
@@ -1464,10 +1461,9 @@ static int mxt_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   int                       ret;
 
   iinfo("cmd: %d arg: %ld\n", cmd, arg);
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (FAR struct mxt_dev_s *)inode->i_private;
 
   /* Get exclusive access to the driver data structure */
@@ -1521,10 +1517,10 @@ static int mxt_poll(FAR struct file *filep, FAR struct pollfd *fds,
   int                       i;
 
   iinfo("setup: %d\n", (int)setup);
-  DEBUGASSERT(filep && fds);
+  DEBUGASSERT(fds);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (FAR struct mxt_dev_s *)inode->i_private;
 
   /* Are we setting up the poll?  Or tearing it down? */

--- a/drivers/input/nunchuck.c
+++ b/drivers/input/nunchuck.c
@@ -275,7 +275,6 @@ static int nunchuck_open(FAR struct file *filep)
   FAR struct nunchuck_open_s *opriv;
   int ret;
 
-  DEBUGASSERT(filep && filep->f_inode);
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private);
   priv = (FAR struct nunchuck_dev_s *)inode->i_private;
@@ -330,7 +329,7 @@ static int nunchuck_close(FAR struct file *filep)
   bool closing;
   int ret;
 
-  DEBUGASSERT(filep && filep->f_priv && filep->f_inode);
+  DEBUGASSERT(filep->f_priv);
   opriv = filep->f_priv;
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private);
@@ -414,7 +413,6 @@ static ssize_t nunchuck_read(FAR struct file *filep, FAR char *buffer,
   FAR struct nunchuck_dev_s *priv;
   int ret;
 
-  DEBUGASSERT(filep && filep->f_inode);
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private);
   priv  = (FAR struct nunchuck_dev_s *)inode->i_private;
@@ -462,7 +460,7 @@ static int nunchuck_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   FAR struct nunchuck_dev_s *priv;
   int ret;
 
-  DEBUGASSERT(filep && filep->f_priv && filep->f_inode);
+  DEBUGASSERT(filep->f_priv);
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private);
   priv  = (FAR struct nunchuck_dev_s *)inode->i_private;

--- a/drivers/input/spq10kbd.c
+++ b/drivers/input/spq10kbd.c
@@ -453,7 +453,6 @@ static int spq10kbd_open(FAR struct file *filep)
   FAR struct inode          *inode;
   FAR struct spq10kbd_dev_s *priv;
 
-  DEBUGASSERT(filep && filep->f_inode);
   inode = filep->f_inode;
   priv  = inode->i_private;
 
@@ -477,7 +476,6 @@ static int spq10kbd_close(FAR struct file *filep)
   FAR struct inode          *inode;
   FAR struct spq10kbd_dev_s *priv;
 
-  DEBUGASSERT(filep && filep->f_inode);
   inode = filep->f_inode;
   priv  = inode->i_private;
 
@@ -507,7 +505,7 @@ static ssize_t spq10kbd_read(FAR struct file *filep, FAR char *buffer,
   uint16_t                   tail;
   int                        ret;
 
-  DEBUGASSERT(filep && filep->f_inode && buffer);
+  DEBUGASSERT(buffer);
   inode = filep->f_inode;
   priv  = inode->i_private;
 
@@ -607,7 +605,7 @@ static int spq10kbd_poll(FAR struct file *filep, FAR struct pollfd *fds,
   int                        ret;
   int                        i;
 
-  DEBUGASSERT(filep && filep->f_inode && fds);
+  DEBUGASSERT(fds);
   inode = filep->f_inode;
   priv  = inode->i_private;
 

--- a/drivers/input/stmpe811_tsc.c
+++ b/drivers/input/stmpe811_tsc.c
@@ -308,10 +308,9 @@ static int stmpe811_open(FAR struct file *filep)
   uint8_t                   tmp;
   int                       ret;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (FAR struct stmpe811_dev_s *)inode->i_private;
 
   /* Get exclusive access to the driver data structure */
@@ -365,10 +364,9 @@ static int stmpe811_close(FAR struct file *filep)
   FAR struct stmpe811_dev_s *priv;
   int                       ret;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (FAR struct stmpe811_dev_s *)inode->i_private;
 
   /* Get exclusive access to the driver data structure */
@@ -413,10 +411,9 @@ static ssize_t stmpe811_read(FAR struct file *filep,
   int                        ret;
 
   iinfo("len=%d\n", len);
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (FAR struct stmpe811_dev_s *)inode->i_private;
 
   /* Verify that the caller has provided a buffer large enough to receive
@@ -538,10 +535,9 @@ static int stmpe811_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   int                        ret;
 
   iinfo("cmd: %d arg: %ld\n", cmd, arg);
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (FAR struct stmpe811_dev_s *)inode->i_private;
 
   /* Get exclusive access to the driver data structure */
@@ -631,10 +627,10 @@ static int stmpe811_poll(FAR struct file *filep, FAR struct pollfd *fds,
   int                        i;
 
   iinfo("setup: %d\n", (int)setup);
-  DEBUGASSERT(filep && fds);
+  DEBUGASSERT(fds);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (FAR struct stmpe811_dev_s *)inode->i_private;
 
   /* Are we setting up the poll?  Or tearing it down? */

--- a/drivers/input/tsc2007.c
+++ b/drivers/input/tsc2007.c
@@ -776,10 +776,9 @@ static int tsc2007_open(FAR struct file *filep)
   uint8_t                   tmp;
   int                       ret;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (FAR struct tsc2007_dev_s *)inode->i_private;
 
   /* Get exclusive access to the driver data structure */
@@ -829,10 +828,9 @@ static int tsc2007_close(FAR struct file *filep)
   FAR struct tsc2007_dev_s *priv;
   int                       ret;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (FAR struct tsc2007_dev_s *)inode->i_private;
 
   /* Get exclusive access to the driver data structure */
@@ -872,10 +870,9 @@ static ssize_t tsc2007_read(FAR struct file *filep, FAR char *buffer,
   struct tsc2007_sample_s    sample;
   int                        ret;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (FAR struct tsc2007_dev_s *)inode->i_private;
 
   /* Verify that the caller has provided a buffer large enough to receive
@@ -1003,10 +1000,9 @@ static int tsc2007_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   int                       ret;
 
   iinfo("cmd: %d arg: %ld\n", cmd, arg);
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (FAR struct tsc2007_dev_s *)inode->i_private;
 
   /* Get exclusive access to the driver data structure */
@@ -1076,10 +1072,10 @@ static int tsc2007_poll(FAR struct file *filep, FAR struct pollfd *fds,
   int                       i;
 
   iinfo("setup: %d\n", (int)setup);
-  DEBUGASSERT(filep && fds);
+  DEBUGASSERT(fds);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (FAR struct tsc2007_dev_s *)inode->i_private;
 
   /* Are we setting up the poll?  Or tearing it down? */

--- a/drivers/ioexpander/gpio.c
+++ b/drivers/ioexpander/gpio.c
@@ -115,7 +115,6 @@ static ssize_t gpio_read(FAR struct file *filep, FAR char *buffer,
   FAR struct gpio_dev_s *dev;
   int ret;
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private != NULL);
   dev = inode->i_private;
@@ -174,7 +173,6 @@ static ssize_t gpio_write(FAR struct file *filep, FAR const char *buffer,
   int ret;
   bool val;
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private != NULL);
   dev = inode->i_private;
@@ -278,7 +276,6 @@ static int gpio_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   int i;
   int j = 0;
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private != NULL);
   dev = inode->i_private;

--- a/drivers/ipcc/ipcc_close.c
+++ b/drivers/ipcc/ipcc_close.c
@@ -63,7 +63,6 @@ int ipcc_close(FAR struct file *filep)
 
   /* Get our private data structure */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   priv = filep->f_inode->i_private;
 
   /* Get exclusive access to the IPCC driver state structure */

--- a/drivers/ipcc/ipcc_open.c
+++ b/drivers/ipcc/ipcc_open.c
@@ -60,7 +60,6 @@ int ipcc_open(FAR struct file *filep)
 
   /* Get our private data structure */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   priv = filep->f_inode->i_private;
 
   /* Get exclusive access to the IPCC driver state structure */

--- a/drivers/ipcc/ipcc_poll.c
+++ b/drivers/ipcc/ipcc_poll.c
@@ -72,7 +72,6 @@ int ipcc_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
   /* Get our private data structure */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   priv = filep->f_inode->i_private;
 
   /* Get exclusive access to driver */

--- a/drivers/ipcc/ipcc_read.c
+++ b/drivers/ipcc/ipcc_read.c
@@ -126,7 +126,6 @@ ssize_t ipcc_read(FAR struct file *filep, FAR char *buffer,
 
   /* Get our private data structure */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   priv = filep->f_inode->i_private;
 
   /* Get exclusive access to driver */

--- a/drivers/ipcc/ipcc_unlink.c
+++ b/drivers/ipcc/ipcc_unlink.c
@@ -65,7 +65,6 @@ int ipcc_unlink(FAR struct inode *inode)
 
   /* Get our private data structure */
 
-  DEBUGASSERT(inode);
   priv = inode->i_private;
 
   /* Get exclusive access to the IPCC driver state structure */

--- a/drivers/ipcc/ipcc_write.c
+++ b/drivers/ipcc/ipcc_write.c
@@ -128,7 +128,6 @@ ssize_t ipcc_write(FAR struct file *filep, FAR const char *buffer,
 
   /* Get our private data structure */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   priv = filep->f_inode->i_private;
 
   /* Get exclusive access to driver */

--- a/drivers/lcd/ft80x.c
+++ b/drivers/lcd/ft80x.c
@@ -451,9 +451,8 @@ static int ft80x_open(FAR struct file *filep)
   uint8_t tmp;
   int ret;
 
-  DEBUGASSERT(filep != NULL);
   inode = filep->f_inode;
-  DEBUGASSERT(inode != NULL && inode->i_private != NULL);
+  DEBUGASSERT(inode->i_private != NULL);
   priv  = inode->i_private;
 
   lcdinfo("crefs: %d\n", priv->crefs);
@@ -507,9 +506,8 @@ static int ft80x_close(FAR struct file *filep)
   FAR struct ft80x_dev_s *priv;
   int ret;
 
-  DEBUGASSERT(filep != NULL);
   inode = filep->f_inode;
-  DEBUGASSERT(inode != NULL && inode->i_private != NULL);
+  DEBUGASSERT(inode->i_private != NULL);
   priv  = inode->i_private;
 
   lcdinfo("crefs: %d\n", priv->crefs);
@@ -583,9 +581,8 @@ static ssize_t ft80x_write(FAR struct file *filep, FAR const char *buffer,
   DEBUGASSERT(buffer != NULL && ((uintptr_t)buffer & 3) == 0 &&
               len > 0 && (len & 3) == 0 && len <= FT80X_RAM_DL_SIZE);
 
-  DEBUGASSERT(filep != NULL);
   inode = filep->f_inode;
-  DEBUGASSERT(inode != NULL && inode->i_private != NULL);
+  DEBUGASSERT(inode->i_private != NULL);
   priv  = inode->i_private;
 
   if (buffer == NULL || ((uintptr_t)buffer & 3) != 0 ||
@@ -632,9 +629,8 @@ static int ft80x_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   FAR struct ft80x_dev_s *priv;
   int ret;
 
-  DEBUGASSERT(filep != NULL);
   inode = filep->f_inode;
-  DEBUGASSERT(inode != NULL && inode->i_private != NULL);
+  DEBUGASSERT(inode->i_private != NULL);
   priv  = inode->i_private;
 
   lcdinfo("cmd: %d arg: %lu\n", cmd, arg);
@@ -1159,7 +1155,7 @@ static int ft80x_unlink(FAR struct inode *inode)
    * structure.
    */
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = inode->i_private;
 
   /* Indicate that the driver has been unlinked */

--- a/drivers/lcd/tda19988.c
+++ b/drivers/lcd/tda19988.c
@@ -823,7 +823,6 @@ static int tda19988_open(FAR struct file *filep)
 
   /* Get the private driver state instance */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode = filep->f_inode;
 
   priv = (FAR struct tda1988_dev_s *)inode->i_private;
@@ -866,7 +865,6 @@ static int tda19988_close(FAR struct file *filep)
 
   /* Get the private driver state instance */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode = filep->f_inode;
 
   priv = (FAR struct tda1988_dev_s *)inode->i_private;
@@ -923,7 +921,6 @@ static ssize_t tda19988_read(FAR struct file *filep, FAR char *buffer,
 
   /* Get the private driver state instance */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode = filep->f_inode;
 
   priv = (FAR struct tda1988_dev_s *)inode->i_private;
@@ -993,7 +990,6 @@ static off_t tda19988_seek(FAR struct file *filep, off_t offset, int whence)
 
   /* Get the private driver state instance */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode = filep->f_inode;
 
   priv = (FAR struct tda1988_dev_s *)inode->i_private;
@@ -1087,7 +1083,6 @@ static int tda19988_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
   /* Get the private driver state instance */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode = filep->f_inode;
 
   priv = (FAR struct tda1988_dev_s *)inode->i_private;
@@ -1166,7 +1161,6 @@ static int tda19988_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
   /* Get the private driver state instance */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode = filep->f_inode;
 
   priv = (FAR struct tda1988_dev_s *)inode->i_private;
@@ -1209,7 +1203,7 @@ static int tda19988_unlink(FAR struct inode *inode)
 
   /* Get the private driver state instance */
 
-  DEBUGASSERT(inode != NULL && inode->i_private != NULL);
+  DEBUGASSERT(inode->i_private != NULL);
   priv = (FAR struct tda1988_dev_s *)inode->i_private;
 
   /* Get exclusive access to the driver */

--- a/drivers/leds/userled_upper.c
+++ b/drivers/leds/userled_upper.c
@@ -122,7 +122,6 @@ static int userled_open(FAR struct file *filep)
   FAR struct userled_open_s *opriv;
   int ret;
 
-  DEBUGASSERT(filep && filep->f_inode);
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private);
   priv = (FAR struct userled_upperhalf_s *)inode->i_private;
@@ -177,7 +176,7 @@ static int userled_close(FAR struct file *filep)
   bool closing;
   int ret;
 
-  DEBUGASSERT(filep && filep->f_priv && filep->f_inode);
+  DEBUGASSERT(filep->f_priv);
   opriv = filep->f_priv;
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private);
@@ -262,7 +261,6 @@ static ssize_t userled_write(FAR struct file *filep, FAR const char *buffer,
   userled_set_t ledset;
   int ret;
 
-  DEBUGASSERT(filep && filep->f_inode);
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private);
   priv  = (FAR struct userled_upperhalf_s *)inode->i_private;
@@ -317,7 +315,7 @@ static int userled_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   FAR const struct userled_lowerhalf_s *lower;
   int ret;
 
-  DEBUGASSERT(filep != NULL && filep->f_priv != NULL &&
+  DEBUGASSERT(filep->f_priv != NULL &&
               filep->f_inode != NULL);
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private);

--- a/drivers/loop/losetup.c
+++ b/drivers/loop/losetup.c
@@ -110,7 +110,7 @@ static int loop_open(FAR struct inode *inode)
   FAR struct loop_struct_s *dev;
   int ret;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (FAR struct loop_struct_s *)inode->i_private;
 
   /* Make sure we have exclusive access to the state structure */
@@ -147,7 +147,7 @@ static int loop_close(FAR struct inode *inode)
   FAR struct loop_struct_s *dev;
   int ret;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (FAR struct loop_struct_s *)inode->i_private;
 
   /* Make sure we have exclusive access to the state structure */
@@ -187,7 +187,7 @@ static ssize_t loop_read(FAR struct inode *inode, FAR unsigned char *buffer,
   off_t offset;
   off_t ret;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (FAR struct loop_struct_s *)inode->i_private;
 
   if (start_sector + nsectors > dev->nsectors)
@@ -241,7 +241,7 @@ static ssize_t loop_write(FAR struct inode *inode,
   off_t offset;
   off_t ret;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (FAR struct loop_struct_s *)inode->i_private;
 
   /* Calculate the offset to write the sectors and seek to the position */
@@ -284,7 +284,6 @@ static int loop_geometry(FAR struct inode *inode,
 {
   FAR struct loop_struct_s *dev;
 
-  DEBUGASSERT(inode);
   if (geometry)
     {
       dev = (FAR struct loop_struct_s *)inode->i_private;

--- a/drivers/misc/ramdisk.c
+++ b/drivers/misc/ramdisk.c
@@ -167,7 +167,7 @@ static int rd_open(FAR struct inode *inode)
 {
   FAR struct rd_struct_s *dev;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (FAR struct rd_struct_s *)inode->i_private;
 
   /* Increment the open reference count */
@@ -192,7 +192,7 @@ static int rd_close(FAR struct inode *inode)
 {
   FAR struct rd_struct_s *dev;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (FAR struct rd_struct_s *)inode->i_private;
 
   /* Increment the open reference count */
@@ -233,7 +233,7 @@ static ssize_t rd_read(FAR struct inode *inode, unsigned char *buffer,
 {
   FAR struct rd_struct_s *dev;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (FAR struct rd_struct_s *)inode->i_private;
 
   finfo("sector: %" PRIuOFF " nsectors: %u sectorsize: %d\n",
@@ -267,7 +267,7 @@ static ssize_t rd_write(FAR struct inode *inode, const unsigned char *buffer,
 {
   struct rd_struct_s *dev;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (struct rd_struct_s *)inode->i_private;
 
   finfo("sector: %" PRIuOFF " nsectors: %u sectorsize: %d\n",
@@ -306,7 +306,6 @@ static int rd_geometry(FAR struct inode *inode, struct geometry *geometry)
 
   finfo("Entry\n");
 
-  DEBUGASSERT(inode);
   if (geometry)
     {
       dev = (struct rd_struct_s *)inode->i_private;
@@ -347,7 +346,7 @@ static int rd_ioctl(FAR struct inode *inode, int cmd, unsigned long arg)
 
   /* Only one ioctl command is supported */
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   if (cmd == BIOC_XIPBASE && ppv)
     {
       dev  = (FAR struct rd_struct_s *)inode->i_private;
@@ -373,7 +372,7 @@ static int rd_unlink(FAR struct inode *inode)
 {
   FAR struct rd_struct_s *dev;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (FAR struct rd_struct_s *)inode->i_private;
 
   /* Mark the pipe unlinked */

--- a/drivers/misc/rpmsgdev.c
+++ b/drivers/misc/rpmsgdev.c
@@ -200,10 +200,6 @@ static int rpmsgdev_open(FAR struct file *filep)
   struct rpmsgdev_open_s msg;
   int ret;
 
-  /* Sanity checks */
-
-  DEBUGASSERT(filep->f_inode != NULL);
-
   /* Get the mountpoint inode reference from the file structure and the
    * mountpoint private data from the inode structure
    */
@@ -262,10 +258,6 @@ static int rpmsgdev_close(FAR struct file *filep)
   FAR struct rpmsgdev_priv_s *priv;
   struct rpmsgdev_close_s msg;
   int ret;
-
-  /* Sanity checks */
-
-  DEBUGASSERT(filep->f_inode != NULL);
 
   /* Recover our private data from the struct file instance */
 
@@ -405,10 +397,6 @@ static ssize_t rpmsgdev_read(FAR struct file *filep, FAR char *buffer,
       return -EINVAL;
     }
 
-  /* Sanity checks */
-
-  DEBUGASSERT(filep->f_inode != NULL);
-
   /* Recover our private data from the struct file instance */
 
   dev  = filep->f_inode->i_private;
@@ -479,8 +467,6 @@ static ssize_t rpmsgdev_write(FAR struct file *filep, const char *buffer,
     {
       return -EINVAL;
     }
-
-  DEBUGASSERT(filep->f_inode != NULL);
 
   /* Recover our private data from the struct file instance */
 
@@ -589,10 +575,6 @@ static off_t rpmsgdev_seek(FAR struct file *filep, off_t offset, int whence)
   struct rpmsgdev_lseek_s msg;
   int ret;
 
-  /* Sanity checks */
-
-  DEBUGASSERT(filep->f_inode != NULL);
-
   /* Recover our private data from the struct file instance */
 
   dev  = filep->f_inode->i_private;
@@ -675,10 +657,6 @@ static int rpmsgdev_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   size_t msglen;
   int ret;
 
-  /* Sanity checks */
-
-  DEBUGASSERT(filep->f_inode != NULL);
-
   /* Recover our private data from the struct file instance */
 
   dev  = filep->f_inode->i_private;
@@ -744,10 +722,6 @@ static int rpmsgdev_poll(FAR struct file *filep, FAR struct pollfd *fds,
   FAR struct rpmsgdev_s *dev;
   FAR struct rpmsgdev_priv_s *priv;
   struct rpmsgdev_poll_s msg;
-
-  /* Sanity checks */
-
-  DEBUGASSERT(filep->f_inode != NULL);
 
   /* Recover our private data from the struct file instance */
 

--- a/drivers/mmcsd/mmcsd_sdio.c
+++ b/drivers/mmcsd/mmcsd_sdio.c
@@ -2043,7 +2043,7 @@ static int mmcsd_open(FAR struct inode *inode)
   int ret;
 
   finfo("Entry\n");
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (FAR struct mmcsd_state_s *)inode->i_private;
 
   /* Just increment the reference count on the driver */
@@ -2074,7 +2074,7 @@ static int mmcsd_close(FAR struct inode *inode)
   int ret;
 
   finfo("Entry\n");
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (FAR struct mmcsd_state_s *)inode->i_private;
 
   /* Decrement the reference count on the block driver */
@@ -2109,7 +2109,7 @@ static ssize_t mmcsd_read(FAR struct inode *inode, unsigned char *buffer,
   ssize_t nread;
   ssize_t ret = nsectors;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (FAR struct mmcsd_state_s *)inode->i_private;
   finfo("startsector: %" PRIuOFF " nsectors: %u sectorsize: %d\n",
         startsector, nsectors, priv->blocksize);
@@ -2187,7 +2187,7 @@ static ssize_t mmcsd_write(FAR struct inode *inode,
   ssize_t nwrite;
   ssize_t ret = nsectors;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (FAR struct mmcsd_state_s *)inode->i_private;
   finfo("startsector: %" PRIuOFF " nsectors: %u sectorsize: %d\n",
         startsector, nsectors, priv->blocksize);
@@ -2259,7 +2259,7 @@ static int mmcsd_geometry(FAR struct inode *inode, struct geometry *geometry)
   int ret = -EINVAL;
 
   finfo("Entry\n");
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
 
   if (geometry)
     {
@@ -2321,7 +2321,7 @@ static int mmcsd_ioctl(FAR struct inode *inode, int cmd, unsigned long arg)
   int ret;
 
   finfo("Entry\n");
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (FAR struct mmcsd_state_s *)inode->i_private;
 
   /* Process the IOCTL by command */

--- a/drivers/modem/alt1250/alt1250.c
+++ b/drivers/modem/alt1250/alt1250.c
@@ -1127,7 +1127,6 @@ static int alt1250_open(FAR struct file *filep)
 
   /* Get our private data structure */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode = filep->f_inode;
 
   dev = (FAR struct alt1250_dev_s *)inode->i_private;
@@ -1174,7 +1173,6 @@ static int alt1250_close(FAR struct file *filep)
 
   /* Get our private data structure */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode = filep->f_inode;
 
   dev = (FAR struct alt1250_dev_s *)inode->i_private;
@@ -1220,7 +1218,6 @@ static ssize_t alt1250_read(FAR struct file *filep, FAR char *buffer,
 
   /* Get our private data structure */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode = filep->f_inode;
 
   dev = (FAR struct alt1250_dev_s *)inode->i_private;
@@ -1246,7 +1243,6 @@ static int alt1250_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
   /* Get our private data structure */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode = filep->f_inode;
 
   dev = (FAR struct alt1250_dev_s *)inode->i_private;
@@ -1311,7 +1307,6 @@ static int alt1250_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
   /* Get our private data structure */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode = filep->f_inode;
 
   dev = (FAR struct alt1250_dev_s *)inode->i_private;

--- a/drivers/mtd/dhara.c
+++ b/drivers/mtd/dhara.c
@@ -296,7 +296,7 @@ static int dhara_open(FAR struct inode *inode)
 {
   FAR dhara_dev_t *dev;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (FAR dhara_dev_t *) inode->i_private;
   nxmutex_lock(&dev->lock);
   dev->refs++;
@@ -316,7 +316,7 @@ static int dhara_close(FAR struct inode *inode)
 {
   FAR dhara_dev_t *dev;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (FAR dhara_dev_t *) inode->i_private;
   nxmutex_lock(&dev->lock);
   dev->refs--;
@@ -349,7 +349,7 @@ static ssize_t dhara_read(FAR struct inode *inode,
   size_t nread = 0;
   int ret = 0;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (FAR dhara_dev_t *)inode->i_private;
 
   nxmutex_lock(&dev->lock);
@@ -393,7 +393,7 @@ static ssize_t dhara_write(FAR struct inode *inode,
   size_t nwrite = 0;
   int ret = 0;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (FAR dhara_dev_t *)inode->i_private;
 
   nxmutex_lock(&dev->lock);
@@ -433,7 +433,7 @@ static int dhara_geometry(FAR struct inode *inode,
 {
   FAR dhara_dev_t *dev;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (FAR dhara_dev_t *)inode->i_private;
 
   if (geometry)
@@ -466,7 +466,7 @@ static int dhara_ioctl(FAR struct inode *inode,
   FAR dhara_dev_t *dev;
   int ret;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (dhara_dev_t *)inode->i_private;
 
   /* No other block driver ioctl commands are not recognized by this
@@ -495,7 +495,7 @@ static int dhara_unlink(FAR struct inode *inode)
 {
   FAR dhara_dev_t *dev;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (FAR dhara_dev_t *)inode->i_private;
   nxmutex_lock(&dev->lock);
   dev->unlinked = true;

--- a/drivers/mtd/ftl.c
+++ b/drivers/mtd/ftl.c
@@ -212,7 +212,7 @@ static int ftl_open(FAR struct inode *inode)
 {
   FAR struct ftl_struct_s *dev;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (FAR struct ftl_struct_s *)inode->i_private;
 
   dev->refs++;
@@ -230,7 +230,7 @@ static int ftl_close(FAR struct inode *inode)
 {
   FAR struct ftl_struct_s *dev;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (FAR struct ftl_struct_s *)inode->i_private;
 
 #ifdef CONFIG_FTL_WRITEBUFFER
@@ -442,7 +442,7 @@ static ssize_t ftl_read(FAR struct inode *inode, unsigned char *buffer,
 
   finfo("sector: %" PRIuOFF " nsectors: %u\n", start_sector, nsectors);
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
 
   dev = (FAR struct ftl_struct_s *)inode->i_private;
 #ifdef FTL_HAVE_RWBUFFER
@@ -660,7 +660,7 @@ static ssize_t ftl_write(FAR struct inode *inode,
 
   finfo("sector: %" PRIuOFF " nsectors: %u\n", start_sector, nsectors);
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (struct ftl_struct_s *)inode->i_private;
 #ifdef FTL_HAVE_RWBUFFER
   return rwb_write(&dev->rwb, start_sector, nsectors, buffer);
@@ -683,7 +683,6 @@ static int ftl_geometry(FAR struct inode *inode,
 
   finfo("Entry\n");
 
-  DEBUGASSERT(inode);
   if (geometry)
     {
       dev = (struct ftl_struct_s *)inode->i_private;
@@ -720,7 +719,7 @@ static int ftl_ioctl(FAR struct inode *inode, int cmd, unsigned long arg)
   int ret;
 
   finfo("Entry\n");
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
 
   dev = (struct ftl_struct_s *)inode->i_private;
 
@@ -757,7 +756,7 @@ static int ftl_unlink(FAR struct inode *inode)
 {
   FAR struct ftl_struct_s *dev;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (FAR struct ftl_struct_s *)inode->i_private;
 
   dev->unlinked = true;

--- a/drivers/mtd/smart.c
+++ b/drivers/mtd/smart.c
@@ -903,7 +903,7 @@ static ssize_t smart_read(FAR struct inode *inode, unsigned char *buffer,
   finfo("SMART: sector: %" PRIuOFF " nsectors: %u\n",
         start_sector, nsectors);
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
 #ifdef CONFIG_SMARTFS_MULTI_ROOT_DIRS
   dev = ((FAR struct smart_multiroot_device_s *)inode->i_private)->dev;
 #else
@@ -939,7 +939,7 @@ static ssize_t smart_write(FAR struct inode *inode,
 
   finfo("sector: %" PRIuOFF " nsectors: %u\n", start_sector, nsectors);
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
 #ifdef CONFIG_SMARTFS_MULTI_ROOT_DIRS
   dev = ((FAR struct smart_multiroot_device_s *)inode->i_private)->dev;
 #else
@@ -1049,7 +1049,6 @@ static int smart_geometry(FAR struct inode *inode, struct geometry *geometry)
 
   finfo("Entry\n");
 
-  DEBUGASSERT(inode);
   if (geometry)
     {
 #ifdef CONFIG_SMARTFS_MULTI_ROOT_DIRS
@@ -5483,7 +5482,7 @@ static int smart_ioctl(FAR struct inode *inode, int cmd, unsigned long arg)
 #endif
 
   finfo("Entry\n");
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
 
 #ifdef CONFIG_SMARTFS_MULTI_ROOT_DIRS
   dev = ((FAR struct smart_multiroot_device_s *)inode->i_private)->dev;

--- a/drivers/pipes/pipe_common.c
+++ b/drivers/pipes/pipe_common.c
@@ -887,7 +887,7 @@ int pipecommon_unlink(FAR struct inode *inode)
 {
   FAR struct pipe_dev_s *dev;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (FAR struct pipe_dev_s *)inode->i_private;
 
   /* Mark the pipe unlinked */

--- a/drivers/power/relay/relay.c
+++ b/drivers/power/relay/relay.c
@@ -84,7 +84,6 @@ static int relay_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   FAR struct inode *inode;
   int ret;
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private != NULL);
   dev = inode->i_private;

--- a/drivers/sensors/adxl345_base.c
+++ b/drivers/sensors/adxl345_base.c
@@ -82,10 +82,9 @@ static ssize_t adxl345_read(FAR struct file *filep,
   int                       ret;
 
   sninfo("len=%d\n", len);
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (FAR struct adxl345_dev_s *)inode->i_private;
 
   /* Verify that the caller has provided a buffer large enough to receive

--- a/drivers/sensors/aht10.c
+++ b/drivers/sensors/aht10.c
@@ -534,7 +534,7 @@ static int aht10_unlink(FAR struct inode *inode)
   FAR struct aht10_dev_s *priv;
   int ret;
 
-  DEBUGASSERT(inode != NULL && inode->i_private != NULL);
+  DEBUGASSERT(inode->i_private != NULL);
   priv = (FAR struct aht10_dev_s *)inode->i_private;
 
   /* Get exclusive access */

--- a/drivers/sensors/apds9922.c
+++ b/drivers/sensors/apds9922.c
@@ -2037,12 +2037,10 @@ static ssize_t apds9922_als_read(FAR struct file *filep, FAR char *buffer,
   int *ptr;
   int ret;
 
-  DEBUGASSERT(filep);
-
   inode = filep->f_inode;
   priv = inode->i_private;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
 
   ret = nxmutex_lock(&priv->devlock);
   if (ret < 0)
@@ -2183,10 +2181,10 @@ static int apds9922_als_poll(FAR struct file *filep,
   int ret;
   int i;
 
-  DEBUGASSERT(filep && fds);
+  DEBUGASSERT(fds);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (FAR struct apds9922_dev_s *)inode->i_private;
 
   ret = nxmutex_lock(&priv->devlock);
@@ -2272,9 +2270,7 @@ static ssize_t apds9922_ps_read(FAR struct file *filep, FAR char *buffer,
   FAR struct apds9922_ps_data *ptr;
   int ret;
 
-  DEBUGASSERT(filep);
-
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
 
   if (buflen < sizeof(struct apds9922_ps_data))
     {
@@ -2410,10 +2406,10 @@ static int apds9922_ps_poll(FAR struct file *filep,
   int ret;
   int i;
 
-  DEBUGASSERT(filep && fds);
+  DEBUGASSERT(fds);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (FAR struct apds9922_dev_s *)inode->i_private;
 
   ret = nxmutex_lock(&priv->devlock);

--- a/drivers/sensors/apds9960.c
+++ b/drivers/sensors/apds9960.c
@@ -1134,10 +1134,9 @@ static ssize_t apds9960_read(FAR struct file *filep, FAR char *buffer,
   FAR struct apds9960_dev_s *priv;
   int ret;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (FAR struct apds9960_dev_s *)inode->i_private;
 
   /* Check if the user is reading the right size */

--- a/drivers/sensors/bh1750fvi.c
+++ b/drivers/sensors/bh1750fvi.c
@@ -179,10 +179,9 @@ static ssize_t bh1750fvi_read(FAR struct file *filep, FAR char *buffer,
   FAR struct bh1750fvi_dev_s *priv;
   uint16_t lux = 0;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (FAR struct bh1750fvi_dev_s *)inode->i_private;
 
   /* Check if the user is reading the right size */

--- a/drivers/sensors/gps.c
+++ b/drivers/sensors/gps.c
@@ -197,7 +197,6 @@ static int gps_open(FAR struct file *filep)
   FAR struct gps_user_s *user;
   int ret = OK;
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   upper = filep->f_inode->i_private;
 
   user = kmm_zalloc(sizeof(struct gps_user_s));
@@ -242,7 +241,7 @@ static int gps_close(FAR struct file *filep)
   FAR struct gps_user_s *user;
   int ret = OK;
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL && filep->f_priv);
+  DEBUGASSERT(filep->f_priv);
   upper = filep->f_inode->i_private;
   user = filep->f_priv;
 
@@ -280,7 +279,6 @@ static ssize_t gps_read(FAR struct file *filep, FAR char *buffer,
       return 0;
     }
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   upper = filep->f_inode->i_private;
   user = filep->f_priv;
 
@@ -327,7 +325,6 @@ static ssize_t gps_write(FAR struct file *filep, FAR const char *buffer,
   FAR struct gps_upperhalf_s *upper;
   int ret = -ENOTSUP;
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   upper = filep->f_inode->i_private;
 
   nxmutex_lock(&upper->lock);
@@ -346,7 +343,6 @@ static int gps_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   FAR struct gps_upperhalf_s *upper;
   int ret = -ENOTTY;
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   upper = filep->f_inode->i_private;
 
   nxmutex_lock(&upper->lock);
@@ -374,7 +370,6 @@ static int gps_poll(FAR struct file *filep, FAR struct pollfd *fds,
   FAR struct gps_user_s *user;
   ssize_t ret = OK;
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   upper = filep->f_inode->i_private;
   user = filep->f_priv;
 

--- a/drivers/sensors/hc_sr04.c
+++ b/drivers/sensors/hc_sr04.c
@@ -280,10 +280,10 @@ static int hcsr04_poll(FAR struct file *filep, FAR struct pollfd *fds,
   int ret = OK;
   int i;
 
-  DEBUGASSERT(filep && fds);
+  DEBUGASSERT(fds);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (FAR struct hcsr04_dev_s *)inode->i_private;
 
   /* Get exclusive access */

--- a/drivers/sensors/hdc1008.c
+++ b/drivers/sensors/hdc1008.c
@@ -598,8 +598,6 @@ static ssize_t hdc1008_read(FAR struct file *filep, FAR char *buffer,
   int len = 0;
   struct hdc1008_conv_data_s data;
 
-  DEBUGASSERT(filep != NULL);
-
   /* Sanity check of input buffer argument */
 
   if (buffer == NULL)

--- a/drivers/sensors/hts221.c
+++ b/drivers/sensors/hts221.c
@@ -1063,10 +1063,10 @@ static int hts221_poll(FAR struct file *filep, FAR struct pollfd *fds,
   int ret = OK;
   int i;
 
-  DEBUGASSERT(filep && fds);
+  DEBUGASSERT(fds);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (FAR struct hts221_dev_s *)inode->i_private;
 
   /* Get exclusive access */

--- a/drivers/sensors/kxtj9.c
+++ b/drivers/sensors/kxtj9.c
@@ -480,7 +480,7 @@ static ssize_t kxtj9_read(FAR struct file *filep, FAR char *buffer,
       return (ssize_t)-EINVAL;
     }
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL && buffer != NULL);
+  DEBUGASSERT(buffer != NULL);
   inode = filep->f_inode;
 
   priv = (FAR struct kxtj9_dev_s *)inode->i_private;
@@ -538,7 +538,6 @@ static int kxtj9_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
   /* Sanity check */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode = filep->f_inode;
 
   priv = (FAR struct kxtj9_dev_s *)inode->i_private;

--- a/drivers/sensors/lis2dh.c
+++ b/drivers/sensors/lis2dh.c
@@ -517,7 +517,7 @@ static ssize_t lis2dh_read(FAR struct file *filep, FAR char *buffer,
 static ssize_t lis2dh_write(FAR struct file *filep, FAR const char *buffer,
                             size_t buflen)
 {
-  DEBUGASSERT(filep != NULL && buffer != NULL && buflen > 0);
+  DEBUGASSERT(buffer != NULL && buflen > 0);
 
   return -ENOSYS;
 }
@@ -538,10 +538,9 @@ static int lis2dh_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   int ret;
   uint8_t buf;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (FAR struct lis2dh_dev_s *)inode->i_private;
 
   ret = nxmutex_lock(&dev->devlock);
@@ -665,10 +664,10 @@ static int lis2dh_poll(FAR struct file *filep, FAR struct pollfd *fds,
   int ret;
   int i;
 
-  DEBUGASSERT(filep && fds);
+  DEBUGASSERT(fds);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (FAR struct lis2dh_dev_s *)inode->i_private;
 
   ret = nxmutex_lock(&dev->devlock);

--- a/drivers/sensors/lsm303agr.c
+++ b/drivers/sensors/lsm303agr.c
@@ -954,10 +954,8 @@ static ssize_t lsm303agr_read(FAR struct file *filep,
 
   /* Sanity check */
 
-  DEBUGASSERT(filep != NULL);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode != NULL);
   priv = (FAR struct lsm303agr_dev_s *)inode->i_private;
 
   DEBUGASSERT(priv != NULL);
@@ -1077,10 +1075,8 @@ static int lsm303agr_ioctl(FAR struct file *filep, int cmd,
 
   /* Sanity check */
 
-  DEBUGASSERT(filep != NULL);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode != NULL);
   priv = (FAR struct lsm303agr_dev_s *)inode->i_private;
 
   DEBUGASSERT(priv != NULL);

--- a/drivers/sensors/lsm6dsl.c
+++ b/drivers/sensors/lsm6dsl.c
@@ -977,10 +977,8 @@ static ssize_t lsm6dsl_read(FAR struct file *filep,
 
   /* Sanity check */
 
-  DEBUGASSERT(filep != NULL);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode != NULL);
   priv = (FAR struct lsm6dsl_dev_s *)inode->i_private;
 
   DEBUGASSERT(priv != NULL);
@@ -1099,10 +1097,8 @@ static int lsm6dsl_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
   /* Sanity check */
 
-  DEBUGASSERT(filep != NULL);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode != NULL);
   priv = (FAR struct lsm6dsl_dev_s *)inode->i_private;
 
   DEBUGASSERT(priv != NULL);

--- a/drivers/sensors/lsm9ds1.c
+++ b/drivers/sensors/lsm9ds1.c
@@ -1216,10 +1216,8 @@ static ssize_t lsm9ds1_read(FAR struct file *filep, FAR char *buffer,
 
   /* Sanity check */
 
-  DEBUGASSERT(filep != NULL);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode != NULL);
   priv = (FAR struct lsm9ds1_dev_s *)inode->i_private;
 
   DEBUGASSERT(priv != NULL);
@@ -1339,10 +1337,8 @@ static int lsm9ds1_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
   /* Sanity check */
 
-  DEBUGASSERT(filep != NULL);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode != NULL);
   priv = (FAR struct lsm9ds1_dev_s *)inode->i_private;
 
   DEBUGASSERT(priv != NULL);

--- a/drivers/sensors/max44009.c
+++ b/drivers/sensors/max44009.c
@@ -215,10 +215,9 @@ static int max44009_open(FAR struct file *filep)
   unsigned int use_count;
   int ret;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (FAR struct max44009_dev_s *)inode->i_private;
 
   ret = nxmutex_lock(&priv->dev_lock);
@@ -264,10 +263,9 @@ static int max44009_close(FAR struct file *filep)
   int use_count;
   int ret;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (FAR struct max44009_dev_s *)inode->i_private;
 
   ret = nxmutex_lock(&priv->dev_lock);
@@ -307,10 +305,9 @@ static ssize_t max44009_read(FAR struct file *filep, FAR char *buffer,
   int ret;
   struct max44009_data_s data;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (FAR struct max44009_dev_s *)inode->i_private;
 
   ret = nxmutex_lock(&priv->dev_lock);
@@ -711,10 +708,9 @@ static int max44009_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   FAR struct max44009_dev_s *priv;
   int ret;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (FAR struct max44009_dev_s *)inode->i_private;
 
   ret = nxmutex_lock(&priv->dev_lock);
@@ -783,10 +779,10 @@ static int max44009_poll(FAR struct file *filep, FAR struct pollfd *fds,
   int ret = OK;
   int i;
 
-  DEBUGASSERT(filep && fds);
+  DEBUGASSERT(fds);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (FAR struct max44009_dev_s *)inode->i_private;
 
   ret = nxmutex_lock(&priv->dev_lock);

--- a/drivers/sensors/mlx90614.c
+++ b/drivers/sensors/mlx90614.c
@@ -260,10 +260,9 @@ static ssize_t mlx90614_read(FAR struct file *filep, FAR char *buffer,
   uint8_t cmd;
   int ret;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (FAR struct mlx90614_dev_s *)inode->i_private;
 
   /* Check if the user is reading the right size */

--- a/drivers/sensors/msa301.c
+++ b/drivers/sensors/msa301.c
@@ -479,10 +479,8 @@ static int msa301_open(FAR struct file *filep)
   FAR struct inode *       inode;
   FAR struct msa301_dev_s *priv;
 
-  DEBUGASSERT(filep != NULL);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode != NULL);
   priv = (FAR struct msa301_dev_s *)inode->i_private;
 
   DEBUGASSERT(priv != NULL);
@@ -507,10 +505,8 @@ static int msa301_close(FAR struct file *filep)
   FAR struct inode *       inode;
   FAR struct msa301_dev_s *priv;
 
-  DEBUGASSERT(filep != NULL);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode != NULL);
   priv = (FAR struct msa301_dev_s *)inode->i_private;
 
   DEBUGASSERT(priv != NULL);
@@ -539,10 +535,8 @@ static ssize_t msa301_read(FAR struct file *filep,
 
   /* Sanity check */
 
-  DEBUGASSERT(filep != NULL);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode != NULL);
   priv = (FAR struct msa301_dev_s *)inode->i_private;
 
   DEBUGASSERT(priv != NULL);
@@ -593,10 +587,8 @@ static int msa301_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
   /* Sanity check */
 
-  DEBUGASSERT(filep != NULL);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode != NULL);
   priv = (FAR struct msa301_dev_s *)inode->i_private;
 
   DEBUGASSERT(priv != NULL);

--- a/drivers/sensors/scd30.c
+++ b/drivers/sensors/scd30.c
@@ -982,7 +982,7 @@ static int scd30_unlink(FAR struct inode *inode)
   FAR struct scd30_dev_s *priv;
   int ret;
 
-  DEBUGASSERT(inode != NULL && inode->i_private != NULL);
+  DEBUGASSERT(inode->i_private != NULL);
   priv = (FAR struct scd30_dev_s *)inode->i_private;
 
   /* Get exclusive access */

--- a/drivers/sensors/scd41.c
+++ b/drivers/sensors/scd41.c
@@ -939,7 +939,7 @@ static int scd41_unlink(FAR struct inode *inode)
   FAR struct scd41_dev_s *priv;
   int ret;
 
-  DEBUGASSERT(inode != NULL && inode->i_private != NULL);
+  DEBUGASSERT(inode->i_private != NULL);
   priv = (FAR struct scd41_dev_s *)inode->i_private;
 
   /* Get exclusive access */

--- a/drivers/sensors/sgp30.c
+++ b/drivers/sensors/sgp30.c
@@ -989,7 +989,7 @@ static int sgp30_unlink(FAR struct inode *inode)
   FAR struct sgp30_dev_s *priv;
   int ret;
 
-  DEBUGASSERT(inode != NULL && inode->i_private != NULL);
+  DEBUGASSERT(inode->i_private != NULL);
   priv = (FAR struct sgp30_dev_s *)inode->i_private;
 
   /* Get exclusive access */

--- a/drivers/sensors/sht21.c
+++ b/drivers/sensors/sht21.c
@@ -591,7 +591,7 @@ static int sht21_unlink(FAR struct inode *inode)
   FAR struct sht21_dev_s *priv;
   int ret;
 
-  DEBUGASSERT(inode != NULL && inode->i_private != NULL);
+  DEBUGASSERT(inode->i_private != NULL);
   priv = (FAR struct sht21_dev_s *)inode->i_private;
 
   /* Get exclusive access */

--- a/drivers/sensors/sht3x.c
+++ b/drivers/sensors/sht3x.c
@@ -610,7 +610,7 @@ static int sht3x_unlink(FAR struct inode *inode)
   FAR struct sht3x_dev_s *priv;
   int ret;
 
-  DEBUGASSERT(inode != NULL && inode->i_private != NULL);
+  DEBUGASSERT(inode->i_private != NULL);
   priv = (FAR struct sht3x_dev_s *)inode->i_private;
 
   /* Get exclusive access */

--- a/drivers/sensors/sps30.c
+++ b/drivers/sensors/sps30.c
@@ -1000,7 +1000,7 @@ static int sps30_unlink(FAR struct inode *inode)
   FAR struct sps30_dev_s *priv;
   int ret;
 
-  DEBUGASSERT(inode != NULL && inode->i_private != NULL);
+  DEBUGASSERT(inode->i_private != NULL);
   priv = (FAR struct sps30_dev_s *)inode->i_private;
 
   /* Get exclusive access */

--- a/drivers/sensors/veml6070.c
+++ b/drivers/sensors/veml6070.c
@@ -175,10 +175,9 @@ static ssize_t veml6070_read(FAR struct file *filep, FAR char *buffer,
   int msb = 1;
   uint16_t regdata;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (FAR struct veml6070_dev_s *)inode->i_private;
 
   /* Check if the user is reading the right size */

--- a/drivers/sensors/xen1210.c
+++ b/drivers/sensors/xen1210.c
@@ -101,10 +101,9 @@ static ssize_t xen1210_read(FAR struct file *filep, FAR char *buffer,
   int                       ret;
 
   sninfo("len=%d\n", len);
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv  = (FAR struct xen1210_dev_s *)inode->i_private;
 
   /* Verify that the caller has provided a buffer large enough to receive

--- a/drivers/sensors/zerocross.c
+++ b/drivers/sensors/zerocross.c
@@ -200,7 +200,6 @@ static int zc_open(FAR struct file *filep)
   FAR struct zc_open_s            *opriv;
   int ret;
 
-  DEBUGASSERT(filep && filep->f_inode);
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private);
   priv = (FAR struct zc_upperhalf_s *)inode->i_private;
@@ -258,7 +257,7 @@ static int zc_close(FAR struct file *filep)
   bool closing;
   int ret;
 
-  DEBUGASSERT(filep && filep->f_priv && filep->f_inode);
+  DEBUGASSERT(filep->f_priv);
   opriv = filep->f_priv;
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private);
@@ -386,7 +385,7 @@ static int zc_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   int                        ret;
 
   sninfo("cmd: %d arg: %ld\n", cmd, arg);
-  DEBUGASSERT(filep && filep->f_priv && filep->f_inode);
+  DEBUGASSERT(filep->f_priv);
   opriv = filep->f_priv;
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private);

--- a/drivers/serial/pty.c
+++ b/drivers/serial/pty.c
@@ -231,7 +231,6 @@ static int pty_open(FAR struct file *filep)
   FAR struct pty_devpair_s *devpair;
   int ret = OK;
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode   = filep->f_inode;
   dev     = inode->i_private;
   DEBUGASSERT(dev != NULL && dev->pd_devpair != NULL);
@@ -328,7 +327,6 @@ static int pty_close(FAR struct file *filep)
   FAR struct pty_devpair_s *devpair;
   int ret;
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode   = filep->f_inode;
   dev     = inode->i_private;
   DEBUGASSERT(dev != NULL && dev->pd_devpair != NULL);
@@ -400,7 +398,6 @@ static ssize_t pty_read(FAR struct file *filep, FAR char *buffer, size_t len)
   ssize_t j;
   char ch;
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode = filep->f_inode;
   dev   = inode->i_private;
   DEBUGASSERT(dev != NULL);
@@ -555,7 +552,6 @@ static ssize_t pty_write(FAR struct file *filep,
   size_t i;
   char ch;
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode = filep->f_inode;
   dev   = inode->i_private;
   DEBUGASSERT(dev != NULL);
@@ -665,7 +661,6 @@ static int pty_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   FAR struct pty_devpair_s *devpair;
   int ret;
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode   = filep->f_inode;
   dev     = inode->i_private;
   DEBUGASSERT(dev != NULL && dev->pd_devpair != NULL);
@@ -854,7 +849,6 @@ static int pty_poll(FAR struct file *filep, FAR struct pollfd *fds,
   int ret;
   int i;
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode   = filep->f_inode;
   dev     = inode->i_private;
   devpair = dev->pd_devpair;
@@ -943,7 +937,7 @@ static int pty_unlink(FAR struct inode *inode)
   FAR struct pty_devpair_s *devpair;
   int ret;
 
-  DEBUGASSERT(inode != NULL && inode->i_private != NULL);
+  DEBUGASSERT(inode->i_private != NULL);
   dev     = inode->i_private;
   devpair = dev->pd_devpair;
   DEBUGASSERT(dev->pd_devpair != NULL);

--- a/drivers/spi/spi_driver.c
+++ b/drivers/spi/spi_driver.c
@@ -124,7 +124,6 @@ static int spidrvr_open(FAR struct file *filep)
 
   /* Get our private data structure */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode = filep->f_inode;
 
   priv = (FAR struct spi_driver_s *)inode->i_private;
@@ -161,7 +160,6 @@ static int spidrvr_close(FAR struct file *filep)
 
   /* Get our private data structure */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode = filep->f_inode;
 
   priv = (FAR struct spi_driver_s *)inode->i_private;
@@ -231,7 +229,6 @@ static int spidrvr_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
   /* Get our private data structure */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode = filep->f_inode;
 
   priv = (FAR struct spi_driver_s *)inode->i_private;
@@ -293,7 +290,7 @@ static int spidrvr_unlink(FAR struct inode *inode)
 
   /* Get our private data structure */
 
-  DEBUGASSERT(inode != NULL && inode->i_private != NULL);
+  DEBUGASSERT(inode->i_private != NULL);
   priv = (FAR struct spi_driver_s *)inode->i_private;
 
   /* Get exclusive access to the SPI driver state structure */

--- a/drivers/spi/spi_slave_driver.c
+++ b/drivers/spi/spi_slave_driver.c
@@ -175,8 +175,6 @@ static int spi_slave_open(FAR struct file *filep)
   FAR struct spi_slave_driver_s *priv;
   int ret;
 
-  DEBUGASSERT(filep != NULL);
-  DEBUGASSERT(filep->f_inode != NULL);
   DEBUGASSERT(filep->f_inode->i_private != NULL);
 
   spiinfo("filep: %p\n", filep);
@@ -225,8 +223,6 @@ static int spi_slave_close(FAR struct file *filep)
   FAR struct spi_slave_driver_s *priv;
   int ret;
 
-  DEBUGASSERT(filep != NULL);
-  DEBUGASSERT(filep->f_inode != NULL);
   DEBUGASSERT(filep->f_inode->i_private != NULL);
 
   spiinfo("filep: %p\n", filep);
@@ -514,7 +510,6 @@ static int spi_slave_unlink(FAR struct inode *inode)
   FAR struct spi_slave_driver_s *priv;
   int ret;
 
-  DEBUGASSERT(inode != NULL);
   DEBUGASSERT(inode->i_private != NULL);
 
   /* Get our private data structure */

--- a/drivers/syslog/ramlog.c
+++ b/drivers/syslog/ramlog.c
@@ -460,7 +460,7 @@ static ssize_t ramlog_file_read(FAR struct file *filep, FAR char *buffer,
 
   /* Some sanity checking */
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (FAR struct ramlog_dev_s *)inode->i_private;
 
   /* If the circular buffer is empty, then wait for something to be written
@@ -622,7 +622,7 @@ static ssize_t ramlog_file_write(FAR struct file *filep,
 
   /* Some sanity checking */
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (FAR struct ramlog_dev_s *)inode->i_private;
 
   return ramlog_addbuf(priv, buffer, len);
@@ -639,7 +639,7 @@ static int ramlog_file_ioctl(FAR struct file *filep, int cmd,
   FAR struct ramlog_dev_s *priv;
   int ret;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (FAR struct ramlog_dev_s *)inode->i_private;
 
   ret = nxmutex_lock(&priv->rl_lock);
@@ -679,7 +679,7 @@ static int ramlog_file_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
   /* Some sanity checking */
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (FAR struct ramlog_dev_s *)inode->i_private;
 
   /* Get exclusive access to the poll structures */

--- a/drivers/syslog/syslog_rpmsg.c
+++ b/drivers/syslog/syslog_rpmsg.c
@@ -304,7 +304,7 @@ static ssize_t syslog_rpmsg_file_read(FAR struct file *filep,
 
   /* Some sanity checking */
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (FAR struct syslog_rpmsg_s *)inode->i_private;
 
   flags = enter_critical_section();

--- a/drivers/timers/oneshot.c
+++ b/drivers/timers/oneshot.c
@@ -120,7 +120,6 @@ static ssize_t oneshot_read(FAR struct file *filep, FAR char *buffer,
   /* Return zero -- usually meaning end-of-file */
 
   tmrinfo("buflen=%ld\n", (unsigned long)buflen);
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   return 0;
 }
 
@@ -138,7 +137,6 @@ static ssize_t oneshot_write(FAR struct file *filep, FAR const char *buffer,
   /* Return a failure */
 
   tmrinfo("buflen=%ld\n", (unsigned long)buflen);
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   return -EPERM;
 }
 
@@ -158,7 +156,6 @@ static int oneshot_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
   tmrinfo("cmd=%d arg=%08lx\n", cmd, (unsigned long)arg);
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode = filep->f_inode;
   priv  = (FAR struct oneshot_dev_s *)inode->i_private;
   DEBUGASSERT(priv != NULL);

--- a/drivers/timers/rtc.c
+++ b/drivers/timers/rtc.c
@@ -240,9 +240,8 @@ static int rtc_open(FAR struct file *filep)
    * structure.
    */
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   upper = inode->i_private;
 
   /* Get exclusive access to the device structures */
@@ -277,9 +276,8 @@ static int rtc_close(FAR struct file *filep)
    * structure.
    */
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   upper = inode->i_private;
 
   /* Get exclusive access to the device structures */
@@ -343,9 +341,8 @@ static int rtc_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
    * structure.
    */
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   upper = inode->i_private;
   DEBUGASSERT(upper->lower && upper->lower->ops);
 
@@ -766,7 +763,7 @@ static int rtc_unlink(FAR struct inode *inode)
    * structure.
    */
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   upper = inode->i_private;
 
   /* Get exclusive access to the device structures */

--- a/drivers/usbhost/usbhost_cdcacm.c
+++ b/drivers/usbhost/usbhost_cdcacm.c
@@ -2360,10 +2360,9 @@ static int usbhost_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   int ret = 0;
 
   uinfo("Entry\n");
-  DEBUGASSERT(filep && filep->f_inode);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   uartdev = (FAR struct uart_dev_s *)inode->i_private;
 
   DEBUGASSERT(uartdev && uartdev->priv);

--- a/drivers/usbhost/usbhost_cdcmbim.c
+++ b/drivers/usbhost/usbhost_cdcmbim.c
@@ -537,7 +537,7 @@ static int cdcwdm_poll(FAR struct file *filep, FAR struct pollfd *fds,
   int                           ret = OK;
   int                           i;
 
-  DEBUGASSERT(filep && filep->f_inode && fds);
+  DEBUGASSERT(fds);
   inode = filep->f_inode;
   priv  = inode->i_private;
 

--- a/drivers/usbhost/usbhost_ft232r.c
+++ b/drivers/usbhost/usbhost_ft232r.c
@@ -2306,10 +2306,9 @@ static int usbhost_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   int ret = 0;
 
   uinfo("Entry\n");
-  DEBUGASSERT(filep && filep->f_inode);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   uartdev = (FAR struct uart_dev_s *)inode->i_private;
 
   DEBUGASSERT(uartdev && uartdev->priv);

--- a/drivers/usbhost/usbhost_hidkbd.c
+++ b/drivers/usbhost/usbhost_hidkbd.c
@@ -2496,7 +2496,6 @@ static int usbhost_open(FAR struct file *filep)
   int ret;
 
   uinfo("Entry\n");
-  DEBUGASSERT(filep && filep->f_inode);
   inode = filep->f_inode;
   priv  = inode->i_private;
 
@@ -2555,7 +2554,6 @@ static int usbhost_close(FAR struct file *filep)
   int ret;
 
   uinfo("Entry\n");
-  DEBUGASSERT(filep && filep->f_inode);
   inode = filep->f_inode;
   priv  = inode->i_private;
 
@@ -2654,7 +2652,7 @@ static ssize_t usbhost_read(FAR struct file *filep, FAR char *buffer,
   int                         ret;
 
   uinfo("Entry\n");
-  DEBUGASSERT(filep && filep->f_inode && buffer);
+  DEBUGASSERT(buffer);
   inode = filep->f_inode;
   priv  = inode->i_private;
 
@@ -2786,7 +2784,7 @@ static int usbhost_poll(FAR struct file *filep, FAR struct pollfd *fds,
   int                         i;
 
   uinfo("Entry\n");
-  DEBUGASSERT(filep && filep->f_inode && fds);
+  DEBUGASSERT(fds);
   inode = filep->f_inode;
   priv  = inode->i_private;
 

--- a/drivers/usbhost/usbhost_hidmouse.c
+++ b/drivers/usbhost/usbhost_hidmouse.c
@@ -1989,7 +1989,6 @@ static int usbhost_open(FAR struct file *filep)
   int ret;
 
   uinfo("Entry\n");
-  DEBUGASSERT(filep && filep->f_inode);
   inode = filep->f_inode;
   priv  = inode->i_private;
 
@@ -2069,7 +2068,6 @@ static int usbhost_close(FAR struct file *filep)
   int ret;
 
   uinfo("Entry\n");
-  DEBUGASSERT(filep && filep->f_inode);
   inode = filep->f_inode;
   priv  = inode->i_private;
 
@@ -2170,7 +2168,7 @@ static ssize_t usbhost_read(FAR struct file *filep, FAR char *buffer,
   int                         ret;
 
   uinfo("Entry\n");
-  DEBUGASSERT(filep && filep->f_inode && buffer);
+  DEBUGASSERT(buffer);
   inode = filep->f_inode;
   priv  = inode->i_private;
 
@@ -2332,7 +2330,7 @@ static int usbhost_poll(FAR struct file *filep, FAR struct pollfd *fds,
   int                         i;
 
   uinfo("Entry\n");
-  DEBUGASSERT(filep && filep->f_inode && fds);
+  DEBUGASSERT(fds);
   inode = filep->f_inode;
   priv  = inode->i_private;
 

--- a/drivers/usbhost/usbhost_storage.c
+++ b/drivers/usbhost/usbhost_storage.c
@@ -1875,7 +1875,7 @@ static int usbhost_open(FAR struct inode *inode)
   int ret;
 
   uinfo("Entry\n");
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (FAR struct usbhost_state_s *)inode->i_private;
 
   /* Make sure that we have exclusive access to the private data structure */
@@ -1929,7 +1929,7 @@ static int usbhost_close(FAR struct inode *inode)
   irqstate_t flags;
 
   uinfo("Entry\n");
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (FAR struct usbhost_state_s *)inode->i_private;
 
   /* Decrement the reference count on the block driver */
@@ -1987,7 +1987,7 @@ static ssize_t usbhost_read(FAR struct inode *inode, unsigned char *buffer,
   ssize_t nbytes = 0;
   int ret;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (FAR struct usbhost_state_s *)inode->i_private;
 
   DEBUGASSERT(priv->usbclass.hport);
@@ -2102,7 +2102,7 @@ static ssize_t usbhost_write(FAR struct inode *inode,
 
   uinfo("sector: %" PRIuOFF " nsectors: %u\n", startsector, nsectors);
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (FAR struct usbhost_state_s *)inode->i_private;
 
   DEBUGASSERT(priv->usbclass.hport);
@@ -2199,7 +2199,7 @@ static int usbhost_geometry(FAR struct inode *inode,
   int ret = -EINVAL;
 
   uinfo("Entry\n");
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
 
   /* Check if the mass storage device is still connected */
 
@@ -2250,7 +2250,7 @@ static int usbhost_ioctl(FAR struct inode *inode, int cmd, unsigned long arg)
   int ret;
 
   uinfo("Entry\n");
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (FAR struct usbhost_state_s *)inode->i_private;
 
   /* Check if the mass storage device is still connected */

--- a/drivers/usbhost/usbhost_xboxcontroller.c
+++ b/drivers/usbhost/usbhost_xboxcontroller.c
@@ -1729,7 +1729,6 @@ static int usbhost_open(FAR struct file *filep)
   int ret;
 
   uinfo("Entry\n");
-  DEBUGASSERT(filep && filep->f_inode);
   inode = filep->f_inode;
   priv  = inode->i_private;
 
@@ -1810,7 +1809,6 @@ static int usbhost_close(FAR struct file *filep)
   int ret;
 
   uinfo("Entry\n");
-  DEBUGASSERT(filep && filep->f_inode);
   inode = filep->f_inode;
   priv  = inode->i_private;
 
@@ -1905,7 +1903,7 @@ static ssize_t usbhost_read(FAR struct file *filep, FAR char *buffer,
   struct xbox_controller_buttonstate_s sample;
   int                                  ret;
 
-  DEBUGASSERT(filep && filep->f_inode && buffer);
+  DEBUGASSERT(buffer);
   inode = filep->f_inode;
   priv  = inode->i_private;
 
@@ -2015,7 +2013,7 @@ static int usbhost_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   };
 
   uinfo("Entered\n");
-  DEBUGASSERT(filep && filep->f_inode && buffer);
+  DEBUGASSERT(buffer);
   inode = filep->f_inode;
   priv  = inode->i_private;
   hport = priv->usbclass.hport;
@@ -2092,7 +2090,7 @@ static int usbhost_poll(FAR struct file *filep, FAR struct pollfd *fds,
   int                         ret;
   int                         i;
 
-  DEBUGASSERT(filep && filep->f_inode && fds);
+  DEBUGASSERT(fds);
   inode = filep->f_inode;
   priv  = inode->i_private;
 

--- a/drivers/usbmisc/fusb301.c
+++ b/drivers/usbmisc/fusb301.c
@@ -655,10 +655,10 @@ static int fusb301_poll(FAR struct file *filep,
   int ret = OK;
   int i;
 
-  DEBUGASSERT(filep && fds);
+  DEBUGASSERT(fds);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (FAR struct fusb301_dev_s *)inode->i_private;
 
   ret = nxmutex_lock(&priv->devlock);

--- a/drivers/usbmisc/fusb302.c
+++ b/drivers/usbmisc/fusb302.c
@@ -1758,10 +1758,10 @@ static int fusb302_poll(FAR struct file *filep,
   int ret = OK;
   int i;
 
-  DEBUGASSERT(filep && fds);
+  DEBUGASSERT(fds);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (FAR struct fusb302_dev_s *)inode->i_private;
 
   ret = nxmutex_lock(&priv->devlock);

--- a/drivers/usbmisc/fusb303.c
+++ b/drivers/usbmisc/fusb303.c
@@ -843,10 +843,10 @@ static int fusb303_poll(FAR struct file *filep, FAR struct pollfd *fds,
   int ret = OK;
   int i;
 
-  DEBUGASSERT(filep && fds);
+  DEBUGASSERT(fds);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (FAR struct fusb303_dev_s *)inode->i_private;
 
   ret = nxmutex_lock(&priv->devlock);

--- a/drivers/usrsock/usrsock_dev.c
+++ b/drivers/usrsock/usrsock_dev.c
@@ -154,8 +154,6 @@ static ssize_t usrsockdev_read(FAR struct file *filep, FAR char *buffer,
       return -EINVAL;
     }
 
-  DEBUGASSERT(inode);
-
   dev = inode->i_private;
 
   DEBUGASSERT(dev);
@@ -213,8 +211,6 @@ static off_t usrsockdev_seek(FAR struct file *filep, off_t offset,
     {
       return -EINVAL;
     }
-
-  DEBUGASSERT(inode);
 
   dev = inode->i_private;
 
@@ -287,8 +283,6 @@ static ssize_t usrsockdev_write(FAR struct file *filep,
       return -EINVAL;
     }
 
-  DEBUGASSERT(inode);
-
   dev = inode->i_private;
 
   DEBUGASSERT(dev);
@@ -321,8 +315,6 @@ static int usrsockdev_open(FAR struct file *filep)
   FAR struct usrsockdev_s *dev;
   int ret;
   int tmp;
-
-  DEBUGASSERT(inode);
 
   dev = inode->i_private;
 
@@ -367,8 +359,6 @@ static int usrsockdev_close(FAR struct file *filep)
   FAR struct usrsockdev_s *dev;
   int ret;
 
-  DEBUGASSERT(inode);
-
   dev = inode->i_private;
 
   DEBUGASSERT(dev);
@@ -408,8 +398,6 @@ static int usrsockdev_poll(FAR struct file *filep, FAR struct pollfd *fds,
   pollevent_t eventset;
   int ret;
   int i;
-
-  DEBUGASSERT(inode);
 
   dev = inode->i_private;
 

--- a/drivers/video/fb.c
+++ b/drivers/video/fb.c
@@ -130,7 +130,6 @@ static int fb_open(FAR struct file *filep)
   FAR struct fb_chardev_s *fb;
   int ret;
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode = filep->f_inode;
   fb    = inode->i_private;
 
@@ -170,7 +169,6 @@ static int fb_close(FAR struct file *filep)
   FAR struct fb_chardev_s *fb;
   int ret;
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode = filep->f_inode;
   fb    = inode->i_private;
 
@@ -218,7 +216,6 @@ static ssize_t fb_read(FAR struct file *filep, FAR char *buffer, size_t len)
 
   /* Get the framebuffer instance */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode = filep->f_inode;
   fb    = (FAR struct fb_chardev_s *)inode->i_private;
 
@@ -273,7 +270,6 @@ static ssize_t fb_write(FAR struct file *filep, FAR const char *buffer,
 
   /* Get the framebuffer instance */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode = filep->f_inode;
   fb    = (FAR struct fb_chardev_s *)inode->i_private;
 
@@ -333,7 +329,6 @@ static off_t fb_seek(FAR struct file *filep, off_t offset, int whence)
 
   /* Get the framebuffer instance */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode = filep->f_inode;
   fb    = (FAR struct fb_chardev_s *)inode->i_private;
 
@@ -413,7 +408,6 @@ static int fb_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
   /* Get the framebuffer instance */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode = filep->f_inode;
   fb    = (FAR struct fb_chardev_s *)inode->i_private;
 
@@ -862,7 +856,6 @@ static int fb_mmap(FAR struct file *filep, FAR struct mm_map_entry_s *map)
 
   /* Get the framebuffer instance */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode = filep->f_inode;
   fb    = (FAR struct fb_chardev_s *)inode->i_private;
 
@@ -902,7 +895,6 @@ static int fb_poll(FAR struct file *filep, struct pollfd *fds, bool setup)
 
   /* Get the framebuffer instance */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode = filep->f_inode;
   fb    = (FAR struct fb_chardev_s *)inode->i_private;
 

--- a/drivers/video/mipidsi/mipi_dsi_device_driver.c
+++ b/drivers/video/mipidsi/mipi_dsi_device_driver.c
@@ -111,7 +111,6 @@ static int dsi_dev_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
   /* Get our private data structure */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode = filep->f_inode;
 
   priv = (FAR struct mipi_dsi_device_driver_s *)inode->i_private;

--- a/drivers/video/mipidsi/mipi_dsi_host_driver.c
+++ b/drivers/video/mipidsi/mipi_dsi_host_driver.c
@@ -115,7 +115,6 @@ static int dsi_host_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
   /* Get our private data structure */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode = filep->f_inode;
 
   priv = inode->i_private;

--- a/drivers/virtio/virtio-blk.c
+++ b/drivers/virtio/virtio-blk.c
@@ -254,7 +254,7 @@ err:
 
 static int virtio_blk_open(FAR struct inode *inode)
 {
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   return OK;
 }
 
@@ -267,7 +267,7 @@ static int virtio_blk_open(FAR struct inode *inode)
 
 static int virtio_blk_close(FAR struct inode *inode)
 {
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   return OK;
 }
 
@@ -286,7 +286,7 @@ static ssize_t virtio_blk_read(FAR struct inode *inode,
 {
   FAR struct virtio_blk_priv_s *priv;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (FAR struct virtio_blk_priv_s *)inode->i_private;
   return virtio_blk_rdwr(priv, buffer, startsector, nsectors, false);
 }
@@ -306,7 +306,7 @@ static ssize_t virtio_blk_write(FAR struct inode *inode,
 {
   FAR struct virtio_blk_priv_s *priv;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (FAR struct virtio_blk_priv_s *)inode->i_private;
   return virtio_blk_rdwr(priv, (FAR void *)buffer, startsector, nsectors,
                          true);
@@ -325,7 +325,7 @@ static int virtio_blk_geometry(FAR struct inode *inode,
   FAR struct virtio_blk_priv_s *priv;
   int ret = -EINVAL;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (FAR struct virtio_blk_priv_s *)inode->i_private;
 
   if (geometry)
@@ -404,7 +404,7 @@ static int virtio_blk_ioctl(FAR struct inode *inode, int cmd,
   FAR struct virtio_blk_priv_s *priv;
   int ret = -ENOTTY;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = (FAR struct virtio_blk_priv_s *)inode->i_private;
 
   switch (cmd)

--- a/drivers/wireless/cc1101.c
+++ b/drivers/wireless/cc1101.c
@@ -330,10 +330,9 @@ static int cc1101_file_open(FAR struct file *filep)
 
   wlinfo("Opening CC1101 dev\n");
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (FAR struct cc1101_dev_s *)inode->i_private;
 
   /* Get exclusive access to the driver data structure */
@@ -378,10 +377,9 @@ static int cc1101_file_close(FAR struct file *filep)
 
   wlinfo("Closing CC1101 dev\n");
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (FAR struct cc1101_dev_s *)inode->i_private;
 
   /* Get exclusive access to the driver data structure */
@@ -420,10 +418,9 @@ static ssize_t cc1101_file_write(FAR struct file *filep,
 
   wlinfo("write CC1101 dev\n");
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (FAR struct cc1101_dev_s *)inode->i_private;
 
   /* Get exclusive access to the driver data structure */
@@ -532,10 +529,9 @@ static ssize_t cc1101_file_read(FAR struct file *filep, FAR char *buffer,
   FAR struct inode *inode;
   int ret;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (FAR struct cc1101_dev_s *)inode->i_private;
 
   ret = nxmutex_lock(&dev->devlock);
@@ -581,10 +577,10 @@ static int cc1101_file_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
   wlinfo("setup: %d\n", (int)setup);
 
-  DEBUGASSERT(filep && fds);
+  DEBUGASSERT(fds);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (FAR struct cc1101_dev_s *)inode->i_private;
 
   /* Exclusive access */

--- a/drivers/wireless/gs2200m.c
+++ b/drivers/wireless/gs2200m.c
@@ -699,10 +699,9 @@ static ssize_t gs2200m_read(FAR struct file *filep, FAR char *buffer,
   FAR struct gs2200m_dev_s *dev;
   int ret;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (FAR struct gs2200m_dev_s *)inode->i_private;
 
   ASSERT(1 == len);
@@ -2967,10 +2966,9 @@ static int gs2200m_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   FAR struct gs2200m_dev_s *dev;
   int ret = -EINVAL;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (FAR struct gs2200m_dev_s *)inode->i_private;
 
   /* Lock the device */
@@ -3105,10 +3103,10 @@ static int gs2200m_poll(FAR struct file *filep, FAR struct pollfd *fds,
   int ret = OK;
 
   wlinfo("== setup:%d\n", (int)setup);
-  DEBUGASSERT(filep && fds);
+  DEBUGASSERT(fds);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (FAR struct gs2200m_dev_s *)inode->i_private;
 
   ret = nxmutex_lock(&dev->dev_lock);

--- a/drivers/wireless/lpwan/sx127x/sx127x.c
+++ b/drivers/wireless/lpwan/sx127x/sx127x.c
@@ -738,10 +738,9 @@ static int sx127x_open(FAR struct file *filep)
 
   wlinfo("Opening sx127x dev\n");
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (FAR struct sx127x_dev_s *)inode->i_private;
 
   /* Get exclusive access to the driver data structure */
@@ -792,10 +791,9 @@ static int sx127x_close(FAR struct file *filep)
   int ret = 0;
 
   wlinfo("Closing sx127x dev\n");
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (FAR struct sx127x_dev_s *)inode->i_private;
 
   /* Get exclusive access to the driver data structure */
@@ -836,10 +834,9 @@ static ssize_t sx127x_read(FAR struct file *filep, FAR char *buffer,
   FAR struct inode        *inode = NULL;
   int ret = 0;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (FAR struct sx127x_dev_s *)inode->i_private;
 
   ret = nxmutex_lock(&dev->dev_lock);
@@ -890,10 +887,9 @@ static ssize_t sx127x_write(FAR struct file *filep, FAR const char *buffer,
   FAR struct inode        *inode = NULL;
   int ret = 0;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (FAR struct sx127x_dev_s *)inode->i_private;
 
   ret = nxmutex_lock(&dev->dev_lock);
@@ -962,10 +958,9 @@ static int sx127x_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   int ret                      = 0;
 
   wlinfo("cmd: %d arg: %ld\n", cmd, arg);
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (FAR struct sx127x_dev_s *)inode->i_private;
 
   /* Get exclusive access to the driver data structure */
@@ -1177,10 +1172,10 @@ static int sx127x_poll(FAR struct file *filep, FAR struct pollfd *fds,
   int ret = 0;
 
   wlinfo("setup: %d\n", (int)setup);
-  DEBUGASSERT(filep && fds);
+  DEBUGASSERT(fds);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (FAR struct sx127x_dev_s *)inode->i_private;
 
   /* Exclusive access */

--- a/drivers/wireless/nrf24l01.c
+++ b/drivers/wireless/nrf24l01.c
@@ -942,10 +942,9 @@ static int nrf24l01_open(FAR struct file *filep)
 
   wlinfo("Opening nRF24L01 dev\n");
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (FAR struct nrf24l01_dev_s *)inode->i_private;
 
   /* Get exclusive access to the driver data structure */
@@ -986,10 +985,9 @@ static int nrf24l01_close(FAR struct file *filep)
   int ret;
 
   wlinfo("Closing nRF24L01 dev\n");
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev  = (FAR struct nrf24l01_dev_s *)inode->i_private;
 
   /* Get exclusive access to the driver data structure */
@@ -1021,10 +1019,9 @@ static ssize_t nrf24l01_read(FAR struct file *filep, FAR char *buffer,
   FAR struct inode *inode;
   int ret;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (FAR struct nrf24l01_dev_s *)inode->i_private;
 
   ret = nxmutex_lock(&dev->devlock);
@@ -1072,10 +1069,9 @@ static ssize_t nrf24l01_write(FAR struct file *filep, FAR const char *buffer,
   FAR struct inode *inode;
   int ret;
 
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev = (FAR struct nrf24l01_dev_s *)inode->i_private;
 
   ret = nxmutex_lock(&dev->devlock);
@@ -1101,10 +1097,9 @@ static int nrf24l01_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   int ret;
 
   wlinfo("cmd: %d arg: %ld\n", cmd, arg);
-  DEBUGASSERT(filep);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev  = (FAR struct nrf24l01_dev_s *)inode->i_private;
 
   /* Get exclusive access to the driver data structure */
@@ -1362,10 +1357,10 @@ static int nrf24l01_poll(FAR struct file *filep, FAR struct pollfd *fds,
   int ret;
 
   wlinfo("setup: %d\n", (int)setup);
-  DEBUGASSERT(filep && fds);
+  DEBUGASSERT(fds);
   inode = filep->f_inode;
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   dev  = (FAR struct nrf24l01_dev_s *)inode->i_private;
 
   /* Exclusive access */

--- a/fs/aio/aioc_contain.c
+++ b/fs/aio/aioc_contain.c
@@ -74,8 +74,6 @@ FAR struct aio_container_s *aio_contain(FAR struct aiocb *aiocbp)
       goto errout;
     }
 
-  DEBUGASSERT(filep != NULL);
-
   /* Allocate the AIO control block container, waiting for one to become
    * available if necessary.  This should not fail except for in the case
    * where the calling thread is canceled.

--- a/fs/binfs/fs_binfs.c
+++ b/fs/binfs/fs_binfs.c
@@ -271,7 +271,7 @@ static int binfs_dup(FAR const struct file *oldp, FAR struct file *newp)
 
 static int binfs_fstat(FAR const struct file *filep, FAR struct stat *buf)
 {
-  DEBUGASSERT(filep != NULL && buf != NULL);
+  DEBUGASSERT(buf != NULL);
 
   /* It's a execute-only file system */
 

--- a/fs/cromfs/fs_cromfs.c
+++ b/fs/cromfs/fs_cromfs.c
@@ -736,7 +736,7 @@ static int cromfs_open(FAR struct file *filep, FAR const char *relpath,
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv == NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv == NULL);
 
   /* Get the mountpoint inode reference from the file structure and the
    * volume private data from the inode structure
@@ -815,7 +815,7 @@ static int cromfs_close(FAR struct file *filep)
   FAR struct cromfs_file_s *ff;
 
   finfo("Closing\n");
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Get the open file instance from the file structure */
 
@@ -853,7 +853,7 @@ static ssize_t cromfs_read(FAR struct file *filep, FAR char *buffer,
   unsigned int copyoffs;
 
   finfo("Read %zu bytes from offset %jd\n", buflen, (intmax_t)filep->f_pos);
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Get the mountpoint inode reference from the file structure and the
    * volume private data from the inode structure
@@ -1153,7 +1153,7 @@ static int cromfs_fstat(FAR const struct file *filep, FAR struct stat *buf)
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Get the mountpoint inode reference from the file structure and the
    * volume private data from the inode structure

--- a/fs/driver/fs_findblockdriver.c
+++ b/fs/driver/fs_findblockdriver.c
@@ -88,7 +88,6 @@ int find_blockdriver(FAR const char *pathname, int mountflags,
   /* Get the search results */
 
   inode = desc.node;
-  DEBUGASSERT(inode != NULL);
 
   /* Verify that the inode is a block driver. */
 

--- a/fs/driver/fs_findmtddriver.c
+++ b/fs/driver/fs_findmtddriver.c
@@ -81,7 +81,6 @@ int find_mtddriver(FAR const char *pathname, FAR struct inode **ppinode)
   /* Get the search results */
 
   inode = desc.node;
-  DEBUGASSERT(inode != NULL);
 
   /* Verify that the inode is a block driver. */
 

--- a/fs/fat/fs_fat32.c
+++ b/fs/fat/fs_fat32.c
@@ -169,7 +169,7 @@ static int fat_open(FAR struct file *filep, FAR const char *relpath,
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv == NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv == NULL);
 
   /* Get the mountpoint inode reference from the file structure and the
    * mountpoint private data from the inode structure
@@ -408,7 +408,7 @@ static int fat_close(FAR struct file *filep)
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover our private data from the struct file instance */
 
@@ -494,7 +494,7 @@ static ssize_t fat_read(FAR struct file *filep, FAR char *buffer,
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover our private data from the struct file instance */
 
@@ -732,7 +732,7 @@ static ssize_t fat_write(FAR struct file *filep, FAR const char *buffer,
   bool force_indirect = false;
 #endif
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover our private data from the struct file instance */
 
@@ -1027,7 +1027,7 @@ static off_t fat_seek(FAR struct file *filep, off_t offset, int whence)
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover our private data from the struct file instance */
 
@@ -1280,7 +1280,7 @@ static int fat_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Check for the forced mount condition */
 
@@ -1337,7 +1337,7 @@ static int fat_sync(FAR struct file *filep)
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Check for the forced mount condition */
 
@@ -1712,7 +1712,7 @@ static int fat_fstat(FAR const struct file *filep, FAR struct stat *buf)
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Get the mountpoint inode reference from the file structure and the
    * mountpoint private data from the inode structure
@@ -1786,7 +1786,7 @@ static int fat_truncate(FAR struct file *filep, off_t length)
   off_t oldsize;
   int ret;
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover our private data from the struct file instance */
 

--- a/fs/fat/fs_fat32attrib.c
+++ b/fs/fat/fs_fat32attrib.c
@@ -70,7 +70,6 @@ static int fat_attrib(const char *path, fat_attrib_t *retattrib,
   /* Get the search results */
 
   inode = desc.node;
-  DEBUGASSERT(inode != NULL);
 
   /* Verify that the inode is a valid mountpoint. */
 

--- a/fs/hostfs/hostfs.c
+++ b/fs/hostfs/hostfs.c
@@ -353,7 +353,7 @@ static int hostfs_close(FAR struct file *filep)
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover our private data from the struct file instance */
 
@@ -441,7 +441,7 @@ static ssize_t hostfs_read(FAR struct file *filep, FAR char *buffer,
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover our private data from the struct file instance */
 
@@ -483,7 +483,7 @@ static ssize_t hostfs_write(FAR struct file *filep, const char *buffer,
   FAR struct hostfs_ofile_s *hf;
   ssize_t ret;
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover our private data from the struct file instance */
 
@@ -537,7 +537,7 @@ static off_t hostfs_seek(FAR struct file *filep, off_t offset, int whence)
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover our private data from the struct file instance */
 
@@ -580,7 +580,7 @@ static int hostfs_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover our private data from the struct file instance */
 
@@ -623,7 +623,7 @@ static int hostfs_sync(FAR struct file *filep)
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover our private data from the struct file instance */
 
@@ -696,11 +696,11 @@ static int hostfs_fstat(FAR const struct file *filep, FAR struct stat *buf)
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep != NULL && buf != NULL);
+  DEBUGASSERT(buf != NULL);
 
   /* Recover our private data from the struct file instance */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
   hf    = filep->f_priv;
   inode = filep->f_inode;
 
@@ -742,11 +742,11 @@ static int hostfs_fchstat(FAR const struct file *filep,
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep != NULL && buf != NULL);
+  DEBUGASSERT(buf != NULL);
 
   /* Recover our private data from the struct file instance */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
   hf    = filep->f_priv;
   inode = filep->f_inode;
 
@@ -785,13 +785,9 @@ static int hostfs_ftruncate(FAR struct file *filep, off_t length)
   FAR struct hostfs_ofile_s *hf;
   int ret = OK;
 
-  /* Sanity checks */
-
-  DEBUGASSERT(filep != NULL);
-
   /* Recover our private data from the struct file instance */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
   hf    = filep->f_priv;
   inode = filep->f_inode;
 

--- a/fs/inode/fs_files.c
+++ b/fs/inode/fs_files.c
@@ -369,7 +369,6 @@ int files_duplist(FAR struct filelist *plist, FAR struct filelist *clist)
 #endif
 
           filep = &plist->fl_files[i][j];
-          DEBUGASSERT(filep);
 
           if (filep && (filep->f_inode == NULL ||
                        (filep->f_oflags & O_CLOEXEC) != 0))
@@ -424,7 +423,6 @@ int fs_getfilep(int fd, FAR struct file **filep)
   fd = fdcheck_restore(fd);
 #endif
 
-  DEBUGASSERT(filep != NULL);
   *filep = NULL;
 
   list = nxsched_get_files();

--- a/fs/mount/fs_automount.c
+++ b/fs/mount/fs_automount.c
@@ -250,7 +250,7 @@ static int automount_close(FAR struct file *filep)
   FAR struct automounter_open_s *prev;
   int ret;
 
-  DEBUGASSERT(filep && filep->f_priv && filep->f_inode);
+  DEBUGASSERT(filep->f_priv);
   opriv = filep->f_priv;
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private);
@@ -317,7 +317,7 @@ static int automount_ioctl(FAR struct file *filep, int cmd,
   FAR struct automounter_open_s *opriv;
   int ret;
 
-  DEBUGASSERT(filep && filep->f_priv && filep->f_inode);
+  DEBUGASSERT(filep->f_priv);
   opriv = filep->f_priv;
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private);

--- a/fs/mqueue/mq_open.c
+++ b/fs/mqueue/mq_open.c
@@ -239,7 +239,6 @@ static int file_mq_vopen(FAR struct file *mq, FAR const char *mq_name,
       /* Something exists at this path.  Get the search results */
 
       inode = desc.node;
-      DEBUGASSERT(inode != NULL);
 
       /* Verify that the inode is a message queue */
 

--- a/fs/mqueue/mq_unlink.c
+++ b/fs/mqueue/mq_unlink.c
@@ -123,7 +123,6 @@ int file_mq_unlink(FAR const char *mq_name)
   /* Get the search results */
 
   inode = desc.node;
-  DEBUGASSERT(inode != NULL);
 
   /* Verify that what we found is, indeed, a message queue */
 

--- a/fs/nfs/nfs_vfsops.c
+++ b/fs/nfs/nfs_vfsops.c
@@ -655,10 +655,6 @@ static int nfs_open(FAR struct file *filep, FAR const char *relpath,
   FAR struct nfsnode *np;
   int ret;
 
-  /* Sanity checks */
-
-  DEBUGASSERT(filep->f_inode != NULL);
-
   /* Get the mountpoint inode reference from the file structure and the
    * mountpoint private data from the inode structure
    */
@@ -777,7 +773,7 @@ static int nfs_close(FAR struct file *filep)
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover our private data from the struct file instance */
 
@@ -880,7 +876,7 @@ static ssize_t nfs_read(FAR struct file *filep, FAR char *buffer,
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover our private data from the struct file instance */
 
@@ -1055,7 +1051,7 @@ static ssize_t nfs_write(FAR struct file *filep, FAR const char *buffer,
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover our private data from the struct file instance */
 
@@ -1232,7 +1228,7 @@ static off_t nfs_seek(FAR struct file *filep, off_t offset, int whence)
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover our private data from the struct file instance */
 
@@ -1355,11 +1351,11 @@ static int nfs_fstat(FAR const struct file *filep, FAR struct stat *buf)
   int ret;
 
   finfo("Buf %p\n", buf);
-  DEBUGASSERT(filep != NULL && buf != NULL);
+  DEBUGASSERT(buf != NULL);
 
   /* Recover our private data from the struct file instance */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
   np  = (FAR struct nfsnode *)filep->f_priv;
 
   nmp = (FAR struct nfsmount *)filep->f_inode->i_private;
@@ -1407,11 +1403,11 @@ static int nfs_fchstat(FAR const struct file *filep,
   int ret;
 
   finfo("Buf %p\n", buf);
-  DEBUGASSERT(filep != NULL && buf != NULL);
+  DEBUGASSERT(buf != NULL);
 
   /* Recover our private data from the struct file instance */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
   np  = (FAR struct nfsnode *)filep->f_priv;
 
   nmp = (FAR struct nfsmount *)filep->f_inode->i_private;
@@ -1447,7 +1443,7 @@ static int nfs_truncate(FAR struct file *filep, off_t length)
   int ret;
 
   finfo("Truncate to %ld bytes\n", (long)length);
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover our private data from the struct file instance */
 

--- a/fs/nxffs/nxffs_ioctl.c
+++ b/fs/nxffs/nxffs_ioctl.c
@@ -56,7 +56,7 @@ int nxffs_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover the file system state from the open file */
 

--- a/fs/nxffs/nxffs_open.c
+++ b/fs/nxffs/nxffs_open.c
@@ -994,7 +994,7 @@ int nxffs_open(FAR struct file *filep, FAR const char *relpath,
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv == NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv == NULL);
 
   /* Get the mountpoint private data from the NuttX inode reference in the
    * file structure
@@ -1116,7 +1116,7 @@ int nxffs_close(FAR struct file *filep)
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover the open file state from the struct file instance */
 

--- a/fs/nxffs/nxffs_read.c
+++ b/fs/nxffs/nxffs_read.c
@@ -142,7 +142,7 @@ ssize_t nxffs_read(FAR struct file *filep, FAR char *buffer, size_t buflen)
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover the open file state from the struct file instance */
 

--- a/fs/nxffs/nxffs_stat.c
+++ b/fs/nxffs/nxffs_stat.c
@@ -181,11 +181,11 @@ int nxffs_fstat(FAR const struct file *filep, FAR struct stat *buf)
   int ret;
 
   finfo("Buf %p\n", buf);
-  DEBUGASSERT(filep != NULL && buf != NULL);
+  DEBUGASSERT(buf != NULL);
 
   /* Recover the open file state from the struct file instance */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
   ofile = (FAR struct nxffs_ofile_s *)filep->f_priv;
 
   /* Recover the volume state from the open file */

--- a/fs/nxffs/nxffs_truncate.c
+++ b/fs/nxffs/nxffs_truncate.c
@@ -57,7 +57,7 @@ int nxffs_truncate(FAR struct file *filep, off_t length)
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover the open file state from the struct file instance */
 

--- a/fs/nxffs/nxffs_write.c
+++ b/fs/nxffs/nxffs_write.c
@@ -519,7 +519,7 @@ ssize_t nxffs_write(FAR struct file *filep, FAR const char *buffer,
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover the open file state from the struct file instance */
 

--- a/fs/procfs/fs_procfscpuinfo.c
+++ b/fs/procfs/fs_procfscpuinfo.c
@@ -149,7 +149,7 @@ static ssize_t cpuinfo_read(FAR struct file *filep, FAR char *buffer,
 
   finfo("buffer=%p buflen=%zu\n", buffer, buflen);
 
-  DEBUGASSERT(filep != NULL && buffer != NULL && buflen > 0);
+  DEBUGASSERT(buffer != NULL && buflen > 0);
   offset = filep->f_pos;
 
   copylen = up_show_cpuinfo(buffer, buflen, offset);

--- a/fs/procfs/fs_procfsfdt.c
+++ b/fs/procfs/fs_procfsfdt.c
@@ -168,7 +168,7 @@ static ssize_t fdt_read(FAR struct file *filep, FAR char *buffer,
   ssize_t ret;
 
   finfo("buffer=%p buflen=%zu\n", buffer, buflen);
-  DEBUGASSERT(filep != NULL && buffer != NULL && buflen > 0);
+  DEBUGASSERT(buffer != NULL && buflen > 0);
 
   /* Load FDT and parse extents. */
 

--- a/fs/procfs/fs_procfsiobinfo.c
+++ b/fs/procfs/fs_procfsiobinfo.c
@@ -185,7 +185,7 @@ static ssize_t iobinfo_read(FAR struct file *filep, FAR char *buffer,
 
   finfo("buffer=%p buflen=%d\n", buffer, (int)buflen);
 
-  DEBUGASSERT(filep != NULL && buffer != NULL && buflen > 0);
+  DEBUGASSERT(buffer != NULL && buflen > 0);
   offset = filep->f_pos;
 
   /* Recover our private data from the struct file instance */

--- a/fs/procfs/fs_procfsmeminfo.c
+++ b/fs/procfs/fs_procfsmeminfo.c
@@ -280,7 +280,7 @@ static ssize_t meminfo_read(FAR struct file *filep, FAR char *buffer,
 
   finfo("buffer=%p buflen=%d\n", buffer, (int)buflen);
 
-  DEBUGASSERT(filep != NULL && buffer != NULL && buflen > 0);
+  DEBUGASSERT(buffer != NULL && buflen > 0);
   offset = filep->f_pos;
 
   /* Recover our private data from the struct file instance */
@@ -408,7 +408,7 @@ static ssize_t memdump_read(FAR struct file *filep, FAR char *buffer,
 
   finfo("buffer=%p buflen=%d\n", buffer, (int)buflen);
 
-  DEBUGASSERT(filep != NULL && buffer != NULL && buflen > 0);
+  DEBUGASSERT(buffer != NULL && buflen > 0);
   offset = filep->f_pos;
 
   /* Recover our private data from the struct file instance */
@@ -467,7 +467,7 @@ static ssize_t memdump_write(FAR struct file *filep, FAR const char *buffer,
   FAR struct tcb_s *tcb;
 #endif
 
-  DEBUGASSERT(filep != NULL && buffer != NULL && buflen > 0);
+  DEBUGASSERT(buffer != NULL && buflen > 0);
 
   /* Recover our private data from the struct file instance */
 

--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -1585,7 +1585,7 @@ static ssize_t proc_write(FAR struct file *filep, FAR const char *buffer,
   FAR struct tcb_s *tcb;
   ssize_t ret;
 
-  DEBUGASSERT(filep != NULL && buffer != NULL && buflen > 0);
+  DEBUGASSERT(buffer != NULL && buflen > 0);
 
   procfile = (FAR struct proc_file_s *)filep->f_priv;
   DEBUGASSERT(procfile != NULL);

--- a/fs/romfs/fs_romfs.c
+++ b/fs/romfs/fs_romfs.c
@@ -167,7 +167,7 @@ static int romfs_open(FAR struct file *filep, FAR const char *relpath,
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv == NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv == NULL);
 
   /* Get mountpoint private data from the inode reference from the file
    * structure
@@ -310,7 +310,7 @@ static int romfs_close(FAR struct file *filep)
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover our private data from the struct file instance */
 
@@ -374,7 +374,7 @@ static ssize_t romfs_read(FAR struct file *filep, FAR char *buffer,
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover our private data from the struct file instance */
 
@@ -508,7 +508,7 @@ static off_t romfs_seek(FAR struct file *filep, off_t offset, int whence)
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover our private data from the struct file instance */
 
@@ -588,7 +588,7 @@ static int romfs_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover our private data from the struct file instance */
 
@@ -614,7 +614,7 @@ static int romfs_mmap(FAR struct file *filep, FAR struct mm_map_entry_s *map)
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover our private data from the struct file instance */
 
@@ -741,7 +741,7 @@ static int romfs_fstat(FAR const struct file *filep, FAR struct stat *buf)
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Get mountpoint private data from the inode reference from the file
    * structure

--- a/fs/romfs/fs_romfsutil.c
+++ b/fs/romfs/fs_romfsutil.c
@@ -538,7 +538,6 @@ int romfs_hwread(FAR struct romfs_mountpt_s *rm, FAR uint8_t *buffer,
       FAR struct inode *inode = rm->rm_blkdriver;
       ssize_t nsectorsread = -ENODEV;
 
-      DEBUGASSERT(inode);
       if (INODE_IS_MTD(inode))
         {
           nsectorsread =

--- a/fs/rpmsgfs/rpmsgfs.c
+++ b/fs/rpmsgfs/rpmsgfs.c
@@ -387,7 +387,7 @@ static int rpmsgfs_close(FAR struct file *filep)
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover our private data from the struct file instance */
 
@@ -475,7 +475,7 @@ static ssize_t rpmsgfs_read(FAR struct file *filep, FAR char *buffer,
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover our private data from the struct file instance */
 
@@ -517,7 +517,7 @@ static ssize_t rpmsgfs_write(FAR struct file *filep, const char *buffer,
   FAR struct rpmsgfs_ofile_s *hf;
   ssize_t ret;
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover our private data from the struct file instance */
 
@@ -571,7 +571,7 @@ static off_t rpmsgfs_seek(FAR struct file *filep, off_t offset, int whence)
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover our private data from the struct file instance */
 
@@ -614,7 +614,7 @@ static int rpmsgfs_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover our private data from the struct file instance */
 
@@ -661,7 +661,7 @@ static int rpmsgfs_sync(FAR struct file *filep)
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover our private data from the struct file instance */
 
@@ -734,11 +734,11 @@ static int rpmsgfs_fstat(FAR const struct file *filep, FAR struct stat *buf)
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep != NULL && buf != NULL);
+  DEBUGASSERT(buf != NULL);
 
   /* Recover our private data from the struct file instance */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
   hf    = filep->f_priv;
   inode = filep->f_inode;
 
@@ -780,11 +780,11 @@ static int rpmsgfs_fchstat(FAR const struct file *filep,
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep != NULL && buf != NULL);
+  DEBUGASSERT(buf != NULL);
 
   /* Recover our private data from the struct file instance */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
   hf    = filep->f_priv;
   inode = filep->f_inode;
 
@@ -823,13 +823,9 @@ static int rpmsgfs_truncate(FAR struct file *filep, off_t length)
   FAR struct rpmsgfs_ofile_s *hf;
   int ret = OK;
 
-  /* Sanity checks */
-
-  DEBUGASSERT(filep != NULL);
-
   /* Recover our private data from the struct file instance */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
   hf    = filep->f_priv;
   inode = filep->f_inode;
 

--- a/fs/semaphore/sem_open.c
+++ b/fs/semaphore/sem_open.c
@@ -136,7 +136,6 @@ FAR sem_t *sem_open(FAR const char *name, int oflags, ...)
       /* Something exists at this path.  Get the search results */
 
       inode = desc.node;
-      DEBUGASSERT(inode != NULL);
 
       /* Verify that the inode is a semaphore */
 

--- a/fs/semaphore/sem_unlink.c
+++ b/fs/semaphore/sem_unlink.c
@@ -90,7 +90,6 @@ int sem_unlink(FAR const char *name)
   /* Get the search results */
 
   inode = desc.node;
-  DEBUGASSERT(inode != NULL);
 
   /* Verify that what we found is, indeed, a semaphore */
 

--- a/fs/shm/shm_unlink.c
+++ b/fs/shm/shm_unlink.c
@@ -93,7 +93,6 @@ static int file_shm_unlink(FAR const char *name)
   /* Get the search results */
 
   inode = desc.node;
-  DEBUGASSERT(inode != NULL);
 
   /* Verify that what we found is, indeed, an shm inode */
 

--- a/fs/shm/shmfs.c
+++ b/fs/shm/shmfs.c
@@ -94,7 +94,7 @@ static ssize_t shmfs_read(FAR struct file *filep, FAR char *buffer,
   off_t startpos;
   off_t endpos;
 
-  DEBUGASSERT(filep->f_inode != NULL && filep->f_inode->i_private != NULL);
+  DEBUGASSERT(filep->f_inode->i_private != NULL);
 
   sho = filep->f_inode->i_private;
 
@@ -142,7 +142,7 @@ static ssize_t shmfs_write(FAR struct file *filep, FAR const char *buffer,
   off_t startpos;
   off_t endpos;
 
-  DEBUGASSERT(filep->f_inode != NULL && filep->f_inode->i_private != NULL);
+  DEBUGASSERT(filep->f_inode->i_private != NULL);
 
   sho = filep->f_inode->i_private;
 
@@ -351,8 +351,6 @@ static int shmfs_mmap(FAR struct file *filep,
 {
   FAR struct shmfs_object_s *object;
   int ret = -EINVAL;
-
-  DEBUGASSERT(filep->f_inode != NULL);
 
   /* We don't support offset at the moment, just mapping the whole object
    * object is NULL if it hasn't been truncated yet

--- a/fs/smartfs/smartfs_smart.c
+++ b/fs/smartfs/smartfs_smart.c
@@ -419,7 +419,7 @@ static int smartfs_close(FAR struct file *filep)
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover our private data from the struct file instance */
 
@@ -527,7 +527,7 @@ static ssize_t smartfs_read(FAR struct file *filep, FAR char *buffer,
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover our private data from the struct file instance */
 
@@ -656,7 +656,7 @@ static ssize_t smartfs_write(FAR struct file *filep, FAR const char *buffer,
   size_t                             byteswritten;
   int                                ret;
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover our private data from the struct file instance */
 
@@ -960,7 +960,7 @@ static off_t smartfs_seek(FAR struct file *filep, off_t offset, int whence)
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover our private data from the struct file instance */
 
@@ -1018,7 +1018,7 @@ static int smartfs_sync(FAR struct file *filep)
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover our private data from the struct file instance */
 
@@ -1091,11 +1091,11 @@ static int smartfs_fstat(FAR const struct file *filep, FAR struct stat *buf)
   FAR struct smartfs_ofile_s *sf;
   int ret;
 
-  DEBUGASSERT(filep != NULL && buf != NULL);
+  DEBUGASSERT(buf != NULL);
 
   /* Recover our private data from the struct file instance */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
   sf    = filep->f_priv;
   inode = filep->f_inode;
 
@@ -1134,7 +1134,7 @@ static int smartfs_truncate(FAR struct file *filep, off_t length)
   off_t oldsize;
   int ret;
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover our private data from the struct file instance */
 

--- a/fs/spiffs/src/spiffs_vfs.c
+++ b/fs/spiffs/src/spiffs_vfs.c
@@ -305,7 +305,7 @@ static int spiffs_open(FAR struct file *filep, FAR const char *relpath,
   int ret;
 
   finfo("relpath=%s oflags; %04x\n", relpath, oflags);
-  DEBUGASSERT(filep->f_priv == NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv == NULL);
 
   /* Get the mountpoint inode reference from the file structure and the
    * mountpoint private data from the inode structure
@@ -465,7 +465,7 @@ static int spiffs_close(FAR struct file *filep)
   int ret;
 
   finfo("filep=%p\n", filep);
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Get the mountpoint inode reference from the file structure and the
    * volume state data from the inode structure
@@ -550,7 +550,7 @@ static ssize_t spiffs_read(FAR struct file *filep, FAR char *buffer,
 
   finfo("filep=%p buffer=%p buflen=%lu\n",
         filep, buffer, (unsigned long)buflen);
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Get the mountpoint inode reference from the file structure and the
    * volume state data from the inode structure
@@ -602,7 +602,7 @@ static ssize_t spiffs_write(FAR struct file *filep, FAR const char *buffer,
 
   finfo("filep=%p buffer=%p buflen=%zu\n",
         filep, buffer, buflen);
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Get the mountpoint inode reference from the file structure and the
    * volume state data from the inode structure
@@ -821,7 +821,7 @@ static off_t spiffs_seek(FAR struct file *filep, off_t offset, int whence)
   int ret;
 
   finfo("filep=%p offset=%ld whence=%d\n", filep, (long)offset, whence);
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Get the mountpoint inode reference from the file structure and the
    * volume state data from the inode structure
@@ -939,7 +939,7 @@ static int spiffs_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   int ret;
 
   finfo("filep=%p cmd=%d arg=%ld\n", filep, cmd, (long)arg);
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Get the mountpoint inode reference from the file structure and the
    * volume state data from the inode structure
@@ -1056,7 +1056,7 @@ static int spiffs_sync(FAR struct file *filep)
   int ret;
 
   finfo("filep=%p\n", filep);
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Get the mountpoint inode reference from the file structure and the
    * volume state data from the inode structure
@@ -1153,7 +1153,7 @@ static int spiffs_fstat(FAR const struct file *filep, FAR struct stat *buf)
   int ret;
 
   finfo("filep=%p buf=%p\n", filep, buf);
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL &&
+  DEBUGASSERT(filep->f_priv != NULL &&
               buf != NULL);
 
   /* Get the mountpoint inode reference from the file structure and the
@@ -1203,7 +1203,7 @@ static int spiffs_truncate(FAR struct file *filep, off_t length)
   int ret;
 
   finfo("filep=%p length=%ld\n", filep, (long)length);
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL &&
+  DEBUGASSERT(filep->f_priv != NULL &&
               length >= 0);
 
   /* Get the mountpoint inode reference from the file structure and the

--- a/fs/tmpfs/fs_tmpfs.c
+++ b/fs/tmpfs/fs_tmpfs.c
@@ -1283,7 +1283,7 @@ static int tmpfs_open(FAR struct file *filep, FAR const char *relpath,
   int ret;
 
   finfo("filep: %p\n", filep);
-  DEBUGASSERT(filep->f_priv == NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv == NULL);
 
   /* Get the mountpoint inode reference from the file structure and the
    * mountpoint private data from the inode structure
@@ -1433,7 +1433,7 @@ static int tmpfs_close(FAR struct file *filep)
   int ret;
 
   finfo("filep: %p\n", filep);
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   tfo = filep->f_priv;
 
@@ -1461,7 +1461,7 @@ static ssize_t tmpfs_read(FAR struct file *filep, FAR char *buffer,
 
   finfo("filep: %p buffer: %p buflen: %lu\n",
         filep, buffer, (unsigned long)buflen);
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover our private data from the struct file instance */
 
@@ -1527,7 +1527,7 @@ static ssize_t tmpfs_write(FAR struct file *filep, FAR const char *buffer,
 
   finfo("filep: %p buffer: %p buflen: %lu\n",
         filep, buffer, (unsigned long)buflen);
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover our private data from the struct file instance */
 
@@ -1590,7 +1590,7 @@ static off_t tmpfs_seek(FAR struct file *filep, off_t offset, int whence)
   off_t position;
 
   finfo("filep: %p\n", filep);
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover our private data from the struct file instance */
 
@@ -1678,7 +1678,7 @@ static int tmpfs_mmap(FAR struct file *filep, FAR struct mm_map_entry_s *map)
   FAR struct tmpfs_file_s *tfo;
   int ret = -EINVAL;
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
 
   /* Recover our private data from the struct file instance */
 
@@ -1767,11 +1767,11 @@ static int tmpfs_fstat(FAR const struct file *filep, FAR struct stat *buf)
   int ret;
 
   finfo("Fstat %p\n", buf);
-  DEBUGASSERT(filep != NULL && buf != NULL);
+  DEBUGASSERT(buf != NULL);
 
   /* Recover our private data from the struct file instance */
 
-  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
   tfo = filep->f_priv;
 
   /* Get exclusive access to the file */
@@ -1803,7 +1803,7 @@ static int tmpfs_truncate(FAR struct file *filep, off_t length)
   int ret;
 
   finfo("filep: %p length: %ld\n", filep, (long)length);
-  DEBUGASSERT(filep != NULL && length >= 0);
+  DEBUGASSERT(length >= 0);
 
   /* Recover our private data from the struct file instance */
 

--- a/fs/unionfs/fs_unionfs.c
+++ b/fs/unionfs/fs_unionfs.c
@@ -391,7 +391,7 @@ static int unionfs_tryopen(FAR struct file *filep, FAR const char *relpath,
 
   /* Yes.. try to open this directory */
 
-  DEBUGASSERT(filep->f_inode != NULL && filep->f_inode->u.i_mops != NULL);
+  DEBUGASSERT(filep->f_inode->u.i_mops != NULL);
   ops = filep->f_inode->u.i_mops;
 
   if (!ops->open)
@@ -852,7 +852,6 @@ static int unionfs_open(FAR struct file *filep, FAR const char *relpath,
 
   /* Recover the open file data from the struct file instance */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   ui = (FAR struct unionfs_inode_s *)filep->f_inode->i_private;
 
   finfo("Opening: ui_nopen=%d\n", ui->ui_nopen);
@@ -941,7 +940,6 @@ static int unionfs_close(FAR struct file *filep)
 
   /* Recover the open file data from the struct file instance */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   ui = (FAR struct unionfs_inode_s *)filep->f_inode->i_private;
 
   /* Get exclusive access to the file system data structures */
@@ -1008,7 +1006,6 @@ static ssize_t unionfs_read(FAR struct file *filep, FAR char *buffer,
 
   /* Recover the open file data from the struct file instance */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   ui = (FAR struct unionfs_inode_s *)filep->f_inode->i_private;
 
   DEBUGASSERT(ui != NULL && filep->f_priv != NULL);
@@ -1042,7 +1039,6 @@ static ssize_t unionfs_write(FAR struct file *filep, FAR const char *buffer,
 
   /* Recover the open file data from the struct file instance */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   ui = (FAR struct unionfs_inode_s *)filep->f_inode->i_private;
 
   DEBUGASSERT(ui != NULL && filep->f_priv != NULL);
@@ -1075,7 +1071,6 @@ static off_t unionfs_seek(FAR struct file *filep, off_t offset, int whence)
 
   /* Recover the open file data from the struct file instance */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   ui = (FAR struct unionfs_inode_s *)filep->f_inode->i_private;
 
   DEBUGASSERT(ui != NULL && filep->f_priv != NULL);
@@ -1154,7 +1149,6 @@ static int unionfs_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
   /* Recover the open file data from the struct file instance */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   ui = (FAR struct unionfs_inode_s *)filep->f_inode->i_private;
 
   DEBUGASSERT(ui != NULL && filep->f_priv != NULL);
@@ -1187,7 +1181,6 @@ static int unionfs_sync(FAR struct file *filep)
 
   /* Recover the open file data from the struct file instance */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   ui = (FAR struct unionfs_inode_s *)filep->f_inode->i_private;
 
   DEBUGASSERT(ui != NULL && filep->f_priv != NULL);
@@ -1289,7 +1282,6 @@ static int unionfs_fstat(FAR const struct file *filep, FAR struct stat *buf)
 
   /* Recover the open file data from the struct file instance */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   ui = (FAR struct unionfs_inode_s *)filep->f_inode->i_private;
 
   DEBUGASSERT(ui != NULL && filep->f_priv != NULL);
@@ -1328,7 +1320,6 @@ static int unionfs_fchstat(FAR const struct file *filep,
 
   /* Recover the open file data from the struct file instance */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   ui = (FAR struct unionfs_inode_s *)filep->f_inode->i_private;
 
   DEBUGASSERT(ui != NULL && filep->f_priv != NULL);
@@ -1365,7 +1356,6 @@ static int unionfs_truncate(FAR struct file *filep, off_t length)
 
   /* Recover the open file data from the struct file instance */
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   ui = (FAR struct unionfs_inode_s *)filep->f_inode->i_private;
 
   DEBUGASSERT(ui != NULL && filep->f_priv != NULL);

--- a/fs/userfs/fs_userfs.c
+++ b/fs/userfs/fs_userfs.c
@@ -206,7 +206,7 @@ static int userfs_open(FAR struct file *filep, FAR const char *relpath,
 
   finfo("Open '%s'\n", relpath);
 
-  DEBUGASSERT(filep != NULL &&
+  DEBUGASSERT(
               filep->f_inode != NULL &&
               filep->f_inode->i_private != NULL);
   priv = filep->f_inode->i_private;
@@ -292,7 +292,7 @@ static int userfs_close(FAR struct file *filep)
   ssize_t nrecvd;
   int ret;
 
-  DEBUGASSERT(filep != NULL &&
+  DEBUGASSERT(
               filep->f_inode != NULL &&
               filep->f_inode->i_private != NULL);
   priv = filep->f_inode->i_private;
@@ -372,7 +372,7 @@ static ssize_t userfs_read(FAR struct file *filep, char *buffer,
 
   finfo("Read %zu bytes from offset %jd\n", buflen, (intmax_t)filep->f_pos);
 
-  DEBUGASSERT(filep != NULL &&
+  DEBUGASSERT(
               filep->f_inode != NULL &&
               filep->f_inode->i_private != NULL);
   priv = filep->f_inode->i_private;
@@ -463,7 +463,7 @@ static ssize_t userfs_write(FAR struct file *filep, FAR const char *buffer,
 
   finfo("Write %zu bytes to offset %jd\n", buflen, (intmax_t)filep->f_pos);
 
-  DEBUGASSERT(filep != NULL &&
+  DEBUGASSERT(
               filep->f_inode != NULL &&
               filep->f_inode->i_private != NULL);
   priv = filep->f_inode->i_private;
@@ -547,7 +547,7 @@ static off_t userfs_seek(FAR struct file *filep, off_t offset, int whence)
 
   finfo("Offset %lu bytes to whence=%d\n", (unsigned long)offset, whence);
 
-  DEBUGASSERT(filep != NULL &&
+  DEBUGASSERT(
               filep->f_inode != NULL &&
               filep->f_inode->i_private != NULL);
   priv = filep->f_inode->i_private;
@@ -622,7 +622,7 @@ static int userfs_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
   finfo("cmd: %d arg: %08lx\n", cmd, arg);
 
-  DEBUGASSERT(filep != NULL &&
+  DEBUGASSERT(
               filep->f_inode != NULL &&
               filep->f_inode->i_private != NULL);
   priv = filep->f_inode->i_private;
@@ -695,7 +695,7 @@ static int userfs_sync(FAR struct file *filep)
   ssize_t nrecvd;
   int ret;
 
-  DEBUGASSERT(filep != NULL &&
+  DEBUGASSERT(
               filep->f_inode != NULL &&
               filep->f_inode->i_private != NULL);
   priv = filep->f_inode->i_private;
@@ -849,7 +849,7 @@ static int userfs_fstat(FAR const struct file *filep, FAR struct stat *buf)
   ssize_t nrecvd;
   int ret;
 
-  DEBUGASSERT(filep != NULL &&
+  DEBUGASSERT(
               filep->f_inode != NULL &&
               filep->f_inode->i_private != NULL);
   priv = filep->f_inode->i_private;
@@ -930,7 +930,7 @@ static int userfs_fchstat(FAR const struct file *filep,
   ssize_t nrecvd;
   int ret;
 
-  DEBUGASSERT(filep != NULL &&
+  DEBUGASSERT(
               filep->f_inode != NULL &&
               filep->f_inode->i_private != NULL);
   priv = filep->f_inode->i_private;
@@ -1007,7 +1007,7 @@ static int userfs_truncate(FAR struct file *filep, off_t length)
   ssize_t nrecvd;
   int ret;
 
-  DEBUGASSERT(filep != NULL &&
+  DEBUGASSERT(
               filep->f_inode != NULL &&
               filep->f_inode->i_private != NULL);
   priv = filep->f_inode->i_private;

--- a/graphics/nxterm/nxterm_driver.c
+++ b/graphics/nxterm/nxterm_driver.c
@@ -107,8 +107,6 @@ static int nxterm_open(FAR struct file *filep)
   FAR struct inode         *inode = filep->f_inode;
   FAR struct nxterm_state_s *priv = inode->i_private;
 
-  DEBUGASSERT(filep && filep->f_inode);
-
   /* Get the driver structure from the inode */
 
   inode = filep->f_inode;
@@ -150,7 +148,7 @@ static int nxterm_close(FAR struct file *filep)
 
   /* Recover our private state structure */
 
-  DEBUGASSERT(filep != NULL && filep->f_priv != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
   priv = (FAR struct nxterm_state_s *)filep->f_priv;
 
   /* Get exclusive access */
@@ -202,7 +200,7 @@ static ssize_t nxterm_write(FAR struct file *filep, FAR const char *buffer,
 
   /* Recover our private state structure */
 
-  DEBUGASSERT(filep != NULL && filep->f_priv != NULL);
+  DEBUGASSERT(filep->f_priv != NULL);
   priv = (FAR struct nxterm_state_s *)filep->f_priv;
 
   /* Get exclusive access */
@@ -327,7 +325,7 @@ static int nxterm_unlink(FAR struct inode *inode)
   FAR struct nxterm_state_s *priv;
   int ret;
 
-  DEBUGASSERT(inode != NULL && inode->i_private != NULL);
+  DEBUGASSERT(inode->i_private != NULL);
   priv = inode->i_private;
 
   /* Get exclusive access */

--- a/graphics/nxterm/nxterm_kbdin.c
+++ b/graphics/nxterm/nxterm_kbdin.c
@@ -83,7 +83,7 @@ ssize_t nxterm_read(FAR struct file *filep, FAR char *buffer, size_t len)
 
   /* Recover our private state structure */
 
-  DEBUGASSERT(filep && filep->f_priv);
+  DEBUGASSERT(filep->f_priv);
   priv = (FAR struct nxterm_state_s *)filep->f_priv;
 
   /* Get exclusive access to the driver structure */
@@ -231,7 +231,7 @@ int nxterm_poll(FAR struct file *filep, FAR struct pollfd *fds, bool setup)
 
   /* Some sanity checking */
 
-  DEBUGASSERT(inode && inode->i_private);
+  DEBUGASSERT(inode->i_private);
   priv = inode->i_private;
 
   /* Get exclusive access to the driver structure */

--- a/wireless/ieee802154/mac802154_device.c
+++ b/wireless/ieee802154/mac802154_device.c
@@ -165,7 +165,6 @@ static int mac802154dev_open(FAR struct file *filep)
   FAR struct mac802154dev_open_s *opriv;
   int ret;
 
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
   inode = filep->f_inode;
 
   dev   = inode->i_private;
@@ -226,7 +225,7 @@ static int mac802154dev_close(FAR struct file *filep)
   bool closing;
   int ret;
 
-  DEBUGASSERT(filep && filep->f_priv && filep->f_inode);
+  DEBUGASSERT(filep->f_priv);
   opriv = filep->f_priv;
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private);
@@ -338,7 +337,6 @@ static ssize_t mac802154dev_read(FAR struct file *filep, FAR char *buffer,
   struct ieee802154_get_req_s req;
   int ret;
 
-  DEBUGASSERT(filep && filep->f_inode);
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private);
   dev = (FAR struct mac802154_chardevice_s *)inode->i_private;
@@ -484,7 +482,6 @@ static ssize_t mac802154dev_write(FAR struct file *filep,
   FAR struct iob_s *iob;
   int ret;
 
-  DEBUGASSERT(filep && filep->f_inode);
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private);
   dev  = (FAR struct mac802154_chardevice_s *)inode->i_private;
@@ -553,7 +550,7 @@ static int mac802154dev_ioctl(FAR struct file *filep, int cmd,
     (FAR union ieee802154_macarg_u *)((uintptr_t)arg);
   int ret;
 
-  DEBUGASSERT(filep != NULL && filep->f_priv != NULL &&
+  DEBUGASSERT(filep->f_priv != NULL &&
               filep->f_inode != NULL);
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private);


### PR DESCRIPTION
## Summary

fs/inode: remove all unnecessary check for filep/inode

Since VFS layer already contains sanity checks, so remove unnecessary lower half checks

Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

ci-check