### PR TITLE
drivers/note: Add support for atrace mark/counter type

### DIFF
--- a/include/nuttx/sched_note.h
+++ b/include/nuttx/sched_note.h
@@ -139,6 +139,11 @@
           sched_note_printf_ip(tag, SCHED_NOTE_IP, "B|%d|%s", gettid(), str)
 #  define sched_note_endex(tag, str) \
           sched_note_printf_ip(tag, SCHED_NOTE_IP, "E|%d|%s", gettid(), str)
+#  define sched_note_mark(tag, str) \
+          sched_note_printf_ip(tag, SCHED_NOTE_IP, "I|%d|%s", gettid(), str)
+#  define sched_note_counter(tag, name, value) \
+          sched_note_printf_ip(tag, SCHED_NOTE_IP, "C|%d|%s|%" PRId32, \
+                               gettid(), name, value)
 #  define sched_note_begin(tag) \
           sched_note_string_ip(tag, SCHED_NOTE_IP, "B")
 #  define sched_note_end(tag) \


### PR DESCRIPTION
## Summary
Use sched_note_mark to view event markers/counter in perfetto

![image](https://github.com/apache/nuttx/assets/33870028/720142f1-ced4-4417-9a79-a4b619399fa9)


## Impact

## Testing

