### PR TITLE
samv7: allow usage of QSPI in SPI mode for all MCUs

### DIFF
--- a/arch/arm/include/samv7/chip.h
+++ b/arch/arm/include/samv7/chip.h
@@ -72,6 +72,7 @@
 #  define SAMV7_NUSART                3             /* 3 USARTs */
 #  define SAMV7_NUART                 5             /* 5 UARTs */
 #  define SAMV7_NQSPI                 1             /* 1 Quad SPI */
+#  define SAMV7_NQSPI_SPI             0             /* QSPI functions in SPI mode only */
 #  define SAMV7_NSPI                  2             /* 2 SPI, SPI0-1 */
 #  define SAMV7_NTWIHS                3             /* 3 TWIHS */
 #  define SAMV7_NHSMCI4               1             /* 1 4-bit HSMCI port */
@@ -128,6 +129,7 @@
 #  define SAMV7_NUSART                3             /* 3 USARTs */
 #  define SAMV7_NUART                 5             /* 5 UARTs */
 #  define SAMV7_NQSPI                 1             /* 1 Quad SPI */
+#  define SAMV7_NQSPI_SPI             0             /* QSPI functions in SPI mode only */
 #  define SAMV7_NSPI                  1             /* 1 SPI, SPI0 only */
 #  define SAMV7_NTWIHS                3             /* 3 TWIHS */
 #  define SAMV7_NHSMCI4               1             /* 1 4-bit HSMCI port */
@@ -239,6 +241,7 @@
 #  define SAMV7_NUSART                3             /* 3 USARTs */
 #  define SAMV7_NUART                 5             /* 5 UARTs */
 #  define SAMV7_NQSPI                 1             /* 1 Quad SPI */
+#  define SAMV7_NQSPI_SPI             0             /* QSPI functions in SPI mode only */
 #  define SAMV7_NSPI                  2             /* 2 SPI, SPI0-1 */
 #  define SAMV7_NTWIHS                3             /* 3 TWIHS */
 #  define SAMV7_NHSMCI4               1             /* 1 4-bit HSMCI port */
@@ -295,6 +298,7 @@
 #  define SAMV7_NUSART                3             /* 3 USARTs */
 #  define SAMV7_NUART                 5             /* 5 UARTs */
 #  define SAMV7_NQSPI                 1             /* 1 Quad SPI */
+#  define SAMV7_NQSPI_SPI             0             /* QSPI functions in SPI mode only */
 #  define SAMV7_NSPI                  1             /* 1 SPI, SPI0 */
 #  define SAMV7_NTWIHS                3             /* 3 TWIHS */
 #  define SAMV7_NHSMCI4               1             /* 1 4-bit HSMCI port */
@@ -351,7 +355,8 @@
 #  define SAMV7_NUSART                0             /* No USARTs */
 #  define SAMV7_NUART                 5             /* 5 UARTs */
 #  define SAMV7_NQSPI                 0             /* No Quad SPI */
-#  define SAMV7_NSPI                  1             /* 1 SPI, QSPI functions in SPI mode only */
+#  define SAMV7_NQSPI_SPI             1             /* QSPI functions in SPI mode only */
+#  define SAMV7_NSPI                  0             /* No SPI */
 #  define SAMV7_NTWIHS                2             /* 2 TWIHS */
 #  define SAMV7_NHSMCI4               0             /* No 4-bit HSMCI port */
 #  define SAMV7_NCAN                  1             /* 1 CAN port */

--- a/arch/arm/src/samv7/Kconfig
+++ b/arch/arm/src/samv7/Kconfig
@@ -137,6 +137,7 @@ config ARCH_CHIP_SAME70Q
 	bool
 	default n
 	select ARCH_CHIP_SAME70
+	select SAMV7_QSPI_IS_SPI
 	select SAMV7_HAVE_MCAN1
 	select SAMV7_HAVE_DAC1 if !SAMV7_EMAC0
 	select SAMV7_HAVE_EBI
@@ -154,6 +155,7 @@ config ARCH_CHIP_SAME70N
 	bool
 	default n
 	select ARCH_CHIP_SAME70
+	select SAMV7_QSPI_IS_SPI
 	select SAMV7_HAVE_MCAN1
 	select SAMV7_HAVE_DAC1 if !SAMV7_EMAC0
 	select SAMV7_HAVE_HSMCI0
@@ -187,6 +189,7 @@ config ARCH_CHIP_SAMV71Q
 	bool
 	default n
 	select ARCH_CHIP_SAMV71
+	select SAMV7_QSPI_IS_SPI
 	select SAMV7_HAVE_MCAN1
 	select SAMV7_HAVE_DAC1 if !SAMV7_EMAC0
 	select SAMV7_HAVE_EBI
@@ -204,6 +207,7 @@ config ARCH_CHIP_SAMV71N
 	bool
 	default n
 	select ARCH_CHIP_SAMV71
+	select SAMV7_QSPI_IS_SPI
 	select SAMV7_HAVE_MCAN1
 	select SAMV7_HAVE_DAC1 if !SAMV7_EMAC0
 	select SAMV7_HAVE_HSMCI0

--- a/arch/arm/src/samv7/sam_qspi_spi.c
+++ b/arch/arm/src/samv7/sam_qspi_spi.c
@@ -771,7 +771,7 @@ struct spi_dev_s *sam_qspi_spi_initialize(int intf)
   /* The supported SAM parts have only a single QSPI port */
 
   spiinfo("intf: %d\n", intf);
-  DEBUGASSERT(intf >= 0 && intf < SAMV7_NQSPI_SPI);
+  DEBUGASSERT(intf >= 0 && intf < (SAMV7_NQSPI_SPI + SAMV7_NQSPI));
 
   /* Allocate a new state structure for this chip select. */
 


### PR DESCRIPTION
## Summary
Current implementation of QSPI in SPI mode was available only for MCUs that do not have standard SPI at all. MCUs with both QSPI and SPI can however also use QSPI in SPI mode and thus have one more SPI bus. This commit adds required defines and config options to support QSPI in SPI mode for all SAMv7 MCUs.

## Testing
Tested on SAMv7 custom board.

