### PR TITLE
signal: add siginterrupt implementation

### DIFF
--- a/include/signal.h
+++ b/include/signal.h
@@ -405,6 +405,7 @@ int  sigtimedwait(FAR const sigset_t *set, FAR struct siginfo *value,
 int  sigsuspend(FAR const sigset_t *sigmask);
 int  sigwaitinfo(FAR const sigset_t *set, FAR struct siginfo *value);
 int  sigaltstack(FAR const stack_t *ss, FAR stack_t *oss);
+int  siginterrupt(int signo, int flag);
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/libs/libc/signal/CMakeLists.txt
+++ b/libs/libc/signal/CMakeLists.txt
@@ -29,6 +29,7 @@ target_sources(
           sig_orset.c
           sig_xorset.c
           sig_isemptyset.c
+          sig_interrupt.c
           sig_hold.c
           sig_ignore.c
           sig_ismember.c

--- a/libs/libc/signal/Make.defs
+++ b/libs/libc/signal/Make.defs
@@ -22,7 +22,7 @@
 
 CSRCS += sig_addset.c sig_delset.c sig_emptyset.c sig_fillset.c
 CSRCS += sig_nandset.c sig_andset.c sig_orset.c sig_xorset.c
-CSRCS += sig_isemptyset.c sig_killpg.c sig_altstack.c
+CSRCS += sig_isemptyset.c sig_killpg.c sig_altstack.c sig_interrupt.c
 CSRCS += sig_hold.c sig_ignore.c sig_ismember.c sig_pause.c sig_psignal.c
 CSRCS += sig_raise.c sig_relse.c sig_set.c sig_signal.c sig_wait.c
 

--- a/libs/libc/signal/sig_interrupt.c
+++ b/libs/libc/signal/sig_interrupt.c
@@ -1,0 +1,69 @@
+/****************************************************************************
+ * libs/libc/signal/sig_interrupt.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <signal.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: siginterrupt
+ *
+ * Description:
+ * The siginterrupt() function allows signals to interrupt functions
+ *
+ * Input Parameters:
+ *   signo - Signal to interrupt functions
+ *   flag  - Flag to get restarting signal
+ *
+ * Returned Value:
+ *   Upon successful completion, siginterrupt() shall return 0;
+ *   otherwise, -1 shall be returned and errno set to indicate the error.
+ *
+ *    EINVAL - The signo argument is invalid.
+ ****************************************************************************/
+
+int siginterrupt(int signo, int flag)
+{
+  struct sigaction act;
+
+  if (sigaction(signo, NULL, &act) < 0)
+    {
+      return ERROR;
+    }
+
+  if (flag)
+    {
+      act.sa_flags &= ~SA_RESTART;
+    }
+  else
+    {
+      act.sa_flags |= SA_RESTART;
+    }
+
+  return sigaction(signo, &act, NULL);
+}


### PR DESCRIPTION
https://pubs.opengroup.org/onlinepubs/9699919799/functions/siginterrupt.html

## Summary
LTP posix API need support siginterrupt for buildonly case
## Impact
None
## Testing
LTP buildonly case and ci pass
