### PR TITLE
drivers/video: Fix an issue isx019 may freeze

### DIFF
--- a/drivers/video/isx019.c
+++ b/drivers/video/isx019.c
@@ -1671,14 +1671,6 @@ static int isx019_start_capture(FAR struct imgsensor_s *sensor,
 static int isx019_stop_capture(FAR struct imgsensor_s *sensor,
                                imgsensor_stream_type_t type)
 {
-  FAR isx019_dev_t *priv = (FAR isx019_dev_t *)sensor;
-  uint8_t regval;
-
-  regval = FPGA_DATA_OUTPUT_STOP;
-  nxmutex_lock(&priv->fpga_lock);
-  fpga_i2c_write(priv, FPGA_DATA_OUTPUT, &regval, 1);
-  fpga_activate_setting(priv);
-  nxmutex_unlock(&priv->fpga_lock);
   return OK;
 }
 


### PR DESCRIPTION
## Summary
 isx019 driver freezes by I2C access in the interrupt context.
 This I2C access is intended to stop data output from FPGA.
 Delete this I2C access for the following reasons.
 - Data output from FPGA does not affect power consumption
 - There are no problems in capture restart without data output stop
    since restart is done by image data block first.

## Impact
video/isx019

## Testing

