### PR TITLE
net/socket/bind: make sure that an address was provided

### DIFF
--- a/net/socket/bind.c
+++ b/net/socket/bind.c
@@ -82,7 +82,14 @@ int psock_bind(FAR struct socket *psock, const struct sockaddr *addr,
 
   if (!psock || psock->s_conn == NULL)
     {
-      return -ENOTSOCK;
+      return -EBADF;
+    }
+
+  /* Make sure that an address was provided */
+
+  if (addr == NULL)
+    {
+      return -EFAULT;
     }
 
   /* Let the address family's connect() method handle the operation */


### PR DESCRIPTION
## Summary

net/socket/bind: make sure that an address was provided

1. make sure that an address was provided on bind() call
2. correct the return value if bad socket handler

Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

ci-check