### PR TITLE
pcf8575: fix compilation warnings

### DIFF
--- a/drivers/ioexpander/pcf8575.c
+++ b/drivers/ioexpander/pcf8575.c
@@ -63,9 +63,9 @@ static int pcf8575_readpin(FAR struct ioexpander_dev_s *dev, uint8_t pin,
              FAR bool *value);
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int pcf8575_multiwritepin(FAR struct ioexpander_dev_s *dev,
-             FAR uint8_t *pins, FAR bool *values, int count);
+             FAR const uint8_t *pins, FAR bool *values, int count);
 static int pcf8575_multireadpin(FAR struct ioexpander_dev_s *dev,
-             FAR uint8_t *pins, FAR bool *values, int count);
+             FAR const uint8_t *pins, FAR bool *values, int count);
 #endif
 
 /****************************************************************************
@@ -467,7 +467,7 @@ errout_with_lock:
 
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int pcf8575_multiwritepin(FAR struct ioexpander_dev_s *dev,
-                                 FAR uint8_t *pins, FAR bool *values,
+                                 FAR const uint8_t *pins, FAR bool *values,
                                  int count)
 {
   FAR struct pcf8575_dev_s *priv = (FAR struct pcf8575_dev_s *)dev;
@@ -501,7 +501,7 @@ static int pcf8575_multiwritepin(FAR struct ioexpander_dev_s *dev,
           return -ENXIO;
         }
 
-      gpioinfo("%d. pin=%u value=%u\n", pin, values[i]);
+      gpioinfo("%d. pin=%u value=%u\n", i, pin, values[i]);
 
       if ((priv->inpins & (1 << pin)) != 0)
         {
@@ -551,11 +551,11 @@ static int pcf8575_multiwritepin(FAR struct ioexpander_dev_s *dev,
 
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int pcf8575_multireadpin(FAR struct ioexpander_dev_s *dev,
-                                FAR uint8_t *pins, FAR bool *values,
+                                FAR const uint8_t *pins, FAR bool *values,
                                 int count)
 {
   FAR struct pcf8575_dev_s *priv = (FAR struct pcf8575_dev_s *)dev;
-  uint8_t regval;
+  uint16_t regval;
   uint8_t pin;
   int ret;
   int i;
@@ -615,7 +615,7 @@ static int pcf8575_multireadpin(FAR struct ioexpander_dev_s *dev,
           values[i] = ((regval & (1 << pin)) != 0);
         }
 
-      gpioinfo("%d. pin=%u value=%u\n", pin, values[i]);
+      gpioinfo("%d. pin=%u value=%u\n", i, pin, values[i]);
     }
 
   ret = OK;


### PR DESCRIPTION
## Summary
Just few compile warning fixes in case `CONFIG_IOEXPANDER_MULTIPIN` is selected.

## Testing
CI build pass

