### PR TITLE
net/can: correct the return value if unsupported socket type

### DIFF
--- a/net/can/can_recvmsg.c
+++ b/net/can/can_recvmsg.c
@@ -480,7 +480,7 @@ ssize_t can_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
   if (psock->s_type != SOCK_RAW)
     {
       nerr("ERROR: Unsupported socket type: %d\n", psock->s_type);
-      ret = -ENOSYS;
+      return -ENOSYS;
     }
 
   net_lock();


### PR DESCRIPTION
## Summary

net/can: correct the return value if unsupported socket type

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

ci-check