### PR TITLE
net/assert: remove all unnecessary check for psock/conn

### DIFF
--- a/net/bluetooth/bluetooth_sendmsg.c
+++ b/net/bluetooth/bluetooth_sendmsg.c
@@ -417,7 +417,6 @@ static ssize_t bluetooth_l2cap_send(FAR struct socket *psock,
   ssize_t ret;
 
   conn = psock->s_conn;
-  DEBUGASSERT(conn != NULL);
 
   if (!_SS_ISCONNECTED(conn->bc_conn.s_flags))
     {
@@ -490,8 +489,6 @@ static ssize_t bluetooth_send(FAR struct socket *psock, FAR const void *buf,
                               size_t len, int flags)
 {
   ssize_t ret;
-
-  DEBUGASSERT(psock != NULL || buf != NULL);
 
   /* Only SOCK_RAW is supported */
 

--- a/net/bluetooth/bluetooth_sockif.c
+++ b/net/bluetooth/bluetooth_sockif.c
@@ -208,8 +208,7 @@ static void bluetooth_addref(FAR struct socket *psock)
 {
   FAR struct bluetooth_conn_s *conn;
 
-  DEBUGASSERT(psock != NULL && psock->s_conn != NULL &&
-              (psock->s_type == SOCK_RAW || psock->s_type == SOCK_CTRL));
+  DEBUGASSERT(psock->s_type == SOCK_RAW || psock->s_type == SOCK_CTRL);
 
   conn = psock->s_conn;
   DEBUGASSERT(conn->bc_crefs > 0 && conn->bc_crefs < 255);
@@ -250,9 +249,7 @@ static int bluetooth_connect(FAR struct socket *psock,
   FAR struct sockaddr_l2 *btaddr;
   int ret = OK;
 
-  DEBUGASSERT(psock != NULL || addr != NULL);
   conn = psock->s_conn;
-  DEBUGASSERT(conn != NULL);
 
   /* Verify the address family */
 
@@ -308,8 +305,6 @@ static int bluetooth_connect(FAR struct socket *psock,
 static int bluetooth_bind(FAR struct socket *psock,
                           FAR const struct sockaddr *addr, socklen_t addrlen)
 {
-  DEBUGASSERT(psock != NULL && addr != NULL);
-
   /* Verify that a valid address has been provided */
 
   if (addr->sa_family != AF_BLUETOOTH)
@@ -521,10 +516,7 @@ static int bluetooth_getsockname(FAR struct socket *psock,
   FAR struct sockaddr_l2 tmp;
   socklen_t copylen;
 
-  DEBUGASSERT(psock != NULL && addr != NULL && addrlen != NULL);
-
   conn = psock->s_conn;
-  DEBUGASSERT(conn != NULL);
 
   /* Create a copy of the full address on the stack */
 
@@ -583,15 +575,12 @@ static int bluetooth_getpeername(FAR struct socket *psock,
   FAR struct sockaddr_l2 tmp;
   socklen_t copylen;
 
-  DEBUGASSERT(psock != NULL && addr != NULL && addrlen != NULL);
-
   if (psock->s_proto != BTPROTO_L2CAP)
     {
       return -EPFNOSUPPORT;
     }
 
   conn = psock->s_conn;
-  DEBUGASSERT(conn != NULL);
 
   /* Create a copy of the full address on the stack */
 

--- a/net/can/can_getsockopt.c
+++ b/net/can/can_getsockopt.c
@@ -80,8 +80,7 @@ int can_getsockopt(FAR struct socket *psock, int level, int option,
   FAR struct can_conn_s *conn;
   int ret = OK;
 
-  DEBUGASSERT(psock != NULL && value != NULL && value_len != NULL &&
-              psock->s_conn != NULL);
+  DEBUGASSERT(value != NULL && value_len != NULL);
   conn = psock->s_conn;
 
 #ifdef CONFIG_NET_TIMESTAMP

--- a/net/can/can_recvmsg.c
+++ b/net/can/can_recvmsg.c
@@ -473,8 +473,6 @@ ssize_t can_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
   struct can_recvfrom_s state;
   int ret;
 
-  DEBUGASSERT(psock != NULL && psock->s_conn != NULL);
-
   conn = psock->s_conn;
 
   if (psock->s_type != SOCK_RAW)

--- a/net/can/can_setsockopt.c
+++ b/net/can/can_setsockopt.c
@@ -77,7 +77,6 @@ int can_setsockopt(FAR struct socket *psock, int level, int option,
   int ret = OK;
   int count = 0;
 
-  DEBUGASSERT(psock != NULL && psock->s_conn != NULL);
   DEBUGASSERT(value_len == 0 || value != NULL);
 
   conn = psock->s_conn;

--- a/net/can/can_sockif.c
+++ b/net/can/can_sockif.c
@@ -270,8 +270,6 @@ static void can_addref(FAR struct socket *psock)
 {
   FAR struct can_conn_s *conn;
 
-  DEBUGASSERT(psock != NULL && psock->s_conn != NULL);
-
   conn = psock->s_conn;
   DEBUGASSERT(conn->crefs > 0 && conn->crefs < 255);
   conn->crefs++;
@@ -312,7 +310,7 @@ static int can_bind(FAR struct socket *psock,
 {
   FAR struct sockaddr_can *canaddr;
   FAR struct can_conn_s *conn;
-  DEBUGASSERT(psock != NULL && psock->s_conn != NULL && addr != NULL &&
+  DEBUGASSERT(addr != NULL &&
               addrlen >= sizeof(struct sockaddr_can));
 
   /* Save the address information in the connection structure */
@@ -365,7 +363,6 @@ static int can_poll_local(FAR struct socket *psock, FAR struct pollfd *fds,
   pollevent_t eventset = 0;
   int ret = OK;
 
-  DEBUGASSERT(psock != NULL && psock->s_conn != NULL);
   conn = psock->s_conn;
   info = conn->pollinfo;
 

--- a/net/icmp/icmp_netpoll.c
+++ b/net/icmp/icmp_netpoll.c
@@ -84,7 +84,6 @@ static uint16_t icmp_poll_eventhandler(FAR struct net_driver_s *dev,
        */
 
       psock = info->psock;
-      DEBUGASSERT(psock != NULL && psock->s_conn != NULL);
       conn  = psock->s_conn;
       if (dev != conn->dev)
         {

--- a/net/icmp/icmp_recvmsg.c
+++ b/net/icmp/icmp_recvmsg.c
@@ -104,7 +104,6 @@ static uint16_t recvfrom_eventhandler(FAR struct net_driver_s *dev,
         }
 
       psock = pstate->recv_sock;
-      DEBUGASSERT(psock != NULL && psock->s_conn != NULL);
 
       /* Check if we have just received a ICMP ECHO reply. */
 
@@ -295,7 +294,7 @@ ssize_t icmp_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
 
   /* Some sanity checks */
 
-  DEBUGASSERT(psock != NULL && psock->s_conn != NULL && buf != NULL);
+  DEBUGASSERT(buf != NULL);
 
   if (len < ICMP_HDRLEN)
     {

--- a/net/icmp/icmp_sendmsg.c
+++ b/net/icmp/icmp_sendmsg.c
@@ -290,8 +290,7 @@ ssize_t icmp_sendmsg(FAR struct socket *psock, FAR struct msghdr *msg,
 
   /* Some sanity checks */
 
-  DEBUGASSERT(psock != NULL && psock->s_conn != NULL &&
-              buf != NULL && to != NULL);
+  DEBUGASSERT(buf != NULL && to != NULL);
 
   if (len < ICMP_HDRLEN || tolen < sizeof(struct sockaddr_in))
     {

--- a/net/icmp/icmp_sockif.c
+++ b/net/icmp/icmp_sockif.c
@@ -190,8 +190,6 @@ static void icmp_addref(FAR struct socket *psock)
 {
   FAR struct icmp_conn_s *conn;
 
-  DEBUGASSERT(psock != NULL && psock->s_conn != NULL);
-
   conn = psock->s_conn;
   DEBUGASSERT(conn->crefs > 0 && conn->crefs < 255);
   conn->crefs++;
@@ -254,7 +252,6 @@ static int icmp_close(FAR struct socket *psock)
 {
   FAR struct icmp_conn_s *conn;
 
-  DEBUGASSERT(psock != NULL && psock->s_conn != NULL);
   conn = psock->s_conn;
 
   /* Is this the last reference to the connection structure (there could be\

--- a/net/icmpv6/icmpv6_netpoll.c
+++ b/net/icmpv6/icmpv6_netpoll.c
@@ -84,7 +84,6 @@ static uint16_t icmpv6_poll_eventhandler(FAR struct net_driver_s *dev,
        */
 
       psock = info->psock;
-      DEBUGASSERT(psock != NULL && psock->s_conn != NULL);
       conn  = psock->s_conn;
       if (dev != conn->dev)
         {

--- a/net/icmpv6/icmpv6_recvmsg.c
+++ b/net/icmpv6/icmpv6_recvmsg.c
@@ -96,7 +96,6 @@ static uint16_t recvfrom_eventhandler(FAR struct net_driver_s *dev,
                                       FAR void *pvpriv, uint16_t flags)
 {
   FAR struct icmpv6_recvfrom_s *pstate = pvpriv;
-  FAR struct socket *psock;
   FAR struct ipv6_hdr_s *ipv6;
 
   ninfo("flags: %04x\n", flags);
@@ -112,15 +111,12 @@ static uint16_t recvfrom_eventhandler(FAR struct net_driver_s *dev,
           goto end_wait;
         }
 
-      psock = pstate->recv_sock;
-      DEBUGASSERT(psock != NULL && psock->s_conn != NULL);
-
       /* Check if we have just received a ICMPv6 message. */
 
       if ((flags & ICMPv6_NEWDATA) != 0)    /* No incoming data */
         {
 #ifdef CONFIG_NET_SOCKOPTS
-          FAR struct icmpv6_conn_s *conn = psock->s_conn;
+          FAR struct icmpv6_conn_s *conn = pstate->recv_sock->s_conn;
 #endif
           unsigned int recvsize;
 
@@ -309,7 +305,7 @@ ssize_t icmpv6_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
 
   /* Some sanity checks */
 
-  DEBUGASSERT(psock != NULL && psock->s_conn != NULL && buf != NULL);
+  DEBUGASSERT(buf != NULL);
 
   if (len < ICMPv6_HDRLEN)
     {

--- a/net/icmpv6/icmpv6_sendmsg.c
+++ b/net/icmpv6/icmpv6_sendmsg.c
@@ -286,8 +286,7 @@ ssize_t icmpv6_sendmsg(FAR struct socket *psock, FAR struct msghdr *msg,
 
   /* Some sanity checks */
 
-  DEBUGASSERT(psock != NULL && psock->s_conn != NULL &&
-              buf != NULL && to != NULL);
+  DEBUGASSERT(buf != NULL && to != NULL);
 
   if (len < ICMPv6_HDRLEN || tolen < sizeof(struct sockaddr_in6))
     {

--- a/net/icmpv6/icmpv6_sockif.c
+++ b/net/icmpv6/icmpv6_sockif.c
@@ -191,8 +191,6 @@ static void icmpv6_addref(FAR struct socket *psock)
 {
   FAR struct icmpv6_conn_s *conn;
 
-  DEBUGASSERT(psock != NULL && psock->s_conn != NULL);
-
   conn = psock->s_conn;
   DEBUGASSERT(conn->crefs > 0 && conn->crefs < 255);
   conn->crefs++;
@@ -255,7 +253,6 @@ static int icmpv6_close(FAR struct socket *psock)
 {
   FAR struct icmpv6_conn_s *conn;
 
-  DEBUGASSERT(psock != NULL && psock->s_conn != NULL);
   conn = psock->s_conn;
 
   /* Is this the last reference to the connection structure (there could be\

--- a/net/ieee802154/ieee802154_sendmsg.c
+++ b/net/ieee802154/ieee802154_sendmsg.c
@@ -176,8 +176,6 @@ static void ieee802154_meta_data(FAR struct radio_driver_s *radio,
               meta != NULL);
 
   psock    = pstate->is_sock;
-  DEBUGASSERT(psock->s_conn != NULL);
-
   conn     = psock->s_conn;
   srcaddr  = &conn->laddr;
   destaddr = &pstate->is_destaddr;
@@ -565,9 +563,7 @@ static ssize_t ieee802154_send(FAR struct socket *psock, FAR const void *buf,
   FAR struct ieee802154_conn_s *conn;
   ssize_t ret;
 
-  DEBUGASSERT(psock != NULL || buf != NULL);
   conn = psock->s_conn;
-  DEBUGASSERT(conn != NULL);
 
   /* Only SOCK_DGRAM is supported (because the MAC header is stripped) */
 

--- a/net/ieee802154/ieee802154_sockif.c
+++ b/net/ieee802154/ieee802154_sockif.c
@@ -199,8 +199,7 @@ static void ieee802154_addref(FAR struct socket *psock)
 {
   FAR struct ieee802154_conn_s *conn;
 
-  DEBUGASSERT(psock != NULL && psock->s_conn != NULL &&
-              (psock->s_type == SOCK_DGRAM || psock->s_type == SOCK_CTRL));
+  DEBUGASSERT(psock->s_type == SOCK_DGRAM || psock->s_type == SOCK_CTRL);
 
   conn = psock->s_conn;
   DEBUGASSERT(conn->crefs > 0 && conn->crefs < 255);
@@ -247,9 +246,7 @@ static int ieee802154_connect(FAR struct socket *psock,
   FAR struct sockaddr_ieee802154_s *ieeeaddr;
   int ret = OK;
 
-  DEBUGASSERT(psock != NULL || addr != NULL);
   conn = psock->s_conn;
-  DEBUGASSERT(conn != NULL);
 
   /* Verify the address family */
 
@@ -301,8 +298,6 @@ static int ieee802154_bind(FAR struct socket *psock,
   FAR const struct sockaddr_ieee802154_s *iaddr;
   FAR struct ieee802154_conn_s *conn;
   FAR struct radio_driver_s *radio;
-
-  DEBUGASSERT(psock != NULL && addr != NULL);
 
   /* Verify that a valid address has been provided */
 
@@ -400,10 +395,7 @@ static int ieee802154_getsockname(FAR struct socket *psock,
   FAR struct sockaddr_ieee802154_s tmp;
   socklen_t copylen;
 
-  DEBUGASSERT(psock != NULL && addr != NULL && addrlen != NULL);
-
   conn = psock->s_conn;
-  DEBUGASSERT(conn != NULL);
 
   /* Create a copy of the full address on the stack */
 
@@ -462,10 +454,7 @@ static int ieee802154_getpeername(FAR struct socket *psock,
   FAR struct sockaddr_ieee802154_s tmp;
   socklen_t copylen;
 
-  DEBUGASSERT(psock != NULL && addr != NULL && addrlen != NULL);
-
   conn = psock->s_conn;
-  DEBUGASSERT(conn != NULL);
 
   /* Create a copy of the full address on the stack */
 

--- a/net/local/local_accept.c
+++ b/net/local/local_accept.c
@@ -108,7 +108,6 @@ int local_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
 
   /* Some sanity checks */
 
-  DEBUGASSERT(psock && psock->s_conn);
   DEBUGASSERT(newsock && !newsock->s_conn);
 
   /* Is the socket a stream? */

--- a/net/local/local_bind.c
+++ b/net/local/local_bind.c
@@ -53,8 +53,7 @@ int psock_local_bind(FAR struct socket *psock,
   FAR const struct sockaddr_un *unaddr =
     (FAR const struct sockaddr_un *)addr;
 
-  DEBUGASSERT(psock != NULL && psock->s_conn != NULL &&
-              unaddr != NULL && unaddr->sun_family == AF_LOCAL);
+  DEBUGASSERT(unaddr->sun_family == AF_LOCAL);
 
   if (addrlen <= sizeof(sa_family_t) + 1)
     {

--- a/net/local/local_connect.c
+++ b/net/local/local_connect.c
@@ -245,7 +245,6 @@ int psock_local_connect(FAR struct socket *psock,
   struct stat buf;
   int ret;
 
-  DEBUGASSERT(psock && psock->s_conn);
   client = psock->s_conn;
 
   if (client->lc_state == LOCAL_STATE_ACCEPT ||

--- a/net/local/local_recvmsg.c
+++ b/net/local/local_recvmsg.c
@@ -509,7 +509,7 @@ ssize_t local_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
   FAR void *buf = msg->msg_iov->iov_base;
   size_t len = msg->msg_iov->iov_len;
 
-  DEBUGASSERT(psock && psock->s_conn && buf);
+  DEBUGASSERT(buf);
 
   /* Check for a stream socket */
 

--- a/net/local/local_sendmsg.c
+++ b/net/local/local_sendmsg.c
@@ -179,7 +179,7 @@ static ssize_t local_send(FAR struct socket *psock,
 
           /* Local TCP packet send */
 
-          DEBUGASSERT(psock && psock->s_conn && buf);
+          DEBUGASSERT(buf);
           peer = psock->s_conn;
 
           /* Verify that this is a connected peer socket and that it has

--- a/net/local/local_sockif.c
+++ b/net/local/local_sockif.c
@@ -261,8 +261,7 @@ static void local_addref(FAR struct socket *psock)
 {
   FAR struct local_conn_s *conn;
 
-  DEBUGASSERT(psock != NULL && psock->s_conn != NULL &&
-              psock->s_domain == PF_LOCAL);
+  DEBUGASSERT(psock->s_domain == PF_LOCAL);
 
   conn = psock->s_conn;
   DEBUGASSERT(conn->lc_crefs > 0 && conn->lc_crefs < 255);
@@ -368,9 +367,6 @@ static int local_getsockname(FAR struct socket *psock,
   FAR struct sockaddr_un *unaddr = (FAR struct sockaddr_un *)addr;
   FAR struct local_conn_s *conn;
 
-  DEBUGASSERT(psock != NULL && psock->s_conn != NULL &&
-              unaddr != NULL && addrlen != NULL);
-
   if (*addrlen < sizeof(sa_family_t))
     {
       /* This is apparently not an error */
@@ -466,9 +462,6 @@ static int local_getpeername(FAR struct socket *psock,
   FAR struct sockaddr_un *unaddr = (FAR struct sockaddr_un *)addr;
   FAR struct local_conn_s *conn;
   FAR struct local_conn_s *peer;
-
-  DEBUGASSERT(psock != NULL && psock->s_conn != NULL &&
-              unaddr != NULL && addrlen != NULL);
 
   if (*addrlen < sizeof(sa_family_t))
     {
@@ -573,8 +566,7 @@ static int local_getpeername(FAR struct socket *psock,
 static int local_getsockopt(FAR struct socket *psock, int level, int option,
                             FAR void *value, FAR socklen_t *value_len)
 {
-  DEBUGASSERT(psock != NULL && psock->s_conn != NULL &&
-              psock->s_domain == PF_LOCAL);
+  DEBUGASSERT(psock->s_domain == PF_LOCAL);
 
 #ifdef CONFIG_NET_LOCAL_SCM
   if (level == SOL_SOCKET && option == SO_PEERCRED)
@@ -1018,8 +1010,7 @@ errout:
 
 static int local_shutdown(FAR struct socket *psock, int how)
 {
-  DEBUGASSERT(psock != NULL && psock->s_conn != NULL &&
-              psock->s_domain == PF_LOCAL);
+  DEBUGASSERT(psock->s_domain == PF_LOCAL);
 
   switch (psock->s_type)
     {

--- a/net/netlink/netlink_sockif.c
+++ b/net/netlink/netlink_sockif.c
@@ -204,8 +204,6 @@ static void netlink_addref(FAR struct socket *psock)
 {
   FAR struct netlink_conn_s *conn;
 
-  DEBUGASSERT(psock != NULL && psock->s_conn != NULL);
-
   conn = psock->s_conn;
   DEBUGASSERT(conn->crefs > 0 && conn->crefs < 255);
   conn->crefs++;
@@ -247,8 +245,7 @@ static int netlink_bind(FAR struct socket *psock,
   FAR struct sockaddr_nl *nladdr;
   FAR struct netlink_conn_s *conn;
 
-  DEBUGASSERT(psock != NULL && psock->s_conn != NULL && addr != NULL &&
-              addrlen >= sizeof(struct sockaddr_nl));
+  DEBUGASSERT(addrlen >= sizeof(struct sockaddr_nl));
 
   /* Save the address information in the connection structure */
 
@@ -290,8 +287,7 @@ static int netlink_getsockname(FAR struct socket *psock,
   FAR struct sockaddr_nl *nladdr;
   FAR struct netlink_conn_s *conn;
 
-  DEBUGASSERT(psock != NULL && psock->s_conn != NULL && addr != NULL &&
-              addrlen != NULL && *addrlen >= sizeof(struct sockaddr_nl));
+  DEBUGASSERT(*addrlen >= sizeof(struct sockaddr_nl));
 
   conn = psock->s_conn;
 
@@ -343,8 +339,7 @@ static int netlink_getpeername(FAR struct socket *psock,
   FAR struct sockaddr_nl *nladdr;
   FAR struct netlink_conn_s *conn;
 
-  DEBUGASSERT(psock != NULL && psock->s_conn != NULL && addr != NULL &&
-              addrlen != NULL && *addrlen >= sizeof(struct sockaddr_nl));
+  DEBUGASSERT(*addrlen >= sizeof(struct sockaddr_nl));
 
   conn = psock->s_conn;
 
@@ -386,8 +381,7 @@ static int netlink_connect(FAR struct socket *psock,
   FAR struct sockaddr_nl *nladdr;
   FAR struct netlink_conn_s *conn;
 
-  DEBUGASSERT(psock != NULL && psock->s_conn != NULL && addr != NULL &&
-              addrlen >= sizeof(struct sockaddr_nl));
+  DEBUGASSERT(addrlen >= sizeof(struct sockaddr_nl));
 
   /* Save the address information in the connection structure */
 
@@ -473,7 +467,6 @@ static int netlink_poll(FAR struct socket *psock, FAR struct pollfd *fds,
   FAR struct netlink_conn_s *conn;
   int ret = OK;
 
-  DEBUGASSERT(psock != NULL && psock->s_conn != NULL);
   conn = psock->s_conn;
 
   /* Check if we are setting up or tearing down the poll */
@@ -582,8 +575,6 @@ static ssize_t netlink_sendmsg(FAR struct socket *psock,
   struct sockaddr_nl nladdr;
   int ret;
 
-  DEBUGASSERT(psock != NULL && psock->s_conn != NULL && buf != NULL);
-
   /* Validity check, only single iov supported */
 
   if (msg->msg_iovlen != 1)
@@ -665,7 +656,6 @@ static ssize_t netlink_recvmsg(FAR struct socket *psock,
   FAR struct netlink_response_s *entry;
   FAR struct socket_conn_s *conn;
 
-  DEBUGASSERT(psock != NULL && psock->s_conn != NULL && buf != NULL);
   DEBUGASSERT(from == NULL ||
               (fromlen != NULL && *fromlen >= sizeof(struct sockaddr_nl)));
 

--- a/net/pkt/pkt_sockif.c
+++ b/net/pkt/pkt_sockif.c
@@ -190,8 +190,7 @@ static void pkt_addref(FAR struct socket *psock)
 {
   FAR struct pkt_conn_s *conn;
 
-  DEBUGASSERT(psock != NULL && psock->s_conn != NULL &&
-              (psock->s_type == SOCK_RAW || psock->s_type == SOCK_CTRL));
+  DEBUGASSERT(psock->s_type == SOCK_RAW || psock->s_type == SOCK_CTRL);
 
   conn = psock->s_conn;
   DEBUGASSERT(conn->crefs > 0 && conn->crefs < 255);

--- a/net/sixlowpan/sixlowpan_tcpsend.c
+++ b/net/sixlowpan/sixlowpan_tcpsend.c
@@ -591,8 +591,6 @@ static int sixlowpan_send_packet(FAR struct socket *psock,
   struct sixlowpan_send_s sinfo;
 
   ninfo("len=%lu timeout=%u\n", (unsigned long)len, timeout);
-  DEBUGASSERT(psock != NULL && dev != NULL && conn != NULL && buf != NULL &&
-              destmac != NULL);
 
   memset(&sinfo, 0, sizeof(struct sixlowpan_send_s));
 
@@ -718,7 +716,6 @@ ssize_t psock_6lowpan_tcp_send(FAR struct socket *psock, FAR const void *buf,
   ninfo("buflen %lu\n", (unsigned long)buflen);
   sixlowpan_dumpbuffer("Outgoing TCP payload", buf, buflen);
 
-  DEBUGASSERT(psock != NULL && psock->s_conn != NULL);
   DEBUGASSERT(psock->s_type == SOCK_STREAM);
 
   /* Make sure that this is a valid socket */

--- a/net/sixlowpan/sixlowpan_udpsend.c
+++ b/net/sixlowpan/sixlowpan_udpsend.c
@@ -157,7 +157,7 @@ ssize_t psock_6lowpan_udp_sendto(FAR struct socket *psock,
 
   ninfo("buflen %lu\n", (unsigned long)buflen);
 
-  DEBUGASSERT(psock != NULL && psock->s_conn != NULL && to != NULL);
+  DEBUGASSERT(to != NULL);
   DEBUGASSERT(psock->s_type == SOCK_DGRAM);
 
   sixlowpan_dumpbuffer("Outgoing UDP payload", buf, buflen);
@@ -336,7 +336,6 @@ ssize_t psock_6lowpan_udp_send(FAR struct socket *psock, FAR const void *buf,
 
   ninfo("buflen %lu\n", (unsigned long)buflen);
 
-  DEBUGASSERT(psock != NULL && psock->s_conn != NULL);
   DEBUGASSERT(psock->s_type == SOCK_DGRAM);
 
   sixlowpan_dumpbuffer("Outgoing UDP payload", buf, buflen);

--- a/net/tcp/tcp_accept.c
+++ b/net/tcp/tcp_accept.c
@@ -217,8 +217,6 @@ int psock_tcp_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
   struct accept_s state;
   int ret;
 
-  DEBUGASSERT(psock && newconn);
-
   /* Check the backlog to see if there is a connection already pending for
    * this listener.
    */

--- a/net/tcp/tcp_close.c
+++ b/net/tcp/tcp_close.c
@@ -220,7 +220,6 @@ static inline int tcp_close_disconnect(FAR struct socket *psock)
   net_lock();
 
   conn = psock->s_conn;
-  DEBUGASSERT(conn != NULL);
 
   /* Discard our reference to the connection */
 

--- a/net/tcp/tcp_getsockopt.c
+++ b/net/tcp/tcp_getsockopt.c
@@ -85,8 +85,7 @@ int tcp_getsockopt(FAR struct socket *psock, int option,
   FAR struct tcp_conn_s *conn;
   int ret;
 
-  DEBUGASSERT(psock != NULL && value != NULL && value_len != NULL &&
-              psock->s_conn != NULL);
+  DEBUGASSERT(value != NULL && value_len != NULL);
   conn = psock->s_conn;
 
   /* All of the TCP protocol options apply only TCP sockets.  The sockets

--- a/net/tcp/tcp_monitor.c
+++ b/net/tcp/tcp_monitor.c
@@ -197,8 +197,6 @@ static uint16_t tcp_monitor_event(FAR struct net_driver_s *dev,
 
 static void tcp_shutdown_monitor(FAR struct tcp_conn_s *conn, uint16_t flags)
 {
-  DEBUGASSERT(conn);
-
   /* Perform callbacks to assure that all sockets, including dup'ed copies,
    * are informed of the loss of connection event.
    */
@@ -248,7 +246,6 @@ int tcp_start_monitor(FAR struct socket *psock)
   FAR struct tcp_conn_s *conn;
   bool nonblock_conn;
 
-  DEBUGASSERT(psock != NULL && psock->s_conn != NULL);
   conn = psock->s_conn;
 
   net_lock();

--- a/net/tcp/tcp_setsockopt.c
+++ b/net/tcp/tcp_setsockopt.c
@@ -75,7 +75,6 @@ int tcp_setsockopt(FAR struct socket *psock, int option,
   FAR struct tcp_conn_s *conn;
   int ret = OK;
 
-  DEBUGASSERT(psock != NULL && value != NULL && psock->s_conn != NULL);
   conn = psock->s_conn;
 
   /* All of the TCP protocol options apply only TCP sockets.  The sockets

--- a/net/tcp/tcp_txdrain.c
+++ b/net/tcp/tcp_txdrain.c
@@ -92,7 +92,6 @@ int tcp_txdrain(FAR struct socket *psock, unsigned int timeout)
   sem_t waitsem;
   int ret;
 
-  DEBUGASSERT(psock != NULL && psock->s_conn != NULL);
   DEBUGASSERT(psock->s_type == SOCK_STREAM);
 
   conn = psock->s_conn;

--- a/net/udp/udp_sendto_buffered.c
+++ b/net/udp/udp_sendto_buffered.c
@@ -541,7 +541,6 @@ ssize_t psock_udp_sendto(FAR struct socket *psock, FAR const void *buf,
   /* Get the underlying the UDP connection structure.  */
 
   conn = psock->s_conn;
-  DEBUGASSERT(conn);
 
   /* The length of a datagram to be up to 65,535 octets */
 

--- a/net/udp/udp_sendto_unbuffered.c
+++ b/net/udp/udp_sendto_unbuffered.c
@@ -101,7 +101,6 @@ static inline void sendto_ipselect(FAR struct net_driver_s *dev,
                                    FAR struct sendto_s *pstate)
 {
   FAR struct udp_conn_s *conn = pstate->st_conn;
-  DEBUGASSERT(conn);
 
   /* Which domain the socket support */
 

--- a/net/udp/udp_txdrain.c
+++ b/net/udp/udp_txdrain.c
@@ -92,7 +92,6 @@ int udp_txdrain(FAR struct socket *psock, unsigned int timeout)
   sem_t waitsem;
   int ret;
 
-  DEBUGASSERT(psock != NULL && psock->s_conn != NULL);
   DEBUGASSERT(psock->s_type == SOCK_DGRAM);
 
   conn = psock->s_conn;

--- a/net/usrsock/usrsock_accept.c
+++ b/net/usrsock/usrsock_accept.c
@@ -227,8 +227,6 @@ int usrsock_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
   socklen_t outaddrlen = 0;
   int ret;
 
-  DEBUGASSERT(conn);
-
   if (addrlen)
     {
       if (*addrlen > 0 && addr == NULL)

--- a/net/usrsock/usrsock_bind.c
+++ b/net/usrsock/usrsock_bind.c
@@ -156,8 +156,6 @@ int usrsock_bind(FAR struct socket *psock,
 
   int ret;
 
-  DEBUGASSERT(conn);
-
   net_lock();
 
   if (conn->state == USRSOCK_CONN_STATE_UNINITIALIZED ||

--- a/net/usrsock/usrsock_connect.c
+++ b/net/usrsock/usrsock_connect.c
@@ -154,8 +154,6 @@ int usrsock_connect(FAR struct socket *psock,
 
   int ret;
 
-  DEBUGASSERT(conn);
-
   net_lock();
 
   if (conn->state == USRSOCK_CONN_STATE_UNINITIALIZED ||

--- a/net/usrsock/usrsock_listen.c
+++ b/net/usrsock/usrsock_listen.c
@@ -148,8 +148,6 @@ int usrsock_listen(FAR struct socket *psock, int backlog)
 
   int ret;
 
-  DEBUGASSERT(conn);
-
   net_lock();
 
   if (conn->state == USRSOCK_CONN_STATE_UNINITIALIZED ||

--- a/net/usrsock/usrsock_recvmsg.c
+++ b/net/usrsock/usrsock_recvmsg.c
@@ -220,8 +220,6 @@ ssize_t usrsock_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
   socklen_t outaddrlen = 0;
   ssize_t ret;
 
-  DEBUGASSERT(conn);
-
   if (fromlen)
     {
       if (*fromlen > 0 && from == NULL)

--- a/net/usrsock/usrsock_sendmsg.c
+++ b/net/usrsock/usrsock_sendmsg.c
@@ -209,8 +209,6 @@ ssize_t usrsock_sendmsg(FAR struct socket *psock,
 
   ssize_t ret;
 
-  DEBUGASSERT(conn);
-
   net_lock();
 
   if (conn->state == USRSOCK_CONN_STATE_UNINITIALIZED ||

--- a/net/usrsock/usrsock_setsockopt.c
+++ b/net/usrsock/usrsock_setsockopt.c
@@ -167,8 +167,6 @@ int usrsock_setsockopt(FAR struct socket *psock, int level, int option,
 
   int ret;
 
-  DEBUGASSERT(conn);
-
   /* SO_[RCV|SND]TIMEO have to be handled locally to break the block i/o */
 
   if (level == SOL_SOCKET && (option == SO_TYPE ||

--- a/net/usrsock/usrsock_sockif.c
+++ b/net/usrsock/usrsock_sockif.c
@@ -158,8 +158,6 @@ static void usrsock_sockif_addref(FAR struct socket *psock)
 {
   FAR struct usrsock_conn_s *conn;
 
-  DEBUGASSERT(psock != NULL && psock->s_conn != NULL);
-
   conn = psock->s_conn;
   DEBUGASSERT(conn->crefs > 0 && conn->crefs < 255);
   conn->crefs++;


### PR DESCRIPTION
## Summary

net/assert: remove all unnecessary check for psock/conn

Since inet/socket layer already contains sanity checks, so remove unnecessary lower half checks

Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

ci-check