### PR TITLE
usbdev: Use BOARD_USBDEV_SERIALSTR config directly

### DIFF
--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -4429,5 +4429,7 @@ config BOARDCTL_IOCTL
 endif # BOARDCTL
 
 config BOARD_USBDEV_SERIALSTR
-	bool
+	bool "Board-specific usbdev serial string"
 	default n
+	---help---
+		Use board unique serial number to iSerialNumber in the device descriptor.

--- a/drivers/usbdev/Kconfig
+++ b/drivers/usbdev/Kconfig
@@ -227,17 +227,10 @@ config COMPOSITE_PRODUCTSTR
 	---help---
 		The product ID code/string
 
-config COMPOSITE_BOARD_SERIALSTR
-	bool "Enable board unique ID to composite serial string"
-	default n
-	select BOARD_USBDEV_SERIALSTR
-	---help---
-		Use board unique serial number to iSerialNumber in the device descriptor.
-
 config COMPOSITE_SERIALSTR
 	string "Composite serial string"
 	default "001"
-	depends on !COMPOSITE_BOARD_SERIALSTR
+	depends on !BOARD_USBDEV_SERIALSTR
 	---help---
 		Device serial number string
 
@@ -365,13 +358,6 @@ config PL2303_PRODUCTID
 config PL2303_VENDORSTR
 	string "Vendor string"
 	default "NuttX"
-
-config PL2303_BOARD_SERIALSTR
-	bool "Enable board unique ID to PL2303 serial string"
-	default n
-	select BOARD_USBDEV_SERIALSTR
-	---help---
-		Use board unique serial number to iSerialNumber in the device descriptor.
 
 config PL2303_PRODUCTSTR
 	string "Product string"
@@ -598,13 +584,6 @@ config CDCACM_PRODUCTSTR
 	string "Product string"
 	default "CDC/ACM Serial"
 
-config CDCACM_BOARD_SERIALSTR
-	bool "Enable board unique ID to CDC/ACM serial string"
-	default n
-	select BOARD_USBDEV_SERIALSTR
-	---help---
-		Use board unique serial number to iSerialNumber in the device descriptor.
-
 endif # !CDCACM_COMPOSITE
 endif # CDCACM
 
@@ -723,17 +702,10 @@ config USBADB_PRODUCTSTR
 	string "Product string"
 	default "Debug Bridge"
 
-config USBADB_BOARD_SERIALSTR
-	bool "Enable board unique ID to USBADB serial string"
-	default n
-	select BOARD_USBDEV_SERIALSTR
-	---help---
-		Use board unique serial number to iSerialNumber in the device descriptor.
-
 config USBADB_SERIALSTR
 	string "Serial string"
 	default "1234"
-	depends on !USBADB_BOARD_SERIALSTR
+	depends on !BOARD_USBDEV_SERIALSTR
 
 endif # !USBADB_COMPOSITE
 
@@ -908,13 +880,6 @@ config USBMSC_PRODUCTSTR
 	string "Mass storage product string"
 	default "Mass Storage"
 
-config USBMSC_BOARD_SERIALSTR
-	bool "Enable board unique ID to mass storage serial string"
-	default n
-	select BOARD_USBDEV_SERIALSTR
-	---help---
-		Use board unique serial number to iSerialNumber in the device descriptor.
-
 endif # !USBMSC_COMPOSITE
 
 config USBMSC_VERSIONNO
@@ -1012,17 +977,10 @@ config RNDIS_PRODUCTSTR
 	string "RNDIS product string"
 	default "RNDIS gadget"
 
-config RNDIS_BOARD_SERIALSTR
-	bool "Enable board unique ID to RNDIS serial string"
-	default n
-	select BOARD_USBDEV_SERIALSTR
-	---help---
-		Use board unique serial number to iSerialNumber in the device descriptor.
-
 config RNDIS_SERIALSTR
 	string "RNDIS serial string"
 	default "1234"
-	depends on !RNDIS_BOARD_SERIALSTR
+	depends on !BOARD_USBDEV_SERIALSTR
 
 config RNDIS_VERSIONNO
 	hex "RNDIS Version Number"
@@ -1248,13 +1206,6 @@ config CDCECM_VENDORSTR
 config CDCECM_PRODUCTSTR
 	string "Product string"
 	default "CDC/ECM Ethernet"
-
-config CDCECM_BOARD_SERIALSTR
-	bool "Enable board unique ID to CDC/ECM serial string"
-	default n
-	select BOARD_USBDEV_SERIALSTR
-	---help---
-		Use board unique serial number to iSerialNumber in the device descriptor.
 
 endif # !CDCECM_COMPOSITE
 endif # CDCECM

--- a/drivers/usbdev/adb.c
+++ b/drivers/usbdev/adb.c
@@ -40,7 +40,7 @@
 #include <nuttx/usb/adb.h>
 #include <nuttx/fs/fs.h>
 
-#ifdef CONFIG_USBADB_BOARD_SERIALSTR
+#ifdef CONFIG_BOARD_USBDEV_SERIALSTR
 #include <nuttx/board.h>
 #endif
 
@@ -837,7 +837,7 @@ static int usbclass_mkstrdesc(uint8_t id, FAR struct usb_strdesc_s *strdesc)
       break;
 
     case USBADB_SERIALSTRID:
-#ifdef CONFIG_USBADB_BOARD_SERIALSTR
+#ifdef CONFIG_BOARD_USBDEV_SERIALSTR
       str = board_usbdev_serialstr();
 #else
       str = CONFIG_USBADB_SERIALSTR;

--- a/drivers/usbdev/cdcacm_desc.c
+++ b/drivers/usbdev/cdcacm_desc.c
@@ -36,7 +36,7 @@
 #include <nuttx/usb/cdcacm.h>
 #include <nuttx/usb/usbdev_trace.h>
 
-#ifdef CONFIG_CDCACM_BOARD_SERIALSTR
+#ifdef CONFIG_BOARD_USBDEV_SERIALSTR
 #include <nuttx/board.h>
 #endif
 
@@ -148,7 +148,7 @@ int cdcacm_mkstrdesc(uint8_t id, FAR struct usb_strdesc_s *strdesc)
       break;
 
     case CDCACM_SERIALSTRID:
-#ifdef CONFIG_CDCACM_BOARD_SERIALSTR
+#ifdef CONFIG_BOARD_USBDEV_SERIALSTR
       str = board_usbdev_serialstr();
 #else
       str = CONFIG_CDCACM_SERIALSTR;

--- a/drivers/usbdev/cdcecm.c
+++ b/drivers/usbdev/cdcecm.c
@@ -54,7 +54,7 @@
 #  include <nuttx/net/pkt.h>
 #endif
 
-#ifdef CONFIG_CDCECM_BOARD_SERIALSTR
+#ifdef CONFIG_BOARD_USBDEV_SERIALSTR
 #include <nuttx/board.h>
 #endif
 
@@ -1173,7 +1173,7 @@ static int cdcecm_mkstrdesc(uint8_t id, FAR struct usb_strdesc_s *strdesc)
       break;
 
     case CDCECM_SERIALSTRID:
-#ifdef CONFIG_CDCECM_BOARD_SERIALSTR
+#ifdef CONFIG_BOARD_USBDEV_SERIALSTR
       str = board_usbdev_serialstr();
 #else
       str = "0";

--- a/drivers/usbdev/composite_desc.c
+++ b/drivers/usbdev/composite_desc.c
@@ -32,7 +32,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#ifdef CONFIG_COMPOSITE_BOARD_SERIALSTR
+#ifdef CONFIG_BOARD_USBDEV_SERIALSTR
 #include <nuttx/board.h>
 #endif
 
@@ -183,7 +183,7 @@ static const struct usb_qualdesc_s g_qualdesc =
 
 const char g_compvendorstr[]  = CONFIG_COMPOSITE_VENDORSTR;
 const char g_compproductstr[] = CONFIG_COMPOSITE_PRODUCTSTR;
-#ifndef CONFIG_COMPOSITE_BOARD_SERIALSTR
+#ifndef CONFIG_BOARD_USBDEV_SERIALSTR
 const char g_compserialstr[]  = CONFIG_COMPOSITE_SERIALSTR;
 #endif
 
@@ -233,7 +233,7 @@ int composite_mkstrdesc(uint8_t id, FAR struct usb_strdesc_s *strdesc)
       break;
 
     case COMPOSITE_SERIALSTRID:
-#ifdef CONFIG_COMPOSITE_BOARD_SERIALSTR
+#ifdef CONFIG_BOARD_USBDEV_SERIALSTR
       str = board_usbdev_serialstr();
 #else
       str = g_compserialstr;

--- a/drivers/usbdev/pl2303.c
+++ b/drivers/usbdev/pl2303.c
@@ -48,7 +48,7 @@
 #include <nuttx/usb/usbdev.h>
 #include <nuttx/usb/usbdev_trace.h>
 
-#ifdef CONFIG_PL2303_BOARD_SERIALSTR
+#ifdef CONFIG_BOARD_USBDEV_SERIALSTR
 #include <nuttx/board.h>
 #endif
 
@@ -791,7 +791,7 @@ static int usbclass_mkstrdesc(uint8_t id, FAR struct usb_strdesc_s *strdesc)
       break;
 
     case PL2303_SERIALSTRID:
-#ifdef CONFIG_PL2303_BOARD_SERIALSTR
+#ifdef CONFIG_BOARD_USBDEV_SERIALSTR
       str = board_usbdev_serialstr();
 #else
       str = CONFIG_PL2303_SERIALSTR;

--- a/drivers/usbdev/rndis.c
+++ b/drivers/usbdev/rndis.c
@@ -50,7 +50,7 @@
 #include <nuttx/usb/rndis.h>
 #include <nuttx/wqueue.h>
 
-#ifdef CONFIG_RNDIS_BOARD_SERIALSTR
+#ifdef CONFIG_BOARD_USBDEV_SERIALSTR
 #include <nuttx/board.h>
 #endif
 
@@ -1839,7 +1839,7 @@ static int usbclass_mkstrdesc(uint8_t id, FAR struct usb_strdesc_s *strdesc)
         break;
 
       case RNDIS_SERIALSTRID:
-#ifdef CONFIG_RNDIS_BOARD_SERIALSTR
+#ifdef CONFIG_BOARD_USBDEV_SERIALSTR
         str = board_usbdev_serialstr();
 #else
         str = CONFIG_RNDIS_SERIALSTR;

--- a/drivers/usbdev/usbmsc.h
+++ b/drivers/usbdev/usbmsc.h
@@ -458,7 +458,7 @@ extern "C"
 #ifndef CONFIG_USBMSC_COMPOSITE
 EXTERN const char g_mscvendorstr[];
 EXTERN const char g_mscproductstr[];
-#ifndef CONFIG_USBMSC_BOARD_SERIALSTR
+#ifndef CONFIG_BOARD_USBDEV_SERIALSTR
 EXTERN const char g_mscserialstr[];
 #endif
 
@@ -469,13 +469,13 @@ EXTERN const char g_mscserialstr[];
 #else
 EXTERN const char g_compvendorstr[];
 EXTERN const char g_compproductstr[];
-#ifndef CONFIG_COMPOSITE_BOARD_SERIALSTR
+#ifndef CONFIG_BOARD_USBDEV_SERIALSTR
 EXTERN const char g_compserialstr[];
 #endif
 
 #define g_mscvendorstr  g_compvendorstr
 #define g_mscproductstr g_compproductstr
-#ifndef CONFIG_USBMSC_BOARD_SERIALSTR
+#ifndef CONFIG_BOARD_USBDEV_SERIALSTR
 #define g_mscserialstr  g_compserialstr
 #endif
 #endif

--- a/drivers/usbdev/usbmsc_desc.c
+++ b/drivers/usbdev/usbmsc_desc.c
@@ -33,7 +33,7 @@
 #include <nuttx/usb/usb.h>
 #include <nuttx/usb/usbdev_trace.h>
 
-#ifdef CONFIG_USBMSC_BOARD_SERIALSTR
+#ifdef CONFIG_BOARD_USBDEV_SERIALSTR
 #include <nuttx/board.h>
 #endif
 
@@ -107,7 +107,7 @@ static const struct usb_qualdesc_s g_qualdesc =
 #ifndef CONFIG_USBMSC_COMPOSITE
 const char g_mscvendorstr[]  = CONFIG_USBMSC_VENDORSTR;
 const char g_mscproductstr[] = CONFIG_USBMSC_PRODUCTSTR;
-#ifndef CONFIG_USBMSC_BOARD_SERIALSTR
+#ifndef CONFIG_BOARD_USBDEV_SERIALSTR
 const char g_mscserialstr[]  = CONFIG_USBMSC_SERIALSTR;
 #endif
 #endif
@@ -159,7 +159,7 @@ int usbmsc_mkstrdesc(uint8_t id, struct FAR usb_strdesc_s *strdesc)
       break;
 
     case USBMSC_SERIALSTRID:
-#ifdef CONFIG_USBMSC_BOARD_SERIALSTR
+#ifdef CONFIG_BOARD_USBDEV_SERIALSTR
       str = board_usbdev_serialstr();
 #else
       str = g_mscserialstr;


### PR DESCRIPTION
## Summary

A usbdev has only one serial string, so use a unique macro to control it.
Delete the configurations for COMPOSITE_BOARD_SERIALSTR, PL2303_BOARD_SERIALSTR, CDCACM_BOARD_SERIALSTR, USBADB_BOARD_SERIALSTR, USBMSC_BOARD_SERIALSTR, and RNDIS_BOARD_SERIALSTR, and use BOARD_USBDEV_SERIALSTR for unification.

## Impact

For boards that enable board serial string using COMPOSITE_BOARD_SERIALSTR, PL2303_BOARD_SERIALSTR, CDCACM_BOARD_SERIALSTR, USBADB_BOARD_SERIALSTR, USBMSC_BOARD_SERIALSTR, and RNDIS_BOARD_SERIALSTR, they need to be replaced with BOARD_USBDEV_SERIALSTR.

## Testing

sim:usbdev and bes board