### PR TITLE
samv7: include mpu.h in sam_boot_image.c to avoid compilation warnings

### DIFF
--- a/boards/arm/samv7/common/src/sam_boot_image.c
+++ b/boards/arm/samv7/common/src/sam_boot_image.c
@@ -36,6 +36,10 @@
 #include "arm_internal.h"
 #include "barriers.h"
 
+#ifdef CONFIG_ARM_MPU
+#  include "mpu.h"
+#endif
+
 #ifdef CONFIG_BOARDCTL_BOOT_IMAGE
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
Header file mpu.h was not included although mpu_control() function was used.

## Impact
Fix compilation warnings.

## Testing
CI pass.

