### PR TITLE
video/fb: add xres and yres for fb overlay

### DIFF
--- a/include/nuttx/video/fb.h
+++ b/include/nuttx/video/fb.h
@@ -546,6 +546,8 @@ struct fb_overlayinfo_s
   fb_coord_t stride;          /* Length of a line in bytes */
   uint8_t    overlay;         /* Overlay number */
   uint8_t    bpp;             /* Bits per pixel */
+  uint32_t   xres;            /* Horizontal resolution in pixel columns */
+  uint32_t   yres;            /* Vertical resolution in pixel rows */
   uint32_t   xres_virtual;    /* Virtual Horizontal resolution in pixel columns */
   uint32_t   yres_virtual;    /* Virtual Vertical resolution in pixel rows */
   uint32_t   xoffset;         /* Offset from virtual to visible resolution */


### PR DESCRIPTION
## Summary

xres and yres of video overlay buffer may not same as primay framebuffer. so add it to check the framebuffer count of overlay

## Impact

fb overlay

## Testing

internal test