### PR TITLE
usrsock_server: fix coverity for recvfrom handle

### DIFF
--- a/drivers/usrsock/usrsock_rpmsg_server.c
+++ b/drivers/usrsock/usrsock_rpmsg_server.c
@@ -642,7 +642,7 @@ static int usrsock_rpmsg_recvfrom_handler(FAR struct rpmsg_endpoint *ept,
             events, req->head.xid, totlen, iov[i].iov_len);
     }
 
-  if (retr >= 0 && events == 0)
+  if (retr >= 0 && (ret > 0 || ret == -EAGAIN) && events == 0)
     {
       usrsock_rpmsg_poll_setup(&priv->pfds[req->usockid],
                                priv->pfds[req->usockid].events | POLLIN);


### PR DESCRIPTION
## Summary
req->usockid may not be in a valid range when ret less than zero and not -EAGAIN.
## Impact

## Testing
Cortex-M33
