### PR TITLE
risc-v/mpfs: clear L2 before use

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_head.S
+++ b/arch/risc-v/src/mpfs/mpfs_head.S
@@ -166,6 +166,16 @@ __start:
 
 .continue_boot:
 
+  /* L2 needs to be zeroed before ECC (error correction) is enabled later. */
+
+  la  a4, __l2lim_start
+  la  a5, __l2lim_end
+
+.clear_l2lim:
+  sd   x0, 0(a4)
+  add  a4, a4, 8
+  blt  a4, a5, .clear_l2lim
+
   /* Clear PMP */
 
   csrw pmpcfg0, zero

--- a/boards/risc-v/mpfs/icicle/scripts/ld-envm-opensbi.script
+++ b/boards/risc-v/mpfs/icicle/scripts/ld-envm-opensbi.script
@@ -32,6 +32,9 @@ ENTRY(_stext)
 EXTERN(__start)
 SECTIONS
 {
+    PROVIDE(__l2lim_start = ORIGIN(l2lim));
+    PROVIDE(__l2lim_end   = ORIGIN(l2lim) + LENGTH(l2lim));
+
     .text.sbi : {
       */sbi*
       */riscv_atomic*

--- a/boards/risc-v/mpfs/icicle/scripts/ld-envm.script
+++ b/boards/risc-v/mpfs/icicle/scripts/ld-envm.script
@@ -35,6 +35,9 @@ ENTRY(_stext)
 EXTERN(__start)
 SECTIONS
 {
+    PROVIDE(__l2lim_start = ORIGIN(lim));
+    PROVIDE(__l2lim_end   = ORIGIN(lim) + LENGTH(lim));
+
     .text : {
         _stext = ABSOLUTE(.);
         *(.start .start.*)


### PR DESCRIPTION
SiFive document: "ECC Error Handling Guide" states:

"Any SRAM block or cache memory containing ECC functionality needs to be initialized prior to use. ECC will correct defective bits based on memory contents, so if memory is not first initialized to a known state, then ECC will not operate as expected. It is recommended to use a DMA, if available, to write the entire SRAM or cache to zeros prior to enabling ECC reporting. If no DMA is present, use store instructions issued from the processor."

Clean the cache at this early stage so no ECC errors will be flooding later.

## Summary

If ECC reporting is turned on, it initially reports many pointless errors; for example if that's enabled in Linux. Uninitialized L2LIM area is where the trouble comes from.

## Impact

L2 ECC reporting enabled, all Polarfire devices

## Testing

Throughout testing with several boards that had ECC reporting turned on in Linux
