### PR TITLE
ELF Loader

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -401,6 +401,12 @@ config ARCH_HAVE_TEXT_HEAP
 	---help---
 		Special memory region for dynamic code loading
 
+config ARCH_HAVE_COPY_SECTION
+	bool
+	default n
+	---help---
+		Section copying for dynamic code loading
+
 config ARCH_HAVE_MULTICPU
 	bool
 	default n
@@ -622,6 +628,15 @@ menuconfig ARCH_ADDRENV
 	---help---
 		Support per-task address environments using the MMU... i.e., support
 		"processes"
+
+config ARCH_USE_COPY_SECTION
+	bool "Enable arch copy section by self for dynamic code loading"
+	default n
+	depends on ARCH_HAVE_COPY_SECTION
+	---help---
+		This option enables architecture-specific memory copy for
+		dynamic code loading. For example, Ambiq has MRAM regions
+		for instruction which can't load by the memcpy directly.
 
 if ARCH_ADDRENV && ARCH_NEED_ADDRENV_MAPPING
 

--- a/binfmt/elf.c
+++ b/binfmt/elf.c
@@ -142,6 +142,23 @@ static void elf_dumploadinfo(FAR struct elf_loadinfo_s *loadinfo)
   binfo("  e_shnum:      %d\n",    loadinfo->ehdr.e_shnum);
   binfo("  e_shstrndx:   %d\n",    loadinfo->ehdr.e_shstrndx);
 
+  if (loadinfo->phdr && loadinfo->ehdr.e_phnum > 0)
+    {
+      for (i = 0; i < loadinfo->ehdr.e_phnum; i++)
+        {
+          FAR Elf_Phdr *phdr = &loadinfo->phdr[i];
+          binfo("Programs %d:\n", i);
+          binfo("  p_type:       %08jx\n", (uintmax_t)phdr->p_type);
+          binfo("  p_offset:     %08jx\n", (uintmax_t)phdr->p_offset);
+          binfo("  p_vaddr:      %08jx\n", (uintmax_t)phdr->p_vaddr);
+          binfo("  p_paddr:      %08jx\n", (uintmax_t)phdr->p_paddr);
+          binfo("  p_filesz:     %08jx\n", (uintmax_t)phdr->p_filesz);
+          binfo("  p_memsz:      %08jx\n", (uintmax_t)phdr->p_memsz);
+          binfo("  p_flags:      %08jx\n", (uintmax_t)phdr->p_flags);
+          binfo("  p_align:      %08x\n",  phdr->p_align);
+        }
+    }
+
   if (loadinfo->shdr && loadinfo->ehdr.e_shnum > 0)
     {
       for (i = 0; i < loadinfo->ehdr.e_shnum; i++)

--- a/binfmt/libelf/Kconfig
+++ b/binfmt/libelf/Kconfig
@@ -73,3 +73,11 @@ config ELF_COREDUMP
 		The memory state embeds a snapshot of all segments mapped in the
 		memory space of the program. The CPU state contains register values
 		when the core dump has been generated.
+
+config ELF_LOADTO_LMA
+	bool "ELF load sections to LMA"
+	default n
+	---help---
+		Load all section to LMA not VMA, so the startup code(e.g. start.S) need
+		relocate .data section to the final address(VMA) and zero .bss section
+		by self.

--- a/binfmt/libelf/libelf.h
+++ b/binfmt/libelf/libelf.h
@@ -66,6 +66,20 @@ int elf_read(FAR struct elf_loadinfo_s *loadinfo, FAR uint8_t *buffer,
              size_t readsize, off_t offset);
 
 /****************************************************************************
+ * Name: elf_loadphdrs
+ *
+ * Description:
+ *   Loads program headers into memory.
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int elf_loadphdrs(FAR struct elf_loadinfo_s *loadinfo);
+
+/****************************************************************************
  * Name: elf_loadshdrs
  *
  * Description:

--- a/binfmt/libelf/libelf_load.c
+++ b/binfmt/libelf/libelf_load.c
@@ -123,6 +123,41 @@ static void elf_elfsize(FAR struct elf_loadinfo_s *loadinfo)
   loadinfo->datasize = datasize;
 }
 
+#ifdef CONFIG_ELF_LOADTO_LMA
+/****************************************************************************
+ * Name: elf_vma2lma
+ *
+ * Description:
+ *   Convert section`s VMA to LMA according to PhysAddr(p_paddr) of
+ *   Program Header.
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+static int elf_vma2lma(FAR struct elf_loadinfo_s *loadinfo,
+                       FAR Elf_Shdr *shdr, FAR Elf_Addr *lma)
+{
+  int i;
+
+  for (i = 0; i < loadinfo->ehdr.e_phnum; i++)
+    {
+      FAR Elf_Phdr *phdr = &loadinfo->phdr[i];
+
+      if (shdr->sh_addr >= phdr->p_vaddr &&
+          shdr->sh_addr < phdr->p_vaddr + phdr->p_memsz)
+        {
+          *lma = phdr->p_paddr + shdr->sh_addr - phdr->p_vaddr;
+          return 0;
+        }
+    }
+
+  return -ENOENT;
+}
+#endif
+
 /****************************************************************************
  * Name: elf_loadfile
  *
@@ -178,9 +213,20 @@ static inline int elf_loadfile(FAR struct elf_loadinfo_s *loadinfo)
         {
           if (shdr->sh_type != SHT_NOBITS)
             {
+              Elf_Addr addr = shdr->sh_addr;
+
+#ifdef CONFIG_ELF_LOADTO_LMA
+              ret = elf_vma2lma(loadinfo, shdr, &addr);
+              if (ret < 0)
+                {
+                  berr("ERROR: Failed to convert addr %d: %d\n", i, ret);
+                  return ret;
+                }
+#endif
+
               /* Read the section data from sh_offset to specified region */
 
-              ret = elf_read(loadinfo, (FAR uint8_t *)shdr->sh_addr,
+              ret = elf_read(loadinfo, (FAR uint8_t *)addr,
                              shdr->sh_size, shdr->sh_offset);
               if (ret < 0)
                 {
@@ -189,6 +235,7 @@ static inline int elf_loadfile(FAR struct elf_loadinfo_s *loadinfo)
                 }
             }
 
+#ifndef CONFIG_ELF_LOADTO_LMA
           /* If there is no data in an allocated section, then the
            * allocated section must be cleared.
            */
@@ -197,6 +244,7 @@ static inline int elf_loadfile(FAR struct elf_loadinfo_s *loadinfo)
             {
               memset((FAR uint8_t *)shdr->sh_addr, 0, shdr->sh_size);
             }
+#endif
 
           continue;
         }
@@ -283,6 +331,15 @@ int elf_load(FAR struct elf_loadinfo_s *loadinfo)
 
   binfo("loadinfo: %p\n", loadinfo);
   DEBUGASSERT(loadinfo && loadinfo->file.f_inode);
+
+  /* Load program headers into memory */
+
+  ret = elf_loadphdrs(loadinfo);
+  if (ret < 0)
+    {
+      berr("ERROR: elf_loadphdrs failed: %d\n", ret);
+      goto errout_with_buffers;
+    }
 
   /* Load section headers into memory */
 

--- a/binfmt/libelf/libelf_uninit.c
+++ b/binfmt/libelf/libelf_uninit.c
@@ -94,6 +94,12 @@ int elf_freebuffers(FAR struct elf_loadinfo_s *loadinfo)
 {
   /* Release all working allocations  */
 
+  if (loadinfo->phdr)
+    {
+      kmm_free((FAR void *)loadinfo->phdr);
+      loadinfo->phdr = NULL;
+    }
+
   if (loadinfo->shdr)
     {
       kmm_free(loadinfo->shdr);

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -773,6 +773,21 @@ bool up_textheap_heapmember(FAR void *p);
 #endif
 
 /****************************************************************************
+ * Name: up_copy_section
+ *
+ * Description:
+ *   Copy section from general temporary buffer(src) to special addr(dest).
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_ARCH_USE_COPY_SECTION)
+int up_copy_section(FAR void *dest, FAR const void *src, size_t n);
+#endif
+
+/****************************************************************************
  * Name: up_setpicbase and up_getpicbase
  *
  * Description:

--- a/include/nuttx/binfmt/elf.h
+++ b/include/nuttx/binfmt/elf.h
@@ -91,6 +91,7 @@ struct elf_loadinfo_s
   int                filemode;   /* Mode of the file system */
 
   Elf_Ehdr           ehdr;       /* Buffered ELF file header */
+  FAR Elf_Phdr      *phdr;       /* Buffered ELF program headers */
   FAR Elf_Shdr      *shdr;       /* Buffered ELF section headers */
   uint8_t           *iobuffer;   /* File I/O buffer */
 


### PR DESCRIPTION
## Summary
1. ELF_LOADTO_LMA
    - Load all sections to LMA not VMA, so the startup code(e.g. start.S) need relocate .data section to the final address(VMA) and zero .bss section by self.
    - For example, SiFli and Actions: Background: Device with small sram, Bootloader run in sram and psram, need boot to Application, with memory overlap and without XIP. VMA of .data is in "psram" and LMA in "rom", if not enable  `ELF_LOADTO_LMA` , ELF loader will load the section to VMA (will fill bootloader itself). For more details, please see Testing.1
2. ARCH_USE_COPY_SECTION
   - This option enables architecture-specific memory copy for dynamic code loading. For example, Ambiq has MRAM regions for instruction which can't load by the memcpy directly.

## Impact
Disabled by default

## Testing
1. Enable `ELF_LOADTO_LMA` so that the ELF loader loads .data to LMA, and do not zero .bss. The sections(.data, .bss, .etc) will be initialized in __start())
- start.c / start.S
```c
void __start(void)
{
    /* Zero .bss section */
    for (ptr = _sbss; ptr < _ebss;)
    {   
      *ptr++ = 0;
    }

    /* Copy .data section */
    for (src = _rom_data, dest = _sdata; dest < _edata;)
    { 
      *dest++ = *src++;
    }
}
```
- ld script
```lds
MEMORY
{ 
  rom (rx)            : ORIGIN = 0x18100000, LENGTH = 0x080000
  sram (rwx)          : ORIGIN = 0x01000400, LENGTH = 0x20000
  psram (rwx)         : ORIGIN = 0x18180000, LENGTH = 0x380000
// ... ...
}

SECTIONS
{
    _rom_data = LOADADDR(.data);
    .data : ALIGN(4) {
        _sdata = ABSOLUTE(.);
       // ... ...
        _edata = ABSOLUTE(.);
    } > psram AT > rom
    .bss : ALIGN(4) {
        _sbss = ABSOLUTE(.);
       // ... ...
        _ebss = ABSOLUTE(.);
    } > psram
}
```
- Header Info
```
$ readelf -l -S nuttx.elf 
Section Headers:
  [Nr] Name              Type            Addr     Off    Size   ES Flg Lk Inf Al
  [ 0]                   NULL            00000000 000000 000000 00      0   0  0
// ... ...
  [ 5] .data             PROGBITS        18180000 070000 00056c 00  WA  0   0  4
// ... ...
  [ 8] .bss              NOBITS          18180570 070570 002998 00  WA  0   0 16
// ... ...

Program Headers:
  Type           Offset   VirtAddr   PhysAddr   FileSiz MemSiz  Flg Align
  EXIDX          0x05940c 0x1814940c 0x1814940c 0x00008 0x00008 R   0x4
// ... ...
  LOAD           0x070000 0x18180000 0x1814a324 0x0056c 0x0056c RW  0x10000
  LOAD           0x000570 0x18180570 0x18180570 0x00000 0x02998 RW  0x10000

 Section to Segment mapping:
  Segment Sections...
   00     .ARM.exidx 
// ... ...
   03     .data 
   04     .bss 
```
```
Sections:
Idx Name          Size      VMA       LMA       File off  Algn
  0 .text         00049409  18100000  18100000  00010000  2**3
                  CONTENTS, ALLOC, LOAD, READONLY, CODE
// ... ...
  4 .data         0000056c  18180000  1814a324  00070000  2**2
                  CONTENTS, ALLOC, LOAD, DATA
// ... ...
  7 .bss          00002998  18180570  18180570  00070570  2**4
                  ALLOC
// ... ...
```

2. The `ARCH_USE_COPY_SECTION` enables architecture-specific memory copy for dynamic code loading.
```c
int up_copy_section(void *dest, const void *src, size_t n)
{
  // ... ...
  if ((uint32_t)dest >= ADDR_MRAM_START && (uint32_t)dest < ADDR_MRAM_END)
    {
      mram->write(mram, dest, n, src);
    }
  else
    {
      memcpy(dest, src, n);
    }
  // ... ...
}
```