### PR TITLE
drivers/clk: Change CLK_SET_RATE_NO_REPARENT to CLK_MUX_SET_RATE_NO_REPARENT

### DIFF
--- a/drivers/clk/clk_mux.c
+++ b/drivers/clk/clk_mux.c
@@ -96,7 +96,7 @@ clk_mux_determine_rate(FAR struct clk_s *clk, uint32_t rate,
   uint32_t parent_rate;
   uint32_t best = 0;
 
-  if (clk->flags & CLK_SET_RATE_NO_REPARENT)
+  if (mux->flags & CLK_MUX_SET_RATE_NO_REPARENT)
     {
       parent = clk->parent;
       if (clk->flags & CLK_SET_RATE_PARENT)

--- a/include/nuttx/clk/clk_provider.h
+++ b/include/nuttx/clk/clk_provider.h
@@ -40,7 +40,6 @@
 #define CLK_SET_RATE_GATE               0x01
 #define CLK_SET_PARENT_GATE             0x02
 #define CLK_SET_RATE_PARENT             0x04
-#define CLK_SET_RATE_NO_REPARENT        0x08
 #define CLK_GET_RATE_NOCACHE            0x10
 #define CLK_NAME_IS_STATIC              0x20
 #define CLK_PARENT_NAME_IS_STATIC       0x40
@@ -71,6 +70,7 @@
 #define CLK_MUX_HIWORD_MASK             0x01
 #define CLK_MUX_READ_ONLY               0x02
 #define CLK_MUX_ROUND_CLOSEST           0x04
+#define CLK_MUX_SET_RATE_NO_REPARENT    0x08
 
 #define CLK_PHASE_HIWORD_MASK           0x01
 


### PR DESCRIPTION
## Summary

since only mux clk use this flag

## Impact

clk driver

## Testing

internal test