### PR TITLE
Fix loading of ET_DYN type of shared objects

### DIFF
--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -230,6 +230,7 @@ CMODULEFLAGS += -fno-stack-protector
 
 LDMODULEFLAGS = -r -e module_initialize --gc-sections
 LDMODULEFLAGS += -T $(call CONVERT_PATH,$(TOPDIR)/libs/libc/modlib/gnu-elf.ld)
+SHMODULEFLAGS = -Bsymbolic -G -Bdynamic
 
 # NuttX modules are ELF binaries.
 # Non-ELF platforms like macOS need to use a separate ELF toolchain.
@@ -270,5 +271,6 @@ ifeq ($(CONFIG_SIM_M32),y)
   LDLINKFLAGS += -melf_i386
   LDFLAGS += -m32
   LDMODULEFLAGS += -melf_i386
+  SHMODULEFLAGS += -melf_i386
   LDELFFLAGS += -melf_i386
 endif

--- a/include/elf64.h
+++ b/include/elf64.h
@@ -142,9 +142,9 @@ typedef struct
   Elf64_Off     p_offset;   /* Offset in file */
   Elf64_Addr    p_vaddr;    /* Virtual address in memory */
   Elf64_Addr    p_paddr;    /* Reserved */
-  Elf64_Word    p_filesz;   /* Size of segment in file */
-  Elf64_Word    p_memsz;    /* Size of segment in memory */
-  Elf64_Word    p_align;    /* Alignment of segment */
+  Elf64_Xword   p_filesz;   /* Size of segment in file */
+  Elf64_Xword   p_memsz;    /* Size of segment in memory */
+  Elf64_Xword   p_align;    /* Alignment of segment */
 } Elf64_Phdr;
 
 /* Figure 7. Format of a Note Section */

--- a/include/nuttx/lib/modlib.h
+++ b/include/nuttx/lib/modlib.h
@@ -159,6 +159,7 @@ struct module_s
   struct mod_info_s modinfo;           /* Module information */
   FAR void *textalloc;                 /* Allocated kernel text memory */
   FAR void *dataalloc;                 /* Allocated kernel memory */
+  int dynamic;                         /* Module is a dynamic shared object */
 #if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_MODULE)
   size_t textsize;                     /* Size of the kernel .text memory allocation */
   size_t datasize;                     /* Size of the kernel .bss/.data memory allocation */

--- a/libs/libc/dlfcn/lib_dlclose.c
+++ b/libs/libc/dlfcn/lib_dlclose.c
@@ -125,37 +125,44 @@ static inline int dlremove(FAR void *handle)
 
   /* Release resources held by the module */
 
-  if (modp->textalloc != NULL)
+  /* Dynamic shared objects have text and data allocated in one
+   * operation to keep the relative positions between the two
+   * areas relative otherwise references to the GOT will fail
+   */
+
+  if (!modp->dynamic)
     {
-      /* Free the module memory */
+      if (modp->textalloc != NULL)
+        {
+          /* Free the module memory */
 
 #if defined(CONFIG_ARCH_USE_TEXT_HEAP)
-      up_textheap_free(modp->textalloc);
+          up_textheap_free((FAR void *)modp->textalloc);
 #else
-      lib_free(modp->textalloc);
+          lib_free((FAR void *)modp->textalloc);
 #endif
+        }
 
-      /* Nullify so that the memory cannot be freed again */
+      if (modp->dataalloc != NULL)
+        {
+          /* Free the module memory */
 
-      modp->textalloc = NULL;
-#if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_MODULE)
-      modp->textsize  = 0;
-#endif
+          lib_free((FAR void *)modp->dataalloc);
+        }
     }
-
-  if (modp->dataalloc != NULL)
+  else
     {
-      /* Free the module memory */
-
-      lib_free(modp->dataalloc);
-
-      /* Nullify so that the memory cannot be freed again */
-
-      modp->dataalloc = NULL;
-#if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_MODULE)
-      modp->datasize  = 0;
-#endif
+      lib_free((FAR void *)modp->textalloc);
     }
+
+  /* Nullify so that the memory cannot be freed again */
+
+  modp->textalloc = NULL;
+  modp->dataalloc = NULL;
+#if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_MODULE)
+  modp->textsize  = 0;
+  modp->datasize  = 0;
+#endif
 
   /* Free the modules exported symmbols table */
 

--- a/libs/libc/dlfcn/lib_dlopen.c
+++ b/libs/libc/dlfcn/lib_dlopen.c
@@ -232,6 +232,7 @@ static inline FAR void *dlinsert(FAR const char *filename)
 
   modp->textalloc = (FAR void *)loadinfo.textalloc;
   modp->dataalloc = (FAR void *)loadinfo.datastart;
+  modp->dynamic   = (loadinfo.ehdr.e_type == ET_DYN);
 #if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_MODULE)
   modp->textsize  = loadinfo.textsize;
   modp->datasize  = loadinfo.datasize;

--- a/libs/libc/modlib/modlib_globals.S
+++ b/libs/libc/modlib/modlib_globals.S
@@ -1,28 +1,25 @@
 #ifdef __CYGWIN__
-#  define SYMBOL(s) s
-#  define WEAK .weak
+#  define SYMBOL(s) _##s
 #  define GLOBAL .global
 #  define SECTION .data
 	.macro GLOBAL ep
-	.global SYMBOL(\ep)
-	.type 	SYMBOL(\ep), "object"
+	.global	SYMBOL(\ep)
+	.type	SYMBOL(\ep), "object"
 	.endm
 	.macro SIZE ep
 	.endm
 #elif defined(__ELF__)
 #  define SYMBOL(s) s
-#  define WEAK .weak
 #  define SECTION .data
 	.macro GLOBAL ep
-	.global SYMBOL(\ep)
-	.type 	SYMBOL(\ep), "object"
+	.global	SYMBOL(\ep)
+	.type	SYMBOL(\ep), "object"
 	.endm
 	.macro SIZE ep
- 	.size 	SYMBOL(\ep), . - SYMBOL(\ep)
+	.size	SYMBOL(\ep), . - SYMBOL(\ep)
 	.endm
 #else
 #  define SYMBOL(s) _##s
-#  define WEAK .weak_definition
 #  define SECTION .section __DATA,__data
 	.macro GLOBAL ep
 	.private_extern SYMBOL(\ep)
@@ -34,14 +31,12 @@
 
 #if __SIZEOF_POINTER__ == 8
 	.macro globalEntry index, ep
-	WEAK	SYMBOL(\ep)
 	.quad	.l\index
 	.quad	\ep
 	.endm
 # define ALIGN 8
 #else
 	.macro globalEntry index, ep
-	WEAK	SYMBOL(\ep)		
 	.long	.l\index
 	.long	\ep
 	.endm
@@ -54,20 +49,20 @@
 	.arch armv8-m.base
 #endif
 #ifdef __ARM_ASM_SYNTAX_UNIFIED__
-	.syntax unified
+	.syntax	unified
 #endif
 	.thumb
 #endif
 	.data
 	.align	ALIGN
-	GLOBAL	globalNames
+	GLOBAL	globalNames 
 
 SYMBOL(globalNames):
-	SIZE globalNames
+	SIZE	globalNames 
 
 	.align	ALIGN
 	GLOBAL	nglobals
-SYMBOL(nglobals):
+SYMBOL(nglobals):	
 	.word	0
 	SIZE	nglobals
 

--- a/libs/libc/modlib/modlib_load.c
+++ b/libs/libc/modlib/modlib_load.c
@@ -313,36 +313,62 @@ int modlib_load(FAR struct mod_loadinfo_s *loadinfo)
 
   /* Allocate memory to hold the ELF image */
 
-  if (loadinfo->textsize > 0)
+  /* For Dynamic shared objects the relative positions between
+   * text and data must be maintained due to references to the
+   * GOT. Therefore we cannot do two different allocations.
+   */
+
+  if (loadinfo->ehdr.e_type == ET_REL)
     {
-#if defined(CONFIG_ARCH_USE_TEXT_HEAP)
-      loadinfo->textalloc = (uintptr_t)
-                            up_textheap_memalign(loadinfo->textalign,
-                                                 loadinfo->textsize +
-                                                 loadinfo->segpad);
-#else
-      loadinfo->textalloc = (uintptr_t)lib_memalign(loadinfo->textalign,
-                                                    loadinfo->textsize +
-                                                    loadinfo->segpad);
-#endif
-      if (!loadinfo->textalloc)
+      if (loadinfo->textsize > 0)
         {
-          berr("ERROR: Failed to allocate memory for the module text\n");
-          ret = -ENOMEM;
-          goto errout_with_buffers;
+#if defined(CONFIG_ARCH_USE_TEXT_HEAP)
+          loadinfo->textalloc = (uintptr_t)
+                                up_textheap_memalign(loadinfo->textalign,
+                                                     loadinfo->textsize +
+                                                     loadinfo->segpad);
+#else
+          loadinfo->textalloc = (uintptr_t)lib_memalign(loadinfo->textalign,
+                                                        loadinfo->textsize +
+                                                        loadinfo->segpad);
+#endif
+          if (!loadinfo->textalloc)
+            {
+              berr("ERROR: Failed to allocate memory for the module text\n");
+              ret = -ENOMEM;
+              goto errout_with_buffers;
+            }
+        }
+
+      if (loadinfo->datasize > 0)
+        {
+          loadinfo->datastart = (uintptr_t)lib_memalign(loadinfo->dataalign,
+                                                        loadinfo->datasize);
+          if (!loadinfo->datastart)
+            {
+              berr("ERROR: Failed to allocate memory for the module data\n");
+              ret = -ENOMEM;
+              goto errout_with_buffers;
+            }
         }
     }
-
-  if (loadinfo->datasize > 0)
+  else
     {
-      loadinfo->datastart = (uintptr_t)lib_memalign(loadinfo->dataalign,
-                                                    loadinfo->datasize);
-      if (!loadinfo->datastart)
+      loadinfo->textalloc = (uintptr_t)lib_memalign(loadinfo->textalign,
+                                                    loadinfo->textsize +
+                                                    loadinfo->datasize +
+                                                    loadinfo->segpad);
+
+      if (!loadinfo->textalloc)
         {
-          berr("ERROR: Failed to allocate memory for the module data\n");
+          berr("ERROR: Failed to allocate memory for the module\n");
           ret = -ENOMEM;
           goto errout_with_buffers;
         }
+
+      loadinfo->datastart = loadinfo->textalloc +
+                            loadinfo->textsize +
+                            loadinfo->segpad;
     }
 
   /* Load ELF section data into memory */

--- a/libs/libc/modlib/modlib_unload.c
+++ b/libs/libc/modlib/modlib_unload.c
@@ -58,18 +58,27 @@ int modlib_unload(FAR struct mod_loadinfo_s *loadinfo)
 
   /* Release memory holding the relocated ELF image */
 
-  if (loadinfo->textalloc != 0)
-    {
-#if defined(CONFIG_ARCH_USE_TEXT_HEAP)
-      up_textheap_free((FAR void *)loadinfo->textalloc);
-#else
-      lib_free((FAR void *)loadinfo->textalloc);
-#endif
-    }
+  /* ET_DYN has a single allocation so we only free textalloc */
 
-  if (loadinfo->datastart != 0)
+  if (loadinfo->ehdr.e_type != ET_DYN)
     {
-      lib_free((FAR void *)loadinfo->datastart);
+      if (loadinfo->textalloc != 0)
+        {
+#if defined(CONFIG_ARCH_USE_TEXT_HEAP)
+           up_textheap_free((FAR void *)loadinfo->textalloc);
+#else
+           lib_free((FAR void *)loadinfo->textalloc);
+#endif
+        }
+
+      if (loadinfo->datastart != 0)
+        {
+          lib_free((FAR void *)loadinfo->datastart);
+        }
+    }
+  else
+    {
+      lib_free((FAR void *)loadinfo->textalloc);
     }
 
   /* Clear out all indications of the allocated address environment */

--- a/sched/module/mod_insmod.c
+++ b/sched/module/mod_insmod.c
@@ -155,7 +155,9 @@ FAR void *insmod(FAR const char *filename, FAR const char *modname)
   struct mod_loadinfo_s loadinfo;
   FAR struct module_s *modp;
   mod_initializer_t initializer;
+  FAR void (**array)(void);
   int ret;
+  int i;
 
   DEBUGASSERT(filename != NULL && modname != NULL);
   binfo("Loading file: %s\n", filename);
@@ -237,11 +239,37 @@ FAR void *insmod(FAR const char *filename, FAR const char *modname)
 
   /* Call the module initializer */
 
-  ret = initializer(&modp->modinfo);
-  if (ret < 0)
+  switch (loadinfo.ehdr.e_type)
     {
-      binfo("Failed to initialize the module: %d\n", ret);
-      goto errout_with_load;
+      case ET_REL :
+          ret = initializer(&modp->modinfo);
+          if (ret < 0)
+            {
+              binfo("Failed to initialize the module: %d\n", ret);
+              goto errout_with_load;
+            }
+          break;
+      case ET_DYN :
+
+          /* Process any preinit_array entries */
+
+          array = (FAR void (**)(void))loadinfo.preiarr;
+          for (i = 0; i < loadinfo.nprei; i++)
+            {
+              array[i]();
+            }
+
+          /* Process any init_array entries */
+
+          array = (FAR void (**)(void))loadinfo.initarr;
+          for (i = 0; i < loadinfo.ninit; i++)
+            {
+              array[i]();
+            }
+
+          modp->finiarr = loadinfo.finiarr;
+          modp->nfini = loadinfo.nfini;
+          break;
     }
 
   /* Add the new module entry to the registry */

--- a/sched/module/mod_rmmod.c
+++ b/sched/module/mod_rmmod.c
@@ -116,16 +116,27 @@ int rmmod(FAR void *handle)
 
   if (modp->textalloc != NULL || modp->dataalloc != NULL)
     {
-      /* Free the module memory
-       * and nullify so that the memory cannot be freed again
+      /* Free the module memory and nullify so that the memory cannot
+       * be freed again
+       *
+       * NOTE: For dynamic shared objects there is only a single
+       * allocation: the text/data were allocated in one operation
        */
 
+      if (!modp->dynamic)
+        {
 #if defined(CONFIG_ARCH_USE_TEXT_HEAP)
-      up_textheap_free(modp->textalloc);
+          up_textheap_free((FAR void *)modp->textalloc);
 #else
-      kmm_free(modp->textalloc);
+          kmm_free((FAR void *)modp->textalloc);
 #endif
-      kmm_free(modp->dataalloc);
+          kmm_free((FAR void *)modp->dataalloc);
+        }
+      else
+        {
+          kmm_free((FAR void *)modp->textalloc);
+        }
+
       modp->textalloc = NULL;
       modp->dataalloc = NULL;
 #if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_MODULE)


### PR DESCRIPTION
* build-globals.sh
  - Only look in the nuttx for external symbols used when loading dynamic shared objects

* include/elf64.h
  - Correct the type of fields in the Elf64_Phdr structure

* libs/libc/dlfcn/lib_dlclose.c
  - Distinguish between ET_DYN and other objects as the former has both text and data in a single allocation to reserve GOT offsets

* libs/libc/dlfcn/lib_dlopen.c
  - Code formatting

* libs/libc/modlib/modlib_bind.c
  - Distinguish between relocation entry sizes by section type
  - Handle RELA style relocations

* libs/libc/modlib/modlib_globals.S
  - Formatting fixes
  - Symbols should not be weak - they exist or they don't

* include/nuttx/lib/modlib.h
  - Add an inidcator to module_s to distinguish between ET_DYN and other

* libs/libc/modlib/modlib_load.c
  - ET_DYN objects need to keep the relative displacement between the text and data sections due to GOT references from the former to the latter. This also implies that linking may require modification from the default for the shared objects being produced. For example, default alignment may mean nearly 64K of wasted space.

* libs/libc/modlib/modlib_unload.c sched/module/mod_rmmod.c
  - Distingusih between freeing of ET_DYN storage and other as the former is a single allocation.

* libs/libc/modlib/mod_insmod.c
  - Cater for ET_DYN objects having init and pre-init sections

## Summary

An ET_DYN type of shared objects relies on its text section and data sections remaining in relative position as there are references from the text section to GOT offsets in the data section. Therefore you cannot just arbitrarily load text and data separately and hope the offsets are not changed. 

## Impact

ET_DYN objects will load, execute, and unload correctly.

## Testing

Added test to [sotest](nuttx-apps/examples/sotest)
https://github.com/apache/nuttx-apps/pull/2026

