### PR TITLE
fix argument of nxsem_wait_uninterruptible

### DIFF
--- a/arch/arm/src/stm32l4/stm32l4_sdmmc.c
+++ b/arch/arm/src/stm32l4/stm32l4_sdmmc.c
@@ -2603,7 +2603,7 @@ static sdio_eventset_t stm32_eventwait(struct sdio_dev_s *dev)
        * incremented and there will be no wait.
        */
 
-      ret = nxsem_wait_uninterruptible(priv);
+      ret = nxsem_wait_uninterruptible(&priv->waitsem);
       if (ret < 0)
         {
           /* Task canceled.  Cancel the wdog (assuming it was started) and


### PR DESCRIPTION
## Summary
Trying to make SDMMC work on STM32L4R5ZI, stumbled upon inconsistency (this gives warning on compilation).
`
chip/stm32l4_sdmmc.c:2606:40: warning: passing argument 1 of 'nxsem_wait_uninterruptible' from incompatible pointer type [-Wincompatible-pointer-types]
`
## Impact
chip family: STM32L4, driver: SDMMC, function: stm32_eventwait
board: nucleo-l496zg

## Testing
board: nucleo-l496zg with SDMMC driver.
Compiles. 
Unable to test execution.