### PR TITLE
binfmt: The program headers are optional.

### DIFF
--- a/binfmt/libelf/libelf_sections.c
+++ b/binfmt/libelf/libelf_sections.c
@@ -188,8 +188,8 @@ int elf_loadphdrs(FAR struct elf_loadinfo_s *loadinfo)
 
   if (loadinfo->ehdr.e_phnum < 1)
     {
-      berr("No programs(?)\n");
-      return -EINVAL;
+      binfo("No programs(?)\n");
+      return 0;
     }
 
   /* Get the total size of the program header table */


### PR DESCRIPTION
## Summary
The program headers are optional. see https://github.com/apache/nuttx/pull/10462

## Impact
binfmt

## Testing
boards: sim:elf
- with this patch
```
nsh> /data/data/hello
Hello, World!!
nsh> echo $?
0
```
- without this patch
```
NuttShell (NSH)
MOTD: username=admin password=Administrator
nsh> mount -t hostfs -o fs=. /data
nsh> /data/data/hello

Program received signal SIGSEGV, Segmentation fault.
0x0000000000000000 in ?? ()
(gdb) bt
#0  0x0000000000000000 in ?? ()
#1  0x000055555556cb86 in nxtask_startup (entrypt=0x0, argc=1, argv=0x7ffff3ea3e60) at sched/task_startup.c:70
#2  0x000055555556654c in nxtask_start () at task/task_start.c:134
#3  0x0000555555570ae3 in pre_start () at sim/sim_initialstate.c:52
#4  0x0000000000000000 in ?? ()
```
