### PR TITLE
Minor clk improvement

### DIFF
--- a/drivers/clk/clk.c
+++ b/drivers/clk/clk.c
@@ -491,18 +491,6 @@ static void clk_change_rate(FAR struct clk_s *clk, uint32_t best_parent_rate)
   FAR struct clk_s *old_parent;
   bool skip_set_rate = false;
 
-  list_for_every_entry(&clk->children, child, struct clk_s, node)
-    {
-      if (child->new_parent && child->new_parent != clk)
-        {
-          continue;
-        }
-      if (child->new_rate > __clk_get_rate(child))
-        {
-          clk_change_rate(child, clk->new_rate);
-        }
-    }
-
   old_parent = clk->parent;
 
   if (clk->new_parent && clk->new_parent != clk->parent)

--- a/drivers/clk/clk_divider.c
+++ b/drivers/clk/clk_divider.c
@@ -297,6 +297,11 @@ static int32_t divider_get_val(uint32_t rate, uint32_t parent_rate,
   uint32_t div;
   uint32_t value;
 
+  if (rate == 0)
+    {
+      return -EINVAL;
+    }
+
   div = DIV_ROUND_UP(parent_rate, rate);
 
   if ((flags & CLK_DIVIDER_POWER_OF_TWO) && !is_power_of_2(div))


### PR DESCRIPTION
## Summary

- Solve the risk of dividing by 0 when setting frequency points
- To solve the problem of unordered setting of div & mux, after solving the problem, the frequency will be set to mux first, and then div

## Impact

clk driver

## Testing

internal testing