### PR TITLE
smp: irq_csection: enable irq to process the pending pause request

### DIFF
--- a/sched/irq/irq_csection.c
+++ b/sched/irq/irq_csection.c
@@ -185,9 +185,9 @@ irqstate_t enter_critical_section(void)
    * the local CPU.
    */
 
-try_again:
   ret = up_irq_save();
 
+try_again:
   /* Verify that the system has sufficiently initialized so that the task
    * lists are valid.
    */
@@ -355,7 +355,8 @@ try_again_in_irq:
                    * request.
                    */
 
-                  up_irq_restore(ret);
+                  up_irq_enable();
+                  up_irq_save();
                   goto try_again;
                 }
 


### PR DESCRIPTION
## Summary
It's found in a complicated task-exiting/rescheduling scenario, two CPUs are deadlocked.

Use JTAG to dump the backtrace of the two CPUs to see what happened.

CPU0‘s backtrace shows it's waiting CPU1 to pause:
```
(gdb) bt
#0  spin_lock (lock=lock@entry=0x40ed66cd <g_cpu_paused+1> "\001") at semaphore/spinlock.c:74
#1  0x40017bb0 in up_cpu_pause (cpu=cpu@entry=1) at armv7-a/arm_cpupause.c:280
#2  0x40066714 in nxsched_add_readytorun (btcb=btcb@entry=0x418b9b50) at sched/sched_addreadytorun.c:260
#3  0x400686f0 in nxsem_post (sem=sem@entry=0x42a905bc) at semaphore/sem_post.c:174
#4  0x40065e58 in pthread_sem_give (sem=sem@entry=0x42a905bc) at pthread/pthread_initialize.c:108
#5  0x4006603c in pthread_notifywaiters (pjoin=0x42a905b0) at pthread/pthread_completejoin.c:76
#6  pthread_completejoin (pid=<optimized out>, exit_value=exit_value@entry=0x0) at pthread/pthread_completejoin.c:224
#7  0x401c6f40 in nx_pthread_exit (exit_value=exit_value@entry=0x0) at pthread/pthread_exit.c:82
#8  0x40093b7c in pthread_exit (exit_value=0x0) at pthread/pthread_exit.c:71
#9  0x40093acc in pthread_startup (entry=<optimized out>, arg=<optimized out>) at pthread/pthread_create.c:59
#10 0x401c6be4 in pthread_start () at pthread/pthread_create.c:139
#11 0x00000000 in ?? ()
```

And the backtrace shows that CPU1 is in `enter_critical_section()` and has percepted it is asked to pause:
```
(gdb) bt
#0  enter_critical_section () at irq/irq_csection.c:320
#1  0x40067b98 in nxsem_wait (sem=0x418a7a00) at semaphore/sem_wait.c:88
#2  sem_wait (sem=sem@entry=0x418a7a00) at semaphore/sem_wait.c:303
#3  0x4009315c in nxmutex_lock (mutex=mutex@entry=0x418a7a00) at misc/lib_mutex.c:203
#4  0x400a37b4 in mm_lock (heap=heap@entry=0x418a7a00) at mm_heap/mm_lock.c:96
#5  0x400a3b58 in mm_free (heap=0x418a7a00, mem=0x43680000) at mm_heap/mm_free.c:96
#6  0x400a1764 in free (mem=<optimized out>) at umm_heap/umm_free.c:49
```
So it's repeatly looping, trying to ack the pause request, a SGI interrupt.
But for some reason, the local interrupt on CPU1 is already disabled, so CPU1 will never ack the SGI interrupt.
This is why the two CPUs are deadlocked.
```
try_again:
  ret = up_irq_save();
...
...
  up_irq_restore(ret);
  goto try_again;
```
This fix will really enable local interrupt when doing the retry.
## Impact
smp, `enter_critical_section`

## Testing
Tested in an armv7a smp configuration.
