### PR TITLE
drivers/sensors: fix race condition about sensor rpmsg

### DIFF
--- a/drivers/sensors/sensor_rpmsg.c
+++ b/drivers/sensors/sensor_rpmsg.c
@@ -349,6 +349,7 @@ static int sensor_rpmsg_ioctl(FAR struct sensor_rpmsg_dev_s *dev,
 {
   struct sensor_rpmsg_ioctl_cookie_s cookie;
   FAR struct sensor_rpmsg_proxy_s *proxy;
+  FAR struct sensor_rpmsg_proxy_s *ptmp;
   FAR struct sensor_rpmsg_ioctl_s *msg;
   uint32_t space;
   int ret = -ENOTTY;
@@ -365,8 +366,8 @@ static int sensor_rpmsg_ioctl(FAR struct sensor_rpmsg_dev_s *dev,
    */
 
   sensor_rpmsg_lock(dev);
-  list_for_every_entry(&dev->proxylist, proxy,
-                       struct sensor_rpmsg_proxy_s, node)
+  list_for_every_entry_safe(&dev->proxylist, proxy, ptmp,
+                            struct sensor_rpmsg_proxy_s, node)
     {
       msg = rpmsg_get_tx_payload_buffer(proxy->ept, &space, true);
       if (!msg)
@@ -840,6 +841,7 @@ static ssize_t sensor_rpmsg_push_event(FAR void *priv, FAR const void *data,
 {
   FAR struct sensor_rpmsg_dev_s *dev = priv;
   FAR struct sensor_rpmsg_stub_s *stub;
+  FAR struct sensor_rpmsg_stub_s *stmp;
   ssize_t ret;
 
   /* Push new data to upperhalf driver's circular buffer */
@@ -855,8 +857,8 @@ static ssize_t sensor_rpmsg_push_event(FAR void *priv, FAR const void *data,
    */
 
   sensor_rpmsg_lock(dev);
-  list_for_every_entry(&dev->stublist, stub,
-                       struct sensor_rpmsg_stub_s, node)
+  list_for_every_entry_safe(&dev->stublist, stub, stmp,
+                            struct sensor_rpmsg_stub_s, node)
     {
       sensor_rpmsg_push_event_one(dev, stub);
     }
@@ -1097,6 +1099,7 @@ static int sensor_rpmsg_ioctl_handler(FAR struct rpmsg_endpoint *ept,
 {
   FAR struct sensor_rpmsg_ioctl_s *msg = data;
   FAR struct sensor_rpmsg_stub_s *stub;
+  FAR struct sensor_rpmsg_stub_s *stmp;
   FAR struct sensor_rpmsg_dev_s *dev;
   unsigned long arg;
   int ret;
@@ -1105,8 +1108,8 @@ static int sensor_rpmsg_ioctl_handler(FAR struct rpmsg_endpoint *ept,
                           msg->arg;
   dev = (FAR struct sensor_rpmsg_dev_s *)(uintptr_t)msg->proxy;
   sensor_rpmsg_lock(dev);
-  list_for_every_entry(&dev->stublist, stub,
-                       struct sensor_rpmsg_stub_s, node)
+  list_for_every_entry_safe(&dev->stublist, stub, stmp,
+                            struct sensor_rpmsg_stub_s, node)
     {
       if (stub->ept == ept)
         {


### PR DESCRIPTION
## Summary
1. using list_for_every_entry_safe to protect list foreach, avoid removing the entry during the process to cause crash.
2. Back up proxy content in advance to avoid use after free.
## Impact
fix race condition
## Testing
daily test
