### PR TITLE
pic32mx: sched_lock should replace with enter_critical_secion

### DIFF
--- a/arch/mips/src/pic32mx/pic32mx_gpio.c
+++ b/arch/mips/src/pic32mx/pic32mx_gpio.c
@@ -136,6 +136,7 @@ int pic32mx_configgpio(uint16_t cfgset)
   unsigned int pin  = pic32mx_pinno(cfgset);
   uint32_t     mask = (1 << pin);
   uintptr_t    base;
+  irqstate_t   flags;
 
   /* Verify that the port number is within range */
 
@@ -147,7 +148,7 @@ int pic32mx_configgpio(uint16_t cfgset)
 
       /* Is this an input or an output? */
 
-      sched_lock();
+      flags = enter_critical_section();
       if (pic32mx_output(cfgset))
         {
           /* Not analog */
@@ -203,7 +204,7 @@ int pic32mx_configgpio(uint16_t cfgset)
 #endif
         }
 
-      sched_unlock();
+      leave_critical_section(flags);
       return OK;
     }
 


### PR DESCRIPTION
## Summary
pic32mx: sched_lock should replace with enter_critical_secion
## Impact
none
## Testing

