### PR TITLE
sim/framebuffer: fix memory leak in XStringListToTextProperty

### DIFF
--- a/arch/sim/src/sim/posix/sim_x11framebuffer.c
+++ b/arch/sim/src/sim/posix/sim_x11framebuffer.c
@@ -106,6 +106,8 @@ static inline Display *sim_x11createframe(void)
 
   XSetWMProperties(display, g_window, &winprop, &iconprop, argv, 1,
                    &hints, NULL, NULL);
+  XFree(winprop.value);
+  XFree(iconprop.value);
 
   /* Select window input events */
 


### PR DESCRIPTION
## Summary

LeakSanitizer: detected memory leaks in XStringListToTextProperty

## Impact

## Testing

Please ignore the XFree ci warning