### PR TITLE
libc/fopen: support fopen with mode 'm'

### DIFF
--- a/libs/libc/stdio/lib_fopen.c
+++ b/libs/libc/stdio/lib_fopen.c
@@ -165,7 +165,7 @@ int lib_mode2oflags(FAR const char *mode)
     {
       switch (*mode)
         {
-          /* Open for read access ("r{b|x|+}") */
+          /* Open for read access ("r{m|b|x|+}") */
 
           case 'r' :
             if (state == MODE_NONE)
@@ -261,6 +261,15 @@ int lib_mode2oflags(FAR const char *mode)
                 default:
                   goto errout;
                   break;
+              }
+            break;
+
+          /* Attempt to access the file using mmap. */
+
+          case 'm' :
+            if (state != MODE_R)
+              {
+                goto errout;
               }
             break;
 


### PR DESCRIPTION


## Summary
libc/fopen: support fopen with mode 'm'
refs:
https://pubs.opengroup.org/onlinepubs/9699919799/functions/fopen.html This is a fake implementation, in order for fopen to succeed, Because the complete mmap mapping the entire file will waste a lot of memory.
## Impact
support fopen with m
## Testing
daily test
