### PR TITLE
libc/mallopt: implement dummy mallopt

### DIFF
--- a/include/malloc.h
+++ b/include/malloc.h
@@ -42,6 +42,17 @@
 
 #define malloc_usable_size malloc_size
 
+/* mallopt options that actually do something */
+
+#define M_TRIM_THRESHOLD    -1
+#define M_TOP_PAD           -2
+#define M_MMAP_THRESHOLD    -3
+#define M_MMAP_MAX          -4
+#define M_CHECK_ACTION      -5
+#define M_PERTURB           -6
+#define M_ARENA_TEST        -7
+#define M_ARENA_MAX         -8
+
 /****************************************************************************
  * Public Type Definitions
  ****************************************************************************/
@@ -83,6 +94,7 @@ extern "C"
 {
 #endif
 
+int mallopt(int param, int value);
 struct mallinfo mallinfo(void);
 size_t malloc_size(FAR void *ptr);
 struct mallinfo_task mallinfo_task(FAR const struct malltask *task);

--- a/libs/libc/misc/Make.defs
+++ b/libs/libc/misc/Make.defs
@@ -24,7 +24,7 @@ CSRCS += lib_mknod.c lib_umask.c lib_utsname.c lib_getrandom.c
 CSRCS += lib_xorshift128.c lib_tea_encrypt.c lib_tea_decrypt.c
 CSRCS += lib_cxx_initialize.c lib_impure.c lib_memfd.c lib_mutex.c
 CSRCS += lib_fchmodat.c lib_fstatat.c lib_getfullpath.c lib_openat.c
-CSRCS += lib_mkdirat.c lib_utimensat.c
+CSRCS += lib_mkdirat.c lib_utimensat.c lib_mallopt.c
 
 # Support for platforms that do not have long long types
 

--- a/libs/libc/misc/lib_mallopt.c
+++ b/libs/libc/misc/lib_mallopt.c
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * libs/libc/misc/lib_mallopt.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <malloc.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: mallopt
+ ****************************************************************************/
+
+int mallopt(int param, int value)
+{
+  return 1;
+}


### PR DESCRIPTION

## Summary
libc/mallopt: implement dummy mallopt

refs:
https://man.freebsd.org/cgi/man.cgi?query=malloc&apropos=0&sektion=3&manpath=SunOS+4.1.3&format=html

## Impact
support dummy mallopt, let compile happy.
## Testing
daily test.
