### PR TITLE
driver/syslog: reset syslog buffer when syslog buffer include invalid character

### DIFF
--- a/drivers/syslog/ramlog.c
+++ b/drivers/syslog/ramlog.c
@@ -257,9 +257,10 @@ static void ramlog_initbuf(void)
     {
       cur = priv->rl_buffer[i];
 
-      if (!isascii(cur))
+      if (!isprint(cur) && !isspace(cur) && cur != '\0')
         {
           memset(priv->rl_buffer, 0, priv->rl_bufsize);
+          is_empty = true;
           break;
         }
       else if (prev && !cur)

--- a/drivers/syslog/syslog_rpmsg.c
+++ b/drivers/syslog/syslog_rpmsg.c
@@ -418,9 +418,10 @@ void syslog_rpmsg_init_early(FAR void *buffer, size_t size)
     {
       cur = priv->buffer[i];
 
-      if (!isascii(cur))
+      if (!isprint(cur) && !isspace(cur) && cur != '\0')
         {
-          memset(priv->buffer, 0, size);
+          memset(buffer, 0, size);
+          is_empty = true;
           break;
         }
       else if (prev && !cur)


### PR DESCRIPTION


## Summary
driver/syslog: reset syslog buffer when syslog buffer include invalid data

When the machine is cold started, the psram area where the syslog buffer is located contains some random values, so it will cause loss of valid log.
## Impact

## Testing
daily test
