### PR TITLE
aio: change aio_fildes int type

### DIFF
--- a/include/aio.h
+++ b/include/aio.h
@@ -121,7 +121,7 @@ struct aiocb
   FAR volatile void *aio_buf;    /* Location of buffer */
   off_t aio_offset;              /* File offset */
   size_t aio_nbytes;             /* Length of transfer */
-  int16_t aio_fildes;            /* File descriptor (should be int) */
+  int aio_fildes;                /* File descriptor */
   int8_t aio_reqprio;            /* Request priority offset (not used, should be int) */
   uint8_t aio_lio_opcode;        /* Operation to be performed (should be int) */
 


### PR DESCRIPTION
## Summary
if fdcheck enabled, protected fd used to aio_fildes will overflow. Change to int and also follow posix spec:
https://pubs.opengroup.org/onlinepubs/7908799/xsh/aio.h.html
## Impact
None

## Testing
LTP aio case with fdcheck enabed
