### PR TITLE
Revert "rpmsgfs: cache statfs result in case of deadlock"

### DIFF
--- a/fs/rpmsgfs/rpmsgfs.c
+++ b/fs/rpmsgfs/rpmsgfs.c
@@ -83,7 +83,6 @@ struct rpmsgfs_mountpt_s
   char                       fs_root[PATH_MAX];
   void                       *handle;
   int                        timeout;  /* Connect timeout */
-  struct statfs              statfs;
 };
 
 /****************************************************************************
@@ -1221,19 +1220,7 @@ static int rpmsgfs_statfs(FAR struct inode *mountpt, FAR struct statfs *buf)
       return ret;
     }
 
-  if (fs->statfs.f_type == RPMSGFS_MAGIC)
-    {
-      memcpy(buf, &fs->statfs, sizeof(struct statfs));
-      nxmutex_unlock(&fs->fs_lock);
-      return 0;
-    }
-
-  /* Call the host fs to perform the statfs */
-
   ret = rpmsgfs_client_statfs(fs->handle, fs->fs_root, buf);
-  buf->f_type = RPMSGFS_MAGIC;
-
-  memcpy(&fs->statfs, buf, sizeof(struct statfs));
 
   nxmutex_unlock(&fs->fs_lock);
   return ret;


### PR DESCRIPTION


## Summary
Revert "rpmsgfs: cache statfs result in case of deadlock"
we need to update statfs info when rpmsgfs happend.

This reverts commit 572d8650340550a467d4583eb7d5c2b184eb7475.
## Impact
fix statfs for rpmsgfs
## Testing
daily test
