### PR TITLE
crypto: fix multiple definition of `poly1305_init'

### DIFF
--- a/crypto/chachapoly.c
+++ b/crypto/chachapoly.c
@@ -101,7 +101,7 @@ void chacha20_poly1305_reinit(FAR void *xctx, FAR const uint8_t *iv,
   chacha_ivsetup((FAR chacha_ctx *)&ctx->chacha, iv, ctx->nonce);
   chacha_encrypt_bytes((FAR chacha_ctx *)&ctx->chacha, ctx->key, ctx->key,
                         POLY1305_KEYLEN);
-  poly1305_init((FAR poly1305_state *)&ctx->poly, ctx->key);
+  poly1305_begin((FAR poly1305_state *)&ctx->poly, ctx->key);
 }
 
 int chacha20_poly1305_update(FAR void *xctx, FAR const uint8_t *data,
@@ -160,7 +160,7 @@ void chacha20poly1305_encrypt(
   chacha_keysetup(&ctx, key, CHACHA20POLY1305_KEY_SIZE * 8);
   chacha_ivsetup(&ctx, (FAR uint8_t *) &le_nonce, NULL);
   chacha_encrypt_bytes(&ctx, b.b0, b.b0, sizeof(b.b0));
-  poly1305_init(&poly1305_ctx, b.b0);
+  poly1305_begin(&poly1305_ctx, b.b0);
 
   poly1305_update(&poly1305_ctx, ad, ad_len);
   poly1305_update(&poly1305_ctx, pad0, (0x10 - ad_len) & 0xf);
@@ -214,7 +214,7 @@ int chacha20poly1305_decrypt(
   chacha_keysetup(&ctx, key, CHACHA20POLY1305_KEY_SIZE * 8);
   chacha_ivsetup(&ctx, (FAR uint8_t *) &le_nonce, NULL);
   chacha_encrypt_bytes(&ctx, b.b0, b.b0, sizeof(b.b0));
-  poly1305_init(&poly1305_ctx, b.b0);
+  poly1305_begin(&poly1305_ctx, b.b0);
 
   poly1305_update(&poly1305_ctx, ad, ad_len);
   poly1305_update(&poly1305_ctx, pad0, (0x10 - ad_len) & 0xf);

--- a/crypto/poly1305.c
+++ b/crypto/poly1305.c
@@ -47,7 +47,7 @@ static void U32TO8(FAR unsigned char *p, unsigned long v)
  * Public Functions
  ****************************************************************************/
 
-void poly1305_init(FAR poly1305_state *st, FAR const unsigned char *key)
+void poly1305_begin(FAR poly1305_state *st, FAR const unsigned char *key)
 {
   /* r &= 0xffffffc0ffffffc0ffffffc0fffffff */
 

--- a/include/crypto/poly1305.h
+++ b/include/crypto/poly1305.h
@@ -29,7 +29,7 @@ typedef struct poly1305_state
   unsigned char final;
 } poly1305_state;
 
-void poly1305_init(FAR poly1305_state *, FAR const unsigned char *);
+void poly1305_begin(FAR poly1305_state *, FAR const unsigned char *);
 void poly1305_update(FAR poly1305_state *,
                      FAR const unsigned char *, size_t);
 void poly1305_finish(FAR poly1305_state *, FAR unsigned char *);


### PR DESCRIPTION
apps/crypto/libtomcrypt/libtomcrypt/src/mac/poly1305/poly1305.c:90: multiple definition of `poly1305_init';
nuttx/crypto/poly1305.c:51: first defined here
