### PR TITLE
libs/libc: Fix a fatal bug in fread

### DIFF
--- a/libs/libc/stdio/lib_libfread_unlocked.c
+++ b/libs/libc/stdio/lib_libfread_unlocked.c
@@ -137,6 +137,7 @@ ssize_t lib_fread_unlocked(FAR void *ptr, size_t count, FAR FILE *stream)
 
                   remaining -= gulp_size;
                   stream->fs_bufpos += gulp_size;
+                  dest += gulp_size;
                 }
 
               /* The buffer is empty OR we have already supplied the number


### PR DESCRIPTION
## Summary
Fix a bug the destination buffer is not updated.
It is caused by https://github.com/apache/nuttx/pull/10358.

## Impact
stdio fread

## Testing

