### PR TITLE
nuttx/usrsock: fix rpmsg_usrsock memory leak when stop remote

### DIFF
--- a/drivers/usrsock/usrsock_rpmsg_server.c
+++ b/drivers/usrsock/usrsock_rpmsg_server.c
@@ -1023,6 +1023,7 @@ static void usrsock_rpmsg_ns_unbind(FAR struct rpmsg_endpoint *ept)
     }
 
   rpmsg_destroy_ept(ept);
+  kmm_free(ept);
 }
 
 static int usrsock_rpmsg_ept_cb(FAR struct rpmsg_endpoint *ept,


### PR DESCRIPTION
## Summary
nuttx/usrsock: fix rpmsg_usrsock memory leak when stop remote

## Impact

## Testing

