### PR TITLE
fb: add vsync queue mechanism

### DIFF
--- a/arch/sim/Kconfig
+++ b/arch/sim/Kconfig
@@ -355,6 +355,14 @@ config SIM_FBBPP
 		If you use the X11 display emulation, the selected BPP must match the BPP
 		of your graphics hardware (probably 32 bits).  Default: 8
 
+config SIM_FRAMEBUFFER_COUNT
+	int "Framebuffer count"
+	depends on SIM_FRAMEBUFFER
+	default 2
+	---help---
+		Framebuffer count.
+		Simulated frambuffer count.  Default: 2
+
 endmenu
 
 choice

--- a/arch/sim/src/sim/posix/sim_x11framebuffer.c
+++ b/arch/sim/src/sim/posix/sim_x11framebuffer.c
@@ -55,7 +55,7 @@ static XShmSegmentInfo g_xshminfo;
 static int g_xerror;
 #endif
 static XImage *g_image;
-static unsigned char *g_framebuffer;
+static char *g_framebuffer;
 static unsigned short g_fbpixelwidth;
 static unsigned short g_fbpixelheight;
 static int g_shmcheckpoint = 0;
@@ -206,6 +206,9 @@ static void sim_x11uninit(void)
 
   if (g_shmcheckpoint > 1)
     {
+#ifdef CONFIG_SIM_X11NOSHM
+      g_image->data = g_framebuffer;
+#endif
       XDestroyImage(g_image);
     }
 
@@ -247,7 +250,8 @@ static void sim_x11uninitialize(void)
  ****************************************************************************/
 
 static inline int sim_x11mapsharedmem(Display *display,
-                                      int depth, unsigned int fblen)
+                                      int depth, unsigned int fblen,
+                                      int fbcount)
 {
 #ifndef CONFIG_SIM_X11NOSHM
   Status result;
@@ -282,8 +286,9 @@ static inline int sim_x11mapsharedmem(Display *display,
       g_shmcheckpoint++;
 
       g_xshminfo.shmid = shmget(IPC_PRIVATE,
-                              g_image->bytes_per_line * g_image->height,
-                              IPC_CREAT | 0777);
+                                g_image->bytes_per_line *
+                                g_image->height * fbcount,
+                                IPC_CREAT | 0777);
       if (g_xshminfo.shmid < 0)
         {
           sim_x11uninitialize();
@@ -312,7 +317,7 @@ static inline int sim_x11mapsharedmem(Display *display,
           goto shmerror;
         }
 
-      g_framebuffer = (unsigned char *)g_image->data;
+      g_framebuffer = g_image->data;
       g_shmcheckpoint++;
     }
   else
@@ -324,10 +329,10 @@ shmerror:
 #endif
       b_useshm = 0;
 
-      g_framebuffer = malloc(fblen);
+      g_framebuffer = malloc(fblen * fbcount);
 
       g_image = XCreateImage(display, DefaultVisual(display, g_screen),
-                             depth, ZPixmap, 0, (char *)g_framebuffer,
+                             depth, ZPixmap, 0, g_framebuffer,
                              g_fbpixelwidth, g_fbpixelheight,
                              8, 0);
 
@@ -357,7 +362,7 @@ shmerror:
 
 int sim_x11initialize(unsigned short width, unsigned short height,
                      void **fbmem, size_t *fblen, unsigned char *bpp,
-                     unsigned short *stride)
+                     unsigned short *stride, int fbcount)
 {
   XWindowAttributes windowattributes;
   Display *display;
@@ -397,7 +402,7 @@ int sim_x11initialize(unsigned short width, unsigned short height,
 
   /* Map the window to shared memory */
 
-  sim_x11mapsharedmem(display, windowattributes.depth, *fblen);
+  sim_x11mapsharedmem(display, windowattributes.depth, *fblen, fbcount);
 
   *fbmem  = (void *)g_framebuffer;
   g_display = display;
@@ -434,6 +439,22 @@ int sim_x11closewindow(void)
 
   XUnmapWindow(g_display, g_window);
   XSync(g_display, 0);
+
+  return 0;
+}
+
+/****************************************************************************
+ * Name: sim_x11setoffset
+ ****************************************************************************/
+
+int sim_x11setoffset(unsigned int offset)
+{
+  if (g_display == NULL)
+    {
+      return -ENODEV;
+    }
+
+  g_image->data = g_framebuffer + offset;
 
   return 0;
 }

--- a/arch/sim/src/sim/sim_framebuffer.c
+++ b/arch/sim/src/sim/sim_framebuffer.c
@@ -424,12 +424,8 @@ void sim_x11loop(void)
 
   if (now - last >= MSEC2TICK(16))
     {
-      if (sim_x11update() >= 0)
-        {
-          fb_pollnotify(&g_fbobject);
-        }
-
       last = now;
+      sim_x11update();
     }
 #endif
 }

--- a/arch/sim/src/sim/sim_internal.h
+++ b/arch/sim/src/sim/sim_internal.h
@@ -261,10 +261,11 @@ void sim_registerblockdevice(void);
 #ifdef CONFIG_SIM_X11FB
 int sim_x11initialize(unsigned short width, unsigned short height,
                       void **fbmem, size_t *fblen, unsigned char *bpp,
-                      unsigned short *stride);
+                      unsigned short *stride, int fbcount);
 int sim_x11update(void);
 int sim_x11openwindow(void);
 int sim_x11closewindow(void);
+int sim_x11setoffset(unsigned int offset);
 #ifdef CONFIG_FB_CMAP
 int sim_x11cmap(unsigned short first, unsigned short len,
                 unsigned char *red, unsigned char *green,

--- a/arch/sim/src/sim/sim_lcd.c
+++ b/arch/sim/src/sim/sim_lcd.c
@@ -79,6 +79,10 @@
 #  error "Unsupported BPP"
 #endif
 
+#if !defined(CONFIG_LCD_FBCOUNT)
+#  define CONFIG_LCD_FBCOUNT 1
+#endif
+
 /****************************************************************************
  * Private Type Definition
  ****************************************************************************/
@@ -467,7 +471,7 @@ int board_lcd_initialize(void)
 #ifdef CONFIG_SIM_X11FB
   ret = sim_x11initialize(CONFIG_SIM_FBWIDTH, CONFIG_SIM_FBHEIGHT,
                           (void**)&g_planeinfo.buffer, &g_fblen,
-                          &g_planeinfo.bpp, &g_stride);
+                          &g_planeinfo.bpp, &g_stride, CONFIG_LCD_FBCOUNT);
 #endif
 
   return ret;

--- a/drivers/video/Kconfig
+++ b/drivers/video/Kconfig
@@ -50,6 +50,11 @@ config VIDEO_FB
 	bool "Framebuffer character driver"
 	default n
 
+config VIDEO_FB_NPOLLWAITERS
+	int "Video fb poll count of each layer"
+	depends on VIDEO_FB
+	default 2
+
 config VIDEO_STREAM
 	bool "Video Stream Support"
 	default n

--- a/drivers/video/fb.c
+++ b/drivers/video/fb.c
@@ -63,7 +63,7 @@ struct fb_chardev_s
   FAR struct fb_vtable_s *vtable; /* Framebuffer interface */
   FAR struct pollfd *fds;         /* Polling structure of waiting thread */
   uint8_t plane;                  /* Video plan number */
-  volatile bool pollready;        /* Poll ready flag */
+  volatile int pollcnt;           /* Poll ready count */
   clock_t vsyncoffset;            /* VSync offset ticks */
   struct wdog_s wdog;             /* VSync offset timer */
 #ifdef CONFIG_FB_OVERLAY
@@ -281,8 +281,6 @@ static ssize_t fb_write(FAR struct file *filep, FAR const char *buffer,
     {
       return ret;
     }
-
-  fb->pollready = false;
 
   /* Get the start and size of the transfer */
 
@@ -680,14 +678,11 @@ static int fb_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
           DEBUGASSERT(pinfo != NULL && fb->vtable != NULL &&
                       fb->vtable->pandisplay != NULL);
           ret = fb->vtable->pandisplay(fb->vtable, pinfo);
-          fb->pollready = false;
-        }
-        break;
+          fb->pollcnt--;
 
-      case FBIO_CLEARNOTIFY:
-        {
-          fb->pollready = false;
-          ret = OK;
+          /* Check pan display overrun. */
+
+          DEBUGASSERT(fb->pollcnt >= 0);
         }
         break;
 
@@ -910,7 +905,7 @@ static int fb_poll(FAR struct file *filep, struct pollfd *fds, bool setup)
           return -EBUSY;
         }
 
-      if (fb->pollready)
+      if (fb->pollcnt > 0)
         {
           poll_notify(&fb->fds, 1, POLLOUT);
         }
@@ -982,7 +977,7 @@ static void fb_do_pollnotify(wdparm_t arg)
 {
   FAR struct fb_chardev_s *fb = (FAR struct fb_chardev_s *)arg;
 
-  fb->pollready = true;
+  fb->pollcnt++;
 
   /* Notify framebuffer is writable. */
 
@@ -1057,6 +1052,7 @@ int fb_register(int display, int plane)
   FAR struct fb_chardev_s *fb;
   struct fb_panelinfo_s panelinfo;
   struct fb_videoinfo_s vinfo;
+  struct fb_planeinfo_s pinfo;
 #ifdef CONFIG_FB_OVERLAY
   struct fb_overlayinfo_s oinfo;
 #endif
@@ -1111,6 +1107,28 @@ int fb_register(int display, int plane)
 
   nplanes = vinfo.nplanes;
   DEBUGASSERT(vinfo.nplanes > 0 && (unsigned)plane < vinfo.nplanes);
+
+  /* Get plane info */
+
+  DEBUGASSERT(fb->vtable->getplaneinfo != NULL);
+  ret = fb->vtable->getplaneinfo(fb->vtable, fb->plane, &pinfo);
+  if (ret < 0)
+    {
+      gerr("ERROR: getplaneinfo() failed: %d\n", ret);
+      goto errout_with_fb;
+    }
+
+  /* The initial value of pollcnt is the number of virtual framebuffers */
+
+  if (pinfo.yres_virtual > 0)
+    {
+      fb->pollcnt = pinfo.yres_virtual / vinfo.yres;
+      DEBUGASSERT(fb->pollcnt > 0);
+    }
+  else
+    {
+      fb->pollcnt = 1;
+    }
 
   /* Get panel info */
 

--- a/drivers/video/fb.c
+++ b/drivers/video/fb.c
@@ -98,6 +98,9 @@ static int     fb_poll(FAR struct file *filep, FAR struct pollfd *fds,
                        bool setup);
 static int     fb_get_panelinfo(FAR struct fb_chardev_s *fb,
                                 FAR struct fb_panelinfo_s *panelinfo);
+static int     fb_get_planeinfo(FAR struct fb_chardev_s *fb,
+                                FAR struct fb_planeinfo_s *pinfo,
+                                uint8_t display);
 
 /****************************************************************************
  * Private Data
@@ -429,9 +432,8 @@ static int fb_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
           FAR struct fb_planeinfo_s *pinfo =
             (FAR struct fb_planeinfo_s *)((uintptr_t)arg);
 
-          DEBUGASSERT(pinfo != 0 && fb->vtable != NULL &&
-                      fb->vtable->getplaneinfo != NULL);
-          ret = fb->vtable->getplaneinfo(fb->vtable, fb->plane, pinfo);
+          DEBUGASSERT(pinfo != 0);
+          ret = fb_get_planeinfo(fb, pinfo, pinfo->display);
         }
         break;
 
@@ -701,16 +703,14 @@ static int fb_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
             (FAR struct fb_var_screeninfo *)((uintptr_t)arg);
 
           DEBUGASSERT(varinfo != 0 && fb->vtable != NULL &&
-                      fb->vtable->getvideoinfo != NULL &&
-                      fb->vtable->getplaneinfo != NULL);
+                      fb->vtable->getvideoinfo != NULL);
           ret = fb->vtable->getvideoinfo(fb->vtable, &vinfo);
           if (ret < 0)
             {
               break;
             }
 
-          memset(&pinfo, 0, sizeof(pinfo));
-          ret = fb->vtable->getplaneinfo(fb->vtable, fb->plane, &pinfo);
+          ret = fb_get_planeinfo(fb, &pinfo, 0);
           if (ret < 0)
             {
               break;
@@ -795,16 +795,14 @@ static int fb_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
             (FAR struct fb_fix_screeninfo *)((uintptr_t)arg);
 
           DEBUGASSERT(fixinfo != 0 && fb->vtable != NULL &&
-                      fb->vtable->getvideoinfo != NULL &&
-                      fb->vtable->getplaneinfo != NULL);
+                      fb->vtable->getvideoinfo != NULL);
           ret = fb->vtable->getvideoinfo(fb->vtable, &vinfo);
           if (ret < 0)
             {
               break;
             }
 
-          memset(&pinfo, 0, sizeof(pinfo));
-          ret = fb->vtable->getplaneinfo(fb->vtable, fb->plane, &pinfo);
+          ret = fb_get_planeinfo(fb, &pinfo, 0);
           if (ret < 0)
             {
               break;
@@ -950,21 +948,42 @@ static int fb_get_panelinfo(FAR struct fb_chardev_s *fb,
     }
 #endif
 
-  DEBUGASSERT(fb->vtable != NULL);
-  DEBUGASSERT(fb->vtable->getplaneinfo != NULL);
-  memset(&pinfo, 0, sizeof(pinfo));
-
-  ret = fb->vtable->getplaneinfo(fb->vtable, fb->plane, &pinfo);
-
+  ret = fb_get_planeinfo(fb, &pinfo, 0);
   if (ret < 0)
     {
-      gerr("ERROR: getplaneinfo() failed: %d\n", ret);
       return ret;
     }
 
   panelinfo->fbmem  = pinfo.fbmem;
   panelinfo->fblen  = pinfo.fblen;
   panelinfo->bpp    = pinfo.bpp;
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: fb_get_planeinfo
+ ****************************************************************************/
+
+static int fb_get_planeinfo(FAR struct fb_chardev_s *fb,
+                            FAR struct fb_planeinfo_s *pinfo,
+                            uint8_t display)
+{
+  int ret;
+
+  DEBUGASSERT(fb->vtable != NULL);
+  DEBUGASSERT(fb->vtable->getplaneinfo != NULL);
+
+  memset(pinfo, 0, sizeof(struct fb_planeinfo_s));
+  pinfo->display = display;
+
+  ret = fb->vtable->getplaneinfo(fb->vtable, fb->plane, pinfo);
+
+  if (ret < 0)
+    {
+      gerr("ERROR: getplaneinfo() failed: %d\n", ret);
+      return ret;
+    }
 
   return OK;
 }
@@ -1110,11 +1129,9 @@ int fb_register(int display, int plane)
 
   /* Get plane info */
 
-  DEBUGASSERT(fb->vtable->getplaneinfo != NULL);
-  ret = fb->vtable->getplaneinfo(fb->vtable, fb->plane, &pinfo);
+  ret = fb_get_planeinfo(fb, &pinfo, 0);
   if (ret < 0)
     {
-      gerr("ERROR: getplaneinfo() failed: %d\n", ret);
       goto errout_with_fb;
     }
 

--- a/include/nuttx/video/fb.h
+++ b/include/nuttx/video/fb.h
@@ -181,6 +181,8 @@
 
 /* Hardware overlay acceleration ********************************************/
 
+#define FB_NO_OVERLAY         -1
+
 #ifdef CONFIG_FB_OVERLAY
 #  define FB_ACCL_TRANSP      0x01        /* Hardware tranparency support */
 #  define FB_ACCL_CHROMA      0x02        /* Hardware chromakey support */
@@ -673,6 +675,14 @@ struct fb_setcursor_s
 };
 #endif
 
+union fb_paninfo_u
+{
+  struct fb_planeinfo_s planeinfo;
+#ifdef CONFIG_FB_OVERLAY
+  struct fb_overlayinfo_s overlayinfo;
+#endif
+};
+
 /* The framebuffer "object" is accessed through within the OS via
  * the following vtable:
  */
@@ -996,17 +1006,55 @@ FAR struct fb_vtable_s *up_fbgetvplane(int display, int vplane);
 void up_fbuninitialize(int display);
 
 /****************************************************************************
- * Name: fb_pollnotify
- *
+ * Name: fb_peek_paninfo
  * Description:
- *   Notify the waiting thread that the framebuffer can be written.
+ *   Peek a frame from pan info queue of the specified overlay.
  *
  * Input Parameters:
- *   vtable - Pointer to framebuffer's virtual table.
+ *   vtable  - Pointer to framebuffer's virtual table.
+ *   info    - Pointer to pan info.
+ *   overlay - Overlay index.
  *
+ * Returned Value:
+ *   Zero is returned on success; a negated errno value is returned on any
+ *   failure.
  ****************************************************************************/
 
-void fb_pollnotify(FAR struct fb_vtable_s *vtable);
+int fb_peek_paninfo(FAR struct fb_vtable_s *vtable,
+                    FAR union fb_paninfo_u *info,
+                    int overlay);
+
+/****************************************************************************
+ * Name: fb_remove_paninfo
+ * Description:
+ *   Remove a frame from pan info queue of the specified overlay.
+ *
+ * Input Parameters:
+ *   vtable  - Pointer to framebuffer's virtual table.
+ *   overlay - Overlay index.
+ *
+ * Returned Value:
+ *   Zero is returned on success; a negated errno value is returned on any
+ *   failure.
+ ****************************************************************************/
+
+int fb_remove_paninfo(FAR struct fb_vtable_s *vtable, int overlay);
+
+/****************************************************************************
+ * Name: fb_paninfo_count
+ * Description:
+ *   Get pan info count of specified overlay pan info queue.
+ *
+ * Input Parameters:
+ *   vtable  - Pointer to framebuffer's virtual table.
+ *   overlay - Overlay index.
+ *
+ * Returned Value:
+ *   a non-negative value is returned on success; a negated errno value is
+ *   returned on any failure.
+ ****************************************************************************/
+
+int fb_paninfo_count(FAR struct fb_vtable_s *vtable, int overlay);
 
 /****************************************************************************
  * Name: fb_register

--- a/include/nuttx/video/fb.h
+++ b/include/nuttx/video/fb.h
@@ -296,17 +296,15 @@
                                                * Argument: read-only struct
                                                *           fb_planeinfo_s* */
 
-#define FBIO_CLEARNOTIFY      _FBIOC(0x0019)  /* Clear notify signal */
-
-#define FBIOSET_VSYNCOFFSET   _FBIOC(0x001a)  /* Set VSync offset in usec
+#define FBIOSET_VSYNCOFFSET   _FBIOC(0x0019)  /* Set VSync offset in usec
                                                * Argument:             int */
 
 /* Linux Support ************************************************************/
 
-#define FBIOGET_VSCREENINFO   _FBIOC(0x001b)  /* Get video variable info */
+#define FBIOGET_VSCREENINFO   _FBIOC(0x001a)  /* Get video variable info */
                                               /* Argument: writable struct
                                                *           fb_var_screeninfo */
-#define FBIOGET_FSCREENINFO   _FBIOC(0x001c)  /* Get video fix info */
+#define FBIOGET_FSCREENINFO   _FBIOC(0x001b)  /* Get video fix info */
                                               /* Argument: writable struct
                                                *           fb_fix_screeninfo */
 


### PR DESCRIPTION
## Summary
Refactor vsync queue and adapt to sim and goldfish modules.

In the new mechanism, the vendor driver does not need to create its own queue management mechanism. it is uniformly handled by the upper layer .
It also supports multiple file opening and polling for fb poll, such as polling for primary fb and overlay at the same time.

## Impact

## Testing

