### PR TITLE
Pinephone Pro: Add support for board reset.

### DIFF
--- a/boards/arm64/rk3399/pinephonepro/src/Makefile
+++ b/boards/arm64/rk3399/pinephonepro/src/Makefile
@@ -24,6 +24,9 @@ CSRCS = pinephonepro_boardinit.c pinephonepro_bringup.c
 
 ifeq ($(CONFIG_BOARDCTL),y)
 CSRCS += pinephonepro_appinit.c
+ifeq ($(CONFIG_BOARDCTL_RESET),y)
+CSRCS += pinephonepro_reset.c
+endif
 endif
 
 include $(TOPDIR)/boards/Board.mk

--- a/boards/arm64/rk3399/pinephonepro/src/pinephonepro_appinit.c
+++ b/boards/arm64/rk3399/pinephonepro/src/pinephonepro_appinit.c
@@ -64,7 +64,7 @@ int board_app_initialize(uintptr_t arg)
 #ifndef CONFIG_BOARD_LATE_INITIALIZE
   /* Perform board initialization */
 
-  return pinephone_bringup();
+  return pinephonepro_bringup();
 #else
   return OK;
 #endif

--- a/boards/arm64/rk3399/pinephonepro/src/pinephonepro_boardinit.c
+++ b/boards/arm64/rk3399/pinephonepro/src/pinephonepro_boardinit.c
@@ -101,6 +101,6 @@ void board_late_initialize(void)
 {
   /* Perform board initialization */
 
-  pinephone_bringup();
+  pinephonepro_bringup();
 }
 #endif /* CONFIG_BOARD_LATE_INITIALIZE */

--- a/boards/arm64/rk3399/pinephonepro/src/pinephonepro_bringup.c
+++ b/boards/arm64/rk3399/pinephonepro/src/pinephonepro_bringup.c
@@ -37,14 +37,14 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: pinephone_bringup
+ * Name: pinephonepro_bringup
  *
  * Description:
  *   Bring up board features
  *
  ****************************************************************************/
 
-int pinephone_bringup(void)
+int pinephonepro_bringup(void)
 {
   int ret = OK;
 

--- a/boards/arm64/rk3399/pinephonepro/src/pinephonepro_reset.c
+++ b/boards/arm64/rk3399/pinephonepro/src/pinephonepro_reset.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * boards/arm64/rk3399/pinephonepro/src/pinephonepro.h
+ * boards/arm64/rk3399/pinephonepro/src/pinephonepro_reset.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,32 +18,49 @@
  *
  ****************************************************************************/
 
-#ifndef __BOARDS_ARM64_RK3399_PINEPHONE_SRC_PINEPHONEPRO_H
-#define __BOARDS_ARM64_RK3399_PINEPHONE_SRC_PINEPHONEPRO_H
-
 /****************************************************************************
  * Included Files
  ****************************************************************************/
 
 #include <nuttx/config.h>
-#include <stdint.h>
-#ifndef __ASSEMBLY__
+
+#include <nuttx/arch.h>
+#include <nuttx/board.h>
+
+#ifdef CONFIG_BOARDCTL_RESET
 
 /****************************************************************************
- * Public Functions Definitions
+ * Private Functions
  ****************************************************************************/
 
 /****************************************************************************
- * Name: pinephonepro_bringup
+ * Public functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_reset
  *
  * Description:
- *   Bring up board features
+ *   Reset board.  Support for this function is required by board-level
+ *   logic if CONFIG_BOARDCTL_RESET is selected.
+ *
+ * Input Parameters:
+ *   status - Status information provided with the reset event.  This
+ *            meaning of this status information is board-specific.  If not
+ *            used by a board, the value zero may be provided in calls to
+ *            board_reset().
+ *
+ * Returned Value:
+ *   If this function returns, then it was not possible to power-off the
+ *   board due to some constraints.  The return value int this case is a
+ *   board-specific reason for the failure to shutdown.
  *
  ****************************************************************************/
 
-#if defined(CONFIG_BOARDCTL) || defined(CONFIG_BOARD_LATE_INITIALIZE)
-int pinephonepro_bringup(void);
-#endif
+int board_reset(int status)
+{
+  up_systemreset();
+  return 0;
+}
 
-#endif /* __ASSEMBLY__ */
-#endif /* __BOARDS_ARM64_RK3399_PINEPHONE_SRC_PINEPHONEPRO_H */
+#endif /* CONFIG_BOARDCTL_RESET */


### PR DESCRIPTION
## Summary

* Add support for board reset this fixes an issue where nsh `reboot` would hang

## Impact

* Add new board reset file `boards/arm64/rk3399/pinephonepro/src/pinephonepro_reset.c`
* Rename function from `pinephone_bringup` to `pinephonepro_bringup` based on suggestion from @lupyuen 
## Testing
See below
```txt

Tow-Boot TPL 2022.07
Channel 0: LPDDR4, 50MHz
BW=32 Col=10 Bk=8 CS0 Row=15 CS1 Row=15 CS=2 Die BW=16 Size=2048MB
Channel 1: LPDDR4, 50MHz
BW=32 Col=10 Bk=8 CS0 Row=15 CS1 Row=15 CS=2 Die BW=16 Size=2048MB
256B stride
lpddr4_set_rate: change freq to 400000000 mhz 0, 1
lpddr4_set_rate: change freq to 800000000 mhz 1, 0
Trying to boot from BOOTROM
Returning to boot ROM...

Tow-Boot SPL 2022.07
Trying to boot from SPI
NOTICE:  BL31: v2.6(release):
NOTICE:  BL31: Built : 00:00:00, Jan  1 1980


Tow-Boot 2022.07 006 [variant: spi]

SoC: Rockchip rk3399
Reset cause: POR
Model: Pine64 PinePhonePro
DRAM:  3.9 GiB
Initializing Pinephone Pro charger
PMIC:  RK8180 (on=0x40, off=0x00)
Core:  324 devices, 34 uclasses, devicetree: separate
MMC:   mmc@fe310000: 3, mmc@fe320000: 1, mmc@fe330000: 0
Loading Environment from SPIFlash... SF: Detected gd25lq128e with page size 256 Bytes, erase size 4 KiB, total 16 MiB
*** Warning - bad CRC, using default environment

In:    serial
Out:   serial
Err:   serial
Model: Pine64 PinePhonePro
Net:   No ethernet found.
starting USB...
Bus usb@fe380000: ehci_generic usb@fe380000: Failed to get clocks (ret=-19)
Port not available.
Bus usb@fe3a0000: USB OHCI 1.0
Bus usb@fe3c0000: ehci_generic usb@fe3c0000: Failed to get clocks (ret=-19)
Port not available.
Bus usb@fe3e0000: USB OHCI 1.0
scanning bus usb@fe3a0000 for devices... 1 USB Device(s) found
scanning bus usb@fe3e0000 for devices... 1 USB Device(s) found
       scanning usb for storage devices... 0 Storage Device(s) found
Please press [ESCAPE] or [CTRL+C] to enter the boot menu.
off
off
switch to partitions #0, OK
mmc0(part 0) is current device
Scanning mmc 0:1...
Found U-Boot script /boot.scr
788 bytes read in 9 ms (85 KiB/s)
## Executing script at 00500000
Bad data crc
SCRIPT FAILED: continuing...
No EFI system partition
BootOrder not defined
EFI boot manager: Cannot load any image
switch to partitions #0, OK
mmc1 is current device
Scanning mmc 1:1...
Found /extlinux/extlinux.conf
Retrieving file: /extlinux/extlinux.conf
U-Boot menu
1:      Mobian GNU/Linux 6.1-rockchip
Enter choice: 1:        Mobian GNU/Linux 6.1-rockchip
Retrieving file: /Image.gz
Retrieving file: /rk3399-pinephone-pro.dtb
   Uncompressing Kernel Image
## Flattened Device Tree blob at 01f00000
   Booting using the fdt blob at 0x1f00000
   Loading Device Tree to 00000000f4ed2000, end 00000000f4ee62fb ... OK

Starting kernel ...

- Ready to Boot Primary CPU
- Boot from EL2
- Boot from EL1
- Boot to C runtime for OS Initialize
nsh: mkfatfs: command not found

NuttShell (NSH)
nsh> reset
nsh: reset: command not found
nsh> reboot▒
Tow-Boot TPL 2022.07
Channel 0: LPDDR4, 50MHz
BW=32 Col=10 Bk=8 CS0 Row=15 CS1 Row=15 CS=2 Die BW=16 Size=2048MB
Channel 1: LPDDR4, 50MHz
BW=32 Col=10 Bk=8 CS0 Row=15 CS1 Row=15 CS=2 Die BW=16 Size=2048MB
256B stride
lpddr4_set_rate: change freq to 400000000 mhz 0, 1
lpddr4_set_rate: change freq to 800000000 mhz 1, 0
Trying to boot from BOOTROM
Returning to boot ROM...

Tow-Boot SPL 2022.07
Trying to boot from SPI
NOTICE:  BL31: v2.6(release):
NOTICE:  BL31: Built : 00:00:00, Jan  1 1980


Tow-Boot 2022.07 006 [variant: spi]

SoC: Rockchip rk3399
Reset cause: RST
Model: Pine64 PinePhonePro
DRAM:  3.9 GiB
Initializing Pinephone Pro charger
PMIC:  RK8180 (on=0x40, off=0x00)
```
