### PR TITLE
button_upper.c:Modify log level

### DIFF
--- a/drivers/input/button_upper.c
+++ b/drivers/input/button_upper.c
@@ -630,7 +630,7 @@ static int btn_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
       break;
 
     default:
-      ierr("ERROR: Unrecognized command: %d\n", cmd);
+      iinfo("ERROR: Unrecognized command: %d\n", cmd);
       ret = -ENOTTY;
       break;
     }


### PR DESCRIPTION
## Summary
In the previous PR#10267, there was a problem that fsync would fail if the device node was registered as a BCH, so after revert that patch, the log level was modified to avoid reproducing the same problem (unknown command message in non-block device situations).

## Impact

## Testing

