### PR TITLE
arch/arm/armv[7|8]-m: implement dcache clean as barrier in write-through mode

### DIFF
--- a/arch/arm/src/armv7-m/arm_cache.c
+++ b/arch/arm/src/armv7-m/arm_cache.c
@@ -838,10 +838,10 @@ void up_clean_dcache(uintptr_t start, uintptr_t end)
       start += ssize;
     }
   while (start < end);
+#endif /* !CONFIG_ARMV7M_DCACHE_WRITETHROUGH */
 
   ARM_DSB();
   ARM_ISB();
-#endif /* !CONFIG_ARMV7M_DCACHE_WRITETHROUGH */
 }
 #endif /* CONFIG_ARMV7M_DCACHE */
 
@@ -915,10 +915,10 @@ void up_clean_dcache_all(void)
       while (tmpways--);
     }
   while (sets--);
+#endif /* !CONFIG_ARMV7M_DCACHE_WRITETHROUGH */
 
   ARM_DSB();
   ARM_ISB();
-#endif /* !CONFIG_ARMV7M_DCACHE_WRITETHROUGH */
 }
 #endif /* CONFIG_ARMV7M_DCACHE */
 

--- a/arch/arm/src/armv8-m/arm_cache.c
+++ b/arch/arm/src/armv8-m/arm_cache.c
@@ -838,10 +838,10 @@ void up_clean_dcache(uintptr_t start, uintptr_t end)
       start += ssize;
     }
   while (start < end);
+#endif /* !CONFIG_ARMV8M_DCACHE_WRITETHROUGH */
 
   ARM_DSB();
   ARM_ISB();
-#endif /* !CONFIG_ARMV8M_DCACHE_WRITETHROUGH */
 }
 #endif /* CONFIG_ARMV8M_DCACHE */
 
@@ -915,10 +915,10 @@ void up_clean_dcache_all(void)
       while (tmpways--);
     }
   while (sets--);
+#endif /* !CONFIG_ARMV8M_DCACHE_WRITETHROUGH */
 
   ARM_DSB();
   ARM_ISB();
-#endif /* !CONFIG_ARMV8M_DCACHE_WRITETHROUGH */
 }
 #endif /* CONFIG_ARMV8M_DCACHE */
 

--- a/arch/arm/src/samv7/sam_emac.c
+++ b/arch/arm/src/samv7/sam_emac.c
@@ -1407,13 +1407,6 @@ static int sam_transmit(struct sam_emac_s *priv, int qid)
   regval |= EMAC_NCR_TSTART;
   sam_putreg(priv, SAM_EMAC_NCR_OFFSET, regval);
 
-  /* REVISIT: Sometimes TSTART is missed?  In this case, the symptom is
-   * that the packet is not sent until the next transfer when TXSTART
-   * is set again.
-   */
-
-  sam_putreg(priv, SAM_EMAC_NCR_OFFSET, regval);
-
   /* Setup the TX timeout watchdog (perhaps restarting the timer) */
 
   wd_start(&priv->txtimeout, SAM_TXTIMEOUT,


### PR DESCRIPTION
## Summary
Implement dcache clean as barrier (DSB + ISB) in write-through mode.

This change fixes the issue when SAMv7 GMAC sometimes does not start packet transmission. The issue is that EMAC_NCR_TSTART is written to EMAC_NCR register while tx descriptor is not delivered to memory.

## Impact
Improve throughput of SAMv7 Ethernet. Should give positive influence on all devices based on armv7-m and armv8-m

## Testing
Tested on custom board based on SAMv7. More testing from community is welcomed