### PR TITLE
rpmsg_sockif: add recvlock for conn->sendsize in connect

### DIFF
--- a/net/rpmsg/rpmsg_sockif.c
+++ b/net/rpmsg/rpmsg_sockif.c
@@ -717,8 +717,10 @@ static int rpmsg_socket_connect_internal(FAR struct socket *psock)
       return ret;
     }
 
+  nxmutex_lock(&conn->recvlock);
   if (conn->sendsize == 0)
     {
+      nxmutex_unlock(&conn->recvlock);
       if (_SS_ISNONBLOCK(conn->sconn.s_flags))
         {
           return -EINPROGRESS;
@@ -735,6 +737,10 @@ static int rpmsg_socket_connect_internal(FAR struct socket *psock)
                                     NULL,
                                     NULL);
         }
+    }
+  else
+    {
+      nxmutex_unlock(&conn->recvlock);
     }
 
   return ret;


### PR DESCRIPTION
## Summary
conn->sendsize is used in rpmsg_socket_ept_cb() and rpmsg_socket_connect_internal(), the connected event may be missed as stated below:

1. in rpmsg_socket_connect_internal(), judge conn->sendsize == 0 and prepare to wait sendsem;
2. interrupt by rptun thread, rpmsg_socket_ept_cb() is called to update conn->sendsize and post the sendsem, but the no one wait rx sem yet, so not post (see rpmsg_socket_post());
3. return to rpmsg_socket_connect_internal() to wait the sendsem, but has miss the connected event.

So add recvlock in rpmsg_socket_connect_internal() also.


## Impact
rpmsg socket

## Testing
Tested in BES chip (Cortex-A7 Dual Core and Cortex-M33 Single Core)
