### PR TITLE
MLD: add byte order conversion for ipv6 address printing

### DIFF
--- a/net/mld/mld_group.c
+++ b/net/mld/mld_group.c
@@ -156,17 +156,18 @@ FAR struct mld_group_s *mld_grpfind(FAR struct net_driver_s *dev,
   FAR struct mld_group_s *group;
 
   mldinfo("Searching for group: %04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
-          addr[0], addr[1], addr[2], addr[3], addr[4], addr[5], addr[6],
-          addr[7]);
+          NTOHS(addr[0]), NTOHS(addr[1]), NTOHS(addr[2]), NTOHS(addr[3]),
+          NTOHS(addr[4]), NTOHS(addr[5]), NTOHS(addr[6]), NTOHS(addr[7]));
 
   for (group = (FAR struct mld_group_s *)dev->d_mld.grplist.head;
        group;
        group = group->next)
     {
       mldinfo("Compare: %04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
-              group->grpaddr[0], group->grpaddr[1], group->grpaddr[2],
-              group->grpaddr[3], group->grpaddr[4], group->grpaddr[5],
-              group->grpaddr[6], group->grpaddr[7]);
+              NTOHS(group->grpaddr[0]), NTOHS(group->grpaddr[1]),
+              NTOHS(group->grpaddr[2]), NTOHS(group->grpaddr[3]),
+              NTOHS(group->grpaddr[4]), NTOHS(group->grpaddr[5]),
+              NTOHS(group->grpaddr[6]), NTOHS(group->grpaddr[7]));
 
       if (net_ipv6addr_cmp(group->grpaddr, addr))
         {

--- a/net/mld/mld_join.c
+++ b/net/mld/mld_join.c
@@ -147,14 +147,14 @@ int mld_joingroup(FAR const struct ipv6_mreq *mrec)
     }
 
   mldinfo("Join group: %04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
-          mrec->ipv6mr_multiaddr.s6_addr16[0],
-          mrec->ipv6mr_multiaddr.s6_addr16[1],
-          mrec->ipv6mr_multiaddr.s6_addr16[2],
-          mrec->ipv6mr_multiaddr.s6_addr16[3],
-          mrec->ipv6mr_multiaddr.s6_addr16[4],
-          mrec->ipv6mr_multiaddr.s6_addr16[5],
-          mrec->ipv6mr_multiaddr.s6_addr16[5],
-          mrec->ipv6mr_multiaddr.s6_addr16[7]);
+          NTOHS(mrec->ipv6mr_multiaddr.s6_addr16[0]),
+          NTOHS(mrec->ipv6mr_multiaddr.s6_addr16[1]),
+          NTOHS(mrec->ipv6mr_multiaddr.s6_addr16[2]),
+          NTOHS(mrec->ipv6mr_multiaddr.s6_addr16[3]),
+          NTOHS(mrec->ipv6mr_multiaddr.s6_addr16[4]),
+          NTOHS(mrec->ipv6mr_multiaddr.s6_addr16[5]),
+          NTOHS(mrec->ipv6mr_multiaddr.s6_addr16[6]),
+          NTOHS(mrec->ipv6mr_multiaddr.s6_addr16[7]));
 
   /* Check if a this address is already in the group */
 

--- a/net/mld/mld_leave.c
+++ b/net/mld/mld_leave.c
@@ -93,14 +93,14 @@ int mld_leavegroup(FAR const struct ipv6_mreq *mrec)
     }
 
   mldinfo("Leave group: %04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
-          mrec->ipv6mr_multiaddr.s6_addr16[0],
-          mrec->ipv6mr_multiaddr.s6_addr16[1],
-          mrec->ipv6mr_multiaddr.s6_addr16[2],
-          mrec->ipv6mr_multiaddr.s6_addr16[3],
-          mrec->ipv6mr_multiaddr.s6_addr16[4],
-          mrec->ipv6mr_multiaddr.s6_addr16[5],
-          mrec->ipv6mr_multiaddr.s6_addr16[5],
-          mrec->ipv6mr_multiaddr.s6_addr16[7]);
+          NTOHS(mrec->ipv6mr_multiaddr.s6_addr16[0]),
+          NTOHS(mrec->ipv6mr_multiaddr.s6_addr16[1]),
+          NTOHS(mrec->ipv6mr_multiaddr.s6_addr16[2]),
+          NTOHS(mrec->ipv6mr_multiaddr.s6_addr16[3]),
+          NTOHS(mrec->ipv6mr_multiaddr.s6_addr16[4]),
+          NTOHS(mrec->ipv6mr_multiaddr.s6_addr16[5]),
+          NTOHS(mrec->ipv6mr_multiaddr.s6_addr16[6]),
+          NTOHS(mrec->ipv6mr_multiaddr.s6_addr16[7]));
 
   /* Find the entry corresponding to the address leaving the group */
 

--- a/net/mld/mld_mcastmac.c
+++ b/net/mld/mld_mcastmac.c
@@ -55,8 +55,9 @@ static void mld_mcastmac(FAR const net_ipv6addr_t ipaddr, FAR uint8_t *mac)
   FAR uint8_t *ipaddr8 = (FAR uint8_t *)ipaddr;
 
   mldinfo("Mcast IP: %04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
-          ipaddr[0], ipaddr[1], ipaddr[2], ipaddr[3],
-          ipaddr[4], ipaddr[5], ipaddr[6], ipaddr[7]);
+          NTOHS(ipaddr[0]), NTOHS(ipaddr[1]), NTOHS(ipaddr[2]),
+          NTOHS(ipaddr[3]), NTOHS(ipaddr[4]), NTOHS(ipaddr[5]),
+          NTOHS(ipaddr[6]), NTOHS(ipaddr[7]));
 
   /* For the MAC address by insert the low 32 Bits of the multicast IPv6
    * Address into the Ethernet Address .  This mapping is from the IETF

--- a/net/mld/mld_report.c
+++ b/net/mld/mld_report.c
@@ -59,8 +59,9 @@ int mld_report(FAR struct net_driver_s *dev,
    */
 
   mldinfo("grpaddr: %04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
-          grpaddr[0], grpaddr[1], grpaddr[2], grpaddr[3],
-          grpaddr[4], grpaddr[5], grpaddr[6], grpaddr[7]);
+          NTOHS(grpaddr[0]), NTOHS(grpaddr[1]), NTOHS(grpaddr[2]),
+          NTOHS(grpaddr[3]), NTOHS(grpaddr[4]), NTOHS(grpaddr[5]),
+          NTOHS(grpaddr[6]), NTOHS(grpaddr[7]));
 
 #ifdef CONFIG_NET_MLD_ROUTER
   /* Assure that the group address is an IPv6 multicast address */

--- a/net/mld/mld_send.c
+++ b/net/mld/mld_send.c
@@ -206,8 +206,9 @@ void mld_send(FAR struct net_driver_s *dev, FAR struct mld_group_s *group,
     }
 
   mldinfo("destipaddr: %04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
-          destipaddr[0], destipaddr[1], destipaddr[2], destipaddr[3],
-          destipaddr[4], destipaddr[5], destipaddr[6], destipaddr[7]);
+          NTOHS(destipaddr[0]), NTOHS(destipaddr[1]), NTOHS(destipaddr[2]),
+          NTOHS(destipaddr[3]), NTOHS(destipaddr[4]), NTOHS(destipaddr[5]),
+          NTOHS(destipaddr[6]), NTOHS(destipaddr[7]));
 
   ipv6_build_header(IPv6BUF, dev->d_sndlen, NEXT_HOPBYBOT_EH,
                     dev->d_ipv6addr, destipaddr, MLD_TTL, 0);


### PR DESCRIPTION
## Summary
MLD: add byte order conversion for ipv6 address printing
## Impact
MLD debug
## Testing
Tested in ESP32C3 chip
