### PR TITLE
tools/mkexport: copy full library directly if library without path 

### DIFF
--- a/tools/mkexport.sh
+++ b/tools/mkexport.sh
@@ -423,6 +423,11 @@ for lib in ${EXTRA_LIBS}; do
     lib=`echo "${lib}" | sed -e "s/-l/lib/" -e "s/$/${LIBEXT}/"`
   fi
 
+  if [ -f "${lib}" ]; then
+    cp -a ${lib} ${EXPORTDIR}/libs
+    continue
+  fi
+
   for path in ${EXTRA_LIBPATHS}; do
 
     # Skip the library path options


### PR DESCRIPTION

## Summary

tools/mkexport: copy full library directly if library without path 

copy full library directly if library without path


## Impact

N/A

## Testing

ci-check
