### PR TITLE
drivers/sensors: Remove unnecessary heap allocation for bmi270

### DIFF
--- a/boards/arm/cxd56xx/common/CMakeLists.txt
+++ b/boards/arm/cxd56xx/common/CMakeLists.txt
@@ -79,6 +79,10 @@ if(CONFIG_ARCH_BOARD_COMMON)
     list(APPEND SRCS src/cxd56_bmi160_i2c.c)
   endif()
 
+  if(CONFIG_SENSORS_BMI270_I2C)
+    list(APPEND SRCS src/cxd56_bmi270_i2c.c)
+  endif()
+
   if(CONFIG_SENSORS_BMI160_SCU)
     list(APPEND SRCS src/cxd56_bmi160_scu.c)
   endif()

--- a/boards/arm/cxd56xx/common/src/Make.defs
+++ b/boards/arm/cxd56xx/common/src/Make.defs
@@ -88,6 +88,10 @@ ifeq ($(CONFIG_SENSORS_BMI160_SPI),y)
 CSRCS += cxd56_bmi160_spi.c
 endif
 
+ifeq ($(CONFIG_SENSORS_BMI270_I2C),y)
+CSRCS += cxd56_bmi270_i2c.c
+endif
+
 ifeq ($(CONFIG_SENSORS_BMP280),y)
 CSRCS += cxd56_bmp280_i2c.c
 endif

--- a/boards/arm/cxd56xx/common/src/cxd56_bmi270_i2c.c
+++ b/boards/arm/cxd56xx/common/src/cxd56_bmi270_i2c.c
@@ -1,0 +1,69 @@
+/****************************************************************************
+ * boards/arm/cxd56xx/common/src/cxd56_bmi270_i2c.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdio.h>
+#include <debug.h>
+#include <errno.h>
+
+#include <nuttx/board.h>
+#include <nuttx/sensors/bmi270.h>
+
+#include "cxd56_i2c.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define BMI270_I2C_ADDRESS  (0x69)
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int board_bmi270_initialize(int bus)
+{
+  int ret;
+  struct i2c_master_s *i2c;
+
+  sninfo("Initializing BMI270..\n");
+
+  /* Initialize i2c device */
+
+  i2c = cxd56_i2cbus_initialize(bus);
+  if (!i2c)
+    {
+      snerr("ERROR: Failed to initialize i2c%d.\n", bus);
+      return -ENODEV;
+    }
+
+  ret = bmi270_register("/dev/accel0", i2c, BMI270_I2C_ADDRESS);
+  if (ret < 0)
+    {
+      snerr("Error registering BMI270\n");
+    }
+
+  return ret;
+}

--- a/boards/arm/cxd56xx/common/src/cxd56_sensors.c
+++ b/boards/arm/cxd56xx/common/src/cxd56_sensors.c
@@ -53,6 +53,12 @@
 #  define _BMI160  0
 #endif
 
+#if defined(CONFIG_SENSORS_BMI270) || defined(CONFIG_SENSORS_BMI270_SCU)
+#  define _BMI270  1
+#else
+#  define _BMI270  0
+#endif
+
 #if defined(CONFIG_SENSORS_KX022) || defined(CONFIG_SENSORS_KX022_SCU)
 #  define _KX022  1
 #else
@@ -107,7 +113,7 @@
 #  define _RPR0521RS  0
 #endif
 
-#if (_BMI160 + _KX022) > 1
+#if (_BMI160 + _BMI270 + _KX022) > 1
 #  error "Duplicate accelerometer sensor device."
 #endif
 
@@ -181,6 +187,13 @@ static struct sensor_device_s sensor_device[] =
   _I2C_DEVICE_WOPATH(bmi160), /* Accel + Gyro */
 #  else /* CONFIG_SENSORS_BMI160_SPI */
   _SPI_DEVICE_WOPATH(bmi160),
+#  endif
+#endif
+#if defined(CONFIG_SENSORS_BMI270) || defined(CONFIG_SENSORS_BMI270_SCU)
+#  if defined(CONFIG_SENSORS_BMI270_I2C) || defined(CONFIG_SENSORS_BMI270_SCU_I2C)
+  _I2C_DEVICE_WOPATH(bmi270),
+#  else /* CONFIG_SENSORS_BMI270_SPI */
+  _SPI_DEVICE_WOPATH(bmi270),
 #  endif
 #endif
 #if defined(CONFIG_SENSORS_KX022) || defined(CONFIG_SENSORS_KX022_SCU)

--- a/boards/arm/cxd56xx/spresense/include/board.h
+++ b/boards/arm/cxd56xx/spresense/include/board.h
@@ -57,6 +57,7 @@
 #include "cxd56_bm1383glv.h"
 #include "cxd56_bm1422gmv.h"
 #include "cxd56_bmi160.h"
+#include "cxd56_bmi270.h"
 #include "cxd56_bmp280.h"
 #include "cxd56_emmcdev.h"
 #include "cxd56_spisd.h"

--- a/boards/arm/cxd56xx/spresense/include/cxd56_bmi270.h
+++ b/boards/arm/cxd56xx/spresense/include/cxd56_bmi270.h
@@ -1,0 +1,69 @@
+/****************************************************************************
+ * boards/arm/cxd56xx/spresense/include/cxd56_bmi270.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __BOARDS_ARM_CXD56XX_SPRESENSE_INCLUDE_CXD56_BMI270_H
+#define __BOARDS_ARM_CXD56XX_SPRESENSE_INCLUDE_CXD56_BMI270_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+#ifndef __ASSEMBLY__
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_bmi270_initialize
+ *
+ * Description:
+ *   Initialize BMI270 i2c driver and register the BMI270 device.
+ *
+ ****************************************************************************/
+
+int board_bmi270_initialize(int bus);
+
+#undef EXTERN
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* __ASSEMBLY__ */
+#endif /* __BOARDS_ARM_CXD56XX_SPRESENSE_INCLUDE_CXD56_BMI270_H */

--- a/drivers/sensors/Kconfig
+++ b/drivers/sensors/Kconfig
@@ -232,6 +232,14 @@ config SENSORS_BMI270_SPI
 
 endchoice
 
+config SENSORS_BMI270_LOAD_FROM_HEAP
+	bool "BMI270 config loading from heap memory"
+	default n
+	---help---
+		Enable support to load the configuration data from heap memory.
+		Some chips can not do DMA transfer from FLASH and therefore
+		it is necessary to transfer the configuration file to RAM.
+
 endif
 
 config SENSORS_BMP180

--- a/drivers/sensors/bmi270.c
+++ b/drivers/sensors/bmi270.c
@@ -1258,9 +1258,11 @@ static int bmi270_init_seq(FAR struct bmi270_dev_s *priv)
 
   bmi270_putreg8(priv, BMI270_INIT_CTRL, 0);
 
+#ifdef CONFIG_SENSORS_BMI270_LOAD_FROM_HEAP
+
   /* Copy configuration to RAM */
 
-  tmp = malloc(sizeof(g_bmi270_config_file));
+  tmp = kmm_malloc(sizeof(g_bmi270_config_file));
   if (tmp == NULL)
     {
       snerr("Failed to allocate memory for configuration file\n");
@@ -1269,11 +1271,23 @@ static int bmi270_init_seq(FAR struct bmi270_dev_s *priv)
 
   memcpy(tmp, g_bmi270_config_file, sizeof(g_bmi270_config_file));
 
+#else
+
+  /* Transfer directly from const data memory */
+
+  tmp = (FAR uint8_t *)&g_bmi270_config_file;
+
+#endif
+
   /* Load configuration - start with byte 0 */
 
   bmi270_putregs(priv, BMI270_INIT_DATA,
                  tmp,
                  sizeof(g_bmi270_config_file));
+
+#ifdef CONFIG_SENSORS_BMI270_LOAD_FROM_HEAP
+  kmm_free(tmp);
+#endif
 
   /* Complete config load INIT_CTRL=0x01 */
 

--- a/drivers/sensors/bmi270.c
+++ b/drivers/sensors/bmi270.c
@@ -1241,7 +1241,7 @@ static int bmi270_init_seq(FAR struct bmi270_dev_s *priv)
   FAR uint8_t *tmp    = NULL;
   uint8_t      regval = 0;
 
-  /* Check if initalization already done */
+  /* Check if initialization already done */
 
   regval = bmi270_getreg8(priv, BMI270_INTERNAL_STAT);
   if ((regval & INTSTAT_MSG_MASK) == INTSTAT_MSG_INITOK)


### PR DESCRIPTION
## Summary
Remove temporary heap allocation and fix memory leak.
Add spresense board-specific driver for bmi270.

## Impact
bmi270 sensor

## Testing

