### PR TITLE
driver/sensors: BMI270 fix compilation if sensor works in SPI mode

### DIFF
--- a/drivers/sensors/CMakeLists.txt
+++ b/drivers/sensors/CMakeLists.txt
@@ -49,6 +49,10 @@ if(CONFIG_SENSORS)
     list(APPEND SRCS dhtxx.c)
   endif()
 
+  if(CONFIG_SENSORS_BMI270)
+    list(APPEND SRCS bmi270.c)
+  endif()
+
   # These drivers depend on I2C support
 
   if(CONFIG_I2C)

--- a/drivers/sensors/Make.defs
+++ b/drivers/sensors/Make.defs
@@ -56,6 +56,10 @@ ifeq ($(CONFIG_SENSORS_DHTXX),y)
   CSRCS += dhtxx.c
 endif
 
+ifeq ($(CONFIG_SENSORS_BMI270),y)
+  CSRCS += bmi270.c
+endif
+
 # These drivers depend on I2C support
 
 ifeq ($(CONFIG_I2C),y)
@@ -143,10 +147,6 @@ ifeq ($(CONFIG_SENSORS_BMI160_UORB),y)
 else
   CSRCS += bmi160.c
 endif
-endif
-
-ifeq ($(CONFIG_SENSORS_BMI270),y)
-  CSRCS += bmi270.c
 endif
 
 ifeq ($(CONFIG_SENSORS_BMP180),y)


### PR DESCRIPTION
## Summary

- driver/sensors/: BMI270 fix compilation if sensor works in SPI mode
- cmake: add support for sensors/bmi270

## Impact

## Testing
thingy53
