### PR TITLE
fs/vfs: fix dup issue for eventfd/signalfd/timerfd

### DIFF
--- a/fs/vfs/fs_eventfd.c
+++ b/fs/vfs/fs_eventfd.c
@@ -135,6 +135,7 @@ static FAR struct eventfd_priv_s *eventfd_allocdev(void)
 
       nxmutex_init(&dev->lock);
       nxmutex_lock(&dev->lock);
+      dev->crefs++;
     }
 
   return dev;

--- a/fs/vfs/fs_signalfd.c
+++ b/fs/vfs/fs_signalfd.c
@@ -355,6 +355,8 @@ int signalfd(int fd, FAR const sigset_t *mask, int flags)
           ret = -fd;
           goto errout_with_dev;
         }
+
+      dev->crefs++;
     }
   else
     {

--- a/fs/vfs/fs_timerfd.c
+++ b/fs/vfs/fs_timerfd.c
@@ -146,6 +146,7 @@ static FAR struct timerfd_priv_s *timerfd_allocdev(void)
 
       nxmutex_init(&dev->lock);
       nxmutex_lock(&dev->lock);
+      dev->crefs++;
     }
 
   return dev;


### PR DESCRIPTION
## Summary
fs/vfs: fix dup issue for eventfd/signalfd/timerfd

add refs when called eventfd(), signalfd(), timerfd()
## Impact
slove crash issue when fd is closed in child task.
## Testing
daily test 
