### PR TITLE
tools/mkdeps: increase MAX_BUFFER/MAX_EXPAND/MAX_SHQUOTE to 16384

### DIFF
--- a/tools/mkdeps.c
+++ b/tools/mkdeps.c
@@ -44,9 +44,9 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define MAX_BUFFER  (10240)
-#define MAX_EXPAND  (2048)
-#define MAX_SHQUOTE (4096)
+#define MAX_BUFFER  (16384)
+#define MAX_EXPAND  (16384)
+#define MAX_SHQUOTE (16384)
 
 /* MAX_PATH might be defined in stdlib.h */
 


### PR DESCRIPTION
## Summary
solve XXX string is too long when building in deep path

## Impact
Allow deeper path of nuttx building  in pc

## Testing
Pass vela CI
