### PR TITLE
sam_usbdevhs.c: fix compile warning

### DIFF
--- a/arch/arm/src/samv7/sam_usbdevhs.c
+++ b/arch/arm/src/samv7/sam_usbdevhs.c
@@ -2005,6 +2005,13 @@ static void sam_ep0_setup(struct sam_usbdev_s *priv)
   int                  nbytes = 0; /* Assume zero-length packet */
   int                  ret;
 
+  /* We want to pass pointer to response.b to sam_ctrlep_write function.
+   * Memset the union to avoid compilation warnings of uninitialized
+   * variable.
+   */
+
+  memset(&response, 0, sizeof(union wb_u));
+
   /* Terminate any pending requests */
 
   sam_req_cancel(ep0, -EPROTO);


### PR DESCRIPTION
Fix compile warning

chip/sam_usbdevhs.c:2474:11: warning: 'response' may be used uninitialized [-Wmaybe-uninitialized]
 2474 |           sam_ctrlep_write(ep0, response.b, nbytes);
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
chip/sam_usbdevhs.c:1845:13: note: by argument 2 of type 'const uint8_t *' {aka 'const unsigned char *'} to 'sam_ctrlep_write' declared here
 1845 | static void sam_ctrlep_write(struct sam_ep_s *privep, const uint8_t *buffer,
      |             ^~~~~~~~~~~~~~~~
chip/sam_usbdevhs.c:2001:24: note: 'response' declared here
 2001 |   union wb_u           response;
      |                        ^~~~~~~~

