### PR TITLE
arm64/qemu: fix build error.

### DIFF
--- a/arch/arm64/src/qemu/Make.defs
+++ b/arch/arm64/src/qemu/Make.defs
@@ -21,7 +21,7 @@
 include common/Make.defs
 
 # qemu-specific C source files
-CHIP_CSRCS  = qemu_boot.c qemu_serial.c
+CHIP_CSRCS  = qemu_boot.c qemu_serial.c qemu_net.c
 
 ifeq ($(CONFIG_ARCH_EARLY_PRINT),y)
 CHIP_ASRCS  = qemu_lowputc.S

--- a/arch/arm64/src/qemu/qemu_net.c
+++ b/arch/arm64/src/qemu/qemu_net.c
@@ -1,0 +1,28 @@
+/****************************************************************************
+ * arch/arm64/src/qemu/qemu_net.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void arm64_netinitialize(void)
+{
+  /* TODO: Support net initialize */
+}


### PR DESCRIPTION
## Summary
Fix build error.
LD: nuttx
aarch64-none-elf-ld: /home/cuiziwei/vela/happy/nuttx/staging/libarch.a(arm64_initialize.o): in function `up_initialize':
/home/cuiziwei/vela/happy/nuttx/arch/arm64/src/common/arm64_initialize.c:208: undefined reference to `arm64_netinitialize'
/home/cuiziwei/vela/happy/nuttx/arch/arm64/src/common/arm64_initialize.c:208:(.text.up_initialize+0x18): relocation truncated to fit: R_AARCH64_CALL26 against undefined symbol `arm64_netinitialize'
make[1]: *** [Makefile:166: nuttx] Error 1
make: *** [tools/Unix.mk:520: nuttx] Error 2
make: Leaving directory '/home/cuiziwei/vela/happy/nuttx'
Error: ############# build /home/cuiziwei/vela/happy/vendor/qemu/boards/vela/configs/armv8a fail ##############
## Impact

## Testing

