### PR TITLE
c++ compatibility: rename reserved C++ identifiers 'public' and 'this'

### DIFF
--- a/arch/arm64/src/common/arm64_initialize.c
+++ b/arch/arm64/src/common/arm64_initialize.c
@@ -145,7 +145,7 @@ static void up_color_intstack(void)
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_FPU
-int arm64_panic_disable_fpu(struct notifier_block *this,
+int arm64_panic_disable_fpu(struct notifier_block *block,
                             unsigned long action, void *data)
 {
   arm64_fpu_disable();

--- a/boards/arm/sam34/sam4l-xplained/src/sam_slcd.c
+++ b/boards/arm/sam34/sam4l-xplained/src/sam_slcd.c
@@ -873,7 +873,7 @@ static ssize_t slcd_write(struct file *filep,
   /* Decode and process every byte in the input buffer */
 
   options = 0;
-  while ((result = slcd_decode(&instream.public,
+  while ((result = slcd_decode(&instream.common,
                                &state, &ch, &count)) != SLCDRET_EOF)
     {
       lcdinfo("slcd_decode returned result=%d char=%d count=%d\n",

--- a/boards/arm/sama5/sama5d4-ek/src/at25_main.c
+++ b/boards/arm/sama5/sama5d4-ek/src/at25_main.c
@@ -157,7 +157,7 @@ int at25_main(int argc, char *argv[])
   printf("Send Intel HEX file now\n");
   fflush(stdout);
 
-  ret = hex2bin(&rawinstream.public, &memoutstream.public,
+  ret = hex2bin(&rawinstream.common, &memoutstream.common,
                 SAM_ISRAM_VSECTION,
                 SAM_ISRAM_VSECTION + CONFIG_SAMA5D4EK_AT25_PROGSIZE,
                 0);
@@ -175,20 +175,20 @@ int at25_main(int argc, char *argv[])
    * location.
    */
 
-  *(uint32_t *)(SAM_DDRCS_VSECTION + 0x14) = memoutstream.public.nput;
+  *(uint32_t *)(SAM_DDRCS_VSECTION + 0x14) = memoutstream.common.nput;
 
   /* The HEX file load was successful, write the data to FLASH */
 
   printf("Successfully loaded the Intel HEX file into memory...\n");
   printf("  Writing %d bytes to the AT25 Serial FLASH\n",
-         memoutstream.public.nput);
+         memoutstream.common.nput);
 
-  remaining = memoutstream.public.nput;
+  remaining = memoutstream.common.nput;
   src = (uint8_t *)SAM_DDRCS_VSECTION;
 
   do
     {
-      nwritten = write(fd, src, memoutstream.public.nput);
+      nwritten = write(fd, src, memoutstream.common.nput);
       if (nwritten <= 0)
         {
           int errcode = errno;
@@ -214,7 +214,7 @@ int at25_main(int argc, char *argv[])
    */
 
   printf("  Verifying %d bytes in the AT25 Serial FLASH\n",
-         memoutstream.public.nput);
+         memoutstream.common.nput);
 
   /* Open the AT25 device for writing */
 
@@ -226,7 +226,7 @@ int at25_main(int argc, char *argv[])
       return EXIT_FAILURE;
     }
 
-  remaining = memoutstream.public.nput;
+  remaining = memoutstream.common.nput;
   src = (const uint8_t *)SAM_DDRCS_VSECTION;
 
   do
@@ -253,7 +253,7 @@ int at25_main(int argc, char *argv[])
           if (memcmp(g_iobuffer, src, nread) != 0)
             {
               fprintf(stderr, "ERROR: Verify failed at offset %d\n",
-                      memoutstream.public.nput - remaining);
+                      memoutstream.common.nput - remaining);
               close(fd);
               return EXIT_FAILURE;
             }
@@ -265,7 +265,7 @@ int at25_main(int argc, char *argv[])
   while (remaining > 0);
 
   printf("  Successfully verified %d bytes in the AT25 Serial FLASH\n",
-         memoutstream.public.nput);
+         memoutstream.common.nput);
 
   close(fd);
   return EXIT_SUCCESS;

--- a/boards/arm/stm32/stm32ldiscovery/src/stm32_lcd.c
+++ b/boards/arm/stm32/stm32ldiscovery/src/stm32_lcd.c
@@ -1138,7 +1138,7 @@ static ssize_t slcd_write(struct file *filep,
    */
 
   memset(&state, 0, sizeof(struct slcdstate_s));
-  result = slcd_decode(&instream.public, &state, &prev, &count);
+  result = slcd_decode(&instream.common, &state, &prev, &count);
 
   lcdinfo("slcd_decode returned result=%d char=%d count=%d\n",
            result, prev, count);
@@ -1162,7 +1162,7 @@ static ssize_t slcd_write(struct file *filep,
 
   /* Now decode and process every byte in the input buffer */
 
-  while ((result = slcd_decode(&instream.public,
+  while ((result = slcd_decode(&instream.common,
                                &state, &ch, &count)) != SLCDRET_EOF)
     {
       lcdinfo("slcd_decode returned result=%d char=%d count=%d\n",

--- a/boards/mips/pic32mx/sure-pic32mx/src/pic32mx_lcd1602.c
+++ b/boards/mips/pic32mx/sure-pic32mx/src/pic32mx_lcd1602.c
@@ -230,7 +230,7 @@ static void lcd_dumpstream(const char *msg,
 {
   lcdinfo("%s:\n", msg);
   lcdinfo("  nget: %d nbytes: %d\n",
-          stream->public.nget, stream->buflen);
+          stream->common.nget, stream->buflen);
   lib_dumpbuffer("STREAM", stream->buffer, stream->buflen);
 }
 #endif
@@ -800,7 +800,7 @@ static ssize_t lcd_write(struct file *filep,  const char *buffer,
   /* Now decode and process every byte in the input buffer */
 
   memset(&state, 0, sizeof(struct slcdstate_s));
-  while ((result = slcd_decode(&instream.public,
+  while ((result = slcd_decode(&instream.common,
                                &state, &ch, &count)) != SLCDRET_EOF)
     {
       lcdinfo("slcd_decode returned result=%d char=%d count=%d\n",

--- a/boards/z80/ez80/z20x/src/w25_main.c
+++ b/boards/z80/ez80/z20x/src/w25_main.c
@@ -131,7 +131,7 @@ static int w25_read_hex(FAR uint24_t *len)
   printf("Send Intel HEX file now\n");
   fflush(stdout);
 
-  ret = hex2bin(&rawinstream.public, &memoutstream.public,
+  ret = hex2bin(&rawinstream.common, &memoutstream.common,
                 (uint32_t)PROGSTART, (uint32_t)(PROGSTART + PROGSIZE),
                 0);
 
@@ -147,7 +147,7 @@ static int w25_read_hex(FAR uint24_t *len)
   printf("Intel HEX file into memory loaded into RAM...\n");
   fflush(stdout);
 
-  *len = memoutstream.public.nput;
+  *len = memoutstream.common.nput;
   return OK;
 }
 

--- a/drivers/lcd/ht16k33_14seg.c
+++ b/drivers/lcd/ht16k33_14seg.c
@@ -779,7 +779,7 @@ static ssize_t ht16k33_write(FAR struct file *filep, FAR const char *buffer,
   /* Now decode and process every byte in the input buffer */
 
   memset(&state, 0, sizeof(struct slcdstate_s));
-  while ((result = slcd_decode(&instream.public,
+  while ((result = slcd_decode(&instream.common,
                                &state, &ch, &count)) != SLCDRET_EOF)
     {
       /* Is there some pending scroll? */

--- a/drivers/lcd/pcf8574_lcd_backpack.c
+++ b/drivers/lcd/pcf8574_lcd_backpack.c
@@ -1207,7 +1207,7 @@ static ssize_t pcf8574_lcd_write(FAR struct file *filep,
   /* Now decode and process every byte in the input buffer */
 
   memset(&state, 0, sizeof(struct slcdstate_s));
-  while ((result = slcd_decode(&instream.public,
+  while ((result = slcd_decode(&instream.common,
                                &state, &ch, &count)) != SLCDRET_EOF)
     {
       if (result == SLCDRET_CHAR)       /* A normal character was returned */

--- a/drivers/lcd/st7032.c
+++ b/drivers/lcd/st7032.c
@@ -701,7 +701,7 @@ static ssize_t st7032_write(FAR struct file *filep, FAR const char *buffer,
   /* Now decode and process every byte in the input buffer */
 
   memset(&state, 0, sizeof(struct slcdstate_s));
-  while ((result = slcd_decode(&instream.public,
+  while ((result = slcd_decode(&instream.common,
                                &state, &ch, &count)) != SLCDRET_EOF)
     {
       /* Is there some pending scroll? */

--- a/drivers/note/noteram_driver.c
+++ b/drivers/note/noteram_driver.c
@@ -1020,7 +1020,7 @@ static void noteram_dump(FAR struct noteram_driver_s *drv)
   uint8_t note[64];
 
   lib_syslograwstream_open(&stream);
-  lib_sprintf(&stream.public, "# tracer:nop\n#\n");
+  lib_sprintf(&stream.common, "# tracer:nop\n#\n");
 
   while (1)
     {
@@ -1032,7 +1032,7 @@ static void noteram_dump(FAR struct noteram_driver_s *drv)
           break;
         }
 
-      noteram_dump_one(note, &stream.public, &ctx);
+      noteram_dump_one(note, &stream.common, &ctx);
     }
 
   lib_syslograwstream_close(&stream);

--- a/drivers/note/notesnap_driver.c
+++ b/drivers/note/notesnap_driver.c
@@ -436,6 +436,6 @@ void notesnap_dump(void)
 {
   struct lib_syslograwstream_s stream;
   lib_syslograwstream_open(&stream);
-  notesnap_dump_with_stream(&stream.public);
+  notesnap_dump_with_stream(&stream.common);
   lib_syslograwstream_close(stream);
 }

--- a/drivers/segger/stream_rtt.c
+++ b/drivers/segger/stream_rtt.c
@@ -39,29 +39,29 @@
  * Name: rttstream_putc
  ****************************************************************************/
 
-static void rttstream_putc(FAR struct lib_outstream_s *this, int ch)
+static void rttstream_putc(FAR struct lib_outstream_s *self, int ch)
 {
   FAR struct lib_rttoutstream_s *stream =
-                                 (FAR struct lib_rttoutstream_s *)this;
+                                 (FAR struct lib_rttoutstream_s *)self;
 
   SEGGER_RTT_BLOCK_IF_FIFO_FULL(0);
-  stream->public.nput += SEGGER_RTT_PutChar(stream->channel, ch);
+  stream->common.nput += SEGGER_RTT_PutChar(stream->channel, ch);
 }
 
 /****************************************************************************
  * Name: rttstream_puts
  ****************************************************************************/
 
-static int rttstream_puts(FAR struct lib_outstream_s *this,
+static int rttstream_puts(FAR struct lib_outstream_s *self,
                           FAR const void *buf, int len)
 {
   FAR struct lib_rttoutstream_s *stream =
-                                (FAR struct lib_rttoutstream_s *)this;
+                                (FAR struct lib_rttoutstream_s *)self;
   int ret;
 
   SEGGER_RTT_BLOCK_IF_FIFO_FULL(0);
   ret = SEGGER_RTT_Write(stream->channel, buf, len);
-  stream->public.nput += ret;
+  stream->common.nput += ret;
   return ret;
 }
 
@@ -69,14 +69,14 @@ static int rttstream_puts(FAR struct lib_outstream_s *this,
  * Name: rttstream_getc
  ****************************************************************************/
 
-static int rttstream_getc(FAR struct lib_instream_s *this)
+static int rttstream_getc(FAR struct lib_instream_s *self)
 {
   FAR struct lib_rttinstream_s *stream =
-                                (FAR struct lib_rttinstream_s *)this;
+                                (FAR struct lib_rttinstream_s *)self;
   int ch = -1;
 
   DEBUGASSERT(stream);
-  stream->public.nget += SEGGER_RTT_Read(stream->channel, &ch, 1);
+  stream->common.nget += SEGGER_RTT_Read(stream->channel, &ch, 1);
   return ch;
 }
 
@@ -84,16 +84,16 @@ static int rttstream_getc(FAR struct lib_instream_s *this)
  * Name: rttstream_gets
  ****************************************************************************/
 
-static int rttstream_gets(FAR struct lib_instream_s *this,
+static int rttstream_gets(FAR struct lib_instream_s *self,
                           FAR void * buffer, int size)
 {
   FAR struct lib_rttinstream_s *stream =
-                                (FAR struct lib_rttinstream_s *)this;
+                                (FAR struct lib_rttinstream_s *)self;
   int ret;
 
   DEBUGASSERT(stream);
   ret = SEGGER_RTT_Read(stream->channel, buffer, size);
-  stream->public.nget += ret;
+  stream->common.nget += ret;
   return ret;
 }
 
@@ -131,10 +131,10 @@ void lib_rttoutstream_open(FAR struct lib_rttoutstream_s *stream,
                                 bufsize, SEGGER_RTT_MODE_DEFAULT);
     }
 
-  stream->public.putc = rttstream_putc;
-  stream->public.puts = rttstream_puts;
-  stream->public.flush = lib_noflush;
-  stream->public.nput = 0;
+  stream->common.putc = rttstream_putc;
+  stream->common.puts = rttstream_puts;
+  stream->common.flush = lib_noflush;
+  stream->common.nput = 0;
   stream->channel = channel;
 }
 
@@ -179,9 +179,9 @@ void lib_rttinstream_open(FAR struct lib_rttinstream_s *stream,
                                   bufsize, SEGGER_RTT_MODE_DEFAULT);
     }
 
-  stream->public.getc = rttstream_getc;
-  stream->public.gets = rttstream_gets;
-  stream->public.nget = 0;
+  stream->common.getc = rttstream_getc;
+  stream->common.gets = rttstream_gets;
+  stream->common.nget = 0;
   stream->channel = channel;
 }
 

--- a/drivers/syslog/vsyslog.c
+++ b/drivers/syslog/vsyslog.c
@@ -150,7 +150,7 @@ int nx_vsyslog(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
     defined(CONFIG_SYSLOG_PRIORITY) || defined(CONFIG_SYSLOG_PREFIX) || \
     defined(CONFIG_SYSLOG_PROCESS_NAME)
 
-  ret = lib_sprintf_internal(&stream.public,
+  ret = lib_sprintf_internal(&stream.common,
 #if defined(CONFIG_SYSLOG_COLOR_OUTPUT)
   /* Reset the terminal style. */
 
@@ -253,18 +253,18 @@ int nx_vsyslog(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
 
   /* Generate the output */
 
-  ret += lib_vsprintf_internal(&stream.public, fmt, *ap);
+  ret += lib_vsprintf_internal(&stream.common, fmt, *ap);
 
   if (stream.last_ch != '\n')
     {
-      lib_stream_putc(&stream.public, '\n');
+      lib_stream_putc(&stream.common, '\n');
       ret++;
     }
 
 #if defined(CONFIG_SYSLOG_COLOR_OUTPUT)
   /* Reset the terminal style back to normal. */
 
-  ret += lib_stream_puts(&stream.public, "\e[0m", sizeof("\e[0m"));
+  ret += lib_stream_puts(&stream.common, "\e[0m", sizeof("\e[0m"));
 #endif
 
   /* Flush and destroy the syslog stream buffer */

--- a/drivers/usbhost/usbhost_hidkbd.c
+++ b/drivers/usbhost/usbhost_hidkbd.c
@@ -271,7 +271,7 @@ static void usbhost_destroy(FAR void *arg);
 static void usbhost_putbuffer(FAR struct usbhost_state_s *priv,
               uint8_t keycode);
 #ifdef CONFIG_HIDKBD_ENCODED
-static void usbhost_putstream(FAR struct lib_outstream_s *this, int ch);
+static void usbhost_putstream(FAR struct lib_outstream_s *self, int ch);
 #endif
 static inline uint8_t usbhost_mapscancode(uint8_t scancode,
               uint8_t modifier);

--- a/include/nuttx/segger/rtt.h
+++ b/include/nuttx/segger/rtt.h
@@ -40,7 +40,7 @@
 #ifdef CONFIG_STREAM_RTT
 struct lib_rttoutstream_s
 {
-  struct lib_outstream_s public;
+  struct lib_outstream_s common;
   char name[32];
   FAR char *buffer;
   int channel;
@@ -48,7 +48,7 @@ struct lib_rttoutstream_s
 
 struct lib_rttinstream_s
 {
-  struct lib_instream_s public;
+  struct lib_instream_s common;
   char name[32];
   FAR char *buffer;
   int channel;

--- a/include/nuttx/streams.h
+++ b/include/nuttx/streams.h
@@ -70,15 +70,15 @@
 /* These are the generic representations of a streams used by the NuttX */
 
 struct lib_instream_s;
-typedef CODE int  (*lib_getc_t)(FAR struct lib_instream_s *this);
-typedef CODE int  (*lib_gets_t)(FAR struct lib_instream_s *this,
+typedef CODE int  (*lib_getc_t)(FAR struct lib_instream_s *self);
+typedef CODE int  (*lib_gets_t)(FAR struct lib_instream_s *self,
                                 FAR void *buf, int len);
 
 struct lib_outstream_s;
-typedef CODE void (*lib_putc_t)(FAR struct lib_outstream_s *this, int ch);
-typedef CODE int  (*lib_puts_t)(FAR struct lib_outstream_s *this,
+typedef CODE void (*lib_putc_t)(FAR struct lib_outstream_s *self, int ch);
+typedef CODE int  (*lib_puts_t)(FAR struct lib_outstream_s *self,
                                 FAR const void *buf, int len);
-typedef CODE int  (*lib_flush_t)(FAR struct lib_outstream_s *this);
+typedef CODE int  (*lib_flush_t)(FAR struct lib_outstream_s *self);
 
 struct lib_instream_s
 {
@@ -100,18 +100,18 @@ struct lib_outstream_s
 /* Seek-able streams */
 
 struct lib_sistream_s;
-typedef CODE int   (*lib_sigetc_t)(FAR struct lib_sistream_s *this);
-typedef CODE int   (*lib_sigets_t)(FAR struct lib_sistream_s *this,
+typedef CODE int   (*lib_sigetc_t)(FAR struct lib_sistream_s *self);
+typedef CODE int   (*lib_sigets_t)(FAR struct lib_sistream_s *self,
                                    FAR void *buf, int len);
-typedef CODE off_t (*lib_siseek_t)(FAR struct lib_sistream_s *this,
+typedef CODE off_t (*lib_siseek_t)(FAR struct lib_sistream_s *self,
                                    off_t offset, int whence);
 
 struct lib_sostream_s;
-typedef CODE void  (*lib_soputc_t)(FAR struct lib_sostream_s *this, int ch);
-typedef CODE int   (*lib_soputs_t)(FAR struct lib_sostream_s *this,
+typedef CODE void  (*lib_soputc_t)(FAR struct lib_sostream_s *self, int ch);
+typedef CODE int   (*lib_soputs_t)(FAR struct lib_sostream_s *self,
                                    FAR const void *buf, int len);
-typedef CODE int   (*lib_soflush_t)(FAR struct lib_sostream_s *this);
-typedef CODE off_t (*lib_soseek_t)(FAR struct lib_sostream_s *this,
+typedef CODE int   (*lib_soflush_t)(FAR struct lib_sostream_s *self);
+typedef CODE off_t (*lib_soseek_t)(FAR struct lib_sostream_s *self,
                                    off_t offset, int whence);
 
 struct lib_sistream_s
@@ -137,21 +137,21 @@ struct lib_sostream_s
 
 struct lib_meminstream_s
 {
-  struct lib_instream_s  public;
+  struct lib_instream_s  common;
   FAR const char        *buffer;  /* Address of first byte in the buffer */
   size_t                 buflen;  /* Size of the buffer in bytes */
 };
 
 struct lib_memoutstream_s
 {
-  struct lib_outstream_s public;
+  struct lib_outstream_s common;
   FAR char              *buffer;  /* Address of first byte in the buffer */
   size_t                 buflen;  /* Size of the buffer in bytes */
 };
 
 struct lib_memsistream_s
 {
-  struct lib_sistream_s  public;
+  struct lib_sistream_s  common;
   FAR const char        *buffer;  /* Address of first byte in the buffer */
   size_t                 offset;  /* Current buffer offset in bytes */
   size_t                 buflen;  /* Size of the buffer in bytes */
@@ -159,7 +159,7 @@ struct lib_memsistream_s
 
 struct lib_memsostream_s
 {
-  struct lib_sostream_s  public;
+  struct lib_sostream_s  common;
   FAR char              *buffer;  /* Address of first byte in the buffer */
   size_t                 offset;  /* Current buffer offset in bytes */
   size_t                 buflen;  /* Size of the buffer in bytes */
@@ -169,57 +169,57 @@ struct lib_memsostream_s
 
 struct lib_stdinstream_s
 {
-  struct lib_instream_s  public;
-  FAR FILE              *stream;
+  struct lib_instream_s  common;
+  FAR FILE              *handle;
 };
 
 struct lib_stdoutstream_s
 {
-  struct lib_outstream_s public;
-  FAR FILE              *stream;
+  struct lib_outstream_s common;
+  FAR FILE              *handle;
 };
 
 struct lib_stdsistream_s
 {
-  struct lib_sistream_s  public;
-  FAR FILE              *stream;
+  struct lib_sistream_s  common;
+  FAR FILE              *handle;
 };
 
 struct lib_stdsostream_s
 {
-  struct lib_sostream_s  public;
-  FAR FILE              *stream;
+  struct lib_sostream_s  common;
+  FAR FILE              *handle;
 };
 
 /* These are streams that operate on a file descriptor */
 
 struct lib_rawinstream_s
 {
-  struct lib_instream_s  public;
+  struct lib_instream_s  common;
   int                    fd;
 };
 
 struct lib_rawoutstream_s
 {
-  struct lib_outstream_s public;
+  struct lib_outstream_s common;
   int                    fd;
 };
 
 struct lib_rawsistream_s
 {
-  struct lib_sistream_s  public;
+  struct lib_sistream_s  common;
   int                    fd;
 };
 
 struct lib_rawsostream_s
 {
-  struct lib_sostream_s  public;
+  struct lib_sostream_s  common;
   int                    fd;
 };
 
 struct lib_bufferedoutstream_s
 {
-  struct lib_outstream_s      public;
+  struct lib_outstream_s      common;
   FAR struct lib_outstream_s *backend;
   int                         pending;
   char                        buffer[CONFIG_STREAM_OUT_BUFFER_SIZE];
@@ -227,7 +227,7 @@ struct lib_bufferedoutstream_s
 
 struct lib_hexdumpstream_s
 {
-  struct lib_outstream_s      public;
+  struct lib_outstream_s      common;
   FAR struct lib_outstream_s *backend;
   int                         pending;
   char                        buffer[CONFIG_STREAM_HEXDUMP_BUFFER_SIZE + 1];
@@ -240,7 +240,7 @@ struct lib_hexdumpstream_s
 
 struct lib_syslogstream_s
 {
-  struct lib_outstream_s public;
+  struct lib_outstream_s common;
   int priority;
 };
 
@@ -248,7 +248,7 @@ struct iob_s;  /* Forward reference */
 
 struct lib_syslograwstream_s
 {
-  struct lib_outstream_s public;
+  struct lib_outstream_s common;
 #ifdef CONFIG_SYSLOG_BUFFER
 #  ifdef CONFIG_MM_IOB
   FAR struct iob_s *iob;
@@ -267,7 +267,7 @@ struct lib_syslograwstream_s
 #ifdef CONFIG_LIBC_LZF
 struct lib_lzfoutstream_s
 {
-  struct lib_outstream_s      public;
+  struct lib_outstream_s      common;
   FAR struct lib_outstream_s *backend;
   lzf_state_t                 state;
   size_t                      offset;
@@ -279,7 +279,7 @@ struct lib_lzfoutstream_s
 #ifndef CONFIG_DISABLE_MOUNTPOINT
 struct lib_blkoutstream_s
 {
-  struct lib_outstream_s public;
+  struct lib_outstream_s common;
   FAR struct inode      *inode;
   struct geometry        geo;
   FAR unsigned char     *cache;
@@ -289,7 +289,7 @@ struct lib_blkoutstream_s
 #if !defined(CONFIG_DISABLE_MOUNTPOINT) && defined(CONFIG_MTD)
 struct lib_mtdoutstream_s
 {
-  struct lib_outstream_s public;
+  struct lib_outstream_s common;
   FAR struct inode      *inode;
   struct mtd_geometry_s  geo;
   FAR unsigned char     *cache;
@@ -323,25 +323,23 @@ extern "C"
  *   lib/stdio/lib_memsostream.c.
  *
  * Input Parameters:
- *   memstream    - User allocated, uninitialized instance of struct
- *                  lib_meminstream_s to be initialized.
- *   memstream    - User allocated, uninitialized instance of struct
- *                  lib_memoutstream_s to be initialized.
- *   bufstart     - Address of the beginning of the fixed-size memory buffer
- *   buflen       - Size of the fixed-sized memory buffer in bytes
+ *   stream    - User allocated, uninitialized instance of stream struct
+ *               to be initialized.
+ *   bufstart  - Address of the beginning of the fixed-size memory buffer
+ *   buflen    - Size of the fixed-sized memory buffer in bytes
  *
  * Returned Value:
  *   None (User allocated instance initialized).
  *
  ****************************************************************************/
 
-void lib_meminstream(FAR struct lib_meminstream_s *instream,
+void lib_meminstream(FAR struct lib_meminstream_s *stream,
                      FAR const char *bufstart, int buflen);
-void lib_memoutstream(FAR struct lib_memoutstream_s *outstream,
+void lib_memoutstream(FAR struct lib_memoutstream_s *stream,
                       FAR char *bufstart, int buflen);
-void lib_memsistream(FAR struct lib_memsistream_s *instream,
+void lib_memsistream(FAR struct lib_memsistream_s *stream,
                      FAR const char *bufstart, int buflen);
-void lib_memsostream(FAR struct lib_memsostream_s *outstream,
+void lib_memsostream(FAR struct lib_memsostream_s *stream,
                      FAR char *bufstart, int buflen);
 
 /****************************************************************************
@@ -352,26 +350,24 @@ void lib_memsostream(FAR struct lib_memsostream_s *outstream,
  *   Defined in lib/stdio/lib_stdinstream.c and lib/stdio/lib_stdoutstream.c
  *
  * Input Parameters:
- *   instream  - User allocated, uninitialized instance of struct
- *               lib_stdinstream_s to be initialized.
- *   outstream - User allocated, uninitialized instance of struct
- *               lib_stdoutstream_s to be initialized.
- *   stream    - User provided stream instance (must have been opened for
- *               the correct access).
+ *   stream  - User allocated, uninitialized instance of stream
+ *             to be initialized
+ *   handle  - User provided FILE instance (must have been opened for
+ *             the correct access).
  *
  * Returned Value:
  *   None (User allocated instance initialized).
  *
  ****************************************************************************/
 
-void lib_stdinstream(FAR struct lib_stdinstream_s *instream,
-                     FAR FILE *stream);
-void lib_stdoutstream(FAR struct lib_stdoutstream_s *outstream,
-                      FAR FILE *stream);
-void lib_stdsistream(FAR struct lib_stdsistream_s *instream,
-                     FAR FILE *stream);
-void lib_stdsostream(FAR struct lib_stdsostream_s *outstream,
-                     FAR FILE *stream);
+void lib_stdinstream(FAR struct lib_stdinstream_s *stream,
+                     FAR FILE *handle);
+void lib_stdoutstream(FAR struct lib_stdoutstream_s *stream,
+                      FAR FILE *handle);
+void lib_stdsistream(FAR struct lib_stdsistream_s *stream,
+                     FAR FILE *handle);
+void lib_stdsostream(FAR struct lib_stdsostream_s *stream,
+                     FAR FILE *handle);
 
 /****************************************************************************
  * Name: lib_rawinstream, lib_rawoutstream, lib_rawsistream, and
@@ -384,22 +380,20 @@ void lib_stdsostream(FAR struct lib_stdsostream_s *outstream,
  *   lib/stdio/lib_rawsostream.c
  *
  * Input Parameters:
- *   instream  - User allocated, uninitialized instance of struct
- *               lib_rawinstream_s to be initialized.
- *   outstream - User allocated, uninitialized instance of struct
- *               lib_rawoutstream_s to be initialized.
- *   fd        - User provided file/socket descriptor (must have been opened
- *               for the correct access).
+ *   stream  - User allocated, uninitialized instance of stream struct
+ *             to be initialized.
+ *   fd      - User provided file/socket descriptor (must have been opened
+ *             for the correct access).
  *
  * Returned Value:
  *   None (User allocated instance initialized).
  *
  ****************************************************************************/
 
-void lib_rawinstream(FAR struct lib_rawinstream_s *instream, int fd);
-void lib_rawoutstream(FAR struct lib_rawoutstream_s *outstream, int fd);
-void lib_rawsistream(FAR struct lib_rawsistream_s *instream, int fd);
-void lib_rawsostream(FAR struct lib_rawsostream_s *outstream, int fd);
+void lib_rawinstream(FAR struct lib_rawinstream_s *stream, int fd);
+void lib_rawoutstream(FAR struct lib_rawoutstream_s *stream, int fd);
+void lib_rawsistream(FAR struct lib_rawsistream_s *stream, int fd);
+void lib_rawsostream(FAR struct lib_rawsostream_s *stream, int fd);
 
 /****************************************************************************
  * Name: lib_bufferedoutstream
@@ -408,17 +402,17 @@ void lib_rawsostream(FAR struct lib_rawsostream_s *outstream, int fd);
  *   Wrap a raw output stream to a buffered output stream.
  *
  * Input Parameters:
- *   outstream - User allocated, uninitialized instance of struct
- *               lib_bufferedoutstream_s to be initialized.
- *   backend   - User allocated, initialized instance of struct
- *               lib_outstream_s to be buffered.
+ *   stream  - User allocated, uninitialized instance of struct
+ *             lib_bufferedoutstream_s to be initialized.
+ *   backend - User allocated, initialized instance of struct
+ *             lib_outstream_s to be buffered.
  *
  * Returned Value:
  *   None (User allocated instance initialized).
  *
  ****************************************************************************/
 
-void lib_bufferedoutstream(FAR struct lib_bufferedoutstream_s *outstream,
+void lib_bufferedoutstream(FAR struct lib_bufferedoutstream_s *stream,
                            FAR struct lib_outstream_s *backend);
 
 /****************************************************************************
@@ -487,9 +481,9 @@ void lib_lowoutstream(FAR struct lib_outstream_s *lowoutstream);
  *
  ****************************************************************************/
 
-void lib_zeroinstream(FAR struct lib_instream_s *zeroinstream);
-void lib_nullinstream(FAR struct lib_instream_s *nullinstream);
-void lib_nulloutstream(FAR struct lib_outstream_s *nulloutstream);
+void lib_zeroinstream(FAR struct lib_instream_s *stream);
+void lib_nullinstream(FAR struct lib_instream_s *stream);
+void lib_nulloutstream(FAR struct lib_outstream_s *stream);
 
 /****************************************************************************
  * Name: lib_syslogstream
@@ -661,7 +655,7 @@ void lib_mtdoutstream_close(FAR struct lib_mtdoutstream_s *stream);
  *
  ****************************************************************************/
 
-int lib_noflush(FAR struct lib_outstream_s *stream);
+int lib_noflush(FAR struct lib_outstream_s *self);
 
 /****************************************************************************
  * Name: lib_snoflush
@@ -676,7 +670,7 @@ int lib_noflush(FAR struct lib_outstream_s *stream);
  *
  ****************************************************************************/
 
-int lib_snoflush(FAR struct lib_sostream_s *this);
+int lib_snoflush(FAR struct lib_sostream_s *self);
 
 /****************************************************************************
  * Name: lib_sprintf
@@ -686,7 +680,7 @@ int lib_snoflush(FAR struct lib_sostream_s *this);
  *
  ****************************************************************************/
 
-int lib_sprintf(FAR struct lib_outstream_s *obj,
+int lib_sprintf(FAR struct lib_outstream_s *stream,
                 FAR const IPTR char *fmt, ...) printf_like(2, 3);
 
 /****************************************************************************
@@ -698,7 +692,7 @@ int lib_sprintf(FAR struct lib_outstream_s *obj,
  *
  ****************************************************************************/
 
-int lib_sprintf_internal(FAR struct lib_outstream_s *obj,
+int lib_sprintf_internal(FAR struct lib_outstream_s *stream,
                          FAR const IPTR char *fmt, ...) printf_like(2, 3);
 
 /****************************************************************************
@@ -723,7 +717,7 @@ int lib_vsprintf_internal(FAR struct lib_outstream_s *stream,
  *
  ****************************************************************************/
 
-int lib_vsprintf(FAR struct lib_outstream_s *obj,
+int lib_vsprintf(FAR struct lib_outstream_s *stream,
                  FAR const IPTR char *src, va_list ap) printf_like(2, 0);
 
 /****************************************************************************
@@ -735,7 +729,7 @@ int lib_vsprintf(FAR struct lib_outstream_s *obj,
  *
  ****************************************************************************/
 
-int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
+int lib_vscanf(FAR struct lib_instream_s *stream, FAR int *lastc,
                FAR const IPTR char *src, va_list ap) scanf_like(3, 0);
 
 #undef EXTERN

--- a/libs/libc/hex2bin/lib_fhex2mem.c
+++ b/libs/libc/hex2bin/lib_fhex2mem.c
@@ -80,7 +80,7 @@ int fhex2mem(FAR FILE *instream, unsigned long baseaddr,
 
   /* And do the deed */
 
-  return hex2bin(&stdinstream.public, &memoutstream.public,
+  return hex2bin(&stdinstream.common, &memoutstream.common,
                  (unsigned long)baseaddr, (unsigned long)endpaddr,
                  (enum hex2bin_swap_e)swap);
 }

--- a/libs/libc/hex2bin/lib_hex2mem.c
+++ b/libs/libc/hex2bin/lib_hex2mem.c
@@ -80,7 +80,7 @@ int hex2mem(int fd, unsigned long baseaddr, unsigned long endpaddr,
 
   /* And do the deed */
 
-  return hex2bin(&rawinstream.public, &memoutstream.public,
+  return hex2bin(&rawinstream.common, &memoutstream.common,
                  (unsigned long)baseaddr, (unsigned long)endpaddr,
                  (enum hex2bin_swap_e)swap);
 }

--- a/libs/libc/obstack/lib_obstack_vprintf.c
+++ b/libs/libc/obstack/lib_obstack_vprintf.c
@@ -32,7 +32,7 @@
 
 struct obstack_stream
 {
-  struct lib_outstream_s public;
+  struct lib_outstream_s common;
   FAR struct obstack *h;
 };
 
@@ -40,22 +40,22 @@ struct obstack_stream
  * Private Functions
  ****************************************************************************/
 
-static int obstack_puts(FAR struct lib_outstream_s *this,
+static int obstack_puts(FAR struct lib_outstream_s *self,
     FAR const void *buf, int len)
 {
-  FAR struct obstack_stream *mthis = (FAR struct obstack_stream *)this;
+  FAR struct obstack_stream *stream = (FAR struct obstack_stream *)self;
 
-  DEBUGASSERT(this);
+  DEBUGASSERT(self);
 
-  obstack_grow(mthis->h, buf, len);
+  obstack_grow(stream->h, buf, len);
 
   return len;
 }
 
-static void obstack_putc(FAR struct lib_outstream_s *this, int ch)
+static void obstack_putc(FAR struct lib_outstream_s *self, int ch)
 {
   char tmp = ch;
-  obstack_puts(this, &tmp, 1);
+  obstack_puts(self, &tmp, 1);
 }
 
 /****************************************************************************
@@ -87,11 +87,11 @@ int obstack_vprintf(FAR struct obstack *h, FAR const char *fmt, va_list ap)
 {
   struct obstack_stream outstream;
 
-  outstream.public.putc = obstack_putc;
-  outstream.public.puts = obstack_puts;
-  outstream.public.flush = lib_noflush;
-  outstream.public.nput = 0;
+  outstream.common.putc = obstack_putc;
+  outstream.common.puts = obstack_puts;
+  outstream.common.flush = lib_noflush;
+  outstream.common.nput = 0;
   outstream.h = h;
 
-  return lib_vsprintf(&outstream.public, fmt, ap);
+  return lib_vsprintf(&outstream.common, fmt, ap);
 }

--- a/libs/libc/stdio/lib_libsprintf.c
+++ b/libs/libc/stdio/lib_libsprintf.c
@@ -33,7 +33,7 @@
  * Name: lib_sprintf
  ****************************************************************************/
 
-int lib_sprintf(FAR struct lib_outstream_s *obj, FAR const IPTR char *fmt,
+int lib_sprintf(FAR struct lib_outstream_s *stream, FAR const IPTR char *fmt,
                 ...)
 {
   va_list ap;
@@ -42,7 +42,7 @@ int lib_sprintf(FAR struct lib_outstream_s *obj, FAR const IPTR char *fmt,
   /* Let lib_vsprintf do the real work */
 
   va_start(ap, fmt);
-  n = lib_vsprintf(obj, fmt, ap);
+  n = lib_vsprintf(stream, fmt, ap);
   va_end(ap);
   return n;
 }

--- a/libs/libc/stdio/lib_libvscanf.c
+++ b/libs/libc/stdio/lib_libvscanf.c
@@ -199,7 +199,7 @@ doexit:
  *
  ****************************************************************************/
 
-int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
+int lib_vscanf(FAR struct lib_instream_s *stream, FAR int *lastc,
                FAR const IPTR char *fmt, va_list ap)
 {
   int c;
@@ -240,7 +240,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
   conv        = false;
   noassign    = false;
   modifier    = NO_MOD;
-  ngetstart   = obj->nget;      /* for %n calculations */
+  ngetstart   = stream->nget;      /* for %n calculations */
 
   /* Make sure lastc is not NULL. */
 
@@ -256,7 +256,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
 
   /* Get first character, we keep always the next character in c */
 
-  c = lib_stream_getc(obj);
+  c = lib_stream_getc(stream);
 
   while (fmt_char(fmt))
     {
@@ -266,7 +266,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
         {
           while (isspace(c))
             {
-              c = lib_stream_getc(obj);
+              c = lib_stream_getc(stream);
             }
         }
 
@@ -366,7 +366,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
 
               while (isspace(c))
                 {
-                  c = lib_stream_getc(obj);
+                  c = lib_stream_getc(stream);
                 }
 
               /* But we only perform the data conversion is we still have
@@ -390,7 +390,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
                         }
 
                       fwidth++;
-                      c = lib_stream_getc(obj);
+                      c = lib_stream_getc(stream);
                     }
 
                   if (!noassign)
@@ -445,7 +445,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
                         }
 
                       fwidth++;
-                      c = lib_stream_getc(obj);
+                      c = lib_stream_getc(stream);
                     }
 
                   if (!fwidth)
@@ -509,7 +509,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
                         }
 
                       fwidth++;
-                      c = lib_stream_getc(obj);
+                      c = lib_stream_getc(stream);
                     }
 
                   if (fwidth != width)
@@ -582,7 +582,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
 
               while (isspace(c))
                 {
-                  c = lib_stream_getc(obj);
+                  c = lib_stream_getc(stream);
                 }
 
               /* But we only perform the data conversion if we still have
@@ -641,7 +641,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
                           if (!stopconv)
                             {
                               tmp[fwidth++] = c;
-                              c = lib_stream_getc(obj);
+                              c = lib_stream_getc(stream);
                             }
                         }
 
@@ -691,7 +691,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
                           if (!stopconv)
                             {
                               tmp[fwidth++] = c;
-                              c = lib_stream_getc(obj);
+                              c = lib_stream_getc(stream);
                             }
                         }
 
@@ -716,7 +716,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
                           if (!stopconv)
                             {
                               tmp[fwidth++] = c;
-                              c = lib_stream_getc(obj);
+                              c = lib_stream_getc(stream);
                             }
                         }
 
@@ -741,7 +741,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
                           if (!stopconv)
                             {
                               tmp[fwidth++] = c;
-                              c = lib_stream_getc(obj);
+                              c = lib_stream_getc(stream);
                             }
                         }
 
@@ -796,7 +796,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
                           if (!stopconv)
                             {
                               tmp[fwidth++] = c;
-                              c = lib_stream_getc(obj);
+                              c = lib_stream_getc(stream);
                             }
                         }
                       break;
@@ -954,7 +954,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
 
               while (isspace(c))
                 {
-                  c = lib_stream_getc(obj);
+                  c = lib_stream_getc(stream);
                 }
 
               /* But we only perform the data conversion is we still have
@@ -1038,7 +1038,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
                       if (!stopconv)
                         {
                           tmp[fwidth++] = c;
-                          c = lib_stream_getc(obj);
+                          c = lib_stream_getc(stream);
                         }
                     }
 
@@ -1115,7 +1115,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
 
               if (!noassign)
                 {
-                  size_t nchars = (size_t) (obj->nget - ngetstart);
+                  size_t nchars = (size_t) (stream->nget - ngetstart);
 
                   if (c != EOF)
                     {
@@ -1168,7 +1168,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
                 }
               else
                 {
-                  c = lib_stream_getc(obj);
+                  c = lib_stream_getc(stream);
                 }
             }
 
@@ -1188,7 +1188,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
 
           while (isspace(c))
             {
-              c = lib_stream_getc(obj);
+              c = lib_stream_getc(stream);
             }
 #endif
 
@@ -1201,7 +1201,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
           else
             {
               fmt++;
-              c = lib_stream_getc(obj);
+              c = lib_stream_getc(stream);
             }
         }
       else

--- a/libs/libc/stdio/lib_snprintf.c
+++ b/libs/libc/stdio/lib_snprintf.c
@@ -60,7 +60,7 @@ int snprintf(FAR char *buf, size_t size, FAR const IPTR char *format, ...)
       /* Initialize a memory stream to write to the buffer */
 
       lib_memoutstream(&u.memoutstream, buf, size);
-      stream = &u.memoutstream.public;
+      stream = &u.memoutstream.common;
     }
   else
     {

--- a/libs/libc/stdio/lib_sprintf.c
+++ b/libs/libc/stdio/lib_sprintf.c
@@ -47,7 +47,7 @@ int sprintf(FAR char *buf, FAR const IPTR char *fmt, ...)
   /* Then let lib_vsprintf do the real work */
 
   va_start(ap, fmt);
-  n = lib_vsprintf((FAR struct lib_outstream_s *)&memoutstream.public,
+  n = lib_vsprintf((FAR struct lib_outstream_s *)&memoutstream.common,
                    fmt, ap);
   va_end(ap);
   return n;

--- a/libs/libc/stdio/lib_vasprintf.c
+++ b/libs/libc/stdio/lib_vasprintf.c
@@ -110,11 +110,11 @@ int vasprintf(FAR char **ptr, FAR const IPTR char *fmt, va_list ap)
   /* Then let lib_vsprintf do it's real thing */
 
 #ifdef va_copy
-  nbytes = lib_vsprintf((FAR struct lib_outstream_s *)&memoutstream.public,
+  nbytes = lib_vsprintf((FAR struct lib_outstream_s *)&memoutstream.common,
                         fmt, ap2);
   va_end(ap2);
 #else
-  nbytes = lib_vsprintf((FAR struct lib_outstream_s *)&memoutstream.public,
+  nbytes = lib_vsprintf((FAR struct lib_outstream_s *)&memoutstream.common,
                         fmt, ap);
 #endif
 

--- a/libs/libc/stdio/lib_vdprintf.c
+++ b/libs/libc/stdio/lib_vdprintf.c
@@ -57,8 +57,8 @@ int vdprintf(int fd, FAR const IPTR char *fmt, va_list ap)
   /* Wrap the fd in a stream object and let lib_vsprintf do the work. */
 
   lib_rawoutstream(&rawoutstream, fd);
-  lib_bufferedoutstream(&outstream, &rawoutstream.public);
-  ret = lib_vsprintf(&outstream.public, fmt, ap);
-  lib_stream_flush(&outstream.public);
+  lib_bufferedoutstream(&outstream, &rawoutstream.common);
+  ret = lib_vsprintf(&outstream.common, fmt, ap);
+  lib_stream_flush(&outstream.common);
   return ret;
 }

--- a/libs/libc/stdio/lib_vfprintf.c
+++ b/libs/libc/stdio/lib_vfprintf.c
@@ -49,7 +49,7 @@ int vfprintf(FAR FILE *stream, FAR const IPTR char *fmt, va_list ap)
    */
 
   flockfile(stream);
-  n = lib_vsprintf(&stdoutstream.public, fmt, ap);
+  n = lib_vsprintf(&stdoutstream.common, fmt, ap);
   funlockfile(stream);
 
   return n;

--- a/libs/libc/stdio/lib_vfscanf.c
+++ b/libs/libc/stdio/lib_vfscanf.c
@@ -57,7 +57,7 @@ int vfscanf(FAR FILE *stream, FAR const IPTR char *fmt, va_list ap)
 
       flockfile(stream);
 
-      n = lib_vscanf(&stdinstream.public, &lastc, fmt, ap);
+      n = lib_vscanf(&stdinstream.common, &lastc, fmt, ap);
 
       /* The lib_vscanf function reads always one character more, this
        * character needs to be written back.

--- a/libs/libc/stdio/lib_vsnprintf.c
+++ b/libs/libc/stdio/lib_vsnprintf.c
@@ -60,7 +60,7 @@ int vsnprintf(FAR char *buf, size_t size, FAR const IPTR char *format,
       /* Initialize a memory stream to write to the buffer */
 
       lib_memoutstream(&u.memoutstream, buf, size);
-      stream = &u.memoutstream.public;
+      stream = &u.memoutstream.common;
     }
   else
     {

--- a/libs/libc/stdio/lib_vsprintf.c
+++ b/libs/libc/stdio/lib_vsprintf.c
@@ -46,6 +46,6 @@ int vsprintf(FAR char *dest, FAR const IPTR char *src, va_list ap)
 
   lib_memoutstream((FAR struct lib_memoutstream_s *)&memoutstream, dest,
                    LIB_BUFLEN_UNKNOWN);
-  return lib_vsprintf((FAR struct lib_outstream_s *)&memoutstream.public,
+  return lib_vsprintf((FAR struct lib_outstream_s *)&memoutstream.common,
                       src, ap);
 }

--- a/libs/libc/stdio/lib_vsscanf.c
+++ b/libs/libc/stdio/lib_vsscanf.c
@@ -50,7 +50,7 @@ int vsscanf(FAR const char *buf, FAR const IPTR char *fmt, va_list ap)
 
   /* Then let lib_vscanf do the real work */
 
-  n = lib_vscanf((FAR struct lib_instream_s *)&meminstream.public, NULL,
-                  fmt, ap);
+  n = lib_vscanf((FAR struct lib_instream_s *)&meminstream.common, NULL,
+                 fmt, ap);
   return n;
 }

--- a/libs/libc/stream/lib_blkoutstream.c
+++ b/libs/libc/stream/lib_blkoutstream.c
@@ -43,17 +43,17 @@
  * Name: blkoutstream_flush
  ****************************************************************************/
 
-static int blkoutstream_flush(FAR struct lib_outstream_s *this)
+static int blkoutstream_flush(FAR struct lib_outstream_s *self)
 {
   FAR struct lib_blkoutstream_s *stream =
-                                 (FAR struct lib_blkoutstream_s *)this;
+                                 (FAR struct lib_blkoutstream_s *)self;
   size_t sectorsize = stream->geo.geo_sectorsize;
   int ret = OK;
 
-  if (this->nput % sectorsize > 0)
+  if (self->nput % sectorsize > 0)
     {
       ret = stream->inode->u.i_bops->write(stream->inode, stream->cache,
-                                           this->nput / sectorsize, 1);
+                                           self->nput / sectorsize, 1);
     }
 
   return ret;
@@ -63,11 +63,11 @@ static int blkoutstream_flush(FAR struct lib_outstream_s *this)
  * Name: blkoutstream_puts
  ****************************************************************************/
 
-static int blkoutstream_puts(FAR struct lib_outstream_s *this,
+static int blkoutstream_puts(FAR struct lib_outstream_s *self,
                              FAR const void *buf, int len)
 {
   FAR struct lib_blkoutstream_s *stream =
-                                 (FAR struct lib_blkoutstream_s *)this;
+                                 (FAR struct lib_blkoutstream_s *)self;
   size_t sectorsize = stream->geo.geo_sectorsize;
   FAR struct inode *inode = stream->inode;
   FAR const unsigned char *ptr = buf;
@@ -76,8 +76,8 @@ static int blkoutstream_puts(FAR struct lib_outstream_s *this,
 
   while (remain > 0)
     {
-      size_t sblock = this->nput / sectorsize;
-      size_t offset = this->nput % sectorsize;
+      size_t sblock = self->nput / sectorsize;
+      size_t offset = self->nput % sectorsize;
 
       if (offset > 0)
         {
@@ -88,7 +88,7 @@ static int blkoutstream_puts(FAR struct lib_outstream_s *this,
 
           ptr        += copyin;
           offset     += copyin;
-          this->nput += copyin;
+          self->nput += copyin;
           remain     -= copyin;
 
           if (offset == stream->geo.geo_sectorsize)
@@ -103,7 +103,7 @@ static int blkoutstream_puts(FAR struct lib_outstream_s *this,
       else if (remain < stream->geo.geo_sectorsize)
         {
           memcpy(stream->cache, ptr, remain);
-          this->nput += remain;
+          self->nput += remain;
           remain      = 0;
         }
       else if (remain >= stream->geo.geo_sectorsize)
@@ -119,7 +119,7 @@ static int blkoutstream_puts(FAR struct lib_outstream_s *this,
             }
 
           ptr        += copyin;
-          this->nput += copyin;
+          self->nput += copyin;
           remain     -= copyin;
         }
     }
@@ -131,10 +131,10 @@ static int blkoutstream_puts(FAR struct lib_outstream_s *this,
  * Name: blkoutstream_putc
  ****************************************************************************/
 
-static void blkoutstream_putc(FAR struct lib_outstream_s *this, int ch)
+static void blkoutstream_putc(FAR struct lib_outstream_s *self, int ch)
 {
   char tmp = ch;
-  blkoutstream_puts(this, &tmp, 1);
+  blkoutstream_puts(self, &tmp, 1);
 }
 
 /****************************************************************************
@@ -227,9 +227,9 @@ int lib_blkoutstream_open(FAR struct lib_blkoutstream_s *stream,
     }
 
   stream->inode        = inode;
-  stream->public.putc  = blkoutstream_putc;
-  stream->public.puts  = blkoutstream_puts;
-  stream->public.flush = blkoutstream_flush;
+  stream->common.putc  = blkoutstream_putc;
+  stream->common.puts  = blkoutstream_puts;
+  stream->common.flush = blkoutstream_flush;
 
   return OK;
 }

--- a/libs/libc/stream/lib_bufferedoutstream.c
+++ b/libs/libc/stream/lib_bufferedoutstream.c
@@ -40,18 +40,18 @@
  * Name: bufferedoutstream_flush
  ****************************************************************************/
 
-static int bufferedoutstream_flush(FAR struct lib_outstream_s *this)
+static int bufferedoutstream_flush(FAR struct lib_outstream_s *self)
 {
-  FAR struct lib_bufferedoutstream_s *rthis =
-    (FAR struct lib_bufferedoutstream_s *)this;
+  FAR struct lib_bufferedoutstream_s *stream =
+    (FAR struct lib_bufferedoutstream_s *)self;
   int ret = OK;
 
-  ret = lib_stream_puts(rthis->backend, rthis->buffer,
-                        rthis->pending);
+  ret = lib_stream_puts(stream->backend, stream->buffer,
+                        stream->pending);
 
   if (ret >= 0)
     {
-      rthis->pending = 0;
+      stream->pending = 0;
     }
 
   return ret;
@@ -61,28 +61,28 @@ static int bufferedoutstream_flush(FAR struct lib_outstream_s *this)
  * Name: bufferedoutstream_puts
  ****************************************************************************/
 
-static int bufferedoutstream_puts(FAR struct lib_outstream_s *this,
+static int bufferedoutstream_puts(FAR struct lib_outstream_s *self,
                                  FAR const void *buf, int len)
 {
-  FAR struct lib_bufferedoutstream_s *rthis =
-    (FAR struct lib_bufferedoutstream_s *)this;
+  FAR struct lib_bufferedoutstream_s *stream =
+    (FAR struct lib_bufferedoutstream_s *)self;
   int ret = len;
 
-  if (rthis->pending + len <= CONFIG_STREAM_OUT_BUFFER_SIZE)
+  if (stream->pending + len <= CONFIG_STREAM_OUT_BUFFER_SIZE)
     {
       /* If buffer is enough to save incoming data, cache it */
 
-      memcpy(rthis->buffer + rthis->pending, buf, len);
-      rthis->pending += len;
+      memcpy(stream->buffer + stream->pending, buf, len);
+      stream->pending += len;
     }
   else
     {
       /* Or, for long data flush buffer and write it directly */
 
-      ret = lib_stream_flush(this);
+      ret = lib_stream_flush(self);
       if (ret >= 0)
         {
-          ret = lib_stream_puts(rthis->backend, buf, len);
+          ret = lib_stream_puts(stream->backend, buf, len);
         }
     }
 
@@ -93,11 +93,11 @@ static int bufferedoutstream_puts(FAR struct lib_outstream_s *this,
  * Name: bufferedoutstream_putc
  ****************************************************************************/
 
-static void bufferedoutstream_putc(FAR struct lib_outstream_s *this, int ch)
+static void bufferedoutstream_putc(FAR struct lib_outstream_s *self, int ch)
 {
   char c = ch;
 
-  bufferedoutstream_puts(this, &c, 1);
+  bufferedoutstream_puts(self, &c, 1);
 }
 
 /****************************************************************************
@@ -108,13 +108,13 @@ static void bufferedoutstream_putc(FAR struct lib_outstream_s *this, int ch)
  * Name: lib_bufferedoutstream
  ****************************************************************************/
 
-void lib_bufferedoutstream(FAR struct lib_bufferedoutstream_s *outstream,
+void lib_bufferedoutstream(FAR struct lib_bufferedoutstream_s *stream,
                            FAR struct lib_outstream_s *backend)
 {
-  outstream->public.putc  = bufferedoutstream_putc;
-  outstream->public.puts  = bufferedoutstream_puts;
-  outstream->public.flush = bufferedoutstream_flush;
-  outstream->public.nput  = 0;
-  outstream->backend      = backend;
-  outstream->pending      = 0;
+  stream->common.putc  = bufferedoutstream_putc;
+  stream->common.puts  = bufferedoutstream_puts;
+  stream->common.flush = bufferedoutstream_flush;
+  stream->common.nput  = 0;
+  stream->backend      = backend;
+  stream->pending      = 0;
 }

--- a/libs/libc/stream/lib_hexdumpstream.c
+++ b/libs/libc/stream/lib_hexdumpstream.c
@@ -77,15 +77,15 @@ static size_t bin2hex(FAR const uint8_t *buf, size_t buflen,
  * Name: hexdumpstream_flush
  ****************************************************************************/
 
-static int hexdumpstream_flush(FAR struct lib_outstream_s *this)
+static int hexdumpstream_flush(FAR struct lib_outstream_s *self)
 {
-  FAR struct lib_hexdumpstream_s *rthis = (FAR void *)this;
+  FAR struct lib_hexdumpstream_s *stream = (FAR void *)self;
 
-  if (rthis->pending > 0)
+  if (stream->pending > 0)
     {
-      rthis->buffer[rthis->pending] = '\n';
-      lib_stream_puts(rthis->backend, rthis->buffer, rthis->pending + 1);
-      rthis->pending = 0;
+      stream->buffer[stream->pending] = '\n';
+      lib_stream_puts(stream->backend, stream->buffer, stream->pending + 1);
+      stream->pending = 0;
     }
 
   return OK;
@@ -95,20 +95,20 @@ static int hexdumpstream_flush(FAR struct lib_outstream_s *this)
  * Name: hexdumpstream_putc
  ****************************************************************************/
 
-static void hexdumpstream_putc(FAR struct lib_outstream_s *this, int ch)
+static void hexdumpstream_putc(FAR struct lib_outstream_s *self, int ch)
 {
-  FAR struct lib_hexdumpstream_s *rthis = (FAR void *)this;
+  FAR struct lib_hexdumpstream_s *stream = (FAR void *)self;
   int outlen = CONFIG_STREAM_HEXDUMP_BUFFER_SIZE;
   const uint8_t byte = ch;
 
-  bin2hex(&byte, 1, rthis->buffer + rthis->pending,
-          (outlen - rthis->pending) / 2);
+  bin2hex(&byte, 1, stream->buffer + stream->pending,
+          (outlen - stream->pending) / 2);
 
-  rthis->pending += 2;
+  stream->pending += 2;
 
-  if (rthis->pending == outlen)
+  if (stream->pending == outlen)
     {
-      hexdumpstream_flush(this);
+      hexdumpstream_flush(self);
     }
 }
 
@@ -116,10 +116,10 @@ static void hexdumpstream_putc(FAR struct lib_outstream_s *this, int ch)
  * Name: hexdumpstream_puts
  ****************************************************************************/
 
-static int hexdumpstream_puts(FAR struct lib_outstream_s *this,
+static int hexdumpstream_puts(FAR struct lib_outstream_s *self,
                            FAR const void *buf, int len)
 {
-  FAR struct lib_hexdumpstream_s *rthis = (FAR void *)this;
+  FAR struct lib_hexdumpstream_s *stream = (FAR void *)self;
   const unsigned char *p = buf;
   int outlen = CONFIG_STREAM_HEXDUMP_BUFFER_SIZE;
   int line = outlen / 2;
@@ -129,20 +129,20 @@ static int hexdumpstream_puts(FAR struct lib_outstream_s *this,
   while (remain > 0)
     {
       ret = remain > line ? line : remain;
-      ret = bin2hex(p, ret, rthis->buffer + rthis->pending,
-                    (outlen - rthis->pending) / 2);
+      ret = bin2hex(p, ret, stream->buffer + stream->pending,
+                    (outlen - stream->pending) / 2);
 
       p              += ret;
       remain         -= ret;
-      rthis->pending += ret * 2;
+      stream->pending += ret * 2;
 
-      if (rthis->pending == outlen)
+      if (stream->pending == outlen)
         {
-          hexdumpstream_flush(this);
+          hexdumpstream_flush(self);
         }
     }
 
-  this->nput += len;
+  self->nput += len;
 
   return len;
 }
@@ -170,7 +170,7 @@ static int hexdumpstream_puts(FAR struct lib_outstream_s *this,
 void lib_hexdumpstream(FAR struct lib_hexdumpstream_s *stream,
                        FAR struct lib_outstream_s *backend)
 {
-  struct lib_outstream_s *public = &stream->public;
+  struct lib_outstream_s *public = &stream->common;
 
   public->putc    = hexdumpstream_putc;
   public->puts    = hexdumpstream_puts;

--- a/libs/libc/stream/lib_libnoflush.c
+++ b/libs/libc/stream/lib_libnoflush.c
@@ -50,8 +50,8 @@
  *
  ****************************************************************************/
 
-int lib_noflush(FAR struct lib_outstream_s *this)
+int lib_noflush(FAR struct lib_outstream_s *self)
 {
-  UNUSED(this);
+  UNUSED(self);
   return OK;
 }

--- a/libs/libc/stream/lib_libsnoflush.c
+++ b/libs/libc/stream/lib_libsnoflush.c
@@ -49,8 +49,8 @@
  *
  ****************************************************************************/
 
-int lib_snoflush(FAR struct lib_sostream_s *this)
+int lib_snoflush(FAR struct lib_sostream_s *self)
 {
-  UNUSED(this);
+  UNUSED(self);
   return OK;
 }

--- a/libs/libc/stream/lib_lowoutstream.c
+++ b/libs/libc/stream/lib_lowoutstream.c
@@ -41,13 +41,13 @@
  * Name: lowoutstream_putc
  ****************************************************************************/
 
-static void lowoutstream_putc(FAR struct lib_outstream_s *this, int ch)
+static void lowoutstream_putc(FAR struct lib_outstream_s *self, int ch)
 {
-  DEBUGASSERT(this);
+  DEBUGASSERT(self);
 
   if (up_putc(ch) != EOF)
     {
-      this->nput++;
+      self->nput++;
     }
 }
 
@@ -55,12 +55,12 @@ static void lowoutstream_putc(FAR struct lib_outstream_s *this, int ch)
  * Name: lowoutstream_puts
  ****************************************************************************/
 
-static int lowoutstream_puts(FAR struct lib_outstream_s *this,
+static int lowoutstream_puts(FAR struct lib_outstream_s *self,
                              FAR const void *buf, int len)
 {
-  DEBUGASSERT(this);
+  DEBUGASSERT(self);
 
-  this->nput += len;
+  self->nput += len;
   up_nputs(buf, len);
   return len;
 }

--- a/libs/libc/stream/lib_lzfcompress.c
+++ b/libs/libc/stream/lib_lzfcompress.c
@@ -35,10 +35,10 @@
  * Name: lzfoutstream_flush
  ****************************************************************************/
 
-static int lzfoutstream_flush(FAR struct lib_outstream_s *this)
+static int lzfoutstream_flush(FAR struct lib_outstream_s *self)
 {
   FAR struct lib_lzfoutstream_s *stream =
-                                 (FAR struct lib_lzfoutstream_s *)this;
+                                 (FAR struct lib_lzfoutstream_s *)self;
   FAR struct lzf_header_s *header;
   size_t outlen;
 
@@ -62,11 +62,11 @@ static int lzfoutstream_flush(FAR struct lib_outstream_s *this)
  * Name: lzfoutstream_puts
  ****************************************************************************/
 
-static int lzfoutstream_puts(FAR struct lib_outstream_s *this,
+static int lzfoutstream_puts(FAR struct lib_outstream_s *self,
                              FAR const void *buf, int len)
 {
   FAR struct lib_lzfoutstream_s *stream =
-                                 (FAR struct lib_lzfoutstream_s *)this;
+                                 (FAR struct lib_lzfoutstream_s *)self;
   FAR struct lzf_header_s *header;
   FAR const char *ptr = buf;
   size_t total = len;
@@ -83,7 +83,7 @@ static int lzfoutstream_puts(FAR struct lib_outstream_s *this,
 
       ptr            += copyin;
       stream->offset += copyin;
-      this->nput     += copyin;
+      self->nput     += copyin;
       total          -= copyin;
 
       if (stream->offset == LZF_STREAM_BLOCKSIZE)
@@ -137,7 +137,7 @@ void lib_lzfoutstream(FAR struct lib_lzfoutstream_s *stream,
     }
 
   memset(stream, 0, sizeof(*stream));
-  stream->public.puts  = lzfoutstream_puts;
-  stream->public.flush = lzfoutstream_flush;
+  stream->common.puts  = lzfoutstream_puts;
+  stream->common.flush = lzfoutstream_flush;
   stream->backend      = backend;
 }

--- a/libs/libc/stream/lib_meminstream.c
+++ b/libs/libc/stream/lib_meminstream.c
@@ -35,19 +35,20 @@
  * Name: meminstream_getc
  ****************************************************************************/
 
-static int meminstream_getc(FAR struct lib_instream_s *this)
+static int meminstream_getc(FAR struct lib_instream_s *self)
 {
-  FAR struct lib_meminstream_s *mthis = (FAR struct lib_meminstream_s *)this;
+  FAR struct lib_meminstream_s *stream =
+                                       (FAR struct lib_meminstream_s *)self;
   int ret;
 
-  DEBUGASSERT(this);
+  DEBUGASSERT(self);
 
   /* Get the next character (if any) from the buffer */
 
-  if (this->nget < mthis->buflen)
+  if (self->nget < stream->buflen)
     {
-      ret = mthis->buffer[this->nget];
-      this->nget++;
+      ret = stream->buffer[self->nget];
+      self->nget++;
     }
   else
     {
@@ -61,22 +62,23 @@ static int meminstream_getc(FAR struct lib_instream_s *this)
  * Name: meminstream_gets
  ****************************************************************************/
 
-static int meminstream_gets(FAR struct lib_instream_s *this,
+static int meminstream_gets(FAR struct lib_instream_s *self,
                             FAR void *buffer, int len)
 {
-  FAR struct lib_meminstream_s *mthis = (FAR struct lib_meminstream_s *)this;
+  FAR struct lib_meminstream_s *stream =
+                                       (FAR struct lib_meminstream_s *)self;
   int ret;
 
-  DEBUGASSERT(this);
+  DEBUGASSERT(self);
 
   /* Get the buffer (if any) from the stream */
 
-  if (this->nget < mthis->buflen)
+  if (self->nget < stream->buflen)
     {
-      ret = mthis->buflen - this->nget < len ?
-            mthis->buflen - this->nget : len;
-      this->nget += ret;
-      memcpy(buffer, mthis->buffer, ret);
+      ret = stream->buflen - self->nget < len ?
+            stream->buflen - self->nget : len;
+      self->nget += ret;
+      memcpy(buffer, stream->buffer, ret);
     }
   else
     {
@@ -97,22 +99,22 @@ static int meminstream_gets(FAR struct lib_instream_s *this,
  *   Initializes a stream for use with a fixed-size memory buffer.
  *
  * Input Parameters:
- *   instream    - User allocated, uninitialized instance of struct
- *                 lib_meminstream_s to be initialized.
- *   bufstart    - Address of the beginning of the fixed-size memory buffer
- *   buflen      - Size of the fixed-sized memory buffer in bytes
+ *   stream   - User allocated, uninitialized instance of struct
+ *              lib_meminstream_s to be initialized.
+ *   bufstart - Address of the beginning of the fixed-size memory buffer
+ *   buflen   - Size of the fixed-sized memory buffer in bytes
  *
  * Returned Value:
- *   None (instream initialized).
+ *   None (stream initialized).
  *
  ****************************************************************************/
 
-void lib_meminstream(FAR struct lib_meminstream_s *instream,
+void lib_meminstream(FAR struct lib_meminstream_s *stream,
                      FAR const char *bufstart, int buflen)
 {
-  instream->public.getc = meminstream_getc;
-  instream->public.gets = meminstream_gets;
-  instream->public.nget = 0;          /* Will be buffer index */
-  instream->buffer      = bufstart;   /* Start of buffer */
-  instream->buflen      = buflen;     /* Length of the buffer */
+  stream->common.getc = meminstream_getc;
+  stream->common.gets = meminstream_gets;
+  stream->common.nget = 0;          /* Will be buffer index */
+  stream->buffer      = bufstart;   /* Start of buffer */
+  stream->buflen      = buflen;     /* Length of the buffer */
 }

--- a/libs/libc/stream/lib_memoutstream.c
+++ b/libs/libc/stream/lib_memoutstream.c
@@ -34,27 +34,27 @@
  * Name: memoutstream_puts
  ****************************************************************************/
 
-static int memoutstream_puts(FAR struct lib_outstream_s *this,
+static int memoutstream_puts(FAR struct lib_outstream_s *self,
                              FAR const void *buf, int len)
 {
-  FAR struct lib_memoutstream_s *mthis =
-                                (FAR struct lib_memoutstream_s *)this;
+  FAR struct lib_memoutstream_s *stream =
+                                (FAR struct lib_memoutstream_s *)self;
   int ncopy;
 
-  DEBUGASSERT(this);
+  DEBUGASSERT(self);
 
   /* If this will not overrun the buffer, then write the character to the
-   * buffer.  Not that buflen was pre-decremented when the stream was
+   * buffer.  Note that buflen was pre-decremented when the stream was
    * created so it is okay to write past the end of the buflen by one.
    */
 
-  ncopy = mthis->buflen - this->nput >= len ?
-          len : mthis->buflen - this->nput;
+  ncopy = stream->buflen - self->nput >= len ?
+          len : stream->buflen - self->nput;
   if (ncopy > 0)
     {
-      memcpy(mthis->buffer + this->nput, buf, ncopy);
-      this->nput += ncopy;
-      mthis->buffer[this->nput] = '\0';
+      memcpy(stream->buffer + self->nput, buf, ncopy);
+      self->nput += ncopy;
+      stream->buffer[self->nput] = '\0';
     }
 
   return ncopy;
@@ -64,10 +64,10 @@ static int memoutstream_puts(FAR struct lib_outstream_s *this,
  * Name: memoutstream_putc
  ****************************************************************************/
 
-static void memoutstream_putc(FAR struct lib_outstream_s *this, int ch)
+static void memoutstream_putc(FAR struct lib_outstream_s *self, int ch)
 {
   char tmp = ch;
-  memoutstream_puts(this, &tmp, 1);
+  memoutstream_puts(self, &tmp, 1);
 }
 
 /****************************************************************************
@@ -94,10 +94,10 @@ static void memoutstream_putc(FAR struct lib_outstream_s *this, int ch)
 void lib_memoutstream(FAR struct lib_memoutstream_s *outstream,
                       FAR char *bufstart, int buflen)
 {
-  outstream->public.putc  = memoutstream_putc;
-  outstream->public.puts  = memoutstream_puts;
-  outstream->public.flush = lib_noflush;
-  outstream->public.nput  = 0;          /* Will be buffer index */
+  outstream->common.putc  = memoutstream_putc;
+  outstream->common.puts  = memoutstream_puts;
+  outstream->common.flush = lib_noflush;
+  outstream->common.nput  = 0;          /* Will be buffer index */
   outstream->buffer       = bufstart;   /* Start of buffer */
   outstream->buflen       = buflen - 1; /* Save space for null terminator */
   outstream->buffer[0]    = '\0';       /* Start with an empty string */

--- a/libs/libc/stream/lib_memsistream.c
+++ b/libs/libc/stream/lib_memsistream.c
@@ -34,20 +34,21 @@
  * Name: memsistream_getc
  ****************************************************************************/
 
-static int memsistream_getc(FAR struct lib_sistream_s *this)
+static int memsistream_getc(FAR struct lib_sistream_s *self)
 {
-  FAR struct lib_memsistream_s *mthis = (FAR struct lib_memsistream_s *)this;
+  FAR struct lib_memsistream_s *stream =
+                                       (FAR struct lib_memsistream_s *)self;
   int ret;
 
-  DEBUGASSERT(this);
+  DEBUGASSERT(self);
 
   /* Get the next character (if any) from the buffer */
 
-  if (mthis->offset < mthis->buflen)
+  if (stream->offset < stream->buflen)
     {
-      ret = mthis->buffer[mthis->offset];
-      mthis->offset++;
-      this->nget++;
+      ret = stream->buffer[stream->offset];
+      stream->offset++;
+      self->nget++;
     }
   else
     {
@@ -61,22 +62,23 @@ static int memsistream_getc(FAR struct lib_sistream_s *this)
  * Name: meminstream_gets
  ****************************************************************************/
 
-static int memsistream_gets(FAR struct lib_instream_s *this,
+static int memsistream_gets(FAR struct lib_instream_s *self,
                             FAR void *buffer, int len)
 {
-  FAR struct lib_memsistream_s *mthis = (FAR struct lib_memsistream_s *)this;
+  FAR struct lib_memsistream_s *stream =
+                                       (FAR struct lib_memsistream_s *)self;
   int ret;
 
-  DEBUGASSERT(this);
+  DEBUGASSERT(self);
 
   /* Get the buffer (if any) from the stream */
 
-  if (this->nget < mthis->buflen)
+  if (self->nget < stream->buflen)
     {
-      ret = mthis->buflen - this->nget;
+      ret = stream->buflen - self->nget;
       ret = ret < len ? ret : len;
-      this->nget += ret;
-      memcpy(buffer, mthis->buffer, ret);
+      self->nget += ret;
+      memcpy(buffer, stream->buffer, ret);
     }
   else
     {
@@ -90,18 +92,19 @@ static int memsistream_gets(FAR struct lib_instream_s *this,
  * Name: memsistream_seek
  ****************************************************************************/
 
-static off_t memsistream_seek(FAR struct lib_sistream_s *this, off_t offset,
+static off_t memsistream_seek(FAR struct lib_sistream_s *self, off_t offset,
                               int whence)
 {
-  FAR struct lib_memsistream_s *mthis = (FAR struct lib_memsistream_s *)this;
+  FAR struct lib_memsistream_s *stream =
+                                       (FAR struct lib_memsistream_s *)self;
   off_t newpos;
 
-  DEBUGASSERT(this);
+  DEBUGASSERT(self);
 
   switch (whence)
     {
       case SEEK_CUR:
-        newpos = (off_t)mthis->offset + offset;
+        newpos = (off_t)stream->offset + offset;
         break;
 
       case SEEK_SET:
@@ -109,7 +112,7 @@ static off_t memsistream_seek(FAR struct lib_sistream_s *this, off_t offset,
         break;
 
       case SEEK_END:
-        newpos = (off_t)mthis->buflen + offset;
+        newpos = (off_t)stream->buflen + offset;
         break;
 
       default:
@@ -118,14 +121,14 @@ static off_t memsistream_seek(FAR struct lib_sistream_s *this, off_t offset,
 
   /* Make sure that the new position is within range */
 
-  if (newpos < 0 || newpos >= (off_t)mthis->buflen)
+  if (newpos < 0 || newpos >= (off_t)stream->buflen)
     {
       return (off_t)ERROR;
     }
 
   /* Return the new position */
 
-  mthis->offset = (size_t)newpos;
+  stream->offset = (size_t)newpos;
   return newpos;
 }
 
@@ -153,10 +156,10 @@ static off_t memsistream_seek(FAR struct lib_sistream_s *this, off_t offset,
 void lib_memsistream(FAR struct lib_memsistream_s *instream,
                      FAR const char *bufstart, int buflen)
 {
-  instream->public.getc = memsistream_getc;
-  instream->public.gets = memsistream_gets;
-  instream->public.seek = memsistream_seek;
-  instream->public.nget = 0;          /* Total number of characters read */
+  instream->common.getc = memsistream_getc;
+  instream->common.gets = memsistream_gets;
+  instream->common.seek = memsistream_seek;
+  instream->common.nget = 0;          /* Total number of characters read */
   instream->buffer      = bufstart;   /* Start of buffer */
   instream->offset      = 0;          /* Will be the buffer index */
   instream->buflen      = buflen;     /* Length of the buffer */

--- a/libs/libc/stream/lib_memsostream.c
+++ b/libs/libc/stream/lib_memsostream.c
@@ -34,23 +34,24 @@
  * Name: memsostream_putc
  ****************************************************************************/
 
-static void memsostream_putc(FAR struct lib_sostream_s *this, int ch)
+static void memsostream_putc(FAR struct lib_sostream_s *self, int ch)
 {
-  FAR struct lib_memsostream_s *mthis = (FAR struct lib_memsostream_s *)this;
+  FAR struct lib_memsostream_s *stream =
+                                       (FAR struct lib_memsostream_s *)self;
 
-  DEBUGASSERT(this);
+  DEBUGASSERT(self);
 
   /* If this will not overrun the buffer, then write the character to the
-   * buffer.  Not that buflen was pre-decremented when the stream was
+   * buffer.  Note that buflen was pre-decremented when the stream was
    * created so it is okay to write past the end of the buflen by one.
    */
 
-  if (mthis->offset < mthis->buflen)
+  if (stream->offset < stream->buflen)
     {
-      mthis->buffer[mthis->offset] = ch;
-      mthis->offset++;
-      this->nput++;
-      mthis->buffer[mthis->offset] = '\0';
+      stream->buffer[stream->offset] = ch;
+      stream->offset++;
+      self->nput++;
+      stream->buffer[stream->offset] = '\0';
     }
 }
 
@@ -58,22 +59,23 @@ static void memsostream_putc(FAR struct lib_sostream_s *this, int ch)
  * Name: memoutstream_puts
  ****************************************************************************/
 
-static int memsostream_puts(FAR struct lib_sostream_s *this,
+static int memsostream_puts(FAR struct lib_sostream_s *self,
                             FAR const void *buf, int len)
 {
   int ncopy;
-  FAR struct lib_memsostream_s *mthis = (FAR struct lib_memsostream_s *)this;
+  FAR struct lib_memsostream_s *stream =
+                                       (FAR struct lib_memsostream_s *)self;
 
-  DEBUGASSERT(this);
+  DEBUGASSERT(self);
 
-  ncopy = mthis->offset + len + 1 < mthis->buflen ? len :
-          mthis->buflen - mthis->offset - 1;
+  ncopy = stream->offset + len + 1 < stream->buflen ? len :
+          stream->buflen - stream->offset - 1;
   if (ncopy > 0)
     {
-      memcpy(mthis->buffer + mthis->offset, buf, ncopy);
-      mthis->public.nput += ncopy;
-      mthis->offset += ncopy;
-      mthis->buffer[mthis->offset] = '\0';
+      memcpy(stream->buffer + stream->offset, buf, ncopy);
+      stream->common.nput += ncopy;
+      stream->offset += ncopy;
+      stream->buffer[stream->offset] = '\0';
     }
 
   return ncopy;
@@ -83,18 +85,19 @@ static int memsostream_puts(FAR struct lib_sostream_s *this,
  * Name: memsostream_seek
  ****************************************************************************/
 
-static off_t memsostream_seek(FAR struct lib_sostream_s *this, off_t offset,
+static off_t memsostream_seek(FAR struct lib_sostream_s *self, off_t offset,
                               int whence)
 {
-  FAR struct lib_memsostream_s *mthis = (FAR struct lib_memsostream_s *)this;
+  FAR struct lib_memsostream_s *stream =
+                                       (FAR struct lib_memsostream_s *)self;
   off_t newpos;
 
-  DEBUGASSERT(this);
+  DEBUGASSERT(self);
 
   switch (whence)
     {
       case SEEK_CUR:
-        newpos = (off_t)mthis->offset + offset;
+        newpos = (off_t)stream->offset + offset;
         break;
 
       case SEEK_SET:
@@ -102,7 +105,7 @@ static off_t memsostream_seek(FAR struct lib_sostream_s *this, off_t offset,
         break;
 
       case SEEK_END:
-        newpos = (off_t)mthis->buflen + offset;
+        newpos = (off_t)stream->buflen + offset;
         break;
 
       default:
@@ -111,14 +114,14 @@ static off_t memsostream_seek(FAR struct lib_sostream_s *this, off_t offset,
 
   /* Make sure that the new position is within range */
 
-  if (newpos < 0 || newpos >= (off_t)mthis->buflen)
+  if (newpos < 0 || newpos >= (off_t)stream->buflen)
     {
       return (off_t)ERROR;
     }
 
   /* Return the new position */
 
-  mthis->offset = (size_t)newpos;
+  stream->offset = (size_t)newpos;
   return newpos;
 }
 
@@ -146,11 +149,11 @@ static off_t memsostream_seek(FAR struct lib_sostream_s *this, off_t offset,
 void lib_memsostream(FAR struct lib_memsostream_s *outstream,
                      FAR char *bufstart, int buflen)
 {
-  outstream->public.putc  = memsostream_putc;
-  outstream->public.puts  = memsostream_puts;
-  outstream->public.flush = lib_snoflush;
-  outstream->public.seek  = memsostream_seek;
-  outstream->public.nput  = 0;          /* Total number of characters written */
+  outstream->common.putc  = memsostream_putc;
+  outstream->common.puts  = memsostream_puts;
+  outstream->common.flush = lib_snoflush;
+  outstream->common.seek  = memsostream_seek;
+  outstream->common.nput  = 0;          /* Total number of characters written */
   outstream->buffer       = bufstart;   /* Start of buffer */
   outstream->offset       = 0;          /* Will be the buffer index */
   outstream->buflen       = buflen - 1; /* Save space for null terminator */

--- a/libs/libc/stream/lib_nullinstream.c
+++ b/libs/libc/stream/lib_nullinstream.c
@@ -31,13 +31,13 @@
  * Private Functions
  ****************************************************************************/
 
-static int nullinstream_getc(FAR struct lib_instream_s *this)
+static int nullinstream_getc(FAR struct lib_instream_s *self)
 {
-  UNUSED(this);
+  UNUSED(self);
   return EOF;
 }
 
-static int nullinstream_gets(FAR struct lib_instream_s *this,
+static int nullinstream_gets(FAR struct lib_instream_s *self,
                              FAR void *buffer, int len)
 {
   UNUSED(buffer);
@@ -57,17 +57,17 @@ static int nullinstream_gets(FAR struct lib_instream_s *this,
  *   EOF.
  *
  * Input Parameters:
- *   nullinstream  - User allocated, uninitialized instance of struct
- *                   lib_instream_s to be initialized.
+ *   stream  - User allocated, uninitialized instance of struct
+ *             lib_instream_s to be initialized.
  *
  * Returned Value:
  *   None (User allocated instance initialized).
  *
  ****************************************************************************/
 
-void lib_nullinstream(FAR struct lib_instream_s *nullinstream)
+void lib_nullinstream(FAR struct lib_instream_s *stream)
 {
-  nullinstream->getc = nullinstream_getc;
-  nullinstream->gets = nullinstream_gets;
-  nullinstream->nget = 0;
+  stream->getc = nullinstream_getc;
+  stream->gets = nullinstream_gets;
+  stream->nget = 0;
 }

--- a/libs/libc/stream/lib_nulloutstream.c
+++ b/libs/libc/stream/lib_nulloutstream.c
@@ -32,20 +32,20 @@
  * Private Functions
  ****************************************************************************/
 
-static void nulloutstream_putc(FAR struct lib_outstream_s *this, int ch)
+static void nulloutstream_putc(FAR struct lib_outstream_s *self, int ch)
 {
   UNUSED(ch);
-  DEBUGASSERT(this);
-  this->nput++;
+  DEBUGASSERT(self);
+  self->nput++;
 }
 
-static int nulloutstream_puts(FAR struct lib_outstream_s *this,
+static int nulloutstream_puts(FAR struct lib_outstream_s *self,
                               FAR const void *buffer, int len)
 {
   UNUSED(buffer);
   UNUSED(len);
-  DEBUGASSERT(this);
-  this->nput += len;
+  DEBUGASSERT(self);
+  self->nput += len;
   return len;
 }
 
@@ -61,18 +61,18 @@ static int nulloutstream_puts(FAR struct lib_outstream_s *this,
  *   to the bit-bucket.
  *
  * Input Parameters:
- *   nulloutstream - User allocated, uninitialized instance of struct
- *                   lib_outstream_s to be initialized.
+ *   stream - User allocated, uninitialized instance of struct
+ *            lib_outstream_s to be initialized.
  *
  * Returned Value:
  *   None (User allocated instance initialized).
  *
  ****************************************************************************/
 
-void lib_nulloutstream(FAR struct lib_outstream_s *nulloutstream)
+void lib_nulloutstream(FAR struct lib_outstream_s *stream)
 {
-  nulloutstream->putc  = nulloutstream_putc;
-  nulloutstream->puts  = nulloutstream_puts;
-  nulloutstream->flush = lib_noflush;
-  nulloutstream->nput  = 0;
+  stream->putc  = nulloutstream_putc;
+  stream->puts  = nulloutstream_puts;
+  stream->flush = lib_noflush;
+  stream->nput  = 0;
 }

--- a/libs/libc/stream/lib_rawinstream.c
+++ b/libs/libc/stream/lib_rawinstream.c
@@ -40,20 +40,21 @@
  * Name: rawinstream_getc
  ****************************************************************************/
 
-static int rawinstream_getc(FAR struct lib_instream_s *this)
+static int rawinstream_getc(FAR struct lib_instream_s *self)
 {
-  FAR struct lib_rawinstream_s *rthis = (FAR struct lib_rawinstream_s *)this;
+  FAR struct lib_rawinstream_s *stream =
+                                       (FAR struct lib_rawinstream_s *)self;
   int nread;
   char ch;
 
-  DEBUGASSERT(this && rthis->fd >= 0);
+  DEBUGASSERT(self && stream->fd >= 0);
 
   /* Attempt to read one character */
 
-  nread = _NX_READ(rthis->fd, &ch, 1);
+  nread = _NX_READ(stream->fd, &ch, 1);
   if (nread == 1)
     {
-      this->nget++;
+      self->nget++;
       return ch;
     }
 
@@ -70,20 +71,21 @@ static int rawinstream_getc(FAR struct lib_instream_s *this)
  * Name: rawinstream_getc
  ****************************************************************************/
 
-static int rawinstream_gets(FAR struct lib_instream_s *this,
+static int rawinstream_gets(FAR struct lib_instream_s *self,
                             FAR void *buffer, int len)
 {
-  FAR struct lib_rawinstream_s *rthis = (FAR struct lib_rawinstream_s *)this;
+  FAR struct lib_rawinstream_s *stream =
+                                       (FAR struct lib_rawinstream_s *)self;
   int nread;
 
-  DEBUGASSERT(this && rthis->fd >= 0);
+  DEBUGASSERT(self && stream->fd >= 0);
 
   /* Attempt to read one character */
 
-  nread = _NX_READ(rthis->fd, buffer, len);
+  nread = _NX_READ(stream->fd, buffer, len);
   if (nread >= 0)
     {
-      this->nget += nread;
+      self->nget += nread;
     }
   else
     {
@@ -104,7 +106,7 @@ static int rawinstream_gets(FAR struct lib_instream_s *this,
  *   Initializes a stream for use with a file descriptor.
  *
  * Input Parameters:
- *   instream - User allocated, uninitialized instance of struct
+ *   stream   - User allocated, uninitialized instance of struct
  *              lib_rawinstream_s to be initialized.
  *   fd       - User provided file/socket descriptor (must have been opened
  *              for the correct access).
@@ -114,10 +116,10 @@ static int rawinstream_gets(FAR struct lib_instream_s *this,
  *
  ****************************************************************************/
 
-void lib_rawinstream(FAR struct lib_rawinstream_s *instream, int fd)
+void lib_rawinstream(FAR struct lib_rawinstream_s *stream, int fd)
 {
-  instream->public.getc = rawinstream_getc;
-  instream->public.gets = rawinstream_gets;
-  instream->public.nget = 0;
-  instream->fd          = fd;
+  stream->common.getc = rawinstream_getc;
+  stream->common.gets = rawinstream_gets;
+  stream->common.nget = 0;
+  stream->fd          = fd;
 }

--- a/libs/libc/stream/lib_rawoutstream.c
+++ b/libs/libc/stream/lib_rawoutstream.c
@@ -40,19 +40,19 @@
  * Name: rawoutstream_puts
  ****************************************************************************/
 
-static int rawoutstream_puts(FAR struct lib_outstream_s *this,
+static int rawoutstream_puts(FAR struct lib_outstream_s *self,
                              FAR const void *buf, int len)
 {
-  FAR struct lib_rawoutstream_s *rthis =
-                                (FAR struct lib_rawoutstream_s *)this;
+  FAR struct lib_rawoutstream_s *stream =
+                                (FAR struct lib_rawoutstream_s *)self;
   int nwritten = 0;
 
   do
     {
-      nwritten = _NX_WRITE(rthis->fd, buf, len);
+      nwritten = _NX_WRITE(stream->fd, buf, len);
       if (nwritten >= 0)
         {
-          this->nput += nwritten;
+          self->nput += nwritten;
           return nwritten;
         }
 
@@ -73,10 +73,10 @@ static int rawoutstream_puts(FAR struct lib_outstream_s *this,
  * Name: rawoutstream_putc
  ****************************************************************************/
 
-static void rawoutstream_putc(FAR struct lib_outstream_s *this, int ch)
+static void rawoutstream_putc(FAR struct lib_outstream_s *self, int ch)
 {
   char tmp = ch;
-  rawoutstream_puts(this, &tmp, 1);
+  rawoutstream_puts(self, &tmp, 1);
 }
 
 /****************************************************************************
@@ -90,21 +90,21 @@ static void rawoutstream_putc(FAR struct lib_outstream_s *this, int ch)
  *   Initializes a stream for use with a file descriptor.
  *
  * Input Parameters:
- *   outstream - User allocated, uninitialized instance of struct
- *               lib_rawoutstream_s to be initialized.
- *   fd        - User provided file/socket descriptor (must have been opened
- *               for write access).
+ *   stream - User allocated, uninitialized instance of struct
+ *            lib_rawoutstream_s to be initialized.
+ *   fd     - User provided file/socket descriptor (must have been opened
+ *            for write access).
  *
  * Returned Value:
  *   None (User allocated instance initialized).
  *
  ****************************************************************************/
 
-void lib_rawoutstream(FAR struct lib_rawoutstream_s *outstream, int fd)
+void lib_rawoutstream(FAR struct lib_rawoutstream_s *stream, int fd)
 {
-  outstream->public.putc  = rawoutstream_putc;
-  outstream->public.puts  = rawoutstream_puts;
-  outstream->public.flush = lib_noflush;
-  outstream->public.nput  = 0;
-  outstream->fd           = fd;
+  stream->common.putc  = rawoutstream_putc;
+  stream->common.puts  = rawoutstream_puts;
+  stream->common.flush = lib_noflush;
+  stream->common.nput  = 0;
+  stream->fd           = fd;
 }

--- a/libs/libc/stream/lib_rawsistream.c
+++ b/libs/libc/stream/lib_rawsistream.c
@@ -40,20 +40,21 @@
  * Name: rawsistream_getc
  ****************************************************************************/
 
-static int rawsistream_getc(FAR struct lib_sistream_s *this)
+static int rawsistream_getc(FAR struct lib_sistream_s *self)
 {
-  FAR struct lib_rawsistream_s *rthis = (FAR struct lib_rawsistream_s *)this;
+  FAR struct lib_rawsistream_s *stream =
+                                       (FAR struct lib_rawsistream_s *)self;
   int nread;
   char ch;
 
-  DEBUGASSERT(this && rthis->fd >= 0);
+  DEBUGASSERT(self && stream->fd >= 0);
 
   /* Attempt to read one character */
 
-  nread = _NX_READ(rthis->fd, &ch, 1);
+  nread = _NX_READ(stream->fd, &ch, 1);
   if (nread == 1)
     {
-      this->nget++;
+      self->nget++;
       return ch;
     }
 
@@ -70,20 +71,21 @@ static int rawsistream_getc(FAR struct lib_sistream_s *this)
  * Name: rawsistream_gets
  ****************************************************************************/
 
-static int rawsistream_gets(FAR struct lib_instream_s *this,
+static int rawsistream_gets(FAR struct lib_instream_s *self,
                             FAR void *buffer, int len)
 {
-  FAR struct lib_rawsistream_s *rthis = (FAR struct lib_rawsistream_s *)this;
+  FAR struct lib_rawsistream_s *stream =
+                                       (FAR struct lib_rawsistream_s *)self;
   int nread;
 
-  DEBUGASSERT(this && rthis->fd >= 0);
+  DEBUGASSERT(self && stream->fd >= 0);
 
   /* Attempt to read a buffer */
 
-  nread = _NX_READ(rthis->fd, buffer, len);
+  nread = _NX_READ(stream->fd, buffer, len);
   if (nread >= 0)
     {
-      this->nget += nread;
+      self->nget += nread;
     }
   else
     {
@@ -97,13 +99,14 @@ static int rawsistream_gets(FAR struct lib_instream_s *this,
  * Name: rawsistream_seek
  ****************************************************************************/
 
-static off_t rawsistream_seek(FAR struct lib_sistream_s *this, off_t offset,
+static off_t rawsistream_seek(FAR struct lib_sistream_s *self, off_t offset,
                               int whence)
 {
-  FAR struct lib_rawsistream_s *mthis = (FAR struct lib_rawsistream_s *)this;
+  FAR struct lib_rawsistream_s *stream =
+                                       (FAR struct lib_rawsistream_s *)self;
 
-  DEBUGASSERT(this);
-  return _NX_SEEK(mthis->fd, offset, whence);
+  DEBUGASSERT(self);
+  return _NX_SEEK(stream->fd, offset, whence);
 }
 
 /****************************************************************************
@@ -117,21 +120,21 @@ static off_t rawsistream_seek(FAR struct lib_sistream_s *this, off_t offset,
  *   Initializes a stream for use with a file descriptor.
  *
  * Input Parameters:
- *   instream - User allocated, uninitialized instance of struct
- *              lib_rawsistream_s to be initialized.
- *   fd       - User provided file/socket descriptor (must have been opened
- *              for the correct access).
+ *   stream - User allocated, uninitialized instance of struct
+ *            lib_rawsistream_s to be initialized.
+ *   fd     - User provided file/socket descriptor (must have been opened
+ *            for the correct access).
  *
  * Returned Value:
  *   None (User allocated instance initialized).
  *
  ****************************************************************************/
 
-void lib_rawsistream(FAR struct lib_rawsistream_s *instream, int fd)
+void lib_rawsistream(FAR struct lib_rawsistream_s *stream, int fd)
 {
-  instream->public.getc = rawsistream_getc;
-  instream->public.gets = rawsistream_gets;
-  instream->public.seek = rawsistream_seek;
-  instream->public.nget = 0;
-  instream->fd          = fd;
+  stream->common.getc = rawsistream_getc;
+  stream->common.gets = rawsistream_gets;
+  stream->common.seek = rawsistream_seek;
+  stream->common.nget = 0;
+  stream->fd          = fd;
 }

--- a/libs/libc/stream/lib_rawsostream.c
+++ b/libs/libc/stream/lib_rawsostream.c
@@ -40,13 +40,14 @@
  * Name: rawsostream_putc
  ****************************************************************************/
 
-static void rawsostream_putc(FAR struct lib_sostream_s *this, int ch)
+static void rawsostream_putc(FAR struct lib_sostream_s *self, int ch)
 {
-  FAR struct lib_rawsostream_s *rthis = (FAR struct lib_rawsostream_s *)this;
+  FAR struct lib_rawsostream_s *stream =
+                                       (FAR struct lib_rawsostream_s *)self;
   char buffer = ch;
   int nwritten;
 
-  DEBUGASSERT(this && rthis->fd >= 0);
+  DEBUGASSERT(self && stream->fd >= 0);
 
   /* Loop until the character is successfully transferred or until an
    * irrecoverable error occurs.
@@ -54,10 +55,10 @@ static void rawsostream_putc(FAR struct lib_sostream_s *this, int ch)
 
   do
     {
-      nwritten = _NX_WRITE(rthis->fd, &buffer, 1);
+      nwritten = _NX_WRITE(stream->fd, &buffer, 1);
       if (nwritten == 1)
         {
-          this->nput++;
+          self->nput++;
           return;
         }
 
@@ -76,13 +77,14 @@ static void rawsostream_putc(FAR struct lib_sostream_s *this, int ch)
  * Name: rawsostream_puts
  ****************************************************************************/
 
-static int rawsostream_puts(FAR struct lib_sostream_s *this,
+static int rawsostream_puts(FAR struct lib_sostream_s *self,
                             FAR const void *buffer, int len)
 {
-  FAR struct lib_rawsostream_s *rthis = (FAR struct lib_rawsostream_s *)this;
+  FAR struct lib_rawsostream_s *stream =
+                                       (FAR struct lib_rawsostream_s *)self;
   int nwritten;
 
-  DEBUGASSERT(this && rthis->fd >= 0);
+  DEBUGASSERT(self && stream->fd >= 0);
 
   /* Loop until the buffer is successfully transferred or until an
    * irrecoverable error occurs.
@@ -90,10 +92,10 @@ static int rawsostream_puts(FAR struct lib_sostream_s *this,
 
   do
     {
-      nwritten = _NX_WRITE(rthis->fd, buffer, len);
+      nwritten = _NX_WRITE(stream->fd, buffer, len);
       if (nwritten >= 0)
         {
-          this->nput += nwritten;
+          self->nput += nwritten;
           return nwritten;
         }
 
@@ -114,13 +116,14 @@ static int rawsostream_puts(FAR struct lib_sostream_s *this,
  * Name: rawsostream_seek
  ****************************************************************************/
 
-static off_t rawsostream_seek(FAR struct lib_sostream_s *this, off_t offset,
+static off_t rawsostream_seek(FAR struct lib_sostream_s *self, off_t offset,
                               int whence)
 {
-  FAR struct lib_rawsostream_s *mthis = (FAR struct lib_rawsostream_s *)this;
+  FAR struct lib_rawsostream_s *stream =
+                                       (FAR struct lib_rawsostream_s *)self;
 
-  DEBUGASSERT(this);
-  return _NX_SEEK(mthis->fd, offset, whence);
+  DEBUGASSERT(self);
+  return _NX_SEEK(stream->fd, offset, whence);
 }
 
 /****************************************************************************
@@ -134,22 +137,22 @@ static off_t rawsostream_seek(FAR struct lib_sostream_s *this, off_t offset,
  *   Initializes a stream for use with a file descriptor.
  *
  * Input Parameters:
- *   outstream - User allocated, uninitialized instance of struct
- *               lib_rawsostream_s to be initialized.
- *   fd        - User provided file/socket descriptor (must have been opened
- *               for write access).
+ *   stream - User allocated, uninitialized instance of struct
+ *            lib_rawsostream_s to be initialized.
+ *   fd     - User provided file/socket descriptor (must have been opened
+ *            for write access).
  *
  * Returned Value:
  *   None (User allocated instance initialized).
  *
  ****************************************************************************/
 
-void lib_rawsostream(FAR struct lib_rawsostream_s *outstream, int fd)
+void lib_rawsostream(FAR struct lib_rawsostream_s *stream, int fd)
 {
-  outstream->public.putc  = rawsostream_putc;
-  outstream->public.puts  = rawsostream_puts;
-  outstream->public.flush = lib_snoflush;
-  outstream->public.seek  = rawsostream_seek;
-  outstream->public.nput  = 0;
-  outstream->fd           = fd;
+  stream->common.putc  = rawsostream_putc;
+  stream->common.puts  = rawsostream_puts;
+  stream->common.flush = lib_snoflush;
+  stream->common.seek  = rawsostream_seek;
+  stream->common.nput  = 0;
+  stream->fd           = fd;
 }

--- a/libs/libc/stream/lib_stdinstream.c
+++ b/libs/libc/stream/lib_stdinstream.c
@@ -35,19 +35,20 @@
  * Name: stdinstream_getc
  ****************************************************************************/
 
-static int stdinstream_getc(FAR struct lib_instream_s *this)
+static int stdinstream_getc(FAR struct lib_instream_s *self)
 {
-  FAR struct lib_stdinstream_s *sthis = (FAR struct lib_stdinstream_s *)this;
+  FAR struct lib_stdinstream_s *stream =
+                                       (FAR struct lib_stdinstream_s *)self;
   int ret;
 
-  DEBUGASSERT(this);
+  DEBUGASSERT(self);
 
   /* Get the next character from the incoming stream */
 
-  ret = getc(sthis->stream);
+  ret = getc(stream->handle);
   if (ret != EOF)
     {
-      this->nget++;
+      self->nget++;
     }
 
   return ret;
@@ -57,20 +58,21 @@ static int stdinstream_getc(FAR struct lib_instream_s *this)
  * Name: stdinstream_gets
  ****************************************************************************/
 
-static int stdinstream_gets(FAR struct lib_instream_s *this,
+static int stdinstream_gets(FAR struct lib_instream_s *self,
                             FAR void *buffer, int len)
 {
-  FAR struct lib_stdinstream_s *sthis = (FAR struct lib_stdinstream_s *)this;
+  FAR struct lib_stdinstream_s *stream =
+                                       (FAR struct lib_stdinstream_s *)self;
   int nread = 0;
 
-  DEBUGASSERT(this);
+  DEBUGASSERT(self);
 
-  /* Get the buffer from the incoming stream */
+  /* Get the buffer from the incoming stream handle */
 
-  nread = fread(buffer, len, 1, sthis->stream);
+  nread = fread(buffer, len, 1, stream->handle);
   if (nread >= 0)
     {
-      this->nget += nread;
+      self->nget += nread;
     }
   else
     {
@@ -93,7 +95,7 @@ static int stdinstream_gets(FAR struct lib_instream_s *this,
  * Input Parameters:
  *   instream - User allocated, uninitialized instance of struct
  *              lib_stdinstream_s to be initialized.
- *   stream   - User provided stream instance (must have been opened for
+ *   handle   - User provided handle instance (must have been opened for
  *              read access).
  *
  * Returned Value:
@@ -101,11 +103,11 @@ static int stdinstream_gets(FAR struct lib_instream_s *this,
  *
  ****************************************************************************/
 
-void lib_stdinstream(FAR struct lib_stdinstream_s *instream,
-                     FAR FILE *stream)
+void lib_stdinstream(FAR struct lib_stdinstream_s *stream,
+                     FAR FILE *handle)
 {
-  instream->public.getc = stdinstream_getc;
-  instream->public.gets = stdinstream_gets;
-  instream->public.nget = 0;
-  instream->stream      = stream;
+  stream->common.getc = stdinstream_getc;
+  stream->common.gets = stdinstream_gets;
+  stream->common.nget = 0;
+  stream->handle      = handle;
 }

--- a/libs/libc/stream/lib_stdoutstream.c
+++ b/libs/libc/stream/lib_stdoutstream.c
@@ -37,13 +37,13 @@
  * Name: stdoutstream_putc
  ****************************************************************************/
 
-static void stdoutstream_putc(FAR struct lib_outstream_s *this, int ch)
+static void stdoutstream_putc(FAR struct lib_outstream_s *self, int ch)
 {
-  FAR struct lib_stdoutstream_s *sthis =
-                               (FAR struct lib_stdoutstream_s *)this;
+  FAR struct lib_stdoutstream_s *stream =
+                                      (FAR struct lib_stdoutstream_s *)self;
   int result;
 
-  DEBUGASSERT(this && sthis->stream);
+  DEBUGASSERT(self && stream->handle);
 
   /* Loop until the character is successfully transferred or an irrecoverable
    * error occurs.
@@ -51,10 +51,10 @@ static void stdoutstream_putc(FAR struct lib_outstream_s *this, int ch)
 
   do
     {
-      result = fputc(ch, sthis->stream);
+      result = fputc(ch, stream->handle);
       if (result != EOF)
         {
-          this->nput++;
+          self->nput++;
           return;
         }
 
@@ -69,14 +69,14 @@ static void stdoutstream_putc(FAR struct lib_outstream_s *this, int ch)
  * Name: stdoutstream_puts
  ****************************************************************************/
 
-static int stdoutstream_puts(FAR struct lib_outstream_s *this,
+static int stdoutstream_puts(FAR struct lib_outstream_s *self,
                              FAR const void *buffer, int len)
 {
-  FAR struct lib_stdoutstream_s *sthis =
-                               (FAR struct lib_stdoutstream_s *)this;
+  FAR struct lib_stdoutstream_s *stream =
+                               (FAR struct lib_stdoutstream_s *)self;
   int result;
 
-  DEBUGASSERT(this && sthis->stream);
+  DEBUGASSERT(self && stream->handle);
 
   /* Loop until the buffer is successfully transferred or an irrecoverable
    * error occurs.
@@ -84,10 +84,10 @@ static int stdoutstream_puts(FAR struct lib_outstream_s *this,
 
   do
     {
-      result = fwrite(buffer, len, 1, sthis->stream);
+      result = fwrite(buffer, len, 1, stream->handle);
       if (result >= 0)
         {
-          this->nput += result;
+          self->nput += result;
           return result;
         }
 
@@ -107,13 +107,13 @@ static int stdoutstream_puts(FAR struct lib_outstream_s *this,
  ****************************************************************************/
 
 #ifndef CONFIG_STDIO_DISABLE_BUFFERING
-static int stdoutstream_flush(FAR struct lib_outstream_s *this)
+static int stdoutstream_flush(FAR struct lib_outstream_s *self)
 {
-  FAR struct lib_stdoutstream_s *sthis =
-                                (FAR struct lib_stdoutstream_s *)this;
+  FAR struct lib_stdoutstream_s *stream =
+                                (FAR struct lib_stdoutstream_s *)self;
 
-  DEBUGASSERT(sthis != NULL && sthis->stream != NULL);
-  return lib_fflush(sthis->stream, true);
+  DEBUGASSERT(stream != NULL && stream->handle != NULL);
+  return lib_fflush(stream->handle, true);
 }
 #endif
 
@@ -130,7 +130,7 @@ static int stdoutstream_flush(FAR struct lib_outstream_s *this)
  * Input Parameters:
  *   outstream - User allocated, uninitialized instance of struct
  *               lib_stdoutstream_s to be initialized.
- *   stream    - User provided stream instance (must have been opened for
+ *   handle    - User provided FILE instance (must have been opened for
  *               write access).
  *
  * Returned Value:
@@ -138,34 +138,34 @@ static int stdoutstream_flush(FAR struct lib_outstream_s *this)
  *
  ****************************************************************************/
 
-void lib_stdoutstream(FAR struct lib_stdoutstream_s *outstream,
-                      FAR FILE *stream)
+void lib_stdoutstream(FAR struct lib_stdoutstream_s *stream,
+                      FAR FILE *handle)
 {
   /* Select the putc operation */
 
-  outstream->public.putc = stdoutstream_putc;
-  outstream->public.puts = stdoutstream_puts;
+  stream->common.putc = stdoutstream_putc;
+  stream->common.puts = stdoutstream_puts;
 
   /* Select the correct flush operation.  This flush is only called when
-   * a newline is encountered in the output stream.  However, we do not
-   * want to support this line buffering behavior if the stream was
+   * a newline is encountered in the output file stream.  However, we do not
+   * want to support this line buffering behavior if the file was
    * opened in binary mode.  In binary mode, the newline has no special
    * meaning.
    */
 
 #ifndef CONFIG_STDIO_DISABLE_BUFFERING
-  if (stream->fs_bufstart != NULL && (stream->fs_oflags & O_TEXT) != 0)
+  if (handle->fs_bufstart != NULL && (handle->fs_oflags & O_TEXT) != 0)
     {
-      outstream->public.flush = stdoutstream_flush;
+      stream->common.flush = stdoutstream_flush;
     }
   else
 #endif
     {
-      outstream->public.flush = lib_noflush;
+      stream->common.flush = lib_noflush;
     }
 
-  /* Set the number of bytes put to zero and remember the stream */
+  /* Set the number of bytes put to zero and remember the handle */
 
-  outstream->public.nput = 0;
-  outstream->stream      = stream;
+  stream->common.nput = 0;
+  stream->handle      = handle;
 }

--- a/libs/libc/stream/lib_stdsistream.c
+++ b/libs/libc/stream/lib_stdsistream.c
@@ -34,19 +34,20 @@
  * Name: stdsistream_getc
  ****************************************************************************/
 
-static int stdsistream_getc(FAR struct lib_sistream_s *this)
+static int stdsistream_getc(FAR struct lib_sistream_s *self)
 {
-  FAR struct lib_stdsistream_s *sthis = (FAR struct lib_stdsistream_s *)this;
+  FAR struct lib_stdsistream_s *stream =
+                                       (FAR struct lib_stdsistream_s *)self;
   int ret;
 
-  DEBUGASSERT(this);
+  DEBUGASSERT(self);
 
-  /* Get the next character from the incoming stream */
+  /* Get the next character from the incoming file stream */
 
-  ret = getc(sthis->stream);
+  ret = getc(stream->handle);
   if (ret != EOF)
     {
-      this->nget++;
+      self->nget++;
     }
 
   return ret;
@@ -56,20 +57,21 @@ static int stdsistream_getc(FAR struct lib_sistream_s *this)
  * Name: stdsistream_gets
  ****************************************************************************/
 
-static int stdsistream_gets(FAR struct lib_instream_s *this,
+static int stdsistream_gets(FAR struct lib_instream_s *self,
                             FAR void *buffer, int len)
 {
-  FAR struct lib_stdsistream_s *sthis = (FAR struct lib_stdsistream_s *)this;
+  FAR struct lib_stdsistream_s *stream =
+                                        (FAR struct lib_stdsistream_s *)self;
   int nread = 0;
 
-  DEBUGASSERT(this);
+  DEBUGASSERT(self);
 
-  /* Get the buffer from the incoming stream */
+  /* Get the buffer from the incoming file stream */
 
-  nread = fread(buffer, len, 1, sthis->stream);
+  nread = fread(buffer, len, 1, stream->handle);
   if (nread >= 0)
     {
-      this->nget += nread;
+      self->nget += nread;
     }
   else
     {
@@ -83,13 +85,14 @@ static int stdsistream_gets(FAR struct lib_instream_s *this,
  * Name: stdsistream_seek
  ****************************************************************************/
 
-static off_t stdsistream_seek(FAR struct lib_sistream_s *this, off_t offset,
+static off_t stdsistream_seek(FAR struct lib_sistream_s *self, off_t offset,
                               int whence)
 {
-  FAR struct lib_stdsistream_s *mthis = (FAR struct lib_stdsistream_s *)this;
+  FAR struct lib_stdsistream_s *stream =
+                                        (FAR struct lib_stdsistream_s *)self;
 
-  DEBUGASSERT(this);
-  return fseek(mthis->stream, offset, whence);
+  DEBUGASSERT(self);
+  return fseek(stream->handle, offset, whence);
 }
 
 /****************************************************************************
@@ -103,22 +106,22 @@ static off_t stdsistream_seek(FAR struct lib_sistream_s *this, off_t offset,
  *   Initializes a stream for use with a FILE instance.
  *
  * Input Parameters:
- *   instream - User allocated, uninitialized instance of struct
- *              lib_stdsistream_s to be initialized.
- *   stream   - User provided stream instance (must have been opened for
- *              read access).
+ *   stream - User allocated, uninitialized instance of struct
+ *            lib_stdsistream_s to be initialized.
+ *   handle - User provided file instance (must have been opened for
+ *            read access).
  *
  * Returned Value:
  *   None (User allocated instance initialized).
  *
  ****************************************************************************/
 
-void lib_stdsistream(FAR struct lib_stdsistream_s *instream,
-                     FAR FILE *stream)
+void lib_stdsistream(FAR struct lib_stdsistream_s *stream,
+                     FAR FILE *handle)
 {
-  instream->public.getc = stdsistream_getc;
-  instream->public.gets = stdsistream_gets;
-  instream->public.seek = stdsistream_seek;
-  instream->public.nget = 0;
-  instream->stream      = stream;
+  stream->common.getc = stdsistream_getc;
+  stream->common.gets = stdsistream_gets;
+  stream->common.seek = stdsistream_seek;
+  stream->common.nget = 0;
+  stream->handle      = handle;
 }

--- a/libs/libc/stream/lib_syslograwstream.c
+++ b/libs/libc/stream/lib_syslograwstream.c
@@ -85,7 +85,7 @@ static void syslograwstream_addchar(FAR struct lib_syslograwstream_s *stream,
 
   /* Increment the total number of bytes buffered. */
 
-  stream->public.nput++;
+  stream->common.nput++;
 
   /* Is the buffer full? */
 
@@ -93,7 +93,7 @@ static void syslograwstream_addchar(FAR struct lib_syslograwstream_s *stream,
     {
       /* Yes.. then flush the buffer */
 
-      syslograwstream_flush(&stream->public);
+      syslograwstream_flush(&stream->common);
     }
 }
 
@@ -121,14 +121,14 @@ syslograwstream_addstring(FAR struct lib_syslograwstream_s *stream,
         {
           /* Yes.. then flush the buffer */
 
-          syslograwstream_flush(&stream->public);
+          syslograwstream_flush(&stream->common);
         }
     }
   while (ret < len);
 
   /* Increment the total number of bytes buffered. */
 
-  stream->public.nput += len;
+  stream->common.nput += len;
   return len;
 }
 #endif
@@ -137,10 +137,10 @@ syslograwstream_addstring(FAR struct lib_syslograwstream_s *stream,
  * Name: syslograwstream_putc
  ****************************************************************************/
 
-static void syslograwstream_putc(FAR struct lib_outstream_s *this, int ch)
+static void syslograwstream_putc(FAR struct lib_outstream_s *self, int ch)
 {
   FAR struct lib_syslograwstream_s *stream =
-                                    (FAR struct lib_syslograwstream_s *)this;
+                                    (FAR struct lib_syslograwstream_s *)self;
 
   DEBUGASSERT(stream != NULL);
   stream->last_ch = ch;
@@ -176,7 +176,7 @@ static void syslograwstream_putc(FAR struct lib_outstream_s *this, int ch)
               ret = syslog_putc(ch);
               if (ret >= 0)
                 {
-                  this->nput++;
+                  self->nput++;
                   return;
                 }
 
@@ -190,11 +190,11 @@ static void syslograwstream_putc(FAR struct lib_outstream_s *this, int ch)
     }
 }
 
-static int syslograwstream_puts(FAR struct lib_outstream_s *this,
+static int syslograwstream_puts(FAR struct lib_outstream_s *self,
                                 FAR const void *buff, int len)
 {
   FAR struct lib_syslograwstream_s *stream =
-                                    (FAR struct lib_syslograwstream_s *)this;
+                                    (FAR struct lib_syslograwstream_s *)self;
   int ret;
 
   DEBUGASSERT(stream != NULL);
@@ -231,7 +231,7 @@ static int syslograwstream_puts(FAR struct lib_outstream_s *this,
           ret = syslog_write(buff, len);
           if (ret >= 0)
             {
-              this->nput += ret;
+              self->nput += ret;
               return ret;
             }
 
@@ -272,12 +272,12 @@ void lib_syslograwstream_open(FAR struct lib_syslograwstream_s *stream)
 
   /* Initialize the common fields */
 
-  stream->public.putc  = syslograwstream_putc;
-  stream->public.puts  = syslograwstream_puts;
-  stream->public.nput  = 0;
+  stream->common.putc  = syslograwstream_putc;
+  stream->common.puts  = syslograwstream_puts;
+  stream->common.nput  = 0;
 
 #ifdef CONFIG_SYSLOG_BUFFER
-  stream->public.flush = syslograwstream_flush;
+  stream->common.flush = syslograwstream_flush;
 
   /* Allocate an IOB */
 
@@ -299,7 +299,7 @@ void lib_syslograwstream_open(FAR struct lib_syslograwstream_s *stream)
 #  endif
   stream->offset = 0;
 #else
-  stream->public.flush = lib_noflush;
+  stream->common.flush = lib_noflush;
 #endif
 }
 
@@ -330,7 +330,7 @@ void lib_syslograwstream_close(FAR struct lib_syslograwstream_s *stream)
     {
       /* Flush the output buffered in the IOB */
 
-      syslograwstream_flush(&stream->public);
+      syslograwstream_flush(&stream->common);
 
       /* Free the IOB */
 
@@ -338,7 +338,7 @@ void lib_syslograwstream_close(FAR struct lib_syslograwstream_s *stream)
       stream->iob = NULL;
     }
 #  else
-  syslograwstream_flush(&stream->public);
+  syslograwstream_flush(&stream->common);
 #  endif
 }
 #endif

--- a/libs/libc/stream/lib_syslogstream.c
+++ b/libs/libc/stream/lib_syslogstream.c
@@ -37,21 +37,21 @@
  * Name: syslogstream_putc
  ****************************************************************************/
 
-static void syslogstream_putc(FAR struct lib_outstream_s *this, int ch)
+static void syslogstream_putc(FAR struct lib_outstream_s *self, int ch)
 {
   FAR struct lib_syslogstream_s *stream =
-                                       (FAR struct lib_syslogstream_s *)this;
+                                       (FAR struct lib_syslogstream_s *)self;
 
   DEBUGASSERT(stream != NULL);
   syslog(stream->priority, "%c", ch);
-  stream->public.nput++;
+  stream->common.nput++;
 }
 
-static int syslogstream_puts(FAR struct lib_outstream_s *this,
+static int syslogstream_puts(FAR struct lib_outstream_s *self,
                              FAR const void *buff, int len)
 {
   FAR struct lib_syslogstream_s *stream =
-                                       (FAR struct lib_syslogstream_s *)this;
+                                       (FAR struct lib_syslogstream_s *)self;
 
   DEBUGASSERT(stream != NULL);
   if (len <= 0)
@@ -89,9 +89,9 @@ void lib_syslogstream(FAR struct lib_syslogstream_s *stream, int priority)
 
   /* Initialize the common fields */
 
-  stream->public.nput  = 0;
-  stream->public.putc  = syslogstream_putc;
-  stream->public.puts  = syslogstream_puts;
-  stream->public.flush = lib_noflush;
+  stream->common.nput  = 0;
+  stream->common.putc  = syslogstream_putc;
+  stream->common.puts  = syslogstream_puts;
+  stream->common.flush = lib_noflush;
   stream->priority     = priority;
 }

--- a/libs/libc/stream/lib_zeroinstream.c
+++ b/libs/libc/stream/lib_zeroinstream.c
@@ -30,16 +30,16 @@
  * Private Functions
  ****************************************************************************/
 
-static int zeroinstream_getc(FAR struct lib_instream_s *this)
+static int zeroinstream_getc(FAR struct lib_instream_s *self)
 {
-  this->nget++;
+  self->nget++;
   return 0;
 }
 
-static int zeroinstream_gets(FAR struct lib_instream_s *this,
+static int zeroinstream_gets(FAR struct lib_instream_s *self,
                              FAR void *buffer, int len)
 {
-  this->nget += len;
+  self->nget += len;
   memset(buffer, 0, len);
   return len;
 }
@@ -56,17 +56,17 @@ static int zeroinstream_gets(FAR struct lib_instream_s *this,
  *   infinitely long stream of zeroes.
  *
  * Input Parameters:
- *   zeroinstream  - User allocated, uninitialized instance of struct
- *                   lib_instream_s to be initialized.
+ *   stream  - User allocated, uninitialized instance of struct
+ *             lib_instream_s to be initialized.
  *
  * Returned Value:
  *   None (User allocated instance initialized).
  *
  ****************************************************************************/
 
-void lib_zeroinstream(FAR struct lib_instream_s *zeroinstream)
+void lib_zeroinstream(FAR struct lib_instream_s *stream)
 {
-  zeroinstream->getc = zeroinstream_getc;
-  zeroinstream->gets = zeroinstream_gets;
-  zeroinstream->nget = 0;
+  stream->getc = zeroinstream_getc;
+  stream->gets = zeroinstream_gets;
+  stream->nget = 0;
 }

--- a/libs/libc/wchar/lib_swprintf.c
+++ b/libs/libc/wchar/lib_swprintf.c
@@ -50,7 +50,7 @@ int vswprintf(FAR wchar_t *buf, size_t maxlen, FAR const wchar_t *fmt,
 
   /* Then let lib_vsprintf do the real work */
 
-  return lib_vsprintf((FAR struct lib_outstream_s *)&memoutstream.public,
+  return lib_vsprintf((FAR struct lib_outstream_s *)&memoutstream.common,
                       (FAR const char *)fmt, ap);
 }
 


### PR DESCRIPTION
## Summary
Rename stream struct fields named `public` and functions parameters named `this` in `streams.h` and `rtti.h` so C++ compilers won't fail to compile them (these are [reserved keywords](https://en.cppreference.com/w/cpp/keyword) in C++). This fixes the issue called out by https://github.com/apache/nuttx/issues/10556

## Impact
`lib/libc/stream`, `segger/rtt.h`
## Testing
- Successfully compiled `nsh` app for IMXRT after I:
  - modified it to include [segger/rtt.h](https://github.com/apache/nuttx/blob/master/include/nuttx/segger/rtt.h)
  - set the following [segger Kconfigs](https://github.com/apache/nuttx/blob/master/drivers/segger/Kconfig):  `STREAM_RTT`, `SEGGER_RTT`

