### PR TITLE
mm/shm/shmget: Zero allocated shared memory pages when created.

### DIFF
--- a/mm/shm/shmget.c
+++ b/mm/shm/shmget.c
@@ -188,6 +188,10 @@ static int shm_extend(int shmid, size_t size)
           break;
         }
 
+      /* Zero the allocated page. */
+
+      memset((void *)region->sr_pages[pgalloc], 0, MM_PGSIZE);
+
       /* Increment the number of pages successfully allocated */
 
       pgalloc++;


### PR DESCRIPTION
## Summary

Modification based on opengroup's description for shmget: "When the shared memory segment is created, it shall be initialized with all zero values."

Link to documentation page for shmget: https://pubs.opengroup.org/onlinepubs/9699919799/

## Impact

XSI shared memory page's values are set to zero when `IPC_CREAT` is specified and the page doesn't already exist.

## Testing

-
