### PR TITLE
usbdev: support usb adb fastboot

### DIFF
--- a/drivers/usbdev/Kconfig
+++ b/drivers/usbdev/Kconfig
@@ -596,6 +596,12 @@ menuconfig USBADB
 
 if USBADB
 
+config USBFASTBOOT
+	bool "USB Android Debug Bridge (FASTBOOT) support"
+	default n
+	---help---
+		Enables USB Android Debug Bridge (FASTBOOT) support
+
 menuconfig USBADB_COMPOSITE
 	bool "USBADB composite support"
 	default n

--- a/drivers/usbdev/adb.c
+++ b/drivers/usbdev/adb.c
@@ -48,7 +48,11 @@
 
 /* FIXME use minor for char device npath */
 
-#define USBADB_CHARDEV_PATH        "/dev/adb0"
+#ifdef CONFIG_USBFASTBOOT
+#  define USBADB_CHARDEV_PATH      "/dev/fastboot"
+#else
+#  define USBADB_CHARDEV_PATH      "/dev/adb0"
+#endif
 
 /* USB Controller */
 
@@ -97,6 +101,12 @@
 #endif
 
 #define USBADB_NCONFIGS            (1)
+
+#ifdef CONFIG_USBFASTBOOT
+#  define USBADB_INTERFACEPROTOCOL (3)
+#else
+#  define USBADB_INTERFACEPROTOCOL (1)
+#endif
 
 /****************************************************************************
  * Private Data
@@ -209,7 +219,7 @@ static const struct usb_ifdesc_s g_adb_ifdesc =
   .neps     = 2,
   .classid  = USB_CLASS_VENDOR_SPEC,
   .subclass = 0x42,
-  .protocol = 0x01,
+  .protocol = USBADB_INTERFACEPROTOCOL,
   .iif      = USBADB_INTERFACESTRID
 };
 


### PR DESCRIPTION
## Summary

This PR is used to support fastboot driver,
The usage of fastboot APP Please refer https://github.com/apache/nuttx-apps/pull/2032 for more details.

## Impact

Fastboot

## Testing

BES board enable fastboot