### PR TITLE
libc/sched: Use TLS when available to cache the result of gettid syscall

### DIFF
--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -160,7 +160,11 @@
 #  define _SCHED_ERRNO(r)            (-(r))
 #  define _SCHED_ERRVAL(r)           (r)
 #else
+#if defined(CONFIG_SCHED_THREAD_LOCAL)
+#  define _SCHED_GETTID()            sched_gettid()
+#else
 #  define _SCHED_GETTID()            gettid()
+#endif
 #  define _SCHED_GETPID()            getpid()
 #  define _SCHED_GETPPID()           getppid()
 #  define _SCHED_GETPARAM(t,p)       sched_getparam(t,p)

--- a/include/nuttx/tls.h
+++ b/include/nuttx/tls.h
@@ -206,6 +206,7 @@ struct tls_info_s
 #endif
 
   int tl_errno;                        /* Per-thread error number */
+  pid_t tl_tid;                        /* ID for thread */
 };
 
 /****************************************************************************

--- a/libs/libc/sched/Make.defs
+++ b/libs/libc/sched/Make.defs
@@ -20,7 +20,7 @@
 
 # Add the sched C files to the build
 
-CSRCS += sched_getprioritymax.c sched_getprioritymin.c
+CSRCS += sched_getprioritymax.c sched_getprioritymin.c sched_gettid.c
 CSRCS += clock_ticks2time.c clock_time2ticks.c
 CSRCS += clock_timespec_add.c clock_timespec_subtract.c
 CSRCS += clock_getcpuclockid.c clock_getres.c

--- a/libs/libc/sched/sched_gettid.c
+++ b/libs/libc/sched/sched_gettid.c
@@ -1,0 +1,65 @@
+/****************************************************************************
+ * libs/libc/sched/sched_gettid.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/tls.h>
+
+#include <unistd.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: nxsched_gettid
+ *
+ * Description:
+ *   Utilise thread local storage to get the thread ID of the currently
+ *   executing thread and cache the result for further queries. Caching this
+ *   result reduces system call loading when using CONFIG_BUILD_KERNEL.
+ *
+ * Input parameters:
+ *   None
+ *
+ * Returned Value:
+ *   On success, returns the thread ID of the calling process.
+ *
+ ****************************************************************************/
+
+#if !defined(CONFIG_BUILD_FLAT) && defined(CONFIG_SCHED_THREAD_LOCAL) && !defined(__KERNEL__)
+
+pid_t sched_gettid(void)
+{
+  FAR struct tls_info_s *tlsinfo = tls_get_info();
+
+  DEBUGASSERT(tlsinfo);
+
+  if (tlsinfo->tl_tid <= 0)
+    {
+        tlsinfo->tl_tid = gettid();
+    }
+
+  return tlsinfo->tl_tid;
+}
+#endif


### PR DESCRIPTION
## Summary

This is a proposed solution to #10571

When using CONFIG_BUILD_KERNEL, there is a significantly large system call loading to gettid(). Considering this value should be static in the context of a thread, TLS should be able to be used to cache this value.

## Impact

Reduced system call loading when using `CONFIG_BUILD_KERNEL`

## Testing

Before and after with profiling and trace compass to assess system call reduction. 
Further testing on recommendation ?

