### PR TITLE
nuttx/build: Restore ARLOCK to improve compile speed in incremental case

### DIFF
--- a/Documentation/quickstart/install.rst
+++ b/Documentation/quickstart/install.rst
@@ -45,6 +45,8 @@ First, install the following set of system dependencies according to your Operat
 
     .. code-block:: console
 
+      $ brew tap discoteq/discoteq
+      $ brew install flock
       $ brew install x86_64-elf-gcc  # Used by simulator
       $ brew install u-boot-tools  # Some platform integrate with u-boot
 

--- a/README.md
+++ b/README.md
@@ -522,8 +522,16 @@ framework like GTK or Qt.  So this might be a trip down the rabbit hole.
 
 ### Using macOS
 
-You need to install at least the following tools specific to macOS
-if you want to build the sim:
+You need to install at least the following tools specific to macOS.
+
+  * flock (used by APPDIR build logic)
+
+A macOS port is available at: <https://github.com/discoteq/flock>
+
+    brew tap discoteq/discoteq
+    brew install flock
+
+  If you want to build the sim:
 
   * Xcode (the native compiler and the rest of the toolchain)
 

--- a/libs/libc/zoneinfo/Makefile
+++ b/libs/libc/zoneinfo/Makefile
@@ -46,7 +46,7 @@ $(COBJS): %$(OBJEXT): %.c
 	$(call COMPILE, $<, $@)
 
 .built: .tzbuilt romfs $(OBJS)
-	$(call ARCHIVE_ADD, ..$(DELIM)$(BIN), $(OBJS))
+	$(call ARCHIVE, ..$(DELIM)$(BIN), $(OBJS))
 	$(Q) touch .built
 
 # ROMFS file system containing the TZ database

--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -395,8 +395,8 @@ define INSTALL_LIB
 	$(ECHO_END)
 endef
 
-# ARCHIVE_ADD - Add a list of files to an archive
-# Example: $(call ARCHIVE_ADD, archive-file, "file1 file2 file3 ...")
+# ARCHIVE - Add a list of files to an archive
+# Example: $(call ARCHIVE, archive-file, "file1 file2 file3 ...")
 #
 # Note: The fileN strings may not contain spaces or  characters that may be
 # interpreted strangely by the shell
@@ -411,18 +411,8 @@ endef
 #
 #   CONFIG_WINDOWS_NATIVE - Defined for a Windows native build
 
-define ARCHIVE_ADD
-	$(ECHO_BEGIN)"AR (add): ${shell basename $(1)} "
-	$(Q) $(AR) $1 $2
-	$(ECHO_END)
-endef
-
-# ARCHIVE - Same as above, but ensure the archive is
-# created from scratch
-
 define ARCHIVE
-	$(Q) $(RM) $1
-	$(Q) $(AR) $1  $2
+	$(AR) $1  $2
 endef
 
 # PRELINK - Prelink a list of files


### PR DESCRIPTION
## Summary

nuttx/build: Restore ARLOCK to improve compile speed in incremental case

To solve the issue of carrying object files from previous builds, Matias changed the archiving process to re-archive libapps.a on every compilation, if libapps.a carries more object files, incremental compilation will waste too many time in re-archiving, compared with the previous implement, this is a degradation of the build system.  Referring to mature engineering projects such as cmake, if there is configuration or source file changed, the best solution should be to reconfigure the environment.

Revert this PR to ensure the compilation speed during incremental compilation.

https://github.com/apache/nuttx/pull/1765
```
|  commit 34b34e2d4519956f9a61f5985aca29947c4b8b23 (tag: nuttx-20200914-172150)
|  Author: Matias N <matias@protobits.dev>
|  Date:   Fri Sep 11 22:31:38 2020 -0300
|
|      Fix: ensure archive files do not carry object files from prior builds
|
|      In some cases, when NuttX configuration changes and this makes the
|      object list used to build one of the .a libraries change as well,
|      since the command used to build it is "ar crs" and this simply appends
|      the list of object files, the library could still include object
|      files from prior builds. This commit modifies the ARCHIVE macro to
|      erase the .a file if it already exists.
|
|      Since in some cases this behavior was actually expected (object
|      files from a subdirectory were appended to a library created one
|      level above) I added a ARCHIVE_ADD which works as ARCHIVE did.
|
|      This change should greatly improve behavior of building after
|      configuration changes.
```



## Impact

Build system
Depends on: https://github.com/apache/nuttx-apps/pull/2048

## Testing


Testing:

```
sim:nsh
-------------------------------
|   Patched    |  Current
-------------------------------
|$ time make   |  $ time make
|real 0m1.270s |  real 0m1.728s
|user 0m0.971s |  user 0m1.276s
|sys  0m0.363s |  sys  0m0.530s
-------------------------------
```

```
Private project (20+ 3rd library needs archive to libapps.a)
-------------------------------
|   Patched     |  Current
-------------------------------
|$ time make    |  $ time make
|real 0m21.181s |  real 0m39.721s
|user 0m14.638s |  user 0m24.837s
|sys  0m6.919s  |  sys  0m14.394s
-------------------------------
```