### PR TITLE
Fix error: procfs/fs_procfscritmon.c CI break

### DIFF
--- a/fs/procfs/fs_procfscritmon.c
+++ b/fs/procfs/fs_procfscritmon.c
@@ -181,12 +181,10 @@ static ssize_t critmon_read_cpu(FAR struct critmon_file_s *attr,
                                 FAR off_t *offset, int cpu)
 {
   struct timespec maxtime;
-  size_t remaining;
   size_t linesize;
   size_t copysize;
   size_t totalsize;
 
-  remaining = buflen;
   totalsize = 0;
 
   /* Convert the for maximum time pre-emption disabled */
@@ -214,7 +212,6 @@ static ssize_t critmon_read_cpu(FAR struct critmon_file_s *attr,
 
   totalsize += copysize;
   buffer    += copysize;
-  remaining -= copysize;
 
   if (totalsize >= buflen)
     {


### PR DESCRIPTION
## Summary
found in https://github.com/apache/nuttx-apps/actions/runs/6143676193/job/16667713342?pr=2051
```Makefile
Error: procfs/fs_procfscritmon.c:184:10: error: variable 'remaining' set but not used [-Werror,-Wunused-but-set-variable]
``` 
## Impact

## Testing
CI