### PR TITLE
arch/arm/samv7: fix typos in quadrature encoder and timer drivers

### DIFF
--- a/arch/arm/src/samv7/sam_qencoder.c
+++ b/arch/arm/src/samv7/sam_qencoder.c
@@ -118,7 +118,7 @@ static struct sam_lowerhalf_s g_tc0lower =
 static struct sam_lowerhalf_s g_tc1lower =
 {
   .ops      = &g_qecallbacks,
-  .timid    = 1,
+  .tcid     = 1,
   .inuse    = false,
 };
 #endif

--- a/arch/arm/src/samv7/sam_tc.c
+++ b/arch/arm/src/samv7/sam_tc.c
@@ -514,7 +514,7 @@ static struct sam_tc_s g_tc345 =
 static struct sam_tc_s g_tc678 =
 {
   .lock    = NXMUTEX_INITIALIZER,
-  .base    = SAM_TC789_BASE,
+  .base    = SAM_TC678_BASE,
   .tc      = 2,
 };
 #endif


### PR DESCRIPTION
## Summary

The typo s/.timid/.tcid prevents to compile NuttX with quadrature encoder configured for timer1 (CONFIG_SAMV7_TC1_QE) and s/SAM_TC789_BASE/SAM_TC678_BASE prevented use of the of the timer 2.

## Impact

The  same70-xplained:netnsh configuration  with CONFIG_SAMV7_TC1_QE and or  CONFIG_SAMV7_TC2 set builds fail.

## Testing

Build working after the fix. Testing on future hardware planed in the frame of SaMoCoN controller development

  https://gitlab.fel.cvut.cz/otrees/motion/work-and-ideas/-/wikis/SaMoCon
