### PR TITLE
Split a single queue to two separate queues at node p.

### DIFF
--- a/include/nuttx/queue.h
+++ b/include/nuttx/queue.h
@@ -251,6 +251,27 @@
     } \
   while (0)
 
+#define dq_split(p, q1, q2) \
+  do \
+    { \
+      if (dq_peek(q1) == (p)) \
+        { \
+          dq_move(q1, q2); \
+        } \
+      else \
+        { \
+          (q2)->tail = (q1)->tail; \
+          (q2)->head = (p); \
+          (q1)->tail = (p)->blink; \
+          (p)->blink = NULL; \
+          if((q1)->tail) \
+            { \
+              (q1)->tail->flink = NULL; \
+            } \
+        } \
+    } \
+  while(0)
+
 #define sq_next(p)  ((p)->flink)
 #define dq_next(p)  ((p)->flink)
 #define dq_prev(p)  ((p)->blink)


### PR DESCRIPTION
## Summary
Split a single queue to two separate queues at node p.
## Impact
None
## Testing
```C
#define FAR 
#define NULL ((void *)0)
#include <stdio.h>
#include "queue.h"

struct node {
    struct dq_entry_s *flink;
    struct dq_entry_s *blink;
    int val;
};
typedef struct node node_t;

void node_init(node_t *a, int val)
{
    a->flink = NULL;
    a->blink = NULL;
    a->val = val;
}


int main(){
    dq_queue_t q1, q2;
    dq_init(&q1);
    dq_init(&q2);

    node_t a ,b,c,d;
    node_init(&a, 1);
    node_init(&b, 2);
    node_init(&c, 3);
    node_init(&d, 4);

    dq_addlast(&a, &q1);
    dq_addlast(&b, &q1);
    dq_addlast(&c, &q1);
    dq_addlast(&d, &q1);

    // three testcases
    // dq_split(dq_next(dq_peek(&q1)), &q1, &q2);
    // dq_split(dq_peek(&q1), &q1, &q2);
    // dq_split(dq_tail(&q1), &q1, &q2);

    
    printf("q1:");
    node_t *curr = q1.head;
    while(curr){
        printf("%d ", curr->val);
        curr = curr->flink;
    }

    printf("\nq2:");
    curr = q2.head;
    while(curr){
        printf("%d ", curr->val);
        curr = curr->flink;
    }
}
```