### PR TITLE
tools/showstack: add configurable rank parameters

### DIFF
--- a/tools/showstack.sh
+++ b/tools/showstack.sh
@@ -29,10 +29,17 @@ function analyse()
 }
 
 if [[ $# == 0 ]]; then
-  echo "usage: $0 <dir>..."
+  echo "usage: $0 <rank> <dir>..."
   exit
 fi
 
+rank=20
+
+if [[ "$1" =~ ^[0-9]+$ ]]; then
+  rank=$1
+  shift
+fi
+
 for dir in $@; do
-  analyse $dir 20
+  analyse $dir $rank
 done


### PR DESCRIPTION
## Summary

Add customizable ranking parameters.

## Impact

None

## Testing

Enable config:

`CONFIG_STACK_USAGE=y`

Print the top 10 stack usage numbers to the console:

```shell
./nuttx/tools/showstack.sh 10 nuttx
```
