### PR TITLE
Fixed typo in S32K CRC define

### DIFF
--- a/arch/arm/src/s32k1xx/hardware/s32k1xx_crc.h
+++ b/arch/arm/src/s32k1xx/hardware/s32k1xx_crc.h
@@ -74,7 +74,7 @@
 
 #define CRC_CTRL_TCRC               (1 << 24) /* Bit 24: Width of CRC protocol */
 #  define CRC_CTRL_TCRC_16BIT       (0)       /*         16-bit CRC protocol */
-#  define CRC_CTRL_TCRC_16BIT       (1 << 24) /*         32-bit CRC protocol */
+#  define CRC_CTRL_TCRC_32BIT       (1 << 24) /*         32-bit CRC protocol */
 #define CRC_CTRL_WAS                (1 << 25) /* Bit 25: Write CRC Data Register As Seed */
 #define CRC_CTRL_FXOR               (1 << 26) /* Bit 26: Complement Read Of CRC Data Register */
 #define CRC_CTRL_TOTR_SHIFT         (28)      /* Bits 28-29:  Type Of Transpose For Read */


### PR DESCRIPTION
## Summary
Simple fix of a typo in arch/arm/src/s32k1xx/hardware/s32k1xx_crc.h
CRC_CTRL_TCRC_16BIT was defined twice instead of defining CRC_CTRL_TCRC_32BIT

## Impact
This file is not included anywhere so it was never caught. It would create a duplicate define if it were to have been included.
I noticed this when including the file in some private code.

## Testing
Verified correct bit offset in Section "24.3.1.4 CRC Control register (CTRL)" of the S32k1xx reference manual
