### PR TITLE
Check mutex holder and releaser are same thread

### DIFF
--- a/libs/libc/misc/lib_mutex.c
+++ b/libs/libc/misc/lib_mutex.c
@@ -337,6 +337,7 @@ int nxmutex_unlock(FAR mutex_t *mutex)
     }
 
   DEBUGASSERT(nxmutex_is_hold(mutex));
+  ASSERT(mutex->holder == _SCHED_GETTID());
 
   mutex->holder = NXMUTEX_NO_HOLDER;
 


### PR DESCRIPTION
## Summary
The holder and releaser of a Mutex must be the same thread.
So There should be a assert to check holder and releaser is the same guy.
## Impact
Mutex
## Testing
sim:ostest
