### PR TITLE
Support defconfig merge

### DIFF
--- a/Documentation/quickstart/configuring.rst
+++ b/Documentation/quickstart/configuring.rst
@@ -124,3 +124,19 @@ This is also useful to script configuration changes that you perform often:
    kconfig-tweak --disable CONFIG_DEBUG_NOOPT
    kconfig-tweak --disable CONFIG_SYSLOG_TIMESTAMP
    make oldconfig
+
+Reference configuration
+--------------------------
+
+Defconfig supports the use of #include statements to reference other configuration files.
+The default header file search path includes:
+   ${current directory}
+   ${boards}/configs/comnon
+   ${boards}/common/configs
+
+.. code-block::
+
+   CONFIG_XXX1=y
+   CONFIG_XXX2=y
+   #include "configs/system.config"
+   #include "configs/net.config"

--- a/Documentation/quickstart/configuring.rst
+++ b/Documentation/quickstart/configuring.rst
@@ -140,3 +140,13 @@ The default header file search path includes:
    CONFIG_XXX2=y
    #include "configs/system.config"
    #include "configs/net.config"
+
+Merge configuration
+--------------------------
+
+Multiple config fragments can be merged manually using the tools/merge_config.py script.
+
+.. code-block:: console
+
+   $ cd nuttx
+   $ ./tools/merge_config.py -o defconfig .config1 .config2

--- a/tools/configure.sh
+++ b/tools/configure.sh
@@ -203,6 +203,22 @@ if [ -r ${dest_config} ]; then
   fi
 fi
 
+# Okay... Everything looks good.  Setup the configuration
+
+echo "  Copy files"
+ln -sf ${src_makedefs} ${dest_makedefs} || \
+  { echo "Failed to symlink ${src_makedefs}" ; exit 8 ; }
+${TOPDIR}/tools/process_config.sh -I ${configpath}/../../common/configs \
+  -I ${configpath}/../common -o ${dest_config} ${src_config}
+install -m 644 ${src_config} "${backup_config}" || \
+  { echo "Failed to backup ${src_config}" ; exit 10 ; }
+
+# Install any optional files
+
+for opt in ${OPTFILES}; do
+  test -f ${configpath}/${opt} && install ${configpath}/${opt} "${TOPDIR}/"
+done
+
 # Extract values needed from the defconfig file.  We need:
 # (1) The CONFIG_WINDOWS_NATIVE setting to know it this is target for a
 #     native Windows
@@ -271,21 +287,6 @@ if [ ! -z "${appdir}" -a ! -d "${TOPDIR}/${posappdir}" ]; then
   exit 7
 fi
 
-# Okay... Everything looks good.  Setup the configuration
-
-echo "  Copy files"
-ln -sf ${src_makedefs} ${dest_makedefs} || \
-  { echo "Failed to symlink ${src_makedefs}" ; exit 8 ; }
-install -m 644 ${src_config} "${dest_config}" || \
-  { echo "Failed to copy ${src_config}" ; exit 9 ; }
-install -m 644 ${src_config} "${backup_config}" || \
-  { echo "Failed to backup ${src_config}" ; exit 10 ; }
-
-# Install any optional files
-
-for opt in ${OPTFILES}; do
-  test -f ${configpath}/${opt} && install ${configpath}/${opt} "${TOPDIR}/"
-done
 
 # If we did not use the CONFIG_APPS_DIR that was in the defconfig config file,
 # then append the correct application information to the tail of the .config

--- a/tools/merge_config.py
+++ b/tools/merge_config.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+############################################################################
+# tools/merge_config.py
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+import argparse
+import os
+
+try:
+    from kconfiglib import Kconfig
+except ModuleNotFoundError:
+    print("Please execute the following command to install dependencies:")
+    print("pip install kconfiglib")
+    exit()
+
+script_path = os.path.split(os.path.realpath(__file__))[0]
+topdir = os.path.join(script_path, "..")
+kconfig_path = os.path.join(topdir, "Kconfig")
+
+# Set environment variables
+
+os.environ["BINDIR"] = os.path.join(topdir)
+os.environ["APPSDIR"] = os.path.join(topdir, "../apps")
+os.environ["APPSBINDIR"] = os.path.join(topdir, "../apps")
+
+
+def merge_configs(output_file, input_files):
+    kconf = Kconfig(kconfig_path, suppress_traceback=True)
+
+    kconf.warn_assign_undef = True
+    kconf.warn_assign_override = False
+    kconf.warn_assign_redun = False
+
+    for input_file in input_files:
+        print(kconf.load_config(input_file, replace=False))
+
+    # Save the merged configuration to the output file
+
+    kconf.write_min_config(output_file)
+    print(f"Configuration successfully merged to {output_file}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Merge Kconfig configuration files")
+    parser.add_argument(
+        "-o", "--output", required=True, help="Output merged configuration file"
+    )
+    parser.add_argument(
+        "input_files", nargs="+", help="List of input configuration files"
+    )
+    args = parser.parse_args()
+
+    merge_configs(args.output, args.input_files)

--- a/tools/process_config.sh
+++ b/tools/process_config.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# tools/process_config.sh
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+process_file() {
+    local output_file="$1"
+    local input_file="$2"
+    local include_paths=("${!3}")
+
+    while IFS= read -r line || [ -n "$line" ]
+    do
+        if [[ $line == \#include* ]]; then
+            local include_file=$(echo $line | sed -E 's/#include [<"](.+)[">]/\1/')
+            local found=false
+
+            # Check current directory first
+
+            if [ -f $include_file ]; then
+                process_file $output_file $include_file include_paths[@]
+                found=true
+            else
+                # Then check in the include paths
+
+                for path in "${include_paths[@]}"; do
+                    local full_path="$path/$include_file"
+                    if [ -f $full_path ]; then
+                        process_file $output_file $full_path include_paths[@]
+                        found=true
+                        break
+                    fi
+                done
+            fi
+
+            # Configuration file not found
+
+            if [ "$found" = false ]; then
+                echo "ERROR: Can't find \"$include_file\" in current directory or search paths."
+                rm $output_file
+                exit 1
+            fi
+        else
+            echo "$line" >> $output_file
+        fi
+    done < "$input_file"
+}
+
+usage() {
+    echo "Usage: $0 [OPTIONS] [INPUT_FILE]"
+    echo "  -h    display this help"
+    echo "  -I    include path, can be specified multiple times"
+    echo "  -o    output file"
+    echo "  [INPUT_FILE]  the file to be processed"
+}
+
+while [[ $# -gt 0 ]]
+do
+    key="$1"
+
+    case $key in
+        -I)
+            INCLUDE_PATHS+=("$2")
+            shift
+            shift
+            ;;
+        -o)
+            OUTPUT_FILE="$2"
+            shift
+            shift
+            ;;
+        *)
+            if [ -z "$INPUT_FILE" ]; then
+                INPUT_FILE="$1"
+                shift
+            else
+                echo "Error: Multiple input files specified"
+                usage
+                exit 1
+            fi
+            ;;
+    esac
+done
+
+if [ -z "$INPUT_FILE" ]; then
+    echo "Error: Input file not specified"
+    usage
+    exit 1
+fi
+
+if [ -z "$OUTPUT_FILE" ]; then
+    echo "Error: Output file not specified"
+    usage
+    exit 1
+fi
+
+echo "" > $OUTPUT_FILE
+process_file "$OUTPUT_FILE" "$INPUT_FILE" INCLUDE_PATHS[@]


### PR DESCRIPTION
## Summary
I've added two scripts that can reference the config snippets in different ways

1. process_config allows the use of #include statements in defcnfig, which can reference other config files
2. merge_config supports merging multiple config files into one
    ./tools/merge_config.py -o defconfig .config1 .config2

## Impact

## Testing

