### PR TITLE
sim:change Mac sim archive operate from replace to quick insertion

### DIFF
--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -163,7 +163,7 @@ CPP = $(CROSSDEV)cc -E -P -x c
 LD = $(CROSSDEV)ld
 ifeq ($(CONFIG_HOST_MACOS),y)
 STRIP = $(CROSSDEV)strip
-AR = $(TOPDIR)/tools/macar-rcs.sh
+AR = $(TOPDIR)/tools/macar-qcs.sh
 else
 STRIP = $(CROSSDEV)strip --strip-unneeded
 AR = $(CROSSDEV)ar rcsP

--- a/tools/macar-qcs.sh
+++ b/tools/macar-qcs.sh
@@ -39,6 +39,6 @@
 # https://opensource.apple.com/source/cctools/cctools-949.0.1/misc/
 
 set -e
-ar rcS "$@"
+ar qcS "$@"
 # Note: the following line is using bash process substitution
 ranlib -no_warning_for_no_symbols "$1" 2> >(grep -F -v "the table of contents is empty")


### PR DESCRIPTION
## Summary
`'rcS'` will case files that has duplicate name been replaced. 
so on the Mac platform we use `'q'` instead of `'r'` to achieve an effect similar to '-P'

## Impact

Fix the ci break reported here:
https://github.com/apache/nuttx/actions/runs/6154533695/job/16700095528?pr=10596

## Testing
Mac sim-02 ci
