### PR TITLE
sched: do not DEBUGASSERT for priority multi-boost

### DIFF
--- a/sched/wqueue/kwork_inherit.c
+++ b/sched/wqueue/kwork_inherit.c
@@ -68,7 +68,10 @@ static void lpwork_boostworker(pid_t wpid, uint8_t reqprio)
 
   /* REVISIT: Priority multi-boost is not supported */
 
-  DEBUGASSERT(wtcb->boost_priority == 0);
+  if (wtcb->boost_priority != 0)
+    {
+      return;
+    }
 
   /* If the priority of the client thread that is greater than the base
    * priority of the worker thread, then we may need to adjust the worker
@@ -131,7 +134,10 @@ static void lpwork_restoreworker(pid_t wpid, uint8_t reqprio)
 
   /* REVISIT: Priority multi-boost is not supported. */
 
-  DEBUGASSERT(wtcb->boost_priority == reqprio);
+  if (wtcb->boost_priority != reqprio)
+    {
+      return;
+    }
 
   /* Clear the threat boost priority. */
 


### PR DESCRIPTION
## Summary

aio client will queue asynchronous io requests to the worker threads. if PRIORITY_INHERITANCE is enabled, client thread's priority will be set to worker threads. There will be multi-boost/restore of worker threads' priority and assert the system.

No need priority multi-boot/restore to worker thread because client thread's priority is alway the same.

## Impact
None

## Testing
LTP aio case with CONFIG_PRIORITY_INHERITANCE=y and pass CI
