### PR TITLE
arm/psci: Fixed arm psci related compilation errors

### DIFF
--- a/arch/arm/include/syscall.h
+++ b/arch/arm/include/syscall.h
@@ -126,31 +126,6 @@
  * Public Types
  ****************************************************************************/
 
-/* Result from SMC/HVC call
- * a0-a7 result values from registers 0 to 7
- */
-
-struct arm_smccc_res
-{
-  unsigned long a0;
-  unsigned long a1;
-  unsigned long a2;
-  unsigned long a3;
-  unsigned long a4;
-  unsigned long a5;
-  unsigned long a6;
-  unsigned long a7;
-};
-
-typedef struct arm_smccc_res arm_smccc_res_t;
-
-enum arm_smccc_conduit
-{
-  SMCCC_CONDUIT_NONE,
-  SMCCC_CONDUIT_SMC,
-  SMCCC_CONDUIT_HVC,
-};
-
 /****************************************************************************
  * Inline functions
  ****************************************************************************/
@@ -340,32 +315,6 @@ static inline long smh_call(unsigned int nbr, void *parm)
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
-
-/* Make HVC calls
- *
- * param a0 function identifier
- * param a1-a7 parameters registers
- * param res results
- */
-
-void arm_smccc_hvc(unsigned long a0, unsigned long a1,
-                   unsigned long a2, unsigned long a3,
-                   unsigned long a4, unsigned long a5,
-                   unsigned long a6, unsigned long a7,
-                   struct arm_smccc_res *res);
-
-/* Make SMC calls
- *
- * param a0 function identifier
- * param a1-a7 parameters registers
- * param res results
- */
-
-void arm_smccc_smc(unsigned long a0, unsigned long a1,
-                   unsigned long a2, unsigned long a3,
-                   unsigned long a4, unsigned long a5,
-                   unsigned long a6, unsigned long a7,
-                   struct arm_smccc_res *res);
 
 #ifdef __cplusplus
 #define EXTERN extern "C"

--- a/arch/arm/src/armv7-a/CMakeLists.txt
+++ b/arch/arm/src/armv7-a/CMakeLists.txt
@@ -110,4 +110,8 @@ if(CONFIG_SMP)
     arm_scu.c)
 endif()
 
+if(CONFIG_ARCH_HAVE_PSCI)
+  list(APPEND SRCS arm_cpu_psci.c arm_smccc.S)
+endif()
+
 target_sources(arch PRIVATE ${SRCS})

--- a/arch/arm/src/armv7-a/Make.defs
+++ b/arch/arm/src/armv7-a/Make.defs
@@ -94,3 +94,7 @@ ifeq ($(CONFIG_SMP),y)
   CMN_CSRCS += arm_scu.c
 endif
 
+ifeq ($(CONFIG_ARCH_HAVE_PSCI),y)
+  CMN_ASRCS += arm_smccc.S
+  CMN_CSRCS += arm_cpu_psci.c
+endif

--- a/arch/arm/src/armv7-a/arm_cpu_psci.c
+++ b/arch/arm/src/armv7-a/arm_cpu_psci.c
@@ -1,5 +1,5 @@
 /***************************************************************************
- * arch/arm/src/common/arm_cpu_psci.c
+ * arch/arm/src/armv7-a/arm_cpu_psci.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/arch/arm/src/armv7-a/arm_cpu_psci.h
+++ b/arch/arm/src/armv7-a/arm_cpu_psci.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm/src/common/arm_cpu_psci.h
+ * arch/arm/src/armv7-a/arm_cpu_psci.h
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,8 +18,8 @@
  *
  ****************************************************************************/
 
-#ifndef __ARCH_ARM_SRC_COMMON_ARM_CPU_PSCI_H
-#define __ARCH_ARM_SRC_COMMON_ARM_CPU_PSCI_H
+#ifndef __ARCH_ARM_SRC_ARMV7_A_ARM_CPU_PSCI_H
+#define __ARCH_ARM_SRC_ARMV7_A_ARM_CPU_PSCI_H
 
 /****************************************************************************
  * Included Files
@@ -83,6 +83,31 @@
 #define PSCI_VERSION_MINOR(ver) \
   ((ver) & PSCI_VERSION_MINOR_MASK)
 
+/* Result from SMC/HVC call
+ * a0-a7 result values from registers 0 to 7
+ */
+
+struct arm_smccc_res
+{
+  unsigned long a0;
+  unsigned long a1;
+  unsigned long a2;
+  unsigned long a3;
+  unsigned long a4;
+  unsigned long a5;
+  unsigned long a6;
+  unsigned long a7;
+};
+
+typedef struct arm_smccc_res arm_smccc_res_t;
+
+enum arm_smccc_conduit
+{
+  SMCCC_CONDUIT_NONE,
+  SMCCC_CONDUIT_SMC,
+  SMCCC_CONDUIT_HVC,
+};
+
 typedef unsigned long (*psci_fn)(unsigned long, unsigned long, unsigned long,
                                  unsigned long);
 
@@ -97,6 +122,32 @@ struct psci_interface
  * Public Function Prototypes
  ****************************************************************************/
 
+/* Make HVC calls
+ *
+ * param a0 function identifier
+ * param a1-a7 parameters registers
+ * param res results
+ */
+
+void arm_smccc_hvc(unsigned long a0, unsigned long a1,
+                   unsigned long a2, unsigned long a3,
+                   unsigned long a4, unsigned long a5,
+                   unsigned long a6, unsigned long a7,
+                   struct arm_smccc_res *res);
+
+/* Make SMC calls
+ *
+ * param a0 function identifier
+ * param a1-a7 parameters registers
+ * param res results
+ */
+
+void arm_smccc_smc(unsigned long a0, unsigned long a1,
+                   unsigned long a2, unsigned long a3,
+                   unsigned long a4, unsigned long a5,
+                   unsigned long a6, unsigned long a7,
+                   struct arm_smccc_res *res);
+
 uint32_t psci_version(void);
 int psci_cpu_off(void);
 int psci_cpu_reset(void);
@@ -104,4 +155,4 @@ int psci_cpu_on(unsigned long cpuid, uintptr_t entry_point);
 int psci_sys_poweroff(void);
 int psci_sys_reset(void);
 
-#endif /* __ARCH_ARM_SRC_COMMON_ARM_CPU_PSCI_H */
+#endif /* __ARCH_ARM_SRC_ARMV7_A_ARM_CPU_PSCI_H */

--- a/arch/arm/src/armv7-a/arm_smccc.S
+++ b/arch/arm/src/armv7-a/arm_smccc.S
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm/src/common/arm_smccc.S
+ * arch/arm/src/armv7-a/arm_smccc.S
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/arch/arm/src/common/CMakeLists.txt
+++ b/arch/arm/src/common/CMakeLists.txt
@@ -55,11 +55,6 @@ if(NOT CONFIG_ARCH_IDLE_CUSTOM)
   list(APPEND SRCS arm_idle.c)
 endif()
 
-if(CONFIG_ARCH_HAVE_PSCI)
-  list(APPEND SRCS arm_smccc.S)
-  list(APPEND SRCS arm_cpu_psci.c)
-endif()
-
 if(CONFIG_BUILD_PROTECTED OR CONFIG_BUILD_KERNEL)
   list(APPEND SRCS arm_task_start.c arm_pthread_start.c arm_signal_dispatch.c)
 

--- a/arch/arm/src/common/Make.defs
+++ b/arch/arm/src/common/Make.defs
@@ -41,11 +41,6 @@ ifneq ($(CONFIG_ARCH_IDLE_CUSTOM),y)
   CMN_CSRCS += arm_idle.c
 endif
 
-ifeq ($(CONFIG_ARCH_HAVE_PSCI),y)
-  CMN_ASRCS += arm_smccc.S
-  CMN_CSRCS += arm_cpu_psci.c
-endif
-
 ifeq ($(CONFIG_BUILD_PROTECTED)$(CONFIG_BUILD_KERNEL),y)
   CMN_CSRCS += arm_task_start.c arm_pthread_start.c
   CMN_CSRCS += arm_signal_dispatch.c


### PR DESCRIPTION
## Summary
include/arch/syscall.h: Assembler messages:
include/arch/syscall.h:133: Error: bad instruction `struct arm_smccc_res'
include/arch/syscall.h:134: Error: junk at end of line, first unrecognized character is `{'
include/arch/syscall.h:135: Error: bad instruction `unsigned long a0'
include/arch/syscall.h:136: Error: bad instruction `unsigned long a1'
include/arch/syscall.h:137: Error: bad instruction `unsigned long a2'
include/arch/syscall.h:138: Error: bad instruction `unsigned long a3'
include/arch/syscall.h:139: Error: bad instruction `unsigned long a4'
include/arch/syscall.h:140: Error: bad instruction `unsigned long a5'
include/arch/syscall.h:141: Error: bad instruction `unsigned long a6'
include/arch/syscall.h:142: Error: bad instruction `unsigned long a7'
include/arch/syscall.h:143: Error: junk at end of line, first unrecognized character is `}'
include/arch/syscall.h:145: Error: bad instruction `typedef struct arm_smccc_res

## Impact

## Testing

