### PR TITLE
stdio/lib_libfread: Fix buffer overflow issue

### DIFF
--- a/libs/libc/stdio/lib_libfread_unlocked.c
+++ b/libs/libc/stdio/lib_libfread_unlocked.c
@@ -126,11 +126,11 @@ ssize_t lib_fread_unlocked(FAR void *ptr, size_t count, FAR FILE *stream)
 
               if (gulp_size > 0)
                 {
-                  if (gulp_size > count)
+                  if (gulp_size > remaining)
                     {
                       /* Clip the gulp size to the requested byte count */
 
-                      gulp_size = count;
+                      gulp_size = remaining;
                     }
 
                   memcpy(dest, stream->fs_bufpos, gulp_size);


### PR DESCRIPTION
## Summary
If the gulp size in the stdio buffer is greater than the remaining user buffer size it will:
- Corrupt memory in dest (user memory) and
- Keep corrupting KERNEL memory via the stdio character buffer until the whole system crashes, as the 'remaining' count underflows

This patch fixes this behavior.
## Impact
Fix fatal memory leak bug in lib_libfread
## Testing
Read from file fails without this patch, works with it
