### PR TITLE
usbdev: Fix build error with BOARD_USBDEV_SERIALSTR

### DIFF
--- a/drivers/usbdev/composite.c
+++ b/drivers/usbdev/composite.c
@@ -38,6 +38,10 @@
 #include <nuttx/usb/usbdev.h>
 #include <nuttx/usb/usbdev_trace.h>
 
+#ifdef CONFIG_BOARD_USBDEV_SERIALSTR
+#  include <nuttx/board.h>
+#endif
+
 #include "composite.h"
 
 /****************************************************************************

--- a/drivers/usbdev/composite.h
+++ b/drivers/usbdev/composite.h
@@ -50,6 +50,13 @@
 #define COMPOSITE_CONFIGIDNONE        (0)  /* Config ID = 0 means to return to address mode */
 #define COMPOSITE_CONFIGID            (1)  /* The only supported configuration ID */
 
+/* Descriptor strings */
+
+#define COMPOSITE_MANUFACTURERSTRID   (1)
+#define COMPOSITE_PRODUCTSTRID        (2)
+#define COMPOSITE_SERIALSTRID         (3)
+#define COMPOSITE_CONFIGSTRID         (4)
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/

--- a/drivers/usbdev/composite_desc.c
+++ b/drivers/usbdev/composite_desc.c
@@ -93,13 +93,6 @@
 
 #define COMPOSITE_STR_LANGUAGE          (0x0409) /* en-us */
 
-/* Descriptor strings */
-
-#define COMPOSITE_MANUFACTURERSTRID     (1)
-#define COMPOSITE_PRODUCTSTRID          (2)
-#define COMPOSITE_SERIALSTRID           (3)
-#define COMPOSITE_CONFIGSTRID           (4)
-
 /****************************************************************************
  * Private Data
  ****************************************************************************/


### PR DESCRIPTION
## Summary

Fix build error and warning when enable BOARD_USBDEV_SERIALSTR.

## Impact

drivers/usbdev

## Testing

on Spresense board.