### PR TITLE
net/tcp: Stop monitor in `tcp_free`

### DIFF
--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -920,6 +920,10 @@ void tcp_free(FAR struct tcp_conn_s *conn)
 
   tcp_stop_timer(conn);
 
+  /* Make sure monitor is stopped. */
+
+  tcp_stop_monitor(conn, TCP_CLOSE);
+
   /* Free remaining callbacks, actually there should be only the send
    * callback for CONFIG_NET_TCP_WRITE_BUFFERS is left.
    */


### PR DESCRIPTION
## Summary
We may just free some TCP connections before monitor stopped, e.g. sacrificie a TCP conn in `tcp_alloc` will just call `tcp_free` and reuse the connection.  But we noticed that the TCP monitor is not released in `tcp_free` because it is mounted on `conn->connevents` instead of `conn->sconn.list` while `tcp_free` only release the latter.

## Impact
`tcp_free` only.
Note: `tcp_stop_monitor` can be called multiple times without problem.

## Testing
Manually
