### PR TITLE
nuttx/sensors/sensor.h: remove non-standard message from bream privat…

### DIFF
--- a/include/nuttx/sensors/sensor.h
+++ b/include/nuttx/sensors/sensor.h
@@ -448,11 +448,6 @@ struct sensor_gps           /* Type: Gps */
 
   float course;
 
-  float hspeed_err;         /* Horizontal speed error RMS (m/s) */
-  float vspeed_err;         /* Vertical speed error RMS (m/s) */
-  float env_range_resid;    /* Environment RangeResid (meters) */
-  float altitude_err;       /* Altitude error RMS (meters) */
-
   uint32_t satellites_used; /* Number of satellites used */
 };
 


### PR DESCRIPTION
## Summary
Remove non-standard nmea message (value from private $PGLOR_LSQ) form sensor_gps (NMEA 0183)

## Impact
Using these non-standard NMEA messages previously required special data structures. 

## Testing
Pass Vela CI