### PR TITLE
tools/ci: Install util-linux instead flock on macOS

### DIFF
--- a/tools/ci/cibuild.sh
+++ b/tools/ci/cibuild.sh
@@ -211,8 +211,7 @@ function util-linux {
   if ! type flock &> /dev/null; then
     case ${os} in
       Darwin)
-        brew tap discoteq/discoteq
-        brew install flock
+        brew install util-linux
         ;;
       Linux)
         apt-get install -y util-linux


### PR DESCRIPTION
## Summary

See the dissusion here: https://github.com/apache/nuttx/pull/10614

## Impact

ci on macOS

## Testing

ci