### PR TITLE
binfmt/binfmt_execmodule: Copy filename if CONFIG_BUILD_KERNEL and argv=NULL

### DIFF
--- a/binfmt/binfmt_execmodule.c
+++ b/binfmt/binfmt_execmodule.c
@@ -122,6 +122,7 @@ int exec_module(FAR struct binary_s *binp,
 #if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
   FAR struct arch_addrenv_s *addrenv = &binp->addrenv->addrenv;
   FAR void *vheap;
+  char name[CONFIG_PATH_MAX];
 #endif
   FAR void *stackaddr = NULL;
   pid_t pid;
@@ -166,6 +167,14 @@ int exec_module(FAR struct binary_s *binp,
     }
 
 #if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
+  /* If there is no argument vector, the process name must be copied here */
+
+  if (argv == NULL)
+    {
+      strlcpy(name, filename, CONFIG_PATH_MAX);
+      filename = name;
+    }
+
   /* Instantiate the address environment containing the user heap */
 
   ret = addrenv_select(binp->addrenv, &binp->oldenv);


### PR DESCRIPTION
## Summary
The 'filename' parameter comes from user space and cannot be accessed after calling ret = addrenv_select(binp->addrenv, &binp->oldenv); as it changes the address environment and 'filename' points to who knows where. In this case, calling nxtask_init(filename...) will cause a crash.

Solve this by making a local copy before changing address environment IF argv = NULL. Why ? Because argv[0] contains the process name in this case and the argument vector is already copied into kernel memory, thus passing argv[0] to nxtask_init(argv[0]...) is safe.

## Impact
Fix system crash when user creates a process with argv = NULL

## Testing
CONFIG_BUILD_KERNEL=y
