### PR TITLE
xtensa/esp32s3: Fix octal lines mode SPIRAM blocking issue

### DIFF
--- a/arch/xtensa/src/esp32s3/esp32s3_psram_octal.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_psram_octal.c
@@ -177,7 +177,8 @@ static size_t g_psram_size;
  *
  ****************************************************************************/
 
-static void set_psram_reg(int spi_num, const struct opi_psram_reg *in_reg)
+static void IRAM_ATTR set_psram_reg(int spi_num,
+                                    const struct opi_psram_reg *in_reg)
 {
   esp_rom_spiflash_read_mode_t mode = ESP_ROM_SPIFLASH_OPI_DTR_MODE;
   int cmd_len = 16;
@@ -234,7 +235,8 @@ static void set_psram_reg(int spi_num, const struct opi_psram_reg *in_reg)
  *
  ****************************************************************************/
 
-static void get_psram_reg(int spi_num, struct opi_psram_reg *out_reg)
+static void IRAM_ATTR get_psram_reg(int spi_num,
+                                    struct opi_psram_reg *out_reg)
 {
   esp_rom_spiflash_read_mode_t mode = ESP_ROM_SPIFLASH_OPI_DTR_MODE;
   int cmd_len = 16;
@@ -314,7 +316,7 @@ static void get_psram_reg(int spi_num, struct opi_psram_reg *out_reg)
  *
  ****************************************************************************/
 
-static void print_psram_reg(const struct opi_psram_reg *psram_reg)
+static void IRAM_ATTR print_psram_reg(const struct opi_psram_reg *psram_reg)
 {
   minfo("vendor id : 0x%02x (%s)\n", psram_reg->mr1.vendor_id,
         psram_reg->mr1.vendor_id == 0x0d ? "AP" : "UNKNOWN");
@@ -363,7 +365,7 @@ static void print_psram_reg(const struct opi_psram_reg *psram_reg)
  *
  ****************************************************************************/
 
-static void init_cs_timing(void)
+static void IRAM_ATTR init_cs_timing(void)
 {
   /* SPI0/1 share the cs_hold / cs_setup, cd_hold_time / cd_setup_time,
    * cs_hold_delay registers for PSRAM, so we only need to set SPI0
@@ -404,7 +406,7 @@ static void init_cs_timing(void)
  *
  ****************************************************************************/
 
-static void init_psram_pins(void)
+static void IRAM_ATTR init_psram_pins(void)
 {
   uint32_t reg = REG_IO_MUX_BASE +
                  (CONFIG_ESP32S3_DEFAULT_PSRAM_CS_IO + 1) * 4;
@@ -429,7 +431,7 @@ static void init_psram_pins(void)
  *
  ****************************************************************************/
 
-static void config_psram_spi_phases(void)
+static void IRAM_ATTR config_psram_spi_phases(void)
 {
   /* Config Write CMD phase for SPI0 to access PSRAM */
 

--- a/boards/xtensa/esp32s3/common/scripts/legacy_sections.ld
+++ b/boards/xtensa/esp32s3/common/scripts/legacy_sections.ld
@@ -79,6 +79,7 @@ SECTIONS
     *libarch.a:esp32s3_spiflash.*(.literal .text .literal.* .text.*)
     *libarch.a:xtensa_cpupause.*(.literal .text .literal.* .text.*)
     *libarch.a:xtensa_testset.*(.literal .text .literal.* .text.*)
+    *libarch.a:xtensa_modifyreg32.*(.literal.modifyreg32 .text.modifyreg32)
 
     *libsched.a:irq_csection.*(.literal .text .literal.* .text.*)
     *libsched.a:irq_dispatch.*(.literal .text .literal.* .text.*)


### PR DESCRIPTION
## Summary

xtensa/esp32s3: Fix octal lines mode SPIRAM blocking issue

## Impact

During  octal lines mode SPIRAM initialization, SPI flash operation may cause the system blocking, this issue can be fixed using this PR

## Testing
`./tools/configure.sh esp32s3-devkit:psram_octal`
