### PR TITLE
Adding Byte-Per-Pixel Memory model option to memlcd

### DIFF
--- a/drivers/lcd/Kconfig
+++ b/drivers/lcd/Kconfig
@@ -1148,6 +1148,13 @@ config MEMLCD_SPI_FREQUENCY
 	---help---
 		Define to use a different bus frequency, FIXME DEFAULT VALUE OK?
 
+config MEMLCD_BYTE_PER_PIXEL
+	bool "Byte-Per-Pixel Memory Model"
+	default n
+	---help---
+		Selects the Byte-Per-Pixel buffer model, instead of Bit-Per-Pixel.
+		LVGL Graphics Library uses Byte-Per-Pixel memory model.
+
 endif # LCD_SHARP_MEMLCD
 
 choice

--- a/drivers/lcd/memlcd.c
+++ b/drivers/lcd/memlcd.c
@@ -477,7 +477,9 @@ static int memlcd_putrun(FAR struct lcd_dev_s *dev,
           __clear_bit(col % 8 + i, p);
         }
 
-#ifdef CONFIG_LCD_PACKEDMSFIRST
+#ifdef CONFIG_MEMLCD_BYTE_PER_PIXEL
+      buffer++;
+#elif defined(CONFIG_LCD_PACKEDMSFIRST)
       if (usrmask == LS_BIT)
         {
           buffer++;
@@ -570,7 +572,9 @@ static int memlcd_getrun(FAR struct lcd_dev_s *dev,
           *buffer &= ~usrmask;
         }
 
-#ifdef CONFIG_LCD_PACKEDMSFIRST
+#ifdef CONFIG_MEMLCD_BYTE_PER_PIXEL
+      buffer++;
+#elif defined(CONFIG_LCD_PACKEDMSFIRST)
       if (usrmask == LS_BIT)
         {
           buffer++;


### PR DESCRIPTION
## Summary

LVGL uses Byte-Per-Pixel Memory model for monochromatic displays. This option enables memlcd driver to be used with LVGL.

## Impact

memlcd driver

## Testing

LVGL with Sharp MEMLCD.
