### PR TITLE
arch/risc-v/esp32c6: fix compilation of esp32c6 serial driver

### DIFF
--- a/arch/risc-v/src/esp32c6/hardware/esp32c6_soc.h
+++ b/arch/risc-v/src/esp32c6/hardware/esp32c6_soc.h
@@ -148,6 +148,10 @@
 
 #define BIT(nr)                     (1UL << (nr))
 
+/* Extract the field from the register and shift it to avoid wrong reading */
+
+#define REG_MASK(_reg, _field) (((_reg) & (_field##_M)) >> (_field##_S))
+
 /* Helper to place a value in a field */
 
 #define VALUE_TO_FIELD(_value, _field) (((_value) << (_field##_S)) & (_field##_M))


### PR DESCRIPTION
## Summary
Fix compilation of esp32c6 serial driver that was broken in c56aa7b527ddd4617950a03259f01859ad86af52

## Impact
Bugfix

## Testing
Pass RISC-V CI
