### PR TITLE
arm64: add mcpu option for all Cortex CPU

### DIFF
--- a/arch/arm64/src/Toolchain.defs
+++ b/arch/arm64/src/Toolchain.defs
@@ -39,13 +39,13 @@ ifeq ($(CONFIG_ARCH_ARMV8R),y)
 endif
 
 ifeq ($(CONFIG_ARCH_CORTEX_A53),y)
-  ARCHCPUFLAGS += -mtune=cortex-a53
+  ARCHCPUFLAGS += -mcpu=cortex-a53
 else ifeq ($(CONFIG_ARCH_CORTEX_A57),y)
-  ARCHCPUFLAGS += -mtune=cortex-a57
+  ARCHCPUFLAGS += -mcpu=cortex-a57
 else ifeq ($(CONFIG_ARCH_CORTEX_A72),y)
-  ARCHCPUFLAGS += -mtune=cortex-a72
+  ARCHCPUFLAGS += -mcpu=cortex-a72
 else ifeq ($(CONFIG_ARCH_CORTEX_R82),y)
-  ARCHCPUFLAGS += -mtune=cortex-r82
+  ARCHCPUFLAGS += -mcpu=cortex-r82
 endif
 
 ifeq ($(CONFIG_DEBUG_CUSTOMOPT),y)


### PR DESCRIPTION
## Summary
   add mcpu option for all Cortex CPU, from Spec of gcc

https://gcc.gnu.org/onlinedocs/gcc-12.3.0/gcc/AArch64-Options.html

## Impact
None

## Testing
testing with ostest for every option

