### PR TITLE
arch/arm64: fix link RWX warning for NuttX arm64

### DIFF
--- a/arch/arm64/src/Toolchain.defs
+++ b/arch/arm64/src/Toolchain.defs
@@ -162,6 +162,18 @@ ifeq ($(CONFIG_LTO_FULL),y)
   endif
 endif
 
+# Workaround for GCC-12.2 linker warning
+
+ifeq ($(CONFIG_ARCH_TOOLCHAIN_GNU),y)
+  ifeq ($(GCCVER),)
+    export GCCVER := $(shell $(CC) --version | grep gcc | sed -r "s/.* ([0-9]+\.[0-9]+).*/\1/")
+  endif
+
+  ifeq ($(GCCVER),12.2)
+    LDFLAGS += --no-warn-rwx-segments
+  endif
+endif
+
 # Add the builtin library
 
 EXTRA_LIBS += $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name))

--- a/arch/arm64/src/Toolchain.defs
+++ b/arch/arm64/src/Toolchain.defs
@@ -166,10 +166,10 @@ endif
 
 ifeq ($(CONFIG_ARCH_TOOLCHAIN_GNU),y)
   ifeq ($(GCCVER),)
-    export GCCVER := $(shell $(CC) --version | grep gcc | sed -r "s/.* ([0-9]+\.[0-9]+).*/\1/")
+    export GCCVER := $(shell $(CC) --version | grep gcc | sed -r "s/.* ([0-9]+\.[0-9]+).*/\1/" | cut -d'.' -f1)
   endif
 
-  ifeq ($(GCCVER),12.2)
+  ifeq ($(GCCVER),12)
     LDFLAGS += --no-warn-rwx-segments
   endif
 endif


### PR DESCRIPTION
## Summary
  when using new gcc verion like:
  GNU ld (Arm GNU Toolchain 12.2.Rel1 (Build arm-12.24)) 2.39.0.20221210)

  we will get link warning like:

  aarch64-none-elf-ld: warning: XXX/nuttx has a LOAD segment with RWX permissions

  The patch fix the warning through add link option --no-warn-rwx-segments

## Impact
None

## Testing
Testing with compile
