### PR TITLE
net/rpmsg: set conn->backlog=-1 only when socket listening

### DIFF
--- a/net/rpmsg/rpmsg_sockif.c
+++ b/net/rpmsg/rpmsg_sockif.c
@@ -402,7 +402,7 @@ static inline void rpmsg_socket_destroy_ept(
 
   if (conn->ept.rdev)
     {
-      if (conn->backlog)
+      if (conn->backlog > 0)
         {
           /* Listen socket */
 


### PR DESCRIPTION
## Summary
net/rpmsg: set conn->backlog=-1 only when socket listening

## Impact

## Testing

