### PR TITLE
libm/libmcs: Fix clang build libmcs warning

### DIFF
--- a/libs/libm/libmcs/Make.defs
+++ b/libs/libm/libmcs/Make.defs
@@ -187,6 +187,7 @@ CSRCS = signgam.c \
         tgammaf.c \
         truncf.c
 
+CFLAGS += -DLIBMCS_LONG_IS_32BITS
 ifeq ($(CONFIG_LIBM_LIBMCS_WANT_COMPLEX),y)
 CFLAGS += -DLIBMCS_WANT_COMPLEX
 CSRCS += cabsd.c \


### PR DESCRIPTION
## Summary

Fix warnings:
```
1 warning generated.
CC:  libmcs/libmcs/libm/mathd/lrintd.c libmcs/libmcs/libm/mathd/lrintd.c:141:20: warning: implicit conversion from 'unsigned long long' to 'long' changes value from 9223372036854775808 to 0 [-Wconstant-conversion]             return __MIN_LONG;
            ~~~~~~ ^~~~~~~~~~
/mnt/yang/vela_keystore_sim/nuttx/libs/libm/libmcs/libmcs/libm/include/internal_config.h:50:24: note: expanded from macro '__MIN_LONG'     #define __MIN_LONG 0x8000000000000000L
                       ^~~~~~~~~~~~~~~~~~~
libmcs/libmcs/libm/mathd/lrintd.c:144:20: warning: implicit conversion from 'long long' to 'long' changes value from 9223372036854775807 to -1 [-Wconstant-conversion]             return __MAX_LONG;
            ~~~~~~ ^~~~~~~~~~
/mnt/yang/vela_keystore_sim/nuttx/libs/libm/libmcs/libmcs/libm/include/internal_config.h:49:24: note: expanded from macro '__MAX_LONG'     #define __MAX_LONG 0x7FFFFFFFFFFFFFFFL
                       ^~~~~~~~~~~~~~~~~~~
2 warnings generated.
CC:  libmcs/libmcs/libm/mathd/lroundd.c libmcs/libmcs/libm/mathd/lroundd.c:123:20: warning: implicit conversion from 'unsigned long long' to 'long' changes value from 9223372036854775808 to 0 [-Wconstant-conversion]             return __MIN_LONG;
            ~~~~~~ ^~~~~~~~~~
/mnt/yang/vela_keystore_sim/nuttx/libs/libm/libmcs/libmcs/libm/include/internal_config.h:50:24: note: expanded from macro '__MIN_LONG'     #define __MIN_LONG 0x8000000000000000L
                       ^~~~~~~~~~~~~~~~~~~
libmcs/libmcs/libm/mathd/lroundd.c:126:20: warning: implicit conversion from 'long long' to 'long' changes value from 9223372036854775807 to -1 [-Wconstant-conversion]             return __MAX_LONG;
            ~~~~~~ ^~~~~~~~~~
/mnt/yang/vela_keystore_sim/nuttx/libs/libm/libmcs/libmcs/libm/include/internal_config.h:49:24: note: expanded from macro '__MAX_LONG'     #define __MAX_LONG 0x7FFFFFFFFFFFFFFFL
                       ^~~~~~~~~~~~~~~~~~~
2 warnings generated.
CC:  libmcs/libmcs/libm/mathf/lrintf.c libmcs/libmcs/libm/mathf/lrintf.c:67:20: warning: implicit conversion from 'unsigned long long' to 'long' changes value from 9223372036854775808 to 0 [-Wconstant-conversion]             return __MIN_LONG;
            ~~~~~~ ^~~~~~~~~~
/mnt/yang/vela_keystore_sim/nuttx/libs/libm/libmcs/libmcs/libm/include/internal_config.h:50:24: note: expanded from macro '__MIN_LONG'     #define __MIN_LONG 0x8000000000000000L
                       ^~~~~~~~~~~~~~~~~~~
libmcs/libmcs/libm/mathf/lrintf.c:70:20: warning: implicit conversion from 'long long' to 'long' changes value from 9223372036854775807 to -1 [-Wconstant-conversion]             return __MAX_LONG;
            ~~~~~~ ^~~~~~~~~~
/mnt/yang/vela_keystore_sim/nuttx/libs/libm/libmcs/libmcs/libm/include/internal_config.h:49:24: note: expanded from macro '__MAX_LONG'     #define __MAX_LONG 0x7FFFFFFFFFFFFFFFL
                       ^~~~~~~~~~~~~~~~~~~
2 warnings generated.
CC:  libmcs/libmcs/libm/mathf/lroundf.c libmcs/libmcs/libm/mathf/lroundf.c:32:20: warning: implicit conversion from 'unsigned long long' to 'long' changes value from 9223372036854775808 to 0 [-Wconstant-conversion]             return __MIN_LONG;
            ~~~~~~ ^~~~~~~~~~
/mnt/yang/vela_keystore_sim/nuttx/libs/libm/libmcs/libmcs/libm/include/internal_config.h:50:24: note: expanded from macro '__MIN_LONG'     #define __MIN_LONG 0x8000000000000000L
                       ^~~~~~~~~~~~~~~~~~~
libmcs/libmcs/libm/mathf/lroundf.c:34:20: warning: implicit conversion from 'long long' to 'long' changes value from 9223372036854775807 to -1 [-Wconstant-conversion]             return __MAX_LONG;
            ~~~~~~ ^~~~~~~~~~
/mnt/yang/vela_keystore_sim/nuttx/libs/libm/libmcs/libmcs/libm/include/internal_config.h:49:24: note: expanded from macro '__MAX_LONG'     #define __MAX_LONG 0x7FFFFFFFFFFFFFFFL
```

## Impact

minor

## Testing

ci