### PR TITLE
timer/timer_getoverrun: adjust the default errno from ENOSYS to EINVAL

### DIFF
--- a/sched/timer/timer_getoverrun.c
+++ b/sched/timer/timer_getoverrun.c
@@ -76,7 +76,7 @@
 int timer_getoverrun(timer_t timerid)
 {
   UNUSED(timerid);
-  set_errno(ENOSYS);
+  set_errno(EINVAL);
   return ERROR;
 }
 


### PR DESCRIPTION
## Summary
modify the default errno from ENOSYS to EINVAL can pass the ltp case: ltp_timer_getoverrun_speculative_6_1,
ltp_timer_getoverrun_speculative_6_2, ltp_timer_getoverrun_speculative_6_3

## Impact

## Testing

