### PR TITLE
libxx/libcxx: select PTHREAD_MUTEX_TYPES to support recursive mutex

### DIFF
--- a/libs/libxx/Kconfig
+++ b/libs/libxx/Kconfig
@@ -37,6 +37,7 @@ config LIBCXX
 	bool "LLVM libc++ C++ Standard Library"
 	select HAVE_CXXINITIALIZE
 	select LIBC_LOCALE
+	select PTHREAD_MUTEX_TYPES
 	---help---
 		LLVM "libc++" C++ Standard Library
 		https://libcxx.llvm.org/


### PR DESCRIPTION
## Summary
libxx/libcxx: select PTHREAD_MUTEX_TYPES to support recursive mutex
## Impact
fix recursive mutex issue for c++
## Testing
local test
