### PR TITLE
lib_iconv.c:Fix possible out-of-bounds reads

### DIFF
--- a/libs/libc/locale/lib_iconv.c
+++ b/libs/libc/locale/lib_iconv.c
@@ -420,6 +420,20 @@ size_t iconv(iconv_t cd, FAR char **in, FAR size_t *inb,
 
   to = extract_to(cd);
   from = extract_from(cd);
+  if (to > sizeof(g_charmaps) - 1)
+    {
+      /* Avoid going outside the range of the array */
+
+      to = sizeof(g_charmaps) - 1;
+    }
+
+  if (from > sizeof(g_charmaps) - 1)
+    {
+      /* Avoid going outside the range of the array */
+
+      from = sizeof(g_charmaps) - 1;
+    }
+
   map = g_charmaps + from + 1;
   tomap = g_charmaps + to + 1;
   type = map[0 - 1];


### PR DESCRIPTION
## Summary
Fixed a situation that would cause the fetched value to be out of range of the array in some cases.
Please ignore the follow nxstyle warning since the implementation require the special inclusion sequence:
```
Warning: /home/runner/work/nuttx/nuttx/nuttx/libs/libc/locale/lib_iconv.c:110:3: warning: #include outside of 'Included Files' section
```

## Impact
None

## Testing
None
