### PR TITLE
libc/modlib: fix minor issue about modlib

### DIFF
--- a/libs/libc/dlfcn/lib_dlopen.c
+++ b/libs/libc/dlfcn/lib_dlopen.c
@@ -196,7 +196,7 @@ static inline FAR void *dlinsert(FAR const char *filename)
   if (ret != 0)
     {
       serr("ERROR: Failed to initialize to load module: %d\n", ret);
-      goto errout_with_lock;
+      goto errout_with_loadinfo;
     }
 
   /* Allocate a module registry entry to hold the module data */
@@ -296,7 +296,6 @@ errout_with_registry_entry:
   lib_free(modp);
 errout_with_loadinfo:
   modlib_uninitialize(&loadinfo);
-errout_with_lock:
   modlib_registry_unlock();
   set_errno(-ret);
   return NULL;

--- a/libs/libc/modlib/modlib_init.c
+++ b/libs/libc/modlib/modlib_init.c
@@ -173,8 +173,7 @@ int modlib_initialize(FAR const char *filename,
        */
 
       berr("ERROR: Bad ELF header: %d\n", ret);
-      return ret;
     }
 
-  return OK;
+  return ret;
 }

--- a/libs/libc/modlib/modlib_load.c
+++ b/libs/libc/modlib/modlib_load.c
@@ -62,10 +62,6 @@
  * Description:
  *   Calculate total memory allocation for the ELF file.
  *
- * Returned Value:
- *   0 (OK) is returned on success and a negated errno is returned on
- *   failure.
- *
  ****************************************************************************/
 
 static void modlib_elfsize(FAR struct mod_loadinfo_s *loadinfo)

--- a/libs/libc/modlib/modlib_loadhdrs.c
+++ b/libs/libc/modlib/modlib_loadhdrs.c
@@ -116,7 +116,6 @@ int modlib_loadhdrs(FAR struct mod_loadinfo_s *loadinfo)
       loadinfo->phdr = (FAR Elf_Phdr *)lib_malloc(phdrsize);
       if (!loadinfo->phdr)
         {
-          lib_free(loadinfo->shdr);
           berr("ERROR: Failed to allocate the program header table."
                "Size: %zu\n", phdrsize);
           return -ENOMEM;
@@ -129,8 +128,6 @@ int modlib_loadhdrs(FAR struct mod_loadinfo_s *loadinfo)
       if (ret < 0)
         {
           berr("ERROR: Failed to read program header table: %d\n", ret);
-          lib_free(loadinfo->phdr);
-          lib_free(loadinfo->shdr);
         }
     }
   else

--- a/libs/libc/modlib/modlib_read.c
+++ b/libs/libc/modlib/modlib_read.c
@@ -50,23 +50,7 @@
  ****************************************************************************/
 
 #ifdef ELF_DUMP_READDATA
-static inline void modlib_dumpreaddata(FAR char *buffer, size_t buflen)
-{
-  FAR uint32_t *buf32 = (FAR uint32_t *)buffer;
-  size_t i;
-  size_t j;
-
-  for (i = 0; i < buflen; i += 32)
-    {
-      syslog(LOG_DEBUG, "%04zx:", i);
-      for (j = 0; j < 32; j += sizeof(uint32_t))
-        {
-          syslog(LOG_DEBUG, " %08" PRIx32, *buf32++);
-        }
-
-      syslog(LOG_DEBUG, "\n");
-    }
-}
+#  define modlib_dumpreaddata(b,n) binfodumpbuffer("modlib_read",b,n)
 #else
 #  define modlib_dumpreaddata(b,n)
 #endif
@@ -94,38 +78,39 @@ int modlib_read(FAR struct mod_loadinfo_s *loadinfo, FAR uint8_t *buffer,
   size_t  nsize = readsize;
   ssize_t nbytes;      /* Number of bytes read */
   off_t   rpos;        /* Position returned by lseek */
+  int     errval;
 
   binfo("Read %zu bytes from offset %" PRIdOFF "\n", readsize, offset);
 
   /* Loop until all of the requested data has been read. */
 
+  /* Seek to the read position */
+
+  rpos = _NX_SEEK(loadinfo->filfd, offset, SEEK_SET);
+  if (rpos != offset)
+    {
+      errval = _NX_GETERRNO(rpos);
+      berr("ERROR: Failed to seek to position %" PRIdOFF ": %d\n",
+           offset, errval);
+      return -errval;
+    }
+
   while (readsize > 0)
     {
-      /* Seek to the next read position */
-
-      rpos = _NX_SEEK(loadinfo->filfd, offset, SEEK_SET);
-      if (rpos != offset)
-        {
-          int errval = _NX_GETERRNO(rpos);
-          berr("ERROR: Failed to seek to position %" PRIdOFF ": %d\n",
-               offset, errval);
-          return -errval;
-        }
-
       /* Read the file data at offset into the user buffer */
 
       nbytes = _NX_READ(loadinfo->filfd,
                         buffer + nsize - readsize, readsize);
       if (nbytes < 0)
         {
-          int errval = _NX_GETERRNO(nbytes);
+          errval = _NX_GETERRNO(nbytes);
 
           /* EINTR just means that we received a signal */
 
           if (errval != EINTR)
             {
               berr("ERROR: Read from offset %" PRIdOFF " failed: %d\n",
-                   offset, errval);
+                   (off_t)(offset + nsize - readsize), errval);
               return -errval;
             }
         }
@@ -137,7 +122,6 @@ int modlib_read(FAR struct mod_loadinfo_s *loadinfo, FAR uint8_t *buffer,
       else
         {
           readsize -= nbytes;
-          offset   += nbytes;
         }
     }
 

--- a/libs/libc/modlib/modlib_uninit.c
+++ b/libs/libc/modlib/modlib_uninit.c
@@ -61,6 +61,7 @@ int modlib_uninitialize(FAR struct mod_loadinfo_s *loadinfo)
   if (loadinfo->filfd >= 0)
     {
       _NX_CLOSE(loadinfo->filfd);
+      loadinfo->filfd = -1;
     }
 
   return OK;


### PR DESCRIPTION
## Summary
1. libs/modlib: close fd when error happen
2. libs/modlib: avoid seeking in each reading
3. libs/modlib: avoid double free when call modlib_unload with erro
4. libc/mod: fix minor issue about description

## Impact

## Testing
daily  test
