### PR TITLE
libm/libmcs: Fix clang build download libmcs warning

### DIFF
--- a/libs/libm/libmcs/0004-Fix-warning-function-declaration-isn-t-a-prototype-W.patch
+++ b/libs/libm/libmcs/0004-Fix-warning-function-declaration-isn-t-a-prototype-W.patch
@@ -1,0 +1,40 @@
+From ea4cb25a98c0f2f0313c47257742cf6565c57dc7 Mon Sep 17 00:00:00 2001
+From: Xiang Xiao <xiaoxiang@xiaomi.com>
+Date: Wed, 5 Apr 2023 10:27:47 +0800
+Subject: [PATCH 1/2] =?UTF-8?q?Fix=20warning:=20function=20declaration=20i?=
+ =?UTF-8?q?sn=E2=80=99t=20a=20prototype=20[-Wstrict-prototypes]?=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>
+Change-Id: Ie8f405c14d6bae5a5d25caa82e7190c4bcb4504f
+---
+ libm/common/tools.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/libmcs/libmcs/libm/common/tools.h libmcs/libmcs/libm/common/tools.h
+index 56bde02bb..b10aa173d 100644
+--- a/libmcs/libmcs/libm/common/tools.h
++++ libmcs/libmcs/libm/common/tools.h
+@@ -335,7 +335,7 @@ static inline float __forced_calculationf(float x) {
+     return r;
+ }
+ 
+-static inline double __raise_invalid() {
++static inline double __raise_invalid(void) {
+     double r = __forced_calculation(0.0 / 0.0);
+     return r;
+ }
+@@ -355,7 +355,7 @@ static inline double __raise_inexact(double x) {
+     return (__forced_calculation(huge - 1.0e-300) != 0.0) ? x : 0.0;
+ }
+ 
+-static inline float __raise_invalidf() {
++static inline float __raise_invalidf(void) {
+     double r = __forced_calculationf(0.0f / 0.0f);
+     return r;
+ }
+-- 
+2.40.1
+

--- a/libs/libm/libmcs/0005-libm-libmcs-Fix-clang-build-libmcs-warning.patch
+++ b/libs/libm/libmcs/0005-libm-libmcs-Fix-clang-build-libmcs-warning.patch
@@ -1,0 +1,33 @@
+From a33e70c36a968577a710eb73cd734d1aa87d41ae Mon Sep 17 00:00:00 2001
+From: yanghuatao <yanghuatao@xiaomi.com>
+Date: Mon, 4 Sep 2023 21:29:55 +0800
+Subject: [PATCH 2/2] libm/libmcs: Fix clang build libmcs warning
+
+VELAPLATFO-15795
+
+Fix warnings:
+libmcs/libmcs/libm/common/fenv.c libmcs/libmcs/libm/common/fenv.c:26:15: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
+int fegetround()
+
+Change-Id: I91e956a46b0ea0bbf187c1790a1f236da8ee6b01
+Signed-off-by: yanghuatao <yanghuatao@xiaomi.com>
+---
+ libmcs/libmcs/libm/common/fenv.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libmcs/libmcs/libm/common/fenv.c libmcs/libmcs/libm/common/fenv.c
+index df0fdc241..7cc50c876 100644
+--- a/libmcs/libmcs/libm/common/fenv.c
++++ libmcs/libmcs/libm/common/fenv.c
+@@ -23,7 +23,7 @@ int fesetexceptflag(const fexcept_t *flagp, int excepts)
+     return -1;
+ }
+ 
+-int fegetround()
++int fegetround(void)
+ {
+     return -1;
+ }
+-- 
+2.40.1
+

--- a/libs/libm/libmcs/Make.defs
+++ b/libs/libm/libmcs/Make.defs
@@ -29,6 +29,8 @@ libmcs/libmcs: libmcs-$(LIBMCS_VERSION).zip
 	$(Q) patch -p1 < libmcs/0001-fix-build-error-remove-unused-file-fenv.h.patch
 	$(Q) patch -p1 < libmcs/0002-fix-build-error-do-not-include-config.h.patch
 	$(Q) patch -p1 < libmcs/0003-fix-build-error-INFINITY-error-in-quickjs.c.patch
+	$(Q) patch -p1 < libmcs/0004-Fix-warning-function-declaration-isn-t-a-prototype-W.patch
+	$(Q) patch -p1 < libmcs/0005-libm-libmcs-Fix-clang-build-libmcs-warning.patch
 	$(Q) touch $@
 
 ifeq ($(wildcard libmcs/libmcs/.git),)


### PR DESCRIPTION
VELAPLATFO-16865

Fix warnings:
CC:  libmcs/libmcs/libm/common/fenv.c libmcs/libmcs/libm/common/fenv.c:26:15: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes] int fegetround()
              ^
               void
Signed-off-by: yanghuatao <yanghuatao@xiaomi.com>

## Summary

## Impact

## Testing

