### PR TITLE
pthread_cleanup: rm sched_[un]lock

### DIFF
--- a/libs/libc/pthread/pthread_cleanup.c
+++ b/libs/libc/pthread/pthread_cleanup.c
@@ -52,9 +52,6 @@
  * Returned Value:
  *   None
  *
- * Assumptions:
- *   The scheduler is locked.
- *
  ****************************************************************************/
 
 static void pthread_cleanup_pop_tls(FAR struct tls_info_s *tls, int execute)
@@ -122,14 +119,7 @@ void pthread_cleanup_pop(int execute)
 
   DEBUGASSERT(tls != NULL);
 
-  /* sched_lock() should provide sufficient protection.  We only need to
-   * have this TCB stationary; the pthread cleanup stack should never be
-   * modified by interrupt level logic.
-   */
-
-  sched_lock();
   pthread_cleanup_pop_tls(tls, execute);
-  sched_unlock();
 }
 
 void pthread_cleanup_push(pthread_cleanup_t routine, FAR void *arg)
@@ -139,12 +129,6 @@ void pthread_cleanup_push(pthread_cleanup_t routine, FAR void *arg)
   DEBUGASSERT(tls != NULL);
   DEBUGASSERT(tls->tos < CONFIG_PTHREAD_CLEANUP_STACKSIZE);
 
-  /* sched_lock() should provide sufficient protection.  We only need to
-   * have this TCB stationary; the pthread cleanup stack should never be
-   * modified by interrupt level logic.
-   */
-
-  sched_lock();
   if (tls->tos < CONFIG_PTHREAD_CLEANUP_STACKSIZE)
     {
       unsigned int ndx = tls->tos;
@@ -153,8 +137,6 @@ void pthread_cleanup_push(pthread_cleanup_t routine, FAR void *arg)
       tls->stack[ndx].pc_cleaner = routine;
       tls->stack[ndx].pc_arg = arg;
     }
-
-  sched_unlock();
 }
 
 /****************************************************************************
@@ -177,13 +159,10 @@ void pthread_cleanup_popall(FAR struct tls_info_s *tls)
 {
   DEBUGASSERT(tls != NULL);
 
-  sched_lock();
   while (tls->tos > 0)
     {
       pthread_cleanup_pop_tls(tls, 1);
     }
-
-  sched_unlock();
 }
 
 #endif /* defined(CONFIG_PTHREAD_CLEANUP_STACKSIZE) && CONFIG_PTHREAD_CLEANUP_STACKSIZE > 0 */


### PR DESCRIPTION
## Summary
Since TLS is only used within a single thread and requires no additional protection. https://github.com/apache/nuttx/issues/1137

## Impact

## Testing

