### PR TITLE
sched/wdog:change g_wdtickbase update situation.

### DIFF
--- a/sched/wdog/wd_start.c
+++ b/sched/wdog/wd_start.c
@@ -373,6 +373,10 @@ unsigned int wd_timer(int ticks, bool noswitches)
   unsigned int ret;
   int decr;
 
+  /* Update clock tickbase */
+
+  g_wdtickbase += ticks;
+
   /* Check if there are any active watchdogs to process */
 
   wdog = (FAR struct wdog_s *)g_wdactivelist.head;
@@ -386,7 +390,6 @@ unsigned int wd_timer(int ticks, bool noswitches)
 
       wdog->lag    -= decr;
       ticks        -= decr;
-      g_wdtickbase += decr;
 
       wdog = wdog->next;
     }
@@ -397,10 +400,6 @@ unsigned int wd_timer(int ticks, bool noswitches)
     {
       wd_expiration();
     }
-
-  /* Update clock tickbase */
-
-  g_wdtickbase += ticks;
 
   /* Return the delay for the next watchdog to expire */
 


### PR DESCRIPTION
## Summary

In the 'wd_timer',the callback function executed by 'wd_expiration' could call wd_start,and g_wdtickbase might be updated.Subsequently, g_wdtickbase is incremented by the value of ticks, causing g_wdtickbase to be greater than the actual passage of time.

## Impact

wdog

## Testing

internal device