### PR TITLE
sim/sim_alsa: reset alsa pcm device when snd_pcm_avail < 0

### DIFF
--- a/arch/sim/src/sim/posix/sim_alsa.c
+++ b/arch/sim/src/sim/posix/sim_alsa.c
@@ -934,6 +934,12 @@ static void sim_audio_process(struct sim_audio_s *priv)
   avail = host_uninterruptible(snd_pcm_avail, priv->pcm);
   if (avail < expect)
     {
+      if (avail < 0)
+        {
+          ret = avail;
+          goto out;
+        }
+
       return;
     }
 


### PR DESCRIPTION
## Summary

sim/sim_alsa: reset alsa pcm device when snd_pcm_avail < 0

## Impact

Xiaomi vela simulator 

## Testing
Xiaomi Vela
