### PR TITLE
sched: return 0 from clock_systime_ticks if failed

### DIFF
--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -1655,7 +1655,7 @@ void up_timer_initialize(void);
  * set a time in the future and get an event when that alarm goes off.
  *
  *   int up_alarm_cancel(void):  Cancel the alarm.
- *   int up_alarm_start(FAR const struct timespec *ts): Enable (or re-anable
+ *   int up_alarm_start(FAR const struct timespec *ts): Enable (or re-enable
  *     the alarm.
  * #else
  *   int up_timer_cancel(void):  Cancels the interval timer.

--- a/sched/clock/clock_systime_ticks.c
+++ b/sched/clock/clock_systime_ticks.c
@@ -84,13 +84,18 @@ clock_t clock_systime_ticks(void)
 
       /* Get the time from the platform specific hardware */
 
-      clock_systime_timespec(&ts);
+      if (clock_systime_timespec(&ts) == OK)
+        {
+          /* Convert to a 64-bit value in microseconds,
+           * then in clock tick units.
+           */
 
-      /* Convert to a 64-bit value in microseconds,
-       * then in clock tick units.
-       */
-
-      return timespec_to_tick(&ts);
+          return timespec_to_tick(&ts);
+        }
+      else
+        {
+          return 0;
+        }
     }
   else
 #endif
@@ -101,12 +106,24 @@ clock_t clock_systime_ticks(void)
 
 #if defined(CONFIG_SCHED_TICKLESS_TICK_ARGUMENT)
       clock_t ticks;
-      up_timer_gettick(&ticks);
-      return ticks;
+      if (up_timer_gettick(&ticks) == OK)
+        {
+          return ticks;
+        }
+      else
+        {
+          return 0;
+        }
 #elif defined(CONFIG_SCHED_TICKLESS)
       struct timespec ts;
-      up_timer_gettime(&ts);
-      return timespec_to_tick(&ts);
+      if (up_timer_gettime(&ts) == OK)
+        {
+          return timespec_to_tick(&ts);
+        }
+      else
+        {
+          return 0;
+        }
 #elif defined(CONFIG_SYSTEM_TIME64)
 
       clock_t sample;


### PR DESCRIPTION
## Summary

Initialize tick to zero so the value returned is also reasonable even if failed to get current tick.

## Impact
None

## Testing
Internal CI and project
