### PR TITLE
add remote poweroff support

### DIFF
--- a/arch/sim/src/sim/sim_head.c
+++ b/arch/sim/src/sim/sim_head.c
@@ -34,6 +34,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
 #include <nuttx/symtab.h>
+#include <nuttx/rptun/rptun.h>
 #include <nuttx/syslog/syslog_rpmsg.h>
 
 #include "sim_internal.h"
@@ -201,6 +202,10 @@ int main(int argc, char **argv, char **envp)
 #ifdef CONFIG_BOARDCTL_POWEROFF
 int board_power_off(int status)
 {
+#ifdef CONFIG_RPTUN
+  rptun_poweroff(NULL);
+#endif
+
   /* Abort simulator */
 
   host_abort(status);

--- a/arch/sim/src/sim/sim_rptun.c
+++ b/arch/sim/src/sim/sim_rptun.c
@@ -198,7 +198,7 @@ static int sim_rptun_stop(struct rptun_dev_s *dev)
   struct sim_rptun_dev_s *priv = container_of(dev,
                               struct sim_rptun_dev_s, rptun);
 
-  if (priv->master & SIM_RPTUN_BOOT)
+  if ((priv->master & SIM_RPTUN_BOOT) && (priv->pid > 0))
     {
       priv->shmem->cmdm = SIM_RPTUN_STOP << SIM_RPTUN_SHIFT;
 

--- a/drivers/rptun/rptun.c
+++ b/drivers/rptun/rptun.c
@@ -743,6 +743,8 @@ static int rptun_dev_start(FAR struct remoteproc *rproc)
         {
           cb->device_created(&priv->rvdev.rdev, cb->priv);
         }
+
+      rptun_update_rx(priv);
     }
 
   nxrmutex_unlock(&g_rptun_lockcb);

--- a/include/nuttx/rptun/rptun.h
+++ b/include/nuttx/rptun/rptun.h
@@ -366,6 +366,7 @@ extern "C"
 
 int rptun_initialize(FAR struct rptun_dev_s *dev);
 int rptun_boot(FAR const char *cpuname);
+int rptun_poweroff(FAR const char *cpuname);
 int rptun_reset(FAR const char *cpuname, int value);
 int rptun_panic(FAR const char *cpuname);
 void rptun_dump_all(void);

--- a/openamp/0001-libmetal-add-metal_list_for_each_safe-support.patch
+++ b/openamp/0001-libmetal-add-metal_list_for_each_safe-support.patch
@@ -1,0 +1,28 @@
+From f06b90cdc478124eba45b3be4f3630e8a729c51b Mon Sep 17 00:00:00 2001
+From: ligd <liguiding1@xiaomi.com>
+Date: Tue, 25 Jul 2023 14:25:58 +0800
+Subject: [PATCH] libmetal: add metal_list_for_each_safe() support
+
+Signed-off-by: ligd <liguiding1@xiaomi.com>
+---
+ lib/list.h | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/lib/list.h libmetal/lib/list.h
+index eb0e7b3..3e8d17f 100644
+--- a/lib/list.h
++++ libmetal/lib/list.h
+@@ -98,6 +98,10 @@ static inline struct metal_list *metal_list_first(struct metal_list *list)
+ 	     (node) != (list);			\
+ 	     (node) = (node)->next)
+ 
++#define metal_list_for_each_safe(list, node, temp)		\
++	for(node = (list)->next, temp = node->next;		\
++	    node != (list); node = temp, temp = node->next)
++
+ static inline bool metal_list_find_node(struct metal_list *list,
+ 					struct metal_list *node)
+ {
+-- 
+2.25.1
+

--- a/openamp/libmetal.cmake
+++ b/openamp/libmetal.cmake
@@ -33,6 +33,9 @@ if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/libmetal)
         ""
         INSTALL_COMMAND
         ""
+    PATCH_COMMAND
+      patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
+      ${CMAKE_CURRENT_LIST_DIR}/0001-libmetal-add-metal_list_for_each_safe-support.patch
     DOWNLOAD_NO_PROGRESS true
     TIMEOUT 30)
 

--- a/openamp/libmetal.defs
+++ b/openamp/libmetal.defs
@@ -77,6 +77,7 @@ libmetal.zip:
 	$(call DOWNLOAD,https://github.com/OpenAMP/libmetal/archive,v$(VERSION).zip,libmetal.zip)
 	$(Q) unzip -o libmetal.zip
 	$(Q) mv libmetal-$(VERSION) libmetal
+	$(Q) patch -p0 < 0001-libmetal-add-metal_list_for_each_safe-support.patch
 
 .libmetal_headers: libmetal.zip
 else


### PR DESCRIPTION
## Summary
rptun: add remote poweroff support

## Impact
can use RPTUNIOC_STOP and RPTUNIOC_START causes remote powerdown or re powerup

## Testing

