### PR TITLE
drivers/video: Fix crash caused by priv->capture_cb = null

### DIFF
--- a/drivers/video/goldfish_camera.c
+++ b/drivers/video/goldfish_camera.c
@@ -464,6 +464,11 @@ reload:
 
           DEBUGASSERT(ret == priv->buf_size);
 
+          if (priv->capture_cb == NULL)
+            {
+              return 0;
+            }
+
           clock_systime_timespec(&ts);
           TIMESPEC_TO_TIMEVAL(&tv, &ts);
           priv->capture_cb(0, priv->buf_size, &tv, priv->capture_arg);


### PR DESCRIPTION
## Summary

When the upper layer calls goldfish_camera_data_uninit, priv->capture_cb=NULL, but when there is data transmission in goldfish_camera_thread, priv->capture_cb will be called, which will cause a crash.

## Impact

goldfish camera

## Testing

inertnal test