### PR TITLE
Exec: Support run exec in current task

### DIFF
--- a/binfmt/CMakeLists.txt
+++ b/binfmt/CMakeLists.txt
@@ -63,3 +63,4 @@ endif()
 
 target_sources(binfmt PRIVATE ${SRCS})
 target_include_directories(binfmt PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(binfmt PRIVATE ${CMAKE_SOURCE_DIR}/sched)

--- a/binfmt/Makefile
+++ b/binfmt/Makefile
@@ -58,6 +58,8 @@ endif
 include libnxflat/Make.defs
 include libelf/Make.defs
 
+CFLAGS += ${INCDIR_PREFIX}$(TOPDIR)$(DELIM)sched
+
 AOBJS = $(ASRCS:.S=$(OBJEXT))
 COBJS = $(CSRCS:.c=$(OBJEXT))
 

--- a/include/nuttx/binfmt/binfmt.h
+++ b/include/nuttx/binfmt/binfmt.h
@@ -270,7 +270,8 @@ int unload_module(FAR struct binary_s *bin);
 int exec_module(FAR struct binary_s *binp,
                 FAR const char *filename, FAR char * const *argv,
                 FAR char * const *envp,
-                FAR const posix_spawn_file_actions_t *actions);
+                FAR const posix_spawn_file_actions_t *actions,
+                bool spawn);
 
 /****************************************************************************
  * Name: exec


### PR DESCRIPTION
## Summary
There is a problem when vfork() calls execv() (or execl()) to start a new application: When the parent thread calls vfork() it receives and gets the pid of the vforked task, and not the pid of the desired execv'ed application.
see issue https://github.com/apache/nuttx/issues/3334

## Impact
exec series funciton

## Testing
sim:posix_test
sim:elf
