### PR TITLE
tools/minidumpserver: don't stop while gdb client is stopping

### DIFF
--- a/tools/minidumpserver.py
+++ b/tools/minidumpserver.py
@@ -648,14 +648,16 @@ if __name__ == "__main__":
     gdbserver.listen(1)
 
     logger.info(f"Waiting GDB connection on port {args.port} ...")
+    logger.info("Press Ctrl+C to stop ...")
 
-    conn, remote = gdbserver.accept()
+    while True:
+        try:
+            conn, remote = gdbserver.accept()
 
-    if conn:
-        logger.info(f"Accepted GDB connection from {remote}")
-
-        gdbstub.run(conn)
-
-        conn.close()
+            if conn:
+                logger.info(f"Accepted GDB connection from {remote}")
+                gdbstub.run(conn)
+        except KeyboardInterrupt:
+            break
 
     gdbserver.close()


### PR DESCRIPTION
## Summary

minidump server doesn't stop while gdb client is stopping now

## Impact

## Testing

