### PR TITLE
iob: limit the iob bufsize is sufficient to fill all L2/L3/L4 headers

### DIFF
--- a/mm/iob/Kconfig
+++ b/mm/iob/Kconfig
@@ -26,6 +26,8 @@ config IOB_NBUFFERS
 
 config IOB_BUFSIZE
 	int "Payload size of one I/O buffer"
+	range 196 65535 if NET_TCP_SELECTIVE_ACK && NET_IPv6 && RNDIS
+	range 128 65535 if NET_TCP_SELECTIVE_ACK && (NET_IPv4 || NET_IPv6)
 	default 196
 	---help---
 		Each packet is represented by a series of small I/O buffers in a


### PR DESCRIPTION
## Summary
rndis header length is 36, L2 header is 14, IPv6 header is 40, tcp header is 56 when sack option count is 4(default max_ofosegs is 4). so the iob bufsize should greater than we need.

## Impact

## Testing
Cortex-M55
