### PR TITLE
sched/clock Add special handling for TCB null pointer cases

### DIFF
--- a/sched/clock/clock_gettime.c
+++ b/sched/clock/clock_gettime.c
@@ -153,7 +153,14 @@ int clock_gettime(clockid_t clock_id, struct timespec *tp)
           tcb = nxsched_get_tcb(pid);
         }
 
-      up_perf_convert(tcb->run_time, tp);
+      if (tcb != NULL)
+        {
+          up_perf_convert(tcb->run_time, tp);
+        }
+      else
+        {
+          ret = -EFAULT;
+        }
     }
   else if (clock_type == CLOCK_PROCESS_CPUTIME_ID)
     {
@@ -174,18 +181,28 @@ int clock_gettime(clockid_t clock_id, struct timespec *tp)
           tcb = nxsched_get_tcb(pid);
         }
 
-      group = tcb->group;
-      runtime = 0;
-
-      flags = enter_critical_section();
-      for (i = group->tg_nmembers - 1; i >= 0; i--)
+      if (tcb != NULL)
         {
-          tcb = nxsched_get_tcb(group->tg_members[i]);
-          runtime += tcb->run_time;
-        }
+          group = tcb->group;
+          runtime = 0;
 
-      leave_critical_section(flags);
-      up_perf_convert(runtime, tp);
+          flags = enter_critical_section();
+          for (i = group->tg_nmembers - 1; i >= 0; i--)
+            {
+              tcb = nxsched_get_tcb(group->tg_members[i]);
+              if (tcb != NULL)
+                {
+                  runtime += tcb->run_time;
+                }
+            }
+
+          leave_critical_section(flags);
+          up_perf_convert(runtime, tp);
+        }
+      else
+        {
+          ret = -EFAULT;
+        }
     }
 #endif
   else


### PR DESCRIPTION
Adding a judgment in the code that null return values are not referenced for dereference

## Summary

## Impact
Collecting CPU time of processes and threads through interfaces , and the verification of this function requires the activation of CONFIG_ SCHED_ CRITMONITOR switch
## Testing
Open CONFIG_ SCHED_ CRITMONITOR , in hello_main Adding a Clock to the  Test Program Method calls corresponding to gettime to obtain the CPUtime of threads and processes

Test Code
```
int main(int argc, FAR char *argv[])
{
  struct timespec myts;
  myts.tv_sec = 0;
  myts.tv_nsec = 0;
  if ((clock_gettime(CLOCK_THREAD_CPUTIME_ID, &myts)) < 0) {
		perror("clock_gettime: CLOCK_THREAD_CPUTIME_ID: ");
		exit(1);
	}
  else {
    syslog(LOG_INFO,"clock_gettime succ type CLOCK_THREAD_CPUTIME_ID myts.tv_sec is [%d]",myts.tv_sec);
    syslog(LOG_INFO,"clock_gettime succ type CLOCK_THREAD_CPUTIME_ID myts.tv_nsec is [%ld]",myts.tv_nsec);
  }
  sleep(1);
  myts.tv_sec = 0;
  myts.tv_nsec = 0;
  if ((clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &myts)) < 0) {
		perror("clock_gettime: CLOCK_THREAD_CPUTIME_ID: ");
		exit(1);
	}
  else {
    syslog(LOG_INFO,"clock_gettime succ type CLOCK_THREAD_CPUTIME_ID myts.tv_sec is [%d]",myts.tv_sec);
    syslog(LOG_INFO,"clock_gettime succ type CLOCK_PROCESS_CPUTIME_ID myts.tv_nsec is [%ld]",myts.tv_nsec);
  }
  return 0;
}
```
