### PR TITLE
esp32s3: fix build error

### DIFF
--- a/arch/xtensa/src/esp32s3/esp32s3_qspi.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_qspi.c
@@ -978,7 +978,7 @@ static int esp32s3_qspi_memory(struct qspi_dev_s *dev,
       esp32s3_dma_setup(priv->dma_desc,
                         QSPI_DMA_DESC_NUM,
                         (uint8_t *)meminfo->buffer,
-                        meminfo->buflen
+                        meminfo->buflen,
                         true);
       esp32s3_dma_load(priv->dma_desc, priv->dma_channel, true);
       esp32s3_dma_enable(priv->dma_channel, true);
@@ -994,7 +994,7 @@ static int esp32s3_qspi_memory(struct qspi_dev_s *dev,
       esp32s3_dma_setup(priv->dma_desc,
                         QSPI_DMA_DESC_NUM,
                         (uint8_t *)meminfo->buffer,
-                        meminfo->buflen
+                        meminfo->buflen,
                         false);
       esp32s3_dma_load(priv->dma_desc, priv->dma_channel, false);
       esp32s3_dma_enable(priv->dma_channel, false);

--- a/arch/xtensa/src/esp32s3/esp32s3_spi_slave.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_spi_slave.c
@@ -903,7 +903,7 @@ static void spislave_setup_rx_dma(struct spislave_priv_s *priv)
   esp32s3_dma_setup(priv->dma_rxdesc,
                     SPI_DMA_DESC_NUM,
                     priv->rx_buffer + priv->rx_length,
-                    length
+                    length,
                     false);
   esp32s3_dma_load(priv->dma_rxdesc, priv->dma_channel, false);
 
@@ -947,7 +947,7 @@ static void spislave_setup_tx_dma(struct spislave_priv_s *priv)
   esp32s3_dma_setup(priv->dma_txdesc,
                     SPI_DMA_DESC_NUM,
                     priv->tx_buffer,
-                    SPI_SLAVE_BUFSIZE
+                    SPI_SLAVE_BUFSIZE,
                     true);
   esp32s3_dma_load(priv->dma_txdesc, priv->dma_channel, true);
 


### PR DESCRIPTION
## Summary
Fix below build error when enable `SPI_SLAVE` and `ESP32S3_SPI_DMA` or enable `ESP32S3_SPI_IO_QIO`
```
CC:  chip/esp32s3_spi_slave.c In file included from /home/u0228848401/workdir/contribution/royfengsss/nuttx/include/syslog.h:33,
                 from /home/u0228848401/workdir/contribution/royfengsss/nuttx/include/debug.h:41,
                 from chip/esp32s3_spi_slave.c:30:
chip/esp32s3_spi_slave.c: In function 'spislave_setup_rx_dma':
chip/esp32s3_spi_slave.c:907:21: error: expected expression before '_Bool'
                     false);
                     ^~~~~
chip/esp32s3_spi_slave.c:906:21: error: called object 'length' is not a function or function pointer
                     length
                     ^~~~~~
chip/esp32s3_spi_slave.c:901:12: note: declared here
   uint32_t length = SPI_SLAVE_BUFSIZE - priv->rx_length;
            ^~~~~~
In file included from /home/u0228848401/workdir/contribution/royfengsss/nuttx/include/syslog.h:33,
                 from /home/u0228848401/workdir/contribution/royfengsss/nuttx/include/debug.h:41,
                 from chip/esp32s3_spi_slave.c:30:
chip/esp32s3_spi_slave.c:907:21: error: expected ')' before numeric constant
                     false);
                     ^~~~~
chip/esp32s3_spi_slave.c:903:3: error: too few arguments to function 'esp32s3_dma_setup'
   esp32s3_dma_setup(priv->dma_rxdesc,
   ^~~~~~~~~~~~~~~~~
In file included from chip/esp32s3_spi_slave.c:52:
chip/esp32s3_dma.h:167:10: note: declared here
 uint32_t esp32s3_dma_setup(struct esp32s3_dmadesc_s *dmadesc, uint32_t num,
          ^~~~~~~~~~~~~~~~~
In file included from /home/u0228848401/workdir/contribution/royfengsss/nuttx/include/syslog.h:33,
                 from /home/u0228848401/workdir/contribution/royfengsss/nuttx/include/debug.h:41,
                 from chip/esp32s3_spi_slave.c:30:
chip/esp32s3_spi_slave.c: In function 'spislave_setup_tx_dma':
chip/esp32s3_spi_slave.c:951:21: error: expected expression before '_Bool'
                     true);
                     ^~~~
chip/esp32s3_spi_slave.c:66:27: error: called object is not a function or function pointer
 #define SPI_SLAVE_BUFSIZE (CONFIG_ESP32S3_SPI_SLAVE_BUFSIZE)
                           ^
chip/esp32s3_spi_slave.c:950:21: note: in expansion of macro 'SPI_SLAVE_BUFSIZE'
                     SPI_SLAVE_BUFSIZE
                     ^~~~~~~~~~~~~~~~~
In file included from /home/u0228848401/workdir/contribution/royfengsss/nuttx/include/syslog.h:33,
                 from /home/u0228848401/workdir/contribution/royfengsss/nuttx/include/debug.h:41,
                 from chip/esp32s3_spi_slave.c:30:
chip/esp32s3_spi_slave.c:951:21: error: expected ')' before numeric constant
                     true);
                     ^~~~
chip/esp32s3_spi_slave.c:947:3: error: too few arguments to function 'esp32s3_dma_setup'
   esp32s3_dma_setup(priv->dma_txdesc,
   ^~~~~~~~~~~~~~~~~
In file included from chip/esp32s3_spi_slave.c:52:
chip/esp32s3_dma.h:167:10: note: declared here
 uint32_t esp32s3_dma_setup(struct esp32s3_dmadesc_s *dmadesc, uint32_t num,
          ^~~~~~~~~~~~~~~~~
make[1]: *** [Makefile:143: esp32s3_spi_slave.o] Error 1
make: *** [tools/LibTargets.mk:164: arch/xtensa/src/libarch.a] Error 2


CC:  chip/esp32s3_qspi.c In file included from /home/u0228848401/workdir/contribution/royfengsss/nuttx/include/syslog.h:33,
                 from /home/u0228848401/workdir/contribution/royfengsss/nuttx/include/debug.h:41,
                 from chip/esp32s3_qspi.c:30:
chip/esp32s3_qspi.c: In function 'esp32s3_qspi_memory':
chip/esp32s3_qspi.c:982:25: error: expected expression before '_Bool'
                         true);
                         ^~~~
chip/esp32s3_qspi.c:981:25: error: called object is not a function or function pointer
                         meminfo->buflen
                         ^~~~~~~
In file included from /home/u0228848401/workdir/contribution/royfengsss/nuttx/include/syslog.h:33,
                 from /home/u0228848401/workdir/contribution/royfengsss/nuttx/include/debug.h:41,
                 from chip/esp32s3_qspi.c:30:
chip/esp32s3_qspi.c:982:25: error: expected ')' before numeric constant
                         true);
                         ^~~~
chip/esp32s3_qspi.c:978:7: error: too few arguments to function 'esp32s3_dma_setup'
       esp32s3_dma_setup(priv->dma_desc,
       ^~~~~~~~~~~~~~~~~
In file included from chip/esp32s3_qspi.c:60:
chip/esp32s3_dma.h:167:10: note: declared here
 uint32_t esp32s3_dma_setup(struct esp32s3_dmadesc_s *dmadesc, uint32_t num,
          ^~~~~~~~~~~~~~~~~
In file included from /home/u0228848401/workdir/contribution/royfengsss/nuttx/include/syslog.h:33,
                 from /home/u0228848401/workdir/contribution/royfengsss/nuttx/include/debug.h:41,
                 from chip/esp32s3_qspi.c:30:
chip/esp32s3_qspi.c:998:25: error: expected expression before '_Bool'
                         false);
                         ^~~~~
chip/esp32s3_qspi.c:997:25: error: called object is not a function or function pointer
                         meminfo->buflen
                         ^~~~~~~
In file included from /home/u0228848401/workdir/contribution/royfengsss/nuttx/include/syslog.h:33,
                 from /home/u0228848401/workdir/contribution/royfengsss/nuttx/include/debug.h:41,
                 from chip/esp32s3_qspi.c:30:
chip/esp32s3_qspi.c:998:25: error: expected ')' before numeric constant
                         false);
                         ^~~~~
chip/esp32s3_qspi.c:994:7: error: too few arguments to function 'esp32s3_dma_setup'
       esp32s3_dma_setup(priv->dma_desc,
       ^~~~~~~~~~~~~~~~~
In file included from chip/esp32s3_qspi.c:60:
chip/esp32s3_dma.h:167:10: note: declared here
 uint32_t esp32s3_dma_setup(struct esp32s3_dmadesc_s *dmadesc, uint32_t num,
          ^~~~~~~~~~~~~~~~~
```


## Impact
Fix build error, no impact

## Testing
Pass the build
