### PR TITLE
wifi: parse channel from IE when ctl_ch is 0

### DIFF
--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c
@@ -765,11 +765,6 @@ void bcmf_wl_scan_event_handler(FAR struct bcmf_dev_s *priv,
           continue;
         }
 
-      if (bss->ctl_ch == 0)
-        {
-          continue;
-        }
-
       ie_offset = 0;
       ie_buffer = (FAR uint8_t *)bss + bss->ie_offset;
 
@@ -795,6 +790,16 @@ void bcmf_wl_scan_event_handler(FAR struct bcmf_dev_s *priv,
 
           switch (ie_buffer[ie_offset])
             {
+              case WLAN_EID_DS_PARAMS:
+                {
+                  if (bss->ctl_ch == 0)
+                    {
+                      bss->ctl_ch = ie_buffer[ie_offset + 2];
+                    }
+
+                  break;
+                }
+
               case WLAN_EID_RSN:
                 {
                   FAR wpa_rsn_t *rsn = (FAR wpa_rsn_t *)


### PR DESCRIPTION
## Summary
The scan information will contain the channel information.
## Impact

## Testing
Cortex-M55 and bcm43xxx chipset
