### PR TITLE
drivers/net/rpmsgdrv.c: Take netdev_register() return value into account

### DIFF
--- a/drivers/net/rpmsgdrv.c
+++ b/drivers/net/rpmsgdrv.c
@@ -1145,14 +1145,30 @@ int net_rpmsg_drv_init(FAR const char *cpuname,
 
   /* Register the device with the openamp */
 
-  rpmsg_register_callback(dev,
+  ret = rpmsg_register_callback(dev,
                           net_rpmsg_drv_device_created,
                           net_rpmsg_drv_device_destroy,
                           NULL,
                           NULL);
 
+  if (ret < 0)
+    {
+      kmm_free(priv);
+      return ret;
+    }
+
   /* Register the device with the OS so that socket IOCTLs can be performed */
 
   ret = netdev_register(dev, lltype);
+  if (ret < 0)
+    {
+      rpmsg_unregister_callback(dev,
+                          net_rpmsg_drv_device_created,
+                          net_rpmsg_drv_device_destroy,
+                          NULL,
+                          NULL);
+      kmm_free(priv);
+    }
+
   return ret;
 }

--- a/drivers/net/rpmsgdrv.c
+++ b/drivers/net/rpmsgdrv.c
@@ -1113,6 +1113,7 @@ int net_rpmsg_drv_init(FAR const char *cpuname,
 {
   FAR struct net_rpmsg_drv_s *priv;
   FAR struct net_driver_s *dev;
+  int ret;
 
   /* Allocate the interface structure */
 
@@ -1152,6 +1153,6 @@ int net_rpmsg_drv_init(FAR const char *cpuname,
 
   /* Register the device with the OS so that socket IOCTLs can be performed */
 
-  netdev_register(dev, lltype);
-  return OK;
+  ret = netdev_register(dev, lltype);
+  return ret;
 }


### PR DESCRIPTION
## Summary

net_rpmsg_drv_init() bypass return value of netdev_register(). This should be taken into account.

## Impact

net_rpmsg_drv_init() returns negated errno in case of netdev_register() failure.

## Testing

Custom MPFS board