### PR TITLE
Fix CI failure on RISC-V

### DIFF
--- a/arch/risc-v/src/espressif/esp_libc_stubs.c
+++ b/arch/risc-v/src/espressif/esp_libc_stubs.c
@@ -243,52 +243,52 @@ void _lock_release_recursive(_lock_t *lock)
 #if ESP_ROM_HAS_RETARGETABLE_LOCKING
 void __retarget_lock_init(_LOCK_T *lock)
 {
-  _lock_init(lock);
+  _lock_init((_lock_t *)lock);
 }
 
 void __retarget_lock_init_recursive(_LOCK_T *lock)
 {
-  _lock_init_recursive(lock);
+  _lock_init_recursive((_lock_t *)lock);
 }
 
 void __retarget_lock_close(_LOCK_T lock)
 {
-  _lock_close(&lock);
+  _lock_close((_lock_t *)&lock);
 }
 
 void __retarget_lock_close_recursive(_LOCK_T lock)
 {
-  _lock_close_recursive(&lock);
+  _lock_close_recursive((_lock_t *)&lock);
 }
 
 void __retarget_lock_acquire(_LOCK_T lock)
 {
-  _lock_acquire(&lock);
+  _lock_acquire((_lock_t *)&lock);
 }
 
 void __retarget_lock_acquire_recursive(_LOCK_T lock)
 {
-  _lock_acquire_recursive(&lock);
+  _lock_acquire_recursive((_lock_t *)&lock);
 }
 
 int __retarget_lock_try_acquire(_LOCK_T lock)
 {
-  return _lock_try_acquire(&lock);
+  return _lock_try_acquire((_lock_t *)&lock);
 }
 
 int __retarget_lock_try_acquire_recursive(_LOCK_T lock)
 {
-  return _lock_try_acquire_recursive(&lock);
+  return _lock_try_acquire_recursive((_lock_t *)&lock);
 }
 
 void __retarget_lock_release(_LOCK_T lock)
 {
-  _lock_release(&lock);
+  _lock_release((_lock_t *)&lock);
 }
 
 void __retarget_lock_release_recursive(_LOCK_T lock)
 {
-  _lock_release_recursive(&lock);
+  _lock_release_recursive((_lock_t *)&lock);
 }
 #endif
 

--- a/arch/risc-v/src/rv32m1/rv32m1_irq.c
+++ b/arch/risc-v/src/rv32m1/rv32m1_irq.c
@@ -95,7 +95,7 @@ void up_irqinitialize(void)
 
 #if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 15
   size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~15);
-  riscv_stack_color(g_intstacktop - intstack_size, intstack_size);
+  riscv_stack_color(g_intstackalloc, intstack_size);
 #endif
 
   /* Clear all pending flags */

--- a/boards/risc-v/c906/smartl-c906/scripts/Make.defs
+++ b/boards/risc-v/c906/smartl-c906/scripts/Make.defs
@@ -40,7 +40,7 @@ AFLAGS += $(CFLAGS) -D__ASSEMBLY__
 
 CMODULEFLAGS = $(CFLAGS)
 
-LDMODULEFLAGS = -r -e module_initialize
+LDMODULEFLAGS = -melf64lriscv -r -e module_initialize
 LDMODULEFLAGS += -T $(call CONVERT_PATH,$(TOPDIR)/libs/libc/modlib/gnu-elf.ld)
 
 # ELF module definitions

--- a/boards/risc-v/k210/maix-bit/scripts/Make.defs
+++ b/boards/risc-v/k210/maix-bit/scripts/Make.defs
@@ -36,7 +36,7 @@ AFLAGS += $(CFLAGS) -D__ASSEMBLY__
 
 CMODULEFLAGS = $(CFLAGS)
 
-LDMODULEFLAGS = -r -e module_initialize
+LDMODULEFLAGS = -melf64lriscv -r -e module_initialize
 LDMODULEFLAGS += -T $(call CONVERT_PATH,$(TOPDIR)/libs/libc/modlib/gnu-elf.ld)
 
 # ELF module definitions

--- a/boards/risc-v/mpfs/icicle/scripts/Make.defs
+++ b/boards/risc-v/mpfs/icicle/scripts/Make.defs
@@ -64,7 +64,7 @@ AFLAGS += $(CFLAGS) -D__ASSEMBLY__
 
 CMODULEFLAGS = $(CFLAGS)
 
-LDMODULEFLAGS = -r -e module_initialize
+LDMODULEFLAGS = -melf64lriscv -r -e module_initialize
 LDMODULEFLAGS += -T $(call CONVERT_PATH,$(TOPDIR)/libs/libc/modlib/gnu-elf.ld)
 
 # ELF module definitions
@@ -72,5 +72,5 @@ LDMODULEFLAGS += -T $(call CONVERT_PATH,$(TOPDIR)/libs/libc/modlib/gnu-elf.ld)
 CELFFLAGS = $(CFLAGS)
 CXXELFFLAGS = $(CXXFLAGS)
 
-LDELFFLAGS = -r -e main
+LDELFFLAGS = -melf64lriscv -r -e main
 LDELFFLAGS += -T $(call CONVERT_PATH,$(TOPDIR)/binfmt/libelf/gnu-elf.ld)


### PR DESCRIPTION


## Summary
Fix:
```
riscv-none-elf-ld: sotest.o: ABI is incompatible with that of the selected emulation:
  target emulation `elf64-littleriscv' does not match `elf32-littleriscv'
riscv-none-elf-ld: failed to merge target specific data of file sotest.o

```
## Impact
c906 only
## Testing
CI
