### PR TITLE
arch: cxd56xx: Return error for RTC alarm setting before initialization

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_rtc.c
+++ b/arch/arm/src/cxd56xx/cxd56_rtc.c
@@ -553,7 +553,7 @@ int cxd56_rtc_setalarm(struct alm_setalarm_s *alminfo)
   id = alminfo->as_id;
   cbinfo = &g_alarmcb[id];
 
-  if (cbinfo->ac_cb == NULL)
+  if (g_rtc_enabled && (cbinfo->ac_cb == NULL))
     {
       /* The set the alarm */
 


### PR DESCRIPTION
## Summary
Return EBUSY error for alarm setting before completion of RTC initialization.

## Impact
Only spresense board.

## Testing

