### PR TITLE
riscv/riscv_pmp.c: fix broken TOR checks

### DIFF
--- a/arch/risc-v/src/common/riscv_pmp.c
+++ b/arch/risc-v/src/common/riscv_pmp.c
@@ -32,6 +32,7 @@
 #include <nuttx/compiler.h>
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
+#include <nuttx/lib/math32.h>
 
 #include "riscv_internal.h"
 
@@ -101,32 +102,6 @@ typedef struct pmp_entry_s pmp_entry_t;
  ****************************************************************************/
 
 /****************************************************************************
- * Name: log2ceil
- *
- * Description:
- *   Calculate the up-rounded power-of-two for input.
- *
- * Input Parameters:
- *   size - The size of the PMP region.
- *
- * Returned Value:
- *   Power-of-two for argument, rounded up.
- *
- ****************************************************************************/
-
-static uintptr_t log2ceil(uintptr_t size)
-{
-  uintptr_t pot = 0;
-
-  for (size = size - 1; size > 1; size >>= 1)
-    {
-      pot++;
-    }
-
-  return pot;
-}
-
-/****************************************************************************
  * Name: pmp_check_addrmatch_type
  *
  * Description:
@@ -191,7 +166,7 @@ static bool pmp_check_region_attrs(uintptr_t base, uintptr_t size,
 {
   /* Check that the size is not too small */
 
-  if (size < MIN_BLOCK_SIZE)
+  if ((type != PMPCFG_A_TOR) && (size < MIN_BLOCK_SIZE))
     {
       return false;
     }
@@ -216,7 +191,7 @@ static bool pmp_check_region_attrs(uintptr_t base, uintptr_t size,
     {
       /* Get the power-of-two for size, rounded up */
 
-      uintptr_t pot = log2ceil(size);
+      uintptr_t pot = LOG2_CEIL(size);
 
       if ((base & ((UINT64_C(1) << pot) - 1)) != 0)
         {


### PR DESCRIPTION
PMPCFG_A_TOR region may have zero size. The pmp configuration currently fails for zero-sized TOR. This patch bypasses such a restriction.

Also replace log2ceil with LOG2_CEIL from lib/math32.h.

## Summary

All risc-v TOR implementations are broken.

## Impact

Risc-v TOR implentations

## Testing

Polarfire soc