### PR TITLE
driver/sensor: Solve the busy loop problem caused by sampling problems

### DIFF
--- a/drivers/sensors/sensor.c
+++ b/drivers/sensors/sensor.c
@@ -483,6 +483,14 @@ static ssize_t sensor_do_samples(FAR struct sensor_upperhalf_s *upper,
       generation = next_generation;
     }
 
+  if (pos - 1 == end && sensor_is_updated(upper, user))
+    {
+      generation = upper->state.generation - user->state.generation +
+                   (upper->state.min_interval >> 1);
+      user->state.generation += ROUND_DOWN(generation,
+                                           user->state.interval);
+    }
+
   return ret;
 }
 


### PR DESCRIPTION


## Summary
Solve the problem that when a user modifies the sampling rate, the difference between the generation and the mainline generation may be greater than the own sampling interval.

After this problem occurs, sensor_is_update() will continue to return true, resulting in a busy loop in the upper-layer application, so, need update user generation according to mainline generation.
## Impact
fix bug
## Testing
daily test
