### PR TITLE
bcm43xxx: optimize the Bluetooth experience when Bluetooth Wi-Fi co-e…

### DIFF
--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.h
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.h
@@ -104,7 +104,11 @@ struct bcmf_dev_s
   sclock_t      lp_ticks;       /* Ticks of last tx time */
 #endif
 #ifdef CONFIG_IEEE80211_BROADCOM_PTA_PRIORITY
-  int pta_priority; /* Current priority of Packet Traffic Arbitration */
+  int pta_priority;    /* Current priority of Packet Traffic Arbitration */
+  int pta_priority_th; /* PTA WIFI threshold.
+                        * Cannot be directly set to the WLAN_MAX in some special scenarios,
+                        * otherwise the bluetooth experience will be affected.
+                        */
 #endif
 };
 

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_netdev.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_netdev.c
@@ -1010,7 +1010,7 @@ static int bcmf_ioctl(FAR struct net_driver_s *dev, int cmd,
   FAR struct bcmf_dev_s *priv = (FAR struct bcmf_dev_s *)dev->d_private;
   int ret;
 
-  if (!priv->bc_bifup)
+  if (!priv->bc_bifup && (cmd != SIOCSIWPTAPRIO && cmd != SIOCGIWPTAPRIO))
     {
       wlerr("ERROR: invalid state "
             "(IFF_DOWN, unable to execute command: %x)\n", cmd);


### PR DESCRIPTION
…xists

## Summary
In order to optimize the Bluetooth experience when Bluetooth Wi-Fi co-exists, add a record of the PTA threshold to limit antenna occupancy when Wi-Fi scans and connects, thus avoiding Bluetooth transmission delay in these cases.
## Impact

## Testing
Cortex-M55 and bcm43xxx chipset
