### PR TITLE
drivers/modem/alt1250: Fix bug that modem version could not be taken

### DIFF
--- a/drivers/modem/alt1250/altcom_cmd.h
+++ b/drivers/modem/alt1250/altcom_cmd.h
@@ -128,6 +128,8 @@
 
 #define APICMD_FW_INJECTDATA_MAXLEN                         (4096)
 #define APICMD_FW_INJECTDATA_MAXLEN_V4                      (3000)
+#define APICMD_FW_VER_BB_PRODUCT_LEN                        (5)
+#define APICMD_FW_VER_NP_PACKAGE_LEN                        (32)
 
 #define APICMD_IPV4_LEN                                     (4)
 #define APICMD_IPV6_LEN                                     (16)
@@ -811,8 +813,8 @@ begin_packed_struct struct apicmd_cmddat_setpsmres_s
 begin_packed_struct struct apicmd_cmddat_getverres_s
 {
   uint8_t result;
-  uint8_t bb_product[LTE_VER_BB_PRODUCT_LEN];
-  uint8_t np_package[LTE_VER_NP_PACKAGE_LEN];
+  uint8_t bb_product[APICMD_FW_VER_BB_PRODUCT_LEN];
+  uint8_t np_package[APICMD_FW_VER_NP_PACKAGE_LEN];
 } end_packed_struct;
 
 /* structure for APICMDID_FW_INJECTDELTAIMG */


### PR DESCRIPTION
## Summary
Fix bug that modem version could not be taken.

## Impact
Only alt1250 driver

## Testing
Test with spresense LTE board.
