### PR TITLE
sensors: add suffix _uorb to all sensors that use the new sensor framework

### DIFF
--- a/drivers/sensors/CMakeLists.txt
+++ b/drivers/sensors/CMakeLists.txt
@@ -29,12 +29,20 @@ if(CONFIG_SENSORS)
     list(APPEND SRCS sensor_rpmsg.c)
   endif()
 
+  if(CONFIG_SENSORS_GPS)
+    list(APPEND SRCS gps_uorb.c)
+  endif()
+
   if(CONFIG_SENSORS_WTGAHRS2)
-    list(APPEND SRCS wtgahrs2.c)
+    list(APPEND SRCS wtgahrs2_uorb.c)
   endif()
 
   if(CONFIG_SENSORS_FAKESENSOR)
-    list(APPEND SRCS fakesensor.c)
+    list(APPEND SRCS fakesensor_uorb.c)
+  endif()
+
+  if(CONFIG_SENSORS_GOLDFISH_GPS)
+    list(APPEND SRCS goldfish_gps_uorb.c)
   endif()
 
   if(CONFIG_SENSORS_HCSR04)
@@ -78,7 +86,7 @@ if(CONFIG_SENSORS)
     endif()
 
     if(CONFIG_SENSORS_HYT271)
-      list(APPEND SRCS hyt271.c)
+      list(APPEND SRCS hyt271_uorb.c)
     endif()
 
     if(CONFIG_SENSORS_KXTJ9)
@@ -134,11 +142,11 @@ if(CONFIG_SENSORS)
     endif()
 
     if(CONFIG_SENSORS_BMP280)
-      list(APPEND SRCS bmp280.c)
+      list(APPEND SRCS bmp280_uorb.c)
     endif()
 
     if(CONFIG_SENSORS_BME680)
-      list(APPEND SRCS bme680.c)
+      list(APPEND SRCS bme680_uorb.c)
     endif()
 
     if(CONFIG_SENSORS_ISL29023)
@@ -178,7 +186,7 @@ if(CONFIG_SENSORS)
     endif()
 
     if(CONFIG_SENSORS_MS5611)
-      list(APPEND SRCS ms5611.c)
+      list(APPEND SRCS ms5611_uorb.c)
     endif()
 
     if(CONFIG_SENSORS_MS58XX)
@@ -233,6 +241,10 @@ if(CONFIG_SENSORS)
       list(APPEND SRCS t67xx.c)
     endif()
 
+    if(CONFIG_SENSORS_LTR308)
+      list(APPEND SRCS ltr308_uorb.c)
+    endif()
+
   endif() # CONFIG_I2C
 
   # These drivers depend on SPI support
@@ -276,7 +288,7 @@ if(CONFIG_SENSORS)
     endif()
 
     if(CONFIG_SENSORS_L3GD20)
-      list(APPEND SRCS l3gd20.c)
+      list(APPEND SRCS l3gd20_uorb.c)
     endif()
 
     if(CONFIG_SENSORS_ADT7320)
@@ -294,13 +306,17 @@ if(CONFIG_SENSORS)
   if(CONFIG_1WIRE)
 
     if(CONFIG_SENSORS_DS18B20)
-      list(APPEND SRCS ds18b20.c)
+      list(APPEND SRCS ds18b20_uorb.c)
     endif()
 
   endif() # CONFIG_1WIRE
 
   if(CONFIG_SENSORS_MPU60X0)
     list(APPEND SRCS mpu60x0.c)
+  endif()
+
+  if(CONFIG_SENSORS_MPU9250)
+    list(APPEND SRCS mpu9250_uorb.c)
   endif()
 
   # Quadrature encoder upper half

--- a/drivers/sensors/Make.defs
+++ b/drivers/sensors/Make.defs
@@ -33,19 +33,19 @@ CSRCS += sensor_rpmsg.c
 endif
 
 ifeq ($(CONFIG_SENSORS_GPS),y)
-  CSRCS += gps.c
+  CSRCS += gps_uorb.c
 endif
 
 ifeq ($(CONFIG_SENSORS_WTGAHRS2),y)
-  CSRCS += wtgahrs2.c
+  CSRCS += wtgahrs2_uorb.c
 endif
 
 ifeq ($(CONFIG_SENSORS_FAKESENSOR),y)
-  CSRCS += fakesensor.c
+  CSRCS += fakesensor_uorb.c
 endif
 
 ifeq ($(CONFIG_SENSORS_GOLDFISH_GPS),y)
-  CSRCS += goldfish_gps.c
+  CSRCS += goldfish_gps_uorb.c
 endif
 
 ifeq ($(CONFIG_SENSORS_HCSR04),y)
@@ -93,7 +93,7 @@ ifeq ($(CONFIG_SENSORS_FXOS8700CQ),y)
 endif
 
 ifeq ($(CONFIG_SENSORS_HYT271),y)
-  CSRCS += hyt271.c
+  CSRCS += hyt271_uorb.c
 endif
 
 ifeq ($(CONFIG_SENSORS_KXTJ9),y)
@@ -163,11 +163,11 @@ endif
 endif
 
 ifeq ($(CONFIG_SENSORS_BMP280),y)
-  CSRCS += bmp280.c
+  CSRCS += bmp280_uorb.c
 endif
 
 ifeq ($(CONFIG_SENSORS_BME680),y)
-  CSRCS += bme680.c
+  CSRCS += bme680_uorb.c
 endif
 
 ifeq ($(CONFIG_SENSORS_ISL29023),y)
@@ -207,7 +207,7 @@ ifeq ($(CONFIG_SENSORS_MLX90614),y)
 endif
 
 ifeq ($(CONFIG_SENSORS_MS5611),y)
-  CSRCS += ms5611.c
+  CSRCS += ms5611_uorb.c
 endif
 
 ifeq ($(CONFIG_SENSORS_MS58XX),y)
@@ -263,7 +263,7 @@ ifeq ($(CONFIG_SENSORS_T67XX),y)
 endif
 
 ifeq ($(CONFIG_SENSORS_LTR308),y)
-  CSRCS += ltr308.c
+  CSRCS += ltr308_uorb.c
 endif
 
 endif # CONFIG_I2C
@@ -309,7 +309,7 @@ ifeq ($(CONFIG_SENSORS_LSM330SPI),y)
 endif
 
 ifeq ($(CONFIG_SENSORS_L3GD20),y)
-  CSRCS += l3gd20.c
+  CSRCS += l3gd20_uorb.c
 endif
 
 ifeq ($(CONFIG_SENSORS_ADT7320),y)
@@ -327,7 +327,7 @@ endif # CONFIG_SPI
 ifeq ($(CONFIG_1WIRE),y)
 
 ifeq ($(CONFIG_SENSORS_DS18B20),y)
-  CSRCS += ds18b20.c
+  CSRCS += ds18b20_uorb.c
 endif
 
 endif # CONFIG_1WIRE
@@ -337,7 +337,7 @@ ifeq ($(CONFIG_SENSORS_MPU60X0),y)
 endif
 
 ifeq ($(CONFIG_SENSORS_MPU9250),y)
-  CSRCS += mpu9250.c
+  CSRCS += mpu9250_uorb.c
 endif
 
 # Quadrature encoder upper half

--- a/drivers/sensors/bme680_uorb.c
+++ b/drivers/sensors/bme680_uorb.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * drivers/sensors/bme680.c
+ * drivers/sensors/bme680_uorb.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/drivers/sensors/bmp280_uorb.c
+++ b/drivers/sensors/bmp280_uorb.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * drivers/sensors/bmp280.c
+ * drivers/sensors/bmp280_uorb.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/drivers/sensors/ds18b20_uorb.c
+++ b/drivers/sensors/ds18b20_uorb.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * drivers/sensors/ds18b20.c
+ * drivers/sensors/ds18b20_uorb.c
  * Character driver for DS18B20 Digital Humidity and Temperature Module.
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/drivers/sensors/fakesensor_uorb.c
+++ b/drivers/sensors/fakesensor_uorb.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * drivers/sensors/fakesensor.c
+ * drivers/sensors/fakesensor_uorb.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/drivers/sensors/goldfish_gps_uorb.c
+++ b/drivers/sensors/goldfish_gps_uorb.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * drivers/sensors/goldfish_gps.c
+ * drivers/sensors/goldfish_gps_uorb.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/drivers/sensors/gps_uorb.c
+++ b/drivers/sensors/gps_uorb.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * drivers/sensors/gps.c
+ * drivers/sensors/gps_uorb.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/drivers/sensors/hyt271_uorb.c
+++ b/drivers/sensors/hyt271_uorb.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * drivers/sensors/hyt271.c
+ * drivers/sensors/hyt271_uorb.c
  * Character driver for HYT271 Digital Humidity and Temperature Module.
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/drivers/sensors/l3gd20_uorb.c
+++ b/drivers/sensors/l3gd20_uorb.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * drivers/sensors/l3gd20.c
+ * drivers/sensors/l3gd20_uorb.c
  * Character driver for the ST L3GD20 3-Axis gyroscope.
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/drivers/sensors/ltr308_uorb.c
+++ b/drivers/sensors/ltr308_uorb.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * drivers/sensors/ltr308.c
+ * drivers/sensors/ltr308_uorb.c
  * Character driver for the LTR-308ALS-01 Lite-On ambient light sensor.
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/drivers/sensors/mpu9250_uorb.c
+++ b/drivers/sensors/mpu9250_uorb.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * drivers/sensors/mpu9250.c
+ * drivers/sensors/mpu9250_uorb.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/drivers/sensors/ms5611_uorb.c
+++ b/drivers/sensors/ms5611_uorb.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * drivers/sensors/ms5611.c
+ * drivers/sensors/ms5611_uorb.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/drivers/sensors/wtgahrs2_uorb.c
+++ b/drivers/sensors/wtgahrs2_uorb.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * drivers/sensors/wtgahrs2.c
+ * drivers/sensors/wtgahrs2_uorb.c
  * Driver for the Wit-Motion WTGAHRS2 accelerometer, gyroscope, magnetic,
  * angle, barometer, temperature, gps sensors by serial interface with host
  *


### PR DESCRIPTION
## Summary
- sensors: add suffix _uorb to all sensors that use the new sensor framework
This'll make it easier to identify sensors supporting the new sensor approach

I think `_uorb` suffix isn't the best way to describe the new sensor framework, but at the moment we haven't come up with a better name.

## Impact
It's easier to distinguish which sensor supports which interface

## Testing
CI