### PR TITLE
arch/nrf{52|53|91}: fixes for serial driver

### DIFF
--- a/arch/arm/src/nrf52/nrf52_serial.c
+++ b/arch/arm/src/nrf52/nrf52_serial.c
@@ -86,7 +86,7 @@
 #ifdef CONFIG_UART0_SERIAL_CONSOLE
 #  define CONSOLE_DEV         g_uart0port /* UART0 is console */
 #  define TTYS0_DEV           g_uart0port /* UART0 is ttyS0 */
-#elif CONFIG_UART1_SERIAL_CONSOLE
+#elif defined(CONFIG_UART1_SERIAL_CONSOLE)
 #  define CONSOLE_DEV         g_uart1port /* UART1 is console */
 #  define TTYS0_DEV           g_uart1port /* UART1 is ttyS0 */
 #endif
@@ -773,10 +773,9 @@ void arm_serialinit(void)
   /* Register the serial console */
 
   uart_register("/dev/console", &CONSOLE_DEV);
-#endif
-
   uart_register("/dev/ttyS0", &TTYS0_DEV);
   minor = 1;
+#endif
 
   /* Register all remaining UARTs */
 
@@ -786,7 +785,7 @@ void arm_serialinit(void)
     {
       /* Don't create a device for non-configured ports. */
 
-      if (g_uart_devs[i] == 0)
+      if (g_uart_devs[i] == NULL)
         {
           continue;
         }

--- a/arch/arm/src/nrf52/nrf52_serial.c
+++ b/arch/arm/src/nrf52/nrf52_serial.c
@@ -856,8 +856,8 @@ int up_putc(int ch)
     }
 
   arm_lowputc(ch);
-  return ch;
 #endif
+  return ch;
 }
 
 #endif /* HAVE_UART_DEVICE && USE_SERIALDRIVER */

--- a/arch/arm/src/nrf53/nrf53_serial.c
+++ b/arch/arm/src/nrf53/nrf53_serial.c
@@ -86,7 +86,7 @@
 #ifdef CONFIG_UART0_SERIAL_CONSOLE
 #  define CONSOLE_DEV         g_uart0port /* UART0 is console */
 #  define TTYS0_DEV           g_uart0port /* UART0 is ttyS0 */
-#elif CONFIG_UART1_SERIAL_CONSOLE
+#elif defined(CONFIG_UART1_SERIAL_CONSOLE)
 #  define CONSOLE_DEV         g_uart1port /* UART1 is console */
 #  define TTYS0_DEV           g_uart1port /* UART1 is ttyS0 */
 #endif
@@ -773,10 +773,9 @@ void arm_serialinit(void)
   /* Register the serial console */
 
   uart_register("/dev/console", &CONSOLE_DEV);
-#endif
-
   uart_register("/dev/ttyS0", &TTYS0_DEV);
   minor = 1;
+#endif
 
   /* Register all remaining UARTs */
 
@@ -786,7 +785,7 @@ void arm_serialinit(void)
     {
       /* Don't create a device for non-configured ports. */
 
-      if (g_uart_devs[i] == 0)
+      if (g_uart_devs[i] == NULL)
         {
           continue;
         }

--- a/arch/arm/src/nrf53/nrf53_serial.c
+++ b/arch/arm/src/nrf53/nrf53_serial.c
@@ -856,8 +856,8 @@ int up_putc(int ch)
     }
 
   arm_lowputc(ch);
-  return ch;
 #endif
+  return ch;
 }
 
 #endif /* HAVE_UART_DEVICE && USE_SERIALDRIVER */

--- a/arch/arm/src/nrf91/nrf91_serial.c
+++ b/arch/arm/src/nrf91/nrf91_serial.c
@@ -86,7 +86,7 @@
 #ifdef CONFIG_UART0_SERIAL_CONSOLE
 #  define CONSOLE_DEV         g_uart0port /* UART0 is console */
 #  define TTYS0_DEV           g_uart0port /* UART0 is ttyS0 */
-#elif CONFIG_UART1_SERIAL_CONSOLE
+#elif defined(CONFIG_UART1_SERIAL_CONSOLE)
 #  define CONSOLE_DEV         g_uart1port /* UART1 is console */
 #  define TTYS0_DEV           g_uart1port /* UART1 is ttyS0 */
 #endif
@@ -773,10 +773,9 @@ void arm_serialinit(void)
   /* Register the serial console */
 
   uart_register("/dev/console", &CONSOLE_DEV);
-#endif
-
   uart_register("/dev/ttyS0", &TTYS0_DEV);
   minor = 1;
+#endif
 
   /* Register all remaining UARTs */
 
@@ -786,7 +785,7 @@ void arm_serialinit(void)
     {
       /* Don't create a device for non-configured ports. */
 
-      if (g_uart_devs[i] == 0)
+      if (g_uart_devs[i] == NULL)
         {
           continue;
         }

--- a/arch/arm/src/nrf91/nrf91_serial.c
+++ b/arch/arm/src/nrf91/nrf91_serial.c
@@ -856,8 +856,8 @@ int up_putc(int ch)
     }
 
   arm_lowputc(ch);
-  return ch;
 #endif
+  return ch;
 }
 
 #endif /* HAVE_UART_DEVICE && USE_SERIALDRIVER */


### PR DESCRIPTION
## Summary

- arch/nrf{52|53|91}/serial: fix warning if HAVE_UART_CONSOLE not defined
   warning: control reaches end of non-void function [-Wreturn-type]
- arch/nrf{52|53|91}/serial: fix serial registration when ther is no console on serial

## Impact

## Testing
thingy91
