### PR TITLE
Regulator:fix some issues about rpmsg regualtor

### DIFF
--- a/drivers/power/supply/regulator.c
+++ b/drivers/power/supply/regulator.c
@@ -217,14 +217,6 @@ static FAR struct regulator_dev_s *regulator_dev_lookup(const char *supply)
     }
 
   regulator_unlock(&g_reg_lock, flags);
-
-#if defined(CONFIG_REGULATOR_RPMSG)
-  if (rdev_found == NULL && strchr(supply, '/'))
-    {
-      rdev_found = regulator_rpmsg_get(supply);
-    }
-#endif
-
   return rdev_found;
 }
 
@@ -569,6 +561,14 @@ FAR struct regulator_s *regulator_get(FAR const char *id)
     }
 
   rdev = regulator_dev_lookup(id);
+
+#if defined(CONFIG_REGULATOR_RPMSG)
+  if (rdev == NULL && strchr(id, '/'))
+    {
+      rdev = regulator_rpmsg_get(id);
+    }
+#endif
+
   if (rdev == NULL)
     {
       pwrerr("regulator %s not found\n", id);


### PR DESCRIPTION
## Summary
1.fix regulator_register check rpmsg regulator which leads to recursion.
2.client get the regualtor which is enabled by server, will disable the regualtor.
3.regulator_rpmsg_server_unbind will disable regualtor which maybe used by other client.
4.regulator_rpmsg_server_unbind will be deadloop when the regulator is always_on;
5.regulator_rpmsg_client_destroy does not match server cpu name,may destory by stop other rptun dev
## Impact

## Testing
self test
