### PR TITLE
clk:fix some issues when use rpmsg clk

### DIFF
--- a/drivers/clk/clk_mux.c
+++ b/drivers/clk/clk_mux.c
@@ -85,8 +85,8 @@ static int clk_mux_set_parent(FAR struct clk_s *clk, uint8_t index)
 
 static uint32_t
 clk_mux_determine_rate(FAR struct clk_s *clk, uint32_t rate,
-                       uint32_t *best_parent_rate,
-                       struct clk_s **best_parent_p)
+                       FAR uint32_t *best_parent_rate,
+                       FAR struct clk_s **best_parent_p)
 {
   FAR struct clk_mux_s *mux = to_clk_mux(clk);
   FAR struct clk_s *parent;
@@ -173,7 +173,7 @@ const struct clk_ops_s g_clk_mux_ro_ops =
  ****************************************************************************/
 
 FAR struct clk_s *clk_register_mux(FAR const char *name,
-                                   const char * const *parent_names,
+                                   FAR const char * const *parent_names,
                                    uint8_t num_parents,
                                    uint8_t flags, uint32_t reg,
                                    uint8_t shift, uint8_t width,

--- a/include/nuttx/clk/clk_provider.h
+++ b/include/nuttx/clk/clk_provider.h
@@ -114,10 +114,10 @@ struct clk_ops_s
   CODE int       (*is_enabled)(FAR struct clk_s *clk);
   CODE uint32_t  (*recalc_rate)(FAR struct clk_s *clk, uint32_t parent_rate);
   CODE uint32_t  (*round_rate)(FAR struct clk_s *clk,
-                               uint32_t rate, uint32_t *parent_rate);
+                               uint32_t rate, FAR uint32_t *parent_rate);
   CODE uint32_t  (*determine_rate)(FAR struct clk_s *clk, uint32_t rate,
-                                   uint32_t *best_parent_rate,
-                                   struct clk_s **best_parent_clk);
+                                   FAR uint32_t *best_parent_rate,
+                                   FAR struct clk_s **best_parent_clk);
   CODE int       (*set_parent)(FAR struct clk_s *clk, uint8_t index);
   CODE uint8_t   (*get_parent)(FAR struct clk_s *clk);
   CODE int       (*set_rate)(FAR struct clk_s *clk, uint32_t rate,
@@ -243,7 +243,7 @@ FAR struct clk_s *clk_register_multiplier(FAR const char *name,
                                           uint8_t clk_multiplier_flags);
 
 FAR struct clk_s *clk_register_mux(FAR const char *name,
-                                   const char * const *parent_names,
+                                   FAR const char * const *parent_names,
                                    uint8_t num_parents, uint8_t flags,
                                    uint32_t reg, uint8_t shift,
                                    uint8_t width, uint8_t clk_mux_flags);


### PR DESCRIPTION
## Summary
1.check the rpmsg name when clk_register.
2.clk_get rpmsg clk print error:
clk/clk.c:1231:3: runtime error: null pointer passed as argument 2, which is declared to never be null 
3.fix some function miss keyword FAR.
4.clk_disable_unused may disable rpmsg clk which disable the clk that maybe used by others

## Impact
rpmsg clk

## Testing
self test