### PR TITLE
debug: add support for IPC (interprocessor communication) debug messages

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -2078,6 +2078,37 @@ config DEBUG_RESET_INFO
 
 endif # DEBUG_RESET
 
+config DEBUG_IPC
+	bool "IPC (Interprocessor communication) Debug Features"
+	default n
+	---help---
+		Enable IPC debug features.
+
+if DEBUG_IPC
+
+config DEBUG_IPC_ERROR
+	bool "IPC Error Output"
+	default n
+	depends on DEBUG_ERROR
+	---help---
+		Enable IPC error output to SYSLOG.
+
+config DEBUG_IPC_WARN
+	bool "IPC Warnings Output"
+	default n
+	depends on DEBUG_WARN
+	---help---
+		Enable IPC warning output to SYSLOG.
+
+config DEBUG_IPC_INFO
+	bool "IPC Informational Output"
+	default n
+	depends on DEBUG_INFO
+	---help---
+		Enable IPC informational output to SYSLOG.
+
+endif # DEBUG_IPC
+
 endif # DEBUG_FEATURES
 
 config ARCH_HAVE_STACKCHECK

--- a/arch/arm/src/nrf53/nrf53_ipc.c
+++ b/arch/arm/src/nrf53/nrf53_ipc.c
@@ -79,7 +79,7 @@ static int nrf53_ipc_interrupt(int irq, void *context, void *args)
 
   regval = getreg32(NRF53_IPC_INTPEND);
 
-  _info("IPC interrupt 0x%" PRIx32 "\n", regval);
+  ipcinfo("IPC interrupt 0x%" PRIx32 "\n", regval);
 
   for (i = 0; i < NRF53_IPC_CHANS; i += 1)
     {
@@ -113,7 +113,7 @@ void nrf53_ipc_subscribe(int id, ipc_callback_t callback, void *args)
 
   DEBUGASSERT(id < NRF53_IPC_CHANS);
 
-  _info("IPC subscribe %d\n", id);
+  ipcinfo("IPC subscribe %d\n", id);
 
   /* Register callaback */
 
@@ -143,7 +143,7 @@ void nrf53_ipc_signal(int id)
 {
   DEBUGASSERT(id < NRF53_IPC_CHANS);
 
-  _info("IPC signal %d\n", id);
+  ipcinfo("IPC signal %d\n", id);
 
   putreg32(1, NRF53_IPC_TASKS_SEND(id));
 }
@@ -156,7 +156,7 @@ void nrf53_ipc_send_cfg(int id)
 {
   DEBUGASSERT(id < NRF53_IPC_CHANS);
 
-  _info("IPC send cfg %d\n", id);
+  ipcinfo("IPC send cfg %d\n", id);
 
   /* Enable send event on a single IPC channel */
 

--- a/arch/arm/src/nrf53/nrf53_rptun.c
+++ b/arch/arm/src/nrf53/nrf53_rptun.c
@@ -365,7 +365,7 @@ static void nrf53_rptun_panic(struct rptun_dev_s *dev)
 
 static void nrf53_ipc_master_callback(int id, void *arg)
 {
-  _info("Rptun IPC master %d\n", id);
+  ipcinfo("Rptun IPC master %d\n", id);
 
   switch (id)
     {
@@ -404,7 +404,7 @@ static void nrf53_rptun_ipc_app(struct nrf53_rptun_dev_s *dev)
 
 static void nrf53_ipc_slave_callback(int id, void *arg)
 {
-  _info("Rptun IPC slave %d\n", id);
+  ipcinfo("Rptun IPC slave %d\n", id);
 
   switch (id)
     {
@@ -516,7 +516,7 @@ int nrf53_rptun_init(const char *shmemname, const char *cpuname)
   ret = rptun_initialize(&dev->rptun);
   if (ret < 0)
     {
-      _err("ERROR: rptun_initialize failed %d!\n", ret);
+      ipcerr("ERROR: rptun_initialize failed %d!\n", ret);
       goto errout;
     }
 
@@ -526,7 +526,7 @@ int nrf53_rptun_init(const char *shmemname, const char *cpuname)
                        CONFIG_RPTUN_STACKSIZE, nrf53_rptun_thread, NULL);
   if (ret < 0)
     {
-      _err("ERROR: kthread_create failed %d\n", ret);
+      ipcerr("ERROR: kthread_create failed %d\n", ret);
     }
 
 errout:

--- a/arch/arm/src/stm32h7/stm32_hsem.c
+++ b/arch/arm/src/stm32h7/stm32_hsem.c
@@ -74,7 +74,7 @@ static int stm32_hsem_interrupt(int irq, void *context, void *args)
 
   regval = getreg32(STM32_HSEM_CXMISR(dev->block));
 
-  _info("HSEM interrupt 0x%" PRIx32 "\n", regval);
+  ipcinfo("HSEM interrupt 0x%" PRIx32 "\n", regval);
 
   for (i = 0; i < STM32_HSEM_CHANS; i++)
     {
@@ -112,7 +112,7 @@ void stm32_hsem_subscribe(uint8_t id, hsem_callback_t callback, void *args)
 
   DEBUGASSERT(id < STM32_HSEM_CHANS);
 
-  _info("HSEM subscribe %d\n", id);
+  ipcinfo("HSEM subscribe %d\n", id);
 
   /* Register callaback */
 
@@ -149,7 +149,7 @@ void stm32_hsem_signal(uint8_t id)
 {
   DEBUGASSERT(id < STM32_HSEM_CHANS);
 
-  _info("HSEM signal %d\n", id);
+  ipcinfo("HSEM signal %d\n", id);
 
   /* Lock semaphore */
 
@@ -172,7 +172,7 @@ void stm32_hsem_busywait_lock(uint8_t id)
 {
   DEBUGASSERT(id < STM32_HSEM_CHANS);
 
-  _info("HSEM busywait lock %d\n", id);
+  ipcinfo("HSEM busywait lock %d\n", id);
 
   /* Wait for semaphore lock */
 
@@ -191,7 +191,7 @@ void stm32_hsem_busywait_free(uint8_t id)
 {
   DEBUGASSERT(id < STM32_HSEM_CHANS);
 
-  _info("HSEM busywait free %d\n", id);
+  ipcinfo("HSEM busywait free %d\n", id);
 
   /* Wait for semaphore free */
 
@@ -210,7 +210,7 @@ void stm32_hsem_wait_take(uint8_t id)
 {
   DEBUGASSERT(id < STM32_HSEM_CHANS);
 
-  _info("HSEM wait take %d\n", id);
+  ipcinfo("HSEM wait take %d\n", id);
 
   stm32_hsem_busywait_free(id);
   while (stm32_hsem_take(id) == 0);
@@ -228,7 +228,7 @@ bool stm32_hsem_take(uint8_t id)
 {
   DEBUGASSERT(id < STM32_HSEM_CHANS);
 
-  _info("HSEM take %d\n", id);
+  ipcinfo("HSEM take %d\n", id);
 
   /* Take semaphore */
 

--- a/arch/arm/src/stm32h7/stm32_rptun.c
+++ b/arch/arm/src/stm32h7/stm32_rptun.c
@@ -363,7 +363,7 @@ static void stm32_rptun_panic(struct rptun_dev_s *dev)
 
 static void stm32_hsem_master_callback(uint8_t id, void *arg)
 {
-  _info("Rptun HSEM master %d\n", id);
+  ipcinfo("Rptun HSEM master %d\n", id);
 
   switch (id)
     {
@@ -399,7 +399,7 @@ static void stm32_rptun_hsem_cm7(struct stm32_rptun_dev_s *dev)
 
 static void stm32_hsem_slave_callback(uint8_t id, void *arg)
 {
-  _info("Rptun HSEM slave %d\n", id);
+  ipcinfo("Rptun HSEM slave %d\n", id);
 
   switch (id)
     {
@@ -510,7 +510,7 @@ int stm32_rptun_init(const char *shmemname, const char *cpuname)
   ret = rptun_initialize(&dev->rptun);
   if (ret < 0)
     {
-      _err("ERROR: rptun_initialize failed %d!\n", ret);
+      ipcerr("ERROR: rptun_initialize failed %d!\n", ret);
       goto errout;
     }
 
@@ -520,7 +520,7 @@ int stm32_rptun_init(const char *shmemname, const char *cpuname)
                        CONFIG_RPTUN_STACKSIZE, stm32_rptun_thread, NULL);
   if (ret < 0)
     {
-      _err("ERROR: kthread_create failed %d\n", ret);
+      ipcerr("ERROR: kthread_create failed %d\n", ret);
     }
 
 errout:

--- a/include/debug.h
+++ b/include/debug.h
@@ -866,6 +866,24 @@
 #  define rstinfo     _none
 #endif
 
+#ifdef CONFIG_DEBUG_IPC_ERROR
+#  define ipcerr       _err
+#else
+#  define ipcerr      _none
+#endif
+
+#ifdef CONFIG_DEBUG_IPC_WARN
+#  define ipcwarn     _warn
+#else
+#  define ipcwarn     _none
+#endif
+
+#ifdef CONFIG_DEBUG_IPC_INFO
+#  define ipcinfo     _info
+#else
+#  define ipcinfo     _none
+#endif
+
 /* Buffer dumping macros do not depend on varargs */
 
 #ifdef CONFIG_DEBUG_ERROR


### PR DESCRIPTION
## Summary
debug: add support for IPC (interprocessor communication) debug messages

I'm not sure if IPC is a good name since this name is used for various things (inter-process communication, inter-processor communication, inter-partition communication and probably more). If anyone has a better idea for a name, I can change it.

## Impact

## Testing
CI
