### PR TITLE
dns: fix dns failed when ipv4/6 dual stack enable

### DIFF
--- a/libs/libc/netdb/lib_dnsquery.c
+++ b/libs/libc/netdb/lib_dnsquery.c
@@ -712,6 +712,11 @@ static int dns_query_callback(FAR void *arg, FAR struct sockaddr *addr,
             {
               /* Obtain the IPv4 response */
 
+              if (next >= *query->naddr)
+                {
+                  next = *query->naddr / 2;
+                }
+
               ret = dns_recv_response(sd, &query->addr[next],
                                       *query->naddr - next, &qdata->qinfo,
                                       &query->ttl, qdata->buffer);

--- a/libs/libc/netdb/lib_gethostentbynamer.c
+++ b/libs/libc/netdb/lib_gethostentbynamer.c
@@ -502,15 +502,15 @@ static int lib_dns_lookup(FAR const char *name, FAR struct hostent_s *host,
 
   naddr = (buflen - (namelen + 1)) / sizeof(union dns_addr_u);
   DEBUGASSERT(naddr >= 1);
+
+  /* We can read more than maximum, limit here. */
+
+  naddr = MIN(naddr, CONFIG_NETDB_MAX_IPADDR);
   ret = lib_dns_query(name, (FAR union dns_addr_u *)ptr, &naddr);
   if (ret < 0)
     {
       return ret;
     }
-
-  /* We can read more than maximum, limit here. */
-
-  naddr = MIN(naddr, CONFIG_NETDB_MAX_IPADDR);
 
   for (i = 0; i < naddr; i++)
     {


### PR DESCRIPTION
## Summary
when ipv6 address filled the cache, the ipv4 address did not have a place to store it, causing the resolution to fail. so if IPV6 has already filled the buffer, rewrite ipv4 DNS results from half of the buffer.
## Impact

## Testing
sim:local
