### PR TITLE
refine: set file mode when oflags contains O_CREAT

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_nxaudio_src.c
+++ b/arch/arm/src/cxd56xx/cxd56_nxaudio_src.c
@@ -446,8 +446,10 @@ int cxd56_src_init(struct cxd56_dev_s *dev,
 #ifdef DUMP_DATA
   nx_unlink(dump_name_pre);
   nx_unlink(dump_name_post);
-  file_open(&dump_file_pre, dump_name_pre, O_WRONLY | O_CREAT | O_APPEND);
-  file_open(&dump_file_post, dump_name_post, O_WRONLY | O_CREAT | O_APPEND);
+  file_open(&dump_file_pre, dump_name_pre, O_WRONLY | O_CREAT | O_APPEND,
+            0666);
+  file_open(&dump_file_post, dump_name_post, O_WRONLY | O_CREAT | O_APPEND,
+            0666);
 #endif
 
   /* Join any old worker threads to prevent memory leaks */

--- a/net/utils/net_snoop.c
+++ b/net/utils/net_snoop.c
@@ -361,7 +361,8 @@ int snoop_open(FAR struct snoop_s *snoop, FAR const char *filename,
         }
     }
 
-  ret = file_open(&snoop->filep, filename, O_RDWR | O_CREAT | O_CLOEXEC);
+  ret = file_open(&snoop->filep, filename, O_RDWR | O_CREAT | O_CLOEXEC,
+                  0666);
   if (ret < 0)
     {
       return ret;


### PR DESCRIPTION
to avoid opend files have random permission mode
