### PR TITLE
Unix.mk:replace process substitution to pipe avoid out of order

### DIFF
--- a/tools/Unix.mk
+++ b/tools/Unix.mk
@@ -648,7 +648,7 @@ else
                               rm kwarning; \
                           fi
   MODULE_WARNING        = "warning: the 'modules' option is not supported"
-  PURGE_MODULE_WARNING  = 2> >(grep -v ${MODULE_WARNING} | tee kwarning) && ${KCONFIG_WARNING}
+  PURGE_MODULE_WARNING  = 2>&1 >/dev/null | grep -v ${MODULE_WARNING} | tee kwarning && ${KCONFIG_WARNING}
   KCONFIG_OLDCONFIG     = oldconfig ${PURGE_MODULE_WARNING}
   KCONFIG_OLDDEFCONFIG  = olddefconfig ${PURGE_MODULE_WARNING}
   KCONFIG_MENUCONFIG    = menuconfig ${PURGE_MODULE_WARNING}


### PR DESCRIPTION
## Summary
process substitution `>(..)` have different behaviors in different shells
unreliable execution order will lead to the problem of being unable to intercept errors. 
pipe are used here to ensure that `kwarning` is generated before the if statement.
## Impact
kconfig warning
## Testing
use CI build to test with and without kconfig warning separately.
