### PR TITLE
Revert "enable O_CLOEXEC explicit"

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_gnss.c
+++ b/arch/arm/src/cxd56xx/cxd56_gnss.c
@@ -914,7 +914,7 @@ static int cxd56_gnss_save_backup_data(struct file *filep,
     }
 
   n = file_open(&file, CONFIG_CXD56_GNSS_BACKUP_FILENAME,
-                O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC);
+                O_WRONLY | O_CREAT | O_TRUNC);
   if (n < 0)
     {
       kmm_free(buf);
@@ -2333,8 +2333,7 @@ static void cxd56_gnss_read_backup_file(int *retval)
       goto err;
     }
 
-  ret = file_open(&file, CONFIG_CXD56_GNSS_BACKUP_FILENAME,
-                  O_RDONLY | O_CLOEXEC);
+  ret = file_open(&file, CONFIG_CXD56_GNSS_BACKUP_FILENAME, O_RDONLY);
   if (ret < 0)
     {
       kmm_free(buf);
@@ -2490,8 +2489,7 @@ static void cxd56_gnss_default_sighandler(uint32_t data, void *userdata)
           file_close(&priv->cepfp);
         }
 
-      file_open(&priv->cepfp, CONFIG_CXD56_GNSS_CEP_FILENAME,
-                O_RDONLY | O_CLOEXEC);
+      file_open(&priv->cepfp, CONFIG_CXD56_GNSS_CEP_FILENAME, O_RDONLY);
       return;
 
     case CXD56_GNSS_NOTIFY_TYPE_REQCEPCLOSE:

--- a/arch/arm/src/lc823450/lc823450_ipl2.c
+++ b/arch/arm/src/lc823450/lc823450_ipl2.c
@@ -187,7 +187,7 @@ static int install_recovery(const char *srcpath)
       return -1;
     }
 
-  ret = file_open(&rfile, srcpath, O_RDONLY | O_CLOEXEC, 0444);
+  ret = file_open(&rfile, srcpath, O_RDONLY, 0444);
 
   if (file_read(&rfile, &upg_image, sizeof(upg_image)) != sizeof(upg_image))
     {

--- a/arch/arm/src/rtl8720c/ameba_hci.c
+++ b/arch/arm/src/rtl8720c/ameba_hci.c
@@ -389,7 +389,7 @@ static int hci_open(struct file *filep)
   hci_dev_t *dev = inode->i_private;
   int ret;
   ret = file_open(&dev->filep,
-                  CONFIG_AMEBA_HCI_DEV_NAME, O_RDWR | O_CLOEXEC);
+                  CONFIG_AMEBA_HCI_DEV_NAME, O_RDWR);
   if (ret < 0)
     {
       return ret;

--- a/binfmt/libelf/libelf_init.c
+++ b/binfmt/libelf/libelf_init.c
@@ -127,7 +127,7 @@ int elf_init(FAR const char *filename, FAR struct elf_loadinfo_s *loadinfo)
 
   /* Open the binary file for reading (only) */
 
-  ret = file_open(&loadinfo->file, filename, O_RDONLY | O_CLOEXEC);
+  ret = file_open(&loadinfo->file, filename, O_RDONLY);
   if (ret < 0)
     {
       berr("Failed to open ELF binary %s: %d\n", filename, ret);

--- a/binfmt/libnxflat/libnxflat_init.c
+++ b/binfmt/libnxflat/libnxflat_init.c
@@ -96,7 +96,7 @@ int nxflat_init(const char *filename, struct nxflat_loadinfo_s *loadinfo)
 
   /* Open the binary file */
 
-  ret = file_open(&loadinfo->file, filename, O_RDONLY | O_CLOEXEC);
+  ret = file_open(&loadinfo->file, filename, O_RDONLY);
   if (ret < 0)
     {
       berr("ERROR: Failed to open NXFLAT binary %s: %d\n", filename, ret);

--- a/drivers/bch/bchdev_unregister.c
+++ b/drivers/bch/bchdev_unregister.c
@@ -70,7 +70,7 @@ int bchdev_unregister(FAR const char *chardev)
 
   /* Open the character driver associated with chardev */
 
-  ret = file_open(&filestruct, chardev, O_RDONLY | O_CLOEXEC);
+  ret = file_open(&filestruct, chardev, O_RDONLY);
   if (ret < 0)
     {
       _err("ERROR: Failed to open %s: %d\n", chardev, ret);

--- a/drivers/loop/losetup.c
+++ b/drivers/loop/losetup.c
@@ -372,7 +372,7 @@ int losetup(FAR const char *devname, FAR const char *filename,
   ret = -ENOSYS;
   if (!readonly)
     {
-      ret = file_open(&dev->devfile, filename, O_RDWR | O_CLOEXEC);
+      ret = file_open(&dev->devfile, filename, O_RDWR);
     }
 
   if (ret >= 0)
@@ -383,7 +383,7 @@ int losetup(FAR const char *devname, FAR const char *filename,
     {
       /* If that fails, then try to open the device read-only */
 
-      ret = file_open(&dev->devfile, filename, O_RDONLY | O_CLOEXEC);
+      ret = file_open(&dev->devfile, filename, O_RDONLY);
       if (ret < 0)
         {
           ferr("ERROR: Failed to open %s: %d\n", filename, ret);

--- a/drivers/mtd/filemtd.c
+++ b/drivers/mtd/filemtd.c
@@ -749,7 +749,7 @@ FAR struct mtd_dev_s *filemtd_initialize(FAR const char *path, size_t offset,
 
   /* Set the file open mode. */
 
-  mode = O_RDOK | O_WROK | O_CLOEXEC;
+  mode = O_RDOK | O_WROK;
 
   /* Try to open the file.  NOTE that block devices will use a character
    * driver proxy.

--- a/drivers/mtd/mtd_config.c
+++ b/drivers/mtd/mtd_config.c
@@ -37,7 +37,6 @@
 #include <stdbool.h>
 #include <string.h>
 #include <poll.h>
-#include <fcntl.h>
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
@@ -1802,7 +1801,7 @@ int mtdconfig_unregister(void)
   FAR struct inode *inode;
   FAR struct mtdconfig_struct_s *dev;
 
-  ret = file_open(&file, "/dev/config", O_CLOEXEC);
+  ret = file_open(&file, "/dev/config", 0);
   if (ret < 0)
     {
       ferr("ERROR: open /dev/config failed: %d\n", ret);

--- a/drivers/mtd/mtd_config_fs.c
+++ b/drivers/mtd/mtd_config_fs.c
@@ -2081,7 +2081,7 @@ int mtdconfig_unregister_by_path(FAR const char *path)
   FAR struct inode *inode;
   FAR struct nvs_fs *fs;
 
-  ret = file_open(&file, path, O_CLOEXEC);
+  ret = file_open(&file, path, 0);
   if (ret < 0)
     {
       ferr("ERROR: open file %s err: %d\n", path, ret);

--- a/drivers/net/slip.c
+++ b/drivers/net/slip.c
@@ -997,7 +997,8 @@ int slip_initialize(int intf, FAR const char *devname)
   self->dev.d_txavail = slip_txavail; /* New TX data callback */
   self->dev.d_private = self;         /* Used to recover SLIP I/F instance */
 
-  ret = file_open(&self->tty, devname, O_RDWR | O_NONBLOCK | O_CLOEXEC);
+  ret = file_open(&self->tty, devname, O_RDWR | O_NONBLOCK);
+
   if (ret < 0)
     {
       nerr("ERROR: Failed to open %s: %d\n", devname, ret);

--- a/drivers/rptun/rptun.c
+++ b/drivers/rptun/rptun.c
@@ -870,7 +870,7 @@ static int rptun_store_open(FAR void *store_,
   int len = 0x100;
   int ret;
 
-  ret = file_open(&store->file, path, O_RDONLY | O_CLOEXEC);
+  ret = file_open(&store->file, path, O_RDONLY);
   if (ret < 0)
     {
       return ret;

--- a/drivers/sensors/fakesensor_uorb.c
+++ b/drivers/sensors/fakesensor_uorb.c
@@ -317,8 +317,7 @@ static int fakesensor_thread(int argc, char** argv)
 
       /* Open csv file and init file handle */
 
-      ret = file_open(&sensor->data, sensor->file_path,
-                      O_RDONLY | O_CLOEXEC);
+      ret = file_open(&sensor->data, sensor->file_path, O_RDONLY);
       if (ret < 0)
         {
           snerr("Failed to open file:%s, err:%d", sensor->file_path, ret);

--- a/drivers/sensors/goldfish_gps_uorb.c
+++ b/drivers/sensors/goldfish_gps_uorb.c
@@ -192,8 +192,7 @@ int goldfish_gps_init(int devno, uint32_t batch_number)
       return -ENOMEM;
     }
 
-  ret = goldfish_gps_open_pipe(&gps->pipe, "qemud", "gps",
-                               O_RDWR | O_CLOEXEC);
+  ret = goldfish_gps_open_pipe(&gps->pipe, "qemud", "gps", O_RDWR);
   if (ret < 0)
     {
       kmm_free(gps);

--- a/drivers/sensors/sensor_rpmsg.c
+++ b/drivers/sensors/sensor_rpmsg.c
@@ -468,7 +468,7 @@ sensor_rpmsg_alloc_proxy(FAR struct sensor_rpmsg_dev_s *dev,
 
   proxy->ept = ept;
   proxy->cookie = msg->cookie;
-  ret = file_open(&file, dev->path, SENSOR_REMOTE | O_CLOEXEC);
+  ret = file_open(&file, dev->path, SENSOR_REMOTE);
   if (ret < 0)
     {
       kmm_free(proxy);
@@ -537,7 +537,7 @@ sensor_rpmsg_alloc_stub(FAR struct sensor_rpmsg_dev_s *dev,
   stub->ept = ept;
   stub->cookie = cookie;
   ret = file_open(&stub->file, dev->path,
-                  O_RDOK | O_NONBLOCK | O_CLOEXEC | SENSOR_REMOTE);
+                  O_RDOK | O_NONBLOCK | SENSOR_REMOTE);
   if (ret < 0)
     {
       kmm_free(stub);
@@ -1081,7 +1081,7 @@ static int sensor_rpmsg_publish_handler(FAR struct rpmsg_endpoint *ept,
           struct file file;
           int ret;
 
-          ret = file_open(&file, dev->path, SENSOR_REMOTE | O_CLOEXEC);
+          ret = file_open(&file, dev->path, SENSOR_REMOTE);
           if (ret >= 0)
             {
               file_ioctl(&file, SNIOC_SET_BUFFER_NUMBER, cell->nbuffer);

--- a/drivers/sensors/wtgahrs2_uorb.c
+++ b/drivers/sensors/wtgahrs2_uorb.c
@@ -453,7 +453,7 @@ int wtgahrs2_initialize(FAR const char *path, int devno)
 
   /* Open serial tty port and set baud rate */
 
-  ret = file_open(&rtdata->file, path, O_RDWR | O_CLOEXEC);
+  ret = file_open(&rtdata->file, path, O_RDWR);
   if (ret < 0)
     {
       snerr("Failed to open wtgahrs2 serial:%s, err:%d", path, ret);

--- a/drivers/serial/ptmx.c
+++ b/drivers/serial/ptmx.c
@@ -204,7 +204,7 @@ static int ptmx_open(FAR struct file *filep)
 
   snprintf(devname, sizeof(devname), "/dev/pty%d", minor);
   memcpy(&temp, filep, sizeof(temp));
-  ret = file_open(filep, devname, O_RDWR | O_CLOEXEC);
+  ret = file_open(filep, devname, O_RDWR);
   DEBUGASSERT(ret >= 0);  /* file_open() should never fail */
 
   /* Close the multiplexor device: /dev/ptmx */

--- a/drivers/serial/pty.c
+++ b/drivers/serial/pty.c
@@ -34,7 +34,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <poll.h>
-#include <fcntl.h>
 #include <assert.h>
 #include <errno.h>
 
@@ -202,7 +201,7 @@ static int pty_pipe(FAR struct pty_devpair_s *devpair)
   pipe_a[0] = &devpair->pp_master.pd_src;
   pipe_a[1] = &devpair->pp_slave.pd_sink;
 
-  ret = file_pipe(pipe_a, CONFIG_PSEUDOTERM_TXBUFSIZE, O_CLOEXEC);
+  ret = file_pipe(pipe_a, CONFIG_PSEUDOTERM_TXBUFSIZE, 0);
   if (ret < 0)
     {
       return ret;
@@ -211,7 +210,7 @@ static int pty_pipe(FAR struct pty_devpair_s *devpair)
   pipe_b[0] = &devpair->pp_slave.pd_src;
   pipe_b[1] = &devpair->pp_master.pd_sink;
 
-  ret = file_pipe(pipe_b, CONFIG_PSEUDOTERM_RXBUFSIZE, O_CLOEXEC);
+  ret = file_pipe(pipe_b, CONFIG_PSEUDOTERM_RXBUFSIZE, 0);
   if (ret < 0)
     {
       file_close(pipe_a[0]);

--- a/drivers/syslog/syslog_filechannel.c
+++ b/drivers/syslog/syslog_filechannel.c
@@ -58,7 +58,7 @@ static void log_separate(FAR const char *log_file)
 {
   struct file fp;
 
-  if (file_open(&fp, log_file, (O_WRONLY | O_APPEND | O_CLOEXEC)) < 0)
+  if (file_open(&fp, log_file, (O_WRONLY | O_APPEND)) < 0)
     {
       return;
     }

--- a/drivers/video/goldfish_camera.c
+++ b/drivers/video/goldfish_camera.c
@@ -301,7 +301,7 @@ static ssize_t goldfish_camera_get_list(FAR goldfish_camera_priv_t **priv,
 
   ret = file_open(&file,
                   CONFIG_GOLDFISH_CAMERA_PIPE_PATH,
-                  O_RDWR | O_CLOEXEC);
+                  O_RDWR);
   if (ret < 0)
     {
       verr("Failed to open: %s: %d\n",
@@ -570,7 +570,7 @@ static int goldfish_camera_data_init(FAR struct imgdata_s *data)
 
   ret = file_open(&priv->file,
                   CONFIG_GOLDFISH_CAMERA_PIPE_PATH,
-                  O_RDWR | O_CLOEXEC);
+                  O_RDWR);
   if (ret < 0)
     {
       verr("Failed to open: %s: %d\n",

--- a/drivers/wireless/bluetooth/bt_uart_shim.c
+++ b/drivers/wireless/bluetooth/bt_uart_shim.c
@@ -359,7 +359,7 @@ FAR struct btuart_lowerhalf_s *btuart_shim_getdevice(FAR const char *path)
 
   s = &n->state;
 
-  ret = file_open(&s->f, path, O_RDWR | O_CLOEXEC);
+  ret = file_open(&s->f, path, O_RDWR);
   if (ret < 0)
     {
       kmm_free(n);

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_core.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_core.c
@@ -247,7 +247,7 @@ int bcmf_upload_file(FAR bcmf_interface_dev_t *ibus, uint32_t address,
 
   /* Open the file in the detached state */
 
-  ret = file_open(&finfo, path, O_RDONLY | O_CLOEXEC);
+  ret = file_open(&finfo, path, O_RDONLY);
   if (ret < 0)
     {
       wlerr("ERROR: Failed to open the FILE MTD file %s: %d\n", path, ret);
@@ -345,7 +345,7 @@ int bcmf_upload_nvram(FAR bcmf_interface_dev_t *ibus)
       goto out;
     }
 
-  ret = file_open(&finfo, nvfile, O_RDONLY | O_CLOEXEC);
+  ret = file_open(&finfo, nvfile, O_RDONLY);
   if (ret < 0)
     {
       goto out;

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c
@@ -271,7 +271,7 @@ int bcmf_driver_download_clm(FAR struct bcmf_dev_s *priv)
   wlinfo("Download %d bytes\n", datalen);
 
   ret = file_open(&finfo, CONFIG_IEEE80211_BROADCOM_FWCLMNAME,
-                  O_RDONLY | O_CLOEXEC);
+                  O_RDONLY);
   if (ret < 0)
     {
       wlerr("ERROR: Failed to open the FILE MTD file\n", ret);

--- a/net/local/local_fifo.c
+++ b/net/local/local_fifo.c
@@ -239,7 +239,7 @@ static int local_rx_open(FAR struct local_conn_s *conn, FAR const char *path,
   int oflags = nonblock ? O_RDONLY | O_NONBLOCK : O_RDONLY;
   int ret;
 
-  ret = file_open(&conn->lc_infile, path, oflags | O_CLOEXEC);
+  ret = file_open(&conn->lc_infile, path, oflags);
   if (ret < 0)
     {
       nerr("ERROR: Failed on open %s for reading: %d\n",
@@ -272,8 +272,7 @@ static int local_tx_open(FAR struct local_conn_s *conn, FAR const char *path,
 {
   int ret;
 
-  ret = file_open(&conn->lc_outfile, path, O_WRONLY | O_NONBLOCK |
-                  O_CLOEXEC);
+  ret = file_open(&conn->lc_outfile, path, O_WRONLY | O_NONBLOCK);
   if (ret < 0)
     {
       nerr("ERROR: Failed on open %s for writing: %d\n",

--- a/net/utils/net_snoop.c
+++ b/net/utils/net_snoop.c
@@ -361,7 +361,7 @@ int snoop_open(FAR struct snoop_s *snoop, FAR const char *filename,
         }
     }
 
-  ret = file_open(&snoop->filep, filename, O_RDWR | O_CREAT | O_CLOEXEC);
+  ret = file_open(&snoop->filep, filename, O_RDWR | O_CREAT);
   if (ret < 0)
     {
       return ret;


### PR DESCRIPTION
Reverts apache/nuttx#10758 since rv-virt:knsh64 crashed at boot.
