### PR TITLE
tools/Config.mk: preprocess link script to make configure more flexibly

### DIFF
--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -680,6 +680,8 @@ ARCHXXINCLUDES += ${INCSYSDIR_PREFIX}$(TOPDIR)$(DELIM)include
 
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
   CONVERT_PATH = $(foreach FILE,$1,${shell cygpath -w $(FILE)})
+else ifeq ($(CONFIG_HOST_MACOS),)
+  CONVERT_PATH = $(shell readlink -m $1)
 else
   CONVERT_PATH = $1
 endif


### PR DESCRIPTION
## Summary

use readlink "-m" to be more flexible without requirements on every component existence of the given path.

## Impact

None

## Testing

pass CI
