### PR TITLE
sim_rptun: unlink shm when quit

### DIFF
--- a/arch/sim/src/sim/posix/sim_hostmemory.c
+++ b/arch/sim/src/sim/posix/sim_hostmemory.c
@@ -119,7 +119,7 @@ void *host_allocshmem(const char *name, size_t size, int master)
     {
       /* Avoid the second slave instance open successfully */
 
-      host_uninterruptible(shm_unlink, name);
+      host_unlinkshmem(name);
     }
 
   ret = host_uninterruptible(ftruncate, fd, size);
@@ -143,6 +143,11 @@ void *host_allocshmem(const char *name, size_t size, int master)
 void host_freeshmem(void *mem)
 {
   host_uninterruptible(munmap, mem, 0);
+}
+
+int host_unlinkshmem(const char *name)
+{
+  return host_uninterruptible(shm_unlink, name);
 }
 
 size_t host_mallocsize(void *mem)

--- a/arch/sim/src/sim/sim_internal.h
+++ b/arch/sim/src/sim/sim_internal.h
@@ -222,6 +222,7 @@ void *host_memalign(size_t alignment, size_t size);
 void host_free(void *mem);
 void *host_realloc(void *oldmem, size_t size);
 void host_mallinfo(int *aordblks, int *uordblks);
+int host_unlinkshmem(const char *name);
 
 /* sim_hosttime.c ***********************************************************/
 

--- a/arch/sim/src/sim/sim_rptun.c
+++ b/arch/sim/src/sim/sim_rptun.c
@@ -201,11 +201,14 @@ static int sim_rptun_stop(struct rptun_dev_s *dev)
   if ((priv->master & SIM_RPTUN_BOOT) && (priv->pid > 0))
     {
       priv->shmem->cmdm = SIM_RPTUN_STOP << SIM_RPTUN_SHIFT;
-
       host_waitpid(priv->pid);
+    }
 
+  if (priv->shmem)
+    {
       host_freeshmem(priv->shmem);
       priv->shmem = NULL;
+      host_unlinkshmem(priv->shmemname);
     }
 
   return 0;


### PR DESCRIPTION
## Summary
if not unlink shm, the shared memory object still exists in host /dev/shm after quit
if nuttx is started with administrator privileges, or if it is restarted with user
privileges, there will be a problem with the permission to open this shm file

## Impact
sim_rptun

## Testing

sim:rproxy and sim:rpserver
