### PR TITLE
driver/spi: avoid calling QPOLL to change rx_length and cause data loss

### DIFF
--- a/drivers/spi/spi_slave_driver.c
+++ b/drivers/spi/spi_slave_driver.c
@@ -326,7 +326,7 @@ static ssize_t spi_slave_read(FAR struct file *filep, FAR char *buffer,
       return ret;
     }
 
-  do
+  while (priv->rx_length == 0)
     {
       remaining_words = SPIS_CTRLR_QPOLL(priv->ctrlr);
       if (remaining_words == 0)
@@ -360,11 +360,11 @@ static ssize_t spi_slave_read(FAR struct file *filep, FAR char *buffer,
             }
         }
     }
-  while (priv->rx_length == 0);
 
   read_bytes = MIN(buflen, priv->rx_length);
 
   memcpy(buffer, priv->rx_buffer, read_bytes);
+  priv->rx_length -= read_bytes;
 
   nxmutex_unlock(&priv->lock);
   return (ssize_t)read_bytes;


### PR DESCRIPTION

## Summary
driver/spi: avoid calling QPOLL to change rx_length and cause data loss

When the application calls poll and returns the POLLIN event, QPOLL will be called again during the read operation, causing rx_length to change and data to be lost.
Therefore, read only need to actively call qpoll to collect driver data when rx length is 0.

## Impact

## Testing
daily test
