### PR TITLE
bcm43xxx: revert part of the previous upstream code

### DIFF
--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_ioctl.h
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_ioctl.h
@@ -3297,22 +3297,22 @@ typedef enum
 
   /* WPA failure reason codes carried in the WLC_E_PSK_SUP event */
 
-  WLC_E_SUP_OTHER               = 0,  /* Other reason */
-  WLC_E_SUP_DECRYPT_KEY_DATA    = 1,  /* Decryption of key data failed */
-  WLC_E_SUP_BAD_UCAST_WEP128    = 2,  /* Illegal use of ucast WEP128 */
-  WLC_E_SUP_BAD_UCAST_WEP40     = 3,  /* Illegal use of ucast WEP40 */
-  WLC_E_SUP_UNSUP_KEY_LEN       = 4,  /* Unsupported key length */
-  WLC_E_SUP_PW_KEY_CIPHER       = 5,  /* Unicast cipher mismatch in pairwise key */
-  WLC_E_SUP_MSG3_TOO_MANY_IE    = 6,  /* WPA IE contains > 1 RSN IE in key msg 3 */
-  WLC_E_SUP_MSG3_IE_MISMATCH    = 7,  /* WPA IE mismatch in key message 3 */
-  WLC_E_SUP_NO_INSTALL_FLAG     = 8,  /* INSTALL flag unset in 4-way msg */
-  WLC_E_SUP_MSG3_NO_GTK         = 9,  /* encapsulated GTK missing from msg 3 */
-  WLC_E_SUP_GRP_KEY_CIPHER      = 10, /* Multicast cipher mismatch in group key */
-  WLC_E_SUP_GRP_MSG1_NO_GTK     = 11, /* encapsulated GTK missing from group msg 1 */
-  WLC_E_SUP_GTK_DECRYPT_FAIL    = 12, /* GTK decrypt failure */
-  WLC_E_SUP_SEND_FAIL           = 13, /* message send failure */
-  WLC_E_SUP_DEAUTH              = 14, /* received FC_DEAUTH */
-  WLC_E_SUP_WPA_PSK_TMO         = 15, /* WPA PSK 4-way handshake timeout */
+  WLC_E_SUP_OTHER               = 0  + WLC_E_SUP_REASON_OFFSET,  /* Other reason */
+  WLC_E_SUP_DECRYPT_KEY_DATA    = 1  + WLC_E_SUP_REASON_OFFSET,  /* Decryption of key data failed */
+  WLC_E_SUP_BAD_UCAST_WEP128    = 2  + WLC_E_SUP_REASON_OFFSET,  /* Illegal use of ucast WEP128 */
+  WLC_E_SUP_BAD_UCAST_WEP40     = 3  + WLC_E_SUP_REASON_OFFSET,  /* Illegal use of ucast WEP40 */
+  WLC_E_SUP_UNSUP_KEY_LEN       = 4  + WLC_E_SUP_REASON_OFFSET,  /* Unsupported key length */
+  WLC_E_SUP_PW_KEY_CIPHER       = 5  + WLC_E_SUP_REASON_OFFSET,  /* Unicast cipher mismatch in pairwise key */
+  WLC_E_SUP_MSG3_TOO_MANY_IE    = 6  + WLC_E_SUP_REASON_OFFSET,  /* WPA IE contains > 1 RSN IE in key msg 3 */
+  WLC_E_SUP_MSG3_IE_MISMATCH    = 7  + WLC_E_SUP_REASON_OFFSET,  /* WPA IE mismatch in key message 3 */
+  WLC_E_SUP_NO_INSTALL_FLAG     = 8  + WLC_E_SUP_REASON_OFFSET,  /* INSTALL flag unset in 4-way msg */
+  WLC_E_SUP_MSG3_NO_GTK         = 9  + WLC_E_SUP_REASON_OFFSET,  /* encapsulated GTK missing from msg 3 */
+  WLC_E_SUP_GRP_KEY_CIPHER      = 10 + WLC_E_SUP_REASON_OFFSET,  /* Multicast cipher mismatch in group key */
+  WLC_E_SUP_GRP_MSG1_NO_GTK     = 11 + WLC_E_SUP_REASON_OFFSET,  /* encapsulated GTK missing from group msg 1 */
+  WLC_E_SUP_GTK_DECRYPT_FAIL    = 12 + WLC_E_SUP_REASON_OFFSET,  /* GTK decrypt failure */
+  WLC_E_SUP_SEND_FAIL           = 13 + WLC_E_SUP_REASON_OFFSET,  /* message send failure */
+  WLC_E_SUP_DEAUTH              = 14 + WLC_E_SUP_REASON_OFFSET,  /* received FC_DEAUTH */
+  WLC_E_SUP_WPA_PSK_TMO         = 15 + WLC_E_SUP_REASON_OFFSET,  /* WPA PSK 4-way handshake timeout */
 
   /* Reason codes for LINK */
 


### PR DESCRIPTION
## Summary
Revert WPA failure reason codes to the previous community version
## Impact

## Testing
Cortex-M33 and bcm43xxx chipset
