### PR TITLE
driver/sensors: fix sensor_rpmsg_ns_unbind_cb crash

### DIFF
--- a/drivers/sensors/sensor_rpmsg.c
+++ b/drivers/sensors/sensor_rpmsg.c
@@ -1219,8 +1219,8 @@ static void sensor_rpmsg_ns_unbind_cb(FAR struct rpmsg_endpoint *ept)
   nxrmutex_unlock(&g_ept_lock);
 
   nxrmutex_destroy(&sre->lock);
-  kmm_free(sre);
   rpmsg_destroy_ept(ept);
+  kmm_free(sre);
 }
 
 static void sensor_rpmsg_device_ns_bound(FAR struct rpmsg_endpoint *ept)


### PR DESCRIPTION

## Summary
driver/sensors: fix sensor_rpmsg_ns_unbind_cb crash

==2787216==ERROR: AddressSanitizer: heap-use-after-free on address 0xf4702448 at pc 0x0136c544 bp 0x9f54d358 sp 0x9f54d348 READ of size 4 at 0xf4702448 thread T0
```
0 0x136c543 in rpmsg_destroy_ept open-amp/lib/rpmsg/rpmsg.c:357
1 0x1252b29 in sensor_rpmsg_ns_unbind_cb sensors/sensor_rpmsg.c:1216
2 0x1371de5 in rpmsg_virtio_ns_callback open-amp/lib/rpmsg/rpmsg_virtio.c:663
3 0x1371026 in rpmsg_virtio_rx_callback open-amp/lib/rpmsg/rpmsg_virtio.c:583 
4 0x137c105 in virtqueue_notification open-amp/lib/virtio/virtqueue.c:711 
5 0x1368604 in rproc_virtio_notified open-amp/lib/remoteproc/remoteproc_virtio.c:433 
6 0x1363abe in remoteproc_get_notification open-amp/lib/remoteproc/remoteproc.c:10
```
## Impact

## Testing
daily test
