### PR TITLE
lib/netdb: Change the default NETDB_DNSCLIENT_NAMESIZE to PATH_MAX

### DIFF
--- a/libs/libc/netdb/Kconfig
+++ b/libs/libc/netdb/Kconfig
@@ -95,7 +95,7 @@ config NETDB_DNSCLIENT_ENTRIES
 
 config NETDB_DNSCLIENT_NAMESIZE
 	int "Max size of a cached hostname"
-	default 32
+	default PATH_MAX
 	---help---
 		The size of a hostname string in the DNS resolver cache is fixed.
 		This setting provides the maximum size of a hostname.  Names longer


### PR DESCRIPTION
## Summary

Domain name has the similar layout as file path, so it's too small to use 32 bytes as the default value, and better to has the same default value as PATH_MAX which is 255.

## Impact

default value of NETDB_DNSCLIENT_NAMESIZE

## Testing

ci