### PR TITLE
Fix mmcsd/mmcsd_debug.c:110:9: error: format '%d' expects argument oftype 'int', but argument 3 has type 'long unsigned int'

### DIFF
--- a/drivers/mmcsd/mmcsd_debug.c
+++ b/drivers/mmcsd/mmcsd_debug.c
@@ -107,7 +107,7 @@ void mmcsd_dmpcsd(FAR const uint8_t *csd, uint8_t cardtype)
       MMCSD_CSD_READBLKMISALIGN(csd));
   finfo("  DSR_IMP:                 %d\n",
       sd2 ? SD20_CSD_DSRIMP(csd) : MMCSD_CSD_DSRIMP(csd));
-  finfo("  C_SIZE:                  %d\n",
+  finfo("  C_SIZE:                  %" PRId32" \n",
       sd2 ? SD20_CSD_CSIZE(csd) : MMCSD_CSD_CSIZE(csd));
   finfo("  VDD_R_CURR_MIN:          %d\n",
       sd2 ? SD20_CSD_VDDRCURRMIN(csd) : MMCSD_CSD_VDDRCURRMIN(csd));


### PR DESCRIPTION

## Summary

## Impact

fix the compiler warning

## Testing

ci