### PR TITLE
tools/Unix.mk:ignore Kconfiglib menuconfig module warning

### DIFF
--- a/tools/Unix.mk
+++ b/tools/Unix.mk
@@ -648,10 +648,10 @@ else
                               rm kwarning; \
                           fi
   MODULE_WARNING        = "warning: the 'modules' option is not supported"
-  PURGE_MODULE_WARNING  = 2>&1 >/dev/null | grep -v ${MODULE_WARNING} | tee kwarning && ${KCONFIG_WARNING}
+  PURGE_MODULE_WARNING  = 2> >(grep -v ${MODULE_WARNING} | tee kwarning) | cat && ${KCONFIG_WARNING}
   KCONFIG_OLDCONFIG     = oldconfig ${PURGE_MODULE_WARNING}
   KCONFIG_OLDDEFCONFIG  = olddefconfig ${PURGE_MODULE_WARNING}
-  KCONFIG_MENUCONFIG    = menuconfig ${PURGE_MODULE_WARNING}
+  KCONFIG_MENUCONFIG    = menuconfig $(subst | cat,,${PURGE_MODULE_WARNING})
   KCONFIG_NCONFIG       = guiconfig ${PURGE_MODULE_WARNING}
   KCONFIG_QCONFIG       = ${KCONFIG_NCONFIG}
   KCONFIG_GCONFIG       = ${KCONFIG_NCONFIG}


### PR DESCRIPTION
## Summary
terminal character redirection will cause curselib errors. 
the warning check has been completed before the menuconfig execution phase, so lets ignored here.
this is a supplementary change of https://github.com/apache/nuttx/pull/10763
fix the issue https://github.com/apache/nuttx/issues/10794
## Impact

## Testing
CI build
