### PR TITLE
arch/arm: Fix  error: format '%x' expects argument of type 'unsigned int', but argument 3 has type 'uint32_t' {aka 'long unsigned int'}

### DIFF
--- a/arch/arm/src/armv7-a/arm_dataabort.c
+++ b/arch/arm/src/armv7-a/arm_dataabort.c
@@ -138,8 +138,8 @@ uint32_t *arm_dataabort(uint32_t *regs, uint32_t dfar, uint32_t dfsr)
   return regs;
 
 segfault:
-  _alert("Data abort. PC: %08x DFAR: %08x DFSR: %08x\n",
-        regs[REG_PC], dfar, dfsr);
+  _alert("Data abort. PC: %08" PRIx32 " DFAR: %08" PRIx32 " DFSR: %08"
+         PRIx32 "\n", regs[REG_PC], dfar, dfsr);
   PANIC_WITH_REGS("panic", regs);
   return regs; /* To keep the compiler happy */
 }
@@ -156,8 +156,8 @@ uint32_t *arm_dataabort(uint32_t *regs, uint32_t dfar, uint32_t dfsr)
 
   /* Crash -- possibly showing diagnostic debug information. */
 
-  _alert("Data abort. PC: %08x DFAR: %08x DFSR: %08x\n",
-        regs[REG_PC], dfar, dfsr);
+  _alert("Data abort. PC: %08" PRIx32 " DFAR: %08" PRIx32 " DFSR: %08"
+         PRIx32 "\n", regs[REG_PC], dfar, dfsr);
   PANIC_WITH_REGS("panic", regs);
   return regs; /* To keep the compiler happy */
 }

--- a/arch/arm/src/armv7-a/arm_prefetchabort.c
+++ b/arch/arm/src/armv7-a/arm_prefetchabort.c
@@ -109,8 +109,8 @@ uint32_t *arm_prefetchabort(uint32_t *regs, uint32_t ifar, uint32_t ifsr)
     }
   else
     {
-      _alert("Prefetch abort. PC: %08x IFAR: %08x IFSR: %08x\n",
-            regs[REG_PC], ifar, ifsr);
+      _alert("Prefetch abort. PC: %08" PRIx32 " IFAR: %08" PRIx32
+             " IFSR: %08" PRIx32 "\n", regs[REG_PC], ifar, ifsr);
       PANIC_WITH_REGS("panic", regs);
     }
 
@@ -129,8 +129,8 @@ uint32_t *arm_prefetchabort(uint32_t *regs, uint32_t ifar, uint32_t ifsr)
 
   /* Crash -- possibly showing diagnostic debug information. */
 
-  _alert("Prefetch abort. PC: %08x IFAR: %08x IFSR: %08x\n",
-        regs[REG_PC], ifar, ifsr);
+  _alert("Prefetch abort. PC: %08" PRIx32 " IFAR: %08" PRIx32 " IFSR: %08"
+         PRIx32 "\n", regs[REG_PC], ifar, ifsr);
   PANIC_WITH_REGS("panic", regs);
   return regs; /* To keep the compiler happy */
 }

--- a/arch/arm/src/armv7-a/arm_undefinedinsn.c
+++ b/arch/arm/src/armv7-a/arm_undefinedinsn.c
@@ -42,7 +42,7 @@
 
 uint32_t *arm_undefinedinsn(uint32_t *regs)
 {
-  _alert("Undefined instruction at 0x%x\n", regs[REG_PC]);
+  _alert("Undefined instruction at 0x%" PRIx32 "\n", regs[REG_PC]);
   CURRENT_REGS = regs;
   PANIC_WITH_REGS("panic", regs);
   return regs; /* To keep the compiler happy */

--- a/arch/arm/src/armv7-r/arm_dataabort.c
+++ b/arch/arm/src/armv7-r/arm_dataabort.c
@@ -61,8 +61,8 @@ uint32_t *arm_dataabort(uint32_t *regs, uint32_t dfar, uint32_t dfsr)
 
   /* Crash -- possibly showing diagnostic debug information. */
 
-  _alert("Data abort. PC: %08x DFAR: %08x DFSR: %08x\n",
-        regs[REG_PC], dfar, dfsr);
+  _alert("Data abort. PC: %08" PRIx32 " DFAR: %08" PRIx32 " DFSR: %08"
+         PRIx32 "\n", regs[REG_PC], dfar, dfsr);
   PANIC_WITH_REGS("panic", regs);
   return regs; /* To keep the compiler happy */
 }

--- a/arch/arm/src/armv7-r/arm_prefetchabort.c
+++ b/arch/arm/src/armv7-r/arm_prefetchabort.c
@@ -57,8 +57,8 @@ uint32_t *arm_prefetchabort(uint32_t *regs, uint32_t ifar, uint32_t ifsr)
 
   /* Crash -- possibly showing diagnostic debug information. */
 
-  _alert("Prefetch abort. PC: %08x IFAR: %08x IFSR: %08x\n",
-        regs[REG_PC], ifar, ifsr);
+  _alert("Prefetch abort. PC: %08" PRIx32 " IFAR: %08" PRIx32 " IFSR: %08"
+         PRIx32 "\n", regs[REG_PC], ifar, ifsr);
   PANIC_WITH_REGS("panic", regs);
   return regs; /* To keep the compiler happy */
 }

--- a/arch/arm/src/armv7-r/arm_undefinedinsn.c
+++ b/arch/arm/src/armv7-r/arm_undefinedinsn.c
@@ -42,7 +42,7 @@
 
 uint32_t *arm_undefinedinsn(uint32_t *regs)
 {
-  _alert("Undefined instruction at 0x%x\n", regs[REG_PC]);
+  _alert("Undefined instruction at 0x%" PRIx32 "\n", regs[REG_PC]);
   CURRENT_REGS = regs;
   PANIC_WITH_REGS("panic", regs);
   return regs; /* To keep the compiler happy */

--- a/arch/arm/src/armv8-r/arm_dataabort.c
+++ b/arch/arm/src/armv8-r/arm_dataabort.c
@@ -61,8 +61,8 @@ uint32_t *arm_dataabort(uint32_t *regs, uint32_t dfar, uint32_t dfsr)
 
   /* Crash -- possibly showing diagnostic debug information. */
 
-  _alert("Data abort. PC: %08x DFAR: %08x DFSR: %08x\n",
-        regs[REG_PC], dfar, dfsr);
+  _alert("Data abort. PC: %08" PRIx32 " DFAR: %08" PRIx32 " DFSR: %08"
+         PRIx32 "\n", regs[REG_PC], dfar, dfsr);
   PANIC_WITH_REGS("panic", regs);
   return regs; /* To keep the compiler happy */
 }

--- a/arch/arm/src/armv8-r/arm_prefetchabort.c
+++ b/arch/arm/src/armv8-r/arm_prefetchabort.c
@@ -57,8 +57,8 @@ uint32_t *arm_prefetchabort(uint32_t *regs, uint32_t ifar, uint32_t ifsr)
 
   /* Crash -- possibly showing diagnostic debug information. */
 
-  _alert("Prefetch abort. PC: %08x IFAR: %08x IFSR: %08x\n",
-        regs[REG_PC], ifar, ifsr);
+  _alert("Prefetch abort. PC: %08" PRIx32 " IFAR: %08" PRIx32 " IFSR: %08"
+         PRIx32 "\n", regs[REG_PC], ifar, ifsr);
   PANIC_WITH_REGS("panic", regs);
   return regs; /* To keep the compiler happy */
 }

--- a/arch/arm/src/armv8-r/arm_undefinedinsn.c
+++ b/arch/arm/src/armv8-r/arm_undefinedinsn.c
@@ -42,7 +42,7 @@
 
 uint32_t *arm_undefinedinsn(uint32_t *regs)
 {
-  _alert("Undefined instruction at 0x%x\n", regs[REG_PC]);
+  _alert("Undefined instruction at 0x%" PRIx32 "\n", regs[REG_PC]);
   CURRENT_REGS = regs;
   PANIC_WITH_REGS("panic", regs);
   return regs; /* To keep the compiler happy */


### PR DESCRIPTION

## Summary

fix warning

## Impact

minor

## Testing

internal ci