### PR TITLE
Minor fix for ioexpander driver

### DIFF
--- a/drivers/analog/lmp92001.c
+++ b/drivers/analog/lmp92001.c
@@ -254,11 +254,11 @@ static int lmp92001_gpio_readpin(FAR struct ioexpander_dev_s *dev,
                                  uint8_t pin, FAR bool *value);
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int lmp92001_gpio_multiwritepin(FAR struct ioexpander_dev_s *dev,
-                                       FAR uint8_t *pins, FAR bool *values,
-                                       int count);
+                                       FAR const uint8_t *pins,
+                                       FAR bool *values, int count);
 static int lmp92001_gpio_multireadpin(FAR struct ioexpander_dev_s *dev,
-                                      FAR uint8_t *pins, FAR bool *values,
-                                      int count);
+                                      FAR const uint8_t *pins,
+                                      FAR bool *values, int count);
 #endif
 #ifdef CONFIG_IOEXPANDER_INT_ENABLE
 static FAR void *lmp92001_gpio_attach(FAR struct ioexpander_dev_s *dev,
@@ -1375,8 +1375,8 @@ static int lmp92001_gpio_readpin(FAR struct ioexpander_dev_s *dev,
 
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int lmp92001_gpio_multiwritepin(FAR struct ioexpander_dev_s *dev,
-                                       FAR uint8_t *pins, FAR bool *values,
-                                       int count)
+                                       FAR const uint8_t *pins,
+                                       FAR bool *values, int count)
 {
 }
 
@@ -1398,8 +1398,8 @@ static int lmp92001_gpio_multiwritepin(FAR struct ioexpander_dev_s *dev,
  ****************************************************************************/
 
 static int lmp92001_gpio_multireadpin(FAR struct ioexpander_dev_s *dev,
-                                      FAR uint8_t *pins, FAR bool *values,
-                                      int count)
+                                      FAR const uint8_t *pins,
+                                      FAR bool *values, int count)
 {
 }
 #endif

--- a/drivers/analog/lmp92001.c
+++ b/drivers/analog/lmp92001.c
@@ -255,7 +255,7 @@ static int lmp92001_gpio_readpin(FAR struct ioexpander_dev_s *dev,
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int lmp92001_gpio_multiwritepin(FAR struct ioexpander_dev_s *dev,
                                        FAR const uint8_t *pins,
-                                       FAR bool *values, int count);
+                                       FAR const bool *values, int count);
 static int lmp92001_gpio_multireadpin(FAR struct ioexpander_dev_s *dev,
                                       FAR const uint8_t *pins,
                                       FAR bool *values, int count);
@@ -1376,7 +1376,7 @@ static int lmp92001_gpio_readpin(FAR struct ioexpander_dev_s *dev,
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int lmp92001_gpio_multiwritepin(FAR struct ioexpander_dev_s *dev,
                                        FAR const uint8_t *pins,
-                                       FAR bool *values, int count)
+                                       FAR const bool *values, int count)
 {
 }
 

--- a/drivers/ioexpander/ioe_dummy.c
+++ b/drivers/ioexpander/ioe_dummy.c
@@ -119,7 +119,7 @@ static int ioe_dummy_readpin(FAR struct ioexpander_dev_s *dev,
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int ioe_dummy_multiwritepin(FAR struct ioexpander_dev_s *dev,
                                    FAR const uint8_t *pins,
-                                   FAR bool *values, int count);
+                                   FAR const bool *values, int count);
 static int ioe_dummy_multireadpin(FAR struct ioexpander_dev_s *dev,
                                   FAR const uint8_t *pins,
                                   FAR bool *values, int count);
@@ -442,7 +442,7 @@ static int ioe_dummy_readpin(FAR struct ioexpander_dev_s *dev,
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int ioe_dummy_multiwritepin(FAR struct ioexpander_dev_s *dev,
                                    FAR const uint8_t *pins,
-                                   FAR bool *values, int count)
+                                   FAR const bool *values, int count)
 {
   FAR struct ioe_dummy_dev_s *priv = (FAR struct ioe_dummy_dev_s *)dev;
   uint8_t pin;

--- a/drivers/ioexpander/ioe_dummy.c
+++ b/drivers/ioexpander/ioe_dummy.c
@@ -118,11 +118,11 @@ static int ioe_dummy_readpin(FAR struct ioexpander_dev_s *dev,
                              uint8_t pin, FAR bool *value);
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int ioe_dummy_multiwritepin(FAR struct ioexpander_dev_s *dev,
-                                   FAR uint8_t *pins, FAR bool *values,
-                                   int count);
+                                   FAR const uint8_t *pins,
+                                   FAR bool *values, int count);
 static int ioe_dummy_multireadpin(FAR struct ioexpander_dev_s *dev,
-                                  FAR uint8_t *pins, FAR bool *values,
-                                  int count);
+                                  FAR const uint8_t *pins,
+                                  FAR bool *values, int count);
 #endif
 #ifdef CONFIG_IOEXPANDER_INT_ENABLE
 static FAR void *ioe_dummy_attach(FAR struct ioexpander_dev_s *dev,
@@ -441,8 +441,8 @@ static int ioe_dummy_readpin(FAR struct ioexpander_dev_s *dev,
 
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int ioe_dummy_multiwritepin(FAR struct ioexpander_dev_s *dev,
-                                   FAR uint8_t *pins, FAR bool *values,
-                                   int count)
+                                   FAR const uint8_t *pins,
+                                   FAR bool *values, int count)
 {
   FAR struct ioe_dummy_dev_s *priv = (FAR struct ioe_dummy_dev_s *)dev;
   uint8_t pin;
@@ -491,8 +491,8 @@ static int ioe_dummy_multiwritepin(FAR struct ioexpander_dev_s *dev,
 
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int ioe_dummy_multireadpin(FAR struct ioexpander_dev_s *dev,
-                                  FAR uint8_t *pins, FAR bool *values,
-                                  int count)
+                                  FAR const uint8_t *pins,
+                                  FAR bool *values, int count)
 {
   FAR struct ioe_dummy_dev_s *priv = (FAR struct ioe_dummy_dev_s *)dev;
   ioe_pinset_t inval;

--- a/drivers/ioexpander/iso1h812g.c
+++ b/drivers/ioexpander/iso1h812g.c
@@ -81,7 +81,7 @@ static int iso1h812g_readpin(FAR struct ioexpander_dev_s *dev, uint8_t pin,
              FAR bool *value);
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int iso1h812g_multiwritepin(FAR struct ioexpander_dev_s *dev,
-             FAR const uint8_t *pins, FAR bool *values, int count);
+             FAR const uint8_t *pins, FAR const bool *values, int count);
 static int iso1h812g_multireadpin(FAR struct ioexpander_dev_s *dev,
              FAR const uint8_t *pins, FAR bool *values, int count);
 #endif
@@ -336,8 +336,8 @@ static int iso1h812g_readpin(FAR struct ioexpander_dev_s *dev, uint8_t pin,
 
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int iso1h812g_multiwritepin(FAR struct ioexpander_dev_s *dev,
-                                   FAR const uint8_t *pins, FAR bool *values,
-                                   int count)
+                                   FAR const uint8_t *pins,
+                                   FAR const bool *values, int count)
 {
   FAR struct iso1h812g_dev_s *priv = (FAR struct iso1h812g_dev_s *)dev;
   int ret;

--- a/drivers/ioexpander/iso1i813t.c
+++ b/drivers/ioexpander/iso1i813t.c
@@ -80,7 +80,7 @@ static int iso1i813t_readpin(FAR struct ioexpander_dev_s *dev, uint8_t pin,
              FAR bool *value);
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int iso1i813t_multiwritepin(FAR struct ioexpander_dev_s *dev,
-             FAR const uint8_t *pins, FAR bool *values, int count);
+             FAR const uint8_t *pins, FAR const bool *values, int count);
 static int iso1i813t_multireadpin(FAR struct ioexpander_dev_s *dev,
              FAR const uint8_t *pins, FAR bool *values, int count);
 #endif
@@ -349,8 +349,8 @@ static int iso1i813t_readpin(FAR struct ioexpander_dev_s *dev, uint8_t pin,
 
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int iso1i813t_multiwritepin(FAR struct ioexpander_dev_s *dev,
-                                   FAR const uint8_t *pins, FAR bool *values,
-                                   int count)
+                                   FAR const uint8_t *pins,
+                                   FAR const bool *values, int count)
 {
   gpiowarn("WARNING: ISO1I813T is only input expander!\n");
 

--- a/drivers/ioexpander/mcp23x08.c
+++ b/drivers/ioexpander/mcp23x08.c
@@ -74,9 +74,9 @@ static int mcp23x08_readbuf(FAR struct ioexpander_dev_s *dev, uint8_t pin,
              FAR bool *value);
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int mcp23x08_multiwritepin(FAR struct ioexpander_dev_s *dev,
-             FAR uint8_t *pins, FAR bool *values, int count);
+             FAR const uint8_t *pins, FAR bool *values, int count);
 static int mcp23x08_multireadpin(FAR struct ioexpander_dev_s *dev,
-             FAR uint8_t *pins, FAR bool *values, int count);
+             FAR const uint8_t *pins, FAR bool *values, int count);
 static int mcp23x08_multireadbuf(FAR struct ioexpander_dev_s *dev,
              FAR uint8_t *pins, FAR bool *values, int count);
 #endif
@@ -561,8 +561,8 @@ static int mcp23x08_getmultibits(FAR struct mcp23x08_dev_s *priv,
  ****************************************************************************/
 
 static int mcp23x08_multiwritepin(FAR struct ioexpander_dev_s *dev,
-                                  FAR uint8_t *pins, FAR bool *values,
-                                  int count)
+                                  FAR const uint8_t *pins,
+                                  FAR bool *values, int count)
 {
   FAR struct mcp23x08_dev_s *priv = (FAR struct mcp23x08_dev_s *)dev;
   uint8_t addr = MCP23X08_GPIOA;
@@ -659,8 +659,8 @@ static int mcp23x08_multiwritepin(FAR struct ioexpander_dev_s *dev,
  ****************************************************************************/
 
 static int mcp23x08_multireadpin(FAR struct ioexpander_dev_s *dev,
-                                 FAR uint8_t *pins, FAR bool *values,
-                                 int count)
+                                 FAR const uint8_t *pins,
+                                 FAR bool *values, int count)
 {
   FAR struct mcp23x08_dev_s *priv = (FAR struct mcp23x08_dev_s *)dev;
   int ret;
@@ -697,8 +697,8 @@ static int mcp23x08_multireadpin(FAR struct ioexpander_dev_s *dev,
  ****************************************************************************/
 
 static int mcp23x08_multireadbuf(FAR struct ioexpander_dev_s *dev,
-                                 FAR uint8_t *pins, FAR bool *values,
-                                 int count)
+                                 FAR const uint8_t *pins,
+                                 FAR bool *values, int count)
 {
   FAR struct mcp23x08_dev_s *priv = (FAR struct mcp23x08_dev_s *)dev;
   int ret;

--- a/drivers/ioexpander/mcp23x08.c
+++ b/drivers/ioexpander/mcp23x08.c
@@ -74,7 +74,7 @@ static int mcp23x08_readbuf(FAR struct ioexpander_dev_s *dev, uint8_t pin,
              FAR bool *value);
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int mcp23x08_multiwritepin(FAR struct ioexpander_dev_s *dev,
-             FAR const uint8_t *pins, FAR bool *values, int count);
+             FAR const uint8_t *pins, FAR const bool *values, int count);
 static int mcp23x08_multireadpin(FAR struct ioexpander_dev_s *dev,
              FAR const uint8_t *pins, FAR bool *values, int count);
 static int mcp23x08_multireadbuf(FAR struct ioexpander_dev_s *dev,
@@ -562,7 +562,7 @@ static int mcp23x08_getmultibits(FAR struct mcp23x08_dev_s *priv,
 
 static int mcp23x08_multiwritepin(FAR struct ioexpander_dev_s *dev,
                                   FAR const uint8_t *pins,
-                                  FAR bool *values, int count)
+                                  FAR const bool *values, int count)
 {
   FAR struct mcp23x08_dev_s *priv = (FAR struct mcp23x08_dev_s *)dev;
   uint8_t addr = MCP23X08_GPIOA;

--- a/drivers/ioexpander/mcp23x17.c
+++ b/drivers/ioexpander/mcp23x17.c
@@ -74,11 +74,11 @@ static int mcp23x17_readbuf(FAR struct ioexpander_dev_s *dev, uint8_t pin,
              FAR bool *value);
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int mcp23x17_multiwritepin(FAR struct ioexpander_dev_s *dev,
-             FAR uint8_t *pins, FAR bool *values, int count);
+             FAR const uint8_t *pins, FAR bool *values, int count);
 static int mcp23x17_multireadpin(FAR struct ioexpander_dev_s *dev,
-             FAR uint8_t *pins, FAR bool *values, int count);
+             FAR const uint8_t *pins, FAR bool *values, int count);
 static int mcp23x17_multireadbuf(FAR struct ioexpander_dev_s *dev,
-             FAR uint8_t *pins, FAR bool *values, int count);
+             FAR const uint8_t *pins, FAR bool *values, int count);
 #endif
 #ifdef CONFIG_IOEXPANDER_INT_ENABLE
 static FAR void *mcp23x17_attach(FAR struct ioexpander_dev_s *dev,
@@ -571,8 +571,8 @@ static int mcp23x17_getmultibits(FAR struct mcp23x17_dev_s *priv,
  ****************************************************************************/
 
 static int mcp23x17_multiwritepin(FAR struct ioexpander_dev_s *dev,
-                                  FAR uint8_t *pins, FAR bool *values,
-                                  int count)
+                                  FAR const uint8_t *pins,
+                                  FAR bool *values, int count)
 {
   FAR struct mcp23x17_dev_s *priv = (FAR struct mcp23x17_dev_s *)dev;
   uint8_t addr = MCP23X17_GPIOA;
@@ -669,8 +669,8 @@ static int mcp23x17_multiwritepin(FAR struct ioexpander_dev_s *dev,
  ****************************************************************************/
 
 static int mcp23x17_multireadpin(FAR struct ioexpander_dev_s *dev,
-                                 FAR uint8_t *pins, FAR bool *values,
-                                 int count)
+                                 FAR const uint8_t *pins,
+                                 FAR bool *values, int count)
 {
   FAR struct mcp23x17_dev_s *priv = (FAR struct mcp23x17_dev_s *)dev;
   int ret;
@@ -707,8 +707,8 @@ static int mcp23x17_multireadpin(FAR struct ioexpander_dev_s *dev,
  ****************************************************************************/
 
 static int mcp23x17_multireadbuf(FAR struct ioexpander_dev_s *dev,
-                                 FAR uint8_t *pins, FAR bool *values,
-                                 int count)
+                                 FAR const uint8_t *pins,
+                                 FAR bool *values, int count)
 {
   FAR struct mcp23x17_dev_s *priv = (FAR struct mcp23x17_dev_s *)dev;
   int ret;

--- a/drivers/ioexpander/mcp23x17.c
+++ b/drivers/ioexpander/mcp23x17.c
@@ -74,7 +74,7 @@ static int mcp23x17_readbuf(FAR struct ioexpander_dev_s *dev, uint8_t pin,
              FAR bool *value);
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int mcp23x17_multiwritepin(FAR struct ioexpander_dev_s *dev,
-             FAR const uint8_t *pins, FAR bool *values, int count);
+             FAR const uint8_t *pins, FAR const bool *values, int count);
 static int mcp23x17_multireadpin(FAR struct ioexpander_dev_s *dev,
              FAR const uint8_t *pins, FAR bool *values, int count);
 static int mcp23x17_multireadbuf(FAR struct ioexpander_dev_s *dev,
@@ -572,7 +572,7 @@ static int mcp23x17_getmultibits(FAR struct mcp23x17_dev_s *priv,
 
 static int mcp23x17_multiwritepin(FAR struct ioexpander_dev_s *dev,
                                   FAR const uint8_t *pins,
-                                  FAR bool *values, int count)
+                                  FAR const bool *values, int count)
 {
   FAR struct mcp23x17_dev_s *priv = (FAR struct mcp23x17_dev_s *)dev;
   uint8_t addr = MCP23X17_GPIOA;

--- a/drivers/ioexpander/pca9538.c
+++ b/drivers/ioexpander/pca9538.c
@@ -67,9 +67,9 @@ static int pca9538_readbuf(FAR struct ioexpander_dev_s *dev, uint8_t pin,
              FAR bool *value);
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int pca9538_multiwritepin(FAR struct ioexpander_dev_s *dev,
-             FAR uint8_t *pins, FAR bool *values, int count);
+             FAR const uint8_t *pins, FAR bool *values, int count);
 static int pca9538_multireadpin(FAR struct ioexpander_dev_s *dev,
-             FAR uint8_t *pins, FAR bool *values, int count);
+             FAR const uint8_t *pins, FAR bool *values, int count);
 static int pca9538_multireadbuf(FAR struct ioexpander_dev_s *dev,
              FAR uint8_t *pins, FAR bool *values, int count);
 #endif
@@ -535,8 +535,8 @@ static int pca9538_getmultibits(FAR struct pca9538_dev_s *pca, uint8_t addr,
  ****************************************************************************/
 
 static int pca9538_multiwritepin(FAR struct ioexpander_dev_s *dev,
-                                 FAR uint8_t *pins, FAR bool *values,
-                                 int count)
+                                 FAR const uint8_t *pins,
+                                 FAR bool *values, int count)
 {
   FAR struct pca9538_dev_s *pca = (FAR struct pca9538_dev_s *)dev;
   uint8_t addr = PCA9538_REG_OUTPUT;
@@ -628,8 +628,8 @@ static int pca9538_multiwritepin(FAR struct ioexpander_dev_s *dev,
  ****************************************************************************/
 
 static int pca9538_multireadpin(FAR struct ioexpander_dev_s *dev,
-                                FAR uint8_t *pins, FAR bool *values,
-                                int count)
+                                FAR const uint8_t *pins,
+                                FAR bool *values, int count)
 {
   FAR struct pca9538_dev_s *pca = (FAR struct pca9538_dev_s *)dev;
   int ret;

--- a/drivers/ioexpander/pca9538.c
+++ b/drivers/ioexpander/pca9538.c
@@ -67,7 +67,7 @@ static int pca9538_readbuf(FAR struct ioexpander_dev_s *dev, uint8_t pin,
              FAR bool *value);
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int pca9538_multiwritepin(FAR struct ioexpander_dev_s *dev,
-             FAR const uint8_t *pins, FAR bool *values, int count);
+             FAR const uint8_t *pins, FAR const bool *values, int count);
 static int pca9538_multireadpin(FAR struct ioexpander_dev_s *dev,
              FAR const uint8_t *pins, FAR bool *values, int count);
 static int pca9538_multireadbuf(FAR struct ioexpander_dev_s *dev,
@@ -536,7 +536,7 @@ static int pca9538_getmultibits(FAR struct pca9538_dev_s *pca, uint8_t addr,
 
 static int pca9538_multiwritepin(FAR struct ioexpander_dev_s *dev,
                                  FAR const uint8_t *pins,
-                                 FAR bool *values, int count)
+                                 FAR const bool *values, int count)
 {
   FAR struct pca9538_dev_s *pca = (FAR struct pca9538_dev_s *)dev;
   uint8_t addr = PCA9538_REG_OUTPUT;

--- a/drivers/ioexpander/pca9555.c
+++ b/drivers/ioexpander/pca9555.c
@@ -71,7 +71,7 @@ static int pca9555_readbuf(FAR struct ioexpander_dev_s *dev, uint8_t pin,
              FAR bool *value);
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int pca9555_multiwritepin(FAR struct ioexpander_dev_s *dev,
-             FAR const uint8_t *pins, FAR bool *values, int count);
+             FAR const uint8_t *pins, FAR const bool *values, int count);
 static int pca9555_multireadpin(FAR struct ioexpander_dev_s *dev,
              FAR const uint8_t *pins, FAR bool *values, int count);
 static int pca9555_multireadbuf(FAR struct ioexpander_dev_s *dev,
@@ -554,8 +554,8 @@ static int pca9555_getmultibits(FAR struct pca9555_dev_s *pca, uint8_t addr,
  ****************************************************************************/
 
 static int pca9555_multiwritepin(FAR struct ioexpander_dev_s *dev,
-                                 FAR const uint8_t *pins, FAR bool *values,
-                                 int count)
+                                 FAR const uint8_t *pins,
+                                 FAR const bool *values, int count)
 {
   FAR struct pca9555_dev_s *pca = (FAR struct pca9555_dev_s *)dev;
   uint8_t addr = PCA9555_REG_OUTPUT;

--- a/drivers/ioexpander/pcf8574.c
+++ b/drivers/ioexpander/pcf8574.c
@@ -61,7 +61,7 @@ static int pcf8574_readpin(FAR struct ioexpander_dev_s *dev, uint8_t pin,
              FAR bool *value);
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int pcf8574_multiwritepin(FAR struct ioexpander_dev_s *dev,
-             FAR const uint8_t *pins, FAR bool *values, int count);
+             FAR const uint8_t *pins, FAR const bool *values, int count);
 static int pcf8574_multireadpin(FAR struct ioexpander_dev_s *dev,
              FAR const uint8_t *pins, FAR bool *values, int count);
 #endif
@@ -527,7 +527,7 @@ errout_with_lock:
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int pcf8574_multiwritepin(FAR struct ioexpander_dev_s *dev,
                                  FAR const uint8_t *pins,
-                                 FAR bool *values, int count)
+                                 FAR const bool *values, int count)
 {
   FAR struct pcf8574_dev_s *priv = (FAR struct pcf8574_dev_s *)dev;
   uint8_t pin;

--- a/drivers/ioexpander/pcf8574.c
+++ b/drivers/ioexpander/pcf8574.c
@@ -61,9 +61,9 @@ static int pcf8574_readpin(FAR struct ioexpander_dev_s *dev, uint8_t pin,
              FAR bool *value);
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int pcf8574_multiwritepin(FAR struct ioexpander_dev_s *dev,
-             FAR uint8_t *pins, FAR bool *values, int count);
+             FAR const uint8_t *pins, FAR bool *values, int count);
 static int pcf8574_multireadpin(FAR struct ioexpander_dev_s *dev,
-             FAR uint8_t *pins, FAR bool *values, int count);
+             FAR const uint8_t *pins, FAR bool *values, int count);
 #endif
 #ifdef CONFIG_IOEXPANDER_INT_ENABLE
 static FAR void *pcf8574_attach(FAR struct ioexpander_dev_s *dev,
@@ -526,8 +526,8 @@ errout_with_lock:
 
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int pcf8574_multiwritepin(FAR struct ioexpander_dev_s *dev,
-                                 FAR uint8_t *pins, FAR bool *values,
-                                 int count)
+                                 FAR const uint8_t *pins,
+                                 FAR bool *values, int count)
 {
   FAR struct pcf8574_dev_s *priv = (FAR struct pcf8574_dev_s *)dev;
   uint8_t pin;
@@ -606,8 +606,8 @@ static int pcf8574_multiwritepin(FAR struct ioexpander_dev_s *dev,
 
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int pcf8574_multireadpin(FAR struct ioexpander_dev_s *dev,
-                                FAR uint8_t *pins, FAR bool *values,
-                                int count)
+                                FAR const uint8_t *pins,
+                                FAR bool *values, int count)
 {
   FAR struct pcf8574_dev_s *priv = (FAR struct pcf8574_dev_s *)dev;
   uint8_t regval;

--- a/drivers/ioexpander/pcf8575.c
+++ b/drivers/ioexpander/pcf8575.c
@@ -63,7 +63,7 @@ static int pcf8575_readpin(FAR struct ioexpander_dev_s *dev, uint8_t pin,
              FAR bool *value);
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int pcf8575_multiwritepin(FAR struct ioexpander_dev_s *dev,
-             FAR const uint8_t *pins, FAR bool *values, int count);
+             FAR const uint8_t *pins, FAR const bool *values, int count);
 static int pcf8575_multireadpin(FAR struct ioexpander_dev_s *dev,
              FAR const uint8_t *pins, FAR bool *values, int count);
 #endif
@@ -467,8 +467,8 @@ errout_with_lock:
 
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int pcf8575_multiwritepin(FAR struct ioexpander_dev_s *dev,
-                                 FAR const uint8_t *pins, FAR bool *values,
-                                 int count)
+                                 FAR const uint8_t *pins,
+                                 FAR const bool *values, int count)
 {
   FAR struct pcf8575_dev_s *priv = (FAR struct pcf8575_dev_s *)dev;
   uint8_t pin;

--- a/drivers/ioexpander/skeleton.c
+++ b/drivers/ioexpander/skeleton.c
@@ -92,12 +92,14 @@ static int skel_readbuf(FAR struct ioexpander_dev_s *dev, uint8_t pin,
                         FAR bool *value);
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int skel_multiwritepin(FAR struct ioexpander_dev_s *dev,
-                              FAR uint8_t *pins, FAR bool *values,
-                              int count);
+                              FAR const uint8_t *pins,
+                              FAR bool *values, int count);
 static int skel_multireadpin(FAR struct ioexpander_dev_s *dev,
-                             FAR uint8_t *pins, FAR bool *values, int count);
+                             FAR const uint8_t *pins,
+                             FAR bool *values, int count);
 static int skel_multireadbuf(FAR struct ioexpander_dev_s *dev,
-                             FAR uint8_t *pins, FAR bool *values, int count);
+                             FAR const uint8_t *pins,
+                             FAR bool *values, int count);
 #endif
 #ifdef CONFIG_IOEXPANDER_INT_ENABLE
 static int skel_attach(FAR struct ioexpander_dev_s *dev,
@@ -427,7 +429,8 @@ static int skel_getmultibits(FAR struct skel_dev_s *priv, FAR uint8_t *pins,
 
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int skel_multiwritepin(FAR struct ioexpander_dev_s *dev,
-                              FAR uint8_t *pins, FAR bool *values, int count)
+                              FAR const uint8_t *pins,
+                              FAR bool *values, int count)
 {
   FAR struct skel_dev_s *priv = (FAR struct skel_dev_s *)dev;
   ioe_pinset_t pinset;
@@ -494,7 +497,8 @@ static int skel_multiwritepin(FAR struct ioexpander_dev_s *dev,
 
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int skel_multireadpin(FAR struct ioexpander_dev_s *dev,
-                             FAR uint8_t *pins, FAR bool *values, int count)
+                             FAR const uint8_t *pins,
+                             FAR bool *values, int count)
 {
   FAR struct skel_dev_s *priv = (FAR struct skel_dev_s *)dev;
   int ret;
@@ -536,7 +540,8 @@ static int skel_multireadpin(FAR struct ioexpander_dev_s *dev,
 
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int skel_multireadbuf(FAR struct ioexpander_dev_s *dev,
-                             FAR uint8_t *pins, FAR bool *values, int count)
+                             FAR const uint8_t *pins,
+                             FAR bool *values, int count)
 {
   FAR struct skel_dev_s *priv = (FAR struct skel_dev_s *)dev;
   int ret;

--- a/drivers/ioexpander/skeleton.c
+++ b/drivers/ioexpander/skeleton.c
@@ -93,7 +93,7 @@ static int skel_readbuf(FAR struct ioexpander_dev_s *dev, uint8_t pin,
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int skel_multiwritepin(FAR struct ioexpander_dev_s *dev,
                               FAR const uint8_t *pins,
-                              FAR bool *values, int count);
+                              FAR const bool *values, int count);
 static int skel_multireadpin(FAR struct ioexpander_dev_s *dev,
                              FAR const uint8_t *pins,
                              FAR bool *values, int count);
@@ -430,7 +430,7 @@ static int skel_getmultibits(FAR struct skel_dev_s *priv, FAR uint8_t *pins,
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int skel_multiwritepin(FAR struct ioexpander_dev_s *dev,
                               FAR const uint8_t *pins,
-                              FAR bool *values, int count)
+                              FAR const bool *values, int count)
 {
   FAR struct skel_dev_s *priv = (FAR struct skel_dev_s *)dev;
   ioe_pinset_t pinset;

--- a/drivers/ioexpander/tca64xx.c
+++ b/drivers/ioexpander/tca64xx.c
@@ -68,9 +68,9 @@ static int tca64_readpin(FAR struct ioexpander_dev_s *dev, uint8_t pin,
              FAR bool *value);
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int tca64_multiwritepin(FAR struct ioexpander_dev_s *dev,
-             FAR uint8_t *pins, FAR bool *values, int count);
+             FAR const uint8_t *pins, FAR bool *values, int count);
 static int tca64_multireadpin(FAR struct ioexpander_dev_s *dev,
-             FAR uint8_t *pins, FAR bool *values, int count);
+             FAR const uint8_t *pins, FAR bool *values, int count);
 #endif
 #ifdef CONFIG_IOEXPANDER_INT_ENABLE
 static FAR void *tca64_attach(FAR struct ioexpander_dev_s *dev,
@@ -163,8 +163,8 @@ static const struct tca64_part_s g_tca64_parts[TCA64_NPARTS] =
  *
  ****************************************************************************/
 
-static FAR const struct tca64_part_s *tca64_getpart(
-                          FAR struct tca64_dev_s *priv)
+static FAR const struct tca64_part_s *
+tca64_getpart(FAR struct tca64_dev_s *priv)
 {
   DEBUGASSERT(priv != NULL && priv->config != NULL &&
               priv->config->part < TCA64_NPARTS);
@@ -366,7 +366,7 @@ static int tca64_putreg(struct tca64_dev_s *priv, uint8_t regaddr,
  ****************************************************************************/
 
 static int tca64_direction(FAR struct ioexpander_dev_s *dev, uint8_t pin,
-                          int direction)
+                           int direction)
 {
   FAR struct tca64_dev_s *priv = (FAR struct tca64_dev_s *)dev;
   uint8_t regaddr;
@@ -608,7 +608,7 @@ static int tca64_option(FAR struct ioexpander_dev_s *dev, uint8_t pin,
  ****************************************************************************/
 
 static int tca64_writepin(FAR struct ioexpander_dev_s *dev, uint8_t pin,
-                         bool value)
+                          bool value)
 {
   FAR struct tca64_dev_s *priv = (FAR struct tca64_dev_s *)dev;
   uint8_t regaddr;
@@ -688,7 +688,7 @@ errout_with_lock:
  ****************************************************************************/
 
 static int tca64_readpin(FAR struct ioexpander_dev_s *dev, uint8_t pin,
-                        FAR bool *value)
+                         FAR bool *value)
 {
   FAR struct tca64_dev_s *priv = (FAR struct tca64_dev_s *)dev;
   uint8_t regaddr;
@@ -760,8 +760,8 @@ errout_with_lock:
 
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int tca64_multiwritepin(FAR struct ioexpander_dev_s *dev,
-                                 FAR uint8_t *pins, FAR bool *values,
-                                 int count)
+                               FAR const uint8_t *pins,
+                               FAR bool *values, int count)
 {
   FAR struct tca64_dev_s *priv = (FAR struct tca64_dev_s *)dev;
   ioe_pinset_t pinset;
@@ -848,8 +848,8 @@ errout_with_lock:
 
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int tca64_multireadpin(FAR struct ioexpander_dev_s *dev,
-                                FAR uint8_t *pins, FAR bool *values,
-                                int count)
+                              FAR const uint8_t *pins,
+                              FAR bool *values, int count)
 {
   FAR struct tca64_dev_s *priv = (FAR struct tca64_dev_s *)dev;
   ioe_pinset_t pinset;
@@ -1344,8 +1344,9 @@ static void tca64_poll_expiry(wdparm_t arg)
  *
  ****************************************************************************/
 
-FAR struct ioexpander_dev_s *tca64_initialize(FAR struct i2c_master_s *i2c,
-                               FAR struct tca64_config_s *config)
+FAR struct ioexpander_dev_s *
+tca64_initialize(FAR struct i2c_master_s *i2c,
+                 FAR struct tca64_config_s *config)
 {
   FAR struct tca64_dev_s *priv;
   int ret;

--- a/drivers/ioexpander/tca64xx.c
+++ b/drivers/ioexpander/tca64xx.c
@@ -68,7 +68,7 @@ static int tca64_readpin(FAR struct ioexpander_dev_s *dev, uint8_t pin,
              FAR bool *value);
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int tca64_multiwritepin(FAR struct ioexpander_dev_s *dev,
-             FAR const uint8_t *pins, FAR bool *values, int count);
+             FAR const uint8_t *pins, FAR const bool *values, int count);
 static int tca64_multireadpin(FAR struct ioexpander_dev_s *dev,
              FAR const uint8_t *pins, FAR bool *values, int count);
 #endif
@@ -761,7 +761,7 @@ errout_with_lock:
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
 static int tca64_multiwritepin(FAR struct ioexpander_dev_s *dev,
                                FAR const uint8_t *pins,
-                               FAR bool *values, int count)
+                               FAR const bool *values, int count)
 {
   FAR struct tca64_dev_s *priv = (FAR struct tca64_dev_s *)dev;
   ioe_pinset_t pinset;

--- a/include/nuttx/ioexpander/ioexpander.h
+++ b/include/nuttx/ioexpander/ioexpander.h
@@ -331,8 +331,8 @@ struct ioexpander_ops_s
                           FAR bool *value);
 #ifdef CONFIG_IOEXPANDER_MULTIPIN
   CODE int (*ioe_multiwritepin)(FAR struct ioexpander_dev_s *dev,
-                                FAR const uint8_t *pins, FAR bool *values,
-                                int count);
+                                FAR const uint8_t *pins,
+                                FAR const bool *values, int count);
   CODE int (*ioe_multireadpin)(FAR struct ioexpander_dev_s *dev,
                                FAR const uint8_t *pins, FAR bool *values,
                                int count);


### PR DESCRIPTION
## Summary

- drivers/ioexpander: Add const to the pin array, forget in patch: https://github.com/apache/nuttx/pull/9529
- drivers/ioexpander: Add const to the value array of multiwritepin

## Impact

ioexpander

## Testing

internal test