### PR TITLE
mm:fix warning

### DIFF
--- a/mm/mm_heap/mm_initialize.c
+++ b/mm/mm_heap/mm_initialize.c
@@ -65,7 +65,7 @@ static FAR void *mempool_memalign(FAR void *arg, size_t alignment,
   if (ret)
     {
       node = (FAR struct mm_allocnode_s *)
-      ((FAR char *)ret - MM_SIZEOF_ALLOCNODE);
+      ((uintptr_t)ret - MM_SIZEOF_ALLOCNODE);
       node->pid = PID_MM_MEMPOOL;
     }
 


### PR DESCRIPTION
## Summary

```
mm_heap/mm_initialize.c:69:11: warning: array subscript -1 is outside array bounds of 'void[2147483647]' [-Warray-bounds]
   69 |       node->pid = MM_BACKTRACE_MEMPOOL_PID;
      |           ^~
mm_heap/mm_initialize.c:64:9: note: at offset -16 into object of size [0, 2147483647] allocated by 'mm_memalign'
   64 |   ret = mm_memalign(arg, alignment, size);
```

## Impact
mm

## Testing
arm64
