### PR TITLE
assert: Skip to include arch/board/board.h if CONFIG_ARCH_LEDS=n

### DIFF
--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -30,8 +30,9 @@
 #include <nuttx/irq.h>
 #include <nuttx/tls.h>
 #include <nuttx/signal.h>
-#include <arch/board/board.h>
-
+#ifdef CONFIG_ARCH_LEDS
+#  include <arch/board/board.h>
+#endif
 #include <nuttx/panic_notifier.h>
 #include <nuttx/reboot_notifier.h>
 #include <nuttx/syslog/syslog.h>


### PR DESCRIPTION
## Summary

follow up the change: https://github.com/apache/nuttx/pull/10553

## Impact

minor

## Testing

ci