### PR TITLE
video/goldfish: Remove the vsync residual code

### DIFF
--- a/drivers/video/goldfish_fb.c
+++ b/drivers/video/goldfish_fb.c
@@ -306,8 +306,6 @@ int up_fbinitialize(int display)
 err_irq_attach_failed:
   kmm_free(fb->planeinfo.fbmem);
 err_fbmem_alloc_failed:
-  circbuf_uninit(&fb->vsync);
-err_circbuf_alloc_failed:
   kmm_free(fb);
   return ret;
 }
@@ -332,7 +330,6 @@ void up_fbuninitialize(int display)
       FAR struct goldfish_fb_s *fb = g_goldfish_fb;
 
       irq_detach(fb->irq);
-      circbuf_uninit(&fb->vsync);
       kmm_free(fb->planeinfo.fbmem);
       kmm_free(fb);
       g_goldfish_fb = NULL;


### PR DESCRIPTION
## Summary

forget from patch:
```
commit bbf5b0bb6d970da9fbe91f40c8640551a3ecd29c
Author: jianglianfang <jianglianfang@xiaomi.com>
Date:   Tue Aug 15 19:47:14 2023 +0800

    driver/video: adapting Goldfish FB to VSync optimized FB driver

    The circbuf part is implemented by the fb driver, and goldfish needs to
    delete the part related to circbuf and adapt to the interface of the fb
    driver.
```

## Impact

goldfish fb driver

## Testing

internal ci