### PR TITLE
Add CONFIG_NET_ICMPv6_ROUTER_LIFETIME

### DIFF
--- a/net/icmpv6/Kconfig
+++ b/net/icmpv6/Kconfig
@@ -120,6 +120,14 @@ config NET_ICMPv6_ROUTER
 
 if NET_ICMPv6_ROUTER
 
+config NET_ICMPv6_ROUTER_LIFETIME
+	int "Router Advertisement router lifetime in seconds"
+	default 1800
+	---help---
+		Set the router lifetime for advertising as a default router.
+		Set to 0 to only advertise autoconfiguration prefix without
+		advertising as a router.
+
 config NET_ICMPv6_ROUTER_MANUAL
 	bool "Manual router prefix"
 	default n

--- a/net/icmpv6/icmpv6_radvertise.c
+++ b/net/icmpv6/icmpv6_radvertise.c
@@ -197,7 +197,8 @@ void icmpv6_radvertise(FAR struct net_driver_s *dev)
   adv->code         = 0;                       /* Message qualifier */
   adv->hoplimit     = 64;                      /* Current hop limit */
   adv->flags        = ICMPv6_RADV_FLAG_M;      /* Managed address flag. */
-  adv->lifetime     = HTONS(1800);             /* Router lifetime */
+  adv->lifetime     =
+     HTONS(CONFIG_NET_ICMPv6_ROUTER_LIFETIME); /* Router lifetime */
   adv->reachable[0] = 0;                       /* Reachable time */
   adv->reachable[1] = 0;
   adv->retrans[0]   = 0;                       /* Retransmission timer */


### PR DESCRIPTION
## Summary

Allows setting the advertised route lifetime, and also to set it to 0 for advertising only the prefix.

From RFC4861:

>   A router might want to send Router Advertisements without advertising
   itself as a default router.  For instance, a router might advertise
   prefixes for stateless address autoconfiguration while not wishing to
   forward packets.  Such a router sets the Router Lifetime field in
   outgoing advertisements to zero.

## Impact

Default setting is the same 1800 as previously hardcoded value.

## Testing

Tested on custom STM32F4 target communicating with Linux system.

With default settings NuttX appears as a default router in `ip -6 route` output.
By setting `CONFIG_NET_ICMPv6_ROUTER_LIFETIME=0` only the advertised prefix appears.