### PR TITLE
Fix dependencies of CONFIG_SCHED_CPULOAD_ settings

### DIFF
--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -911,6 +911,7 @@ choice
 
 config SCHED_CPULOAD_SYSCLK
 	bool "Use system clock"
+	depends on !SCHED_TICKLESS
 	---help---
 		If this option is enabled, the system clock is used for cpu load
 		measurement by default.
@@ -929,7 +930,6 @@ config SCHED_CPULOAD_SYSCLK
 
 config SCHED_CPULOAD_EXTCLK
 	bool "Use external clock"
-	depends on SCHED_TICKLESS
 	---help---
 		There is a serious issue for the accuracy of measurements if the
 		system clock is used, however.  NuttX threads are often started at


### PR DESCRIPTION
## Summary

Fix some Kconfig dependency problems from #10063.

CONFIG_SCHED_CPULOAD_EXTCLK doesn't actually require tickless mode. As long as the platform provides external call to nxsched_process_cpuload(), it will work in either tickless or ticking mode.
Removed Kconfig dependency.

Instead, CONFIG_SCHED_CPULOAD_SYSCLK does require ticking mode to work, as documented in CONFIG_SCHED_CPULOAD help text.
Added the dependency to Kconfig also.

## Impact

Fixes breaking of configurations using `CONFIG_SCHED_CPULOAD_EXTCLK`.

Automatically selects `SCHED_CPULOAD_EXTCLK` if tickless mode is enabled and selection was previously `SCHED_CPULOAD_SYSCLK`. It will behave the same: if there is no user code calling `nxsched_process_cpuload()`, cpu load will not be updated. But now the dependency is visible from Kconfig also.

## Testing

Only CI build.