### PR TITLE
Sort SAMA5D2 adc/tsd dma

### DIFF
--- a/arch/arm/src/sama5/Kconfig
+++ b/arch/arm/src/sama5/Kconfig
@@ -4260,7 +4260,7 @@ if SAMA5_ADC_HAVE_CHAN
 config SAMA5_ADC_DMA
 	bool "DMA Support"
 	default n
-	depends on SAMA5_DMAC1
+	depends on SAMA5_DMAC1 || SAMA5_XDMAC0 || SAMA5_XDMAC1
 	---help---
 		Enable DMA transfers of converted data.  This option is only
 		useful if you have numerous DMA channels enabled.  The end result

--- a/arch/arm/src/sama5/sam_adc.c
+++ b/arch/arm/src/sama5/sam_adc.c
@@ -318,14 +318,20 @@
 /* DMA configuration flags */
 
 #ifdef CONFIG_SAMA5_ADC_DMA
+#  ifdef ATSAMA5D2
+#    define DMACH_FLAG_PERIPHAHB_AHB DMACH_FLAG_PERIPHAHB_AHB_IF1
+#  else
+#    define DMACH_FLAG_PERIPHAHB_AHB DMACH_FLAG_PERIPHAHB_AHB_IF2
+#  endif
+
 #  define DMA_FLAGS \
-     DMACH_FLAG_FIFOCFG_LARGEST | \
-     DMACH_FLAG_PERIPHPID(SAM_IRQ_ADC) | DMACH_FLAG_PERIPHAHB_AHB_IF2 | \
-     DMACH_FLAG_PERIPHH2SEL | DMACH_FLAG_PERIPHISPERIPH |  \
-     DMACH_FLAG_PERIPHWIDTH_16BITS | DMACH_FLAG_PERIPHCHUNKSIZE_1 | \
-     DMACH_FLAG_MEMPID_MAX | DMACH_FLAG_MEMAHB_AHB_IF0 | \
-     DMACH_FLAG_MEMWIDTH_16BITS | DMACH_FLAG_MEMINCREMENT | \
-     DMACH_FLAG_MEMCHUNKSIZE_1 | DMACH_FLAG_MEMBURST_4)
+      DMACH_FLAG_FIFOCFG_LARGEST   | DMACH_FLAG_PERIPHPID(SAM_IRQ_ADC) | \
+      DMACH_FLAG_PERIPHAHB_AHB     | DMACH_FLAG_PERIPHH2SEL            | \
+      DMACH_FLAG_PERIPHISPERIPH    | DMACH_FLAG_PERIPHWIDTH_16BITS     | \
+      DMACH_FLAG_PERIPHCHUNKSIZE_1 | DMACH_FLAG_MEMPID_MAX             | \
+      DMACH_FLAG_MEMAHB_AHB_IF0    | DMACH_FLAG_MEMWIDTH_16BITS        | \
+      DMACH_FLAG_MEMINCREMENT      | DMACH_FLAG_MEMCHUNKSIZE_1         | \
+      DMACH_FLAG_MEMBURST_4
 #endif
 
 /* Pick an unused channel number */
@@ -1244,10 +1250,6 @@ static int sam_adc_setup(struct adc_dev_s *dev)
 
 static void sam_adc_shutdown(struct adc_dev_s *dev)
 {
-#ifdef CONFIG_SAMA5_ADC_DMA
-  struct sam_adc_s *priv = (struct sam_adc_s *)dev->ad_priv;
-#endif
-
   ainfo("Shutdown\n");
 
   /* Reset the ADC peripheral */


### PR DESCRIPTION
## Summary
SAMA5D2 uses XDMA not DMA and a few minor changes were required to get XDMA working for the ADC and TSD peripherals

## Impact
DMA should now work

## Testing
Custom board with SAM5D27C-D1G with 6 channels of ADC + touchscreen LCD

