### PR TITLE
net/local: Fix the problem that local udp socketpair cannot release fifo files.

### DIFF
--- a/net/local/local_conn.c
+++ b/net/local/local_conn.c
@@ -207,10 +207,10 @@ void local_free(FAR struct local_conn_s *conn)
     }
 #endif /* CONFIG_NET_LOCAL_SCM */
 
-#ifdef CONFIG_NET_LOCAL_STREAM
   /* Destroy all FIFOs associted with the connection */
 
   local_release_fifos(conn);
+#ifdef CONFIG_NET_LOCAL_STREAM
   nxsem_destroy(&conn->lc_waitsem);
   nxsem_destroy(&conn->lc_donesem);
 #endif


### PR DESCRIPTION

## Summary
Allow the local udp socketpair function to use the local_release_fifos interface.

## Impact
When CONFIG_NET_LOCAL_STREAM is disabled, the local udp socketpair can use the local_release_fifos
## Testing
When CONFIG_NET_LOCAL_STREAM is disabled, we can close the fifo files created by the local udp socketpair.
