### PR TITLE
Improve adjtime() functionality

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -429,6 +429,7 @@ config ARCH_CHIP_STM32
 	select ARCH_HAVE_TIMEKEEPING
 	select ARM_HAVE_MPU_UNIFIED
 	select ARMV7M_HAVE_STACKCHECK
+	select ARCH_HAVE_ADJTIME
 	---help---
 		STMicro STM32 architectures (ARM Cortex-M3/4).
 

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -217,28 +217,24 @@ config CLOCK_ADJTIME
 
 if CLOCK_ADJTIME
 
-config CLOCK_ADJTIME_SLEWLIMIT
+config CLOCK_ADJTIME_SLEWLIMIT_PPM
 	int "Adjtime slew limit"
-	default 2
-	range 0 100
+	default 20000
+	range 1 1000000
 	---help---
+		Set limit of adjtime() clock slewing as parts per million.
+
 		In real time systems we do not want the time to adjust too quickly.
-		CLOCK_ADJTIME_SLEWLIMIT defines how many seconds can time change
-		during each clock.
+		For example CLOCK_ADJTIME_SLEWLIMIT=1000 will slow or speed the timer
+		tick period by at most 0.1 percent of the nominal value.
 
-		Note that CLOCK_ADJTIME_SLEWLIMIT is divided by 100 in source code,
-		therefore CLOCK_ADJTIME_SLEWLIMIT=2 will result in possible 0.02 second
-		adjustment.
-
-config CLOCK_ADJTIME_PERIOD
+config CLOCK_ADJTIME_PERIOD_MS
 	int "Adjtime period"
-	default 97
-	range 0 100
+	default 970
+	range 1 3600000
 	---help---
-		Define system clock adjustment period. Should be between 0.95 and 0.99.
-
-		Note that CLOCK_ADJTIME_PERIOD is divided by 100 in source code,
-		therefore CLOCK_ADJTIME_PERIOD=97 will result in 0.97.
+		Define system clock adjustment period in milliseconds.
+		The adjustment commanded by adjtime() call is applied over this time period.
 
 endif
 


### PR DESCRIPTION
## Summary

Prior pull request #9084 and issue #8858 added basic adjtime() support for the SAMv7 platform.

This pull request adds support for STM32 platform.

In addition I have made a few changes to the adjtime() configuration options:

    1) Previously adjustments less than 1 microsecond per tick would be
       completely ignored. Now they are applied over a shorter period at
       a rate of 1 us per tick.
    
    2) Previously CLOCK_ADJTIME_PERIOD was in units of 1/100th of second.
       Change to milliseconds to be more generally useful unit.
       Change setting name to CLOCK_ADJTIME_PERIOD_MS to make the unit change
       easier to notice.
    
    3) Previously CLOCK_ADJTIME_SLEWLIMIT was in percentage.
       Most clock crystals have better accuracy than 1%, so the minimum slew
       rate was excessive. Change to CLOCK_ADJTIME_SLEWLIMIT_PPM with setting
       value in parts per million.
    
    4) No need to use floating point math in clock_adjtime.c.

## Impact

Users who have used `CLOCK_ADJTIME_PERIOD` and `CLOCK_ADJTIME_SLEWLIMIT` settings should update their configuration. New `CLOCK_ADJTIME_PERIOD_MS` is 10x the old period value, and new `CLOCK_ADJTIME_SLEWLIMIT_PPM` is 10000 times the old slewlimit.

## Testing

Tested on custom STM32 board with the `adjtime` example program.

## Questions

@michallenc I couldn't find the significance of the `Should be between 0.95 and 0.99.` comment that was previously in help text for `CLOCK_ADJTIME_PERIOD`. To me it appears that the desirable value for this setting will depend entirely on what code will be calling `adjtime()` and how often.
