### PR TITLE
arch: add a flag indicating that we need up_perf_xxx

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -502,6 +502,7 @@ config ARCH_HAVE_PERF_EVENTS
 
 config ARCH_PERF_EVENTS
 	bool "Configure hardware performance counting"
+	default y if SCHED_CRITMONITOR || SCHED_IRQMONITOR || RPTUN_PING || SEGGER_SYSVIEW
 	default n
 	depends on ARCH_HAVE_PERF_EVENTS
 	---help---

--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -502,7 +502,7 @@ config ARCH_HAVE_PERF_EVENTS
 
 config ARCH_PERF_EVENTS
 	bool "Configure hardware performance counting"
-	default y
+	default n
 	depends on ARCH_HAVE_PERF_EVENTS
 	---help---
 		Enable hardware performance counter support for perf events. If

--- a/arch/arm/src/at32/at32_start.c
+++ b/arch/arm/src/at32/at32_start.c
@@ -155,7 +155,7 @@ void __start(void)
 
   showprogress('C');
 
-#ifdef CONFIG_SCHED_IRQMONITOR
+#ifdef CONFIG_ARCH_PERF_EVENTS
   up_perf_init((void *)AT32_SYSCLK_FREQUENCY);
 #endif
 

--- a/arch/arm/src/nrf52/nrf52_start.c
+++ b/arch/arm/src/nrf52/nrf52_start.c
@@ -203,7 +203,7 @@ void __start(void)
   nrf52_enable_profile(true);
 #endif
 
-#if defined(CONFIG_SCHED_IRQMONITOR) || defined(CONFIG_SEGGER_SYSVIEW)
+#ifdef CONFIG_ARCH_PERF_EVENTS
   up_perf_init((void *)BOARD_SYSTICK_CLOCK);
 #endif
 

--- a/arch/arm/src/nrf53/nrf53_start.c
+++ b/arch/arm/src/nrf53/nrf53_start.c
@@ -247,7 +247,7 @@ void __start(void)
   nrf53_enable_profile(true);
 #endif
 
-#if defined(CONFIG_SCHED_IRQMONITOR) || defined(CONFIG_SEGGER_SYSVIEW)
+#ifdef CONFIG_ARCH_PERF_EVENTS
   up_perf_init((void *)BOARD_SYSTICK_CLOCK);
 #endif
 

--- a/arch/arm/src/nrf91/nrf91_start.c
+++ b/arch/arm/src/nrf91/nrf91_start.c
@@ -235,7 +235,7 @@ void __start(void)
   nrf91_enable_profile(true);
 #endif
 
-#if defined(CONFIG_SCHED_IRQMONITOR) || defined(CONFIG_SEGGER_SYSVIEW)
+#ifdef CONFIG_ARCH_PERF_EVENTS
   up_perf_init((void *)BOARD_SYSTICK_CLOCK);
 #endif
 

--- a/arch/arm/src/stm32/stm32_start.c
+++ b/arch/arm/src/stm32/stm32_start.c
@@ -158,7 +158,7 @@ void __start(void)
 
   showprogress('C');
 
-#if defined(CONFIG_SCHED_IRQMONITOR) || defined(CONFIG_SEGGER_SYSVIEW)
+#ifdef CONFIG_ARCH_PERF_EVENTS
   up_perf_init((void *)STM32_SYSCLK_FREQUENCY);
 #endif
 

--- a/arch/arm/src/stm32f0l0g0/stm32_start.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_start.c
@@ -115,7 +115,7 @@ void __start(void)
 
   showprogress('C');
 
-#if defined(CONFIG_SCHED_IRQMONITOR) || defined(CONFIG_SEGGER_SYSVIEW)
+#ifdef CONFIG_ARCH_PERF_EVENTS
   up_perf_init((void *)STM32_SYSCLK_FREQUENCY);
 #endif
 

--- a/arch/arm/src/stm32f7/stm32_start.c
+++ b/arch/arm/src/stm32f7/stm32_start.c
@@ -245,7 +245,7 @@ void __start(void)
   up_enable_dcache();
   showprogress('C');
 
-#if defined(CONFIG_SCHED_IRQMONITOR) || defined(CONFIG_SEGGER_SYSVIEW)
+#ifdef CONFIG_ARCH_PERF_EVENTS
   up_perf_init((void *)STM32_SYSCLK_FREQUENCY);
 #endif
 

--- a/arch/arm/src/stm32h7/stm32_start.c
+++ b/arch/arm/src/stm32h7/stm32_start.c
@@ -265,7 +265,7 @@ void __start(void)
 #endif
   showprogress('C');
 
-#if defined(CONFIG_SCHED_IRQMONITOR) || defined(CONFIG_SEGGER_SYSVIEW)
+#ifdef CONFIG_ARCH_PERF_EVENTS
   up_perf_init((void *)STM32_CPUCLK_FREQUENCY);
 #endif
 

--- a/arch/arm/src/stm32l4/stm32l4_start.c
+++ b/arch/arm/src/stm32l4/stm32l4_start.c
@@ -179,7 +179,7 @@ void __start(void)
 
   showprogress('C');
 
-#if defined(CONFIG_SCHED_IRQMONITOR) || defined(CONFIG_SEGGER_SYSVIEW)
+#ifdef CONFIG_ARCH_PERF_EVENTS
   up_perf_init((void *)STM32_SYSCLK_FREQUENCY);
 #endif
 

--- a/arch/arm/src/stm32l5/stm32l5_start.c
+++ b/arch/arm/src/stm32l5/stm32l5_start.c
@@ -181,7 +181,7 @@ void __start(void)
 
   showprogress('C');
 
-#if defined(CONFIG_SCHED_IRQMONITOR) || defined(CONFIG_SEGGER_SYSVIEW)
+#ifdef CONFIG_ARCH_PERF_EVENTS
   up_perf_init((void *)STM32_SYSCLK_FREQUENCY);
 #endif
 

--- a/arch/arm/src/stm32u5/stm32_start.c
+++ b/arch/arm/src/stm32u5/stm32_start.c
@@ -181,7 +181,7 @@ void __start(void)
 
   showprogress('C');
 
-#if defined(CONFIG_SCHED_IRQMONITOR) || defined(CONFIG_SEGGER_SYSVIEW)
+#ifdef CONFIG_ARCH_PERF_EVENTS
   up_perf_init((void *)STM32_SYSCLK_FREQUENCY);
 #endif
 

--- a/arch/arm/src/stm32wb/stm32wb_start.c
+++ b/arch/arm/src/stm32wb/stm32wb_start.c
@@ -199,7 +199,7 @@ void __start(void)
 
   showprogress('C');
 
-#if defined(CONFIG_SCHED_IRQMONITOR) || defined(CONFIG_SEGGER_SYSVIEW)
+#ifdef CONFIG_ARCH_PERF_EVENTS
   up_perf_init((void *)STM32_SYSCLK_FREQUENCY);
 #endif
 

--- a/arch/arm/src/stm32wl5/stm32wl5_start.c
+++ b/arch/arm/src/stm32wl5/stm32wl5_start.c
@@ -183,7 +183,7 @@ void __start(void)
 
   showprogress('C');
 
-#if defined(CONFIG_SCHED_IRQMONITOR) || defined(CONFIG_SEGGER_SYSVIEW)
+#ifdef CONFIG_ARCH_PERF_EVENTS
   up_perf_init((void *)STM32_SYSCLK_FREQUENCY);
 #endif
 

--- a/boards/arm/lpc17xx_40xx/lx_cpu/src/lpc17_40_boardinitialize.c
+++ b/boards/arm/lpc17xx_40xx/lx_cpu/src/lpc17_40_boardinitialize.c
@@ -51,7 +51,7 @@
 
 void lpc17_40_boardinitialize(void)
 {
-#ifdef CONFIG_SCHED_IRQMONITOR
+#ifdef CONFIG_ARCH_PERF_EVENTS
   up_perf_init((void *)LPC17_40_CCLK);
 #endif
 

--- a/boards/arm/s32k1xx/rddrone-bms772/src/s32k1xx_boot.c
+++ b/boards/arm/s32k1xx/rddrone-bms772/src/s32k1xx_boot.c
@@ -47,7 +47,7 @@
 
 void s32k1xx_board_initialize(void)
 {
-#ifdef CONFIG_SEGGER_SYSVIEW
+#ifdef CONFIG_ARCH_PERF_EVENTS
   up_perf_init((void *)RDDRONE_BMS772_RUN_SYSCLK_FREQUENCY);
 #endif
 

--- a/boards/arm/s32k1xx/s32k144evb/src/s32k1xx_boot.c
+++ b/boards/arm/s32k1xx/s32k144evb/src/s32k1xx_boot.c
@@ -45,7 +45,7 @@
 
 void s32k1xx_board_initialize(void)
 {
-#ifdef CONFIG_SEGGER_SYSVIEW
+#ifdef CONFIG_ARCH_PERF_EVENTS
   up_perf_init((void *)S32K144EVB_RUN_SYSCLK_FREQUENCY);
 #endif
 

--- a/boards/arm/s32k1xx/s32k146evb/src/s32k1xx_boot.c
+++ b/boards/arm/s32k1xx/s32k146evb/src/s32k1xx_boot.c
@@ -45,7 +45,7 @@
 
 void s32k1xx_board_initialize(void)
 {
-#ifdef CONFIG_SEGGER_SYSVIEW
+#ifdef CONFIG_ARCH_PERF_EVENTS
   up_perf_init((void *)S32K146EVB_RUN_SYSCLK_FREQUENCY);
 #endif
 

--- a/boards/arm/s32k1xx/s32k148evb/src/s32k1xx_boot.c
+++ b/boards/arm/s32k1xx/s32k148evb/src/s32k1xx_boot.c
@@ -45,7 +45,7 @@
 
 void s32k1xx_board_initialize(void)
 {
-#ifdef CONFIG_SEGGER_SYSVIEW
+#ifdef CONFIG_ARCH_PERF_EVENTS
   up_perf_init((void *)S32K148EVB_RUN_SYSCLK_FREQUENCY);
 #endif
 

--- a/boards/arm/s32k1xx/ucans32k146/src/s32k1xx_boot.c
+++ b/boards/arm/s32k1xx/ucans32k146/src/s32k1xx_boot.c
@@ -45,7 +45,7 @@
 
 void s32k1xx_board_initialize(void)
 {
-#ifdef CONFIG_SEGGER_SYSVIEW
+#ifdef CONFIG_ARCH_PERF_EVENTS
   up_perf_init((void *)UCANS32K146_RUN_SYSCLK_FREQUENCY);
 #endif
 

--- a/boards/arm/s32k3xx/mr-canhubk3/src/s32k3xx_boot.c
+++ b/boards/arm/s32k3xx/mr-canhubk3/src/s32k3xx_boot.c
@@ -47,7 +47,7 @@
 
 void s32k3xx_board_initialize(void)
 {
-#ifdef CONFIG_SEGGER_SYSVIEW
+#ifdef CONFIG_ARCH_PERF_EVENTS
   up_perf_init((void *)MR_CANHUBK3_SYSCLK_FREQUENCY);
 #endif
 

--- a/boards/risc-v/esp32c3/esp32c3-devkit-rust-1/src/esp32c3_boot.c
+++ b/boards/risc-v/esp32c3/esp32c3-devkit-rust-1/src/esp32c3_boot.c
@@ -52,7 +52,7 @@
 
 void esp32c3_board_initialize(void)
 {
-#ifdef CONFIG_SCHED_CRITMONITOR
+#ifdef CONFIG_ARCH_PERF_EVENTS
   up_perf_init(NULL);
 #endif
 

--- a/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_boot.c
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_boot.c
@@ -51,7 +51,7 @@
 
 void esp32c3_board_initialize(void)
 {
-#ifdef CONFIG_SCHED_CRITMONITOR
+#ifdef CONFIG_ARCH_PERF_EVENTS
   up_perf_init(NULL);
 #endif
 


### PR DESCRIPTION
## Summary

- arch/ add a flag indicating that we need up_perf_xxx
- arch/{all stm32 | all nordic | at32}: simplify the enable condition for up_perf_init

waiting for https://github.com/apache/nuttx/pull/10826

## Impact

automatically initializes perf when needed

## Testing
CI
