### PR TITLE
arch/nrf{52|53|91}: fixes for timer

### DIFF
--- a/arch/arm/src/nrf52/nrf52_tim_lowerhalf.c
+++ b/arch/arm/src/nrf52/nrf52_tim_lowerhalf.c
@@ -46,9 +46,13 @@
 #define NRF52_TIMER_CC  (NRF52_TIM_CC0)
 #define NRF52_TIMER_INT (NRF52_TIM_INT_COMPARE0)
 #define NRF52_TIMER_RES (NRF52_TIM_WIDTH_32B)
-#define NRF52_TIMER_MAX (0xffffffff)
+#define NRF52_TIMER_MAX (4294967295ul)
 #define NRF52_TIMER_PRE (NRF52_TIM_PRE_1000000)
 #define NRF52_TIMER_PER (1000000)
+
+/* Maximum supported timeout */
+
+#define NRF52_TIMER_MAXTIMEOUT (NRF52_TIMER_MAX * 1000000 / NRF52_TIMER_PER)
 
 /****************************************************************************
  * Private Types
@@ -350,7 +354,7 @@ static int nrf52_timer_settimeout(struct timer_lowerhalf_s *lower,
 {
   struct nrf52_timer_lowerhalf_s *priv =
     (struct nrf52_timer_lowerhalf_s *)lower;
-  uint64_t cc  = 0;
+  uint32_t cc  = 0;
   int      ret = OK;
 
   DEBUGASSERT(priv);
@@ -361,13 +365,13 @@ static int nrf52_timer_settimeout(struct timer_lowerhalf_s *lower,
       goto errout;
     }
 
-  if (timeout > NRF52_TIMER_MAX)
+  if (timeout > NRF52_TIMER_MAXTIMEOUT)
     {
       ret = -EINVAL;
       goto errout;
     }
 
-  cc = (timeout / 1000000) * NRF52_TIMER_PER;
+  cc = (timeout * NRF52_TIMER_PER / 1000000);
   NRF52_TIM_SETCC(priv->tim, NRF52_TIMER_CC, cc);
 
 errout:

--- a/arch/arm/src/nrf53/nrf53_tim_lowerhalf.c
+++ b/arch/arm/src/nrf53/nrf53_tim_lowerhalf.c
@@ -46,9 +46,13 @@
 #define NRF53_TIMER_CC  (NRF53_TIM_CC0)
 #define NRF53_TIMER_INT (NRF53_TIM_INT_COMPARE0)
 #define NRF53_TIMER_RES (NRF53_TIM_WIDTH_32B)
-#define NRF53_TIMER_MAX (0xffffffff)
+#define NRF53_TIMER_MAX (4294967295ul)
 #define NRF53_TIMER_PRE (NRF53_TIM_PRE_1000000)
 #define NRF53_TIMER_PER (1000000)
+
+/* Maximum supported timeout */
+
+#define NRF53_TIMER_MAXTIMEOUT (NRF53_TIMER_MAX * 1000000 / NRF53_TIMER_PER)
 
 /****************************************************************************
  * Private Types
@@ -350,7 +354,7 @@ static int nrf53_timer_settimeout(struct timer_lowerhalf_s *lower,
 {
   struct nrf53_timer_lowerhalf_s *priv =
     (struct nrf53_timer_lowerhalf_s *)lower;
-  uint64_t cc  = 0;
+  uint32_t cc  = 0;
   int      ret = OK;
 
   DEBUGASSERT(priv);
@@ -361,13 +365,13 @@ static int nrf53_timer_settimeout(struct timer_lowerhalf_s *lower,
       goto errout;
     }
 
-  if (timeout > NRF53_TIMER_MAX)
+  if (timeout > NRF53_TIMER_MAXTIMEOUT)
     {
       ret = -EINVAL;
       goto errout;
     }
 
-  cc = (timeout / 1000000) * NRF53_TIMER_PER;
+  cc = (timeout * NRF53_TIMER_PER / 1000000);
   NRF53_TIM_SETCC(priv->tim, NRF53_TIMER_CC, cc);
 
 errout:

--- a/arch/arm/src/nrf91/nrf91_tim_lowerhalf.c
+++ b/arch/arm/src/nrf91/nrf91_tim_lowerhalf.c
@@ -46,9 +46,13 @@
 #define NRF91_TIMER_CC  (NRF91_TIM_CC0)
 #define NRF91_TIMER_INT (NRF91_TIM_INT_COMPARE0)
 #define NRF91_TIMER_RES (NRF91_TIM_WIDTH_32B)
-#define NRF91_TIMER_MAX (0xffffffff)
+#define NRF91_TIMER_MAX (4294967295ul)
 #define NRF91_TIMER_PRE (NRF91_TIM_PRE_1000000)
 #define NRF91_TIMER_PER (1000000)
+
+/* Maximum supported timeout */
+
+#define NRF91_TIMER_MAXTIMEOUT (NRF91_TIMER_MAX * 1000000 / NRF91_TIMER_PER)
 
 /****************************************************************************
  * Private Types
@@ -350,7 +354,7 @@ static int nrf91_timer_settimeout(struct timer_lowerhalf_s *lower,
 {
   struct nrf91_timer_lowerhalf_s *priv =
     (struct nrf91_timer_lowerhalf_s *)lower;
-  uint64_t cc  = 0;
+  uint32_t cc  = 0;
   int      ret = OK;
 
   DEBUGASSERT(priv);
@@ -361,13 +365,13 @@ static int nrf91_timer_settimeout(struct timer_lowerhalf_s *lower,
       goto errout;
     }
 
-  if (timeout > NRF91_TIMER_MAX)
+  if (timeout > NRF91_TIMER_MAXTIMEOUT)
     {
       ret = -EINVAL;
       goto errout;
     }
 
-  cc = (timeout / 1000000) * NRF91_TIMER_PER;
+  cc = (timeout * NRF91_TIMER_PER / 1000000);
   NRF91_TIM_SETCC(priv->tim, NRF91_TIMER_CC, cc);
 
 errout:


### PR DESCRIPTION
## Summary
arch/nrf{52|53|91}: fix timer for small intervals and correct CC overflow check
## Impact

## Testing
nrf52832-dk
