### PR TITLE
drivers/rtt: make RTT console optional

### DIFF
--- a/drivers/segger/Kconfig
+++ b/drivers/segger/Kconfig
@@ -173,8 +173,15 @@ config SERIAL_RTT2
 		This option is used to enable the serial driver of channel 2
 
 config SERIAL_RTT_CONSOLE
-	int "Segger RTT console channel"
+	bool "Segger RTT console support"
 	depends on SERIAL_RTT
+	default y
+	---help---
+		If this opsion is selected, then RTT channel can be used as console
+
+config SERIAL_RTT_CONSOLE_CHANNEL
+	int "Segger RTT console channel"
+	depends on SERIAL_RTT && SERIAL_RTT_CONSOLE
 	default 0 if SERIAL_RTT0
 	default 1 if SERIAL_RTT1
 	default 2 if SERIAL_RTT2

--- a/drivers/segger/serial_rtt.c
+++ b/drivers/segger/serial_rtt.c
@@ -116,7 +116,9 @@ static struct serial_rtt_s g_serial_rtt0 =
 {
   .uart =
   {
-    .isconsole = CONFIG_SERIAL_RTT_CONSOLE == 0,
+#ifdef CONFIG_SERIAL_RTT_CONSOLE
+    .isconsole = CONFIG_SERIAL_RTT_CONSOLE_CHANNEL == 0,
+#endif
     .recv =
     {
       .buffer = g_rtt0_recv_buffer,
@@ -149,7 +151,9 @@ static struct serial_rtt_s g_serial_rtt1 =
 {
   .uart =
   {
-    .isconsole = CONFIG_SERIAL_RTT_CONSOLE == 1,
+#ifdef CONFIG_SERIAL_RTT_CONSOLE
+    .isconsole = CONFIG_SERIAL_RTT_CONSOLE_CHANNEL == 1,
+#endif
     .recv =
     {
       .buffer = g_rtt1_recv_buffer,
@@ -182,7 +186,9 @@ static struct serial_rtt_s g_serial_rtt2 =
 {
   .uart =
   {
-    .isconsole = CONFIG_SERIAL_RTT_CONSOLE == 2,
+#ifdef CONFIG_SERIAL_RTT_CONSOLE
+    .isconsole = CONFIG_SERIAL_RTT_CONSOLE_CHANNEL == 2,
+#endif
     .recv =
     {
       .buffer = g_rtt2_recv_buffer,
@@ -427,10 +433,12 @@ static void serial_rtt_register(FAR const char *name,
                               rtt->uart.recv.size,
                               SEGGER_RTT_MODE_NO_BLOCK_TRIM);
 
+#ifdef CONFIG_SERIAL_RTT_CONSOLE
   if (rtt->uart.isconsole)
     {
       uart_register("/dev/console", &rtt->uart);
     }
+#endif
 
   uart_register(name, &rtt->uart);
 }


### PR DESCRIPTION
## Summary
drivers/rtt: make RTT console optional
## Impact
in case we want to use serial RTT to stream data without console support
## Testing
nxscope stream over RTT
