### PR TITLE
Initialize LED driver during late initialization for nucleo-f446re

### DIFF
--- a/boards/arm/stm32/nucleo-f446re/src/stm32_bringup.c
+++ b/boards/arm/stm32/nucleo-f446re/src/stm32_bringup.c
@@ -54,6 +54,10 @@
 #  include <nuttx/video/fb.h>
 #endif
 
+#ifdef CONFIG_USERLED
+#  include <nuttx/leds/userled.h>
+#endif
+
 #include "stm32_romfs.h"
 #include "nucleo-f446re.h"
 
@@ -247,6 +251,16 @@ int stm32_bringup(void)
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: stm32_gpio_initialize() failed: %d\n", ret);
+    }
+#endif
+
+#ifdef CONFIG_USERLED
+  /* Register the LED driver */
+
+  ret = userled_lower_initialize("/dev/userleds");
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: userled_lower_initialize() failed: %d\n", ret);
     }
 #endif
 


### PR DESCRIPTION
## Summary
Changes are made for the nucleo-f446re board.
- Initialize LED driver when `CONFIG_USERLED` is set, during late initialization. 
- Cleaned up `stm32_userleds.c`.

## Impact
Make LED driver work when:
1. `CONFIG_ARCH_LEDS` is not set.
2. `CONFIG_USERLED` is set.
3. `CONFIG_BOARD_LATE_INITIALIZE` is set.

## Testing
Using `nucleo-f446re:nsh` configuration as a starting point, apply the above-mentioned changes, and enable the LED Example. The LED blink as expected. 
