### PR TITLE
timer: handle perf count overflow

### DIFF
--- a/drivers/note/note_driver.c
+++ b/drivers/note/note_driver.c
@@ -234,20 +234,13 @@ static void note_common(FAR struct tcb_s *tcb,
                         FAR struct note_common_s *note,
                         uint8_t length, uint8_t type)
 {
-#ifdef CONFIG_SCHED_INSTRUMENTATION_PERFCOUNT
-  struct timespec perftime;
-#endif
   struct timespec ts;
-  clock_systime_timespec(&ts);
-#ifdef CONFIG_SCHED_INSTRUMENTATION_PERFCOUNT
-  up_perf_convert(up_perf_gettime(), &perftime);
-  ts.tv_nsec = perftime.tv_nsec;
-#endif
+  perf_convert(perf_gettime(), &ts);
 
   /* Save all of the common fields */
 
-  note->nc_length   = length;
-  note->nc_type     = type;
+  note->nc_length = length;
+  note->nc_type   = type;
 
   if (tcb == NULL)
     {

--- a/drivers/rptun/rptun_ping.c
+++ b/drivers/rptun/rptun_ping.c
@@ -28,6 +28,7 @@
 #include <inttypes.h>
 #include <string.h>
 #include <sys/param.h>
+#include <time.h>
 
 #include "rptun.h"
 
@@ -121,11 +122,11 @@ static int rptun_ping_once(FAR struct rpmsg_endpoint *ept,
   return ret;
 }
 
-static void rptun_ping_logout(FAR const char *s, unsigned long value)
+static void rptun_ping_logout(FAR const char *s, clock_t value)
 {
   struct timespec ts;
 
-  up_perf_convert(value, &ts);
+  perf_convert(value, &ts);
 
 #ifdef CONFIG_SYSTEM_TIME64
   syslog(LOG_INFO, "%s: s %" PRIu64 ", ns %ld\n", s, ts.tv_sec, ts.tv_nsec);
@@ -141,8 +142,8 @@ static void rptun_ping_logout(FAR const char *s, unsigned long value)
 int rptun_ping(FAR struct rpmsg_endpoint *ept,
                FAR const struct rptun_ping_s *ping)
 {
-  unsigned long min = ULONG_MAX;
-  unsigned long max = 0;
+  clock_t min = ULONG_MAX;
+  clock_t max = 0;
   uint64_t total = 0;
   int i;
 
@@ -153,7 +154,7 @@ int rptun_ping(FAR struct rpmsg_endpoint *ept,
 
   for (i = 0; i < ping->times; i++)
     {
-      unsigned long tm = up_perf_gettime();
+      clock_t tm = perf_gettime();
 
       int ret = rptun_ping_once(ept, ping->len, ping->ack);
       if (ret < 0)
@@ -161,7 +162,7 @@ int rptun_ping(FAR struct rpmsg_endpoint *ept,
           return ret;
         }
 
-      tm     = up_perf_gettime() - tm;
+      tm     = perf_gettime() - tm;
       min    = MIN(min, tm);
       max    = MAX(max, tm);
       total += tm;
@@ -169,8 +170,7 @@ int rptun_ping(FAR struct rpmsg_endpoint *ept,
       usleep(ping->sleep * USEC_PER_MSEC);
     }
 
-  syslog(LOG_INFO, "current CPU freq: %lu, ping times: %d\n",
-                    up_perf_getfreq(), ping->times);
+  syslog(LOG_INFO, "ping times: %d\n", ping->times);
 
   rptun_ping_logout("avg", total / ping->times);
   rptun_ping_logout("min", min);

--- a/drivers/segger/note_sysview.c
+++ b/drivers/segger/note_sysview.c
@@ -350,7 +350,7 @@ unsigned int note_sysview_get_interrupt_id(void)
 
 unsigned long note_sysview_get_timestamp(void)
 {
-  return up_perf_gettime();
+  return perf_gettime();
 }
 
 /****************************************************************************
@@ -369,7 +369,7 @@ unsigned long note_sysview_get_timestamp(void)
 
 int note_sysview_initialize(void)
 {
-  unsigned long freq = up_perf_getfreq();
+  unsigned long freq = perf_getfreq();
   int ret;
 
   static const SEGGER_SYSVIEW_OS_API g_sysview_trace_api =

--- a/fs/procfs/fs_procfscritmon.c
+++ b/fs/procfs/fs_procfscritmon.c
@@ -191,7 +191,7 @@ static ssize_t critmon_read_cpu(FAR struct critmon_file_s *attr,
 
   if (g_premp_max[cpu] > 0)
     {
-      up_perf_convert(g_premp_max[cpu], &maxtime);
+      perf_convert(g_premp_max[cpu], &maxtime);
     }
   else
     {
@@ -222,7 +222,7 @@ static ssize_t critmon_read_cpu(FAR struct critmon_file_s *attr,
 
   if (g_crit_max[cpu] > 0)
     {
-      up_perf_convert(g_crit_max[cpu], &maxtime);
+      perf_convert(g_crit_max[cpu], &maxtime);
     }
   else
     {

--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -775,7 +775,7 @@ static ssize_t proc_critmon(FAR struct proc_file_s *procfile,
 
   if (tcb->premp_max > 0)
     {
-      up_perf_convert(tcb->premp_max, &maxtime);
+      perf_convert(tcb->premp_max, &maxtime);
     }
   else
     {
@@ -808,7 +808,7 @@ static ssize_t proc_critmon(FAR struct proc_file_s *procfile,
 
   if (tcb->crit_max > 0)
     {
-      up_perf_convert(tcb->crit_max, &maxtime);
+      perf_convert(tcb->crit_max, &maxtime);
     }
   else
     {
@@ -841,7 +841,7 @@ static ssize_t proc_critmon(FAR struct proc_file_s *procfile,
 
   if (tcb->run_max > 0)
     {
-      up_perf_convert(tcb->run_max, &maxtime);
+      perf_convert(tcb->run_max, &maxtime);
     }
   else
     {
@@ -852,7 +852,7 @@ static ssize_t proc_critmon(FAR struct proc_file_s *procfile,
   /* Reset the maximum */
 
   tcb->run_max = 0;
-  up_perf_convert(tcb->run_time, &runtime);
+  perf_convert(tcb->run_time, &runtime);
 
   /* Output the maximum time the thread has run and
    * the total time the thread has run

--- a/include/limits.h
+++ b/include/limits.h
@@ -232,6 +232,12 @@
 #define TIMER_MAX      _POSIX_TIMER_MAX
 #define CLOCKRES_MIN   _POSIX_CLOCKRES_MIN
 
+#ifdef CONFIG_SYSTEM_TIME64
+#  define CLOCK_MAX    UINT64_MAX
+#else
+#  define CLOCK_MAX    UINT32_MAX
+#endif
+
 /* Other invariant values */
 
 /* CHARCLASS_NAME_MAX

--- a/include/nuttx/clock.h
+++ b/include/nuttx/clock.h
@@ -663,6 +663,24 @@ struct timer_lowerhalf_s;
 void nxsched_period_extclk(FAR struct timer_lowerhalf_s *lower);
 #endif
 
+/****************************************************************************
+ * perf_gettime
+ ****************************************************************************/
+
+clock_t perf_gettime(void);
+
+/****************************************************************************
+ * perf_convert
+ ****************************************************************************/
+
+void perf_convert(clock_t elapsed, FAR struct timespec *ts);
+
+/****************************************************************************
+ * perf_gettfreq
+ ****************************************************************************/
+
+unsigned long perf_getfreq(void);
+
 #undef EXTERN
 #ifdef __cplusplus
 }

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -631,13 +631,13 @@ struct tcb_s
   /* Pre-emption monitor support ********************************************/
 
 #ifdef CONFIG_SCHED_CRITMONITOR
-  unsigned long premp_start;             /* Time when preemption disabled   */
-  unsigned long premp_max;               /* Max time preemption disabled    */
-  unsigned long crit_start;              /* Time critical section entered   */
-  unsigned long crit_max;                /* Max time in critical section    */
-  unsigned long run_start;               /* Time when thread begin run      */
-  unsigned long run_max;                 /* Max time thread run             */
-  unsigned long run_time;                /* Total time thread run           */
+  clock_t premp_start;             /* Time when preemption disabled   */
+  clock_t premp_max;               /* Max time preemption disabled    */
+  clock_t crit_start;              /* Time critical section entered   */
+  clock_t crit_max;                /* Max time in critical section    */
+  clock_t run_start;               /* Time when thread begin run      */
+  clock_t run_max;                 /* Max time thread run             */
+  clock_t run_time;                /* Total time thread run           */
 #endif
 
   /* State save areas *******************************************************/
@@ -762,8 +762,8 @@ extern "C"
 #ifdef CONFIG_SCHED_CRITMONITOR
 /* Maximum time with pre-emption disabled or within critical section. */
 
-EXTERN unsigned long g_premp_max[CONFIG_SMP_NCPUS];
-EXTERN unsigned long g_crit_max[CONFIG_SMP_NCPUS];
+EXTERN clock_t g_premp_max[CONFIG_SMP_NCPUS];
+EXTERN clock_t g_crit_max[CONFIG_SMP_NCPUS];
 #endif /* CONFIG_SCHED_CRITMONITOR */
 
 EXTERN const struct tcbinfo_s g_tcbinfo;

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -1080,14 +1080,6 @@ config SCHED_INSTRUMENTATION_CPUSET
 	---help---
 		Monitor only CPUs in the bitset.  Bit 0=CPU0, Bit1=CPU1, etc.
 
-config SCHED_INSTRUMENTATION_PERFCOUNT
-	bool "Use perf count for instrumentation"
-	default n
-	---help---
-		Enabling this option will use perfcount as the clock source for tv_nsec
-		to achieve higher precision time.
-		This requires calling up_perf_init at system startup.
-
 config SCHED_INSTRUMENTATION_FILTER
 	bool "Instrumentation filter"
 	default n

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -283,6 +283,16 @@ config PREALLOC_TIMERS
 		pool of preallocated timer structures to minimize dynamic allocations.  Set to
 		zero for all dynamic allocations.
 
+config PERF_OVERFLOW_CORRECTION
+	bool "Compensate perf count overflow"
+	depends on SYSTEM_TIME64 && (ALARM_ARCH || TIMER_ARCH || ARCH_PERF_EVENTS)
+	default n
+	---help---
+		If this option is enabled, then the perf event will be enabled
+		by default.
+		When enabled, it will always return an increasing count value to
+		avoid overflow on 32-bit platforms.
+
 endmenu # Clocks and Timers
 
 menu "Tasks and Scheduling"

--- a/sched/clock/CMakeLists.txt
+++ b/sched/clock/CMakeLists.txt
@@ -20,6 +20,7 @@
 
 set(SRCS
     clock.c
+    clock_perf.c
     clock_initialize.c
     clock_settime.c
     clock_gettime.c

--- a/sched/clock/Make.defs
+++ b/sched/clock/Make.defs
@@ -20,6 +20,7 @@
 
 CSRCS += clock.c clock_initialize.c clock_settime.c clock_gettime.c
 CSRCS += clock_abstime2ticks.c clock_systime_ticks.c clock_systime_timespec.c
+CSRCS += clock_perf.c
 
 ifeq ($(CONFIG_CLOCK_TIMEKEEPING),y)
 CSRCS += clock_timekeeping.c

--- a/sched/clock/clock.h
+++ b/sched/clock/clock.h
@@ -94,4 +94,10 @@ int  clock_abstime2ticks(clockid_t clockid,
                          FAR const struct timespec *abstime,
                          FAR sclock_t *ticks);
 
+/****************************************************************************
+ * perf_init
+ ****************************************************************************/
+
+void perf_init(void);
+
 #endif /* __SCHED_CLOCK_CLOCK_H */

--- a/sched/clock/clock_gettime.c
+++ b/sched/clock/clock_gettime.c
@@ -155,7 +155,7 @@ int clock_gettime(clockid_t clock_id, struct timespec *tp)
 
       if (tcb != NULL)
         {
-          up_perf_convert(tcb->run_time, tp);
+          perf_convert(tcb->run_time, tp);
         }
       else
         {
@@ -197,7 +197,7 @@ int clock_gettime(clockid_t clock_id, struct timespec *tp)
             }
 
           leave_critical_section(flags);
-          up_perf_convert(runtime, tp);
+          perf_convert(runtime, tp);
         }
       else
         {

--- a/sched/clock/clock_initialize.c
+++ b/sched/clock/clock_initialize.c
@@ -237,6 +237,8 @@ void clock_initialize(void)
 
 #endif
 
+  perf_init();
+
   sched_trace_end();
 }
 

--- a/sched/clock/clock_perf.c
+++ b/sched/clock/clock_perf.c
@@ -1,0 +1,203 @@
+/****************************************************************************
+ * sched/clock/clock_perf.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdint.h>
+
+#include <nuttx/clock.h>
+#include <nuttx/arch.h>
+#include <nuttx/wdog.h>
+
+#if defined(CONFIG_PERF_OVERFLOW_CORRECTION) && ULONG_MAX != UINT64_MAX
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct perf_s
+{
+  struct wdog_s wdog;
+  unsigned long last;
+  unsigned long overflow;
+};
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static struct perf_s g_perf;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * perf_update
+ ****************************************************************************/
+
+static void perf_update(wdparm_t arg)
+{
+  clock_t tick = (clock_t)LONG_MAX * TICK_PER_SEC / up_perf_getfreq();
+
+  perf_gettime();
+  wd_start((FAR struct wdog_s *)arg, tick, perf_update, arg);
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * perf_init
+ ****************************************************************************/
+
+void perf_init(void)
+{
+  FAR struct perf_s *perf = &g_perf;
+  clock_t tick = (clock_t)LONG_MAX * TICK_PER_SEC / up_perf_getfreq();
+
+  perf->last = up_perf_gettime();
+
+  /* Periodic check for overflow */
+
+  wd_start(&perf->wdog, tick, perf_update, (wdparm_t)perf);
+}
+
+/****************************************************************************
+ * perf_gettime
+ ****************************************************************************/
+
+clock_t perf_gettime(void)
+{
+  FAR struct perf_s *perf = &g_perf;
+  unsigned long now = up_perf_gettime();
+
+  /* Check if overflow */
+
+  if (now < perf->last)
+    {
+      perf->overflow++;
+    }
+
+  perf->last = now;
+  return (clock_t)now | (clock_t)perf->overflow << 32;
+}
+
+/****************************************************************************
+ * perf_convert
+ ****************************************************************************/
+
+void perf_convert(clock_t elapsed, FAR struct timespec *ts)
+{
+  unsigned long freq = up_perf_getfreq();
+
+  ts->tv_sec  = elapsed / freq;
+  elapsed -= ts->tv_sec * freq;
+  ts->tv_nsec = NSEC_PER_SEC * elapsed / freq;
+}
+
+/****************************************************************************
+ * perf_getfreq
+ ****************************************************************************/
+
+unsigned long perf_getfreq(void)
+{
+  return up_perf_getfreq();
+}
+
+#elif defined(CONFIG_ALARM_ARCH) || defined (CONFIG_TIMER_ARCH) || \
+      defined(CONFIG_ARCH_PERF_EVENTS)
+
+/****************************************************************************
+ * perf_init
+ ****************************************************************************/
+
+void perf_init(void)
+{
+}
+
+/****************************************************************************
+ * perf_gettime
+ ****************************************************************************/
+
+clock_t perf_gettime(void)
+{
+  return up_perf_gettime();
+}
+
+/****************************************************************************
+ * perf_convert
+ ****************************************************************************/
+
+void perf_convert(clock_t elapsed, FAR struct timespec *ts)
+{
+  up_perf_convert(elapsed, ts);
+}
+
+/****************************************************************************
+ * perf_getfreq
+ ****************************************************************************/
+
+unsigned long perf_getfreq(void)
+{
+  return up_perf_getfreq();
+}
+
+#else
+
+/****************************************************************************
+ * perf_init
+ ****************************************************************************/
+
+void perf_init(void)
+{
+}
+
+/****************************************************************************
+ * perf_gettime
+ ****************************************************************************/
+
+clock_t perf_gettime(void)
+{
+  return clock_systime_ticks();
+}
+
+/****************************************************************************
+ * perf_convert
+ ****************************************************************************/
+
+void perf_convert(clock_t elapsed, FAR struct timespec *ts)
+{
+  clock_ticks2time(elapsed, ts);
+}
+
+/****************************************************************************
+ * perf_getfreq
+ ****************************************************************************/
+
+unsigned long perf_getfreq(void)
+{
+  return TICK_PER_SEC;
+}
+
+#endif

--- a/sched/irq/irq.h
+++ b/sched/irq/irq.h
@@ -60,13 +60,8 @@ struct irq_info_s
   FAR void *arg;     /* The argument provided to the interrupt handler. */
 #ifdef CONFIG_SCHED_IRQMONITOR
   clock_t start;     /* Time interrupt attached */
-#ifdef CONFIG_HAVE_LONG_LONG
-  uint64_t count;    /* Number of interrupts on this IRQ */
-#else
-  uint32_t mscount;  /* Number of interrupts on this IRQ (MS) */
-  uint32_t lscount;  /* Number of interrupts on this IRQ (LS) */
-#endif
-  uint32_t time;     /* Maximum execution time on this IRQ */
+  clock_t time;      /* Maximum execution time on this IRQ */
+  uint32_t count;    /* Number of interrupts on this IRQ */
 #endif
 };
 

--- a/sched/irq/irq_attach.c
+++ b/sched/irq/irq_attach.c
@@ -117,12 +117,8 @@ int irq_attach(int irq, xcpt_t isr, FAR void *arg)
       g_irqvector[ndx].arg     = arg;
 #ifdef CONFIG_SCHED_IRQMONITOR
       g_irqvector[ndx].start   = clock_systime_ticks();
-#ifdef CONFIG_HAVE_LONG_LONG
+      g_irqvector[ndx].time    = 0;
       g_irqvector[ndx].count   = 0;
-#else
-      g_irqvector[ndx].mscount = 0;
-      g_irqvector[ndx].lscount = 0;
-#endif
 #endif
 
       leave_critical_section(flags);

--- a/sched/irq/irq_dispatch.c
+++ b/sched/irq/irq_dispatch.c
@@ -45,29 +45,6 @@
 #  define NUSER_IRQS NR_IRQS
 #endif
 
-/* INCR_COUNT - Increment the count of interrupts taken on this IRQ number */
-
-#ifndef CONFIG_SCHED_IRQMONITOR
-#  define INCR_COUNT(ndx)
-#elif defined(CONFIG_HAVE_LONG_LONG)
-#  define INCR_COUNT(ndx) \
-     do \
-       { \
-         g_irqvector[ndx].count++; \
-       } \
-     while (0)
-#else
-#  define INCR_COUNT(ndx) \
-     do \
-       { \
-         if (++g_irqvector[ndx].lscount == 0) \
-           { \
-             g_irqvector[ndx].mscount++; \
-           } \
-       } \
-     while (0)
-#endif
-
 /* CALL_VECTOR - Call the interrupt service routine attached to this
  * interrupt request
  */
@@ -80,14 +57,14 @@
 #  define CALL_VECTOR(ndx, vector, irq, context, arg) \
      do \
        { \
-         unsigned long start; \
-         unsigned long elapsed; \
-         start = up_perf_gettime(); \
+         clock_t start; \
+         clock_t elapsed; \
+         start = perf_gettime(); \
          vector(irq, context, arg); \
-         elapsed = up_perf_gettime() - start; \
+         elapsed = perf_gettime() - start; \
          if (ndx < NUSER_IRQS) \
            { \
-             INCR_COUNT(ndx); \
+             g_irqvector[ndx].count++; \
              if (elapsed > g_irqvector[ndx].time) \
                { \
                  g_irqvector[ndx].time = elapsed; \
@@ -96,8 +73,8 @@
          if (CONFIG_SCHED_CRITMONITOR_MAXTIME_IRQ > 0 && \
              elapsed > CONFIG_SCHED_CRITMONITOR_MAXTIME_IRQ) \
            { \
-             CRITMONITOR_PANIC("IRQ %d(%p), execute time too long %lu\n", \
-                               irq, vector, elapsed); \
+             CRITMONITOR_PANIC("IRQ %d(%p), execute time too long %ju\n", \
+                               irq, vector, (uintmax_t)elapsed); \
            } \
        } \
      while (0)

--- a/sched/irq/irq_procfs.c
+++ b/sched/irq/irq_procfs.c
@@ -159,15 +159,10 @@ static int irq_callback(int irq, FAR struct irq_info_s *info,
 
   flags = enter_critical_section();
   memcpy(&copy, info, sizeof(struct irq_info_s));
-  now           = clock_systime_ticks();
-  info->start   = now;
-#ifdef CONFIG_HAVE_LONG_LONG
-  info->count   = 0;
-#else
-  info->mscount = 0;
-  info->lscount = 0;
-#endif
-  info->time    = 0;
+  now         = clock_systime_ticks();
+  info->start = now;
+  info->time  = 0;
+  info->count = 0;
   leave_critical_section(flags);
 
   /* Don't bother if count == 0.
@@ -201,7 +196,7 @@ static int irq_callback(int irq, FAR struct irq_info_s *info,
    */
 
   elapsed = now - copy.start;
-  up_perf_convert(copy.time, &delta);
+  perf_convert(copy.time, &delta);
 
 #ifdef CONFIG_HAVE_LONG_LONG
   /* elapsed = <current-time> - <start-time>, units=clock ticks

--- a/sched/wdog/wd_start.c
+++ b/sched/wdog/wd_start.c
@@ -52,16 +52,16 @@
 #  define CALL_FUNC(func, arg) \
      do \
        { \
-         unsigned long start; \
-         unsigned long elapsed; \
-         start = up_perf_gettime(); \
+         clock_t start; \
+         clock_t elapsed; \
+         start = perf_gettime(); \
          func(arg); \
-         elapsed = up_perf_gettime() - start; \
+         elapsed = perf_gettime() - start; \
          if (elapsed > CONFIG_SCHED_CRITMONITOR_MAXTIME_WDOG) \
            { \
-             CRITMONITOR_PANIC("WDOG %p, %s IRQ, execute too long %lu\n", \
+             CRITMONITOR_PANIC("WDOG %p, %s IRQ, execute too long %ju\n", \
                                func, up_interrupt_context() ? \
-                               "IN" : "NOT", elapsed); \
+                               "IN" : "NOT", (uintmax_t)elapsed); \
            } \
        } \
      while (0)

--- a/sched/wqueue/kwork_thread.c
+++ b/sched/wqueue/kwork_thread.c
@@ -55,15 +55,15 @@
 #  define CALL_WORKER(worker, arg) \
      do \
        { \
-         unsigned long start; \
-         unsigned long elapsed; \
-         start = up_perf_gettime(); \
+         clock_t start; \
+         clock_t elapsed; \
+         start = perf_gettime(); \
          worker(arg); \
-         elapsed = up_perf_gettime() - start; \
+         elapsed = perf_gettime() - start; \
          if (elapsed > CONFIG_SCHED_CRITMONITOR_MAXTIME_WQUEUE) \
            { \
-             CRITMONITOR_PANIC("WORKER %p execute too long %lu\n", \
-                               worker, elapsed); \
+             CRITMONITOR_PANIC("WORKER %p execute too long %ju\n", \
+                               worker, (uintmax_t)elapsed); \
            } \
        } \
      while (0)


### PR DESCRIPTION
## Summary

perf_getime always returns an incremented cycle value If the hardware does not support perf event, it will use arch_alarm's up_perf_gettime.
convert up_perf_ api invocation to perf_ api.

## Impact

new perf_ api

## Testing

ci