### PR TITLE
 arch: add a flag indicating that the chip doesn't support DMA transfer from/to FLASH

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -355,6 +355,10 @@ config ARCH_DMA
 	bool
 	default n
 
+config ARCH_DMA_NO_FLASH_TRANSFER
+	bool
+	default n
+
 config ARCH_HAVE_IRQPRIO
 	bool
 	default n

--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -284,6 +284,7 @@ config ARCH_CHIP_NRF52
 	select ARCH_HAVE_FPU
 	select ARCH_HAVE_PWM_MULTICHAN
 	select ARCH_HAVE_SERIAL_TERMIOS
+	select ARCH_DMA_NO_FLASH_TRANSFER
 	---help---
 		Nordic nRF52 architectures (ARM Cortex-M4).
 
@@ -291,6 +292,7 @@ config ARCH_CHIP_NRF53
 	bool "Nordic nRF53"
 	select ARCH_CORTEXM33
 	select ARCH_HAVE_PWM_MULTICHAN
+	select ARCH_DMA_NO_FLASH_TRANSFER
 	depends on EXPERIMENTAL
 	---help---
 		Nordic nRF53 architectures (ARM dual Cortex-M33).
@@ -301,6 +303,7 @@ config ARCH_CHIP_NRF91
 	select ARCH_HAVE_PWM_MULTICHAN
 	select ARCH_HAVE_TRUSTZONE
 	select ARCH_HAVE_TICKLESS
+	select ARCH_DMA_NO_FLASH_TRANSFER
 	depends on EXPERIMENTAL
 	---help---
 		Nordic nRF91 architectures (ARM Cortex-M33 with integrated

--- a/drivers/sensors/Kconfig
+++ b/drivers/sensors/Kconfig
@@ -242,7 +242,7 @@ endchoice
 
 config SENSORS_BMI270_LOAD_FROM_HEAP
 	bool "BMI270 config loading from heap memory"
-	default n
+	default ARCH_DMA_NO_FLASH_TRANSFER
 	---help---
 		Enable support to load the configuration data from heap memory.
 		Some chips can not do DMA transfer from FLASH and therefore


### PR DESCRIPTION
## Summary

- arch: add a flag indicating that the chip doesn't support DMA transfer from/to FLASH
- sensors: SENSORS_BMI270_LOAD_FROM_HEAP equals ARCH_DMA_NO_FLASH_TRANSFER

## Impact

## Testing
CI
