### PR TITLE
mm/kmap: Fix bug in kmm_unmap

### DIFF
--- a/include/nuttx/mm/kmap.h
+++ b/include/nuttx/mm/kmap.h
@@ -72,7 +72,7 @@ FAR void *kmm_map(FAR void **pages, size_t npages, int prot);
 void kmm_unmap(FAR void *kaddr);
 
 /****************************************************************************
- * Name: kmm_user_map
+ * Name: kmm_map_user
  *
  * Description:
  *   Map a region of user memory (physical pages) for kernel use through
@@ -87,7 +87,7 @@ void kmm_unmap(FAR void *kaddr);
  *
  ****************************************************************************/
 
-FAR void *kmm_user_map(FAR void *uaddr, size_t size);
+FAR void *kmm_map_user(FAR void *uaddr, size_t size);
 
 /****************************************************************************
  * Name: kmm_map_user_page

--- a/mm/kmap/kmm_map.c
+++ b/mm/kmap/kmm_map.c
@@ -331,7 +331,7 @@ void kmm_unmap(FAR void *kaddr)
 }
 
 /****************************************************************************
- * Name: kmm_user_map
+ * Name: kmm_map_user
  *
  * Description:
  *   Map a region of user memory (physical pages) for kernel use through
@@ -346,7 +346,7 @@ void kmm_unmap(FAR void *kaddr)
  *
  ****************************************************************************/
 
-FAR void *kmm_user_map(FAR void *uaddr, size_t size)
+FAR void *kmm_map_user(FAR void *uaddr, size_t size)
 {
   FAR void *pages;
   uintptr_t vaddr;

--- a/mm/kmap/kmm_map.c
+++ b/mm/kmap/kmm_map.c
@@ -308,7 +308,7 @@ void kmm_unmap(FAR void *kaddr)
     {
       /* Find the entry, it is OK if none found */
 
-      entry = mm_map_find(get_current_mm(), kaddr, 1);
+      entry = mm_map_find(&g_kmm_map, kaddr, 1);
       if (entry)
         {
           npages = MM_NPAGES(entry->length);


### PR DESCRIPTION
## Summary
Fixes a bug in kmm_unmap; kernel mappings are found in the kernel's mapping list, not in the current process's list.
## Impact
CONFIG_MM_KMAP only
## Testing
MPFS + CONFIG_MM_KMAP=y
