### PR TITLE
Add memory tracing event support

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -2301,6 +2301,10 @@ config TRACE_LIBS
 	bool "Enable tracepoints in libs"
 	default n
 
+config TRACE_MM
+	bool "Enable tracepoints in mm"
+	default n
+
 config TRACE_NET
 	bool "Enable tracepoints in net"
 	default n

--- a/drivers/note/note_driver.c
+++ b/drivers/note/note_driver.c
@@ -156,10 +156,20 @@ static struct note_filter_s g_note_filter =
 {
   {
     CONFIG_SCHED_INSTRUMENTATION_FILTER_DEFAULT_MODE
-#ifdef CONFIG_SMP
+#  ifdef CONFIG_SMP
     , (cpu_set_t)CONFIG_SCHED_INSTRUMENTATION_CPUSET
-#endif
+#  endif
+  },
+
+  /* All tags are enabled by default */
+
+#  ifdef CONFIG_SCHED_INSTRUMENTATION_DUMP
+  {
+    {
+      [0 ... NOTE_TAG_MAX / 8 - 1] = 0
+    }
   }
+#  endif
 };
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_IRQHANDLER

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -598,6 +598,10 @@ struct tcb_s
                                          /* after the frame has been        */
                                          /* removed from the stack.         */
 
+  /* The allocated memory size of the current thread ************************/
+
+  ssize_t alloc_size;
+
   /* External Module Support ************************************************/
 
 #ifdef CONFIG_PIC

--- a/include/nuttx/sched_note.h
+++ b/include/nuttx/sched_note.h
@@ -59,6 +59,8 @@
 #  define CONFIG_SCHED_INSTRUMENTATION_CPUSET 0xffff
 #endif
 
+#define NOTE_ALIGN_UP(n) (((n) + 7) & ~7)
+
 /* Note filter mode flag definitions */
 
 #define NOTE_FILTER_MODE_FLAG_ENABLE       (1 << 0) /* Enable instrumentation */
@@ -190,6 +192,12 @@ enum note_type_e
   NOTE_DUMP_END        = 25,
   NOTE_DUMP_MARK       = 28,
   NOTE_DUMP_COUNTER    = 29,
+  NOTE_EVENT_MALLOC    = 30,
+  NOTE_EVENT_FREE      = 31,
+  NOTE_EVENT_REALLOC   = 32,
+
+  /* Always last */
+
   NOTE_TYPE_LAST
 };
 
@@ -214,7 +222,7 @@ enum note_tag_e
   /* Always last */
 
   NOTE_TAG_LAST,
-  NOTE_TAG_MAX = NOTE_TAG_LAST + 16
+  NOTE_TAG_MAX = NOTE_ALIGN_UP(NOTE_TAG_LAST)
 };
 
 /* This structure provides the common header of each note */
@@ -401,6 +409,13 @@ struct note_counter_s
   char name[NAME_MAX];
 };
 
+struct note_alloc_s
+{
+  FAR void *mem;
+  size_t size;
+  ssize_t used;
+};
+
 /* This is the type of the argument passed to the NOTECTL_GETMODE and
  * NOTECTL_SETMODE ioctls
  */
@@ -435,7 +450,7 @@ struct note_filter_irq_s
 
 struct note_filter_tag_s
 {
-  uint8_t tag_mask[(NOTE_TAG_MAX + 7) / 8];
+  uint8_t tag_mask[NOTE_TAG_MAX / 8];
 };
 
 /****************************************************************************

--- a/include/nuttx/trace.h
+++ b/include/nuttx/trace.h
@@ -151,4 +151,46 @@
 #  define wireless_trace_end()
 #endif
 
+#ifdef CONFIG_TRACE_MM
+static inline void trace_mm_malloc(FAR void *mem, size_t size)
+{
+  struct note_alloc_s note;
+  FAR struct tcb_s *tcb = nxsched_self();
+
+  note.mem = mem;
+  note.size = size;
+  note.used = tcb->alloc_size;
+  sched_note_event(NOTE_TAG_MM, NOTE_EVENT_MALLOC, &note,
+                   sizeof(struct note_alloc_s));
+}
+
+static inline void trace_mm_free(FAR void *mem, int size)
+{
+  struct note_alloc_s note;
+  FAR struct tcb_s *tcb = nxsched_self();
+
+  note.mem = mem;
+  note.size = size;
+  note.used = tcb->alloc_size;
+  sched_note_event(NOTE_TAG_MM, NOTE_EVENT_FREE, &note,
+                   sizeof(struct note_alloc_s));
+}
+
+static inline void trace_mm_realloc(FAR void *mem, int size)
+{
+  struct note_alloc_s note;
+  FAR struct tcb_s *tcb = nxsched_self();
+
+  note.mem = mem;
+  note.size = size;
+  note.used = tcb->alloc_size;
+  sched_note_event(NOTE_TAG_MM, NOTE_EVENT_REALLOC, &note,
+                   sizeof(struct note_alloc_s));
+}
+#else
+#  define trace_mm_malloc(m,s)
+#  define trace_mm_free(m,s)
+#  define trace_mm_realloc(m,s)
+#endif /* CONFIG_TRACE_MM */
+
 #endif /* __INCLUDE_NUTTX_TRACE_H */

--- a/mm/mm_heap/mm_free.c
+++ b/mm/mm_heap/mm_free.c
@@ -72,6 +72,7 @@ void mm_free(FAR struct mm_heap_s *heap, FAR void *mem)
   FAR struct mm_freenode_s *node;
   FAR struct mm_freenode_s *prev;
   FAR struct mm_freenode_s *next;
+  FAR struct tcb_s *tcb = nxsched_self();
   size_t nodesize;
   size_t prevsize;
 
@@ -114,6 +115,7 @@ void mm_free(FAR struct mm_heap_s *heap, FAR void *mem)
 
   node = (FAR struct mm_freenode_s *)((FAR char *)mem - MM_SIZEOF_ALLOCNODE);
   nodesize = MM_SIZEOF_NODE(node);
+  tcb->alloc_size -= nodesize;
 
   /* Sanity check against double-frees */
 

--- a/mm/mm_heap/mm_malloc.c
+++ b/mm/mm_heap/mm_malloc.c
@@ -262,6 +262,9 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
 
   if (ret)
     {
+      FAR struct tcb_s *tcb = nxsched_self();
+      tcb->alloc_size += alignsize;
+
       MM_ADD_BACKTRACE(heap, node);
       kasan_unpoison(ret, mm_malloc_size(heap, ret));
 #ifdef CONFIG_MM_FILL_ALLOCATIONS

--- a/mm/mm_heap/mm_memalign.c
+++ b/mm/mm_heap/mm_memalign.c
@@ -52,6 +52,7 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment,
                       size_t size)
 {
   FAR struct mm_allocnode_s *node;
+  FAR struct tcb_s *tcb = nxsched_self();
   uintptr_t rawchunk;
   uintptr_t alignedchunk;
   size_t mask;
@@ -132,6 +133,7 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment,
       return NULL;
     }
 
+  tcb->alloc_size -= mm_malloc_size(heap, (FAR void *)rawchunk);
   kasan_poison((FAR void *)rawchunk,
                mm_malloc_size(heap, (FAR void *)rawchunk));
 
@@ -263,6 +265,7 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment,
 
   MM_ADD_BACKTRACE(heap, node);
 
+  tcb->alloc_size += mm_malloc_size(heap, (FAR void *)alignedchunk);
   kasan_unpoison((FAR void *)alignedchunk,
                  mm_malloc_size(heap, (FAR void *)alignedchunk));
 

--- a/mm/mm_heap/mm_realloc.c
+++ b/mm/mm_heap/mm_realloc.c
@@ -68,6 +68,7 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
   FAR struct mm_allocnode_s *oldnode;
   FAR struct mm_freenode_s  *prev = NULL;
   FAR struct mm_freenode_s  *next;
+  FAR struct tcb_s *tcb = nxsched_self();
   size_t newsize;
   size_t oldsize;
   size_t prevsize = 0;
@@ -143,6 +144,7 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
 
       if (newsize < oldsize)
         {
+          tcb->alloc_size -= oldsize - newsize;
           mm_shrinkchunk(heap, oldnode, newsize);
           kasan_poison((FAR char *)oldnode + MM_SIZEOF_NODE(oldnode) +
                        sizeof(mmsize_t), oldsize - MM_SIZEOF_NODE(oldnode));
@@ -378,6 +380,7 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
           memcpy(newmem, oldmem, oldsize - MM_ALLOCNODE_OVERHEAD);
         }
 
+      tcb->alloc_size += mm_malloc_size(heap, newmem);
       return newmem;
     }
 

--- a/mm/umm_heap/umm_calloc.c
+++ b/mm/umm_heap/umm_calloc.c
@@ -27,6 +27,7 @@
 #include <stdlib.h>
 
 #include <nuttx/mm/mm.h>
+#include <nuttx/trace.h>
 
 #include "umm_heap/umm_heap.h"
 
@@ -70,6 +71,8 @@ FAR void *calloc(size_t n, size_t elem_size)
 #else
   /* Use mm_calloc() because it implements the clear */
 
-  return mm_calloc(USR_HEAP, n, elem_size);
+  FAR void *mem = mm_calloc(USR_HEAP, n, elem_size);
+  trace_mm_malloc(mem, n * elem_size);
+  return mem;
 #endif
 }

--- a/mm/umm_heap/umm_free.c
+++ b/mm/umm_heap/umm_free.c
@@ -27,6 +27,7 @@
 #include <stdlib.h>
 
 #include <nuttx/mm/mm.h>
+#include <nuttx/trace.h>
 
 #include "umm_heap/umm_heap.h"
 
@@ -46,5 +47,6 @@
 #undef free /* See mm/README.txt */
 void free(FAR void *mem)
 {
+  trace_mm_free(mem, mm_malloc_size(USR_HEAP, mem));
   mm_free(USR_HEAP, mem);
 }

--- a/mm/umm_heap/umm_malloc.c
+++ b/mm/umm_heap/umm_malloc.c
@@ -28,6 +28,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <nuttx/mm/mm.h>
+#include <nuttx/trace.h>
 
 #include "umm_heap/umm_heap.h"
 
@@ -67,6 +68,7 @@ FAR void *malloc(size_t size)
       set_errno(ENOMEM);
     }
 
+  trace_mm_malloc(ret, size);
   return ret;
 #endif
 }

--- a/mm/umm_heap/umm_memalign.c
+++ b/mm/umm_heap/umm_memalign.c
@@ -28,6 +28,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <nuttx/mm/mm.h>
+#include <nuttx/trace.h>
 
 #include "umm_heap/umm_heap.h"
 
@@ -94,6 +95,7 @@ FAR void *memalign(size_t alignment, size_t size)
       set_errno(ENOMEM);
     }
 
+  trace_mm_malloc(ret, size);
   return ret;
 #endif
 }

--- a/mm/umm_heap/umm_realloc.c
+++ b/mm/umm_heap/umm_realloc.c
@@ -28,6 +28,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <nuttx/mm/mm.h>
+#include <nuttx/trace.h>
 
 #include "umm_heap/umm_heap.h"
 
@@ -96,6 +97,7 @@ FAR void *realloc(FAR void *oldmem, size_t size)
       set_errno(ENOMEM);
     }
 
+  trace_mm_realloc(ret, size);
   return ret;
 #endif
 }

--- a/mm/umm_heap/umm_zalloc.c
+++ b/mm/umm_heap/umm_zalloc.c
@@ -28,6 +28,7 @@
 #include <string.h>
 #include <errno.h>
 #include <nuttx/mm/mm.h>
+#include <nuttx/trace.h>
 
 #include "umm_heap/umm_heap.h"
 
@@ -73,6 +74,7 @@ FAR void *zalloc(size_t size)
       set_errno(ENOMEM);
     }
 
+  trace_mm_malloc(ret, size);
   return ret;
 #endif
 }


### PR DESCRIPTION
## Summary
Change 1: alloc_size field to tcb to record the memory size used by the current thread
This statistical value will be different from the meminfo statistics.
This is because there is memory that thread A may apply for and thread B may release.

Change 2：Support displaying memory usage in perfetto

![image](https://github.com/apache/nuttx/assets/33870028/1c420167-2f7e-40e1-b1e8-2a77447effb4)

## Impact
The absolute value of its statistics may not be accurate because what is created by one thread may be released by another thread.
For example: the task stack is created by nsh, but will be released when the task exits, so negative numbers may occur.

## Testing
Enable following configuration
```
CONFIG_DRIVERS_NOTE=y
CONFIG_DRIVERS_NOTECTL=y
CONFIG_DRIVERS_NOTERAM_BUFSIZE=2048000
CONFIG_TRACE=y
CONFIG_TRACE_MM=y
CONFIG_SYSTEM_TRACE=y
CONFIG_SCHED_INSTRUMENTATION=y
CONFIG_SCHED_INSTRUMENTATION_DUMP=y
CONFIG_SCHED_INSTRUMENTATION_FILTER=y
CONFIG_SCHED_INSTRUMENTATION_SWITCH=y
```