### PR TITLE
arch/arm/src/stm32h7/stm32_oneshot.c: Fix format warnings.

### DIFF
--- a/arch/arm/src/stm32h7/stm32_oneshot.c
+++ b/arch/arm/src/stm32h7/stm32_oneshot.c
@@ -183,14 +183,14 @@ int stm32_oneshot_initialize(struct stm32_oneshot_s *oneshot, int chan,
 {
   uint32_t frequency;
 
-  tmrinfo("chan=%d resolution=%d usec, USEC_PER_SEC:%d\n", chan, resolution,
+  tmrinfo("chan=%d resolution=%u usec, USEC_PER_SEC:%ld\n", chan, resolution,
           USEC_PER_SEC);
   DEBUGASSERT(oneshot && resolution > 0);
 
   /* Get the TC frequency the corresponds to the requested resolution */
 
   frequency = USEC_PER_SEC / (uint32_t)resolution;
-  tmrinfo("frequency: %d\n", frequency);
+  tmrinfo("frequency: %" PRIu32 "\n", frequency);
   oneshot->frequency = frequency;
 
   oneshot->tch = stm32_tim_init(chan);
@@ -226,7 +226,7 @@ int stm32_oneshot_max_delay(struct stm32_oneshot_s *oneshot, uint64_t *usec)
 {
   DEBUGASSERT(oneshot != NULL && usec != NULL);
 
-  tmrinfo("frequency: %d, USEC_PER_SEC: %d\n", oneshot->frequency,
+  tmrinfo("frequency: %" PRIu32 ", USEC_PER_SEC: %ld\n", oneshot->frequency,
           USEC_PER_SEC);
   *usec = (uint64_t)(UINT32_MAX / oneshot->frequency) *
           (uint64_t)USEC_PER_SEC;


### PR DESCRIPTION
## Summary

There are some format warnings in printf-linke format strings. This patch removes them.

## Impact

No functional change, only affects the build process.

## Testing

To show the warnings:

```
tools/configure.sh nucleo-h743zi2:nsh
make menuconfig
```
Select `System Type -> Timer Configuration -> TIM one-shot wrapper`
```
make
```

Before the patch, warnings are printed:
```
chip/stm32_oneshot.c:186:11: warning: format '%d' expects argument of type 'int', but argument 5 has type 'long int' [-Wformat=]
  186 |   tmrinfo("chan=%d resolution=%d usec, USEC_PER_SEC:%d\n", chan, resolution,
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[...]
chip/stm32_oneshot.c:193:11: warning: format '%d' expects argument of type 'int', but argument 3 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
  193 |   tmrinfo("frequency: %d\n", frequency);
      |           ^~~~~~~~~~~~~~~~~  ~~~~~~~~~
      |                              |
      |                              uint32_t {aka long unsigned int}
[...]
chip/stm32_oneshot.c:229:11: warning: format '%d' expects argument of type 'int', but argument 3 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
  229 |   tmrinfo("frequency: %d, USEC_PER_SEC: %d\n", oneshot->frequency,
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~~~~~~~~~
      |                                                       |
      |                                                       uint32_t {aka long unsigned int}
[...]
chip/stm32_oneshot.c:229:11: warning: format '%d' expects argument of type 'int', but argument 4 has type 'long int' [-Wformat=]
  229 |   tmrinfo("frequency: %d, USEC_PER_SEC: %d\n", oneshot->frequency,
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

After this patch, those warnings are gone.