### PR TITLE
cmake: raise error if previous make build was not cleaned

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,12 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 set(NUTTX_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
+# unceaned previous make build can cause various types of cmake error
+if(EXISTS "${NUTTX_DIR}/.config")
+  message(
+    FATAL_ERROR "Please distclean previous make build with `make distclean`")
+endif()
+
 if(NOT DEFINED BOARD_CONFIG)
   message(FATAL_ERROR "Please define configuration with BOARD_CONFIG")
 endif()


### PR DESCRIPTION
## Summary
- cmake: raise error if previous make build was not cleaned
Uncleanded make build can cause various cmake errors.
It's better to stop cmake build early and display an error.

## Impact
better user experience when using cmake

## Testing
local cmake build
