### PR TITLE
arch/arm/src/s32k1xx: Fix warnings in PWM code.

### DIFF
--- a/arch/arm/src/s32k1xx/hardware/s32k1xx_ftm.h
+++ b/arch/arm/src/s32k1xx/hardware/s32k1xx_ftm.h
@@ -590,7 +590,7 @@
 
 #define FTM_SC_PWMEN_SHIFT               (16)      /* Bits 16-23: Channel n PWM enable bit */
 #define FTM_SC_PWMEN_MASK                (0xff << FTM_SC_PWMEN_SHIFT)
-#define FTM_SC_PWMEN(n)                  (1 << FTM_SC_PWMEN_SHIFT + (n))
+#define FTM_SC_PWMEN(n)                  (1 << (FTM_SC_PWMEN_SHIFT + (n)))
 #define FTM_SC_FLTPS_SHIFT               (24)      /* Bits 24-27: Filter Prescaler */
 #define FTM_SC_FLTPS_MASK                (0x07 << FTM_SC_FLTPS_SHIFT)
 #  define FTM_SC_FLTPS_DIV1              (0 << FTM_SC_FLTPS_SHIFT)  /* Divide by 1 */

--- a/arch/arm/src/s32k1xx/s32k1xx_pwm.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_pwm.c
@@ -357,7 +357,7 @@ static int pwm_timer(struct s32k1xx_pwmtimer_s *priv,
 
   DEBUGASSERT(priv != NULL && info != NULL);
 
-  pwminfo("FTM%d channel: %d frequency: %d duty: %08x\n",
+  pwminfo("FTM%d channel: %d frequency: %" PRId32 " duty: %08" PRIx32 "\n",
           priv->tpmid, priv->channel, info->frequency, info->duty);
 
   DEBUGASSERT(info->frequency > 0 && info->duty > 0 &&
@@ -427,8 +427,8 @@ static int pwm_timer(struct s32k1xx_pwmtimer_s *priv,
 
   cv = b16toi(info->duty * modulo + b16HALF);
 
-  pwminfo("FTM%d PCLK: %d frequency: %d FTMCLK: %d prescaler: %d modulo: %d \
-           c0v: %d\n",
+  pwminfo("FTM%d PCLK: %" PRId32 " frequency: %" PRId32 " FTMCLK: %" PRId32
+          " prescaler: %d modulo: %" PRId32 "c0v: %" PRId32 "\n",
           priv->tpmid, priv->pclk, info->frequency, tpmclk,
           presc_values[prescaler], modulo, cv);
 
@@ -554,7 +554,7 @@ static int pwm_setup(struct pwm_lowerhalf_s *dev)
    * already be enabled in the board-specific s32k1xx_periphclocks.c file.
    */
 
-  pwminfo("FTM%d pincfg: %08x\n", priv->tpmid, priv->pincfg);
+  pwminfo("FTM%d pincfg: %08" PRIx32 "\n", priv->tpmid, priv->pincfg);
   pwm_dumpregs(priv, "Initially");
 
   /* Configure the PWM output pin, but do not start the timer yet */
@@ -585,7 +585,7 @@ static int pwm_shutdown(struct pwm_lowerhalf_s *dev)
   struct s32k1xx_pwmtimer_s *priv = (struct s32k1xx_pwmtimer_s *)dev;
   uint32_t pincfg;
 
-  pwminfo("FTM%d pincfg: %08x\n", priv->tpmid, priv->pincfg);
+  pwminfo("FTM%d pincfg: %08" PRIx32 "\n", priv->tpmid, priv->pincfg);
 
   /* Make sure that the output has been stopped */
 


### PR DESCRIPTION
## Summary

There are some warnings, mainly in printf-like format strings. This patch removed them.

## Impact

No functional change, only affects the build process.

## Testing

```
tools/configure.sh s32k148evb:nsh
make menuconfig
```
Select:
1. `Device Drivers -> Timer Driver Support -> PWM Driver Support`
2. `System Type -> S32K1XX Peripheral Selection -> FTM0`
3. `System Type -> S32K1XX Peripheral Selection -> S32K1XX FTM PWM Configuration -> FTM0 PWM`
```
make
```
Warnings are printed:
```
chip/s32k1xx_pwm.c:360:11: warning: format '%d' expects argument of type 'int', but argument 5 has type 'uint32_t' {aka 'const long unsigned int'} [-Wformat=]
  360 |   pwminfo("FTM%d channel: %d frequency: %d duty: %08x\n",
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  361 |           priv->tpmid, priv->channel, info->frequency, info->duty);
      |                                       ~~~~~~~~~~~~~~~
      |                                           |
      |                                           uint32_t {aka const long unsigned int}
[...]
chip/s32k1xx_pwm.c:360:11: warning: format '%x' expects argument of type 'unsigned int', but argument 6 has type 'ub16_t' {aka 'const long unsigned int'} [-Wformat=]
  360 |   pwminfo("FTM%d channel: %d frequency: %d duty: %08x\n",
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  361 |           priv->tpmid, priv->channel, info->frequency, info->duty);
      |                                                        ~~~~~~~~~~
      |                                                            |
      |                                                            ub16_t {aka const long unsigned int}
[...]
chip/s32k1xx_pwm.c:430:11: warning: format '%d' expects argument of type 'int', but argument 4 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
  430 |   pwminfo("FTM%d PCLK: %d frequency: %d FTMCLK: %d prescaler: %d modulo: %d \
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  431 |            c0v: %d\n",
      |            ~~~~~~~~~~
  432 |           priv->tpmid, priv->pclk, info->frequency, tpmclk,
      |                        ~~~~~~~~~~
      |                            |
      |                            uint32_t {aka long unsigned int}
chip/s32k1xx_pwm.c:430:11: warning: format '%d' expects argument of type 'int', but argument 5 has type 'uint32_t' {aka 'const long unsigned int'} [-Wformat=]
chip/s32k1xx_pwm.c:430:11: warning: format '%d' expects argument of type 'int', but argument 6 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
chip/s32k1xx_pwm.c:430:11: warning: format '%d' expects argument of type 'int', but argument 8 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
chip/s32k1xx_pwm.c:430:11: warning: format '%d' expects argument of type 'int', but argument 9 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
[...]
chip/hardware/s32k1xx_ftm.h:593:67: warning: suggest parentheses around '+' inside '<<' [-Wparentheses]
  593 | #define FTM_SC_PWMEN(n)                  (1 << FTM_SC_PWMEN_SHIFT + (n))
      |                                                                   ^
[...]
  557 |   pwminfo("FTM%d pincfg: %08x\n", priv->tpmid, priv->pincfg);
      |           ^~~~~~~~~~~~~~~~~~~~~~               ~~~~~~~~~~~~
      |                                                    |
      |                                                    uint32_t {aka long unsigned int}
[...]
chip/s32k1xx_pwm.c:588:11: warning: format '%x' expects argument of type 'unsigned int', but argument 4 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
  588 |   pwminfo("FTM%d pincfg: %08x\n", priv->tpmid, priv->pincfg);
      |           ^~~~~~~~~~~~~~~~~~~~~~               ~~~~~~~~~~~~
      |                                                    |
      |                                                    uint32_t {aka long unsigned int}
```

After applying the patch, those warnings are gone.

**Note**
Build fails (with an error) before and after the test, because `GPIO_FTM0_CH0OUT` is undefined. Unfortunately, I have found no board in upstream repository which uses S32K1xx and has connected GPIOs for PWM. But warning removal is still good. In my case, I am using a custom board which uses S32K1xx and PWM.
