### PR TITLE
arch/{stm32|stm32f7|at32|samv7|imxrt}: fix for adc_setup

### DIFF
--- a/arch/arm/src/at32/at32_adc.c
+++ b/arch/arm/src/at32/at32_adc.c
@@ -2458,6 +2458,7 @@ static int adc_setup(struct adc_dev_s *dev)
 
   if (priv->initialized > 0)
     {
+      priv->initialized += 1;
       return OK;
     }
 

--- a/arch/arm/src/imxrt/imxrt_adc.c
+++ b/arch/arm/src/imxrt/imxrt_adc.c
@@ -513,6 +513,7 @@ static int adc_setup(struct adc_dev_s *dev)
 
   if (priv->initialized > 0)
     {
+      priv->initialized++;
       return OK;
     }
 

--- a/arch/arm/src/samv7/sam_afec.c
+++ b/arch/arm/src/samv7/sam_afec.c
@@ -868,6 +868,7 @@ static int afec_setup(struct adc_dev_s *dev)
 
   if (priv->initialized > 0)
     {
+      priv->initialized++;
       return OK;
     }
 

--- a/arch/arm/src/stm32/stm32_adc.c
+++ b/arch/arm/src/stm32/stm32_adc.c
@@ -2886,6 +2886,7 @@ static int adc_setup(struct adc_dev_s *dev)
 
   if (priv->initialized > 0)
     {
+      priv->initialized += 1;
       return OK;
     }
 

--- a/arch/arm/src/stm32f7/stm32_adc.c
+++ b/arch/arm/src/stm32f7/stm32_adc.c
@@ -1798,6 +1798,7 @@ static int adc_setup(struct adc_dev_s *dev)
 
   if (priv->initialized > 0)
     {
+      priv->initialized += 1;
       return OK;
     }
 


### PR DESCRIPTION
## Summary

- stm32{f7}/adc: always increase initialization counter when adc_setup called
- at32/adc: always increase initialization counter when adc_setup called
- imxrt/adc: always increase initialization counter when adc_setup called
- samv7/adc: always increase initialization counter when adc_setup called

The problem originally occurred in stm32_adc.c and has propagated to other architectures.
the `initialized` flag should be incremented every time adc_setup is called, otherwise the protective logic in adc_reset that is supposed to prevent resetting the ADC in use doesn't work properly.

The problem occurs when the ADC peripheral is shared by more than one different driver. In my case this is ADC upper-half driver and FOC lower-half driver.

## Impact

## Testing
only stm32 tested with b-g431b-esc1/foc_f32.
