### PR TITLE
 esp32s3/ble: enable the BLE interrupt during a SPI flash operation

### DIFF
--- a/arch/xtensa/include/esp32s3/irq.h
+++ b/arch/xtensa/include/esp32s3/irq.h
@@ -37,6 +37,16 @@
 
 #define ESP32S3_INT_PRIO_DEF        1
 
+/* CPU interrupt flags:
+ *   These flags can be used to specify which interrupt qualities the
+ *   code calling esp32s3_setup_irq needs.
+ */
+
+#define ESP32S3_CPUINT_FLAG_LEVEL   (1 << 0) /* Level-triggered interrupt */
+#define ESP32S3_CPUINT_FLAG_EDGE    (1 << 1) /* Edge-triggered interrupt */
+#define ESP32S3_CPUINT_FLAG_SHARED  (1 << 2) /* Interrupt can be shared between ISRs */
+#define ESP32S3_CPUINT_FLAG_IRAM    (1 << 3) /* ISR can be called if cache is disabled */
+
 /* Interrupt Matrix
  *
  * The Interrupt Matrix embedded in the ESP32-S3 independently allocates
@@ -386,17 +396,13 @@
  * 26 can be mapped to peripheral interrupts:
  *
  *   Level triggered peripherals (21 total):
- *     0-5, 8-9, 12-13, 17-18 - Priority 1
- *     19-21                  - Priority 2
- *     23, 27                 - Priority 3
- *     24-25                  - Priority 4
- *     26, 31                 - Priority 5
- *   Edge triggered peripherals (4 total):
- *     10                     - Priority 1
- *     22                     - Priority 3
- *     28, 30                 - Priority 4
+ *     0-5, 8-10, 12-13, 17-18 - Priority 1
+ *     19-21                   - Priority 2
+ *     22-23, 27               - Priority 3
+ *     24-25, 28, 30           - Priority 4
+ *     26, 31                  - Priority 5
  *   NMI (1 total):
- *     14                     - NMI
+ *     14                      - NMI
  *
  * CPU peripheral interrupts can be a assigned to a CPU interrupt using the
  * PRO_*_MAP_REG or APP_*_MAP_REG.  There are a pair of these registers for

--- a/arch/xtensa/src/esp32s3/Kconfig
+++ b/arch/xtensa/src/esp32s3/Kconfig
@@ -1415,6 +1415,12 @@ config ESP32S3_BLE_TASK_PRIORITY
 	int "Controller task priority"
 	default 253
 
+config ESP32S3_BLE_INTERRUPT_SAVE_STATUS
+	int "Number of interrupt save status"
+	default 3
+	---help---
+		Number of interrupt save status variables to keep track. Increase it if any related bug is found.
+
 endmenu # BLE Configuration
 
 menu "Timer/Counter Configuration"

--- a/arch/xtensa/src/esp32s3/Kconfig
+++ b/arch/xtensa/src/esp32s3/Kconfig
@@ -734,6 +734,19 @@ menuconfig ESP32S3_WIFI_BT_COEXIST
 	depends on ESP32S3_WIFI && ESP32S3_BLE
 	select ESP32S3_WIFI_STA_DISCONNECT_PM
 
+menu "Interrupt Configuration"
+
+config ESP32S3_IRAM_ISR_DEBUG
+	bool "Enable debugging of the IRAM-enabled interrupts"
+	default n
+	---help---
+		This option enables keeping track of the IRAM-enabled interrupts by
+		registering its execution when non-IRAM interrupts are disabled. It
+		keeps track of the IRQ executed and register how many times since
+		boot it was executed.
+
+endmenu # Interrupt Configuration
+
 menu "SPI RAM Configuration"
 	depends on ESP32S3_SPIRAM
 
@@ -1604,6 +1617,17 @@ config ESP32S3_STORAGE_MTD_DEBUG
 	---help---
 		If this option is enabled, Storage MTD driver read and write functions
 		will output input parameters and return values (if applicable).
+
+config ESP32S3_SPIFLASH_OP_TASK_STACKSIZE
+	int "The SPI flash operation task stack size"
+	default 768
+	depends on SMP
+	---help---
+		When SMP is enabled, it is needed to create two tasks (one for each
+		core) to be able to run IRAM-enabled interrupts. These tasks ensures
+		that the core that isn't performing the SPI flash operation is able
+		to disable non-IRAM interrupts and wait for the SPI flash operation
+		to be finished.
 
 endif # ESP32S3_SPIFLASH
 

--- a/arch/xtensa/src/esp32s3/esp32s3_irq.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_irq.c
@@ -251,6 +251,7 @@ static void esp32s3_intinfo(int cpu, int periphid,
  *   devices.
  *
  * Input Parameters:
+ *   cpu     - CPU core to query for CPU interrupt candidates
  *   intmask - mask of candidate CPU interrupts.  The CPU interrupt will be
  *             be allocated from free interrupts within this set
  *
@@ -260,20 +261,18 @@ static void esp32s3_intinfo(int cpu, int periphid,
  *
  ****************************************************************************/
 
-static int esp32s3_getcpuint(uint32_t intmask)
+static int esp32s3_getcpuint(int cpu, uint32_t intmask)
 {
   uint32_t *freeints;
   uint32_t bitmask;
   uint32_t intset;
   int cpuint;
   int ret = -ENOMEM;
-  int cpu = 0;
 
   /* Check if there are CPU interrupts with the requested properties
    * available.
    */
 
-  cpu = up_cpu_index();
 #ifdef CONFIG_SMP
   if (cpu != 0)
     {
@@ -337,6 +336,7 @@ static int esp32s3_getcpuint(uint32_t intmask)
  *   Allocate a level CPU interrupt
  *
  * Input Parameters:
+ *   cpu      - CPU core to query for CPU interrupt candidates
  *   priority - Priority of the CPU interrupt (1-5)
  *   type     - Interrupt type (level or edge).
  *
@@ -348,7 +348,7 @@ static int esp32s3_getcpuint(uint32_t intmask)
  *
  ****************************************************************************/
 
-static int esp32s3_alloc_cpuint(int priority, int type)
+static int esp32s3_alloc_cpuint(int cpu, int priority, int type)
 {
   uint32_t mask;
 
@@ -363,7 +363,7 @@ static int esp32s3_alloc_cpuint(int priority, int type)
   mask = g_priority[ESP32S3_PRIO_INDEX(priority)] &
           ESP32S3_CPUINT_LEVELSET;
 
-  return esp32s3_getcpuint(mask);
+  return esp32s3_getcpuint(cpu, mask);
 }
 
 /****************************************************************************
@@ -763,7 +763,7 @@ int esp32s3_setup_irq(int cpu, int periphid, int priority, int type)
    *    3. Map the CPU interrupt to the IRQ to ease searching later.
    */
 
-  cpuint = esp32s3_alloc_cpuint(priority, type);
+  cpuint = esp32s3_alloc_cpuint(cpu, priority, type);
   if (cpuint < 0)
     {
       irqerr("Unable to allocate CPU interrupt for priority=%d and type=%d",

--- a/arch/xtensa/src/esp32s3/esp32s3_wireless.h
+++ b/arch/xtensa/src/esp32s3/esp32s3_wireless.h
@@ -24,8 +24,12 @@
 /****************************************************************************
  * Included Files
  ****************************************************************************/
+#include <semaphore.h>
+#include <stdbool.h>
+#include <stdint.h>
 
 #include <nuttx/config.h>
+#include <nuttx/list.h>
 
 #include "xtensa_attr.h"
 #include "esp32s3_rt_timer.h"
@@ -44,6 +48,31 @@
 #define CONFIG_MAC_BB_PD                                    0
 
 #define MAC_LEN                                       (6)
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/* Semaphore Cache Data */
+
+struct esp_semcache_s
+{
+  struct list_node node;
+
+  sem_t *sem;
+  uint32_t count;
+};
+
+/* Queue Cache Data */
+
+struct esp_queuecache_s
+{
+  struct list_node node;
+
+  struct file *mq_ptr;
+  size_t size;
+  uint8_t *buffer;
+};
 
 /****************************************************************************
  * Public Function Prototypes
@@ -265,5 +294,114 @@ int32_t esp_timer_stop(esp_timer_handle_t timer);
  ****************************************************************************/
 
 int32_t esp_timer_delete(esp_timer_handle_t timer);
+
+/****************************************************************************
+ * Name: esp_init_semcache
+ *
+ * Description:
+ *   Initialize semaphore cache.
+ *
+ * Parameters:
+ *   sc  - Semaphore cache data pointer
+ *   sem - Semaphore data pointer
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void esp_init_semcache(struct esp_semcache_s *sc, sem_t *sem);
+
+/****************************************************************************
+ * Name: esp_post_semcache
+ *
+ * Description:
+ *   Store posting semaphore action into semaphore cache.
+ *
+ * Parameters:
+ *   sc  - Semaphore cache data pointer
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void esp_post_semcache(struct esp_semcache_s *sc);
+
+/****************************************************************************
+ * Name: esp_init_queuecache
+ *
+ * Description:
+ *   Initialize queue cache.
+ *
+ * Parameters:
+ *   qc     - Queue cache data pointer
+ *   mq_ptr - Queue data pointer
+ *   buffer - Queue cache buffer pointer
+ *   size   - Queue cache buffer size
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void esp_init_queuecache(struct esp_queuecache_s *qc,
+                         struct file *mq_ptr,
+                         uint8_t *buffer,
+                         size_t size);
+
+/****************************************************************************
+ * Name: esp32_wl_send_queuecache
+ *
+ * Description:
+ *   Store posting queue action and data into queue cache.
+ *
+ * Parameters:
+ *   qc     - Queue cache data pointer
+ *   buffer - Data buffer
+ *   size   - Buffer size
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void esp_send_queuecache(struct esp_queuecache_s *qc,
+                         uint8_t *buffer,
+                         int size);
+
+/****************************************************************************
+ * Name: esp_wireless_init
+ *
+ * Description:
+ *   Initialize ESP32 wireless common components for both BT and Wi-Fi.
+ *
+ * Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success. A negated errno value is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int esp_wireless_init(void);
+
+/****************************************************************************
+ * Name: esp_wireless_deinit
+ *
+ * Description:
+ *   De-initialize ESP32 wireless common components.
+ *
+ * Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success. A negated errno value is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int esp_wireless_deinit(void);
 
 #endif /* __ARCH_XTENSA_SRC_ESP32S3_ESP32S3_WIRELESS_H */

--- a/arch/xtensa/src/esp32s3/hardware/esp32s3_soc.h
+++ b/arch/xtensa/src/esp32s3/hardware/esp32s3_soc.h
@@ -522,6 +522,19 @@ static inline bool IRAM_ATTR esp32s3_ptr_extram(const void *p)
 }
 
 /****************************************************************************
+ * Name: esp32s3_ptr_iram
+ *
+ * Description:
+ *   Check if the pointer is in IRAM
+ *
+ ****************************************************************************/
+
+static inline bool IRAM_ATTR esp32s3_ptr_iram(const void *p)
+{
+  return ((intptr_t)p >= SOC_IRAM_LOW && (intptr_t)p < SOC_IRAM_HIGH);
+}
+
+/****************************************************************************
  * Name: esp32s3_ptr_exec
  *
  * Description:

--- a/boards/xtensa/esp32s3/common/scripts/legacy_sections.ld
+++ b/boards/xtensa/esp32s3/common/scripts/legacy_sections.ld
@@ -76,24 +76,30 @@ SECTIONS
 
     *(.iram1 .iram1.*)
 
+    *libarch.a:esp32s3_cpuindex.*(.literal .text .literal.* .text.*)
+    *libarch.a:esp32s3_irq.*(.literal .text .literal.* .text.*)
     *libarch.a:esp32s3_spiflash.*(.literal .text .literal.* .text.*)
+    *libarch.a:xtensa_assert.*(.literal .text .literal.* .text.*)
+    *libarch.a:xtensa_cpuint.*(.literal .text .literal.* .text.*)
     *libarch.a:xtensa_cpupause.*(.literal .text .literal.* .text.*)
+    *libarch.a:xtensa_irqdispatch.*(.literal .text .literal.* .text.*)
+    *libarch.a:xtensa_modifyreg32.*(.literal .text .literal.* .text.*)
     *libarch.a:xtensa_testset.*(.literal .text .literal.* .text.*)
-    *libarch.a:xtensa_modifyreg32.*(.literal.modifyreg32 .text.modifyreg32)
 
+    *libdrivers.a:syslog_flush.*(.literal .text .literal.* .text.*)
+
+    *libsched.a:assert.*(.literal .text .literal.* .text.*)
     *libsched.a:irq_csection.*(.literal .text .literal.* .text.*)
     *libsched.a:irq_dispatch.*(.literal .text .literal.* .text.*)
+    *libsched.a:irq_spinlock.*(.literal .text .literal.* .text.*)
     *libsched.a:sched_note.*(.literal .text .literal.* .text.*)
     *libsched.a:sched_suspendscheduler.*(.literal .text .literal.* .text.*)
     *libsched.a:sched_thistask.*(.literal .text .literal.* .text.*)
     *libsched.a:spinlock.*(.literal .text .literal.* .text.*)
 
 #ifdef CONFIG_ESP32S3_SPEED_UP_ISR
-    *libarch.a:xtensa_irqdispatch.*(.literal.xtensa_irq_dispatch .text.xtensa_irq_dispatch)
     *libarch.a:xtensa_switchcontext.*(.literal.up_switch_context .text.up_switch_context)
-    *libarch.a:xtensa_modifyreg32.*(.literal.modifyreg32 .text.modifyreg32)
 
-    *libarch.a:esp32s3_irq.*(.literal.xtensa_int_decode .text.xtensa_int_decode)
     *libarch.a:esp32s3_timerisr.*(.literal.systimer_isr .text.systimer_isr)
     *libarch.a:esp32s3_idle.*(.literal.up_idle .text.up_idle)
     *libarch.a:esp32s3_dma.*(.literal.esp32s3_dma_load .text.esp32s3_dma_load \
@@ -195,6 +201,7 @@ SECTIONS
     *(.dram1 .dram1.*)
 
     *libphy.a:(.rodata  .rodata.*)
+    *libarch.a:xtensa_context.*(.rodata  .rodata.*)
 
     _edata = ABSOLUTE(.);
     . = ALIGN(4);

--- a/boards/xtensa/esp32s3/common/scripts/legacy_sections.ld
+++ b/boards/xtensa/esp32s3/common/scripts/legacy_sections.ld
@@ -78,6 +78,7 @@ SECTIONS
 
     *libarch.a:esp32s3_cpuindex.*(.literal .text .literal.* .text.*)
     *libarch.a:esp32s3_irq.*(.literal .text .literal.* .text.*)
+    *libarch.a:esp32s3_user.*(.literal .text .literal.* .text.*)
     *libarch.a:esp32s3_spiflash.*(.literal .text .literal.* .text.*)
     *libarch.a:xtensa_assert.*(.literal .text .literal.* .text.*)
     *libarch.a:xtensa_cpuint.*(.literal .text .literal.* .text.*)
@@ -85,6 +86,10 @@ SECTIONS
     *libarch.a:xtensa_irqdispatch.*(.literal .text .literal.* .text.*)
     *libarch.a:xtensa_modifyreg32.*(.literal .text .literal.* .text.*)
     *libarch.a:xtensa_testset.*(.literal .text .literal.* .text.*)
+
+#ifdef CONFIG_ESP32S3_BLE
+    *libc.a:bin/sq_remlast.*(.literal .text .literal.* .text.*)
+#endif
 
     *libdrivers.a:syslog_flush.*(.literal .text .literal.* .text.*)
 


### PR DESCRIPTION
## Summary

* esp32s3/irq: Fix erroneous interrupt allocation for each CPU core

* esp32s3/ble: fix saving/restoring the interrupt status flags

* esp32s3/irq: Allow IRAM ISRs to run during SPI flash operation

* esp32s3/ble: enable the BLE interrupt during a SPI flash operation

## Impact

This PR provides an interface to register ISRs that run from IRAM and keeps track of the non-IRAM interrupts. It enables, for instance, to avoid disabling all the interrupts during a SPI flash operation: IRAM-enabled ISRs are, then, able to run during these operations. One direct impact: it avoids BLE's packet losses while an SPI flash operation takes place.

## Testing

Internal CI testing + NuttX CI + ESP32-S3-DevKitC-1 board;