### PR TITLE
 riscv_addrenv_utils.c: Determine page table flags by type of vaddr 

### DIFF
--- a/arch/risc-v/src/common/riscv_mmu.h
+++ b/arch/risc-v/src/common/riscv_mmu.h
@@ -59,6 +59,10 @@
 
 #define MMU_IO_FLAGS            (PTE_R | PTE_W | PTE_G)
 
+/* Flags for kernel page tables */
+
+#define MMU_KPGT_FLAGS          (PTE_G)
+
 /* Kernel FLASH and RAM are mapped globally */
 
 #define MMU_KTEXT_FLAGS         (PTE_R | PTE_X | PTE_G)


### PR DESCRIPTION
## Summary
Use kernel page table flags if the mapped virtual address is in kernel space.
## Impact
Minor fixe, impact to others should be nothing.
## Testing
icicle + CONFIG_BUILD_KERNEL=y
