### PR TITLE
CONFIG_BUILD_KERNEL: PANIC() if someone tries to kill the init process

### DIFF
--- a/sched/group/group.h
+++ b/sched/group/group.h
@@ -68,7 +68,7 @@ void group_initialize(FAR struct task_tcb_s *tcb);
 int  group_bind(FAR struct pthread_tcb_s *tcb);
 int  group_join(FAR struct pthread_tcb_s *tcb);
 #endif
-void group_leave(FAR struct tcb_s *tcb);
+int  group_leave(FAR struct tcb_s *tcb);
 void group_drop(FAR struct task_group_s *group);
 #if defined(CONFIG_SCHED_WAITPID) && !defined(CONFIG_SCHED_HAVE_PARENT)
 void group_add_waiter(FAR struct task_group_s *group);

--- a/sched/init/nx_bringup.c
+++ b/sched/init/nx_bringup.c
@@ -116,6 +116,14 @@ extern const int             CONFIG_INIT_NEXPORTS;
 #endif
 
 /****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#ifdef CONFIG_BUILD_KERNEL
+pid_t g_init_tg_pid = INVALID_PROCESS_ID;
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -300,6 +308,14 @@ static inline void nx_start_application(void)
 #endif
   posix_spawnattr_destroy(&attr);
   DEBUGASSERT(ret > 0);
+
+#ifdef CONFIG_BUILD_KERNEL
+  if (ret > 0)
+    {
+      struct tcb_s *init = nxsched_get_tcb(ret);
+      g_init_tg_pid = init->group->tg_pid;
+    }
+#endif
 }
 
 /****************************************************************************

--- a/sched/sched/CMakeLists.txt
+++ b/sched/sched/CMakeLists.txt
@@ -119,4 +119,8 @@ if(CONFIG_SCHED_BACKTRACE)
   list(APPEND SRCS sched_backtrace.c)
 endif()
 
+if(CONFIG_BUILD_KERNEL)
+  list(APPEND SRCS sched_is_inittask.c)
+endif()
+
 target_sources(sched PRIVATE ${SRCS})

--- a/sched/sched/Make.defs
+++ b/sched/sched/Make.defs
@@ -96,6 +96,10 @@ ifeq ($(CONFIG_SCHED_BACKTRACE),y)
 CSRCS += sched_backtrace.c
 endif
 
+ifeq ($(CONFIG_BUILD_KERNEL), y)
+CSRCS += sched_is_inittask.c
+endif
+
 # Include sched build support
 
 DEPPATH += --dep-path sched

--- a/sched/sched/sched.h
+++ b/sched/sched/sched.h
@@ -417,4 +417,10 @@ void nxsched_suspend_critmon(FAR struct tcb_s *tcb);
 
 bool nxsched_verify_tcb(FAR struct tcb_s *tcb);
 
+#ifdef CONFIG_BUILD_KERNEL
+bool nxsched_is_inittask(FAR struct tcb_s *tcb);
+#else
+#define nxsched_is_inittask(tcb) false
+#endif
+
 #endif /* __SCHED_SCHED_SCHED_H */

--- a/sched/sched/sched_is_inittask.c
+++ b/sched/sched/sched_is_inittask.c
@@ -1,0 +1,57 @@
+/****************************************************************************
+ * sched/sched/sched_is_inittask.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdbool.h>
+#include <sys/types.h>
+
+#include "sched/sched.h"
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#ifdef CONFIG_BUILD_KERNEL
+extern pid_t g_init_tg_pid;
+#endif
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: nxsched_self
+ *
+ * Description:
+ *   Return the current threads TCB.  Basically, this function just wraps the
+ *   head of the ready-to-run list and manages access to the TCB from outside
+ *   of the sched/ sub-directory.
+ *
+ ****************************************************************************/
+
+bool nxsched_is_inittask(FAR struct tcb_s *tcb)
+{
+  return (bool)(tcb->group->tg_pid == g_init_tg_pid);
+}

--- a/sched/task/task_exithook.c
+++ b/sched/task/task_exithook.c
@@ -465,7 +465,15 @@ void nxtask_exithook(FAR struct tcb_s *tcb, int status)
    * status (no zombies here!)
    */
 
-  group_leave(tcb);
+  if (group_leave(tcb) == 0)
+    {
+      /* Group is dead now, PANIC() if this is the init task */
+
+      if (nxsched_is_inittask(tcb))
+        {
+          PANIC();
+        }
+    }
 
   /* Deallocate anything left in the TCB's queues */
 


### PR DESCRIPTION
## Summary
As everything is inherited from the init process, there is no way it can be allowed to be killed.

Mark the init process's group ID and PANIC() at once if someone tries to kill it / calls exit() from it.

This is more of a debug feature, under normal conditions such a thing can never happen.
## Impact
CONFIG_BUILD_KERNEL=y only
## Testing
icicle + CONFIG_BUILD_KERNEL=y
