### PR TITLE
libxx: Use gnu++20 option only if using libcxx

### DIFF
--- a/libs/libxx/Kconfig
+++ b/libs/libxx/Kconfig
@@ -90,7 +90,8 @@ endif
 
 config CXX_STANDARD
 	string "Language standard"
-	default "gnu++20"
+	default "gnu++20" if LIBCXX
+	default "gnu++17" if !LIBCXX
 	---help---
 		Possible values:
 		gnu++98/c++98, gnu++11/c++11, gnu++14/c++14, gnu++17/c++17 and gnu++20/c++20


### PR DESCRIPTION
## Summary
Fix an issue that gnu++20 option is always used.
By https://github.com/apache/nuttx/pull/8244#discussion_r1294750528, when libcxx is not used, gnu++17 should be retained.

## Impact

## Testing

