### PR TITLE
Documentation: improve documentation for ESP32-C3/C6 and fix defconfig include list

### DIFF
--- a/Documentation/platforms/risc-v/esp32c3/index.rst
+++ b/Documentation/platforms/risc-v/esp32c3/index.rst
@@ -26,8 +26,47 @@ core and supports 2.4 GHz Wi-Fi and Bluetooth Low Energy.
 ESP32-C3 Toolchain
 ==================
 
-A generic RISC-V toolchain can be used to build ESP32-C3 projects.
-SiFive's toolchain can be downloaded from: https://github.com/sifive/freedom-tools/releases
+A generic RISC-V toolchain can be used to build ESP32-C3 projects. It's recommended to use the same
+toolchain used by NuttX CI. Please refer to the Docker
+`container <https://github.com/apache/nuttx/tree/master/tools/ci/docker/linux/Dockerfile>`_ and
+check for the current compiler version being used. For instance:
+
+.. code-block::
+
+   ###############################################################################
+   # Build image for tool required by RISCV builds
+   ###############################################################################
+   FROM nuttx-toolchain-base AS nuttx-toolchain-riscv
+   # Download the latest RISCV GCC toolchain prebuilt by xPack
+   RUN mkdir riscv-none-elf-gcc && \
+   curl -s -L "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-1/xpack-riscv-none-elf-gcc-12.3.0-1-linux-x64.tar.gz" \
+   | tar -C riscv-none-elf-gcc --strip-components 1 -xz
+
+It uses the xPack's prebuilt toolchain based on GCC 12.3.0.
+
+Installing
+----------
+
+First, create a directory to hold the toolchain:
+
+.. code-block:: console
+
+   $ mkdir -p /path/to/your/toolchain/riscv-none-elf-gcc
+
+Download and extract toolchain:
+
+.. code-block:: console
+
+   $ curl -s -L "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-1/xpack-riscv-none-elf-gcc-12.3.0-1-linux-x64.tar.gz" \
+   | tar -C /path/to/your/toolchain/riscv-none-elf-gcc --strip-components 1 -xz
+
+Add the toolchain to your `PATH`:
+
+.. code-block:: console
+
+   $ echo "export PATH=/path/to/your/toolchain/riscv-none-elf-gcc/bin:$PATH" >> ~/.bashrc
+
+You can edit your shell's rc files if you don't use bash.
 
 Second stage bootloader and partition table
 ===========================================

--- a/Documentation/platforms/risc-v/esp32c6/index.rst
+++ b/Documentation/platforms/risc-v/esp32c6/index.rst
@@ -26,8 +26,47 @@ core and supports 2.4 GHz Wi-Fi 6, Bluetooth 5 (LE) and the 802.15.4 protocol.
 ESP32-C6 Toolchain
 ==================
 
-A generic RISC-V toolchain can be used to build ESP32-C6 projects.
-SiFive's toolchain can be downloaded from: https://github.com/sifive/freedom-tools/releases
+A generic RISC-V toolchain can be used to build ESP32-C6 projects. It's recommended to use the same
+toolchain used by NuttX CI. Please refer to the Docker
+`container <https://github.com/apache/nuttx/tree/master/tools/ci/docker/linux/Dockerfile>`_ and
+check for the current compiler version being used. For instance:
+
+.. code-block::
+
+   ###############################################################################
+   # Build image for tool required by RISCV builds
+   ###############################################################################
+   FROM nuttx-toolchain-base AS nuttx-toolchain-riscv
+   # Download the latest RISCV GCC toolchain prebuilt by xPack
+   RUN mkdir riscv-none-elf-gcc && \
+   curl -s -L "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-1/xpack-riscv-none-elf-gcc-12.3.0-1-linux-x64.tar.gz" \
+   | tar -C riscv-none-elf-gcc --strip-components 1 -xz
+
+It uses the xPack's prebuilt toolchain based on GCC 12.3.0.
+
+Installing
+----------
+
+First, create a directory to hold the toolchain:
+
+.. code-block:: console
+
+   $ mkdir -p /path/to/your/toolchain/riscv-none-elf-gcc
+
+Download and extract toolchain:
+
+.. code-block:: console
+
+   $ curl -s -L "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-1/xpack-riscv-none-elf-gcc-12.3.0-1-linux-x64.tar.gz" \
+   | tar -C /path/to/your/toolchain/riscv-none-elf-gcc --strip-components 1 -xz
+
+Add the toolchain to your `PATH`:
+
+.. code-block:: console
+
+   $ echo "export PATH=/path/to/your/toolchain/riscv-none-elf-gcc/bin:$PATH" >> ~/.bashrc
+
+You can edit your shell's rc files if you don't use bash.
 
 Second stage bootloader and partition table
 ===========================================

--- a/Documentation/quickstart/configuring.rst
+++ b/Documentation/quickstart/configuring.rst
@@ -128,11 +128,7 @@ This is also useful to script configuration changes that you perform often:
 Reference configuration
 --------------------------
 
-Defconfig supports the use of #include statements to reference other configuration files.
-The default header file search path includes:
-   ${current directory}
-   ${boards}/configs/comnon
-   ${boards}/common/configs
+Defconfig supports the use of ``#include`` statements to reference other configuration files:
 
 .. code-block::
 
@@ -140,6 +136,12 @@ The default header file search path includes:
    CONFIG_XXX2=y
    #include "configs/system.config"
    #include "configs/net.config"
+
+The default header file search path includes:
+
+* Current directory;
+* ``${boards}/configs/common``;
+* ``${boards}/common/configs``;
 
 Merge configuration
 --------------------------


### PR DESCRIPTION
## Summary

* Currently, this toolchain is being used for NuttX CI testing and provides. features that weren't available in the old toolchain based on GCC 10.2;
* Fix search path for defconfig include list;

## Impact

None.

## Testing

`sphinx-build` locally.