### PR TITLE
UART needs to be disabled before changing setup

### DIFF
--- a/arch/arm/src/stm32/stm32_serial.c
+++ b/arch/arm/src/stm32/stm32_serial.c
@@ -1445,6 +1445,10 @@ static void up_set_format(struct uart_dev_s *dev)
 
   regval = up_serialin(priv, STM32_USART_CR1_OFFSET);
 
+#if defined(CONFIG_STM32_STM32G4XXX)
+  regval &= ~(USART_CR1_UE | USART_CR1_TE | USART_CR1_RE);
+  up_serialout(priv, STM32_USART_CR1_OFFSET, regval);
+#endif
 #if defined(CONFIG_STM32_STM32F30XX) || defined(CONFIG_STM32_STM32F33XX)|| \
     defined(CONFIG_STM32_STM32F37XX) || defined(CONFIG_STM32_STM32G4XXX)
   /* This first implementation is for U[S]ARTs that support oversampling
@@ -1623,6 +1627,11 @@ static void up_set_format(struct uart_dev_s *dev)
 #endif
 
   up_serialout(priv, STM32_USART_CR3_OFFSET, regval);
+#if defined(CONFIG_STM32_STM32G4XXX)
+  regval      = up_serialin(priv, STM32_USART_CR1_OFFSET);
+  regval     |= (USART_CR1_UE | USART_CR1_TE | USART_CR1_RE);
+  up_serialout(priv, STM32_USART_CR1_OFFSET, regval);
+#endif
 }
 #endif /* CONFIG_SUPPRESS_UART_CONFIG */
 


### PR DESCRIPTION
## Summary
As specified in STM32G4 series reference manual(RM0440 v7.0) page 1643, PS or PCE bit can only be modified when USART is disabled.
## Impact
Disable USART before changing any configuration and enable it after work done.
## Testing
Tested in PX4 flight controller firmware
