### PR TITLE
sys/types: supporting 32-bit IDs for gid_t/uid_t

### DIFF
--- a/include/sys/types.h
+++ b/include/sys/types.h
@@ -121,20 +121,27 @@ typedef uint16_t     size_t;
 typedef int16_t      ssize_t;
 typedef uint16_t     rsize_t;
 
-#else /* CONFIG_SMALL_MEMORY */
-
-typedef _size_t      size_t;
-typedef _ssize_t     ssize_t;
-typedef _size_t      rsize_t;
-
-#endif /* CONFIG_SMALL_MEMORY */
-
 /* uid_t is used for user IDs
  * gid_t is used for group IDs.
  */
 
 typedef int16_t      uid_t;
 typedef int16_t      gid_t;
+
+#else /* CONFIG_SMALL_MEMORY */
+
+typedef _size_t      size_t;
+typedef _ssize_t     ssize_t;
+typedef _size_t      rsize_t;
+
+/* uid_t is used for user IDs
+ * gid_t is used for group IDs.
+ */
+
+typedef unsigned int uid_t;
+typedef unsigned int gid_t;
+
+#endif /* CONFIG_SMALL_MEMORY */
 
 /* dev_t is used for device IDs */
 


### PR DESCRIPTION
## Summary

sys/types: supporting 32-bit IDs for gid_t/uid_t

## Impact

N/A

## Testing

ci-check