### PR TITLE
arch/sim: improve arch text heap implementation

### DIFF
--- a/arch/sim/src/sim/posix/sim_hostmemory.c
+++ b/arch/sim/src/sim/posix/sim_hostmemory.c
@@ -60,18 +60,18 @@ static atomic_int g_uordblks;
  *
  ****************************************************************************/
 
-void *host_allocheap(size_t sz)
+void *host_allocheap(size_t size, bool exec)
 {
   void *p;
 
 #if defined(CONFIG_HOST_MACOS) && defined(CONFIG_HOST_ARM64)
   /* see: https://developer.apple.com/forums/thread/672804 */
 
-  p = host_uninterruptible(mmap, NULL, sz, PROT_READ | PROT_WRITE,
+  p = host_uninterruptible(mmap, NULL, size, PROT_READ | PROT_WRITE,
                            MAP_ANON | MAP_SHARED, -1, 0);
 #else
-  p = host_uninterruptible(mmap, NULL, sz,
-                           PROT_READ | PROT_WRITE | PROT_EXEC,
+  p = host_uninterruptible(mmap, NULL, size, PROT_READ | PROT_WRITE |
+                           (exec ? PROT_EXEC : 0),
                            MAP_ANON | MAP_PRIVATE, -1, 0);
 #endif
 

--- a/arch/sim/src/sim/sim_heap.c
+++ b/arch/sim/src/sim/sim_heap.c
@@ -136,7 +136,7 @@ static void mm_free_delaylist(struct mm_heap_s *heap)
  ****************************************************************************/
 
 struct mm_heap_s *mm_initialize(const char *name,
-                                    void *heap_start, size_t heap_size)
+                                void *heap_start, size_t heap_size)
 {
   struct mm_heap_s *heap;
 
@@ -466,18 +466,7 @@ void up_allocate_heap(void **heap_start, size_t *heap_size)
 
 void up_allocate_heap(void **heap_start, size_t *heap_size)
 {
-  /* Note: Some subsystems like modlib and binfmt need to allocate
-   * executable memory.
-   */
-
-  /* We make the entire heap executable here to keep
-   * the sim simpler. If it turns out to be a problem, the
-   * ARCH_HAVE_TEXT_HEAP mechanism can be an alternative.
-   */
-
-  uint8_t *sim_heap = host_allocheap(SIM_HEAP_SIZE);
-
-  *heap_start = sim_heap;
+  *heap_start = host_allocheap(SIM_HEAP_SIZE, false);
   *heap_size  = SIM_HEAP_SIZE;
 }
 

--- a/arch/sim/src/sim/sim_internal.h
+++ b/arch/sim/src/sim/sim_internal.h
@@ -216,7 +216,7 @@ int   host_waitpid(pid_t pid);
 
 /* sim_hostmemory.c *********************************************************/
 
-void *host_allocheap(size_t sz);
+void *host_allocheap(size_t size, bool exec);
 void  host_freeheap(void *mem);
 void *host_allocshmem(const char *name, size_t size, int master);
 void  host_freeshmem(void *mem);

--- a/arch/sim/src/sim/sim_textheap.c
+++ b/arch/sim/src/sim/sim_textheap.c
@@ -66,7 +66,7 @@ void *up_textheap_memalign(size_t align, size_t size)
    * don't need to do anything here.
    */
 
-  p = host_allocheap(size);
+  p = host_allocheap(size, true);
 
   flags = up_irq_save();
 


### PR DESCRIPTION
## Summary

- arch/sim: Call host_memalign in up_allocate_heap 
- arch/sim: Simplify the implementation of textheap

## Impact

sim elf loader

## Testing

sim:elf