### PR TITLE
ESP32-S3 I2C improvements

### DIFF
--- a/arch/xtensa/src/esp32s3/esp32s3_i2c.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_i2c.c
@@ -820,8 +820,6 @@ static void i2c_reset_fsmc(struct esp32s3_i2c_priv_s *priv)
   /* Reset FSM machine */
 
   modifyreg32(I2C_CTR_REG(priv->id), 0, I2C_FSM_RST);
-
-  i2c_clear_bus(priv);
 }
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32s3/esp32s3_i2c.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_i2c.c
@@ -1125,9 +1125,9 @@ static void i2c_clear_bus(struct esp32s3_i2c_priv_s *priv)
               I2C_SCL_RST_SLV_EN | I2C_SCL_RST_SLV_NUM_M,
               VALUE_TO_FIELD(I2C_SCL_CYC_NUM_DEF, I2C_SCL_RST_SLV_NUM));
 
-  modifyreg32(I2C_CTR_REG(priv->id), 0, I2C_CONF_UPGATE);
-
   modifyreg32(I2C_SCL_SP_CONF_REG(priv->id), 0, I2C_SCL_RST_SLV_EN);
+
+  modifyreg32(I2C_CTR_REG(priv->id), 0, I2C_CONF_UPGATE);
 }
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32s3/esp32s3_i2c.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_i2c.c
@@ -257,9 +257,9 @@ static int i2c_sem_waitdone(struct esp32s3_i2c_priv_s *priv);
 #ifdef CONFIG_I2C_POLLED
 static int i2c_polling_waitdone(struct esp32s3_i2c_priv_s *priv);
 #endif
-static void i2c_clear_bus(struct esp32s3_i2c_priv_s *priv);
 static void i2c_reset_fsmc(struct esp32s3_i2c_priv_s *priv);
 #ifdef CONFIG_I2C_RESET
+static void i2c_clear_bus(struct esp32s3_i2c_priv_s *priv);
 static int i2c_reset(struct i2c_master_s *dev);
 #endif
 
@@ -1117,6 +1117,7 @@ static int i2c_transfer(struct i2c_master_s *dev, struct i2c_msg_s *msgs,
  *
  ****************************************************************************/
 
+#ifdef CONFIG_I2C_RESET
 static void i2c_clear_bus(struct esp32s3_i2c_priv_s *priv)
 {
   modifyreg32(I2C_SCL_SP_CONF_REG(priv->id),
@@ -1142,7 +1143,6 @@ static void i2c_clear_bus(struct esp32s3_i2c_priv_s *priv)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_I2C_RESET
 static int i2c_reset(struct i2c_master_s *dev)
 {
   struct esp32s3_i2c_priv_s *priv = (struct esp32s3_i2c_priv_s *)dev;


### PR DESCRIPTION
## Summary

Apparently there is an error on the i2c handling of the esp32s3. When there is a bus error, the master will never be able to recover (not even after a reset, since the reset control was broken). If we need to send the 9 clk, we can use the i2c reset function.

This PR includes:

- the fix to the reset_fsmc (do as we do on the esp32c3 and as specified in the TRM).
- The improvement to not send 9 CLK every time we want to clear the fsm. 

## Impact

The i2c on the esp32s3 is now much faster, as we don't need to send the 9 clocks on every transaction. We also recover from failed transactions, as the reset of the fsm is done correctly.

## Testing

Only manual testing: after these changes I am able to do `i2c dev 1 7f` on my esp32-s3-eye and it will always find the IMU at address 12.