### PR TITLE
riscv-v/pgalloc.h: Return kernel vaddr for kernel RAM paddr

### DIFF
--- a/arch/risc-v/src/common/pgalloc.h
+++ b/arch/risc-v/src/common/pgalloc.h
@@ -75,6 +75,10 @@ static inline uintptr_t riscv_pgvaddr(uintptr_t paddr)
     {
       return paddr - CONFIG_ARCH_PGPOOL_PBASE + CONFIG_ARCH_PGPOOL_VBASE;
     }
+  else if (paddr >= CONFIG_RAM_START && paddr < CONFIG_RAM_END)
+    {
+      return paddr - CONFIG_RAM_START + CONFIG_RAM_VSTART;
+    }
 
   return 0;
 }


### PR DESCRIPTION
## Summary
All kernel memory is mapped paddr=vaddr, so it is trivial to give mapping for kernel memory. Only interesting region should be kernel RAM, so omit kernel ROM and don't allow re-mapping it.

## Impact
Extend address range understood by riscv_pgvaddr

## Testing
mpfs + CONFIG_BUILD_KERNEL
