### PR TITLE
net/usersock: Return -ENOSUPP directly if domain isn't equal to PF_INET/PF_INET6

### DIFF
--- a/net/usrsock/usrsock_sockif.c
+++ b/net/usrsock/usrsock_sockif.c
@@ -100,6 +100,11 @@ static int usrsock_sockif_setup(FAR struct socket *psock)
 {
   int ret;
 
+  if (psock->s_domain != PF_INET && psock->s_domain != PF_INET6)
+    {
+      return -ENOTSUP; /* Only ipv4 and ipv6 support the offload */
+    };
+
   /* Let the user socket logic handle the setup...
    *
    * A return value of zero means that the operation was


### PR DESCRIPTION
## Summary

## Impact

## Testing

