### PR TITLE
Fix the os halt issue when esp32s3 wlan has high-speed or long time d…

### DIFF
--- a/arch/xtensa/src/esp32s3/esp32s3_wlan.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_wlan.c
@@ -296,13 +296,8 @@ static inline void wlan_cache_txpkt_tail(struct wlan_priv_s *priv)
 static struct iob_s *wlan_recvframe(struct wlan_priv_s *priv)
 {
   struct iob_s *iob;
-  irqstate_t flags;
-
-  flags = spin_lock_irqsave(&priv->lock);
 
   iob = iob_remove_queue(&priv->rxb);
-
-  spin_unlock_irqrestore(&priv->lock, flags);
 
   return iob;
 }


### PR DESCRIPTION
## Summary
 Fix the os halt issue when esp32s3 wlan has high-speed or long time data transmission.
 
0x40377f08 in up_interrupt_context () at /media/zzq/sda4/work/esp32s3/midokura_esp32s3/esp32s3_devkitSK/nuttx/include/arch/irq.h:455
455  return ret;
(gdb) bt
#0  0x40377f08 in up_interrupt_context ()
    at /media/zzq/sda4/work/esp32s3/midokura_esp32s3/esp32s3_devkitSK/nuttx/include/arch/irq.h:455
#1  0x40377f79 in enter_critical_section () at irq/irq_csection.c:202
#2  0x4206678c in iob_remove_queue (iobq=0x3fc92fe4 <g_wlan_priv+220>) at iob/iob_remove_queue.c:59
#3  0x42069b8a in wlan_recvframe (priv=<optimized out>) at chip/esp32s3_wlan.c:303
#4  wlan_rxpoll (arg=0x3fc92f08 <g_wlan_priv>) at chip/esp32s3_wlan.c:507
#5  0x42002b58 in work_thread (argc=<optimized out>, argv=<optimized out>) at wqueue/kwork_thread.c:186
#6  0x42003c14 in nxtask_start () at task/task_start.c:129

## Impact
Only ESP32S3
## Testing
ESP32-S3-DevKitC-1 board + iperf server + >20Mbits
