### PR TITLE
lib_memfd: turn a runtime error into a linker error

### DIFF
--- a/libs/libc/misc/lib_memfd.c
+++ b/libs/libc/misc/lib_memfd.c
@@ -29,6 +29,7 @@
 #include <stdio.h>
 #include <unistd.h>
 
+#if defined(CONFIG_LIBC_MEMFD_TMPFS) || defined(CONFIG_LIBC_MEMFD_SHMFS)
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -73,3 +74,4 @@ int memfd_create(FAR const char *name, unsigned int flags)
   return ret;
 #endif
 }
+#endif


### PR DESCRIPTION
## Summary
lib_memfd: turn a runtime error into a linker error
## Impact
none
## Testing
none

