### PR TITLE
net: allow icmpv6 and udp to find the dev by the ifindex with s_boundto.

### DIFF
--- a/net/icmpv6/icmpv6_sendmsg.c
+++ b/net/icmpv6/icmpv6_sendmsg.c
@@ -298,8 +298,18 @@ ssize_t icmpv6_sendmsg(FAR struct socket *psock, FAR struct msghdr *msg,
 
   /* Get the device that will be used to route this ICMPv6 ECHO request */
 
-  dev = netdev_findby_ripv6addr(g_ipv6_unspecaddr,
-                               inaddr->sin6_addr.s6_addr16);
+#ifdef CONFIG_NET_BINDTODEVICE
+  if (conn->sconn.s_boundto != 0)
+    {
+      dev = netdev_findbyindex(conn->sconn.s_boundto);
+    }
+  else
+#endif
+    {
+      dev = netdev_findby_ripv6addr(g_ipv6_unspecaddr,
+                                    inaddr->sin6_addr.s6_addr16);
+    }
+
   if (dev == NULL)
     {
       nerr("ERROR: Not reachable\n");

--- a/net/inet/inet_sockif.c
+++ b/net/inet/inet_sockif.c
@@ -1909,6 +1909,11 @@ static ssize_t inet_sendmsg(FAR struct socket *psock,
 
   for (len = 0, iov = msg->msg_iov; iov != end; iov++)
     {
+      if (iov->iov_len == 0 || iov->iov_base == NULL)
+        {
+          continue;
+        }
+
       memcpy(((unsigned char *)buf) + len, iov->iov_base, iov->iov_len);
       len += iov->iov_len;
     }

--- a/net/udp/udp_finddev.c
+++ b/net/udp/udp_finddev.c
@@ -215,10 +215,13 @@ udp_find_raddr_device(FAR struct udp_conn_s *conn,
 #if defined(CONFIG_NET_MLD) && defined(CONFIG_NET_BINDTODEVICE)
           if (IN6_IS_ADDR_MULTICAST(&raddr))
             {
-              if ((conn->sconn.s_boundto == 0) &&
-                  (conn->mreq.imr_ifindex != 0))
+              if (conn->mreq.imr_ifindex != 0)
                 {
                   return netdev_findbyindex(conn->mreq.imr_ifindex);
+                }
+              else if (conn->sconn.s_boundto != 0)
+                {
+                  return netdev_findbyindex(conn->sconn.s_boundto);
                 }
             }
           else


### PR DESCRIPTION
## Summary
 Allow icmpv6 and udp to find the dev by the ifindex with s_boundto..
## Impact
  When the ipv6 socket was set SO_BINDTODEVICE, the icmpv6 and udp can 
  find the dev by the ifindex with s_boundto.
## Testing
  In the sim, create two ethernet interfaces. Bind the ipv6 socket to eth1.
  then, use ping6 or renew6 to send ipv6 packets, we can check that 
  the conn is bound to device eth1 in icpmv6_sendmsg/sendto_next_transfer function.
