### PR TITLE
arch: x86_64: Fix idle stack assignment

### DIFF
--- a/arch/x86_64/src/intel64/intel64_head.S
+++ b/arch/x86_64/src/intel64/intel64_head.S
@@ -289,7 +289,7 @@ clear_bss:
 
     // Properly setup RSP to idle stack
     movabs  $g_idle_topstack,    %rbx
-    mov     %rbx,   %rsp
+    mov     (%rbx),   %rsp
 
     /* Initialize and start NuttX */
     call    up_lowsetup                     /* Low-level, pre-OS initialization */


### PR DESCRIPTION
## Summary

`qemu-intel64` init does not work properly due to invalid stack initialization.
`g_idle_topstack` is a variable, it's content must be moved to `rsp`.

## Impact

Deterministic behavior with `qemu-intel64:*` targets.

## Testing

qemu-intel64:nsh
