### PR TITLE
arm64: XN should only be set when the attribute MT_EXECUTE_NEVER is set

### DIFF
--- a/arch/arm64/src/common/arm64_mmu.c
+++ b/arch/arm64/src/common/arm64_mmu.c
@@ -336,7 +336,7 @@ static void set_pte_block_desc(uint64_t *pte, uint64_t addr_pa,
       {
         /* Make Normal RW memory as execute never */
 
-        if ((attrs & MT_RW) || (attrs & MT_EXECUTE_NEVER))
+        if (attrs & MT_EXECUTE_NEVER)
           {
             desc |= PTE_BLOCK_DESC_PXN;
           }


### PR DESCRIPTION
## Summary

Only when SCTLR_ELn.WXN is set to 1, regions that are writable at ELn are treated as non-executable. Therefore, when SCTLR_ELn.WXN is set to 0, regions that are writable at ELn can be executed, so the writable attribute cannot be used to restrict the executable attribute.

## Impact

arm64 mmu config

## Testing

qemu-armv8a:nsh with mmu region attr set to (MT_NORMAL | MT_RW | MT_EXECUTE)