### PR TITLE
Update Fix more generic for platforms that do not have execinfo.h

### DIFF
--- a/arch/sim/src/sim/posix/sim_hostmisc.c
+++ b/arch/sim/src/sim/posix/sim_hostmisc.c
@@ -40,6 +40,12 @@
 #include <mach-o/dyld.h>
 #endif
 
+#if defined __has_include
+#   if __has_include(<execinfo.h>)
+#      define SIM_GLIBC_PLATFORM 1
+#   endif
+#endif
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
@@ -90,10 +96,10 @@ void host_abort(int status)
 
 int host_backtrace(void** array, int size)
 {
-#ifdef CONFIG_WINDOWS_CYGWIN
-  return 0;
-#else
+#ifdef SIM_GLIBC_PLATFORM
   return host_uninterruptible(backtrace, array, size);
+#else
+  return 0;
 #endif
 }
 


### PR DESCRIPTION
Summary
Simulator build fails on non-GLIBC platform #5621 #5623.
On platforms where the execinfo.h file is missing, the Gnulib substitute implementation is just a stub, and does nothing.
https://www.gnu.org/software/gnulib/manual/html_node/execinfo_002eh.html
Improve multiplatform code with __has_include.
https://gcc.gnu.org/onlinedocs/cpp/_005f_005fhas_005finclude.html

Impact
On Linux with glibc: There should be no impact.
On other platforms: Enable simulator compilation.

Testing
We tested on platform Alpine linux [sim:nsh on github](https://github.com/simbit18/nuttx-alpine) sim:lua

