### PR TITLE
assert: move the backtrace dump after the stack dump

### DIFF
--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -631,18 +631,18 @@ void _assert(FAR const char *filename, int linenum,
 #endif
          rtcb->entry.main);
 
-  /* Show back trace */
-
-#ifdef CONFIG_SCHED_BACKTRACE
-  sched_dumpstack(rtcb->pid);
-#endif
-
   /* Register dump */
 
   up_dump_register(regs);
 
 #ifdef CONFIG_ARCH_STACKDUMP
   dump_stacks(rtcb, up_getusrsp(regs));
+#endif
+
+  /* Show back trace */
+
+#ifdef CONFIG_SCHED_BACKTRACE
+  sched_dumpstack(rtcb->pid);
 #endif
 
   /* Flush any buffered SYSLOG data */


### PR DESCRIPTION
## Summary
Execute the simple logic first to avoid rarely crash information when crash in backtrace again.

## Impact
Show backtrace after the stack dump.

## Testing
Internal project board with BES Cortex-A7 dual core and Cortex-M33 chip
