### PR TITLE
mpfs_ethernet.c: Fix RX/TX buffer and descriptor handling

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_ethernet.c
+++ b/arch/risc-v/src/mpfs/mpfs_ethernet.c
@@ -2805,10 +2805,10 @@ static void mpfs_buffer_free(struct mpfs_ethmac_s *priv, unsigned int queue)
 #ifndef CONFIG_MPFS_GMAC_PREALLOCATE
   /* Free allocated buffers */
 
-  if (priv->queue[queue].rx_desc_tab != NULL)
+  if (priv->queue[queue].tx_desc_tab != NULL)
     {
-      kmm_free(priv->queue[queue].rx_desc_tab);
-      priv->queue[queue].rx_desc_tab = NULL;
+      kmm_free(priv->queue[queue].tx_desc_tab);
+      priv->queue[queue].tx_desc_tab = NULL;
     }
 
   if (priv->queue[queue].rx_desc_tab != NULL)
@@ -2823,10 +2823,10 @@ static void mpfs_buffer_free(struct mpfs_ethmac_s *priv, unsigned int queue)
       priv->queue[queue].txbuffer = NULL;
     }
 
-  if (priv->queue[queue].txbuffer != NULL)
+  if (priv->queue[queue].rxbuffer != NULL)
     {
-      kmm_free(priv->queue[queue].txbuffer);
-      priv->queue[queue].txbuffer = NULL;
+      kmm_free(priv->queue[queue].rxbuffer);
+      priv->queue[queue].rxbuffer = NULL;
     }
 #endif
 }

--- a/arch/risc-v/src/mpfs/mpfs_ethernet.c
+++ b/arch/risc-v/src/mpfs/mpfs_ethernet.c
@@ -1180,6 +1180,13 @@ static void mpfs_txreset(struct mpfs_ethmac_s *priv)
       priv->queue[qi].txhead = 0;
       priv->queue[qi].txtail = 0;
 
+      if (!txdesc || !txbuffer)
+        {
+          /* The queue index is not set up */
+
+          continue;
+        }
+
       for (ndx = 0; ndx < CONFIG_MPFS_ETHMAC_NTXBUFFERS; ndx++)
         {
           bufaddr = (uintptr_t)&txbuffer[ndx * GMAC_TX_UNITSIZE];
@@ -1254,6 +1261,13 @@ static void mpfs_rxreset(struct mpfs_ethmac_s *priv)
       rxbuffer = priv->queue[qi].rxbuffer;
       rxdesc   = priv->queue[qi].rx_desc_tab;
       priv->queue[qi].rxndx = 0;
+
+      if (!rxdesc || !rxbuffer)
+        {
+          /* The queue index is not set up */
+
+          continue;
+        }
 
       for (ndx = 0; ndx < CONFIG_MPFS_ETHMAC_NRXBUFFERS; ndx++)
         {


### PR DESCRIPTION
## Summary
This fixes two issues with RX/TX buffers and descriptors. A NULL de-reference and a memory leak.
## Impact
MPFS only
## Testing
MPFS
