### PR TITLE
{BP-10815} stm32_eth: Fix excessively long critical section in ifdown handler

### DIFF
--- a/arch/arm/src/stm32/stm32_eth.c
+++ b/arch/arm/src/stm32/stm32_eth.c
@@ -3542,6 +3542,7 @@ static int stm32_ethreset(struct stm32_ethmac_s *priv)
 
   /* Wait for software reset to complete. The SR bit is cleared automatically
    * after the reset operation has completed in all core clock domains.
+   * Should take at most a few clock ticks of the 50 MHz domain.
    */
 
   retries = 10;
@@ -3549,7 +3550,7 @@ static int stm32_ethreset(struct stm32_ethmac_s *priv)
          retries > 0)
     {
       retries--;
-      up_mdelay(10);
+      up_udelay(1);
     }
 
   if (retries == 0)


### PR DESCRIPTION
## Summary
stm32_ifdown() holds critical section when calling stm32_ethreset(). That function used to call up_mdelay(10) while waiting for the ethernet peripheral reset to complete. This resulted in excessively long critical section time with interrupts disabled.

The actual expected delay is a few clock ticks of the 50 MHz clock domain. This commit changes polling interval to 1us and maximum to 10us.

## Impact
RELEASE

## Testing
RC1
