### PR TITLE
{BP-10838} riscv/addrenv: Fix the user VMA end address

### DIFF
--- a/arch/risc-v/src/common/addrenv.h
+++ b/arch/risc-v/src/common/addrenv.h
@@ -58,7 +58,7 @@
 
 /* User address environment end */
 
-#define ARCH_ADDRENV_VEND       (ARCH_ADDRENV_VBASE + ARCH_ADDRENV_MAX_SIZE)
+#define ARCH_ADDRENV_VEND       (ARCH_ADDRENV_VBASE + ARCH_ADDRENV_MAX_SIZE - 1)
 
 /****************************************************************************
  * Public Function Prototypes


### PR DESCRIPTION
## Summary
The end address was off by 1, making it overflow to 0 (0x100000000 represented by u32 value).

## Impact
RELEASE

## Testing
RC1
