### PR TITLE
{BP-10846} arch/arm/src/s32k1xx: Fix LPUART inversion warnings & config

### DIFF
--- a/arch/arm/src/s32k1xx/Kconfig
+++ b/arch/arm/src/s32k1xx/Kconfig
@@ -628,14 +628,6 @@ config S32K1XX_EDMA_EDBG
 
 endmenu # eDMA Global Configuration
 
-menu "LPUART Configuration"
-	depends on S32K1XX_LPUART
-
-config S32K1XX_LPUART_INVERT
-	bool "Signal Invert Support"
-	default n
-endmenu
-
 menu "LPSPI Configuration"
 	depends on S32K1XX_LPSPI
 
@@ -821,6 +813,10 @@ endmenu # LPI2C Configuration
 menu "LPUART Configuration"
 comment "LP Uart Driver Configuration"
 
+config S32K1XX_LPUART_INVERT
+	depends on S32K1XX_LPUART
+	bool "Signal Invert Support"
+	default n
 
 config S32K1XX_LPUART_RXDMA_BUFFER_SIZE
 	int "Rx DMA buffer size"

--- a/arch/arm/src/s32k1xx/s32k1xx_serial.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_serial.c
@@ -1149,7 +1149,9 @@ static int s32k1xx_interrupt(int irq, void *context, void *arg)
 
 static int s32k1xx_ioctl(struct file *filep, int cmd, unsigned long arg)
 {
-#if defined(CONFIG_SERIAL_TIOCSERGSTRUCT) || defined(CONFIG_SERIAL_TERMIOS)
+#if defined(CONFIG_SERIAL_TIOCSERGSTRUCT)	\
+  || defined(CONFIG_SERIAL_TERMIOS)		\
+  || defined(CONFIG_S32K1XX_LPUART_INVERT)
   struct inode *inode = filep->f_inode;
   struct uart_dev_s *dev = inode->i_private;
   irqstate_t flags;
@@ -1347,7 +1349,6 @@ static int s32k1xx_ioctl(struct file *filep, int cmd, unsigned long arg)
         uint32_t ctrl;
         uint32_t stat;
         uint32_t regval;
-        irqstate_t flags;
         struct s32k1xx_uart_s *priv = (struct s32k1xx_uart_s *)dev->priv;
 
         flags  = spin_lock_irqsave(NULL);


### PR DESCRIPTION
## Summary
Enabling S32K1XX_LPUART_INVERT causes warning when building serial driver. This patch fixes it, and also
removes a duplicated menu entry in Kconfig.

## Impact
RELEASE

## Testing
RC1
