### PR TITLE
{BP-10859} esp32/ble: Fix task_create_wrapper CPU core ID passed as argument

### DIFF
--- a/arch/xtensa/src/esp32/esp32_ble_adapter.c
+++ b/arch/xtensa/src/esp32/esp32_ble_adapter.c
@@ -1565,7 +1565,7 @@ static int task_create_wrapper(void *task_func, const char *name,
 {
   return esp_task_create_pinned_to_core(task_func, name,
                                         stack_depth, param,
-                                        prio, task_handle, UINT32_MAX);
+                                        prio, task_handle, core_id);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
The registered `task_create_wrapper` receives the `core_id`, but the current implementation ignores this parameter while calling `esp_task_create_pinned_to_core`. This commit fix this.

## Impact
RELEASE

## Testing
RC1
