### PR TITLE
{BP-10882} esp32s3: fix the halt issue when esp32s3 wlan has high-speed or long …

### DIFF
--- a/arch/xtensa/src/esp32s3/esp32s3_wlan.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_wlan.c
@@ -296,13 +296,8 @@ static inline void wlan_cache_txpkt_tail(struct wlan_priv_s *priv)
 static struct iob_s *wlan_recvframe(struct wlan_priv_s *priv)
 {
   struct iob_s *iob;
-  irqstate_t flags;
-
-  flags = spin_lock_irqsave(&priv->lock);
 
   iob = iob_remove_queue(&priv->rxb);
-
-  spin_unlock_irqrestore(&priv->lock, flags);
 
   return iob;
 }


### PR DESCRIPTION
## Summary
…time data transmission.

The spin_lock in the wlan_recvframe() function that receives RX data packets from the wireless network card and the critical section lock in the iob_remove_queue() processing are nested, which causes the interrupt to be disabled for a longer period of time, resulting in a risk of deadlock.

## Impact
RELEASE

## Testing
RC1
