### PR TITLE
{BP-10909} filemtd:Fix teardown return error number EINVAL

### DIFF
--- a/drivers/mtd/filemtd.c
+++ b/drivers/mtd/filemtd.c
@@ -569,14 +569,12 @@ static int mtd_loop_teardown(FAR const char *devname)
   FAR struct inode *inode;
   int ret;
 
-  /* Open the block driver associated with devname so that we can get the
-   * inode reference.
-   */
+  /* Find the reference to the inode by devname */
 
-  ret = open_blockdriver(devname, MS_RDONLY, &inode);
+  ret = find_mtddriver(devname, &inode);
   if (ret < 0)
     {
-      ferr("ERROR: Failed to open %s: %d\n", devname, -ret);
+      ferr("ERROR: Failed to find %s: %d\n", devname, -ret);
       return ret;
     }
 
@@ -589,16 +587,16 @@ static int mtd_loop_teardown(FAR const char *devname)
   if (!filemtd_isfilemtd(&dev->mtd))
     {
       ferr("ERROR: Device is not a FILEMTD loop: %s\n", devname);
+      close_mtddriver(inode);
       return -EINVAL;
     }
 
-  close_blockdriver(inode);
+  close_mtddriver(inode);
 
   /* Now teardown the filemtd */
 
   filemtd_teardown(&dev->mtd);
-  unregister_blockdriver(devname);
-  kmm_free(dev);
+  unregister_mtddriver(devname);
 
   return OK;
 }


### PR DESCRIPTION
## Summary
In previous versions, during the teardown phase, the "open_blockdriver" would call the "mtd proxy" causing the "file mtd" node to be registered in the ftl. " node is registered in ftl. Therefore, we changed the behavior to find the corresponding inode by node name.

## Impact
RELEASE

## Testing
RC1
