### PR TITLE
Minor improvement for mmc

### DIFF
--- a/drivers/mmcsd/mmcsd_sdio.c
+++ b/drivers/mmcsd/mmcsd_sdio.c
@@ -3260,7 +3260,6 @@ static int mmcsd_multi_iocmd(FAR struct mmcsd_state_s *priv,
 static int mmcsd_sdinitialize(FAR struct mmcsd_state_s *priv)
 {
   uint32_t cid[4];
-  uint32_t csd[4];
   uint32_t scr[2];
   int ret;
 
@@ -3338,7 +3337,7 @@ static int mmcsd_sdinitialize(FAR struct mmcsd_state_s *priv)
       return ret;
     }
 
-  mmcsd_decode_csd(priv, csd);
+  mmcsd_decode_csd(priv, priv->csd);
 
   /* Send CMD7 with the argument == RCA in order to select the card.
    * Since we are supporting only a single card, we just leave the

--- a/drivers/mmcsd/mmcsd_sdio.c
+++ b/drivers/mmcsd/mmcsd_sdio.c
@@ -185,7 +185,7 @@ static void    mmcsd_mediachange(FAR void *arg);
 static int     mmcsd_widebus(FAR struct mmcsd_state_s *priv);
 #ifdef CONFIG_MMCSD_MMCSUPPORT
 static int     mmcsd_mmcinitialize(FAR struct mmcsd_state_s *priv);
-static int     mmcsd_read_csd(FAR struct mmcsd_state_s *priv);
+static int     mmcsd_read_extcsd(FAR struct mmcsd_state_s *priv);
 #endif
 static int     mmcsd_sdinitialize(FAR struct mmcsd_state_s *priv);
 static int     mmcsd_cardidentify(FAR struct mmcsd_state_s *priv);
@@ -2736,7 +2736,7 @@ static int mmcsd_mmcinitialize(FAR struct mmcsd_state_s *priv)
   if (IS_BLOCK(priv->type))
     {
       finfo("Card supports eMMC spec 4.0 (or greater). Reading ext_csd.\n");
-      ret = mmcsd_read_csd(priv);
+      ret = mmcsd_read_extcsd(priv);
       if (ret != OK)
         {
           ferr("ERROR: Failed to determinate number of blocks: %d\n", ret);
@@ -2760,7 +2760,7 @@ static int mmcsd_mmcinitialize(FAR struct mmcsd_state_s *priv)
 }
 
 /****************************************************************************
- * Name: mmcsd_read_csd
+ * Name: mmcsd_read_extcsd
  *
  * Description:
  *   MMC card is detected with block addressing and this function will read
@@ -2771,7 +2771,7 @@ static int mmcsd_mmcinitialize(FAR struct mmcsd_state_s *priv)
  *
  ****************************************************************************/
 
-static int mmcsd_read_csd(FAR struct mmcsd_state_s *priv)
+static int mmcsd_read_extcsd(FAR struct mmcsd_state_s *priv)
 {
   uint8_t buffer[512] aligned_data(16);
   int ret;


### PR DESCRIPTION
## Summary

- drivers/mmcsd: Rename mmcsd_read_csd to mmcsd_read_extcsd 
- drivers/mmcsd: mmcsd_sdinitialize should save csd register into priv->csd

## Impact

code refactor only

## Testing

ci