### PR TITLE
arch: arm64: Remove unnecessary code in arm64_cpu_idle.S

### DIFF
--- a/arch/arm64/src/common/arm64_cpu_idle.S
+++ b/arch/arm64/src/common/arm64_cpu_idle.S
@@ -50,7 +50,6 @@ SECTION_FUNC(text, arch_cpu_idle)
 #endif
     dsb    sy
     wfi
-    msr    daifclr, #(DAIFCLR_IRQ_BIT)
     ret
 
 GTEXT(arch_cpu_atomic_idle)


### PR DESCRIPTION
## Summary

- I noticed that irq is enabled explicitly in arm64_cpu_idle.S
- The code is unnecessary since tasks, including the idle task, are created with irq enabled in up_initial_state()

## Impact

- Should be none

## Testing

- qemu-armv8a:netnsh_smp_hv with qemu-7.2.4

