### PR TITLE
nuttx:generate nuttx.map file when enable debug link map.

### DIFF
--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -267,6 +267,12 @@ else
   LDFLAGS += -Wl,-Ttext-segment=0x400000
 endif
 
+ifeq ($(CONFIG_DEBUG_LINK_MAP),y)
+  ifeq ($(CONFIG_HOST_MACOS),)
+    LDFLAGS += -Wl,-Map=$(TOPDIR)/nuttx.map
+  endif
+endif
+
 ifeq ($(CONFIG_SIM_M32),y)
   LDLINKFLAGS += -melf_i386
   LDFLAGS += -m32


### PR DESCRIPTION
## Summary
In the sim environment, to facilitate debugging, support for generating nuttx.map is added.
## Impact

## Testing

