### PR TITLE
sched: smp call exit immediately when cpuset change to 0.

### DIFF
--- a/sched/sched/sched_smp.c
+++ b/sched/sched/sched_smp.c
@@ -235,6 +235,11 @@ int nxsched_smp_call(cpu_set_t cpuset, nxsched_smp_call_t func,
       CPU_CLR(this_cpu(), &cpuset);
     }
 
+  if (CPU_COUNT(&cpuset) == 0)
+    {
+      goto out;
+    }
+
   /* If waiting is necessary, initialize and wait for the cookie. */
 
   if (wait)


### PR DESCRIPTION
## Summary

Exit immediately when finished processing the current CPU if there are no other CPUs to be processed.

## Impact

smp call

## Testing

qemu-armv8a:nsh_smp smp_call test