### PR TITLE
libds: add missing observer_b16.c to cmake build

### DIFF
--- a/libs/libdsp/CMakeLists.txt
+++ b/libs/libdsp/CMakeLists.txt
@@ -24,6 +24,7 @@ if(CONFIG_LIBDSP)
     lib_svm.c
     lib_transform.c
     lib_observer.c
+    lib_observer_b16.c
     lib_foc.c
     lib_misc.c
     lib_motor.c


### PR DESCRIPTION
## Summary
libds: add missing observer_b16.c to cmake build
## Impact

## Testing

