### PR TITLE
debug/assert: decouple configuration of show file name feature

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -638,6 +638,15 @@ config NDEBUG
 	bool "Define NDEBUG globally"
 	default !DEBUG_ASSERTIONS
 
+config ASSERTIONS_FILENAME
+	bool "Enable library call assert(3) show the file name"
+	default DEBUG_ASSERTIONS_FILENAME || !DEFAULT_SMALL
+	depends on !NDEBUG
+	---help---
+		This option can display the file information of the library call assert(3)
+		function when it is enabled. This option maybe will take up a lot
+		of space from applications.
+
 config DEBUG_ALERT
 	bool
 	default n

--- a/include/assert.h
+++ b/include/assert.h
@@ -42,60 +42,68 @@
 #undef DEBUGASSERT  /* Like ASSERT, but only if CONFIG_DEBUG_ASSERTIONS is defined */
 #undef DEBUGVERIFY  /* Like VERIFY, but only if CONFIG_DEBUG_ASSERTIONS is defined */
 
-#if !defined(CONFIG_HAVE_FILENAME) || !defined(CONFIG_DEBUG_ASSERTIONS_FILENAME)
+/* Macro to define the assertions file name and file line
+ * | Function         |CONFIG                            | Show name/line |
+ * | ---              | ---                              | ---            |
+ * |assert(), ASSERT()|CONFIG_ASSERTIONS_FILENAME=y      | Yes            |
+ * |assert(), ASSERT()|CONFIG_ASSERTIONS_FILENAME=n      | No             |
+ * |DEBUGASSERT()     |CONFIG_DEBUG_ASSERTIONS_FILENAME=y| Yes            |
+ * |DEBUGASSERT()     |CONFIG_DEBUG_ASSERTIONS_FILENAME=n| No             |
+ */
+
+#ifdef CONFIG_HAVE_FILENAME
+#  ifdef CONFIG_DEBUG_ASSERTIONS_FILENAME
+#    define __DEBUG_ASSERT_FILE__ __FILE__
+#    define __DEBUG_ASSERT_LINE__ __LINE__
+#  endif
+#  ifdef CONFIG_ASSERTIONS_FILENAME
+#    define __ASSERT_FILE__ __FILE__
+#    define __ASSERT_LINE__ __LINE__
+#  endif
+#endif
+
+#ifndef __DEBUG_ASSERT_FILE__
+#  define __DEBUG_ASSERT_FILE__ 0
+#  define __DEBUG_ASSERT_LINE__ 0
+#endif
+
+#ifndef __ASSERT_FILE__
 #  define __ASSERT_FILE__ 0
 #  define __ASSERT_LINE__ 0
-#else
-#  define __ASSERT_FILE__ __FILE__
-#  define __ASSERT_LINE__ __LINE__
 #endif
 
 #define PANIC() __assert(__ASSERT_FILE__, __ASSERT_LINE__, "panic")
 #define PANIC_WITH_REGS(msg, regs) _assert(__ASSERT_FILE__, \
                                            __ASSERT_LINE__, msg, regs)
 
+#define __ASSERT(f, file, line, _f) \
+  do                                \
+    {                               \
+      if (predict_false(!(f)))      \
+        __assert(file, line, _f);   \
+    }                               \
+  while (0)
+
+#define __VERIFY(f, file, line, _f) \
+  do                                \
+    {                               \
+      if (predict_false((f) < 0))   \
+        __assert(file, line, _f);   \
+    }                               \
+  while (0)
+
 #ifdef CONFIG_DEBUG_ASSERTIONS_EXPRESSION
-#  define ASSERT(f)                       \
-  do                                      \
-    {                                     \
-      if (predict_false(!(f)))            \
-        __assert(__ASSERT_FILE__,         \
-                 __ASSERT_LINE__, #f);    \
-    }                                     \
-  while (0)
-
-#  define VERIFY(f)                       \
-  do                                      \
-    {                                     \
-      if (predict_false((f) < 0))         \
-        __assert(__ASSERT_FILE__,         \
-                 __ASSERT_LINE__, #f);    \
-    }                                     \
-  while (0)
+#  define _ASSERT(f,file,line) __ASSERT(f, file, line, #f)
+#  define _VERIFY(f,file,line) __VERIFY(f, file, line, #f)
 #else
-#  define ASSERT(f)                       \
-  do                                      \
-    {                                     \
-      if (predict_false(!(f)))            \
-        __assert(__ASSERT_FILE__,         \
-                 __ASSERT_LINE__, 0);     \
-    }                                     \
-  while (0)
-
-#  define VERIFY(f)                       \
-  do                                      \
-    {                                     \
-      if (predict_false((f) < 0))         \
-        __assert(__ASSERT_FILE__,         \
-                 __ASSERT_LINE__, 0);     \
-    }                                     \
-  while (0)
+#  define _ASSERT(f,file,line) __ASSERT(f, file, line, NULL)
+#  define _VERIFY(f,file,line) __VERIFY(f, file, line, NULL)
 #endif
 
 #ifdef CONFIG_DEBUG_ASSERTIONS
-#  define DEBUGPANIC()   PANIC()
-#  define DEBUGASSERT(f) ASSERT(f)
-#  define DEBUGVERIFY(f) VERIFY(f)
+#  define DEBUGPANIC()   __assert(__DEBUG_ASSERT_FILE__, __DEBUG_ASSERT_LINE__, "panic")
+#  define DEBUGASSERT(f) _ASSERT(f, __DEBUG_ASSERT_FILE__, __DEBUG_ASSERT_LINE__)
+#  define DEBUGVERIFY(f) _VERIFY(f, __DEBUG_ASSERT_FILE__, __DEBUG_ASSERT_LINE__)
 #else
 #  define DEBUGPANIC()
 #  define DEBUGASSERT(f) ((void)(1 || (f)))
@@ -109,9 +117,13 @@
 
 #ifdef NDEBUG
 #  define assert(f) ((void)(1 || (f)))
+#  define VERIFY(f) assert(f)
 #else
-#  define assert(f) ASSERT(f)
+#  define assert(f) _ASSERT(f, __ASSERT_FILE__, __ASSERT_LINE__)
+#  define VERIFY(f) _VERIFY(f, __ASSERT_FILE__, __ASSERT_LINE__)
 #endif
+
+#define ASSERT(f) assert(f)
 
 /* Suppress 3rd party library redefine _assert/__assert */
 


### PR DESCRIPTION
## Summary

debug/assert: decouple configuration of show file name feature

add new config CONFIG_ASSERTIONS_FILENAME to library call assert(3) to decouple with CONFIG_DEBUG_ASSERTIONS

| Function         |CONFIG                            | Show filename/line |
| ---              | ---                              | ---                |
|assert(), ASSERT()|CONFIG_ASSERTIONS_FILENAME=y      | Yes                |
|assert(), ASSERT()|CONFIG_ASSERTIONS_FILENAME=n      | No                 |
|DEBUGASSERT()     |CONFIG_DEBUG_ASSERTIONS_FILENAME=y| Yes                |
|DEBUGASSERT()     |CONFIG_DEBUG_ASSERTIONS_FILENAME=n| No                 |


## Impact

Resolve issue: https://github.com/apache/nuttx/issues/10416

## Testing

ci-check