### PR TITLE
usrsock: Make the field of usrsock_request native alignment

### DIFF
--- a/drivers/usrsock/usrsock_rpmsg.c
+++ b/drivers/usrsock/usrsock_rpmsg.c
@@ -94,7 +94,6 @@ static int usrsock_rpmsg_send_dns_request(FAR void *arg,
 
   dns->head.reqid = USRSOCK_RPMSG_DNS_REQUEST;
   dns->head.xid = 0;
-  dns->head.reserved = 0;
   dns->addrlen = addrlen;
   memcpy(dns + 1, addr, addrlen);
 

--- a/include/nuttx/net/usrsock.h
+++ b/include/nuttx/net/usrsock.h
@@ -100,8 +100,7 @@ enum usrsock_message_types_e
 begin_packed_struct struct usrsock_request_common_s
 {
   uint32_t xid;
-  int8_t   reqid;
-  int8_t   reserved;
+  uint32_t reqid;
 } end_packed_struct;
 
 begin_packed_struct struct usrsock_request_socket_s
@@ -157,9 +156,9 @@ begin_packed_struct struct usrsock_request_sendto_s
   struct usrsock_request_common_s head;
 
   int16_t usockid;
+  uint16_t addrlen;
   int32_t flags;
   uint32_t buflen;
-  uint16_t addrlen;
 } end_packed_struct;
 
 begin_packed_struct struct usrsock_request_recvfrom_s
@@ -167,9 +166,9 @@ begin_packed_struct struct usrsock_request_recvfrom_s
   struct usrsock_request_common_s head;
 
   int16_t usockid;
+  uint16_t max_addrlen;
   int32_t flags;
   uint32_t max_buflen;
-  uint16_t max_addrlen;
 } end_packed_struct;
 
 begin_packed_struct struct usrsock_request_setsockopt_s
@@ -213,8 +212,8 @@ begin_packed_struct struct usrsock_request_ioctl_s
   struct usrsock_request_common_s head;
 
   int16_t usockid;
-  int32_t cmd;
   uint16_t arglen;
+  int32_t cmd;
 } end_packed_struct;
 
 begin_packed_struct struct usrsock_request_shutdown_s


### PR DESCRIPTION
## Summary
There is a risk that interfaces such as psock_ioctl/psock_setsockopt will cause paramete to be not four-byte aligned after calculating the offset, so align the length of the structure with parameters by four bytes.

## Impact

## Testing
sim:local
