### PR TITLE
Improve stdio unlock version function

### DIFF
--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -1231,19 +1231,6 @@ int find_mtddriver(FAR const char *pathname, FAR struct inode **ppinode);
 int close_mtddriver(FAR struct inode *pinode);
 
 /****************************************************************************
- * Name: lib_flushall
- *
- * Description:
- *   Called either (1) by the OS when a task exits, or (2) from fflush()
- *   when a NULL stream argument is provided.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_FILE_STREAM
-int lib_flushall(FAR struct streamlist *list);
-#endif
-
-/****************************************************************************
  * Name: file_read
  *
  * Description:

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -99,7 +99,6 @@
 
 #define setlinebuf(stream)   setvbuf(stream, NULL, _IOLBF, 0)
 
-#define clearerr_unlocked(stream) clearerr(stream)
 #define feof_unlocked(stream)     feof(stream)
 #define ferror_unlocked(stream)   ferror(stream)
 #define fileno_unlocked(stream)   fileno(stream)
@@ -140,8 +139,10 @@ extern "C"
 /* Operations on streams (FILE) */
 
 void   clearerr(FAR FILE *stream);
+void   clearerr_unlocked(FAR FILE *stream);
 int    fclose(FAR FILE *stream);
 int    fflush(FAR FILE *stream);
+int    fflush_unlocked(FAR FILE *stream);
 int    feof(FAR FILE *stream);
 int    ferror(FAR FILE *stream);
 int    fileno(FAR FILE *stream);
@@ -174,6 +175,7 @@ size_t fwrite(FAR const void *ptr, size_t size, size_t n_items,
 size_t fwrite_unlocked(FAR const void *ptr, size_t size, size_t n_items,
                        FAR FILE *stream);
 int     getc(FAR FILE *stream);
+int     getc_unlocked(FAR FILE *stream);
 int     getchar(void);
 int     getchar_unlocked(void);
 ssize_t getdelim(FAR char **lineptr, size_t *n, int delimiter,

--- a/include/wchar.h
+++ b/include/wchar.h
@@ -162,6 +162,7 @@ size_t            mbsrtowcs(FAR wchar_t *, FAR const char **, size_t,
 wint_t            putwc(wchar_t, FILE *);
 wint_t            putwc_unlocked(wchar_t, FAR FILE *);
 wint_t            putwchar(wchar_t);
+wint_t            putwchar_unlocked(wchar_t);
 int               swprintf(FAR wchar_t *, size_t, FAR const wchar_t *, ...);
 int               swscanf(FAR const wchar_t *, FAR const wchar_t *, ...);
 wint_t            ungetwc(wint_t, FILE *);

--- a/libs/libc/libc.h
+++ b/libs/libc/libc.h
@@ -211,8 +211,8 @@ FAR char *lib_fgets_unlocked(FAR char *buf, size_t buflen, FILE *stream,
 
 /* Defined in lib_libfflush.c */
 
-ssize_t lib_fflush(FAR FILE *stream, bool bforce);
-ssize_t lib_fflush_unlocked(FAR FILE *stream, bool bforce);
+ssize_t lib_fflush(FAR FILE *stream);
+ssize_t lib_fflush_unlocked(FAR FILE *stream);
 
 /* Defined in lib_rdflush_unlocked.c */
 

--- a/libs/libc/libc.h
+++ b/libs/libc/libc.h
@@ -209,6 +209,13 @@ FAR char *lib_fgets(FAR char *buf, size_t buflen, FILE *stream,
 FAR char *lib_fgets_unlocked(FAR char *buf, size_t buflen, FILE *stream,
                              bool keepnl, bool consume);
 
+/* Defined in lib_flushall.c */
+
+#ifdef CONFIG_FILE_STREAM
+int lib_flushall(FAR struct streamlist *list);
+int lib_flushall_unlocked(FAR struct streamlist *list);
+#endif
+
 /* Defined in lib_libfflush.c */
 
 ssize_t lib_fflush(FAR FILE *stream);

--- a/libs/libc/stdio/lib_clearerr.c
+++ b/libs/libc/stdio/lib_clearerr.c
@@ -46,8 +46,15 @@
  *
  ****************************************************************************/
 
-void clearerr(FAR FILE *stream)
+void clearerr_unlocked(FAR FILE *stream)
 {
   stream->fs_flags &= (__FS_FLAG_LBF | __FS_FLAG_UBF);
+}
+
+void clearerr(FAR FILE *stream)
+{
+  flockfile(stream);
+  clearerr_unlocked(stream);
+  funlockfile(stream);
 }
 #endif /* CONFIG_FILE_STREAM */

--- a/libs/libc/stdio/lib_fclose.c
+++ b/libs/libc/stdio/lib_fclose.c
@@ -75,7 +75,7 @@ int fclose(FAR FILE *stream)
 
       if ((stream->fs_oflags & O_WROK) != 0)
         {
-          ret = lib_fflush(stream, true);
+          ret = lib_fflush(stream);
           errcode = get_errno();
         }
 

--- a/libs/libc/stdio/lib_fflush.c
+++ b/libs/libc/stdio/lib_fflush.c
@@ -66,7 +66,7 @@ int fflush(FAR FILE *stream)
     }
   else
     {
-      ret = lib_fflush(stream, true);
+      ret = lib_fflush(stream);
     }
 
   /* Check the return value */

--- a/libs/libc/stdio/lib_fflush.c
+++ b/libs/libc/stdio/lib_fflush.c
@@ -52,13 +52,48 @@
  *
  ****************************************************************************/
 
+int fflush_unlocked(FAR FILE *stream)
+{
+  int ret;
+
+  /* Is the stream argument NULL? */
+
+  if (stream == NULL)
+    {
+      /* Yes... then this is a request to flush all streams */
+
+      ret = lib_flushall_unlocked(lib_get_streams());
+    }
+  else
+    {
+      ret = lib_fflush_unlocked(stream);
+    }
+
+  /* Check the return value */
+
+  if (ret < 0)
+    {
+      /* An error occurred during the flush AND/OR we were unable to flush
+       * all of the buffered write data. Set the errno value.
+       */
+
+      set_errno(-ret);
+
+      /* And return EOF on failure. */
+
+      return EOF;
+    }
+
+  return OK;
+}
+
 int fflush(FAR FILE *stream)
 {
   int ret;
 
   /* Is the stream argument NULL? */
 
-  if (!stream)
+  if (stream == NULL)
     {
       /* Yes... then this is a request to flush all streams */
 

--- a/libs/libc/stdio/lib_fputc.c
+++ b/libs/libc/stdio/lib_fputc.c
@@ -45,7 +45,7 @@ int fputc_unlocked(int c, FAR FILE *stream)
 
       if (c == '\n' && (stream->fs_flags & __FS_FLAG_LBF) != 0)
         {
-          ret = lib_fflush_unlocked(stream, true);
+          ret = lib_fflush_unlocked(stream);
           if (ret < 0)
             {
               return EOF;

--- a/libs/libc/stdio/lib_fputs.c
+++ b/libs/libc/stdio/lib_fputs.c
@@ -67,7 +67,7 @@ int fputs_unlocked(FAR const IPTR char *s, FAR FILE *stream)
 
       if (ch == '\n' && (stream->fs_flags & __FS_FLAG_LBF) != 0)
         {
-          ret = lib_fflush_unlocked(stream, true);
+          ret = lib_fflush_unlocked(stream);
           if (ret < 0)
             {
               return EOF;
@@ -107,7 +107,7 @@ int fputs_unlocked(FAR const IPTR char *s, FAR FILE *stream)
 
           if (*s == '\n')
             {
-              ret = lib_fflush_unlocked(stream, true);
+              ret = lib_fflush_unlocked(stream);
               if (ret < 0)
                 {
                   return EOF;

--- a/libs/libc/stdio/lib_fputwc.c
+++ b/libs/libc/stdio/lib_fputwc.c
@@ -64,7 +64,7 @@ wint_t fputwc_unlocked(wchar_t c, FAR FILE *f)
 
   if (isascii(c))
     {
-      c = putc(c, f);
+      c = putc_unlocked(c, f);
     }
   else
     {

--- a/libs/libc/stdio/lib_freopen.c
+++ b/libs/libc/stdio/lib_freopen.c
@@ -106,7 +106,7 @@ FAR FILE *freopen(FAR const char *path, FAR const char *mode,
 
       /* Flush the stream and invalidate the read buffer. */
 
-      lib_fflush_unlocked(stream, true);
+      lib_fflush_unlocked(stream);
 
 #ifndef CONFIG_STDIO_DISABLE_BUFFERING
       lib_rdflush_unlocked(stream);

--- a/libs/libc/stdio/lib_libfflush.c
+++ b/libs/libc/stdio/lib_libfflush.c
@@ -48,7 +48,6 @@
  *
  * Input Parameters:
  *  stream - the stream to flush
- *  bforce - flush must be complete.
  *
  * Returned Value:
  *  A negated errno value on failure, otherwise the number of bytes remaining
@@ -56,7 +55,7 @@
  *
  ****************************************************************************/
 
-ssize_t lib_fflush_unlocked(FAR FILE *stream, bool bforce)
+ssize_t lib_fflush_unlocked(FAR FILE *stream)
 {
 #ifndef CONFIG_STDIO_DISABLE_BUFFERING
   FAR const char *src;
@@ -137,7 +136,7 @@ ssize_t lib_fflush_unlocked(FAR FILE *stream, bool bforce)
           src     += bytes_written;
           nbuffer -= bytes_written;
         }
-      while (bforce && nbuffer > 0);
+      while (nbuffer > 0);
 
       /* Reset the buffer position to the beginning of the buffer */
 
@@ -168,14 +167,14 @@ ssize_t lib_fflush_unlocked(FAR FILE *stream, bool bforce)
 #endif
 }
 
-ssize_t lib_fflush(FAR FILE *stream, bool bforce)
+ssize_t lib_fflush(FAR FILE *stream)
 {
   ssize_t ret;
 
   /* Make sure that we have exclusive access to the stream */
 
   flockfile(stream);
-  ret = lib_fflush_unlocked(stream, bforce);
+  ret = lib_fflush_unlocked(stream);
   funlockfile(stream);
   return ret;
 }

--- a/libs/libc/stdio/lib_libflushall.c
+++ b/libs/libc/stdio/lib_libflushall.c
@@ -45,6 +45,54 @@
  *
  ****************************************************************************/
 
+int lib_flushall_unlocked(FAR struct streamlist *list)
+{
+  int lasterrno = OK;
+  int ret;
+
+  /* Make sure that there are streams associated with this thread */
+
+  if (list != NULL)
+    {
+      FAR FILE *stream;
+      int i;
+
+      /* Process each stream in the thread's stream list */
+
+      for (i = 0; i < 3; i++)
+        {
+          lib_fflush_unlocked(&list->sl_std[i]);
+        }
+
+      for (stream = list->sl_head; stream != NULL; stream = stream->fs_next)
+        {
+          /* If the stream is opened for writing, then flush all of
+           * the pending write data in the stream.
+           */
+
+          if ((stream->fs_oflags & O_WROK) != 0)
+            {
+              /* Flush the writable FILE */
+
+              ret = lib_fflush_unlocked(stream);
+              if (ret < 0)
+                {
+                  /* An error occurred during the flush AND/OR we were unable
+                   * to flush all of the buffered write data.  Remember the
+                   * last errcode.
+                   */
+
+                  lasterrno = ret;
+                }
+            }
+        }
+    }
+
+  /* If any flush failed, return the errorcode of the last failed flush */
+
+  return lasterrno;
+}
+
 int lib_flushall(FAR struct streamlist *list)
 {
   int lasterrno = OK;
@@ -52,7 +100,7 @@ int lib_flushall(FAR struct streamlist *list)
 
   /* Make sure that there are streams associated with this thread */
 
-  if (list)
+  if (list != NULL)
     {
       FAR FILE *stream;
       int i;
@@ -66,8 +114,7 @@ int lib_flushall(FAR struct streamlist *list)
           lib_fflush(&list->sl_std[i]);
         }
 
-      stream = list->sl_head;
-      for (; stream != NULL; stream = stream->fs_next)
+      for (stream = list->sl_head; stream != NULL; stream = stream->fs_next)
         {
           /* If the stream is opened for writing, then flush all of
            * the pending write data in the stream.

--- a/libs/libc/stdio/lib_libflushall.c
+++ b/libs/libc/stdio/lib_libflushall.c
@@ -63,7 +63,7 @@ int lib_flushall(FAR struct streamlist *list)
 
       for (i = 0; i < 3; i++)
         {
-          lib_fflush(&list->sl_std[i], true);
+          lib_fflush(&list->sl_std[i]);
         }
 
       stream = list->sl_head;
@@ -77,7 +77,7 @@ int lib_flushall(FAR struct streamlist *list)
             {
               /* Flush the writable FILE */
 
-              ret = lib_fflush(stream, true);
+              ret = lib_fflush(stream);
               if (ret < 0)
                 {
                   /* An error occurred during the flush AND/OR we were unable

--- a/libs/libc/stdio/lib_libfwrite.c
+++ b/libs/libc/stdio/lib_libfwrite.c
@@ -130,7 +130,7 @@ ssize_t lib_fwrite_unlocked(FAR const void *ptr, size_t count,
         {
           /* Flush the buffered data to the IO stream */
 
-          int bytes_buffered = lib_fflush_unlocked(stream, false);
+          int bytes_buffered = lib_fflush_unlocked(stream, true);
           if (bytes_buffered < 0)
             {
               goto errout;

--- a/libs/libc/stdio/lib_libfwrite.c
+++ b/libs/libc/stdio/lib_libfwrite.c
@@ -130,7 +130,7 @@ ssize_t lib_fwrite_unlocked(FAR const void *ptr, size_t count,
         {
           /* Flush the buffered data to the IO stream */
 
-          int bytes_buffered = lib_fflush_unlocked(stream, true);
+          int bytes_buffered = lib_fflush_unlocked(stream);
           if (bytes_buffered < 0)
             {
               goto errout;

--- a/libs/libc/stdio/lib_putc.c
+++ b/libs/libc/stdio/lib_putc.c
@@ -32,3 +32,8 @@ int putc(int c, FAR FILE *stream)
 {
   return fputc(c, stream);
 }
+
+int putc_unlocked(int c, FAR FILE *stream)
+{
+  return fputc_unlocked(c, stream);
+}

--- a/libs/libc/stdio/lib_puts.c
+++ b/libs/libc/stdio/lib_puts.c
@@ -71,7 +71,7 @@ int puts(FAR const IPTR char *s)
 
           if ((stream->fs_flags & __FS_FLAG_LBF) != 0)
             {
-              ret = lib_fflush_unlocked(stream, true);
+              ret = lib_fflush_unlocked(stream);
               if (ret < 0)
                 {
                   nput = EOF;

--- a/libs/libc/stdio/lib_putwchar.c
+++ b/libs/libc/stdio/lib_putwchar.c
@@ -51,13 +51,14 @@
  *
  ****************************************************************************/
 
-wint_t putwchar(wchar_t c)
+wint_t putwchar_unlocked(wchar_t c)
 {
 #ifdef CONFIG_FILE_STREAM
-  return fputwc(c, stdout);
+  return fputwc_unlocked(c, stdout);
 #else
   char mbc[MB_LEN_MAX];
   int l;
+
   l = wctomb(mbc, c);
   if (l < 0)
     {
@@ -66,4 +67,19 @@ wint_t putwchar(wchar_t c)
 
   return write(STDOUT_FILENO, mbc, l) == l ? c : WEOF;
 #endif
+}
+
+wint_t putwchar(wchar_t c)
+{
+  wint_t w;
+
+#ifdef CONFIG_FILE_STREAM
+  flockfile(stdout);
+#endif
+  w = putwchar_unlocked(c);
+#ifdef CONFIG_FILE_STREAM
+  funlockfile(stdout);
+#endif
+
+  return w;
 }

--- a/libs/libc/stdio/lib_wrflush_unlocked.c
+++ b/libs/libc/stdio/lib_wrflush_unlocked.c
@@ -82,7 +82,7 @@ int lib_wrflush_unlocked(FAR FILE *stream)
    * buffered write data was successfully flushed by lib_fflush().
    */
 
-  return lib_fflush_unlocked(stream, true);
+  return lib_fflush_unlocked(stream);
 
 #else
   /* Verify that we were passed a valid (i.e., non-NULL) stream */

--- a/libs/libc/stream/lib_stdoutstream.c
+++ b/libs/libc/stream/lib_stdoutstream.c
@@ -113,7 +113,7 @@ static int stdoutstream_flush(FAR struct lib_outstream_s *self)
                                 (FAR struct lib_stdoutstream_s *)self;
 
   DEBUGASSERT(stream != NULL && stream->handle != NULL);
-  return lib_fflush(stream->handle, true);
+  return lib_fflush(stream->handle);
 }
 #endif
 

--- a/libs/libc/stream/lib_stdsostream.c
+++ b/libs/libc/stream/lib_stdsostream.c
@@ -112,7 +112,7 @@ static int stdsostream_flush(FAR struct lib_sostream_s *self)
                                         (FAR struct lib_stdsostream_s *)self;
 
   DEBUGASSERT(stream != NULL && stream->handle != NULL);
-  return lib_fflush(stream->handle, true);
+  return lib_fflush(stream->handle);
 }
 #endif
 


### PR DESCRIPTION
## Summary

- libc/stdio: lib_fwrite_unlocked must call lib_fflush_unlocked with true 
- libc/stdio: Remove bforce from lib_fflush[_unlocked]
- stdio: Implement [clearerr|putc|fflush]_unlocked 

## Impact

stdio function

## Testing

ci