### PR TITLE
tun: Fix the error of calling tun_close when tun_txavail or tun_txavail_work is executed

### DIFF
--- a/drivers/net/tun.c
+++ b/drivers/net/tun.c
@@ -775,13 +775,20 @@ static void tun_txavail_work(FAR void *arg)
 static int tun_txavail(FAR struct net_driver_s *dev)
 {
   FAR struct tun_device_s *priv = (FAR struct tun_device_s *)dev->d_private;
+  irqstate_t flags;
 
-  /* Schedule to perform the TX poll on the worker thread. */
+  flags = enter_critical_section(); /* No interrupts */
 
-  if (work_available(&priv->work))
+  /* Schedule to perform the TX poll on the worker thread when priv->bifup
+   * is true.
+   */
+
+  if (priv->bifup && work_available(&priv->work))
     {
       work_queue(TUNWORK, &priv->work, tun_txavail_work, priv, 0);
     }
+
+  leave_critical_section(flags);
 
   return OK;
 }
@@ -910,6 +917,8 @@ static void tun_dev_uninit(FAR struct tun_device_s *priv)
   /* Put the interface in the down state */
 
   tun_ifdown(&priv->dev);
+
+  work_cancel_sync(TUNWORK, &priv->work);
 
   /* Remove the device from the OS */
 

--- a/drivers/net/tun.c
+++ b/drivers/net/tun.c
@@ -184,7 +184,7 @@ static int tun_rmmac(FAR struct net_driver_s *dev, FAR const uint8_t *mac);
 static int tun_dev_init(FAR struct tun_device_s *priv,
                         FAR struct file *filep,
                         FAR const char *devfmt, bool tun);
-static int tun_dev_uninit(FAR struct tun_device_s *priv);
+static void tun_dev_uninit(FAR struct tun_device_s *priv);
 
 /* File interface */
 
@@ -775,21 +775,13 @@ static void tun_txavail_work(FAR void *arg)
 static int tun_txavail(FAR struct net_driver_s *dev)
 {
   FAR struct tun_device_s *priv = (FAR struct tun_device_s *)dev->d_private;
-  int ret = nxmutex_lock(&priv->lock);
-
-  if (ret < 0)
-    {
-      return ret;
-    }
 
   /* Schedule to perform the TX poll on the worker thread. */
 
-  if (priv->bifup && work_available(&priv->work))
+  if (work_available(&priv->work))
     {
       work_queue(TUNWORK, &priv->work, tun_txavail_work, priv, 0);
     }
-
-  nxmutex_unlock(&priv->lock);
 
   return OK;
 }
@@ -913,26 +905,11 @@ static int tun_dev_init(FAR struct tun_device_s *priv,
  * Name: tun_dev_uninit
  ****************************************************************************/
 
-static int tun_dev_uninit(FAR struct tun_device_s *priv)
+static void tun_dev_uninit(FAR struct tun_device_s *priv)
 {
-  int ret;
-
-  ret = nxmutex_lock(&priv->lock);
-  if (ret < 0)
-    {
-      return ret;
-    }
-
   /* Put the interface in the down state */
 
   tun_ifdown(&priv->dev);
-
-  if (!work_available(&priv->work))
-    {
-      work_cancel_sync(TUNWORK, &priv->work);
-    }
-
-  nxmutex_unlock(&priv->lock);
 
   /* Remove the device from the OS */
 
@@ -941,8 +918,6 @@ static int tun_dev_uninit(FAR struct tun_device_s *priv)
   nxmutex_destroy(&priv->lock);
   nxsem_destroy(&priv->read_wait_sem);
   nxsem_destroy(&priv->write_wait_sem);
-
-  return ret;
 }
 
 /****************************************************************************
@@ -966,11 +941,8 @@ static int tun_close(FAR struct file *filep)
   ret  = nxmutex_lock(&tun->lock);
   if (ret >= 0)
     {
-      ret = tun_dev_uninit(priv);
-      if (ret >= 0)
-        {
-          tun->free_tuns |= (1 << intf);
-        }
+      tun->free_tuns |= (1 << intf);
+      tun_dev_uninit(priv);
 
       nxmutex_unlock(&tun->lock);
     }


### PR DESCRIPTION
## Summary
When tun_txavail_work is running, switch to tun_close thread and priv->lock will be destroyed, then switch back to tun_txavail_work thread, an error will occur when nxmutex_unlock(&priv->lock).

The previous modified mode was found to have a deadlock(net_lock and tun_lock) problem after stress testing, revert the previous patch, the new implementation was fix the error and avoids the deadlock issue.
## Impact

## Testing
Cortex-M33
