### PR TITLE
net/icmpv6: Fix net mask logic in `icmpv6_setaddresses`

### DIFF
--- a/net/icmpv6/icmpv6_rnotify.c
+++ b/net/icmpv6/icmpv6_rnotify.c
@@ -110,7 +110,7 @@ void icmpv6_setaddresses(FAR struct net_driver_s *dev,
 
   /* Copy prefix to the current IPv6 address, applying the mask */
 
-  for (i = 0; i < 7; i++)
+  for (i = 0; i < 8; i++)
     {
       dev->d_ipv6addr[i] = (dev->d_ipv6addr[i] & ~dev->d_ipv6netmask[i]) |
                            (prefix[i] & dev->d_ipv6netmask[i]);

--- a/net/utils/net_ipv6_pref2mask.c
+++ b/net/utils/net_ipv6_pref2mask.c
@@ -91,7 +91,7 @@ void net_ipv6_pref2mask(uint8_t preflen, net_ipv6addr_t mask)
                *          = 0xfc00
                */
 
-              mask[i] = 0xffff << (16 - (preflen - bit));
+              mask[i] = HTONS(0xffff << (16 - (preflen - bit)));
             }
         }
       else


### PR DESCRIPTION
## Summary
1. Both IPv6 addresses and net masks should be stored in network byte order
2. Fix last 2 bytes of mask applying (although it seldom triggers)

## Impact
`icmpv6_setaddresses` and `net_ipv6_pref2mask`

## Testing
Manually, CI
