### PR TITLE
net/local: Support `SO_SNDBUF` option in `getsockopt`

### DIFF
--- a/net/local/local.h
+++ b/net/local/local.h
@@ -49,6 +49,8 @@
 #define LOCAL_NPOLLWAITERS 2
 #define LOCAL_NCONTROLFDS  4
 
+#define LOCAL_SEND_LIMIT   (CONFIG_DEV_FIFO_SIZE - sizeof(uint16_t))
+
 /****************************************************************************
  * Public Type Definitions
  ****************************************************************************/

--- a/net/local/local_sendpacket.c
+++ b/net/local/local_sendpacket.c
@@ -130,7 +130,7 @@ int local_send_packet(FAR struct file *filep, FAR const struct iovec *buf,
           len16 += iov->iov_len;
         }
 
-      if (len16 > CONFIG_DEV_FIFO_SIZE - sizeof(uint16_t))
+      if (len16 > LOCAL_SEND_LIMIT)
         {
           nerr("ERROR: Packet is too big: %d\n", len16);
           return -EMSGSIZE;

--- a/net/local/local_sockif.c
+++ b/net/local/local_sockif.c
@@ -562,19 +562,36 @@ static int local_getsockopt(FAR struct socket *psock, int level, int option,
 {
   DEBUGASSERT(psock->s_domain == PF_LOCAL);
 
-#ifdef CONFIG_NET_LOCAL_SCM
-  if (level == SOL_SOCKET && option == SO_PEERCRED)
+  if (level == SOL_SOCKET)
     {
-      FAR struct local_conn_s *conn = psock->s_conn;
-      if (*value_len != sizeof(struct ucred))
+      switch (option)
         {
-          return -EINVAL;
-        }
+#ifdef CONFIG_NET_LOCAL_SCM
+          case SO_PEERCRED:
+            {
+              FAR struct local_conn_s *conn = psock->s_conn;
+              if (*value_len != sizeof(struct ucred))
+                {
+                  return -EINVAL;
+                }
 
-      memcpy(value, &conn->lc_peer->lc_cred, sizeof(struct ucred));
-      return OK;
-    }
+              memcpy(value, &conn->lc_peer->lc_cred, sizeof(struct ucred));
+              return OK;
+            }
 #endif
+
+          case SO_SNDBUF:
+            {
+              if (*value_len != sizeof(int))
+                {
+                  return -EINVAL;
+                }
+
+              *(FAR int *)value = LOCAL_SEND_LIMIT;
+              return OK;
+            }
+        }
+    }
 
   return -ENOPROTOOPT;
 }


### PR DESCRIPTION
## Summary
For datagram unix sockets, the `SO_SNDBUF` value imposes an upper limit on the size of outgoing datagrams.

Note: We don't support to change the buffer size yet, so only add support to getsockopt now.
Refs: https://man7.org/linux/man-pages/man7/unix.7.html

## Impact
`getsockopt` of local socket

## Testing
CI

