### PR TITLE
Documentation: add fmemopen test entry

### DIFF
--- a/Documentation/applications/testing/fmemopen/index.rst
+++ b/Documentation/applications/testing/fmemopen/index.rst
@@ -1,0 +1,11 @@
+=======================================
+``fmemopen`` - fmemopen test tool
+=======================================
+
+``CONFIG_TESTING_FMEMOPEN_TEST=y``
+
+Performs a basic operations with fmemopen call.
+
+Usage::
+
+    fmemopen_test

--- a/Documentation/applications/testing/index.rst
+++ b/Documentation/applications/testing/index.rst
@@ -26,6 +26,8 @@ with little value as usage examples.
 - drivertest - vela cmocka driver test
 - fatutf8 - FAT UTF8 test
 - fdsantest - vela cmocka fdsan test
+- fmemopen - fmemopen() test
+- fopencookie - fopencookie() test
 - getprime - getprime example
 - iozone - IOzone, filesystem benchmark tool
 - irtest - IR driver test


### PR DESCRIPTION
## Summary
Test tool for fmemopen() function added to documentation.

## Impact
Docs only. Should be merged with [testing: add fmemopen function test tool](https://github.com/apache/nuttx-apps/pull/2155).
