### PR TITLE
group/killchildren: replace syscall(2) to kernel api

### DIFF
--- a/sched/clock/clock_adjtime.c
+++ b/sched/clock/clock_adjtime.c
@@ -119,8 +119,6 @@ int adjtime(FAR const struct timeval *delta, FAR struct timeval *olddelta)
   long long incr_limit;
   int is_negative;
 
-  is_negative = 0;
-
   if (!delta)
     {
       set_errno(EINVAL);
@@ -135,6 +133,10 @@ int adjtime(FAR const struct timeval *delta, FAR struct timeval *olddelta)
     {
       adjust_usec = -adjust_usec;
       is_negative = 1;
+    }
+  else
+    {
+      is_negative = 0;
     }
 
   /* Get period in usec. Target hardware has to provide support for

--- a/sched/group/group_create.c
+++ b/sched/group/group_create.c
@@ -129,7 +129,7 @@ static inline void group_inherit_identity(FAR struct task_group_s *group)
 int group_allocate(FAR struct task_tcb_s *tcb, uint8_t ttype)
 {
   FAR struct task_group_s *group;
-  int ret = -ENOMEM;
+  int ret;
 
   DEBUGASSERT(tcb && !tcb->cmn.group);
 
@@ -158,6 +158,7 @@ int group_allocate(FAR struct task_tcb_s *tcb, uint8_t ttype)
   group->tg_members = kmm_malloc(GROUP_INITIAL_MEMBERS * sizeof(pid_t));
   if (!group->tg_members)
     {
+      ret = -ENOMEM;
       goto errout_with_group;
     }
 

--- a/sched/group/group_killchildren.c
+++ b/sched/group/group_killchildren.c
@@ -32,6 +32,7 @@
 #include <sys/types.h>
 
 #include <nuttx/sched.h>
+#include <nuttx/signal.h>
 
 #include "sched/sched.h"
 #include "group/group.h"
@@ -201,9 +202,11 @@ int group_kill_children(FAR struct tcb_s *tcb)
   while (1)
     {
       if (tcb->group->tg_nmembers <= 1)
+        {
           break;
+        }
 
-      usleep(USEC_PER_MSEC);
+      nxsig_usleep(USEC_PER_MSEC);
 
 #  if CONFIG_GROUP_KILL_CHILDREN_TIMEOUT_MS > 0
       if (--ret < 0)

--- a/sched/group/group_setupidlefiles.c
+++ b/sched/group/group_setupidlefiles.c
@@ -59,7 +59,6 @@
 
 int group_setupidlefiles(void)
 {
-  int ret = OK;
 #if defined(CONFIG_DEV_CONSOLE) || defined(CONFIG_DEV_NULL)
   int fd;
 #endif
@@ -115,5 +114,5 @@ int group_setupidlefiles(void)
 #endif /* defined(CONFIG_DEV_CONSOLE) || defined(CONFIG_DEV_NULL) */
 
   sched_trace_end();
-  return ret;
+  return OK;
 }

--- a/sched/group/group_setuptaskfiles.c
+++ b/sched/group/group_setuptaskfiles.c
@@ -76,11 +76,6 @@ int group_setuptaskfiles(FAR struct task_tcb_s *tcb)
   /* Duplicate the parent task's file descriptors */
 
   ret = files_duplist(&rtcb->group->tg_filelist, &group->tg_filelist);
-  if (ret < 0)
-    {
-      sched_trace_end();
-      return ret;
-    }
 #endif
 
   sched_trace_end();

--- a/sched/pthread/pthread_detach.c
+++ b/sched/pthread/pthread_detach.c
@@ -65,7 +65,7 @@ int pthread_detach(pthread_t thread)
   FAR struct tcb_s *rtcb = this_task();
   FAR struct task_group_s *group = rtcb->group;
   FAR struct join_s *pjoin;
-  int ret = OK;
+  int ret;
 
   sinfo("Thread=%d group=%p\n", thread, group);
   DEBUGASSERT(group);

--- a/sched/task/task_delete.c
+++ b/sched/task/task_delete.c
@@ -66,7 +66,6 @@ int nxtask_delete(pid_t pid)
 {
   FAR struct tcb_s *dtcb;
   FAR struct tcb_s *rtcb;
-  int ret;
 
   /* Check if the task to delete is the calling task:  PID=0 means to delete
    * the calling task.  In this case, task_delete() is much like exit()
@@ -132,13 +131,7 @@ int nxtask_delete(pid_t pid)
    * nxtask_terminate() do all of the heavy lifting.
    */
 
-  ret = nxtask_terminate(pid);
-  if (ret < 0)
-    {
-      return ret;
-    }
-
-  return OK;
+  return nxtask_terminate(pid);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

1. group/killchildren: replace syscall(2) to kernel api
syscall(2) cannot be called from kernel space

2. sched: fix the minor style issue

## Impact

N/A

## Testing

ci-check