### PR TITLE
arch/risc-v/litex/litex_gpio: Fix ISR dispatch when using higher GPIO indexes.

### DIFF
--- a/arch/risc-v/include/litex/irq.h
+++ b/arch/risc-v/include/litex/irq.h
@@ -37,15 +37,16 @@
 
 /* Map RISC-V exception code to NuttX IRQ */
 
-#define LITEX_IRQ_UART0    (RISCV_IRQ_EXT + 1)
-#define LITEX_IRQ_TIMER0   (RISCV_IRQ_EXT + 2)
-#define LITEX_IRQ_ETHMAC   (RISCV_IRQ_EXT + 3)
-#define LITEX_IRQ_SDCARD   (RISCV_IRQ_EXT + 4)
-#define LITEX_IRQ_GPIO     (RISCV_IRQ_EXT + 5)
+#define LITEX_IRQ_UART0       (RISCV_IRQ_EXT + 1)
+#define LITEX_IRQ_TIMER0      (RISCV_IRQ_EXT + 2)
+#define LITEX_IRQ_ETHMAC      (RISCV_IRQ_EXT + 3)
+#define LITEX_IRQ_SDCARD      (RISCV_IRQ_EXT + 4)
+#define LITEX_IRQ_GPIO_BASE   (RISCV_IRQ_EXT + 5)
+#define LITEX_IRQ_GPIO_LENGTH 8
 
 /* The last hardware IRQ number */
 
-#define LITEX_IRQ_LAST     (LITEX_IRQ_GPIO)
+#define LITEX_LAST_IRQ          (LITEX_IRQ_GPIO_BASE + LITEX_IRQ_GPIO_LENGTH)
 
 /* Second level GPIO interrupts.  GPIO interrupts are decoded and dispatched
  * as a second level of decoding:  The first level dispatches to the GPIO
@@ -53,7 +54,7 @@
  */
 
 #ifdef CONFIG_LITEX_GPIO_IRQ
-#  define LITEX_NIRQ_GPIO           32
+#  define LITEX_NIRQ_GPIO           LITEX_IRQ_GPIO_LENGTH * 32
 #  define LITEX_FIRST_GPIOIRQ       (LITEX_IRQ_LAST + 1)
 #  define LITEX_LAST_GPIOIRQ        (LITES_FIRST_GPIOIRQ + LITEX_NIRQ_GPIO)
 #else

--- a/arch/risc-v/src/litex/litex_gpio.c
+++ b/arch/risc-v/src/litex/litex_gpio.c
@@ -53,7 +53,7 @@
 
 #ifdef CONFIG_LITEX_GPIO_IRQ
 /* Helper to calculate the GPIO port index from an IRQ number. */
-#define irq_to_gpio_index(_irqno) (( _irqno - LITEX_IRQ_GPIO) % 32)
+#define irq_to_gpio_index(_irqno) (( _irqno - LITEX_IRQ_GPIO_BASE) % 32)
 
 /* Helper to calculate the extended IRQ number from GPIO  port index. */
 #define gpio_index_to_irq(_i, _p) ((_i * 32) + _p + LITEX_FIRST_GPIOIRQ)
@@ -160,7 +160,8 @@ static int litex_gpio_interrupt(int irq, void * context, void * arg)
 
   gpiobase = gpiobase_at(gpioindex);
 
-  gpio_dispatch(LITEX_FIRST_GPIOIRQ, gpiobase, (uint32_t *)context);
+  gpio_dispatch(LITEX_FIRST_GPIOIRQ + (gpioindex * 32),
+                gpiobase, (uint32_t *)context);
   return OK;
 }
 #endif


### PR DESCRIPTION
## Summary

Previously, GPIO interrupts were not correctly mapped to the peripheral base register responsible for the interrupt.

Change the IRQ number calculation so the interrupts work correctly on all GPIO peripheral bases.

## Impact

Interrupts are mapped correctly when enabled on port index > 0.

## Testing

Custom hardware using Litex.