### PR TITLE
sim/wifidriver: Fix the scan error.

### DIFF
--- a/arch/sim/src/sim/sim_wifidriver.c
+++ b/arch/sim/src/sim/sim_wifidriver.c
@@ -594,6 +594,10 @@ get_scan:
       goto get_scan;
     }
 
+  /* Add a terminator for the rbuf */
+
+  rbuf[ret] = '\0';
+
   ret = -EAGAIN;
   for (p = rbuf; *p != '\0'; p++)
     {


### PR DESCRIPTION

## Summary
Fix the simwifi scan error that Using the uninitialized buffer causes the out of bounds.
## Impact
 Add a terminator for the rbuf, and the simwifi scan can return the scan results.
## Testing
The command 'wapi scan wlan0' works fine. 

