### PR TITLE
cmake:init RISC-V cmake qemu-rv build

### DIFF
--- a/arch/risc-v/CMakeLists.txt
+++ b/arch/risc-v/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# libs/libc/machine/risc-v/CMakeLists.txt
+# arch/risc-v/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
@@ -17,20 +17,5 @@
 # the License.
 #
 # ##############################################################################
-add_subdirectory(gnu)
 
-if(CONFIG_ARCH_RV64GC)
-  add_subdirectory(rv64)
-endif()
-
-if(CONFIG_ARCH_RV32IM)
-  add_subdirectory(rv32)
-endif()
-
-set(SRCS)
-
-if(CONFIG_LIBC_ARCH_ELF)
-  list(APPEND SRCS arch_elf.c)
-endif()
-
-target_sources(c PRIVATE ${SRCS})
+nuttx_add_subdirectory()

--- a/arch/risc-v/src/CMakeLists.txt
+++ b/arch/risc-v/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# libs/libc/machine/risc-v/CMakeLists.txt
+# arch/risc-v/src/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
@@ -17,20 +17,15 @@
 # the License.
 #
 # ##############################################################################
-add_subdirectory(gnu)
 
-if(CONFIG_ARCH_RV64GC)
-  add_subdirectory(rv64)
+add_subdirectory(common)
+add_subdirectory(${NUTTX_CHIP_ABS_DIR} EXCLUDE_FROM_ALL exclude_chip)
+
+# Include directories (before system ones) as PUBLIC so that it can be exposed
+# to libboard
+target_include_directories(arch BEFORE PUBLIC ${NUTTX_CHIP_ABS_DIR} common)
+
+if(NOT CONFIG_BUILD_FLAT)
+  target_include_directories(arch_interface BEFORE PUBLIC ${NUTTX_CHIP_ABS_DIR}
+                                                          common)
 endif()
-
-if(CONFIG_ARCH_RV32IM)
-  add_subdirectory(rv32)
-endif()
-
-set(SRCS)
-
-if(CONFIG_LIBC_ARCH_ELF)
-  list(APPEND SRCS arch_elf.c)
-endif()
-
-target_sources(c PRIVATE ${SRCS})

--- a/arch/risc-v/src/cmake/Toolchain.cmake
+++ b/arch/risc-v/src/cmake/Toolchain.cmake
@@ -1,0 +1,281 @@
+# ##############################################################################
+# arch/risc-v/src/cmake/Toolchain.cmake
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_VERSION 1)
+
+set(CMAKE_C_COMPILER_FORCED TRUE)
+set(CMAKE_CXX_COMPILER_FORCED TRUE)
+
+if(CONFIG_RISCV_TOOLCHAIN_GNU_RV32 OR CONFIG_RISCV_TOOLCHAIN_GNU_RV64)
+  if(NOT CONFIG_RISCV_TOOLCHAIN)
+    set(CONFIG_RISCV_TOOLCHAIN GNU_RVG)
+  endif()
+endif()
+
+if(CONFIG_DEBUG_CUSTOMOPT)
+  add_compile_options(${CONFIG_DEBUG_OPTLEVEL})
+elseif(CONFIG_DEBUG_FULLOPT)
+  add_compile_options(-Os)
+endif()
+
+if(NOT CONFIG_DEBUG_NOOPT)
+  add_compile_options(-fno-strict-aliasing)
+endif()
+
+if(CONFIG_FRAME_POINTER)
+  add_compile_options(-fno-omit-frame-pointer -fno-optimize-sibling-calls)
+else()
+  add_compile_options(-fomit-frame-pointer)
+endif()
+
+if(CONFIG_STACK_CANARIES)
+  add_compile_options(-fstack-protector-all)
+endif()
+
+if(CONFIG_STACK_USAGE)
+  add_compile_options(-fstack-usage)
+endif()
+
+if(${CONFIG_STACK_USAGE_WARNING})
+  if(NOT ${CONFIG_STACK_USAGE_WARNING} STREQUAL 0)
+    add_compile_options(-Wstack-usage=${CONFIG_STACK_USAGE_WARNING})
+  endif()
+endif()
+
+if(CONFIG_ARCH_COVERAGE)
+  add_compile_options(-fprofile-generate -ftest-coverage)
+endif()
+
+set(ARCHCFLAGS
+    "-Wstrict-prototypes -fno-common -Wall -Wshadow -Wundef -Wno-attributes -Wno-unknown-pragmas"
+)
+set(ARCHCXXFLAGS
+    "-nostdinc++ -fno-common -Wall -Wshadow -Wundef -Wno-attributes -Wno-unknown-pragmas"
+)
+
+if(NOT ${CONFIG_ARCH_TOOLCHAIN_CLANG})
+  string(APPEND ARCHCFLAGS " -Wno-psabi")
+  string(APPEND ARCHCXXFLAGS " -Wno-psabi")
+endif()
+
+if(${CONFIG_CXX_STANDARD})
+  string(APPEND ARCHCXXFLAGS " -std=${CONFIG_CXX_STANDARD}")
+endif()
+
+if(NOT ${CONFIG_CXX_EXCEPTION})
+  string(APPEND ARCHCXXFLAGS " -fno-exceptions -fcheck-new")
+endif()
+
+if(NOT ${CONFIG_CXX_RTTI})
+  string(APPEND ARCHCXXFLAGS " -fno-rtti")
+endif()
+
+if(CONFIG_ARCH_RV32)
+  add_link_options(-Wl,-melf32lriscv)
+elseif(CONFIG_ARCH_RV64)
+  add_compile_options(-mcmodel=medany)
+  add_link_options(-Wl,-melf64lriscv)
+endif()
+
+if(CONFIG_DEBUG_OPT_UNUSED_SECTIONS)
+  add_link_options(-Wl,--gc-sections)
+  add_compile_options(-ffunction-sections -fdata-sections)
+endif()
+
+add_link_options(-Wl,-nostdlib)
+add_link_options(-Wl,--entry=__start)
+
+if(CONFIG_DEBUG_LINK_MAP)
+  add_link_options(-Wl,--cref -Wl,-Map=nuttx.map)
+endif()
+
+if(CONFIG_DEBUG_SYMBOLS)
+  add_compile_options(-g)
+endif()
+
+if(NOT "${CMAKE_C_FLAGS}" STREQUAL "")
+  string(REGEX MATCH "${ARCHCFLAGS}" EXISTS_FLAGS "${CMAKE_C_FLAGS}")
+endif()
+
+if(NOT EXISTS_FLAGS)
+  set(CMAKE_ASM_FLAGS
+      "${CMAKE_ASM_FLAGS} ${ARCHCFLAGS}"
+      CACHE STRING "" FORCE)
+  set(CMAKE_C_FLAGS
+      "${CMAKE_C_FLAGS} ${ARCHCFLAGS}"
+      CACHE STRING "" FORCE)
+  set(CMAKE_CXX_FLAGS
+      "${CMAKE_CXX_FLAGS} ${ARCHCXXFLAGS}"
+      CACHE STRING "" FORCE)
+endif()
+
+# Generic GNU RVG toolchain
+if(${CONFIG_RISCV_TOOLCHAIN} STREQUAL GNU_RVG)
+
+  if(CONFIG_ARCH_RV_ISA_M)
+    set(ARCHRVISAM m)
+  endif()
+
+  if(CONFIG_ARCH_RV_ISA_A)
+    set(ARCHRVISAA a)
+  endif()
+
+  if(CONFIG_ARCH_RV_ISA_C)
+    set(ARCHRVISAC c)
+  endif()
+
+  if(CONFIG_ARCH_FPU)
+    set(ARCHRVISAF f)
+  endif()
+
+  if(CONFIG_ARCH_DPFPU)
+    set(ARCHRVISAD d)
+  endif()
+
+  # Detect abi type
+
+  if(CONFIG_ARCH_RV32)
+    set(ARCHTYPE "rv32")
+    set(ARCHABITYPE "ilp32")
+    set(LLVM_ARCHTYPE "riscv32")
+  elseif(CONFIG_ARCH_RV64)
+    set(ARCHTYPE "rv64")
+    set(ARCHABITYPE "lp64")
+    set(LLVM_ARCHTYPE "riscv64")
+  endif()
+
+  # Construct arch flags
+
+  set(ARCHCPUEXTFLAGS
+      i${ARCHRVISAM}${ARCHRVISAA}${ARCHRVISAF}${ARCHRVISAD}${ARCHRVISAC})
+  set(ARCHCPUFLAGS -march=${ARCHTYPE}${ARCHCPUEXTFLAGS})
+
+  # Construct arch abi flags
+
+  if(CONFIG_ARCH_DPFPU)
+    list(APPEND ARCHCPUFLAGS -mabi=${ARCHABITYPE}d)
+    set(LLVM_ABITYPE ${ARCHABITYPE}d)
+  elseif(CONFIG_ARCH_FPU)
+    list(APPEND ARCHCPUFLAGS -mabi=${ARCHABITYPE}f)
+    set(LLVM_ABITYPE ${ARCHABITYPE}f)
+  else()
+    list(APPEND ARCHCPUFLAGS -mabi=${ARCHABITYPE})
+    set(LLVM_ABITYPE ${ARCHABITYPE})
+  endif()
+
+  # RISCV has a modular instruction set. It's hard to define cpu-model to
+  # support all toolchain. For Zig, cpu model is this formal:
+  # generic_rv[32|64][i][m][a][f][d][c] For Rust, cpu model is this formal:
+  # riscv[32|64][i][m][a][f][d][c] So, it's better to map the NuttX config to
+  # LLVM builtin cpu model, these models supported by all LLVM based toolchain.
+  # Refer to :
+  # https://github.com/llvm/llvm-project/blob/release/15.x/llvm/lib/Target/RISCV/RISCV.td
+  # These models can't cover all implementation of RISCV, but it's enough for
+  # most cases.
+
+  set(PLATFORM_FLAGS)
+
+  if(CONFIG_ARCH_RV32)
+    if(${ARCHCPUEXTFLAGS} STREQUAL imc)
+      list(APPEND PLATFORM_FLAGS -mcpu=sifive-e20)
+    elseif(${ARCHCPUEXTFLAGS} STREQUAL imac)
+      list(APPEND PLATFORM_FLAGS -mcpu=sifive-e31)
+    elseif(${ARCHCPUEXTFLAGS} STREQUAL imafc)
+      list(APPEND PLATFORM_FLAGS -mcpu=sifive-e76)
+    endif()
+  else()
+    if(${ARCHCPUEXTFLAGS} STREQUAL imac)
+      list(APPEND PLATFORM_FLAGS -mcpu=sifive-s51)
+    elseif(${ARCHCPUEXTFLAGS} STREQUAL imafdc)
+      list(APPEND PLATFORM_FLAGS -mcpu=sifive-u54)
+    endif()
+  endif()
+
+  list(APPEND PLATFORM_FLAGS ${ARCHCPUFLAGS})
+
+  add_compile_options(${PLATFORM_FLAGS})
+
+endif()
+
+if(CONFIG_MM_KASAN_ALL)
+  add_compile_options(-fsanitize=kernel-address)
+endif()
+
+if(CONFIG_MM_KASAN_DISABLE_READS_CHECK)
+  add_compile_options(--param asan-instrument-reads=0)
+endif()
+
+if(CONFIG_MM_KASAN_DISABLE_WRITES_CHECK)
+  add_compile_options(--param asan-instrument-writes=0)
+endif()
+
+if(CONFIG_MM_UBSAN_ALL)
+  add_compile_options(${CONFIG_MM_UBSAN_OPTION})
+endif()
+
+if(CONFIG_MM_UBSAN_TRAP_ON_ERROR)
+  add_compile_options(-fsanitize-undefined-trap-on-error)
+endif()
+
+# Default toolchain
+find_program(RV_COMPILER riscv-none-elf-gcc)
+if(RV_COMPILER)
+  set(TOOLCHAIN_PREFIX riscv-none-elf)
+else()
+  if(CONFIG_RISCV_TOOLCHAIN_GNU_RV32)
+    set(TOOLCHAIN_PREFIX riscv32-unknown-elf)
+  else()
+    set(TOOLCHAIN_PREFIX riscv64-unknown-elf)
+  endif()
+endif()
+
+set(CMAKE_LIBRARY_ARCHITECTURE ${TOOLCHAIN_PREFIX})
+set(CMAKE_C_COMPILER_TARGET ${TOOLCHAIN_PREFIX})
+set(CMAKE_CXX_COMPILER_TARGET ${TOOLCHAIN_PREFIX})
+
+set(CMAKE_ASM_COMPILER ${CMAKE_C_COMPILER})
+set(CMAKE_C_COMPILER ${TOOLCHAIN_PREFIX}-gcc)
+set(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}-g++)
+set(CMAKE_STRIP ${TOOLCHAIN_PREFIX}-strip --strip-unneeded)
+set(CMAKE_OBJCOPY ${TOOLCHAIN_PREFIX}-objcopy)
+set(CMAKE_OBJDUMP ${TOOLCHAIN_PREFIX}-objdump)
+set(CMAKE_LINKER ${TOOLCHAIN_PREFIX}-gcc)
+set(CMAKE_LD ${TOOLCHAIN_PREFIX}-ld)
+set(CMAKE_AR ${TOOLCHAIN_PREFIX}-ar)
+set(CMAKE_NM ${TOOLCHAIN_PREFIX}-nm)
+set(CMAKE_RANLIB ${TOOLCHAIN_PREFIX}-gcc-ranlib)
+
+if(CONFIG_LTO_FULL)
+  add_compile_options(-flto)
+  if(${CONFIG_RISCV_TOOLCHAIN} STREQUAL "GNU_RVG")
+    set(CMAKE_LD ${TOOLCHAIN_PREFIX}-gcc)
+    set(CMAKE_AR ${TOOLCHAIN_PREFIX}-gcc-ar)
+    set(CMAKE_NM ${TOOLCHAIN_PREFIX}-gcc-nm)
+    add_compile_options(-fuse-linker-plugin)
+    add_compile_options(-fno-builtin)
+  endif()
+endif()
+
+# override the ARCHIVE command
+
+set(CMAKE_C_ARCHIVE_CREATE "<CMAKE_AR> rcs <TARGET> <LINK_FLAGS> <OBJECTS>")
+set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> rcs <TARGET> <LINK_FLAGS> <OBJECTS>")
+set(CMAKE_ASM_ARCHIVE_CREATE "<CMAKE_AR> rcs <TARGET> <LINK_FLAGS> <OBJECTS>")

--- a/arch/risc-v/src/cmake/platform.cmake
+++ b/arch/risc-v/src/cmake/platform.cmake
@@ -1,0 +1,62 @@
+# ##############################################################################
+# ./arch/risc-v/src/cmake/platform.cmake
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+get_directory_property(NUTTX_EXTRA_FLAGS DIRECTORY ${CMAKE_SOURCE_DIR}
+                                                   COMPILE_OPTIONS)
+
+execute_process(
+  COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS} ${NUTTX_EXTRA_FLAGS}
+          --print-libgcc-file-name
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  OUTPUT_VARIABLE extra_library)
+
+list(APPEND EXTRA_LIB ${extra_library})
+
+if(NOT CONFIG_LIBM)
+  execute_process(
+    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS} ${NUTTX_EXTRA_FLAGS}
+            --print-file-name=libm.a
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE extra_library)
+  list(APPEND EXTRA_LIB ${extra_library})
+endif()
+
+if(CONFIG_LIBSUPCXX)
+  execute_process(
+    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS} ${NUTTX_EXTRA_FLAGS}
+            --print-file-name=libsupc++.a
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE extra_library)
+  list(APPEND EXTRA_LIB ${extra_library})
+endif()
+
+if(CONFIG_ARCH_COVERAGE)
+  execute_process(
+    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS} ${NUTTX_EXTRA_FLAGS}
+            --print-file-name=libgcov.a
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE extra_library)
+  list(APPEND EXTRA_LIB ${extra_library})
+endif()
+
+set_property(GLOBAL APPEND PROPERTY NUTTX_EXTRA_LIBRARIES ${EXTRA_LIB})
+
+separate_arguments(CMAKE_C_FLAG_ARGS NATIVE_COMMAND ${CMAKE_C_FLAGS})
+set(PREPROCES ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} -E -P -x c)

--- a/arch/risc-v/src/common/CMakeLists.txt
+++ b/arch/risc-v/src/common/CMakeLists.txt
@@ -1,0 +1,102 @@
+# ##############################################################################
+# arch/arm/src/common/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS)
+
+list(APPEND SRCS riscv_exception_common.S riscv_mhartid.S riscv_vectors.S)
+list(APPEND SRCS riscv_saveusercontext.S)
+list(APPEND SRCS riscv_allocateheap.c riscv_cpuidlestack.c)
+list(APPEND SRCS riscv_cpuinfo.c riscv_createstack.c riscv_doirq.c
+     riscv_exception.c)
+list(APPEND SRCS riscv_exit.c riscv_getintstack.c riscv_getnewintctx.c
+     riscv_idle.c)
+list(APPEND SRCS riscv_initialize.c riscv_initialstate.c riscv_modifyreg32.c)
+list(APPEND SRCS riscv_mtimer.c riscv_nputs.c riscv_registerdump.c)
+list(APPEND SRCS riscv_releasestack.c riscv_schedulesigaction.c
+     riscv_sigdeliver.c)
+list(APPEND SRCS riscv_stackframe.c riscv_tcbinfo.c riscv_swint.c)
+list(APPEND SRCS riscv_switchcontext.c riscv_usestack.c)
+
+if(NOT CONFIG_ALARM_ARCH)
+  if(NOT CONFIG_TIMER_ARCH)
+    list(APPEND SRCS riscv_mdelay.c riscv_udelay.c)
+  endif()
+endif()
+
+if(CONFIG_SMP)
+  list(APPEND SRCS riscv_cpuindex.c riscv_cpupause.c riscv_cpustart.c)
+endif()
+
+if(CONFIG_RISCV_MISALIGNED_HANDLER)
+  list(APPEND SRCS riscv_misaligned.c)
+endif()
+
+if(NOT CONFIG_BUILD_FLAT)
+  list(APPEND SRCS riscv_task_start.c riscv_pthread_start.c
+       riscv_signal_dispatch.c)
+  list(APPEND SRCS riscv_signal_handler.S)
+endif()
+
+if(CONFIG_SCHED_BACKTRACE)
+  list(APPEND SRCS riscv_backtrace.c)
+endif()
+
+if(CONFIG_STACK_COLORATION)
+  list(APPEND SRCS riscv_checkstack.c)
+endif()
+
+if(CONFIG_ARCH_HAVE_FORK)
+  list(APPEND SRCS fork.S riscv_fork.c)
+endif()
+
+if(CONFIG_SCHED_THREAD_LOCAL)
+  list(APPEND SRCS riscv_tls.c)
+endif()
+
+if(CONFIG_ARCH_FPU)
+  list(APPEND SRCS riscv_fpu.S riscv_fpucmp.c)
+endif()
+
+if(CONFIG_ARCH_RV_ISA_A)
+  list(APPEND SRCS riscv_testset.S)
+endif()
+
+if(CONFIG_RISCV_SEMIHOSTING_HOSTFS)
+  list(APPEND SRCS riscv_semihost.S riscv_hostfs.c)
+endif()
+
+if(CONFIG_ARCH_USE_MPU)
+  list(APPEND SRCS riscv_pmp.c)
+endif()
+
+if(CONFIG_ARCH_USE_MMU)
+  list(APPEND SRCS riscv_mmu.c)
+endif()
+
+if(CONFIG_ARCH_KERNEL_STACK)
+  list(APPEND SRCS riscv_addrenv_kstack.c)
+endif()
+
+if(CONFIG_ARCH_ADDRENV)
+  list(APPEND SRCS riscv_addrenv.c riscv_pgalloc.c riscv_addrenv_perms.c)
+  list(APPEND SRCS riscv_addrenv_utils.c riscv_addrenv_shm.c)
+endif()
+
+target_sources(arch PRIVATE ${SRCS})

--- a/arch/risc-v/src/qemu-rv/CMakeLists.txt
+++ b/arch/risc-v/src/qemu-rv/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# libs/libc/machine/risc-v/CMakeLists.txt
+# arch/arm/src/qemu-rv/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
@@ -17,20 +17,24 @@
 # the License.
 #
 # ##############################################################################
-add_subdirectory(gnu)
 
-if(CONFIG_ARCH_RV64GC)
-  add_subdirectory(rv64)
+set(SRCS qemu_rv_head.S)
+
+list(
+  APPEND
+  SRCS
+  qemu_rv_start.c
+  qemu_rv_irq_dispatch.c
+  qemu_rv_irq.c
+  qemu_rv_timerisr.c
+  qemu_rv_allocateheap.c)
+
+if(CONFIG_BUILD_KERNEL)
+  list(APPEND SRCS qemu_rv_mm_init.c qemu_rv_exception_m.S)
 endif()
 
-if(CONFIG_ARCH_RV32IM)
-  add_subdirectory(rv32)
+if(CONFIG_MM_PGALLOC)
+  list(APPEND SRCS qemu_rv_pgalloc.c)
 endif()
 
-set(SRCS)
-
-if(CONFIG_LIBC_ARCH_ELF)
-  list(APPEND SRCS arch_elf.c)
-endif()
-
-target_sources(c PRIVATE ${SRCS})
+target_sources(arch PRIVATE ${SRCS})

--- a/boards/risc-v/qemu-rv/rv-virt/CMakeLists.txt
+++ b/boards/risc-v/qemu-rv/rv-virt/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# libs/libc/machine/risc-v/CMakeLists.txt
+# boards/risc-v/qemu-rv/rv-virt/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
@@ -17,20 +17,5 @@
 # the License.
 #
 # ##############################################################################
-add_subdirectory(gnu)
 
-if(CONFIG_ARCH_RV64GC)
-  add_subdirectory(rv64)
-endif()
-
-if(CONFIG_ARCH_RV32IM)
-  add_subdirectory(rv32)
-endif()
-
-set(SRCS)
-
-if(CONFIG_LIBC_ARCH_ELF)
-  list(APPEND SRCS arch_elf.c)
-endif()
-
-target_sources(c PRIVATE ${SRCS})
+add_subdirectory(src)

--- a/boards/risc-v/qemu-rv/rv-virt/src/CMakeLists.txt
+++ b/boards/risc-v/qemu-rv/rv-virt/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# libs/libc/machine/risc-v/CMakeLists.txt
+# boards/risc-v/qemu-rv/rv-virt/src/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
@@ -17,20 +17,22 @@
 # the License.
 #
 # ##############################################################################
-add_subdirectory(gnu)
 
-if(CONFIG_ARCH_RV64GC)
-  add_subdirectory(rv64)
+set(SRCS qemu_rv_appinit.c)
+
+target_sources(board PRIVATE ${SRCS})
+
+if(CONFIG_ARCH_CHIP_QEMU_RV)
+
+  if(CONFIG_BUILD_KERNEL)
+    if(CONFIG_ARCH_CHIP_QEMU_RV64)
+      set(LDFILE ld-kernel64.script)
+    else()
+      set(LDFILE ld-kernel32.script)
+    endif()
+  else()
+    set(LDFILE ld.script)
+  endif()
 endif()
 
-if(CONFIG_ARCH_RV32IM)
-  add_subdirectory(rv32)
-endif()
-
-set(SRCS)
-
-if(CONFIG_LIBC_ARCH_ELF)
-  list(APPEND SRCS arch_elf.c)
-endif()
-
-target_sources(c PRIVATE ${SRCS})
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/${LDFILE}")

--- a/libs/libc/machine/risc-v/common/CMakeLists.txt
+++ b/libs/libc/machine/risc-v/common/CMakeLists.txt
@@ -17,14 +17,3 @@
 # the License.
 #
 # ##############################################################################
-set(SRCS)
-
-if(CONFIG_LIBC_ARCH_ELF)
-  list(APPEND SRCS arch_elf.c)
-endif()
-
-if(CONFIG_ARCH_SETJMP_H)
-  list(APPEND SRCS arch_setjmp.S)
-endif()
-
-target_sources(c PRIVATE ${SRCS})

--- a/libs/libc/machine/risc-v/gnu/CMakeLists.txt
+++ b/libs/libc/machine/risc-v/gnu/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# libs/libc/machine/risc-v/CMakeLists.txt
+# libs/libc/machine/risc-v/gnu/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
@@ -17,20 +17,23 @@
 # the License.
 #
 # ##############################################################################
-add_subdirectory(gnu)
-
-if(CONFIG_ARCH_RV64GC)
-  add_subdirectory(rv64)
-endif()
-
-if(CONFIG_ARCH_RV32IM)
-  add_subdirectory(rv32)
-endif()
 
 set(SRCS)
 
-if(CONFIG_LIBC_ARCH_ELF)
-  list(APPEND SRCS arch_elf.c)
+if(CONFIG_RISCV_MEMCPY)
+  list(APPEND SRCS arch_memcpy.S)
+endif()
+
+if(CONFIG_RISCV_MEMSET)
+  list(APPEND SRCS arch_memset.S)
+endif()
+
+if(CONFIG_RISCV_STRCMP)
+  list(APPEND SRCS arch_strcmp.S)
+endif()
+
+if(CONFIG_ARCH_SETJMP_H)
+  list(APPEND SRCS arch_setjmp.S)
 endif()
 
 target_sources(c PRIVATE ${SRCS})

--- a/libs/libc/machine/risc-v/rv32/CMakeLists.txt
+++ b/libs/libc/machine/risc-v/rv32/CMakeLists.txt
@@ -17,6 +17,3 @@
 # the License.
 #
 # ##############################################################################
-if(CONFIG_RISCV_MEMCPY)
-  target_sources(c PRIVATE arch_memcpy.S)
-endif()

--- a/tools/ci/testlist/risc-v.dat
+++ b/tools/ci/testlist/risc-v.dat
@@ -1,2 +1,6 @@
 /risc-v
 -,arty_a7:.+
+
+# Boards build by CMake
+CMake,rv-virt:smp
+CMake,rv-virt:smp64


### PR DESCRIPTION

## Summary
1. init RISC-V cmake build
2. enable rv32 smp rv64 smp ci cmake build

cmake currently does not support non-FlatBuild,
need disable ELF and LOADABLE when compiling other defconfigs

## Impact
risc-v arch

## Testing
```
# From within nuttx/. Configure:

$ cmake -B build -DBOARD_CONFIG=rv-virt/smp64  -GNinja  # for rv32:rv-virt/smp

# this uses ninja generator (install with sudo apt install ninja-build). 
# To build:

$ cmake --build build

# menuconfig:

$ cmake --build build -t menuconfig

```