### PR TITLE
libc/localtime: fix the timezone error caused by minor error

### DIFF
--- a/libs/libc/time/lib_localtime.c
+++ b/libs/libc/time/lib_localtime.c
@@ -812,6 +812,10 @@ static int tzload(FAR const char *name,
            */
 
           memset(&sp->chars[i], 0, CHARS_EXTRA);
+
+          /* Read leap seconds, discarding those out of time_t range. */
+
+          leapcnt = 0;
           for (i = 0; i < sp->leapcnt; ++i)
             {
               int_fast64_t tr = stored == 4 ? detzcode(p) : detzcode64(p);
@@ -1717,7 +1721,7 @@ static int tzparse(FAR const char *name, FAR struct state_s *sp,
                                                janoffset + endtime) &&
                       atlo <= sp->ats[timecnt])
                     {
-                      sp->types[timecnt++] = !reversed;
+                      sp->types[timecnt++] = reversed;
                     }
                 }
 


### PR DESCRIPTION

## Summary
libc/localtime: fix the timezone error caused by minor error

align: https://github.com/eggert/tz/blob/main/localtime.c

correct timeone in test:

server> timedatectl set-timezone Pacific/Auckland
server> timedatectl
      TimeZone: NZDT, 46800
    Local time: Sat, Oct 21 21:47:34 2023 NZDT
Universal time: Sat, Oct 21 08:47:34 2023 UTC
      RTC time: Sat, Oct 21 08:47:35 2023

error timezone:

server> timedatectl set-timezone Pacific/Auckland
server> timedatectl
      TimeZone: NZST, 43200
    Local time: Sat, Oct 21 20:52:27 2023 NZST
Universal time: Sat, Oct 21 08:52:27 2023 UTC
      RTC time: Sat, Oct 21 08:52:27 2023

## Impact
timezone with summer time
## Testing
sim:rpserver and vela
