### PR TITLE
Follow o_cloexe semantics when calling the exec function

### DIFF
--- a/binfmt/binfmt_execmodule.c
+++ b/binfmt/binfmt_execmodule.c
@@ -34,6 +34,7 @@
 
 #include <nuttx/addrenv.h>
 #include <nuttx/arch.h>
+#include <nuttx/fs/fs.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/sched.h>
 #include <sched/sched.h>
@@ -374,6 +375,10 @@ int exec_module(FAR struct binary_s *binp,
       tcb->cmn.group->tg_egid = binp->gid;
     }
 #endif
+
+  /* Close the file descriptors with O_CLOEXEC before active task */
+
+  files_close_onexec(&tcb->cmn);
 
   if (!spawn)
     {

--- a/fs/vfs/fs_dup.c
+++ b/fs/vfs/fs_dup.c
@@ -50,26 +50,19 @@
  *
  ****************************************************************************/
 
-int file_dup(FAR struct file *filep, int minfd, bool cloexec)
+int file_dup(FAR struct file *filep, int minfd, int flags)
 {
   struct file filep2;
   int fd2;
   int ret;
 
-  /* Let file_dup2() do the real work */
+  /* Let file_dup3() do the real work */
 
   memset(&filep2, 0, sizeof(filep2));
-  ret = file_dup2(filep, &filep2);
+  ret = file_dup3(filep, &filep2, flags);
   if (ret < 0)
     {
       return ret;
-    }
-
-  /* Then allocate a new file descriptor for the inode */
-
-  if (cloexec)
-    {
-      filep2.f_oflags |= O_CLOEXEC;
     }
 
   fd2 = file_allocate(filep2.f_inode, filep2.f_oflags,

--- a/fs/vfs/fs_dup2.c
+++ b/fs/vfs/fs_dup2.c
@@ -83,7 +83,10 @@ int file_dup2(FAR struct file *filep1, FAR struct file *filep2)
   /* Then clone the file structure */
 
   memset(&temp, 0, sizeof(temp));
-  temp.f_oflags = filep1->f_oflags;
+
+  /* The two filep don't share flags (the close-on-exec flag). */
+
+  temp.f_oflags = filep1->f_oflags & ~O_CLOEXEC;
   temp.f_pos    = filep1->f_pos;
   temp.f_inode  = inode;
 

--- a/fs/vfs/fs_dup2.c
+++ b/fs/vfs/fs_dup2.c
@@ -39,13 +39,13 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: file_dup2
+ * Name: file_dup3
  *
  * Description:
  *   Assign an inode to a specific files structure.  This is the heart of
- *   dup2.
+ *   dup3.
  *
- *   Equivalent to the non-standard dup2() function except that it
+ *   Equivalent to the non-standard dup3() function except that it
  *   accepts struct file instances instead of file descriptors and it does
  *   not set the errno variable.
  *
@@ -55,7 +55,7 @@
  *
  ****************************************************************************/
 
-int file_dup2(FAR struct file *filep1, FAR struct file *filep2)
+int file_dup3(FAR struct file *filep1, FAR struct file *filep2, int flags)
 {
   FAR struct inode *inode;
   struct file temp;
@@ -64,6 +64,11 @@ int file_dup2(FAR struct file *filep1, FAR struct file *filep2)
   if (filep1 == NULL || filep1->f_inode == NULL || filep2 == NULL)
     {
       return -EBADF;
+    }
+
+  if (flags != 0 && flags != O_CLOEXEC)
+    {
+      return -EINVAL;
     }
 
   if (filep1 == filep2)
@@ -86,7 +91,15 @@ int file_dup2(FAR struct file *filep1, FAR struct file *filep2)
 
   /* The two filep don't share flags (the close-on-exec flag). */
 
-  temp.f_oflags = filep1->f_oflags & ~O_CLOEXEC;
+  if (flags == O_CLOEXEC)
+    {
+      temp.f_oflags = filep1->f_oflags | O_CLOEXEC;
+    }
+  else
+    {
+      temp.f_oflags = filep1->f_oflags & ~O_CLOEXEC;
+    }
+
   temp.f_pos    = filep1->f_pos;
   temp.f_inode  = inode;
 
@@ -154,4 +167,26 @@ int file_dup2(FAR struct file *filep1, FAR struct file *filep2)
 
   memcpy(filep2, &temp, sizeof(temp));
   return OK;
+}
+
+/****************************************************************************
+ * Name: file_dup2
+ *
+ * Description:
+ *   Assign an inode to a specific files structure.  This is the heart of
+ *   dup2.
+ *
+ *   Equivalent to the non-standard dup2() function except that it
+ *   accepts struct file instances instead of file descriptors and it does
+ *   not set the errno variable.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; a negated errno value is return on
+ *   any failure.
+ *
+ ****************************************************************************/
+
+int file_dup2(FAR struct file *filep1, FAR struct file *filep2)
+{
+  return file_dup3(filep1, filep2, 0);
 }

--- a/fs/vfs/fs_fcntl.c
+++ b/fs/vfs/fs_fcntl.c
@@ -71,13 +71,13 @@ static int file_vfcntl(FAR struct file *filep, int cmd, va_list ap)
         {
           /* Does not set the errno variable in the event of a failure */
 
-          ret = file_dup(filep, va_arg(ap, int), false);
+          ret = file_dup(filep, va_arg(ap, int), 0);
         }
         break;
 
       case F_DUPFD_CLOEXEC:
         {
-          ret = file_dup(filep, va_arg(ap, int), true);
+          ret = file_dup(filep, va_arg(ap, int), O_CLOEXEC);
         }
         break;
 

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -866,6 +866,16 @@ void files_releaselist(FAR struct filelist *list);
 int files_duplist(FAR struct filelist *plist, FAR struct filelist *clist);
 
 /****************************************************************************
+ * Name: files_close_onexec
+ *
+ * Description:
+ *   Close specified task's file descriptors with O_CLOEXEC before exec.
+ *
+ ****************************************************************************/
+
+void files_close_onexec(FAR struct tcb_s *tcb);
+
+/****************************************************************************
  * Name: file_allocate_from_tcb
  *
  * Description:

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -911,7 +911,7 @@ int file_allocate(FAR struct inode *inode, int oflags, off_t pos,
  *
  ****************************************************************************/
 
-int file_dup(FAR struct file *filep, int minfd, bool cloexec);
+int file_dup(FAR struct file *filep, int minfd, int flags);
 
 /****************************************************************************
  * Name: file_dup2
@@ -969,6 +969,24 @@ int nx_dup2_from_tcb(FAR struct tcb_s *tcb, int fd1, int fd2);
  ****************************************************************************/
 
 int nx_dup2(int fd1, int fd2);
+
+/****************************************************************************
+ * Name: file_dup3
+ *
+ * Description:
+ *   Assign an inode to a specific files structure.  This is the heart of
+ *   dup3.
+ *
+ *   Equivalent to the non-standard dup3() function except that it
+ *   accepts struct file instances instead of file descriptors.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; a negated errno value is return on
+ *   any failure.
+ *
+ ****************************************************************************/
+
+int file_dup3(FAR struct file *filep1, FAR struct file *filep2, int flags);
 
 /****************************************************************************
  * Name: file_open

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -328,6 +328,7 @@ int     daemon(int nochdir, int noclose);
 int     close(int fd);
 int     dup(int fd);
 int     dup2(int fd1, int fd2);
+int     dup3(int fd1, int fd2, int flags);
 int     fsync(int fd);
 off_t   lseek(int fd, off_t offset, int whence);
 ssize_t read(int fd, FAR void *buf, size_t nbytes);

--- a/libs/libc/spawn/lib_psfa_adddup2.c
+++ b/libs/libc/spawn/lib_psfa_adddup2.c
@@ -66,7 +66,6 @@ int posix_spawn_file_actions_adddup2(
                          int fd1, int fd2)
 {
   FAR struct spawn_dup2_file_action_s *entry;
-  int flags;
 
   DEBUGASSERT(file_actions && fd1 >= 0 && fd2 >= 0);
 
@@ -85,23 +84,6 @@ int posix_spawn_file_actions_adddup2(
   entry->action = SPAWN_FILE_ACTION_DUP2;
   entry->fd1    = fd1;
   entry->fd2    = fd2;
-
-  /* NOTE: Workaround to avoid an error when executing dup2 action */
-
-  flags = fcntl(fd1, F_GETFD);
-  if (flags < 0)
-    {
-      lib_free(entry);
-      return flags;
-    }
-
-  flags &= ~FD_CLOEXEC;
-  flags = fcntl(fd1, F_SETFD, flags);
-  if (flags < 0)
-    {
-      lib_free(entry);
-      return flags;
-    }
 
   /* And add it to the file action list */
 

--- a/net/local/local_recvmsg.c
+++ b/net/local/local_recvmsg.c
@@ -33,6 +33,7 @@
 #include <errno.h>
 #include <assert.h>
 #include <debug.h>
+#include <fcntl.h>
 
 #include <nuttx/kmalloc.h>
 #include <nuttx/fs/fs.h>
@@ -175,7 +176,8 @@ static void local_recvctl(FAR struct local_conn_s *conn,
   count = peer->lc_cfpcount;
   for (i = 0; i < count; i++)
     {
-      fds[i] = file_dup(peer->lc_cfps[i], 0, !!(flags & MSG_CMSG_CLOEXEC));
+      fds[i] = file_dup(peer->lc_cfps[i], 0,
+                        flags & MSG_CMSG_CLOEXEC ? O_CLOEXEC : 0);
       file_close(peer->lc_cfps[i]);
       kmm_free(peer->lc_cfps[i]);
       peer->lc_cfps[i] = NULL;

--- a/sched/task/task_create.c
+++ b/sched/task/task_create.c
@@ -33,6 +33,7 @@
 #include <nuttx/kmalloc.h>
 #include <nuttx/sched.h>
 #include <nuttx/kthread.h>
+#include <nuttx/fs/fs.h>
 
 #include "sched/sched.h"
 #include "group/group.h"
@@ -101,6 +102,10 @@ int nxthread_create(FAR const char *name, uint8_t ttype, int priority,
       kmm_free(tcb);
       return ret;
     }
+
+  /* Close the file descriptors with O_CLOEXEC before active task */
+
+  files_close_onexec(&tcb->cmn);
 
   /* Get the assigned pid before we start the task */
 

--- a/sched/task/task_spawn.c
+++ b/sched/task/task_spawn.c
@@ -31,6 +31,7 @@
 #include <debug.h>
 #include <errno.h>
 
+#include <nuttx/fs/fs.h>
 #include <nuttx/sched.h>
 #include <nuttx/kthread.h>
 #include <nuttx/spawn.h>
@@ -124,6 +125,10 @@ static int nxtask_spawn_create(FAR const char *name, int priority,
           goto errout_with_taskinit;
         }
     }
+
+  /* Close the file descriptors with O_CLOEXEC before active task */
+
+  files_close_onexec(&tcb->cmn);
 
   /* Set the attributes */
 


### PR DESCRIPTION
## Summary
### sched/task: close file descriptor with O_CLOEXEC before active task or exec
modify:
1. Ensure that the child task copies all fds of the parent task,
   including those with O_CLOEXE.
2. Make sure spawn_file_action is executed under fd with O_CLOEXEC,
   otherwise it will fail.
3. When a new task is activated or exec is called, close all fds
   with O_CLOEXEC flags.

### fs/dup3: impletement dup3/nx_dup3_from_tcb function
     refs: https://man7.org/linux/man-pages/man2/dup.2.html
### fs/dup/dup2: don't add O_CLOEXEC for new file descriptor
    refs: https://man7.org/linux/man-pages/man2/dup.2.html
    
    The two file descriptors do not share file descriptor flags (the
    close-on-exec flag).  The close-on-exec flag (FD_CLOEXEC; see
    fcntl(2)) for the duplicate descriptor is off.

### libs/lib_psfa_adddup2.c: remove workaround aboud dup2
    Because popen no longer needs to rely on intermediate
    tasks to start command tasks.

## Impact
posix_spawn/exec_module/task_create/... with exec or start new task
## Testing
Vela
