### PR TITLE
tools/cfgdefine.c: Resolve compile warning array subscript has type 'char'

### DIFF
--- a/tools/cfgdefine.c
+++ b/tools/cfgdefine.c
@@ -88,7 +88,7 @@ static const char *dequote_list[] =
 
 static char *skip_space(char *ptr)
 {
-  while (*ptr && isspace(*ptr)) ptr++;
+  while (*ptr && isspace((int)*ptr)) ptr++;
   return ptr;
 }
 
@@ -96,7 +96,7 @@ static char *skip_space(char *ptr)
 
 static char *find_name_end(char *ptr)
 {
-  while (*ptr && (isalnum(*ptr) || *ptr == '_')) ptr++;
+  while (*ptr && (isalnum((int)*ptr) || *ptr == '_')) ptr++;
   return ptr;
 }
 
@@ -104,7 +104,7 @@ static char *find_name_end(char *ptr)
 
 static char *find_value_end(char *ptr)
 {
-  while (*ptr && !isspace(*ptr))
+  while (*ptr && !isspace((int)*ptr))
     {
       if (*ptr == '"')
         {
@@ -113,7 +113,7 @@ static char *find_value_end(char *ptr)
         }
       else
         {
-          do ptr++; while (*ptr && !isspace(*ptr) && *ptr != '"');
+          do ptr++; while (*ptr && !isspace((int)*ptr) && *ptr != '"');
         }
     }
 


### PR DESCRIPTION
## Summary
fix 
In file included from cfgdefine.c:26:
cfgdefine.c: In function ‘skip_space’:
cfgdefine.c:91:26: warning: array subscript has type ‘char’ [-Wchar-subscripts]
   91 |   while (*ptr && isspace(*ptr)) ptr++;
      |                          ^~~~
cfgdefine.c: In function ‘find_name_end’:
cfgdefine.c:99:27: warning: array subscript has type ‘char’ [-Wchar-subscripts]
   99 |   while (*ptr && (isalnum(*ptr) || *ptr == '_')) ptr++;
      |                           ^~~~
cfgdefine.c: In function ‘find_value_end’:
cfgdefine.c:107:27: warning: array subscript has type ‘char’ [-Wchar-subscripts]
  107 |   while (*ptr && !isspace(*ptr))
      |                           ^~~~
cfgdefine.c:116:45: warning: array subscript has type ‘char’ [-Wchar-subscripts]
  116 |           do ptr++; while (*ptr && !isspace(*ptr) && *ptr != '"');
      |
## Impact
none
## Testing
local
