### PR TITLE
libs/modlib: optimize code and add arch api for allocating data section

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -405,6 +405,12 @@ config ARCH_HAVE_TEXT_HEAP
 	---help---
 		Special memory region for dynamic code loading
 
+config ARCH_HAVE_DATA_HEAP
+	bool
+	default n
+	---help---
+		Special memory region for dynamic data loading
+
 config ARCH_HAVE_COPY_SECTION
 	bool
 	default n
@@ -625,6 +631,14 @@ config ARCH_USE_TEXT_HEAP
 		for dynamic code loading. For example, ESP32 has separate memory
 		regions for instruction and data and the memory region used for
 		usual malloc doesn't work for instruction.
+
+config ARCH_USE_DATA_HEAP
+	bool "Enable separate data allocation for dynamic data loading"
+	default n
+	depends on ARCH_HAVE_DATA_HEAP
+	---help---
+		This option enables architecture-specific memory allocator
+		for dynamic data loading.
 
 menuconfig ARCH_ADDRENV
 	bool "Address environments"

--- a/arch/sim/src/sim/posix/sim_hostmemory.c
+++ b/arch/sim/src/sim/posix/sim_hostmemory.c
@@ -60,18 +60,18 @@ static atomic_int g_uordblks;
  *
  ****************************************************************************/
 
-void *host_allocheap(size_t sz)
+void *host_allocheap(size_t size, bool exec)
 {
   void *p;
 
 #if defined(CONFIG_HOST_MACOS) && defined(CONFIG_HOST_ARM64)
   /* see: https://developer.apple.com/forums/thread/672804 */
 
-  p = host_uninterruptible(mmap, NULL, sz, PROT_READ | PROT_WRITE,
+  p = host_uninterruptible(mmap, NULL, size, PROT_READ | PROT_WRITE,
                            MAP_ANON | MAP_SHARED, -1, 0);
 #else
-  p = host_uninterruptible(mmap, NULL, sz,
-                           PROT_READ | PROT_WRITE | PROT_EXEC,
+  p = host_uninterruptible(mmap, NULL, size, PROT_READ | PROT_WRITE |
+                           (exec ? PROT_EXEC : 0),
                            MAP_ANON | MAP_PRIVATE, -1, 0);
 #endif
 

--- a/arch/sim/src/sim/sim_heap.c
+++ b/arch/sim/src/sim/sim_heap.c
@@ -475,7 +475,7 @@ void up_allocate_heap(void **heap_start, size_t *heap_size)
    * ARCH_HAVE_TEXT_HEAP mechanism can be an alternative.
    */
 
-  uint8_t *sim_heap = host_allocheap(SIM_HEAP_SIZE);
+  uint8_t *sim_heap = host_allocheap(SIM_HEAP_SIZE, false);
 
   *heap_start = sim_heap;
   *heap_size  = SIM_HEAP_SIZE;

--- a/arch/sim/src/sim/sim_internal.h
+++ b/arch/sim/src/sim/sim_internal.h
@@ -216,7 +216,7 @@ int   host_waitpid(pid_t pid);
 
 /* sim_hostmemory.c *********************************************************/
 
-void *host_allocheap(size_t sz);
+void *host_allocheap(size_t sz, bool exec);
 void  host_freeheap(void *mem);
 void *host_allocshmem(const char *name, size_t size, int master);
 void  host_freeshmem(void *mem);

--- a/arch/sim/src/sim/sim_textheap.c
+++ b/arch/sim/src/sim/sim_textheap.c
@@ -49,7 +49,8 @@ void *up_textheap_memalign(size_t align, size_t size)
 {
   if (g_textheap == NULL)
     {
-      g_textheap = mm_initialize("textheap", host_allocheap(SIM_HEAP_SIZE),
+      g_textheap = mm_initialize("textheap",
+                                 host_allocheap(SIM_HEAP_SIZE, true),
                                  SIM_HEAP_SIZE);
     }
 

--- a/arch/sim/src/sim/sim_textheap.c
+++ b/arch/sim/src/sim/sim_textheap.c
@@ -23,8 +23,7 @@
  ****************************************************************************/
 
 #include <nuttx/arch.h>
-#include <nuttx/queue.h>
-#include <nuttx/kmalloc.h>
+#include <nuttx/mm/mm.h>
 
 #include "sim_internal.h"
 
@@ -32,16 +31,7 @@
  * Private Data
  ****************************************************************************/
 
-/* Record memory allocated for text sections by sq_queue_t */
-
-struct textheap_s
-{
-  sq_entry_t entry;
-  void *p;
-  size_t size;
-};
-
-static sq_queue_t g_textheap_list;
+static struct mm_heap_s *g_textheap;
 
 /****************************************************************************
  * Public Functions
@@ -57,40 +47,13 @@ static sq_queue_t g_textheap_list;
 
 void *up_textheap_memalign(size_t align, size_t size)
 {
-  struct textheap_s *node;
-  void *p;
-  irqstate_t flags;
-
-  /* host_allocheap (mmap) returns memory aligned to the page size, which
-   * is always a multiple of the alignment (4/8) for text section. So, we
-   * don't need to do anything here.
-   */
-
-  p = host_allocheap(size);
-
-  flags = up_irq_save();
-
-  if (p)
+  if (g_textheap == NULL)
     {
-      node = kmm_malloc(sizeof(*node));
-
-      if (node)
-        {
-          node->p = p;
-          node->size = size;
-
-          sq_addlast(&node->entry, &g_textheap_list);
-        }
-      else
-        {
-          host_freeheap(p);
-          p = NULL;
-        }
+      g_textheap = mm_initialize("textheap", host_allocheap(SIM_HEAP_SIZE),
+                                 SIM_HEAP_SIZE);
     }
 
-  up_irq_restore(flags);
-
-  return p;
+  return mm_memalign(g_textheap, align, size);
 }
 
 /****************************************************************************
@@ -103,26 +66,10 @@ void *up_textheap_memalign(size_t align, size_t size)
 
 void up_textheap_free(void *p)
 {
-  sq_entry_t *node;
-  struct textheap_s *entry;
-  irqstate_t flags = up_irq_save();
-
-  for (node = sq_peek(&g_textheap_list);
-       node != NULL;
-       node = sq_next(node))
+  if (g_textheap != NULL)
     {
-      entry = (struct textheap_s *)node;
-
-      if (entry->p == p)
-        {
-          sq_rem(node, &g_textheap_list);
-          host_freeheap(p);
-          kmm_free(entry);
-          break;
-        }
+      mm_free(g_textheap, p);
     }
-
-  up_irq_restore(flags);
 }
 
 /****************************************************************************
@@ -135,24 +82,5 @@ void up_textheap_free(void *p)
 
 bool up_textheap_heapmember(void *p)
 {
-  bool ret = false;
-  sq_entry_t *node;
-  struct textheap_s *entry;
-  irqstate_t flags = up_irq_save();
-
-  for (node = sq_peek(&g_textheap_list);
-       node != NULL;
-       node = sq_next(node))
-    {
-      entry = (struct textheap_s *)node;
-
-      if (entry->p == p)
-        {
-          ret = true;
-          break;
-        }
-    }
-
-  up_irq_restore(flags);
-  return ret;
+  return g_textheap != NULL && mm_heapmember(g_textheap, p);
 }

--- a/arch/sim/src/sim/win/sim_hostmemory.c
+++ b/arch/sim/src/sim/win/sim_hostmemory.c
@@ -36,7 +36,7 @@
  *
  ****************************************************************************/
 
-void *host_allocheap(size_t sz)
+void *host_allocheap(size_t sz, bool exec)
 {
   return _aligned_malloc(sz, 8);
 }

--- a/binfmt/libelf/libelf_addrenv.c
+++ b/binfmt/libelf/libelf_addrenv.c
@@ -159,8 +159,14 @@ errout_with_addrenv:
 
   if (loadinfo->datasize > 0)
     {
+#  if defined(CONFIG_ARCH_USE_DATA_HEAP)
+      loadinfo->dataalloc = (uintptr_t)
+                            up_dataheap_memalign(loadinfo->dataalign,
+                                                 datasize);
+#  else
       loadinfo->dataalloc = (uintptr_t)
                             kumm_memalign(loadinfo->dataalign, datasize);
+#  endif
       if (!loadinfo->dataalloc)
         {
           return -ENOMEM;
@@ -293,7 +299,11 @@ void elf_addrenv_free(FAR struct elf_loadinfo_s *loadinfo)
 
   if (loadinfo->dataalloc != 0)
     {
+#  if defined(CONFIG_ARCH_USE_DATA_HEAP)
+      up_dataheap_free((FAR void *)loadinfo->dataalloc);
+#  else
       kumm_free((FAR void *)loadinfo->dataalloc);
+#  endif
     }
 #endif
 

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -761,15 +761,27 @@ void up_textheap_free(FAR void *p);
 #endif
 
 /****************************************************************************
- * Name: up_textheap_heapmember
+ * Name: up_dataheap_memalign
  *
  * Description:
- *   Test if memory is from text heap.
+ *   Allocate memory for data sections with the specified alignment.
  *
  ****************************************************************************/
 
-#if defined(CONFIG_ARCH_USE_TEXT_HEAP)
-bool up_textheap_heapmember(FAR void *p);
+#if defined(CONFIG_ARCH_USE_DATA_HEAP)
+FAR void *up_dataheap_memalign(size_t align, size_t size);
+#endif
+
+/****************************************************************************
+ * Name: up_dataheap_free
+ *
+ * Description:
+ *   Free memory allocated for data sections.
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_ARCH_USE_DATA_HEAP)
+void up_dataheap_free(FAR void *p);
 #endif
 
 /****************************************************************************

--- a/libs/libc/modlib/modlib_depend.c
+++ b/libs/libc/modlib/modlib_depend.c
@@ -31,6 +31,8 @@
 
 #include <nuttx/lib/modlib.h>
 
+#if CONFIG_MODLIB_MAXDEPEND > 0
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -55,7 +57,6 @@
 int modlib_depend(FAR struct module_s *importer,
                   FAR struct module_s *exporter)
 {
-#if CONFIG_MODLIB_MAXDEPEND > 0
   int freendx = -1;
   int i;
 
@@ -127,10 +128,6 @@ int modlib_depend(FAR struct module_s *importer,
 
   DEBUGPANIC();
   return -ENFILE;
-
-#else
-  return OK;
-#endif
 }
 
 /****************************************************************************
@@ -152,7 +149,6 @@ int modlib_depend(FAR struct module_s *importer,
 
 int modlib_undepend(FAR struct module_s *importer)
 {
-#if CONFIG_MODLIB_MAXDEPEND > 0
   FAR struct module_s *exporter;
   int i;
 
@@ -178,7 +174,8 @@ int modlib_undepend(FAR struct module_s *importer)
           importer->dependencies[i] = NULL;
         }
     }
-#endif
 
   return OK;
 }
+
+#endif

--- a/libs/libc/modlib/modlib_init.c
+++ b/libs/libc/modlib/modlib_init.c
@@ -38,24 +38,6 @@
 #include "modlib/modlib.h"
 
 /****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-/* CONFIG_DEBUG_FEATURES, CONFIG_DEBUG_INFO, and CONFIG_MODLIB_DUMPBUFFER
- * have to be defined or CONFIG_MODLIB_DUMPBUFFER does nothing.
- */
-
-#if !defined(CONFIG_DEBUG_INFO) || !defined(CONFIG_MODLIB_DUMPBUFFER)
-#  undef CONFIG_MODLIB_DUMPBUFFER
-#endif
-
-#ifdef CONFIG_MODLIB_DUMPBUFFER
-#  define modlib_dumpbuffer(m,b,n) binfodumpbuffer(m,b,n)
-#else
-#  define modlib_dumpbuffer(m,b,n)
-#endif
-
-/****************************************************************************
  * Private Functions
  ****************************************************************************/
 

--- a/libs/libc/modlib/modlib_load.c
+++ b/libs/libc/modlib/modlib_load.c
@@ -338,8 +338,14 @@ int modlib_load(FAR struct mod_loadinfo_s *loadinfo)
 
       if (loadinfo->datasize > 0)
         {
+#if defined(CONFIG_ARCH_USE_DATA_HEAP)
+          loadinfo->datastart = (uintptr_t)
+                                 up_dataheap_memalign(loadinfo->dataalign,
+                                                      loadinfo->datasize);
+#else
           loadinfo->datastart = (uintptr_t)lib_memalign(loadinfo->dataalign,
                                                         loadinfo->datasize);
+#endif
           if (!loadinfo->datastart)
             {
               berr("ERROR: Failed to allocate memory for the module data\n");

--- a/libs/libc/modlib/modlib_load.c
+++ b/libs/libc/modlib/modlib_load.c
@@ -84,7 +84,7 @@ static void modlib_elfsize(FAR struct mod_loadinfo_s *loadinfo)
               if (phdr->p_flags & PF_X)
                 {
                   textsize += phdr->p_memsz;
-                  textaddr = (FAR void *)phdr->p_vaddr;
+                  textaddr = (FAR void *)(uintptr_t)phdr->p_vaddr;
                 }
               else
                 {

--- a/libs/libc/modlib/modlib_symbols.c
+++ b/libs/libc/modlib/modlib_symbols.c
@@ -198,7 +198,6 @@ static int modlib_symcallback(FAR struct module_s *modp, FAR void *arg)
 {
   FAR struct mod_exportinfo_s *exportinfo = (FAR struct mod_exportinfo_s *)
                                             arg;
-  int ret;
 
   /* Check if this module exports a symbol of that name */
 
@@ -212,12 +211,14 @@ static int modlib_symcallback(FAR struct module_s *modp, FAR void *arg)
        * stop the traversal.
        */
 
-      ret = modlib_depend(exportinfo->modp, modp);
+#if CONFIG_MODLIB_MAXDEPEND > 0
+      int ret = modlib_depend(exportinfo->modp, modp);
       if (ret < 0)
         {
           berr("ERROR: modlib_depend failed: %d\n", ret);
           return ret;
         }
+#endif
 
       return SYM_FOUND;
     }

--- a/libs/libc/modlib/modlib_symbols.c
+++ b/libs/libc/modlib/modlib_symbols.c
@@ -521,7 +521,8 @@ int modlib_insertsymtab(FAR struct module_s *modp,
 
                   symbol[j].sym_name =
                       strdup((FAR char *)loadinfo->iobuffer);
-                  symbol[j].sym_value = (FAR const void *)sym[i].st_value;
+                  symbol[j].sym_value =
+                      (FAR const void *)(uintptr_t)sym[i].st_value;
                   j++;
                 }
             }

--- a/libs/libc/modlib/modlib_unload.c
+++ b/libs/libc/modlib/modlib_unload.c
@@ -65,15 +65,19 @@ int modlib_unload(FAR struct mod_loadinfo_s *loadinfo)
       if (loadinfo->textalloc != 0)
         {
 #if defined(CONFIG_ARCH_USE_TEXT_HEAP)
-           up_textheap_free((FAR void *)loadinfo->textalloc);
+          up_textheap_free((FAR void *)loadinfo->textalloc);
 #else
-           lib_free((FAR void *)loadinfo->textalloc);
+          lib_free((FAR void *)loadinfo->textalloc);
 #endif
         }
 
       if (loadinfo->datastart != 0)
         {
+#if defined(CONFIG_ARCH_USE_DATA_HEAP)
+          up_dataheap_free((FAR void *)loadinfo->datastart);
+#else
           lib_free((FAR void *)loadinfo->datastart);
+#endif
         }
     }
   else

--- a/sched/module/mod_insmod.c
+++ b/sched/module/mod_insmod.c
@@ -282,7 +282,9 @@ FAR void *insmod(FAR const char *filename, FAR const char *modname)
 
 errout_with_load:
   modlib_unload(&loadinfo);
+#if CONFIG_MODLIB_MAXDEPEND > 0
   modlib_undepend(modp);
+#endif
 errout_with_registry_entry:
   kmm_free(modp);
 errout_with_loadinfo:

--- a/sched/module/mod_rmmod.c
+++ b/sched/module/mod_rmmod.c
@@ -130,7 +130,11 @@ int rmmod(FAR void *handle)
 #else
           kmm_free((FAR void *)modp->textalloc);
 #endif
+#if defined(CONFIG_ARCH_USE_DATA_HEAP)
+          up_dataheap_free((FAR void *)modp->dataalloc);
+#else
           kmm_free((FAR void *)modp->dataalloc);
+#endif
         }
       else
         {


### PR DESCRIPTION
## Summary
1. simplify textheap logic for arch/sim
2. libs/modlib: remove duplicate dumpbuffer
3. add arch memory allocator for data section.
4. fix compile warning.
## Impact
add up_dataheap_memalign, up_dataheap_free api
## Testing
vela test
