### PR TITLE
simwifi: Support that simwifi connects to the hidden ssid.

### DIFF
--- a/arch/sim/src/sim/sim_wifidriver.c
+++ b/arch/sim/src/sim/sim_wifidriver.c
@@ -927,6 +927,7 @@ static int wifidriver_set_essid(struct sim_netdev_s *wifidev,
   if (wifidev->mode == IW_MODE_INFRA)
     {
       WPA_SET_NETWORK(wifidev, "ssid \\\"%s\\\"", ssid_buf);
+      WPA_SET_NETWORK(wifidev, "scan_ssid 1");
 
       if (wifidev->psk_flag == 0)
         {
@@ -1011,6 +1012,7 @@ static int wifidriver_set_bssid(struct sim_netdev_s *wifidev,
   if (wifidev->mode == IW_MODE_INFRA)
     {
       WPA_SET_NETWORK(wifidev, "bssid %s", bssid_buf);
+      WPA_SET_NETWORK(wifidev, "scan_ssid 0");
 
       if (wifidev->psk_flag == 0)
         {


### PR DESCRIPTION
## Summary
In the SIM emulator, allow the SIM-WiFi to connect the hidden SSID.
## Impact
N/A
## Testing
We can connect the hidden SSID, using the following steps:
1.`ifup wlan0`
2.`wapi mode wlan0 2`
3.`wapi psk wlan0 <flags>`
4.`wapi essid wlan0 <hidden_ssid>`

