### PR TITLE
nuttx/include/spawn: Suppress compiler warning for posix_spawnattr_destroy.

### DIFF
--- a/include/spawn.h
+++ b/include/spawn.h
@@ -174,8 +174,7 @@ int posix_spawn_file_actions_addopen(
 
 int posix_spawnattr_init(FAR posix_spawnattr_t *attr);
 
-/* int posix_spawnattr_destroy(FAR posix_spawnattr_t *); */
-#define posix_spawnattr_destroy(attr) (0)
+int posix_spawnattr_destroy(FAR posix_spawnattr_t *attr);
 
 /* Get spawn attributes interfaces */
 

--- a/libs/libc/spawn/CMakeLists.txt
+++ b/libs/libc/spawn/CMakeLists.txt
@@ -29,6 +29,7 @@ set(SRCS
     lib_psa_getschedparam.c
     lib_psa_getschedpolicy.c
     lib_psa_init.c
+    lib_psa_destroy.c
     lib_psa_setflags.c
     lib_psa_setschedparam.c
     lib_psa_setschedpolicy.c

--- a/libs/libc/spawn/Make.defs
+++ b/libs/libc/spawn/Make.defs
@@ -26,7 +26,7 @@ CSRCS += lib_psfa_addopen.c lib_psfa_destroy.c lib_psfa_init.c
 CSRCS += lib_psa_getflags.c lib_psa_getschedparam.c lib_psa_getschedpolicy.c
 CSRCS += lib_psa_init.c lib_psa_setflags.c lib_psa_setschedparam.c
 CSRCS += lib_psa_setschedpolicy.c lib_psa_getsigmask.c lib_psa_setsigmask.c
-CSRCS += lib_psa_getstacksize.c lib_psa_setstacksize.c
+CSRCS += lib_psa_getstacksize.c lib_psa_setstacksize.c lib_psa_destroy.c
 
 ifneq ($(CONFIG_BUILD_KERNEL),y)
 CSRCS += lib_psa_getstackaddr.c lib_psa_setstackaddr.c

--- a/libs/libc/spawn/lib_psa_destroy.c
+++ b/libs/libc/spawn/lib_psa_destroy.c
@@ -1,0 +1,60 @@
+/****************************************************************************
+ * libs/libc/spawn/lib_psa_destroy.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sched.h>
+#include <spawn.h>
+#include <assert.h>
+#include <errno.h>
+
+#include <nuttx/sched.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: posix_spawnattr_destroy
+ *
+ * Description:
+ *   The posix_spawnattr_destroy() function shall destroy a spawn attributes
+ *   object. A destroyed attr attributes object can be reinitialized using
+ *   posix_spawnattr_init();
+ *
+ * Input Parameters:
+ *   attr - The address of the spawn attributes to be destroyed.
+ *
+ * Returned Value:
+ *   Return 0 on success. On failure returns an error
+ *   number from <errno.h>.
+ *
+ ****************************************************************************/
+
+int posix_spawnattr_destroy(FAR posix_spawnattr_t *attr)
+{
+  UNUSED(attr);
+
+  return OK;
+}


### PR DESCRIPTION
## Summary

When building with a c++ compiler and GCC 12.2.0, the following warning is emitted:

nuttx/include/spawn.h:178:40: warning: statement has no effect [-Wunused-value]
  178 | #define posix_spawnattr_destroy(attr) (0)

Casting the attribute value to void has the same effect, whist silencing this warning.

## Impact

Silence warning

## Testing

- Build with `sim:ostest` to verify normal build.
- Build with custom application to verify build in our environemnt.
