### PR TITLE
libs/libc/stdlib/lib_exit.c: fix multiple definition of __dso_handle and sethost.sh: add MSYS environmen for msys2

### DIFF
--- a/libs/libc/stdlib/lib_exit.c
+++ b/libs/libc/stdlib/lib_exit.c
@@ -45,7 +45,10 @@
  ****************************************************************************/
 
 extern FAR void *__dso_handle weak_data;
+
+#ifndef CONFIG_HOST_WINDOWS
 FAR void *__dso_handle = &__dso_handle;
+#endif
 
 /****************************************************************************
  * Public Functions

--- a/tools/sethost.sh
+++ b/tools/sethost.sh
@@ -79,6 +79,7 @@ done
 #   Cygwin: CYGWIN_NT-10.0-WOW
 #   Linux: Linux
 #   MSYS: MINGW32_NT-6.2
+#   MSYS2: MSYS_NT-6.3-9600
 #   BSD: FreeBSD, OpenBSD, NetBSD, *BSD
 
 if [ -z "$host" ]; then
@@ -95,6 +96,10 @@ if [ -z "$host" ]; then
       wenv=cygwin
       ;;
     MINGW32*)
+      host=windows
+      wenv=msys
+      ;;
+    MSYS*)
       host=windows
       wenv=msys
       ;;


### PR DESCRIPTION
## Summary
fix

```shell
CPP: nuttx-names.in-> nuttx-names.dat
LD: nuttx
/usr/lib/gcc/x86_64-pc-msys/13.2.0/../../../../x86_64-pc-msys/bin/ld: nuttx.rel:/d/a/nuttx_windows/nuttx_windows/nuttxspace/nuttx/libs/libc/stdlib/lib_exit.c:48: multiple definition of `__dso_handle'; /usr/lib/gcc/x86_64-pc-msys/13.2.0/crtbegin.o:cygming-crtbeg:(.data+0x0): first defined here
```  
tools/sethost.sh: add for MSYS2 MSYS environment
## Impact
none
## Testing
We tested on platform MSYS2 and Alpine linux
