### PR TITLE
simwifi: host wlan0 obtains ip and set dns for wlan0 in the defwan wlan0

### DIFF
--- a/tools/simwifi/sim_wifi.sh
+++ b/tools/simwifi/sim_wifi.sh
@@ -33,7 +33,7 @@ HOSTAPD_CONF_FILE="$RUN_DIR/hostapd.conf"
 DNSMASQ_PID="$RUN_DIR/dnsmasq.pid"
 DNSMASQ_CONF="$RUN_DIR/dnsmasq.conf"
 UDHCPC_PID="$RUN_DIR/udhcpc.pid"
-UDHCPC_SCRIPT="$RUN_DIR/udhcpc.script"
+UDHCPC_SCRIPT="/var/udhcpc.script"
 
 LOG_FILE="$RUN_DIR/simwifi.log"
 STATE_FILE="$RUN_DIR/simwifi.state"
@@ -151,6 +151,7 @@ init_env()
 
   cp -fr $CUR_DIR/dnsmasq.conf $DNSMASQ_CONF
   cp -fr $CUR_DIR/udhcpc.script $UDHCPC_SCRIPT
+  chmod +x $UDHCPC_SCRIPT
 }
 
 # Rename the interface name
@@ -337,6 +338,8 @@ del_gw_wlan()
     ip route del $router
     sw_dbg 1 "del the default router on $wlan_if"
   }
+
+  ifconfig $wlan_if 0.0.0.0
 }
 
 stop_sta()
@@ -512,7 +515,7 @@ init()
   echo "mode:$2" >> $DEFCONF_FILE
   [ "$2" = "hwsim" ] &&  modprobe  mac80211_hwsim
 
-  set_state SW_INIT
+  set_state SW_INIT  "" $NUTTX_BR_IF $1
 }
 
 clean()
@@ -523,6 +526,7 @@ clean()
   [ "$cur_mode" = "hwsim" ] &&  modprobe -r mac80211_hwsim
 
   rm -fr $RUN_DIR
+  rm -f $UDHCPC_SCRIPT
 }
 
 usage()

--- a/tools/simwifi/udhcpc.script
+++ b/tools/simwifi/udhcpc.script
@@ -10,6 +10,8 @@ log() {
   logger -t "udhcpc[$PPID]" -p daemon.$1 "$interface: $2"
 }
 
+SIMWIFILOG_FILE=/var/run/simwifi/simwifi.log
+DEFCONF_FILE=/var/run/simwifi/simwifi.conf
 case $1 in
   bound|renew)
 
@@ -18,6 +20,34 @@ case $1 in
   # to also set subnet, broadcast, mtu, ...
   busybox ifconfig $interface ${mtu:+mtu $mtu} \
       $ip netmask $subnet ${broadcast:+broadcast $broadcast}
+
+  # defwan equals to wlanx, should add router and DEF_NS
+
+  defwan=$(cat $DEFCONF_FILE | grep defwan | awk -F':' '{print $2}')
+  [ ".$defwan" = ".wlan0" ] && {
+    # get current ("old") routes (after setting new IP)
+    crouter=$(busybox ip -4 route show dev $interface |
+              busybox awk '$1 == "default" { print $3; }')
+    router="${router%% *}" # linux kernel supports only one (default) route
+    if [ ".$router" != ".$crouter" ]; then
+        # reset just default routes
+        busybox ip -4 route flush exact 0.0.0.0/0 dev $interface
+    fi
+
+    if [ -n "$router" ]; then
+        # special case for /32 subnets: use onlink keyword
+        [ ".$subnet" = .255.255.255.255 ] \
+            && onlink=onlink || onlink=
+        busybox ip -4 route add default via $router dev $interface $onlink
+        log info "udhcpc add router $router on $interfac"
+    fi
+
+    DEF_NS="nameserver 8.8.8.8"
+    RESOLV_CONF_FILE=${RESOLV_CONF:-/etc/resolv.conf}
+    [ -f $RESOLV_CONF_FILE -a -z "$(cat $RESOLV_CONF_FILE | grep 8.8.8.8)" ] && {
+        echo "$DEF_NS" >> "$RESOLV_CONF_FILE"
+    }
+  }
 
   log info "$1: IP=$ip/$subnet router=$router domain=\"$domain\" dns=\"$dns\" lease=$lease"
   ;;


### PR DESCRIPTION
## Summary
Fix the problem that host wlan0 can not obtain IP, and when the defwan is wlan0, the sim can not access the Internet.

## Impact
When the host wlan0 successfully connects to a WiFi, and obtains an IP address through udhcpc, the following operations will be performed.
- Set the IP for host wlan0.
- Add the dns server (8.8.8.8) to the file `/etc/resolv.conf`.
- Add an default route through the wlan0 interface.
All these configurations will be clean by the command `sim_wifi.sh clean`.

## Testing
We can verify the changes using the following steps:
1. Set the defwan as wlan0. ` sudo ./toos/simwifi/sim_wifi.sh init wlan0 rnc`
2. In sim, configure the wlan0 and connects a WiFi.  Then access the Internet.
3. Check the configurations of HOST,  including the ip of wlan0, dns server in the `/etc/resolv.conf`, and the default route through the wlan0.
4. Clean the simwifi configurations `sudo ./toos/simwifi/sim_wifi.sh clean`, then check to see if they are all restored.
