### PR TITLE
mm: both use spin_lock_irqxx() when operated delaylist

### DIFF
--- a/mm/mm_heap/mm_free.c
+++ b/mm/mm_heap/mm_free.c
@@ -45,12 +45,12 @@ static void add_delaylist(FAR struct mm_heap_s *heap, FAR void *mem)
 
   /* Delay the deallocation until a more appropriate time. */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
 
   tmp->flink = heap->mm_delaylist[up_cpu_index()];
   heap->mm_delaylist[up_cpu_index()] = tmp;
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 #endif
 }
 


### PR DESCRIPTION


## Summary

mm: both use spin_lock_irqxx() when operated delaylist
align with free_delaylist()

## Impact

mm

## Testing

SIM
