### PR TITLE
NXP Serial overcome race where DMA has not fetched TCD again

### DIFF
--- a/arch/arm/src/imxrt/imxrt_serial.c
+++ b/arch/arm/src/imxrt/imxrt_serial.c
@@ -1375,7 +1375,7 @@ static int imxrt_dma_nextrx(struct imxrt_uart_s *priv)
   int dmaresidual = imxrt_dmach_getcount(priv->rxdma);
   DEBUGASSERT(dmaresidual <= RXDMA_BUFFER_SIZE);
 
-  return RXDMA_BUFFER_SIZE - dmaresidual;
+  return (RXDMA_BUFFER_SIZE - dmaresidual) % RXDMA_BUFFER_SIZE;
 }
 #endif
 

--- a/arch/arm/src/s32k1xx/s32k1xx_serial.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_serial.c
@@ -658,7 +658,7 @@ static int s32k1xx_dma_nextrx(struct s32k1xx_uart_s *priv)
 {
   int dmaresidual = s32k1xx_dmach_getcount(priv->rxdma);
 
-  return RXDMA_BUFFER_SIZE - dmaresidual;
+  return (RXDMA_BUFFER_SIZE - dmaresidual) % RXDMA_BUFFER_SIZE;
 }
 #endif
 

--- a/arch/arm/src/s32k3xx/s32k3xx_serial.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_serial.c
@@ -2815,7 +2815,7 @@ static int s32k3xx_dma_nextrx(struct s32k3xx_uart_s *priv)
 {
   int dmaresidual = s32k3xx_dmach_getcount(priv->rxdma);
 
-  return RXDMA_BUFFER_SIZE - dmaresidual;
+  return (RXDMA_BUFFER_SIZE - dmaresidual) % RXDMA_BUFFER_SIZE;
 }
 #endif
 


### PR DESCRIPTION
## Summary

   As reported by @danielappiagyei-bc [here](https://github.com/apache/nuttx/issues/10912) with more discussion [here](https://github.com/apache/nuttx/pull/11020)  

   With TCD set to loop, there is a window where the
   DMA has raised Done, but not reloaded the TCD, resetting
   count and clearing Done.

   In this window  imxrt_dmach_getcount could then return 0.
   Resulting in imxrt_dma_nextrx returning RXDMA_BUFFER_SIZE.
   Which is not a valid index in the FIFO.

   Since the count will be set to RXDMA_BUFFER_SIZE. When the DMA
   engine completes the TCD reload. The imxrt_dma_nextrx would
   return 0. Therefore:

    (RXDMA_BUFFER_SIZE - dmaresidual) % RXDMA_BUFFER_SIZE

   accomplishes this.

## Impact

Without this change serial data could be corrupted.

## Testing

imxrt1170
