### PR TITLE
bluetooth rpmsg depends on RPTUN

### DIFF
--- a/drivers/wireless/bluetooth/Kconfig
+++ b/drivers/wireless/bluetooth/Kconfig
@@ -77,12 +77,12 @@ config BLUETOOTH_NULL
 
 config BLUETOOTH_RPMSG_SERVER
 	bool "RPMSG Bluetooth HCI server support"
-	depends on EXPERIMENTAL
+	depends on EXPERIMENTAL && RPTUN
 	default n
 
 config BLUETOOTH_RPMSG
 	bool "RPMSG Bluetooth HCI client support"
-	depends on EXPERIMENTAL
+	depends on EXPERIMENTAL && RPTUN
 	default n
 
 endif # DRIVERS_BLUETOOTH


### PR DESCRIPTION
## Summary
bluetooth rpmsg depends on RPTUN
## Impact

## Testing
CI