### PR TITLE
net/netconfig: Enable SOCK_CLOEXEC for ioctl sockets

### DIFF
--- a/include/nuttx/net/netconfig.h
+++ b/include/nuttx/net/netconfig.h
@@ -109,7 +109,7 @@
  * socket for performing driver ioctls.
  */
 
-#define NET_SOCK_TYPE SOCK_CTRL
+#define NET_SOCK_TYPE (SOCK_CTRL | SOCK_CLOEXEC)
 
 #if NET_SOCK_FAMILY == AF_INET
 #  if !defined(CONFIG_NET_UDP) && !defined(CONFIG_NET_TCP) && \


### PR DESCRIPTION
## Summary
`NET_SOCK_TYPE` is used for ioctl sockets only, they can set `O_CLOEXEC` explicitly.

## Impact
Do not inherit temporary fds created with `NET_SOCK_TYPE` for ioctl.

## Testing
CI
