### PR TITLE
arch/sim: Provide a dummy g_reg_offs for arm64

### DIFF
--- a/arch/sim/src/sim/sim_tcbinfo.c
+++ b/arch/sim/src/sim/sim_tcbinfo.c
@@ -78,6 +78,11 @@ static const uint16_t g_reg_offs[] =
   UINT16_MAX,            /* ES */
   UINT16_MAX,            /* FS */
 };
+#else
+static const uint16_t g_reg_offs[] =
+{
+  [0 ... XCPTCONTEXT_REGS] = UINT16_MAX
+};
 #endif
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

to avoid the link error on M1/M2 MacOS

## Impact

M1/M2 macOS

## Testing

ci