### PR TITLE
arch/mpfs: Add option for board specific PMP configuration

### DIFF
--- a/arch/risc-v/src/mpfs/Kconfig
+++ b/arch/risc-v/src/mpfs/Kconfig
@@ -46,6 +46,15 @@ config MPFS_BOOTLOADER
 	---help---
 		This NuttX image is used as a bootloader, which will boot only on one hart, putting the others in WFI
 
+config MPFS_BOARD_PMP
+	bool "Enable board specific PMP configuration"
+	depends on ARCH_USE_MPU && MPFS_BOOTLOADER
+	default n
+	---help---
+		If true, the board must provide "mpfs_board_pmp_setup" for PMP
+		configuration. If false, set ALL memory accessible for every
+		configured HART. Only the bootloader should do this.
+
 config MPFS_OPENSBI
 	bool "Use OpenSBI"
 	depends on MPFS_BOOTLOADER && OPENSBI

--- a/arch/risc-v/src/mpfs/mpfs_opensbi.c
+++ b/arch/risc-v/src/mpfs/mpfs_opensbi.c
@@ -56,9 +56,6 @@
 #define MPFS_ACLINT_MSWI_ADDR      MPFS_CLINT_MSIP0
 #define MPFS_ACLINT_MTIMER_ADDR    MPFS_CLINT_MTIMECMP0
 
-#define MPFS_PMP_DEFAULT_ADDR      0xfffffffff
-#define MPFS_PMP_DEFAULT_PERM      0x000000009f
-
 #define MPFS_SYSREG_SOFT_RESET_CR     (MPFS_SYSREG_BASE + \
                                        MPFS_SYSREG_SOFT_RESET_CR_OFFSET)
 #define MPFS_SYSREG_SUBBLK_CLOCK_CR   (MPFS_SYSREG_BASE + \
@@ -486,30 +483,6 @@ static void mpfs_opensbi_scratch_setup(uint32_t hartid)
 }
 
 /****************************************************************************
- * Name: mpfs_opensbi_pmp_setup
- *
- * Description:
- *   Initializes the PMP registers in a known default state.  All harts need
- *   to set these registers.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   None
- *
- ****************************************************************************/
-
-static void mpfs_opensbi_pmp_setup(void)
-{
-  /* All access granted */
-
-  csr_write(pmpaddr0, MPFS_PMP_DEFAULT_ADDR);
-  csr_write(pmpcfg0, MPFS_PMP_DEFAULT_PERM);
-  csr_write(pmpcfg2, 0);
-}
-
-/****************************************************************************
  * Name: mpfs_opensbi_vendor_ext_check
  *
  * Description:
@@ -602,8 +575,6 @@ static int mpfs_opensbi_ecall_handler(long extid, long funcid,
 void __attribute__((noreturn)) mpfs_opensbi_setup(void)
 {
   uint32_t hartid = current_hartid();
-
-  mpfs_opensbi_pmp_setup();
 
   sbi_console_set_device(&mpfs_console);
   mpfs_opensbi_scratch_setup(hartid);


### PR DESCRIPTION
## Summary
This removes "mpfs_opensbi_pmp_setup" and moves the logic to a lower level routine. Also an option to provide a board specific PMP configuration is given, instead of just opening up the entire SoC's memory for each hart.
## Impact
MPFS and PMP configuration only.
## Testing
MPFS
