### PR TITLE
sched/task: Remove spawn_proxyattrs as obsolete implementation 

### DIFF
--- a/sched/task/spawn.h
+++ b/sched/task/spawn.h
@@ -58,19 +58,4 @@
 
 int spawn_execattrs(pid_t pid, FAR const posix_spawnattr_t *attr);
 
-/****************************************************************************
- * Name: spawn_proxyattrs
- *
- * Description:
- *   Set attributes of the proxy task before it has started the new child
- *   task.
- *
- * Input Parameters:
- *
- *   attr - The attributes to use
- *
- ****************************************************************************/
-
-void spawn_proxyattrs(FAR const posix_spawnattr_t *attr);
-
 #endif /* __SCHED_TASK_SPAWN_H */

--- a/sched/task/task_posixspawn.c
+++ b/sched/task/task_posixspawn.c
@@ -221,11 +221,6 @@ int posix_spawn(FAR pid_t *pid, FAR const char *path,
   sinfo("pid=%p path=%s file_actions=%p attr=%p argv=%p\n",
         pid, path, file_actions, attr, argv);
 
-  if (attr != NULL)
-    {
-      spawn_proxyattrs(attr);
-    }
-
   return nxposix_spawn_exec(pid, path,
                             file_actions != NULL ?
                             *file_actions : NULL, attr, argv, envp);

--- a/sched/task/task_spawn.c
+++ b/sched/task/task_spawn.c
@@ -326,11 +326,6 @@ int task_spawn(FAR const char *name, main_t entry,
   sinfo("name=%s entry=%p file_actions=%p attr=%p argv=%p\n",
         name, entry, file_actions, attr, argv);
 
-  if (attr != NULL)
-    {
-      spawn_proxyattrs(attr);
-    }
-
   ret = nxtask_spawn_exec(&pid, name, entry,
                           file_actions != NULL ? *file_actions : NULL,
                           attr, argv, envp);

--- a/sched/task/task_spawnparms.c
+++ b/sched/task/task_spawnparms.c
@@ -149,6 +149,17 @@ int spawn_execattrs(pid_t pid, FAR const posix_spawnattr_t *attr)
    * return an error value, then we would also have to stop the task.
    */
 
+  /* Firstly, set the signal mask if requested to do so */
+
+  if ((attr->flags & POSIX_SPAWN_SETSIGMASK) != 0)
+    {
+      FAR struct tcb_s *tcb = nxsched_get_tcb(pid);
+      if (tcb)
+        {
+          tcb->sigprocmask = attr->sigmask;
+        }
+    }
+
   /* If we are only setting the priority, then call sched_setparm()
    * to set the priority of the of the new task.
    */

--- a/sched/task/task_spawnparms.c
+++ b/sched/task/task_spawnparms.c
@@ -228,29 +228,6 @@ int spawn_execattrs(pid_t pid, FAR const posix_spawnattr_t *attr)
 }
 
 /****************************************************************************
- * Name: spawn_proxyattrs
- *
- * Description:
- *   Set attributes of the proxy task before it has started the new child
- *   task.
- *
- * Input Parameters:
- *
- *   attr - The attributes to use
- *
- ****************************************************************************/
-
-void spawn_proxyattrs(FAR const posix_spawnattr_t *attr)
-{
-  /* Check if we need to change the signal mask */
-
-  if (attr != NULL && (attr->flags & POSIX_SPAWN_SETSIGMASK) != 0)
-    {
-      nxsig_procmask(SIG_SETMASK, &attr->sigmask, NULL);
-    }
-}
-
-/****************************************************************************
  * Name: spawn_file_actions
  *
  * Description:


### PR DESCRIPTION
## Summary
This removes the obsolete spawn_proxyatts() function, which was used to set the posix spawn proxy task's signal mask, among other things. Why does it need to be removed ? Now it changes the spawning process's (nsh in most cases) signal mask unexpectedly, while previously only the temporary proxy task was affected.

Fix the signal mask by setting it directly, much simpler this way.
## Impact
posix_spawn(), fixes regression after https://github.com/apache/nuttx/pull/9100
## Testing
rv-virt:knsh64 and MPFS (kernel mode)
