### PR TITLE
tools/configure.c and tools/sethost.sh Add CONFIG_EXPERIMENTAL for configure windows native

### DIFF
--- a/tools/configure.c
+++ b/tools/configure.c
@@ -1441,6 +1441,7 @@ static void set_host(const char *destconfig)
                 printf("  Select Windows native host\n");
                 disable_feature(destconfig, "CONFIG_WINDOWS_CYGWIN");
                 disable_feature(destconfig, "CONFIG_WINDOWS_MSYS");
+                enable_feature(destconfig, "CONFIG_EXPERIMENTAL");
                 enable_feature(destconfig, "CONFIG_WINDOWS_NATIVE");
                 break;
 

--- a/tools/sethost.sh
+++ b/tools/sethost.sh
@@ -218,6 +218,7 @@ else
       kconfig-tweak --file $nuttx/.config --enable CONFIG_WINDOWS_MSYS
     else
       echo "  Select CONFIG_WINDOWS_NATIVE=y"
+      kconfig-tweak --file $nuttx/.config --enable CONFIG_EXPERIMENTAL
       kconfig-tweak --file $nuttx/.config --enable CONFIG_WINDOWS_NATIVE
     fi
   fi


### PR DESCRIPTION
## Summary
Add CONFIG_EXPERIMENTAL for configure windows native
## Impact
There should be no impact.
## Testing
We tested on platform MSYS2 and Alpine linux
