### PR TITLE
FIX: s32kxxx flexcan doesn't set srr bit for extended frames

### DIFF
--- a/arch/arm/src/s32k1xx/s32k1xx_flexcan.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_flexcan.c
@@ -695,6 +695,7 @@ static int s32k1xx_transmit(struct s32k1xx_driver_s *priv)
       if (frame->can_id & CAN_EFF_FLAG)
         {
           cs.ide = 1;
+          cs.srr = 1;
           mb->id.ext = frame->can_id & MASKEXTID;
         }
       else
@@ -718,6 +719,7 @@ static int s32k1xx_transmit(struct s32k1xx_driver_s *priv)
       if (frame->can_id & CAN_EFF_FLAG)
         {
           cs.ide = 1;
+          cs.srr = 1;
           mb->id.ext = frame->can_id & MASKEXTID;
         }
       else

--- a/arch/arm/src/s32k3xx/s32k3xx_flexcan.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_flexcan.c
@@ -857,6 +857,7 @@ static int s32k3xx_transmit(struct s32k3xx_driver_s *priv)
       if (frame->can_id & CAN_EFF_FLAG)
         {
           cs.ide = 1;
+          cs.srr = 1;
           mb->id.ext = frame->can_id & MASKEXTID;
         }
       else
@@ -880,6 +881,7 @@ static int s32k3xx_transmit(struct s32k3xx_driver_s *priv)
       if (frame->can_id & CAN_EFF_FLAG)
         {
           cs.ide = 1;
+          cs.srr = 1;
           mb->id.ext = frame->can_id & MASKEXTID;
         }
       else


### PR DESCRIPTION
## Summary
This patch explicitly forces the srr bit to be recessive as per CAN specification  ISO 118898-1.

## Impact

## Testing
Tested on s32k1xx not FD, not tested on s32k3xx
