### PR TITLE
usrsock_rpmsg_server: Keep msg order in recursive call

### DIFF
--- a/drivers/usrsock/usrsock_rpmsg_server.c
+++ b/drivers/usrsock/usrsock_rpmsg_server.c
@@ -48,11 +48,16 @@
 struct usrsock_rpmsg_s
 {
   rmutex_t                  mutex;
-  ssize_t                   remain;
-  struct iovec              iov[CONFIG_NET_USRSOCK_RPMSG_SERVER_NIOVEC];
   struct socket             socks[CONFIG_NET_USRSOCK_RPMSG_SERVER_NSOCKS];
   FAR struct rpmsg_endpoint *epts[CONFIG_NET_USRSOCK_RPMSG_SERVER_NSOCKS];
   struct pollfd             pfds[CONFIG_NET_USRSOCK_RPMSG_SERVER_NSOCKS];
+};
+
+struct usrsock_rpmsg_ept_s
+{
+  struct rpmsg_endpoint ept;
+  struct iovec          iov[CONFIG_NET_USRSOCK_RPMSG_SERVER_NIOVEC];
+  ssize_t               remain;
 };
 
 /****************************************************************************
@@ -380,37 +385,39 @@ static int usrsock_rpmsg_sendto_handler(FAR struct rpmsg_endpoint *ept,
                                         uint32_t src, FAR void *priv_)
 {
   FAR struct usrsock_request_sendto_s *req;
+  FAR struct usrsock_rpmsg_ept_s *uept =
+    (FAR struct usrsock_rpmsg_ept_s *)ept;
   FAR struct usrsock_rpmsg_s *priv = priv_;
   uint16_t events = 0;
   ssize_t ret = -EBADF;
   int retr;
   int i;
 
-  if (priv->remain > 0)
+  if (uept->remain > 0)
     {
       size_t hlen;
       struct msghdr msg =
       {
       };
 
-      priv->remain -= len;
+      uept->remain -= len;
 
-      if (!priv->iov[0].iov_base)
+      if (!uept->iov[0].iov_base)
         {
           /* Maybe error occurred previously, skip processing. */
 
           return 0;
         }
 
-      req = priv->iov[0].iov_base;
+      req = uept->iov[0].iov_base;
       hlen = sizeof(*req) + req->addrlen;
 
       for (i = 0; i < CONFIG_NET_USRSOCK_RPMSG_SERVER_NIOVEC; i++)
         {
-          if (!priv->iov[i].iov_base)
+          if (!uept->iov[i].iov_base)
             {
-              priv->iov[i].iov_base = data;
-              priv->iov[i].iov_len = len;
+              uept->iov[i].iov_base = data;
+              uept->iov[i].iov_len = len;
               rpmsg_hold_rx_buffer(ept, data);
               break;
             }
@@ -418,7 +425,7 @@ static int usrsock_rpmsg_sendto_handler(FAR struct rpmsg_endpoint *ept,
 
       /* Partial packet ? continue to fetch */
 
-      if (priv->remain > 0)
+      if (uept->remain > 0)
         {
           /* We've used the last I/O vector, cannot continue. */
 
@@ -431,7 +438,7 @@ static int usrsock_rpmsg_sendto_handler(FAR struct rpmsg_endpoint *ept,
 
           return 0;
         }
-      else if (priv->remain < 0)
+      else if (uept->remain < 0)
         {
           ret = -EINVAL;
           goto out;
@@ -439,20 +446,20 @@ static int usrsock_rpmsg_sendto_handler(FAR struct rpmsg_endpoint *ept,
 
       /* Skip the sendto header from I/O vector */
 
-      priv->iov[0].iov_base = (FAR char *)priv->iov[0].iov_base + hlen;
-      priv->iov[0].iov_len -= hlen;
+      uept->iov[0].iov_base = (FAR char *)uept->iov[0].iov_base + hlen;
+      uept->iov[0].iov_len -= hlen;
 
       msg.msg_name = req->addrlen ? (FAR void *)(req + 1) : NULL;
       msg.msg_namelen = req->addrlen;
-      msg.msg_iov = priv->iov;
+      msg.msg_iov = uept->iov;
       msg.msg_iovlen = i + 1;
 
       ret = psock_sendmsg(&priv->socks[req->usockid], &msg, req->flags);
 
       /* Recover the I/O vector */
 
-      priv->iov[0].iov_base = (FAR char *)priv->iov[0].iov_base - hlen;
-      priv->iov[0].iov_len += hlen;
+      uept->iov[0].iov_base = (FAR char *)uept->iov[0].iov_base - hlen;
+      uept->iov[0].iov_len += hlen;
     }
   else
     {
@@ -461,12 +468,12 @@ static int usrsock_rpmsg_sendto_handler(FAR struct rpmsg_endpoint *ept,
       if (req->usockid >= 0 &&
           req->usockid < CONFIG_NET_USRSOCK_RPMSG_SERVER_NSOCKS)
         {
-          priv->remain = sizeof(*req) + req->addrlen + req->buflen - len;
-          if (priv->remain > 0)
+          uept->remain = sizeof(*req) + req->addrlen + req->buflen - len;
+          if (uept->remain > 0)
             {
 #if CONFIG_NET_USRSOCK_RPMSG_SERVER_NIOVEC >= 2
-              priv->iov[0].iov_base = data;
-              priv->iov[0].iov_len = len;
+              uept->iov[0].iov_base = data;
+              uept->iov[0].iov_len = len;
 
               rpmsg_hold_rx_buffer(ept, data);
               return 0;
@@ -500,18 +507,18 @@ out:
                                priv->pfds[req->usockid].events | POLLOUT);
     }
 
-  if (priv->iov[0].iov_base)
+  if (uept->iov[0].iov_base)
     {
       for (i = 0; i < CONFIG_NET_USRSOCK_RPMSG_SERVER_NIOVEC; i++)
         {
-          if (priv->iov[i].iov_base == NULL)
+          if (uept->iov[i].iov_base == NULL)
             {
               break;
             }
 
-          rpmsg_release_rx_buffer(ept, priv->iov[i].iov_base);
-          priv->iov[i].iov_base = NULL;
-          priv->iov[i].iov_len = 0;
+          rpmsg_release_rx_buffer(ept, uept->iov[i].iov_base);
+          uept->iov[i].iov_base = NULL;
+          uept->iov[i].iov_len = 0;
         }
     }
 
@@ -980,28 +987,28 @@ static void usrsock_rpmsg_ns_bind(FAR struct rpmsg_device *rdev,
                                   uint32_t dest)
 {
   FAR struct usrsock_rpmsg_s *priv = priv_;
-  FAR struct rpmsg_endpoint *ept;
+  FAR struct usrsock_rpmsg_ept_s *uept;
   int ret;
 
-  ept = kmm_zalloc(sizeof(struct rpmsg_endpoint));
-  if (!ept)
+  uept = kmm_zalloc(sizeof(*uept));
+  if (!uept)
     {
       return;
     }
 
-  ept->priv = priv;
+  uept->ept.priv = priv;
 
-  ret = rpmsg_create_ept(ept, rdev, USRSOCK_RPMSG_EPT_NAME,
+  ret = rpmsg_create_ept(&uept->ept, rdev, USRSOCK_RPMSG_EPT_NAME,
                          RPMSG_ADDR_ANY, dest,
                          usrsock_rpmsg_ept_cb, usrsock_rpmsg_ns_unbind);
   if (ret < 0)
     {
-      kmm_free(ept);
+      kmm_free(uept);
       return;
     }
 
 #ifdef CONFIG_NETDB_DNSCLIENT
-  dns_register_notify(usrsock_rpmsg_send_dns_event, ept);
+  dns_register_notify(usrsock_rpmsg_send_dns_event, &uept->ept);
 #endif
 }
 
@@ -1040,9 +1047,11 @@ static int usrsock_rpmsg_ept_cb(FAR struct rpmsg_endpoint *ept,
                                 FAR void *priv_)
 {
   FAR struct usrsock_request_common_s *common = data;
+  FAR struct usrsock_rpmsg_ept_s *uept =
+    (FAR struct usrsock_rpmsg_ept_s *)ept;
   FAR struct usrsock_rpmsg_s *priv = priv_;
 
-  if (priv->remain > 0)
+  if (uept->remain > 0)
     {
       return usrsock_rpmsg_sendto_handler(ept, data, len, src, priv);
     }


### PR DESCRIPTION
## Summary
In `drivers/rptun/rptun.c`, we have a `rptun_is_recursive` function, which lets rptun thread run recursively. Then the `usrsock_rpmsg_ept_cb` may be called inside `usrsock_rpmsg_ept_cb`, which can cause some unexpected behavior, so we add a queue to keep the order of incoming messages to reduce the complexity.

Patches included:
- usrsock_rpmsg_server: Save iov and remain per endpoint
  - Prepare for keeping msg order, also helps sendto to work correctly on multiple endpoints.
- usrsock_rpmsg_server: Keep msg order in recursive call

## Impact
Usrsock rpmsg server only.

## Testing
Manually.
