### PR TITLE
riscv_addrenv: Fix static page table mapping (paddr instead of vaddr)

### DIFF
--- a/arch/risc-v/include/arch.h
+++ b/arch/risc-v/include/arch.h
@@ -69,6 +69,11 @@
  *
  * The implications ? They depend on the MMU type.
  *
+ * For Sv32 this means that:
+ * - A task can not have more than 4GB of memory allocated.
+ * - The minimum amount of memory needed for page tables per task is 8K,
+ *   which gives access to 4MB of memory. This is plenty for many tasks.
+ *
  * For Sv39 this means that:
  * - A task can not have more than 1GB of memory allocated. This should be
  *   plenty enough...
@@ -78,26 +83,20 @@
 
 struct arch_addrenv_s
 {
-  /* Pointers to MAX_LEVELS-1 tables here, one of each are allocated for the
-   * task when it is created.
+  /* Physical addresses of the static page tables (levels N-1) here, these
+   * are allocated when a task is created.
    */
 
   uintptr_t spgtables[ARCH_SPGTS];
 
-  /* For convenience store the text base here */
+  /* The text, data, heap bases and heap size here */
 
   uintptr_t textvbase;
-
-  /* For convenience store the data base here */
-
   uintptr_t datavbase;
-
-  /* For convenience store the heap base and initial size here */
-
   uintptr_t heapvbase;
   size_t    heapsize;
 
-  /* For convenience store the satp value here */
+  /* The page directory root (satp) value */
 
   uintptr_t satp;
 };

--- a/arch/risc-v/src/common/riscv_addrenv.c
+++ b/arch/risc-v/src/common/riscv_addrenv.c
@@ -132,9 +132,9 @@ static void map_spgtables(arch_addrenv_t *addrenv, uintptr_t vaddr)
 
   for (i = 0; i < (ARCH_SPGTS - 1); i++)
     {
-      uintptr_t next = riscv_pgvaddr(addrenv->spgtables[i + 1]);
+      uintptr_t next = addrenv->spgtables[i + 1];
       mmu_ln_setentry(i + 1, prev, next, vaddr, MMU_UPGT_FLAGS);
-      prev = next;
+      prev = riscv_pgvaddr(next);
     }
 }
 


### PR DESCRIPTION
## Summary
Fixes issue with page table addresses; virtual address is used when physical address should be used.
Also improve commenting on the architecture dependent address environment structure (it has confused me too many times -> add comment to remove confusion)
## Impact
None, since all targets currently use vaddr=paddr for page pool, but it is good to fix this regardless.
## Testing
rv-virt:knsh64
