### PR TITLE
mm/kmap: Fix bad dependency to ARCH_VMA_MAPPING

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -686,7 +686,6 @@ config ARCH_SHM_VBASE
 
 config ARCH_KMAP_VBASE
 	hex "Kernel dynamic virtual mappings base"
-	depends on ARCH_VMA_MAPPING
 	---help---
 		The virtual address of the beginning of the kernel dynamic mapping
 		region.
@@ -743,6 +742,8 @@ config ARCH_SHM_NPAGES
 		maximum number of pages per region, and the configured size of
 		each page.
 
+endif # ARCH_VMA_MAPPING
+
 config ARCH_KMAP_NPAGES
 	int "Max kernel dynamic mapping pages"
 	default 1
@@ -754,8 +755,6 @@ config ARCH_KMAP_NPAGES
 		determined by the product of the maximum number of regions, the
 		maximum number of pages per region, and the configured size of
 		each page.
-
-endif # ARCH_VMA_MAPPING
 
 config ARCH_STACK_DYNAMIC
 	bool "Dynamic user stack"

--- a/mm/Kconfig
+++ b/mm/Kconfig
@@ -198,7 +198,6 @@ config MM_KMAP
 	bool "Support for dynamic kernel virtual mappings"
 	default n
 	depends on MM_PGALLOC && BUILD_KERNEL
-	select ARCH_VMA_MAPPING
 	---help---
 		Build support for dynamically mapping pages from the page pool into
 		kernel virtual memory. This includes pages that are already mapped


### PR DESCRIPTION
## Summary
Fixes bad dependency for kmm_map; kmap does not need ARCH_VMA_MAPPING => remove the dependency

Produces build error if MM_SHM is not enabled via:

```
#ifdef CONFIG_ARCH_VMA_MAPPING
#  ifndef CONFIG_ARCH_SHM_VBASE
#    error CONFIG_ARCH_SHM_VBASE not defined
#    define CONFIG_ARCH_SHM_VBASE __ARCH_SHM_VBASE
#  endif
```

## Impact
Remove build error when enabling CONFIG_MM_KMAP without enabling CONFIG_MM_SHM
## Testing
CI pass
