### PR TITLE
arch: cxd56xx: Support to get gnss firmware version

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_gnss.c
+++ b/arch/arm/src/cxd56xx/cxd56_gnss.c
@@ -49,6 +49,7 @@
 #include "cxd56_cpu1signal.h"
 #include "cxd56_gnss.h"
 #include "cxd56_pinconfig.h"
+#include "hardware/cxd5602_backupmem.h"
 
 #if defined(CONFIG_CXD56_GNSS)
 
@@ -285,6 +286,8 @@ static int cxd56_gnss_set_1pps_output(struct file *filep,
                                       unsigned long arg);
 static int cxd56_gnss_get_1pps_output(struct file *filep,
                                       unsigned long arg);
+static int cxd56_gnss_get_version(struct file *filep,
+                                  unsigned long arg);
 
 /* file operation functions */
 
@@ -382,6 +385,10 @@ static int (*g_cmdlist[CXD56_GNSS_IOCTL_MAX])(struct file *filep,
   cxd56_gnss_get_usecase,
   cxd56_gnss_set_1pps_output,
   cxd56_gnss_get_1pps_output,
+  cxd56_gnss_get_version,
+  NULL,
+  NULL,
+  NULL,
 
   /* max CXD56_GNSS_IOCTL_MAX */
 };
@@ -482,7 +489,7 @@ static int cxd56_gnss_stop(struct file *filep, unsigned long arg)
 }
 
 /****************************************************************************
- * Name: cxd56_gnss_get_satellite_system
+ * Name: cxd56_gnss_select_satellite_system
  *
  * Description:
  *   Process CXD56_GNSS_IOCTL_SELECT_SATELLITE_SYSTEM command.
@@ -642,7 +649,7 @@ static int cxd56_gnss_set_ope_mode(struct file *filep, unsigned long arg)
  *
  * Description:
  *   Process CXD56_GNSS_IOCTL_GET_OPE_MODE command.
- *   Set the TCXO offset
+ *   Get GNSS operation mode.
  *
  * Input Parameters:
  *   filep - File structure pointer
@@ -2175,6 +2182,45 @@ static int cxd56_gnss_get_1pps_output(struct file *filep,
   return ret;
 }
 
+/****************************************************************************
+ * Name: cxd56_gnss_get_version
+ *
+ * Description:
+ *   Get the GNSS FW version
+ *
+ * Input Parameters:
+ *   filep - File structure pointer
+ *   arg   - Pointer to a string array for version information
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+static int cxd56_gnss_get_version(struct file *filep, unsigned long arg)
+{
+  char *version;
+  uint32_t gnssfw_version;
+
+  if (!arg)
+    {
+      return -EINVAL;
+    }
+
+  version = (char *)arg;
+
+  memset(version, 0, CXD56_GNSS_VERSION_MAXLEN);
+
+  gnssfw_version = BKUP->gnssfw_version;
+
+  snprintf(version, CXD56_GNSS_VERSION_MAXLEN, "%ld.%ld.%ld",
+           (gnssfw_version >> 28) & 0xf,
+           (gnssfw_version >> 20) & 0xff,
+           gnssfw_version & 0xfffff);
+
+  return 0;
+}
+
 /* Synchronized with processes and CPUs
  *  CXD56_GNSS signal handler and utils
  */
@@ -2969,7 +3015,14 @@ static int cxd56_gnss_ioctl(struct file *filep, int cmd,
       return ret;
     }
 
-  ret = g_cmdlist[cmd](filep, arg);
+  if (g_cmdlist[cmd] != NULL)
+    {
+      ret = g_cmdlist[cmd](filep, arg);
+    }
+  else
+    {
+      ret = -ENOTSUP;
+    }
 
   nxmutex_unlock(&priv->ioctllock);
   return ret;


### PR DESCRIPTION
## Summary
Support to get gnss firmware version and fix typo.

## Impact
Only spresense board.

## Testing

