### PR TITLE
sim_netdriver: some sim defconfig have problems when using the network

### DIFF
--- a/arch/sim/src/sim/sim_netdriver.c
+++ b/arch/sim/src/sim/sim_netdriver.c
@@ -280,7 +280,8 @@ void sim_netdriver_setmacaddr(int devidx, unsigned char *macaddr)
 
 void sim_netdriver_setmtu(int devidx, int mtu)
 {
-  g_sim_dev[devidx].dev.netdev.d_pktsize = mtu + ETH_HDRLEN;
+  g_sim_dev[devidx].dev.netdev.d_pktsize = MIN(SIM_NETDEV_BUFSIZE,
+                                               mtu + ETH_HDRLEN);
 }
 
 void sim_netdriver_loop(void)


### PR DESCRIPTION
## Summary
if the configured SIM_NETDEV_BUFSIZE < host MTU, there will be issues with access out of bounds

## Impact

## Testing
sim:linux private defconfig
