### PR TITLE
net/tcp: Support initial sequence number described in RFC 6528

### DIFF
--- a/net/tcp/Kconfig
+++ b/net/tcp/Kconfig
@@ -158,6 +158,17 @@ config NET_TCP_CC_NEWRENO
 			The TCP Congestion Control defines four congestion control algorithms,
 			slow start, congestion avoidance, fast retransmit, and fast recovery.
 
+config NET_TCP_ISN_RFC6528
+	bool "Use Initial Sequence Number Algorithm from RFC 6528"
+	default n
+	depends on CRYPTO
+	---help---
+		Initial Sequence Number Generation Algorithm from RFC 6528:
+			ISN = M + F(localip, localport, remoteip, remoteport, secretkey)
+
+			M is the 4 microsecond timer, and F() is a pseudorandom
+			function (PRF) which is MD5 (suggested by RFC 6528).
+
 config NET_TCP_WINDOW_SCALE
 	bool "Enable TCP/IP Window Scale Option"
 	default n

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -896,7 +896,7 @@ uint32_t tcp_addsequence(FAR uint8_t *seqno, uint16_t len);
  *
  ****************************************************************************/
 
-void tcp_initsequence(FAR uint8_t *seqno);
+void tcp_initsequence(FAR struct tcp_conn_s *conn);
 
 /****************************************************************************
  * Name: tcp_nextsequence

--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -49,7 +49,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
-#include <sys/random.h>
 
 #include <netinet/in.h>
 
@@ -70,6 +69,7 @@
 #include "icmpv6/icmpv6.h"
 #include "nat/nat.h"
 #include "netdev/netdev.h"
+#include "utils/utils.h"
 
 /****************************************************************************
  * Private Data
@@ -579,26 +579,14 @@ int tcp_selectport(uint8_t domain,
                    uint16_t portno)
 {
   static uint16_t g_last_tcp_port;
-  ssize_t ret;
 
   /* Generate port base dynamically */
 
   if (g_last_tcp_port == 0)
     {
-      ret = getrandom(&g_last_tcp_port, sizeof(uint16_t), 0);
-      if (ret < 0)
-        {
-          ret = getrandom(&g_last_tcp_port, sizeof(uint16_t), GRND_RANDOM);
-        }
+      net_getrandom(&g_last_tcp_port, sizeof(uint16_t));
 
-      if (ret != sizeof(uint16_t))
-        {
-          g_last_tcp_port = clock_systime_ticks() % 32000;
-        }
-      else
-        {
-          g_last_tcp_port = g_last_tcp_port % 32000;
-        }
+      g_last_tcp_port = g_last_tcp_port % 32000;
 
       if (g_last_tcp_port < 4096)
         {

--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -1200,7 +1200,7 @@ FAR struct tcp_conn_s *tcp_alloc_accept(FAR struct net_driver_s *dev,
       conn->rport            = tcp->srcport;
       conn->tcpstateflags    = TCP_SYN_RCVD;
 
-      tcp_initsequence(conn->sndseq);
+      tcp_initsequence(conn);
 #if !defined(CONFIG_NET_TCP_WRITE_BUFFERS)
       conn->rexmit_seq       = tcp_getsequence(conn->sndseq);
 #endif
@@ -1506,13 +1506,6 @@ int tcp_connect(FAR struct tcp_conn_s *conn, FAR const struct sockaddr *addr)
    */
 
   conn->tcpstateflags = TCP_SYN_SENT;
-  tcp_initsequence(conn->sndseq);
-
-  /* Save initial sndseq to rexmit_seq, otherwise it will be zero */
-
-#if !defined(CONFIG_NET_TCP_WRITE_BUFFERS)
-  conn->rexmit_seq = tcp_getsequence(conn->sndseq);
-#endif
 
   conn->tx_unacked = 1;    /* TCP length of the SYN is one. */
   conn->nrtx       = 0;
@@ -1526,6 +1519,16 @@ int tcp_connect(FAR struct tcp_conn_s *conn, FAR const struct sockaddr *addr)
   conn->isn        = 0;
   conn->sent       = 0;
   conn->sndseq_max = 0;
+#endif
+
+  /* Set initial sndseq when we have both local/remote addr and port */
+
+  tcp_initsequence(conn);
+
+  /* Save initial sndseq to rexmit_seq, otherwise it will be zero */
+
+#if !defined(CONFIG_NET_TCP_WRITE_BUFFERS)
+  conn->rexmit_seq = tcp_getsequence(conn->sndseq);
 #endif
 
 #ifdef CONFIG_NET_TCP_CC_NEWRENO

--- a/net/tcp/tcp_seqno.c
+++ b/net/tcp/tcp_seqno.c
@@ -45,13 +45,13 @@
 
 #include <stdint.h>
 #include <debug.h>
-#include <sys/random.h>
 
 #include <nuttx/clock.h>
 #include <nuttx/net/netconfig.h>
 #include <nuttx/net/netdev.h>
 
 #include "devif/devif.h"
+#include "utils/utils.h"
 
 /****************************************************************************
  * Private Data
@@ -144,32 +144,17 @@ uint32_t tcp_addsequence(FAR uint8_t *seqno, uint16_t len)
 
 void tcp_initsequence(FAR uint8_t *seqno)
 {
-  int ret;
-
   /* If g_tcpsequence is already initialized, just copy it */
 
   if (g_tcpsequence == 0)
     {
       /* Get a random TCP sequence number */
 
-      ret = getrandom(&g_tcpsequence, sizeof(uint32_t), 0);
-      if (ret < 0)
-        {
-          ret = getrandom(&g_tcpsequence, sizeof(uint32_t), GRND_RANDOM);
-        }
+      net_getrandom(&g_tcpsequence, sizeof(uint32_t));
 
-      /* If getrandom() failed use sys ticks, use about half of allowed
-       * values
-       */
+      /* Use about half of allowed values */
 
-      if (ret != sizeof(uint32_t))
-        {
-          g_tcpsequence = clock_systime_ticks() % 2000000000;
-        }
-      else
-        {
-          g_tcpsequence = g_tcpsequence % 2000000000;
-        }
+      g_tcpsequence = g_tcpsequence % 2000000000;
 
       /* If the random value is "small" increase it */
 

--- a/net/tcp/tcp_seqno.c
+++ b/net/tcp/tcp_seqno.c
@@ -43,23 +43,84 @@
 #include <nuttx/config.h>
 #if defined(CONFIG_NET) && defined(CONFIG_NET_TCP)
 
-#include <stdint.h>
+#include <crypto/md5.h>
 #include <debug.h>
+#include <stdint.h>
 
 #include <nuttx/clock.h>
 #include <nuttx/net/netconfig.h>
 #include <nuttx/net/netdev.h>
 
 #include "devif/devif.h"
+#include "tcp/tcp.h"
 #include "utils/utils.h"
 
 /****************************************************************************
  * Private Data
  ****************************************************************************/
 
-/* g_tcpsequence is used to generate initial TCP sequence numbers */
+/* These fields are used to generate initial TCP sequence numbers */
 
+#ifdef CONFIG_NET_TCP_ISN_RFC6528
+/* RFC 6528, Section 3: Key lengths of 128 bits should be adequate. */
+
+static uint32_t g_tcp_isnkey[4];
+#else
 static uint32_t g_tcpsequence;
+#endif
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: tcp_isn_rfc6528
+ *
+ * Description:
+ *   Calculate the initial sequence number described in RFC 6528.
+ *   ISN = M + F(localip, localport, remoteip, remoteport, secretkey)
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_TCP_ISN_RFC6528
+static uint32_t tcp_isn_rfc6528(FAR struct tcp_conn_s *conn)
+{
+  const size_t addrlen = net_ip_domain_select(conn->domain,
+                                  sizeof(in_addr_t), sizeof(net_ipv6addr_t));
+  MD5_CTX ctx;
+  uint32_t digest[MD5_DIGEST_LENGTH / 4];
+  uint32_t m;
+
+  /* Make sure we have a secret key */
+
+  if (g_tcp_isnkey[0] == 0)
+    {
+      net_getrandom(g_tcp_isnkey, sizeof(g_tcp_isnkey));
+    }
+
+  /* M is the 4 microsecond timer */
+
+  m = TICK2USEC(clock_systime_ticks()) / 4;
+
+  /* F() is suggested to be MD5 */
+
+  md5init(&ctx);
+
+  /* Calculate F(localip, localport, remoteip, remoteport, secretkey) */
+
+  md5update(&ctx, net_ip_binding_laddr(&conn->u, conn->domain), addrlen);
+  md5update(&ctx, &conn->lport, sizeof(conn->lport));
+  md5update(&ctx, net_ip_binding_raddr(&conn->u, conn->domain), addrlen);
+  md5update(&ctx, &conn->rport, sizeof(conn->rport));
+  md5update(&ctx, g_tcp_isnkey, sizeof(g_tcp_isnkey));
+
+  md5final((FAR uint8_t *)digest, &ctx);
+
+  /* ISN = M + F(localip, localport, remoteip, remoteport, secretkey) */
+
+  return m + digest[0];
+}
+#endif
 
 /****************************************************************************
  * Public Functions
@@ -142,8 +203,11 @@ uint32_t tcp_addsequence(FAR uint8_t *seqno, uint16_t len)
  *
  ****************************************************************************/
 
-void tcp_initsequence(FAR uint8_t *seqno)
+void tcp_initsequence(FAR struct tcp_conn_s *conn)
 {
+#ifdef CONFIG_NET_TCP_ISN_RFC6528
+  tcp_setsequence(conn->sndseq, tcp_isn_rfc6528(conn));
+#else
   /* If g_tcpsequence is already initialized, just copy it */
 
   if (g_tcpsequence == 0)
@@ -164,7 +228,8 @@ void tcp_initsequence(FAR uint8_t *seqno)
         }
     }
 
-  tcp_setsequence(seqno, g_tcpsequence);
+  tcp_setsequence(conn->sndseq, g_tcpsequence);
+#endif
 }
 
 /****************************************************************************
@@ -180,7 +245,9 @@ void tcp_initsequence(FAR uint8_t *seqno)
 
 void tcp_nextsequence(void)
 {
+#ifndef CONFIG_NET_TCP_ISN_RFC6528
   g_tcpsequence++;
+#endif
 }
 
 #endif /* CONFIG_NET && CONFIG_NET_TCP */

--- a/net/utils/CMakeLists.txt
+++ b/net/utils/CMakeLists.txt
@@ -30,7 +30,8 @@ set(SRCS
     net_lock.c
     net_snoop.c
     net_cmsg.c
-    net_iob_concat.c)
+    net_iob_concat.c
+    net_getrandom.c)
 
 # IPv6 utilities
 

--- a/net/utils/Make.defs
+++ b/net/utils/Make.defs
@@ -22,7 +22,7 @@
 
 NET_CSRCS += net_dsec2tick.c net_dsec2timeval.c net_timeval2dsec.c
 NET_CSRCS += net_chksum.c net_ipchksum.c net_incr32.c net_lock.c net_snoop.c
-NET_CSRCS += net_cmsg.c net_iob_concat.c
+NET_CSRCS += net_cmsg.c net_iob_concat.c net_getrandom.c
 
 # IPv6 utilities
 

--- a/net/utils/net_getrandom.c
+++ b/net/utils/net_getrandom.c
@@ -1,0 +1,82 @@
+/****************************************************************************
+ * net/utils/net_getrandom.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+#include <string.h>
+#include <sys/param.h>
+#include <sys/random.h>
+
+#include <nuttx/clock.h>
+#include <nuttx/hashtable.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: net_getrandom
+ *
+ * Description:
+ *   Fill a buffer of arbitrary length with randomness. This function is
+ *   guaranteed to be success.
+ *
+ * Input Parameters:
+ *   bytes  - Buffer for returned random bytes
+ *   nbytes - Number of bytes requested.
+ *
+ ****************************************************************************/
+
+void net_getrandom(FAR void *bytes, size_t nbytes)
+{
+#if defined(CONFIG_DEV_URANDOM) || defined(CONFIG_DEV_RANDOM)
+  ssize_t ret = getrandom(bytes, nbytes, 0);
+
+  if (ret < 0)
+    {
+      ret = getrandom(bytes, nbytes, GRND_RANDOM);
+    }
+
+  if (ret == nbytes)
+    {
+      return;
+    }
+#endif
+
+  /* Fallback to hash of clock_systime_ticks(), minus nbytes to avoid getting
+   * same tick count when looping more than once.
+   */
+
+  while (nbytes > 0)
+    {
+      uint32_t hash  = HASH(clock_systime_ticks() - nbytes, 32);
+      size_t   ncopy = MIN(nbytes, sizeof(hash));
+
+      memcpy(bytes, &hash, ncopy);
+
+      nbytes -= ncopy;
+      bytes   = (FAR uint8_t *)bytes + ncopy;
+    }
+}

--- a/net/utils/utils.h
+++ b/net/utils/utils.h
@@ -145,6 +145,21 @@ unsigned int net_timeval2dsec(FAR struct timeval *tv,
                               enum tv2ds_remainder_e remainder);
 
 /****************************************************************************
+ * Name: net_getrandom
+ *
+ * Description:
+ *   Fill a buffer of arbitrary length with randomness. This function is
+ *   guaranteed to be success.
+ *
+ * Input Parameters:
+ *   bytes  - Buffer for returned random bytes
+ *   nbytes - Number of bytes requested.
+ *
+ ****************************************************************************/
+
+void net_getrandom(FAR void *bytes, size_t nbytes);
+
+/****************************************************************************
  * Name: net_ipv6_mask2pref
  *
  * Description:


### PR DESCRIPTION
## Summary
- Patches included:
  - net/tcp: Take out get random process as common function
  - net/tcp: Support initial sequence number described in RFC 6528

Support initial sequence number described in RFC 6528
https://github.com/apache/nuttx/blob/eddcc0f51b9c8f6c7ff79d6f8d163ced13a66b45/net/tcp/Kconfig#L166-L170

## Impact
TCP's initial sequence number, controlled by Kconfig option

## Testing
Manually, CI
