### PR TITLE
drivers/rptun: check the status before stop remote proc 

### DIFF
--- a/drivers/serial/uart_rpmsg.c
+++ b/drivers/serial/uart_rpmsg.c
@@ -339,7 +339,8 @@ static void uart_rpmsg_device_destroy(FAR struct rpmsg_device *rdev,
   FAR struct uart_dev_s *dev = priv_;
   FAR struct uart_rpmsg_priv_s *priv = dev->priv;
 
-  if (strcmp(priv->cpuname, rpmsg_get_cpuname(rdev)) == 0)
+  if (priv->ept.priv != NULL &&
+      strcmp(priv->cpuname, rpmsg_get_cpuname(rdev)) == 0)
     {
       rpmsg_destroy_ept(&priv->ept);
     }


### PR DESCRIPTION
## Summary

1. drivers/rptun: check the status before stop remote proc 

Race condition if the remote proc is stoped during initialization phase

```
| #0  0x0249f959 in rpmsg_destroy_ept (ept=0xffffffc0) at open-amp/lib/rpmsg/rpmsg.c:376
| #1  0x024a938c in rpmsg_deinit_vdev (rvdev=0xf2303a48) at open-amp/lib/rpmsg/rpmsg_virtio.c:971
| #2  0x02117e33 in rptun_dev_stop (rproc=0xf2303a04, stop_ns=true) at rptun/rptun.c:891
| #3  0x021181d8 in rptun_do_ioctl (priv=0xf2303a00, cmd=11010, arg=0) at rptun/rptun.c:922
| #4  0x02119722 in rptun_ioctl_foreach (cpuname=0x0, cmd=11010, value=0) at rptun/rptun.c:1086
| #5  0x0211b9df in rptun_poweroff (cpuname=0x0) at rptun/rptun.c:1378
| #6  0x02053aa6 in board_power_off (status=0) at sim/sim_head.c:206
| #7  0x0253d65c in boardctl (cmd=65283, arg=0) at boardctl.c:400
| #8  0x021eb497 in cmd_poweroff (vtbl=0xef606280, argc=1, argv=0xef9b73e0) at nsh_syscmds.c:356
| #9  0x021cdb4d in nsh_command (vtbl=0xef606280, argc=1, argv=0xef9b73e0) at nsh_command.c:1164
| #10 0x021baa72 in nsh_execute (vtbl=0xef606280, argc=1, argv=0xef9b73e0, redirfile=0x0, oflags=0) at nsh_parse.c:845
| #11 0x021c6b0a in nsh_parse_command (vtbl=0xef606280, cmdline=0xef606708 "poweroff") at nsh_parse.c:2744
| #12 0x021c7166 in nsh_parse (vtbl=0xef606280, cmdline=0xef606708 "poweroff") at nsh_parse.c:2828
| #13 0x0221fa2f in nsh_session (pstate=0xef606280, login=1, argc=1, argv=0xef7a7860) at nsh_session.c:245
| #14 0x021f8c04 in nsh_consolemain (argc=1, argv=0xef7a7860) at nsh_consolemain.c:75
| #15 0x021b77eb in nsh_main (argc=1, argv=0xef7a7860) at nsh_main.c:74
| #16 0x02166ddf in nxtask_startup (entrypt=0x21b76ca <nsh_main>, argc=1, argv=0xef7a7860) at sched/task_startup.c:70
| #17 0x020b363c in nxtask_start () at task/task_start.c:134
```


2. drivers/serial: check the remote device before get name

```
| #0 0x2119bf1 in rpmsg_get_cpuname rptun/rptun.c:1157
| #1 0x24f97bd in uart_rpmsg_device_destroy serial/uart_rpmsg.c:342
| #2 0x2117d56 in rptun_dev_stop rptun/rptun.c:883
| #3 0x21181d7 in rptun_do_ioctl rptun/rptun.c:922
| #4 0x2119721 in rptun_ioctl_foreach rptun/rptun.c:1086
```


## Impact

## Testing

