### PR TITLE
libc/realpath: allocate link buffer of pseudofs to save stack

### DIFF
--- a/libs/libc/stdlib/lib_realpath.c
+++ b/libs/libc/stdlib/lib_realpath.c
@@ -39,7 +39,10 @@
 FAR char *realpath(FAR const char *path, FAR char *resolved)
 {
 #ifdef CONFIG_PSEUDOFS_SOFTLINKS
-  char wbuf[2][PATH_MAX];
+  FAR char *wbuf[2] =
+    {
+    };
+
   int nlnk = 0;
   int idx = 0;
   ssize_t n;
@@ -117,6 +120,14 @@ loop:
         }
 
       *p = '\0';
+
+#ifdef CONFIG_PSEUDOFS_SOFTLINKS
+      if (wbuf[0] != NULL)
+        {
+          lib_free(wbuf[0]);
+        }
+#endif
+
       return resolved;
     }
 
@@ -186,7 +197,19 @@ loop:
           goto out;
         }
 
-      n = readlink(resolved, wbuf[idx], sizeof(wbuf[0]) - 1);
+      if (wbuf[0] == NULL)
+        {
+          wbuf[0] = lib_calloc(2, PATH_MAX);
+          if (wbuf[0] == NULL)
+            {
+              set_errno(ENOMEM);
+              goto out;
+            }
+
+          wbuf[1] = wbuf[0] + PATH_MAX;
+        }
+
+      n = readlink(resolved, wbuf[idx], PATH_MAX - 1);
       if (n <= 0)
         {
           if (n == 0)
@@ -199,7 +222,7 @@ loop:
 
       /* Append unresolved path to link target and switch to it. */
 
-      if (n + (len = strlen(q)) + 1 > sizeof(wbuf[0]))
+      if (n + (len = strlen(q)) + 1 > PATH_MAX)
         {
           set_errno(ENAMETOOLONG);
           goto out;
@@ -234,5 +257,12 @@ loop:
 
 out:
   lib_free(fres);
+#ifdef CONFIG_PSEUDOFS_SOFTLINKS
+  if (wbuf[0] != NULL)
+    {
+      lib_free(wbuf[0]);
+    }
+#endif
+
   return NULL;
 }


### PR DESCRIPTION

## Summary

libc/realpath: allocate link buffer of pseudofs to save stack

The link buffer of pseudofs will occupy too much of stack, allocate from the heap to save the stack usage.


## Impact

N/A

## Testing

ci-check