### PR TITLE
esp32s3: Fix issue regarding IRAM-enabled ISRs by fixing the linker

### DIFF
--- a/boards/xtensa/esp32s3/common/scripts/legacy_sections.ld
+++ b/boards/xtensa/esp32s3/common/scripts/legacy_sections.ld
@@ -88,7 +88,7 @@ SECTIONS
     *libarch.a:xtensa_testset.*(.literal .text .literal.* .text.*)
 
 #ifdef CONFIG_ESP32S3_BLE
-    *libc.a:bin/sq_remlast.*(.literal .text .literal.* .text.*)
+    *libc.a:sq_remlast.*(.literal .text .literal.* .text.*)
 #endif
 
     *libdrivers.a:syslog_flush.*(.literal .text .literal.* .text.*)
@@ -121,7 +121,7 @@ SECTIONS
     *libsched.a:sched_mergepending.*(.literal.nxsched_merge_pending .text.nxsched_merge_pending)
     *libsched.a:sched_resumescheduler.*(.literal.nxsched_resume_scheduler .text.nxsched_resume_scheduler)
 
-    *libc.a:bin/sq_remfirst.*(.literal.sq_remfirst .text.sq_remfirst)
+    *libc.a:sq_remfirst.*(.literal.sq_remfirst .text.sq_remfirst)
 #endif
 
     *(.wifirxiram .wifirxiram.*)


### PR DESCRIPTION
## Summary

* esp32s3: Fix issue regarding IRAM-enabled ISRs by fixing the linker

After https://github.com/apache/nuttx/pull/11007/ was merged, the path for some files changed, requiring the linker to be fixed to make it run from the internal memory once again.

## Impact

Make the IRAM-enabled interrupts run successfully once again.

## Testing

Internal CI testing + ESP32-S3-DevKitC-1 v1.0