### PR TITLE
Solve some problems encountered during cmake compilation

### DIFF
--- a/arch/arm/src/CMakeLists.txt
+++ b/arch/arm/src/CMakeLists.txt
@@ -18,9 +18,9 @@
 #
 # ##############################################################################
 
-add_subdirectory(common)
 add_subdirectory(${ARCH_SUBDIR})
 add_subdirectory(${NUTTX_CHIP_ABS_DIR} EXCLUDE_FROM_ALL exclude_chip)
+add_subdirectory(common)
 
 # Include directories (before system ones) as PUBLIC so that it can be exposed
 # to libboard

--- a/arch/risc-v/src/CMakeLists.txt
+++ b/arch/risc-v/src/CMakeLists.txt
@@ -18,8 +18,8 @@
 #
 # ##############################################################################
 
-add_subdirectory(common)
 add_subdirectory(${NUTTX_CHIP_ABS_DIR} EXCLUDE_FROM_ALL exclude_chip)
+add_subdirectory(common)
 
 # Include directories (before system ones) as PUBLIC so that it can be exposed
 # to libboard

--- a/drivers/misc/CMakeLists.txt
+++ b/drivers/misc/CMakeLists.txt
@@ -65,6 +65,9 @@ if(CONFIG_BLK_RPMSG)
 endif()
 
 if(CONFIG_BLK_RPMSG_SERVER)
+  set_source_files_properties(
+    rpmsgblk_server.c DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/..
+    PROPERTIES INCLUDE_DIRECTORIES ${NUTTX_DIR}/fs/inode)
   list(APPEND SRCS rpmsgblk_server.c)
 endif()
 

--- a/drivers/sensors/CMakeLists.txt
+++ b/drivers/sensors/CMakeLists.txt
@@ -30,6 +30,9 @@ if(CONFIG_SENSORS)
   endif()
 
   if(CONFIG_SENSORS_GPS)
+    set_source_files_properties(
+      gps_uorb.c DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/..
+      PROPERTIES INCLUDE_DIRECTORIES ${NUTTX_DIR}/libs/libc/gpsutils)
     list(APPEND SRCS gps_uorb.c)
   endif()
 

--- a/fs/vfs/CMakeLists.txt
+++ b/fs/vfs/CMakeLists.txt
@@ -69,6 +69,9 @@ endif()
 # Support for timerfd
 
 if(CONFIG_TIMER_FD)
+  set_source_files_properties(
+    fs_timerfd.c DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/..
+    PROPERTIES INCLUDE_DIRECTORIES ${NUTTX_DIR}/sched)
   list(APPEND SRCS fs_timerfd.c)
 endif()
 

--- a/libs/libc/gpsutils/CMakeLists.txt
+++ b/libs/libc/gpsutils/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# libs/libc/builtin/CMakeLists.txt
+# libs/libc/gpsutils/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
@@ -18,17 +18,31 @@
 #
 # ##############################################################################
 
-if(CONFIG_BUILTIN)
-  set(SRCS lib_builtin_getname.c lib_builtin_isavail.c lib_builtin_forindex.c)
+nuttx_generate_kconfig(MENUDESC "GPS Utilities")
 
-  if(CONFIG_BUILD_PROTECTED)
-    list(APPEND SRCS lib_builtin_setlist.c)
+if(CONFIG_GPSUTILS_MINMEA_LIB)
+
+  set(MINMEA_DIR ${CMAKE_CURRENT_LIST_DIR}/minmea)
+
+  if(NOT EXISTS ${MINMEA_DIR})
+    set(MINMEA_URL https://github.com/kosma/minmea/archive)
+    set(MINMEA_VERSION db46128e73cee26d6a6eb0482dcba544ee1ea9f5)
+
+    FetchContent_Declare(
+      minmea_fetch
+      URL ${MINMEA_URL}/${MINMEA_VERSION}.zip SOURCE_DIR
+          ${CMAKE_CURRENT_LIST_DIR}/minmea BINARY_DIR
+          ${CMAKE_BINARY_DIR}/libs/libc/gpsutils/minmea
+      DOWNLOAD_NO_PROGRESS true
+      TIMEOUT 30)
+
+    FetchContent_GetProperties(minmea_fetch)
+
+    if(NOT minmea_fetch_POPULATED)
+      FetchContent_Populate(minmea_fetch)
+    endif()
   endif()
 
-  if(CONFIG_SCHED_USER_IDENTITY)
-    list(APPEND SRCS lib_builtin_getuid.c lib_builtin_getgid.c
-         lib_builtin_getmode.c)
-  endif()
+  target_sources(c PRIVATE minmea/minmea.c)
 
-  target_sources(c PRIVATE ${SRCS})
 endif()

--- a/libs/libc/machine/CMakeLists.txt
+++ b/libs/libc/machine/CMakeLists.txt
@@ -19,3 +19,7 @@
 # ##############################################################################
 
 add_subdirectory(${CONFIG_ARCH})
+
+if(CONFIG_LIBC_ARCH_ATOMIC)
+  target_sources(c PRIVATE arch_atomic.c)
+endif()

--- a/libs/libc/misc/CMakeLists.txt
+++ b/libs/libc/misc/CMakeLists.txt
@@ -98,4 +98,12 @@ if(CONFIG_LIBC_ENVPATH)
   list(APPEND SRCS lib_envpath.c)
 endif()
 
+if(CONFIG_FDSAN)
+  list(APPEND SRCS lib_fdsan.c)
+endif()
+
+if(CONFIG_FDCHECK)
+  list(APPEND SRCS lib_fdcheck.c)
+endif()
+
 target_sources(c PRIVATE ${SRCS})

--- a/libs/libc/string/CMakeLists.txt
+++ b/libs/libc/string/CMakeLists.txt
@@ -58,6 +58,7 @@ set(SRCS
     lib_strerrorr.c
     lib_explicit_bzero.c
     lib_strsignal.c
+    lib_timingsafe_bcmp.c
     lib_index.c
     lib_rindex.c)
 


### PR DESCRIPTION
## Summary
Some compilation problems were encountered when the cmake compilation tool was used locally to adapt the Matter compilation.
After the compilation is complete and verified, the nuttx related changes are collated and submitted.
## Impact

## Testing
risc-v32 and sim:local
