### PR TITLE
fs/inode: improve the performance of get file pointer

### DIFF
--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -1188,16 +1188,23 @@ static ssize_t proc_groupfd(FAR struct proc_file_s *procfile,
                             size_t buflen, off_t offset)
 {
   FAR struct task_group_s *group = tcb->group;
-  FAR struct file *file;
+  FAR struct file *filep;
   char path[PATH_MAX];
   size_t remaining;
   size_t linesize;
   size_t copysize;
   size_t totalsize;
+  int count;
+  int ret;
   int i;
-  int j;
 
   DEBUGASSERT(group != NULL);
+
+  count = files_countlist(&group->tg_filelist);
+  if (count == 0)
+    {
+      return 0;
+    }
 
   remaining = buflen;
   totalsize = 0;
@@ -1219,41 +1226,34 @@ static ssize_t proc_groupfd(FAR struct proc_file_s *procfile,
 
   /* Examine each open file descriptor */
 
-  for (i = 0; i < group->tg_filelist.fl_rows; i++)
+  for (i = 0; i < count; i++)
     {
-      for (j = 0, file = group->tg_filelist.fl_files[i];
-           j < CONFIG_NFILE_DESCRIPTORS_PER_BLOCK;
-           j++, file++)
+      ret = fs_getfilep(i, &filep);
+      if (ret != OK || filep == NULL)
         {
-          /* Is there an inode associated with the file descriptor? */
+          continue;
+        }
 
-          if (file->f_inode == NULL)
-            {
-              continue;
-            }
+      if (file_ioctl(filep, FIOC_FILEPATH, path) < 0)
+        {
+          path[0] = '\0';
+        }
 
-          if (file_ioctl(file, FIOC_FILEPATH, path) < 0)
-            {
-              path[0] = '\0';
-            }
+      linesize   = procfs_snprintf(procfile->line, STATUS_LINELEN,
+                                   "%-3d %-7d %-4x %-9ld %s\n",
+                                   i, filep->f_oflags,
+                                   INODE_GET_TYPE(filep->f_inode),
+                                   (long)filep->f_pos, path);
+      copysize   = procfs_memcpy(procfile->line, linesize,
+                                 buffer, remaining, &offset);
 
-          linesize   = procfs_snprintf(procfile->line, STATUS_LINELEN,
-                                       "%-3d %-7d %-4x %-9ld %s\n",
-                                       i * CONFIG_NFILE_DESCRIPTORS_PER_BLOCK
-                                       + j, file->f_oflags,
-                                       INODE_GET_TYPE(file->f_inode),
-                                       (long)file->f_pos, path);
-          copysize   = procfs_memcpy(procfile->line, linesize,
-                                     buffer, remaining, &offset);
+      totalsize += copysize;
+      buffer    += copysize;
+      remaining -= copysize;
 
-          totalsize += copysize;
-          buffer    += copysize;
-          remaining -= copysize;
-
-          if (totalsize >= buflen)
-            {
-              return totalsize;
-            }
+      if (totalsize >= buflen)
+        {
+          return totalsize;
         }
     }
 

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -853,6 +853,19 @@ void files_initlist(FAR struct filelist *list);
 void files_releaselist(FAR struct filelist *list);
 
 /****************************************************************************
+ * Name: files_countlist
+ *
+ * Description:
+ *   Get file count from file list
+ *
+ * Returned Value:
+ *   file count of file list
+ *
+ ****************************************************************************/
+
+int files_countlist(FAR struct filelist *list);
+
+/****************************************************************************
  * Name: files_duplist
  *
  * Description:

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -37,6 +37,7 @@
 
 #include <nuttx/mutex.h>
 #include <nuttx/semaphore.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/mm/map.h>
 
 /****************************************************************************
@@ -478,7 +479,7 @@ struct file
 
 struct filelist
 {
-  mutex_t           fl_lock;    /* Manage access to the file list */
+  spinlock_t        fl_lock;    /* Manage access to the file list */
   uint8_t           fl_rows;    /* The number of rows of fl_files array */
   FAR struct file **fl_files;   /* The pointer of two layer file descriptors array */
 };

--- a/include/nuttx/spinlock.h
+++ b/include/nuttx/spinlock.h
@@ -32,12 +32,21 @@
 
 #include <nuttx/irq.h>
 
-#ifdef CONFIG_RW_SPINLOCK
-#include <stdatomic.h>
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+#if defined(CONFIG_RW_SPINLOCK) && !defined(__cplusplus)
+#  include <stdatomic.h>
 typedef atomic_int rwlock_t;
-#define RW_SP_UNLOCKED      0
-#define RW_SP_READ_LOCKED   1
-#define RW_SP_WRITE_LOCKED -1
+#  define RW_SP_UNLOCKED      0
+#  define RW_SP_READ_LOCKED   1
+#  define RW_SP_WRITE_LOCKED -1
 #endif
 
 #ifndef CONFIG_SPINLOCK
@@ -500,7 +509,7 @@ void spin_unlock_irqrestore_wo_note(FAR spinlock_t *lock, irqstate_t flags);
 #  define spin_unlock_irqrestore_wo_note(l, f) up_irq_restore(f)
 #endif
 
-#ifdef CONFIG_RW_SPINLOCK
+#if defined(CONFIG_RW_SPINLOCK) && !defined(__cplusplus)
 
 /****************************************************************************
  * Name: rwlock_init
@@ -808,5 +817,11 @@ void write_unlock_irqrestore(FAR rwlock_t *lock, irqstate_t flags);
 #  define write_unlock_irqrestore(l, f) up_irq_restore(f)
 #endif
 
-#endif /* CONFIG_RW_SPINLOCK */
+#endif /* CONFIG_RW_SPINLOCK && !__cplusplus */
+
+#undef EXTERN
+#if defined(__cplusplus)
+}
+#endif
+
 #endif /* __INCLUDE_NUTTX_SPINLOCK_H */


### PR DESCRIPTION
## Summary

1. fs/inode: improve the performance of get file pointer

Remove file locks and enter critical sections to protect file lists

Signed-off-by: chao an <anchao@xiaomi.com>

2. fs/inode: minor change to save the code size

```
Before:
   text    data     bss     dec     hex filename
 360641    7889    4064  372594   5af72 nuttx

After:
   text    data     bss     dec     hex filename
 360313    7889    4064  372266   5ae2a nuttx
```

Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

ci-check