### PR TITLE
Documentation: migrate more wiki pages 

### DIFF
--- a/Documentation/guides/index.rst
+++ b/Documentation/guides/index.rst
@@ -27,3 +27,4 @@ Guides
   testingtcpip.rst
   automounter.rst
   stm32nullpointer.rst
+  stm32ccm.rst

--- a/Documentation/guides/index.rst
+++ b/Documentation/guides/index.rst
@@ -26,3 +26,4 @@ Guides
   ofloader.rst
   testingtcpip.rst
   automounter.rst
+  stm32nullpointer.rst

--- a/Documentation/guides/stm32ccm.rst
+++ b/Documentation/guides/stm32ccm.rst
@@ -1,0 +1,108 @@
+===================
+STM32 CCM Allocator
+===================
+
+CCM Memory
+==========
+
+The STM32 F2, F3, and F4 families have a special block of SRAM available called
+CCM (Core Coupled Memory). This memory has the drawback that it cannot be used
+for STM32 DMA operations.
+
+By default, the CCM memory is lumped in with the rest of memory when the NuttX
+heaps are created. But this can be a problem because it will be a toss of the
+coin if non-DMA-able CCM memory or other DMA-able memory gets returned when
+``malloc()`` is called. That usually does not matter but it certainly does make
+a difference if you are allocating memory that will be used for DMA! In that
+case, getting CCM memory for your DMA buffer will cause a failure.
+
+CONFIG_STM32_CCMEXCLUDE
+=======================
+
+There is a configuration option called ``CONFIG_STM32_CCMEXCLUDE`` that can be
+used to exclude CCM memory from the heap. That solves the problem of getting
+CCM memory when you want to allocate a DMA buffer. But then what do you do
+with the CCM memory? Do you let it go unused?
+
+CCM Allocator
+=============
+
+In order to make use of the CCM memory, a CCM memory allocator is available.
+This memory allocator is automatically enabled when the following options are set:
+
+* ``CONFIG_STM32_CCMEXCLUDE`` CCM memory is excluded from the normal heap, and
+* ``CONFIG_MM_MULTIHEAP`` Support for multiple heaps is enabled.
+
+Under those conditions, the CCM memory allocator is enabled and the allocator
+interfaces prototyped in the ``arch/arm/src/stm32/stm32_ccm.h`` are available.
+
+NOTE: These interfaces are, technically, not prototyped since they are really
+provided via C pre-processor macros.
+
+NOTE: In order to use the CCM memory allocator functions, you must first call
+``ccm_initialize()`` somwhere in your early boot-up logic.
+
+With these interfaces you have a (nearly) standard way to manage memory from a
+heap that consists of the the CCM SRAM. And, since the CCM memory is no longer
+a part of the normal heap, all allocated I/O buffers will be DMA-able (unless you
+have included other non-DMA-able memory regions in the stack).
+
+CCM Stacks
+==========
+
+One particular problem that has been reported by Petteri Aimonen requires some
+additional work-arounds. The STM32 SPI driver supports DMA and with SPI it is
+sometimes necessary to do some very small transfers for which there is no real
+gain from using DMA. In this case, Petteri has devised a clever way to both 1) make
+use of the CMM memory and 2) to force fallback to non-DMA transfers for these small
+stack transfers.
+
+Here is what Petteri has done:
+
+#. First, he has modified ``arch/arm/src/common/up_createstack.c`` and
+   ``up_releasestack.c`` so that stacks are allocated from CCM memory. That
+   allocation is something like the following:
+
+   .. code-block:: C
+
+      void *result = ccm_zalloc(size);
+      if (!result)
+        {
+         /* Fall back to main heap */
+          result = zalloc(size);
+        }
+
+   With the matching:
+
+   .. code-block:: C
+
+      if (((uint32_t)p & 0xF0000000) == 0x10000000)
+        {
+          ccm_free(p);
+        }
+      else
+        {
+          free(p);
+        }
+
+#. Then Petteri added special DMA support enabled with ``CONFIG_STM32_DMACAPABLE``.
+   That option enables an option in all of the DMA logic called:
+
+   .. code-block:: C
+
+      bool stm32_dmacapable(uint32_t maddr);
+
+   That will return true if it is possible to do DMA from the address and false
+   if not.
+
+#. Finally, Petteri added logic to the STM32 SPI driver that use ``stm32_dmacapable()``:
+   If the address is not DMA capable, then the SPI driver will fall back to
+   non-DMA operation.
+
+   With Petteri's changes all of the large I/O buffers will be allocated from
+   DMA-able memory. All stacks will be allocated from non-DMA-able CCM memory
+   (provided that there is space). Small SPI DMA buffers on the non-DMA-able stack
+   will be detected by ``stm32_dmacapable()`` and in that case, the STM32 SPI driver
+   will fall back and use non-DMA-transfers.
+
+   From all reports this works quite well.

--- a/Documentation/guides/stm32nullpointer.rst
+++ b/Documentation/guides/stm32nullpointer.rst
@@ -1,0 +1,70 @@
+============================
+STM32 Null Pointer Detection
+============================
+
+The NULL Pointer Problem
+========================
+
+A common cause of software bugs is null pointers. Pointers may be NULL if they
+are un-initialized and un-checked. The use of NULL pointers almost always results
+in something bad happening. Often, NULL pointer access can cause error exceptions
+and or diagnostic crashes. But on MCUs that have valid address decoding at address
+0x0000:0000, the use of NULL pointers may not cause a crash at all but may, instead,
+cause strange behaviors that can sometimes be difficult to debug.
+
+Cortex-M Memory
+===============
+
+The Cortex-M family (Cortex-M0, M3, and M4) are such MCUs. They have their
+interrupt vectors positioned at address zero. Because of this, NULL pointer
+accesses will not necessarily cause crashes. Instead, the NULL pointers will
+access memory in the vicinity of the vector table and who knows what will happen
+next?
+
+STM32 Memory Aliasing
+=====================
+
+The STMicro STM32 family of Cortex-M3/4 MCUs do things a little differently.
+FLASH is physically addressed at address 0x0800:0000; the STM32 vector table
+is then physically located at 0x0800:0000 instead of 0x0000:0000. If the STM32
+hardware is configured to boot from FLASH, then the the STM32 will remap the
+FLASH memory so that is aliased at address 0x0000:00000. In that way, the STM32
+can boot from FLASH or external memory or any other memory region that it is
+capable of mapping.
+
+In the NuttX linker scripts, the applications are linked to execute from the
+physical FLASH region at address 0x0800:0000. All valid FLASH memory access
+will then access memory in the 0x0800:0000 FLASH address range. But illegal
+NULL pointer access will access the aliased copy of FLASH beginning at 0x0000:0000.
+So we still have the problem.
+
+The Cortex-M Memory Protection Unit
+===================================
+
+The Memory Protection Unit (MPU) is an optional component of a Cortex-M implementation.
+Most popular Cortex-M3/4 MCUs do support the MPU. The MPU can be used to protect regions
+of memory so that if there is any attempted, unauthorized access to certain memory
+regions, then a memory protection violation exception will occur and the system will
+detect the illegal access.
+
+See the ARM website for more information about the Cortex-M3/4 families and the
+Cortex-M3/4 MPU. See, for example
+`2.2. Memory Protection Unit (MPU) <http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dai0179b/CHDFDFIG.html>`_.
+
+Using the MPU to Detect Null Pointer Usage
+==========================================
+
+So, for the STM32, one thing that we can do is to program the MPU to prohibit software
+access to the memory region beginning at address 0x0000:0000. Petteri Aimonen posted a code
+snippet on the NuttX Forum showing how to do this. Here is Petteri's post:
+
+.. code-block:: C
+
+   /* Catch any null pointer dereferences */
+
+   int region = 0;
+
+   putreg32(region, MPU_RNR);
+   putreg32(0, MPU_RBAR);
+   putreg32(MPU_RASR_ENABLE | MPU_RASR_SIZE_LOG2(20) | (0xFF << MPU_RASR_SRD_SHIFT) | MPU_RASR_AP_NONO, MPU_RASR);
+   mpu_control(true, false, true);

--- a/Documentation/implementation/bottomhalf_interrupt.rst
+++ b/Documentation/implementation/bottomhalf_interrupt.rst
@@ -1,0 +1,135 @@
+==============================
+Bottom-Half Interrupt Handlers
+==============================
+
+RTOS Interrupts
+===============
+
+A well-design RTOS depends on the most minimal of interrupt level processing.
+This is a very different concept that for bare metal programming:
+
+* With bare metal programming most of the real-time work is usually performed
+  in interrupt handlers. Interrupt handler execution may then extend in time
+  considerably due to this interrupt level processing.
+
+To compensate for this extended interrupt processing time, bare metal programmers
+also need prioritized interrupts:
+
+* If an interrupt request for a higher priority interrupt occurs during the
+  extended processing of the lower priority interrupt, then that interrupt handler
+  will itself be interrupted to service the higher priority interrupt requests.
+  In this way bare metal interrupt handling is nested.
+
+With an RTOS, the real-time strategy is very different:
+
+* Interrupts must run very, very briefly so that they do not interfere with the
+  RTOS real-time scheduling. Normally, the interrupt simply performs whatever
+  minor housekeeping is necessary and then immediately defers processing by waking up
+  some task via some Inter-Process Communication(IPC). The RTOS is then responsible for
+  the real-time behavior, not the interrupt. And,
+  
+* since the interrupts must be very brief, there is little or no gain from nesting of interrupts.
+
+Extending interrupt processing
+==============================
+
+But what if extended interrupt processing is required?
+What if there is a significant amount of hardware-related operations that absolutely
+must be performed as quickly as possible before we can turn processing over to
+general, real-time tasking?
+
+In NuttX, this is handled through a high priority trampoline called
+the "High Priority Work Queue". It is a trampoline because it changes the interrupt
+processing context for extended interrupt processing before notifying the normal
+real-time task.
+
+Processing on that ultra-high priority work thread then completes the extended
+interrupt processing with interrupts enabled, but without interference from any
+other real-time tasks.
+
+At the completion of the extended processing, the high priority worker thread can
+then continue processing via some IPC to a normal real-time task.
+
+The portion of interrupt processing that is performed in the interrupt handler with
+interrupts disabled is referred to as Top Half Interrupt processing; the portion of
+interrupt processing that is performed on the high priority work queue with interrupts
+enabled is referred to as Bottom Half Interrupt processing.
+
+High Priority Work Queue
+========================
+
+NuttX supports a high priority work queue as well as a low priority work queue with
+somewhat different properties.
+The high priority work queue is dedicated to the support of Bottom Half Interrupt
+processing.
+Other uses of the high priority work queue may be inappropriate and may harm the
+real-time performance of your system.
+
+The high priority work queue must have these properties:
+
+* **Highest Priority** The high priority work queue must be the highest priority
+  task in your system. No other task should execute at a higher priority; No other
+  task can be permitted to interfere with execution of the high priority work queue.
+
+* **Zero Latency Context Switches** Provided that the priority of the high priority
+  work queue is the highest in the system, then there will be no context switch
+  overhead in getting from the Top Half Interrupt processing to the Bottom Half
+  Interrupt processing other that the normal overhead of returning from an interrupt.
+  Upon return from the interrupt, the system will immediately vector to high priority
+  worker thread.
+
+* **Brief Processing** Processing on the high priority work queue must still be brief.
+  If there is high priority work in progress when the high priority worker is signaled,
+  then that processing will be queued and delayed until it can be processed. That delay
+  will add jitter to your real-time response. You must not generate a backlog of work
+  for the high priority worker thread!
+
+* **No Waiting** Work executing on the high priority work queue must not wait for
+  resources or events on the high priority worker thread. Waiting on the high priority
+  work queue blocks the queue and will, again, damage real-time performance.
+
+Setting Up Bottom Half Interrupt Processing
+===========================================
+
+Bottom half interrupt processing is scheduled by top half interrupt processing by
+simply calling the function ``work_queue()``:
+
+.. code-block:: C
+
+   int work_queue(int qid, FAR struct work_s *work, worker_t worker,
+                  FAR void *arg, clock_t delay);
+
+This same interface is the same for both high- and low-priority.
+The qid argument distinguishes which work queue will be used. For bottom half
+interrupt processing, ``qid`` must be set to ``HPWORK``.
+
+The work argument is memory that will be used to actually queue the work.
+It has no meaning to the caller; it is simply a memory allocation by the caller.
+Otherwise, the work structure is completely managed by the work queue logic.
+The caller should never modify the contents of the work queue structure directly.
+If ``work_queue()`` is called before the previous work as been performed and removed
+from the queue, then any pending work will be canceled and lost.
+The ``work_available()`` function can be called to determine if the work represented
+by the work structure is still in-use.
+
+For the interrupt handling case at hand, the work structure must be pre-allocated
+or statically allocated since dynamic allocations are not supported from the
+interrupt handling context.
+
+The ``worker`` is the name of the function that will perform the bottom half interrupt
+work.
+``arg`` is an arbitrary value that the user provides and will be given to the worker
+function when it executes.
+Normally ``arg`` produces some context in which the work will be performed.
+The type of the worker function is given by:
+
+.. code-block:: C
+
+   typedef CODE void (*worker_t)(FAR void *arg);
+
+Where ``arg`` has the same value as was passed to ``work_queue()``.
+
+Processing or work can be delayed in time.
+The ``work_queue()`` ``delay`` argument provides that time delay in units of system
+clock ticks. However, when used to provide bottom half interrupt processing, the
+delay should always be zero.

--- a/Documentation/implementation/index.rst
+++ b/Documentation/implementation/index.rst
@@ -10,3 +10,4 @@ Implementation Details
    critical_sections.rst
    interrupt_controls.rst
    preemption_latency.rst
+   bottomhalf_interrupt.rst

--- a/Documentation/reference/os/index.rst
+++ b/Documentation/reference/os/index.rst
@@ -26,3 +26,4 @@ in other header files.
   smp.rst
   time_clock.rst
   wqueue.rst
+  netdev.rst


### PR DESCRIPTION
## Summary
- Documentation: migrate "STM32 Null Pointer Detection" from wiki 
- Documentation: migrate "STM32 CCM Allocator" from wiki
- Documentation: fix warning
- Documentation: migrate "Bottom-Half Interrupt Handlers" from wiki

## Impact

## Testing
local
