### PR TITLE
simwifi: Fix a compile error.

### DIFF
--- a/arch/sim/src/sim/sim_wifidriver.c
+++ b/arch/sim/src/sim/sim_wifidriver.c
@@ -566,7 +566,7 @@ static size_t wpa_ssid_decode(uint8_t *buf, size_t maxlen, const char *str)
                     val = hex2byte(pos);
                     if (val < 0)
                       {
-                        val = hex2num(*pos);
+                        val = hex2nibble(*pos);
                         if (val < 0)
                             break;
                         buf[len++] = val;


### PR DESCRIPTION


## Summary
Fix a compilation error, as follows：
sim/sim_wifidriver.c:569:31: warning: implicit declaration of function ‘hex2num’ [-Wimplicit-function-declaration]
  569 |                         val = hex2num(*pos);
      |                               ^~~~~~~
## Impact
N/A
## Testing
The SIM-WiFi can be compiled seccessfully.
