### PR TITLE
sama5d2-xult: add support for QSPI flash and nxffs

### DIFF
--- a/boards/arm/sama5/sama5d2-xult/Kconfig
+++ b/boards/arm/sama5/sama5d2-xult/Kconfig
@@ -127,4 +127,18 @@ config SAMA5_SDMMC1_WIDTH_D1_D4
 	default y
 	depends on SAMA5_SDMMC1
 
+config SAMA5_QSPI0_SIZE
+	int "QSPI0 memory size in bytes"
+	default 1073741824
+	depends on SAMA5_QSPI0
+	---help---
+		Size of QSPI0 memory mapped area in bytes. Default: 1GB
+
+config SAMA5_QSPI1_SIZE
+	int "QSPI1 memory size in bytes"
+	default 1073741824
+	depends on SAMA5_QSPI1
+	---help---
+		Size of QSPI1 memory mapped area in bytes. Default: 1GB
+
 endif # ARCH_BOARD_SAMA5D2_XULT

--- a/boards/arm/sama5/sama5d2-xult/src/sama5d2-xult.h
+++ b/boards/arm/sama5/sama5d2-xult/src/sama5d2-xult.h
@@ -42,13 +42,15 @@
 
 /* Configuration ************************************************************/
 
-#define HAVE_SDMMC      1
-#define HAVE_AT25       1
-#define HAVE_NAND       1
-#define HAVE_USBHOST    1
-#define HAVE_USBDEV     1
-#define HAVE_USBMONITOR 1
-#define HAVE_NETWORK    1
+#define HAVE_SDMMC         1
+#define HAVE_AT25          1
+#define HAVE_NAND          1
+#define HAVE_USBHOST       1
+#define HAVE_USBDEV        1
+#define HAVE_USBMONITOR    1
+#define HAVE_NETWORK       1
+#define HAVE_MX25RXX       1
+#define HAVE_MX25RXX_NXFFS 1
 
 /* SDMMC */
 
@@ -167,6 +169,17 @@
 
 #ifdef HAVE_AT25
 #  define AT25_MINOR  _AT25_MINOR
+#endif
+
+/* MX25RXX QuadSPI flash */
+
+#if !defined(CONFIG_MTD_MX25RXX) || !defined(CONFIG_SAMA5_QSPI0)
+#  undef HAVE_MX25RXX
+#  undef HAVE_MX25RXX_NXFFS
+#endif
+
+#ifndef CONFIG_FS_NXFFS
+#  undef HAVE_MX25RXX_NXFFS
 #endif
 
 /* MMC/SD minor numbers:  The NSH device minor extended is extended to


### PR DESCRIPTION
## Summary
add support for onboard qspi flash with nxffs
depends on #11150 for qspi support

## Impact
sama5d2-xult board qspi flash can be used as filesystem.

## Testing
Tested on xult board.
