### PR TITLE
boards/esp32s3: Link stack checking function and data to SRAM when enable flash or PSRAM driver

### DIFF
--- a/boards/xtensa/esp32s3/common/scripts/legacy_sections.ld
+++ b/boards/xtensa/esp32s3/common/scripts/legacy_sections.ld
@@ -131,6 +131,12 @@ SECTIONS
 #ifdef CONFIG_ESP32S3_SPIRAM_MODE_OCT
     *libarch.a:esp32s3_psram_octal.*(.literal .text .literal.* .text.*)
 #endif
+#if defined(CONFIG_STACK_CANARIES) && \
+    (defined(CONFIG_ESP32S3_SPIFLASH) || \
+     defined(CONFIG_ESP32S3_SPIRAM))
+    *libc.a:lib_stackchk.*(.literal .text .literal.* .text.*)
+#endif
+
     *(.wifirxiram .wifirxiram.*)
     *(.wifi0iram  .wifi0iram.*)
     *(.wifiorslpiram .wifiorslpiram.*)
@@ -214,6 +220,11 @@ SECTIONS
 
     *libphy.a:(.rodata  .rodata.*)
     *libarch.a:xtensa_context.*(.rodata  .rodata.*)
+#if defined(CONFIG_STACK_CANARIES) && \
+    (defined(CONFIG_ESP32S3_SPIFLASH) || \
+     defined(CONFIG_ESP32S3_SPIRAM))
+    *libc.a:lib_stackchk.*(.rodata  .rodata.*)
+#endif
 
     _edata = ABSOLUTE(.);
     . = ALIGN(4);


### PR DESCRIPTION
## Summary

This PR intends to fix the PSRAM support on ESP32S3 when Stack Smash Protection is enabled (CONFIG_STACK_CANARIES=1).

During PSRAM initialization and flash operations, the Cache needs to be disabled, so all data and code for the aforementioned scope is required to be placed in Internal RAM (DRAM and IRAM regions).

## Impact

Only for PSRAM-enabled configurations on ESP32S3.

## Testing

- Successful execution of `ramtest` in `esp32s3-devkit:psram_octal` with `CONFIG_STACK_CANARIES=1`
