### PR TITLE
xtensa/esp32s3: Support multiple PHY init data bin

### DIFF
--- a/arch/xtensa/src/esp32s3/Kconfig
+++ b/arch/xtensa/src/esp32s3/Kconfig
@@ -1448,6 +1448,62 @@ config ESP32S3_BLE_INTERRUPT_SAVE_STATUS
 
 endmenu # BLE Configuration
 
+menu "PHY"
+	depends on ESP32S3_PARTITION_TABLE
+
+menuconfig ESP32S3_PHY_INIT_DATA_IN_PARTITION
+	bool "Use a partition to store PHY init data"
+	default n
+	---help---
+		If enabled, PHY init data will be loaded from a partition. Otherwise,
+		PHY init data will be embedded into the application binary.
+
+		When using a custom partition table, make sure that the PHY data
+		partition is included (type: 'data', subtype: 'phy').
+
+		If PHY init data is stored in a partition, it has to be flashed there,
+		otherwise runtime error will occur.
+
+config ESP32S3_PHY_DEFAULT_INIT_IF_INVALID
+	bool "Reset default PHY init data if invalid"
+	default n
+	depends on ESP32S3_PHY_INIT_DATA_IN_PARTITION
+	---help---
+		If enabled, PHY init data will be restored to default if
+		it cannot be verified successfully to avoid endless bootloops.
+
+		If unsure, choose 'n'.
+
+if ESP32S3_PHY_INIT_DATA_IN_PARTITION
+
+config ESP32S3_SUPPORT_MULTIPLE_PHY_INIT_DATA
+	bool "Support multiple PHY init data bin"
+	depends on ESP32S3_PHY_INIT_DATA_IN_PARTITION
+	default n
+	---help---
+		If enabled, the corresponding PHY init data type can be automatically switched
+		according to the country code. China's PHY init data bin is used by default.
+		Can be modified by country information in API esp_wifi_set_country().
+		The priority of switching the PHY init data type is:
+		1. Country configured by API esp_wifi_set_country()
+		and the parameter policy is WIFI_COUNTRY_POLICY_MANUAL.
+		2. Country notified by the connected AP.
+		3. Country configured by API esp_wifi_set_country()
+		and the parameter policy is WIFI_COUNTRY_POLICY_AUTO.
+
+config ESP32S3_PHY_INIT_DATA_ERROR
+	bool "Terminate operation when PHY init data error"
+	depends on ESP32S3_SUPPORT_MULTIPLE_PHY_INIT_DATA
+	default n
+	---help---
+		If enabled, when an error occurs while the PHY init data is updated,
+		the program will terminate and restart.
+		If not enabled, the PHY init data will not be updated when an error occurs.
+
+endif
+
+endmenu  # PHY
+
 menu "Timer/Counter Configuration"
 	depends on ESP32S3_TIMER
 
@@ -1667,7 +1723,7 @@ comment "Partition Table configuration"
 config ESP32S3_PARTITION_TABLE
 	bool "Create MTD partitions from Partition Table"
 	default n
-	depends on ESP32S3_MTD
+	depends on ESP32S3_MTD && ESP32S3_BOOTLOADER_BUILD_FROM_SOURCE
 	---help---
 		Decode partition table and initialize partitions as MTD.
 

--- a/arch/xtensa/src/esp32s3/Kconfig
+++ b/arch/xtensa/src/esp32s3/Kconfig
@@ -1660,6 +1660,24 @@ config ESP32S3_SPIFLASH_OP_TASK_STACKSIZE
 		to disable non-IRAM interrupts and wait for the SPI flash operation
 		to be finished.
 
+if ESP32S3_APP_FORMAT_LEGACY
+
+comment "Partition Table configuration"
+
+config ESP32S3_PARTITION_TABLE
+	bool "Create MTD partitions from Partition Table"
+	default n
+	depends on ESP32S3_MTD
+	---help---
+		Decode partition table and initialize partitions as MTD.
+
+config ESP32S3_PARTITION_MOUNTPT
+	string "Partition mount point"
+	default "/dev/esp/partition/"
+	depends on ESP32S3_PARTITION_TABLE
+
+endif # ESP32S3_APP_FORMAT_LEGACY
+
 endif # ESP32S3_SPIFLASH
 
 endmenu # SPI Flash configuration

--- a/arch/xtensa/src/esp32s3/Make.defs
+++ b/arch/xtensa/src/esp32s3/Make.defs
@@ -132,6 +132,10 @@ CHIP_CSRCS += esp32s3_spiflash_mtd.c
 endif
 endif
 
+ifeq ($(CONFIG_ESP32S3_PARTITION_TABLE),y)
+CHIP_CSRCS += esp32s3_partition.c
+endif
+
 ifeq ($(CONFIG_ESP32S3_SPIRAM),y)
 CHIP_CSRCS += esp32s3_spiram.c
 

--- a/arch/xtensa/src/esp32s3/esp32s3_partition.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_partition.c
@@ -1,0 +1,836 @@
+/****************************************************************************
+ * arch/xtensa/src/esp32s3/esp32s3_partition.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <stdint.h>
+#include <string.h>
+#include <debug.h>
+#include <stdio.h>
+#include <errno.h>
+
+#include <nuttx/kmalloc.h>
+
+#include "esp32s3_spiflash_mtd.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Partition table max size */
+
+#define PARTITION_MAX_SIZE    (0xc00)
+
+/* Partition max number */
+
+#define PARTITION_MAX_NUM     (PARTITION_MAX_SIZE / \
+                               sizeof(struct partition_info_priv_s))
+
+/* Partition table header magic value */
+
+#define PARTITION_MAGIC       (0x50aa)
+
+/* Partition table member label length */
+
+#define PARTITION_LABEL_LEN   (16)
+
+/* OTA data offset in OTA partition */
+
+#define OTA_DATA_OFFSET       (4096)
+
+/* OTA data number */
+
+#define OTA_DATA_NUM          (2)
+
+/* Partition offset in SPI Flash */
+
+#define PARTITION_TABLE_OFFSET CONFIG_ESP32S3_PARTITION_TABLE_OFFSET
+
+/* Partition MTD device mount point */
+
+#define PARTITION_MOUNT_POINT CONFIG_ESP32S3_PARTITION_MOUNTPT
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/* OTA image operation code */
+
+enum ota_img_ctrl_e
+{
+  OTA_IMG_GET_BOOT        = 0xe1,
+  OTA_IMG_SET_BOOT        = 0xe2
+};
+
+/* OTA image state */
+
+enum ota_img_state_e
+{
+  /**
+   *  Monitor the first boot. In bootloader of esp-idf this state is changed
+   *  to ESP_OTA_IMG_PENDING_VERIFY if this bootloader enable app rollback.
+   *
+   *  So this driver doesn't use this state currently.
+   */
+
+  OTA_IMG_NEW             = 0x0,
+
+  /**
+   * First boot for this app was. If while the second boot this state is then
+   * it will be changed to ABORTED if this bootloader enable app rollback.
+   *
+   * So this driver doesn't use this state currently.
+   */
+
+  OTA_IMG_PENDING_VERIFY  = 0x1,
+
+  /* App was confirmed as workable. App can boot and work without limits. */
+
+  OTA_IMG_VALID           = 0x2,
+
+  /* App was confirmed as non-workable. This app will not selected to boot. */
+
+  OTA_IMG_INVALID         = 0x3,
+
+  /**
+   * App could not confirm the workable or non-workable. In bootloader
+   * IMG_PENDING_VERIFY state will be changed to IMG_ABORTED. This app will
+   * not selected to boot at all if this bootloader enable app rollback.
+   *
+   * So this driver doesn't use this state currently.
+   */
+
+  OTA_IMG_ABORTED         = 0x4,
+
+  /**
+   * Undefined. App can boot and work without limits in esp-idf.
+   *
+   * This state is not used.
+   */
+
+  OTA_IMG_UNDEFINED       = 0xffffffff,
+};
+
+/* OTA image boot sequency */
+
+enum ota_img_bootseq_e
+{
+  OTA_IMG_BOOT_FACTORY    = 0,
+  OTA_IMG_BOOT_OTA_0      = 1,
+  OTA_IMG_BOOT_OTA_1      = 2,
+  OTA_IMG_BOOT_SEQ_MAX
+};
+
+/* Partition information data */
+
+struct partition_info_priv_s
+{
+  uint16_t magic;                       /* Partition magic */
+  uint8_t  type;                        /* Partition type */
+  uint8_t  subtype;                     /* Partition sub-type */
+
+  uint32_t offset;                      /* Offset in SPI Flash */
+  uint32_t size;                        /* Size by byte */
+
+  uint8_t  label[PARTITION_LABEL_LEN];  /* Partition label */
+
+  uint32_t flags;                       /* Partition flags */
+};
+
+/* Partition device data */
+
+struct mtd_dev_priv_s
+{
+  struct mtd_dev_s mtd;                 /* MTD data */
+
+  uint8_t  type;                        /* Partition type */
+  uint8_t  subtype;                     /* Partition sub-type */
+  uint32_t flags;                       /* Partition flags */
+
+  struct mtd_dev_s  *ll_mtd;            /* Low-level MTD data */
+  struct mtd_dev_s  *part_mtd;          /* Partition MTD data */
+};
+
+/* OTA data entry */
+
+struct ota_data_entry_s
+{
+  uint32_t ota_seq;                     /* Boot sequence */
+  uint8_t  seq_label[20];               /* Boot sequence label */
+  uint32_t ota_state;                   /* Boot entry state */
+  uint32_t crc;                         /* Boot ota_seq CRC32 */
+};
+
+/****************************************************************************
+ * External Function Prototypes
+ ****************************************************************************/
+
+extern uint32_t crc32_le(uint32_t crc, uint8_t const *buf, uint32_t len);
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: ota_is_valid
+ *
+ * Description:
+ *   Check if OTA data is valid
+ *
+ * Input Parameters:
+ *   ota_data - OTA data
+ *
+ * Returned Value:
+ *   true if checking success or false if fail
+ *
+ ****************************************************************************/
+
+static bool ota_is_valid(struct ota_data_entry_s *ota_data)
+{
+  if ((ota_data->ota_seq >= OTA_IMG_BOOT_SEQ_MAX) ||
+      (ota_data->ota_state != OTA_IMG_VALID) ||
+      (ota_data->crc != crc32_le(UINT32_MAX, (uint8_t *)ota_data, 4)))
+    {
+      return false;
+    }
+
+  return true;
+}
+
+/****************************************************************************
+ * Name: ota_get_bootseq
+ *
+ * Description:
+ *   Get boot sequence
+ *
+ * Input Parameters:
+ *   dev - Partition private MTD data
+ *   num - boot sequence buffer
+ *
+ * Returned Value:
+ *   0 if success or a negative value if fail.
+ *
+ ****************************************************************************/
+
+static int ota_get_bootseq(struct mtd_dev_priv_s *dev, int *num)
+{
+  int i;
+  int ret;
+  struct ota_data_entry_s ota_data;
+  int size = sizeof(struct ota_data_entry_s);
+
+  /* Each OTA data locates in independent sector */
+
+  for (i = 0; i < OTA_DATA_NUM; i++)
+    {
+      ret = MTD_READ(dev->part_mtd, i * OTA_DATA_OFFSET,
+                     size, (uint8_t *)&ota_data);
+      if (ret != size)
+        {
+          ferr("ERROR: Failed to read OTA%d data error=%d\n", i, ret);
+          return -EIO;
+        }
+
+      if (ota_is_valid(&ota_data))
+        {
+          *num = i + OTA_IMG_BOOT_OTA_0;
+          break;
+        }
+    }
+
+  if (i >= 2)
+    {
+      *num = OTA_IMG_BOOT_FACTORY;
+    }
+
+  return 0;
+}
+
+/****************************************************************************
+ * Name: ota_set_bootseq
+ *
+ * Description:
+ *   Set boot sequence
+ *
+ * Input Parameters:
+ *   dev - Partition private MTD data
+ *   num - boot sequence buffer
+ *
+ * Returned Value:
+ *   0 if success or a negative value if fail.
+ *
+ ****************************************************************************/
+
+static int ota_set_bootseq(struct mtd_dev_priv_s *dev, int num)
+{
+  int ret;
+  int id;
+  int old_id;
+  struct ota_data_entry_s ota_data;
+  int size = sizeof(struct ota_data_entry_s);
+
+  finfo("INFO: num=%d\n", num);
+
+  switch (num)
+    {
+      case OTA_IMG_BOOT_FACTORY:
+
+        /* Erase all OTA data to force use factory app */
+
+        ret = MTD_ERASE(dev->part_mtd, 0, OTA_DATA_NUM);
+        if (ret != OTA_DATA_NUM)
+          {
+            ferr("ERROR: Failed to erase OTA data error=%d\n", ret);
+            return -EIO;
+          }
+
+        break;
+      case OTA_IMG_BOOT_OTA_0:
+      case OTA_IMG_BOOT_OTA_1:
+        {
+          id = num - 1;
+          old_id = num == OTA_IMG_BOOT_OTA_0 ? OTA_IMG_BOOT_OTA_1 - 1:
+                                               OTA_IMG_BOOT_OTA_0 - 1;
+
+          ret = MTD_ERASE(dev->part_mtd, id, 1);
+          if (ret != 1)
+            {
+              ferr("ERROR: Failed to erase OTA%d data error=%d\n", id, ret);
+              return -EIO;
+            }
+
+          ota_data.ota_state = OTA_IMG_VALID;
+          ota_data.ota_seq = num;
+          ota_data.crc = crc32_le(UINT32_MAX, (uint8_t *)&ota_data, 4);
+          ret = MTD_WRITE(dev->part_mtd, id * OTA_DATA_OFFSET,
+                          size, (uint8_t *)&ota_data);
+          if (ret != size)
+            {
+              ferr("ERROR: Failed to write OTA%d data error=%d\n",
+                   id, ret);
+              return -1;
+            }
+
+          /* Erase old OTA data to force new OTA bin */
+
+          ret = MTD_ERASE(dev->part_mtd, old_id, 1);
+          if (ret != 1)
+            {
+              ferr("ERROR: Failed to erase OTA%d data error=%d\n",
+                   old_id, ret);
+              return -EIO;
+            }
+        }
+
+        break;
+      default:
+        ferr("ERROR: num=%d is error\n", num);
+        return -EINVAL;
+    }
+
+    return 0;
+}
+
+/****************************************************************************
+ * Name: esp32s3_part_erase
+ *
+ * Description:
+ *   Erase SPI Flash designated sectors.
+ *
+ * Input Parameters:
+ *   dev        - ESP32-S3 MTD device data
+ *   startblock - start block number, it is not equal to SPI Flash's block
+ *   nblocks    - blocks number
+ *
+ * Returned Value:
+ *   0 if success or a negative value if fail.
+ *
+ ****************************************************************************/
+
+static int esp32s3_part_erase(struct mtd_dev_s *dev, off_t startblock,
+                              size_t nblocks)
+{
+  struct mtd_dev_priv_s *mtd_priv = (struct mtd_dev_priv_s *)dev;
+
+  return MTD_ERASE(mtd_priv->ll_mtd, startblock, nblocks);
+}
+
+/****************************************************************************
+ * Name: esp32s3_part_read
+ *
+ * Description:
+ *   Read data from SPI Flash at designated address.
+ *
+ * Input Parameters:
+ *   dev    - ESP32-S3 MTD device data
+ *   offset - target address offset
+ *   nbytes - data number
+ *   buffer - data buffer pointer
+ *
+ * Returned Value:
+ *   Read data bytes if success or a negative value if fail.
+ *
+ ****************************************************************************/
+
+static ssize_t esp32s3_part_read(struct mtd_dev_s *dev, off_t offset,
+                                 size_t nbytes, uint8_t *buffer)
+{
+  struct mtd_dev_priv_s *mtd_priv = (struct mtd_dev_priv_s *)dev;
+
+  return MTD_READ(mtd_priv->ll_mtd, offset, nbytes, buffer);
+}
+
+/****************************************************************************
+ * Name: esp32s3_part_bread
+ *
+ * Description:
+ *   Read data from designated blocks.
+ *
+ * Input Parameters:
+ *   dev        - ESP32-S3 MTD device data
+ *   startblock - start block number, it is not equal to SPI Flash's block
+ *   nblocks    - blocks number
+ *   buffer     - data buffer pointer
+ *
+ * Returned Value:
+ *   Read block number if success or a negative value if fail.
+ *
+ ****************************************************************************/
+
+static ssize_t esp32s3_part_bread(struct mtd_dev_s *dev,  off_t startblock,
+                                  size_t nblocks, uint8_t *buffer)
+{
+  struct mtd_dev_priv_s *mtd_priv = (struct mtd_dev_priv_s *)dev;
+
+  return MTD_BREAD(mtd_priv->ll_mtd, startblock, nblocks, buffer);
+}
+
+/****************************************************************************
+ * Name: esp32s3_part_write
+ *
+ * Description:
+ *   write data to SPI Flash at designated address.
+ *
+ * Input Parameters:
+ *   dev    - ESP32-S3 MTD device data
+ *   offset - target address offset
+ *   nbytes - data number
+ *   buffer - data buffer pointer
+ *
+ * Returned Value:
+ *   Written bytes if success or a negative value if fail.
+ *
+ ****************************************************************************/
+
+static ssize_t esp32s3_part_write(struct mtd_dev_s *dev, off_t offset,
+                                  size_t nbytes, const uint8_t *buffer)
+{
+  struct mtd_dev_priv_s *mtd_priv = (struct mtd_dev_priv_s *)dev;
+
+  return MTD_WRITE(mtd_priv->ll_mtd, offset, nbytes, buffer);
+}
+
+/****************************************************************************
+ * Name: esp32s3_part_bwrite
+ *
+ * Description:
+ *   Write data to designated blocks.
+ *
+ * Input Parameters:
+ *   dev        - ESP32-S3 MTD device data
+ *   startblock - start MTD block number,
+ *                it is not equal to SPI Flash's block
+ *   nblocks    - blocks number
+ *   buffer     - data buffer pointer
+ *
+ * Returned Value:
+ *   Written block number if success or a negative value if fail.
+ *
+ ****************************************************************************/
+
+static ssize_t esp32s3_part_bwrite(struct mtd_dev_s *dev, off_t startblock,
+                                   size_t nblocks, const uint8_t *buffer)
+{
+  struct mtd_dev_priv_s *mtd_priv = (struct mtd_dev_priv_s *)dev;
+
+  return MTD_BWRITE(mtd_priv->ll_mtd, startblock, nblocks, buffer);
+}
+
+/****************************************************************************
+ * Name: esp32s3_part_ioctl
+ *
+ * Description:
+ *   Set/Get option to/from ESP32-S3 SPI Flash MTD device data.
+ *
+ * Input Parameters:
+ *   dev - ESP32-S3 MTD device data
+ *   cmd - operation command
+ *   arg - operation argument
+ *
+ * Returned Value:
+ *   0 if success or a negative value if fail.
+ *
+ ****************************************************************************/
+
+static int esp32s3_part_ioctl(struct mtd_dev_s *dev, int cmd,
+                              unsigned long arg)
+{
+  int ret;
+  struct mtd_dev_priv_s *mtd_priv = (struct mtd_dev_priv_s *)dev;
+
+  finfo("INFO: cmd=%d(0x%x) arg=%lx\n", cmd, cmd, arg);
+
+  switch (_IOC_NR(cmd))
+    {
+      case OTA_IMG_GET_BOOT:
+        {
+          int *num = (int *)arg;
+
+          ret = ota_get_bootseq(mtd_priv, num);
+          if (ret < 0)
+            {
+              ferr("ERROR: Failed to get boot img\n");
+            }
+        }
+
+        break;
+      case OTA_IMG_SET_BOOT:
+        {
+          ret = ota_set_bootseq(mtd_priv, arg);
+          if (ret < 0)
+            {
+              ferr("ERROR: Failed to set boot img\n");
+            }
+        }
+
+        break;
+      default:
+        {
+          ret = MTD_IOCTL(mtd_priv->ll_mtd, cmd, arg);
+        }
+
+        break;
+    }
+
+  return ret;
+}
+
+/****************************************************************************
+ * Name: partition_get_offset
+ *
+ * Description:
+ *   Get offset in SPI flash of the partition label
+ *
+ * Input Parameters:
+ *   label - Partition label
+ *   size  - Data number
+ *
+ * Returned Value:
+ *   Get partition offset(>= 0) if success or a negative value if fail.
+ *
+ ****************************************************************************/
+
+static int partition_get_offset(const char *label, size_t size)
+{
+  int i;
+  int ret;
+  uint8_t *pbuf;
+  int partion_offset;
+  const struct partition_info_priv_s *info;
+  DEBUGASSERT(label != NULL);
+  struct mtd_dev_s *mtd = esp32s3_spiflash_mtd();
+  if (!mtd)
+    {
+      ferr("ERROR: Failed to get SPI flash MTD\n");
+      return -ENOSYS;
+    }
+
+  pbuf = kmm_malloc(PARTITION_MAX_SIZE);
+  if (!pbuf)
+    {
+      ferr("ERROR: Failed to allocate %d byte\n", PARTITION_MAX_SIZE);
+      return -ENOMEM;
+    }
+
+  ret = MTD_READ(mtd, PARTITION_TABLE_OFFSET,
+                 PARTITION_MAX_SIZE, pbuf);
+  if (ret != PARTITION_MAX_SIZE)
+    {
+      ferr("ERROR: Failed to get read data from MTD\n");
+      kmm_free(pbuf);
+      return -EIO;
+    }
+
+  info = (struct partition_info_priv_s *)pbuf;
+  for (i = 0; i < PARTITION_MAX_NUM; i++)
+    {
+      if (memcmp(info[i].label, label, size) == 0)
+        {
+          partion_offset = info[i].offset;
+          break;
+        }
+    }
+
+  kmm_free(pbuf);
+  if (i == PARTITION_MAX_NUM)
+    {
+      ferr("ERROR: No %s  partition is created\n", label);
+      return -EPERM;
+    }
+
+  finfo("Get Partition offset: 0x%x\n", partion_offset);
+  return partion_offset;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: esp32s3_partition_init
+ *
+ *   Initialize ESP32-S3 partition. Read partition information, and use
+ *   these data for creating MTD.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   0 if success or a negative value if fail.
+ *
+ ****************************************************************************/
+
+int esp32s3_partition_init(void)
+{
+  int i;
+  struct partition_info_priv_s *info;
+  uint8_t *pbuf;
+  struct mtd_dev_s *mtd;
+  struct mtd_dev_s *mtd_part;
+  struct mtd_geometry_s geo;
+  struct mtd_dev_priv_s *mtd_priv;
+  int ret = 0;
+  const int num = PARTITION_MAX_SIZE / sizeof(struct partition_info_priv_s);
+  const char path_base[] = PARTITION_MOUNT_POINT;
+  char label[PARTITION_LABEL_LEN + 1];
+  char path[PARTITION_LABEL_LEN + sizeof(PARTITION_MOUNT_POINT)];
+
+  pbuf = kmm_malloc(PARTITION_MAX_SIZE);
+  if (pbuf == NULL)
+    {
+      ferr("ERROR: Failed to allocate %d byte\n", PARTITION_MAX_SIZE);
+      ret = -ENOMEM;
+      goto errout_with_malloc;
+    }
+
+  mtd = esp32s3_spiflash_mtd();
+  if (mtd == NULL)
+    {
+      ferr("ERROR: Failed to get SPI flash MTD\n");
+      ret = -EIO;
+      goto errout_with_mtd;
+    }
+
+  ret = MTD_IOCTL(mtd, MTDIOC_GEOMETRY, (unsigned long)&geo);
+  if (ret < 0)
+    {
+      ferr("ERROR: Failed to get info from MTD\n");
+      ret = -EIO;
+      goto errout_with_mtd;
+    }
+
+  ret = MTD_READ(mtd, PARTITION_TABLE_OFFSET, PARTITION_MAX_SIZE, pbuf);
+  if (ret != PARTITION_MAX_SIZE)
+    {
+      ferr("ERROR: Failed to get read data from MTD\n");
+      ret = -EIO;
+      goto errout_with_mtd;
+    }
+
+  info = (struct partition_info_priv_s *)pbuf;
+
+  for (i = 0; i < num; i++)
+    {
+      if (info->magic != PARTITION_MAGIC)
+        {
+          break;
+        }
+
+      strlcpy(label, (char *)info->label, sizeof(label));
+      snprintf(path, sizeof(path), "%s%s", path_base, label);
+
+      finfo("INFO: [label]:   %s\n", label);
+      finfo("INFO: [type]:    %d\n", info->type);
+      finfo("INFO: [subtype]: %d\n", info->subtype);
+      finfo("INFO: [offset]:  0x%08" PRIx32 "\n", info->offset);
+      finfo("INFO: [size]:    0x%08" PRIx32 "\n", info->size);
+      finfo("INFO: [flags]:   0x%08" PRIx32 "\n", info->flags);
+      finfo("INFO: [mount]:   %s\n", path);
+
+      mtd_priv = kmm_malloc(sizeof(struct mtd_dev_priv_s));
+      if (!mtd_priv)
+        {
+          ferr("ERROR: Failed to allocate %d byte\n",
+               sizeof(struct mtd_dev_priv_s));
+          ret = -1;
+          goto errout_with_mtd;
+        }
+
+      mtd_priv->ll_mtd = mtd;
+      mtd_priv->mtd.bread  = esp32s3_part_bread;
+      mtd_priv->mtd.bwrite = esp32s3_part_bwrite;
+      mtd_priv->mtd.erase  = esp32s3_part_erase;
+      mtd_priv->mtd.ioctl  = esp32s3_part_ioctl;
+      mtd_priv->mtd.read   = esp32s3_part_read;
+      mtd_priv->mtd.write  = esp32s3_part_write;
+      mtd_priv->mtd.name   = label;
+
+      mtd_part = mtd_partition(&mtd_priv->mtd,
+                               info->offset / geo.blocksize,
+                               info->size / geo.blocksize);
+      if (!mtd_part)
+        {
+          ferr("ERROR: Failed to create MTD partition\n");
+          kmm_free(mtd_priv);
+          ret = -1;
+          goto errout_with_mtd;
+        }
+
+      mtd_priv->part_mtd = mtd_part;
+
+      ret = register_mtddriver(path, mtd_part, 0777, NULL);
+      if (ret < 0)
+        {
+          ferr("ERROR: Failed to register MTD @ %s\n", path);
+          kmm_free(mtd_priv);
+          ret = -1;
+          goto errout_with_mtd;
+        }
+
+      info++;
+    }
+
+  ret = 0;
+
+errout_with_mtd:
+  kmm_free(pbuf);
+
+errout_with_malloc:
+  return ret;
+}
+
+/****************************************************************************
+ * Name: esp32s3_partition_read
+ *
+ * Description:
+ *   Read data from SPI Flash at designated address.
+ *
+ * Input Parameters:
+ *   label  - Partition label
+ *   offset - Offset in SPI Flash
+ *   buf    - Data buffer pointer
+ *   size   - Data number
+ *
+ * Returned Value:
+ *   0 if success or a negative value if fail.
+ *
+ ****************************************************************************/
+
+int esp32s3_partition_read(const char *label, size_t offset, void *buf,
+                           size_t size)
+{
+  int ret;
+  int partion_offset;
+  DEBUGASSERT(label != NULL && buf != NULL);
+  struct mtd_dev_s *mtd = esp32s3_spiflash_mtd();
+  if (!mtd)
+    {
+      ferr("ERROR: Failed to get SPI flash MTD\n");
+      return -ENOSYS;
+    }
+
+  partion_offset = partition_get_offset(label, sizeof(label));
+  if (partion_offset < 0)
+    {
+      ferr("ERROR: Failed to get partition: %s offset\n", label);
+      return partion_offset;
+    }
+
+  ret = MTD_READ(mtd, partion_offset + offset,
+                 size, (uint8_t *)buf);
+  if (ret != size)
+    {
+      ferr("ERROR: Failed to get read data from MTD\n");
+      return -EIO;
+    }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: esp32s3_partition_write
+ *
+ * Description:
+ *   Write data to SPI Flash at designated address.
+ *
+ * Input Parameters:
+ *   label  - Partition label
+ *   offset - Offset in SPI Flash
+ *   buf    - Data buffer pointer
+ *   size   - Data number
+ *
+ * Returned Value:
+ *   0 if success or a negative value if fail.
+ *
+ ****************************************************************************/
+
+int esp32s3_partition_write(const char *label, size_t offset, void *buf,
+                            size_t size)
+{
+  int ret;
+  int partion_offset;
+  DEBUGASSERT(label != NULL && buf != NULL);
+  struct mtd_dev_s *mtd = esp32s3_spiflash_mtd();
+  if (!mtd)
+    {
+      ferr("ERROR: Failed to get SPI flash MTD\n");
+      return -ENOSYS;
+    }
+
+  partion_offset = partition_get_offset(label, sizeof(label));
+  if (partion_offset < 0)
+    {
+      ferr("ERROR: Failed to get partition: %s offset\n", label);
+      return partion_offset;
+    }
+
+  ret = MTD_WRITE(mtd, partion_offset + offset,
+                  size, (uint8_t *)buf);
+  if (ret != size)
+    {
+      ferr("ERROR: Failed to get read data from MTD\n");
+      return -EIO;
+    }
+
+  return OK;
+}

--- a/arch/xtensa/src/esp32s3/esp32s3_partition.h
+++ b/arch/xtensa/src/esp32s3/esp32s3_partition.h
@@ -1,0 +1,112 @@
+/****************************************************************************
+ * arch/xtensa/src/esp32s3/esp32s3_partition.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_XTENSA_SRC_ESP32S3S3_ESP32S3S3_PARTITION_H
+#define __ARCH_XTENSA_SRC_ESP32S3S3_ESP32S3S3_PARTITION_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <stdint.h>
+#include <nuttx/mtd/mtd.h>
+
+#ifndef __ASSEMBLY__
+
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: esp32s3_partition_init
+ *
+ * Description:
+ *   Initialize ESP32-S3 partition. Read partition information
+ *   and use these data for creating MTD.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   0 if success or a negative value if fail.
+ *
+ ****************************************************************************/
+
+int esp32s3_partition_init(void);
+
+/****************************************************************************
+ * Name: esp32s3_partition_read
+ *
+ * Description:
+ *   Read data from SPI Flash at designated address.
+ *
+ * Input Parameters:
+ *   label  - Partition label
+ *   offset - Offset in SPI Flash
+ *   buf    - Data buffer pointer
+ *   size   - Data number
+ *
+ * Returned Value:
+ *   0 if success or a negative value if fail.
+ *
+ ****************************************************************************/
+
+int esp32s3_partition_read(const char *label, size_t offset, void *buf,
+                           size_t size);
+
+/****************************************************************************
+ * Name: esp32s3_partition_write
+ *
+ * Description:
+ *   Write data to SPI Flash at designated address.
+ *
+ * Input Parameters:
+ *   label  - Partition label
+ *   offset - Offset in SPI Flash
+ *   buf    - Data buffer pointer
+ *   size   - Data number
+ *
+ * Returned Value:
+ *   0 if success or a negative value if fail.
+ *
+ ****************************************************************************/
+
+int esp32s3_partition_write(const char *label, size_t offset, void *buf,
+                            size_t size);
+
+#ifdef __cplusplus
+}
+#endif
+#undef EXTERN
+
+#endif /* __ASSEMBLY__ */
+#endif /* __ARCH_XTENSA_SRC_ESP32S3S3_ESP32S3S3_PARTITION_H */

--- a/arch/xtensa/src/esp32s3/esp32s3_wifi_adapter.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_wifi_adapter.c
@@ -259,7 +259,6 @@ static void esp_dport_access_stall_other_cpu_start(void);
 static void esp_dport_access_stall_other_cpu_end(void);
 static void wifi_apb80m_request(void);
 static void wifi_apb80m_release(void);
-static int32_t wifi_phy_update_country_info(const char *country);
 static int32_t esp_wifi_read_mac(uint8_t *mac, uint32_t type);
 static void esp_timer_arm(void *timer, uint32_t tmout, bool repeat);
 static void esp_timer_disarm(void *timer);
@@ -487,7 +486,7 @@ wifi_osi_funcs_t g_wifi_osi_funcs =
   ._wifi_apb80m_release = wifi_apb80m_release,
   ._phy_disable = esp32s3_phy_disable,
   ._phy_enable = esp32s3_phy_enable,
-  ._phy_update_country_info = wifi_phy_update_country_info,
+  ._phy_update_country_info = esp32s3_phy_update_country_info,
   ._read_mac = esp_wifi_read_mac,
   ._timer_arm = esp_timer_arm,
   ._timer_disarm = esp_timer_disarm,
@@ -2533,19 +2532,6 @@ static void wifi_apb80m_release(void)
 #ifdef CONFIG_ESP32S3_AUTO_SLEEP
   esp32s3_pm_lockrelease();
 #endif
-}
-
-/****************************************************************************
- * Name: wifi_phy_update_country_info
- *
- * Description:
- *   Don't support
- *
- ****************************************************************************/
-
-static int32_t wifi_phy_update_country_info(const char *country)
-{
-  return -1;
 }
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32s3/esp32s3_wireless.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_wireless.c
@@ -25,9 +25,12 @@
 #include <nuttx/config.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/mqueue.h>
+#include <nuttx/spinlock.h>
 
 #include <debug.h>
 #include <assert.h>
+#include <netinet/in.h>
+#include <sys/param.h>
 
 #include "xtensa.h"
 #include "hardware/esp32s3_efuse.h"
@@ -42,6 +45,7 @@
 #include "phy_init_data.h"
 
 #include "esp32s3_wireless.h"
+#include "esp32s3_partition.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -90,6 +94,7 @@ extern uint8_t phy_dig_reg_backup(bool init, uint32_t *regs);
 extern int  register_chipv7_phy(const esp_phy_init_data_t *init_data,
                                 esp_phy_calibration_data_t *cal_data,
                                 esp_phy_calibration_mode_t cal_mode);
+extern uint32_t crc32_le(uint32_t crc, uint8_t const *buf, uint32_t len);
 
 /****************************************************************************
  * Private Data
@@ -118,6 +123,83 @@ static uint8_t g_wifi_bt_pd_controller;
 /* Private data of the wireless common interface */
 
 static struct esp_wireless_priv_s g_esp_wireless_priv;
+
+#ifdef CONFIG_ESP32S3_PHY_INIT_DATA_IN_PARTITION
+static const char *phy_partion_label = "phy_init";
+#endif
+
+#ifdef CONFIG_ESP32S3_SUPPORT_MULTIPLE_PHY_INIT_DATA
+
+static phy_init_data_type_t g_phy_init_data_type;
+
+static phy_init_data_type_t g_current_apply_phy_init_data;
+
+static char g_phy_current_country[PHY_COUNTRY_CODE_LEN];
+
+/* Whether it is a new bin */
+
+static bool g_multiple_phy_init_data_bin;
+
+/* PHY init data type array */
+
+static const char *g_phy_type[ESP_PHY_INIT_DATA_TYPE_NUMBER] =
+{
+  "DEFAULT", "SRRC", "FCC", "CE", "NCC", "KCC", "MIC", "IC",
+  "ACMA", "ANATEL", "ISED", "WPC", "OFCA", "IFETEL", "RCM"
+};
+
+/* Country and PHY init data type map */
+
+static phy_country_to_bin_type_t g_country_code_map_type_table[] =
+{
+  {"01",  ESP_PHY_INIT_DATA_TYPE_DEFAULT},
+  {"AT",  ESP_PHY_INIT_DATA_TYPE_CE},
+  {"AU",  ESP_PHY_INIT_DATA_TYPE_ACMA},
+  {"BE",  ESP_PHY_INIT_DATA_TYPE_CE},
+  {"BG",  ESP_PHY_INIT_DATA_TYPE_CE},
+  {"BR",  ESP_PHY_INIT_DATA_TYPE_ANATEL},
+  {"CA",  ESP_PHY_INIT_DATA_TYPE_ISED},
+  {"CH",  ESP_PHY_INIT_DATA_TYPE_CE},
+  {"CN",  ESP_PHY_INIT_DATA_TYPE_SRRC},
+  {"CY",  ESP_PHY_INIT_DATA_TYPE_CE},
+  {"CZ",  ESP_PHY_INIT_DATA_TYPE_CE},
+  {"DE",  ESP_PHY_INIT_DATA_TYPE_CE},
+  {"DK",  ESP_PHY_INIT_DATA_TYPE_CE},
+  {"EE",  ESP_PHY_INIT_DATA_TYPE_CE},
+  {"ES",  ESP_PHY_INIT_DATA_TYPE_CE},
+  {"FI",  ESP_PHY_INIT_DATA_TYPE_CE},
+  {"FR",  ESP_PHY_INIT_DATA_TYPE_CE},
+  {"GB",  ESP_PHY_INIT_DATA_TYPE_CE},
+  {"GR",  ESP_PHY_INIT_DATA_TYPE_CE},
+  {"HK",  ESP_PHY_INIT_DATA_TYPE_OFCA},
+  {"HR",  ESP_PHY_INIT_DATA_TYPE_CE},
+  {"HU",  ESP_PHY_INIT_DATA_TYPE_CE},
+  {"IE",  ESP_PHY_INIT_DATA_TYPE_CE},
+  {"IN",  ESP_PHY_INIT_DATA_TYPE_WPC},
+  {"IS",  ESP_PHY_INIT_DATA_TYPE_CE},
+  {"IT",  ESP_PHY_INIT_DATA_TYPE_CE},
+  {"JP",  ESP_PHY_INIT_DATA_TYPE_MIC},
+  {"KR",  ESP_PHY_INIT_DATA_TYPE_KCC},
+  {"LI",  ESP_PHY_INIT_DATA_TYPE_CE},
+  {"LT",  ESP_PHY_INIT_DATA_TYPE_CE},
+  {"LU",  ESP_PHY_INIT_DATA_TYPE_CE},
+  {"LV",  ESP_PHY_INIT_DATA_TYPE_CE},
+  {"MT",  ESP_PHY_INIT_DATA_TYPE_CE},
+  {"MX",  ESP_PHY_INIT_DATA_TYPE_IFETEL},
+  {"NL",  ESP_PHY_INIT_DATA_TYPE_CE},
+  {"NO",  ESP_PHY_INIT_DATA_TYPE_CE},
+  {"NZ",  ESP_PHY_INIT_DATA_TYPE_RCM},
+  {"PL",  ESP_PHY_INIT_DATA_TYPE_CE},
+  {"PT",  ESP_PHY_INIT_DATA_TYPE_CE},
+  {"RO",  ESP_PHY_INIT_DATA_TYPE_CE},
+  {"SE",  ESP_PHY_INIT_DATA_TYPE_CE},
+  {"SI",  ESP_PHY_INIT_DATA_TYPE_CE},
+  {"SK",  ESP_PHY_INIT_DATA_TYPE_CE},
+  {"TW",  ESP_PHY_INIT_DATA_TYPE_NCC},
+  {"US",  ESP_PHY_INIT_DATA_TYPE_FCC},
+};
+
+#endif
 
 /****************************************************************************
  * Private Functions
@@ -312,6 +394,481 @@ void IRAM_ATTR esp32s3_phy_disable_clock(void)
   esp32s3_periph_wifi_bt_common_module_disable();
 }
 
+#ifdef CONFIG_ESP32S3_SUPPORT_MULTIPLE_PHY_INIT_DATA
+
+/****************************************************************************
+ * Name: phy_crc_check
+ *
+ * Description:
+ *   Check the checksum value of data
+ *
+ * Input Parameters:
+ *   data     - Data buffer pointer
+ *   length   - Data length
+ *   checksum - Checksum pointer
+ *
+ * Returned Value:
+ *   OK on success; a negated errno on failure
+ *
+ ****************************************************************************/
+
+static int phy_crc_check(uint8_t *data, const uint8_t *checksum,
+                         size_t length)
+{
+  uint32_t crc_data = crc32_le(0, data, length);
+  uint32_t crc_size_conversion = HTONL(crc_data);
+  uint32_t tmp_crc = checksum[0] | (checksum[1] << 8) | (checksum[2] << 16) |
+                     (checksum[3] << 24);
+  if (crc_size_conversion != tmp_crc)
+    {
+      return ERROR;
+    }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: phy_find_bin_type_according_country
+ *
+ * Description:
+ *   Find the PHY initialization data type according to country code
+ *
+ * Input Parameters:
+ *   country - Country code pointer
+ *
+ * Returned Value:
+ *   PHY initialization data type
+ *
+ ****************************************************************************/
+
+static uint8_t phy_find_bin_type_according_country(const char *country)
+{
+  uint8_t i;
+  uint8_t phy_init_data_type;
+  uint8_t num = nitems(g_country_code_map_type_table);
+  for (i = 0; i < num; i++)
+    {
+      if (memcmp(country, g_country_code_map_type_table[i].cc,
+                 sizeof(g_phy_current_country)) == 0)
+        {
+          phy_init_data_type = g_country_code_map_type_table[i].type;
+          wlinfo("Current country is %c%c, PHY init data type is %s\n",
+                  g_country_code_map_type_table[i].cc[0],
+                  g_country_code_map_type_table[i].cc[1],
+                  g_phy_type[g_country_code_map_type_table[i].type]);
+          break;
+        }
+    }
+
+  if (i == num)
+    {
+      phy_init_data_type = ESP_PHY_INIT_DATA_TYPE_DEFAULT;
+      wlerr("Use the default certification code beacuse %c%c doesn't "
+            "have a certificate\n", country[0], country[1]);
+    }
+
+  return phy_init_data_type;
+}
+
+/****************************************************************************
+ * Name: phy_find_bin_data_according_type
+ *
+ * Description:
+ *   Find the PHY initialization data according to PHY init data type
+ *
+ * Input Parameters:
+ *   output_data    - Output data buffer pointer
+ *   control_info   - PHY init data control infomation
+ *   input_data     - Input data buffer pointer
+ *   init_data_type - PHY init data type
+ *
+ * Returned Value:
+ *   OK on success; a negated errno on failure
+ *
+ ****************************************************************************/
+
+static int phy_find_bin_data_according_type(uint8_t *output_data,
+        const phy_control_info_data_t *control_info,
+        const esp_phy_init_data_t *input_data,
+        phy_init_data_type_t init_data_type)
+{
+  int i;
+  for (i = 0; i < control_info->number; i++)
+    {
+      if (init_data_type == *((uint8_t *)(input_data + i)
+                              + PHY_INIT_DATA_TYPE_OFFSET))
+        {
+          memcpy(output_data + sizeof(phy_init_magic_pre),
+                 (input_data + i), sizeof(esp_phy_init_data_t));
+          break;
+        }
+    }
+
+  if (i == control_info->number)
+    {
+      return ERROR;
+    }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: phy_get_multiple_init_data
+ *
+ * Description:
+ *   Get multiple PHY init data according to PHY init data type
+ *
+ * Input Parameters:
+ *   data           - Data buffer pointer
+ *   length         - Data length
+ *   init_data_type - PHY init data type
+ *
+ * Returned Value:
+ *   OK on success; a negated errno on failure
+ *
+ ****************************************************************************/
+
+static int phy_get_multiple_init_data(uint8_t *data, size_t length,
+                                      phy_init_data_type_t init_data_type)
+{
+  phy_control_info_data_t *control_info = (phy_control_info_data_t *)
+                                kmm_malloc(sizeof(phy_control_info_data_t));
+  if (control_info == NULL)
+    {
+      wlerr("ERROR: Failed to allocate memory for\
+            PHY init data control info\n");
+      return -ENOMEM;
+    }
+
+  int ret = esp32s3_partition_read(phy_partion_label, length, control_info,
+                                   sizeof(phy_control_info_data_t));
+  if (ret != OK)
+    {
+      kmm_free(control_info);
+      wlerr("ERROR: Failed to read PHY control info data partition\n");
+      return ret;
+    }
+
+  if ((control_info->check_algorithm) == PHY_CRC_ALGORITHM)
+    {
+      ret = phy_crc_check(control_info->multiple_bin_checksum,
+                          control_info->control_info_checksum,
+                          sizeof(phy_control_info_data_t) -
+                          sizeof(control_info->control_info_checksum));
+      if (ret != OK)
+        {
+          kmm_free(control_info);
+          wlerr("ERROR: PHY init data control info check error\n");
+          return ret;
+        }
+    }
+  else
+    {
+      kmm_free(control_info);
+      wlerr("ERROR: Check algorithm not CRC, PHY init data update failed\n");
+      return ERROR;
+    }
+
+  uint8_t *init_data_multiple = (uint8_t *)
+        kmm_malloc(sizeof(esp_phy_init_data_t) * control_info->number);
+  if (init_data_multiple == NULL)
+    {
+      kmm_free(control_info);
+      wlerr("ERROR: Failed to allocate memory for PHY init data\n");
+      return -ENOMEM;
+    }
+
+  ret = esp32s3_partition_read(phy_partion_label, length +
+          sizeof(phy_control_info_data_t), init_data_multiple,
+          sizeof(esp_phy_init_data_t) * control_info->number);
+  if (ret != OK)
+    {
+      kmm_free(init_data_multiple);
+      kmm_free(control_info);
+      wlerr("ERROR: Failed to read PHY init data multiple bin partition\n");
+      return ret;
+    }
+
+  if ((control_info->check_algorithm) == PHY_CRC_ALGORITHM)
+    {
+      ret = phy_crc_check(init_data_multiple,
+                    control_info->multiple_bin_checksum,
+                    sizeof(esp_phy_init_data_t) * control_info->number);
+      if (ret != OK)
+        {
+          kmm_free(init_data_multiple);
+          kmm_free(control_info);
+          wlerr("ERROR: PHY init data multiple bin check error\n");
+          return ret;
+        }
+    }
+  else
+    {
+      kmm_free(init_data_multiple);
+      kmm_free(control_info);
+      wlerr("ERROR: Check algorithm not CRC, PHY init data update failed\n");
+      return ERROR;
+    }
+
+  ret = phy_find_bin_data_according_type(data, control_info,
+          (const esp_phy_init_data_t *)init_data_multiple, init_data_type);
+  if (ret != OK)
+    {
+      wlerr("ERROR: %s has not been certified, use DEFAULT PHY init data\n",
+            g_phy_type[init_data_type]);
+      g_phy_init_data_type = ESP_PHY_INIT_DATA_TYPE_DEFAULT;
+    }
+  else
+    {
+      g_phy_init_data_type = init_data_type;
+    }
+
+  kmm_free(init_data_multiple);
+  kmm_free(control_info);
+  return OK;
+}
+
+/****************************************************************************
+ * Name: phy_update_init_data
+ *
+ * Description:
+ *   Update PHY init data according to PHY init data type
+ *
+ * Input Parameters:
+ *   init_data_type - PHY init data type
+ *
+ * Returned Value:
+ *   OK on success; a negated errno on failure
+ *
+ ****************************************************************************/
+
+static int phy_update_init_data(phy_init_data_type_t init_data_type)
+{
+  int ret;
+  size_t length = sizeof(phy_init_magic_pre) +
+      sizeof(esp_phy_init_data_t) + sizeof(phy_init_magic_post);
+  uint8_t *init_data_store = kmm_malloc(length);
+  if (init_data_store == NULL)
+    {
+      wlerr("ERROR: Failed to allocate memory for updated country code "
+            "PHY init data\n");
+      return -ENOMEM;
+    }
+
+  ret = esp32s3_partition_read(phy_partion_label, 0, init_data_store,
+                               length);
+  if (ret != OK)
+    {
+      kmm_free(init_data_store);
+      wlerr("ERROR: Failed to read updated country code PHY data\n");
+      return ret;
+    }
+
+  if (memcmp(init_data_store, PHY_INIT_MAGIC,
+             sizeof(phy_init_magic_pre)) != 0 ||
+      memcmp(init_data_store + length - sizeof(phy_init_magic_post),
+             PHY_INIT_MAGIC, sizeof(phy_init_magic_post)) != 0)
+    {
+      kmm_free(init_data_store);
+      wlerr("ERROR: Failed to validate updated country code PHY data\n");
+      return ERROR;
+    }
+
+  /* find init data bin according init data type */
+
+  if (init_data_type != ESP_PHY_INIT_DATA_TYPE_DEFAULT)
+    {
+      ret = phy_get_multiple_init_data(init_data_store, length,
+                                       init_data_type);
+      if (ret != OK)
+        {
+          kmm_free(init_data_store);
+#ifdef CONFIG_ESP32S3_PHY_INIT_DATA_ERROR
+          abort();
+#else
+          return ret;
+#endif
+        }
+    }
+  else
+    {
+      g_phy_init_data_type = ESP_PHY_INIT_DATA_TYPE_DEFAULT;
+    }
+
+  if (g_current_apply_phy_init_data != g_phy_init_data_type)
+    {
+      ret = esp_phy_apply_phy_init_data(init_data_store +
+                                        sizeof(phy_init_magic_pre));
+      if (ret != OK)
+        {
+          wlerr("ERROR: PHY init data failed to load\n");
+          kmm_free(init_data_store);
+          return ret;
+        }
+
+      wlinfo("PHY init data type updated from %s to %s\n",
+             g_phy_type[g_current_apply_phy_init_data],
+             g_phy_type[g_phy_init_data_type]);
+      g_current_apply_phy_init_data = g_phy_init_data_type;
+    }
+
+  kmm_free(init_data_store);
+  return OK;
+}
+
+#endif
+
+#ifdef CONFIG_ESP32S3_PHY_INIT_DATA_IN_PARTITION
+
+/****************************************************************************
+ * Name: esp_phy_get_init_data
+ *
+ * Description:
+ *   Get PHY init data
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   Pointer to PHY init data structure
+ *
+ ****************************************************************************/
+
+const esp_phy_init_data_t *esp_phy_get_init_data(void)
+{
+  int ret;
+  size_t length = sizeof(phy_init_magic_pre) +
+                  sizeof(esp_phy_init_data_t) + sizeof(phy_init_magic_post);
+  uint8_t *init_data_store = kmm_malloc(length);
+  if (init_data_store == NULL)
+    {
+      wlerr("ERROR: Failed to allocate memory for PHY init data\n");
+      return NULL;
+    }
+
+  ret = esp32s3_partition_read(phy_partion_label, 0, init_data_store,
+                               length);
+  if (ret != OK)
+    {
+      wlerr("ERROR: Failed to get read data from MTD\n");
+      kmm_free(init_data_store);
+      return NULL;
+    }
+
+  if (memcmp(init_data_store, PHY_INIT_MAGIC, sizeof(phy_init_magic_pre))
+      != 0 || memcmp(init_data_store + length - sizeof(phy_init_magic_post),
+              PHY_INIT_MAGIC, sizeof(phy_init_magic_post)) != 0)
+    {
+#ifdef CONFIG_ESP32S3_PHY_DEFAULT_INIT_IF_INVALID
+      wlerr("ERROR: Failed to validate PHY data partition, restoring "
+            "default data into flash...");
+      memcpy(init_data_store, PHY_INIT_MAGIC, sizeof(phy_init_magic_pre));
+      memcpy(init_data_store + sizeof(phy_init_magic_pre),
+             &phy_init_data, sizeof(phy_init_data));
+      memcpy(init_data_store + sizeof(phy_init_magic_pre) +
+             sizeof(phy_init_data), PHY_INIT_MAGIC,
+             sizeof(phy_init_magic_post));
+      DEBUGASSERT(memcmp(init_data_store, PHY_INIT_MAGIC,
+                  sizeof(phy_init_magic_pre)) == 0);
+      DEBUGASSERT(memcmp(init_data_store + length -
+                  sizeof(phy_init_magic_post), PHY_INIT_MAGIC,
+                  sizeof(phy_init_magic_post)) == 0);
+
+      /* write default data */
+
+      ret = esp32s3_partition_write(phy_partion_label, 0, init_data_store,
+                                    length);
+      if (ret != OK)
+        {
+          wlerr("ERROR: Failed to write default PHY data partition\n");
+          kmm_free(init_data_store);
+          return NULL;
+        }
+#else /* CONFIG_ESP32S3_PHY_DEFAULT_INIT_IF_INVALID */ 
+      wlerr("ERROR: Failed to validate PHY data partition\n");
+      kmm_free(init_data_store);
+      return NULL;
+#endif
+    }
+
+#ifdef CONFIG_ESP32S3_SUPPORT_MULTIPLE_PHY_INIT_DATA
+  if (*(init_data_store + (sizeof(phy_init_magic_pre) +
+      PHY_SUPPORT_MULTIPLE_BIN_OFFSET)))
+    {
+      g_multiple_phy_init_data_bin = true;
+      wlinfo("Support multiple PHY init data bins\n");
+    }
+  else
+    {
+      wlinfo("Does not support multiple PHY init data bins\n");
+    }
+#endif
+
+  wlinfo("PHY data partition validated\n");
+  return (const esp_phy_init_data_t *)
+         (init_data_store + sizeof(phy_init_magic_pre));
+}
+
+/****************************************************************************
+ * Name: esp_phy_release_init_data
+ *
+ * Description:
+ *   Release PHY init data
+ *
+ * Input Parameters:
+ *   init_data - Pointer to PHY init data structure
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void esp_phy_release_init_data(const esp_phy_init_data_t *init_data)
+{
+  kmm_free((uint8_t *)init_data - sizeof(phy_init_magic_pre));
+}
+
+#else /* CONFIG_ESP32S3_PHY_INIT_DATA_IN_PARTITION */ 
+
+/****************************************************************************
+ * Name: esp_phy_get_init_data
+ *
+ * Description:
+ *   Get PHY init data
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   Pointer to PHY init data structure
+ *
+ ****************************************************************************/
+
+const esp_phy_init_data_t *esp_phy_get_init_data(void)
+{
+  wlinfo("Loading PHY init data from application binary\n");
+  return &phy_init_data;
+}
+
+/****************************************************************************
+ * Name: esp_phy_release_init_data
+ *
+ * Description:
+ *   Release PHY init data
+ *
+ * Input Parameters:
+ *   init_data - Pointer to PHY init data structure
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void esp_phy_release_init_data(const esp_phy_init_data_t *init_data)
+{
+}
+#endif
+
 /****************************************************************************
  * Name: esp_read_mac
  *
@@ -396,6 +953,54 @@ int32_t esp_read_mac(uint8_t *mac, esp_mac_type_t type)
 }
 
 /****************************************************************************
+ * Name: esp32s3_phy_update_country_info
+ *
+ * Description:
+ *   Update PHY init data according to country code
+ *
+ * Input Parameters:
+ *   country - PHY init data type
+ *
+ * Returned Value:
+ *   OK on success; a negated errno on failure
+ *
+ ****************************************************************************/
+
+int esp32s3_phy_update_country_info(const char *country)
+{
+#ifdef CONFIG_ESP32S3_SUPPORT_MULTIPLE_PHY_INIT_DATA
+  uint8_t phy_init_data_type_map = 0;
+  if (memcmp(country, g_phy_current_country, sizeof(g_phy_current_country))
+      == 0)
+    {
+      return OK;
+    }
+
+  memcpy(g_phy_current_country, country, sizeof(g_phy_current_country));
+  if (!g_multiple_phy_init_data_bin)
+    {
+      wlerr("ERROR: Does not support multiple PHY init data bins\n");
+      return ERROR;
+    }
+
+  phy_init_data_type_map = phy_find_bin_type_according_country(country);
+  if (phy_init_data_type_map == g_phy_init_data_type)
+    {
+      return OK;
+    }
+
+  int ret =  phy_update_init_data(phy_init_data_type_map);
+  if (ret != OK)
+    {
+      wlerr("ERROR: Failed to update PHY init data\n");
+      return ret;
+    }
+#endif
+
+  return OK;
+}
+
+/****************************************************************************
  * Name: esp32s3_phy_disable
  *
  * Description:
@@ -465,7 +1070,7 @@ void esp32s3_phy_enable(void)
       debug = true;
     }
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
 
   if (g_phy_access_ref == 0)
     {
@@ -485,7 +1090,15 @@ void esp32s3_phy_enable(void)
           phy_bbpll_en_usb(true);
 #endif
           wlinfo("calibrating");
-          register_chipv7_phy(&phy_init_data, cal_data, PHY_RF_CAL_FULL);
+          const esp_phy_init_data_t *init_data = esp_phy_get_init_data();
+          if (init_data == NULL)
+            {
+              wlerr("ERROR: Failed to obtain PHY init data");
+              abort();
+            }
+
+          register_chipv7_phy(init_data, cal_data, PHY_RF_CAL_FULL);
+          esp_phy_release_init_data(init_data);
           g_is_phy_calibrated = true;
           kmm_free(cal_data);
         }
@@ -498,7 +1111,7 @@ void esp32s3_phy_enable(void)
 
   g_phy_access_ref++;
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32s3/esp32s3_wireless.h
+++ b/arch/xtensa/src/esp32s3/esp32s3_wireless.h
@@ -44,9 +44,7 @@
  * headers
  */
 
-#define CONFIG_ESP32_SUPPORT_MULTIPLE_PHY_INIT_DATA_BIN     0
-#define CONFIG_MAC_BB_PD                                    0
-
+#define CONFIG_MAC_BB_PD                              (0)
 #define MAC_LEN                                       (6)
 
 /****************************************************************************
@@ -158,6 +156,22 @@ void IRAM_ATTR esp32s3_phy_enable_clock(void);
  ****************************************************************************/
 
 void esp32s3_phy_disable_clock(void);
+
+/****************************************************************************
+ * Name: esp32s3_phy_update_country_info
+ *
+ * Description:
+ *   Update PHY init data according to country code
+ *
+ * Input Parameters:
+ *   country - PHY init data type
+ *
+ * Returned Value:
+ *   OK on success; a negated errno on failure
+ *
+ ****************************************************************************/
+
+int esp32s3_phy_update_country_info(const char *country);
 
 /****************************************************************************
  * Functions needed by libphy.a

--- a/boards/xtensa/esp32s3/esp32s3-devkit/src/esp32s3_bringup.c
+++ b/boards/xtensa/esp32s3/esp32s3-devkit/src/esp32s3_bringup.c
@@ -90,6 +90,10 @@
 #  include "esp32s3_ledc.h"
 #endif
 
+#ifdef CONFIG_ESP32S3_PARTITION_TABLE
+#  include "esp32s3_partition.h"
+#endif
+
 #include "esp32s3-devkit.h"
 
 /****************************************************************************
@@ -163,6 +167,15 @@ int esp32s3_bringup(void)
   if (ret < 0)
     {
       syslog(LOG_ERR, "Failed to initialize timers: %d\n", ret);
+    }
+#endif
+
+#ifdef CONFIG_ESP32S3_PARTITION_TABLE
+  ret = esp32s3_partition_init();
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to initialize partition error=%d\n",
+             ret);
     }
 #endif
 

--- a/boards/xtensa/esp32s3/esp32s3-devkit/src/esp32s3_bringup.c
+++ b/boards/xtensa/esp32s3/esp32s3-devkit/src/esp32s3_bringup.c
@@ -170,6 +170,14 @@ int esp32s3_bringup(void)
     }
 #endif
 
+#ifdef CONFIG_ESP32S3_SPIFLASH
+  ret = board_spiflash_init();
+  if (ret)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to initialize SPI Flash\n");
+    }
+#endif
+
 #ifdef CONFIG_ESP32S3_PARTITION_TABLE
   ret = esp32s3_partition_init();
   if (ret < 0)
@@ -316,14 +324,6 @@ int esp32s3_bringup(void)
   if (ret != OK)
     {
       syslog(LOG_ERR, "Failed to register djoystick driver: %d\n", ret);
-    }
-#endif
-
-#ifdef CONFIG_ESP32S3_SPIFLASH
-  ret = board_spiflash_init();
-  if (ret)
-    {
-      syslog(LOG_ERR, "ERROR: Failed to initialize SPI Flash\n");
     }
 #endif
 


### PR DESCRIPTION
## Summary

- Support partition and OTA device
- Support multiple PHY init data bin

## Impact

## Testing

If `CONFIG_ESP32S3_PHY_INIT_DATA_IN_PARTITION` and `CONFIG_ESP32S3_SUPPORT_MULTIPLE_PHY_INIT_DATA` are enabled, PHY initialization data (PHY initialization data is used for RF calibration) will be loaded from a partition, make sure that PHY data partition is included (type: 'data', subtype: 'phy').

The corresponding PHY init data type can be automatically switched according to the country code, China's PHY init data bin is used by default, country code can be modified through the wapi command: `wapi country <ifname> <country code>`.

Successful execution of `wapi country <ifname> <country code>` in `esp32s3-devkit:wifi` with `CONFIG_ESP32S3_PHY_INIT_DATA_IN_PARTITION=y` and `CONFIG_ESP32S3_SUPPORT_MULTIPLE_PHY_INIT_DATA=y`
