### PR TITLE
libm/newlib: Change the download site to https

### DIFF
--- a/libs/libm/newlib/Make.defs
+++ b/libs/libm/newlib/Make.defs
@@ -26,7 +26,7 @@ ifeq ($(CONFIG_ARCH_CHIP_ESP32),y)
 else
   NEWLIB_VERSION=4.3.0.20230120
   NEWLIB_BASENAME=newlib
-  NEWLIB_URL_BASE=ftp://sourceware.org/pub/newlib
+  NEWLIB_URL_BASE=https://sourceware.org/pub/newlib
   NEWLIB_TARBALL=$(NEWLIB_BASENAME)-$(NEWLIB_VERSION).tar.gz
 endif
 


### PR DESCRIPTION
## Summary
Change newlib download site from ftp to more secure https.

## Impact
None

## Testing
Build pass with `CONFIG_LIBM_NEWLIB=y`

