### PR TITLE
NXP Serial Do not wait on TXDMA semaphore

### DIFF
--- a/arch/arm/src/imxrt/imxrt_serial.c
+++ b/arch/arm/src/imxrt/imxrt_serial.c
@@ -2535,9 +2535,12 @@ static void imxrt_dma_txavailable(struct uart_dev_s *dev)
 
   /* Only send when the DMA is idle */
 
-  nxsem_wait(&priv->txdmasem);
+  int rv = nxsem_trywait(&priv->txdmasem);
 
-  uart_xmitchars_dma(dev);
+  if (rv == 0)
+    {
+      uart_xmitchars_dma(dev);
+    }
 }
 #endif
 

--- a/arch/arm/src/s32k1xx/s32k1xx_serial.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_serial.c
@@ -1768,9 +1768,12 @@ static void s32k1xx_dma_txavailable(struct uart_dev_s *dev)
 
   /* Only send when the DMA is idle */
 
-  nxsem_wait(&priv->txdmasem);
+  int rv = nxsem_trywait(&priv->txdmasem);
 
-  uart_xmitchars_dma(dev);
+  if (rv == OK)
+    {
+      uart_xmitchars_dma(dev);
+    }
 }
 #endif
 

--- a/arch/arm/src/s32k3xx/s32k3xx_serial.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_serial.c
@@ -3969,9 +3969,12 @@ static void s32k3xx_dma_txavailable(struct uart_dev_s *dev)
 
   /* Only send when the DMA is idle */
 
-  nxsem_wait(&priv->txdmasem);
+  int rv = nxsem_trywait(&priv->txdmasem);
 
-  uart_xmitchars_dma(dev);
+  if (rv == OK)
+    {
+      uart_xmitchars_dma(dev);
+    }
 }
 #endif
 


### PR DESCRIPTION
## Summary

   If using flow control with a high CTS the thread may be
    blocked forever on the second transmit attempt due to waiting
    on the txdma semaphore.  The calling thread can then never
    make progress and release any resources it has taken, thus
    may cause a deadlock in other parts of the system.

    The implementation differs in behavior from interrupt-driven
    TX. It should not implicitly wait on a taken semaphore but
    return immediately and let the upper layers decide on what to
    do next.

## Impact

Prevent blocking

## Testing

