### PR TITLE
stm32h7/linum-stm32h753bi: Added suport to userlerds library.

### DIFF
--- a/boards/arm/stm32h7/linum-stm32h753bi/src/CMakeLists.txt
+++ b/boards/arm/stm32h7/linum-stm32h753bi/src/CMakeLists.txt
@@ -24,6 +24,10 @@ if(CONFIG_ARCH_LEDS)
   list(APPEND SRCS stm32_autoleds.c)
 endif()
 
+if(CONFIG_USERLED)
+  list(APPEND SRCS stm32_userled.c)
+endif()
+
 if(CONFIG_BOARDCTL)
   list(APPEND SRCS stm32_appinitialize.c)
 endif()

--- a/boards/arm/stm32h7/linum-stm32h753bi/src/Makefile
+++ b/boards/arm/stm32h7/linum-stm32h753bi/src/Makefile
@@ -24,6 +24,10 @@ CSRCS = stm32_boot.c stm32_bringup.c
 
 ifeq ($(CONFIG_ARCH_LEDS),y)
 CSRCS += stm32_autoleds.c
+else
+  ifeq ($(CONFIG_USERLED),y)
+  CSRCS += stm32_userleds.c
+  endif
 endif
 
 ifeq ($(CONFIG_BOARDCTL),y)

--- a/boards/arm/stm32h7/linum-stm32h753bi/src/stm32_bringup.c
+++ b/boards/arm/stm32h7/linum-stm32h753bi/src/stm32_bringup.c
@@ -35,6 +35,10 @@
 
 #include "linum-stm32h753bi.h"
 
+#ifdef CONFIG_USERLED
+#include <nuttx/leds/userled.h>
+#endif
+
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
@@ -74,6 +78,16 @@ int stm32_bringup(void)
              "ERROR: Failed to mount the PROC filesystem: %d\n",  ret);
     }
 #endif /* CONFIG_FS_PROCFS */
+
+#ifdef CONFIG_USERLED
+  /* Register the LED driver */
+
+  ret = userled_lower_initialize("/dev/userleds");
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: userled_lower_initialize() failed: %d\n", ret);
+    }
+#endif
 
   return OK;
 }

--- a/boards/arm/stm32h7/linum-stm32h753bi/src/stm32_userleds.c
+++ b/boards/arm/stm32h7/linum-stm32h753bi/src/stm32_userleds.c
@@ -1,0 +1,214 @@
+/****************************************************************************
+ * boards/arm/stm32h7/linum-stm32h753bi/src/stm32_userleds.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <debug.h>
+
+#include <nuttx/board.h>
+#include <nuttx/power/pm.h>
+#include <arch/board/board.h>
+
+#include "chip.h"
+#include "arm_internal.h"
+#include "stm32.h"
+#include "linum-stm32h753bi.h"
+
+#ifndef CONFIG_ARCH_LEDS
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/* This array maps an LED number to GPIO pin configuration */
+
+static uint32_t g_ledcfg[BOARD_NLEDS] =
+{
+  GPIO_LED_RED,
+  GPIO_LED_GREEN,
+  GPIO_LED_BLUE
+};
+
+/****************************************************************************
+ * Private Function Protototypes
+ ****************************************************************************/
+
+/* LED Power Management */
+
+#ifdef CONFIG_PM
+static void led_pm_notify(struct pm_callback_s *cb, int domain,
+                          enum pm_state_e pmstate);
+static int led_pm_prepare(struct pm_callback_s *cb, int domain,
+                          enum pm_state_e pmstate);
+#endif
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#ifdef CONFIG_PM
+static struct pm_callback_s g_ledscb =
+{
+  .notify  = led_pm_notify,
+  .prepare = led_pm_prepare,
+};
+#endif
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: led_pm_notify
+ *
+ * Description:
+ *   Notify the driver of new power state. This callback is called after
+ *   all drivers have had the opportunity to prepare for the new power state.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_PM
+static void led_pm_notify(struct pm_callback_s *cb, int domain,
+                          enum pm_state_e pmstate)
+{
+  switch (pmstate)
+    {
+      case(PM_NORMAL):
+        {
+          /* Restore normal LEDs operation */
+        }
+        break;
+
+      case(PM_IDLE):
+        {
+          /* Entering IDLE mode - Turn leds off */
+        }
+        break;
+
+      case(PM_STANDBY):
+        {
+          /* Entering STANDBY mode - Logic for PM_STANDBY goes here */
+        }
+        break;
+
+      case(PM_SLEEP):
+        {
+          /* Entering SLEEP mode - Logic for PM_SLEEP goes here */
+        }
+        break;
+
+      default:
+        {
+          /* Should not get here */
+        }
+        break;
+    }
+}
+#endif
+
+/****************************************************************************
+ * Name: led_pm_prepare
+ *
+ * Description:
+ *   Request the driver to prepare for a new power state. This is a warning
+ *   that the system is about to enter into a new power state. The driver
+ *   should begin whatever operations that may be required to enter power
+ *   state. The driver may abort the state change mode by returning a
+ *   non-zero value from the callback function.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_PM
+static int led_pm_prepare(struct pm_callback_s *cb, int domain,
+                          enum pm_state_e pmstate)
+{
+  /* No preparation to change power modes is required by the LEDs driver.
+   * We always accept the state change by returning OK.
+   */
+
+  return OK;
+}
+#endif
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_userled_initialize
+ ****************************************************************************/
+
+uint32_t board_userled_initialize(void)
+{
+  /* Configure LED1-4 GPIOs for output */
+
+  stm32_configgpio(GPIO_LED_RED);
+  stm32_configgpio(GPIO_LED_GREEN);
+  stm32_configgpio(GPIO_LED_BLUE);
+  return BOARD_NLEDS;
+}
+
+/****************************************************************************
+ * Name: board_userled
+ ****************************************************************************/
+
+void board_userled(int led, bool ledon)
+{
+  if ((unsigned)led < BOARD_NLEDS)
+    {
+      stm32_gpiowrite(g_ledcfg[led], ledon);
+    }
+}
+
+/****************************************************************************
+ * Name: board_userled_all
+ ****************************************************************************/
+
+void board_userled_all(uint32_t ledset)
+{
+  stm32_gpiowrite(GPIO_LED_RED, (ledset & BOARD_LED1_BIT) == 0);
+  stm32_gpiowrite(GPIO_LED_GREEN, (ledset & BOARD_LED2_BIT) == 0);
+  stm32_gpiowrite(GPIO_LED_BLUE, (ledset & BOARD_LED3_BIT) == 0);
+}
+
+/****************************************************************************
+ * Name: stm32_led_pminitialize
+ ****************************************************************************/
+
+#ifdef CONFIG_PM
+void stm32_led_pminitialize(void)
+{
+  /* Register to receive power management callbacks */
+
+  int ret = pm_register(&g_ledscb);
+  if (ret != OK)
+    {
+      board_autoled_on(LED_ASSERTION);
+    }
+}
+#endif /* CONFIG_PM */
+
+#endif /* !CONFIG_ARCH_LEDS */


### PR DESCRIPTION
Summary
Added support to userleds on board LINUM-STM32H753BI

Impact
The user can enable and use LED driver.

Testing
Enabled LED driver on menuconfig and tested on application.