### PR TITLE
mm: Remove mm_spinlock

### DIFF
--- a/mm/mm_heap/mm.h
+++ b/mm/mm_heap/mm.h
@@ -258,7 +258,6 @@ struct mm_heap_s
    * immdiately.
    */
 
-  spinlock_t mm_spinlock;
   FAR struct mm_delaynode_s *mm_delaylist[CONFIG_SMP_NCPUS];
 
   /* The is a multiple mempool of the heap */

--- a/mm/mm_heap/mm_free.c
+++ b/mm/mm_heap/mm_free.c
@@ -45,12 +45,12 @@ static void add_delaylist(FAR struct mm_heap_s *heap, FAR void *mem)
 
   /* Delay the deallocation until a more appropriate time. */
 
-  flags = spin_lock_irqsave(&heap->mm_spinlock);
+  flags = up_irq_save();
 
   tmp->flink = heap->mm_delaylist[up_cpu_index()];
   heap->mm_delaylist[up_cpu_index()] = tmp;
 
-  spin_unlock_irqrestore(&heap->mm_spinlock, flags);
+  up_irq_restore(flags);
 #endif
 }
 

--- a/mm/mm_heap/mm_malloc.c
+++ b/mm/mm_heap/mm_malloc.c
@@ -47,12 +47,12 @@ static void free_delaylist(FAR struct mm_heap_s *heap)
 
   /* Move the delay list to local */
 
-  flags = spin_lock_irqsave(&heap->mm_spinlock);
+  flags = up_irq_save();
 
   tmp = heap->mm_delaylist[up_cpu_index()];
   heap->mm_delaylist[up_cpu_index()] = NULL;
 
-  spin_unlock_irqrestore(&heap->mm_spinlock, flags);
+  up_irq_restore(flags);
 
   /* Test if the delayed is empty */
 


### PR DESCRIPTION
## Summary

since it's enough to protect per cpu delay list by disabling interrupt

## Impact

code refactor

## Testing

ci