### PR TITLE
arch/arm: Let's old arm's arm_doirq return register context like armv7-a

### DIFF
--- a/arch/arm/src/arm/arm_doirq.c
+++ b/arch/arm/src/arm/arm_doirq.c
@@ -56,7 +56,7 @@
  * Public Functions
  ****************************************************************************/
 
-void arm_doirq(int irq, uint32_t *regs)
+uint32_t *arm_doirq(int irq, uint32_t *regs)
 {
   board_autoled_on(LED_INIRQ);
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
@@ -105,6 +105,8 @@ void arm_doirq(int irq, uint32_t *regs)
        */
 
       g_running_tasks[this_cpu()] = this_task();
+
+      regs = (uint32_t *)CURRENT_REGS;
     }
 
   /* Set CURRENT_REGS to NULL to indicate that we are no longer in an
@@ -114,4 +116,5 @@ void arm_doirq(int irq, uint32_t *regs)
   CURRENT_REGS = NULL;
 #endif
   board_autoled_off(LED_INIRQ);
+  return regs;
 }

--- a/arch/arm/src/common/arm_internal.h
+++ b/arch/arm/src/common/arm_internal.h
@@ -358,6 +358,11 @@ uintptr_t arm_intstack_top(void);
 void weak_function arm_initialize_stack(void);
 #endif
 
+/* Interrupt acknowledge and dispatch */
+
+void arm_ack_irq(int irq);
+uint32_t *arm_doirq(int irq, uint32_t *regs);
+
 /* Exception handling logic unique to the Cortex-M family */
 
 #if defined(CONFIG_ARCH_ARMV6M) || defined(CONFIG_ARCH_ARMV7M) || \
@@ -374,11 +379,6 @@ EXTERN const void *__vector_table[];
 #else
 EXTERN const void * const _vectors[];
 #endif
-
-/* Interrupt acknowledge and dispatch */
-
-void arm_ack_irq(int irq);
-uint32_t *arm_doirq(int irq, uint32_t *regs);
 
 /* Exception Handlers */
 
@@ -400,10 +400,6 @@ int  arm_securefault(int irq, void *context, void *arg);
 
 #elif defined(CONFIG_ARCH_ARMV7A) || defined(CONFIG_ARCH_ARMV7R) || defined(CONFIG_ARCH_ARMV8R)
 
-/* Interrupt acknowledge and dispatch */
-
-uint32_t *arm_doirq(int irq, uint32_t *regs);
-
 /* Paging support */
 
 #ifdef CONFIG_PAGING
@@ -423,11 +419,6 @@ uint32_t *arm_undefinedinsn(uint32_t *regs);
 /* Exception handling logic common to other ARM7 and ARM9 family. */
 
 #else /* ARM7 | ARM9 */
-
-/* Interrupt acknowledge and dispatch */
-
-void arm_ack_irq(int irq);
-void arm_doirq(int irq, uint32_t *regs);
 
 /* Paging support (and exception handlers) */
 


### PR DESCRIPTION
## Summary

and remove the duplicated arm_doirq and arm_ack_irq prototype

## Impact

no any functionality change

## Testing

ci