### PR TITLE
rp2040: pwm: Fix errors at CONFIG_PWM_NCHANNELS=1

### DIFF
--- a/arch/arm/src/rp2040/Kconfig
+++ b/arch/arm/src/rp2040/Kconfig
@@ -276,6 +276,7 @@ if PWM_MULTICHAN
 config PWM_NCHANNELS
 	int "Number of channels"
 	default 2
+	range 1 2
 	---help---
 		If the number of channels is set to 1, the generated code will
 		only support the A channel of the PWM slices.  This is functionally

--- a/arch/arm/src/rp2040/rp2040_pwm.c
+++ b/arch/arm/src/rp2040/rp2040_pwm.c
@@ -288,8 +288,8 @@ int pwm_shutdown (struct pwm_lowerhalf_s  * dev)
 
   if (priv->pin >= 0)
     {
-      rp2040_gpio_setdir(priv->pin[0], true);
-      rp2040_gpio_put(priv->pin[0],
+      rp2040_gpio_setdir(priv->pin, true);
+      rp2040_gpio_put(priv->pin,
                       ((priv->flags & RP2040_PWM_CSR_A_INV) != 0));
       rp2040_gpio_set_function(priv->pin, RP2040_GPIO_FUNC_SIO);
     }

--- a/boards/arm/rp2040/common/src/rp2040_pwmdev.c
+++ b/boards/arm/rp2040/common/src/rp2040_pwmdev.c
@@ -58,11 +58,18 @@ int rp2040_pwmdev_initialize(int      slice,
   int ret;
   struct rp2040_pwm_lowerhalf_s *pwm_lowerhalf;
 
+#if defined(CONFIG_PWM_NCHANNELS) && CONFIG_PWM_NCHANNELS == 2
   pwminfo("Initializing /dev/pwm%d a %d b %d f 0x%08lX..\n",
            slice,
            pin_a,
            pin_b,
            flags);
+#else
+  pwminfo("Initializing /dev/pwm%d %d 0x%08lX..\n",
+           slice,
+           pin,
+           flags);
+#endif
 
   /* Initialize spi device */
 


### PR DESCRIPTION
## Summary
Currently, we cannot build with ```CONFIG_PWM_NCHANNELS=1```.  
Perhaps it has just never been tested...