### PR TITLE
stm32/foc: add support for board-specific ioctl

### DIFF
--- a/arch/arm/src/stm32/stm32_foc.c
+++ b/arch/arm/src/stm32/stm32_foc.c
@@ -1657,7 +1657,14 @@ errout:
 static int stm32_foc_ioctl(struct foc_dev_s *dev, int cmd,
                            unsigned long arg)
 {
-  return -1;
+  struct stm32_foc_board_s *board = STM32_FOC_BOARD_FROM_DEV_GET(dev);
+
+  if (board->ops->ioctl != NULL)
+    {
+      return board->ops->ioctl(dev, cmd, arg);
+    }
+
+  return -ENOTTY;
 }
 
 /****************************************************************************

--- a/arch/arm/src/stm32/stm32_foc.h
+++ b/arch/arm/src/stm32/stm32_foc.h
@@ -89,6 +89,10 @@ struct stm32_foc_board_ops_s
 
   int (*shutdown)(struct foc_dev_s *dev);
 
+  /* Board-specific ioctl (optional) */
+
+  int (*ioctl)(struct foc_dev_s *dev, int cmd, unsigned long arg);
+
   /* Board-specific calibration setup */
 
   int (*calibration)(struct foc_dev_s *dev, bool state);

--- a/arch/arm/src/stm32f7/stm32_foc.c
+++ b/arch/arm/src/stm32f7/stm32_foc.c
@@ -1422,10 +1422,16 @@ errout:
  *
  ****************************************************************************/
 
-static int stm32_foc_ioctl(struct foc_dev_s *dev, int cmd,
-                           unsigned long arg)
+static int stm32_foc_ioctl(struct foc_dev_s *dev, int cmd, unsigned long arg)
 {
-  return -1;
+  struct stm32_foc_board_s *board = STM32_FOCBOARD_FROM_DEV_GET(dev);
+
+  if (board->ops->ioctl != NULL)
+    {
+      return board->ops->ioctl(dev, cmd, arg);
+    }
+
+  return -ENOTTY;
 }
 
 /****************************************************************************

--- a/arch/arm/src/stm32f7/stm32_foc.h
+++ b/arch/arm/src/stm32f7/stm32_foc.h
@@ -89,6 +89,10 @@ struct stm32_foc_board_ops_s
 
   int (*shutdown)(struct foc_dev_s *dev);
 
+  /* Board-specific ioctl (optional) */
+
+  int (*ioctl)(struct foc_dev_s *dev, int cmd, unsigned long arg);
+
   /* Board-specific calibration setup */
 
   int (*calibration)(struct foc_dev_s *dev, bool state);


### PR DESCRIPTION
## Summary
stm32/foc: add support for board-specific ioctl

## Impact

## Testing
CI
