### PR TITLE
drivers/foc: return scaling factor for phase currents and BEMF via ioctl

### DIFF
--- a/arch/arm/src/stm32/stm32_foc.h
+++ b/arch/arm/src/stm32/stm32_foc.h
@@ -106,6 +106,10 @@ struct stm32_foc_board_ops_s
   int (*current_get)(struct foc_dev_s *dev, int16_t *curr_raw,
                      foc_current_t *curr);
 
+  /* Board-specific info */
+
+  int (*info_get)(struct foc_dev_s *dev, struct foc_info_s *cfg);
+
 #ifdef CONFIG_MOTOR_FOC_BEMF_SENSE
   /* Get BEMF voltage */
 
@@ -141,14 +145,6 @@ struct stm32_foc_board_data_s
   /* PWM deadtime register value */
 
   uint8_t pwm_dt;
-
-  /* PWM deadtime in ns */
-
-  uint16_t pwm_dt_ns;
-
-  /* PWM max supported duty cycle */
-
-  foc_duty_t duty_max;
 };
 
 /* Board-specific FOC configuration */

--- a/arch/arm/src/stm32f7/stm32_foc.c
+++ b/arch/arm/src/stm32f7/stm32_foc.c
@@ -648,6 +648,8 @@ static int stm32_foc_start(struct foc_dev_s *dev, bool state);
 static int stm32_foc_pwm_duty_set(struct foc_dev_s *dev,
                                   foc_duty_t *duty);
 static int stm32_foc_pwm_off(struct foc_dev_s *dev, bool off);
+static int stm32_foc_info_get(struct foc_dev_s *dev,
+                              struct foc_info_s *info);
 static int stm32_foc_ioctl(struct foc_dev_s *dev, int cmd,
                            unsigned long arg);
 static int stm32_foc_bind(struct foc_dev_s *dev,
@@ -688,8 +690,6 @@ static void stm32_foc_adc_trgo_trg_set(struct foc_dev_s *dev,
 #else
 #  error Invalid FOC ADC trigger
 #endif
-
-static void stm32_foc_hw_config_get(struct foc_dev_s *dev);
 
 /****************************************************************************
  * Private Data
@@ -1095,12 +1095,14 @@ static void stm32_foc_adc_trgo_trg_set(struct foc_dev_s *dev,
 static int stm32_foc_configure(struct foc_dev_s *dev,
                                struct foc_cfg_s *cfg)
 {
-  struct stm32_foc_priv_s *priv = STM32_FOCPRIV_FROM_DEV_GET(dev);
-  int                      ret  = OK;
+  struct stm32_foc_priv_s  *priv  = STM32_FOCPRIV_FROM_DEV_GET(dev);
+  struct stm32_foc_board_s *board = STM32_FOCBOARD_FROM_DEV_GET(dev);
+  int                       ret   = OK;
 
   DEBUGASSERT(dev);
   DEBUGASSERT(cfg);
   DEBUGASSERT(priv);
+  DEBUGASSERT(board);
   DEBUGASSERT(cfg->pwm_freq > 0);
   DEBUGASSERT(cfg->notifier_freq > 0);
 
@@ -1308,10 +1310,6 @@ static int stm32_foc_setup(struct foc_dev_s *dev)
       mtrerr("irq_attach failed: %d\n", ret);
       goto errout;
     }
-
-  /* Get HW configuration */
-
-  stm32_foc_hw_config_get(dev);
 
 #ifdef CONFIG_MOTOR_FOC_TRACE
   /* Initialize trace interface */
@@ -1904,14 +1902,14 @@ static int stm32_foc_pwm_off(struct foc_dev_s *dev, bool off)
 }
 
 /****************************************************************************
- * Name: stm32_foc_hw_config_get
+ * Name: stm32_foc_info_get
  *
  * Description:
  *   Get HW configuration for FOC device
  *
  ****************************************************************************/
 
-static void stm32_foc_hw_config_get(struct foc_dev_s *dev)
+static int stm32_foc_info_get(struct foc_dev_s *dev, struct foc_info_s *info)
 {
   struct stm32_foc_board_s *board = STM32_FOCBOARD_FROM_DEV_GET(dev);
 
@@ -1920,8 +1918,7 @@ static void stm32_foc_hw_config_get(struct foc_dev_s *dev)
 
   /* Get data from board configuration */
 
-  dev->info.hw_cfg.pwm_dt_ns = board->data->pwm_dt_ns;
-  dev->info.hw_cfg.pwm_max   = board->data->duty_max;
+  return board->ops->info_get(dev, info);
 }
 
 /****************************************************************************
@@ -1967,7 +1964,7 @@ static void stm32_foc_curr_get(struct foc_dev_s *dev,
 
 static void stm32_foc_volt_get(struct foc_dev_s *dev, int16_t *volt)
 {
-  struct stm32_foc_priv_s *priv = STM32_FOC_PRIV_FROM_DEV_GET(dev);
+  struct stm32_foc_priv_s *priv = STM32_FOCPRIV_FROM_DEV_GET(dev);
   struct stm32_adc_dev_s  *vadc  = VADC_FROM_FOC_DEV_GET(dev);
   int                      i    = 0;
 
@@ -2229,6 +2226,7 @@ stm32_foc_initialize(int inst, struct stm32_foc_board_s *board)
   DEBUGASSERT(board->ops->fault_clear);
   DEBUGASSERT(board->ops->pwm_start);
   DEBUGASSERT(board->ops->current_get);
+  DEBUGASSERT(board->ops->info_get);
 #ifdef CONFIG_MOTOR_FOC_TRACE
   DEBUGASSERT(board->ops->trace_init);
   DEBUGASSERT(board->ops->trace);

--- a/arch/arm/src/stm32f7/stm32_foc.h
+++ b/arch/arm/src/stm32f7/stm32_foc.h
@@ -113,6 +113,10 @@ struct stm32_foc_board_ops_s
                      foc_voltage_t *volt);
 #endif
 
+  /* Board-specific info */
+
+  int (*info_get)(struct foc_dev_s *dev, struct foc_info_s *info);
+
 #ifdef CONFIG_MOTOR_FOC_TRACE
   /* FOC trace interface setup */
 
@@ -141,14 +145,6 @@ struct stm32_foc_board_data_s
   /* PWM deadtime register value */
 
   uint8_t pwm_dt;
-
-  /* PWM deadtime in ns */
-
-  uint16_t pwm_dt_ns;
-
-  /* PWM max supported duty cycle */
-
-  foc_duty_t duty_max;
 };
 
 /* Board-specific FOC configuration */

--- a/boards/arm/stm32/b-g431b-esc1/src/stm32_foc.c
+++ b/boards/arm/stm32/b-g431b-esc1/src/stm32_foc.c
@@ -390,7 +390,7 @@ static struct stm32_foc_board_data_s g_stm32_foc_board_data =
 #ifdef CONFIG_MOTOR_FOC_BEMF_SENSE
   .vadc_cfg = &g_vadc_cfg,
 #endif
-  .pwm_dt   = (PWM_DEADTIME),
+  .pwm_dt   = PWM_DEADTIME
 };
 
 /* Board specific configuration */
@@ -598,6 +598,17 @@ static int board_foc_info_get(struct foc_dev_s *dev, struct foc_info_s *info)
 
   info->hw_cfg.pwm_dt_ns = PWM_DEADTIME_NS;
   info->hw_cfg.pwm_max   = MAX_DUTY_B16;
+
+  /* ADC BEMF */
+
+#ifdef CONFIG_MOTOR_FOC_BEMF_SENSE
+  info->hw_cfg.bemf_scale = 0;      /* TODO */
+#endif
+
+  /* ADC Current - dynamic current scale not supported */
+
+  info->hw_cfg.iphase_max   = 40000;
+  info->hw_cfg.iphase_scale = -2939;
 
   return OK;
 }

--- a/boards/arm/stm32/b-g431b-esc1/src/stm32_foc.c
+++ b/boards/arm/stm32/b-g431b-esc1/src/stm32_foc.c
@@ -217,6 +217,8 @@ static int board_foc_voltage_get(struct foc_dev_s *dev,
                                  int16_t *volt_raw,
                                  foc_voltage_t *volt);
 #endif
+static int board_foc_info_get(struct foc_dev_s *dev,
+                              struct foc_info_s *info);
 #ifdef CONFIG_MOTOR_FOC_TRACE
 static int board_foc_trace_init(struct foc_dev_s *dev);
 static void board_foc_trace(struct foc_dev_s *dev, int type, bool state);
@@ -373,6 +375,7 @@ static struct stm32_foc_board_ops_s g_stm32_foc_board_ops =
 #ifdef CONFIG_MOTOR_FOC_BEMF_SENSE
   .voltage_get = board_foc_voltage_get,
 #endif
+  .info_get  = board_foc_info_get,
 #ifdef CONFIG_MOTOR_FOC_TRACE
   .trace_init  = board_foc_trace_init,
   .trace       = board_foc_trace
@@ -383,13 +386,11 @@ static struct stm32_foc_board_ops_s g_stm32_foc_board_ops =
 
 static struct stm32_foc_board_data_s g_stm32_foc_board_data =
 {
-  .adc_cfg   = &g_adc_cfg,
+  .adc_cfg  = &g_adc_cfg,
 #ifdef CONFIG_MOTOR_FOC_BEMF_SENSE
-  .vadc_cfg   = &g_vadc_cfg,
+  .vadc_cfg = &g_vadc_cfg,
 #endif
-  .duty_max  = (MAX_DUTY_B16),
-  .pwm_dt    = (PWM_DEADTIME),
-  .pwm_dt_ns = (PWM_DEADTIME_NS)
+  .pwm_dt   = (PWM_DEADTIME),
 };
 
 /* Board specific configuration */
@@ -581,6 +582,25 @@ static int board_foc_voltage_get(struct foc_dev_s *dev,
   return OK;
 }
 #endif
+
+/****************************************************************************
+ * Name: board_foc_info_get
+ ****************************************************************************/
+
+static int board_foc_info_get(struct foc_dev_s *dev, struct foc_info_s *info)
+{
+  DEBUGASSERT(dev);
+  DEBUGASSERT(info);
+
+  UNUSED(dev);
+
+  /* PWM */
+
+  info->hw_cfg.pwm_dt_ns = PWM_DEADTIME_NS;
+  info->hw_cfg.pwm_max   = MAX_DUTY_B16;
+
+  return OK;
+}
 
 #ifdef CONFIG_MOTOR_FOC_TRACE
 /****************************************************************************

--- a/boards/arm/stm32/common/src/stm32_ihm07m1.c
+++ b/boards/arm/stm32/common/src/stm32_ihm07m1.c
@@ -146,7 +146,7 @@ static struct stm32_foc_board_ops_s g_stm32_foc_board_ops =
 static struct stm32_foc_board_data_s g_stm32_foc_board_data =
 {
   .adc_cfg = NULL,     /* board-specific */
-  .pwm_dt  = (PWM_DEADTIME)
+  .pwm_dt  = PWM_DEADTIME
 };
 
 /* Board specific configuration */
@@ -306,6 +306,17 @@ static int board_foc_info_get(struct foc_dev_s *dev,
 
   info->hw_cfg.pwm_dt_ns = PWM_DEADTIME_NS;
   info->hw_cfg.pwm_max   = MAX_DUTY_B16;
+
+  /* ADC BEMF */
+
+#ifdef CONFIG_MOTOR_FOC_BEMF_SENSE
+  info->hw_cfg.bemf_scale = 0;      /* TODO */
+#endif
+
+  /* ADC Current - dynamic current scale not supported */
+
+  info->hw_cfg.iphase_max   = 1400;
+  info->hw_cfg.iphase_scale = -160;
 
   return OK;
 }

--- a/boards/arm/stm32/common/src/stm32_ihm07m1.c
+++ b/boards/arm/stm32/common/src/stm32_ihm07m1.c
@@ -113,6 +113,8 @@ static int board_foc_pwm_start(struct foc_dev_s *dev, bool state);
 static int board_foc_current_get(struct foc_dev_s *dev,
                                  int16_t *curr_raw,
                                  foc_current_t *curr);
+static int board_foc_info_get(struct foc_dev_s *dev,
+                              struct foc_info_s *info);
 #ifdef CONFIG_MOTOR_FOC_TRACE
 static int board_foc_trace_init(struct foc_dev_s *dev);
 static void board_foc_trace(struct foc_dev_s *dev, int type, bool state);
@@ -132,6 +134,7 @@ static struct stm32_foc_board_ops_s g_stm32_foc_board_ops =
   .fault_clear = board_foc_fault_clear,
   .pwm_start   = board_foc_pwm_start,
   .current_get = board_foc_current_get,
+  .info_get    = board_foc_info_get,
 #ifdef CONFIG_MOTOR_FOC_TRACE
   .trace_init  = board_foc_trace_init,
   .trace       = board_foc_trace
@@ -142,10 +145,8 @@ static struct stm32_foc_board_ops_s g_stm32_foc_board_ops =
 
 static struct stm32_foc_board_data_s g_stm32_foc_board_data =
 {
-  .adc_cfg   = NULL,     /* board-specific */
-  .duty_max  = (MAX_DUTY_B16),
-  .pwm_dt    = (PWM_DEADTIME),
-  .pwm_dt_ns = (PWM_DEADTIME_NS)
+  .adc_cfg = NULL,     /* board-specific */
+  .pwm_dt  = (PWM_DEADTIME)
 };
 
 /* Board specific configuration */
@@ -285,6 +286,26 @@ static int board_foc_trace_init(struct foc_dev_s *dev)
   stm32_configgpio(GPIO_FOC_DEBUG1);
   stm32_configgpio(GPIO_FOC_DEBUG2);
   stm32_configgpio(GPIO_FOC_DEBUG3);
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: board_foc_info_get
+ ****************************************************************************/
+
+static int board_foc_info_get(struct foc_dev_s *dev,
+                              struct foc_info_s *info)
+{
+  DEBUGASSERT(dev);
+  DEBUGASSERT(info);
+
+  UNUSED(dev);
+
+  /* PWM */
+
+  info->hw_cfg.pwm_dt_ns = PWM_DEADTIME_NS;
+  info->hw_cfg.pwm_max   = MAX_DUTY_B16;
 
   return OK;
 }

--- a/boards/arm/stm32/common/src/stm32_ihm08m1.c
+++ b/boards/arm/stm32/common/src/stm32_ihm08m1.c
@@ -154,7 +154,7 @@ static struct stm32_foc_board_ops_s g_stm32_foc_board_ops =
 static struct stm32_foc_board_data_s g_stm32_foc_board_data =
 {
   .adc_cfg = NULL,     /* board-specific */
-  .pwm_dt  = (PWM_DEADTIME)
+  .pwm_dt  = PWM_DEADTIME
 };
 
 /* Board specific configuration */
@@ -275,6 +275,17 @@ static int board_foc_info_get(struct foc_dev_s *dev,
 
   info->hw_cfg.pwm_dt_ns = PWM_DEADTIME_NS;
   info->hw_cfg.pwm_max   = MAX_DUTY_B16;
+
+  /* ADC BEMF */
+
+#ifdef CONFIG_MOTOR_FOC_BEMF_SENSE
+  info->hw_cfg.bemf_scale = 0;      /* TODO */
+#endif
+
+  /* ADC Current - dynamic current scale not supported */
+
+  info->hw_cfg.iphase_max   = 15000;
+  info->hw_cfg.iphase_scale = -1555;
 
   return OK;
 }

--- a/boards/arm/stm32/common/src/stm32_ihm08m1.c
+++ b/boards/arm/stm32/common/src/stm32_ihm08m1.c
@@ -121,6 +121,8 @@ static int board_foc_pwm_start(struct foc_dev_s *dev, bool state);
 static int board_foc_current_get(struct foc_dev_s *dev,
                                  int16_t *curr_raw,
                                  foc_current_t *curr);
+static int board_foc_info_get(struct foc_dev_s *dev,
+                              struct foc_info_s *info);
 #ifdef CONFIG_MOTOR_FOC_TRACE
 static int board_foc_trace_init(struct foc_dev_s *dev);
 static void board_foc_trace(struct foc_dev_s *dev, int type, bool state);
@@ -140,6 +142,7 @@ static struct stm32_foc_board_ops_s g_stm32_foc_board_ops =
   .fault_clear = board_foc_fault_clear,
   .pwm_start   = board_foc_pwm_start,
   .current_get = board_foc_current_get,
+  .info_get    = board_foc_info_get,
 #ifdef CONFIG_MOTOR_FOC_TRACE
   .trace_init  = board_foc_trace_init,
   .trace       = board_foc_trace
@@ -150,10 +153,8 @@ static struct stm32_foc_board_ops_s g_stm32_foc_board_ops =
 
 static struct stm32_foc_board_data_s g_stm32_foc_board_data =
 {
-  .adc_cfg   = NULL,     /* board-specific */
-  .duty_max  = (MAX_DUTY_B16),
-  .pwm_dt    = (PWM_DEADTIME),
-  .pwm_dt_ns = (PWM_DEADTIME_NS)
+  .adc_cfg = NULL,     /* board-specific */
+  .pwm_dt  = (PWM_DEADTIME)
 };
 
 /* Board specific configuration */
@@ -254,6 +255,26 @@ static int board_foc_current_get(struct foc_dev_s *dev,
   curr[0] = curr_raw[0];
   curr[1] = curr_raw[1];
   curr[2] = curr_raw[2];
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: board_foc_info_get
+ ****************************************************************************/
+
+static int board_foc_info_get(struct foc_dev_s *dev,
+                              struct foc_info_s *info)
+{
+  DEBUGASSERT(dev);
+  DEBUGASSERT(info);
+
+  UNUSED(dev);
+
+  /* PWM */
+
+  info->hw_cfg.pwm_dt_ns = PWM_DEADTIME_NS;
+  info->hw_cfg.pwm_max   = MAX_DUTY_B16;
 
   return OK;
 }

--- a/boards/arm/stm32/common/src/stm32_ihm16m1.c
+++ b/boards/arm/stm32/common/src/stm32_ihm16m1.c
@@ -111,6 +111,8 @@ static int board_foc_pwm_start(struct foc_dev_s *dev, bool state);
 static int board_foc_current_get(struct foc_dev_s *dev,
                                  int16_t *curr_raw,
                                  foc_current_t *curr);
+static int board_foc_info_get(struct foc_dev_s *dev,
+                              struct foc_info_s *info);
 #ifdef CONFIG_MOTOR_FOC_TRACE
 static int board_foc_trace_init(struct foc_dev_s *dev);
 static void board_foc_trace(struct foc_dev_s *dev, int type, bool state);
@@ -130,6 +132,7 @@ static struct stm32_foc_board_ops_s g_stm32_foc_board_ops =
   .fault_clear = board_foc_fault_clear,
   .pwm_start   = board_foc_pwm_start,
   .current_get = board_foc_current_get,
+  .info_get    = board_foc_info_get,
 #ifdef CONFIG_MOTOR_FOC_TRACE
   .trace_init  = board_foc_trace_init,
   .trace       = board_foc_trace
@@ -140,10 +143,8 @@ static struct stm32_foc_board_ops_s g_stm32_foc_board_ops =
 
 static struct stm32_foc_board_data_s g_stm32_foc_board_data =
 {
-  .adc_cfg   = NULL,     /* board-specific */
-  .duty_max  = (MAX_DUTY_B16),
-  .pwm_dt    = (PWM_DEADTIME),
-  .pwm_dt_ns = (PWM_DEADTIME_NS)
+  .adc_cfg = NULL,     /* board-specific */
+  .pwm_dt  = (PWM_DEADTIME)
 };
 
 /* Board specific configuration */
@@ -262,6 +263,26 @@ static int board_foc_current_get(struct foc_dev_s *dev,
   curr[0] = curr_raw[0];
   curr[1] = curr_raw[1];
   curr[2] = curr_raw[2];
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: board_foc_info_get
+ ****************************************************************************/
+
+static int board_foc_info_get(struct foc_dev_s *dev,
+                              struct foc_info_s *info)
+{
+  DEBUGASSERT(dev);
+  DEBUGASSERT(info);
+
+  UNUSED(dev);
+
+  /* PWM */
+
+  info->hw_cfg.pwm_dt_ns = PWM_DEADTIME_NS;
+  info->hw_cfg.pwm_max   = MAX_DUTY_B16;
 
   return OK;
 }

--- a/boards/arm/stm32/common/src/stm32_ihm16m1.c
+++ b/boards/arm/stm32/common/src/stm32_ihm16m1.c
@@ -144,7 +144,7 @@ static struct stm32_foc_board_ops_s g_stm32_foc_board_ops =
 static struct stm32_foc_board_data_s g_stm32_foc_board_data =
 {
   .adc_cfg = NULL,     /* board-specific */
-  .pwm_dt  = (PWM_DEADTIME)
+  .pwm_dt  = PWM_DEADTIME
 };
 
 /* Board specific configuration */
@@ -283,6 +283,17 @@ static int board_foc_info_get(struct foc_dev_s *dev,
 
   info->hw_cfg.pwm_dt_ns = PWM_DEADTIME_NS;
   info->hw_cfg.pwm_max   = MAX_DUTY_B16;
+
+  /* ADC BEMF */
+
+#ifdef CONFIG_MOTOR_FOC_BEMF_SENSE
+  info->hw_cfg.bemf_scale = 0;      /* TODO */
+#endif
+
+  /* ADC Current - dynamic current scale not supported */
+
+  info->hw_cfg.iphase_max   = 1500;
+  info->hw_cfg.iphase_scale = -160;
 
   return OK;
 }

--- a/boards/arm/stm32f7/steval-eth001v1/src/stm32_foc.c
+++ b/boards/arm/stm32f7/steval-eth001v1/src/stm32_foc.c
@@ -260,7 +260,7 @@ static struct stm32_foc_board_ops_s g_stm32_foc_board_ops =
 static struct stm32_foc_board_data_s g_stm32_foc_board_data =
 {
   .adc_cfg = &g_adc_cfg,
-  .pwm_dt  = (PWM_DEADTIME),
+  .pwm_dt  = PWM_DEADTIME,
 };
 
 /* Board specific configuration */
@@ -381,6 +381,17 @@ static int board_foc_info_get(struct foc_dev_s *dev,
 
   info->hw_cfg.pwm_dt_ns = PWM_DEADTIME_NS;
   info->hw_cfg.pwm_max   = MAX_DUTY_B16;
+
+  /* ADC BEMF */
+
+#ifdef CONFIG_MOTOR_FOC_BEMF_SENSE
+  info->hw_cfg.bemf_scale = 0;      /* TODO */
+#endif
+
+  /* ADC Current - dynamic current scale not supported */
+
+  info->hw_cfg.iphase_max   = 40000;
+  info->hw_cfg.iphase_scale = -2287;
 
   return OK;
 }

--- a/boards/arm/stm32f7/steval-eth001v1/src/stm32_foc.c
+++ b/boards/arm/stm32f7/steval-eth001v1/src/stm32_foc.c
@@ -155,6 +155,8 @@ static int board_foc_pwm_start(struct foc_dev_s *dev, bool state);
 static int board_foc_current_get(struct foc_dev_s *dev,
                                  int16_t *curr_raw,
                                  foc_current_t *curr);
+static int board_foc_info_get(struct foc_dev_s *dev,
+                              struct foc_info_s *info);
 #ifdef CONFIG_MOTOR_FOC_TRACE
 static int board_foc_trace_init(struct foc_dev_s *dev);
 static void board_foc_trace(struct foc_dev_s *dev, int type, bool state);
@@ -246,6 +248,7 @@ static struct stm32_foc_board_ops_s g_stm32_foc_board_ops =
   .fault_clear = board_foc_fault_clear,
   .pwm_start   = board_foc_pwm_start,
   .current_get = board_foc_current_get,
+  .info_get  = board_foc_info_get,
 #ifdef CONFIG_MOTOR_FOC_TRACE
   .trace_init  = board_foc_trace_init,
   .trace       = board_foc_trace
@@ -256,10 +259,8 @@ static struct stm32_foc_board_ops_s g_stm32_foc_board_ops =
 
 static struct stm32_foc_board_data_s g_stm32_foc_board_data =
 {
-  .adc_cfg   = &g_adc_cfg,
-  .duty_max  = (MAX_DUTY_B16),
-  .pwm_dt    = (PWM_DEADTIME),
-  .pwm_dt_ns = (PWM_DEADTIME_NS)
+  .adc_cfg = &g_adc_cfg,
+  .pwm_dt  = (PWM_DEADTIME),
 };
 
 /* Board specific configuration */
@@ -360,6 +361,26 @@ static int board_foc_current_get(struct foc_dev_s *dev,
   curr[0] = curr_raw[0];
   curr[1] = curr_raw[1];
   curr[2] = curr_raw[2];
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: board_foc_info_get
+ ****************************************************************************/
+
+static int board_foc_info_get(struct foc_dev_s *dev,
+                              struct foc_info_s *info)
+{
+  DEBUGASSERT(dev);
+  DEBUGASSERT(info);
+
+  UNUSED(dev);
+
+  /* PWM */
+
+  info->hw_cfg.pwm_dt_ns = PWM_DEADTIME_NS;
+  info->hw_cfg.pwm_max   = MAX_DUTY_B16;
 
   return OK;
 }

--- a/drivers/motor/foc/foc_dev.c
+++ b/drivers/motor/foc/foc_dev.c
@@ -404,6 +404,7 @@ static int foc_lower_ops_assert(FAR struct foc_lower_ops_s *ops)
   DEBUGASSERT(ops->shutdown);
   DEBUGASSERT(ops->start);
   DEBUGASSERT(ops->pwm_off);
+  DEBUGASSERT(ops->info_get);
   DEBUGASSERT(ops->ioctl);
   DEBUGASSERT(ops->bind);
   DEBUGASSERT(ops->fault_clear);
@@ -753,11 +754,9 @@ errout:
 static int foc_info_get(FAR struct foc_dev_s *dev,
                         FAR struct foc_info_s *info)
 {
-  /* Copy data from device */
+  /* Call lower-half logic */
 
-  memcpy(info, &dev->info, sizeof(struct foc_info_s));
-
-  return OK;
+  return FOC_OPS_INFOGET(dev, info);
 }
 
 /****************************************************************************

--- a/drivers/motor/foc/foc_dummy.c
+++ b/drivers/motor/foc/foc_dummy.c
@@ -107,7 +107,9 @@ static int foc_dummy_shutdown(FAR struct foc_dev_s *dev);
 static int foc_dummy_start(FAR struct foc_dev_s *dev, bool state);
 static int foc_dummy_pwm_duty_set(FAR struct foc_dev_s *dev,
                                   FAR foc_duty_t *duty);
-static int foc_pwm_off(struct foc_dev_s *dev, bool off);
+static int foc_dummy_pwm_off(FAR struct foc_dev_s *dev, bool off);
+static int foc_dummy_info_get(FAR struct foc_dev_s *dev,
+                              FAR struct foc_info_s *info);
 static int foc_dummy_ioctl(FAR struct foc_dev_s *dev, int cmd,
                            unsigned long arg);
 static int foc_dummy_bind(FAR struct foc_dev_s *dev,
@@ -123,7 +125,6 @@ static void foc_dummy_notifier_handler(FAR struct foc_dev_s *dev);
 
 /* Helpers */
 
-static void foc_dummy_hw_config_get(FAR struct foc_dev_s *dev);
 static int foc_dummy_notifier_cfg(FAR struct foc_dev_s *dev, uint32_t freq);
 static int foc_dummy_pwm_setup(FAR struct foc_dev_s *dev, uint32_t freq);
 static int foc_dummy_pwm_start(FAR struct foc_dev_s *dev, bool state);
@@ -147,8 +148,9 @@ static struct foc_lower_ops_s g_foc_dummy_ops =
   foc_dummy_setup,
   foc_dummy_shutdown,
   foc_dummy_pwm_duty_set,
-  foc_pwm_off,
+  foc_dummy_pwm_off,
   foc_dummy_start,
+  foc_dummy_info_get,
   foc_dummy_ioctl,
   foc_dummy_bind,
   foc_dummy_fault_clear,
@@ -396,10 +398,6 @@ static int foc_dummy_setup(FAR struct foc_dev_s *dev)
 
   mtrinfo("[FOC_SETUP]\n");
 
-  /* Get HW configuration */
-
-  foc_dummy_hw_config_get(dev);
-
   return OK;
 }
 
@@ -521,14 +519,14 @@ static int foc_dummy_pwm_duty_set(FAR struct foc_dev_s *dev,
 }
 
 /****************************************************************************
- * Name: foc_pwm_off
+ * Name: foc_dummy_pwm_off
  *
  * Description:
  *   Set the 3-phase bridge switches in off state.
  *
  ****************************************************************************/
 
-static int foc_pwm_off(struct foc_dev_s *dev, bool off)
+static int foc_dummy_pwm_off(FAR struct foc_dev_s *dev, bool off)
 {
   mtrinfo("[PWM_OFF] %d\n", off);
 
@@ -536,21 +534,22 @@ static int foc_pwm_off(struct foc_dev_s *dev, bool off)
 }
 
 /****************************************************************************
- * Name: foc_dummy_hw_config_get
+ * Name: foc_dummy_info_get
  *
  * Description:
- *   Get HW configuration for FOC controller
+ *   Get HW configuration for FOC device
  *
  ****************************************************************************/
 
-static void foc_dummy_hw_config_get(FAR struct foc_dev_s *dev)
+static int foc_dummy_info_get(FAR struct foc_dev_s *dev,
+                              FAR struct foc_info_s *info)
 {
-  DEBUGASSERT(dev);
-
   /* Get HW configuration */
 
-  dev->info.hw_cfg.pwm_dt_ns = FOC_DUMMY_HW_PWM_NS;
-  dev->info.hw_cfg.pwm_max   = ftob16(FOC_DUMMY_HW_PWM_MAX);
+  info->hw_cfg.pwm_dt_ns = FOC_DUMMY_HW_PWM_NS;
+  info->hw_cfg.pwm_max   = ftob16(FOC_DUMMY_HW_PWM_MAX);
+
+  return OK;
 }
 
 /****************************************************************************

--- a/drivers/motor/foc/foc_dummy.c
+++ b/drivers/motor/foc/foc_dummy.c
@@ -44,8 +44,11 @@
 
 /* Board HW configuration */
 
-#define FOC_DUMMY_HW_PWM_NS      (500)
-#define FOC_DUMMY_HW_PWM_MAX     (0.95f)
+#define FOC_DUMMY_HW_PWM_NS       (500)
+#define FOC_DUMMY_HW_PWM_MAX      (0.95f)
+#define FOC_DUMMY_HW_BEMF_SCALE   (1000)
+#define FOC_DUMMY_HW_IPHASE_SCALE (1000)
+#define FOC_DUMMY_HW_IPHASE_MAX   (40000)
 
 /* Helper macros ************************************************************/
 
@@ -546,8 +549,13 @@ static int foc_dummy_info_get(FAR struct foc_dev_s *dev,
 {
   /* Get HW configuration */
 
-  info->hw_cfg.pwm_dt_ns = FOC_DUMMY_HW_PWM_NS;
-  info->hw_cfg.pwm_max   = ftob16(FOC_DUMMY_HW_PWM_MAX);
+  info->hw_cfg.pwm_dt_ns    = FOC_DUMMY_HW_PWM_NS;
+  info->hw_cfg.pwm_max      = ftob16(FOC_DUMMY_HW_PWM_MAX);
+#ifdef CONFIG_MOTOR_FOC_BEMF_SENSE
+  info->hw_cfg.bemf_scale   = FOC_DUMMY_HW_IPHASE_SCALE;
+#endif
+  info->hw_cfg.iphase_max   = FOC_DUMMY_HW_IPHASE_MAX;
+  info->hw_cfg.iphase_scale = FOC_DUMMY_HW_IPHASE_SCALE;
 
   return OK;
 }

--- a/include/nuttx/motor/foc/foc.h
+++ b/include/nuttx/motor/foc/foc.h
@@ -98,9 +98,9 @@ struct foc_params_s
   foc_duty_t duty[CONFIG_MOTOR_FOC_PHASES]; /* PWM duty cycle for phases */
 };
 
-/* Hardware specific configuration */
+/* Hardware specific informations */
 
-struct foc_hw_config_s
+struct foc_info_hw_s
 {
   uint32_t   pwm_dt_ns;   /* PWM dead-time in nano seconds */
   foc_duty_t pwm_max;     /* Maximum PWM duty cycle */
@@ -110,7 +110,7 @@ struct foc_hw_config_s
 
 struct foc_info_s
 {
-  struct foc_hw_config_s hw_cfg; /* Hardware specific configuration */
+  struct foc_info_hw_s hw_cfg; /* Hardware specific informations  */
 };
 
 /* FOC device upper-half */

--- a/include/nuttx/motor/foc/foc.h
+++ b/include/nuttx/motor/foc/foc.h
@@ -102,8 +102,28 @@ struct foc_params_s
 
 struct foc_info_hw_s
 {
+  /* PWM configuration */
+
   uint32_t   pwm_dt_ns;   /* PWM dead-time in nano seconds */
   foc_duty_t pwm_max;     /* Maximum PWM duty cycle */
+
+  /* ADC configuration for phase current sampling
+   *
+   * In most cases it will be:
+   *
+   *   iphase_scale = iphase_ratio * adc_to_volt
+   *   adc_to_volt  = adc_ref_volt / adc_val_max
+   *   for shunt sensors iphase_ratio = 1 / (R_shunt * gain)
+   */
+
+  int32_t    iphase_scale;              /* Current phase scale [x100000] */
+  int32_t    iphase_max;                /* Maximum phase curretn [x1000] */
+
+  /* ADC configuration for BEMF sampling */
+
+#ifdef CONFIG_MOTOR_FOC_BEMF_SENSE
+  int32_t    bemf_scale;                /* BEMF sampling scale [x1000] */
+#endif
 };
 
 /* FOC driver info */

--- a/include/nuttx/motor/foc/foc_lower.h
+++ b/include/nuttx/motor/foc/foc_lower.h
@@ -48,6 +48,7 @@
 #define FOC_OPS_PWMOFF(d, o)            (d)->lower->ops->pwm_off(d, o)
 #define FOC_OPS_DUTY(d, x)              (d)->lower->ops->pwm_duty_set(d, x)
 #define FOC_OPS_IOCTL(d, c, a)          (d)->lower->ops->ioctl(d, c, a)
+#define FOC_OPS_INFOGET(d, i)           (d)->lower->ops->info_get(d, i)
 #define FOC_OPS_BIND(d, c)              (d)->lower->ops->bind(d, c)
 #define FOC_OPS_FAULT_CLEAR(d)          (d)->lower->ops->fault_clear(d)
 #ifdef CONFIG_MOTOR_FOC_TRACE
@@ -118,6 +119,11 @@ struct foc_lower_ops_s
   /* Lower-half start/stop */
 
   CODE int (*start)(FAR struct foc_dev_s *dev, bool state);
+
+  /* Get all hardware information */
+
+  CODE int (*info_get)(FAR struct foc_dev_s *dev,
+                       FAR struct foc_info_s *info);
 
   /* Lower-half IOCTL */
 


### PR DESCRIPTION
## Summary
- drivers/foc: get hardware information via lower-half interface
- drivers/foc: return scaling factor for phase currents and BEMF via ioctl  
    These values are board-specific properties that must be known on the application side.
    Until now, these values had to be hardcoded on the application side.
    
## Impact
we can get rid of the hardcoded ADC scaling values on the app side.
This is also the first step to support configurable phase currents gain.

## Testing
odriver3.6 board (not yet upstream)
