### PR TITLE
sched/taskfiles: skip unnecessary file open/close operations to improve performance

### DIFF
--- a/binfmt/CMakeLists.txt
+++ b/binfmt/CMakeLists.txt
@@ -36,6 +36,7 @@ list(
   binfmt_execmodule.c
   binfmt_exec.c
   binfmt_copyargv.c
+  binfmt_copyactions.c
   binfmt_dumpmodule.c
   binfmt_coredump.c)
 

--- a/binfmt/Makefile
+++ b/binfmt/Makefile
@@ -24,7 +24,7 @@ include $(TOPDIR)/Make.defs
 
 CSRCS  = binfmt_globals.c binfmt_initialize.c binfmt_register.c binfmt_unregister.c
 CSRCS += binfmt_loadmodule.c binfmt_unloadmodule.c binfmt_execmodule.c
-CSRCS += binfmt_exec.c binfmt_copyargv.c binfmt_dumpmodule.c
+CSRCS += binfmt_exec.c binfmt_copyargv.c binfmt_copyactions.c binfmt_dumpmodule.c
 CSRCS += binfmt_coredump.c
 
 ifeq ($(CONFIG_BINFMT_LOADABLE),y)

--- a/binfmt/binfmt.h
+++ b/binfmt/binfmt.h
@@ -165,6 +165,51 @@ void binfmt_freeargv(FAR char * const *argv);
 #  define binfmt_freeenv(envp)
 #endif
 
+/****************************************************************************
+ * Name: binfmt_copyactions
+ *
+ * Description:
+ *   In the kernel build, the file actions will likely lie in the caller's
+ *   address environment and, hence, be inaccessible when we switch to the
+ *   address environment of the new process address environment.  So we
+ *   do not have any real option other than to copy the callers action list.
+ *
+ * Input Parameters:
+ *   copy     - Pointer of file actions
+ *
+ * Returned Value:
+ *   A non-zero copy is returned on success.
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
+int binfmt_copyactions(FAR const posix_spawn_file_actions_t **copy,
+                       FAR const posix_spawn_file_actions_t *actions);
+#else
+#  define binfmt_copyactions(copy, actp) \
+          (*(copy) = (FAR posix_spawn_file_actions_t *)(actp), 0)
+#endif
+
+/****************************************************************************
+ * Name: binfmt_freeactions
+ *
+ * Description:
+ *   Release the copied file action list.
+ *
+ * Input Parameters:
+ *   copy     - Pointer of file actions
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
+void binfmt_freeactions(FAR const posix_spawn_file_actions_t *copy);
+#else
+#  define binfmt_freeactions(copy)
+#endif
+
 #ifdef CONFIG_BUILTIN
 /****************************************************************************
  * Name: builtin_initialize

--- a/binfmt/binfmt_copyactions.c
+++ b/binfmt/binfmt_copyactions.c
@@ -1,0 +1,194 @@
+/****************************************************************************
+ * binfmt/binfmt_copyactions.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <string.h>
+#include <debug.h>
+#include <errno.h>
+
+#include <nuttx/kmalloc.h>
+#include <nuttx/binfmt/binfmt.h>
+
+#include "binfmt.h"
+
+#if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL) && !defined(CONFIG_BINFMT_DISABLE)
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define ROUNDUP(x, y)     (((x) + (y) - 1) / (y) * (y))
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: binfmt_copyactions
+ *
+ * Description:
+ *   In the kernel build, the file actions will likely lie in the caller's
+ *   address environment and, hence, be inaccessible when we switch to the
+ *   address environment of the new process address environment.  So we
+ *   do not have any real option other than to copy the callers action list.
+ *
+ * Input Parameters:
+ *   copy     - Pointer of file actions
+ *
+ * Returned Value:
+ *   A non-zero copy is returned on success.
+ *
+ ****************************************************************************/
+
+int binfmt_copyactions(FAR const posix_spawn_file_actions_t **copy,
+                       FAR const posix_spawn_file_actions_t *actions)
+{
+  FAR struct spawn_general_file_action_s *entry;
+  FAR struct spawn_general_file_action_s *prev;
+  FAR struct spawn_close_file_action_s *close;
+  FAR struct spawn_open_file_action_s *open;
+  FAR struct spawn_open_file_action_s *tmp;
+  FAR struct spawn_dup2_file_action_s *dup2;
+  FAR void *buffer;
+  int size = 0;
+
+  if (actions == NULL)
+    {
+      *copy = NULL;
+      return OK;
+    }
+
+  for (entry = (FAR struct spawn_general_file_action_s *)actions;
+       entry != NULL;
+       entry = entry->flink)
+    {
+      switch (entry->action)
+        {
+          case SPAWN_FILE_ACTION_CLOSE:
+            size += sizeof(struct spawn_close_file_action_s);
+            break;
+
+          case SPAWN_FILE_ACTION_DUP2:
+            size += sizeof(struct spawn_dup2_file_action_s);
+            break;
+
+          case SPAWN_FILE_ACTION_OPEN:
+            open = (FAR struct spawn_open_file_action_s *)entry;
+            size += ROUNDUP(SIZEOF_OPEN_FILE_ACTION_S(strlen(open->path)),
+                            sizeof(FAR void *));
+            break;
+
+          default:
+            return -EINVAL;
+        }
+    }
+
+  *copy = buffer = kmm_malloc(size);
+  if (buffer == NULL)
+    {
+      return -ENOMEM;
+    }
+
+  for (entry = (FAR struct spawn_general_file_action_s *)actions,
+       prev = NULL; entry != NULL; prev = entry, entry = entry->flink)
+    {
+      switch (entry->action)
+        {
+          case SPAWN_FILE_ACTION_CLOSE:
+            close = buffer;
+            memcpy(close, entry, sizeof(struct spawn_close_file_action_s));
+            close->flink = NULL;
+            if (prev)
+              {
+                prev->flink = (FAR void *)close;
+              }
+
+            buffer = close + 1;
+            break;
+
+          case SPAWN_FILE_ACTION_DUP2:
+            dup2 = buffer;
+            memcpy(dup2, entry, sizeof(struct spawn_dup2_file_action_s));
+            dup2->flink = NULL;
+            if (prev)
+              {
+                prev->flink = (FAR void *)dup2;
+              }
+
+            buffer = dup2 + 1;
+            break;
+
+          case SPAWN_FILE_ACTION_OPEN:
+            tmp = (FAR struct spawn_open_file_action_s *)entry;
+            open = buffer;
+            memcpy(open, entry, sizeof(struct spawn_open_file_action_s));
+            open->flink = NULL;
+            if (prev)
+              {
+                prev->flink = (FAR void *)open;
+              }
+
+            strcpy(open->path, tmp->path);
+
+            buffer = (FAR char *)buffer +
+                     ROUNDUP(SIZEOF_OPEN_FILE_ACTION_S(strlen(tmp->path)),
+                             sizeof(FAR void *));
+            break;
+
+          default:
+            break;
+        }
+    }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: binfmt_freeactions
+ *
+ * Description:
+ *   Release the copied file action list.
+ *
+ * Input Parameters:
+ *   copy     - Pointer of file actions
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void binfmt_freeactions(FAR const posix_spawn_file_actions_t *copy)
+{
+  /* Is there an allocated argument buffer */
+
+  if (copy != NULL)
+    {
+      /* Free the argument buffer */
+
+      kmm_free((FAR void *)copy);
+    }
+}
+
+#endif

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -39,6 +39,7 @@
 #include <nuttx/semaphore.h>
 #include <nuttx/spinlock.h>
 #include <nuttx/mm/map.h>
+#include <nuttx/spawn.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -877,17 +878,9 @@ int files_countlist(FAR struct filelist *list);
  *
  ****************************************************************************/
 
-int files_duplist(FAR struct filelist *plist, FAR struct filelist *clist);
-
-/****************************************************************************
- * Name: files_close_onexec
- *
- * Description:
- *   Close specified task's file descriptors with O_CLOEXEC before exec.
- *
- ****************************************************************************/
-
-void files_close_onexec(FAR struct tcb_s *tcb);
+int files_duplist(FAR struct filelist *plist, FAR struct filelist *clist,
+                  FAR const posix_spawn_file_actions_t *actions,
+                  bool cloexec);
 
 /****************************************************************************
  * Name: file_allocate_from_tcb

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -923,7 +923,8 @@ FAR struct filelist *nxsched_get_files(void);
 
 int nxtask_init(FAR struct task_tcb_s *tcb, const char *name, int priority,
                 FAR void *stack, uint32_t stack_size, main_t entry,
-                FAR char * const argv[], FAR char * const envp[]);
+                FAR char * const argv[], FAR char * const envp[],
+                FAR const posix_spawn_file_actions_t *actions);
 
 /****************************************************************************
  * Name: nxtask_uninit

--- a/include/nuttx/spawn.h
+++ b/include/nuttx/spawn.h
@@ -100,8 +100,13 @@ extern "C"
 void add_file_action(FAR posix_spawn_file_actions_t *file_action,
                      FAR struct spawn_general_file_action_s *entry);
 
+struct tcb_s;
 int spawn_file_actions(FAR struct tcb_s *tcb,
                        FAR const posix_spawn_file_actions_t *actions);
+
+bool
+spawn_file_is_duplicateable(FAR const posix_spawn_file_actions_t *actions,
+                            int fd, bool cloexec);
 
 #ifdef __cplusplus
 }

--- a/sched/group/group.h
+++ b/sched/group/group.h
@@ -120,6 +120,8 @@ void group_remove_children(FAR struct task_group_s *group);
 /* Group data resource configuration */
 
 int  group_setupidlefiles(void);
-int  group_setuptaskfiles(FAR struct task_tcb_s *tcb);
+int  group_setuptaskfiles(FAR struct task_tcb_s *tcb,
+                          FAR const posix_spawn_file_actions_t *actions,
+                          bool cloexec);
 
 #endif /* __SCHED_GROUP_GROUP_H */

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -649,7 +649,7 @@ void nx_start(void)
         {
           /* Clone stdout, stderr, stdin from the CPU0 IDLE task. */
 
-          DEBUGVERIFY(group_setuptaskfiles(&g_idletcb[i]));
+          DEBUGVERIFY(group_setuptaskfiles(&g_idletcb[i], NULL, true));
         }
       else
         {

--- a/sched/task/task_create.c
+++ b/sched/task/task_create.c
@@ -96,16 +96,12 @@ int nxthread_create(FAR const char *name, uint8_t ttype, int priority,
   /* Initialize the task */
 
   ret = nxtask_init(tcb, name, priority, stack_addr, stack_size,
-                    entry, argv, envp);
+                    entry, argv, envp, NULL);
   if (ret < OK)
     {
       kmm_free(tcb);
       return ret;
     }
-
-  /* Close the file descriptors with O_CLOEXEC before active task */
-
-  files_close_onexec(&tcb->cmn);
 
   /* Get the assigned pid before we start the task */
 

--- a/sched/task/task_fork.c
+++ b/sched/task/task_fork.c
@@ -160,7 +160,7 @@ FAR struct task_tcb_s *nxtask_setup_fork(start_t retaddr)
 
   /* Associate file descriptors with the new task */
 
-  ret = group_setuptaskfiles(child);
+  ret = group_setuptaskfiles(child, NULL, false);
   if (ret < OK)
     {
       goto errout_with_tcb;

--- a/sched/task/task_init.c
+++ b/sched/task/task_init.c
@@ -86,7 +86,8 @@
 int nxtask_init(FAR struct task_tcb_s *tcb, const char *name, int priority,
                 FAR void *stack, uint32_t stack_size,
                 main_t entry, FAR char * const argv[],
-                FAR char * const envp[])
+                FAR char * const envp[],
+                FAR const posix_spawn_file_actions_t *actions)
 {
   uint8_t ttype = tcb->cmn.flags & TCB_FLAG_TTYPE_MASK;
   int ret;
@@ -127,7 +128,7 @@ int nxtask_init(FAR struct task_tcb_s *tcb, const char *name, int priority,
 
   /* Associate file descriptors with the new task */
 
-  ret = group_setuptaskfiles(tcb);
+  ret = group_setuptaskfiles(tcb, actions, true);
   if (ret < 0)
     {
       goto errout_with_group;

--- a/sched/task/task_spawn.c
+++ b/sched/task/task_spawn.c
@@ -104,7 +104,7 @@ static int nxtask_spawn_create(FAR const char *name, int priority,
   /* Initialize the task */
 
   ret = nxtask_init(tcb, name, priority, stack_addr, stack_size,
-                    entry, argv, envp);
+                    entry, argv, envp, actions);
   if (ret < OK)
     {
       kmm_free(tcb);
@@ -114,21 +114,6 @@ static int nxtask_spawn_create(FAR const char *name, int priority,
   /* Get the assigned pid before we start the task */
 
   pid = tcb->cmn.pid;
-
-  /* Perform file actions */
-
-  if (actions != NULL)
-    {
-      ret = spawn_file_actions(&tcb->cmn, actions);
-      if (ret < 0)
-        {
-          goto errout_with_taskinit;
-        }
-    }
-
-  /* Close the file descriptors with O_CLOEXEC before active task */
-
-  files_close_onexec(&tcb->cmn);
 
   /* Set the attributes */
 

--- a/sched/task/task_spawnparms.c
+++ b/sched/task/task_spawnparms.c
@@ -58,14 +58,15 @@
  *
  ****************************************************************************/
 
-static inline int nxspawn_close(FAR struct tcb_s *tcb,
-                                FAR struct spawn_close_file_action_s *action)
+static inline void
+nxspawn_close(FAR struct tcb_s *tcb,
+              FAR struct spawn_close_file_action_s *action)
 {
   /* The return value from nx_close() is ignored */
 
   sinfo("Closing fd=%d\n", action->fd);
 
-  return nx_close_from_tcb(tcb, action->fd);
+  nx_close_from_tcb(tcb, action->fd);
 }
 
 static inline int nxspawn_dup2(FAR struct tcb_s *tcb,
@@ -268,7 +269,13 @@ int spawn_file_actions(FAR struct tcb_s *tcb,
       switch (entry->action)
         {
           case SPAWN_FILE_ACTION_CLOSE:
-            ret = nxspawn_close(tcb, (FAR void *)entry);
+
+            /* Ignore return value of nxspawn_close(),
+             * Closing an invalid file descriptor will
+             * not cause the action fail.
+             */
+
+            nxspawn_close(tcb, (FAR void *)entry);
             break;
 
           case SPAWN_FILE_ACTION_DUP2:


### PR DESCRIPTION
## Summary

sched/taskfiles: skip unnecessary file open/close operations to improve performance

The task files should consult the "spawn action" and "O_CLOEXEC flags"
to determine further whether the file should be duplicated.

This PR will further optimize file list duplicating to avoid the performance
regression caused by additional file operations.

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

ci-check