### PR TITLE
uart_tcsendbreak: Remove cancel point, as tcsendbreak is not one

### DIFF
--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -500,20 +500,6 @@ static int uart_tcsendbreak(FAR uart_dev_t *dev, FAR struct file *filep,
 {
   int ret;
 
-  /* tcsendbreak is a cancellation point */
-
-  if (enter_cancellation_point())
-    {
-#ifdef CONFIG_CANCELLATION_POINTS
-      /* If there is a pending cancellation, then do not perform
-       * the wait.  Exit now with ECANCELED.
-       */
-
-      leave_cancellation_point();
-      return -ECANCELED;
-#endif
-    }
-
   /* REVISIT: Do we need to perform the equivalent of tcdrain() before
    * beginning the Break to avoid corrupting the transmit data? If so, note
    * that just calling uart_tcdrain() here would create a race condition,
@@ -553,7 +539,6 @@ static int uart_tcsendbreak(FAR uart_dev_t *dev, FAR struct file *filep,
       ret = -ENOTTY;
     }
 
-  leave_cancellation_point();
   return ret;
 }
 


### PR DESCRIPTION
## Summary
tcsendbreak is not a cancellation point -> remove cancel point logic from it.

Reference:
https://pubs.opengroup.org/onlinepubs/009695399/functions/xsh_chap02_09.html

## Impact
POSIX standard compliance
## Testing
None
