### PR TITLE
stm32/stm32_adc.c: protect irq_attach with refcounter

### DIFF
--- a/arch/arm/src/stm32/stm32_adc.c
+++ b/arch/arm/src/stm32/stm32_adc.c
@@ -2890,17 +2890,6 @@ static int adc_setup(struct adc_dev_s *dev)
       return OK;
     }
 
-  /* Attach the ADC interrupt */
-
-#ifndef CONFIG_STM32_ADC_NOIRQ
-  ret = irq_attach(priv->irq, priv->isr, NULL);
-  if (ret < 0)
-    {
-      ainfo("irq_attach failed: %d\n", ret);
-      return ret;
-    }
-#endif
-
   /* Make sure that the ADC device is in the powered up, reset state */
 
   adc_reset(dev);
@@ -2954,9 +2943,18 @@ static int adc_setup(struct adc_dev_s *dev)
   if (priv->cmn->refcount == 0)
 #endif
     {
+#ifndef CONFIG_STM32_ADC_NOIRQ
+      /* Attach the ADC interrupt */
+
+      ret = irq_attach(priv->irq, priv->isr, NULL);
+      if (ret < 0)
+        {
+          ainfo("irq_attach failed: %d\n", ret);
+          return ret;
+        }
+
       /* Enable the ADC interrupt */
 
-#ifndef CONFIG_STM32_ADC_NOIRQ
       ainfo("Enable the ADC interrupt: irq=%d\n", priv->irq);
       up_enable_irq(priv->irq);
 #endif


### PR DESCRIPTION
## Summary
stm32/stm32_adc.c: protect irq_attach with refcounter

irq_attach should only be called once for ADCs that share a common interrupt handler. We can move irq_attach to just before interrupts are enabled.

## Impact
fix occasional ADC irq handler overwrites for FOC dual motor configuration on stm32f4

## Testing
odrive3.6