### PR TITLE
Documentation, tools: Bump xpack-riscv-none-elf-gcc to 12.3.0-2

### DIFF
--- a/Documentation/platforms/risc-v/esp32c3/index.rst
+++ b/Documentation/platforms/risc-v/esp32c3/index.rst
@@ -39,7 +39,7 @@ check for the current compiler version being used. For instance:
    FROM nuttx-toolchain-base AS nuttx-toolchain-riscv
    # Download the latest RISCV GCC toolchain prebuilt by xPack
    RUN mkdir riscv-none-elf-gcc && \
-   curl -s -L "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-1/xpack-riscv-none-elf-gcc-12.3.0-1-linux-x64.tar.gz" \
+   curl -s -L "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-2/xpack-riscv-none-elf-gcc-12.3.0-2-linux-x64.tar.gz" \
    | tar -C riscv-none-elf-gcc --strip-components 1 -xz
 
 It uses the xPack's prebuilt toolchain based on GCC 12.3.0.
@@ -57,7 +57,7 @@ Download and extract toolchain:
 
 .. code-block:: console
 
-   $ curl -s -L "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-1/xpack-riscv-none-elf-gcc-12.3.0-1-linux-x64.tar.gz" \
+   $ curl -s -L "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-2/xpack-riscv-none-elf-gcc-12.3.0-2-linux-x64.tar.gz" \
    | tar -C /path/to/your/toolchain/riscv-none-elf-gcc --strip-components 1 -xz
 
 Add the toolchain to your `PATH`:

--- a/Documentation/platforms/risc-v/esp32c6/index.rst
+++ b/Documentation/platforms/risc-v/esp32c6/index.rst
@@ -39,7 +39,7 @@ check for the current compiler version being used. For instance:
    FROM nuttx-toolchain-base AS nuttx-toolchain-riscv
    # Download the latest RISCV GCC toolchain prebuilt by xPack
    RUN mkdir riscv-none-elf-gcc && \
-   curl -s -L "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-1/xpack-riscv-none-elf-gcc-12.3.0-1-linux-x64.tar.gz" \
+   curl -s -L "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-2/xpack-riscv-none-elf-gcc-12.3.0-2-linux-x64.tar.gz" \
    | tar -C riscv-none-elf-gcc --strip-components 1 -xz
 
 It uses the xPack's prebuilt toolchain based on GCC 12.3.0.
@@ -57,7 +57,7 @@ Download and extract toolchain:
 
 .. code-block:: console
 
-   $ curl -s -L "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-1/xpack-riscv-none-elf-gcc-12.3.0-1-linux-x64.tar.gz" \
+   $ curl -s -L "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-2/xpack-riscv-none-elf-gcc-12.3.0-2-linux-x64.tar.gz" \
    | tar -C /path/to/your/toolchain/riscv-none-elf-gcc --strip-components 1 -xz
 
 Add the toolchain to your `PATH`:

--- a/tools/ci/cibuild.sh
+++ b/tools/ci/cibuild.sh
@@ -337,10 +337,10 @@ function riscv-gcc-toolchain {
         ;;
     esac
     cd "${tools}"
-    wget --quiet https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-1/xpack-riscv-none-elf-gcc-12.3.0-1-${flavor}.tar.gz
-    tar zxf xpack-riscv-none-elf-gcc-12.3.0-1-${flavor}.tar.gz
-    mv xpack-riscv-none-elf-gcc-12.3.0-1 riscv-none-elf-gcc
-    rm xpack-riscv-none-elf-gcc-12.3.0-1-${flavor}.tar.gz
+    wget --quiet https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-2/xpack-riscv-none-elf-gcc-12.3.0-2-${flavor}.tar.gz
+    tar zxf xpack-riscv-none-elf-gcc-12.3.0-2-${flavor}.tar.gz
+    mv xpack-riscv-none-elf-gcc-12.3.0-2 riscv-none-elf-gcc
+    rm xpack-riscv-none-elf-gcc-12.3.0-2-${flavor}.tar.gz
   fi
 
   command riscv-none-elf-gcc --version

--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -170,7 +170,7 @@ RUN cd /tools/renesas-tools/build/gcc && \
 FROM nuttx-toolchain-base AS nuttx-toolchain-riscv
 # Download the latest RISCV GCC toolchain prebuilt by xPack
 RUN mkdir riscv-none-elf-gcc && \
-  curl -s -L "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-1/xpack-riscv-none-elf-gcc-12.3.0-1-linux-x64.tar.gz" \
+  curl -s -L "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-2/xpack-riscv-none-elf-gcc-12.3.0-2-linux-x64.tar.gz" \
   | tar -C riscv-none-elf-gcc --strip-components 1 -xz
 
 ###############################################################################


### PR DESCRIPTION
## Summary

- Upgraded to xpack-riscv-none-elf-gcc-12.3.0-2 to resolve symbol recognition issues in riscv-none-elf-gdb,
   as reported in https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/issues/22.

## Impact

- Expected to enhance toolchain stability with no negative side effects.

## Testing

- Verified with rv-virt:netnsh and rv-virt:netnsh64 configurations

