### PR TITLE
drivers/lcd: change lcd stride from pixel to bytes

### DIFF
--- a/drivers/lcd/lcd_dev.c
+++ b/drivers/lcd/lcd_dev.c
@@ -121,8 +121,7 @@ static int lcddev_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         size_t pixel_size = priv->planeinfo.bpp > 1 ?
                             priv->planeinfo.bpp >> 3 : 1;
         size_t row_size = lcd_area->stride > 0 ?
-                          lcd_area->stride * pixel_size :
-                          cols * pixel_size;
+                          lcd_area->stride : cols * pixel_size;
 
         if (priv->planeinfo.getarea)
           {
@@ -164,8 +163,7 @@ static int lcddev_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         size_t pixel_size = priv->planeinfo.bpp > 1 ?
                             priv->planeinfo.bpp >> 3 : 1;
         size_t row_size = lcd_area->stride > 0 ?
-                          lcd_area->stride * pixel_size :
-                          cols * pixel_size;
+                          lcd_area->stride : cols * pixel_size;
 
         if (priv->planeinfo.putarea)
           {

--- a/include/nuttx/lcd/lcd_dev.h
+++ b/include/nuttx/lcd/lcd_dev.h
@@ -87,7 +87,7 @@ struct lcddev_area_s
 {
   fb_coord_t row_start, row_end;
   fb_coord_t col_start, col_end;
-  fb_coord_t stride;
+  fb_coord_t stride;               /* row stride in bytes */
   FAR uint8_t *data;
 };
 


### PR DESCRIPTION
In order to achieve better scalability, change the stride from pixel mode to byte mode.For example, in the case of RGB888 mode with 466 pixels in width and a 4-byte aligned buffer,it is only necessary to extend the buffer of one line from 1398 bytes to 1400 bytes, instead of extending it to 1404 bytes.

## Summary

## Impact

## Testing

