### PR TITLE
s25fl1: fix compile warnings caused by incorrect variable print format

### DIFF
--- a/drivers/mtd/s25fl1.c
+++ b/drivers/mtd/s25fl1.c
@@ -36,6 +36,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
+#include <inttypes.h>
 
 #include <nuttx/kmalloc.h>
 #include <nuttx/signal.h>
@@ -1018,7 +1019,7 @@ static int s25fl1_write_page(struct s25fl1_dev_s *priv,
 
       if (ret < 0)
         {
-          ferr("ERROR: QSPI_MEMORY failed writing address=%06x\n",
+          ferr("ERROR: QSPI_MEMORY failed writing address=%06" PRIxOFF "\n",
                address);
           return ret;
         }
@@ -1443,7 +1444,8 @@ static int s25fl1_ioctl(FAR struct mtd_dev_s *dev,
 #endif
               ret               = OK;
 
-              finfo("blocksize: %d erasesize: %d neraseblocks: %d\n",
+              finfo("blocksize: %" PRIu32 " erasesize: %" PRIu32
+                    " neraseblocks: %" PRIu32 "\n",
                     geo->blocksize, geo->erasesize, geo->neraseblocks);
             }
         }


### PR DESCRIPTION
## Summary
Compilation warnings fixes.

## Impact
Build fixes.

## Testing
Build pass.
