### PR TITLE
arch/dumponexit: unify dump on exit to common code

### DIFF
--- a/arch/arm/src/common/arm_exit.c
+++ b/arch/arm/src/common/arm_exit.c
@@ -30,64 +30,12 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
-#ifdef CONFIG_DUMP_ON_EXIT
-#  include <nuttx/fs/fs.h>
-#endif
 
 #include "task/task.h"
 #include "sched/sched.h"
 #include "group/group.h"
 #include "irq/irq.h"
 #include "arm_internal.h"
-
-/****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-#ifndef CONFIG_DEBUG_SCHED_INFO
-#  undef CONFIG_DUMP_ON_EXIT
-#endif
-
-/****************************************************************************
- * Private Functions
- ****************************************************************************/
-
-/****************************************************************************
- * Name: _up_dumponexit
- *
- * Description:
- *   Dump the state of all tasks whenever on task exits.  This is debug
- *   instrumentation that was added to check file-related reference counting
- *   but could be useful again sometime in the future.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_DUMP_ON_EXIT
-static void _up_dumponexit(struct tcb_s *tcb, void *arg)
-{
-  struct filelist *filelist;
-  int i;
-  int j;
-
-  sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->name, tcb->pid);
-  sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
-
-  filelist = &tcb->group->tg_filelist;
-  for (i = 0; i < filelist->fl_rows; i++)
-    {
-      for (j = 0; j < CONFIG_NFILE_DESCRIPTORS_PER_BLOCK; j++)
-        {
-          struct inode *inode = filelist->fl_files[i][j].f_inode;
-          if (inode)
-            {
-              sinfo("      fd=%d refcount=%d\n",
-                    i * CONFIG_NFILE_DESCRIPTORS_PER_BLOCK + j,
-                    inode->i_crefs);
-            }
-        }
-    }
-}
-#endif
 
 /****************************************************************************
  * Public Functions
@@ -116,14 +64,11 @@ void up_exit(int status)
 
   sinfo("TCB=%p exiting\n", tcb);
 
+  nxsched_dumponexit();
+
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();
-
-#ifdef CONFIG_DUMP_ON_EXIT
-  sinfo("Other tasks:\n");
-  nxsched_foreach(_up_dumponexit, NULL);
-#endif
 
   /* Now, perform the context switch to the new ready-to-run task at the
    * head of the list.

--- a/arch/avr/src/common/avr_exit.c
+++ b/arch/avr/src/common/avr_exit.c
@@ -30,63 +30,11 @@
 #include <nuttx/addrenv.h>
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
-#ifdef CONFIG_DUMP_ON_EXIT
-#  include <nuttx/fs/fs.h>
-#endif
 
 #include "task/task.h"
 #include "sched/sched.h"
 #include "group/group.h"
 #include "avr_internal.h"
-
-/****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-#ifndef CONFIG_DEBUG_SCHED_INFO
-#  undef CONFIG_DUMP_ON_EXIT
-#endif
-
-/****************************************************************************
- * Private Functions
- ****************************************************************************/
-
-/****************************************************************************
- * Name: _up_dumponexit
- *
- * Description:
- *   Dump the state of all tasks whenever on task exits.  This is debug
- *   instrumentation that was added to check file-related reference counting
- *   but could be useful again sometime in the future.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_DUMP_ON_EXIT
-static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
-{
-  FAR struct filelist *filelist;
-  int i;
-  int j;
-
-  sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->name, tcb->pid);
-  sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
-
-  filelist = &tcb->group->tg_filelist;
-  for (i = 0; i < filelist->fl_rows; i++)
-    {
-      for (j = 0; j < CONFIG_NFILE_DESCRIPTORS_PER_BLOCK; j++)
-        {
-          struct inode *inode = filelist->fl_files[i][j].f_inode;
-          if (inode)
-            {
-              sinfo("      fd=%d refcount=%d\n",
-                    i * CONFIG_NFILE_DESCRIPTORS_PER_BLOCK + j,
-                    inode->i_crefs);
-            }
-        }
-    }
-}
-#endif
 
 /****************************************************************************
  * Public Functions
@@ -115,14 +63,11 @@ void up_exit(int status)
 
   sinfo("TCB=%p exiting\n", tcb);
 
+  nxsched_dumponexit();
+
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();
-
-#ifdef CONFIG_DUMP_ON_EXIT
-  sinfo("Other tasks:\n");
-  nxsched_foreach(_up_dumponexit, NULL);
-#endif
 
   /* Now, perform the context switch to the new ready-to-run task at the
    * head of the list.

--- a/arch/hc/src/common/hc_exit.c
+++ b/arch/hc/src/common/hc_exit.c
@@ -29,63 +29,11 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
-#ifdef CONFIG_DUMP_ON_EXIT
-#  include <nuttx/fs/fs.h>
-#endif
 
 #include "task/task.h"
 #include "sched/sched.h"
 #include "group/group.h"
 #include "hc_internal.h"
-
-/****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-#ifndef CONFIG_DEBUG_SCHED_INFO
-#  undef CONFIG_DUMP_ON_EXIT
-#endif
-
-/****************************************************************************
- * Private Functions
- ****************************************************************************/
-
-/****************************************************************************
- * Name: _up_dumponexit
- *
- * Description:
- *   Dump the state of all tasks whenever on task exits.  This is debug
- *   instrumentation that was added to check file-related reference counting
- *   but could be useful again sometime in the future.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_DUMP_ON_EXIT
-static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
-{
-  FAR struct filelist *filelist;
-  int i;
-  int j;
-
-  sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->name, tcb->pid);
-  sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
-
-  filelist = &tcb->group->tg_filelist;
-  for (i = 0; i < filelist->fl_rows; i++)
-    {
-      for (j = 0; j < CONFIG_NFILE_DESCRIPTORS_PER_BLOCK; j++)
-        {
-          struct inode *inode = filelist->fl_files[i][j].f_inode;
-          if (inode)
-            {
-              sinfo("      fd=%d refcount=%d\n",
-                    i * CONFIG_NFILE_DESCRIPTORS_PER_BLOCK + j,
-                    inode->i_crefs);
-            }
-        }
-    }
-}
-#endif
 
 /****************************************************************************
  * Public Functions
@@ -114,14 +62,11 @@ void up_exit(int status)
 
   sinfo("TCB=%p exiting\n", tcb);
 
+  nxsched_dumponexit();
+
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();
-
-#ifdef CONFIG_DUMP_ON_EXIT
-  sinfo("Other tasks:\n");
-  nxsched_foreach(_up_dumponexit, NULL);
-#endif
 
   /* Now, perform the context switch to the new ready-to-run task at the
    * head of the list.

--- a/arch/mips/src/common/mips_exit.c
+++ b/arch/mips/src/common/mips_exit.c
@@ -31,63 +31,11 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
-#ifdef CONFIG_DUMP_ON_EXIT
-#  include <nuttx/fs/fs.h>
-#endif
 
 #include "task/task.h"
 #include "sched/sched.h"
 #include "group/group.h"
 #include "mips_internal.h"
-
-/****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-#ifndef CONFIG_DEBUG_SCHED_INFO
-#  undef CONFIG_DUMP_ON_EXIT
-#endif
-
-/****************************************************************************
- * Private Functions
- ****************************************************************************/
-
-/****************************************************************************
- * Name: _up_dumponexit
- *
- * Description:
- *   Dump the state of all tasks whenever on task exits.  This is debug
- *   instrumentation that was added to check file-related reference counting
- *   but could be useful again sometime in the future.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_DUMP_ON_EXIT
-static void _up_dumponexit(struct tcb_s *tcb, void *arg)
-{
-  struct filelist *filelist;
-  int i;
-  int j;
-
-  sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->name, tcb->pid);
-  sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
-
-  filelist = &tcb->group->tg_filelist;
-  for (i = 0; i < filelist->fl_rows; i++)
-    {
-      for (j = 0; j < CONFIG_NFILE_DESCRIPTORS_PER_BLOCK; j++)
-        {
-          struct inode *inode = filelist->fl_files[i][j].f_inode;
-          if (inode)
-            {
-              sinfo("      fd=%d refcount=%d\n",
-                    i * CONFIG_NFILE_DESCRIPTORS_PER_BLOCK + j,
-                    inode->i_crefs);
-            }
-        }
-    }
-}
-#endif
 
 /****************************************************************************
  * Public Functions
@@ -116,14 +64,11 @@ void up_exit(int status)
 
   sinfo("TCB=%p exiting\n", tcb);
 
+  nxsched_dumponexit();
+
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();
-
-#ifdef CONFIG_DUMP_ON_EXIT
-  sinfo("Other tasks:\n");
-  nxsched_foreach(_up_dumponexit, NULL);
-#endif
 
   /* Now, perform the context switch to the new ready-to-run task at the
    * head of the list.

--- a/arch/misoc/src/lm32/lm32_exit.c
+++ b/arch/misoc/src/lm32/lm32_exit.c
@@ -29,9 +29,6 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
-#ifdef CONFIG_DUMP_ON_EXIT
-#  include <nuttx/fs/fs.h>
-#endif
 
 #include <arch/syscall.h>
 
@@ -39,47 +36,6 @@
 #include "sched/sched.h"
 #include "group/group.h"
 #include "lm32.h"
-
-/****************************************************************************
- * Private Functions
- ****************************************************************************/
-
-/****************************************************************************
- * Name: _up_dumponexit
- *
- * Description:
- *   Dump the state of all tasks whenever on task exits.  This is debug
- *   instrumentation that was added to check file-related reference counting
- *   but could be useful again sometime in the future.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_DUMP_ON_EXIT
-static void _up_dumponexit(struct tcb_s *tcb, void *arg)
-{
-  struct filelist *filelist;
-  int i;
-  int j;
-
-  sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->name, tcb->pid);
-  sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
-
-  filelist = &tcb->group->tg_filelist;
-  for (i = 0; i < filelist->fl_rows; i++)
-    {
-      for (j = 0; j < CONFIG_NFILE_DESCRIPTORS_PER_BLOCK; j++)
-        {
-          struct inode *inode = filelist->fl_files[i][j].f_inode;
-          if (inode)
-            {
-              sinfo("      fd=%d refcount=%d\n",
-                    i * CONFIG_NFILE_DESCRIPTORS_PER_BLOCK + j,
-                    inode->i_crefs);
-            }
-        }
-    }
-}
-#endif
 
 /****************************************************************************
  * Public Functions
@@ -108,14 +64,11 @@ void up_exit(int status)
 
   sinfo("TCB=%p exiting\n", tcb);
 
+  nxsched_dumponexit();
+
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();
-
-#ifdef CONFIG_DUMP_ON_EXIT
-  sinfo("Other tasks:\n");
-  nxsched_foreach(_up_dumponexit, NULL);
-#endif
 
   /* Now, perform the context switch to the new ready-to-run task at the
    * head of the list.

--- a/arch/misoc/src/minerva/minerva_exit.c
+++ b/arch/misoc/src/minerva/minerva_exit.c
@@ -29,9 +29,6 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
-#ifdef CONFIG_DUMP_ON_EXIT
-#  include <nuttx/fs/fs.h>
-#endif
 
 #include <arch/syscall.h>
 
@@ -39,47 +36,6 @@
 #include "sched/sched.h"
 #include "group/group.h"
 #include "minerva.h"
-
-/****************************************************************************
- * Private Functions
- ****************************************************************************/
-
-/****************************************************************************
- * Name: _up_dumponexit
- *
- * Description:
- *   Dump the state of all tasks whenever on task exits.  This is debug
- *   instrumentation that was added to check file-related reference counting
- *   but could be useful again sometime in the future.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_DUMP_ON_EXIT
-static void _up_dumponexit(struct tcb_s *tcb, void *arg)
-{
-  struct filelist *filelist;
-  int i;
-  int j;
-
-  sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->name, tcb->pid);
-  sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
-
-  filelist = &tcb->group->tg_filelist;
-  for (i = 0; i < filelist->fl_rows; i++)
-    {
-      for (j = 0; j < CONFIG_NFILE_DESCRIPTORS_PER_BLOCK; j++)
-        {
-          struct inode *inode = filelist->fl_files[i][j].f_inode;
-          if (inode)
-            {
-              sinfo("      fd=%d refcount=%d\n",
-                    i * CONFIG_NFILE_DESCRIPTORS_PER_BLOCK + j,
-                    inode->i_crefs);
-            }
-        }
-    }
-}
-#endif
 
 /****************************************************************************
  * Public Functions
@@ -108,14 +64,11 @@ void up_exit(int status)
 
   sinfo("TCB=%p exiting\n", tcb);
 
+  nxsched_dumponexit();
+
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();
-
-#ifdef CONFIG_DUMP_ON_EXIT
-  sinfo("Other tasks:\n");
-  nxsched_foreach(_up_dumponexit, NULL);
-#endif
 
   /* Now, perform the context switch to the new ready-to-run task at the head
    * of the list.

--- a/arch/or1k/src/common/or1k_exit.c
+++ b/arch/or1k/src/common/or1k_exit.c
@@ -30,64 +30,12 @@
 #include <nuttx/addrenv.h>
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
-#ifdef CONFIG_DUMP_ON_EXIT
-#  include <nuttx/fs/fs.h>
-#endif
 
 #include "task/task.h"
 #include "sched/sched.h"
 #include "group/group.h"
 #include "irq/irq.h"
 #include "or1k_internal.h"
-
-/****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-#ifndef CONFIG_DEBUG_SCHED_INFO
-#  undef CONFIG_DUMP_ON_EXIT
-#endif
-
-/****************************************************************************
- * Private Functions
- ****************************************************************************/
-
-/****************************************************************************
- * Name: _up_dumponexit
- *
- * Description:
- *   Dump the state of all tasks whenever on task exits.  This is debug
- *   instrumentation that was added to check file-related reference counting
- *   but could be useful again sometime in the future.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_DUMP_ON_EXIT
-static void _up_dumponexit(struct tcb_s *tcb, void *arg)
-{
-  struct filelist *filelist;
-  int i;
-  int j;
-
-  sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->name, tcb->pid);
-  sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
-
-  filelist = &tcb->group->tg_filelist;
-  for (i = 0; i < filelist->fl_rows; i++)
-    {
-      for (j = 0; j < CONFIG_NFILE_DESCRIPTORS_PER_BLOCK; j++)
-        {
-          struct inode *inode = filelist->fl_files[i][j].f_inode;
-          if (inode)
-            {
-              sinfo("      fd=%d refcount=%d\n",
-                    i * CONFIG_NFILE_DESCRIPTORS_PER_BLOCK + j,
-                    inode->i_crefs);
-            }
-        }
-    }
-}
-#endif
 
 /****************************************************************************
  * Public Functions
@@ -116,14 +64,11 @@ void up_exit(int status)
 
   sinfo("TCB=%p exiting\n", tcb);
 
+  nxsched_dumponexit();
+
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();
-
-#ifdef CONFIG_DUMP_ON_EXIT
-  sinfo("Other tasks:\n");
-  nxsched_foreach(_up_dumponexit, NULL);
-#endif
 
   /* Now, perform the context switch to the new ready-to-run task at the
    * head of the list.

--- a/arch/renesas/src/common/renesas_exit.c
+++ b/arch/renesas/src/common/renesas_exit.c
@@ -29,63 +29,11 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
-#ifdef CONFIG_DUMP_ON_EXIT
-#  include <nuttx/fs/fs.h>
-#endif
 
 #include "task/task.h"
 #include "sched/sched.h"
 #include "group/group.h"
 #include "renesas_internal.h"
-
-/****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-#ifndef CONFIG_DEBUG_SCHED_INFO
-#  undef CONFIG_DUMP_ON_EXIT
-#endif
-
-/****************************************************************************
- * Private Functions
- ****************************************************************************/
-
-/****************************************************************************
- * Name: _up_dumponexit
- *
- * Description:
- *   Dump the state of all tasks whenever on task exits.  This is debug
- *   instrumentation that was added to check file-related reference counting
- *   but could be useful again sometime in the future.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_DUMP_ON_EXIT
-static void _up_dumponexit(struct tcb_s *tcb, void *arg)
-{
-  struct filelist *filelist;
-  int i;
-  int j;
-
-  sinfo("  TCB=%p name=%s\n", tcb, tcb->name);
-  sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
-
-  filelist = &tcb->group->tg_filelist;
-  for (i = 0; i < filelist->fl_rows; i++)
-    {
-      for (j = 0; j < CONFIG_NFILE_DESCRIPTORS_PER_BLOCK; j++)
-        {
-          struct inode *inode = filelist->fl_files[i][j].f_inode;
-          if (inode)
-            {
-              sinfo("      fd=%d refcount=%d\n",
-                    i * CONFIG_NFILE_DESCRIPTORS_PER_BLOCK + j,
-                    inode->i_crefs);
-            }
-        }
-    }
-}
-#endif
 
 /****************************************************************************
  * Public Functions
@@ -114,14 +62,11 @@ void up_exit(int status)
 
   sinfo("TCB=%p exiting\n", tcb);
 
+  nxsched_dumponexit();
+
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();
-
-#ifdef CONFIG_DUMP_ON_EXIT
-  sinfo("Other tasks:\n");
-  nxsched_foreach(_up_dumponexit, NULL);
-#endif
 
   /* Now, perform the context switch to the new ready-to-run task at the
    * head of the list.

--- a/arch/sparc/src/common/sparc_exit.c
+++ b/arch/sparc/src/common/sparc_exit.c
@@ -31,58 +31,11 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
-#ifdef CONFIG_DUMP_ON_EXIT
-#  include <nuttx/fs/fs.h>
-#endif
 
 #include "task/task.h"
 #include "sched/sched.h"
 #include "group/group.h"
 #include "sparc_internal.h"
-
-/****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-#ifndef CONFIG_DEBUG_SCHED_INFO
-#  undef CONFIG_DUMP_ON_EXIT
-#endif
-
-/****************************************************************************
- * Private Functions
- ****************************************************************************/
-
-/****************************************************************************
- * Name: _up_dumponexit
- *
- * Description:
- *   Dump the state of all tasks whenever on task exits.  This is debug
- *   instrumentation that was added to check file-related reference counting
- *   but could be useful again sometime in the future.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_DUMP_ON_EXIT
-static void _up_dumponexit(struct tcb_s *tcb, void *arg)
-{
-  struct filelist *filelist;
-  int i;
-
-  sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->argv[0], tcb->pid);
-  sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
-
-  filelist = &tcb->group->tg_filelist;
-  for (i = 0; i < CONFIG_NFILE_DESCRIPTORS; i++)
-    {
-      struct inode *inode = filelist->fl_files[i].f_inode;
-      if (inode)
-        {
-          sinfo("      fd=%d refcount=%d\n",
-                i, inode->i_crefs);
-        }
-    }
-}
-#endif
 
 /****************************************************************************
  * Public Functions
@@ -111,6 +64,8 @@ void up_exit(int status)
 
   sinfo("TCB=%p exiting\n", tcb);
 
+  nxsched_dumponexit();
+
   /* Update scheduler parameters */
 
   nxsched_suspend_scheduler(tcb);
@@ -118,11 +73,6 @@ void up_exit(int status)
   /* Destroy the task at the head of the ready to run list. */
 
   (void)nxtask_exit();
-
-#ifdef CONFIG_DUMP_ON_EXIT
-  sinfo("Other tasks:\n");
-  sched_foreach(_up_dumponexit, NULL);
-#endif
 
   /* Now, perform the context switch to the new ready-to-run task at the
    * head of the list.

--- a/arch/x86/src/common/x86_exit.c
+++ b/arch/x86/src/common/x86_exit.c
@@ -30,63 +30,11 @@
 #include <nuttx/addrenv.h>
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
-#ifdef CONFIG_DUMP_ON_EXIT
-#  include <nuttx/fs/fs.h>
-#endif
 
 #include "task/task.h"
 #include "sched/sched.h"
 #include "group/group.h"
 #include "x86_internal.h"
-
-/****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-#ifndef CONFIG_DEBUG_SCHED_INFO
-#  undef CONFIG_DUMP_ON_EXIT
-#endif
-
-/****************************************************************************
- * Private Functions
- ****************************************************************************/
-
-/****************************************************************************
- * Name: _up_dumponexit
- *
- * Description:
- *   Dump the state of all tasks whenever on task exits.  This is debug
- *   instrumentation that was added to check file-related reference counting
- *   but could be useful again sometime in the future.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_DUMP_ON_EXIT
-static void _up_dumponexit(struct tcb_s *tcb, void *arg)
-{
-  struct filelist *filelist;
-  int i;
-  int j;
-
-  sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->name, tcb->pid);
-  sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
-
-  filelist = &tcb->group->tg_filelist;
-  for (i = 0; i < filelist->fl_rows; i++)
-    {
-      for (j = 0; j < CONFIG_NFILE_DESCRIPTORS_PER_BLOCK; j++)
-        {
-          struct inode *inode = filelist->fl_files[i][j].f_inode;
-          if (inode)
-            {
-              sinfo("      fd=%d refcount=%d\n",
-                    i * CONFIG_NFILE_DESCRIPTORS_PER_BLOCK + j,
-                    inode->i_crefs);
-            }
-        }
-    }
-}
-#endif
 
 /****************************************************************************
  * Public Functions
@@ -115,14 +63,11 @@ void up_exit(int status)
 
   sinfo("TCB=%p exiting\n", tcb);
 
+  nxsched_dumponexit();
+
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();
-
-#ifdef CONFIG_DUMP_ON_EXIT
-  sinfo("Other tasks:\n");
-  nxsched_foreach(_up_dumponexit, NULL);
-#endif
 
   /* Now, perform the context switch to the new ready-to-run task at the
    * head of the list.

--- a/arch/x86_64/src/common/x86_64_exit.c
+++ b/arch/x86_64/src/common/x86_64_exit.c
@@ -29,63 +29,11 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
-#ifdef CONFIG_DUMP_ON_EXIT
-#  include <nuttx/fs/fs.h>
-#endif
 
 #include "task/task.h"
 #include "sched/sched.h"
 #include "group/group.h"
 #include "x86_64_internal.h"
-
-/****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-#ifndef CONFIG_DEBUG_SCHED_INFO
-#  undef CONFIG_DUMP_ON_EXIT
-#endif
-
-/****************************************************************************
- * Private Functions
- ****************************************************************************/
-
-/****************************************************************************
- * Name: _up_dumponexit
- *
- * Description:
- *   Dump the state of all tasks whenever on task exits.  This is debug
- *   instrumentation that was added to check file-related reference counting
- *   but could be useful again sometime in the future.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_DUMP_ON_EXIT
-static void _up_dumponexit(struct tcb_s *tcb, void *arg)
-{
-  struct filelist *filelist;
-  int i;
-  int j;
-
-  sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->name, tcb->pid);
-  sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
-
-  filelist = &tcb->group->tg_filelist;
-  for (i = 0; i < filelist->fl_rows; i++)
-    {
-      for (j = 0; j < CONFIG_NFILE_DESCRIPTORS_PER_BLOCK; j++)
-        {
-          struct inode *inode = filelist->fl_files[i][j].f_inode;
-          if (inode)
-            {
-              sinfo("      fd=%d refcount=%d\n",
-                    i * CONFIG_NFILE_DESCRIPTORS_PER_BLOCK + j,
-                    inode->i_crefs);
-            }
-        }
-    }
-}
-#endif
 
 /****************************************************************************
  * Public Functions
@@ -114,14 +62,11 @@ void up_exit(int status)
 
   sinfo("TCB=%p exiting\n", this_task());
 
+  nxsched_dumponexit();
+
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();
-
-#ifdef CONFIG_DUMP_ON_EXIT
-  sinfo("Other tasks:\n");
-  nxsched_foreach(_up_dumponexit, NULL);
-#endif
 
   /* Now, perform the context switch to the new ready-to-run task at the
    * head of the list.

--- a/arch/x86_64/src/common/x86_64_internal.h
+++ b/arch/x86_64/src/common/x86_64_internal.h
@@ -47,11 +47,6 @@
 #undef  CONFIG_SUPPRESS_TIMER_INTS    /* DEFINED: No timer */
 #undef  CONFIG_SUPPRESS_SERIAL_INTS   /* DEFINED: Console will poll */
 #undef  CONFIG_SUPPRESS_UART_CONFIG   /* DEFINED: Do not reconfig UART */
-#undef  CONFIG_DUMP_ON_EXIT           /* DEFINED: Dump task state on exit */
-
-#ifndef CONFIG_DEBUG_SCHED_INFO
-#  undef CONFIG_DUMP_ON_EXIT          /* Needs CONFIG_DEBUG_SCHED_INFO */
-#endif
 
 /* Determine which (if any) console driver to use.  If a console is enabled
  * and no other console device is specified, then a serial console is

--- a/arch/xtensa/src/common/xtensa_exit.c
+++ b/arch/xtensa/src/common/xtensa_exit.c
@@ -31,63 +31,11 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
-#ifdef CONFIG_DUMP_ON_EXIT
-#  include <nuttx/fs/fs.h>
-#endif
 
 #include "task/task.h"
 #include "sched/sched.h"
 #include "group/group.h"
 #include "xtensa.h"
-
-/****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-#ifndef CONFIG_DEBUG_SCHED_INFO
-#  undef CONFIG_DUMP_ON_EXIT
-#endif
-
-/****************************************************************************
- * Private Functions
- ****************************************************************************/
-
-/****************************************************************************
- * Name: _xtensa_dumponexit
- *
- * Description:
- *   Dump the state of all tasks whenever on task exits.  This is debug
- *   instrumentation that was added to check file-related reference counting
- *   but could be useful again sometime in the future.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_DUMP_ON_EXIT
-static void _xtensa_dumponexit(struct tcb_s *tcb, void *arg)
-{
-  struct filelist *filelist;
-  int i;
-  int j;
-
-  sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->name, tcb->pid);
-  sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
-
-  filelist = &tcb->group->tg_filelist;
-  for (i = 0; i < filelist->fl_rows; i++)
-    {
-      for (j = 0; j < CONFIG_NFILE_DESCRIPTORS_PER_BLOCK; j++)
-        {
-          struct inode *inode = filelist->fl_files[i][j].f_inode;
-          if (inode)
-            {
-              sinfo("      fd=%d refcount=%d\n",
-                    i * CONFIG_NFILE_DESCRIPTORS_PER_BLOCK + j,
-                    inode->i_crefs);
-            }
-        }
-    }
-}
-#endif
 
 /****************************************************************************
  * Public Functions
@@ -116,14 +64,11 @@ void up_exit(int status)
 
   sinfo("TCB=%p exiting\n", tcb);
 
+  nxsched_dumponexit();
+
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();
-
-#ifdef CONFIG_DUMP_ON_EXIT
-  sinfo("Other tasks:\n");
-  nxsched_foreach(_xtensa_dumponexit, NULL);
-#endif
 
   /* Now, perform the context switch to the new ready-to-run task at the
    * head of the list.

--- a/arch/z16/src/common/z16_exit.c
+++ b/arch/z16/src/common/z16_exit.c
@@ -29,63 +29,11 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
-#ifdef CONFIG_DUMP_ON_EXIT
-#  include <nuttx/fs/fs.h>
-#endif
 
 #include "chip.h"
 #include "task/task.h"
 #include "sched/sched.h"
 #include "z16_internal.h"
-
-/****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-#ifndef CONFIG_DEBUG_SCHED_INFO
-#  undef CONFIG_DUMP_ON_EXIT
-#endif
-
-/****************************************************************************
- * Private Functions
- ****************************************************************************/
-
-/****************************************************************************
- * Name: _z16_dumponexit
- *
- * Description:
- *   Dump the state of all tasks whenever on task exits.  This is debug
- *   instrumentation that was added to check file-related reference counting
- *   but could be useful again sometime in the future.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_DUMP_ON_EXIT
-static void _z16_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
-{
-  FAR struct filelist *filelist;
-  int i;
-  int j;
-
-  sinfo("  TCB=%p name=%s\n", tcb, tcb->name);
-  sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
-
-  filelist = &tcb->group->tg_filelist;
-  for (i = 0; i < filelist->fl_rows; i++)
-    {
-      for (j = 0; j < CONFIG_NFILE_DESCRIPTORS_PER_BLOCK; j++)
-        {
-          struct inode *inode = filelist->fl_files[i][j].f_inode;
-          if (inode)
-            {
-              sinfo("      fd=%d refcount=%d\n",
-                    i * CONFIG_NFILE_DESCRIPTORS_PER_BLOCK + j,
-                    inode->i_crefs);
-            }
-        }
-    }
-}
-#endif
 
 /****************************************************************************
  * Public Functions
@@ -114,14 +62,11 @@ void up_exit(int status)
 
   sinfo("TCB=%p exiting\n", tcb);
 
+  nxsched_dumponexit();
+
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();
-
-#ifdef CONFIG_DUMP_ON_EXIT
-  sinfo("Other tasks:\n");
-  nxsched_foreach(_z16_dumponexit, NULL);
-#endif
 
   /* Now, perform the context switch to the new ready-to-run task at the
    * head of the list.

--- a/arch/z80/src/common/z80_exit.c
+++ b/arch/z80/src/common/z80_exit.c
@@ -31,64 +31,11 @@
 #include <nuttx/addrenv.h>
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
-#ifdef CONFIG_DUMP_ON_EXIT
-#  include <nuttx/fs/fs.h>
-#endif
-
 #include "chip.h"
 #include "task/task.h"
 #include "sched/sched.h"
 #include "group/group.h"
 #include "z80_internal.h"
-
-/****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-#ifndef CONFIG_DEBUG_SCHED_INFO
-#  undef CONFIG_DUMP_ON_EXIT
-#endif
-
-/****************************************************************************
- * Private Functions
- ****************************************************************************/
-
-/****************************************************************************
- * Name: _up_dumponexit
- *
- * Description:
- *   Dump the state of all tasks whenever on task exits.  This is debug
- *   instrumentation that was added to check file-related reference counting
- *   but could be useful again sometime in the future.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_DUMP_ON_EXIT
-static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
-{
-  FAR struct filelist *filelist;
-  int i;
-  int j;
-
-  sinfo("  TCB=%p name=%s\n", tcb, tcb->name);
-  sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
-
-  filelist = &tcb->group->tg_filelist;
-  for (i = 0; i < filelist->fl_rows; i++)
-    {
-      for (j = 0; j < CONFIG_NFILE_DESCRIPTORS_PER_BLOCK; j++)
-        {
-          struct inode *inode = filelist->fl_files[i][j].f_inode;
-          if (inode)
-            {
-              sinfo("      fd=%d refcount=%d\n",
-                    i * CONFIG_NFILE_DESCRIPTORS_PER_BLOCK + j,
-                    inode->i_crefs);
-            }
-        }
-    }
-}
-#endif
 
 /****************************************************************************
  * Public Functions
@@ -117,14 +64,11 @@ void up_exit(int status)
 
   sinfo("TCB=%p exiting\n", tcb);
 
+  nxsched_dumponexit();
+
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();
-
-#ifdef CONFIG_DUMP_ON_EXIT
-  sinfo("Other tasks:\n");
-  nxsched_foreach(_up_dumponexit, NULL);
-#endif
 
   /* Now, perform the context switch to the new ready-to-run task at the
    * head of the list.

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -1573,6 +1573,22 @@ pid_t nxsched_getppid(void);
 
 size_t nxsched_collect_deadlock(FAR pid_t *pid, size_t count);
 
+/****************************************************************************
+ * Name: nxsched_dumponexit
+ *
+ * Description:
+ *   Dump the state of all tasks whenever on task exits.  This is debug
+ *   instrumentation that was added to check file-related reference counting
+ *   but could be useful again sometime in the future.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_DUMP_ON_EXIT
+void nxsched_dumponexit(void);
+#else
+#  define nxsched_dumponexit()
+#endif /* CONFIG_DUMP_ON_EXIT */
+
 #ifdef CONFIG_SMP_CALL
 /****************************************************************************
  * Name: nxsched_smp_call_handler

--- a/sched/misc/CMakeLists.txt
+++ b/sched/misc/CMakeLists.txt
@@ -24,4 +24,8 @@ if(CONFIG_ARCH_DEADLOCKDUMP)
   list(APPEND SRCS deadlock.c)
 endif()
 
+if(CONFIG_DUMP_ON_EXIT)
+  list(APPEND SRCS dump.c)
+endif()
+
 target_sources(sched PRIVATE ${SRCS})

--- a/sched/misc/Make.defs
+++ b/sched/misc/Make.defs
@@ -24,6 +24,10 @@ ifeq ($(CONFIG_ARCH_DEADLOCKDUMP),y)
 CSRCS += deadlock.c
 endif
 
+ifeq ($(CONFIG_DUMP_ON_EXIT),y)
+CSRCS += dump.c
+endif
+
 # Include init build support
 
 DEPPATH += --dep-path misc

--- a/sched/misc/dump.c
+++ b/sched/misc/dump.c
@@ -1,0 +1,97 @@
+/****************************************************************************
+ * sched/misc/dump.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/fs/fs.h>
+
+#include <debug.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifdef CONFIG_DUMP_ON_EXIT
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: dumphandler
+ *
+ * Description:
+ *   Dump the state of all tasks whenever on task exits.  This is debug
+ *   instrumentation that was added to check file-related reference counting
+ *   but could be useful again sometime in the future.
+ *
+ ****************************************************************************/
+
+static void dumphandler(FAR struct tcb_s *tcb, FAR void *arg)
+{
+  FAR struct filelist *filelist;
+  int i;
+  int j;
+
+  sinfo("  TCB=%p name=%s\n", tcb, tcb->name);
+  sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
+
+  filelist = &tcb->group->tg_filelist;
+  for (i = 0; i < filelist->fl_rows; i++)
+    {
+      for (j = 0; j < CONFIG_NFILE_DESCRIPTORS_PER_BLOCK; j++)
+        {
+          struct inode *inode = filelist->fl_files[i][j].f_inode;
+          if (inode)
+            {
+              sinfo("      fd=%d refcount=%d\n",
+                    i * CONFIG_NFILE_DESCRIPTORS_PER_BLOCK + j,
+                    inode->i_crefs);
+            }
+        }
+    }
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: nxsched_dumponexit
+ *
+ * Description:
+ *   Dump the state of all tasks whenever on task exits.  This is debug
+ *   instrumentation that was added to check file-related reference counting
+ *   but could be useful again sometime in the future.
+ *
+ ****************************************************************************/
+
+void nxsched_dumponexit(void)
+{
+  sinfo("Other tasks:\n");
+  nxsched_foreach(dumphandler, NULL);
+}
+
+#endif /* CONFIG_DUMP_ON_EXIT */


### PR DESCRIPTION
## Summary

arch/dumponexit: unify dump on exit to common code

remove arch implement and move to common code


## Impact

N/A

## Testing

ci-check
