### PR TITLE
sched/sem_holder.c: When accessing SEM_WAITLIST, use holder's addrenv

### DIFF
--- a/sched/semaphore/sem_holder.c
+++ b/sched/semaphore/sem_holder.c
@@ -27,6 +27,8 @@
 #include <sched.h>
 #include <assert.h>
 #include <debug.h>
+
+#include <nuttx/addrenv.h>
 #include <nuttx/arch.h>
 
 #include "sched/sched.h"
@@ -400,6 +402,15 @@ static void nxsem_restore_priority(FAR struct tcb_s *htcb)
     {
       FAR struct semholder_s *pholder;
 
+#ifdef CONFIG_ARCH_ADDRENV
+      FAR struct addrenv_s *oldenv;
+
+      if (htcb->addrenv_own)
+        {
+          addrenv_select(htcb->addrenv_own, &oldenv);
+        }
+#endif
+
       /* Try to find the highest priority across all the threads that are
        * waiting for any semaphore held by htcb.
        */
@@ -416,6 +427,13 @@ static void nxsem_restore_priority(FAR struct tcb_s *htcb)
               hpriority = stcb->sched_priority;
             }
         }
+
+#ifdef CONFIG_ARCH_ADDRENV
+      if (htcb->addrenv_own)
+        {
+          addrenv_restore(oldenv);
+        }
+#endif
 
       /* Apply the selected priority to the thread (hopefully back to the
        * threads base_priority).


### PR DESCRIPTION
## Summary
If the semaphore is shared, the holder has put its own mmapped address to pholder->sem. This means we must switch to the holder's address environment when going through the held semaphores list.

A better option would be to get the kernel mapped address for the semaphore's physical page, but that mechanism is not functional yet.

This fixes a full system crash when CONFIG_PRIORITY_INHERITANCE=y and CONFIG_BUILD_KERNEL=y and user makes shared semaphore via:

int semfd  = shm_open("sem", O_CREAT | O_RDWR, 0666); 
sem_t *sem = mmap(0, sizeof(sem_t), PROT_READ | PROT_WRITE, MAP_SHARED, semfd, 0);

## Impact
Fixes system crash as mentioned above
## Testing
MPFS target with kernel mode, priority inheritance and shared semaphores
