### PR TITLE
stm32/stm32_foc.c: rename some macros

### DIFF
--- a/arch/arm/src/stm32/stm32_foc.c
+++ b/arch/arm/src/stm32/stm32_foc.c
@@ -671,27 +671,27 @@
 
 /* Get arch-specific FOC private part */
 
-#define STM32_FOC_PRIV_FROM_DEV_GET(d)              \
+#define STM32_FOCPIRV_FROM_DEV_GET(d)              \
   ((struct stm32_foc_priv_s *)(d)->lower->data)
 
 /* Get board-specific FOC data */
 
-#define STM32_FOC_BOARD_FROM_DEV_GET(d)         \
-  ((STM32_FOC_PRIV_FROM_DEV_GET(d))->board)
+#define STM32_FOCBOARD_FROM_DEV_GET(d)         \
+  ((STM32_FOCPIRV_FROM_DEV_GET(d))->board)
 
 /* Get arch-specific FOC devices */
 
-#define STM32_FOC_DEV_FROM_DEV_GET(d)           \
-  ((STM32_FOC_PRIV_FROM_DEV_GET(d))->dev)
+#define STM32_FOCDEV_FROM_DEV_GET(d)           \
+  ((STM32_FOCPIRV_FROM_DEV_GET(d))->dev)
 
 /* Get PWM device */
 
-#define PWM_FROM_FOC_DEV_GET(d) (STM32_FOC_DEV_FROM_DEV_GET(d)->pwm)
+#define PWM_FROM_FOC_DEV_GET(d) (STM32_FOCDEV_FROM_DEV_GET(d)->pwm)
 
 /* Get ADC device */
 
-#define ADC_FROM_FOC_DEV_GET(d)  (STM32_FOC_DEV_FROM_DEV_GET(d)->adc)
-#define VADC_FROM_FOC_DEV_GET(d) (STM32_FOC_DEV_FROM_DEV_GET(d)->vadc)
+#define ADC_FROM_FOC_DEV_GET(d)  (STM32_FOCDEV_FROM_DEV_GET(d)->adc)
+#define VADC_FROM_FOC_DEV_GET(d) (STM32_FOCDEV_FROM_DEV_GET(d)->vadc)
 
 /* Define PWM all outputs */
 
@@ -988,7 +988,7 @@ void stm32_foc_sync_all(void)
 
       /* Get FOC lower half devices */
 
-      foc_dev = STM32_FOC_DEV_FROM_DEV_GET(dev);
+      foc_dev = STM32_FOCDEV_FROM_DEV_GET(dev);
 
       /* Store EGR register address */
 
@@ -1016,7 +1016,7 @@ void stm32_foc_sync_all(void)
 
 static int stm32_foc_pwm_cfg(struct foc_dev_s *dev, uint32_t freq)
 {
-  struct stm32_foc_board_s *board = STM32_FOC_BOARD_FROM_DEV_GET(dev);
+  struct stm32_foc_board_s *board = STM32_FOCBOARD_FROM_DEV_GET(dev);
   struct stm32_pwm_dev_s   *pwm   = PWM_FROM_FOC_DEV_GET(dev);
   int                       ret   = OK;
 
@@ -1070,7 +1070,7 @@ errout:
 
 static int stm32_foc_pwm_freq_set(struct foc_dev_s *dev, uint32_t freq)
 {
-  struct stm32_foc_priv_s *priv = STM32_FOC_PRIV_FROM_DEV_GET(dev);
+  struct stm32_foc_priv_s *priv = STM32_FOCPIRV_FROM_DEV_GET(dev);
   struct stm32_pwm_dev_s  *pwm  = PWM_FROM_FOC_DEV_GET(dev);
   int                      ret  = OK;
 
@@ -1143,7 +1143,7 @@ errout:
 
 static int stm32_foc_pwm_start(struct foc_dev_s *dev, bool state)
 {
-  struct stm32_foc_board_s *board = STM32_FOC_BOARD_FROM_DEV_GET(dev);
+  struct stm32_foc_board_s *board = STM32_FOCBOARD_FROM_DEV_GET(dev);
   struct stm32_pwm_dev_s   *pwm   = PWM_FROM_FOC_DEV_GET(dev);
 
   DEBUGASSERT(dev);
@@ -1174,7 +1174,7 @@ static int stm32_foc_pwm_start(struct foc_dev_s *dev, bool state)
 
 static int stm32_foc_adc_start(struct foc_dev_s *dev, bool state)
 {
-  struct stm32_foc_dev_s *foc_dev = STM32_FOC_DEV_FROM_DEV_GET(dev);
+  struct stm32_foc_dev_s *foc_dev = STM32_FOCDEV_FROM_DEV_GET(dev);
   struct stm32_adc_dev_s *adc     = ADC_FROM_FOC_DEV_GET(dev);
 
   DEBUGASSERT(dev);
@@ -1223,7 +1223,7 @@ static int stm32_foc_adc_start(struct foc_dev_s *dev, bool state)
 
 static int stm32_foc_adc_cfg(struct foc_dev_s *dev)
 {
-  struct stm32_foc_dev_s *foc_dev = STM32_FOC_DEV_FROM_DEV_GET(dev);
+  struct stm32_foc_dev_s *foc_dev = STM32_FOCDEV_FROM_DEV_GET(dev);
 
   DEBUGASSERT(dev);
   DEBUGASSERT(foc_dev);
@@ -1318,8 +1318,8 @@ static void stm32_foc_adc_trgo_trg_set(struct foc_dev_s *dev,
 static int stm32_foc_configure(struct foc_dev_s *dev,
                                struct foc_cfg_s *cfg)
 {
-  struct stm32_foc_priv_s  *priv  = STM32_FOC_PRIV_FROM_DEV_GET(dev);
-  struct stm32_foc_board_s *board = STM32_FOC_BOARD_FROM_DEV_GET(dev);
+  struct stm32_foc_priv_s  *priv  = STM32_FOCPIRV_FROM_DEV_GET(dev);
+  struct stm32_foc_board_s *board = STM32_FOCBOARD_FROM_DEV_GET(dev);
   int                       ret   = OK;
 
   DEBUGASSERT(dev);
@@ -1401,9 +1401,9 @@ errout:
 
 static int stm32_foc_setup(struct foc_dev_s *dev)
 {
-  struct stm32_foc_dev_s   *foc_dev = STM32_FOC_DEV_FROM_DEV_GET(dev);
-  struct stm32_foc_board_s *board   = STM32_FOC_BOARD_FROM_DEV_GET(dev);
-  struct stm32_foc_priv_s  *priv    = STM32_FOC_PRIV_FROM_DEV_GET(dev);
+  struct stm32_foc_dev_s   *foc_dev = STM32_FOCDEV_FROM_DEV_GET(dev);
+  struct stm32_foc_board_s *board   = STM32_FOCBOARD_FROM_DEV_GET(dev);
+  struct stm32_foc_priv_s  *priv    = STM32_FOCPIRV_FROM_DEV_GET(dev);
   struct stm32_adc_dev_s   *adc     = ADC_FROM_FOC_DEV_GET(dev);
 #ifdef CONFIG_MOTOR_FOC_BEMF_SENSE
   struct stm32_adc_dev_s   *vadc    = VADC_FROM_FOC_DEV_GET(dev);
@@ -1579,9 +1579,9 @@ errout:
 
 static int stm32_foc_shutdown(struct foc_dev_s *dev)
 {
-  struct stm32_foc_dev_s   *foc_dev = STM32_FOC_DEV_FROM_DEV_GET(dev);
-  struct stm32_foc_board_s *board   = STM32_FOC_BOARD_FROM_DEV_GET(dev);
-  struct stm32_foc_priv_s  *priv    = STM32_FOC_PRIV_FROM_DEV_GET(dev);
+  struct stm32_foc_dev_s   *foc_dev = STM32_FOCDEV_FROM_DEV_GET(dev);
+  struct stm32_foc_board_s *board   = STM32_FOCBOARD_FROM_DEV_GET(dev);
+  struct stm32_foc_priv_s  *priv    = STM32_FOCPIRV_FROM_DEV_GET(dev);
   int                       ret     = OK;
 
   DEBUGASSERT(dev);
@@ -1656,7 +1656,7 @@ errout:
 static int stm32_foc_ioctl(struct foc_dev_s *dev, int cmd,
                            unsigned long arg)
 {
-  struct stm32_foc_board_s *board = STM32_FOC_BOARD_FROM_DEV_GET(dev);
+  struct stm32_foc_board_s *board = STM32_FOCBOARD_FROM_DEV_GET(dev);
 
   if (board->ops->ioctl != NULL)
     {
@@ -1676,7 +1676,7 @@ static int stm32_foc_ioctl(struct foc_dev_s *dev, int cmd,
 
 static int stm32_foc_adc_calibration_handler(struct foc_dev_s *dev)
 {
-  struct stm32_foc_priv_s *priv = STM32_FOC_PRIV_FROM_DEV_GET(dev);
+  struct stm32_foc_priv_s *priv = STM32_FOCPIRV_FROM_DEV_GET(dev);
   int                      i    = 0;
 
   DEBUGASSERT(dev);
@@ -1775,14 +1775,14 @@ static int stm32_foc_adc_handler(int irq, void *context, void *arg)
 
       if (dev != NULL)
         {
-          priv = STM32_FOC_PRIV_FROM_DEV_GET(dev);
+          priv = STM32_FOCPIRV_FROM_DEV_GET(dev);
           DEBUGASSERT(priv);
 
-          foc_dev = STM32_FOC_DEV_FROM_DEV_GET(dev);
+          foc_dev = STM32_FOCDEV_FROM_DEV_GET(dev);
           DEBUGASSERT(foc_dev);
 
 #ifdef CONFIG_MOTOR_FOC_TRACE
-          board = STM32_FOC_BOARD_FROM_DEV_GET(dev);
+          board = STM32_FOCBOARD_FROM_DEV_GET(dev);
           DEBUGASSERT(board);
 
           board->ops->trace(dev, FOC_TRACE_LOWER, true);
@@ -1825,8 +1825,8 @@ static int stm32_foc_adc_handler(int irq, void *context, void *arg)
 
 static int stm32_foc_worker_handler(struct foc_dev_s *dev)
 {
-  struct stm32_foc_priv_s  *priv  = STM32_FOC_PRIV_FROM_DEV_GET(dev);
-  struct stm32_foc_board_s *board = STM32_FOC_BOARD_FROM_DEV_GET(dev);
+  struct stm32_foc_priv_s  *priv  = STM32_FOCPIRV_FROM_DEV_GET(dev);
+  struct stm32_foc_board_s *board = STM32_FOCBOARD_FROM_DEV_GET(dev);
   struct stm32_adc_dev_s   *adc   = ADC_FROM_FOC_DEV_GET(dev);
   int                       ret   = OK;
 
@@ -1883,9 +1883,9 @@ static int stm32_foc_worker_handler(struct foc_dev_s *dev)
 
 static int stm32_foc_calibration_start(struct foc_dev_s *dev)
 {
-  struct stm32_foc_dev_s   *foc_dev = STM32_FOC_DEV_FROM_DEV_GET(dev);
-  struct stm32_foc_priv_s  *priv    = STM32_FOC_PRIV_FROM_DEV_GET(dev);
-  struct stm32_foc_board_s *board   = STM32_FOC_BOARD_FROM_DEV_GET(dev);
+  struct stm32_foc_dev_s   *foc_dev = STM32_FOCDEV_FROM_DEV_GET(dev);
+  struct stm32_foc_priv_s  *priv    = STM32_FOCPIRV_FROM_DEV_GET(dev);
+  struct stm32_foc_board_s *board   = STM32_FOCBOARD_FROM_DEV_GET(dev);
   struct stm32_pwm_dev_s   *pwm     = PWM_FROM_FOC_DEV_GET(dev);
   struct stm32_adc_dev_s   *adc     = ADC_FROM_FOC_DEV_GET(dev);
 #ifdef CONFIG_MOTOR_FOC_BEMF_SENSE
@@ -2047,8 +2047,8 @@ errout:
 static int stm32_foc_pwm_duty_set(struct foc_dev_s *dev,
                                   foc_duty_t *duty)
 {
-  struct stm32_foc_priv_s *priv    = STM32_FOC_PRIV_FROM_DEV_GET(dev);
-  struct stm32_foc_dev_s  *foc_dev = STM32_FOC_DEV_FROM_DEV_GET(dev);
+  struct stm32_foc_priv_s *priv    = STM32_FOCPIRV_FROM_DEV_GET(dev);
+  struct stm32_foc_dev_s  *foc_dev = STM32_FOCDEV_FROM_DEV_GET(dev);
   uint16_t                 ccr[CONFIG_MOTOR_FOC_PHASES];
 
   DEBUGASSERT(dev);
@@ -2151,7 +2151,7 @@ static int stm32_foc_pwm_off(struct foc_dev_s *dev, bool off)
 
 static int stm32_foc_info_get(struct foc_dev_s *dev, struct foc_info_s *info)
 {
-  struct stm32_foc_board_s *board = STM32_FOC_BOARD_FROM_DEV_GET(dev);
+  struct stm32_foc_board_s *board = STM32_FOCBOARD_FROM_DEV_GET(dev);
 
   DEBUGASSERT(dev);
   DEBUGASSERT(board);
@@ -2172,7 +2172,7 @@ static int stm32_foc_info_get(struct foc_dev_s *dev, struct foc_info_s *info)
 static void stm32_foc_curr_get(struct foc_dev_s *dev,
                                int16_t *curr, int shunts)
 {
-  struct stm32_foc_priv_s *priv = STM32_FOC_PRIV_FROM_DEV_GET(dev);
+  struct stm32_foc_priv_s *priv = STM32_FOCPIRV_FROM_DEV_GET(dev);
   struct stm32_adc_dev_s  *adc  = ADC_FROM_FOC_DEV_GET(dev);
   int                      i    = 0;
 
@@ -2210,7 +2210,7 @@ static void stm32_foc_curr_get(struct foc_dev_s *dev,
 
 static void stm32_foc_volt_get(struct foc_dev_s *dev, int16_t *volt)
 {
-  struct stm32_foc_priv_s *priv = STM32_FOC_PRIV_FROM_DEV_GET(dev);
+  struct stm32_foc_priv_s *priv = STM32_FOCPIRV_FROM_DEV_GET(dev);
   struct stm32_adc_dev_s  *vadc  = VADC_FROM_FOC_DEV_GET(dev);
   int                      i    = 0;
 
@@ -2264,7 +2264,7 @@ static void stm32_foc_volt_get(struct foc_dev_s *dev, int16_t *volt)
 
 static int stm32_foc_notifier_cfg(struct foc_dev_s *dev, uint32_t freq)
 {
-  struct stm32_foc_priv_s *priv = STM32_FOC_PRIV_FROM_DEV_GET(dev);
+  struct stm32_foc_priv_s *priv = STM32_FOCPIRV_FROM_DEV_GET(dev);
   int                      ret  = OK;
 
   DEBUGASSERT(dev);
@@ -2318,7 +2318,7 @@ errout:
 static int stm32_foc_bind(struct foc_dev_s *dev,
                           struct foc_callbacks_s *cb)
 {
-  struct stm32_foc_priv_s *priv = STM32_FOC_PRIV_FROM_DEV_GET(dev);
+  struct stm32_foc_priv_s *priv = STM32_FOCPIRV_FROM_DEV_GET(dev);
   int                      ret  = OK;
 
   DEBUGASSERT(dev);
@@ -2345,7 +2345,7 @@ static int stm32_foc_bind(struct foc_dev_s *dev,
 
 static int stm32_foc_fault_clear(struct foc_dev_s *dev)
 {
-  struct stm32_foc_board_s *board = STM32_FOC_BOARD_FROM_DEV_GET(dev);
+  struct stm32_foc_board_s *board = STM32_FOCBOARD_FROM_DEV_GET(dev);
 
   DEBUGASSERT(dev);
   DEBUGASSERT(board);
@@ -2365,7 +2365,7 @@ static int stm32_foc_fault_clear(struct foc_dev_s *dev)
 
 int stm32_foc_trace_init(struct foc_dev_s *dev)
 {
-  struct stm32_foc_board_s *board = STM32_FOC_BOARD_FROM_DEV_GET(dev);
+  struct stm32_foc_board_s *board = STM32_FOCBOARD_FROM_DEV_GET(dev);
 
   DEBUGASSERT(dev);
   DEBUGASSERT(board);
@@ -2385,7 +2385,7 @@ int stm32_foc_trace_init(struct foc_dev_s *dev)
 
 void stm32_foc_trace(struct foc_dev_s *dev, int type, bool state)
 {
-  struct stm32_foc_board_s *board = STM32_FOC_BOARD_FROM_DEV_GET(dev);
+  struct stm32_foc_board_s *board = STM32_FOCBOARD_FROM_DEV_GET(dev);
 
   DEBUGASSERT(dev);
   DEBUGASSERT(board);
@@ -2738,7 +2738,7 @@ errout:
 
 struct adc_dev_s *stm32_foc_adcget(struct foc_dev_s *dev)
 {
-  struct stm32_foc_dev_s *foc_dev = STM32_FOC_DEV_FROM_DEV_GET(dev);
+  struct stm32_foc_dev_s *foc_dev = STM32_FOCDEV_FROM_DEV_GET(dev);
 
   DEBUGASSERT(dev);
   DEBUGASSERT(foc_dev);


### PR DESCRIPTION
## Summary

- stm32/stm32_foc.c: rename some macros
change the names to be the same as for stm32f7/stm32_foc.c

## Impact
Cosmetic change.
Copying changes from one implementation to another will be less prone to compilation errors

## Testing
CI
