### PR TITLE
misc/assert: restore assertion registers to array of last registers

### DIFF
--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -581,6 +581,10 @@ void _assert(FAR const char *filename, int linenum,
       up_saveusercontext(g_last_regs);
       regs = g_last_regs;
     }
+  else
+    {
+      memcpy(g_last_regs, regs, sizeof(g_last_regs));
+    }
 
 #if CONFIG_BOARD_RESET_ON_ASSERT < 2
   if (!up_interrupt_context() &&


### PR DESCRIPTION

## Summary

misc/assert: restore assertion registers to array of last registers

Some assertions in extreme cases will cause syslog to be unable to output logs normally, so this PR will restore the input registers into the array of last registers to ensure that we can also obtain some important informations.


## Impact

N/A

## Testing

ci-check