### PR TITLE
fs/fat: fix ubsan warning of shift-out-of-bounds 

### DIFF
--- a/fs/fat/fs_fat32util.c
+++ b/fs/fat/fs_fat32util.c
@@ -986,7 +986,7 @@ int fat_putcluster(struct fat_mountpt_s *fs, uint32_t clusterno,
                   /* Save the LS four bits of the next cluster */
 
                   value = (fs->fs_buffer[fatindex] & 0x0f) |
-                           nextcluster << 4;
+                           (uint8_t)nextcluster << 4;
                 }
               else
                 {


### PR DESCRIPTION

## Summary

fs/fat: fix ubsan warning of shift-out-of-bounds 

```
ubsan_prologue: ================================================================================
ubsan_prologue: UBSAN: shift-out-of-bounds in fat/fs_fat32util.c:989:40
__ubsan_handle_shift_out_of_bounds: left shift of 268435455 by 4 places cannot be represented in type 'int'
ubsan_epilogue: ================================================================================


```
## Impact

N/A

## Testing

ci-check