### PR TITLE
igmp: call IFF_SET_IPv4 when igmp_send

### DIFF
--- a/net/igmp/igmp_send.c
+++ b/net/igmp/igmp_send.c
@@ -116,6 +116,10 @@ void igmp_send(FAR struct net_driver_s *dev, FAR struct igmp_group_s *group,
       return;
     }
 
+  /* Select IPv4 */
+
+  IFF_SET_IPv4(dev->d_flags);
+
   /* The IGMP header immediately follows the IP header */
 
   iphdrlen          = IPv4_HDRLEN + RASIZE;


### PR DESCRIPTION
## Summary
If the flag is not set, The flag is affected by the previously sent and received packets, L2 header may be filled with ipv6.

## Impact

## Testing
sim:local
