### PR TITLE
arch/imx6: Replace cpu_start_t with start_t

### DIFF
--- a/arch/arm/src/imx6/imx_cpuboot.c
+++ b/arch/arm/src/imx6/imx_cpuboot.c
@@ -28,6 +28,7 @@
 #include <assert.h>
 
 #include <nuttx/arch.h>
+#include <nuttx/sched.h>
 #include <arch/irq.h>
 
 #include "arm_internal.h"
@@ -40,12 +41,6 @@
 #include "barriers.h"
 
 #ifdef CONFIG_SMP
-
-/****************************************************************************
- * Private Types
- ****************************************************************************/
-
-typedef void (*cpu_start_t)(void);
 
 /****************************************************************************
  * Private Data
@@ -95,7 +90,7 @@ static const uintptr_t g_cpu_gpr[CONFIG_SMP_NCPUS] =
 #endif
 };
 
-static const cpu_start_t g_cpu_boot[CONFIG_SMP_NCPUS] =
+static const start_t g_cpu_boot[CONFIG_SMP_NCPUS] =
 {
   0,
 #if CONFIG_SMP_NCPUS > 1
@@ -200,7 +195,7 @@ void imx_cpu_disable(void)
 
 void imx_cpu_enable(void)
 {
-  cpu_start_t bootaddr;
+  start_t bootaddr;
   uintptr_t regaddr;
   uint32_t regval;
   int cpu;


### PR DESCRIPTION
## Summary

avoid the unnecessary typedef

## Impact

code refactor

## Testing

ci