### PR TITLE
tcbinfo:remove total_num form tcbinfo.

### DIFF
--- a/arch/arm/src/arm/arm_tcbinfo.c
+++ b/arch/arm/src/arm/arm_tcbinfo.c
@@ -66,8 +66,7 @@ const struct tcbinfo_s g_tcbinfo used_data =
   .stack_off      = TCB_STACK_OFF,
   .stack_size_off = TCB_STACK_SIZE_OFF,
   .regs_off       = TCB_REGS_OFF,
-  .basic_num      = 17,
-  .total_num      = nitems(g_reg_offs),
+  .regs_num       = nitems(g_reg_offs),
   {
     .p = g_reg_offs,
   },

--- a/arch/arm/src/armv6-m/arm_tcbinfo.c
+++ b/arch/arm/src/armv6-m/arm_tcbinfo.c
@@ -51,13 +51,14 @@ static const uint16_t g_reg_offs[] =
   TCB_REG_OFF(REG_R14),
   TCB_REG_OFF(REG_R15),
   TCB_REG_OFF(REG_XPSR),
-
+#if 0
   UINT16_MAX,                     /* msp */
   TCB_REG_OFF(REG_R13),
   TCB_REG_OFF(REG_PRIMASK),
   UINT16_MAX,                     /* basepri */
   UINT16_MAX,                     /* faultmask */
   UINT16_MAX,                     /* control */
+#endif
 };
 
 /****************************************************************************
@@ -73,8 +74,7 @@ const struct tcbinfo_s g_tcbinfo used_data =
   .stack_off      = TCB_STACK_OFF,
   .stack_size_off = TCB_STACK_SIZE_OFF,
   .regs_off       = TCB_REGS_OFF,
-  .basic_num      = 17,
-  .total_num      = nitems(g_reg_offs),
+  .regs_num       = nitems(g_reg_offs),
   {
     .p = g_reg_offs,
   },

--- a/arch/arm/src/armv7-a/arm_tcbinfo.c
+++ b/arch/arm/src/armv7-a/arm_tcbinfo.c
@@ -52,7 +52,8 @@ static const uint16_t g_reg_offs[] =
   TCB_REG_OFF(REG_R15),
   TCB_REG_OFF(REG_CPSR),
 
-#ifdef CONFIG_ARCH_FPU
+#if 0
+#  ifdef CONFIG_ARCH_FPU
   TCB_REG_OFF(REG_D0),
   TCB_REG_OFF(REG_D1),
   TCB_REG_OFF(REG_D2),
@@ -69,9 +70,9 @@ static const uint16_t g_reg_offs[] =
   TCB_REG_OFF(REG_D13),
   TCB_REG_OFF(REG_D14),
   TCB_REG_OFF(REG_D15),
-#endif
+#  endif
 
-#ifdef CONFIG_ARM_DPFPU32
+#  ifdef CONFIG_ARM_DPFPU32
   TCB_REG_OFF(REG_D16),
   TCB_REG_OFF(REG_D17),
   TCB_REG_OFF(REG_D18),
@@ -88,10 +89,11 @@ static const uint16_t g_reg_offs[] =
   TCB_REG_OFF(REG_D29),
   TCB_REG_OFF(REG_D30),
   TCB_REG_OFF(REG_D31),
-#endif
+#  endif
 
-#ifdef CONFIG_ARCH_FPU
+#  ifdef CONFIG_ARCH_FPU
   TCB_REG_OFF(REG_FPSCR),
+#  endif
 #endif
 };
 
@@ -108,8 +110,7 @@ const struct tcbinfo_s g_tcbinfo used_data =
   .stack_off      = TCB_STACK_OFF,
   .stack_size_off = TCB_STACK_SIZE_OFF,
   .regs_off       = TCB_REGS_OFF,
-  .basic_num      = 17,
-  .total_num      = nitems(g_reg_offs),
+  .regs_num       = nitems(g_reg_offs),
   {
     .p = g_reg_offs,
   },

--- a/arch/arm/src/armv7-m/arm_tcbinfo.c
+++ b/arch/arm/src/armv7-m/arm_tcbinfo.c
@@ -52,19 +52,20 @@ static const uint16_t g_reg_offs[] =
   TCB_REG_OFF(REG_R15),
   TCB_REG_OFF(REG_XPSR),
 
+#if 0
   UINT16_MAX,                         /* msp */
   TCB_REG_OFF(REG_R13),
-#ifdef CONFIG_ARMV7M_USEBASEPRI
+#  ifdef CONFIG_ARMV7M_USEBASEPRI
   UINT16_MAX,                         /* primask */
   TCB_REG_OFF(REG_BASEPRI),
-#else
+#  else
   TCB_REG_OFF(REG_PRIMASK),
   UINT16_MAX,                         /* basepri */
-#endif
+#  endif
   UINT16_MAX,                         /* faultmask */
   UINT16_MAX,                         /* control */
 
-#ifdef CONFIG_ARCH_FPU
+#  ifdef CONFIG_ARCH_FPU
   TCB_REG_OFF(REG_S0),
   TCB_REG_OFF(REG_S1),
   TCB_REG_OFF(REG_S2),
@@ -98,6 +99,7 @@ static const uint16_t g_reg_offs[] =
   TCB_REG_OFF(REG_S30),
   TCB_REG_OFF(REG_S31),
   TCB_REG_OFF(REG_FPSCR),
+#  endif
 #endif
 };
 
@@ -114,8 +116,7 @@ const struct tcbinfo_s g_tcbinfo used_data =
   .stack_off      = TCB_STACK_OFF,
   .stack_size_off = TCB_STACK_SIZE_OFF,
   .regs_off       = TCB_REGS_OFF,
-  .basic_num      = 17,
-  .total_num      = nitems(g_reg_offs),
+  .regs_num       = nitems(g_reg_offs),
   {
     .p = g_reg_offs,
   },

--- a/arch/arm/src/armv7-r/arm_tcbinfo.c
+++ b/arch/arm/src/armv7-r/arm_tcbinfo.c
@@ -52,7 +52,8 @@ static const uint16_t g_reg_offs[] =
   TCB_REG_OFF(REG_R15),
   TCB_REG_OFF(REG_CPSR),
 
-#ifdef CONFIG_ARCH_FPU
+#if 0
+#  ifdef CONFIG_ARCH_FPU
   TCB_REG_OFF(REG_D0),
   TCB_REG_OFF(REG_D1),
   TCB_REG_OFF(REG_D2),
@@ -69,9 +70,9 @@ static const uint16_t g_reg_offs[] =
   TCB_REG_OFF(REG_D13),
   TCB_REG_OFF(REG_D14),
   TCB_REG_OFF(REG_D15),
-#endif
+#  endif
 
-#ifdef CONFIG_ARM_DPFPU32
+#  ifdef CONFIG_ARM_DPFPU32
   TCB_REG_OFF(REG_D16),
   TCB_REG_OFF(REG_D17),
   TCB_REG_OFF(REG_D18),
@@ -88,10 +89,11 @@ static const uint16_t g_reg_offs[] =
   TCB_REG_OFF(REG_D29),
   TCB_REG_OFF(REG_D30),
   TCB_REG_OFF(REG_D31),
-#endif
+#  endif
 
-#ifdef CONFIG_ARCH_FPU
+#  ifdef CONFIG_ARCH_FPU
   TCB_REG_OFF(REG_FPSCR),
+#  endif
 #endif
 };
 
@@ -108,8 +110,7 @@ const struct tcbinfo_s g_tcbinfo used_data =
   .stack_off      = TCB_STACK_OFF,
   .stack_size_off = TCB_STACK_SIZE_OFF,
   .regs_off       = TCB_REGS_OFF,
-  .basic_num      = 17,
-  .total_num      = nitems(g_reg_offs),
+  .regs_num       = nitems(g_reg_offs),
   {
     .p = g_reg_offs,
   },

--- a/arch/arm/src/armv8-m/arm_tcbinfo.c
+++ b/arch/arm/src/armv8-m/arm_tcbinfo.c
@@ -52,19 +52,20 @@ static const uint16_t g_reg_offs[] =
   TCB_REG_OFF(REG_R15),
   TCB_REG_OFF(REG_XPSR),
 
+#if 0
   UINT16_MAX,                       /* msp */
   TCB_REG_OFF(REG_R13),
-#ifdef CONFIG_ARMV8M_USEBASEPRI
+#  ifdef CONFIG_ARMV8M_USEBASEPRI
   UINT16_MAX,                       /* primask */
   TCB_REG_OFF(REG_BASEPRI),
-#else
+#  else
   TCB_REG_OFF(REG_PRIMASK),
   UINT16_MAX,                       /* basepri */
-#endif
+#  endif
   UINT16_MAX,                       /* faultmask */
   UINT16_MAX,                       /* control */
 
-#ifdef CONFIG_ARCH_FPU
+#  ifdef CONFIG_ARCH_FPU
   TCB_REG_OFF(REG_S0),
   TCB_REG_OFF(REG_S1),
   TCB_REG_OFF(REG_S2),
@@ -98,6 +99,7 @@ static const uint16_t g_reg_offs[] =
   TCB_REG_OFF(REG_S30),
   TCB_REG_OFF(REG_S31),
   TCB_REG_OFF(REG_FPSCR),
+#  endif
 #endif
 };
 
@@ -114,8 +116,7 @@ const struct tcbinfo_s g_tcbinfo used_data =
   .stack_off      = TCB_STACK_OFF,
   .stack_size_off = TCB_STACK_SIZE_OFF,
   .regs_off       = TCB_REGS_OFF,
-  .basic_num      = 17,
-  .total_num      = nitems(g_reg_offs),
+  .regs_num       = nitems(g_reg_offs),
   {
     .p = g_reg_offs,
   },

--- a/arch/arm/src/armv8-r/arm_tcbinfo.c
+++ b/arch/arm/src/armv8-r/arm_tcbinfo.c
@@ -52,7 +52,8 @@ static const uint16_t g_reg_offs[] =
   TCB_REG_OFF(REG_R15),
   TCB_REG_OFF(REG_CPSR),
 
-#ifdef CONFIG_ARCH_FPU
+#if 0
+#  ifdef CONFIG_ARCH_FPU
   TCB_REG_OFF(REG_D0),
   TCB_REG_OFF(REG_D1),
   TCB_REG_OFF(REG_D2),
@@ -69,9 +70,9 @@ static const uint16_t g_reg_offs[] =
   TCB_REG_OFF(REG_D13),
   TCB_REG_OFF(REG_D14),
   TCB_REG_OFF(REG_D15),
-#endif
+#  endif
 
-#ifdef CONFIG_ARM_DPFPU32
+#  ifdef CONFIG_ARM_DPFPU32
   TCB_REG_OFF(REG_D16),
   TCB_REG_OFF(REG_D17),
   TCB_REG_OFF(REG_D18),
@@ -88,10 +89,11 @@ static const uint16_t g_reg_offs[] =
   TCB_REG_OFF(REG_D29),
   TCB_REG_OFF(REG_D30),
   TCB_REG_OFF(REG_D31),
-#endif
+#  endif
 
-#ifdef CONFIG_ARCH_FPU
+#  ifdef CONFIG_ARCH_FPU
   TCB_REG_OFF(REG_FPSCR),
+#  endif
 #endif
 };
 
@@ -106,8 +108,7 @@ const struct tcbinfo_s g_tcbinfo =
   .pri_off   = TCB_PRI_OFF,
   .name_off  = TCB_NAME_OFF,
   .regs_off  = TCB_REGS_OFF,
-  .basic_num = 17,
-  .total_num = nitems(g_reg_offs),
+  .regs_num  = nitems(g_reg_offs),
   {
     .p = g_reg_offs,
   },

--- a/arch/arm64/src/common/arm64_tcbinfo.c
+++ b/arch/arm64/src/common/arm64_tcbinfo.c
@@ -82,8 +82,7 @@ const struct tcbinfo_s g_tcbinfo =
   .stack_off      = TCB_STACK_OFF,
   .stack_size_off = TCB_STACK_SIZE_OFF,
   .regs_off       = TCB_REGS_OFF,
-  .basic_num      = nitems(g_reg_offs),
-  .total_num      = nitems(g_reg_offs),
+  .regs_num       = nitems(g_reg_offs),
   {
     .p = g_reg_offs,
   },

--- a/arch/risc-v/src/common/riscv_tcbinfo.c
+++ b/arch/risc-v/src/common/riscv_tcbinfo.c
@@ -68,7 +68,8 @@ static const uint16_t g_reg_offs[] =
   TCB_REG_OFF(REG_X31_NDX),
   TCB_REG_OFF(REG_EPC_NDX),
 
-#ifdef CONFIG_ARCH_FPU
+#if 0
+#  ifdef CONFIG_ARCH_FPU
   TCB_REG_OFF(REG_F0_NDX),
   TCB_REG_OFF(REG_F1_NDX),
   TCB_REG_OFF(REG_F2_NDX),
@@ -104,6 +105,7 @@ static const uint16_t g_reg_offs[] =
   UINT16_MAX,                      /* fflags */
   UINT16_MAX,                      /* frm */
   TCB_REG_OFF(REG_FCSR_NDX),
+#  endif
 #endif
 };
 
@@ -120,8 +122,7 @@ const struct tcbinfo_s g_tcbinfo used_data =
   .stack_off      = TCB_STACK_OFF,
   .stack_size_off = TCB_STACK_SIZE_OFF,
   .regs_off       = TCB_REGS_OFF,
-  .basic_num      = 33,
-  .total_num      = nitems(g_reg_offs),
+  .regs_num       = nitems(g_reg_offs),
   {
     .p = g_reg_offs,
   },

--- a/arch/sim/src/sim/sim_tcbinfo.c
+++ b/arch/sim/src/sim/sim_tcbinfo.c
@@ -78,6 +78,67 @@ static const uint16_t g_reg_offs[] =
   UINT16_MAX,            /* ES */
   UINT16_MAX,            /* FS */
 };
+#elif defined(CONFIG_HOST_ARM64)
+static const uint16_t g_reg_offs[] =
+{
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  TCB_REG_OFF(JB_SP),
+  TCB_REG_OFF(JB_PC),
+  UINT16_MAX,
+  UINT16_MAX,
+};
+#elif defined(CONFIG_HOST_ARM)
+static const uint16_t g_reg_offs[] =
+{
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+  UINT16_MAX,
+};
 #endif
 
 /****************************************************************************
@@ -93,8 +154,7 @@ const struct tcbinfo_s g_tcbinfo used_data =
   .stack_off      = TCB_STACK_OFF,
   .stack_size_off = TCB_STACK_SIZE_OFF,
   .regs_off       = TCB_REGS_OFF,
-  .basic_num      = nitems(g_reg_offs),
-  .total_num      = nitems(g_reg_offs),
+  .regs_num       = nitems(g_reg_offs),
   {
     .p = g_reg_offs,
   },

--- a/arch/sparc/src/common/sparc_tcbinfo.c
+++ b/arch/sparc/src/common/sparc_tcbinfo.c
@@ -81,8 +81,7 @@ const struct tcbinfo_s g_tcbinfo =
   .stack_off      = TCB_STACK_OFF,
   .stack_size_off = TCB_STACK_SIZE_OFF,
   .regs_off       = TCB_REGS_OFF,
-  .basic_num      = nitems(g_reg_offs),
-  .total_num      = nitems(g_reg_offs),
+  .regs_num       = nitems(g_reg_offs),
   {
     .p = g_reg_offs,
   },

--- a/arch/x86/src/common/x86_tcbinfo.c
+++ b/arch/x86/src/common/x86_tcbinfo.c
@@ -64,8 +64,7 @@ const struct tcbinfo_s g_tcbinfo =
   .stack_off      = TCB_STACK_OFF,
   .stack_size_off = TCB_STACK_SIZE_OFF,
   .regs_off       = TCB_REGS_OFF,
-  .basic_num      = nitems(g_reg_offs),
-  .total_num      = nitems(g_reg_offs),
+  .regs_num       = nitems(g_reg_offs),
   {
     .p = g_reg_offs,
   },

--- a/arch/x86_64/src/common/x86_64_tcbinfo.c
+++ b/arch/x86_64/src/common/x86_64_tcbinfo.c
@@ -72,8 +72,7 @@ const struct tcbinfo_s g_tcbinfo used_data =
   .stack_off      = TCB_STACK_OFF,
   .stack_size_off = TCB_STACK_SIZE_OFF,
   .regs_off       = TCB_REGS_OFF,
-  .basic_num      = nitems(g_reg_offs),
-  .total_num      = nitems(g_reg_offs),
+  .regs_num       = nitems(g_reg_offs),
   {
     .p = g_reg_offs,
   },

--- a/arch/xtensa/src/common/xtensa_tcbinfo.c
+++ b/arch/xtensa/src/common/xtensa_tcbinfo.c
@@ -67,8 +67,7 @@ const struct tcbinfo_s g_tcbinfo used_data =
   .stack_off      = TCB_STACK_OFF,
   .stack_size_off = TCB_STACK_SIZE_OFF,
   .regs_off       = TCB_REGS_OFF,
-  .basic_num      = COMMON_CTX_REGS,
-  .total_num      = nitems(g_reg_offs),
+  .regs_num       = COMMON_CTX_REGS,
   {
     .p = g_reg_offs,
   },

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -715,8 +715,7 @@ begin_packed_struct struct tcbinfo_s
   uint16_t stack_off;                    /* Offset of tcb.stack_alloc_ptr   */
   uint16_t stack_size_off;               /* Offset of tcb.adj_stack_size    */
   uint16_t regs_off;                     /* Offset of tcb.regs              */
-  uint16_t basic_num;                    /* Num of genernal regs            */
-  uint16_t total_num;                    /* Num of regs in tcbinfo.reg_offs */
+  uint16_t regs_num;                     /* Num of general regs             */
 
   /* Offset pointer of xcp.regs, order in GDB org.gnu.gdb.xxx feature.
    * Please refer:

--- a/libs/libc/gdbstub/lib_gdbstub.c
+++ b/libs/libc/gdbstub/lib_gdbstub.c
@@ -1406,7 +1406,7 @@ FAR struct gdb_state_s *gdb_state_init(gdb_send_func_t send,
                                        gdb_monitor_func_t monitor,
                                        FAR void *priv)
 {
-  size_t size = g_tcbinfo.basic_num * sizeof(uintptr_t);
+  size_t size = g_tcbinfo.regs_num * sizeof(uintptr_t);
   FAR struct gdb_state_s *state = lib_zalloc(sizeof(*state) + size);
 
   if (state == NULL)

--- a/tools/gdb/thread.py
+++ b/tools/gdb/thread.py
@@ -36,7 +36,7 @@ def save_regs():
     saved_regs = []
     i = 0
     for reg in arch.registers():
-        if i >= tcbinfo["basic_num"]:
+        if i >= tcbinfo["regs_num"]:
             break
 
         saved_regs.append(gdb.parse_and_eval("$%s" % reg.name))
@@ -53,7 +53,7 @@ def restore_regs():
     arch = gdb.selected_frame().architecture()
     i = 0
     for reg in arch.registers():
-        if i >= tcbinfo["basic_num"]:
+        if i >= tcbinfo["regs_num"]:
             break
 
         gdb.execute("set $%s=%d" % (reg.name, int(saved_regs[i])))
@@ -108,7 +108,7 @@ class Nxsetregs(gdb.Command):
         arch = gdb.selected_frame().architecture()
         i = 0
         for reg in arch.registers():
-            if i >= tcbinfo["basic_num"]:
+            if i >= tcbinfo["regs_num"]:
                 return
 
             if tcbinfo["reg_off"]["p"][i] != UINT16_MAX:

--- a/tools/jlink-nuttx.c
+++ b/tools/jlink-nuttx.c
@@ -100,8 +100,7 @@ begin_packed_struct struct tcbinfo_s
   uint16_t stack_off;
   uint16_t stack_size_off;
   uint16_t regs_off;
-  uint16_t basic_num;
-  uint16_t total_num;
+  uint16_t regs_num;
   begin_packed_struct
   union
   {
@@ -254,7 +253,7 @@ static int setget_reg(struct plugin_priv_s *priv, uint32_t idx,
 {
   uint32_t regaddr;
 
-  if (regidx >= priv->tcbinfo->total_num)
+  if (regidx >= priv->tcbinfo->regs_num)
     {
       return -EINVAL;
     }
@@ -292,19 +291,19 @@ static int update_tcbinfo(struct plugin_priv_s *priv)
 {
   if (!priv->tcbinfo)
     {
-      uint16_t total_num;
+      uint16_t regs_num;
       uint32_t reg_off;
       int ret;
 
       ret = READU16(g_symbols[TCBINFO].address +
-                    offsetof(struct tcbinfo_s, total_num), &total_num);
+                    offsetof(struct tcbinfo_s, regs_num), &regs_num);
       if (ret != 0)
         {
           PERROR("error reading regs ret %d\n", ret);
           return ret;
         }
 
-      if (!total_num)
+      if (!regs_num)
         {
           return -EIO;
         }
@@ -318,7 +317,7 @@ static int update_tcbinfo(struct plugin_priv_s *priv)
         }
 
       priv->tcbinfo = ALLOC(sizeof(struct tcbinfo_s) +
-                            total_num * sizeof(uint16_t));
+                            regs_num * sizeof(uint16_t));
 
       if (!priv->tcbinfo)
         {
@@ -335,8 +334,8 @@ static int update_tcbinfo(struct plugin_priv_s *priv)
         }
 
       ret = READMEM(reg_off, (char *)&priv->tcbinfo->reg_offs[0],
-                    total_num * sizeof(uint16_t));
-      if (ret != total_num * sizeof(uint16_t))
+                    regs_num * sizeof(uint16_t));
+      if (ret != regs_num * sizeof(uint16_t))
         {
           PERROR("error in read tcbinfo_s reg_offs ret %d\n", ret);
           return ret;
@@ -643,7 +642,7 @@ int RTOS_GetThreadRegList(char *hexreglist, uint32_t threadid)
       return idx;
     }
 
-  for (j = 0; j < g_plugin_priv.tcbinfo->basic_num; j++)
+  for (j = 0; j < g_plugin_priv.tcbinfo->regs_num; j++)
     {
       regval = 0;
 
@@ -704,7 +703,7 @@ int RTOS_SetThreadRegList(char *hexreglist, uint32_t threadid)
       return idx;
     }
 
-  for (j = 0; j < g_plugin_priv.tcbinfo->basic_num; j++)
+  for (j = 0; j < g_plugin_priv.tcbinfo->regs_num; j++)
     {
       regval = decode_hex(hexreglist);
 


### PR DESCRIPTION
## Summary
tcbinfo:remove total_num form tcbinfo. Can solve Mac os alignment problem
## Impact
debug with jlink
## Testing
`make -f tools/Makefile.host`
`cp tools/jlink-nuttx /opt/SEGGER/JLink_V786a/libnuttxplugin.so `
`JLinkGDBServer -if SWD -speed 5000 -device STM32F429ZI -NoGui 1 -rtos libnuttxplugin`

