### PR TITLE
udp: Add support for SO_TIMESTAMP

### DIFF
--- a/include/nuttx/net/netdev.h
+++ b/include/nuttx/net/netdev.h
@@ -442,6 +442,18 @@ struct net_driver_s
   struct netdev_statistics_s d_statistics;
 #endif
 
+#if defined(CONFIG_NET_TIMESTAMP)
+  /* Reception timestamp of packet being currently processed.
+   * If CONFIG_ARCH_HAVE_NETDEV_TIMESTAMP is true, the timestamp is provided
+   * by hardware driver. Otherwise it is filled in by kernel when packet
+   * enters ipv4_input or ipv6_input.
+   *
+   * The timestamp is in CLOCK_REALTIME.
+   */
+
+  struct timespec d_rxtime;
+#endif
+
   /* Application callbacks:
    *
    * Network device event handlers are retained in a 'list' and are called

--- a/net/Kconfig
+++ b/net/Kconfig
@@ -23,6 +23,10 @@ config ARCH_HAVE_NETDEV_STATISTICS
 	bool
 	default n
 
+config ARCH_HAVE_NETDEV_TIMESTAMP
+	bool
+	default n
+
 config NET_WRITE_BUFFERS
 	bool
 	default n

--- a/net/devif/ipv4_input.c
+++ b/net/devif/ipv4_input.c
@@ -491,6 +491,12 @@ int ipv4_input(FAR struct net_driver_s *dev)
   FAR uint8_t *buf;
   int ret;
 
+  /* Store reception timestamp if enabled and not provided by hardware. */
+
+#if defined(CONFIG_NET_TIMESTAMP) && !defined(CONFIG_ARCH_HAVE_NETDEV_TIMESTAMP)
+  clock_gettime(CLOCK_REALTIME, &dev->d_rxtime);
+#endif
+
   if (dev->d_iob != NULL)
     {
       buf = dev->d_buf;

--- a/net/devif/ipv6_input.c
+++ b/net/devif/ipv6_input.c
@@ -609,6 +609,12 @@ int ipv6_input(FAR struct net_driver_s *dev)
   FAR uint8_t *buf;
   int ret;
 
+  /* Store reception timestamp if enabled and not provided by hardware. */
+
+#if defined(CONFIG_NET_TIMESTAMP) && !defined(CONFIG_ARCH_HAVE_NETDEV_TIMESTAMP)
+  clock_gettime(CLOCK_REALTIME, &dev->d_rxtime);
+#endif
+
   if (dev->d_iob != NULL)
     {
       buf = dev->d_buf;

--- a/net/socket/Kconfig
+++ b/net/socket/Kconfig
@@ -74,9 +74,10 @@ config NET_SOLINGER
 config NET_TIMESTAMP
 	bool "SO_TIMESTAMP socket option"
 	default n
-	depends on NET_CAN
+	depends on NET_CAN || NET_ETHERNET
 	---help---
-		Enable or disable support for the SO_TIMESTAMP socket option. Currently only tested & implemented in SocketCAN but should work on all sockets
+		Enable or disable support for the SO_TIMESTAMP socket option.
+		Supported on SocketCAN and Ethernet/UDP.
 
 config NET_BINDTODEVICE
 	bool "SO_BINDTODEVICE socket option Bind-to-device support"

--- a/net/udp/udp.h
+++ b/net/udp/udp.h
@@ -156,6 +156,10 @@ struct udp_conn_s
    */
 
   struct udp_poll_s pollinfo[CONFIG_NET_UDP_NPOLLWAITERS];
+
+#ifdef CONFIG_NET_TIMESTAMP
+  int timestamp; /* Nonzero when SO_TIMESTAMP is enabled */
+#endif
 };
 
 /* This structure supports UDP write buffering.  It is simply a container


### PR DESCRIPTION
## Summary

Adds support for timestamping received UDP packets, either in hardware or in kernel. Builds on the existing support of `SO_TIMESTAMP` for SocketCAN.

Implementation uses `CLOCK_REALTIME` for timestamping to match the behavior of Linux. This could be made configurable in future if needed.

## Impact

When `CONFIG_NET_TIMESTAMP` is enabled, `setsockopt(..., SO_TIMESTAMP)` can be used to enable timestamping.

Software timestamping is supported on all platforms. This already removes any queuing latency, but threads with higher priority than network processing can delay timestamping.

Platforms where hardware support exists can define `ARCH_HAVE_NETDEV_TIMESTAMP` and store the timestamp to `d_rxtime` before calling `ipv4_input`/`ipv6_input`.

## Testing

Tested on custom STM32F4 board with a ptpd version that has SO_TIMESTAMP support. I'll submit a pull request of that to nuttx-apps once I have cleaned it up.