### PR TITLE
sam_dmac: Fix compilation and fix SAM_DMAC_CHINTENCLR settings

### DIFF
--- a/arch/arm/src/samd2l2/sam_dmac.c
+++ b/arch/arm/src/samd2l2/sam_dmac.c
@@ -137,9 +137,9 @@ static struct sam_dmach_s g_dmach[SAMD2L2_NDMACHAN];
  */
 
 static struct dma_desc_s g_base_desc[SAMD2L2_NDMACHAN]
-  locate_data(".lpram"), aligned(16);
+  locate_data(".lpram") aligned_data(16);
 static struct dma_desc_s g_writeback_desc[SAMD2L2_NDMACHAN]
-  locate_data(".lpram"), aligned(16);
+  locate_data(".lpram") aligned_data(16);
 
 #if CONFIG_SAMD2L2_DMAC_NDESC > 0
 /* Additional DMA descriptors for (optional) multi-block transfer support.
@@ -147,7 +147,7 @@ static struct dma_desc_s g_writeback_desc[SAMD2L2_NDMACHAN]
  */
 
 static struct dma_desc_s g_dma_desc[CONFIG_SAMD2L2_DMAC_NDESC]
-  locate_data(".lpram"), aligned(16);
+  locate_data(".lpram") aligned_data(16);
 #endif
 
 /****************************************************************************
@@ -178,7 +178,7 @@ static void sam_dmaterminate(struct sam_dmach_s *dmach, int result)
 
   /* Disable all channel interrupts */
 
-  putreg8(1 << dmach->dc_chan, SAM_DMAC_CHINTENCLR);
+  putreg8(DMAC_INT_ALL, SAM_DMAC_CHINTENCLR);
   leave_critical_section(flags);
 
   /* Free the DMA descriptor list */
@@ -833,7 +833,7 @@ DMA_HANDLE sam_dmachannel(uint32_t chflags)
 
           /* Disable all channel interrupts */
 
-          putreg8(1 << chndx, SAM_DMAC_CHINTENCLR);
+          putreg8(DMAC_INT_ALL, SAM_DMAC_CHINTENCLR);
           leave_critical_section(flags);
           break;
         }

--- a/arch/arm/src/samd2l2/sam_dmac.h
+++ b/arch/arm/src/samd2l2/sam_dmac.h
@@ -31,8 +31,6 @@
 
 #include "chip.h"
 
-#include "hardware/sam_dmac.h"
-
 #ifdef CONFIG_SAMD2L2_DMAC
 
 #if defined(CONFIG_ARCH_FAMILY_SAMD20) || defined(CONFIG_ARCH_FAMILY_SAMD21)


### PR DESCRIPTION
## Summary
### In sam_dmac.c
SAM_DMAC was not compiling out of the box and I found one inconsistency:

- aligned keyword is changed to aligned_data. 
- When setting the register CHINTENCLR in order to `Disable all channel interrupts`:

|0x4C    |CHINTENSET | 7:0    |        |        |        |        |        |SUSP    |TCMPL   |TERR    |
|--------|-----------|--------|--------|--------|--------|--------|--------|--------|--------|--------|
|0x4D    |CHINTENSET | 7:0    |        |        |        |        |        |SUSP    |TCMPL   |TERR    |

Before:
```c
putreg8(1 << chndx, SAM_DMAC_CHINTENCLR);
```

if the number of channel (chndx) is above 3, it will do nothing, and above 7 it will set the next register  CHINTENSET with potential misbehavior.
I suppose the intent was to set the resister to 0000111 -> 0x07 or the existing DMAC_INT_ALL constant in sam_dmac.h

After:
```c
putreg8(DMAC_INT_ALL, SAM_DMAC_CHINTENCLR);
```
### In sam_dmac.h

`#include "hardware/sam_dmac.h"` is removed because it does not exist.

## Impact

This code now compiles.

## Testing
The code runs. 
In the context of using ws2812 driver, DMAC is interrupted after 2 beats because of Rx channel. I **still** get the error message in console: `Failed to allocate descriptor`. 

I am still investigating.
I did not test with a real spi peripheral yet.