### PR TITLE
skeleton.c doesn't compile without this patch if ioctls are enabled

### DIFF
--- a/drivers/net/skeleton.c
+++ b/drivers/net/skeleton.c
@@ -955,7 +955,7 @@ static int skel_ioctl(FAR struct net_driver_s *dev, int cmd,
       /* Add cases here to support the IOCTL commands */
 
       default:
-        nerr("ERROR: Unrecognized IOCTL command: %d\n", command);
+        nerr("ERROR: Unrecognized IOCTL command: %d\n", cmd);
         return -ENOTTY;  /* Special return value for this case */
     }
 


### PR DESCRIPTION
## Summary
skeleton.c doesn't compile without this patch if ioctls are enabled

## Impact
skeleton network driver cannot be used if ioctl feature (CONFIG_NETDEV_IOCTL) is true
## Testing
The file compiles with this change. Code not actually executed yet,
