### PR TITLE
drivers/mmcsd: mmcsd_sdinitialize should save csd register into priv->csd

### DIFF
--- a/drivers/mmcsd/mmcsd_sdio.c
+++ b/drivers/mmcsd/mmcsd_sdio.c
@@ -3260,7 +3260,6 @@ static int mmcsd_multi_iocmd(FAR struct mmcsd_state_s *priv,
 static int mmcsd_sdinitialize(FAR struct mmcsd_state_s *priv)
 {
   uint32_t cid[4];
-  uint32_t csd[4];
   uint32_t scr[2];
   int ret;
 
@@ -3331,14 +3330,14 @@ static int mmcsd_sdinitialize(FAR struct mmcsd_state_s *priv)
    */
 
   mmcsd_sendcmdpoll(priv, MMCSD_CMD9, (uint32_t)priv->rca << 16);
-  ret = SDIO_RECVR2(priv->dev, MMCSD_CMD9, csd);
+  ret = SDIO_RECVR2(priv->dev, MMCSD_CMD9, priv->csd);
   if (ret != OK)
     {
       ferr("ERROR: Could not get SD CSD register(%d)\n", ret);
       return ret;
     }
 
-  mmcsd_decode_csd(priv, csd);
+  mmcsd_decode_csd(priv, priv->csd);
 
   /* Send CMD7 with the argument == RCA in order to select the card.
    * Since we are supporting only a single card, we just leave the


### PR DESCRIPTION
## Summary

just like what mmcsd_mmcinitialize do
 
## Impact

code refactor only

## Testing

ci
