### PR TITLE
poll: pollsetup should notify only one fd passed by caller

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_gnss.c
+++ b/arch/arm/src/cxd56xx/cxd56_gnss.c
@@ -3097,7 +3097,7 @@ static int cxd56_gnss_poll(struct file *filep, struct pollfd *fds,
 
       if (priv->has_event)
         {
-          cxd56_gnss_pollnotify(priv);
+          poll_notify(&fds, 1, POLLIN);
         }
     }
   else if (fds->priv)
@@ -3108,9 +3108,9 @@ static int cxd56_gnss_poll(struct file *filep, struct pollfd *fds,
 
       /* Remove all memory of the poll setup */
 
-      *slot                = NULL;
-      fds->priv            = NULL;
-      priv->has_event      = false;
+      *slot           = NULL;
+      fds->priv       = NULL;
+      priv->has_event = false;
     }
 
 errout:

--- a/arch/arm/src/sama5/sam_tsd.c
+++ b/arch/arm/src/sama5/sam_tsd.c
@@ -206,9 +206,9 @@ struct sam_tsd_s
 
 static void sam_tsd_notify(struct sam_tsd_s *priv);
 static int  sam_tsd_sample(struct sam_tsd_s *priv,
-              struct sam_sample_s *sample);
+                           struct sam_sample_s *sample);
 static int  sam_tsd_waitsample(struct sam_tsd_s *priv,
-              struct sam_sample_s *sample);
+                               struct sam_sample_s *sample);
 static void sam_tsd_bottomhalf(void *arg);
 static int  sam_tsd_schedule(struct sam_tsd_s *priv);
 static void sam_tsd_expiry(wdparm_t arg);
@@ -1185,8 +1185,8 @@ static int sam_tsd_poll(struct file *filep, struct pollfd *fds, bool setup)
 
       if (i >= CONFIG_SAMA5_TSD_NPOLLWAITERS)
         {
-          fds->priv    = NULL;
-          ret          = -EBUSY;
+          fds->priv = NULL;
+          ret       = -EBUSY;
           goto errout;
         }
 
@@ -1194,7 +1194,7 @@ static int sam_tsd_poll(struct file *filep, struct pollfd *fds, bool setup)
 
       if (priv->penchange)
         {
-          sam_tsd_notify(priv);
+          poll_notify(&fds, 1, POLLIN);
         }
     }
   else if (fds->priv)
@@ -1206,8 +1206,8 @@ static int sam_tsd_poll(struct file *filep, struct pollfd *fds, bool setup)
 
       /* Remove all memory of the poll setup */
 
-      *slot                = NULL;
-      fds->priv            = NULL;
+      *slot     = NULL;
+      fds->priv = NULL;
     }
 
 errout:

--- a/arch/arm/src/stm32/stm32_bbsram.c
+++ b/arch/arm/src/stm32/stm32_bbsram.c
@@ -109,15 +109,15 @@ struct stm32_bbsram_s
 static int     stm32_bbsram_open(struct file *filep);
 static int     stm32_bbsram_close(struct file *filep);
 static off_t   stm32_bbsram_seek(struct file *filep, off_t offset,
-                 int whence);
+                                 int whence);
 static ssize_t stm32_bbsram_read(struct file *filep, char *buffer,
-                 size_t len);
+                                 size_t len);
 static ssize_t stm32_bbsram_write(struct file *filep,
-                 const char *buffer, size_t len);
+                                  const char *buffer, size_t len);
 static int stm32_bbsram_ioctl(struct file *filep, int cmd,
-                 unsigned long arg);
+                              unsigned long arg);
 static int     stm32_bbsram_poll(struct file *filep,
-                 struct pollfd *fds, bool setup);
+                                 struct pollfd *fds, bool setup);
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
 static int     stm32_bbsram_unlink(struct inode *inode);
 #endif

--- a/arch/arm/src/stm32f7/stm32_bbsram.c
+++ b/arch/arm/src/stm32f7/stm32_bbsram.c
@@ -109,15 +109,15 @@ struct stm32_bbsram_s
 static int     stm32_bbsram_open(struct file *filep);
 static int     stm32_bbsram_close(struct file *filep);
 static off_t   stm32_bbsram_seek(struct file *filep, off_t offset,
-                 int whence);
+                                 int whence);
 static ssize_t stm32_bbsram_read(struct file *filep, char *buffer,
-                 size_t len);
+                                 size_t len);
 static ssize_t stm32_bbsram_write(struct file *filep,
-                 const char *buffer, size_t len);
+                                  const char *buffer, size_t len);
 static int stm32_bbsram_ioctl(struct file *filep, int cmd,
-                 unsigned long arg);
+                              unsigned long arg);
 static int     stm32_bbsram_poll(struct file *filep,
-                 struct pollfd *fds, bool setup);
+                                 struct pollfd *fds, bool setup);
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
 static int     stm32_bbsram_unlink(struct inode *inode);
 #endif

--- a/arch/arm/src/stm32h7/stm32_bbsram.c
+++ b/arch/arm/src/stm32h7/stm32_bbsram.c
@@ -130,15 +130,15 @@ struct stm32_bbsram_s
 static int     stm32_bbsram_open(struct file *filep);
 static int     stm32_bbsram_close(struct file *filep);
 static off_t   stm32_bbsram_seek(struct file *filep, off_t offset,
-                 int whence);
+                                 int whence);
 static ssize_t stm32_bbsram_read(struct file *filep, char *buffer,
-                 size_t len);
+                                 size_t len);
 static ssize_t stm32_bbsram_write(struct file *filep,
-                 const char *buffer, size_t len);
+                                  const char *buffer, size_t len);
 static int stm32_bbsram_ioctl(struct file *filep, int cmd,
-                 unsigned long arg);
+                              unsigned long arg);
 static int     stm32_bbsram_poll(struct file *filep,
-                 struct pollfd *fds, bool setup);
+                                 struct pollfd *fds, bool setup);
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
 static int     stm32_bbsram_unlink(struct inode *inode);
 #endif

--- a/boards/arm/cxd56xx/drivers/sensors/cxd5610_gnss.c
+++ b/boards/arm/cxd56xx/drivers/sensors/cxd5610_gnss.c
@@ -325,7 +325,7 @@ static int cxd5610_gnss_post_interrupt(void);
 
 #if CONFIG_SENSORS_CXD5610_GNSS_NSIGNALRECEIVERS != 0
 static void cxd5610_gnss_signalhandler(struct cxd5610_gnss_dev_s *priv,
-                                uint8_t sigtype);
+                                       uint8_t sigtype);
 #endif
 
 #if CONFIG_SENSORS_CXD5610_GNSS_NPOLLWAITERS != 0
@@ -2037,7 +2037,7 @@ static int cxd5610_gnss_poll(struct file *filep, struct pollfd *fds,
 
       if (priv->has_event)
         {
-          cxd5610_gnss_pollnotify(priv);
+          poll_notify(&fds, 1, POLLIN);
         }
     }
   else if (fds->priv)
@@ -2048,9 +2048,9 @@ static int cxd5610_gnss_poll(struct file *filep, struct pollfd *fds,
 
       /* Remove all memory of the poll setup */
 
-      *slot                = NULL;
-      fds->priv            = NULL;
-      priv->has_event      = false;
+      *slot           = NULL;
+      fds->priv       = NULL;
+      priv->has_event = false;
     }
 
 errout:

--- a/boards/arm/stm32/mikroe-stm32f4/src/stm32_touchscreen.c
+++ b/boards/arm/stm32/mikroe-stm32f4/src/stm32_touchscreen.c
@@ -1397,8 +1397,8 @@ static int tc_poll(struct file *filep, struct pollfd *fds, bool setup)
       if (i >= CONFIG_TOUCHSCREEN_NPOLLWAITERS)
         {
           ierr("ERROR: No available slot found: %d\n", i);
-          fds->priv    = NULL;
-          ret          = -EBUSY;
+          fds->priv = NULL;
+          ret       = -EBUSY;
           goto errout;
         }
 
@@ -1406,7 +1406,7 @@ static int tc_poll(struct file *filep, struct pollfd *fds, bool setup)
 
       if (priv->penchange)
         {
-          tc_notify(priv);
+          poll_notify(&fds, 1, POLLIN);
         }
     }
   else if (fds->priv)
@@ -1418,8 +1418,8 @@ static int tc_poll(struct file *filep, struct pollfd *fds, bool setup)
 
       /* Remove all memory of the poll setup */
 
-      *slot                = NULL;
-      fds->priv            = NULL;
+      *slot     = NULL;
+      fds->priv = NULL;
     }
 
 errout:

--- a/boards/mips/pic32mx/pic32mx7mmb/src/pic32_touchscreen.c
+++ b/boards/mips/pic32mx/pic32mx7mmb/src/pic32_touchscreen.c
@@ -1274,8 +1274,8 @@ static int tc_poll(struct file *filep, struct pollfd *fds, bool setup)
       if (i >= CONFIG_TOUCHSCREEN_NPOLLWAITERS)
         {
           ierr("ERROR: No available slot found: %d\n", i);
-          fds->priv    = NULL;
-          ret          = -EBUSY;
+          fds->priv = NULL;
+          ret       = -EBUSY;
           goto errout;
         }
 
@@ -1283,7 +1283,7 @@ static int tc_poll(struct file *filep, struct pollfd *fds, bool setup)
 
       if (priv->penchange)
         {
-          tc_notify(priv);
+          poll_notify(&fds, 1, POLLIN);
         }
     }
   else if (fds->priv)
@@ -1295,8 +1295,8 @@ static int tc_poll(struct file *filep, struct pollfd *fds, bool setup)
 
       /* Remove all memory of the poll setup */
 
-      *slot                = NULL;
-      fds->priv            = NULL;
+      *slot     = NULL;
+      fds->priv = NULL;
     }
 
 errout:

--- a/boards/mips/pic32mx/sure-pic32mx/src/pic32mx_lcd1602.c
+++ b/boards/mips/pic32mx/sure-pic32mx/src/pic32mx_lcd1602.c
@@ -971,7 +971,7 @@ static int lcd_ioctl(struct file *filep, int cmd, unsigned long arg)
  ****************************************************************************/
 
 static int lcd_poll(struct file *filep, struct pollfd *fds,
-                        bool setup)
+                    bool setup)
 {
   if (setup)
     {

--- a/drivers/analog/adc.c
+++ b/drivers/analog/adc.c
@@ -567,8 +567,8 @@ static int adc_poll(FAR struct file *filep, struct pollfd *fds, bool setup)
 
       if (i >= CONFIG_ADC_NPOLLWAITERS)
         {
-          fds->priv    = NULL;
-          ret          = -EBUSY;
+          fds->priv = NULL;
+          ret       = -EBUSY;
           goto return_with_irqdisabled;
         }
 
@@ -576,7 +576,7 @@ static int adc_poll(FAR struct file *filep, struct pollfd *fds, bool setup)
 
       if (dev->ad_recv.af_head != dev->ad_recv.af_tail)
         {
-          poll_notify(dev->fds, CONFIG_ADC_NPOLLWAITERS, POLLIN);
+          poll_notify(&fds, 1, POLLIN);
         }
     }
   else if (fds->priv)
@@ -587,8 +587,8 @@ static int adc_poll(FAR struct file *filep, struct pollfd *fds, bool setup)
 
       /* Remove all memory of the poll setup */
 
-      *slot                = NULL;
-      fds->priv            = NULL;
+      *slot     = NULL;
+      fds->priv = NULL;
     }
 
 return_with_irqdisabled:

--- a/drivers/analog/comp.c
+++ b/drivers/analog/comp.c
@@ -86,9 +86,9 @@ static const struct comp_callback_s g_comp_callback =
 static int comp_poll(FAR struct file *filep, FAR struct pollfd *fds,
                      bool setup)
 {
-  FAR struct inode      *inode    = filep->f_inode;
-  FAR struct comp_dev_s *dev      = inode->i_private;
-  int                    ret      = OK;
+  FAR struct inode      *inode = filep->f_inode;
+  FAR struct comp_dev_s *dev   = inode->i_private;
+  int                    ret   = OK;
   int                    i;
 
   DEBUGASSERT(dev && fds);
@@ -123,8 +123,8 @@ static int comp_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       if (i >= CONFIG_DEV_COMP_NPOLLWAITERS)
         {
-          fds->priv   = NULL;
-          ret         = -EBUSY;
+          fds->priv = NULL;
+          ret       = -EBUSY;
           goto errout;
         }
     }
@@ -137,15 +137,15 @@ static int comp_poll(FAR struct file *filep, FAR struct pollfd *fds,
 #ifdef CONFIG_DEBUG_FEATURES
       if (!slot)
         {
-          ret              = -EIO;
+          ret = -EIO;
           goto errout;
         }
 #endif
 
       /* Remove all memory of the poll setup */
 
-      *slot                = NULL;
-      fds->priv            = NULL;
+      *slot     = NULL;
+      fds->priv = NULL;
     }
 
 errout:

--- a/drivers/bch/bchdev_driver.c
+++ b/drivers/bch/bchdev_driver.c
@@ -55,13 +55,13 @@ static int     bch_open(FAR struct file *filep);
 static int     bch_close(FAR struct file *filep);
 static off_t   bch_seek(FAR struct file *filep, off_t offset, int whence);
 static ssize_t bch_read(FAR struct file *filep, FAR char *buffer,
-                 size_t buflen);
+                        size_t buflen);
 static ssize_t bch_write(FAR struct file *filep, FAR const char *buffer,
-                 size_t buflen);
+                         size_t buflen);
 static int     bch_ioctl(FAR struct file *filep, int cmd,
-                 unsigned long arg);
+                         unsigned long arg);
 static int     bch_poll(FAR struct file *filep, FAR struct pollfd *fds,
-                 bool setup);
+                        bool setup);
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
 static int     bch_unlink(FAR struct inode *inode);
 #endif

--- a/drivers/can/can.c
+++ b/drivers/can/can.c
@@ -1199,7 +1199,7 @@ static int can_poll(FAR struct file *filep, FAR struct pollfd *fds,
             }
         }
 
-      poll_notify(dev->cd_fds, CONFIG_CAN_NPOLLWAITERS, eventset);
+      poll_notify(&fds, 1, eventset);
     }
   else if (fds->priv != NULL)
     {

--- a/drivers/input/ads7843e.c
+++ b/drivers/input/ads7843e.c
@@ -994,7 +994,7 @@ static int ads7843e_poll(FAR struct file *filep, FAR struct pollfd *fds,
   inode = filep->f_inode;
 
   DEBUGASSERT(inode->i_private);
-  priv  = inode->i_private;
+  priv = inode->i_private;
 
   /* Are we setting up the poll?  Or tearing it down? */
 
@@ -1034,8 +1034,8 @@ static int ads7843e_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       if (i >= CONFIG_ADS7843E_NPOLLWAITERS)
         {
-          fds->priv    = NULL;
-          ret          = -EBUSY;
+          fds->priv = NULL;
+          ret       = -EBUSY;
           goto errout;
         }
 
@@ -1043,7 +1043,7 @@ static int ads7843e_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       if (priv->penchange)
         {
-          ads7843e_notify(priv);
+          poll_notify(&fds, 1, POLLIN);
         }
     }
   else if (fds->priv)
@@ -1055,8 +1055,8 @@ static int ads7843e_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       /* Remove all memory of the poll setup */
 
-      *slot                = NULL;
-      fds->priv            = NULL;
+      *slot     = NULL;
+      fds->priv = NULL;
     }
 
 errout:

--- a/drivers/input/ajoystick.c
+++ b/drivers/input/ajoystick.c
@@ -630,8 +630,8 @@ static int ajoy_poll(FAR struct file *filep, FAR struct pollfd *fds,
       if (i >= CONFIG_INPUT_AJOYSTICK_NPOLLWAITERS)
         {
           ierr("ERROR: Too man poll waiters\n");
-          fds->priv    = NULL;
-          ret          = -EBUSY;
+          fds->priv = NULL;
+          ret       = -EBUSY;
           goto errout;
         }
     }

--- a/drivers/input/button_upper.c
+++ b/drivers/input/button_upper.c
@@ -710,8 +710,8 @@ static int btn_poll(FAR struct file *filep, FAR struct pollfd *fds,
       if (i >= CONFIG_INPUT_BUTTONS_NPOLLWAITERS)
         {
           ierr("ERROR: Too many poll waiters\n");
-          fds->priv    = NULL;
-          ret          = -EBUSY;
+          fds->priv = NULL;
+          ret       = -EBUSY;
           goto errout;
         }
     }

--- a/drivers/input/cypress_mbr3108.c
+++ b/drivers/input/cypress_mbr3108.c
@@ -1034,9 +1034,7 @@ static int mbr3108_poll(FAR struct file *filep, FAR struct pollfd *fds,
           pending = priv->int_pending;
           if (pending)
             {
-              poll_notify(priv->fds,
-                          CONFIG_INPUT_CYPRESS_MBR3108_NPOLLWAITERS,
-                          POLLIN);
+              poll_notify(&fds, 1, POLLIN);
             }
         }
     }

--- a/drivers/input/djoystick.c
+++ b/drivers/input/djoystick.c
@@ -624,8 +624,8 @@ static int djoy_poll(FAR struct file *filep, FAR struct pollfd *fds,
       if (i >= CONFIG_INPUT_DJOYSTICK_NPOLLWAITERS)
         {
           ierr("ERROR: Too man poll waiters\n");
-          fds->priv    = NULL;
-          ret          = -EBUSY;
+          fds->priv = NULL;
+          ret       = -EBUSY;
           goto errout;
         }
     }

--- a/drivers/input/ft5x06.c
+++ b/drivers/input/ft5x06.c
@@ -1013,8 +1013,8 @@ static int ft5x06_poll(FAR struct file *filep, FAR struct pollfd *fds,
       if (i >= CONFIG_FT5X06_NPOLLWAITERS)
         {
           ierr("ERROR: No available slot found: %d\n", i);
-          fds->priv    = NULL;
-          ret          = -EBUSY;
+          fds->priv = NULL;
+          ret       = -EBUSY;
           goto errout;
         }
 
@@ -1022,7 +1022,7 @@ static int ft5x06_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       if (priv->valid)
         {
-          ft5x06_notify(priv);
+          poll_notify(&fds, 1, POLLIN);
         }
     }
   else if (fds->priv)
@@ -1034,8 +1034,8 @@ static int ft5x06_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       /* Remove all memory of the poll setup */
 
-      *slot                = NULL;
-      fds->priv            = NULL;
+      *slot     = NULL;
+      fds->priv = NULL;
     }
 
 errout:

--- a/drivers/input/gt9xx.c
+++ b/drivers/input/gt9xx.c
@@ -813,9 +813,7 @@ static int gt9xx_poll(FAR struct file *filep, FAR struct pollfd *fds,
           pending = priv->int_pending;
           if (pending)
             {
-              poll_notify(priv->fds,
-                          CONFIG_INPUT_GT9XX_NPOLLWAITERS,
-                          POLLIN);
+              poll_notify(&fds, 1, POLLIN);
             }
         }
     }

--- a/drivers/input/keyboard_upper.c
+++ b/drivers/input/keyboard_upper.c
@@ -276,7 +276,7 @@ static int keyboard_poll(FAR struct file *filep,
 
       if (!circbuf_is_empty(&opriv->circ))
         {
-          poll_notify(&opriv->fds, 1, POLLIN);
+          poll_notify(&fds, 1, POLLIN);
         }
     }
   else

--- a/drivers/input/max11802.c
+++ b/drivers/input/max11802.c
@@ -1027,8 +1027,8 @@ static int max11802_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       if (i >= CONFIG_MAX11802_NPOLLWAITERS)
         {
-          fds->priv    = NULL;
-          ret          = -EBUSY;
+          fds->priv = NULL;
+          ret       = -EBUSY;
           goto errout;
         }
 
@@ -1036,7 +1036,7 @@ static int max11802_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       if (priv->penchange)
         {
-          max11802_notify(priv);
+          poll_notify(&fds, 1, POLLIN);
         }
     }
   else if (fds->priv)
@@ -1048,8 +1048,8 @@ static int max11802_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       /* Remove all memory of the poll setup */
 
-      *slot                = NULL;
-      fds->priv            = NULL;
+      *slot     = NULL;
+      fds->priv = NULL;
     }
 
 errout:

--- a/drivers/input/mouse_upper.c
+++ b/drivers/input/mouse_upper.c
@@ -218,7 +218,8 @@ out:
  * Name: mouse_poll
  ****************************************************************************/
 
-static int mouse_poll(FAR struct file *filep, struct pollfd *fds, bool setup)
+static int mouse_poll(FAR struct file *filep,
+                      FAR struct pollfd *fds, bool setup)
 {
   FAR struct mouse_openpriv_s *openpriv = filep->f_priv;
   pollevent_t eventset = 0;
@@ -248,7 +249,7 @@ static int mouse_poll(FAR struct file *filep, struct pollfd *fds, bool setup)
           eventset |= POLLIN;
         }
 
-      poll_notify(&openpriv->fds, 1, eventset);
+      poll_notify(&fds, 1, eventset);
     }
   else if (fds->priv)
     {

--- a/drivers/input/mxt.c
+++ b/drivers/input/mxt.c
@@ -212,18 +212,18 @@ struct mxt_dev_s
 /* MXT register access */
 
 static int  mxt_getreg(FAR struct mxt_dev_s *priv, uint16_t regaddr,
-              FAR uint8_t *buffer, size_t buflen);
+                       FAR uint8_t *buffer, size_t buflen);
 static int  mxt_putreg(FAR struct mxt_dev_s *priv, uint16_t regaddr,
-              FAR const uint8_t *buffer, size_t buflen);
+                       FAR const uint8_t *buffer, size_t buflen);
 
 /* MXT object/message access */
 
 static FAR struct mxt_object_s *mxt_object(FAR struct mxt_dev_s *priv,
-              uint8_t type);
+                                           uint8_t type);
 static int mxt_getmessage(FAR struct mxt_dev_s *priv,
-              FAR struct mxt_msg_s *msg);
+                          FAR struct mxt_msg_s *msg);
 static int mxt_putobject(FAR struct mxt_dev_s *priv, uint8_t type,
-              uint8_t offset, uint8_t value);
+                         uint8_t offset, uint8_t value);
 #if 0 /* Not used */
 static int mxt_getobject(FAR struct mxt_dev_s *priv, uint8_t type,
               uint8_t offset, FAR uint8_t *value);
@@ -236,27 +236,27 @@ static void mxt_notify(FAR struct mxt_dev_s *priv);
 
 /* Touch event waiting */
 
-static inline int  mxt_checksample(FAR struct mxt_dev_s *priv);
-static inline int  mxt_waitsample(FAR struct mxt_dev_s *priv);
+static inline int mxt_checksample(FAR struct mxt_dev_s *priv);
+static inline int mxt_waitsample(FAR struct mxt_dev_s *priv);
 
 /* Interrupt handling/position sampling */
 
 #ifdef CONFIG_MXT_BUTTONS
 static void mxt_button_event(FAR struct mxt_dev_s *priv,
-              FAR struct mxt_msg_s *msg);
+                             FAR struct mxt_msg_s *msg);
 #endif
 static void mxt_touch_event(FAR struct mxt_dev_s *priv,
-              FAR struct mxt_msg_s *msg, int ndx);
+                            FAR struct mxt_msg_s *msg, int ndx);
 static void mxt_worker(FAR void *arg);
 static int  mxt_interrupt(FAR const struct mxt_lower_s *lower,
-              FAR void *context);
+                          FAR void *context);
 
 /* Character driver methods */
 
 static int  mxt_open(FAR struct file *filep);
 static int  mxt_close(FAR struct file *filep);
 static ssize_t mxt_read(FAR struct file *filep, FAR char *buffer,
-              size_t len);
+                        size_t len);
 static int  mxt_ioctl(FAR struct file *filep, int cmd, unsigned long arg);
 static int  mxt_poll(FAR struct file *filep, struct pollfd *fds, bool setup);
 
@@ -1511,10 +1511,10 @@ static int mxt_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 static int mxt_poll(FAR struct file *filep, FAR struct pollfd *fds,
                         bool setup)
 {
-  FAR struct inode         *inode;
+  FAR struct inode     *inode;
   FAR struct mxt_dev_s *priv;
-  int                       ret;
-  int                       i;
+  int                   ret;
+  int                   i;
 
   iinfo("setup: %d\n", (int)setup);
   DEBUGASSERT(fds);
@@ -1564,8 +1564,8 @@ static int mxt_poll(FAR struct file *filep, FAR struct pollfd *fds,
       if (i >= CONFIG_MXT_NPOLLWAITERS)
         {
           ierr("ERROR: No available slot found: %d\n", i);
-          fds->priv    = NULL;
-          ret          = -EBUSY;
+          fds->priv = NULL;
+          ret       = -EBUSY;
           goto errout;
         }
 
@@ -1573,7 +1573,7 @@ static int mxt_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       if (priv->event)
         {
-          mxt_notify(priv);
+          poll_notify(&fds, 1, POLLIN);
         }
     }
   else if (fds->priv)
@@ -1585,8 +1585,8 @@ static int mxt_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       /* Remove all memory of the poll setup */
 
-      *slot                = NULL;
-      fds->priv            = NULL;
+      *slot     = NULL;
+      fds->priv = NULL;
     }
 
 errout:

--- a/drivers/input/spq10kbd.c
+++ b/drivers/input/spq10kbd.c
@@ -640,8 +640,8 @@ static int spq10kbd_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       if (i >= CONFIG_SPQ10KBD_NPOLLWAITERS)
         {
-          fds->priv    = NULL;
-          ret          = -EBUSY;
+          fds->priv = NULL;
+          ret       = -EBUSY;
           goto errout;
         }
 
@@ -651,7 +651,7 @@ static int spq10kbd_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       if (priv->headndx != priv->tailndx)
         {
-          poll_notify(priv->fds, CONFIG_SPQ10KBD_NPOLLWAITERS, POLLIN);
+          poll_notify(&fds, 1, POLLIN);
         }
     }
   else
@@ -663,8 +663,8 @@ static int spq10kbd_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       /* Remove all memory of the poll setup */
 
-      *slot                = NULL;
-      fds->priv            = NULL;
+      *slot     = NULL;
+      fds->priv = NULL;
     }
 
 errout:

--- a/drivers/input/stmpe811_tsc.c
+++ b/drivers/input/stmpe811_tsc.c
@@ -677,8 +677,8 @@ static int stmpe811_poll(FAR struct file *filep, FAR struct pollfd *fds,
       if (i >= CONFIG_STMPE811_NPOLLWAITERS)
         {
           ierr("ERROR: No available slot found: %d\n", i);
-          fds->priv    = NULL;
-          ret          = -EBUSY;
+          fds->priv = NULL;
+          ret       = -EBUSY;
           goto errout;
         }
 
@@ -686,7 +686,7 @@ static int stmpe811_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       if (priv->penchange)
         {
-          stmpe811_notify(priv);
+          poll_notify(&fds, 1, POLLIN);
         }
     }
   else if (fds->priv)
@@ -698,8 +698,8 @@ static int stmpe811_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       /* Remove all memory of the poll setup */
 
-      *slot                = NULL;
-      fds->priv            = NULL;
+      *slot     = NULL;
+      fds->priv = NULL;
     }
 
 errout:

--- a/drivers/input/touchscreen_upper.c
+++ b/drivers/input/touchscreen_upper.c
@@ -308,12 +308,12 @@ static int touch_poll(FAR struct file *filep, struct pollfd *fds, bool setup)
           eventset |= POLLIN;
         }
 
-      poll_notify(&openpriv->fds, 1, eventset);
+      poll_notify(&fds, 1, eventset);
     }
   else if (fds->priv)
     {
       openpriv->fds = NULL;
-      fds->priv   = NULL;
+      fds->priv     = NULL;
     }
 
 errout:

--- a/drivers/input/tsc2007.c
+++ b/drivers/input/tsc2007.c
@@ -1120,8 +1120,8 @@ static int tsc2007_poll(FAR struct file *filep, FAR struct pollfd *fds,
       if (i >= CONFIG_TSC2007_NPOLLWAITERS)
         {
           ierr("ERROR: No available slot found: %d\n", i);
-          fds->priv    = NULL;
-          ret          = -EBUSY;
+          fds->priv = NULL;
+          ret       = -EBUSY;
           goto errout;
         }
 
@@ -1129,7 +1129,7 @@ static int tsc2007_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       if (priv->penchange)
         {
-          tsc2007_notify(priv);
+          poll_notify(&fds, 1, POLLIN);
         }
     }
   else if (fds->priv)
@@ -1141,8 +1141,8 @@ static int tsc2007_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       /* Remove all memory of the poll setup */
 
-      *slot                = NULL;
-      fds->priv            = NULL;
+      *slot     = NULL;
+      fds->priv = NULL;
     }
 
 errout:

--- a/drivers/ipcc/ipcc_poll.c
+++ b/drivers/ipcc/ipcc_poll.c
@@ -62,7 +62,7 @@
  ****************************************************************************/
 
 int ipcc_poll(FAR struct file *filep, FAR struct pollfd *fds,
-                     bool setup)
+              bool setup)
 {
   FAR struct ipcc_driver_s *priv;
   FAR struct pollfd **slot;
@@ -144,7 +144,7 @@ int ipcc_poll(FAR struct file *filep, FAR struct pollfd *fds,
     }
 #endif
 
-  poll_notify(priv->fds, CONFIG_IPCC_NPOLLWAITERS, eventset);
+  poll_notify(&fds, 1, eventset);
 
   nxmutex_unlock(&priv->lock);
   return OK;

--- a/drivers/ipcc/ipcc_priv.h
+++ b/drivers/ipcc/ipcc_priv.h
@@ -53,9 +53,9 @@ int ipcc_close(FAR struct file *filep);
 int ipcc_ioctl(FAR struct file *filep, int cmd, unsigned long arg);
 ssize_t ipcc_read(FAR struct file *filep, FAR char *buffer, size_t buflen);
 ssize_t ipcc_write(FAR struct file *filep, FAR const char *buffer,
-                          size_t buflen);
+                   size_t buflen);
 int ipcc_poll(FAR struct file *filep, FAR struct pollfd *fds,
-                  bool setup);
+              bool setup);
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
 int ipcc_unlink(FAR struct inode *inode);
 #endif

--- a/drivers/lcd/tda19988.c
+++ b/drivers/lcd/tda19988.c
@@ -126,25 +126,26 @@ static int     tda19988_connected(FAR struct tda1988_dev_s *priv);
 /* HDMI Module Helpers */
 
 static int     tda19988_fetch_edid_block(FAR struct tda1988_dev_s *priv,
-                 FAR uint8_t *buf, int block);
+                                         FAR uint8_t *buf, int block);
 static int     tda19988_fetch_edid(struct tda1988_dev_s *priv);
 static ssize_t tda19988_read_internal(FAR struct tda1988_dev_s *priv,
-                 off_t offset, FAR uint8_t *buffer, size_t buflen);
+                                      off_t offset, FAR uint8_t *buffer,
+                                      size_t buflen);
 
 /* Character driver methods */
 
 static int     tda19988_open(FAR struct file *filep);
 static int     tda19988_close(FAR struct file *filep);
 static ssize_t tda19988_read(FAR struct file *filep, FAR char *buffer,
-                 size_t buflen);
+                             size_t buflen);
 static ssize_t tda19988_write(FAR struct file *filep, FAR const char *buffer,
-                 size_t buflen);
+                              size_t buflen);
 static off_t   tda19988_seek(FAR struct file *filep, off_t offset,
-                 int whence);
+                             int whence);
 static int     tda19988_ioctl(FAR struct file *filep, int cmd,
-                 unsigned long arg);
+                              unsigned long arg);
 static int     tda19988_poll(FAR struct file *filep, FAR struct pollfd *fds,
-                 bool setup);
+                             bool setup);
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
 static int     tda19988_unlink(FAR struct inode *inode);
 #endif

--- a/drivers/misc/dev_null.c
+++ b/drivers/misc/dev_null.c
@@ -39,11 +39,11 @@
  ****************************************************************************/
 
 static ssize_t devnull_read(FAR struct file *filep, FAR char *buffer,
-                 size_t buflen);
+                            size_t buflen);
 static ssize_t devnull_write(FAR struct file *filep, FAR const char *buffer,
-                 size_t buflen);
+                             size_t buflen);
 static int     devnull_poll(FAR struct file *filep, FAR struct pollfd *fds,
-                 bool setup);
+                            bool setup);
 
 /****************************************************************************
  * Private Data

--- a/drivers/misc/dev_zero.c
+++ b/drivers/misc/dev_zero.c
@@ -39,11 +39,11 @@
  ****************************************************************************/
 
 static ssize_t devzero_read(FAR struct file *filep, FAR char *buffer,
-                 size_t buflen);
+                            size_t buflen);
 static ssize_t devzero_write(FAR struct file *filep, FAR const char *buffer,
-                 size_t buflen);
+                             size_t buflen);
 static int     devzero_poll(FAR struct file *filep, FAR struct pollfd *fds,
-                 bool setup);
+                            bool setup);
 
 /****************************************************************************
  * Private Data

--- a/drivers/net/telnet.c
+++ b/drivers/net/telnet.c
@@ -159,13 +159,13 @@ static void    telnet_sendopt(FAR struct telnet_dev_s *priv, uint8_t option,
 static int     telnet_open(FAR struct file *filep);
 static int     telnet_close(FAR struct file *filep);
 static ssize_t telnet_read(FAR struct file *filep, FAR char *buffer,
-                 size_t len);
+                           size_t len);
 static ssize_t telnet_write(FAR struct file *filep, FAR const char *buffer,
-                 size_t len);
+                            size_t len);
 static int     telnet_ioctl(FAR struct file *filep, int cmd,
-                 unsigned long arg);
+                            unsigned long arg);
 static int     telnet_poll(FAR struct file *filep, FAR struct pollfd *fds,
-                 bool setup);
+                           bool setup);
 
 /* Telnet session creation */
 

--- a/drivers/net/tun.c
+++ b/drivers/net/tun.c
@@ -246,11 +246,6 @@ static void tun_pollnotify(FAR struct tun_device_s *priv,
       nxsem_post(&priv->write_wait_sem);
     }
 
-  if (fds == NULL)
-    {
-      return;
-    }
-
   poll_notify(&fds, 1, eventset);
 }
 
@@ -1186,7 +1181,7 @@ static int tun_poll(FAR struct file *filep,
           eventset |= POLLIN;
         }
 
-      tun_pollnotify(priv, eventset);
+      poll_notify(&fds, 1, eventset);
     }
   else
     {

--- a/drivers/pipes/pipe_common.c
+++ b/drivers/pipes/pipe_common.c
@@ -741,7 +741,7 @@ int pipecommon_poll(FAR struct file *filep, FAR struct pollfd *fds,
           eventset |= POLLERR;
         }
 
-      poll_notify(dev->d_fds, CONFIG_DEV_PIPE_NPOLLWAITERS, eventset);
+      poll_notify(&fds, 1, eventset);
     }
   else
     {

--- a/drivers/power/battery/battery_monitor.c
+++ b/drivers/power/battery/battery_monitor.c
@@ -104,14 +104,9 @@ static const struct file_operations g_batteryops =
 static int battery_monitor_notify(FAR struct battery_monitor_priv_s *priv,
                                   uint32_t mask)
 {
-  FAR struct pollfd *fd = priv->fds;
+  FAR struct pollfd *fds = priv->fds;
   int semcnt;
   int ret;
-
-  if (!fd)
-    {
-      return OK;
-    }
 
   ret = nxmutex_lock(&priv->lock);
   if (ret < 0)
@@ -122,7 +117,7 @@ static int battery_monitor_notify(FAR struct battery_monitor_priv_s *priv,
   priv->mask |= mask;
   if (priv->mask)
     {
-      poll_notify(&fd, 1, POLLIN);
+      poll_notify(&fds, 1, POLLIN);
 
       nxsem_get_value(&priv->wait, &semcnt);
       if (semcnt < 1)
@@ -470,6 +465,10 @@ static int bat_monitor_poll(FAR struct file *filep,
         {
           priv->fds = fds;
           fds->priv = &priv->fds;
+          if (priv->mask)
+            {
+              poll_notify(&fds, 1, POLLIN);
+            }
         }
       else
         {
@@ -483,12 +482,6 @@ static int bat_monitor_poll(FAR struct file *filep,
     }
 
   nxmutex_unlock(&priv->lock);
-
-  if (setup)
-    {
-      battery_monitor_notify(priv, 0);
-    }
-
   return ret;
 }
 

--- a/drivers/sensors/gps_uorb.c
+++ b/drivers/sensors/gps_uorb.c
@@ -386,7 +386,7 @@ static int gps_poll(FAR struct file *filep, FAR struct pollfd *fds,
       fds->priv = filep;
       if (upper->buffer.head > user->pos)
         {
-          poll_notify(&user->fds, 1, POLLIN);
+          poll_notify(&fds, 1, POLLIN);
         }
     }
   else if (user->fds)

--- a/drivers/sensors/hc_sr04.c
+++ b/drivers/sensors/hc_sr04.c
@@ -332,7 +332,7 @@ static int hcsr04_poll(FAR struct file *filep, FAR struct pollfd *fds,
       flags = enter_critical_section();
       if (hcsr04_sample(priv))
         {
-          poll_notify(priv->fds, CONFIG_HCSR04_NPOLLWAITERS, POLLIN);
+          poll_notify(&fds, 1, POLLIN);
         }
 
       leave_critical_section(flags);

--- a/drivers/sensors/hts221.c
+++ b/drivers/sensors/hts221.c
@@ -1115,7 +1115,7 @@ static int hts221_poll(FAR struct file *filep, FAR struct pollfd *fds,
       flags = enter_critical_section();
       if (priv->int_pending || hts221_sample(priv))
         {
-          poll_notify(priv->fds, CONFIG_HTS221_NPOLLWAITERS, POLLIN);
+          poll_notify(&fds, 1, POLLIN);
         }
 
       leave_critical_section(flags);

--- a/drivers/sensors/lis2dh.c
+++ b/drivers/sensors/lis2dh.c
@@ -108,38 +108,40 @@ static int            lis2dh_open(FAR struct file *filep);
 static int            lis2dh_close(FAR struct file *filep);
 static ssize_t        lis2dh_read(FAR struct file *, FAR char *, size_t);
 static ssize_t        lis2dh_write(FAR struct file *filep,
-                        FAR const char *buffer, size_t buflen);
+                                   FAR const char *buffer, size_t buflen);
 static int            lis2dh_ioctl(FAR struct file *filep, int cmd,
-                        unsigned long arg);
+                                   unsigned long arg);
 static int            lis2dh_access(FAR struct lis2dh_dev_s *dev,
-                        uint8_t subaddr, FAR uint8_t *buf, int length);
+                                    uint8_t subaddr, FAR uint8_t *buf,
+                                    int length);
 static int            lis2dh_get_reading(FAR struct lis2dh_dev_s *dev,
-                        FAR struct lis2dh_vector_s *res, bool force_read);
+                                         FAR struct lis2dh_vector_s *res,
+                                         bool force_read);
 static int            lis2dh_powerdown(FAR struct lis2dh_dev_s *dev);
 static int            lis2dh_reboot(FAR struct lis2dh_dev_s *dev);
 static int            lis2dh_poll(FAR struct file *filep,
-                        FAR struct pollfd *fds, bool setup);
+                                  FAR struct pollfd *fds, bool setup);
 static int            lis2dh_int_handler(int irq, FAR void *context,
-                        FAR void *arg);
+                                         FAR void *arg);
 static int            lis2dh_setup(FAR struct lis2dh_dev_s *dev,
-                        FAR struct lis2dh_setup *new_setup);
+                                   FAR struct lis2dh_setup *new_setup);
 static inline int16_t lis2dh_raw_to_mg(uint8_t raw_hibyte,
-                        uint8_t raw_lobyte, int scale);
+                                       uint8_t raw_lobyte, int scale);
 static int            lis2dh_read_temp(FAR struct lis2dh_dev_s *dev,
-                        FAR int16_t *temper);
+                                       FAR int16_t *temper);
 static int            lis2dh_clear_interrupts(FAR struct lis2dh_dev_s *priv,
-                        uint8_t interrupts);
+                                              uint8_t interrupts);
 static unsigned int   lis2dh_get_fifo_readings(FAR struct lis2dh_dev_s *priv,
-                        FAR struct lis2dh_result *res,
-                        unsigned int readcount,
-                        FAR int *perr);
+                                               FAR struct lis2dh_result *res,
+                                               unsigned int readcount,
+                                               FAR int *perr);
 #ifdef CONFIG_LIS2DH_DRIVER_SELFTEST
 static int            lis2dh_handle_selftest(FAR struct lis2dh_dev_s *priv);
 static int16_t        lis2dh_raw_convert_to_12bit(uint8_t raw_hibyte,
-                        uint8_t raw_lobyte);
+                                                  uint8_t raw_lobyte);
 static FAR const struct lis2dh_vector_s *
                        lis2dh_get_raw_readings(FAR struct lis2dh_dev_s *dev,
-                        FAR int *err);
+                                               FAR int *err);
 #endif
 
 /****************************************************************************
@@ -713,7 +715,7 @@ static int lis2dh_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       if (priv->int_pending)
         {
-          poll_notify(priv->fds, CONFIG_LIS2DH_NPOLLWAITERS, POLLIN);
+          poll_notify(&fds, 1, POLLIN);
         }
     }
   else if (fds->priv)

--- a/drivers/sensors/max44009.c
+++ b/drivers/sensors/max44009.c
@@ -828,7 +828,8 @@ static int max44009_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       if (priv->int_pending)
         {
-          max44009_notify(priv);
+          poll_notify(&fds, 1, POLLIN);
+          priv->int_pending = false;
         }
     }
   else if (fds->priv)

--- a/drivers/sensors/sensor.c
+++ b/drivers/sensors/sensor.c
@@ -936,7 +936,7 @@ static int sensor_poll(FAR struct file *filep,
           eventset |= POLLPRI;
         }
 
-        sensor_pollnotify_one(user, eventset);
+        poll_notify(&fds, 1, eventset);
     }
   else
     {

--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -1617,8 +1617,8 @@ static int uart_poll(FAR struct file *filep,
             {
               /* Bind the poll structure and this slot */
 
-              dev->fds[i]  = fds;
-              fds->priv    = &dev->fds[i];
+              dev->fds[i] = fds;
+              fds->priv   = &dev->fds[i];
               break;
             }
         }
@@ -1678,7 +1678,7 @@ static int uart_poll(FAR struct file *filep,
         }
 #endif
 
-      poll_notify(dev->fds, CONFIG_SERIAL_NPOLLWAITERS, eventset);
+      poll_notify(&fds, 1, eventset);
     }
   else if (fds->priv != NULL)
     {

--- a/drivers/serial/uart_bth4.c
+++ b/drivers/serial/uart_bth4.c
@@ -369,8 +369,8 @@ static int uart_bth4_poll(FAR struct file *filep, FAR struct pollfd *fds,
             {
               /* Bind the poll structure and this slot */
 
-              dev->fds[i]  = fds;
-              fds->priv    = &dev->fds[i];
+              dev->fds[i] = fds;
+              fds->priv   = &dev->fds[i];
               break;
             }
         }
@@ -388,7 +388,7 @@ static int uart_bth4_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       eventset |= POLLOUT;
 
-      uart_bth4_pollnotify(dev, eventset);
+      poll_notify(&fds, 1, eventset);
     }
   else if (fds->priv != NULL)
     {

--- a/drivers/serial/uart_bth5.c
+++ b/drivers/serial/uart_bth5.c
@@ -1209,7 +1209,7 @@ uart_bth5_poll(FAR struct file *filep, FAR struct pollfd *fds, bool setup)
       nxmutex_unlock(&dev->recvlock);
       eventset |= POLLOUT;
 
-      uart_bth5_pollnotify(dev, eventset);
+      poll_notify(&fds, 1, eventset);
     }
   else if (fds->priv != NULL)
     {

--- a/drivers/spi/spi_slave_driver.c
+++ b/drivers/spi/spi_slave_driver.c
@@ -490,7 +490,7 @@ static int spi_slave_poll(FAR struct file *filep, FAR struct pollfd *fds,
           eventset |= POLLOUT;
         }
 
-      poll_notify(&priv->fds, 1, eventset);
+      poll_notify(&fds, 1, eventset);
     }
   else if (fds->priv != NULL)
     {

--- a/drivers/syslog/ramlog.c
+++ b/drivers/syslog/ramlog.c
@@ -204,16 +204,12 @@ static void ramlog_pollnotify(FAR struct ramlog_dev_s *priv,
                               pollevent_t eventset)
 {
   irqstate_t flags;
-  int i;
 
   /* This function may be called from an interrupt handler */
 
-  for (i = 0; i < CONFIG_RAMLOG_NPOLLWAITERS; i++)
-    {
-      flags = enter_critical_section();
-      poll_notify(&priv->rl_fds[i], 1, eventset);
-      leave_critical_section(flags);
-    }
+  flags = enter_critical_section();
+  poll_notify(priv->rl_fds, CONFIG_RAMLOG_NPOLLWAITERS, eventset);
+  leave_critical_section(flags);
 }
 
 /****************************************************************************
@@ -709,8 +705,8 @@ static int ramlog_file_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       if (i >= CONFIG_RAMLOG_NPOLLWAITERS)
         {
-          fds->priv    = NULL;
-          ret          = -EBUSY;
+          fds->priv = NULL;
+          ret       = -EBUSY;
           goto errout;
         }
 
@@ -741,7 +737,7 @@ static int ramlog_file_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       leave_critical_section(flags);
 
-      ramlog_pollnotify(priv, eventset);
+      poll_notify(&fds, 1, eventset);
     }
   else if (fds->priv)
     {

--- a/drivers/usbdev/usbdev_fs.c
+++ b/drivers/usbdev/usbdev_fs.c
@@ -856,7 +856,7 @@ static int usbdev_fs_poll(FAR struct file *filep, FAR struct pollfd *fds,
         }
     }
 
-  poll_notify(fs_ep->fds, CONFIG_USBDEV_FS_NPOLLWAITERS, eventset);
+  poll_notify(&fds, 1, eventset);
 
 exit_leave_critical:
   leave_critical_section(flags);

--- a/drivers/usbhost/usbhost_cdcmbim.c
+++ b/drivers/usbhost/usbhost_cdcmbim.c
@@ -572,8 +572,8 @@ static int cdcwdm_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       if (i >= CONFIG_USBHOST_CDCMBIM_NPOLLWAITERS)
         {
-          fds->priv    = NULL;
-          ret          = -EBUSY;
+          fds->priv = NULL;
+          ret       = -EBUSY;
           goto errout;
         }
 
@@ -583,8 +583,7 @@ static int cdcwdm_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       if (priv->comm_rxlen > 0)
         {
-          poll_notify(priv->fds, CONFIG_USBHOST_CDCMBIM_NPOLLWAITERS,
-                      POLLIN);
+          poll_notify(&fds, 1, POLLIN);
         }
     }
   else

--- a/drivers/usbhost/usbhost_hidkbd.c
+++ b/drivers/usbhost/usbhost_hidkbd.c
@@ -263,21 +263,22 @@ static inline void usbhost_freeclass(FAR struct usbhost_state_s *usbclass);
 static int  usbhost_allocdevno(FAR struct usbhost_state_s *priv);
 static void usbhost_freedevno(FAR struct usbhost_state_s *priv);
 static inline void usbhost_mkdevname(FAR struct usbhost_state_s *priv,
-              FAR char *devname);
+                                     FAR char *devname);
 
 /* Keyboard polling thread */
 
 static void usbhost_destroy(FAR void *arg);
 static void usbhost_putbuffer(FAR struct usbhost_state_s *priv,
-              uint8_t keycode);
+                              uint8_t keycode);
 #ifdef CONFIG_HIDKBD_ENCODED
 static void usbhost_putstream(FAR struct lib_outstream_s *self, int ch);
 #endif
 static inline uint8_t usbhost_mapscancode(uint8_t scancode,
-              uint8_t modifier);
+                                          uint8_t modifier);
 #ifdef CONFIG_HIDKBD_ENCODED
 static inline void usbhost_encodescancode(FAR struct usbhost_state_s *priv,
-              uint8_t scancode, uint8_t modifier);
+                                          uint8_t scancode,
+                                          uint8_t modifier);
 #endif
 static int  usbhost_kbdpoll(int argc, char *argv[]);
 
@@ -298,7 +299,8 @@ static inline void usbhost_toggle_capslock(void);
 /* Helpers for usbhost_connect() */
 
 static inline int usbhost_cfgdesc(FAR struct usbhost_state_s *priv,
-              FAR const uint8_t *configdesc, int desclen);
+                                  FAR const uint8_t *configdesc,
+                                  int desclen);
 static inline int usbhost_devinit(FAR struct usbhost_state_s *priv);
 
 /* (Little Endian) Data helpers */
@@ -318,9 +320,9 @@ static int usbhost_crfree(FAR struct usbhost_state_s *priv);
 
 /* struct usbhost_registry_s methods */
 
-static FAR struct usbhost_class_s *usbhost_create(
-              FAR struct usbhost_hubport_s *hport,
-              FAR const struct usbhost_id_s *id);
+static FAR struct usbhost_class_s *
+usbhost_create(FAR struct usbhost_hubport_s *hport,
+               FAR const struct usbhost_id_s *id);
 
 /* struct usbhost_class_s methods */
 
@@ -333,11 +335,11 @@ static int  usbhost_disconnected(FAR struct usbhost_class_s *usbclass);
 static int  usbhost_open(FAR struct file *filep);
 static int  usbhost_close(FAR struct file *filep);
 static ssize_t usbhost_read(FAR struct file *filep,
-              FAR char *buffer, size_t len);
+                            FAR char *buffer, size_t len);
 static ssize_t usbhost_write(FAR struct file *filep,
-              FAR const char *buffer, size_t len);
+                             FAR const char *buffer, size_t len);
 static int  usbhost_poll(FAR struct file *filep, FAR struct pollfd *fds,
-              bool setup);
+                         bool setup);
 
 /****************************************************************************
  * Private Data
@@ -2832,8 +2834,8 @@ static int usbhost_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       if (i >= CONFIG_HIDKBD_NPOLLWAITERS)
         {
-          fds->priv    = NULL;
-          ret          = -EBUSY;
+          fds->priv = NULL;
+          ret       = -EBUSY;
           goto errout;
         }
 
@@ -2843,7 +2845,7 @@ static int usbhost_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       if (priv->headndx != priv->tailndx)
         {
-          poll_notify(priv->fds, CONFIG_HIDKBD_NPOLLWAITERS, POLLIN);
+          poll_notify(&fds, 1, POLLIN);
         }
     }
   else
@@ -2855,8 +2857,8 @@ static int usbhost_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       /* Remove all memory of the poll setup */
 
-      *slot                = NULL;
-      fds->priv            = NULL;
+      *slot     = NULL;
+      fds->priv = NULL;
     }
 
 errout:

--- a/drivers/usbhost/usbhost_hidmouse.c
+++ b/drivers/usbhost/usbhost_hidmouse.c
@@ -2378,8 +2378,8 @@ static int usbhost_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       if (i >= CONFIG_HIDMOUSE_NPOLLWAITERS)
         {
-          fds->priv    = NULL;
-          ret          = -EBUSY;
+          fds->priv = NULL;
+          ret       = -EBUSY;
           goto errout;
         }
 
@@ -2389,7 +2389,7 @@ static int usbhost_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       if (priv->valid)
         {
-          poll_notify(priv->fds, CONFIG_HIDMOUSE_NPOLLWAITERS, POLLIN);
+          poll_notify(&fds, 1, POLLIN);
         }
     }
   else

--- a/drivers/usbhost/usbhost_xboxcontroller.c
+++ b/drivers/usbhost/usbhost_xboxcontroller.c
@@ -2139,8 +2139,8 @@ static int usbhost_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       if (i >= CONFIG_XBOXCONTROLLER_NPOLLWAITERS)
         {
-          fds->priv    = NULL;
-          ret          = -EBUSY;
+          fds->priv = NULL;
+          ret       = -EBUSY;
           goto errout;
         }
 
@@ -2150,7 +2150,7 @@ static int usbhost_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       if (priv->valid)
         {
-          usbhost_pollnotify(priv);
+          poll_notify(&fds, 1, POLLIN);
         }
     }
   else

--- a/drivers/usbmisc/fusb301.c
+++ b/drivers/usbmisc/fusb301.c
@@ -705,7 +705,7 @@ static int fusb301_poll(FAR struct file *filep,
       flags = enter_critical_section();
       if (priv->int_pending)
         {
-          poll_notify(priv->fds, CONFIG_FUSB301_NPOLLWAITERS, POLLIN);
+          poll_notify(&fds, 1, POLLIN);
         }
 
       leave_critical_section(flags);

--- a/drivers/usbmisc/fusb302.c
+++ b/drivers/usbmisc/fusb302.c
@@ -456,6 +456,7 @@ void           enableccmeas(FAR struct fusb302_dev_s *priv,
 void           set_switches(FAR struct fusb302_dev_s *priv,
                             uint8_t toggsval);
 static int     set_int_mask(struct fusb302_dev_s *priv);
+
 /****************************************************************************
  * Private Data
  ****************************************************************************/

--- a/drivers/usbmisc/fusb303.c
+++ b/drivers/usbmisc/fusb303.c
@@ -893,7 +893,7 @@ static int fusb303_poll(FAR struct file *filep, FAR struct pollfd *fds,
       flags = enter_critical_section();
       if (priv->int_pending)
         {
-          poll_notify(priv->fds, CONFIG_FUSB303_NPOLLWAITERS, POLLIN);
+          poll_notify(&fds, 1, POLLIN);
         }
 
       leave_critical_section(flags);

--- a/drivers/usrsock/usrsock_dev.c
+++ b/drivers/usrsock/usrsock_dev.c
@@ -77,17 +77,12 @@ struct usrsockdev_s
 
 static ssize_t usrsockdev_read(FAR struct file *filep, FAR char *buffer,
                                size_t len);
-
 static ssize_t usrsockdev_write(FAR struct file *filep,
                                 FAR const char *buffer, size_t len);
-
 static off_t usrsockdev_seek(FAR struct file *filep, off_t offset,
                              int whence);
-
 static int usrsockdev_open(FAR struct file *filep);
-
 static int usrsockdev_close(FAR struct file *filep);
-
 static int usrsockdev_poll(FAR struct file *filep, FAR struct pollfd *fds,
                            bool setup);
 
@@ -395,7 +390,6 @@ static int usrsockdev_poll(FAR struct file *filep, FAR struct pollfd *fds,
 {
   FAR struct inode *inode = filep->f_inode;
   FAR struct usrsockdev_s *dev;
-  pollevent_t eventset;
   int ret;
   int i;
 
@@ -447,18 +441,14 @@ static int usrsockdev_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       /* Should immediately notify on any of the requested events? */
 
-      eventset = 0;
-
       /* Notify the POLLIN event if pending request. */
 
       if (dev->req.iov != NULL &&
           !(usrsock_iovec_get(NULL, 0, dev->req.iov,
                               dev->req.iovcnt, dev->req.pos, NULL) < 0))
         {
-          eventset |= POLLIN;
+          poll_notify(&fds, 1, POLLIN);
         }
-
-      poll_notify(dev->pollfds, nitems(dev->pollfds), eventset);
     }
   else
     {

--- a/drivers/video/fb.c
+++ b/drivers/video/fb.c
@@ -1068,7 +1068,7 @@ static int fb_poll(FAR struct file *filep, struct pollfd *fds, bool setup)
       panbuf = fb_get_panbuf(fb, priv->overlay);
       if (!circbuf_is_full(panbuf))
         {
-          poll_notify(pollfds, 1, POLLOUT);
+          poll_notify(&fds, 1, POLLOUT);
         }
     }
   else if (fds->priv != NULL)
@@ -1177,19 +1177,12 @@ static void fb_do_pollnotify(wdparm_t arg)
 {
   FAR struct fb_paninfo_s *paninfo = (FAR struct fb_paninfo_s *)arg;
   irqstate_t flags;
-  int i;
 
   flags = enter_critical_section();
 
-  for (i = 0; i < CONFIG_VIDEO_FB_NPOLLWAITERS; i++)
-    {
-      if (paninfo->fds[i] != NULL)
-        {
-          /* Notify framebuffer is writable. */
+  /* Notify framebuffer is writable. */
 
-          poll_notify(&paninfo->fds[i], 1, POLLOUT);
-        }
-    }
+  poll_notify(paninfo->fds, CONFIG_VIDEO_FB_NPOLLWAITERS, POLLOUT);
 
   leave_critical_section(flags);
 }

--- a/drivers/video/video.c
+++ b/drivers/video/video.c
@@ -3280,7 +3280,7 @@ static int video_poll(FAR struct file *filep, struct pollfd *fds, bool setup)
           fds->priv     = &type_inf->fds;
           if (!video_framebuff_is_empty(&type_inf->bufinf))
             {
-              poll_notify(&type_inf->fds, 1, POLLIN);
+              poll_notify(&fds, 1, POLLIN);
             }
         }
       else

--- a/drivers/wireless/cc1101.c
+++ b/drivers/wireless/cc1101.c
@@ -623,7 +623,7 @@ static int cc1101_file_poll(FAR struct file *filep, FAR struct pollfd *fds,
       nxmutex_lock(&dev->lock_rx_buffer);
       if (dev->fifo_len > 0)
         {
-          poll_notify(&dev->pfd, 1, POLLIN);
+          poll_notify(&fds, 1, POLLIN);
         }
 
       nxmutex_unlock(&dev->lock_rx_buffer);

--- a/drivers/wireless/gs2200m.c
+++ b/drivers/wireless/gs2200m.c
@@ -3143,7 +3143,7 @@ static int gs2200m_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       if (0 < n)
         {
-          poll_notify(&dev->pfd, 1, POLLIN);
+          poll_notify(&fds, 1, POLLIN);
         }
     }
   else

--- a/drivers/wireless/lpwan/sx127x/sx127x.c
+++ b/drivers/wireless/lpwan/sx127x/sx127x.c
@@ -1220,7 +1220,7 @@ static int sx127x_poll(FAR struct file *filep, FAR struct pollfd *fds,
         {
           /* Data available for input */
 
-          poll_notify(&dev->pfd, 1, POLLIN);
+          poll_notify(&fds, 1, POLLIN);
         }
 
       nxmutex_unlock(&dev->rx_buffer_lock);

--- a/drivers/wireless/nrf24l01.c
+++ b/drivers/wireless/nrf24l01.c
@@ -1403,7 +1403,7 @@ static int nrf24l01_poll(FAR struct file *filep, FAR struct pollfd *fds,
       nxmutex_lock(&dev->lock_fifo);
       if (dev->fifo_len > 0)
         {
-          poll_notify(&dev->pfd, 1, POLLIN);
+          poll_notify(&fds, 1, POLLIN);
         }
 
       nxmutex_unlock(&dev->lock_fifo);

--- a/fs/mqueue/mq_open.c
+++ b/fs/mqueue/mq_open.c
@@ -134,7 +134,7 @@ static int nxmq_file_poll(FAR struct file *filep,
           eventset |= POLLIN;
         }
 
-      nxmq_pollnotify(msgq, eventset);
+      poll_notify(&fds, 1, eventset);
     }
   else if (fds->priv != NULL)
     {

--- a/fs/vfs/fs_eventfd.c
+++ b/fs/vfs/fs_eventfd.c
@@ -78,7 +78,7 @@ static ssize_t eventfd_do_write(FAR struct file *filep,
                                 FAR const char *buffer, size_t len);
 #ifdef CONFIG_EVENT_FD_POLL
 static int eventfd_do_poll(FAR struct file *filep, FAR struct pollfd *fds,
-                       bool setup);
+                           bool setup);
 #endif
 
 static int eventfd_blocking_io(FAR struct eventfd_priv_s *dev,
@@ -489,7 +489,7 @@ static int eventfd_do_poll(FAR struct file *filep, FAR struct pollfd *fds,
       eventset |= POLLIN;
     }
 
-  poll_notify(dev->fds, CONFIG_EVENT_FD_NPOLLWAITERS, eventset);
+  poll_notify(&fds, 1, eventset);
 
 out:
   nxmutex_unlock(&dev->lock);

--- a/fs/vfs/fs_signalfd.c
+++ b/fs/vfs/fs_signalfd.c
@@ -271,7 +271,7 @@ static int signalfd_file_poll(FAR struct file *filep,
   sigandset(&mask, &mask, &dev->sigmask);
   if (!sigisemptyset(&mask))
     {
-      poll_notify(dev->fds, CONFIG_SIGNAL_FD_NPOLLWAITERS, POLLIN);
+      poll_notify(&fds, 1, POLLIN);
     }
 
 out:

--- a/fs/vfs/fs_timerfd.c
+++ b/fs/vfs/fs_timerfd.c
@@ -370,7 +370,7 @@ static int timerfd_poll(FAR struct file *filep, FAR struct pollfd *fds,
   if (dev->counter > 0)
     {
 #ifdef CONFIG_TIMER_FD_POLL
-      poll_notify(dev->fds, CONFIG_TIMER_FD_NPOLLWAITERS, POLLIN);
+      poll_notify(&fds, 1, POLLIN);
 #endif
     }
 

--- a/graphics/nxterm/nxterm.h
+++ b/graphics/nxterm/nxterm.h
@@ -175,10 +175,11 @@ extern const struct file_operations g_nxterm_drvrops;
 
 /* Common device registration/un-registration */
 
-FAR struct nxterm_state_s *nxterm_register(NXTERM handle,
-    FAR struct nxterm_window_s *wndo,
-    FAR const struct nxterm_operations_s *ops,
-    int minor);
+FAR struct nxterm_state_s *
+nxterm_register(NXTERM handle,
+                FAR struct nxterm_window_s *wndo,
+                FAR const struct nxterm_operations_s *ops,
+                int minor);
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
 void nxterm_unregister(FAR struct nxterm_state_s *priv);
 #endif
@@ -213,7 +214,7 @@ FAR const
 struct nxterm_bitmap_s *nxterm_addchar(FAR struct nxterm_state_s *priv,
                                        uint8_t ch);
 int nxterm_hidechar(FAR struct nxterm_state_s *priv,
-    FAR const struct nxterm_bitmap_s *bm);
+                    FAR const struct nxterm_bitmap_s *bm);
 int nxterm_backspace(FAR struct nxterm_state_s *priv);
 void nxterm_fillchar(FAR struct nxterm_state_s *priv,
                      FAR const struct nxgl_rect_s *rect,

--- a/net/can/can_sockif.c
+++ b/net/can/can_sockif.c
@@ -52,9 +52,9 @@ static int  can_setup(FAR struct socket *psock);
 static sockcaps_t can_sockcaps(FAR struct socket *psock);
 static void can_addref(FAR struct socket *psock);
 static int  can_bind(FAR struct socket *psock,
-              FAR const struct sockaddr *addr, socklen_t addrlen);
+                     FAR const struct sockaddr *addr, socklen_t addrlen);
 static int  can_poll_local(FAR struct socket *psock, FAR struct pollfd *fds,
-              bool setup);
+                           bool setup);
 static int can_close(FAR struct socket *psock);
 
 /****************************************************************************
@@ -394,9 +394,9 @@ static int can_poll_local(FAR struct socket *psock, FAR struct pollfd *fds,
        * during callback processing.
        */
 
-      cb->flags   = NETDEV_DOWN;
-      cb->priv    = (FAR void *)info;
-      cb->event   = can_poll_eventhandler;
+      cb->flags = NETDEV_DOWN;
+      cb->priv  = info;
+      cb->event = can_poll_eventhandler;
 
       if ((fds->events & POLLOUT) != 0)
         {
@@ -412,7 +412,7 @@ static int can_poll_local(FAR struct socket *psock, FAR struct pollfd *fds,
        * for use during poll teardown as well.
        */
 
-      fds->priv = (FAR void *)info;
+      fds->priv = info;
 
       /* Check for read data availability now */
 

--- a/net/icmp/icmp_netpoll.c
+++ b/net/icmp/icmp_netpoll.c
@@ -190,7 +190,7 @@ int icmp_pollsetup(FAR struct socket *psock, FAR struct pollfd *fds)
    */
 
   cb->flags = NETDEV_DOWN;
-  cb->priv  = (FAR void *)info;
+  cb->priv  = info;
   cb->event = icmp_poll_eventhandler;
 
   if ((fds->events & POLLIN) != 0)
@@ -202,7 +202,7 @@ int icmp_pollsetup(FAR struct socket *psock, FAR struct pollfd *fds)
    * for use during poll teardown as well.
    */
 
-  fds->priv = (FAR void *)info;
+  fds->priv = info;
 
   /* Check for read data availability now */
 

--- a/net/icmp/icmp_sockif.c
+++ b/net/icmp/icmp_sockif.c
@@ -50,13 +50,15 @@ static int        icmp_setup(FAR struct socket *psock);
 static sockcaps_t icmp_sockcaps(FAR struct socket *psock);
 static void       icmp_addref(FAR struct socket *psock);
 static int        icmp_netpoll(FAR struct socket *psock,
-                    FAR struct pollfd *fds, bool setup);
+                               FAR struct pollfd *fds, bool setup);
 static int        icmp_close(FAR struct socket *psock);
 #ifdef CONFIG_NET_SOCKOPTS
 static int        icmp_getsockopt(FAR struct socket *psock, int level,
-                    int option, FAR void *value, FAR socklen_t *value_len);
+                                  int option, FAR void *value,
+                                  FAR socklen_t *value_len);
 static int        icmp_setsockopt(FAR struct socket *psock, int level,
-                    int option, FAR const void *value, socklen_t value_len);
+                                  int option, FAR const void *value,
+                                  socklen_t value_len);
 #endif
 
 /****************************************************************************

--- a/net/icmpv6/icmpv6_netpoll.c
+++ b/net/icmpv6/icmpv6_netpoll.c
@@ -189,7 +189,7 @@ int icmpv6_pollsetup(FAR struct socket *psock, FAR struct pollfd *fds)
    */
 
   cb->flags = NETDEV_DOWN;
-  cb->priv  = (FAR void *)info;
+  cb->priv  = info;
   cb->event = icmpv6_poll_eventhandler;
 
   if ((fds->events & POLLIN) != 0)
@@ -201,7 +201,7 @@ int icmpv6_pollsetup(FAR struct socket *psock, FAR struct pollfd *fds)
    * for use during poll teardown as well.
    */
 
-  fds->priv = (FAR void *)info;
+  fds->priv = info;
 
   /* Check for read data availability now */
 

--- a/net/inet/inet_sockif.c
+++ b/net/inet/inet_sockif.c
@@ -66,42 +66,50 @@ static int        inet_setup(FAR struct socket *psock);
 static sockcaps_t inet_sockcaps(FAR struct socket *psock);
 static void       inet_addref(FAR struct socket *psock);
 static int        inet_bind(FAR struct socket *psock,
-                    FAR const struct sockaddr *addr, socklen_t addrlen);
+                            FAR const struct sockaddr *addr,
+                            socklen_t addrlen);
 static int        inet_getsockname(FAR struct socket *psock,
-                    FAR struct sockaddr *addr, FAR socklen_t *addrlen);
+                                   FAR struct sockaddr *addr,
+                                   FAR socklen_t *addrlen);
 static int        inet_getpeername(FAR struct socket *psock,
-                    FAR struct sockaddr *addr, FAR socklen_t *addrlen);
+                                   FAR struct sockaddr *addr,
+                                   FAR socklen_t *addrlen);
 static int        inet_listen(FAR struct socket *psock, int backlog);
 static int        inet_connect(FAR struct socket *psock,
-                    FAR const struct sockaddr *addr, socklen_t addrlen);
+                               FAR const struct sockaddr *addr,
+                               socklen_t addrlen);
 static int        inet_accept(FAR struct socket *psock,
-                    FAR struct sockaddr *addr, FAR socklen_t *addrlen,
-                    FAR struct socket *newsock, int flags);
+                              FAR struct sockaddr *addr,
+                              FAR socklen_t *addrlen,
+                              FAR struct socket *newsock, int flags);
 static int        inet_poll(FAR struct socket *psock,
-                    FAR struct pollfd *fds, bool setup);
+                            FAR struct pollfd *fds, bool setup);
 static ssize_t    inet_send(FAR struct socket *psock, FAR const void *buf,
-                    size_t len, int flags);
+                            size_t len, int flags);
 static ssize_t    inet_sendto(FAR struct socket *psock, FAR const void *buf,
-                    size_t len, int flags, FAR const struct sockaddr *to,
-                    socklen_t tolen);
+                              size_t len, int flags,
+                              FAR const struct sockaddr *to,
+                              socklen_t tolen);
 static ssize_t    inet_sendmsg(FAR struct socket *psock,
-                    FAR struct msghdr *msg, int flags);
+                               FAR struct msghdr *msg, int flags);
 static ssize_t    inet_recvmsg(FAR struct socket *psock,
-                    FAR struct msghdr *msg, int flags);
+                               FAR struct msghdr *msg, int flags);
 static int        inet_ioctl(FAR struct socket *psock,
-                    int cmd, unsigned long arg);
+                             int cmd, unsigned long arg);
 static int        inet_socketpair(FAR struct socket *psocks[2]);
 static int        inet_shutdown(FAR struct socket *psock, int how);
 #ifdef CONFIG_NET_SOCKOPTS
 static int        inet_getsockopt(FAR struct socket *psock, int level,
-                    int option, FAR void *value, FAR socklen_t *value_len);
+                                  int option, FAR void *value,
+                                  FAR socklen_t *value_len);
 static int        inet_setsockopt(FAR struct socket *psock, int level,
-                    int option, FAR const void *value, socklen_t value_len);
+                                  int option, FAR const void *value,
+                                  socklen_t value_len);
 #endif
 #ifdef CONFIG_NET_SENDFILE
 static ssize_t    inet_sendfile(FAR struct socket *psock,
-                    FAR struct file *infile, FAR off_t *offset,
-                    size_t count);
+                                FAR struct file *infile, FAR off_t *offset,
+                                size_t count);
 #endif
 
 /****************************************************************************

--- a/net/local/local_netpoll.c
+++ b/net/local/local_netpoll.c
@@ -87,7 +87,7 @@ static int local_event_pollsetup(FAR struct local_conn_s *conn,
           eventset |= POLLIN;
         }
 
-      local_event_pollnotify(conn, eventset);
+      poll_notify(&fds, 1, eventset);
     }
   else
     {

--- a/net/local/local_sockif.c
+++ b/net/local/local_sockif.c
@@ -51,25 +51,31 @@ static int        local_setup(FAR struct socket *psock);
 static sockcaps_t local_sockcaps(FAR struct socket *psock);
 static void       local_sockaddref(FAR struct socket *psock);
 static int        local_bind(FAR struct socket *psock,
-                    FAR const struct sockaddr *addr, socklen_t addrlen);
+                             FAR const struct sockaddr *addr,
+                             socklen_t addrlen);
 static int        local_getsockname(FAR struct socket *psock,
-                    FAR struct sockaddr *addr, FAR socklen_t *addrlen);
+                                    FAR struct sockaddr *addr,
+                                    FAR socklen_t *addrlen);
 static int        local_getpeername(FAR struct socket *psock,
-                    FAR struct sockaddr *addr, FAR socklen_t *addrlen);
+                                    FAR struct sockaddr *addr,
+                                    FAR socklen_t *addrlen);
 static int        local_connect(FAR struct socket *psock,
-                    FAR const struct sockaddr *addr, socklen_t addrlen);
+                                FAR const struct sockaddr *addr,
+                                socklen_t addrlen);
 static int        local_poll(FAR struct socket *psock,
-                    FAR struct pollfd *fds, bool setup);
+                             FAR struct pollfd *fds, bool setup);
 static int        local_close(FAR struct socket *psock);
 static int        local_ioctl(FAR struct socket *psock,
-                    int cmd, unsigned long arg);
+                              int cmd, unsigned long arg);
 static int        local_socketpair(FAR struct socket *psocks[2]);
 static int        local_shutdown(FAR struct socket *psock, int how);
 #ifdef CONFIG_NET_SOCKOPTS
 static int        local_getsockopt(FAR struct socket *psock, int level,
-                    int option, FAR void *value, FAR socklen_t *value_len);
+                                   int option, FAR void *value,
+                                   FAR socklen_t *value_len);
 static int        local_setsockopt(FAR struct socket *psock, int level,
-                    int option, FAR const void *value, socklen_t value_len);
+                                   int option, FAR const void *value,
+                                   socklen_t value_len);
 #endif
 
 /****************************************************************************

--- a/net/netlink/netlink_sockif.c
+++ b/net/netlink/netlink_sockif.c
@@ -51,15 +51,18 @@ static int  netlink_setup(FAR struct socket *psock);
 static sockcaps_t netlink_sockcaps(FAR struct socket *psock);
 static void netlink_addref(FAR struct socket *psock);
 static int  netlink_bind(FAR struct socket *psock,
-              FAR const struct sockaddr *addr, socklen_t addrlen);
+                        FAR const struct sockaddr *addr, socklen_t addrlen);
 static int  netlink_getsockname(FAR struct socket *psock,
-              FAR struct sockaddr *addr, FAR socklen_t *addrlen);
+                                FAR struct sockaddr *addr,
+                                FAR socklen_t *addrlen);
 static int  netlink_getpeername(FAR struct socket *psock,
-              FAR struct sockaddr *addr, FAR socklen_t *addrlen);
+                                FAR struct sockaddr *addr,
+                                FAR socklen_t *addrlen);
 static int  netlink_connect(FAR struct socket *psock,
-              FAR const struct sockaddr *addr, socklen_t addrlen);
+                            FAR const struct sockaddr *addr,
+                            socklen_t addrlen);
 static int  netlink_poll(FAR struct socket *psock, FAR struct pollfd *fds,
-              bool setup);
+                         bool setup);
 static ssize_t netlink_sendmsg(FAR struct socket *psock,
                                FAR struct msghdr *msg, int flags);
 static ssize_t netlink_recvmsg(FAR struct socket *psock,

--- a/net/rpmsg/rpmsg_sockif.c
+++ b/net/rpmsg/rpmsg_sockif.c
@@ -141,30 +141,36 @@ static int        rpmsg_socket_setup(FAR struct socket *psock);
 static sockcaps_t rpmsg_socket_sockcaps(FAR struct socket *psock);
 static void       rpmsg_socket_addref(FAR struct socket *psock);
 static int        rpmsg_socket_bind(FAR struct socket *psock,
-                    FAR const struct sockaddr *addr, socklen_t addrlen);
+                                    FAR const struct sockaddr *addr,
+                                    socklen_t addrlen);
 static int        rpmsg_socket_getsockname(FAR struct socket *psock,
-                    FAR struct sockaddr *addr, FAR socklen_t *addrlen);
+                                           FAR struct sockaddr *addr,
+                                           FAR socklen_t *addrlen);
 static int        rpmsg_socket_getconnname(FAR struct socket *psock,
-                    FAR struct sockaddr *addr, FAR socklen_t *addrlen);
+                                           FAR struct sockaddr *addr,
+                                           FAR socklen_t *addrlen);
 static int        rpmsg_socket_listen(FAR struct socket *psock, int backlog);
 static int        rpmsg_socket_connect(FAR struct socket *psock,
-                    FAR const struct sockaddr *addr, socklen_t addrlen);
+                                       FAR const struct sockaddr *addr,
+                                       socklen_t addrlen);
 static int        rpmsg_socket_accept(FAR struct socket *psock,
-                    FAR struct sockaddr *addr, FAR socklen_t *addrlen,
-                    FAR struct socket *newsock, int flags);
+                                      FAR struct sockaddr *addr,
+                                      FAR socklen_t *addrlen,
+                                      FAR struct socket *newsock, int flags);
 static int        rpmsg_socket_poll(FAR struct socket *psock,
-                    FAR struct pollfd *fds, bool setup);
+                                    FAR struct pollfd *fds, bool setup);
 static ssize_t    rpmsg_socket_sendmsg(FAR struct socket *psock,
-                    FAR struct msghdr *msg, int flags);
+                                       FAR struct msghdr *msg, int flags);
 static ssize_t    rpmsg_socket_recvmsg(FAR struct socket *psock,
-                    FAR struct msghdr *msg, int flags);
+                                       FAR struct msghdr *msg, int flags);
 static int        rpmsg_socket_close(FAR struct socket *psock);
 static int        rpmsg_socket_ioctl(FAR struct socket *psock,
                                      int cmd, unsigned long arg);
 #ifdef CONFIG_NET_SOCKOPTS
 static int        rpmsg_socket_getsockopt(FAR struct socket *psock,
-                    int level, int option, FAR void *value,
-                    FAR socklen_t *value_len);
+                                          int level, int option,
+                                          FAR void *value,
+                                          FAR socklen_t *value_len);
 #endif
 
 /****************************************************************************
@@ -943,7 +949,7 @@ static int rpmsg_socket_poll(FAR struct socket *psock,
             }
         }
 
-      rpmsg_socket_poll_notify(conn, eventset);
+      poll_notify(&fds, 1, eventset);
     }
   else
     {

--- a/net/tcp/tcp_netpoll.c
+++ b/net/tcp/tcp_netpoll.c
@@ -165,9 +165,9 @@ static uint16_t tcp_poll_eventhandler(FAR struct net_driver_s *dev,
         {
           /* Stop further callbacks */
 
-          info->cb->flags   = 0;
-          info->cb->priv    = NULL;
-          info->cb->event   = NULL;
+          info->cb->flags = 0;
+          info->cb->priv  = NULL;
+          info->cb->event = NULL;
         }
     }
 
@@ -256,17 +256,16 @@ int tcp_pollsetup(FAR struct socket *psock, FAR struct pollfd *fds)
    * callback processing.
    */
 
-  cb->flags    = TCP_DISCONN_EVENTS;
-  cb->priv     = (FAR void *)info;
-  cb->event    = tcp_poll_eventhandler;
+  cb->flags = TCP_DISCONN_EVENTS;
+  cb->priv  = info;
+  cb->event = tcp_poll_eventhandler;
 
   if ((fds->events & POLLOUT) != 0)
     {
-      cb->flags |= TCP_POLL
+      cb->flags |= TCP_POLL;
 #if defined(CONFIG_NET_TCP_WRITE_BUFFERS)
-                   | TCP_ACKDATA
+      cb->flags |= TCP_ACKDATA;
 #endif
-                   ;
 
       /* Monitor the connected event */
 
@@ -285,7 +284,7 @@ int tcp_pollsetup(FAR struct socket *psock, FAR struct pollfd *fds)
    * for use during poll teardown as well.
    */
 
-  fds->priv    = (FAR void *)info;
+  fds->priv = info;
 
   /* Check for read data or backlogged connection availability now */
 

--- a/net/udp/udp_netpoll.c
+++ b/net/udp/udp_netpoll.c
@@ -186,9 +186,9 @@ int udp_pollsetup(FAR struct socket *psock, FAR struct pollfd *fds)
    * callback processing.
    */
 
-  cb->flags    = NETDEV_DOWN;
-  cb->priv     = (FAR void *)info;
-  cb->event    = udp_poll_eventhandler;
+  cb->flags = NETDEV_DOWN;
+  cb->priv  = info;
+  cb->event = udp_poll_eventhandler;
 
   if ((fds->events & POLLOUT) != 0)
     {
@@ -204,7 +204,7 @@ int udp_pollsetup(FAR struct socket *psock, FAR struct pollfd *fds)
    * for use during poll teardown as well.
    */
 
-  fds->priv = (FAR void *)info;
+  fds->priv = info;
 
   /* Check for read data availability now */
 

--- a/net/usrsock/usrsock_poll.c
+++ b/net/usrsock/usrsock_poll.c
@@ -174,17 +174,17 @@ static int usrsock_pollsetup(FAR struct socket *psock,
    * callback processing.
    */
 
-  cb->flags  = USRSOCK_EVENT_ABORT | USRSOCK_EVENT_CONNECT_READY |
-               USRSOCK_EVENT_SENDTO_READY | USRSOCK_EVENT_RECVFROM_AVAIL |
-               USRSOCK_EVENT_REMOTE_CLOSED;
-  cb->priv   = (FAR void *)info;
-  cb->event  = poll_event;
+  cb->flags = USRSOCK_EVENT_ABORT | USRSOCK_EVENT_CONNECT_READY |
+              USRSOCK_EVENT_SENDTO_READY | USRSOCK_EVENT_RECVFROM_AVAIL |
+              USRSOCK_EVENT_REMOTE_CLOSED;
+  cb->priv  = info;
+  cb->event = poll_event;
 
   /* Save the reference in the poll info structure as fds private as well
    * for use during poll teardown as well.
    */
 
-  fds->priv  = (FAR void *)info;
+  fds->priv = info;
 
   /* Check if socket is in error state */
 


### PR DESCRIPTION
## Summary

since it's redundant to iterate the whole fds array in setup

## Impact

code refactor

## Testing

ci