### PR TITLE
RTC driver improvement

### DIFF
--- a/drivers/timers/rpmsg_rtc.c
+++ b/drivers/timers/rpmsg_rtc.c
@@ -472,10 +472,22 @@ static int rpmsg_rtc_server_settime(FAR struct rtc_lowerhalf_s *lower,
   ret = server->lower->ops->settime(server->lower, rtctime);
   if (ret >= 0)
     {
-      nxmutex_lock(&server->lock);
       msg.sec  = timegm((FAR struct tm *)rtctime);
       msg.nsec = rtctime->tm_nsec;
       msg.header.command = RPMSG_RTC_SYNC;
+
+      if (ret == 0)
+        {
+          struct timespec tp;
+
+          tp.tv_sec  = msg.sec;
+          tp.tv_nsec = msg.nsec;
+          clock_synchronize(&tp);
+
+          ret = 1; /* Request the upper half skip clock synchronize */
+        }
+
+      nxmutex_lock(&server->lock);
       list_for_every(&server->list, node)
         {
           client = (FAR struct rpmsg_rtc_client_s *)node;
@@ -649,16 +661,6 @@ static int rpmsg_rtc_server_ept_cb(FAR struct rpmsg_endpoint *ept,
         rtctime.tm_nsec = msg->nsec;
 
         header->result = rpmsg_rtc_server_settime(priv, &rtctime);
-        if (header->result >= 0)
-          {
-            struct timespec tp;
-
-            tp.tv_sec  = msg->sec;
-            tp.tv_nsec = msg->nsec;
-
-            clock_synchronize(&tp);
-          }
-
         return rpmsg_send(ept, msg, sizeof(*msg));
       }
 

--- a/drivers/timers/rtc.c
+++ b/drivers/timers/rtc.c
@@ -335,7 +335,7 @@ static int rtc_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   FAR struct inode *inode;
   FAR struct rtc_upperhalf_s *upper;
   FAR const struct rtc_ops_s *ops;
-  int ret = -ENOSYS;
+  int ret;
 
   /* Get the reference to our internal state structure from the inode
    * structure.
@@ -359,7 +359,9 @@ static int rtc_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
    * RTC implementation.
    */
 
+  ret = -ENOSYS;
   ops = upper->lower->ops;
+
   switch (cmd)
     {
     /* RTC_RD_TIME returns the current RTC time.
@@ -474,16 +476,16 @@ static int rtc_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
              * alarm expires.
              */
 
-            upperinfo->active   = true;
-            upperinfo->pid      = pid;
-            upperinfo->event    = alarminfo->event;
+            upperinfo->active = true;
+            upperinfo->pid    = pid;
+            upperinfo->event  = alarminfo->event;
 
             /* Format the alarm info needed by the lower half driver */
 
-            lowerinfo.id        = alarmid;
-            lowerinfo.cb        = rtc_alarm_callback;
-            lowerinfo.priv      = (FAR void *)upper;
-            lowerinfo.time      = alarminfo->time;
+            lowerinfo.id   = alarmid;
+            lowerinfo.cb   = rtc_alarm_callback;
+            lowerinfo.priv = (FAR void *)upper;
+            lowerinfo.time = alarminfo->time;
 
             /* Then set the alarm */
 
@@ -545,16 +547,16 @@ static int rtc_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
              * alarm expires.
              */
 
-            upperinfo->active   = true;
-            upperinfo->pid      = pid;
-            upperinfo->event    = alarminfo->event;
+            upperinfo->active = true;
+            upperinfo->pid    = pid;
+            upperinfo->event  = alarminfo->event;
 
             /* Format the alarm info needed by the lower half driver */
 
-            lowerinfo.id        = alarmid;
-            lowerinfo.cb        = rtc_alarm_callback;
-            lowerinfo.priv      = (FAR void *)upper;
-            lowerinfo.reltime   = alarminfo->reltime;
+            lowerinfo.id      = alarmid;
+            lowerinfo.cb      = rtc_alarm_callback;
+            lowerinfo.priv    = (FAR void *)upper;
+            lowerinfo.reltime = alarminfo->reltime;
 
             /* Then set the alarm */
 
@@ -679,16 +681,16 @@ static int rtc_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
              * alarm expires.
              */
 
-            upperinfo->active   = true;
-            upperinfo->pid      = pid;
-            upperinfo->event    = alarminfo->event;
+            upperinfo->active = true;
+            upperinfo->pid    = pid;
+            upperinfo->event  = alarminfo->event;
 
             /* Format the alarm info needed by the lower half driver. */
 
-            lowerinfo.id        = id;
-            lowerinfo.cb        = rtc_periodic_callback;
-            lowerinfo.priv      = (FAR void *)upper;
-            lowerinfo.period    = alarminfo->period;
+            lowerinfo.id     = id;
+            lowerinfo.cb     = rtc_periodic_callback;
+            lowerinfo.priv   = (FAR void *)upper;
+            lowerinfo.period = alarminfo->period;
 
             /* Then set the periodic wakeup. */
 
@@ -734,7 +736,6 @@ static int rtc_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
     default:
       {
-        ret = -ENOTTY;
 #ifdef CONFIG_RTC_IOCTL
         if (ops->ioctl)
           {

--- a/drivers/timers/rtc.c
+++ b/drivers/timers/rtc.c
@@ -396,7 +396,7 @@ static int rtc_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         if (ops->settime)
           {
             ret = ops->settime(upper->lower, rtctime);
-            if (ret >= 0)
+            if (ret == 0)
               {
                 /* If the RTC time was set successfully, then update the
                  * current system time to match.


### PR DESCRIPTION
## Summary

- drivers/rtc: Return -ENOTTY if lower half doesn't implement the corresponding callback
- drivers/rtc: Skip clock_synchronize if settime return positive value
- drivers/rtc/rpmsg: Move clock_synchronize rpmsg_rtc_server_settime 

## Impact

minor

## Testing

sim:rpsever and sim:rproxy