### PR TITLE
sched: delete check when pick nexttcb in readytorun list

### DIFF
--- a/sched/sched/sched_removereadytorun.c
+++ b/sched/sched/sched_removereadytorun.c
@@ -194,22 +194,15 @@ bool nxsched_remove_readytorun(FAR struct tcb_s *rtcb, bool merge)
        * next tcb in the assigned task list (nxttcb) or a TCB in the
        * g_readytorun list.  We can only select a task from that list if
        * the affinity mask includes the current CPU.
-       *
-       * If pre-emption is locked or another CPU is in a critical section,
-       * then use the 'nxttcb' which will probably be the IDLE thread.
-       * REVISIT: What if it is not the IDLE thread?
        */
 
-      if (!nxsched_islocked_global() && !irq_cpu_locked(me))
-        {
-          /* Search for the highest priority task that can run on this
-           * CPU.
-           */
+      /* Search for the highest priority task that can run on this
+       * CPU.
+       */
 
-          for (rtrtcb = (FAR struct tcb_s *)g_readytorun.head;
-               rtrtcb != NULL && !CPU_ISSET(cpu, &rtrtcb->affinity);
-               rtrtcb = rtrtcb->flink);
-        }
+      for (rtrtcb = (FAR struct tcb_s *)g_readytorun.head;
+           rtrtcb != NULL && !CPU_ISSET(cpu, &rtrtcb->affinity);
+           rtrtcb = rtrtcb->flink);
 
       /* Did we find a task in the g_readytorun list?  Which task should
        * we use?  We decide strictly by the priority of the two tasks:


### PR DESCRIPTION
## Summary

sched: delete check when pick nexttcb in readytorun list

```
    CPU0                     CPU1
1. feed0 thread             feed1 thread
   (prio 1 affinity)        (prio 1 affinity)
2. nsh_main
   sched_lock()
3. waitpid()                hello_main
4. ------                   hello exit()
5. ------                   exit()->exit_wakeup()->wakeup nsh ->
                            add_readytorun()->
                            nsh at schedlock state set g_cpu_schedlock
6. -----                    exit()->nxtask_exit()->remove_readytorun()
                            -> check g_cpu_schedlock -> pick idle1
7. waitpid() return         idle thread
8. sched_unlock             idle thread
```

The error is in step 6:
pick a idle thread to execute not feed1 thread.

resolve:
remove the schedlocked-check in remove_readytorun()

## Impact

SMP scheduler

## Testing

BES SMP board