### PR TITLE
Add support enconder to ESP32-2432S028

### DIFF
--- a/boards/xtensa/esp32/esp32-2432S028/src/esp32-2432S028.h
+++ b/boards/xtensa/esp32/esp32-2432S028/src/esp32-2432S028.h
@@ -37,6 +37,19 @@
 
 #define BUTTON_BOOT  0
 
+/* LED
+ *
+ * This is the external RGB LED.
+ */
+
+#define GPIO_LED_RED             17
+#define GPIO_LED_GREEN           4
+#define GPIO_LED_BLUE            16
+
+/* PCNT Quadrature Encoder IDs */
+
+#define PCNT_QE0_ID           0
+
 /* TIMERS */
 
 #define TIMER0 0

--- a/boards/xtensa/esp32/esp32-2432S028/src/esp32_bringup.c
+++ b/boards/xtensa/esp32/esp32-2432S028/src/esp32_bringup.c
@@ -64,6 +64,10 @@
 #  include "esp32_board_wlan.h"
 #endif
 
+#ifdef CONFIG_ESP32_PCNT_AS_QE
+#  include "board_qencoder.h"
+#endif
+
 #ifdef CONFIG_ESP32_RT_TIMER
 #  include "esp32_rt_timer.h"
 #endif
@@ -300,17 +304,6 @@ int esp32_bringup(void)
 
 #endif
 
-#ifdef CONFIG_SENSORS_BMP180
-  /* Try to register BMP180 device in I2C0 */
-
-  ret = board_bmp180_initialize(0, 0);
-
-  if (ret < 0)
-    {
-      syslog(LOG_ERR, "Failed to initialize BMP180 driver: %d\n", ret);
-    }
-#endif
-
 #ifdef CONFIG_INPUT_BUTTONS
   /* Register the BUTTON driver */
 
@@ -346,6 +339,19 @@ int esp32_bringup(void)
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: lcddev_register() failed: %d\n", ret);
+    }
+#endif
+
+#ifdef CONFIG_SENSORS_QENCODER
+  /* Initialize and register the qencoder driver */
+
+  ret = board_qencoder_initialize(0, PCNT_QE0_ID);
+  if (ret != OK)
+    {
+      syslog(LOG_ERR,
+             "ERROR: Failed to register the qencoder: %d\n",
+             ret);
+      return ret;
     }
 #endif
 


### PR DESCRIPTION
## Summary
Adding support to qenconder and defining GPIOs to external RGB LED.
## Impact
None 
## Testing
![image](https://github.com/apache/nuttx/assets/41307385/5540dc33-d342-4e06-ab54-316dc13160e5)


