### PR TITLE
risc-v/mpfs/opensbi: update opensbi to version 1.3.1

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_opensbi.c
+++ b/arch/risc-v/src/mpfs/mpfs_opensbi.c
@@ -84,6 +84,8 @@ typedef struct sbi_scratch_holder_s sbi_scratch_holder_t;
 
 extern const uint8_t __mpfs_nuttx_start[];
 extern const uint8_t __mpfs_nuttx_end[];
+extern const uint8_t _ssbi_ddr[];
+extern const uint8_t _esbi_ddr[];
 
 /****************************************************************************
  * Private Function Prototypes
@@ -96,8 +98,8 @@ static int  mpfs_irqchip_init(bool cold_boot);
 static int  mpfs_ipi_init(bool cold_boot);
 static int  mpfs_timer_init(bool cold_boot);
 #ifdef CONFIG_MPFS_IHC_SBI
-static int  mpfs_opensbi_vendor_ext_check(long extid);
-static int  mpfs_opensbi_ecall_handler(long extid, long funcid,
+static bool mpfs_opensbi_vendor_ext_check(void);
+static int  mpfs_opensbi_ecall_handler(long funcid,
                                        const struct sbi_trap_regs *regs,
                                        unsigned long *out_val,
                                        struct sbi_trap_info *out_trap);
@@ -148,7 +150,7 @@ static struct aclint_mtimer_data mpfs_mtimer =
   .mtimecmp_size  = ACLINT_DEFAULT_MTIMECMP_SIZE,
   .first_hartid   = 0,
   .hart_count     = MPFS_HART_COUNT,
-  .has_64bit_mmio = TRUE,
+  .has_64bit_mmio = true,
 };
 
 static const struct sbi_platform_operations platform_ops =
@@ -477,19 +479,45 @@ static void mpfs_opensbi_scratch_setup(uint32_t hartid)
    * them so that OpenSBI has no chance override then.
    */
 
-  g_scratches[hartid].scratch.fw_start = (unsigned long)__mpfs_nuttx_start;
-  g_scratches[hartid].scratch.fw_size  = (unsigned long)__mpfs_nuttx_end -
-                                         (unsigned long)__mpfs_nuttx_start;
+  g_scratches[hartid].scratch.fw_start = (unsigned long)_ssbi_ddr;
+  g_scratches[hartid].scratch.fw_size  = (unsigned long)_esbi_ddr -
+                                         (unsigned long)_ssbi_ddr;
+
+  g_scratches[hartid].scratch.fw_rw_offset =
+      (unsigned long)g_scratches[hartid].scratch.fw_size;
+
+  /* fw_rw_offset needs to be an aligned address */
+
+  g_scratches[hartid].scratch.fw_rw_offset += 1024 * 2;
+  g_scratches[hartid].scratch.fw_rw_offset &= 0xffffff800;
+  g_scratches[hartid].scratch.fw_size =
+      g_scratches[hartid].scratch.fw_rw_offset;
+
+  g_scratches[hartid].scratch.fw_heap_offset =
+      (unsigned long)g_scratches[hartid].scratch.fw_size;
+
+  /* Heap minimum is 16k.  Otherwise sbi_heap.c fails:
+   * hpctrl.hksize = hpctrl.size / HEAP_HOUSEKEEPING_FACTOR;
+   * hpctrl.hksize &= ~((unsigned long)HEAP_BASE_ALIGN - 1);
+   * eg. 8k:  (0x2000 / 16) & ~(1024 - 1) = 0      (Fail!)
+   *     16k: (0x4000 / 16) & ~(1024 - 1) = 0x400  (Ok)
+   * hpctrl.hksize gets to be zero making the OpenSBI crash.
+   */
+
+  g_scratches[hartid].scratch.fw_heap_size = 1024 * 16;
+  g_scratches[hartid].scratch.fw_size      =
+      g_scratches[hartid].scratch.fw_heap_offset +
+      g_scratches[hartid].scratch.fw_heap_size;
 }
 
 /****************************************************************************
  * Name: mpfs_opensbi_vendor_ext_check
  *
  * Description:
- *   Used by the OpenSBI in vendor probe to check the vendor ID.
+ *   Used by the OpenSBI to check if vendor extension is enabled.
  *
  * Input Parameters:
- *   extid       - Vendor ID to be checked
+ *   None
  *
  * Returned Value:
  *   1 on match, zero in case of no match
@@ -497,9 +525,9 @@ static void mpfs_opensbi_scratch_setup(uint32_t hartid)
  ****************************************************************************/
 
 #ifdef CONFIG_MPFS_IHC_SBI
-static int mpfs_opensbi_vendor_ext_check(long extid)
+static bool mpfs_opensbi_vendor_ext_check(void)
 {
-  return (SBI_EXT_MICROCHIP_TECHNOLOGY == extid);
+  return true;
 }
 
 /****************************************************************************
@@ -510,7 +538,6 @@ static int mpfs_opensbi_vendor_ext_check(long extid)
  *   related to Inter-Hart Communication (IHC).
  *
  * Input Parameters:
- *   extid          - Vendor ID
  *   funcid         - One of the valid functions
  *   sbi_trap_regs  - SBI trap registers
  *   out_val        - Error code location
@@ -521,7 +548,7 @@ static int mpfs_opensbi_vendor_ext_check(long extid)
  *
  ****************************************************************************/
 
-static int mpfs_opensbi_ecall_handler(long extid, long funcid,
+static int mpfs_opensbi_ecall_handler(long funcid,
                                       const struct sbi_trap_regs *regs,
                                       unsigned long *out_val,
                                       struct sbi_trap_info *out_trap)

--- a/arch/risc-v/src/opensbi/Make.defs
+++ b/arch/risc-v/src/opensbi/Make.defs
@@ -28,6 +28,12 @@ SBI_CSRCS += opensbi/opensbi-3rdparty/lib/utils/ipi/aclint_mswi.c
 SBI_CSRCS += opensbi/opensbi-3rdparty/lib/utils/irqchip/plic.c
 SBI_CSRCS += opensbi/opensbi-3rdparty/lib/utils/timer/aclint_mtimer.c
 
+EXCLUDED_FILES  = opensbi/opensbi-3rdparty/lib/sbi/sbi_pmu.c
+EXCLUDED_FILES += opensbi/opensbi-3rdparty/lib/sbi/sbi_ecall_dbcn.c
+
+TMPVAR := $(SBI_CSRCS)
+SBI_CSRCS = $(filter-out $(EXCLUDED_FILES), $(TMPVAR))
+
 SBI_ASRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_expected_trap.S
 SBI_ASRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_hfence.S
 SBI_ASRCS += opensbi/opensbi-3rdparty/lib/sbi/riscv_hardfp.S
@@ -37,10 +43,10 @@ INCLUDES  += ${INCDIR_PREFIX}$(ARCH_SRCDIR)$(DELIM)opensbi$(DELIM)opensbi-3rdpar
 SBI_DIR   := opensbi
 
 OPENSBI_UNPACK  = opensbi-3rdparty
-OPENSBI_COMMIT  = 4998a712b2ab504eff306110879ee05af6050177
+OPENSBI_COMMIT  = fbaaafe808f3da7745760d757c436ef1b293d3ed
 OPENSBI_URL     = https://github.com/riscv-software-src/opensbi/tarball
 OPENSBI_TARBALL = opensbi.tar.gz
-OPENSBI_DIR     = riscv-software-src-opensbi-4998a71
+OPENSBI_DIR     = riscv-software-src-opensbi-fbaaafe
 
 $(OPENSBI_TARBALL):
 	$(call DOWNLOAD,$(OPENSBI_URL),$(OPENSBI_COMMIT),opensbi/$(OPENSBI_TARBALL))
@@ -50,6 +56,7 @@ $(OPENSBI_TARBALL):
 	$(Q) tar xzf opensbi/$(OPENSBI_TARBALL) -C opensbi
 	$(Q) mv opensbi/$(OPENSBI_DIR) opensbi/$(OPENSBI_UNPACK)
 	$(Q) touch opensbi/.opensbi_unpack
+	$(Q) opensbi/$(OPENSBI_UNPACK)/scripts/carray.sh -i opensbi/$(OPENSBI_UNPACK)/lib/sbi/sbi_ecall_exts.carray -l "ecall_base ecall_hsm ecall_ipi ecall_rfence ecall_time ecall_vendor" > opensbi/$(OPENSBI_UNPACK)/lib/sbi/sbi_ecall_exts.c
 
 ifeq ($(wildcard opensbi/$(OPENSBI_UNPACK)/.git),)
 context:: .opensbi_unpack

--- a/boards/risc-v/mpfs/icicle/scripts/ld-envm-opensbi.script
+++ b/boards/risc-v/mpfs/icicle/scripts/ld-envm-opensbi.script
@@ -36,10 +36,14 @@ SECTIONS
     PROVIDE(__l2lim_end   = ORIGIN(l2lim) + LENGTH(l2lim));
 
     .text.sbi : {
+      _ssbi_ddr = ABSOLUTE(.);
       sbi*
       riscv_atomic*
       riscv_locks*
       riscv_asm*
+      _esbi_ddr = ABSOLUTE(.);
+      . = ALIGN(0x2000);
+      . += 16k; /* OpenSBI heap, aligned, at least 16k */
     } > ddr
 
     .l2_scratchpad : ALIGN(0x10)


### PR DESCRIPTION
Version 1.3.1 is the latest tagged version as of November the 21st, 2023.  This patch prepares the required changes to make v1.3.1 work.

## Summary

Update OpenSBI

## Impact

All OpenSBI related work

## Testing

Polarfire -based devices