### PR TITLE
simwifi: Connect the wifi whose ssid contains the special charaters.

### DIFF
--- a/arch/sim/src/sim/sim_wifidriver.c
+++ b/arch/sim/src/sim/sim_wifidriver.c
@@ -453,7 +453,12 @@ static int utf8_escape(char *outp, int out_size,
       switch (*inp)
         {
           case '\\':
-          case '\'':
+            if (*(inp + 1) == '\'')
+              {
+                inp++;
+                break;
+              }
+
           case '\"':
             if (res_size++ >= out_size)
               {


### PR DESCRIPTION
## Summary
When setting the ESSID that contains the special characters (\"'), we need to add an escape (\) for them.
## Impact
N/A
## Testing
If we want to connect the SSID that contains special characters, for example `#2@%"!'3` .
We should add an escape before the special characters. The command is as follows:
`wapi essid wlan0 #2@%\"!\'3`
Then the host wlan0 can connect the WiFi.
