### PR TITLE
arm64_vector: no need to save x0 to sp

### DIFF
--- a/arch/arm64/src/common/arm64_vectors.S
+++ b/arch/arm64/src/common/arm64_vectors.S
@@ -70,7 +70,6 @@
  ****************************************************************************/
 GTEXT(up_saveusercontext)
 SECTION_FUNC(text, up_saveusercontext)
-    str    x0, [sp, #-16]!
 
     stp    x0,  x1,  [x0, #8 * REG_X0]
     stp    x2,  x3,  [x0, #8 * REG_X2]
@@ -98,8 +97,6 @@ SECTION_FUNC(text, up_saveusercontext)
     stp    x4,  x5,  [x0, #8 * REG_ELR]
 
     arm64_exception_context_save x4 x5 x0
-
-    ldr    x0, [sp], #16
 
     ret
 


### PR DESCRIPTION
## Summary
It will cause an incorrect sp value saved in context when saving X0 to sp.
## Impact

## Testing

