### PR TITLE
fs/spiffs: correct mutex lock cycle of spiffs 

### DIFF
--- a/arch/arm/src/tiva/common/tiva_sock_can.c
+++ b/arch/arm/src/tiva/common/tiva_sock_can.c
@@ -1263,6 +1263,7 @@ static int tivacan_alloc_fifo(struct net_driver_s *dev, int depth)
   if (free_fifo_idx < 0)
     {
       canwarn("Max number of filters allocated.\n");
+      nxmutex_unlock(&canmod->fifo_lock);
       return -ENOMEM;
     }
 

--- a/fs/spiffs/src/spiffs_vfs.c
+++ b/fs/spiffs/src/spiffs_vfs.c
@@ -1123,7 +1123,6 @@ static int spiffs_dup(FAR const struct file *oldp, FAR struct file *newp)
   ret = spiffs_lock_volume(fs);
   if (ret >= 0)
     {
-      spiffs_lock_volume(fs);
       fobj->crefs++;
       spiffs_unlock_volume(fs);
 
@@ -1519,7 +1518,6 @@ static int spiffs_unbind(FAR void *handle, FAR struct inode **mtdinode,
 {
   FAR struct spiffs_s *fs = (FAR struct spiffs_s *)handle;
   FAR struct spiffs_file_s *fobj;
-  int ret;
 
   finfo("handle=%p mtdinode=%p flags=%02x\n",
         handle, mtdinode, flags);
@@ -1534,8 +1532,8 @@ static int spiffs_unbind(FAR void *handle, FAR struct inode **mtdinode,
   if (!dq_empty(&fs->objq) && (flags & MNT_FORCE) == 0)
     {
       fwarn("WARNING: Open files and umount not forced\n");
-      ret = -EBUSY;
-      goto errout_with_lock;
+      spiffs_unlock_volume(fs);
+      return spiffs_map_errno(-EBUSY);
     }
 
   /* Release all of the open file objects... Very scary stuff. */
@@ -1561,13 +1559,11 @@ static int spiffs_unbind(FAR void *handle, FAR struct inode **mtdinode,
 
   /* Free the volume memory (note that the mutex is now stale!) */
 
+  spiffs_unlock_volume(fs);
   nxrmutex_destroy(&fs->lock);
   kmm_free(fs);
-  ret = OK;
 
-errout_with_lock:
-  spiffs_unlock_volume(fs);
-  return spiffs_map_errno(ret);
+  return spiffs_map_errno(OK);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

fs/spiffs: correct mutex lock cycle of spiffs

This PR will fix the below issues:
1. double lock() on dup
2. use after free on unbind

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

ci-check