### PR TITLE
video.c: modify set_buf call seqence in start_capture function.

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_cisif.c
+++ b/arch/arm/src/cxd56xx/cxd56_cisif.c
@@ -223,6 +223,8 @@ static int cxd56_cisif_stop_capture(struct imgdata_s *data);
 static int cxd56_cisif_validate_buf(struct imgdata_s *data,
                                     uint8_t *addr, uint32_t size);
 static int cxd56_cisif_set_buf(struct imgdata_s *data,
+                               uint8_t nr_datafmt,
+                               imgdata_format_t *datafmt,
                                uint8_t *addr, uint32_t size);
 
 static const intc_func_table g_intcomp_func[] =
@@ -977,6 +979,8 @@ static int cxd56_cisif_validate_buf(struct imgdata_s *data,
 }
 
 static int cxd56_cisif_set_buf(struct imgdata_s *data,
+                               uint8_t nr_datafmts,
+                               FAR imgdata_format_t *datafmts,
                                uint8_t *addr, uint32_t size)
 {
   int      ret;

--- a/arch/sim/src/sim/sim_camera.c
+++ b/arch/sim/src/sim/sim_camera.c
@@ -91,6 +91,8 @@ static int sim_camera_data_start_capture(struct imgdata_s *data,
                                          void *arg);
 static int sim_camera_data_stop_capture(struct imgdata_s *data);
 static int sim_camera_data_set_buf(struct imgdata_s *data,
+                                   uint8_t nr_datafmts,
+                                   FAR imgdata_format_t *datafmts,
                                    uint8_t *addr, uint32_t size);
 
 /****************************************************************************
@@ -258,6 +260,8 @@ static int sim_camera_data_validate_buf(uint8_t *addr, uint32_t size)
 }
 
 static int sim_camera_data_set_buf(struct imgdata_s *data,
+                                   uint8_t nr_datafmts,
+                                   FAR imgdata_format_t *datafmts,
                                    uint8_t *addr, uint32_t size)
 {
   sim_camera_priv_t *priv = (sim_camera_priv_t *)data;

--- a/drivers/video/goldfish_camera.c
+++ b/drivers/video/goldfish_camera.c
@@ -119,6 +119,8 @@ goldfish_camera_data_start_capture(FAR struct imgdata_s *data,
                                    FAR void *arg);
 static int goldfish_camera_data_stop_capture(FAR struct imgdata_s *data);
 static int goldfish_camera_data_set_buf(FAR struct imgdata_s *data,
+                                        uint8_t nr_datafmts,
+                                        FAR imgdata_format_t *datafmts,
                                         FAR uint8_t *addr,
                                         uint32_t size);
 
@@ -653,6 +655,8 @@ static int goldfish_camera_data_validate_buf(FAR uint8_t *addr,
 }
 
 static int goldfish_camera_data_set_buf(FAR struct imgdata_s *data,
+                                        uint8_t nr_datafmts,
+                                        FAR imgdata_format_t *datafmts,
                                         FAR uint8_t *addr,
                                         uint32_t size)
 {

--- a/drivers/video/video.c
+++ b/drivers/video/video.c
@@ -631,13 +631,14 @@ static int start_capture(FAR video_mng_t *vmng,
   convert_to_imgsensorfmt(&fmt[VIDEO_FMT_SUB], &sf[IMGSENSOR_FMT_SUB]);
   convert_to_imgsensorinterval(interval, &si);
 
+  IMGDATA_SET_BUF(vmng->imgdata,
+     nr_fmt, df, (FAR uint8_t *)bufaddr, bufsize);
+  IMGDATA_START_CAPTURE(vmng->imgdata,
+     nr_fmt, df, &di, video_complete_capture, vmng);
   IMGSENSOR_START_CAPTURE(vmng->imgsensor,
      type == V4L2_BUF_TYPE_VIDEO_CAPTURE ?
      IMGSENSOR_STREAM_TYPE_VIDEO : IMGSENSOR_STREAM_TYPE_STILL,
      nr_fmt, sf, &si);
-  IMGDATA_START_CAPTURE(vmng->imgdata,
-     nr_fmt, df, &di, video_complete_capture, vmng);
-  IMGDATA_SET_BUF(vmng->imgdata, (FAR uint8_t *)bufaddr, bufsize);
   return OK;
 }
 
@@ -3311,6 +3312,8 @@ static int video_complete_capture(uint8_t err_code, uint32_t datasize,
   FAR vbuf_container_t *container = NULL;
   enum v4l2_buf_type buf_type;
   irqstate_t           flags;
+  imgdata_format_t df[MAX_VIDEO_FMT];
+  video_format_t c_fmt[MAX_VIDEO_FMT];
 
   flags = enter_critical_section();
 
@@ -3385,7 +3388,18 @@ static int video_complete_capture(uint8_t err_code, uint32_t datasize,
         }
       else
         {
+          get_clipped_format(type_inf->nr_fmt,
+                             type_inf->fmt,
+                             &type_inf->clip,
+                             c_fmt);
+
+          convert_to_imgdatafmt(&c_fmt[VIDEO_FMT_MAIN],
+                                &df[IMGDATA_FMT_MAIN]);
+          convert_to_imgdatafmt(&c_fmt[VIDEO_FMT_SUB], &df[IMGDATA_FMT_SUB]);
+
           IMGDATA_SET_BUF(vmng->imgdata,
+            type_inf->nr_fmt,
+            df,
             (FAR uint8_t *)container->buf.m.userptr,
             container->buf.length);
           container->buf.sequence = type_inf->seqnum++;

--- a/include/nuttx/video/imgdata.h
+++ b/include/nuttx/video/imgdata.h
@@ -53,8 +53,8 @@
   ((d)->ops->init ? (d)->ops->init(d) : -ENOTTY)
 #define IMGDATA_UNINIT(d) \
   ((d)->ops->uninit ? (d)->ops->uninit(d) : -ENOTTY)
-#define IMGDATA_SET_BUF(d, a, s) \
-  ((d)->ops->set_buf ? (d)->ops->set_buf(d, a, s) : NULL)
+#define IMGDATA_SET_BUF(d, n, f, a, s) \
+  ((d)->ops->set_buf ? (d)->ops->set_buf(d, n, f, a, s) : NULL)
 #define IMGDATA_VALIDATE_FRAME_SETTING(d, n, f, i) \
   ((d)->ops->validate_frame_setting ? \
    (d)->ops->validate_frame_setting(d, n, f, i) : -ENOTTY)
@@ -96,6 +96,8 @@ struct imgdata_ops_s
   CODE int (*uninit)(FAR struct imgdata_s *data);
 
   CODE int (*set_buf)(FAR struct imgdata_s *data,
+                      uint8_t nr_datafmts,
+                      FAR imgdata_format_t *datafmts,
                       uint8_t *addr, uint32_t size);
 
   CODE int (*validate_frame_setting)(FAR struct imgdata_s *data,


### PR DESCRIPTION
To avoid losing the first frame, the set_buf needs to excute first. At the same time, imgdata->start_capture should excuted before the imgsensor->start_capture.

## Summary

## Impact
Video capture.

## Testing
Testing in sim environment, camera  can run normally.
