### PR TITLE
sched/taskspawn: fix spawn fail if enable FDCHECK

### DIFF
--- a/fs/inode/fs_files.c
+++ b/fs/inode/fs_files.c
@@ -507,6 +507,9 @@ int files_duplist(FAR struct filelist *plist, FAR struct filelist *clist,
 
           if (actions != NULL)
             {
+#ifdef CONFIG_FDCHECK
+              fd = fdcheck_protect(fd);
+#endif
               if (!spawn_file_is_duplicateable(actions, fd, fcloexec))
                 {
                   continue;


### PR DESCRIPTION

## Summary

sched/taskspawn: fix spawn fail if enable FDCHECK

restore file descriptor before compare


## Impact

N/A

## Testing

ci-check