### PR TITLE
sigaction: Expand si_user for non-kernel signals

### DIFF
--- a/include/signal.h
+++ b/include/signal.h
@@ -390,7 +390,7 @@ struct sigaction
   } sa_u;
   sigset_t          sa_mask;
   int               sa_flags;
-  FAR void         *sa_user;
+  FAR void         *sa_user; /* Passed to siginfo.si_user (non-standard) */
 };
 
 /* Definitions that adjust the non-standard naming */

--- a/sched/signal/sig_dispatch.c
+++ b/sched/signal/sig_dispatch.c
@@ -101,6 +101,7 @@ static int nxsig_queue_action(FAR struct tcb_s *stcb, siginfo_t *info)
             }
 
           memcpy(&sigq->info, info, sizeof(siginfo_t));
+          sigq->info.si_user = sigact->act.sa_user;
 
           /* Put it at the end of the pending signals list */
 

--- a/sched/signal/sig_queue.c
+++ b/sched/signal/sig_queue.c
@@ -101,6 +101,7 @@ int nxsig_queue(int pid, int signo, union sigval value)
   info.si_pid             = rtcb->pid;
   info.si_status          = OK;
 #endif
+  info.si_user            = NULL; /* Will be set in sig_dispatch.c */
 
   /* Send the signal */
 


### PR DESCRIPTION
## Summary

Commit 9244b5a737c9222aa3df3eac167f76ce7e7e50b8 added support for non-standard field `si_user` that is useful for passing context pointers to signal handlers.

This commits makes it work for all signals, not just `SA_KERNELHAND`.
Previously `si_user` for normal signals was uninitialized garbage.

## Impact

Does not affect existing working code. Makes it possible to use `si_user` for any signal (with the caveat that it is NuttX-specific).

## Testing

Tested on custom STM32F4 board with simple code sending signal between two tasks.