### PR TITLE
stm32f401rc-rs485: Fix f401rc flash size

### DIFF
--- a/Documentation/platforms/arm/stm32f4/boards/stm32f401rc-rs485/index.rst
+++ b/Documentation/platforms/arm/stm32f4/boards/stm32f401rc-rs485/index.rst
@@ -16,7 +16,7 @@ STM32F401RCT6 microcontroller.
 
 STM32F401RCT6 microcontroller features:
  - Arm 32-bit Cortex®-M4 CPU with FPU
- - 128 Kbytes of Flash memory
+ - 256 Kbytes of Flash memory
  - 64 Kbytes of SRAM
  - Serial wire debug (SWD) & JTAG interfaces
  - Up to 81 I/O ports with interrupt capability

--- a/boards/arm/stm32/stm32f401rc-rs485/scripts/ld.script
+++ b/boards/arm/stm32/stm32f401rc-rs485/scripts/ld.script
@@ -18,7 +18,7 @@
  *
  ****************************************************************************/
 
-/* The STM32F401RC has 128Kb of FLASH beginning at address 0x0800:0000 and
+/* The STM32F401RC has 256Kb of FLASH beginning at address 0x0800:0000 and
  * 64Kb of SRAM beginning at address 0x2000:0000.  When booting from FLASH,
  * FLASH memory is aliased to address 0x0000:0000 where the code expects to
  * begin execution by jumping to the entry point in the 0x0800:0000 address
@@ -27,7 +27,7 @@
 
 MEMORY
 {
-  flash (rx) : ORIGIN = 0x08000000, LENGTH = 128K
+  flash (rx) : ORIGIN = 0x08000000, LENGTH = 256K
   sram (rwx) : ORIGIN = 0x20000000, LENGTH = 64K
 }
 


### PR DESCRIPTION
## Summary
Fix flash size for stm32f401rc.
## Impact
Use the correct flash size.
## Testing
<img width="811" alt="image" src="https://github.com/apache/nuttx/assets/34151213/bcab8f2f-3d7e-43d4-bef6-5aeac023fc6a">

