### PR TITLE
libm: Fix an issue that public header files are not exported

### DIFF
--- a/libs/libm/libmcs/Make.defs
+++ b/libs/libm/libmcs/Make.defs
@@ -20,6 +20,7 @@
 
 LIBMCS_VERSION=1.2.0
 
+ifeq ($(wildcard libmcs/libmcs/.git),)
 libmcs-$(LIBMCS_VERSION).zip:
 	$(call DOWNLOAD,https://gitlab.com/gtd-gmbh/libmcs/-/archive/$(LIBMCS_VERSION),libmcs-$(LIBMCS_VERSION).zip,libmcs.zip)
 
@@ -32,17 +33,19 @@ libmcs/libmcs: libmcs-$(LIBMCS_VERSION).zip
 	$(Q) patch -p1 < libmcs/0004-Fix-warning-function-declaration-isn-t-a-prototype-W.patch
 	$(Q) patch -p1 < libmcs/0005-libm-libmcs-Fix-clang-build-libmcs-warning.patch
 	$(Q) touch $@
+endif
 
-ifeq ($(wildcard libmcs/libmcs/.git),)
 distclean::
+	$(Q) $(DIRUNLINK) $(TOPDIR)/include/libmcs
+ifeq ($(wildcard libmcs/libmcs/.git),)
 	$(call DELFILE, libmcs.zip)
 	$(call DELDIR, libmcs/libmcs)
-
-context:: libmcs/libmcs
-else
-distclean::
-context::
 endif
+
+$(TOPDIR)/include/libmcs: libmcs/libmcs
+	$(Q) $(DIRLINK) $(CURDIR)/libmcs/libmcs/libm/include $@
+
+context:: $(TOPDIR)/include/libmcs
 
 VPATH += :libmcs/libmcs/libm/common
 VPATH += :libmcs/libmcs/libm/complexd

--- a/libs/libm/newlib/Make.defs
+++ b/libs/libm/newlib/Make.defs
@@ -30,6 +30,7 @@ else
   NEWLIB_TARBALL=$(NEWLIB_BASENAME)-$(NEWLIB_VERSION).tar.gz
 endif
 
+ifeq ($(wildcard newlib/newlib/.git),)
 $(NEWLIB_BASENAME)-$(NEWLIB_VERSION).tar.gz:
 	$(call DOWNLOAD,$(NEWLIB_URL_BASE),$(NEWLIB_TARBALL),$(NEWLIB_BASENAME)-$(NEWLIB_VERSION).tar.gz)
 
@@ -39,17 +40,19 @@ newlib/newlib: $(NEWLIB_BASENAME)-$(NEWLIB_VERSION).tar.gz
 	$(Q) patch -p0 < newlib/0001-newlib-libm-fix-__RCSID-build-error.patch
 	$(Q) patch -p0 < newlib/0002-newlib-libm-remove-include-reent.h.patch
 	$(Q) touch $@
+endif
 
-ifeq ($(wildcard newlib/newlib/.git),)
 distclean::
+	$(Q) $(DIRUNLINK) $(TOPDIR)/include/newlib
+ifeq ($(wildcard newlib/newlib/.git),)
 	$(call DELFILE, $(NEWLIB_BASENAME)-$(NEWLIB_VERSION).tar.gz)
 	$(call DELDIR, newlib/newlib)
-
-context:: newlib/newlib
-else
-distclean::
-context::
 endif
+
+$(TOPDIR)/include/newlib: newlib/newlib
+	$(Q) $(DIRLINK) $(CURDIR)/newlib/include $@
+
+context:: $(TOPDIR)/include/newlib
 
 CSRCS += $(wildcard newlib/newlib/newlib/libm/common/*.c)
 CSRCS += $(wildcard newlib/newlib/newlib/libm/complex/*.c)

--- a/libs/libm/openlibm/Make.defs
+++ b/libs/libm/openlibm/Make.defs
@@ -21,6 +21,7 @@
 
 OPENLIBM_VERSION=0.8.1
 
+ifeq ($(wildcard openlibm/openlibm/.git),)
 openlibm-$(OPENLIBM_VERSION).zip:
 	$(call DOWNLOAD,https://github.com/JuliaMath/openlibm/archive/refs/tags,v$(OPENLIBM_VERSION).zip,openlibm.zip)
 
@@ -29,16 +30,19 @@ openlibm/openlibm: openlibm-$(OPENLIBM_VERSION).zip
 	$(Q) mv openlibm-$(OPENLIBM_VERSION) openlibm/openlibm
 	$(Q) patch -p0 < openlibm/0001-fix-build-float_t-error-float_t-has-not-been-declare.patch
 	$(Q) patch -p0 < openlibm/0002-add-math.h-and-complex.h-to-openlibm.patch
+endif
 
-ifeq ($(wildcard openlibm/openlibm/.git),)
 distclean::
+	$(Q) $(DIRUNLINK) $(TOPDIR)/include/openlibm
+ifeq ($(wildcard openlibm/openlibm/.git),)
 	$(call DELFILE, openlibm.zip)
 	$(call DELDIR, openlibm/openlibm)
-context:: openlibm/openlibm
-else
-distclean::
-context::
 endif
+
+$(TOPDIR)/include/openlibm: openlibm/openlibm
+	$(Q) $(DIRLINK) $(CURDIR)/openlibm/openlibm/include $@
+
+context:: $(TOPDIR)/include/openlibm
 
 # OS-specific stuff
 # Get ARCH, it is used to read source code file list form $(ARCH)/Make.files

--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -658,20 +658,20 @@ else
 endif
 
 ifeq ($(CONFIG_LIBM_NEWLIB),y)
-  ARCHINCLUDES += ${INCSYSDIR_PREFIX}$(TOPDIR)$(DELIM)libs$(DELIM)libm$(DELIM)newlib$(DELIM)include
-  ARCHXXINCLUDES += ${INCSYSDIR_PREFIX}$(TOPDIR)$(DELIM)libs$(DELIM)libm$(DELIM)newlib$(DELIM)include
+  ARCHINCLUDES += ${INCSYSDIR_PREFIX}$(TOPDIR)$(DELIM)include$(DELIM)newlib
+  ARCHXXINCLUDES += ${INCSYSDIR_PREFIX}$(TOPDIR)$(DELIM)include$(DELIM)newlib
 endif
 
 #libmcs`s math.h should include after libcxx, or it will override libcxx/include/math.h and build error
 ifeq ($(CONFIG_LIBM_LIBMCS),y)
   ARCHDEFINES += ${DEFINE_PREFIX}LIBMCS_LONG_DOUBLE_IS_64BITS
-  ARCHXXINCLUDES += ${INCSYSDIR_PREFIX}$(TOPDIR)$(DELIM)libs$(DELIM)libm$(DELIM)libmcs$(DELIM)libmcs$(DELIM)libm$(DELIM)include
-  ARCHINCLUDES += ${INCSYSDIR_PREFIX}$(TOPDIR)$(DELIM)libs$(DELIM)libm$(DELIM)libmcs$(DELIM)libmcs$(DELIM)libm$(DELIM)include
+  ARCHINCLUDES += ${INCSYSDIR_PREFIX}$(TOPDIR)$(DELIM)include$(DELIM)libmcs
+  ARCHXXINCLUDES += ${INCSYSDIR_PREFIX}$(TOPDIR)$(DELIM)include$(DELIM)libmcs
 endif
 
 ifeq ($(CONFIG_LIBM_OPENLIBM),y)
-  ARCHINCLUDES += ${INCSYSDIR_PREFIX}$(TOPDIR)$(DELIM)libs$(DELIM)libm$(DELIM)openlibm$(DELIM)openlibm$(DELIM)include
-  ARCHXXINCLUDES += ${INCSYSDIR_PREFIX}$(TOPDIR)$(DELIM)libs$(DELIM)libm$(DELIM)openlibm$(DELIM)openlibm$(DELIM)include
+  ARCHINCLUDES += ${INCSYSDIR_PREFIX}$(TOPDIR)$(DELIM)include$(DELIM)openlibm
+  ARCHXXINCLUDES += ${INCSYSDIR_PREFIX}$(TOPDIR)$(DELIM)include$(DELIM)openlibm
 endif
 
 ARCHXXINCLUDES += ${INCSYSDIR_PREFIX}$(TOPDIR)$(DELIM)include


### PR DESCRIPTION
## Summary
Fix an issue https://github.com/apache/nuttx/issues/11239
that math library header files are not exported by `make export`.
Create symbolic links of libmcs, newlib and openlibm header to nuttx/include.

## Impact

## Testing
Build check: pass
