### PR TITLE
Documentation: Fix errors on linum-stm32h753bi

### DIFF
--- a/Documentation/platforms/arm/stm32h7/boards/linum-stm32h753bi/index.rst
+++ b/Documentation/platforms/arm/stm32h7/boards/linum-stm32h753bi/index.rst
@@ -103,7 +103,7 @@ The LINUM-STM32H753BI board has two on-board RS-232 transceiver connected to USA
 The LINUM-STM32H753BI board has two on-board RS-485 transceiver connected to USART4 and USART6.
 
   ====== =====
-  UART4 PINS
+  UART4  PINS
   ====== =====
   TXD    PB9
   RXD    PB8
@@ -238,7 +238,7 @@ The touchscreen sensor used is the GT928.
   ======== =====
   TS_RESET PI7
   TS_ISR   PH9
-  ========  =====
+  ======== =====
 
 I2C4
 =======
@@ -339,6 +339,7 @@ The LINUM-STM32H753BI use the LTDC to support one LCD with RGB connection.
   PWM           PINS
   ============= =====
   PWM_BACKLIGHT PH6
+  ============= =====
 
 I2S
 =======


### PR DESCRIPTION
## Summary
Fix errors on linum-stm32h753bi

>  /home/rcsim/Workspace/learning/nuttx/nuttxspace/nuttx/Documentation/platforms/arm/stm32h7/boards/linum-stm32h753bi/index.rst:106: ERROR: Malformed table.
> Text in column margin in table line 2.
> 
> ====== =====
> UART4 PINS
> ====== =====
> TXD    PB9
> RXD    PB8
> DE     PA15
> ====== =====
> /home/rcsim/Workspace/learning/nuttx/nuttxspace/nuttx/Documentation/platforms/arm/stm32h7/boards/linum-stm32h753bi/index.rst:236: ERROR: Malformed table.
> Bottom/header table border does not match top border.
> 
> ======== =====
> GPIO     PINS
> ======== =====
> TS_RESET PI7
> TS_ISR   PH9
> ========  =====
> /home/rcsim/Workspace/learning/nuttx/nuttxspace/nuttx/Documentation/platforms/arm/stm32h7/boards/linum-stm32h753bi/index.rst:338: ERROR: Malformed table.
> No bottom table border found or no blank line after table bottom.
> 
> ============= =====
> PWM           PINS
> ============= =====
> /home/rcsim/Workspace/learning/nuttx/nuttxspace/nuttx/Documentation/platforms/arm/stm32h7/boards/linum-stm32h753bi/index.rst:341: WARNING: Blank line required after table.

## Impact
 No errors related to linum board during Documentation build

## Testing
![image](https://github.com/apache/nuttx/assets/30301531/bdfde0c6-d74e-43e4-b3f3-a583e6fc6164)

