### PR TITLE
tools/ci: Upgrade riscv toolchain to v13.2.0

### DIFF
--- a/tools/ci/cibuild.sh
+++ b/tools/ci/cibuild.sh
@@ -337,10 +337,10 @@ function riscv-gcc-toolchain {
         ;;
     esac
     cd "${tools}"
-    wget --quiet https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-2/xpack-riscv-none-elf-gcc-12.3.0-2-${flavor}.tar.gz
-    tar zxf xpack-riscv-none-elf-gcc-12.3.0-2-${flavor}.tar.gz
-    mv xpack-riscv-none-elf-gcc-12.3.0-2 riscv-none-elf-gcc
-    rm xpack-riscv-none-elf-gcc-12.3.0-2-${flavor}.tar.gz
+    wget --quiet https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/xpack-riscv-none-elf-gcc-13.2.0-2-${flavor}.tar.gz
+    tar zxf xpack-riscv-none-elf-gcc-13.2.0-2-${flavor}.tar.gz
+    mv xpack-riscv-none-elf-gcc-13.2.0-2 riscv-none-elf-gcc
+    rm xpack-riscv-none-elf-gcc-13.2.0-2-${flavor}.tar.gz
   fi
 
   command riscv-none-elf-gcc --version

--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -192,7 +192,7 @@ RUN cd /tools/renesas-tools/build/gcc && \
 FROM nuttx-toolchain-base AS nuttx-toolchain-riscv
 # Download the latest RISCV GCC toolchain prebuilt by xPack
 RUN mkdir riscv-none-elf-gcc && \
-  curl -s -L "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-2/xpack-riscv-none-elf-gcc-12.3.0-2-linux-x64.tar.gz" \
+  curl -s -L "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/xpack-riscv-none-elf-gcc-13.2.0-2-linux-x64.tar.gz" \
   | tar -C riscv-none-elf-gcc --strip-components 1 -xz
 
 ###############################################################################

--- a/tools/ci/testlist/macos.dat
+++ b/tools/ci/testlist/macos.dat
@@ -26,7 +26,7 @@
 # RISC-V
 
 /risc-v/bl602/bl602evb/configs/wifi
-
+/risc-v/esp32c3/esp32c3-devkit/configs/cxx
 /risc-v/esp32c3/esp32c3-devkit/configs/wifi
 
 # x86_64-elf-gcc from homebrew doesn't seem to


### PR DESCRIPTION
## Summary

and add esp32c3-devkit:cxx to macOS ci
## Impact

ci

## Testing

ci