### PR TITLE
tools/ci: Upgrade clang arm toolchain to 17.0.1

### DIFF
--- a/tools/ci/cibuild.sh
+++ b/tools/ci/cibuild.sh
@@ -46,15 +46,15 @@ function arm-clang-toolchain {
     local flavor
     case ${os} in
       Linux)
-        flavor=linux
+        flavor=Linux
         ;;
     esac
     cd "${tools}"
-    curl -O -L -s https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/releases/download/release-14.0.0/LLVMEmbeddedToolchainForArm-14.0.0-${flavor}.tar.gz
-    tar zxf LLVMEmbeddedToolchainForArm-14.0.0-${flavor}.tar.gz
-    mv LLVMEmbeddedToolchainForArm-14.0.0 clang-arm-none-eabi
+    curl -O -L -s https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/releases/download/release-17.0.1/LLVMEmbeddedToolchainForArm-17.0.1-${flavor}-x86_64.tar.xz
+    xz -d LLVMEmbeddedToolchainForArm-17.0.1-${flavor}.tar.xz
+    mv LLVMEmbeddedToolchainForArm-17.0.1 clang-arm-none-eabi
     cp /usr/bin/clang-extdef-mapping-10 clang-arm-none-eabi/bin/clang-extdef-mapping
-    rm LLVMEmbeddedToolchainForArm-14.0.0-${flavor}.tar.gz
+    rm LLVMEmbeddedToolchainForArm-17.0.1-${flavor}.tar.xz
   fi
 
   command clang --version

--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -79,8 +79,8 @@ WORKDIR /tools
 FROM nuttx-toolchain-base AS nuttx-toolchain-arm
 # Download the latest ARM clang toolchain prebuilt by ARM
 RUN mkdir clang-arm-none-eabi && \
-  curl -s -L  "https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/releases/download/release-14.0.0/LLVMEmbeddedToolchainForArm-14.0.0-linux.tar.gz" \
-  | tar -C clang-arm-none-eabi --strip-components 1 -xz
+  curl -s -L  "https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/releases/download/release-17.0.1/LLVMEmbeddedToolchainForArm-17.0.1-Linux-x86_64.tar.xz" \
+  | tar -C clang-arm-none-eabi --strip-components 1 -xJ
 
 # Download the latest ARM GCC toolchain prebuilt by ARM
 RUN mkdir gcc-arm-none-eabi && \


### PR DESCRIPTION
## Summary

from https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/releases/tag/release-17.0.1

## Impact

ci

## Testing

ci