### PR TITLE
tools/ci: Upgrade macOS arm64 toolchain to 12.3.rel1

### DIFF
--- a/tools/ci/cibuild.sh
+++ b/tools/ci/cibuild.sh
@@ -91,18 +91,18 @@ function arm64-gcc-toolchain {
     local flavor
     case ${os} in
       Darwin)
-        flavor=darwin-x86_64
+        flavor=-darwin
         ;;
       Linux)
-        flavor=x86_64
+        flavor=
         ;;
     esac
     cd "${tools}"
-    wget --quiet https://developer.arm.com/-/media/Files/downloads/gnu/11.2-2022.02/binrel/gcc-arm-11.2-2022.02-${flavor}-aarch64-none-elf.tar.xz
-    xz -d gcc-arm-11.2-2022.02-${flavor}-aarch64-none-elf.tar.xz
-    tar xf gcc-arm-11.2-2022.02-${flavor}-aarch64-none-elf.tar
-    mv gcc-arm-11.2-2022.02-${flavor}-aarch64-none-elf gcc-aarch64-none-elf
-    rm gcc-arm-11.2-2022.02-${flavor}-aarch64-none-elf.tar
+    wget --quiet https://developer.arm.com/-/media/Files/downloads/gnu/12.3.rel1/binrel/arm-gnu-toolchain-12.3.rel1${flavor}-x86_64-aarch64-none-elf.tar.xz
+    xz -d arm-gnu-toolchain-12.3.rel1${flavor}-x86_64-aarch64-none-elf.tar.xz
+    tar xf arm-gnu-toolchain-12.3.rel1${flavor}-x86_64-aarch64-none-elf.tar
+    mv arm-gnu-toolchain-12.3.rel1${flavor}-x86_64-aarch64-none-elf gcc-aarch64-none-elf
+    rm arm-gnu-toolchain-12.3.rel1${flavor}-x86_64-aarch64-none-elf.tar
   fi
 
   command aarch64-none-elf-gcc --version

--- a/tools/ci/testlist/macos.dat
+++ b/tools/ci/testlist/macos.dat
@@ -1,6 +1,14 @@
 # Chose a minimalistic subset of board/configs due to macOS builds
 # being extremely slow on GitHub
 
+# ARM
+
+/arm/stm32/stm32f4discovery/configs/nsh,CONFIG_ARM_TOOLCHAIN_GNU_EABI
+
+# ARM64
+
+/arm64/qemu/qemu-armv8a/configs/nsh_smp
+
 # AVR
 #
 # We do not have a toolchain for avr32 outside of Microchip login wall.
@@ -21,14 +29,6 @@
 
 /risc-v/esp32c3/esp32c3-devkit/configs/wifi
 
-# ARM
-
-/arm/stm32/stm32f4discovery/configs/nsh,CONFIG_ARM_TOOLCHAIN_GNU_EABI
-
-# XTENSA
-
-/xtensa/esp32/esp32-devkitc/configs/wifi
-
 # x86_64-elf-gcc from homebrew doesn't seem to
 # provide __udivdi3 etc for -m32, so we do not build
 # x86
@@ -37,8 +37,6 @@
 
 /x86_64/intel64/qemu-intel64/configs/nsh
 
-# The gcc 11.2 toolcain for MACOS maybe fail when compile
-# with float, disable the cibuild check for MACOS
-# it will be enbaled while new toolchain release
+# XTENSA
 
-# /arm64/qemu/qemu-armv8a/configs/nsh_smp
+/xtensa/esp32/esp32-devkitc/configs/wifi


### PR DESCRIPTION
## Summary

and enable arm64 ci build on macOS

## Impact

arm64 ci

## Testing

ci