### PR TITLE
mpfs/mpfs_corespi.c: Round up divider to prevent overlock of SPI

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_corespi.c
+++ b/arch/risc-v/src/mpfs/mpfs_corespi.c
@@ -543,9 +543,9 @@ static uint32_t mpfs_spi_setfrequency(struct spi_dev_s *dev,
 
   priv->frequency = frequency;
 
-  /* Formula is SPICLK = PCLK/(2*(CFG_CLK + 1)) */
+  /* Formula is SPICLK = PCLK/(2*(CFG_CLK + 1)) (result is rounded up) */
 
-  divider = ((MPFS_FPGA_PERIPHERAL_CLK / frequency) >> 1) - 1;
+  divider = (MPFS_FPGA_PERIPHERAL_CLK / frequency) >> 1;
   priv->actual = MPFS_FPGA_PERIPHERAL_CLK / ((divider + 1) << 1);
 
   DEBUGASSERT(divider < 256u);


### PR DESCRIPTION
## Summary
The divider should be rounded to the next full integer to ensure that the resulting SPI frequency is <= target frequency, i.e. the SPI is not overclocked.
## Impact
Fix bug in mpfs corespi driver
## Testing
MPFS with SPI sensors
