### PR TITLE
xtensa/esp32s3: Fix some ESP32S3 module reboot and QVL issues

### DIFF
--- a/arch/xtensa/src/esp32s3/Kconfig
+++ b/arch/xtensa/src/esp32s3/Kconfig
@@ -861,6 +861,14 @@ config ESP32S3_SPIRAM_SPEED
 	default 80 if ESP32S3_SPIRAM_SPEED_80M
 	default 40 if ESP32S3_SPIRAM_SPEED_40M
 
+config ESP32S3_SPIRAM_ECC_ENABLE
+	bool "Enable SPI RAM ECC"
+	default n
+	depends on ESP32S3_SPIRAM_MODE_OCT
+	---help---
+		Enable MSPI Error-Correcting Code function when accessing SPIRAM.
+		If enabled, 1/16 of the SPI RAM total size will be reserved for error-correcting code.
+
 config ESP32S3_SPIRAM_BOOT_INIT
 	bool "Initialize SPI RAM during startup"
 	depends on ESP32S3_SPIRAM

--- a/arch/xtensa/src/esp32s3/esp32s3_spi_timing.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_spi_timing.c
@@ -171,7 +171,7 @@
 #define MSPI_TIMING_FLASH_DTR_MODE           CONFIG_ESP32S3_FLASH_SAMPLE_MODE_DTR
 #define MSPI_TIMING_FLASH_STR_MODE           CONFIG_ESP32S3_FLASH_SAMPLE_MODE_STR
 
-#define MSPI_TIMING_TEST_DATA_LEN            64
+#define MSPI_TIMING_TEST_DATA_LEN            1024
 #define MSPI_TIMING_PSRAM_TEST_DATA_ADDR     0
 #define MSPI_TIMING_FLASH_TEST_DATA_ADDR     0
 
@@ -1356,7 +1356,7 @@ static void do_tuning(const uint8_t *reference_data,
  *
  ****************************************************************************/
 
-void esp32s3_spi_timing_set_pin_drive_strength(void)
+void IRAM_ATTR esp32s3_spi_timing_set_pin_drive_strength(void)
 {
   const uint32_t regs[] =
     {

--- a/arch/xtensa/src/esp32s3/esp32s3_spiram.h
+++ b/arch/xtensa/src/esp32s3/esp32s3_spiram.h
@@ -76,7 +76,7 @@ int esp_spiram_add_to_heapalloc(void);
  * @brief Get the available physical size of the attached SPI RAM chip
  *
  * @note If ECC is enabled, the available physical size would be smaller
- * than the physical size. See `CONFIG_SPIRAM_ECC_ENABLE`
+ * than the physical size. See `CONFIG_ESP32S3_SPIRAM_ECC_ENABLE`
  *
  * @return Size in bytes, or 0 if no external RAM chip support compiled in.
  */


### PR DESCRIPTION
## Summary

- Increase the data length in timing tuning.
- Add MSPI Error-Correcting Code function when accessing SPIRAM.
- Add delay before timing tuning.

## Impact

## Testing

