### PR TITLE
net/loopback: Fix flags of lo device

### DIFF
--- a/drivers/net/loopback.c
+++ b/drivers/net/loopback.c
@@ -357,7 +357,7 @@ int localhost_initialize(void)
 
   /* Put the network in the UP state */
 
-  priv->lo_dev.d_flags = IFF_UP;
+  IFF_SET_UP(priv->lo_dev.d_flags);
   return lo_ifup(&priv->lo_dev);
 }
 


### PR DESCRIPTION
## Summary
`netdev_register` will set `IFF_LOOPBACK` in `d_flags`, we should not just change it into `IFF_UP` only.

## Impact
`d_flags` of `lo` device

## Testing
Manually
