### PR TITLE
Fix -nan issue with f32

### DIFF
--- a/libs/libc/stdio/lib_libvsprintf.c
+++ b/libs/libc/stdio/lib_libvsprintf.c
@@ -616,7 +616,7 @@ flt_oper:
           exp = _dtoa.exp;
 
           sign = 0;
-          if ((_dtoa.flags & DTOA_MINUS) && !(_dtoa.flags & DTOA_NAN))
+          if (_dtoa.flags & DTOA_MINUS)
             {
               sign = '-';
             }


### PR DESCRIPTION
## Summary
Fix printf issue that -nan cannot be parsed correctly
## Impact
Update libc with lib_libvsnprintf.c file
## Testing
4290772992UL(-nan)
