### PR TITLE
xtensa/esp32s3: Fix esp32s3 mcuboot ota crash

### DIFF
--- a/boards/xtensa/esp32s3/common/scripts/mcuboot_sections.ld
+++ b/boards/xtensa/esp32s3/common/scripts/mcuboot_sections.ld
@@ -71,6 +71,13 @@ SECTIONS
 
     *(.rodata)
     *(.rodata.*)
+#ifdef CONFIG_ESP32S3_WIRELESS
+    *(.rodata_wlog_verbose.*)
+    *(.rodata_wlog_debug.*)
+    *(.rodata_wlog_info.*)
+    *(.rodata_wlog_warning.*)
+    *(.rodata_wlog_error.*)
+#endif
     *(.irom1.text) /* catch stray ICACHE_RODATA_ATTR */
     *(.gnu.linkonce.r.*)
     *(.rodata1)
@@ -168,6 +175,74 @@ SECTIONS
     *(.iram1 .iram1.*)
     esp32s3_start.*(.literal .text .literal.* .text.*)
 
+    *libarch.a:esp32s3_cpuindex.*(.literal .text .literal.* .text.*)
+    *libarch.a:esp32s3_irq.*(.literal .text .literal.* .text.*)
+    *libarch.a:esp32s3_user.*(.literal .text .literal.* .text.*)
+    *libarch.a:esp32s3_spiflash.*(.literal .text .literal.* .text.*)
+    *libarch.a:xtensa_assert.*(.literal .text .literal.* .text.*)
+    *libarch.a:xtensa_cpuint.*(.literal .text .literal.* .text.*)
+    *libarch.a:xtensa_cpupause.*(.literal .text .literal.* .text.*)
+    *libarch.a:xtensa_irqdispatch.*(.literal .text .literal.* .text.*)
+    *libarch.a:xtensa_modifyreg32.*(.literal .text .literal.* .text.*)
+    *libarch.a:xtensa_testset.*(.literal .text .literal.* .text.*)
+
+#ifdef CONFIG_ESP32S3_BLE
+    *libc.a:sq_remlast.*(.literal .text .literal.* .text.*)
+#endif
+
+    *libdrivers.a:syslog_flush.*(.literal .text .literal.* .text.*)
+
+    *libsched.a:assert.*(.literal .text .literal.* .text.*)
+    *libsched.a:irq_csection.*(.literal .text .literal.* .text.*)
+    *libsched.a:irq_dispatch.*(.literal .text .literal.* .text.*)
+    *libsched.a:irq_spinlock.*(.literal .text .literal.* .text.*)
+    *libsched.a:sched_note.*(.literal .text .literal.* .text.*)
+    *libsched.a:sched_suspendscheduler.*(.literal .text .literal.* .text.*)
+    *libsched.a:sched_thistask.*(.literal .text .literal.* .text.*)
+    *libsched.a:spinlock.*(.literal .text .literal.* .text.*)
+
+#ifdef CONFIG_ESP32S3_SPEED_UP_ISR
+    *libarch.a:xtensa_switchcontext.*(.literal.up_switch_context .text.up_switch_context)
+
+    *libarch.a:esp32s3_timerisr.*(.literal.systimer_isr .text.systimer_isr)
+    *libarch.a:esp32s3_idle.*(.literal.up_idle .text.up_idle)
+    *libarch.a:esp32s3_dma.*(.literal.esp32s3_dma_load .text.esp32s3_dma_load \
+                             .literal.esp32s3_dma_enable .text.esp32s3_dma_enable)
+
+    *libsched.a:sched_processtimer.*(.literal.nxsched_process_timer .text.nxsched_process_timer)
+    *libsched.a:clock_initialize.*(.literal.clock_timer .text.clock_timer)
+    *libsched.a:wd_start.*(.literal.wd_timer .text.wd_timer)
+    *libsched.a:sched_roundrobin.*(.literal.nxsched_process_roundrobin .text.nxsched_process_roundrobin)
+    *libsched.a:sched_reprioritizertr.*(.literal.nxsched_reprioritize_rtr .text.nxsched_reprioritize_rtr)
+    *libsched.a:sched_removereadytorun.*(.literal.nxsched_remove_readytorun .text.nxsched_remove_readytorun)
+    *libsched.a:sched_addreadytorun.*(.literal.nxsched_add_readytorun .text.nxsched_add_readytorun)
+    *libsched.a:sched_addprioritized.*(.literal.nxsched_add_prioritized .text.nxsched_add_prioritized)
+    *libsched.a:sched_mergepending.*(.literal.nxsched_merge_pending .text.nxsched_merge_pending)
+    *libsched.a:sched_resumescheduler.*(.literal.nxsched_resume_scheduler .text.nxsched_resume_scheduler)
+
+    *libc.a:sq_remfirst.*(.literal.sq_remfirst .text.sq_remfirst)
+#endif
+
+    *libarch.a:esp32s3_spi_timing.*(.literal .text .literal.* .text.*)
+#ifdef CONFIG_ESP32S3_SPIRAM_MODE_QUAD
+    *libarch.a:esp32s3_psram_quad.*(.literal .text .literal.* .text.*)
+#endif
+#ifdef CONFIG_ESP32S3_SPIRAM_MODE_OCT
+    *libarch.a:esp32s3_psram_octal.*(.literal .text .literal.* .text.*)
+#endif
+#if defined(CONFIG_STACK_CANARIES) && \
+    (defined(CONFIG_ESP32S3_SPIFLASH) || \
+     defined(CONFIG_ESP32S3_SPIRAM))
+    *libc.a:lib_stackchk.*(.literal .text .literal.* .text.*)
+#endif
+
+    *(.wifirxiram .wifirxiram.*)
+    *(.wifi0iram  .wifi0iram.*)
+    *(.wifiorslpiram .wifiorslpiram.*)
+    *(.wifislpiram .wifislpiram.*)
+    *(.wifislprxiram .wifislprxiram.*)
+    *(.phyiram .phyiram.*)
+
     /* align + add 16B for CPU dummy speculative instr. fetch */
 
     . = ALIGN(4) + 16;
@@ -242,6 +317,15 @@ SECTIONS
     KEEP (*(.jcr))
     *(.dram1 .dram1.*)
     esp32s3_start.*(.rodata .rodata.*)
+
+    *libphy.a:(.rodata  .rodata.*)
+    *libarch.a:xtensa_context.*(.rodata  .rodata.*)
+#if defined(CONFIG_STACK_CANARIES) && \
+    (defined(CONFIG_ESP32S3_SPIFLASH) || \
+     defined(CONFIG_ESP32S3_SPIRAM))
+    *libc.a:lib_stackchk.*(.rodata  .rodata.*)
+#endif
+
     _edata = ABSOLUTE(.);
     . = ALIGN(4);
 
@@ -260,6 +344,25 @@ SECTIONS
 
     . += 16;
     . = ALIGN(256);
+    _iram_end = ABSOLUTE(.);
+  } >iram0_0_seg
+
+  .iram0.data :
+  {
+    . = ALIGN(4);
+
+    *(.iram.data)
+    *(.iram.data.*)
+  } >iram0_0_seg
+
+  .iram0.bss (NOLOAD) :
+  {
+    . = ALIGN(4);
+
+    *(.iram.bss)
+    *(.iram.bss.*)
+
+    . = ALIGN(4);
     _iram_end = ABSOLUTE(.);
   } >iram0_0_seg
 


### PR DESCRIPTION
## Summary

* Bugfix of [this issue](https://github.com/apache/nuttx/issues/11279)
* xtensa/esp32s3: Fix esp32s3 mcuboot ota crash

## Impact

Only ESP32S3

## Testing

`esp32s3-devkit:wifi` config used with added these lines into rtc defconfig:

```
CONFIG_ESP32S3_HAVE_OTA_PARTITION=y
CONFIG_ESP32S3_STORAGE_MTD_OFFSET=0x250000
CONFIG_ESP32S3_STORAGE_MTD_SIZE=0x100000
CONFIG_ESP32S3_APP_FORMAT_MCUBOOT=y
```