### PR TITLE
upgrade llvm version to 17.0.6

### DIFF
--- a/libs/libxx/Kconfig
+++ b/libs/libxx/Kconfig
@@ -84,7 +84,7 @@ config LIBCXXABI_VERSION
 	string "Select libcxxabi version"
 	depends on LIBCXXABI
 	default LIBCXX_VERSION if LIBCXX
-	default "15.0.7" if !LIBCXX
+	default "17.0.6" if !LIBCXX
 
 endif
 
@@ -117,6 +117,6 @@ endif
 config LIBCXX_VERSION
 	string "Select libcxx version"
 	depends on LIBCXX
-	default "15.0.7"
+	default "17.0.6"
 
 endif

--- a/libs/libxx/__config_site
+++ b/libs/libxx/__config_site
@@ -9,10 +9,6 @@
 #ifndef _LIBCPP___CONFIG_SITE
 #define _LIBCPP___CONFIG_SITE
 
-/* The following is generated from include/__config_site.in
- * in Ubunutu 22.0.4 with g++ 11.3.0.
- */
-
 #define _LIBCPP_ABI_VERSION 1
 #define _LIBCPP_ABI_NAMESPACE __1
 /* #undef _LIBCPP_ABI_FORCE_ITANIUM */
@@ -23,18 +19,24 @@
 /* #undef _LIBCPP_HAS_THREAD_API_PTHREAD */
 /* #undef _LIBCPP_HAS_THREAD_API_EXTERNAL */
 /* #undef _LIBCPP_HAS_THREAD_API_WIN32 */
-/* #undef _LIBCPP_HAS_THREAD_LIBRARY_EXTERNAL */
 /* #undef _LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS */
 #define _LIBCPP_HAS_NO_VENDOR_AVAILABILITY_ANNOTATIONS
 /* #undef _LIBCPP_NO_VCRUNTIME */
 /* #undef _LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION */
-/* #undef _LIBCPP_HAS_NO_FILESYSTEM_LIBRARY */
-/* #undef _LIBCPP_HAS_PARALLEL_ALGORITHMS */
+/* #undef _LIBCPP_HAS_NO_FILESYSTEM */
 /* #undef _LIBCPP_HAS_NO_RANDOM_DEVICE */
 /* #undef _LIBCPP_HAS_NO_LOCALIZATION */
 /* #undef _LIBCPP_HAS_NO_WIDE_CHARACTERS */
 #define _LIBCPP_ENABLE_ASSERTIONS_DEFAULT 0
-/* #undef _LIBCPP_ENABLE_DEBUG_MODE */
+
+// PSTL backends
+#define _LIBCPP_PSTL_CPU_BACKEND_SERIAL
+/* #undef _LIBCPP_PSTL_CPU_BACKEND_THREAD */
+/* #undef _LIBCPP_PSTL_CPU_BACKEND_LIBDISPATCH */
+
+// Hardening.
+#define _LIBCPP_ENABLE_HARDENED_MODE_DEFAULT 0
+#define _LIBCPP_ENABLE_DEBUG_MODE_DEFAULT 0
 
 // __USE_MINGW_ANSI_STDIO gets redefined on MinGW
 #ifdef __clang__
@@ -48,5 +50,7 @@
 #ifdef __clang__
 #  pragma clang diagnostic pop
 #endif
+
+#define _SYS_REENT_H_
 
 #endif // _LIBCPP___CONFIG_SITE

--- a/libs/libxx/libcxx.defs
+++ b/libs/libxx/libcxx.defs
@@ -29,6 +29,7 @@ libcxx: libcxx-$(LIBCXX_VERSION).src.tar.xz
 	$(Q) tar -xf libcxx-$(LIBCXX_VERSION).src.tar.xz \
 	         --exclude libcxx-$(LIBCXX_VERSION).src/test/std/pstl
 	$(Q) mv libcxx-$(LIBCXX_VERSION).src libcxx
+	$(Q) patch -p2 < mbstate_t.patch
 	$(Q) touch $@
 endif
 
@@ -79,7 +80,7 @@ libcxx/src/filesystem/operations.cpp_CXXFLAGS += -Wno-shadow
 #       |                                ^~~~~~
 
 ifeq ($(GCCVER),)
-  export GCCVER = $(shell $(CXX) --version | grep g++ | sed -E 's/.* ([0-9]+\.[0-9]+).*/\1/' | cut -d'.' -f1)
+  export GCCVER = $(shell $(CXX) --version | grep ++ | sed -E 's/.* ([0-9]+\.[0-9]+).*/\1/' | cut -d'.' -f1)
 endif
 
 ifeq ($(GCCVER),12)
@@ -135,7 +136,50 @@ ifeq ($(GCCVER),12)
 	libcxx/src/locale.cpp_CXXFLAGS += -Wno-attributes
 endif
 
+# warning on gcc >= 12.3.Rel1
+# libcxx/src/string.cpp:58:33: warning: 'template<class _CharT> struct std::__1::char_traits' is deprecated: char_traits<T> for T not equal to char, wchar_t, char8_t, char16_t or char32_t is non-standard and is provided for a temporary period. It will be removed in LLVM 18, so please migrate off of it. [-Wdeprecated-declarations]
+#    58 | template string operator+<char, char_traits<char>, allocator<char>>(char const*, string const&);
+ifeq ($(shell expr $(GCCVER) \>= 12), 1)
+	libcxx/src/string.cpp_CXXFLAGS += -Wno-deprecated-declarations
+endif
+
+# warning on gcc >= 12.3.Rel1
+# libcxx/src/filesystem/path.cpp:14:
+# libcxx/src/filesystem/path_parser.h: In constructor 'std::__1::__fs::filesystem::parser::PathParser::PathParser(std::__1::__fs::filesystem::parser::string_view_t, ParserState)':
+# libcxx/src/filesystem/path_parser.h:58:43: warning: declaration of 'State' shadows a member of 'std::__1::__fs::filesystem::parser::PathParser' [-Wshadow]
+#    58 |   PathParser(string_view_t P, ParserState State) noexcept : Path(P),
+#       |                               ~~~~~~~~~~~~^~~~~
+# libcxx/src/filesystem/path_parser.h:55:15: note: shadowed declaration is here
+#    55 |   ParserState State;
+#       |               ^~~~~
+# libcxx/src/filesystem/path_parser.h: In constructor 'std::__1::__fs::filesystem::parser::PathParser::PathParser(std::__1::__fs::filesystem::parser::string_view_t, ParserState)':
+# libcxx/src/filesystem/path_parser.h:58:43: warning: declaration of 'State' shadows a member of 'std::__1::__fs::filesystem::parser::PathParser' [-Wshadow]
+#    58 |   PathParser(string_view_t P, ParserState State) noexcept : Path(P),
+#       |                               ~~~~~~~~~~~~^~~~~
+# libcxx/src/filesystem/path_parser.h:55:15: note: shadowed declaration is here
+#    55 |   ParserState State;
+#       |               ^~~~~
+# libcxx/src/filesystem/path_parser.h: In constructor 'std::__1::__fs::filesystem::parser::PathParser::PathParser(std::__1::__fs::filesystem::parser::string_view_t, ParserState)':
+# libcxx/src/filesystem/path_parser.h:58:43: warning: declaration of 'State' shadows a member of 'std::__1::__fs::filesystem::parser::PathParser' [-Wshadow]
+#    58 |   PathParser(string_view_t P, ParserState State) noexcept : Path(P),
+#       |                               ~~~~~~~~~~~~^~~~~
+# libcxx/src/filesystem/path_parser.h:55:15: note: shadowed declaration is here
+#    55 |   ParserState State;
+#       |               ^~~~~
+ifeq ($(shell expr $(GCCVER) \>= 12), 1)
+	libcxx/src/filesystem/path.cpp_CXXFLAGS += -Wno-shadow
+endif
+
+# warning on gcc >= 12.3.Rel1
+# libcxx/src/ryu/d2s.cpp:490:31: warning: '_Trailing_zero_bits' may be used uninitialized [-Wmaybe-uninitialized]
+#   490 |           _Trailing_zero_bits += 32;
+#       |           ~~~~~~~~~~~~~~~~~~~~^~~~~
+ifeq ($(shell expr $(GCCVER) \>= 12), 1)
+	libcxx/src/ryu/d2s.cpp_CXXFLAGS += -Wno-maybe-uninitialized
+endif
+
 
 CPPSRCS += $(wildcard libcxx/src/*.cpp)
 CPPSRCS += $(wildcard libcxx/src/experimental/*.cpp)
 CPPSRCS += $(wildcard libcxx/src/filesystem/*.cpp)
+CPPSRCS += $(wildcard libcxx/src/ryu/*.cpp)

--- a/libs/libxx/mbstate_t.patch
+++ b/libs/libxx/mbstate_t.patch
@@ -1,0 +1,17 @@
+--- libs/libxx/libcxx/include/__mbstate_t.h	2023-11-28 09:52:28.000000000 +0100
++++ libs/libxx/libcxx/include/__mbstate_t.h	2023-12-05 16:14:46.523689408 +0100
+@@ -39,12 +39,12 @@
+ #   define __NEED_mbstate_t
+ #   include <bits/alltypes.h>
+ #   undef __NEED_mbstate_t
++#elif !defined(_LIBCPP_HAS_NO_WIDE_CHARACTERS) && __has_include_next(<wchar.h>)
++#   include_next <wchar.h> // fall back to the C standard provider of mbstate_t
+ #elif __has_include(<bits/types/mbstate_t.h>)
+ #   include <bits/types/mbstate_t.h> // works on most Unixes
+ #elif __has_include(<sys/_types/_mbstate_t.h>)
+ #   include <sys/_types/_mbstate_t.h> // works on Darwin
+-#elif !defined(_LIBCPP_HAS_NO_WIDE_CHARACTERS) && __has_include_next(<wchar.h>)
+-#   include_next <wchar.h> // fall back to the C standard provider of mbstate_t
+ #elif __has_include_next(<uchar.h>)
+ #   include_next <uchar.h> // <uchar.h> is also required to make mbstate_t visible
+ #else

--- a/tools/ci/testlist/sim-01.dat
+++ b/tools/ci/testlist/sim-01.dat
@@ -33,8 +33,7 @@
 # Skip WebAssembly Micro Runtime
 -Darwin,sim:wamr
 
-# macOS matter compilation is not currently supported
--Darwin,sim:matter
+-sim:matter
 
 # Boards build by CMake
 CMake,sim:alsa
@@ -54,4 +53,3 @@ CMake,sim:nettest
 CMake,sim:note
 CMake,sim:nsh
 CMake,sim:nxffs
-CMake,sim:matter


### PR DESCRIPTION
## Summary
Related to https://github.com/apache/nuttx/pull/11269
Upgrade to LLVM version 17.0.6
Also set Nuttx libm as default math lib to prevent compilation failures

Tested with gcc version 12.3.Rel1 and 13.2.rel1

## Impact

## Testing

