### PR TITLE
sh:Enhanced compilation system

### DIFF
--- a/tools/Unix.mk
+++ b/tools/Unix.mk
@@ -279,10 +279,16 @@ include/arch:
 	$(Q) $(DIRLINK) $(TOPDIR)/$(ARCH_DIR)/include $@
 
 # Link the boards/<arch>/<chip>/<board>/include directory to include/arch/board
+# If the above path does not exist, then we try to link to common
+
+LINK_INCLUDE_DIR=$(BOARD_DIR)/include
+ifeq ($(wildcard $(LINK_INCLUDE_DIR)),)
+	LINK_INCLUDE_DIR = $(BOARD_COMMON_DIR)/include
+endif
 
 include/arch/board: | include/arch
 	@echo "LN: $@ to $(BOARD_DIR)/include"
-	$(Q) $(DIRLINK) $(BOARD_DIR)/include $@
+	$(Q) $(DIRLINK) $(LINK_INCLUDE_DIR) $@
 
 # Link the boards/<arch>/<chip>/common dir to arch/<arch-name>/src/board
 # Link the boards/<arch>/<chip>/<board>/src dir to arch/<arch-name>/src/board/board

--- a/tools/Unix.mk
+++ b/tools/Unix.mk
@@ -283,7 +283,9 @@ include/arch:
 
 LINK_INCLUDE_DIR=$(BOARD_DIR)/include
 ifeq ($(wildcard $(LINK_INCLUDE_DIR)),)
-	LINK_INCLUDE_DIR = $(BOARD_COMMON_DIR)/include
+	ifneq ($(strip $(BOARD_COMMON_DIR)),)
+		LINK_INCLUDE_DIR = $(BOARD_COMMON_DIR)/include
+	endif
 endif
 
 include/arch/board: | include/arch

--- a/tools/Win.mk
+++ b/tools/Win.mk
@@ -264,10 +264,18 @@ include\arch:
 	$(Q) $(DIRLINK) $(TOPDIR)\$(ARCH_DIR)\include $@
 
 # Link the boards\<arch>\<chip>\<board>\include directory to include\arch\board
+# If the above path does not exist, then we try to link to common
+
+LINK_INCLUDE_DIR=$(BOARD_DIR)/include
+ifeq ($(wildcard $(LINK_INCLUDE_DIR)),)
+	ifneq ($(strip $(BOARD_COMMON_DIR)),)
+		LINK_INCLUDE_DIR = $(BOARD_COMMON_DIR)/include
+	endif
+endif
 
 include\arch\board: | include\arch
 	@echo "LN: $@ to $(BOARD_DIR)\include"
-	$(Q) $(DIRLINK) $(BOARD_DIR)\include $@
+	$(Q) $(DIRLINK) $(LINK_INCLUDE_DIR) $@
 
 # Link the boards\<arch>\<chip>\common dir to arch\<arch-name>\src\board
 # Link the boards\<arch>\<chip>\<board>\src dir to arch\<arch-name>\src\board\board

--- a/tools/configure.c
+++ b/tools/configure.c
@@ -1121,13 +1121,19 @@ static void check_configuration(void)
           debug("check_configuration: Checking %s\n", g_buffer);
           if (!verify_file(g_buffer))
             {
-              fprintf(stderr, "ERROR: No Make.defs file in %s\n",
-                      g_configpath);
-              fprintf(stderr, "       No Make.defs file in %s\n",
-                      g_scriptspath);
-              fprintf(stderr, "Run tools/configure -L"
-                              " to list available configurations.\n");
-              exit(EXIT_FAILURE);
+              /* Let’s check if there is a script in the common directory */
+
+              snprintf(g_buffer, BUFFER_SIZE,
+                       "%s%c..%c..%c..%ccommon%cscripts%cMake.defs",
+                       g_configpath, g_delim, g_delim, g_delim, g_delim,
+                       g_delim, g_delim);
+              if (!verify_file(g_buffer))
+                {
+                  fprintf(stderr, "ERROR: No Make.defs file found\n");
+                  fprintf(stderr, "Run tools/configure -L"
+                                  " to list available configurations.\n");
+                  exit(EXIT_FAILURE);
+                }
             }
         }
       else

--- a/tools/configure.sh
+++ b/tools/configure.sh
@@ -167,8 +167,12 @@ if [ ! -r ${src_makedefs} ]; then
       src_makedefs=${configpath}/../../scripts/Make.defs
 
       if [ ! -r ${src_makedefs} ]; then
-        echo "File Make.defs could not be found"
-        exit 4
+        src_makedefs=${configpath}/../../../common/scripts/Make.defs
+
+        if [ ! -r ${src_makedefs} ]; then
+          echo "File Make.defs could not be found"
+          exit 4
+        fi
       fi
     fi
   fi

--- a/tools/refresh.sh
+++ b/tools/refresh.sh
@@ -170,6 +170,9 @@ for CONFIG in ${CONFIGS}; do
   DEFCONFIG=$CONFIGDIR/defconfig
   MAKEDEFS2=$CONFIGDIR/Make.defs
 
+  SCRIPTSDIR2=$BOARDDIR/../common/scripts
+  MAKEDEFS3=$SCRIPTSDIR2/Make.defs
+
   # Check the board configuration directory
 
   if [ ! -d $BOARDDIR ]; then
@@ -193,8 +196,12 @@ for CONFIG in ${CONFIGS}; do
     if [ -r $MAKEDEFS1 ]; then
       MAKEDEFS=$MAKEDEFS1
     else
-      echo "No readable Make.defs file at $MAKEDEFS1 or $MAKEDEFS2"
-      exit 1
+      if [ -r $MAKEDEFS3 ]; then
+        MAKEDEFS=$MAKEDEFS3
+      else
+        echo "No readable Make.defs file at $MAKEDEFS1 or $MAKEDEFS2 or $MAKEDEFS3"
+        exit 1
+      fi
     fi
   fi
 


### PR DESCRIPTION
## Summary
While simplifying some of the Simulator-based configurations, I found one area that could be improved - I added an extra layer to retrieve paths at compile time.
This means that we can extract the script and include paths to the common directory, and in common we only need to store some private files for configuration.

## Impact
Added a layer of path searching, now common is placed in a flat directory with board, if there is no include / script stored in the board directory, then it will look in common.

## Testing
Based on this change, the local board path accomplishes the desired goal and does not affect configurations such as sim:nsh
