### PR TITLE
invert tx and rx in spi_dma_setup

### DIFF
--- a/arch/arm/src/samd2l2/sam_spi.c
+++ b/arch/arm/src/samd2l2/sam_spi.c
@@ -1429,13 +1429,13 @@ static void spi_dma_setup(struct sam_spidev_s *priv)
 {
   /* Allocate a pair of DMA channels */
 
-  priv->dma_rx = sam_dmachannel(DMACH_FLAG_BEATSIZE_BYTE |
-                                DMACH_FLAG_MEM_INCREMENT |
-                                DMACH_FLAG_PERIPH_RXTRIG(priv->dma_rx_trig));
-
   priv->dma_tx = sam_dmachannel(DMACH_FLAG_BEATSIZE_BYTE |
                                 DMACH_FLAG_MEM_INCREMENT |
                                 DMACH_FLAG_PERIPH_TXTRIG(priv->dma_tx_trig));
+
+  priv->dma_rx = sam_dmachannel(DMACH_FLAG_BEATSIZE_BYTE |
+                                DMACH_FLAG_MEM_INCREMENT |
+                                DMACH_FLAG_PERIPH_RXTRIG(priv->dma_rx_trig));
 }
 #endif
 


### PR DESCRIPTION
## Summary
According to SAMD21 Errata:
```text
1.7.2 Linked Descriptor

When at least one channel using linked descriptors is already active, enabling another DMA channel (with or without
linked descriptors) can result in a channel Fetch Error (FERR) or an incorrect descriptor fetch.
This occurs if the channel number of the channel being enabled is lower than the channel already active.

Workaround

When enabling a DMA channel while other channels using linked descriptors are already active, the channel number
of the new channel enabled must be greater than the other channel numbers.`
```

In the spi driver, in the description and in the code it is always Tx and then Rx except in one place where it is Rx and then Tx which could lead in the FERR according to Errata

I think it would be better to swap Rx/Tx in the following code:

```c
static void spi_dma_setup(struct sam_spidev_s *priv)
{
  /* Allocate a pair of DMA channels */

    priv->dma_rx = sam_dmachannel(DMACH_FLAG_BEATSIZE_BYTE |
                                                           DMACH_FLAG_MEM_INCREMENT |
                                                           DMACH_FLAG_PERIPH_RXTRIG(priv->dma_rx_trig)); 
    priv->dma_tx = sam_dmachannel(DMACH_FLAG_BEATSIZE_BYTE |
                                                           DMACH_FLAG_MEM_INCREMENT |
                                                           DMACH_FLAG_PERIPH_TXTRIG(priv->dma_tx_trig));
                               
}
```
into
```c
static void spi_dma_setup(struct sam_spidev_s *priv)
{
  /* Allocate a pair of DMA channels */

  priv->dma_tx = sam_dmachannel(DMACH_FLAG_BEATSIZE_BYTE |
                                                        DMACH_FLAG_MEM_INCREMENT |
                                                        DMACH_FLAG_PERIPH_TXTRIG(priv->dma_tx_trig));

  priv->dma_rx = sam_dmachannel(DMACH_FLAG_BEATSIZE_BYTE |
                                                         DMACH_FLAG_MEM_INCREMENT |
                                                         DMACH_FLAG_PERIPH_RXTRIG(priv->dma_rx_trig));                                
}
```
## Impact
In my case (driving led strip ws2812), I still get an error TERR on the Rx channel. It has no particular impact but it makes more sense and should avoid potential FERR according to errata.

## Testing
Compiles and runs

