### PR TITLE
arch/nrf{52|53|91}: add missing support for 1 Mbps UART baud

### DIFF
--- a/arch/arm/src/nrf52/nrf52_lowputc.c
+++ b/arch/arm/src/nrf52/nrf52_lowputc.c
@@ -204,6 +204,12 @@ static void nrf52_setbaud(uintptr_t base, const struct uart_config_s *config)
           break;
         }
 
+      case 1000000:
+        {
+          br = UART_BAUDRATE_1000000;
+          break;
+        }
+
       default:
         {
           DEBUGPANIC();

--- a/arch/arm/src/nrf53/nrf53_lowputc.c
+++ b/arch/arm/src/nrf53/nrf53_lowputc.c
@@ -204,6 +204,12 @@ static void nrf53_setbaud(uintptr_t base, const struct uart_config_s *config)
           break;
         }
 
+      case 1000000:
+        {
+          br = UART_BAUDRATE_1000000;
+          break;
+        }
+
       default:
         {
           DEBUGPANIC();

--- a/arch/arm/src/nrf91/nrf91_lowputc.c
+++ b/arch/arm/src/nrf91/nrf91_lowputc.c
@@ -204,6 +204,12 @@ static void nrf91_setbaud(uintptr_t base, const struct uart_config_s *config)
           break;
         }
 
+      case 1000000:
+        {
+          br = UART_BAUDRATE_1000000;
+          break;
+        }
+
       default:
         {
           DEBUGPANIC();


### PR DESCRIPTION
## Summary
arch/nrf{52|53|91}: add missing support for 1 Mbps UART baud
## Impact
add missing logic
## Testing
nrf52832-dk
