### PR TITLE
arch/arm/samv7/sam_emac: Implement errata workaround for KSZ8061 PHY

### DIFF
--- a/arch/arm/src/samv7/sam_emac.c
+++ b/arch/arm/src/samv7/sam_emac.c
@@ -3751,6 +3751,37 @@ static int sam_autonegotiate(struct sam_emac_s *priv)
       goto errout;
     }
 
+  if (priv->phytype == SAMV7_PHY_KSZ8061)
+    {
+      ret = sam_phywrite(priv, priv->phyaddr, MII_MMDCONTROL, 0x0001);
+      if (ret < 0)
+        {
+          nerr("ERROR: Failed to write MMDCONTROL\n");
+          goto errout;
+        }
+
+      ret = sam_phywrite(priv, priv->phyaddr, MII_MMDADDRDATA, 0x0002);
+      if (ret < 0)
+        {
+          nerr("ERROR: Failed to write MMDADDRDATA\n");
+          goto errout;
+        }
+
+      ret = sam_phywrite(priv, priv->phyaddr, MII_MMDCONTROL, 0x4001);
+      if (ret < 0)
+        {
+          nerr("ERROR: Failed to write MMDCONTROL\n");
+          goto errout;
+        }
+
+      ret = sam_phywrite(priv, priv->phyaddr, MII_MMDADDRDATA, 0xb61a);
+      if (ret < 0)
+        {
+          nerr("ERROR: Failed to write MMDADDRDATA\n");
+          goto errout;
+        }
+    }
+
   /* Restart Auto_negotiation */
 
   mcr |=  MII_MCR_ANRESTART;

--- a/include/nuttx/net/mii.h
+++ b/include/nuttx/net/mii.h
@@ -53,6 +53,7 @@
 #define MII_PSECONTROL               0x0b      /* PSE control register */
 #define MII_PSESTATUS                0x0c      /* PSE status register */
 #define MII_MMDCONTROL               0x0d      /* MMD access control register */
+#define MII_MMDADDRDATA              0x0e      /* MMD access address data register */
 #define MII_ESTATUS                  0x0f      /* Extended status register */
 
 /* Extended Registers: Registers 16-31 may be used for vendor specific


### PR DESCRIPTION
## Summary
Implement workaround for KSZ8061 PHY errata:
- Potential link-up failure when Ethernet cable is connected slowly

Similar can be applied for other architectures

## Impact
Improve link detection for SAMv7 based boards with KSZ8061 PHY.

## Testing
Custom SAMe70 based board with KSZ8061 PHY.