### PR TITLE
fs/proc: Fix groupfd to get fd by group instead of current tcb

### DIFF
--- a/fs/inode/fs_files.c
+++ b/fs/inode/fs_files.c
@@ -72,16 +72,6 @@ static FAR struct file *files_fget_by_index(FAR struct filelist *list,
 }
 
 /****************************************************************************
- * Name: files_fget
- ****************************************************************************/
-
-static FAR struct file *files_fget(FAR struct filelist *list, int fd)
-{
-  return files_fget_by_index(list, fd / CONFIG_NFILE_DESCRIPTORS_PER_BLOCK,
-                             fd % CONFIG_NFILE_DESCRIPTORS_PER_BLOCK);
-}
-
-/****************************************************************************
  * Name: files_extend
  ****************************************************************************/
 
@@ -345,6 +335,27 @@ void files_releaselist(FAR struct filelist *list)
 int files_countlist(FAR struct filelist *list)
 {
   return list->fl_rows * CONFIG_NFILE_DESCRIPTORS_PER_BLOCK;
+}
+
+/****************************************************************************
+ * Name: files_fget
+ *
+ * Description:
+ *   Get the instance of struct file from file list by file descriptor.
+ *
+ * Input Parameters:
+ *   list - The list of files for a task.
+ *   fd   - A valid descriptor between 0 and files_countlist(list).
+ *
+ * Returned Value:
+ *   Pointer to file structure of list[fd].
+ *
+ ****************************************************************************/
+
+FAR struct file *files_fget(FAR struct filelist *list, int fd)
+{
+  return files_fget_by_index(list, fd / CONFIG_NFILE_DESCRIPTORS_PER_BLOCK,
+                             fd % CONFIG_NFILE_DESCRIPTORS_PER_BLOCK);
 }
 
 /****************************************************************************

--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -1193,7 +1193,6 @@ static ssize_t proc_groupfd(FAR struct proc_file_s *procfile,
   size_t copysize;
   size_t totalsize;
   int count;
-  int ret;
   int i;
 
   DEBUGASSERT(group != NULL);
@@ -1226,8 +1225,11 @@ static ssize_t proc_groupfd(FAR struct proc_file_s *procfile,
 
   for (i = 0; i < count; i++)
     {
-      ret = fs_getfilep(i, &filep);
-      if (ret != OK || filep == NULL)
+      filep = files_fget(&group->tg_filelist, i);
+
+      /* Is there an inode associated with the file descriptor? */
+
+      if (filep->f_inode == NULL)
         {
           continue;
         }

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -883,6 +883,23 @@ int files_duplist(FAR struct filelist *plist, FAR struct filelist *clist,
                   bool cloexec);
 
 /****************************************************************************
+ * Name: files_fget
+ *
+ * Description:
+ *   Get the instance of struct file from file list by file descriptor.
+ *
+ * Input Parameters:
+ *   list - The list of files for a task.
+ *   fd   - A valid descriptor between 0 and files_countlist(list).
+ *
+ * Returned Value:
+ *   Pointer to file structure of list[fd].
+ *
+ ****************************************************************************/
+
+FAR struct file *files_fget(FAR struct filelist *list, int fd);
+
+/****************************************************************************
  * Name: file_allocate_from_tcb
  *
  * Description:


### PR DESCRIPTION
## Summary
`/proc/<pid>/group/fd` should read the fds of `<pid>`, not current tcb.

Note: This problem exists between https://github.com/apache/nuttx/pull/11140 and this PR.

## Impact
`/proc/<pid>/group/fd`

## Testing
`fdinfo` command, which shows the same result for every thread before this patch.

