### PR TITLE
riscv/arch_elf.c: Handle PCREL_HI20/LO12_I/S relocations correctly

### DIFF
--- a/arch/risc-v/include/elf.h
+++ b/arch/risc-v/include/elf.h
@@ -83,4 +83,25 @@
 #define R_RISCV_SET32         56
 #define R_RISCV_32_PCREL      57
 
+#define ARCH_ELFDATA          1
+#define ARCH_ELF_RELCNT       8
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+#ifndef __ASSEMBLY__
+
+struct arch_elfdata_s
+{
+  struct hi20_rels_s
+  {
+    uintptr_t hi20_rel;
+    uintptr_t hi20_offset;
+  }
+  hi20_rels[ARCH_ELF_RELCNT];
+};
+typedef struct arch_elfdata_s arch_elfdata_t;
+
+#endif /* __ASSEMBLY__ */
 #endif /* __ARCH_RISCV_INCLUDE_ELF_H */

--- a/binfmt/libelf/libelf_bind.c
+++ b/binfmt/libelf/libelf_bind.c
@@ -55,6 +55,15 @@
 #  define elf_dumpbuffer(m,b,n)
 #endif
 
+#ifdef ARCH_ELFDATA
+#  define ARCH_ELFDATA_DEF  arch_elfdata_t arch_data; \
+                            memset(&arch_data, 0, sizeof(arch_elfdata_t))
+#  define ARCH_ELFDATA_PARM &arch_data
+#else
+#  define ARCH_ELFDATA_DEF
+#  define ARCH_ELFDATA_PARM NULL
+#endif
+
 /****************************************************************************
  * Private Types
  ****************************************************************************/
@@ -184,6 +193,10 @@ static int elf_relocate(FAR struct elf_loadinfo_s *loadinfo, int relidx,
   int                   ret;
   int                   i;
   int                   j;
+
+  /* Define potential architecture specific elf data container */
+
+  ARCH_ELFDATA_DEF;
 
   rels = kmm_malloc(CONFIG_ELF_RELOCATION_BUFFERCOUNT * sizeof(Elf_Rel));
   if (rels == NULL)
@@ -334,7 +347,7 @@ static int elf_relocate(FAR struct elf_loadinfo_s *loadinfo, int relidx,
 
       /* Now perform the architecture-specific relocation */
 
-      ret = up_relocate(rel, sym, addr);
+      ret = up_relocate(rel, sym, addr, ARCH_ELFDATA_PARM);
       if (ret < 0)
         {
           berr("ERROR: Section %d reloc %d: Relocation failed: %d\n",
@@ -369,6 +382,10 @@ static int elf_relocateadd(FAR struct elf_loadinfo_s *loadinfo, int relidx,
   int                   ret;
   int                   i;
   int                   j;
+
+  /* Define potential architecture specific elf data container */
+
+  ARCH_ELFDATA_DEF;
 
   relas = kmm_malloc(CONFIG_ELF_RELOCATION_BUFFERCOUNT * sizeof(Elf_Rela));
   if (relas == NULL)
@@ -519,7 +536,7 @@ static int elf_relocateadd(FAR struct elf_loadinfo_s *loadinfo, int relidx,
 
       /* Now perform the architecture-specific relocation */
 
-      ret = up_relocateadd(rela, sym, addr);
+      ret = up_relocateadd(rela, sym, addr, ARCH_ELFDATA_PARM);
       if (ret < 0)
         {
           berr("ERROR: Section %d reloc %d: Relocation failed: %d\n",

--- a/include/nuttx/elf.h
+++ b/include/nuttx/elf.h
@@ -142,9 +142,9 @@ bool up_checkarch(FAR const Elf_Ehdr *hdr);
 
 #ifdef CONFIG_LIBC_ARCH_ELF
 int up_relocate(FAR const Elf_Rel *rel, FAR const Elf_Sym *sym,
-                uintptr_t addr);
-int up_relocateadd(FAR const Elf_Rela *rel,
-                   FAR const Elf_Sym *sym, uintptr_t addr);
+                uintptr_t addr, FAR void *arch_data);
+int up_relocateadd(FAR const Elf_Rela *rel, FAR const Elf_Sym *sym,
+                   uintptr_t addr, FAR void *arch_data);
 #endif
 
 /****************************************************************************

--- a/libs/libc/machine/arm/arm/arch_elf.c
+++ b/libs/libc/machine/arm/arm/arch_elf.c
@@ -123,7 +123,8 @@ bool up_checkarch(const Elf32_Ehdr *ehdr)
  *
  ****************************************************************************/
 
-int up_relocate(const Elf32_Rel *rel, const Elf32_Sym *sym, uintptr_t addr)
+int up_relocate(const Elf32_Rel *rel, const Elf32_Sym *sym, uintptr_t addr,
+                void *arch_data)
 {
   int32_t offset;
   unsigned int relotype;
@@ -477,7 +478,7 @@ int up_relocate(const Elf32_Rel *rel, const Elf32_Sym *sym, uintptr_t addr)
 }
 
 int up_relocateadd(const Elf32_Rela *rel, const Elf32_Sym *sym,
-                   uintptr_t addr)
+                   uintptr_t addr, void *arch_data)
 {
   berr("ERROR: RELA relocation not supported\n");
   return -ENOSYS;

--- a/libs/libc/machine/arm/armv6-m/arch_elf.c
+++ b/libs/libc/machine/arm/armv6-m/arch_elf.c
@@ -110,7 +110,8 @@ bool up_checkarch(const Elf32_Ehdr *ehdr)
  *
  ****************************************************************************/
 
-int up_relocate(const Elf32_Rel *rel, const Elf32_Sym *sym, uintptr_t addr)
+int up_relocate(const Elf32_Rel *rel, const Elf32_Sym *sym, uintptr_t addr,
+                void *arch_data)
 {
   int32_t offset;
   uint32_t upper_insn;
@@ -513,7 +514,7 @@ int up_relocate(const Elf32_Rel *rel, const Elf32_Sym *sym, uintptr_t addr)
 }
 
 int up_relocateadd(const Elf32_Rela *rel, const Elf32_Sym *sym,
-                   uintptr_t addr)
+                   uintptr_t addr, void *arch_data)
 {
   berr("ERROR: RELA relocation not supported\n");
   return -ENOSYS;

--- a/libs/libc/machine/arm/armv7-a/arch_elf.c
+++ b/libs/libc/machine/arm/armv7-a/arch_elf.c
@@ -123,7 +123,8 @@ bool up_checkarch(const Elf32_Ehdr *ehdr)
  *
  ****************************************************************************/
 
-int up_relocate(const Elf32_Rel *rel, const Elf32_Sym *sym, uintptr_t addr)
+int up_relocate(const Elf32_Rel *rel, const Elf32_Sym *sym, uintptr_t addr,
+                void *arch_data)
 {
   int32_t offset;
   unsigned int relotype;
@@ -474,7 +475,7 @@ int up_relocate(const Elf32_Rel *rel, const Elf32_Sym *sym, uintptr_t addr)
 }
 
 int up_relocateadd(const Elf32_Rela *rel, const Elf32_Sym *sym,
-                   uintptr_t addr)
+                   uintptr_t addr, void *arch_data)
 {
   berr("ERROR: RELA relocation not supported\n");
   return -ENOSYS;

--- a/libs/libc/machine/arm/armv7-m/arch_elf.c
+++ b/libs/libc/machine/arm/armv7-m/arch_elf.c
@@ -110,7 +110,8 @@ bool up_checkarch(const Elf32_Ehdr *ehdr)
  *
  ****************************************************************************/
 
-int up_relocate(const Elf32_Rel *rel, const Elf32_Sym *sym, uintptr_t addr)
+int up_relocate(const Elf32_Rel *rel, const Elf32_Sym *sym, uintptr_t addr,
+                void *arch_data)
 {
   int32_t offset;
   uint32_t upper_insn;
@@ -513,7 +514,7 @@ int up_relocate(const Elf32_Rel *rel, const Elf32_Sym *sym, uintptr_t addr)
 }
 
 int up_relocateadd(const Elf32_Rela *rel, const Elf32_Sym *sym,
-                   uintptr_t addr)
+                   uintptr_t addr, void *arch_data)
 {
   berr("ERROR: RELA relocation not supported\n");
   return -ENOSYS;

--- a/libs/libc/machine/arm/armv7-r/arch_elf.c
+++ b/libs/libc/machine/arm/armv7-r/arch_elf.c
@@ -123,7 +123,8 @@ bool up_checkarch(const Elf32_Ehdr *ehdr)
  *
  ****************************************************************************/
 
-int up_relocate(const Elf32_Rel *rel, const Elf32_Sym *sym, uintptr_t addr)
+int up_relocate(const Elf32_Rel *rel, const Elf32_Sym *sym, uintptr_t addr,
+                void *arch_data)
 {
   int32_t offset;
   unsigned int relotype;
@@ -474,7 +475,7 @@ int up_relocate(const Elf32_Rel *rel, const Elf32_Sym *sym, uintptr_t addr)
 }
 
 int up_relocateadd(const Elf32_Rela *rel, const Elf32_Sym *sym,
-                   uintptr_t addr)
+                   uintptr_t addr, void *arch_data)
 {
   berr("ERROR: RELA relocation not supported\n");
   return -ENOSYS;

--- a/libs/libc/machine/arm/armv8-m/arch_elf.c
+++ b/libs/libc/machine/arm/armv8-m/arch_elf.c
@@ -110,7 +110,8 @@ bool up_checkarch(const Elf32_Ehdr *ehdr)
  *
  ****************************************************************************/
 
-int up_relocate(const Elf32_Rel *rel, const Elf32_Sym *sym, uintptr_t addr)
+int up_relocate(const Elf32_Rel *rel, const Elf32_Sym *sym, uintptr_t addr,
+                void *arch_data)
 {
   int32_t offset;
   uint32_t upper_insn;
@@ -513,7 +514,7 @@ int up_relocate(const Elf32_Rel *rel, const Elf32_Sym *sym, uintptr_t addr)
 }
 
 int up_relocateadd(const Elf32_Rela *rel, const Elf32_Sym *sym,
-                   uintptr_t addr)
+                   uintptr_t addr, void *arch_data)
 {
   berr("ERROR: RELA relocation not supported\n");
   return -ENOSYS;

--- a/libs/libc/machine/arm64/arch_elf.c
+++ b/libs/libc/machine/arm64/arch_elf.c
@@ -465,14 +465,15 @@ bool up_checkarch(const Elf64_Ehdr *ehdr)
  *
  ****************************************************************************/
 
-int up_relocate(const Elf64_Rel *rel, const Elf64_Sym *sym, uintptr_t addr)
+int up_relocate(const Elf64_Rel *rel, const Elf64_Sym *sym, uintptr_t addr,
+                void *arch_data)
 {
   berr("ERROR: REL relocation not supported\n");
   return -ENOSYS;
 }
 
 int up_relocateadd(const Elf64_Rela *rel, const Elf64_Sym *sym,
-                   uintptr_t addr)
+                   uintptr_t addr, void *arch_data)
 {
   bool overflow_check = true;
   uint64_t val;

--- a/libs/libc/machine/sim/arch_elf.c
+++ b/libs/libc/machine/sim/arch_elf.c
@@ -87,7 +87,8 @@ bool up_checkarch(const Elf32_Ehdr *hdr)
  *
  ****************************************************************************/
 
-int up_relocate(const Elf32_Rel *rel, const Elf32_Sym *sym, uintptr_t addr)
+int up_relocate(const Elf32_Rel *rel, const Elf32_Sym *sym, uintptr_t addr,
+                void *arch_data)
 {
   uint32_t *ptr = (uint32_t *)addr;
 
@@ -119,7 +120,7 @@ int up_relocate(const Elf32_Rel *rel, const Elf32_Sym *sym, uintptr_t addr)
 }
 
 int up_relocateadd(const Elf32_Rela *rel, const Elf32_Sym *sym,
-                   uintptr_t addr)
+                   uintptr_t addr, void *arch_data)
 {
   berr("ERROR: Not supported\n");
   return -ENOSYS;

--- a/libs/libc/machine/sim/arch_elf64.c
+++ b/libs/libc/machine/sim/arch_elf64.c
@@ -140,14 +140,15 @@ bool up_checkarch(const Elf64_Ehdr *ehdr)
  *
  ****************************************************************************/
 
-int up_relocate(const Elf64_Rel *rel, const Elf64_Sym *sym, uintptr_t addr)
+int up_relocate(const Elf64_Rel *rel, const Elf64_Sym *sym, uintptr_t addr,
+                FAR void *arch_data)
 {
   berr("Not implemented\n");
   return -ENOSYS;
 }
 
 int up_relocateadd(const Elf64_Rela *rel, const Elf64_Sym *sym,
-                   uintptr_t addr)
+                   uintptr_t addr, FAR void *arch_data)
 {
   unsigned int relotype;
   uint64_t value;

--- a/libs/libc/machine/sparc/arch_elf.c
+++ b/libs/libc/machine/sparc/arch_elf.c
@@ -121,7 +121,7 @@ bool up_checkarch(const Elf32_Ehdr *ehdr)
  ****************************************************************************/
 
 int up_relocate(const Elf32_Rel *rel, const Elf32_Sym *sym,
-                uintptr_t addr)
+                uintptr_t addr, void *arch_data)
 {
   unsigned int relotype;
 
@@ -141,7 +141,7 @@ int up_relocate(const Elf32_Rel *rel, const Elf32_Sym *sym,
 }
 
 int up_relocateadd(const Elf32_Rela *rel, const Elf32_Sym *sym,
-                   uintptr_t addr)
+                   uintptr_t addr, void *arch_data)
 {
   unsigned int relotype;
   uint32_t value;

--- a/libs/libc/machine/x86/arch_elf.c
+++ b/libs/libc/machine/x86/arch_elf.c
@@ -95,7 +95,8 @@ bool up_checkarch(const Elf32_Ehdr *hdr)
  *
  ****************************************************************************/
 
-int up_relocate(const Elf32_Rel *rel, const Elf32_Sym *sym, uintptr_t addr)
+int up_relocate(const Elf32_Rel *rel, const Elf32_Sym *sym, uintptr_t addr,
+                void *arch_data)
 {
   uint32_t *ptr = (uint32_t *)addr;
 
@@ -126,7 +127,7 @@ int up_relocate(const Elf32_Rel *rel, const Elf32_Sym *sym, uintptr_t addr)
 }
 
 int up_relocateadd(const Elf32_Rela *rel, const Elf32_Sym *sym,
-                   uintptr_t addr)
+                   uintptr_t addr, void *arch_data)
 {
   bwarn("WARNING: Not supported\n");
   return -ENOSYS;

--- a/libs/libc/machine/xtensa/arch_elf.c
+++ b/libs/libc/machine/xtensa/arch_elf.c
@@ -126,7 +126,8 @@ bool up_checkarch(const Elf32_Ehdr *ehdr)
  *
  ****************************************************************************/
 
-int up_relocate(const Elf32_Rel *rel, const Elf32_Sym *sym, uintptr_t addr)
+int up_relocate(const Elf32_Rel *rel, const Elf32_Sym *sym, uintptr_t addr,
+                void *arch_data)
 {
   unsigned int relotype;
 
@@ -159,7 +160,7 @@ int up_relocate(const Elf32_Rel *rel, const Elf32_Sym *sym, uintptr_t addr)
 }
 
 int up_relocateadd(const Elf32_Rela *rel, const Elf32_Sym *sym,
-                   uintptr_t addr)
+                   uintptr_t addr, void *arch_data)
 {
   unsigned int relotype;
   unsigned char *p;

--- a/libs/libc/modlib/modlib_bind.c
+++ b/libs/libc/modlib/modlib_bind.c
@@ -44,6 +44,15 @@
 #define I_PLT   1    /* ... for PLTs */
 #define N_RELS  2    /* Number of relxxx[] indexes */
 
+#ifdef ARCH_ELFDATA
+#  define ARCH_ELFDATA_DEF  arch_elfdata_t arch_data; \
+                            memset(&arch_data, 0, sizeof(arch_elfdata_t))
+#  define ARCH_ELFDATA_PARM &arch_data
+#else
+#  define ARCH_ELFDATA_DEF
+#  define ARCH_ELFDATA_PARM NULL
+#endif
+
 /****************************************************************************
  * Private Types
  ****************************************************************************/
@@ -180,6 +189,10 @@ static int modlib_relocate(FAR struct module_s *modp,
   int               ret = OK;
   int               i;
   int               j;
+
+  /* Define potential architecture specific elf data container */
+
+  ARCH_ELFDATA_DEF;
 
   rels = lib_malloc(CONFIG_MODLIB_RELOCATION_BUFFERCOUNT * sizeof(Elf_Rel));
   if (!rels)
@@ -331,7 +344,7 @@ static int modlib_relocate(FAR struct module_s *modp,
 
       /* Now perform the architecture-specific relocation */
 
-      ret = up_relocate(rel, sym, addr);
+      ret = up_relocate(rel, sym, addr, ARCH_ELFDATA_PARM);
       if (ret < 0)
         {
           berr("ERROR: Section %d reloc %d: Relocation failed: %d\n",
@@ -367,6 +380,10 @@ static int modlib_relocateadd(FAR struct module_s *modp,
   int               ret = OK;
   int               i;
   int               j;
+
+  /* Define potential architecture specific elf data container */
+
+  ARCH_ELFDATA_DEF;
 
   relas = lib_malloc(CONFIG_MODLIB_RELOCATION_BUFFERCOUNT *
                      sizeof(Elf_Rela));
@@ -519,7 +536,7 @@ static int modlib_relocateadd(FAR struct module_s *modp,
 
       /* Now perform the architecture-specific relocation */
 
-      ret = up_relocateadd(rela, sym, addr);
+      ret = up_relocateadd(rela, sym, addr, ARCH_ELFDATA_PARM);
       if (ret < 0)
         {
           berr("ERROR: Section %d reloc %d: Relocation failed: %d\n",
@@ -567,6 +584,10 @@ static int modlib_relocatedyn(FAR struct module_s *modp,
   int           i;
   int           idx_rel;
   int           idx_sym;
+
+  /* Define potential architecture specific elf data container */
+
+  ARCH_ELFDATA_DEF;
 
   dyn = lib_malloc(shdr->sh_size);
   ret = modlib_read(loadinfo, (FAR uint8_t *)dyn, shdr->sh_size,
@@ -778,7 +799,7 @@ static int modlib_relocatedyn(FAR struct module_s *modp,
                                     loadinfo->datasec + loadinfo->datastart;
                 }
 
-              ret = up_relocate(rel, &dynsym, addr);
+              ret = up_relocate(rel, &dynsym, addr, ARCH_ELFDATA_PARM);
             }
 
           if (ret < 0)


### PR DESCRIPTION
## Summary
There is a problem with the current elf loader for risc-v: when a pair of PCREL_HI20 / LO12 relocations are encountered, it is assumed that these will follow each other immediately, as follows:

label:
	auipc      a0, %pcrel_hi(symbol)    // R_RISCV_PCREL_HI20
	load/store a0, %pcrel_lo(label)(a0) // R_RISCV_PCREL_LO12_I/S

With this assumption, the hi/lo relocations are both done when a hi20 relocation entry is encountered, first to the current instruction (addr) and to the next instruction (addr + 4).

However, this assumption is wrong. There is nothing in the elf relocation specification[1] that mandates this. Thus, the hi/lo relocation always needs to first fixup the hi-part, and when the lo-part is encountered, it needs to find the corresponding hi relocation entry, via the given "label". This necessitates (re-)visiting the relocation entries for the current section as well as looking for "label" in the symbol table.

The NuttX elf loader does not allow such operations to be done in the machine specific part, so this patch fixes the relocation issue by introducing an architecture specific cache for the hi20 relocation and symbol table entries. When a lo12 relocation is encountered, the cache can be consulted to find the hi20 part.

[1] https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-elf.adoc
## Impact
Fix elf loader for risc-v
## Testing
qemu-rv:knsh64
