### PR TITLE
net/icmpv6:Optimize the process of obtaining the IPv6 address through RA.

### DIFF
--- a/net/icmpv6/icmpv6.h
+++ b/net/icmpv6/icmpv6.h
@@ -536,9 +536,9 @@ int icmpv6_rwait(FAR struct icmpv6_rnotify_s *notify, unsigned int timeout);
  ****************************************************************************/
 
 #ifdef CONFIG_NET_ICMPv6_AUTOCONF
-void icmpv6_rnotify(FAR struct net_driver_s *dev);
+void icmpv6_rnotify(FAR struct net_driver_s *dev, int result);
 #else
-#  define icmpv6_rnotify(d) (0)
+#  define icmpv6_rnotify(d,r) (0)
 #endif
 
 /****************************************************************************

--- a/net/icmpv6/icmpv6_input.c
+++ b/net/icmpv6/icmpv6_input.c
@@ -441,20 +441,22 @@ void icmpv6_input(FAR struct net_driver_s *dev, unsigned int iplen)
                     FAR struct icmpv6_prefixinfo_s *prefixopt =
                                       (FAR struct icmpv6_prefixinfo_s *)opt;
 
-                    /* Is the "A" flag set? */
+                    /* if "M" flag isn't set, and the "A" flag is set.
+                     * Set the new network addresses.
+                     */
 
-                    if ((prefixopt->flags & ICMPv6_PRFX_FLAG_A) != 0)
+                    if ((adv->flags & ICMPv6_RADV_FLAG_M) == 0 &&
+                        (prefixopt->flags & ICMPv6_PRFX_FLAG_A) != 0)
                       {
-                        /* Yes.. Set the new network addresses. */
-
-                        icmpv6_setaddresses(dev, ipv6->srcipaddr,
+                         icmpv6_setaddresses(dev, ipv6->srcipaddr,
                                     prefixopt->prefix, prefixopt->preflen);
-
-                        /* Notify any waiting threads */
-
-                        icmpv6_rnotify(dev);
-                        prefix = true;
                       }
+
+                      /* Notify any waiting threads */
+
+                      icmpv6_rnotify(dev, (adv->flags & ICMPv6_RADV_FLAG_M) ?
+                                          -EADDRNOTAVAIL : OK);
+                      prefix = true;
                   }
                   break;
 

--- a/net/icmpv6/icmpv6_rnotify.c
+++ b/net/icmpv6/icmpv6_rnotify.c
@@ -289,7 +289,7 @@ int icmpv6_rwait(FAR struct icmpv6_rnotify_s *notify, unsigned int timeout)
  *
  ****************************************************************************/
 
-void icmpv6_rnotify(FAR struct net_driver_s *dev)
+void icmpv6_rnotify(FAR struct net_driver_s *dev, int result)
 {
   FAR struct icmpv6_rnotify_s *curr;
 
@@ -309,7 +309,7 @@ void icmpv6_rnotify(FAR struct net_driver_s *dev)
         {
           /* And signal the waiting, returning success */
 
-          curr->rn_result = OK;
+          curr->rn_result = result;
           nxsem_post(&curr->rn_sem);
           break;
         }


### PR DESCRIPTION
## Summary
 When receiving Router Advertisement Message, if Managed Address Configuration flag is set, we should ignore the Autonomous Address-configuration flag, and obtain the IPv6 address via the stateful process.

## Impact
The change will affect the process of obtaining IPv6 address.

## Testing
We can use radvd to simulte the IPv6 server, and control the RA flags by turning on or off the `AdvManagedFlag` field.
- open the `NET_ICMPv6_AUTOCONF`;
- then, get the IPv6 address by `renew6`;
- and check the result with `ifconfig`;

The radvd configuration is as follows:
```
interface nuttx0 {
        IgnoreIfMissing on;
        AdvSendAdvert on;
        MinRtrAdvInterval 200;
        MaxRtrAdvInterval 600;
        AdvOtherConfigFlag on;
        AdvManagedFlag on;
        AdvLinkMTU 1500;
        prefix 2408:501:ffff:abc::/64 {
                AdvOnLink on;
                AdvAutonomous on;
                AdvRouterAddr off;
                AdvValidLifetime 600;
                AdvPreferredLifetime 600;
        };
        route 2408:501:ffff:f01::/64 {
        };
};
```