### PR TITLE
NXP S32K3xx Fixes stuttering output 

### DIFF
--- a/arch/arm/src/s32k3xx/s32k3xx_edma.h
+++ b/arch/arm/src/s32k3xx/s32k3xx_edma.h
@@ -1,7 +1,7 @@
 /****************************************************************************
  * arch/arm/src/s32k3xx/s32k3xx_edma.h
  *
- *   Copyright (C) 2019, 2021 Gregory Nutt. All rights reserved.
+ *   Copyright (C) 2019, 2021, 2023 Gregory Nutt. All rights reserved.
  *   Copyright 2022 NXP
  *   Authors: Gregory Nutt <gnutt@nuttx.org>
  *            David Sidrane <david.sidrane@nscdg.com>
@@ -430,6 +430,20 @@ void s32k3xx_dmach_stop(DMACH_HANDLE handle);
  ****************************************************************************/
 
 unsigned int s32k3xx_dmach_getcount(DMACH_HANDLE *handle);
+
+/****************************************************************************
+ * Name: s32k3xx_dmach_idle
+ *
+ * Description:
+ *   This function checks if the dma is idle
+ *
+ * Returned Value:
+ *   0  - if idle
+ *   !0 - not
+ *
+ ****************************************************************************/
+
+unsigned int s32k3xx_dmach_idle(DMACH_HANDLE handle);
 
 /****************************************************************************
  * Name: s32k3xx_dmasample


### PR DESCRIPTION
## Summary

Fixes stuttering output.

The use of the semaphore was causing blocking
on non blocking callers. This ensured that
the TX DAM would be restated, but when it
was switched to trywait in https://github.com/apache/nuttx/commit/8362e3147e8000ea70f622fd02fbcafbcfef1a2b, it left
data in the xmit queue unsent.

This solution removes the semaphore and restart
the DMA on completion if there is more data in
the xmit queue to be sent.

This prevents dma stop operations called of a completion
   call back from rentering, the callback and ensures that
   the call back will see the idle state.
## Impact

Fixes issue with TXDMA  stuttering output.

## Testing

nxp_mr-canhubk3_fmu
