### PR TITLE
samv7/sam_emac.c: fix compile error with unknown structure member

### DIFF
--- a/arch/arm/src/samv7/sam_emac.c
+++ b/arch/arm/src/samv7/sam_emac.c
@@ -3751,6 +3751,7 @@ static int sam_autonegotiate(struct sam_emac_s *priv)
       goto errout;
     }
 
+#if defined(CONFIG_NETDEV_PHY_IOCTL) && defined(CONFIG_ARCH_PHY_INTERRUPT)
   if (priv->phytype == SAMV7_PHY_KSZ8061)
     {
       ret = sam_phywrite(priv, priv->phyaddr, MII_MMDCONTROL, 0x0001);
@@ -3781,6 +3782,7 @@ static int sam_autonegotiate(struct sam_emac_s *priv)
           goto errout;
         }
     }
+#endif
 
   /* Restart Auto_negotiation */
 


### PR DESCRIPTION
## Summary
```
chip/sam_emac.c:3754:11: error: 'struct sam_emac_s' has no member named 'phytype'
 3754 |   if (priv->phytype == SAMV7_PHY_KSZ8061)
      |           ^~
make[3]: *** [Makefile:167: sam_emac.o] Error 1
```

Member phytype is available only if `CONFIG_NETDEV_PHY_IOCTL` and `CONFIG_ARCH_PHY_INTERRUPT` is set.

## Impact
Build fix

## Testing
Build pass.
