### PR TITLE
ci_sim01: install g++-multilib into docker to support libcxx

### DIFF
--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -273,6 +273,7 @@ RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" apt-get install -y -q
   ccache \
   clang \
   clang-tidy \
+  g++-multilib \
   gcc-avr \
   gcc-multilib \
   genromfs \


### PR DESCRIPTION
## Summary
fix build break:
/usr/bin/ld: skipping incompatible /usr/lib/gcc/x86_64-linux-gnu/11/libstdc++.so when searching for -lstdc++ /usr/bin/ld: skipping incompatible /usr/lib/gcc/x86_64-linux-gnu/11/libstdc++.a when searching for -lstdc++ /usr/bin/ld: cannot find -lstdc++: No such file or directory /usr/bin/ld: skipping incompatible /usr/lib/gcc/x86_64-linux-gnu/11/libstdc++.so when searching for -lstdc++ collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
## Impact

## Testing
sim:local
