### PR TITLE
xtensa/esp32s3: QSPI disable DMA when sending command to slave

### DIFF
--- a/arch/xtensa/src/esp32s3/esp32s3_qspi.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_qspi.c
@@ -725,6 +725,17 @@ static int esp32s3_qspi_command(struct qspi_dev_s *dev,
 
   /* Initiliaze QSPI user register */
 
+#ifdef CONFIG_ESP32S3_SPI_DMA
+
+  /* Disable QSPI DMA */
+
+  regval  = getreg32(SPI_DMA_CONF_REG(id));
+  regval &= ~(SPI_DMA_TX_ENA_M | SPI_DMA_RX_ENA_M);
+  putreg32(regval, SPI_DMA_CONF_REG(id));
+
+  putreg32(0, SPI_DMA_INT_ENA_REG(id));
+#endif
+
   user_reg &= ~(SPI_USR_ADDR_M |
                 SPI_USR_MOSI_M |
                 SPI_USR_MISO_M |
@@ -753,7 +764,8 @@ static int esp32s3_qspi_command(struct qspi_dev_s *dev,
 
       user_reg |= SPI_USR_ADDR_M;
 
-      putreg32(cmdinfo->addr, SPI_ADDR_REG(id));
+      regval = cmdinfo->addr << (32 - cmdinfo->addrlen * 8);
+      putreg32(regval, SPI_ADDR_REG(id));
     }
 
   /* Set dummy */
@@ -944,7 +956,8 @@ static int esp32s3_qspi_memory(struct qspi_dev_s *dev,
   user1_reg &= ~SPI_USR_ADDR_BITLEN_M;
   user1_reg |= (meminfo->addrlen * 8 - 1) << SPI_USR_ADDR_BITLEN_S;
 
-  putreg32(meminfo->addr, SPI_ADDR_REG(id));
+  regval = meminfo->addr << (32 - meminfo->addrlen * 8);
+  putreg32(regval, SPI_ADDR_REG(id));
 
   /* Set dummy */
 


### PR DESCRIPTION
## Summary

QSPI disable DMA when sending command to slave.

## Impact

## Testing

