### PR TITLE
esp32s3: remove an extra S from ESP32S3S_SPI_FLASH_USE_32BIT_ADDRESS

### DIFF
--- a/arch/xtensa/src/esp32s3/Kconfig
+++ b/arch/xtensa/src/esp32s3/Kconfig
@@ -233,7 +233,7 @@ config ESP32S3_FLASH_16M
 config ESP32S3_FLASH_32M
 	bool
 	default n
-	select ESP32S3S_SPI_FLASH_USE_32BIT_ADDRESS
+	select ESP32S3_SPI_FLASH_USE_32BIT_ADDRESS
 
 config ESP32S3_ESPTOOLPY_NO_STUB
 	bool "Disable download stub"
@@ -1753,7 +1753,7 @@ config ESP32S3_SPI_FLASH_DONT_USE_ROM_CODE
 		Use source code for SPI flash driver instead of functions
 		in ROM.
 
-config ESP32S3S_SPI_FLASH_USE_32BIT_ADDRESS
+config ESP32S3_SPI_FLASH_USE_32BIT_ADDRESS
 	bool "SPI flash uses 32-bit address"
 	default n
 	select ESP32S3_SPI_FLASH_DONT_USE_ROM_CODE

--- a/arch/xtensa/src/esp32s3/esp32s3_spiflash.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_spiflash.c
@@ -118,7 +118,7 @@
 
 /* SPI flash operation */
 
-#  ifdef CONFIG_ESP32S3S_SPI_FLASH_USE_32BIT_ADDRESS
+#  ifdef CONFIG_ESP32S3_SPI_FLASH_USE_32BIT_ADDRESS
 #    define ADDR_BITS(addr)         (((addr) & 0xff000000) ? 32 : 24)
 #    define READ_CMD(addr)          (ADDR_BITS(addr) == 32 ? FLASH_CMD_FSTRD4B : \
                                                              FLASH_CMD_FSTRD)


### PR DESCRIPTION
## Summary
esp32s3: remove an extra S from ESP32S3S_SPI_FLASH_USE_32BIT_ADDRESS

## Impact

## Testing

