### PR TITLE
mempool:change sq to dq,free to head, alloc form tail

### DIFF
--- a/include/nuttx/mm/mempool.h
+++ b/include/nuttx/mm/mempool.h
@@ -61,6 +61,8 @@ typedef CODE FAR void *(*mempool_alloc_t)(FAR struct mempool_s *pool,
                                           size_t size);
 typedef CODE void (*mempool_free_t)(FAR struct mempool_s *pool,
                                     FAR void *addr);
+typedef CODE void (*mempool_check_t)(FAR struct mempool_s *pool,
+                                     FAR void *addr);
 
 typedef CODE FAR void *(*mempool_multiple_alloc_t)(FAR void *arg,
                                                    size_t alignment,
@@ -100,13 +102,14 @@ struct mempool_s
   FAR void  *priv;          /* This pointer is used to store the user's private data */
   mempool_alloc_t alloc;    /* The alloc function for mempool */
   mempool_free_t  free;     /* The free function for mempool */
+  mempool_check_t check;    /* The check function for mempool */
 
   /* Private data for memory pool */
 
   FAR char  *ibase;   /* The inerrupt mempool base pointer */
-  sq_queue_t queue;   /* The free block queue in normal mempool */
-  sq_queue_t iqueue;  /* The free block queue in interrupt mempool */
-  sq_queue_t equeue;  /* The expand block queue for normal mempool */
+  dq_queue_t queue;   /* The free block queue in normal mempool */
+  dq_queue_t iqueue;  /* The free block queue in interrupt mempool */
+  dq_queue_t equeue;  /* The expand block queue for normal mempool */
 #if CONFIG_MM_BACKTRACE >= 0
   struct list_node alist;     /* The used block list in mempool */
 #else

--- a/include/nuttx/queue.h
+++ b/include/nuttx/queue.h
@@ -162,6 +162,9 @@
   for((p) = (q)->head, (tmp) = (p) ? (p)->flink : NULL; \
       (p) != NULL; (p) = (tmp), (tmp) = (p) ? (p)->flink : NULL)
 
+#define dq_for_every(q, p) sq_for_every(q, p)
+#define dq_for_every_safe(q, p, tmp) sq_for_every_safe(q, p, tmp)
+
 #define sq_rem(p, q) \
   do \
     { \

--- a/mm/mempool/mempool.c
+++ b/mm/mempool/mempool.c
@@ -46,41 +46,54 @@
  * Private Functions
  ****************************************************************************/
 
-static inline FAR sq_entry_t *mempool_remove_queue(FAR sq_queue_t *queue)
+static inline FAR dq_entry_t *
+mempool_remove_queue(FAR struct mempool_s *pool, FAR dq_queue_t *queue)
 {
-  if (!sq_empty(queue))
-    {
-      FAR sq_entry_t *entry = queue->head;
+  FAR dq_entry_t *ret = queue->tail;
 
-      queue->head = entry->flink;
-      return entry;
-    }
-  else
+  if (ret)
     {
-      return NULL;
+      FAR dq_entry_t *prev = ret->blink;
+      if (prev == NULL)
+        {
+          queue->head = NULL;
+          queue->tail = NULL;
+        }
+      else
+        {
+          pool->check(pool, prev);
+          queue->tail = prev;
+          prev->flink = NULL;
+        }
+
+      ret->flink = NULL;
+      ret->blink = NULL;
     }
+
+  return ret;
 }
 
-static inline size_t mempool_queue_lenth(FAR sq_queue_t *queue)
-{
-  FAR sq_entry_t *node;
-  size_t count;
-
-  for (node = queue->head, count = 0;
-       node != NULL;
-       node = node->flink, count++);
-
-  return count;
-}
-
-static inline void mempool_add_queue(FAR sq_queue_t *queue,
+static inline void mempool_add_queue(FAR dq_queue_t *queue,
                                      FAR char *base, size_t nblks,
                                      size_t blocksize)
 {
   while (nblks-- > 0)
     {
-      sq_addfirst((FAR sq_entry_t *)(base + blocksize * nblks), queue);
+      dq_addfirst((FAR dq_entry_t *)(base + blocksize * nblks), queue);
     }
+}
+
+static size_t mempool_dq_count(FAR dq_queue_t *queue)
+{
+  FAR dq_entry_t *entry;
+  size_t count = 0;
+
+  dq_for_every(queue, entry)
+    {
+      count++;
+    }
+
+  return count;
 }
 
 #if CONFIG_MM_BACKTRACE >= 0
@@ -134,9 +147,9 @@ int mempool_init(FAR struct mempool_s *pool, FAR const char *name)
 {
   size_t blocksize = MEMPOOL_REALBLOCKSIZE(pool);
 
-  sq_init(&pool->queue);
-  sq_init(&pool->iqueue);
-  sq_init(&pool->equeue);
+  dq_init(&pool->queue);
+  dq_init(&pool->iqueue);
+  dq_init(&pool->equeue);
 
 #if CONFIG_MM_BACKTRACE >= 0
   list_initialize(&pool->alist);
@@ -163,10 +176,10 @@ int mempool_init(FAR struct mempool_s *pool, FAR const char *name)
       pool->ibase = NULL;
     }
 
-  if (pool->initialsize >= blocksize + sizeof(sq_entry_t))
+  if (pool->initialsize >= blocksize + sizeof(dq_entry_t))
     {
-      size_t ninitial = (pool->initialsize - sizeof(sq_entry_t)) / blocksize;
-      size_t size = ninitial * blocksize + sizeof(sq_entry_t);
+      size_t ninitial = (pool->initialsize - sizeof(dq_entry_t)) / blocksize;
+      size_t size = ninitial * blocksize + sizeof(dq_entry_t);
       FAR char *base;
 
       base = pool->alloc(pool, size);
@@ -181,7 +194,7 @@ int mempool_init(FAR struct mempool_s *pool, FAR const char *name)
         }
 
       mempool_add_queue(&pool->queue, base, ninitial, blocksize);
-      sq_addlast((FAR sq_entry_t *)(base + ninitial * blocksize),
+      dq_addlast((FAR dq_entry_t *)(base + ninitial * blocksize),
                   &pool->equeue);
       kasan_poison(base, size);
     }
@@ -221,17 +234,17 @@ int mempool_init(FAR struct mempool_s *pool, FAR const char *name)
 
 FAR void *mempool_alloc(FAR struct mempool_s *pool)
 {
-  FAR sq_entry_t *blk;
+  FAR dq_entry_t *blk;
   irqstate_t flags;
 
 retry:
   flags = spin_lock_irqsave(&pool->lock);
-  blk = mempool_remove_queue(&pool->queue);
+  blk = mempool_remove_queue(pool, &pool->queue);
   if (blk == NULL)
     {
       if (up_interrupt_context())
         {
-          blk = mempool_remove_queue(&pool->iqueue);
+          blk = mempool_remove_queue(pool, &pool->iqueue);
           if (blk == NULL)
             {
               goto out_with_lock;
@@ -242,11 +255,11 @@ retry:
           size_t blocksize = MEMPOOL_REALBLOCKSIZE(pool);
 
           spin_unlock_irqrestore(&pool->lock, flags);
-          if (pool->expandsize >= blocksize + sizeof(sq_entry_t))
+          if (pool->expandsize >= blocksize + sizeof(dq_entry_t))
             {
-              size_t nexpand = (pool->expandsize - sizeof(sq_entry_t)) /
+              size_t nexpand = (pool->expandsize - sizeof(dq_entry_t)) /
                                blocksize;
-              size_t size = nexpand * blocksize + sizeof(sq_entry_t);
+              size_t size = nexpand * blocksize + sizeof(dq_entry_t);
               FAR char *base = pool->alloc(pool, size);
 
               if (base == NULL)
@@ -257,9 +270,9 @@ retry:
               kasan_poison(base, size);
               flags = spin_lock_irqsave(&pool->lock);
               mempool_add_queue(&pool->queue, base, nexpand, blocksize);
-              sq_addlast((FAR sq_entry_t *)(base + nexpand * blocksize),
+              dq_addlast((FAR dq_entry_t *)(base + nexpand * blocksize),
                          &pool->equeue);
-              blk = mempool_remove_queue(&pool->queue);
+              blk = mempool_remove_queue(pool, &pool->queue);
             }
           else if (!pool->wait ||
                    nxsem_wait_uninterruptible(&pool->waitsem) < 0)
@@ -325,16 +338,16 @@ void mempool_free(FAR struct mempool_s *pool, FAR void *blk)
       if ((FAR char *)blk >= pool->ibase &&
           (FAR char *)blk < pool->ibase + pool->interruptsize - blocksize)
         {
-          sq_addfirst(blk, &pool->iqueue);
+          dq_addfirst(blk, &pool->iqueue);
         }
       else
         {
-          sq_addfirst(blk, &pool->queue);
+          dq_addfirst(blk, &pool->queue);
         }
     }
   else
     {
-      sq_addfirst(blk, &pool->queue);
+      dq_addfirst(blk, &pool->queue);
     }
 
   kasan_poison(blk, pool->blocksize);
@@ -373,15 +386,14 @@ int mempool_info(FAR struct mempool_s *pool, FAR struct mempoolinfo_s *info)
   DEBUGASSERT(pool != NULL && info != NULL);
 
   flags = spin_lock_irqsave(&pool->lock);
-  info->ordblks = mempool_queue_lenth(&pool->queue);
-  info->iordblks = mempool_queue_lenth(&pool->iqueue);
+  info->ordblks = mempool_dq_count(&pool->queue);
+  info->iordblks = mempool_dq_count(&pool->iqueue);
 #if CONFIG_MM_BACKTRACE >= 0
   info->aordblks = list_length(&pool->alist);
 #else
   info->aordblks = pool->nalloc;
 #endif
-  info->arena =
-    mempool_queue_lenth(&pool->equeue) * sizeof(sq_entry_t) +
+  info->arena = mempool_dq_count(&pool->equeue) * sizeof(dq_entry_t) +
     (info->aordblks + info->ordblks + info->iordblks) * blocksize;
   spin_unlock_irqrestore(&pool->lock, flags);
   info->sizeblks = blocksize;
@@ -417,8 +429,8 @@ mempool_info_task(FAR struct mempool_s *pool,
 
   if (task->pid == PID_MM_FREE)
     {
-      size_t count = mempool_queue_lenth(&pool->queue) +
-                     mempool_queue_lenth(&pool->iqueue);
+      size_t count = mempool_dq_count(&pool->queue) +
+                     mempool_dq_count(&pool->iqueue);
 
       info.aordblks += count;
       info.uordblks += count * blocksize;
@@ -479,15 +491,15 @@ void mempool_memdump(FAR struct mempool_s *pool,
 
   if (dump->pid == PID_MM_FREE)
     {
-      FAR sq_entry_t *entry;
+      FAR dq_entry_t *entry;
 
-      sq_for_every(&pool->queue, entry)
+      dq_for_every(&pool->queue, entry)
         {
           syslog(LOG_INFO, "%12zu%*p\n",
                  blocksize, MM_PTR_FMT_WIDTH, (FAR char *)entry);
         }
 
-      sq_for_every(&pool->iqueue, entry)
+      dq_for_every(&pool->iqueue, entry)
         {
           syslog(LOG_INFO, "%12zu%*p\n",
                  blocksize, MM_PTR_FMT_WIDTH, (FAR char *)entry);
@@ -542,7 +554,7 @@ void mempool_memdump(FAR struct mempool_s *pool,
 int mempool_deinit(FAR struct mempool_s *pool)
 {
   size_t blocksize = MEMPOOL_REALBLOCKSIZE(pool);
-  FAR sq_entry_t *blk;
+  FAR dq_entry_t *blk;
   size_t count = 0;
 
 #if CONFIG_MM_BACKTRACE >= 0
@@ -554,16 +566,16 @@ int mempool_deinit(FAR struct mempool_s *pool)
       return -EBUSY;
     }
 
-  if (pool->initialsize >= blocksize + sizeof(sq_entry_t))
+  if (pool->initialsize >= blocksize + sizeof(dq_entry_t))
     {
-      count = (pool->initialsize - sizeof(sq_entry_t)) / blocksize;
+      count = (pool->initialsize - sizeof(dq_entry_t)) / blocksize;
     }
 
   if (count == 0)
     {
-      if (pool->expandsize >= blocksize + sizeof(sq_entry_t))
+      if (pool->expandsize >= blocksize + sizeof(dq_entry_t))
         {
-          count = (pool->expandsize - sizeof(sq_entry_t)) / blocksize;
+          count = (pool->expandsize - sizeof(dq_entry_t)) / blocksize;
         }
     }
 
@@ -571,13 +583,13 @@ int mempool_deinit(FAR struct mempool_s *pool)
   mempool_procfs_unregister(&pool->procfs);
 #endif
 
-  while ((blk = mempool_remove_queue(&pool->equeue)) != NULL)
+  while ((blk = mempool_remove_queue(pool, &pool->equeue)) != NULL)
     {
-      blk = (FAR sq_entry_t *)((FAR char *)blk - count * blocksize);
+      blk = (FAR dq_entry_t *)((FAR char *)blk - count * blocksize);
       pool->free(pool, blk);
-      if (pool->expandsize >= blocksize + sizeof(sq_entry_t))
+      if (pool->expandsize >= blocksize + sizeof(dq_entry_t))
         {
-          count = (pool->expandsize - sizeof(sq_entry_t)) / blocksize;
+          count = (pool->expandsize - sizeof(dq_entry_t)) / blocksize;
         }
     }
 

--- a/mm/mempool/mempool_multiple.c
+++ b/mm/mempool/mempool_multiple.c
@@ -335,6 +335,26 @@ mempool_multiple_get_dict(FAR struct mempool_multiple_s *mpool,
 }
 
 /****************************************************************************
+ * Name: mempool_multiple_check
+ *
+ * Description:
+ *   Check the blk is in the pool
+ *
+ * Input Parameters:
+ *   mpool - The handle of the multiple memory pool to be used.
+ *   blk   - The pointer of memory block.
+ *
+ ****************************************************************************/
+
+static void mempool_multiple_check(FAR struct mempool_s *pool,
+                                   FAR void *blk)
+{
+  FAR struct mempool_multiple_s *mpool = pool->priv;
+
+  assert(mempool_multiple_get_dict(mpool, blk));
+}
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -439,6 +459,8 @@ mempool_multiple_init(FAR const char *name,
       pools[i].priv = mpool;
       pools[i].alloc = mempool_multiple_alloc_callback;
       pools[i].free = mempool_multiple_free_callback;
+      pools[i].check = mempool_multiple_check;
+
       ret = mempool_init(pools + i, name);
       if (ret < 0)
         {


### PR DESCRIPTION
## Summary
Mempool:Change single queue to double queue and add more checks
## Impact
mempool
## Testing
sim with mm_testing & mempool


add santiy check for used after free
Using a double linked queue can allow the free memory
to be malloced out in the end.
Use tools (Kasan) as much as possible to check
the memory stampede problem without causing
speed reduction or memory usage.
