### PR TITLE
trying to fix CI: pin external action to the specific git hash

### DIFF
--- a/.github/workflows/docker_linux.yml
+++ b/.github/workflows/docker_linux.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
         with:
           # this might remove tools that are actually needed,
           # if set to "true" but frees about 6 GB


### PR DESCRIPTION
## Summary
trying to fix CI: pin external action to the specific git hash
according to: https://infra.apache.org/github-actions-policy.html
## Impact

## Testing
none
