### PR TITLE
usbdev: Add callback for CONFIG_USBDEV_SOFINTERRUPT

### DIFF
--- a/arch/arm/src/efm32/efm32_usbdev.c
+++ b/arch/arm/src/efm32/efm32_usbdev.c
@@ -3673,6 +3673,7 @@ static int efm32_usbinterrupt(int irq, void *context, void *arg)
           usbtrace(TRACE_INTDECODE(EFM32_TRACEINTID_SOF),
                   (uint16_t)regval);
           efm32_putreg(USB_GINTSTS_SOF, EFM32_USB_GINTSTS);
+          usbdev_sof_irq(&priv->usbdev, efm32_getframe(&priv->usbdev));
         }
 #endif
 

--- a/arch/arm/src/stm32/stm32_otgfsdev.c
+++ b/arch/arm/src/stm32/stm32_otgfsdev.c
@@ -3759,6 +3759,7 @@ static int stm32_usbinterrupt(int irq, void *context, void *arg)
       if ((regval & OTGFS_GINT_SOF) != 0)
         {
           usbtrace(TRACE_INTDECODE(STM32_TRACEINTID_SOF), (uint16_t)regval);
+          usbdev_sof_irq(&priv->usbdev, stm32_getframe(&priv->usbdev));
         }
 #endif
 

--- a/arch/arm/src/stm32f7/stm32_otgdev.c
+++ b/arch/arm/src/stm32f7/stm32_otgdev.c
@@ -3782,6 +3782,7 @@ static int stm32_usbinterrupt(int irq, void *context, void *arg)
       if ((regval & OTG_GINT_SOF) != 0)
         {
           usbtrace(TRACE_INTDECODE(STM32_TRACEINTID_SOF), (uint16_t) regval);
+          usbdev_sof_irq(&priv->usbdev, stm32_getframe(&priv->usbdev));
         }
 #  endif
 

--- a/arch/arm/src/stm32h7/stm32_otgdev.c
+++ b/arch/arm/src/stm32h7/stm32_otgdev.c
@@ -3769,6 +3769,7 @@ static int stm32_usbinterrupt(int irq, void *context, void *arg)
         {
           usbtrace(TRACE_INTDECODE(STM32_TRACEINTID_SOF),
                   (uint16_t)regval);
+          usbdev_sof_irq(&priv->usbdev, stm32_getframe(&priv->usbdev));
         }
 #endif
 

--- a/arch/arm/src/stm32l4/stm32l4_otgfsdev.c
+++ b/arch/arm/src/stm32l4/stm32l4_otgfsdev.c
@@ -3811,6 +3811,7 @@ static int stm32l4_usbinterrupt(int irq, void *context, void *arg)
         {
           usbtrace(TRACE_INTDECODE(STM32L4_TRACEINTID_SOF),
                   (uint16_t)regval);
+          usbdev_sof_irq(&priv->usbdev, stm32l4_getframe(&priv->usbdev));
         }
 #endif
 

--- a/arch/xtensa/src/esp32s3/esp32s3_otg_device.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_otg_device.c
@@ -3724,6 +3724,7 @@ static int esp32s3_usbinterrupt(int irq, void *context, void *arg)
         {
           usbtrace(TRACE_INTDECODE(ESP32S3_TRACEINTID_SOF),
                    (uint16_t)regval);
+          usbdev_sof_irq(&priv->usbdev, esp32s3_getframe(&priv->usbdev));
         }
 #endif
 

--- a/drivers/usbdev/Kconfig
+++ b/drivers/usbdev/Kconfig
@@ -50,6 +50,14 @@ config USBDEV_MAXPOWER
 		the device is bus powered (USBDEV_BUSPOWERED).  It is, however, used
 		unconditionally in several USB device drivers.
 
+config USBDEV_SOFINTERRUPT
+	bool "Enable USB device SOF interrupts"
+	default n
+	---help---
+		Enable USB start-of-frame interrupts.
+		Can be used for synchronizing to host clock rate.
+		Board logic must provide usbdev_sof_irq() function.
+
 config USBDEV_DMA
 	bool "Enable DMA methods"
 	default n

--- a/include/nuttx/usb/usbdev.h
+++ b/include/nuttx/usb/usbdev.h
@@ -480,6 +480,19 @@ FAR void *usbdev_dma_alloc(size_t size);
 void usbdev_dma_free(FAR void *memory);
 #endif
 
+/****************************************************************************
+ * Name: up_usbdev_sof_irq
+ *
+ * Description:
+ *   If CONFIG_USBDEV_SOFINTERRUPT is enabled, board logic must provide
+ *   this function. It gets called in interrupt mode by USB device code
+ *   every time start-of-frame USB packet is received from host.
+ *
+ ****************************************************************************/
+#ifdef CONFIG_USBDEV_SOFINTERRUPT
+void usbdev_sof_irq(FAR struct usbdev_s *dev, uint16_t frameno);
+#endif
+
 #undef EXTERN
 #if defined(__cplusplus)
 }


### PR DESCRIPTION
## Summary

The option `CONFIG_USBDEV_SOFINTERRUPT` has existed in architecture USB drivers for a long time now.
The implementation was not fully finished though, as Kconfig entry was missing and the interrupt handler did nothing.

Previously we had a local patch to call a custom callback function, used to synchronize clocks between USB devices.
This pull request adds a generally usable `usbdev_sof_irq()` callback that would be implemented by board logic.

## Impact

No impact it `CONFIG_USBDEV_SOFINTERRUPT` is not enabled (as it typically wouldn't be, as it wasn't in Kconfig previously).
When it is enabled, `usbdev_sof_irq()` function must be added to board logic.

## Testing

Tested on custom STM32H417 board.
Implementations for other hardware was added based on similar structure of code.