### PR TITLE
ci/docker: Fix " Could not find GN_EXECUTABLEXX using the following names: gn"

### DIFF
--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -417,7 +417,7 @@ ENV WASI_SDK_PATH="/tools/wasi-sdk"
 ENV PATH="/tools/wamr:$PATH"
 
 # gn tool
-COPY --from=nuttx-tools /tools/gn/ /tools/gn/out/
+COPY --from=nuttx-tools /tools/gn/ /tools/gn/gn/out/
 ENV PATH="/tools/gn:$PATH"
 
 # ZAP tool and nodejs packet


### PR DESCRIPTION
## Summary

report here:
https://github.com/apache/nuttx-apps/actions/runs/7149109828/job/19470959712?pr=2225
regression by:
https://github.com/apache/nuttx/pull/11345

## Impact

ci

## Testing

ci