### PR TITLE
procfs/cpuinfo: Zero copylen in cpuinfo_read

### DIFF
--- a/fs/procfs/fs_procfscpuinfo.c
+++ b/fs/procfs/fs_procfscpuinfo.c
@@ -157,6 +157,10 @@ static ssize_t cpuinfo_read(FAR struct file *filep, FAR char *buffer,
     {
       filep->f_pos += copylen;
     }
+  else
+    {
+      copylen = 0;
+    }
 
   return copylen;
 }


### PR DESCRIPTION
## Summary

to avoid return the negative number

## Impact

/proc/cpuinfo

## Testing

internal