### PR TITLE
Fix the issue about the generation of docker image

### DIFF
--- a/.github/workflows/docker_linux.yml
+++ b/.github/workflows/docker_linux.yml
@@ -73,11 +73,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Free Up Extra Disk Space
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/gch
       - name: Pre-build Disk Stats
         run: |
           df -h

--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -417,8 +417,8 @@ ENV WASI_SDK_PATH="/tools/wasi-sdk"
 ENV PATH="/tools/wamr:$PATH"
 
 # gn tool
-COPY --from=nuttx-tools /tools/gn/ /tools/gn/gn/out/
-ENV PATH="/tools/gn:$PATH"
+COPY --from=nuttx-tools /tools/gn/ /tools/gn/
+ENV PATH="/tools/gn/gn/out:$PATH"
 
 # ZAP tool and nodejs packet
 COPY --from=nuttx-tools /tools/zap/ /tools/zap/


### PR DESCRIPTION
## Summary

- Revert "CI: Free space on worker building container", see:
   https://github.com/apache/nuttx/pull/11343
- ci/docker: Revert the change about gn to unblock ci, reported here: 
  https://github.com/apache/nuttx/actions/runs/7155266012/job/19483732190?pr=11360)

## Impact

docker image

## Testing

ci