### PR TITLE
virtio.h: add virtio_has_feature api for virtio driver

### DIFF
--- a/include/nuttx/virtio/virtio.h
+++ b/include/nuttx/virtio/virtio.h
@@ -38,6 +38,9 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+#define virtio_has_feature(vdev, fbit) \
+      (((vdev)->features & (1UL << (fbit))) != 0)
+
 #define virtio_read_config_member(vdev, structname, member, ptr) \
       virtio_read_config((vdev), offsetof(structname, member), \
                          (ptr), sizeof(*(ptr)));


### PR DESCRIPTION
## Summary
Virtio driver can used this api to judge whether the this feature is supported by both virtio driver and device.

## Impact
New Virtio API

## Testing
New api, will be used by virtio driver(e.g., virtio-net, virtio-blk).
