### PR TITLE
lib_slcd: fix encode/decode of binary nibble to/from ascii hex

### DIFF
--- a/libs/libc/misc/lib_slcddecode.c
+++ b/libs/libc/misc/lib_slcddecode.c
@@ -87,7 +87,7 @@ static uint8_t slcd_nibble(uint8_t ascii)
     }
   else
     {
-      return ascii - 'a';
+      return ascii - 'a' + 10;
     }
 }
 

--- a/libs/libc/misc/lib_slcdencode.c
+++ b/libs/libc/misc/lib_slcdencode.c
@@ -60,7 +60,7 @@ static uint8_t slcd_nibble(uint8_t binary)
     }
   else
     {
-      return 'a' + binary;
+      return 'a' + binary - 10;
     }
 }
 


### PR DESCRIPTION
Binary nibble to/from ascii hex conversion was buggy on both lib_slcdencode and lib_slcddecode libraries.

This bug caused the slcd library to fail to decode 5-byte sequence command which have 'count' argument value bigger than 0x9.

