### PR TITLE
riscv/mmu: Extend MMU Flags to 64-bit for T-Head C906 and Svpbmt

### DIFF
--- a/arch/risc-v/src/common/riscv_mmu.c
+++ b/arch/risc-v/src/common/riscv_mmu.c
@@ -60,7 +60,7 @@ static const size_t g_pgt_sizes[] =
  ****************************************************************************/
 
 void mmu_ln_setentry(uint32_t ptlevel, uintptr_t lnvaddr, uintptr_t paddr,
-                     uintptr_t vaddr, uint32_t mmuflags)
+                     uintptr_t vaddr, uint64_t mmuflags)
 {
   uintptr_t *lntable = (uintptr_t *)lnvaddr;
   uint32_t   index;
@@ -136,7 +136,7 @@ void mmu_ln_restore(uint32_t ptlevel, uintptr_t lnvaddr, uintptr_t vaddr,
 }
 
 void mmu_ln_map_region(uint32_t ptlevel, uintptr_t lnvaddr, uintptr_t paddr,
-                       uintptr_t vaddr, size_t size, uint32_t mmuflags)
+                       uintptr_t vaddr, size_t size, uint64_t mmuflags)
 {
   uintptr_t end_paddr = paddr + size;
   size_t    page_size = g_pgt_sizes[ptlevel - 1];

--- a/arch/risc-v/src/common/riscv_mmu.h
+++ b/arch/risc-v/src/common/riscv_mmu.h
@@ -367,7 +367,7 @@ static inline uintptr_t mmu_get_satp_pgbase(void)
  ****************************************************************************/
 
 void mmu_ln_setentry(uint32_t ptlevel, uintptr_t lnvaddr, uintptr_t paddr,
-                     uintptr_t vaddr, uint32_t mmuflags);
+                     uintptr_t vaddr, uint64_t mmuflags);
 
 /****************************************************************************
  * Name: mmu_ln_getentry
@@ -448,7 +448,7 @@ void mmu_ln_restore(uint32_t ptlevel, uintptr_t lnvaddr, uintptr_t vaddr,
  ****************************************************************************/
 
 void mmu_ln_map_region(uint32_t ptlevel, uintptr_t lnvaddr, uintptr_t paddr,
-                       uintptr_t vaddr, size_t size, uint32_t mmuflags);
+                       uintptr_t vaddr, size_t size, uint64_t mmuflags);
 
 /****************************************************************************
  * Name: mmu_ln_map_region


### PR DESCRIPTION
## Summary

Currently RISC-V NuttX supports 32-bit MMU Flags inside a Page Table Entry. This PR extends the MMU Flags to 64-bit, to support T-Head C906 Core and the new RISC-V Svpbmt Extension.

T-Head C906 uses Bits 59 to 63 in a Leaf Page Table Entry to configure the Memory Type: Cacheable / Bufferable / Strongly-Ordered. For the upcoming port of NuttX to PINE64 Ox64 BL808 SBC, we need to set the Memory Type to Strongly-Ordered for I/O Memory, which requires 64-bit MMU Flags. [Details of C906 MMU](https://lupyuen.github.io/articles/plic3#t-head-errata)

Newer RISC-V Cores will use the Svpbmt Extension to configure the Memory Type (Cacheable / Strongly-Ordered). Svpbmt uses Bits 61 to 62 in a Leaf Page Table Entry to define the Memory Type. This also requires 64-bit MMU Flags. [Details of Svpbmt](https://github.com/riscv/riscv-isa-manual/blob/main/src/supervisor.adoc#svpbmt)

This PR modifies the Function Signatures of `mmu_ln_setentry()` and `mmu_ln_map_region()`. The parameter `mmuflags` changes from `uint32_t` to `uint64_t`.

## Impact

### For Sv39 MMU (64-bit RISC-V)

With this PR, T-Head C906 (Ox64 BL808) and Svpbmt MMUs will support the new Memory Types (Cacheable / Strongly-Ordered):

```c
/* T-Head C906 MMU requires Strong Order (Bit 63) and Shareable (Bit 60) for I/O Memory */
#define MMU_THEAD_SHAREABLE    (1ul << 60)
#define MMU_THEAD_STRONG_ORDER (1ul << 63)
#define MMU_THEAD_IO_FLAGS     (MMU_IO_FLAGS | MMU_THEAD_SHAREABLE | \
                                MMU_THEAD_STRONG_ORDER)
...
/* [Strong Order] Map I/O region, use enough large page tables for the IO region. */
mmu_ln_map_region(1, PGT_L1_VBASE, MMU_IO_BASE, MMU_IO_BASE,
                  MMU_IO_SIZE, MMU_THEAD_IO_FLAGS);

/* [Strong Order] Map the PLIC with L2 page table */
mmu_ln_map_region(2, PGT_L2_INT_PBASE, MMU_INT_BASE, MMU_INT_BASE,
                  MMU_INT_SIZE, MMU_THEAD_IO_FLAGS);
```

[(Source)](https://github.com/lupyuen2/wip-pinephone-nuttx/blob/bl808/arch/risc-v/src/bl808/bl808_mm_init.c#L43-L254)

### For Sv32 MMU (32-bit RISC-V)

Sv32 MMU only supports 32-bit MMU Flags. This PR will have no impact on Sv32 MMU.

We assume that NuttX will never use 64-bit MMU Flags for Sv32 MMU. Bits 32 to 63 of the MMU Flags will be ignored.

### For Sv48 and Sv57 MMUs (64-bit RISC-V)

NuttX doesn't support Sv48 and Sv57 MMUs yet. These MMUs will support the Svpbmt Extension, which will work with 64-bit MMU Flags.

## Testing

### For T-Head C906

This PR was tested successfully with the upcoming port of [NuttX for PINE64 Ox64 BL808 SBC](https://github.com/lupyuen2/wip-pinephone-nuttx/pull/43):

```bash
tools/configure.sh ox64:nsh
```

[NuttX Log for PINE64 Ox64 BL808 SBC](https://gist.github.com/lupyuen/19a2e9235eaf7272fb5aae14a340b815)

### For Sv39 MMU (64-bit RISC-V)

For Regression Testing, we tested with 64-bit QEMU and Sv39 MMU:

```bash
tools/configure.sh rv-virt:knsh64
```

[NuttX Log for QEMU RISC-V 64-bit (rv-virt:knsh64)](https://gist.github.com/lupyuen/207ede7dd2e3d5b6b7c63745b4aafb1a)

### For Sv32 MMU (32-bit RISC-V)

Also for Regression Testing, we tested with 32-bit QEMU and Sv32 MMU:

```bash
tools/configure.sh rv-virt:knsh32
```

[NuttX Log for QEMU RISC-V 32-bit (rv-virt:knsh32)](https://gist.github.com/lupyuen/6b609cecf1231840b176474db73d2815)
