### PR TITLE
stm32u5: fix EXTICR2,3,4 register offsets

### DIFF
--- a/arch/arm/src/stm32u5/hardware/stm32_exti.h
+++ b/arch/arm/src/stm32u5/hardware/stm32_exti.h
@@ -49,9 +49,9 @@
 #define STM32_EXTI_SECCFGR2_OFFSET   0x0034  /* Security Configuration 2         */
 #define STM32_EXTI_PRIVCFGR2_OFFSET  0x0038  /* Privilege Configuration 2        */
 #define STM32_EXTI_EXTICR1_OFFSET    0x0060  /* External Interrupt Selection 1   */
-#define STM32_EXTI_EXTICR2_OFFSET    0x0060  /* External Interrupt Selection 2   */
-#define STM32_EXTI_EXTICR3_OFFSET    0x0060  /* External Interrupt Selection 3   */
-#define STM32_EXTI_EXTICR4_OFFSET    0x0060  /* External Interrupt Selection 4   */
+#define STM32_EXTI_EXTICR2_OFFSET    0x0064  /* External Interrupt Selection 2   */
+#define STM32_EXTI_EXTICR3_OFFSET    0x0068  /* External Interrupt Selection 3   */
+#define STM32_EXTI_EXTICR4_OFFSET    0x006C  /* External Interrupt Selection 4   */
 #define STM32_EXTI_LOCKR_OFFSET      0x0070  /* Lock                             */
 #define STM32_EXTI_IMR1_OFFSET       0x0080  /* CPU Wakeup with Interrupt Mask 1 */
 #define STM32_EXTI_EMR1_OFFSET       0x0084  /* CPU Wakeup with Event Mask 1     */


### PR DESCRIPTION
## Summary

EXTI2,3,4 register offsets were the same as EXTICR1, possibly a typo. 

## Impact

Possibly no impact, I do not see any use in nuttx or nuttx-apps.

## Testing

Not tested.
