### PR TITLE
linux_Dockerfile: only copy gn binary into docker

### DIFF
--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -417,8 +417,9 @@ ENV WASI_SDK_PATH="/tools/wasi-sdk"
 ENV PATH="/tools/wamr:$PATH"
 
 # gn tool
-COPY --from=nuttx-tools /tools/gn/ /tools/gn/
-ENV PATH="/tools/gn/gn/out:$PATH"
+RUN mkdir -p /tools/gn
+COPY --from=nuttx-tools /tools/gn/gn/out/gn /tools/gn
+ENV PATH="/tools/gn:$PATH"
 
 # ZAP tool and nodejs packet
 COPY --from=nuttx-tools /tools/zap/ /tools/zap/


### PR DESCRIPTION
## Summary
Minimize the size of the docker image

## Impact

## Testing
sim:matter
