### PR TITLE
net/udp: Add check when sending too big packet without IP frag

### DIFF
--- a/drivers/net/netdev_upperhalf.c
+++ b/drivers/net/netdev_upperhalf.c
@@ -270,7 +270,16 @@ static int netdev_upper_txpoll(FAR struct net_driver_s *dev)
 #endif
 
   pkt = netpkt_get(dev, NETPKT_TX);
-  ret = lower->ops->transmit(lower, pkt);
+
+  if (netpkt_getdatalen(lower, pkt) > NETDEV_PKTSIZE(dev))
+    {
+      nerr("ERROR: Packet too long to send!\n");
+      ret = -EMSGSIZE;
+    }
+  else
+    {
+      ret = lower->ops->transmit(lower, pkt);
+    }
 
   if (ret != OK)
     {

--- a/net/udp/udp_sendto_buffered.c
+++ b/net/udp/udp_sendto_buffered.c
@@ -289,6 +289,16 @@ static int sendto_next_transfer(FAR struct udp_conn_s *conn)
       return -EHOSTUNREACH;
     }
 
+#ifndef CONFIG_NET_IPFRAG
+  /* Sanity check if the packet len (with IP hdr) is greater than the MTU */
+
+  if (wrb->wb_iob->io_pktlen > devif_get_mtu(dev))
+    {
+      nerr("ERROR: Packet too long to send!\n");
+      return -EMSGSIZE;
+    }
+#endif
+
   /* If this is not the same device that we used in the last call to
    * udp_callback_alloc(), then we need to release and reallocate the old
    * callback instance.


### PR DESCRIPTION
## Summary
Commit 8a63d29c removed `devif_iob_send` from `udp_sendto_buffered` workflow, `devif_iob_send` drops too big packet. Now we still need a place to check the packet length, otherwise a packet larger than MTU may be sent to the net driver.

In case of similar problem happens somewhere else, this commit also adds a check in `netdev_upperhalf`, and count these cases into `NETDEV_TXERRORS`.

## Impact
`udp_sendto_buffered`

## Testing
iperf with UDP TX LEN larger than 1472, without `CONFIG_NET_IPFRAG` enabled.

