### PR TITLE
riscv_pmp.c: Revert LOG2_CEIL back to run-time log2ceil function

### DIFF
--- a/arch/risc-v/src/common/riscv_pmp.c
+++ b/arch/risc-v/src/common/riscv_pmp.c
@@ -32,7 +32,6 @@
 #include <nuttx/compiler.h>
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
-#include <nuttx/lib/math32.h>
 
 #include "riscv_internal.h"
 
@@ -90,6 +89,32 @@ typedef struct pmp_entry_s pmp_entry_t;
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: log2ceil
+ *
+ * Description:
+ *   Calculate the up-rounded power-of-two for input.
+ *
+ * Input Parameters:
+ *   x - Argument to calculate the power-of-two from.
+ *
+ * Returned Value:
+ *   Power-of-two for argument, rounded up.
+ *
+ ****************************************************************************/
+
+static uintptr_t log2ceil(uintptr_t x)
+{
+  uintptr_t pot = 0;
+
+  for (x = x - 1; x; x >>= 1)
+    {
+      pot++;
+    }
+
+  return pot;
+}
+
+/****************************************************************************
  * Name: pmp_check_region_attrs
  *
  * Description:
@@ -143,7 +168,7 @@ static bool pmp_check_region_attrs(uintptr_t base, uintptr_t size,
 
         /* Get the power-of-two for size, rounded up */
 
-        if ((base & ((UINT64_C(1) << LOG2_CEIL(size)) - 1)) != 0)
+        if ((base & ((UINT64_C(1) << log2ceil(size)) - 1)) != 0)
           {
             /* The start address is not properly aligned with size */
 


### PR DESCRIPTION
## Summary
The macro LOG2_CEIL is intended to be used in the pre-processor phase. If used run-time it will generate a massive amount of extra code (~3.5K) which is a problem, as the PMP configuration is quite often executed from a first stage bootloader with a limited amount of code memory.

Code size differences pre- and post:

```
Memory region         Used Size  Region Size  %age Used
            envm:      112064 B     112384 B     99.72%

Memory region         Used Size  Region Size  %age Used
            envm:      108952 B     112384 B     96.95%
```

## Impact
Decrease code footprint of the PMP driver
## Testing
MPFS
