### PR TITLE
Support for setting MAC addresses of the virtio-net interfaces

### DIFF
--- a/openamp/0020-virtio-Add-the-virtio_negotiate_features-interface.patch
+++ b/openamp/0020-virtio-Add-the-virtio_negotiate_features-interface.patch
@@ -1,0 +1,41 @@
+From 49e9be3fee1c3f56e1891959965420550bbafa92 Mon Sep 17 00:00:00 2001
+From: liqinhui <liqinhui@xiaomi.com>
+Date: Mon, 4 Dec 2023 19:35:59 +0800
+Subject: [PATCH] virtio: Add the virtio_negotiate_features interface.
+
+Add the interface for the VIRTIO_NET_F_MAC feature.
+
+Change-Id: I51fcb0e5388a908ebf43912b793c061c9488e226
+Signed-off-by: liqinhui <liqinhui@xiaomi.com>
+---
+ lib/include/openamp/virtio.h | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/lib/include/openamp/virtio.h open-amp/lib/include/openamp/virtio.h
+index 6ef1746..e32dc16 100644
+--- a/lib/include/openamp/virtio.h
++++ open-amp/lib/include/openamp/virtio.h
+@@ -299,6 +299,20 @@ static inline void virtio_set_features(struct virtio_device *vdev,
+ 	return vdev->func->set_features(vdev, features);
+ }
+ 
++/**
++ * @brief Negotiate features between virtio device and driver.
++ *
++ * @param dev		Pointer to device structure.
++ * @param features	Supported features.
++ *
++ * @return The final features after negotiate.
++ */
++static inline uint32_t virtio_negotiate_features(struct virtio_device *vdev,
++                                                 uint32_t features)
++{
++	return vdev->func->negotiate_features(vdev, features);
++}
++
+ /**
+  * @brief Reset virtio device.
+  *
+-- 
+2.34.1
+

--- a/openamp/open-amp.cmake
+++ b/openamp/open-amp.cmake
@@ -74,6 +74,8 @@ if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/open-amp)
       ${CMAKE_CURRENT_LIST_DIR}/0018-virtio-decoupling-the-transport-layer-and-virtio-dev.patch
       && patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
       ${CMAKE_CURRENT_LIST_DIR}/0019-virtio.h-add-version-in-device-id-table.patch
+      && patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
+      ${CMAKE_CURRENT_LIST_DIR}/0020-virtio-Add-the-virtio_negotiate_features-interface.patch
     DOWNLOAD_NO_PROGRESS true
     TIMEOUT 30)
 

--- a/openamp/open-amp.defs
+++ b/openamp/open-amp.defs
@@ -66,6 +66,7 @@ open-amp.zip:
 	$(Q) patch -p0 < 0017-virtio-follow-virtio-1.2-spec-add-more-virtio-status.patch
 	$(Q) patch -p0 < 0018-virtio-decoupling-the-transport-layer-and-virtio-dev.patch
 	$(Q) patch -p0 < 0019-virtio.h-add-version-in-device-id-table.patch
+	$(Q) patch -p0 < 0020-virtio-Add-the-virtio_negotiate_features-interface.patch
 
 
 


### PR DESCRIPTION
## Summary
Initialize the MAC address of the virtio-net interfaces.

Refers to https://docs.oasis-open.org/virtio/virtio/v1.2/cs01/virtio-v1.2-cs01.html#x1-2230004
 A driver SHOULD negotiate VIRTIO_NET_F_MAC if the device offers it.
 If the driver negotiates the VIRTIO_NET_F_MAC feature, the driver MUST
 set the physical address of the NIC to mac. Otherwise, it SHOULD use a
 locally-administered MAC address.

## Impact
N/A
## Testing
When we start the multiple virtio-net interfaces, and the MAC address of each interface can be configured.
we can check it by the `ifconfig` command.
