### PR TITLE
ipv6: Fix source address with many addresses in same network

### DIFF
--- a/include/nuttx/net/netdev.h
+++ b/include/nuttx/net/netdev.h
@@ -1062,11 +1062,19 @@ int netdev_ipv6_del(FAR struct net_driver_s *dev, const net_ipv6addr_t addr,
  * Name: netdev_ipv6_srcaddr/srcifaddr
  *
  * Description:
- *   Get the source IPv6 address (RFC6724).
+ *   Get the source IPv6 address (RFC6724) to use for transmitted packets.
+ *   If we are responding to a received packet, use the destination address
+ *   from that packet. If we are initiating communication, pick a local
+ *   address that best matches the destination address.
+ *
+ * Input parameters:
+ *   dev - Network device that packet is being transmitted from
+ *   dst - Address to compare against when choosing local address.
  *
  * Returned Value:
- *   A pointer to the IPv6 address is returned on success.  It will never be
- *   NULL, but can be an address containing g_ipv6_unspecaddr.
+ *   A pointer to a net_ipv6addr_t contained in net_driver_s is returned on
+ *   success.  It will never be NULL, but can be an address containing
+ *   g_ipv6_unspecaddr.
  *
  * Assumptions:
  *   The caller has locked the network.

--- a/net/icmpv6/icmpv6_input.c
+++ b/net/icmpv6/icmpv6_input.c
@@ -543,11 +543,13 @@ void icmpv6_input(FAR struct net_driver_s *dev, unsigned int iplen)
          * ICMPv6 checksum before we return the packet.
          */
 
+        FAR const uint16_t *srcaddr;
+
         icmpv6->type = ICMPv6_ECHO_REPLY;
 
+        srcaddr = netdev_ipv6_srcaddr(dev, ipv6->destipaddr);
         net_ipv6addr_copy(ipv6->destipaddr, ipv6->srcipaddr);
-        net_ipv6addr_copy(ipv6->srcipaddr,
-                          netdev_ipv6_srcaddr(dev, ipv6->srcipaddr));
+        net_ipv6addr_copy(ipv6->srcipaddr, srcaddr);
 
         icmpv6->chksum = 0;
         icmpv6->chksum = ~icmpv6_chksum(dev, iplen);

--- a/net/icmpv6/icmpv6_reply.c
+++ b/net/icmpv6/icmpv6_reply.c
@@ -172,7 +172,7 @@ void icmpv6_reply(FAR struct net_driver_s *dev, int type, int code, int data)
   dev->d_len = ipicmplen + datalen;
 
   ipv6_build_header(IPv6BUF, dev->d_len - IPv6_HDRLEN, IP_PROTO_ICMP6,
-                    netdev_ipv6_srcaddr(dev, ipv6->srcipaddr),
+                    netdev_ipv6_srcaddr(dev, ipv6->destipaddr),
                     ipv6->srcipaddr, 255, 0);
 
   /* Initialize the ICMPv6 header */

--- a/net/inet/ipv6_getsockname.c
+++ b/net/inet/ipv6_getsockname.c
@@ -151,7 +151,7 @@ int ipv6_getsockname(FAR struct socket *psock, FAR struct sockaddr *addr,
 
   outaddr->sin6_family = AF_INET6;
   net_ipv6addr_copy(outaddr->sin6_addr.in6_u.u6_addr8,
-                    netdev_ipv6_srcaddr(dev, *ripaddr));
+                    netdev_ipv6_srcaddr(dev, *lipaddr));
   *addrlen = sizeof(struct sockaddr_in6);
 
   net_unlock();

--- a/net/netdev/netdev_ipv6.c
+++ b/net/netdev/netdev_ipv6.c
@@ -220,11 +220,19 @@ int netdev_ipv6_del(FAR struct net_driver_s *dev, const net_ipv6addr_t addr,
  * Name: netdev_ipv6_srcaddr/srcifaddr
  *
  * Description:
- *   Get the source IPv6 address (RFC6724).
+ *   Get the source IPv6 address (RFC6724) to use for transmitted packets.
+ *   If we are responding to a received packet, use the destination address
+ *   from that packet. If we are initiating communication, pick a local
+ *   address that best matches the destination address.
+ *
+ * Input parameters:
+ *   dev - Network device that packet is being transmitted from
+ *   dst - Address to compare against when choosing local address.
  *
  * Returned Value:
- *   A pointer to the IPv6 address is returned on success.  It will never be
- *   NULL, but can be an address containing g_ipv6_unspecaddr.
+ *   A pointer to a net_ipv6addr_t contained in net_driver_s is returned on
+ *   success.  It will never be NULL, but can be an address containing
+ *   g_ipv6_unspecaddr.
  *
  * Assumptions:
  *   The caller has locked the network.

--- a/net/tcp/tcp_send.c
+++ b/net/tcp/tcp_send.c
@@ -182,7 +182,7 @@ static void tcp_sendcommon(FAR struct net_driver_s *dev,
       ninfo("do IPv6 IP header build!\n");
       ipv6_build_header(IPv6BUF, dev->d_len - IPv6_HDRLEN,
                         IP_PROTO_TCP,
-                        netdev_ipv6_srcaddr(dev, conn->u.ipv6.raddr),
+                        netdev_ipv6_srcaddr(dev, conn->u.ipv6.laddr),
                         conn->u.ipv6.raddr,
                         conn->sconn.ttl, conn->sconn.s_tclass);
 
@@ -479,7 +479,7 @@ void tcp_reset(FAR struct net_driver_s *dev, FAR struct tcp_conn_s *conn)
 
       ipv6_build_header(ipv6, dev->d_len - IPv6_HDRLEN,
                         IP_PROTO_TCP,
-                        netdev_ipv6_srcaddr(dev, ipv6->srcipaddr),
+                        netdev_ipv6_srcaddr(dev, ipv6->destipaddr),
                         ipv6->srcipaddr,
                         conn ? conn->sconn.ttl : IP_TTL_DEFAULT,
                         conn ? conn->sconn.s_tos : 0);

--- a/net/udp/udp_send.c
+++ b/net/udp/udp_send.c
@@ -149,7 +149,7 @@ void udp_send(FAR struct net_driver_s *dev, FAR struct udp_conn_s *conn)
           dev->d_len        = dev->d_sndlen + UDP_HDRLEN;
 
           ipv6_build_header(IPv6BUF, dev->d_len, IP_PROTO_UDP,
-                            netdev_ipv6_srcaddr(dev, conn->u.ipv6.raddr),
+                            netdev_ipv6_srcaddr(dev, conn->u.ipv6.laddr),
                             conn->u.ipv6.raddr,
                             conn->sconn.ttl, conn->sconn.s_tclass);
 


### PR DESCRIPTION
## Summary

Previously ipv6 multi-address support decided packet source address based on its destination. This doesn't work if NuttX device has multiple addresses within same subnet. Replies will come from different address that the originator contacted, which causes warnings for ICMPv6 and stops TCP from working.

Instead when a packet is a response to existing connection, the source address should be based on the destination address used in the received packet.

[RFC6724](https://datatracker.ietf.org/doc/html/rfc6724#section-2) does not go much into detail on this, but says:

>   Although source and destination address selection is most typically
>   done when initiating communication, a responder also must deal with
>   address selection.  In many cases, this is trivially dealt with by an
>   application using the source address of a received packet as the
>   response destination and the destination address of the received
>   packet as the response source.  Other cases, however, are handled
>   like an initiator, such as when the request is multicast and hence
>   source address selection must still occur when generating a response
>   or when the request includes a list of the initiator's addresses from
>   which to choose a destination.  Finally, a third application scenario
>   is that of a listening application choosing on what local addresses
>   to listen.  This third scenario is out of the scope of this document.

This commit implements it so that the destination address of received packet is used if it is among the local interface addresses.
If it is not, a best matching address is selected.

Related to #11054 and #11378.
@wengzhe Does this look reasonable to you?

## Impact

Makes a difference only when `CONFIG_NETDEV_MULTIPLE_IPv6` is enabled.
Affects ICMPv6 and TCP & UDP.

## Testing

Tested with following addresses:

* NuttX eth0 assigned `fd0f::e100` before `ifup()`, with netmask /64.
* NuttX eth0 added `fd0f::1:0:e100` using `ifconfig`.
* Connecting from PC that has auto-assigned `fd0f::aaa1:59ff:fe15:4b25` to itself.
