### PR TITLE
libs/log2ceil: Move implementation of log2ceil to a common place

### DIFF
--- a/arch/risc-v/src/common/riscv_pmp.c
+++ b/arch/risc-v/src/common/riscv_pmp.c
@@ -32,6 +32,7 @@
 #include <nuttx/compiler.h>
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
+#include <nuttx/lib/math32.h>
 
 #include "riscv_internal.h"
 
@@ -87,32 +88,6 @@ typedef struct pmp_entry_s pmp_entry_t;
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
-
-/****************************************************************************
- * Name: log2ceil
- *
- * Description:
- *   Calculate the up-rounded power-of-two for input.
- *
- * Input Parameters:
- *   x - Argument to calculate the power-of-two from.
- *
- * Returned Value:
- *   Power-of-two for argument, rounded up.
- *
- ****************************************************************************/
-
-static uintptr_t log2ceil(uintptr_t x)
-{
-  uintptr_t pot = 0;
-
-  for (x = x - 1; x; x >>= 1)
-    {
-      pot++;
-    }
-
-  return pot;
-}
 
 /****************************************************************************
  * Name: pmp_check_region_attrs

--- a/include/nuttx/lib/math32.h
+++ b/include/nuttx/lib/math32.h
@@ -249,6 +249,38 @@ void umul64(FAR const struct uint64_s *factor1,
             FAR const struct uint64_s *factor2,
             FAR struct uint64_s *product);
 
+/****************************************************************************
+ * Name: log2ceil
+ *
+ * Description:
+ *   Calculate the up-rounded power-of-two for input.
+ *
+ * Input Parameters:
+ *   x - Argument to calculate the power-of-two from.
+ *
+ * Returned Value:
+ *   Power-of-two for argument, rounded up.
+ *
+ ****************************************************************************/
+
+uintptr_t log2ceil(uintptr_t x);
+
+/****************************************************************************
+ * Name: log2floor
+ *
+ * Description:
+ *   Calculate the down-rounded (truncated) power-of-two for input.
+ *
+ * Input Parameters:
+ *   x - Argument to calculate the power-of-two from.
+ *
+ * Returned Value:
+ *   Power-of-two for argument, rounded (truncated) down.
+ *
+ ****************************************************************************/
+
+uintptr_t log2floor(uintptr_t x);
+
 #undef EXTERN
 #ifdef __cplusplus
 }

--- a/libs/libc/misc/CMakeLists.txt
+++ b/libs/libc/misc/CMakeLists.txt
@@ -82,6 +82,10 @@ list(
   lib_err.c
   lib_instrument.c)
 
+# Add generic integer math functions
+
+list(APPEND SRCS lib_log2ceil.c lib_log2floor.c)
+
 # Keyboard driver encoder/decoder
 
 if(CONFIG_LIBC_KBDCODEC)

--- a/libs/libc/misc/Make.defs
+++ b/libs/libc/misc/Make.defs
@@ -42,6 +42,10 @@ CSRCS += lib_crc64.c lib_crc32.c lib_crc16.c lib_crc16ccitt.c lib_crc8.c
 CSRCS += lib_crc8ccitt.c lib_crc8table.c lib_glob.c lib_execinfo.c
 CSRCS += lib_ftok.c lib_err.c lib_instrument.c
 
+# Add generic integer math functions
+
+CSRCS += lib_log2ceil.c lib_log2floor.c
+
 # Keyboard driver encoder/decoder
 
 ifeq ($(CONFIG_LIBC_KBDCODEC),y)

--- a/libs/libc/misc/lib_log2ceil.c
+++ b/libs/libc/misc/lib_log2ceil.c
@@ -1,0 +1,55 @@
+/****************************************************************************
+ * libs/libc/misc/lib_log2ceil.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/lib/math32.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: log2ceil
+ *
+ * Description:
+ *   Calculate the up-rounded power-of-two for input.
+ *
+ * Input Parameters:
+ *   x - Argument to calculate the power-of-two from.
+ *
+ * Returned Value:
+ *   Power-of-two for argument, rounded up.
+ *
+ ****************************************************************************/
+
+uintptr_t log2ceil(uintptr_t x)
+{
+  uintptr_t pot = 0;
+
+  for (x = x - 1; x; x >>= 1)
+    {
+      pot++;
+    }
+
+  return pot;
+}

--- a/libs/libc/misc/lib_log2floor.c
+++ b/libs/libc/misc/lib_log2floor.c
@@ -1,0 +1,55 @@
+/****************************************************************************
+ * libs/libc/misc/lib_log2floor.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/lib/math32.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: log2floor
+ *
+ * Description:
+ *   Calculate the down-rounded (truncated) power-of-two for input.
+ *
+ * Input Parameters:
+ *   x - Argument to calculate the power-of-two from.
+ *
+ * Returned Value:
+ *   Power-of-two for argument, rounded (truncated) down.
+ *
+ ****************************************************************************/
+
+uintptr_t log2floor(uintptr_t x)
+{
+  uintptr_t pot = 0;
+
+  for (; x > 1; x >>= 1)
+    {
+      pot++;
+    }
+
+  return pot;
+}


### PR DESCRIPTION
## Summary
Move log2ceil from riscv_pmp to libc. Also, implement log2floor for completeness.

These are the run-time alternative to the compile-time macros.

## Impact
Move handy utility function to common code
## Testing
CI pass
