### PR TITLE
net/netdev: Modify the logic for setting the IFF_RUNNING status of interfaces.

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_wlan.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_wlan.c
@@ -1462,27 +1462,18 @@ static void wlan_softap_tx_done(uint8_t *data, uint16_t *len, bool status)
 #ifdef ESP32C3_WLAN_HAS_STA
 int esp32c3_wlan_sta_set_linkstatus(bool linkstatus)
 {
-  int ret = -EINVAL;
   struct wlan_priv_s *priv = &g_wlan_priv[ESP32C3_WLAN_STA_DEVNO];
 
-  if (priv != NULL)
+  if (linkstatus == true)
     {
-      if (linkstatus == true)
-        {
-          ret = netdev_carrier_on(&priv->dev);
-        }
-      else
-        {
-          ret = netdev_carrier_off(&priv->dev);
-        }
-
-      if (ret < 0)
-        {
-          nerr("ERROR: Failed to notify the networking layer\n");
-        }
+      netdev_carrier_on(&priv->dev);
+    }
+  else
+    {
+      netdev_carrier_off(&priv->dev);
     }
 
-  return ret;
+  return OK;
 }
 
 /****************************************************************************

--- a/arch/sim/src/sim/sim_wifidriver.c
+++ b/arch/sim/src/sim/sim_wifidriver.c
@@ -1538,7 +1538,7 @@ static int wifidriver_connect(struct netdev_lowerhalf_s *dev)
   ret = wifidriver_start_connect((struct sim_netdev_s *)dev);
   if (ret >= 0)
     {
-      ret = netdev_lower_carrier_on(dev);
+      netdev_lower_carrier_on(dev);
     }
 
   return ret;
@@ -1551,7 +1551,7 @@ static int wifidriver_disconnect(struct netdev_lowerhalf_s *dev)
   ret = wifidriver_start_disconnect((struct sim_netdev_s *)dev);
   if (ret >= 0)
     {
-      ret = netdev_lower_carrier_off(dev);
+      netdev_lower_carrier_off(dev);
     }
 
   return ret;

--- a/arch/xtensa/src/esp32/esp32_wlan.c
+++ b/arch/xtensa/src/esp32/esp32_wlan.c
@@ -1788,19 +1788,18 @@ static void wlan_softap_tx_done(uint8_t *data, uint16_t *len, bool status)
 #ifdef ESP32_WLAN_HAS_STA
 int esp32_wlan_sta_set_linkstatus(bool linkstatus)
 {
-  int ret = -EINVAL;
   struct wlan_priv_s *priv = &g_wlan_priv[ESP32_WLAN_STA_DEVNO];
 
   if (linkstatus)
     {
-      ret = netdev_carrier_on(&priv->dev);
+      netdev_carrier_on(&priv->dev);
     }
   else
     {
-      ret = netdev_carrier_off(&priv->dev);
+      netdev_carrier_off(&priv->dev);
     }
 
-  return ret;
+  return OK;
 }
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32s3/esp32s3_wlan.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_wlan.c
@@ -1452,27 +1452,18 @@ static void wlan_softap_tx_done(uint8_t *data, uint16_t *len, bool status)
 #ifdef ESP32S3_WLAN_HAS_STA
 int esp32s3_wlan_sta_set_linkstatus(bool linkstatus)
 {
-  int ret = -EINVAL;
   struct wlan_priv_s *priv = &g_wlan_priv[ESP32S3_WLAN_STA_DEVNO];
 
-  if (priv != NULL)
+  if (linkstatus == true)
     {
-      if (linkstatus == true)
-        {
-          ret = netdev_carrier_on(&priv->dev);
-        }
-      else
-        {
-          ret = netdev_carrier_off(&priv->dev);
-        }
-
-      if (ret < 0)
-        {
-          nerr("ERROR: Failed to notify the networking layer\n");
-        }
+      netdev_carrier_on(&priv->dev);
+    }
+  else
+    {
+      netdev_carrier_off(&priv->dev);
     }
 
-  return ret;
+  return OK;
 }
 
 /****************************************************************************

--- a/drivers/net/netdev_upperhalf.c
+++ b/drivers/net/netdev_upperhalf.c
@@ -1063,14 +1063,11 @@ int netdev_lower_unregister(FAR struct netdev_lowerhalf_s *dev)
  * Input Parameters:
  *   dev - The lower half device driver structure
  *
- * Returned Value:
- *   0:Success; negated errno on failure
- *
  ****************************************************************************/
 
-int netdev_lower_carrier_on(FAR struct netdev_lowerhalf_s *dev)
+void netdev_lower_carrier_on(FAR struct netdev_lowerhalf_s *dev)
 {
-  return netdev_carrier_on(&dev->netdev);
+  netdev_carrier_on(&dev->netdev);
 }
 
 /****************************************************************************
@@ -1083,14 +1080,11 @@ int netdev_lower_carrier_on(FAR struct netdev_lowerhalf_s *dev)
  * Input Parameters:
  *   dev - The lower half device driver structure
  *
- * Returned Value:
- *   0:Success; negated errno on failure
- *
  ****************************************************************************/
 
-int netdev_lower_carrier_off(FAR struct netdev_lowerhalf_s *dev)
+void netdev_lower_carrier_off(FAR struct netdev_lowerhalf_s *dev)
 {
-  return netdev_carrier_off(&dev->netdev);
+  netdev_carrier_off(&dev->netdev);
 }
 
 /****************************************************************************

--- a/drivers/net/wifi_sim.c
+++ b/drivers/net/wifi_sim.c
@@ -1715,7 +1715,7 @@ static int wifidriver_connect(FAR struct netdev_lowerhalf_s *dev)
   ret = wifidriver_start_connect(LOWERDEV2WIFIDEV(dev));
   if (ret >= 0)
     {
-      ret = netdev_lower_carrier_on(dev);
+      netdev_lower_carrier_on(dev);
     }
 
   return ret;

--- a/drivers/virtio/virtio-net.c
+++ b/drivers/virtio/virtio-net.c
@@ -313,15 +313,13 @@ static int virtio_net_ifup(FAR struct netdev_lowerhalf_s *dev)
   virtio_net_rxfill(dev);
 
 #ifdef CONFIG_DRIVERS_WIFI_SIM
-  if (priv->lower.wifi)
-    {
-      return OK;
-    }
-  else
+  if (priv->lower.wifi == NULL)
 #endif
     {
-      return netdev_lower_carrier_on(dev);
+      netdev_lower_carrier_on(dev);
     }
+
+  return OK;
 }
 
 /****************************************************************************
@@ -348,7 +346,8 @@ static int virtio_net_ifdown(FAR struct netdev_lowerhalf_s *dev)
   else
 #endif
     {
-      return netdev_lower_carrier_off(dev);
+      netdev_lower_carrier_off(dev);
+      return OK;
     }
 }
 

--- a/include/nuttx/net/netdev.h
+++ b/include/nuttx/net/netdev.h
@@ -736,8 +736,8 @@ int netdev_ifdown(FAR struct net_driver_s *dev);
  *
  ****************************************************************************/
 
-int netdev_carrier_on(FAR struct net_driver_s *dev);
-int netdev_carrier_off(FAR struct net_driver_s *dev);
+void netdev_carrier_on(FAR struct net_driver_s *dev);
+void netdev_carrier_off(FAR struct net_driver_s *dev);
 
 /****************************************************************************
  * Name: chksum

--- a/include/nuttx/net/netdev_lowerhalf.h
+++ b/include/nuttx/net/netdev_lowerhalf.h
@@ -259,12 +259,9 @@ int netdev_lower_unregister(FAR struct netdev_lowerhalf_s *dev);
  * Input Parameters:
  *   dev - The lower half device driver structure
  *
- * Returned Value:
- *   0:Success; negated errno on failure
- *
  ****************************************************************************/
 
-int netdev_lower_carrier_on(FAR struct netdev_lowerhalf_s *dev);
+void netdev_lower_carrier_on(FAR struct netdev_lowerhalf_s *dev);
 
 /****************************************************************************
  * Name: netdev_lower_carrier_off
@@ -276,12 +273,9 @@ int netdev_lower_carrier_on(FAR struct netdev_lowerhalf_s *dev);
  * Input Parameters:
  *   dev - The lower half device driver structure
  *
- * Returned Value:
- *   0:Success; negated errno on failure
- *
  ****************************************************************************/
 
-int netdev_lower_carrier_off(FAR struct netdev_lowerhalf_s *dev);
+void netdev_lower_carrier_off(FAR struct netdev_lowerhalf_s *dev);
 
 /****************************************************************************
  * Name: netdev_lower_rxready

--- a/net/netdev/netdev_carrier.c
+++ b/net/netdev/netdev_carrier.c
@@ -54,21 +54,15 @@
  * Input Parameters:
  *   dev - The device driver structure
  *
- * Returned Value:
- *   0:Success; negated errno on failure
- *
  ****************************************************************************/
 
-int netdev_carrier_on(FAR struct net_driver_s *dev)
+void netdev_carrier_on(FAR struct net_driver_s *dev)
 {
   if (dev && !IFF_IS_RUNNING(dev->d_flags))
     {
       dev->d_flags |= IFF_RUNNING;
       netlink_device_notify(dev);
-      return OK;
     }
-
-  return -EINVAL;
 }
 
 /****************************************************************************
@@ -81,12 +75,9 @@ int netdev_carrier_on(FAR struct net_driver_s *dev)
  * Input Parameters:
  *   dev - The device driver structure
  *
- * Returned Value:
- *   0:Success; negated errno on failure
- *
  ****************************************************************************/
 
-int netdev_carrier_off(FAR struct net_driver_s *dev)
+void netdev_carrier_off(FAR struct net_driver_s *dev)
 {
   if (dev && IFF_IS_RUNNING(dev->d_flags))
     {
@@ -103,9 +94,5 @@ int netdev_carrier_off(FAR struct net_driver_s *dev)
 
       devif_dev_event(dev, NETDEV_DOWN);
       arp_cleanup(dev);
-
-      return OK;
     }
-
-  return -EINVAL;
 }


### PR DESCRIPTION



## Summary
Modify the logic for setting the IFF_RUNNING status of interfaces.
  Refer to the logic of the `netif_carrier_on` on linux. 
  https://github.com/torvalds/linux/blob/master/net/sched/sch_generic.c#L575
## Impact
N/A
## Testing
When we set the `eth0` interface with the commands `ifup eth0` （or `ifdown eth0`）continuously on emulator.
And no error is returned.
