### PR TITLE
mpfs_ethernet.c: Remove DMA_ENABLE hack

### DIFF
--- a/arch/risc-v/src/mpfs/Kconfig
+++ b/arch/risc-v/src/mpfs/Kconfig
@@ -789,13 +789,6 @@ config MPFS_ETHMAC_REGDEBUG
 		Enable very low-level register access debug.  Depends on
 		CONFIG_DEBUG_FEATURES.
 
-config MPFS_MPU_DMA_ENABLE
-	bool "Enable ALL memory access for eth DMA"
-	default n
-	---help---
-		Set ALL memory accessible for Ethernet DMA.
-		This should be done on bootloader. This is mostly for testing only.
-
 endmenu
 
 config MPFS_HAVE_CORERMII

--- a/arch/risc-v/src/mpfs/mpfs_ethernet.c
+++ b/arch/risc-v/src/mpfs/mpfs_ethernet.c
@@ -3627,17 +3627,6 @@ int mpfs_ethinitialize(int intf)
 
   mpfs_read_dsn(&priv->dev.d_mac.ether.ether_addr_octet[1], 5);
 
-  /* MPU hack for ETH DMA if not enabled by bootloader */
-
-#ifdef CONFIG_MPFS_MPU_DMA_ENABLE
-#  ifdef CONFIG_MPFS_ETHMAC_0
-  putreg64(0x1f00000fffffffff, MPFS_PMPCFG_ETH0_0);
-#  endif
-#  ifdef CONFIG_MPFS_ETHMAC_1
-  putreg64(0x1f00000fffffffff, MPFS_PMPCFG_ETH1_0);
-#  endif
-#endif
-
   /* Allocate buffers */
 
   ret = mpfs_buffer_initialize(priv, 0);


### PR DESCRIPTION
## Summary
The hack just opens the entire SoC memory unconditionally, which is not a good idea.

Test features can be used ad-hoc, they don't need to be supported by the build.
## Impact
Unused code removal
## Testing
None
