### PR TITLE
cmake: restore old behavior for savedefconfig

### DIFF
--- a/cmake/menuconfig.cmake
+++ b/cmake/menuconfig.cmake
@@ -98,8 +98,6 @@ add_custom_target(
   COMMAND echo "\\#" >> ${CMAKE_BINARY_DIR}/warning.tmp
   COMMAND cat ${CMAKE_BINARY_DIR}/warning.tmp
           ${CMAKE_BINARY_DIR}/sortedconfig.tmp > ${CMAKE_BINARY_DIR}/defconfig
-  COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_BINARY_DIR}/defconfig
-          ${NUTTX_DEFCONFIG}
   COMMAND ${CMAKE_COMMAND} -E remove -f ${CMAKE_BINARY_DIR}/warning.tmp
   COMMAND ${CMAKE_COMMAND} -E remove -f ${CMAKE_BINARY_DIR}/defconfig.tmp
   COMMAND ${CMAKE_COMMAND} -E remove -f ${CMAKE_BINARY_DIR}/sortedconfig.tmp


### PR DESCRIPTION
## Summary
cmake: restore old behavior for savedefconfig (changed in 375959eac1bbb26ce3450ba19c34953df33db7db)

savedefconfig shouldn't overwrite the original defconfig, but only create a new defconfig in the current directory. Otherwise, creating new configs based on existing ones becomes irritating, because every time we use savedefconfig, the original configuration is overwritten which is not the excepted behavior

## Impact
savedefconfig behaves the same for cmake and make

## Testing

