### PR TITLE
tools/ci: Upgrade arm/arm64 toolchain to 13.2.Rel1

### DIFF
--- a/tools/ci/cibuild.sh
+++ b/tools/ci/cibuild.sh
@@ -74,11 +74,11 @@ function arm-gcc-toolchain {
         ;;
     esac
     cd "${tools}"
-    wget --quiet https://developer.arm.com/-/media/Files/downloads/gnu/12.3.rel1/binrel/arm-gnu-toolchain-12.3.rel1${flavor}-x86_64-arm-none-eabi.tar.xz
-    xz -d arm-gnu-toolchain-12.3.rel1${flavor}-x86_64-arm-none-eabi.tar.xz
-    tar xf arm-gnu-toolchain-12.3.rel1${flavor}-x86_64-arm-none-eabi.tar
-    mv arm-gnu-toolchain-12.3.rel1${flavor}-x86_64-arm-none-eabi gcc-arm-none-eabi
-    rm arm-gnu-toolchain-12.3.rel1${flavor}-x86_64-arm-none-eabi.tar
+    wget --quiet https://developer.arm.com/-/media/Files/downloads/gnu/13.2.Rel1/binrel/arm-gnu-toolchain-13.2.Rel1${flavor}-x86_64-arm-none-eabi.tar.xz
+    xz -d arm-gnu-toolchain-13.2.Rel1${flavor}-x86_64-arm-none-eabi.tar.xz
+    tar xf arm-gnu-toolchain-13.2.Rel1${flavor}-x86_64-arm-none-eabi.tar
+    mv arm-gnu-toolchain-13.2.Rel1${flavor}-x86_64-arm-none-eabi gcc-arm-none-eabi
+    rm arm-gnu-toolchain-13.2.Rel1${flavor}-x86_64-arm-none-eabi.tar
   fi
 
   command arm-none-eabi-gcc --version
@@ -98,11 +98,11 @@ function arm64-gcc-toolchain {
         ;;
     esac
     cd "${tools}"
-    wget --quiet https://developer.arm.com/-/media/Files/downloads/gnu/12.3.rel1/binrel/arm-gnu-toolchain-12.3.rel1${flavor}-x86_64-aarch64-none-elf.tar.xz
-    xz -d arm-gnu-toolchain-12.3.rel1${flavor}-x86_64-aarch64-none-elf.tar.xz
-    tar xf arm-gnu-toolchain-12.3.rel1${flavor}-x86_64-aarch64-none-elf.tar
-    mv arm-gnu-toolchain-12.3.rel1${flavor}-x86_64-aarch64-none-elf gcc-aarch64-none-elf
-    rm arm-gnu-toolchain-12.3.rel1${flavor}-x86_64-aarch64-none-elf.tar
+    wget --quiet https://developer.arm.com/-/media/Files/downloads/gnu/13.2.Rel1/binrel/arm-gnu-toolchain-13.2.Rel1${flavor}-x86_64-aarch64-none-elf.tar.xz
+    xz -d arm-gnu-toolchain-13.2.Rel1${flavor}-x86_64-aarch64-none-elf.tar.xz
+    tar xf arm-gnu-toolchain-13.2.Rel1${flavor}-x86_64-aarch64-none-elf.tar
+    mv arm-gnu-toolchain-13.2.Rel1${flavor}-x86_64-aarch64-none-elf gcc-aarch64-none-elf
+    rm arm-gnu-toolchain-13.2.Rel1${flavor}-x86_64-aarch64-none-elf.tar
   fi
 
   command aarch64-none-elf-gcc --version

--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -106,7 +106,7 @@ RUN mkdir clang-arm-none-eabi && \
 
 # Download the latest ARM GCC toolchain prebuilt by ARM
 RUN mkdir gcc-arm-none-eabi && \
-  curl -s -L  "https://developer.arm.com/-/media/Files/downloads/gnu/12.3.rel1/binrel/arm-gnu-toolchain-12.3.rel1-x86_64-arm-none-eabi.tar.xz" \
+  curl -s -L  "https://developer.arm.com/-/media/Files/downloads/gnu/13.2.Rel1/binrel/arm-gnu-toolchain-13.2.Rel1-x86_64-arm-none-eabi.tar.xz" \
   | tar -C gcc-arm-none-eabi --strip-components 1 -xJ
 
 ###############################################################################
@@ -115,7 +115,7 @@ RUN mkdir gcc-arm-none-eabi && \
 FROM nuttx-toolchain-base AS nuttx-toolchain-arm64
 # Download the latest ARM64 GCC toolchain prebuilt by ARM
 RUN mkdir gcc-aarch64-none-elf && \
-  curl -s -L  "https://developer.arm.com/-/media/Files/downloads/gnu/12.3.rel1/binrel/arm-gnu-toolchain-12.3.rel1-x86_64-aarch64-none-elf.tar.xz" \
+  curl -s -L  "https://developer.arm.com/-/media/Files/downloads/gnu/13.2.Rel1/binrel/arm-gnu-toolchain-13.2.Rel1-x86_64-aarch64-none-elf.tar.xz" \
   | tar -C gcc-aarch64-none-elf --strip-components 1 -xJ
 
 ###############################################################################


### PR DESCRIPTION
## Summary

from https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads

## Impact

arm/arm64 toolchain

## Testing

ci