### PR TITLE
arm/debug:fix gdbstub clear fpb & dwt when already use jtag/swo bug

### DIFF
--- a/arch/arm/src/armv7-m/arm_dbgmonitor.c
+++ b/arch/arm/src/armv7-m/arm_dbgmonitor.c
@@ -633,6 +633,13 @@ int up_debugpoint_remove(int type, void *addr, size_t size)
 
 int arm_enable_dbgmonitor(void)
 {
+  if (getreg32(NVIC_DHCSR) & NVIC_DHCSR_C_DEBUGEN)
+    {
+      /* If already on debug mode(jtag/swo), just return */
+
+      return OK;
+    }
+
   arm_fpb_init();
   arm_dwt_init();
   modifyreg32(NVIC_DEMCR, 0, NVIC_DEMCR_MONEN | NVIC_DEMCR_TRCENA);

--- a/arch/arm/src/armv8-m/arm_dbgmonitor.c
+++ b/arch/arm/src/armv8-m/arm_dbgmonitor.c
@@ -659,6 +659,13 @@ int up_debugpoint_remove(int type, void *addr, size_t size)
 
 int arm_enable_dbgmonitor(void)
 {
+  if (getreg32(NVIC_DHCSR) & NVIC_DHCSR_C_DEBUGEN)
+    {
+      /* If already on debug mode(jtag/swo), just return */
+
+      return OK;
+    }
+
   arm_fpb_init();
   arm_dwt_init();
   modifyreg32(NVIC_DEMCR, 0, NVIC_DEMCR_MONEN | NVIC_DEMCR_TRCENA);


### PR DESCRIPTION
## Summary
If jtag or swo is connected, there is no need to clear the `fpb` and `dwt` registers
## Impact
arm/debug
## Testing
stm32f429i-disco:gdbstub

set `__strat` and `up_idle` a breakpoint, both works, if jtag and swo connected, don't clear `fpb` and `dwt`
