### PR TITLE
Revert "cmake: restore old behavior for savedefconfig"

### DIFF
--- a/cmake/menuconfig.cmake
+++ b/cmake/menuconfig.cmake
@@ -98,6 +98,8 @@ add_custom_target(
   COMMAND echo "\\#" >> ${CMAKE_BINARY_DIR}/warning.tmp
   COMMAND cat ${CMAKE_BINARY_DIR}/warning.tmp
           ${CMAKE_BINARY_DIR}/sortedconfig.tmp > ${CMAKE_BINARY_DIR}/defconfig
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_BINARY_DIR}/defconfig
+          ${NUTTX_DEFCONFIG}
   COMMAND ${CMAKE_COMMAND} -E remove -f ${CMAKE_BINARY_DIR}/warning.tmp
   COMMAND ${CMAKE_COMMAND} -E remove -f ${CMAKE_BINARY_DIR}/defconfig.tmp
   COMMAND ${CMAKE_COMMAND} -E remove -f ${CMAKE_BINARY_DIR}/sortedconfig.tmp


### PR DESCRIPTION
## Summary

Revert "cmake: restore old behavior for savedefconfig"

@raiden00pl I'm surprised why this commit was reverted. It maintains the same functionality as `tools/refresh.sh`. this change is a good improvement because overwriting the original `defconfig` to prevent developers from missing out on enabled or disabled features during the development process. If you find any changes in the `defconfig` after saving it, you should manually restore it, `git diff` will tell you what has happened. and also this feature prevents more junior developers from forgetting to save their own `defconfig`

This reverts commit 751bc1528a8e9f3bfbe1701619b4894f1d6dcb86.

## Impact

N/A

## Testing

ci-check