### PR TITLE
esp32<|s2|s3>_board_spiflash: Fix error message about SmartFS init

### DIFF
--- a/boards/xtensa/esp32/common/src/esp32_board_spiflash.c
+++ b/boards/xtensa/esp32/common/src/esp32_board_spiflash.c
@@ -131,7 +131,8 @@ static int init_ota_partitions(void)
       ret = ftl_initialize(i, mtd);
       if (ret < 0)
         {
-          ferr("ERROR: Failed to initialize the FTL layer: %d\n", ret);
+          syslog(LOG_ERR, "ERROR: Failed to initialize the FTL layer: %d\n",
+                 ret);
           return ret;
         }
 
@@ -141,7 +142,8 @@ static int init_ota_partitions(void)
       ret = bchdev_register(blockdev, part->devpath, false);
       if (ret < 0)
         {
-          ferr("ERROR: bchdev_register %s failed: %d\n", part->devpath, ret);
+          syslog(LOG_ERR, "ERROR: bchdev_register %s failed: %d\n",
+                 part->devpath, ret);
           return ret;
         }
 #endif
@@ -179,19 +181,20 @@ static int setup_smartfs(int smartn, struct mtd_dev_s *mtd,
   ret = smart_initialize(smartn, mtd, NULL);
   if (ret < 0)
     {
-      finfo("smart_initialize failed, Trying to erase first...\n");
+      syslog(LOG_INFO, "smart_initialize failed, "
+             "Trying to erase first...\n");
       ret = mtd->ioctl(mtd, MTDIOC_BULKERASE, 0);
       if (ret < 0)
         {
-          ferr("ERROR: ioctl(BULKERASE) failed: %d\n", ret);
+          syslog(LOG_ERR, "ERROR: ioctl(BULKERASE) failed: %d\n", ret);
           return ret;
         }
 
-      finfo("Erase successful, initializing it again.\n");
+      syslog(LOG_INFO, "Erase successful, initializing it again.\n");
       ret = smart_initialize(smartn, mtd, NULL);
       if (ret < 0)
         {
-          ferr("ERROR: smart_initialize failed: %d\n", ret);
+          syslog(LOG_ERR, "ERROR: smart_initialize failed: %d\n", ret);
           return ret;
         }
     }
@@ -203,11 +206,11 @@ static int setup_smartfs(int smartn, struct mtd_dev_s *mtd,
       ret = nx_mount(path, mnt_pt, "smartfs", 0, NULL);
       if (ret < 0)
         {
-          ferr("ERROR: Failed to mount the FS volume: %d\n", ret);
+          syslog(LOG_ERR, "ERROR: Failed to mount the FS volume: %d\n", ret);
           if (ret == -ENODEV)
             {
-              fwarn("Smartfs seems unformatted. "
-                    "Did you run 'mksmartfs /dev/smart%d'?\n", smartn);
+              syslog(LOG_WARNING, "Smartfs seems unformatted. "
+                     "Did you run 'mksmartfs /dev/smart%d'?\n", smartn);
             }
 
           return ret;
@@ -244,7 +247,7 @@ static int setup_littlefs(const char *path, struct mtd_dev_s *mtd,
   ret = register_mtddriver(path, mtd, priv, NULL);
   if (ret < 0)
     {
-      ferr("ERROR: Failed to register MTD: %d\n", ret);
+      syslog(LOG_ERR, "ERROR: Failed to register MTD: %d\n", ret);
       return -ENOMEM;
     }
 
@@ -256,7 +259,8 @@ static int setup_littlefs(const char *path, struct mtd_dev_s *mtd,
           ret = nx_mount(path, mnt_pt, "littlefs", 0, "forceformat");
           if (ret < 0)
             {
-              ferr("ERROR: Failed to mount the FS volume: %d\n", ret);
+              syslog(LOG_ERR, "ERROR: Failed to mount the FS volume: %d\n",
+                     ret);
               return ret;
             }
         }
@@ -292,7 +296,7 @@ static int setup_spiffs(const char *path, struct mtd_dev_s *mtd,
   ret = register_mtddriver(path, mtd, priv, NULL);
   if (ret < 0)
     {
-      ferr("ERROR: Failed to register MTD: %d\n", ret);
+      syslog(LOG_ERR, "ERROR: Failed to register MTD: %d\n", ret);
       return -ENOMEM;
     }
 
@@ -301,7 +305,7 @@ static int setup_spiffs(const char *path, struct mtd_dev_s *mtd,
       ret = nx_mount(path, mnt_pt, "spiffs", 0, NULL);
       if (ret < 0)
         {
-          ferr("ERROR: Failed to mount the FS volume: %d\n", ret);
+          syslog(LOG_ERR, "ERROR: Failed to mount the FS volume: %d\n", ret);
           return ret;
         }
     }
@@ -333,7 +337,7 @@ static int setup_nxffs(struct mtd_dev_s *mtd, const char *mnt_pt)
   ret = nxffs_initialize(mtd);
   if (ret < 0)
     {
-      ferr("ERROR: NXFFS init failed: %d\n", ret);
+      syslog(LOG_ERR, "ERROR: NXFFS init failed: %d\n", ret);
       return ret;
     }
 
@@ -342,7 +346,7 @@ static int setup_nxffs(struct mtd_dev_s *mtd, const char *mnt_pt)
       ret = nx_mount(NULL, mnt_pt, "nxffs", 0, NULL);
       if (ret < 0)
         {
-          ferr("ERROR: Failed to mount the FS volume: %d\n", ret);
+          syslog(LOG_ERR, "ERROR: Failed to mount the FS volume: %d\n", ret);
           return ret;
         }
     }
@@ -372,7 +376,7 @@ static int init_storage_partition(void)
                                      STORAGE_ENCRYPT);
   if (!mtd)
     {
-      ferr("ERROR: Failed to alloc MTD partition of SPI Flash\n");
+      syslog(LOG_ERR, "ERROR: Failed to alloc MTD partition of SPI Flash\n");
       return -ENOMEM;
     }
 
@@ -381,7 +385,7 @@ static int init_storage_partition(void)
   ret = setup_smartfs(0, mtd, "/data");
   if (ret < 0)
     {
-      ferr("ERROR: Failed to setup smartfs\n");
+      syslog(LOG_ERR, "ERROR: Failed to setup smartfs\n");
       return ret;
     }
 
@@ -390,7 +394,7 @@ static int init_storage_partition(void)
   ret = setup_nxffs(mtd, "/data");
   if (ret < 0)
     {
-      ferr("ERROR: Failed to setup nxffs\n");
+      syslog(LOG_ERR, "ERROR: Failed to setup nxffs\n");
       return ret;
     }
 
@@ -400,7 +404,7 @@ static int init_storage_partition(void)
   ret = setup_littlefs(path, mtd, "/data", 0755);
   if (ret < 0)
     {
-      ferr("ERROR: Failed to setup littlefs\n");
+      syslog(LOG_ERR, "ERROR: Failed to setup littlefs\n");
       return ret;
     }
 
@@ -410,7 +414,7 @@ static int init_storage_partition(void)
   ret = setup_spiffs(path, mtd, "/data", 0755);
   if (ret < 0)
     {
-      ferr("ERROR: Failed to setup spiffs\n");
+      syslog(LOG_ERR, "ERROR: Failed to setup spiffs\n");
       return ret;
     }
 
@@ -419,7 +423,7 @@ static int init_storage_partition(void)
   ret = register_mtddriver("/dev/esp32flash", mtd, 0755, NULL);
   if (ret < 0)
     {
-      ferr("ERROR: Failed to register MTD: %d\n", ret);
+      syslog(LOG_ERR, "ERROR: Failed to register MTD: %d\n", ret);
       return ret;
     }
 

--- a/boards/xtensa/esp32/common/src/esp32_board_spiflash.c
+++ b/boards/xtensa/esp32/common/src/esp32_board_spiflash.c
@@ -204,6 +204,12 @@ static int setup_smartfs(int smartn, struct mtd_dev_s *mtd,
       if (ret < 0)
         {
           ferr("ERROR: Failed to mount the FS volume: %d\n", ret);
+          if (ret == -ENODEV)
+            {
+              fwarn("Smartfs seems unformatted. "
+                    "Did you run 'mksmartfs /dev/smart%d'?\n", smartn);
+            }
+
           return ret;
         }
     }

--- a/boards/xtensa/esp32s2/common/src/esp32s2_board_spiflash.c
+++ b/boards/xtensa/esp32s2/common/src/esp32s2_board_spiflash.c
@@ -115,6 +115,12 @@ static int setup_smartfs(int smartn, struct mtd_dev_s *mtd,
       if (ret < 0)
         {
           ferr("ERROR: Failed to mount the FS volume: %d\n", ret);
+          if (ret == -ENODEV)
+            {
+              fwarn("Smartfs seems unformatted. "
+                    "Did you run 'mksmartfs /dev/smart%d'?\n", smartn);
+            }
+
           return ret;
         }
     }

--- a/boards/xtensa/esp32s2/common/src/esp32s2_board_spiflash.c
+++ b/boards/xtensa/esp32s2/common/src/esp32s2_board_spiflash.c
@@ -90,19 +90,20 @@ static int setup_smartfs(int smartn, struct mtd_dev_s *mtd,
   ret = smart_initialize(smartn, mtd, NULL);
   if (ret < 0)
     {
-      finfo("smart_initialize failed, Trying to erase first...\n");
+      syslog(LOG_INFO, "smart_initialize failed, "
+             "Trying to erase first...\n");
       ret = mtd->ioctl(mtd, MTDIOC_BULKERASE, 0);
       if (ret < 0)
         {
-          ferr("ERROR: ioctl(BULKERASE) failed: %d\n", ret);
+          syslog(LOG_ERR, "ERROR: ioctl(BULKERASE) failed: %d\n", ret);
           return ret;
         }
 
-      finfo("Erase successful, initializing it again.\n");
+      syslog(LOG_INFO, "Erase successful, initializing it again.\n");
       ret = smart_initialize(smartn, mtd, NULL);
       if (ret < 0)
         {
-          ferr("ERROR: smart_initialize failed: %d\n", ret);
+          syslog(LOG_ERR, "ERROR: smart_initialize failed: %d\n", ret);
           return ret;
         }
     }
@@ -114,11 +115,11 @@ static int setup_smartfs(int smartn, struct mtd_dev_s *mtd,
       ret = nx_mount(path, mnt_pt, "smartfs", 0, NULL);
       if (ret < 0)
         {
-          ferr("ERROR: Failed to mount the FS volume: %d\n", ret);
+          syslog(LOG_ERR, "ERROR: Failed to mount the FS volume: %d\n", ret);
           if (ret == -ENODEV)
             {
-              fwarn("Smartfs seems unformatted. "
-                    "Did you run 'mksmartfs /dev/smart%d'?\n", smartn);
+              syslog(LOG_WARNING, "Smartfs seems unformatted. "
+                     "Did you run 'mksmartfs /dev/smart%d'?\n", smartn);
             }
 
           return ret;
@@ -156,7 +157,7 @@ static int setup_littlefs(const char *path, struct mtd_dev_s *mtd,
   ret = register_mtddriver(path, mtd, priv, NULL);
   if (ret < 0)
     {
-      ferr("ERROR: Failed to register MTD: %d\n", ret);
+      syslog(LOG_ERR, "ERROR: Failed to register MTD: %d\n", ret);
       return ERROR;
     }
 
@@ -168,7 +169,8 @@ static int setup_littlefs(const char *path, struct mtd_dev_s *mtd,
           ret = nx_mount(path, mnt_pt, "littlefs", 0, "forceformat");
           if (ret < 0)
             {
-              ferr("ERROR: Failed to mount the FS volume: %d\n", ret);
+              syslog(LOG_ERR, "ERROR: Failed to mount the FS volume: %d\n",
+                     ret);
               return ret;
             }
         }
@@ -204,7 +206,7 @@ static int setup_spiffs(const char *path, struct mtd_dev_s *mtd,
   ret = register_mtddriver(path, mtd, priv, NULL);
   if (ret < 0)
     {
-      ferr("ERROR: Failed to register MTD: %d\n", ret);
+      syslog(LOG_ERR, "ERROR: Failed to register MTD: %d\n", ret);
       return ERROR;
     }
 
@@ -213,7 +215,7 @@ static int setup_spiffs(const char *path, struct mtd_dev_s *mtd,
       ret = nx_mount(path, mnt_pt, "spiffs", 0, NULL);
       if (ret < 0)
         {
-          ferr("ERROR: Failed to mount the FS volume: %d\n", ret);
+          syslog(LOG_ERR, "ERROR: Failed to mount the FS volume: %d\n", ret);
           return ret;
         }
     }
@@ -245,7 +247,7 @@ static int setup_nxffs(struct mtd_dev_s *mtd, const char *mnt_pt)
   ret = nxffs_initialize(mtd);
   if (ret < 0)
     {
-      ferr("ERROR: NXFFS init failed: %d\n", ret);
+      syslog(LOG_ERR, "ERROR: NXFFS init failed: %d\n", ret);
       return ret;
     }
 
@@ -254,7 +256,7 @@ static int setup_nxffs(struct mtd_dev_s *mtd, const char *mnt_pt)
       ret = nx_mount(NULL, mnt_pt, "nxffs", 0, NULL);
       if (ret < 0)
         {
-          ferr("ERROR: Failed to mount the FS volume: %d\n", ret);
+          syslog(LOG_ERR, "ERROR: Failed to mount the FS volume: %d\n", ret);
           return ret;
         }
     }
@@ -284,7 +286,7 @@ static int init_storage_partition(void)
                                        false);
   if (!mtd)
     {
-      ferr("ERROR: Failed to alloc MTD partition of SPI Flash\n");
+      syslog(LOG_ERR, "ERROR: Failed to alloc MTD partition of SPI Flash\n");
       return ERROR;
     }
 
@@ -293,7 +295,7 @@ static int init_storage_partition(void)
   ret = setup_smartfs(0, mtd, "/data");
   if (ret < 0)
     {
-      ferr("ERROR: Failed to setup smartfs\n");
+      syslog(LOG_ERR, "ERROR: Failed to setup smartfs\n");
       return ret;
     }
 
@@ -302,7 +304,7 @@ static int init_storage_partition(void)
   ret = setup_nxffs(mtd, "/data");
   if (ret < 0)
     {
-      ferr("ERROR: Failed to setup nxffs\n");
+      syslog(LOG_ERR, "ERROR: Failed to setup nxffs\n");
       return ret;
     }
 
@@ -312,7 +314,7 @@ static int init_storage_partition(void)
   ret = setup_littlefs(path, mtd, "/data", 0755);
   if (ret < 0)
     {
-      ferr("ERROR: Failed to setup littlefs\n");
+      syslog(LOG_ERR, "ERROR: Failed to setup littlefs\n");
       return ret;
     }
 
@@ -322,7 +324,7 @@ static int init_storage_partition(void)
   ret = setup_spiffs(path, mtd, "/data", 0755);
   if (ret < 0)
     {
-      ferr("ERROR: Failed to setup spiffs\n");
+      syslog(LOG_ERR, "ERROR: Failed to setup spiffs\n");
       return ret;
     }
 
@@ -331,7 +333,7 @@ static int init_storage_partition(void)
   ret = register_mtddriver("/dev/esp32s2flash", mtd, 0755, NULL);
   if (ret < 0)
     {
-      ferr("ERROR: Failed to register MTD: %d\n", ret);
+      syslog(LOG_ERR, "ERROR: Failed to register MTD: %d\n", ret);
       return ret;
     }
 

--- a/boards/xtensa/esp32s3/common/src/esp32s3_board_spiflash.c
+++ b/boards/xtensa/esp32s3/common/src/esp32s3_board_spiflash.c
@@ -106,6 +106,12 @@ static int setup_smartfs(int smartn, struct mtd_dev_s *mtd,
       if (ret < 0)
         {
           ferr("ERROR: Failed to mount the FS volume: %d\n", ret);
+          if (ret == -ENODEV)
+            {
+              fwarn("Smartfs seems unformatted. "
+                    "Did you run 'mksmartfs /dev/smart%d'?\n", smartn);
+            }
+
           return ret;
         }
     }

--- a/boards/xtensa/esp32s3/common/src/esp32s3_board_spiflash.c
+++ b/boards/xtensa/esp32s3/common/src/esp32s3_board_spiflash.c
@@ -81,19 +81,20 @@ static int setup_smartfs(int smartn, struct mtd_dev_s *mtd,
   ret = smart_initialize(smartn, mtd, NULL);
   if (ret < 0)
     {
-      finfo("smart_initialize failed, Trying to erase first...\n");
+      syslog(LOG_INFO, "smart_initialize failed, "
+             "Trying to erase first...\n");
       ret = mtd->ioctl(mtd, MTDIOC_BULKERASE, 0);
       if (ret < 0)
         {
-          ferr("ERROR: ioctl(BULKERASE) failed: %d\n", ret);
+          syslog(LOG_ERR, "ERROR: ioctl(BULKERASE) failed: %d\n", ret);
           return ret;
         }
 
-      finfo("Erase successful, initializing it again.\n");
+      syslog(LOG_INFO, "Erase successful, initializing it again.\n");
       ret = smart_initialize(smartn, mtd, NULL);
       if (ret < 0)
         {
-          ferr("ERROR: smart_initialize failed: %d\n", ret);
+          syslog(LOG_ERR, "ERROR: smart_initialize failed: %d\n", ret);
           return ret;
         }
     }
@@ -105,11 +106,11 @@ static int setup_smartfs(int smartn, struct mtd_dev_s *mtd,
       ret = nx_mount(path, mnt_pt, "smartfs", 0, NULL);
       if (ret < 0)
         {
-          ferr("ERROR: Failed to mount the FS volume: %d\n", ret);
+          syslog(LOG_ERR, "ERROR: Failed to mount the FS volume: %d\n", ret);
           if (ret == -ENODEV)
             {
-              fwarn("Smartfs seems unformatted. "
-                    "Did you run 'mksmartfs /dev/smart%d'?\n", smartn);
+              syslog(LOG_WARNING, "Smartfs seems unformatted. "
+                     "Did you run 'mksmartfs /dev/smart%d'?\n", smartn);
             }
 
           return ret;
@@ -147,7 +148,7 @@ static int setup_littlefs(const char *path, struct mtd_dev_s *mtd,
   ret = register_mtddriver(path, mtd, priv, NULL);
   if (ret < 0)
     {
-      ferr("ERROR: Failed to register MTD: %d\n", ret);
+      syslog(LOG_ERR, "ERROR: Failed to register MTD: %d\n", ret);
       return ERROR;
     }
 
@@ -159,7 +160,8 @@ static int setup_littlefs(const char *path, struct mtd_dev_s *mtd,
           ret = nx_mount(path, mnt_pt, "littlefs", 0, "forceformat");
           if (ret < 0)
             {
-              ferr("ERROR: Failed to mount the FS volume: %d\n", ret);
+              syslog(LOG_ERR, "ERROR: Failed to mount the FS volume: %d\n",
+                     ret);
               return ret;
             }
         }
@@ -195,7 +197,7 @@ static int setup_spiffs(const char *path, struct mtd_dev_s *mtd,
   ret = register_mtddriver(path, mtd, priv, NULL);
   if (ret < 0)
     {
-      ferr("ERROR: Failed to register MTD: %d\n", ret);
+      syslog(LOG_ERR, "ERROR: Failed to register MTD: %d\n", ret);
       return ERROR;
     }
 
@@ -204,7 +206,7 @@ static int setup_spiffs(const char *path, struct mtd_dev_s *mtd,
       ret = nx_mount(path, mnt_pt, "spiffs", 0, NULL);
       if (ret < 0)
         {
-          ferr("ERROR: Failed to mount the FS volume: %d\n", ret);
+          syslog(LOG_ERR, "ERROR: Failed to mount the FS volume: %d\n", ret);
           return ret;
         }
     }
@@ -236,7 +238,7 @@ static int setup_nxffs(struct mtd_dev_s *mtd, const char *mnt_pt)
   ret = nxffs_initialize(mtd);
   if (ret < 0)
     {
-      ferr("ERROR: NXFFS init failed: %d\n", ret);
+      syslog(LOG_ERR, "ERROR: NXFFS init failed: %d\n", ret);
       return ret;
     }
 
@@ -245,7 +247,7 @@ static int setup_nxffs(struct mtd_dev_s *mtd, const char *mnt_pt)
       ret = nx_mount(NULL, mnt_pt, "nxffs", 0, NULL);
       if (ret < 0)
         {
-          ferr("ERROR: Failed to mount the FS volume: %d\n", ret);
+          syslog(LOG_ERR, "ERROR: Failed to mount the FS volume: %d\n", ret);
           return ret;
         }
     }
@@ -275,7 +277,7 @@ static int init_storage_partition(void)
                                        false);
   if (!mtd)
     {
-      ferr("ERROR: Failed to alloc MTD partition of SPI Flash\n");
+      syslog(LOG_ERR, "ERROR: Failed to alloc MTD partition of SPI Flash\n");
       return ERROR;
     }
 
@@ -284,7 +286,7 @@ static int init_storage_partition(void)
   ret = setup_smartfs(0, mtd, "/data");
   if (ret < 0)
     {
-      ferr("ERROR: Failed to setup smartfs\n");
+      syslog(LOG_ERR, "ERROR: Failed to setup smartfs\n");
       return ret;
     }
 
@@ -293,7 +295,7 @@ static int init_storage_partition(void)
   ret = setup_nxffs(mtd, "/data");
   if (ret < 0)
     {
-      ferr("ERROR: Failed to setup nxffs\n");
+      syslog(LOG_ERR, "ERROR: Failed to setup nxffs\n");
       return ret;
     }
 
@@ -303,7 +305,7 @@ static int init_storage_partition(void)
   ret = setup_littlefs(path, mtd, "/data", 0755);
   if (ret < 0)
     {
-      ferr("ERROR: Failed to setup littlefs\n");
+      syslog(LOG_ERR, "ERROR: Failed to setup littlefs\n");
       return ret;
     }
 
@@ -313,7 +315,7 @@ static int init_storage_partition(void)
   ret = setup_spiffs(path, mtd, "/data", 0755);
   if (ret < 0)
     {
-      ferr("ERROR: Failed to setup spiffs\n");
+      syslog(LOG_ERR, "ERROR: Failed to setup spiffs\n");
       return ret;
     }
 
@@ -322,7 +324,7 @@ static int init_storage_partition(void)
   ret = register_mtddriver("/dev/esp32s3flash", mtd, 0755, NULL);
   if (ret < 0)
     {
-      ferr("ERROR: Failed to register MTD: %d\n", ret);
+      syslog(LOG_ERR, "ERROR: Failed to register MTD: %d\n", ret);
       return ret;
     }
 


### PR DESCRIPTION
## Summary

* esp32<|s2|s3>_board_spiflash: Substitute fs messages to syslog

Once these messages are thrown during the system's bring-up, it is
advisable them to be output by the syslog considering the file
system initialization.

* esp32<|s2|s3>_board_spiflash: Fix error message about SmartFS init

The SmartFS partition needs to be formatted before being mounted.
Otherwise, it would throw an error message. The error message now
contains a suggestion to format the partition when such an error
is detected.

## Impact

Avoid any confusion regarding the usage of the SmartFS file system on NuttX. This PR is intended to solve the reported error message in https://github.com/apache/nuttx/issues/11337

## Testing

Internal CI testing + ESP32-S3-DevKitC-1 v1.6