### PR TITLE
CMake:switch CMake Linker from gcc/g++ to ld

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -599,11 +599,9 @@ set(nuttx_libs ${nuttx_kernel_libs} ${nuttx_system_libs} ${nuttx_apps_libs})
 
 if(NOT CONFIG_ARCH_SIM)
 
-  # TODO: nostart/nodefault not applicable to nuttx toolchain
   target_link_libraries(
-    nuttx
-    PRIVATE ${NUTTX_EXTRA_FLAGS} -Wl,--script=${ldscript} -Wl,--start-group
-            ${nuttx_libs} ${nuttx_extra_libs} -Wl,--end-group)
+    nuttx PRIVATE --script=${ldscript} --start-group ${nuttx_libs}
+                  ${nuttx_extra_libs} --end-group)
 
   # generate binary outputs in different formats (.bin, .hex, etc)
   nuttx_generate_outputs(nuttx)
@@ -720,22 +718,21 @@ if(NOT CONFIG_BUILD_FLAT)
   get_property(nuttx_system_libs GLOBAL PROPERTY NUTTX_SYSTEM_LIBRARIES)
 
   get_property(user_ldscript GLOBAL PROPERTY LD_SCRIPT_USER)
-  list(TRANSFORM user_ldscript PREPEND "-Wl,--script=")
+  list(TRANSFORM user_ldscript PREPEND "--script=")
 
   target_link_options(
     nuttx_user PRIVATE -nostartfiles -nodefaultlibs
-    -Wl,--entry=${CONFIG_USER_ENTRYPOINT}
-    -Wl,--undefined=${CONFIG_USER_ENTRYPOINT})
+    --entry=${CONFIG_USER_ENTRYPOINT} --undefined=${CONFIG_USER_ENTRYPOINT})
 
   target_link_libraries(
     nuttx_user
     PRIVATE ${user_ldscript}
             userspace
-            $<$<NOT:$<BOOL:${APPLE}>>:-Wl,--start-group>
+            $<$<NOT:$<BOOL:${APPLE}>>:--start-group>
             ${nuttx_system_libs}
             gcc
             $<$<BOOL:${CONFIG_HAVE_CXX}>:supc++>
-            $<$<NOT:$<BOOL:${APPLE}>>:-Wl,--end-group>)
+            $<$<NOT:$<BOOL:${APPLE}>>:--end-group>)
 
   add_custom_command(
     OUTPUT User.map

--- a/arch/arm/src/cmake/Toolchain.cmake
+++ b/arch/arm/src/cmake/Toolchain.cmake
@@ -93,9 +93,20 @@ set(CMAKE_C_ARCHIVE_CREATE "<CMAKE_AR> rcs <TARGET> <LINK_FLAGS> <OBJECTS>")
 set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> rcs <TARGET> <LINK_FLAGS> <OBJECTS>")
 set(CMAKE_ASM_ARCHIVE_CREATE "<CMAKE_AR> rcs <TARGET> <LINK_FLAGS> <OBJECTS>")
 
+# override LINK command use `ld` linker
+
+set(CMAKE_C_LINK_EXECUTABLE
+    "<CMAKE_LINKER> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")
+
+set(CMAKE_CXX_LINK_EXECUTABLE
+    "<CMAKE_LINKER> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")
+
+set(CMAKE_ASM_LINK_EXECUTABLE
+    "<CMAKE_LINKER> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")
+
 # Architecture flags
 
-add_link_options(-Wl,--entry=__start)
+add_link_options(--entry=__start)
 add_link_options(-nostdlib)
 add_compile_options(-fno-common)
 add_compile_options(-Wall -Wshadow -Wundef)
@@ -151,7 +162,7 @@ endif()
 # Optimization of unused sections
 
 if(CONFIG_DEBUG_OPT_UNUSED_SECTIONS)
-  add_link_options(-Wl,--gc-sections)
+  add_link_options(--gc-sections)
   add_compile_options(-ffunction-sections -fdata-sections)
 endif()
 
@@ -174,7 +185,7 @@ endif()
 # Debug link map
 
 if(CONFIG_DEBUG_LINK_MAP)
-  add_link_options(-Wl,--cref -Wl,-Map=nuttx.map)
+  add_link_options(--cref -Map=nuttx.map)
 endif()
 
 if(CONFIG_DEBUG_SYMBOLS)
@@ -206,10 +217,4 @@ if(NOT EXISTS_FLAGS)
   set(CMAKE_CXX_FLAGS
       "${CMAKE_CXX_FLAGS} ${ARCHCXXFLAGS}"
       CACHE STRING "" FORCE)
-endif()
-
-if(CONFIG_ARCH_TOOLCHAIN_CLANG)
-  set(CMAKE_EXE_LINKER_FLAGS_INIT "-c")
-else()
-  set(CMAKE_EXE_LINKER_FLAGS_INIT "--specs=nosys.specs")
 endif()

--- a/arch/risc-v/src/cmake/Toolchain.cmake
+++ b/arch/risc-v/src/cmake/Toolchain.cmake
@@ -52,7 +52,7 @@ set(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}-g++)
 set(CMAKE_STRIP ${TOOLCHAIN_PREFIX}-strip --strip-unneeded)
 set(CMAKE_OBJCOPY ${TOOLCHAIN_PREFIX}-objcopy)
 set(CMAKE_OBJDUMP ${TOOLCHAIN_PREFIX}-objdump)
-set(CMAKE_LINKER ${TOOLCHAIN_PREFIX}-gcc)
+set(CMAKE_LINKER ${TOOLCHAIN_PREFIX}-ld)
 set(CMAKE_LD ${TOOLCHAIN_PREFIX}-ld)
 set(CMAKE_AR ${TOOLCHAIN_PREFIX}-ar)
 set(CMAKE_NM ${TOOLCHAIN_PREFIX}-nm)
@@ -74,6 +74,17 @@ endif()
 set(CMAKE_C_ARCHIVE_CREATE "<CMAKE_AR> rcs <TARGET> <LINK_FLAGS> <OBJECTS>")
 set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> rcs <TARGET> <LINK_FLAGS> <OBJECTS>")
 set(CMAKE_ASM_ARCHIVE_CREATE "<CMAKE_AR> rcs <TARGET> <LINK_FLAGS> <OBJECTS>")
+
+# override LINK command use `ld` linker
+
+set(CMAKE_C_LINK_EXECUTABLE
+    "<CMAKE_LINKER> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")
+
+set(CMAKE_CXX_LINK_EXECUTABLE
+    "<CMAKE_LINKER> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")
+
+set(CMAKE_ASM_LINK_EXECUTABLE
+    "<CMAKE_LINKER> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")
 
 if(CONFIG_DEBUG_CUSTOMOPT)
   add_compile_options(${CONFIG_DEBUG_OPTLEVEL})
@@ -134,22 +145,23 @@ if(NOT ${CONFIG_CXX_RTTI})
 endif()
 
 if(CONFIG_ARCH_RV32)
-  add_link_options(-Wl,-melf32lriscv)
+  add_link_options(-melf32lriscv)
 elseif(CONFIG_ARCH_RV64)
   add_compile_options(-mcmodel=medany)
-  add_link_options(-Wl,-melf64lriscv)
+  add_link_options(-melf64lriscv)
 endif()
 
 if(CONFIG_DEBUG_OPT_UNUSED_SECTIONS)
-  add_link_options(-Wl,--gc-sections)
+  add_link_options(--gc-sections)
   add_compile_options(-ffunction-sections -fdata-sections)
 endif()
 
-add_link_options(-Wl,-nostdlib)
-add_link_options(-Wl,--entry=__start)
+add_link_options(-nostdlib)
+add_link_options(--entry=__start)
+add_link_options(--no-warn-rwx-segments)
 
 if(CONFIG_DEBUG_LINK_MAP)
-  add_link_options(-Wl,--cref -Wl,-Map=nuttx.map)
+  add_link_options(--cref -Map=nuttx.map)
 endif()
 
 if(CONFIG_DEBUG_SYMBOLS)


### PR DESCRIPTION
## Summary
the current CMake link stage uses gcc/g++ as the linker, 
which may cause unexpected issues such as link options do not taking effect,
so it is better to be switched to ld.
the behavior of link will be consistent with Makefile

```shell
aarch64-none-elf-g++ -Wl,--entry=__start -Wl,-nostdlib -Wl,--gc-sections -Wl,--cref -Wl,-Map=nuttx.map CMakeFiles/nuttx.dir/empty.cxx.obj -o nuttx -Wl,--script=/home/data/vela/vela-all/nuttx/build/dramboot.ld.tmp -Wl,--start-group arch/libarch.a binfmt/libbinfmt.a drivers/libdrivers.a fs/libfs.a libs/libc/libc.a mm/libmm.a sched/libsched.a boards/libboard.a libs/libxx/liblibcxxmini.a apps/libapps.a apps/builtin/libapps_builtin.a apps/system/nsh/libapps_nsh.a apps/system/nsh/libapps_sh.a  -Wl,--end-group
```
```shell
aarch64-none-elf-ld --entry=__start  -nostdlib --gc-sections --cref -Map=nuttx.map --nostartfiles  CMakeFiles/nuttx.dir/empty.cxx.obj -o nuttx --script=/home/data/vela/vela-all/nuttx/build/dramboot.ld.tmp --start-group arch/libarch.a binfmt/libbinfmt.a drivers/libdrivers.a fs/libfs.a libs/libc/libc.a mm/libmm.a sched/libsched.a boards/libboard.a libs/libxx/liblibcxxmini.a apps/libapps.a apps/builtin/libapps_builtin.a apps/system/nsh/libapps_nsh.a apps/system/nsh/libapps_sh.a --end-group 

```
## Impact

## Testing

CI build