### PR TITLE
xtensa/esp32s3: Fixed bbpll not calibrated from bootloader issue

### DIFF
--- a/arch/xtensa/src/esp32s3/Kconfig
+++ b/arch/xtensa/src/esp32s3/Kconfig
@@ -1644,6 +1644,15 @@ config ESP32S3_RTC_CLK_INT_8MD256
 	bool "Internal 8.5MHz oscillator, divided by 256 (~33kHz)"
 
 endchoice
+
+config ESP32S3_SYSTEM_BBPLL_RECALIB
+	bool "Re-calibration BBPLL at startup"
+	default y
+	---help---
+		This configuration helps to address an BBPLL inaccurate issue when boot from certain
+		bootloader version, which may increase about the boot-up time by about 200 us.
+		Disable this when your bootloader is built with ESP-IDF version v5.2 and above.
+
 endmenu # "RTC Configuration"
 
 

--- a/arch/xtensa/src/esp32s3/esp32s3_rtc.h
+++ b/arch/xtensa/src/esp32s3/esp32s3_rtc.h
@@ -597,6 +597,25 @@ void esp32s3_rtc_clk_cpu_freq_set_config(
 void esp32s3_rtc_clk_cpu_freq_get_config(
              struct esp32s3_cpu_freq_config_s *out_config);
 
+/****************************************************************************
+ * Name: esp32s3_rtc_recalib_bbpll
+ *
+ * Description:
+ *   Re-calibration BBPLL, workaround for bootloader not calibration well
+ *   issue.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_ESP32S3_SYSTEM_BBPLL_RECALIB
+void esp32s3_rtc_recalib_bbpll(void);
+#endif
+
 #ifdef CONFIG_RTC_DRIVER
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32s3/esp32s3_start.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_start.c
@@ -356,6 +356,14 @@ noinstrument_function void noreturn_function IRAM_ATTR __esp32s3_start(void)
   esp32s3_spi_timing_set_pin_drive_strength();
 #endif
 
+  /* The PLL provided by bootloader is not stable enough, do calibration
+   * again here so that we can use better clock for the timing tuning.
+   */
+
+#ifdef CONFIG_ESP32S3_SYSTEM_BBPLL_RECALIB
+  esp32s3_rtc_recalib_bbpll();
+#endif
+
   esp32s3_spi_timing_set_mspi_flash_tuning();
 #if defined(CONFIG_ESP32S3_SPIRAM_BOOT_INIT)
   if (esp_spiram_init() != OK)


### PR DESCRIPTION
## Summary

Fixed bbpll not calibrated from bootloader issue

- Solve Wi-Fi may not work bug for bbpll not lock or not stable when enable RF.
- Improved timing tuning stability on ESP32-S3.

The root cause is as following:

- The Application won't re-calibrate the BBPLL clock if it's already enabled.
- Add a force-recalib function in the app startup code to make sure even if the patch is applied by OTA, the clock is still re-calibrated.

## Impact

## Testing

