### PR TITLE
arch: arm64: Fix GICv2 detection

### DIFF
--- a/arch/arm64/src/common/arm64_gicv2.c
+++ b/arch/arm64/src/common/arm64_gicv2.c
@@ -756,13 +756,13 @@ static int gic_validate_dist_version(void)
 {
   uint32_t  reg;
 
-  /* Read the Peripheral ID2 Register (ICPIDR2) */
+  /* Read the CPU Interface Implementer ID Register */
 
-  reg = getreg32(GIC_ICDPIDR(GIC_ICPIDR2)) & GICD_PIDR2_ARCH_MASK;
+  reg = getreg32(GIC_ICCIDR) & GIC_ICCIDR_ARCHNO_MASK;
 
   /* GIC Version should be 2 */
 
-  if (reg == GICD_PIDR2_ARCH_GICV2)
+  if (reg == (0x2 << GIC_ICCIDR_ARCHNO_SHIFT))
     {
       sinfo("GICv2 detected\n");
     }


### PR DESCRIPTION
## Summary

- I noticed that qemu-armv8a:netnsh_smp_hv does not detect GICv2 on Raspi4B (ubuntu 22.04 server + qemu-8.1.2)
- According to the GIC-400 TRM, it says that the architecture version can be obtained from GICC_IIDR (See Table 3-7)
- This commit fixes this issue.

## Impact

- Should be none

## Testing

- Tested with qemu-armv8a:netnsh_smp_hv on
  - Raspi3B+ (ubuntu 22.04 server + qemu-8.1.2)
  - Raspi4B (ubuntu 22.04 server + qemu-8.1.2)
  - M1/MacBook Pro 2021 (macOS 13.6 + qemu-8.1.2)

