### PR TITLE
virtio-net:Fix the compile error.

### DIFF
--- a/drivers/virtio/virtio-net.c
+++ b/drivers/virtio/virtio-net.c
@@ -591,7 +591,7 @@ static void virtio_net_set_macaddr(FAR struct virtio_net_priv_s *priv)
 #ifdef CONFIG_NETDEV_IFINDEX
             dev->d_ifindex
 #else
-            dev % 256
+            (uintptr_t)dev % 256
 #endif
           );
 


### PR DESCRIPTION
## Summary
Fix the compile error, log as follows:
```
CC:  virtio/virtio-net.c virtio/virtio-net.c: In function 'virtio_net_set_macaddr': 
virtio/virtio-net.c:595:17: error: invalid operands to binary % (have 'struct net_driver_s *' and 'int')
  595 |             dev % 256
      |                 ^
make[1]: *** [Makefile:107: virtio-net.o] Error 1
make: *** [tools/LibTargets.mk:101: drivers/libdrivers.a] Error 2
make: *** Waiting for unfinished jobs....
```
## Impact
NA
## Testing
No longer appears when recompiling.
