### PR TITLE
tool/Config.mk:whether verbosity is enabled or not, should use bash

### DIFF
--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -38,12 +38,14 @@ endif
 
 ifeq ($(CONFIG_WINDOWS_NATIVE),y)
   export SHELL=cmd
-else ifeq ($(V),)
+else
   BASHCMD := $(shell command -v bash 2> /dev/null)
   ifneq ($(BASHCMD),)
     export SHELL=$(BASHCMD)
-    export ECHO_BEGIN=@echo -ne "\033[1K\r"
-    export ECHO_END=$(ECHO_BEGIN)
+    ifeq ($(V),)
+      export ECHO_BEGIN=@echo -ne "\033[1K\r"
+      export ECHO_END=$(ECHO_BEGIN)
+    endif
   endif
 endif
 


### PR DESCRIPTION
## Summary
https://github.com/apache/nuttx/blob/a506f9fb709fa7d3d6646d6c9ffd2246ded8e377/tools/Config.mk#L41-L44

the verbosity option should only control silent mode and should not limit the type of shell
## Impact
the patch should fix https://github.com/apache/nuttx/issues/11424#issuecomment-1865372001
## Testing

CI build