### PR TITLE
imxrt: flexio move ifdef guard lower

### DIFF
--- a/arch/arm/src/imxrt/imxrt_flexio.h
+++ b/arch/arm/src/imxrt/imxrt_flexio.h
@@ -34,8 +34,6 @@
 #include "imxrt_config.h"
 #include "hardware/imxrt_flexio.h"
 
-#ifdef CONFIG_IMXRT_FLEXIO
-
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -239,6 +237,8 @@ enum flexio_shifter_buffer_type_e
   FLEXIO_SHIFTER_BUFFER_HALF_WORD_SWAPPED   = 0x5u, /* Shifter Buffer N Half Word Swapped Register. */
   FLEXIO_SHIFTER_BUFFER_NIBBLE_SWAPPED      = 0x6u, /* Shifter Buffer N Nibble Swapped Register. */
 };
+
+#ifdef CONFIG_IMXRT_FLEXIO
 
 struct flexio_timer_config_s
 {


### PR DESCRIPTION
## Summary
FlexIO hardware register are now defined in the driver header with a kconfig guard. This blocks other drivers from using the definitions.
This PR moves the kconfig guard lower to access them.

## Impact
minor

## Testing
imxrt
