### PR TITLE
espressif/mcuboot: Fix dependency of the Espressif's port MCUboot.

### DIFF
--- a/arch/risc-v/src/esp32c3/Kconfig
+++ b/arch/risc-v/src/esp32c3/Kconfig
@@ -1051,6 +1051,7 @@ config ESP32C3_APP_FORMAT_LEGACY
 
 config ESP32C3_APP_FORMAT_MCUBOOT
 	bool "MCUboot-bootable format"
+	depends on !MCUBOOT_BOOTLOADER
 	select ESP32C3_HAVE_OTA_PARTITION
 	---help---
 		The Espressif port of MCUboot supports the loading of unsegmented firmware

--- a/arch/xtensa/src/esp32/Kconfig
+++ b/arch/xtensa/src/esp32/Kconfig
@@ -2462,6 +2462,7 @@ config ESP32_APP_FORMAT_LEGACY
 
 config ESP32_APP_FORMAT_MCUBOOT
 	bool "MCUboot-bootable format"
+	depends on !MCUBOOT_BOOTLOADER
 	select ESP32_HAVE_OTA_PARTITION
 	---help---
 		The ESP32 port of MCUboot supports the loading of unsegmented firmware

--- a/arch/xtensa/src/esp32s2/Kconfig
+++ b/arch/xtensa/src/esp32s2/Kconfig
@@ -1211,6 +1211,7 @@ config ESP32S2_APP_FORMAT_LEGACY
 
 config ESP32S2_APP_FORMAT_MCUBOOT
 	bool "MCUboot-bootable format"
+	depends on !MCUBOOT_BOOTLOADER
 	select ESP32S2_HAVE_OTA_PARTITION
 	---help---
 		The Espressif port of MCUboot supports the loading of unsegmented firmware

--- a/arch/xtensa/src/esp32s3/Kconfig
+++ b/arch/xtensa/src/esp32s3/Kconfig
@@ -2169,6 +2169,7 @@ config ESP32S3_APP_FORMAT_LEGACY
 
 config ESP32S3_APP_FORMAT_MCUBOOT
 	bool "MCUboot-bootable format"
+	depends on !MCUBOOT_BOOTLOADER
 	select ESP32S3_HAVE_OTA_PARTITION
 	---help---
 		The Espressif port of MCUboot supports the loading of unsegmented firmware


### PR DESCRIPTION
## Summary

* espressif/mcuboot: Fix dependency of the Espressif's port MCUboot.

If the MCUboot (from the `nuttx-apps`) is selected, the Espressif's port of the MCUboot (on upstream MCUboot repository) is not used as the 2nd stage bootloader.

## Impact

Avoid misuse of the MCUboot from the `nuttx-apps` repository on Espressif's SoCs

## Testing

Internal CI testing + ESP32-DevKitC V4