### PR TITLE
Update mode.h to add CSR_TVEC

### DIFF
--- a/arch/risc-v/include/mode.h
+++ b/arch/risc-v/include/mode.h
@@ -42,6 +42,7 @@
 #  define CSR_IE            sie              /* Interrupt enable register */
 #  define CSR_CAUSE         scause           /* Interrupt cause register */
 #  define CSR_TVAL          stval            /* Trap value register */
+#  define CSR_TVEC          stvec            /* Trap vector base addr register */
 
 /* In status register */
 
@@ -76,6 +77,7 @@
 #  define CSR_IE            mie              /* Interrupt enable register */
 #  define CSR_CAUSE         mcause           /* Interrupt cause register */
 #  define CSR_TVAL          mtval            /* Trap value register */
+#  define CSR_TVEC          mtvec            /* Trap vector base addr register */
 
 /* In status register */
 


### PR DESCRIPTION
## Summary

this adds CSR_TVEC definition for trap vector base address register to risc-v mode.h

## Impact

None for existing RiscV ports
