### PR TITLE
net/local: make the call return of each process consistent with linux

### DIFF
--- a/net/local/local.h
+++ b/net/local/local.h
@@ -80,7 +80,6 @@ enum local_state_s
   /* SOCK_STREAM peers only */
 
   LOCAL_STATE_ACCEPT,          /* Client waiting for a connection */
-  LOCAL_STATE_CONNECTING,      /* Non-blocking connect */
   LOCAL_STATE_CONNECTED,       /* Peer connected */
   LOCAL_STATE_DISCONNECTED     /* Peer disconnected */
 };
@@ -144,7 +143,6 @@ struct local_conn_s
   /* SOCK_STREAM fields common to both client and server */
 
   sem_t lc_waitsem;            /* Use to wait for a connection to be accepted */
-  sem_t lc_donesem;            /* Use to wait for client connected done */
   FAR struct socket *lc_psock; /* A reference to the socket structure */
 
   /* The following is a list if poll structures of threads waiting for
@@ -169,13 +167,12 @@ struct local_conn_s
       dq_queue_t lc_waiters;   /* List of connections waiting to be accepted */
     } server;
 
-    /* Fields unique to the connecting client side */
+    /* Fields unique to the connecting accept side */
 
     struct
     {
-      volatile int lc_result;  /* Result of the connection operation (client) */
       dq_entry_t lc_waiter;    /* Linked to the lc_waiters lists */
-    } client;
+    } accept;
   } u;
 #endif /* CONFIG_NET_LOCAL_STREAM */
 };
@@ -213,6 +210,20 @@ struct socket;   /* Forward reference */
  ****************************************************************************/
 
 FAR struct local_conn_s *local_alloc(void);
+
+/****************************************************************************
+ * Name: local_alloc_accept
+ *
+ * Description:
+ *    Called when a client calls connect and can find the appropriate
+ *    connection in LISTEN. In that case, this function will create
+ *    a new connection and initialize it.
+ *
+ ****************************************************************************/
+
+int local_alloc_accept(FAR struct local_conn_s *server,
+                       FAR struct local_conn_s *client,
+                       FAR struct local_conn_s **accept);
 
 /****************************************************************************
  * Name: local_free
@@ -698,6 +709,16 @@ int32_t local_generate_instance_id(void);
 int local_set_pollthreshold(FAR struct local_conn_s *conn,
                             unsigned long threshold);
 #endif
+
+/****************************************************************************
+ * Name: local_set_nonblocking
+ *
+ * Description:
+ *   Set the local conntion to nonblocking mode
+ *
+ ****************************************************************************/
+
+int local_set_nonblocking(FAR struct local_conn_s *conn);
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/net/local/local_fifo.c
+++ b/net/local/local_fifo.c
@@ -738,4 +738,30 @@ int local_open_sender(FAR struct local_conn_s *conn, FAR const char *path,
 }
 #endif /* CONFIG_NET_LOCAL_DGRAM */
 
+/****************************************************************************
+ * Name: local_set_nonblocking
+ *
+ * Description:
+ *   Set the local conntion to nonblocking mode
+ *
+ ****************************************************************************/
+
+int local_set_nonblocking(FAR struct local_conn_s *conn)
+{
+  int nonblock = 1;
+  int ret;
+
+  /* Set the conn to nonblocking mode */
+
+  ret  = file_ioctl(&conn->lc_infile, FIONBIO, &nonblock);
+  ret |= file_ioctl(&conn->lc_outfile, FIONBIO, &nonblock);
+
+  if (ret < 0)
+    {
+      nerr("ERROR: Failed to set the conn to nonblocking mode: %d\n", ret);
+    }
+
+  return ret;
+}
+
 #endif /* CONFIG_NET && CONFIG_NET_LOCAL */

--- a/net/local/local_netpoll.c
+++ b/net/local/local_netpoll.c
@@ -171,8 +171,7 @@ int local_pollsetup(FAR struct socket *psock, FAR struct pollfd *fds)
     }
 
 #ifdef CONFIG_NET_LOCAL_STREAM
-  if (conn->lc_state == LOCAL_STATE_LISTENING ||
-       conn->lc_state == LOCAL_STATE_CONNECTING)
+  if (conn->lc_state == LOCAL_STATE_LISTENING)
     {
       return local_event_pollsetup(conn, fds, true);
     }
@@ -324,8 +323,7 @@ int local_pollteardown(FAR struct socket *psock, FAR struct pollfd *fds)
     }
 
 #ifdef CONFIG_NET_LOCAL_STREAM
-  if (conn->lc_state == LOCAL_STATE_LISTENING ||
-       conn->lc_state == LOCAL_STATE_CONNECTING)
+  if (conn->lc_state == LOCAL_STATE_LISTENING)
     {
       return local_event_pollsetup(conn, fds, false);
     }

--- a/net/local/local_recvmsg.c
+++ b/net/local/local_recvmsg.c
@@ -240,11 +240,6 @@ psock_stream_recvfrom(FAR struct socket *psock, FAR void *buf, size_t len,
   if (conn->lc_state != LOCAL_STATE_CONNECTED ||
       conn->lc_infile.f_inode == NULL)
     {
-      if (conn->lc_state == LOCAL_STATE_CONNECTING)
-        {
-          return -EAGAIN;
-        }
-
       nerr("ERROR: not connected\n");
       return -ENOTCONN;
     }

--- a/net/local/local_sendmsg.c
+++ b/net/local/local_sendmsg.c
@@ -189,11 +189,6 @@ static ssize_t local_send(FAR struct socket *psock,
           if (peer->lc_state != LOCAL_STATE_CONNECTED ||
               peer->lc_outfile.f_inode == NULL)
             {
-              if (peer->lc_state == LOCAL_STATE_CONNECTING)
-                {
-                  return -EAGAIN;
-                }
-
               nerr("ERROR: not connected\n");
               return -ENOTCONN;
             }


### PR DESCRIPTION
## Summary
move the accept logic into connect flow.
In order to successfully establish a blocking connection between the client and server on the same thread.
## Impact
nonblock is not affected, and the block connect is now the same as the nonblock flow, other apis are not affected.
## Testing
sim:local