### PR TITLE
libc/stream: add stream interface

### DIFF
--- a/include/nuttx/streams.h
+++ b/include/nuttx/streams.h
@@ -309,6 +309,8 @@ extern "C"
 #  define EXTERN extern
 #endif
 
+extern struct lib_outstream_s g_lowoutstream;
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/

--- a/include/nuttx/streams.h
+++ b/include/nuttx/streams.h
@@ -205,6 +205,12 @@ struct lib_rawoutstream_s
   int                    fd;
 };
 
+struct lib_fileoutstream_s
+{
+  struct lib_outstream_s common;
+  struct file            *file;
+};
+
 struct lib_rawsistream_s
 {
   struct lib_sistream_s  common;
@@ -396,6 +402,8 @@ void lib_rawinstream(FAR struct lib_rawinstream_s *stream, int fd);
 void lib_rawoutstream(FAR struct lib_rawoutstream_s *stream, int fd);
 void lib_rawsistream(FAR struct lib_rawsistream_s *stream, int fd);
 void lib_rawsostream(FAR struct lib_rawsostream_s *stream, int fd);
+void lib_fileoutstream(FAR struct lib_fileoutstream_s *stream,
+                       FAR struct file *file);
 
 /****************************************************************************
  * Name: lib_bufferedoutstream

--- a/libs/libc/stream/Make.defs
+++ b/libs/libc/stream/Make.defs
@@ -27,7 +27,7 @@ CSRCS += lib_rawoutstream.c lib_rawsistream.c lib_rawsostream.c
 CSRCS += lib_zeroinstream.c lib_nullinstream.c lib_nulloutstream.c
 CSRCS += lib_mtdoutstream.c lib_libnoflush.c lib_libsnoflush.c
 CSRCS += lib_syslogstream.c lib_syslograwstream.c lib_bufferedoutstream.c
-CSRCS += lib_hexdumpstream.c
+CSRCS += lib_hexdumpstream.c lib_fileoutstream.c
 
 # The remaining sources files depend upon C streams
 

--- a/libs/libc/stream/lib_fileoutstream.c
+++ b/libs/libc/stream/lib_fileoutstream.c
@@ -1,0 +1,110 @@
+/****************************************************************************
+ * libs/libc/stream/lib_fileoutstream.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <unistd.h>
+#include <assert.h>
+#include <errno.h>
+
+#include <nuttx/fs/fs.h>
+
+#include "libc.h"
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: rawoutstream_puts
+ ****************************************************************************/
+
+static int fileoutstream_puts(FAR struct lib_outstream_s *self,
+                              FAR const void *buf, int len)
+{
+  FAR struct lib_fileoutstream_s *stream =
+                                  (FAR struct lib_fileoutstream_s *)self;
+  int nwritten;
+
+  do
+    {
+      nwritten = file_write(stream->file, buf, len);
+      if (nwritten >= 0)
+        {
+          self->nput += nwritten;
+          return nwritten;
+        }
+
+      /* The only expected error is EINTR, meaning that the write operation
+       * was awakened by a signal.  Zero would not be a valid return value
+       * from _NX_WRITE().
+       */
+
+      DEBUGASSERT(nwritten < 0);
+    }
+  while (nwritten == -EINTR);
+
+  return nwritten;
+}
+
+/****************************************************************************
+ * Name: rawoutstream_putc
+ ****************************************************************************/
+
+static void fileoutstream_putc(FAR struct lib_outstream_s *self, int ch)
+{
+  char tmp = ch;
+  fileoutstream_puts(self, &tmp, 1);
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: lib_fileoutstream
+ *
+ * Description:
+ *   Initializes a stream for use with a file descriptor.
+ *
+ * Input Parameters:
+ *   stream - User allocated, uninitialized instance of struct
+ *            lib_rawoutstream_s to be initialized.
+ *   file   - User provided FILE instance (must have been opened for
+ *            write access).
+ *
+ * Returned Value:
+ *   None (User allocated instance initialized).
+ *
+ ****************************************************************************/
+
+void lib_fileoutstream(FAR struct lib_fileoutstream_s *stream,
+                       FAR struct file *file)
+{
+  stream->common.putc  = fileoutstream_putc;
+  stream->common.puts  = fileoutstream_puts;
+  stream->common.flush = lib_noflush;
+  stream->common.nput  = 0;
+  stream->file         = file;
+}

--- a/libs/libc/stream/lib_lowoutstream.c
+++ b/libs/libc/stream/lib_lowoutstream.c
@@ -34,6 +34,26 @@
 #include "libc.h"
 
 /****************************************************************************
+ * Private Functions Prototypes
+ ****************************************************************************/
+
+static void lowoutstream_putc(FAR struct lib_outstream_s *self, int ch);
+static int lowoutstream_puts(FAR struct lib_outstream_s *self,
+                             FAR const void *buf, int len);
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+struct lib_outstream_s g_lowoutstream =
+{
+  0,
+  lowoutstream_putc,
+  lowoutstream_puts,
+  lib_noflush
+};
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 


### PR DESCRIPTION
## Summary
1. Add a global lowerout stream
    which can simplify the steps of lib_sprintf writing data to the serial port
2. Add a file stream based on struct file

## Impact

## Testing
sim/nsh
