### PR TITLE
support sorting symbol tables by name

### DIFF
--- a/arch/arm/src/Makefile
+++ b/arch/arm/src/Makefile
@@ -181,7 +181,7 @@ board$(DELIM)libboard$(LIBEXT):
 	$(Q) $(MAKE) -C board libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
 
 define LINK_ALLSYMS
-	$(Q) $(TOPDIR)/tools/mkallsyms.py $(NUTTX) allsyms.tmp
+	$(Q) $(TOPDIR)/tools/mkallsyms.py $(NUTTX) allsyms.tmp --orderbyname $(CONFIG_SYMTAB_ORDEREDBYNAME)
 	$(Q) $(call COMPILE, allsyms.tmp, allsyms$(OBJEXT), -x c)
 	$(Q) $(LD) --entry=__start $(LDFLAGS) $(LIBPATHS) $(EXTRA_LIBPATHS) \
 		-o $(NUTTX) $(HEAD_OBJ) allsyms$(OBJEXT) $(EXTRA_OBJS) \

--- a/arch/arm64/src/Makefile
+++ b/arch/arm64/src/Makefile
@@ -157,7 +157,7 @@ board$(DELIM)libboard$(LIBEXT):
 	$(Q) $(MAKE) -C board libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
 
 define LINK_ALLSYMS
-	$(Q) $(TOPDIR)/tools/mkallsyms.py $(NUTTX) allsyms.tmp
+	$(Q) $(TOPDIR)/tools/mkallsyms.py $(NUTTX) allsyms.tmp --orderbyname $(CONFIG_SYMTAB_ORDEREDBYNAME)
 	$(Q) $(call COMPILE, allsyms.tmp, allsyms$(OBJEXT), -x c)
 	$(Q) $(LD) --entry=__start $(LDFLAGS) $(LIBPATHS) $(EXTRA_LIBPATHS) \
 		-o $(NUTTX) $(HEAD_OBJ) allsyms$(OBJEXT) $(EXTRA_OBJS) \

--- a/arch/risc-v/src/Makefile
+++ b/arch/risc-v/src/Makefile
@@ -162,7 +162,7 @@ board/libboard$(LIBEXT):
 	$(Q) $(MAKE) -C board libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
 
 define LINK_ALLSYMS
-	$(Q) $(TOPDIR)/tools/mkallsyms.py $(NUTTX) allsyms.tmp
+	$(Q) $(TOPDIR)/tools/mkallsyms.py $(NUTTX) allsyms.tmp --orderbyname $(CONFIG_SYMTAB_ORDEREDBYNAME)
 	$(Q) $(call COMPILE, allsyms.tmp, allsyms$(OBJEXT), -x c)
 	$(Q) $(LD) --entry=__start $(LDFLAGS) $(LIBPATHS) $(EXTRA_LIBPATHS) \
 		-o $(NUTTX) $(HEAD_OBJ) allsyms$(OBJEXT) $(EXTRA_OBJS) \

--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -354,7 +354,7 @@ nuttx-names.dat: nuttx-names.in
 define LINK_ALLSYMS
 	$(if $(CONFIG_HOST_MACOS), \
 	$(Q) $(TOPDIR)/tools/mkallsyms.sh noconst $(NUTTX) $(CROSSDEV) > allsyms.tmp, \
-	$(Q) $(TOPDIR)/tools/mkallsyms.py $(NUTTX) allsyms.tmp)
+	$(Q) $(TOPDIR)/tools/mkallsyms.py $(NUTTX) allsyms.tmp --orderbyname $(CONFIG_SYMTAB_ORDEREDBYNAME))
 	$(Q) $(call COMPILE, allsyms.tmp, allsyms$(OBJEXT), -x c)
 	$(if $(CONFIG_HAVE_CXX),\
 	$(Q) "$(CXX)" $(CFLAGS) $(LDFLAGS) -o $(NUTTX) \

--- a/arch/xtensa/src/Makefile
+++ b/arch/xtensa/src/Makefile
@@ -158,7 +158,7 @@ board/libboard$(LIBEXT):
 	$(Q) $(MAKE) -C board libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
 
 define LINK_ALLSYMS
-	$(Q) $(TOPDIR)/tools/mkallsyms.py $(NUTTX) allsyms.tmp
+	$(Q) $(TOPDIR)/tools/mkallsyms.py $(NUTTX) allsyms.tmp --orderbyname $(CONFIG_SYMTAB_ORDEREDBYNAME)
 	$(Q) $(call COMPILE, allsyms.tmp, allsyms$(OBJEXT), -x c)
 	$(Q) $(LD) --entry=__start $(LDFLAGS) $(LIBPATHS) $(EXTRA_LIBPATHS) \
 		-o $(NUTTX) $(STARTUP_OBJS) allsyms$(OBJEXT) $(EXTRA_OBJS) \

--- a/libs/libc/symtab/symtab_findbyvalue.c
+++ b/libs/libc/symtab/symtab_findbyvalue.c
@@ -92,7 +92,7 @@ symtab_findbyvalue(FAR const struct symtab_s *symtab,
         }
       else if (symtab[mid].sym_value < value)
         {
-          if (symtab[mid + 1].sym_value >= value)
+          if (symtab[mid + 1].sym_value > value)
             {
               break;
             }

--- a/tools/mkallsyms.py
+++ b/tools/mkallsyms.py
@@ -110,7 +110,7 @@ class SymbolTables(object):
                     func_name = re.sub(r"\(.*$", "", symbol_name)
                 except cxxfilt.InvalidName:
                     symbol_name = symbol.name
-                self.symbol_list.append((symbol["st_value"] & ~0x01, func_name))
+                self.symbol_list.append((symbol["st_value"], func_name))
         if orderbyname:
             self.symbol_list = sorted(self.symbol_list, key=lambda item: item[1])
         else:

--- a/tools/mkallsyms.py
+++ b/tools/mkallsyms.py
@@ -19,6 +19,7 @@
 #
 ############################################################################
 
+import argparse
 import errno
 import os
 import re
@@ -33,6 +34,7 @@ try:
 except ModuleNotFoundError:
     print("Please execute the following command to install dependencies:")
     print("pip install pyelftools cxxfilt")
+    os._exit(errno.EINVAL)
 
 
 class SymbolTables(object):
@@ -97,7 +99,7 @@ class SymbolTables(object):
 
             return section
 
-    def parse_symbol(self):
+    def parse_symbol(self, orderbyname=False):
         if self.elffile is None:
             return
         symtable = self.get_symtable()
@@ -109,47 +111,49 @@ class SymbolTables(object):
                 except cxxfilt.InvalidName:
                     symbol_name = symbol.name
                 self.symbol_list.append((symbol["st_value"] & ~0x01, func_name))
-        self.symbol_list = sorted(self.symbol_list, key=lambda item: item[0])
+        if orderbyname:
+            self.symbol_list = sorted(self.symbol_list, key=lambda item: item[1])
+        else:
+            self.symbol_list = sorted(self.symbol_list, key=lambda item: item[0])
 
     def emitline(self, s=""):
         self.output.write(str(s) + "\n")
 
 
 def usage():
-    print("Usage: mkallsyms.py [noconst] <ELFBIN> [output file]")
+    print(
+        "Usage: mkallsyms.py [noconst] <ELFBIN> [output file] [order symbols by name]"
+    )
     os._exit(errno.ENOENT)
 
 
-def parse_args(argv):
-    index = 1
-    argc = len(argv)
-    outfile = None
-    elffile = None
-
-    if argc > index and argv[index] == "--version":
-        print("mkallsyms.py: based on pyelftools %s" % __version__)
-        os.exit(0)
-
-    if argc > index and argv[index] == "noconst":
-        noconst = True
-        index += 1
-    else:
-        noconst = False
-
-    if argc > index:
-        elffile = argv[index]
-        index += 1
-
-    if argc > index:
-        outfile = open(argv[index], "w")
-    else:
-        outfile = sys.stdout
-
-    return noconst, elffile, outfile
-
-
 if __name__ == "__main__":
-    noconst, elffile, outfile = parse_args(sys.argv)
-    readelf = SymbolTables(elffile, outfile)
-    readelf.parse_symbol()
-    readelf.print_symbol_tables(noconst)
+    parser = argparse.ArgumentParser(
+        description="Process ELF binary to extract symbols."
+    )
+    parser.add_argument("elffile", help="Path to the ELF binary file.")
+    parser.add_argument(
+        "outfile",
+        nargs="?",
+        type=argparse.FileType("w"),
+        default=sys.stdout,
+        help="Output file to write symbols to (default: stdout).",
+    )
+    parser.add_argument("--noconst", action="store_true", help="Exclude const symbols.")
+    parser.add_argument(
+        "--version",
+        action="version",
+        version="mkallsyms.py: based on pyelftools %s" % __version__,
+    )
+    parser.add_argument(
+        "--orderbyname",
+        nargs="?",
+        const=False,
+        default=False,
+        help='Order symbols by name (specify "y" to enable, default: False).',
+    )
+    args = parser.parse_args()
+
+    readelf = SymbolTables(args.elffile, args.outfile)
+    readelf.parse_symbol(args.orderbyname)
+    readelf.print_symbol_tables(args.noconst)


### PR DESCRIPTION
## Summary
1. support sorting symbol tables by name
2. libs: fix the problem that the address obtained in thumb mode cannot be executed.

In arm, the lowest bit of the instruction is 1, which is a thumb instruction, and 0, which is an arm instruction.

The nm command was used in mkallsym.sh before, and the result it will return will set the lowest bit of the thumb instruction to 0. 
There will be a one-byte deviation during binary search, so mkallsyms.py will also set the lowest bit to 0 according to the previous format.

```sh
arm-none-eabi-nm -Cn nuttx | grep hello
0801c384 T hello_main
arm-none-eabi-objdump nuttx -t |grep hello
0801c384 g F .text 0000004c hello_main
arm-none-eabi-readelf nuttx -s |grep hello
4558: 0801c385 76 FUNC GLOBAL DEFAULT 1 hello_main
```

However, in the following case, when you need to find the function address according to the symbol name and execute the corresponding function, the lowest address obtained is 0. It will follow the arm instruction, causing an exception.
```c
void sym_test(void)
{
  printf("call sym_test\n");
}

int main(int argc, FAR char *argv[])
{
  size_t size;
  void (*func)(void);
  const struct symtab_s *sym;
  void *addr = sym_test;

  printf("sym_test:%p %pS\n",addr, addr);
  printf("sym_test - 1: %pS\n", (char *)addr - 1);
  printf("sym_test + 1: %pS\n", (char *)addr + 1);

  sym = allsyms_findbyname("sym_test", &size);
  printf("sym_test:%p %pS\n",sym, sym);
  func = sym->sym_value;
  func();

  return 0;
}
```

Therefore, you need to change mkallsyms.py back to the correct result and correct the binary search.

## Impact

## Testing
 stm32 and sim
