### PR TITLE
fs: smartfs: Add necessary aligned access in smartfs_rename()

### DIFF
--- a/fs/smartfs/smartfs_smart.c
+++ b/fs/smartfs/smartfs_smart.c
@@ -1983,10 +1983,22 @@ int smartfs_rename(FAR struct inode *mountpt, FAR const char *oldrelpath,
       direntry = (FAR struct smartfs_entry_header_s *)
         &fs->fs_rwbuffer[oldentry.doffset];
 #if CONFIG_SMARTFS_ERASEDSTATE == 0xff
+#ifdef CONFIG_SMARTFS_ALIGNED_ACCESS
+      smartfs_wrle16(&direntry->flags,
+                     smartfs_rdle16(&direntry->flags)
+                     & ~SMARTFS_DIRENT_ACTIVE);
+#else
       direntry->flags &= ~SMARTFS_DIRENT_ACTIVE;
+#endif
+#else /* CONFIG_SMARTFS_ERASEDSTATE == 0xff */
+#ifdef CONFIG_SMARTFS_ALIGNED_ACCESS
+      smartfs_wrle16(&direntry->flags,
+                     smartfs_rdle16(&direntry->flags)
+                     | SMARTFS_DIRENT_ACTIVE);
 #else
       direntry->flags |= SMARTFS_DIRENT_ACTIVE;
 #endif
+#endif /* CONFIG_SMARTFS_ERASEDSTATE == 0xff */
 
       /* Now write the updated flags back to the device */
 


### PR DESCRIPTION
## Summary

```smartfs_rename()``` was stuck on the boards they need ```CONFIG_SMARTFS_ALIGNED_ACCESS```.

## Impact

All of the boards they need ```CONFIG_SMARTFS_ALIGNED_ACCESS```

## Testing

I tested with Raspberry Pi Pico W [like this](https://github.com/apache/nuttx/issues/11444).