### PR TITLE
net/udp: set ipv6 remote addr before udpip_hdrsize

### DIFF
--- a/net/udp/udp_sendto_buffered.c
+++ b/net/udp/udp_sendto_buffered.c
@@ -792,6 +792,7 @@ ssize_t psock_udp_sendto(FAR struct socket *psock, FAR const void *buf,
       else
         {
           memcpy(&wrb->wb_dest, to, tolen);
+          udp_connect(conn, to);
         }
 
       /* Skip l2/l3/l4 offset before copy */


### PR DESCRIPTION
## Summary
In this case, remote addr is all zero, and the length of the ip header is not recognized as ipv6_is_ipv4, This will cause problems in subsequent data filling.

## Impact

## Testing
sim:local
