### PR TITLE
bcmf_driver: add ioctl_mutex to restrict ioctl from reentrant

### DIFF
--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c
@@ -1143,7 +1143,6 @@ int bcmf_wl_get_interface(FAR struct bcmf_dev_s *priv, FAR struct iwreq *iwr)
 
 FAR struct bcmf_dev_s *bcmf_allocate_device(void)
 {
-  int ret;
   FAR struct bcmf_dev_s *priv;
 
   /* Allocate a bcmf device structure */
@@ -1160,25 +1159,20 @@ FAR struct bcmf_dev_s *bcmf_allocate_device(void)
 
   /* Init control frames mutex and timeout signal */
 
-  if ((ret = nxsem_init(&priv->control_mutex, 0, 1)) != OK)
-    {
-      goto exit_free_priv;
-    }
+  nxsem_init(&priv->control_mutex, 0, 1);
+  nxsem_init(&priv->control_timeout, 0, 0);
 
-  if ((ret = nxsem_init(&priv->control_timeout, 0, 0)) != OK)
-    {
-      goto exit_free_priv;
-    }
+  /* Init ioctl mutex */
+
+#ifdef CONFIG_NETDEV_IOCTL
+  nxmutex_init(&priv->ioctl_mutex);
+#endif
 
   /* Init scan timeout timer */
 
   priv->scan_status = BCMF_SCAN_DISABLED;
 
   return priv;
-
-exit_free_priv:
-  kmm_free(priv);
-  return NULL;
 }
 
 /****************************************************************************

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.h
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.h
@@ -82,6 +82,9 @@ struct bcmf_dev_s
   uint16_t control_rxdata_len; /* Received control frame out buffer length */
   FAR uint8_t *control_rxdata; /* Received control frame out buffer */
   uint32_t control_status;     /* Last received frame status */
+#ifdef CONFIG_NETDEV_IOCTL
+  mutex_t ioctl_mutex;         /* Avoid handle multiple ioctl requests */
+#endif
 
   /* AP Scan state machine.
    * During scan, control_mutex is locked to prevent control requests

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_netdev.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_netdev.c
@@ -936,6 +936,11 @@ static int bcmf_ioctl(FAR struct net_driver_s *dev, int cmd,
       return -EPERM;
     }
 
+  if ((ret = nxmutex_lock(&priv->ioctl_mutex)) < 0)
+    {
+      return ret;
+    }
+
 #ifdef CONFIG_IEEE80211_BROADCOM_LOWPOWER
   bcmf_lowpower_poll(priv);
 #endif
@@ -1071,6 +1076,8 @@ static int bcmf_ioctl(FAR struct net_driver_s *dev, int cmd,
         ret = -ENOTTY;  /* Special return value for this case */
         break;
     }
+
+  nxmutex_unlock(&priv->ioctl_mutex);
 
   return ret;
 }


### PR DESCRIPTION
## Summary
avoiding resource race conditions

## Impact

## Testing
cortex-m33 and bcm43xxx wifi chip
