### PR TITLE
CMake:init arch arm64 CMake and qemu-armv8a build

### DIFF
--- a/arch/arm64/CMakeLists.txt
+++ b/arch/arm64/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# libs/libc/fdt/CMakeLists.txt
+# arch/arm64/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
@@ -17,37 +17,5 @@
 # the License.
 #
 # ##############################################################################
-if(CONFIG_LIBC_FDT)
 
-  set(FDT_DIR ${CMAKE_CURRENT_LIST_DIR}/dtc)
-  if(NOT EXISTS ${FDT_DIR})
-    set(VERSION ${CONFIG_LIBC_FDT_DTC_VERSION})
-
-    FetchContent_Declare(
-      dtc
-      URL https://github.com/dgibson/dtc/archive/v${VERSION}.zip SOURCE_DIR
-          ${CMAKE_CURRENT_LIST_DIR}/dtc BINARY_DIR
-          ${CMAKE_BINARY_DIR}/libs/libc/fdt/dtc)
-    FetchContent_GetProperties(dtc)
-    if(NOT dtc_POPULATED)
-      FetchContent_Populate(dtc)
-    endif()
-  endif()
-
-  set(SRCS
-      fdt.c
-      fdt_ro.c
-      fdt_wip.c
-      fdt_sw.c
-      fdt_rw.c
-      fdt_strerror.c
-      fdt_empty_tree.c
-      fdt_addresses.c
-      fdt_overlay.c
-      fdt_check.c)
-  list(TRANSFORM SRCS PREPEND ${FDT_DIR}/libfdt/)
-
-  target_sources(c PRIVATE ${SRCS})
-
-  target_include_directories(c PRIVATE ${FDT_DIR}/libfdt)
-endif()
+nuttx_add_subdirectory()

--- a/arch/arm64/src/CMakeLists.txt
+++ b/arch/arm64/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# libs/libc/fdt/CMakeLists.txt
+# arch/arm64/src/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
@@ -17,37 +17,12 @@
 # the License.
 #
 # ##############################################################################
-if(CONFIG_LIBC_FDT)
-
-  set(FDT_DIR ${CMAKE_CURRENT_LIST_DIR}/dtc)
-  if(NOT EXISTS ${FDT_DIR})
-    set(VERSION ${CONFIG_LIBC_FDT_DTC_VERSION})
-
-    FetchContent_Declare(
-      dtc
-      URL https://github.com/dgibson/dtc/archive/v${VERSION}.zip SOURCE_DIR
-          ${CMAKE_CURRENT_LIST_DIR}/dtc BINARY_DIR
-          ${CMAKE_BINARY_DIR}/libs/libc/fdt/dtc)
-    FetchContent_GetProperties(dtc)
-    if(NOT dtc_POPULATED)
-      FetchContent_Populate(dtc)
-    endif()
-  endif()
-
-  set(SRCS
-      fdt.c
-      fdt_ro.c
-      fdt_wip.c
-      fdt_sw.c
-      fdt_rw.c
-      fdt_strerror.c
-      fdt_empty_tree.c
-      fdt_addresses.c
-      fdt_overlay.c
-      fdt_check.c)
-  list(TRANSFORM SRCS PREPEND ${FDT_DIR}/libfdt/)
-
-  target_sources(c PRIVATE ${SRCS})
-
-  target_include_directories(c PRIVATE ${FDT_DIR}/libfdt)
+add_subdirectory(common)
+add_subdirectory(${NUTTX_CHIP_ABS_DIR} EXCLUDE_FROM_ALL exclude_chip)
+# Include directories (before system ones) as PUBLIC so that it can be exposed
+# to libboard
+target_include_directories(arch BEFORE PUBLIC ${NUTTX_CHIP_ABS_DIR} common)
+if(NOT CONFIG_BUILD_FLAT)
+  target_include_directories(arch_interface BEFORE PUBLIC ${NUTTX_CHIP_ABS_DIR}
+                                                          common)
 endif()

--- a/arch/arm64/src/cmake/Toolchain.cmake
+++ b/arch/arm64/src/cmake/Toolchain.cmake
@@ -1,0 +1,189 @@
+# ##############################################################################
+# arch/arm64/src/cmake/Toolchain.cmake
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_VERSION 1)
+set(CMAKE_C_COMPILER_FORCED TRUE)
+set(CMAKE_CXX_COMPILER_FORCED TRUE)
+
+# Default toolchain
+set(TOOLCHAIN_PREFIX aarch64-none-elf)
+
+set(CMAKE_LIBRARY_ARCHITECTURE ${TOOLCHAIN_PREFIX})
+set(CMAKE_C_COMPILER_TARGET ${TOOLCHAIN_PREFIX})
+set(CMAKE_CXX_COMPILER_TARGET ${TOOLCHAIN_PREFIX})
+set(CMAKE_ASM_COMPILER ${CMAKE_C_COMPILER})
+set(CMAKE_C_COMPILER ${TOOLCHAIN_PREFIX}-gcc)
+set(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}-g++)
+set(CMAKE_STRIP ${TOOLCHAIN_PREFIX}-strip --strl dunneeded)
+set(CMAKE_OBJCOPY ${TOOLCHAIN_PREFIX}-objcopy)
+set(CMAKE_OBJDUMP ${TOOLCHAIN_PREFIX}-objdump)
+set(CMAKE_LINKER ${TOOLCHAIN_PREFIX}-ld)
+set(CMAKE_LD ${TOOLCHAIN_PREFIX}-ld)
+set(CMAKE_AR ${TOOLCHAIN_PREFIX}-ar)
+set(CMAKE_NM ${TOOLCHAIN_PREFIX}-nm)
+set(CMAKE_RANLIB ${TOOLCHAIN_PREFIX}-gcc-ranlib)
+if(CONFIG_LTO_FULL)
+  add_compile_options(-flto)
+  if(CONFIG_ARM64_TOOLCHAIN_GNU_EABI)
+    set(CMAKE_LD ${TOOLCHAIN_PREFIX}-gcc)
+    set(CMAKE_AR ${TOOLCHAIN_PREFIX}-gcc-ar)
+    set(CMAKE_NM ${TOOLCHAIN_PREFIX}-gcc-nm)
+    add_compile_options(-fuse-linker-plugin)
+    add_compile_options(-fno-builtin)
+  endif()
+endif()
+
+add_link_options(--entry=__start)
+# override the ARCHIVE command
+set(CMAKE_C_ARCHIVE_CREATE "<CMAKE_AR> rcs <TARGET> <LINK_FLAGS> <OBJECTS>")
+set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> rcs <TARGET> <LINK_FLAGS> <OBJECTS>")
+set(CMAKE_ASM_ARCHIVE_CREATE "<CMAKE_AR> rcs <TARGET> <LINK_FLAGS> <OBJECTS>")
+
+if(CONFIG_ARCH_ARMV8A)
+  add_compile_options(-march=armv8-a)
+endif()
+
+if(CONFIG_ARCH_ARMV8R)
+  add_compile_options(-march=armv8-r)
+endif()
+
+if(CONFIG_ARCH_CORTEX_A53)
+  add_compile_options(-mcpu=cortex-a53)
+elseif(CONFIG_ARCH_CORTEX_A57)
+  add_compile_options(-mcpu=cortex-a57)
+elseif(CONFIG_ARCH_CORTEX_A72)
+  add_compile_options(-mcpu=cortex-a72)
+elseif(CONFIG_ARCH_CORTEX_R82)
+  add_compile_options(-mcpu=cortex-r82)
+endif()
+
+if(CONFIG_DEBUG_CUSTOMOPT)
+  add_compile_options(${CONFIG_DEBUG_OPTLEVEL})
+elseif(CONFIG_DEBUG_FULLOPT)
+  add_compile_options(-Os)
+endif()
+
+if(NOT CONFIG_DEBUG_NOOPT)
+  add_compile_options(-fno-strict-aliasing)
+endif()
+
+if(CONFIG_FRAME_POINTER)
+  add_compile_options(-fno-omit-frame-pointer -fno-optimize-sibling-calls)
+else()
+  add_compile_options(-fomit-frame-pointer)
+endif()
+
+if(CONFIG_STACK_CANARIES)
+  add_compile_options(-fstack-protector-all)
+endif()
+
+if(CONFIG_ARCH_COVERAGE_ALL)
+  add_compile_options(-fprofile-generate -ftest-coverage)
+endif()
+
+if(CONFIG_MM_UBSAN_ALL)
+  add_compile_options(${CONFIG_MM_UBSAN_OPTION})
+endif()
+
+if(CONFIG_MM_UBSAN_TRAP_ON_ERROR)
+  add_compile_options(-fsanitize-undefined-trap-on-error)
+endif()
+
+if(CONFIG_MM_KASAN_ALL)
+  add_compile_options(-fsanitize=kernel-address)
+endif()
+
+if(CONFIG_ARCH_INSTRUMENT_ALL)
+  add_compile_options(-finstrument-functions)
+endif()
+
+if(CONFIG_ARCH_FPU)
+  add_compile_options(-D_LDBL_EQ_DBL)
+endif()
+
+set(ARCHCFLAGS
+    "-Wstrict-prototypes -fno-common -Wall -Wshadow -Werror -Wundef -Wno-attributes -Wno-unknown-pragmas"
+)
+set(ARCHCXXFLAGS
+    "-nostdinc++ -fno-common -Wall -Wshadow -Wundef -Wno-attributes -Wno-unknown-pragmas"
+)
+if(NOT ${CONFIG_ARCH_TOOLCHAIN_CLANG})
+  string(APPEND ARCHCFLAGS " -Wno-psabi")
+  string(APPEND ARCHCXXFLAGS " -Wno-psabi")
+endif()
+
+if(${CONFIG_CXX_STANDARD})
+  string(APPEND ARCHCXXFLAGS " -std=${CONFIG_CXX_STANDARD}")
+endif()
+
+if(NOT ${CONFIG_CXX_EXCEPTION})
+  string(APPEND ARCHCXXFLAGS " -fno-exceptions -fcheck-new")
+endif()
+
+if(NOT ${CONFIG_CXX_RTTI})
+  string(APPEND ARCHCXXFLAGS " -fno-rtti")
+endif()
+
+add_link_options(-nostdlib)
+
+if(CONFIG_DEBUG_OPT_UNUSED_SECTIONS)
+  add_link_options(-Wl,--gc-sections)
+  add_compile_options(-ffunction-sections -fdata-sections)
+endif()
+
+if(CONFIG_DEBUG_LINK_MAP)
+  add_link_options(-Wl,-cref,-Map=nuttx.map)
+endif()
+
+if(CONFIG_DEBUG_SYMBOLS)
+  add_compile_options(-g)
+endif()
+
+if(CONFIG_ARCH_TOOLCHAIN_GNU)
+  if(NOT GCCVER)
+
+    execute_process(COMMAND ${CMAKE_C_COMPILER} --version
+                    OUTPUT_VARIABLE GCC_VERSION_INFO)
+
+    string(REGEX MATCH "[0-9]+\\.[0-9]+" GCC_VERSION ${GCC_VERSION_INFO})
+    string(REGEX REPLACE "\\..*" "" GCCVER ${GCC_VERSION})
+
+  endif()
+
+  if(GCCVER EQUAL 12)
+    add_link_options(-Wl,--no-warn-rwx-segments)
+  endif()
+endif()
+
+if(NOT "${CMAKE_C_FLAGS}" STREQUAL "")
+  string(REGEX MATCH "${ARCHCFLAGS}" EXISTS_FLAGS "${CMAKE_C_FLAGS}")
+endif()
+if(NOT EXISTS_FLAGS)
+  set(CMAKE_ASM_FLAGS
+      "${CMAKE_ASM_FLAGS} ${ARCHCFLAGS}"
+      CACHE STRING "" FORCE)
+  set(CMAKE_C_FLAGS
+      "${CMAKE_C_FLAGS} ${ARCHCFLAGS}"
+      CACHE STRING "" FORCE)
+  set(CMAKE_CXX_FLAGS
+      "${CMAKE_CXX_FLAGS} ${ARCHCXXFLAGS}"
+      CACHE STRING "" FORCE)
+endif()

--- a/arch/arm64/src/cmake/platform.cmake
+++ b/arch/arm64/src/cmake/platform.cmake
@@ -1,0 +1,54 @@
+# ##############################################################################
+# ./arch/arm64/src/cmake/platform.cmake
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+get_directory_property(NUTTX_EXTRA_FLAGS DIRECTORY ${CMAKE_SOURCE_DIR}
+                                                   COMPILE_OPTIONS)
+execute_process(
+  COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS} ${NUTTX_EXTRA_FLAGS}
+          --print-libgcc-file-name
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  OUTPUT_VARIABLE extra_library)
+list(APPEND EXTRA_LIB ${extra_library})
+if(NOT CONFIG_LIBM)
+  execute_process(
+    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS} ${NUTTX_EXTRA_FLAGS}
+            --print-file-name=libm.a
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE extra_library)
+  list(APPEND EXTRA_LIB ${extra_library})
+endif()
+if(CONFIG_LIBSUPCXX)
+  execute_process(
+    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS} ${NUTTX_EXTRA_FLAGS}
+            --print-file-name=libsupc++.a
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE extra_library)
+  list(APPEND EXTRA_LIB ${extra_library})
+endif()
+if(CONFIG_ARCH_COVERAGE)
+  execute_process(
+    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS} ${NUTTX_EXTRA_FLAGS}
+            --print-file-name=libgcov.a
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE extra_library)
+  list(APPEND EXTRA_LIB ${extra_library})
+endif()
+set_property(GLOBAL APPEND PROPERTY NUTTX_EXTRA_LIBRARIES ${EXTRA_LIB})
+separate_arguments(CMAKE_C_FLAG_ARGS NATIVE_COMMAND ${CMAKE_C_FLAGS})
+set(PREPROCES ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} -E -P -x c)

--- a/arch/arm64/src/common/CMakeLists.txt
+++ b/arch/arm64/src/common/CMakeLists.txt
@@ -1,0 +1,118 @@
+# ##############################################################################
+# arch/arm64/src/common/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS arm64_head.S)
+
+# TODO: support kernel startup obj ctr0
+
+list(APPEND SRCS arm64_vector_table.S arm64_vectors.S arm64_smccc.S)
+list(APPEND SRCS arm64_cpu_idle.S arm64_fork_func.S)
+
+if(CONFIG_ARCH_HAVE_TESTSET)
+  list(APPEND SRCS arm64_testset.S)
+endif()
+
+# Common C source files ( OS call up_xxx)
+list(APPEND SRCS arm64_initialize.c arm64_initialstate.c arm64_boot.c)
+list(APPEND SRCS arm64_nputs.c arm64_idle.c arm64_copystate.c
+     arm64_createstack.c)
+list(APPEND SRCS arm64_releasestack.c arm64_stackframe.c arm64_usestack.c)
+list(APPEND SRCS arm64_task_sched.c arm64_exit.c arm64_fork.c
+     arm64_switchcontext.c)
+list(APPEND SRCS arm64_schedulesigaction.c arm64_sigdeliver.c)
+list(APPEND SRCS arm64_getintstack.c arm64_registerdump.c)
+list(APPEND SRCS arm64_perf.c arm64_tcbinfo.c)
+
+# Common C source files ( hardware BSP )
+list(APPEND SRCS arm64_arch_timer.c arm64_cache.c)
+list(APPEND SRCS arm64_doirq.c arm64_fatal.c)
+list(APPEND SRCS arm64_syscall.c)
+
+# Use common heap allocation for now (may need to be customized later)
+list(APPEND SRCS arm64_allocateheap.c)
+
+if(CONFIG_ARM_GIC_VERSION EQUAL 3)
+  list(APPEND SRCS arm64_gicv3.c)
+endif()
+
+if(CONFIG_ARM_GIC_VERSION EQUAL 2)
+  list(APPEND SRCS arm64_gicv2.c)
+endif()
+
+if(CONFIG_ARCH_HAVE_MMU)
+  list(APPEND SRCS arm64_mmu.c)
+endif()
+
+if(CONFIG_ARCH_HAVE_MPU)
+  list(APPEND SRCS arm64_mpu.c)
+endif()
+
+if(CONFIG_ARCH_HAVE_PSCI)
+  list(APPEND SRCS arm64_cpu_psci.c arm64_systemreset.c)
+endif()
+
+if(CONFIG_SMP)
+  list(APPEND SRCS arm64_cpuidlestack.c arm64_cpustart.c)
+  list(APPEND SRCS arm64_cpupause.c)
+endif()
+
+if(CONFIG_BUILD_KERNEL)
+  list(APPEND SRCS arm64_task_start.c arm64_pthread_start.c
+       arm64_signal_dispatch.c)
+endif()
+
+if(CONFIG_ARCH_ADDRENV)
+  list(APPEND SRCS arm64_addrenv.c arm64_addrenv_utils.c arm64_pgalloc.c)
+  if(CONFIG_ARCH_STACK_DYNAMIC)
+    list(APPEND SRCS arm64_addrenv_ustack.c)
+  endif()
+  if(CONFIG_ARCH_KERNEL_STACK)
+    list(APPEND SRCS arm64_addrenv_kstack.c)
+  endif()
+  if(CONFIG_ARCH_VMA_MAPPING)
+    list(APPEND SRCS arm64_addrenv_shm.c)
+  endif()
+endif()
+
+if(CONFIG_MM_PGALLOC)
+  list(APPEND SRCS arm64_physpgaddr.c)
+  if(CONFIG_ARCH_PGPOOL_MAPPING)
+    list(APPEND SRCS arm64_virtpgaddr.c)
+  endif()
+endif()
+
+if(CONFIG_ARCH_FPU)
+  list(APPEND SRCS arm64_fpu.c)
+  list(APPEND SRCS arm64_fpu_func.S)
+endif()
+
+if(CONFIG_STACK_COLORATION)
+  list(APPEND SRCS arm64_checkstack.c)
+endif()
+
+if(CONFIG_SCHED_BACKTRACE)
+  list(APPEND SRCS arm64_backtrace.c)
+endif()
+
+if(CONFIG_ARM64_SEMIHOSTING_HOSTFS)
+  list(APPEND SRCS arm64_hostfs.c)
+endif()
+
+target_sources(arch PRIVATE ${SRCS})

--- a/arch/arm64/src/qemu/CMakeLists.txt
+++ b/arch/arm64/src/qemu/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# libs/libc/fdt/CMakeLists.txt
+# arch/arm64/src/qemu/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
@@ -17,37 +17,12 @@
 # the License.
 #
 # ##############################################################################
-if(CONFIG_LIBC_FDT)
+set(SRCS qemu_boot.c qemu_serial.c)
 
-  set(FDT_DIR ${CMAKE_CURRENT_LIST_DIR}/dtc)
-  if(NOT EXISTS ${FDT_DIR})
-    set(VERSION ${CONFIG_LIBC_FDT_DTC_VERSION})
-
-    FetchContent_Declare(
-      dtc
-      URL https://github.com/dgibson/dtc/archive/v${VERSION}.zip SOURCE_DIR
-          ${CMAKE_CURRENT_LIST_DIR}/dtc BINARY_DIR
-          ${CMAKE_BINARY_DIR}/libs/libc/fdt/dtc)
-    FetchContent_GetProperties(dtc)
-    if(NOT dtc_POPULATED)
-      FetchContent_Populate(dtc)
-    endif()
-  endif()
-
-  set(SRCS
-      fdt.c
-      fdt_ro.c
-      fdt_wip.c
-      fdt_sw.c
-      fdt_rw.c
-      fdt_strerror.c
-      fdt_empty_tree.c
-      fdt_addresses.c
-      fdt_overlay.c
-      fdt_check.c)
-  list(TRANSFORM SRCS PREPEND ${FDT_DIR}/libfdt/)
-
-  target_sources(c PRIVATE ${SRCS})
-
-  target_include_directories(c PRIVATE ${FDT_DIR}/libfdt)
+if(CONFIG_ARCH_EARLY_PRINT)
+  list(APPEND SRCS qemu_lowputc.S)
 endif()
+if(CONFIG_ARCH_USE_TEXT_HEAP)
+  list(APPEND SRCS qemu_textheap.c)
+endif()
+target_sources(arch PRIVATE ${SRCS})

--- a/boards/arm64/qemu/qemu-armv8a/CMakeLists.txt
+++ b/boards/arm64/qemu/qemu-armv8a/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# libs/libc/fdt/CMakeLists.txt
+# boards/arm64/qemu/qemu-armv8a/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
@@ -17,37 +17,7 @@
 # the License.
 #
 # ##############################################################################
-if(CONFIG_LIBC_FDT)
 
-  set(FDT_DIR ${CMAKE_CURRENT_LIST_DIR}/dtc)
-  if(NOT EXISTS ${FDT_DIR})
-    set(VERSION ${CONFIG_LIBC_FDT_DTC_VERSION})
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/dramboot.ld")
 
-    FetchContent_Declare(
-      dtc
-      URL https://github.com/dgibson/dtc/archive/v${VERSION}.zip SOURCE_DIR
-          ${CMAKE_CURRENT_LIST_DIR}/dtc BINARY_DIR
-          ${CMAKE_BINARY_DIR}/libs/libc/fdt/dtc)
-    FetchContent_GetProperties(dtc)
-    if(NOT dtc_POPULATED)
-      FetchContent_Populate(dtc)
-    endif()
-  endif()
-
-  set(SRCS
-      fdt.c
-      fdt_ro.c
-      fdt_wip.c
-      fdt_sw.c
-      fdt_rw.c
-      fdt_strerror.c
-      fdt_empty_tree.c
-      fdt_addresses.c
-      fdt_overlay.c
-      fdt_check.c)
-  list(TRANSFORM SRCS PREPEND ${FDT_DIR}/libfdt/)
-
-  target_sources(c PRIVATE ${SRCS})
-
-  target_include_directories(c PRIVATE ${FDT_DIR}/libfdt)
-endif()
+add_subdirectory(src)

--- a/boards/arm64/qemu/qemu-armv8a/src/CMakeLists.txt
+++ b/boards/arm64/qemu/qemu-armv8a/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# libs/libc/fdt/CMakeLists.txt
+# boards/arm64/qemu/qemu-armv8a/src/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
@@ -17,37 +17,16 @@
 # the License.
 #
 # ##############################################################################
-if(CONFIG_LIBC_FDT)
+set(SRCS qemu_boardinit.c qemu_bringup.c)
 
-  set(FDT_DIR ${CMAKE_CURRENT_LIST_DIR}/dtc)
-  if(NOT EXISTS ${FDT_DIR})
-    set(VERSION ${CONFIG_LIBC_FDT_DTC_VERSION})
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS qemu_appinit.c)
 
-    FetchContent_Declare(
-      dtc
-      URL https://github.com/dgibson/dtc/archive/v${VERSION}.zip SOURCE_DIR
-          ${CMAKE_CURRENT_LIST_DIR}/dtc BINARY_DIR
-          ${CMAKE_BINARY_DIR}/libs/libc/fdt/dtc)
-    FetchContent_GetProperties(dtc)
-    if(NOT dtc_POPULATED)
-      FetchContent_Populate(dtc)
-    endif()
-  endif()
-
-  set(SRCS
-      fdt.c
-      fdt_ro.c
-      fdt_wip.c
-      fdt_sw.c
-      fdt_rw.c
-      fdt_strerror.c
-      fdt_empty_tree.c
-      fdt_addresses.c
-      fdt_overlay.c
-      fdt_check.c)
-  list(TRANSFORM SRCS PREPEND ${FDT_DIR}/libfdt/)
-
-  target_sources(c PRIVATE ${SRCS})
-
-  target_include_directories(c PRIVATE ${FDT_DIR}/libfdt)
 endif()
+
+if(CONFIG_LIBC_FDT)
+  target_include_directories(board
+                             PRIVATE ${NUTTX_DIR}/libs/libc/fdt/dtc/libfdt)
+endif()
+
+target_sources(board PRIVATE ${SRCS})

--- a/libs/libc/machine/arm64/CMakeLists.txt
+++ b/libs/libc/machine/arm64/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# libs/libc/fdt/CMakeLists.txt
+# libs/libc/machine/arm64/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
@@ -17,37 +17,12 @@
 # the License.
 #
 # ##############################################################################
-if(CONFIG_LIBC_FDT)
+add_subdirectory(gnu)
 
-  set(FDT_DIR ${CMAKE_CURRENT_LIST_DIR}/dtc)
-  if(NOT EXISTS ${FDT_DIR})
-    set(VERSION ${CONFIG_LIBC_FDT_DTC_VERSION})
+set(SRCS)
 
-    FetchContent_Declare(
-      dtc
-      URL https://github.com/dgibson/dtc/archive/v${VERSION}.zip SOURCE_DIR
-          ${CMAKE_CURRENT_LIST_DIR}/dtc BINARY_DIR
-          ${CMAKE_BINARY_DIR}/libs/libc/fdt/dtc)
-    FetchContent_GetProperties(dtc)
-    if(NOT dtc_POPULATED)
-      FetchContent_Populate(dtc)
-    endif()
-  endif()
-
-  set(SRCS
-      fdt.c
-      fdt_ro.c
-      fdt_wip.c
-      fdt_sw.c
-      fdt_rw.c
-      fdt_strerror.c
-      fdt_empty_tree.c
-      fdt_addresses.c
-      fdt_overlay.c
-      fdt_check.c)
-  list(TRANSFORM SRCS PREPEND ${FDT_DIR}/libfdt/)
-
-  target_sources(c PRIVATE ${SRCS})
-
-  target_include_directories(c PRIVATE ${FDT_DIR}/libfdt)
+if(CONFIG_LIBC_ARCH_ELF_64BIT)
+  list(APPEND SRCS arch_elf.c)
 endif()
+
+target_sources(c PRIVATE ${SRCS})

--- a/libs/libc/machine/arm64/gnu/CMakeLists.txt
+++ b/libs/libc/machine/arm64/gnu/CMakeLists.txt
@@ -1,0 +1,79 @@
+# ##############################################################################
+# libs/libc/machine/arm64/gnu/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS)
+
+if(CONFIG_ARM64_MEMCHR)
+  list(APPEND SRCS arch_memchr.S)
+endif()
+
+if(CONFIG_ARM64_MEMCMP)
+  list(APPEND SRCS arch_memcmp.S)
+endif()
+
+if(CONFIG_ARM64_MEMCPY)
+  list(APPEND SRCS arch_memcpy.S)
+endif()
+
+if(CONFIG_ARM64_MEMMOVE)
+  list(APPEND SRCS arch_memmove.S)
+endif()
+
+if(CONFIG_ARM64_MEMSET)
+  list(APPEND SRCS arch_memset.S)
+endif()
+
+if(CONFIG_ARM64_STRCHR)
+  list(APPEND SRCS arch_strchr.S)
+endif()
+
+if(CONFIG_ARM64_STRCHRNUL)
+  list(APPEND SRCS arch_strchrnul.S)
+endif()
+
+if(CONFIG_ARM64_STRCMP)
+  list(APPEND SRCS arch_strcmp.S)
+endif()
+
+if(CONFIG_ARM64_STRCPY)
+  list(APPEND SRCS arch_strcpy.S)
+endif()
+
+if(CONFIG_ARM64_STRLEN)
+  list(APPEND SRCS arch_strlen.S)
+endif()
+
+if(CONFIG_ARM64_STRNCMP)
+  list(APPEND SRCS arch_strncmp.S)
+endif()
+
+if(CONFIG_ARM64_STRNLEN)
+  list(APPEND SRCS arch_strnlen.S)
+endif()
+
+if(CONFIG_ARM64_STRRCHR)
+  list(APPEND SRCS arch_strrchr.S)
+endif()
+
+if(CONFIG_ARCH_SETJMP_H)
+  list(APPEND SRCS arch_setjmp.S)
+endif()
+
+target_sources(c PRIVATE ${SRCS})

--- a/tools/ci/testlist/other.dat
+++ b/tools/ci/testlist/other.dat
@@ -22,3 +22,13 @@
 -xx3823:nsh
 
 /arm64
+
+# arm64 Boards build by CMake
+CMake,qemu-armv8a:citest
+CMake,qemu-armv8a:citest_smp
+CMake,qemu-armv8a:nsh
+CMake,qemu-armv8a:nsh_fiq
+CMake,qemu-armv8a:nsh_gicv2
+CMake,qemu-armv8a:nsh_smp
+CMake,qemu-armv8a:nsh_smp_tickless
+CMake,qemu-armv8a:sotest


### PR DESCRIPTION
## Summary
1. init arch arm64 CMake build
2. enable qemu-armv8a ci cmake build

## Impact
arm64 arch

## Testing
```
# From within nuttx/. Configure:

$ cmake -B build -DBOARD_CONFIG=qemu-armv8a:nsh -GNinja

# To build:

$ cmake --build build

# menuconfig:

$ cmake --build build -t menuconfig

# Run:

$ qemu-system-aarch64 -cpu cortex-a53 -nographic -machine virt,virtualization=on,gic-version=3 -net none -chardev stdio,id=con,mux=on -serial chardev:con -mon chardev=con,mode=readline -kernel ./nuttx

```