### PR TITLE
[Fix]CI warning in GNU make 4.3 'jobserver unavailable'

### DIFF
--- a/tools/Unix.mk
+++ b/tools/Unix.mk
@@ -24,12 +24,6 @@ ifeq ($(V),)
   MAKE := $(MAKE) -s --no-print-directory
 endif
 
-# Build any necessary tools needed early in the build.
-# incdir - Is needed immediately by all Make.defs file.
-
-DUMMY  := ${shell $(MAKE) -C tools -f Makefile.host incdir \
-          INCDIR="$(TOPDIR)/tools/incdir.sh"}
-
 include $(TOPDIR)/Make.defs
 
 # GIT directory present
@@ -221,6 +215,13 @@ ifeq ($(CONFIG_ARCH_SETJMP_H),y)
 include/setjmp.h: include/nuttx/lib/setjmp.h
 	$(Q) cp -f include/nuttx/lib/setjmp.h include/setjmp.h
 endif
+
+# Targets used to generate compiler-specific include paths
+# Build this tools needed early in the build
+# so we define it as a dependency of `context` target
+
+tools/incdir$(HOSTEXEEXT):
+	$(Q) $(MAKE) -C tools -f Makefile.host incdir INCDIR="$(TOPDIR)/tools/incdir.sh"
 
 # Targets used to build include/nuttx/version.h.  Creation of version.h is
 # part of the overall NuttX configuration sequence. Notice that the
@@ -440,7 +441,7 @@ endif
 
 CONTEXTDIRS_DEPS = $(patsubst %,%/.context,$(CONTEXTDIRS))
 
-context: include/nuttx/config.h include/nuttx/version.h .dirlinks $(CONTEXTDIRS_DEPS) | staging
+context: tools/incdir$(HOSTEXEEXT) include/nuttx/config.h include/nuttx/version.h .dirlinks $(CONTEXTDIRS_DEPS) | staging
 
 staging:
 	$(Q) mkdir -p $@

--- a/tools/Win.mk
+++ b/tools/Win.mk
@@ -22,12 +22,6 @@ export SHELL=cmd
 
 export TOPDIR := ${shell echo %CD%}
 
-# Build any necessary tools needed early in the build.
-# incdir - Is needed immediately by all Make.defs file.
-
-DUMMY  := ${shell $(MAKE) -C tools -f Makefile.host incdir \
-          INCDIR="$(TOPDIR)\tools\incdir.bat"}
-
 include $(TOPDIR)\Make.defs
 -include $(TOPDIR)\.version
 
@@ -209,6 +203,13 @@ include\setjmp.h: include\nuttx\lib\setjmp.h
 else
 include\setjmp.h:
 endif
+
+# Targets used to generate compiler-specific include paths
+# Build this tools needed early in the build
+# so we define it as a dependency of `context` target
+
+tools\incdir$(HOSTEXEEXT):
+	$(Q) $(MAKE) -C tools -f Makefile.host incdir INCDIR="$(TOPDIR)\tools\incdir.bat"
 
 # Targets used to build include\nuttx\version.h.  Creation of version.h is
 # part of the overall NuttX configuration sequence. Notice that the
@@ -424,7 +425,7 @@ endif
 
 CONTEXTDIRS_DEPS = $(patsubst %,%\.context,$(CONTEXTDIRS))
 
-context: include\nuttx\config.h include\nuttx\version.h $(CONTEXTDIRS_DEPS) .dirlinks | staging
+context: tools\incdir$(HOSTEXEEXT) include\nuttx\config.h include\nuttx\version.h $(CONTEXTDIRS_DEPS) .dirlinks | staging
 
 ifeq ($(NEED_MATH_H),y)
 context: include\math.h


### PR DESCRIPTION

## Summary
after the CI environment is upgraded to Ubuntu 22 and GNU make is upgraded to 4.3, 
`warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.` warning appears. 
**these warnings make it difficult to troubleshoot errors in github actions.**
![image](https://github.com/apache/nuttx/assets/31881278/3b817380-56bc-4173-8a52-a6c9a0509a0e)

this because when executing a shell in Make, the new shell created will not inherit the parallel environment of the parent shell(jobserver).

in our case:
```
$ make olddefconfig

## this execute into Unix.mk twice,
## because it will call make clean_context in its target

###  olddefconfig:
###          $(Q) $(MAKE) clean_context
```
## Impact

## Testing
CI warning

