### PR TITLE
sim: make the cmake version of hostfs build similar to the Makefile one

### DIFF
--- a/arch/sim/src/sim/CMakeLists.txt
+++ b/arch/sim/src/sim/CMakeLists.txt
@@ -229,9 +229,10 @@ list(APPEND HOST_DEFINITIONS CONFIG_NAME_MAX=${CONFIG_NAME_MAX})
 
 configure_file(${NUTTX_DIR}/include/nuttx/fs/hostfs.h
                ${CMAKE_CURRENT_BINARY_DIR}/hostfs.h COPYONLY)
+configure_file(${CMAKE_BINARY_DIR}/include/nuttx/config.h
+               ${CMAKE_CURRENT_BINARY_DIR}/config.h COPYONLY)
 target_include_directories(nuttx PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-target_include_directories(nuttx PRIVATE ${CMAKE_BINARY_DIR}/include/nuttx)
 target_include_directories(nuttx PRIVATE ${CMAKE_CURRENT_LIST_DIR})
 
 target_include_directories(sim_head PUBLIC ${NUTTX_DIR}/sched)


### PR DESCRIPTION
## Summary
sim: make the cmake version of hostfs build similar to the Makefile one

## Impact
solve https://github.com/apache/nuttx/pull/11458#issuecomment-1870297510

## Testing

