### PR TITLE
adjust log levels of a few binfmt logs

### DIFF
--- a/binfmt/libelf/libelf_bind.c
+++ b/binfmt/libelf/libelf_bind.c
@@ -496,7 +496,7 @@ static int elf_relocateadd(FAR struct elf_loadinfo_s *loadinfo, int relidx,
 
               if (ret == -ESRCH)
                 {
-                  berr("Section %d reloc %d: "
+                  bwarn("Section %d reloc %d: "
                        "Undefined symbol[%d] has no name: %d\n",
                        relidx, i, symidx, ret);
                 }

--- a/binfmt/libelf/libelf_symbols.c
+++ b/binfmt/libelf/libelf_symbols.c
@@ -76,7 +76,7 @@ static int elf_symname(FAR struct elf_loadinfo_s *loadinfo,
 
   if (sym->st_name == 0)
     {
-      berr("Symbol has no name\n");
+      bwarn("Symbol has no name\n");
       return -ESRCH;
     }
 
@@ -292,7 +292,7 @@ int elf_symvalue(FAR struct elf_loadinfo_s *loadinfo, FAR Elf_Sym *sym,
              * indicate the nameless symbol.
              */
 
-            berr("SHN_UNDEF: Failed to get symbol name: %d\n", ret);
+            bwarn("SHN_UNDEF: Failed to get symbol name: %d\n", ret);
             return ret;
           }
 


### PR DESCRIPTION
## Summary

log messages from binfmt are very much.
this is to adjust levels of a few based on debugging experiences. These non-critical logs were marked as errors. So we likely can adjust them as warnings so that real errors can stand out easily.

## Impact

None as we can always adjust debug configs if we want see them.
 
## Testing

checked with canmv230
