### PR TITLE
make 64-bit time_t back to unsigned

### DIFF
--- a/include/nuttx/fs/hostfs.h
+++ b/include/nuttx/fs/hostfs.h
@@ -135,7 +135,7 @@ typedef int          nuttx_fsid_t[2];
 /* These must match the definition in include/time.h */
 
 #  ifdef CONFIG_SYSTEM_TIME64
-typedef int64_t      nuttx_time_t;
+typedef uint64_t     nuttx_time_t;
 #  else
 typedef uint32_t     nuttx_time_t;
 #  endif

--- a/include/sys/types.h
+++ b/include/sys/types.h
@@ -249,7 +249,7 @@ typedef uint16_t     sa_family_t;
 
 #ifdef CONFIG_SYSTEM_TIME64
 typedef uint64_t     clock_t;
-typedef int64_t      time_t;         /* Holds time in seconds */
+typedef uint64_t     time_t;         /* Holds time in seconds */
 #else
 typedef uint32_t     clock_t;
 typedef uint32_t     time_t;         /* Holds time in seconds */


### PR DESCRIPTION
## Summary

it has been changed by https://github.com/apache/nuttx/pull/10303 without any explicit mentions. i suppose it was a mistake.

see https://github.com/apache/nuttx/pull/8201 and referenced PRs for previous discussions.

## Impact

## Testing

