### PR TITLE
add missing dependency to MM_KMAP for ARCH_KMAP_VBASE

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -696,6 +696,7 @@ config ARCH_SHM_VBASE
 
 config ARCH_KMAP_VBASE
 	hex "Kernel dynamic virtual mappings base"
+	depends on MM_KMAP
 	---help---
 		The virtual address of the beginning of the kernel dynamic mapping
 		region.


### PR DESCRIPTION
## Summary

This is to align with ARCH_KMAP_VBASE by source codes. 
It also fixes CI warnings/errors reported by `tools/refresh.sh` for some KERNEL mode defconfigs.

## Impact

None

## Testing

Checked with CanMV230
