### PR TITLE
armv7-m: Expose section name to allow relocation

### DIFF
--- a/arch/arm/src/armv7-m/arm_exception.S
+++ b/arch/arm/src/armv7-m/arm_exception.S
@@ -118,6 +118,7 @@
  */
 
 	.text
+	.section    .text.exception_common
 	.thumb_func
 	.type	exception_common, function
 exception_common:

--- a/libs/libc/machine/arm/armv7-m/gnu/arch_memchr.S
+++ b/libs/libc/machine/arm/armv7-m/gnu/arch_memchr.S
@@ -136,6 +136,7 @@
  */
 
 	.text
+	.section .text.memchr
 	.thumb_func
 	.align 4
 	.p2align 4,,15

--- a/libs/libc/machine/arm/armv7-m/gnu/arch_memcpy.S
+++ b/libs/libc/machine/arm/armv7-m/gnu/arch_memcpy.S
@@ -94,6 +94,7 @@
 
 	.syntax unified
 	.text
+	.section .text.memcpy
 	.align	2
 	.global	memcpy
 	.thumb

--- a/libs/libc/machine/arm/armv7-m/gnu/arch_memmove.S
+++ b/libs/libc/machine/arm/armv7-m/gnu/arch_memmove.S
@@ -35,6 +35,8 @@
 
 	.thumb
 	.syntax unified
+	.text
+	.section .text.memmove
 	.global memmove
 	.type	memmove, %function
 memmove:

--- a/libs/libc/machine/arm/armv7-m/gnu/arch_memset.S
+++ b/libs/libc/machine/arm/armv7-m/gnu/arch_memset.S
@@ -35,6 +35,8 @@
 
 	.thumb
 	.syntax unified
+	.text
+	.section .text.memset
 	.global memset
 	.type	memset, %function
 memset:

--- a/libs/libc/machine/arm/armv7-m/gnu/arch_strcmp.S
+++ b/libs/libc/machine/arm/armv7-m/gnu/arch_strcmp.S
@@ -72,6 +72,7 @@
 
 	.macro def_fn f p2align=0
 	.text
+	.section .text.strcmp
 	.p2align \p2align
 	.global \f
 	.type \f, %function

--- a/libs/libc/machine/arm/armv7-m/gnu/arch_strcpy.S
+++ b/libs/libc/machine/arm/armv7-m/gnu/arch_strcpy.S
@@ -58,6 +58,7 @@
 
     .syntax unified
     .text
+    .section .text.strcpy
     .align  2
     .global strcpy
     .thumb

--- a/libs/libc/machine/arm/armv7-m/gnu/arch_strlen.S
+++ b/libs/libc/machine/arm/armv7-m/gnu/arch_strlen.S
@@ -70,6 +70,7 @@
 
 	.macro def_fn f p2align=0
 	.text
+	.section .text.strlen
 	.p2align \p2align
 	.global \f
 	.type \f, %function


### PR DESCRIPTION
## Summary
Current armv7-m end up in `.text` without any way for the linker to relocate the symbol.
Symbol relocation is needed for example to run the interrupt handler from ITCM

## Impact
Minimal compile hints

## Testing
ARMV7M imxrt

