### PR TITLE
qemu_bringup: add tmp fs mount for qemu-armv8a

### DIFF
--- a/boards/arm64/qemu/qemu-armv8a/src/qemu_bringup.c
+++ b/boards/arm64/qemu/qemu-armv8a/src/qemu_bringup.c
@@ -198,6 +198,16 @@ int qemu_bringup(void)
 {
   int ret;
 
+#ifdef CONFIG_FS_TMPFS
+  /* Mount the tmp file system */
+
+  ret = nx_mount(NULL, CONFIG_LIBC_TMPDIR, "tmpfs", 0, NULL);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to mount tmpfs at /tmp: %d\n", ret);
+    }
+#endif
+
 #ifdef CONFIG_FS_PROCFS
   /* Mount the procfs file system */
 


### PR DESCRIPTION
## Summary
tmpfs can be used for the rpmsgfs test after the qemu rptun driver added.

## Impact
Should be none

## Testing
qemu-armv8a:netnsh with CONFIG_FS_TMPFS enable
