### PR TITLE
local_sendmsg: fix peer->lc_cfps[] array out-of-range write

### DIFF
--- a/net/local/local_sendmsg.c
+++ b/net/local/local_sendmsg.c
@@ -91,7 +91,7 @@ static int local_sendctl(FAR struct local_conn_s *conn,
       fds = (int *)CMSG_DATA(cmsg);
       count = (cmsg->cmsg_len - sizeof(struct cmsghdr)) / sizeof(int);
 
-      if (count + peer->lc_cfpcount > LOCAL_NCONTROLFDS)
+      if (count + peer->lc_cfpcount >= LOCAL_NCONTROLFDS)
         {
           ret = -EMFILE;
           goto fail;


### PR DESCRIPTION
## Summary
When peer->lc_cfpcount == LOCAL_NCONTROLFDS,
Line 122: peer->lc_cfps[peer->lc_cfpcount++] = filep2; access out-of-range

## Impact
Bug fix

## Testing
The static code scanning tool scanned this issue.
