### PR TITLE
rpmsg_sockif: recv/recvmsg return 0 when peer close

### DIFF
--- a/net/rpmsg/rpmsg_sockif.c
+++ b/net/rpmsg/rpmsg_sockif.c
@@ -1301,7 +1301,7 @@ static ssize_t rpmsg_socket_recvmsg(FAR struct socket *psock,
                       _SO_TIMEOUT(conn->sconn.s_rcvtimeo));
   if (!conn->ept.rdev || conn->unbind)
     {
-      ret = -ECONNRESET;
+      ret = 0;
     }
 
   nxmutex_lock(&conn->recvlock);


### PR DESCRIPTION
## Summary
Follow the posix standard:
If no messages are available to be received and the peer has performed an orderly shutdown, recv() shall return 0.

## Impact
rpmsg socket

## Testing
sim:rpserver, rpproxy, and rpmsg socket example (EXAMPLES_RPMSGSOCKET)
