### PR TITLE
assert: fix flags type, should be irqstate_t

### DIFF
--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -514,8 +514,8 @@ void _assert(FAR const char *filename, int linenum,
 #endif
   struct panic_notifier_s notifier_data;
   struct utsname name;
+  irqstate_t flags;
   bool fatal = true;
-  int flags;
 
 #if CONFIG_TASK_NAME_SIZE > 0
   if (rtcb->group && !(rtcb->flags & TCB_FLAG_TTYPE_KERNEL))


### PR DESCRIPTION
## Summary
fix flags type, should be irqstate_t

## Impact
should be none

## Testing
qemu-armv8a:netnsh compile pass
