### PR TITLE
risc-v/k230: revise CanMV230 kernel build support

### DIFF
--- a/boards/risc-v/k230/canmv230/scripts/Make.defs
+++ b/boards/risc-v/k230/canmv230/scripts/Make.defs
@@ -48,3 +48,18 @@ CXXELFFLAGS = $(CXXFLAGS)
 LDELFFLAGS = --oformat elf64-littleriscv
 LDELFFLAGS += -r -e main
 LDELFFLAGS += -T $(call CONVERT_PATH,$(TOPDIR)/binfmt/libelf/gnu-elf.ld)
+
+# POSTBUILD management
+
+ifeq ($(CONFIG_BUILD_KERNEL),y)
+ifeq ($(wildcard $(BOARD_DIR)$(DELIM)src$(DELIM)romfs_boot.c),)
+define POSTBUILD
+  $(Q) echo "Please replace stub ROMFS w/ real one."
+  $(Q) rm $(BOARD_DIR)$(DELIM)src$(DELIM)libboard.a
+endef
+else
+define POSTBUILD
+  $(Q) echo "wrap nuttx.bin w/ SBI to run on target."
+endef
+endif
+endif

--- a/boards/risc-v/k230/canmv230/scripts/ld-flat.script
+++ b/boards/risc-v/k230/canmv230/scripts/ld-flat.script
@@ -1,5 +1,5 @@
 /****************************************************************************
- * boards/risc-v/qemu-rv/rv-virt/scripts/ld.script
+ * boards/risc-v/k230/canmv230/scripts/ld-flat.script
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -20,7 +20,7 @@
 
 SECTIONS
 {
-  . = 0x08000000;
+  . = 0x8000000;
 
   .text :
     {
@@ -114,7 +114,7 @@ SECTIONS
       _ebss = . ;
     }
 
-    /* Stabs debugging sections.    */
+    /* Stabs debugging sections. */
 
     .stab 0 : { *(.stab) }
     .stabstr 0 : { *(.stabstr) }

--- a/boards/risc-v/k230/canmv230/scripts/ld-kernel.script
+++ b/boards/risc-v/k230/canmv230/scripts/ld-kernel.script
@@ -126,7 +126,7 @@ SECTIONS
         _ebss = ABSOLUTE(.);
     } > ksram
 
-    /* Stabs debugging sections.    */
+    /* Stabs debugging sections. */
 
     .stab 0 : { *(.stab) }
     .stabstr 0 : { *(.stabstr) }

--- a/boards/risc-v/k230/canmv230/src/Makefile
+++ b/boards/risc-v/k230/canmv230/src/Makefile
@@ -25,7 +25,17 @@ RCSRCS = etc/init.d/rc.sysinit etc/init.d/rcS
 CSRCS = canmv_init.c 
 
 ifeq ($(CONFIG_BUILD_KERNEL),y)
-CSRCS += $(wildcard romfs_*.c)
+CSRCS += $(if $(wildcard romfs_boot.c), romfs_boot.c, romfs_stub.c)
 endif
 
 include $(TOPDIR)/boards/Board.mk
+
+# don't use single-colon targets as they may coflict with those included ones.
+# use double-colon targets to avoid collisions below.
+
+ifeq ($(CONFIG_BUILD_KERNEL),y)
+.PHONY: clean
+clean::
+	$(call DELFILE, romfs_boot.c)
+endif
+

--- a/boards/risc-v/k230/canmv230/src/canmv_init.c
+++ b/boards/risc-v/k230/canmv230/src/canmv_init.c
@@ -125,19 +125,15 @@ void board_late_initialize(void)
 #ifdef CONFIG_BUILD_KERNEL
   /* Create ROM disk for mount in nx_start_application */
 
-  if (NSECTORS(romfs_img_len) > 5)
+  if (NSECTORS(romfs_img_len) > 1)
     {
       int ret = OK;
       ret = romdisk_register(0, romfs_img, NSECTORS(romfs_img_len),
         SECTORSIZE);
       if (ret < 0)
         {
-          serr("ERROR: Failed to register romfs: %d\n", -ret);
+          ferr("ERROR: Failed to register romfs: %d\n", -ret);
         }
-    }
-  else
-    {
-      swarn("ROMFS too small: %d\n", NSECTORS(romfs_img_len));
     }
 #endif /* CONFIG_BUILD_KERNEL */
 

--- a/boards/risc-v/k230/canmv230/src/romfs_stub.c
+++ b/boards/risc-v/k230/canmv230/src/romfs_stub.c
@@ -27,7 +27,7 @@ weak_data const unsigned char aligned_data(4) romfs_img[] =
 {
   0x00
 };
-weak_data unsigned int romfs_img_len = 1;
+weak_data const unsigned int romfs_img_len = 1;
 
 /****************************************************************************
  * Private Functions


### PR DESCRIPTION
## Summary

changes:
- under boards/risc-v/k230/canmv230/scripts/:
  - Make.defs            add POSTBUILD actions
  - ld-flat.script         minor reformating
  - ld-kernel.script   minor reformating
- under boards/risc-v/k230/canmv230/src/:
  - Makefile               add clean of generated ROMFS source
  - canmv_init.c        use `ferr` and drop too late runtime warning
  - romfs_stub.c       use const for romfs_img_len

The POSTBULD actions can warn stub ROMFS usage at build time, thus the too late warning in canmv_init.c can be removed. 
The cleaning of `libboard.a` in POSTBUILD can also ensure real ROMFS is in use, as some times weak_data is still in use.

## Impact

risc-v canmv230 device 

## Testing

tested with canmv230 