### PR TITLE
net: Only call `arp_send` for `PF_INET` and `icmpv6_neighbor` for `PF_INET6`

### DIFF
--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -1319,7 +1319,7 @@ int tcp_bind(FAR struct tcp_conn_s *conn, FAR const struct sockaddr *addr)
 int tcp_connect(FAR struct tcp_conn_s *conn, FAR const struct sockaddr *addr)
 {
   int port;
-  int ret;
+  int ret = OK;
 
   /* The connection is expected to be in the TCP_ALLOCATED state.. i.e.,
    * allocated via up_tcpalloc(), but not yet put into the active connections
@@ -1468,7 +1468,7 @@ int tcp_connect(FAR struct tcp_conn_s *conn, FAR const struct sockaddr *addr)
 
 #if defined(CONFIG_NET_ARP_SEND) || defined(CONFIG_NET_ICMPv6_NEIGHBOR)
 #ifdef CONFIG_NET_ARP_SEND
-#ifdef CONFIG_NET_ICMPv6_NEIGHBOR
+#if defined(CONFIG_NET_IPv4) && defined(CONFIG_NET_IPv6)
   if (conn->domain == PF_INET)
 #endif
     {
@@ -1479,8 +1479,8 @@ int tcp_connect(FAR struct tcp_conn_s *conn, FAR const struct sockaddr *addr)
 #endif /* CONFIG_NET_ARP_SEND */
 
 #ifdef CONFIG_NET_ICMPv6_NEIGHBOR
-#ifdef CONFIG_NET_ARP_SEND
-  else
+#if defined(CONFIG_NET_IPv4) && defined(CONFIG_NET_IPv6)
+  if (conn->domain == PF_INET6)
 #endif
     {
       /* Make sure that the IP address mapping is in the Neighbor Table */

--- a/net/tcp/tcp_send_buffered.c
+++ b/net/tcp/tcp_send_buffered.c
@@ -1304,9 +1304,7 @@ ssize_t psock_tcp_send(FAR struct socket *psock, FAR const void *buf,
 
 #if defined(CONFIG_NET_ARP_SEND) || defined(CONFIG_NET_ICMPv6_NEIGHBOR)
 #ifdef CONFIG_NET_ARP_SEND
-#ifdef CONFIG_NET_ICMPv6_NEIGHBOR
   if (psock->s_domain == PF_INET)
-#endif
     {
       /* Make sure that the IP address mapping is in the ARP table */
 
@@ -1315,9 +1313,7 @@ ssize_t psock_tcp_send(FAR struct socket *psock, FAR const void *buf,
 #endif /* CONFIG_NET_ARP_SEND */
 
 #ifdef CONFIG_NET_ICMPv6_NEIGHBOR
-#ifdef CONFIG_NET_ARP_SEND
-  else
-#endif
+  if (psock->s_domain == PF_INET6)
     {
       /* Make sure that the IP address mapping is in the Neighbor Table */
 

--- a/net/tcp/tcp_send_unbuffered.c
+++ b/net/tcp/tcp_send_unbuffered.c
@@ -508,9 +508,7 @@ ssize_t psock_tcp_send(FAR struct socket *psock,
 
 #if defined(CONFIG_NET_ARP_SEND) || defined(CONFIG_NET_ICMPv6_NEIGHBOR)
 #ifdef CONFIG_NET_ARP_SEND
-#ifdef CONFIG_NET_ICMPv6_NEIGHBOR
   if (psock->s_domain == PF_INET)
-#endif
     {
       /* Make sure that the IP address mapping is in the ARP table */
 
@@ -519,9 +517,7 @@ ssize_t psock_tcp_send(FAR struct socket *psock,
 #endif /* CONFIG_NET_ARP_SEND */
 
 #ifdef CONFIG_NET_ICMPv6_NEIGHBOR
-#ifdef CONFIG_NET_ARP_SEND
-  else
-#endif
+  if (psock->s_domain == PF_INET6)
     {
       /* Make sure that the IP address mapping is in the Neighbor Table */
 

--- a/net/tcp/tcp_sendfile.c
+++ b/net/tcp/tcp_sendfile.c
@@ -417,7 +417,7 @@ ssize_t tcp_sendfile(FAR struct socket *psock, FAR struct file *infile,
   FAR struct tcp_conn_s *conn;
   struct sendfile_s state;
   off_t startpos;
-  int ret;
+  int ret = OK;
 
   conn = psock->s_conn;
   DEBUGASSERT(conn != NULL);
@@ -434,19 +434,16 @@ ssize_t tcp_sendfile(FAR struct socket *psock, FAR struct file *infile,
 
 #if defined(CONFIG_NET_ARP_SEND) || defined(CONFIG_NET_ICMPv6_NEIGHBOR)
 #ifdef CONFIG_NET_ARP_SEND
-#ifdef CONFIG_NET_ICMPv6_NEIGHBOR
   if (psock->s_domain == PF_INET)
-#endif
     {
       /* Make sure that the IP address mapping is in the ARP table */
 
       ret = arp_send(conn->u.ipv4.raddr);
     }
 #endif /* CONFIG_NET_ARP_SEND */
+
 #ifdef CONFIG_NET_ICMPv6_NEIGHBOR
-#ifdef CONFIG_NET_ARP_SEND
-  else
-#endif
+  if (psock->s_domain == PF_INET6)
     {
       /* Make sure that the IP address mapping is in the Neighbor Table */
 

--- a/net/udp/udp_sendto_buffered.c
+++ b/net/udp/udp_sendto_buffered.c
@@ -593,9 +593,7 @@ ssize_t psock_udp_sendto(FAR struct socket *psock, FAR const void *buf,
    * the ARP table.
    */
 
-#ifdef CONFIG_NET_ICMPv6_NEIGHBOR
   if (psock->s_domain == PF_INET)
-#endif
     {
       in_addr_t destipaddr;
 
@@ -632,9 +630,7 @@ ssize_t psock_udp_sendto(FAR struct socket *psock, FAR const void *buf,
    * the neighbor table.
    */
 
-#ifdef CONFIG_NET_ARP_SEND
-  else
-#endif
+  if (psock->s_domain == PF_INET6)
     {
       FAR const uint16_t *destipaddr;
 

--- a/net/udp/udp_sendto_unbuffered.c
+++ b/net/udp/udp_sendto_unbuffered.c
@@ -267,7 +267,7 @@ ssize_t psock_udp_sendto(FAR struct socket *psock, FAR const void *buf,
 {
   FAR struct udp_conn_s *conn;
   struct sendto_s state;
-  int ret;
+  int ret = OK;
 
   /* Verify that the sockfd corresponds to valid, allocated socket */
 
@@ -314,9 +314,7 @@ ssize_t psock_udp_sendto(FAR struct socket *psock, FAR const void *buf,
    * the ARP table.
    */
 
-#ifdef CONFIG_NET_ICMPv6_NEIGHBOR
   if (psock->s_domain == PF_INET)
-#endif
     {
       in_addr_t destipaddr;
 
@@ -353,9 +351,7 @@ ssize_t psock_udp_sendto(FAR struct socket *psock, FAR const void *buf,
    * the neighbor table.
    */
 
-#ifdef CONFIG_NET_ARP_SEND
-  else
-#endif
+  if (psock->s_domain == PF_INET6)
     {
       FAR const uint16_t *destipaddr;
 


### PR DESCRIPTION
## Summary
If we only enable one of `CONFIG_NET_ARP_SEND` and `CONFIG_NET_ICMPv6_NEIGHBOR`, both IPv4 and IPv6 traffic will send ARP or NDP, which causes problem.

Example:
`CONFIG_NET_ARP_SEND=n`
`CONFIG_NET_ICMPv6_NEIGHBOR=y`

Wrong:
IPv4 traffic (`PF_INET`) goes into `icmpv6_neighbor`, which definitely causes problem.

Correct:
IPv4 traffic doesn't call anything(`CONFIG_NET_ARP_SEND=n`), IPv6 traffic calls `icmpv6_neighbor`(`CONFIG_NET_ICMPv6_NEIGHBOR=y`)

## Impact
The behavior of `CONFIG_NET_ARP_SEND` and `CONFIG_NET_ICMPv6_NEIGHBOR`, especially when we only enable one of them.

## Testing
Manually & CI
