### PR TITLE
SAMA5 - add LCD backlight PWM clock source selection

### DIFF
--- a/arch/arm/src/sama5/sam_lcd.c
+++ b/arch/arm/src/sama5/sam_lcd.c
@@ -2282,6 +2282,9 @@ static void sam_lcd_enable(void)
 #ifdef BOARD_LCDC_PIXCLK_INV
   regval |= LCDC_LCDCFG0_CLKPOL;
 #endif
+#ifdef BOARD_LCDC_PWMCLK
+  regval |= LCDC_LCDCFG0_CLKPWMSEL;
+#endif
 #ifdef BOARD_LCDC_MCK_MUL2
   regval |= LCDC_LCDCFG0_CLKSEL;
 #endif


### PR DESCRIPTION
## Summary

The SAMA5 lcd driver was missing option to set the PWM clock source for backlight dimming

## Impact
None - uses new board-specific #define

## Testing
Custom board with SAMA5D27C-D1G and 800x480 TFT LCD with dimmable backlight

