### PR TITLE
net:Add support for multi PHY and optionally use it on imxrt

### DIFF
--- a/arch/arm/src/imxrt/imxrt_enet.c
+++ b/arch/arm/src/imxrt/imxrt_enet.c
@@ -250,8 +250,25 @@
  * ...and further PHY descriptions here.
  */
 
-#if defined(CONFIG_ETH0_PHY_KSZ8081)
-#  define BOARD_PHY_NAME        "KSZ8081"
+#if defined(CONFIG_ETH0_PHY_MULTI)
+#  if !defined(BOARD_ETH0_PHY_LIST)
+#    error "CONFIG_ETH0_PHY_MULTI requires board.h to define BOARD_ETH0_PHY_LIST!"
+#  endif
+#  define BOARD_PHY_NAME        g_board_phys[priv->current_phy].name
+#  define BOARD_PHYID1          g_board_phys[priv->current_phy].id1
+#  define BOARD_PHYID2          g_board_phys[priv->current_phy].id2
+#  define BOARD_PHY_STATUS      g_board_phys[priv->current_phy].status
+#  define BOARD_PHY_ADDR        priv->current_phy_address
+#  define BOARD_PHY_10BASET(s)  (imxrt_phy_status(priv, (s), g_board_phys[priv->current_phy].mbps10) != 0)
+#  define BOARD_PHY_100BASET(s) (imxrt_phy_status(priv, (s), g_board_phys[priv->current_phy].mbps100) != 0)
+#  define BOARD_PHY_ISDUPLEX(s) (imxrt_phy_status(priv, (s), g_board_phys[priv->current_phy].duplex) != 0)
+#  define BOARD_PHY_ISCLAUSE45() (g_board_phys[priv->current_phy].clause == 45)
+#  define CLAUSE45
+#  define MMD1                  1
+#  define MMD1_PMA_STATUS1      1
+#  define MMD1_PS1_RECEIVE_LINK_STATUS (1 << 2)
+#elif defined(CONFIG_ETH0_PHY_KSZ8081)
+#  define BOARD_PHY_NAME        MII_KSZ8081_NAME
 #  define BOARD_PHYID1          MII_PHYID1_KSZ8081
 #  define BOARD_PHYID2          MII_PHYID2_KSZ8081
 #  define BOARD_PHY_STATUS      MII_KSZ8081_PHYCTRL1
@@ -260,7 +277,7 @@
 #  define BOARD_PHY_100BASET(s) (((s) & MII_PHYCTRL1_MODE_100HDX) != 0)
 #  define BOARD_PHY_ISDUPLEX(s) (((s) & MII_PHYCTRL1_MODE_DUPLEX) != 0)
 #elif defined(CONFIG_ETH0_PHY_LAN8720)
-#  define BOARD_PHY_NAME        "LAN8720"
+#  define BOARD_PHY_NAME        MII_LAN8720_NAME
 #  define BOARD_PHYID1          MII_PHYID1_LAN8720
 #  define BOARD_PHYID2          MII_PHYID2_LAN8720
 #  define BOARD_PHY_STATUS      MII_LAN8720_SCSR
@@ -269,7 +286,7 @@
 #  define BOARD_PHY_100BASET(s) (((s)&MII_LAN8720_SPSCR_100MBPS) != 0)
 #  define BOARD_PHY_ISDUPLEX(s) (((s)&MII_LAN8720_SPSCR_DUPLEX) != 0)
 #elif defined(CONFIG_ETH0_PHY_LAN8742A)
-#  define BOARD_PHY_NAME        "LAN8742A"
+#  define BOARD_PHY_NAME        MII_LAN8742A_NAME
 #  define BOARD_PHYID1          MII_PHYID1_LAN8742A
 #  define BOARD_PHYID2          MII_PHYID2_LAN8742A
 #  define BOARD_PHY_STATUS      MII_LAN8740_SCSR
@@ -278,7 +295,7 @@
 #  define BOARD_PHY_100BASET(s) (((s)&MII_LAN8720_SPSCR_100MBPS) != 0)
 #  define BOARD_PHY_ISDUPLEX(s) (((s)&MII_LAN8720_SPSCR_DUPLEX) != 0)
 #elif defined(CONFIG_ETH0_PHY_DP83825I)
-#  define BOARD_PHY_NAME        "DP83825I"
+#  define BOARD_PHY_NAME        MII_DP83825I_NAME
 #  define BOARD_PHYID1          MII_PHYID1_DP83825I
 #  define BOARD_PHYID2          MII_PHYID2_DP83825I
 #  define BOARD_PHY_STATUS      MII_DP83825I_PHYSTS
@@ -287,7 +304,7 @@
 #  define BOARD_PHY_100BASET(s) (((s) & MII_DP83825I_PHYSTS_SPEED) == 0)
 #  define BOARD_PHY_ISDUPLEX(s) (((s) & MII_DP83825I_PHYSTS_DUPLEX) != 0)
 #elif defined(CONFIG_ETH0_PHY_TJA1103)
-#  define BOARD_PHY_NAME        "TJA1103"
+#  define BOARD_PHY_NAME        MII_TJA1103_NAME
 #  define BOARD_PHYID1          MII_PHYID1_TJA1103
 #  define BOARD_PHYID2          MII_PHYID2_TJA1103
 #  define BOARD_PHY_STATUS      MII_TJA110X_BSR
@@ -300,7 +317,7 @@
 #  define MMD1_PMA_STATUS1      1
 #  define MMD1_PS1_RECEIVE_LINK_STATUS (1 << 2)
 #elif defined(CONFIG_ETH0_PHY_YT8512)
-#  define BOARD_PHY_NAME        "YT8512"
+#  define BOARD_PHY_NAME        MII_YT8512_NAME
 #  define BOARD_PHYID1          MII_PHYID1_YT8512
 #  define BOARD_PHYID2          MII_PHYID2_YT8512
 #  define BOARD_PHY_STATUS      MII_YT8512_PHYSTS
@@ -375,6 +392,10 @@ struct imxrt_driver_s
   struct enet_desc_s *txdesc;  /* A pointer to the list of TX descriptor */
   struct enet_desc_s *rxdesc;  /* A pointer to the list of RX descriptors */
 
+#if defined(CONFIG_ETH0_PHY_MULTI)
+  uint8_t  current_phy;         /* The index of the PHY being used */
+  uint8_t  current_phy_address; /* The address of the PHY being used */
+#endif
   /* This holds the information visible to the NuttX network */
 
   struct net_driver_s dev;     /* Interface understood by the network */
@@ -383,6 +404,15 @@ struct imxrt_driver_s
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
+/* BOARD_ETH0_PHY_LIST provided by the board.h for  CONFIG_ETH0_PHY_MULTI */
+
+#if defined(CONFIG_ETH0_PHY_MULTI)
+const struct phy_desc_s  g_board_phys[] =
+    {
+        BOARD_ETH0_PHY_LIST
+    };
+#endif
 
 static struct imxrt_driver_s g_enet[CONFIG_IMXRT_ENET_NETHIFS];
 
@@ -469,6 +499,13 @@ static int  imxrt_ioctl(struct net_driver_s *dev, int cmd,
 #endif
 
 /* PHY/MII support */
+
+#if defined(CONFIG_ETH0_PHY_MULTI)
+static int imxrt_phy_is(struct imxrt_driver_s *priv, const char *name);
+static int imxrt_phy_status(struct imxrt_driver_s *priv, int phydata,
+                            uint16_t mask);
+static int imxrt_determine_phy(struct imxrt_driver_s *priv);
+#endif
 
 #if defined(CONFIG_NETDEV_PHY_IOCTL) && defined(CONFIG_ARCH_PHY_INTERRUPT)
 static int imxrt_phyintenable(struct imxrt_driver_s *priv);
@@ -1377,6 +1414,15 @@ static int imxrt_ifup_action(struct net_driver_s *dev, bool resetphy)
 
   /* Configure the PHY */
 
+#if defined(CONFIG_ETH0_PHY_MULTI)
+  ret = imxrt_determine_phy(priv);
+  if (ret < 0)
+    {
+      nerr("ERROR: Failed to determine the PHY: %d\n", ret);
+      return ret;
+    }
+#endif
+
   ret = imxrt_initphy(priv, resetphy);
   if (ret < 0)
     {
@@ -1872,7 +1918,11 @@ static int imxrt_ioctl(struct net_driver_s *dev, int cmd, unsigned long arg)
           struct mii_ioctl_data_s *req =
             (struct mii_ioctl_data_s *)((uintptr_t)arg);
 #if defined(CLAUSE45)
-          if (MII_MSR == req->reg_num)
+          if (
+#  if defined(CONFIG_ETH0_PHY_MULTI)
+              BOARD_PHY_ISCLAUSE45() &&
+#  endif
+              MII_MSR == req->reg_num)
             {
               ret = imxrt_readmmd(priv, req->phy_id, MMD1, MMD1_PMA_STATUS1,
                                   &req->val_out);
@@ -1926,46 +1976,60 @@ static int imxrt_ioctl(struct net_driver_s *dev, int cmd, unsigned long arg)
 #if defined(CONFIG_NETDEV_PHY_IOCTL) && defined(CONFIG_ARCH_PHY_INTERRUPT)
 static int imxrt_phyintenable(struct imxrt_driver_s *priv)
 {
+#if defined(CONFIG_ETH0_PHY_KSZ8051) || defined(CONFIG_ETH0_PHY_KSZ8061) || \
+    defined(CONFIG_ETH0_PHY_KSZ8081) || defined(CONFIG_ETH0_PHY_DP83825I) || \
+    defined(CONFIG_ETH0_YT8512)      || defined(CONFIG_ETH0_PHY_MULTI)
+
   uint16_t phyval;
   int ret;
 
-#if defined(CONFIG_ETH0_PHY_KSZ8051) || defined(CONFIG_ETH0_PHY_KSZ8061) || \
-    defined(CONFIG_ETH0_PHY_KSZ8081) || defined(CONFIG_ETH0_PHY_DP83825I)
+  /* Compile time Kzxxxx defaults */
 
-  /* Read the interrupt status register in order to clear any pending
-   * interrupts
-   */
+  uint16_t mask = MII_KSZ80X1_INT_LDEN | MII_KSZ80X1_INT_LUEN;
+  uint8_t  rreg = MII_KSZ8081_INT;
+  uint8_t  wreg = rreg;
 
-  ret = imxrt_readmii(priv, priv->phyaddr, MII_KSZ8081_INT, &phyval);
-  if (ret == OK)
+  /* Compile time YT8512 defaults */
+#  if defined(CONFIG_ETH0_YT8512)
+  mask = MII_YT8512_IMR_LD_EN | MII_YT8512_IMR_LU_EN;
+  rreg  = MII_YT8512_ISR;
+  wreg  = MII_YT8512_IMR;
+#  endif
+
+  /* Run time YT8512 defaults */
+#  if defined(CONFIG_ETH0_PHY_MULTI)
+  if (imxrt_phy_is(priv, MII_YT8512_NAME))
     {
-      /* Enable link up/down interrupts */
-
-      ret = imxrt_writemii(priv, priv->phyaddr, MII_KSZ8081_INT,
-                           (MII_KSZ80X1_INT_LDEN | MII_KSZ80X1_INT_LUEN));
+      mask = MII_YT8512_IMR_LD_EN | MII_YT8512_IMR_LU_EN;
+      rreg  = MII_YT8512_ISR;
+      wreg  = MII_YT8512_IMR;
     }
-
-  return ret;
-#elif defined(CONFIG_ETH0_YT8512)
+  else if (!(imxrt_phy_is(priv, MII_KSZ8051_NAME) ||
+             imxrt_phy_is(priv, MII_KSZ8061_NAME) ||
+             imxrt_phy_is(priv, MII_KSZ8081_NAME) ||
+             imxrt_phy_is(priv, MII_DP83825I_NAME)))
+    {
+      return -ENOSYS;
+    }
+#  endif
 
   /* Read the interrupt status register in order to clear any pending
    * interrupts
    */
 
-  ret = imxrt_readmii(priv, priv->phyaddr, MII_YT8512_ISR, &phyval);
+  ret = imxrt_readmii(priv, priv->phyaddr, rreg, &phyval);
   if (ret == OK)
     {
       /* Enable link up/down interrupts */
 
-      ret = imxrt_writemii(priv, priv->phyaddr, MII_YT8512_IMR,
-                           (MII_YT8512_IMR_LD_EN | MII_YT8512_IMR_LU_EN));
+      ret = imxrt_writemii(priv, priv->phyaddr, wreg, mask);
     }
 
   return ret;
 #else
 #  error Unrecognized PHY
   return -ENOSYS;
-#endif
+#  endif
 }
 #endif
 
@@ -2120,6 +2184,126 @@ static int imxrt_readmii(struct imxrt_driver_s *priv, uint8_t phyaddr,
                                     ENET_MMFR_DATA_MASK);
   return OK;
 }
+
+#if defined(CONFIG_ETH0_PHY_MULTI)
+/****************************************************************************
+ * Function: imxrt_determine_phy
+ *
+ * Description:
+ *   Uses the board.h supplied PHY list to determine which PHY
+ *   is populated on this board.
+ *
+ * Input Parameters:
+ *   priv - Reference to the private ENET driver state structure
+ *
+ * Returned Value:
+ *   Zero on success, a -ENOENT errno value on failure.
+ *
+ ****************************************************************************/
+
+static int imxrt_determine_phy(struct imxrt_driver_s *priv)
+{
+  uint16_t phydata     = 0xffff;
+  uint8_t phyaddr      = 0;
+  uint8_t last_phyaddr = 0;
+  int retries;
+  int ret;
+
+  for (priv->current_phy = 0; priv->current_phy < nitems(g_board_phys);
+      priv->current_phy++)
+    {
+      priv->current_phy_address =
+          (uint8_t) g_board_phys[priv->current_phy].address_lo;
+      last_phyaddr = g_board_phys[priv->current_phy].address_high == 0xffff ?
+          priv->current_phy_address :
+          (uint8_t) g_board_phys[priv->current_phy].address_high;
+
+      for (phyaddr = priv->current_phy_address; phyaddr <= last_phyaddr;
+          phyaddr++)
+        {
+          retries = 0;
+          do
+            {
+              nxsig_usleep(100);
+              phydata = 0xffff;
+              ret = imxrt_readmii(priv, phyaddr, MII_PHYID1, &phydata);
+            }
+          while ((ret < 0 || phydata == 0xffff) && ++retries < 3);
+
+          if (retries <= 3 && ret == 0 &&
+              phydata == g_board_phys[priv->current_phy].id1)
+            {
+              do
+                {
+                  nxsig_usleep(100);
+                  phydata = 0xffff;
+                  ret = imxrt_readmii(priv, phyaddr, MII_PHYID2, &phydata);
+                }
+              while ((ret < 0 || phydata == 0xffff) && ++retries < 3);
+              if (retries <= 3 && ret == 0 &&
+                  (phydata & 0xfff0) ==
+                  (g_board_phys[priv->current_phy].id2 & 0xfff0))
+                {
+                  return OK;
+                }
+            }
+        }
+    }
+
+  return -ENOENT;
+}
+
+/****************************************************************************
+ * Function: imxrt_phy_is
+ *
+ * Description:
+ *   Compares the name with the current selected PHY's name
+ *
+ * Input Parameters:
+ *   priv - Reference to the private ENET driver state structure
+ *   name - a pointer to comapre to.
+ *
+ * Returned Value:
+ *   1 on match, a 0 on no match.
+ *
+ ****************************************************************************/
+
+static int imxrt_phy_is(struct imxrt_driver_s *priv, const char *name)
+{
+  return strcmp(g_board_phys[priv->current_phy].name, name) == 0;
+}
+
+/****************************************************************************
+ * Function: imxrt_phy_status
+ *
+ * Description:
+ *   Compares the name with the current selected PHY's name.
+ *
+ * Input Parameters:
+ *   priv    - Reference to the private ENET driver state structure
+ *   phydata - last read phy data - may be ignored if there is no
+ *             status register defined by the current PHY.
+ *   mask - A value to and with phydata if a status register is
+ *          defined. Or the value retunred if no status register is
+ *          defined.
+ *
+ * Returned Value:
+ *   mask or (phydat & mask)
+ *
+ ****************************************************************************/
+
+static int imxrt_phy_status(struct imxrt_driver_s *priv, int phydata,
+                            uint16_t mask)
+{
+  int rv = mask;
+  if (g_board_phys[priv->current_phy].status != 0xffff)
+    {
+      rv &= phydata;
+    }
+
+  return rv;
+}
+#endif
 
 #if 0
 #if defined(CLAUSE45)
@@ -2416,213 +2600,265 @@ static inline int imxrt_initphy(struct imxrt_driver_s *priv, bool renogphy)
           return -ENXIO;
         }
 
-#ifdef CONFIG_ETH0_PHY_KSZ8081
-      /* Reset PHY */
-
-      imxrt_writemii(priv, phyaddr, MII_MCR, MII_MCR_RESET);
-
-      /* Set RMII mode */
-
-      ret = imxrt_readmii(priv, phyaddr, MII_KSZ8081_PHYCTRL2, &phydata);
-      if (ret < 0)
+#if defined(CONFIG_ETH0_PHY_KSZ8081) || defined(CONFIG_ETH0_PHY_MULTI)
+#  if defined(CONFIG_ETH0_PHY_MULTI)
+      if (imxrt_phy_is(priv, MII_KSZ8081_NAME))
         {
-          nerr("ERROR: Failed to read MII_KSZ8081_PHYCTRL2\n");
-          return ret;
-        }
+#  endif
+          /* Reset PHY */
 
-      /* Indicate 50MHz clock */
+          imxrt_writemii(priv, phyaddr, MII_MCR, MII_MCR_RESET);
 
-      imxrt_writemii(priv, phyaddr, MII_KSZ8081_PHYCTRL2,
-                     (phydata | (1 << 7)));
+          /* Set RMII mode */
 
-      /* Switch off NAND Tree mode (in case it was set via pinning) */
-
-      ret = imxrt_readmii(priv, phyaddr, MII_KSZ8081_OMSO, &phydata);
-      if (ret < 0)
-        {
-          nerr("ERROR: Failed to read MII_KSZ8081_OMSO: %d\n", ret);
-          return ret;
-        }
-
-      imxrt_writemii(priv, phyaddr, MII_KSZ8081_OMSO,
-                     (phydata & ~(1 << 5)));
-
-      /* Set Ethernet led to green = activity and yellow = link and  */
-
-      ret = imxrt_readmii(priv, phyaddr, MII_KSZ8081_PHYCTRL2, &phydata);
-      if (ret < 0)
-        {
-          nerr("ERROR: Failed to read MII_KSZ8081_PHYCTRL2\n");
-          return ret;
-        }
-
-      imxrt_writemii(priv, phyaddr, MII_KSZ8081_PHYCTRL2,
-                     (phydata | (1 << 4)));
-
-      imxrt_writemii(priv, phyaddr, MII_ADVERTISE,
-                     MII_ADVERTISE_100BASETXFULL |
-                     MII_ADVERTISE_100BASETXHALF |
-                     MII_ADVERTISE_10BASETXFULL |
-                     MII_ADVERTISE_10BASETXHALF |
-                     MII_ADVERTISE_CSMA);
-
-#elif defined (CONFIG_ETH0_PHY_LAN8720) || defined (CONFIG_ETH0_PHY_LAN8742A)
-      /* Make sure that PHY comes up in correct mode when it's reset */
-
-      imxrt_writemii(priv, phyaddr, MII_LAN8720_MODES,
-                     MII_LAN8720_MODES_RESV | MII_LAN8720_MODES_ALL |
-                     MII_LAN8720_MODES_PHYAD(BOARD_PHY_ADDR));
-
-      /* ...and reset PHY */
-
-      imxrt_writemii(priv, phyaddr, MII_MCR, MII_MCR_RESET);
-
-#elif defined (CONFIG_ETH0_PHY_DP83825I)
-
-      /* Reset PHY */
-
-      imxrt_writemii(priv, phyaddr, MII_MCR, MII_MCR_RESET);
-
-      /* Set RMII mode and Indicate 50MHz clock */
-
-      imxrt_writemii(priv, phyaddr, MII_DP83825I_RCSR,
-                    MII_DP83825I_RCSC_ELAST_2 | MII_DP83825I_RCSC_RMIICS);
-
-      imxrt_writemii(priv, phyaddr, MII_ADVERTISE,
-                     MII_ADVERTISE_100BASETXFULL |
-                     MII_ADVERTISE_100BASETXHALF |
-                     MII_ADVERTISE_10BASETXFULL |
-                     MII_ADVERTISE_10BASETXHALF |
-                     MII_ADVERTISE_CSMA);
-
-#elif defined (CONFIG_ETH0_PHY_YT8512)
-
-      /* Reset PHY */
-
-      imxrt_writemii(priv, phyaddr, MII_MCR, MII_MCR_RESET);
-
-      /* Config LEDs */
-
-      imxrt_writemii(priv, phyaddr, MII_YT8512_DEBUG_ADDR_OFFSET,
-                     MII_YT8512_LED0);
-
-      imxrt_readmii(priv, phyaddr, MII_YT8512_DEBUG_DATA, &phydata);
-
-      imxrt_writemii(priv, phyaddr, MII_YT8512_DEBUG_ADDR_OFFSET,
-                     MII_YT8512_LED0);
-
-      imxrt_writemii(priv, phyaddr, MII_YT8512_DEBUG_DATA, 0x331);
-
-      imxrt_writemii(priv, phyaddr, MII_YT8512_DEBUG_ADDR_OFFSET,
-                     MII_YT8512_LED1);
-
-      imxrt_readmii(priv, phyaddr, MII_YT8512_DEBUG_DATA, &phydata);
-
-      imxrt_writemii(priv, phyaddr, MII_YT8512_DEBUG_ADDR_OFFSET,
-                     MII_YT8512_LED1);
-
-      imxrt_writemii(priv, phyaddr, MII_YT8512_DEBUG_DATA, 0x30);
-
-      /* Set negotiation */
-
-      imxrt_writemii(priv, phyaddr, MII_ADVERTISE,
-                     MII_ADVERTISE_100BASETXFULL |
-                     MII_ADVERTISE_100BASETXHALF |
-                     MII_ADVERTISE_10BASETXFULL |
-                     MII_ADVERTISE_10BASETXHALF |
-                     MII_ADVERTISE_CSMA);
-
-#endif
-#if !defined(CONFIG_ETH0_PHY_TJA1103)
-
-      /* Start auto negotiation */
-
-      ninfo("%s: Start Autonegotiation...\n",  BOARD_PHY_NAME);
-      imxrt_writemii(priv, phyaddr, MII_MCR,
-                     (MII_MCR_ANRESTART | MII_MCR_ANENABLE));
-
-      /* Wait for auto negotiation to complete */
-
-      for (retries = 0; retries < LINK_NLOOPS; retries++)
-        {
-          ret = imxrt_readmii(priv, phyaddr, MII_MSR, &phydata);
+          ret = imxrt_readmii(priv, phyaddr, MII_KSZ8081_PHYCTRL2, &phydata);
           if (ret < 0)
             {
-              nerr("ERROR: Failed to read %s MII_MSR: %d\n",
-                    BOARD_PHY_NAME, ret);
+              nerr("ERROR: Failed to read MII_KSZ8081_PHYCTRL2\n");
               return ret;
+            }
+
+          /* Indicate 50MHz clock */
+
+          imxrt_writemii(priv, phyaddr, MII_KSZ8081_PHYCTRL2,
+                         (phydata | (1 << 7)));
+
+          /* Switch off NAND Tree mode (in case it was set via pinning) */
+
+          ret = imxrt_readmii(priv, phyaddr, MII_KSZ8081_OMSO, &phydata);
+          if (ret < 0)
+            {
+              nerr("ERROR: Failed to read MII_KSZ8081_OMSO: %d\n", ret);
+              return ret;
+            }
+
+          imxrt_writemii(priv, phyaddr, MII_KSZ8081_OMSO,
+                         (phydata & ~(1 << 5)));
+
+          /* Set Ethernet led to green = activity and yellow = link and  */
+
+          ret = imxrt_readmii(priv, phyaddr, MII_KSZ8081_PHYCTRL2, &phydata);
+          if (ret < 0)
+            {
+              nerr("ERROR: Failed to read MII_KSZ8081_PHYCTRL2\n");
+              return ret;
+            }
+
+          imxrt_writemii(priv, phyaddr, MII_KSZ8081_PHYCTRL2,
+                         (phydata | (1 << 4)));
+
+          imxrt_writemii(priv, phyaddr, MII_ADVERTISE,
+                         MII_ADVERTISE_100BASETXFULL |
+                         MII_ADVERTISE_100BASETXHALF |
+                         MII_ADVERTISE_10BASETXFULL |
+                         MII_ADVERTISE_10BASETXHALF |
+                         MII_ADVERTISE_CSMA);
+#  if defined(CONFIG_ETH0_PHY_MULTI)
+        }
+
+#  endif
+#endif
+#if defined (CONFIG_ETH0_PHY_LAN8720)  || \
+    defined (CONFIG_ETH0_PHY_LAN8742A) || \
+    defined (CONFIG_ETH0_PHY_MULTI)
+
+#  if defined(CONFIG_ETH0_PHY_MULTI)
+      if (imxrt_phy_is(priv, MII_LAN8720_NAME) ||
+          imxrt_phy_is(priv, MII_LAN8742A_NAME))
+        {
+#  endif
+
+          /* Make sure that PHY comes up in correct mode when it's reset */
+
+          imxrt_writemii(priv, phyaddr, MII_LAN8720_MODES,
+                         MII_LAN8720_MODES_RESV | MII_LAN8720_MODES_ALL |
+                         MII_LAN8720_MODES_PHYAD(BOARD_PHY_ADDR));
+
+          /* ...and reset PHY */
+
+          imxrt_writemii(priv, phyaddr, MII_MCR, MII_MCR_RESET);
+
+#  if defined(CONFIG_ETH0_PHY_MULTI)
+        }
+#  endif
+#endif
+#if defined (CONFIG_ETH0_PHY_DP83825I) || defined (CONFIG_ETH0_PHY_MULTI)
+
+#if defined(CONFIG_ETH0_PHY_MULTI)
+      if (imxrt_phy_is(priv, MII_DP83825I_NAME))
+        {
+#endif
+
+          /* Reset PHY */
+
+          imxrt_writemii(priv, phyaddr, MII_MCR, MII_MCR_RESET);
+
+          /* Set RMII mode and Indicate 50MHz clock */
+
+          imxrt_writemii(priv, phyaddr, MII_DP83825I_RCSR,
+                        MII_DP83825I_RCSC_ELAST_2 |
+                        MII_DP83825I_RCSC_RMIICS);
+
+          imxrt_writemii(priv, phyaddr, MII_ADVERTISE,
+                         MII_ADVERTISE_100BASETXFULL |
+                         MII_ADVERTISE_100BASETXHALF |
+                         MII_ADVERTISE_10BASETXFULL |
+                         MII_ADVERTISE_10BASETXHALF |
+                         MII_ADVERTISE_CSMA);
+
+#  if defined(CONFIG_ETH0_PHY_MULTI)
+        }
+#  endif
+#endif
+
+#if defined(CONFIG_ETH0_PHY_YT8512) || defined(CONFIG_ETH0_PHY_MULTI)
+#  if defined(CONFIG_ETH0_PHY_MULTI)
+      if (!imxrt_phy_is(priv, MII_YT8512_NAME))
+        {
+#  endif
+          /* Reset PHY */
+
+          imxrt_writemii(priv, phyaddr, MII_MCR, MII_MCR_RESET);
+
+          /* Config LEDs */
+
+          imxrt_writemii(priv, phyaddr, MII_YT8512_DEBUG_ADDR_OFFSET,
+                         MII_YT8512_LED0);
+
+          imxrt_readmii(priv, phyaddr, MII_YT8512_DEBUG_DATA, &phydata);
+
+          imxrt_writemii(priv, phyaddr, MII_YT8512_DEBUG_ADDR_OFFSET,
+                         MII_YT8512_LED0);
+
+          imxrt_writemii(priv, phyaddr, MII_YT8512_DEBUG_DATA, 0x331);
+
+          imxrt_writemii(priv, phyaddr, MII_YT8512_DEBUG_ADDR_OFFSET,
+                         MII_YT8512_LED1);
+
+          imxrt_readmii(priv, phyaddr, MII_YT8512_DEBUG_DATA, &phydata);
+
+          imxrt_writemii(priv, phyaddr, MII_YT8512_DEBUG_ADDR_OFFSET,
+                         MII_YT8512_LED1);
+
+          imxrt_writemii(priv, phyaddr, MII_YT8512_DEBUG_DATA, 0x30);
+
+          /* Set negotiation */
+
+          imxrt_writemii(priv, phyaddr, MII_ADVERTISE,
+                         MII_ADVERTISE_100BASETXFULL |
+                         MII_ADVERTISE_100BASETXHALF |
+                         MII_ADVERTISE_10BASETXFULL |
+                         MII_ADVERTISE_10BASETXHALF |
+                         MII_ADVERTISE_CSMA);
+
+#  if defined(CONFIG_ETH0_PHY_MULTI)
+        }
+#  endif
+#endif
+
+#if !defined(CONFIG_ETH0_PHY_TJA1103)
+#if defined(CONFIG_ETH0_PHY_MULTI)
+      if (!imxrt_phy_is(priv, MII_TJA1103_NAME))
+        {
+#endif
+          /* Start auto negotiation */
+
+          ninfo("%s: Start Autonegotiation...\n",  BOARD_PHY_NAME);
+          imxrt_writemii(priv, phyaddr, MII_MCR,
+                         (MII_MCR_ANRESTART | MII_MCR_ANENABLE));
+
+          /* Wait for auto negotiation to complete */
+
+          for (retries = 0; retries < LINK_NLOOPS; retries++)
+            {
+              ret = imxrt_readmii(priv, phyaddr, MII_MSR, &phydata);
+              if (ret < 0)
+                {
+                  nerr("ERROR: Failed to read %s MII_MSR: %d\n",
+                        BOARD_PHY_NAME, ret);
+                  return ret;
+                }
+
+              if (phydata & MII_MSR_ANEGCOMPLETE)
+                {
+                  break;
+                }
+
+              nxsig_usleep(LINK_WAITUS);
             }
 
           if (phydata & MII_MSR_ANEGCOMPLETE)
             {
-              break;
+              ninfo("%s: Autonegotiation complete\n",  BOARD_PHY_NAME);
+              ninfo("%s: MII_MSR: %04x\n", BOARD_PHY_NAME, phydata);
             }
+          else
+            {
+              /* TODO: Autonegotiation has right now failed. Maybe the Eth
+               * cable is not connected.  PHY chip have mechanisms to
+               * configure link OK. We should leave autconf on, and find a
+               * way to re-configure MCU whenever the link is ready.
+               */
 
-          nxsig_usleep(LINK_WAITUS);
+              ninfo("%s: Autonegotiation failed [%d] (is cable plugged-in ?)"
+                    ", default to 10Mbs mode\n",
+                    BOARD_PHY_NAME, retries);
+
+              /* Stop auto negotiation */
+
+              imxrt_writemii(priv, phyaddr, MII_MCR, 0);
+            }
+#  if defined(CONFIG_ETH0_PHY_MULTI)
         }
-
-      if (phydata & MII_MSR_ANEGCOMPLETE)
-        {
-          ninfo("%s: Autonegotiation complete\n",  BOARD_PHY_NAME);
-          ninfo("%s: MII_MSR: %04x\n", BOARD_PHY_NAME, phydata);
-        }
-      else
-        {
-          /* TODO: Autonegotiation has right now failed. Maybe the Eth cable
-           * is not connected.  PHY chip have mechanisms to configure link
-           * OK. We should leave autconf on, and find a way to re-configure
-           * MCU whenever the link is ready.
-           */
-
-          ninfo("%s: Autonegotiation failed [%d] (is cable plugged-in ?), "
-                "default to 10Mbs mode\n", \
-                BOARD_PHY_NAME, retries);
-
-          /* Stop auto negotiation */
-
-          imxrt_writemii(priv, phyaddr, MII_MCR, 0);
-        }
+#  endif
 #endif
     }
 
 #if !defined(CONFIG_ETH0_PHY_TJA1103)
-  /* When we get here we have a (negotiated) speed and duplex. This is also
-   * the point we enter if renegotiation is turned off, so have multiple
-   * attempts at reading the status register in case the PHY isn't awake
-   * properly.
-   */
-
-  retries = 0;
-  do
+#  if defined(CONFIG_ETH0_PHY_MULTI)
+  if (!imxrt_phy_is(priv, MII_TJA1103_NAME))
     {
-      phydata = 0xffff;
-      ret = imxrt_readmii(priv, phyaddr, BOARD_PHY_STATUS, &phydata);
-    }
-  while ((ret < 0 || phydata == 0xffff) && ++retries < 3);
+#  endif
+      /* When we get here we have a (negotiated) speed and duplex. This
+       * is also the point we enter if renegotiation is turned off, so have
+       * multiple attempts at reading the status register in case the PHY
+       * isn't awake properly.
+       */
 
-  /* If we didn't successfully read anything and we haven't tried a physical
-   * renegotiation then lets do that
-   */
-
-  if (retries >= 3)
-    {
-      if (renogphy == false)
+      retries = 0;
+      do
         {
-          /* Give things one more chance with renegotiation turned on */
-
-          return imxrt_initphy(priv, true);
+          phydata = 0xffff;
+          ret = imxrt_readmii(priv, phyaddr, BOARD_PHY_STATUS, &phydata);
         }
-      else
+      while ((ret < 0 || phydata == 0xffff) && ++retries < 3);
+
+      /* If we didn't successfully read anything and we haven't tried
+       * a physical renegotiation then lets do that
+       */
+
+      if (retries >= 3)
         {
-          /* That didn't end well, just give up */
+          if (renogphy == false)
+            {
+              /* Give things one more chance with renegotiation turned on */
 
-          nerr("ERROR: Failed to read %s BOARD_PHY_STATUS[%02x]: %d\n",
-               BOARD_PHY_NAME, BOARD_PHY_STATUS, ret);
-          return ret;
+              return imxrt_initphy(priv, true);
+            }
+          else
+            {
+              /* That didn't end well, just give up */
+
+              nerr("ERROR: Failed to read %s BOARD_PHY_STATUS[%02x]: %d\n",
+                   BOARD_PHY_NAME, BOARD_PHY_STATUS, ret);
+              return ret;
+            }
         }
-    }
 
-  ninfo("%s: BOARD_PHY_STATUS: %04x\n", BOARD_PHY_NAME, phydata);
+      ninfo("%s: BOARD_PHY_STATUS: %04x\n", BOARD_PHY_NAME, phydata);
+#  if defined(CONFIG_ETH0_PHY_MULTI)
+    }
+#  endif
 #endif
 
   /* Set up the transmit and receive control registers based on the

--- a/drivers/net/Kconfig
+++ b/drivers/net/Kconfig
@@ -549,6 +549,13 @@ choice
 config ETH0_PHY_NONE
 	bool "No PHY support"
 
+config ETH0_PHY_MULTI
+	bool "Multiple PHYs are supported"
+	---help---
+		The Board will provide a list of PHYs to probe for.
+		The first one found on the bpard will be used.
+		This setting is not supported by all Ethernet drivers.
+
 config ETH0_PHY_AM79C874
 	bool "AMD Am79C874 PHY"
 

--- a/include/nuttx/net/mii.h
+++ b/include/nuttx/net/mii.h
@@ -21,11 +21,14 @@
 #ifndef __INCLUDE_NUTTX_NET_MII_H
 #define __INCLUDE_NUTTX_NET_MII_H
 
+#ifndef __ASSEMBLY__
+
 /****************************************************************************
  * Included Files
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <stdint.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -62,12 +65,14 @@
 
 /* AR8031: */
 
+#define MII_AR8031_NAME             "AR8031"
 #define MII_AR8031_PSSR              0x11      /* Phy-Specific Status Register */
 
 /* National Semiconductor DP83840: 0x07-0x11, 0x14, 0x1a, 0x1d-0x1f
  * reserved
  */
 
+#define MII_DP83840_NAME             "DP83840"
 #define MII_DP83840_COUNTER          0x12      /* Disconnect counter */
 #define MII_DP83840_FCSCOUNTER       0x13      /* False carrier sense counter */
 #define MII_DP83840_NWAYTEST         0x14      /* N-way auto-neg test reg */
@@ -80,6 +85,7 @@
 
 /* Am79c874: 0x08-0x0f, 0x14, 0x16, 0x19-0x1f reserved */
 
+#define MII_AM79C874_NAME            "AM79C874"
 #define MII_AM79C874_NPADVERTISE     0x07      /* Auto-negotiation next page advertisement */
 #define MII_AM79C874_MISCFEATURES    0x10      /* Miscellaneous features reg */
 #define MII_AM79C874_INTCS           0x11      /* Interrupt control/status */
@@ -91,6 +97,7 @@
 
 /* Luminary LM3S6918 built-in PHY: 0x07-0x0f, 0x14-0x16, 0x19-0x1f reserved */
 
+#define MII_LM3S6918_NAME            "LM3S6918"
 #define MII_LM_VSPECIFIC             0x10      /* Vendor-Specific */
 #define MII_LM_INTCS                 0x11      /* Interrupt control/status */
 #define MII_LM_DIAGNOSTIC            0x12      /* Diagnostic */
@@ -100,12 +107,14 @@
 
 /* Micrel KS8721: 0x15, 0x1b, and 0x1f */
 
+#define MII_KS8721_NAME              "KS8721"
 #define MII_KS8721_RXERCOUNTER       0x15      /* RXER counter */
 #define MII_KS8721_INTCS             0x1b      /* Interrupt control/status register */
 #define MII_KS8721_10BTCR            0x1f      /* 10BASE-TX PHY control register */
 
 /* Micrel KSZ8041:  0x15, 0x1b, 0x1e-0x1f */
 
+#define MII_KSZ8041_NAME             "KSZ8041"
 #define MII_KSZ8041_RXERR            0x15      /* RXERR Counter */
 #define MII_KSZ8041_INT              0x1b      /* Interrupt Control/Status */
 #define MII_KSZ8041_PHYCTRL1         0x1e      /* PHY Control 1 */
@@ -113,6 +122,7 @@
 
 /* Micrel KSZ8051:  0x11, 0x15-0x18, 0x1b, 0x1d-0x1f */
 
+#define MII_KSZ8051_NAME             "KSZ8051"
 #define MII_KSZ8051_AFEC1            0x11      /* AFE Control 1 */
 #define MII_KSZ8051_RXERR            0x15      /* RXERR Counter */
 #define MII_KSZ8051_OMSO             0x16      /* Operation Mode Strap Override */
@@ -124,6 +134,8 @@
 #define MII_KSZ8051_PHYCTRL2         0x1f      /* PHY Control 2 */
 
 /* Micrel KSZ8061:  0x10-0x18, 0x1b, 0x1c-0x1f */
+
+#define MII_KSZ8061_NAME               "KSZ8061"
 #define MII_KSZ8061_DIG_CTRL           0x10   /* Digital Control */
 #define MII_KSZ8061_AFE_CTRL_0         0x11   /* AFE Control 0 */
 #define MII_KSZ8061_AFE_CTRL_1         0x12   /* AFE Control 1 */
@@ -141,6 +153,7 @@
 
 /* Micrel KSZ8081:  0x10-0x11, 0x15-0x18, 0x1b, 0x1d-0x1f */
 
+#define MII_KSZ8081_NAME             "KSZ8081"
 #define MII_KSZ8081_DRCTRL           0x10      /* Digital Reserve Control */
 #define MII_KSZ8081_AFEC1            0x11      /* AFE Control 1 */
 #define MII_KSZ8081_RXERR            0x15      /* RXERR Counter */
@@ -156,6 +169,7 @@
  * 0x8-0x15, 0x13, 0x1c reserved
  */
 
+#define MII_DP83848C_NAME            "DP83848C"
 #define MII_DP83848C_STS             0x10      /* RO PHY Status Register */
 #define MII_DP83848C_MICR            0x11      /* RW MII Interrupt Control Register */
 #define MII_DP83848C_MISR            0x12      /* RO MII Interrupt Status Register */
@@ -171,6 +185,7 @@
 
 /* Texas Instruments DP83825I PHY Extended Registers. */
 
+#define MII_DP83825I_NAME            "DP83825I"
 #define MII_DP83825I_PHYSTS          0x10      /* RO PHY Status Register */
 #define MII_DP83825I_PHYSCR          0x11      /* RW PHY Specific Control Register */
 #define MII_DP83825I_MISR1           0x12      /* RO MII Interrupt Status Register 1 */
@@ -189,6 +204,7 @@
 
 /* SMSC LAN8720 PHY Extended Registers */
 
+#define MII_LAN8720_NAME             "LAN8720"
 #define MII_LAN8720_REV              0x10      /* Silicon Revision Register */
 #define MII_LAN8720_MCSR             0x11      /* Mode Control/Status Register */
 #define MII_LAN8720_MODES            0x12      /* Special modes */
@@ -201,6 +217,8 @@
 
 /* SMSC LAN8740/LAN8742A PHY Extended Registers */
 
+#define MII_LAN8740_NAME             "LAN8740"
+#define MII_LAN8742A_NAME            "LAN8742A"
 #define MII_LAN8740_CONFIG           0x10      /* EDPD NDL/Crossover Timer/EEE Configuration */
 #define MII_LAN8740_MCSR             0x11      /* Mode Control/Status Register */
 #define MII_LAN8740_MODES            0x12      /* Special modes */
@@ -215,6 +233,7 @@
 
 /* Motorcomm YT8512C/YT8512H Extended Registers */
 
+#define MII_YT8512_NAME             "YT8512"
 #define MII_YT8512_PHYSFC            0x10      /* PHY Function conrtol Register */
 #define MII_YT8512_PHYSTS            0x11      /* PHY Status Register */
 #define MII_YT8512_IMR               0x12      /* Interrupt Mask Register */
@@ -728,12 +747,15 @@
 
 /* TJA110X MII ID1/2 register bits */
 
+#define MII_TJA1100_NAME                  "TJA1100"
 #define MII_PHYID1_TJA1100                0x0180  /* ID1 value for NXP TJA1100 */
 #define MII_PHYID2_TJA1100                0xdc40  /* ID2 value for NXP TJA1100 */
 
+#define MII_TJA1101_NAME                  "TJA1101"
 #define MII_PHYID1_TJA1101                0x0180  /* ID1 value for NXP TJA1101 */
 #define MII_PHYID2_TJA1101                0xdd00  /* ID2 value for NXP TJA1101 */
 
+#define MII_TJA1103_NAME                  "TJA1103"
 #define MII_PHYID1_TJA1103                0x01b   /* ID1 value for NXP TJA1103 */
 #define MII_PHYID2_TJA1103                0xB013  /* ID2 value for NXP TJA1103 */
 
@@ -915,6 +937,22 @@
  * Type Definitions
  ****************************************************************************/
 
+struct phy_desc_s
+{
+  char      name[16];       /* The name of the PHY */
+  uint16_t  id1;            /* The MII_PHYID1 registers value */
+  uint16_t  id2;            /* The MII_PHYID2 registers value */
+  uint16_t  status;         /* The Phys status register or 0xffff */
+  uint16_t  address_lo;     /* The lowest address to check for the PHY */
+  uint16_t  address_high;   /* The highest address to check for the PHY or
+                             * 0xffff uses only the address_lo (one address)
+                             */
+  uint16_t  mbps10;         /* The bit mask for 10MBP if status is not 0xffff */
+  uint16_t  mbps100;        /* The bit mask for 100MBP if status is not 0xffff */
+  uint16_t  duplex;         /* The bit mask for DUPLEX if status is not 0xffff */
+  uint16_t  clause;         /* The PHY clause supported. 22 or 45 */
+};
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
@@ -932,4 +970,5 @@ extern "C"
 }
 #endif
 
+#endif /* __ASSEMBLY__ */
 #endif /* __INCLUDE_NUTTX_NET_MII_H */


### PR DESCRIPTION
## Summary

   Support runtime phy selection based on a list    supplied by board.h
   For Example:

```
   #define BOARD_ETH0_PHY_LIST                   \
	{                                        \
		"LAN8742A",                      \
		MII_PHYID1_LAN8742A,             \
		MII_PHYID2_LAN8742A,             \
		MII_LAN8740_SCSR,                \
		0,                               \
		0xffff,                          \
		MII_LAN8720_SPSCR_10MBPS,        \
		MII_LAN8720_SPSCR_100MBPS,       \
		MII_LAN8720_SPSCR_DUPLEX,        \
		22,                              \
	},                                       \
	{                                        \
		"TJA1103",                       \
		MII_PHYID1_TJA1103,              \
		MII_PHYID2_TJA1103,              \
		0xffff,                          \
		18,                              \
		0xffff,                          \
		0,                               \
		MII_LAN8720_SPSCR_100MBPS,       \
		MII_LAN8720_SPSCR_DUPLEX,        \
		45,                              \
	},                                       \
```
## Impact

 Non behind a Kconfig

## Testing

PX4_FMUV6XRT - on HB-T 100 base and NXP T-1 base

LAN8742A - compile time 
TJA1103     - compile time 

LAN8742A and TJA1103     - run time selection


