### PR TITLE
risc-v/rv-virt: revise mstatus operations

### DIFF
--- a/arch/risc-v/src/qemu-rv/qemu_rv_start.c
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_start.c
@@ -191,10 +191,10 @@ void qemu_rv_start(int mhartid, const char *dtb)
 
   CLEAR_CSR(mstatus, MSTATUS_TVM);
 
-  /* Set mstatus to S-mode and enable SUM */
+  /* Set mstatus to S-mode */
 
-  CLEAR_CSR(mstatus, ~MSTATUS_MPP_MASK);
-  SET_CSR(mstatus, MSTATUS_MPPS | SSTATUS_SUM);
+  CLEAR_CSR(mstatus, MSTATUS_MPP_MASK);
+  SET_CSR(mstatus, MSTATUS_MPPS);
 
   /* Set the trap vector for S-mode */
 


### PR DESCRIPTION

## Summary

This contain revision for kernel mode startup logic:
- no need for SUM as it is taken care by `riscv_set_idleintctx()`
- fix the CLEAR_CSR() before setting MPP field

## Impact

rv-virt kernel build

## Testing

checked with `rv-virt/knsh32` and `rv-virt/knsh64`
