### PR TITLE
risc-v/litex: fix typo in litex/irq.h

### DIFF
--- a/arch/risc-v/include/litex/irq.h
+++ b/arch/risc-v/include/litex/irq.h
@@ -46,7 +46,7 @@
 
 /* The last hardware IRQ number */
 
-#define LITEX_LAST_IRQ          (LITEX_IRQ_GPIO_BASE + LITEX_IRQ_GPIO_LENGTH)
+#define LITEX_IRQ_LAST        (LITEX_IRQ_GPIO_BASE + LITEX_IRQ_GPIO_LENGTH)
 
 /* Second level GPIO interrupts.  GPIO interrupts are decoded and dispatched
  * as a second level of decoding:  The first level dispatches to the GPIO


### PR DESCRIPTION

## Summary

The LITEX_LAST_IRQ looks like a typo and it blocks build of `arty_a7/knsh` configuration. 
This fixes the build issue but I have no such device for test.

## Impact

risc-v/arty_a7 devices

## Testing

can build but lack of devices for test
