### PR TITLE
nucleo-l432kc: Fix board configuration for USART2

### DIFF
--- a/boards/arm/stm32l4/nucleo-l432kc/include/board.h
+++ b/boards/arm/stm32l4/nucleo-l432kc/include/board.h
@@ -90,13 +90,9 @@
 #  define GPIO_USART1_TX GPIO_USART1_TX_2    /* PB6  */
 #endif
 
-/* USART2: Connected to STLInk Debug via PA2(TX), PA15(RX) */
+/* USART2: Connected to STLInk Debug via PA2(TX), PA3(RX) */
 
-#if defined(CONFIG_ARCH_BOARD_USART2_RX_PA3)
-#  define GPIO_USART2_RX   GPIO_USART2_RX_1  /* PA3 */
-#elif defined(CONFIG_ARCH_BOARD_USART2_RX_PA15)
-#  define GPIO_USART2_RX   GPIO_USART2_RX_2  /* PA15 */
-#endif
+#define GPIO_USART2_RX   GPIO_USART2_RX_1    /* PA3 */
 #define GPIO_USART2_TX   GPIO_USART2_TX_1    /* PA2 */
 #define GPIO_USART2_RTS  GPIO_USART2_RTS_2
 #define GPIO_USART2_CTS  GPIO_USART2_CTS_2


### PR DESCRIPTION
## Summary
Fix board configuration for USART2.
Currently users are not able to connect to USART2 using default NSH configuration as the board Nucleo-l432kc does not expose the PA15 on its connectors, so this commit make PA3 the default pin for USART2

![image](https://github.com/apache/nuttx/assets/30301531/c4645090-c884-4178-9cf3-5cadabd17e68)

Table 16 from UM1956 - User manual
## Impact
Users will be able to connect to NSH using USART2 without any additional configuration.

## Testing
- Build NSH config
- Connect to NSH via USART2

nsh> uname -a
NuttX 12.3.0 b516b29efc-dirty Jan  7 2024 19:25:49 arm nucleo-l432kc
nsh> 

