### PR TITLE
net/route: Support longest prefix match for routing

### DIFF
--- a/include/nuttx/net/neighbor.h
+++ b/include/nuttx/net/neighbor.h
@@ -79,9 +79,10 @@ struct neighbor_addr_s
 
 struct neighbor_entry_s
 {
-  net_ipv6addr_t         ne_ipaddr;  /* IPv6 address of the Neighbor */
-  struct neighbor_addr_s ne_addr;    /* Link layer address of the Neighbor */
-  clock_t                ne_time;    /* For aging, units of tick */
+  net_ipv6addr_t           ne_ipaddr;  /* IPv6 address of the Neighbor */
+  struct neighbor_addr_s   ne_addr;    /* Link layer address of the Neighbor */
+  clock_t                  ne_time;    /* For aging, units of tick */
+  FAR struct net_driver_s *ne_dev;     /* The device driver structure */
 };
 
 #ifdef __cplusplus

--- a/net/neighbor/neighbor_add.c
+++ b/net/neighbor/neighbor_add.c
@@ -99,6 +99,7 @@ void neighbor_add(FAR struct net_driver_s *dev, FAR net_ipv6addr_t ipaddr,
    * "oldest_ndx" variable).
    */
 
+  g_neighbors[oldest_ndx].ne_dev  = dev;
   g_neighbors[oldest_ndx].ne_time = clock_systime_ticks();
   net_ipv6addr_copy(g_neighbors[oldest_ndx].ne_ipaddr, ipaddr);
 

--- a/net/route/Kconfig
+++ b/net/route/Kconfig
@@ -137,5 +137,12 @@ config ROUTE_MAX_IPv6_CACHEROUTES
 		This determines the maximum number of routes that can be cached in
 		memory.
 
+config ROUTE_LONGEST_MATCH
+	bool "Enable longest prefix match support"
+	default y
+	---help---
+		Enable support for longest prefix match routing.
+		("Longest Match" in RFC 1812, Section 5.2.4.3, Page 75)
+
 endif # NET_ROUTE
-endmenu # ARP Configuration
+endmenu # Routing Table Configuration

--- a/net/route/net_alloc_ramroute.c
+++ b/net/route/net_alloc_ramroute.c
@@ -159,6 +159,11 @@ FAR struct net_route_ipv4_s *net_allocroute_ipv4(void)
   route = ramroute_ipv4_remfirst(&g_free_ipv4routes);
 
   net_unlock();
+  if (!route)
+    {
+      return NULL;
+    }
+
   return &route->entry;
 }
 #endif
@@ -177,6 +182,11 @@ FAR struct net_route_ipv6_s *net_allocroute_ipv6(void)
   route = ramroute_ipv6_remfirst(&g_free_ipv6routes);
 
   net_unlock();
+  if (!route)
+    {
+      return NULL;
+    }
+
   return &route->entry;
 }
 #endif

--- a/net/route/net_router.c
+++ b/net/route/net_router.c
@@ -35,6 +35,7 @@
 #include "devif/devif.h"
 #include "route/cacheroute.h"
 #include "route/route.h"
+#include "utils/utils.h"
 
 #if defined(CONFIG_NET) && defined(CONFIG_NET_ROUTE)
 
@@ -67,6 +68,14 @@ struct route_ipv4_match_s
 #else
   in_addr_t router;              /* IPv4 address of router a local networks */
 #endif
+#ifdef CONFIG_ROUTE_LONGEST_MATCH
+  /* Only match prefix longer than prefixlen, equals to entry.netmask if we
+   * have got a match (then we only find longer prefix later).
+   * Range: -1 ~ 32
+   */
+
+  int8_t prefixlen;
+#endif
 };
 #endif
 
@@ -78,6 +87,14 @@ struct route_ipv6_match_s
   struct net_route_ipv6_s entry; /* Full entry from the IPv6 routing table */
 #else
   net_ipv6addr_t router;         /* IPv6 address of router a local networks */
+#endif
+#ifdef CONFIG_ROUTE_LONGEST_MATCH
+  /* Only match prefix longer than prefixlen, equals to entry.netmask if we
+   * have got a match (then we only find longer prefix later).
+   * Range: -1 ~ 128
+   */
+
+  int16_t prefixlen;
 #endif
 };
 #endif
@@ -106,13 +123,20 @@ static int net_ipv4_match(FAR struct net_route_ipv4_s *route, FAR void *arg)
 {
   FAR struct route_ipv4_match_s *match =
                                (FAR struct route_ipv4_match_s *)arg;
+#ifdef CONFIG_ROUTE_LONGEST_MATCH
+  int8_t prefixlen = (int8_t)net_ipv4_mask2pref(route->netmask);
+#endif
 
   /* To match, the masked target addresses must be the same.  In the event
    * of multiple matches, only the first is returned.  There is not (yet) any
    * concept for the precedence of networks.
    */
 
-  if (net_ipv4addr_maskcmp(route->target, match->target, route->netmask))
+  if (net_ipv4addr_maskcmp(route->target, match->target, route->netmask)
+#ifdef CONFIG_ROUTE_LONGEST_MATCH
+      && prefixlen > match->prefixlen
+#endif
+     )
     {
 #ifdef CONFIG_ROUTE_IPv4_CACHEROUTE
       /* They match.. Copy the entire routing table entry */
@@ -123,7 +147,13 @@ static int net_ipv4_match(FAR struct net_route_ipv4_s *route, FAR void *arg)
 
       net_ipv4addr_copy(match->router, route->router);
 #endif
+#ifdef CONFIG_ROUTE_LONGEST_MATCH
+      /* Cache the prefix length */
+
+      match->prefixlen = prefixlen;
+#else
       return 1;
+#endif
     }
 
   return 0;
@@ -150,13 +180,20 @@ static int net_ipv6_match(FAR struct net_route_ipv6_s *route, FAR void *arg)
 {
   FAR struct route_ipv6_match_s *match =
                                 (FAR struct route_ipv6_match_s *)arg;
+#ifdef CONFIG_ROUTE_LONGEST_MATCH
+  int16_t prefixlen = (int16_t)net_ipv6_mask2pref(route->netmask);
+#endif
 
   /* To match, the masked target addresses must be the same.  In the event
    * of multiple matches, only the first is returned.  There is not (yet) any
    * concept for the precedence of networks.
    */
 
-  if (net_ipv6addr_maskcmp(route->target, match->target, route->netmask))
+  if (net_ipv6addr_maskcmp(route->target, match->target, route->netmask)
+#ifdef CONFIG_ROUTE_LONGEST_MATCH
+      && prefixlen > match->prefixlen
+#endif
+     )
     {
 #ifdef CONFIG_ROUTE_IPv6_CACHEROUTE
       /* They match.. Copy the entire routing table entry */
@@ -167,7 +204,13 @@ static int net_ipv6_match(FAR struct net_route_ipv6_s *route, FAR void *arg)
 
       net_ipv6addr_copy(match->router, route->router);
 #endif
+#ifdef CONFIG_ROUTE_LONGEST_MATCH
+      /* Cache the prefix length */
+
+      match->prefixlen = prefixlen;
+#else
       return 1;
+#endif
     }
 
   return 0;
@@ -186,9 +229,12 @@ static int net_ipv6_match(FAR struct net_route_ipv6_s *route, FAR void *arg)
  *   router on a local network that can forward to the external network.
  *
  * Input Parameters:
- *   target - An IPv4 address on a remote network to use in the lookup.
- *   router - The address of router on a local network that can forward our
- *     packets to the target.
+ *   target    - An IPv4 address on a remote network to use in the lookup.
+ *   router    - The address of router on a local network that can forward
+ *               our packets to the target.
+ *   prefixlen - The prefix length of previously matched routes (maybe on
+ *               device), will only match prefix longer than prefixlen.
+ *               Range: -1(match all) ~ 32(match none)
  *
  * Returned Value:
  *   OK on success; Negated errno on failure.
@@ -196,10 +242,18 @@ static int net_ipv6_match(FAR struct net_route_ipv6_s *route, FAR void *arg)
  ****************************************************************************/
 
 #ifdef CONFIG_NET_IPv4
-int net_ipv4_router(in_addr_t target, FAR in_addr_t *router)
+int net_ipv4_router(in_addr_t target, FAR in_addr_t *router,
+                    int8_t prefixlen)
 {
   struct route_ipv4_match_s match;
   int ret;
+
+  /* Just early return for long prefix, maybe already got exact match. */
+
+  if (prefixlen >= 32)
+    {
+      return -ENOENT;
+    }
 
   /* Do not route the special broadcast IP address */
 
@@ -212,6 +266,9 @@ int net_ipv4_router(in_addr_t target, FAR in_addr_t *router)
 
   memset(&match, 0, sizeof(struct route_ipv4_match_s));
   net_ipv4addr_copy(match.target, target);
+#ifdef CONFIG_ROUTE_LONGEST_MATCH
+  match.prefixlen = prefixlen;
+#endif
 
 #ifdef CONFIG_ROUTE_IPv4_CACHEROUTE
   /* First see if we can find a router entry in the cache */
@@ -229,7 +286,12 @@ int net_ipv4_router(in_addr_t target, FAR in_addr_t *router)
 
   /* Did we find a route? */
 
+#ifdef CONFIG_ROUTE_LONGEST_MATCH
+  UNUSED(ret);
+  if (match.prefixlen <= prefixlen)
+#else
   if (ret <= 0)
+#endif
     {
       /* No.. there is no route for this address */
 
@@ -261,9 +323,12 @@ int net_ipv4_router(in_addr_t target, FAR in_addr_t *router)
  *   router on a local network that can forward to the external network.
  *
  * Input Parameters:
- *   target - An IPv6 address on a remote network to use in the lookup.
- *   router - The address of router on a local network that can forward our
- *     packets to the target.
+ *   target    - An IPv6 address on a remote network to use in the lookup.
+ *   router    - The address of router on a local network that can forward
+ *               our packets to the target.
+ *   prefixlen - The prefix length of previously matched routes (maybe on
+ *               device), will only match prefix longer than prefixlen.
+ *               Range: -1(match all) ~ 128(match none)
  *
  * Returned Value:
  *   OK on success; Negated errno on failure.
@@ -271,10 +336,18 @@ int net_ipv4_router(in_addr_t target, FAR in_addr_t *router)
  ****************************************************************************/
 
 #ifdef CONFIG_NET_IPv6
-int net_ipv6_router(const net_ipv6addr_t target, net_ipv6addr_t router)
+int net_ipv6_router(const net_ipv6addr_t target, net_ipv6addr_t router,
+                    int16_t prefixlen)
 {
   struct route_ipv6_match_s match;
   int ret;
+
+  /* Just early return for long prefix, maybe already got exact match. */
+
+  if (prefixlen >= 128)
+    {
+      return -ENOENT;
+    }
 
   /* Do not route to any the special IPv6 multicast addresses */
 
@@ -287,6 +360,9 @@ int net_ipv6_router(const net_ipv6addr_t target, net_ipv6addr_t router)
 
   memset(&match, 0, sizeof(struct route_ipv6_match_s));
   net_ipv6addr_copy(match.target, target);
+#ifdef CONFIG_ROUTE_LONGEST_MATCH
+  match.prefixlen = prefixlen;
+#endif
 
 #ifdef CONFIG_ROUTE_IPv6_CACHEROUTE
   /* First see if we can find a router entry in the cache */
@@ -304,7 +380,12 @@ int net_ipv6_router(const net_ipv6addr_t target, net_ipv6addr_t router)
 
   /* Did we find a route? */
 
+#ifdef CONFIG_ROUTE_LONGEST_MATCH
+  UNUSED(ret);
+  if (match.prefixlen <= prefixlen)
+#else
   if (ret <= 0)
+#endif
     {
       /* No.. there is no route for this address */
 

--- a/net/route/netdev_router.c
+++ b/net/route/netdev_router.c
@@ -34,6 +34,7 @@
 #include "netdev/netdev.h"
 #include "route/cacheroute.h"
 #include "route/route.h"
+#include "utils/utils.h"
 
 #if defined(CONFIG_NET) && defined(CONFIG_NET_ROUTE)
 
@@ -67,6 +68,14 @@ struct route_ipv4_devmatch_s
 #else
   in_addr_t router;              /* IPv4 address of router a local networks */
 #endif
+#ifdef CONFIG_ROUTE_LONGEST_MATCH
+  /* Only match prefix longer than prefixlen, equals to entry.netmask if we
+   * have got a match (then we only find longer prefix later).
+   * Range: -1 ~ 32
+   */
+
+  int8_t prefixlen;
+#endif
 };
 #endif
 
@@ -79,6 +88,14 @@ struct route_ipv6_devmatch_s
   struct net_route_ipv6_s entry; /* Full entry from the IPv6 routing table */
 #else
   net_ipv6addr_t router;         /* IPv6 address of router a local networks */
+#endif
+#ifdef CONFIG_ROUTE_LONGEST_MATCH
+  /* Only match prefix longer than prefixlen, equals to entry.netmask if we
+   * have got a match (then we only find longer prefix later).
+   * Range: -1 ~ 128
+   */
+
+  int16_t prefixlen;
 #endif
 };
 #endif
@@ -109,16 +126,24 @@ static int net_ipv4_devmatch(FAR struct net_route_ipv4_s *route,
   FAR struct route_ipv4_devmatch_s *match =
     (FAR struct route_ipv4_devmatch_s *)arg;
   FAR struct net_driver_s *dev = match->dev;
+#ifdef CONFIG_ROUTE_LONGEST_MATCH
+  int8_t prefixlen = (int8_t)net_ipv4_mask2pref(route->netmask);
+#endif
 
   /* To match, (1) the masked target addresses must be the same, and (2) the
    * router address must like on the network provided by the device.
    *
-   * In the event of multiple matches, only the first is returned.  There
-   * not (yet) any concept for the precedence of networks.
+   * In the event of multiple matches, we try to get the longest prefix if
+   * CONFIG_ROUTE_LONGEST_MATCH is set, otherwise only the first match is
+   * returned.
    */
 
   if (net_ipv4addr_maskcmp(route->target, match->target, route->netmask) &&
-      net_ipv4addr_maskcmp(route->router, dev->d_ipaddr, dev->d_netmask))
+      net_ipv4addr_maskcmp(route->router, dev->d_ipaddr, dev->d_netmask)
+#ifdef CONFIG_ROUTE_LONGEST_MATCH
+      && prefixlen > match->prefixlen
+#endif
+      )
     {
 #ifdef CONFIG_ROUTE_IPv4_CACHEROUTE
       /* They match.. Copy the entire routing table entry */
@@ -129,7 +154,13 @@ static int net_ipv4_devmatch(FAR struct net_route_ipv4_s *route,
 
       net_ipv4addr_copy(match->router, route->router);
 #endif
+#ifdef CONFIG_ROUTE_LONGEST_MATCH
+      /* Cache the prefix length */
+
+      match->prefixlen = prefixlen;
+#else
       return 1;
+#endif
     }
 
   return 0;
@@ -158,16 +189,24 @@ static int net_ipv6_devmatch(FAR struct net_route_ipv6_s *route,
   FAR struct route_ipv6_devmatch_s *match =
     (FAR struct route_ipv6_devmatch_s *)arg;
   FAR struct net_driver_s *dev = match->dev;
+#ifdef CONFIG_ROUTE_LONGEST_MATCH
+  int16_t prefixlen = (int16_t)net_ipv6_mask2pref(route->netmask);
+#endif
 
   /* To match, (1) the masked target addresses must be the same, and (2) the
    * router address must like on the network provided by the device.
    *
-   * In the event of multiple matches, only the first is returned.  There
-   * not (yet) any concept for the precedence of networks.
+   * In the event of multiple matches, we try to get the longest prefix if
+   * CONFIG_ROUTE_LONGEST_MATCH is set, otherwise only the first match is
+   * returned.
    */
 
   if (net_ipv6addr_maskcmp(route->target, match->target, route->netmask) &&
-      NETDEV_V6ADDR_ONLINK(dev, route->router))
+      NETDEV_V6ADDR_ONLINK(dev, route->router)
+#ifdef CONFIG_ROUTE_LONGEST_MATCH
+      && prefixlen > match->prefixlen
+#endif
+      )
     {
 #ifdef CONFIG_ROUTE_IPv6_CACHEROUTE
       /* They match.. Copy the entire routing table entry */
@@ -178,7 +217,13 @@ static int net_ipv6_devmatch(FAR struct net_route_ipv6_s *route,
 
       net_ipv6addr_copy(match->router, route->router);
 #endif
+#ifdef CONFIG_ROUTE_LONGEST_MATCH
+      /* Cache the prefix length */
+
+      match->prefixlen = prefixlen;
+#else
       return 1;
+#endif
     }
 
   return 0;
@@ -222,6 +267,9 @@ void netdev_ipv4_router(FAR struct net_driver_s *dev, in_addr_t target,
   memset(&match, 0, sizeof(struct route_ipv4_devmatch_s));
   match.dev = dev;
   net_ipv4addr_copy(match.target, target);
+#ifdef CONFIG_ROUTE_LONGEST_MATCH
+  match.prefixlen = -1;
+#endif
 
 #ifdef CONFIG_ROUTE_IPv4_CACHEROUTE
   /* First see if we can find a router entry in the cache */
@@ -239,7 +287,12 @@ void netdev_ipv4_router(FAR struct net_driver_s *dev, in_addr_t target,
 
   /* Did we find a route? */
 
+#ifdef CONFIG_ROUTE_LONGEST_MATCH
+  UNUSED(ret);
+  if (match.prefixlen >= 0)
+#else
   if (ret > 0)
+#endif
     {
       /* We found a route. */
 
@@ -301,6 +354,9 @@ void netdev_ipv6_router(FAR struct net_driver_s *dev,
   memset(&match, 0, sizeof(struct route_ipv6_devmatch_s));
   match.dev = dev;
   net_ipv6addr_copy(match.target, target);
+#ifdef CONFIG_ROUTE_LONGEST_MATCH
+  match.prefixlen = -1;
+#endif
 
 #ifdef CONFIG_ROUTE_IPv6_CACHEROUTE
   /* First see if we can find a router entry in the cache */
@@ -318,7 +374,12 @@ void netdev_ipv6_router(FAR struct net_driver_s *dev,
 
   /* Did we find a route? */
 
+#ifdef CONFIG_ROUTE_LONGEST_MATCH
+  UNUSED(ret);
+  if (match.prefixlen >= 0)
+#else
   if (ret > 0)
+#endif
     {
       /* We found a route. */
 

--- a/net/route/route.h
+++ b/net/route/route.h
@@ -159,9 +159,12 @@ int net_delroute_ipv6(net_ipv6addr_t target, net_ipv6addr_t netmask);
  *   router on a local network that can forward to the external network.
  *
  * Input Parameters:
- *   target - An IPv4 address on a remote network to use in the lookup.
- *   router - The address of router on a local network that can forward our
- *     packets to the target.
+ *   target    - An IPv4 address on a remote network to use in the lookup.
+ *   router    - The address of router on a local network that can forward
+ *               our packets to the target.
+ *   prefixlen - The prefix length of previously matched routes (maybe on
+ *               device), will only match prefix longer than prefixlen.
+ *               Range: -1(match all) ~ 32(match none)
  *
  * Returned Value:
  *   OK on success; Negated errno on failure.
@@ -169,7 +172,8 @@ int net_delroute_ipv6(net_ipv6addr_t target, net_ipv6addr_t netmask);
  ****************************************************************************/
 
 #ifdef CONFIG_NET_IPv4
-int net_ipv4_router(in_addr_t target, FAR in_addr_t *router);
+int net_ipv4_router(in_addr_t target, FAR in_addr_t *router,
+                    int8_t prefixlen);
 #endif
 
 /****************************************************************************
@@ -180,9 +184,12 @@ int net_ipv4_router(in_addr_t target, FAR in_addr_t *router);
  *   router on a local network that can forward to the external network.
  *
  * Input Parameters:
- *   target - An IPv6 address on a remote network to use in the lookup.
- *   router - The address of router on a local network that can forward our
- *     packets to the target.
+ *   target    - An IPv6 address on a remote network to use in the lookup.
+ *   router    - The address of router on a local network that can forward
+ *               our packets to the target.
+ *   prefixlen - The prefix length of previously matched routes (maybe on
+ *               device), will only match prefix longer than prefixlen.
+ *               Range: -1(match all) ~ 128(match none)
  *
  * Returned Value:
  *   OK on success; Negated errno on failure.
@@ -190,7 +197,8 @@ int net_ipv4_router(in_addr_t target, FAR in_addr_t *router);
  ****************************************************************************/
 
 #ifdef CONFIG_NET_IPv6
-int net_ipv6_router(const net_ipv6addr_t target, net_ipv6addr_t router);
+int net_ipv6_router(const net_ipv6addr_t target, net_ipv6addr_t router,
+                    int16_t prefixlen);
 #endif
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
Support longest prefix match routing described as "Longest Match" in RFC 1812, Section 5.2.4.3, Page 75.
    
Introduced `prefixlen` to indicate the prefix length of currently founded route, and only looks up for longer prefix in all later steps.

## Impact
Routing Table with Kconfig protected.

## Testing
Manually & CI
