### PR TITLE
rpmsgfs: synchronous message transfer format

### DIFF
--- a/fs/rpmsgfs/rpmsgfs.h
+++ b/fs/rpmsgfs/rpmsgfs.h
@@ -115,19 +115,35 @@ begin_packed_struct struct rpmsgfs_ioctl_s
 #define rpmsgfs_sync_s rpmsgfs_close_s
 #define rpmsgfs_dup_s  rpmsgfs_close_s
 
+begin_packed_struct struct rpmsgfs_stat_priv_s
+{
+  uint32_t dev;       /* Device ID of device containing file */
+  uint32_t mode;      /* File type, attributes, and access mode bits */
+  uint32_t rdev;      /* Device ID (if file is character or block special) */
+  uint16_t ino;       /* File serial number */
+  uint16_t nlink;     /* Number of hard links to the file */
+  int64_t  size;      /* Size of file/directory, in bytes */
+  int64_t  atim_sec;  /* Time of last access, seconds */
+  int64_t  atim_nsec; /* Time of last access, nanoseconds */
+  int64_t  mtim_sec;  /* Time of last modification, seconds */
+  int64_t  mtim_nsec; /* Time of last modification, nanoseconds */
+  int64_t  ctim_sec;  /* Time of last status change, seconds */
+  int64_t  ctim_nsec; /* Time of last status change, nanoseconds */
+  uint64_t blocks;    /* Number of blocks allocated */
+  int16_t  uid;       /* User ID of file */
+  int16_t  gid;       /* Group ID of file */
+  int16_t  blksize;   /* Block size used for filesystem I/O */
+  uint16_t reserved;  /* Reserved space */
+} end_packed_struct;
+
 begin_packed_struct struct rpmsgfs_fstat_s
 {
-  struct rpmsgfs_header_s header;
+  struct rpmsgfs_header_s    header;
+  struct rpmsgfs_stat_priv_s buf;
   union
   {
-    struct stat           buf;
-    uint32_t              reserved[16];
-  };
-
-  union
-  {
-    int32_t               fd;
-    char                  pathname[0];
+    int32_t                  fd;
+    char                     pathname[0];
   };
 } end_packed_struct;
 
@@ -158,12 +174,15 @@ begin_packed_struct struct rpmsgfs_readdir_s
 begin_packed_struct struct rpmsgfs_statfs_s
 {
   struct rpmsgfs_header_s header;
-  union
-  {
-    struct statfs         buf;
-    uint32_t              reserved[16];
-  };
-
+  uint32_t                type;     /* Type of filesystem */
+  uint32_t                reserved; /* Reserved space */
+  uint64_t                namelen;  /* Maximum length of filenames */
+  uint64_t                bsize;    /* Optimal block size for transfers */
+  uint64_t                blocks;   /* Total data blocks in the file system of this size */
+  uint64_t                bfree;    /* Free blocks in the file system */
+  uint64_t                bavail;   /* Free blocks avail to non-superuser */
+  uint64_t                files;    /* Total file nodes in the file system */
+  uint64_t                ffree;    /* Free file nodes in the file system */
   char                    pathname[0];
 } end_packed_struct;
 
@@ -183,18 +202,13 @@ begin_packed_struct struct rpmsgfs_mkdir_s
 
 begin_packed_struct struct rpmsgfs_fchstat_s
 {
-  struct rpmsgfs_header_s header;
-  int32_t                 flags;
+  struct rpmsgfs_header_s    header;
+  struct rpmsgfs_stat_priv_s buf;
+  int32_t                    flags;
   union
   {
-    struct stat           buf;
-    uint32_t              reserved[16];
-  };
-
-  union
-  {
-    int32_t               fd;
-    char                  pathname[0];
+    int32_t                  fd;
+    char                     pathname[0];
   };
 } end_packed_struct;
 

--- a/fs/rpmsgfs/rpmsgfs_client.c
+++ b/fs/rpmsgfs/rpmsgfs_client.c
@@ -219,14 +219,14 @@ static int rpmsgfs_statfs_handler(FAR struct rpmsg_endpoint *ept,
   cookie->result = header->result;
   if (cookie->result >= 0)
     {
-      buf->f_type    = rsp->buf.f_type;
-      buf->f_namelen = rsp->buf.f_namelen;
-      buf->f_bsize   = rsp->buf.f_bsize;
-      buf->f_blocks  = rsp->buf.f_blocks;
-      buf->f_bfree   = rsp->buf.f_bfree;
-      buf->f_bavail  = rsp->buf.f_bavail;
-      buf->f_files   = rsp->buf.f_files;
-      buf->f_ffree   = rsp->buf.f_ffree;
+      buf->f_type    = rsp->type;
+      buf->f_namelen = rsp->namelen;
+      buf->f_bsize   = rsp->bsize;
+      buf->f_blocks  = rsp->blocks;
+      buf->f_bfree   = rsp->bfree;
+      buf->f_bavail  = rsp->bavail;
+      buf->f_files   = rsp->files;
+      buf->f_ffree   = rsp->ffree;
     }
 
   rpmsg_post(ept, &cookie->sem);
@@ -247,19 +247,22 @@ static int rpmsgfs_stat_handler(FAR struct rpmsg_endpoint *ept,
   cookie->result = header->result;
   if (cookie->result >= 0)
     {
-      buf->st_dev     = rsp->buf.st_dev;
-      buf->st_ino     = rsp->buf.st_ino;
-      buf->st_mode    = rsp->buf.st_mode;
-      buf->st_nlink   = rsp->buf.st_nlink;
-      buf->st_uid     = rsp->buf.st_uid;
-      buf->st_gid     = rsp->buf.st_gid;
-      buf->st_rdev    = rsp->buf.st_rdev;
-      buf->st_size    = rsp->buf.st_size;
-      buf->st_atime   = rsp->buf.st_atime;
-      buf->st_mtime   = rsp->buf.st_mtime;
-      buf->st_ctime   = rsp->buf.st_ctime;
-      buf->st_blksize = rsp->buf.st_blksize;
-      buf->st_blocks  = rsp->buf.st_blocks;
+      buf->st_dev          = rsp->buf.dev;
+      buf->st_ino          = rsp->buf.ino;
+      buf->st_mode         = rsp->buf.mode;
+      buf->st_nlink        = rsp->buf.nlink;
+      buf->st_uid          = rsp->buf.uid;
+      buf->st_gid          = rsp->buf.gid;
+      buf->st_rdev         = rsp->buf.rdev;
+      buf->st_size         = rsp->buf.size;
+      buf->st_atim.tv_sec  = rsp->buf.atim_sec;
+      buf->st_atim.tv_nsec = rsp->buf.atim_nsec;
+      buf->st_mtim.tv_sec  = rsp->buf.mtim_sec;
+      buf->st_mtim.tv_nsec = rsp->buf.mtim_nsec;
+      buf->st_ctim.tv_sec  = rsp->buf.ctim_sec;
+      buf->st_ctim.tv_nsec = rsp->buf.ctim_nsec;
+      buf->st_blksize      = rsp->buf.blksize;
+      buf->st_blocks       = rsp->buf.blocks;
     }
 
   rpmsg_post(ept, &cookie->sem);
@@ -909,9 +912,24 @@ int rpmsgfs_client_fchstat(FAR void *handle, int fd,
 {
   struct rpmsgfs_fchstat_s msg =
   {
-    .flags = flags,
-    .buf = *buf,
-    .fd = fd,
+    .buf.dev       = buf->st_dev,
+    .buf.ino       = buf->st_ino,
+    .buf.mode      = buf->st_mode,
+    .buf.nlink     = buf->st_nlink,
+    .buf.uid       = buf->st_uid,
+    .buf.gid       = buf->st_gid,
+    .buf.rdev      = buf->st_rdev,
+    .buf.size      = buf->st_size,
+    .buf.atim_sec  = buf->st_atim.tv_sec,
+    .buf.atim_nsec = buf->st_atim.tv_nsec,
+    .buf.mtim_sec  = buf->st_mtim.tv_sec,
+    .buf.mtim_nsec = buf->st_mtim.tv_nsec,
+    .buf.ctim_sec  = buf->st_ctim.tv_sec,
+    .buf.ctim_nsec = buf->st_ctim.tv_nsec,
+    .buf.blksize   = buf->st_blksize,
+    .buf.blocks    = buf->st_blocks,
+    .flags            = flags,
+    .fd               = fd,
   };
 
   return rpmsgfs_send_recv(handle, RPMSGFS_FCHSTAT, true,

--- a/fs/rpmsgfs/rpmsgfs_server.c
+++ b/fs/rpmsgfs/rpmsgfs_server.c
@@ -547,7 +547,22 @@ static int rpmsgfs_fstat_handler(FAR struct rpmsg_endpoint *ept,
       ret = file_fstat(filep, &buf);
       if (ret >= 0)
         {
-          msg->buf = buf;
+          msg->buf.dev       = buf.st_dev;
+          msg->buf.ino       = buf.st_ino;
+          msg->buf.mode      = buf.st_mode;
+          msg->buf.nlink     = buf.st_nlink;
+          msg->buf.uid       = buf.st_uid;
+          msg->buf.gid       = buf.st_gid;
+          msg->buf.rdev      = buf.st_rdev;
+          msg->buf.size      = buf.st_size;
+          msg->buf.atim_sec  = buf.st_atim.tv_sec;
+          msg->buf.atim_nsec = buf.st_atim.tv_nsec;
+          msg->buf.mtim_sec  = buf.st_mtim.tv_sec;
+          msg->buf.mtim_nsec = buf.st_mtim.tv_nsec;
+          msg->buf.ctim_sec  = buf.st_ctim.tv_sec;
+          msg->buf.ctim_nsec = buf.st_ctim.tv_nsec;
+          msg->buf.blksize   = buf.st_blksize;
+          msg->buf.blocks    = buf.st_blocks;
         }
     }
 
@@ -677,7 +692,14 @@ static int rpmsgfs_statfs_handler(FAR struct rpmsg_endpoint *ept,
     }
   else
     {
-      msg->buf = buf;
+      msg->type    = buf.f_type;
+      msg->namelen = buf.f_namelen;
+      msg->bsize   = buf.f_bsize;
+      msg->blocks  = buf.f_blocks;
+      msg->bfree   = buf.f_bfree;
+      msg->bavail  = buf.f_bavail;
+      msg->files   = buf.f_files;
+      msg->ffree   = buf.f_ffree;
     }
 
   msg->header.result = ret;
@@ -746,7 +768,22 @@ static int rpmsgfs_stat_handler(FAR struct rpmsg_endpoint *ept,
   ret = nx_stat(msg->pathname, &buf, 1);
   if (ret >= 0)
     {
-      msg->buf = buf;
+      msg->buf.dev       = buf.st_dev;
+      msg->buf.ino       = buf.st_ino;
+      msg->buf.mode      = buf.st_mode;
+      msg->buf.nlink     = buf.st_nlink;
+      msg->buf.uid       = buf.st_uid;
+      msg->buf.gid       = buf.st_gid;
+      msg->buf.rdev      = buf.st_rdev;
+      msg->buf.size      = buf.st_size;
+      msg->buf.atim_sec  = buf.st_atim.tv_sec;
+      msg->buf.atim_nsec = buf.st_atim.tv_nsec;
+      msg->buf.mtim_sec  = buf.st_mtim.tv_sec;
+      msg->buf.mtim_nsec = buf.st_mtim.tv_nsec;
+      msg->buf.ctim_sec  = buf.st_ctim.tv_sec;
+      msg->buf.ctim_nsec = buf.st_ctim.tv_nsec;
+      msg->buf.blksize   = buf.st_blksize;
+      msg->buf.blocks    = buf.st_blocks;
     }
 
   msg->header.result = ret;
@@ -765,7 +802,23 @@ static int rpmsgfs_fchstat_handler(FAR struct rpmsg_endpoint *ept,
   filep = rpmsgfs_get_file(priv, msg->fd);
   if (filep != NULL)
     {
-      buf = msg->buf;
+      buf.st_dev          = msg->buf.dev;
+      buf.st_ino          = msg->buf.ino;
+      buf.st_mode         = msg->buf.mode;
+      buf.st_nlink        = msg->buf.nlink ;
+      buf.st_uid          = msg->buf.uid ;
+      buf.st_gid          = msg->buf.gid;
+      buf.st_rdev         = msg->buf.rdev;
+      buf.st_size         = msg->buf.size;
+      buf.st_atim.tv_sec  = msg->buf.atim_sec;
+      buf.st_atim.tv_nsec = msg->buf.atim_nsec;
+      buf.st_mtim.tv_sec  = msg->buf.mtim_sec;
+      buf.st_mtim.tv_nsec = msg->buf.mtim_nsec;
+      buf.st_ctim.tv_sec  = msg->buf.ctim_sec;
+      buf.st_ctim.tv_nsec = msg->buf.ctim_nsec;
+      buf.st_blksize      = msg->buf.blksize;
+      buf.st_blocks       = msg->buf.blocks;
+
       ret = file_fchstat(filep, &buf, msg->flags);
     }
 
@@ -783,7 +836,7 @@ static int rpmsgfs_chstat_handler(FAR struct rpmsg_endpoint *ept,
 
   if (msg->flags & CH_STAT_MODE)
     {
-      ret = chmod(msg->pathname, msg->buf.st_mode);
+      ret = chmod(msg->pathname, msg->buf.mode);
       if (ret < 0)
         {
           ret = -get_errno();
@@ -793,7 +846,7 @@ static int rpmsgfs_chstat_handler(FAR struct rpmsg_endpoint *ept,
 
   if (msg->flags & (CH_STAT_UID | CH_STAT_GID))
     {
-      ret = chown(msg->pathname, msg->buf.st_uid, msg->buf.st_gid);
+      ret = chown(msg->pathname, msg->buf.uid, msg->buf.gid);
       if (ret < 0)
         {
           ret = -get_errno();
@@ -805,7 +858,8 @@ static int rpmsgfs_chstat_handler(FAR struct rpmsg_endpoint *ept,
     {
       if (msg->flags & CH_STAT_ATIME)
         {
-          times[0] = msg->buf.st_atim;
+          times[0].tv_sec = msg->buf.atim_sec;
+          times[0].tv_nsec = msg->buf.atim_nsec;
         }
       else
         {
@@ -815,7 +869,8 @@ static int rpmsgfs_chstat_handler(FAR struct rpmsg_endpoint *ept,
 
       if (msg->flags & CH_STAT_MTIME)
         {
-          times[1] = msg->buf.st_mtim;
+          times[1].tv_sec = msg->buf.mtim_sec;
+          times[1].tv_nsec = msg->buf.mtim_nsec;
         }
       else
         {


### PR DESCRIPTION
## Summary
In order to avoid the different memory occupied by the structure on different systems, this PR unifies the data type of the structure so that it occupies the same memory on 64-bit, 32-bit systems and other systems.
## Impact
Improved communication protocol consistency of rpmsgfs to help reduce potential communication errors.
## Testing
Test in sim vela and 86panel.
