### PR TITLE
rpmsgmtd: use fixed length struct to transfer between two cpus

### DIFF
--- a/drivers/mtd/rpmsgmtd.h
+++ b/drivers/mtd/rpmsgmtd.h
@@ -35,13 +35,15 @@
 
 #define RPMSGMTD_NAME_PREFIX     "rpmsgmtd-"
 #define RPMSGMTD_NAME_PREFIX_LEN 9
+#define RPMSGMTD_NAME_MAX        32
 
 #define RPMSGMTD_ERASE           1
 #define RPMSGMTD_BREAD           2
 #define RPMSGMTD_BWRITE          3
 #define RPMSGMTD_READ            4
 #define RPMSGMTD_WRITE           5
-#define RPMSGMTD_IOCTL           6
+#define RPMSGMTD_GEOMETRY        6
+#define RPMSGMTD_IOCTL           7
 
 /****************************************************************************
  * Public Types
@@ -81,6 +83,15 @@ begin_packed_struct struct rpmsgmtd_read_s
 } end_packed_struct;
 
 #define rpmsgmtd_write_s rpmsgmtd_read_s
+
+begin_packed_struct struct rpmsgmtd_geometry_s
+{
+  struct rpmsgmtd_header_s header;
+  uint32_t                 blocksize;
+  uint32_t                 erasesize;
+  uint32_t                 neraseblocks;
+  char                     model[RPMSGMTD_NAME_MAX + 1];
+} end_packed_struct;
 
 begin_packed_struct struct rpmsgmtd_ioctl_s
 {


### PR DESCRIPTION
## Summary
1. rpmsgmtd_geometry_s use fixed length struct to transfer between two cpus.
2. Strip geometry out of ioctl and add rpmsgmtd_geometry_handler function, it will be called to process the return message of rpmsgmtd_get_geometry().
## Impact
Improved communication protocol consistency of rpmsgmtd to help reduce potential communication errors.
## Testing
Test in sim vela and 86panel.
