### PR TITLE
esp32[s2|s3] Following up update interrupt type constants.

### DIFF
--- a/arch/xtensa/src/esp32s2/esp32s2_spi_slave.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_spi_slave.c
@@ -1203,7 +1203,7 @@ static void spislave_initialize(struct spi_slave_ctrlr_s *ctrlr)
   spislave_dma_init(priv);
 #endif
 
-  esp32s2_gpioirqenable(ESP32S2_PIN2IRQ(config->cs_pin), GPIO_INTR_POSEDGE);
+  esp32s2_gpioirqenable(ESP32S2_PIN2IRQ(config->cs_pin), RISING);
 
   /* Force a transaction done interrupt.
    * This interrupt won't fire yet because we initialized the SPI interrupt

--- a/arch/xtensa/src/esp32s3/esp32s3_spi_slave.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_spi_slave.c
@@ -1347,7 +1347,7 @@ static void spislave_initialize(struct spi_slave_ctrlr_s *ctrlr)
   spislave_dma_init(priv);
 #endif
 
-  esp32s3_gpioirqenable(ESP32S3_PIN2IRQ(config->cs_pin), GPIO_INTR_POSEDGE);
+  esp32s3_gpioirqenable(ESP32S3_PIN2IRQ(config->cs_pin), RISING);
 
   /* Force a transaction done interrupt.
    * This interrupt won't fire yet because we initialized the SPI interrupt


### PR DESCRIPTION
## Summary
Following up the 'Espressif HAL fullly integration for ESP32s2/s3' changes in https://github.com/apache/nuttx/pull/11428. There are still few interrupt type constants need update. Updated them to avoid the build error.

## Impact
ESP32s2/s3 SPI slave mode

## Testing
Pass the build
