### PR TITLE
linux/Dockerfile: Add the python3 coloredlogs package for the matter build

### DIFF
--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -343,10 +343,11 @@ RUN pip3 install pytest==6.2.5
 RUN pip3 install pytest-json==0.4.0
 RUN pip3 install pytest-ordering==0.6
 RUN pip3 install pytest-repeat==0.9.1
-# Install lark stringcase and jinja2 for matter build
+# Install lark stringcase jinja2 and coloredlogs for matter build
 RUN pip3 install lark
 RUN pip3 install stringcase
 RUN pip3 install jinja2
+RUN pip3 install coloredlogs
 
 # Upgrade nodejs to the latest version
 RUN npm install -g n && n stable && hash -r


### PR DESCRIPTION
## Summary
Depend on this package when we compile using the build_examples.py script that comes with matter.

## Impact

## Testing
local docker ghcr.io/apache/nuttx/apache-nuttx-ci-linux
