### PR TITLE
rptun: remove rptun work queue related unused code

### DIFF
--- a/drivers/rptun/Kconfig
+++ b/drivers/rptun/Kconfig
@@ -12,26 +12,12 @@ menuconfig RPTUN
 
 if RPTUN
 
-choice
-	prompt "rptun dispatch method"
-
-config RPTUN_THREAD
-	bool "rptun thread"
-
-config RPTUN_WORKQUEUE
-	bool "rptun workqueue"
-	depends on SCHED_WORKQUEUE
-
-endchoice
-
 config RPTUN_PRIORITY
 	int "rptun thread priority"
-	depends on RPTUN_THREAD
 	default 224
 
 config RPTUN_STACKSIZE
 	int "rptun stack size"
-	depends on RPTUN_THREAD
 	default 4096
 
 config RPTUN_LOADER


### PR DESCRIPTION
## Summary
Remove rptun work queue related unused code, currently only rptun thread is used.
## Impact
Make code leaner.
## Testing
Tested in sim vela and 86 panel.

