### PR TITLE
arm/fvp-v8r: fix arm_earlyserialinit() is not called correctly 

### DIFF
--- a/arch/arm/src/fvp-v8r-aarch32/fvp_boot.c
+++ b/arch/arm/src/fvp-v8r-aarch32/fvp_boot.c
@@ -30,6 +30,8 @@
 
 #include <arch/chip/chip.h>
 
+#include "arm_internal.h"
+
 #include "barriers.h"
 #include "cp15.h"
 #include "arm_gic.h"


### PR DESCRIPTION
## Summary

arm/fvp-v8r: fix arm_earlyserialinit() is not called correctly 

USE_EARLYSERIALINIT will depends on the definition in arm_internal.h

## Impact

N/A

## Testing

fvp-armv8r-aarch32/nsh