### PR TITLE
arm/armv8-r: fix compile warning

### DIFF
--- a/arch/arm/src/armv8-r/arm_gicv3.c
+++ b/arch/arm/src/armv8-r/arm_gicv3.c
@@ -727,7 +727,7 @@ static int gic_validate_dist_version(void)
   spis  = MIN(GICD_TYPER_SPIS(typer), 1020U) - 32;
   espis = GICD_TYPER_ESPIS(typer);
 
-  sinfo("GICD_TYPER = 0x%x\n", typer);
+  sinfo("GICD_TYPER = 0x%" PRIu32 "\n", typer);
   sinfo("%d SPIs implemented\n", spis);
   sinfo("%d Extended SPIs implemented\n", espis);
 


### PR DESCRIPTION

## Summary

arm/armv8-r: fix compile warning

```
armv8-r/arm_gicv3.c: In function 'gic_validate_dist_version': armv8-r/arm_gicv3.c:730:9: warning: format '%x' expects argument of type 'unsigned int', but argument 3 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
  730 |   sinfo("GICD_TYPER = 0x%x\n", typer);
      |         ^~~~~~~~~~~~~~~~~~~~~  ~~~~~
      |                                |
      |                                uint32_t {aka long unsigned int}
armv8-r/arm_gicv3.c:730:26: note: format string is defined here
  730 |   sinfo("GICD_TYPER = 0x%x\n", typer);
      |                         ~^
      |                          |
      |                          unsigned int
      |                         %lx
```

## Impact

N/A

## Testing

fvp-armv8r-aarch32/nsh