### PR TITLE
decoupling rptun ping and rptun_virtio_device, rptun ping and rptun.

### DIFF
--- a/drivers/rptun/Kconfig
+++ b/drivers/rptun/Kconfig
@@ -10,6 +10,13 @@ menuconfig RPTUN
 	---help---
 		RPTUN driver is used for multi-cores' communication.
 
+config RPTUN_PING
+	bool "rptun ping support"
+	default n
+	---help---
+		This is for debugging & profiling, create ping rpmsg
+		channel, user can use it to get send/recv speed & latency.
+
 if RPTUN
 
 config RPTUN_PRIORITY
@@ -37,12 +44,5 @@ config RPTUN_PM
 		And when one CPU in DEEP sleep, then it's buffer will
 		goto RAM-retention mode, can't access from another CPU.
 		So, we provide this method to resolve this.
-
-config RPTUN_PING
-	bool "rptun ping support"
-	default n
-	---help---
-		This is for rptun debugging & profiling, create ping RPMSG
-		channel, user can use it to get send/recv speed & latency.
 
 endif # RPTUN

--- a/drivers/rptun/rptun.c
+++ b/drivers/rptun/rptun.c
@@ -719,7 +719,7 @@ static int rptun_dev_start(FAR struct remoteproc *rproc)
   virtqueue_enable_cb(priv->rvdev.svq);
 
 #ifdef CONFIG_RPTUN_PING
-  rptun_ping_init(&priv->rvdev, &priv->ping);
+  rptun_ping_init(&priv->rvdev.rdev, &priv->ping);
 #endif
   return 0;
 }

--- a/drivers/rptun/rptun.h
+++ b/drivers/rptun/rptun.h
@@ -35,7 +35,7 @@
 int rptun_buffer_nused(FAR struct rpmsg_virtio_device *rvdev, bool rx);
 void rptun_dump(FAR struct rpmsg_virtio_device *rvdev);
 
-int rptun_ping_init(FAR struct rpmsg_virtio_device *rvdev,
+int rptun_ping_init(FAR struct rpmsg_device *rvdev,
                     FAR struct rpmsg_endpoint *ept);
 void rptun_ping_deinit(FAR struct rpmsg_endpoint *ept);
 int rptun_ping(FAR struct rpmsg_endpoint *ept,

--- a/drivers/rptun/rptun_ping.c
+++ b/drivers/rptun/rptun_ping.c
@@ -226,10 +226,10 @@ int rptun_ping(FAR struct rpmsg_endpoint *ept,
   return 0;
 }
 
-int rptun_ping_init(FAR struct rpmsg_virtio_device *rvdev,
+int rptun_ping_init(FAR struct rpmsg_device *rdev,
                     FAR struct rpmsg_endpoint *ept)
 {
-  return rpmsg_create_ept(ept, &rvdev->rdev, RPTUN_PING_EPT_NAME,
+  return rpmsg_create_ept(ept, rdev, RPTUN_PING_EPT_NAME,
                           RPMSG_ADDR_ANY, RPMSG_ADDR_ANY,
                           rptun_ping_ept_cb, NULL);
 }

--- a/drivers/rptun/rptun_ping.c
+++ b/drivers/rptun/rptun_ping.c
@@ -31,8 +31,7 @@
 #include <time.h>
 #include <nuttx/signal.h>
 
-#include "rptun.h"
-
+#include "rptun_ping.h"
 /****************************************************************************
  * Pre-processor definitions
  ****************************************************************************/

--- a/drivers/rptun/rptun_ping.h
+++ b/drivers/rptun/rptun_ping.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * drivers/rptun/rptun.h
+ * drivers/rptun/rptun_ping.h
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,23 +18,27 @@
  *
  ****************************************************************************/
 
-#ifndef __DRIVERS_RPTUN_RPTUN_H
-#define __DRIVERS_RPTUN_RPTUN_H
+#ifndef __DRIVERS_RPTUN_RPTUN_PING_H
+#define __DRIVERS_RPTUN_RPTUN_PING_H
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
 
-#include <nuttx/rptun/rptun.h>
+#include <nuttx/rptun/rptun_ping.h>
 #include <openamp/open_amp.h>
 
-#include "rptun_ping.h"
+#ifdef CONFIG_RPTUN_PING
 
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
 
-int rptun_buffer_nused(FAR struct rpmsg_virtio_device *rvdev, bool rx);
-void rptun_dump(FAR struct rpmsg_virtio_device *rvdev);
+int rptun_ping_init(FAR struct rpmsg_device *rvdev,
+                    FAR struct rpmsg_endpoint *ept);
+void rptun_ping_deinit(FAR struct rpmsg_endpoint *ept);
+int rptun_ping(FAR struct rpmsg_endpoint *ept,
+               FAR const struct rptun_ping_s *ping);
 
-#endif /* __DRIVERS_RPTUN_RPTUN_H */
+#endif /* CONFIG_RPTUN_PING */
+#endif /* __DRIVERS_RPTUN_RPTUN_PING_H */

--- a/include/nuttx/rptun/rptun.h
+++ b/include/nuttx/rptun/rptun.h
@@ -30,6 +30,7 @@
 #ifdef CONFIG_RPTUN
 
 #include <nuttx/fs/ioctl.h>
+#include <nuttx/rptun/rptun_ping.h>
 #include <openamp/open_amp.h>
 
 /****************************************************************************
@@ -340,16 +341,6 @@ struct rptun_ops_s
 struct rptun_dev_s
 {
   FAR const struct rptun_ops_s *ops;
-};
-
-/* used for ioctl RPTUNIOC_PING */
-
-struct rptun_ping_s
-{
-  int  times;
-  int  len;
-  int  ack;
-  int  sleep; /* unit: ms */
 };
 
 /****************************************************************************

--- a/include/nuttx/rptun/rptun_ping.h
+++ b/include/nuttx/rptun/rptun_ping.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * drivers/rptun/rptun.h
+ * include/nuttx/rptun/rptun_ping.h
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,23 +18,30 @@
  *
  ****************************************************************************/
 
-#ifndef __DRIVERS_RPTUN_RPTUN_H
-#define __DRIVERS_RPTUN_RPTUN_H
+#ifndef __INCLUDE_NUTTX_RPTUN_RPTUN_PING_H
+#define __INCLUDE_NUTTX_RPTUN_RPTUN_PING_H
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
 
-#include <nuttx/rptun/rptun.h>
-#include <openamp/open_amp.h>
+#include <nuttx/config.h>
 
-#include "rptun_ping.h"
+#ifdef CONFIG_RPTUN_PING
 
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
 
-int rptun_buffer_nused(FAR struct rpmsg_virtio_device *rvdev, bool rx);
-void rptun_dump(FAR struct rpmsg_virtio_device *rvdev);
+/* used for ioctl RPTUNIOC_PING */
 
-#endif /* __DRIVERS_RPTUN_RPTUN_H */
+struct rptun_ping_s
+{
+  int  times;
+  int  len;
+  int  ack;
+  int  sleep; /* unit: ms */
+};
+
+#endif /* CONFIG_RPTUN_PING */
+#endif /* __INCLUDE_NUTTX_RPTUN_RPTUN_PING_H */


### PR DESCRIPTION
## Summary
Decoupling rptun ping and rptun_virtio_device, rptun ping and rptun.
ping is not only rptun support, so move it to public part.
## Impact
Decoupling ping and rptun, other transport layers can also call ping.
## Testing
Tested in sim vela, 86panel.

