### PR TITLE
esp32s3/wifi: Fix Wi-Fi connection to WPA3-SAE APs.

### DIFF
--- a/arch/xtensa/src/esp32s3/esp32s3_wifi_adapter.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_wifi_adapter.c
@@ -5125,6 +5125,7 @@ int esp_wifi_sta_essid(struct iwreq *iwr, bool set)
     {
       memset(wifi_cfg.sta.ssid, 0x0, SSID_MAX_LEN);
       memcpy(wifi_cfg.sta.ssid, pdata, len);
+      memset(wifi_cfg.sta.sae_h2e_identifier, 0x0, SAE_H2E_IDENTIFIER_LEN);
       wifi_cfg.sta.sae_pwe_h2e = WPA3_SAE_PWE_BOTH;
 
       if (g_sta_connected)


### PR DESCRIPTION
## Summary

* esp32s3/wifi: Fix Wi-Fi connection to WPA3-SAE APs.

This commit fixes the connection issues while trying to connect to WPA3-SAE-secured Access Points (APs).

## Impact

Reenable connecting to WPA3-SAE-secured APs.

## Testing

Internal CI testing + ESP32-S3-DevKitC-1 v1.0 (WROOM-1)