### PR TITLE
fs: partition: fs_mbr: fix for MBR block count calculation.

### DIFF
--- a/fs/partition/fs_mbr.c
+++ b/fs/partition/fs_mbr.c
@@ -36,7 +36,7 @@
  ****************************************************************************/
 
 #define MBR_SIZE                   512
-#define MBR_LBA_TO_BLOCK(lba, blk) ((le32toh(lba) * 512 + (blk) - 1) / (blk))
+#define MBR_LBA_TO_BLOCK(lba, blk) (((blkcnt_t)le32toh(lba) * 512 + (blk) - 1) / (blk))
 
 /****************************************************************************
  * Private Types


### PR DESCRIPTION
When the MBR partition size exceeds 2 GiB, a 32-bit wrap-around occurs,
causing an error in the block count calculation.

* wrong
 brw-rw-rw- 5150605312 mmcblk0
 brw-rw-rw-  629145600 mmcblk0p1
 brw-rw-rw-  225443840 mmcblk0p2 <--
* fixed
 brw-rw-rw- 5150605312 mmcblk0
 brw-rw-rw-  629145600 mmcblk0p1
 brw-rw-rw- 4520411136 mmcblk0p2 <--

## Summary

## Impact

## Testing

