### PR TITLE
risc-v/nuttsbi: add device specific initialization hook

### DIFF
--- a/arch/risc-v/src/nuttsbi/sbi_internal.h
+++ b/arch/risc-v/src/nuttsbi/sbi_internal.h
@@ -140,5 +140,17 @@ uint64_t sbi_get_mtime(void);
 
 void sbi_set_mtimecmp(uint64_t value);
 
+/****************************************************************************
+ * Name: sbi_late_initialize
+ *
+ * Description:
+ *   Conduct any device specific initialization before entering S-mode from
+ *   NUTTSBI as some chips need such preparations. This function still runs
+ *   in M-mode.
+ *
+ ****************************************************************************/
+
+weak_function void sbi_late_initialize(void);
+
 #endif /* __ASSEMBLY__ */
 #endif /* __ARCH_RISC_V_SRC_NUTTSBI_SBI_INTERNAL_H */

--- a/arch/risc-v/src/nuttsbi/sbi_start.c
+++ b/arch/risc-v/src/nuttsbi/sbi_start.c
@@ -107,6 +107,10 @@ void sbi_start(void)
   WRITE_CSR(mcounteren, UINT32_C(~0));
   WRITE_CSR(scounteren, UINT32_C(~0));
 
+  /* Do device specific initialization as needed */
+
+  sbi_late_initialize();
+
   /* Set program counter to __start_s */
 
   WRITE_CSR(mepc, __start_s);


### PR DESCRIPTION
## Summary

Some devices have special preparations before entering S-mode, thus a hook is needed from NUTTSBI to give them the chance.

## Impact

None

## Testing

Checked with CanMV230

