### PR TITLE
sched/logging: add task activation/exit logs

### DIFF
--- a/sched/task/task_activate.c
+++ b/sched/task/task_activate.c
@@ -84,6 +84,13 @@ void nxtask_activate(FAR struct tcb_s *tcb)
 
   nxsched_remove_blocked(tcb);
 
+#if CONFIG_TASK_NAME_SIZE > 0
+  sinfo("%s pid=%d,TCB=%p\n", tcb->name,
+#else
+  sinfo("pid=%d,TCB=%p\n",
+#endif  
+        tcb->pid, tcb);
+
   /* Add the task to ready-to-run task list, and
    * perform the context switch if one is needed
    */

--- a/sched/task/task_exit.c
+++ b/sched/task/task_exit.c
@@ -25,6 +25,7 @@
 #include <nuttx/config.h>
 
 #include <sched.h>
+#include <debug.h>
 
 #include "sched/sched.h"
 
@@ -87,6 +88,13 @@ int nxtask_exit(void)
 #else
   dtcb = this_task();
 #endif
+
+#if CONFIG_TASK_NAME_SIZE > 0
+  sinfo("%s pid=%d,TCB=%p\n", dtcb->name,
+#else
+  sinfo("pid=%d,TCB=%p\n",
+#endif  
+        dtcb->pid, dtcb);
 
   /* Update scheduler parameters */
 


### PR DESCRIPTION
## Summary

Task activation/exit logs are helpful for device bringup, especially when user space nsh prompt doesn't show up.

Putting them here also allows cleaning of logs in multiple `up_exit()` functions later.

## Impact

None

## Testing

Checked with rv-virt/nsh, rv-virt/knsh, canmv230/nsh etc.
