### PR TITLE
libcxx: Fix CMake compile with correct CMAKE_CXX_STANDARD

### DIFF
--- a/libs/libxx/libcxx.cmake
+++ b/libs/libxx/libcxx.cmake
@@ -80,7 +80,7 @@ if(CONFIG_LIBSUPCXX)
   add_compile_definitions(__GLIBCXX__)
 endif()
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(SRCS)


### PR DESCRIPTION
## Summary
It seems libcxx needs C++20 from 12.0.0 to 17.0.6: https://github.com/llvm/llvm-project/commit/3b625060fc91598d28196e559196bfc7b9a929f9

But we're setting `CMAKE_CXX_STANDARD to 17`, errors on my side:

```
nuttx/libs/libxx/libcxx/src/include/to_chars_floating_point.h:122:46: error: ‘bit_cast’ is not a member of ‘std’
  122 |     const _Uint_type _Uint_value    = _VSTD::bit_cast<_Uint_type>(_Value);
      |                                              ^~~~~~~~
nuttx/libs/libxx/libcxx/src/memory_resource_init_helper.h:2:8: error: ‘constinit’ does not name a type
    2 | static constinit ResourceInitHelper res_init _LIBCPP_INIT_PRIORITY_MAX;
      |        ^~~~~~~~~
nuttx/libs/libxx/libcxx/src/memory_resource_init_helper.h:2:8: note: C++20 ‘constinit’ only available with ‘-std=c++20’ or ‘-std=gnu++20’
```

## Impact
CMake compile for libcxx

## Testing
locally & CI
