### PR TITLE
arch/: remove duplicated task exit logging

### DIFF
--- a/arch/arm/src/common/arm_exit.c
+++ b/arch/arm/src/common/arm_exit.c
@@ -62,8 +62,6 @@ void up_exit(int status)
 
   enter_critical_section();
 
-  sinfo("TCB=%p exiting\n", tcb);
-
   nxsched_dumponexit();
 
   /* Destroy the task at the head of the ready to run list. */

--- a/arch/avr/src/common/avr_exit.c
+++ b/arch/avr/src/common/avr_exit.c
@@ -61,8 +61,6 @@ void up_exit(int status)
 
   enter_critical_section();
 
-  sinfo("TCB=%p exiting\n", tcb);
-
   nxsched_dumponexit();
 
   /* Destroy the task at the head of the ready to run list. */

--- a/arch/hc/src/common/hc_exit.c
+++ b/arch/hc/src/common/hc_exit.c
@@ -60,8 +60,6 @@ void up_exit(int status)
 
   enter_critical_section();
 
-  sinfo("TCB=%p exiting\n", tcb);
-
   nxsched_dumponexit();
 
   /* Destroy the task at the head of the ready to run list. */

--- a/arch/mips/src/common/mips_exit.c
+++ b/arch/mips/src/common/mips_exit.c
@@ -62,8 +62,6 @@ void up_exit(int status)
 
   enter_critical_section();
 
-  sinfo("TCB=%p exiting\n", tcb);
-
   nxsched_dumponexit();
 
   /* Destroy the task at the head of the ready to run list. */

--- a/arch/misoc/src/lm32/lm32_exit.c
+++ b/arch/misoc/src/lm32/lm32_exit.c
@@ -62,8 +62,6 @@ void up_exit(int status)
 
   enter_critical_section();
 
-  sinfo("TCB=%p exiting\n", tcb);
-
   nxsched_dumponexit();
 
   /* Destroy the task at the head of the ready to run list. */

--- a/arch/misoc/src/minerva/minerva_exit.c
+++ b/arch/misoc/src/minerva/minerva_exit.c
@@ -62,8 +62,6 @@ void up_exit(int status)
 
   enter_critical_section();
 
-  sinfo("TCB=%p exiting\n", tcb);
-
   nxsched_dumponexit();
 
   /* Destroy the task at the head of the ready to run list. */

--- a/arch/or1k/src/common/or1k_exit.c
+++ b/arch/or1k/src/common/or1k_exit.c
@@ -62,8 +62,6 @@ void up_exit(int status)
 
   enter_critical_section();
 
-  sinfo("TCB=%p exiting\n", tcb);
-
   nxsched_dumponexit();
 
   /* Destroy the task at the head of the ready to run list. */

--- a/arch/renesas/src/common/renesas_exit.c
+++ b/arch/renesas/src/common/renesas_exit.c
@@ -60,8 +60,6 @@ void up_exit(int status)
 
   enter_critical_section();
 
-  sinfo("TCB=%p exiting\n", tcb);
-
   nxsched_dumponexit();
 
   /* Destroy the task at the head of the ready to run list. */

--- a/arch/risc-v/src/common/riscv_exit.c
+++ b/arch/risc-v/src/common/riscv_exit.c
@@ -62,8 +62,6 @@ void up_exit(int status)
 
   enter_critical_section();
 
-  sinfo("TCB=%p exiting\n", tcb);
-
   nxsched_dumponexit();
 
   /* Destroy the task at the head of the ready to run list. */

--- a/arch/sim/src/sim/sim_exit.c
+++ b/arch/sim/src/sim/sim_exit.c
@@ -58,8 +58,6 @@ void up_exit(int status)
 
   enter_critical_section();
 
-  sinfo("TCB=%p exiting\n", this_task());
-
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();

--- a/arch/sparc/src/common/sparc_exit.c
+++ b/arch/sparc/src/common/sparc_exit.c
@@ -62,8 +62,6 @@ void up_exit(int status)
 
   (void)enter_critical_section();
 
-  sinfo("TCB=%p exiting\n", tcb);
-
   nxsched_dumponexit();
 
   /* Update scheduler parameters */

--- a/arch/x86/src/common/x86_exit.c
+++ b/arch/x86/src/common/x86_exit.c
@@ -61,8 +61,6 @@ void up_exit(int status)
 
   enter_critical_section();
 
-  sinfo("TCB=%p exiting\n", tcb);
-
   nxsched_dumponexit();
 
   /* Destroy the task at the head of the ready to run list. */

--- a/arch/x86_64/src/common/x86_64_exit.c
+++ b/arch/x86_64/src/common/x86_64_exit.c
@@ -60,8 +60,6 @@ void up_exit(int status)
 
   enter_critical_section();
 
-  sinfo("TCB=%p exiting\n", this_task());
-
   nxsched_dumponexit();
 
   /* Destroy the task at the head of the ready to run list. */

--- a/arch/xtensa/src/common/xtensa_exit.c
+++ b/arch/xtensa/src/common/xtensa_exit.c
@@ -62,8 +62,6 @@ void up_exit(int status)
 
   enter_critical_section();
 
-  sinfo("TCB=%p exiting\n", tcb);
-
   nxsched_dumponexit();
 
   /* Destroy the task at the head of the ready to run list. */

--- a/arch/z16/src/common/z16_exit.c
+++ b/arch/z16/src/common/z16_exit.c
@@ -60,8 +60,6 @@ void up_exit(int status)
 
   enter_critical_section();
 
-  sinfo("TCB=%p exiting\n", tcb);
-
   nxsched_dumponexit();
 
   /* Destroy the task at the head of the ready to run list. */

--- a/arch/z80/src/common/z80_exit.c
+++ b/arch/z80/src/common/z80_exit.c
@@ -62,8 +62,6 @@ void up_exit(int status)
 
   enter_critical_section();
 
-  sinfo("TCB=%p exiting\n", tcb);
-
   nxsched_dumponexit();
 
   /* Destroy the task at the head of the ready to run list. */


### PR DESCRIPTION
## Summary

the log duplciates with the one in `sched/task_exit.c`

## Impact

debugging logs

## Testing

checked on rv-virt/nsh
