### PR TITLE
risc-v/cmake: set llvm cputype only for LLVM based toolchain

### DIFF
--- a/arch/risc-v/src/cmake/Toolchain.cmake
+++ b/arch/risc-v/src/cmake/Toolchain.cmake
@@ -184,24 +184,52 @@ if(${CONFIG_RISCV_TOOLCHAIN} STREQUAL GNU_RVG)
     set(ARCHRVISAZ "_zicsr_zifencei")
   endif()
 
+  set(ARCHCPUEXTFLAGS i)
+
   if(CONFIG_ARCH_RV_ISA_M)
-    set(ARCHRVISAM m)
+    set(ARCHCPUEXTFLAGS ${ARCHCPUEXTFLAGS}m)
   endif()
 
   if(CONFIG_ARCH_RV_ISA_A)
-    set(ARCHRVISAA a)
-  endif()
-
-  if(CONFIG_ARCH_RV_ISA_C)
-    set(ARCHRVISAC c)
+    set(ARCHCPUEXTFLAGS ${ARCHCPUEXTFLAGS}a)
   endif()
 
   if(CONFIG_ARCH_FPU)
-    set(ARCHRVISAF f)
+    set(ARCHCPUEXTFLAGS ${ARCHCPUEXTFLAGS}f)
   endif()
 
   if(CONFIG_ARCH_DPFPU)
-    set(ARCHRVISAD d)
+    set(ARCHCPUEXTFLAGS ${ARCHCPUEXTFLAGS}d)
+  endif()
+
+  if(CONFIG_ARCH_QPFPU)
+    set(ARCHCPUEXTFLAGS ${ARCHCPUEXTFLAGS}q)
+  endif()
+
+  if(CONFIG_ARCH_RV_ISA_C)
+    set(ARCHCPUEXTFLAGS ${ARCHCPUEXTFLAGS}c)
+  endif()
+
+  if(CONFIG_ARCH_RV_ISA_V)
+    set(ARCHCPUEXTFLAGS ${ARCHCPUEXTFLAGS}v)
+  endif()
+
+  if(CONFIG_ARCH_RV_ISA_ZICSR_ZIFENCEI)
+    if(NOT DEFINED GCCVER)
+      execute_process(COMMAND ${CMAKE_CXX_COMPILER} --version
+                      OUTPUT_VARIABLE GCC_VERSION_OUTPUT)
+      string(REGEX MATCH "\\+\\+.* ([0-9]+)\\.[0-9]+" GCC_VERSION_REGEX
+                   "${GCC_VERSION_OUTPUT}")
+      set(GCCVER ${CMAKE_MATCH_1})
+    endif()
+    if(GCCVER GREATER_EQUAL 12)
+      set(ARCHCPUEXTFLAGS ${ARCHCPUEXTFLAGS}_zicsr_zifencei)
+    endif()
+  endif()
+
+  if(CONFIG_ARCH_RV_ISA_VENDOR_EXTENSIONS)
+    set(ARCHCPUEXTFLAGS
+        ${ARCHCPUEXTFLAGS}_${CONFIG_ARCH_RV_ISA_VENDOR_EXTENSIONS})
   endif()
 
   # Detect abi type
@@ -218,9 +246,6 @@ if(${CONFIG_RISCV_TOOLCHAIN} STREQUAL GNU_RVG)
 
   # Construct arch flags
 
-  set(ARCHCPUEXTFLAGS
-      i${ARCHRVISAM}${ARCHRVISAA}${ARCHRVISAF}${ARCHRVISAD}${ARCHRVISAC}${ARCHRVISAZ}
-  )
   set(ARCHCPUFLAGS -march=${ARCHTYPE}${ARCHCPUEXTFLAGS})
 
   # Construct arch abi flags

--- a/arch/risc-v/src/cmake/Toolchain.cmake
+++ b/arch/risc-v/src/cmake/Toolchain.cmake
@@ -145,7 +145,7 @@ if(CONFIG_DEBUG_OPT_UNUSED_SECTIONS)
   add_compile_options(-ffunction-sections -fdata-sections)
 endif()
 
-add_link_options(-Wl,-nostdlib)
+add_link_options(-nostdlib)
 add_link_options(-Wl,--entry=__start)
 
 if(CONFIG_DEBUG_LINK_MAP)


### PR DESCRIPTION
## Summary

1. risc-v/cmake: set llvm cputype only for LLVM based toolchain

```
remove LLVM_CPUTYPE from compile line

set llvm cputype only for LLVM based toolchain to avoid build break:

riscv64-unknown-elf-gcc: error: unrecognized command-line option '-mcpu=sifive-u54'
```

2. risc-v/cmake: configurable vendor ISA extensions

```
merge below commit into cmake:

1. risc-v/toolchain: configurable vendor ISA extensions

This option allows the platform to enable some vendor-customized ISA extensions,
E.g OpenHW, SiFive, T-Head.

SiFive Intelligence Extensions:
    SiFive Vector Coprocessor Interface(VCIX): xsfvcp
    SiFive FP32-to-int8 Ranged Clip Instructions: Xsfvfnrclipxfqf
    SiFive Matrix Multiply Accumulate Instructions: Xsfvfwmaccqqq
    SiFive Int8 Matrix Multiplication Instructions: XSFvqmaccqoq
Command Line:
    xsfvcp0p1_xsfvfnrclipxfqf0p1_xsfvfwmaccqqq0p1_xsfvqmaccqoq0p1

2. "V" Standard Extension for Vector Operations
3. "Q" Standard Extension for Quad-Precision Floating-Point
```


## Impact

N/A

## Testing

ci-check
