### PR TITLE
xtensa/esp32s3: Fix USB pull-up and pull-down issue

### DIFF
--- a/arch/xtensa/src/esp32s3/esp32s3_otg_device.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_otg_device.c
@@ -5063,14 +5063,22 @@ static int esp32s3_pullup(struct usbdev_s *dev, bool enable)
   usbtrace(TRACE_DEVPULLUP, (uint16_t)enable);
 
   irqstate_t flags = enter_critical_section();
-  regval = esp32s3_getreg(ESP32S3_OTG_DCTL);
   if (enable)
     {
       /* Connect the device by clearing the soft disconnect bit in the DCTL
        * register.
        */
 
+      regval = esp32s3_getreg(ESP32S3_OTG_DCTL);
       regval &= ~OTG_DCTL_SDIS;
+      esp32s3_putreg(regval, ESP32S3_OTG_DCTL);
+
+      /* Set DP pull-up */
+
+      regval  = esp32s3_getreg(USB_WRAP_OTG_CONF_REG);
+      regval &= ~USB_WRAP_DP_PULLDOWN;
+      regval |= USB_WRAP_DP_PULLUP;
+      esp32s3_putreg(regval, USB_WRAP_OTG_CONF_REG);
     }
   else
     {
@@ -5078,10 +5086,18 @@ static int esp32s3_pullup(struct usbdev_s *dev, bool enable)
        * register.
        */
 
+      regval = esp32s3_getreg(ESP32S3_OTG_DCTL);
       regval |= OTG_DCTL_SDIS;
+      esp32s3_putreg(regval, ESP32S3_OTG_DCTL);
+
+      /* Set DP pull-down */
+
+      regval  = esp32s3_getreg(USB_WRAP_OTG_CONF_REG);
+      regval &= ~USB_WRAP_DP_PULLUP;
+      regval |= USB_WRAP_DP_PULLDOWN;
+      esp32s3_putreg(regval, USB_WRAP_OTG_CONF_REG);
     }
 
-  esp32s3_putreg(regval, ESP32S3_OTG_DCTL);
   leave_critical_section(flags);
   return OK;
 }
@@ -5297,11 +5313,12 @@ static void esp32s3_hwinitialize(struct esp32s3_usbdev_s *priv)
   regval |= RTC_CNTL_SW_HW_USB_PHY_SEL | RTC_CNTL_SW_USB_PHY_SEL;
   esp32s3_putreg(regval, RTC_CNTL_RTC_USB_CONF_REG);
 
+  /* Set USB DM and DP pin pull-down */
+
   regval  = esp32s3_getreg(USB_WRAP_OTG_CONF_REG);
-  regval &= ~(USB_WRAP_PHY_SEL | USB_WRAP_DM_PULLUP |
-              USB_WRAP_DP_PULLDOWN | USB_WRAP_DM_PULLDOWN);
-  regval |= USB_WRAP_PAD_PULL_OVERRIDE | USB_WRAP_DP_PULLUP |
-            USB_WRAP_USB_PAD_ENABLE;
+  regval &= ~(USB_WRAP_PHY_SEL | USB_WRAP_DP_PULLUP | USB_WRAP_DM_PULLUP);
+  regval |= USB_WRAP_PAD_PULL_OVERRIDE | USB_WRAP_DP_PULLDOWN |
+            USB_WRAP_DM_PULLDOWN | USB_WRAP_USB_PAD_ENABLE;
   esp32s3_putreg(regval, USB_WRAP_OTG_CONF_REG);
 
   /* At start-up the core is in FS mode. */


### PR DESCRIPTION
## Summary

ESP32-S3 USB OTG device can't call function esp32s3_pullup to notify USB host that it connects or disconnects.

## Impact

## Testing

