### PR TITLE
arm: sama5: sam_ehci: fix transfer cancellation process.

### DIFF
--- a/arch/arm/src/sama5/sam_ehci.c
+++ b/arch/arm/src/sama5/sam_ehci.c
@@ -2719,7 +2719,7 @@ static int sam_qh_cancel(struct sam_qh_s *qh, uint32_t **bp, void *arg)
 
   /* Check if this is the QH that we are looking for */
 
-  if (qh->epinfo == epinfo)
+  if (qh->epinfo != epinfo)
     {
       /* No... keep looking */
 
@@ -4441,7 +4441,7 @@ static int sam_cancel(struct usbhost_driver_s *drvr, usbhost_ep_t ep)
            * head.
            */
 
-          if (qh && qh != &g_asynchead)
+          if (qh && qh == &g_asynchead)
             {
               /* Claim that we successfully cancelled the transfer */
 


### PR DESCRIPTION
## Summary

The logic of the conditional expression that determines whether the QH is a target QH or not is reversed in the process of canceling a transfer in INPROGRESS state.

Therefore, the QH in INPROGRESS state is not released and subsequent communication is not successful.

## Impact

## Testing

Checked with CDC-ACM driver and cu command.

