### PR TITLE
esp32s3/spi-dma: Fix spi dma transfer.

### DIFF
--- a/arch/xtensa/include/esp32s3/irq.h
+++ b/arch/xtensa/include/esp32s3/irq.h
@@ -137,17 +137,19 @@
 #define ESP32S3_PERIPH_DCACHE_SYNC                         63
 #define ESP32S3_PERIPH_ICACHE_SYNC                         64
 #define ESP32S3_PERIPH_APB_ADC                             65
+
 #define ESP32S3_PERIPH_DMA_IN_CH0                          66
 #define ESP32S3_PERIPH_DMA_IN_CH1                          67
 #define ESP32S3_PERIPH_DMA_IN_CH2                          68
 #define ESP32S3_PERIPH_DMA_IN_CH3                          69
-
 #define ESP32S3_PERIPH_DMA_IN_CH4                          70
+
 #define ESP32S3_PERIPH_DMA_OUT_CH0                         71
 #define ESP32S3_PERIPH_DMA_OUT_CH1                         72
 #define ESP32S3_PERIPH_DMA_OUT_CH2                         73
 #define ESP32S3_PERIPH_DMA_OUT_CH3                         74
 #define ESP32S3_PERIPH_DMA_OUT_CH4                         75
+
 #define ESP32S3_PERIPH_RSA                                 76
 #define ESP32S3_PERIPH_AES                                 77
 #define ESP32S3_PERIPH_SHA                                 78

--- a/arch/xtensa/src/esp32s3/esp32s3_dma.h
+++ b/arch/xtensa/src/esp32s3/esp32s3_dma.h
@@ -64,7 +64,7 @@ extern "C"
 
 /* DMA channel number */
 
-#define ESP32S3_DMA_CHAN_MAX          (3)
+#define ESP32S3_DMA_CHAN_MAX          (5)
 
 /* DMA RX MAX priority */
 


### PR DESCRIPTION
## Summary
Fix esp32s3 spi dma transfer.

## Impact
Fix esp32s3 spi dma transfer only transmit first byte and receive empty problem.

## Testing
Base config: esp32s3-devkit:spi  
Changes: 
```
CONFIG_DEBUG_FEATURES=y
CONFIG_DEBUG_SPI=y
CONFIG_DEBUG_SPI_ERROR=y
CONFIG_DEBUG_SPI_INFO=y
CONFIG_DEBUG_SPI_WARN=y
CONFIG_ESP32S3_SPI2_CLKPIN=2
CONFIG_ESP32S3_SPI2_CSPIN=1
CONFIG_ESP32S3_SPI2_MISOPIN=41
CONFIG_ESP32S3_SPI2_MOSIPIN=42
CONFIG_ESP32S3_SPI3_CLKPIN=13
CONFIG_ESP32S3_SPI3_CSPIN=11
CONFIG_ESP32S3_SPI3_MISOPIN=12
CONFIG_ESP32S3_SPI3_MOSIPIN=14
CONFIG_ESP32S3_SPI_DMA=y
CONFIG_ESP32S3_SPI_DMATHRESHOLD=4
```

defconfig after edit : 
``` 
#
# This file is autogenerated: PLEASE DO NOT EDIT IT.
#
# You can use "make menuconfig" to make any modifications to the installed .config file.
# You can then do "make savedefconfig" to generate a new defconfig file that includes your
# modifications.
#
# CONFIG_ARCH_LEDS is not set
# CONFIG_NSH_ARGCAT is not set
# CONFIG_NSH_CMDOPT_HEXDUMP is not set
CONFIG_ARCH="xtensa"
CONFIG_ARCH_BOARD="esp32s3-devkit"
CONFIG_ARCH_BOARD_COMMON=y
CONFIG_ARCH_BOARD_ESP32S3_DEVKIT=y
CONFIG_ARCH_CHIP="esp32s3"
CONFIG_ARCH_CHIP_ESP32S3=y
CONFIG_ARCH_CHIP_ESP32S3WROOM1=y
CONFIG_ARCH_INTERRUPTSTACK=2048
CONFIG_ARCH_STACKDUMP=y
CONFIG_ARCH_XTENSA=y
CONFIG_BOARD_LOOPSPERMSEC=16717
CONFIG_BUILTIN=y
CONFIG_DEBUG_FEATURES=y
CONFIG_DEBUG_SPI=y
CONFIG_DEBUG_SPI_ERROR=y
CONFIG_DEBUG_SPI_INFO=y
CONFIG_DEBUG_SPI_WARN=y
CONFIG_ESP32S3_SPI2=y
CONFIG_ESP32S3_SPI2_CLKPIN=2
CONFIG_ESP32S3_SPI2_CSPIN=1
CONFIG_ESP32S3_SPI2_MISOPIN=41
CONFIG_ESP32S3_SPI2_MOSIPIN=42
CONFIG_ESP32S3_SPI3=y
CONFIG_ESP32S3_SPI3_CLKPIN=13
CONFIG_ESP32S3_SPI3_CSPIN=11
CONFIG_ESP32S3_SPI3_MISOPIN=12
CONFIG_ESP32S3_SPI3_MOSIPIN=14
CONFIG_ESP32S3_SPI_DMA=y
CONFIG_ESP32S3_SPI_DMATHRESHOLD=4
CONFIG_ESP32S3_UART0=y
CONFIG_FS_PROCFS=y
CONFIG_HAVE_CXX=y
CONFIG_HAVE_CXXINITIALIZE=y
CONFIG_IDLETHREAD_STACKSIZE=3072
CONFIG_INIT_ENTRYPOINT="nsh_main"
CONFIG_INTELHEX_BINARY=y
CONFIG_NSH_ARCHINIT=y
CONFIG_NSH_BUILTIN_APPS=y
CONFIG_NSH_FILEIOSIZE=512
CONFIG_NSH_LINELEN=64
CONFIG_NSH_READLINE=y
CONFIG_PREALLOC_TIMERS=4
CONFIG_RAM_SIZE=114688
CONFIG_RAM_START=0x20000000
CONFIG_RR_INTERVAL=200
CONFIG_SCHED_WAITPID=y
CONFIG_SPITOOL_MINBUS=2
CONFIG_START_DAY=6
CONFIG_START_MONTH=12
CONFIG_START_YEAR=2011
CONFIG_SYSLOG_BUFFER=y
CONFIG_SYSTEM_NSH=y
CONFIG_SYSTEM_SPITOOL=y
CONFIG_UART0_SERIAL_CONSOLE=y
``` 
### Test in cli: 
1. On spi 2, use poll method to read icm-20602 chip id.
![icm20602-poll-cli](https://github.com/apache/nuttx/assets/40821031/db7b7452-3242-497a-836d-252c53fc3590)
On hardware:
![icm20602-poll](https://github.com/apache/nuttx/assets/40821031/d645d6ce-a65c-4828-85cd-ee9e14b9511c)

2. On spi 2, use dma method to read icm-20602 chip id.
![icm20602-dma-cli](https://github.com/apache/nuttx/assets/40821031/00c36601-7690-4c3a-8719-cda100648f7c)
On hardware:
![icm20602-dma](https://github.com/apache/nuttx/assets/40821031/efb1983d-92be-4a29-94ef-6e867dd711f6)

3. On spi 3, use poll to read FM25V05 chip id:
![fm25-poll-cli](https://github.com/apache/nuttx/assets/40821031/9953ca3f-b51a-4372-ada6-8ed48aaa49ff)
On hardware:
![fm25-poll](https://github.com/apache/nuttx/assets/40821031/72c1f2d3-d078-47e1-b82f-e86e29606a3a)

4. On spi 3, use dma to read FM25V05 chip id:
![fm25-dma-cli](https://github.com/apache/nuttx/assets/40821031/23d3a751-da99-48a4-9334-dff01afd39a7)
On hardware: 
![fm25-dma](https://github.com/apache/nuttx/assets/40821031/c86cb632-e1e5-4667-b094-e736fa51abc4)

