### PR TITLE
risc-v/cmake: add support for Ubuntu stock toolchain

### DIFF
--- a/arch/risc-v/src/cmake/Toolchain.cmake
+++ b/arch/risc-v/src/cmake/Toolchain.cmake
@@ -271,21 +271,21 @@ if(${CONFIG_RISCV_TOOLCHAIN} STREQUAL GNU_RVG)
   # These models can't cover all implementation of RISCV, but it's enough for
   # most cases.
 
-  set(PLATFORM_FLAGS)
+  set(LLVM_CPUFLAGS)
 
   if(CONFIG_ARCH_RV32)
     if(${ARCHCPUEXTFLAGS} STREQUAL imc)
-      list(APPEND PLATFORM_FLAGS -mcpu=sifive-e20)
+      list(APPEND LLVM_CPUFLAGS -mcpu=sifive-e20)
     elseif(${ARCHCPUEXTFLAGS} STREQUAL imac)
-      list(APPEND PLATFORM_FLAGS -mcpu=sifive-e31)
+      list(APPEND LLVM_CPUFLAGS -mcpu=sifive-e31)
     elseif(${ARCHCPUEXTFLAGS} STREQUAL imafc)
-      list(APPEND PLATFORM_FLAGS -mcpu=sifive-e76)
+      list(APPEND LLVM_CPUFLAGS -mcpu=sifive-e76)
     endif()
   else()
     if(${ARCHCPUEXTFLAGS} STREQUAL imac)
-      list(APPEND PLATFORM_FLAGS -mcpu=sifive-s51)
+      list(APPEND LLVM_CPUFLAGS -mcpu=sifive-s51)
     elseif(${ARCHCPUEXTFLAGS} STREQUAL imafdc)
-      list(APPEND PLATFORM_FLAGS -mcpu=sifive-u54)
+      list(APPEND LLVM_CPUFLAGS -mcpu=sifive-u54)
     endif()
   endif()
 

--- a/arch/risc-v/src/cmake/platform.cmake
+++ b/arch/risc-v/src/cmake/platform.cmake
@@ -21,8 +21,10 @@
 get_directory_property(NUTTX_EXTRA_FLAGS DIRECTORY ${CMAKE_SOURCE_DIR}
                                                    COMPILE_OPTIONS)
 
+separate_arguments(LIBPRT_CFLAGS NATIVE_COMMAND ${CMAKE_C_FLAGS})
+
 execute_process(
-  COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS} ${NUTTX_EXTRA_FLAGS}
+  COMMAND ${CMAKE_C_COMPILER} ${LIBPRT_CFLAGS} ${NUTTX_EXTRA_FLAGS}
           --print-libgcc-file-name
   OUTPUT_STRIP_TRAILING_WHITESPACE
   OUTPUT_VARIABLE extra_library)
@@ -31,7 +33,7 @@ list(APPEND EXTRA_LIB ${extra_library})
 
 if(NOT CONFIG_LIBM)
   execute_process(
-    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS} ${NUTTX_EXTRA_FLAGS}
+    COMMAND ${CMAKE_C_COMPILER} ${LIBPRT_CFLAGS} ${NUTTX_EXTRA_FLAGS}
             --print-file-name=libm.a
     OUTPUT_STRIP_TRAILING_WHITESPACE
     OUTPUT_VARIABLE extra_library)
@@ -40,7 +42,7 @@ endif()
 
 if(CONFIG_LIBSUPCXX)
   execute_process(
-    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS} ${NUTTX_EXTRA_FLAGS}
+    COMMAND ${CMAKE_C_COMPILER} ${LIBPRT_CFLAGS} ${NUTTX_EXTRA_FLAGS}
             --print-file-name=libsupc++.a
     OUTPUT_STRIP_TRAILING_WHITESPACE
     OUTPUT_VARIABLE extra_library)
@@ -49,7 +51,7 @@ endif()
 
 if(CONFIG_ARCH_COVERAGE)
   execute_process(
-    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS} ${NUTTX_EXTRA_FLAGS}
+    COMMAND ${CMAKE_C_COMPILER} ${LIBPRT_CFLAGS} ${NUTTX_EXTRA_FLAGS}
             --print-file-name=libgcov.a
     OUTPUT_STRIP_TRAILING_WHITESPACE
     OUTPUT_VARIABLE extra_library)


### PR DESCRIPTION
## Summary

Ubuntu stock toolchain complains about current CMake scripts.  This patch revises risc-v/cmake logic so that users of stock toolchain users can enjoy CMake system.

The change doesn't affect XPack toolchain uses and can fix issue #11573

## Impact

risc-v cmake toolchain users

## Testing

checked with `rv-virt/nsh(64` for both XPack and stock toolchain.



