### PR TITLE
rpmsgfs: decoupling rpmsgfs server and rpmsg virtio.

### DIFF
--- a/drivers/rpmsg/rpmsg.c
+++ b/drivers/rpmsg/rpmsg.c
@@ -126,6 +126,30 @@ FAR const char *rpmsg_get_cpuname(FAR struct rpmsg_device *rdev)
   return rpmsg->ops->get_cpuname(rpmsg);
 }
 
+int rpmsg_get_tx_buffer_size(FAR struct rpmsg_device *rdev)
+{
+  FAR struct rpmsg_s *rpmsg = rpmsg_get_by_rdev(rdev);
+
+  if (!rpmsg)
+    {
+      return -EINVAL;
+    }
+
+  return rpmsg->ops->get_tx_buffer_size(rpmsg);
+}
+
+int rpmsg_get_rx_buffer_size(FAR struct rpmsg_device *rdev)
+{
+  FAR struct rpmsg_s *rpmsg = rpmsg_get_by_rdev(rdev);
+
+  if (!rpmsg)
+    {
+      return -EINVAL;
+    }
+
+  return rpmsg->ops->get_rx_buffer_size(rpmsg);
+}
+
 int rpmsg_register_callback(FAR void *priv,
                             rpmsg_dev_cb_t device_created,
                             rpmsg_dev_cb_t device_destroy,

--- a/drivers/rptun/rptun.c
+++ b/drivers/rptun/rptun.c
@@ -131,9 +131,11 @@ static metal_phys_addr_t rptun_pa_to_da(FAR struct rptun_dev_s *dev,
 static metal_phys_addr_t rptun_da_to_pa(FAR struct rptun_dev_s *dev,
                                         metal_phys_addr_t da);
 
-static FAR const char *rptun_get_cpuname(FAR struct rpmsg_s *rpmsg);
 static int rptun_wait(FAR struct rpmsg_s *rpmsg, FAR sem_t *sem);
 static int rptun_post(FAR struct rpmsg_s *rpmsg, FAR sem_t *sem);
+static FAR const char *rptun_get_cpuname(FAR struct rpmsg_s *rpmsg);
+static int rptun_get_tx_buffer_size(FAR struct rpmsg_s *rpmsg);
+static int rptun_get_rx_buffer_size(FAR struct rpmsg_s *rpmsg);
 
 /****************************************************************************
  * Private Data
@@ -173,9 +175,11 @@ static const struct image_store_ops g_rptun_store_ops =
 
 static const struct rpmsg_ops_s g_rptun_rpmsg_ops =
 {
-  rptun_get_cpuname,
   rptun_wait,
   rptun_post,
+  rptun_get_cpuname,
+  rptun_get_tx_buffer_size,
+  rptun_get_rx_buffer_size,
 };
 
 /****************************************************************************
@@ -424,13 +428,6 @@ static int rptun_notify_wait(FAR struct remoteproc *rproc, uint32_t id)
   return 0;
 }
 
-static FAR const char *rptun_get_cpuname(FAR struct rpmsg_s *rpmsg)
-{
-  FAR struct rptun_priv_s *priv = (FAR struct rptun_priv_s *)rpmsg;
-
-  return RPTUN_GET_CPUNAME(priv->dev);
-}
-
 static int rptun_wait(FAR struct rpmsg_s *rpmsg, FAR sem_t *sem)
 {
   FAR struct rptun_priv_s *priv = (FAR struct rptun_priv_s *)rpmsg;
@@ -471,6 +468,23 @@ static int rptun_post(FAR struct rpmsg_s *rpmsg, FAR sem_t *sem)
     }
 
   return ret;
+}
+
+static FAR const char *rptun_get_cpuname(FAR struct rpmsg_s *rpmsg)
+{
+  FAR struct rptun_priv_s *priv = (FAR struct rptun_priv_s *)rpmsg;
+
+  return RPTUN_GET_CPUNAME(priv->dev);
+}
+
+static int rptun_get_tx_buffer_size(FAR struct rpmsg_s *rpmsg)
+{
+  return rpmsg_virtio_get_buffer_size(rpmsg->rdev);
+}
+
+static int rptun_get_rx_buffer_size(FAR struct rpmsg_s *rpmsg)
+{
+  return rpmsg_virtio_get_rx_buffer_size(rpmsg->rdev);
 }
 
 static int rptun_dev_start(FAR struct remoteproc *rproc)

--- a/fs/rpmsgfs/rpmsgfs_server.c
+++ b/fs/rpmsgfs/rpmsgfs_server.c
@@ -35,7 +35,6 @@
 #include <nuttx/mutex.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/rptun/openamp.h>
-#include <openamp/rpmsg_virtio.h>
 
 #include "rpmsgfs.h"
 
@@ -627,8 +626,8 @@ static int rpmsgfs_readdir_handler(FAR struct rpmsg_endpoint *ept,
       entry = readdir(dir);
       if (entry)
         {
-          size = MIN(rpmsg_virtio_get_buffer_size(ept->rdev),
-                     rpmsg_virtio_get_rx_buffer_size(ept->rdev));
+          size = MIN(rpmsg_get_tx_buffer_size(ept->rdev),
+                     rpmsg_get_rx_buffer_size(ept->rdev));
           size = MIN(size - len, strlen(entry->d_name) + 1);
           msg->type = entry->d_type;
           strlcpy(msg->name, entry->d_name, size);

--- a/include/nuttx/rpmsg/rpmsg.h
+++ b/include/nuttx/rpmsg/rpmsg.h
@@ -49,16 +49,20 @@ typedef CODE int (*rpmsg_foreach_t)(FAR struct rpmsg_s *rpmsg,
 
 /**
  * struct rpmsg_ops_s - Rpmsg device operations
- * get_cpuname: get cpu name.
  * wait: wait sem.
  * post: post sem.
+ * get_cpuname: get cpu name.
+ * get_tx_buffer_size: get tx buffer size.
+ * get_rx_buffer_size: get rx buffer size.
  */
 
 struct rpmsg_ops_s
 {
-  CODE FAR const char *(*get_cpuname)(FAR struct rpmsg_s *rpmsg);
   CODE int (*wait)(FAR struct rpmsg_s *rpmsg, FAR sem_t *sem);
   CODE int (*post)(FAR struct rpmsg_s *rpmsg, FAR sem_t *sem);
+  CODE FAR const char *(*get_cpuname)(FAR struct rpmsg_s *rpmsg);
+  CODE int (*get_tx_buffer_size)(FAR struct rpmsg_s *rpmsg);
+  CODE int (*get_rx_buffer_size)(FAR struct rpmsg_s *rpmsg);
 };
 
 CODE typedef void (*rpmsg_dev_cb_t)(FAR struct rpmsg_device *rdev,
@@ -86,6 +90,9 @@ int rpmsg_wait(FAR struct rpmsg_endpoint *ept, FAR sem_t *sem);
 int rpmsg_post(FAR struct rpmsg_endpoint *ept, FAR sem_t *sem);
 
 FAR const char *rpmsg_get_cpuname(FAR struct rpmsg_device *rdev);
+
+int rpmsg_get_tx_buffer_size(FAR struct rpmsg_device *rdev);
+int rpmsg_get_rx_buffer_size(FAR struct rpmsg_device *rdev);
 
 int rpmsg_register_callback(FAR void *priv,
                             rpmsg_dev_cb_t device_created,


### PR DESCRIPTION

## Summary
rpmsgfs: decoupling rpmsgfs server and rpmsg virtio.
## Impact
create a new general api to make rpmsgfs work with virtio/spi/uart transport.
## Testing
tested in sim vela and 86panel.

