### PR TITLE
bcmf_driver:wlan interface status reset by unsolicited wpa packet

### DIFF
--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c
@@ -632,7 +632,7 @@ void bcmf_wl_auth_event_handler(FAR struct bcmf_dev_s *priv,
 
   if (type == WLC_E_PSK_SUP)
     {
-      carrier = (reason == WLC_E_SUP_OTHER) ? 1 : 0;
+      carrier = ((reason == WLC_E_SUP_OTHER) || (reason == 0)) ? 1 : 0;
       if (priv->auth_pending)
         {
           priv->auth_status = reason;


### PR DESCRIPTION
## Summary
Avoid incorrect NIC flag Settings

## Impact

## Testing
Cortex-M33 and bcm43xxx Wi-Fi chip
