### PR TITLE
mpfs_corespi: Fix firing of stale interrupt after warm reset

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_corespi.c
+++ b/arch/risc-v/src/mpfs/mpfs_corespi.c
@@ -1435,6 +1435,22 @@ static void mpfs_spi_init(struct spi_dev_s *dev)
   mpfs_spi_set_master_mode(priv, 1);
   mpfs_spi_enable(priv, 1);
 
+  /* Disable all interrupt sources */
+
+  modifyreg32(MPFS_SPI_CONTROL, MPFS_SPI_INTTXTURUN |
+                                MPFS_SPI_INTRXOVRFLOW |
+                                MPFS_SPI_INTTXDONE,
+                                0);
+
+  /* Clear all interrupt sources */
+
+  putreg32(MPFS_SPI_TXCHUNDRUN |
+           MPFS_SPI_RXCHOVRFLW |
+           MPFS_SPI_DATA_RX |
+           MPFS_SPI_TXDONE, MPFS_SPI_INT_CLEAR);
+
+  /* Then enable the interrupt */
+
   up_enable_irq(priv->plic_irq);
 }
 


### PR DESCRIPTION
## Summary
After warm reset the interrupt source in the HW block is not explicitly cleared, thus once the interrupt source is enabled the old / stale interrupt fires immediately.

This causes a DEBUGASSERT() failure on line 808 mpfs_spi_unload_rx_fifo:
  DEBUGASSERT(nwords > 0);
## Impact
Fix minor bug, MPFS only
## Testing
MPFS
