### PR TITLE
samv7: fix QSPI DMA option not showing in menuconfig

### DIFF
--- a/arch/arm/src/samv7/Kconfig
+++ b/arch/arm/src/samv7/Kconfig
@@ -1873,7 +1873,7 @@ config SAMV7_SPI_REGDEBUG
 endmenu # SPI device driver options
 
 menu "QSPI Device Driver Configuration"
-	depends on SAMV7_QSPI && !SAMV7_QSPI_IS_SPI
+	depends on SAMV7_QSPI && !SAMV7_QSPI_SPI_MODE
 
 config SAMV7_QSPI_DLYBS
 	int "Delay Before QSCK (nsec)"


### PR DESCRIPTION
## Summary
Commit 03e5c02 introduced option to have both standard SPI and QSPI in SPI mode on one system. However this change broke the appearance of QSPI driver configuration menu entry in menuconfig as it was dependent on `!SAMV7_QSPI_IS_SPI` (which is now true for all MCUs having standard SPI ability in QSPI driver).

This change makes sure the menu is correctly shown when QSPI driver used.

## Impact
Just menuconfig

## Testing
Menuconfig now shows the menu when it should. 

