### PR TITLE
risc-v/canmv230: add CMake support

### DIFF
--- a/arch/risc-v/src/k230/CMakeLists.txt
+++ b/arch/risc-v/src/k230/CMakeLists.txt
@@ -1,0 +1,42 @@
+# ##############################################################################
+# arch/risc-v/src/k230/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS k230_head.S)
+
+list(
+  APPEND
+  SRCS
+  k230_start.c
+  k230_irq_dispatch.c
+  k230_irq.c
+  k230_timerisr.c
+  k230_allocateheap.c)
+
+if(CONFIG_BUILD_KERNEL)
+  list(APPEND SRCS k230_mm_init.c)
+elseif(CONFIG_BUILD_PROTECTED)
+  list(APPEND SRCS k230_userspace.c)
+endif()
+
+if(CONFIG_MM_PGALLOC)
+  list(APPEND SRCS k230_pgalloc.c)
+endif()
+
+target_sources(arch PRIVATE ${SRCS})

--- a/boards/risc-v/k230/canmv230/CMakeLists.txt
+++ b/boards/risc-v/k230/canmv230/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/risc-v/k230/canmv230/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/risc-v/k230/canmv230/src/CMakeLists.txt
+++ b/boards/risc-v/k230/canmv230/src/CMakeLists.txt
@@ -1,0 +1,47 @@
+# ##############################################################################
+# boards/risc-v/k230/canmv230/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS canmv_init.c)
+
+if(CONFIG_BUILD_KERNEL)
+  if(EXISTS romfs_boot.c)
+    list(APPEND SRCS romfs_boot.c)
+  else()
+    list(APPEND SRCS romfs_stub.c)
+  endif()
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+if(CONFIG_ARCH_CHIP_K230)
+  if(CONFIG_BUILD_KERNEL)
+    if(CONFIG_ARCH_NUTTSBI)
+      set(LDFILE ld-nuttsbi.script)
+    else()
+      set(LDFILE ld-kernel.script)
+    endif()
+  elseif(CONFIG_BUILD_PROTECTED)
+    set(LDFILE ld-protected.script)
+  else()
+    set(LDFILE ld-flat.script)
+  endif()
+endif()
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/${LDFILE}")


### PR DESCRIPTION
## Summary

Adding CMakeLists.txt files to support CMake build system. Note that only FLAT build works now due to limitations of current CMake build system.

## Impact

None

## Testing

checked with 'canmv230/nsh`
