### PR TITLE
arch/sim: fix X11 compile failed

### DIFF
--- a/arch/sim/src/sim/CMakeLists.txt
+++ b/arch/sim/src/sim/CMakeLists.txt
@@ -166,7 +166,12 @@ endif()
 
 if(CONFIG_SIM_X11FB)
   list(APPEND HOSTSRCS sim_x11framebuffer.c)
-  list(APPEND STDLIBS X11 Xext)
+
+  find_package(X11 REQUIRED)
+  if(X11_FOUND)
+    target_include_directories(nuttx PRIVATE ${X11_INCLUDE_DIR})
+    target_link_libraries(nuttx PRIVATE ${X11_LIBRARIES})
+  endif()
 
   if(CONFIG_SIM_TOUCHSCREEN)
     list(APPEND SRCS sim_touchscreen.c)


### PR DESCRIPTION
## Summary

fix X11 compile failed with CMake

## Impact
N/A
## Testing
N/A
