### PR TITLE
arch/{nrf52|nrf53|nrf91}/tim.c: fix typo

### DIFF
--- a/arch/arm/src/nrf52/nrf52_tim.c
+++ b/arch/arm/src/nrf52/nrf52_tim.c
@@ -657,7 +657,7 @@ static int nrf52_tim_checkint(struct nrf52_tim_dev_s *dev, uint8_t s)
 
       case NRF52_TIM_INT_COMPARE1:
         {
-          ret = nrf52_tim_getreg(dev, NRF52_TIM_EVENTS_COMPARE_OFFSET(0));
+          ret = nrf52_tim_getreg(dev, NRF52_TIM_EVENTS_COMPARE_OFFSET(1));
           break;
         }
 

--- a/arch/arm/src/nrf53/nrf53_tim.c
+++ b/arch/arm/src/nrf53/nrf53_tim.c
@@ -657,7 +657,7 @@ static int nrf53_tim_checkint(struct nrf53_tim_dev_s *dev, uint8_t s)
 
       case NRF53_TIM_INT_COMPARE1:
         {
-          ret = nrf53_tim_getreg(dev, NRF53_TIM_EVENTS_COMPARE_OFFSET(0));
+          ret = nrf53_tim_getreg(dev, NRF53_TIM_EVENTS_COMPARE_OFFSET(1));
           break;
         }
 

--- a/arch/arm/src/nrf91/nrf91_tim.c
+++ b/arch/arm/src/nrf91/nrf91_tim.c
@@ -657,7 +657,7 @@ static int nrf91_tim_checkint(struct nrf91_tim_dev_s *dev, uint8_t s)
 
       case NRF91_TIM_INT_COMPARE1:
         {
-          ret = nrf91_tim_getreg(dev, NRF91_TIM_EVENTS_COMPARE_OFFSET(0));
+          ret = nrf91_tim_getreg(dev, NRF91_TIM_EVENTS_COMPARE_OFFSET(1));
           break;
         }
 


### PR DESCRIPTION
## Summary
arch/{nrf52|nrf53|nrf91}/tim.c: fix typo
fix offset for EVENT COMPARE0

## Impact

## Testing

