### PR TITLE
mrf24j40: minor fixes

### DIFF
--- a/drivers/wireless/ieee802154/mrf24j40/Kconfig
+++ b/drivers/wireless/ieee802154/mrf24j40/Kconfig
@@ -5,4 +5,10 @@
 
 if IEEE802154_MRF24J40
 
+config IEEE802154_MRF24J40_FREQUENCY
+	int "SPI Frequency for MRF24J40"
+	default 8000000
+	---help---
+		SPI SLCK frequency in Hz
+
 endif # IEEE802154_MRF24J40

--- a/drivers/wireless/ieee802154/mrf24j40/mrf24j40.h
+++ b/drivers/wireless/ieee802154/mrf24j40/mrf24j40.h
@@ -76,6 +76,8 @@
 
 #define MRF24J40_SYMBOL_DURATION_PS 16000000
 
+#define MRF24J40_SPIMODE SPIDEV_MODE0
+
 /* Clock configuration macros */
 
 #define MRF24J40_BEACONINTERVAL_NSEC(beaconorder) \
@@ -88,10 +90,6 @@
 
 #ifndef CONFIG_SCHED_HPWORK
 #  error High priority work queue required in this driver
-#endif
-
-#ifndef CONFIG_IEEE802154_MRF24J40_SPIMODE
-#  define CONFIG_IEEE802154_MRF24J40_SPIMODE SPIDEV_MODE0
 #endif
 
 #ifndef CONFIG_IEEE802154_MRF24J40_FREQUENCY
@@ -174,7 +172,7 @@ static inline void mrf24j40_spi_lock(FAR struct spi_dev_s *spi)
 {
   SPI_LOCK(spi, 1);
   SPI_SETBITS(spi, 8);
-  SPI_SETMODE(spi, CONFIG_IEEE802154_MRF24J40_SPIMODE);
+  SPI_SETMODE(spi, MRF24J40_SPIMODE);
   SPI_SETFREQUENCY(spi, CONFIG_IEEE802154_MRF24J40_FREQUENCY);
 }
 


### PR DESCRIPTION
## Summary

-  mrf24j40/Kconfig: add missing IEEE802154_MRF24J40_FREQUENCY option

-  mrf24j40: always use SPI MODE(0,0)
   
    Other SPI modes are not supported. From doc:
    
      "The MRF24J40 supports SPI (mode 0,0) which requires
      that SCK idles in a low state."

## Impact

## Testing

