### PR TITLE
compiler/tasking: fix unreachable code on tasking toolchain

### DIFF
--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -181,7 +181,7 @@ static int uart_putxmitchar(FAR uart_dev_t *dev, int ch, bool oktoblock)
 
           dev->xmit.buffer[dev->xmit.head] = ch;
           dev->xmit.head = nexthead;
-          return OK;
+          break;
         }
 
       /* The TX buffer is full.  Should be block, waiting for the hardware

--- a/fs/vfs/fs_lseek.c
+++ b/fs/vfs/fs_lseek.c
@@ -84,15 +84,13 @@ off_t file_seek(FAR struct file *filep, off_t offset, int whence)
             /* FALLTHROUGH */
 
           case SEEK_SET:
-            if (offset >= 0)
-              {
-                filep->f_pos = offset; /* Might be beyond the end-of-file */
-                break;
-              }
-            else
+            if (offset < 0)
               {
                 return -EINVAL;
               }
+
+            filep->f_pos = offset; /* Might be beyond the end-of-file */
+
             break;
 
           case SEEK_END:

--- a/libs/libc/stdio/lib_fopen.c
+++ b/libs/libc/stdio/lib_fopen.c
@@ -324,7 +324,6 @@ int lib_mode2oflags(FAR const char *mode)
 
                 default:
                   goto errout;
-                  break;
               }
             break;
 
@@ -401,7 +400,6 @@ int lib_mode2oflags(FAR const char *mode)
 
           default:
             goto errout;
-            break;
         }
     }
 

--- a/libs/libc/string/lib_strcasestr.c
+++ b/libs/libc/string/lib_strcasestr.c
@@ -92,7 +92,7 @@ FAR char *strcasestr(FAR const char *str, FAR const char *substr)
            * substring.
            */
 
-          return NULL;
+          break;
         }
 
       /* Check if this is the beginning of a matching substring

--- a/libs/libc/unistd/lib_getopt_common.c
+++ b/libs/libc/unistd/lib_getopt_common.c
@@ -153,7 +153,6 @@ static int getopt_long_option(FAR struct getopt_s *go,
 
                   default:
                     goto errout;
-                    break;
                 }
             }
           else
@@ -213,7 +212,6 @@ static int getopt_long_option(FAR struct getopt_s *go,
 
                   default:
                     goto errout;
-                    break;
                 }
             }
 

--- a/libs/libc/wctype/lib_iswctype.c
+++ b/libs/libc/wctype/lib_iswctype.c
@@ -147,7 +147,7 @@ int iswctype(wint_t c, wctype_t desc)
       return iswxdigit(c);
 
     default:
-      return 0;                 /* eliminate warning */
+      break;                 /* eliminate warning */
     }
 
   /* Otherwise unknown */


### PR DESCRIPTION
## Summary

compiler/tasking: fix unreachable code on tasking toolchain

```
ctc W544: ["serial/serial.c" 284/3] unreachable code
ctc W544: ["vfs/fs_lseek.c" 96/13] unreachable code
ctc W544: ["wqueue/kwork_thread.c" 210/32] unreachable code
ctc W544: ["stdio/lib_fopen.c" 327/19] unreachable code
ctc W544: ["stdio/lib_fopen.c" 404/13] unreachable code
ctc W544: ["string/lib_strcasestr.c" 120/3] unreachable code
ctc W544: ["unistd/lib_getopt_common.c" 156/21] unreachable code
ctc W544: ["unistd/lib_getopt_common.c" 216/21] unreachable code
ctc W544: ["wctype/lib_iswctype.c" 155/3] unreachable code
```

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

Tricore / Aurix Tasking TC397
