### PR TITLE
compiler/tasking: fix compiler warning on tasking

### DIFF
--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -874,10 +874,8 @@ static ssize_t uart_read(FAR struct file *filep,
                 {
                   /* Skipping character count down */
 
-                  if (dev->escape-- > 0)
-                    {
-                      continue;
-                    }
+                  dev->escape--;
+                  continue;
                 }
 
               /* Echo if the character is not a control byte */

--- a/fs/inode/fs_inodesearch.c
+++ b/fs/inode/fs_inodesearch.c
@@ -69,11 +69,6 @@ static int _inode_compare(FAR const char *fname, FAR struct inode *node)
 {
   FAR char *nname = node->i_name;
 
-  if (!nname)
-    {
-      return 1;
-    }
-
   if (!fname)
     {
       return -1;

--- a/libs/libc/obstack/lib_obstack_malloc.c
+++ b/libs/libc/obstack/lib_obstack_malloc.c
@@ -66,6 +66,7 @@ FAR void *lib_obstack_malloc(size_t size)
 
   obstack_alloc_failed_handler();
   PANIC();
+  return NULL;
 }
 
 FAR void *lib_obstack_realloc(FAR void *ptr, size_t size)
@@ -79,4 +80,5 @@ FAR void *lib_obstack_realloc(FAR void *ptr, size_t size)
 
   obstack_alloc_failed_handler();
   PANIC();
+  return NULL;
 }

--- a/mm/map/mm_map.c
+++ b/mm/map/mm_map.c
@@ -64,7 +64,15 @@ static bool in_range(FAR const void *start, size_t length,
 
 int mm_map_lock(void)
 {
-  return nxrmutex_lock(&get_current_mm()->mm_map_mutex);
+  FAR struct tcb_s *tcb = nxsched_self();
+  FAR struct task_group_s *group = tcb->group;
+
+  if (group == NULL)
+    {
+      return -EINVAL;
+    }
+
+  return nxrmutex_lock(&group->tg_mm_map.mm_map_mutex);
 }
 
 /****************************************************************************
@@ -77,7 +85,15 @@ int mm_map_lock(void)
 
 void mm_map_unlock(void)
 {
-  DEBUGVERIFY(nxrmutex_unlock(&get_current_mm()->mm_map_mutex));
+  FAR struct tcb_s *tcb = nxsched_self();
+  FAR struct task_group_s *group = tcb->group;
+
+  if (group == NULL)
+    {
+      return;
+    }
+
+  DEBUGVERIFY(nxrmutex_unlock(&group->tg_mm_map.mm_map_mutex));
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

compiler/tasking: fix compiler warning on tasking


```
ctc W549: ["serial/serial.c" 877/37] condition is always true
ctc W549: ["inode/fs_inodesearch.c" 72/8] condition is always true
ctc W545: ["obstack/lib_obstack_malloc.c" 69/1] missing 'return'
ctc W545: ["obstack/lib_obstack_malloc.c" 82/1] missing 'return'
ctc E246: ["map/mm_map.c" 67/41] left side of '.' or '->' is not struct or union
ctc E260: ["map/mm_map.c" 67/25] not an lvalue
ctc E246: ["map/mm_map.c" 80/3] left side of '.' or '->' is not struct or union
ctc E260: ["map/mm_map.c" 80/3] not an lvalue
```


## Impact

N/A

## Testing

Tricore / Aurix Tasking TC397