### PR TITLE
rptun: remove temporarily retained RPTUNIOC_xxx definitions.

### DIFF
--- a/include/nuttx/rpmsg/rpmsg_ping.h
+++ b/include/nuttx/rpmsg/rpmsg_ping.h
@@ -33,7 +33,7 @@
  * Public Function Prototypes
  ****************************************************************************/
 
-/* used for ioctl RPTUNIOC_PING */
+/* used for ioctl RPMSGIOC_PING */
 
 struct rpmsg_ping_s
 {

--- a/include/nuttx/rptun/rptun.h
+++ b/include/nuttx/rptun/rptun.h
@@ -29,7 +29,6 @@
 
 #ifdef CONFIG_RPTUN
 
-#include <nuttx/fs/ioctl.h>
 #include <nuttx/rpmsg/rpmsg.h>
 #include <openamp/remoteproc.h>
 #include <openamp/rpmsg_virtio.h>
@@ -37,13 +36,6 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
-
-#define RPTUNIOC_START              _RPMSGIOC(1)
-#define RPTUNIOC_STOP               _RPMSGIOC(2)
-#define RPTUNIOC_RESET              _RPMSGIOC(3)
-#define RPTUNIOC_PANIC              _RPMSGIOC(4)
-#define RPTUNIOC_DUMP               _RPMSGIOC(5)
-#define RPTUNIOC_PING               _RPMSGIOC(6)
 
 #define RPTUN_NOTIFY_ALL            (UINT32_MAX - 0)
 


### PR DESCRIPTION
## Summary
rptun: remove temporarily retained RPTUNIOC_xxx definitions.
## Impact
remove temporary codes to make the code more concise.
## Testing
tested in sim vela and 86 panel.
