### PR TITLE
drivers/sensor: delete warning about argument type in bmi160

### DIFF
--- a/drivers/sensors/bmi160.c
+++ b/drivers/sensors/bmi160.c
@@ -147,7 +147,7 @@ static ssize_t bmi160_read(FAR struct file *filep, FAR char *buffer,
 
   if (len < sizeof(struct accel_gyro_st_s))
     {
-      snerr("Expected buffer size is %lu\n", sizeof(struct accel_gyro_st_s));
+      snerr("Expected buffer size is %u\n", sizeof(struct accel_gyro_st_s));
       return 0;
     }
 


### PR DESCRIPTION
## Summary
Remove warning due to variable type difference in format.

## Impact
None

## Testing
Build check
