### PR TITLE
arch/risc-v/mpfs: wrapper for sdio device drivers

### DIFF
--- a/arch/risc-v/src/mpfs/Make.defs
+++ b/arch/risc-v/src/mpfs/Make.defs
@@ -58,6 +58,10 @@ ifeq ($(CONFIG_I2C),y)
 CHIP_CSRCS += mpfs_i2c.c
 endif
 
+ifneq ($(filter y,$(CONFIG_MPFS_EMMCSD) $(CONFIG_MPFS_COREMMC)),)
+CHIP_CSRCS += mpfs_sdio.c
+endif
+
 ifeq ($(CONFIG_MPFS_EMMCSD),y)
 CHIP_CSRCS += mpfs_emmcsd.c
 endif

--- a/arch/risc-v/src/mpfs/mpfs_coremmc.h
+++ b/arch/risc-v/src/mpfs/mpfs_coremmc.h
@@ -48,7 +48,7 @@ extern "C"
 #endif
 
 /****************************************************************************
- * Name: sdio_initialize
+ * Name: mpfs_coremmc_sdio_initialize
  *
  * Description:
  *   Initialize SDIO for operation.
@@ -63,10 +63,10 @@ extern "C"
  ****************************************************************************/
 
 struct sdio_dev_s; /* See include/nuttx/sdio.h */
-struct sdio_dev_s *sdio_initialize(int slotno);
+struct sdio_dev_s *mpfs_coremmc_sdio_initialize(int slotno);
 
 /****************************************************************************
- * Name: sdio_mediachange
+ * Name: mpfs_coremmc_sdio_mediachange
  *
  * Description:
  *   Called by board-specific logic -- possibly from an interrupt handler --
@@ -84,10 +84,10 @@ struct sdio_dev_s *sdio_initialize(int slotno);
  *
  ****************************************************************************/
 
-void sdio_mediachange(struct sdio_dev_s *dev, bool cardinslot);
+void mpfs_coremmc_sdio_mediachange(struct sdio_dev_s *dev, bool cardinslot);
 
 /****************************************************************************
- * Name: sdio_wrprotect
+ * Name: mpfs_coremmc_sdio_wrprotect
  *
  * Description:
  *   Called by board-specific logic to report if the card in the slot is
@@ -102,7 +102,7 @@ void sdio_mediachange(struct sdio_dev_s *dev, bool cardinslot);
  *
  ****************************************************************************/
 
-void sdio_wrprotect(struct sdio_dev_s *dev, bool wrprotect);
+void mpfs_coremmc_sdio_wrprotect(struct sdio_dev_s *dev, bool wrprotect);
 
 #undef EXTERN
 #if defined(__cplusplus)

--- a/arch/risc-v/src/mpfs/mpfs_emmcsd.c
+++ b/arch/risc-v/src/mpfs/mpfs_emmcsd.c
@@ -50,6 +50,8 @@
 #include "hardware/mpfs_emmcsd.h"
 #include "hardware/mpfs_mpucfg.h"
 
+#include "mpfs_sdio_dev.h"
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -290,58 +292,6 @@
 /****************************************************************************
  * Private Types
  ****************************************************************************/
-
-/* This structure defines the state of the MPFS eMMCSD interface */
-
-struct mpfs_dev_s
-{
-  struct sdio_dev_s  dev;             /* Standard, base SDIO interface */
-
-  const uintptr_t    hw_base;         /* Base address */
-  const int          plic_irq;        /* PLIC interrupt */
-  bool               clk_enabled;     /* Clk state */
-
-  /* eMMC / SD and HW parameters */
-
-  const bool         emmc;            /* eMMC or SD */
-  int                bus_voltage;     /* Bus voltage */
-  int                bus_mode;        /* eMMC Bus mode */
-  bool               jumpers_3v3;     /* Jumper settings: 1v8 or 3v3 */
-
-  /* Event support */
-
-  sem_t              waitsem;         /* Implements event waiting */
-  sdio_eventset_t    waitevents;      /* Set of events to be waited for */
-  uint32_t           waitmask;        /* Interrupt enables for event waiting */
-  volatile sdio_eventset_t wkupevent; /* The event that caused the wakeup */
-  struct wdog_s      waitwdog;        /* Watchdog that handles event timeouts */
-
-  /* Callback support */
-
-  sdio_statset_t     cdstatus;        /* Card status */
-  sdio_eventset_t    cbevents;        /* Set of events to be cause callbacks */
-  worker_t           callback;        /* Registered callback function */
-  void              *cbarg;           /* Registered callback argument */
-  struct work_s      cbwork;          /* Callback work queue structure */
-
-  /* Interrupt mode data transfer support */
-
-  uint32_t          *buffer;          /* Address of current R/W buffer */
-  size_t             remaining;       /* Number of bytes remaining in the transfer */
-  size_t             receivecnt;      /* Real count to receive */
-  uint32_t           xfrmask;         /* Interrupt enables for data transfer */
-
-  bool               widebus;         /* Required for DMA support */
-  bool               onebit;          /* true: Only 1-bit transfers are supported */
-
-  /* DMA data transfer support */
-
-  bool               polltransfer;    /* Indicate a poll transfer, no DMA */
-
-  /* Misc */
-
-  uint32_t           blocksize;       /* Current block size */
-};
 
 /****************************************************************************
  * Private Function Prototypes
@@ -1135,14 +1085,14 @@ static int mpfs_emmcsd_interrupt(int irq, void *context, void *arg)
         {
           mcinfo("Card inserted!\n");
 
-          sdio_mediachange((struct sdio_dev_s *)priv, true);
+          mpfs_emmcsd_sdio_mediachange((struct sdio_dev_s *)priv, true);
           putreg32(MPFS_EMMCSD_SRS12_CIN, MPFS_EMMCSD_SRS12);
         }
       else if (status & MPFS_EMMCSD_SRS12_CR)
         {
           mcinfo("Card removed!\n");
 
-          sdio_mediachange((struct sdio_dev_s *)priv, false);
+          mpfs_emmcsd_sdio_mediachange((struct sdio_dev_s *)priv, false);
           putreg32(MPFS_EMMCSD_SRS12_CR, MPFS_EMMCSD_SRS12);
         }
       else
@@ -2948,7 +2898,7 @@ static void mpfs_callback(void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: sdio_initialize
+ * Name: mpfs_emmcsd_sdio_initialize
  *
  * Description:
  *   Initialize SDIO for operation.
@@ -2962,7 +2912,7 @@ static void mpfs_callback(void *arg)
  *
  ****************************************************************************/
 
-struct sdio_dev_s *sdio_initialize(int slotno)
+struct sdio_dev_s *mpfs_emmcsd_sdio_initialize(int slotno)
 {
   struct mpfs_dev_s *priv = NULL;
   priv = &g_emmcsd_dev;
@@ -2973,14 +2923,14 @@ struct sdio_dev_s *sdio_initialize(int slotno)
 
   if (!mpfs_device_reset(&priv->dev))
     {
-      return NULL;
+      return (struct sdio_dev_s *)NULL;
     }
 
-  return &priv->dev;
+  return (struct sdio_dev_s *) &priv->dev;
 }
 
 /****************************************************************************
- * Name: sdio_mediachange
+ * Name: mpfs_emmcsd_sdio_mediachange
  *
  * Description:
  *   Called by board-specific logic -- possible from an interrupt handler --
@@ -2998,7 +2948,7 @@ struct sdio_dev_s *sdio_initialize(int slotno)
  *
  ****************************************************************************/
 
-void sdio_mediachange(struct sdio_dev_s *dev, bool cardinslot)
+void mpfs_emmcsd_sdio_mediachange(struct sdio_dev_s *dev, bool cardinslot)
 {
   struct mpfs_dev_s *priv = (struct mpfs_dev_s *)dev;
   sdio_statset_t cdstatus;
@@ -3031,7 +2981,7 @@ void sdio_mediachange(struct sdio_dev_s *dev, bool cardinslot)
 }
 
 /****************************************************************************
- * Name: sdio_wrprotect
+ * Name: mpfs_emmcsd_sdio_wrprotect
  *
  * Description:
  *   Called by board-specific logic to report if the card in the slot is
@@ -3046,7 +2996,7 @@ void sdio_mediachange(struct sdio_dev_s *dev, bool cardinslot)
  *
  ****************************************************************************/
 
-void sdio_wrprotect(struct sdio_dev_s *dev, bool wrprotect)
+void mpfs_emmcsd_sdio_wrprotect(struct sdio_dev_s *dev, bool wrprotect)
 {
   struct mpfs_dev_s *priv = (struct mpfs_dev_s *)dev;
   irqstate_t flags;

--- a/arch/risc-v/src/mpfs/mpfs_sdio.h
+++ b/arch/risc-v/src/mpfs/mpfs_sdio.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/risc-v/src/mpfs/mpfs_emmcsd.h
+ * arch/risc-v/src/mpfs/mpfs_sdio.h
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,19 +18,18 @@
  *
  ****************************************************************************/
 
-#ifndef __ARCH_RISCV_SRC_MPFS_MPFS_EMMCSD_H
-#define __ARCH_RISCV_SRC_MPFS_MPFS_EMMCSD_H
+#ifndef __ARCH_RISCV_SRC_MPFS_MPFS_SDIO_H
+#define __ARCH_RISCV_SRC_MPFS_MPFS_SDIO_H
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
 
 #include <nuttx/config.h>
-#include <sys/types.h>
 #include <stdbool.h>
+#include <sys/types.h>
 
 #include "chip.h"
-#include "hardware/mpfs_emmcsd.h"
 
 /****************************************************************************
  * Public Function Prototypes
@@ -48,7 +47,7 @@ extern "C"
 #endif
 
 /****************************************************************************
- * Name: mpfs_emmcsd_sdio_initialize
+ * Name: sdio_initialize
  *
  * Description:
  *   Initialize SDIO for operation.
@@ -63,10 +62,10 @@ extern "C"
  ****************************************************************************/
 
 struct sdio_dev_s; /* See include/nuttx/sdio.h */
-struct sdio_dev_s *mpfs_emmcsd_sdio_initialize(int slotno);
+struct sdio_dev_s *sdio_initialize(int slotno);
 
 /****************************************************************************
- * Name: mpfs_emmcsd_sdio_mediachange
+ * Name: sdio_mediachange
  *
  * Description:
  *   Called by board-specific logic -- possibly from an interrupt handler --
@@ -84,10 +83,10 @@ struct sdio_dev_s *mpfs_emmcsd_sdio_initialize(int slotno);
  *
  ****************************************************************************/
 
-void mpfs_emmcsd_sdio_mediachange(struct sdio_dev_s *dev, bool cardinslot);
+void sdio_mediachange(struct sdio_dev_s *dev, bool cardinslot);
 
 /****************************************************************************
- * Name: mpfs_emmcsd_sdio_wrprotect
+ * Name: sdio_wrprotect
  *
  * Description:
  *   Called by board-specific logic to report if the card in the slot is
@@ -102,7 +101,7 @@ void mpfs_emmcsd_sdio_mediachange(struct sdio_dev_s *dev, bool cardinslot);
  *
  ****************************************************************************/
 
-void mpfs_emmcsd_sdio_wrprotect(struct sdio_dev_s *dev, bool wrprotect);
+void sdio_wrprotect(struct sdio_dev_s *dev, bool wrprotect);
 
 #undef EXTERN
 #if defined(__cplusplus)
@@ -110,4 +109,4 @@ void mpfs_emmcsd_sdio_wrprotect(struct sdio_dev_s *dev, bool wrprotect);
 #endif
 
 #endif /* __ASSEMBLY__ */
-#endif /* __ARCH_RISCV_SRC_MPFS_MPFS_EMMCSD_H */
+#endif /* __ARCH_RISCV_SRC_MPFS_MPFS_SDIO_H */

--- a/arch/risc-v/src/mpfs/mpfs_sdio_dev.h
+++ b/arch/risc-v/src/mpfs/mpfs_sdio_dev.h
@@ -1,0 +1,92 @@
+/****************************************************************************
+ * arch/risc-v/src/mpfs/mpfs_sdio_dev.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_RISCV_SRC_MPFS_MPFS_SDIO_DEV_H
+#define __ARCH_RISCV_SRC_MPFS_MPFS_SDIO_DEV_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/sdio.h>
+#include <stdbool.h>
+#include <sys/types.h>
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/* This structure defines the state of the MPFS eMMCSD interface */
+
+struct mpfs_dev_s
+{
+  struct sdio_dev_s dev; /* Standard, base SDIO interface */
+
+  const uintptr_t hw_base; /* Base address */
+  const int plic_irq;      /* PLIC interrupt */
+  bool clk_enabled;        /* Clk state */
+
+  /* eMMC / SD and HW parameters */
+
+  const bool emmc;  /* eMMC or SD */
+  int bus_voltage;  /* Bus voltage */
+  int bus_mode;     /* eMMC Bus mode */
+  bool jumpers_3v3; /* Jumper settings: 1v8 or 3v3 */
+
+  /* Event support */
+
+  sem_t waitsem;                      /* Implements event waiting */
+  sdio_eventset_t waitevents;         /* Set of events to be waited for */
+  uint32_t waitmask;                  /* Interrupt enables for event waiting */
+  volatile sdio_eventset_t wkupevent; /* The event that caused the wakeup */
+  struct wdog_s waitwdog;             /* Watchdog that handles event timeouts */
+
+  /* Callback support */
+
+  sdio_statset_t cdstatus;  /* Card status */
+  sdio_eventset_t cbevents; /* Set of events to be cause callbacks */
+  worker_t callback;        /* Registered callback function */
+  void *cbarg;              /* Registered callback argument */
+  struct work_s cbwork;     /* Callback work queue structure */
+
+  /* Interrupt mode data transfer support */
+
+  uint32_t *buffer;     /* Address of current R/W buffer */
+  size_t remaining;     /* Number of bytes remaining in the transfer */
+  size_t receivecnt;    /* Real count to receive */
+  uint32_t xfrmask;     /* Interrupt enables for data transfer */
+  uint32_t xfr_blkmask; /* Interrupt enables for SB/MB data transfer */
+
+  bool widebus; /* Required for DMA support */
+  bool onebit;  /* true: Only 1-bit transfers are supported */
+
+  /* DMA data transfer support */
+
+  bool polltransfer; /* Indicate a poll transfer, no DMA */
+  bool multiblock;   /* Indicate a multi-block transfer */
+
+  /* Misc */
+
+  uint32_t blocksize;  /* Current block size */
+  uint32_t fifo_depth; /* Fifo size, read from the register */
+};
+
+#endif /* __ARCH_RISCV_SRC_MPFS_MPFS_SDIO_DEV_H */

--- a/boards/risc-v/mpfs/common/src/mpfs_emmcsd.c
+++ b/boards/risc-v/mpfs/common/src/mpfs_emmcsd.c
@@ -28,7 +28,7 @@
 #include <errno.h>
 #include <nuttx/mmcsd.h>
 
-#include "mpfs_emmcsd.h"
+#include "mpfs_sdio.h"
 #include "board_config.h"
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
Additional mpfs_sdio layer on top of mpfs_emmcsd and mpfs_coremmc block device drivers to let both block devices be enabled at the same time.

```
board_init ---> mpfs_sdio_dev ---+----> mpfs_coremmc
                                 |
                                 +----> mpfs_emmcsd

```

## Impact
mpfs mmcsd block device drivers

## Testing
mount sd-card / emmc
