### PR TITLE
arch/Kconfig: replace RPTUN_PING with RPMSG_PING

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -523,7 +523,7 @@ config ARCH_HAVE_PERF_EVENTS
 
 config ARCH_PERF_EVENTS
 	bool "Configure hardware performance counting"
-	default y if SCHED_CRITMONITOR || SCHED_IRQMONITOR || RPTUN_PING || SEGGER_SYSVIEW
+	default y if SCHED_CRITMONITOR || SCHED_IRQMONITOR || RPMSG_PING || SEGGER_SYSVIEW
 	default n
 	depends on ARCH_HAVE_PERF_EVENTS
 	---help---


### PR DESCRIPTION
## Summary

The RPTUN_PING option has been replaced by RPMSG_PING but this use for PERF_EVENTS is left behind, so replace it here as well.

## Impact

PERF_EVENTS use cases

## Testing

CI.
