### PR TITLE
rv-virt: Guard mount point for procfs/tmpfs

### DIFF
--- a/boards/risc-v/qemu-rv/rv-virt/src/qemu_rv_appinit.c
+++ b/boards/risc-v/qemu-rv/rv-virt/src/qemu_rv_appinit.c
@@ -110,6 +110,10 @@ int board_app_initialize(uintptr_t arg)
 
   mount(NULL, "/proc", "procfs", 0, NULL);
 
+#ifdef CONFIG_FS_TMPFS
+  mount(NULL, "/tmp", "tmpfs", 0, NULL);
+#endif
+
 #endif
 
 #ifdef CONFIG_DRIVERS_VIRTIO_MMIO

--- a/boards/risc-v/qemu-rv/rv-virt/src/qemu_rv_appinit.c
+++ b/boards/risc-v/qemu-rv/rv-virt/src/qemu_rv_appinit.c
@@ -108,7 +108,9 @@ int board_app_initialize(uintptr_t arg)
 
 #ifdef CONFIG_NSH_ARCHINIT
 
+#ifdef CONFIG_FS_PROCFS
   mount(NULL, "/proc", "procfs", 0, NULL);
+#endif
 
 #ifdef CONFIG_FS_TMPFS
   mount(NULL, "/tmp", "tmpfs", 0, NULL);


### PR DESCRIPTION
## Summary
* This commit add mount point for tmpfs in the
board_app_initialize function.
* Don't mount procfs if it is not enabled in the kernel configuration.
## Impact
rv-virt only, minor
## Testing
CI
