### PR TITLE
fs/shmfs: Fix stat() system call for shmfs object

### DIFF
--- a/fs/shm/shmfs.c
+++ b/fs/shm/shmfs.c
@@ -238,7 +238,12 @@ static int shmfs_truncate(FAR struct file *filep, off_t length)
           filep->f_inode->i_private = shmfs_alloc_object(length);
           if (!filep->f_inode->i_private)
             {
+              filep->f_inode->i_size = 0;
               ret = -EFAULT;
+            }
+          else
+            {
+              filep->f_inode->i_size = length;
             }
         }
       else if (object->length != length)

--- a/fs/vfs/fs_stat.c
+++ b/fs/vfs/fs_stat.c
@@ -284,6 +284,7 @@ int inode_stat(FAR struct inode *inode, FAR struct stat *buf, int resolve)
   if (INODE_IS_SHM(inode))
     {
       buf->st_mode = S_IFSHM;
+      buf->st_size = inode->i_size;
     }
   else
 #endif

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -412,7 +412,7 @@ struct inode
   uint16_t          i_flags;    /* Flags for inode */
   union inode_ops_u u;          /* Inode operations */
   ino_t             i_ino;      /* Inode serial number */
-#ifdef CONFIG_PSEUDOFS_FILE
+#if defined(CONFIG_PSEUDOFS_FILE) || defined(CONFIG_FS_SHMFS)
   size_t            i_size;     /* The size of per inode driver */
 #endif
 #ifdef CONFIG_PSEUDOFS_ATTRIBUTES


### PR DESCRIPTION
## Summary
Fixes stat() system call for shmfs objects
## Impact
fstat() now works as expected
## Testing
mpfs + kernel mode with shmfs
