### PR TITLE
fs/shmfs: Fix shmfs_truncate

### DIFF
--- a/arch/arm/src/armv7-a/CMakeLists.txt
+++ b/arch/arm/src/armv7-a/CMakeLists.txt
@@ -74,8 +74,14 @@ else()
 endif()
 
 if(CONFIG_ARCH_ADDRENV)
-  list(APPEND SRCS arm_addrenv.c arm_addrenv_utils.c arm_addrenv_perms.c
-       arm_pgalloc.c)
+  list(
+    APPEND
+    SRCS
+    arm_addrenv.c
+    arm_addrenv_utils.c
+    arm_addrenv_perms.c
+    arm_pgalloc.c
+    arm_addrenv_pgmap.c)
   if(CONFIG_ARCH_STACK_DYNAMIC)
     list(APPEND SRCS arm_addrenv_ustack.c)
   endif()

--- a/arch/arm/src/armv7-a/Make.defs
+++ b/arch/arm/src/armv7-a/Make.defs
@@ -65,6 +65,7 @@ endif
 
 ifeq ($(CONFIG_ARCH_ADDRENV),y)
   CMN_CSRCS += arm_addrenv.c arm_addrenv_utils.c arm_addrenv_perms.c arm_pgalloc.c
+  CMN_CSRCS += arm_addrenv_pgmap.c
   ifeq ($(CONFIG_ARCH_STACK_DYNAMIC),y)
     CMN_CSRCS += arm_addrenv_ustack.c
   endif

--- a/arch/arm/src/armv7-a/arm_addrenv_pgmap.c
+++ b/arch/arm/src/armv7-a/arm_addrenv_pgmap.c
@@ -1,0 +1,75 @@
+/****************************************************************************
+ * arch/arm/src/armv7-a/arm_addrenv_pgmap.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/compiler.h>
+#include <nuttx/pgalloc.h>
+
+#include "pgalloc.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_addrenv_page_vaddr
+ *
+ * Description:
+ *   Find the kernel virtual address associated with physical page.
+ *
+ * Input Parameters:
+ *   page - The page physical address.
+ *
+ * Returned Value:
+ *   Page kernel virtual address on success; NULL on failure.
+ *
+ ****************************************************************************/
+
+uintptr_t up_addrenv_page_vaddr(uintptr_t page)
+{
+  return arm_pgvaddr(page);
+}
+
+/****************************************************************************
+ * Name: up_addrenv_page_wipe
+ *
+ * Description:
+ *   Wipe a page of physical memory, first mapping it into kernel virtual
+ *   memory.
+ *
+ * Input Parameters:
+ *   page - The page physical address.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void up_addrenv_page_wipe(uintptr_t page)
+{
+  uintptr_t vaddr = arm_pgvaddr(page);
+  memset((void *)vaddr, 0, MM_PGSIZE);
+}

--- a/arch/risc-v/src/common/riscv_addrenv_pgmap.c
+++ b/arch/risc-v/src/common/riscv_addrenv_pgmap.c
@@ -147,6 +147,26 @@ bool up_addrenv_user_vaddr(uintptr_t vaddr)
   return riscv_uservaddr(vaddr);
 }
 
+/****************************************************************************
+ * Name: up_addrenv_page_wipe
+ *
+ * Description:
+ *   Wipe a page of physical memory, first mapping it into kernel virtual
+ *   memory.
+ *
+ * Input Parameters:
+ *   page - The page physical address.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void up_addrenv_page_wipe(uintptr_t page)
+{
+  riscv_pgwipe(page);
+}
+
 #ifdef CONFIG_MM_KMAP
 
 /****************************************************************************

--- a/fs/shm/shmfs_alloc.c
+++ b/fs/shm/shmfs_alloc.c
@@ -22,7 +22,11 @@
  * Included Files
  ****************************************************************************/
 
+#include <nuttx/config.h>
+
 #include <stdbool.h>
+
+#include <nuttx/arch.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/pgalloc.h>
 
@@ -86,6 +90,12 @@ FAR struct shmfs_object_s *shmfs_alloc_object(size_t length)
           if (!pages[i])
             {
               break;
+            }
+          else
+            {
+              /* Clear the page memory (requirement for truncate) */
+
+              up_addrenv_page_wipe((uintptr_t)pages[i]);
             }
         }
     }

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -1378,12 +1378,31 @@ uintptr_t up_addrenv_page_vaddr(uintptr_t page);
  *   vaddr - The virtual address.
  *
  * Returned Value:
- *   True if it is; false if it's not
+ *   True if it is; false if it's not.
  *
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_ADDRENV
 bool up_addrenv_user_vaddr(uintptr_t vaddr);
+#endif
+
+/****************************************************************************
+ * Name: up_addrenv_page_wipe
+ *
+ * Description:
+ *   Wipe a page of physical memory, first mapping it into kernel virtual
+ *   memory.
+ *
+ * Input Parameters:
+ *   page - The page physical address.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_ARCH_ADDRENV
+void up_addrenv_page_wipe(uintptr_t page);
 #endif
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
When shmfs_truncate is called, it uses shmfs_alloc_object to create the
physical backing for the shm file. However, the allocated physical
memory returned by mm_pgalloc is not cleared when CONFIG_BUILD_KERNEL is
set, which is a clear POSIX violation:

https://pubs.opengroup.org/onlinepubs/9699919799/functions/truncate.html

"If the file was previously shorter than length, its size is increased,
and the extended area appears as if it were zero-filled."

For FLAT and PROTECTED modes zalloc is used, so the violation affects
KERNEL mode only.
## Impact
Fix shmfs_truncate
## Testing
MPFS + shmfs + kernel mode
