### PR TITLE
Fix typo in mtx_timedlock

### DIFF
--- a/include/threads.h
+++ b/include/threads.h
@@ -203,7 +203,7 @@ static inline int mtx_init(FAR mtx_t *mutex, int type)
  * int mtx_timedlock(FAR mtx_t *mutex, FAR const struct timespec *tp);
  */
 
-#define mtx_timedlock(mutex,tp) pthread_mutex_timedwait(mutex,tp)
+#define mtx_timedlock(mutex,tp) pthread_mutex_timedlock(mutex,tp)
 
 /* mtx_trylock: locks a mutex or returns without blocking if already locked
  *


### PR DESCRIPTION
## Summary
Fix typo in `mtx_timedlock` define: `pthread_mutex_timedwait` → `pthread_mutex_timedlock`.

## Impact
None

## Testing
Manual testing, linker error is gone
