### PR TITLE
tools: Allow trigger docker build manually

### DIFF
--- a/.github/workflows/docker_linux.yml
+++ b/.github/workflows/docker_linux.yml
@@ -27,6 +27,8 @@ on:
       - 'tools/ci/docker/linux/**'
       - '.github/workflows/docker_linux.yml'
 
+  workflow_dispatch:
+
 env:
   IMAGE_NAME: apache-nuttx-ci-linux
 


### PR DESCRIPTION
## Summary

In some cases, we may need to manually trigger the docker image building process, for example, if the automatic build fails due to some reasons.

Make it easier for downstream users to build their docker images.

For example, I‘m maintaining the CI infrastructure for WAMR on the wamr-ci-12.4(based on release/12.4) branch and have added some additional toolchains to the NuttX Dockerfile. If I want the CI to compile the images I need, I must ensure that my modifications to the Dockerfile are applied to the wamr-ci-12.4 branch, while also keeping this PR on the master branch. Considering that I often submit code to NuttX, this will cause some inconvenience (I must have this PR on my master branch to manually trigger the Docker build process).

## Impact
Minor
## Testing
CI
