### PR TITLE
fs/vfat: Fix typo in the macro DIRSEC_BYTENDX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ uImage
 .DS_Store
 tools/gdb/__pycache__
 /build
+.ccls-cache
+compile_commands.json

--- a/fs/fat/fs_fat32.h
+++ b/fs/fat/fs_fat32.h
@@ -261,7 +261,7 @@
 
 #define DIRSEC_NDXMASK(f)   (((f)->fs_hwsectorsize - 1) >> 5)
 #define DIRSEC_NDIRS(f)     (((f)->fs_hwsectorsize) >> 5)
-#define DIRSEC_BYTENDX(f,i) (((i) & DIRSEC_NDXMASK(fs)) << 5)
+#define DIRSEC_BYTENDX(f,i) (((i) & DIRSEC_NDXMASK(f)) << 5)
 
 #define SEC_NDXMASK(f)      ((f)->fs_hwsectorsize - 1)
 #define SEC_NSECTORS(f,n)   ((n) / (f)->fs_hwsectorsize)


### PR DESCRIPTION
The `DIRSEC_BYTENDX(f, i)` is supposed to have `DIRSEC_NDXMASK(f)` in its expansion instead of `DIRSEC_NDXMASK(fs)`. It went unnoticed in the codebase as `DIRSEC_BYTENDX(fs, idx)` is the way it is used, and it leads to a similar expansion as desired, and thus it has worked till now without any issues from this.

## Summary

fs/vfat: Fix typo in the macro DIRSEC_BYTENDX

## Impact

None

## Testing

Build and Checkpatch

