### PR TITLE
risc-v/common: add param to mmu_flush_cache interface

### DIFF
--- a/arch/risc-v/src/bl808/bl808_mm_init.c
+++ b/arch/risc-v/src/bl808/bl808_mm_init.c
@@ -307,8 +307,9 @@ void bl808_mm_init(void)
  *
  ****************************************************************************/
 
-void weak_function mmu_flush_cache(void)
+void weak_function mmu_flush_cache(uintptr_t reg)
 {
+  UNUSED(reg);
   __asm__ __volatile__
     (
 

--- a/arch/risc-v/src/common/riscv_mmu.h
+++ b/arch/risc-v/src/common/riscv_mmu.h
@@ -158,7 +158,7 @@ extern uintptr_t g_kernel_pgt_pbase;
  * Public Function Prototypes
  ****************************************************************************/
 
-void weak_function mmu_flush_cache(void);
+void weak_function mmu_flush_cache(uintptr_t);
 
 /****************************************************************************
  * Inline Functions
@@ -216,7 +216,7 @@ static inline void mmu_write_satp(uintptr_t reg)
 
   if (mmu_flush_cache != NULL)
     {
-      mmu_flush_cache();
+      mmu_flush_cache(reg);
     }
 }
 


### PR DESCRIPTION
## Summary

Current mmu_flush_cache() hook lacks the `reg` param which is needed by some targets. So this PR adds the param and update existing targets using that hook.

## Impact

bl808 devices

## Testing

Build passes for `ox64/nsh`.  
