### PR TITLE
boards/arm/cxd56xx: Fix the modem reset sequence

### DIFF
--- a/boards/arm/cxd56xx/common/src/cxd56_alt1250.c
+++ b/boards/arm/cxd56xx/common/src/cxd56_alt1250.c
@@ -377,7 +377,8 @@ static void alt1250_reset(void)
 {
   /* Reset Altair modem device */
 
-  board_alt1250_reset();
+  alt1250_poweroff();
+  alt1250_poweron(false);
 }
 
 /****************************************************************************
@@ -499,6 +500,46 @@ int board_alt1250_initialize(const char *devpath)
     }
 
   return OK;
+}
+
+/****************************************************************************
+ * Name: board_alt1250_reset
+ *
+ * Description:
+ *   Reset the Altair modem device on the board.
+ *
+ ****************************************************************************/
+
+void board_alt1250_reset(void)
+{
+  /* power off Altair modem device */
+
+  board_alt1250_poweroff();
+
+  /* Hi-Z SHUTDOWN and PowerBTN signals before power-on */
+
+  cxd56_gpio_config(ALT1250_SHUTDOWN, false);
+
+  /* power on alt1250 modem device and wait until the power is distributed */
+
+  board_alt1250_poweron();
+  up_mdelay(POWER_ON_WAIT_TIME);
+
+  /* Drive SHUTDOWN signal low */
+
+  cxd56_gpio_write(ALT1250_SHUTDOWN, 0);
+
+  /* Keep the SHUTDOWN signal low for reset period */
+
+  up_mdelay(ACTIVE_SHUTDOWN_TIME);
+
+  /* Undrive SHUTDOWN signal to rise up to high by pull-up */
+
+  cxd56_gpio_write_hiz(ALT1250_SHUTDOWN);
+
+  /* Wait VDDIO on Alt1250 stable */
+
+  up_mdelay(TIME_TO_STABLE_VDDIO);
 }
 
 #endif

--- a/boards/arm/cxd56xx/spresense/src/cxd56_alt1250_power.c
+++ b/boards/arm/cxd56xx/spresense/src/cxd56_alt1250_power.c
@@ -39,19 +39,6 @@
 #include "cxd56_pinconfig.h"
 
 /****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-#define RESET_INTERVAL_TIMEOUT MSEC2TICK(1)
-
-/****************************************************************************
- * Private Data
- ****************************************************************************/
-
-static struct wdog_s g_reset_wd;
-static sem_t g_wd_wait;
-
-/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -113,52 +100,5 @@ int board_alt1250_powerkeep(bool enable)
       return board_set_reset_gpo(POWER_LTE);
     }
 }
-
-/****************************************************************************
- * Name: board_alt1250_timeout
- *
- * Description:
- *   Watchdog timer for timeout of reset interval.
- *
- ****************************************************************************/
-
-static void board_alt1250_timeout(wdparm_t arg)
-{
-  sem_t *wd_wait = (sem_t *)arg;
-
-  nxsem_post(wd_wait);
-}
-
-/****************************************************************************
- * Name: board_alt1250_reset
- *
- * Description:
- *   Reset the Altair modem device on the board.
- *
- ****************************************************************************/
-
-void board_alt1250_reset(void)
-{
-  memset(&g_reset_wd, 0, sizeof(struct wdog_s));
-  nxsem_init(&g_wd_wait, 0, 0);
-
-  /* Reset Altair modem device */
-
-  board_alt1250_poweroff();
-
-  /* ALT1250_SHUTDOWN should be low in the range 101usec to 100msec */
-
-  wd_start(&g_reset_wd, RESET_INTERVAL_TIMEOUT,
-           board_alt1250_timeout, (wdparm_t)&g_wd_wait);
-
-  /* Wait for the watchdog timer to expire */
-
-  nxsem_wait_uninterruptible(&g_wd_wait);
-
-  board_alt1250_poweron();
-
-  nxsem_destroy(&g_wd_wait);
-}
-
 #endif
 


### PR DESCRIPTION

## Summary
Since there were some cases in which the current modem reset sequence did not reset the modem, the reset was ensured by executing power off and power on of the modem.

## Impact
Only ALT1250 driver.

## Testing
Test with Spresense LTE board.
