### PR TITLE
Mpfs i2c fixes

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_i2c.c
+++ b/arch/risc-v/src/mpfs/mpfs_i2c.c
@@ -493,7 +493,10 @@ static int mpfs_i2c_irq(int cpuint, void *context, void *arg)
 
             /* Jump to the next message */
 
-            priv->msgid++;
+            if (priv->msgid < (priv->msgc - 1))
+              {
+                priv->msgid++;
+              }
           }
         else
           {
@@ -512,7 +515,10 @@ static int mpfs_i2c_irq(int cpuint, void *context, void *arg)
 
                 /* Jump to the next message */
 
-                priv->msgid++;
+                if (priv->msgid < (priv->msgc - 1))
+                  {
+                    priv->msgid++;
+                  }
               }
             else
               {

--- a/arch/risc-v/src/mpfs/mpfs_i2c.c
+++ b/arch/risc-v/src/mpfs/mpfs_i2c.c
@@ -358,10 +358,9 @@ static int mpfs_i2c_init(struct mpfs_i2c_priv_s *priv)
 
       putreg32(priv->ser_address, MPFS_I2C_ADDR);
 
-      /* Enable i2c bus */
+      /* Enable i2c bus, clear all other bits */
 
-      modifyreg32(MPFS_I2C_CTRL, MPFS_I2C_CTRL_ENS1_MASK,
-                  MPFS_I2C_CTRL_ENS1_MASK);
+      putreg32(MPFS_I2C_CTRL_ENS1_MASK, MPFS_I2C_CTRL);
 
       priv->initialized = true;
     }
@@ -385,8 +384,7 @@ static void mpfs_i2c_deinit(struct mpfs_i2c_priv_s *priv)
   up_disable_irq(priv->plic_irq);
   irq_detach(priv->plic_irq);
 
-  modifyreg32(MPFS_I2C_CTRL, MPFS_I2C_CTRL_ENS1_MASK,
-              ~MPFS_I2C_CTRL_ENS1_MASK);
+  putreg32(0, MPFS_I2C_CTRL);
 
   priv->initialized = false;
 }


### PR DESCRIPTION
## Summary

This is a collection of corrections for MFPS i2c driver from TII repositories.

## Impact

Correct some issues with concurrent bus access and stabilize i2c in different various error conditions

## Testing

Tested on an MPFS250 based HW, where several i2c devices are connected to the same bus
