### PR TITLE
avr32dev1: Fix compilation and nsh boot-up

### DIFF
--- a/arch/avr/include/avr32/types.h
+++ b/arch/avr/include/avr32/types.h
@@ -79,7 +79,7 @@ typedef int                _wchar_t;
  */
 
 #define unsigned signed
-typedef __SIZE_TYPE__      _ssize_t;
+typedef int                _ssize_t; /* Keep avr32-gcc 4.4.7 happy. */
 #undef unsigned
 typedef __SIZE_TYPE__      _size_t;
 #elif defined(CONFIG_ARCH_SIZET_LONG)

--- a/boards/avr/at32uc3/avr32dev1/include/board.h
+++ b/boards/avr/at32uc3/avr32dev1/include/board.h
@@ -124,7 +124,7 @@
 /* Pin muliplexing selecion *************************************************/
 
 #define PINMUX_USART1_RXD     PINMUX_USART1_RXD_2
-#define PINMUX_USART1_TXD     PINMUX_USART1_TXD_1
+#define PINMUX_USART1_TXD     PINMUX_USART1_TXD_2
 
 /* LED definitions **********************************************************/
 

--- a/boards/avr/at32uc3/avr32dev1/scripts/avr32dev1.ld
+++ b/boards/avr/at32uc3/avr32dev1/scripts/avr32dev1.ld
@@ -39,7 +39,8 @@ MEMORY
 SECTIONS
 {
     .text : {
-        _stext = ABSOLUTE(.);
+        . = ALIGN(4);
+        _stext = .;
         *(.vectors)
         *(.text .text.*)
         *(.fixup)
@@ -51,27 +52,29 @@ SECTIONS
         *(.got)
         *(.gcc_except_table)
         *(.gnu.linkonce.r.*)
-        _etext = ABSOLUTE(.);
+        . = ALIGN(4);
+        _etext = .;
     } > flash
 
-    _eronly = ABSOLUTE(.);      /* See below                    */
+    _eronly = .;                /* See below                    */
 
-    .data : {
-        _sdata = ABSOLUTE(.);
+    .data : AT(_etext) {
+        . = ALIGN(4);
+        _sdata = .;
         *(.data .data.*)
         *(.gnu.linkonce.d.*)
         CONSTRUCTORS
         . = ALIGN(4);
-        _edata = ABSOLUTE(.);
-    } > intram AT > flash
+        _edata = .;
+    } > intram
 
     .bss : {            /* BSS              */
-        _sbss = ABSOLUTE(.);
+        _sbss = .;
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
         . = ALIGN(4);
-        _ebss = ABSOLUTE(.);
+        _ebss = .;
     } > intram
     /* Stabs debugging sections.    */
     .stab 0 : { *(.stab) }

--- a/libs/libc/assert/Make.defs
+++ b/libs/libc/assert/Make.defs
@@ -24,8 +24,10 @@ ifeq ($(CONFIG_STACK_CANARIES),y)
 CSRCS += lib_stackchk.c
 endif
 
+ifeq ($(CONFIG_LTO_NONE),n)
 assert/lib_assert.c_CFLAGS += -fno-lto
 assert/lib_stackchk.c_CFLAGS += -fno-lto
+endif
 
 # Add the assert directory to the build
 


### PR DESCRIPTION

Dear NuttX community, Greetings!

## Summary

I recently imported NuttX version 6.0 (and nsh) into a Microchip
Studio project [1] on Windows to figure out what was going wrong with
the avr32dev1 build. I also briefly checked NuttX version 10.

I worked with the assumption that the avr32 (avr32dev1) specific
changes to the codebase were minimal across NuttX releases.

For the initial proof of concept I used Microchip Studio version 7.0
(with the recent Microchip's ASF updates). I use avr32-gcc (4.4.7)
hosted here [2] for building NuttX for avr32dev1 on GNU/Linux.

Even with the Microchip Studio project, I had initial debug problems
with just stepping through the code a line at a time. I had to bring
in crt0, a trampoline stub and the linker file from one of my older
projects to really build on the suspicion I had with the linker file.

Perhaps an older version of avr32-gcc did something differently. I am
not sure about this. I used avr32-objdump to see the output sections
of the generated elf file. I just had to tweak the linker script to
ensure correct linking of the sections.

With those changes, I was able to inspect the UART sections within
NuttX Microchip Studio project.

Second important change: the transmit pin: I had to reassign the pin
to see the nsh console.

These are the currently assigned UART pins:

RX: PA_24 -> Physical IC pin 59
TX: PB_02 -> Physical IC pin 24

For the avr32dev1 board, they are pins: J1 (berg pin 28) and J2 (berg
pin 10).

## Impact

This PR won't affect any other build. The -fno-lto flag will apply to
all other targets but not avr32dev1 (OR other avr32 targets).
Otherwise, this PR only touches files specific to avr32dev1.

## Testing

I have tested the nsh build with my avr32dev1 boards. I used Atmel ICE
to program one of them (flash at 0x80000000) and dfu-programmer to
test my other board (flash at 0x80002000). The other RS-232 parameters
are the same as they were.

In addition, the PR fixes silly compilation problems with avr32dev1.
Please let me know if these are fine OR if there's something I have
missed.

References:
[1]: https://github.com/ramangopalan/nuttx_avr32dev1
[2]: https://github.com/ramangopalan/avr32-gnu-toolchain-linux_x86_64