### PR TITLE
rpmsg/rpmsg_ping: fix CI check issues

### DIFF
--- a/drivers/rpmsg/rpmsg_ping.c
+++ b/drivers/rpmsg/rpmsg_ping.c
@@ -188,11 +188,11 @@ static void rpmsg_ping_logout_rate(uint64_t len, clock_t avg)
 int rpmsg_ping(FAR struct rpmsg_endpoint *ept,
                FAR const struct rpmsg_ping_s *ping)
 {
-  clock_t min = ULONG_MAX;
+  clock_t min = UINT_MAX;
   clock_t max = 0;
   uint64_t total = 0;
   uint32_t buf_len = 0;
-  int send_len;
+  int send_len = 0;
   int i;
 
   if (!ept || !ping || ping->times <= 0)


### PR DESCRIPTION
## Summary

rpmsg_ping.c is blocking CI checks for RPTUN related patches like #11673. this patch simply fix the compilation issue of rpmsg_ping.c:

- line 191: overflow conversion from "long unsigned int" to "unsigned int"
- line 226: "sendlen" used uninitialized

## Impact

Ths is to unblock RPTUN/RPMSG related pull requests

## Testing

build check 

