### PR TITLE
tools/ci: Modify cibuild.sh to support new platforms

### DIFF
--- a/tools/ci/cibuild.sh
+++ b/tools/ci/cibuild.sh
@@ -1,527 +1,92 @@
 #!/usr/bin/env bash
-
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
+############################################################################
+# tools/ci/cibuild.sh
 #
-#  http://www.apache.org/licenses/LICENSE-2.0
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
 #
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
 # under the License.
-
-# Prerequisites for macOS
-#  - Xcode (cc, etc)
-#  - homebrew
-#  - autoconf
-#  - wget
-
+#
+############################################################################
 set -e
 set -o xtrace
 
-WD=$(cd "$(dirname "$0")" && pwd)
-WORKSPACE=$(cd "${WD}"/../../../ && pwd -P)
-nuttx=${WORKSPACE}/nuttx
-apps=${WORKSPACE}/apps
-tools=${WORKSPACE}/tools
+
+CID=$(cd "$(dirname "$0")" && pwd)
+CIWORKSPACE=$(cd "${CID}"/../../../ && pwd -P)
+CIPLAT=${CIWORKSPACE}/nuttx/tools/ci/platforms
+nuttx=${CIWORKSPACE}/nuttx
+apps=${CIWORKSPACE}/apps
+
 os=$(uname -s)
-EXTRA_PATH=
+if [ -f /etc/os-release ]; then
+  osname=$(grep "^ID=" /etc/os-release | cut -d'=' -f2 | tr -d '"')
+else
+  osname=${os}
+fi
 
-function add_path {
-  PATH=$1:${PATH}
-  EXTRA_PATH=$1:${EXTRA_PATH}
+function to_do {
+  echo ""
+  echo "NuttX TODO: $1"
+  echo "The $1 platform does not appear to have been added to this project."
+  echo ""
+  exit 1
 }
 
-function arm-clang-toolchain {
-  add_path "${tools}"/clang-arm-none-eabi/bin
+function install_tools {
+  export NUTTXTOOLS=${CIWORKSPACE}/tools
+  mkdir -p "${NUTTXTOOLS}"
 
-  if [ ! -f "${tools}/clang-arm-none-eabi/bin/clang" ]; then
-    local flavor
-    case ${os} in
-      Linux)
-        flavor=Linux
-        ;;
-    esac
-    cd "${tools}"
-    curl -O -L -s https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/releases/download/release-17.0.1/LLVMEmbeddedToolchainForArm-17.0.1-${flavor}-x86_64.tar.xz
-    xz -d LLVMEmbeddedToolchainForArm-17.0.1-${flavor}.tar.xz
-    mv LLVMEmbeddedToolchainForArm-17.0.1 clang-arm-none-eabi
-    cp /usr/bin/clang-extdef-mapping-10 clang-arm-none-eabi/bin/clang-extdef-mapping
-    rm LLVMEmbeddedToolchainForArm-17.0.1-${flavor}.tar.xz
-  fi
-
-  command clang --version
-}
-
-function arm-gcc-toolchain {
-  add_path "${tools}"/gcc-arm-none-eabi/bin
-
-  if [ ! -f "${tools}/gcc-arm-none-eabi/bin/arm-none-eabi-gcc" ]; then
-    local archivetool
-    local basefile
-    case ${os} in
-      Darwin)
-        archivetool=tar
-        basefile=arm-gnu-toolchain-13.2.rel1-darwin-x86_64-arm-none-eabi
-        ;;
-      Linux)
-       archivetool=tar
-        basefile=arm-gnu-toolchain-13.2.rel1-x86_64-arm-none-eabi
-        ;;
-      MSYS*)
-        archivetool=unzip
-        basefile=arm-gnu-toolchain-13.2.rel1-mingw-w64-i686-arm-none-eabi
-        ;;
-    esac
-    cd "${tools}"
-    if [ "$archivetool" == "tar" ]; then
-      wget --quiet https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/${basefile}.tar.xz
-      xz -d ${basefile}.tar.xz
-      tar xf ${basefile}.tar
-      mv ${basefile} gcc-arm-none-eabi
-      rm ${basefile}.tar
-    else
-      wget --quiet https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/${basefile}.zip
-      unzip -qo ${basefile}.zip
-      mv ${basefile} gcc-arm-none-eabi
-      rm ${basefile}.zip
-    fi
-  fi
-
-  command arm-none-eabi-gcc --version
-}
-
-function arm64-gcc-toolchain {
-  add_path "${tools}"/gcc-aarch64-none-elf/bin
-
-  if [ ! -f "${tools}/gcc-aarch64-none-elf/bin/aarch64-none-elf-gcc" ]; then
-    local flavor
-    case ${os} in
-      Darwin)
-        flavor=-darwin
-        ;;
-      Linux)
-        flavor=
-        ;;
-    esac
-    cd "${tools}"
-    wget --quiet https://developer.arm.com/-/media/Files/downloads/gnu/13.2.Rel1/binrel/arm-gnu-toolchain-13.2.Rel1${flavor}-x86_64-aarch64-none-elf.tar.xz
-    xz -d arm-gnu-toolchain-13.2.Rel1${flavor}-x86_64-aarch64-none-elf.tar.xz
-    tar xf arm-gnu-toolchain-13.2.Rel1${flavor}-x86_64-aarch64-none-elf.tar
-    mv arm-gnu-toolchain-13.2.Rel1${flavor}-x86_64-aarch64-none-elf gcc-aarch64-none-elf
-    rm arm-gnu-toolchain-13.2.Rel1${flavor}-x86_64-aarch64-none-elf.tar
-  fi
-
-  command aarch64-none-elf-gcc --version
-}
-
-function avr-gcc-toolchain {
-  if ! type avr-gcc &> /dev/null; then
-    case ${os} in
-      Darwin)
-        brew tap osx-cross/avr
-        brew install avr-gcc
-        ;;
-      Linux)
-        apt-get install -y avr-libc gcc-avr
-        ;;
-    esac
-  fi
-
-  command avr-gcc --version
-}
-
-function binutils {
-  mkdir -p "${tools}"/bintools/bin
-  add_path "${tools}"/bintools/bin
-
-  if ! type objcopy &> /dev/null; then
-    case ${os} in
-      Darwin)
-        brew install binutils
-        # It is possible we cached prebuilt but did brew install so recreate
-        # symlink if it exists
-        rm -f "${tools}"/bintools/bin/objcopy
-        ln -s /usr/local/opt/binutils/bin/objcopy "${tools}"/bintools/bin/objcopy
-        ;;
-    esac
-  fi
-
-  command objcopy --version
-}
-
-function bloaty {
-  add_path "${tools}"/bloaty/bin
-
-  if [ ! -f "${tools}/bloaty/bin/bloaty" ]; then
-    git clone --branch main https://github.com/google/bloaty "${tools}"/bloaty-src
-    cd "${tools}"/bloaty-src
-    # Due to issues with latest MacOS versions use pinned commit.
-    # https://github.com/google/bloaty/pull/326
-    git checkout 52948c107c8f81045e7f9223ec02706b19cfa882
-    mkdir -p "${tools}"/bloaty
-    cmake -D BLOATY_PREFER_SYSTEM_CAPSTONE=NO -DCMAKE_SYSTEM_PREFIX_PATH="${tools}"/bloaty
-    make install -j 6
-    cd "${tools}"
-    rm -rf bloaty-src
-  fi
-
-  command bloaty --version
-}
-
-function c-cache {
-  add_path "${tools}"/ccache/bin
-
-  if ! type ccache &> /dev/null; then
-    case ${os} in
-      Darwin)
-        brew install ccache
-        ;;
-      Linux)
-        cd "${tools}";
-        wget https://github.com/ccache/ccache/releases/download/v3.7.7/ccache-3.7.7.tar.gz
-        tar zxf ccache-3.7.7.tar.gz
-        cd ccache-3.7.7; ./configure --prefix="${tools}"/ccache; make; make install
-        cd "${tools}"; rm -rf ccache-3.7.7; rm ccache-3.7.7.tar.gz
-        ;;
-      MSYS*)
-        pacman -S --noconfirm --needed ccache
-        pacman -Q
-        ;;
-    esac
-  fi
-
-  command ccache --version
-}
-
-function clang-tidy {
-  if ! type clang-tidy &> /dev/null; then
-    case ${os} in
-      Linux)
-        apt-get install -y clang clang-tidy
-        ;;
-    esac
-  fi
-
-  command clang-tidy --version
-}
-
-function elf-toolchain {
-  if ! type x86_64-elf-gcc &> /dev/null; then
-    case ${os} in
-      Darwin)
-        brew install x86_64-elf-gcc
-        ;;
-    esac
-  fi
-
-  command x86_64-elf-gcc --version
-}
-
-function util-linux {
-  if ! type flock &> /dev/null; then
-    case ${os} in
-      Darwin)
-        brew tap discoteq/discoteq
-        brew install flock
-        ;;
-      Linux)
-        apt-get install -y util-linux
-        ;;
-    esac
-  fi
-
-  command flock --version
-}
-
-function gen-romfs {
-  if ! type genromfs &> /dev/null; then
-    case ${os} in
-      Darwin)
-        brew tap PX4/px4
-        brew install genromfs
-        ;;
-      Linux)
-        apt-get install -y genromfs
-        ;;
-    esac
-  fi
-}
-
-function gperf {
-  add_path "${tools}"/gperf/bin
-
-  if [ ! -f "${tools}/gperf/bin/gperf" ]; then
-    cd "${tools}"
-    wget --quiet http://ftp.gnu.org/pub/gnu/gperf/gperf-3.1.tar.gz
-    tar zxf gperf-3.1.tar.gz
-    cd "${tools}"/gperf-3.1
-    ./configure --prefix="${tools}"/gperf; make; make install
-    cd "${tools}"
-    rm -rf gperf-3.1; rm gperf-3.1.tar.gz
-  fi
-
-  command gperf --version
-}
-
-function kconfig-frontends {
-  add_path "${tools}"/kconfig-frontends/bin
-
-  if [ ! -f "${tools}/kconfig-frontends/bin/kconfig-conf" ]; then
-    git clone https://bitbucket.org/nuttx/tools.git "${tools}"/nuttx-tools
-    cd "${tools}"/nuttx-tools/kconfig-frontends
-    ./configure --prefix="${tools}"/kconfig-frontends \
-      --disable-kconfig --disable-nconf --disable-qconf \
-      --disable-gconf --disable-mconf --disable-static \
-      --disable-shared --disable-L10n
-    # Avoid "aclocal/automake missing" errors
-    touch aclocal.m4 Makefile.in
-    make install
-    cd "${tools}"
-    rm -rf nuttx-tools
-  fi
-}
-
-function mips-gcc-toolchain {
-  if [ ! -d "${tools}/pinguino-compilers" ]; then
-    cd "${tools}"
-    git clone https://github.com/PinguinoIDE/pinguino-compilers
-  fi
-
-  case ${os} in
+  case ${osname} in
+    alpine)
+      to_do "alpine"
+      ;;
+    arch)
+      to_do "arch"
+      ;;
+    CYGWIN*)
+      to_do "CYGWIN"
+      ;;
+    debian)
+      to_do "debian"
+      ;;
+    fedora)
+      to_do "fedora"
+      ;;
+    freebsd)
+      to_do "freebsd"
+      ;;
     Darwin)
-      add_path "${tools}"/pinguino-compilers/macosx/p32/bin
-      command mips-elf-gcc --version
+      "${CIPLAT}"/darwin.sh
       ;;
     Linux)
-      add_path "${tools}"/pinguino-compilers/linux64/p32/bin
-      command p32-gcc --version
+      "${CIPLAT}"/linux.sh
+      ;;
+    manjaro)
+      to_do "manjaro"
+      ;;
+    msys2)
+      "${CIPLAT}"/msys2.sh
+      ;;
+    ubuntu)
+      "${CIPLAT}"/ubuntu.sh
+      ;;
+    *)
+      to_do "unknown"
       ;;
   esac
-}
 
-function python-tools {
-  # Python User Env
-  export PIP_USER=yes
-  export PYTHONUSERBASE=${tools}/pylocal
-  add_path "${PYTHONUSERBASE}"/bin
-
-  # workaround for Cython issue
-  # https://github.com/yaml/pyyaml/pull/702#issuecomment-1638930830
-  pip3 install "Cython<3.0"
-  git clone https://github.com/yaml/pyyaml.git && \
-  cd pyyaml && \
-  git checkout release/5.4.1 && \
-  sed -i.bak 's/Cython/Cython<3.0/g' pyproject.toml && \
-  python setup.py sdist && \
-  pip3 install --pre dist/PyYAML-5.4.1.tar.gz
-  cd ..
-
-  pip3 install \
-    cmake-format \
-    CodeChecker \
-    cvt2utf \
-    cxxfilt \
-    esptool==4.5.1 \
-    imgtool==1.9.0 \
-    kconfiglib \
-    pexpect==4.8.0 \
-    pyelftools \
-    pyserial==3.5 \
-    pytest==6.2.5 \
-    pytest-json==0.4.0 \
-    pytest-ordering==0.6 \
-    pytest-repeat==0.9.1
-}
-
-function riscv-gcc-toolchain {
-  add_path "${tools}"/riscv-none-elf-gcc/bin
-
-  if [ ! -f "${tools}/riscv-none-elf-gcc/bin/riscv-none-elf-gcc" ]; then
-    local flavor
-    case ${os} in
-      Darwin)
-        flavor=darwin-x64
-        ;;
-      Linux)
-        flavor=linux-x64
-        ;;
-    esac
-    cd "${tools}"
-    wget --quiet https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/xpack-riscv-none-elf-gcc-13.2.0-2-${flavor}.tar.gz
-    tar zxf xpack-riscv-none-elf-gcc-13.2.0-2-${flavor}.tar.gz
-    mv xpack-riscv-none-elf-gcc-13.2.0-2 riscv-none-elf-gcc
-    rm xpack-riscv-none-elf-gcc-13.2.0-2-${flavor}.tar.gz
-  fi
-
-  command riscv-none-elf-gcc --version
-}
-
-function rust {
-  mkdir -p "${tools}"/rust/bin
-  add_path "${tools}"/rust/bin
-
-  if ! type rustc &> /dev/null; then
-    case ${os} in
-      Darwin)
-        brew install rust
-        ;;
-      Linux)
-        # Currently Debian installed rustc doesn't support 2021 edition.
-        export CARGO_HOME=${tools}/rust
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-        ;;
-    esac
-  fi
-
-  command rustc --version
-}
-
-function rx-gcc-toolchain {
-  add_path "${tools}"/renesas-toolchain/rx-elf-gcc/bin
-
-  if [ ! -f "${tools}/renesas-toolchain/rx-elf-gcc/bin/rx-elf-gcc" ]; then
-    case ${os} in
-      Linux)
-        # Download toolchain source code
-        # RX toolchain is built from source code. Once prebuilt RX toolchain is made available, the below code snippet can be removed.
-        mkdir -p "${tools}"/renesas-tools/rx/source; cd "${tools}"/renesas-tools/rx/source
-        wget --quiet https://gcc-renesas.com/downloads/d.php?f=rx/binutils/4.8.4.201803-gnurx/rx_binutils2.24_2018Q3.tar.gz \
-          -O rx_binutils2.24_2018Q3.tar.gz
-        tar zxf rx_binutils2.24_2018Q3.tar.gz
-        wget --quiet https://gcc-renesas.com/downloads/d.php?f=rx/gcc/4.8.4.201803-gnurx/rx_gcc_4.8.4_2018Q3.tar.gz \
-          -O rx_gcc_4.8.4_2018Q3.tar.gz
-        tar zxf rx_gcc_4.8.4_2018Q3.tar.gz
-        wget --quiet https://gcc-renesas.com/downloads/d.php?f=rx/newlib/4.8.4.201803-gnurx/rx_newlib2.2.0_2018Q3.tar.gz \
-          -O rx_newlib2.2.0_2018Q3.tar.gz
-        tar zxf rx_newlib2.2.0_2018Q3.tar.gz
-
-        # Install binutils
-        cd "${tools}"/renesas-tools/rx/source/binutils; chmod +x ./configure ./mkinstalldirs
-        mkdir -p "${tools}"/renesas-tools/rx/build/binutils; cd "${tools}"/renesas-tools/rx/build/binutils
-        "${tools}"/renesas-tools/rx/source/binutils/configure --target=rx-elf --prefix="${tools}"/renesas-toolchain/rx-elf-gcc \
-          --disable-werror
-        make; make install
-
-        # Install gcc
-        cd "${tools}"/renesas-tools/rx/source/gcc
-        chmod +x ./contrib/download_prerequisites ./configure ./move-if-change ./libgcc/mkheader.sh
-        ./contrib/download_prerequisites
-        sed -i '1s/^/@documentencoding ISO-8859-1\n/' ./gcc/doc/gcc.texi
-        sed -i 's/@tex/\n&/g' ./gcc/doc/gcc.texi && sed -i 's/@end tex/\n&/g' ./gcc/doc/gcc.texi
-        mkdir -p "${tools}"/renesas-tools/rx/build/gcc; cd "${tools}"/renesas-tools/rx/build/gcc
-        "${tools}"/renesas-tools/rx/source/gcc/configure --target=rx-elf --prefix="${tools}"/renesas-toolchain/rx-elf-gcc \
-        --disable-shared --disable-multilib --disable-libssp --disable-libstdcxx-pch --disable-werror --enable-lto \
-        --enable-gold --with-pkgversion=GCC_Build_1.02 --with-newlib --enable-languages=c
-        make; make install
-
-        # Install newlib
-        cd "${tools}"/renesas-tools/rx/source/newlib; chmod +x ./configure
-        mkdir -p "${tools}"/renesas-tools/rx/build/newlib; cd "${tools}"/renesas-tools/rx/build/newlib
-        "${tools}"/renesas-tools/rx/source/newlib/configure --target=rx-elf --prefix="${tools}"/renesas-toolchain/rx-elf-gcc
-        make; make install
-        rm -rf "${tools}"/renesas-tools/
-        ;;
-    esac
-  fi
-
-  command rx-elf-gcc --version
-}
-
-function sparc-gcc-toolchain {
-  add_path "${tools}"/sparc-gaisler-elf-gcc/bin
-
-  if [ ! -f "${tools}/sparc-gaisler-elf-gcc/bin/sparc-gaisler-elf-gcc" ]; then
-    case ${os} in
-      Linux)
-        cd "${tools}"
-        wget --quiet https://www.gaisler.com/anonftp/bcc2/bin/bcc-2.1.0-gcc-linux64.tar.xz
-        xz -d bcc-2.1.0-gcc-linux64.tar.xz
-        tar xf bcc-2.1.0-gcc-linux64.tar
-        mv bcc-2.1.0-gcc sparc-gaisler-elf-gcc
-        rm bcc-2.1.0-gcc-linux64.tar
-        ;;
-    esac
-  fi
-
-  command sparc-gaisler-elf-gcc --version
-}
-
-function xtensa-esp32-gcc-toolchain {
-  add_path "${tools}"/xtensa-esp32-elf/bin
-
-  if [ ! -f "${tools}/xtensa-esp32-elf/bin/xtensa-esp32-elf-gcc" ]; then
-    cd "${tools}"
-    case ${os} in
-      Darwin)
-        wget --quiet https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/xtensa-esp32-elf-12.2.0_20230208-x86_64-apple-darwin.tar.xz
-        xz -d xtensa-esp32-elf-12.2.0_20230208-x86_64-apple-darwin.tar.xz
-        tar xf xtensa-esp32-elf-12.2.0_20230208-x86_64-apple-darwin.tar
-        rm xtensa-esp32-elf-12.2.0_20230208-x86_64-apple-darwin.tar
-        ;;
-      Linux)
-        wget --quiet https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/xtensa-esp32-elf-12.2.0_20230208-x86_64-linux-gnu.tar.xz
-        xz -d xtensa-esp32-elf-12.2.0_20230208-x86_64-linux-gnu.tar.xz
-        tar xf xtensa-esp32-elf-12.2.0_20230208-x86_64-linux-gnu.tar
-        rm xtensa-esp32-elf-12.2.0_20230208-x86_64-linux-gnu.tar
-        ;;
-    esac
-  fi
-
-  command xtensa-esp32-elf-gcc --version
-}
-
-function u-boot-tools {
-  if ! type mkimage &> /dev/null; then
-    case ${os} in
-      Darwin)
-        brew install u-boot-tools
-        ;;
-      Linux)
-        apt-get install -y u-boot-tools
-        ;;
-    esac
-  fi
-}
-
-function wasi-sdk {
-  add_path "${tools}"/wamrc
-
-  if [ ! -f "${tools}/wasi-sdk/bin/clang" ]; then
-    cd "${tools}"
-    mkdir wamrc
-
-    case ${os} in
-      Darwin)
-        wget --quiet https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-19/wasi-sdk-19.0-macos.tar.gz
-        tar xzf wasi-sdk-19.0-macos.tar.gz
-        mv wasi-sdk-19.0 wasi-sdk
-        cd wamrc
-        wget --quiet https://github.com/bytecodealliance/wasm-micro-runtime/releases/download/WAMR-1.1.2/wamrc-1.1.2-x86_64-macos-latest.tar.gz
-        tar xzf wamrc-1.1.2-x86_64-macos-latest.tar.gz
-        ;;
-      Linux)
-        wget --quiet https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-19/wasi-sdk-19.0-linux.tar.gz
-        tar xzf wasi-sdk-19.0-linux.tar.gz
-        mv wasi-sdk-19.0 wasi-sdk
-        cd wamrc
-        wget --quiet https://github.com/bytecodealliance/wasm-micro-runtime/releases/download/WAMR-1.1.2/wamrc-1.1.2-x86_64-ubuntu-20.04.tar.gz
-        tar xzf wamrc-1.1.2-x86_64-ubuntu-20.04.tar.gz
-        ;;
-    esac
-  fi
-
-  export WASI_SDK_PATH="${tools}/wasi-sdk"
-
-  command ${WASI_SDK_PATH}/bin/clang --version
-  command wamrc --version
+  source "${CIWORKSPACE}"/tools/env.sh
 }
 
 function usage {
@@ -534,38 +99,14 @@ function usage {
   echo "  -s setup repos"
   echo "  -c enable ccache"
   echo "  -* support all options in testbuild.sh"
-  echo "  -h will show this help test and terminate"
+  echo "  -h will show this help text and terminate"
   echo "  <testlist> select testlist file"
   echo ""
   exit 1
 }
 
 function enable_ccache {
-  export CCACHE_DIR="${tools}"/ccache
-}
-
-function setup_links {
-  mkdir -p "${tools}"/ccache/bin/
-  ln -sf "$(which ccache)" "${tools}"/ccache/bin/aarch64-none-elf-gcc
-  ln -sf "$(which ccache)" "${tools}"/ccache/bin/aarch64-none-elf-g++
-  ln -sf "$(which ccache)" "${tools}"/ccache/bin/arm-none-eabi-gcc
-  ln -sf "$(which ccache)" "${tools}"/ccache/bin/arm-none-eabi-g++
-  ln -sf "$(which ccache)" "${tools}"/ccache/bin/avr-gcc
-  ln -sf "$(which ccache)" "${tools}"/ccache/bin/avr-g++
-  ln -sf "$(which ccache)" "${tools}"/ccache/bin/cc
-  ln -sf "$(which ccache)" "${tools}"/ccache/bin/c++
-  ln -sf "$(which ccache)" "${tools}"/ccache/bin/clang
-  ln -sf "$(which ccache)" "${tools}"/ccache/bin/clang++
-  ln -sf "$(which ccache)" "${tools}"/ccache/bin/gcc
-  ln -sf "$(which ccache)" "${tools}"/ccache/bin/g++
-  ln -sf "$(which ccache)" "${tools}"/ccache/bin/p32-gcc
-  ln -sf "$(which ccache)" "${tools}"/ccache/bin/riscv64-unknown-elf-gcc
-  ln -sf "$(which ccache)" "${tools}"/ccache/bin/riscv64-unknown-elf-g++
-  ln -sf "$(which ccache)" "${tools}"/ccache/bin/sparc-gaisler-elf-gcc
-  ln -sf "$(which ccache)" "${tools}"/ccache/bin/sparc-gaisler-elf-g++
-  ln -sf "$(which ccache)" "${tools}"/ccache/bin/x86_64-elf-gcc
-  ln -sf "$(which ccache)" "${tools}"/ccache/bin/x86_64-elf-g++
-  ln -sf "$(which ccache)" "${tools}"/ccache/bin/xtensa-esp32-elf-gcc
+  export CCACHE_DIR="${CIWORKSPACE}"/tools/ccache
 }
 
 function setup_repos {
@@ -588,57 +129,13 @@ function setup_repos {
   popd
 }
 
-function install_tools {
-  mkdir -p "${tools}"
-
-case ${os} in
-  Darwin)
-    install="arm-gcc-toolchain arm64-gcc-toolchain avr-gcc-toolchain binutils bloaty elf-toolchain gen-romfs gperf kconfig-frontends mips-gcc-toolchain python-tools riscv-gcc-toolchain rust xtensa-esp32-gcc-toolchain u-boot-tools util-linux wasi-sdk c-cache"
-    mkdir -p "${tools}"/homebrew
-    export HOMEBREW_CACHE=${tools}/homebrew
-    # https://github.com/apache/arrow/issues/15025
-    rm -f /usr/local/bin/2to3* || :
-    rm -f /usr/local/bin/idle3* || :
-    rm -f /usr/local/bin/pydoc3* || :
-    rm -f /usr/local/bin/python3* || :
-    rm -f /usr/local/bin/python3-config || :
-    # same for openssl
-    rm -f /usr/local/bin/openssl || :
-    ;;
-  Linux)
-    install="arm-clang-toolchain arm-gcc-toolchain arm64-gcc-toolchain avr-gcc-toolchain binutils bloaty clang-tidy gen-romfs gperf kconfig-frontends mips-gcc-toolchain python-tools riscv-gcc-toolchain rust rx-gcc-toolchain sparc-gcc-toolchain xtensa-esp32-gcc-toolchain u-boot-tools util-linux wasi-sdk c-cache"
-    ;;
-  MSYS*)
-    install="arm-gcc-toolchain kconfig-frontends"
-    ;;
-esac
-
-  pushd .
-  for func in ${install}; do
-    ${func}
-  done
-  popd
-
-  if [ -d "${CCACHE_DIR}" ]; then
-    setup_links
-  fi
-  echo PATH="${EXTRA_PATH}"/"${PATH}" > "${tools}"/env.sh
-}
-
 function run_builds {
   local ncpus
-
-  case ${os} in
-    Darwin)
-      ncpus=$(sysctl -n hw.ncpu)
-      ;;
-    Linux)
-      ncpus=$(grep -c ^processor /proc/cpuinfo)
-      ;;
-    MSYS*)
-      ncpus=$(grep -c ^processor /proc/cpuinfo)
-      ;;
-  esac
+  if [ "X$osname" == "XDarwin" ]; then
+    ncpus=$(sysctl -n hw.ncpu)
+  else
+    ncpus=$(grep -c ^processor /proc/cpuinfo)
+  fi
 
   options+="-j ${ncpus}"
 
@@ -647,6 +144,7 @@ function run_builds {
   done
 
   if [ -d "${CCACHE_DIR}" ]; then
+    # Print a summary of configuration and statistics counters
     ccache -s
   fi
 }

--- a/tools/ci/platforms/darwin.sh
+++ b/tools/ci/platforms/darwin.sh
@@ -1,0 +1,358 @@
+#!/usr/bin/env sh
+############################################################################
+# tools/ci/platforms/darwin.sh
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+# Darwin
+# Prerequisites for macOS
+#  - Xcode (cc, etc)
+#  - homebrew
+#  - autoconf
+#  - wget
+
+set -e
+set -o xtrace
+
+add_path() {
+  PATH=$1:${PATH}
+}
+
+arm_gcc_toolchain() {
+  add_path "${NUTTXTOOLS}"/gcc-arm-none-eabi/bin
+
+  if [ ! -f "${NUTTXTOOLS}/gcc-arm-none-eabi/bin/arm-none-eabi-gcc" ]; then
+    local basefile
+    basefile=arm-gnu-toolchain-13.2.rel1-darwin-x86_64-arm-none-eabi
+    cd "${NUTTXTOOLS}"
+    wget --quiet https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/${basefile}.tar.xz
+    xz -d ${basefile}.tar.xz
+    tar xf ${basefile}.tar
+    mv ${basefile} gcc-arm-none-eabi
+    rm ${basefile}.tar
+  fi
+
+  command arm-none-eabi-gcc --version
+}
+
+arm64_gcc_toolchain() {
+  add_path "${NUTTXTOOLS}"/gcc-aarch64-none-elf/bin
+
+  if [ ! -f "${NUTTXTOOLS}/gcc-aarch64-none-elf/bin/aarch64-none-elf-gcc" ]; then
+    local basefile
+    basefile=arm-gnu-toolchain-13.2.Rel1-darwin-x86_64-aarch64-none-elf
+    cd "${NUTTXTOOLS}"
+    # Download the latest ARM64 GCC toolchain prebuilt by ARM
+    wget --quiet https://developer.arm.com/-/media/Files/downloads/gnu/13.2.Rel1/binrel/${basefile}.tar.xz
+    xz -d ${basefile}.tar.xz
+    tar xf ${basefile}.tar
+    mv ${basefile} gcc-aarch64-none-elf
+    rm ${basefile}.tar
+  fi
+
+  command aarch64-none-elf-gcc --version
+}
+
+avr_gcc_toolchain() {
+  if ! type avr-gcc > /dev/null 2>&1; then
+    brew tap osx-cross/avr
+    brew install avr-gcc
+  fi
+
+  command avr-gcc --version
+}
+
+binutils() {
+  mkdir -p "${NUTTXTOOLS}"/bintools/bin
+  add_path "${NUTTXTOOLS}"/bintools/bin
+
+  if ! type objcopy > /dev/null 2>&1; then
+    brew install binutils
+    # It is possible we cached prebuilt but did brew install so recreate
+    # symlink if it exists
+    rm -f "${NUTTXTOOLS}"/bintools/bin/objcopy
+    ln -s /usr/local/opt/binutils/bin/objcopy "${NUTTXTOOLS}"/bintools/bin/objcopy
+  fi
+
+  command objcopy --version
+}
+
+bloaty() {
+  add_path "${NUTTXTOOLS}"/bloaty/bin
+
+  if [ ! -f "${NUTTXTOOLS}/bloaty/bin/bloaty" ]; then
+    git clone --branch main https://github.com/google/bloaty "${NUTTXTOOLS}"/bloaty-src
+    cd "${NUTTXTOOLS}"/bloaty-src
+    # Due to issues with latest MacOS versions use pinned commit.
+    # https://github.com/google/bloaty/pull/326
+    git checkout 52948c107c8f81045e7f9223ec02706b19cfa882
+    mkdir -p "${NUTTXTOOLS}"/bloaty
+    cmake -D BLOATY_PREFER_SYSTEM_CAPSTONE=NO -DCMAKE_SYSTEM_PREFIX_PATH="${NUTTXTOOLS}"/bloaty
+    make install -j 4
+    cd "${NUTTXTOOLS}"
+    rm -rf bloaty-src
+  fi
+
+  command bloaty --version
+}
+
+c_cache() {
+  add_path "${NUTTXTOOLS}"/ccache/bin
+
+  if ! type ccache > /dev/null 2>&1; then
+    brew install ccache
+  fi
+  setup_links
+  command ccache --version
+}
+
+elf_toolchain() {
+  if ! type x86_64-elf-gcc > /dev/null 2>&1; then
+    brew install x86_64-elf-gcc
+  fi
+
+  command x86_64-elf-gcc --version
+}
+
+gen_romfs() {
+  if ! type genromfs > /dev/null 2>&1; then
+    brew tap PX4/px4
+    brew install genromfs
+  fi
+}
+
+gperf() {
+  add_path "${NUTTXTOOLS}"/gperf/bin
+
+  if [ ! -f "${NUTTXTOOLS}/gperf/bin/gperf" ]; then
+    local basefile
+    basefile=gperf-3.1
+
+    cd "${NUTTXTOOLS}"
+    wget --quiet http://ftp.gnu.org/pub/gnu/gperf/${basefile}.tar.gz
+    tar zxf ${basefile}.tar.gz
+    cd "${NUTTXTOOLS}"/${basefile}
+    ./configure --prefix="${NUTTXTOOLS}"/gperf; make; make install
+    cd "${NUTTXTOOLS}"
+    rm -rf ${basefile}; rm ${basefile}.tar.gz
+  fi
+
+  command gperf --version
+}
+
+kconfig_frontends() {
+  add_path "${NUTTXTOOLS}"/kconfig-frontends/bin
+
+  if [ ! -f "${NUTTXTOOLS}/kconfig-frontends/bin/kconfig-conf" ]; then
+    git clone https://bitbucket.org/nuttx/tools.git "${NUTTXTOOLS}"/nuttx-tools
+    cd "${NUTTXTOOLS}"/nuttx-tools/kconfig-frontends
+    ./configure --prefix="${NUTTXTOOLS}"/kconfig-frontends \
+      --disable-kconfig --disable-nconf --disable-qconf \
+      --disable-gconf --disable-mconf --disable-static \
+      --disable-shared --disable-L10n
+    # Avoid "aclocal/automake missing" errors
+    touch aclocal.m4 Makefile.in
+    make install
+    cd "${NUTTXTOOLS}"
+    rm -rf nuttx-tools
+  fi
+}
+
+mips_gcc_toolchain() {
+  add_path "${NUTTXTOOLS}"/pinguino-compilers/macosx/p32/bin
+
+  if [ ! -d "${NUTTXTOOLS}/pinguino-compilers" ]; then
+    cd "${NUTTXTOOLS}"
+    git clone https://github.com/PinguinoIDE/pinguino-compilers
+  fi
+
+  command mips-elf-gcc --version
+}
+
+python_tools() {
+  # Python User Env
+  export PIP_USER=yes
+  export PYTHONUSERBASE=${NUTTXTOOLS}/pylocal
+  echo "export PIP_USER=yes" >> "${NUTTXTOOLS}"/env.sh
+  echo "export PYTHONUSERBASE=${NUTTXTOOLS}/pylocal" >> "${NUTTXTOOLS}"/env.sh
+  add_path "${PYTHONUSERBASE}"/bin
+
+  # workaround for Cython issue
+  # https://github.com/yaml/pyyaml/pull/702#issuecomment-1638930830
+  pip3 install "Cython<3.0"
+  git clone https://github.com/yaml/pyyaml.git && \
+  cd pyyaml && \
+  git checkout release/5.4.1 && \
+  sed -i.bak 's/Cython/Cython<3.0/g' pyproject.toml && \
+  python setup.py sdist && \
+  pip3 install --pre dist/PyYAML-5.4.1.tar.gz
+  cd ..
+
+  pip3 install \
+    cmake-format \
+    CodeChecker \
+    cvt2utf \
+    cxxfilt \
+    esptool==4.5.1 \
+    imgtool==1.9.0 \
+    kconfiglib \
+    pexpect==4.8.0 \
+    pyelftools \
+    pyserial==3.5 \
+    pytest==6.2.5 \
+    pytest-json==0.4.0 \
+    pytest-ordering==0.6 \
+    pytest-repeat==0.9.1
+}
+
+riscv_gcc_toolchain() {
+  add_path "${NUTTXTOOLS}"/riscv-none-elf-gcc/bin
+
+  if [ ! -f "${NUTTXTOOLS}/riscv-none-elf-gcc/bin/riscv-none-elf-gcc" ]; then
+    local basefile
+    basefile=xpack-riscv-none-elf-gcc-13.2.0-2-darwin-x64
+    cd "${NUTTXTOOLS}"
+    # Download the latest RISCV GCC toolchain prebuilt by xPack
+    wget --quiet https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/${basefile}.tar.gz
+    tar zxf ${basefile}.tar.gz
+    mv xpack-riscv-none-elf-gcc-13.2.0-2 riscv-none-elf-gcc
+    rm ${basefile}.tar.gz
+  fi
+  command riscv-none-elf-gcc --version
+}
+
+rust() {
+  if ! type rustc > /dev/null 2>&1; then
+    brew install rust
+  fi
+
+  command rustc --version
+}
+
+xtensa_esp32_gcc_toolchain() {
+  add_path "${NUTTXTOOLS}"/xtensa-esp32-elf/bin
+
+  if [ ! -f "${NUTTXTOOLS}/xtensa-esp32-elf/bin/xtensa-esp32-elf-gcc" ]; then
+    local basefile
+    basefile=xtensa-esp32-elf-12.2.0_20230208-x86_64-apple-darwin
+    cd "${NUTTXTOOLS}"
+    wget --quiet https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/${basefile}.tar.xz
+    xz -d ${basefile}.tar.xz
+    tar xf ${basefile}.tar
+    rm ${basefile}.tar
+  fi
+
+  command xtensa-esp32-elf-gcc --version
+}
+
+u_boot_tools() {
+  if ! type mkimage > /dev/null 2>&1; then
+    brew install u-boot-tools
+  fi
+}
+
+util_linux() {
+  if ! type flock > /dev/null 2>&1; then
+    brew tap discoteq/discoteq
+    brew install flock
+  fi
+
+  command flock --version
+}
+
+wasi_sdk() {
+  add_path "${NUTTXTOOLS}"/wamrc
+
+  if [ ! -f "${NUTTXTOOLS}/wamrc/wasi-sdk/bin/clang" ]; then
+    local wasibasefile
+    local wasmbasefile
+    wasibasefile=wasi-sdk-19.0-macos
+    wasmbasefile=wamrc-1.1.2-x86_64-macos-latest
+    cd "${NUTTXTOOLS}"
+    mkdir wamrc
+    wget --quiet https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-19/${wasibasefile}.tar.gz
+    tar xzf ${wasibasefile}.tar.gz
+    mv wasi-sdk-19.0 wasi-sdk
+    rm ${wasibasefile}.tar.gz
+    cd wamrc
+    wget --quiet https://github.com/bytecodealliance/wasm-micro-runtime/releases/download/WAMR-1.1.2/${wasmbasefile}.tar.gz
+    tar xzf ${wasmbasefile}.tar.gz
+    rm ${wasmbasefile}.tar.gz
+  fi
+
+  export WASI_SDK_PATH="${NUTTXTOOLS}/wasi-sdk"
+  echo "export WASI_SDK_PATH=${NUTTXTOOLS}/wasi-sdk" >> "${NUTTXTOOLS}"/env.sh
+
+  command "${WASI_SDK_PATH}"/bin/clang --version
+  command wamrc --version
+}
+
+setup_links() {
+  # Configure ccache
+  mkdir -p "${NUTTXTOOLS}"/ccache/bin/
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/aarch64-none-elf-gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/aarch64-none-elf-g++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/arm-none-eabi-gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/arm-none-eabi-g++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/avr-gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/avr-g++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/cc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/c++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/clang
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/clang++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/g++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/p32-gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/riscv64-unknown-elf-gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/riscv64-unknown-elf-g++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/sparc-gaisler-elf-gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/sparc-gaisler-elf-g++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/x86_64-elf-gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/x86_64-elf-g++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/xtensa-esp32-elf-gcc
+}
+
+install_build_tools() {
+  mkdir -p "${NUTTXTOOLS}"
+  echo "#!/usr/bin/env sh" > "${NUTTXTOOLS}"/env.sh
+
+  install="arm_gcc_toolchain arm64_gcc_toolchain avr_gcc_toolchain binutils bloaty elf_toolchain gen_romfs gperf kconfig_frontends mips_gcc_toolchain python_tools riscv_gcc_toolchain rust xtensa_esp32_gcc_toolchain u_boot_tools util_linux wasi_sdk c_cache"
+
+  mkdir -p "${NUTTXTOOLS}"/homebrew
+  export HOMEBREW_CACHE=${NUTTXTOOLS}/homebrew
+  echo "export HOMEBREW_CACHE=${NUTTXTOOLS}/homebrew" >> "${NUTTXTOOLS}"/env.sh
+  # https://github.com/apache/arrow/issues/15025
+  rm -f /usr/local/bin/2to3* || :
+  rm -f /usr/local/bin/idle3* || :
+  rm -f /usr/local/bin/pydoc3* || :
+  rm -f /usr/local/bin/python3* || :
+  rm -f /usr/local/bin/python3-config || :
+  # same for openssl
+  rm -f /usr/local/bin/openssl || :
+
+  oldpath=$(cd . && pwd -P)
+  for func in ${install}; do
+    ${func}
+  done
+  cd "${oldpath}"
+
+  echo "PATH=${PATH}" >> "${NUTTXTOOLS}"/env.sh
+  echo "export PATH" >> "${NUTTXTOOLS}"/env.sh
+}
+
+install_build_tools

--- a/tools/ci/platforms/linux.sh
+++ b/tools/ci/platforms/linux.sh
@@ -1,0 +1,380 @@
+#!/usr/bin/env bash
+############################################################################
+# tools/ci/platforms/linux.sh
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+# Linux
+
+set -e
+set -o xtrace
+
+add_path() {
+  PATH=$1:${PATH}
+}
+
+arm_clang_toolchain() {
+  add_path "${NUTTXTOOLS}"/clang-arm-none-eabi/bin
+
+  if [ ! -f "${NUTTXTOOLS}/clang-arm-none-eabi/bin/clang" ]; then
+    local basefile
+    basefile=LLVMEmbeddedToolchainForArm-17.0.1-Linux-x86_64
+    cd "${NUTTXTOOLS}"
+    # Download the latest ARM clang toolchain prebuilt by ARM
+    curl -O -L -s https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/releases/download/release-17.0.1/${basefile}.tar.xz
+    xz -d ${basefile}.tar.xz
+    tar xf ${basefile}.tar
+    mv ${basefile} clang-arm-none-eabi
+    rm ${basefile}.tar
+  fi
+
+  command clang --version
+}
+
+arm_gcc_toolchain() {
+  add_path "${NUTTXTOOLS}"/gcc-arm-none-eabi/bin
+
+  if [ ! -f "${NUTTXTOOLS}/gcc-arm-none-eabi/bin/arm-none-eabi-gcc" ]; then
+    local basefile
+    basefile=arm-gnu-toolchain-13.2.Rel1-x86_64-arm-none-eabi
+    cd "${NUTTXTOOLS}"
+    # Download the latest ARM GCC toolchain prebuilt by ARM
+    wget --quiet https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/${basefile}.tar.xz
+    xz -d ${basefile}.tar.xz
+    tar xf ${basefile}.tar
+    mv ${basefile} gcc-arm-none-eabi
+    rm ${basefile}.tar
+  fi
+
+  command arm-none-eabi-gcc --version
+}
+
+arm64_gcc_toolchain() {
+  add_path "${NUTTXTOOLS}"/gcc-aarch64-none-elf/bin
+
+  if [ ! -f "${NUTTXTOOLS}/gcc-aarch64-none-elf/bin/aarch64-none-elf-gcc" ]; then
+    local basefile
+    basefile=arm-gnu-toolchain-13.2.Rel1-x86_64-aarch64-none-elf
+    cd "${NUTTXTOOLS}"
+    # Download the latest ARM64 GCC toolchain prebuilt by ARM
+    wget --quiet https://developer.arm.com/-/media/Files/downloads/gnu/13.2.Rel1/binrel/${basefile}.tar.xz
+    xz -d ${basefile}.tar.xz
+    tar xf ${basefile}.tar
+    mv ${basefile} gcc-aarch64-none-elf
+    rm ${basefile}.tar
+  fi
+
+  command aarch64-none-elf-gcc --version
+}
+
+bloaty() {
+  add_path "${NUTTXTOOLS}"/bloaty/bin
+
+  if [ ! -f "${NUTTXTOOLS}/bloaty/bin/bloaty" ]; then
+    git clone --depth 1 --branch v1.1 https://github.com/google/bloaty "${NUTTXTOOLS}"/bloaty-src
+    mkdir -p "${NUTTXTOOLS}"/bloaty
+    cd "${NUTTXTOOLS}"/bloaty-src
+    cmake -B build -DCMAKE_INSTALL_PREFIX="${NUTTXTOOLS}"/bloaty
+    cmake --build build
+    cmake --build build --target install
+    cd "${NUTTXTOOLS}"
+    rm -rf bloaty-src
+    ls -a "${NUTTXTOOLS}"/bloaty
+  fi
+
+  command bloaty --version
+}
+
+kconfig_frontends() {
+  add_path "${NUTTXTOOLS}"/kconfig-frontends/bin
+
+  if [ ! -f "${NUTTXTOOLS}/kconfig-frontends/bin/kconfig-conf" ]; then
+    git clone https://bitbucket.org/nuttx/tools.git "${NUTTXTOOLS}"/nuttx-tools
+    cd "${NUTTXTOOLS}"/nuttx-tools/kconfig-frontends
+    ./configure --prefix="${NUTTXTOOLS}"/kconfig-frontends \
+      --disable-kconfig --disable-nconf --disable-qconf \
+      --disable-gconf --disable-mconf --disable-static \
+      --disable-shared --disable-L10n
+    # Avoid "aclocal/automake missing" errors
+    touch aclocal.m4 Makefile.in
+    make install
+    cd "${NUTTXTOOLS}"
+    rm -rf nuttx-tools
+  fi
+}
+
+mips_gcc_toolchain() {
+  add_path "${NUTTXTOOLS}"/pinguino-compilers/p32/bin
+
+  if [ ! -d "${NUTTXTOOLS}/pinguino-compilers/p32/bin/p32-gcc" ]; then
+    local basefile
+    basefile=pinguino-linux64-p32
+    mkdir -p "${NUTTXTOOLS}"/pinguino-compilers
+    cd "${NUTTXTOOLS}"
+    # Download the latest pinguino toolchain prebuilt by 32bit
+    curl -O -L -s  https://github.com/PinguinoIDE/pinguino-compilers/releases/download/v20.10/${basefile}.zip
+    unzip -qo ${basefile}.zip
+    mv p32 "${NUTTXTOOLS}"/pinguino-compilers/p32
+    rm ${basefile}.zip
+  fi
+
+  command p32-gcc --version
+}
+
+python_tools() {
+
+  pip3 install \
+    cmake-format \
+    CodeChecker \
+    cvt2utf \
+    cxxfilt \
+    esptool \
+    imgtool \
+    kconfiglib \
+    pexpect==4.8.0 \
+    pyelftools \
+    pyserial==3.5 \
+    pytest==6.2.5 \
+    pytest-json==0.4.0 \
+    pytest-ordering==0.6 \
+    pytest-repeat==0.9.1
+}
+
+riscv_gcc_toolchain() {
+  add_path "${NUTTXTOOLS}"/riscv-none-elf-gcc/bin
+
+  if [ ! -f "${NUTTXTOOLS}/riscv-none-elf-gcc/bin/riscv-none-elf-gcc" ]; then
+    local basefile
+    basefile=xpack-riscv-none-elf-gcc-13.2.0-2-linux-x64
+    cd "${NUTTXTOOLS}"
+    # Download the latest RISCV GCC toolchain prebuilt by xPack
+    wget --quiet https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/${basefile}.tar.gz
+    tar zxf ${basefile}.tar.gz
+    mv xpack-riscv-none-elf-gcc-13.2.0-2 riscv-none-elf-gcc
+    rm ${basefile}.tar.gz
+  fi
+  command riscv-none-elf-gcc --version
+}
+
+rx_gcc_toolchain() {
+  add_path "${NUTTXTOOLS}"/renesas-toolchain/rx-elf-gcc/bin
+
+  if [ ! -f "${NUTTXTOOLS}/renesas-toolchain/rx-elf-gcc/bin/rx-elf-gcc" ]; then
+    # Download toolchain source code
+    # RX toolchain is built from source code. Once prebuilt RX toolchain is made available, the below code snippet can be removed.
+    local basefilebinutils
+    local basefilegcc
+    local basefilenewlib
+    basefilebinutils=binutils-2.36.1
+    basefilegcc=gcc-8.3.0
+    basefilenewlib=newlib-4.1.0
+
+    mkdir -p "${NUTTXTOOLS}"/renesas-tools/source
+    curl -L -s "https://llvm-gcc-renesas.com/downloads/d.php?f=rx/binutils/8.3.0.202305-gnurx/binutils-2.36.1.tar.gz" -o ${basefilebinutils}.tar.gz
+    tar zxf ${basefilebinutils}.tar.gz
+    mv ${basefilebinutils} "${NUTTXTOOLS}"/renesas-tools/source/binutils
+    rm ${basefilebinutils}.tar.gz
+
+    curl -L -s "https://llvm-gcc-renesas.com/downloads/d.php?f=rx/gcc/8.3.0.202305-gnurx/gcc-8.3.0.tar.gz" -o ${basefilegcc}.tar.gz
+    tar zxf ${basefilegcc}.tar.gz
+    mv ${basefilegcc} "${NUTTXTOOLS}"/renesas-tools/source/gcc
+    rm ${basefilegcc}.tar.gz
+
+    curl -L -s "https://llvm-gcc-renesas.com/downloads/d.php?f=rx/newlib/8.3.0.202305-gnurx/newlib-4.1.0.tar.gz" -o ${basefilenewlib}.tar.gz
+    tar zxf ${basefilenewlib}.tar.gz
+    mv ${basefilenewlib} "${NUTTXTOOLS}"/renesas-tools/source/newlib
+    rm ${basefilenewlib}.tar.gz
+
+    # Install binutils
+    cd "${NUTTXTOOLS}"/renesas-tools/source/binutils; chmod +x ./configure ./mkinstalldirs
+    mkdir -p "${NUTTXTOOLS}"/renesas-tools/build/binutils; cd "${NUTTXTOOLS}"/renesas-tools/build/binutils
+    "${NUTTXTOOLS}"/renesas-tools/source/binutils/configure --target=rx-elf --prefix="${NUTTXTOOLS}"/renesas-toolchain/rx-elf-gcc \
+        --disable-werror
+    make; make install
+
+    # Install gcc
+    cd "${NUTTXTOOLS}"/renesas-tools/source/gcc
+    chmod +x ./contrib/download_prerequisites ./configure ./move-if-change ./libgcc/mkheader.sh
+    ./contrib/download_prerequisites
+    sed -i '1s/^/@documentencoding ISO-8859-1\n/' ./gcc/doc/gcc.texi
+    sed -i 's/@tex/\n&/g' ./gcc/doc/gcc.texi && sed -i 's/@end tex/\n&/g' ./gcc/doc/gcc.texi
+    mkdir -p "${NUTTXTOOLS}"/renesas-tools/build/gcc; cd "${NUTTXTOOLS}"/renesas-tools/build/gcc
+    "${NUTTXTOOLS}"/renesas-tools/source/gcc/configure --target=rx-elf --prefix="${NUTTXTOOLS}"/renesas-toolchain/rx-elf-gcc \
+        --disable-shared --disable-multilib --disable-libssp --disable-libstdcxx-pch --disable-werror --enable-lto \
+        --enable-gold --with-pkgversion=GCC_Build_1.02 --with-newlib --enable-languages=c
+    make; make install
+
+    # Install newlib
+    cd "${NUTTXTOOLS}"/renesas-tools/source/newlib; chmod +x ./configure
+    mkdir -p "${NUTTXTOOLS}"/renesas-tools/build/newlib; cd "${NUTTXTOOLS}"/renesas-tools/build/newlib
+    "${NUTTXTOOLS}"/renesas-tools/source/newlib/configure --target=rx-elf --prefix="${NUTTXTOOLS}"/renesas-toolchain/rx-elf-gcc
+    make; make install
+    rm -rf "${NUTTXTOOLS}"/renesas-tools/
+  fi
+
+  command rx-elf-gcc --version
+}
+
+sparc_gcc_toolchain() {
+  add_path "${NUTTXTOOLS}"/sparc-gaisler-elf-gcc/bin
+
+  if [ ! -f "${NUTTXTOOLS}/sparc-gaisler-elf-gcc/bin/sparc-gaisler-elf-gcc" ]; then
+    local basefile
+    basefile=bcc-2.1.0-gcc-linux64
+    cd "${NUTTXTOOLS}"
+    # Download the SPARC GCC toolchain prebuilt by Gaisler
+    wget --quiet https://www.gaisler.com/anonftp/bcc2/bin/${basefile}.tar.xz
+    xz -d ${basefile}.tar.xz
+    tar xf ${basefile}.tar
+    mv bcc-2.1.0-gcc sparc-gaisler-elf-gcc
+    rm ${basefile}.tar
+  fi
+
+  command sparc-gaisler-elf-gcc --version
+}
+
+xtensa_esp32_gcc_toolchain() {
+  add_path "${NUTTXTOOLS}"/xtensa-esp32-elf/bin
+
+  if [ ! -f "${NUTTXTOOLS}/xtensa-esp32-elf/bin/xtensa-esp32-elf-gcc" ]; then
+    local basefile
+    basefile=xtensa-esp32-elf-12.2.0_20230208-x86_64-linux-gnu
+    cd "${NUTTXTOOLS}"
+    # Download the latest ESP32 GCC toolchain prebuilt by Espressif
+    wget --quiet https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/${basefile}.tar.xz
+    xz -d ${basefile}.tar.xz
+    tar xf ${basefile}.tar
+    rm ${basefile}.tar
+  fi
+
+  command xtensa-esp32-elf-gcc --version
+}
+
+xtensa_esp32s2_gcc_toolchain() {
+  add_path "${NUTTXTOOLS}"/xtensa-esp32s2-elf/bin
+
+  if [ ! -f "${NUTTXTOOLS}/xtensa-esp32s2-elf/bin/xtensa-esp32s2-elf-gcc" ]; then
+    local basefile
+    basefile=xtensa-esp32s2-elf-12.2.0_20230208-x86_64-linux-gnu
+    cd "${NUTTXTOOLS}"
+    # Download the latest ESP32 S2 GCC toolchain prebuilt by Espressif
+    wget --quiet https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/${basefile}.tar.xz
+    xz -d ${basefile}.tar.xz
+    tar xf ${basefile}.tar
+    rm ${basefile}.tar
+  fi
+
+  command xtensa-esp32s2-elf-gcc --version
+}
+
+xtensa_esp32s3_gcc_toolchain() {
+  add_path "${NUTTXTOOLS}"/xtensa-esp32s3-elf/bin
+
+  if [ ! -f "${NUTTXTOOLS}/xtensa-esp32s3-elf/bin/xtensa-esp32s3-elf-gcc" ]; then
+    local basefile
+    basefile=xtensa-esp32s3-elf-12.2.0_20230208-x86_64-linux-gnu
+    cd "${NUTTXTOOLS}"
+    # Download the latest ESP32 S3 GCC toolchain prebuilt by Espressif
+    wget --quiet https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/${basefile}.tar.xz
+    xz -d ${basefile}.tar.xz
+    tar xf ${basefile}.tar
+    rm ${basefile}.tar
+  fi
+
+  command xtensa-esp32s3-elf-gcc --version
+}
+
+wasi_sdk() {
+  add_path "${NUTTXTOOLS}"/wamrc
+
+  if [ ! -f "${NUTTXTOOLS}/wasi-sdk/bin/clang" ]; then
+    local wasibasefile
+    local wasmbasefile
+    wasibasefile=wasi-sdk-19.0-linux
+    wasmbasefile=wamrc-1.1.2-x86_64-ubuntu-20.04
+    cd "${NUTTXTOOLS}"
+    mkdir wamrc
+
+    # Download the latest WASI-enabled WebAssembly C/C++ toolchain prebuilt by WASM
+    wget --quiet https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-19/${wasibasefile}.tar.gz
+    tar xzf ${wasibasefile}.tar.gz
+    mv wasi-sdk-19.0 wasi-sdk
+    rm ${wasibasefile}.tar.gz
+    cd wamrc
+    # Download the latest "wamrc" AOT compiler prebuilt by WAMR
+    wget --quiet https://github.com/bytecodealliance/wasm-micro-runtime/releases/download/WAMR-1.1.2/${wasmbasefile}.tar.gz
+    tar xzf ${wasmbasefile}.tar.gz
+    rm ${wasmbasefile}.tar.gz
+
+  fi
+
+  export WASI_SDK_PATH="${NUTTXTOOLS}/wasi-sdk"
+  echo "export WASI_SDK_PATH=${NUTTXTOOLS}/wasi-sdk" >> "${NUTTXTOOLS}"/env.sh
+
+  command "${WASI_SDK_PATH}"/bin/clang --version
+  command wamrc --version
+}
+
+setup_links() {
+  # Configure ccache
+  mkdir -p "${NUTTXTOOLS}"/ccache/bin/
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/aarch64-none-elf-gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/aarch64-none-elf-g++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/arm-none-eabi-gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/arm-none-eabi-g++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/avr-gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/avr-g++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/cc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/c++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/clang
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/clang++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/g++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/p32-gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/rx-elf-gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/riscv-none-elf-gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/riscv-none-elf-g++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/sparc-gaisler-elf-gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/sparc-gaisler-elf-g++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/x86_64-elf-gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/x86_64-elf-g++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/xtensa-esp32-elf-gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/xtensa-esp32-elf-g++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/xtensa-esp32s2-elf-gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/xtensa-esp32s2-elf-g++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/xtensa-esp32s3-elf-gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/xtensa-esp32s3-elf-g++
+}
+
+install_build_tools() {
+  mkdir -p "${NUTTXTOOLS}"
+  echo "#!/usr/bin/env sh" > "${NUTTXTOOLS}"/env.sh
+
+  install="arm_clang_toolchain arm_gcc_toolchain arm64_gcc_toolchain bloaty kconfig_frontends mips_gcc_toolchain python_tools riscv_gcc_toolchain rx_gcc_toolchain sparc_gcc_toolchain xtensa_esp32_gcc_toolchain util_linux wasi_sdk"
+
+  oldpath=$(cd . && pwd -P)
+  for func in ${install}; do
+    ${func}
+  done
+  cd "${oldpath}"
+
+  echo "PATH=${PATH}" >> "${NUTTXTOOLS}"/env.sh
+  echo "export PATH" >> "${NUTTXTOOLS}"/env.sh
+}
+
+install_build_tools

--- a/tools/ci/platforms/msys2.sh
+++ b/tools/ci/platforms/msys2.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/env sh
+############################################################################
+# tools/ci/platforms/msys2.sh
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+# MSYS2
+
+set -e
+set -o xtrace
+
+add_path() {
+  PATH=$1:${PATH}
+}
+
+arm_clang_toolchain() {
+  add_path "${NUTTXTOOLS}"/clang-arm-none-eabi/bin
+
+  if [ ! -f "${NUTTXTOOLS}/clang-arm-none-eabi/bin/clang" ]; then
+    local basefile
+    basefile=LLVMEmbeddedToolchainForArm-17.0.1-Windows-x86_64
+    cd "${NUTTXTOOLS}"
+    # Download the latest ARM clang toolchain prebuilt by ARM
+    curl -O -L -s https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/releases/download/release-17.0.1/${basefile}.zip
+    unzip -qo ${basefile}.zip
+    mv ${basefile} clang-arm-none-eabi
+    rm ${basefile}.zip
+  fi
+
+  command clang --version
+}
+
+arm_gcc_toolchain() {
+  add_path "${NUTTXTOOLS}"/gcc-arm-none-eabi/bin
+
+  if [ ! -f "${NUTTXTOOLS}/gcc-arm-none-eabi/bin/arm-none-eabi-gcc" ]; then
+    local basefile
+    basefile=arm-gnu-toolchain-13.2.Rel1-mingw-w64-i686-arm-none-eabi
+    cd "${NUTTXTOOLS}"
+    wget --quiet https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/${basefile}.zip
+    unzip -qo ${basefile}.zip
+    mv ${basefile} gcc-arm-none-eabi
+    rm ${basefile}.zip
+  fi
+
+  command arm-none-eabi-gcc --version
+}
+
+arm64_gcc_toolchain() {
+  add_path "${NUTTXTOOLS}"/gcc-aarch64-none-elf/bin
+
+  if [ ! -f "${NUTTXTOOLS}/gcc-aarch64-none-elf/bin/aarch64-none-elf-gcc" ]; then
+    local basefile
+    basefile=arm-gnu-toolchain-13.2.rel1-mingw-w64-i686-aarch64-none-elf
+    cd "${NUTTXTOOLS}"
+    # Download the latest ARM64 GCC toolchain prebuilt by ARM
+    wget --quiet https://developer.arm.com/-/media/Files/downloads/gnu/13.2.Rel1/binrel/${basefile}.zip
+    unzip -qo ${basefile}.zip
+    mv ${basefile} gcc-aarch64-none-elf
+    rm ${basefile}.zip
+  fi
+
+  command aarch64-none-elf-gcc --version
+}
+
+c_cache() {
+  add_path "${NUTTXTOOLS}"/ccache/bin
+
+  if ! type ccache > /dev/null 2>&1; then
+    pacman -S --noconfirm --needed ccache
+  fi
+  setup_links
+  command ccache --version
+}
+
+esp_tool() {
+  add_path "${NUTTXTOOLS}"/esp-tool
+
+  if ! type esptool > /dev/null 2>&1; then
+    local basefile
+    basefile=esptool-v4.7.0-win64
+    cd "${NUTTXTOOLS}"
+    curl -O -L -s https://github.com/espressif/esptool/releases/download/v4.7.0/${basefile}.zip
+    unzip -qo ${basefile}.zip
+    mv esptool-win64 esp-tool
+    rm ${basefile}.zip
+  fi
+  command esptool version
+}
+
+gen_romfs() {
+  add_path "${NUTTXTOOLS}"/genromfs/usr/bin
+
+  if ! type genromfs > /dev/null 2>&1; then
+    git clone https://bitbucket.org/nuttx/tools.git "${NUTTXTOOLS}"/nuttx-tools
+    cd "${NUTTXTOOLS}"/nuttx-tools
+    tar zxf genromfs-0.5.2.tar.gz
+    cd genromfs-0.5.2
+    make install PREFIX="${NUTTXTOOLS}"/genromfs
+    cd "${NUTTXTOOLS}"
+    rm -rf nuttx-tools
+  fi
+}
+
+kconfig_frontends() {
+  add_path "${NUTTXTOOLS}"/kconfig-frontends/bin
+
+  if [ ! -f "${NUTTXTOOLS}/kconfig-frontends/bin/kconfig-conf" ]; then
+    git clone https://bitbucket.org/nuttx/tools.git "${NUTTXTOOLS}"/nuttx-tools
+    cd "${NUTTXTOOLS}"/nuttx-tools/kconfig-frontends
+    ./configure --prefix="${NUTTXTOOLS}"/kconfig-frontends \
+      --disable-kconfig --disable-nconf --disable-qconf \
+      --disable-gconf --disable-mconf --disable-static \
+      --disable-shared --disable-L10n
+    # Avoid "aclocal/automake missing" errors
+    touch aclocal.m4 Makefile.in
+    make install
+    cd "${NUTTXTOOLS}"
+    rm -rf nuttx-tools
+  fi
+}
+
+mips_gcc_toolchain() {
+  add_path "${NUTTXTOOLS}"/pinguino-compilers/windows64/p32/bin
+
+  if [ ! -d "${NUTTXTOOLS}/pinguino-compilers" ]; then
+    cd "${NUTTXTOOLS}"
+    git clone https://github.com/PinguinoIDE/pinguino-compilers
+  fi
+
+  command p32-gcc --version
+}
+
+riscv_gcc_toolchain() {
+  add_path "${NUTTXTOOLS}"/riscv-none-elf-gcc/bin
+
+  if [ ! -f "${NUTTXTOOLS}/riscv-none-elf-gcc/bin/riscv-none-elf-gcc" ]; then
+    local basefile
+    basefile=xpack-riscv-none-elf-gcc-13.2.0-2-win32-x64
+    cd "${NUTTXTOOLS}"
+    # Download the latest RISCV GCC toolchain prebuilt by xPack
+    wget --quiet https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/${basefile}.zip
+    unzip -qo ${basefile}.zip
+    mv xpack-riscv-none-elf-gcc-13.2.0-2 riscv-none-elf-gcc
+    rm ${basefile}.zip
+  fi
+  command riscv-none-elf-gcc --version
+}
+
+rust() {
+  add_path "${NUTTXTOOLS}"/rust/cargo/bin
+  # Configuring the PATH environment variable
+  export CARGO_HOME=${NUTTXTOOLS}/rust/cargo
+  export RUSTUP_HOME=${NUTTXTOOLS}/rust/rustup
+  echo "export CARGO_HOME=${NUTTXTOOLS}/rust/cargo" >> "${NUTTXTOOLS}"/env.sh
+  echo "export RUSTUP_HOME=${NUTTXTOOLS}/rust/rustup" >> "${NUTTXTOOLS}"/env.sh
+  if ! type rustc > /dev/null 2>&1; then
+    local basefile
+    basefile=x86_64-pc-windows-gnu
+    mkdir -p "${NUTTXTOOLS}"/rust
+    cd "${NUTTXTOOLS}"
+    # Download tool rustup-init.exe
+    curl -O -L -s https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-gnu/rustup-init.exe
+    # Install Rust target x86_64-pc-windows-gnu
+    ./rustup-init.exe -y --default-host ${basefile} --no-modify-path
+    # Install targets supported from NuttX
+    "$CARGO_HOME"/bin/rustup target add thumbv6m-none-eabi
+    "$CARGO_HOME"/bin/rustup target add thumbv7m-none-eabi
+    rm rustup-init.exe
+  fi
+  command rustc --version
+}
+
+sparc_gcc_toolchain() {
+  add_path "${NUTTXTOOLS}"/sparc-gaisler-elf-gcc/bin
+
+  if [ ! -f "${NUTTXTOOLS}/sparc-gaisler-elf-gcc/bin/sparc-gaisler-elf-gcc" ]; then
+    local basefile
+    basefile=bcc-2.1.0-gcc-mingw64
+    cd "${NUTTXTOOLS}"
+    # Download the SPARC GCC toolchain prebuilt by Gaisler
+    wget --quiet https://www.gaisler.com/anonftp/bcc2/bin/${basefile}.zip
+    unzip -qo ${basefile}.zip
+    mv bcc-2.1.0-gcc sparc-gaisler-elf-gcc
+    rm ${basefile}.zip
+  fi
+
+  command sparc-gaisler-elf-gcc --version
+}
+
+xtensa_esp32_gcc_toolchain() {
+  add_path "${NUTTXTOOLS}"/xtensa-esp32-elf/bin
+
+  if [ ! -f "${NUTTXTOOLS}/xtensa-esp32-elf/bin/xtensa-esp32-elf-gcc" ]; then
+    local basefile
+    basefile=xtensa-esp32-elf-12.2.0_20230208-x86_64-w64-mingw32
+    cd "${NUTTXTOOLS}"
+    # Download the latest ESP32 GCC toolchain prebuilt by Espressif
+    wget --quiet https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/${basefile}.zip
+    unzip -qo ${basefile}.zip
+    rm ${basefile}.zip
+  fi
+
+  command xtensa-esp32-elf-gcc --version
+}
+
+xtensa_esp32s2_gcc_toolchain() {
+  add_path "${NUTTXTOOLS}"/xtensa-esp32s2-elf/bin
+
+  if [ ! -f "${NUTTXTOOLS}/xtensa-esp32s2-elf/bin/xtensa-esp32s2-elf-gcc" ]; then
+    local basefile
+    basefile=xtensa-esp32s2-elf-12.2.0_20230208-x86_64-w64-mingw32
+    cd "${NUTTXTOOLS}"
+    # Download the latest ESP32 S2 GCC toolchain prebuilt by Espressif
+    wget --quiet https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/${basefile}.zip
+    unzip -qo ${basefile}.zip
+    rm ${basefile}.zip
+  fi
+
+  command xtensa-esp32s2-elf-gcc --version
+}
+
+xtensa_esp32s3_gcc_toolchain() {
+  add_path "${NUTTXTOOLS}"/xtensa-esp32s3-elf/bin
+
+  if [ ! -f "${NUTTXTOOLS}/xtensa-esp32s3-elf/bin/xtensa-esp32s3-elf-gcc" ]; then
+    local basefile
+    basefile=xtensa-esp32s3-elf-12.2.0_20230208-x86_64-w64-mingw32
+    cd "${NUTTXTOOLS}"
+    # Download the latest ESP32 S3 GCC toolchain prebuilt by Espressif
+    wget --quiet https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/${basefile}.zip
+    unzip -qo ${basefile}.zip
+    rm ${basefile}.zip
+  fi
+
+  command xtensa-esp32s3-elf-gcc --version
+}
+
+setup_links() {
+  # Configure ccache
+  mkdir -p "${NUTTXTOOLS}"/ccache/bin/
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/aarch64-none-elf-gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/aarch64-none-elf-g++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/arm-none-eabi-gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/arm-none-eabi-g++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/avr-gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/avr-g++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/cc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/c++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/clang
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/clang++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/g++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/p32-gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/riscv64-unknown-elf-gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/riscv64-unknown-elf-g++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/sparc-gaisler-elf-gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/sparc-gaisler-elf-g++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/x86_64-elf-gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/x86_64-elf-g++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/xtensa-esp32-elf-gcc
+}
+
+install_build_tools() {
+  mkdir -p "${NUTTXTOOLS}"
+  echo "#!/usr/bin/env sh" > "${NUTTXTOOLS}"/env.sh
+
+  install="arm_clang_toolchain arm_gcc_toolchain arm64_gcc_toolchain kconfig_frontends riscv_gcc_toolchain rust"
+
+  oldpath=$(cd . && pwd -P)
+  for func in ${install}; do
+    ${func}
+  done
+  cd "${oldpath}"
+
+  echo "PATH=${PATH}" >> "${NUTTXTOOLS}"/env.sh
+  echo "export PATH" >> "${NUTTXTOOLS}"/env.sh
+}
+
+install_build_tools

--- a/tools/ci/platforms/ubuntu.sh
+++ b/tools/ci/platforms/ubuntu.sh
@@ -1,0 +1,450 @@
+#!/usr/bin/env sh
+############################################################################
+# tools/ci/platforms/ubuntu.sh
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+# Ubuntu
+
+set -e
+set -o xtrace
+
+add_path() {
+  PATH=$1:${PATH}
+}
+
+arm_clang_toolchain() {
+  add_path "${NUTTXTOOLS}"/clang-arm-none-eabi/bin
+
+  if [ ! -f "${NUTTXTOOLS}/clang-arm-none-eabi/bin/clang" ]; then
+    local basefile
+    basefile=LLVMEmbeddedToolchainForArm-17.0.1-Linux-x86_64
+    cd "${NUTTXTOOLS}"
+    # Download the latest ARM clang toolchain prebuilt by ARM
+    curl -O -L -s https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/releases/download/release-17.0.1/${basefile}.tar.xz
+    xz -d ${basefile}.tar.xz
+    tar xf ${basefile}.tar
+    mv ${basefile} clang-arm-none-eabi
+    rm ${basefile}.tar
+  fi
+
+  command clang --version
+}
+
+arm_gcc_toolchain() {
+  add_path "${NUTTXTOOLS}"/gcc-arm-none-eabi/bin
+
+  if [ ! -f "${NUTTXTOOLS}/gcc-arm-none-eabi/bin/arm-none-eabi-gcc" ]; then
+    local basefile
+    basefile=arm-gnu-toolchain-13.2.Rel1-x86_64-arm-none-eabi
+    cd "${NUTTXTOOLS}"
+    # Download the latest ARM GCC toolchain prebuilt by ARM
+    wget --quiet https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/${basefile}.tar.xz
+    xz -d ${basefile}.tar.xz
+    tar xf ${basefile}.tar
+    mv ${basefile} gcc-arm-none-eabi
+    rm ${basefile}.tar
+  fi
+
+  command arm-none-eabi-gcc --version
+}
+
+arm64_gcc_toolchain() {
+  add_path "${NUTTXTOOLS}"/gcc-aarch64-none-elf/bin
+
+  if [ ! -f "${NUTTXTOOLS}/gcc-aarch64-none-elf/bin/aarch64-none-elf-gcc" ]; then
+    local basefile
+    basefile=arm-gnu-toolchain-13.2.Rel1-x86_64-aarch64-none-elf
+    cd "${NUTTXTOOLS}"
+    # Download the latest ARM64 GCC toolchain prebuilt by ARM
+    wget --quiet https://developer.arm.com/-/media/Files/downloads/gnu/13.2.Rel1/binrel/${basefile}.tar.xz
+    xz -d ${basefile}.tar.xz
+    tar xf ${basefile}.tar
+    mv ${basefile} gcc-aarch64-none-elf
+    rm ${basefile}.tar
+  fi
+
+  command aarch64-none-elf-gcc --version
+}
+
+avr_gcc_toolchain() {
+  if ! type avr-gcc > /dev/null 2>&1; then
+    sudo apt-get install -y binutils-avr gcc-avr avr-libc 
+  fi
+
+  command avr-gcc --version
+}
+
+binutils() {
+  if ! type objcopy > /dev/null 2>&1; then
+    sudo apt-get install -y binutils-dev
+  fi
+
+  command objcopy --version
+}
+
+bloaty() {
+  add_path "${NUTTXTOOLS}"/bloaty/bin
+
+  if [ ! -f "${NUTTXTOOLS}/bloaty/bin/bloaty" ]; then
+    git clone --depth 1 --branch v1.1 https://github.com/google/bloaty "${NUTTXTOOLS}"/bloaty-src
+    mkdir -p "${NUTTXTOOLS}"/bloaty
+    cd "${NUTTXTOOLS}"/bloaty-src
+    cmake -B build -DCMAKE_INSTALL_PREFIX="${NUTTXTOOLS}"/bloaty
+    cmake --build build
+    cmake --build build --target install
+    cd "${NUTTXTOOLS}"
+    rm -rf bloaty-src
+    ls -a "${NUTTXTOOLS}"/bloaty
+  fi
+
+  command bloaty --version
+}
+
+c_cache() {
+  if ! type ccache > /dev/null 2>&1; then
+    sudo apt-get install -y ccache
+  fi
+  setup_links
+  command ccache --version
+}
+
+clang_tidy() {
+  if ! type clang-tidy > /dev/null 2>&1; then
+    sudo apt-get install -y clang clang-tidy
+  fi
+
+  command clang-tidy --version
+}
+
+util_linux() {
+  if ! type flock > /dev/null 2>&1; then
+    sudo apt-get install -y util-linux
+  fi
+
+  command flock --version
+}
+
+gen_romfs() {
+  if ! type genromfs > /dev/null 2>&1; then
+    sudo apt-get install -y genromfs
+  fi
+}
+
+gperf() {
+ if ! type gperf > /dev/null 2>&1; then
+    sudo apt-get install -y gperf
+  fi
+
+}
+
+kconfig_frontends() {
+  add_path "${NUTTXTOOLS}"/kconfig-frontends/bin
+
+  if [ ! -f "${NUTTXTOOLS}/kconfig-frontends/bin/kconfig-conf" ]; then
+    git clone https://bitbucket.org/nuttx/tools.git "${NUTTXTOOLS}"/nuttx-tools
+    cd "${NUTTXTOOLS}"/nuttx-tools/kconfig-frontends
+    ./configure --prefix="${NUTTXTOOLS}"/kconfig-frontends \
+      --disable-kconfig --disable-nconf --disable-qconf \
+      --disable-gconf --disable-mconf --disable-static \
+      --disable-shared --disable-L10n
+    # Avoid "aclocal/automake missing" errors
+    touch aclocal.m4 Makefile.in
+    make install
+    cd "${NUTTXTOOLS}"
+    rm -rf nuttx-tools
+  fi
+}
+
+mips_gcc_toolchain() {
+  add_path "${NUTTXTOOLS}"/pinguino-compilers/p32/bin
+
+  if [ ! -d "${NUTTXTOOLS}/pinguino-compilers/p32/bin/p32-gcc" ]; then
+    local basefile
+    basefile=pinguino-linux64-p32
+    mkdir -p "${NUTTXTOOLS}"/pinguino-compilers
+    cd "${NUTTXTOOLS}"
+    # Download the latest pinguino toolchain prebuilt by 32bit
+    curl -O -L -s  https://github.com/PinguinoIDE/pinguino-compilers/releases/download/v20.10/${basefile}.zip
+    unzip -qo ${basefile}.zip
+    mv p32 "${NUTTXTOOLS}"/pinguino-compilers/p32
+    rm ${basefile}.zip
+  fi
+
+  command p32-gcc --version
+}
+
+python_tools() {
+
+  pip3 install \
+    cmake-format \
+    CodeChecker \
+    cvt2utf \
+    cxxfilt \
+    esptool \
+    imgtool \
+    kconfiglib \
+    pexpect==4.8.0 \
+    pyelftools \
+    pyserial==3.5 \
+    pytest==6.2.5 \
+    pytest-json==0.4.0 \
+    pytest-ordering==0.6 \
+    pytest-repeat==0.9.1
+}
+
+riscv_gcc_toolchain() {
+  add_path "${NUTTXTOOLS}"/riscv-none-elf-gcc/bin
+
+  if [ ! -f "${NUTTXTOOLS}/riscv-none-elf-gcc/bin/riscv-none-elf-gcc" ]; then
+    local basefile
+    basefile=xpack-riscv-none-elf-gcc-13.2.0-2-linux-x64
+    cd "${NUTTXTOOLS}"
+    # Download the latest RISCV GCC toolchain prebuilt by xPack
+    wget --quiet https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/${basefile}.tar.gz
+    tar zxf ${basefile}.tar.gz
+    mv xpack-riscv-none-elf-gcc-13.2.0-2 riscv-none-elf-gcc
+    rm ${basefile}.tar.gz
+  fi
+  command riscv-none-elf-gcc --version
+}
+
+rust() {
+  if ! type rustc > /dev/null 2>&1; then
+    sudo apt-get install rustc
+    # Install targets supported from NuttX
+    rustup target add thumbv6m-none-eabi
+    rustup target add thumbv7m-none-eabi
+  fi
+
+  command rustc --version
+}
+
+rx_gcc_toolchain() {
+  add_path "${NUTTXTOOLS}"/renesas-toolchain/rx-elf-gcc/bin
+
+  if [ ! -f "${NUTTXTOOLS}/renesas-toolchain/rx-elf-gcc/bin/rx-elf-gcc" ]; then
+    # Download toolchain source code
+    # RX toolchain is built from source code. Once prebuilt RX toolchain is made available, the below code snippet can be removed.
+    local basefilebinutils
+    local basefilegcc
+    local basefilenewlib
+    basefilebinutils=binutils-2.36.1
+    basefilegcc=gcc-8.3.0
+    basefilenewlib=newlib-4.1.0
+
+    mkdir -p "${NUTTXTOOLS}"/renesas-tools/source
+    curl -L -s "https://llvm-gcc-renesas.com/downloads/d.php?f=rx/binutils/8.3.0.202305-gnurx/binutils-2.36.1.tar.gz" -o ${basefilebinutils}.tar.gz
+    tar zxf ${basefilebinutils}.tar.gz
+    mv ${basefilebinutils} "${NUTTXTOOLS}"/renesas-tools/source/binutils
+    rm ${basefilebinutils}.tar.gz
+
+    curl -L -s "https://llvm-gcc-renesas.com/downloads/d.php?f=rx/gcc/8.3.0.202305-gnurx/gcc-8.3.0.tar.gz" -o ${basefilegcc}.tar.gz
+    tar zxf ${basefilegcc}.tar.gz
+    mv ${basefilegcc} "${NUTTXTOOLS}"/renesas-tools/source/gcc
+    rm ${basefilegcc}.tar.gz
+
+    curl -L -s "https://llvm-gcc-renesas.com/downloads/d.php?f=rx/newlib/8.3.0.202305-gnurx/newlib-4.1.0.tar.gz" -o ${basefilenewlib}.tar.gz
+    tar zxf ${basefilenewlib}.tar.gz
+    mv ${basefilenewlib} "${NUTTXTOOLS}"/renesas-tools/source/newlib
+    rm ${basefilenewlib}.tar.gz
+
+    # Install binutils
+    cd "${NUTTXTOOLS}"/renesas-tools/source/binutils; chmod +x ./configure ./mkinstalldirs
+    mkdir -p "${NUTTXTOOLS}"/renesas-tools/build/binutils; cd "${NUTTXTOOLS}"/renesas-tools/build/binutils
+    "${NUTTXTOOLS}"/renesas-tools/source/binutils/configure --target=rx-elf --prefix="${NUTTXTOOLS}"/renesas-toolchain/rx-elf-gcc \
+      --disable-werror
+    make; make install
+
+    # Install gcc
+    cd "${NUTTXTOOLS}"/renesas-tools/source/gcc
+    chmod +x ./contrib/download_prerequisites ./configure ./move-if-change ./libgcc/mkheader.sh
+    ./contrib/download_prerequisites
+    sed -i '1s/^/@documentencoding ISO-8859-1\n/' ./gcc/doc/gcc.texi
+    sed -i 's/@tex/\n&/g' ./gcc/doc/gcc.texi && sed -i 's/@end tex/\n&/g' ./gcc/doc/gcc.texi
+    mkdir -p "${NUTTXTOOLS}"/renesas-tools/build/gcc; cd "${NUTTXTOOLS}"/renesas-tools/build/gcc
+    "${NUTTXTOOLS}"/renesas-tools/source/gcc/configure --target=rx-elf --prefix="${NUTTXTOOLS}"/renesas-toolchain/rx-elf-gcc \
+      --disable-shared --disable-multilib --disable-libssp --disable-libstdcxx-pch --disable-werror --enable-lto \
+      --enable-gold --with-pkgversion=GCC_Build_1.02 --with-newlib --enable-languages=c
+    make; make install
+
+    # Install newlib
+    cd "${NUTTXTOOLS}"/renesas-tools/source/newlib; chmod +x ./configure
+    mkdir -p "${NUTTXTOOLS}"/renesas-tools/build/newlib; cd "${NUTTXTOOLS}"/renesas-tools/build/newlib
+    "${NUTTXTOOLS}"/renesas-tools/source/newlib/configure --target=rx-elf --prefix="${NUTTXTOOLS}"/renesas-toolchain/rx-elf-gcc
+    make; make install
+    rm -rf "${NUTTXTOOLS}"/renesas-tools/
+  fi
+
+  command rx-elf-gcc --version
+}
+
+sparc_gcc_toolchain() {
+  add_path "${NUTTXTOOLS}"/sparc-gaisler-elf-gcc/bin
+
+  if [ ! -f "${NUTTXTOOLS}/sparc-gaisler-elf-gcc/bin/sparc-gaisler-elf-gcc" ]; then
+    local basefile
+    basefile=bcc-2.1.0-gcc-linux64
+    cd "${NUTTXTOOLS}"
+    # Download the SPARC GCC toolchain prebuilt by Gaisler
+    wget --quiet https://www.gaisler.com/anonftp/bcc2/bin/${basefile}.tar.xz
+    xz -d ${basefile}.tar.xz
+    tar xf ${basefile}.tar
+    mv bcc-2.1.0-gcc sparc-gaisler-elf-gcc
+    rm ${basefile}.tar
+  fi
+
+  command sparc-gaisler-elf-gcc --version
+}
+
+xtensa_esp32_gcc_toolchain() {
+  add_path "${NUTTXTOOLS}"/xtensa-esp32-elf/bin
+
+  if [ ! -f "${NUTTXTOOLS}/xtensa-esp32-elf/bin/xtensa-esp32-elf-gcc" ]; then
+    local basefile
+    basefile=xtensa-esp32-elf-12.2.0_20230208-x86_64-linux-gnu
+    cd "${NUTTXTOOLS}"
+    # Download the latest ESP32 GCC toolchain prebuilt by Espressif
+    wget --quiet https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/${basefile}.tar.xz
+    xz -d ${basefile}.tar.xz
+    tar xf ${basefile}.tar
+    rm ${basefile}.tar
+  fi
+
+  command xtensa-esp32-elf-gcc --version
+}
+
+xtensa_esp32s2_gcc_toolchain() {
+  add_path "${NUTTXTOOLS}"/xtensa-esp32s2-elf/bin
+
+  if [ ! -f "${NUTTXTOOLS}/xtensa-esp32s2-elf/bin/xtensa-esp32s2-elf-gcc" ]; then
+    local basefile
+    basefile=xtensa-esp32s2-elf-12.2.0_20230208-x86_64-linux-gnu
+    cd "${NUTTXTOOLS}"
+    # Download the latest ESP32 S2 GCC toolchain prebuilt by Espressif
+    wget --quiet https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/${basefile}.tar.xz
+    xz -d ${basefile}.tar.xz
+    tar xf ${basefile}.tar
+    rm ${basefile}.tar
+  fi
+
+  command xtensa-esp32s2-elf-gcc --version
+}
+
+xtensa_esp32s3_gcc_toolchain() {
+  add_path "${NUTTXTOOLS}"/xtensa-esp32s3-elf/bin
+
+  if [ ! -f "${NUTTXTOOLS}/xtensa-esp32s3-elf/bin/xtensa-esp32s3-elf-gcc" ]; then
+    local basefile
+    basefile=xtensa-esp32s3-elf-12.2.0_20230208-x86_64-linux-gnu
+    cd "${NUTTXTOOLS}"
+    # Download the latest ESP32 S3 GCC toolchain prebuilt by Espressif
+    wget --quiet https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/${basefile}.tar.xz
+    xz -d ${basefile}.tar.xz
+    tar xf ${basefile}.tar
+    rm ${basefile}.tar
+  fi
+
+  command xtensa-esp32s3-elf-gcc --version
+}
+
+u_boot_tools() {
+  if ! type mkimage > /dev/null 2>&1; then
+    sudo apt-get install -y u-boot-tools
+  fi
+}
+
+wasi_sdk() {
+  add_path "${NUTTXTOOLS}"/wamrc
+
+  if [ ! -f "${NUTTXTOOLS}/wasi-sdk/bin/clang" ]; then
+    local wasibasefile
+    local wasmbasefile
+    wasibasefile=wasi-sdk-19.0-linux
+    wasmbasefile=wamrc-1.1.2-x86_64-ubuntu-20.04
+    cd "${NUTTXTOOLS}"
+    mkdir wamrc
+
+    # Download the latest WASI-enabled WebAssembly C/C++ toolchain prebuilt by WASM
+    wget --quiet https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-19/${wasibasefile}.tar.gz
+    tar xzf ${wasibasefile}.tar.gz
+    mv wasi-sdk-19.0 wasi-sdk
+    rm ${wasibasefile}.tar.gz
+    cd wamrc
+    # Download the latest "wamrc" AOT compiler prebuilt by WAMR
+    wget --quiet https://github.com/bytecodealliance/wasm-micro-runtime/releases/download/WAMR-1.1.2/${wasmbasefile}.tar.gz
+    tar xzf ${wasmbasefile}.tar.gz
+    rm ${wasmbasefile}.tar.gz
+
+  fi
+
+  export WASI_SDK_PATH="${NUTTXTOOLS}/wasi-sdk"
+  echo "export WASI_SDK_PATH=${NUTTXTOOLS}/wasi-sdk" >> "${NUTTXTOOLS}"/env.sh
+
+  command "${WASI_SDK_PATH}"/bin/clang --version
+  command wamrc --version
+}
+
+setup_links() {
+  # Configure ccache
+  mkdir -p "${NUTTXTOOLS}"/ccache/bin/
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/aarch64-none-elf-gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/aarch64-none-elf-g++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/arm-none-eabi-gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/arm-none-eabi-g++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/avr-gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/avr-g++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/cc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/c++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/clang
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/clang++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/g++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/p32-gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/rx-elf-gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/riscv-none-elf-gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/riscv-none-elf-g++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/sparc-gaisler-elf-gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/sparc-gaisler-elf-g++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/x86_64-elf-gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/x86_64-elf-g++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/xtensa-esp32-elf-gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/xtensa-esp32-elf-g++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/xtensa-esp32s2-elf-gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/xtensa-esp32s2-elf-g++
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/xtensa-esp32s3-elf-gcc
+  ln -sf "$(which ccache)" "${NUTTXTOOLS}"/ccache/bin/xtensa-esp32s3-elf-g++
+}
+
+install_build_tools() {
+  mkdir -p "${NUTTXTOOLS}"
+  echo "#!/usr/bin/env sh" > "${NUTTXTOOLS}"/env.sh
+
+  install="arm_clang_toolchain arm_gcc_toolchain arm64_gcc_toolchain avr_gcc_toolchain binutils bloaty clang_tidy gen_romfs gperf kconfig_frontends mips_gcc_toolchain python_tools riscv_gcc_toolchain rust rx_gcc_toolchain sparc_gcc_toolchain xtensa_esp32_gcc_toolchain u_boot_tools util_linux wasi_sdk c_cache"
+
+  oldpath=$(cd . && pwd -P)
+  for func in ${install}; do
+    ${func}
+  done
+  cd "${oldpath}"
+
+  echo "PATH=${PATH}" >> "${NUTTXTOOLS}"/env.sh
+  echo "export PATH" >> "${NUTTXTOOLS}"/env.sh
+}
+
+install_build_tools


### PR DESCRIPTION
## Summary
This is an idea for tweaking how we build on GitHub and test locally. This will make it easier to maintain and make it easier to develop on new platforms. 

The proposed solution is based on the following changes:

- **cibuild.sh** -> Only detect platforms.
- **platforms** ->  Added a folder with scripts for each platform (installing toolchains, tools, etc.). 
                               darwin.sh, msys2.sh, linux.sh (Without the package management commands) and ubuntu.sh
 
Why each distribution has different packages (apt, apk, dnf, pacman, pkg) and each distribution has different versions of programs and  their dependencies.

## Impact
There should be no impact.

## Testing
We tested on the local platform MSYS2 and GitHub
