### PR TITLE
fs/mount: add FS_RPMSGFS as cause of NODFS_SUPPORT

### DIFF
--- a/fs/mount/fs_mount.c
+++ b/fs/mount/fs_mount.c
@@ -68,7 +68,7 @@
     defined(CONFIG_FS_PROCFS) || defined(CONFIG_NFS) || \
     defined(CONFIG_FS_TMPFS) || defined(CONFIG_FS_USERFS) || \
     defined(CONFIG_FS_CROMFS) || defined(CONFIG_FS_UNIONFS) || \
-    defined(CONFIG_FS_HOSTFS)
+    defined(CONFIG_FS_HOSTFS) || defined(CONFIG_FS_RPMSGFS)
 #  define NODFS_SUPPORT
 #endif
 


### PR DESCRIPTION

## Summary

It seems that RPMSGFS is missed from the list that doesn't need block or MTD drivers. This attempts to add it.

## Impact

None

## Testing

Checked on CanMV230
