### PR TITLE
rpmsg/debug: add debug configs and macros

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -2230,6 +2230,38 @@ config DEBUG_PCI_INFO
 		Enable PCI driver informational output to SYSLOG.
 
 endif # DEBUG_PCI
+
+config DEBUG_RPMSG
+	bool "RPMSG Debug Features"
+	default n
+	depends on RPMSG
+	---help---
+		Enable RPMSG driver debug features.
+
+if DEBUG_RPMSG
+
+config DEBUG_RPMSG_ERROR
+	bool "RPMSG Error Output"
+	default n
+	depends on DEBUG_ERROR
+	---help---
+		Enable RPMSG driver error output to SYSLOG.
+
+config DEBUG_RPMSG_WARN
+	bool "RPMSG Warnings Output"
+	default n
+	depends on DEBUG_WARN
+	---help---
+		Enable RPMSG driver warning output to SYSLOG.
+
+config DEBUG_RPMSG_INFO
+	bool "RPMSG Informational Output"
+	default n
+	depends on DEBUG_INFO
+	---help---
+		Enable RPMSG driver informational output to SYSLOG.
+
+endif # DEBUG_RPMSG
 endif # DEBUG_FEATURES
 
 config ARCH_HAVE_STACKCHECK

--- a/include/debug.h
+++ b/include/debug.h
@@ -938,6 +938,24 @@
 #  define pciinfo     _none
 #endif
 
+#ifdef CONFIG_DEBUG_RPMSG_ERROR
+#  define rpmsgerr       _err
+#else
+#  define rpmsgerr      _none
+#endif
+
+#ifdef CONFIG_DEBUG_RPMSG_WARN
+#  define rpmsgwarn     _warn
+#else
+#  define rpmsgwarn     _none
+#endif
+
+#ifdef CONFIG_DEBUG_RPMSG_INFO
+#  define rpmsginfo     _info
+#else
+#  define rpmsginfo     _none
+#endif
+
 /* Buffer dumping macros do not depend on varargs */
 
 #ifdef CONFIG_DEBUG_ERROR


### PR DESCRIPTION
## Summary

This patch adds debug macros for RPTUN/RPMSG related debug logging.

## Impact

None

## Testing

CI checks
