### PR TITLE
xtensa/esp32s2: Fix esp32s2 wdt interrupt bug

### DIFF
--- a/arch/xtensa/src/esp32s2/esp32s2_wdt.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_wdt.c
@@ -852,6 +852,10 @@ static void wdt_enableint(struct esp32s2_wdt_dev_s *dev)
     }
   else if (IS_MWDT(dev))
     {
+      /* Level Interrupt */
+
+      wdt_modifyreg32(dev, MWDT_CONFIG0_OFFSET, 0, TIMG_WDT_LEVEL_INT_EN);
+
       wdt_modifyreg32(dev, MWDT_INT_ENA_REG_OFFSET, 0, TIMG_WDT_INT_ENA);
     }
   else
@@ -882,6 +886,10 @@ static void wdt_disableint(struct esp32s2_wdt_dev_s *dev)
     }
   else if (IS_MWDT(dev))
     {
+      /* Level Interrupt */
+
+      wdt_modifyreg32(dev, MWDT_CONFIG0_OFFSET, TIMG_WDT_LEVEL_INT_EN, 0);
+
       wdt_modifyreg32(dev, MWDT_INT_ENA_REG_OFFSET, TIMG_WDT_INT_ENA, 0);
     }
   else

--- a/arch/xtensa/src/esp32s2/hardware/esp32s2_tim.h
+++ b/arch/xtensa/src/esp32s2/hardware/esp32s2_tim.h
@@ -45,7 +45,7 @@
 #define MWDT_FEED_OFFSET                0x0060
 #define MWDT_WP_REG                     0x0064
 #define MWDT_INT_ENA_REG_OFFSET         0x0098
-#define MWDT_INT_CLR_REG_OFFSET         0x00a0
+#define MWDT_INT_CLR_REG_OFFSET         0x00a4
 
 /* The value that needs to be written to TIMG_WDT_WKEY to
  * write-enable the WDT registers.


### PR DESCRIPTION
## Summary
ESP32S2 MWDT interrrupt trigger bugfix

## Impact

Only ESP32S2

## Testing

`esp32s2-saola-1:watchdog` config with customized irq handler added wdog example. 
