### PR TITLE
rptun/rptun_initialize: add explicit initialization for variable

### DIFF
--- a/drivers/rptun/rptun.c
+++ b/drivers/rptun/rptun.c
@@ -849,7 +849,7 @@ int rptun_initialize(FAR struct rptun_dev_s *dev)
 {
   struct metal_init_params params = METAL_INIT_DEFAULTS;
   FAR struct rptun_priv_s *priv;
-  static bool onceinit;
+  static bool onceinit = false;
   FAR char *argv[3];
   char arg1[19];
   char name[32];


### PR DESCRIPTION
## Summary

This patch add explicit initialization for variable `onceinit` before use.

## Impact

RPTUN driver use cases, should be none as it is a minor improvement.

## Testing

Checked with CanMV230
