### PR TITLE
PoC: include APPDIR/Make.defs in all archs

### DIFF
--- a/arch/arm/src/Makefile
+++ b/arch/arm/src/Makefile
@@ -19,6 +19,8 @@
 ############################################################################
 
 include $(TOPDIR)/Make.defs
+-include $(APPDIR)/Make.defs
+
 include chip/Make.defs
 
 ifeq ($(CONFIG_ARCH_ARMV7A),y)          # ARMv7-A

--- a/arch/arm64/src/Makefile
+++ b/arch/arm64/src/Makefile
@@ -19,6 +19,8 @@
 ############################################################################
 
 include $(TOPDIR)/Make.defs
+-include $(APPDIR)/Make.defs
+
 include chip/Make.defs
 
 ARCH_SRCDIR = $(TOPDIR)$(DELIM)arch$(DELIM)$(CONFIG_ARCH)$(DELIM)src

--- a/arch/avr/src/Makefile
+++ b/arch/avr/src/Makefile
@@ -19,6 +19,8 @@
 ############################################################################
 
 include $(TOPDIR)/Make.defs
+-include $(APPDIR)/Make.defs
+
 include chip/Make.defs
 
 ifeq ($(CONFIG_ARCH_FAMILY_AVR32),y)

--- a/arch/ceva/src/Makefile
+++ b/arch/ceva/src/Makefile
@@ -19,6 +19,8 @@
 ############################################################################
 
 -include $(TOPDIR)/Make.defs
+-include $(APPDIR)/Make.defs
+
 -include chip$(DELIM)Make.defs
 
 ifeq ($(CONFIG_ARCH_XC5),y)

--- a/arch/hc/src/Makefile
+++ b/arch/hc/src/Makefile
@@ -19,6 +19,8 @@
 ############################################################################
 
 include $(TOPDIR)/Make.defs
+-include $(APPDIR)/Make.defs
+
 include chip/Make.defs
 
 ifeq ($(CONFIG_ARCH_HC12),y)

--- a/arch/mips/src/Makefile
+++ b/arch/mips/src/Makefile
@@ -19,6 +19,8 @@
 ############################################################################
 
 include $(TOPDIR)/Make.defs
+-include $(APPDIR)/Make.defs
+
 include chip/Make.defs
 
 ifeq ($(CONFIG_ARCH_MIPS),y)

--- a/arch/misoc/src/Makefile
+++ b/arch/misoc/src/Makefile
@@ -19,6 +19,8 @@
 ############################################################################
 
 include $(TOPDIR)/Make.defs
+-include $(APPDIR)/Make.defs
+
 include chip/Make.defs
 
 ifeq ($(CONFIG_ARCH_CHIP_LM32),y)

--- a/arch/or1k/src/Makefile
+++ b/arch/or1k/src/Makefile
@@ -19,6 +19,8 @@
 ############################################################################
 
 include $(TOPDIR)/Make.defs
+-include $(APPDIR)/Make.defs
+
 include chip/Make.defs
 
 ifeq ($(CONFIG_ARCH_MOR1KX),y)          # OpenRISC mor1kx

--- a/arch/renesas/src/Makefile
+++ b/arch/renesas/src/Makefile
@@ -19,6 +19,8 @@
 ############################################################################
 
 include $(TOPDIR)/Make.defs
+-include $(APPDIR)/Make.defs
+
 include chip/Make.defs
 
 ARCH_SRCDIR = $(TOPDIR)$(DELIM)arch$(DELIM)$(CONFIG_ARCH)$(DELIM)src

--- a/arch/risc-v/src/Makefile
+++ b/arch/risc-v/src/Makefile
@@ -19,6 +19,8 @@
 ############################################################################
 
 include $(TOPDIR)/Make.defs
+-include $(APPDIR)/Make.defs
+
 include chip/Make.defs
 ifeq ($(CONFIG_OPENSBI),y)
 include opensbi/Make.defs

--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -19,6 +19,8 @@
 ############################################################################
 
 -include $(TOPDIR)/Make.defs
+-include $(APPDIR)/Make.defs
+
 
 ARCH_SRCDIR = $(TOPDIR)$(DELIM)arch$(DELIM)$(CONFIG_ARCH)$(DELIM)src
 

--- a/arch/sparc/src/Makefile
+++ b/arch/sparc/src/Makefile
@@ -19,6 +19,8 @@
 ############################################################################
 
 -include $(TOPDIR)/Make.defs
+-include $(APPDIR)/Make.defs
+
 -include chip/Make.defs
 
 ARCH_SUBDIR = sparc_v8

--- a/arch/x86/src/Makefile
+++ b/arch/x86/src/Makefile
@@ -19,6 +19,8 @@
 ############################################################################
 
 include $(TOPDIR)/Make.defs
+-include $(APPDIR)/Make.defs
+
 include chip/Make.defs
 
 ifeq ($(CONFIG_ARCH_I486),y)

--- a/arch/x86_64/src/Makefile
+++ b/arch/x86_64/src/Makefile
@@ -19,6 +19,8 @@
 ############################################################################
 
 include $(TOPDIR)/Make.defs
+-include $(APPDIR)/Make.defs
+
 include chip/Make.defs
 
 ifeq ($(CONFIG_ARCH_INTEL64),y)

--- a/arch/xtensa/src/Makefile
+++ b/arch/xtensa/src/Makefile
@@ -19,6 +19,8 @@
 ############################################################################
 
 include $(TOPDIR)/Make.defs
+-include $(APPDIR)/Make.defs
+
 include chip/Make.defs
 
 ifeq ($(CONFIG_ARCH_FAMILY_LX6),y)

--- a/arch/z16/src/Makefile
+++ b/arch/z16/src/Makefile
@@ -19,6 +19,8 @@
 ############################################################################
 
 include $(TOPDIR)/Make.defs
+-include $(APPDIR)/Make.defs
+
 include chip/Make.defs
 
 COMPILER = ${shell basename "$(CC)"}

--- a/arch/z80/src/Makefile
+++ b/arch/z80/src/Makefile
@@ -21,6 +21,8 @@
 # Makefile fragments
 
 include $(TOPDIR)/Make.defs
+-include $(APPDIR)/Make.defs
+
 include chip/Make.defs
 
 # Compiler-Dependent Make:  SDCC, Clang, or ZiLOG ZDS-II


### PR DESCRIPTION
## Summary

This is a tentative alternative to https://github.com/apache/nuttx/pull/11202

This is a PoC of one of the potentically possible ways to let the applications customize build-time options of NuttX (in `Make.defs`). For example, the `libtest` example is adding some libs to `EXTRA_LIBS`, and this is not being set.

I tried different approaches to do this and it looks like this is the less invasive of doing it in the current build system that I could come up with.

Maybe this is not good enough to merge, we might still polish it to make it cleaner, however I just wanted to share the idea and get feedback from the devs. Please be nice! :)

If I come up with other solutions, I will open other draft PRs to get feedback.

## Impact

- Fixes https://github.com/apache/nuttx-apps/issues/2189
- Example apps can now tweak nuttx build-time variables

## Testing

Enable `libtest` example and the executable (`EXAMPLES_LIBTEST` and `EXAMPLES_LIBTEST_CMDTOOL`) and it works out of the box. I have tested for `esp32s3-devkit:nsh` and `sim:nsh`

We could also enable the `libtest` example by default in a config, so the CI will make sure this will keep working.


