### PR TITLE
risc-v/k230: revise k230 hart operations and kernel linker script.

### DIFF
--- a/arch/risc-v/src/k230/k230_hart.h
+++ b/arch/risc-v/src/k230/k230_hart.h
@@ -32,13 +32,11 @@
 #ifndef __ASSEMBLY__
 #if !defined(CONFIG_BUILD_KERNEL) || defined(CONFIG_NUTTSBI)
 
-void k230_hart_init(void);            /* M-mode initialization  */
-int  k230_hart_is_big(void);          /* check if on big core   */
-
-#endif /* !defined(CONFIG_BUILD_KERNEL) || defined(CONFIG_NUTTSBI) */
-
-void k230_hart_big_boot(uintptr_t boot);  /* turn on big core w/ boot addr */
+void k230_hart_init(void);                /* M-mode initialization */
+bool k230_hart_is_big(void);              /* true if on big core */
+void k230_hart_big_boot(uintptr_t addr);  /* turn on big core w/ boot addr */
 void k230_hart_big_stop(void);            /* turn off big core */
 
+#endif /* !defined(CONFIG_BUILD_KERNEL) || defined(CONFIG_NUTTSBI) */
 #endif /* __ASSEMBLY__ */
 #endif /* __ARCH_RISCV_SRC_K230_K230_HART_H */

--- a/boards/risc-v/k230/canmv230/scripts/ld-kernel.script
+++ b/boards/risc-v/k230/canmv230/scripts/ld-kernel.script
@@ -20,8 +20,8 @@
 
 MEMORY
 {
-    kflash (rx) : ORIGIN = 0x08200000, LENGTH = 2048K   /* w/ cache */
-    ksram (rwx) : ORIGIN = 0x08400000, LENGTH = 2048K   /* w/ cache */
+    kflash (rx) : ORIGIN = 0x08200000, LENGTH = 1024K   /* w/ cache */
+    ksram (rwx) : ORIGIN = 0x08300000, LENGTH = 1024K   /* w/ cache */
     pgram (rwx) : ORIGIN = 0x08600000, LENGTH =   10M   /* w/ cache */
 }
 


### PR DESCRIPTION
## Summary

This patch revises `k230_hart.[ch]` by:

  - revising big core boot and stop functions.
  - making k230_hart_is_big() available in S-mode.
  - adding more comments.

This patch also revises the `ld-kernel.script` so that to match the latest pgtable design.

## Impact

k230 based devices

## Testing

checked with CanMV230

