### PR TITLE
fixing typo error in quickstart compiling cmake doc

### DIFF
--- a/Documentation/quickstart/compiling_cmake.rst
+++ b/Documentation/quickstart/compiling_cmake.rst
@@ -45,10 +45,10 @@ We can now build NuttX. To do so, you can simply run:
   .. code-block:: console
 
      $ cd nuttx
-     $ cmake --build build -t menuconfig 
+     $ cmake --build build 
 
 The build will complete by generating the binary outputs
-inside ``build/nuttx`` directory. Typically this includes the ``nuttx``
+inside ``build/`` directory. Typically this includes the ``nuttx``
 ELF file (suitable for debugging using ``gdb``) and a ``nuttx.bin``
 file that can be flashed to the board.
 


### PR DESCRIPTION
I used
··
cd nuttx
cmake -B build -DBOARD_CONFIG=stm32f401rc-rs485:nsh -GNinja
··
to config
and when following the instruction in this official websites I found the command to use cmake to build the target is wrong.
which is "cmake --build build -t menuconfig" also wrong the output dir "build/nuttx".
and by the way, In my practice I find the bin file and elf file is not in build/nuttx but in build/. So I changed these. But I'm not 100% sure that my fix is right as I'm a beginner, but what I fix works fine in my computer. This is my first PR to the public doc. My fix maybe totally wrong as I am not get into the nuttx, just following the instruction and encountered some mistakes.
thx for reviewing

