### PR TITLE
citest/sim01: disable libcxxtest on macOS to unblock CI checks

### DIFF
--- a/tools/ci/testlist/sim-01.dat
+++ b/tools/ci/testlist/sim-01.dat
@@ -36,6 +36,9 @@
 # macOS matter compilation is not currently supported
 -Darwin,sim:matter
 
+# macOS has trouble with sim:libcxxtest
+-Darwin,sim:libcxxtest
+
 # Boards build by CMake
 CMake,sim:alsa
 CMake,sim:bluetooth


### PR DESCRIPTION
## Summary

This config failes CI check on `MacOS(sim-01)` in the past week. It blocks multiple PRs. This patch disables it tenatively so that to unblock PRs. 

The error looks like:

```
Error: /Applications/Xcode_15.0.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/mach/vm_page_size.h:59:44: error: expected ';' after top level declarator
```

This issue blocks #11684, #11691 and once blocked  #11673, #11681 etc.

## Impact

CI checks

## Testing

CI check
