### PR TITLE
Fix STM32xx PWM STOP in multichannel mode

### DIFF
--- a/arch/arm/src/stm32/stm32_pwm.c
+++ b/arch/arm/src/stm32/stm32_pwm.c
@@ -4463,6 +4463,13 @@ static int pwm_stop(struct pwm_lowerhalf_s *dev)
   outputs = pwm_outputs_from_channels(priv);
   ret = pwm_outputs_enable(dev, outputs, false);
 
+  /* Clear all channels */
+
+  pwm_putreg(priv, STM32_GTIM_CCR1_OFFSET, 0);
+  pwm_putreg(priv, STM32_GTIM_CCR2_OFFSET, 0);
+  pwm_putreg(priv, STM32_GTIM_CCR3_OFFSET, 0);
+  pwm_putreg(priv, STM32_GTIM_CCR4_OFFSET, 0);
+
   leave_critical_section(flags);
 
   pwm_dumpregs(dev, "After stop");

--- a/arch/arm/src/stm32f7/stm32_pwm.c
+++ b/arch/arm/src/stm32f7/stm32_pwm.c
@@ -4007,6 +4007,13 @@ static int pwm_stop(struct pwm_lowerhalf_s *dev)
   outputs = pwm_outputs_from_channels(priv);
   ret = pwm_outputs_enable(dev, outputs, false);
 
+  /* Clear all channels */
+
+  pwm_putreg(priv, STM32_GTIM_CCR1_OFFSET, 0);
+  pwm_putreg(priv, STM32_GTIM_CCR2_OFFSET, 0);
+  pwm_putreg(priv, STM32_GTIM_CCR3_OFFSET, 0);
+  pwm_putreg(priv, STM32_GTIM_CCR4_OFFSET, 0);
+
   leave_critical_section(flags);
 
   pwm_dumpregs(dev, "After stop");

--- a/arch/arm/src/stm32h7/stm32_pwm.c
+++ b/arch/arm/src/stm32h7/stm32_pwm.c
@@ -4227,6 +4227,14 @@ static int pwm_stop(struct pwm_lowerhalf_s *dev)
 
   regval &= ~resetbit;
   putreg32(regval, regaddr);
+
+  /* Clear all channels */
+
+  pwm_putreg(priv, STM32_GTIM_CCR1_OFFSET, 0);
+  pwm_putreg(priv, STM32_GTIM_CCR2_OFFSET, 0);
+  pwm_putreg(priv, STM32_GTIM_CCR3_OFFSET, 0);
+  pwm_putreg(priv, STM32_GTIM_CCR4_OFFSET, 0);
+
   leave_critical_section(flags);
 
   pwminfo("regaddr: %08" PRIx32 " resetbit: %08" PRIx32 "\n",


### PR DESCRIPTION
## Summary
Clear all PWM channel when STOP command is executed
    
I noticed when executing pwm STOP command in
multichannel mode, the channel still outputting.
    
This commit fixes this issue.
## Impact
Now the PWM will stop correctly
## Testing
stm32f4discovery
