### PR TITLE
rpmsg/ping: Replace UINT_MAX with CLOCK_MAX

### DIFF
--- a/drivers/rpmsg/rpmsg_ping.c
+++ b/drivers/rpmsg/rpmsg_ping.c
@@ -188,7 +188,7 @@ static void rpmsg_ping_logout_rate(uint64_t len, clock_t avg)
 int rpmsg_ping(FAR struct rpmsg_endpoint *ept,
                FAR const struct rpmsg_ping_s *ping)
 {
-  clock_t min = UINT_MAX;
+  clock_t min = CLOCK_MAX;
   clock_t max = 0;
   uint64_t total = 0;
   uint32_t buf_len = 0;


### PR DESCRIPTION
## Summary

since clock_t may map to either 32-bit or 64-bit integer type, UINT_MAX may not be the maximum value of clock_t.

## Impact

rpmsg ping

## Testing

ci