### PR TITLE
citest/sim01: fix sim:libcxxtest on macOS

### DIFF
--- a/libs/libxx/0001-libcxx-remove-mach-time-h.patch
+++ b/libs/libxx/0001-libcxx-remove-mach-time-h.patch
@@ -1,0 +1,13 @@
+--- libcxx/src/chrono.cpp
++++ libcxx/src/chrono.cpp
+@@ -48,10 +48,6 @@
+ #  include <zircon/syscalls.h>
+ #endif
+ 
+-#if __has_include(<mach/mach_time.h>)
+-# include <mach/mach_time.h>
+-#endif
+-
+ #if defined(__ELF__) && defined(_LIBCPP_LINK_RT_LIB)
+ #  pragma comment(lib, "rt")
+ #endif

--- a/libs/libxx/libcxx.cmake
+++ b/libs/libxx/libcxx.cmake
@@ -43,7 +43,9 @@ if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/libcxx)
       patch -p1 -d ${CMAKE_CURRENT_LIST_DIR}/libcxx <
       ${CMAKE_CURRENT_LIST_DIR}/0001_fix_stdatomic_h_miss_typedef.patch && patch
       -p3 -d ${CMAKE_CURRENT_LIST_DIR}/libcxx <
-      ${CMAKE_CURRENT_LIST_DIR}/mbstate_t.patch
+      ${CMAKE_CURRENT_LIST_DIR}/mbstate_t.patch && patch -p1 -d
+      ${CMAKE_CURRENT_LIST_DIR}/libcxx <
+      ${CMAKE_CURRENT_LIST_DIR}/0001-libcxx-remove-mach-time-h.patch
     DOWNLOAD_NO_PROGRESS true
     TIMEOUT 30)
 

--- a/libs/libxx/libcxx.defs
+++ b/libs/libxx/libcxx.defs
@@ -30,6 +30,7 @@ libcxx: libcxx-$(LIBCXX_VERSION).src.tar.xz
 	         --exclude libcxx-$(LIBCXX_VERSION).src/test/std/pstl
 	$(Q) mv libcxx-$(LIBCXX_VERSION).src libcxx
 	$(Q) patch -p2 < mbstate_t.patch
+	$(Q) patch -p0 < 0001-libcxx-remove-mach-time-h.patch
 	$(Q) touch $@
 endif
 

--- a/tools/ci/testlist/sim-01.dat
+++ b/tools/ci/testlist/sim-01.dat
@@ -36,9 +36,6 @@
 # macOS matter compilation is not currently supported
 -Darwin,sim:matter
 
-# macOS has trouble with sim:libcxxtest
--Darwin,sim:libcxxtest
-
 # Boards build by CMake
 CMake,sim:alsa
 CMake,sim:bluetooth


### PR DESCRIPTION
## Summary
Inclusion of `mach/mach_time.h` by `libcxx/src/chrono.cpp` breaks the build on latest MACOS dues to https://forums.developer.apple.com/forums/thread/746737. The interface from `mach/mach_time.h` is not referenced in `chrono.cpp` so it is safe to remove it

## Impact
Get back sim:libcxxtest to GitHub CI

## Testing
Pass CI