### PR TITLE
arch/nrf{52|53}/gpiote.c: fix event reconfiguration for a given pin

### DIFF
--- a/arch/arm/src/nrf52/nrf52_gpiote.c
+++ b/arch/arm/src/nrf52/nrf52_gpiote.c
@@ -53,8 +53,9 @@
 
 struct nrf52_gpiote_callback_s
 {
-  xcpt_t callback;
-  void  *arg;
+  xcpt_t    callback;
+  void     *arg;
+  uint32_t  pinset;
 };
 
 /****************************************************************************
@@ -462,12 +463,15 @@ int nrf52_gpiote_set_event(uint32_t pinset,
 
   flags = enter_critical_section();
 
-  /* Get free channel */
+  /* Get free channel or channel already used by pinset */
 
   for (i = 0; i < GPIOTE_CHANNELS; i++)
     {
-      if (g_gpiote_ch_callbacks[i].callback == NULL)
+      if (g_gpiote_ch_callbacks[i].callback == NULL ||
+          g_gpiote_ch_callbacks[i].pinset == pinset)
         {
+          g_gpiote_ch_callbacks[i].pinset = pinset;
+
           /* Configure channel */
 
           nrf52_gpiote_set_ch_event(pinset, i,

--- a/arch/arm/src/nrf53/nrf53_gpiote.c
+++ b/arch/arm/src/nrf53/nrf53_gpiote.c
@@ -59,8 +59,9 @@
 
 struct nrf53_gpiote_callback_s
 {
-  xcpt_t callback;
-  void  *arg;
+  xcpt_t    callback;
+  void     *arg;
+  uint32_t  pinset;
 };
 
 /****************************************************************************
@@ -501,13 +502,14 @@ int nrf53_gpiote_set_event(uint32_t pinset,
 
   flags = enter_critical_section();
 
-  /* Get free channel */
+  /* Get free channel or channel already used by pinset */
 
   for (i = 0; i < GPIOTE_CHANNELS; i++)
     {
-      if (g_gpiote_ch_callbacks[i].callback == NULL)
+      if (g_gpiote_ch_callbacks[i].callback == NULL ||
+          g_gpiote_ch_callbacks[i].pinset == pinset)
         {
-          /* Configure channel */
+          g_gpiote_ch_callbacks[i].pinset = pinset;
 
           nrf53_gpiote_set_ch_event(pinset, i,
                                     risingedge, fallingedge,


### PR DESCRIPTION
## Summary

- arch/nrf{52|53}/gpiote.c: fix event reconfiguration for a given pin
if a given pinset is already used, we need to update it, not add another event

## Impact

## Testing

