### PR TITLE
mrf24j40: add support for IEEE802154_ATTR_PHY_REGDUMP

### DIFF
--- a/drivers/wireless/ieee802154/mrf24j40/mrf24j40_radif.c
+++ b/drivers/wireless/ieee802154/mrf24j40/mrf24j40_radif.c
@@ -554,6 +554,12 @@ int mrf24j40_getattr(FAR struct ieee802154_radio_s *radio,
         }
         break;
 
+      case IEEE802154_ATTR_PHY_REGDUMP:
+        {
+          ret = mrf24j40_regdump(dev);
+        }
+        break;
+
       default:
         ret = IEEE802154_STATUS_UNSUPPORTED_ATTRIBUTE;
     }


### PR DESCRIPTION
## Summary
mrf24j40: add support for IEEE802154_ATTR_PHY_REGDUMP

## Impact

## Testing

