### PR TITLE
arch/arm/src/nrf{52|53|91}/xxx_rtc.h: include nuttx/irq.h

### DIFF
--- a/arch/arm/src/nrf52/nrf52_rtc.h
+++ b/arch/arm/src/nrf52/nrf52_rtc.h
@@ -27,6 +27,8 @@
 
 #include <nuttx/config.h>
 
+#include <nuttx/irq.h>
+
 #include <stdint.h>
 
 /****************************************************************************

--- a/arch/arm/src/nrf53/nrf53_rtc.h
+++ b/arch/arm/src/nrf53/nrf53_rtc.h
@@ -27,6 +27,8 @@
 
 #include <nuttx/config.h>
 
+#include <nuttx/irq.h>
+
 #include <stdint.h>
 
 /****************************************************************************

--- a/arch/arm/src/nrf91/nrf91_rtc.h
+++ b/arch/arm/src/nrf91/nrf91_rtc.h
@@ -27,6 +27,8 @@
 
 #include <nuttx/config.h>
 
+#include <nuttx/irq.h>
+
 #include <stdint.h>
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

- arch/arm/src/nrf{52|53|91}/xxx_rtc.h: include nuttx/irq.h
fixes undefined xcpt_t error that sometimes occurs
## Impact

## Testing

