### PR TITLE
toolchain/lto: enable lto flags only on GNU toolchain

### DIFF
--- a/libs/libc/assert/Make.defs
+++ b/libs/libc/assert/Make.defs
@@ -24,9 +24,11 @@ ifeq ($(CONFIG_STACK_CANARIES),y)
 CSRCS += lib_stackchk.c
 endif
 
-ifeq ($(CONFIG_LTO_NONE),n)
-assert/lib_assert.c_CFLAGS += -fno-lto
-assert/lib_stackchk.c_CFLAGS += -fno-lto
+ifeq ($(CONFIG_ARCH_TOOLCHAIN_GNU),y)
+  ifeq ($(CONFIG_LTO_NONE),n)
+    assert/lib_assert.c_CFLAGS += -fno-lto
+    assert/lib_stackchk.c_CFLAGS += -fno-lto
+  endif
 endif
 
 # Add the assert directory to the build

--- a/mm/kasan/Make.defs
+++ b/mm/kasan/Make.defs
@@ -24,8 +24,12 @@ CSRCS += kasan.c
 
 # Disable kernel-address in mm subsystem
 
-CFLAGS += -fno-sanitize=kernel-address
-CFLAGS += -fno-lto
+ifeq ($(CONFIG_ARCH_TOOLCHAIN_GNU),y)
+  CFLAGS += -fno-sanitize=kernel-address
+  ifeq ($(CONFIG_LTO_NONE),n)
+    CFLAGS += -fno-lto
+  endif
+endif
 
 # Add the core heap directory to the build
 


### PR DESCRIPTION
## Summary

toolchain/lto: enable lto flags only on GNU toolchain

Some commercial customized toolchains do not support these options

Signed-off-by: chao an <anchao@lixiang.com>

## Impact

N/A

## Testing

Tasking toolchain