### PR TITLE
toolchain/tasking: add dependencies rules for tasking compiler 

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -263,6 +263,10 @@ config ARCH_TOOLCHAIN_CLANG
 	select ARCH_TOOLCHAIN_GNU
 	default n
 
+config ARCH_TOOLCHAIN_TASKING
+	bool
+	default n
+
 choice
 	prompt "Link Time Optimization (LTO)"
 	default LTO_NONE

--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -944,6 +944,85 @@
 
 #  define no_builtin(n)
 
+/* TASKING (Infineon AURIX C/C++)-specific definitions **********************/
+
+#elif defined(__TASKING__)
+
+/* Define these here and allow specific architectures to override as needed */
+
+#  define CONFIG_HAVE_LONG_LONG         1
+#  define CONFIG_HAVE_FLOAT             1
+#  define CONFIG_HAVE_DOUBLE            1
+#  define CONFIG_HAVE_LONG_DOUBLE       1
+
+/* Pre-processor */
+
+#  define CONFIG_CPP_HAVE_VARARGS       1 /* Supports variable argument macros */
+
+/* Intriniscs */
+
+#  define CONFIG_HAVE_FUNCTIONNAME      1 /* Has __FUNCTION__ */
+#  define CONFIG_HAVE_FILENAME          1 /* Has __FILE__ */
+
+#  undef  CONFIG_CPP_HAVE_WARNING
+#  undef  CONFIG_HAVE_WEAKFUNCTIONS
+#  define weak_alias(name, aliasname)
+#  define weak_data                     __attribute__((weak))
+#  define weak_function                 __attribute__((weak))
+#  define weak_const_function           __attribute__((weak, __const__))
+#  define restrict
+#  define noreturn_function
+#  define farcall_function              __attribute__((long_call))
+#  define predict_true(x) (x)
+#  define predict_false(x) (x)
+#  define aligned_data(n)               __attribute__((aligned(n)))
+#  define locate_code(n)                __attribute__((section(n)))
+#  define locate_data(n)                __attribute__((section(n)))
+#  define begin_packed_struct
+#  define end_packed_struct             __attribute__((packed))
+#  define reentrant_function
+#  define naked_function
+#  define always_inline_function        __attribute__((always_inline))
+#  define noinline_function             __attribute__((noinline))
+#  define noinstrument_function
+#  define nooptimiziation_function      __attribute__((optimize(0)))
+#  define nosanitize_address
+#  define nosanitize_undefined
+#  define nostackprotect_function
+#  define unused_code                   __attribute__((unused))
+#  define unused_data                   __attribute__((unused))
+#  define used_code                     __attribute__((used))
+#  define used_data                     __attribute__((used))
+#  define fopen_like
+#  define popen_like
+#  define malloc_like
+#  define malloc_like1(a)
+#  define malloc_like2(a, b)
+#  define realloc_like(a)
+#  define format_like(a)
+#  define printf_like(a, b)
+#  define syslog_like(a, b)
+#  define scanf_like(a, b)
+#  define strftime_like(a)
+
+#  define FAR
+#  define NEAR
+#  define DSEG
+#  define CODE
+#  define IOBJ
+#  define IPTR
+
+#  undef  CONFIG_SMALL_MEMORY
+#  undef  CONFIG_LONG_IS_NOT_INT
+#  undef  CONFIG_PTR_IS_NOT_INT
+
+#  define UNUSED(a) ((void)(1 || &(a)))
+
+#  define offsetof(a, b) ((size_t)(&(((a *)(0))->b)))
+#  define return_address(x) 0
+
+#  define no_builtin(n)
+
 /* Unknown compiler *********************************************************/
 
 #else

--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -578,6 +578,11 @@ ifeq ($(CONFIG_STACK_USAGE),y)
 	EXTRA += *.su
 endif
 
+ifeq ($(CONFIG_ARCH_TOOLCHAIN_TASKING),y)
+	EXTRA += *.d
+	EXTRA += *.src
+endif
+
 ifeq ($(CONFIG_WINDOWS_NATIVE),y)
 define CLEAN
 	$(Q) if exist *$(OBJEXT) (del /f /q *$(OBJEXT))

--- a/tools/incdir.c
+++ b/tools/incdir.c
@@ -67,7 +67,8 @@ enum compiler_e
   COMPILER_CLANG,
   COMPILER_MINGW,
   COMPILER_SDCC,
-  COMPILER_ZDSII
+  COMPILER_ZDSII,
+  COMPILER_TASKING
 };
 
 /****************************************************************************
@@ -199,6 +200,10 @@ static enum compiler_e get_compiler(char *ccname)
            strstr(ccname, "ez80cc") != NULL)
     {
       return COMPILER_ZDSII;
+    }
+  else if (strstr(ccname, "ctc") != NULL)
+    {
+      return COMPILER_TASKING;
     }
   else
     {
@@ -347,7 +352,7 @@ int main(int argc, char **argv, char **envp)
       wintool = true;
 #endif
     }
-  else if (compiler == COMPILER_SDCC)
+  else if (compiler == COMPILER_SDCC || compiler == COMPILER_TASKING)
     {
       cmdarg = "-I";
     }

--- a/tools/mkdeps.c
+++ b/tools/mkdeps.c
@@ -81,12 +81,12 @@
  * Private Types
  ****************************************************************************/
 
-enum slashmode_e
+typedef enum
 {
-  MODE_FSLASH  = 0,
-  MODE_BSLASH  = 1,
-  MODE_DBLBACK = 2
-};
+  COMPILER_GNU      = 0,
+  COMPILER_TASKING  = 1,
+  COMPILER_NUM      = 2
+} compiler_t;
 
 /****************************************************************************
  * Private Data
@@ -115,9 +115,36 @@ static char g_posixpath[MAX_PATH];
 static char g_shquote[MAX_SHQUOTE];
 #endif
 
+static const char * const g_moptions[COMPILER_NUM][2] =
+{
+  /* GNU C/C++ Compiler */
+
+  {
+    " -M ",
+    " -MT "
+  },
+
+  /* Tasking C/C++ Compiler */
+
+  {
+    " -Em ",
+    " --pass-c=--make-target="
+  }
+};
+
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
+
+static compiler_t get_compiler(char *ccname)
+{
+  if (strstr(ccname, "ctc") != NULL)
+    {
+      return COMPILER_TASKING;
+    }
+
+  return COMPILER_GNU;
+}
 
 /* MinGW does not seem to provide strtok_r */
 
@@ -684,7 +711,7 @@ static const char *convert_path(const char *path)
 
 static void do_dependency(const char *file)
 {
-  static const char moption[] = " -M ";
+  const char * const * moption;
   struct stat buf;
   char *alloc;
   char *altpath;
@@ -704,6 +731,8 @@ static void do_dependency(const char *file)
 #else
   separator =  g_winnative ? '\\' : '/';
 #endif
+
+  moption = g_moptions[get_compiler(g_cc)];
 
   /* Copy the compiler into the command buffer */
 
@@ -741,15 +770,15 @@ static void do_dependency(const char *file)
           *dotptr = '\0';
         }
 
-      snprintf(tmp, NAME_MAX + 6, " -MT %s%c%s%s ",
-               g_objpath, separator, objname, g_suffix);
+      snprintf(tmp, NAME_MAX + 6, "%s%s%c%s%s ",
+               moption[1], g_objpath, separator, objname, g_suffix);
       expanded = do_expand(tmp);
 
       cmdlen += strlen(expanded);
       if (cmdlen >= MAX_BUFFER)
         {
           fprintf(stderr, "ERROR: Option string is too long [%d/%d]: %s\n",
-                  cmdlen, MAX_BUFFER, moption);
+                  cmdlen, MAX_BUFFER, moption[0]);
           exit(EXIT_FAILURE);
         }
 
@@ -759,15 +788,15 @@ static void do_dependency(const char *file)
 
   /* Copy " -M " */
 
-  cmdlen += strlen(moption);
+  cmdlen += strlen(moption[0]);
   if (cmdlen >= MAX_BUFFER)
     {
       fprintf(stderr, "ERROR: Option string is too long [%d/%d]: %s\n",
-              cmdlen, MAX_BUFFER, moption);
+              cmdlen, MAX_BUFFER, moption[0]);
       exit(EXIT_FAILURE);
     }
 
-  strcat(g_command, moption);
+  strcat(g_command, moption[0]);
 
   /* Copy the CFLAGS into the command buffer */
 


### PR DESCRIPTION
## Summary

toolchain/tasking: add dependencies rules for tasking compiler

Tasking compiler uses customized compilation options for generating dependencies files

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

Tasking