### PR TITLE
x86/x86_64: move common toolchain options to Toolchain.defs

### DIFF
--- a/arch/x86_64/src/common/Toolchain.defs
+++ b/arch/x86_64/src/common/Toolchain.defs
@@ -1,0 +1,63 @@
+############################################################################
+# arch/x86_64/src/common/Toolchain.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifeq ($(CONFIG_DEBUG_SYMBOLS),y)
+  ARCHOPTIMIZATION = -g
+endif
+
+ifneq ($(CONFIG_DEBUG_NOOPT),y)
+  ARCHOPTIMIZATION += -O2 -fno-optimize-sibling-calls
+  ARCHOPTIMIZATION += -fno-omit-frame-pointer -fno-crossjumping
+  ARCHOPTIMIZATION += -fno-delete-null-pointer-checks
+endif
+
+ARCHCPUFLAGS = -fPIC -fno-stack-protector -mno-red-zone -mrdrnd
+ARCHPICFLAGS = -fPIC
+ARCHWARNINGS = -Wall -Wstrict-prototypes -Wshadow -Wundef
+
+# We have to use a cross-development toolchain under Cygwin because the native
+# Cygwin toolchains don't generate ELF binaries.
+
+ifeq ($(CONFIG_WINDOWS_CYGWIN),y)
+CROSSDEV = i486-nuttx-elf-
+endif
+
+ifeq ($(CONFIG_HOST_MACOS),y)
+CROSSDEV = x86_64-elf-
+endif
+
+CC = $(CROSSDEV)gcc
+CPP = $(CROSSDEV)gcc -E -x c
+LD = $(CROSSDEV)ld
+STRIP = $(CROSSDEV)strip --strip-unneeded
+AR = $(CROSSDEV)ar rcs
+NM = $(CROSSDEV)nm
+OBJCOPY = $(CROSSDEV)objcopy
+OBJDUMP = $(CROSSDEV)objdump
+
+CFLAGS := $(ARCHWARNINGS) $(ARCHOPTIMIZATION) $(ARCHCPUFLAGS) $(ARCHINCLUDES) $(ARCHDEFINES) $(EXTRAFLAGS) -pipe
+CPPFLAGS := $(ARCHINCLUDES) $(ARCHDEFINES) $(EXTRAFLAGS)
+AFLAGS := $(CFLAGS) -D__ASSEMBLY__
+
+ifeq ($(CONFIG_HOST_MACOS),y)
+AFLAGS += -Wa,--divide
+endif
+
+EXEEXT = .elf

--- a/arch/x86_64/src/common/x86_64_initialize.c
+++ b/arch/x86_64/src/common/x86_64_initialize.c
@@ -117,7 +117,9 @@ void up_initialize(void)
 
   /* Initialize the network */
 
+#ifndef CONFIG_NETDEV_LATEINIT
   x86_64_netinitialize();
+#endif
 
   /* Initialize USB -- device and/or host */
 

--- a/arch/x86_64/src/common/x86_64_internal.h
+++ b/arch/x86_64/src/common/x86_64_internal.h
@@ -221,7 +221,7 @@ void x86_64_timer_initialize(void);
 
 /* Defined in board/x86_64_network.c */
 
-#ifdef CONFIG_NET
+#if defined(CONFIG_NET) && !defined(CONFIG_NETDEV_LATEINIT)
 void x86_64_netinitialize(void);
 #else
 #  define x86_64_netinitialize()

--- a/arch/x86_64/src/intel64/Toolchain.defs
+++ b/arch/x86_64/src/intel64/Toolchain.defs
@@ -1,5 +1,5 @@
 ############################################################################
-# boards/x86_64/intel64/qemu-intel64/scripts/Make.defs
+# arch/x86_64/src/intel64/Toolchain.defs
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -18,8 +18,4 @@
 #
 ############################################################################
 
-include $(TOPDIR)/.config
-include $(TOPDIR)/tools/Config.mk
-include $(TOPDIR)/arch/x86_64/src/intel64/Toolchain.defs
-
-ARCHSCRIPT += $(BOARD_DIR)$(DELIM)scripts$(DELIM)qemu.ld
+include $(TOPDIR)/arch/x86_64/src/common/Toolchain.defs

--- a/boards/x86_64/intel64/qemu-intel64/src/qemu_net.c
+++ b/boards/x86_64/intel64/qemu-intel64/src/qemu_net.c
@@ -49,7 +49,7 @@
  *
  ****************************************************************************/
 
-#ifdef CONFIG_NET
+#if defined(CONFIG_NET) && !defined(CONFIG_NETDEV_LATEINIT)
 void x86_64_netinitialize(void)
 {
 }


### PR DESCRIPTION
## Summary
Commit 1:
Support config CONFIG_NETDEV_LATEINIT FOR X64_64

Commit 2:
intel64: move toolchain releated option to Toolchain.defs

## Impact
Only code refactor, should be none

## Testing
qemu-intel64:nsh
