### PR TITLE
virtio: move metal_init to the virtio_register_drivers()

### DIFF
--- a/drivers/virtio/virtio-mmio.c
+++ b/drivers/virtio/virtio-mmio.c
@@ -819,22 +819,10 @@ static int virtio_mmio_init_device(FAR struct virtio_mmio_device_s *vmdev,
 
 int virtio_register_mmio_device(FAR void *regs, int irq)
 {
-  struct metal_init_params params = METAL_INIT_DEFAULTS;
   FAR struct virtio_mmio_device_s *vmdev;
-  static bool onceinit;
   int ret;
 
   DEBUGASSERT(regs != NULL);
-
-  if (onceinit == false)
-    {
-      onceinit = true;
-      ret = metal_init(&params);
-      if (ret < 0)
-        {
-          return ret;
-        }
-    }
 
   vmdev = kmm_zalloc(sizeof(*vmdev));
   if (vmdev == NULL)

--- a/drivers/virtio/virtio.c
+++ b/drivers/virtio/virtio.c
@@ -119,7 +119,14 @@ void virtio_free_buf(FAR struct virtio_device *vdev, FAR void *buf)
 
 void virtio_register_drivers(void)
 {
+  struct metal_init_params params = METAL_INIT_DEFAULTS;
   int ret = OK;
+
+  ret = metal_init(&params);
+  if (ret < 0)
+    {
+      vrterr("metal_init failed, ret=%d\n", ret);
+    }
 
 #ifdef CONFIG_DRIVERS_VIRTIO_BLK
   ret = virtio_register_blk_driver();


### PR DESCRIPTION
## Summary
Only call metal_init() once for virtio framework

## Impact
Should be none

## Testing
CI
