### PR TITLE
Remove the back slash from long literal string

### DIFF
--- a/arch/arm/src/sama5/sam_spi.c
+++ b/arch/arm/src/sama5/sam_spi.c
@@ -507,7 +507,7 @@ static void spi_dumpregs(struct sam_spidev_s *spi, const char *msg)
           getreg32(spi->base + SAM_SPI_MR_OFFSET),
           getreg32(spi->base + SAM_SPI_SR_OFFSET),
           getreg32(spi->base + SAM_SPI_IMR_OFFSET));
-  spiinfo("  CSR0:%" PRIx32 " CSR1:%" PRIx32 " CSR2:%" PRIx32 " CSR3:%" \
+  spiinfo("  CSR0:%" PRIx32 " CSR1:%" PRIx32 " CSR2:%" PRIx32 " CSR3:%"
           PRIx32 "\n",
           getreg32(spi->base + SAM_SPI_CSR0_OFFSET),
           getreg32(spi->base + SAM_SPI_CSR1_OFFSET),

--- a/arch/arm/src/samv7/sam_pwm.c
+++ b/arch/arm/src/samv7/sam_pwm.c
@@ -594,14 +594,14 @@ static void pwm_set_deadtime(struct pwm_lowerhalf_s *dev, uint8_t channel,
 
   if (width_1 > (period - regval))
     {
-      pwmerr("ERROR: Dead Time value DTH has to be < period - duty! " \
+      pwmerr("ERROR: Dead Time value DTH has to be < period - duty! "
              "Setting DTH to 0\n");
       width_1 = 0;
     }
 
   if (width_2 > regval)
     {
-      pwmerr("ERROR: Dead Time value DTL has to be < duty! " \
+      pwmerr("ERROR: Dead Time value DTL has to be < duty! "
              "Setting DTL to 0\n");
       width_2 = 0;
     }

--- a/arch/risc-v/src/esp32c3-legacy/esp32c3_ledc.c
+++ b/arch/risc-v/src/esp32c3-legacy/esp32c3_ledc.c
@@ -419,7 +419,7 @@ static void setup_timer(struct esp32c3_ledc_s *priv)
 
   prescaler = pwmclk * 256 / reload / priv->frequency;
 
-  pwminfo("PWM timer%" PRIu8 " frequency=%0.4f reload=%" PRIu32 " shift=%" \
+  pwminfo("PWM timer%" PRIu8 " frequency=%0.4f reload=%" PRIu32 " shift=%"
           PRIu32 " prescaler=%0.4f\n",
           priv->num, (float)pwmclk / reload / ((float)prescaler / 256),
           reload, shift, (float)prescaler / 256);

--- a/arch/risc-v/src/mpfs/mpfs_coremmc.c
+++ b/arch/risc-v/src/mpfs/mpfs_coremmc.c
@@ -1905,7 +1905,7 @@ static int mpfs_recvlong(struct sdio_dev_s *dev, uint32_t cmd,
                  getreg8(MPFS_COREMMC_RR14) << 8  |
                  getreg8(MPFS_COREMMC_RR15);
 
-      mcinfo("recv: %08" PRIx32 " %08" PRIx32 " %08" PRIx32 " %08" \
+      mcinfo("recv: %08" PRIx32 " %08" PRIx32 " %08" PRIx32 " %08"
              PRIx32"\n", rlong[0], rlong[1], rlong[2], rlong[3]);
     }
 

--- a/arch/risc-v/src/mpfs/mpfs_emmcsd.c
+++ b/arch/risc-v/src/mpfs/mpfs_emmcsd.c
@@ -2554,7 +2554,7 @@ static int mpfs_recvlong(struct sdio_dev_s *dev, uint32_t cmd,
 
       rlong[3] = tmp << 8;
 
-      mcinfo("recv: %08" PRIx32 " %08" PRIx32 " %08" PRIx32 " %08" \
+      mcinfo("recv: %08" PRIx32 " %08" PRIx32 " %08" PRIx32 " %08"
              PRIx32"\n", rlong[0], rlong[1], rlong[2], rlong[3]);
     }
 

--- a/boards/arm/gd32f4/gd32f450zk-eval/src/gd32f4xx_bringup.c
+++ b/boards/arm/gd32f4/gd32f450zk-eval/src/gd32f4xx_bringup.c
@@ -260,8 +260,8 @@ int gd32_bringup(void)
             }
         }
 
-      syslog(LOG_INFO, "INFO: LittleFS volume /mnt/fmc mount " \
-            "on chip flash success: %d\n", ret);
+      syslog(LOG_INFO, "INFO: LittleFS volume /mnt/fmc mount "
+             "on chip flash success: %d\n", ret);
 #    endif
 #  endif
 
@@ -352,8 +352,8 @@ int gd32_bringup(void)
             }
         }
 
-    syslog(LOG_INFO, "INFO: FAT volume /mnt/sd mount " \
-        "sd card success: %d\n", ret);
+    syslog(LOG_INFO, "INFO: FAT volume /mnt/sd mount "
+           "sd card success: %d\n", ret);
 #endif
   return ret;
 }

--- a/boards/arm/gd32f4/gd32f470ik-eval/src/gd32f4xx_bringup.c
+++ b/boards/arm/gd32f4/gd32f470ik-eval/src/gd32f4xx_bringup.c
@@ -260,8 +260,8 @@ int gd32_bringup(void)
             }
         }
 
-      syslog(LOG_INFO, "INFO: LittleFS volume /mnt/fmc mount " \
-            "on chip flash success: %d\n", ret);
+      syslog(LOG_INFO, "INFO: LittleFS volume /mnt/fmc mount "
+             "on chip flash success: %d\n", ret);
 #    endif
 #  endif
 
@@ -352,8 +352,8 @@ int gd32_bringup(void)
             }
         }
 
-    syslog(LOG_INFO, "INFO: FAT volume /mnt/sd mount " \
-        "sd card success: %d\n", ret);
+    syslog(LOG_INFO, "INFO: FAT volume /mnt/sd mount "
+           "sd card success: %d\n", ret);
 #endif
   return ret;
 }

--- a/boards/arm/gd32f4/gd32f470zk-eval/src/gd32f4xx_bringup.c
+++ b/boards/arm/gd32f4/gd32f470zk-eval/src/gd32f4xx_bringup.c
@@ -260,7 +260,7 @@ int gd32_bringup(void)
             }
         }
 
-      syslog(LOG_INFO, "INFO: LittleFS volume /mnt/fmc mount " \
+      syslog(LOG_INFO, "INFO: LittleFS volume /mnt/fmc mount "
             "on chip flash success: %d\n", ret);
 #    endif
 #  endif
@@ -352,8 +352,8 @@ int gd32_bringup(void)
             }
         }
 
-    syslog(LOG_INFO, "INFO: FAT volume /mnt/sd mount " \
-        "sd card success: %d\n", ret);
+    syslog(LOG_INFO, "INFO: FAT volume /mnt/sd mount "
+           "sd card success: %d\n", ret);
 #endif
   return ret;
 }

--- a/drivers/sensors/ds18b20_uorb.c
+++ b/drivers/sensors/ds18b20_uorb.c
@@ -531,7 +531,7 @@ static int ds18b20_set_alarm(FAR struct ds18b20_dev_s *dev,
   if (spad[DS18B20_SPAD_TH_OFFSET] != alarm->thigh ||
       spad[DS18B20_SPAD_TL_OFFSET] != alarm->tlow)
     {
-      snerr("ERROR: Expected alarm trigger does not match, " \
+      snerr("ERROR: Expected alarm trigger does not match, "
             "received TH: %d, TL: %d\n",
             spad[DS18B20_SPAD_TH_OFFSET],
             spad[DS18B20_SPAD_TL_OFFSET]);

--- a/wireless/bluetooth/bt_hcicore.c
+++ b/wireless/bluetooth/bt_hcicore.c
@@ -329,7 +329,7 @@ static void hci_cmd_done(uint16_t opcode, uint8_t status,
 
   if (g_btdev.sent_cmd->u.hci.opcode != opcode)
     {
-      wlerr("ERROR:  Unexpected completion of opcode 0x%04x " \
+      wlerr("ERROR:  Unexpected completion of opcode 0x%04x "
             "expected 0x%04x\n",
             opcode, g_btdev.sent_cmd->u.hci.opcode);
       return;


### PR DESCRIPTION
## Summary

since the back slash is only needed for the long macro definition

## Impact

code refactor only

## Testing

ci