### PR TITLE
fs: fat: fs_fat32: fix default return value of fat_ioctl().

### DIFF
--- a/fs/fat/fs_fat32.c
+++ b/fs/fat/fs_fat32.c
@@ -1316,7 +1316,7 @@ static int fat_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   /* ioctl calls are just passed through to the contained block driver */
 
   nxmutex_unlock(&fs->fs_lock);
-  return -ENOSYS;
+  return -ENOTTY;
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

When issuing an ioctl for a file that exists in a FAT32 file system, the FAT ioctl() is first executed, but it returns -ENOSYS in an attempt to pass through to the vfs.

Therefore, the ioctl of the VFS layer, which expects -ENOTTY, is not processed and an error occurs.

## Impact

## Testing
Nim file operations (write file to FAT filesystem) on NuttX.
