### PR TITLE
Implement Filelock 

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -8564,3 +8564,72 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+include/search.h
+======================
+$NetBSD: search.h,v 1.12 1999/02/22 10:34:28 christos Exp $
+$FreeBSD: src/include/search.h,v 1.4 2002/03/23 17:24:53 imp Exp $
+
+Written by J.T. Conklin <jtc@netbsd.org>
+Public domain.
+
+libs/libc/search/hcreate.c
+libs/libc/search/hcreate_r.c
+======================
+$NetBSD: hcreate.c,v 1.2 2001/02/19 21:26:04 ross Exp $
+
+Copyright (c) 2001 Christopher G. Demetriou
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. The name of the author may not be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+libs/libc/search/hash_func.c
+======================
+Copyright (c) 1990, 1993
+The Regents of the University of California.  All rights reserved.
+
+This code is derived from software contributed to Berkeley by
+Margo Seltzer.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of the University nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.

--- a/fs/Kconfig
+++ b/fs/Kconfig
@@ -64,6 +64,10 @@ config FS_NEPOLL_DESCRIPTORS
 	---help---
 		The maximum number of default epoll descriptors for epoll_create1(2)
 
+config FS_LOCK_BUCKET_SIZE
+	int "Maximum number of hash bucket using file locks"
+	default 0
+
 config DISABLE_PSEUDOFS_OPERATIONS
 	bool "Disable pseudo-filesystem operations"
 	default DEFAULT_SMALL

--- a/fs/vfs/Make.defs
+++ b/fs/vfs/Make.defs
@@ -29,6 +29,10 @@ CSRCS += fs_syncfs.c fs_truncate.c
 
 # Certain interfaces are not available if there is no mountpoint support
 
+ifneq ($(CONFIG_FS_LOCK_BUCKET_SIZE),0)
+CSRCS += fs_lock.c
+endif
+
 ifneq ($(CONFIG_PSEUDOFS_SOFTLINKS),0)
 CSRCS += fs_link.c fs_symlink.c fs_readlink.c
 endif

--- a/fs/vfs/fs_close.c
+++ b/fs/vfs/fs_close.c
@@ -32,6 +32,7 @@
 #include <nuttx/fs/fs.h>
 
 #include "inode/inode.h"
+#include "vfs/lock.h"
 
 /****************************************************************************
  * Public Functions
@@ -65,6 +66,8 @@ int file_close(FAR struct file *filep)
 
   if (inode)
     {
+      file_closelk(filep);
+
       /* Close the file, driver, or mountpoint. */
 
       if (inode->u.i_ops && inode->u.i_ops->close)

--- a/fs/vfs/fs_fcntl.c
+++ b/fs/vfs/fs_fcntl.c
@@ -35,6 +35,7 @@
 #include <nuttx/fs/fs.h>
 
 #include "inode/inode.h"
+#include "lock.h"
 
 /****************************************************************************
  * Private Functions
@@ -195,6 +196,12 @@ static int file_vfcntl(FAR struct file *filep, int cmd, va_list ap)
          * for the lock type which shall be set to F_UNLCK.
          */
 
+        {
+          FAR struct flock *flock = va_arg(ap, FAR struct flock *);
+          ret = file_getlk(filep, flock);
+        }
+
+        break;
       case F_SETLK:
         /* Set or clear a file segment lock according to the lock
          * description pointed to by the third argument, arg, taken as a
@@ -206,6 +213,12 @@ static int file_vfcntl(FAR struct file *filep, int cmd, va_list ap)
          * shall return immediately with a return value of -1.
          */
 
+        {
+          FAR struct flock *flock = va_arg(ap, FAR struct flock *);
+          ret = file_setlk(filep, flock, true);
+        }
+
+        break;
       case F_SETLKW:
         /* This command shall be equivalent to F_SETLK except that if a
          * shared or exclusive lock is blocked by other locks, the thread
@@ -216,9 +229,12 @@ static int file_vfcntl(FAR struct file *filep, int cmd, va_list ap)
          * the lock operation shall not be done.
          */
 
-        ret = -ENOSYS; /* Not implemented */
-        break;
+        {
+          FAR struct flock *flock = va_arg(ap, FAR struct flock *);
+          ret = file_setlk(filep, flock, false);
+        }
 
+        break;
       case F_GETPATH:
         /* Get the path of the file descriptor. The argument must be a buffer
          * of size PATH_MAX or greater.

--- a/fs/vfs/fs_lock.c
+++ b/fs/vfs/fs_lock.c
@@ -1,0 +1,769 @@
+/****************************************************************************
+ * fs/vfs/fs_lock.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <fcntl.h>
+#include <errno.h>
+#include <search.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+#include <nuttx/lib/lib.h>
+#include <nuttx/kmalloc.h>
+#include <nuttx/mutex.h>
+#include <nuttx/list.h>
+
+#include "lock.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifdef CONFIG_FS_LARGEFILE
+#  define OFFSET_MAX INT64_MAX
+#else
+#  define OFFSET_MAX INT32_MAX
+#endif
+
+#define l_end l_len
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct file_lock_s
+{
+  struct flock     fl_lock;  /* File lock related information */
+  FAR struct file  *fl_file; /* Identifies the file descriptor information
+                              * held by the caller
+                              */
+  struct list_node fl_node;  /* Used to manage each filelock by means of a
+                              * chained list.
+                              */
+};
+
+struct file_lock_bucket_s
+{
+  struct list_node list;         /* Manage a chained list for each
+                                  * filelock
+                                  */
+  sem_t            wait;         /* Blocking lock, called when SETLKW is
+                                  * called and there is a conflict.
+                                  */
+  size_t           nwaiter;      /* Indicates how many blocking locks are
+                                  * currently blocked.
+                                  */
+};
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static struct hsearch_data g_file_lock_table;
+static mutex_t g_protect_lock = NXMUTEX_INITIALIZER;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: file_lock_normalize
+ ****************************************************************************/
+
+static int file_lock_normalize(FAR struct file *filep,
+                               FAR struct flock *flock,
+                               FAR struct flock *out)
+{
+  off_t start;
+  off_t end;
+
+  /* Check the legality of incoming flocks */
+
+  if (flock->l_len - 1 > OFFSET_MAX - flock->l_start)
+    {
+      return -EOVERFLOW;
+    }
+
+  /* Check that the type brought in the flock is correct */
+
+  switch (flock->l_type)
+    {
+      case F_RDLCK:
+      case F_WRLCK:
+      case F_UNLCK:
+        break;
+      default:
+        return -EINVAL;
+    }
+
+  /* Converts and saves flock information */
+
+  switch (flock->l_whence)
+    {
+      case SEEK_SET:
+        {
+          start = 0;
+        }
+
+        break;
+      case SEEK_CUR:
+        {
+          start = filep->f_pos;
+        }
+
+        break;
+      case SEEK_END:
+        {
+          struct stat st;
+          int ret;
+
+          ret = file_fstat(filep, &st);
+          if (ret < 0)
+            {
+              return ret;
+            }
+
+          start = st.st_size;
+        }
+
+        break;
+      default:
+        return -EINVAL;
+    }
+
+  /* Check for overflow in converted flock */
+
+  if (flock->l_start > OFFSET_MAX - start)
+    {
+      return -EOVERFLOW;
+    }
+
+  start += flock->l_start;
+  if (flock->l_len > 0)
+    {
+      end = start + flock->l_len - 1;
+    }
+  else if (flock->l_len < 0)
+    {
+      if (start + flock->l_len < 0)
+        {
+          return -EINVAL;
+        }
+
+      end = start - 1;
+      start += flock->l_len;
+    }
+  else
+    {
+      end = OFFSET_MAX;
+    }
+
+  out->l_whence = SEEK_SET;
+  out->l_pid = getpid();
+  out->l_type = flock->l_type;
+  out->l_start = start;
+  out->l_end = end;
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: file_lock_delete
+ ****************************************************************************/
+
+static void file_lock_delete(FAR struct file_lock_s *file_lock)
+{
+  list_delete(&file_lock->fl_node);
+  kmm_free(file_lock);
+}
+
+/****************************************************************************
+ * Name: file_lock_delete_bucket
+ ****************************************************************************/
+
+static void file_lock_delete_bucket(FAR struct file_lock_bucket_s *bucket,
+                                    FAR const char *filepath)
+{
+  ENTRY item;
+
+  /* If there is still a lock on the chain table at this point, it means
+   * that there is still someone else holding it, so it doesn't need to be
+   * released
+   */
+
+  if (list_is_empty(&bucket->list))
+    {
+      /* At this point, the file has no lock information context, so we can
+       * remove it from the hash table, and the return result is 0 or 1 means
+       * that the node does not exist, so we do not need to care about the
+       * final return results
+       */
+
+      item.key = (FAR char *)filepath;
+      hsearch_r(item, DELETE, NULL, &g_file_lock_table);
+    }
+}
+
+/****************************************************************************
+ * Name: file_lock_is_conflict
+ ****************************************************************************/
+
+static bool file_lock_is_conflict(FAR struct flock *request,
+                                  FAR struct flock *internal)
+{
+  /* If the request is not exactly to the left or right of the internal,
+   * then there is an overlap.
+   */
+
+  if (request->l_start <= internal->l_end && request->l_end >=
+      internal->l_start)
+    {
+      if (request->l_type == F_WRLCK || internal->l_type == F_WRLCK)
+        {
+          return request->l_pid != internal->l_pid;
+        }
+    }
+
+  return false;
+}
+
+/****************************************************************************
+ * Name: file_lock_find_bucket
+ ****************************************************************************/
+
+static FAR struct file_lock_bucket_s *
+file_lock_find_bucket(FAR const char *filepath)
+{
+  FAR ENTRY *hretvalue;
+  ENTRY item;
+
+  item.key = (FAR char *)filepath;
+  item.data = NULL;
+
+  if (hsearch_r(item, FIND, &hretvalue, &g_file_lock_table) == 1)
+    {
+      return hretvalue->data;
+    }
+
+  return NULL;
+}
+
+/****************************************************************************
+ * Name: file_lock_create_bucket
+ ****************************************************************************/
+
+static FAR struct file_lock_bucket_s *
+file_lock_create_bucket(FAR const char *filepath)
+{
+  FAR struct file_lock_bucket_s *bucket;
+  FAR ENTRY *hretvalue;
+  ENTRY item;
+
+  bucket = kmm_zalloc(sizeof(*bucket));
+  if (bucket == NULL)
+    {
+      return NULL;
+    }
+
+  /* Creating an instance store */
+
+  item.key = strdup(filepath);
+  if (item.key == NULL)
+    {
+      kmm_free(bucket);
+      return NULL;
+    }
+
+  item.data = bucket;
+
+  if (hsearch_r(item, ENTER, &hretvalue, &g_file_lock_table) == 0)
+    {
+      lib_free(item.key);
+      kmm_free(bucket);
+      return NULL;
+    }
+
+  list_initialize(&bucket->list);
+  nxsem_init(&bucket->wait, 0, 0);
+
+  return bucket;
+}
+
+/****************************************************************************
+ * Name: file_lock_modify
+ ****************************************************************************/
+
+static int file_lock_modify(FAR struct file *filep,
+                            FAR struct file_lock_bucket_s *bucket,
+                            FAR struct flock *request)
+{
+  FAR struct file_lock_s *new_file_lock = NULL;
+  FAR struct file_lock_s *right = NULL;
+  FAR struct file_lock_s *left = NULL;
+  FAR struct file_lock_s *file_lock;
+  FAR struct file_lock_s *tmp;
+  bool added = false;
+  bool find = false;
+
+  list_for_every_entry_safe(&bucket->list, file_lock, tmp,
+                            struct file_lock_s, fl_node)
+    {
+      if (request->l_pid != file_lock->fl_lock.l_pid)
+        {
+          /* Only file locks with the same pid need to be processed, so the
+           * lookup is skipped.
+           */
+
+          if (find)
+            {
+              /* We've searched around and come back to the beginning. */
+
+              break;
+            }
+        }
+      else
+        {
+          find = true;
+
+          /* Checking the type of overlapping locks */
+
+          if (request->l_type == file_lock->fl_lock.l_type)
+            {
+              /* Compare the starting point of the last lock with the
+               * starting point of the request, and use start - 1 instead of
+               * end + 1, because if end is "off_t" max, then end + 1 will
+               * be negative.
+               */
+
+              if (request->l_start - 1 > file_lock->fl_lock.l_end)
+                {
+                  continue;
+                }
+
+              if (request->l_end < file_lock->fl_lock.l_start - 1)
+                {
+                  break;
+                }
+
+              /* If the two locks are of the same type, then they are merged
+               * into one lock with a lower start position and a higher end
+               * position.
+               */
+
+              if (request->l_start < file_lock->fl_lock.l_start)
+                {
+                  file_lock->fl_lock.l_start = request->l_start;
+                }
+              else
+                {
+                  request->l_start = file_lock->fl_lock.l_start;
+                }
+
+              if (request->l_end > file_lock->fl_lock.l_end)
+                {
+                  file_lock->fl_lock.l_end = request->l_end;
+                }
+              else
+                {
+                  request->l_end = file_lock->fl_lock.l_end;
+                }
+
+              if (added)
+                {
+                  file_lock_delete(file_lock);
+                  continue;
+                }
+
+              request = &file_lock->fl_lock;
+              added = true;
+            }
+          else
+            {
+              if (request->l_start > file_lock->fl_lock.l_end)
+                {
+                  continue;
+                }
+
+              if (request->l_end < file_lock->fl_lock.l_start)
+                {
+                  break;
+                }
+
+              /* Scenarios for handling different types of locks */
+
+              if (request->l_type == F_UNLCK)
+                {
+                  added = true;
+                }
+
+              /* The new lock and the old lock are adjacent or overlapping.
+               * The code will handle this depending on the situation.
+               * If the end address of the old lock is higher than the
+               * new lock, then go ahead and insert the new lock here.
+               */
+
+              if (request->l_start > file_lock->fl_lock.l_start)
+                {
+                  left = file_lock;
+                }
+
+              if (request->l_end < file_lock->fl_lock.l_end)
+                {
+                  right = file_lock;
+                  break;
+                }
+
+              if (request->l_start <= file_lock->fl_lock.l_start)
+                {
+                  /* In other cases, we are replacing old locks with new
+                   * ones
+                   */
+
+                  if (added)
+                    {
+                      file_lock_delete(file_lock);
+                      continue;
+                    }
+
+                  memcpy(&file_lock->fl_lock, request, sizeof(struct flock));
+                  added = true;
+                }
+            }
+        }
+    }
+
+  if (!added)
+    {
+      if (request->l_type == F_UNLCK)
+        {
+          return OK;
+        }
+
+      /* insert a new lock */
+
+      new_file_lock = kmm_zalloc(sizeof(struct file_lock_s));
+      if (new_file_lock == NULL)
+        {
+          return -ENOMEM;
+        }
+
+      new_file_lock->fl_file = filep;
+      memcpy(&new_file_lock->fl_lock, request, sizeof(struct flock));
+      list_add_before(&file_lock->fl_node, &new_file_lock->fl_node);
+      file_lock = new_file_lock;
+    }
+
+  if (right)
+    {
+      if (left == right)
+        {
+          /* Splitting old locks */
+
+          new_file_lock = kmm_zalloc(sizeof(struct file_lock_s));
+          if (new_file_lock == NULL)
+            {
+              return -ENOMEM;
+            }
+
+          left = new_file_lock;
+          memcpy(left, right, sizeof(struct file_lock_s));
+          list_add_before(&file_lock->fl_node, &left->fl_node);
+        }
+
+      right->fl_lock.l_start = request->l_end + 1;
+    }
+
+  if (left)
+    {
+      left->fl_lock.l_end = request->l_start - 1;
+    }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: file_getlk
+ *
+ * Description:
+ *   Attempts to lock the region (not a real lock), and if there is a
+ *   conflict then returns information about the conflicting locks
+ *
+ * Input Parameters:
+ *   filep - File structure instance
+ *   flock - Lock types to be converted
+ *
+ * Returned Value:
+ *   The resulting 0 on success. A errno value is returned on any failure.
+ *
+ ****************************************************************************/
+
+int file_getlk(FAR struct file *filep, FAR struct flock *flock)
+{
+  FAR struct file_lock_bucket_s *bucket;
+  FAR struct file_lock_s *file_lock;
+  char path[PATH_MAX];
+  int ret;
+
+  /* We need to get the unique identifier (Path) via filep */
+
+  ret = file_fcntl(filep, F_GETPATH, path);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  /* Convert a flock to a posix lock */
+
+  ret = file_lock_normalize(filep, flock, flock);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  flock->l_type = F_UNLCK;
+
+  nxmutex_lock(&g_protect_lock);
+
+  bucket = file_lock_find_bucket(path);
+  if (bucket != NULL)
+    {
+      list_for_every_entry(&bucket->list, file_lock, struct file_lock_s,
+                           fl_node)
+        {
+          if (file_lock_is_conflict(flock, &file_lock->fl_lock))
+            {
+              memcpy(flock, &file_lock->fl_lock, sizeof(*flock));
+              break;
+            }
+        }
+    }
+
+  nxmutex_unlock(&g_protect_lock);
+
+  /* Convert back to flock
+   * The flock information saved in filelock is used as an offset
+   * to the relative position. And for upper level applications,
+   * l_len should be converted to cover the data quantity
+   */
+
+  if (flock->l_end == OFFSET_MAX)
+    {
+      flock->l_len = 0;
+    }
+  else
+    {
+      flock->l_len = flock->l_end - flock->l_start + 1;
+    }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: file_setlk
+ *
+ * Description:
+ *   Actual execution of locking and unlocking behaviors
+ *
+ * Input Parameters:
+ *   filep    - File structure instance
+ *   flock    - Lock types to be converted
+ *   nonblock - Waiting for lock
+ *
+ * Returned Value:
+ *   The resulting 0 on success. A errno value is returned on any failure.
+ *
+ ****************************************************************************/
+
+int file_setlk(FAR struct file *filep, FAR struct flock *flock,
+               bool nonblock)
+{
+  FAR struct file_lock_bucket_s *bucket;
+  FAR struct file_lock_s *file_lock;
+  struct flock request;
+  char path[PATH_MAX];
+  int ret;
+
+  /* We need to get the unique identifier (Path) via filep */
+
+  ret = file_fcntl(filep, F_GETPATH, path);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  /* Convert a flock to a posix lock */
+
+  ret = file_lock_normalize(filep, flock, &request);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  nxmutex_lock(&g_protect_lock);
+
+  bucket = file_lock_find_bucket(path);
+  if (bucket == NULL)
+    {
+      /* If we request to unlock and the bucket is not found, it means
+       * there is no lock here.
+       */
+
+      if (request.l_type == F_UNLCK)
+        {
+          nxmutex_unlock(&g_protect_lock);
+          return OK;
+        }
+
+      /* It looks like we didn't find a bucket, let's go create one */
+
+      bucket = file_lock_create_bucket(path);
+      if (bucket == NULL)
+        {
+          nxmutex_unlock(&g_protect_lock);
+          return -ENOMEM;
+        }
+    }
+  else if (request.l_type != F_UNLCK)
+    {
+retry:
+      list_for_every_entry(&bucket->list, file_lock, struct file_lock_s,
+                           fl_node)
+        {
+          if (file_lock_is_conflict(&request, &file_lock->fl_lock))
+            {
+              if (nonblock)
+                {
+                  ret = -EAGAIN;
+                  goto out;
+                }
+
+              bucket->nwaiter++;
+              nxmutex_unlock(&g_protect_lock);
+              nxsem_wait(&bucket->wait);
+              nxmutex_lock(&g_protect_lock);
+              bucket->nwaiter--;
+              goto retry;
+            }
+        }
+    }
+
+  ret = file_lock_modify(filep, bucket, &request);
+  if (ret < 0)
+    {
+      goto out;
+    }
+
+  /* When there is a lock change, we need to wake up the blocking lock */
+
+  if (bucket->nwaiter > 0)
+    {
+      nxsem_post(&bucket->wait);
+    }
+
+out:
+  file_lock_delete_bucket(bucket, path);
+  nxmutex_unlock(&g_protect_lock);
+  return ret;
+}
+
+/****************************************************************************
+ * Name: file_closelk
+ *
+ * Description:
+ *   Remove all locks associated with the filep when call close is applied.
+ *
+ * Input Parameters:
+ *   filep - The filep that corresponds to the shutdown.
+ *
+ ****************************************************************************/
+
+void file_closelk(FAR struct file *filep)
+{
+  FAR struct file_lock_bucket_s *bucket;
+  FAR struct file_lock_s *file_lock;
+  FAR struct file_lock_s *temp;
+  char path[PATH_MAX];
+  bool deleted = false;
+  int ret;
+
+  ret = file_fcntl(filep, F_GETPATH, path);
+  if (ret < 0)
+    {
+      /* It isn't an error if fs doesn't support F_GETPATH, so we just end
+       * it.
+       */
+
+      return;
+    }
+
+  bucket = file_lock_find_bucket(path);
+  if (bucket == NULL)
+    {
+      /* There is no bucket here, so we don't need to free it. */
+
+      return;
+    }
+
+  nxmutex_lock(&g_protect_lock);
+  list_for_every_entry_safe(&bucket->list, file_lock, temp,
+                            struct file_lock_s, fl_node)
+    {
+      if (file_lock->fl_file == filep)
+        {
+          deleted = true;
+          file_lock_delete(file_lock);
+        }
+    }
+
+  if (bucket->nwaiter > 0 && deleted)
+    {
+      nxsem_post(&bucket->wait);
+    }
+  else if (deleted)
+    {
+      file_lock_delete_bucket(bucket, path);
+    }
+
+  nxmutex_unlock(&g_protect_lock);
+}
+
+/****************************************************************************
+ * Name: file_initlk
+ *
+ * Description:
+ *   Initializing file locks
+ *
+ ****************************************************************************/
+
+void file_initlk(void)
+{
+  /* Initialize file lock context hash table */
+
+  hcreate_r(CONFIG_FS_LOCK_BUCKET_SIZE, &g_file_lock_table);
+}

--- a/fs/vfs/fs_lock.c
+++ b/fs/vfs/fs_lock.c
@@ -89,6 +89,22 @@ static mutex_t g_protect_lock = NXMUTEX_INITIALIZER;
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: file_lock_get_path
+ ****************************************************************************/
+
+static int file_lock_get_path(FAR struct file *filep, FAR char *path)
+{
+  /* We only apply file lock on mount points (f_inode won't be NULL). */
+
+  if (!INODE_IS_MOUNTPT(filep->f_inode))
+    {
+      return -EBADF;
+    }
+
+  return file_fcntl(filep, F_GETPATH, path);
+}
+
+/****************************************************************************
  * Name: file_lock_normalize
  ****************************************************************************/
 
@@ -534,7 +550,7 @@ int file_getlk(FAR struct file *filep, FAR struct flock *flock)
 
   /* We need to get the unique identifier (Path) via filep */
 
-  ret = file_fcntl(filep, F_GETPATH, path);
+  ret = file_lock_get_path(filep, path);
   if (ret < 0)
     {
       return ret;
@@ -613,7 +629,7 @@ int file_setlk(FAR struct file *filep, FAR struct flock *flock,
 
   /* We need to get the unique identifier (Path) via filep */
 
-  ret = file_fcntl(filep, F_GETPATH, path);
+  ret = file_lock_get_path(filep, path);
   if (ret < 0)
     {
       return ret;
@@ -716,7 +732,7 @@ void file_closelk(FAR struct file *filep)
   bool deleted = false;
   int ret;
 
-  ret = file_fcntl(filep, F_GETPATH, path);
+  ret = file_lock_get_path(filep, path);
   if (ret < 0)
     {
       /* It isn't an error if fs doesn't support F_GETPATH, so we just end

--- a/include/nuttx/list.h
+++ b/include/nuttx/list.h
@@ -257,6 +257,13 @@
       &entry->member != (list); entry = temp, \
       temp = container_of(temp->member.next, type, member))
 
+/* Iterate from a given entry node in a safe way */
+
+#define list_for_every_entry_safe_from(list, cur, temp, type, member) \
+  for ((temp) = list_next_entry(cur, type, member); \
+       &(cur)->member != (list); \
+       (cur) = (temp), (temp) = list_next_entry(temp, type, member))
+
 #define list_for_every_entry_continue(list, head, type, member)    \
   for ((list) = list_next_entry(list, type, member); \
        &(list)->member != (head); \

--- a/include/search.h
+++ b/include/search.h
@@ -35,7 +35,8 @@ typedef struct entry
 typedef enum
 {
   FIND,
-  ENTER
+  ENTER,
+  DELETE
 } ACTION;
 
 struct hsearch_data

--- a/include/search.h
+++ b/include/search.h
@@ -1,0 +1,162 @@
+/****************************************************************************
+ * include/search.h
+ *
+ * $NetBSD: search.h,v 1.12 1999/02/22 10:34:28 christos Exp $
+ * $FreeBSD: src/include/search.h,v 1.4 2002/03/23 17:24:53 imp Exp $
+ *
+ * Written by J.T. Conklin <jtc@netbsd.org>
+ * Public domain.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_SEARCH_H
+#define __INCLUDE_SEARCH_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sys/types.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Type Definitions
+ ****************************************************************************/
+
+typedef struct entry
+{
+  FAR char *key;
+  FAR void *data;
+} ENTRY;
+
+typedef enum
+{
+  FIND,
+  ENTER
+} ACTION;
+
+struct hsearch_data
+{
+  FAR struct internal_head *htable;
+  size_t htablesize;
+};
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: hcreate
+ *
+ * Description:
+ *   The hcreate() function creates a new hashing table with nel elements.
+ *   The hashing table will be used by subsequent calls to hsearch() with
+ *   the same htab argument.  The hashing table is initialized with nel
+ *   hashing buckets.
+ *
+ *   The hcreate_r() function is the reentrant version of hcreate().
+ *
+ * Returned Value:
+ *   If successful, hcreate() and hcreate_r() return 1; otherwise, they
+ *   return 0.
+ *
+ ****************************************************************************/
+
+int hcreate(size_t);
+
+/****************************************************************************
+ * Name: hdestroy
+ *
+ * Description:
+ *   The hdestroy() function destroys the hashing table specified by htab.
+ *   The hashing table is destroyed only if there are no entries in the
+ *   table.  The hashing table cannot be used again until hcreate() or
+ *   hcreate_r() is called.
+ *
+ *   The hdestroy_r() function is the reentrant version of hdestroy().
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void hdestroy(void);
+
+/****************************************************************************
+ * Name: hsearch
+ *
+ * Description:
+ *   The hsearch() function searches the hashing table specified by htab
+ *   for an entry with a key matching that of item.  If such an entry is
+ *   found, hsearch() returns a pointer to the entry's data object.  If
+ *   such an entry is not found, hsearch() creates a new entry using the
+ *   key and data objects specified by item and returns a pointer to the
+ *   new entry's data object.
+ *
+ *   The hsearch_r() function is the reentrant version of hsearch().
+ *
+ * Returned Value:
+ *   If successful, hsearch() and hsearch_r() return a pointer to the data
+ *   object of the matching or newly created entry.  Otherwise, they return
+ *   NULL.
+ *
+ ****************************************************************************/
+
+FAR ENTRY *hsearch(ENTRY, ACTION);
+
+/****************************************************************************
+ * Name: hcreate_r
+ *
+ * Description:
+ *   Create a new hash table.
+ *
+ * Input Parameters:
+ *   nel - The number of elements in the hash table.
+ *   htab - The location to return the hash table reference.
+ *
+ * Returned Value:
+ *   1 on success; 0 on failure with errno set appropriately.
+ *
+ ****************************************************************************/
+
+int hcreate_r(size_t, FAR struct hsearch_data *);
+
+/****************************************************************************
+ * Name: hdestroy_r
+ *
+ * Description:
+ *   Destroy a hash table.
+ *
+ * Input Parameters:
+ *   htab - The hash table to be destroyed.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void hdestroy_r(FAR struct hsearch_data *);
+
+/****************************************************************************
+ * Name: hsearch_r
+ *
+ * Description:
+ *   Search a hash table.
+ *
+ * Input Parameters:
+ *   item - The search key.
+ *   action - The action to take.
+ *   result - The location to return the search result.
+ *   htab - The hash table to be searched.
+ *
+ * Returned Value:
+ *   1 on success; 0 on failure with errno set appropriately.
+ *
+ ****************************************************************************/
+
+int hsearch_r(ENTRY, ACTION, FAR ENTRY **, FAR struct hsearch_data *);
+
+#endif /* __INCLUDE_SEARCH_H */

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -289,6 +289,18 @@
 #  define execvpe                        execve
 #endif
 
+/* Commands for lockf()
+ * F_ULOCK - Unlock
+ * F_LOCK  - Blocking Exclusive Lock
+ * F_TLOCK - Attempted Exclusive Locking
+ * F_TEST  - Test Locked Status
+ */
+
+#define F_ULOCK                          0
+#define F_LOCK                           1
+#define F_TLOCK                          2
+#define F_TEST                           3
+
 /****************************************************************************
  * Public Data
  ****************************************************************************/
@@ -337,6 +349,7 @@ ssize_t pread(int fd, FAR void *buf, size_t nbytes, off_t offset);
 ssize_t pwrite(int fd, FAR const void *buf, size_t nbytes, off_t offset);
 int     ftruncate(int fd, off_t length);
 int     fchown(int fd, uid_t owner, gid_t group);
+int     lockf(int fd, int cmd, off_t len);
 
 /* Check if a file descriptor corresponds to a terminal I/O file */
 

--- a/libs/libc/Makefile
+++ b/libs/libc/Makefile
@@ -49,6 +49,7 @@ include pwd/Make.defs
 include queue/Make.defs
 include regex/Make.defs
 include sched/Make.defs
+include search/Make.defs
 include semaphore/Make.defs
 include signal/Make.defs
 include spawn/Make.defs

--- a/libs/libc/search/CMakeLists.txt
+++ b/libs/libc/search/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# libs/libc/search/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS hash_func.c hcreate.c hcreate_r.c)
+
+target_sources(c PRIVATE ${SRCS})

--- a/libs/libc/search/Make.defs
+++ b/libs/libc/search/Make.defs
@@ -1,0 +1,28 @@
+############################################################################
+# libs/libc/search/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+# Add the search C files to the build
+
+CSRCS += hcreate_r.c hcreate.c hash_func.c
+
+# Add the search directory to the build
+
+DEPPATH += --dep-path search
+VPATH += :search

--- a/libs/libc/search/hash_func.c
+++ b/libs/libc/search/hash_func.c
@@ -1,0 +1,126 @@
+/****************************************************************************
+ * libs/libc/search/hash_func.c
+ *
+ * Copyright (c) 1990, 1993
+ * The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * Margo Seltzer.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sys/types.h>
+
+#include <stdint.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define HASH4 h = (h << 5) + h + *key++;
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+static uint32_t hash4(FAR const void *, size_t);
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* Global default hash function */
+
+uint32_t (*g_default_hash)(FAR const void *, size_t) = hash4;
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/* Hash function from Chris Torek. */
+
+static uint32_t hash4(FAR const void *keyarg, size_t len)
+{
+  FAR const u_char *key = keyarg;
+  uint32_t h = 0;
+  size_t loop;
+
+  if (len > 0)
+    {
+      loop = (len + 8 - 1) >> 3;
+      switch (len & (8 - 1))
+        {
+          case 0:
+            do
+              {
+                HASH4;
+
+                /* FALLTHROUGH */
+
+          case 7:
+                HASH4;
+
+                /* FALLTHROUGH */
+
+          case 6:
+                HASH4;
+
+                /* FALLTHROUGH */
+
+          case 5:
+                HASH4;
+
+                /* FALLTHROUGH */
+
+          case 4:
+                HASH4;
+
+                /* FALLTHROUGH */
+
+          case 3:
+                HASH4;
+
+                /* FALLTHROUGH */
+
+          case 2:
+                HASH4;
+
+                /* FALLTHROUGH */
+
+          case 1:
+                HASH4;
+              }
+            while (--loop);
+        }
+    }
+
+  return h;
+}

--- a/libs/libc/search/hcreate.c
+++ b/libs/libc/search/hcreate.c
@@ -1,0 +1,140 @@
+/****************************************************************************
+ * libs/libc/search/hcreate.c
+ *
+ * $NetBSD: hcreate.c,v 1.2 2001/02/19 21:26:04 ross Exp $
+ *
+ * Copyright (c) 2001 Christopher G. Demetriou
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * <<Id: LICENSE_GC,v 1.1 2001/10/01 23:24:05 cgd Exp>>
+ *
+ *
+ * hcreate() / hsearch() / hdestroy()
+ *
+ * SysV/XPG4 hash table functions.
+ *
+ * Implementation done based on NetBSD manual page and Solaris manual page,
+ * plus my own personal experience about how they're supposed to work.
+ *
+ * I tried to look at Knuth (as cited by the Solaris manual page), but
+ * nobody had a copy in the office, so...
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <search.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static struct hsearch_data g_htab;
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: hcreate
+ *
+ * Description:
+ *   The hcreate() function creates a new hashing table with nel elements.
+ *   The hashing table will be used by subsequent calls to hsearch() with
+ *   the same htab argument.  The hashing table is initialized with nel
+ *   hashing buckets.
+ *
+ *   The hcreate_r() function is the reentrant version of hcreate().
+ *
+ * Returned Value:
+ *   If successful, hcreate() and hcreate_r() return 1; otherwise, they
+ *   return 0.
+ *
+ ****************************************************************************/
+
+int hcreate(size_t nel)
+{
+  return hcreate_r(nel, &g_htab);
+}
+
+/****************************************************************************
+ * Name: hdestroy
+ *
+ * Description:
+ *   The hdestroy() function destroys the hashing table specified by htab.
+ *   The hashing table is destroyed only if there are no entries in the
+ *   table.  The hashing table cannot be used again until hcreate() or
+ *   hcreate_r() is called.
+ *
+ *   The hdestroy_r() function is the reentrant version of hdestroy().
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void hdestroy(void)
+{
+  hdestroy_r(&g_htab);
+}
+
+/****************************************************************************
+ * Name: hsearch
+ *
+ * Description:
+ *   The hsearch() function searches the hashing table specified by htab
+ *   for an entry with a key matching that of item.  If such an entry is
+ *   found, hsearch() returns a pointer to the entry's data object.  If
+ *   such an entry is not found, hsearch() creates a new entry using the
+ *   key and data objects specified by item and returns a pointer to the
+ *   new entry's data object.
+ *
+ *   The hsearch_r() function is the reentrant version of hsearch().
+ *
+ * Returned Value:
+ *   If successful, hsearch() and hsearch_r() return a pointer to the data
+ *   object of the matching or newly created entry.  Otherwise, they return
+ *   NULL.
+ *
+ ****************************************************************************/
+
+FAR ENTRY *hsearch(ENTRY item, ACTION action)
+{
+  FAR ENTRY *retval;
+
+  hsearch_r(item, action, &retval, &g_htab);
+
+  return retval;
+}

--- a/libs/libc/search/hcreate_r.c
+++ b/libs/libc/search/hcreate_r.c
@@ -191,6 +191,7 @@ void hdestroy_r(FAR struct hsearch_data *htab)
           ie = SLIST_FIRST(&(htab->htable[idx]));
           SLIST_REMOVE_HEAD(&(htab->htable[idx]), link);
           lib_free(ie->ent.key);
+          lib_free(ie->ent.data);
           lib_free(ie);
         }
     }
@@ -239,7 +240,20 @@ int hsearch_r(ENTRY item, ACTION action, FAR ENTRY **retval,
       ie = SLIST_NEXT(ie, link);
     }
 
-  if (ie != NULL)
+  if (action == DELETE)
+    {
+      if (ie != NULL)
+        {
+          SLIST_REMOVE(head, ie, internal_entry, link);
+          lib_free(ie->ent.key);
+          lib_free(ie->ent.data);
+          lib_free(ie);
+          return 1;
+        }
+
+      return 0;
+    }
+  else if (ie != NULL)
     {
       *retval = &ie->ent;
       return 1;

--- a/libs/libc/search/hcreate_r.c
+++ b/libs/libc/search/hcreate_r.c
@@ -1,0 +1,266 @@
+/****************************************************************************
+ * libs/libc/search/hcreate_r.c
+ *
+ * $NetBSD: hcreate.c,v 1.2 2001/02/19 21:26:04 ross Exp $
+ *
+ * Copyright (c) 2001 Christopher G. Demetriou
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * <<Id: LICENSE_GC,v 1.1 2001/10/01 23:24:05 cgd Exp>>
+ *
+ * hcreate() / hsearch() / hdestroy()
+ *
+ * SysV/XPG4 hash table functions.
+ *
+ * Implementation done based on NetBSD manual page and Solaris manual page,
+ * plus my own personal experience about how they're supposed to work.
+ *
+ * I tried to look at Knuth (as cited by the Solaris manual page), but
+ * nobody had a copy in the office, so...
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sys/types.h>
+#include <sys/queue.h>
+
+#include <errno.h>
+#include <search.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "libc.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define MIN_BUCKETS_LG2 4
+#define MIN_BUCKETS     (1 << MIN_BUCKETS_LG2)
+#define MAX_BUCKETS_LG2 (sizeof (size_t) * 8 - 1 - 5)
+#define MAX_BUCKETS     ((size_t)1 << MAX_BUCKETS_LG2)
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct internal_entry
+{
+  SLIST_ENTRY(internal_entry) link;
+  ENTRY ent;
+};
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+SLIST_HEAD(internal_head, internal_entry);
+extern uint32_t (*g_default_hash)(FAR const void *, size_t);
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: hcreate_r
+ *
+ * Description:
+ *   Create a new hash table.
+ *
+ * Input Parameters:
+ *   nel - The number of elements in the hash table.
+ *   htab - The location to return the hash table reference.
+ *
+ * Returned Value:
+ *   1 on success; 0 on failure with errno set appropriately.
+ *
+ ****************************************************************************/
+
+int hcreate_r(size_t nel, FAR struct hsearch_data *htab)
+{
+  size_t idx;
+  unsigned int p2;
+
+  /* Make sure this this isn't called when a table already exists. */
+
+  if (htab->htable != NULL)
+    {
+      _NX_SETERRNO(-EINVAL);
+      return 0;
+    }
+
+  /* If nel is too small, make it min sized. */
+
+  if (nel < MIN_BUCKETS)
+    {
+      nel = MIN_BUCKETS;
+    }
+
+  /* If it's too large, cap it. */
+
+  if (nel > MAX_BUCKETS)
+    {
+      nel = MAX_BUCKETS;
+    }
+
+  /* If it's is not a power of two in size, round up. */
+
+  if ((nel & (nel - 1)) != 0)
+    {
+      for (p2 = 0; nel != 0; p2++)
+        {
+          nel >>= 1;
+        }
+
+      nel = 1 << p2;
+    }
+
+  /* Allocate the table. */
+
+  htab->htablesize = nel;
+  htab->htable = lib_malloc(htab->htablesize * sizeof htab->htable[0]);
+  if (htab->htable == NULL)
+    {
+      _NX_SETERRNO(-ENOMEM);
+      return 0;
+    }
+
+  /* Initialize it. */
+
+  for (idx = 0; idx < htab->htablesize; idx++)
+    {
+      SLIST_INIT(&(htab->htable[idx]));
+    }
+
+  return 1;
+}
+
+/****************************************************************************
+ * Name: hdestroy_r
+ *
+ * Description:
+ *   Destroy a hash table.
+ *
+ * Input Parameters:
+ *   htab - The hash table to be destroyed.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void hdestroy_r(FAR struct hsearch_data *htab)
+{
+  FAR struct internal_entry *ie;
+  size_t idx;
+
+  if (htab->htable == NULL)
+    {
+      return;
+    }
+
+  for (idx = 0; idx < htab->htablesize; idx++)
+    {
+      while (!SLIST_EMPTY(&(htab->htable[idx])))
+        {
+          ie = SLIST_FIRST(&(htab->htable[idx]));
+          SLIST_REMOVE_HEAD(&(htab->htable[idx]), link);
+          lib_free(ie->ent.key);
+          lib_free(ie);
+        }
+    }
+
+  lib_free(htab->htable);
+  htab->htable = NULL;
+}
+
+/****************************************************************************
+ * Name: hsearch_r
+ *
+ * Description:
+ *   Search for an entry in a hash table.
+ *
+ * Input Parameters:
+ *   item - The search key
+ *   action - The action to take if the item is not found
+ *   retval - The location to return the search result
+ *   htab - The hash table to be searched
+ *
+ * Returned Value:
+ *   1 on success; 0 on failure with errno set appropriately.
+ *
+ ****************************************************************************/
+
+int hsearch_r(ENTRY item, ACTION action, FAR ENTRY **retval,
+              FAR struct hsearch_data *htab)
+{
+  FAR struct internal_head *head;
+  FAR struct internal_entry *ie;
+  uint32_t hashval;
+  size_t len;
+
+  len = strlen(item.key);
+  hashval = (*g_default_hash)(item.key, len);
+
+  head = &(htab->htable[hashval & (htab->htablesize - 1)]);
+  ie = SLIST_FIRST(head);
+  while (ie != NULL)
+    {
+      if (strcmp(ie->ent.key, item.key) == 0)
+        {
+          break;
+        }
+
+      ie = SLIST_NEXT(ie, link);
+    }
+
+  if (ie != NULL)
+    {
+      *retval = &ie->ent;
+      return 1;
+    }
+  else if (action == FIND)
+    {
+      *retval = NULL;
+      return 0;
+    }
+
+  ie = lib_malloc(sizeof *ie);
+  if (ie == NULL)
+    {
+      *retval = NULL;
+      return 0;
+    }
+
+  ie->ent.key = item.key;
+  ie->ent.data = item.data;
+
+  SLIST_INSERT_HEAD(head, ie, link);
+  *retval = &ie->ent;
+  return 1;
+}

--- a/libs/libc/unistd/Make.defs
+++ b/libs/libc/unistd/Make.defs
@@ -30,6 +30,7 @@ CSRCS += lib_setrlimit.c lib_getrlimit.c lib_setpriority.c lib_getpriority.c
 CSRCS += lib_futimes.c lib_lutimes.c lib_gethostname.c lib_sethostname.c
 CSRCS += lib_fchownat.c lib_linkat.c lib_readlinkat.c lib_symlinkat.c
 CSRCS += lib_unlinkat.c lib_usleep.c lib_getpgrp.c lib_getpgid.c
+CSRCS += lib_lockf.c
 
 ifneq ($(CONFIG_SCHED_USER_IDENTITY),y)
 CSRCS += lib_setuid.c lib_setgid.c lib_getuid.c lib_getgid.c

--- a/libs/libc/unistd/lib_lockf.c
+++ b/libs/libc/unistd/lib_lockf.c
@@ -1,0 +1,117 @@
+/****************************************************************************
+ * libs/libc/unistd/lib_lockf.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: lockf
+ *
+ * Description:
+ *   lockf() is a function that allows a process to apply or remove an
+ *   advisory lock on an open file. The lock can be either a shared (read)
+ *   lock or an exclusive (write) lock. This lock is advisory, meaning that
+ *   it is not enforced by the system and it is up to cooperating processes
+ *   to honor the lock.
+ *
+ * Input Parameters:
+ *   fd  - File descriptor of the open file.
+ *   cmd - Specifies the type of lock operation to be performed.
+ *   It can be one of the following:
+ *     F_LOCK: Request an exclusive (write) lock. If the lock is not
+ *             available, the call may block until it can be acquired.
+ *     F_TLOCK: Try to request an exclusive (write) lock. If the lock is not
+ *              available, the call will not block and will return
+ *              immediately.
+ *     F_ULOCK: Unlock an existing lock.
+ *     F_TEST: Test the lock. Returns 0 if the file is unlocked or locked by
+ *             the calling process, or -1 with errno set to EACCES if another
+ *             process holds the lock.
+ *   len - Length of the locked region, relative to the current file
+ *         position.
+ *
+ * Returned Value:
+ *   The returned value of lockf() depends on the success or failure of the
+ *   operation. On success, the return value is 0. On failure, the return
+ *   value is -1, and the errno variable is set to indicate the specific
+ *   error.
+ *
+ ****************************************************************************/
+
+int lockf(int fd, int cmd, off_t len)
+{
+  struct flock lock;
+
+  lock.l_whence = SEEK_CUR;
+  lock.l_start = 0;
+  lock.l_len = len;
+
+  switch (cmd)
+    {
+      case F_LOCK:
+        {
+          lock.l_type = F_WRLCK;
+          return fcntl(fd, F_SETLKW, &lock);
+        }
+
+      case F_TLOCK:
+        {
+          lock.l_type = F_WRLCK;
+          return fcntl(fd, F_SETLK, &lock);
+        }
+
+      case F_ULOCK:
+        {
+          lock.l_type = F_UNLCK;
+          return fcntl(fd, F_SETLK, &lock);
+        }
+
+      case F_TEST:
+        {
+          lock.l_type = F_RDLCK;
+          if (fcntl(fd, F_GETLK, &lock) < 0)
+            {
+              return ERROR;
+            }
+
+          /* Check result */
+
+          if (lock.l_type == F_UNLCK || lock.l_pid == getpid())
+            {
+              return OK;
+            }
+
+          set_errno(EACCES);
+          return ERROR;
+        }
+    }
+
+  set_errno(EINVAL);
+  return ERROR;
+}


### PR DESCRIPTION
## Summary
I made functional implementations of F_SETLK, F_SETLKW, F_GETLK in fcntl to extend the capabilities of fcntl.
The way to implement this is to use a simple Hashtable implementation, using the path as the key to store the lock information context of a file, from which you can go to the lock, unlock, merge locks and other operations.
## Impact
Implemented file locking functionality, extending the F_SETLK, F_SETLKW, F_GETLK implementations in fcntl.
## Testing
Through a series of tests on file locks, its functionality aligns with Linux file locks
