### PR TITLE
assert: change the do-while of assert to a conditional expression

### DIFF
--- a/fs/procfs/fs_procfsmeminfo.c
+++ b/fs/procfs/fs_procfsmeminfo.c
@@ -454,7 +454,6 @@ static ssize_t memdump_write(FAR struct file *filep, FAR const char *buffer,
                              size_t buflen)
 {
   FAR struct procfs_meminfo_entry_s *entry;
-  FAR struct meminfo_file_s *procfile;
   struct mm_memdump_s dump =
     {
       PID_MM_ALLOC,
@@ -475,8 +474,7 @@ static ssize_t memdump_write(FAR struct file *filep, FAR const char *buffer,
 
   /* Recover our private data from the struct file instance */
 
-  procfile = filep->f_priv;
-  DEBUGASSERT(procfile);
+  DEBUGASSERT(filep->f_priv);
 
 #if CONFIG_MM_BACKTRACE > 0
   if (strcmp(buffer, "on") == 0)

--- a/include/assert.h
+++ b/include/assert.h
@@ -77,20 +77,10 @@
                                            __ASSERT_LINE__, msg, regs)
 
 #define __ASSERT__(f, file, line, _f) \
-  do                                  \
-    {                                 \
-      if (predict_false(!(f)))        \
-        __assert(file, line, _f);     \
-    }                                 \
-  while (0)
+  (predict_false(!(f))) ? __assert(file, line, _f) : ((void)0)
 
 #define __VERIFY__(f, file, line, _f) \
-  do                                  \
-    {                                 \
-      if (predict_false((f) < 0))     \
-        __assert(file, line, _f);     \
-    }                                 \
-  while (0)
+  (predict_false((f) < 0)) ? __assert(file, line, _f) : ((void)0)
 
 #ifdef CONFIG_DEBUG_ASSERTIONS_EXPRESSION
 #  define _ASSERT(f,file,line) __ASSERT__(f, file, line, #f)

--- a/include/assert.h
+++ b/include/assert.h
@@ -96,7 +96,7 @@
 #  define DEBUGVERIFY(f) _VERIFY(f, __DEBUG_ASSERT_FILE__, __DEBUG_ASSERT_LINE__)
 #else
 #  define DEBUGPANIC()
-#  define DEBUGASSERT(f) ((void)(1 || (f)))
+#  define DEBUGASSERT(f) ((void)(0))
 #  define DEBUGVERIFY(f) ((void)(f))
 #endif
 
@@ -106,7 +106,7 @@
  */
 
 #ifdef NDEBUG
-#  define assert(f) ((void)(1 || (f)))
+#  define assert(f) ((void)(0))
 #  define VERIFY(f) assert(f)
 #else
 #  define assert(f) _ASSERT(f, __ASSERT_FILE__, __ASSERT_LINE__)

--- a/mm/mm_heap/mm_foreach.c
+++ b/mm/mm_heap/mm_foreach.c
@@ -55,6 +55,7 @@ void mm_foreach(FAR struct mm_heap_s *heap, mm_node_handler_t handler,
 #  define region 0
 #endif
 
+  UNUSED(prev);
   DEBUGASSERT(handler);
 
   /* Visit each region */

--- a/mm/mm_heap/mm_mallinfo.c
+++ b/mm/mm_heap/mm_mallinfo.c
@@ -65,7 +65,7 @@ static void mallinfo_handler(FAR struct mm_allocnode_s *node, FAR void *arg)
   else
     {
       FAR struct mm_freenode_s *fnode = (FAR void *)node;
-
+      UNUSED(fnode);
       DEBUGASSERT(nodesize >= MM_MIN_CHUNK);
       DEBUGASSERT(fnode->blink->flink == fnode);
       DEBUGASSERT(MM_SIZEOF_NODE(fnode->blink) <= nodesize);

--- a/mm/mm_heap/mm_memdump.c
+++ b/mm/mm_heap/mm_memdump.c
@@ -104,7 +104,7 @@ static void memdump_handler(FAR struct mm_allocnode_s *node, FAR void *arg)
   else if (dump->pid == PID_MM_FREE)
     {
       FAR struct mm_freenode_s *fnode = (FAR void *)node;
-
+      UNUSED(fnode);
       DEBUGASSERT(nodesize >= MM_MIN_CHUNK);
       DEBUGASSERT(fnode->blink->flink == fnode);
       DEBUGASSERT(MM_SIZEOF_NODE(fnode->blink) <= nodesize);

--- a/sched/init/nx_bringup.c
+++ b/sched/init/nx_bringup.c
@@ -307,6 +307,7 @@ static inline void nx_start_application(void)
   posix_spawnattr_t attr;
 #endif
   int ret;
+  UNUSED(ret);
 
 #ifdef CONFIG_ETC_ROMFS
   nx_romfsetc();

--- a/sched/sched/sched_removeblocked.c
+++ b/sched/sched/sched_removeblocked.c
@@ -55,12 +55,10 @@
 
 void nxsched_remove_blocked(FAR struct tcb_s *btcb)
 {
-  tstate_t task_state = btcb->task_state;
-
   /* Make sure the TCB is in a valid blocked state */
 
-  DEBUGASSERT(task_state >= FIRST_BLOCKED_STATE &&
-              task_state <= LAST_BLOCKED_STATE);
+  DEBUGASSERT(btcb->task_state >= FIRST_BLOCKED_STATE &&
+              btcb->task_state <= LAST_BLOCKED_STATE);
 
   /* Remove the TCB from the blocked task list associated
    * with this state


### PR DESCRIPTION
## Summary
assert: change the do-while of assert to a conditional expression

According to the standard definition, assert should return a void expression
https://pubs.opengroup.org/onlinepubs/007904875/basedefs/assert.h.html

This patch involves two changes:

If you define the NDEBUG macro, assert does not use any parameters and directly returns a void expression.
assert should return a void expression and cannot use do-while statements.
If the following code , a compilation error will occur.

## Impact

## Testing
sim
