### PR TITLE
cmake/toolchain: fix compiler warning on ARM32

### DIFF
--- a/arch/arm/src/cmake/platform.cmake
+++ b/arch/arm/src/cmake/platform.cmake
@@ -59,15 +59,17 @@ endif()
 get_directory_property(NUTTX_EXTRA_FLAGS DIRECTORY ${CMAKE_SOURCE_DIR}
                                                    COMPILE_OPTIONS)
 
+separate_arguments(CMAKE_C_FLAG_ARGS NATIVE_COMMAND ${CMAKE_C_FLAGS})
+
 execute_process(
-  COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS} ${NUTTX_EXTRA_FLAGS}
+  COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
           --print-libgcc-file-name
   OUTPUT_STRIP_TRAILING_WHITESPACE
   OUTPUT_VARIABLE extra_library)
 if(NOT EXISTS ${extra_library} AND CONFIG_ARCH_TOOLCHAIN_CLANG)
   get_filename_component(COMPILER_RT_LIB ${extra_library} NAME)
   execute_process(
-    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS} ${NUTTX_EXTRA_FLAGS}
+    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
             --print-file-name ${COMPILER_RT_LIB}
     OUTPUT_STRIP_TRAILING_WHITESPACE
     OUTPUT_VARIABLE extra_library)
@@ -77,7 +79,7 @@ list(APPEND EXTRA_LIB ${extra_library})
 
 if(NOT CONFIG_LIBM)
   execute_process(
-    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS} ${NUTTX_EXTRA_FLAGS}
+    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
             --print-file-name=libm.a
     OUTPUT_STRIP_TRAILING_WHITESPACE
     OUTPUT_VARIABLE extra_library)
@@ -86,7 +88,7 @@ endif()
 
 if(CONFIG_LIBSUPCXX)
   execute_process(
-    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS} ${NUTTX_EXTRA_FLAGS}
+    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
             --print-file-name=libsupc++.a
     OUTPUT_STRIP_TRAILING_WHITESPACE
     OUTPUT_VARIABLE extra_library)
@@ -95,7 +97,7 @@ endif()
 
 if(CONFIG_ARCH_COVERAGE)
   execute_process(
-    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS} ${NUTTX_EXTRA_FLAGS}
+    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
             --print-file-name=libgcov.a
     OUTPUT_STRIP_TRAILING_WHITESPACE
     OUTPUT_VARIABLE extra_library)
@@ -104,5 +106,4 @@ endif()
 
 nuttx_add_extra_library(${EXTRA_LIB})
 
-separate_arguments(CMAKE_C_FLAG_ARGS NATIVE_COMMAND ${CMAKE_C_FLAGS})
 set(PREPROCES ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} -E -P -x c)

--- a/arch/risc-v/src/cmake/platform.cmake
+++ b/arch/risc-v/src/cmake/platform.cmake
@@ -21,10 +21,10 @@
 get_directory_property(NUTTX_EXTRA_FLAGS DIRECTORY ${CMAKE_SOURCE_DIR}
                                                    COMPILE_OPTIONS)
 
-separate_arguments(LIBPRT_CFLAGS NATIVE_COMMAND ${CMAKE_C_FLAGS})
+separate_arguments(CMAKE_C_FLAG_ARGS NATIVE_COMMAND ${CMAKE_C_FLAGS})
 
 execute_process(
-  COMMAND ${CMAKE_C_COMPILER} ${LIBPRT_CFLAGS} ${NUTTX_EXTRA_FLAGS}
+  COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
           --print-libgcc-file-name
   OUTPUT_STRIP_TRAILING_WHITESPACE
   OUTPUT_VARIABLE extra_library)
@@ -33,7 +33,7 @@ list(APPEND EXTRA_LIB ${extra_library})
 
 if(NOT CONFIG_LIBM)
   execute_process(
-    COMMAND ${CMAKE_C_COMPILER} ${LIBPRT_CFLAGS} ${NUTTX_EXTRA_FLAGS}
+    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
             --print-file-name=libm.a
     OUTPUT_STRIP_TRAILING_WHITESPACE
     OUTPUT_VARIABLE extra_library)
@@ -42,7 +42,7 @@ endif()
 
 if(CONFIG_LIBSUPCXX)
   execute_process(
-    COMMAND ${CMAKE_C_COMPILER} ${LIBPRT_CFLAGS} ${NUTTX_EXTRA_FLAGS}
+    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
             --print-file-name=libsupc++.a
     OUTPUT_STRIP_TRAILING_WHITESPACE
     OUTPUT_VARIABLE extra_library)
@@ -51,7 +51,7 @@ endif()
 
 if(CONFIG_ARCH_COVERAGE)
   execute_process(
-    COMMAND ${CMAKE_C_COMPILER} ${LIBPRT_CFLAGS} ${NUTTX_EXTRA_FLAGS}
+    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
             --print-file-name=libgcov.a
     OUTPUT_STRIP_TRAILING_WHITESPACE
     OUTPUT_VARIABLE extra_library)
@@ -60,5 +60,4 @@ endif()
 
 nuttx_add_extra_library(${EXTRA_LIB})
 
-separate_arguments(CMAKE_C_FLAG_ARGS NATIVE_COMMAND ${CMAKE_C_FLAGS})
 set(PREPROCES ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} -E -P -x c)


### PR DESCRIPTION

## Summary

cmake/toolchain: fix compiler warning on ARM32

```
-- Detecting CXX compile features
-- Detecting CXX compile features - done
arm-none-eabi-gcc: error:  -Wstrict-prototypes: No such file or directory
arm-none-eabi-gcc: error:  -Wstrict-prototypes: No such file or directory
-- Configuring done
-- Generating done
```

## Impact

N/A

## Testing

sabre-6quad/nsh