### PR TITLE
cmake:add target that define in external moduleCMakeLists.txt

### DIFF
--- a/cmake/nuttx_add_library.cmake
+++ b/cmake/nuttx_add_library.cmake
@@ -200,3 +200,22 @@ function(nuttx_library_import library_name library_path)
   set_target_properties(${library_name} PROPERTIES IMPORTED_LOCATION
                                                    ${library_path})
 endfunction()
+
+# nuttx_add_external_library
+#
+# the target library of add_library has been called in external CMakeLists.txt
+# so that they can be added to the final link
+#
+# Usually used with Nuttx to include an external system that already supports
+# CMake compilation
+function(nuttx_add_external_library target)
+  cmake_parse_arguments(ARGS MODE "" "" ${ARGN})
+  if(NOT ARGS_MODE)
+    set_property(GLOBAL APPEND PROPERTY NUTTX_SYSTEM_LIBRARIES ${target})
+  elseif("${ARGS_MODE}" STREQUAL "APPS")
+    set_property(GLOBAL APPEND PROPERTY NUTTX_APPS_LIBRARIES ${target})
+  elseif("${ARGS_MODE}" STREQUAL "KERNEL")
+    set_property(GLOBAL APPEND PROPERTY NUTTX_KERNEL_LIBRARIES ${target})
+  endif()
+  nuttx_add_library_internal(${target})
+endfunction()


### PR DESCRIPTION

## Summary

when NuttX's CMake build system calls an external module that already supports CMake,
since `add_library` may have been called internally,
it needs to provide a way to add its internally defined target to the final link.

Usually used with Nuttx to include an external system that already supports CMake compilation

for example:
```CMake
# lvgl support platform adaptation through cmake

# include lvgl CMakeLists.txt
add_subdirectory(${LVGL_CMAKELIST_DIR})
# prepare NuttX options for target
target_compile_options(lvgl PRIVATE ${CFLAGS})
# call add external lib
nuttx_add_external_library(lvgl)


```
## Impact
enhancement
no effect

## Testing
CI
