### PR TITLE
build/ci: fix CI blocking unused warning issues (nuttx repo part)

### DIFF
--- a/arch/arm/src/sama5/sam_ohci.c
+++ b/arch/arm/src/sama5/sam_ohci.c
@@ -2855,13 +2855,12 @@ errout:
 
 static int sam_epfree(struct usbhost_driver_s *drvr, usbhost_ep_t ep)
 {
-  struct sam_rhport_s *rhport = (struct sam_rhport_s *)drvr;
   struct sam_eplist_s *eplist = (struct sam_eplist_s *)ep;
   struct sam_ed_s *ed;
   int ret;
   int ret2;
 
-  DEBUGASSERT(rhport != NULL && eplist != NULL &&
+  DEBUGASSERT(drvr != NULL && eplist != NULL &&
               eplist->ed != NULL && eplist->tail != NULL);
 
   /* There should not be any pending, real TDs linked to this ED */

--- a/drivers/input/djoystick.c
+++ b/drivers/input/djoystick.c
@@ -588,6 +588,7 @@ static int djoy_poll(FAR struct file *filep, FAR struct pollfd *fds,
   opriv = filep->f_priv;
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private);
+  UNUSED(inode);
 
   /* Get exclusive access to the driver structure */
 

--- a/drivers/net/slip.c
+++ b/drivers/net/slip.c
@@ -630,6 +630,8 @@ static void slip_receive(FAR struct slip_driver_s *self)
         }
     }
 
+  UNUSED(ret);
+
   /* Move remaining bytes in rxbuf to the front */
 
   DEBUGASSERT((pend - self->rxbuf) <= self->rxlen);

--- a/fs/hostfs/hostfs.c
+++ b/fs/hostfs/hostfs.c
@@ -451,6 +451,7 @@ static ssize_t hostfs_read(FAR struct file *filep, FAR char *buffer,
   fs    = inode->i_private;
 
   DEBUGASSERT(fs != NULL);
+  UNUSED(fs);
 
   /* Take the lock */
 
@@ -493,6 +494,7 @@ static ssize_t hostfs_write(FAR struct file *filep, const char *buffer,
   fs    = inode->i_private;
 
   DEBUGASSERT(fs != NULL);
+  UNUSED(fs);
 
   /* Take the lock */
 
@@ -547,6 +549,7 @@ static off_t hostfs_seek(FAR struct file *filep, off_t offset, int whence)
   fs    = inode->i_private;
 
   DEBUGASSERT(fs != NULL);
+  UNUSED(fs);
 
   /* Take the lock */
 
@@ -588,8 +591,7 @@ static int hostfs_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   hf    = filep->f_priv;
   inode = filep->f_inode;
   fs    = inode->i_private;
-
-  DEBUGASSERT(fs != NULL);
+  UNUSED(fs);
 
   /* Take the lock */
 
@@ -633,6 +635,7 @@ static int hostfs_sync(FAR struct file *filep)
   fs    = inode->i_private;
 
   DEBUGASSERT(fs != NULL);
+  UNUSED(fs);
 
   /* Take the lock */
 
@@ -707,6 +710,7 @@ static int hostfs_fstat(FAR const struct file *filep, FAR struct stat *buf)
 
   fs    = inode->i_private;
   DEBUGASSERT(fs != NULL);
+  UNUSED(fs);
 
   /* Take the lock */
 
@@ -753,6 +757,7 @@ static int hostfs_fchstat(FAR const struct file *filep,
 
   fs    = inode->i_private;
   DEBUGASSERT(fs != NULL);
+  UNUSED(fs);
 
   /* Take the lock */
 
@@ -794,6 +799,7 @@ static int hostfs_ftruncate(FAR struct file *filep, off_t length)
 
   fs    = inode->i_private;
   DEBUGASSERT(fs != NULL);
+  UNUSED(fs);
 
   /* Take the lock */
 

--- a/fs/littlefs/Make.defs
+++ b/fs/littlefs/Make.defs
@@ -52,6 +52,7 @@ $(LITTLEFS_TARBALL):
 	$(Q) mv littlefs/littlefs-$(LITTLEFS_VERSION) littlefs/littlefs
 	$(Q) git apply littlefs/lfs_util.patch
 	$(Q) git apply littlefs/lfs_getpath.patch
+	$(Q) git apply littlefs/lfs_unused.patch
 	$(Q) touch littlefs/.littlefsunpack
 
 # Download and unpack tarball if no git repo found

--- a/libs/libc/machine/risc-v/arch_elf.c
+++ b/libs/libc/machine/risc-v/arch_elf.c
@@ -492,6 +492,7 @@ int up_relocateadd(const Elf_Rela *rel, const Elf_Sym *sym,
 
           insn = _get_val((uint16_t *)addr);
           ASSERT(OPCODE_AUIPC == (insn & RVI_OPCODE_MASK));
+          UNUSED(insn);
 
           _calc_imm(offset, &imm_hi, &imm_lo);
 

--- a/mm/mm_gran/mm_pgalloc.c
+++ b/mm/mm_gran/mm_pgalloc.c
@@ -125,6 +125,7 @@ void mm_pgreserve(uintptr_t start, size_t size)
 {
   FAR void * ret = gran_reserve(g_pgalloc, start, size);
   DEBUGASSERT(ret != NULL);
+  UNUSED(ret);
 }
 
 /****************************************************************************

--- a/net/bluetooth/bluetooth_input.c
+++ b/net/bluetooth/bluetooth_input.c
@@ -169,6 +169,7 @@ static int bluetooth_queue_frame(FAR struct bluetooth_conn_s *conn,
     }
 
   DEBUGASSERT((int)conn->bc_backlog == bluetooth_count_frames(conn));
+  UNUSED(bluetooth_count_frames);
 #endif
 
   return OK;

--- a/net/bluetooth/bluetooth_recvmsg.c
+++ b/net/bluetooth/bluetooth_recvmsg.c
@@ -153,6 +153,7 @@ static ssize_t
       DEBUGASSERT(conn->bc_backlog > 0);
       conn->bc_backlog--;
       DEBUGASSERT((int)conn->bc_backlog == bluetooth_count_frames(conn));
+      UNUSED(bluetooth_count_frames);
 #endif
 
       /* Extract the IOB containing the frame from the container */

--- a/net/ieee802154/ieee802154_input.c
+++ b/net/ieee802154/ieee802154_input.c
@@ -176,6 +176,7 @@ static int ieee802154_queue_frame(FAR struct ieee802154_conn_s *conn,
     }
 
   DEBUGASSERT((int)conn->backlog == ieee802154_count_frames(conn));
+  UNUSED(ieee802154_count_frames);
 #endif
 
   return OK;

--- a/net/ieee802154/ieee802154_recvmsg.c
+++ b/net/ieee802154/ieee802154_recvmsg.c
@@ -151,6 +151,7 @@ static ssize_t
       DEBUGASSERT(conn->backlog > 0);
       conn->backlog--;
       DEBUGASSERT((int)conn->backlog == ieee802154_count_frames(conn));
+      UNUSED(ieee802154_count_frames);
 #endif
 
       /* Extract the IOB containing the frame from the container */

--- a/net/netdev/netdev_ifconf.c
+++ b/net/netdev/netdev_ifconf.c
@@ -235,6 +235,7 @@ static int ifconf_ipv6_callback(FAR struct net_driver_s *dev, FAR void *arg)
   FAR struct ifconf_ipv6_info_s *info = (FAR struct ifconf_ipv6_info_s *)arg;
 
   DEBUGASSERT(dev != NULL && info != NULL && info->lifc != NULL);
+  UNUSED(info);
 
   /* Check if this adapter has an IPv6 address assigned and is in the UP
    * state.

--- a/wireless/bluetooth/bt_hcicore.c
+++ b/wireless/bluetooth/bt_hcicore.c
@@ -1525,6 +1525,7 @@ static void cmd_queue_init(void)
                        CONFIG_BLUETOOTH_TXCMD_STACKSIZE,
                        hci_tx_kthread, NULL);
   DEBUGASSERT(pid > 0);
+  UNUSED(pid);
 
 #ifdef CONFIG_BLUETOOTH_TXCMD_PINNED_TO_CORE
   CPU_ZERO(&cpuset);


### PR DESCRIPTION
## Summary

This patch attempts to fix CI blocking issues encountered with build 6374 of apps/pull/2300. They happened at various places, including the getprime app, which needs another patch 2301 in apps repo.

## Impact

CI checks

## Testing

CI checks
