### PR TITLE
rptun ioctl: remove rptun_panic and rptun_dump_all

### DIFF
--- a/drivers/rptun/rptun.c
+++ b/drivers/rptun/rptun.c
@@ -1053,13 +1053,3 @@ int rptun_reset(FAR const char *cpuname, int value)
 {
   return rpmsg_ioctl(cpuname, RPTUNIOC_RESET, value);
 }
-
-int rptun_panic(FAR const char *cpuname)
-{
-  return rpmsg_ioctl(cpuname, RPMSGIOC_PANIC, 0);
-}
-
-void rptun_dump_all(void)
-{
-  rpmsg_ioctl(NULL, RPMSGIOC_DUMP, 0);
-}

--- a/include/nuttx/rptun/rptun.h
+++ b/include/nuttx/rptun/rptun.h
@@ -359,8 +359,6 @@ int rptun_initialize(FAR struct rptun_dev_s *dev);
 int rptun_boot(FAR const char *cpuname);
 int rptun_poweroff(FAR const char *cpuname);
 int rptun_reset(FAR const char *cpuname, int value);
-int rptun_panic(FAR const char *cpuname);
-void rptun_dump_all(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION


## Summary
In the previous patch, we moved rptun_panic and rptun_dump_all in rptun to rpmsg. In order to ensure CI pass, this two API in rptun is not removed. so we remove rptun_panic and rptun_dump_all in this patch.
## Impact
remove redundant code.
## Testing
tested in sim vela.
