### PR TITLE
fix variable set but not used

### DIFF
--- a/arch/arm/src/sama5/sam_ohci.c
+++ b/arch/arm/src/sama5/sam_ohci.c
@@ -2855,13 +2855,12 @@ errout:
 
 static int sam_epfree(struct usbhost_driver_s *drvr, usbhost_ep_t ep)
 {
-  struct sam_rhport_s *rhport = (struct sam_rhport_s *)drvr;
   struct sam_eplist_s *eplist = (struct sam_eplist_s *)ep;
   struct sam_ed_s *ed;
   int ret;
   int ret2;
 
-  DEBUGASSERT(rhport != NULL && eplist != NULL &&
+  DEBUGASSERT(drvr != NULL && eplist != NULL &&
               eplist->ed != NULL && eplist->tail != NULL);
 
   /* There should not be any pending, real TDs linked to this ED */

--- a/arch/arm/src/stm32/stm32_foc.c
+++ b/arch/arm/src/stm32/stm32_foc.c
@@ -1322,6 +1322,8 @@ static int stm32_foc_configure(struct foc_dev_s *dev,
   struct stm32_foc_board_s *board = STM32_FOCBOARD_FROM_DEV_GET(dev);
   int                       ret   = OK;
 
+  UNUSED(board);
+
   DEBUGASSERT(dev);
   DEBUGASSERT(cfg);
   DEBUGASSERT(priv);
@@ -1830,6 +1832,7 @@ static int stm32_foc_worker_handler(struct foc_dev_s *dev)
   struct stm32_adc_dev_s   *adc   = ADC_FROM_FOC_DEV_GET(dev);
   int                       ret   = OK;
 
+  UNUSED(adc);
   DEBUGASSERT(dev);
   DEBUGASSERT(priv);
   DEBUGASSERT(adc);
@@ -2176,6 +2179,7 @@ static void stm32_foc_curr_get(struct foc_dev_s *dev,
   struct stm32_adc_dev_s  *adc  = ADC_FROM_FOC_DEV_GET(dev);
   int                      i    = 0;
 
+  UNUSED(priv);
   DEBUGASSERT(dev);
   DEBUGASSERT(priv);
   DEBUGASSERT(adc);

--- a/arch/xtensa/src/esp32/esp32_cpustart.c
+++ b/arch/xtensa/src/esp32/esp32_cpustart.c
@@ -75,6 +75,7 @@ static inline void xtensa_attach_fromcpu0_interrupt(void)
 
   /* Connect all CPU peripheral source to allocated CPU interrupt */
 
+  UNUSED(cpuint);
   cpuint = esp32_setup_irq(1, ESP32_PERIPH_CPU_CPU0, 1, ESP32_CPUINT_LEVEL);
   DEBUGASSERT(cpuint >= 0);
 

--- a/arch/xtensa/src/esp32/esp32_irq.c
+++ b/arch/xtensa/src/esp32/esp32_irq.c
@@ -239,6 +239,7 @@ static inline void xtensa_attach_fromcpu1_interrupt(void)
 
   /* Connect all CPU peripheral source to allocated CPU interrupt */
 
+  UNUSED(cpuint);
   cpuint = esp32_setup_irq(0, ESP32_PERIPH_CPU_CPU1, 1, ESP32_CPUINT_LEVEL);
   DEBUGASSERT(cpuint >= 0);
 

--- a/arch/xtensa/src/esp32/esp32_tim_lowerhalf.c
+++ b/arch/xtensa/src/esp32/esp32_tim_lowerhalf.c
@@ -467,6 +467,7 @@ static void esp32_timer_setcallback(struct timer_lowerhalf_s *lower,
   irqstate_t flags;
   int ret = OK;
 
+  UNUSED(ret);
   DEBUGASSERT(priv);
 
   /* Save the new callback */

--- a/arch/xtensa/src/esp32/esp32_userspace.c
+++ b/arch/xtensa/src/esp32/esp32_userspace.c
@@ -144,6 +144,7 @@ static noinline_function IRAM_ATTR void configure_flash_mmu(void)
   uint32_t irom_lma_aligned;
   uint32_t irom_vma_aligned;
   uint32_t irom_page_count;
+  int ret;
 
   size_t partition_offset = USER_IMAGE_OFFSET;
   uint32_t app_drom_lma = partition_offset + g_header.drom_lma;
@@ -153,40 +154,49 @@ static noinline_function IRAM_ATTR void configure_flash_mmu(void)
   uint32_t app_irom_size = g_header.irom_size;
   uint32_t app_irom_vma = g_header.irom_vma;
 
+  UNUSED(ret);
   cache_read_disable(0);
   cache_flush(0);
 
   drom_lma_aligned = app_drom_lma & MMU_FLASH_MASK;
   drom_vma_aligned = app_drom_vma & MMU_FLASH_MASK;
   drom_page_count = calc_mmu_pages(app_drom_size, app_drom_vma);
-  ASSERT(cache_flash_mmu_set(0, PIDCTRL_PID_KERNEL, drom_vma_aligned,
-                             drom_lma_aligned, 64,
-                             (int)drom_page_count) == 0);
-  ASSERT(cache_flash_mmu_set(1, PIDCTRL_PID_KERNEL, drom_vma_aligned,
-                             drom_lma_aligned, 64,
-                             (int)drom_page_count) == 0);
-  ASSERT(cache_flash_mmu_set(0, PIDCTRL_PID_USER, drom_vma_aligned,
-                             drom_lma_aligned, 64,
-                             (int)drom_page_count) == 0);
-  ASSERT(cache_flash_mmu_set(1, PIDCTRL_PID_USER, drom_vma_aligned,
-                             drom_lma_aligned, 64,
-                             (int)drom_page_count) == 0);
+  cache_flash_mmu_set(0, PIDCTRL_PID_KERNEL, drom_vma_aligned,
+                      drom_lma_aligned, 64,
+                      (int)drom_page_count);
+  ASSERT(ret == 0);
+  cache_flash_mmu_set(1, PIDCTRL_PID_KERNEL, drom_vma_aligned,
+                      drom_lma_aligned, 64,
+                      (int)drom_page_count);
+  ASSERT(ret == 0);
+  ret = cache_flash_mmu_set(0, PIDCTRL_PID_USER, drom_vma_aligned,
+                            drom_lma_aligned, 64,
+                            (int)drom_page_count);
+  ASSERT(ret == 0);
+  ret = cache_flash_mmu_set(1, PIDCTRL_PID_USER, drom_vma_aligned,
+                            drom_lma_aligned, 64,
+                            (int)drom_page_count);
+  ASSERT(ret == 0);
 
   irom_lma_aligned = app_irom_lma & MMU_FLASH_MASK;
   irom_vma_aligned = app_irom_vma & MMU_FLASH_MASK;
   irom_page_count = calc_mmu_pages(app_irom_size, app_irom_vma);
-  ASSERT(cache_flash_mmu_set(0, PIDCTRL_PID_KERNEL, irom_vma_aligned,
-                             irom_lma_aligned, 64,
-                             (int)irom_page_count) == 0);
-  ASSERT(cache_flash_mmu_set(1, PIDCTRL_PID_KERNEL, irom_vma_aligned,
-                             irom_lma_aligned, 64,
-                             (int)irom_page_count) == 0);
-  ASSERT(cache_flash_mmu_set(0, PIDCTRL_PID_USER, irom_vma_aligned,
-                             irom_lma_aligned, 64,
-                             (int)irom_page_count) == 0);
-  ASSERT(cache_flash_mmu_set(1, PIDCTRL_PID_USER, irom_vma_aligned,
-                             irom_lma_aligned, 64,
-                             (int)irom_page_count) == 0);
+  ret = cache_flash_mmu_set(0, PIDCTRL_PID_KERNEL, irom_vma_aligned,
+                            irom_lma_aligned, 64,
+                            (int)irom_page_count);
+  ASSERT(ret == 0);
+  ret = cache_flash_mmu_set(1, PIDCTRL_PID_KERNEL, irom_vma_aligned,
+                            irom_lma_aligned, 64,
+                            (int)irom_page_count);
+  ASSERT(ret == 0);
+  ret = cache_flash_mmu_set(0, PIDCTRL_PID_USER, irom_vma_aligned,
+                            irom_lma_aligned, 64,
+                            (int)irom_page_count);
+  ASSERT(ret == 0);
+  ret = cache_flash_mmu_set(1, PIDCTRL_PID_USER, irom_vma_aligned,
+                            irom_lma_aligned, 64,
+                            (int)irom_page_count);
+  ASSERT(ret == 0);
 
   cache_read_enable(0);
 }
@@ -254,14 +264,17 @@ static noinline_function IRAM_ATTR const void *map_flash(uint32_t src_addr,
 {
   uint32_t src_addr_aligned;
   uint32_t page_count;
+  int ret;
 
+  UNUSED(ret);
   cache_read_disable(0);
   cache_flush(0);
 
   src_addr_aligned = src_addr & MMU_FLASH_MASK;
   page_count = calc_mmu_pages(size, src_addr);
-  ASSERT(cache_flash_mmu_set(0, PIDCTRL_PID_KERNEL, MMU_BLOCK50_VADDR,
-                             src_addr_aligned, 64, (int)page_count) == 0);
+  ret = cache_flash_mmu_set(0, PIDCTRL_PID_KERNEL, MMU_BLOCK50_VADDR,
+                      src_addr_aligned, 64, (int)page_count);
+  ASSERT(ret == 0);
 
   cache_read_enable(0);
 

--- a/boards/arm/cxd56xx/spresense/src/cxd56_automount.c
+++ b/boards/arm/cxd56xx/spresense/src/cxd56_automount.c
@@ -212,6 +212,7 @@ static void sdcard_enable(const struct automount_lower_s *lower,
 static bool sdcard_inserted(const struct automount_lower_s *lower)
 {
   const struct cxd56_automount_config_s *config;
+  UNUSED(config);
 
   config = (struct cxd56_automount_config_s *)lower;
   DEBUGASSERT(config && config->state);

--- a/drivers/input/djoystick.c
+++ b/drivers/input/djoystick.c
@@ -578,7 +578,6 @@ static int djoy_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 static int djoy_poll(FAR struct file *filep, FAR struct pollfd *fds,
                      bool setup)
 {
-  FAR struct inode *inode;
   FAR struct djoy_open_s *opriv;
   irqstate_t flags;
   int ret = OK;
@@ -586,8 +585,7 @@ static int djoy_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
   DEBUGASSERT(filep->f_priv);
   opriv = filep->f_priv;
-  inode = filep->f_inode;
-  DEBUGASSERT(inode->i_private);
+  DEBUGASSERT(filep->f_inode->i_private);
 
   /* Get exclusive access to the driver structure */
 

--- a/drivers/net/w5500.c
+++ b/drivers/net/w5500.c
@@ -493,6 +493,7 @@ static void w5500_lock(FAR struct w5500_driver_s *self)
 {
   int ret;
 
+  UNUSED(ret);
   ret = SPI_LOCK(self->spi_dev, true);
   DEBUGASSERT(ret == OK);
 
@@ -518,6 +519,7 @@ static void w5500_unlock(FAR struct w5500_driver_s *self)
 {
   int ret;
 
+  UNUSED(ret);
   SPI_SELECT(self->spi_dev, SPIDEV_ETHERNET(self->lower->spidevid), false);
   ret = SPI_LOCK(self->spi_dev, false);
   DEBUGASSERT(ret == OK);

--- a/drivers/wireless/gs2200m.c
+++ b/drivers/wireless/gs2200m.c
@@ -325,6 +325,7 @@ static uint16_t _to_uint16(char *str)
 {
   uint16_t ret = 0;
   int n;
+  UNUSED(n);
 
   n = sscanf(str, "%04hu", &ret);
   ASSERT(1 == n);
@@ -600,6 +601,7 @@ static void _remove_all_pkt(FAR struct gs2200m_dev_s *dev, uint8_t c)
   FAR struct pkt_dat_s *pkt_dat;
   uint32_t mask;
 
+  UNUSED(mask);
   mask = 1 << c;
   ASSERT(0 == (dev->valid_cid_bits & mask));
 
@@ -1091,6 +1093,7 @@ static void _parse_pkt_in_s1(FAR struct pkt_ctx_s *pkt_ctx,
   int msize;
   int n;
 
+  UNUSED(n);
   if (ASCII_LF != *(pkt_ctx->ptr))
     {
       return;
@@ -1251,6 +1254,7 @@ static void _parse_pkt_in_s4(FAR struct pkt_ctx_s *pkt_ctx,
   char port[6];
   int n;
 
+  UNUSED(n);
   ASSERT(pkt_dat);
 
   if ('z' == pkt_ctx->cid)
@@ -1691,6 +1695,7 @@ static enum pkt_type_e gs2200m_join_network(FAR struct gs2200m_dev_s *dev,
 
   /* Initialize pkt_dat and send command */
 
+  UNUSED(n);
   memset(&pkt_dat, 0, sizeof(pkt_dat));
 
   if (0 == dev->op_mode)
@@ -2207,6 +2212,8 @@ static enum pkt_type_e gs2200m_get_cstatus(FAR struct gs2200m_dev_s *dev,
       int  p[2];
       char type[8];
       char mode[8];
+
+      UNUSED(n);
       memset(type, 0, sizeof(type));
       memset(mode, 0, sizeof(mode));
       n = sscanf(pkt_dat.msg[i], "%c %7s %6s %d %d %d.%d.%d.%d",
@@ -2537,6 +2544,7 @@ static int gs2200m_ioctl_accept(FAR struct gs2200m_dev_s *dev,
   int ret = OK;
   int n;
 
+  UNUSED(n);
   wlinfo("+++ start: cid=%c\n", msg->cid);
 
   c = _cid_to_uint8(msg->cid);
@@ -2605,6 +2613,7 @@ static int gs2200m_ioctl_assoc_sta(FAR struct gs2200m_dev_s *dev,
 
   /* Remember assoc request msg for reconnection */
 
+  UNUSED(t);
   memcpy(&dev->reconnect_msg, msg, sizeof(struct gs2200m_assoc_msg));
 
   /* Disassociate */
@@ -2680,6 +2689,7 @@ static int gs2200m_ioctl_assoc_ap(FAR struct gs2200m_dev_s *dev,
 
   /* Set to AP mode */
 
+  UNUSED(t);
   t = gs2200m_set_opmode(dev, 2);
   ASSERT(TYPE_OK == t);
 
@@ -3372,6 +3382,7 @@ static int gs2200m_start(FAR struct gs2200m_dev_s *dev)
 
   /* Check boot msg */
 
+  UNUSED(t);
   wlinfo("*** wait for boot msg\n");
 
   while (dev->lower->dready(NULL))

--- a/drivers/wireless/ieee802154/xbee/xbee_mac.c
+++ b/drivers/wireless/ieee802154/xbee/xbee_mac.c
@@ -295,7 +295,6 @@ int xbee_req_data(XBEEHANDLE xbee,
   int index;
   uint16_t apiframelen;
   uint8_t frametype;
-  int prevoffs = frame->io_offset;
 #ifdef CONFIG_XBEE_LOCKUP_WORKAROUND
   int retries = XBEE_LOCKUP_SENDATTEMPTS;
 #endif
@@ -352,7 +351,7 @@ int xbee_req_data(XBEEHANDLE xbee,
 
   frame->io_data[index++] = 0; /* Options byte. Currently we do not support anything here */
 
-  DEBUGASSERT(index == prevoffs);
+  DEBUGASSERT(index == frame->io_offset);
 
   /* Increment io_len by 1 to account for checksum */
 

--- a/fs/hostfs/hostfs.c
+++ b/fs/hostfs/hostfs.c
@@ -435,8 +435,6 @@ okout:
 static ssize_t hostfs_read(FAR struct file *filep, FAR char *buffer,
                            size_t buflen)
 {
-  FAR struct inode *inode;
-  FAR struct hostfs_mountpt_s *fs;
   FAR struct hostfs_ofile_s *hf;
   ssize_t ret;
 
@@ -447,10 +445,7 @@ static ssize_t hostfs_read(FAR struct file *filep, FAR char *buffer,
   /* Recover our private data from the struct file instance */
 
   hf    = filep->f_priv;
-  inode = filep->f_inode;
-  fs    = inode->i_private;
-
-  DEBUGASSERT(fs != NULL);
+  DEBUGASSERT(filep->f_inode->i_private != NULL);
 
   /* Take the lock */
 
@@ -479,8 +474,6 @@ static ssize_t hostfs_read(FAR struct file *filep, FAR char *buffer,
 static ssize_t hostfs_write(FAR struct file *filep, const char *buffer,
                          size_t buflen)
 {
-  FAR struct inode *inode;
-  FAR struct hostfs_mountpt_s *fs;
   FAR struct hostfs_ofile_s *hf;
   ssize_t ret;
 
@@ -489,10 +482,7 @@ static ssize_t hostfs_write(FAR struct file *filep, const char *buffer,
   /* Recover our private data from the struct file instance */
 
   hf    = filep->f_priv;
-  inode = filep->f_inode;
-  fs    = inode->i_private;
-
-  DEBUGASSERT(fs != NULL);
+  DEBUGASSERT(filep->f_inode->i_private != NULL);
 
   /* Take the lock */
 
@@ -531,8 +521,6 @@ errout_with_lock:
 
 static off_t hostfs_seek(FAR struct file *filep, off_t offset, int whence)
 {
-  FAR struct inode *inode;
-  FAR struct hostfs_mountpt_s *fs;
   FAR struct hostfs_ofile_s *hf;
   off_t ret;
 
@@ -543,10 +531,7 @@ static off_t hostfs_seek(FAR struct file *filep, off_t offset, int whence)
   /* Recover our private data from the struct file instance */
 
   hf    = filep->f_priv;
-  inode = filep->f_inode;
-  fs    = inode->i_private;
-
-  DEBUGASSERT(fs != NULL);
+  DEBUGASSERT(filep->f_inode->i_private != NULL);
 
   /* Take the lock */
 
@@ -574,8 +559,6 @@ static off_t hostfs_seek(FAR struct file *filep, off_t offset, int whence)
 
 static int hostfs_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 {
-  FAR struct inode *inode;
-  FAR struct hostfs_mountpt_s *fs;
   FAR struct hostfs_ofile_s *hf;
   int ret;
 
@@ -586,10 +569,7 @@ static int hostfs_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   /* Recover our private data from the struct file instance */
 
   hf    = filep->f_priv;
-  inode = filep->f_inode;
-  fs    = inode->i_private;
-
-  DEBUGASSERT(fs != NULL);
+  DEBUGASSERT(filep->f_inode->i_private != NULL);
 
   /* Take the lock */
 
@@ -617,8 +597,6 @@ static int hostfs_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
 static int hostfs_sync(FAR struct file *filep)
 {
-  FAR struct inode            *inode;
-  FAR struct hostfs_mountpt_s *fs;
   FAR struct hostfs_ofile_s   *hf;
   int ret;
 
@@ -629,10 +607,7 @@ static int hostfs_sync(FAR struct file *filep)
   /* Recover our private data from the struct file instance */
 
   hf    = filep->f_priv;
-  inode = filep->f_inode;
-  fs    = inode->i_private;
-
-  DEBUGASSERT(fs != NULL);
+  DEBUGASSERT(filep->f_inode->i_private != NULL);
 
   /* Take the lock */
 
@@ -690,8 +665,6 @@ static int hostfs_dup(FAR const struct file *oldp, FAR struct file *newp)
 
 static int hostfs_fstat(FAR const struct file *filep, FAR struct stat *buf)
 {
-  FAR struct inode *inode;
-  FAR struct hostfs_mountpt_s *fs;
   FAR struct hostfs_ofile_s *hf;
   int ret = OK;
 
@@ -703,10 +676,7 @@ static int hostfs_fstat(FAR const struct file *filep, FAR struct stat *buf)
 
   DEBUGASSERT(filep->f_priv != NULL);
   hf    = filep->f_priv;
-  inode = filep->f_inode;
-
-  fs    = inode->i_private;
-  DEBUGASSERT(fs != NULL);
+  DEBUGASSERT(filep->f_inode->i_private != NULL);
 
   /* Take the lock */
 
@@ -736,8 +706,6 @@ static int hostfs_fstat(FAR const struct file *filep, FAR struct stat *buf)
 static int hostfs_fchstat(FAR const struct file *filep,
                           FAR const struct stat *buf, int flags)
 {
-  FAR struct inode *inode;
-  FAR struct hostfs_mountpt_s *fs;
   FAR struct hostfs_ofile_s *hf;
   int ret = OK;
 
@@ -749,10 +717,7 @@ static int hostfs_fchstat(FAR const struct file *filep,
 
   DEBUGASSERT(filep->f_priv != NULL);
   hf    = filep->f_priv;
-  inode = filep->f_inode;
-
-  fs    = inode->i_private;
-  DEBUGASSERT(fs != NULL);
+  DEBUGASSERT(filep->f_inode->i_private != NULL);
 
   /* Take the lock */
 
@@ -781,8 +746,6 @@ static int hostfs_fchstat(FAR const struct file *filep,
 
 static int hostfs_ftruncate(FAR struct file *filep, off_t length)
 {
-  FAR struct inode *inode;
-  FAR struct hostfs_mountpt_s *fs;
   FAR struct hostfs_ofile_s *hf;
   int ret = OK;
 
@@ -790,10 +753,7 @@ static int hostfs_ftruncate(FAR struct file *filep, off_t length)
 
   DEBUGASSERT(filep->f_priv != NULL);
   hf    = filep->f_priv;
-  inode = filep->f_inode;
-
-  fs    = inode->i_private;
-  DEBUGASSERT(fs != NULL);
+  DEBUGASSERT(filep->f_inode->i_private != NULL);
 
   /* Take the lock */
 

--- a/fs/littlefs/Make.defs
+++ b/fs/littlefs/Make.defs
@@ -31,6 +31,11 @@ CSRCS += lfs.c lfs_util.c
 DEPPATH += --dep-path littlefs/littlefs
 VPATH += :littlefs/littlefs
 
+# Fix warnings in littlefs
+# Error: littlefs/littlefs/lfs.c:450:13: error: 'lfs_mlist_isopen' defined but not used [-Werror=unused-function]
+
+littlefs/littlefs/lfs.c_CFLAGS += -Wno-error=unused-function
+
 CFLAGS += -DLFS_TRACE=finfo
 CFLAGS += -DLFS_DEBUG=finfo
 CFLAGS += -DLFS_WARN=fwarn

--- a/libs/libc/machine/risc-v/arch_elf.c
+++ b/libs/libc/machine/risc-v/arch_elf.c
@@ -482,6 +482,7 @@ int up_relocateadd(const Elf_Rela *rel, const Elf_Sym *sym,
           long imm_hi;
           long imm_lo;
 
+          UNUSED(insn);
           binfo("%s at %08" PRIxPTR " [%08" PRIx32 "] "
                 "to sym=%p st_value=%08lx\n",
                 _get_rname(relotype),

--- a/mm/mm_gran/mm_pgalloc.c
+++ b/mm/mm_gran/mm_pgalloc.c
@@ -124,6 +124,7 @@ void mm_pginitialize(FAR void *heap_start, size_t heap_size)
 void mm_pgreserve(uintptr_t start, size_t size)
 {
   FAR void * ret = gran_reserve(g_pgalloc, start, size);
+  UNUSED(ret);
   DEBUGASSERT(ret != NULL);
 }
 

--- a/net/bluetooth/bluetooth_input.c
+++ b/net/bluetooth/bluetooth_input.c
@@ -98,6 +98,9 @@ static int bluetooth_queue_frame(FAR struct bluetooth_conn_s *conn,
                                   FAR struct bluetooth_frame_meta_s *meta)
 {
   FAR struct bluetooth_container_s *container;
+  int ret;
+
+  UNUSED(ret);
 
   /* Allocate a container for the frame */
 
@@ -168,7 +171,8 @@ static int bluetooth_queue_frame(FAR struct bluetooth_conn_s *conn,
       conn->bc_backlog++;
     }
 
-  DEBUGASSERT((int)conn->bc_backlog == bluetooth_count_frames(conn));
+  ret = bluetooth_count_frames(conn);
+  DEBUGASSERT((int)conn->bc_backlog == ret);
 #endif
 
   return OK;

--- a/net/bluetooth/bluetooth_recvmsg.c
+++ b/net/bluetooth/bluetooth_recvmsg.c
@@ -152,7 +152,8 @@ static ssize_t
 
       DEBUGASSERT(conn->bc_backlog > 0);
       conn->bc_backlog--;
-      DEBUGASSERT((int)conn->bc_backlog == bluetooth_count_frames(conn));
+      ret = bluetooth_count_frames(conn);
+      DEBUGASSERT((int)conn->bc_backlog == ret);
 #endif
 
       /* Extract the IOB containing the frame from the container */

--- a/net/netdev/netdev_ifconf.c
+++ b/net/netdev/netdev_ifconf.c
@@ -234,6 +234,7 @@ static int ifconf_ipv6_callback(FAR struct net_driver_s *dev, FAR void *arg)
 {
   FAR struct ifconf_ipv6_info_s *info = (FAR struct ifconf_ipv6_info_s *)arg;
 
+  UNUSED(info);
   DEBUGASSERT(dev != NULL && info != NULL && info->lifc != NULL);
 
   /* Check if this adapter has an IPv6 address assigned and is in the UP

--- a/openamp/Makefile
+++ b/openamp/Makefile
@@ -31,6 +31,7 @@ COBJS = $(CSRCS:.c=$(OBJEXT))
 SRCS = $(ASRCS) $(CSRCS)
 OBJS = $(AOBJS) $(COBJS)
 
+CFLAGS += -Wno-error=unused-but-set-variable
 BIN = libopenamp$(LIBEXT)
 
 all: $(BIN)

--- a/sched/group/group_setuptaskfiles.c
+++ b/sched/group/group_setuptaskfiles.c
@@ -67,6 +67,7 @@ int group_setuptaskfiles(FAR struct task_tcb_s *tcb,
   FAR struct tcb_s *rtcb = this_task();
 #endif
 
+  UNUSED(group);
   sched_trace_begin();
   DEBUGASSERT(group);
 #ifndef CONFIG_DISABLE_PTHREAD

--- a/wireless/bluetooth/bt_hcicore.c
+++ b/wireless/bluetooth/bt_hcicore.c
@@ -1504,6 +1504,8 @@ static void cmd_queue_init(void)
 #endif
   int pid;
 
+  UNUSED(PID);
+
   /* When there is a command to be sent to the Bluetooth driver, it queued on
    * the Tx queue and received by logic on the Tx kernel thread.
    */


### PR DESCRIPTION
## Summary
These variables will trigger variable 'ret' set but not used warnings due to different configurations.

For using variables only in assert, added UNUSED to declare
Warnings in external repositories are ignored in the makefile

## Impact

## Testing

