### PR TITLE
arch/x86_64: add cmake support

### DIFF
--- a/arch/x86_64/CMakeLists.txt
+++ b/arch/x86_64/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# arch/x86_64/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+nuttx_add_subdirectory()

--- a/arch/x86_64/src/CMakeLists.txt
+++ b/arch/x86_64/src/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# arch/x86_64/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(${ARCH_SUBDIR})
+add_subdirectory(${NUTTX_CHIP_ABS_DIR} EXCLUDE_FROM_ALL exclude_chip)
+add_subdirectory(common)
+
+# Include directories (before system ones) as PUBLIC so that it can be exposed
+# to libboard
+target_include_directories(arch BEFORE PUBLIC ${NUTTX_CHIP_ABS_DIR} common
+                                              ${ARCH_SUBDIR})
+
+if(NOT CONFIG_BUILD_FLAT)
+  target_include_directories(arch_interface BEFORE PUBLIC ${NUTTX_CHIP_ABS_DIR}
+                                                          common ${ARCH_SUBDIR})
+endif()

--- a/arch/x86_64/src/cmake/Toolchain.cmake
+++ b/arch/x86_64/src/cmake/Toolchain.cmake
@@ -1,0 +1,121 @@
+# ##############################################################################
+# arch/x86_64/src/cmake/Toolchain.cmake
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+# Toolchain
+
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_VERSION 1)
+
+set(ARCH_SUBDIR intel64)
+
+# override the ARCHIVE command
+
+set(CMAKE_C_ARCHIVE_CREATE "<CMAKE_AR> rcs <TARGET> <LINK_FLAGS> <OBJECTS>")
+set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> rcs <TARGET> <LINK_FLAGS> <OBJECTS>")
+set(CMAKE_ASM_ARCHIVE_CREATE "<CMAKE_AR> rcs <TARGET> <LINK_FLAGS> <OBJECTS>")
+
+if(CONFIG_DEBUG_CUSTOMOPT)
+  add_compile_options(${CONFIG_DEBUG_OPTLEVEL})
+elseif(CONFIG_DEBUG_FULLOPT)
+  add_compile_options(-Os)
+endif()
+
+if(NOT CONFIG_DEBUG_NOOPT)
+  add_compile_options(-fno-strict-aliasing)
+endif()
+
+# NOTE: don't set -fomit-frame-pointer - it breaks debugging with gdb. The
+# addresses of local variables are shifted in gdb if this option is enabled
+
+if(CONFIG_FRAME_POINTER)
+  add_compile_options(-fno-omit-frame-pointer -fno-optimize-sibling-calls)
+endif()
+
+if(CONFIG_STACK_CANARIES)
+  add_compile_options(-fstack-protector-all)
+else()
+  add_compile_options(-fno-stack-protector)
+endif()
+
+if(CONFIG_STACK_USAGE)
+  add_compile_options(-fstack-usage)
+endif()
+
+if(${CONFIG_STACK_USAGE_WARNING})
+  if(NOT ${CONFIG_STACK_USAGE_WARNING} STREQUAL 0)
+    add_compile_options(-Wstack-usage=${CONFIG_STACK_USAGE_WARNING})
+  endif()
+endif()
+
+if(CONFIG_ARCH_COVERAGE)
+  add_compile_options(-fprofile-generate -ftest-coverage)
+endif()
+
+if(CONFIG_DEBUG_SYMBOLS)
+  add_compile_options(-g)
+endif()
+
+# Architecture flags
+
+add_link_options(-Wl,--entry=__pmode_entry)
+add_link_options(-z max-page-size=0x1000)
+add_link_options(-no-pie -nostdlib)
+add_link_options(-Wl,--no-relax)
+add_compile_options(-fPIC)
+add_compile_options(-mno-red-zone)
+
+if(CONFIG_DEBUG_LINK_MAP)
+  add_link_options(-Wl,--cref -Wl,-Map=nuttx.map)
+endif()
+
+set(ARCHCFLAGS
+    "-Wstrict-prototypes -fno-common -Wall -Wshadow -Wundef -Wno-attributes -Wno-unknown-pragmas"
+)
+set(ARCHCXXFLAGS
+    "-nostdinc++ -fno-common -Wall -Wshadow -Wundef -Wno-attributes -Wno-unknown-pragmas"
+)
+
+if(CONFIG_CXX_EXCEPTION)
+  string(APPEND ARCHCXXFLAGS " -fno-exceptions -fcheck-new")
+endif()
+
+if(CONFIG_CXX_RTTI)
+  string(APPEND ARCHCXXFLAGS " -fno-rtti")
+endif()
+
+if(NOT "${CMAKE_C_FLAGS}" STREQUAL "")
+  string(REGEX MATCH "${ARCHCFLAGS}" EXISTS_FLAGS "${CMAKE_C_FLAGS}")
+endif()
+
+if(NOT EXISTS_FLAGS)
+  set(CMAKE_ASM_FLAGS
+      "${CMAKE_ASM_FLAGS} ${ARCHCFLAGS}"
+      CACHE STRING "" FORCE)
+  set(CMAKE_C_FLAGS
+      "${CMAKE_C_FLAGS} ${ARCHCFLAGS}"
+      CACHE STRING "" FORCE)
+  set(CMAKE_CXX_FLAGS
+      "${CMAKE_CXX_FLAGS} ${ARCHCXXFLAGS}"
+      CACHE STRING "" FORCE)
+endif()
+
+if(CONFIG_ARCH_INTEL64_HAVE_RDRAND)
+  add_compile_options(-mrdrnd)
+endif()

--- a/arch/x86_64/src/cmake/platform.cmake
+++ b/arch/x86_64/src/cmake/platform.cmake
@@ -1,0 +1,62 @@
+# ##############################################################################
+# arch/x86_64/src/cmake/platform.cmake
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+get_directory_property(NUTTX_EXTRA_FLAGS DIRECTORY ${CMAKE_SOURCE_DIR}
+                                                   COMPILE_OPTIONS)
+
+execute_process(
+  COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS} ${NUTTX_EXTRA_FLAGS}
+          --print-libgcc-file-name
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  OUTPUT_VARIABLE extra_library)
+
+list(APPEND EXTRA_LIB ${extra_library})
+
+if(NOT CONFIG_LIBM)
+  execute_process(
+    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS} ${NUTTX_EXTRA_FLAGS}
+            --print-file-name=libm.a
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE extra_library)
+  list(APPEND EXTRA_LIB ${extra_library})
+endif()
+
+if(CONFIG_LIBSUPCXX)
+  execute_process(
+    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS} ${NUTTX_EXTRA_FLAGS}
+            --print-file-name=libsupc++.a
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE extra_library)
+  list(APPEND EXTRA_LIB ${extra_library})
+endif()
+
+if(CONFIG_ARCH_COVERAGE)
+  execute_process(
+    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS} ${NUTTX_EXTRA_FLAGS}
+            --print-file-name=libgcov.a
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE extra_library)
+  list(APPEND EXTRA_LIB ${extra_library})
+endif()
+
+nuttx_add_extra_library(${EXTRA_LIB})
+
+separate_arguments(CMAKE_C_FLAG_ARGS NATIVE_COMMAND ${CMAKE_C_FLAGS})
+set(PREPROCES ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} -E -P -x c)

--- a/arch/x86_64/src/common/CMakeLists.txt
+++ b/arch/x86_64/src/common/CMakeLists.txt
@@ -1,0 +1,36 @@
+# ##############################################################################
+# arch/x86_64/src/common/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS
+    x86_64_allocateheap.c
+    x86_64_copystate.c
+    x86_64_exit.c
+    x86_64_getintstack.c
+    x86_64_mdelay.c
+    x86_64_initialize.c
+    x86_64_modifyreg8.c
+    x86_64_modifyreg16.c
+    x86_64_modifyreg32.c
+    x86_64_nputs.c
+    x86_64_switchcontext.c
+    x86_64_udelay.c
+    x86_64_tcbinfo.c)
+
+target_sources(arch PRIVATE ${SRCS})

--- a/arch/x86_64/src/intel64/CMakeLists.txt
+++ b/arch/x86_64/src/intel64/CMakeLists.txt
@@ -1,0 +1,56 @@
+# ##############################################################################
+# arch/x86_64/src/intel64/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS
+    intel64_saveusercontext.S
+    intel64_fullcontextrestore.S
+    intel64_vectors.S
+    intel64_head.S
+    intel64_createstack.c
+    intel64_initialstate.c
+    intel64_irq.c
+    intel64_map_region.c
+    intel64_regdump.c
+    intel64_releasestack.c
+    intel64_rtc.c
+    intel64_restore_auxstate.c
+    intel64_savestate.c
+    intel64_stackframe.c
+    intel64_schedulesigaction.c
+    intel64_sigdeliver.c
+    intel64_usestack.c
+    intel64_handlers.c
+    intel64_idle.c
+    intel64_lowsetup.c
+    intel64_serial.c
+    intel64_rng.c
+    intel64_check_capability.c)
+
+if(CONFIG_MULTBOOT2_FB_TERM)
+  list(APPEND SRCS intel64_mbfb.c)
+endif()
+
+if(CONFIG_SCHED_TICKLESS)
+  list(APPEND SRCS intel64_tickless.c)
+else()
+  list(APPEND SRCS intel64_timerisr.c)
+endif()
+
+target_sources(arch PRIVATE ${SRCS})

--- a/boards/x86_64/intel64/qemu-intel64/CMakeLists.txt
+++ b/boards/x86_64/intel64/qemu-intel64/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/x84_64/intel64/qemu-intel64/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/x86_64/intel64/qemu-intel64/src/CMakeLists.txt
+++ b/boards/x86_64/intel64/qemu-intel64/src/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# boards/arm/x84_64/intel64/qemu-intel64/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS qemu_boot.c qemu_bringup.c qemu_freq.c qemu_net.c)
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS qemu_appinit.c)
+endif()
+
+if(CONFIG_QEMU_PCI)
+  list(APPEND SRCS qemu_pci.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/qemu.ld")

--- a/libs/libc/machine/x86_64/CMakeLists.txt
+++ b/libs/libc/machine/x86_64/CMakeLists.txt
@@ -1,0 +1,19 @@
+# ##############################################################################
+# libs/libc/machine/x86_64/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################

--- a/libs/libc/machine/x86_64/Kconfig
+++ b/libs/libc/machine/x86_64/Kconfig
@@ -1,0 +1,4 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#


### PR DESCRIPTION
## Summary
arch/x86_64: add cmake support

## Impact

## Testing
qemu and intel64 hardware
