### PR TITLE
stm32/stm32f30xxx_rcc.c: fix broken flash setup

### DIFF
--- a/arch/arm/src/stm32/stm32f30xxx_rcc.c
+++ b/arch/arm/src/stm32/stm32f30xxx_rcc.c
@@ -476,6 +476,13 @@ static void stm32_stdclockconfig(void)
 
 #endif
 
+  /* Enable FLASH prefetch buffer and set FLASH wait states */
+
+  regval  = getreg32(STM32_FLASH_ACR);
+  regval &= ~FLASH_ACR_LATENCY_MASK;
+  regval |= (FLASH_ACR_LATENCY_SETTING | FLASH_ACR_PRTFBE);
+  putreg32(regval, STM32_FLASH_ACR);
+
   /* Set the HCLK source/divider */
 
   regval = getreg32(STM32_RCC_CFGR);


### PR DESCRIPTION
## Summary

During removal of F1 related stuff, code that configures FLASH latency was removed, which rendered some of the F3 line unbootable.

It was done by mistake, since previous removed block was '#ifdef VALUE_LINE', and block with FLASH code was '#ifndef VALUE_LINE' and so it should not have been removed.

This partially reverts: b2399850375a452932bdf5c9f107be51d6d80237

## Impact

Probably whole stm32f3 line

## Testing

Tested on nucleof303re