### PR TITLE
risc-v/k230: update AMP related document

### DIFF
--- a/Documentation/platforms/risc-v/k230/boards/canmv230/index.rst
+++ b/Documentation/platforms/risc-v/k230/boards/canmv230/index.rst
@@ -166,8 +166,6 @@ Let's put the NuttX image files as ``master.bin`` and ``remote.bin`` respectivel
    k230# usb start
    k230# ping $serverip
    k230# tftp 7000000 remote.bin
-   k230# mw.l 80200000 0 8192
-   k230# boot_baremetal 1 7000000 $filesize
    k230# tftp 8000000 master.bin
    k230# go 8000000
 

--- a/boards/risc-v/k230/canmv230/src/canmv_init.c
+++ b/boards/risc-v/k230/canmv230/src/canmv_init.c
@@ -40,6 +40,10 @@
 #  include <nuttx/serial/uart_rpmsg.h>
 #endif
 
+#if !defined(CONFIG_BUILD_KERNEL) || defined(CONFIG_NUTTSBI)
+#  include "k230_hart.h"
+#endif
+
 #ifdef CONFIG_RPTUN
 #  include "k230_rptun.h"
 #endif
@@ -60,6 +64,15 @@
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
+
+static void debug_dumps(void)
+{
+  /* Dumps to aid investigation */
+
+#if !defined(CONFIG_BUILD_KERNEL) || defined(CONFIG_NUTTSBI)
+  sinfo("is_big=%d\n", k230_hart_is_big());
+#endif
+}
 
 /****************************************************************************
  * Public Functions
@@ -129,7 +142,7 @@ int board_app_initialize(uintptr_t arg)
   mount(NULL, "/proc", "procfs", 0, NULL);
 
 #endif
-
+  debug_dumps();
   return OK;
 #endif
 }
@@ -155,6 +168,8 @@ int board_app_initialize(uintptr_t arg)
 
 void board_late_initialize(void)
 {
+  debug_dumps();
+
   /* Perform board-specific initialization */
 
 #ifdef CONFIG_BUILD_KERNEL


### PR DESCRIPTION

## Summary

This patch update documents to reflect the fact that remote node is kicked off by master node. It also adds debug dump to aid the MISA reading issue investigation.

## Impact

K230

## Testing

Checked with CanMV230
