### PR TITLE
build/ci: tenatively disable sim/posix_test for macOS to unblock CI

### DIFF
--- a/tools/ci/testlist/sim-02.dat
+++ b/tools/ci/testlist/sim-02.dat
@@ -24,6 +24,9 @@
 -Darwin,sim:usbdev
 -Darwin,sim:usbhost
 
+# this blocks #11753, #11754 etc
+-Darwin,sim:posix_test
+
 # Boards build by CMake
 CMake,sim:ostest
 CMake,sim:ostest_oneholder


### PR DESCRIPTION


## Summary
The sim/posix_test blocks at least #11754 and #11753 on macOS.

## Impact
Unblocking CI checks

## Testing
CI checks
