### PR TITLE
net: Fix minor coding problems

### DIFF
--- a/net/icmpv6/icmpv6_autoconfig.c
+++ b/net/icmpv6/icmpv6_autoconfig.c
@@ -363,6 +363,7 @@ int icmpv6_autoconfig(FAR struct net_driver_s *dev)
   ret = netdev_ipv6_add(dev, lladdr, net_ipv6_mask2pref(g_ipv6_llnetmask));
   if (ret < 0)
     {
+      net_unlock();
       return ret;
     }
 

--- a/net/pkt/pkt_sendmsg.c
+++ b/net/pkt/pkt_sendmsg.c
@@ -194,7 +194,7 @@ ssize_t pkt_sendmsg(FAR struct socket *psock, FAR struct msghdr *msg,
 
   /* Only SOCK_RAW is supported */
 
-  if (psock->s_type == SOCK_RAW)
+  if (psock->s_type != SOCK_RAW)
     {
       /* EDESTADDRREQ.  Signifies that the socket is not connection-mode and
        * no peer address is set.


### PR DESCRIPTION
## Summary
Fix minor problems when reading codes:
- `icmpv6_autoconfig`: Call `net_unlock` before return
- `pkt_sendmsg`: Return error for types other than `SOCK_RAW`

## Impact
Minor, `icmpv6_autoconfig` and `pkt_sendmsg`

## Testing
CI

