### PR TITLE
Enhance board/board.mk compilation capabilities

### DIFF
--- a/boards/Board.mk
+++ b/boards/Board.mk
@@ -30,11 +30,11 @@ $(RCOBJS): $(ETCDIR)$(DELIM)%: %
 	$(Q) mkdir -p $(dir $@)
 	$(call PREPROCESS, $<, $@)
 
-$(ETCSRC): $(addprefix $(BOARD_DIR)$(DELIM)src$(DELIM),$(RCRAWS)) $(RCOBJS)
+$(ETCSRC): $(foreach raw,$(RCRAWS), $(if $(wildcard $(BOARD_DIR)$(DELIM)src$(DELIM)$(raw)), $(BOARD_DIR)$(DELIM)src$(DELIM)$(raw), $(BOARD_COMMON_DIR)$(DELIM)$(raw))) $(RCOBJS)
 	$(foreach raw, $(RCRAWS), \
 	  $(shell rm -rf $(ETCDIR)$(DELIM)$(raw)) \
 	  $(shell mkdir -p $(dir $(ETCDIR)$(DELIM)$(raw))) \
-	  $(shell cp -rfp $(BOARD_DIR)$(DELIM)src$(DELIM)$(raw) $(ETCDIR)$(DELIM)$(raw)))
+	  $(shell cp -rfp $(if $(wildcard $(BOARD_DIR)$(DELIM)src$(DELIM)$(raw)), $(BOARD_DIR)$(DELIM)src$(DELIM)$(raw), $(BOARD_COMMON_DIR)$(DELIM)$(raw)) $(ETCDIR)$(DELIM)$(raw)))
 	$(Q) genromfs -f romfs.img -d $(ETCDIR)$(DELIM)$(CONFIG_ETC_ROMFSMOUNTPT) -V "NSHInitVol"
 	$(Q) echo "#include <nuttx/compiler.h>" > $@
 	$(Q) xxd -i romfs.img | sed -e "s/^unsigned char/const unsigned char aligned_data(4)/g" >> $@

--- a/boards/Board.mk
+++ b/boards/Board.mk
@@ -30,11 +30,11 @@ $(RCOBJS): $(ETCDIR)$(DELIM)%: %
 	$(Q) mkdir -p $(dir $@)
 	$(call PREPROCESS, $<, $@)
 
-$(ETCSRC): $(foreach raw,$(RCRAWS), $(if $(wildcard $(BOARD_DIR)$(DELIM)src$(DELIM)$(raw)), $(BOARD_DIR)$(DELIM)src$(DELIM)$(raw), $(BOARD_COMMON_DIR)$(DELIM)$(raw))) $(RCOBJS)
+$(ETCSRC): $(foreach raw,$(RCRAWS), $(if $(wildcard $(BOARD_DIR)$(DELIM)src$(DELIM)$(raw)), $(BOARD_DIR)$(DELIM)src$(DELIM)$(raw), $(if $(wildcard $(BOARD_COMMON_DIR)$(DELIM)$(raw)), $(BOARD_COMMON_DIR)$(DELIM)$(raw), $(BOARD_DIR)$(DELIM)src$(DELIM)$(raw)))) $(RCOBJS)
 	$(foreach raw, $(RCRAWS), \
 	  $(shell rm -rf $(ETCDIR)$(DELIM)$(raw)) \
 	  $(shell mkdir -p $(dir $(ETCDIR)$(DELIM)$(raw))) \
-	  $(shell cp -rfp $(if $(wildcard $(BOARD_DIR)$(DELIM)src$(DELIM)$(raw)), $(BOARD_DIR)$(DELIM)src$(DELIM)$(raw), $(BOARD_COMMON_DIR)$(DELIM)$(raw)) $(ETCDIR)$(DELIM)$(raw)))
+	  $(shell cp -rfp $(if $(wildcard $(BOARD_DIR)$(DELIM)src$(DELIM)$(raw)), $(BOARD_DIR)$(DELIM)src$(DELIM)$(raw), $(if $(wildcard $(BOARD_COMMON_DIR)$(DELIM)$(raw)), $(BOARD_COMMON_DIR)$(DELIM)$(raw), $(BOARD_DIR)$(DELIM)src$(DELIM)$(raw))) $(ETCDIR)$(DELIM)$(raw)))
 	$(Q) genromfs -f romfs.img -d $(ETCDIR)$(DELIM)$(CONFIG_ETC_ROMFSMOUNTPT) -V "NSHInitVol"
 	$(Q) echo "#include <nuttx/compiler.h>" > $@
 	$(Q) xxd -i romfs.img | sed -e "s/^unsigned char/const unsigned char aligned_data(4)/g" >> $@


### PR DESCRIPTION
## Summary
When using the common directory, some etc resources can be placed under common/etc to reduce the storage of duplicate resources.
The purpose of this change is to perform resource search logic during the compilation process without affecting the original makefile:
This expectation will first search whether the resource specified by the makefile is stored in the private src/etc. If it does not exist, it will then search whether the resource exists under common/etc.
If the resource does not exist under common/etc, the path will eventually be spliced ​​back to the original target (i.e. src/etc under the private path)

## Impact
During the compilation process, the search logic for resource expansion

## Testing
The local test passed.
Add the resource file (etc/test) that needs to be compiled in the configured src/makefile, and the resource file is only stored under common/etc. Finally, the content of common/etc/test can be successfully retrieved.
