### PR TITLE
arch/intel64: add software reset support

### DIFF
--- a/arch/x86_64/Kconfig
+++ b/arch/x86_64/Kconfig
@@ -21,6 +21,7 @@ config ARCH_INTEL64
 	select ARCH_HAVE_TICKLESS
 	select ARCH_HAVE_STACKCHECK
 	select ARCH_HAVE_RNG
+	select ARCH_HAVE_RESET
 	---help---
 		Intel x86_64 architecture
 

--- a/arch/x86_64/include/intel64/arch.h
+++ b/arch/x86_64/include/intel64/arch.h
@@ -248,6 +248,13 @@
 
 #define BITS_PER_LONG    64
 
+/* Reset Control Register (RST_CNT) */
+
+#define X86_RST_CNT_REG        0xcf9
+#  define X86_RST_CNT_SYS_RST  0x02
+#  define X86_RST_CNT_CPU_RST  0x04
+#  define X86_RST_CNT_FULL_RST 0x08
+
 #ifndef __ASSEMBLY__
 
 /****************************************************************************

--- a/arch/x86_64/src/intel64/CMakeLists.txt
+++ b/arch/x86_64/src/intel64/CMakeLists.txt
@@ -36,6 +36,7 @@ set(SRCS
     intel64_schedulesigaction.c
     intel64_sigdeliver.c
     intel64_usestack.c
+    intel64_systemreset.c
     intel64_start.c
     intel64_handlers.c
     intel64_idle.c

--- a/arch/x86_64/src/intel64/Make.defs
+++ b/arch/x86_64/src/intel64/Make.defs
@@ -30,6 +30,7 @@ CMN_CSRCS += intel64_map_region.c intel64_regdump.c intel64_releasestack.c
 CMN_CSRCS += intel64_rtc.c intel64_restore_auxstate.c intel64_savestate.c
 CMN_CSRCS += intel64_stackframe.c intel64_schedulesigaction.c
 CMN_CSRCS += intel64_sigdeliver.c intel64_usestack.c x86_64_tcbinfo.c
+CMN_CSRCS += intel64_systemreset.c
 
 # Required Intel64 files
 

--- a/arch/x86_64/src/intel64/intel64_systemreset.c
+++ b/arch/x86_64/src/intel64/intel64_systemreset.c
@@ -1,0 +1,62 @@
+/****************************************************************************
+ * arch/x86_64/src/intel64/intel64_systemreset.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <nuttx/arch.h>
+#include <arch/io.h>
+
+#include <stdint.h>
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_systemreset
+ *
+ * Description:
+ *   Internal, intel64 reset logic.
+ *
+ ****************************************************************************/
+
+void up_systemreset(void)
+{
+  uint8_t regval = (X86_RST_CNT_CPU_RST |
+                    X86_RST_CNT_SYS_RST |
+                    X86_RST_CNT_FULL_RST);
+
+  /* Write to Reset Control Register */
+
+  outb(regval, X86_RST_CNT_REG);
+
+  while (1)
+    {
+      asm volatile("hlt");
+    }
+}

--- a/boards/x86_64/intel64/qemu-intel64/src/CMakeLists.txt
+++ b/boards/x86_64/intel64/qemu-intel64/src/CMakeLists.txt
@@ -28,6 +28,10 @@ if(CONFIG_QEMU_PCI)
   list(APPEND SRCS qemu_pci.c)
 endif()
 
+if(CONFIG_BOARDCTL_RESET)
+  list(APPEND SRCS qemu_reset.c)
+endif()
+
 target_sources(board PRIVATE ${SRCS})
 
 set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/qemu.ld")

--- a/boards/x86_64/intel64/qemu-intel64/src/Makefile
+++ b/boards/x86_64/intel64/qemu-intel64/src/Makefile
@@ -30,4 +30,8 @@ ifeq ($(CONFIG_QEMU_PCI),y)
   CSRCS += qemu_pci.c
 endif
 
+ifeq ($(CONFIG_BOARDCTL_RESET),y)
+  CSRCS += qemu_reset.c
+endif
+
 include $(TOPDIR)/boards/Board.mk

--- a/boards/x86_64/intel64/qemu-intel64/src/qemu_reset.c
+++ b/boards/x86_64/intel64/qemu-intel64/src/qemu_reset.c
@@ -1,0 +1,57 @@
+/****************************************************************************
+ * boards/x86_64/intel64/qemu-intel64/src/qemu_reset.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/board.h>
+#include <nuttx/arch.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_reset
+ *
+ * Description:
+ *   Reset board.  Support for this function is required by board-level
+ *   logic if CONFIG_BOARDCTL_RESET is selected.
+ *
+ * Input Parameters:
+ *   status - Status information provided with the reset event.  This
+ *            meaning of this status information is board-specific.  If not
+ *            used by a board, the value zero may be provided in calls to
+ *            board_reset().
+ *
+ * Returned Value:
+ *   If this function returns, then it was not possible to power-off the
+ *   board due to some constraints.  The return value int this case is a
+ *   board-specific reason for the failure to shutdown.
+ *
+ ****************************************************************************/
+
+int board_reset(int status)
+{
+  up_systemreset();
+  return 0;
+}


### PR DESCRIPTION
## Summary
arch/intel64: add software reset support

## Impact

## Testing
qemu and intel64
