### PR TITLE
newlib: fix support for x86_64

### DIFF
--- a/arch/x86_64/src/cmake/platform.cmake
+++ b/arch/x86_64/src/cmake/platform.cmake
@@ -29,7 +29,7 @@ execute_process(
 
 list(APPEND EXTRA_LIB ${extra_library})
 
-if(NOT CONFIG_LIBM)
+if(CONFIG_LIBM_TOOLCHAIN)
   execute_process(
     COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS} ${NUTTX_EXTRA_FLAGS}
             --print-file-name=libm.a

--- a/libs/libm/newlib/0003-newlib-fix-compilation-for-x86.patch
+++ b/libs/libm/newlib/0003-newlib-fix-compilation-for-x86.patch
@@ -1,0 +1,39 @@
+From 3035e2e223999497364dbc54b881ebc958be701c Mon Sep 17 00:00:00 2001
+From: p-szafonimateusz <p-szafonimateusz@xiaomi.com>
+Date: Thu, 22 Feb 2024 15:05:36 +0100
+Subject: [PATCH] newlib: fix compilation for x86
+
+Change-Id: I5286ef72e358010ea7b4805e6087b06f67e42d44
+Signed-off-by: p-szafonimateusz <p-szafonimateusz@xiaomi.com>
+---
+ newlib/libc/machine/shared_x86/sys/fenv.h | 1 +
+ newlib/libm/machine/shared_x86/fenv.c     | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/newlib/newlib/newlib/libc/machine/shared_x86/sys/fenv.h newlib/newlib/newlib/libc/machine/shared_x86/sys/fenv.h
+index 243cac27a..be39db4d0 100644
+--- a/newlib/newlib/newlib/libc/machine/shared_x86/sys/fenv.h
++++ newlib/newlib/newlib/libc/machine/shared_x86/sys/fenv.h
+@@ -30,6 +30,7 @@
+ #define _SYS_FENV_H 1
+ 
+ #include <sys/cdefs.h>
++#include <stdint.h>
+ 
+ #ifdef __cplusplus
+ extern "C" {
+diff --git a/newlib/newlib/newlib/libm/machine/shared_x86/fenv.c newlib/newlib/newlib/libm/machine/shared_x86/fenv.c
+index ccc08e2d8..892a8b2cd 100644
+--- a/newlib/newlib/newlib/libm/machine/shared_x86/fenv.c
++++ newlib/newlib/newlib/libm/machine/shared_x86/fenv.c
+@@ -5,6 +5,7 @@
+  */
+ 
+ #define _GNU_SOURCE        // for FE_NOMASK_ENV
++#define __GNU_VISIBLE 1
+ 
+ #include <fenv.h>
+ #include <errno.h>
+-- 
+2.43.1
+

--- a/libs/libm/newlib/CMakeLists.txt
+++ b/libs/libm/newlib/CMakeLists.txt
@@ -40,7 +40,9 @@ if(CONFIG_LIBM_NEWLIB)
         patch -p1 -d ${CMAKE_CURRENT_LIST_DIR} <
         ${CMAKE_CURRENT_LIST_DIR}/0001-newlib-libm-fix-__RCSID-build-error.patch
         && patch -p1 -d ${CMAKE_CURRENT_LIST_DIR} <
-        ${CMAKE_CURRENT_LIST_DIR}/0002-newlib-libm-remove-include-reent.h.patch)
+        ${CMAKE_CURRENT_LIST_DIR}/0002-newlib-libm-remove-include-reent.h.patch
+        && patch -p1 -d ${CMAKE_CURRENT_LIST_DIR} <
+        ${CMAKE_CURRENT_LIST_DIR}/0003-newlib-fix-compilation-for-x86.patch)
 
     FetchContent_GetProperties(newlib_fetch)
 
@@ -85,6 +87,10 @@ if(CONFIG_LIBM_NEWLIB)
   file(GLOB_RECURSE ARCH_CSRCS
        ${NEWLIB_DIR}/newlib/libm/machine/${ARCH_DIR}/*.c)
 
+  if(CONFIG_ARCH_X86_64)
+    file(GLOB_RECURSE ARCH_CSRCS ${NEWLIB_DIR}/newlib/libm/fenv/*.c)
+  endif()
+
   set(CSRCS ${COMMON_CSRCS} ${COMPLEX_CSRCS} ${ARCH_CSRCS})
 
   if(CONFIG_LIBM_NEWLIB_HW_FP)
@@ -111,6 +117,10 @@ if(CONFIG_LIBM_NEWLIB)
 
   set(INCDIR ${CMAKE_CURRENT_LIST_DIR}/include ${NEWLIB_DIR}/newlib/libm/common)
 
+  if(CONFIG_ARCH_X86_64)
+    list(APPEND INCDIR ${NEWLIB_DIR}/newlib/libc/machine/shared_x86/sys)
+  endif()
+
   # ############################################################################
   # Library Configuration
   # ############################################################################
@@ -120,5 +130,10 @@ if(CONFIG_LIBM_NEWLIB)
   target_sources(m PRIVATE ${CSRCS})
   target_include_directories(m PRIVATE ${INCDIR})
   target_compile_options(m PRIVATE ${CFLAGS})
+
+  set_property(
+    TARGET nuttx
+    APPEND
+    PROPERTY NUTTX_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_LIST_DIR}/include)
 
 endif()

--- a/libs/libm/newlib/CMakeLists.txt
+++ b/libs/libm/newlib/CMakeLists.txt
@@ -93,6 +93,12 @@ if(CONFIG_LIBM_NEWLIB)
 
   set(CSRCS ${COMMON_CSRCS} ${COMPLEX_CSRCS} ${ARCH_CSRCS})
 
+  # aggresive optimisation can replace occurrences of sinl() and cosl() with
+  # sincosl(), but sincosl() is missing in newlib which causes error. So let's
+  # use custom implementation here.
+
+  list(APPEND CSRCS ${CMAKE_CURRENT_LIST_DIR}/sincosl.c)
+
   if(CONFIG_LIBM_NEWLIB_HW_FP)
     file(GLOB_RECURSE MATHFP_CSRCS ${NEWLIB_DIR}/newlib/libm/mathfp/*.c)
     list(APPEND CSRCS ${MATHFP_CSRCS})

--- a/libs/libm/newlib/Make.defs
+++ b/libs/libm/newlib/Make.defs
@@ -39,6 +39,7 @@ newlib/newlib: $(NEWLIB_BASENAME)-$(NEWLIB_VERSION).tar.gz
 	$(Q) mv $(NEWLIB_BASENAME)-$(NEWLIB_VERSION) newlib/newlib
 	$(Q) patch -p0 < newlib/0001-newlib-libm-fix-__RCSID-build-error.patch
 	$(Q) patch -p0 < newlib/0002-newlib-libm-remove-include-reent.h.patch
+	$(Q) patch -p0 < newlib/0003-newlib-fix-compilation-for-x86.patch
 	$(Q) touch $@
 endif
 
@@ -80,6 +81,13 @@ endif
 
 CSRCS += $(wildcard newlib/newlib/newlib/libm/machine/$(ARCH)/*.c)
 VPATH += :newlib/newlib/newlib/libm/machine/$(ARCH)
+
+ifeq ($(CONFIG_ARCH_X86_64),y)
+CSRCS += $(wildcard newlib/newlib/newlib/libm/fenv/*.c)
+VPATH += :newlib/newlib/newlib/libm/fenv
+
+CFLAGS += ${INCDIR_PREFIX}newlib/newlib/newlib/libc/machine/shared_x86/sys
+endif
 
 ifeq ($(CONFIG_LIBM_NEWLIB_HW_FP),y)
   CSRCS += $(wildcard newlib/newlib/newlib/libm/mathfp/*.c)

--- a/libs/libm/newlib/Make.defs
+++ b/libs/libm/newlib/Make.defs
@@ -89,6 +89,13 @@ VPATH += :newlib/newlib/newlib/libm/fenv
 CFLAGS += ${INCDIR_PREFIX}newlib/newlib/newlib/libc/machine/shared_x86/sys
 endif
 
+# aggresive optimisation can replace occurrences of sinl() and cosl() with
+# sincosl(), but sincosl() is missing in newlib which causes error. So let's
+# use custom implementation here.
+
+CSRCS += newlib/sincosl.c
+VPATH += :newlib
+
 ifeq ($(CONFIG_LIBM_NEWLIB_HW_FP),y)
   CSRCS += $(wildcard newlib/newlib/newlib/libm/mathfp/*.c)
   VPATH += :newlib/newlib/newlib/libm/mathfp

--- a/libs/libm/newlib/sincosl.c
+++ b/libs/libm/newlib/sincosl.c
@@ -1,0 +1,35 @@
+/****************************************************************************
+ * libs/libm/newlib/sincosl.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <math.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void sincosl(long double x, long double *s, long double *c)
+{
+  *s = sinl(x);
+  *c = cosl(x);
+}


### PR DESCRIPTION
## Summary
- newlib: fix support for x86
- newlib: fix compilation for sincosl
    aggresive optimisation can replace occurrences of sinl() and cosl() with
    sincosl(), but sincosl() is missing in newlib which causes error. So let's
    use custom implementation here
    
## Impact
alternative libm for x86_64

## Testing
qemu
