### PR TITLE
audio: migrate to SPDX identifier

### DIFF
--- a/audio/CMakeLists.txt
+++ b/audio/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # audio/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/audio/Makefile
+++ b/audio/Makefile
@@ -1,6 +1,8 @@
 ############################################################################
 # audio/Makefile
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/audio/audio.c
+++ b/audio/audio.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * audio/audio.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/audio/audio_comp.c
+++ b/audio/audio_comp.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * audio/audio_comp.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/audio/pcm_decode.c
+++ b/audio/pcm_decode.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * audio/pcm_decode.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The


### PR DESCRIPTION
## Summary
Most tools used for compliance and SBOM generation use SPDX identifiers.
This change brings us a step closer to an easy SBOM generation.

## Impact
Compliance

## Testing
NONE
