### PR TITLE
fs/procfs: add build config to /proc/version

### DIFF
--- a/fs/procfs/fs_procfsversion.c
+++ b/fs/procfs/fs_procfsversion.c
@@ -201,8 +201,9 @@ static ssize_t version_read(FAR struct file *filep, FAR char *buffer,
     {
       uname(&name);
       linesize = procfs_snprintf(attr->line, VERSION_LINELEN,
-                                 "%s version %s %s\n",
-                                 name.sysname, name.release, name.version);
+                                 "%s version %s %s %s\n",
+                                 name.sysname, name.release, name.version,
+                                 CONFIG_BASE_DEFCONFIG);
 
       /* Save the linesize in case we are re-entered with f_pos > 0 */
 


### PR DESCRIPTION
## Summary

Currently at runtime it is hard to know the exact build config of the current NuttX instance. Thus it is inconvenient when there are multiple configs for the same board. This patch attempts to solve the issue by adding build config to /proc/version.

## Impact

/proc/version content

## Testing

checked with CanMV230 and sim/nsh

