### PR TITLE
sched/tls: inline group info in flat mode to improve performance

### DIFF
--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -45,6 +45,7 @@
 #include <nuttx/fs/fs.h>
 #include <nuttx/net/net.h>
 #include <nuttx/mm/map.h>
+#include <nuttx/tls.h>
 
 #include <arch/arch.h>
 
@@ -401,8 +402,6 @@ struct stackinfo_s
  * the struct task_group_s is free.
  */
 
-struct task_info_s;
-
 #ifndef CONFIG_DISABLE_PTHREAD
 struct join_s;                      /* Forward reference                        */
                                     /* Defined in sched/pthread/pthread.h       */
@@ -480,6 +479,9 @@ struct task_group_s
 
   /* Thread local storage ***************************************************/
 
+#ifndef CONFIG_MM_KERNEL_HEAP
+  struct task_info_s tg_info_;
+#endif
   FAR struct task_info_s *tg_info;
 
   /* POSIX Signal Control Fields ********************************************/

--- a/include/nuttx/tls.h
+++ b/include/nuttx/tls.h
@@ -27,7 +27,14 @@
 
 #include <nuttx/config.h>
 
-#include <nuttx/arch.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#include <arch/arch.h>
+#include <arch/types.h>
+
+#include <nuttx/compiler.h>
+#include <nuttx/cache.h>
 #include <nuttx/atexit.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/list.h>

--- a/libs/libc/tls/tls_getinfo.c
+++ b/libs/libc/tls/tls_getinfo.c
@@ -28,6 +28,7 @@
 #include <assert.h>
 
 #include <nuttx/tls.h>
+#include <nuttx/sched.h>
 
 #if !defined(up_tls_info) && (defined(__KERNEL__) || !defined(CONFIG_TLS_ALIGNED))
 

--- a/sched/tls/task_initinfo.c
+++ b/sched/tls/task_initinfo.c
@@ -119,11 +119,15 @@ int task_init_info(FAR struct task_group_s *group)
 
   /* Allocate task info for group */
 
+#ifdef CONFIG_MM_KERNEL_HEAP
   info = group_zalloc(group, sizeof(struct task_info_s));
   if (info == NULL)
     {
       return -ENOMEM;
     }
+#else
+  info = &group->tg_info_;
+#endif
 
   /* Initialize user space mutex */
 

--- a/sched/tls/task_uninitinfo.c
+++ b/sched/tls/task_uninitinfo.c
@@ -142,5 +142,7 @@ void task_uninit_info(FAR struct task_group_s *group)
 #endif /* CONFIG_FILE_STREAM */
 
   nxmutex_destroy(&info->ta_lock);
+#ifdef CONFIG_MM_KERNEL_HEAP
   group_free(group, info);
+#endif
 }

--- a/sched/tls/tls.h
+++ b/sched/tls/tls.h
@@ -25,6 +25,7 @@
  * Included Files
  ****************************************************************************/
 
+#include <nuttx/arch.h>
 #include <nuttx/sched.h>
 #include <nuttx/tls.h>
 


### PR DESCRIPTION
## Summary

sched/tls: inline group info in flat mode to improve performance

inline group info in flat mode to improve the task create/destroy performance

Signed-off-by: chao an <anchao@lixiang.com>

## Impact

N/A

## Testing

nsh/sim