### PR TITLE
xtensa/esp32s3: Fix issue of system blocking when SPIRAM is used as stack

### DIFF
--- a/arch/xtensa/src/esp32s3/esp32s3_spiflash_mtd.h
+++ b/arch/xtensa/src/esp32s3/esp32s3_spiflash_mtd.h
@@ -47,6 +47,24 @@ extern "C"
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: esp32s3_set_bank
+ *
+ * Description:
+ *   Set Ext-SRAM-Cache mmu mapping.
+ *
+ * Input Parameters:
+ *   virt_bank - Beginning of the virtual bank
+ *   phys_bank - Beginning of the physical bank
+ *   ct        - Number of banks
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void esp32s3_set_bank(int virt_bank, int phys_bank, int ct);
+
+/****************************************************************************
  * Name: esp32s3_spiflash_mtd
  *
  * Description:

--- a/arch/xtensa/src/esp32s3/esp32s3_spiram.h
+++ b/arch/xtensa/src/esp32s3/esp32s3_spiram.h
@@ -34,6 +34,24 @@ extern "C"
 {
 #endif
 
+/****************************************************************************
+ * Name: cache_dbus_mmu_map
+ *
+ * Description:
+ *   Set Ext-SRAM-Cache mmu mapping.
+ *
+ * Input Parameters:
+ *   vaddr - Virtual address in CPU address space
+ *   paddr - Physical address in Ext-SRAM
+ *   num   - Pages to be set
+ *
+ * Returned Value:
+ *   0 if success or a negative value if fail.
+ *
+ ****************************************************************************/
+
+int cache_dbus_mmu_map(int vaddr, int paddr, int num);
+
 /* Initialize spiram interface/hardware. Normally called from
  * cpu_start.c.
  *


### PR DESCRIPTION
## Summary
  
Tasks use SPIRAM as stack can do Ext-SRAM-Cache MMU mapping.

The root cause is as following:

1. When operating Ext-SRAM-Cache MMU  mapping, cache is also disable, then software can't access PSRAM by data cache.

2. MMU mapping functions have instruction like stack-pop and stack-push which may use stack buffer which is PSRAM space or load/store temp variables which locate in PSRAM space too.

Once operation in step 2 triggers, CPU will trigger exception.
So related MMU mapping functions should be sent and run in tasks which use SRAM as task stack.
## Impact

## Testing

