### PR TITLE
qemu-intel64: add .note.gnu.* to linker script

### DIFF
--- a/boards/x86_64/intel64/qemu-intel64/scripts/qemu.ld
+++ b/boards/x86_64/intel64/qemu-intel64/scripts/qemu.ld
@@ -79,6 +79,7 @@ SECTIONS
         *(.gcc_except_table)
         *(.gnu.linkonce.r.*)
         *(.eh_frame)
+        *(.note.gnu.*)
         _erodata = ABSOLUTE(.);
     }
 


### PR DESCRIPTION
## Summary
- qemu-intel64: add .note.gnu.* to linker script
  this prevents section overlap linker errors which sometimes occurs:

  ld: section .rodata LMA [0000000000990000,00000000009c1f27] overlaps section .note.gnu.property LMA [000000000098ffe0,000000000099000f]
  make[1]: *** [Makefile:114: nuttx.elf] Error 1
  
## Impact

## Testing
make and cmake build
