### PR TITLE
x86_64/common/Toolchain.defs: change optimization to -Os for FULLOPT

### DIFF
--- a/arch/x86_64/src/common/Toolchain.defs
+++ b/arch/x86_64/src/common/Toolchain.defs
@@ -22,10 +22,10 @@ ifeq ($(CONFIG_DEBUG_SYMBOLS),y)
   ARCHOPTIMIZATION = -g
 endif
 
-ifneq ($(CONFIG_DEBUG_NOOPT),y)
-  ARCHOPTIMIZATION += -O2 -fno-optimize-sibling-calls
-  ARCHOPTIMIZATION += -fno-omit-frame-pointer -fno-crossjumping
-  ARCHOPTIMIZATION += -fno-delete-null-pointer-checks
+ifeq ($(CONFIG_DEBUG_CUSTOMOPT),y)
+  ARCHOPTIMIZATION += $(CONFIG_DEBUG_OPTLEVEL)
+else ifeq ($(CONFIG_DEBUG_FULLOPT),y)
+  ARCHOPTIMIZATION += -Os
 endif
 
 ARCHCPUFLAGS = -fPIC -fno-stack-protector -mno-red-zone -mrdrnd


### PR DESCRIPTION
## Summary
- x86_64/common/Toolchain.defs: change optimization to -Os for CONFIG_DEBUG_FULLOPT
change optimization to -Os for CONFIG_DEBUG_FULLOPT to be compatible with other architectures and add an option to select CONFIG_DEBUG_CUSTOMOPT

## Impact

## Testing
qemu and intel hardware
