### PR TITLE
boards/stm32f411-minimum: remove non existing include in Kconfig

### DIFF
--- a/boards/arm/stm32/stm32f411-minimum/Kconfig
+++ b/boards/arm/stm32/stm32f411-minimum/Kconfig
@@ -75,12 +75,4 @@ config STM32F411MINIMUM_HX711_DATA_PIN
 
 endif # STM32F411MINIMUM_HX711
 
-menuconfig STM32F411MINIMUM_GPIO
-	select DEV_GPIO
-	bool "enable gpio subsystem"
-
-if STM32F411MINIMUM_GPIO
-source boards/arm/stm32/stm32f411-minimum/Kconfig.gpio
-endif
-
 endif


### PR DESCRIPTION
This is leak from another feature that was not yet meant to be pushed.

## Summary

## Impact

## Testing

