### PR TITLE
nuttx/tls: report warning if pthread enabled only 

### DIFF
--- a/include/nuttx/tls.h
+++ b/include/nuttx/tls.h
@@ -48,7 +48,6 @@
 #endif
 
 #ifndef CONFIG_TLS_NELEM
-#  warning CONFIG_TLS_NELEM is not defined
 #  define CONFIG_TLS_NELEM 0
 #endif
 


### PR DESCRIPTION

## Summary

nuttx/tls: report warning if pthread enabled only
```
include/nuttx/tls.h:52:4: warning: #warning CONFIG_TLS_NELEM is not defined [-Wcpp]
   52 | #  warning CONFIG_TLS_NELEM is not defined
      |    ^~~~~~~
In file included from include/nuttx/sched.h:48,
                 from include/nuttx/arch.h:87,
                 from include/nuttx/userspace.h:35,
                 from include/nuttx/mm/mm.h:30,
                 from include/nuttx/kmalloc.h:34,
                 from sim_bringup.c:33:
include/nuttx/tls.h:52:4: warning: #warning CONFIG_TLS_NELEM is not defined [-Wcpp]
   52 | #  warning CONFIG_TLS_NELEM is not defined
      |    ^~~~~~~
```

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

sim/nsh + CONFIG_DISABLE_PTHREAD 