### PR TITLE
sensors/bmi160: fix compilation errors

### DIFF
--- a/drivers/sensors/CMakeLists.txt
+++ b/drivers/sensors/CMakeLists.txt
@@ -137,7 +137,12 @@ if(CONFIG_SENSORS)
     endif()
 
     if(CONFIG_SENSORS_BMI160)
-      list(APPEND SRCS bmi160.c)
+      list(APPEND SRCS bmi160_base.c)
+      if(CONFIG_SENSORS_BMI160_UORB)
+        list(APPEND SRCS bmi160_uorb.c)
+      else()
+        list(APPEND SRCS bmi160.c)
+      endif()
     endif()
 
     if(CONFIG_SENSORS_BMP180)

--- a/drivers/sensors/bmi160_base.c
+++ b/drivers/sensors/bmi160_base.c
@@ -39,6 +39,25 @@
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: bmi160_configspi
+ *
+ * Description:
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_SENSORS_BMI160_SPI
+static void bmi160_configspi(FAR struct spi_dev_s *spi)
+{
+  /* Configure SPI for the BMI160 */
+
+  SPI_SETMODE(spi, SPIDEV_MODE0);
+  SPI_SETBITS(spi, 8);
+  SPI_HWFEATURES(spi, 0);
+  SPI_SETFREQUENCY(spi, BMI160_SPI_MAXFREQUENCY);
+}
+#endif
+
+/****************************************************************************
  * Private Data
  ****************************************************************************/
 

--- a/drivers/sensors/bmi160_base.h
+++ b/drivers/sensors/bmi160_base.h
@@ -240,22 +240,4 @@ void bmi160_getregs(FAR struct bmi160_dev_s *priv, uint8_t regaddr,
 
 int bmi160_checkid(FAR struct bmi160_dev_s *priv);
 
-/****************************************************************************
- * Name: bmi160_configspi
- *
- * Description:
- *
- ****************************************************************************/
-
-#ifdef CONFIG_SENSORS_BMI160_SPI
-inline void bmi160_configspi(FAR struct spi_dev_s *spi)
-{
-  /* Configure SPI for the BMI160 */
-
-  SPI_SETMODE(spi, SPIDEV_MODE0);
-  SPI_SETBITS(spi, 8);
-  SPI_HWFEATURES(spi, 0);
-  SPI_SETFREQUENCY(spi, BMI160_SPI_MAXFREQUENCY);
-}
-#endif
 #endif /* __INCLUDE_NUTTX_SENSORS_BMI160_COMMOM_H */


### PR DESCRIPTION
## Summary
- sensors/bmi160: fix compilation errors
fix compilation errors about undefined reference to `bmi160_configspi'

reported on the mailing list

## Impact

## Testing

