### PR TITLE
arm/armv8-r: fix build break if disable CONFIG_UART_PL011

### DIFF
--- a/arch/arm/src/fvp-v8r-aarch32/fvp_serial.c
+++ b/arch/arm/src/fvp-v8r-aarch32/fvp_serial.c
@@ -56,7 +56,9 @@ void arm_earlyserialinit(void)
    * when they are first opened.
    */
 
+#ifdef CONFIG_UART_PL011
   pl011_earlyserialinit();
+#endif
 }
 
 /***************************************************************************
@@ -69,7 +71,16 @@ void arm_earlyserialinit(void)
 
 void arm_serialinit(void)
 {
+#ifdef CONFIG_UART_PL011
   pl011_serialinit();
+#endif
+}
+
+#else /* USE_SERIALDRIVER */
+
+int up_putc(int ch)
+{
+  return 0;
 }
 
 #endif /* USE_SERIALDRIVER */


### PR DESCRIPTION
## Summary

arm/armv8-r: fix build break if disable CONFIG_UART_PL011

Common code should support the if PL011 is not enabled

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

ci-check