### PR TITLE
audio: Add setup method and add reference counter on shutdown

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_nxaudio.c
+++ b/arch/arm/src/cxd56xx/cxd56_nxaudio.c
@@ -381,7 +381,7 @@ static int     cxd56_release(struct audio_lowerhalf_s *lower);
 
 static int     cxd56_getcaps(struct audio_lowerhalf_s *lower, int type,
                              struct audio_caps_s *caps);
-static int     cxd56_shutdown(struct audio_lowerhalf_s *lower);
+static int     cxd56_shutdown(struct audio_lowerhalf_s *lower, int opencnt);
 static int     cxd56_enqueuebuffer(struct audio_lowerhalf_s *lower,
                                    struct ap_buffer_s *apb);
 static int     cxd56_cancelbuffer(struct audio_lowerhalf_s *lower,
@@ -438,6 +438,7 @@ static uint16_t g_codec_start_count = 0;
 
 static const struct audio_ops_s g_audioops =
 {
+  NULL,                /* setup          */
   cxd56_getcaps,       /* getcaps        */
   cxd56_configure,     /* configure      */
   cxd56_shutdown,      /* shutdown       */
@@ -2698,7 +2699,7 @@ static int cxd56_getcaps(struct audio_lowerhalf_s *lower, int type,
  *
  ****************************************************************************/
 
-static int cxd56_shutdown(struct audio_lowerhalf_s *lower)
+static int cxd56_shutdown(struct audio_lowerhalf_s *lower, int opencnt)
 {
   int ret;
   struct cxd56_dev_s *priv = (struct cxd56_dev_s *)lower;

--- a/arch/arm/src/sama5/sam_classd.c
+++ b/arch/arm/src/sama5/sam_classd.c
@@ -554,6 +554,7 @@ static struct sam_classd_config_s sam_classd_const =
 
 static const struct audio_ops_s g_audioops =
 {
+  NULL,                 /* setup          */
   classd_getcaps,       /* getcaps        */
   classd_configure,     /* configure      */
   classd_shutdown,      /* shutdown       */
@@ -1747,7 +1748,7 @@ static int classd_configure(struct audio_lowerhalf_s *dev,
  *
  ****************************************************************************/
 
-static int classd_shutdown(struct audio_lowerhalf_s *dev)
+static int classd_shutdown(struct audio_lowerhalf_s *dev, int cnt)
 {
   struct classd_dev_s *priv = (struct classd_dev_s *)dev;
 

--- a/arch/sim/src/sim/posix/sim_alsa.c
+++ b/arch/sim/src/sim/posix/sim_alsa.c
@@ -104,7 +104,7 @@ static int sim_audio_resume(struct audio_lowerhalf_s *dev);
 static int sim_audio_reserve(struct audio_lowerhalf_s *dev);
 static int sim_audio_release(struct audio_lowerhalf_s *dev);
 #endif
-static int sim_audio_shutdown(struct audio_lowerhalf_s *dev);
+static int sim_audio_shutdown(struct audio_lowerhalf_s *dev, int cnt);
 static int sim_audio_enqueuebuffer(struct audio_lowerhalf_s *dev,
                                    struct ap_buffer_s *apb);
 static int sim_audio_ioctl(struct audio_lowerhalf_s *dev, int cmd,
@@ -115,6 +115,7 @@ static int sim_audio_ioctl(struct audio_lowerhalf_s *dev, int cmd,
 
 static const struct audio_ops_s g_sim_audio_ops =
 {
+  .setup         = NULL,
   .getcaps       = sim_audio_getcaps,
   .configure     = sim_audio_configure,
   .shutdown      = sim_audio_shutdown,
@@ -484,7 +485,7 @@ static int sim_audio_configure(struct audio_lowerhalf_s *dev,
   return ret;
 }
 
-static int sim_audio_shutdown(struct audio_lowerhalf_s *dev)
+static int sim_audio_shutdown(struct audio_lowerhalf_s *dev, int cnt)
 {
   return 0;
 }

--- a/drivers/audio/audio_dma.c
+++ b/drivers/audio/audio_dma.c
@@ -55,7 +55,7 @@ struct audio_dma_s
 
 static int audio_dma_getcaps(struct audio_lowerhalf_s *dev, int type,
                              struct audio_caps_s *caps);
-static int audio_dma_shutdown(struct audio_lowerhalf_s *dev);
+static int audio_dma_shutdown(struct audio_lowerhalf_s *dev, int cnt);
 #ifdef CONFIG_AUDIO_MULTI_SESSION
 static int audio_dma_configure(struct audio_lowerhalf_s *dev,
                                void *session,
@@ -106,6 +106,7 @@ static void audio_dma_callback(struct dma_chan_s *chan, void *arg,
 
 static const struct audio_ops_s g_audio_dma_ops =
 {
+  .setup = NULL,
   .getcaps = audio_dma_getcaps,
   .configure = audio_dma_configure,
   .shutdown = audio_dma_shutdown,
@@ -255,7 +256,7 @@ static int audio_dma_configure(struct audio_lowerhalf_s *dev,
   return ret;
 }
 
-static int audio_dma_shutdown(struct audio_lowerhalf_s *dev)
+static int audio_dma_shutdown(struct audio_lowerhalf_s *dev, int cnt)
 {
   /* apps enqueued buffers, but doesn't start. stop here to
    * clear audio_dma->pendq.

--- a/drivers/audio/audio_i2s.c
+++ b/drivers/audio/audio_i2s.c
@@ -48,7 +48,7 @@ struct audio_i2s_s
 
 static int audio_i2s_getcaps(FAR struct audio_lowerhalf_s *dev, int type,
                              FAR struct audio_caps_s *caps);
-static int audio_i2s_shutdown(FAR struct audio_lowerhalf_s *dev);
+static int audio_i2s_shutdown(FAR struct audio_lowerhalf_s *dev, int cnt);
 #ifdef CONFIG_AUDIO_MULTI_SESSION
 static int audio_i2s_configure(FAR struct audio_lowerhalf_s *dev,
                                FAR void *session,
@@ -101,6 +101,7 @@ static void audio_i2s_callback(struct i2s_dev_s *dev,
 
 static const struct audio_ops_s g_audio_i2s_ops =
 {
+  NULL,                    /* setup          */
   audio_i2s_getcaps,       /* getcaps        */
   audio_i2s_configure,     /* configure      */
   audio_i2s_shutdown,      /* shutdown       */
@@ -185,9 +186,7 @@ static int audio_i2s_getcaps(FAR struct audio_lowerhalf_s *dev, int type,
             /* Report the Sample rates we support */
 
               caps->ac_controls.hw[0] = AUDIO_SAMP_RATE_DEF_ALL;
-
               caps->ac_channels = 2;
-
               break;
           }
 
@@ -255,7 +254,7 @@ static int audio_i2s_configure(FAR struct audio_lowerhalf_s *dev,
   return ret;
 }
 
-static int audio_i2s_shutdown(FAR struct audio_lowerhalf_s *dev)
+static int audio_i2s_shutdown(FAR struct audio_lowerhalf_s *dev, int cnt)
 {
   FAR struct audio_i2s_s *audio_i2s = (struct audio_i2s_s *)dev;
   FAR struct i2s_dev_s *i2s = audio_i2s->i2s;

--- a/drivers/audio/audio_null.c
+++ b/drivers/audio/audio_null.c
@@ -132,6 +132,7 @@ static int   null_sleep(FAR struct audio_lowerhalf_s *dev,
 
 static const struct audio_ops_s g_audioops =
 {
+  NULL,               /* setup          */
   null_getcaps,       /* getcaps        */
   null_configure,     /* configure      */
   null_shutdown,      /* shutdown       */
@@ -451,7 +452,7 @@ static int null_configure(FAR struct audio_lowerhalf_s *dev,
  *
  ****************************************************************************/
 
-static int null_shutdown(FAR struct audio_lowerhalf_s *dev)
+static int null_shutdown(FAR struct audio_lowerhalf_s *dev, int cnt)
 {
   audinfo("Return OK\n");
   return OK;

--- a/drivers/audio/cs4344.c
+++ b/drivers/audio/cs4344.c
@@ -71,7 +71,7 @@ static int  cs4344_configure(FAR struct audio_lowerhalf_s *dev,
 static int  cs4344_configure(FAR struct audio_lowerhalf_s *dev,
                               FAR const struct audio_caps_s *caps);
 #endif
-static int  cs4344_shutdown(FAR struct audio_lowerhalf_s *dev);
+static int  cs4344_shutdown(FAR struct audio_lowerhalf_s *dev, int cnt);
 static void cs4344_senddone(FAR struct i2s_dev_s *i2s,
                              FAR struct ap_buffer_s *apb, FAR void *arg,
                              int result);
@@ -134,6 +134,7 @@ static int cs4344_reset(FAR struct cs4344_dev_s *priv);
 
 static const struct audio_ops_s g_audioops =
 {
+  NULL,                 /* setup */
   cs4344_getcaps,       /* getcaps */
   cs4344_configure,     /* configure */
   cs4344_shutdown,      /* shutdown */
@@ -627,7 +628,7 @@ cs4344_configure(FAR struct audio_lowerhalf_s *dev,
  *
  ****************************************************************************/
 
-static int cs4344_shutdown(FAR struct audio_lowerhalf_s *dev)
+static int cs4344_shutdown(FAR struct audio_lowerhalf_s *dev, int cnt)
 {
   FAR struct cs4344_dev_s *priv = (FAR struct cs4344_dev_s *)dev;
 

--- a/drivers/audio/cs43l22.c
+++ b/drivers/audio/cs43l22.c
@@ -88,7 +88,7 @@ static int  cs43l22_configure(FAR struct audio_lowerhalf_s *dev,
 static int  cs43l22_configure(FAR struct audio_lowerhalf_s *dev,
                               FAR const struct audio_caps_s *caps);
 #endif
-static int  cs43l22_shutdown(FAR struct audio_lowerhalf_s *dev);
+static int  cs43l22_shutdown(FAR struct audio_lowerhalf_s *dev, int cnt);
 static void cs43l22_senddone(FAR struct i2s_dev_s *i2s,
                              FAR struct ap_buffer_s *apb, FAR void *arg,
                              int result);
@@ -168,6 +168,7 @@ static void cs43l22_reset(FAR struct cs43l22_dev_s *priv);
 
 static const struct audio_ops_s g_audioops =
 {
+  NULL,                  /* setup */
   cs43l22_getcaps,       /* getcaps */
   cs43l22_configure,     /* configure */
   cs43l22_shutdown,      /* shutdown */
@@ -858,7 +859,7 @@ cs43l22_configure(FAR struct audio_lowerhalf_s *dev,
  *
  ****************************************************************************/
 
-static int cs43l22_shutdown(FAR struct audio_lowerhalf_s *dev)
+static int cs43l22_shutdown(FAR struct audio_lowerhalf_s *dev, int cnt)
 {
   FAR struct cs43l22_dev_s *priv = (FAR struct cs43l22_dev_s *)dev;
 

--- a/drivers/audio/es8311.c
+++ b/drivers/audio/es8311.c
@@ -91,7 +91,7 @@ static int  es8311_configure(FAR struct audio_lowerhalf_s *dev,
 static int  es8311_configure(FAR struct audio_lowerhalf_s *dev,
                              FAR const struct audio_caps_s *caps);
 #endif /* !CONFIG_AUDIO_MULTI_SESSION */
-static int  es8311_shutdown(FAR struct audio_lowerhalf_s *dev);
+static int  es8311_shutdown(FAR struct audio_lowerhalf_s *dev, int cnt);
 static void es8311_processdone(FAR struct i2s_dev_s *i2s,
                                   FAR struct ap_buffer_s *apb,
                                   FAR void *arg,
@@ -154,6 +154,7 @@ static int  es8311_get_mclk_src(void);
 
 static const struct audio_ops_s g_audioops =
 {
+  NULL,                 /* setup          */
   es8311_getcaps,       /* getcaps        */
   es8311_configure,     /* configure      */
   es8311_shutdown,      /* shutdown       */
@@ -1107,7 +1108,7 @@ static int es8311_configure(FAR struct audio_lowerhalf_s *dev,
  *
  ****************************************************************************/
 
-static int es8311_shutdown(FAR struct audio_lowerhalf_s *dev)
+static int es8311_shutdown(FAR struct audio_lowerhalf_s *dev, int cnt)
 {
   FAR struct es8311_dev_s *priv = (FAR struct es8311_dev_s *)dev;
 

--- a/drivers/audio/es8388.c
+++ b/drivers/audio/es8388.c
@@ -91,7 +91,7 @@ static int  es8388_configure(FAR struct audio_lowerhalf_s *dev,
 static int  es8388_configure(FAR struct audio_lowerhalf_s *dev,
                              FAR const struct audio_caps_s *caps);
 #endif
-static int  es8388_shutdown(FAR struct audio_lowerhalf_s *dev);
+static int  es8388_shutdown(FAR struct audio_lowerhalf_s *dev, int cnt);
 static void es8388_processdone(FAR struct i2s_dev_s *i2s,
                                   FAR struct ap_buffer_s *apb,
                                   FAR void *arg,
@@ -153,6 +153,7 @@ static void es8388_reset(FAR struct es8388_dev_s *priv);
 
 static const struct audio_ops_s g_audioops =
 {
+  NULL,                 /* setup          */
   es8388_getcaps,       /* getcaps        */
   es8388_configure,     /* configure      */
   es8388_shutdown,      /* shutdown       */
@@ -1123,7 +1124,7 @@ static int es8388_configure(FAR struct audio_lowerhalf_s *dev,
  *
  ****************************************************************************/
 
-static int es8388_shutdown(FAR struct audio_lowerhalf_s *dev)
+static int es8388_shutdown(FAR struct audio_lowerhalf_s *dev, int cnt)
 {
   FAR struct es8388_dev_s *priv = (FAR struct es8388_dev_s *)dev;
 

--- a/drivers/audio/vs1053.c
+++ b/drivers/audio/vs1053.c
@@ -181,6 +181,7 @@ static int     vs1053_ioctl(FAR struct audio_lowerhalf_s *lower, int cmd,
 
 static const struct audio_ops_s g_audioops =
 {
+  NULL,                 /* setup          */
   vs1053_getcaps,       /* getcaps        */
   vs1053_configure,     /* configure      */
   vs1053_shutdown,      /* shutdown       */
@@ -932,7 +933,7 @@ static int vs1053_hardreset(FAR struct vs1053_struct_s *dev)
  *
  ****************************************************************************/
 
-static int vs1053_shutdown(FAR struct audio_lowerhalf_s *lower)
+static int vs1053_shutdown(FAR struct audio_lowerhalf_s *lower, int cnt)
 {
   FAR struct vs1053_struct_s *dev = (struct vs1053_struct_s *) lower;
   FAR struct spi_dev_s  *spi = dev->spi;

--- a/drivers/audio/wm8776.c
+++ b/drivers/audio/wm8776.c
@@ -67,7 +67,7 @@ static int      wm8776_configure(FAR struct audio_lowerhalf_s *dev,
 static int      wm8776_configure(FAR struct audio_lowerhalf_s *dev,
                   FAR const struct audio_caps_s *caps);
 #endif
-static int      wm8776_shutdown(FAR struct audio_lowerhalf_s *dev);
+static int      wm8776_shutdown(FAR struct audio_lowerhalf_s *dev, int cnt);
 static void     wm8776_senddone(FAR struct i2s_dev_s *i2s,
                   FAR struct ap_buffer_s *apb, FAR void *arg, int result);
 static void     wm8776_returnbuffers(FAR struct wm8776_dev_s *priv);
@@ -133,6 +133,7 @@ static void     wm8776_hw_reset(FAR struct wm8776_dev_s *priv);
 
 static const struct audio_ops_s g_audioops =
 {
+  NULL,                 /* setup          */
   wm8776_getcaps,       /* getcaps        */
   wm8776_configure,     /* configure      */
   wm8776_shutdown,      /* shutdown       */
@@ -450,7 +451,7 @@ static int wm8776_configure(FAR struct audio_lowerhalf_s *dev,
  *
  ****************************************************************************/
 
-static int wm8776_shutdown(FAR struct audio_lowerhalf_s *dev)
+static int wm8776_shutdown(FAR struct audio_lowerhalf_s *dev, int cnt)
 {
   FAR struct wm8776_dev_s *priv = (FAR struct wm8776_dev_s *)dev;
 

--- a/drivers/audio/wm8904.c
+++ b/drivers/audio/wm8904.c
@@ -103,7 +103,7 @@ static int      wm8904_configure(FAR struct audio_lowerhalf_s *dev,
 static int      wm8904_configure(FAR struct audio_lowerhalf_s *dev,
                   FAR const struct audio_caps_s *caps);
 #endif
-static int      wm8904_shutdown(FAR struct audio_lowerhalf_s *dev);
+static int      wm8904_shutdown(FAR struct audio_lowerhalf_s *dev, int cnt);
 static void     wm8904_senddone(FAR struct i2s_dev_s *i2s,
                   FAR struct ap_buffer_s *apb, FAR void *arg, int result);
 static void     wm8904_returnbuffers(FAR struct wm8904_dev_s *priv);
@@ -182,6 +182,7 @@ static void     wm8904_hw_reset(FAR struct wm8904_dev_s *priv);
 
 static const struct audio_ops_s g_audioops =
 {
+  NULL,                 /* setup          */
   wm8904_getcaps,       /* getcaps        */
   wm8904_configure,     /* configure      */
   wm8904_shutdown,      /* shutdown       */
@@ -1298,7 +1299,7 @@ static int wm8904_configure(FAR struct audio_lowerhalf_s *dev,
  *
  ****************************************************************************/
 
-static int wm8904_shutdown(FAR struct audio_lowerhalf_s *dev)
+static int wm8904_shutdown(FAR struct audio_lowerhalf_s *dev, int cnt)
 {
   FAR struct wm8904_dev_s *priv = (FAR struct wm8904_dev_s *)dev;
 

--- a/drivers/audio/wm8994.c
+++ b/drivers/audio/wm8994.c
@@ -113,7 +113,7 @@ static int      wm8994_configure(FAR struct audio_lowerhalf_s *dev,
 static int      wm8994_configure(FAR struct audio_lowerhalf_s *dev,
                   FAR const struct audio_caps_s *caps);
 #endif
-static int      wm8994_shutdown(FAR struct audio_lowerhalf_s *dev);
+static int      wm8994_shutdown(FAR struct audio_lowerhalf_s *dev, int cnt);
 static void     wm8994_senddone(FAR struct i2s_dev_s *i2s,
                   FAR struct ap_buffer_s *apb, FAR void *arg, int result);
 static void     wm8994_returnbuffers(FAR struct wm8994_dev_s *priv);
@@ -190,6 +190,7 @@ static void     wm8994_hw_reset(FAR struct wm8994_dev_s *priv);
 
 static const struct audio_ops_s g_audioops =
 {
+  NULL,                 /* setup          */
   wm8994_getcaps,       /* getcaps        */
   wm8994_configure,     /* configure      */
   wm8994_shutdown,      /* shutdown       */
@@ -993,7 +994,7 @@ static int wm8994_configure(FAR struct audio_lowerhalf_s *dev,
  *
  */
 
-static int wm8994_shutdown(FAR struct audio_lowerhalf_s *dev)
+static int wm8994_shutdown(FAR struct audio_lowerhalf_s *dev, int cnt)
 {
   FAR struct wm8994_dev_s *priv = (FAR struct wm8994_dev_s *)dev;
 

--- a/drivers/virtio/virtio-snd.c
+++ b/drivers/virtio/virtio-snd.c
@@ -168,7 +168,7 @@ static int virtio_snd_enqueuebuffer(FAR struct audio_lowerhalf_s *dev,
 static int virtio_snd_ioctl(FAR struct audio_lowerhalf_s *dev,
                             int cmd,
                             unsigned long arg);
-static int virtio_snd_shutdown(FAR struct audio_lowerhalf_s *dev);
+static int virtio_snd_shutdown(FAR struct audio_lowerhalf_s *dev, int cnt);
 
 static int virtio_snd_probe(FAR struct virtio_device *vdev);
 static void virtio_snd_remove(FAR struct virtio_device *vdev);
@@ -243,6 +243,7 @@ static struct virtio_driver g_virtio_snd_driver =
 
 static const struct audio_ops_s g_virtio_snd_ops =
 {
+  NULL,                      /* setup          */
   virtio_snd_getcaps,        /* getcaps        */
   virtio_snd_configure,      /* configure      */
   virtio_snd_shutdown,       /* shutdown       */
@@ -1004,7 +1005,7 @@ static int virtio_snd_ioctl(FAR struct audio_lowerhalf_s *dev,
  *
  ****************************************************************************/
 
-static int virtio_snd_shutdown(FAR struct audio_lowerhalf_s *dev)
+static int virtio_snd_shutdown(FAR struct audio_lowerhalf_s *dev, int cnt)
 {
   vrtinfo("Return OK\n");
   return OK;

--- a/include/nuttx/audio/audio.h
+++ b/include/nuttx/audio/audio.h
@@ -114,6 +114,7 @@
 #define AUDIOIOC_SETPARAMTER        _AUDIOIOC(18)
 #define AUDIOIOC_GETLATENCY         _AUDIOIOC(19)
 #define AUDIOIOC_FLUSH              _AUDIOIOC(20)
+#define AUDIOIOC_VENDORSPECIFIC     _AUDIOIOC(255)
 
 /* Audio Device Types *******************************************************/
 
@@ -353,6 +354,7 @@
 #define AUDIO_MSG_COMMAND          10
 #define AUDIO_MSG_SLIENCE          11
 #define AUDIO_MSG_UNDERRUN         12
+#define AUDIO_MSG_IOERROR          13
 #define AUDIO_MSG_USER             64
 
 /* Audio Pipeline Buffer flags */
@@ -534,6 +536,10 @@ typedef CODE void (*audio_callback_t)(FAR void *priv, uint16_t reason,
 struct audio_lowerhalf_s;
 struct audio_ops_s
 {
+  /* This method is called when the related device file is opened. */
+
+  CODE int (*setup)(FAR struct audio_lowerhalf_s *dev, int opencnt);
+
   /* This method is called to retrieve the lower-half device capabilities.
    * It will be called with device type AUDIO_TYPE_QUERY to request the
    * overall capabilities, such as to determine the types of devices
@@ -571,7 +577,7 @@ struct audio_ops_s
    * processed / dequeued should be dequeued by this function.
    */
 
-  CODE int (*shutdown)(FAR struct audio_lowerhalf_s *dev);
+  CODE int (*shutdown)(FAR struct audio_lowerhalf_s *dev, int opencnt);
 
   /* Start audio streaming in the configured mode.  For input and synthesis
    * devices, this means it should begin sending streaming audio data.


### PR DESCRIPTION
## Summary

Add an 'setup' method on the 'struct audio_ops_s' to notify to the driver that the related device file has been opened and is ready for use.
And also add refcount argument on shutdown method to know how many device file is still opened.

## Impact

Audio drivers

## Testing

Build check
