### PR TITLE
Minor local socket improvement

### DIFF
--- a/net/local/local.h
+++ b/net/local/local.h
@@ -143,7 +143,6 @@ struct local_conn_s
   /* SOCK_STREAM fields common to both client and server */
 
   sem_t lc_waitsem;            /* Use to wait for a connection to be accepted */
-  FAR struct socket *lc_psock; /* A reference to the socket structure */
 
   /* The following is a list if poll structures of threads waiting for
    * socket events.

--- a/net/local/local_accept.c
+++ b/net/local/local_accept.c
@@ -150,8 +150,6 @@ int local_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
 
           /* Setup the accpet socket structure */
 
-          conn->lc_psock = newsock;
-
           newsock->s_domain = psock->s_domain;
           newsock->s_type   = SOCK_STREAM;
           newsock->s_sockif = psock->s_sockif;

--- a/net/local/local_conn.c
+++ b/net/local/local_conn.c
@@ -118,9 +118,10 @@ FAR struct local_conn_s *local_alloc(void)
        * necessary to zerio-ize any structure elements.
        */
 
+      conn->lc_crefs = 1;
+
 #ifdef CONFIG_NET_LOCAL_STREAM
       nxsem_init(&conn->lc_waitsem, 0, 0);
-
 #endif
 
       /* This semaphore is used for sending safely in multithread.
@@ -173,10 +174,6 @@ int local_alloc_accept(FAR struct local_conn_s *server,
       nerr("ERROR:  Failed to allocate new connection structure\n");
       return -ENOMEM;
     }
-
-  /* Initialize the new connection structure */
-
-  local_addref(conn);
 
   conn->lc_proto  = SOCK_STREAM;
   conn->lc_type   = LOCAL_TYPE_PATHNAME;

--- a/net/local/local_connect.c
+++ b/net/local/local_connect.c
@@ -287,11 +287,8 @@ int psock_local_connect(FAR struct socket *psock,
 
               /* We have to do more for the SOCK_STREAM family */
 
-              if (conn->lc_proto == SOCK_STREAM)
-                {
-                  ret = local_stream_connect(client, conn,
+              ret = local_stream_connect(client, conn,
                           _SS_ISNONBLOCK(client->lc_conn.s_flags));
-                }
 
               net_unlock();
               return ret;

--- a/net/local/local_recvmsg.c
+++ b/net/local/local_recvmsg.c
@@ -237,11 +237,17 @@ psock_stream_recvfrom(FAR struct socket *psock, FAR void *buf, size_t len,
 
   /* Verify that this is a connected peer socket */
 
-  if (conn->lc_state != LOCAL_STATE_CONNECTED ||
-      conn->lc_infile.f_inode == NULL)
+  if (conn->lc_state != LOCAL_STATE_CONNECTED)
     {
       nerr("ERROR: not connected\n");
       return -ENOTCONN;
+    }
+
+  /* Check shutdown state */
+
+  if (conn->lc_infile.f_inode == NULL)
+    {
+      return 0;
     }
 
   /* If it is non-blocking mode, the data in fifo is 0 and

--- a/net/local/local_sendmsg.c
+++ b/net/local/local_sendmsg.c
@@ -186,11 +186,17 @@ static ssize_t local_send(FAR struct socket *psock,
            * opened the outgoing FIFO for write-only access.
            */
 
-          if (peer->lc_state != LOCAL_STATE_CONNECTED ||
-              peer->lc_outfile.f_inode == NULL)
+          if (peer->lc_state != LOCAL_STATE_CONNECTED)
             {
               nerr("ERROR: not connected\n");
               return -ENOTCONN;
+            }
+
+          /* Check shutdown state */
+
+          if (peer->lc_outfile.f_inode == NULL)
+            {
+              return -EPIPE;
             }
 
           /* Send the packet */

--- a/net/local/local_sockif.c
+++ b/net/local/local_sockif.c
@@ -148,9 +148,6 @@ static int local_sockif_alloc(FAR struct socket *psock)
   /* Save the pre-allocated connection in the socket structure */
 
   psock->s_conn = conn;
-#if defined(CONFIG_NET_LOCAL_STREAM)
-  conn->lc_psock = psock;
-#endif
   return OK;
 }
 #endif

--- a/net/local/local_sockif.c
+++ b/net/local/local_sockif.c
@@ -139,12 +139,6 @@ static int local_sockif_alloc(FAR struct socket *psock)
       return -ENOMEM;
     }
 
-  /* Set the reference count on the connection structure.  This reference
-   * count will be incremented only if the socket is dup'ed
-   */
-
-  local_addref(conn);
-
   /* Save the pre-allocated connection in the socket structure */
 
   psock->s_conn = conn;


### PR DESCRIPTION
## Summary

- local: correct shutdown state when use UDP mode
- net/local: Remove the unused lc_psock from local_conn_s
- net/local: Initialize lc_crefs to 1
- net/local: Remove the check of SOCK_STREAM before local_stream_connect
- net/local: Add local_freectl to avoid the code duplicaton

## Impact

local socket

## Testing

internal testing