### PR TITLE
nuttx/list: rename container_of to list_container_of from public header

### DIFF
--- a/arch/arm/src/lc823450/lc823450_timer.c
+++ b/arch/arm/src/lc823450/lc823450_timer.c
@@ -29,6 +29,7 @@
 #include <time.h>
 #include <assert.h>
 #include <debug.h>
+#include <nuttx/nuttx.h>
 #include <nuttx/arch.h>
 #include <nuttx/spinlock.h>
 #include <arch/board/board.h>

--- a/arch/arm/src/lc823450/lc823450_usbdev.c
+++ b/arch/arm/src/lc823450/lc823450_usbdev.c
@@ -38,6 +38,7 @@
 #  include <system_property.h>
 #endif
 
+#include <nuttx/nuttx.h>
 #include <nuttx/arch.h>
 #include <nuttx/spinlock.h>
 #include <nuttx/kmalloc.h>

--- a/arch/arm/src/stm32h7/stm32_adc.c
+++ b/arch/arm/src/stm32h7/stm32_adc.c
@@ -55,6 +55,7 @@
 #include <string.h>
 
 #include <arch/board/board.h>
+#include <nuttx/nuttx.h>
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
 #include <nuttx/fs/ioctl.h>

--- a/arch/arm/src/stm32l4/stm32l4_adc.c
+++ b/arch/arm/src/stm32l4/stm32l4_adc.c
@@ -34,6 +34,7 @@
 #include <string.h>
 
 #include <arch/board/board.h>
+#include <nuttx/nuttx.h>
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
 #include <nuttx/fs/ioctl.h>

--- a/arch/risc-v/src/bl602/bl602_netdev.c
+++ b/arch/risc-v/src/bl602/bl602_netdev.c
@@ -32,6 +32,7 @@
 #include <assert.h>
 #include <debug.h>
 #include <sched.h>
+#include <nuttx/nuttx.h>
 #include <nuttx/mutex.h>
 #include <nuttx/semaphore.h>
 #include <nuttx/nuttx.h>

--- a/arch/risc-v/src/common/espressif/esp_hr_timer.c
+++ b/arch/risc-v/src/common/espressif/esp_hr_timer.c
@@ -33,6 +33,7 @@
 #include <string.h>
 #include <sys/types.h>
 
+#include <nuttx/nuttx.h>
 #include <nuttx/irq.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/kthread.h>

--- a/arch/risc-v/src/esp32c3-legacy/esp32c3_rt_timer.c
+++ b/arch/risc-v/src/esp32c3-legacy/esp32c3_rt_timer.c
@@ -33,6 +33,7 @@
 #include <errno.h>
 #include <debug.h>
 
+#include <nuttx/nuttx.h>
 #include <nuttx/irq.h>
 #include <nuttx/kthread.h>
 #include <nuttx/kmalloc.h>

--- a/arch/risc-v/src/k230/k230_rptun.c
+++ b/arch/risc-v/src/k230/k230_rptun.c
@@ -34,6 +34,7 @@
 #include <sys/types.h>
 #include <time.h>
 
+#include <nuttx/nuttx.h>
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
 #include <nuttx/kthread.h>

--- a/arch/risc-v/src/mpfs/mpfs_ihc.c
+++ b/arch/risc-v/src/mpfs/mpfs_ihc.c
@@ -34,6 +34,7 @@
 #include <sys/types.h>
 #include <time.h>
 
+#include <nuttx/nuttx.h>
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
 #include <nuttx/kthread.h>

--- a/arch/risc-v/src/rv32m1/rv32m1_gpio.c
+++ b/arch/risc-v/src/rv32m1/rv32m1_gpio.c
@@ -32,6 +32,7 @@
 #include <nuttx/arch.h>
 #include <arch/board/board.h>
 
+#include <nuttx/nuttx.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/queue.h>
 

--- a/arch/sim/src/sim/posix/sim_alsa.c
+++ b/arch/sim/src/sim/posix/sim_alsa.c
@@ -23,6 +23,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/nuttx.h>
 #include <nuttx/audio/audio.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/queue.h>

--- a/arch/sim/src/sim/sim_rptun.c
+++ b/arch/sim/src/sim/sim_rptun.c
@@ -22,6 +22,7 @@
  * Included Files
  ****************************************************************************/
 
+#include <nuttx/nuttx.h>
 #include <nuttx/drivers/addrenv.h>
 #include <nuttx/rptun/rptun.h>
 #include <nuttx/list.h>

--- a/arch/xtensa/src/esp32/esp32_rt_timer.c
+++ b/arch/xtensa/src/esp32/esp32_rt_timer.c
@@ -33,6 +33,7 @@
 #include <errno.h>
 #include <debug.h>
 
+#include <nuttx/nuttx.h>
 #include <nuttx/irq.h>
 #include <nuttx/kthread.h>
 #include <nuttx/kmalloc.h>

--- a/arch/xtensa/src/esp32/esp32_wlan.c
+++ b/arch/xtensa/src/esp32/esp32_wlan.c
@@ -31,6 +31,7 @@
 #include <debug.h>
 #include <arpa/inet.h>
 
+#include <nuttx/nuttx.h>
 #include <nuttx/crc64.h>
 #include <nuttx/nuttx.h>
 #include <nuttx/arch.h>

--- a/arch/xtensa/src/esp32s2/esp32s2_rt_timer.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_rt_timer.c
@@ -33,6 +33,7 @@
 #include <errno.h>
 #include <debug.h>
 
+#include <nuttx/nuttx.h>
 #include <nuttx/irq.h>
 #include <nuttx/kthread.h>
 #include <nuttx/kmalloc.h>

--- a/arch/xtensa/src/esp32s3/esp32s3_rt_timer.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_rt_timer.c
@@ -33,6 +33,7 @@
 #include <string.h>
 #include <sys/types.h>
 
+#include <nuttx/nuttx.h>
 #include <nuttx/irq.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/kthread.h>

--- a/drivers/input/uinput.c
+++ b/drivers/input/uinput.c
@@ -26,6 +26,7 @@
 #include <errno.h>
 #include <stdio.h>
 
+#include <nuttx/nuttx.h>
 #include <nuttx/input/buttons.h>
 #include <nuttx/input/keyboard.h>
 #include <nuttx/input/touchscreen.h>

--- a/drivers/misc/rpmsgdev_server.c
+++ b/drivers/misc/rpmsgdev_server.c
@@ -28,6 +28,7 @@
 #include <errno.h>
 #include <debug.h>
 
+#include <nuttx/nuttx.h>
 #include <nuttx/list.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/mutex.h>

--- a/drivers/power/battery/goldfish_battery.c
+++ b/drivers/power/battery/goldfish_battery.c
@@ -25,6 +25,7 @@
 #include <stdint.h>
 #include <errno.h>
 #include <debug.h>
+#include <nuttx/nuttx.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/power/battery_gauge.h>
 #include <nuttx/power/battery_ioctl.h>

--- a/drivers/power/supply/regulator.c
+++ b/drivers/power/supply/regulator.c
@@ -30,6 +30,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <nuttx/nuttx.h>
 #include <nuttx/arch.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/power/consumer.h>

--- a/drivers/sensors/sensor_rpmsg.c
+++ b/drivers/sensors/sensor_rpmsg.c
@@ -27,6 +27,7 @@
 #include <fcntl.h>
 #include <debug.h>
 
+#include <nuttx/nuttx.h>
 #include <nuttx/list.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/mutex.h>

--- a/drivers/timers/rpmsg_rtc.c
+++ b/drivers/timers/rpmsg_rtc.c
@@ -24,6 +24,7 @@
 
 #include <nuttx/config.h>
 
+#include <nuttx/nuttx.h>
 #include <nuttx/list.h>
 #include <nuttx/clock.h>
 #include <nuttx/kmalloc.h>

--- a/drivers/virtio/virtio.c
+++ b/drivers/virtio/virtio.c
@@ -24,6 +24,7 @@
 
 #include <debug.h>
 
+#include <nuttx/nuttx.h>
 #include <nuttx/mutex.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/virtio/virtio.h>

--- a/fs/vfs/fs_epoll.c
+++ b/fs/vfs/fs_epoll.c
@@ -33,6 +33,7 @@
 #include <string.h>
 #include <debug.h>
 
+#include <nuttx/nuttx.h>
 #include <nuttx/clock.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/kmalloc.h>

--- a/include/nuttx/list.h
+++ b/include/nuttx/list.h
@@ -44,14 +44,27 @@
  * Included Files
  ****************************************************************************/
 
-#include <nuttx/nuttx.h>
-
 #include <stddef.h>
 #include <stdbool.h>
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
+/* Name: list_container_of
+ *
+ * Description:
+ *   Cast a member of a structure out to get the address of the containing
+ *   structure
+ *
+ * Arguments:
+ *   ptr    - The pointer to the member.
+ *   type   - The type of the container struct this is embedded in.
+ *   member - The name of the member within the struct.
+ */
+
+#define list_container_of(ptr, type, member) \
+  ((type *)((uintptr_t)(ptr) - offsetof(type, member)))
 
 #define LIST_INITIAL_VALUE(list) { &(list), &(list) }
 #define LIST_INITIAL_CLEARED_VALUE { NULL, NULL }
@@ -89,11 +102,11 @@
   ((item)->next != (list) ? (item)->next : \
    (item)->next->next != (list) ? (item)->next->next : NULL)
 
-#define list_entry(ptr, type, member) container_of(ptr, type, member)
-#define list_first_entry(list, type, member) container_of((list)->next, type, member)
-#define list_last_entry(list, type, member) container_of((list)->prev, type, member)
-#define list_next_entry(list, type, member) container_of((list)->member.next, type, member)
-#define list_prev_entry(list, type, member) container_of((list)->member.prev, type, member)
+#define list_entry(ptr, type, member) list_container_of(ptr, type, member)
+#define list_first_entry(list, type, member) list_container_of((list)->next, type, member)
+#define list_last_entry(list, type, member) list_container_of((list)->prev, type, member)
+#define list_next_entry(list, type, member) list_container_of((list)->member.next, type, member)
+#define list_prev_entry(list, type, member) list_container_of((list)->member.prev, type, member)
 
 #define list_add_after(entry, new_entry) list_add_head(entry, new_entry)
 #define list_add_head(list, item) \
@@ -145,7 +158,7 @@
     FAR type *__t = NULL; \
     if(__node) \
       { \
-        __t = container_of(__node, type, member); \
+        __t = list_container_of(__node, type, member); \
       } \
     __t; \
   })
@@ -156,7 +169,7 @@
     FAR type *__t = NULL; \
     if(__node) \
       { \
-        __t = container_of(__node, type, member); \
+        __t = list_container_of(__node, type, member); \
       } \
     __t; \
   })
@@ -167,7 +180,7 @@
     FAR type *__t = NULL; \
     if(__node) \
       { \
-        __t = container_of(__node, type, member); \
+        __t = list_container_of(__node, type, member); \
       } \
     __t; \
   })
@@ -178,7 +191,7 @@
     FAR type *__t = NULL; \
     if(__node) \
       { \
-        __t = container_of(__node, type, member); \
+        __t = list_container_of(__node, type, member); \
       } \
     __t; \
   })
@@ -189,7 +202,7 @@
     FAR type *__t = NULL; \
     if(__node) \
       { \
-        __t = container_of(__node, type, member); \
+        __t = list_container_of(__node, type, member); \
       } \
     __t; \
   })
@@ -200,7 +213,7 @@
     FAR type *__t = NULL; \
     if(__node) \
       { \
-        __t = container_of(__node, type, member); \
+        __t = list_container_of(__node, type, member); \
       } \
     __t; \
   })
@@ -211,7 +224,7 @@
     FAR type *__t = NULL; \
     if(__node) \
       { \
-        __t = container_of(__node, type, member); \
+        __t = list_container_of(__node, type, member); \
       } \
     __t; \
   })
@@ -222,7 +235,7 @@
     FAR type *__t = NULL; \
     if(__node) \
       { \
-        __t = container_of(__node, type, member); \
+        __t = list_container_of(__node, type, member); \
       } \
     __t; \
   })
@@ -243,19 +256,19 @@
 /* iterates over the list, entry should be the container structure type */
 
 #define list_for_every_entry(list, entry, type, member) \
-  for(entry = container_of((list)->next, type, member); \
+  for(entry = list_container_of((list)->next, type, member); \
       &entry->member != (list); \
-      entry = container_of(entry->member.next, type, member))
+      entry = list_container_of(entry->member.next, type, member))
 
 /* iterates over the list in a safe way for deletion of current node
  * entry and temp_entry should be the container structure type *
  */
 
 #define list_for_every_entry_safe(list, entry, temp, type, member) \
-  for(entry = container_of((list)->next, type, member), \
-      temp = container_of(entry->member.next, type, member); \
+  for(entry = list_container_of((list)->next, type, member), \
+      temp = list_container_of(entry->member.next, type, member); \
       &entry->member != (list); entry = temp, \
-      temp = container_of(temp->member.next, type, member))
+      temp = list_container_of(temp->member.next, type, member))
 
 /* Iterate from a given entry node in a safe way */
 
@@ -274,9 +287,9 @@
  */
 
 #define list_for_every_entry_reverse(list, entry, type, member) \
-  for(entry = container_of((list)->prev, type, member); \
+  for(entry = list_container_of((list)->prev, type, member); \
       &entry->member != (list); \
-      entry = container_of(entry->member.prev, type, member))
+      entry = list_container_of(entry->member.prev, type, member))
 
 /****************************************************************************
  * Public Type Definitions


### PR DESCRIPTION
## Summary
nuttx/list: rename container_of to list_container_of from public header

Use private naming to avoid conflicts with user applications

```
In file included from libuv/src/unix/internal.h:25,
                 from libuv/src/unix/udp.c:23:
libuv/src/uv-common.h:57: warning: "container_of" redefined
   57 | #define container_of(ptr, type, member) \
      |
In file included from nuttx/include/nuttx/list.h:47,
                 from nuttx/include/nuttx/tls.h:40,
                 from nuttx/include/nuttx/sched.h:48,
                 from nuttx/include/nuttx/arch.h:87,
                 from nuttx/include/nuttx/userspace.h:35,
                 from nuttx/include/nuttx/mm/mm.h:30,
                 from nuttx/include/nuttx/kmalloc.h:34,
                 from nuttx/include/nuttx/lib/lib.h:31,
                 from nuttx/include/stdio.h:35,
                 from apps/system/libuv/libuv/include/uv.h:59,
                 from libuv/src/unix/udp.c:22:
nuttx/include/nuttx/nuttx.h:48: note: this is the location of the previous definition
   48 | #define container_of(ptr, type, member) \
      |
```

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A
## Testing
ci-check
