### PR TITLE
Documentation: correct `CMakeList.txt` to `CMakeLists.txt`

### DIFF
--- a/Documentation/quickstart/organization.rst
+++ b/Documentation/quickstart/organization.rst
@@ -237,10 +237,10 @@ support.
 
 For details see :doc:`/components/wireless`.
 
-``nuttx/CMakeList.txt``
-=======================
+``nuttx/CMakeLists.txt``
+========================
 
-The top-level ``CMakeList.txt`` file.
+The top-level ``CMakeLists.txt`` file.
 
 ``nuttx/Makefile``
 ==================


### PR DESCRIPTION
## Summary

Documentation: correct `CMakeList.txt` to `CMakeLists.txt`
    
Signed-off-by: Junbo Zheng <zhengjunbo1@xiaomi.com>

## Impact

## Testing

