### PR TITLE
syslog_rpmsg: handle syslog_rpmsg_transfer() return value

### DIFF
--- a/drivers/syslog/syslog_rpmsg.c
+++ b/drivers/syslog/syslog_rpmsg.c
@@ -189,11 +189,14 @@ static void syslog_rpmsg_putchar(FAR struct syslog_rpmsg_s *priv, int ch,
 {
   if (priv->head + 1 - priv->tail >= priv->size)
     {
+      bool ret = false;
+
       if (!priv->flush && !up_interrupt_context() && !sched_idletask())
         {
-          syslog_rpmsg_transfer(priv, true);
+          ret = syslog_rpmsg_transfer(priv, true);
         }
-      else
+
+      if (!ret)
         {
           /* Overwrite */
 


### PR DESCRIPTION
## Summary

syslog_rpmsg: handle syslog_rpmsg_transfer() return value

in case of only update head

## Impact

syslog rpmsg

## Testing

SIM