### PR TITLE
armv7-a/r: use _ebss as idle stack both in SMP mode or not

### DIFF
--- a/arch/arm/src/armv7-a/arm_head.S
+++ b/arch/arm/src/armv7-a/arm_head.S
@@ -34,8 +34,6 @@
 #ifndef IDLE_STACK_BASE
   #ifdef CONFIG_BOOT_SDRAM_DATA
     #define IDLE_STACK_BASE IDLE_STACK_VBASE
-  #elif defined(CONFIG_SMP)
-    #define IDLE_STACK_BASE _enoinit
   #else
     #define IDLE_STACK_BASE _ebss
   #endif

--- a/arch/arm/src/armv7-r/arm_head.S
+++ b/arch/arm/src/armv7-r/arm_head.S
@@ -76,11 +76,7 @@
  */
 
 #ifndef IDLE_STACK_BASE
-#  ifdef CONFIG_SMP
-#    define IDLE_STACK_BASE _enoinit
-#  else
-#    define IDLE_STACK_BASE _ebss
-#  endif
+#  define IDLE_STACK_BASE _ebss
 #endif
 
 #define IDLE_STACK_TOP  IDLE_STACK_BASE+CONFIG_IDLETHREAD_STACKSIZE


### PR DESCRIPTION

## Summary

armv7-a/r: use _ebss as idle stack both in SMP mode or not

It is better take the _ebss as IDLE_STACK_BASE like armv8-m

## Impact

armv7a/r

## Testing

BES board & qemu