### PR TITLE
cpuload: remove ciritical_section() to fix recursive

### DIFF
--- a/fs/procfs/fs_procfscpuload.c
+++ b/fs/procfs/fs_procfscpuload.c
@@ -203,8 +203,8 @@ static ssize_t cpuload_read(FAR struct file *filep, FAR char *buffer,
 
   if (filep->f_pos == 0)
     {
-      uint32_t total = 0;
-      uint32_t active = 0;
+      clock_t total = 0;
+      clock_t active = 0;
       uint32_t intpart;
       uint32_t fracpart;
 

--- a/include/nuttx/clock.h
+++ b/include/nuttx/clock.h
@@ -277,8 +277,8 @@
 #ifndef CONFIG_SCHED_CPULOAD_NONE
 struct cpuload_s
 {
-  volatile uint32_t total;   /* Total number of clock ticks */
-  volatile uint32_t active;  /* Number of ticks while this thread was active */
+  volatile clock_t total;   /* Total number of clock ticks */
+  volatile clock_t active;  /* Number of ticks while this thread was active */
 };
 #endif
 

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -623,7 +623,7 @@ struct tcb_s
   /* CPU load monitoring support ********************************************/
 
 #ifndef CONFIG_SCHED_CPULOAD_NONE
-  uint32_t ticks;                        /* Number of ticks on this thread */
+  clock_t ticks;                         /* Number of ticks on this thread */
 #endif
 
   /* Pre-emption monitor support ********************************************/

--- a/sched/sched/sched.h
+++ b/sched/sched/sched.h
@@ -240,7 +240,7 @@ extern const struct tasklist_s g_tasklisttable[NUM_TASK_STATES];
  * 'denominator' for all CPU load calculations.
  */
 
-extern volatile uint32_t g_cpuload_total;
+extern volatile clock_t g_cpuload_total;
 #endif
 
 /* Declared in sched_lock.c *************************************************/
@@ -399,8 +399,8 @@ int  nxsched_pause_cpu(FAR struct tcb_s *tcb);
 
 #if defined(CONFIG_SCHED_CPULOAD_SYSCLK) || \
     defined (CONFIG_SCHED_CPULOAD_CRITMONITOR)
-void nxsched_process_taskload_ticks(FAR struct tcb_s *tcb, uint32_t ticks);
-void nxsched_process_cpuload_ticks(uint32_t ticks);
+void nxsched_process_taskload_ticks(FAR struct tcb_s *tcb, clock_t ticks);
+void nxsched_process_cpuload_ticks(clock_t ticks);
 #define nxsched_process_cpuload() nxsched_process_cpuload_ticks(1)
 #endif
 

--- a/sched/sched/sched_cpuload.c
+++ b/sched/sched/sched_cpuload.c
@@ -99,10 +99,6 @@ volatile uint32_t g_cpuload_total;
 
 void nxsched_process_taskload_ticks(FAR struct tcb_s *tcb, uint32_t ticks)
 {
-  irqstate_t flags;
-
-  flags = enter_critical_section();
-
   tcb->ticks += ticks;
   g_cpuload_total += ticks;
 
@@ -128,8 +124,6 @@ void nxsched_process_taskload_ticks(FAR struct tcb_s *tcb, uint32_t ticks)
 
       g_cpuload_total = total;
     }
-
-  leave_critical_section(flags);
 }
 
 /****************************************************************************

--- a/sched/sched/sched_cpuload.c
+++ b/sched/sched/sched_cpuload.c
@@ -76,7 +76,7 @@
  * each would have a load of 25% of the total.
  */
 
-volatile uint32_t g_cpuload_total;
+volatile clock_t g_cpuload_total;
 
 /****************************************************************************
  * Public Functions
@@ -97,7 +97,7 @@ volatile uint32_t g_cpuload_total;
  *
  ****************************************************************************/
 
-void nxsched_process_taskload_ticks(FAR struct tcb_s *tcb, uint32_t ticks)
+void nxsched_process_taskload_ticks(FAR struct tcb_s *tcb, clock_t ticks)
 {
   tcb->ticks += ticks;
   g_cpuload_total += ticks;
@@ -147,7 +147,7 @@ void nxsched_process_taskload_ticks(FAR struct tcb_s *tcb, uint32_t ticks)
  *
  ****************************************************************************/
 
-void nxsched_process_cpuload_ticks(uint32_t ticks)
+void nxsched_process_cpuload_ticks(clock_t ticks)
 {
   int i;
 


### PR DESCRIPTION
## Summary

    cpuload: remove ciritical_section() to fix recursive
    cpuload: change cpuload type to clock_t
    
    Recursive:
    25 0x44000e5a in up_cpu_paused (cpu=cpu@entry=1) at armv7-a/arm_cpupause.c:120
    26 0x440032f2 in enter_critical_section () at irq/irq_csection.c:275
    27 0x44006f24 in nxsched_process_taskload_ticks (tcb=tcb@entry=0x442ba638 <g_idletcb+256>, ticks=0) at sched/sched_cpuload.c:104
    28 0x44007310 in nxsched_suspend_critmon (tcb=tcb@entry=0x442ba638 <g_idletcb+256>) at sched/sched_critmonitor.c:303
    29 0x44006ef0 in nxsched_suspend_scheduler (tcb=tcb@entry=0x442ba638 <g_idletcb+256>) at sched/sched_suspendscheduler.c:78
    30 0x44000e5a in up_cpu_paused (cpu=cpu@entry=1) at armv7-a/arm_cpupause.c:120
    31 0x440032f2 in enter_critical_section () at irq/irq_csection.c:275
    32 0x44000f1a in arm_pause_handler (irq=<optimized out>, context=<optimized out>, arg=<optimized out>) at armv7-a/arm_cpupause.c:216
    33 0x44002ffe in irq_dispatch (irq=irq@entry=2, context=context@entry=0x4449f6b8 <g_cpu1_idlestack+1720>) at irq/irq_dispatch.c:146
    34 0x44001612 in arm_doirq (irq=2, irq@entry=0, regs=0x4449f6b8 <g_cpu1_idlestack+1720>) at armv7-a/arm_doirq.c:72
    35 0x44000940 in arm_decodeirq (regs=<optimized out>) at armv7-a/arm_gicv2.c:403
    36 0x440000b4 in arm_vectorirq () at armv7-a/arm_vectors.S:236


## Impact

cpuload

## Testing

SIM
