### PR TITLE
armv7-a/r timer update

### DIFF
--- a/arch/arm/src/armv7-a/arm_perf.c
+++ b/arch/arm/src/armv7-a/arm_perf.c
@@ -26,6 +26,7 @@
 #include <nuttx/clock.h>
 
 #include "arm_internal.h"
+#include "arm_timer.h"
 #include "sctlr.h"
 
 #ifdef CONFIG_ARCH_PERF_EVENTS
@@ -63,6 +64,13 @@ static unsigned long g_cpu_freq = ULONG_MAX;
 void up_perf_init(void *arg)
 {
   g_cpu_freq = (unsigned long)(uintptr_t)arg;
+
+#ifdef CONFIG_ARMV7A_HAVE_PTM
+  if (g_cpu_freq == ULONG_MAX || g_cpu_freq == 0)
+    {
+      g_cpu_freq = arm_timer_get_freq();
+    }
+#endif
 
   cp15_pmu_uer(PMUER_UME);
   cp15_pmu_pmcr(PMCR_E);

--- a/arch/arm/src/armv7-a/arm_timer.c
+++ b/arch/arm/src/armv7-a/arm_timer.c
@@ -87,12 +87,6 @@ static const struct oneshot_operations_s g_arm_timer_ops =
  * Private Functions
  ****************************************************************************/
 
-static inline uint32_t arm_timer_get_freq(void)
-{
-  ARM_ISB();
-  return CP15_GET(CNTFRQ);
-}
-
 static inline void arm_timer_set_freq(uint32_t freq)
 {
   CP15_SET(CNTFRQ, freq);
@@ -262,6 +256,12 @@ static int arm_timer_interrupt(int irq, void *context, void *arg)
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
+
+uint32_t arm_timer_get_freq(void)
+{
+  ARM_ISB();
+  return CP15_GET(CNTFRQ);
+}
 
 struct oneshot_lowerhalf_s *arm_timer_initialize(unsigned int freq)
 {

--- a/arch/arm/src/armv7-a/arm_timer.c
+++ b/arch/arm/src/armv7-a/arm_timer.c
@@ -129,6 +129,18 @@ static inline void arm_timer_set_tval(uint32_t tval)
   ARM_ISB();
 }
 
+static inline uint64_t arm_timer_get_cval(void)
+{
+  ARM_ISB();
+  return CP15_GET64(CNTP_CVAL);
+}
+
+static inline void arm_timer_set_cval(uint64_t cval)
+{
+  CP15_SET64(CNTP_CVAL, cval);
+  ARM_ISB();
+}
+
 static inline uint64_t nsec_from_count(uint64_t count, uint32_t freq)
 {
   return (uint64_t)count * NSEC_PER_SEC / freq;
@@ -165,7 +177,7 @@ static int arm_timer_start(struct oneshot_lowerhalf_s *lower_,
   struct arm_timer_lowerhalf_s *lower =
     (struct arm_timer_lowerhalf_s *)lower_;
   irqstate_t flags;
-  uint32_t count;
+  uint64_t count;
   uint32_t ctrl;
 
   flags = up_irq_save();
@@ -175,7 +187,7 @@ static int arm_timer_start(struct oneshot_lowerhalf_s *lower_,
 
   count = sec_to_count(ts->tv_sec, lower->freq) +
           nsec_to_count(ts->tv_nsec, lower->freq);
-  arm_timer_set_tval(count);
+  arm_timer_set_cval(arm_timer_get_count() + count);
 
   ctrl = arm_timer_get_ctrl();
   ctrl &= ~ARM_TIMER_CTRL_INT_MASK;
@@ -229,6 +241,8 @@ static int arm_timer_interrupt(int irq, void *context, void *arg)
   void *cbarg;
 
   DEBUGASSERT(lower != NULL);
+
+  arm_timer_set_ctrl(arm_timer_get_ctrl() | ARM_TIMER_CTRL_INT_MASK);
 
   if (lower->callback != NULL)
     {

--- a/arch/arm/src/armv7-a/arm_timer.c
+++ b/arch/arm/src/armv7-a/arm_timer.c
@@ -150,7 +150,7 @@ static int arm_timer_maxdelay(struct oneshot_lowerhalf_s *lower_,
   struct arm_timer_lowerhalf_s *lower =
     (struct arm_timer_lowerhalf_s *)lower_;
 
-  uint64_t maxnsec = nsec_from_count(UINT32_MAX, lower->freq);
+  uint64_t maxnsec = nsec_from_count(UINT64_MAX, lower->freq);
 
   ts->tv_sec  = maxnsec / NSEC_PER_SEC;
   ts->tv_nsec = maxnsec % NSEC_PER_SEC;

--- a/arch/arm/src/armv7-a/arm_timer.h
+++ b/arch/arm/src/armv7-a/arm_timer.h
@@ -59,8 +59,10 @@ extern "C"
 
 #ifdef CONFIG_ARMV7A_HAVE_PTM
 struct oneshot_lowerhalf_s *arm_timer_initialize(unsigned int freq);
+uint32_t arm_timer_get_freq(void);
 #else
 #  define arm_timer_initialize(freq) NULL
+#  define arm_timer_get_freq() 0
 #endif
 
 #undef EXTERN

--- a/arch/arm/src/armv7-r/arm_perf.c
+++ b/arch/arm/src/armv7-r/arm_perf.c
@@ -26,6 +26,7 @@
 #include <nuttx/clock.h>
 
 #include "arm_internal.h"
+#include "arm_timer.h"
 #include "sctlr.h"
 
 #ifdef CONFIG_ARCH_PERF_EVENTS
@@ -63,6 +64,13 @@ static unsigned long g_cpu_freq = ULONG_MAX;
 void up_perf_init(void *arg)
 {
   g_cpu_freq = (unsigned long)(uintptr_t)arg;
+
+#ifdef CONFIG_ARMV7R_HAVE_PTM
+  if (g_cpu_freq == ULONG_MAX || g_cpu_freq == 0)
+    {
+      g_cpu_freq = arm_timer_get_freq();
+    }
+#endif
 
   cp15_pmu_uer(PMUER_UME);
   cp15_pmu_pmcr(PMCR_E);

--- a/arch/arm/src/armv7-r/arm_timer.c
+++ b/arch/arm/src/armv7-r/arm_timer.c
@@ -87,12 +87,6 @@ static const struct oneshot_operations_s g_arm_timer_ops =
  * Private Functions
  ****************************************************************************/
 
-static inline uint32_t arm_timer_get_freq(void)
-{
-  ARM_ISB();
-  return CP15_GET(CNTFRQ);
-}
-
 static inline void arm_timer_set_freq(uint32_t freq)
 {
   CP15_SET(CNTFRQ, freq);
@@ -264,6 +258,12 @@ static int arm_timer_interrupt(int irq, void *context, void *arg)
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
+
+uint32_t arm_timer_get_freq(void)
+{
+  ARM_ISB();
+  return CP15_GET(CNTFRQ);
+}
 
 struct oneshot_lowerhalf_s *arm_timer_initialize(unsigned int freq)
 {

--- a/arch/arm/src/armv7-r/arm_timer.c
+++ b/arch/arm/src/armv7-r/arm_timer.c
@@ -129,6 +129,18 @@ static inline void arm_timer_set_tval(uint32_t tval)
   ARM_ISB();
 }
 
+static inline uint64_t arm_timer_get_cval(void)
+{
+  ARM_ISB();
+  return CP15_GET64(CNTP_CVAL);
+}
+
+static inline void arm_timer_set_cval(uint64_t cval)
+{
+  CP15_SET64(CNTP_CVAL, cval);
+  ARM_ISB();
+}
+
 static inline uint64_t nsec_from_count(uint64_t count, uint32_t freq)
 {
   return (uint64_t)count * NSEC_PER_SEC / freq;
@@ -165,7 +177,7 @@ static int arm_timer_start(struct oneshot_lowerhalf_s *lower_,
   struct arm_timer_lowerhalf_s *lower =
     (struct arm_timer_lowerhalf_s *)lower_;
   irqstate_t flags;
-  uint32_t count;
+  uint64_t count;
   uint32_t ctrl;
 
   flags = up_irq_save();
@@ -175,7 +187,7 @@ static int arm_timer_start(struct oneshot_lowerhalf_s *lower_,
 
   count = sec_to_count(ts->tv_sec, lower->freq) +
           nsec_to_count(ts->tv_nsec, lower->freq);
-  arm_timer_set_tval(count);
+  arm_timer_set_cval(arm_timer_get_count() + count);
 
   ctrl = arm_timer_get_ctrl();
   ctrl &= ~ARM_TIMER_CTRL_INT_MASK;
@@ -229,6 +241,8 @@ static int arm_timer_interrupt(int irq, void *context, void *arg)
   void *cbarg;
 
   DEBUGASSERT(lower != NULL);
+
+  arm_timer_set_ctrl(arm_timer_get_ctrl() | ARM_TIMER_CTRL_INT_MASK);
 
   if (lower->callback != NULL)
     {

--- a/arch/arm/src/armv7-r/arm_timer.c
+++ b/arch/arm/src/armv7-r/arm_timer.c
@@ -150,7 +150,7 @@ static int arm_timer_maxdelay(struct oneshot_lowerhalf_s *lower_,
   struct arm_timer_lowerhalf_s *lower =
     (struct arm_timer_lowerhalf_s *)lower_;
 
-  uint64_t maxnsec = nsec_from_count(UINT32_MAX, lower->freq);
+  uint64_t maxnsec = nsec_from_count(UINT64_MAX, lower->freq);
 
   ts->tv_sec  = maxnsec / NSEC_PER_SEC;
   ts->tv_nsec = maxnsec % NSEC_PER_SEC;

--- a/arch/arm/src/armv7-r/arm_timer.c
+++ b/arch/arm/src/armv7-r/arm_timer.c
@@ -143,7 +143,9 @@ static inline void arm_timer_set_cval(uint64_t cval)
 
 static inline uint64_t nsec_from_count(uint64_t count, uint32_t freq)
 {
-  return (uint64_t)count * NSEC_PER_SEC / freq;
+  uint64_t sec = count / freq;
+  uint64_t nsec = (count % freq) * NSEC_PER_SEC / freq;
+  return sec * NSEC_PER_SEC + nsec;
 }
 
 static inline uint64_t nsec_to_count(uint32_t nsec, uint32_t freq)

--- a/arch/arm/src/armv7-r/arm_timer.h
+++ b/arch/arm/src/armv7-r/arm_timer.h
@@ -59,8 +59,10 @@ extern "C"
 
 #ifdef CONFIG_ARMV7R_HAVE_PTM
 struct oneshot_lowerhalf_s *arm_timer_initialize(unsigned int freq);
+uint32_t arm_timer_get_freq(void);
 #else
 #  define arm_timer_initialize(freq) NULL
+#  define arm_timer_get_freq() 0
 #endif
 
 #undef EXTERN

--- a/arch/arm/src/goldfish/goldfish_boot.c
+++ b/arch/arm/src/goldfish/goldfish_boot.c
@@ -47,6 +47,10 @@
 
 void arm_boot(void)
 {
+  /* Perf init */
+
+  up_perf_init(0);
+
   /* Set the page table for section */
 
   goldfish_setupmappings();

--- a/arch/arm/src/qemu/qemu_boot.c
+++ b/arch/arm/src/qemu/qemu_boot.c
@@ -47,6 +47,10 @@
 
 void arm_boot(void)
 {
+  /* Perf init */
+
+  up_perf_init(0);
+
   /* Set the page table for section */
 
   qemu_setupmappings();


### PR DESCRIPTION
## Summary

    armv7-a/r: use arm_timer to setup perf
    armv7-a timer:fix timer overflow
    armv7a/r: use register cval to set timer
    armv7-a/r: correct maxdelay calculating

## Impact

armv7-a/r timer 

## Testing

Qemu
