### PR TITLE
feat(esp32s3): allow SPI and SPI_QIO at the same time

### DIFF
--- a/arch/xtensa/src/esp32s3/Kconfig
+++ b/arch/xtensa/src/esp32s3/Kconfig
@@ -988,17 +988,13 @@ config ESP32S3_RTCIO_IRQ
 menu "SPI configuration"
 	depends on ESP32S3_SPI
 
-choice
-	prompt "SPI I/O Mode"
-	default ESP32S3_SPI_IO_SPI
-
 config ESP32S3_SPI_IO_SPI
 	bool "SPI (4-line)"
+	default y
 
 config ESP32S3_SPI_IO_QIO
 	bool "QIO (6-line)"
-
-endchoice # SPI I/O Mode
+	default n
 
 config ESP32S3_SPI_SWCS
 	bool "SPI software CS"

--- a/arch/xtensa/src/esp32s3/Make.defs
+++ b/arch/xtensa/src/esp32s3/Make.defs
@@ -116,7 +116,8 @@ endif
 ifeq ($(CONFIG_ESP32S3_SPI),y)
   ifeq ($(CONFIG_ESP32S3_SPI_IO_SPI),y)
     CHIP_CSRCS += esp32s3_spi.c
-  else
+  endif
+  ifeq ($(CONFIG_ESP32S3_SPI_IO_QIO),y)
     CHIP_CSRCS += esp32s3_qspi.c
   endif
 


### PR DESCRIPTION
## Summary

Some boards use SPI2 in quad mode and SPI3 in SPI mode.

There is no reason why we should not allow to configure both files.

## Impact

This removes the choice between one or ther other, and instead let us select both. Now SPI can be used in both modes.

## Testing

N/A
