### PR TITLE
docs/comments: add simple document and fix typo

### DIFF
--- a/Documentation/components/filesystem/shmfs.rst
+++ b/Documentation/components/filesystem/shmfs.rst
@@ -2,4 +2,16 @@
 Shared Memory File System
 =========================
 
-Include support for shm_open() and shm_close.
+This supports the POSIX shm_open() APIs for shared memory among unrelated
+apps.
+
+It can be enabled with ``CONFIG_FS_SHMFS=y``. To check how it works, please
+also enable the example app via ``CONFIG_EXMAPLE_SHM=y`` and run ``shm_test``
+from NSH command line.
+
+This file system doesn't support mount operations though.
+
+If comment the line using ``shm_unlink()`` in the example app, we can see
+a file under ``/var/shm/`` from NSH command line after running the example.
+We can also remove that file from command line.
+

--- a/net/Kconfig
+++ b/net/Kconfig
@@ -394,7 +394,7 @@ choice
 	depends on NET_STAR
 	default NET_STARPOINT
 	---help---
-		Specifies the role of this not in the star configuration.
+		Specifies the role of this node in the star configuration.
 
 config NET_STARPOINT
 	bool "Point node in star"


### PR DESCRIPTION
## Summary

This patch adds simple document for the shared memory file system. 
It also fix typos fix in a other places.

## Impact

None

## Testing

CI checks

