### PR TITLE
arm: fix compile error

### DIFF
--- a/arch/arm/src/common/arm_allocateheap.c
+++ b/arch/arm/src/common/arm_allocateheap.c
@@ -36,11 +36,6 @@
 #include <arch/board/board.h>
 
 #include "arm_internal.h"
-#include "chip.h"
-
-#ifdef CONFIG_ARCH_HAVE_MMU
-#include "mmu.h"
-#endif
 
 /****************************************************************************
  * Pre-processor Definitions

--- a/arch/arm/src/goldfish/chip.h
+++ b/arch/arm/src/goldfish/chip.h
@@ -38,9 +38,6 @@
 #define PGTABLE_BASE_PADDR    (CONFIG_RAM_START + CONFIG_RAM_SIZE - ALL_PGTABLE_SIZE)
 #define PGTABLE_BASE_VADDR    (CONFIG_RAM_START + CONFIG_RAM_SIZE - ALL_PGTABLE_SIZE)
 
-#undef CONFIG_RAM_END
-#define CONFIG_RAM_END        PGTABLE_BASE_PADDR
-
 #define NUTTX_TEXT_VADDR      (CONFIG_FLASH_VSTART & 0xfff00000)
 #define NUTTX_TEXT_PADDR      (CONFIG_FLASH_VSTART & 0xfff00000)
 #define NUTTX_TEXT_PEND       ((CONFIG_FLASH_END + 0x000fffff) & 0xfff00000)
@@ -48,7 +45,7 @@
 
 #define NUTTX_RAM_VADDR       (CONFIG_RAM_VSTART & 0xfff00000)
 #define NUTTX_RAM_PADDR       (CONFIG_RAM_START & 0xfff00000)
-#define NUTTX_RAM_PEND        ((CONFIG_RAM_START + CONFIG_RAM_SIZE + 0x000fffff) & 0xfff00000)
+#define NUTTX_RAM_PEND        ((CONFIG_RAM_END + 0x000fffff) & 0xfff00000)
 #define NUTTX_RAM_SIZE        (NUTTX_RAM_PEND - NUTTX_RAM_PADDR)
 
 /****************************************************************************

--- a/arch/arm/src/qemu/chip.h
+++ b/arch/arm/src/qemu/chip.h
@@ -38,9 +38,6 @@
 #define PGTABLE_BASE_PADDR    (CONFIG_RAM_START + CONFIG_RAM_SIZE - ALL_PGTABLE_SIZE)
 #define PGTABLE_BASE_VADDR    (CONFIG_RAM_START + CONFIG_RAM_SIZE - ALL_PGTABLE_SIZE)
 
-#undef CONFIG_RAM_END
-#define CONFIG_RAM_END        PGTABLE_BASE_PADDR
-
 #define NUTTX_TEXT_VADDR      (CONFIG_FLASH_VSTART & 0xfff00000)
 #define NUTTX_TEXT_PADDR      (CONFIG_FLASH_VSTART & 0xfff00000)
 #define NUTTX_TEXT_PEND       ((CONFIG_FLASH_END + 0x000fffff) & 0xfff00000)
@@ -48,7 +45,7 @@
 
 #define NUTTX_RAM_VADDR       (CONFIG_RAM_VSTART & 0xfff00000)
 #define NUTTX_RAM_PADDR       (CONFIG_RAM_START & 0xfff00000)
-#define NUTTX_RAM_PEND        ((CONFIG_RAM_START + CONFIG_RAM_SIZE + 0x000fffff) & 0xfff00000)
+#define NUTTX_RAM_PEND        ((CONFIG_RAM_END + 0x000fffff) & 0xfff00000)
 #define NUTTX_RAM_SIZE        (NUTTX_RAM_PEND - NUTTX_RAM_PADDR)
 
 /****************************************************************************

--- a/arch/arm/src/stm32h7/stm32_sdmmc.c
+++ b/arch/arm/src/stm32h7/stm32_sdmmc.c
@@ -1900,8 +1900,8 @@ static void stm32_reset(struct sdio_dev_s *dev)
   struct stm32_dev_s *priv = (struct stm32_dev_s *)dev;
   irqstate_t flags;
   uint32_t regval;
-  uint32_t regaddress;
-  uint32_t restval;
+  uint32_t regaddress = 0;
+  uint32_t restval = 0;
 
   /* Disable clocking */
 


### PR DESCRIPTION

## Summary

arm: fix compile error

./common/arm_allocateheap.c:42:10: fatal error: mmu.h: No such file or directory
   42 | #include "mmu.h"
      |          ^~~~~~~
compilation terminated.


## Impact

compile error

## Testing

