### PR TITLE
sched/task: save argument counter to avoid limit check

### DIFF
--- a/drivers/sensors/ds18b20_uorb.c
+++ b/drivers/sensors/ds18b20_uorb.c
@@ -802,7 +802,7 @@ static int ds18b20_set_interval(FAR struct sensor_lowerhalf_s *lower,
  *              read.
  *
  * Parameter:
- *   argc - Number opf arguments
+ *   argc - Number of arguments
  *   argv - Pointer to argument list
  ****************************************************************************/
 

--- a/drivers/sensors/hyt271_uorb.c
+++ b/drivers/sensors/hyt271_uorb.c
@@ -773,7 +773,7 @@ static int hyt271_set_interval(FAR struct sensor_lowerhalf_s *lower,
  *              read.
  *
  * Parameter:
- *   argc - Number opf arguments
+ *   argc - Number of arguments
  *   argv - Pointer to argument list
  ****************************************************************************/
 

--- a/drivers/sensors/mpu9250_uorb.c
+++ b/drivers/sensors/mpu9250_uorb.c
@@ -1842,7 +1842,7 @@ static void mpu9250_mag_data(FAR struct mpu9250_sensor_s *priv,
  *              read.
  *
  * Parameter:
- *   argc - Number opf arguments
+ *   argc - Number of arguments
  *   argv - Pointer to argument list
  ****************************************************************************/
 

--- a/drivers/sensors/ms56xx_uorb.c
+++ b/drivers/sensors/ms56xx_uorb.c
@@ -366,7 +366,7 @@ static inline void baro_measure_read(FAR struct ms56xx_dev_s *priv,
  *              read.
  *
  * Parameter:
- *   argc - Number opf arguments
+ *   argc - Number of arguments
  *   argv - Pointer to argument list
  ****************************************************************************/
 

--- a/include/nuttx/tls.h
+++ b/include/nuttx/tls.h
@@ -122,7 +122,8 @@ struct pthread_atfork_s
 struct task_info_s
 {
   mutex_t         ta_lock;
-  FAR char      **argv;                         /* Name+start-up parameters     */
+  int             ta_argc;                         /* Number of arguments     */
+  FAR char      **ta_argv;                         /* Name+start-up parameters     */
 #if CONFIG_TLS_TASK_NELEM > 0
   uintptr_t       ta_telem[CONFIG_TLS_TASK_NELEM]; /* Task local storage elements */
 #endif

--- a/libs/libc/stdlib/lib_getprogname.c
+++ b/libs/libc/stdlib/lib_getprogname.c
@@ -40,5 +40,5 @@ FAR const char *getprogname(void)
   FAR struct task_info_s *info;
 
   info = task_get_info();
-  return info->argv[0];
+  return info->ta_argv[0];
 }

--- a/sched/group/group_argvstr.c
+++ b/sched/group/group_argvstr.c
@@ -90,7 +90,7 @@ size_t group_argvstr(FAR struct tcb_s *tcb, FAR char *args, size_t size)
   else
 #endif
     {
-      FAR char **argv = tcb->group->tg_info->argv + 1;
+      FAR char **argv = tcb->group->tg_info->ta_argv + 1;
 
       while (*argv != NULL && n < size)
         {

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -517,7 +517,7 @@ void nx_start(void)
       /* Allocate the IDLE group */
 
       DEBUGVERIFY(group_allocate(&g_idletcb[i], g_idletcb[i].cmn.flags));
-      g_idletcb[i].cmn.group->tg_info->argv = &g_idleargv[i][0];
+      g_idletcb[i].cmn.group->tg_info->ta_argv = &g_idleargv[i][0];
 
 #ifdef CONFIG_SMP
       /* Create a stack for all CPU IDLE threads (except CPU0 which already

--- a/sched/task/task_fork.c
+++ b/sched/task/task_fork.c
@@ -205,8 +205,8 @@ FAR struct task_tcb_s *nxtask_setup_fork(start_t retaddr)
 
   /* Setup to pass parameters to the new task */
 
-  ret = nxtask_setup_arguments(child, parent->group->tg_info->argv[0],
-                               &parent->group->tg_info->argv[1]);
+  ret = nxtask_setup_arguments(child, parent->group->tg_info->ta_argv[0],
+                               &parent->group->tg_info->ta_argv[1]);
   if (ret < OK)
     {
       goto errout_with_tcb;

--- a/sched/task/task_setup.c
+++ b/sched/task/task_setup.c
@@ -629,7 +629,9 @@ static int nxtask_setup_stackargs(FAR struct task_tcb_s *tcb,
    */
 
   stackargv[argc + 1] = NULL;
-  tcb->cmn.group->tg_info->argv = stackargv;
+
+  tcb->cmn.group->tg_info->ta_argc = argc;
+  tcb->cmn.group->tg_info->ta_argv = stackargv;
 
   return OK;
 }

--- a/sched/task/task_start.c
+++ b/sched/task/task_start.c
@@ -40,16 +40,6 @@
 #include "task/task.h"
 
 /****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-/* This is an artificial limit to detect error conditions where an argv[]
- * list is not properly terminated.
- */
-
-#define MAX_START_ARGS 256
-
-/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -75,67 +65,55 @@
 
 void nxtask_start(void)
 {
-  FAR struct task_tcb_s *tcb = (FAR struct task_tcb_s *)this_task();
+  FAR struct tcb_s *tcb = this_task();
+#ifdef CONFIG_SCHED_STARTHOOK
+  FAR struct task_tcb_s *ttcb = (FAR struct task_tcb_s *)tcb;
+#endif
   int exitcode = EXIT_FAILURE;
   int argc;
 
-  DEBUGASSERT((tcb->cmn.flags & TCB_FLAG_TTYPE_MASK) != \
+  DEBUGASSERT((tcb->flags & TCB_FLAG_TTYPE_MASK) != \
               TCB_FLAG_TTYPE_PTHREAD);
 
 #ifdef CONFIG_SIG_DEFAULT
-  if ((tcb->cmn.flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL)
+  if ((tcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL)
     {
       /* Set up default signal actions for NON-kernel thread */
 
-      nxsig_default_initialize(&tcb->cmn);
+      nxsig_default_initialize(tcb);
     }
 #endif
 
   /* Execute the start hook if one has been registered */
 
 #ifdef CONFIG_SCHED_STARTHOOK
-  if (tcb->starthook != NULL)
+  if (ttcb->starthook != NULL)
     {
-      tcb->starthook(tcb->starthookarg);
+      ttcb->starthook(ttcb->starthookarg);
     }
 #endif
 
-  /* Count how many non-null arguments we are passing. The first non-null
-   * argument terminates the list .
-   */
+  /* Add program name */
 
-  argc = 1;
-  while (tcb->cmn.group->tg_info->argv[argc])
-    {
-      /* Increment the number of args.  Here is a sanity check to
-       * prevent running away with an unterminated argv[] list.
-       * MAX_START_ARGS should be sufficiently large that this never
-       * happens in normal usage.
-       */
-
-      if (++argc > MAX_START_ARGS)
-        {
-          _exit(EXIT_FAILURE);
-        }
-    }
+  argc = tcb->group->tg_info->ta_argc + 1;
 
   /* Call the 'main' entry point passing argc and argv.  In the kernel build
    * this has to be handled differently if we are starting a user-space task;
    * we have to switch to user-mode before calling the task.
    */
 
-  if ((tcb->cmn.flags & TCB_FLAG_TTYPE_MASK) == TCB_FLAG_TTYPE_KERNEL)
+  if ((tcb->flags & TCB_FLAG_TTYPE_MASK) == TCB_FLAG_TTYPE_KERNEL)
     {
-      exitcode = tcb->cmn.entry.main(argc, tcb->cmn.group->tg_info->argv);
+      exitcode = tcb->entry.main(argc, tcb->group->tg_info->ta_argv);
     }
   else
     {
 #ifdef CONFIG_BUILD_FLAT
-      nxtask_startup(tcb->cmn.entry.main, argc,
-                     tcb->cmn.group->tg_info->argv);
+      nxtask_startup(tcb->entry.main, argc,
+                     tcb->group->tg_info->ta_argv);
 #else
-      up_task_start(tcb->cmn.entry.main, argc,
-                    tcb->cmn.group->tg_info->argv);
+      up_task_start(tcb->entry.main, argc,
+                    tcb->group->tg_info->ta_argv);
 #endif
     }
 


### PR DESCRIPTION
## Summary

sched/task: save argument counter to avoid limit check

The maximum startup parameters have been checked accordingly in nxtask_setup_stackargs(),
let us save argument counter to avoid limit check.

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

ci-check