### PR TITLE
nuttx/sched: remove unused group link node

### DIFF
--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -414,9 +414,6 @@ struct binary_s;                    /* Forward reference                        
 
 struct task_group_s
 {
-#if defined(HAVE_GROUP_MEMBERS)
-  struct task_group_s *flink;       /* Supports a singly linked list            */
-#endif
   pid_t tg_pid;                     /* The ID of the task within the group      */
   pid_t tg_ppid;                    /* This is the ID of the parent thread      */
   uint8_t tg_flags;                 /* See GROUP_FLAG_* definitions             */


### PR DESCRIPTION
## Summary

nuttx/sched: remove unused group link node

This change is missing from the below commit:

```
| commit 7cb1f3b3c008e4d16861b9ee214c7c8c5d445fbe
| Author: chao an <anchao@lixiang.com>
| Date:   Tue Mar 5 10:23:30 2024 +0800
|
|     sched/group: replace group_findbypid to task_getgroup
|
|     Task group could find from process id, replace group_findbypid to
|     task_getgroup to simplify the search logic
|
|     Signed-off-by: chao an <anchao@lixiang.com>
```

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

ci-check
