### PR TITLE
comments/docs: fix typos in comments

### DIFF
--- a/arch/arm/include/irq.h
+++ b/arch/arm/include/irq.h
@@ -83,7 +83,7 @@ extern "C"
  ****************************************************************************/
 
 /* g_current_regs[] holds a references to the current interrupt level
- * register storage structure.  If is non-NULL only during interrupt
+ * register storage structure.  It is non-NULL only during interrupt
  * processing.  Access to g_current_regs[] must be through the macro
  * CURRENT_REGS for portability.
  */

--- a/arch/arm64/include/irq.h
+++ b/arch/arm64/include/irq.h
@@ -207,7 +207,7 @@ extern "C"
  ****************************************************************************/
 
 /* g_current_regs[] holds a references to the current interrupt level
- * register storage structure.  If is non-NULL only during interrupt
+ * register storage structure.  It is non-NULL only during interrupt
  * processing.  Access to g_current_regs[] must be through the macro
  * CURRENT_REGS for portability.
  */

--- a/arch/avr/include/irq.h
+++ b/arch/avr/include/irq.h
@@ -74,7 +74,7 @@ extern "C"
 
 #ifndef __ASSEMBLY__
 /* This holds a references to the current interrupt level register storage
- * structure.  If is non-NULL only during interrupt processing.
+ * structure.  It is non-NULL only during interrupt processing.
  */
 
 #ifdef CONFIG_ARCH_FAMILY_AVR32

--- a/arch/ceva/include/irq.h
+++ b/arch/ceva/include/irq.h
@@ -94,7 +94,7 @@ extern "C"
 #endif
 
 /* g_current_regs[] holds a references to the current interrupt level
- * register storage structure.  If is non-NULL only during interrupt
+ * register storage structure.  It is non-NULL only during interrupt
  * processing.  Access to g_current_regs[] must be through the macro
  * CURRENT_REGS for portability.
  */

--- a/arch/hc/include/irq.h
+++ b/arch/hc/include/irq.h
@@ -91,7 +91,7 @@ static inline uint16_t up_getsp(void)
  ****************************************************************************/
 
 /* This holds a references to the current interrupt level register storage
- * structure.  If is non-NULL only during interrupt processing.
+ * structure.  It is non-NULL only during interrupt processing.
  */
 
 EXTERN volatile uint8_t *g_current_regs;

--- a/arch/misoc/include/irq.h
+++ b/arch/misoc/include/irq.h
@@ -77,7 +77,7 @@ static inline uint32_t up_getsp(void)
  ****************************************************************************/
 
 /* This holds a references to the current interrupt level register storage
- * structure.  If is non-NULL only during interrupt processing.
+ * structure.  It is non-NULL only during interrupt processing.
  */
 
 EXTERN volatile uint32_t *g_current_regs;

--- a/arch/or1k/include/irq.h
+++ b/arch/or1k/include/irq.h
@@ -75,7 +75,7 @@ extern "C"
 #endif
 
 /* g_current_regs[] holds a references to the current interrupt level
- * register storage structure.  If is non-NULL only during interrupt
+ * register storage structure.  It is non-NULL only during interrupt
  * processing.  Access to g_current_regs[] must be through the macro
  * CURRENT_REGS for portability.
  */

--- a/arch/renesas/include/irq.h
+++ b/arch/renesas/include/irq.h
@@ -59,7 +59,7 @@ extern "C"
  ****************************************************************************/
 
 /* This holds a references to the current interrupt level
- * register storage structure.  If is non-NULL only during
+ * register storage structure.  It is non-NULL only during
  * interrupt processing.
  */
 

--- a/arch/risc-v/include/irq.h
+++ b/arch/risc-v/include/irq.h
@@ -620,7 +620,7 @@ extern "C"
 #endif
 
 /* g_current_regs[] holds a references to the current interrupt level
- * register storage structure.  If is non-NULL only during interrupt
+ * register storage structure.  It is non-NULL only during interrupt
  * processing.  Access to g_current_regs[] must be through the macro
  * CURRENT_REGS for portability.
  */

--- a/arch/sim/include/irq.h
+++ b/arch/sim/include/irq.h
@@ -68,7 +68,7 @@ extern "C"
  ****************************************************************************/
 
 /* g_current_regs[] holds a references to the current interrupt level
- * register storage structure.  If is non-NULL only during interrupt
+ * register storage structure.  It is non-NULL only during interrupt
  * processing.  Access to g_current_regs[] must be through the macro
  * CURRENT_REGS for portability.
  */

--- a/arch/sparc/include/irq.h
+++ b/arch/sparc/include/irq.h
@@ -93,7 +93,7 @@ static inline uint32_t up_getsp(void)
  ****************************************************************************/
 
 /* g_current_regs[] holds a references to the current interrupt level
- * register storage structure.  If is non-NULL only during interrupt
+ * register storage structure.  It is non-NULL only during interrupt
  * processing.  Access to g_current_regs[] must be through the macro
  * CURRENT_REGS for portability.
  */

--- a/arch/tricore/include/irq.h
+++ b/arch/tricore/include/irq.h
@@ -61,7 +61,7 @@ extern "C"
  ****************************************************************************/
 
 /* g_current_regs[] holds a references to the current interrupt level
- * register storage structure.  If is non-NULL only during interrupt
+ * register storage structure.  It is non-NULL only during interrupt
  * processing.  Access to g_current_regs[] must be through the macro
  * CURRENT_REGS for portability.
  */

--- a/arch/x86/include/irq.h
+++ b/arch/x86/include/irq.h
@@ -76,7 +76,7 @@ extern "C"
 
 #ifndef __ASSEMBLY__
 /* This holds a references to the current interrupt level register storage
- * structure.  If is non-NULL only during interrupt processing.
+ * structure.  It is non-NULL only during interrupt processing.
  */
 
 EXTERN volatile uint32_t *g_current_regs;

--- a/arch/x86_64/include/irq.h
+++ b/arch/x86_64/include/irq.h
@@ -59,7 +59,7 @@
 
 #ifndef __ASSEMBLY__
 /* This holds a references to the current interrupt level register storage
- * structure.  If is non-NULL only during interrupt processing.
+ * structure.  It is non-NULL only during interrupt processing.
  */
 
 extern volatile uint64_t *g_current_regs;

--- a/arch/xtensa/include/irq.h
+++ b/arch/xtensa/include/irq.h
@@ -367,7 +367,7 @@ extern "C"
 
 #ifndef __ASSEMBLY__
 /* g_current_regs[] holds a references to the current interrupt level
- * register storage structure.  If is non-NULL only during interrupt
+ * register storage structure.  It is non-NULL only during interrupt
  * processing.  Access to g_current_regs[] must be through the macro
  * CURRENT_REGS for portability.
  */

--- a/arch/z16/include/irq.h
+++ b/arch/z16/include/irq.h
@@ -72,7 +72,7 @@ chipreg_t up_getsp(void);
 
 #ifndef __ASSEMBLY__
 /* This holds a references to the current interrupt level
- * register storage structure.  If is non-NULL only during
+ * register storage structure.  It is non-NULL only during
  * interrupt processing.
  */
 

--- a/arch/z80/src/ez80/switch.h
+++ b/arch/z80/src/ez80/switch.h
@@ -115,7 +115,7 @@
 
 #ifndef __ASSEMBLY__
 /* This holds a references to the current interrupt level register
- * storage structure.  If is non-NULL only during interrupt processing.
+ * storage structure.  It is non-NULL only during interrupt processing.
  */
 
 extern volatile chipreg_t *g_current_regs;

--- a/arch/z80/src/z180/switch.h
+++ b/arch/z80/src/z180/switch.h
@@ -170,7 +170,7 @@
 
 #ifndef __ASSEMBLY__
 /* This holds a references to the current interrupt level register
- * storage structure.  If is non-NULL only during interrupt processing.
+ * storage structure.  It is non-NULL only during interrupt processing.
  */
 
 extern volatile chipreg_t *g_current_regs;

--- a/arch/z80/src/z80/switch.h
+++ b/arch/z80/src/z80/switch.h
@@ -114,7 +114,7 @@
 
 #ifndef __ASSEMBLY__
 /* This holds a references to the current interrupt level register
- * storage structure.  If is non-NULL only during interrupt processing.
+ * storage structure.  It is non-NULL only during interrupt processing.
  */
 
 extern volatile chipreg_t *g_current_regs;


### PR DESCRIPTION

## Summary
This fix some typos in comments.

## Impact
None

## Testing
CI checks
