### PR TITLE
fs/inode: add pre-allocated task files to avoid allocator access

### DIFF
--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -484,6 +484,15 @@ struct filelist
   spinlock_t        fl_lock;    /* Manage access to the file list */
   uint8_t           fl_rows;    /* The number of rows of fl_files array */
   FAR struct file **fl_files;   /* The pointer of two layer file descriptors array */
+
+  /* Pre-allocated files to avoid allocator access during thread creation
+   * phase, For functional safety requirements, increase
+   * CONFIG_NFILE_DESCRIPTORS_PER_BLOCK could also avoid allocator access
+   * caused by the file descriptor exceeding the limit.
+   */
+
+  FAR struct file  *fl_prefile;
+  FAR struct file   fl_prefiles[CONFIG_NFILE_DESCRIPTORS_PER_BLOCK];
 };
 
 /* The following structure defines the list of files used for standard C I/O.


### PR DESCRIPTION
## Summary

fs/inode: add pre-allocated task files to avoid allocator access

Pre-allocated files to avoid allocator access during thread creation
phase, For functional safety requirements, increase
CONFIG_NFILE_DESCRIPTORS_PER_BLOCK could also avoid allocator access
caused by the file descriptor exceeding the limit.

For Task Termination, the time consumption will be reduced ~3us (Tricore TC397 300MHZ):
10.65(us) -> 7.35(us)

**NOTE:
This commit will not waste of extra heap, just pre-allocates the list of files for task_group.**

Signed-off-by: chao an <anchao@lixiang.com>



## Impact

N/A

## Testing

ci-check