### PR TITLE
xtensa/esp32s3: Configure DMA maximum buffer size based on access to different RAM

### DIFF
--- a/arch/xtensa/src/esp32s3/esp32s3_dma.h
+++ b/arch/xtensa/src/esp32s3/esp32s3_dma.h
@@ -54,13 +54,17 @@ extern "C"
 #define SET_GDMA_CH_BITS(_r, _ch, _b)   modifyreg32((_r) + (_ch) * GDMA_REG_OFFSET, 0, (_b))
 #define CLR_GDMA_CH_BITS(_r, _ch, _b)   modifyreg32((_r) + (_ch) * GDMA_REG_OFFSET, (_b), 0)
 
-/* DMA max data length */
+/* Maximum size of the buffer that can be attached to DMA descriptor  */
 
-#define ESP32S3_DMA_DATALEN_MAX       (0x1000 - 4)
+#define ESP32S3_DMA_BUFFER_MAX_SIZE       (0x1000 - 1)
+
+/* DMA max data length, and aligned to 4Bytes */
+
+#define ESP32S3_DMA_BUFLEN_MAX_4B_ALIGNED (0x1000 - 4)
 
 /* DMA max buffer length */
 
-#define ESP32S3_DMA_BUFLEN_MAX        ESP32S3_DMA_DATALEN_MAX
+#define ESP32S3_DMA_BUFLEN_MAX        ESP32S3_DMA_BUFFER_MAX_SIZE
 
 /* DMA channel number */
 
@@ -174,6 +178,7 @@ void esp32s3_dma_release(int chan);
  *   pbuf    - RX/TX buffer pointer
  *   len     - RX/TX buffer length
  *   tx      - true: TX mode (transmitter); false: RX mode (receiver)
+ *   chan    - DMA channel of the receiver/transmitter
  *
  * Returned Value:
  *   Bound pbuf data bytes
@@ -181,7 +186,7 @@ void esp32s3_dma_release(int chan);
  ****************************************************************************/
 
 uint32_t esp32s3_dma_setup(struct esp32s3_dmadesc_s *dmadesc, uint32_t num,
-                           uint8_t *pbuf, uint32_t len, bool tx);
+                           uint8_t *pbuf, uint32_t len, bool tx, int chan);
 
 /****************************************************************************
  * Name: esp32s3_dma_load

--- a/arch/xtensa/src/esp32s3/esp32s3_lcd.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_lcd.c
@@ -135,7 +135,7 @@
                                    ESP32S3_LCD_DATA_WIDTH)
 
 #define ESP32S3_LCD_DMADESC_NUM   (ESP32S3_LCD_FB_SIZE / \
-                                   ESP32S3_DMA_DATALEN_MAX + 1)
+                                   ESP32S3_DMA_BUFLEN_MAX + 1)
 
 #define ESP32S3_LCD_LAYERS        CONFIG_ESP32S3_LCD_BUFFER_LAYERS
 
@@ -666,7 +666,7 @@ static void esp32s3_lcd_dmasetup(void)
                         ESP32S3_LCD_DMADESC_NUM,
                         layer->framebuffer,
                         ESP32S3_LCD_FB_SIZE,
-                        true);
+                        true, priv->dma_channel);
     }
 }
 

--- a/arch/xtensa/src/esp32s3/esp32s3_qspi.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_qspi.c
@@ -992,7 +992,7 @@ static int esp32s3_qspi_memory(struct qspi_dev_s *dev,
                         QSPI_DMA_DESC_NUM,
                         (uint8_t *)meminfo->buffer,
                         meminfo->buflen,
-                        true);
+                        true, priv->dma_channel);
       esp32s3_dma_load(priv->dma_desc, priv->dma_channel, true);
       esp32s3_dma_enable(priv->dma_channel, true);
     }
@@ -1008,7 +1008,7 @@ static int esp32s3_qspi_memory(struct qspi_dev_s *dev,
                         QSPI_DMA_DESC_NUM,
                         (uint8_t *)meminfo->buffer,
                         meminfo->buflen,
-                        false);
+                        false, priv->dma_channel);
       esp32s3_dma_load(priv->dma_desc, priv->dma_channel, false);
       esp32s3_dma_enable(priv->dma_channel, false);
     }

--- a/arch/xtensa/src/esp32s3/esp32s3_spi.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_spi.c
@@ -909,7 +909,7 @@ static void esp32s3_spi_dma_exchange(struct esp32s3_spi_priv_s *priv,
                               SPI_DMA_TX_ENA_M);
 
       n = esp32s3_dma_setup(priv->dma_txdesc, SPI_DMA_DESC_NUM,
-                            tp, bytes, true);
+                            tp, bytes, true, priv->dma_channel);
       esp32s3_dma_load(priv->dma_txdesc, channel, true);
       esp32s3_dma_enable(channel, true);
 
@@ -935,7 +935,7 @@ static void esp32s3_spi_dma_exchange(struct esp32s3_spi_priv_s *priv,
                                   SPI_DMA_RX_ENA_M);
 
           esp32s3_dma_setup(priv->dma_rxdesc, SPI_DMA_DESC_NUM,
-                            rp, bytes, false);
+                            rp, bytes, false, priv->dma_channel);
           esp32s3_dma_load(priv->dma_rxdesc, channel, false);
           esp32s3_dma_enable(channel, false);
 

--- a/arch/xtensa/src/esp32s3/esp32s3_spi_slave.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_spi_slave.c
@@ -904,7 +904,7 @@ static void spislave_setup_rx_dma(struct spislave_priv_s *priv)
                     SPI_DMA_DESC_NUM,
                     priv->rx_buffer + priv->rx_length,
                     length,
-                    false);
+                    false, priv->dma_channel);
   esp32s3_dma_load(priv->dma_rxdesc, priv->dma_channel, false);
 
   priv->rx_dma_offset = priv->rx_length;
@@ -948,7 +948,7 @@ static void spislave_setup_tx_dma(struct spislave_priv_s *priv)
                     SPI_DMA_DESC_NUM,
                     priv->tx_buffer,
                     SPI_SLAVE_BUFSIZE,
-                    true);
+                    true, priv->dma_channel);
   esp32s3_dma_load(priv->dma_txdesc, priv->dma_channel, true);
 
   spislave_dma_tx_fifo_reset(priv);


### PR DESCRIPTION
## Summary

- Configure DMA maximum buffer size based on access to different RAM

## Impact

## Testing

