### PR TITLE
sched/pthread: fix memory leak of pthread_tcb_s

### DIFF
--- a/sched/pthread/pthread_create.c
+++ b/sched/pthread/pthread_create.c
@@ -216,6 +216,8 @@ int nx_pthread_create(pthread_trampoline_t trampoline, FAR pthread_t *thread,
       return ENOMEM;
     }
 
+  ptcb->cmn.flags |= TCB_FLAG_FREE_TCB;
+
   /* Bind the parent's group to the new TCB (we have not yet joined the
    * group).
    */


### PR DESCRIPTION
## Summary

sched/pthread: fix memory leak of pthread_tcb_s

pthread tcb should be released appropriately

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

ci-check