### PR TITLE
Replace PRIxPTR with %p and remove the cast of (uintptr_t)

### DIFF
--- a/arch/risc-v/src/common/espressif/esp_wdt.c
+++ b/arch/risc-v/src/common/espressif/esp_wdt.c
@@ -428,7 +428,7 @@ static xcpt_t wdt_capture(struct watchdog_lowerhalf_s *lower, xcpt_t handler)
 
   DEBUGASSERT(priv != NULL);
 
-  wdinfo("Entry: handler=0x%" PRIxPTR "\n", (uintptr_t)handler);
+  wdinfo("Entry: handler=%p\n", handler);
 
   oldhandler = priv->handler;
 

--- a/arch/risc-v/src/esp32c3-legacy/esp32c3_i2c.c
+++ b/arch/risc-v/src/esp32c3-legacy/esp32c3_i2c.c
@@ -1476,7 +1476,7 @@ struct i2c_master_s *esp32c3_i2cbus_initialize(int port)
       nxmutex_unlock(&priv->lock);
 
       i2cinfo("Returning previously initialized I2C bus. "
-              "Handler: %" PRIxPTR "\n", (uintptr_t)priv);
+              "Handler: %p\n", priv);
 
       return (struct i2c_master_s *)priv;
     }
@@ -1525,7 +1525,7 @@ struct i2c_master_s *esp32c3_i2cbus_initialize(int port)
   esp32c3_i2c_init(priv);
   nxmutex_unlock(&priv->lock);
 
-  i2cinfo("I2C bus initialized! Handler: %" PRIxPTR "\n", (uintptr_t)priv);
+  i2cinfo("I2C bus initialized! Handler: %p\n", priv);
 
   return (struct i2c_master_s *)priv;
 }

--- a/arch/risc-v/src/esp32c3-legacy/esp32c3_wdt_lowerhalf.c
+++ b/arch/risc-v/src/esp32c3-legacy/esp32c3_wdt_lowerhalf.c
@@ -530,7 +530,7 @@ static xcpt_t esp32c3_wdt_capture(struct watchdog_lowerhalf_s *lower,
 
   DEBUGASSERT(priv);
 
-  wdinfo("Entry: handler=0x%" PRIxPTR "\n", (uintptr_t) handler);
+  wdinfo("Entry: handler=%p\n", handler);
 
   /* Get the old handler to return it */
 

--- a/arch/risc-v/src/mpfs/mpfs_i2c.c
+++ b/arch/risc-v/src/mpfs/mpfs_i2c.c
@@ -1128,7 +1128,7 @@ struct i2c_master_s *mpfs_i2cbus_initialize(int port)
       nxmutex_unlock(&priv->lock);
 
       i2cinfo("Returning previously initialized I2C bus. "
-              "Handler: %" PRIxPTR "\n", (uintptr_t)priv);
+              "Handler: %p\n", priv);
 
       return (struct i2c_master_s *)priv;
     }
@@ -1154,7 +1154,7 @@ struct i2c_master_s *mpfs_i2cbus_initialize(int port)
 
   nxmutex_unlock(&priv->lock);
 
-  i2cinfo("I2C bus initialized! Handler: %" PRIxPTR "\n", (uintptr_t)priv);
+  i2cinfo("I2C bus initialized! Handler: %p\n", priv);
 
   return (struct i2c_master_s *)priv;
 }

--- a/arch/xtensa/src/esp32s2/esp32s2_wdt_lowerhalf.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_wdt_lowerhalf.c
@@ -588,7 +588,7 @@ static xcpt_t wdt_lh_capture(struct watchdog_lowerhalf_s *lower,
 
   DEBUGASSERT(priv);
 
-  wdinfo("Entry: handler=0x%" PRIxPTR "\n", (uintptr_t) handler);
+  wdinfo("Entry: handler=%p\n", handler);
 
   /* Get the old handler to return it */
 

--- a/arch/xtensa/src/esp32s3/esp32s3_wdt_lowerhalf.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_wdt_lowerhalf.c
@@ -590,7 +590,7 @@ static xcpt_t wdt_lh_capture(struct watchdog_lowerhalf_s *lower,
 
   DEBUGASSERT(priv);
 
-  wdinfo("Entry: handler=0x%" PRIxPTR "\n", (uintptr_t) handler);
+  wdinfo("Entry: handler=%p\n", handler);
 
   /* Get the old handler to return it */
 

--- a/boards/arm/cxd56xx/drivers/sensors/cxd5610_gnss.c
+++ b/boards/arm/cxd56xx/drivers/sensors/cxd5610_gnss.c
@@ -1546,7 +1546,7 @@ static int cxd5610_gnss_initialize(struct cxd5610_gnss_dev_s *priv)
 
   /* Create thread for receiving from CXD5610 device */
 
-  snprintf(arg1, 16, "0x%" PRIxPTR, (uintptr_t)priv);
+  snprintf(arg1, 16, "%p", priv);
   argv[0] = arg1;
   argv[1] = NULL;
 


### PR DESCRIPTION
## Summary

The cast of (uintptr_t) is not necessary, and it is better to use %p

## Impact

code refactor only

## Testing

ci