### PR TITLE
Revert "sched/group: change type of task group member to single queue"

### DIFF
--- a/binfmt/binfmt_execmodule.c
+++ b/binfmt/binfmt_execmodule.c
@@ -121,7 +121,7 @@ static void exec_swap(FAR struct tcb_s *ptcb, FAR struct tcb_s *chtcb)
   pid_t      pid;
   irqstate_t flags;
 #ifdef HAVE_GROUP_MEMBERS
-  sq_queue_t tg_members;
+  FAR pid_t  *tg_members;
 #endif
 #ifdef CONFIG_SCHED_HAVE_PARENT
 #  ifdef CONFIG_SCHED_CHILD_STATUS

--- a/include/nuttx/list.h
+++ b/include/nuttx/list.h
@@ -69,10 +69,9 @@
 #define LIST_INITIAL_VALUE(list) { &(list), &(list) }
 #define LIST_INITIAL_CLEARED_VALUE { NULL, NULL }
 
-#define list_in_list(item)     ((item)->prev != NULL)
-#define list_is_empty(list)    ((list)->next == list)
-#define list_is_clear(list)    ((list)->next == NULL)
-#define list_is_singular(list) ((list)->next == (list)->prev)
+#define list_in_list(item) ((item)->prev != NULL)
+#define list_is_empty(list) ((list)->next == list)
+#define list_is_clear(list) ((list)->next == NULL)
 
 #define list_initialize(list) \
   do \

--- a/include/nuttx/queue.h
+++ b/include/nuttx/queue.h
@@ -290,14 +290,6 @@
 #define dq_inqueue(p, q) \
       ((p)->flink || dq_tail(q) == (p))
 
-/* sq/dq_is_singular - tests whether a list has just one entry.  */
-
-#define sq_is_singular(q) \
-      (!sq_empty(q) && (q)->head->flink == NULL)
-
-#define dq_is_singular(q) \
-      (!dq_empty(q) && (q)->head->flink == NULL)
-
 /****************************************************************************
  * Public Type Definitions
  ****************************************************************************/

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -429,8 +429,10 @@ struct task_group_s
 
   /* Group membership *******************************************************/
 
+  uint8_t    tg_nmembers;           /* Number of members in the group           */
 #ifdef HAVE_GROUP_MEMBERS
-  sq_queue_t tg_members;            /* List of members for task             */
+  uint8_t    tg_mxmembers;          /* Number of members in allocation          */
+  FAR pid_t *tg_members;            /* Members of the group                     */
 #endif
 
 #ifdef CONFIG_BINFMT_LOADABLE
@@ -535,12 +537,6 @@ struct tcb_s
   /* Task Group *************************************************************/
 
   FAR struct task_group_s *group;        /* Pointer to shared task group data */
-
-  /* Group membership *******************************************************/
-
-#ifdef HAVE_GROUP_MEMBERS
-  sq_entry_t member;                     /* List entry of task member       */
-#endif
 
   /* Address Environment ****************************************************/
 

--- a/sched/group/group_create.c
+++ b/sched/group/group_create.c
@@ -40,6 +40,14 @@
 #include "tls/tls.h"
 
 /****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Is this worth making a configuration option? */
+
+#define GROUP_INITIAL_MEMBERS 4
+
+/****************************************************************************
  * Public Data
  ****************************************************************************/
 
@@ -139,9 +147,18 @@ int group_allocate(FAR struct task_tcb_s *tcb, uint8_t ttype)
 #endif /* defined(CONFIG_MM_KERNEL_HEAP) */
 
 #ifdef HAVE_GROUP_MEMBERS
-  /* Initialize member list of the group */
+  /* Allocate space to hold GROUP_INITIAL_MEMBERS members of the group */
 
-  sq_init(&group->tg_members);
+  group->tg_members = kmm_malloc(GROUP_INITIAL_MEMBERS * sizeof(pid_t));
+  if (!group->tg_members)
+    {
+      ret = -ENOMEM;
+      goto errout_with_group;
+    }
+
+  /* Number of members in allocation */
+
+  group->tg_mxmembers = GROUP_INITIAL_MEMBERS;
 #endif
 
   /* Attach the group to the TCB */
@@ -161,7 +178,7 @@ int group_allocate(FAR struct task_tcb_s *tcb, uint8_t ttype)
   ret = task_init_info(group);
   if (ret < 0)
     {
-      goto errout_with_group;
+      goto errout_with_member;
     }
 
 #ifndef CONFIG_DISABLE_PTHREAD
@@ -178,7 +195,11 @@ int group_allocate(FAR struct task_tcb_s *tcb, uint8_t ttype)
 
   return OK;
 
+errout_with_member:
+#ifdef HAVE_GROUP_MEMBERS
+  kmm_free(group->tg_members);
 errout_with_group:
+#endif
   kmm_free(group);
   return ret;
 }
@@ -219,7 +240,7 @@ void group_initialize(FAR struct task_tcb_s *tcb)
 #ifdef HAVE_GROUP_MEMBERS
   /* Assign the PID of this new task as a member of the group. */
 
-  sq_addlast(&tcb->cmn.member, &group->tg_members);
+  group->tg_members[0] = tcb->cmn.pid;
 #endif
 
   /* Save the ID of the main task within the group of threads.  This needed
@@ -229,4 +250,8 @@ void group_initialize(FAR struct task_tcb_s *tcb)
    */
 
   group->tg_pid = tcb->cmn.pid;
+
+  /* Mark that there is one member in the group, the main task */
+
+  group->tg_nmembers = 1;
 }

--- a/sched/group/group_foreachchild.c
+++ b/sched/group/group_foreachchild.c
@@ -25,9 +25,7 @@
 #include <nuttx/config.h>
 
 #include <assert.h>
-#include <nuttx/nuttx.h>
 #include <nuttx/sched.h>
-#include <nuttx/queue.h>
 
 #include "group/group.h"
 
@@ -60,27 +58,23 @@
 int group_foreachchild(FAR struct task_group_s *group,
                        foreachchild_t handler, FAR void *arg)
 {
-  FAR sq_entry_t *curr;
-  FAR sq_entry_t *next;
   int ret;
+  int i;
 
   DEBUGASSERT(group);
 
   /* Visit the main thread last (if present) */
 
-  sq_for_every_safe(&group->tg_members, curr, next)
+  for (i = group->tg_nmembers - 1; i >= 0; i--)
     {
-      FAR struct tcb_s *mtcb =
-        container_of(curr, struct tcb_s, member);
-
-      ret = handler(mtcb->pid, arg);
-      if (ret != OK)
+      ret = handler(group->tg_members[i], arg);
+      if (ret != 0)
         {
-          break;
+          return ret;
         }
     }
 
-  return ret;
+  return 0;
 }
 
 #endif /* HAVE_GROUP_MEMBERS */

--- a/sched/group/group_join.c
+++ b/sched/group/group_join.c
@@ -39,6 +39,102 @@
 #ifndef CONFIG_DISABLE_PTHREAD
 
 /****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Is this worth making a configuration option? */
+
+#define GROUP_REALLOC_MEMBERS 4
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: group_addmember
+ *
+ * Description:
+ *   Add a new member to a group.
+ *
+ * Input Parameters:
+ *   group - The task group to add the new member
+ *   pid - The new member
+ *
+ * Returned Value:
+ *   0 (OK) on success; a negated errno value on failure.
+ *
+ * Assumptions:
+ *   Called during thread creation and during reparenting in a safe context.
+ *   No special precautions are required here.
+ *
+ ****************************************************************************/
+
+#ifdef HAVE_GROUP_MEMBERS
+static inline int group_addmember(FAR struct task_group_s *group, pid_t pid)
+{
+  FAR pid_t *oldmembers = NULL;
+  irqstate_t flags;
+
+  DEBUGASSERT(group && group->tg_nmembers < UINT8_MAX);
+
+  /* Will we need to extend the size of the array of groups? */
+
+  if (group->tg_nmembers >= group->tg_mxmembers)
+    {
+      FAR pid_t *newmembers;
+      unsigned int newmax;
+
+      /* Yes... reallocate the array of members */
+
+      newmax = group->tg_mxmembers + GROUP_REALLOC_MEMBERS;
+      if (newmax > UINT8_MAX)
+        {
+          newmax = UINT8_MAX;
+        }
+
+      newmembers = kmm_malloc(sizeof(pid_t) * newmax);
+
+      if (!newmembers)
+        {
+          serr("ERROR: Failed to reallocate tg_members\n");
+          return -ENOMEM;
+        }
+
+      /* Save the new number of members in the reallocated members array.
+       * We need to make the following atomic because the member list
+       * may be traversed from an interrupt handler (read-only).
+       */
+
+      flags = spin_lock_irqsave(NULL);
+      memcpy(newmembers, group->tg_members,
+             sizeof(pid_t) * group->tg_mxmembers);
+      oldmembers = group->tg_members;
+      group->tg_members   = newmembers;
+      group->tg_mxmembers = newmax;
+    }
+  else
+    {
+      flags = spin_lock_irqsave(NULL);
+    }
+
+  /* Assign this new pid to the group; group->tg_nmembers will be incremented
+   * by the caller.
+   */
+
+  group->tg_members[group->tg_nmembers] = pid;
+  group->tg_nmembers++;
+  spin_unlock_irqrestore(NULL, flags);
+
+  if (oldmembers != NULL)
+    {
+      kmm_free(oldmembers);
+    }
+
+  return OK;
+}
+#endif /* HAVE_GROUP_MEMBERS */
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -46,7 +142,12 @@
  * Name: group_bind
  *
  * Description:
- *   A thread joins the group when it is created.
+ *   A thread joins the group when it is created. This is a two step process,
+ *   first, the group must bound to the new threads TCB.  group_bind() does
+ *   this (at the return from group_join, things are a little unstable:  The
+ *   group has been bound, but tg_nmembers has not yet been incremented).
+ *   Then, after the new thread is initialized and has a PID assigned to it,
+ *   group_join() is called, incrementing the tg_nmembers count on the group.
  *
  * Input Parameters:
  *   tcb - The TCB of the new "child" task that need to join the group.
@@ -78,7 +179,12 @@ int group_bind(FAR struct pthread_tcb_s *tcb)
  * Name: group_join
  *
  * Description:
- *   A thread joins the group when it is created.
+ *   A thread joins the group when it is created. This is a two step process,
+ *   first, the group must bound to the new threads TCB.  group_bind() does
+ *   this (at the return from group_join, things are a little unstable:  The
+ *   group has been bound, but tg_nmembers has not yet been incremented).
+ *   Then, after the new thread is initialized and has a PID assigned to it,
+ *   group_join() is called, incrementing the tg_nmembers count on the group.
  *
  * Input Parameters:
  *   tcb - The TCB of the new "child" task that need to join the group.
@@ -97,19 +203,32 @@ int group_bind(FAR struct pthread_tcb_s *tcb)
 int group_join(FAR struct pthread_tcb_s *tcb)
 {
   FAR struct task_group_s *group;
+#ifdef HAVE_GROUP_MEMBERS
+  int ret;
+#else
   irqstate_t flags;
+#endif
 
-  DEBUGASSERT(tcb && tcb->cmn.group);
+  DEBUGASSERT(tcb && tcb->cmn.group &&
+              tcb->cmn.group->tg_nmembers < UINT8_MAX);
 
   /* Get the group from the TCB */
 
   group = tcb->cmn.group;
 
+#ifdef HAVE_GROUP_MEMBERS
   /* Add the member to the group */
 
+  ret = group_addmember(group, tcb->cmn.pid);
+  if (ret < 0)
+    {
+      return ret;
+    }
+#else
   flags = spin_lock_irqsave(NULL);
-  sq_addfirst(&tcb->cmn.member, &group->tg_members);
+  group->tg_nmembers++;
   spin_unlock_irqrestore(NULL, flags);
+#endif
 
   return OK;
 }

--- a/sched/group/group_killchildren.c
+++ b/sched/group/group_killchildren.c
@@ -191,7 +191,7 @@ int group_kill_children(FAR struct tcb_s *tcb)
   ret = CONFIG_GROUP_KILL_CHILDREN_TIMEOUT_MS;
   while (1)
     {
-      if (sq_empty(&tcb->group->tg_members))
+      if (tcb->group->tg_nmembers <= 1)
         {
           break;
         }

--- a/sched/group/group_leave.c
+++ b/sched/group/group_leave.c
@@ -105,6 +105,16 @@ static inline void group_release(FAR struct task_group_s *group)
 
   mm_map_destroy(&group->tg_mm_map);
 
+#ifdef HAVE_GROUP_MEMBERS
+  /* Release the members array */
+
+  if (group->tg_members)
+    {
+      kmm_free(group->tg_members);
+      group->tg_members = NULL;
+    }
+#endif
+
 #ifdef CONFIG_BINFMT_LOADABLE
   /* If the exiting task was loaded into RAM from a file, then we need to
    * lease all of the memory resource when the last thread exits the task
@@ -126,6 +136,58 @@ static inline void group_release(FAR struct task_group_s *group)
 
   group_drop(group);
 }
+
+/****************************************************************************
+ * Name: group_removemember
+ *
+ * Description:
+ *   Remove a member from a group.
+ *
+ * Input Parameters:
+ *   group - The group from which to remove the member.
+ *   pid - The member to be removed.
+ *
+ * Returned Value:
+ *   On success, returns the number of members remaining in the group (>=0).
+ *   Can fail only if the member is not found in the group.  On failure,
+ *   returns -ENOENT
+ *
+ * Assumptions:
+ *   Called during task deletion and also from the reparenting logic, both
+ *   in a safe context.  No special precautions are required here.
+ *
+ ****************************************************************************/
+
+#ifdef HAVE_GROUP_MEMBERS
+static inline void group_removemember(FAR struct task_group_s *group,
+                                      pid_t pid)
+{
+  irqstate_t flags;
+  int i;
+
+  DEBUGASSERT(group);
+
+  /* Find the member in the array of members and remove it */
+
+  for (i = 0; i < group->tg_nmembers; i++)
+    {
+      /* Does this member have the matching pid */
+
+      if (group->tg_members[i] == pid)
+        {
+          /* Remove the member from the array of members.  This must be an
+           * atomic operation because the member array may be accessed from
+           * interrupt handlers (read-only).
+           */
+
+          flags = enter_critical_section();
+          group->tg_members[i] = group->tg_members[group->tg_nmembers - 1];
+          group->tg_nmembers--;
+          leave_critical_section(flags);
+        }
+    }
+}
+#endif /* HAVE_GROUP_MEMBERS */
 
 /****************************************************************************
  * Public Functions
@@ -152,12 +214,10 @@ static inline void group_release(FAR struct task_group_s *group)
  *
  ****************************************************************************/
 
+#ifdef HAVE_GROUP_MEMBERS
 void group_leave(FAR struct tcb_s *tcb)
 {
   FAR struct task_group_s *group;
-#ifdef HAVE_GROUP_MEMBERS
-  irqstate_t flags;
-#endif
 
   DEBUGASSERT(tcb);
 
@@ -166,17 +226,17 @@ void group_leave(FAR struct tcb_s *tcb)
   group = tcb->group;
   if (group)
     {
-      /* Remove the member from group. */
+      /* Remove the member from group.  This function may be called
+       * during certain error handling before the PID has been
+       * added to the group.  In this case tcb->pid will be uninitialized
+       * group_removemember() will fail.
+       */
 
-#ifdef HAVE_GROUP_MEMBERS
-      flags = spin_lock_irqsave(NULL);
-      sq_rem(&tcb->member, &group->tg_members);
-      spin_unlock_irqrestore(NULL, flags);
+      group_removemember(group, tcb->pid);
 
       /* Have all of the members left the group? */
 
-      if (sq_empty(&group->tg_members))
-#endif
+      if (group->tg_nmembers == 0)
         {
           /* Yes.. Release all of the resource held by the task group */
 
@@ -190,6 +250,47 @@ void group_leave(FAR struct tcb_s *tcb)
       tcb->group = NULL;
     }
 }
+
+#else /* HAVE_GROUP_MEMBERS */
+
+void group_leave(FAR struct tcb_s *tcb)
+{
+  FAR struct task_group_s *group;
+
+  DEBUGASSERT(tcb);
+
+  /* Make sure that we have a group */
+
+  group = tcb->group;
+  if (group)
+    {
+      /* Yes, we have a group.. Is this the last member of the group? */
+
+      if (group->tg_nmembers > 1)
+        {
+          /* No.. just decrement the number of members in the group */
+
+          group->tg_nmembers--;
+        }
+
+      /* Yes.. that was the last member remaining in the group */
+
+      else
+        {
+          /* Release all of the resource held by the task group */
+
+          group_release(group);
+        }
+
+      /* In any event, we can detach the group from the TCB so we won't do
+       * this again.
+       */
+
+      tcb->group = NULL;
+    }
+}
+
+#endif /* HAVE_GROUP_MEMBERS */
 
 /****************************************************************************
  * Name: group_drop

--- a/sched/task/task_exithook.c
+++ b/sched/task/task_exithook.c
@@ -174,7 +174,7 @@ static inline void nxtask_sigchild(pid_t ppid, FAR struct tcb_s *ctcb,
    * should generate SIGCHLD.
    */
 
-  if (sq_is_singular(&chgrp->tg_members))
+  if (chgrp->tg_nmembers == 1)
     {
       /* Mark that all of the threads in the task group have exited */
 
@@ -360,9 +360,7 @@ static inline void nxtask_exitwakeup(FAR struct tcb_s *tcb, int status)
 
       /* Is this the last thread in the group? */
 
-#ifndef CONFIG_DISABLE_PTHREAD
-      if (sq_is_singular(&group->tg_members))
-#endif
+      if (group->tg_nmembers == 1)
         {
           /* Yes.. Wakeup any tasks waiting for this task to exit */
 


### PR DESCRIPTION
Reverts apache/nuttx#11848, since spresense:elf, sabre-6quad:elf, sim:elf do not work.

See https://github.com/apache/nuttx/pull/11848
