### PR TITLE
binfmt/task/member: remove invaild membership reverse

### DIFF
--- a/binfmt/binfmt_execmodule.c
+++ b/binfmt/binfmt_execmodule.c
@@ -120,9 +120,6 @@ static void exec_swap(FAR struct tcb_s *ptcb, FAR struct tcb_s *chtcb)
   int        chndx;
   pid_t      pid;
   irqstate_t flags;
-#ifdef HAVE_GROUP_MEMBERS
-  sq_queue_t tg_members;
-#endif
 #ifdef CONFIG_SCHED_HAVE_PARENT
 #  ifdef CONFIG_SCHED_CHILD_STATUS
   FAR struct child_status_s *tg_children;
@@ -162,12 +159,6 @@ static void exec_swap(FAR struct tcb_s *ptcb, FAR struct tcb_s *chtcb)
   pid = chtcb->group->tg_ppid;
   chtcb->group->tg_ppid = ptcb->group->tg_ppid;
   ptcb->group->tg_ppid = pid;
-
-#ifdef HAVE_GROUP_MEMBERS
-  tg_members = chtcb->group->tg_members;
-  chtcb->group->tg_members = ptcb->group->tg_members;
-  ptcb->group->tg_members = tg_members;
-#endif
 
 #ifdef CONFIG_SCHED_HAVE_PARENT
 #  ifdef CONFIG_SCHED_CHILD_STATUS

--- a/sched/group/group_killchildren.c
+++ b/sched/group/group_killchildren.c
@@ -191,7 +191,8 @@ int group_kill_children(FAR struct tcb_s *tcb)
   ret = CONFIG_GROUP_KILL_CHILDREN_TIMEOUT_MS;
   while (1)
     {
-      if (sq_empty(&tcb->group->tg_members))
+      if (sq_empty(&tcb->group->tg_members) ||
+          sq_is_singular(&tcb->group->tg_members))
         {
           break;
         }


### PR DESCRIPTION
## Summary

1. binfmt/task/member: remove invaild membership reverse

As long as the process id reversed between parent and child,
the process member ship will automatically reversed.

Fix Regression by PR #11848:

```
| commit ec08031e4bf01f0abc9e590484382c166d90915e
| Author: chao an <anchao@lixiang.com>
| Date:   Wed Mar 6 10:13:47 2024 +0800
|
|     sched/group: change type of task group member to single queue
|
|     Change the type of task group member to single list chain to
|     avoid accessing the memory allocator to improve the performance
|
|     Signed-off-by: chao an <anchao@lixiang.com>
```

2. sched/group: skip child wait if here is only self in member list

Skip the child wait if here is only self in member list,
since the members of the task group should be 1 if task exit.

Signed-off-by: chao an <anchao@lixiang.com>




## Impact

Fix regression:
https://github.com/apache/nuttx/pull/11860
https://github.com/apache/nuttx/pull/11848

## Testing

sim/elf