### PR TITLE
riscv/nuttsbi: revise PMP manipulation in NuttX SBI

### DIFF
--- a/arch/risc-v/src/common/riscv_internal.h
+++ b/arch/risc-v/src/common/riscv_internal.h
@@ -160,6 +160,9 @@
      __asm__ __volatile__("csrc " __STR(reg) ", %0" :: "rK"(bits)); \
   })
 
+#define riscv_append_pmp_region(a, b, s) \
+  riscv_config_pmp_region(riscv_next_free_pmp_region(), a, b, s)
+
 #endif
 
 /****************************************************************************

--- a/arch/risc-v/src/nuttsbi/sbi_start.c
+++ b/arch/risc-v/src/nuttsbi/sbi_start.c
@@ -119,8 +119,7 @@ void sbi_start(void)
 
   /* Open everything for PMP */
 
-  WRITE_CSR(pmpaddr0, -1);
-  WRITE_CSR(pmpcfg0, (PMPCFG_A_NAPOT | PMPCFG_R | PMPCFG_W | PMPCFG_X));
+  riscv_append_pmp_region(PMPCFG_A_NAPOT | PMPCFG_RWX_MASK, 0, -1);
 
   /* Then jump to the S-mode start function */
 


### PR DESCRIPTION

## Summary

Current NuttX SBI assumes empty PMP settings but that is not always true, some bootloaders may have locked a few PMP before handling over to NuttX. This patch revises it by not using hardcoded PMP region number.

## Impact

NuttSBI use cases

## Testing

Checked with CanMV230


