### PR TITLE
arch/x86_64: add addrenv support

### DIFF
--- a/arch/x86_64/src/common/x86_64_initialize.c
+++ b/arch/x86_64/src/common/x86_64_initialize.c
@@ -26,7 +26,26 @@
 #include <nuttx/board.h>
 #include <arch/board/board.h>
 
+#ifdef CONFIG_DEV_SIMPLE_ADDRENV
+#  include <nuttx/drivers/addrenv.h>
+#endif
+
 #include "x86_64_internal.h"
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#ifdef CONFIG_DEV_SIMPLE_ADDRENV
+/* Map 1:1 with 0x100000000 offset */
+
+struct simple_addrenv_s g_addrenv =
+{
+  .va   = X86_64_LOAD_OFFSET,
+  .pa   = 0,
+  .size = 0xffffffffffffffff
+};
+#endif
 
 /****************************************************************************
  * Private Functions
@@ -60,6 +79,21 @@ static void up_calibratedelay(void)
 #endif
 
 /****************************************************************************
+ * Name: up_addrenv_init
+ *
+ * Description:
+ *   Initialize addrenv.
+ *
+ ****************************************************************************/
+
+static void x86_64_addrenv_init(void)
+{
+#ifdef CONFIG_DEV_SIMPLE_ADDRENV
+  simple_addrenv_initialize(&g_addrenv);
+#endif
+}
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -85,6 +119,10 @@ void up_initialize(void)
   /* Add any extra memory fragments to the memory manager */
 
   x86_64_addregion();
+
+  /* Initialzie addrenv */
+
+  x86_64_addrenv_init();
 
 #ifdef CONFIG_PM
   /* Initialize the power management subsystem.  This MCU-specific function

--- a/arch/x86_64/src/common/x86_64_initialize.c
+++ b/arch/x86_64/src/common/x86_64_initialize.c
@@ -52,33 +52,6 @@ struct simple_addrenv_s g_addrenv =
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_calibratedelay
- *
- * Description:
- *   Delay loops are provided for short timing loops.  This function, if
- *   enabled, will just wait for 100 seconds.  Using a stopwatch, you can
- *   can then determine if the timing loops are properly calibrated.
- *
- ****************************************************************************/
-
-#if defined(CONFIG_ARCH_CALIBRATION) && defined(CONFIG_DEBUG_FEATURES)
-static void up_calibratedelay(void)
-{
-  int i;
-
-  _warn("Beginning 100s delay\n");
-  for (i = 0; i < 100; i++)
-    {
-      up_mdelay(1000);
-    }
-
-  _warn("End 100s delay\n");
-}
-#else
-#  define up_calibratedelay()
-#endif
-
-/****************************************************************************
  * Name: up_addrenv_init
  *
  * Description:


### PR DESCRIPTION
## Summary

- arch/x86_64: add addrenv support

- x86_64/x86_64_initialzie.c: remove up_calibratedelay
    
    This function is not used anywhere.
    For udelay calibration we have the calib_udelay app

## Impact

## Testing
qemu and intel hw
