### PR TITLE
arch/x86_64: add SSE instruction support

### DIFF
--- a/arch/x86_64/Kconfig
+++ b/arch/x86_64/Kconfig
@@ -22,6 +22,14 @@ config ARCH_INTEL64
 	select ARCH_HAVE_STACKCHECK
 	select ARCH_HAVE_RNG
 	select ARCH_HAVE_RESET
+	select ARCH_HAVE_MMX
+	select ARCH_HAVE_SSE
+	select ARCH_HAVE_SSE2
+	select ARCH_HAVE_SSE3
+	select ARCH_HAVE_SSSE3
+	select ARCH_HAVE_SSE41
+	select ARCH_HAVE_SSE42
+	select ARCH_HAVE_SSE4A
 	---help---
 		Intel x86_64 architecture
 
@@ -32,6 +40,48 @@ config ARCH_CHIP_X86_64_CUSTOM
 		Select this option if there is no directory for the chip under arch/x86_64/src/.
 
 endchoice
+
+# CPU features
+
+config ARCH_HAVE_MMX
+	bool
+	default n
+
+config ARCH_HAVE_SSE
+	bool
+	default y
+
+config ARCH_HAVE_SSE2
+	bool
+	default y
+
+config ARCH_HAVE_SSE3
+	bool
+	default n
+
+config ARCH_HAVE_SSSE3
+	bool
+	default n
+
+config ARCH_HAVE_SSE41
+	bool
+	default n
+
+config ARCH_HAVE_SSE42
+	bool
+	default n
+
+config ARCH_HAVE_SSE4A
+	bool
+	default n
+
+config ARCH_HAVE_AVX
+	bool
+	default n
+
+config ARCH_HAVE_AVX512
+	bool
+	default n
 
 source "arch/x86_64/src/common/Kconfig"
 

--- a/arch/x86_64/src/cmake/Toolchain.cmake
+++ b/arch/x86_64/src/cmake/Toolchain.cmake
@@ -124,3 +124,23 @@ endif()
 if(CONFIG_ARCH_INTEL64_HAVE_RDRAND)
   add_compile_options(-mrdrnd)
 endif()
+
+if(CONFIG_ARCH_X86_64_SSE3)
+  add_compile_options(-msse3)
+endif()
+
+if(CONFIG_ARCH_X86_64_SSSE3)
+  add_compile_options(-mssse3)
+endif()
+
+if(CONFIG_ARCH_X86_64_SSE41)
+  add_compile_options(-msse4.1)
+endif()
+
+if(CONFIG_ARCH_X86_64_SSE42)
+  add_compile_options(-msse4.2)
+endif()
+
+if(CONFIG_ARCH_X86_64_SSE4A)
+  add_compile_options(-msse4a)
+endif()

--- a/arch/x86_64/src/common/Kconfig
+++ b/arch/x86_64/src/common/Kconfig
@@ -6,4 +6,54 @@
 if ARCH_X86_64
 comment "Common Configuration Options"
 
+config ARCH_X86_64_MMX
+	bool "MMX support"
+	depends on ARCH_HAVE_MMX
+	default y
+
+config ARCH_X86_64_SSE
+	bool "SSE support"
+	depends on ARCH_HAVE_SSE
+	default y
+
+config ARCH_X86_64_SSE2
+	bool "SSE2 support"
+	depends on ARCH_HAVE_SSE2
+	default y
+
+config ARCH_X86_64_SSE3
+	bool "SSE3 support"
+	depends on ARCH_HAVE_SSE3
+	default n
+
+config ARCH_X86_64_SSSE3
+	bool "SSSE3 support"
+	depends on ARCH_HAVE_SSSE3
+	default n
+
+config ARCH_X86_64_SSE41
+	bool "SSE41 support"
+	depends on ARCH_HAVE_SSE41
+	default n
+
+config ARCH_X86_64_SSE42
+	bool "SSE42 support"
+	depends on ARCH_HAVE_SSE42
+	default n
+
+config ARCH_X86_64_SSE4A
+	bool "SSE4A support"
+	depends on ARCH_HAVE_SSE4A
+	default n
+
+config ARCH_X86_64_AVX
+	bool "AVX support"
+	depends on ARCH_HAVE_AVX
+	default n
+
+config ARCH_X86_64_AVX512
+	bool "AVX512 support"
+	depends on ARCH_HAVE_AVX512
+	default n
+
 endif

--- a/arch/x86_64/src/common/Toolchain.defs
+++ b/arch/x86_64/src/common/Toolchain.defs
@@ -61,3 +61,23 @@ AFLAGS += -Wa,--divide
 endif
 
 EXEEXT = .elf
+
+ifeq ($(CONFIG_ARCH_X86_64_SSE3),y)
+  ARCHCPUFLAGS += -msse3
+endif
+
+ifeq ($(CONFIG_ARCH_X86_64_SSSE3),y)
+  ARCHCPUFLAGS += -mssse3
+endif
+
+ifeq ($(CONFIG_ARCH_X86_64_SSE41),y)
+  ARCHCPUFLAGS += -msse41
+endif
+
+ifeq ($(CONFIG_ARCH_X86_64_SSE42),y)
+  ARCHCPUFLAGS += -msse42
+endif
+
+ifeq ($(CONFIG_ARCH_X86_64_SSE4a),y)
+  ARCHCPUFLAGS += -msse4a
+endif


### PR DESCRIPTION
## Summary
- arch/x86_64: add SSE instruction support
at default x86_64 supports SSE, SSE2, this commit adds support for SSE3, SSSE3, SSE41, SSE42 and SSE4A

## Impact

## Testing
qemu and intel hw