### PR TITLE
qemu-intel64: move PCI initialization back to board logic

### DIFF
--- a/arch/x86_64/src/common/x86_64_initialize.c
+++ b/arch/x86_64/src/common/x86_64_initialize.c
@@ -115,12 +115,6 @@ void up_initialize(void)
   x86_64_serialinit();
 #endif
 
-  /* Initialize the PCI bus */
-
-#ifdef CONFIG_PCI
-  x86_64_pci_init();
-#endif
-
   /* Initialize the network */
 
 #ifndef CONFIG_NETDEV_LATEINIT

--- a/boards/x86_64/intel64/qemu-intel64/src/qemu_bringup.c
+++ b/boards/x86_64/intel64/qemu-intel64/src/qemu_bringup.c
@@ -36,6 +36,7 @@
 #  include <nuttx/timers/oneshot.h>
 #endif
 
+#include "x86_64_internal.h"
 #include "qemu_intel64.h"
 
 /****************************************************************************
@@ -53,6 +54,12 @@ int qemu_bringup(void)
 #endif
 
   int ret = OK;
+
+  /* Initialize the PCI bus */
+
+#ifdef CONFIG_PCI
+  x86_64_pci_init();
+#endif
 
 #ifdef CONFIG_FS_PROCFS
   /* Mount the procfs file system */


### PR DESCRIPTION
## Summary

- qemu-intel64: move PCI initialization back to board logic
this partly revert 4123615621 which works OK for PCI serial and network cards but breaks QEMU EDU due to usage of sem and usleep in IDLE thread context. Another solution will be provided later.

## Impact

## Testing
qemu
