### PR TITLE
riscv/k230: minor revision on PMP settings

### DIFF
--- a/arch/risc-v/src/k230/k230_hart.c
+++ b/arch/risc-v/src/k230/k230_hart.c
@@ -87,7 +87,7 @@
 
 #if !defined(CONFIG_BUILD_KERNEL) || defined(CONFIG_NUTTSBI)
 
-static bool g_big = false;    /* true if running on big core */
+static volatile uint64_t g_misa = 0;
 
 /****************************************************************************
  * Private Functions
@@ -127,28 +127,21 @@ static void k230_hart_cleanup(void)
 
 void k230_hart_init(void)
 {
-  /* TODO: when called from sbi_start(), MISA is 0 somehow. */
-
-  g_big = (READ_CSR(CSR_MISA) & (1 << 21));
-
   k230_hart_cleanup();
 
   WRITE_CSR(CSR_MXSTATUS, XSTATUS);
   WRITE_CSR(CSR_MHCR,  MHCR);
   WRITE_CSR(CSR_MCOR,  MCOR);
   WRITE_CSR(CSR_MSMPR, MSMPR);
-  WRITE_CSR(CSR_MCCR2, g_big ? MCCR2_BIG : MCCR2);
-  WRITE_CSR(CSR_MHINT, g_big ? MHINT_BIG : MHINT);
+  WRITE_CSR(CSR_MCCR2, MCCR2);
+  WRITE_CSR(CSR_MHINT, MHINT);
 
 #ifdef RISCV_PBMT
   SET_CSR(CSR_MENVCFG, MENVCFG_PBMT);
 #endif
+  /* TODO: why 0 when reading from NuttSBI S-mode? */
 
-#ifdef CONFIG_NUTTSBI
-  /* Some PMP entries might have been locked */
-
-  k230_add_pmp(PMPCFG_A_NAPOT | PMPCFG_RWX_MASK, 0, 1024ul << 30);
-#endif
+  while (!(g_misa = READ_CSR(CSR_MISA)));
 }
 
 /****************************************************************************
@@ -158,7 +151,8 @@ void k230_hart_init(void)
 
 bool k230_hart_is_big(void)
 {
-  return g_big;
+  sinfo("g_misa=%lx\n", g_misa);
+  return g_misa & (1 << 21);
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/k230/k230_hart.h
+++ b/arch/risc-v/src/k230/k230_hart.h
@@ -25,11 +25,6 @@
  * Preprocessor Macros
  ****************************************************************************/
 
-/* add PMP entry with (attr, base, size) */
-
-#define k230_add_pmp(a, b, s)   riscv_config_pmp_region( \
-                                  riscv_next_free_pmp_region(), a, b, s)
-
 #define CSR_MSECCFG     0x747
 #define CSR_MSECCFGH    0x757
 

--- a/arch/risc-v/src/k230/k230_userspace.c
+++ b/arch/risc-v/src/k230/k230_userspace.c
@@ -34,7 +34,6 @@
 
 #include "k230_userspace.h"
 #include "riscv_internal.h"
-#include "k230_hart.h"
 
 #ifdef CONFIG_BUILD_PROTECTED
 
@@ -128,8 +127,8 @@ void k230_userspace(void)
 
 static void configure_mpu(void)
 {
-  k230_add_pmp(UFLASH_F, UFLASH_START, UFLASH_SIZE);
-  k230_add_pmp(USRAM_F, USRAM_START, USRAM_SIZE);
+  riscv_append_pmp_region(UFLASH_F, UFLASH_START, UFLASH_SIZE);
+  riscv_append_pmp_region(USRAM_F, USRAM_START, USRAM_SIZE);
 }
 
 #endif /* CONFIG_BUILD_PROTECTED */


### PR DESCRIPTION

## Summary

This patch simplifies PMP handling using common APIs. It also uses `g_misa` variable to expose the MISA issue.

## Impact

K230 devices

## Testing

checked on CanMV230

