### PR TITLE
arch/nrf: fixes for SPI

### DIFF
--- a/arch/arm/src/nrf52/nrf52_spi.c
+++ b/arch/arm/src/nrf52/nrf52_spi.c
@@ -235,7 +235,7 @@ static const struct spi_ops_s g_spi1ops =
 #  ifdef CONFIG_SPI_EXCHANGE
   .exchange          = nrf52_spi_exchange,
 #  else
-  .sndlock           = nrf52_spi_sndblock,
+  .sndblock          = nrf52_spi_sndblock,
   .recvblock         = nrf52_spi_recvblock,
 #  endif
 #ifdef CONFIG_SPI_TRIGGER

--- a/arch/arm/src/nrf53/nrf53_spi.c
+++ b/arch/arm/src/nrf53/nrf53_spi.c
@@ -210,7 +210,7 @@ static const struct spi_ops_s g_spi1ops =
 #  ifdef CONFIG_SPI_EXCHANGE
   .exchange          = nrf53_spi_exchange,
 #  else
-  .sndlock           = nrf53_spi_sndblock,
+  .sndblock          = nrf53_spi_sndblock,
   .recvblock         = nrf53_spi_recvblock,
 #  endif
 #ifdef CONFIG_SPI_TRIGGER

--- a/arch/arm/src/nrf91/nrf91_spi.c
+++ b/arch/arm/src/nrf91/nrf91_spi.c
@@ -210,7 +210,7 @@ static const struct spi_ops_s g_spi1ops =
 #  ifdef CONFIG_SPI_EXCHANGE
   .exchange          = nrf91_spi_exchange,
 #  else
-  .sndlock           = nrf91_spi_sndblock,
+  .sndblock          = nrf91_spi_sndblock,
   .recvblock         = nrf91_spi_recvblock,
 #  endif
 #ifdef CONFIG_SPI_TRIGGER


### PR DESCRIPTION
## Summary
- arch/nrf{52|53|91}: fix typo
fix typo sndlock -> sndblock

- arch/nrf91: fix compilation for SPI
remove references to unsupported SPI freq and SPI4 which is not supported

## Impact

## Testing
CI
