### PR TITLE
SAMV7: fix typos in Kconfig PWM0 fault input selections - inv. polarity

### DIFF
--- a/arch/arm/src/samv7/Kconfig
+++ b/arch/arm/src/samv7/Kconfig
@@ -789,9 +789,9 @@ config SAMV7_PWM0_PA9
 	bool "External fault input from PA9"
 	default n
 
-if SAMV7_PWM1_PA9
+if SAMV7_PWM0_PA9
 
-config SAMV7_PWM1_PA9_POL
+config SAMV7_PWM0_PA9_POL
 	bool "Inverted polarity"
 	default n
 	---help---
@@ -804,9 +804,9 @@ config SAMV7_PWM0_PD8
 	bool "External fault input from PD8"
 	default n
 
-if SAMV7_PWM1_PD8
+if SAMV7_PWM0_PD8
 
-config SAMV7_PWM1_PD8_POL
+config SAMV7_PWM0_PD8_POL
 	bool "Inverted polarity"
 	default n
 	---help---
@@ -819,9 +819,9 @@ config SAMV7_PWM0_PD9
 	bool "External fault input from PD9"
 	default n
 
-if SAMV7_PWM1_PD9
+if SAMV7_PWM0_PD9
 
-config SAMV7_PWM1_PD9_POL
+config SAMV7_PWM0_PD9_POL
 	bool "Inverted polarity"
 	default n
 	---help---


### PR DESCRIPTION
## Summary
ATSAMV7 MCUs allow usage of fault inputs for PWMs. However, there were typos in arch/arm/src/samv7/Kconfig that didn't allow for choosing inverted polarity of these inputs for PWM0 because of typos. PWM1 is fine.