### PR TITLE
mm/kconfig: fix typo in MM_DEFAULT_ALIGNMENT

### DIFF
--- a/include/nuttx/mm/mempool.h
+++ b/include/nuttx/mm/mempool.h
@@ -38,10 +38,10 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#if CONFIG_MM_DFAULT_ALIGNMENT == 0
+#if CONFIG_MM_DEFAULT_ALIGNMENT == 0
 #  define MEMPOOL_ALIGN       (2 * sizeof(uintptr_t))
 #else
-#  define MEMPOOL_ALIGN       CONFIG_MM_DFAULT_ALIGNMENT
+#  define MEMPOOL_ALIGN       CONFIG_MM_DEFAULT_ALIGNMENT
 #endif
 
 #if CONFIG_MM_BACKTRACE >= 0

--- a/mm/Kconfig
+++ b/mm/Kconfig
@@ -60,7 +60,7 @@ config MM_KERNEL_HEAPSIZE
 		user-mode heap.  This value may need to be aligned to units of the
 		size of the smallest memory protection region.
 
-config MM_DFAULT_ALIGNMENT
+config MM_DEFAULT_ALIGNMENT
 	int "Memory default alignment in bytes"
 	default 0
 	range 0 64

--- a/mm/mm_heap/mm.h
+++ b/mm/mm_heap/mm.h
@@ -112,10 +112,10 @@
 #define MM_MAX_CHUNK     (1 << MM_MAX_SHIFT)
 #define MM_NNODES        (MM_MAX_SHIFT - MM_MIN_SHIFT + 1)
 
-#if CONFIG_MM_DFAULT_ALIGNMENT == 0
+#if CONFIG_MM_DEFAULT_ALIGNMENT == 0
 #  define MM_ALIGN       (2 * sizeof(uintptr_t))
 #else
-#  define MM_ALIGN       CONFIG_MM_DFAULT_ALIGNMENT
+#  define MM_ALIGN       CONFIG_MM_DEFAULT_ALIGNMENT
 #endif
 #define MM_GRAN_MASK     (MM_ALIGN - 1)
 #define MM_ALIGN_UP(a)   (((a) + MM_GRAN_MASK) & ~MM_GRAN_MASK)


### PR DESCRIPTION

## Summary
This fixes minor typo in MM_DEFAULT_ALIGNMENT

## Impact
None

## Testing
CI checks

