### PR TITLE
sched/group: set clear flag if the group is not really needed

### DIFF
--- a/sched/group/group_leave.c
+++ b/sched/group/group_leave.c
@@ -120,15 +120,15 @@ group_release(FAR struct task_group_s *group, uint8_t ttype)
     }
 #endif
 
-  /* Mark the group as deleted now */
-
-  group->tg_flags |= GROUP_FLAG_DELETED;
-
   /* Then drop the group freeing the allocated memory */
 
 #ifndef CONFIG_DISABLE_PTHREAD
   if (ttype == TCB_FLAG_TTYPE_PTHREAD)
     {
+      /* Mark the group as deleted now */
+
+      group->tg_flags |= GROUP_FLAG_DELETED;
+
       group_drop(group);
     }
 #endif

--- a/sched/sched/sched_releasetcb.c
+++ b/sched/sched/sched_releasetcb.c
@@ -176,6 +176,10 @@ int nxsched_release_tcb(FAR struct tcb_s *tcb, uint8_t ttype)
 #endif
               )
             {
+              /* Mark the group as deleted now */
+
+              ttcb->group.tg_flags |= GROUP_FLAG_DELETED;
+
               return ret;
             }
         }


### PR DESCRIPTION

## Summary

sched/group: set clear flag if the group is not really needed

The delete flag is not synchronized with the life cycle of the group, if the flag set before waitpid(), the tcb will be mistakenly deleted by group_del_waiter(), use-after-free will happen.

Regression by:
```
| commit 29e50ffa7374fa4c473d8d4f8cb3506665443d3e (origin/master, origin/HEAD)
| Author: chao an <anchao@lixiang.com>
| Date:   Mon Mar 4 09:19:27 2024 +0800
|
|     sched/group: move task group into task_tcb_s to improve performance
|
|     move task group into task_tcb_s to avoid access allocator to improve performance
|
|     for Task Termination, the time consumption will be reduced ~2us (Tricore TC397 300MHZ):
|     15.97(us) -> 13.55(us)
|
|     Signed-off-by: chao an <anchao@lixiang.com>

```

## Impact

N/A

## Testing

rv-virt:ksmp64