### PR TITLE
libs/libc/string: fix memmem() boundary case when needle is at end of haystack

### DIFF
--- a/libs/libc/string/lib_memmem.c
+++ b/libs/libc/string/lib_memmem.c
@@ -51,12 +51,17 @@ FAR void *memmem(FAR const void *haystack, size_t haystacklen,
   size_t i;
   size_t y;
 
+  if (needlelen == 0)
+    {
+      return (void *)haystack;
+    }
+
   if (needlelen > haystacklen)
     {
       return NULL;
     }
 
-  for (i = 0; i < haystacklen - needlelen; i++)
+  for (i = 0; i <= haystacklen - needlelen; i++)
     {
       y = 0;
       while (h[i + y] == n[y])


### PR DESCRIPTION
## Summary

libs/libc/string: fix memmem() boundary case when needle is at end of haystack

This fixes calls like memmem("hello", 5, "lo", 2);

Also zero-length needle is deemed to exist at beginning of haystack. This behavior matches memmem() on Linux, FreeBSD, NetBSD and OpenBSD.

## Impact

Bug fix. Zero-length needle was incorrectly accessing bytes of needle.

## Testing

Passes there tests:

```
void test_memmem(void)
{
    char *haystack = "hello";
    char *s;

    s = memmem(haystack, 5, "hel", 3);
    assert(s == haystack);

    s = memmem(haystack, 5, "lo", 2);
    assert(s == haystack + 3);

    s = memmem(haystack, 5, "hello", 5);
    assert(s == haystack);

    /* Compare '\0' bytes at string ends. */
    s = memmem(haystack, 6, "o", 2);
    assert(s == haystack + 4);

    /* Must not find needle that is right after end of haystack. */
    s = memmem("helloX", 5, "X", 1);
    assert(s == NULL);

    /* Too long needle should return NULL. */
    s = memmem(haystack, 5, "hellohello", 10);
    assert(s == NULL);

    /* Zero length needle is deemed to reside at start of haystack. */
    s = memmem(haystack, 5, "", 0);
    assert(s == haystack);
}
```
