### PR TITLE
sched/pthread/join: remove unused joininfo

### DIFF
--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -714,7 +714,6 @@ struct pthread_tcb_s
 
   pthread_trampoline_t trampoline;       /* User-space pthread startup function */
   pthread_addr_t arg;                    /* Startup argument                    */
-  FAR void *joininfo;                    /* Detach-able info to support join    */
   bool join_complete;                    /* Join was completed                  */
 };
 #endif /* !CONFIG_DISABLE_PTHREAD */

--- a/sched/pthread/pthread_findjoininfo.c
+++ b/sched/pthread/pthread_findjoininfo.c
@@ -82,8 +82,6 @@ int pthread_createjoininfo(FAR struct pthread_tcb_s *ptcb,
 
       /* Attach the join info to the TCB. */
 
-      ptcb->joininfo = (FAR void *)(*pjoin);
-
       (*pjoin)->next = NULL;
       if (!group->tg_jointail)
         {


### PR DESCRIPTION
## Summary

sched/pthread/join: remove unused joininfo

remove unused joininfo, minor issue found from code reading

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

ci-check