### PR TITLE
sched/pthread: replace pthread_sem_give() to nxsem_post() to unify the post method

### DIFF
--- a/sched/pthread/pthread_completejoin.c
+++ b/sched/pthread/pthread_completejoin.c
@@ -73,7 +73,7 @@ static bool pthread_notifywaiters(FAR struct join_s *pjoin)
 
       do
         {
-          status = pthread_sem_give(&pjoin->exit_sem);
+          status = nxsem_post(&pjoin->exit_sem);
           if (status == OK)
             {
               status = nxsem_get_value(&pjoin->exit_sem, &ntasks_waiting);

--- a/sched/pthread/pthread_join.c
+++ b/sched/pthread/pthread_join.c
@@ -187,7 +187,7 @@ int pthread_join(pthread_t thread, FAR pthread_addr_t *pexit_value)
            * will know that we have received the data.
            */
 
-          pthread_sem_give(&pjoin->data_sem);
+          nxsem_post(&pjoin->data_sem);
 
           /* Retake the join semaphore, we need to hold this when
            * pthread_destroyjoin is called.


### PR DESCRIPTION
## Summary

 sched/pthread: replace pthread_sem_give() to nxsem_post() to unify the post method
 
 replace pthread_sem_give() to nxsem_post() to unify the post method
 
 Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

ci-check