### PR TITLE
fs/driver: using nx_unlink to call unlink ops to release some resource

### DIFF
--- a/fs/driver/fs_unregisterdriver.c
+++ b/fs/driver/fs_unregisterdriver.c
@@ -44,6 +44,16 @@ int unregister_driver(FAR const char *path)
 {
   int ret;
 
+  /* Call unlink to release driver resource and inode. */
+
+  ret = nx_unlink(path);
+  if (ret >= 0)
+    {
+      return ret;
+    }
+
+  /* If unlink failed, only remove inode. */
+
   ret = inode_lock();
   if (ret >= 0)
     {


### PR DESCRIPTION


## Summary
fs/driver: using nx_unlink to call unlink ops to release some resource

if driver complete unlink ops, we need to call it to release some resource, otherwise, it will only remove inode.
## Impact
release resource after unlink
## Testing
adb test
