### PR TITLE
docs/esp32c6: Add spiflash docs for esp32c6

### DIFF
--- a/Documentation/platforms/risc-v/esp32c3/boards/esp32c3-generic/index.rst
+++ b/Documentation/platforms/risc-v/esp32c3/boards/esp32c3-generic/index.rst
@@ -150,10 +150,17 @@ You can set an alarm, check its progress and receive a notification after it exp
     Alarm 0 is active with 10 seconds to expiration
     nsh> alarm_daemon: alarm 0 received
 
-sotest
-------
+spiflash
+--------
 
-This config is to run apps/examples/sotest.
+This config tests the external SPI that comes with the ESP32-C3 module connected
+through SPI1.
+
+By default a SmartFS file system is selected.
+Once booted you can use the following commands to mount the file system::
+
+    nsh> mksmartfs /dev/smart0
+    nsh> mount -t smartfs /dev/smart0 /mnt
 
 timer
 -----

--- a/Documentation/platforms/risc-v/esp32c3/index.rst
+++ b/Documentation/platforms/risc-v/esp32c3/index.rst
@@ -159,7 +159,7 @@ RSA          No
 RTC          Yes
 SHA          No
 SPI          No
-SPIFLASH     No
+SPIFLASH     Yes
 Timers       Yes
 Touch        No
 UART         Yes

--- a/Documentation/platforms/risc-v/esp32c6/boards/esp32c6-devkit/index.rst
+++ b/Documentation/platforms/risc-v/esp32c6/boards/esp32c6-devkit/index.rst
@@ -185,10 +185,17 @@ You can set an alarm, check its progress and receive a notification after it exp
     Alarm 0 is active with 10 seconds to expiration
     nsh> alarm_daemon: alarm 0 received
 
-sotest
-------
+spiflash
+--------
 
-This config is to run apps/examples/sotest.
+This config tests the external SPI that comes with the ESP32-C6 module connected
+through SPI1.
+
+By default a SmartFS file system is selected.
+Once booted you can use the following commands to mount the file system::
+
+    nsh> mksmartfs /dev/smart0
+    nsh> mount -t smartfs /dev/smart0 /mnt
 
 timer
 -----

--- a/Documentation/platforms/risc-v/esp32c6/index.rst
+++ b/Documentation/platforms/risc-v/esp32c6/index.rst
@@ -167,7 +167,7 @@ SD/MMC           No
 SDIO             No
 SHA              No
 SPI              No
-SPIFLASH         No
+SPIFLASH         Yes
 Timers           Yes
 UART             Yes
 Watchdog         Yes

--- a/Documentation/platforms/risc-v/esp32h2/boards/esp32h2-devkit/index.rst
+++ b/Documentation/platforms/risc-v/esp32h2/boards/esp32h2-devkit/index.rst
@@ -184,10 +184,17 @@ You can set an alarm, check its progress and receive a notification after it exp
     Alarm 0 is active with 10 seconds to expiration
     nsh> alarm_daemon: alarm 0 received
 
-sotest
-------
+spiflash
+--------
 
-This config is to run apps/examples/sotest.
+This config tests the external SPI that comes with the ESP32-H2 module connected
+through SPI1.
+
+By default a SmartFS file system is selected.
+Once booted you can use the following commands to mount the file system::
+
+    nsh> mksmartfs /dev/smart0
+    nsh> mount -t smartfs /dev/smart0 /mnt
 
 timer
 -----

--- a/Documentation/platforms/risc-v/esp32h2/index.rst
+++ b/Documentation/platforms/risc-v/esp32h2/index.rst
@@ -167,7 +167,7 @@ SD/MMC           No
 SDIO             No
 SHA              No
 SPI              No
-SPIFLASH         No
+SPIFLASH         Yes
 Timers           Yes
 UART             Yes
 Watchdog         Yes


### PR DESCRIPTION
## Summary

- docs/esp32c6: Remove sotest docs esp32c6
- docs/esp32c3: Add spiflash docs esp32c3
- docs/esp32c3: Remove sotest docs esp32c3
- docs/esp32h2: Add spiflash docs esp32h2
- docs/esp32h2: Remove sotest docs esp32h2

## Impact

ESP32-H2, ESP32-C3, ESP32-C6

## Testing

