### PR TITLE
revise comments and harden nx_mount logic

### DIFF
--- a/fs/mount/fs_mount.c
+++ b/fs/mount/fs_mount.c
@@ -279,12 +279,12 @@ int nx_mount(FAR const char *source, FAR const char *target,
 {
 #if defined(BDFS_SUPPORT) || defined(MDFS_SUPPORT) || defined(NODFS_SUPPORT)
   FAR struct inode *drvr_inode = NULL;
-  FAR struct inode *mountpt_inode;
+  FAR struct inode *mountpt_inode = NULL;
   FAR const struct mountpt_operations *mops = NULL;
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   struct inode_search_s desc;
 #endif
-  void *fshandle;
+  void *fshandle = NULL;
   int ret;
 
   /* Verify required pointer arguments */
@@ -293,7 +293,7 @@ int nx_mount(FAR const char *source, FAR const char *target,
 
   /* Find the specified filesystem. Try the block driver filesystems first */
 
-  if (source != NULL &&
+  if (source != NULL && source[0] != '\0' &&
       find_blockdriver(source, mountflags, &drvr_inode) >= 0)
     {
       /* Find the block based file system */
@@ -310,7 +310,7 @@ int nx_mount(FAR const char *source, FAR const char *target,
           goto errout_with_inode;
         }
     }
-  else if (source != NULL &&
+  else if (source != NULL && source[0] != '\0' &&
            (ret = find_mtddriver(source, &drvr_inode)) >= 0)
     {
       /* Find the MTD based file system */
@@ -331,6 +331,7 @@ int nx_mount(FAR const char *source, FAR const char *target,
 #ifdef NODFS_SUPPORT
   if ((mops = mount_findfs(g_nonbdfsmap, filesystemtype)) != NULL)
     {
+      finfo("found %s\n", filesystemtype);
     }
   else
 #endif /* NODFS_SUPPORT */

--- a/mm/mm_heap/mm.h
+++ b/mm/mm_heap/mm.h
@@ -121,8 +121,10 @@
 #define MM_ALIGN_UP(a)   (((a) + MM_GRAN_MASK) & ~MM_GRAN_MASK)
 #define MM_ALIGN_DOWN(a) ((a) & ~MM_GRAN_MASK)
 
-/* An allocated chunk is distinguished from a free chunk by bit 0
- * of the 'preceding' chunk size.  If set, then this is an allocated chunk.
+/* Due to alignment, the lowest two bits of valid chunk size are always
+ * zero, thus the two bits are reused to depict allocation status: bit
+ * 0 depicts the allocation state of current chunk, and bit 1 depicts that
+ * of the physically preceding chunk.
  */
 
 #define MM_ALLOC_BIT     0x1
@@ -169,14 +171,11 @@ typedef uint16_t mmsize_t;
 typedef size_t mmsize_t;
 #endif
 
-/* This describes an allocated chunk.  An allocated chunk is
- * distinguished from a free chunk by bit 15/31 of the 'preceding' chunk
- * size.  If set, then this is an allocated chunk.
- */
+/* This describes an allocated chunk */
 
 struct mm_allocnode_s
 {
-  mmsize_t preceding;                       /* Size of the preceding chunk */
+  mmsize_t preceding;                       /* Physical preceding chunk size */
   mmsize_t size;                            /* Size of this chunk */
 #if CONFIG_MM_BACKTRACE >= 0
   pid_t pid;                                /* The pid for caller */
@@ -191,7 +190,7 @@ struct mm_allocnode_s
 
 struct mm_freenode_s
 {
-  mmsize_t preceding;                       /* Size of the preceding chunk */
+  mmsize_t preceding;                       /* Physical preceding chunk size */
   mmsize_t size;                            /* Size of this chunk */
 #if CONFIG_MM_BACKTRACE >= 0
   pid_t pid;                                /* The pid for caller */
@@ -220,9 +219,7 @@ struct mm_delaynode_s
 
 struct mm_heap_s
 {
-  /* Mutually exclusive access to this data set is enforced with
-   * the following un-named mutex.
-   */
+  /* Mutex for controling access to this heap */
 
   mutex_t mm_lock;
 
@@ -238,7 +235,7 @@ struct mm_heap_s
 
   size_t mm_curused;
 
-  /* This is the first and last nodes of the heap */
+  /* The first and last allocated nodes of each region */
 
   FAR struct mm_allocnode_s *mm_heapstart[CONFIG_MM_REGIONS];
   FAR struct mm_allocnode_s *mm_heapend[CONFIG_MM_REGIONS];
@@ -249,14 +246,12 @@ struct mm_heap_s
 
   /* All free nodes are maintained in a doubly linked list.  This
    * array provides some hooks into the list at various points to
-   * speed searches for free nodes.
+   * speed up searching of free nodes.
    */
 
   struct mm_freenode_s mm_nodelist[MM_NNODES];
 
-  /* Free delay list, for some situations where we can't do free
-   * immdiately.
-   */
+  /* Free delay list, as sometimes we can't do free immdiately. */
 
   FAR struct mm_delaynode_s *mm_delaylist[CONFIG_SMP_NCPUS];
 


### PR DESCRIPTION
## Summary

This patch contains  improvements to harden logic of nx_mount():
- currently some variables may not get populated by called functions, thus initialization is added.
- empty string device path is possible when multiple type of file systems are enabled.

It also revised comments for mm_heap/mm.h

## Impact

file system mount operations

## Testing

Checked with CanMV230
