### PR TITLE
xtensa/esp32: Fix wrong interrupt number

### DIFF
--- a/arch/xtensa/src/esp32/esp32_emac.c
+++ b/arch/xtensa/src/esp32/esp32_emac.c
@@ -1793,7 +1793,9 @@ static int emac_ifdown(struct net_driver_s *dev)
 
   emac_reset_regbits(EMAC_CR_OFFSET, EMAC_TX_E | EMAC_RX_E);
 
-  up_disable_irq(priv->cpuint);
+  /* Disable the Ethernet interrupt */
+
+  up_disable_irq(ESP32_IRQ_EMAC);
 
   /* Cancel the TX timeout timers */
 


### PR DESCRIPTION
## Summary

- Fix wrong interrupt number: it should be `ESP32_IRQ_EMAC` instead of `priv->cpuint`

## Impact

## Testing

