### PR TITLE
sched/pthread/join: refactor pthread join to support join task

### DIFF
--- a/sched/group/group_create.c
+++ b/sched/group/group_create.c
@@ -161,9 +161,10 @@ int group_initialize(FAR struct task_tcb_s *tcb, uint8_t ttype)
     }
 
 #ifndef CONFIG_DISABLE_PTHREAD
-  /* Initialize the pthread join mutex */
+  /* Initialize the task group join */
 
-  nxmutex_init(&group->tg_joinlock);
+  nxrmutex_init(&group->tg_joinlock);
+  sq_init(&group->tg_joinqueue);
 #endif
 
 #if defined(CONFIG_SCHED_WAITPID) && !defined(CONFIG_SCHED_HAVE_PARENT)

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -46,6 +46,7 @@
 #include <nuttx/drivers/drivers.h>
 #include <nuttx/init.h>
 
+#include "task/task.h"
 #include "sched/sched.h"
 #include "signal/signal.h"
 #include "semaphore/semaphore.h"
@@ -518,6 +519,10 @@ void nx_start(void)
 
       DEBUGVERIFY(group_initialize(&g_idletcb[i], g_idletcb[i].cmn.flags));
       g_idletcb[i].cmn.group->tg_info->ta_argv = &g_idleargv[i][0];
+
+      /* Initialize the task join */
+
+      nxtask_joininit(&g_idletcb[i].cmn);
 
 #ifdef CONFIG_SMP
       /* Create a stack for all CPU IDLE threads (except CPU0 which already

--- a/sched/pthread/pthread.h
+++ b/sched/pthread/pthread.h
@@ -37,29 +37,6 @@
 #include <nuttx/sched.h>
 
 /****************************************************************************
- * Public Type Declarations
- ****************************************************************************/
-
-/* The following defines an entry in the pthread logic's local data set.
- * Note that this structure is used to implemented a singly linked list.
- * This structure is used (instead of, say, a binary search tree) because
- * the data set will be searched using the pid as a key -- a process IDs will
- * always be created in a montonically increasing fashion.
- */
-
-struct join_s
-{
-  FAR struct join_s *next;       /* Implements link list */
-  uint8_t            crefs;      /* Reference count */
-  bool               detached;   /* true: pthread_detached'ed */
-  bool               terminated; /* true: detach'ed+exit'ed */
-  pthread_t          thread;     /* Includes pid */
-  sem_t              exit_sem;   /* Implements join */
-  sem_t              data_sem;   /* Implements join */
-  pthread_addr_t     exit_value; /* Returned data */
-};
-
-/****************************************************************************
  * Public Data
  ****************************************************************************/
 
@@ -83,9 +60,9 @@ int pthread_setup_scheduler(FAR struct pthread_tcb_s *tcb, int priority,
 
 int pthread_completejoin(pid_t pid, FAR void *exit_value);
 void pthread_destroyjoin(FAR struct task_group_s *group,
-                         FAR struct join_s *pjoin);
-int pthread_findjoininfo(FAR struct task_group_s *group,
-                         pid_t pid, FAR struct join_s **join);
+                         FAR struct task_join_s *pjoin);
+int pthread_findjoininfo(FAR struct task_group_s *group, pid_t pid,
+                         FAR struct task_join_s **join, bool create);
 void pthread_release(FAR struct task_group_s *group);
 
 int pthread_sem_take(FAR sem_t *sem, FAR const struct timespec *abs_timeout);

--- a/sched/pthread/pthread_completejoin.c
+++ b/sched/pthread/pthread_completejoin.c
@@ -24,6 +24,7 @@
 
 #include <nuttx/config.h>
 
+#include <nuttx/nuttx.h>
 #include <sys/types.h>
 #include <stdbool.h>
 #include <pthread.h>
@@ -34,133 +35,6 @@
 #include "sched/sched.h"
 #include "group/group.h"
 #include "pthread/pthread.h"
-
-/****************************************************************************
- * Private Functions
- ****************************************************************************/
-
-/****************************************************************************
- * Name: pthread_notifywaiters
- *
- * Description:
- *   Notify all other threads waiting in phread join for this thread's
- *   exit data.  This must  be done by the child at child thread
- *   destruction time.
- *
- ****************************************************************************/
-
-static bool pthread_notifywaiters(FAR struct join_s *pjoin)
-{
-  int ntasks_waiting;
-  int status;
-
-  sinfo("pjoin=%p\n", pjoin);
-
-  /* Are any tasks waiting for our exit value? */
-
-  status = nxsem_get_value(&pjoin->exit_sem, &ntasks_waiting);
-  if (status == OK && ntasks_waiting < 0)
-    {
-      /* Set the data semaphore so that this thread will be
-       * awakened when all waiting tasks receive the data
-       */
-
-      nxsem_init(&pjoin->data_sem, 0, (ntasks_waiting + 1));
-
-      /* Post the semaphore to restart each thread that is waiting
-       * on the semaphore
-       */
-
-      do
-        {
-          status = nxsem_post(&pjoin->exit_sem);
-          if (status == OK)
-            {
-              status = nxsem_get_value(&pjoin->exit_sem, &ntasks_waiting);
-            }
-        }
-      while (ntasks_waiting < 0 && status == OK);
-
-      /* Now wait for all these restarted tasks to obtain the return
-       * value.
-       */
-
-      nxsem_wait_uninterruptible(&pjoin->data_sem);
-      return true;
-    }
-
-  return false;
-}
-
-/****************************************************************************
- * Name: pthread_removejoininfo
- *
- * Description:
- *   Remove a join structure from the local data set.
- *
- * Input Parameters:
- *   pid
- *
- * Returned Value:
- *   None.
- *
- * Assumptions:
- *   The caller has provided protection from re-entrancy.
- *
- ****************************************************************************/
-
-static void pthread_removejoininfo(FAR struct task_group_s *group,
-                                   pid_t pid)
-{
-  FAR struct join_s *prev;
-  FAR struct join_s *join;
-
-  /* Find the entry with the matching pid */
-
-  for (prev = NULL, join = group->tg_joinhead;
-       (join && (pid_t)join->thread != pid);
-       prev = join, join = join->next);
-
-  /* Remove it from the data set. */
-
-  /* First check if this is the entry at the head of the list. */
-
-  if (join)
-    {
-      if (!prev)
-        {
-          /* Check if this is the only entry in the list */
-
-          if (!join->next)
-            {
-              group->tg_joinhead = NULL;
-              group->tg_jointail = NULL;
-            }
-
-          /* Otherwise, remove it from the head of the list */
-
-          else
-            {
-              group->tg_joinhead = join->next;
-            }
-        }
-
-      /* It is not at the head of the list, check if it is at the tail. */
-
-      else if (!join->next)
-        {
-          group->tg_jointail = prev;
-          prev->next = NULL;
-        }
-
-      /* No, remove it from the middle of the list. */
-
-      else
-        {
-          prev->next = join->next;
-        }
-    }
-}
 
 /****************************************************************************
  * Public Functions
@@ -189,59 +63,53 @@ static void pthread_removejoininfo(FAR struct task_group_s *group,
 int pthread_completejoin(pid_t pid, FAR void *exit_value)
 {
   FAR struct tcb_s *tcb = nxsched_get_tcb(pid);
-  FAR struct task_group_s *group = tcb ? tcb->group : NULL;
-  FAR struct join_s *pjoin;
-  int ret;
+  FAR struct task_group_s *group = tcb->group;
+  FAR struct task_join_s *join;
+  FAR struct tcb_s *wtcb;
+  FAR sq_entry_t *curr;
+  FAR sq_entry_t *next;
+  int ret = OK;
 
-  sinfo("pid=%d exit_value=%p group=%p\n", pid, exit_value, group);
-  DEBUGASSERT(group && tcb);
+  sinfo("pid=%d exit_value=%p\n", pid, exit_value);
 
-  /* First, find thread's structure in the private data set. */
+  nxrmutex_lock(&group->tg_joinlock);
 
-  nxmutex_lock(&group->tg_joinlock);
-  ret = pthread_findjoininfo(group, pid, &pjoin);
-  if (ret != OK)
+  if (!sq_empty(&tcb->join_queue))
     {
-      nxmutex_unlock(&group->tg_joinlock);
-
-      return ((tcb->flags & TCB_FLAG_DETACHED) ||
-              (tcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_PTHREAD) ?
-              OK : ERROR;
-    }
-  else
-    {
-      FAR struct pthread_tcb_s *ptcb = (FAR struct pthread_tcb_s *)tcb;
-      bool waiters;
-
-      /* Save the return exit value in the thread structure. */
-
-      pjoin->terminated = true;
-      pjoin->exit_value = exit_value;
-      ptcb->join_complete = true;
-
-      /* Notify waiters of the availability of the exit value */
-
-      waiters = pthread_notifywaiters(pjoin);
-
-      /* If there are no waiters and if the thread is marked as detached.
-       * then discard the join information now.  Otherwise, the pthread
-       * join logic will call pthread_destroyjoin() when all of the threads
-       * have sampled the exit value.
-       */
-
-      if (!waiters && pjoin->detached)
+      sq_for_every_safe(&tcb->join_queue, curr, next)
         {
-          pthread_destroyjoin(group, pjoin);
+          /* Remove join entry from queue */
+
+          sq_rem(curr, &tcb->join_queue);
+
+          /* Get tcb entry which waiting for the join */
+
+          wtcb = container_of(curr, struct tcb_s, join_entry);
+
+          /* Save the return exit value in the thread structure. */
+
+          wtcb->join_val = exit_value;
+
+          /* Notify waiters of the availability of the exit value */
+
+          nxsem_post(&wtcb->join_sem);
         }
-
-      /* Giving the following semaphore will allow the waiters
-       * to call pthread_destroyjoin.
-       */
-
-      nxmutex_unlock(&group->tg_joinlock);
+    }
+  else if (!sq_is_singular(&tcb->group->tg_members))
+    {
+      ret = pthread_findjoininfo(tcb->group, pid, &join, true);
+      if (ret == OK)
+        {
+          join->detached = !!(tcb->flags & TCB_FLAG_DETACHED);
+          join->exit_value = exit_value;
+        }
     }
 
-  return OK;
+  tcb->flags |= TCB_FLAG_JOIN_COMPLETED;
+
+  nxrmutex_unlock(&group->tg_joinlock);
+
+  return ret;
 }
 
 /****************************************************************************
@@ -261,18 +129,15 @@ int pthread_completejoin(pid_t pid, FAR void *exit_value)
  ****************************************************************************/
 
 void pthread_destroyjoin(FAR struct task_group_s *group,
-                         FAR struct join_s *pjoin)
+                         FAR struct task_join_s *pjoin)
 {
   sinfo("pjoin=%p\n", pjoin);
 
   /* Remove the join info from the set of joins */
 
-  pthread_removejoininfo(group, (pid_t)pjoin->thread);
-
-  /* Destroy its semaphores */
-
-  nxsem_destroy(&pjoin->data_sem);
-  nxsem_destroy(&pjoin->exit_sem);
+  nxrmutex_lock(&group->tg_joinlock);
+  sq_rem(&pjoin->entry, &group->tg_joinqueue);
+  nxrmutex_unlock(&group->tg_joinlock);
 
   /* And deallocate the pjoin structure */
 

--- a/sched/pthread/pthread_create.c
+++ b/sched/pthread/pthread_create.c
@@ -40,6 +40,7 @@
 #include <nuttx/kmalloc.h>
 #include <nuttx/pthread.h>
 
+#include "task/task.h"
 #include "sched/sched.h"
 #include "group/group.h"
 #include "clock/clock.h"
@@ -216,6 +217,10 @@ int nx_pthread_create(pthread_trampoline_t trampoline, FAR pthread_t *thread,
     }
 
   ptcb->cmn.flags |= TCB_FLAG_FREE_TCB;
+
+  /* Initialize the task join */
+
+  nxtask_joininit(&ptcb->cmn);
 
   /* Bind the parent's group to the new TCB (we have not yet joined the
    * group).

--- a/sched/sched/sched_releasetcb.c
+++ b/sched/sched/sched_releasetcb.c
@@ -31,6 +31,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/sched.h>
 
+#include "task/task.h"
 #include "sched/sched.h"
 #include "group/group.h"
 #include "timer/timer.h"
@@ -164,9 +165,13 @@ int nxsched_release_tcb(FAR struct tcb_s *tcb, uint8_t ttype)
 
       group_leave(tcb);
 
+#ifndef CONFIG_DISABLE_PTHREAD
+      /* Destroy the pthread join mutex */
+
+      nxtask_joindestroy(tcb);
+
       /* Kernel thread and group still reference by pthread */
 
-#ifndef CONFIG_DISABLE_PTHREAD
       if (ttype != TCB_FLAG_TTYPE_PTHREAD)
         {
           ttcb = (FAR struct task_tcb_s *)tcb;

--- a/sched/task/CMakeLists.txt
+++ b/sched/task/CMakeLists.txt
@@ -36,6 +36,7 @@ set(SRCS
     task_cancelpt.c
     task_terminate.c
     task_gettid.c
+    task_join.c
     exit.c)
 
 if(CONFIG_SCHED_HAVE_PARENT)

--- a/sched/task/Make.defs
+++ b/sched/task/Make.defs
@@ -22,7 +22,7 @@ CSRCS += task_create.c task_init.c task_setup.c task_activate.c
 CSRCS += task_start.c task_delete.c task_exit.c task_exithook.c
 CSRCS += task_getgroup.c task_getpid.c task_prctl.c task_recover.c
 CSRCS += task_restart.c task_spawnparms.c task_cancelpt.c task_terminate.c
-CSRCS += task_gettid.c exit.c
+CSRCS += task_gettid.c exit.c task_join.c
 
 ifeq ($(CONFIG_SCHED_HAVE_PARENT),y)
 CSRCS += task_getppid.c task_reparent.c

--- a/sched/task/task.h
+++ b/sched/task/task.h
@@ -58,4 +58,14 @@ void nxtask_recover(FAR struct tcb_s *tcb);
 
 bool nxnotify_cancellation(FAR struct tcb_s *tcb);
 
+/* Task Join */
+
+#ifndef CONFIG_DISABLE_PTHREAD
+void nxtask_joininit(FAR struct tcb_s *tcb);
+void nxtask_joindestroy(FAR struct tcb_s *tcb);
+#else
+#  define nxtask_joininit(tcb)
+#  define nxtask_joindestroy(tcb)
+#endif
+
 #endif /* __SCHED_TASK_TASK_H */

--- a/sched/task/task_fork.c
+++ b/sched/task/task_fork.c
@@ -144,6 +144,10 @@ FAR struct task_tcb_s *nxtask_setup_fork(start_t retaddr)
 
   child->cmn.flags |= TCB_FLAG_FREE_TCB;
 
+  /* Initialize the task join */
+
+  nxtask_joininit(&child->cmn);
+
   /* Allocate a new task group with the same privileges as the parent */
 
   ret = group_initialize(child, ttype);

--- a/sched/task/task_init.c
+++ b/sched/task/task_init.c
@@ -118,6 +118,12 @@ int nxtask_init(FAR struct task_tcb_s *tcb, const char *name, int priority,
       return ret;
     }
 
+#ifndef CONFIG_DISABLE_PTHREAD
+  /* Initialize the task join */
+
+  nxtask_joininit(&tcb->cmn);
+#endif
+
   /* Duplicate the parent tasks environment */
 
   ret = env_dup(tcb->cmn.group, envp);
@@ -203,6 +209,8 @@ errout_with_group:
           up_release_stack(&tcb->cmn, ttype);
         }
     }
+
+  nxtask_joindestroy(&tcb->cmn);
 
   group_leave(&tcb->cmn);
 


### PR DESCRIPTION
## Summary

sched/pthread/join: refactor pthread join to support join task

1. add support to join main task

```
| static pthread_t self;
|
| static void *join_task(void *arg)
| {
|   int ret;
|   ret = pthread_join(self, NULL);          <---  /* Fix Task could not be joined */
|   return NULL;
| }
|
| int main(int argc, char *argv[])
| {
|   pthread_t thread;
|
|   self = pthread_self();
|
|   pthread_create(&thread, NULL, join_task, NULL);
|   sleep(1);
|
|   pthread_exit(NULL);
|   return 0;
| }
```

2. Detach active thread will not alloc for additional join, just update the task flag.
3. Remove the return value waiting lock logic (data_sem),
   the return value will be stored in the waiting tcb.
4. Revise the return value of pthread_join(), consistent with linux
   e.g:
       Joining a detached and canceled thread should return EINVAL, not ESRCH

```
   https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_join.html

   [EINVAL]
      The value specified by thread does not refer to a joinable thread.
```

NOTE:

This PR will not increase stack usage, but `struct tcb_s` will increase by 32 bytes.

## Impact

Depends on: https://github.com/apache/nuttx-apps/pull/2329

N/A

## Testing

rv-virt:ksmp64
sim/citest
  ostest/usrsocktest/scanftest/getprime
