### PR TITLE
arch/x86_64: move common Make.defs to common

### DIFF
--- a/arch/x86_64/src/common/Make.defs
+++ b/arch/x86_64/src/common/Make.defs
@@ -1,0 +1,30 @@
+############################################################################
+# arch/x86_64/src/common/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+# Common x86_64 files
+
+CMN_CSRCS += x86_64_allocateheap.c x86_64_copystate.c x86_64_exit.c
+CMN_CSRCS += x86_64_getintstack.c x86_64_mdelay.c x86_64_initialize.c
+CMN_CSRCS += x86_64_modifyreg8.c x86_64_modifyreg16.c x86_64_modifyreg32.c
+CMN_CSRCS += x86_64_nputs.c x86_64_switchcontext.c x86_64_udelay.c
+
+ifeq ($(CONFIG_PCI),y)
+CMN_CSRCS += x86_64_pci.c
+endif

--- a/arch/x86_64/src/intel64/Make.defs
+++ b/arch/x86_64/src/intel64/Make.defs
@@ -18,16 +18,7 @@
 #
 ############################################################################
 
-# Common x86_64 and intel64 files
-
-CMN_CSRCS += x86_64_allocateheap.c x86_64_copystate.c x86_64_exit.c
-CMN_CSRCS += x86_64_getintstack.c x86_64_mdelay.c x86_64_initialize.c
-CMN_CSRCS += x86_64_modifyreg8.c x86_64_modifyreg16.c x86_64_modifyreg32.c
-CMN_CSRCS += x86_64_nputs.c x86_64_switchcontext.c x86_64_udelay.c
-
-ifeq ($(CONFIG_PCI),y)
-CMN_CSRCS += x86_64_pci.c
-endif
+include common/Make.defs
 
 CMN_CSRCS += intel64_createstack.c intel64_initialstate.c intel64_irq.c
 CMN_CSRCS += intel64_map_region.c intel64_regdump.c intel64_releasestack.c


### PR DESCRIPTION
## Summary
arch/x86_64: move common Make.defs to common

## Impact
cosmetic change to simplify intel64 Make.defs

## Testing
CI
