### PR TITLE
stm32_serial.c: fix compilation of onewire driver mode

### DIFF
--- a/arch/arm/src/stm32/stm32_serial.c
+++ b/arch/arm/src/stm32/stm32_serial.c
@@ -2227,11 +2227,14 @@ static int up_interrupt(int irq, void *context, void *arg)
 static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
 {
 #if defined(CONFIG_SERIAL_TERMIOS) || defined(CONFIG_SERIAL_TIOCSERGSTRUCT) \
-    || defined(CONFIG_STM32_SERIALBRK_BSDCOMPAT)
+    || defined(CONFIG_STM32_SERIALBRK_BSDCOMPAT) \
+    || defined(CONFIG_STM32_USART_SINGLEWIRE)
   struct inode      *inode = filep->f_inode;
   struct uart_dev_s *dev   = inode->i_private;
 #endif
-#if defined(CONFIG_SERIAL_TERMIOS) || defined(CONFIG_STM32_SERIALBRK_BSDCOMPAT)
+#if defined(CONFIG_SERIAL_TERMIOS) \
+    || defined(CONFIG_STM32_SERIALBRK_BSDCOMPAT) \
+    || defined(CONFIG_STM32_USART_SINGLEWIRE)
   struct up_dev_s   *priv  = (struct up_dev_s *)dev->priv;
 #endif
   int                ret   = OK;


### PR DESCRIPTION
Onewire driver wants to use "struct up_dev_s *priv", which is extracted from "struct uart_dev_s" and "struct inode". But inode and uart dev are only declared when TERMIOS or BSDCOMPAT is also enabled. Without these driver fails to compile with missing declaration errors. Adding some additional "#if defined()" to these declarations fix the issue and driver compiles and works properly (tested with ds18b20 temp sensor).

