### PR TITLE
Revert "assert/panic: disable panic message to save the code size"

### DIFF
--- a/include/assert.h
+++ b/include/assert.h
@@ -72,6 +72,10 @@
 #  define __ASSERT_LINE__ 0
 #endif
 
+#define PANIC() __assert(__ASSERT_FILE__, __ASSERT_LINE__, "panic")
+#define PANIC_WITH_REGS(msg, regs) _assert(__ASSERT_FILE__, \
+                                           __ASSERT_LINE__, msg, regs)
+
 #define __ASSERT__(f, file, line, _f) \
   do                                  \
     {                                 \
@@ -97,9 +101,6 @@
 #endif
 
 #ifdef CONFIG_DEBUG_ASSERTIONS
-#  define PANIC() __assert(__ASSERT_FILE__, __ASSERT_LINE__, "panic")
-#  define PANIC_WITH_REGS(msg, regs) _assert(__ASSERT_FILE__, \
-                                           __ASSERT_LINE__, msg, regs)
 #  define DEBUGPANIC()   __assert(__DEBUG_ASSERT_FILE__, __DEBUG_ASSERT_LINE__, "panic")
 #  define DEBUGASSERT(f) _ASSERT(f, __DEBUG_ASSERT_FILE__, __DEBUG_ASSERT_LINE__)
 #  define DEBUGVERIFY(f) _VERIFY(f, __DEBUG_ASSERT_FILE__, __DEBUG_ASSERT_LINE__)
@@ -107,8 +108,6 @@
 #  define DEBUGPANIC()
 #  define DEBUGASSERT(f) ((void)(1 || (f)))
 #  define DEBUGVERIFY(f) ((void)(f))
-#  define PANIC() do { } while (1)
-#  define PANIC_WITH_REGS(msg, regs) PANIC()
 #endif
 
 /* The C standard states that if NDEBUG is defined, assert will do nothing.


### PR DESCRIPTION
## Summary

This reverts commit 9b1c451f2f881077cd7d56f6496ea3c06ea30f17, introduced by [#11796](https://github.com/apache/nuttx/pull/11796)

Please note that the introduced change replaces the `PANIC` from the `_assert` to an infinite loop when `CONFIG_DEBUG_ASSERTIONS` is not selected. Although it prevents message logs (and saves code size), the `__assert`  (and `_assert`) function also calls other functions like `panic_notifier_call_chain` and `board_reset`, which would not occur if `CONFIG_DEBUG_ASSERTIONS` is not selected.

The correct approach to save code would be to disable some of the log messages on `sched/misc/assert.c` when `CONFIG_DEBUG_ASSERTIONS` is not selected or substitute `PANIC` to `DEBUGPANIC` when applicable.

## Impact

Without it, it prevented important functions to run when panic'ed.

## Testing

Local testing with ESP32-DevKitC V4
