### PR TITLE
binfmt/loadmodule: replace kmm_free() to lib_free()

### DIFF
--- a/binfmt/binfmt_loadmodule.c
+++ b/binfmt/binfmt_loadmodule.c
@@ -194,7 +194,7 @@ int load_module(FAR struct binary_s *bin, FAR const char *filename,
 
                   /* Free the allocated fullpath */
 
-                  kmm_free(fullpath);
+                  lib_free(fullpath);
 
                   /* Break out of the loop with ret == OK on success */
 


### PR DESCRIPTION
## Summary

binfmt/loadmodule: replace kmm_free() to lib_free()

replace kmm_free() to lib_free() unify alloc and free method

## Impact

N/A

## Testing

ci-check