### PR TITLE
Improve export by adding NuttX current target (arch, chip, board)

### DIFF
--- a/tools/Export.mk
+++ b/tools/Export.mk
@@ -80,6 +80,17 @@ endif
 	@echo "OBJDUMP=\"$(OBJDUMP)\"" >> $(EXPORTDIR)/makeinfo.sh
 	@echo "OBJEXT=\"$(OBJEXT)\"" >> $(EXPORTDIR)/makeinfo.sh
 	@echo "STRIP=\"$(STRIP)\"" >> $(EXPORTDIR)/makeinfo.sh
+	@echo "NUTTX_ARCH=\"$(CONFIG_ARCH)\"" >> $(EXPORTDIR)/makeinfo.sh
+ifdef NUTTX_ARCH_CHIP
+	@echo "NUTTX_ARCH_CHIP=\"$(CONFIG_ARCH_CHIP)\"" >> $(EXPORTDIR)/makeinfo.sh
+else
+	@echo "NUTTX_ARCH_CHIP=\"$(ARCH_CHIP_CUSTOM_NAME)\"" >> $(EXPORTDIR)/makeinfo.sh
+endif
+ifdef CONFIG_ARCH_BOARD
+	@echo "NUTTX_BOARD=\"$(CONFIG_ARCH_BOARD)\"" >> $(EXPORTDIR)/makeinfo.sh
+else
+	@echo "NUTTX_BOARD=\"$(CONFIG_ARCH_BOARD_CUSTOM_NAME)\"" >> $(EXPORTDIR)/makeinfo.sh
+endif
 	$(Q) chmod 755 $(EXPORTDIR)/makeinfo.sh
 
 clean:

--- a/tools/mkexport.sh
+++ b/tools/mkexport.sh
@@ -257,6 +257,9 @@ echo "HOSTLDFLAGS      = ${HOSTLDFLAGS}" >>"${EXPORTDIR}/scripts/Make.defs"
 echo "HOSTEXEEXT       = ${HOSTEXEEXT}" >>"${EXPORTDIR}/scripts/Make.defs"
 echo "LDNAME           = ${LDNAME}" >>"${EXPORTDIR}/scripts/Make.defs"
 echo "LDELFFLAGS       = ${LDELFFLAGS}" >>"${EXPORTDIR}/scripts/Make.defs"
+echo "NUTTX_ARCH       = ${NUTTX_ARCH}" >>"${EXPORTDIR}/scripts/Make.defs"
+echo "NUTTX_ARCH_CHIP  = ${NUTTX_ARCH_CHIP}" >>"${EXPORTDIR}/scripts/Make.defs"
+echo "NUTTX_BOARD      = ${NUTTX_BOARD}" >>"${EXPORTDIR}/scripts/Make.defs"
 
 echo "set(ARCHCFLAGS          \"${ARCHCFLAGS}\")"       > "${EXPORTDIR}/scripts/target.cmake"
 echo "set(ARCHCPUFLAGS        \"${ARCHCPUFLAGS}\")"     >>"${EXPORTDIR}/scripts/target.cmake"
@@ -283,6 +286,9 @@ echo "set(HOSTLDFLAGS         \"${HOSTLDFLAGS}\")"      >>"${EXPORTDIR}/scripts/
 echo "set(HOSTEXEEXT          \"${HOSTEXEEXT}\")"       >>"${EXPORTDIR}/scripts/target.cmake"
 echo "set(LDNAME              \"${LDNAME}\")"           >>"${EXPORTDIR}/scripts/target.cmake"
 echo "set(LDELFFLAGS          \"${LDELFFLAGS}\")"       >>"${EXPORTDIR}/scripts/target.cmake"
+echo "set(NUTTX_ARCH          \"${NUTTX_ARCH}\")"       >>"${EXPORTDIR}/scripts/target.cmake"
+echo "set(NUTTX_ARCH_CHIP     \"${NUTTX_ARCH_CHIP}\")"  >>"${EXPORTDIR}/scripts/target.cmake"
+echo "set(NUTTX_BOARD         \"${NUTTX_BOARD}\")"      >>"${EXPORTDIR}/scripts/target.cmake"
 
 
 # Additional compilation options when the kernel is built

--- a/tools/toolchain.cmake.export
+++ b/tools/toolchain.cmake.export
@@ -18,14 +18,16 @@ set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${NUTTX_PATH}/include
 set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES
     ${NUTTX_PATH}/include/libcxx ${NUTTX_PATH}/include ${NUTTX_PATH}/arch/chip)
 
+file(GLOB STARTUP_OBJS ${NUTTX_PATH}/startup/*)
+
 add_compile_options(-nostdlib)
 add_compile_options(-ffunction-sections -fdata-sections)
 
 set(CMAKE_C_LINK_EXECUTABLE
-    "<CMAKE_LINKER> ${LDFLAGS} --entry=__start -T${LINKER_SCRIPT} <OBJECTS> -o <TARGET> <LINK_LIBRARIES> -L${NUTTX_PATH}/libs --start-group ${LDLIBS} ${EXTRA_LIBS} --end-group"
+    "<CMAKE_LINKER> ${LDFLAGS} --entry=__start -T${LINKER_SCRIPT} <OBJECTS> ${STARTUP_OBJS} -o <TARGET> <LINK_LIBRARIES> -L${NUTTX_PATH}/libs --start-group ${LDLIBS} ${EXTRA_LIBS} --end-group"
 )
 set(CMAKE_CXX_LINK_EXECUTABLE
-    "<CMAKE_LINKER> ${LDFLAGS} --entry=__start -T${LINKER_SCRIPT} <OBJECTS> -o <TARGET> <LINK_LIBRARIES> -L${NUTTX_PATH}/libs --start-group ${LDLIBS} ${EXTRA_LIBS} --end-group"
+    "<CMAKE_LINKER> ${LDFLAGS} --entry=__start -T${LINKER_SCRIPT} <OBJECTS> ${STARTUP_OBJS} -o <TARGET> <LINK_LIBRARIES> -L${NUTTX_PATH}/libs --start-group ${LDLIBS} ${EXTRA_LIBS} --end-group"
 )
 
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)


### PR DESCRIPTION
## Summary
Add variables that describe NuttX current build (board, arch, chip)
Fix export: startups files are not added at link step

## Impact

## Testing
picopi:usbnsh with an external project
visual check on export archive files
