### PR TITLE
net/tcp: return true only when send window updates

### DIFF
--- a/net/tcp/tcp_input.c
+++ b/net/tcp/tcp_input.c
@@ -254,9 +254,11 @@ static bool tcp_snd_wnd_update(FAR struct tcp_conn_s *conn,
 
       conn->snd_wl1 = seq;
       conn->snd_wl2 = ackseq;
-      conn->snd_wnd = wnd;
-
-      return true;
+      if (conn->snd_wnd != wnd)
+        {
+          conn->snd_wnd = wnd;
+          return true;
+        }
     }
 
   return false;


### PR DESCRIPTION
## Summary
return true even when window has not changed will cause delayed ack cannot take effect.

## Impact

## Testing
sim:local and cortex-m33
