### PR TITLE
risc-v/k230: fix k230_hart_is_big issue

### DIFF
--- a/arch/risc-v/src/k230/chip.h
+++ b/arch/risc-v/src/k230/chip.h
@@ -73,5 +73,11 @@
 #endif /* !defined(CONFIG_SMP) && defined(CONFIG_ARCH_USE_S_MODE) */
 #endif /* CONFIG_ARCH_INTERRUPTSTACK > 15 */
 
-#endif /* __ASSEMBLY__  */
+#else  /* ! __ASSEMBLY__ */
+
+/* always show on uart0 */
+
+#define k230_putc(c)  (*(volatile uint32_t*)0x91400000 = c)
+
+#endif /* __ASSEMBLY__ */
 #endif /* __ARCH_RISCV_SRC_K230_CHIP_H */


### PR DESCRIPTION


## Summary
This patch fixes the issue that k230_hart_is_big() doesn't work in S-mode. It also adds convenient debug macros to ease debugging process

## Impact
K230 devices

## Testing
Checked with CanMV230

