### PR TITLE
boards/arm/stm32/stm32f429i-disco add CAN driver support

### DIFF
--- a/boards/arm/stm32/stm32f429i-disco/include/board.h
+++ b/boards/arm/stm32/stm32f429i-disco/include/board.h
@@ -205,6 +205,11 @@
 
 #define GPIO_USART3_RX GPIO_USART3_RX_1
 #define GPIO_USART3_TX GPIO_USART3_TX_1
+
+/* CAN: */
+#define GPIO_CAN1_RX GPIO_CAN1_RX_2
+#define GPIO_CAN1_TX GPIO_CAN1_TX_2
+
 /* PWM
  *
  * The STM32F4 Discovery has no real on-board PWM devices, but the board can

--- a/boards/arm/stm32/stm32f429i-disco/src/CMakeLists.txt
+++ b/boards/arm/stm32/stm32f429i-disco/src/CMakeLists.txt
@@ -68,6 +68,10 @@ if(CONFIG_ADC)
   list(APPEND SRCS stm32_adc.c)
 endif()
 
+if(CONFIG_STM32_CAN_CHARDRIVER)
+  list(APPEND SRCS stm32_can.c)
+endif()
+
 if(CONFIG_STM32F429I_DISCO_HIGHPRI)
   list(APPEND SRCS stm32_highpri.c)
 endif()

--- a/boards/arm/stm32/stm32f429i-disco/src/Make.defs
+++ b/boards/arm/stm32/stm32f429i-disco/src/Make.defs
@@ -71,6 +71,10 @@ ifeq ($(CONFIG_ADC),y)
 CSRCS += stm32_adc.c
 endif
 
+ifeq ($(CONFIG_STM32_CAN_CHARDRIVER),y)
+CSRCS += stm32_can.c
+endif
+
 ifeq ($(CONFIG_STM32F429I_DISCO_HIGHPRI),y)
 CSRCS += stm32_highpri.c
 endif

--- a/boards/arm/stm32/stm32f429i-disco/src/stm32_bringup.c
+++ b/boards/arm/stm32/stm32f429i-disco/src/stm32_bringup.c
@@ -415,6 +415,16 @@ int stm32_bringup(void)
     }
 #endif
 
+#ifdef CONFIG_STM32_CAN_CHARDRIVER
+  /* Initialize CAN and register the CAN driver. */
+
+  ret = stm32_can_setup();
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: stm32_can_setup failed: %d\n", ret);
+    }
+#endif
+
   UNUSED(ret);
   return OK;
 }

--- a/boards/arm/stm32/stm32f429i-disco/src/stm32_can.c
+++ b/boards/arm/stm32/stm32f429i-disco/src/stm32_can.c
@@ -1,0 +1,100 @@
+/****************************************************************************
+ * boards/arm/stm32/stm32f429i-disco/src/stm32_can.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <errno.h>
+#include <debug.h>
+
+#include <nuttx/can/can.h>
+#include <arch/board/board.h>
+
+#include "chip.h"
+#include "arm_internal.h"
+#include "stm32.h"
+#include "stm32_can.h"
+#include "stm32f429i-disco.h"
+
+#ifdef CONFIG_CAN
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Configuration ************************************************************/
+
+#if defined(CONFIG_STM32_CAN1) && defined(CONFIG_STM32_CAN2)
+#  warning "Both CAN1 and CAN2 are enabled.  Assuming only CAN1."
+#  undef CONFIG_STM32_CAN2
+#endif
+
+#ifdef CONFIG_STM32_CAN1
+#  define CAN_PORT 1
+#else
+#  define CAN_PORT 2
+#endif
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: stm32_can_setup
+ *
+ * Description:
+ *  Initialize CAN and register the CAN device
+ *
+ ****************************************************************************/
+
+int stm32_can_setup(void)
+{
+#if defined(CONFIG_STM32_CAN1) || defined(CONFIG_STM32_CAN2)
+  struct can_dev_s *can;
+  int ret;
+
+  /* Call stm32_caninitialize() to get an instance of the CAN interface */
+
+  can = stm32_caninitialize(CAN_PORT);
+  if (can == NULL)
+    {
+      canerr("ERROR:  Failed to get CAN interface\n");
+      return -ENODEV;
+    }
+
+  /* Register the CAN driver at "/dev/can0" */
+
+  ret = can_register("/dev/can0", can);
+  if (ret < 0)
+    {
+      canerr("ERROR: can_register failed: %d\n", ret);
+      return ret;
+    }
+
+  return OK;
+#else
+  return -ENODEV;
+#endif
+}
+
+#endif /* CONFIG_CAN */

--- a/boards/arm/stm32/stm32f429i-disco/src/stm32f429i-disco.h
+++ b/boards/arm/stm32/stm32f429i-disco/src/stm32f429i-disco.h
@@ -388,5 +388,17 @@ int stm32_pwm_setup(void);
 int stm32_adc_setup(void);
 #endif
 
+/****************************************************************************
+ * Name: stm32_can_setup
+ *
+ * Description:
+ *  Initialize CAN and register the CAN device
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_STM32_CAN_CHARDRIVER
+int stm32_can_setup(void);
+#endif
+
 #endif /* __ASSEMBLY__ */
 #endif /* __BOARDS_ARM_STM32_STM32F429I_DISCO_SRC_STM32F429I_DISCO_H */


### PR DESCRIPTION
## Summary
add CAN driver support
## Impact

## Testing
on fire development board