### PR TITLE
tools/ci:  Fixed the cmake build and installation of Bloaty in the darwin.sh script.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,7 +197,7 @@ jobs:
           cache-name: ${{ runner.os }}-cache-tools
         with:
           path: ./sources/tools
-          key: ${{ runner.os }}-tools-${{ hashFiles('./sources/nuttx/tools/ci/cibuild.sh') }}
+          key: ${{ runner.os }}-tools-${{ hashFiles('./sources/nuttx/tools/ci/platforms/darwin.sh') }}
 
       - name: Export NuttX Repo SHA
         run: echo "nuttx_sha=`git -C sources/nuttx rev-parse HEAD`" >> $GITHUB_ENV

--- a/tools/ci/platforms/darwin.sh
+++ b/tools/ci/platforms/darwin.sh
@@ -103,10 +103,12 @@ bloaty() {
     # https://github.com/google/bloaty/pull/326
     git checkout 52948c107c8f81045e7f9223ec02706b19cfa882
     mkdir -p "${NUTTXTOOLS}"/bloaty
-    cmake -D BLOATY_PREFER_SYSTEM_CAPSTONE=NO -DCMAKE_SYSTEM_PREFIX_PATH="${NUTTXTOOLS}"/bloaty
-    make install -j 4
+    cmake -B build/bloaty -D BLOATY_PREFER_SYSTEM_CAPSTONE=NO -D CMAKE_INSTALL_PREFIX="${NUTTXTOOLS}"/bloaty
+    cmake --build build/bloaty
+    cmake --build build/bloaty --target install
     cd "${NUTTXTOOLS}"
     rm -rf bloaty-src
+    ls -a "${NUTTXTOOLS}"/bloaty
   fi
 
   command bloaty --version


### PR DESCRIPTION
## Summary
- function bloaty() Add  -D CMAKE_INSTALL_PREFIX="${NUTTXTOOLS}"/bloaty. 
           Improves workflow execution time because it is now cached.

- Changed reference file to calculate the hash for key of actions/cache@v4. Now it is tools/ci/platforms/**darwin.sh**.
## Impact
None
## Testing
Pass CI  [test](https://github.com/simbit18/nuttx-testing-ci/actions/runs/8330882530)
