### PR TITLE
Fix user task exception handling

### DIFF
--- a/sched/group/group_killchildren.c
+++ b/sched/group/group_killchildren.c
@@ -181,30 +181,34 @@ int group_kill_children(FAR struct tcb_s *tcb)
 
 #if defined(CONFIG_GROUP_KILL_CHILDREN_TIMEOUT_MS) && \
             CONFIG_GROUP_KILL_CHILDREN_TIMEOUT_MS != 0
-  /* Send SIGTERM for each first */
 
-  group_foreachchild(tcb->group, group_kill_children_handler,
-                     (FAR void *)((uintptr_t)tcb->pid));
-
-  /* Wait a bit for child exit */
-
-  ret = CONFIG_GROUP_KILL_CHILDREN_TIMEOUT_MS;
-  while (1)
+  if ((tcb->flags & TCB_FLAG_FORCED_CANCEL) == 0)
     {
-      if (sq_empty(&tcb->group->tg_members) ||
-          sq_is_singular(&tcb->group->tg_members))
-        {
-          break;
-        }
+      /* Send SIGTERM for each first */
 
-      nxsig_usleep(USEC_PER_MSEC);
+      group_foreachchild(tcb->group, group_kill_children_handler,
+                         (FAR void *)((uintptr_t)tcb->pid));
+
+      /* Wait a bit for child exit */
+
+      ret = CONFIG_GROUP_KILL_CHILDREN_TIMEOUT_MS;
+      while (1)
+        {
+          if (sq_empty(&tcb->group->tg_members) ||
+              sq_is_singular(&tcb->group->tg_members))
+            {
+              break;
+            }
+
+          nxsig_usleep(USEC_PER_MSEC);
 
 #  if CONFIG_GROUP_KILL_CHILDREN_TIMEOUT_MS > 0
-      if (--ret < 0)
-        {
-          break;
-        }
+          if (--ret < 0)
+            {
+              break;
+            }
 #  endif
+        }
     }
 #endif
 


### PR DESCRIPTION
## Summary

If an user process causes an illegal exception, we want to just kill the user process, not cause system panic. Add this functionality for the riscv_exception.

The group_killchildren is modified in a way that if the parent task is terminated forcefully, it also terminates all the children the same way; i.e. not via signal. This allows terminating all the children also from within an exception.

Also fix the _assert printout. Currently the assert prints out the information about the task to which we are returning from exception. This is not necessarily the same as the one that causes it.

## Impact

Enable user-side crash on RISC-V platforms, e.g. illegal memory accesses w.o. crashing the whole system.

## Testing

Tested on MPFS RISC-V platform, in CONFIG_BUILD_KERNEL.
