### PR TITLE
arm64_mmu: Add data synchronization barrier after page tables are written

### DIFF
--- a/arch/arm64/src/common/arm64_mmu.c
+++ b/arch/arm64/src/common/arm64_mmu.c
@@ -536,6 +536,7 @@ static void enable_mmu_el1(unsigned int flags)
 
   /* Ensure these changes are seen before MMU is enabled */
 
+  ARM64_DSB();
   ARM64_ISB();
 
   /* Enable the MMU and data cache */


### PR DESCRIPTION
## Summary
The page tables must be committed to system memory before we can proceed enabling the MMU. ISB() is not enough to do this.

## Impact
Ensure the translation tables are in system memory (and not CPU cache) before enabling the MMU.
## Testing
i.MX93
