### PR TITLE
sched/wqueue: replace some global variables to macro

### DIFF
--- a/sched/wqueue/kwork_cancel.c
+++ b/sched/wqueue/kwork_cancel.c
@@ -148,7 +148,7 @@ int work_cancel(int qid, FAR struct work_s *work)
     {
       /* Cancel high priority work */
 
-      return work_qcancel((FAR struct kwork_wqueue_s *)&g_hpwork,
+      return work_qcancel((FAR struct kwork_wqueue_s *)&hpwork(),
                           -1, work);
     }
   else
@@ -158,7 +158,7 @@ int work_cancel(int qid, FAR struct work_s *work)
     {
       /* Cancel low priority work */
 
-      return work_qcancel((FAR struct kwork_wqueue_s *)&g_lpwork,
+      return work_qcancel((FAR struct kwork_wqueue_s *)&lpwork(),
                           -1, work);
     }
   else
@@ -196,7 +196,7 @@ int work_cancel_sync(int qid, FAR struct work_s *work)
     {
       /* Cancel high priority work */
 
-      return work_qcancel((FAR struct kwork_wqueue_s *)&g_hpwork,
+      return work_qcancel((FAR struct kwork_wqueue_s *)&hpwork(),
                           CONFIG_SCHED_HPNTHREADS, work);
     }
   else
@@ -206,7 +206,7 @@ int work_cancel_sync(int qid, FAR struct work_s *work)
     {
       /* Cancel low priority work */
 
-      return work_qcancel((FAR struct kwork_wqueue_s *)&g_lpwork,
+      return work_qcancel((FAR struct kwork_wqueue_s *)&lpwork(),
                           CONFIG_SCHED_LPNTHREADS, work);
     }
   else

--- a/sched/wqueue/kwork_inherit.c
+++ b/sched/wqueue/kwork_inherit.c
@@ -225,7 +225,7 @@ void lpwork_boostpriority(uint8_t reqprio)
 
   for (wndx = 0; wndx < CONFIG_SCHED_LPNTHREADS; wndx++)
     {
-      lpwork_boostworker(g_lpwork.worker[wndx].pid, reqprio);
+      lpwork_boostworker(lpwork().worker[wndx].pid, reqprio);
     }
 
   sched_unlock();
@@ -271,7 +271,7 @@ void lpwork_restorepriority(uint8_t reqprio)
 
   for (wndx = 0; wndx < CONFIG_SCHED_LPNTHREADS; wndx++)
     {
-      lpwork_restoreworker(g_lpwork.worker[wndx].pid, reqprio);
+      lpwork_restoreworker(lpwork().worker[wndx].pid, reqprio);
     }
 
   sched_unlock();

--- a/sched/wqueue/kwork_queue.c
+++ b/sched/wqueue/kwork_queue.c
@@ -67,7 +67,7 @@
 static void hp_work_timer_expiry(wdparm_t arg)
 {
   irqstate_t flags = enter_critical_section();
-  queue_work(g_hpwork, arg);
+  queue_work(hpwork(), arg);
   leave_critical_section(flags);
 }
 #endif
@@ -80,7 +80,7 @@ static void hp_work_timer_expiry(wdparm_t arg)
 static void lp_work_timer_expiry(wdparm_t arg)
 {
   irqstate_t flags = enter_critical_section();
-  queue_work(g_lpwork, arg);
+  queue_work(lpwork(), arg);
   leave_critical_section(flags);
 }
 #endif
@@ -152,7 +152,7 @@ int work_queue(int qid, FAR struct work_s *work, worker_t worker,
 
       if (!delay)
         {
-          queue_work(g_hpwork, work);
+          queue_work(hpwork(), work);
         }
       else
         {
@@ -169,7 +169,7 @@ int work_queue(int qid, FAR struct work_s *work, worker_t worker,
 
       if (!delay)
         {
-          queue_work(g_lpwork, work);
+          queue_work(lpwork(), work);
         }
       else
         {

--- a/sched/wqueue/kwork_thread.c
+++ b/sched/wqueue/kwork_thread.c
@@ -305,7 +305,7 @@ void work_foreach(int qid, work_foreach_t handler, FAR void *arg)
 #ifdef CONFIG_SCHED_HPWORK
   if (qid == HPWORK)
     {
-      wqueue  = (FAR struct kwork_wqueue_s *)&g_hpwork;
+      wqueue  = (FAR struct kwork_wqueue_s *)&hpwork();
       nthread = CONFIG_SCHED_HPNTHREADS;
     }
   else
@@ -313,7 +313,7 @@ void work_foreach(int qid, work_foreach_t handler, FAR void *arg)
 #ifdef CONFIG_SCHED_LPWORK
   if (qid == LPWORK)
     {
-      wqueue  = (FAR struct kwork_wqueue_s *)&g_lpwork;
+      wqueue  = (FAR struct kwork_wqueue_s *)&lpwork();
       nthread = CONFIG_SCHED_LPNTHREADS;
     }
   else
@@ -352,7 +352,7 @@ int work_start_highpri(void)
   return work_thread_create(HPWORKNAME, CONFIG_SCHED_HPWORKPRIORITY,
                             CONFIG_SCHED_HPWORKSTACKSIZE,
                             CONFIG_SCHED_HPNTHREADS,
-                            (FAR struct kwork_wqueue_s *)&g_hpwork);
+                            (FAR struct kwork_wqueue_s *)&hpwork());
 }
 #endif /* CONFIG_SCHED_HPWORK */
 
@@ -380,7 +380,7 @@ int work_start_lowpri(void)
   return work_thread_create(LPWORKNAME, CONFIG_SCHED_LPWORKPRIORITY,
                             CONFIG_SCHED_LPWORKSTACKSIZE,
                             CONFIG_SCHED_LPNTHREADS,
-                            (FAR struct kwork_wqueue_s *)&g_lpwork);
+                            (FAR struct kwork_wqueue_s *)&lpwork());
 }
 #endif /* CONFIG_SCHED_LPWORK */
 

--- a/sched/wqueue/wqueue.h
+++ b/sched/wqueue/wqueue.h
@@ -105,11 +105,15 @@ struct lp_wqueue_s
 #ifdef CONFIG_SCHED_HPWORK
 /* The state of the kernel mode, high priority work queue. */
 
+#define hpwork()          g_hpwork
+
 extern struct hp_wqueue_s g_hpwork;
 #endif
 
 #ifdef CONFIG_SCHED_LPWORK
 /* The state of the kernel mode, low priority work queue(s). */
+
+#define lpwork()          g_lpwork
 
 extern struct lp_wqueue_s g_lpwork;
 #endif


### PR DESCRIPTION
## Summary

sched/wqueue: replace some global variables to macro

replace to macro will help to extend the scheduling implementation

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

ci-check