### PR TITLE
arch/risc-v/src/common/supervisor/riscv_perform_syscall.c: Record the…

### DIFF
--- a/arch/risc-v/src/common/supervisor/riscv_perform_syscall.c
+++ b/arch/risc-v/src/common/supervisor/riscv_perform_syscall.c
@@ -28,6 +28,7 @@
 
 #include <nuttx/addrenv.h>
 
+#include "sched/sched.h"
 #include "riscv_internal.h"
 
 /****************************************************************************
@@ -59,6 +60,12 @@ void *riscv_perform_syscall(uintptr_t *regs)
 
   if (regs != CURRENT_REGS)
     {
+      /* Record the new "running" task.  g_running_tasks[] is only used by
+       * assertion logic for reporting crashes.
+       */
+
+      g_running_tasks[this_cpu()] = this_task();
+
       /* Restore the cpu lock */
 
       restore_critical_section();


### PR DESCRIPTION
… currently running task in risc-v syscall

If a context switch occurs in syscall, the g_running_task need to be recorded for assert logic. This copies the logic from arm platforms

This fixes the risc-v assert dump issue discussed already in #11944 

