### PR TITLE
stm32f7/stm32_foc.c: Set .info_get to foc_lower_ops

### DIFF
--- a/arch/arm/src/stm32f7/stm32_foc.c
+++ b/arch/arm/src/stm32f7/stm32_foc.c
@@ -718,6 +718,7 @@ static struct foc_lower_ops_s g_stm32_foc_ops =
   .start          = stm32_foc_start,
   .pwm_duty_set   = stm32_foc_pwm_duty_set,
   .pwm_off        = stm32_foc_pwm_off,
+  .info_get       = stm32_foc_info_get,
   .ioctl          = stm32_foc_ioctl,
   .bind           = stm32_foc_bind,
   .fault_clear    = stm32_foc_fault_clear,


### PR DESCRIPTION
## Summary
This fixes build error (Werror):

Error: chip/stm32_foc.c:1918:12: error: 'stm32_foc_info_get' defined but not used [-Werror=unused-function]
 1918 | static int stm32_foc_info_get(struct foc_dev_s *dev, struct foc_info_s *info)
      |            ^~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors

## Impact
Fix build error
## Testing
CI
