### PR TITLE
tools/ci/testlist/macos.dat: fix path esp32c3-legacy

### DIFF
--- a/tools/ci/testlist/macos.dat
+++ b/tools/ci/testlist/macos.dat
@@ -26,8 +26,8 @@
 # RISC-V
 
 /risc-v/bl602/bl602evb/configs/wifi
-/risc-v/esp32c3/esp32c3-devkit/configs/cxx
-/risc-v/esp32c3/esp32c3-devkit/configs/wifi
+/risc-v/esp32c3-legacy/esp32c3-devkit/configs/cxx
+/risc-v/esp32c3-legacy/esp32c3-devkit/configs/wifi
 
 # x86_64-elf-gcc from homebrew doesn't seem to
 # provide __udivdi3 etc for -m32, so we do not build


### PR DESCRIPTION
## Summary
The cxx and wifi configurations are currently only present in  [esp32c3-legacy](https://github.com/apache/nuttx/tree/master/boards/risc-v/esp32c3-legacy/esp32c3-devkit/configs)

Changed esp32c3-devkit to esp32c3-legacy

[macOS log](https://github.com/apache/nuttx/actions/runs/8372730024/job/22924414032#step:7:1759)
find: boards/risc-v/esp32c3/esp32c3-devkit/configs/cxx: No such file or directory
find: boards/risc-v/esp32c3/esp32c3-devkit/configs/wifi: No such file or directory

Related to these changes #11620

## Impact
none
## Testing

