### PR TITLE
sched/init: move task list table from data to bss

### DIFF
--- a/include/nuttx/init.h
+++ b/include/nuttx/init.h
@@ -38,13 +38,14 @@
  * initialization.
  */
 
-#define nxsched_initstate()       g_nx_initstate
+#define nxsched_set_initstate(s)  g_nx_initstate = (s)
+#define nxsched_get_initstate()   g_nx_initstate
 
-#define OSINIT_MM_READY()        (nxsched_initstate() >= OSINIT_MEMORY)
-#define OSINIT_HW_READY()        (nxsched_initstate() >= OSINIT_HARDWARE)
-#define OSINIT_OS_READY()        (nxsched_initstate() >= OSINIT_OSREADY)
-#define OSINIT_IDLELOOP()        (nxsched_initstate() >= OSINIT_IDLELOOP)
-#define OSINIT_OS_INITIALIZING() (nxsched_initstate()  < OSINIT_OSREADY)
+#define OSINIT_MM_READY()        (nxsched_get_initstate() >= OSINIT_MEMORY)
+#define OSINIT_HW_READY()        (nxsched_get_initstate() >= OSINIT_HARDWARE)
+#define OSINIT_OS_READY()        (nxsched_get_initstate() >= OSINIT_OSREADY)
+#define OSINIT_IDLELOOP()        (nxsched_get_initstate() >= OSINIT_IDLELOOP)
+#define OSINIT_OS_INITIALIZING() (nxsched_get_initstate()  < OSINIT_OSREADY)
 
 /****************************************************************************
  * Public Types

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -539,7 +539,7 @@ void nx_start(void)
 
   /* Boot up is complete */
 
-  nxsched_initstate() = OSINIT_BOOT;
+  nxsched_set_initstate(OSINIT_BOOT);
 
   /* Initialize RTOS Data ***************************************************/
 
@@ -555,7 +555,7 @@ void nx_start(void)
 
   /* Task lists are initialized */
 
-  nxsched_initstate() = OSINIT_TASKLISTS;
+  nxsched_set_initstate(OSINIT_TASKLISTS);
 
   /* Initialize RTOS facilities *********************************************/
 
@@ -641,7 +641,7 @@ void nx_start(void)
 
   /* The memory manager is available */
 
-  nxsched_initstate() = OSINIT_MEMORY;
+  nxsched_set_initstate(OSINIT_MEMORY);
 
   /* Initialize tasking data structures */
 
@@ -727,7 +727,7 @@ void nx_start(void)
 
   /* Hardware resources are now available */
 
-  nxsched_initstate() = OSINIT_HARDWARE;
+  nxsched_set_initstate(OSINIT_HARDWARE);
 
   /* Setup for Multi-Tasking ************************************************/
 
@@ -773,7 +773,7 @@ void nx_start(void)
 
   /* The OS is fully initialized and we are beginning multi-tasking */
 
-  nxsched_initstate() = OSINIT_OSREADY;
+  nxsched_set_initstate(OSINIT_OSREADY);
 
   /* Create initial tasks and bring-up the system */
 
@@ -781,7 +781,7 @@ void nx_start(void)
 
   /* Enter to idleloop */
 
-  nxsched_initstate() = OSINIT_IDLELOOP;
+  nxsched_set_initstate(OSINIT_IDLELOOP);
 
   /* Let other threads have access to the memory manager */
 

--- a/sched/irq/irq_csection.c
+++ b/sched/irq/irq_csection.c
@@ -192,7 +192,7 @@ try_again:
    * lists are valid.
    */
 
-  if (nxsched_initstate() >= OSINIT_TASKLISTS)
+  if (nxsched_get_initstate() >= OSINIT_TASKLISTS)
     {
       /* If called from an interrupt handler, then just take the spinlock.
        * If we are already in a critical section, this will lock the CPU
@@ -416,7 +416,7 @@ irqstate_t enter_critical_section(void)
    * lists have been initialized.
    */
 
-  if (!up_interrupt_context() && nxsched_initstate() >= OSINIT_TASKLISTS)
+  if (!up_interrupt_context() && nxsched_get_initstate() >= OSINIT_TASKLISTS)
     {
       FAR struct tcb_s *rtcb = this_task();
       DEBUGASSERT(rtcb != NULL);
@@ -463,7 +463,7 @@ void leave_critical_section(irqstate_t flags)
    * lists are valid.
    */
 
-  if (nxsched_initstate() >= OSINIT_TASKLISTS)
+  if (nxsched_get_initstate() >= OSINIT_TASKLISTS)
     {
       /* If called from an interrupt handler, then just release the
        * spinlock.  The interrupt handling logic should already hold the
@@ -608,7 +608,7 @@ void leave_critical_section(irqstate_t flags)
    * lists have been initialized.
    */
 
-  if (!up_interrupt_context() && nxsched_initstate() >= OSINIT_TASKLISTS)
+  if (!up_interrupt_context() && nxsched_get_initstate() >= OSINIT_TASKLISTS)
     {
       FAR struct tcb_s *rtcb = this_task();
       DEBUGASSERT(rtcb != NULL);
@@ -667,7 +667,7 @@ bool irq_cpu_locked(int cpu)
 
   /* g_cpu_irqset is not valid in early phases of initialization */
 
-  if (nxsched_initstate() < OSINIT_OSREADY)
+  if (nxsched_get_initstate() < OSINIT_OSREADY)
     {
       /* We are still single threaded.  In either state of g_cpu_irqlock,
        * the correct return value should always be false.

--- a/sched/sched/sched.h
+++ b/sched/sched/sched.h
@@ -251,7 +251,7 @@ extern volatile int g_npidhash;
  * ordered list or not.
  */
 
-extern const struct tasklist_s g_tasklisttable[NUM_TASK_STATES];
+extern struct tasklist_s g_tasklisttable[NUM_TASK_STATES];
 
 #ifndef CONFIG_SCHED_CPULOAD_NONE
 /* This is the total number of clock tick counts.  Essentially the

--- a/sched/sched/sched_idletask.c
+++ b/sched/sched/sched_idletask.c
@@ -62,7 +62,7 @@ bool sched_idletask(void)
    * have been initialized and, in that case, rtcb may be NULL.
    */
 
-  DEBUGASSERT(rtcb != NULL || nxsched_initstate() < OSINIT_TASKLISTS);
+  DEBUGASSERT(rtcb != NULL || nxsched_get_initstate() < OSINIT_TASKLISTS);
   if (rtcb != NULL)
     {
       /* The IDLE task TCB is distinguishable by a few things:


### PR DESCRIPTION
## Summary

sched/init: move task list table from data to bss
sched/init: move idle task initialize to inline function

N/A, help to extend the multi-core implementation

Signed-off-by: chao an <anchao@lixiang.com>

## Impact

N/A

## Testing

ci-check