### PR TITLE
sched/irq: spinlock should not depends on SMP

### DIFF
--- a/include/nuttx/spinlock.h
+++ b/include/nuttx/spinlock.h
@@ -145,7 +145,7 @@ typedef union spinlock_u spinlock_t;
 
 #if defined(CONFIG_ARCH_HAVE_TESTSET)
 spinlock_t up_testset(FAR volatile spinlock_t *lock);
-#elif !defined(CONFIG_SMP)
+#else
 static inline spinlock_t up_testset(FAR volatile spinlock_t *lock)
 {
   irqstate_t flags;
@@ -361,7 +361,7 @@ void spin_unlock_wo_note(FAR volatile spinlock_t *lock);
  *
  ****************************************************************************/
 
-#ifdef CONFIG_SMP
+#ifdef CONFIG_SPINLOCK
 void spin_setbit(FAR volatile cpu_set_t *set, unsigned int cpu,
                  FAR volatile spinlock_t *setlock,
                  FAR volatile spinlock_t *orlock);
@@ -384,7 +384,7 @@ void spin_setbit(FAR volatile cpu_set_t *set, unsigned int cpu,
  *
  ****************************************************************************/
 
-#ifdef CONFIG_SMP
+#ifdef CONFIG_SPINLOCK
 void spin_clrbit(FAR volatile cpu_set_t *set, unsigned int cpu,
                  FAR volatile spinlock_t *setlock,
                  FAR volatile spinlock_t *orlock);
@@ -443,7 +443,7 @@ void spin_clrbit(FAR volatile cpu_set_t *set, unsigned int cpu,
  *
  ****************************************************************************/
 
-#if defined(CONFIG_SMP)
+#if defined(CONFIG_SPINLOCK)
 irqstate_t spin_lock_irqsave(FAR spinlock_t *lock);
 #else
 #  define spin_lock_irqsave(l) ((void)(l), up_irq_save())
@@ -453,7 +453,7 @@ irqstate_t spin_lock_irqsave(FAR spinlock_t *lock);
  * Name: spin_lock_irqsave_wo_note
  ****************************************************************************/
 
-#if defined(CONFIG_SMP)
+#if defined(CONFIG_SPINLOCK)
 irqstate_t spin_lock_irqsave_wo_note(FAR spinlock_t *lock);
 #else
 #  define spin_lock_irqsave_wo_note(l) ((void)(l), up_irq_save())
@@ -488,7 +488,7 @@ irqstate_t spin_lock_irqsave_wo_note(FAR spinlock_t *lock);
  *
  ****************************************************************************/
 
-#if defined(CONFIG_SMP)
+#if defined(CONFIG_SPINLOCK)
 void spin_unlock_irqrestore(FAR spinlock_t *lock, irqstate_t flags);
 #else
 #  define spin_unlock_irqrestore(l, f) up_irq_restore(f)
@@ -498,7 +498,7 @@ void spin_unlock_irqrestore(FAR spinlock_t *lock, irqstate_t flags);
  * Name: spin_unlock_irqrestore_wo_note
  ****************************************************************************/
 
-#if defined(CONFIG_SMP)
+#if defined(CONFIG_SPINLOCK)
 void spin_unlock_irqrestore_wo_note(FAR spinlock_t *lock, irqstate_t flags);
 #else
 #  define spin_unlock_irqrestore_wo_note(l, f) up_irq_restore(f)
@@ -699,7 +699,7 @@ void write_unlock(FAR volatile rwlock_t *lock);
  *
  ****************************************************************************/
 
-#if defined(CONFIG_SMP)
+#if defined(CONFIG_SPINLOCK)
 irqstate_t read_lock_irqsave(FAR rwlock_t *lock);
 #else
 #  define read_lock_irqsave(l) ((void)(l), up_irq_save())
@@ -732,7 +732,7 @@ irqstate_t read_lock_irqsave(FAR rwlock_t *lock);
  *
  ****************************************************************************/
 
-#if defined(CONFIG_SMP)
+#if defined(CONFIG_SPINLOCK)
 void read_unlock_irqrestore(FAR rwlock_t *lock, irqstate_t flags);
 #else
 #  define read_unlock_irqrestore(l, f) up_irq_restore(f)
@@ -771,7 +771,7 @@ void read_unlock_irqrestore(FAR rwlock_t *lock, irqstate_t flags);
  *
  ****************************************************************************/
 
-#if defined(CONFIG_SMP)
+#if defined(CONFIG_SPINLOCK)
 irqstate_t write_lock_irqsave(FAR rwlock_t *lock);
 #else
 #  define write_lock_irqsave(l) ((void)(l), up_irq_save())
@@ -806,7 +806,7 @@ irqstate_t write_lock_irqsave(FAR rwlock_t *lock);
  *
  ****************************************************************************/
 
-#if defined(CONFIG_SMP)
+#if defined(CONFIG_SPINLOCK)
 void write_unlock_irqrestore(FAR rwlock_t *lock, irqstate_t flags);
 #else
 #  define write_unlock_irqrestore(l, f) up_irq_restore(f)

--- a/sched/irq/CMakeLists.txt
+++ b/sched/irq/CMakeLists.txt
@@ -20,7 +20,7 @@
 
 set(SRCS irq_initialize.c irq_attach.c irq_dispatch.c irq_unexpectedisr.c)
 
-if(CONFIG_SMP)
+if(CONFIG_SPINLOCK)
   list(APPEND SRCS irq_spinlock.c)
 endif()
 

--- a/sched/irq/Make.defs
+++ b/sched/irq/Make.defs
@@ -20,7 +20,7 @@
 
 CSRCS += irq_initialize.c irq_attach.c irq_dispatch.c irq_unexpectedisr.c
 
-ifeq ($(CONFIG_SMP),y)
+ifeq ($(CONFIG_SPINLOCK),y)
 CSRCS += irq_spinlock.c
 endif
 

--- a/sched/irq/irq_spinlock.c
+++ b/sched/irq/irq_spinlock.c
@@ -31,7 +31,7 @@
 
 #include "sched/sched.h"
 
-#if defined(CONFIG_SMP)
+#if defined(CONFIG_SPINLOCK)
 
 /****************************************************************************
  * Public Data
@@ -418,4 +418,4 @@ void write_unlock_irqrestore(rwlock_t *lock, irqstate_t flags)
   up_irq_restore(flags);
 }
 #endif /* CONFIG_RW_SPINLOCK */
-#endif /* CONFIG_SMP */
+#endif /* CONFIG_SPINLOCK */


### PR DESCRIPTION
## Summary

sched/irq: spinlock should not depends on SMP

spinlock should work independently without CONFIG_SMP

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

ci-check