### PR TITLE
libc/uname: Use CONFIG_NSH_DISABLE_UNAME_TIMESTAMP

### DIFF
--- a/libs/libc/misc/Kconfig
+++ b/libs/libc/misc/Kconfig
@@ -81,6 +81,15 @@ config LIBC_FTOK_VFS_PATH
 	---help---
 		The relative path to where ftok will exist in the root namespace.
 
+config LIBC_UNAME_DISABLE_TIMESTAMP
+	bool "Disable uname timestamp support"
+	default n
+	---help---
+		Currently uname command will print the timestamp
+		when the binary was built, and it generates an issue
+		because two identical built binaries will have differents
+		hashes/CRC.
+
 choice
 	prompt "Select memfd implementation"
 

--- a/libs/libc/misc/lib_utsname.c
+++ b/libs/libc/misc/lib_utsname.c
@@ -93,7 +93,8 @@ int uname(FAR struct utsname *name)
 
   strlcpy(name->release,  CONFIG_VERSION_STRING, sizeof(name->release));
 
-#if defined(__DATE__) && defined(__TIME__)
+#if defined(__DATE__) && defined(__TIME__) && \
+    !defined(CONFIG_LIBC_UNAME_DISABLE_TIMESTAMP)
   snprintf(name->version, VERSION_NAMELEN, "%s %s %s",
            CONFIG_VERSION_BUILD, __DATE__, __TIME__);
 #else


### PR DESCRIPTION
## Summary
Don't include the build timestamp into final binary when the symbol CONFIG_NSH_DISABLE_UNAME_TIMESTAMP is defined.

## Impact
User will be able to able to generate identical binaries for analysis and debug purposes.

## Testing
SIM

Note: depends on https://github.com/apache/nuttx-apps/pull/2337