### PR TITLE
libc/uname: Add option to disable uname timestamp

### DIFF
--- a/libs/libc/misc/Kconfig
+++ b/libs/libc/misc/Kconfig
@@ -81,6 +81,15 @@ config LIBC_FTOK_VFS_PATH
 	---help---
 		The relative path to where ftok will exist in the root namespace.
 
+config LIBC_UNAME_DISABLE_TIMESTAMP
+	bool "Disable uname timestamp support"
+	default n
+	---help---
+		Currently uname command will print the timestamp
+		when the binary was built, and it generates an issue
+		because two identical built binaries will have differents
+		hashes/CRC.
+
 choice
 	prompt "Select memfd implementation"
 

--- a/libs/libc/misc/Make.defs
+++ b/libs/libc/misc/Make.defs
@@ -79,7 +79,9 @@ endif
 # To ensure uname information is newest,
 # add lib_utsname.o to phony target for force rebuild
 
+#if !defined(CONFIG_LIBC_UNAME_DISABLE_TIMESTAMP)
 .PHONY: lib_utsname$(OBJEXT)
+#endif
 
 # Add the misc directory to the build
 

--- a/libs/libc/misc/lib_utsname.c
+++ b/libs/libc/misc/lib_utsname.c
@@ -93,7 +93,8 @@ int uname(FAR struct utsname *name)
 
   strlcpy(name->release,  CONFIG_VERSION_STRING, sizeof(name->release));
 
-#if defined(__DATE__) && defined(__TIME__)
+#if defined(__DATE__) && defined(__TIME__) && \
+    !defined(CONFIG_LIBC_UNAME_DISABLE_TIMESTAMP)
   snprintf(name->version, VERSION_NAMELEN, "%s %s %s",
            CONFIG_VERSION_BUILD, __DATE__, __TIME__);
 #else


### PR DESCRIPTION
## Summary
Don't include the build timestamp into final binary when the symbol CONFIG_LIBC_UNAME_DISABLE_TIMESTAMP is defined.

## Impact
Users will be able to compile same board config twice and get same identical binary.

## Testing
stm32f103-minimum:nsh

$ cmp /tmp/nuttx1.bin /tmp/nuttx2.bin
$
