### PR TITLE
CMake：Duplicate definition of CMAKE_CXX_STANDARD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,6 @@ endif()
 
 # Basic CMake configuration ##################################################
 
-set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_EXTENSIONS OFF)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)


### PR DESCRIPTION
## Summary
CMAKE_CXX_STANDARD is repeatedly defined in the two files, nuttx/CMakeLists(14) and libs/libxx/libcxx.cmake(17), and is defined to different values. Matter needs to use the new features(std::is_signed_v) of c++17,so delete the definition in nuttx/CMakeLists and retain the definition in libs/libxx/libcxx.cmake.
## Impact

## Testing
sim:matter
