### PR TITLE
minor revision of risc-v/arch.h and fs_mmap.c

### DIFF
--- a/arch/risc-v/include/arch.h
+++ b/arch/risc-v/include/arch.h
@@ -64,8 +64,9 @@
 /* A task group must have its L1 table in memory always, and the rest can
  * be dynamically committed to memory (and even swapped).
  *
- * In this implementation every level tables besides the final level N are
- * kept in memory always, while the level N tables are dynamically allocated.
+ * In this implementation level tables except the final level N are always
+ * kept in static memory, while the level N tables are always dynamically
+ * allocated. There is one static page per level in `spgtables[]`.
  *
  * The implications ? They depend on the MMU type.
  *

--- a/fs/mmap/fs_mmap.c
+++ b/fs/mmap/fs_mmap.c
@@ -73,7 +73,6 @@ static int file_mmap_(FAR struct file *filep, FAR void *start,
    * things.
    */
 
-#ifdef CONFIG_DEBUG_FEATURES
   /* A flags with MAP_PRIVATE and MAP_SHARED is invalid. */
 
   if ((flags & MAP_PRIVATE) && (flags & MAP_SHARED))
@@ -99,7 +98,6 @@ static int file_mmap_(FAR struct file *filep, FAR void *start,
       ferr("ERROR: Invalid length, length=%zu\n", length);
       return -EINVAL;
     }
-#endif /* CONFIG_DEBUG_FEATURES */
 
   /* Check if we are just be asked to allocate memory, i.e., MAP_ANONYMOUS
    * set meaning that the memory is not backed up from a file.  The file


### PR DESCRIPTION
## Summary

This patch revises comments in risc-v/arch.h and minor revision on fs_mmap.c

## Impact

size increasion of `fs_mmap_()`

## Testing

CI  checks
