### PR TITLE
arch/arm64: Add the head obj to libarch.a as well

### DIFF
--- a/arch/arm64/src/Makefile
+++ b/arch/arm64/src/Makefile
@@ -54,7 +54,7 @@ CSRCS = $(CHIP_CSRCS) $(CMN_CSRCS)
 COBJS = $(CSRCS:.c=$(OBJEXT))
 
 SRCS = $(ASRCS) $(CSRCS)
-OBJS = $(AOBJS) $(COBJS)
+OBJS = $(AOBJS) $(COBJS) $(HEAD_OBJ)
 
 # User-mode objects
 


### PR DESCRIPTION
## Summary
On other platforms libarch.a contains the head object. Some projects depend on this fact so let's provide the head object in the archive here as well.
## Impact
Adds arm64_head.o to libarch.a
## Testing
readelf to confirm the object is there
