### PR TITLE
Video improvement

### DIFF
--- a/drivers/video/v4l2_cap.c
+++ b/drivers/video/v4l2_cap.c
@@ -1174,9 +1174,9 @@ static void cleanup_streamresources(FAR capture_type_inf_t *type_inf,
   nxmutex_destroy(&type_inf->lock_state);
   if (type_inf->bufheap != NULL)
     {
-      if (cmng->imgdata->mem_ops && cmng->imgdata->mem_ops->mem_free)
+      if (cmng->imgdata->ops->free)
         {
-          cmng->imgdata->mem_ops->mem_free(type_inf->bufheap);
+          cmng->imgdata->ops->free(cmng->imgdata, type_inf->bufheap);
         }
       else
         {
@@ -2120,7 +2120,7 @@ static int capture_reqbufs(FAR struct v4l2_s *v4l2,
 {
   FAR capture_mng_t *cmng = (FAR capture_mng_t *)v4l2;
   FAR capture_type_inf_t *type_inf;
-  const imgdata_mem_ops_t *mem_ops = cmng->imgdata->mem_ops;
+  struct imgdata_s *imgdata = cmng->imgdata;
 
   irqstate_t flags;
   int ret = OK;
@@ -2158,9 +2158,9 @@ static int capture_reqbufs(FAR struct v4l2_s *v4l2,
         {
           if (type_inf->bufheap != NULL)
             {
-              if (mem_ops && mem_ops->mem_free)
+              if (imgdata->ops->free)
                 {
-                    mem_ops->mem_free(type_inf->bufheap);
+                    imgdata->ops->free(imgdata, type_inf->bufheap);
                 }
               else
                 {
@@ -2168,9 +2168,10 @@ static int capture_reqbufs(FAR struct v4l2_s *v4l2,
                 }
             }
 
-          if (mem_ops && mem_ops->mem_malloc)
+          if (imgdata->ops->alloc)
             {
-              type_inf->bufheap = mem_ops->mem_malloc(32, reqbufs->count *
+              type_inf->bufheap = imgdata->ops->alloc(imgdata, 32,
+                reqbufs->count *
                 get_bufsize(&type_inf->fmt[CAPTURE_FMT_MAIN]));
             }
           else

--- a/drivers/video/v4l2_cap.c
+++ b/drivers/video/v4l2_cap.c
@@ -195,7 +195,7 @@ static bool is_sem_waited(FAR sem_t *sem);
 static int save_scene_param(FAR capture_mng_t *cmng,
                             enum v4l2_scene_mode mode,
                             uint32_t id,
-                            struct v4l2_ext_control *control);
+                            FAR struct v4l2_ext_control *control);
 static int complete_capture(uint8_t err_code, uint32_t datasize,
                             FAR const struct timeval *ts,
                             FAR void *arg);
@@ -1452,7 +1452,7 @@ static int reflect_scene_parameter(FAR capture_mng_t *cmng,
 static int read_scene_param(FAR struct capture_mng_s *cmng,
                             enum v4l2_scene_mode mode,
                             uint32_t id,
-                            struct v4l2_ext_control *control)
+                            FAR struct v4l2_ext_control *control)
 {
   imgsensor_supported_value_t value;
   capture_scene_params_t *sp;
@@ -3609,7 +3609,7 @@ static int capture_mmap(FAR struct file *filep,
 }
 
 static int capture_poll(FAR struct file *filep,
-                        struct pollfd *fds, bool setup)
+                        FAR struct pollfd *fds, bool setup)
 {
   FAR struct inode *inode = filep->f_inode;
   FAR capture_mng_t *cmng = inode->i_private;

--- a/drivers/video/v4l2_cap.c
+++ b/drivers/video/v4l2_cap.c
@@ -1951,7 +1951,7 @@ static int complete_capture(uint8_t err_code,
 
   if (err_code == 0)
     {
-      type_inf->bufinf.vbuf_curr->buf.flags = 0;
+      type_inf->bufinf.vbuf_next->buf.flags = 0;
       if (type_inf->remaining_capnum > 0)
         {
           type_inf->remaining_capnum--;
@@ -1959,13 +1959,13 @@ static int complete_capture(uint8_t err_code,
     }
   else
     {
-      type_inf->bufinf.vbuf_curr->buf.flags = V4L2_BUF_FLAG_ERROR;
+      type_inf->bufinf.vbuf_next->buf.flags = V4L2_BUF_FLAG_ERROR;
     }
 
-  type_inf->bufinf.vbuf_curr->buf.bytesused = datasize;
+  type_inf->bufinf.vbuf_next->buf.bytesused = datasize;
   if (ts != NULL)
     {
-      type_inf->bufinf.vbuf_curr->buf.timestamp = *ts;
+      type_inf->bufinf.vbuf_next->buf.timestamp = *ts;
     }
 
   video_framebuff_capture_done(&type_inf->bufinf);

--- a/drivers/video/v4l2_cap.c
+++ b/drivers/video/v4l2_cap.c
@@ -209,72 +209,72 @@ static size_t get_bufsize(FAR video_format_t *vf);
 
 /* ioctl function for each cmds of ioctl */
 
-static int capture_querycap(FAR struct v4l2_s *v4l2,
+static int capture_querycap(FAR struct file *filep,
                             FAR struct v4l2_capability *cap);
 static int capture_g_input(FAR int *num);
-static int capture_enum_input(FAR struct v4l2_s *v4l2,
+static int capture_enum_input(FAR struct file *filep,
                               FAR struct v4l2_input *input);
-static int capture_reqbufs(FAR struct v4l2_s *v4l2,
+static int capture_reqbufs(FAR struct file *filep,
                            FAR struct v4l2_requestbuffers *reqbufs);
-static int capture_querybuf(FAR struct v4l2_s *v4l2,
+static int capture_querybuf(FAR struct file *filep,
                             FAR struct v4l2_buffer *buf);
-static int capture_qbuf(FAR struct v4l2_s *v4l2,
+static int capture_qbuf(FAR struct file *filep,
                         FAR struct v4l2_buffer *buf);
-static int capture_dqbuf(FAR struct v4l2_s *v4l2,
-                         FAR struct v4l2_buffer *buf, int oflags);
-static int capture_cancel_dqbuf(FAR struct v4l2_s *v4l2,
+static int capture_dqbuf(FAR struct file *filep,
+                         FAR struct v4l2_buffer *buf);
+static int capture_cancel_dqbuf(FAR struct file *filep,
                                 enum v4l2_buf_type type);
-static int capture_g_fmt(FAR struct v4l2_s *v4l2,
+static int capture_g_fmt(FAR struct file *filep,
                          FAR struct v4l2_format *fmt);
-static int capture_s_fmt(FAR struct v4l2_s *v4l2,
+static int capture_s_fmt(FAR struct file *filep,
                          FAR struct v4l2_format *fmt);
-static int capture_try_fmt(FAR struct v4l2_s *v4l2,
+static int capture_try_fmt(FAR struct file *filep,
                            FAR struct v4l2_format *fmt);
-static int capture_g_parm(FAR struct v4l2_s *v4l2,
+static int capture_g_parm(FAR struct file *filep,
                           FAR struct v4l2_streamparm *parm);
-static int capture_s_parm(FAR struct v4l2_s *v4l2,
+static int capture_s_parm(FAR struct file *filep,
                           FAR struct v4l2_streamparm *parm);
-static int capture_streamon(FAR struct v4l2_s *v4l2,
+static int capture_streamon(FAR struct file *filep,
                             FAR enum v4l2_buf_type *type);
-static int capture_streamoff(FAR struct v4l2_s *v4l2,
+static int capture_streamoff(FAR struct file *filep,
                              FAR enum v4l2_buf_type *type);
-static int capture_do_halfpush(FAR struct v4l2_s *v4l2,
+static int capture_do_halfpush(FAR struct file *filep,
                                bool enable);
-static int capture_takepict_start(FAR struct v4l2_s *v4l2,
+static int capture_takepict_start(FAR struct file *filep,
                                   int32_t capture_num);
-static int capture_takepict_stop(FAR struct v4l2_s *v4l2,
+static int capture_takepict_stop(FAR struct file *filep,
                                  bool halfpush);
-static int capture_s_selection(FAR struct v4l2_s *v4l2,
+static int capture_s_selection(FAR struct file *filep,
                                FAR struct v4l2_selection *clip);
-static int capture_g_selection(FAR struct v4l2_s *v4l2,
+static int capture_g_selection(FAR struct file *filep,
                                FAR struct v4l2_selection *clip);
-static int capture_queryctrl(FAR struct v4l2_s *v4l2,
+static int capture_queryctrl(FAR struct file *filep,
                              FAR struct v4l2_queryctrl *ctrl);
-static int capture_query_ext_ctrl(FAR struct v4l2_s *v4l2,
+static int capture_query_ext_ctrl(FAR struct file *filep,
                                   FAR struct v4l2_query_ext_ctrl *ctrl);
-static int capture_querymenu(FAR struct v4l2_s *v4l2,
+static int capture_querymenu(FAR struct file *filep,
                              FAR struct v4l2_querymenu *menu);
-static int capture_g_ctrl(FAR struct v4l2_s *v4l2,
+static int capture_g_ctrl(FAR struct file *filep,
                           FAR struct v4l2_control *ctrl);
-static int capture_s_ctrl(FAR struct v4l2_s *v4l2,
+static int capture_s_ctrl(FAR struct file *filep,
                           FAR struct v4l2_control *ctrl);
-static int capture_g_ext_ctrls(FAR struct v4l2_s *v4l2,
+static int capture_g_ext_ctrls(FAR struct file *filep,
                                FAR struct v4l2_ext_controls *ctrls);
-static int capture_s_ext_ctrls(FAR struct v4l2_s *v4l2,
+static int capture_s_ext_ctrls(FAR struct file *filep,
                                FAR struct v4l2_ext_controls *ctrls);
-static int capture_query_ext_ctrl_scene(FAR struct v4l2_s *v4l2,
+static int capture_query_ext_ctrl_scene(FAR struct file *filep,
              FAR struct v4s_query_ext_ctrl_scene *ctrl);
-static int capture_querymenu_scene(FAR struct v4l2_s *v4l2,
+static int capture_querymenu_scene(FAR struct file *filep,
              FAR struct v4s_querymenu_scene *menu);
-static int capture_g_ext_ctrls_scene(FAR struct v4l2_s *v4l2,
+static int capture_g_ext_ctrls_scene(FAR struct file *filep,
              FAR struct v4s_ext_controls_scene *ctrls);
-static int capture_s_ext_ctrls_scene(FAR struct v4l2_s *v4l2,
+static int capture_s_ext_ctrls_scene(FAR struct file *filep,
              FAR struct v4s_ext_controls_scene *ctrls);
-static int capture_enum_fmt(FAR struct v4l2_s *v4l2,
+static int capture_enum_fmt(FAR struct file *filep,
                             FAR struct v4l2_fmtdesc *f);
-static int capture_enum_frminterval(FAR struct v4l2_s *v4l2,
+static int capture_enum_frminterval(FAR struct file *filep,
                                     FAR struct v4l2_frmivalenum *f);
-static int capture_enum_frmsize(FAR struct v4l2_s *v4l2,
+static int capture_enum_frmsize(FAR struct file *filep,
                                 FAR struct v4l2_frmsizeenum *f);
 
 /* File operations function */
@@ -2054,10 +2054,11 @@ get_connected_imgsensor(FAR struct imgsensor_s **sensors,
  * Ioctl Functions
  ****************************************************************************/
 
-static int capture_querycap(FAR struct v4l2_s *v4l2,
+static int capture_querycap(FAR struct file *filep,
                             FAR struct v4l2_capability *cap)
 {
-  FAR capture_mng_t *cmng = (FAR capture_mng_t *)v4l2;
+  FAR struct inode *inode = filep->f_inode;
+  FAR capture_mng_t *cmng = inode->i_private;
   FAR const char *name;
 
   if (cmng == NULL || cap == NULL)
@@ -2089,10 +2090,11 @@ static int capture_g_input(FAR int *num)
   return OK;
 }
 
-static int capture_enum_input(FAR struct v4l2_s *v4l2,
+static int capture_enum_input(FAR struct file *filep,
                               FAR struct v4l2_input *input)
 {
-  FAR capture_mng_t *cmng = (FAR capture_mng_t *)v4l2;
+  FAR struct inode *inode = filep->f_inode;
+  FAR capture_mng_t *cmng = inode->i_private;
   FAR const char *name;
 
   if (cmng == NULL || input->index > 0)
@@ -2115,10 +2117,11 @@ static int capture_enum_input(FAR struct v4l2_s *v4l2,
   return OK;
 }
 
-static int capture_reqbufs(FAR struct v4l2_s *v4l2,
+static int capture_reqbufs(FAR struct file *filep,
                            FAR struct v4l2_requestbuffers *reqbufs)
 {
-  FAR capture_mng_t *cmng = (FAR capture_mng_t *)v4l2;
+  FAR struct inode *inode = filep->f_inode;
+  FAR capture_mng_t *cmng = inode->i_private;
   FAR capture_type_inf_t *type_inf;
   struct imgdata_s *imgdata = cmng->imgdata;
 
@@ -2191,10 +2194,11 @@ static int capture_reqbufs(FAR struct v4l2_s *v4l2,
   return ret;
 }
 
-static int capture_querybuf(FAR struct v4l2_s *v4l2,
+static int capture_querybuf(FAR struct file *filep,
                             FAR struct v4l2_buffer *buf)
 {
-  FAR capture_mng_t *cmng = (FAR capture_mng_t *)v4l2;
+  FAR struct inode *inode = filep->f_inode;
+  FAR capture_mng_t *cmng = inode->i_private;
   FAR capture_type_inf_t *type_inf;
 
   if (cmng == NULL || buf == NULL || buf->memory != V4L2_MEMORY_MMAP)
@@ -2219,10 +2223,11 @@ static int capture_querybuf(FAR struct v4l2_s *v4l2,
   return OK;
 }
 
-static int capture_qbuf(FAR struct v4l2_s *v4l2,
+static int capture_qbuf(FAR struct file *filep,
                         FAR struct v4l2_buffer *buf)
 {
-  FAR capture_mng_t *cmng = (FAR capture_mng_t *)v4l2;
+  FAR struct inode *inode = filep->f_inode;
+  FAR capture_mng_t *cmng = inode->i_private;
   FAR capture_type_inf_t *type_inf;
   FAR vbuf_container_t *container;
   enum capture_state_e next_capture_state;
@@ -2304,10 +2309,11 @@ static int capture_qbuf(FAR struct v4l2_s *v4l2,
   return OK;
 }
 
-static int capture_dqbuf(FAR struct v4l2_s *v4l2,
-                         FAR struct v4l2_buffer *buf, int oflags)
+static int capture_dqbuf(FAR struct file *filep,
+                         FAR struct v4l2_buffer *buf)
 {
-  FAR capture_mng_t *cmng = (FAR capture_mng_t *)v4l2;
+  FAR struct inode *inode = filep->f_inode;
+  FAR capture_mng_t *cmng = inode->i_private;
   FAR capture_type_inf_t *type_inf;
   FAR vbuf_container_t *container;
   FAR sem_t *dqbuf_wait_flg;
@@ -2328,7 +2334,7 @@ static int capture_dqbuf(FAR struct v4l2_s *v4l2,
   container = video_framebuff_dq_valid_container(&type_inf->bufinf);
   if (container == NULL)
     {
-      if (oflags & O_NONBLOCK)
+      if (filep->f_oflags & O_NONBLOCK)
         {
           return -EAGAIN;
         }
@@ -2379,10 +2385,11 @@ static int capture_dqbuf(FAR struct v4l2_s *v4l2,
   return OK;
 }
 
-static int capture_cancel_dqbuf(FAR struct v4l2_s *v4l2,
+static int capture_cancel_dqbuf(FAR struct file *filep,
                                 enum v4l2_buf_type type)
 {
-  FAR capture_mng_t *cmng = (FAR capture_mng_t *)v4l2;
+  FAR struct inode *inode = filep->f_inode;
+  FAR capture_mng_t *cmng = inode->i_private;
   FAR capture_type_inf_t *type_inf;
 
   if (cmng == NULL)
@@ -2410,10 +2417,11 @@ static int capture_cancel_dqbuf(FAR struct v4l2_s *v4l2,
   return nxsem_post(&type_inf->wait_capture.dqbuf_wait_flg);
 }
 
-static int capture_g_fmt(FAR struct v4l2_s *v4l2,
+static int capture_g_fmt(FAR struct file *filep,
                          FAR struct v4l2_format *fmt)
 {
-  FAR capture_mng_t *cmng = (FAR capture_mng_t *)v4l2;
+  FAR struct inode *inode = filep->f_inode;
+  FAR capture_mng_t *cmng = inode->i_private;
   FAR capture_type_inf_t *type_inf;
 
   if (cmng == NULL)
@@ -2435,10 +2443,11 @@ static int capture_g_fmt(FAR struct v4l2_s *v4l2,
   return OK;
 }
 
-static int capture_s_fmt(FAR struct v4l2_s *v4l2,
+static int capture_s_fmt(FAR struct file *filep,
                          FAR struct v4l2_format *fmt)
 {
-  FAR capture_mng_t *cmng = (FAR capture_mng_t *)v4l2;
+  FAR struct inode *inode = filep->f_inode;
+  FAR capture_mng_t *cmng = inode->i_private;
   FAR capture_type_inf_t *type_inf;
   int ret;
 
@@ -2447,7 +2456,7 @@ static int capture_s_fmt(FAR struct v4l2_s *v4l2,
       return -EINVAL;
     }
 
-  ret = capture_try_fmt(v4l2, fmt);
+  ret = capture_try_fmt(filep, fmt);
   if (ret != 0)
     {
       return ret;
@@ -2494,10 +2503,11 @@ static int capture_s_fmt(FAR struct v4l2_s *v4l2,
   return OK;
 }
 
-static int capture_try_fmt(FAR struct v4l2_s *v4l2,
+static int capture_try_fmt(FAR struct file *filep,
                            FAR struct v4l2_format *fmt)
 {
-  FAR capture_mng_t *cmng = (FAR capture_mng_t *)v4l2;
+  FAR struct inode *inode = filep->f_inode;
+  FAR capture_mng_t *cmng = inode->i_private;
   FAR capture_type_inf_t *type_inf;
   video_format_t vf[MAX_CAPTURE_FMT];
   uint8_t nr_fmt;
@@ -2562,10 +2572,11 @@ static int capture_try_fmt(FAR struct v4l2_s *v4l2,
                                 &type_inf->frame_interval);
 }
 
-static int capture_g_parm(FAR struct v4l2_s *v4l2,
+static int capture_g_parm(FAR struct file *filep,
                           FAR struct v4l2_streamparm *parm)
 {
-  FAR capture_mng_t *cmng = (FAR capture_mng_t *)v4l2;
+  FAR struct inode *inode = filep->f_inode;
+  FAR capture_mng_t *cmng = inode->i_private;
   FAR capture_type_inf_t *type_inf;
   int ret = -EINVAL;
 
@@ -2607,10 +2618,11 @@ static int capture_g_parm(FAR struct v4l2_s *v4l2,
   return OK;
 }
 
-static int capture_s_parm(FAR struct v4l2_s *v4l2,
+static int capture_s_parm(FAR struct file *filep,
                           FAR struct v4l2_streamparm *parm)
 {
-  FAR capture_mng_t *cmng = (FAR capture_mng_t *)v4l2;
+  FAR struct inode *inode = filep->f_inode;
+  FAR capture_mng_t *cmng = inode->i_private;
   FAR capture_type_inf_t *type_inf;
   int ret;
 
@@ -2650,10 +2662,11 @@ static int capture_s_parm(FAR struct v4l2_s *v4l2,
   return ret;
 }
 
-static int capture_streamon(FAR struct v4l2_s *v4l2,
+static int capture_streamon(FAR struct file *filep,
                             FAR enum v4l2_buf_type *type)
 {
-  FAR capture_mng_t *cmng = (FAR capture_mng_t *)v4l2;
+  FAR struct inode *inode = filep->f_inode;
+  FAR capture_mng_t *cmng = inode->i_private;
   FAR capture_type_inf_t *type_inf;
   enum capture_state_e next_capture_state;
   int ret = OK;
@@ -2693,10 +2706,11 @@ static int capture_streamon(FAR struct v4l2_s *v4l2,
   return ret;
 }
 
-static int capture_streamoff(FAR struct v4l2_s *v4l2,
+static int capture_streamoff(FAR struct file *filep,
                              FAR enum v4l2_buf_type *type)
 {
-  FAR capture_mng_t *cmng = (FAR capture_mng_t *)v4l2;
+  FAR struct inode *inode = filep->f_inode;
+  FAR capture_mng_t *cmng = inode->i_private;
   FAR capture_type_inf_t *type_inf;
   enum capture_state_e next_capture_state;
   irqstate_t flags;
@@ -2738,15 +2752,10 @@ static int capture_streamoff(FAR struct v4l2_s *v4l2,
   return ret;
 }
 
-static int capture_do_halfpush(FAR struct v4l2_s *v4l2, bool enable)
+static int capture_do_halfpush(FAR struct file *filep, bool enable)
 {
   struct v4l2_ext_controls ext_controls;
   struct v4l2_ext_control  control[2];
-
-  if (v4l2 == NULL)
-    {
-      return -EINVAL;
-    }
 
   /* Replace to VIDIOC_S_EXT_CTRLS format */
 
@@ -2762,13 +2771,14 @@ static int capture_do_halfpush(FAR struct v4l2_s *v4l2, bool enable)
 
   /* Execute VIDIOC_S_EXT_CTRLS */
 
-  return capture_s_ext_ctrls(v4l2, &ext_controls);
+  return capture_s_ext_ctrls(filep, &ext_controls);
 }
 
-static int capture_takepict_start(FAR struct v4l2_s *v4l2,
+static int capture_takepict_start(FAR struct file *filep,
                                   int32_t capture_num)
 {
-  FAR capture_mng_t *cmng = (FAR capture_mng_t *)v4l2;
+  FAR struct inode *inode = filep->f_inode;
+  FAR capture_mng_t *cmng = inode->i_private;
   enum capture_state_e next_capture_state;
   FAR vbuf_container_t *container;
   irqstate_t flags;
@@ -2833,10 +2843,11 @@ static int capture_takepict_start(FAR struct v4l2_s *v4l2,
   return ret;
 }
 
-static int capture_takepict_stop(FAR struct v4l2_s *v4l2,
+static int capture_takepict_stop(FAR struct file *filep,
                                  bool halfpush)
 {
-  FAR capture_mng_t *cmng = (FAR capture_mng_t *)v4l2;
+  FAR struct inode *inode = filep->f_inode;
+  FAR capture_mng_t *cmng = inode->i_private;
   enum capture_state_e next_capture_state;
   irqstate_t flags;
   int ret = OK;
@@ -2879,10 +2890,11 @@ static int capture_takepict_stop(FAR struct v4l2_s *v4l2,
   return ret;
 }
 
-static int capture_s_selection(FAR struct v4l2_s *v4l2,
+static int capture_s_selection(FAR struct file *filep,
                                FAR struct v4l2_selection *clip)
 {
-  FAR capture_mng_t *cmng = (FAR capture_mng_t *)v4l2;
+  FAR struct inode *inode = filep->f_inode;
+  FAR capture_mng_t *cmng = inode->i_private;
   FAR capture_type_inf_t *type_inf;
   uint32_t p_u32[IMGSENSOR_CLIP_NELEM];
   imgsensor_value_t val;
@@ -2942,10 +2954,11 @@ static int capture_s_selection(FAR struct v4l2_s *v4l2,
   return ret;
 }
 
-static int capture_g_selection(FAR struct v4l2_s *v4l2,
+static int capture_g_selection(FAR struct file *filep,
                                FAR struct v4l2_selection *clip)
 {
-  FAR capture_mng_t *cmng = (FAR capture_mng_t *)v4l2;
+  FAR struct inode *inode = filep->f_inode;
+  FAR capture_mng_t *cmng = inode->i_private;
   FAR capture_type_inf_t *type_inf;
 
   if (cmng == NULL || clip == NULL)
@@ -2963,13 +2976,13 @@ static int capture_g_selection(FAR struct v4l2_s *v4l2,
   return OK;
 }
 
-static int capture_queryctrl(FAR struct v4l2_s *v4l2,
+static int capture_queryctrl(FAR struct file *filep,
                              FAR struct v4l2_queryctrl *ctrl)
 {
   struct v4l2_query_ext_ctrl ext_ctrl;
   int ret;
 
-  if (v4l2 == NULL || ctrl == NULL)
+  if (ctrl == NULL)
     {
       return -EINVAL;
     }
@@ -2979,7 +2992,7 @@ static int capture_queryctrl(FAR struct v4l2_s *v4l2,
   ext_ctrl.ctrl_class = ctrl->ctrl_class;
   ext_ctrl.id         = ctrl->id;
 
-  ret = capture_query_ext_ctrl(v4l2, &ext_ctrl);
+  ret = capture_query_ext_ctrl(filep, &ext_ctrl);
   if (ret != OK)
     {
       return ret;
@@ -3008,10 +3021,11 @@ static int capture_queryctrl(FAR struct v4l2_s *v4l2,
   return OK;
 }
 
-static int capture_query_ext_ctrl(FAR struct v4l2_s *v4l2,
+static int capture_query_ext_ctrl(FAR struct file *filep,
                                   FAR struct v4l2_query_ext_ctrl *attr)
 {
-  FAR capture_mng_t *cmng = (FAR capture_mng_t *)v4l2;
+  FAR struct inode *inode = filep->f_inode;
+  FAR capture_mng_t *cmng = inode->i_private;
   imgsensor_supported_value_t value;
   imgsensor_capability_range_t *range = &value.u.range;
   imgsensor_capability_discrete_t *disc = &value.u.discrete;
@@ -3086,10 +3100,11 @@ static int capture_query_ext_ctrl(FAR struct v4l2_s *v4l2,
   return OK;
 }
 
-static int capture_querymenu(FAR struct v4l2_s *v4l2,
+static int capture_querymenu(FAR struct file *filep,
                              FAR struct v4l2_querymenu *menu)
 {
-  FAR capture_mng_t *cmng = (FAR capture_mng_t *)v4l2;
+  FAR struct inode *inode = filep->f_inode;
+  FAR capture_mng_t *cmng = inode->i_private;
   imgsensor_supported_value_t value;
   int ret;
 
@@ -3141,14 +3156,14 @@ static int capture_querymenu(FAR struct v4l2_s *v4l2,
   return OK;
 }
 
-static int capture_g_ctrl(FAR struct v4l2_s *v4l2,
+static int capture_g_ctrl(FAR struct file *filep,
                           FAR struct v4l2_control *ctrl)
 {
   struct v4l2_ext_controls ext_controls;
   struct v4l2_ext_control control;
   int ret;
 
-  if (v4l2 == NULL || ctrl == NULL)
+  if (ctrl == NULL)
     {
       return -EINVAL;
     }
@@ -3166,7 +3181,7 @@ static int capture_g_ctrl(FAR struct v4l2_s *v4l2,
 
   /* Execute VIDIOC_G_EXT_CTRLS */
 
-  ret = capture_g_ext_ctrls(v4l2, &ext_controls);
+  ret = capture_g_ext_ctrls(filep, &ext_controls);
   if (ret == OK)
     {
       /* Replace gotten value to VIDIOC_G_CTRL parameter */
@@ -3177,13 +3192,13 @@ static int capture_g_ctrl(FAR struct v4l2_s *v4l2,
   return ret;
 }
 
-static int capture_s_ctrl(FAR struct v4l2_s *v4l2,
+static int capture_s_ctrl(FAR struct file *filep,
                           FAR struct v4l2_control *ctrl)
 {
   struct v4l2_ext_controls ext_controls;
   struct v4l2_ext_control control;
 
-  if (v4l2 == NULL || ctrl == NULL)
+  if (ctrl == NULL)
     {
       return -EINVAL;
     }
@@ -3199,13 +3214,14 @@ static int capture_s_ctrl(FAR struct v4l2_s *v4l2,
 
   /* Execute VIDIOC_S_EXT_CTRLS */
 
-  return capture_s_ext_ctrls(v4l2, &ext_controls);
+  return capture_s_ext_ctrls(filep, &ext_controls);
 }
 
-static int capture_g_ext_ctrls(FAR struct v4l2_s *v4l2,
+static int capture_g_ext_ctrls(FAR struct file *filep,
                                FAR struct v4l2_ext_controls *ctrls)
 {
-  FAR capture_mng_t *cmng = (FAR capture_mng_t *)v4l2;
+  FAR struct inode *inode = filep->f_inode;
+  FAR capture_mng_t *cmng = inode->i_private;
   FAR struct v4l2_ext_control *control;
   int ret = OK;
   int cnt;
@@ -3244,10 +3260,11 @@ static int capture_g_ext_ctrls(FAR struct v4l2_s *v4l2,
   return ret;
 }
 
-static int capture_s_ext_ctrls(FAR struct v4l2_s *v4l2,
+static int capture_s_ext_ctrls(FAR struct file *filep,
                                FAR struct v4l2_ext_controls *ctrls)
 {
-  FAR capture_mng_t *cmng = (FAR capture_mng_t *)v4l2;
+  FAR struct inode *inode = filep->f_inode;
+  FAR capture_mng_t *cmng = inode->i_private;
   FAR struct v4l2_ext_control *control;
   int ret = OK;
   int cnt;
@@ -3296,32 +3313,33 @@ static int capture_s_ext_ctrls(FAR struct v4l2_s *v4l2,
   return ret;
 }
 
-static int capture_query_ext_ctrl_scene(FAR struct v4l2_s *v4l2,
+static int capture_query_ext_ctrl_scene(FAR struct file *filep,
              FAR struct v4s_query_ext_ctrl_scene *attr)
 {
-  if (v4l2 == NULL || attr == NULL)
+  if (attr == NULL)
     {
       return -EINVAL;
     }
 
-  return capture_query_ext_ctrl(v4l2, &attr->control);
+  return capture_query_ext_ctrl(filep, &attr->control);
 }
 
-static int capture_querymenu_scene(FAR struct v4l2_s *v4l2,
+static int capture_querymenu_scene(FAR struct file *filep,
              FAR struct v4s_querymenu_scene *menu)
 {
-  if (v4l2 == NULL || menu == NULL)
+  if (menu == NULL)
     {
       return -EINVAL;
     }
 
-  return capture_querymenu(v4l2, &menu->menu);
+  return capture_querymenu(filep, &menu->menu);
 }
 
-static int capture_s_ext_ctrls_scene(FAR struct v4l2_s *v4l2,
+static int capture_s_ext_ctrls_scene(FAR struct file *filep,
              FAR struct v4s_ext_controls_scene *ctrls)
 {
-  FAR capture_mng_t *cmng = (FAR capture_mng_t *)v4l2;
+  FAR struct inode *inode = filep->f_inode;
+  FAR capture_mng_t *cmng = inode->i_private;
   FAR struct v4l2_ext_control *control;
   int ret = OK;
   int cnt;
@@ -3346,10 +3364,11 @@ static int capture_s_ext_ctrls_scene(FAR struct v4l2_s *v4l2,
   return ret;
 }
 
-static int capture_g_ext_ctrls_scene(FAR struct v4l2_s *v4l2,
+static int capture_g_ext_ctrls_scene(FAR struct file *filep,
              FAR struct v4s_ext_controls_scene *ctrls)
 {
-  FAR capture_mng_t *cmng = (FAR capture_mng_t *)v4l2;
+  FAR struct inode *inode = filep->f_inode;
+  FAR capture_mng_t *cmng = inode->i_private;
   FAR struct v4l2_ext_control *control;
   int ret = OK;
   int cnt;
@@ -3376,10 +3395,11 @@ static int capture_g_ext_ctrls_scene(FAR struct v4l2_s *v4l2,
   return ret;
 }
 
-static int capture_enum_fmt(FAR struct v4l2_s *v4l2,
+static int capture_enum_fmt(FAR struct file *filep,
                             FAR struct v4l2_fmtdesc *f)
 {
-  FAR capture_mng_t *cmng = (FAR capture_mng_t *)v4l2;
+  FAR struct inode *inode = filep->f_inode;
+  FAR capture_mng_t *cmng = inode->i_private;
 
   if (cmng == NULL || f == NULL)
     {
@@ -3413,10 +3433,11 @@ static int capture_enum_fmt(FAR struct v4l2_s *v4l2,
   return 0;
 }
 
-static int capture_enum_frmsize(FAR struct v4l2_s *v4l2,
+static int capture_enum_frmsize(FAR struct file *filep,
                                 FAR struct v4l2_frmsizeenum *f)
 {
-  FAR capture_mng_t *cmng = (FAR capture_mng_t *)v4l2;
+  FAR struct inode *inode = filep->f_inode;
+  FAR capture_mng_t *cmng = inode->i_private;
 
   if (cmng == NULL || f == NULL)
     {
@@ -3457,10 +3478,11 @@ static int capture_enum_frmsize(FAR struct v4l2_s *v4l2,
   return 0;
 }
 
-static int capture_enum_frminterval(FAR struct v4l2_s *v4l2,
+static int capture_enum_frminterval(FAR struct file *filep,
                                     FAR struct v4l2_frmivalenum *f)
 {
-  FAR capture_mng_t *cmng = (FAR capture_mng_t *)v4l2;
+  FAR struct inode *inode = filep->f_inode;
+  FAR capture_mng_t *cmng = inode->i_private;
 
   if (cmng == NULL || f == NULL)
     {

--- a/drivers/video/v4l2_core.c
+++ b/drivers/video/v4l2_core.c
@@ -142,7 +142,7 @@ static int v4l2_ioctl(FAR struct file *filep,
             break;
           }
 
-        return v4l2->vops->querycap(v4l2,
+        return v4l2->vops->querycap(filep,
                              (FAR struct v4l2_capability *)arg);
 
       case VIDIOC_G_INPUT:
@@ -159,7 +159,7 @@ static int v4l2_ioctl(FAR struct file *filep,
             break;
           }
 
-        return v4l2->vops->enum_input(v4l2,
+        return v4l2->vops->enum_input(filep,
                              (FAR struct v4l2_input *)arg);
 
       case VIDIOC_REQBUFS:
@@ -168,7 +168,7 @@ static int v4l2_ioctl(FAR struct file *filep,
             break;
           }
 
-        return v4l2->vops->reqbufs(v4l2,
+        return v4l2->vops->reqbufs(filep,
                              (FAR struct v4l2_requestbuffers *)arg);
 
       case VIDIOC_QUERYBUF:
@@ -177,7 +177,7 @@ static int v4l2_ioctl(FAR struct file *filep,
             break;
           }
 
-        return v4l2->vops->querybuf(v4l2,
+        return v4l2->vops->querybuf(filep,
                              (FAR struct v4l2_buffer *)arg);
 
       case VIDIOC_QBUF:
@@ -186,7 +186,7 @@ static int v4l2_ioctl(FAR struct file *filep,
             break;
           }
 
-        return v4l2->vops->qbuf(v4l2,
+        return v4l2->vops->qbuf(filep,
                              (FAR struct v4l2_buffer *)arg);
         break;
 
@@ -196,9 +196,8 @@ static int v4l2_ioctl(FAR struct file *filep,
             break;
           }
 
-        return v4l2->vops->dqbuf(v4l2,
-                             (FAR struct v4l2_buffer *)arg,
-                             filep->f_oflags);
+        return v4l2->vops->dqbuf(filep,
+                             (FAR struct v4l2_buffer *)arg);
 
       case VIDIOC_CANCEL_DQBUF:
         if (v4l2->vops->cancel_dqbuf == NULL)
@@ -206,7 +205,7 @@ static int v4l2_ioctl(FAR struct file *filep,
             break;
           }
 
-        return v4l2->vops->cancel_dqbuf(v4l2,
+        return v4l2->vops->cancel_dqbuf(filep,
                              (FAR enum v4l2_buf_type)arg);
 
       case VIDIOC_STREAMON:
@@ -215,7 +214,7 @@ static int v4l2_ioctl(FAR struct file *filep,
             break;
           }
 
-        return v4l2->vops->streamon(v4l2,
+        return v4l2->vops->streamon(filep,
                              (FAR enum v4l2_buf_type *)arg);
 
       case VIDIOC_STREAMOFF:
@@ -224,7 +223,7 @@ static int v4l2_ioctl(FAR struct file *filep,
             break;
           }
 
-        return v4l2->vops->streamoff(v4l2,
+        return v4l2->vops->streamoff(filep,
                              (FAR enum v4l2_buf_type *)arg);
 
       case VIDIOC_DO_HALFPUSH:
@@ -233,7 +232,7 @@ static int v4l2_ioctl(FAR struct file *filep,
             break;
           }
 
-        return v4l2->vops->do_halfpush(v4l2, arg);
+        return v4l2->vops->do_halfpush(filep, arg);
 
       case VIDIOC_TAKEPICT_START:
         if (v4l2->vops->takepict_start == NULL)
@@ -241,7 +240,7 @@ static int v4l2_ioctl(FAR struct file *filep,
             break;
           }
 
-        return v4l2->vops->takepict_start(v4l2, (int32_t)arg);
+        return v4l2->vops->takepict_start(filep, (int32_t)arg);
 
       case VIDIOC_TAKEPICT_STOP:
         if (v4l2->vops->takepict_stop == NULL)
@@ -249,7 +248,7 @@ static int v4l2_ioctl(FAR struct file *filep,
             break;
           }
 
-        return v4l2->vops->takepict_stop(v4l2, arg);
+        return v4l2->vops->takepict_stop(filep, arg);
 
       case VIDIOC_S_SELECTION:
         if (v4l2->vops->s_selection == NULL)
@@ -257,7 +256,7 @@ static int v4l2_ioctl(FAR struct file *filep,
             break;
           }
 
-        return v4l2->vops->s_selection(v4l2,
+        return v4l2->vops->s_selection(filep,
                              (FAR struct v4l2_selection *)arg);
 
       case VIDIOC_G_SELECTION:
@@ -266,7 +265,7 @@ static int v4l2_ioctl(FAR struct file *filep,
             break;
           }
 
-        return v4l2->vops->g_selection(v4l2,
+        return v4l2->vops->g_selection(filep,
                              (FAR struct v4l2_selection *)arg);
 
       case VIDIOC_TRY_FMT:
@@ -275,7 +274,7 @@ static int v4l2_ioctl(FAR struct file *filep,
             break;
           }
 
-        return v4l2->vops->try_fmt(v4l2,
+        return v4l2->vops->try_fmt(filep,
                              (FAR struct v4l2_format *)arg);
 
       case VIDIOC_G_FMT:
@@ -284,7 +283,7 @@ static int v4l2_ioctl(FAR struct file *filep,
             break;
           }
 
-        return v4l2->vops->g_fmt(v4l2,
+        return v4l2->vops->g_fmt(filep,
                              (FAR struct v4l2_format *)arg);
 
       case VIDIOC_S_FMT:
@@ -293,7 +292,7 @@ static int v4l2_ioctl(FAR struct file *filep,
             break;
           }
 
-        return v4l2->vops->s_fmt(v4l2,
+        return v4l2->vops->s_fmt(filep,
                              (FAR struct v4l2_format *)arg);
 
       case VIDIOC_S_PARM:
@@ -302,7 +301,7 @@ static int v4l2_ioctl(FAR struct file *filep,
             break;
           }
 
-        return v4l2->vops->s_parm(v4l2,
+        return v4l2->vops->s_parm(filep,
                              (FAR struct v4l2_streamparm *)arg);
 
       case VIDIOC_G_PARM:
@@ -311,7 +310,7 @@ static int v4l2_ioctl(FAR struct file *filep,
             break;
           }
 
-        return v4l2->vops->g_parm(v4l2,
+        return v4l2->vops->g_parm(filep,
                              (FAR struct v4l2_streamparm *)arg);
 
       case VIDIOC_QUERYCTRL:
@@ -320,7 +319,7 @@ static int v4l2_ioctl(FAR struct file *filep,
             break;
           }
 
-        return v4l2->vops->queryctrl(v4l2,
+        return v4l2->vops->queryctrl(filep,
                              (FAR struct v4l2_queryctrl *)arg);
 
       case VIDIOC_QUERY_EXT_CTRL:
@@ -329,7 +328,7 @@ static int v4l2_ioctl(FAR struct file *filep,
             break;
           }
 
-        return v4l2->vops->query_ext_ctrl(v4l2,
+        return v4l2->vops->query_ext_ctrl(filep,
                              (FAR struct v4l2_query_ext_ctrl *)arg);
 
       case VIDIOC_QUERYMENU:
@@ -338,7 +337,7 @@ static int v4l2_ioctl(FAR struct file *filep,
             break;
           }
 
-        return v4l2->vops->querymenu(v4l2,
+        return v4l2->vops->querymenu(filep,
                              (FAR struct v4l2_querymenu *)arg);
 
       case VIDIOC_G_CTRL:
@@ -347,7 +346,7 @@ static int v4l2_ioctl(FAR struct file *filep,
             break;
           }
 
-        return v4l2->vops->g_ctrl(v4l2,
+        return v4l2->vops->g_ctrl(filep,
                              (FAR struct v4l2_control *)arg);
 
       case VIDIOC_S_CTRL:
@@ -356,7 +355,7 @@ static int v4l2_ioctl(FAR struct file *filep,
             break;
           }
 
-        return v4l2->vops->s_ctrl(v4l2,
+        return v4l2->vops->s_ctrl(filep,
                              (FAR struct v4l2_control *)arg);
 
       case VIDIOC_G_EXT_CTRLS:
@@ -365,7 +364,7 @@ static int v4l2_ioctl(FAR struct file *filep,
             break;
           }
 
-        return v4l2->vops->g_ext_ctrls(v4l2,
+        return v4l2->vops->g_ext_ctrls(filep,
                              (FAR struct v4l2_ext_controls *)arg);
 
       case VIDIOC_S_EXT_CTRLS:
@@ -374,7 +373,7 @@ static int v4l2_ioctl(FAR struct file *filep,
             break;
           }
 
-        return v4l2->vops->s_ext_ctrls(v4l2,
+        return v4l2->vops->s_ext_ctrls(filep,
                              (FAR struct v4l2_ext_controls *)arg);
 
       case VIDIOC_G_STD:
@@ -389,7 +388,7 @@ static int v4l2_ioctl(FAR struct file *filep,
             break;
           }
 
-        return v4l2->vops->query_ext_ctrl_scene(v4l2,
+        return v4l2->vops->query_ext_ctrl_scene(filep,
                              (FAR struct v4s_query_ext_ctrl_scene *)arg);
 
       case V4SIOC_QUERYMENU_SCENE:
@@ -398,7 +397,7 @@ static int v4l2_ioctl(FAR struct file *filep,
             break;
           }
 
-        return v4l2->vops->querymenu_scene(v4l2,
+        return v4l2->vops->querymenu_scene(filep,
                              (FAR struct v4s_querymenu_scene *)arg);
 
       case V4SIOC_G_EXT_CTRLS_SCENE:
@@ -407,7 +406,7 @@ static int v4l2_ioctl(FAR struct file *filep,
             break;
           }
 
-        return v4l2->vops->g_ext_ctrls_scene(v4l2,
+        return v4l2->vops->g_ext_ctrls_scene(filep,
                              (FAR struct v4s_ext_controls_scene *)arg);
 
       case V4SIOC_S_EXT_CTRLS_SCENE:
@@ -416,7 +415,7 @@ static int v4l2_ioctl(FAR struct file *filep,
             break;
           }
 
-        return v4l2->vops->s_ext_ctrls_scene(v4l2,
+        return v4l2->vops->s_ext_ctrls_scene(filep,
                              (FAR struct v4s_ext_controls_scene *)arg);
 
       case VIDIOC_ENUM_FMT:
@@ -425,7 +424,7 @@ static int v4l2_ioctl(FAR struct file *filep,
             break;
           }
 
-        return v4l2->vops->enum_fmt(v4l2,
+        return v4l2->vops->enum_fmt(filep,
                              (FAR struct v4l2_fmtdesc *)arg);
 
       case VIDIOC_ENUM_FRAMEINTERVALS:
@@ -434,7 +433,7 @@ static int v4l2_ioctl(FAR struct file *filep,
             break;
           }
 
-        return v4l2->vops->enum_frminterval(v4l2,
+        return v4l2->vops->enum_frminterval(filep,
                              (FAR struct v4l2_frmivalenum *)arg);
 
       case VIDIOC_ENUM_FRAMESIZES:
@@ -443,7 +442,7 @@ static int v4l2_ioctl(FAR struct file *filep,
             break;
           }
 
-        return v4l2->vops->enum_frmsize(v4l2,
+        return v4l2->vops->enum_frmsize(filep,
                              (FAR struct v4l2_frmsizeenum *)arg);
 
       case VIDIOC_CROPCAP:
@@ -452,7 +451,7 @@ static int v4l2_ioctl(FAR struct file *filep,
             break;
           }
 
-        return v4l2->vops->cropcap(v4l2,
+        return v4l2->vops->cropcap(filep,
                              (FAR struct v4l2_cropcap *)arg);
 
       case VIDIOC_DQEVENT:
@@ -461,7 +460,7 @@ static int v4l2_ioctl(FAR struct file *filep,
             break;
           }
 
-        return v4l2->vops->dqevent(v4l2,
+        return v4l2->vops->dqevent(filep,
                              (FAR struct v4l2_event *)arg);
 
       case VIDIOC_SUBSCRIBE_EVENT:
@@ -470,7 +469,7 @@ static int v4l2_ioctl(FAR struct file *filep,
             break;
           }
 
-        return v4l2->vops->subscribe_event(v4l2,
+        return v4l2->vops->subscribe_event(filep,
                              (FAR struct v4l2_event_subscription *)arg);
 
       case VIDIOC_DECODER_CMD:
@@ -479,7 +478,7 @@ static int v4l2_ioctl(FAR struct file *filep,
             break;
           }
 
-        return v4l2->vops->decoder_cmd(v4l2,
+        return v4l2->vops->decoder_cmd(filep,
                              (FAR struct v4l2_decoder_cmd *)arg);
 
       case VIDIOC_ENCODER_CMD:
@@ -488,7 +487,7 @@ static int v4l2_ioctl(FAR struct file *filep,
             break;
           }
 
-        return v4l2->vops->encoder_cmd(v4l2,
+        return v4l2->vops->encoder_cmd(filep,
                              (FAR struct v4l2_encoder_cmd *)arg);
 
       default:
@@ -572,4 +571,3 @@ int video_unregister(FAR const char *devpath)
 {
   return unregister_driver(devpath);
 }
-

--- a/drivers/video/video_framebuff.c
+++ b/drivers/video/video_framebuff.c
@@ -103,8 +103,10 @@ int video_framebuff_realloc_container(video_framebuff_t *fbuf, int sz)
 {
   vbuf_container_t *vbuf;
 
+  nxmutex_lock(&fbuf->lock_empty);
   if (fbuf->container_size == sz)
     {
+      nxmutex_unlock(&fbuf->lock_empty);
       return OK;
     }
 
@@ -119,6 +121,7 @@ int video_framebuff_realloc_container(video_framebuff_t *fbuf, int sz)
         }
       else
         {
+          nxmutex_unlock(&fbuf->lock_empty);
           return -ENOMEM;
         }
     }
@@ -130,6 +133,8 @@ int video_framebuff_realloc_container(video_framebuff_t *fbuf, int sz)
     }
 
   init_buf_chain(fbuf);
+  nxmutex_unlock(&fbuf->lock_empty);
+
   return OK;
 }
 

--- a/drivers/video/video_framebuff.c
+++ b/drivers/video/video_framebuff.c
@@ -42,7 +42,6 @@ static void init_buf_chain(video_framebuff_t *fbuf)
 
   fbuf->vbuf_empty = fbuf->vbuf_alloced;
   fbuf->vbuf_next  = NULL;
-  fbuf->vbuf_curr  = NULL;
   fbuf->vbuf_top   = NULL;
   fbuf->vbuf_tail  = NULL;
 
@@ -219,7 +218,7 @@ video_framebuff_get_vacant_container(video_framebuff_t *fbuf)
   irqstate_t flags;
 
   flags = enter_critical_section();
-  ret = fbuf->vbuf_curr = fbuf->vbuf_next;
+  ret = fbuf->vbuf_next;
   leave_critical_section(flags);
 
   return ret;
@@ -227,7 +226,9 @@ video_framebuff_get_vacant_container(video_framebuff_t *fbuf)
 
 void video_framebuff_capture_done(video_framebuff_t *fbuf)
 {
-  fbuf->vbuf_curr = NULL;
+  irqstate_t flags;
+
+  flags = enter_critical_section();
   if (fbuf->vbuf_next != NULL)
     {
       fbuf->vbuf_next = fbuf->vbuf_next->next;

--- a/drivers/video/video_framebuff.c
+++ b/drivers/video/video_framebuff.c
@@ -24,6 +24,7 @@
 
 #include <string.h>
 #include <errno.h>
+#include <syslog.h>
 
 #include <nuttx/irq.h>
 #include <nuttx/kmalloc.h>
@@ -232,6 +233,7 @@ void video_framebuff_capture_done(video_framebuff_t *fbuf)
       fbuf->vbuf_next = fbuf->vbuf_next->next;
       if (fbuf->vbuf_next == fbuf->vbuf_top)  /* RING mode case. */
         {
+          syslog(LOG_WARNING, "video buffer is overflow.\n");
           fbuf->vbuf_top  = fbuf->vbuf_top->next;
           fbuf->vbuf_tail = fbuf->vbuf_tail->next;
         }

--- a/drivers/video/video_framebuff.h
+++ b/drivers/video/video_framebuff.h
@@ -26,7 +26,9 @@
  ****************************************************************************/
 
 #include <sys/videoio.h>
+
 #include <nuttx/mutex.h>
+#include <nuttx/spinlock.h>
 
 /****************************************************************************
  * Public Types
@@ -43,6 +45,7 @@ typedef struct vbuf_container_s vbuf_container_t;
 struct video_framebuff_s
 {
   enum v4l2_buf_mode mode;
+  spinlock_t lock_queue;
   mutex_t lock_empty;
   int container_size;
   vbuf_container_t *vbuf_alloced;

--- a/drivers/video/video_framebuff.h
+++ b/drivers/video/video_framebuff.h
@@ -42,14 +42,13 @@ typedef struct vbuf_container_s vbuf_container_t;
 
 struct video_framebuff_s
 {
-  enum v4l2_buf_mode  mode;
+  enum v4l2_buf_mode mode;
   mutex_t lock_empty;
   int container_size;
   vbuf_container_t *vbuf_alloced;
   vbuf_container_t *vbuf_empty;
   vbuf_container_t *vbuf_top;
   vbuf_container_t *vbuf_tail;
-  vbuf_container_t *vbuf_curr;
   vbuf_container_t *vbuf_next;
 };
 

--- a/include/nuttx/video/imgdata.h
+++ b/include/nuttx/video/imgdata.h
@@ -83,6 +83,14 @@ typedef struct imgdata_interval_s
   uint32_t denominator;
 } imgdata_interval_t;
 
+/* Structure for memory operations */
+
+typedef struct imgdata_mem_ops_s
+{
+  CODE void *(*mem_malloc)(uint32_t align_size, uint32_t size);
+  CODE void (*mem_free)(void *data);
+} imgdata_mem_ops_t;
+
 typedef int (*imgdata_capture_t)(uint8_t result, uint32_t size,
                                  FAR const struct timeval *ts,
                                  FAR void *arg);
@@ -121,6 +129,7 @@ struct imgdata_ops_s
 struct imgdata_s
 {
   FAR const struct imgdata_ops_s *ops;
+  FAR const struct imgdata_mem_ops_s *mem_ops;
 };
 
 #ifdef __cplusplus

--- a/include/nuttx/video/imgdata.h
+++ b/include/nuttx/video/imgdata.h
@@ -83,14 +83,6 @@ typedef struct imgdata_interval_s
   uint32_t denominator;
 } imgdata_interval_t;
 
-/* Structure for memory operations */
-
-typedef struct imgdata_mem_ops_s
-{
-  CODE void *(*mem_malloc)(uint32_t align_size, uint32_t size);
-  CODE void (*mem_free)(void *data);
-} imgdata_mem_ops_t;
-
 typedef int (*imgdata_capture_t)(uint8_t result, uint32_t size,
                                  FAR const struct timeval *ts,
                                  FAR void *arg);
@@ -119,6 +111,14 @@ struct imgdata_ops_s
                             FAR imgdata_capture_t callback,
                             FAR void *arg);
   CODE int (*stop_capture)(FAR struct imgdata_s *data);
+
+  /* This is a pair of user define frame memory allocation interface.
+   * If both are NULL, just using system memory operations.
+   */
+
+  CODE void *(*alloc)(FAR struct imgdata_s *data,
+                           uint32_t align_size, uint32_t size);
+  CODE void (*free)(FAR struct imgdata_s *data, void *addr);
 };
 
 /* Image data private data.  This structure only defines the initial fields
@@ -129,7 +129,6 @@ struct imgdata_ops_s
 struct imgdata_s
 {
   FAR const struct imgdata_ops_s *ops;
-  FAR const struct imgdata_mem_ops_s *mem_ops;
 };
 
 #ifdef __cplusplus

--- a/include/nuttx/video/video.h
+++ b/include/nuttx/video/video.h
@@ -77,82 +77,82 @@ struct v4l2_s
 
 struct v4l2_ops_s
 {
-  CODE int (*querycap)(FAR struct v4l2_s *ctx,
+  CODE int (*querycap)(FAR struct file *filep,
                        FAR struct v4l2_capability *cap);
   CODE int (*g_input)(FAR int *num);
-  CODE int (*enum_input)(FAR struct v4l2_s *ctx,
+  CODE int (*enum_input)(FAR struct file *filep,
                          FAR struct v4l2_input *input);
-  CODE int (*reqbufs)(FAR struct v4l2_s *ctx,
+  CODE int (*reqbufs)(FAR struct file *filep,
                       FAR struct v4l2_requestbuffers *reqbufs);
-  CODE int (*querybuf)(FAR struct v4l2_s *ctx,
+  CODE int (*querybuf)(FAR struct file *filep,
                        FAR struct v4l2_buffer *buf);
-  CODE int (*qbuf)(FAR struct v4l2_s *ctx,
+  CODE int (*qbuf)(FAR struct file *filep,
                    FAR struct v4l2_buffer *buf);
-  CODE int (*dqbuf)(FAR struct v4l2_s *ctx,
-                    FAR struct v4l2_buffer *buf, int oflags);
-  CODE int (*cancel_dqbuf)(FAR struct v4l2_s *ctx,
+  CODE int (*dqbuf)(FAR struct file *filep,
+                    FAR struct v4l2_buffer *buf);
+  CODE int (*cancel_dqbuf)(FAR struct file *filep,
                            enum v4l2_buf_type type);
-  CODE int (*g_fmt)(FAR struct v4l2_s *ctx,
+  CODE int (*g_fmt)(FAR struct file *filep,
                     FAR struct v4l2_format *fmt);
-  CODE int (*s_fmt)(FAR struct v4l2_s *ctx,
+  CODE int (*s_fmt)(FAR struct file *filep,
                     FAR struct v4l2_format *fmt);
-  CODE int (*try_fmt)(FAR struct v4l2_s *ctx,
+  CODE int (*try_fmt)(FAR struct file *filep,
                       FAR struct v4l2_format *v4l2);
-  CODE int (*g_parm)(FAR struct v4l2_s *ctx,
+  CODE int (*g_parm)(FAR struct file *filep,
                      FAR struct v4l2_streamparm *parm);
-  CODE int (*s_parm)(FAR struct v4l2_s *ctx,
+  CODE int (*s_parm)(FAR struct file *filep,
                      FAR struct v4l2_streamparm *parm);
-  CODE int (*streamon)(FAR struct v4l2_s *ctx,
+  CODE int (*streamon)(FAR struct file *filep,
                        FAR enum v4l2_buf_type *type);
-  CODE int (*streamoff)(FAR struct v4l2_s *ctx,
+  CODE int (*streamoff)(FAR struct file *filep,
                         FAR enum v4l2_buf_type *type);
-  CODE int (*do_halfpush)(FAR struct v4l2_s *ctx,
+  CODE int (*do_halfpush)(FAR struct file *filep,
                           bool enable);
-  CODE int (*takepict_start)(FAR struct v4l2_s *ctx,
+  CODE int (*takepict_start)(FAR struct file *filep,
                              int32_t capture_num);
-  CODE int (*takepict_stop)(FAR struct v4l2_s *ctx,
+  CODE int (*takepict_stop)(FAR struct file *filep,
                             bool halfpush);
-  CODE int (*s_selection)(FAR struct v4l2_s *ctx,
+  CODE int (*s_selection)(FAR struct file *filep,
                           FAR struct v4l2_selection *clip);
-  CODE int (*g_selection)(FAR struct v4l2_s *ctx,
+  CODE int (*g_selection)(FAR struct file *filep,
                           FAR struct v4l2_selection *clip);
-  CODE int (*queryctrl)(FAR struct v4l2_s *ctx,
+  CODE int (*queryctrl)(FAR struct file *filep,
                         FAR struct v4l2_queryctrl *ctrl);
-  CODE int (*query_ext_ctrl)(FAR struct v4l2_s *ctx,
+  CODE int (*query_ext_ctrl)(FAR struct file *filep,
                              FAR struct v4l2_query_ext_ctrl *ctrl);
-  CODE int (*querymenu)(FAR struct v4l2_s *ctx,
+  CODE int (*querymenu)(FAR struct file *filep,
                         FAR struct v4l2_querymenu *menu);
-  CODE int (*g_ctrl)(FAR struct v4l2_s *ctx,
+  CODE int (*g_ctrl)(FAR struct file *filep,
                      FAR struct v4l2_control *ctrl);
-  CODE int (*s_ctrl)(FAR struct v4l2_s *ctx,
+  CODE int (*s_ctrl)(FAR struct file *filep,
                      FAR struct v4l2_control *ctrl);
-  CODE int (*g_ext_ctrls)(FAR struct v4l2_s *ctx,
+  CODE int (*g_ext_ctrls)(FAR struct file *filep,
                           FAR struct v4l2_ext_controls *ctrls);
-  CODE int (*s_ext_ctrls)(FAR struct v4l2_s *ctx,
+  CODE int (*s_ext_ctrls)(FAR struct file *filep,
                           FAR struct v4l2_ext_controls *ctrls);
-  CODE int (*query_ext_ctrl_scene)(FAR struct v4l2_s *ctx,
+  CODE int (*query_ext_ctrl_scene)(FAR struct file *filep,
               FAR struct v4s_query_ext_ctrl_scene *ctrl);
-  CODE int (*querymenu_scene)(FAR struct v4l2_s *ctx,
+  CODE int (*querymenu_scene)(FAR struct file *filep,
               FAR struct v4s_querymenu_scene *menu);
-  CODE int (*g_ext_ctrls_scene)(FAR struct v4l2_s *ctx,
+  CODE int (*g_ext_ctrls_scene)(FAR struct file *filep,
               FAR struct v4s_ext_controls_scene *ctrls);
-  CODE int (*s_ext_ctrls_scene)(FAR struct v4l2_s *ctx,
+  CODE int (*s_ext_ctrls_scene)(FAR struct file *filep,
               FAR struct v4s_ext_controls_scene *ctrls);
-  CODE int (*enum_fmt)(FAR struct v4l2_s *ctx,
+  CODE int (*enum_fmt)(FAR struct file *filep,
                        FAR struct v4l2_fmtdesc *f);
-  CODE int (*enum_frminterval)(FAR struct v4l2_s *ctx,
+  CODE int (*enum_frminterval)(FAR struct file *filep,
                                FAR struct v4l2_frmivalenum *f);
-  CODE int (*enum_frmsize)(FAR struct v4l2_s *ctx,
+  CODE int (*enum_frmsize)(FAR struct file *filep,
                            FAR struct v4l2_frmsizeenum *f);
-  CODE int (*cropcap)(FAR struct v4l2_s *ctx,
+  CODE int (*cropcap)(FAR struct file *filep,
                       FAR struct v4l2_cropcap *cropcap);
-  CODE int (*dqevent)(FAR struct v4l2_s *ctx,
+  CODE int (*dqevent)(FAR struct file *filep,
                       FAR struct v4l2_event *event);
-  CODE int (*subscribe_event)(FAR struct v4l2_s *ctx,
+  CODE int (*subscribe_event)(FAR struct file *filep,
                               FAR struct v4l2_event_subscription *sub);
-  CODE int (*decoder_cmd)(FAR struct v4l2_s *ctx,
+  CODE int (*decoder_cmd)(FAR struct file *filep,
                           FAR struct v4l2_decoder_cmd *cmd);
-  CODE int (*encoder_cmd)(FAR struct v4l2_s *ctx,
+  CODE int (*encoder_cmd)(FAR struct file *filep,
                           FAR struct v4l2_encoder_cmd *cmd);
 };
 


### PR DESCRIPTION
## Summary

**V4l2 framework**
1. Make v4l2_ops_s to support the mutilple context
2. Add user define memory ops to v4l2_cap

**video_framebuff**
1. Replace critical section with spinlock
2. Hold mutex in video_framebuff_realloc_container
4. Remove the unnecessary vbuf_curr field

## Impact
1. image capture
2. video capture

## Testing

**Setup virtual video device**
```bash
sudo modprobe v4l2loopback
ffmpeg -f x11grab -r 30 -s 640x480 -i :0.0+0,0 -vcodec rawvideo -pix_fmt yuv420p -threads 0 -f v4l2 /dev/video0

```

**Build nxcamera**

```bash
./tools/configure.sh -l sim:nxcamera
make 
```

**Run nxcamera in nsh**
```bash
nxcamera
input /dev/video
output /dev/fb0
stream 640 480 30 YU12
```
