### PR TITLE
arch/espressif: Fix esp32c6 strange characters on boot

### DIFF
--- a/arch/risc-v/src/common/espressif/esp_lowputc.c
+++ b/arch/risc-v/src/common/espressif/esp_lowputc.c
@@ -263,11 +263,11 @@ void esp_lowputc_config_pins(const struct esp_uart_s *priv)
 {
   /* Configure the pins */
 
-  esp_configgpio(priv->txpin, OUTPUT);
-  esp_gpio_matrix_out(priv->txpin, priv->txsig, 0, 0);
-
   esp_configgpio(priv->rxpin, INPUT | PULLUP);
   esp_gpio_matrix_in(priv->rxpin, priv->rxsig, 0);
+
+  esp_configgpio(priv->txpin, OUTPUT);
+  esp_gpio_matrix_out(priv->txpin, priv->txsig, 0, 0);
 
 #ifdef CONFIG_SERIAL_IFLOWCONTROL
   if (priv->iflow)


### PR DESCRIPTION
## Summary
Fix esp32c6 strange characters on boot

## Impact

Only ESP32-C6

## Testing

`esp32c6-devkit:nsh` with and without `CONFIG_DEBUG_FEATURES` option. Also output followed with an serial analyzer.