### PR TITLE
drivers/video/isx019: Fix the default_value of some parameters

### DIFF
--- a/drivers/video/isx019.c
+++ b/drivers/video/isx019.c
@@ -1975,7 +1975,7 @@ static int isx019_get_supported_value(FAR struct imgsensor_s *sensor,
       case IMGSENSOR_ID_EXPOSURE_ABSOLUTE:
         val->type = IMGSENSOR_CTRL_TYPE_INTEGER;
         SET_RANGE(val->u.range, MIN_EXPOSURETIME, MAX_EXPOSURETIME,
-                                STEP_EXPOSURETIME, def->exptime);
+                                STEP_EXPOSURETIME, 0); /* 0 means undefined */
         break;
 
       case IMGSENSOR_ID_AUTO_N_PRESET_WB:
@@ -1997,7 +1997,7 @@ static int isx019_get_supported_value(FAR struct imgsensor_s *sensor,
         SET_DISCRETE(val->u.discrete,
                      NR_ISO,
                      g_isx019_iso,
-                     def->iso);
+                     0); /* 0 means undefined */
         break;
 
       case IMGSENSOR_ID_ISO_SENSITIVITY_AUTO:


### PR DESCRIPTION
## Summary
Because the exposure time and ISO sensitivity are adjusted automatically by default, the default value can not be defined.
So, return the value out of range as the default_value of ioctl(VIDIOC_QUERYCTRL).

## Impact
isx019

## Testing
Tested with spresense
