### PR TITLE
sched/wdog: remove unecessary branch

### DIFF
--- a/sched/wdog/wd_start.c
+++ b/sched/wdog/wd_start.c
@@ -218,10 +218,6 @@ int wd_start(FAR struct wdog_s *wdog, sclock_t delay,
     {
       delay = 1;
     }
-  else if (++delay <= 0)
-    {
-      delay--;
-    }
 
 #ifdef CONFIG_SCHED_TICKLESS
   /* Cancel the interval timer that drives the timing events.  This will


### PR DESCRIPTION
## Summary
It seems that the `else if` branch would only execute if `++delay` would reults in an integer overflow. For example the `delay` is 0x7fff_ffff or 0x7fffffff_ffffffff according to the type of `sclock_t`. However in that case, `--delay` will revert the delay back to value before overflow. So IMO, the `if else` branch doesn't have any impact on the final result of delay if it is already a positive integer. Pls correct me if I was wrong :-)
## Impact

## Testing

