### PR TITLE
xtensa/esp32s3: Add ESP32-S3 AES driver

### DIFF
--- a/Documentation/platforms/xtensa/esp32s3/index.rst
+++ b/Documentation/platforms/xtensa/esp32s3/index.rst
@@ -90,7 +90,7 @@ The following list indicates the state of peripherals' support in NuttX:
 Peripheral Support NOTES
 ========== ======= =====
 ADC          No
-AES          No
+AES          YES
 Bluetooth    No
 CAMERA       No
 CAN/TWAI     Yes

--- a/arch/xtensa/src/esp32s3/Kconfig
+++ b/arch/xtensa/src/esp32s3/Kconfig
@@ -753,6 +753,10 @@ config ESP32S3_LCD
 	---help---
 		LCD controller that outputs parallel data and supports RGB interface.
 
+config ESP32S3_AES_ACCELERATOR
+	bool "AES Accelerator"
+	default n
+
 endmenu # ESP32-S3 Peripheral Selection
 
 menuconfig ESP32S3_WIFI_BT_COEXIST
@@ -2306,5 +2310,14 @@ config ESP32S3_KERNEL_RAM_SIZE
 endif # BUILD_PROTECTED
 
 endmenu # Bootloader and Image Configuration
+
+menu "AES accelerate"
+	depends on ESP32S3_AES_ACCELERATOR
+
+config ESP32S3_AES_ACCELERATOR_TEST
+	bool "AES driver test"
+	default n
+
+endmenu # ESP32S3_AES_ACCELERATOR
 
 endif # ARCH_CHIP_ESP32S3

--- a/arch/xtensa/src/esp32s3/Make.defs
+++ b/arch/xtensa/src/esp32s3/Make.defs
@@ -183,6 +183,10 @@ ifeq ($(CONFIG_ESP32S3_LCD),y)
 CHIP_CSRCS += esp32s3_lcd.c
 endif
 
+ifeq ($(CONFIG_ESP32S3_AES_ACCELERATOR),y)
+CHIP_CSRCS += esp32s3_aes.c
+endif
+
 #############################################################################
 # Espressif HAL for 3rd Party Platforms
 #############################################################################

--- a/arch/xtensa/src/esp32s3/esp32s3_aes.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_aes.c
@@ -1,0 +1,1080 @@
+/****************************************************************************
+ * arch/xtensa/src/esp32s3/esp32s3_aes.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <debug.h>
+#include <semaphore.h>
+
+#include <nuttx/mutex.h>
+#include <nuttx/crypto/crypto.h>
+
+#include "xtensa.h"
+#include "esp32s3_aes.h"
+
+#include "hardware/esp32s3_aes.h"
+#include "hardware/esp32s3_system.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define AES_BLK_SIZE                    (16)
+
+#define AES_MODE_DECRYPT                (BIT(2))
+
+#define AES_IDLE_STATE                  (0)
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static bool g_aes_inited;
+static mutex_t g_aes_lock = NXMUTEX_INITIALIZER;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: aes_hw_setkey
+ *
+ * Description:
+ *   Set AES hardware key and encryption/decryption mode
+ *
+ * Input Parameters:
+ *   aes     - AES object data pointer
+ *   encrypt - True: encryption mode; False: decryption mode
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static void aes_hw_setkey(struct esp32s3_aes_s *aes, bool encrypt)
+{
+  int i;
+  uint32_t cryptbits = encrypt ? 0 : AES_MODE_DECRYPT;
+  uint32_t keybits = (aes->keybits / 64) - 2;
+  uint32_t keywords = aes->keybits / 32;
+
+  putreg32(cryptbits | keybits, AES_MODE_REG);
+
+  for (i = 0; i < keywords; ++i)
+    {
+      putreg32(aes->key[i], AES_KEY_0_REG + i * 4);
+    }
+}
+
+/****************************************************************************
+ * Name: aes_hw_cypher
+ *
+ * Description:
+ *   Process AES hardware encryption/decryption.
+ *
+ * Input Parameters:
+ *   s - Input data pointer
+ *   d - Output buffer pointer
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+static void aes_hw_cypher(const uint8_t *s, uint8_t *d)
+{
+  uint32_t buffer[AES_BLK_SIZE / 4];
+
+  memcpy(buffer, s, AES_BLK_SIZE);
+
+  putreg32(buffer[0], AES_TEXT_IN_0_REG + 0);
+  putreg32(buffer[1], AES_TEXT_IN_0_REG + 4);
+  putreg32(buffer[2], AES_TEXT_IN_0_REG + 8);
+  putreg32(buffer[3], AES_TEXT_IN_0_REG + 12);
+
+  putreg32(AES_TRIGGER_M, AES_TRIGGER_REG);
+
+  while (getreg32(AES_STATE_REG) != AES_IDLE_STATE)
+    {
+    }
+
+  buffer[0] = getreg32(AES_TEXT_OUT_0_REG + 0);
+  buffer[1] = getreg32(AES_TEXT_OUT_0_REG + 4);
+  buffer[2] = getreg32(AES_TEXT_OUT_0_REG + 8);
+  buffer[3] = getreg32(AES_TEXT_OUT_0_REG + 12);
+
+  memcpy(d, buffer, AES_BLK_SIZE);
+}
+
+/****************************************************************************
+ * Name: gf128mul_x_ble
+ *
+ * Description:
+ *   GF(2^128) multiplication function.
+ *
+ * Input Parameters:
+ *   d - Result buffer
+ *   s - Input data buffer
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+static void gf128mul_x_ble(uint8_t *d, const uint8_t *s)
+{
+  uint64_t a, b, ra, rb;
+
+  memcpy(&a, s, 8);
+  memcpy(&b, s + 8, 8);
+
+  ra = (a <<  1) ^ (0x0087 >> (8 - ((b >> 63) << 3)));
+  rb = (a >> 63) | (b << 1);
+
+  memcpy(d, &ra, 8);
+  memcpy(d + 8, &rb, 8);
+}
+
+#ifdef CONFIG_ESP32S3_AES_ACCELERATOR_TEST
+
+/****************************************************************************
+ * Name: esp32s3_aes_ecb_test
+ *
+ * Description:
+ *   ESP32-S3 AES-ECB test.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static void esp32s3_aes_ecb_test(void)
+{
+  int ret;
+  int i;
+  int keybits;
+  uint8_t encrypt_buf[16];
+  uint8_t decrypt_buf[16];
+  struct esp32s3_aes_s aes;
+  const int size = 16;
+
+  const uint32_t input[8] =
+    {
+      0x740fdb34, 0x002defca, 0xb042437b, 0xc2f42cf9,
+      0xc64444be, 0x32365bc1, 0xb613cfa2, 0x15ce0d23
+    };
+
+  const uint32_t key[16] =
+    {
+      0x8ffdc2c5, 0x14d6c69d, 0x9cb7608f, 0x899b2472,
+      0xbf9e4372, 0x855290d0, 0xc62753da, 0xdeedeab7
+    };
+
+  const uint32_t result[2][4] =
+    {
+      /* keybits = 128 */
+
+      {
+        0xc810df2a, 0x8ae67e6e, 0x50c5e32c, 0xd535f3e4
+      },
+
+      /* keybits = 256 */
+
+      {
+        0xa0714c2b, 0x356adb1f, 0xe905c243, 0x35195a7c
+      }
+    };
+
+  for (i = 0; i < 2; i++)
+    {
+      keybits = i * 128 + 128;
+
+      ret = esp32s3_aes_setkey(&aes, key, keybits);
+      DEBUGASSERT(ret == 0);
+
+      ret = esp32s3_aes_ecb_cypher(&aes, 1, input, encrypt_buf, size);
+      DEBUGASSERT(ret == 0);
+
+      if (memcmp(encrypt_buf, result[i], size))
+        {
+          DEBUGASSERT(0);
+        }
+
+      ret = esp32s3_aes_ecb_cypher(&aes, 0, encrypt_buf, decrypt_buf, size);
+      DEBUGASSERT(ret == 0);
+
+      if (memcmp(decrypt_buf, input, size))
+        {
+          DEBUGASSERT(0);
+        }
+
+      syslog(LOG_INFO, "AES ECB key=%d bits test: PASS\n", keybits);
+    }
+}
+
+/****************************************************************************
+ * Name: esp32s3_aes_cbc_test
+ *
+ * Description:
+ *   ESP32-S3 AES-CBC test.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static void esp32s3_aes_cbc_test(void)
+{
+  int ret;
+  int i;
+  int keybits;
+  uint8_t encrypt_buf[32];
+  uint8_t decrypt_buf[32];
+  uint8_t iv_buf[16];
+  struct esp32s3_aes_s aes;
+  const int size = 32;
+
+  const uint32_t input[8] =
+    {
+      0x740fdb34, 0x002defca, 0xb042437b, 0xc2f42cf9,
+      0xc64444be, 0x32365bc1, 0xb613cfa2, 0x15ce0d23
+    };
+
+  const uint32_t key[16] =
+    {
+      0x8ffdc2c5, 0x14d6c69d, 0x9cb7608f, 0x899b2472,
+      0xbf9e4372, 0x855290d0, 0xc62753da, 0xdeedeab7
+    };
+
+  const uint32_t iv[4] =
+    {
+      0xf53a50f2, 0x8aaf711d, 0x953bbbfa, 0x228d53cb
+    };
+
+  const uint32_t result[2][8] =
+    {
+      /* keybits = 128 */
+
+      {
+        0x04e27d12, 0x1a91e508, 0x01092431, 0x9d572184,
+        0xa39979e1, 0x5543e1bc, 0x7173b71d, 0x4e3be064
+      },
+
+      /* keybits = 256 */
+
+      {
+        0x6f36b8fe, 0x33bc1f37, 0x24fe659c, 0x0370def0,
+        0xb9a852f8, 0x64a79ae2, 0xd59f5045, 0x648a0f44
+      }
+    };
+
+  for (i = 0; i < 2; i++)
+    {
+      keybits = i * 128 + 128;
+
+      ret = esp32s3_aes_setkey(&aes, key, keybits);
+      DEBUGASSERT(ret == 0);
+
+      memcpy(iv_buf, iv, 16);
+      ret = esp32s3_aes_cbc_cypher(&aes, 1, iv_buf, input,
+                                   encrypt_buf, size);
+      DEBUGASSERT(ret == 0);
+
+      if (memcmp(encrypt_buf, result[i], size))
+        {
+          DEBUGASSERT(0);
+        }
+
+      memcpy(iv_buf, iv, 16);
+      ret = esp32s3_aes_cbc_cypher(&aes, 0, iv_buf, encrypt_buf,
+                                   decrypt_buf, size);
+      DEBUGASSERT(ret == 0);
+
+      if (memcmp(decrypt_buf, input, size))
+        {
+          DEBUGASSERT(0);
+        }
+
+      syslog(LOG_INFO, "AES CBC key=%d bits test: PASS\n", keybits);
+    }
+}
+
+/****************************************************************************
+ * Name: esp32s3_aes_ctr_test
+ *
+ * Description:
+ *   ESP32-S3 AES-CTR test.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static void esp32s3_aes_ctr_test(void)
+{
+  int ret;
+  int i;
+  int keybits;
+  uint8_t encrypt_buf[32];
+  uint8_t decrypt_buf[32];
+  uint8_t cnt_buf[16];
+  uint8_t cache_buf[16];
+  uint32_t nc_off;
+  struct esp32s3_aes_s aes;
+  const int size = 32;
+
+  const uint32_t input[8] =
+    {
+      0x740fdb34, 0x002defca, 0xb042437b, 0xc2f42cf9,
+      0xc64444be, 0x32365bc1, 0xb613cfa2, 0x15ce0d23
+    };
+
+  const uint32_t key[16] =
+    {
+      0x8ffdc2c5, 0x14d6c69d, 0x9cb7608f, 0x899b2472,
+      0xbf9e4372, 0x855290d0, 0xc62753da, 0xdeedeab7
+    };
+
+  const uint32_t cnt[4] =
+    {
+      0xf53a50f2, 0x8aaf711d, 0x953bbbfa, 0x228d53cb
+    };
+
+  const uint32_t result[2][8] =
+    {
+      /* keybits = 128 */
+
+      {
+        0x5f922338, 0x5aff403d, 0x45fede3f, 0x616568c6,
+        0x3cd0ffc7, 0xa26cb704, 0x0aaa8b6a, 0x1d0b5e1c
+      },
+
+      /* keybits = 256 */
+
+      {
+        0x70af4473, 0x597d2126, 0xd598ed09, 0x3fea540c,
+        0xfb5c743c, 0x0c1a39ca, 0xcbcf2d17, 0x341a7a0c
+      }
+    };
+
+  for (i = 0; i < 2; i++)
+    {
+      keybits = i * 128 + 128;
+
+      ret = esp32s3_aes_setkey(&aes, key, keybits);
+      DEBUGASSERT(ret == 0);
+
+      nc_off = 0;
+      memcpy(cnt_buf, cnt, 16);
+      ret = esp32s3_aes_ctr_cypher(&aes, &nc_off, cnt_buf, cache_buf,
+                                   input, encrypt_buf, size);
+      DEBUGASSERT(ret == 0);
+
+      if (memcmp(encrypt_buf, result[i], size))
+        {
+          DEBUGASSERT(0);
+        }
+
+      nc_off = 0;
+      memcpy(cnt_buf, cnt, 16);
+      ret = esp32s3_aes_ctr_cypher(&aes, &nc_off, cnt_buf, cache_buf,
+                                   encrypt_buf, decrypt_buf, size);
+      DEBUGASSERT(ret == 0);
+
+      if (memcmp(decrypt_buf, input, size))
+        {
+          DEBUGASSERT(0);
+        }
+
+      syslog(LOG_INFO, "AES CTR key=%d bits test: PASS\n", keybits);
+    }
+}
+
+/****************************************************************************
+ * Name: esp32s3_aes_xts_test
+ *
+ * Description:
+ *   ESP32-S3 AES-XTS test.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static void esp32s3_aes_xts_test(void)
+{
+  int ret;
+  int i;
+  int keybits;
+  uint8_t encrypt_buf[32];
+  uint8_t decrypt_buf[32];
+  uint8_t unit_buf[16];
+  struct esp32s3_aes_xts_s aes;
+  int size;
+
+  const uint32_t input[8] =
+    {
+      0x740fdb34, 0x002defca, 0xb042437b, 0xc2f42cf9,
+      0xc64444be, 0x32365bc1, 0xb613cfa2, 0x15ce0d23
+    };
+
+  const uint32_t key[16] =
+    {
+      0x8ffdc2c5, 0x14d6c69d, 0x9cb7608f, 0x899b2472,
+      0xbf9e4372, 0x855290d0, 0xc62753da, 0xdeedeab7,
+      0x7ac6c53b, 0xc94f0b81, 0xdd673fc9, 0x8c1b71a6,
+      0x1f99b728, 0x5e7af2eb, 0xcc7274a3, 0xf0005b23
+    };
+
+  const uint32_t unit[4] =
+    {
+      0xf53a50f2, 0x8aaf711d, 0x953bbbfa, 0x228d53cb
+    };
+
+  const uint32_t result_in32[2][8] =
+    {
+      /* keybits = 256 */
+
+      {
+        0xf70e05fd, 0x2791be41, 0x926ec006, 0xc76068f4,
+        0x01fd0843, 0xdf5e576a, 0xa4b1833d, 0x90502608
+      },
+
+      /* keybits = 512 */
+
+      {
+        0x164b4185, 0x4cb1cce7, 0xf285e523, 0x06a5923a,
+        0xae4fcb7b, 0x59ce9dc6, 0xed64546f, 0x5889cb17
+      }
+    };
+
+  const uint32_t result_in30[2][8] =
+    {
+      /* keybits = 256 */
+
+      {
+        0x26991fb6, 0x72e4a7bc, 0x97041d61, 0x9ec889af,
+        0xf70e05fd, 0x2791be41, 0x926ec006, 0x000068f4
+      },
+
+      /* keybits = 512 */
+
+      {
+        0x4b42dd86, 0xeee792c0, 0x1516ff95, 0x1f5fd9e6,
+        0x164b4185, 0x4cb1cce7, 0xf285e523, 0x0000923a
+      }
+    };
+
+  for (i = 0; i < 2; i++)
+    {
+      keybits = i * 256 + 256;
+
+      ret = esp32s3_aes_xts_setkey(&aes, key, keybits);
+      DEBUGASSERT(ret == 0);
+
+      /* Encrypt/Decrypt 32 bytes */
+
+      size = 32;
+
+      memcpy(unit_buf, unit, 16);
+      ret = esp32s3_aes_xts_cypher(&aes, true, unit_buf, input,
+                                   encrypt_buf, size);
+      DEBUGASSERT(ret == 0);
+
+      if (memcmp(encrypt_buf, result_in32[i], size))
+        {
+          DEBUGASSERT(0);
+        }
+
+      memcpy(unit_buf, unit, 16);
+      ret = esp32s3_aes_xts_cypher(&aes, false, unit_buf, encrypt_buf,
+                                   decrypt_buf, size);
+      DEBUGASSERT(ret == 0);
+
+      if (memcmp(decrypt_buf, input, size))
+        {
+          DEBUGASSERT(0);
+        }
+
+      /* Encrypt/Decrypt 30 bytes */
+
+      size = 30;
+
+      memcpy(unit_buf, unit, 16);
+      ret = esp32s3_aes_xts_cypher(&aes, true, unit_buf, input,
+                                   encrypt_buf, size);
+      DEBUGASSERT(ret == 0);
+
+      if (memcmp(encrypt_buf, result_in30[i], size))
+        {
+          DEBUGASSERT(0);
+        }
+
+      memcpy(unit_buf, unit, 16);
+      ret = esp32s3_aes_xts_cypher(&aes, false, unit_buf, encrypt_buf,
+                                   decrypt_buf, size);
+      DEBUGASSERT(ret == 0);
+
+      if (memcmp(decrypt_buf, input, size))
+        {
+          DEBUGASSERT(0);
+        }
+
+      syslog(LOG_INFO, "AES XTS key=%d bits test: PASS\n", keybits);
+    }
+}
+
+#endif
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: esp32s3_aes_ecb_cypher
+ *
+ * Description:
+ *   Process AES ECB encryption/decryption.
+ *
+ * Input Parameters:
+ *   aes     - AES object data pointer
+ *   encrypt - True: encryption mode; False: decryption mode
+ *   input   - Input data pointer
+ *   output  - Output buffer pointer
+ *   size    - Data size in bytes
+ *
+ * Returned Value:
+ *   OK is returned on success. Otherwise, a negated errno value is returned.
+ *
+ ****************************************************************************/
+
+int esp32s3_aes_ecb_cypher(struct esp32s3_aes_s *aes, bool encrypt,
+                           const void *input, void *output, uint32_t size)
+{
+  int ret;
+  uint32_t i;
+  const uint8_t *s = (const uint8_t *)input;
+  uint8_t *d = (uint8_t *)output;
+
+  DEBUGASSERT(aes && input && output);
+  DEBUGASSERT(size && ((size % AES_BLK_SIZE) == 0));
+
+  ret = nxmutex_lock(&g_aes_lock);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  aes_hw_setkey(aes, encrypt);
+
+  for (i = 0; i < size; i += AES_BLK_SIZE)
+    {
+      aes_hw_cypher(s, d);
+
+      s += AES_BLK_SIZE;
+      d += AES_BLK_SIZE;
+    }
+
+  ret = nxmutex_unlock(&g_aes_lock);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: esp32s3_aes_cbc_cypher
+ *
+ * Description:
+ *   Process AES CBC encryption/decryption.
+ *
+ * Input Parameters:
+ *   aes     - AES object data pointer
+ *   encrypt - True: encryption mode; False: decryption mode
+ *   ivptr   - Initialization vector pointer
+ *   input   - Input data pointer
+ *   output  - Output buffer pointer
+ *   size    - Data size in bytes
+ *
+ * Returned Value:
+ *   OK is returned on success. Otherwise, a negated errno value is returned.
+ *
+ ****************************************************************************/
+
+int esp32s3_aes_cbc_cypher(struct esp32s3_aes_s *aes, bool encrypt,
+                           void *ivptr, const void *input, void *output,
+                           uint32_t size)
+{
+  int ret;
+  uint32_t i;
+  uint32_t j;
+  const uint8_t *s = (const uint8_t *)input;
+  uint8_t *d = (uint8_t *)output;
+  uint8_t *iv = (uint8_t *)ivptr;
+
+  DEBUGASSERT(aes && input && output && ivptr);
+  DEBUGASSERT(size && ((size % AES_BLK_SIZE) == 0));
+
+  ret = nxmutex_lock(&g_aes_lock);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  aes_hw_setkey(aes, encrypt);
+
+  for (i = 0; i < size; i += AES_BLK_SIZE)
+    {
+      if (encrypt)
+        {
+          for (j = 0; j < AES_BLK_SIZE; j++)
+            {
+              d[j] = s[j] ^ iv[j];
+            }
+
+          aes_hw_cypher(d, d);
+
+          memcpy(iv, d, AES_BLK_SIZE);
+        }
+      else
+        {
+          aes_hw_cypher(s, d);
+
+          for (j = 0; j < AES_BLK_SIZE; j++)
+            {
+              d[j] = d[j] ^ iv[j];
+            }
+
+          memcpy(iv, s, AES_BLK_SIZE);
+        }
+
+      s += AES_BLK_SIZE;
+      d += AES_BLK_SIZE;
+    }
+
+  ret = nxmutex_unlock(&g_aes_lock);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: esp32s3_aes_ctr_cypher
+ *
+ * Description:
+ *   Process AES CTR encryption/decryption.
+ *
+ * Input Parameters:
+ *   aes      - AES object data pointer
+ *   offptr   - Offset buffer pointer
+ *   cntptr   - Counter buffer pointer
+ *   cacheptr - Counter calculation buffer pointer
+ *   input    - Input data pointer
+ *   output   - Output buffer pointer
+ *   size     - Data size in bytes
+ *
+ * Returned Value:
+ *   OK is returned on success. Otherwise, a negated errno value is returned.
+ *
+ ****************************************************************************/
+
+int esp32s3_aes_ctr_cypher(struct esp32s3_aes_s *aes, uint32_t *offptr,
+                           void *cntptr, void *cacheptr, const void *input,
+                           void *output, uint32_t size)
+{
+  int ret;
+  uint32_t i;
+  uint32_t j;
+  uint32_t n;
+  uint8_t *cnt = (uint8_t *)cntptr;
+  uint8_t *cache = (uint8_t *)cacheptr;
+  const uint8_t *s = (const uint8_t *)input;
+  uint8_t *d = (uint8_t *)output;
+
+  DEBUGASSERT(aes && offptr && cntptr && cacheptr && input && output);
+  DEBUGASSERT(size);
+
+  ret = nxmutex_lock(&g_aes_lock);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  aes_hw_setkey(aes, true);
+
+  n = *offptr;
+  for (i = 0; i < size; i++)
+    {
+      if (n == 0)
+        {
+          aes_hw_cypher(cnt, cache);
+          for (j = AES_BLK_SIZE - 1; j > 0; j--)
+            {
+              cnt[j]++;
+              if (cnt[j] != 0)
+                {
+                  break;
+                }
+            }
+        }
+
+      d[i] = s[i] ^ cache[n];
+
+      n = (n + 1) & (AES_BLK_SIZE - 1);
+    }
+
+  *offptr = n;
+
+  ret = nxmutex_unlock(&g_aes_lock);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: esp32s3_aes_xts_cypher
+ *
+ * Description:
+ *   Process AES XTS encryption/decryption.
+ *
+ * Input Parameters:
+ *   aes     - AES object data pointer
+ *   encrypt - True: encryption mode; False: decryption mode
+ *   unitptr - Unit data buffer pointer
+ *   input   - Input data pointer
+ *   output  - Output buffer pointer
+ *   size    - Data size in bytes
+ *
+ * Returned Value:
+ *   OK is returned on success. Otherwise, a negated errno value is returned.
+ *
+ ****************************************************************************/
+
+int esp32s3_aes_xts_cypher(struct esp32s3_aes_xts_s *aes, bool encrypt,
+                           void *unitptr, const void *input, void *output,
+                           uint32_t size)
+{
+  int ret;
+  uint32_t i;
+  uint32_t j;
+  uint32_t blks;
+  uint32_t rst;
+  uint8_t *t;
+  uint8_t *prev_output;
+  uint8_t tweak[AES_BLK_SIZE];
+  uint8_t prev_tweak[AES_BLK_SIZE];
+  uint8_t tmp[AES_BLK_SIZE];
+  uint8_t *unit = (uint8_t *)unitptr;
+  const uint8_t *s = (const uint8_t *)input;
+  uint8_t *d = (uint8_t *)output;
+
+  DEBUGASSERT(aes && unitptr && input && output);
+
+  /* NIST SP 80-38E disallows data units larger than 2**20 blocks. */
+
+  DEBUGASSERT((size >= AES_BLK_SIZE) &&
+              (size <= ((1 << 20) * AES_BLK_SIZE)));
+
+  ret = nxmutex_lock(&g_aes_lock);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  blks = size / AES_BLK_SIZE;
+  rst  = size % AES_BLK_SIZE;
+
+  aes_hw_setkey(&aes->tweak, true);
+  aes_hw_cypher(unit, tweak);
+
+  for (i = 0; i < blks; i++)
+    {
+      if (rst && (encrypt == false) && (blks == 1))
+        {
+          memcpy(prev_tweak, tweak, AES_BLK_SIZE);
+          gf128mul_x_ble(tweak, tweak);
+        }
+
+      for (j = 0; j < AES_BLK_SIZE; j++)
+        {
+          tmp[j] = s[j] ^ tweak[j];
+        }
+
+      aes_hw_setkey(&aes->crypt, encrypt);
+      aes_hw_cypher(tmp, tmp);
+
+      for (j = 0; j < AES_BLK_SIZE; j++)
+        {
+          d[j] = tmp[j] ^ tweak[j];
+        }
+
+      gf128mul_x_ble(tweak, tweak);
+
+      s += AES_BLK_SIZE;
+      d += AES_BLK_SIZE;
+    }
+
+  if (rst)
+    {
+      t = encrypt ? tweak : prev_tweak;
+      prev_output = d - AES_BLK_SIZE;
+
+      for (i = 0; i < rst; i++)
+        {
+          d[i] = prev_output[i];
+          tmp[i] = s[i] ^ t[i];
+        }
+
+      for (; i < AES_BLK_SIZE; i++)
+        {
+          tmp[i] = prev_output[i] ^ t[i];
+        }
+
+      aes_hw_setkey(&aes->crypt, encrypt);
+      aes_hw_cypher(tmp, tmp);
+
+      for (i = 0; i < AES_BLK_SIZE; i++)
+        {
+          prev_output[i] = tmp[i] ^ t[i];
+        }
+    }
+
+  ret = nxmutex_unlock(&g_aes_lock);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: esp32s3_aes_setkey
+ *
+ * Description:
+ *   Configurate AES key.
+ *
+ * Input Parameters:
+ *   aes     - AES object data pointer
+ *   keyptr  - Key data pointer
+ *   keybits - Key data bits
+ *
+ * Returned Value:
+ *   OK is returned on success. Otherwise, a negated errno value is returned.
+ *
+ ****************************************************************************/
+
+int esp32s3_aes_setkey(struct esp32s3_aes_s *aes, const void *keyptr,
+                       uint16_t keybits)
+{
+  DEBUGASSERT(aes && keyptr);
+
+  if ((keybits != 128) && (keybits != 256))
+    {
+      return -EINVAL;
+    }
+
+  aes->keybits = keybits;
+  memcpy(aes->key, keyptr, keybits / 8);
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: esp32s3_aes_xts_setkey
+ *
+ * Description:
+ *   Configurate AES XTS key.
+ *
+ * Input Parameters:
+ *   aes     - AES object data pointer
+ *   keyptr  - Key data pointer
+ *   keybits - Key data bits
+ *
+ * Returned Value:
+ *   OK is returned on success. Otherwise, a negated errno value is returned.
+ *
+ ****************************************************************************/
+
+int esp32s3_aes_xts_setkey(struct esp32s3_aes_xts_s *aes, const void *keyptr,
+                           uint16_t keybits)
+{
+  const uint8_t *key = (const uint8_t *)keyptr;
+  uint16_t half_keybits = keybits / 2;
+
+  DEBUGASSERT(aes && keyptr);
+
+  if ((keybits != 256) && (keybits != 512))
+    {
+      return -EINVAL;
+    }
+
+  aes->crypt.keybits = half_keybits;
+  memcpy(aes->crypt.key, key, half_keybits / 8);
+
+  aes->tweak.keybits = half_keybits;
+  memcpy(aes->tweak.key, key + half_keybits / 8, half_keybits / 8);
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: esp32s3_aes_init
+ *
+ * Description:
+ *   Initialize ESP32-S3 AES hardware.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   OK is returned on success. Otherwise, a negated errno value is returned.
+ *
+ ****************************************************************************/
+
+int esp32s3_aes_init(void)
+{
+  if (g_aes_inited == false)
+    {
+      modifyreg32(SYSTEM_PERIP_CLK_EN1_REG, 0, SYSTEM_CRYPTO_AES_CLK_EN);
+      modifyreg32(SYSTEM_PERIP_RST_EN1_REG, SYSTEM_CRYPTO_AES_RST, 0);
+      g_aes_inited = true;
+    }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: aes_cypher
+ ****************************************************************************/
+
+#ifdef CONFIG_CRYPTO_AES
+
+int aes_cypher(void *out, const void *in, size_t size,
+               const void *iv, const void *key, size_t keysize,
+               int mode, int encrypt)
+{
+  int ret;
+  uint8_t iv_buf[AES_BLK_SIZE];
+  uint8_t cache_buf[AES_BLK_SIZE];
+  uint32_t nc_off;
+  struct esp32s3_aes_s aes;
+
+  if ((size & (AES_BLK_SIZE - 1)) != 0)
+    {
+      return -EINVAL;
+    }
+
+  if (mode == AES_MODE_CTR)
+    {
+      keysize -= 4;
+    }
+
+  if (keysize != 16 && keysize != 32)
+    {
+      return -EINVAL;
+    }
+
+  if ((mode != AES_MODE_ECB) &&
+      (mode != AES_MODE_CBC) &&
+      (mode != AES_MODE_CTR))
+    {
+      return -EINVAL;
+    }
+
+  ret = esp32s3_aes_init();
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  ret = esp32s3_aes_setkey(&aes, key, keysize * 8);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  switch (mode)
+    {
+      case AES_MODE_ECB:
+        ret = esp32s3_aes_ecb_cypher(&aes, encrypt, in, out, size);
+        break;
+      case AES_MODE_CBC:
+        memcpy(iv_buf, iv, AES_BLK_SIZE);
+        ret = esp32s3_aes_cbc_cypher(&aes, encrypt, iv_buf, in, out, size);
+        break;
+      case AES_MODE_CTR:
+        nc_off = 0;
+        memcpy(iv_buf, iv, AES_BLK_SIZE);
+        ret = esp32s3_aes_ctr_cypher(&aes, &nc_off, iv_buf, cache_buf,
+                                     in, out, size);
+        break;
+      default :
+        ret = -EINVAL;
+        break;
+    }
+
+  return ret;
+}
+
+#endif
+
+#ifdef CONFIG_ESP32S3_AES_ACCELERATOR_TEST
+
+/****************************************************************************
+ * Name: esp32s3_aes_test
+ ****************************************************************************/
+
+void esp32s3_aes_test(void)
+{
+  esp32s3_aes_ecb_test();
+  esp32s3_aes_cbc_test();
+  esp32s3_aes_ctr_test();
+  esp32s3_aes_xts_test();
+  syslog(LOG_INFO, "\nAES hardware accelerate test done.\n");
+}
+
+#endif

--- a/arch/xtensa/src/esp32s3/esp32s3_aes.h
+++ b/arch/xtensa/src/esp32s3/esp32s3_aes.h
@@ -1,0 +1,227 @@
+/****************************************************************************
+ * arch/xtensa/src/esp32s3/esp32s3_aes.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#ifndef __ARCH_XTENSA_SRC_ESP32S3_ESP32S3_AES_H
+#define __ARCH_XTENSA_SRC_ESP32S3_ESP32S3_AES_H
+
+#include <nuttx/config.h>
+#include <stdint.h>
+
+#ifndef __ASSEMBLY__
+
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/* AES private description */
+
+struct esp32s3_aes_s
+{
+  uint32_t  key[8];     /* Key data value */
+  uint16_t  keybits;    /* Key data bits */
+};
+
+/* AES XTS private description */
+
+struct esp32s3_aes_xts_s
+{
+  struct esp32s3_aes_s crypt;  /* AES block encryption/decryption */
+  struct esp32s3_aes_s tweak;  /* AES tweak encryption/decryption */
+};
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: esp32s3_aes_ecb_cypher
+ *
+ * Description:
+ *   Process AES ECB encryption/decryption.
+ *
+ * Input Parameters:
+ *   aes     - AES object data pointer
+ *   encrypt - True: encryption mode; False: decryption mode
+ *   input   - Input data pointer
+ *   output  - Output buffer pointer
+ *   size    - Data size in bytes
+ *
+ * Returned Value:
+ *   OK is returned on success. Otherwise, a negated errno value is returned.
+ *
+ ****************************************************************************/
+
+int esp32s3_aes_ecb_cypher(struct esp32s3_aes_s *aes, bool encrypt,
+                           const void *input, void *output, uint32_t size);
+
+/****************************************************************************
+ * Name: esp32s3_aes_cbc_cypher
+ *
+ * Description:
+ *   Process AES CBC encryption/decryption.
+ *
+ * Input Parameters:
+ *   aes     - AES object data pointer
+ *   encrypt - True: encryption mode; False: decryption mode
+ *   ivptr   - Initialization vector pointer
+ *   input   - Input data pointer
+ *   output  - Output buffer pointer
+ *   size    - Data size in bytes
+ *
+ * Returned Value:
+ *   OK is returned on success. Otherwise, a negated errno value is returned.
+ *
+ ****************************************************************************/
+
+int esp32s3_aes_cbc_cypher(struct esp32s3_aes_s *aes, bool encrypt,
+                           void *ivptr, const void *input, void *output,
+                           uint32_t size);
+
+/****************************************************************************
+ * Name: esp32s3_aes_ctr_cypher
+ *
+ * Description:
+ *   Process AES CTR encryption/decryption.
+ *
+ * Input Parameters:
+ *   aes      - AES object data pointer
+ *   offptr   - Offset buffer pointer
+ *   cntptr   - Counter buffer pointer
+ *   cacheptr - Counter calculation buffer pointer
+ *   input    - Input data pointer
+ *   output   - Output buffer pointer
+ *   size     - Data size in bytes
+ *
+ * Returned Value:
+ *   OK is returned on success. Otherwise, a negated errno value is returned.
+ *
+ ****************************************************************************/
+
+int esp32s3_aes_ctr_cypher(struct esp32s3_aes_s *aes, uint32_t *offptr,
+                           void *cntptr, void *cacheptr, const void *input,
+                           void *output, uint32_t size);
+
+/****************************************************************************
+ * Name: esp32s3_aes_xts_cypher
+ *
+ * Description:
+ *   Process AES XTS encryption/decryption.
+ *
+ * Input Parameters:
+ *   aes     - AES object data pointer
+ *   encrypt - True: encryption mode; False: decryption mode
+ *   unitptr - Unit data buffer pointer
+ *   input   - Input data pointer
+ *   output  - Output buffer pointer
+ *   size    - Data size in bytes
+ *
+ * Returned Value:
+ *   OK is returned on success. Otherwise, a negated errno value is returned.
+ *
+ ****************************************************************************/
+
+int esp32s3_aes_xts_cypher(struct esp32s3_aes_xts_s *aes, bool encrypt,
+                           void *unitptr, const void *input, void *output,
+                           uint32_t size);
+
+/****************************************************************************
+ * Name: esp32s3_aes_setkey
+ *
+ * Description:
+ *   Configurate AES key.
+ *
+ * Input Parameters:
+ *   aes     - AES object data pointer
+ *   keyptr  - Key data pointer
+ *   keybits - Key data bits
+ *
+ * Returned Value:
+ *   OK is returned on success. Otherwise, a negated errno value is returned.
+ *
+ ****************************************************************************/
+
+int esp32s3_aes_setkey(struct esp32s3_aes_s *aes, const void *keyptr,
+                       uint16_t keybits);
+
+/****************************************************************************
+ * Name: esp32s3_aes_xts_setkey
+ *
+ * Description:
+ *   Configurate AES XTS key.
+ *
+ * Input Parameters:
+ *   aes     - AES object data pointer
+ *   keyptr  - Key data pointer
+ *   keybits - Key data bits
+ *
+ * Returned Value:
+ *   OK is returned on success. Otherwise, a negated errno value is returned.
+ *
+ ****************************************************************************/
+
+int esp32s3_aes_xts_setkey(struct esp32s3_aes_xts_s *aes, const void *keyptr,
+                           uint16_t keybits);
+
+/****************************************************************************
+ * Name: esp32s3_aes_init
+ *
+ * Description:
+ *   Initialize ESP32-S3 AES hardware driver.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   OK is returned on success. Otherwise, a negated errno value is returned.
+ *
+ ****************************************************************************/
+
+int esp32s3_aes_init(void);
+
+#ifdef CONFIG_ESP32S3_AES_ACCELERATOR_TEST
+
+/****************************************************************************
+ * Name: esp32s3_aes_test
+ ****************************************************************************/
+
+void esp32s3_aes_test(void);
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+#undef EXTERN
+
+#endif /* __ASSEMBLY__ */
+#endif /* __ARCH_RISCV_SRC_ESP32S3_LEGACY_ESP32S3_AES_H */

--- a/arch/xtensa/src/esp32s3/hardware/esp32s3_aes.h
+++ b/arch/xtensa/src/esp32s3/hardware/esp32s3_aes.h
@@ -1,0 +1,780 @@
+/****************************************************************************
+ * arch/xtensa/src/esp32s3/hardware/esp32s3_aes.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_XTENSA_SRC_ESP32S3_HARDWARE_ESP32S3_AES_H
+#define __ARCH_XTENSA_SRC_ESP32S3_HARDWARE_ESP32S3_AES_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include "esp32s3_soc.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* AES_KEY_0_REG register
+ * AES key register 0
+ */
+
+#define AES_KEY_0_REG (DR_REG_AES_BASE + 0x0)
+
+/* AES_KEY_0 : R/W; bitpos: [31:0]; default: 0;
+ * Stores AES keys.
+ */
+
+#define AES_KEY_0    0xFFFFFFFF
+#define AES_KEY_0_M  (AES_KEY_0_V << AES_KEY_0_S)
+#define AES_KEY_0_V  0xFFFFFFFF
+#define AES_KEY_0_S  0
+
+/* AES_KEY_1_REG register
+ * AES key register 1
+ */
+
+#define AES_KEY_1_REG (DR_REG_AES_BASE + 0x4)
+
+/* AES_KEY_1 : R/W; bitpos: [31:0]; default: 0;
+ * Stores AES keys.
+ */
+
+#define AES_KEY_1    0xFFFFFFFF
+#define AES_KEY_1_M  (AES_KEY_1_V << AES_KEY_1_S)
+#define AES_KEY_1_V  0xFFFFFFFF
+#define AES_KEY_1_S  0
+
+/* AES_KEY_2_REG register
+ * AES key register 2
+ */
+
+#define AES_KEY_2_REG (DR_REG_AES_BASE + 0x8)
+
+/* AES_KEY_2 : R/W; bitpos: [31:0]; default: 0;
+ * Stores AES keys.
+ */
+
+#define AES_KEY_2    0xFFFFFFFF
+#define AES_KEY_2_M  (AES_KEY_2_V << AES_KEY_2_S)
+#define AES_KEY_2_V  0xFFFFFFFF
+#define AES_KEY_2_S  0
+
+/* AES_KEY_3_REG register
+ * AES key register 3
+ */
+
+#define AES_KEY_3_REG (DR_REG_AES_BASE + 0xc)
+
+/* AES_KEY_3 : R/W; bitpos: [31:0]; default: 0;
+ * Stores AES keys.
+ */
+
+#define AES_KEY_3    0xFFFFFFFF
+#define AES_KEY_3_M  (AES_KEY_3_V << AES_KEY_3_S)
+#define AES_KEY_3_V  0xFFFFFFFF
+#define AES_KEY_3_S  0
+
+/* AES_KEY_4_REG register
+ * AES key register 4
+ */
+
+#define AES_KEY_4_REG (DR_REG_AES_BASE + 0x10)
+
+/* AES_KEY_4 : R/W; bitpos: [31:0]; default: 0;
+ * Stores AES keys.
+ */
+
+#define AES_KEY_4    0xFFFFFFFF
+#define AES_KEY_4_M  (AES_KEY_4_V << AES_KEY_4_S)
+#define AES_KEY_4_V  0xFFFFFFFF
+#define AES_KEY_4_S  0
+
+/* AES_KEY_5_REG register
+ * AES key register 5
+ */
+
+#define AES_KEY_5_REG (DR_REG_AES_BASE + 0x14)
+
+/* AES_KEY_5 : R/W; bitpos: [31:0]; default: 0;
+ * Stores AES keys.
+ */
+
+#define AES_KEY_5    0xFFFFFFFF
+#define AES_KEY_5_M  (AES_KEY_5_V << AES_KEY_5_S)
+#define AES_KEY_5_V  0xFFFFFFFF
+#define AES_KEY_5_S  0
+
+/* AES_KEY_6_REG register
+ * AES key register 6
+ */
+
+#define AES_KEY_6_REG (DR_REG_AES_BASE + 0x18)
+
+/* AES_KEY_6 : R/W; bitpos: [31:0]; default: 0;
+ * Stores AES keys.
+ */
+
+#define AES_KEY_6    0xFFFFFFFF
+#define AES_KEY_6_M  (AES_KEY_6_V << AES_KEY_6_S)
+#define AES_KEY_6_V  0xFFFFFFFF
+#define AES_KEY_6_S  0
+
+/* AES_KEY_7_REG register
+ * AES key register 7
+ */
+
+#define AES_KEY_7_REG (DR_REG_AES_BASE + 0x1c)
+
+/* AES_KEY_7 : R/W; bitpos: [31:0]; default: 0;
+ * Stores AES keys.
+ */
+
+#define AES_KEY_7    0xFFFFFFFF
+#define AES_KEY_7_M  (AES_KEY_7_V << AES_KEY_7_S)
+#define AES_KEY_7_V  0xFFFFFFFF
+#define AES_KEY_7_S  0
+
+/* AES_TEXT_IN_0_REG register
+ * Source data register 0
+ */
+
+#define AES_TEXT_IN_0_REG (DR_REG_AES_BASE + 0x20)
+
+/* AES_TEXT_IN_0 : R/W; bitpos: [31:0]; default: 0;
+ * Stores the source data when the AES Accelerator operates in the Typical
+ * AES working mode.
+ */
+
+#define AES_TEXT_IN_0    0xFFFFFFFF
+#define AES_TEXT_IN_0_M  (AES_TEXT_IN_0_V << AES_TEXT_IN_0_S)
+#define AES_TEXT_IN_0_V  0xFFFFFFFF
+#define AES_TEXT_IN_0_S  0
+
+/* AES_TEXT_IN_1_REG register
+ * Source data register 1
+ */
+
+#define AES_TEXT_IN_1_REG (DR_REG_AES_BASE + 0x24)
+
+/* AES_TEXT_IN_1 : R/W; bitpos: [31:0]; default: 0;
+ * Stores the source data when the AES Accelerator operates in the Typical
+ * AES working mode.
+ */
+
+#define AES_TEXT_IN_1    0xFFFFFFFF
+#define AES_TEXT_IN_1_M  (AES_TEXT_IN_1_V << AES_TEXT_IN_1_S)
+#define AES_TEXT_IN_1_V  0xFFFFFFFF
+#define AES_TEXT_IN_1_S  0
+
+/* AES_TEXT_IN_2_REG register
+ * Source data register 2
+ */
+
+#define AES_TEXT_IN_2_REG (DR_REG_AES_BASE + 0x28)
+
+/* AES_TEXT_IN_2 : R/W; bitpos: [31:0]; default: 0;
+ * Stores the source data when the AES Accelerator operates in the Typical
+ * AES working mode.
+ */
+
+#define AES_TEXT_IN_2    0xFFFFFFFF
+#define AES_TEXT_IN_2_M  (AES_TEXT_IN_2_V << AES_TEXT_IN_2_S)
+#define AES_TEXT_IN_2_V  0xFFFFFFFF
+#define AES_TEXT_IN_2_S  0
+
+/* AES_TEXT_IN_3_REG register
+ * Source data register 3
+ */
+
+#define AES_TEXT_IN_3_REG (DR_REG_AES_BASE + 0x2c)
+
+/* AES_TEXT_IN_3 : R/W; bitpos: [31:0]; default: 0;
+ * Stores the source data when the AES Accelerator operates in the Typical
+ * AES working mode.
+ */
+
+#define AES_TEXT_IN_3    0xFFFFFFFF
+#define AES_TEXT_IN_3_M  (AES_TEXT_IN_3_V << AES_TEXT_IN_3_S)
+#define AES_TEXT_IN_3_V  0xFFFFFFFF
+#define AES_TEXT_IN_3_S  0
+
+/* AES_TEXT_OUT_0_REG register
+ * Result data register 0
+ */
+
+#define AES_TEXT_OUT_0_REG (DR_REG_AES_BASE + 0x30)
+
+/* AES_TEXT_OUT_0 : R/W; bitpos: [31:0]; default: 0;
+ * Stores the result data when the AES Accelerator operates in the Typical
+ * AES working mode.
+ */
+
+#define AES_TEXT_OUT_0    0xFFFFFFFF
+#define AES_TEXT_OUT_0_M  (AES_TEXT_OUT_0_V << AES_TEXT_OUT_0_S)
+#define AES_TEXT_OUT_0_V  0xFFFFFFFF
+#define AES_TEXT_OUT_0_S  0
+
+/* AES_TEXT_OUT_1_REG register
+ * Result data register 1
+ */
+
+#define AES_TEXT_OUT_1_REG (DR_REG_AES_BASE + 0x34)
+
+/* AES_TEXT_OUT_1 : R/W; bitpos: [31:0]; default: 0;
+ * Stores the result data when the AES Accelerator operates in the Typical
+ * AES working mode.
+ */
+
+#define AES_TEXT_OUT_1    0xFFFFFFFF
+#define AES_TEXT_OUT_1_M  (AES_TEXT_OUT_1_V << AES_TEXT_OUT_1_S)
+#define AES_TEXT_OUT_1_V  0xFFFFFFFF
+#define AES_TEXT_OUT_1_S  0
+
+/* AES_TEXT_OUT_2_REG register
+ * Result data register 2
+ */
+
+#define AES_TEXT_OUT_2_REG (DR_REG_AES_BASE + 0x38)
+
+/* AES_TEXT_OUT_2 : R/W; bitpos: [31:0]; default: 0;
+ * Stores the result data when the AES Accelerator operates in the Typical
+ * AES working mode.
+ */
+
+#define AES_TEXT_OUT_2    0xFFFFFFFF
+#define AES_TEXT_OUT_2_M  (AES_TEXT_OUT_2_V << AES_TEXT_OUT_2_S)
+#define AES_TEXT_OUT_2_V  0xFFFFFFFF
+#define AES_TEXT_OUT_2_S  0
+
+/* AES_TEXT_OUT_3_REG register
+ * Result data register 3
+ */
+
+#define AES_TEXT_OUT_3_REG (DR_REG_AES_BASE + 0x3c)
+
+/* AES_TEXT_OUT_3 : R/W; bitpos: [31:0]; default: 0;
+ * Stores the result data when the AES Accelerator operates in the Typical
+ * AES working mode.
+ */
+
+#define AES_TEXT_OUT_3    0xFFFFFFFF
+#define AES_TEXT_OUT_3_M  (AES_TEXT_OUT_3_V << AES_TEXT_OUT_3_S)
+#define AES_TEXT_OUT_3_V  0xFFFFFFFF
+#define AES_TEXT_OUT_3_S  0
+
+/* AES_MODE_REG register
+ * AES working mode configuration register
+ */
+
+#define AES_MODE_REG (DR_REG_AES_BASE + 0x40)
+
+/* AES_MODE : R/W; bitpos: [2:0]; default: 0;
+ * Defines the operation type of the AES Accelerator operating under the
+ * Typical AES working mode.
+ * &
+ * 0x0(AES_EN_128): AES-EN-128 #
+ * 0x1(AES_EN_192): AES-EN-192 #
+ * 0x2(AES_EN_256): AES-EN-256 #
+ * 0x4(AES_DE_128): AES-DE-128 #
+ * 0x5(AES_DE_192): AES-DE-192 #
+ * 0x6(AES_DE_256): AES-DE-256
+ * &
+ */
+
+#define AES_MODE    0x00000007
+#define AES_MODE_M  (AES_MODE_V << AES_MODE_S)
+#define AES_MODE_V  0x00000007
+#define AES_MODE_S  0
+
+/* AES_ENDIAN_REG register
+ * Endian configuration register
+ */
+
+#define AES_ENDIAN_REG (DR_REG_AES_BASE + 0x44)
+
+/* AES_ENDIAN : R/W; bitpos: [5:0]; default: 0;
+ * Defines the endianness of input and output texts.
+ * &
+ * [1:0] key endian #
+ * [3:2] text_in endian or in_stream endian #
+ * [5:4] text_out endian or out_stream endian #
+ * &
+ */
+
+#define AES_ENDIAN    0x0000003F
+#define AES_ENDIAN_M  (AES_ENDIAN_V << AES_ENDIAN_S)
+#define AES_ENDIAN_V  0x0000003F
+#define AES_ENDIAN_S  0
+
+/* AES_TRIGGER_REG register
+ * Operation start controlling register
+ */
+
+#define AES_TRIGGER_REG (DR_REG_AES_BASE + 0x48)
+
+/* AES_TRIGGER : WO; bitpos: [0]; default: 0;
+ * Set this bit to 1 to start AES operation.
+ */
+
+#define AES_TRIGGER    (BIT(0))
+#define AES_TRIGGER_M  (AES_TRIGGER_V << AES_TRIGGER_S)
+#define AES_TRIGGER_V  0x00000001
+#define AES_TRIGGER_S  0
+
+/* AES_STATE_REG register
+ * Operation status register
+ */
+
+#define AES_STATE_REG (DR_REG_AES_BASE + 0x4c)
+
+/* AES_STATE : RO; bitpos: [1:0]; default: 0;
+ * Stores the working status of the AES Accelerator. For details, see Table
+ * 3 for Typical AES working mode and Table 9 for DMA AES working mode.
+ * For typical AES; 0 = idle; 1 = busy.
+ * For DMA-AES; 0 = idle; 1 = busy; 2 = calculation_done.
+ */
+
+#define AES_STATE    0x00000003
+#define AES_STATE_M  (AES_STATE_V << AES_STATE_S)
+#define AES_STATE_V  0x00000003
+#define AES_STATE_S  0
+
+/* AES_IV_0_REG register
+ * initialization vector
+ */
+
+#define AES_IV_0_REG (DR_REG_AES_BASE + 0x50)
+
+/* AES_IV_0 : R/W; bitpos: [31:0]; default: 0;
+ * This register stores the 0th 32-bit piece of 128-bit initialization vector
+ */
+
+#define AES_IV_0    0xFFFFFFFF
+#define AES_IV_0_M  (AES_IV_0_V << AES_IV_0_S)
+#define AES_IV_0_V  0xFFFFFFFF
+#define AES_IV_0_S  0
+
+/* AES_IV_1_REG register
+ * initialization vector
+ */
+
+#define AES_IV_1_REG (DR_REG_AES_BASE + 0x54)
+
+/* AES_IV_1 : R/W; bitpos: [31:0]; default: 0;
+ * This register stores the 1th 32-bit piece of 128-bit initialization vector
+ */
+
+#define AES_IV_1    0xFFFFFFFF
+#define AES_IV_1_M  (AES_IV_1_V << AES_IV_1_S)
+#define AES_IV_1_V  0xFFFFFFFF
+#define AES_IV_1_S  0
+
+/* AES_IV_2_REG register
+ * initialization vector
+ */
+
+#define AES_IV_2_REG (DR_REG_AES_BASE + 0x58)
+
+/* AES_IV_2 : R/W; bitpos: [31:0]; default: 0;
+ * This register stores the 2th 32-bit piece of 128-bit initialization vector
+ */
+
+#define AES_IV_2    0xFFFFFFFF
+#define AES_IV_2_M  (AES_IV_2_V << AES_IV_2_S)
+#define AES_IV_2_V  0xFFFFFFFF
+#define AES_IV_2_S  0
+
+/* AES_IV_3_REG register
+ * initialization vector
+ */
+
+#define AES_IV_3_REG (DR_REG_AES_BASE + 0x5c)
+
+/* AES_IV_3 : R/W; bitpos: [31:0]; default: 0;
+ * This register stores the 3th 32-bit piece of 128-bit initialization vector
+ */
+
+#define AES_IV_3    0xFFFFFFFF
+#define AES_IV_3_M  (AES_IV_3_V << AES_IV_3_S)
+#define AES_IV_3_V  0xFFFFFFFF
+#define AES_IV_3_S  0
+
+/* AES_H_0_REG register
+ * GCM hash subkey
+ */
+
+#define AES_H_0_REG (DR_REG_AES_BASE + 0x60)
+
+/* AES_H_0 : RO; bitpos: [31:0]; default: 0;
+ * GCM hash subkey
+ */
+
+#define AES_H_0    0xFFFFFFFF
+#define AES_H_0_M  (AES_H_0_V << AES_H_0_S)
+#define AES_H_0_V  0xFFFFFFFF
+#define AES_H_0_S  0
+
+/* AES_H_1_REG register
+ * GCM hash subkey
+ */
+
+#define AES_H_1_REG (DR_REG_AES_BASE + 0x64)
+
+/* AES_H_1 : RO; bitpos: [31:0]; default: 0;
+ * GCM hash subkey
+ */
+
+#define AES_H_1    0xFFFFFFFF
+#define AES_H_1_M  (AES_H_1_V << AES_H_1_S)
+#define AES_H_1_V  0xFFFFFFFF
+#define AES_H_1_S  0
+
+/* AES_H_2_REG register
+ * GCM hash subkey
+ */
+
+#define AES_H_2_REG (DR_REG_AES_BASE + 0x68)
+
+/* AES_H_2 : RO; bitpos: [31:0]; default: 0;
+ * GCM hash subkey
+ */
+
+#define AES_H_2    0xFFFFFFFF
+#define AES_H_2_M  (AES_H_2_V << AES_H_2_S)
+#define AES_H_2_V  0xFFFFFFFF
+#define AES_H_2_S  0
+
+/* AES_H_3_REG register
+ * GCM hash subkey
+ */
+
+#define AES_H_3_REG (DR_REG_AES_BASE + 0x6c)
+
+/* AES_H_3 : RO; bitpos: [31:0]; default: 0;
+ * GCM hash subkey
+ */
+
+#define AES_H_3    0xFFFFFFFF
+#define AES_H_3_M  (AES_H_3_V << AES_H_3_S)
+#define AES_H_3_V  0xFFFFFFFF
+#define AES_H_3_S  0
+
+/* AES_J0_0_REG register
+ * J0
+ */
+
+#define AES_J0_0_REG (DR_REG_AES_BASE + 0x70)
+
+/* AES_J0_0 : R/W; bitpos: [31:0]; default: 0;
+ * This register stores the 0th 32-bit piece of 128-bit J0
+ */
+
+#define AES_J0_0    0xFFFFFFFF
+#define AES_J0_0_M  (AES_J0_0_V << AES_J0_0_S)
+#define AES_J0_0_V  0xFFFFFFFF
+#define AES_J0_0_S  0
+
+/* AES_J0_1_REG register
+ * J0
+ */
+
+#define AES_J0_1_REG (DR_REG_AES_BASE + 0x74)
+
+/* AES_J0_1 : R/W; bitpos: [31:0]; default: 0;
+ * This register stores the 1th 32-bit piece of 128-bit J0
+ */
+
+#define AES_J0_1    0xFFFFFFFF
+#define AES_J0_1_M  (AES_J0_1_V << AES_J0_1_S)
+#define AES_J0_1_V  0xFFFFFFFF
+#define AES_J0_1_S  0
+
+/* AES_J0_2_REG register
+ * J0
+ */
+
+#define AES_J0_2_REG (DR_REG_AES_BASE + 0x78)
+
+/* AES_J0_2 : R/W; bitpos: [31:0]; default: 0;
+ * This register stores the 2th 32-bit piece of 128-bit J0
+ */
+
+#define AES_J0_2    0xFFFFFFFF
+#define AES_J0_2_M  (AES_J0_2_V << AES_J0_2_S)
+#define AES_J0_2_V  0xFFFFFFFF
+#define AES_J0_2_S  0
+
+/* AES_J0_3_REG register
+ * J0
+ */
+
+#define AES_J0_3_REG (DR_REG_AES_BASE + 0x7c)
+
+/* AES_J0_3 : R/W; bitpos: [31:0]; default: 0;
+ * This register stores the 3th 32-bit piece of 128-bit J0
+ */
+
+#define AES_J0_3    0xFFFFFFFF
+#define AES_J0_3_M  (AES_J0_3_V << AES_J0_3_S)
+#define AES_J0_3_V  0xFFFFFFFF
+#define AES_J0_3_S  0
+
+/* AES_T0_0_REG register
+ * T0
+ */
+
+#define AES_T0_0_REG (DR_REG_AES_BASE + 0x80)
+
+/* AES_T0_0 : RO; bitpos: [31:0]; default: 0;
+ * This register stores the 0th 32-bit piece of 128-bit T0
+ */
+
+#define AES_T0_0    0xFFFFFFFF
+#define AES_T0_0_M  (AES_T0_0_V << AES_T0_0_S)
+#define AES_T0_0_V  0xFFFFFFFF
+#define AES_T0_0_S  0
+
+/* AES_T0_1_REG register
+ * T0
+ */
+
+#define AES_T0_1_REG (DR_REG_AES_BASE + 0x84)
+
+/* AES_T0_1 : RO; bitpos: [31:0]; default: 0;
+ * This register stores the 1th 32-bit piece of 128-bit T0
+ */
+
+#define AES_T0_1    0xFFFFFFFF
+#define AES_T0_1_M  (AES_T0_1_V << AES_T0_1_S)
+#define AES_T0_1_V  0xFFFFFFFF
+#define AES_T0_1_S  0
+
+/* AES_T0_2_REG register
+ * T0
+ */
+
+#define AES_T0_2_REG (DR_REG_AES_BASE + 0x88)
+
+/* AES_T0_2 : RO; bitpos: [31:0]; default: 0;
+ * This register stores the 2th 32-bit piece of 128-bit T0
+ */
+
+#define AES_T0_2    0xFFFFFFFF
+#define AES_T0_2_M  (AES_T0_2_V << AES_T0_2_S)
+#define AES_T0_2_V  0xFFFFFFFF
+#define AES_T0_2_S  0
+
+/* AES_T0_3_REG register
+ * T0
+ */
+
+#define AES_T0_3_REG (DR_REG_AES_BASE + 0x8c)
+
+/* AES_T0_3 : RO; bitpos: [31:0]; default: 0;
+ * This register stores the 3th 32-bit piece of 128-bit T0
+ */
+
+#define AES_T0_3    0xFFFFFFFF
+#define AES_T0_3_M  (AES_T0_3_V << AES_T0_3_S)
+#define AES_T0_3_V  0xFFFFFFFF
+#define AES_T0_3_S  0
+
+/* AES_DMA_ENABLE_REG register
+ * DMA enable register
+ */
+
+#define AES_DMA_ENABLE_REG (DR_REG_AES_BASE + 0x90)
+
+/* AES_DMA_ENABLE : R/W; bitpos: [0]; default: 0;
+ * Defines the working mode of the AES Accelerator. For details, see Table 1.
+ * 1'h0: typical AES operation
+ * 1'h1: DMA-AES operation
+ */
+
+#define AES_DMA_ENABLE    (BIT(0))
+#define AES_DMA_ENABLE_M  (AES_DMA_ENABLE_V << AES_DMA_ENABLE_S)
+#define AES_DMA_ENABLE_V  0x00000001
+#define AES_DMA_ENABLE_S  0
+
+/* AES_BLOCK_MODE_REG register
+ * Block operation type register
+ */
+
+#define AES_BLOCK_MODE_REG (DR_REG_AES_BASE + 0x94)
+
+/* AES_BLOCK_MODE : R/W; bitpos: [2:0]; default: 0;
+ * Defines the operation type of the AES Accelerator operating under the
+ * DMA-AES working mode. For details, see Table 8.
+ * &
+ * 3'h0(BLOCK_MODE_ECB): ECB #
+ * 3'h1(BLOCK_MODE_CBC): CBC #
+ * 3'h2(BLOCK_MODE_OFB): OFB #
+ * 3'h3(BLOCK_MODE_CTR): CTR #
+ * 3'h4(BLOCK_MODE_CFB8): CFB-8 #
+ * 3'h5(BLOCK_MODE_CFB128): CFB-128 #
+ * 3'h6(BLOCK_MODE_GCM): GCM
+ * &
+ */
+
+#define AES_BLOCK_MODE    0x00000007
+#define AES_BLOCK_MODE_M  (AES_BLOCK_MODE_V << AES_BLOCK_MODE_S)
+#define AES_BLOCK_MODE_V  0x00000007
+#define AES_BLOCK_MODE_S  0
+
+/* AES_BLOCK_NUM_REG register
+ * Block number configuration register
+ */
+
+#define AES_BLOCK_NUM_REG (DR_REG_AES_BASE + 0x98)
+
+/* AES_BLOCK_NUM : R/W; bitpos: [31:0]; default: 0;
+ * Stores the Block Number of plaintext or cipertext when the AES
+ * Accelerator operates under the DMA-AES working mode. For details, see
+ * Section 1.5.4.
+ */
+
+#define AES_BLOCK_NUM    0xFFFFFFFF
+#define AES_BLOCK_NUM_M  (AES_BLOCK_NUM_V << AES_BLOCK_NUM_S)
+#define AES_BLOCK_NUM_V  0xFFFFFFFF
+#define AES_BLOCK_NUM_S  0
+
+/* AES_INC_SEL_REG register
+ * Standard incrementing function register
+ */
+
+#define AES_INC_SEL_REG (DR_REG_AES_BASE + 0x9c)
+
+/* AES_INC_SEL : R/W; bitpos: [0]; default: 0;
+ * Defines the Standard Incrementing Function for CTR block operation. Set
+ * this bit to 0 or 1 to choose INC 32 or INC 128 .
+ */
+
+#define AES_INC_SEL    (BIT(0))
+#define AES_INC_SEL_M  (AES_INC_SEL_V << AES_INC_SEL_S)
+#define AES_INC_SEL_V  0x00000001
+#define AES_INC_SEL_S  0
+
+/* AES_AAD_BLOCK_NUM_REG register
+ * AAD block number configuration register
+ */
+
+#define AES_AAD_BLOCK_NUM_REG (DR_REG_AES_BASE + 0xa0)
+
+/* AES_AAD_BLOCK_NUM : R/W; bitpos: [31:0]; default: 0;
+ * Stores the ADD Block Number for the GCM operation.
+ */
+
+#define AES_AAD_BLOCK_NUM    0xFFFFFFFF
+#define AES_AAD_BLOCK_NUM_M  (AES_AAD_BLOCK_NUM_V << AES_AAD_BLOCK_NUM_S)
+#define AES_AAD_BLOCK_NUM_V  0xFFFFFFFF
+#define AES_AAD_BLOCK_NUM_S  0
+
+/* AES_REMAINDER_BIT_NUM_REG register
+ * Remainder bit number of plaintext/ciphertext
+ */
+
+#define AES_REMAINDER_BIT_NUM_REG (DR_REG_AES_BASE + 0xa4)
+
+/* AES_REMAINDER_BIT_NUM : R/W; bitpos: [6:0]; default: 0;
+ * Stores the Remainder Bit Number for the GCM operation.
+ */
+
+#define AES_REMAINDER_BIT_NUM    0x0000007F
+#define AES_REMAINDER_BIT_NUM_M  (AES_REMAINDER_BIT_NUM_V << AES_REMAINDER_BIT_NUM_S)
+#define AES_REMAINDER_BIT_NUM_V  0x0000007F
+#define AES_REMAINDER_BIT_NUM_S  0
+
+/* AES_CONTINUE_REG register
+ * Operation continue controlling register
+ */
+
+#define AES_CONTINUE_REG (DR_REG_AES_BASE + 0xa8)
+
+/* AES_CONTINUE : WO; bitpos: [0]; default: 0;
+ * Set this bit to 1 to continue AES operation.
+ */
+
+#define AES_CONTINUE    (BIT(0))
+#define AES_CONTINUE_M  (AES_CONTINUE_V << AES_CONTINUE_S)
+#define AES_CONTINUE_V  0x00000001
+#define AES_CONTINUE_S  0
+
+/* AES_INT_CLR_REG register
+ * DMA-AES interrupt clear register
+ */
+
+#define AES_INT_CLR_REG (DR_REG_AES_BASE + 0xac)
+
+/* AES_INT_CLR : WO; bitpos: [0]; default: 0;
+ * Set this bit to 1 to clear AES interrupt.
+ */
+
+#define AES_INT_CLR    (BIT(0))
+#define AES_INT_CLR_M  (AES_INT_CLR_V << AES_INT_CLR_S)
+#define AES_INT_CLR_V  0x00000001
+#define AES_INT_CLR_S  0
+
+/* AES_INT_ENA_REG register
+ * DMA-AES interrupt enable register
+ */
+
+#define AES_INT_ENA_REG (DR_REG_AES_BASE + 0xb0)
+
+/* AES_INT_ENA : R/W; bitpos: [0]; default: 0;
+ * Set this bit to 1 to enable AES interrupt and 0 to disable interrupt.
+ */
+
+#define AES_INT_ENA    (BIT(0))
+#define AES_INT_ENA_M  (AES_INT_ENA_V << AES_INT_ENA_S)
+#define AES_INT_ENA_V  0x00000001
+#define AES_INT_ENA_S  0
+
+/* AES_DATE_REG register
+ * Version control register
+ */
+
+#define AES_DATE_REG (DR_REG_AES_BASE + 0xb4)
+
+/* AES_DATE : R/W; bitpos: [29:0]; default: 538510612;
+ * Version control register
+ */
+
+#define AES_DATE    0x3FFFFFFF
+#define AES_DATE_M  (AES_DATE_V << AES_DATE_S)
+#define AES_DATE_V  0x3FFFFFFF
+#define AES_DATE_S  0
+
+/* AES_DMA_EXIT_REG register
+ * Operation exit controlling register
+ */
+
+#define AES_DMA_EXIT_REG (DR_REG_AES_BASE + 0xb8)
+
+/* AES_DMA_EXIT : WO; bitpos: [0]; default: 0;
+ * Set this bit to 1 to exit AES operation. This register is only effective
+ * for DMA-AES operation.
+ */
+
+#define AES_DMA_EXIT    (BIT(0))
+#define AES_DMA_EXIT_M  (AES_DMA_EXIT_V << AES_DMA_EXIT_S)
+#define AES_DMA_EXIT_V  0x00000001
+#define AES_DMA_EXIT_S  0
+
+#endif /* __ARCH_XTENSA_SRC_ESP32S3_HARDWARE_ESP32S3_AES_H */

--- a/boards/xtensa/esp32s3/esp32s3-devkit/src/esp32s3_bringup.c
+++ b/boards/xtensa/esp32s3/esp32s3-devkit/src/esp32s3_bringup.c
@@ -105,6 +105,10 @@
 #include "esp32s3_board_spidev.h"
 #endif
 
+#ifdef CONFIG_ESP32S3_AES_ACCELERATOR
+#  include "esp32s3_aes.h"
+#endif
+
 #include "esp32s3-devkit.h"
 
 /****************************************************************************
@@ -436,6 +440,20 @@ int esp32s3_bringup(void)
     {
       syslog(LOG_ERR, "ERROR: Failed to initialize SPI ethernet LAN9250.\n");
     }
+#endif
+
+#ifdef CONFIG_ESP32S3_AES_ACCELERATOR
+  ret = esp32s3_aes_init();
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to initialize AES: %d\n", ret);
+    }
+#ifdef CONFIG_ESP32S3_AES_ACCELERATOR_TEST
+  else
+    {
+      esp32s3_aes_test();
+    }
+#endif
 #endif
 
   /* If we got here then perhaps not all initialization was successful, but


### PR DESCRIPTION
## Summary

- Add ESP32-S3 AES driver

## Impact

## Testing

- `esp32s3-devkit:nsh`

- Enable `CONFIG_ESP32S3_AES_ACCELERATOR & CONFIG_ESP32S3_AES_ACCELERATOR_TEST` through `make menuconfig`
