### PR TITLE
cmake:init protected-mode for CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,6 +416,10 @@ include(platform)
 # Setup main nuttx target ####################################################
 
 add_executable(nuttx)
+if(CONFIG_BUILD_PROTECTED)
+  add_executable(nuttx_user)
+endif()
+
 add_dependencies(nuttx nuttx_context)
 
 if(WIN32)
@@ -604,9 +608,6 @@ get_property(nuttx_extra_libs GLOBAL PROPERTY NUTTX_EXTRA_LIBRARIES)
 
 if(CONFIG_BUILD_FLAT)
   get_property(nuttx_system_libs GLOBAL PROPERTY NUTTX_SYSTEM_LIBRARIES)
-endif()
-
-if(NOT CONFIG_BUILD_KERNEL)
   get_property(nuttx_apps_libs GLOBAL PROPERTY NUTTX_APPS_LIBRARIES)
 endif()
 
@@ -742,25 +743,36 @@ endif()
 # Userspace portion ##########################################################
 
 if(CONFIG_BUILD_PROTECTED)
-  add_executable(nuttx_user)
 
   get_property(nuttx_system_libs GLOBAL PROPERTY NUTTX_SYSTEM_LIBRARIES)
+
+  get_property(nuttx_apps_libs GLOBAL PROPERTY NUTTX_APPS_LIBRARIES)
 
   get_property(user_ldscript GLOBAL PROPERTY LD_SCRIPT_USER)
   list(TRANSFORM user_ldscript PREPEND "-Wl,--script=")
 
+  execute_process(
+    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS} ${NUTTX_EXTRA_FLAGS}
+            --print-libgcc-file-name
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE nuttx_user_libgcc)
+
+  # reset link options for userspace to prevent sections from being accidentally
+  # deleted
+  set_target_properties(nuttx_user PROPERTIES LINK_OPTIONS "")
+
   target_link_options(
     nuttx_user PRIVATE -nostartfiles -nodefaultlibs
-    -Wl,--entry=${CONFIG_USER_ENTRYPOINT}
-    -Wl,--undefined=${CONFIG_USER_ENTRYPOINT})
+    -Wl,--entry=${CONFIG_INIT_ENTRYPOINT}
+    -Wl,--undefined=${CONFIG_INIT_ENTRYPOINT})
 
   target_link_libraries(
     nuttx_user
     PRIVATE ${user_ldscript}
-            userspace
             $<$<NOT:$<BOOL:${APPLE}>>:-Wl,--start-group>
             ${nuttx_system_libs}
-            gcc
+            ${nuttx_apps_libs}
+            ${nuttx_user_libgcc}
             $<$<BOOL:${CONFIG_HAVE_CXX}>:supc++>
             $<$<NOT:$<BOOL:${APPLE}>>:-Wl,--end-group>)
 

--- a/arch/arm/src/common/CMakeLists.txt
+++ b/arch/arm/src/common/CMakeLists.txt
@@ -59,7 +59,8 @@ if(CONFIG_BUILD_PROTECTED OR CONFIG_BUILD_KERNEL)
   list(APPEND SRCS arm_task_start.c arm_pthread_start.c arm_signal_dispatch.c)
 
   if(CONFIG_BUILD_PROTECTED)
-    list(APPEND SRCS ${ARCH_TOOLCHAIN_PATH}/arm_signal_handler.S)
+    target_sources(arch_interface
+                   PRIVATE ${ARCH_TOOLCHAIN_PATH}/arm_signal_handler.S)
   endif()
 endif()
 

--- a/arch/risc-v/src/common/CMakeLists.txt
+++ b/arch/risc-v/src/common/CMakeLists.txt
@@ -51,7 +51,7 @@ endif()
 if(NOT CONFIG_BUILD_FLAT)
   list(APPEND SRCS riscv_task_start.c riscv_pthread_start.c
        riscv_signal_dispatch.c)
-  list(APPEND SRCS riscv_signal_handler.S)
+  target_sources(arch_interface PRIVATE riscv_signal_handler.S)
 endif()
 
 if(CONFIG_SCHED_BACKTRACE)

--- a/boards/arm/tiva/lm3s6965-ek/kernel/CMakeLists.txt
+++ b/boards/arm/tiva/lm3s6965-ek/kernel/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# boards/arm/tiva/lm3s6965-ek/CMakeLists.txt
+# boards/arm/tiva/lm3s6965-ek/kernel/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
@@ -18,11 +18,4 @@
 #
 # ##############################################################################
 
-add_subdirectory(src)
-
-if(CONFIG_BUILD_PROTECTED)
-  add_subdirectory(kernel)
-  set_property(
-    GLOBAL PROPERTY LD_SCRIPT_USER ${CMAKE_CURRENT_LIST_DIR}/scripts/memory.ld
-                    ${CMAKE_CURRENT_LIST_DIR}/scripts/user-space.ld)
-endif()
+target_sources(nuttx_user PRIVATE lm_userspace.c)


### PR DESCRIPTION
## Summary
This patch refines protected-mode based on the current kernel libs SPLIT feature.

1. adjust link options for userspace elf
2. disable link option in Toolchain file for userspace elf
3. specify system libs and apps lib to only link with nuttx target in flat build mode

## Impact
enbale protected-mode build

## Testing
```bash

cmake -B build -DBOARD_CONFIG=lm3s6965-ek:qemu-protected

# because the current CMake support is not perfect yet, 
# need to close  EXAMPLES_ELF ,  EXAMPLES_MODULE  and NSH_SYMTAB

cmake --build build

# the binary product is in the build directory and can be tested using QEMU
qemu-system-arm -semihosting \  
        -M lm3s6965evb \
        -device loader,file=build/nuttx.bin,addr=0x00000000 \
        -device loader,file=build/nuttx_user.bin,addr=0x00020000 \
        -netdev user,id=user0 \
        -nic user,id=user0 \
        -serial mon:stdio -nographic

```

