### PR TITLE
drivers/spi: Add support for FPGA iCE40 bitstream loading.

### DIFF
--- a/arch/risc-v/src/esp32c3-legacy/Kconfig
+++ b/arch/risc-v/src/esp32c3-legacy/Kconfig
@@ -516,6 +516,31 @@ endif # ESP32C3_SPI2
 
 endmenu # SPI configuration
 
+menu "iCE40 Configuration"
+	depends on SPI_ICE40
+
+config ESP32C3_ICE40_CSPIN
+	int "iCE40 CS Pin"
+	default 6
+	range 0 21
+
+config ESP32C3_ICE40_CDONEPIN
+	int "iCE40 CDONE Pin"
+	default 0
+	range 0 21
+
+config ESP32C3_ICE40_CRSTPIN
+	int "iCE40 CRST Pin"
+	default 1
+	range 0 21
+
+config ESP32C3_ICE40_SPI_PORT
+	int "iCE40 SPI port number"
+	default 2
+	range 0 5
+
+endmenu
+
 menu "UART configuration"
 	depends on ESP32C3_UART
 

--- a/arch/risc-v/src/esp32c3-legacy/Make.defs
+++ b/arch/risc-v/src/esp32c3-legacy/Make.defs
@@ -181,6 +181,10 @@ ifeq ($(CONFIG_ESP32C3_BROWNOUT_DET),y)
 CHIP_CSRCS += esp32c3_brownout.c
 endif
 
+ifeq ($(CONFIG_SPI_ICE40),y)
+CHIP_CSRCS += esp32c3_ice40.c
+endif
+
 ifeq ($(CONFIG_ESP32C3_WIRELESS),y)
 WIRELESS_DRV_UNPACK = esp-wireless-drivers-3rdparty
 WIRELESS_DRV_ID     = 45701c0

--- a/arch/risc-v/src/esp32c3-legacy/esp32c3_ice40.c
+++ b/arch/risc-v/src/esp32c3-legacy/esp32c3_ice40.c
@@ -1,0 +1,214 @@
+/****************************************************************************
+ * arch/risc-v/src/esp32c3-legacy/esp32c3_ice40.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/nuttx.h>
+
+#include <assert.h>
+#include <debug.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+
+#include <arch/board/board.h>
+#include <arch/esp32c3-legacy/chip.h>
+#include <arch/irq.h>
+#include <nuttx/arch.h>
+#include <nuttx/irq.h>
+#include <nuttx/kmalloc.h>
+#include <nuttx/spi/ice40.h>
+#include <nuttx/spi/spi.h>
+
+#include "esp32c3_spi.h"
+#include "hardware/esp32c3_spi.h"
+
+#include "hardware/esp32c3_gpio.h"
+#include "hardware/esp32c3_gpio_sigmap.h"
+
+#include "esp32c3_ice40.h"
+
+#include "esp32c3_gpio.h"
+
+#include <nuttx/spi/ice40.h>
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static void ice40_reset(struct ice40_dev_s *dev, bool reset);
+static void ice40_select(struct ice40_dev_s *dev, bool select);
+static bool ice40_get_status(struct ice40_dev_s *dev);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static const struct ice40_ops_s ice40_ops =
+{
+  .reset = ice40_reset,
+  .select = ice40_select,
+  .get_status = ice40_get_status,
+};
+
+struct esp32c3_ice40_dev_s
+{
+  struct ice40_dev_s base;
+  uint16_t cdone_gpio;
+  uint16_t crst_gpio;
+  uint16_t cs_gpio;
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: ice40_reset
+ *
+ * Description:
+ *  Reset ICE40 FPGA
+ *
+ * Input Parameters:
+ *  reset - true to reset, false to release reset (inverse logic, active low)
+ *
+ ****************************************************************************/
+
+static void
+ice40_reset(struct ice40_dev_s *dev, bool reset)
+{
+  struct esp32c3_ice40_dev_s *priv
+      = container_of (dev, struct esp32c3_ice40_dev_s, base);
+  esp32c3_gpiowrite(priv->crst_gpio, !reset);
+}
+
+/****************************************************************************
+ * Name: ice40_select
+ *
+ * Description:
+ *  Select ICE40 FPGA
+ *
+ * Input Parameters:
+ *  select - true to select, false to deselect (inverse logic, active low)
+ *
+ ****************************************************************************/
+
+static void
+ice40_select(struct ice40_dev_s *dev, bool select)
+{
+  struct esp32c3_ice40_dev_s *priv
+      = container_of (dev, struct esp32c3_ice40_dev_s, base);
+  esp32c3_gpiowrite(priv->cs_gpio, !select);
+}
+
+/****************************************************************************
+ * Name: ice40_get_status
+ *
+ * Description:
+ *  Get ICE40 FPGA status via CDONE pin. Important to know if the FPGA is
+ *  programmed and ready to use.
+ *
+ * Returned Value:
+ *  true if the FPGA is programmed and ready to use, false otherwise.
+ *
+ ****************************************************************************/
+
+static bool
+ice40_get_status(struct ice40_dev_s *dev)
+{
+  struct esp32c3_ice40_dev_s *priv
+      = container_of(dev, struct esp32c3_ice40_dev_s, base);
+  return esp32c3_gpioread (priv->cdone_gpio);
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: esp32c3_ice40_initialize
+ *
+ * Description:
+ *  Initialize ICE40 FPGA GPIOs and SPI.
+ *
+ * Input Parameters:
+ *
+ *
+ ****************************************************************************/
+
+FAR struct ice40_dev_s *
+esp32c3_ice40_initialize(const uint16_t cdone_gpio,
+                          const uint16_t crst_gpio,
+                          const uint16_t cs_gpio,
+                          const uint16_t spi_port)
+{
+  struct esp32c3_ice40_dev_s *ice40_ptr;
+
+  ice40_ptr = kmm_malloc(sizeof(struct esp32c3_ice40_dev_s));
+  if (ice40_ptr == NULL)
+    {
+      spierr("ERROR: Failed to allocate memory for ICE40 driver\n");
+      return NULL;
+    }
+
+  memset(ice40_ptr, 0, sizeof (struct esp32c3_ice40_dev_s));
+
+  ice40_ptr->base.ops = &ice40_ops;
+
+  /* Configure GPIO pins */
+
+  DEBUGASSERT(0 <= cdone_gpio && cdone_gpio < 32);
+  DEBUGASSERT(0 <= crst_gpio && crst_gpio < 32);
+  DEBUGASSERT(0 <= cs_gpio && cs_gpio < 32);
+  DEBUGASSERT(0 <= spi_port && spi_port < 3);
+
+  esp32c3_gpio_matrix_out(cdone_gpio, SIG_GPIO_OUT_IDX, 0, 0);
+  esp32c3_gpio_matrix_out(crst_gpio, SIG_GPIO_OUT_IDX, 0, 0);
+  esp32c3_gpio_matrix_out(cs_gpio, SIG_GPIO_OUT_IDX, 0, 0);
+
+  esp32c3_configgpio(cdone_gpio, INPUT_FUNCTION_1 | PULLDOWN);
+  esp32c3_configgpio(crst_gpio, OUTPUT_FUNCTION_1);
+  esp32c3_configgpio(cs_gpio, OUTPUT_FUNCTION_1);
+
+  esp32c3_gpiowrite(crst_gpio, 1);
+  esp32c3_gpiowrite(cs_gpio, 1);
+
+  ice40_ptr->cdone_gpio = cdone_gpio;
+  ice40_ptr->crst_gpio = crst_gpio;
+  ice40_ptr->cs_gpio = cs_gpio;
+
+  /* Configure SPI */
+
+  ice40_ptr->base.spi = esp32c3_spibus_initialize(spi_port);
+  if (ice40_ptr->base.spi == NULL)
+    {
+      spierr("ERROR: Failed to initialize SPI port %d\n",
+              ice40_ptr->base.spi);
+      return NULL;
+    }
+
+  return &ice40_ptr->base;
+}

--- a/arch/risc-v/src/esp32c3-legacy/esp32c3_ice40.h
+++ b/arch/risc-v/src/esp32c3-legacy/esp32c3_ice40.h
@@ -1,0 +1,91 @@
+/****************************************************************************
+ * arch/risc-v/src/esp32c3-legacy/esp32c3_ice40.h
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_RISCV_SRC_ESP32C3_LEGACY_HARDWARE_ESP32C3_ICE40_H
+#define __ARCH_RISCV_SRC_ESP32C3_LEGACY_HARDWARE_ESP32C3_ICE40_H
+
+/****************************************************************************
+ * Included Files
+ * *************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <assert.h>
+#include <debug.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+
+#include <arch/board/board.h>
+#include <arch/esp32c3-legacy/chip.h>
+#include <nuttx/arch.h>
+
+#include <nuttx/spi/ice40.h>
+#include <nuttx/spi/spi.h>
+
+#include "hardware/esp32c3_gpio.h"
+#include "hardware/esp32c3_gpio_sigmap.h"
+
+#include "esp32c3_gpio.h"
+
+#ifndef __ASSEMBLY__
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: esp32c3_ice40_initialize
+ *
+ * Description:
+ *  Initialize ICE40 FPGA GPIOs and SPI interface.
+ *
+ * Input Parameters:
+ *  cdone_gpio - GPIO pin connected to the CDONE pin of the ICE40 FPGA.
+ *  crst_gpio - GPIO pin connected to the CRST pin of the ICE40 FPGA.
+ *  cs_gpio - GPIO pin connected to the CS pin of the ICE40 FPGA.
+ *  spi_port - SPI port number to use for communication with the ICE40 FPGA.
+ *
+ * Returned Value:
+ *  A reference to the initialized ICE40 FPGA driver instance.
+ *  NULL in case of failure.
+ *
+ ****************************************************************************/
+
+  struct ice40_dev_s *esp32c3_ice40_initialize(const uint16_t cdone_gpio,
+                                               const uint16_t crst_gpio,
+                                               const uint16_t cs_gpio,
+                                               const uint16_t spi_port);
+
+#undef EXTERN
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* __ASSEMBLY__ */
+#endif /* __ARCH_RISCV_SRC_ESP32C3_LEGACY_HARDWARE_ESP32C3_ICE40_H */

--- a/boards/risc-v/esp32c3-legacy/common/include/esp32c3_board_ice40.h
+++ b/boards/risc-v/esp32c3-legacy/common/include/esp32c3_board_ice40.h
@@ -1,0 +1,70 @@
+/****************************************************************************
+ * boards/risc-v/esp32c3-legacy/common/include/esp32c3_board_ice40.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __BOARDS_RISCV_ESP32C3_LEGACY_COMMON_INCLUDE_ESP32C3_BOARD_ICE40_H
+#define __BOARDS_RISCV_ESP32C3_LEGACY_COMMON_INCLUDE_ESP32C3_BOARD_ICE40_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifndef __ASSEMBLY__
+
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: esp32c3_ice40_setup
+ *
+ * Description:
+ *  Initialize ICE40 FPGA GPIOs, SPI and register the ICE40 driver.
+ *
+ * Returned Value:
+ *  Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_SPI_ICE40
+int esp32c3_ice40_setup(void);
+#endif
+
+#undef EXTERN
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* __ASSEMBLY__ */
+#endif /* __BOARDS_RISCV_ESP32C3_COMMON_INCLUDE_ESP32C3_BOARD_BMP180_H */

--- a/boards/risc-v/esp32c3-legacy/common/src/Make.defs
+++ b/boards/risc-v/esp32c3-legacy/common/src/Make.defs
@@ -92,6 +92,10 @@ ifeq ($(CONFIG_MPU60X0_I2C),y)
   CSRCS += esp32c3_board_mpu60x0_i2c.c
 endif
 
+ifeq ($(CONFIG_SPI_ICE40),y)
+  CSRCS += esp32c3_board_ice40.c
+endif
+
 DEPPATH += --dep-path src
 VPATH += :src
 CFLAGS += ${INCDIR_PREFIX}$(TOPDIR)$(DELIM)arch$(DELIM)$(CONFIG_ARCH)$(DELIM)src$(DELIM)board$(DELIM)src

--- a/boards/risc-v/esp32c3-legacy/common/src/esp32c3_board_ice40.c
+++ b/boards/risc-v/esp32c3-legacy/common/src/esp32c3_board_ice40.c
@@ -1,0 +1,82 @@
+/****************************************************************************
+ * boards/risc-v/esp32c3-legacy/common/src/esp32c3_board_ice40.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <assert.h>
+#include <debug.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+#include <arch/board/board.h>
+#include <arch/esp32c3-legacy/chip.h>
+#include <nuttx/arch.h>
+#include <nuttx/board.h>
+
+#include "nuttx/spi/ice40.h"
+
+#include "esp32c3_ice40.h"
+#include "esp32c3_board_ice40.h"
+
+#include "esp32c3_gpio.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: esp32c3_ice40_setup
+ *
+ * Description:
+ *  Initialize ICE40 FPGA GPIOs, SPI and register the ICE40 driver.
+ *
+ ****************************************************************************/
+
+int esp32c3_ice40_setup(void)
+{
+  struct ice40_dev_s *ice40;
+
+  /* Initialize ICE40 FPGA GPIOs and SPI interface */
+
+  ice40 = esp32c3_ice40_initialize(CONFIG_ESP32C3_ICE40_CDONEPIN,
+                                   CONFIG_ESP32C3_ICE40_CRSTPIN,
+                                   CONFIG_ESP32C3_ICE40_CSPIN,
+                                   CONFIG_ESP32C3_ICE40_SPI_PORT);
+  if (ice40 <= 0)
+    {
+      _err("ERROR: Failed to initialize ICE40 driver\n");
+      return -ENODEV;
+    }
+
+  /* Register the ICE40 FPGA device at "/dev/ice40-0" */
+
+  int ret = ice40_register("/dev/ice40-0", ice40);
+  if (ret < 0)
+    {
+      _err("ERROR: Failed to register ICE40 driver: %d\n", ret);
+      return ret;
+    }
+
+  return OK;
+}

--- a/boards/risc-v/esp32c3-legacy/esp32c3-devkit/src/esp32c3_bringup.c
+++ b/boards/risc-v/esp32c3-legacy/esp32c3-devkit/src/esp32c3_bringup.c
@@ -54,6 +54,7 @@
 #include "esp32c3_board_wdt.h"
 #include "esp32c3_board_wlan.h"
 #include "esp32c3_board_mpu60x0_i2c.h"
+#include "esp32c3_board_ice40.h"
 
 #ifdef CONFIG_SPI
 #  include "esp32c3_spi.h"
@@ -383,6 +384,14 @@ int esp32c3_bringup(void)
     {
       syslog(LOG_ERR, "Failed to initialize MPU60x0 "
                        "Driver for I2C0: %d\n", ret);
+    }
+#endif
+
+#ifdef CONFIG_SPI_ICE40
+  ret = esp32c3_ice40_setup();
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to initialize ICE40: %d\n", ret);
     }
 #endif
 

--- a/drivers/spi/Kconfig
+++ b/drivers/spi/Kconfig
@@ -234,6 +234,14 @@ config SPI_DRIVER
 		this driver is to support SPI testing.  It is not suitable for use
 		in any real driver application.
 
+config SPI_ICE40
+	bool "SPI iCE40 driver"
+	default n
+	depends on SPI_EXCHANGE
+	---help---
+		Enable support for a character driver at /dev/ice40-[N] for the iCE40 FPGA.
+		This driver is intended for uploading the bitsream to the FPGA.
+
 config SPI_BITBANG
 	bool "SPI bit-bang device"
 	default n

--- a/drivers/spi/Make.defs
+++ b/drivers/spi/Make.defs
@@ -29,6 +29,10 @@ ifeq ($(CONFIG_SPI_EXCHANGE),y)
   endif
 endif
 
+ifeq ($(CONFIG_SPI_ICE40),y)
+  CSRCS += ice40.c
+endif
+
 ifeq ($(CONFIG_SPI_SLAVE_DRIVER),y)
   CSRCS += spi_slave_driver.c
 endif

--- a/drivers/spi/ice40.c
+++ b/drivers/spi/ice40.c
@@ -1,0 +1,411 @@
+/****************************************************************************
+ * drivers/spi/ice40.c
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <assert.h>
+#include <debug.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/fs/fs.h>
+#include <nuttx/fs/ioctl.h>
+#include <nuttx/ioexpander/gpio.h>
+#include <nuttx/kmalloc.h>
+#include <nuttx/spi/spi.h>
+
+#include <nuttx/spi/ice40.h>
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+/* Character driver methods */
+
+static int ice40_open(FAR struct file *filep);
+
+static int ice40_close(FAR struct file *filep);
+
+static ssize_t ice40_read(FAR struct file *filep, FAR char *buffer,
+                           size_t buflen);
+static ssize_t ice40_write(FAR struct file *filep, FAR const char *buffer,
+                            size_t buflen);
+static int ice40_ioctl(FAR struct file *filep, int cmd, unsigned long arg);
+
+/* Helper functions */
+
+static int ice40_init_fpga(FAR struct ice40_dev_s *dev);
+
+static int ice40_writeblk(FAR struct ice40_dev_s *dev,
+                           FAR const char *buffer,
+                           size_t buflen);
+
+static int ice40_endwrite(FAR struct ice40_dev_s *dev);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static const struct file_operations g_ice40_fops =
+{
+  ice40_open,  /* open */
+  ice40_close, /* close */
+  ice40_read,  /* read */
+  ice40_write, /* write */
+  NULL,        /* seek */
+  ice40_ioctl, /* ioctl */
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: ice40_open
+ *
+ * Description:
+ *  This function is called whenever the ICE40 device is opened.
+ *
+ ****************************************************************************/
+
+static int
+ice40_open(FAR struct file *filep)
+{
+  FAR struct inode *inode = filep->f_inode;
+  FAR struct ice40_dev_s *dev = inode->i_private;
+
+  DEBUGASSERT(dev != NULL);
+
+  if (dev->is_open)
+    {
+      return -EBUSY;
+    }
+
+  dev->is_open = true;
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: ice40_close
+ *
+ * Description:
+ *  This function is called whenever the ICE40 device is closed.
+ *
+ ****************************************************************************/
+
+static int
+ice40_close(FAR struct file *filep)
+{
+  FAR struct inode *inode = filep->f_inode;
+  FAR struct ice40_dev_s *dev = inode->i_private;
+
+  DEBUGASSERT(dev != NULL);
+
+  if (dev->in_progress)
+    {
+      if (ice40_endwrite(dev))
+        {
+          _err("ERROR: Failed to end writing to FPGA\n");
+          dev->is_open = false;
+          return -EIO;
+        }
+    }
+
+  dev->is_open = false;
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: ice40_configspi
+ *
+ * Description:
+ *   Configure the SPI instance for to match the DAT-31R5-SP+
+ *   specifications
+ *
+ ****************************************************************************/
+
+static inline void
+ice40_configspi(FAR struct spi_dev_s *spi)
+{
+  DEBUGASSERT(spi != NULL);
+
+  /* Configure SPI Mode for the ICE40 */
+
+  SPI_SETMODE(spi, ICE40_SPI_MODE);
+  SPI_SETBITS(spi, 8);
+
+  SPI_HWFEATURES(spi, 0);
+  SPI_SETFREQUENCY(spi, CONFIG_ICE40_SPI_FREQUENCY);
+}
+
+/****************************************************************************
+ * Name: ice40_init_fpga
+ *
+ * Description:
+ *  Initialize the FPGA - set it to SPI Master load mode
+ *  Reset the FPGA with the CS pin active low
+ *  and send 8 dummy bits with CS high to start the SPI transfer.
+ *
+ ****************************************************************************/
+
+static int
+ice40_init_fpga(FAR struct ice40_dev_s *dev)
+{
+  DEBUGASSERT(dev != NULL);
+  DEBUGASSERT(dev->spi != NULL);
+
+  SPI_LOCK(dev->spi, true);
+
+  ice40_configspi(dev->spi);
+
+  dev->ops->reset(dev, true);
+  up_udelay(2);
+  dev->ops->select(dev, true);
+  up_udelay(2);
+  dev->ops->reset(dev, false);
+  up_udelay(1200);
+
+  dev->ops->select(dev, false);
+  SPI_SEND(dev->spi, 0xff);
+  dev->ops->select(dev, true);
+
+  dev->in_progress = true;
+
+  return 0;
+}
+
+/****************************************************************************
+ * Name: ice_v_writeblk
+ *
+ * Description:
+ *  Write block to the ICE40 FPGA, max 4096 bytes
+ ****************************************************************************/
+
+static inline int
+ice40_writeblk(FAR struct ice40_dev_s *dev, FAR const char *buffer,
+                size_t buflen)
+{
+  uint32_t nbytes;
+
+  DEBUGASSERT(dev != NULL);
+  DEBUGASSERT(dev->spi != NULL);
+
+  DEBUGASSERT(buffer != NULL);
+  DEBUGASSERT(buflen > 0);
+
+  if (!dev->in_progress)
+    {
+      _err("ERROR: FPGA not initialized\n");
+      return -EINVAL;
+    }
+
+  ice40_configspi(dev->spi);
+
+  while (buflen > 0)
+    {
+      nbytes = buflen;
+      if (nbytes >= ICE_SPI_MAX_XFER)
+        {
+          nbytes = ICE_SPI_MAX_XFER;
+        }
+
+      SPI_SNDBLOCK(dev->spi, buffer, nbytes);
+
+      buffer += nbytes;
+      buflen -= nbytes;
+    }
+
+  return 0;
+}
+
+/****************************************************************************
+ * Name: ice_v_endwrite
+ *
+ * Description:
+ *  End writing bitstream to the ICE40 FPGA
+ ****************************************************************************/
+
+static int
+ice40_endwrite(FAR struct ice40_dev_s *dev)
+{
+  ice40_configspi(dev->spi);
+  int cdone = 0;
+
+  DEBUGASSERT(dev != NULL);
+  DEBUGASSERT(dev->spi != NULL);
+
+  if (!dev->in_progress)
+    {
+      _err("ERROR: FPGA not initialized\n");
+      return -EINVAL;
+    }
+
+  dev->ops->select(dev, false);
+
+  for (size_t i = 0; i < ICE40_SPI_FINAL_CLK_CYCLES + 7 / 8; i++)
+    {
+      SPI_SEND(dev->spi, 0xff);
+    }
+
+  cdone = dev->ops->get_status(dev);
+  if (cdone == 0)
+    {
+      _err("ERROR: CDONE not high after writing to FPGA\n");
+      SPI_LOCK(dev->spi, false);
+      return -ENODEV;
+    }
+
+  SPI_LOCK(dev->spi, false);
+
+  dev->in_progress = false;
+
+  return 0;
+}
+
+/****************************************************************************
+ * Name: ice40_write
+ *
+ * Description:
+ *  Write buffer to the ICE40 FPGA
+ ****************************************************************************/
+
+static ssize_t
+ice40_write(FAR struct file *filep, FAR const char *buffer, size_t buflen)
+{
+  int ret;
+
+  DEBUGASSERT(buffer != NULL);
+  DEBUGASSERT(filep != NULL);
+
+  FAR struct inode *inode = filep->f_inode;
+  DEBUGASSERT(inode != NULL);
+  FAR struct ice40_dev_s *dev = inode->i_private;
+  DEBUGASSERT(dev != NULL);
+
+  DEBUGASSERT(dev->spi != NULL);
+
+  if (!dev->in_progress)
+    {
+      ret = ice40_init_fpga(dev);
+      if (ret < 0)
+        {
+          _err("ERROR: Failed to initialize FPGA: %d\n", ret);
+          return ret;
+        }
+    }
+
+  ret = ice40_writeblk(dev, buffer, buflen);
+  if (ret < 0)
+    {
+      _err("ERROR: Failed to write to FPGA: %d\n", ret);
+      return ret;
+    }
+
+  return buflen;
+}
+
+/****************************************************************************
+ * Name: ice40_read
+ *
+ * Description:
+ *   Read is ignored.
+ ****************************************************************************/
+
+static ssize_t
+ice40_read(FAR struct file *filep, FAR char *buffer, size_t buflen)
+{
+  return 0;
+}
+
+/****************************************************************************
+ * Name: ice40_ioctl
+ *
+ * Description:
+ *   The only available ICTL is RFIOC_SETATT. It expects a struct
+ *   attenuator_control* as the argument to set the attenuation
+ *   level. The channel is ignored as the DAT-31R5-SP+ has just a
+ *   single attenuator.
+ ****************************************************************************/
+
+static int
+ice40_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
+{
+  FAR struct inode *inode = filep->f_inode;
+  FAR struct ice40_dev_s *dev = inode->i_private;
+  int ret = OK;
+
+  switch (cmd)
+    {
+    case FPGAIOC_WRITE_INIT:
+      ret = ice40_init_fpga(dev);
+      break;
+
+    case FPGAIOC_WRITE:
+      ret = ice40_writeblk(dev, (FAR const char *)arg, sizeof(arg));
+      break;
+    case FPGAIOC_WRITE_COMPLETE:
+      ret = ice40_endwrite(dev);
+      break;
+
+    default:
+      sninfo("Unrecognized cmd: %d\n", cmd);
+      ret = -EINVAL;
+      break;
+    }
+
+  return ret;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: ice40_register
+ *
+ * Description:
+ *   Register the ice_v character device as 'devpath'.
+ *
+ ****************************************************************************/
+
+int ice40_register(FAR const char *path, FAR struct ice40_dev_s *dev)
+{
+  int ret;
+
+  /* Sanity check */
+
+  DEBUGASSERT(dev != NULL);
+
+  /* Register the character driver */
+
+  ret = register_driver(path, &g_ice40_fops, 0666, dev);
+  if (ret < 0)
+    {
+      snerr("ERROR: Failed to register driver: %d\n", ret);
+    }
+
+  return ret;
+}

--- a/include/nuttx/fs/ioctl.h
+++ b/include/nuttx/fs/ioctl.h
@@ -99,6 +99,7 @@
 #define _SEIOCBASE      (0x3a00) /* Secure element ioctl commands */
 #define _SYSLOGBASE     (0x3c00) /* Syslog device ioctl commands */
 #define _STEPIOBASE     (0x3d00) /* Stepper device ioctl commands */
+#define _FPGACFGBASE    (0x3e00) /* FPGA configuration ioctl commands */
 #define _WLIOCBASE      (0x8b00) /* Wireless modules ioctl network commands */
 
 /* boardctl() commands share the same number space */
@@ -693,6 +694,11 @@
 
 #define _BOARDIOCVALID(c) (_IOC_TYPE(c)==_BOARDBASE)
 #define _BOARDIOC(nr)     _IOC(_BOARDBASE,nr)
+
+/* FPAG configuration ioctl definitions *************************************/
+
+#define _FPGACFGVALID(c) (_IOC_TYPE(c) == _FPGACFGBASE)
+#define _FPGACFGIOC(nr) _IOC(_FPGACFGBASE, nr)
 
 /****************************************************************************
  * Public Type Definitions

--- a/include/nuttx/spi/ice40.h
+++ b/include/nuttx/spi/ice40.h
@@ -1,0 +1,93 @@
+/****************************************************************************
+ * include/nuttx/spi/ice40.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_NUTTX_SPI_ICE40_H
+#define __INCLUDE_NUTTX_SPI_ICE40_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <assert.h>
+#include <debug.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <nuttx/fs/ioctl.h>
+#include <nuttx/spi/spi.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#if(defined(CONFIG_SPI) && defined(CONFIG_SPI_ICE40))
+
+#ifndef CONFIG_ICE40_SPI_FREQUENCY
+#  define CONFIG_ICE40_SPI_FREQUENCY 10000000
+#endif
+
+#define ICE40_SPI_MODE (SPIDEV_MODE0) /* SPI Mode 0: CPOL=0,CPHA=0 */
+
+#define ICE40_SPI_FINAL_CLK_CYCLES 160
+
+#define ICE_SPI_MAX_XFER 4096
+
+#define FPGAIOC_WRITE_INIT _FPGACFGIOC(0x0001)
+#define FPGAIOC_WRITE _FPGACFGIOC(0x0002)
+#define FPGAIOC_WRITE_COMPLETE _FPGACFGIOC(0x0003)
+
+/****************************************************************************
+ * Public Function Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: ice40_register
+ *
+ * Description:
+ *   Register the ice_v character device as 'devpath'.
+ *
+ ****************************************************************************/
+
+struct ice40_dev_s;
+
+struct ice40_ops_s
+{
+  CODE void(*reset)(FAR struct ice40_dev_s *dev, FAR bool reset);
+  CODE void(*select)(FAR struct ice40_dev_s *dev, FAR bool select);
+  CODE bool(*get_status)(FAR struct ice40_dev_s *dev);
+};
+
+struct ice40_dev_s
+{
+  FAR const struct ice40_ops_s *ops;
+  FAR struct spi_dev_s *spi;
+  bool is_open;
+  bool in_progress;
+};
+
+int ice40_register(FAR const char *path, FAR struct ice40_dev_s *dev);
+
+#endif /* CONFIG_SPI && CONFIG_SPI_ICE40 */
+
+#endif /* __INCLUDE_NUTTX_SPI_ICE40_H */


### PR DESCRIPTION
## Summary
drivers/spi: Add support for FPGA iCE40 bitstream loading.
Allows loading of bitstream directly from filesystem, either using ioctl or directly by using e.g. "cp example_bitstream.bin /dev/ice40-0"

arch and board esp32c3-legacy: Add optional iCE40 FPGA loading support 

## Impact
It should have no impact when CONFIG_SPI_ICE40 is not set (which is default)

## Testing
Tested on ICE-V-Wireless board.
https://github.com/ICE-V-Wireless/ICE-V-Wireless
