### PR TITLE
net/udp: Slight improvement on multicast

### DIFF
--- a/include/nuttx/net/netdev.h
+++ b/include/nuttx/net/netdev.h
@@ -1039,6 +1039,20 @@ void netdev_iob_clear(FAR struct net_driver_s *dev);
 void netdev_iob_release(FAR struct net_driver_s *dev);
 
 /****************************************************************************
+ * Name: netdev_iob_clone
+ *
+ * Description:
+ *   Backup the current iob buffer for a given NIC by cloning it.
+ *
+ * Assumptions:
+ *   The caller has locked the network.
+ *
+ ****************************************************************************/
+
+FAR struct iob_s *netdev_iob_clone(FAR struct net_driver_s *dev,
+                                   bool throttled);
+
+/****************************************************************************
  * Name: netdev_ipv6_add/del
  *
  * Description:

--- a/net/inet/ipv4_setsockopt.c
+++ b/net/inet/ipv4_setsockopt.c
@@ -305,10 +305,6 @@ int ipv4_setsockopt(FAR struct socket *psock, int option,
 
       /* The following IPv4 socket options are defined, but not implemented */
 
-      case IP_MULTICAST_LOOP:         /* Set/read boolean that determines
-                                       * whether sent multicast packets
-                                       * should be looped back to local
-                                       * sockets. */
       case IP_UNBLOCK_SOURCE:         /* Unblock previously blocked multicast
                                        * source */
       case IP_BLOCK_SOURCE:           /* Stop receiving multicast data from
@@ -327,8 +323,12 @@ int ipv4_setsockopt(FAR struct socket *psock, int option,
         nwarn("WARNING: Unimplemented IPv4 option: %d\n", option);
         ret = -ENOSYS;
         break;
-#endif /* CONFIG_NET_IGMP */
 
+      case IP_MULTICAST_LOOP:         /* Set/read boolean that determines
+                                       * whether sent multicast packets
+                                       * should be looped back to local
+                                       * sockets. */
+#endif /* CONFIG_NET_IGMP */
       case IP_PKTINFO:
         {
           FAR struct socket_conn_s *conn;

--- a/net/inet/ipv6_setsockopt.c
+++ b/net/inet/ipv6_setsockopt.c
@@ -137,13 +137,11 @@ int ipv6_setsockopt(FAR struct socket *psock, int option,
         ret = OK;
         break;
       }
-#endif
+#endif /* NET_UDP_HAVE_STACK */
+#endif /* CONFIG_NET_MLD */
 
       /* The following IPv6 socket options are defined, but not implemented */
 
-      case IPV6_MULTICAST_LOOP:   /* Multicast packets are delivered back to
-                                   * the local application */
-#endif
       case IPV6_V6ONLY:           /* Restrict AF_INET6 socket to IPv6
                                    * communications only */
         nwarn("WARNING: Unimplemented IPv6 option: %d\n", option);
@@ -160,6 +158,10 @@ int ipv6_setsockopt(FAR struct socket *psock, int option,
         }
         break;
 
+#ifdef CONFIG_NET_MLD
+      case IPV6_MULTICAST_LOOP:   /* Multicast packets are delivered back to
+                                   * the local application */
+#endif
       case IPV6_RECVPKTINFO:
       case IPV6_RECVHOPLIMIT:
         {

--- a/net/ipforward/ipv4_forward.c
+++ b/net/ipforward/ipv4_forward.c
@@ -364,20 +364,11 @@ static int ipv4_forward_callback(FAR struct net_driver_s *fwddev,
     {
       /* Backup the forward IP packet */
 
-      iob = iob_tryalloc(true);
+      iob = netdev_iob_clone(dev, true);
       if (iob == NULL)
         {
-          nerr("ERROR: iob alloc failed when forward broadcast\n");
+          nerr("ERROR: IOB clone failed when forwarding broadcast.\n");
           return -ENOMEM;
-        }
-
-      iob_reserve(iob, CONFIG_NET_LL_GUARDSIZE);
-      ret = iob_clone_partial(dev->d_iob, dev->d_iob->io_pktlen, 0,
-                              iob, 0, true, false);
-      if (ret < 0)
-        {
-          iob_free_chain(iob);
-          return ret;
         }
 
       /* Recover the pointer to the IPv4 header in the receiving device's

--- a/net/ipforward/ipv6_forward.c
+++ b/net/ipforward/ipv6_forward.c
@@ -491,20 +491,11 @@ static int ipv6_forward_callback(FAR struct net_driver_s *fwddev,
     {
       /* Backup the forward IP packet */
 
-      iob = iob_tryalloc(true);
+      iob = netdev_iob_clone(dev, true);
       if (iob == NULL)
         {
-          nerr("ERROR: iob alloc failed when forward broadcast\n");
+          nerr("ERROR: IOB clone failed when forwarding broadcast.\n");
           return -ENOMEM;
-        }
-
-      iob_reserve(iob, CONFIG_NET_LL_GUARDSIZE);
-      ret = iob_clone_partial(dev->d_iob, dev->d_iob->io_pktlen, 0,
-                              iob, 0, true, false);
-      if (ret < 0)
-        {
-          iob_free_chain(iob);
-          return ret;
         }
 
       /* Recover the pointer to the IPv6 header in the receiving device's

--- a/net/udp/udp.h
+++ b/net/udp/udp.h
@@ -237,6 +237,7 @@ void udp_free(FAR struct udp_conn_s *conn);
  ****************************************************************************/
 
 FAR struct udp_conn_s *udp_active(FAR struct net_driver_s *dev,
+                                  FAR struct udp_conn_s *conn,
                                   FAR struct udp_hdr_s *udp);
 
 /****************************************************************************

--- a/net/udp/udp_conn.c
+++ b/net/udp/udp_conn.c
@@ -188,15 +188,16 @@ static FAR struct udp_conn_s *udp_find_conn(uint8_t domain,
 
 #ifdef CONFIG_NET_IPv4
 static inline FAR struct udp_conn_s *
-  udp_ipv4_active(FAR struct net_driver_s *dev, FAR struct udp_hdr_s *udp)
+udp_ipv4_active(FAR struct net_driver_s *dev, FAR struct udp_conn_s *conn,
+                FAR struct udp_hdr_s *udp)
 {
 #ifdef CONFIG_NET_BROADCAST
   static const in_addr_t bcast = INADDR_BROADCAST;
 #endif
   FAR struct ipv4_hdr_s *ip = IPv4BUF;
-  FAR struct udp_conn_s *conn;
 
-  conn = (FAR struct udp_conn_s *)g_active_udp_connections.head;
+  conn = udp_nextconn(conn);
+
   while (conn)
     {
       /* If the local UDP port is non-zero, the connection is considered
@@ -330,12 +331,13 @@ static inline FAR struct udp_conn_s *
 
 #ifdef CONFIG_NET_IPv6
 static inline FAR struct udp_conn_s *
-  udp_ipv6_active(FAR struct net_driver_s *dev, FAR struct udp_hdr_s *udp)
+udp_ipv6_active(FAR struct net_driver_s *dev, FAR struct udp_conn_s *conn,
+                FAR struct udp_hdr_s *udp)
 {
   FAR struct ipv6_hdr_s *ip = IPv6BUF;
-  FAR struct udp_conn_s *conn;
 
-  conn = (FAR struct udp_conn_s *)g_active_udp_connections.head;
+  conn = udp_nextconn(conn);
+
   while (conn != NULL)
     {
       /* If the local UDP port is non-zero, the connection is considered
@@ -747,6 +749,7 @@ void udp_free(FAR struct udp_conn_s *conn)
  ****************************************************************************/
 
 FAR struct udp_conn_s *udp_active(FAR struct net_driver_s *dev,
+                                  FAR struct udp_conn_s *conn,
                                   FAR struct udp_hdr_s *udp)
 {
 #ifdef CONFIG_NET_IPv6
@@ -754,7 +757,7 @@ FAR struct udp_conn_s *udp_active(FAR struct net_driver_s *dev,
   if (IFF_IS_IPv6(dev->d_flags))
 #endif
     {
-      return udp_ipv6_active(dev, udp);
+      return udp_ipv6_active(dev, conn, udp);
     }
 #endif /* CONFIG_NET_IPv6 */
 
@@ -763,7 +766,7 @@ FAR struct udp_conn_s *udp_active(FAR struct net_driver_s *dev,
   else
 #endif
     {
-      return udp_ipv4_active(dev, udp);
+      return udp_ipv4_active(dev, conn, udp);
     }
 #endif /* CONFIG_NET_IPv4 */
 }

--- a/net/udp/udp_input.c
+++ b/net/udp/udp_input.c
@@ -64,6 +64,78 @@
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: udp_input_conn
+ *
+ * Description:
+ *   Handle incoming UDP input for the case where there is an active
+ *   connection.
+ *
+ * Input Parameters:
+ *   dev      - The device driver structure containing the received UDP pkt
+ *   conn     - The UDP connection structure associated with the packet
+ *   udpiplen - Length of the IP and UDP headers
+ *
+ * Returned Value:
+ *   OK     - The packet has been processed
+ *  -EAGAIN - Hold the packet and try again later.  There is a listening
+ *            socket but no receive in place to catch the packet yet.  The
+ *            device's d_len will be set to zero in this case as there is
+ *            no outgoing data.
+ *
+ * Assumptions:
+ *   The network is locked.
+ *
+ ****************************************************************************/
+
+static int udp_input_conn(FAR struct net_driver_s *dev,
+                          FAR struct udp_conn_s *conn, unsigned int udpiplen)
+{
+  uint16_t flags;
+
+  /* Set-up for the application callback */
+
+  dev->d_appdata = IPBUF(udpiplen);
+  dev->d_sndlen  = 0;
+
+  /* Perform the application callback */
+
+  flags = udp_callback(dev, conn, UDP_NEWDATA);
+
+  /* If the operation was successful and the UDP data was "consumed,"
+   * then the UDP_NEWDATA flag will be cleared by logic in
+   * udp_callback().  The packet memory can then be freed by the
+   * network driver.  OK will be returned to the network driver to
+   * indicate this case.
+   *
+   * "Consumed" here means that either the received data was (1)
+   * accepted by a socket waiting for data on the port or was (2)
+   * buffered in the UDP socket's read-ahead buffer.
+   */
+
+  if ((flags & UDP_NEWDATA) != 0)
+    {
+      /* No.. the packet was not processed now.  Return -EAGAIN so
+       * that the driver may retry again later.  We still need to
+       * set d_len to zero so that the driver is aware that there
+       * is nothing to be sent.
+       */
+
+      nwarn("WARNING: Packet not processed\n");
+      dev->d_len = 0;
+      return -EAGAIN;
+    }
+
+  /* If the application has data to send, setup the UDP/IP header */
+
+  if (dev->d_sndlen > 0)
+    {
+      udp_send(dev, conn);
+    }
+
+  return OK;
+}
+
+/****************************************************************************
  * Name: udp_input
  *
  * Description:
@@ -90,6 +162,10 @@ static int udp_input(FAR struct net_driver_s *dev, unsigned int iplen)
 {
   FAR struct udp_hdr_s *udp;
   FAR struct udp_conn_s *conn;
+#ifdef CONFIG_NET_SOCKOPTS
+  FAR struct udp_conn_s *nextconn;
+  FAR struct iob_s *iob;
+#endif
   unsigned int udpiplen;
 #ifdef CONFIG_NET_UDP_CHECKSUMS
   uint16_t chksum;
@@ -157,64 +233,48 @@ static int udp_input(FAR struct net_driver_s *dev, unsigned int iplen)
     {
       /* Demultiplex this UDP packet between the UDP "connections".
        *
-       * REVISIT:  The logic here expects either a single receive socket or
-       * none at all.  However, multiple sockets should be capable of
-       * receiving a UDP datagram (multicast reception).  This could be
-       * handled easily by something like:
-       *
-       *   for (conn = NULL; conn = udp_active(dev, udp); )
-       *
-       * If the callback logic that receives a packet responds with an
-       * outgoing packet, then it will over-write the received buffer,
-       * however.  recvfrom() will not do that, however.  We would have to
-       * make that the rule: Recipients of a UDP packet must treat the
-       * packet as read-only.
+       * REVISIT:  If the callback logic that receives a packet responds with
+       * an outgoing packet, then it may be ignored.  recvfrom() will not do
+       * that, however.
        */
 
-      conn = udp_active(dev, udp);
+      conn = udp_active(dev, NULL, udp);
       if (conn)
         {
-          uint16_t flags;
+          /* We'll only get multiple conn when we support SO_REUSEADDR */
 
-          /* Set-up for the application callback */
+#ifdef CONFIG_NET_SOCKOPTS
+          /* Do we have second connection that can hold this packet? */
 
-          dev->d_appdata = IPBUF(udpiplen);
-          dev->d_sndlen  = 0;
-
-          /* Perform the application callback */
-
-          flags = udp_callback(dev, conn, UDP_NEWDATA);
-
-          /* If the operation was successful and the UDP data was "consumed,"
-           * then the UDP_NEWDATA flag will be cleared by logic in
-           * udp_callback().  The packet memory can then be freed by the
-           * network driver.  OK will be returned to the network driver to
-           * indicate this case.
-           *
-           * "Consumed" here means that either the received data was (1)
-           * accepted by a socket waiting for data on the port or was (2)
-           * buffered in the UDP socket's read-ahead buffer.
-           */
-
-          if ((flags & UDP_NEWDATA) != 0)
+          while ((nextconn = udp_active(dev, conn, udp)) != NULL)
             {
-              /* No.. the packet was not processed now.  Return -EAGAIN so
-               * that the driver may retry again later.  We still need to
-               * set d_len to zero so that the driver is aware that there
-               * is nothing to be sent.
+              /* Yes... There are multiple listeners on the same port.
+               * We need to clone the packet and deliver it to each listener.
                */
 
-              nwarn("WARNING: Packet not processed\n");
-              dev->d_len = 0;
-              ret = -EAGAIN;
-            }
+              iob = netdev_iob_clone(dev, true);
+              if (iob == NULL)
+                {
+                  nerr("ERROR: IOB clone failed.\n");
+                  break; /* We can still process one time without clone. */
+                }
 
-          /* If the application has data to send, setup the UDP/IP header */
+              ret = udp_input_conn(dev, conn, udpiplen);
+              if (ret < 0)
+                {
+                  nwarn("WARNING: A conn failed to process the packet %d\n",
+                        ret); /* We can still continue for next conn. */
+                }
 
-          if (dev->d_sndlen > 0)
-            {
-              udp_send(dev, conn);
+              netdev_iob_replace(dev, iob);
+              udp  = IPBUF(iplen);
+              conn = nextconn;
             }
+#endif
+
+          /* We can deliver the packet directly to the last listener. */
+
+          ret = udp_input_conn(dev, conn, udpiplen);
         }
       else
         {

--- a/net/udp/udp_send.c
+++ b/net/udp/udp_send.c
@@ -58,8 +58,66 @@
 
 #include "devif/devif.h"
 #include "inet/inet.h"
+#include "socket/socket.h"
 #include "utils/utils.h"
 #include "udp/udp.h"
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: udp_send_loopback
+ *
+ * Description:
+ *   Send a copy of the UDP packet to ourself.
+ *
+ * Input Parameters:
+ *   dev - The device driver structure to use in the send operation
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_NET_SOCKOPTS) && \
+    (defined(CONFIG_NET_IGMP) || defined(CONFIG_NET_MLD))
+static void udp_send_loopback(FAR struct net_driver_s *dev)
+{
+  FAR struct iob_s *iob = netdev_iob_clone(dev, true);
+  if (iob == NULL)
+    {
+      nerr("ERROR: IOB clone failed when looping UDP.\n");
+      return;
+    }
+
+#ifdef CONFIG_NET_IPv4
+#ifdef CONFIG_NET_IPv6
+  if (IFF_IS_IPv4(dev->d_flags))
+#endif
+    {
+      ninfo("IPv4 frame\n");
+      NETDEV_RXIPV4(dev);
+      ipv4_input(dev);
+    }
+#endif /* CONFIG_NET_IPv4 */
+
+#ifdef CONFIG_NET_IPv6
+#ifdef CONFIG_NET_IPv4
+  else
+#endif
+    {
+      ninfo("IPv6 frame\n");
+      NETDEV_RXIPV6(dev);
+      ipv6_input(dev);
+    }
+#endif /* CONFIG_NET_IPv6 */
+
+  /* Restore device IOB with backup IOB */
+
+  netdev_iob_replace(dev, iob);
+}
+#endif
 
 /****************************************************************************
  * Public Functions
@@ -192,9 +250,7 @@ void udp_send(FAR struct net_driver_s *dev, FAR struct udp_conn_s *conn)
 
 #ifdef CONFIG_NET_IPv4
 #ifdef CONFIG_NET_IPv6
-      if (conn->domain == PF_INET ||
-          (conn->domain == PF_INET6 &&
-           ip6_is_ipv4addr((FAR struct in6_addr *)conn->u.ipv6.raddr)))
+      if (IFF_IS_IPv4(dev->d_flags))
 #endif
         {
           udp->udpchksum = ~udp_ipv4_chksum(dev);
@@ -221,6 +277,32 @@ void udp_send(FAR struct net_driver_s *dev, FAR struct udp_conn_s *conn)
 #ifdef CONFIG_NET_STATISTICS
       g_netstats.udp.sent++;
 #endif
+
+#ifdef CONFIG_NET_SOCKOPTS
+      /* Try loopback multicast to ourself. */
+
+#ifdef CONFIG_NET_IGMP
+      if (_SO_GETOPT(conn->sconn.s_options, IP_MULTICAST_LOOP) &&
+#ifdef CONFIG_NET_IPv6
+          IFF_IS_IPv4(dev->d_flags) &&
+#endif
+          IN_MULTICAST(NTOHL(raddr)))
+        {
+          udp_send_loopback(dev);
+        }
+#endif /* CONFIG_NET_IGMP */
+
+#ifdef CONFIG_NET_MLD
+      if (_SO_GETOPT(conn->sconn.s_options, IPV6_MULTICAST_LOOP) &&
+#ifdef CONFIG_NET_IPv4
+          IFF_IS_IPv6(dev->d_flags) &&
+#endif
+          IN6_IS_ADDR_MULTICAST((FAR struct in6_addr *)conn->u.ipv6.raddr))
+        {
+          udp_send_loopback(dev);
+        }
+#endif /* CONFIG_NET_MLD */
+#endif /* CONFIG_NET_SOCKOPTS */
     }
 }
 


### PR DESCRIPTION
## Summary
Patches included:
- net/netdev: Add netdev_iob_clone helper
- net/udp: Support deliver multicast packets back to local apps
- net/udp: Deliver data into multiple UDP conn bound to same port

## Impact
UDP only:
- Support `IP_MULTICAST_LOOP`
- Support delivering data into multiple UDP conn bound to same port (to both receive multicast packets)

## Testing
Vela test cases
