### PR TITLE
openamp/cmake: sync with libmetal.defs

### DIFF
--- a/openamp/libmetal.cmake
+++ b/openamp/libmetal.cmake
@@ -36,6 +36,10 @@ if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/libmetal)
     PATCH_COMMAND
       patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
       ${CMAKE_CURRENT_LIST_DIR}/0001-libmetal-add-metal_list_for_each_safe-support.patch
+      && patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
+      ${CMAKE_CURRENT_LIST_DIR}/0002-libmetal-nuttx-io.c-align-access-when-read-write-siz.patch
+      && patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
+      ${CMAKE_CURRENT_LIST_DIR}/0003-libmetal-nuttx-io.c-Fix-void-pointer-arithmetic-in-a.patch
     DOWNLOAD_NO_PROGRESS true
     TIMEOUT 30)
 


### PR DESCRIPTION

## Summary

This adds two missing patches so that to be in sync with libmetal.defs

## Impact

None

## Testing

checked with rv-virt

