### PR TITLE
board/control: add irq affinity control

### DIFF
--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -4703,6 +4703,13 @@ config BOARDCTL_TESTSET
 		Enables support for the BOARDIOC_SPINLOCK boardctl() command.
 		Architecture specific logic must provide up_testset() interface.
 
+config BOARDCTL_IRQ_AFFINITY
+	bool "Set an IRQ affinity to CPUs by software"
+	default n
+	depends on SMP
+	---help---
+		Enables support for Set an IRQ affinity to CPUs by software.
+
 config BOARDCTL_IOCTL
 	bool "Board-specific boardctl() commands"
 	default n

--- a/boards/boardctl.c
+++ b/boards/boardctl.c
@@ -30,6 +30,7 @@
 #include <errno.h>
 #include <assert.h>
 
+#include <nuttx/arch.h>
 #include <nuttx/board.h>
 #include <nuttx/lib/modlib.h>
 #include <nuttx/binfmt/symtab.h>
@@ -831,6 +832,25 @@ int boardctl(unsigned int cmd, uintptr_t arg)
 
           DEBUGASSERT(cause != NULL);
           ret = board_reset_cause(cause);
+        }
+        break;
+#endif
+
+#ifdef CONFIG_BOARDCTL_IRQ_AFFINITY
+      /* CMD:           BOARDIOC_IRQ_AFFINITY
+       * DESCRIPTION:   Set an IRQ affinity by software.
+       * ARG:           Integer array:
+                        member 0 is the interrupt number
+                        member 1 is the CPU index
+       * CONFIGURATION: CONFIG_BOARDCTL_IRQ_AFFINITY
+       * DEPENDENCIES:  Bound Multi-Processing (CONFIG_BMP)
+       */
+
+      case BOARDIOC_IRQ_AFFINITY:
+        {
+          FAR unsigned int *affinity = (FAR unsigned int *)arg;
+          up_affinity_irq(affinity[0], affinity[1]);
+          ret = OK;
         }
         break;
 #endif

--- a/include/sys/boardctl.h
+++ b/include/sys/boardctl.h
@@ -209,6 +209,7 @@
 #define BOARDIOC_SWITCH_BOOT       _BOARDIOC(0x0013)
 #define BOARDIOC_BOOT_IMAGE        _BOARDIOC(0x0014)
 #define BOARDIOC_RESET_CAUSE       _BOARDIOC(0x0015)
+#define BOARDIOC_IRQ_AFFINITY      _BOARDIOC(0x0016)
 
 /* If CONFIG_BOARDCTL_IOCTL=y, then board-specific commands will be support.
  * In this case, all commands not recognized by boardctl() will be forwarded
@@ -217,7 +218,7 @@
  * User defined board commands may begin with this value:
  */
 
-#define BOARDIOC_USER              _BOARDIOC(0x0016)
+#define BOARDIOC_USER              _BOARDIOC(0x0017)
 
 /****************************************************************************
  * Public Type Definitions


### PR DESCRIPTION
## Summary

board/control: add irq affinity control

add support for set an IRQ affinity to CPUs by software

Signed-off-by: chao an <anchao@lixiang.com>

## Impact

N/A

## Testing

ci-check