### PR TITLE
cmake:fix protected build link option break,init canmv230 protected build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -779,8 +779,14 @@ if(CONFIG_BUILD_PROTECTED)
     OUTPUT_VARIABLE nuttx_user_libgcc)
 
   # reset link options for userspace to prevent sections from being accidentally
-  # deleted
-  set_target_properties(nuttx_user PROPERTIES LINK_OPTIONS "")
+  # deleted Toolchain link options
+  get_target_property(nuttx_user_LINK_OPTIONS nuttx_user LINK_OPTIONS)
+  list(REMOVE_ITEM nuttx_user_LINK_OPTIONS "-Wl,--gc-sections")
+  list(REMOVE_ITEM nuttx_user_LINK_OPTIONS "-Wl,--cref")
+  list(REMOVE_ITEM nuttx_user_LINK_OPTIONS "-Wl,-Map=nuttx.map")
+  list(REMOVE_ITEM nuttx_user_LINK_OPTIONS "-Wl,--entry=__start")
+  set_target_properties(nuttx_user PROPERTIES LINK_OPTIONS
+                                              "${nuttx_user_LINK_OPTIONS}")
 
   target_link_options(
     nuttx_user PRIVATE -nostartfiles -nodefaultlibs

--- a/boards/risc-v/k230/canmv230/kernel/CMakeLists.txt
+++ b/boards/risc-v/k230/canmv230/kernel/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# boards/risc-v/k230/canmv230/CMakeLists.txt
+# boards/risc-v/k230/canmv230/kernel/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
@@ -18,11 +18,6 @@
 #
 # ##############################################################################
 
-add_subdirectory(src)
+target_link_options(nuttx_user PRIVATE "-Wl,-melf64lriscv")
 
-if(CONFIG_BUILD_PROTECTED)
-  add_subdirectory(kernel)
-  set_property(
-    GLOBAL PROPERTY LD_SCRIPT_USER
-                    ${CMAKE_CURRENT_LIST_DIR}/scripts/ld-userland.script)
-endif()
+target_sources(nuttx_user PRIVATE k230_userspace.c)

--- a/libs/libc/spawn/CMakeLists.txt
+++ b/libs/libc/spawn/CMakeLists.txt
@@ -29,23 +29,21 @@ set(SRCS
     lib_psa_getschedparam.c
     lib_psa_getschedpolicy.c
     lib_psa_init.c
-    lib_psa_destroy.c
     lib_psa_setflags.c
     lib_psa_setschedparam.c
     lib_psa_setschedpolicy.c
     lib_psa_getsigmask.c
-    lib_psa_setsigmask.c)
-
-if(CONFIG_DEBUG_FEATURES)
-  list(APPEND SRCS lib_psfa_dump.c)
-endif()
+    lib_psa_setsigmask.c
+    lib_psa_getstacksize.c
+    lib_psa_setstacksize.c
+    lib_psa_destroy.c)
 
 if(NOT CONFIG_BUILD_KERNEL)
-  list(APPEND SRCS lib_psa_getstacksize.c lib_psa_setstacksize.c)
+  list(APPEND SRCS lib_psa_getstackaddr.c lib_psa_setstackaddr.c)
 endif()
 
 if(CONFIG_DEBUG_FEATURES)
-  list(APPEND SRCS lib_psa_dump.c)
+  list(APPEND SRCS lib_psfa_dump.c lib_psa_dump.c)
 endif()
 
 target_sources(c PRIVATE ${SRCS})


### PR DESCRIPTION
## Summary
this should resolve https://github.com/apache/nuttx/issues/12019#issuecomment-2024806454

the link_option of nuttx_user target should be allowed to be set freely

## Impact
protected mode

## Testing

```
cmake -B build -DBOARD_CONFIG=canmv230/pnsh

cmake --build build 
```