### PR TITLE
virtio/cmake: sync with makefile system

### DIFF
--- a/drivers/virtio/CMakeLists.txt
+++ b/drivers/virtio/CMakeLists.txt
@@ -31,12 +31,24 @@ if(CONFIG_DRIVERS_VIRTIO_BLK)
   list(APPEND SRCS virtio-blk.c)
 endif()
 
+if(CONFIG_DRIVERS_VIRTIO_GPU)
+  list(APPEND SRCS virtio-gpu.c)
+endif()
+
+if(CONFIG_DRIVERS_VIRTIO_INPUT)
+  list(APPEND SRCS virtio-input.c)
+endif()
+
 if(CONFIG_DRIVERS_VIRTIO_NET)
   list(APPEND SRCS virtio-net.c)
 endif()
 
 if(CONFIG_DRIVERS_VIRTIO_RNG)
   list(APPEND SRCS virtio-rng.c)
+endif()
+
+if(CONFIG_DRIVERS_VIRTIO_RPMB)
+  list(APPEND SRCS virtio-rpmb.c)
 endif()
 
 if(CONFIG_DRIVERS_VIRTIO_SERIAL)


### PR DESCRIPTION

## Summary
This adds drivers like virtio-gpu etc to cmake system to be in line with the makefile system.

## Impact
cmake users

## Testing
checked with rv-virt
