### PR TITLE
boards: raspberrypi-pico: Fix nshsram build error

### DIFF
--- a/boards/arm/rp2040/raspberrypi-pico/configs/nshsram/defconfig
+++ b/boards/arm/rp2040/raspberrypi-pico/configs/nshsram/defconfig
@@ -5,6 +5,7 @@
 # You can then do "make savedefconfig" to generate a new defconfig file that includes your
 # modifications.
 #
+# CONFIG_DEBUG_OPT_UNUSED_SECTIONS is not set
 # CONFIG_LIBC_LONG_LONG is not set
 # CONFIG_NSH_ARGCAT is not set
 # CONFIG_NSH_CMDOPT_HEXDUMP is not set


### PR DESCRIPTION
## Summary

- This commit fixes https://github.com/apache/nuttx/issues/11956.
- The issue was introduced by https://github.com/apache/nuttx/pull/6118.

## Impact

- None

## Testing

- Tested with raspberrypi-pico.
- NOTE: the ci should be fixed later.
