### PR TITLE
modify arm64 gicv3 gic_rdists get type

### DIFF
--- a/arch/arm64/src/common/arm64_gic.h
+++ b/arch/arm64/src/common/arm64_gic.h
@@ -232,6 +232,7 @@
 #define GICR_TYPER_VLPIS            BIT(1)
 #define GICR_TYPER_DIRECTLPIS       BIT(3)
 #define GICR_TYPER_LAST             BIT(4)
+#define GICR_TYPER_AFFINITY_VALUE_SHIFT		32
 
 /* GICR_WAKER */
 #define GICR_WAKER_PS               1


### PR DESCRIPTION
## Summary

Modify the way the gicr base address is obtained, to avoid coupling the base address with the cpu id.

## Impact

The gic_rdists array is no longer bound to the cpu id and adapts to processors of different gicr base address types

## Testing

The test passed in up and smp mode.

