### PR TITLE
ci/darwin: remove codechecker from install list

### DIFF
--- a/arch/arm/src/stm32f7/stm32_rtc.c
+++ b/arch/arm/src/stm32f7/stm32_rtc.c
@@ -758,7 +758,7 @@ static int rtchw_set_alrmar(rtc_alarmreg_t alarmreg)
 
   putreg32(alarmreg, STM32_RTC_ALRMAR);
   putreg32(0, STM32_RTC_ALRMASSR);
-  rtcinfo("  ALRMAR: %08x\n", getreg32(STM32_RTC_ALRMAR));
+  rtcinfo("  ALRMAR: %08" PRIx32 "\n", getreg32(STM32_RTC_ALRMAR));
 
   /* Enable RTC alarm A */
 

--- a/arch/arm/src/stm32h7/stm32_rtc.c
+++ b/arch/arm/src/stm32h7/stm32_rtc.c
@@ -758,7 +758,7 @@ static int rtchw_set_alrmar(rtc_alarmreg_t alarmreg)
 
   putreg32(alarmreg, STM32_RTC_ALRMAR);
   putreg32(0, STM32_RTC_ALRMASSR);
-  rtcinfo("  ALRMAR: %08x\n", getreg32(STM32_RTC_ALRMAR));
+  rtcinfo("  ALRMAR: %08" PRIx32 "\n", getreg32(STM32_RTC_ALRMAR));
 
   /* Enable RTC alarm A */
 

--- a/boards/arm/stm32h7/linum-stm32h753bi/src/Makefile
+++ b/boards/arm/stm32h7/linum-stm32h753bi/src/Makefile
@@ -24,10 +24,10 @@ CSRCS = stm32_boot.c stm32_bringup.c
 
 ifeq ($(CONFIG_ARCH_LEDS),y)
 CSRCS += stm32_autoleds.c
-else
-  ifeq ($(CONFIG_USERLED),y)
-  CSRCS += stm32_userleds.c
-  endif
+endif
+
+ifeq ($(CONFIG_USERLED),y)
+CSRCS += stm32_userleds.c
 endif
 
 ifeq ($(CONFIG_STM32H7_OTGFS),y)

--- a/tools/ci/platforms/darwin.sh
+++ b/tools/ci/platforms/darwin.sh
@@ -209,7 +209,6 @@ python_tools() {
 
   pip3 install \
     cmake-format \
-    CodeChecker \
     cvt2utf \
     cxxfilt \
     esptool==4.5.1 \


### PR DESCRIPTION
## Summary

ci/darwin: remove codechecker from install list

try to fix ci error:

```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
codechecker 6.23.1 requires PyYAML==6.0.1, but you have pyyaml 5.4.1 which is incompatible.
```

arm/stm32f7: fix ci build break

1.
```
In file included from chip/stm32_rtc.c:31:
chip/stm32_rtc.c: In function 'rtchw_set_alrmar':
chip/stm32_rtc.c:761:11: warning: format '%x' expects argument of type 'unsigned int',
                         but argument 3 has type 'uint32_t' {aka 'volatile long unsigned int'} [-Wformat=]
  761 |   rtcinfo("  ALRMAR: %08x\n", getreg32(STM32_RTC_ALRMAR));
      |           ^~~~~~~~~~~~~~~~~~
chip/stm32_rtc.c:761:25: note: format string is defined here
  761 |   rtcinfo("  ALRMAR: %08x\n", getreg32(STM32_RTC_ALRMAR));
      |                      ~~~^
      |                         |
      |                         unsigned int
      |                      %08lx
```

2.

```
arm-none-eabi-ld: staging/libdrivers.a(userled_lower.o): in function `userled_setled':
drivers/leds/userled_lower.c:100: undefined reference to `board_userled'
```

Regression:
    https://github.com/apache/nuttx/pull/12014  stm32h7/linum-stm32h753bi: add support to leds

Signed-off-by: chao an <anchao@lixiang.com>



## Impact

N/A

## Testing

ci-test