### PR TITLE
mm/map.h:  minor revision on comments and field defs

### DIFF
--- a/include/nuttx/mm/map.h
+++ b/include/nuttx/mm/map.h
@@ -44,7 +44,7 @@ struct task_group_s;
 
 struct mm_map_entry_s
 {
-  FAR struct mm_map_entry *flink;  /* this is used as sq_entry_t */
+  FAR struct mm_map_entry_s *flink;  /* this is used as sq_entry_t */
   FAR void *vaddr;
   size_t length;
   off_t offset;
@@ -56,11 +56,11 @@ struct mm_map_entry_s
     int i;
   } priv;
 
-  /* Drivers which register mappings may also
-   * implement the unmap function to undo anything done in mmap.
-   * Nb. Implementation must NOT use "this_task()->group" since
-   * this is not valid during process exit. The argument "group" will be
-   * NULL in this case.
+  /* Drivers which register mappings may also implement the unmap function
+   * to undo anything done in mmap.
+   * Nb. Implementation must NOT use "this_task()->group" since it is not
+   * valid during process exit. The argument "group" will be NULL in this
+   * case.
    */
 
   int (*munmap)(FAR struct task_group_s *group,
@@ -69,16 +69,15 @@ struct mm_map_entry_s
                 size_t length);
 };
 
-/* A structure for the task group */
+/* memory mapping structure for the task group */
 
 struct mm_map_s
 {
-  sq_queue_t mm_map_sq;
-
-  size_t map_count;
+  sq_queue_t mm_map_sq;         /* mappings list */
+  size_t map_count;             /* mappings list length */
 
 #ifdef CONFIG_ARCH_VMA_MAPPING
-  GRAN_HANDLE mm_map_vpages;
+  GRAN_HANDLE mm_map_vpages;    /* SHM virtual zone allocator */
 #endif
 
   rmutex_t mm_map_mutex;


### PR DESCRIPTION
## Summary
This patch uses `struct mm_map_entry_s` instead of the non-existing  `struct mm_map_entry` for the  `flink` field definition, it also includes minor revision on comments.

## Impact
None

## Testing
CI checks

