### PR TITLE
all: Fix accessing uninitialized local variables

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_nxaudio.c
+++ b/arch/arm/src/cxd56xx/cxd56_nxaudio.c
@@ -2020,8 +2020,8 @@ static int cxd56_set_mic_gains(uint8_t gain, enum cxd56_mic_type_e mic_dev,
 static void cxd56_get_mic_config(uint8_t *count, uint8_t *dev, uint8_t *mode)
 {
   uint8_t i;
-  uint8_t is_dmic;
-  uint8_t is_amic;
+  bool is_dmic = false;
+  bool is_amic = false;
   uint8_t mic_sel = 0;
   uint8_t mic_count = 0;
 

--- a/arch/arm/src/kinetis/kinetis_usbdev.c
+++ b/arch/arm/src/kinetis/kinetis_usbdev.c
@@ -3370,7 +3370,7 @@ static int khci_epconfigure(struct usbdev_ep_s *ep,
   uint32_t regval;
   uint8_t  epno;
   bool     epin;
-  bool     bidi;
+  bool     bidi = false;
   int      index;
 
 #ifdef CONFIG_DEBUG_FEATURES

--- a/binfmt/libelf/libelf_coredump.c
+++ b/binfmt/libelf/libelf_coredump.c
@@ -91,7 +91,7 @@ static int elf_emit(FAR struct elf_dumpinfo_s *cinfo,
 {
   FAR const uint8_t *ptr = buf;
   size_t total = len;
-  int ret;
+  int ret = 0;
 
   while (total > 0)
     {
@@ -122,7 +122,7 @@ static int elf_emit_align(FAR struct elf_dumpinfo_s *cinfo)
                         ELF_PAGESIZE) - cinfo->stream->nput;
   unsigned char null[256];
   off_t total = align;
-  off_t ret;
+  off_t ret = 0;
 
   memset(null, 0, sizeof(null));
 


### PR DESCRIPTION
## Summary
Fix accessing uninitialized local variables in several functions.

Specifically in elf_emit() and elf_emit_align(), ret was uninitialized if total was 0.


## Impact

## Testing
 spresense:audio 
 freedom-k28f:nshsdusb
