### PR TITLE
ioexpander/icjx: add support for change of input interrupts on NINT

### DIFF
--- a/drivers/ioexpander/icjx.h
+++ b/drivers/ioexpander/icjx.h
@@ -98,5 +98,29 @@
 #define ICJX_CTRL_WORD_2_NIOL   (1 << 3)
 #define ICJX_CTRL_WORD_2_NIOH   (1 << 7)
 
+/* Control Word 4 */
+
+#define ICJX_CTRL_WORD_4_EOI    (1 << 7)
+
+/* Interrupt Status Register A */
+
+#define ICJX_ISR_A_SCS   (1 << 0)
+#define ICJX_ISR_A_ET1   (1 << 1)
+#define ICJX_ISR_A_ET2   (1 << 2)
+#define ICJX_ISR_A_ISCI  (1 << 4)
+#define ICJX_ISR_A_IET1  (1 << 5)
+#define ICJX_ISR_A_IET2  (1 << 6)
+#define ICJX_ISR_A_DCHI  (1 << 7)
+
+/* Interrupt Status Register B */
+
+#define ICJX_ISR_B_USA   (1 << 0)
+#define ICJX_ISR_B_USD   (1 << 1)
+#define ICJX_ISR_B_EOC   (1 << 2)
+#define ICJX_ISR_B_IUSA  (1 << 4)
+#define ICJX_ISR_B_IUSD  (1 << 5)
+#define ICJX_ISR_B_ISD   (1 << 6)
+#define ICJX_ISR_B_IOEC  (1 << 7)
+
 #endif /* CONFIG_IOEXPANDER && CONFIG_IOEXPANDER_ICJX */
 #endif /* __DRIVERS_IOEXPANDER_ICJX_H */

--- a/include/nuttx/ioexpander/icjx.h
+++ b/include/nuttx/ioexpander/icjx.h
@@ -67,6 +67,20 @@ struct icjx_config_s
   uint8_t addr;         /* Device address (set by A(1:0) pins) */
   uint8_t mode;         /* SPI mode */
   uint32_t frequency;   /* SPI frequency */
+
+#ifdef CONFIG_IOEXPANDER_INT_ENABLE
+  /* IRQ/GPIO access callbacks.  These operations all hidden behind
+   * callbacks to isolate the iC-JX driver from differences in GPIO
+   * interrupt handling by varying boards and MCUs.
+   *
+   * attach  - Attach the iC-JX interrupt handler to the GPIO interrupt
+   * enable  - Enable or disable the GPIO interrupt
+   */
+
+  CODE int  (*attach)(FAR struct icjx_config_s *config, xcpt_t handler,
+                      FAR void *arg);
+  CODE void (*enable)(FAR struct icjx_config_s *config, bool enable);
+#endif
 };
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
iC-JX expander has NINT (not an interrupt) pin that goes to logical zero if interrupt occurs. This commit adds support for iC-JX options settings that allows to enable the interrupt for defined input pins.

The interrupt is handled in HP worker thread to avoid waiting for SPI transfers in interrupt context. Board has to configure interrupt event for GPIO pin connected to NINT.

## Impact
iC-JX new functionality.

## Testing
Tested on SAMv7 custom board with iC-JX expander conencted over SPI.

