### PR TITLE
{Bp-12036} risc-v/espressif: Fix empty cpuint number

### DIFF
--- a/arch/risc-v/src/common/espressif/esp_irq.c
+++ b/arch/risc-v/src/common/espressif/esp_irq.c
@@ -153,7 +153,7 @@ static int esp_cpuint_alloc(int irq)
 {
   uint32_t bitmask;
   uint32_t intset;
-  int cpuint;
+  int cpuint = ESP_NCPUINTS;
 
   /* Check if there are CPU interrupts with the requested properties
    * available.


### PR DESCRIPTION
## Summary
Bugfix which came from as https://github.com/apache/nuttx/issues/11980

    risc-v/espressif: Fix empty cpuint number

## Impact
ESP32-C6, ESP32-H2 and ESP32-C3

## Testing

