### PR TITLE
{bp-12031} SMP: Fix returning uninitialized variable in nxsched_add_readytorun()

### DIFF
--- a/sched/sched/sched_addreadytorun.c
+++ b/sched/sched/sched_addreadytorun.c
@@ -366,6 +366,7 @@ bool nxsched_add_readytorun(FAR struct tcb_s *btcb)
 
           btcb->cpu        = cpu;
           btcb->task_state = TSTATE_TASK_ASSIGNED;
+          doswitch         = false;
         }
 
       /* All done, restart the other CPU (if it was paused). */


### PR DESCRIPTION
## Summary
Prior to this commit, doswitch is returned uninitialized if (task_state == TSTATE_TASK_ASSIGNED || task_state == TSTATE_TASK_RUNNING) && no context switch occurs
&& (cpu == me).

## Impact

## Testing
sabre-6quad:smp
