### PR TITLE
{bp-11998} mm/kmap.h: fix typo in comments

### DIFF
--- a/include/nuttx/mm/kmap.h
+++ b/include/nuttx/mm/kmap.h
@@ -38,7 +38,7 @@
 void kmm_map_initialize(void);
 
 /****************************************************************************
- * Name: kmm_map_pages
+ * Name: kmm_map
  *
  * Description:
  *   Map pages into kernel virtual memory.


### PR DESCRIPTION
## Summary
Fix typo in comments for kmm_map() function.

## Impact

## Testing

