### PR TITLE
{bp-11990} stm32h7:Serial Fix Logic error in up_dma_txavailable

### DIFF
--- a/arch/arm/src/stm32h7/stm32_serial.c
+++ b/arch/arm/src/stm32h7/stm32_serial.c
@@ -3360,7 +3360,8 @@ static void up_dma_txavailable(struct uart_dev_s *dev)
 
   /* Only send when the DMA is idle */
 
-  if ((priv->dev.dmatx.length && priv->dev.dmatx.nlength) == 0 &&
+  if (priv->dev.dmatx.length == 0 &&
+      priv->dev.dmatx.nlength == 0 &&
       stm32_dmaresidual(priv->txdma) == 0)
     {
       uart_xmitchars_dma(dev);


### PR DESCRIPTION
## Summary
Fixed logic error as noted by @kk-thrane

## Impact
Correct logic

## Testing
px4_fmu-v6x serial_test / gps / qgc
