### PR TITLE
include/nuttx/timers/pwm.h: add dcpol attribute to pwm_chan_s

### DIFF
--- a/include/nuttx/timers/pwm.h
+++ b/include/nuttx/timers/pwm.h
@@ -118,12 +118,25 @@
 
 /* These are helper definitions for setting PWM channel output polarity to
  * logical low or high level. The pulsed output should start with this
- * logical value and should return to it when the output is disabled.
+ * logical value.
+ * The output polarity of the PWM's disabled channel does not depend on this
+ * value, refer to DCPOL instead.
  */
 
 #define PWM_CPOL_NDEF             0   /* Not defined, default value by arch driver should be used */
 #define PWM_CPOL_LOW              1   /* Logical zero */
 #define PWM_CPOL_HIGH             2   /* Logical one */
+
+/* PWM disabled channel polarity ********************************************/
+
+/* The output of the PWM disabled channel may depend on the platform
+ * dependant peripheral. These helper definitions can be used for setting
+ * the disabled channel's output state.
+ */
+
+#define PWM_DCPOL_NDEF           0   /* Not defined, the default output state is arch dependant */ 
+#define PWM_DCPOL_LOW            1   /* Logical zero */
+#define PWM_DCPOL_HIGH           2   /* Logical one  */
 
 /****************************************************************************
  * Public Types
@@ -146,6 +159,7 @@ struct pwm_chan_s
   ub16_t dead_time_b;
 #endif
   uint8_t cpol;
+  uint8_t dcpol;
   int8_t channel;
 };
 #endif
@@ -174,6 +188,7 @@ struct pwm_info_s
                                  * generate an indefinite number of pulses */
 #  endif
   uint8_t cpol;                 /* Channel polarity */
+  uint8_t dcpol;                /* Disabled channel polarity */
 #endif /* CONFIG_PWM_MULTICHAN */
 
   FAR void           *arg;      /* User provided argument to be used in the


### PR DESCRIPTION
`PWM_CPOL_xxxx` helper defines and `uint8_t cpol` in the `struct pwm_chan_s` have been added to define the polarity of the running PWM. The only driver that has supported it up to this day was the samv7's one.

However, as with SAMV7 when the channels get turned off, the output polarity of the PWM channel (even if it's not running) also depend on the `cpol` field. This may cause the following problem:
- a certain polarity during runtime is desired, the user sets it
- however when the PWM operation is turned off, a default value should be set (for example a logical zero). If the default value of the disabled channel is undefined, it can cause trouble (undesired high outputs, etc...).

This new attribute extends the `struct pwm_chan_s` (and `struct pwm_info_s`) that defines PWM's output value in the disabled state.
