### PR TITLE
ESP32S3 configuring gpio pin 19 or 20 ( USB_D+/- ) for purposes other than USB/JTAG Controller and I2S pin selection range fixed

### DIFF
--- a/arch/xtensa/src/esp32s3/Kconfig
+++ b/arch/xtensa/src/esp32s3/Kconfig
@@ -366,26 +366,26 @@ config ESP32S3_I2S0_SAMPLE_RATE
 config ESP32S3_I2S0_BCLKPIN
 	int "I2S0 BCLK pin"
 	default 4
-	range 0 33 if ESP32S3_I2S0_ROLE_MASTER
-	range 0 39 if ESP32S3_I2S0_ROLE_SLAVE
+	range 0 48 if ESP32S3_I2S0_ROLE_MASTER
+	range 0 48 if ESP32S3_I2S0_ROLE_SLAVE
 
 config ESP32S3_I2S0_WSPIN
 	int "I2S0 WS pin"
 	default 5
-	range 0 33 if ESP32S3_I2S0_ROLE_MASTER
-	range 0 39 if ESP32S3_I2S0_ROLE_SLAVE
+	range 0 48 if ESP32S3_I2S0_ROLE_MASTER
+	range 0 48 if ESP32S3_I2S0_ROLE_SLAVE
 
 config ESP32S3_I2S0_DINPIN
 	int "I2S0 DIN pin"
 	depends on ESP32S3_I2S0_RX
 	default 19
-	range 0 39
+	range 0 48
 
 config ESP32S3_I2S0_DOUTPIN
 	int "I2S0 DOUT pin"
 	depends on ESP32S3_I2S0_TX
 	default 18
-	range 0 33
+	range 0 48
 
 config ESP32S3_I2S0_MCLK
 	bool "Enable I2S Master Clock"
@@ -398,7 +398,7 @@ config ESP32S3_I2S0_MCLKPIN
 	int "I2S MCLK pin"
 	depends on ESP32S3_I2S0_MCLK
 	default 0
-	range 0 39
+	range 0 48
 
 endif #ESP32S3_I2S0
 
@@ -478,26 +478,26 @@ config ESP32S3_I2S1_SAMPLE_RATE
 config ESP32S3_I2S1_BCLKPIN
 	int "I2S1 BCLK pin"
 	default 22
-	range 0 33 if ESP32S3_I2S1_ROLE_MASTER
-	range 0 39 if ESP32S3_I2S1_ROLE_SLAVE
+	range 0 48 if ESP32S3_I2S1_ROLE_MASTER
+	range 0 48 if ESP32S3_I2S1_ROLE_SLAVE
 
 config ESP32S3_I2S1_WSPIN
 	int "I2S1 WS pin"
 	default 23
-	range 0 33 if ESP32S3_I2S1_ROLE_MASTER
-	range 0 39 if ESP32S3_I2S1_ROLE_SLAVE
+	range 0 48 if ESP32S3_I2S1_ROLE_MASTER
+	range 0 48 if ESP32S3_I2S1_ROLE_SLAVE
 
 config ESP32S3_I2S1_DINPIN
 	int "I2S1 DIN pin"
 	depends on ESP32S3_I2S1_RX
 	default 26
-	range 0 39
+	range 0 48
 
 config ESP32S3_I2S1_DOUTPIN
 	int "I2S1 DOUT pin"
 	depends on ESP32S3_I2S1_TX
 	default 25
-	range 0 33
+	range 0 48
 
 config ESP32S3_I2S1_MCLK
 	bool "Enable I2S Master Clock"
@@ -510,7 +510,7 @@ config ESP32S3_I2S1_MCLKPIN
 	int "I2S MCLK pin"
 	depends on ESP32S3_I2S1_MCLK
 	default 1
-	range 0 39
+	range 0 48
 
 endif #ESP32S3_I2S1
 

--- a/arch/xtensa/src/esp32s3/Kconfig
+++ b/arch/xtensa/src/esp32s3/Kconfig
@@ -366,14 +366,12 @@ config ESP32S3_I2S0_SAMPLE_RATE
 config ESP32S3_I2S0_BCLKPIN
 	int "I2S0 BCLK pin"
 	default 4
-	range 0 48 if ESP32S3_I2S0_ROLE_MASTER
-	range 0 48 if ESP32S3_I2S0_ROLE_SLAVE
+	range 0 48
 
 config ESP32S3_I2S0_WSPIN
 	int "I2S0 WS pin"
 	default 5
-	range 0 48 if ESP32S3_I2S0_ROLE_MASTER
-	range 0 48 if ESP32S3_I2S0_ROLE_SLAVE
+	range 0 48
 
 config ESP32S3_I2S0_DINPIN
 	int "I2S0 DIN pin"
@@ -478,14 +476,12 @@ config ESP32S3_I2S1_SAMPLE_RATE
 config ESP32S3_I2S1_BCLKPIN
 	int "I2S1 BCLK pin"
 	default 22
-	range 0 48 if ESP32S3_I2S1_ROLE_MASTER
-	range 0 48 if ESP32S3_I2S1_ROLE_SLAVE
+	range 0 48
 
 config ESP32S3_I2S1_WSPIN
 	int "I2S1 WS pin"
 	default 23
-	range 0 48 if ESP32S3_I2S1_ROLE_MASTER
-	range 0 48 if ESP32S3_I2S1_ROLE_SLAVE
+	range 0 48
 
 config ESP32S3_I2S1_DINPIN
 	int "I2S1 DIN pin"

--- a/arch/xtensa/src/esp32s3/esp32s3_gpio.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_gpio.c
@@ -41,6 +41,7 @@
 #include "esp32s3_irq.h"
 #include "hardware/esp32s3_gpio.h"
 #include "hardware/esp32s3_iomux.h"
+#include "hardware/esp32s3_usb_serial_jtag.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -206,6 +207,17 @@ int esp32s3_configgpio(uint32_t pin, gpio_pinattr_t attr)
 
   func  = 0;
   cntrl = 0;
+
+  /* if pin 19 or 20 disable the USB/JTAG function and pull-up */
+
+  if (pin ==  19 || pin == 20)
+    {
+      uint32_t regval;
+      regval = getreg32(USB_SERIAL_JTAG_CONF0_REG);
+      regval &= ~(USB_SERIAL_JTAG_USB_PAD_ENABLE |
+                  USB_SERIAL_JTAG_DP_PULLUP);
+      putreg32(regval, USB_SERIAL_JTAG_CONF0_REG);
+    }
 
   /* Handle input pins */
 


### PR DESCRIPTION
## Summary
1. ESP32S3 GPIO pin 19 or 20 by default connected to USB/JTAG controller. When using pin 19 or 20 as GPIO, disable USB/JTAG
2. arch/xtensa/src/esp32s3/Kconfig updated: I2S BCLK, WSPIN, DINPIN, DOUTPIN pin range changed to 0 48

## Impact
pin 19, 20 can be used for other purposes.

pins > 33 can now be used for I2S0 and I2S1 in ESP32S3

## Testing
Tested on ESP32S3-WROOM-1, ESP32S3-MINI-1

