### PR TITLE
filemtd supports Nand-like file systems

### DIFF
--- a/drivers/mtd/filemtd.c
+++ b/drivers/mtd/filemtd.c
@@ -119,6 +119,8 @@ static ssize_t file_bytewrite(FAR struct mtd_dev_s *dev, off_t offset,
 #endif
 static int filemtd_ioctl(FAR struct mtd_dev_s *dev, int cmd,
                          unsigned long arg);
+static int filemtd_isbad(FAR struct mtd_dev_s *dev, off_t block);
+static int filemtd_markbad(FAR struct mtd_dev_s *dev, off_t block);
 
 #ifdef CONFIG_MTD_LOOP
 static ssize_t mtd_loop_read(FAR struct file *filep, FAR char *buffer,
@@ -148,6 +150,28 @@ static const struct file_operations g_fops =
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
+
+/****************************************************************************
+ * Name: filemtd_isbad
+ ****************************************************************************/
+
+static int filemtd_isbad(FAR struct mtd_dev_s *dev, off_t block)
+{
+  /* We always think it's all GOODBLOCK */
+
+  return 0;
+}
+
+/****************************************************************************
+ * Name: filemtd_markbad
+ ****************************************************************************/
+
+static int filemtd_markbad(FAR struct mtd_dev_s *dev, off_t block)
+{
+  /* Provides a dummy interface */
+
+  return 0;
+}
 
 /****************************************************************************
  * Name: filemtd_write
@@ -800,17 +824,19 @@ FAR struct mtd_dev_s *filemtd_initialize(FAR const char *path, size_t offset,
    * nullified by kmm_zalloc).
    */
 
-  priv->mtd.erase  = filemtd_erase;
-  priv->mtd.bread  = filemtd_bread;
-  priv->mtd.bwrite = filemtd_bwrite;
-  priv->mtd.read   = filemtd_byteread;
+  priv->mtd.erase   = filemtd_erase;
+  priv->mtd.bread   = filemtd_bread;
+  priv->mtd.bwrite  = filemtd_bwrite;
+  priv->mtd.read    = filemtd_byteread;
 #ifdef CONFIG_MTD_BYTE_WRITE
-  priv->mtd.write  = file_bytewrite;
+  priv->mtd.write   = file_bytewrite;
 #endif
-  priv->mtd.ioctl  = filemtd_ioctl;
-  priv->mtd.name   = "filemtd";
-  priv->offset     = offset;
-  priv->nblocks    = nblocks;
+  priv->mtd.ioctl   = filemtd_ioctl;
+  priv->mtd.isbad   = filemtd_isbad;
+  priv->mtd.markbad = filemtd_markbad;
+  priv->mtd.name    = "filemtd";
+  priv->offset      = offset;
+  priv->nblocks     = nblocks;
 
   return &priv->mtd;
 }

--- a/drivers/mtd/filemtd.c
+++ b/drivers/mtd/filemtd.c
@@ -279,19 +279,12 @@ static int filemtd_erase(FAR struct mtd_dev_s *dev, off_t startblock,
       nblocks = priv->nblocks - startblock;
     }
 
-  /* Convert the erase block to a logical block and the number of blocks
-   * in logical block numbers
-   */
-
-  startblock *= (priv->erasesize / priv->blocksize);
-  nblocks    *= (priv->erasesize / priv->blocksize);
-
   /* Get the offset corresponding to the first block and the size
    * corresponding to the number of blocks.
    */
 
-  offset = startblock * priv->blocksize;
-  nbytes = nblocks * priv->blocksize;
+  offset = startblock * priv->erasesize;
+  nbytes = nblocks * priv->erasesize;
 
   /* Then erase the data in the file */
 
@@ -303,7 +296,7 @@ static int filemtd_erase(FAR struct mtd_dev_s *dev, off_t startblock,
       nbytes -= MIN(nbytes, sizeof(buffer));
     }
 
-  return OK;
+  return nblocks;
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
1. filemtd adds markbad and isbad interfaces (dummy) to support nandflash file systems (like Yaffs).
2. The return value of the "file_erase" interface is changed to erase nblocks

## Impact
filemtd extension

## Testing
I used Yaffs as the test file system, which can now be mounted on a file through filemtd
