### PR TITLE
net/nat: Support Symmetric NAT

### DIFF
--- a/Documentation/components/net/nat.rst
+++ b/Documentation/components/net/nat.rst
@@ -2,7 +2,7 @@
 Network Address Translation (NAT)
 =================================
 
-NuttX supports full cone NAT logic, which currently supports
+NuttX supports full cone or symmetric NAT logic, which currently supports
 
 - TCP
 
@@ -46,6 +46,12 @@ Configuration Options
 ``CONFIG_NET_NAT``
   Enable or disable Network Address Translation (NAT) function.
   Depends on ``CONFIG_NET_IPFORWARD``.
+``CONFIG_NET_NAT_FULL_CONE``
+  Enable Full Cone NAT logic. Full Cone NAT is easier to traverse than
+  Symmetric NAT, and uses less resources than Symmetric NAT.
+``CONFIG_NET_NAT_SYMMETRIC``
+  Enable Symmetric NAT logic. Symmetric NAT will be safer than Full Cone NAT,
+  be more difficult to traverse, and has more entries which may lead to heavier load.
 ``CONFIG_NET_NAT_HASH_BITS``
   The bits of the hashtable of NAT entries, hashtable has (1 << bits) buckets.
 ``CONFIG_NET_NAT_TCP_EXPIRE_SEC``
@@ -101,7 +107,8 @@ Validated on Ubuntu 22.04 x86_64 with NuttX SIM by following steps:
       # CONFIG_SIM_NET_BRIDGE is not set
       CONFIG_SIM_NETDEV_NUMBER=2
 
-2. Call ``ipv4_nat_enable`` on one dev on startup
+2. Call ``ipv4_nat_enable`` on one dev on startup, or manually enable NAT
+   with ``iptables`` command (either may work).
 
   ..  code-block:: c
 
@@ -112,6 +119,10 @@ Validated on Ubuntu 22.04 x86_64 with NuttX SIM by following steps:
         ipv4_nat_enable(&g_sim_dev[0]);
         ...
       }
+
+  ..  code-block:: shell
+
+      iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
 
 3. Set IP Address for NuttX on startup
 

--- a/net/nat/Kconfig
+++ b/net/nat/Kconfig
@@ -15,6 +15,25 @@ config NET_NAT
 		and NAT may need a continuous buffer of at least 68 Bytes
 		(IPv4 20B + ICMP 8B + IPv4 20B + TCP 20B).
 
+choice
+	prompt "NAT Type"
+	default NET_NAT_FULL_CONE
+	depends on NET_NAT
+
+config NET_NAT_FULL_CONE
+	bool "Full Cone NAT"
+	---help---
+		Full Cone NAT is easier to traverse than Symmetric NAT, and uses
+		less resources than Symmetric NAT.
+
+config NET_NAT_SYMMETRIC
+	bool "Symmetric NAT"
+	---help---
+		Symmetric NAT will be safer than Full Cone NAT, be more difficult
+		to traverse, and has more entries which may lead to heavier load.
+
+endchoice
+
 config NET_NAT_HASH_BITS
 	int "The bits of NAT entry hashtable"
 	default 5

--- a/net/nat/nat.h
+++ b/net/nat/nat.h
@@ -55,13 +55,20 @@ struct ipv4_nat_entry
    *                |----------------|
    *
    * Full cone NAT only need to save local ip:port and external ip:port.
+   * Symmetric NAT need to save peer ip:port as well.
    * For ICMP, save id in port field.
    */
 
   in_addr_t  local_ip;       /* IP address of the local (private) host. */
   in_addr_t  external_ip;    /* External IP address. */
+#ifdef CONFIG_NET_NAT_SYMMETRIC
+  in_addr_t  peer_ip;        /* Peer IP address. */
+#endif
   uint16_t   local_port;     /* Port of the local (private) host. */
   uint16_t   external_port;  /* The external port of local (private) host. */
+#ifdef CONFIG_NET_NAT_SYMMETRIC
+  uint16_t   peer_port;      /* Peer port. */
+#endif
   uint8_t    protocol;       /* L4 protocol (TCP, UDP etc). */
 
   int32_t    expire_time;    /* The expiration time of this entry. */
@@ -203,6 +210,8 @@ void ipv4_nat_entry_clear(FAR struct net_driver_s *dev);
  *   protocol      - The L4 protocol of the packet.
  *   external_ip   - The external ip of the packet, supports INADDR_ANY.
  *   external_port - The external port of the packet.
+ *   peer_ip       - The peer ip of the packet.
+ *   peer_port     - The peer port of the packet.
  *   refresh       - Whether to refresh the selected entry.
  *
  * Returned Value:
@@ -212,7 +221,8 @@ void ipv4_nat_entry_clear(FAR struct net_driver_s *dev);
 
 FAR struct ipv4_nat_entry *
 ipv4_nat_inbound_entry_find(uint8_t protocol, in_addr_t external_ip,
-                            uint16_t external_port, bool refresh);
+                            uint16_t external_port, in_addr_t peer_ip,
+                            uint16_t peer_port, bool refresh);
 
 /****************************************************************************
  * Name: ipv4_nat_outbound_entry_find
@@ -226,6 +236,8 @@ ipv4_nat_inbound_entry_find(uint8_t protocol, in_addr_t external_ip,
  *   protocol   - The L4 protocol of the packet.
  *   local_ip   - The local ip of the packet.
  *   local_port - The local port of the packet.
+ *   peer_ip    - The peer ip of the packet.
+ *   peer_port  - The peer port of the packet.
  *   try_create - Try create the entry if no entry found.
  *
  * Returned Value:
@@ -236,6 +248,7 @@ ipv4_nat_inbound_entry_find(uint8_t protocol, in_addr_t external_ip,
 FAR struct ipv4_nat_entry *
 ipv4_nat_outbound_entry_find(FAR struct net_driver_s *dev, uint8_t protocol,
                              in_addr_t local_ip, uint16_t local_port,
+                             in_addr_t peer_ip, uint16_t peer_port,
                              bool try_create);
 
 #endif /* CONFIG_NET_NAT && CONFIG_NET_IPv4 */


### PR DESCRIPTION
## Summary
NAT: Support "Symmetric NAT" besides current "Full Cone NAT"

The symmetric NAT limits one external port to be used with only one peer ip:port.

Note:
1. To avoid using too much `#ifdef`, we're always passing `peer_ip` and `peer_port` as arguments, but won't use them under full cone NAT, let the compiler optimize them.
2. We need to find port binding without peer ip:port, so don't add peer ip:port into hash key.
3. Symmetric NAT needs to *select another external port if a port is used by any other NAT entry*, this behavior is exactly the same as Full Cone NAT, so we don't need to change anything related to `ipv4_nat_port_inuse`.

## Impact
net/nat module, with Konfig controlled.

## Testing
Manually with methods in nat.rst