### PR TITLE
net/can: deliver data into multiple CAN conn bound to same dev

### DIFF
--- a/net/can/can.h
+++ b/net/can/can.h
@@ -185,6 +185,25 @@ void can_free(FAR struct can_conn_s *conn);
 FAR struct can_conn_s *can_nextconn(FAR struct can_conn_s *conn);
 
 /****************************************************************************
+ * Name: can_active()
+ *
+ * Description:
+ *   Traverse the list of NetLink connections that match dev
+ *
+ * Input Parameters:
+ *   dev  - The device to search for.
+ *   conn - The current connection; may be NULL to start the search at the
+ *          beginning
+ *
+ * Assumptions:
+ *   This function is called from NetLink device logic.
+ *
+ ****************************************************************************/
+
+FAR struct can_conn_s *can_active(FAR struct net_driver_s *dev,
+                                  FAR struct can_conn_s *conn);
+
+/****************************************************************************
  * Name: can_callback
  *
  * Description:

--- a/net/can/can_conn.c
+++ b/net/can/can_conn.c
@@ -225,4 +225,34 @@ FAR struct can_conn_s *can_nextconn(FAR struct can_conn_s *conn)
     }
 }
 
+/****************************************************************************
+ * Name: can_active()
+ *
+ * Description:
+ *   Traverse the list of NetLink connections that match dev
+ *
+ * Input Parameters:
+ *   dev  - The device to search for.
+ *   conn - The current connection; may be NULL to start the search at the
+ *          beginning
+ *
+ * Assumptions:
+ *   This function is called from NetLink device logic.
+ *
+ ****************************************************************************/
+
+FAR struct can_conn_s *can_active(FAR struct net_driver_s *dev,
+                                  FAR struct can_conn_s *conn)
+{
+  while ((conn = can_nextconn(conn)) != NULL)
+    {
+      if (conn->dev == NULL || conn->dev == dev)
+        {
+          break;
+        }
+    }
+
+  return conn;
+}
+
 #endif /* CONFIG_NET_CAN */


### PR DESCRIPTION
## Summary
Because CAN is a broadcast protocol, each conn needs to be given independent data to avoid mutual interference.

## Impact

## Testing
sim:local
