### PR TITLE
{bp12080 }net: Fix max conn always one less than configured value

### DIFF
--- a/net/bluetooth/bluetooth_conn.c
+++ b/net/bluetooth/bluetooth_conn.c
@@ -125,7 +125,7 @@ FAR struct bluetooth_conn_s *bluetooth_conn_alloc(void)
     {
 #if CONFIG_NET_BLUETOOTH_MAX_CONNS > 0
       if (dq_count(&g_active_bluetooth_connections) +
-          CONFIG_NET_BLUETOOTH_ALLOC_CONNS >= CONFIG_NET_BLUETOOTH_MAX_CONNS)
+          CONFIG_NET_BLUETOOTH_ALLOC_CONNS > CONFIG_NET_BLUETOOTH_MAX_CONNS)
         {
           net_unlock();
           return NULL;

--- a/net/can/can_conn.c
+++ b/net/can/can_conn.c
@@ -112,8 +112,8 @@ FAR struct can_conn_s *can_alloc(void)
   if (dq_peek(&g_free_can_connections) == NULL)
     {
 #if CONFIG_CAN_MAX_CONNS > 0
-      if (dq_count(&g_active_can_connections) + CONFIG_CAN_ALLOC_CONNS
-          >= CONFIG_CAN_MAX_CONNS)
+      if (dq_count(&g_active_can_connections) +
+          CONFIG_CAN_ALLOC_CONNS > CONFIG_CAN_MAX_CONNS)
         {
           nxmutex_unlock(&g_free_lock);
           return NULL;

--- a/net/icmp/icmp_conn.c
+++ b/net/icmp/icmp_conn.c
@@ -114,7 +114,7 @@ FAR struct icmp_conn_s *icmp_alloc(void)
         {
 #if CONFIG_NET_ICMP_MAX_CONNS > 0
           if (dq_count(&g_active_icmp_connections) +
-              CONFIG_NET_ICMP_ALLOC_CONNS >= CONFIG_NET_ICMP_MAX_CONNS)
+              CONFIG_NET_ICMP_ALLOC_CONNS > CONFIG_NET_ICMP_MAX_CONNS)
             {
               nxmutex_unlock(&g_free_lock);
               return NULL;

--- a/net/icmpv6/icmpv6_conn.c
+++ b/net/icmpv6/icmpv6_conn.c
@@ -115,7 +115,7 @@ FAR struct icmpv6_conn_s *icmpv6_alloc(void)
         {
 #if CONFIG_NET_ICMPv6_MAX_CONNS > 0
           if (dq_count(&g_active_icmpv6_connections) +
-              CONFIG_NET_ICMPv6_ALLOC_CONNS >= CONFIG_NET_ICMPv6_MAX_CONNS)
+              CONFIG_NET_ICMPv6_ALLOC_CONNS > CONFIG_NET_ICMPv6_MAX_CONNS)
             {
               nxmutex_unlock(&g_free_lock);
               return NULL;

--- a/net/ieee802154/ieee802154_conn.c
+++ b/net/ieee802154/ieee802154_conn.c
@@ -119,8 +119,7 @@ FAR struct ieee802154_conn_s *ieee802154_conn_alloc(void)
     {
 #if CONFIG_NET_IEEE802154_MAX_CONNS > 0
       if (dq_count(&g_active_ieee802154_connections) +
-          CONFIG_NET_IEEE802154_ALLOC_CONNS
-          >= CONFIG_NET_IEEE802154_MAX_CONNS)
+         CONFIG_NET_IEEE802154_ALLOC_CONNS > CONFIG_NET_IEEE802154_MAX_CONNS)
         {
           net_unlock();
           return NULL;

--- a/net/netlink/netlink_conn.c
+++ b/net/netlink/netlink_conn.c
@@ -144,7 +144,7 @@ FAR struct netlink_conn_s *netlink_alloc(void)
     {
 #if CONFIG_NETLINK_MAX_CONNS > 0
       if (dq_count(&g_active_netlink_connections) +
-          CONFIG_NETLINK_ALLOC_CONNS >= CONFIG_NETLINK_MAX_CONNS)
+          CONFIG_NETLINK_ALLOC_CONNS > CONFIG_NETLINK_MAX_CONNS)
         {
           nxmutex_unlock(&g_free_lock);
           return NULL;

--- a/net/pkt/pkt_conn.c
+++ b/net/pkt/pkt_conn.c
@@ -117,8 +117,8 @@ FAR struct pkt_conn_s *pkt_alloc(void)
   if (dq_peek(&g_free_pkt_connections) == NULL)
     {
 #if CONFIG_NET_PKT_MAX_CONNS > 0
-      if (dq_count(&g_active_pkt_connections) + CONFIG_NET_PKT_ALLOC_CONNS
-          >= CONFIG_NET_PKT_MAX_CONNS)
+      if (dq_count(&g_active_pkt_connections) +
+          CONFIG_NET_PKT_ALLOC_CONNS > CONFIG_NET_PKT_MAX_CONNS)
         {
           nxmutex_unlock(&g_free_lock);
           return NULL;

--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -514,8 +514,8 @@ static FAR struct tcp_conn_s *tcp_alloc_conn(void)
   if (dq_peek(&g_free_tcp_connections) == NULL)
     {
 #if CONFIG_NET_TCP_MAX_CONNS > 0
-      if (dq_count(&g_active_tcp_connections) + CONFIG_NET_TCP_ALLOC_CONNS
-          >= CONFIG_NET_TCP_MAX_CONNS)
+      if (dq_count(&g_active_tcp_connections) +
+          CONFIG_NET_TCP_ALLOC_CONNS > CONFIG_NET_TCP_MAX_CONNS)
         {
           return NULL;
         }

--- a/net/udp/udp_conn.c
+++ b/net/udp/udp_conn.c
@@ -474,8 +474,8 @@ static FAR struct udp_conn_s *udp_alloc_conn(void)
   if (dq_peek(&g_free_udp_connections) == NULL)
     {
 #if CONFIG_NET_UDP_MAX_CONNS > 0
-      if (dq_count(&g_active_udp_connections) + CONFIG_NET_UDP_ALLOC_CONNS
-          >= CONFIG_NET_UDP_MAX_CONNS)
+      if (dq_count(&g_active_udp_connections) +
+          CONFIG_NET_UDP_ALLOC_CONNS > CONFIG_NET_UDP_MAX_CONNS)
         {
           return NULL;
         }

--- a/net/usrsock/usrsock_conn.c
+++ b/net/usrsock/usrsock_conn.c
@@ -90,7 +90,7 @@ FAR struct usrsock_conn_s *usrsock_alloc(void)
     {
 #if CONFIG_NET_USRSOCK_MAX_CONNS > 0
       if (dq_count(&g_active_usrsock_connections) +
-          CONFIG_NET_USRSOCK_ALLOC_CONNS >= CONFIG_NET_USRSOCK_MAX_CONNS)
+          CONFIG_NET_USRSOCK_ALLOC_CONNS > CONFIG_NET_USRSOCK_MAX_CONNS)
         {
           nxmutex_unlock(&g_free_lock);
           return NULL;


### PR DESCRIPTION
## Summary
return NULL only when the total number is larger than configured value

## Impact
net 

## Testing
ci