### PR TITLE
{bp-12083} stm32h7/fdcan: fixed kconfig and debug register

### DIFF
--- a/arch/arm/src/stm32h7/Kconfig
+++ b/arch/arm/src/stm32h7/Kconfig
@@ -5914,7 +5914,6 @@ endmenu # STM32H7_FDCAN2
 
 config STM32H7_FDCAN_REGDEBUG
 	bool "Enable register dump debugging"
-	depends on DEBUG_CAN_INFO
 	depends on DEBUG_NET_INFO
 	default n
 	---help---

--- a/arch/arm/src/stm32h7/stm32_fdcan_sock.c
+++ b/arch/arm/src/stm32h7/stm32_fdcan_sock.c
@@ -549,7 +549,7 @@ static void fdcan_dumpregs(struct fdcan_driver_s *priv)
       /* Protocol error -- check protocol status register for details */
 
       regval = getreg32(priv->base + STM32_FDCAN_PSR_OFFSET);
-      printf("--PSR.LEC = %d\n", regval & FDCAN_PSR_LEC);
+      printf("--PSR.LEC = %" PRId32 "\n", regval & FDCAN_PSR_LEC_MASK);
     }
 }
 #endif
@@ -2080,7 +2080,7 @@ int fdcan_initialize(struct fdcan_driver_s *priv)
     }
 
 #ifdef CONFIG_STM32H7_FDCAN_REGDEBUG
-  const fdcan_bitseg *tim = &priv->arbi_timing;
+  const struct fdcan_bitseg *tim = &priv->arbi_timing;
   ninfo("[fdcan][arbi] Timings: presc=%u sjw=%u bs1=%u bs2=%u\r\n",
         tim->prescaler, tim->sjw, tim->bs1, tim->bs2);
 #endif
@@ -2104,7 +2104,7 @@ int fdcan_initialize(struct fdcan_driver_s *priv)
     }
 
 #ifdef CONFIG_STM32H7_FDCAN_REGDEBUG
-  const fdcan_bitseg *tim = &priv->data_timing;
+  tim = &priv->data_timing;
   ninfo("[fdcan][data] Timings: presc=%u sjw=%u bs1=%u bs2=%u\r\n",
         tim->prescaler, tim->sjw, tim->bs1, tim->bs2);
 #endif


### PR DESCRIPTION
## Summary
Fixed kconfig and debug register for stm32h7

## Impact
Enable debug messages for FDCAN for stm32h7

## Testing
Enable fdcan debug messages.
