### PR TITLE
{bp-12093} stm32h7/stm32_i2c: fix sending large data over i2c

### DIFF
--- a/arch/arm/src/stm32h7/stm32_i2c.c
+++ b/arch/arm/src/stm32h7/stm32_i2c.c
@@ -1990,9 +1990,9 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
               i2cinfo("TCR: DISABLE RELOAD: NBYTES = dcnt = %i msgc = %i\n",
                       priv->dcnt, priv->msgc);
 
-              stm32_i2c_disable_reload(priv);
-
               stm32_i2c_set_bytes_to_transfer(priv, priv->dcnt);
+
+              stm32_i2c_disable_reload(priv);
             }
 
           i2cinfo("TCR: EXIT dcnt = %i msgc = %i status 0x%08" PRIx32 "\n",


### PR DESCRIPTION
## Summary
To trigger TC interrupt NBYTES needs to be set before RELOAD is disabled

## Impact
This fixes a very nasty bug in the I2C driver for STM32H7 MCUs if anyone tries sending a chunk of data larger than 255 bytes.
For TC interrupt to be triggered NBYTES needs to be set before RELOAD is disabled, otherwise, an interrupt will never happen, and implemented logic for handling data larger than 255 bytes will not work.

## Testing

