### PR TITLE
stm32f76xx77xx_rcc: Fix PLLI2S factor divisors

### DIFF
--- a/arch/arm/src/stm32f7/stm32f76xx77xx_rcc.c
+++ b/arch/arm/src/stm32f7/stm32f76xx77xx_rcc.c
@@ -913,7 +913,10 @@ static void stm32_stdclockconfig(void)
         {
         }
 #endif
-#if defined(CONFIG_STM32F7_PLLI2S) || (STM32_RCC_DCKCFGR1_SAI1SRC == RCC_DCKCFGR1_SAI1SEL(1)) || (STM32_RCC_DCKCFGR1_SAI2SRC == RCC_DCKCFGR1_SAI2SEL(1))
+
+#if defined(CONFIG_STM32F7_PLLI2S) || \
+    (STM32_RCC_DCKCFGR1_SAI1SRC == RCC_DCKCFGR1_SAI1SEL(1)) || \
+    (STM32_RCC_DCKCFGR1_SAI2SRC == RCC_DCKCFGR1_SAI2SEL(1))
 
       /* Configure PLLI2S */
 
@@ -922,10 +925,10 @@ static void stm32_stdclockconfig(void)
                   | RCC_PLLI2SCFGR_PLLI2SP_MASK
                   | RCC_PLLI2SCFGR_PLLI2SQ_MASK
                   | RCC_PLLI2SCFGR_PLLI2SR_MASK);
-      regval |= (STM32_RCC_PLLSAICFGR_PLLSAIN
-                 | STM32_RCC_PLLSAICFGR_PLLSAIP
-                 | STM32_RCC_PLLSAICFGR_PLLSAIQ
-                 | STM32_RCC_PLLSAICFGR_PLLSAIR);
+      regval |= (STM32_RCC_PLLI2SCFGR_PLLI2SN
+                 | STM32_RCC_PLLI2SCFGR_PLLI2SP
+                 | STM32_RCC_PLLI2SCFGR_PLLI2SQ
+                 | STM32_RCC_PLLI2SCFGR_PLLI2SR);
       putreg32(regval, STM32_RCC_PLLI2SCFGR);
 
       /* Enable PLLI2S */


### PR DESCRIPTION
## Summary
Value was set with PLLSAI factor divisors instead of PLLI2S factor divisors.
## Impact
Fix I2S clock
## Testing
stm32f777 board
