### PR TITLE
net: Make TCP/UDP max & min port customizable

### DIFF
--- a/net/Kconfig
+++ b/net/Kconfig
@@ -57,6 +57,18 @@ config NET_PROMISCUOUS
 		Force the Ethernet driver to operate in promiscuous mode (if supported
 		by the Ethernet driver).
 
+config NET_DEFAULT_MIN_PORT
+	int "Net Default Min Port"
+	default 4096
+	---help---
+		Default Network min port
+
+config NET_DEFAULT_MAX_PORT
+	int "Net Default Max Port"
+	default 32000
+	---help---
+		Default Network max port
+
 menu "Driver buffer configuration"
 
 config NET_ETH_PKTSIZE

--- a/net/Kconfig
+++ b/net/Kconfig
@@ -59,12 +59,14 @@ config NET_PROMISCUOUS
 
 config NET_DEFAULT_MIN_PORT
 	int "Net Default Min Port"
+	range 1 65535
 	default 4096
 	---help---
 		Default Network min port
 
 config NET_DEFAULT_MAX_PORT
 	int "Net Default Max Port"
+	range NET_DEFAULT_MIN_PORT 65535
 	default 32000
 	---help---
 		Default Network max port

--- a/net/nat/ipv4_nat_entry.c
+++ b/net/nat/ipv4_nat_entry.c
@@ -110,7 +110,9 @@ static uint16_t ipv4_nat_select_port_without_stack(
   uint16_t hport = NTOHS(portno);
   while (ipv4_nat_port_inuse(protocol, ip, portno))
     {
-      if (++hport >= CONFIG_NET_DEFAULT_MAX_PORT)
+      ++hport;
+      if (hport >= CONFIG_NET_DEFAULT_MAX_PORT ||
+          hport < CONFIG_NET_DEFAULT_MIN_PORT)
         {
           hport = CONFIG_NET_DEFAULT_MIN_PORT;
         }
@@ -200,7 +202,9 @@ static uint16_t ipv4_nat_select_port(FAR struct net_driver_s *dev,
           while (icmp_findconn(dev, id) ||
                  ipv4_nat_port_inuse(IP_PROTO_ICMP, dev->d_ipaddr, id))
             {
-              if (++hid >= CONFIG_NET_DEFAULT_MAX_PORT)
+              ++hid;
+              if (hid >= CONFIG_NET_DEFAULT_MAX_PORT ||
+                  hid < CONFIG_NET_DEFAULT_MIN_PORT)
                 {
                   hid = CONFIG_NET_DEFAULT_MIN_PORT;
                 }

--- a/net/nat/ipv4_nat_entry.c
+++ b/net/nat/ipv4_nat_entry.c
@@ -41,15 +41,6 @@
 #if defined(CONFIG_NET_NAT) && defined(CONFIG_NET_IPv4)
 
 /****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-/* TODO: Why we limit to 32000 in net stack? */
-
-#define NAT_PORT_REASSIGN_MAX 32000
-#define NAT_PORT_REASSIGN_MIN 4096
-
-/****************************************************************************
  * Private Data
  ****************************************************************************/
 
@@ -119,9 +110,9 @@ static uint16_t ipv4_nat_select_port_without_stack(
   uint16_t hport = NTOHS(portno);
   while (ipv4_nat_port_inuse(protocol, ip, portno))
     {
-      if (++hport >= NAT_PORT_REASSIGN_MAX)
+      if (++hport >= CONFIG_NET_DEFAULT_MAX_PORT)
         {
-          hport = NAT_PORT_REASSIGN_MIN;
+          hport = CONFIG_NET_DEFAULT_MIN_PORT;
         }
 
       portno = HTONS(hport);
@@ -209,9 +200,9 @@ static uint16_t ipv4_nat_select_port(FAR struct net_driver_s *dev,
           while (icmp_findconn(dev, id) ||
                  ipv4_nat_port_inuse(IP_PROTO_ICMP, dev->d_ipaddr, id))
             {
-              if (++hid >= NAT_PORT_REASSIGN_MAX)
+              if (++hid >= CONFIG_NET_DEFAULT_MAX_PORT)
                 {
-                  hid = NAT_PORT_REASSIGN_MIN;
+                  hid = CONFIG_NET_DEFAULT_MIN_PORT;
                 }
 
               id = HTONS(hid);

--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -585,12 +585,10 @@ int tcp_selectport(uint8_t domain,
     {
       net_getrandom(&g_last_tcp_port, sizeof(uint16_t));
 
-      g_last_tcp_port = g_last_tcp_port % CONFIG_NET_DEFAULT_MAX_PORT;
-
-      if (g_last_tcp_port < CONFIG_NET_DEFAULT_MIN_PORT)
-        {
-          g_last_tcp_port += CONFIG_NET_DEFAULT_MIN_PORT;
-        }
+      g_last_tcp_port = g_last_tcp_port %
+                        (CONFIG_NET_DEFAULT_MAX_PORT -
+                         CONFIG_NET_DEFAULT_MIN_PORT + 1);
+      g_last_tcp_port += CONFIG_NET_DEFAULT_MIN_PORT;
     }
 
   if (portno == 0)
@@ -608,7 +606,10 @@ int tcp_selectport(uint8_t domain,
            * is within range.
            */
 
-          if (++g_last_tcp_port >= CONFIG_NET_DEFAULT_MAX_PORT)
+          ++g_last_tcp_port;
+
+          if (g_last_tcp_port > CONFIG_NET_DEFAULT_MAX_PORT ||
+              g_last_tcp_port < CONFIG_NET_DEFAULT_MIN_PORT)
             {
               g_last_tcp_port = CONFIG_NET_DEFAULT_MIN_PORT;
             }

--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -585,11 +585,11 @@ int tcp_selectport(uint8_t domain,
     {
       net_getrandom(&g_last_tcp_port, sizeof(uint16_t));
 
-      g_last_tcp_port = g_last_tcp_port % 32000;
+      g_last_tcp_port = g_last_tcp_port % CONFIG_NET_DEFAULT_MAX_PORT;
 
-      if (g_last_tcp_port < 4096)
+      if (g_last_tcp_port < CONFIG_NET_DEFAULT_MIN_PORT)
         {
-          g_last_tcp_port += 4096;
+          g_last_tcp_port += CONFIG_NET_DEFAULT_MIN_PORT;
         }
     }
 
@@ -608,9 +608,9 @@ int tcp_selectport(uint8_t domain,
            * is within range.
            */
 
-          if (++g_last_tcp_port >= 32000)
+          if (++g_last_tcp_port >= CONFIG_NET_DEFAULT_MAX_PORT)
             {
-              g_last_tcp_port = 4096;
+              g_last_tcp_port = CONFIG_NET_DEFAULT_MIN_PORT;
             }
 
           portno = HTONS(g_last_tcp_port);

--- a/net/udp/udp_conn.c
+++ b/net/udp/udp_conn.c
@@ -540,11 +540,11 @@ uint16_t udp_select_port(uint8_t domain, FAR union ip_binding_u *u)
 
   if (g_last_udp_port == 0)
     {
-      g_last_udp_port = clock_systime_ticks() % 32000;
+      g_last_udp_port = clock_systime_ticks() % CONFIG_NET_DEFAULT_MAX_PORT;
 
-      if (g_last_udp_port < 4096)
+      if (g_last_udp_port < CONFIG_NET_DEFAULT_MIN_PORT)
         {
-          g_last_udp_port += 4096;
+          g_last_udp_port += CONFIG_NET_DEFAULT_MIN_PORT;
         }
     }
 
@@ -562,9 +562,9 @@ uint16_t udp_select_port(uint8_t domain, FAR union ip_binding_u *u)
 
       /* Make sure that the port number is within range */
 
-      if (g_last_udp_port >= 32000)
+      if (g_last_udp_port >= CONFIG_NET_DEFAULT_MAX_PORT)
         {
-          g_last_udp_port = 4096;
+          g_last_udp_port = CONFIG_NET_DEFAULT_MIN_PORT;
         }
     }
   while (udp_find_conn(domain, u, HTONS(g_last_udp_port), 0) != NULL

--- a/net/udp/udp_conn.c
+++ b/net/udp/udp_conn.c
@@ -540,12 +540,10 @@ uint16_t udp_select_port(uint8_t domain, FAR union ip_binding_u *u)
 
   if (g_last_udp_port == 0)
     {
-      g_last_udp_port = clock_systime_ticks() % CONFIG_NET_DEFAULT_MAX_PORT;
-
-      if (g_last_udp_port < CONFIG_NET_DEFAULT_MIN_PORT)
-        {
-          g_last_udp_port += CONFIG_NET_DEFAULT_MIN_PORT;
-        }
+      g_last_udp_port = clock_systime_ticks() %
+                        (CONFIG_NET_DEFAULT_MAX_PORT -
+                         CONFIG_NET_DEFAULT_MIN_PORT + 1);
+      g_last_udp_port += CONFIG_NET_DEFAULT_MIN_PORT;
     }
 
   /* Find an unused local port number.  Loop until we find a valid
@@ -562,7 +560,8 @@ uint16_t udp_select_port(uint8_t domain, FAR union ip_binding_u *u)
 
       /* Make sure that the port number is within range */
 
-      if (g_last_udp_port >= CONFIG_NET_DEFAULT_MAX_PORT)
+      if (g_last_udp_port > CONFIG_NET_DEFAULT_MAX_PORT ||
+          g_last_udp_port < CONFIG_NET_DEFAULT_MIN_PORT)
         {
           g_last_udp_port = CONFIG_NET_DEFAULT_MIN_PORT;
         }


### PR DESCRIPTION
## Summary
Patches included:
- net:add customizable default max & min port
  > add customizable default max & min port
  > Signed-off-by: wangchen <wangchen41@xiaomi.com>
- [tcp/udp] fix port generation not in range
  > (port % max + min)may overflow uint16
  > Signed-off-by: meijian <meijian@xiaomi.com>

## Impact
TCP / UDP / NAT port selection

## Testing
Vela products

