### PR TITLE
arch/riscv: force using encoding macro for CSR access

### DIFF
--- a/arch/risc-v/include/mode.h
+++ b/arch/risc-v/include/mode.h
@@ -36,13 +36,13 @@
 
 /* CSR definitions */
 
-#  define CSR_STATUS        sstatus          /* Global status register */
-#  define CSR_SCRATCH       sscratch         /* Scratch register */
-#  define CSR_EPC           sepc             /* Exception program counter */
-#  define CSR_IE            sie              /* Interrupt enable register */
-#  define CSR_CAUSE         scause           /* Interrupt cause register */
-#  define CSR_TVAL          stval            /* Trap value register */
-#  define CSR_TVEC          stvec            /* Trap vector base addr register */
+#  define CSR_STATUS        CSR_SSTATUS      /* Global status register */
+#  define CSR_SCRATCH       CSR_SSCRATCH     /* Scratch register */
+#  define CSR_EPC           CSR_SEPC         /* Exception program counter */
+#  define CSR_IE            CSR_SIE          /* Interrupt enable register */
+#  define CSR_CAUSE         CSR_SCAUSE       /* Interrupt cause register */
+#  define CSR_TVAL          CSR_STVAL        /* Trap value register */
+#  define CSR_TVEC          CSR_STVEC        /* Trap vector base addr register */
 
 /* In status register */
 
@@ -71,13 +71,13 @@
 
 /* CSR definitions */
 
-#  define CSR_STATUS        mstatus          /* Global status register */
-#  define CSR_SCRATCH       mscratch         /* Scratch register */
-#  define CSR_EPC           mepc             /* Exception program counter */
-#  define CSR_IE            mie              /* Interrupt enable register */
-#  define CSR_CAUSE         mcause           /* Interrupt cause register */
-#  define CSR_TVAL          mtval            /* Trap value register */
-#  define CSR_TVEC          mtvec            /* Trap vector base addr register */
+#  define CSR_STATUS        CSR_MSTATUS      /* Global status register */
+#  define CSR_SCRATCH       CSR_MSCRATCH     /* Scratch register */
+#  define CSR_EPC           CSR_MEPC         /* Exception program counter */
+#  define CSR_IE            CSR_MIE          /* Interrupt enable register */
+#  define CSR_CAUSE         CSR_MCAUSE       /* Interrupt cause register */
+#  define CSR_TVAL          CSR_MTVAL        /* Trap value register */
+#  define CSR_TVEC          CSR_MTVEC        /* Trap vector base addr register */
 
 /* In status register */
 

--- a/arch/risc-v/src/bl602/bl602_head.S
+++ b/arch/risc-v/src/bl602/bl602_head.S
@@ -40,7 +40,7 @@ bl602_start:
   /*disable IRQ*/
 
     li t0, MSTATUS_MIE
-    csrc mstatus, t0
+    csrc CSR_MSTATUS, t0
 
     la gp, __global_pointer$
 .option pop

--- a/arch/risc-v/src/bl602/bl602_irq.c
+++ b/arch/risc-v/src/bl602/bl602_irq.c
@@ -108,7 +108,7 @@ void up_disable_irq(int irq)
     {
       /* Read mstatus & clear machine software interrupt enable in mie */
 
-      CLEAR_CSR(mie, MIE_MSIE);
+      CLEAR_CSR(CSR_MIE, MIE_MSIE);
     }
   else if (irq == RISCV_IRQ_MTIMER)
     {
@@ -116,7 +116,7 @@ void up_disable_irq(int irq)
 
       /* Read mstatus & clear machine timer interrupt enable in mie */
 
-      CLEAR_CSR(mie, MIE_MTIE);
+      CLEAR_CSR(CSR_MIE, MIE_MTIE);
     }
   else
     {
@@ -139,7 +139,7 @@ void up_enable_irq(int irq)
     {
       /* Read mstatus & set machine software interrupt enable in mie */
 
-      SET_CSR(mie, MIE_MSIE);
+      SET_CSR(CSR_MIE, MIE_MSIE);
     }
   else if (irq == RISCV_IRQ_MTIMER)
     {
@@ -147,7 +147,7 @@ void up_enable_irq(int irq)
 
       /* Read mstatus & set machine timer interrupt enable in mie */
 
-      SET_CSR(mie, MIE_MTIE | 0x1 << 11);
+      SET_CSR(CSR_MIE, MIE_MTIE | 0x1 << 11);
     }
   else
     {
@@ -182,10 +182,10 @@ irqstate_t up_irq_enable(void)
 
   /* Enable MEIE (machine external interrupt enable) */
 
-  SET_CSR(mie, MIE_MEIE);
+  SET_CSR(CSR_MIE, MIE_MEIE);
 
   /* Read mstatus & set machine interrupt enable (MIE) in mstatus */
 
-  oldstat = READ_AND_SET_CSR(mstatus, MSTATUS_MIE);
+  oldstat = READ_AND_SET_CSR(CSR_MSTATUS, MSTATUS_MIE);
   return oldstat;
 }

--- a/arch/risc-v/src/bl808/bl808_head.S
+++ b/arch/risc-v/src/bl808/bl808_head.S
@@ -86,7 +86,7 @@ real_start:
   /* If a0 (hartid) >= t1 (the number of CPUs), stop here */
 
   blt  a0, t1, 3f
-  csrw sie, zero
+  csrw CSR_SIE, zero
   wfi
 
 3:
@@ -121,10 +121,10 @@ real_start:
 
   /* Disable all interrupts (i.e. timer, external) in sie */
 
-  csrw	sie, zero
+  csrw CSR_SIE, zero
 
   la   t0, __trap_vec
-  csrw stvec, t0
+  csrw CSR_STVEC, t0
 
   /* Jump to bl808_start */
 

--- a/arch/risc-v/src/bl808/bl808_start.c
+++ b/arch/risc-v/src/bl808/bl808_start.c
@@ -284,11 +284,11 @@ void bl808_start(int mhartid)
 
   /* Disable MMU */
 
-  WRITE_CSR(satp, 0x0);
+  WRITE_CSR(CSR_SATP, 0x0);
 
   /* Set the trap vector for S-mode */
 
-  WRITE_CSR(stvec, (uintptr_t)__trap_vec);
+  WRITE_CSR(CSR_STVEC, (uintptr_t)__trap_vec);
 
   /* Start S-mode */
 

--- a/arch/risc-v/src/c906/c906_head.S
+++ b/arch/risc-v/src/c906/c906_head.S
@@ -68,7 +68,7 @@ __start:
 
   /* Load mhartid (cpuid) */
 
-  csrr a0, mhartid
+  csrr a0, CSR_MHARTID
 
   /* Set stack pointer to the idle thread stack */
 
@@ -76,13 +76,13 @@ __start:
 
   /* Disable all interrupts (i.e. timer, external) in mie */
 
-  csrw mie, zero
-  csrw mip, zero
+  csrw CSR_MIE, zero
+  csrw CSR_MIP, zero
 
   /* Initialize the Machine Trap Vector */
 
   la   t0, __trap_vec
-  csrw mtvec, t0
+  csrw CSR_MTVEC, t0
 
   /* Jump to __c906_start with mhartid */
 

--- a/arch/risc-v/src/c906/c906_irq.c
+++ b/arch/risc-v/src/c906/c906_irq.c
@@ -111,13 +111,13 @@ void up_disable_irq(int irq)
     {
       /* Read mstatus & clear machine software interrupt enable in mie */
 
-      CLEAR_CSR(mie, MIE_MSIE);
+      CLEAR_CSR(CSR_MIE, MIE_MSIE);
     }
   else if (irq == RISCV_IRQ_MTIMER)
     {
       /* Read mstatus & clear machine timer interrupt enable in mie */
 
-      CLEAR_CSR(mie, MIE_MTIE);
+      CLEAR_CSR(CSR_MIE, MIE_MTIE);
     }
   else if (irq >= C906_IRQ_PERI_START)
     {
@@ -153,13 +153,13 @@ void up_enable_irq(int irq)
     {
       /* Read mstatus & set machine software interrupt enable in mie */
 
-      SET_CSR(mie, MIE_MSIE);
+      SET_CSR(CSR_MIE, MIE_MSIE);
     }
   else if (irq == RISCV_IRQ_MTIMER)
     {
       /* Read mstatus & set machine timer interrupt enable in mie */
 
-      SET_CSR(mie, MIE_MTIE);
+      SET_CSR(CSR_MIE, MIE_MTIE);
     }
   else if (irq >= C906_IRQ_PERI_START)
     {
@@ -207,10 +207,10 @@ irqstate_t up_irq_enable(void)
 
   /* TODO: should move to up_enable_irq() */
 
-  SET_CSR(mie, MIE_MEIE);
+  SET_CSR(CSR_MIE, MIE_MEIE);
 
   /* Read mstatus & set machine interrupt enable (MIE) in mstatus */
 
-  oldstat = READ_AND_SET_CSR(mstatus, MSTATUS_MIE);
+  oldstat = READ_AND_SET_CSR(CSR_MSTATUS, MSTATUS_MIE);
   return oldstat;
 }

--- a/arch/risc-v/src/common/espressif/esp_head.S
+++ b/arch/risc-v/src/common/espressif/esp_head.S
@@ -59,7 +59,7 @@ __start:
 
   /* Disable all interrupts (i.e. timer, external) in mstatus */
 
-  csrw mstatus, zero
+  csrw CSR_MSTATUS, zero
 
   .option pop
 
@@ -67,7 +67,7 @@ __start:
 
   lui  t0, %hi(_vector_table)
   addi t0, t0, %lo(_vector_table)
-  csrw  mtvec, t0
+  csrw  CSR_MTVEC, t0
 
   /* Jump to __esp_start */
 

--- a/arch/risc-v/src/common/espressif/esp_irq.c
+++ b/arch/risc-v/src/common/espressif/esp_irq.c
@@ -603,7 +603,7 @@ irqstate_t up_irq_enable(void)
 
   /* Read mstatus & set machine interrupt enable (MIE) in mstatus */
 
-  flags = READ_AND_SET_CSR(mstatus, MSTATUS_MIE);
+  flags = READ_AND_SET_CSR(CSR_MSTATUS, MSTATUS_MIE);
   return flags;
 }
 

--- a/arch/risc-v/src/common/riscv_internal.h
+++ b/arch/risc-v/src/common/riscv_internal.h
@@ -133,16 +133,16 @@
 
 #define READ_CSR(reg) \
   ({ \
-     uintptr_t reg##_val; \
-     __asm__ __volatile__("csrr %0, " __STR(reg) : "=r"(reg##_val)); \
-     reg##_val; \
+     uintptr_t regval; \
+     __asm__ __volatile__("csrr %0, " __STR(reg) : "=r"(regval)); \
+     regval; \
   })
 
 #define READ_AND_SET_CSR(reg, bits) \
   ({ \
-     uintptr_t reg##_val; \
-     __asm__ __volatile__("csrrs %0, " __STR(reg) ", %1": "=r"(reg##_val) : "rK"(bits)); \
-     reg##_val; \
+     uintptr_t regval; \
+     __asm__ __volatile__("csrrs %0, " __STR(reg) ", %1": "=r"(regval) : "rK"(bits)); \
+     regval; \
   })
 
 #define WRITE_CSR(reg, val) \

--- a/arch/risc-v/src/common/riscv_macros.S
+++ b/arch/risc-v/src/common/riscv_macros.S
@@ -278,6 +278,6 @@
   csrr    \out, CSR_SCRATCH
   REGLOAD \out, RISCV_PERCPU_HARTID(\out)
 #else
-  csrr    \out, mhartid
+  csrr    \out, CSR_MHARTID
 #endif
 .endm

--- a/arch/risc-v/src/common/riscv_mtimer.c
+++ b/arch/risc-v/src/common/riscv_mtimer.c
@@ -90,7 +90,7 @@ static uint64_t riscv_mtimer_get_mtime(struct riscv_mtimer_lowerhalf_s *priv)
    *    it could be read from the CSR "time".
    */
 
-  return -1 == priv->mtime ? READ_CSR(time) : getreg64(priv->mtime);
+  return -1 == priv->mtime ? READ_CSR(CSR_TIME) : getreg64(priv->mtime);
 #else
   uint32_t hi;
   uint32_t lo;

--- a/arch/risc-v/src/common/riscv_pmp.c
+++ b/arch/risc-v/src/common/riscv_pmp.c
@@ -180,16 +180,16 @@ static uintptr_t pmp_read_region_cfg(uintptr_t region)
   switch (region)
     {
       case 0 ... 3:
-        return PMP_READ_REGION_FROM_REG(region, pmpcfg0);
+        return PMP_READ_REGION_FROM_REG(region, CSR_PMPCFG0);
 
       case 4 ... 7:
-        return PMP_READ_REGION_FROM_REG(region, pmpcfg1);
+        return PMP_READ_REGION_FROM_REG(region, CSR_PMPCFG1);
 
       case 8 ... 11:
-        return PMP_READ_REGION_FROM_REG(region, pmpcfg2);
+        return PMP_READ_REGION_FROM_REG(region, CSR_PMPCFG2);
 
       case 12 ... 15:
-        return PMP_READ_REGION_FROM_REG(region, pmpcfg3);
+        return PMP_READ_REGION_FROM_REG(region, CSR_PMPCFG3);
 
       default:
         break;
@@ -198,10 +198,10 @@ static uintptr_t pmp_read_region_cfg(uintptr_t region)
   switch (region)
     {
       case 0 ... 7:
-        return PMP_READ_REGION_FROM_REG(region, pmpcfg0);
+        return PMP_READ_REGION_FROM_REG(region, CSR_PMPCFG0);
 
       case 8 ... 15:
-        return PMP_READ_REGION_FROM_REG(region, pmpcfg2);
+        return PMP_READ_REGION_FROM_REG(region, CSR_PMPCFG2);
 
       default:
         break;
@@ -232,52 +232,52 @@ static uintptr_t pmp_read_addr(uintptr_t region)
   switch (region)
       {
         case 0:
-          return READ_CSR(pmpaddr0);
+          return READ_CSR(CSR_PMPADDR0);
 
         case 1:
-          return READ_CSR(pmpaddr1);
+          return READ_CSR(CSR_PMPADDR1);
 
         case 2:
-          return READ_CSR(pmpaddr2);
+          return READ_CSR(CSR_PMPADDR2);
 
         case 3:
-          return READ_CSR(pmpaddr3);
+          return READ_CSR(CSR_PMPADDR3);
 
         case 4:
-          return READ_CSR(pmpaddr4);
+          return READ_CSR(CSR_PMPADDR4);
 
         case 5:
-          return READ_CSR(pmpaddr5);
+          return READ_CSR(CSR_PMPADDR5);
 
         case 6:
-          return READ_CSR(pmpaddr6);
+          return READ_CSR(CSR_PMPADDR6);
 
         case 7:
-          return READ_CSR(pmpaddr7);
+          return READ_CSR(CSR_PMPADDR7);
 
         case 8:
-          return READ_CSR(pmpaddr8);
+          return READ_CSR(CSR_PMPADDR8);
 
         case 9:
-          return READ_CSR(pmpaddr9);
+          return READ_CSR(CSR_PMPADDR9);
 
         case 10:
-          return READ_CSR(pmpaddr10);
+          return READ_CSR(CSR_PMPADDR10);
 
         case 11:
-          return READ_CSR(pmpaddr11);
+          return READ_CSR(CSR_PMPADDR11);
 
         case 12:
-          return READ_CSR(pmpaddr12);
+          return READ_CSR(CSR_PMPADDR12);
 
         case 13:
-          return READ_CSR(pmpaddr13);
+          return READ_CSR(CSR_PMPADDR13);
 
         case 14:
-          return READ_CSR(pmpaddr14);
+          return READ_CSR(CSR_PMPADDR14);
 
         case 15:
-          return READ_CSR(pmpaddr15);
+          return READ_CSR(CSR_PMPADDR15);
 
         default:
           break;
@@ -440,67 +440,67 @@ int riscv_config_pmp_region(uintptr_t region, uintptr_t attr,
   switch (region)
     {
       case 0:
-        WRITE_CSR(pmpaddr0, addr);
+        WRITE_CSR(CSR_PMPADDR0, addr);
         break;
 
       case 1:
-        WRITE_CSR(pmpaddr1, addr);
+        WRITE_CSR(CSR_PMPADDR1, addr);
         break;
 
       case 2:
-        WRITE_CSR(pmpaddr2, addr);
+        WRITE_CSR(CSR_PMPADDR2, addr);
         break;
 
       case 3:
-        WRITE_CSR(pmpaddr3, addr);
+        WRITE_CSR(CSR_PMPADDR3, addr);
         break;
 
       case 4:
-        WRITE_CSR(pmpaddr4, addr);
+        WRITE_CSR(CSR_PMPADDR4, addr);
         break;
 
       case 5:
-        WRITE_CSR(pmpaddr5, addr);
+        WRITE_CSR(CSR_PMPADDR5, addr);
         break;
 
       case 6:
-        WRITE_CSR(pmpaddr6, addr);
+        WRITE_CSR(CSR_PMPADDR6, addr);
         break;
 
       case 7:
-        WRITE_CSR(pmpaddr7, addr);
+        WRITE_CSR(CSR_PMPADDR7, addr);
         break;
 
       case 8:
-        WRITE_CSR(pmpaddr8, addr);
+        WRITE_CSR(CSR_PMPADDR8, addr);
         break;
 
       case 9:
-        WRITE_CSR(pmpaddr9, addr);
+        WRITE_CSR(CSR_PMPADDR9, addr);
         break;
 
       case 10:
-        WRITE_CSR(pmpaddr10, addr);
+        WRITE_CSR(CSR_PMPADDR10, addr);
         break;
 
       case 11:
-        WRITE_CSR(pmpaddr11, addr);
+        WRITE_CSR(CSR_PMPADDR11, addr);
         break;
 
       case 12:
-        WRITE_CSR(pmpaddr12, addr);
+        WRITE_CSR(CSR_PMPADDR12, addr);
         break;
 
       case 13:
-        WRITE_CSR(pmpaddr13, addr);
+        WRITE_CSR(CSR_PMPADDR13, addr);
         break;
 
       case 14:
-        WRITE_CSR(pmpaddr14, addr);
+        WRITE_CSR(CSR_PMPADDR14, addr);
         break;
 
       case 15:
-        WRITE_CSR(pmpaddr15, addr);
+        WRITE_CSR(CSR_PMPADDR15, addr);
         break;
 
       default:
@@ -513,27 +513,27 @@ int riscv_config_pmp_region(uintptr_t region, uintptr_t attr,
   switch (region)
     {
       case 0 ... 3:
-        cfg = READ_CSR(pmpcfg0);
+        cfg = READ_CSR(CSR_PMPCFG0);
         PMP_MASK_SET_ONE_REGION(region, attr, cfg);
-        WRITE_CSR(pmpcfg0, cfg);
+        WRITE_CSR(CSR_PMPCFG0, cfg);
         break;
 
       case 4 ... 7:
-        cfg = READ_CSR(pmpcfg1);
+        cfg = READ_CSR(CSR_PMPCFG1);
         PMP_MASK_SET_ONE_REGION(region, attr, cfg);
-        WRITE_CSR(pmpcfg1, cfg);
+        WRITE_CSR(CSR_PMPCFG1, cfg);
         break;
 
       case 8 ... 11:
-        cfg = READ_CSR(pmpcfg2);
+        cfg = READ_CSR(CSR_PMPCFG2);
         PMP_MASK_SET_ONE_REGION(region, attr, cfg);
-        WRITE_CSR(pmpcfg2, cfg);
+        WRITE_CSR(CSR_PMPCFG2, cfg);
         break;
 
       case 12 ... 15:
-        cfg = READ_CSR(pmpcfg3);
+        cfg = READ_CSR(CSR_PMPCFG3);
         PMP_MASK_SET_ONE_REGION(region, attr, cfg);
-        WRITE_CSR(pmpcfg3, cfg);
+        WRITE_CSR(CSR_PMPCFG3, cfg);
         break;
 
       default:
@@ -543,15 +543,15 @@ int riscv_config_pmp_region(uintptr_t region, uintptr_t attr,
   switch (region)
     {
       case 0 ... 7:
-        cfg = READ_CSR(pmpcfg0);
+        cfg = READ_CSR(CSR_PMPCFG0);
         PMP_MASK_SET_ONE_REGION(region, attr, cfg);
-        WRITE_CSR(pmpcfg0, cfg);
+        WRITE_CSR(CSR_PMPCFG0, cfg);
         break;
 
       case 8 ... 15:
-        cfg = READ_CSR(pmpcfg2);
+        cfg = READ_CSR(CSR_PMPCFG2);
         PMP_MASK_SET_ONE_REGION(region, attr, cfg);
-        WRITE_CSR(pmpcfg2, cfg);
+        WRITE_CSR(CSR_PMPCFG2, cfg);
         break;
 
       default:

--- a/arch/risc-v/src/common/supervisor/riscv_sbi.c
+++ b/arch/risc-v/src/common/supervisor/riscv_sbi.c
@@ -123,17 +123,17 @@ uint64_t riscv_sbi_get_time(void)
   return sbi_mcall_get_time();
 #else
 #ifdef CONFIG_ARCH_RV64
-  return READ_CSR(time);
+  return READ_CSR(CSR_TIME);
 #else
   uint32_t hi;
   uint32_t lo;
 
   do
     {
-      hi = READ_CSR(timeh);
-      lo = READ_CSR(time);
+      hi = READ_CSR(CSR_TIMEH);
+      lo = READ_CSR(CSR_TIME);
     }
-  while (hi != READ_CSR(timeh));
+  while (hi != READ_CSR(CSR_TIMEH));
 
   return (((uint64_t) hi) << 32) | lo;
 #endif

--- a/arch/risc-v/src/esp32c3-legacy/esp32c3_head.S
+++ b/arch/risc-v/src/esp32c3-legacy/esp32c3_head.S
@@ -58,7 +58,7 @@ __start:
 
   /* Disable all interrupts (i.e. timer, external) in mstatus */
 
-  csrw mstatus, zero
+  csrw CSR_MSTATUS, zero
 
   .option pop
 
@@ -66,7 +66,7 @@ __start:
 
   lui  t0, %hi(_vector_table)
   addi t0, t0, %lo(_vector_table)
-  csrw  mtvec, t0
+  csrw  CSR_MTVEC, t0
 
   /* Jump to __esp32c3_start */
 

--- a/arch/risc-v/src/esp32c3-legacy/esp32c3_irq.c
+++ b/arch/risc-v/src/esp32c3-legacy/esp32c3_irq.c
@@ -702,6 +702,6 @@ irqstate_t up_irq_enable(void)
 
   /* Read mstatus & set machine interrupt enable (MIE) in mstatus */
 
-  flags = READ_AND_SET_CSR(mstatus, MSTATUS_MIE);
+  flags = READ_AND_SET_CSR(CSR_MSTATUS, MSTATUS_MIE);
   return flags;
 }

--- a/arch/risc-v/src/fe310/fe310_head.S
+++ b/arch/risc-v/src/fe310/fe310_head.S
@@ -48,12 +48,12 @@ __start:
 
   /* Disable all interrupts (i.e. timer, external) in mie */
 
-  csrw mie, zero
+  csrw CSR_MIE, zero
 
   /* Initialize the Machine Trap Vector */
 
   la   t0, __trap_vec
-  csrw mtvec, t0
+  csrw CSR_MTVEC, t0
 
   /* Jump to __fe310_start */
 

--- a/arch/risc-v/src/fe310/fe310_irq.c
+++ b/arch/risc-v/src/fe310/fe310_irq.c
@@ -104,7 +104,7 @@ void up_disable_irq(int irq)
     {
       /* Read mstatus & clear machine timer interrupt enable in mie */
 
-      CLEAR_CSR(mie, MIE_MTIE);
+      CLEAR_CSR(CSR_MIE, MIE_MTIE);
     }
   else if (irq > RISCV_IRQ_MEXT)
     {
@@ -140,7 +140,7 @@ void up_enable_irq(int irq)
     {
       /* Read mstatus & set machine timer interrupt enable in mie */
 
-      SET_CSR(mie, MIE_MTIE);
+      SET_CSR(CSR_MIE, MIE_MTIE);
     }
   else if (irq > RISCV_IRQ_MEXT)
     {
@@ -190,11 +190,11 @@ irqstate_t up_irq_enable(void)
 
   /* TODO: should move to up_enable_irq() */
 
-  SET_CSR(mie, MIE_MEIE);
+  SET_CSR(CSR_MIE, MIE_MEIE);
 #endif
 
   /* Read mstatus & set machine interrupt enable (MIE) in mstatus */
 
-  oldstat = READ_AND_SET_CSR(mstatus, MSTATUS_MIE);
+  oldstat = READ_AND_SET_CSR(CSR_MSTATUS, MSTATUS_MIE);
   return oldstat;
 }

--- a/arch/risc-v/src/hpm6000/hpm_head.S
+++ b/arch/risc-v/src/hpm6000/hpm_head.S
@@ -43,7 +43,7 @@
 __start:
   /* reset mstatus to 0*/
 
-  csrrw  x0, mstatus, x0
+  csrrw  x0, CSR_MSTATUS, x0
 
   /* Set stack pointer to the idle thread stack */
 
@@ -51,13 +51,13 @@ __start:
 
   /* Disable all interrupts (i.e. timer, external) in mie */
 
-  csrw mie, zero
-  csrw mip, zero
+  csrw CSR_MIE, zero
+  csrw CSR_MIP, zero
 
   /* Initialize the Machine Trap Vector */
 
   la   t0, __trap_vec
-  csrw mtvec, t0
+  csrw CSR_MTVEC, t0
 
   /* Jump to __hpm_start */
 

--- a/arch/risc-v/src/hpm6000/hpm_irq.c
+++ b/arch/risc-v/src/hpm6000/hpm_irq.c
@@ -108,13 +108,13 @@ void up_disable_irq(int irq)
     {
       /* Read mstatus & clear machine software interrupt enable in mie */
 
-      CLEAR_CSR(mie, MIE_MSIE);
+      CLEAR_CSR(CSR_MIE, MIE_MSIE);
     }
   else if (irq == RISCV_IRQ_MTIMER)
     {
       /* Read mstatus & clear machine timer interrupt enable in mie */
 
-      CLEAR_CSR(mie, MIE_MTIE);
+      CLEAR_CSR(CSR_MIE, MIE_MTIE);
     }
   else if (irq >= HPM_IRQ_PERI_START)
     {
@@ -150,13 +150,13 @@ void up_enable_irq(int irq)
     {
       /* Read mstatus & set machine software interrupt enable in mie */
 
-      SET_CSR(mie, MIE_MSIE);
+      SET_CSR(CSR_MIE, MIE_MSIE);
     }
   else if (irq == RISCV_IRQ_MTIMER)
     {
       /* Read mstatus & set machine timer interrupt enable in mie */
 
-      SET_CSR(mie, MIE_MTIE);
+      SET_CSR(CSR_MIE, MIE_MTIE);
     }
   else if (irq >= HPM_IRQ_PERI_START)
     {
@@ -204,10 +204,10 @@ irqstate_t up_irq_enable(void)
 
   /* TODO: should move to up_enable_irq() */
 
-  SET_CSR(mie, MIE_MEIE);
+  SET_CSR(CSR_MIE, MIE_MEIE);
 
   /* Read mstatus & set machine interrupt enable (MIE) in mstatus */
 
-  oldstat = READ_AND_SET_CSR(mstatus, MSTATUS_MIE);
+  oldstat = READ_AND_SET_CSR(CSR_MSTATUS, MSTATUS_MIE);
   return oldstat;
 }

--- a/arch/risc-v/src/hpm6750/hpm6750_head.S
+++ b/arch/risc-v/src/hpm6750/hpm6750_head.S
@@ -43,7 +43,7 @@
 __start:
   /* reset mstatus to 0*/
 
-  csrrw  x0, mstatus, x0
+  csrrw  x0, CSR_MSTATUS, x0
 
   /* Set stack pointer to the idle thread stack */
 
@@ -51,13 +51,13 @@ __start:
 
   /* Disable all interrupts (i.e. timer, external) in mie */
 
-  csrw mie, zero
-  csrw mip, zero
+  csrw CSR_MIE, zero
+  csrw CSR_MIP, zero
 
   /* Initialize the Machine Trap Vector */
 
   la   t0, __trap_vec
-  csrw mtvec, t0
+  csrw CSR_MTVEC, t0
 
   /* Jump to __hpm6750_start */
 

--- a/arch/risc-v/src/hpm6750/hpm6750_irq.c
+++ b/arch/risc-v/src/hpm6750/hpm6750_irq.c
@@ -108,13 +108,13 @@ void up_disable_irq(int irq)
     {
       /* Read mstatus & clear machine software interrupt enable in mie */
 
-      CLEAR_CSR(mie, MIE_MSIE);
+      CLEAR_CSR(CSR_MIE, MIE_MSIE);
     }
   else if (irq == RISCV_IRQ_MTIMER)
     {
       /* Read mstatus & clear machine timer interrupt enable in mie */
 
-      CLEAR_CSR(mie, MIE_MTIE);
+      CLEAR_CSR(CSR_MIE, MIE_MTIE);
     }
   else if (irq >= HPM6750_IRQ_PERI_START)
     {
@@ -150,13 +150,13 @@ void up_enable_irq(int irq)
     {
       /* Read mstatus & set machine software interrupt enable in mie */
 
-      SET_CSR(mie, MIE_MSIE);
+      SET_CSR(CSR_MIE, MIE_MSIE);
     }
   else if (irq == RISCV_IRQ_MTIMER)
     {
       /* Read mstatus & set machine timer interrupt enable in mie */
 
-      SET_CSR(mie, MIE_MTIE);
+      SET_CSR(CSR_MIE, MIE_MTIE);
     }
   else if (irq >= HPM6750_IRQ_PERI_START)
     {
@@ -204,10 +204,10 @@ irqstate_t up_irq_enable(void)
 
   /* TODO: should move to up_enable_irq() */
 
-  SET_CSR(mie, MIE_MEIE);
+  SET_CSR(CSR_MIE, MIE_MEIE);
 
   /* Read mstatus & set machine interrupt enable (MIE) in mstatus */
 
-  oldstat = READ_AND_SET_CSR(mstatus, MSTATUS_MIE);
+  oldstat = READ_AND_SET_CSR(CSR_MSTATUS, MSTATUS_MIE);
   return oldstat;
 }

--- a/arch/risc-v/src/jh7110/jh7110_head.S
+++ b/arch/risc-v/src/jh7110/jh7110_head.S
@@ -92,7 +92,7 @@ real_start:
   /* If a0 (hartid) >= t1 (the number of CPUs), stop here */
 
   blt  a0, t1, 3f
-  csrw sie, zero
+  csrw CSR_SIE, zero
   wfi
 
 3:
@@ -127,10 +127,10 @@ real_start:
 
   /* Disable all interrupts (i.e. timer, external) in sie */
 
-  csrw	sie, zero
+  csrw CSR_SIE, zero
 
   la   t0, __trap_vec
-  csrw stvec, t0
+  csrw CSR_STVEC, t0
 
   /* Jump to jh7110_start */
 

--- a/arch/risc-v/src/jh7110/jh7110_start.c
+++ b/arch/risc-v/src/jh7110/jh7110_start.c
@@ -146,11 +146,11 @@ void jh7110_start(int mhartid)
 
   /* Disable MMU */
 
-  WRITE_CSR(satp, 0x0);
+  WRITE_CSR(CSR_SATP, 0x0);
 
   /* Set the trap vector for S-mode */
 
-  WRITE_CSR(stvec, (uintptr_t)__trap_vec);
+  WRITE_CSR(CSR_STVEC, (uintptr_t)__trap_vec);
 
   /* Start S-mode */
 

--- a/arch/risc-v/src/jh7110/jh7110_timerisr.c
+++ b/arch/risc-v/src/jh7110/jh7110_timerisr.c
@@ -64,7 +64,7 @@ static int jh7110_ssoft_interrupt(int irq, void *context, void *arg)
 {
   /* Cleaer Supervisor Software Interrupt */
 
-  CLEAR_CSR(sip, SIP_SSIP);
+  CLEAR_CSR(CSR_SIP, SIP_SSIP);
 
   if (g_stimer_pending)
     {

--- a/arch/risc-v/src/k210/chip.h
+++ b/arch/risc-v/src/k210/chip.h
@@ -48,7 +48,7 @@
 
 #if defined(CONFIG_SMP) && CONFIG_ARCH_INTERRUPTSTACK > 15
 .macro  setintstack tmp0, tmp1
-  csrr  \tmp0, mhartid
+  csrr  \tmp0, CSR_MHARTID
   li    \tmp1, STACK_ALIGN_DOWN(CONFIG_ARCH_INTERRUPTSTACK)
   mul   \tmp1, \tmp0, \tmp1
   la    \tmp0, g_intstacktop

--- a/arch/risc-v/src/k210/k210_head.S
+++ b/arch/risc-v/src/k210/k210_head.S
@@ -44,7 +44,7 @@ __start:
 
   /* Load mhartid (cpuid) */
 
-  csrr a0, mhartid
+  csrr a0, CSR_MHARTID
 
   /* Set stack pointer to the idle thread stack */
 
@@ -56,7 +56,7 @@ __start:
   /* In case of single CPU config, stop here */
 
 #if !defined(CONFIG_SMP) || (CONFIG_SMP_NCPUS == 1)
-  csrw mie, zero
+  csrw CSR_MIE, zero
   wfi
 #endif
 
@@ -87,12 +87,12 @@ __start:
 
   /* Disable all interrupts (i.e. timer, external) in mie */
 
-  csrw mie, zero
+  csrw CSR_MIE, zero
 
   /* Initialize the Machine Trap Vector */
 
   la   t0, __trap_vec
-  csrw mtvec, t0
+  csrw CSR_MTVEC, t0
 
   /* Jump to __k210_start with mhartid */
 

--- a/arch/risc-v/src/k210/k210_irq.c
+++ b/arch/risc-v/src/k210/k210_irq.c
@@ -116,13 +116,13 @@ void up_disable_irq(int irq)
     {
       /* Read mstatus & clear machine software interrupt enable in mie */
 
-      CLEAR_CSR(mie, MIE_MSIE);
+      CLEAR_CSR(CSR_MIE, MIE_MSIE);
     }
   else if (irq == RISCV_IRQ_MTIMER)
     {
       /* Read mstatus & clear machine timer interrupt enable in mie */
 
-      CLEAR_CSR(mie, MIE_MTIE);
+      CLEAR_CSR(CSR_MIE, MIE_MTIE);
     }
   else if (irq > RISCV_IRQ_MEXT)
     {
@@ -158,13 +158,13 @@ void up_enable_irq(int irq)
     {
       /* Read mstatus & set machine software interrupt enable in mie */
 
-      SET_CSR(mie, MIE_MSIE);
+      SET_CSR(CSR_MIE, MIE_MSIE);
     }
   else if (irq == RISCV_IRQ_MTIMER)
     {
       /* Read mstatus & set machine timer interrupt enable in mie */
 
-      SET_CSR(mie, MIE_MTIE);
+      SET_CSR(CSR_MIE, MIE_MTIE);
     }
   else if (irq > RISCV_IRQ_MEXT)
     {
@@ -213,11 +213,11 @@ irqstate_t up_irq_enable(void)
 
   /* TODO: should move to up_enable_irq() */
 
-  SET_CSR(mie, MIE_MEIE);
+  SET_CSR(CSR_MIE, MIE_MEIE);
 #endif
 
   /* Read mstatus & set machine interrupt enable (MIE) in mstatus */
 
-  oldstat = READ_AND_SET_CSR(mstatus, MSTATUS_MIE);
+  oldstat = READ_AND_SET_CSR(CSR_MSTATUS, MSTATUS_MIE);
   return oldstat;
 }

--- a/arch/risc-v/src/k230/k230_head.S
+++ b/arch/risc-v/src/k230/k230_head.S
@@ -61,7 +61,7 @@ __start:
 #ifndef CONFIG_BUILD_KERNEL
   /* Load mhartid (cpuid) */
 
-  csrr a0, mhartid
+  csrr a0, CSR_MHARTID
 #endif
 
   /* Set stack pointer to the idle thread stack */
@@ -113,11 +113,11 @@ __start:
 
   /* Disable all interrupts (i.e. timer, external) */
 
-	csrw	CSR_IE, zero
-  
+	csrw CSR_IE, zero
+
   la   t0, __trap_vec        /* __trap_dump */
   csrw CSR_TVEC, t0
-  
+
   /* Jump to k230_start, a0=mhartid, a1=dtb */
 
   jal  x1, k230_start

--- a/arch/risc-v/src/k230/k230_start.c
+++ b/arch/risc-v/src/k230/k230_start.c
@@ -134,7 +134,7 @@ void k230_start(int mhartid, const char *dtb)
 
   /* Disable MMU */
 
-  WRITE_CSR(satp, 0x0);
+  WRITE_CSR(CSR_SATP, 0x0);
 
   /* Configure FPU */
 

--- a/arch/risc-v/src/litex/litex_head.S
+++ b/arch/risc-v/src/litex/litex_head.S
@@ -47,13 +47,13 @@ __start:
 
   /* Disable all interrupts (i.e. timer, external) in mie */
 
-  csrw mie, zero
+  csrw CSR_MIE, zero
 
   /* Initialize the Machine Trap Vector */
 
   lui  t0, %hi(__trap_vec)
   addi t0, t0, %lo(__trap_vec)
-  csrw  mtvec, t0
+  csrw CSR_MTVEC, t0
 
   /* Jump to __litex_start */
 

--- a/arch/risc-v/src/litex/litex_irq.c
+++ b/arch/risc-v/src/litex/litex_irq.c
@@ -53,7 +53,7 @@ void up_irqinitialize(void)
 
 #ifdef CONFIG_ARCH_USE_S_MODE
   putreg32(0x0, LITEX_PLIC_ENABLE1);
-#else 
+#else
   asm volatile ("csrw %0, %1" :: "i"(LITEX_MMASK_CSR), "r"(0));
 #endif
 
@@ -147,13 +147,13 @@ void up_disable_irq(int irq)
     {
       /* Read mstatus & clear machine software interrupt enable in mie */
 
-      CLEAR_CSR(mie, MIE_MSIE);
+      CLEAR_CSR(CSR_MIE, MIE_MSIE);
     }
   else if (irq == RISCV_IRQ_MTIMER)
     {
       /* Read mstatus & clear machine timer interrupt enable in mie */
 
-      CLEAR_CSR(mie, MIE_MTIE);
+      CLEAR_CSR(CSR_MIE, MIE_MTIE);
     }
   else if (irq > RISCV_IRQ_MEXT)
     {
@@ -228,13 +228,13 @@ void up_enable_irq(int irq)
     {
       /* Read mstatus & set machine software interrupt enable in mie */
 
-      SET_CSR(mie, MIE_MSIE);
+      SET_CSR(CSR_MIE, MIE_MSIE);
     }
   else if (irq == RISCV_IRQ_MTIMER)
     {
       /* Read mstatus & set machine timer interrupt enable in mie */
 
-      SET_CSR(mie, MIE_MTIE);
+      SET_CSR(CSR_MIE, MIE_MTIE);
     }
   else if (irq > RISCV_IRQ_MEXT)
     {

--- a/arch/risc-v/src/litex/litex_shead.S
+++ b/arch/risc-v/src/litex/litex_shead.S
@@ -56,25 +56,23 @@
 __start:
   /* Disable all interrupts in sie */
 
-
-  csrw sie, zero
-  csrw sip, zero
-
+  csrw CSR_SIE, zero
+  csrw CSR_SIP, zero
 
   /* Set the S-mode trap vector */
 
   la   t0, __trap_vec
-  csrw stvec, t0
+  csrw CSR_STVEC, t0
 
   /* Clear sscratch */
 
-  csrw sscratch, zero
-  csrw scause, zero
-  csrw sepc, zero
+  csrw CSR_SSCRATCH, zero
+  csrw CSR_SCAUSE, zero
+  csrw CSR_SEPC, zero
 
   /* initialize global pointer, global data */
 
-  
+
 .option push
 .option norelax
   la  gp, __global_pointer$

--- a/arch/risc-v/src/mpfs/mpfs_head.S
+++ b/arch/risc-v/src/mpfs/mpfs_head.S
@@ -45,25 +45,25 @@ __start:
 
   /* Disable all interrupts (i.e. timer, external) in mie */
 
-  csrw mie, zero
-  csrw mip, zero
+  csrw CSR_MIE, zero
+  csrw CSR_MIP, zero
 
   /* Initialize the Machine Trap Vector */
 
   la   t0, __trap_vec
-  csrw mtvec, t0
+  csrw CSR_MTVEC, t0
 
   /* Make sure that mtvec is updated before continuing */
 
 1:
-  csrr t1, mtvec
+  csrr t1, CSR_MTVEC
   bne  t0, t1, 1b
 
   /* mscratch must be init to zero- we are not using scratch memory */
 
-  csrw mscratch, zero
-  csrw mcause, zero
-  csrw mepc, zero
+  csrw CSR_MSCRATCH, zero
+  csrw CSR_MCAUSE, zero
+  csrw CSR_MEPC, zero
   li   x1,  0
   li   x2,  0
   li   x3,  0
@@ -97,17 +97,17 @@ __start:
   li   x31, 0
 
   /* Skip delegation register, mmu and floating point initializations if E51 */
-  csrr a0, mhartid
+  csrr a0, CSR_MHARTID
   beqz a0, .skip_e51
 
   /* Delegation registers must be explicitly reset */
 
-  csrw mideleg, 0
-  csrw medeleg, 0
+  csrw CSR_MIDELEG, 0
+  csrw CSR_MEDELEG, 0
 
   /* Remove MMU mappings (if any) */
 
-  csrw satp, zero
+  csrw CSR_SATP, zero
   fence
 
   /* Flush TLB (does not make a difference really) */
@@ -131,8 +131,8 @@ __start:
 #ifdef CONFIG_MPFS_BOOTLOADER
   /* Clear PMP */
 
-  csrw pmpcfg0, zero
-  csrw pmpcfg2, zero
+  csrw CSR_PMPCFG0, zero
+  csrw CSR_PMPCFG2, zero
 
   /* Set all but the boot hart into wfi */
 
@@ -142,7 +142,7 @@ __start:
   /* Enable IRQ_M_SOFT */
 
   li a2, (1U << 3)
-  csrw mie, a2     /* Set MSIE bit to receive IPI */
+  csrw CSR_MIE, a2     /* Set MSIE bit to receive IPI */
 
   /* flush the instruction cache */
   fence.i
@@ -155,15 +155,15 @@ __start:
    * interrupt
    */
 
-  csrr a2, mip
+  csrr a2, CSR_MIP
   andi a2, a2, (1U << 3) /* MIP_MSIP */
   beqz a2, .wait_boot
 
   /* Disable and clear all interrupts (the sw interrupt) */
   li a2, 0x00000008      /* MSTATUS_MIE */
-  csrc mstatus, a2
-  csrw mie, zero
-  csrw mip, zero
+  csrc CSR_MSTATUS, a2
+  csrw CSR_MIE, zero
+  csrw CSR_MIP, zero
 
   /* Jump to application */
   tail mpfs_jump_to_app

--- a/arch/risc-v/src/mpfs/mpfs_opensbi_utils.S
+++ b/arch/risc-v/src/mpfs/mpfs_opensbi_utils.S
@@ -74,7 +74,7 @@ mpfs_opensbi_prepare_hart:
   /* Setup OpenSBI exception handler */
 
   la   t0, mpfs_exception_opensbi
-  csrw mtvec, t0
+  csrw CSR_MTVEC, t0
 
   /* la gp, __global_pointer$ will not work. We want to have the gp as seen
    * in the .map file exactly. We need to restore gp in the trap handler.
@@ -85,7 +85,7 @@ mpfs_opensbi_prepare_hart:
 
   /* Setup stacks per hart, the stack top is the end of the hart's scratch */
 
-  csrr a0, mhartid
+  csrr a0, CSR_MHARTID
   li   t1, SBI_SCRATCH_SIZE
   mul  t0, a0, t1
   la   sp, g_scratches

--- a/arch/risc-v/src/mpfs/mpfs_shead.S
+++ b/arch/risc-v/src/mpfs/mpfs_shead.S
@@ -63,19 +63,19 @@ __start:
 #endif
   /* Disable all interrupts in sie */
 
-  csrw sie, zero
-  csrw sip, zero
+  csrw CSR_SIE, zero
+  csrw CSR_SIP, zero
 
   /* Set the S-mode trap vector */
 
   la   t0, __trap_vec
-  csrw stvec, t0
+  csrw CSR_STVEC, t0
 
   /* Clear sscratch */
 
-  csrw sscratch, zero
-  csrw scause, zero
-  csrw sepc, zero
+  csrw CSR_SSCRATCH, zero
+  csrw CSR_SCAUSE, zero
+  csrw CSR_SEPC, zero
 
   /* initialize global pointer, global data */
 
@@ -86,7 +86,7 @@ __start:
 
   /* Remove MMU mappings (if any) and flush TLB */
 
-  csrw satp, zero
+  csrw CSR_SATP, zero
   sfence.vma x0, x0
 
   /* Make sure the writes to CSR stick before continuing */

--- a/arch/risc-v/src/mpfs/mpfs_userspace.c
+++ b/arch/risc-v/src/mpfs/mpfs_userspace.c
@@ -224,8 +224,8 @@ static void configure_mpu(void)
 {
   /* Open everything for PMP */
 
-  WRITE_CSR(pmpaddr0, UINT64_C(~0));
-  WRITE_CSR(pmpcfg0, (PMPCFG_A_NAPOT | PMPCFG_R | PMPCFG_W | PMPCFG_X));
+  WRITE_CSR(CSR_PMPADDR0, UINT64_C(~0));
+  WRITE_CSR(CSR_PMPCFG0, (PMPCFG_A_NAPOT | PMPCFG_R | PMPCFG_W | PMPCFG_X));
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/nuttsbi/sbi_head.S
+++ b/arch/risc-v/src/nuttsbi/sbi_head.S
@@ -42,25 +42,25 @@ __start:
 
   /* Disable all interrupts (i.e. timer, external) in mie */
 
-  csrw mie, zero
-  csrw mip, zero
+  csrw CSR_MIE, zero
+  csrw CSR_MIP, zero
 
   /* Initialize the Machine Trap Vector */
 
   la   t0, __mtrap_vec
-  csrw mtvec, t0
+  csrw CSR_MTVEC, t0
 
   /* Make sure that mtvec is updated before continuing */
 
 1:
-  csrr t1, mtvec
+  csrr t1, CSR_MTVEC
   bne  t0, t1, 1b
 
   /* mscratch must be init to zero- we are not using scratch memory */
 
-  csrw mscratch, zero
-  csrw mcause, zero
-  csrw mepc, zero
+  csrw CSR_MSCRATCH, zero
+  csrw CSR_MCAUSE, zero
+  csrw CSR_MEPC, zero
   li   x1,  0
   li   x2,  0
   li   x3,  0
@@ -95,12 +95,12 @@ __start:
 
   /* Delegation registers must be explicitly reset */
 
-  csrw mideleg, 0
-  csrw medeleg, 0
+  csrw CSR_MIDELEG, 0
+  csrw CSR_MEDELEG, 0
 
   /* Remove MMU mappings (if any) */
 
-  csrw satp, zero
+  csrw CSR_SATP, zero
   fence
 
   /* Flush TLB (does not make a difference really) */
@@ -109,8 +109,8 @@ __start:
 
   /* Clear PMP */
 
-  csrw pmpcfg0, 0
-  csrw pmpcfg2, 0
+  csrw CSR_PMPCFG0, zero
+  csrw CSR_PMPCFG2, zero
 
   /* Set up a temporary stack */
 

--- a/arch/risc-v/src/nuttsbi/sbi_mcall.c
+++ b/arch/risc-v/src/nuttsbi/sbi_mcall.c
@@ -71,8 +71,8 @@ void sbi_mcall_handle(uintptr_t *regs)
 #else
       sbi_set_mtimecmp(regs[REG_A1] + ((uint64_t)regs[REG_A2] << 32));
 #endif
-      CLEAR_CSR(mip, MIP_STIP);
-      SET_CSR(mie, MIE_MTIE);
+      CLEAR_CSR(CSR_MIP, MIP_STIP);
+      SET_CSR(CSR_MIE, MIE_MTIE);
       break;
 
     default:

--- a/arch/risc-v/src/nuttsbi/sbi_mscratch.c
+++ b/arch/risc-v/src/nuttsbi/sbi_mscratch.c
@@ -77,7 +77,7 @@ void sbi_mscratch_assign(uintptr_t hartid)
   stack_top = (uintptr_t)&g_mintstacktop;
 #endif
 
-  WRITE_CSR(mscratch, stack_top);
+  WRITE_CSR(CSR_MSCRATCH, stack_top);
 
   /* Make sure mscratch is updated before continuing */
 

--- a/arch/risc-v/src/nuttsbi/sbi_mtimer.c
+++ b/arch/risc-v/src/nuttsbi/sbi_mtimer.c
@@ -85,7 +85,8 @@ uint64_t sbi_get_mtime(void)
 
 void sbi_set_mtimecmp(uint64_t value)
 {
-  uintptr_t mtimecmp = g_mtimecmp + READ_CSR(mhartid) * sizeof(uintptr_t);
+  uintptr_t mtimecmp = g_mtimecmp +
+                       READ_CSR(CSR_MHARTID) * sizeof(uintptr_t);
 #if CONFIG_ARCH_RV_MMIO_BITS == 64
   putreg64(value, mtimecmp);
 #else

--- a/arch/risc-v/src/nuttsbi/sbi_mtrap.S
+++ b/arch/risc-v/src/nuttsbi/sbi_mtrap.S
@@ -51,15 +51,15 @@ machine_trap:
 
   /* Switch to M-mode IRQ stack */
 
-  csrrw      sp, mscratch, sp     /* mscratch has user stack */
+  csrrw      sp, CSR_MSCRATCH, sp /* mscratch has user stack */
   beqz       sp, .Lmtrap          /* Detect recursive traps */
 
   addi       sp, sp, -XCPTCONTEXT_SIZE
   save_ctx   sp
 
-  csrr       a0, mcause           /* exception cause  */
+  csrr       a0, CSR_MCAUSE       /* exception cause  */
 
-  csrrw      s0, mscratch, x0     /* read user stack */
+  csrrw      s0, CSR_MSCRATCH, x0 /* read user stack */
   REGSTORE   s0, REG_X2(sp)       /* original SP      */
 
   /* Check if this is an exception */
@@ -75,15 +75,15 @@ machine_trap:
   /* Delegate interrupt to S-mode handler */
 
   li         a0, MIP_MTIP
-  csrc       mie, a0
+  csrc       CSR_MIE, a0
   li         a0, MIP_STIP
-  csrs       mip, a0
+  csrs       CSR_MIP, a0
 
 1:
   /* Restore mscratch */
 
   addi       s0, sp, XCPTCONTEXT_SIZE
-  csrw       mscratch, s0         /* original mscratch */
+  csrw       CSR_MSCRATCH, s0     /* original mscratch */
 
   /* Restore original context */
 
@@ -107,17 +107,17 @@ machine_trap:
 
   mv         a0, sp
   jal        x1, sbi_mcall_handle
-  csrr       a0, mepc
+  csrr       a0, CSR_MEPC
   addi       a0, a0, 4
-  csrw       mepc, a0
+  csrw       CSR_MEPC, a0
   j          1b
 
   /* An unhandled trap to M-mode: this is an error and we cannot proceed */
 
 .Lmtrap:
 
-  csrr        a0, mcause         /* Interrupt cause [arg0] */
-  csrr        a1, mepc           /* Interrupt PC (instruction) [arg1] */
+  csrr        a0, CSR_MCAUSE     /* Interrupt cause [arg0] */
+  csrr        a1, CSR_MEPC       /* Interrupt PC (instruction) [arg1] */
   jal         x1, sbi_mexception
   j           __start
 

--- a/arch/risc-v/src/nuttsbi/sbi_start.c
+++ b/arch/risc-v/src/nuttsbi/sbi_start.c
@@ -62,7 +62,7 @@ void sbi_start(void)
 
   /* Read hart ID */
 
-  hartid = READ_CSR(mhartid);
+  hartid = READ_CSR(CSR_MHARTID);
 
   /* Set mscratch, mtimer */
 
@@ -71,7 +71,7 @@ void sbi_start(void)
 
   /* Setup system to enter S-mode */
 
-  reg  =  READ_CSR(mstatus);
+  reg  =  READ_CSR(CSR_MSTATUS);
   reg &= ~MSTATUS_MPPM; /* Clear MPP */
   reg &= ~MSTATUS_MPIE; /* Clear MPIE */
   reg &= ~MSTATUS_TW;   /* Do not trap WFI */
@@ -82,16 +82,16 @@ void sbi_start(void)
 
   /* Setup next context */
 
-  WRITE_CSR(mstatus, reg);
+  WRITE_CSR(CSR_MSTATUS, reg);
 
   /* Setup a temporary S-mode interrupt vector */
 
-  WRITE_CSR(stvec, __trap_vec_tmp);
+  WRITE_CSR(CSR_STVEC, __trap_vec_tmp);
 
   /* Delegate interrupts */
 
   reg = (MIP_SSIP | MIP_STIP | MIP_SEIP);
-  WRITE_CSR(mideleg, reg);
+  WRITE_CSR(CSR_MIDELEG, reg);
 
   /* Delegate exceptions (all of them) */
 
@@ -100,12 +100,12 @@ void sbi_start(void)
          (1 << RISCV_IRQ_LOADPF) |
          (1 << RISCV_IRQ_STOREPF) |
          (1 << RISCV_IRQ_ECALLU));
-  WRITE_CSR(medeleg, reg);
+  WRITE_CSR(CSR_MEDELEG, reg);
 
   /* Enable access to all counters for S- and U-mode */
 
-  WRITE_CSR(mcounteren, UINT32_C(~0));
-  WRITE_CSR(scounteren, UINT32_C(~0));
+  WRITE_CSR(CSR_MCOUNTEREN, UINT32_C(~0));
+  WRITE_CSR(CSR_SCOUNTEREN, UINT32_C(~0));
 
 #ifdef CONFIG_NUTTSBI_LATE_INIT
   /* Do device specific initialization as needed */
@@ -115,7 +115,7 @@ void sbi_start(void)
 
   /* Set program counter to __start_s */
 
-  WRITE_CSR(mepc, __start_s);
+  WRITE_CSR(CSR_MEPC, __start_s);
 
   /* Open everything for PMP */
 

--- a/arch/risc-v/src/qemu-rv/qemu_rv_exception_m.S
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_exception_m.S
@@ -81,7 +81,7 @@ exception_m:
   /* Swap mscratch with sp */
   /* NOTE: mscratch has been set in up_mtimer_initialize() */
 
-  csrrw     sp, mscratch, sp
+  csrrw     sp, CSR_MSCRATCH, sp
 
   /* Save the context */
 
@@ -98,7 +98,7 @@ exception_m:
 
   /* Swap mscratch with sp */
 
-  csrrw     sp, mscratch, sp
+  csrrw     sp, CSR_MSCRATCH, sp
 
   /* Return from exception */
 

--- a/arch/risc-v/src/qemu-rv/qemu_rv_head.S
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_head.S
@@ -44,7 +44,7 @@ __start:
   /* Preserve a1 as it contains the pointer to DTB */
   /* Load mhartid (cpuid) */
 
-  csrr a0, mhartid
+  csrr a0, CSR_MHARTID
 
   /* Set stack pointer to the idle thread stack */
 
@@ -64,7 +64,7 @@ __start:
   /* If a0 (mhartid) >= t1 (the number of CPUs), stop here */
 
   blt  a0, t1, 3f
-  csrw mie, zero
+  csrw CSR_MIE, zero
   wfi
 
 3:
@@ -99,10 +99,10 @@ __start:
 
   /* Disable all interrupts (i.e. timer, external) in mie */
 
-	csrw	mie, zero
+	csrw CSR_MIE, zero
 
   la   t0, __trap_vec
-  csrw mtvec, t0
+  csrw CSR_MTVEC, t0
 
   /* Jump to qemu_rv_start */
 

--- a/arch/risc-v/src/qemu-rv/qemu_rv_irq.c
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_irq.c
@@ -165,7 +165,7 @@ void up_enable_irq(int irq)
     {
       /* Read m/sstatus & set timer interrupt enable in m/sie */
 
-      SET_CSR(mie, MIE_MTIE);
+      SET_CSR(CSR_MIE, MIE_MTIE);
     }
 #endif
   else if (irq > RISCV_IRQ_EXT)

--- a/arch/risc-v/src/qemu-rv/qemu_rv_start.c
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_start.c
@@ -178,31 +178,31 @@ void qemu_rv_start(int mhartid, const char *dtb)
 
   /* Disable MMU and enable PMP */
 
-  WRITE_CSR(satp, 0x0);
-  WRITE_CSR(pmpaddr0, 0x3fffffffffffffull);
-  WRITE_CSR(pmpcfg0, 0xf);
+  WRITE_CSR(CSR_SATP, 0x0);
+  WRITE_CSR(CSR_PMPADDR0, 0x3fffffffffffffull);
+  WRITE_CSR(CSR_PMPCFG0, 0xf);
 
   /* Set exception and interrupt delegation for S-mode */
 
-  WRITE_CSR(medeleg, 0xffff);
-  WRITE_CSR(mideleg, 0xffff);
+  WRITE_CSR(CSR_MEDELEG, 0xffff);
+  WRITE_CSR(CSR_MIDELEG, 0xffff);
 
   /* Allow to write satp from S-mode */
 
-  CLEAR_CSR(mstatus, MSTATUS_TVM);
+  CLEAR_CSR(CSR_MSTATUS, MSTATUS_TVM);
 
   /* Set mstatus to S-mode */
 
-  CLEAR_CSR(mstatus, MSTATUS_MPP_MASK);
-  SET_CSR(mstatus, MSTATUS_MPPS);
+  CLEAR_CSR(CSR_MSTATUS, MSTATUS_MPP_MASK);
+  SET_CSR(CSR_MSTATUS, MSTATUS_MPPS);
 
   /* Set the trap vector for S-mode */
 
-  WRITE_CSR(stvec, (uintptr_t)__trap_vec);
+  WRITE_CSR(CSR_STVEC, (uintptr_t)__trap_vec);
 
   /* Set the trap vector for M-mode */
 
-  WRITE_CSR(mtvec, (uintptr_t)__trap_vec_m);
+  WRITE_CSR(CSR_MTVEC, (uintptr_t)__trap_vec_m);
 
   if (0 == mhartid)
     {
@@ -215,7 +215,7 @@ void qemu_rv_start(int mhartid, const char *dtb)
 
   /* Set mepc to the entry */
 
-  WRITE_CSR(mepc, (uintptr_t)qemu_rv_start_s);
+  WRITE_CSR(CSR_MEPC, (uintptr_t)qemu_rv_start_s);
 
   /* Set a0 to mhartid and a1 to dtb explicitly and enter to S-mode */
 

--- a/arch/risc-v/src/qemu-rv/qemu_rv_timerisr.c
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_timerisr.c
@@ -75,7 +75,7 @@ static int qemu_rv_ssoft_interrupt(int irq, void *context, void *arg)
 {
   /* Cleaer Supervisor Software Interrupt */
 
-  CLEAR_CSR(sip, SIP_SSIP);
+  CLEAR_CSR(CSR_SIP, SIP_SSIP);
 
   if (g_stimer_pending)
     {
@@ -111,7 +111,7 @@ static void qemu_rv_reload_mtimecmp(void)
   uint64_t current;
   uint64_t next;
 
-  current = READ_CSR(time);
+  current = READ_CSR(CSR_TIME);
   next = current + TICK_COUNT;
   putreg64(next, QEMU_RV_CLINT_MTIMECMP);
 }
@@ -165,7 +165,7 @@ void up_mtimer_initialize(void)
 
   /* Set the irq stack base to mscratch */
 
-  WRITE_CSR(mscratch,
+  WRITE_CSR(CSR_MSCRATCH,
             irqstacktop - STACK_ALIGN_DOWN(CONFIG_ARCH_INTERRUPTSTACK));
 
   /* NOTE: we do not attach a handler for mtimer,
@@ -203,7 +203,7 @@ void qemu_rv_mtimer_interrupt(void)
     {
       /* Post Supervisor Software Interrupt */
 
-      SET_CSR(sip, SIP_SSIP);
+      SET_CSR(CSR_SIP, SIP_SSIP);
     }
 }
 

--- a/arch/risc-v/src/rv32m1/rv32m1_head.S
+++ b/arch/risc-v/src/rv32m1/rv32m1_head.S
@@ -47,14 +47,14 @@ __start:
 
   /* Disable all interrupts (i.e. timer, external) in mie */
 
-  csrci mstatus, 0x8
-  csrw mie, zero
+  csrci CSR_MSTATUS, 0x8
+  csrw CSR_MIE, zero
 
   /* Initialize the Machine Trap Vector */
 
   lui  t0, %hi(_svector)
   addi t0, t0, %lo(_svector)
-  csrw mtvec, t0
+  csrw CSR_MTVEC, t0
 
   /* Jump to __rv32m1_start */
 
@@ -130,7 +130,7 @@ exception_common:
   sw x30, 38*4(sp)
 #endif
 
-  csrr s0, mstatus
+  csrr s0, CSR_MSTATUS
   sw   s0,  32*4(sp)  /* mstatus */
 
   addi s0, sp, XCPTCONTEXT_SIZE
@@ -138,8 +138,8 @@ exception_common:
 
   /* Setup arg0(exception cause), arg1(context) */
 
-  csrr a0, mcause  /* exception cause */
-  csrr s0, mepc
+  csrr a0, CSR_MCAUSE /* exception cause */
+  csrr s0, CSR_MEPC
   sw   s0, 0(sp)   /* exception PC */
 
   mv   a1, sp      /* context = sp */
@@ -159,10 +159,10 @@ exception_common:
 
   mv   sp, a0
   lw   s0, 0(sp)    /* restore mepc */
-  csrw mepc, s0
+  csrw CSR_MEPC, s0
 
   lw   s0, 32*4(sp) /* restore mstatus */
-  csrw mstatus, s0
+  csrw CSR_MSTATUS, s0
 
 #if defined(INT_XCPT_REGS) && INT_XCPT_REGS >= 39
   lw x28, 36*4(sp)

--- a/arch/risc-v/src/rv32m1/rv32m1_irq.c
+++ b/arch/risc-v/src/rv32m1/rv32m1_irq.c
@@ -237,11 +237,11 @@ irqstate_t up_irq_enable(void)
 
   /* TODO: should move to up_enable_irq() */
 
-  SET_CSR(mie, MIE_MEIE);
+  SET_CSR(CSR_MIE, MIE_MEIE);
 #endif
 
   /* Read mstatus & set machine interrupt enable (MIE) in mstatus */
 
-  oldstat = READ_AND_SET_CSR(mstatus, MSTATUS_MIE);
+  oldstat = READ_AND_SET_CSR(CSR_MSTATUS, MSTATUS_MIE);
   return oldstat;
 }


### PR DESCRIPTION
Using CSR name depends on compiler support heavily, but CSR encoding does not have this problem. It also make it easy to add new CSR support even if the compiler does not support.

Unify CSR access by using the CSR encoding macro.