### PR TITLE
drivers/power/pm: Fix warning of type cast

### DIFF
--- a/drivers/power/pm/pm_autoupdate.c
+++ b/drivers/power/pm/pm_autoupdate.c
@@ -40,7 +40,7 @@
 
 static void pm_auto_updatestate_cb(FAR void *arg)
 {
-  int domain = (uintptr_t)arg;
+  int domain = (intptr_t)arg;
   enum pm_state_e newstate;
   irqstate_t flags;
 
@@ -81,12 +81,13 @@ void pm_auto_updatestate(int domain)
       if (up_interrupt_context())
         {
           work_queue(HPWORK, &pdom->update_work,
-                     pm_auto_updatestate_cb, (FAR void *)domain, 0);
+                     pm_auto_updatestate_cb,
+                     (FAR void *)(intptr_t)domain, 0);
         }
       else
 #endif
         {
-          pm_auto_updatestate_cb((FAR void *)domain);
+          pm_auto_updatestate_cb((FAR void *)(intptr_t)domain);
         }
     }
 }


### PR DESCRIPTION
## Summary
sim (Ubuntu 22.04.3 LTS (x86_64 GNU/Linux)), enable PM
```
power/pm/pm_autoupdate.c: In function ‘pm_auto_updatestate’:
power/pm/pm_autoupdate.c:84:46: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
   84 |                      pm_auto_updatestate_cb, (FAR void *)domain, 0);
      |                                              ^
power/pm/pm_autoupdate.c:89:34: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
   89 |           pm_auto_updatestate_cb((FAR void *)domain);
      |                                  ^
```

## Impact

## Testing
sim:nsh
