### PR TITLE
net: Optimize TCP/UDP port selection

### DIFF
--- a/net/nat/nat.c
+++ b/net/nat/nat.c
@@ -32,24 +32,9 @@
 #include "nat/nat.h"
 #include "tcp/tcp.h"
 #include "udp/udp.h"
+#include "utils/utils.h"
 
 #ifdef CONFIG_NET_NAT
-
-/****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-#define NEXT_PORT(nport, hport) \
-  do \
-    { \
-      ++(hport); \
-      if ((hport) >= CONFIG_NET_DEFAULT_MAX_PORT || \
-          (hport) < CONFIG_NET_DEFAULT_MIN_PORT) \
-        { \
-          (hport) = CONFIG_NET_DEFAULT_MIN_PORT; \
-        } \
-      (nport) = HTONS(hport); \
-    } while (0)
 
 /****************************************************************************
  * Private Functions
@@ -86,7 +71,7 @@ static uint16_t nat_port_select_without_stack(
   uint16_t hport = NTOHS(portno);
   while (nat_port_inuse(domain, protocol, ip, portno))
     {
-      NEXT_PORT(portno, hport);
+      NET_PORT_NEXT_NH(portno, hport);
       if (portno == local_port)
         {
           /* We have looped back, failed. */
@@ -308,7 +293,7 @@ uint16_t nat_port_select(FAR struct net_driver_s *dev,
           while (icmp_findconn(dev, id) ||
                  nat_port_inuse(domain, IP_PROTO_ICMP, external_ip, id))
             {
-              NEXT_PORT(id, hid);
+              NET_PORT_NEXT_NH(id, hid);
               if (id == local_port)
                 {
                   /* We have looped back, failed. */
@@ -334,7 +319,7 @@ uint16_t nat_port_select(FAR struct net_driver_s *dev,
           while (icmpv6_active(id) ||
                  nat_port_inuse(domain, IP_PROTO_ICMP6, external_ip, id))
             {
-              NEXT_PORT(id, hid);
+              NET_PORT_NEXT_NH(id, hid);
               if (id == local_port)
                 {
                   /* We have looped back, failed. */

--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -583,38 +583,30 @@ int tcp_selectport(uint8_t domain,
 
   if (g_last_tcp_port == 0)
     {
-      net_getrandom(&g_last_tcp_port, sizeof(uint16_t));
-
-      g_last_tcp_port = g_last_tcp_port %
-                        (CONFIG_NET_DEFAULT_MAX_PORT -
-                         CONFIG_NET_DEFAULT_MIN_PORT + 1);
-      g_last_tcp_port += CONFIG_NET_DEFAULT_MIN_PORT;
+      NET_PORT_RANDOM_INIT(g_last_tcp_port);
     }
 
   if (portno == 0)
     {
+      uint16_t loop_start = g_last_tcp_port;
+
       /* No local port assigned. Loop until we find a valid listen port
-       * number that is not being used by any other connection. NOTE the
-       * following loop is assumed to terminate but could not if all
-       * 32000-4096+1 ports are in used (unlikely).
+       * number that is not being used by any other connection.
        */
 
       do
         {
           /* Guess that the next available port number will be the one after
-           * the last port number assigned. Make sure that the port number
-           * is within range.
+           * the last port number assigned.
            */
 
-          ++g_last_tcp_port;
-
-          if (g_last_tcp_port > CONFIG_NET_DEFAULT_MAX_PORT ||
-              g_last_tcp_port < CONFIG_NET_DEFAULT_MIN_PORT)
+          NET_PORT_NEXT_NH(portno, g_last_tcp_port);
+          if (g_last_tcp_port == loop_start)
             {
-              g_last_tcp_port = CONFIG_NET_DEFAULT_MIN_PORT;
-            }
+              /* We have looped back, failed. */
 
-          portno = HTONS(g_last_tcp_port);
+              return -EADDRINUSE;
+            }
         }
       while (tcp_listener(domain, ipaddr, portno)
 #ifdef CONFIG_NET_NAT

--- a/net/udp/udp.h
+++ b/net/udp/udp.h
@@ -265,6 +265,9 @@ FAR struct udp_conn_s *udp_nextconn(FAR struct udp_conn_s *conn);
  *   implementation, it is reasonable to assume that that error cannot happen
  *   and that a port number will always be available.
  *
+ * Returned Value:
+ *   Next available port number in host byte order, 0 for failure.
+ *
  ****************************************************************************/
 
 uint16_t udp_select_port(uint8_t domain, FAR union ip_binding_u *u);

--- a/net/udp/udp_sendto_buffered.c
+++ b/net/udp/udp_sendto_buffered.c
@@ -263,6 +263,11 @@ static int sendto_next_transfer(FAR struct udp_conn_s *conn)
        */
 
       conn->lport = HTONS(udp_select_port(conn->domain, &conn->u));
+      if (!conn->lport)
+        {
+          nerr("ERROR: Failed to get a local port!\n");
+          return -EADDRINUSE;
+        }
     }
 
   /* Get the device that will handle the remote packet transfers.  This

--- a/net/utils/utils.h
+++ b/net/utils/utils.h
@@ -31,6 +31,47 @@
 #include <nuttx/net/netdev.h>
 
 /****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Some utils for port selection */
+
+#define NET_PORT_RANDOM_INIT(port) \
+  do \
+    { \
+      net_getrandom(&(port), sizeof(port)); \
+      (port) = (port) % (CONFIG_NET_DEFAULT_MAX_PORT - \
+                         CONFIG_NET_DEFAULT_MIN_PORT + 1); \
+      (port) += CONFIG_NET_DEFAULT_MIN_PORT; \
+    } while (0)
+
+/* Get next net port number, and make sure that the port number is within
+ * range.  In host byte order.
+ */
+
+#define NET_PORT_NEXT_H(hport) \
+  do \
+    { \
+      ++(hport); \
+      if ((hport) > CONFIG_NET_DEFAULT_MAX_PORT || \
+          (hport) < CONFIG_NET_DEFAULT_MIN_PORT) \
+        { \
+          (hport) = CONFIG_NET_DEFAULT_MIN_PORT; \
+        } \
+    } while (0)
+
+/* Get next net port number, and make sure that the port number is within
+ * range.  In both network & host byte order.
+ */
+
+#define NET_PORT_NEXT_NH(nport, hport) \
+  do \
+    { \
+      NET_PORT_NEXT_H(hport); \
+      (nport) = HTONS(hport); \
+    } while (0)
+
+/****************************************************************************
  * Public Types
  ****************************************************************************/
 


### PR DESCRIPTION
## Summary
Optimize TCP/UDP port selection, and fix possibly dead loop.

Finish discussion in https://github.com/apache/nuttx/pull/12116#discussion_r1560851977

Note:
Linux also uses `EADDRINUSE` for failing in finding a portno, according to https://man7.org/linux/man-pages/man2/bind.2.html#ERRORS

## Impact
TCP / UDP / NAT Port selection

## Testing
Manually
- Set `CONFIG_NET_DEFAULT_MAX_PORT` close to `CONFIG_NET_DEFAULT_MIN_PORT`, and create several UDP sockets (iperf2 on Vela), we can get "udp_connect: ERROR: Failed to get a local port!" and "udp connect failed: Address already in use"
