### PR TITLE
net/nat: Minor code optimizations

### DIFF
--- a/net/nat/ipv4_nat.c
+++ b/net/nat/ipv4_nat.c
@@ -744,14 +744,7 @@ void ipv4_nat_inbound(FAR struct net_driver_s *dev,
   if (IFF_IS_NAT(dev->d_flags) &&
       net_ipv4addr_hdrcmp(ipv4->destipaddr, &dev->d_ipaddr))
     {
-      FAR ipv4_nat_entry_t *entry =
-          ipv4_nat_inbound_internal(ipv4, NAT_MANIP_DST);
-      if (!entry)
-        {
-          /* Inbound without entry is OK (e.g. towards NuttX itself), skip. */
-
-          return;
-        }
+      ipv4_nat_inbound_internal(ipv4, NAT_MANIP_DST);
     }
 }
 

--- a/net/nat/ipv4_nat.c
+++ b/net/nat/ipv4_nat.c
@@ -60,11 +60,11 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-static FAR struct ipv4_nat_entry *
+static FAR ipv4_nat_entry_t *
 ipv4_nat_inbound_internal(FAR struct ipv4_hdr_s *ipv4,
                           enum nat_manip_type_e manip_type);
 
-static FAR struct ipv4_nat_entry *
+static FAR ipv4_nat_entry_t *
 ipv4_nat_outbound_internal(FAR struct net_driver_s *dev,
                            FAR struct ipv4_hdr_s *ipv4,
                            enum nat_manip_type_e manip_type);
@@ -180,16 +180,16 @@ static void ipv4_nat_port_adjust(FAR uint16_t *l4chksum,
  ****************************************************************************/
 
 #ifdef CONFIG_NET_TCP
-static FAR struct ipv4_nat_entry *
+static FAR ipv4_nat_entry_t *
 ipv4_nat_inbound_tcp(FAR struct ipv4_hdr_s *ipv4,
                      enum nat_manip_type_e manip_type)
 {
-  FAR struct tcp_hdr_s      *tcp           = L4_HDR(ipv4);
-  FAR uint16_t              *external_ip   = MANIP_IPADDR(ipv4, manip_type);
-  FAR uint16_t              *external_port = MANIP_PORT(tcp, manip_type);
-  FAR uint16_t              *peer_ip       = PEER_IPADDR(ipv4, manip_type);
-  FAR uint16_t              *peer_port     = PEER_PORT(tcp, manip_type);
-  FAR struct ipv4_nat_entry *entry         =
+  FAR struct tcp_hdr_s *tcp           = L4_HDR(ipv4);
+  FAR uint16_t         *external_ip   = MANIP_IPADDR(ipv4, manip_type);
+  FAR uint16_t         *external_port = MANIP_PORT(tcp, manip_type);
+  FAR uint16_t         *peer_ip       = PEER_IPADDR(ipv4, manip_type);
+  FAR uint16_t         *peer_port     = PEER_PORT(tcp, manip_type);
+  FAR ipv4_nat_entry_t *entry         =
                  ipv4_nat_inbound_entry_find(IP_PROTO_TCP,
                                              net_ip4addr_conv32(external_ip),
                                              *external_port,
@@ -233,17 +233,17 @@ ipv4_nat_inbound_tcp(FAR struct ipv4_hdr_s *ipv4,
  ****************************************************************************/
 
 #ifdef CONFIG_NET_UDP
-static FAR struct ipv4_nat_entry *
+static FAR ipv4_nat_entry_t *
 ipv4_nat_inbound_udp(FAR struct ipv4_hdr_s *ipv4,
                      enum nat_manip_type_e manip_type)
 {
-  FAR struct udp_hdr_s      *udp           = L4_HDR(ipv4);
-  FAR uint16_t              *external_ip   = MANIP_IPADDR(ipv4, manip_type);
-  FAR uint16_t              *external_port = MANIP_PORT(udp, manip_type);
-  FAR uint16_t              *peer_ip       = PEER_IPADDR(ipv4, manip_type);
-  FAR uint16_t              *peer_port     = PEER_PORT(udp, manip_type);
-  FAR uint16_t              *udpchksum;
-  FAR struct ipv4_nat_entry *entry         =
+  FAR struct udp_hdr_s *udp           = L4_HDR(ipv4);
+  FAR uint16_t         *external_ip   = MANIP_IPADDR(ipv4, manip_type);
+  FAR uint16_t         *external_port = MANIP_PORT(udp, manip_type);
+  FAR uint16_t         *peer_ip       = PEER_IPADDR(ipv4, manip_type);
+  FAR uint16_t         *peer_port     = PEER_PORT(udp, manip_type);
+  FAR uint16_t         *udpchksum;
+  FAR ipv4_nat_entry_t *entry         =
                  ipv4_nat_inbound_entry_find(IP_PROTO_UDP,
                                              net_ip4addr_conv32(external_ip),
                                              *external_port,
@@ -287,14 +287,14 @@ ipv4_nat_inbound_udp(FAR struct ipv4_hdr_s *ipv4,
  ****************************************************************************/
 
 #ifdef CONFIG_NET_ICMP
-static FAR struct ipv4_nat_entry *
+static FAR ipv4_nat_entry_t *
 ipv4_nat_inbound_icmp(FAR struct ipv4_hdr_s *ipv4,
                       enum nat_manip_type_e manip_type)
 {
-  FAR struct icmp_hdr_s     *icmp = L4_HDR(ipv4);
-  FAR uint16_t              *external_ip = MANIP_IPADDR(ipv4, manip_type);
-  FAR uint16_t              *peer_ip     = PEER_IPADDR(ipv4, manip_type);
-  FAR struct ipv4_nat_entry *entry;
+  FAR struct icmp_hdr_s *icmp = L4_HDR(ipv4);
+  FAR uint16_t          *external_ip = MANIP_IPADDR(ipv4, manip_type);
+  FAR uint16_t          *peer_ip     = PEER_IPADDR(ipv4, manip_type);
+  FAR ipv4_nat_entry_t  *entry;
 
   switch (icmp->type)
     {
@@ -409,17 +409,17 @@ ipv4_nat_inbound_icmp(FAR struct ipv4_hdr_s *ipv4,
  ****************************************************************************/
 
 #ifdef CONFIG_NET_TCP
-static FAR struct ipv4_nat_entry *
+static FAR ipv4_nat_entry_t *
 ipv4_nat_outbound_tcp(FAR struct net_driver_s *dev,
                       FAR struct ipv4_hdr_s *ipv4,
                       enum nat_manip_type_e manip_type)
 {
-  FAR struct tcp_hdr_s      *tcp        = L4_HDR(ipv4);
-  FAR uint16_t              *local_ip   = MANIP_IPADDR(ipv4, manip_type);
-  FAR uint16_t              *local_port = MANIP_PORT(tcp, manip_type);
-  FAR uint16_t              *peer_ip    = PEER_IPADDR(ipv4, manip_type);
-  FAR uint16_t              *peer_port  = PEER_PORT(tcp, manip_type);
-  FAR struct ipv4_nat_entry *entry;
+  FAR struct tcp_hdr_s *tcp        = L4_HDR(ipv4);
+  FAR uint16_t         *local_ip   = MANIP_IPADDR(ipv4, manip_type);
+  FAR uint16_t         *local_port = MANIP_PORT(tcp, manip_type);
+  FAR uint16_t         *peer_ip    = PEER_IPADDR(ipv4, manip_type);
+  FAR uint16_t         *peer_port  = PEER_PORT(tcp, manip_type);
+  FAR ipv4_nat_entry_t *entry;
 
   /* Only create entry when it's the outermost packet (manip type is SRC). */
 
@@ -465,18 +465,18 @@ ipv4_nat_outbound_tcp(FAR struct net_driver_s *dev,
  ****************************************************************************/
 
 #ifdef CONFIG_NET_UDP
-static FAR struct ipv4_nat_entry *
+static FAR ipv4_nat_entry_t *
 ipv4_nat_outbound_udp(FAR struct net_driver_s *dev,
                       FAR struct ipv4_hdr_s *ipv4,
                       enum nat_manip_type_e manip_type)
 {
-  FAR struct udp_hdr_s      *udp        = L4_HDR(ipv4);
-  FAR uint16_t              *local_ip   = MANIP_IPADDR(ipv4, manip_type);
-  FAR uint16_t              *local_port = MANIP_PORT(udp, manip_type);
-  FAR uint16_t              *peer_ip    = PEER_IPADDR(ipv4, manip_type);
-  FAR uint16_t              *peer_port  = PEER_PORT(udp, manip_type);
-  FAR uint16_t              *udpchksum;
-  FAR struct ipv4_nat_entry *entry;
+  FAR struct udp_hdr_s *udp        = L4_HDR(ipv4);
+  FAR uint16_t         *local_ip   = MANIP_IPADDR(ipv4, manip_type);
+  FAR uint16_t         *local_port = MANIP_PORT(udp, manip_type);
+  FAR uint16_t         *peer_ip    = PEER_IPADDR(ipv4, manip_type);
+  FAR uint16_t         *peer_port  = PEER_PORT(udp, manip_type);
+  FAR uint16_t         *udpchksum;
+  FAR ipv4_nat_entry_t *entry;
 
   /* Only create entry when it's the outermost packet (manip type is SRC). */
 
@@ -521,15 +521,15 @@ ipv4_nat_outbound_udp(FAR struct net_driver_s *dev,
  ****************************************************************************/
 
 #ifdef CONFIG_NET_ICMP
-static FAR struct ipv4_nat_entry *
+static FAR ipv4_nat_entry_t *
 ipv4_nat_outbound_icmp(FAR struct net_driver_s *dev,
                        FAR struct ipv4_hdr_s *ipv4,
                        enum nat_manip_type_e manip_type)
 {
-  FAR struct icmp_hdr_s     *icmp     = L4_HDR(ipv4);
-  FAR uint16_t              *local_ip = MANIP_IPADDR(ipv4, manip_type);
-  FAR uint16_t              *peer_ip  = PEER_IPADDR(ipv4, manip_type);
-  FAR struct ipv4_nat_entry *entry;
+  FAR struct icmp_hdr_s *icmp     = L4_HDR(ipv4);
+  FAR uint16_t          *local_ip = MANIP_IPADDR(ipv4, manip_type);
+  FAR uint16_t          *peer_ip  = PEER_IPADDR(ipv4, manip_type);
+  FAR ipv4_nat_entry_t  *entry;
 
   switch (icmp->type)
     {
@@ -647,7 +647,7 @@ ipv4_nat_outbound_icmp(FAR struct net_driver_s *dev,
  *
  ****************************************************************************/
 
-static FAR struct ipv4_nat_entry *
+static FAR ipv4_nat_entry_t *
 ipv4_nat_inbound_internal(FAR struct ipv4_hdr_s *ipv4,
                           enum nat_manip_type_e manip_type)
 {
@@ -692,7 +692,7 @@ ipv4_nat_inbound_internal(FAR struct ipv4_hdr_s *ipv4,
  *
  ****************************************************************************/
 
-static FAR struct ipv4_nat_entry *
+static FAR ipv4_nat_entry_t *
 ipv4_nat_outbound_internal(FAR struct net_driver_s *dev,
                            FAR struct ipv4_hdr_s *ipv4,
                            enum nat_manip_type_e manip_type)
@@ -744,7 +744,7 @@ void ipv4_nat_inbound(FAR struct net_driver_s *dev,
   if (IFF_IS_NAT(dev->d_flags) &&
       net_ipv4addr_hdrcmp(ipv4->destipaddr, &dev->d_ipaddr))
     {
-      FAR struct ipv4_nat_entry *entry =
+      FAR ipv4_nat_entry_t *entry =
           ipv4_nat_inbound_internal(ipv4, NAT_MANIP_DST);
       if (!entry)
         {
@@ -788,7 +788,7 @@ int ipv4_nat_outbound(FAR struct net_driver_s *dev,
     {
       /* TODO: Skip broadcast? */
 
-      FAR struct ipv4_nat_entry *entry =
+      FAR ipv4_nat_entry_t *entry =
           ipv4_nat_outbound_internal(dev, ipv4, manip_type);
       if (manip_type == NAT_MANIP_SRC && !entry)
         {

--- a/net/nat/ipv4_nat_entry.c
+++ b/net/nat/ipv4_nat_entry.c
@@ -90,7 +90,7 @@ static inline uint32_t ipv4_nat_outbound_key(in_addr_t local_ip,
  *
  ****************************************************************************/
 
-static void ipv4_nat_entry_refresh(FAR struct ipv4_nat_entry *entry)
+static void ipv4_nat_entry_refresh(FAR ipv4_nat_entry_t *entry)
 {
   entry->expire_time = nat_expire_time(entry->protocol);
 }
@@ -115,14 +115,13 @@ static void ipv4_nat_entry_refresh(FAR struct ipv4_nat_entry *entry)
  *
  ****************************************************************************/
 
-static FAR struct ipv4_nat_entry *
+static FAR ipv4_nat_entry_t *
 ipv4_nat_entry_create(uint8_t protocol,
                       in_addr_t external_ip, uint16_t external_port,
                       in_addr_t local_ip, uint16_t local_port,
                       in_addr_t peer_ip, uint16_t peer_port)
 {
-  FAR struct ipv4_nat_entry *entry =
-      kmm_malloc(sizeof(struct ipv4_nat_entry));
+  FAR ipv4_nat_entry_t *entry = kmm_malloc(sizeof(ipv4_nat_entry_t));
   if (entry == NULL)
     {
       nwarn("WARNING: Failed to allocate IPv4 NAT entry\n");
@@ -160,7 +159,7 @@ ipv4_nat_entry_create(uint8_t protocol,
  *
  ****************************************************************************/
 
-static void ipv4_nat_entry_delete(FAR struct ipv4_nat_entry *entry)
+static void ipv4_nat_entry_delete(FAR ipv4_nat_entry_t *entry)
 {
   ninfo("INFO: Removing NAT44 entry proto=%" PRIu8
         ", local=%" PRIx32 ":%" PRIu16 ", external=:%" PRIu16 "\n",
@@ -211,8 +210,8 @@ static void ipv4_nat_reclaim_entry(int32_t current_time)
 
       hashtable_for_every_safe(g_nat44_inbound, p, tmp, i)
         {
-          FAR struct ipv4_nat_entry *entry =
-            container_of(p, struct ipv4_nat_entry, hash_inbound);
+          FAR ipv4_nat_entry_t *entry =
+            container_of(p, ipv4_nat_entry_t, hash_inbound);
 
           if (entry->expire_time - current_time <= 0)
             {
@@ -258,8 +257,8 @@ void ipv4_nat_entry_clear(FAR struct net_driver_s *dev)
 
   hashtable_for_every_safe(g_nat44_inbound, p, tmp, i)
     {
-      FAR struct ipv4_nat_entry *entry =
-        container_of(p, struct ipv4_nat_entry, hash_inbound);
+      FAR ipv4_nat_entry_t *entry =
+        container_of(p, ipv4_nat_entry_t, hash_inbound);
 
       if (net_ipv4addr_cmp(entry->external_ip, dev->d_ipaddr))
         {
@@ -287,7 +286,7 @@ void ipv4_nat_entry_clear(FAR struct net_driver_s *dev)
  *
  ****************************************************************************/
 
-FAR struct ipv4_nat_entry *
+FAR ipv4_nat_entry_t *
 ipv4_nat_inbound_entry_find(uint8_t protocol, in_addr_t external_ip,
                             uint16_t external_port, in_addr_t peer_ip,
                             uint16_t peer_port, bool refresh)
@@ -305,8 +304,8 @@ ipv4_nat_inbound_entry_find(uint8_t protocol, in_addr_t external_ip,
   hashtable_for_every_possible_safe(g_nat44_inbound, p, tmp,
                   ipv4_nat_inbound_key(external_ip, external_port, protocol))
     {
-      FAR struct ipv4_nat_entry *entry =
-        container_of(p, struct ipv4_nat_entry, hash_inbound);
+      FAR ipv4_nat_entry_t *entry =
+        container_of(p, ipv4_nat_entry_t, hash_inbound);
 
       /* Remove expired entries. */
 
@@ -365,7 +364,7 @@ ipv4_nat_inbound_entry_find(uint8_t protocol, in_addr_t external_ip,
  *
  ****************************************************************************/
 
-FAR struct ipv4_nat_entry *
+FAR ipv4_nat_entry_t *
 ipv4_nat_outbound_entry_find(FAR struct net_driver_s *dev, uint8_t protocol,
                              in_addr_t local_ip, uint16_t local_port,
                              in_addr_t peer_ip, uint16_t peer_port,
@@ -381,8 +380,8 @@ ipv4_nat_outbound_entry_find(FAR struct net_driver_s *dev, uint8_t protocol,
   hashtable_for_every_possible_safe(g_nat44_outbound, p, tmp,
                       ipv4_nat_outbound_key(local_ip, local_port, protocol))
     {
-      FAR struct ipv4_nat_entry *entry =
-        container_of(p, struct ipv4_nat_entry, hash_outbound);
+      FAR ipv4_nat_entry_t *entry =
+        container_of(p, ipv4_nat_entry_t, hash_outbound);
 
       /* Remove expired entries. */
 

--- a/net/nat/ipv6_nat.c
+++ b/net/nat/ipv6_nat.c
@@ -42,11 +42,11 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-static FAR struct ipv6_nat_entry *
+static FAR ipv6_nat_entry_t *
 ipv6_nat_inbound_internal(FAR struct ipv6_hdr_s *ipv6,
                           enum nat_manip_type_e manip_type);
 
-static FAR struct ipv6_nat_entry *
+static FAR ipv6_nat_entry_t *
 ipv6_nat_outbound_internal(FAR struct net_driver_s *dev,
                            FAR struct ipv6_hdr_s *ipv6,
                            enum nat_manip_type_e manip_type);
@@ -130,15 +130,15 @@ static void ipv6_nat_port_adjust(FAR uint16_t *l4chksum,
  ****************************************************************************/
 
 #ifdef CONFIG_NET_TCP
-static FAR struct ipv6_nat_entry *
+static FAR ipv6_nat_entry_t *
 ipv6_nat_inbound_tcp(FAR struct ipv6_hdr_s *ipv6, FAR struct tcp_hdr_s *tcp,
                      enum nat_manip_type_e manip_type)
 {
-  FAR uint16_t              *external_ip   = MANIP_IPADDR(ipv6, manip_type);
-  FAR uint16_t              *external_port = MANIP_PORT(tcp, manip_type);
-  FAR uint16_t              *peer_ip       = PEER_IPADDR(ipv6, manip_type);
-  FAR uint16_t              *peer_port     = PEER_PORT(tcp, manip_type);
-  FAR struct ipv6_nat_entry *entry         =
+  FAR uint16_t         *external_ip   = MANIP_IPADDR(ipv6, manip_type);
+  FAR uint16_t         *external_port = MANIP_PORT(tcp, manip_type);
+  FAR uint16_t         *peer_ip       = PEER_IPADDR(ipv6, manip_type);
+  FAR uint16_t         *peer_port     = PEER_PORT(tcp, manip_type);
+  FAR ipv6_nat_entry_t *entry         =
                  ipv6_nat_inbound_entry_find(IP_PROTO_TCP,
                                              external_ip, *external_port,
                                              peer_ip, *peer_port, true);
@@ -181,16 +181,16 @@ ipv6_nat_inbound_tcp(FAR struct ipv6_hdr_s *ipv6, FAR struct tcp_hdr_s *tcp,
  ****************************************************************************/
 
 #ifdef CONFIG_NET_UDP
-static FAR struct ipv6_nat_entry *
+static FAR ipv6_nat_entry_t *
 ipv6_nat_inbound_udp(FAR struct ipv6_hdr_s *ipv6, FAR struct udp_hdr_s *udp,
                      enum nat_manip_type_e manip_type)
 {
-  FAR uint16_t              *external_ip   = MANIP_IPADDR(ipv6, manip_type);
-  FAR uint16_t              *external_port = MANIP_PORT(udp, manip_type);
-  FAR uint16_t              *peer_ip       = PEER_IPADDR(ipv6, manip_type);
-  FAR uint16_t              *peer_port     = PEER_PORT(udp, manip_type);
-  FAR uint16_t              *udpchksum;
-  FAR struct ipv6_nat_entry *entry         =
+  FAR uint16_t         *external_ip   = MANIP_IPADDR(ipv6, manip_type);
+  FAR uint16_t         *external_port = MANIP_PORT(udp, manip_type);
+  FAR uint16_t         *peer_ip       = PEER_IPADDR(ipv6, manip_type);
+  FAR uint16_t         *peer_port     = PEER_PORT(udp, manip_type);
+  FAR uint16_t         *udpchksum;
+  FAR ipv6_nat_entry_t *entry         =
                  ipv6_nat_inbound_entry_find(IP_PROTO_UDP,
                                              external_ip, *external_port,
                                              peer_ip, *peer_port, true);
@@ -233,14 +233,14 @@ ipv6_nat_inbound_udp(FAR struct ipv6_hdr_s *ipv6, FAR struct udp_hdr_s *udp,
  ****************************************************************************/
 
 #ifdef CONFIG_NET_ICMPv6
-static FAR struct ipv6_nat_entry *
+static FAR ipv6_nat_entry_t *
 ipv6_nat_inbound_icmpv6(FAR struct ipv6_hdr_s *ipv6,
                         FAR struct icmpv6_hdr_s *icmpv6,
                         enum nat_manip_type_e manip_type)
 {
-  FAR uint16_t              *external_ip = MANIP_IPADDR(ipv6, manip_type);
-  FAR uint16_t              *peer_ip     = PEER_IPADDR(ipv6, manip_type);
-  FAR struct ipv6_nat_entry *entry;
+  FAR uint16_t         *external_ip = MANIP_IPADDR(ipv6, manip_type);
+  FAR uint16_t         *peer_ip     = PEER_IPADDR(ipv6, manip_type);
+  FAR ipv6_nat_entry_t *entry;
 
   switch (icmpv6->type)
     {
@@ -325,16 +325,16 @@ ipv6_nat_inbound_icmpv6(FAR struct ipv6_hdr_s *ipv6,
  ****************************************************************************/
 
 #ifdef CONFIG_NET_TCP
-static FAR struct ipv6_nat_entry *
+static FAR ipv6_nat_entry_t *
 ipv6_nat_outbound_tcp(FAR struct net_driver_s *dev,
                       FAR struct ipv6_hdr_s *ipv6, FAR struct tcp_hdr_s *tcp,
                       enum nat_manip_type_e manip_type)
 {
-  FAR uint16_t              *local_ip   = MANIP_IPADDR(ipv6, manip_type);
-  FAR uint16_t              *local_port = MANIP_PORT(tcp, manip_type);
-  FAR uint16_t              *peer_ip    = PEER_IPADDR(ipv6, manip_type);
-  FAR uint16_t              *peer_port  = PEER_PORT(tcp, manip_type);
-  FAR struct ipv6_nat_entry *entry;
+  FAR uint16_t         *local_ip   = MANIP_IPADDR(ipv6, manip_type);
+  FAR uint16_t         *local_port = MANIP_PORT(tcp, manip_type);
+  FAR uint16_t         *peer_ip    = PEER_IPADDR(ipv6, manip_type);
+  FAR uint16_t         *peer_port  = PEER_PORT(tcp, manip_type);
+  FAR ipv6_nat_entry_t *entry;
 
   /* Only create entry when it's the outermost packet (manip type is SRC). */
 
@@ -380,17 +380,17 @@ ipv6_nat_outbound_tcp(FAR struct net_driver_s *dev,
  ****************************************************************************/
 
 #ifdef CONFIG_NET_UDP
-static FAR struct ipv6_nat_entry *
+static FAR ipv6_nat_entry_t *
 ipv6_nat_outbound_udp(FAR struct net_driver_s *dev,
                       FAR struct ipv6_hdr_s *ipv6, FAR struct udp_hdr_s *udp,
                       enum nat_manip_type_e manip_type)
 {
-  FAR uint16_t              *local_ip   = MANIP_IPADDR(ipv6, manip_type);
-  FAR uint16_t              *local_port = MANIP_PORT(udp, manip_type);
-  FAR uint16_t              *peer_ip    = PEER_IPADDR(ipv6, manip_type);
-  FAR uint16_t              *peer_port  = PEER_PORT(udp, manip_type);
-  FAR uint16_t              *udpchksum;
-  FAR struct ipv6_nat_entry *entry;
+  FAR uint16_t         *local_ip   = MANIP_IPADDR(ipv6, manip_type);
+  FAR uint16_t         *local_port = MANIP_PORT(udp, manip_type);
+  FAR uint16_t         *peer_ip    = PEER_IPADDR(ipv6, manip_type);
+  FAR uint16_t         *peer_port  = PEER_PORT(udp, manip_type);
+  FAR uint16_t         *udpchksum;
+  FAR ipv6_nat_entry_t *entry;
 
   /* Only create entry when it's the outermost packet (manip type is SRC). */
 
@@ -435,15 +435,15 @@ ipv6_nat_outbound_udp(FAR struct net_driver_s *dev,
  ****************************************************************************/
 
 #ifdef CONFIG_NET_ICMPv6
-static FAR struct ipv6_nat_entry *
+static FAR ipv6_nat_entry_t *
 ipv6_nat_outbound_icmpv6(FAR struct net_driver_s *dev,
                          FAR struct ipv6_hdr_s *ipv6,
                          FAR struct icmpv6_hdr_s *icmpv6,
                          enum nat_manip_type_e manip_type)
 {
-  FAR uint16_t              *local_ip = MANIP_IPADDR(ipv6, manip_type);
-  FAR uint16_t              *peer_ip  = PEER_IPADDR(ipv6, manip_type);
-  FAR struct ipv6_nat_entry *entry;
+  FAR uint16_t         *local_ip = MANIP_IPADDR(ipv6, manip_type);
+  FAR uint16_t         *peer_ip  = PEER_IPADDR(ipv6, manip_type);
+  FAR ipv6_nat_entry_t *entry;
 
   switch (icmpv6->type)
     {
@@ -531,7 +531,7 @@ ipv6_nat_outbound_icmpv6(FAR struct net_driver_s *dev,
  *
  ****************************************************************************/
 
-static FAR struct ipv6_nat_entry *
+static FAR ipv6_nat_entry_t *
 ipv6_nat_inbound_internal(FAR struct ipv6_hdr_s *ipv6,
                           enum nat_manip_type_e manip_type)
 {
@@ -579,7 +579,7 @@ ipv6_nat_inbound_internal(FAR struct ipv6_hdr_s *ipv6,
  *
  ****************************************************************************/
 
-static FAR struct ipv6_nat_entry *
+static FAR ipv6_nat_entry_t *
 ipv6_nat_outbound_internal(FAR struct net_driver_s *dev,
                            FAR struct ipv6_hdr_s *ipv6,
                            enum nat_manip_type_e manip_type)
@@ -634,7 +634,7 @@ void ipv6_nat_inbound(FAR struct net_driver_s *dev,
   if (IFF_IS_NAT(dev->d_flags) &&
       NETDEV_IS_MY_V6ADDR(dev, ipv6->destipaddr))
     {
-      FAR struct ipv6_nat_entry *entry =
+      FAR ipv6_nat_entry_t *entry =
           ipv6_nat_inbound_internal(ipv6, NAT_MANIP_DST);
       if (!entry)
         {
@@ -676,7 +676,7 @@ int ipv6_nat_outbound(FAR struct net_driver_s *dev,
       !NETDEV_IS_MY_V6ADDR(dev, ipv6->srcipaddr) &&
       !NETDEV_IS_MY_V6ADDR(dev, ipv6->destipaddr))
     {
-      FAR struct ipv6_nat_entry *entry =
+      FAR ipv6_nat_entry_t *entry =
           ipv6_nat_outbound_internal(dev, ipv6, manip_type);
       if (manip_type == NAT_MANIP_SRC && !entry)
         {

--- a/net/nat/ipv6_nat.c
+++ b/net/nat/ipv6_nat.c
@@ -634,14 +634,7 @@ void ipv6_nat_inbound(FAR struct net_driver_s *dev,
   if (IFF_IS_NAT(dev->d_flags) &&
       NETDEV_IS_MY_V6ADDR(dev, ipv6->destipaddr))
     {
-      FAR ipv6_nat_entry_t *entry =
-          ipv6_nat_inbound_internal(ipv6, NAT_MANIP_DST);
-      if (!entry)
-        {
-          /* Inbound without entry is OK (e.g. towards NuttX itself), skip. */
-
-          return;
-        }
+      ipv6_nat_inbound_internal(ipv6, NAT_MANIP_DST);
     }
 }
 

--- a/net/nat/ipv6_nat_entry.c
+++ b/net/nat/ipv6_nat_entry.c
@@ -78,7 +78,7 @@ static inline uint32_t ipv6_nat_hash_key(const net_ipv6addr_t ip,
  *
  ****************************************************************************/
 
-static void ipv6_nat_entry_refresh(FAR struct ipv6_nat_entry *entry)
+static void ipv6_nat_entry_refresh(FAR ipv6_nat_entry_t *entry)
 {
   entry->expire_time = nat_expire_time(entry->protocol);
 }
@@ -103,14 +103,13 @@ static void ipv6_nat_entry_refresh(FAR struct ipv6_nat_entry *entry)
  *
  ****************************************************************************/
 
-static FAR struct ipv6_nat_entry *
+static FAR ipv6_nat_entry_t *
 ipv6_nat_entry_create(uint8_t protocol, const net_ipv6addr_t external_ip,
                       uint16_t external_port, const net_ipv6addr_t local_ip,
                       uint16_t local_port, const net_ipv6addr_t peer_ip,
                       uint16_t peer_port)
 {
-  FAR struct ipv6_nat_entry *entry =
-      kmm_malloc(sizeof(struct ipv6_nat_entry));
+  FAR ipv6_nat_entry_t *entry = kmm_malloc(sizeof(ipv6_nat_entry_t));
   if (entry == NULL)
     {
       nwarn("WARNING: Failed to allocate IPv6 NAT entry\n");
@@ -150,7 +149,7 @@ ipv6_nat_entry_create(uint8_t protocol, const net_ipv6addr_t external_ip,
  *
  ****************************************************************************/
 
-static void ipv6_nat_entry_delete(FAR struct ipv6_nat_entry *entry)
+static void ipv6_nat_entry_delete(FAR ipv6_nat_entry_t *entry)
 {
   ninfo("INFO: Removing NAT66 entry proto=%" PRIu8
         ", local=%04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x:%" PRIu16
@@ -204,8 +203,8 @@ static void ipv6_nat_reclaim_entry(int32_t current_time)
 
       hashtable_for_every_safe(g_nat66_inbound, p, tmp, i)
         {
-          FAR struct ipv6_nat_entry *entry =
-            container_of(p, struct ipv6_nat_entry, hash_inbound);
+          FAR ipv6_nat_entry_t *entry =
+            container_of(p, ipv6_nat_entry_t, hash_inbound);
 
           if (entry->expire_time - current_time <= 0)
             {
@@ -251,8 +250,8 @@ void ipv6_nat_entry_clear(FAR struct net_driver_s *dev)
 
   hashtable_for_every_safe(g_nat66_inbound, p, tmp, i)
     {
-      FAR struct ipv6_nat_entry *entry =
-        container_of(p, struct ipv6_nat_entry, hash_inbound);
+      FAR ipv6_nat_entry_t *entry =
+        container_of(p, ipv6_nat_entry_t, hash_inbound);
 
       if (NETDEV_IS_MY_V6ADDR(dev, entry->external_ip))
         {
@@ -280,7 +279,7 @@ void ipv6_nat_entry_clear(FAR struct net_driver_s *dev)
  *
  ****************************************************************************/
 
-FAR struct ipv6_nat_entry *
+FAR ipv6_nat_entry_t *
 ipv6_nat_inbound_entry_find(uint8_t protocol,
                             const net_ipv6addr_t external_ip,
                             uint16_t external_port,
@@ -300,8 +299,8 @@ ipv6_nat_inbound_entry_find(uint8_t protocol,
   hashtable_for_every_possible_safe(g_nat66_inbound, p, tmp,
                     ipv6_nat_hash_key(external_ip, external_port, protocol))
     {
-      FAR struct ipv6_nat_entry *entry =
-        container_of(p, struct ipv6_nat_entry, hash_inbound);
+      FAR ipv6_nat_entry_t *entry =
+        container_of(p, ipv6_nat_entry_t, hash_inbound);
 
       /* Remove expired entries. */
 
@@ -363,7 +362,7 @@ ipv6_nat_inbound_entry_find(uint8_t protocol,
  *
  ****************************************************************************/
 
-FAR struct ipv6_nat_entry *
+FAR ipv6_nat_entry_t *
 ipv6_nat_outbound_entry_find(FAR struct net_driver_s *dev, uint8_t protocol,
                              const net_ipv6addr_t local_ip,
                              uint16_t local_port,
@@ -381,8 +380,8 @@ ipv6_nat_outbound_entry_find(FAR struct net_driver_s *dev, uint8_t protocol,
   hashtable_for_every_possible_safe(g_nat66_outbound, p, tmp,
                           ipv6_nat_hash_key(local_ip, local_port, protocol))
     {
-      FAR struct ipv6_nat_entry *entry =
-        container_of(p, struct ipv6_nat_entry, hash_outbound);
+      FAR ipv6_nat_entry_t *entry =
+        container_of(p, ipv6_nat_entry_t, hash_outbound);
 
       /* Remove expired entries. */
 

--- a/net/nat/nat.h
+++ b/net/nat/nat.h
@@ -68,7 +68,7 @@
  * Public Types
  ****************************************************************************/
 
-struct ipv4_nat_entry
+struct ipv4_nat_entry_s
 {
   hash_node_t hash_inbound;
   hash_node_t hash_outbound;
@@ -100,7 +100,7 @@ struct ipv4_nat_entry
   int32_t    expire_time;    /* The expiration time of this entry. */
 };
 
-struct ipv6_nat_entry
+struct ipv6_nat_entry_s
 {
   hash_node_t    hash_inbound;
   hash_node_t    hash_outbound;
@@ -119,6 +119,9 @@ struct ipv6_nat_entry
 
   int32_t        expire_time;   /* The expiration time of this entry. */
 };
+
+typedef struct ipv4_nat_entry_s ipv4_nat_entry_t;
+typedef struct ipv6_nat_entry_s ipv6_nat_entry_t;
 
 /* NAT IP/Port manipulate type, to indicate whether to manipulate source or
  * destination IP/Port in a packet.
@@ -320,13 +323,13 @@ void ipv6_nat_entry_clear(FAR struct net_driver_s *dev);
  ****************************************************************************/
 
 #ifdef CONFIG_NET_NAT44
-FAR struct ipv4_nat_entry *
+FAR ipv4_nat_entry_t *
 ipv4_nat_inbound_entry_find(uint8_t protocol, in_addr_t external_ip,
                             uint16_t external_port, in_addr_t peer_ip,
                             uint16_t peer_port, bool refresh);
 #endif
 #ifdef CONFIG_NET_NAT66
-FAR struct ipv6_nat_entry *
+FAR ipv6_nat_entry_t *
 ipv6_nat_inbound_entry_find(uint8_t protocol,
                             const net_ipv6addr_t external_ip,
                             uint16_t external_port,
@@ -356,14 +359,14 @@ ipv6_nat_inbound_entry_find(uint8_t protocol,
  ****************************************************************************/
 
 #ifdef CONFIG_NET_NAT44
-FAR struct ipv4_nat_entry *
+FAR ipv4_nat_entry_t *
 ipv4_nat_outbound_entry_find(FAR struct net_driver_s *dev, uint8_t protocol,
                              in_addr_t local_ip, uint16_t local_port,
                              in_addr_t peer_ip, uint16_t peer_port,
                              bool try_create);
 #endif
 #ifdef CONFIG_NET_NAT66
-FAR struct ipv6_nat_entry *
+FAR ipv6_nat_entry_t *
 ipv6_nat_outbound_entry_find(FAR struct net_driver_s *dev, uint8_t protocol,
                              const net_ipv6addr_t local_ip,
                              uint16_t local_port,


### PR DESCRIPTION
## Summary
Patches included:
- net/nat: Rename `struct ipv*_nat_entry` to `ipv*_nat_entry_t`
  - I found `struct ipv*_nat_entry` is missing `_s` suffix, but the name is too long in some cases, so maybe `ipv*_nat_entry_t` could be better.
- net/nat: Remove unnecessary logic in inbound logic
  - Finish https://github.com/apache/nuttx/pull/12116#discussion_r1560880897

## Impact
Minor

## Testing
CI

