### PR TITLE
Improvements relating to SAMA5 TSD driver

### DIFF
--- a/arch/arm/src/sama5/sam_adc.c
+++ b/arch/arm/src/sama5/sam_adc.c
@@ -481,7 +481,9 @@ static void sam_adc_gain(struct sam_adc_s *priv);
 static void sam_adc_analogchange(struct sam_adc_s *priv);
 static void sam_adc_sequencer(struct sam_adc_s *priv);
 static void sam_adc_channels(struct sam_adc_s *priv);
+#if defined(CONFIG_SAMA5_ADC_PERIODIC_TRIG)
 static void sam_adc_trigperiod(struct sam_adc_s *priv, uint32_t period);
+#endif
 #endif
 
 /****************************************************************************
@@ -858,7 +860,7 @@ static int sam_adc_dmasetup(struct sam_adc_s *priv, uint8_t *buffer,
  *   None
  *
  ****************************************************************************/
-
+#if defined(CONFIG_SAMA5_ADC_PERIODIC_TRIG)
 static void sam_adc_trigperiod(struct sam_adc_s *priv, uint32_t period)
 {
   uint32_t trigper;
@@ -909,6 +911,7 @@ static void sam_adc_trigperiod(struct sam_adc_s *priv, uint32_t period)
   regval |=  ADC_TRGR_TRGPER(trigper);
   sam_adc_putreg(priv, SAM_ADC_TRGR, regval);
 }
+#endif
 
 /****************************************************************************
  * ADC interrupt handling
@@ -1103,7 +1106,11 @@ static int sam_adc_bind(struct adc_dev_s *dev,
 
 static void sam_adc_reset(struct adc_dev_s *dev)
 {
+#if defined(CONFIG_SAMA5_ADC_REGDEBUG) || \
+    defined(CONFIG_SAMA5_ADC_DMA)      || \
+    defined(CONFIG_SAMA5_ADC_TIOATRIG)
   struct sam_adc_s *priv = (struct sam_adc_s *)dev->ad_priv;
+#endif
   uint32_t regval;
 
   ainfo("Resetting..\n");

--- a/arch/arm/src/sama5/sam_tsd.h
+++ b/arch/arm/src/sama5/sam_tsd.h
@@ -40,14 +40,27 @@
 #  define CONFIG_SAMA5_TSD_RXP 6
 #endif
 
+#if !defined(CONFIG_SAMA5_ADC_SWTRIG) && \
+    !defined(CONFIG_SAMA5_ADC_PERIODIC_TRIG) && \
+    !defined(CONFIG_SAMA5_ADC_CONTINUOUS_TRIG)
+#  warning ADC trigger mode incompatible with TSD operation
+#endif
+
 #ifndef CONFIG_SAMA5_ADC_TRIGGER_PERIOD
 #  define CONFIG_SAMA5_ADC_TRIGGER_PERIOD 20000
 #endif
 
-/* Only allow Pendet triggering in limited circumstances */
+/* Only allow TSD trigger mode changes in limited circumstances.
+ * The TSD driver changes between pen detection and periodic triggers
+ * but this can upset normal non-tsd ADC operation, so we only allow the
+ * driver to change the mode if SW trigger mode is set.
+ * NB - this still might conflict of course so BEWARE!
+ */
 
-#if defined(CONFIG_SAMA5_ADC_SWTRIG)
-#  define SAMA5_TSD_PENDET_TRIG_ALLOWED
+#ifdef CONFIG_SAMA5_ADC_SWTRIG
+#  define SAMA5_TSD_TRIG_CHANGE_ALLOWED
+#else
+#  warning TSD will not be using Pen Detection interrupts
 #endif
 
 /* Touchscreen interrupt event sets
@@ -60,6 +73,7 @@
  *   ADC_SR_PENS            Pen detect Status (Not an interrupt)
  */
 
+#define ADC_TSD_PRESSINTS   (ADC_INT_XRDY | ADC_INT_YRDY | ADC_INT_PRDY | ADC_INT_PEN)
 #define ADC_TSD_CMNINTS     (ADC_INT_XRDY | ADC_INT_YRDY | ADC_INT_PRDY | ADC_INT_NOPEN)
 #define ADC_TSD_ALLINTS     (ADC_TSD_CMNINTS | ADC_INT_PEN)
 #define ADC_TSD_ALLSTATUS   (ADC_TSD_ALLINTS | ADC_SR_PENS)


### PR DESCRIPTION
## Summary
Ongoing work using the SAMA5(D2) touchscreen device demonstrated a number of shortcomings with the existing driver, as well as finding a few style errors.

The main issue was poor touch response as well as interactions with the ADC functions when used in conjunction with the TSD, so there are changes that improve that, although in the end not all may have been necessary but they do make the driver a little more flexible and more predictable in its behaviour.

## Impact
Intended that the changes are benign and would not affect anyone using the driver already in a negative way

## Testing
Custom board with a SAMA5D27C-D1G and 800x480 LCD with resistive touch.

