### PR TITLE
arch/risc-v: fix RV32 addrenv destroy issue

### DIFF
--- a/arch/risc-v/src/common/riscv_addrenv.c
+++ b/arch/risc-v/src/common/riscv_addrenv.c
@@ -539,7 +539,10 @@ int up_addrenv_destroy(arch_addrenv_t *addrenv)
   ptprev = (uintptr_t *)riscv_pgvaddr(addrenv->spgtables[ARCH_SPGTS - 1]);
   if (ptprev)
     {
-      for (i = 0; i < ENTRIES_PER_PGT; i++, vaddr += pgsize)
+      /* walk user space only */
+
+      i = (ARCH_SPGTS < 2) ? vaddr / pgsize : 0;
+      for (; i < ENTRIES_PER_PGT; i++, vaddr += pgsize)
         {
           ptlast = (uintptr_t *)riscv_pgvaddr(mmu_pte_to_paddr(ptprev[i]));
           if (ptlast)


### PR DESCRIPTION
## Summary
This patch fixes [issue 12123](https://github.com/apache/nuttx/issue/12123) and [issue 11803](https://github.com/apache/nuttx/issue/11803) for RV32, where the walk should be limited to user space only.

## Impact
RV32 kernel mode

## Testing
rv-virt/knsh32 with DEBUG_ASSERTIONS enabled.

