### PR TITLE
sensors/sensor.h: add devno field

### DIFF
--- a/drivers/sensors/sensor.c
+++ b/drivers/sensors/sensor.c
@@ -1094,6 +1094,7 @@ int sensor_register(FAR struct sensor_lowerhalf_s *lower, int devno)
 
   DEBUGASSERT(lower != NULL);
 
+  lower->devno = devno;
   snprintf(path, PATH_MAX, DEVNAME_FMT,
            g_sensor_info[lower->type].name,
            lower->uncalibrated ? DEVNAME_UNCAL : "",

--- a/include/nuttx/sensors/sensor.h
+++ b/include/nuttx/sensors/sensor.h
@@ -1031,6 +1031,10 @@ struct sensor_lowerhalf_s
 
   int type;
 
+  /* Device number */
+
+  int devno;
+
   /* The number of events that the circular buffer can hold.
    * This sensor circular buffer is used to slove issue that application
    * can't read sensor event in time. If this number of events is too large,


### PR DESCRIPTION
## Summary

- sensors/sensor.h: add devno field
add devno field so we can select the correct device when we have multiple sensors of the same type on the bus (e.g. SPI)

## Impact
none 

## Testing
ci
