### PR TITLE
video: Move video_format_s from video.h to v4l2_cap.c

### DIFF
--- a/drivers/video/v4l2_cap.c
+++ b/drivers/video/v4l2_cap.c
@@ -74,6 +74,15 @@ enum capture_waitend_cause_e
   WAITEND_CAUSE_STILLSTOP   = 2,
 };
 
+struct video_format_s
+{
+  uint16_t width;
+  uint16_t height;
+  uint32_t pixelformat;
+};
+
+typedef struct video_format_s video_format_t;
+
 struct capture_wait_capture_s
 {
   sem_t                dqbuf_wait_flg;

--- a/include/nuttx/video/video.h
+++ b/include/nuttx/video/video.h
@@ -60,15 +60,6 @@ extern "C"
 * Public Types
 *****************************************************************************/
 
-struct video_format_s
-{
-  uint16_t width;
-  uint16_t height;
-  uint32_t pixelformat;
-};
-
-typedef struct video_format_s video_format_t;
-
 struct v4l2_s
 {
   FAR const struct v4l2_ops_s      *vops;


### PR DESCRIPTION
## Summary

since it is only used in v4l2_cap.c.

## Impact

minor

## Testing

ci