### PR TITLE
tools/configure.sh: support listing configs for board

### DIFF
--- a/tools/configure.sh
+++ b/tools/configure.sh
@@ -24,7 +24,7 @@ TOPDIR="${WD}/.."
 MAKECMD="make"
 USAGE="
 
-USAGE: ${0} [-E] [-e] [-l|m|c|g|n|B] [L] [-a <app-dir>] <board-selection> [make-opts]
+USAGE: ${0} [-E] [-e] [-l|m|c|g|n|B] [-L [boardname]] [-a <app-dir>] <board-selection> [make-opts]
 
 Where:
   -E enforces distclean if already configured.
@@ -70,7 +70,13 @@ unset distclean
 
 function dumpcfgs
 {
-  configlist=`find ${TOPDIR}/boards -name defconfig`
+  if [ -n "$1" ]; then
+    local boards=$(find ${TOPDIR}/boards -mindepth 3 -maxdepth 3 -type d -name "*$1*")
+    [ -z "$boards" ] && { echo board "$1" not found; return ;}
+    configlist=$(find $boards -name defconfig -type f)
+  else
+    configlist=$(find ${TOPDIR}/boards -name defconfig -type f)
+  fi
   for defconfig in ${configlist}; do
     config=`dirname ${defconfig} | sed -e "s,${TOPDIR}/boards/,,g"`
     boardname=`echo ${config} | cut -d'/' -f3`
@@ -109,7 +115,8 @@ while [ ! -z "$1" ]; do
     exit 0
     ;;
   -L )
-    dumpcfgs
+    shift
+    dumpcfgs $1
     exit 0
     ;;
   *)


### PR DESCRIPTION
## Summary
This patch supports listing configs for a given board like

- `tools/configure.sh -L sama5`
- `tools/configure.sh -L rv-virt`
- `tools/configure.sh -L virt`

## Impact
None

## Testing
CI checks
