### PR TITLE
driver: There is no need to use sched_[un]lock

### DIFF
--- a/drivers/bch/bchdev_unregister.c
+++ b/drivers/bch/bchdev_unregister.c
@@ -91,13 +91,6 @@ int bchdev_unregister(FAR const char *chardev)
       return ret;
     }
 
-  /* Lock out context switches.  If there are no other references
-   * and no context switches, then we can assume that we can safely
-   * teardown the driver.
-   */
-
-  sched_lock();
-
   /* Check if the internal structure is non-busy (we hold one reference). */
 
   if (bch->refs > 1)
@@ -117,8 +110,6 @@ int bchdev_unregister(FAR const char *chardev)
       goto errout_with_lock;
     }
 
-  sched_unlock();
-
   /* Release the internal structure */
 
   bch->refs = 0;
@@ -126,6 +117,5 @@ int bchdev_unregister(FAR const char *chardev)
 
 errout_with_lock:
   bch->refs--;
-  sched_unlock();
   return ret;
 }

--- a/drivers/ioexpander/pcf8574.c
+++ b/drivers/ioexpander/pcf8574.c
@@ -939,7 +939,6 @@ static void pcf8574_irqworker(void *arg)
 
   /* Re-start the poll timer */
 
-  sched_lock();
   ret = wd_start(&priv->wdog, PCF8574_POLLDELAY,
                  pcf8574_poll_expiry, (wdparm_t)priv);
   if (ret < 0)
@@ -951,10 +950,6 @@ static void pcf8574_irqworker(void *arg)
   /* Re-enable interrupts */
 
   priv->config->enable(priv->config, true);
-
-#ifdef CONFIG_PCF8574_INT_POLL
-  sched_unlock();
-#endif
 }
 #endif
 

--- a/drivers/ioexpander/tca64xx.c
+++ b/drivers/ioexpander/tca64xx.c
@@ -1212,7 +1212,6 @@ errout_with_restart:
 
   /* Re-start the poll timer */
 
-  sched_lock();
   ret = wd_start(&priv->wdog, TCA64XX_POLLDELAY,
                  tca64_poll_expiry, (wdparm_t)priv);
   if (ret < 0)
@@ -1224,10 +1223,6 @@ errout_with_restart:
   /* Re-enable interrupts */
 
   priv->config->enable(priv->config, true);
-
-#ifdef CONFIG_TCA64XX_INT_POLL
-  sched_unlock();
-#endif
 }
 #endif
 

--- a/drivers/syslog/syslog_device.c
+++ b/drivers/syslog/syslog_device.c
@@ -313,13 +313,6 @@ static int syslog_dev_outputready(FAR struct syslog_dev_s *syslog_dev)
           return -EAGAIN; /* Can't access the SYSLOG now... maybe next time? */
         }
 
-      /* NOTE that the scheduler is locked.  That is because we do not have
-       * fully initialized mutex capability until the SYSLOG device is
-       * successfully initialized.
-       */
-
-      sched_lock();
-
       /* Case (6) */
 
       if (syslog_dev->sl_state == SYSLOG_FAILURE)
@@ -352,12 +345,10 @@ static int syslog_dev_outputready(FAR struct syslog_dev_s *syslog_dev)
                                 (int)syslog_dev->sl_mode);
           if (ret < 0)
             {
-              sched_unlock();
               return ret;
             }
         }
 
-      sched_unlock();
       DEBUGASSERT(syslog_dev->sl_state == SYSLOG_OPENED);
     }
 
@@ -758,7 +749,6 @@ void syslog_dev_uninitialize(FAR struct syslog_channel_s *channel)
 
   /* Attempt to flush any buffered data. */
 
-  sched_lock();
   syslog_dev_flush(channel);
 
   /* Close the detached file instance, and destroy the mutex. These are
@@ -787,5 +777,4 @@ void syslog_dev_uninitialize(FAR struct syslog_channel_s *channel)
   /* Free the channel structure */
 
   kmm_free(syslog_dev);
-  sched_unlock();
 }

--- a/drivers/syslog/syslog_filechannel.c
+++ b/drivers/syslog/syslog_filechannel.c
@@ -167,6 +167,7 @@ end:
 FAR struct syslog_channel_s *syslog_file_channel(FAR const char *devpath)
 {
   FAR struct syslog_channel_s *file_channel;
+  irqstate_t flags;
 
   /* Reset the default SYSLOG channel so that we can safely modify the
    * SYSLOG device.  This is an atomic operation and we should be safe
@@ -176,7 +177,7 @@ FAR struct syslog_channel_s *syslog_file_channel(FAR const char *devpath)
    * important debug output is lost while we futz with the channels.
    */
 
-  sched_lock();
+  flags = enter_critical_section();
 
   /* Rotate the log file, if needed. */
 
@@ -209,7 +210,7 @@ FAR struct syslog_channel_s *syslog_file_channel(FAR const char *devpath)
     }
 
 errout_with_lock:
-  sched_unlock();
+  leave_critical_section(flags);
   return file_channel;
 }
 


### PR DESCRIPTION
## Summary

purpose:
1 sched_lock is very time-consuming, and reducing its invocations can improve performance.
2 sched_lock is prone to misuse, and narrowing its scope of use is to prevent people from referencing incorrect code and using it

test:
We can use qemu for testing.
compiling
make distclean -j20; ./tools/configure.sh -l qemu-armv8a:nsh_smp ;make -j20
running
qemu-system-aarch64 -cpu cortex-a53 -smp 4 -nographic -machine virt,virtualization=on,gic-version=3 -net none -chardev stdio,id=con,mux=on -serial chardev:con -mon chardev=con,mode=readline -kernel ./nuttx

We have also tested this patch on other ARM hardware platforms.

## Impact

## Testing

