### PR TITLE
sched_lock: we can remove these sched_lock,

### DIFF
--- a/drivers/syslog/syslog_intbuffer.c
+++ b/drivers/syslog/syslog_intbuffer.c
@@ -249,6 +249,7 @@ int syslog_add_intbuffer(int ch)
 int syslog_flush_intbuffer(bool force)
 {
   syslog_putc_t putfunc;
+  irqstate_t flags;
   int ch;
   int i;
 
@@ -256,7 +257,7 @@ int syslog_flush_intbuffer(bool force)
    * concurrent modification by other tasks.
    */
 
-  sched_lock();
+  flags = enter_critical_section();
 
   do
     {
@@ -293,7 +294,7 @@ int syslog_flush_intbuffer(bool force)
     }
   while (ch != EOF);
 
-  sched_unlock();
+  leave_critical_section(flags);
 
   return ch;
 }

--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -536,8 +536,6 @@ void _assert(FAR const char *filename, int linenum,
 
   flags = enter_critical_section();
 
-  sched_lock();
-
   /* try to save current context if regs is null */
 
   if (regs == NULL)
@@ -671,8 +669,6 @@ void _assert(FAR const char *filename, int linenum,
         }
 #endif
     }
-
-  sched_unlock();
 
   leave_critical_section(flags);
 }


### PR DESCRIPTION
## Summary

purpose:
1 sched_lock is very time-consuming, and reducing its invocations can improve performance.
2 sched_lock is prone to misuse, and narrowing its scope of use is to prevent people from referencing incorrect code and using it

test:
We can use qemu for testing.
compiling
make distclean -j20; ./tools/configure.sh -l qemu-armv8a:nsh_smp ;make -j20
running
qemu-system-aarch64 -cpu cortex-a53 -smp 4 -nographic -machine virt,virtualization=on,gic-version=3 -net none -chardev stdio,id=con,mux=on -serial chardev:con -mon chardev=con,mode=readline -kernel ./nuttx

We have also tested this patch on other ARM hardware platforms.
## Impact

## Testing

