### PR TITLE
sched/wqueue: There is no need to use sched_[un]lock

### DIFF
--- a/sched/wqueue/kwork_inherit.c
+++ b/sched/wqueue/kwork_inherit.c
@@ -219,7 +219,6 @@ void lpwork_boostpriority(uint8_t reqprio)
   /* Prevent context switches until we get the priorities right */
 
   flags = enter_critical_section();
-  sched_lock();
 
   /* Adjust the priority of every worker thread */
 
@@ -228,7 +227,6 @@ void lpwork_boostpriority(uint8_t reqprio)
       lpwork_boostworker(lpwork().worker[wndx].pid, reqprio);
     }
 
-  sched_unlock();
   leave_critical_section(flags);
 }
 
@@ -265,7 +263,6 @@ void lpwork_restorepriority(uint8_t reqprio)
   /* Prevent context switches until we get the priorities right */
 
   flags = enter_critical_section();
-  sched_lock();
 
   /* Adjust the priority of every worker thread */
 
@@ -274,7 +271,6 @@ void lpwork_restorepriority(uint8_t reqprio)
       lpwork_restoreworker(lpwork().worker[wndx].pid, reqprio);
     }
 
-  sched_unlock();
   leave_critical_section(flags);
 }
 


### PR DESCRIPTION
## Summary
purpose:
1 sched_lock is very time-consuming, and reducing its invocations can improve performance.
2 sched_lock is prone to misuse, and narrowing its scope of use is to prevent people from referencing incorrect code and using it

test:
We can use qemu for testing.
compiling
make distclean -j20; ./tools/configure.sh -l qemu-armv8a:nsh_smp ;make -j20
running
qemu-system-aarch64 -cpu cortex-a53 -smp 4 -nographic -machine virt,virtualization=on,gic-version=3 -net none -chardev stdio,id=con,mux=on -serial chardev:con -mon chardev=con,mode=readline -kernel ./nuttx

We have also tested this patch on other ARM hardware platforms.

## Impact

## Testing

