### PR TITLE
arch/arm64_cache.c: Fix cache invalidation

### DIFF
--- a/arch/arm64/src/common/arm64_cache.c
+++ b/arch/arm64/src/common/arm64_cache.c
@@ -117,12 +117,6 @@ static inline int arm64_dcache_range(uintptr_t start_addr,
   if ((start_addr & (line_size - 1)) != 0)
     {
       start_addr = LINE_ALIGN_DOWN(start_addr, line_size);
-
-      if (op == CACHE_OP_INVD)
-        {
-          dc_ops("civac", start_addr);
-          start_addr += line_size;
-        }
     }
 
   while (start_addr < end_addr)
@@ -137,14 +131,7 @@ static inline int arm64_dcache_range(uintptr_t start_addr,
 
         case CACHE_OP_INVD:
           {
-            if (start_addr + line_size <= end_addr)
-              {
-                dc_ops("ivac", start_addr);
-              }
-            else
-              {
-                dc_ops("civac", start_addr);
-              }
+            dc_ops("ivac", start_addr);
             break;
           }
 


### PR DESCRIPTION
## Summary
When a cache invalidation is requested, a cache clean + invalidate must _NOT_ be performed, as this can result in data loss, corruption or most likely both.

There is a separate cache flush command, which should be used instead when a cache clean + invalidate is needed.

## Impact
Remove implicit cache clean when invalidating cache
## Testing
imx93
