### PR TITLE
tools/uncrustify: disable leading space removal for block comment

### DIFF
--- a/tools/uncrustify.cfg
+++ b/tools/uncrustify.cfg
@@ -104,7 +104,7 @@ cmt_star_cont                  = true    # Add star to comment continuation
 cmt_sp_before_star_cont        = 0       # was 1. One space before star on subsequent comment lines
                                          # The value 1 added an extra space, indenting by 2.
 cmt_sp_after_star_cont         = 1       # One space after star on subsequent comment lines
-cmt_multi_check_last           = true    # Multi-line comments with a '*' lead, remove leading spaces
+cmt_multi_check_last           = false   # Multi-line comments with a '*' lead, remove leading spaces
 # cmt_insert_file_header                 # filename containing the file header
 # cmt_insert_file_footer                 # filename containing the file footer
 # cmt_insert_func_header                 # filename containing the function header


### PR DESCRIPTION

## Summary

This patch disables leading spaces removal for block comments so that to avoid changing well-formatted blocking comments.

Without this well-formmated leading blocking comments of C source files will be changed unwantedly as the leading spacs are removed, based on test use with uncrustify 0.72.0+dfsg1-2 on Ubuntu.

## Impact
code formatter

## Testing
CI checks

