### PR TITLE
arch/kconfig: revise kernel mapping configs

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -722,6 +722,10 @@ config ARCH_VMA_MAPPING
 	bool "Support runtime memory mapping into SHM area"
 	default n
 
+config ARCH_KVMA_MAPPING
+	bool
+	default n
+
 config ARCH_SHM_VBASE
 	hex "Shared memory base"
 	depends on ARCH_VMA_MAPPING
@@ -730,7 +734,7 @@ config ARCH_SHM_VBASE
 
 config ARCH_KMAP_VBASE
 	hex "Kernel dynamic virtual mappings base"
-	depends on MM_KMAP
+	depends on ARCH_KVMA_MAPPING
 	---help---
 		The virtual address of the beginning of the kernel dynamic mapping
 		region.
@@ -792,7 +796,7 @@ endif # ARCH_VMA_MAPPING
 config ARCH_KMAP_NPAGES
 	int "Max kernel dynamic mapping pages"
 	default 1
-	depends on MM_KMAP
+	depends on ARCH_KVMA_MAPPING
 	---help---
 		The maximum amount of pages that a kernel can use for dynamically
 		mapping physical pages to itself.

--- a/mm/Kconfig
+++ b/mm/Kconfig
@@ -198,6 +198,7 @@ config MM_KMAP
 	bool "Support for dynamic kernel virtual mappings"
 	default n
 	depends on MM_PGALLOC && BUILD_KERNEL
+	select ARCH_KVMA_MAPPING
 	---help---
 		Build support for dynamically mapping pages from the page pool into
 		kernel virtual memory. This includes pages that are already mapped


### PR DESCRIPTION

## Summary

This treats kernel space virtual memory allocation based mappings similar to that of the user space:
- Add ARCH_KVMA_MAPPING to guard kernel mapping configs.
- Set dependency from MM_KMAP to ARCH_KVMA_MAPPING, as per commit 70de321de3f. 

## Impact
None

## Testing
CI checks
