### PR TITLE
boards/arm64/imx9/imx93-evk/src/imx9_pwm.c: Fix initialization of TPM…

### DIFF
--- a/boards/arm64/imx9/imx93-evk/src/imx9_pwm.c
+++ b/boards/arm64/imx9/imx93-evk/src/imx9_pwm.c
@@ -96,7 +96,7 @@ int imx9_pwm_setup(void)
 #endif
 
 #ifdef CONFIG_IMX9_TPM3_PWM
-  lower_half = imx9_flexio_pwm_init(PWM_TPM3);
+  lower_half = imx9_tpm_pwm_init(PWM_TPM3);
 
   if (lower_half)
     {


### PR DESCRIPTION
… PWM registration

Fix typo causing TPM PWM not initializing on EVK board

## Summary

Small error correction to EVK board initialization logic

## Impact

i.MX93EVK only

## Testing

Tested on the EVK board
