### PR TITLE
boards/stm32: Fix ds1307 and move it to stm32/common

### DIFF
--- a/boards/arm/stm32/common/include/stm32_ds1307.h
+++ b/boards/arm/stm32/common/include/stm32_ds1307.h
@@ -1,0 +1,83 @@
+/****************************************************************************
+ * boards/arm/stm32/common/include/stm32_ds1307.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __BOARDS_ARM_STM32_COMMON_INCLUDE_STM32_DS1307_H
+#define __BOARDS_ARM_STM32_COMMON_INCLUDE_STM32_DS1307_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Type Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Inline Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_ds1307_initialize
+ *
+ * Description:
+ *   Initialize and configure the DS1307 RTC
+ *
+ * Input Parameters:
+ *   busno - The I2C bus number where DS1307 is connected.
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int board_ds1307_initialize(int busno);
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __BOARDS_ARM_STM32_COMMON_INCLUDE_STM32_DS1307_H */

--- a/boards/arm/stm32/common/src/Make.defs
+++ b/boards/arm/stm32/common/src/Make.defs
@@ -60,6 +60,10 @@ ifeq ($(CONFIG_LCD_SSD1306),y)
   CSRCS += stm32_ssd1306.c
 endif
 
+ifeq ($(CONFIG_RTC_DS1307),y)
+  CSRCS += stm32_ds1307.c
+endif
+
 ifeq ($(CONFIG_SENSORS_LM75),y)
   CSRCS += stm32_lm75.c
 endif

--- a/boards/arm/stm32/stm32f4discovery/src/Make.defs
+++ b/boards/arm/stm32/stm32f4discovery/src/Make.defs
@@ -88,10 +88,6 @@ ifeq ($(CONFIG_RGBLED),y)
 CSRCS += stm32_rgbled.c
 endif
 
-ifeq ($(CONFIG_RTC_DS1307),y)
-CSRCS += stm32_ds1307.c
-endif
-
 ifeq ($(CONFIG_PWM),y)
 CSRCS += stm32_pwm.c
 endif

--- a/boards/arm/stm32/stm32f4discovery/src/stm32_bringup.c
+++ b/boards/arm/stm32/stm32f4discovery/src/stm32_bringup.c
@@ -76,6 +76,10 @@
 #include "stm32_bmp180.h"
 #endif
 
+#ifdef CONFIG_RTC_DS1307
+#include "stm32_ds1307.h"
+#endif
+
 #ifdef CONFIG_SENSORS_MS56XX
 #include "stm32_ms5611.h"
 #endif
@@ -454,7 +458,7 @@ int stm32_bringup(void)
 #endif
 
 #ifdef CONFIG_RTC_DS1307
-  ret = stm32_ds1307_init();
+  ret = board_ds1307_initialize(1);
   if (ret < 0)
     {
       syslog(LOG_ERR, "Failed to initialize DS1307 RTC driver: %d\n", ret);

--- a/boards/arm/stm32/stm32f4discovery/src/stm32_ds1307.c
+++ b/boards/arm/stm32/stm32f4discovery/src/stm32_ds1307.c
@@ -87,17 +87,6 @@ int stm32_ds1307_init(void)
           return -ENODEV;
         }
 
-#ifdef CONFIG_I2C_DRIVER
-      /* Register the I2C to get the "nsh> i2c bus" command working */
-
-      ret = i2c_register(i2c, DS1307_I2C_BUS);
-      if (ret < 0)
-        {
-          rtcerr("ERROR: Failed to register I2C%d driver: %d\n", bus, ret);
-          return -ENODEV;
-        }
-#endif
-
       /* Synchronize the system time to the RTC time */
 
       clock_synchronize(NULL);

--- a/boards/arm/stm32/stm32f4discovery/src/stm32f4discovery.h
+++ b/boards/arm/stm32/stm32f4discovery/src/stm32f4discovery.h
@@ -523,18 +523,6 @@ int stm32_max7219init(const char *devpath);
 #endif
 
 /****************************************************************************
- * Name: stm32_ds1307_init
- *
- * Description:
- *   Initialize and register the DS1307 RTC
- *
- ****************************************************************************/
-
-#ifdef CONFIG_RTC_DS1307
-int stm32_ds1307_init(void);
-#endif
-
-/****************************************************************************
  * Name: stm32_st7032init
  *
  * Description:


### PR DESCRIPTION
## Summary
Fix ds1307 and move it to stm32/common
## Impact
Other boards will be able to use it.
## Testing
Only compilation
