### PR TITLE
simwifi:Modify the existing implementation of the simwifi script

### DIFF
--- a/arch/sim/src/sim/sim_wifidriver.c
+++ b/arch/sim/src/sim/sim_wifidriver.c
@@ -56,7 +56,7 @@
 
 #define HOSTAPD_CTRL_PATH " -p /var/run/simwifi/hostapd "
 #define HOSTAPD_CLI "/usr/bin/sudo /usr/sbin/hostapd_cli "
-#define SIMWIFI_FILE "tools/simwifi/sim_wifi.sh "
+#define SIMWIFI_FILE "/usr/bin/sim_wifi.sh "
 
 #define WPA_SET_NETWORK(wifidev, fmt, args...) \
     set_cmd(wifidev,"set_network %d "fmt, (wifidev)->network_id, ##args)
@@ -1360,8 +1360,8 @@ static int wifidriver_set_mode(struct sim_netdev_s *wifidev,
       /* Start the sta config, including wpa_supplicant and udhcpc. */
 
       ret = host_system(NULL, 0,
-                        "/usr/bin/sudo %s/"SIMWIFI_FILE" start_sta %s",
-                        TOPDIR, wifidev->host_ifname);
+                        "/usr/bin/sudo "SIMWIFI_FILE" start_sta %s",
+                        wifidev->host_ifname);
       if (ret == 0)
         {
           /* Check the network number, if no network, should add new network.
@@ -1389,8 +1389,8 @@ static int wifidriver_set_mode(struct sim_netdev_s *wifidev,
       /* Start the hostapd. */
 
       ret = host_system(NULL, 0,
-                        "/usr/bin/sudo %s/"SIMWIFI_FILE" start_ap %s",
-                        TOPDIR, wifidev->host_ifname);
+                        "/usr/bin/sudo "SIMWIFI_FILE" start_ap %s",
+                        wifidev->host_ifname);
 
       break;
     default:

--- a/tools/simwifi/sim_wifi.sh
+++ b/tools/simwifi/sim_wifi.sh
@@ -520,10 +520,18 @@ init()
 
 clean()
 {
+  [ -z "$1" ] && {
+    echo "Missing the default wan interface."
+    exit -1
+  }
+
   recovery_to_init
 
   cur_mode=$(get_var mode $DEFCONF_FILE)
   [ "$cur_mode" = "hwsim" ] &&  modprobe -r mac80211_hwsim
+
+  echo "defwan:$1" > $DEFCONF_FILE
+  [ -n "$1" -a  -n "$(ifconfig | grep $1)" ] && stop_bridge $1
 
   rm -fr $RUN_DIR
   rm -f $UDHCPC_SCRIPT
@@ -532,7 +540,7 @@ clean()
 usage()
 {
   echo "$(basename $SOURCE) (rename <old> <new> |"
-  echo -e "\t init <wan> <mode> |clean |"
+  echo -e "\t init <wan> <mode> |clean <wan> |"
   echo -e "\t start_wpa <wlan0> |stop_wpa |"
   echo -e "\t start_hostapd <wlan0> |stop_hostapd |"
   echo -e "\t start_udhcpc <wlan0> |stop_udhcpc |"
@@ -552,7 +560,7 @@ get_script_path $0
 
 case $1 in
   init) init $2 $3;;
-  clean) clean;;
+  clean) clean $2;;
   start_bridge) start_bridge $2;;
   stop_bridge) stop_bridge $2;;
   start_hwsim)  start_hwsim $2 $3;;

--- a/tools/simwifi/sim_wifi.sh
+++ b/tools/simwifi/sim_wifi.sh
@@ -23,6 +23,7 @@
 
 NUTTX_BR_IF="nuttx0"
 RUN_DIR="/var/run/simwifi"
+LINK_DIR="/usr/bin"
 CUR_DIR=""
 DBG_LEVEL=1
 
@@ -509,6 +510,8 @@ init()
 
   init_env
 
+  ln -s $CUR_DIR/sim_wifi.sh $LINK_DIR/sim_wifi.sh
+
   echo "defwan:$1" > $DEFCONF_FILE
   [ -n "$1" -a  -n "$(ifconfig | grep $1)" ] && start_bridge $1
 
@@ -526,6 +529,8 @@ clean()
   }
 
   recovery_to_init
+
+  rm $LINK_DIR/sim_wifi.sh
 
   cur_mode=$(get_var mode $DEFCONF_FILE)
   [ "$cur_mode" = "hwsim" ] &&  modprobe -r mac80211_hwsim


### PR DESCRIPTION
## Summary
The first patch is to close the nuttx0 node when executing the clean command（sudo ./tools/simwifi/sim_wifi.sh clean eno1）
The second patch is to solve the problem of not being able to find the  simwifi script for non native compiled versions
## Impact
simwifi
## Testing
**The first patch test case**：

wangchen@wangchen-OptiPlex-7080:~/complie/vela_dev_0415/nuttx$ sudo ./tools/simwifi/sim_wifi.sh init eno1 hwsim
init env
start bridge to eno1
[set_state] new state:SW_INIT
state:SW_INIT wlan_if:, br_if:nuttx0 wan_if:eno1
wangchen@wangchen-OptiPlex-7080:~/complie/vela_dev_0415/nuttx$ ifconfig
eno1: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 10.221.99.130  netmask 255.255.224.0  broadcast 10.221.127.255
        inet6 fe80::862:7440:ebaa:de33  prefixlen 64  scopeid 0x20<link>
        ether b0:7b:25:25:67:44  txqueuelen 1000  (以太网)
        RX packets 135763003  bytes 183390753362 (183.3 GB)
        RX errors 0  dropped 18  overruns 0  frame 0
        TX packets 9776540  bytes 2750072233 (2.7 GB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
        device interrupt 16  memory 0x91200000-91220000  

lo: flags=73<UP,LOOPBACK,RUNNING>  mtu 65536
        inet 127.0.0.1  netmask 255.0.0.0
        inet6 ::1  prefixlen 128  scopeid 0x10<host>
        loop  txqueuelen 1000  (本地环回)
        RX packets 769964  bytes 114887513 (114.8 MB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 769964  bytes 114887513 (114.8 MB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

nuttx0: flags=4099<UP,BROADCAST,MULTICAST>  mtu 1500
        inet 10.0.1.1  netmask 255.255.255.0  broadcast 0.0.0.0
        inet6 fc00::1  prefixlen 112  scopeid 0x0<global>
        inet6 fe80::821:4fff:fe73:1d34  prefixlen 64  scopeid 0x20<link>
        ether 3e:65:b1:26:a7:11  txqueuelen 1000  (以太网)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 0  bytes 0 (0.0 B)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

wlan0: flags=-28669<UP,BROADCAST,MULTICAST,DYNAMIC>  mtu 1500
        ether 02:00:00:00:00:00  txqueuelen 1000  (以太网)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 0  bytes 0 (0.0 B)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

wlan1: flags=-28669<UP,BROADCAST,MULTICAST,DYNAMIC>  mtu 1500
        ether 02:00:00:00:01:00  txqueuelen 1000  (以太网)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 0  bytes 0 (0.0 B)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

wangchen@wangchen-OptiPlex-7080:~/complie/vela_dev_0415/nuttx$ sudo ./tools/simwifi/sim_wifi.sh clean eno1
[recovery_to_init] cur_s:SW_INIT
stop bridge to eno1
Warning: The nuttx0 will be deleted!
wangchen@wangchen-OptiPlex-7080:~/complie/vela_dev_0415/nuttx$ ifconfig
eno1: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 10.221.99.130  netmask 255.255.224.0  broadcast 10.221.127.255
        inet6 fe80::862:7440:ebaa:de33  prefixlen 64  scopeid 0x20<link>
        ether b0:7b:25:25:67:44  txqueuelen 1000  (以太网)
        RX packets 135765156  bytes 183391402375 (183.3 GB)
        RX errors 0  dropped 18  overruns 0  frame 0
        TX packets 9777331  bytes 2750390258 (2.7 GB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
        device interrupt 16  memory 0x91200000-91220000  

lo: flags=73<UP,LOOPBACK,RUNNING>  mtu 65536
        inet 127.0.0.1  netmask 255.0.0.0
        inet6 ::1  prefixlen 128  scopeid 0x10<host>
        loop  txqueuelen 1000  (本地环回)
        RX packets 770105  bytes 114909481 (114.9 MB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 770105  bytes 114909481 (114.9 MB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

wangchen@wangchen-OptiPlex-7080:~/complie/vela_dev_0415/nuttx$ 
**The second patch test case**
before
![image](https://github.com/apache/nuttx/assets/129070278/6cd35f58-3bc7-4bd4-9522-a4902129a5c0)
after
![image](https://github.com/apache/nuttx/assets/129070278/aa15bc70-de31-4333-9006-4f29b6332e41)



