### PR TITLE
imx9_boot.c: Add initialization of pin interrupts

### DIFF
--- a/arch/arm64/src/imx9/imx9_boot.c
+++ b/arch/arm64/src/imx9/imx9_boot.c
@@ -37,8 +37,10 @@
 #include "arm64_arch.h"
 #include "arm64_internal.h"
 #include "arm64_mmu.h"
+
 #include "imx9_boot.h"
 #include "imx9_serial.h"
+#include "imx9_gpio.h"
 #include "imx9_lowputc.h"
 
 /****************************************************************************
@@ -101,6 +103,12 @@ void arm64_chip_boot(void)
 
 #ifdef CONFIG_IMX9_LPUART
   imx9_lowsetup();
+#endif
+
+  /* Initialize pin interrupt support */
+
+#ifdef CONFIG_IMX9_GPIO_IRQ
+  imx9_gpioirq_initialize();
 #endif
 
   /* Perform board-specific device initialization. This would include

--- a/arch/arm64/src/imx9/imx9_gpioirq.c
+++ b/arch/arm64/src/imx9/imx9_gpioirq.c
@@ -236,8 +236,8 @@ int imx9_gpioirq_enable(gpio_pinset_t pinset)
 {
   uint32_t  port = (pinset & GPIO_PORT_MASK) >> GPIO_PORT_SHIFT;
   uint32_t  pin  = (pinset & GPIO_PIN_MASK) >> GPIO_PIN_SHIFT;
-  uint32_t  icr  = (pinset & GPIO_INTCFG_MASK) >> GPIO_INTCFG_SHIFT;
   uint32_t  both = (pinset & GPIO_INTBOTHCFG_MASK) >> GPIO_INTBOTHCFG_SHIFT;
+  uint32_t  icr  = (pinset & GPIO_INTCFG_MASK);
   uint32_t  regval;
   uintptr_t regaddr;
 


### PR DESCRIPTION
## Summary
Add initialization of pin interrupt support to generic platform code.

Also, fix a bug in enabling the pin interrupt. The value of pinset.icr should not be shifted, as when it is tested below against e.g. GPIO_INT_LOWLEVEL which is already shifted to the correct position.
## Impact
Pin interrupts are initialized.
## Testing
imx93-evk
