### PR TITLE
boards/stm32: Add ds1307 to CMake build

### DIFF
--- a/boards/arm/stm32/common/src/CMakeLists.txt
+++ b/boards/arm/stm32/common/src/CMakeLists.txt
@@ -56,6 +56,10 @@ if(CONFIG_LCD_SSD1306)
   list(APPEND SRCS stm32_ssd1306.c)
 endif()
 
+if(CONFIG_RTC_DS1307)
+  list(APPEND SRCS stm32_ds1307.c)
+endif()
+
 if(CONFIG_SENSORS_LM75)
   list(APPEND SRCS stm32_lm75.c)
 endif()


### PR DESCRIPTION
## Summary
Add ds1307 to CMake build
## Impact
User could use CMake to build boards with ds1307
## Testing
N/A