### PR TITLE
riscv: Add Vector CSRs to csr.h

### DIFF
--- a/arch/risc-v/include/csr.h
+++ b/arch/risc-v/include/csr.h
@@ -304,6 +304,16 @@
 #define CSR_DSCRATCH0       0x7b2 /* Debug Scratch 0 */
 #define CSR_DSCRATCH1       0x7b3 /* Debug Scratch 1 */
 
+/* Vector CSRs */
+
+#define CSR_VSTART          0x008 /* Vector Start Position */
+#define CSR_VXSAT           0x009 /* Fixed-Point Saturate Flag */
+#define CSR_VXRM            0x00a /* Fixed-Point Rounding Mode */
+#define CSR_VCSR            0x00f /* Vector Control and Status */
+#define CSR_VL              0xc20 /* Vector Length */
+#define CSR_VTYPE           0xc21 /* Vector Data Type */
+#define CSR_VLENB           0xc22 /* Vector Length in Bytes (VLEN/8) */
+
 /* In mstatus register */
 
 #define MSTATUS_UIE         (0x1 << 0)  /* User Interrupt Enable */


### PR DESCRIPTION

## Summary
The CSR register definitions from RVV 1.0 spec: https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc#vector-registers

## Impact
None
## Testing
CI
