### PR TITLE
sched: Move dump.c to sched_dumponexit.c

### DIFF
--- a/sched/misc/CMakeLists.txt
+++ b/sched/misc/CMakeLists.txt
@@ -24,10 +24,6 @@ if(CONFIG_ARCH_DEADLOCKDUMP)
   list(APPEND SRCS deadlock.c)
 endif()
 
-if(CONFIG_DUMP_ON_EXIT)
-  list(APPEND SRCS dump.c)
-endif()
-
 if(CONFIG_BOARD_COREDUMP_SYSLOG OR CONFIG_BOARD_COREDUMP_BLKDEV)
   list(APPEND SRCS coredump.c)
 endif()

--- a/sched/misc/Make.defs
+++ b/sched/misc/Make.defs
@@ -24,10 +24,6 @@ ifeq ($(CONFIG_ARCH_DEADLOCKDUMP),y)
 CSRCS += deadlock.c
 endif
 
-ifeq ($(CONFIG_DUMP_ON_EXIT),y)
-CSRCS += dump.c
-endif
-
 ifneq ($(CONFIG_BOARD_COREDUMP_SYSLOG)$(CONFIG_BOARD_COREDUMP_BLKDEV),)
 CSRCS += coredump.c
 endif

--- a/sched/sched/CMakeLists.txt
+++ b/sched/sched/CMakeLists.txt
@@ -120,6 +120,10 @@ if(CONFIG_SCHED_BACKTRACE)
   list(APPEND SRCS sched_backtrace.c)
 endif()
 
+if(CONFIG_DUMP_ON_EXIT)
+  list(APPEND SRCS sched_dumponexit.c)
+endif()
+
 if(CONFIG_SMP_CALL)
   list(APPEND SRCS sched_smp.c)
 endif()

--- a/sched/sched/Make.defs
+++ b/sched/sched/Make.defs
@@ -96,6 +96,10 @@ ifeq ($(CONFIG_SCHED_BACKTRACE),y)
 CSRCS += sched_backtrace.c
 endif
 
+ifeq ($(CONFIG_DUMP_ON_EXIT),y)
+CSRCS += sched_dumponexit.c
+endif
+
 ifeq ($(CONFIG_SMP_CALL),y)
 CSRCS += sched_smp.c
 endif

--- a/sched/sched/sched_dumponexit.c
+++ b/sched/sched/sched_dumponexit.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * sched/misc/dump.c
+ * sched/sched/sched_dumponexit.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
## Summary

The dump.c is a part of sched module, so move it to sched directory.

## Impact

code reorganization.

## Testing

ci