### PR TITLE
drivers/serial/16550: remove unused function

### DIFF
--- a/drivers/serial/uart_16550.c
+++ b/drivers/serial/uart_16550.c
@@ -684,17 +684,6 @@ static inline void u16550_disableuartint(FAR struct u16550_s *priv,
 }
 
 /****************************************************************************
- * Name: u16550_restoreuartint
- ****************************************************************************/
-
-static inline void u16550_restoreuartint(FAR struct u16550_s *priv,
-                                         uint32_t ier)
-{
-  priv->ier |= ier & UART_IER_ALLIE;
-  u16550_serialout(priv, UART_IER_OFFSET, priv->ier);
-}
-
-/****************************************************************************
  * Name: u16550_enablebreaks
  ****************************************************************************/
 


### PR DESCRIPTION
## Summary

drivers/serial/16550: remove unused function

drivers/serial/uart_16550.c:690:20: warning: unused function 'u16550_restoreuartint' [-Wunused-function]
static inline void u16550_restoreuartint(FAR struct u16550_s *priv,
                   ^

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

clang 