### PR TITLE
imx93-evk/README.txt: Update instructions

### DIFF
--- a/Documentation/platforms/arm64/imx9/boards/imx93-evk/README.txt
+++ b/Documentation/platforms/arm64/imx9/boards/imx93-evk/README.txt
@@ -52,6 +52,7 @@ Automated option:
 
 1. Replace the default bootcmd to disable dcache automatically:
 
+    u-boot=> setenv bootdelay 0
     u-boot=> setenv bootcmd dcache off
     u-boot=> saveenv
     Saving Environment to MMC... Writing to MMC(0)... OK


### PR DESCRIPTION
## Summary
It is advisable to set bootdelay to 0 when using bootcmd to disable dcache on u-boot. Using bootdelay -1 will definitely work as it disables bootcmd altogether (and leaves the dcache enabled). This step is added to remove confusion.

## Impact
Only documentation, but I think this information can save someone's time if they use imx9evk with u-boot and nuttx
## Testing
None
