### PR TITLE
fix: the bug about rwbuffer causing mem overflow

### DIFF
--- a/drivers/misc/rwbuffer.c
+++ b/drivers/misc/rwbuffer.c
@@ -819,7 +819,7 @@ int rwb_initialize(FAR struct rwbuffer_s *rwb)
 
       /* Allocate the write buffer */
 
-      allocsize     = rwb->wrmaxblocks * rwb->blocksize;
+      allocsize     = rwb->wrmaxblocks * rwb->blocksize * 2;
       rwb->wrbuffer = kmm_malloc(allocsize);
       if (!rwb->wrbuffer)
         {


### PR DESCRIPTION
when the offest from rwb->wrblockstart to startblock plus rwb->wrnblocks is greater than rwb->wralignblocks, it will be causing memory overflow since rwb->wrbuffer is allocated rwb.wrmaxblock(rwb.wralignblocks) blocks.

## Summary

## Impact

## Testing

