### PR TITLE
drivers/usbdev: fix complile break about mtp class

### DIFF
--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -4736,6 +4736,12 @@ config BOARD_USBDEV_SERIALSTR
 	---help---
 		Use board unique serial number to iSerialNumber in the device descriptor.
 
+config BOARD_USBDEV_PIDVID
+	bool "Board-specific usbdev pid/vid"
+	default n
+	---help---
+		Use board unique pid/vid.
+
 config BOARD_MEMORY_RANGE
 	string "Board memory range"
 	default ""

--- a/drivers/usbdev/composite.c
+++ b/drivers/usbdev/composite.c
@@ -644,6 +644,20 @@ static int composite_setup(FAR struct usbdevclass_driver_s *driver,
                 {
                   ret = USB_SIZEOF_DEVDESC;
                   memcpy(ctrlreq->buf, priv->descs->devdesc, ret);
+#ifdef CONFIG_BOARD_USBDEV_PIDVID
+                  {
+                    uint16_t pid = board_usbdev_pid();
+                    uint16_t vid = board_usbdev_vid();
+                    FAR struct usb_devdesc_s *p_desc =
+                               (FAR struct usb_devdesc_s *)ctrlreq->buf;
+
+                    p_desc->vendor[0] = LSBYTE(vid);
+                    p_desc->vendor[1] = MSBYTE(vid);
+
+                    p_desc->product[0] = LSBYTE(pid);
+                    p_desc->product[1] = MSBYTE(pid);
+                  }
+#endif
                 }
                 break;
 

--- a/drivers/usbdev/mtp.c
+++ b/drivers/usbdev/mtp.c
@@ -48,11 +48,6 @@
 
 #define USBMTP_CHARDEV_PATH        "/dev/mtp"
 
-#define USBMTP_NUM_EPS             (3)
-#define USBMTP_EP_BULKIN_IDX       (0)
-#define USBMTP_EP_BULKOUT_IDX      (1)
-#define USBMTP_EP_INTIN_IDX        (2)
-
 /* USB Controller */
 
 #ifdef CONFIG_USBDEV_SELFPOWERED
@@ -303,7 +298,7 @@ static int16_t usbclass_mkcfgdesc(FAR uint8_t *buf,
 {
   bool hispeed = false;
   FAR struct usb_epdesc_s *epdesc;
-  FAR struct mtp_cfgdesc_s *dest;
+  FAR struct usb_ifdesc_s *dest;
 
 #ifdef CONFIG_USBDEV_DUALSPEED
   hispeed = (speed == USB_SPEED_HIGH);
@@ -316,7 +311,7 @@ static int16_t usbclass_mkcfgdesc(FAR uint8_t *buf,
     }
 #endif
 
-  dest = (FAR struct mtp_cfgdesc_s *)buf;
+  dest = (FAR struct usb_ifdesc_s *)buf;
   epdesc = (FAR struct usb_epdesc_s *)(buf + sizeof(g_mtp_ifdesc));
 
   memcpy(dest, &g_mtp_ifdesc, sizeof(g_mtp_ifdesc));
@@ -331,8 +326,8 @@ static int16_t usbclass_mkcfgdesc(FAR uint8_t *buf,
 #ifdef CONFIG_USBMTP_COMPOSITE
   /* For composite device, apply possible offset to the interface numbers */
 
-  dest->ifdesc.ifno = devinfo->ifnobase;
-  dest->ifdesc.iif  = devinfo->strbase + USBMTP_INTERFACESTRID;
+  dest->ifno = devinfo->ifnobase;
+  dest->iif  = devinfo->strbase + USBMTP_INTERFACESTRID;
 #endif
 
   return sizeof(g_mtp_ifdesc) + 3 * USB_SIZEOF_EPDESC;

--- a/include/nuttx/board.h
+++ b/include/nuttx/board.h
@@ -451,6 +451,23 @@ FAR const char *board_usbdev_serialstr(void);
 #endif
 
 /****************************************************************************
+ * Name:  board_usbdev_pid,board_usbdev_vid
+ *
+ * Description:
+ *   Use board unique pid/vid in the device descriptor. This is for that
+ *   usb can be dynamically configured while the board is running
+ *
+ * Returned Value:
+ *   The board unique pid/vid.
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_BOARD_USBDEV_PIDVID)
+uint16_t board_usbdev_pid(void);
+uint16_t board_usbdev_vid(void);
+#endif
+
+/****************************************************************************
  * Name: board_graphics_setup
  *
  * Description:

--- a/include/nuttx/usb/mtp.h
+++ b/include/nuttx/usb/mtp.h
@@ -29,6 +29,20 @@
 #include <nuttx/usb/usbdev.h>
 
 /****************************************************************************
+ * Preprocessor definitions
+ ****************************************************************************/
+
+/* Indexes for devinfo.epno[] array.
+ * Used for composite device configuration.
+ */
+
+#define USBMTP_NUM_EPS             (3)
+
+#define USBMTP_EP_BULKIN_IDX       (0)
+#define USBMTP_EP_BULKOUT_IDX      (1)
+#define USBMTP_EP_INTIN_IDX        (2)
+
+/****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
 


### PR DESCRIPTION
## Summary
drivers/usbdev: fix complile break about mtp class
## Impact
fix compile break
## Testing
testing vela
