### PR TITLE
arch/risc-v: rename local variable name to avoid shadowed declaration

### DIFF
--- a/arch/risc-v/src/common/riscv_internal.h
+++ b/arch/risc-v/src/common/riscv_internal.h
@@ -133,16 +133,16 @@
 
 #define READ_CSR(reg) \
   ({ \
-     uintptr_t regval; \
-     __asm__ __volatile__("csrr %0, " __STR(reg) : "=r"(regval)); \
-     regval; \
+     uintptr_t __regval; \
+     __asm__ __volatile__("csrr %0, " __STR(reg) : "=r"(__regval)); \
+     __regval; \
   })
 
 #define READ_AND_SET_CSR(reg, bits) \
   ({ \
-     uintptr_t regval; \
-     __asm__ __volatile__("csrrs %0, " __STR(reg) ", %1": "=r"(regval) : "rK"(bits)); \
-     regval; \
+     uintptr_t __regval; \
+     __asm__ __volatile__("csrrs %0, " __STR(reg) ", %1": "=r"(__regval) : "rK"(bits)); \
+     __regval; \
   })
 
 #define WRITE_CSR(reg, val) \


### PR DESCRIPTION

## Summary

arch/risc-v: rename local variable name to avoid shadowed declaration

```
In file included from common/addrenv.h:33,
                 from common/riscv_initialstate.c:36:
common/riscv_initialstate.c: In function 'up_initial_state':
common/riscv_internal.h:136:16: warning: declaration of 'regval' shadows a previous local [-Wshadow]
  136 |      uintptr_t regval; \
      |                ^~~~~~
common/riscv_initialstate.c:74:12: note: in expansion of macro 'READ_CSR'
   74 |   regval = READ_CSR(CSR_VLENB);
      |            ^~~~~~~~
common/riscv_initialstate.c:63:13: note: shadowed declaration is here
   63 |   uintptr_t regval;
      |             ^~~~~~
```

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

ci-check