### PR TITLE
cmake/export: fix kernel mode app building

### DIFF
--- a/arch/arm/src/armv7-a/crt0.c
+++ b/arch/arm/src/armv7-a/crt0.c
@@ -91,7 +91,7 @@ static void sig_trampoline(void)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: _start
+ * Name: __start
  *
  * Description:
  *   This function is the low level entry point into the main thread of
@@ -110,7 +110,7 @@ static void sig_trampoline(void)
  *
  ****************************************************************************/
 
-void _start(int argc, char *argv[])
+void __start(int argc, char *argv[])
 {
   int ret;
 

--- a/arch/arm64/src/common/crt0.c
+++ b/arch/arm64/src/common/crt0.c
@@ -91,7 +91,7 @@ static void sig_trampoline(void)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: _start
+ * Name: __start
  *
  * Description:
  *   This function is the low level entry point into the main thread of
@@ -110,7 +110,7 @@ static void sig_trampoline(void)
  *
  ****************************************************************************/
 
-void _start(int argc, char *argv[])
+void __start(int argc, char *argv[])
 {
   int ret;
 

--- a/arch/risc-v/src/common/crt0.c
+++ b/arch/risc-v/src/common/crt0.c
@@ -143,7 +143,7 @@ static void exec_dtors(void)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: _start
+ * Name: __start
  *
  * Description:
  *   This function is the low level entry point into the main thread of
@@ -162,7 +162,7 @@ static void exec_dtors(void)
  *
  ****************************************************************************/
 
-void _start(int argc, char *argv[])
+void __start(int argc, char *argv[])
 {
   int ret;
 

--- a/tools/Export.mk
+++ b/tools/Export.mk
@@ -91,6 +91,15 @@ ifdef CONFIG_ARCH_BOARD
 else
 	@echo "NUTTX_BOARD=\"$(CONFIG_ARCH_BOARD_CUSTOM_NAME)\"" >> $(EXPORTDIR)/makeinfo.sh
 endif
+ifdef CONFIG_BUILD_FLAT
+	@echo "NUTTX_BUILD=\"flat\"" >> $(EXPORTDIR)/makeinfo.sh
+endif
+ifdef CONFIG_BUILD_PROTECTED
+	@echo "NUTTX_BUILD=\"protected\"" >> $(EXPORTDIR)/makeinfo.sh
+endif
+ifdef CONFIG_BUILD_KERNEL
+	@echo "NUTTX_BUILD=\"kernel\"" >> $(EXPORTDIR)/makeinfo.sh
+endif
 	$(Q) chmod 755 $(EXPORTDIR)/makeinfo.sh
 
 clean:

--- a/tools/mkexport.sh
+++ b/tools/mkexport.sh
@@ -182,10 +182,15 @@ cp "${TOPDIR}/tools/incdir.c" "${EXPORTDIR}/tools/."
 
 # Copy the board specific linker if found, or use the default when not.
 
-if [ -f "${BOARDDIR}/scripts/gnu-elf.ld" ]; then
-  cp -f "${BOARDDIR}/scripts/gnu-elf.ld" "${EXPORTDIR}/scripts/."
+APPLD=gnu-elf.ld
+if [ -f "${BOARDDIR}/scripts/${APPLD}" ]; then
+  cp -f "${BOARDDIR}/scripts/${APPLD}" "${EXPORTDIR}/scripts/."
 else
-  cp -f "${TOPDIR}/binfmt/libelf/gnu-elf.ld" "${EXPORTDIR}/scripts/."
+  cp -f "${TOPDIR}/binfmt/libelf/${APPLD}" "${EXPORTDIR}/scripts/."
+fi
+
+if [ "${NUTTX_BUILD}" = "kernel" ]; then
+  LDNAME=${APPLD}
 fi
 
 # Copy the board config script
@@ -260,6 +265,7 @@ echo "LDELFFLAGS       = ${LDELFFLAGS}" >>"${EXPORTDIR}/scripts/Make.defs"
 echo "NUTTX_ARCH       = ${NUTTX_ARCH}" >>"${EXPORTDIR}/scripts/Make.defs"
 echo "NUTTX_ARCH_CHIP  = ${NUTTX_ARCH_CHIP}" >>"${EXPORTDIR}/scripts/Make.defs"
 echo "NUTTX_BOARD      = ${NUTTX_BOARD}" >>"${EXPORTDIR}/scripts/Make.defs"
+echo "NUTTX_BUILD      = ${NUTTX_BUILD}" >>"${EXPORTDIR}/scripts/Make.defs"
 
 echo "set(ARCHCFLAGS          \"${ARCHCFLAGS}\")"       > "${EXPORTDIR}/scripts/target.cmake"
 echo "set(ARCHCPUFLAGS        \"${ARCHCPUFLAGS}\")"     >>"${EXPORTDIR}/scripts/target.cmake"
@@ -289,6 +295,7 @@ echo "set(LDELFFLAGS          \"${LDELFFLAGS}\")"       >>"${EXPORTDIR}/scripts/
 echo "set(NUTTX_ARCH          \"${NUTTX_ARCH}\")"       >>"${EXPORTDIR}/scripts/target.cmake"
 echo "set(NUTTX_ARCH_CHIP     \"${NUTTX_ARCH_CHIP}\")"  >>"${EXPORTDIR}/scripts/target.cmake"
 echo "set(NUTTX_BOARD         \"${NUTTX_BOARD}\")"      >>"${EXPORTDIR}/scripts/target.cmake"
+echo "set(NUTTX_BUILD         \"${NUTTX_BUILD}\")"      >>"${EXPORTDIR}/scripts/target.cmake"
 
 
 # Additional compilation options when the kernel is built

--- a/tools/toolchain.cmake.export
+++ b/tools/toolchain.cmake.export
@@ -9,7 +9,7 @@ include(${NUTTX_PATH}/scripts/target.cmake)
 
 set(LINKER_SCRIPT ${NUTTX_PATH}/scripts/${LDNAME})
 
-set(CMAKE_C_FLAGS "${ARCHCPUFLAGS} ${ARCHCFLAGS}   -D__NuttX__")
+set(CMAKE_C_FLAGS "${ARCHCPUFLAGS} ${ARCHCFLAGS} -D__NuttX__")
 set(CMAKE_CXX_FLAGS "${ARCHCPUFLAGS} ${ARCHCXXFLAGS} -D__NuttX__")
 
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${NUTTX_PATH}/include
@@ -23,11 +23,15 @@ file(GLOB STARTUP_OBJS ${NUTTX_PATH}/startup/*)
 add_compile_options(-nostdlib)
 add_compile_options(-ffunction-sections -fdata-sections)
 
+# same entry used for all build modes in crt0.c and arch/.../xxx_start.c
+
+set(ENTRY_NAME "__start")
+
 set(CMAKE_C_LINK_EXECUTABLE
-    "<CMAKE_LINKER> ${LDFLAGS} --entry=__start -T${LINKER_SCRIPT} <OBJECTS> ${STARTUP_OBJS} -o <TARGET> <LINK_LIBRARIES> -L${NUTTX_PATH}/libs --start-group ${LDLIBS} ${EXTRA_LIBS} --end-group"
+    "<CMAKE_LINKER> ${LDFLAGS} --entry=${ENTRY_NAME} -T${LINKER_SCRIPT} <OBJECTS> ${STARTUP_OBJS} -o <TARGET> <LINK_LIBRARIES> -L${NUTTX_PATH}/libs --start-group ${LDLIBS} ${EXTRA_LIBS} --end-group"
 )
 set(CMAKE_CXX_LINK_EXECUTABLE
-    "<CMAKE_LINKER> ${LDFLAGS} --entry=__start -T${LINKER_SCRIPT} <OBJECTS> ${STARTUP_OBJS} -o <TARGET> <LINK_LIBRARIES> -L${NUTTX_PATH}/libs --start-group ${LDLIBS} ${EXTRA_LIBS} --end-group"
+    "<CMAKE_LINKER> ${LDFLAGS} --entry=${ENTRY_NAME} -T${LINKER_SCRIPT} <OBJECTS> ${STARTUP_OBJS} -o <TARGET> <LINK_LIBRARIES> -L${NUTTX_PATH}/libs --start-group ${LDLIBS} ${EXTRA_LIBS} --end-group"
 )
 
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)


### PR DESCRIPTION
## Summary

This fixes names of program entry and linker script files so that to support building kernel mode apps using CMake and exported package.  The behavior for flat/protected build modes is same as before.

## Impact
CMake use cases

## Testing
CI checks
