### PR TITLE
intel64: various cosmetic changes

### DIFF
--- a/arch/x86_64/include/intel64/arch.h
+++ b/arch/x86_64/include/intel64/arch.h
@@ -349,8 +349,7 @@ begin_packed_struct struct ist_s
   uint64_t IST6;                 /* Interrupt Stack 6 */
   uint64_t IST7;                 /* Interrupt Stack 7 */
   uint64_t reserved3;            /* reserved */
-  uint64_t reserved4;            /* reserved */
-  uint16_t reserved5;            /* reserved */
+  uint16_t reserved4;            /* reserved */
   uint16_t IOPB_OFFSET;          /* IOPB_offset */
 } end_packed_struct;
 

--- a/arch/x86_64/src/intel64/intel64.h
+++ b/arch/x86_64/src/intel64/intel64.h
@@ -69,19 +69,6 @@ extern "C"
  ****************************************************************************/
 
 /****************************************************************************
- * Name: intel64_lowsetup
- *
- * Description:
- *   Called at the very beginning of _nxstart.
- *   Performs low level initializationincluding setup of the console UART.
- *   This UART done early so that the serial console is available for
- *   debugging very early in the boot sequence.
- *
- ****************************************************************************/
-
-void intel64_lowsetup(void);
-
-/****************************************************************************
  * Name: vector_*
  *
  * Description:

--- a/arch/x86_64/src/intel64/intel64_handlers.c
+++ b/arch/x86_64/src/intel64/intel64_handlers.c
@@ -62,8 +62,6 @@
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
 static uint64_t *common_handler(int irq, uint64_t *regs)
 {
-  board_autoled_on(LED_INIRQ);
-
   /* Current regs non-zero indicates that we are processing an interrupt;
    * g_current_regs is also used to manage interrupt level context switches.
    *
@@ -135,9 +133,9 @@ static uint64_t *common_handler(int irq, uint64_t *regs)
 
 uint64_t *isr_handler(uint64_t *regs, uint64_t irq)
 {
-#ifdef CONFIG_SUPPRESS_INTERRUPTS
   board_autoled_on(LED_INIRQ);
 
+#ifdef CONFIG_SUPPRESS_INTERRUPTS
   /* Doesn't return */
 
   PANIC();
@@ -188,7 +186,7 @@ uint64_t *isr_handler(uint64_t *regs, uint64_t irq)
 }
 
 /****************************************************************************
- * Name: isr_handler
+ * Name: irq_handler
  *
  * Description:
  *   This gets called from IRQ vector handling logic in intel64_vectors.S
@@ -197,9 +195,9 @@ uint64_t *isr_handler(uint64_t *regs, uint64_t irq)
 
 uint64_t *irq_handler(uint64_t *regs, uint64_t irq_no)
 {
-#ifdef CONFIG_SUPPRESS_INTERRUPTS
   board_autoled_on(LED_INIRQ);
 
+#ifdef CONFIG_SUPPRESS_INTERRUPTS
   /* Doesn't return */
 
   PANIC();
@@ -210,8 +208,6 @@ uint64_t *irq_handler(uint64_t *regs, uint64_t irq_no)
 #else
   uint64_t *ret;
   int irq;
-
-  board_autoled_on(LED_INIRQ);
 
   /* Get the IRQ number */
 

--- a/arch/x86_64/src/intel64/intel64_irq.c
+++ b/arch/x86_64/src/intel64/intel64_irq.c
@@ -358,6 +358,7 @@ legacy_pic_irq_handler(int irq, uint32_t *regs, void *arg)
 #ifndef CONFIG_ARCH_INTEL64_DISABLE_INT_INIT
 static void up_ioapic_init(void)
 {
+  uint32_t maxintr;
   int i;
 
   up_map_region((void *)IOAPIC_BASE, HUGE_PAGE_SIZE,
@@ -365,7 +366,7 @@ static void up_ioapic_init(void)
 
   /* Setup the IO-APIC, remap the interrupt to 32~ */
 
-  uint32_t maxintr = (up_ioapic_read(IOAPIC_REG_VER) >> 16) & 0xff;
+  maxintr = (up_ioapic_read(IOAPIC_REG_VER) >> 16) & 0xff;
 
   for (i = 0; i < maxintr; i++)
     {

--- a/arch/x86_64/src/intel64/intel64_lowsetup.h
+++ b/arch/x86_64/src/intel64/intel64_lowsetup.h
@@ -1,0 +1,64 @@
+/****************************************************************************
+ * arch/x86_64/src/intel64/intel64_lowsetup.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_X86_64_SRC_INTEL64_INTEL64_LOWSETUP_H
+#define __ARCH_X86_64_SRC_INTEL64_INTEL64_LOWSETUP_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#ifndef __ASSEMBLY__
+
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: intel64_lowsetup
+ *
+ * Description:
+ *   Called at the very beginning of _nxstart or up_ap_boot.
+ *   Performs low level initializationincluding setup of the console UART.
+ *   This UART done early so that the serial console is available for
+ *   debugging very early in the boot sequence.
+ *
+ ****************************************************************************/
+
+void intel64_lowsetup(void);
+
+#undef EXTERN
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* __ASSEMBLY__ */
+#endif /* __ARCH_X86_64_SRC_INTEL64_INTEL64_LOWSETUP_H */

--- a/arch/x86_64/src/intel64/intel64_start.c
+++ b/arch/x86_64/src/intel64/intel64_start.c
@@ -30,7 +30,8 @@
 #include <arch/multiboot2.h>
 
 #include "x86_64_internal.h"
-#include "intel64.h"
+
+#include "intel64_lowsetup.h"
 
 /****************************************************************************
  * Public Data


### PR DESCRIPTION
## Summary

- intel64/intel64_irq.c: cosmetic change
- intel64: add header for intel64_lowsetup
- intel64/intel64_handlers.c: cosmetic changes
- intel64/arch.h: fix ist_t structure, there is no reserved5 field

## Impact
None, cosmetic changes

## Testing
CI
