### PR TITLE
arch/x86_64: add simple ACPI parser

### DIFF
--- a/arch/x86_64/include/acpi.h
+++ b/arch/x86_64/include/acpi.h
@@ -1,0 +1,304 @@
+/****************************************************************************
+ * arch/x86_64/include/acpi.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_X86_64_INCLUDE_ACPI_H
+#define __ARCH_X86_64_INCLUDE_ACPI_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <nuttx/compiler.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define ACPI_SIG_RSDP "RSD PTR " /* Root System Description Pointer */
+
+/* Tables defined by ACPI spec */
+
+#define ACPI_SIG_APIC "APIC"    /* Multiple APIC Description Table (MADT) */
+#define ACPI_SIG_BERT "BERT"
+#define ACPI_SIG_BGRT "BGRT"
+#define ACPI_SIG_CCEL "CCEL"
+#define ACPI_SIG_CPEP "CPEP"
+#define ACPI_SIG_DSDT "DSDT"
+#define ACPI_SIG_ECDT "ECDT"
+#define ACPI_SIG_EINJ "EINJ"
+#define ACPI_SIG_ERST "ERST"
+#define ACPI_SIG_FACP "FACP"
+#define ACPI_SIG_FACS "FACS"
+#define ACPI_SIG_FPDT "FPDT"
+#define ACPI_SIG_GTDT "GTDT"
+#define ACPI_SIG_HEST "HEST"
+#define ACPI_SIG_MISC "MISC"
+#define ACPI_SIG_MSCT "MSCT"
+#define ACPI_SIG_MPST "MPST"
+#define ACPI_SIG_NFIT "NFIT"
+#define ACPI_SIG_OEMx "OEMx"
+#define ACPI_SIG_PCCT "PCCT"
+#define ACPI_SIG_PHAT "PHAT"
+#define ACPI_SIG_PMTT "PMTT"
+#define ACPI_SIG_PPTT "PPTT"
+#define ACPI_SIG_PSDT "PSDT"
+#define ACPI_SIG_RASF "RASF"
+#define ACPI_SIG_RAS2 "RAS2"
+#define ACPI_SIG_RSDT "RSDT"
+#define ACPI_SIG_SBST "SBST"
+#define ACPI_SIG_SDEV "SDEV"
+#define ACPI_SIG_SLIT "SLIT"
+#define ACPI_SIG_SRAT "SRAT"
+#define ACPI_SIG_SSDT "SSDT"
+#define ACPI_SIG_SVKL "SVKL"
+#define ACPI_SIG_XSDT "XSDT"
+
+/* Tables not defined by ACPI spec */
+
+#define ACPI_SIG_AEST "AEST"
+#define ACPI_SIG_AGDI "AGDI"
+#define ACPI_SIG_APMT "APMT"
+#define ACPI_SIG_BDAT "BDAT"
+#define ACPI_SIG_BOOT "BOOT"
+#define ACPI_SIG_CEDT "CEDT"
+#define ACPI_SIG_CSRT "CSRT"
+#define ACPI_SIG_DBGT "DBGT"
+#define ACPI_SIG_DBG2 "DBG2"
+#define ACPI_SIG_DMAR "DMAR"
+#define ACPI_SIG_DRTM "DRTM"
+#define ACPI_SIG_DTPR "DTPR"
+#define ACPI_SIG_ETDT "ETDT"
+#define ACPI_SIG_HPET "HPET"
+#define ACPI_SIG_IBFT "IBFT"
+#define ACPI_SIG_IERS "IERS"
+#define ACPI_SIG_IORT "IORT"
+#define ACPI_SIG_IVRS "IVRS"
+#define ACPI_SIG_KEYP "KEYP"
+#define ACPI_SIG_LPIT "LPIT"
+#define ACPI_SIG_MCFG "MCFG"     /* PCI Express Memory-mapped Configuration table */
+#define ACPI_SIG_MCHI "MCHI"
+#define ACPI_SIG_MHSP "MHSP"
+#define ACPI_SIG_MPAM "MPAM"
+#define ACPI_SIG_MSDM "MSDM"
+#define ACPI_SIG_NBFT "NBFT"
+#define ACPI_SIG_PRMT "PRMT"
+#define ACPI_SIG_RGRT "RGRT"
+#define ACPI_SIG_SDEI "SDEI"
+#define ACPI_SIG_SLIC "SLIC"
+#define ACPI_SIG_SPCR "SPCR"
+#define ACPI_SIG_SPMI "SPMI"
+#define ACPI_SIG_STAO "STAO"
+#define ACPI_SIG_SWFT "SWFT"
+#define ACPI_SIG_TCPA "TCPA"
+#define ACPI_SIG_TPM2 "TPM2"
+#define ACPI_SIG_UEFI "UEFI"
+#define ACPI_SIG_WAET "WAET"
+#define ACPI_SIG_WDAT "WDAT"
+#define ACPI_SIG_WDDT "WDDT"
+#define ACPI_SIG_WDRT "WDRT"
+#define ACPI_SIG_WPBT "WPBT"
+#define ACPI_SIG_WSMT "WSMT"
+#define ACPI_SIG_XENV "XENV"
+
+/* MADT Interrupt Controller Structure types */
+
+#define ACPI_MADT_TYPE_LOCAL_APIC   (0)
+#define ACPI_MADT_TYPE_IO_APIC      (1)
+#define ACPI_MADT_TYPE_LOCAL_APIC64 (5)
+#define ACPI_MADT_TYPE_LOCAL_X2APIC (9)
+
+/* Local APIC Flags */
+
+#define ACPI_LAPIC_FLAGS_ENABLED     (1 << 0)
+#define ACPI_LAPIC_FLAGS_ONLINECAP   (1 << 1)
+#define ACPI_LAPIC_FLAGS_RESERVED    (0xfffffffc)
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/* Root System Description Pointer (RSDP) Structure */
+
+begin_packed_struct struct acpi_rsdp_s
+{
+  char     signature[8];     /* "RSD PTR " sugnature */
+  uint8_t  checksum;         /* ACPI 1.0 checksum */
+  char     oem_id[6];        /* An OEM-supplied string */
+  uint8_t  revision;         /* The revision of this structure */
+  uint32_t rsdt_addr;        /* 32 bit physical address of the RSDT */
+  uint32_t length;           /* The length of the table */
+  uint64_t xsdt_addr;        /* 64 bit physical address of the XSDT */
+  uint8_t  ext_checksum;     /* Extended checksum */
+  uint8_t  reserved[3];      /* Reserved field */
+} end_packed_struct;
+
+/* System Description Table Header */
+
+begin_packed_struct struct acpi_sdt_s
+{
+  char     signature[4];        /* Table ASCII identifier */
+  uint32_t length;              /* The length of the table in bytes */
+  uint8_t  revision;            /* The revision of the structure */
+  uint8_t  checksum;            /* The entire table checksum */
+  char     oem_id[6];           /* An OEM identification string */
+  char     oem_table_id[8];     /* An OEM data table string */
+  uint32_t oem_revision;        /* An OEM revision number */
+  uint32_t creator_id;          /* Vendor ID */
+  uint32_t creator_revision;    /* Vendor revision */
+} end_packed_struct;
+
+/* Root System Description Table */
+
+begin_packed_struct struct acpi_rsdt_s
+{
+  struct acpi_sdt_s sdt;
+  uint32_t          table_ptrs;
+} end_packed_struct;
+
+/* Extended System Descriptior Table */
+
+begin_packed_struct struct acpi_xsdt_s
+{
+  struct acpi_sdt_s sdt;
+  uint64_t          table_ptrs;
+} end_packed_struct;
+
+/* Common structure for tables entry */
+
+begin_packed_struct struct acpi_entry_s
+{
+  uint8_t type;
+  uint8_t length;
+} end_packed_struct;
+
+/* Multiple APIC Description Table */
+
+begin_packed_struct struct acpi_madt_s
+{
+  struct acpi_sdt_s   sdt;
+  uint32_t            loapic;
+  uint32_t            flags;
+  struct acpi_entry_s entries;
+} end_packed_struct;
+
+/* Multiple APIC Description Table */
+
+begin_packed_struct struct acpi_lapic_s
+{
+  struct acpi_entry_s entry;
+  uint8_t             acpi_id;
+  uint8_t             apic_id;
+  uint8_t             flags;
+} end_packed_struct;
+
+/* Configuration space base address allocation structure */
+
+begin_packed_struct struct acpi_pciseg_s
+{
+  uint64_t base_addr;           /* Base address */
+  uint16_t seg_group_num;       /* PCI Segment Group Number */
+  uint8_t  start_bus;           /* Strt PCI bus number */
+  uint8_t  end_bus;             /* End PCI bus number */
+  uint32_t reserved;            /* Reserved */
+} end_packed_struct;
+
+/* PCI Express Memory-mapped Configuration Table */
+
+begin_packed_struct struct acpi_mcfg_s
+{
+  struct acpi_sdt_s    sdt;       /* Header */
+  uint64_t             reserved;  /* Reserved */
+  struct acpi_pciseg_s segs;      /* Configuration space base addresses */
+} end_packed_struct;
+
+/****************************************************************************
+ * Inline Functions
+ ****************************************************************************/
+
+#ifndef __ASSEMBLY__
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: acpi_init
+ *
+ * Description:
+ *   Initialize ACPI parser.
+ *
+ ****************************************************************************/
+
+int acpi_init(uintptr_t rsdp);
+
+/****************************************************************************
+ * Name: acpi_madt_get
+ *
+ * Description:
+ *   Find the n'th occurence of a MADT entry with a given type.
+ *
+ ****************************************************************************/
+
+int acpi_madt_get(int type, int n, struct acpi_entry_s **entry);
+
+/****************************************************************************
+ * Name: acpi_lapi_get
+ *
+ * Description:
+ *   Get Local APIC entry for a given CPU.
+ *
+ ****************************************************************************/
+
+int acpi_lapic_get(int cpu, struct acpi_lapic_s **lapic);
+
+#ifdef CONFIG_ARCH_X86_64_ACPI_DUMP
+/****************************************************************************
+ * Name: acpi_dump
+ *
+ * Description:
+ *   Dump ACPI tables.
+ *
+ ****************************************************************************/
+
+void acpi_dump(void);
+#endif
+
+#undef EXTERN
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* __ASSEMBLY__ */
+#endif /* __ARCH_X86_64_INCLUDE_ACPI_H */

--- a/arch/x86_64/src/common/CMakeLists.txt
+++ b/arch/x86_64/src/common/CMakeLists.txt
@@ -37,4 +37,8 @@ if(CONFIG_PCI)
   list(APPEND SRCS x86_64_pci.c)
 endif()
 
+if(CONFIG_ARCH_X86_64_ACPI)
+  list(APPEND SRCS x86_64_acpi.c)
+endif()
+
 target_sources(arch PRIVATE ${SRCS})

--- a/arch/x86_64/src/common/Kconfig
+++ b/arch/x86_64/src/common/Kconfig
@@ -6,6 +6,28 @@
 if ARCH_X86_64
 comment "Common Configuration Options"
 
+config ARCH_X86_64_ACPI
+	bool "ACPI support"
+	default y
+	---help---
+		Select to enable ACPI parser.
+
+if ARCH_X86_64_ACPI
+
+config ARCH_X86_64_ACPI_DUMP
+	bool "ACPI dump"
+	default DEBUG_FEATURES
+	---help---
+		Select to dump ACPI tables.
+
+config ARCH_X86_64_ACPI_BIOS
+	bool "Look for ACPI RSDP in BIOS legacy region"
+	default y
+	---help---
+		Look for RSDP in BIOS legacy region (0x000e0000-0x000fffff).
+
+endif # ARCH_X86_64_ACPI
+
 config ARCH_X86_64_MMX
 	bool "MMX support"
 	depends on ARCH_HAVE_MMX

--- a/arch/x86_64/src/common/Make.defs
+++ b/arch/x86_64/src/common/Make.defs
@@ -28,3 +28,7 @@ CMN_CSRCS += x86_64_nputs.c x86_64_switchcontext.c x86_64_udelay.c
 ifeq ($(CONFIG_PCI),y)
 CMN_CSRCS += x86_64_pci.c
 endif
+
+ifeq ($(CONFIG_ARCH_X86_64_ACPI),y)
+CMN_CSRCS += x86_64_acpi.c
+endif

--- a/arch/x86_64/src/common/x86_64_acpi.c
+++ b/arch/x86_64/src/common/x86_64_acpi.c
@@ -1,0 +1,667 @@
+/****************************************************************************
+ * arch/x86_64/src/common/x86_64_acpi.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <nuttx/arch.h>
+#include <debug.h>
+#include <stdint.h>
+
+#include <arch/acpi.h>
+
+#include "x86_64_internal.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define ACPI_BIOS_MEM_START (0x000e0000)
+#define ACPI_BIOS_MEM_END   (0x000fffff)
+#define ACPI_BIOS_MEM_SIZE  (ACPI_BIOS_MEM_END - ACPI_BIOS_MEM_START)
+#define ACPI_PAGE_FLAGS     (X86_PAGE_PRESENT | X86_PAGE_WR | X86_PAGE_NOCACHE)
+
+/* Debug macros */
+
+#define acpi_info  _info
+#define acpi_err   _err
+#define acpi_warn  _warn
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct acpi_s
+{
+  struct acpi_rsdp_s *rsdp;
+  struct acpi_rsdt_s *rsdt;
+  struct acpi_xsdt_s *xsdt;
+  struct acpi_madt_s *madt;
+  struct acpi_mcfg_s *mcfg;
+};
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static struct acpi_s g_acpi;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: acpi_map_region
+ *
+ * Description:
+ *   Map ACPI region.
+ *
+ ****************************************************************************/
+
+static void acpi_map_region(uintptr_t addr, size_t size)
+{
+  /* Map region */
+
+  up_map_region((void *)addr, size, ACPI_PAGE_FLAGS);
+}
+
+/****************************************************************************
+ * Name: acpi_map_rsdt
+ *
+ * Description:
+ *   Map all ACPI tables.
+ *
+ ****************************************************************************/
+
+static void acpi_map_rsdt(void)
+{
+  void                *tps   = NULL;
+  uint32_t            *tp32  = NULL;
+  uint32_t            *end32 = NULL;
+
+  tps = &g_acpi.rsdt->table_ptrs;
+  tp32  = (uint32_t *)tps;
+  end32 = (uint32_t *)((uintptr_t)g_acpi.rsdt + g_acpi.rsdt->sdt.length);
+
+  while (tp32 < end32)
+    {
+      acpi_map_region((uintptr_t)*tp32,
+                      sizeof(struct acpi_sdt_s));
+
+      /* Next table */
+
+      tp32 += 1;
+    }
+}
+
+/****************************************************************************
+ * Name: acpi_map_xsdt
+ *
+ * Description:
+ *   Map all ACPI tables.
+ *
+ ****************************************************************************/
+
+static void acpi_map_xsdt(void)
+{
+  void                *tps   = NULL;
+  uint64_t            *tp64  = NULL;
+  uint64_t            *end64 = NULL;
+
+  tps = &g_acpi.rsdt->table_ptrs;
+  tp64  = (uint64_t *)tps;
+  end64 = (uint64_t *)((uintptr_t)g_acpi.xsdt + g_acpi.xsdt->sdt.length);
+
+  while (tp64 < end64)
+    {
+      acpi_map_region((uintptr_t)*tp64,
+                      sizeof(struct acpi_sdt_s));
+
+      /* Next table */
+
+      tp64 += 1;
+    }
+}
+
+/****************************************************************************
+ * Name: acpi_sdt_checksum
+ *
+ * Description:
+ *   Verify checksum.
+ *
+ ****************************************************************************/
+
+static bool acpi_sdt_checksum(struct acpi_sdt_s *sdt)
+{
+  uint8_t *ptr = (uint8_t *)sdt;
+  uint8_t  sum = 0;
+  uint32_t i   = 0;
+
+  for (i = 0; i < sdt->length; i++)
+    {
+      sum += ptr[i];
+    }
+
+  return sum == 0;
+}
+
+/****************************************************************************
+ * Name: acpi_rsdp_parse
+ *
+ * Description:
+ *   Parse RSDP.
+ *
+ ****************************************************************************/
+
+static int acpi_rsdp_parse(struct acpi_rsdp_s *rsdp)
+{
+  uint8_t  *ptr = (uint8_t *)rsdp;
+  uint8_t   sum = 0;
+  uint32_t  len = 0;
+  uint32_t  i   = 0;
+
+  /* Checksum */
+
+  len = rsdp->revision < 2 ? 20 : rsdp->length;
+  for (i = 0; i < len; i++)
+    {
+      sum += ptr[i];
+    }
+
+  if (sum != 0)
+    {
+      return -EINVAL;
+    }
+
+  /* Parse RSDT table */
+
+  if (rsdp->rsdt_addr != 0)
+    {
+      struct acpi_rsdt_s *rsdt = NULL;
+
+      acpi_map_region((uintptr_t)rsdp->rsdt_addr,
+                      sizeof(struct acpi_rsdt_s));
+
+      rsdt = (struct acpi_rsdt_s *)(uintptr_t)rsdp->rsdt_addr;
+
+      /* Verify checksum */
+
+      if (!acpi_sdt_checksum(&rsdt->sdt))
+        {
+          return -EINVAL;
+        }
+
+      /* Store pointer */
+
+      g_acpi.rsdt = rsdt;
+
+      /* Map all tables */
+
+      acpi_map_rsdt();
+    }
+
+  /* Parse XSDT table if RSDT not available */
+
+  else if (rsdp->xsdt_addr != 0)
+    {
+      struct acpi_xsdt_s *xsdt = NULL;
+
+      acpi_map_region((uintptr_t)rsdp->xsdt_addr,
+                      sizeof(struct acpi_xsdt_s));
+
+      xsdt = (struct acpi_xsdt_s *)rsdp->xsdt_addr;
+
+      /* Verify checksum */
+
+      if (!acpi_sdt_checksum(&xsdt->sdt))
+        {
+          return -EINVAL;
+        }
+
+      /* Store pointer */
+
+      g_acpi.xsdt = xsdt;
+
+      /* Map all talbes */
+
+      acpi_map_xsdt();
+    }
+
+  return OK;
+}
+
+#ifdef CONFIG_ARCH_X86_64_ACPI_BIOS
+/****************************************************************************
+ * Name: acpi_rsdp_find_bios
+ *
+ * Description:
+ *   Find RSDP in BIOS region.
+ *
+ ****************************************************************************/
+
+static bool acpi_rsdp_find_bios(struct acpi_s *acpi)
+{
+  char *now = (char *)ACPI_BIOS_MEM_START;
+  char *end = (char *)ACPI_BIOS_MEM_END;
+
+  /* Map BIOS region */
+
+  acpi_map_region((uintptr_t)ACPI_BIOS_MEM_START,
+                  ACPI_BIOS_MEM_SIZE);
+
+  acpi->rsdp = NULL;
+
+  while (now < end)
+    {
+      if (strncmp(now, ACPI_SIG_RSDP,
+                  sizeof(ACPI_SIG_RSDP) - 1) == 0)
+        {
+          acpi->rsdp = (struct acpi_rsdp_s *)now;
+          break;
+        }
+
+      now += 16;
+    }
+
+  return acpi->rsdp != NULL;
+}
+#endif
+
+/****************************************************************************
+ * Name: acpi_rsdp_find
+ *
+ * Description:
+ *   Find RSDP.
+ *
+ ****************************************************************************/
+
+static bool acpi_rsdp_find(struct acpi_s *acpi)
+{
+  /* For now ony ACPI from BIOS region us supported */
+
+#ifdef CONFIG_ARCH_X86_64_ACPI_BIOS
+  return acpi_rsdp_find_bios(acpi);
+#else
+#  error For now ony ACPI from BIOS region is supported
+#endif
+}
+
+/****************************************************************************
+ * Name: acpi_table64_find
+ ****************************************************************************/
+
+static int acpi_table64_find(const char *sig, struct acpi_sdt_s **sdt)
+{
+  static struct acpi_s *acpi = &g_acpi;
+  struct acpi_sdt_s    *tmp  = NULL;
+  void                 *tps  = NULL;
+  uint64_t             *tp   = NULL;
+  uint64_t             *end  = NULL;
+
+  tps = &acpi->xsdt->table_ptrs;
+  tp  = (uint64_t *)((uintptr_t)tps);
+  end = (uint64_t *)((uintptr_t)acpi->xsdt + acpi->xsdt->sdt.length);
+
+  while (tp < end)
+    {
+      /* Compare signature */
+
+      tmp = (struct acpi_sdt_s *)(uintptr_t)*tp;
+      if (!strncmp(tmp->signature, sig, 4))
+        {
+          *sdt = tmp;
+          return OK;
+        }
+
+      /* Next table */
+
+      tp += 1;
+    }
+
+  /* Not found */
+
+  return -ENOENT;
+}
+
+/****************************************************************************
+ * Name: acpi_table32_find
+ ****************************************************************************/
+
+static int acpi_table32_find(const char *sig, struct acpi_sdt_s **sdt)
+{
+  struct acpi_s     *acpi = &g_acpi;
+  struct acpi_sdt_s *tmp  = NULL;
+  void              *tps  = NULL;
+  uint32_t          *tp   = NULL;
+  uint32_t          *end  = NULL;
+
+  tps = &acpi->rsdt->table_ptrs;
+  tp  = (uint32_t *)((uintptr_t)tps);
+  end = (uint32_t *)((uintptr_t)acpi->rsdt + acpi->rsdt->sdt.length);
+
+  while (tp < end)
+    {
+      /* Compare signature */
+
+      tmp = (struct acpi_sdt_s *)(uintptr_t)*tp;
+      if (!strncmp(tmp->signature, sig, 4))
+        {
+          *sdt = tmp;
+          return OK;
+        }
+
+      /* Next table */
+
+      tp += 1;
+    }
+
+  /* Not found */
+
+  return -ENOENT;
+}
+
+/****************************************************************************
+ * Name: acpi_table_find
+ *
+ * Description:
+ *   Find and return table with a given signature
+ *
+ ****************************************************************************/
+
+static int acpi_table_find(const char *sig, struct acpi_sdt_s **sdt)
+{
+  struct acpi_s *acpi = &g_acpi;
+
+  /* 64 bit pointers or 32 bit pointers */
+
+  if (acpi->xsdt != 0)
+    {
+      return acpi_table64_find(sig, sdt);
+    }
+  else
+    {
+      return acpi_table32_find(sig, sdt);
+    }
+}
+
+#ifdef CONFIG_ARCH_X86_64_ACPI_DUMP
+/****************************************************************************
+ * Name: acpi_sdt_dump
+ *
+ * Description:
+ *   Dump SDT entry
+ *
+ ****************************************************************************/
+
+static void acpi_sdt_dump(struct acpi_sdt_s *sdt)
+{
+  acpi_info("ptr = %p sig = %.4s", sdt, sdt->signature);
+}
+#endif
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: acpi_init
+ *
+ * Description:
+ *   Initialize ACPI parser.
+ *
+ ****************************************************************************/
+
+int acpi_init(uintptr_t rsdp)
+{
+  struct acpi_s *acpi = &g_acpi;
+  int            ret  = OK;
+
+  if (rsdp == 0)
+    {
+      /* Find RSP */
+
+      if (!acpi_rsdp_find(acpi))
+        {
+          return -EINVAL;
+        }
+    }
+  else
+    {
+      acpi->rsdp = (struct acpi_rsdp_s *)rsdp;
+    }
+
+  /* Parse RSDP */
+
+  ret = acpi_rsdp_parse(acpi->rsdp);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  /* Cache some useful tables */
+
+  /* Get MADT table */
+
+  ret = acpi_table_find(ACPI_SIG_APIC,
+                        (struct acpi_sdt_s **)&acpi->madt);
+  if (ret < 0)
+    {
+      acpi_err("MADT not present");
+    }
+
+  /* Get MCFG */
+
+  ret = acpi_table_find(ACPI_SIG_MCFG,
+                        (struct acpi_sdt_s **)&acpi->mcfg);
+  if (ret < 0)
+    {
+      acpi_err("MCFG not present");
+    }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: acpi_madt_get
+ *
+ * Description:
+ *   Find the n'th occurence of a MADT entry with a given type.
+ *
+ ****************************************************************************/
+
+int acpi_madt_get(int type, int n, struct acpi_entry_s **entry)
+{
+  struct acpi_s       *acpi = &g_acpi;
+  struct acpi_entry_s *tmp  = NULL;
+  uint8_t             *ptr  = NULL;
+  uint8_t             *end  = NULL;
+
+  if (acpi->madt == NULL)
+    {
+      return -EINVAL;
+    }
+
+  ptr = (uint8_t *)&g_acpi.madt->entries;
+  end = (uint8_t *)((uintptr_t)g_acpi.madt + g_acpi.madt->sdt.length);
+
+  while (ptr < end)
+    {
+      tmp = (struct acpi_entry_s *)ptr;
+
+      if (tmp->type == type)
+        {
+          if (n-- == 0)
+            {
+              *entry = tmp;
+              return OK;
+            }
+        }
+
+      ptr += tmp->length;
+    }
+
+  /* Not found */
+
+  return -ENOENT;
+}
+
+/****************************************************************************
+ * Name: acpi_lapi_get
+ *
+ * Description:
+ *   Get Local APIC entry for a given CPU.
+ *
+ ****************************************************************************/
+
+int acpi_lapic_get(int cpu, struct acpi_lapic_s **lapic)
+{
+  return acpi_madt_get(ACPI_MADT_TYPE_LOCAL_APIC, cpu,
+                       (struct acpi_entry_s **)lapic);
+}
+
+#ifdef CONFIG_ARCH_X86_64_ACPI_DUMP
+/****************************************************************************
+ * Name: acpi_dump
+ *
+ * Description:
+ *   Dump ACPI tables.
+ *
+ ****************************************************************************/
+
+void acpi_dump(void)
+{
+  struct acpi_entry_s *entry = NULL;
+  struct acpi_lapic_s *lapic = NULL;
+  uint8_t             *ptr8  = NULL;
+  uint8_t             *end8  = NULL;
+  struct acpi_entry_s *tmp   = NULL;
+  void                *tps   = NULL;
+  uint64_t            *tp64  = NULL;
+  uint64_t            *end64 = NULL;
+  uint32_t            *tp32  = NULL;
+  uint32_t            *end32 = NULL;
+  int                  i     = 0;
+  int                  ret   = 0;
+
+  /* Dump entires */
+
+  if (g_acpi.xsdt != 0)
+    {
+      tps = &g_acpi.rsdt->table_ptrs;
+      tp64  = (uint64_t *)tps;
+      end64 = (uint64_t *)((uintptr_t)g_acpi.xsdt + g_acpi.xsdt->sdt.length);
+
+      acpi_info("XSDT = %p", g_acpi.xsdt);
+      acpi_info("  tp64 = %p", tp64);
+      acpi_info("  end64 = %p", end64);
+
+      while (tp64 < end64)
+        {
+          acpi_sdt_dump((struct acpi_sdt_s *)(uintptr_t)*tp64);
+
+          /* Next table */
+
+          tp64 += 1;
+        }
+    }
+  else
+    {
+      tps = &g_acpi.rsdt->table_ptrs;
+      tp32  = (uint32_t *)tps;
+      end32 = (uint32_t *)((uintptr_t)g_acpi.rsdt + g_acpi.rsdt->sdt.length);
+
+      acpi_info("RSDT = %p", g_acpi.rsdt);
+      acpi_info("  tp32 = %p", tp32);
+      acpi_info("  end32 = %p", end32);
+
+      while (tp32 < end32)
+        {
+          acpi_sdt_dump((struct acpi_sdt_s *)(uintptr_t)*tp32);
+
+          /* Next table */
+
+          tp32 += 1;
+        }
+    }
+
+  /* Dump MADT */
+
+  ptr8 = (uint8_t *)&g_acpi.madt->entries;
+  end8 = (uint8_t *)((uint64_t)g_acpi.madt + g_acpi.madt->sdt.length);
+
+  while (ptr8 < end8)
+    {
+      tmp = (struct acpi_entry_s *)ptr8;
+      acpi_info("Found MADT type %d %p", tmp->type, tmp);
+      ptr8 += tmp->length;
+    }
+
+  /* Print all CPU */
+
+  while (true)
+    {
+      ret = acpi_lapic_get(i, &lapic);
+      if (ret < 0)
+        {
+          break;
+        }
+
+      acpi_info("Found LAPIC for CPU %d %p", i, lapic);
+      acpi_info("    ACPI ID %d", lapic->acpi_id);
+      acpi_info("    APIC ID %d", lapic->apic_id);
+      acpi_info("    flags %d", lapic->flags);
+
+      /* IO_APIC */
+
+      ret = acpi_madt_get(ACPI_MADT_TYPE_IO_APIC, i, &entry);
+      if (ret == OK)
+        {
+          acpi_info("Found IOAPIC %p", entry);
+        }
+
+      /* APIC64 */
+
+      ret = acpi_madt_get(ACPI_MADT_TYPE_LOCAL_APIC64, i, &entry);
+      if (ret == OK)
+        {
+          acpi_info("Found 64 bit APIC %p", entry);
+        }
+
+      /* X2APIC */
+
+      ret = acpi_madt_get(ACPI_MADT_TYPE_LOCAL_X2APIC, i, &entry);
+      if (ret == OK)
+        {
+          acpi_info("Found X2APIC %p", entry);
+        }
+
+      /* Try next core */
+
+      i += 1;
+    }
+}
+#endif

--- a/arch/x86_64/src/common/x86_64_initialize.c
+++ b/arch/x86_64/src/common/x86_64_initialize.c
@@ -30,6 +30,8 @@
 #  include <nuttx/drivers/addrenv.h>
 #endif
 
+#include <arch/acpi.h>
+
 #include "x86_64_internal.h"
 
 /****************************************************************************
@@ -135,6 +137,12 @@ void up_initialize(void)
   /* Initialize USB -- device and/or host */
 
   x86_64_usbinitialize();
+
+#ifdef CONFIG_ARCH_X86_64_ACPI_DUMP
+  /* Dump ACPI tables */
+
+  acpi_dump();
+#endif
 
   board_autoled_on(LED_IRQSENABLED);
 }

--- a/arch/x86_64/src/intel64/intel64_head.S
+++ b/arch/x86_64/src/intel64/intel64_head.S
@@ -87,9 +87,11 @@ header_start:
 
 	.short  MULTIBOOT_HEADER_TAG_INFORMATION_REQUEST
 	.short  0    /* flags, none set */
-	.long   16   /* size, including itself (short + short + long) */
+	.long   24   /* size, including itself (short + short + long) */
 	.long   MULTIBOOT_TAG_TYPE_EFI64
 	.long   MULTIBOOT_TAG_TYPE_FRAMEBUFFER
+	.long   MULTIBOOT_TAG_TYPE_ACPI_OLD
+	.long   MULTIBOOT_TAG_TYPE_ACPI_NEW
 
 	.short  MULTIBOOT_HEADER_TAG_END
 	.short  0    /* flags, none set */

--- a/arch/x86_64/src/intel64/intel64_start.c
+++ b/arch/x86_64/src/intel64/intel64_start.c
@@ -29,6 +29,8 @@
 #include <arch/board/board.h>
 #include <arch/multiboot2.h>
 
+#include <arch/acpi.h>
+
 #include "x86_64_internal.h"
 #include "intel64.h"
 
@@ -40,6 +42,7 @@
 
 uint32_t g_mb_magic __attribute__((section(".loader.bss")));
 uint32_t g_mb_info_struct __attribute__((section(".loader.bss")));
+uintptr_t g_acpi_rsdp = 0;
 
 /****************************************************************************
  * Private Functions
@@ -74,6 +77,22 @@ static void x86_64_mb2_config(void)
         {
           case MULTIBOOT_TAG_TYPE_EFI64:
             {
+              break;
+            }
+
+          case MULTIBOOT_TAG_TYPE_ACPI_OLD:
+            {
+              struct multiboot_tag_old_acpi *acpi
+                  = (struct multiboot_tag_old_acpi *)tag;
+              g_acpi_rsdp = (uintptr_t)acpi->rsdp;
+              break;
+            }
+
+          case MULTIBOOT_TAG_TYPE_ACPI_NEW:
+            {
+              struct multiboot_tag_new_acpi *acpi =
+                (struct multiboot_tag_new_acpi *)tag;
+              g_acpi_rsdp = (uintptr_t)acpi->rsdp;
               break;
             }
 
@@ -134,6 +153,12 @@ void __nxstart(void)
   /* Low-level, pre-OS initialization */
 
   intel64_lowsetup();
+
+#ifdef CONFIG_ARCH_X86_64_ACPI
+  /* Initialize ACPI */
+
+  acpi_init(g_acpi_rsdp);
+#endif
 
   /* perform board-specific initializations */
 


### PR DESCRIPTION
## Summary
- arch/x86_64: add simple ACPI parser
For now ACPI RSDP signature can be found in BIOS legacy region or can be provided by multiboot2

## Impact
we can access data stored in ACPI tables - required for SMP 

## Testing
qemu and intel hw.

example ACPI dump from qemu (smp = 4):

```
  Booting `kernel'

acpi_init: MCFG not present
acpi_dump: RSDT = 0x7ffe1d57
acpi_dump:   tp32 = 0x7ffe1d7b
acpi_dump:   end32 = 0x7ffe1d8b
acpi_sdt_dump: ptr = 0x7ffe1bf3 sig = FACP
acpi_sdt_dump: ptr = 0x7ffe1c67 sig = APIC
acpi_sdt_dump: ptr = 0x7ffe1cf7 sig = HPET
acpi_sdt_dump: ptr = 0x7ffe1d2f sig = WAET
acpi_dump: Found MADT type 0 0x7ffe1c93
acpi_dump: Found MADT type 0 0x7ffe1c9b
acpi_dump: Found MADT type 0 0x7ffe1ca3
acpi_dump: Found MADT type 0 0x7ffe1cab
acpi_dump: Found MADT type 1 0x7ffe1cb3
acpi_dump: Found MADT type 2 0x7ffe1cbf
acpi_dump: Found MADT type 2 0x7ffe1cc9
acpi_dump: Found MADT type 2 0x7ffe1cd3
acpi_dump: Found MADT type 2 0x7ffe1cdd
acpi_dump: Found MADT type 2 0x7ffe1ce7
acpi_dump: Found MADT type 4 0x7ffe1cf1
acpi_dump: Found LAPIC for CPU 0 0x7ffe1c93
acpi_dump:     ACPI ID 0
acpi_dump:     APIC ID 0
acpi_dump:     flags 1
acpi_dump: Found IOAPIC 0x7ffe1cb3
acpi_dump: Found LAPIC for CPU 1 0x7ffe1c9b
acpi_dump:     ACPI ID 1
acpi_dump:     APIC ID 1
acpi_dump:     flags 1
acpi_dump: Found LAPIC for CPU 2 0x7ffe1ca3
acpi_dump:     ACPI ID 2
acpi_dump:     APIC ID 2
acpi_dump:     flags 1
acpi_dump: Found LAPIC for CPU 3 0x7ffe1cab
acpi_dump:     ACPI ID 3
acpi_dump:     APIC ID 3
acpi_dump:     flags 1

```
