### PR TITLE
arch/risc-v: remove the hard code array of cpu idle stack

### DIFF
--- a/arch/risc-v/src/bl808/bl808_head.S
+++ b/arch/risc-v/src/bl808/bl808_head.S
@@ -90,31 +90,27 @@ real_start:
   wfi
 
 3:
-  /* To get g_cpu_basestack[hartid], must get g_cpu_basestack first */
+  /* Get start address of idle stack array */
 
-  la   t0, g_cpu_basestack
+  la   t0, g_cpux_idlestack
 
-  /* Offset = pointer width * hart id */
+  /* Get idle stack offset */
 
-#ifdef CONFIG_ARCH_RV32
-  slli t1, a0, 2
-#else
-  slli t1, a0, 3
-#endif
-  add  t0, t0, t1
+  li   t1, SMP_STACK_SIZE
+  mul  t1, t1, a0
 
-  /* Load idle stack base to sp */
+  /* Load idle stack top to sp */
 
-  REGLOAD sp, 0(t0)
+  add  sp, t0, t1
 
   /*
-   * sp (stack top) = sp + idle stack size - XCPTCONTEXT_SIZE
+   * sp (stack top) = sp (stack top) - XCPTCONTEXT_SIZE
    *
    * Note: Reserve some space used by up_initial_state since we are already
    * running and using the per CPU idle stack.
    */
 
-  li   t0, STACK_ALIGN_UP(CONFIG_IDLETHREAD_STACKSIZE - XCPTCONTEXT_SIZE)
+  li   t0, -STACK_ALIGN_UP(XCPTCONTEXT_SIZE)
   add  sp, sp, t0
 
 2:

--- a/arch/risc-v/src/common/riscv_common_memorymap.h
+++ b/arch/risc-v/src/common/riscv_common_memorymap.h
@@ -45,6 +45,10 @@
 #define _START_TBSS  _stbss
 #define _END_TBSS    _etbss
 
+#define SMP_STACK_MASK (15)
+#define SMP_STACK_SIZE \
+   ((CONFIG_IDLETHREAD_STACKSIZE + SMP_STACK_MASK) & ~SMP_STACK_MASK)
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/
@@ -63,7 +67,8 @@ EXTERN uintptr_t g_idle_topstack;
 
 /* Address of per-cpu idle stack base */
 
-EXTERN const uint8_t * const g_cpu_basestack[CONFIG_SMP_NCPUS];
+EXTERN uint8_t aligned_data(16)
+g_cpux_idlestack[CONFIG_SMP_NCPUS - 1][SMP_STACK_SIZE];
 
 /* Address of the saved user stack pointer */
 

--- a/arch/risc-v/src/common/riscv_cpuidlestack.c
+++ b/arch/risc-v/src/common/riscv_cpuidlestack.c
@@ -37,8 +37,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define SMP_STACK_MASK       15
-#define SMP_STACK_SIZE       (CONFIG_IDLETHREAD_STACKSIZE & ~15)
 #define STACK_ISALIGNED(a)   ((uintptr_t)(a) & ~SMP_STACK_MASK)
 
 /****************************************************************************
@@ -50,63 +48,12 @@
  *   2. RISC-V requires a 16-byte stack alignment.
  */
 
-#if CONFIG_SMP_NCPUS > 1
-static uint8_t aligned_data(16) cpu1_idlestack[CONFIG_IDLETHREAD_STACKSIZE];
-#endif
-
-#if CONFIG_SMP_NCPUS > 2
-static uint8_t aligned_data(16) cpu2_idlestack[CONFIG_IDLETHREAD_STACKSIZE];
-#endif
-
-#if CONFIG_SMP_NCPUS > 3
-static uint8_t aligned_data(16) cpu3_idlestack[CONFIG_IDLETHREAD_STACKSIZE];
-#endif
-
-#if CONFIG_SMP_NCPUS > 4
-static uint8_t aligned_data(16) cpu4_idlestack[CONFIG_IDLETHREAD_STACKSIZE];
-#endif
-
-#if CONFIG_SMP_NCPUS > 5
-static uint8_t aligned_data(16) cpu5_idlestack[CONFIG_IDLETHREAD_STACKSIZE];
-#endif
-
-#if CONFIG_SMP_NCPUS > 6
-static uint8_t aligned_data(16) cpu6_idlestack[CONFIG_IDLETHREAD_STACKSIZE];
-#endif
-
-#if CONFIG_SMP_NCPUS > 7
-static uint8_t aligned_data(16) cpu7_idlestack[CONFIG_IDLETHREAD_STACKSIZE];
-#endif
+uint8_t aligned_data(16)
+g_cpux_idlestack[CONFIG_SMP_NCPUS - 1][SMP_STACK_SIZE];
 
 /****************************************************************************
  * Public Data
  ****************************************************************************/
-
-const uint8_t * const g_cpu_basestack[CONFIG_SMP_NCPUS] =
-{
-    (uint8_t *)_ebss,
-#if CONFIG_SMP_NCPUS > 1
-    cpu1_idlestack,
-#endif
-#if CONFIG_SMP_NCPUS > 2
-    cpu2_idlestack,
-#endif
-#if CONFIG_SMP_NCPUS > 3
-    cpu3_idlestack,
-#endif
-#if CONFIG_SMP_NCPUS > 4
-    cpu4_idlestack,
-#endif
-#if CONFIG_SMP_NCPUS > 5
-    cpu5_idlestack,
-#endif
-#if CONFIG_SMP_NCPUS > 6
-    cpu6_idlestack,
-#endif
-#if CONFIG_SMP_NCPUS > 7
-    cpu7_idlestack,
-#endif
-};
 
 /****************************************************************************
  * Public Functions
@@ -155,6 +102,7 @@ const uint8_t * const g_cpu_basestack[CONFIG_SMP_NCPUS] =
  *
  ****************************************************************************/
 
+#ifdef CONFIG_SMP
 int up_cpu_idlestack(int cpu, struct tcb_s *tcb, size_t stack_size)
 {
   uintptr_t stack_alloc;
@@ -164,7 +112,7 @@ int up_cpu_idlestack(int cpu, struct tcb_s *tcb, size_t stack_size)
 
   /* Get the top of the stack */
 
-  stack_alloc          = (uintptr_t)g_cpu_basestack[cpu];
+  stack_alloc = (uintptr_t)g_cpux_idlestack[cpu - 1];
   DEBUGASSERT(stack_alloc != 0 && STACK_ISALIGNED(stack_alloc));
 
   tcb->adj_stack_size  = SMP_STACK_SIZE;
@@ -172,3 +120,4 @@ int up_cpu_idlestack(int cpu, struct tcb_s *tcb, size_t stack_size)
   tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
   return OK;
 }
+#endif /* CONFIG_SMP */

--- a/arch/risc-v/src/jh7110/jh7110_head.S
+++ b/arch/risc-v/src/jh7110/jh7110_head.S
@@ -96,31 +96,27 @@ real_start:
   wfi
 
 3:
-  /* To get g_cpu_basestack[hartid], must get g_cpu_basestack first */
+  /* Get start address of idle stack array */
 
-  la   t0, g_cpu_basestack
+  la   t0, g_cpux_idlestack
 
-  /* Offset = pointer width * hart id */
+  /* Get idle stack offset */
 
-#ifdef CONFIG_ARCH_RV32
-  slli t1, a0, 2
-#else
-  slli t1, a0, 3
-#endif
-  add  t0, t0, t1
+  li   t1, SMP_STACK_SIZE
+  mul  t1, t1, a0
 
-  /* Load idle stack base to sp */
+  /* Load idle stack top to sp */
 
-  REGLOAD sp, 0(t0)
+  add  sp, t0, t1
 
   /*
-   * sp (stack top) = sp + idle stack size - XCPTCONTEXT_SIZE
+   * sp (stack top) = sp (stack top) - XCPTCONTEXT_SIZE
    *
    * Note: Reserve some space used by up_initial_state since we are already
    * running and using the per CPU idle stack.
    */
 
-  li   t0, STACK_ALIGN_UP(CONFIG_IDLETHREAD_STACKSIZE - XCPTCONTEXT_SIZE)
+  li   t0, -STACK_ALIGN_UP(XCPTCONTEXT_SIZE)
   add  sp, sp, t0
 
 2:

--- a/arch/risc-v/src/k210/k210_head.S
+++ b/arch/risc-v/src/k210/k210_head.S
@@ -60,27 +60,27 @@ __start:
   wfi
 #endif
 
-  /* To get g_cpu_basestack[mhartid], must get g_cpu_basestack first */
+  /* Get start address of idle stack array */
 
-  la   t0, g_cpu_basestack
+  la   t0, g_cpux_idlestack
 
-  /* Offset = pointer width * hart id */
+  /* Get idle stack offset */
 
-  slli t1, a0, 3
-  add  t0, t0, t1
+  li   t1, SMP_STACK_SIZE
+  mul  t1, t1, a0
 
-  /* Load idle stack base to sp */
+  /* Load idle stack top to sp */
 
-  ld   sp, 0(t0)
+  add  sp, t0, t1
 
   /*
-   * sp (stack top) = sp + idle stack size - XCPTCONTEXT_SIZE
+   * sp (stack top) = sp (stack top) - XCPTCONTEXT_SIZE
    *
    * Note: Reserve some space used by up_initial_state since we are already
    * running and using the per CPU idle stack.
    */
 
-  li   t0, STACK_ALIGN_UP(CONFIG_IDLETHREAD_STACKSIZE - XCPTCONTEXT_SIZE)
+  li   t0, -STACK_ALIGN_UP(XCPTCONTEXT_SIZE)
   add  sp, sp, t0
 
 2:

--- a/arch/risc-v/src/k230/k230_head.S
+++ b/arch/risc-v/src/k230/k230_head.S
@@ -86,27 +86,27 @@ __start:
   wfi
 
 3:
-  /* To get g_cpu_basestack[mhartid], must get g_cpu_basestack first */
+  /* Get start address of idle stack array */
 
-  la   t0, g_cpu_basestack
+  la   t0, g_cpux_idlestack
 
-  /* Offset = pointer width * hart id */
+  /* Get idle stack offset */
 
-  slli t1, a0, 3
-  add  t0, t0, t1
+  li   t1, SMP_STACK_SIZE
+  mul  t1, t1, a0
 
-  /* Load idle stack base to sp */
+  /* Load idle stack top to sp */
 
-  REGLOAD sp, 0(t0)
+  add  sp, t0, t1
 
   /*
-   * sp (stack top) = sp + idle stack size - XCPTCONTEXT_SIZE
+   * sp (stack top) = sp (stack top) - XCPTCONTEXT_SIZE
    *
    * Note: Reserve some space used by up_initial_state since we are already
    * running and using the per CPU idle stack.
    */
 
-  li   t0, STACK_ALIGN_UP(CONFIG_IDLETHREAD_STACKSIZE - XCPTCONTEXT_SIZE)
+  li   t0, -STACK_ALIGN_UP(XCPTCONTEXT_SIZE)
   add  sp, sp, t0
 
 2:

--- a/arch/risc-v/src/qemu-rv/qemu_rv_head.S
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_head.S
@@ -68,31 +68,27 @@ __start:
   wfi
 
 3:
-  /* To get g_cpu_basestack[mhartid], must get g_cpu_basestack first */
+  /* Get start address of idle stack array */
 
-  la   t0, g_cpu_basestack
+  la   t0, g_cpux_idlestack
 
-  /* Offset = pointer width * hart id */
+  /* Get idle stack offset */
 
-#ifdef CONFIG_ARCH_RV32
-  slli t1, a0, 2
-#else
-  slli t1, a0, 3
-#endif
-  add  t0, t0, t1
+  li   t1, SMP_STACK_SIZE
+  mul  t1, t1, a0
 
-  /* Load idle stack base to sp */
+  /* Load idle stack top to sp */
 
-  REGLOAD sp, 0(t0)
+  add  sp, t0, t1
 
   /*
-   * sp (stack top) = sp + idle stack size - XCPTCONTEXT_SIZE
+   * sp (stack top) = sp (stack top) - XCPTCONTEXT_SIZE
    *
    * Note: Reserve some space used by up_initial_state since we are already
    * running and using the per CPU idle stack.
    */
 
-  li   t0, STACK_ALIGN_UP(CONFIG_IDLETHREAD_STACKSIZE - XCPTCONTEXT_SIZE)
+  li   t0, -STACK_ALIGN_UP(XCPTCONTEXT_SIZE)
   add  sp, sp, t0
 
 2:


### PR DESCRIPTION
## Summary

arch/risc-v: remove the hard code array of cpu idle stack

Do not limit the number of CPU idle stacks by hard code

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

rv-virt/smp, rv-virt/smp64, 