### PR TITLE
Documentation: improve documentation about ESP32 family

### DIFF
--- a/Documentation/platforms/risc-v/esp32c6/index.rst
+++ b/Documentation/platforms/risc-v/esp32c6/index.rst
@@ -33,16 +33,16 @@ check for the current compiler version being used. For instance:
 
 .. code-block::
 
-   ###############################################################################
-   # Build image for tool required by RISCV builds
-   ###############################################################################
-   FROM nuttx-toolchain-base AS nuttx-toolchain-riscv
-   # Download the latest RISCV GCC toolchain prebuilt by xPack
-   RUN mkdir riscv-none-elf-gcc && \
-   curl -s -L "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-2/xpack-riscv-none-elf-gcc-12.3.0-2-linux-x64.tar.gz" \
-   | tar -C riscv-none-elf-gcc --strip-components 1 -xz
+  ###############################################################################
+  # Build image for tool required by RISCV builds
+  ###############################################################################
+  FROM nuttx-toolchain-base AS nuttx-toolchain-riscv
+  # Download the latest RISCV GCC toolchain prebuilt by xPack
+  RUN mkdir riscv-none-elf-gcc && \
+  curl -s -L "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/xpack-riscv-none-elf-gcc-13.2.0-2-linux-x64.tar.gz" \
+  | tar -C riscv-none-elf-gcc --strip-components 1 -xz
 
-It uses the xPack's prebuilt toolchain based on GCC 12.3.0.
+It uses the xPack's prebuilt toolchain based on GCC 13.2.0-2.
 
 Installing
 ----------
@@ -51,60 +51,52 @@ First, create a directory to hold the toolchain:
 
 .. code-block:: console
 
-   $ mkdir -p /path/to/your/toolchain/riscv-none-elf-gcc
+  $ mkdir -p /path/to/your/toolchain/riscv-none-elf-gcc
 
 Download and extract toolchain:
 
 .. code-block:: console
 
-   $ curl -s -L "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-2/xpack-riscv-none-elf-gcc-12.3.0-2-linux-x64.tar.gz" \
-   | tar -C /path/to/your/toolchain/riscv-none-elf-gcc --strip-components 1 -xz
+  $ curl -s -L "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/xpack-riscv-none-elf-gcc-13.2.0-2-linux-x64.tar.gz" \
+  | tar -C /path/to/your/toolchain/riscv-none-elf-gcc --strip-components 1 -xz
 
 Add the toolchain to your `PATH`:
 
 .. code-block:: console
 
-   $ echo "export PATH=/path/to/your/toolchain/riscv-none-elf-gcc/bin:$PATH" >> ~/.bashrc
+  $ echo "export PATH=/path/to/your/toolchain/riscv-none-elf-gcc/bin:$PATH" >> ~/.bashrc
 
 You can edit your shell's rc files if you don't use bash.
 
-Second stage bootloader and partition table
-===========================================
+Second stage bootloader
+=======================
 
-The NuttX port for now relies on IDF's second stage bootloader to carry on some hardware
-initializations.  The binaries for the bootloader and the partition table can be found in
-this repository: https://github.com/espressif/esp-nuttx-bootloader
-That repository contains a dummy IDF project that's used to build the bootloader and
-partition table, these are then presented as Github assets and can be downloaded
-from: https://github.com/espressif/esp-nuttx-bootloader/releases
-Download ``bootloader-esp32c6.bin`` and ``partition-table-esp32c6.bin`` and place them
-in a folder, the path to this folder will be used later to program them. This
-can be: ``../esp-bins``
+Nuttx can boot the ESP32-H2 directly using the so-called "Simple Boot". 
+An externally-built 2nd stage bootloader is not required in this case as all
+functions required to boot the device are built within Nuttx. Simple boot does not
+require any specific configuration (it is selectable by default if no other
+2nd stage bootloader is used). For compatibility among other SoCs and future options
+of 2nd stage bootloaders, the commands ``make bootloader`` and the ``ESPTOOL_BINDIR``
+option (for the ``make flash``) are kept (and ignored if Simple Boot is used).
 
 Building and flashing
 =====================
 
-First make sure that ``esptool.py`` is installed.  This tool is used to convert
+First, make sure that ``esptool.py`` is installed.  This tool is used to convert
 the ELF to a compatible ESP32-C6 image and to flash the image into the board.
 It can be installed with: ``pip install esptool``.
 
-Configure the NuttX project: ``./tools/configure.sh esp32c6-devkitc:nsh`` or
-``./tools/configure.sh esp32c6-devkitm:nsh``Run ``make`` to build the project.
-Note that the conversion mentioned above is included in the build process.
-The ``esptool.py`` command to flash all the binaries is::
+Configure the NuttX project: ``./tools/configure.sh esp32c6-devkitc:nsh``
+Run ``make`` to build the project.  Note that the conversion mentioned above is
+included in the build process.
+The ``esptool.py`` is used to flash all the binaries. However, this is also
+included in the build process and we can build and flash with::
 
-     esptool.py --chip esp32c6 --port /dev/ttyUSBXX --baud 921600 write_flash 0x0 bootloader.bin 0x8000 partition-table.bin 0x10000 nuttx.bin
+  make flash ESPTOOL_PORT=<port> ESPTOOL_BINDIR=./
 
-However, this is also included in the build process and we can build and flash with::
-
-   make flash ESPTOOL_PORT=<port> ESPTOOL_BINDIR=../esp-bins
-
-Where ``<port>`` is typically ``/dev/ttyUSB0`` or similar and ``../esp-bins`` is
-the path to the folder containing the bootloader and the partition table
-for the ESP32-C6 as explained above.
-Note that this step is required only one time.  Once the bootloader and partition
-table are flashed, we don't need to flash them again.  So subsequent builds
-would just require: ``make flash ESPTOOL_PORT=/dev/ttyUSBXX``
+Where ``<port>`` is typically ``/dev/ttyUSB0`` or similar and ``./`` is
+the path to the folder containing the externally-built 2nd stage bootloader for
+the ESP32-C6 as explained above.
 
 Debugging with OpenOCD
 ======================
@@ -112,12 +104,12 @@ Debugging with OpenOCD
 Download and build OpenOCD from Espressif, that can be found in
 https://github.com/espressif/openocd-esp32
 
-You don not need an external JTAG is to debug, the ESP32-C6 integrates a
+You do not need an external JTAG to debug, the ESP32-C6 integrates a
 USB-to-JTAG adapter.
 
 OpenOCD can then be used::
 
-   openocd -c 'set ESP_RTOS none' -f board/esp32c6-builtin.cfg
+  openocd -c 'set ESP_RTOS none' -f board/esp32c6-builtin.cfg
 
 If you want to debug with an external JTAG adapter it can
 be connected as follows::
@@ -179,7 +171,7 @@ Supported Boards
 ================
 
 .. toctree::
-   :glob:
-   :maxdepth: 1
+  :glob:
+  :maxdepth: 1
 
-   boards/*/*
+  boards/*/*

--- a/Documentation/platforms/risc-v/esp32h2/index.rst
+++ b/Documentation/platforms/risc-v/esp32h2/index.rst
@@ -28,21 +28,21 @@ ESP32-H2 Toolchain
 
 A generic RISC-V toolchain can be used to build ESP32-H2 projects. It's recommended to use the same
 toolchain used by NuttX CI. Please refer to the Docker
-`container <https://github.com/apache/nuttx/tree/master/tools/ci/docker/linux/Dockerfile>`_ and
+`container <https://github.com/apache/nuttx/tree/master/tools/ci/docker/linux/Dockerfile>`_ and 
 check for the current compiler version being used. For instance:
 
 .. code-block::
 
-   ###############################################################################
-   # Build image for tool required by RISCV builds
-   ###############################################################################
-   FROM nuttx-toolchain-base AS nuttx-toolchain-riscv
-   # Download the latest RISCV GCC toolchain prebuilt by xPack
-   RUN mkdir riscv-none-elf-gcc && \
-   curl -s -L "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-2/xpack-riscv-none-elf-gcc-12.3.0-2-linux-x64.tar.gz" \
-   | tar -C riscv-none-elf-gcc --strip-components 1 -xz
+  ###############################################################################
+  # Build image for tool required by RISCV builds
+  ###############################################################################
+  FROM nuttx-toolchain-base AS nuttx-toolchain-riscv
+  # Download the latest RISCV GCC toolchain prebuilt by xPack
+  RUN mkdir riscv-none-elf-gcc && \
+  curl -s -L "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/xpack-riscv-none-elf-gcc-13.2.0-2-linux-x64.tar.gz" \
+  | tar -C riscv-none-elf-gcc --strip-components 1 -xz
 
-It uses the xPack's prebuilt toolchain based on GCC 12.3.0.
+It uses the xPack's prebuilt toolchain based on GCC 13.2.0-2.
 
 Installing
 ----------
@@ -51,60 +51,52 @@ First, create a directory to hold the toolchain:
 
 .. code-block:: console
 
-   $ mkdir -p /path/to/your/toolchain/riscv-none-elf-gcc
+  $ mkdir -p /path/to/your/toolchain/riscv-none-elf-gcc
 
 Download and extract toolchain:
 
 .. code-block:: console
 
-   $ curl -s -L "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-2/xpack-riscv-none-elf-gcc-12.3.0-2-linux-x64.tar.gz" \
-   | tar -C /path/to/your/toolchain/riscv-none-elf-gcc --strip-components 1 -xz
+  $ curl -s -L "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/xpack-riscv-none-elf-gcc-13.2.0-2-linux-x64.tar.gz" \
+  | tar -C /path/to/your/toolchain/riscv-none-elf-gcc --strip-components 1 -xz
 
 Add the toolchain to your `PATH`:
 
 .. code-block:: console
 
-   $ echo "export PATH=/path/to/your/toolchain/riscv-none-elf-gcc/bin:$PATH" >> ~/.bashrc
+  $ echo "export PATH=/path/to/your/toolchain/riscv-none-elf-gcc/bin:$PATH" >> ~/.bashrc
 
 You can edit your shell's rc files if you don't use bash.
 
-Second stage bootloader and partition table
-===========================================
+Second stage bootloader
+=======================
 
-The NuttX port for now relies on IDF's second stage bootloader to carry on some hardware
-initializations.  The binaries for the bootloader and the partition table can be found in
-this repository: https://github.com/espressif/esp-nuttx-bootloader
-That repository contains a dummy IDF project that's used to build the bootloader and
-partition table, these are then presented as Github assets and can be downloaded
-from: https://github.com/espressif/esp-nuttx-bootloader/releases
-Download ``bootloader-esp32h2.bin`` and ``partition-table-esp32h2.bin`` and place them
-in a folder, the path to this folder will be used later to program them. This
-can be: ``../esp-bins``
+Nuttx can boot the ESP32-H2 directly using the so-called "Simple Boot". 
+An externally-built 2nd stage bootloader is not required in this case as all
+functions required to boot the device are built within Nuttx. Simple boot does not
+require any specific configuration (it is selectable by default if no other
+2nd stage bootloader is used). For compatibility among other SoCs and future options
+of 2nd stage bootloaders, the commands ``make bootloader`` and the ``ESPTOOL_BINDIR``
+option (for the ``make flash``) are kept (and ignored if Simple Boot is used).
 
 Building and flashing
 =====================
 
-First make sure that ``esptool.py`` is installed.  This tool is used to convert
+First, make sure that ``esptool.py`` is installed.  This tool is used to convert
 the ELF to a compatible ESP32-H2 image and to flash the image into the board.
 It can be installed with: ``pip install esptool``.
 
 Configure the NuttX project: ``./tools/configure.sh esp32h2-devkit:nsh``
 Run ``make`` to build the project.  Note that the conversion mentioned above is
 included in the build process.
-The ``esptool.py`` command to flash all the binaries is::
+The ``esptool.py`` is used to flash all the binaries. However, this is also
+included in the build process and we can build and flash with::
 
-     esptool.py --chip esp32h2 --port /dev/ttyUSBXX --baud 921600 write_flash 0x0 bootloader.bin 0x8000 partition-table.bin 0x10000 nuttx.bin
+  make flash ESPTOOL_PORT=<port> ESPTOOL_BINDIR=./
 
-However, this is also included in the build process and we can build and flash with::
-
-   make flash ESPTOOL_PORT=<port> ESPTOOL_BINDIR=../esp-bins
-
-Where ``<port>`` is typically ``/dev/ttyUSB0`` or similar and ``../esp-bins`` is
-the path to the folder containing the bootloader and the partition table
-for the ESP32-H2 as explained above.
-Note that this step is required only one time.  Once the bootloader and partition
-table are flashed, we don't need to flash them again.  So subsequent builds
-would just require: ``make flash ESPTOOL_PORT=/dev/ttyUSBXX``
+Where ``<port>`` is typically ``/dev/ttyUSB0`` or similar and ``./`` is
+the path to the folder containing the externally-built 2nd stage bootloader for
+the ESP32-H2 as explained above.
 
 Debugging with OpenOCD
 ======================
@@ -117,7 +109,7 @@ USB-to-JTAG adapter.
 
 OpenOCD can then be used::
 
-   openocd -c 'set ESP_RTOS none' -f board/esp32h2-builtin.cfg
+  openocd -c 'set ESP_RTOS none' -f board/esp32h2-builtin.cfg
 
 If you want to debug with an external JTAG adapter it can
 be connected as follows::
@@ -179,7 +171,7 @@ Supported Boards
 ================
 
 .. toctree::
-   :glob:
-   :maxdepth: 1
+  :glob:
+  :maxdepth: 1
 
-   boards/*/*
+  boards/*/*

--- a/Documentation/platforms/xtensa/esp32/index.rst
+++ b/Documentation/platforms/xtensa/esp32/index.rst
@@ -16,16 +16,61 @@ On dual-core SoCs, the two CPUs are typically named "PRO_CPU" and "APP_CPU"
 (for "protocol" and "application"), however for most purposes the
 two CPUs are interchangeable.
 
-Toolchain
-=========
+ESP32 Toolchain
+==================
 
-You can use the prebuilt `toolchain <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/tools/idf-tools.html#xtensa-esp32-elf>`__
-for Xtensa architecture and `OpenOCD <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/tools/idf-tools.html#openocd-esp32>`__
-for ESP32 by Espressif.
+The toolchain used to build ESP32 firmware can be either downloaded or built from the sources.
+It is **highly** recommended to use (download or build) the same toolchain version that is being
+used by the NuttX CI.
 
-For flashing firmware, you will need to install ``esptool.py`` by running::
+Please refer to the Docker
+`container <https://github.com/apache/nuttx/tree/master/tools/ci/docker/linux/Dockerfile>`_ and
+check for the current compiler version being used. For instance:
 
-    $ pip install esptool
+.. code-block::
+
+  ###############################################################################
+  # Build image for tool required by ESP32 builds
+  ###############################################################################
+  FROM nuttx-toolchain-base AS nuttx-toolchain-esp32
+  # Download the latest ESP32 GCC toolchain prebuilt by Espressif
+  RUN mkdir -p xtensa-esp32-elf-gcc && \
+    curl -s -L "https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/xtensa-esp32-elf-12.2.0_20230208-x86_64-linux-gnu.tar.xz" \
+    | tar -C xtensa-esp32-elf-gcc --strip-components 1 -xJ
+
+  RUN mkdir -p xtensa-esp32s2-elf-gcc && \
+    curl -s -L "https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/xtensa-esp32s2-elf-12.2.0_20230208-x86_64-linux-gnu.tar.xz" \
+    | tar -C xtensa-esp32s2-elf-gcc --strip-components 1 -xJ
+
+  RUN mkdir -p xtensa-esp32s3-elf-gcc && \
+    curl -s -L "https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/xtensa-esp32s3-elf-12.2.0_20230208-x86_64-linux-gnu.tar.xz" \
+    | tar -C xtensa-esp32s3-elf-gcc --strip-components 1 -xJ
+
+For ESP32, the toolchain version is based on GGC 12.2.0 (``xtensa-esp32-elf-12.2.0_20230208``)
+
+The prebuilt Toolchain (Recommended)
+------------------------------------
+
+First, create a directory to hold the toolchain:
+
+.. code-block:: console
+
+  $ mkdir -p /path/to/your/toolchain/xtensa-esp32-elf-gcc
+
+Download and extract toolchain:
+
+.. code-block:: console
+
+  $ curl -s -L "https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/xtensa-esp32-elf-12.2.0_20230208-x86_64-linux-gnu.tar.xz" \
+  | tar -C xtensa-esp32-elf-gcc --strip-components 1 -xJ
+
+Add the toolchain to your `PATH`:
+
+.. code-block:: console
+
+  $ echo "export PATH=/path/to/your/toolchain/xtensa-esp32-elf-gcc/bin:$PATH" >> ~/.bashrc
+
+You can edit your shell's rc files if you don't use bash.
 
 Building from source
 --------------------
@@ -37,7 +82,6 @@ build the toolchain with crosstool-NG on Linux are as follows
 
   $ git clone https://github.com/espressif/crosstool-NG.git
   $ cd crosstool-NG
-  $ git checkout esp-2021r1
   $ git submodule update --init
 
   $ ./bootstrap && ./configure --enable-local && make

--- a/Documentation/platforms/xtensa/esp32s2/index.rst
+++ b/Documentation/platforms/xtensa/esp32s2/index.rst
@@ -9,16 +9,61 @@ All embedded memory, external memory and peripherals are located on the
 data bus and/or the instruction bus of the CPU. Multiple peripherals in
 the system can access embedded memory via DMA.
 
-Toolchain
-=========
+ESP32-S2 Toolchain
+==================
 
-You can use the prebuilt `toolchain <https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-guides/tools/idf-tools.html#xtensa-esp32-elf>`__
-for Xtensa architecture and `OpenOCD <https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-guides/tools/idf-tools.html#openocd-esp32>`__
-for ESP32-S2 by Espressif.
+The toolchain used to build ESP32-S2 firmware can be either downloaded or built from the sources.
+It is **highly** recommended to use (download or build) the same toolchain version that is being
+used by the NuttX CI.
 
-For flashing firmware, you will need to install ``esptool.py`` by running::
+Please refer to the Docker
+`container <https://github.com/apache/nuttx/tree/master/tools/ci/docker/linux/Dockerfile>`_ and
+check for the current compiler version being used. For instance:
 
-    $ pip install esptool
+.. code-block::
+
+  ###############################################################################
+  # Build image for tool required by ESP32 builds
+  ###############################################################################
+  FROM nuttx-toolchain-base AS nuttx-toolchain-esp32
+  # Download the latest ESP32 GCC toolchain prebuilt by Espressif
+  RUN mkdir -p xtensa-esp32-elf-gcc && \
+    curl -s -L "https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/xtensa-esp32-elf-12.2.0_20230208-x86_64-linux-gnu.tar.xz" \
+    | tar -C xtensa-esp32-elf-gcc --strip-components 1 -xJ
+
+  RUN mkdir -p xtensa-esp32s2-elf-gcc && \
+    curl -s -L "https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/xtensa-esp32s2-elf-12.2.0_20230208-x86_64-linux-gnu.tar.xz" \
+    | tar -C xtensa-esp32s2-elf-gcc --strip-components 1 -xJ
+
+  RUN mkdir -p xtensa-esp32s3-elf-gcc && \
+    curl -s -L "https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/xtensa-esp32s3-elf-12.2.0_20230208-x86_64-linux-gnu.tar.xz" \
+    | tar -C xtensa-esp32s3-elf-gcc --strip-components 1 -xJ
+
+For ESP32-S2, the toolchain version is based on GGC 12.2.0 (``xtensa-esp32s2-elf-12.2.0_20230208``)
+
+The prebuilt Toolchain (Recommended)
+------------------------------------
+
+First, create a directory to hold the toolchain:
+
+.. code-block:: console
+
+  $ mkdir -p /path/to/your/toolchain/xtensa-esp32s2-elf-gcc
+
+Download and extract toolchain:
+
+.. code-block:: console
+
+  $ curl -s -L "https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/xtensa-esp32s2-elf-12.2.0_20230208-x86_64-linux-gnu.tar.xz" \
+  | tar -C xtensa-esp32s2-elf-gcc --strip-components 1 -xJ
+
+Add the toolchain to your `PATH`:
+
+.. code-block:: console
+
+  $ echo "export PATH=/path/to/your/toolchain/xtensa-esp32s2-elf-gcc/bin:$PATH" >> ~/.bashrc
+
+You can edit your shell's rc files if you don't use bash.
 
 Building from source
 --------------------
@@ -30,20 +75,19 @@ build the toolchain with crosstool-NG on Linux are as follows
 
   $ git clone https://github.com/espressif/crosstool-NG.git
   $ cd crosstool-NG
-  $ git checkout esp-2021r1
   $ git submodule update --init
 
   $ ./bootstrap && ./configure --enable-local && make
 
-  $ ./ct-ng xtensa-esp32-elf
+  $ ./ct-ng xtensa-esp32s2-elf
   $ ./ct-ng build
 
-  $ chmod -R u+w builds/xtensa-esp32-elf
+  $ chmod -R u+w builds/xtensa-esp32s2-elf
 
   $ export PATH="crosstool-NG/builds/xtensa-esp32-elf/bin:$PATH"
 
-Alternatively, you may follow the steps in
-`ESP-IDF documentation <https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/get-started/linux-macos-setup.html>`_.
+These steps are given in the setup guide in
+`ESP-IDF documentation <https://docs.espressif.com/projects/esp-idf/en/latest/get-started/linux-setup-scratch.html>`_.
 
 Flashing
 ========


### PR DESCRIPTION
## Summary

* Documentation: improve documentation about the ESP32 family

In particular, sections regarding the toolchain setup and usage and the bootloader options were updated. Also, minor issues were fixed.

## Impact

Make it clear how to setup the toolchain and avoid issues like #12111

## Testing

Internal CI testing + 

```
cd Documentation
sphinx-build ./ ./_build
```