### PR TITLE
x86_64_acpi.c: make sure that RSDP is mapped

### DIFF
--- a/arch/x86_64/src/common/x86_64_acpi.c
+++ b/arch/x86_64/src/common/x86_64_acpi.c
@@ -454,6 +454,10 @@ int acpi_init(uintptr_t rsdp)
       acpi->rsdp = (struct acpi_rsdp_s *)rsdp;
     }
 
+  /* Make sure that RSDP is mapped */
+
+  acpi_map_region((uintptr_t)acpi->rsdp, sizeof(struct acpi_rsdp_s));
+
   /* Parse RSDP */
 
   ret = acpi_rsdp_parse(acpi->rsdp);


### PR DESCRIPTION
## Summary
- x86_64_acpi.c: make sure that RSDP is mapped
rsdp memory may be not mapped when provided from multiboot2 header. For some reason the previous code worked on some machines.

## Impact

## Testing
qemu
