### PR TITLE
libs/libc/inttypes: add support for imaxdiv

### DIFF
--- a/include/inttypes.h
+++ b/include/inttypes.h
@@ -348,7 +348,13 @@
  *   function.
  */
 
-typedef void *imaxdiv_t; /* Dummy type since imaxdiv is not yet supported */
+struct imaxdiv_s
+{
+  intmax_t quot;
+  intmax_t rem;
+};
+
+typedef struct imaxdiv_s imaxdiv_t;
 
 /****************************************************************************
  * Public Function Prototypes

--- a/libs/libc/inttypes/CMakeLists.txt
+++ b/libs/libc/inttypes/CMakeLists.txt
@@ -18,4 +18,5 @@
 #
 # ##############################################################################
 
-target_sources(c PRIVATE lib_imaxabs.c lib_strtoimax.c lib_strtoumax.c)
+target_sources(c PRIVATE lib_imaxabs.c lib_imaxdiv.c lib_strtoimax.c
+                         lib_strtoumax.c)

--- a/libs/libc/inttypes/Make.defs
+++ b/libs/libc/inttypes/Make.defs
@@ -20,7 +20,7 @@
 
 # Add the inttypes C files to the build
 
-CSRCS += lib_imaxabs.c lib_strtoimax.c lib_strtoumax.c
+CSRCS += lib_imaxabs.c lib_imaxdiv.c lib_strtoimax.c lib_strtoumax.c
 
 # Add the inttypes directory to the build
 

--- a/libs/libc/inttypes/lib_imaxdiv.c
+++ b/libs/libc/inttypes/lib_imaxdiv.c
@@ -1,0 +1,39 @@
+/****************************************************************************
+ * libs/libc/inttypes/lib_imaxdiv.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <inttypes.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+imaxdiv_t imaxdiv(intmax_t numer, intmax_t denom)
+{
+  imaxdiv_t f;
+
+  f.quot = numer / denom;
+  f.rem  = numer % denom;
+  return f;
+}


### PR DESCRIPTION
## Summary
imaxdiv() is in C99 and Open Group specifications, was missing from NuttX.

## Impact

## Testing

