### PR TITLE
arch/imx9: Add PSCI (system reset) support

### DIFF
--- a/arch/arm64/src/imx9/Kconfig
+++ b/arch/arm64/src/imx9/Kconfig
@@ -16,7 +16,9 @@ config ARCH_CHIP_IMX93
 	select ARCH_HAVE_MULTICPU
 	select ARMV8A_HAVE_GICv3
 	select ARCH_CORTEX_A55
+	select ARCH_HAVE_PSCI
 	select ARCH_HAVE_PWM_MULTICHAN
+	select ARCH_HAVE_RESET
 
 endchoice # i.MX9 Chip Selection
 

--- a/arch/arm64/src/imx9/imx9_boot.c
+++ b/arch/arm64/src/imx9/imx9_boot.c
@@ -105,6 +105,10 @@ void arm64_chip_boot(void)
   imx9_lowsetup();
 #endif
 
+#if defined(CONFIG_SMP) || defined(CONFIG_ARCH_HAVE_PSCI)
+  arm64_psci_init("smc");
+#endif
+
   /* Initialize pin interrupt support */
 
 #ifdef CONFIG_IMX9_GPIO_IRQ


### PR DESCRIPTION
## Summary
ARMv8.2-A has PSCI -> it also has support for system reset

## Impact
Add support for system reset with imx9
## Testing
imx9-evk:nsh
