### PR TITLE
tmpfs:Add ioctl access path function

### DIFF
--- a/fs/tmpfs/fs_tmpfs.h
+++ b/fs/tmpfs/fs_tmpfs.h
@@ -79,6 +79,7 @@ struct tmpfs_object_s
   size_t   to_alloc;     /* Allocated size of the memory object */
   uint8_t  to_type;      /* See enum tmpfs_objtype_e */
   uint8_t  to_refs;      /* Reference count */
+  FAR struct tmpfs_directory_s *to_parent;
 };
 
 /* The form of a directory memory object */
@@ -92,6 +93,7 @@ struct tmpfs_directory_s
   size_t   tdo_alloc;    /* Allocated size of the directory object */
   uint8_t  tdo_type;     /* See enum tmpfs_objtype_e */
   uint8_t  tdo_refs;     /* Reference count */
+  FAR struct tmpfs_directory_s *tdo_parent;
 
   /* Remaining fields are unique to a directory object */
 
@@ -118,6 +120,7 @@ struct tmpfs_file_s
   size_t   tfo_alloc;    /* Allocated size of the file object */
   uint8_t  tfo_type;     /* See enum tmpfs_objtype_e */
   uint8_t  tfo_refs;     /* Reference count */
+  FAR struct tmpfs_directory_s *tfo_parent;
 
   /* Remaining fields are unique to a directory object */
 


### PR DESCRIPTION
## Summary
Added support for FIOC_FILEPATH in tmpfs. Now we can use ioctl to get the path of tmpfs corresponding to fd

```
ioctl(fd, FIOC_FILEPATH, &path)
```

## Impact
tmpfs adds “ioctl” support

## Testing
Local test PASS
