### PR TITLE
x86_64_acpi.c: avoid debug messages in acpi_init()

### DIFF
--- a/arch/x86_64/src/common/x86_64_acpi.c
+++ b/arch/x86_64/src/common/x86_64_acpi.c
@@ -469,21 +469,11 @@ int acpi_init(uintptr_t rsdp)
 
   /* Get MADT table */
 
-  ret = acpi_table_find(ACPI_SIG_APIC,
-                        (struct acpi_sdt_s **)&acpi->madt);
-  if (ret < 0)
-    {
-      acpi_err("MADT not present");
-    }
+  acpi_table_find(ACPI_SIG_APIC, (struct acpi_sdt_s **)&acpi->madt);
 
   /* Get MCFG */
 
-  ret = acpi_table_find(ACPI_SIG_MCFG,
-                        (struct acpi_sdt_s **)&acpi->mcfg);
-  if (ret < 0)
-    {
-      acpi_err("MCFG not present");
-    }
+  acpi_table_find(ACPI_SIG_MCFG, (struct acpi_sdt_s **)&acpi->mcfg);
 
   return OK;
 }


### PR DESCRIPTION
## Summary
- x86_64_acpi.c: avoid debug messages in acpi_init()
acpi_init() must be called early during boot, some system components may be unavailable at this stage, so debug messages won't work

## Impact

## Testing
qemu and hw
