### PR TITLE
lpc17_40 i2c: Fix I2C driver state desynchronization.

### DIFF
--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_i2c.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_i2c.c
@@ -227,6 +227,8 @@ static int lpc17_40_i2c_start(struct lpc17_40_i2cdev_s *priv)
   uint32_t timeout;
   int i;
 
+  nxsem_reset(&priv->wait, 0);
+
   putreg32(I2C_CONCLR_STAC | I2C_CONCLR_SIC,
            priv->base + LPC17_40_I2C_CONCLR_OFFSET);
   putreg32(I2C_CONSET_STA, priv->base + LPC17_40_I2C_CONSET_OFFSET);


### PR DESCRIPTION
## Summary

Fixes a potential state machine desynchronization in the I2C driver of LPC17xx & LPC40xx.

When the I2C driver needs to transmit a new message, [lpc17_40_i2c_start](https://github.com/apache/nuttx/blob/master/arch/arm/src/lpc17xx_40xx/lpc17_40_i2c.c#L223C12-L223C30) is called, that [waits on a semaphore](https://github.com/apache/nuttx/blob/master/arch/arm/src/lpc17xx_40xx/lpc17_40_i2c.c#L255) till the transaction is complete. This semaphore can be posted in two places, allowing the code to continue: when the transaction is [finished](https://github.com/apache/nuttx/blob/master/arch/arm/src/lpc17xx_40xx/lpc17_40_i2c.c#L279) and when there is a [timeout](https://github.com/apache/nuttx/blob/master/arch/arm/src/lpc17xx_40xx/lpc17_40_i2c.c#L296).

As it turns out, in some rare cases it is possible that **both** conditions may be met, posting the semaphore twice.

For example, it is possible that a timeout may post the semaphore, and right after that, an ACK may be received also posting the same semaphore.

In this case, the final value of the semaphore will be 1, instead of 0, desynchronizing the internal state of the driver. During the next transmisssion, `lpc17_40_i2c_start` will never wait, rather it will use the semaphore posted during the last transmission, and return immediatelly. Later a received ACK will once again set the semaphore to 1, and the cycle repeats.

This error is unrecoverable, and a full system reset is required.

This fix ensures that the semaphore is always reset to zero when a transaction is started, essentially restoring the state of the driver. The error may still happen, but the driver will be able to recover quickly on the next transmission. The driver is now guaranteed to only wait for semaphores posted for this transaction and not pending ones.

## Impact

Bug fix in I2C driver.


## Testing

Tested on custom hardware / firmware based on LPC1769.

The system is now verified to successfully recover from this problem.
