### PR TITLE
imx9_clockconfig: Add way to change and ask for PLL frequency

### DIFF
--- a/arch/arm64/src/imx9/Kconfig
+++ b/arch/arm64/src/imx9/Kconfig
@@ -310,10 +310,6 @@ config IMX9_LPSPI
 	bool "LPSPI support"
 	default n
 
-config IMX9_PLL
-	bool "PLL setup support"
-	default n
-
 menu "LPI2C Peripherals"
 
 menuconfig IMX9_LPI2C1

--- a/arch/arm64/src/imx9/Kconfig
+++ b/arch/arm64/src/imx9/Kconfig
@@ -311,7 +311,7 @@ config IMX9_LPSPI
 	default n
 
 config IMX9_PLL
-	bool "PLL setup support (WIP)"
+	bool "PLL setup support"
 	default n
 
 menu "LPI2C Peripherals"

--- a/arch/arm64/src/imx9/hardware/imx93/imx93_ccm.h
+++ b/arch/arm64/src/imx9/hardware/imx93/imx93_ccm.h
@@ -168,6 +168,10 @@
 
 #define CCM_GPR_SH_GPR_SHIFT              (0)       /* Bits 0-31:  General purpose register, shared for all CPU domains (GPR) */
 #define CCM_GPR_SH_GPR_MASK               (0xffffffff << CCM_GPR_SH_GPR_SHIFT)
+#define CCM_GPR_A55_CLK_SEL_SHIFT         (0)
+#define CCM_GPR_A55_CLK_SEL_MASK          (0x01 << CCM_GPR_A55_CLK_SEL_SHIFT)
+#define CCM_GPR_A55_CLK_SEL_CCM           (0 << 0)
+#define CCM_GPR_A55_CLK_SEL_PLL           (1 << 0)
 
 /* General Purpose Register (GPR_SHAREDn_AUTHEN, n=0..7) */
 
@@ -560,6 +564,12 @@
 #define CCM_LPCG_TSTMR2         124
 #define CCM_LPCG_TMC            125
 #define CCM_LPCG_PMRO           126
+
+/* Shared register indices */
+
+#define CCM_SHARED_EXT_CLK      0
+#define CCM_SHARED_A55_CLK      1
+#define CCM_SHARED_DRAM_CLK     2
 
 /* Other parameters */
 

--- a/arch/arm64/src/imx9/hardware/imx93/imx93_pll.h
+++ b/arch/arm64/src/imx9/hardware/imx93/imx93_pll.h
@@ -175,7 +175,7 @@
 #define PLL_DFS_MFN_MASK         (0x7 << PLL_DFS_MFN_SHIFT)
 #define PLL_DFS_MFN(n)           (((n) << PLL_DFS_MFN_SHIFT) & PLL_DFS_MFN_MASK)
 #define PLL_DFS_MFI_SHIFT        (8) /* Bits 8-15: MFI */
-#define PLL_DFS_MFI_MASK         (0xFF << PLL_DFS_MFI_SHIFT)
+#define PLL_DFS_MFI_MASK         (0xff << PLL_DFS_MFI_SHIFT)
 #define PLL_DFS_MFI(n)           (((n) << PLL_DFS_MFI_SHIFT) & PLL_DFS_MFI_MASK)
 
 /* PLL Dividers (DIV) */
@@ -191,36 +191,5 @@
 #define PLL_DFS_STATUS_DFS_OK_SHIFT (0) /* Bits 0-2: DFS OK status */
 #define PLL_DFS_STATUS_DFS_OK_MASK  (0x7 << PLL_DFS_STATUS_DFS_OK_SHIFT)
 #define PLL_DFS_STATUS_DFS_OK(n)    (((n) << PLL_DFS_STATUS_DFS_OK_SHIFT) & PLL_DFS_STATUS_DFS_OK_MASK)
-
-/****************************************************************************
- * Public Types
- ****************************************************************************/
-
-struct pll_parms
-{
-  /* Integer part (DIV) */
-
-  struct
-  {
-    uint32_t rdiv; /* Input clock divider */
-    uint32_t odiv; /* PLL output divider */
-    uint32_t mfi;  /* PLL integer divider */
-  };
-
-  /* Fractional part (NUMERATOR / DENOMINATOR) */
-
-  struct
-  {
-    uint32_t mfn;  /* PLL fractional divider numerator */
-    uint32_t mfd;  /* PLL fractional divider denominator */
-  };
-};
-
-struct pfd_parms
-{
-  uint32_t mfi;       /* PLL integer divider */
-  uint32_t mfn;       /* PLL fractional divider numerator */
-  bool     divby2_en; /* Enable the divide-by-2 output */
-};
 
 #endif /* __ARCH_ARM64_SRC_IMX9_HARDWARE_IMX93_IMX93_PLL_H_*/

--- a/arch/arm64/src/imx9/hardware/imx93/imx93_pll.h
+++ b/arch/arm64/src/imx9/hardware/imx93/imx93_pll.h
@@ -155,7 +155,7 @@
 #define PLL_DIV_ODIV_MASK  (0xff << PLL_DIV_ODIV_SHIFT)
 #define PLL_DIV_ODIV(n)    (((n) << PLL_DIV_ODIV_SHIFT) & PLL_DIV_ODIV_MASK)
 #define PLL_DIV_RDIV_SHIFT (13) /* Bits 13-15: Input Clock Predivider */
-#define PLL_DIV_RDIV_MASK  (0xe << PLL_DIV_RDIV_SHIFT)
+#define PLL_DIV_RDIV_MASK  (0x7 << PLL_DIV_RDIV_SHIFT)
 #define PLL_DIV_RDIV(n)    (((n) << PLL_DIV_RDIV_SHIFT) & PLL_DIV_RDIV_MASK)
 #define PLL_DIV_MFI_SHIFT  (16) /* Bits 16-24: Integer Portion of Loop Divider */
 #define PLL_DIV_MFI_MASK   (0x1ff << PLL_DIV_MFI_SHIFT)

--- a/arch/arm64/src/imx9/imx9_boot.c
+++ b/arch/arm64/src/imx9/imx9_boot.c
@@ -99,6 +99,10 @@ void arm64_chip_boot(void)
 
   arm64_mmu_init(true);
 
+  /* Initialize system clocks to some sensible state */
+
+  imx9_clockconfig();
+
   /* Do UART early initialization & pin muxing */
 
 #ifdef CONFIG_IMX9_LPUART

--- a/arch/arm64/src/imx9/imx9_boot.c
+++ b/arch/arm64/src/imx9/imx9_boot.c
@@ -39,6 +39,7 @@
 #include "arm64_mmu.h"
 
 #include "imx9_boot.h"
+#include "imx9_clockconfig.h"
 #include "imx9_serial.h"
 #include "imx9_gpio.h"
 #include "imx9_lowputc.h"

--- a/arch/arm64/src/imx9/imx9_clockconfig.h
+++ b/arch/arm64/src/imx9/imx9_clockconfig.h
@@ -30,6 +30,85 @@
 #include <stdint.h>
 
 /****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define PLL_PARMS(_rdiv, _odiv, _mfi, _mfn, _mfd) \
+  {                                               \
+    .rdiv = (_rdiv),                              \
+    .odiv = (_odiv),                              \
+    .mfi  = (_mfi),                               \
+    .mfn  = (_mfn),                               \
+    .mfd  = (_mfd),                               \
+  }
+
+#define PLL_CFG(_reg, _frac, _parms) \
+  {                                  \
+    .reg   = (_reg),                 \
+    .frac  = (_frac),                \
+    .parms = _parms,                 \
+  }
+
+#define PFD_PARMS(_mfi, _mfn, _div2) \
+  {                                  \
+    .mfi       = (_mfi),             \
+    .mfn       = (_mfn),             \
+    .divby2_en = (_div2)             \
+  }
+
+#define PFD_CFG(_reg, _pfd, _parms) \
+  {                                 \
+    .reg   = (_reg),                \
+    .pfd   = (_pfd),                \
+    .parms = _parms,                \
+  }
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+struct pll_parms_s
+{
+  /* Integer part (DIV) */
+
+  struct
+  {
+    uint32_t rdiv; /* Input clock divider */
+    uint32_t odiv; /* PLL output divider */
+    uint32_t mfi;  /* PLL integer divider */
+  };
+
+  /* Fractional part (NUMERATOR / DENOMINATOR) */
+
+  struct
+  {
+    uint32_t mfn;  /* PLL fractional divider numerator */
+    uint32_t mfd;  /* PLL fractional divider denominator */
+  };
+};
+
+struct pfd_parms_s
+{
+  uint32_t mfi;       /* PLL integer divider */
+  uint32_t mfn;       /* PLL fractional divider numerator */
+  bool     divby2_en; /* Enable the divide-by-2 output */
+};
+
+struct imx9_pll_cfg_s
+{
+  uintptr_t          reg;   /* The PLL register base */
+  bool               frac;  /* Fractional PLL ? */
+  struct pll_parms_s parms; /* The PLL parameters */
+};
+
+struct imx9_pfd_cfg_s
+{
+  uintptr_t          reg;   /* The PLL register base */
+  int                pfd;   /* The PFD number */
+  struct pfd_parms_s parms; /* The PFD parameters */
+};
+
+/****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
 

--- a/boards/arm64/imx9/imx93-evk/include/board.h
+++ b/boards/arm64/imx9/imx93-evk/include/board.h
@@ -88,6 +88,39 @@
 #define MUX_LPSPI6_CS        IOMUX_CFG(IOMUXC_PAD_GPIO_IO00_GPIO2_IO00,  IOMUX_GPIO_DEFAULT, IOMUXC_MUX_SION_ON)
 #define GPIO_LPSPI6_CS       (GPIO_PORT2 | GPIO_PIN0 | GPIO_OUTPUT | GPIO_OUTPUT_ONE)
 
+/* Set the PLL clocks as follows:
+ *
+ * - OSC24M       : 24   MHz
+ * - ARMPLL_OUT   : 1692 MHz
+ * - DRAMPLL      : 933  MHz
+ * - SYSPLL1      : 4000 MHz
+ * - SYSPLL_PFD0  : 1000 MHz
+ * - SYSPLL_PFD1  : 800  MHz
+ * - SYSPLL_PFD2  : 625  MHz
+ * - AUDIOPLL_OUT : OFF
+ * - VIDEOPLL_OUT : OFF
+ *
+ * After reset all clock sources (OSCPLL) and root clocks (CLOCK_ROOT) are
+ * running, but gated (LPCG).
+ *
+ * By default, all peripheral root clocks are set to the 24 MHz oscillator.
+ */
+
+#define ARMPLL_CFG  PLL_CFG(IMX9_ARMPLL_BASE, false, PLL_PARMS(1, 2, 141, 0, 0))
+#define DRAMPLL_CFG PLL_CFG(IMX9_DRAMPLL_BASE, true, PLL_PARMS(1, 2, 155, 1, 2))
+
+#define PLL_CFGS \
+  { \
+    PLL_CFG(IMX9_SYSPLL_BASE,  true, PLL_PARMS(1, 4, 166, 2, 3)), \
+  }
+
+#define PFD_CFGS \
+  { \
+    PFD_CFG(IMX9_SYSPLL_BASE, 0, PFD_PARMS(4, 0, true)), \
+    PFD_CFG(IMX9_SYSPLL_BASE, 1, PFD_PARMS(5, 0, true)), \
+    PFD_CFG(IMX9_SYSPLL_BASE, 2, PFD_PARMS(6, 2, true)), \
+  }
+
 /****************************************************************************
  * Public Data
  ****************************************************************************/


### PR DESCRIPTION
## Summary
This set of patches adds two things for iMX9:
- A way to set PLL frequencies
- A way to query PLL frequencies

The frequencies should be set during bootup, it is the responsibility of the second stage program loader (bootloader) to do this.
For most peripherals it is also important to know the root clock frequency, in order to calculate data rate for the peripheral.
## Impact
Adds PLL support for iMX9
## Testing
imx93-evk:nsh
