### PR TITLE
Extend default appdir list.

### DIFF
--- a/tools/configure.sh
+++ b/tools/configure.sh
@@ -277,6 +277,10 @@ if [ -z "${appdir}" ]; then
 
   if [ -d "${TOPDIR}/../apps" ]; then
     appdir="../apps"
+  elif [ -d "${TOPDIR}/../nuttx-apps" ]; then
+    appdir="../nuttx-apps"
+  elif [ -d "${TOPDIR}/../nuttx-apps.git" ]; then
+    appdir="../nuttx-apps.git"
   else
     # Check for a versioned apps/ directory
 


### PR DESCRIPTION
* Extends tools/configure.sh default appdir search paths.
* Search for apps in ../nuttx-apps and ../nuttx-apps.git locations.
* This allows -a parameter skip when nuttx-apps or nuttx-apps.git is used.

Signed-off-by Tomasz 'CeDeROM' CEDRO <tomek@cedro.info>

## Summary

* This simple patch adds default search path for application code in `../nuttx-apps` and `../nuttx-apps.git` by `tools/configure.sh` script.
* When code is cloned with `git clone` the work dirs are usually `nuttx` / `nuttx.git` and `nuttx-apps` / `nuttx-apps.git`.

## Impact

* This allows `-a` parameter skip in `tools/configure.sh` when `../nuttx-apps` or `../nuttx-apps.git` is used in addition to `../apps`.

## Testing

Please verify :-)