### PR TITLE
arch/riscv: replace atomic operations to AMO

### DIFF
--- a/arch/risc-v/src/common/riscv_testset.S
+++ b/arch/risc-v/src/common/riscv_testset.S
@@ -32,11 +32,9 @@
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_RV32
-#define LR_INST lr.w
-#define SC_INST sc.w
+#define AMOSWAP amoswap.w
 #else
-#define LR_INST lr.d
-#define SC_INST sc.d
+#define AMOSWAP amoswap.d
 #endif
 
 /****************************************************************************
@@ -86,18 +84,9 @@
 
 up_testset:
 
-  li       a1, SP_LOCKED
-
-  /* Test if the spinlock is locked or not */
-
-retry:
-  LR_INST  a2, (a0)       /* Test if spinlock is locked or not */
-  beq      a2, a1, locked /* Already locked? Go to locked: */
-
-  /* Not locked ... attempt to lock it */
-
-  SC_INST  a2, a1, (a0)   /* Attempt to set the locked state (a1) to (a0) */
-  bnez     a2, retry      /* a2 will not be zero, if sc.b failed, try again */
+  li        a1, SP_LOCKED
+  AMOSWAP   a2, a1, (a0)  /* Attempt to acquire spinlock atomically */
+  beq       a2, a1, locked /* Already locked? Go to locked: */
 
   /* Lock acquired -- return SP_UNLOCKED */
 


### PR DESCRIPTION
## Summary

arch/riscv: replace atomic operations to AMO

RISC-V provided fetch-and-op style atomic primitives as they scale to highly parallel systems better than LR/SC or CAS. A simple microarchitecture can implement AMOs using the LR/SC primitives, provided the implementation can guarantee the AMO eventually completes. More complex implementations might also implement AMOs at memory controllers, and can optimize away fetching the original value when the destination is x0.

https://github.com/riscv/riscv-isa-manual/blob/main/src/a-st-ext.adoc

Signed-off-by: chao an <anchao@lixiang.com>
Co-authored-by: Petro Karashchenko <petro.karashchenko@gmail.com>


## Impact

https://github.com/apache/nuttx/issues/6569
Closes #6569 
N/A

## Testing

rv-virt/smp64  rv-virt/smp