### PR TITLE
arch/x86_64: enable CUSTOMOPT

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -133,6 +133,7 @@ config ARCH_X86_64
 	select ARCH_HAVE_FPU
 	select ARCH_HAVE_DPFPU
 	select ARCH_HAVE_TESTSET
+	select ARCH_HAVE_CUSTOMOPT
 	select LIBC_ARCH_ELF_64BIT if LIBC_ARCH_ELF
 	---help---
 		x86-64 architectures.


### PR DESCRIPTION
## Summary

- arch/x86_64: enable CUSTOMOPT

## Impact
allow to use CONFIG_DEBUG_CUSTOMOPT

## Testing

