### PR TITLE
 arch/risc-v: fix break on kernel mode

### DIFF
--- a/arch/risc-v/src/qemu-rv/qemu_rv_start.c
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_start.c
@@ -117,10 +117,11 @@ void qemu_rv_start(int mhartid, const char *dtb)
 
 #ifndef CONFIG_BUILD_KERNEL
   qemu_rv_clear_bss();
-#endif
 
 #ifdef CONFIG_RISCV_PERCPU_SCRATCH
   riscv_percpu_add_hart(mhartid);
+#endif
+
 #endif
 
 #ifdef CONFIG_DEVICE_TREE


### PR DESCRIPTION
## Summary

arch/risc-v: fix break on kernel mode

merge conflicts lead to incorrect ifdef/endif scope

Regression by: https://github.com/apache/nuttx/pull/12220

Signed-off-by: chao an <anchao@lixiang.com>

## Impact

N/A

## Testing

ci-check