### PR TITLE
drivers/sensors: various fixes for sensors

### DIFF
--- a/drivers/sensors/adxl372_uorb.c
+++ b/drivers/sensors/adxl372_uorb.c
@@ -493,6 +493,10 @@ static int adxl372_thread(int argc, FAR char **argv)
 
       if (priv->enabled)
         {
+          /* Wait for data ready */
+
+          while (!(adxl372_getreg8(priv, ADXL372_STATUS) & 0x01));
+
           adxl372_getregs(priv, ADXL372_XDATA_H, (FAR uint8_t *)data, 6);
 
           accel.timestamp   = sensor_get_timestamp();

--- a/drivers/sensors/bh1749nuc_uorb.c
+++ b/drivers/sensors/bh1749nuc_uorb.c
@@ -236,11 +236,11 @@ static int bh1749nuc_fetch(FAR struct sensor_lowerhalf_s *lower,
 
       rgb_data.timestamp = now;
       tmp = bh1749nuc_read16(dev, BH1749NUC_RED_DATA_LSB);
-      rgb_data.r = (tmp * dev->scale_r);
+      rgb_data.r = (tmp * priv->dev->scale_r);
       tmp = bh1749nuc_read16(dev, BH1749NUC_GREEN_DATA_LSB);
-      rgb_data.g = (tmp * dev->scale_g);
+      rgb_data.g = (tmp * priv->dev->scale_g);
       tmp = bh1749nuc_read16(dev, BH1749NUC_BLUE_DATA_LSB);
-      rgb_data.b = (tmp * dev->scale_b);
+      rgb_data.b = (tmp * priv->dev->scale_b);
 
       memcpy(buffer, &rgb_data, sizeof(rgb_data));
       ret = sizeof(rgb_data);
@@ -255,7 +255,7 @@ static int bh1749nuc_fetch(FAR struct sensor_lowerhalf_s *lower,
 
       ir_data.timestamp = now;
       tmp = bh1749nuc_read16(dev, BH1749NUC_IR_DATA_LSB);
-      ir_data.ir = (tmp * dev->scale_ir);
+      ir_data.ir = (tmp * priv->dev->scale_ir);
 
       memcpy(buffer, &ir_data, sizeof(ir_data));
       ret = sizeof(ir_data);

--- a/drivers/sensors/bmi270_uorb.c
+++ b/drivers/sensors/bmi270_uorb.c
@@ -164,7 +164,7 @@ static int bmi270_activate(FAR struct sensor_lowerhalf_s *lower,
 
       start = true;
     }
-  else if (tmp == 1)
+  else if (!enable && tmp == 1)
     {
       /* One time stop */
 

--- a/drivers/sensors/bmm150_uorb.c
+++ b/drivers/sensors/bmm150_uorb.c
@@ -371,6 +371,8 @@ static int bmm150_activate(FAR struct sensor_lowerhalf_s *lower,
 #endif
   uint8_t                         val          = 0;
 
+  dev = (FAR struct bmm150_sensor_dev_s *)lower;
+
   nxmutex_lock(&dev->lock);
 
   if (enable)
@@ -558,9 +560,9 @@ static int bmm150_fetch(FAR struct sensor_lowerhalf_s *lower,
   /* Get compensated data */
 
   mag_data.timestamp = now;
-  mag_data.x = bmm150_getx(priv, data);
-  mag_data.y = bmm150_gety(priv, data);
-  mag_data.z = bmm150_getz(priv, data);
+  mag_data.x = bmm150_getx(dev, data);
+  mag_data.y = bmm150_gety(dev, data);
+  mag_data.z = bmm150_getz(dev, data);
 
   memcpy(buffer, &mag_data, sizeof(mag_data));
   ret = sizeof(mag_data);


### PR DESCRIPTION
## Summary

- sensors/bh1749nuc_uorb.c: fix compilation when poll interface is disabled
- sensors/bmm150_uorb.c: fix compilation for poll interface
- drivers/adxl362_uorb: various fixes
- sensors/bmi270_uorb.c: fix condition for sensor stop
- sensors/adxl372_uorb: wait for data ready in thread

## Impact

## Testing
thingy53 and thingy91
