### PR TITLE
boards/arm/stm32/common/src/stm32_bh1750.c: fix include

### DIFF
--- a/boards/arm/stm32/common/src/stm32_bh1750.c
+++ b/boards/arm/stm32/common/src/stm32_bh1750.c
@@ -28,7 +28,7 @@
 #include <debug.h>
 #include <stdio.h>
 
-#include <nuttx/spi/spi.h>
+#include <nuttx/i2c/i2c_master.h>
 #include <arch/board/board.h>
 #include <nuttx/sensors/bh1750fvi.h>
 
@@ -61,6 +61,7 @@
 int board_bh1750_initialize(int devno, int busno)
 {
   struct i2c_master_s *i2c;
+  char devpath[12];
   int ret;
 
   sninfo("Initializing BH1750FVI!\n");
@@ -68,7 +69,6 @@ int board_bh1750_initialize(int devno, int busno)
   /* Initialize I2C */
 
   i2c = stm32_i2cbus_initialize(busno);
-
   if (!i2c)
     {
       return -ENODEV;
@@ -76,6 +76,7 @@ int board_bh1750_initialize(int devno, int busno)
 
   /* Then register the ambient light sensor */
 
+  snprintf(devpath, 12, "/dev/light%d", devno);
   ret = bh1750fvi_register(devpath, i2c, BH1750FVI_I2C_ADDR);
   if (ret < 0)
     {


### PR DESCRIPTION
## Summary
boards/arm/stm32/common/src/stm32_bh1750.c: fix include
should include i2c interface, not spi

## Impact

## Testing
ci
