### PR TITLE
arch/risc-v: remove macro test for ipi function

### DIFF
--- a/arch/risc-v/src/common/riscv_ipi.h
+++ b/arch/risc-v/src/common/riscv_ipi.h
@@ -34,18 +34,12 @@
 
 static inline void riscv_ipi_send(int cpu)
 {
-#if defined(RISCV_IPI)
   putreg32(1, (uintptr_t)RISCV_IPI + (4 * cpu));
-#else
-  PANIC();
-#endif
 }
 
 static inline void riscv_ipi_clear(int cpu)
 {
-#if defined(RISCV_IPI)
   putreg32(0, (uintptr_t)RISCV_IPI + (4 * cpu));
-#endif
   CLEAR_CSR(CSR_IP, IP_SIP);
 }
 


### PR DESCRIPTION
Remove the check on RISCV_IPI in riscv_ipi_send/clear and let build fail if RISCV_IPI is not defined.

Fixup: 4f63ca1418 ("arch/risc-v: unfiy IPI access)

This fixed https://github.com/apache/nuttx/pull/12178#discussion_r1581985451

