### PR TITLE
arch/risc-v: Fix typo in riscv_set_inital_sp

### DIFF
--- a/arch/risc-v/src/common/riscv_macros.S
+++ b/arch/risc-v/src/common/riscv_macros.S
@@ -384,7 +384,7 @@
  * Parameter:
  *   base - Pointer to where the stack is allocated (e.g. _ebss)
  *   size - Stack size for pre cpu to allocate
- *   size - Hart id register of this hart (Usually a0)
+ *   hartid - Hart id register of this hart (Usually a0)
  *
  ****************************************************************************/
 .macro riscv_set_inital_sp base, size, hartid


### PR DESCRIPTION
Set right name for the parameter description of riscv_set_inital_sp.

This should improve https://github.com/apache/nuttx/pull/12178#discussion_r1581992407