### PR TITLE
arch/arm/src/samv7/sam_pwm.c: option to enable only the L PWM outputs

### DIFF
--- a/arch/arm/src/samv7/Kconfig
+++ b/arch/arm/src/samv7/Kconfig
@@ -671,8 +671,13 @@ config SAMV7_PWM0_CH0
 
 if SAMV7_PWM0_CH0
 
+config SAMV7_PWM0_CH0_LONLY
+	bool "Use only L output"
+	default n
+
 config SAMV7_PWM0_CH0_COMP
 	bool "Use complementary output"
+	depends on !SAMV7_PWM0_CH0_LONLY
 	default n
 
 endif
@@ -683,8 +688,13 @@ config SAMV7_PWM0_CH1
 
 if SAMV7_PWM0_CH1
 
+config SAMV7_PWM0_CH1_LONLY
+	bool "Use only L output"
+	default n
+
 config SAMV7_PWM0_CH1_COMP
 	bool "Use complementary output"
+	depends on !SAMV7_PWM0_CH1_LONLY
 	default n
 
 endif
@@ -695,8 +705,13 @@ config SAMV7_PWM0_CH2
 
 if SAMV7_PWM0_CH2
 
+config SAMV7_PWM0_CH2_LONLY
+	bool "Use only L output"
+	default n
+
 config SAMV7_PWM0_CH2_COMP
 	bool "Use complementary output"
+	depends on !SAMV7_PWM0_CH2_LONLY
 	default n
 
 endif
@@ -707,8 +722,13 @@ config SAMV7_PWM0_CH3
 
 if SAMV7_PWM0_CH3
 
+config SAMV7_PWM0_CH3_LONLY
+	bool "Use only L output"
+	default n
+
 config SAMV7_PWM0_CH3_COMP
 	bool "Use complementary output"
+	depends on !SAMV7_PWM0_CH3_LONLY
 	default n
 
 endif
@@ -887,8 +907,13 @@ config SAMV7_PWM1_CH0
 
 if SAMV7_PWM1_CH0
 
+config SAMV7_PWM1_CH0_LONLY
+	bool "Use only L output"
+	default n
+
 config SAMV7_PWM1_CH0_COMP
 	bool "Use complementary output"
+	depends on !SAMV7_PWM1_CH0_LONLY
 	default n
 
 endif
@@ -899,8 +924,13 @@ config SAMV7_PWM1_CH1
 
 if SAMV7_PWM1_CH1
 
+config SAMV7_PWM1_CH1_LONLY
+	bool "Use only L output"
+	default n
+
 config SAMV7_PWM1_CH1_COMP
 	bool "Use complementary output"
+	depends on !SAMV7_PWM1_CH1_LONLY
 	default n
 
 endif
@@ -911,8 +941,13 @@ config SAMV7_PWM1_CH2
 
 if SAMV7_PWM1_CH2
 
+config SAMV7_PWM1_CH2_LONLY
+	bool "Use only L output"
+	default n
+
 config SAMV7_PWM1_CH2_COMP
 	bool "Use complementary output"
+	depends on !SAMV7_PWM1_CH2_LONLY
 	default n
 
 endif
@@ -923,8 +958,13 @@ config SAMV7_PWM1_CH3
 
 if SAMV7_PWM1_CH3
 
+config SAMV7_PWM1_CH3_LONLY
+	bool "Use only L output"
+	default n
+
 config SAMV7_PWM1_CH3_COMP
 	bool "Use complementary output"
+	depends on !SAMV7_PWM1_CH3_LONLY
 	default n
 
 endif

--- a/arch/arm/src/samv7/sam_pwm.c
+++ b/arch/arm/src/samv7/sam_pwm.c
@@ -136,44 +136,64 @@ static struct sam_pwm_channel_s g_pwm0_channels[] =
 #ifdef CONFIG_SAMV7_PWM0_CH0
   {
     .channel = 0,
+#ifdef CONFIG_SAMV7_PWM0_CH0_LONLY
+    .pin_h   = 0,
+    .pin_l   = GPIO_PWMC0_L0,
+#else
     .pin_h   = GPIO_PWMC0_H0,
 #ifdef CONFIG_SAMV7_PWM0_CH0_COMP
     .pin_l   = GPIO_PWMC0_L0,
 #else
     .pin_l   = 0,
 #endif
+#endif
   },
 #endif
 #ifdef CONFIG_SAMV7_PWM0_CH1
   {
     .channel = 1,
+#ifdef CONFIG_SAMV7_PWM0_CH1_LONLY
+    .pin_h   = 0,
+    .pin_l   = GPIO_PWMC0_L1,
+#else
     .pin_h   = GPIO_PWMC0_H1,
 #ifdef CONFIG_SAMV7_PWM0_CH1_COMP
     .pin_l   = GPIO_PWMC0_L1,
 #else
     .pin_l   = 0,
 #endif
+#endif
   },
 #endif
 #ifdef CONFIG_SAMV7_PWM0_CH2
   {
     .channel = 2,
+#ifdef CONFIG_SAMV7_PWM0_CH2_LONLY
+    .pin_h   = 0,
+    .pin_l   = GPIO_PWMC0_L2,
+#else
     .pin_h   = GPIO_PWMC0_H2,
 #ifdef CONFIG_SAMV7_PWM0_CH2_COMP
     .pin_l   = GPIO_PWMC0_L2,
 #else
     .pin_l   = 0,
 #endif
+#endif
   },
 #endif
 #ifdef CONFIG_SAMV7_PWM0_CH3
   {
     .channel = 3,
+#ifdef CONFIG_SAMV7_PWM0_CH3_LONLY
+    .pin_h   = 0,
+    .pin_l   = GPIO_PWMC0_L3,
+#else
     .pin_h   = GPIO_PWMC0_H3,
 #ifdef CONFIG_SAMV7_PWM0_CH3_COMP
     .pin_l   = GPIO_PWMC0_L3,
 #else
     .pin_l   = 0,
+#endif
 #endif
   },
 #endif
@@ -227,44 +247,64 @@ static struct sam_pwm_channel_s g_pwm1_channels[] =
 #ifdef CONFIG_SAMV7_PWM1_CH0
   {
     .channel = 0,
+#ifdef CONFIG_SAMV7_PWM1_CH0_LONLY
+    .pin_h   = 0,
+    .pin_l   = GPIO_PWMC1_L0,
+#else
     .pin_h   = GPIO_PWMC1_H0,
 #ifdef CONFIG_SAMV7_PWM1_CH0_COMP
     .pin_l   = GPIO_PWMC1_L0,
 #else
     .pin_l   = 0,
 #endif
+#endif
   },
 #endif
 #ifdef CONFIG_SAMV7_PWM1_CH1
   {
     .channel = 1,
+#ifdef CONFIG_SAMV7_PWM1_CH1_LONLY
+    .pin_h   = 0,
+    .pin_l   = GPIO_PWMC1_L1,
+#else
     .pin_h   = GPIO_PWMC1_H1,
 #ifdef CONFIG_SAMV7_PWM1_CH1_COMP
     .pin_l   = GPIO_PWMC1_L1,
 #else
     .pin_l   = 0,
 #endif
+#endif
   },
 #endif
 #ifdef CONFIG_SAMV7_PWM1_CH2
   {
     .channel = 2,
+#ifdef CONFIG_SAMV7_PWM1_CH2_LONLY
+    .pin_h   = 0,
+    .pin_l   = GPIO_PWMC1_L2,
+#else
     .pin_h   = GPIO_PWMC1_H2,
 #ifdef CONFIG_SAMV7_PWM1_CH2_COMP
     .pin_l   = GPIO_PWMC1_L2,
 #else
     .pin_l   = 0,
 #endif
+#endif
   },
 #endif
 #ifdef CONFIG_SAMV7_PWM1_CH3
   {
     .channel = 3,
+#ifdef CONFIG_SAMV7_PWM1_CH3_LONLY
+    .pin_h   = 0,
+    .pin_l   = GPIO_PWMC1_L3,
+#else
     .pin_h   = GPIO_PWMC1_H3,
 #ifdef CONFIG_SAMV7_PWM1_CH3_COMP
     .pin_l   = GPIO_PWMC1_L3,
 #else
     .pin_l   = 0,
+#endif
 #endif
   },
 #endif


### PR DESCRIPTION
PWMx_CHy_LONLY options have been added to Kconfig, too. If LONLY is selected, it's not possible to use complementary outputs. If LONLY is not selected, it's possible to use H or complementary output. If configured correctly with cpol and dcpol attributes, a H-like behaviour can be achieved. May be useful when you run out of free MCU pins.
