### PR TITLE
tcp: decouple TCP_NODELAY and NET_TCP_KEEPALIVE

### DIFF
--- a/net/tcp/tcp_getsockopt.c
+++ b/net/tcp/tcp_getsockopt.c
@@ -133,23 +133,6 @@ int tcp_getsockopt(FAR struct socket *psock, int option,
           }
         break;
 
-      case TCP_NODELAY:  /* Avoid coalescing of small segments. */
-        if (*value_len < sizeof(int))
-          {
-            ret                = -EINVAL;
-          }
-        else
-          {
-            FAR int *nodelay   = (FAR int *)value;
-
-            /* Always true here since we do not support Nagle. */
-
-            *nodelay           = 1;
-            *value_len         = sizeof(int);
-            ret                = OK;
-          }
-        break;
-
       case TCP_KEEPIDLE:  /* Start keepalives after this IDLE period */
       case TCP_KEEPINTVL: /* Interval between keepalives */
         {
@@ -217,6 +200,23 @@ int tcp_getsockopt(FAR struct socket *psock, int option,
           }
         break;
 #endif /* CONFIG_NET_TCP_KEEPALIVE */
+
+      case TCP_NODELAY:  /* Avoid coalescing of small segments. */
+        if (*value_len < sizeof(int))
+          {
+            ret                = -EINVAL;
+          }
+        else
+          {
+            FAR int *nodelay   = (FAR int *)value;
+
+            /* Always true here since we do not support Nagle. */
+
+            *nodelay           = 1;
+            *value_len         = sizeof(int);
+            ret                = OK;
+          }
+        break;
 
       case TCP_MAXSEG:   /* The maximum segment size */
         if (*value_len < sizeof(int))

--- a/net/tcp/tcp_setsockopt.c
+++ b/net/tcp/tcp_setsockopt.c
@@ -130,23 +130,6 @@ int tcp_setsockopt(FAR struct socket *psock, int option,
           }
         break;
 
-      case TCP_NODELAY: /* Avoid coalescing of small segments. */
-        if (value_len != sizeof(int))
-          {
-            ret = -EDOM;
-          }
-        else
-          {
-            int nodelay = *(FAR int *)value;
-
-            if (!nodelay)
-              {
-                nerr("ERROR: TCP_NODELAY not supported\n");
-                ret = -ENOSYS;
-              }
-          }
-        break;
-
       case TCP_KEEPIDLE:  /* Start keepalives after this IDLE period */
       case TCP_KEEPINTVL: /* Interval between keepalives */
         {
@@ -229,6 +212,23 @@ int tcp_setsockopt(FAR struct socket *psock, int option,
           }
         break;
 #endif /* CONFIG_NET_TCP_KEEPALIVE */
+
+      case TCP_NODELAY: /* Avoid coalescing of small segments. */
+        if (value_len != sizeof(int))
+          {
+            ret = -EDOM;
+          }
+        else
+          {
+            int nodelay = *(FAR int *)value;
+
+            if (!nodelay)
+              {
+                nerr("ERROR: TCP_NODELAY not supported\n");
+                ret = -ENOSYS;
+              }
+          }
+        break;
 
       case TCP_MAXSEG: /* The maximum segment size */
         if (value_len != sizeof(int))


### PR DESCRIPTION
## Summary
TCP_NODELAY is an independent configuration and does not depend on TCP_KEEPALIVE

## Impact

## Testing
sim:local
