### PR TITLE
samv7: build sam_qencoder.c only if at least one timer counter is enabled

### DIFF
--- a/arch/arm/src/samv7/Kconfig
+++ b/arch/arm/src/samv7/Kconfig
@@ -275,6 +275,10 @@ config SAMV7_DAC
 	bool
 	default n
 
+config SAMV7_QENCODER
+	bool
+	default n
+
 config SAMV7_HAVE_DAC1
 	bool
 	default n
@@ -3794,6 +3798,7 @@ config SAMV7_TC0_QE
 	bool "TC0"
 	default n
 	depends on SAMV7_TC0
+	select SAMV7_QENCODER
 	select SAMV7_TC0_TIOA0
 	select SAMV7_TC0_TIOB0
 	---help---
@@ -3803,6 +3808,7 @@ config SAMV7_TC1_QE
 	bool "TC1"
 	default n
 	depends on SAMV7_TC1
+	select SAMV7_QENCODER
 	select SAMV7_TC1_TIOA3
 	select SAMV7_TC1_TIOB3
 	---help---
@@ -3812,6 +3818,7 @@ config SAMV7_TC2_QE
 	bool "TC2"
 	default n
 	depends on SAMV7_TC2
+	select SAMV7_QENCODER
 	select SAMV7_TC2_TIOA6
 	select SAMV7_TC2_TIOB6
 	---help---
@@ -3821,6 +3828,7 @@ config SAMV7_TC3_QE
 	bool "TC3"
 	default n
 	depends on SAMV7_TC3
+	select SAMV7_QENCODER
 	select SAMV7_TC3_TIOA9
 	select SAMV7_TC3_TIOB9
 	---help---

--- a/arch/arm/src/samv7/Make.defs
+++ b/arch/arm/src/samv7/Make.defs
@@ -108,7 +108,7 @@ endif
 ifeq ($(CONFIG_SCHED_TICKLESS),y)
 CHIP_CSRCS += sam_tickless.c
 endif
-ifeq ($(CONFIG_SENSORS_QENCODER),y)
+ifeq ($(CONFIG_SAMV7_QENCODER),y)
 CHIP_CSRCS += sam_qencoder.c
 endif
 endif

--- a/arch/arm/src/samv7/sam_qencoder.c
+++ b/arch/arm/src/samv7/sam_qencoder.c
@@ -41,7 +41,7 @@
 #include "sam_tc.h"
 #include "sam_qencoder.h"
 
-#ifdef CONFIG_SENSORS_QENCODER
+#if defined(CONFIG_SENSORS_QENCODER) && defined(CONFIG_SAMV7_QENCODER)
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -541,4 +541,4 @@ int sam_qeinitialize(const char *devpath, int tc)
   return OK;
 }
 
-#endif /* CONFIG_SENSORS_QENCODER */
+#endif /* CONFIG_SENSORS_QENCODER && CONFIG_SAMV7_QENCODER */

--- a/arch/arm/src/samv7/sam_qencoder.h
+++ b/arch/arm/src/samv7/sam_qencoder.h
@@ -29,7 +29,7 @@
 
 #include "chip.h"
 
-#ifdef CONFIG_SENSORS_QENCODER
+#if defined(CONFIG_SENSORS_QENCODER) && defined(CONFIG_SAMV7_QENCODER)
 
 /****************************************************************************
  * Included Files
@@ -77,5 +77,5 @@
 
 int sam_qeinitialize(const char *devpath, int tc);
 
-#endif /* CONFIG_SENSORS_QENCODER */
+#endif /* CONFIG_SENSORS_QENCODER && CONFIG_SAMV7_QENCODER */
 #endif /* __ARCH_ARM_SRC_SAMV7_SAM_QENCODER_H */


### PR DESCRIPTION
## Summary
Option `CONFIG_SENSORS_QENCODER` might be configured even if SAMv7 qencoder over timer counter is not used (for example encoder over GPIO is selected with `CONFIG_SAMV7_GPIO_ENC`). This can cause compile warnings, also build of `sam_qencoder.c` file is unnecessary in that case.

New hidden option `CONFIG_SAMV7_QENCODER` is added and automatically selected if at least one timer counter is enabled for qencoder. Build is triggered on this option.

## Impact
Fixes possible warnings (unused structures)

