### PR TITLE
libc/string: replace __builtin_ffsl with inline function

### DIFF
--- a/include/strings.h
+++ b/include/strings.h
@@ -73,16 +73,77 @@ extern "C"
  * Public Function Prototypes
  ****************************************************************************/
 
+#ifdef CONFIG_HAVE_BUILTIN_FFS
+static inline_function int ffs(int j)
+{
+  return __builtin_ffs(j);
+}
+#elif defined (CONFIG_HAVE_BUILTIN_CTZ)
+static inline_function int ffs(int j)
+{
+  return __builtin_ctz(j) + 1;
+}
+#else
 int ffs(int j);
-int ffsl(long j);
-#ifdef CONFIG_HAVE_LONG_LONG
-int ffsll(long long j);
 #endif
 
-int fls(int j);
-int flsl(long j);
+#ifdef CONFIG_HAVE_BUILTIN_FFSL
+static inline_function int ffsl(long j)
+{
+  return __builtin_ffsl(j);
+}
+#elif defined (CONFIG_HAVE_BUILTIN_CTZ)
+static inline_function int ffsl(long j)
+{
+  return __builtin_ctzl(j) + 1;
+}
+#else
+int ffsl(long j);
+#endif
+
 #ifdef CONFIG_HAVE_LONG_LONG
+#  ifdef CONFIG_HAVE_BUILTIN_FFSLL
+static inline_function int ffsll(long long j)
+{
+    return __builtin_ffsll(j);
+}
+#  elif defined (CONFIG_HAVE_BUILTIN_CTZ)
+static inline_function int ffsll(long long j)
+{
+    return __builtin_ctzll(j) + 1;
+}
+#  else
+int ffsll(long long j);
+#  endif
+#endif
+
+#ifdef CONFIG_HAVE_BUILTIN_CLZ
+static inline_function int fls(int j)
+{
+  return (8 * sizeof(int)) - __builtin_clz(j);
+}
+#else
+int fls(int j);
+#endif
+
+#ifdef CONFIG_HAVE_BUILTIN_CLZ
+static inline_function int flsl(long j)
+{
+  return (8 * sizeof(long)) - __builtin_clzl(j);
+}
+#else
+int flsl(long j);
+#endif
+
+#ifdef CONFIG_HAVE_LONG_LONG
+#  ifdef CONFIG_HAVE_BUILTIN_CLZ
+static inline_function int flsll(long long j)
+{
+  return (8 * sizeof(long long)) - __builtin_clzll(j);
+}
+#  else
 int flsll(long long j);
+#  endif
 #endif
 
 unsigned int popcount(unsigned int j);

--- a/libs/libc/string/lib_ffs.c
+++ b/libs/libc/string/lib_ffs.c
@@ -19,13 +19,6 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Included Files
- ****************************************************************************/
-
-#include <nuttx/compiler.h>
-#include <strings.h>
-
-/****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
 
@@ -55,13 +48,6 @@ int ffs(int j)
 
   if (j != 0)
     {
-#ifdef CONFIG_HAVE_BUILTIN_FFS
-      ret = __builtin_ffs(j);
-#elif defined (CONFIG_HAVE_BUILTIN_CTZ)
-      /* Count trailing zeros function can be used to implement ffs. */
-
-      ret = __builtin_ctz(j) + 1;
-#else
       unsigned int value = (unsigned int)j;
       int bitno;
 
@@ -73,7 +59,6 @@ int ffs(int j)
               break;
             }
         }
-#endif
     }
 
   return ret;

--- a/libs/libc/string/lib_ffsl.c
+++ b/libs/libc/string/lib_ffsl.c
@@ -19,13 +19,6 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Included Files
- ****************************************************************************/
-
-#include <nuttx/compiler.h>
-#include <strings.h>
-
-/****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
 
@@ -55,13 +48,6 @@ int ffsl(long j)
 
   if (j != 0)
     {
-#ifdef CONFIG_HAVE_BUILTIN_FFSL
-      ret = __builtin_ffsl(j);
-#elif defined (CONFIG_HAVE_BUILTIN_CTZ)
-      /* Count trailing zeros function can be used to implement ffs. */
-
-      ret = __builtin_ctzl(j) + 1;
-#else
       unsigned long value = (unsigned long)j;
       int bitno;
 
@@ -73,7 +59,6 @@ int ffsl(long j)
               break;
             }
         }
-#endif
     }
 
   return ret;

--- a/libs/libc/string/lib_ffsll.c
+++ b/libs/libc/string/lib_ffsll.c
@@ -19,13 +19,6 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Included Files
- ****************************************************************************/
-
-#include <nuttx/compiler.h>
-#include <strings.h>
-
-/****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
 
@@ -57,13 +50,6 @@ int ffsll(long long j)
 
   if (j != 0)
     {
-#ifdef CONFIG_HAVE_BUILTIN_FFSLL
-      ret = __builtin_ffsll(j);
-#elif defined (CONFIG_HAVE_BUILTIN_CTZ)
-      /* Count trailing zeros function can be used to implement ffs. */
-
-      ret = __builtin_ctzll(j) + 1;
-#else
       unsigned long long value = (unsigned long long)j;
       int bitno;
 
@@ -75,10 +61,8 @@ int ffsll(long long j)
               break;
             }
         }
-#endif
     }
 
   return ret;
 }
-
 #endif

--- a/libs/libc/string/lib_fls.c
+++ b/libs/libc/string/lib_fls.c
@@ -19,13 +19,6 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Included Files
- ****************************************************************************/
-
-#include <nuttx/compiler.h>
-#include <strings.h>
-
-/****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
 
@@ -55,11 +48,6 @@ int fls(int j)
 
   if (j != 0)
     {
-#ifdef CONFIG_HAVE_BUILTIN_CLZ
-      /* Count leading zeros function can be used to implement fls. */
-
-      ret = NBITS - __builtin_clz(j);
-#else
       unsigned int value = (unsigned int)j;
       int bitno;
 
@@ -71,7 +59,6 @@ int fls(int j)
               break;
             }
         }
-#endif
     }
 
   return ret;

--- a/libs/libc/string/lib_flsl.c
+++ b/libs/libc/string/lib_flsl.c
@@ -19,13 +19,6 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Included Files
- ****************************************************************************/
-
-#include <nuttx/compiler.h>
-#include <strings.h>
-
-/****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
 
@@ -55,11 +48,6 @@ int flsl(long j)
 
   if (j != 0)
     {
-#ifdef CONFIG_HAVE_BUILTIN_CLZ
-      /* Count leading zeros function can be used to implement fls. */
-
-      ret = NBITS - __builtin_clzl(j);
-#else
       unsigned long value = (unsigned long)j;
       int bitno;
 
@@ -71,7 +59,6 @@ int flsl(long j)
               break;
             }
         }
-#endif
     }
 
   return ret;

--- a/libs/libc/string/lib_flsll.c
+++ b/libs/libc/string/lib_flsll.c
@@ -19,13 +19,6 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Included Files
- ****************************************************************************/
-
-#include <nuttx/compiler.h>
-#include <strings.h>
-
-/****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
 
@@ -57,11 +50,6 @@ int flsll(long long j)
 
   if (j != 0)
     {
-#ifdef CONFIG_HAVE_BUILTIN_CLZ
-      /* Count leading zeros function can be used to implement fls. */
-
-      ret = NBITS - __builtin_clzll(j);
-#else
       unsigned long long value = (unsigned long long)j;
       int bitno;
 
@@ -73,10 +61,8 @@ int flsll(long long j)
               break;
             }
         }
-#endif
     }
 
   return ret;
 }
-
 #endif


### PR DESCRIPTION
## Summary
In the gcc-riscv compiler, __builtin_ffs will call ffs, and calling __builtin_ffs in ffs will cause recursion

__builtin_ffs --> ffs --> ffs --> ffs

Change ffs to an inline function, and compile ffs implemented by nuttx by default. Only call the implementation of nuttx when the compiler cannot provide an ffs implementation.

## Impact

## Testing
arm/riscv
