### PR TITLE
esp32s3: give ESP32S3_APP_FORMAT_LEGACY a prompt

### DIFF
--- a/arch/xtensa/src/esp32s3/Kconfig
+++ b/arch/xtensa/src/esp32s3/Kconfig
@@ -2189,7 +2189,7 @@ config ESP32S3_APP_FORMAT_MCUBOOT
 		Enables the Espressif port of MCUboot to be used as 2nd stage bootloader.
 
 config ESP32S3_APP_FORMAT_LEGACY
-	bool
+	bool "Enable legacy boot format"
 	default y if BUILD_PROTECTED
 	---help---
 		This is the legacy application image format, as supported by the ESP-IDF


### PR DESCRIPTION
## Summary
So that users can enable it.
This fixes a regression in "esp32s3: add simple boot support".

## Impact

## Testing
make oldconfig
