### PR TITLE
imxrt:Add DMA preflight Support

### DIFF
--- a/arch/arm/src/imxrt/Kconfig
+++ b/arch/arm/src/imxrt/Kconfig
@@ -226,6 +226,7 @@ endmenu # Application Image Configuration
 config IMXRT_USDHC
 	bool
 	default n
+	select ARCH_HAVE_SDIO_PREFLIGHT
 
 config IMXRT_FLEXIO
 	bool


### PR DESCRIPTION
## Summary

   With CONFIG_MMCSD_MULTIBLOCK_LIMIT not set. (No limit)
   The DMA driver would overwrite the internal buffer.

   By adding CONFIG_ARCH_HAVE_SDIO_PREFLIGHT and
   CONFIG_FAT_DMAMEMORY we can insure alignment and
   maximize performance using no CONFIG_MMCSD_MULTIBLOCK_LIMIT

## Impact

Fixes hardfault if CONFIG_MMCSD_MULTIBLOCK_LIMIT !=1 and improves performance.  

## Testing

px4_fmu-v6xrt

```
nsh> sd_bench
INFO  [sd_bench] Using block size = 4096 bytes, sync=0
INFO  [sd_bench]
INFO  [sd_bench] Testing Sequential Write Speed...
INFO  [sd_bench]   Run  0:  1332.81 KB/s, max write time: 115 ms (=  34.78 KB/s), fsync: 7 ms
INFO  [sd_bench]   Run  1:  1273.16 KB/s, max write time: 117 ms (=  34.19 KB/s), fsync: 9 ms
INFO  [sd_bench]   Run  2:  1462.41 KB/s, max write time: 10 ms (= 400.00 KB/s), fsync: 9 ms
INFO  [sd_bench]   Run  3:  1437.76 KB/s, max write time: 12 ms (= 333.33 KB/s), fsync: 7 ms
INFO  [sd_bench]   Run  4:  1463.13 KB/s, max write time: 10 ms (= 400.00 KB/s), fsync: 7 ms
INFO  [sd_bench]   Avg   :  1393.83 KB/s
INFO  [sd_bench]   Overall max write time: 117 ms
nsh> sd_bench -u
Block ptr 0x2029b681
INFO  [sd_bench] Using block size = 4096 bytes, sync=0
INFO  [sd_bench]
INFO  [sd_bench] Testing Sequential Write Speed...
INFO  [sd_bench]   Run  0:   326.11 KB/s, max write time: 20 ms (= 200.00 KB/s), fsync: 7 ms
INFO  [sd_bench]   Run  1:   324.69 KB/s, max write time: 20 ms (= 200.00 KB/s), fsync: 7 ms
INFO  [sd_bench]   Run  2:   326.63 KB/s, max write time: 20 ms (= 200.00 KB/s), fsync: 7 ms
INFO  [sd_bench]   Run  3:   325.95 KB/s, max write time: 20 ms (= 200.00 KB/s), fsync: 8 ms
INFO  [sd_bench]   Run  4:   324.71 KB/s, max write time: 21 ms (= 190.48 KB/s), fsync: 7 ms
INFO  [sd_bench]   Avg   :   325.62 KB/s
INFO  [sd_bench]   Overall max write time: 21 ms

```