### PR TITLE
cmake:bugfix __KERNEL__ should not be defined with FLAT mode in libc, mm etc.

### DIFF
--- a/cmake/nuttx_add_library.cmake
+++ b/cmake/nuttx_add_library.cmake
@@ -138,16 +138,19 @@ function(nuttx_add_kernel_library target)
 
   # Add kernel options & definitions See note above in
   # nuttx_add_library_internal() on syntax and nuttx target use
-  target_compile_options(
-    ${kernel_target}
-    PRIVATE $<GENEX_EVAL:$<TARGET_PROPERTY:nuttx,NUTTX_KERNEL_COMPILE_OPTIONS>>)
-  target_compile_definitions(
-    ${kernel_target}
-    PRIVATE $<GENEX_EVAL:$<TARGET_PROPERTY:nuttx,NUTTX_KERNEL_DEFINITIONS>>)
-  target_include_directories(
-    ${kernel_target}
-    PRIVATE
-      $<GENEX_EVAL:$<TARGET_PROPERTY:nuttx,NUTTX_KERNEL_INCLUDE_DIRECTORIES>>)
+  if(NOT ARGS_SPLIT OR NOT "${target}" STREQUAL "${kernel_target}")
+    target_compile_options(
+      ${kernel_target}
+      PRIVATE
+        $<GENEX_EVAL:$<TARGET_PROPERTY:nuttx,NUTTX_KERNEL_COMPILE_OPTIONS>>)
+    target_compile_definitions(
+      ${kernel_target}
+      PRIVATE $<GENEX_EVAL:$<TARGET_PROPERTY:nuttx,NUTTX_KERNEL_DEFINITIONS>>)
+    target_include_directories(
+      ${kernel_target}
+      PRIVATE
+        $<GENEX_EVAL:$<TARGET_PROPERTY:nuttx,NUTTX_KERNEL_INCLUDE_DIRECTORIES>>)
+  endif()
 
   if(NOT "${target}" STREQUAL "${kernel_target}")
     # The k${target} lib will have the same sources added to that ${target} lib.


### PR DESCRIPTION
## Summary

all targets that call `nuttx_add_kernel_library` will have the `__KERNEL__` macro definition added by default.

however, for example, when we build in FLAT mode, `libc` and other libraries should not need __KERNEL__ defined, only in `klibc` with Non-FLAT mode.

this patch distinguishes the target libraries that need to be `SPLIT`, solving this problem.

## Impact

FLAT mode CMake build

## Testing
CI

