### PR TITLE
esp32[c3|c6]: Fix chipname on docs

### DIFF
--- a/Documentation/platforms/risc-v/esp32c3/index.rst
+++ b/Documentation/platforms/risc-v/esp32c3/index.rst
@@ -73,7 +73,7 @@ You can edit your shell's rc files if you don't use bash.
 Second stage bootloader
 =======================
 
-Nuttx can boot the ESP32-H2 directly using the so-called "Simple Boot". 
+Nuttx can boot the ESP32-C3 directly using the so-called "Simple Boot". 
 An externally-built 2nd stage bootloader is not required in this case as all
 functions required to boot the device are built within Nuttx. Simple boot does not
 require any specific configuration (it is selectable by default if no other

--- a/Documentation/platforms/risc-v/esp32c6/index.rst
+++ b/Documentation/platforms/risc-v/esp32c6/index.rst
@@ -71,7 +71,7 @@ You can edit your shell's rc files if you don't use bash.
 Second stage bootloader
 =======================
 
-Nuttx can boot the ESP32-H2 directly using the so-called "Simple Boot". 
+Nuttx can boot the ESP32-C6 directly using the so-called "Simple Boot". 
 An externally-built 2nd stage bootloader is not required in this case as all
 functions required to boot the device are built within Nuttx. Simple boot does not
 require any specific configuration (it is selectable by default if no other


### PR DESCRIPTION
## Summary
esp32[c3|c6]: Fix chipname on docs
## Impact
ESP32-C3 and ESP32-C6
## Testing

