### PR TITLE
Documentation/rv-virt: add required minimal QEMU version information

### DIFF
--- a/Documentation/platforms/risc-v/qemu-rv/boards/rv-virt/index.rst
+++ b/Documentation/platforms/risc-v/qemu-rv/boards/rv-virt/index.rst
@@ -34,6 +34,10 @@ Build and install ``qemu``::
   $ make
   $ sudo make install
 
+QEMU 7.2.9 or later and OpenSBI v1.1 or later (usually shipped with QEMU) is required, to support RISC-V "Sstc" Extension. It is also recommended to use the latest QEMU and OpenSBI.
+
+For users who wish to use their own OpenSBI, please refer to `OpenSBI repository <https://github.com/riscv-software-src/opensbi>`_.
+
 Configurations
 ==============
 


### PR DESCRIPTION
Since SSTC is support by QEMU 7.2.9, kernel mode nuttx is no longer worked for older QEMU.

Add necessary requirement information for rv-virt board.

This should give some information for issues like #12275.
