### PR TITLE
smp optmization

### DIFF
--- a/arch/arm/src/at32/at32_serial.c
+++ b/arch/arm/src/at32/at32_serial.c
@@ -1118,11 +1118,11 @@ static void up_restoreusartint(struct up_dev_s *priv, uint16_t ie)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
 
   up_setusartint(priv, ie);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -1133,7 +1133,7 @@ static void up_disableusartint(struct up_dev_s *priv, uint16_t *ie)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
 
   if (ie)
     {
@@ -1174,7 +1174,7 @@ static void up_disableusartint(struct up_dev_s *priv, uint16_t *ie)
 
   up_setusartint(priv, 0);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/arm/src/efm32/efm32_leserial.c
+++ b/arch/arm/src/efm32/efm32_leserial.c
@@ -308,10 +308,10 @@ static void efm32_restoreuartint(struct efm32_leuart_s *priv, uint32_t ien)
    * bits in ien.
    */
 
-  flags     = enter_critical_section();
+  flags     = spin_lock_irqsave(NULL);
   priv->ien = ien;
   efm32_setuartint(priv);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -322,14 +322,14 @@ static void efm32_disableuartint(struct efm32_leuart_s *priv, uint32_t *ien)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
   if (ien)
     {
       *ien = priv->ien;
     }
 
   efm32_restoreuartint(priv, 0);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/arm/src/efm32/efm32_serial.c
+++ b/arch/arm/src/efm32/efm32_serial.c
@@ -522,10 +522,10 @@ static void efm32_restoreuartint(struct efm32_usart_s *priv, uint32_t ien)
    * ien
    */
 
-  flags     = enter_critical_section();
+  flags     = spin_lock_irqsave(NULL);
   priv->ien = ien;
   efm32_setuartint(priv);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -537,14 +537,14 @@ static void efm32_disableuartint(struct efm32_usart_s *priv, uint32_t *ien)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
   if (ien)
     {
       *ien = priv->ien;
     }
 
   efm32_restoreuartint(priv, 0);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 #endif
 

--- a/arch/arm/src/gd32f4/gd32f4xx_serial.c
+++ b/arch/arm/src/gd32f4/gd32f4xx_serial.c
@@ -1124,7 +1124,7 @@ static void up_disableusartint(struct up_dev_s *priv, uint32_t *ie)
   irqstate_t flags;
   uint32_t ctl_ie;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
 
   if (ie)
     {
@@ -1158,7 +1158,7 @@ static void up_disableusartint(struct up_dev_s *priv, uint32_t *ie)
   ctl_ie = (USART_CFG_CTL_MASK << USART_CFG_SHIFT);
   up_setusartint(priv, ctl_ie);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -1169,11 +1169,11 @@ static void up_restoreusartint(struct up_dev_s *priv, uint32_t ie)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
 
   up_setusartint(priv, ie);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/arm/src/imx6/imx_gpio.c
+++ b/arch/arm/src/imx6/imx_gpio.c
@@ -29,6 +29,7 @@
 #include <errno.h>
 
 #include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 
 #include "chip.h"
 #include "arm_internal.h"
@@ -512,7 +513,7 @@ int imx_config_gpio(gpio_pinset_t pinset)
 
   /* Configure the pin as an input initially to avoid any spurious outputs */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
 
   /* Configure based upon the pin mode */
 
@@ -555,7 +556,7 @@ int imx_config_gpio(gpio_pinset_t pinset)
         break;
     }
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
   return ret;
 }
 

--- a/arch/arm/src/kinetis/kinetis_lpserial.c
+++ b/arch/arm/src/kinetis/kinetis_lpserial.c
@@ -705,10 +705,10 @@ static void kinetis_restoreuartint(struct kinetis_dev_s *priv, uint32_t ie)
    * ie
    */
 
-  flags    = enter_critical_section();
+  flags    = spin_lock_irqsave(NULL);
   priv->ie = ie & LPUART_CTRL_ALL_INTS;
   kinetis_setuartint(priv);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -720,14 +720,14 @@ static void kinetis_disableuartint(struct kinetis_dev_s *priv, uint32_t *ie)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
   if (ie)
     {
       *ie = priv->ie;
     }
 
   kinetis_restoreuartint(priv, 0);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 #endif
 

--- a/arch/arm/src/kinetis/kinetis_serial.c
+++ b/arch/arm/src/kinetis/kinetis_serial.c
@@ -792,12 +792,12 @@ static void up_setuartint(struct up_dev_s *priv)
    * ie
    */
 
-  flags    = enter_critical_section();
+  flags    = spin_lock_irqsave(NULL);
   regval   = up_serialin(priv, KINETIS_UART_C2_OFFSET);
   regval  &= ~UART_C2_ALLINTS;
   regval  |= priv->ie;
   up_serialout(priv, KINETIS_UART_C2_OFFSET, regval);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -812,10 +812,10 @@ static void up_restoreuartint(struct up_dev_s *priv, uint8_t ie)
    * ie
    */
 
-  flags    = enter_critical_section();
+  flags    = spin_lock_irqsave(NULL);
   priv->ie = ie & UART_C2_ALLINTS;
   up_setuartint(priv);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -827,14 +827,14 @@ static void up_disableuartint(struct up_dev_s *priv, uint8_t *ie)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
   if (ie)
     {
       *ie = priv->ie;
     }
 
   up_restoreuartint(priv, 0);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 #endif
 

--- a/arch/arm/src/kl/kl_serial.c
+++ b/arch/arm/src/kl/kl_serial.c
@@ -328,12 +328,12 @@ static void up_setuartint(struct up_dev_s *priv)
    * in ie.
    */
 
-  flags    = enter_critical_section();
+  flags    = spin_lock_irqsave(NULL);
   regval   = up_serialin(priv, KL_UART_C2_OFFSET);
   regval  &= ~UART_C2_ALLINTS;
   regval  |= priv->ie;
   up_serialout(priv, KL_UART_C2_OFFSET, regval);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -348,10 +348,10 @@ static void up_restoreuartint(struct up_dev_s *priv, uint8_t ie)
    * in ie.
    */
 
-  flags    = enter_critical_section();
+  flags    = spin_lock_irqsave(NULL);
   priv->ie = ie & UART_C2_ALLINTS;
   up_setuartint(priv);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -362,14 +362,14 @@ static void up_disableuartint(struct up_dev_s *priv, uint8_t *ie)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
   if (ie)
     {
       *ie = priv->ie;
     }
 
   up_restoreuartint(priv, 0);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/arm/src/lpc54xx/lpc54_lowputc.c
+++ b/arch/arm/src/lpc54xx/lpc54_lowputc.c
@@ -63,6 +63,8 @@
 
 #include <arch/board/board.h>
 
+#include <nuttx/arch.h>
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -797,18 +799,18 @@ void arm_lowputc(char ch)
        * atomic.
        */
 
-      flags = enter_critical_section();
+      flags = spin_lock_irqsave(NULL);
       if ((getreg32(CONSOLE_BASE + LPC54_USART_FIFOSTAT_OFFSET) &
           USART_FIFOSTAT_TXNOTFULL) != 0)
         {
           /* Send the character */
 
           putreg32((uint32_t)ch, CONSOLE_BASE + LPC54_USART_FIFOWR_OFFSET);
-          leave_critical_section(flags);
+          spin_unlock_irqrestore(NULL, flags);
           return;
         }
 
-      leave_critical_section(flags);
+      spin_unlock_irqrestore(NULL, flags);
     }
 #endif
 }

--- a/arch/arm/src/lpc54xx/lpc54_serial.c
+++ b/arch/arm/src/lpc54xx/lpc54_serial.c
@@ -922,14 +922,14 @@ static void lpc54_fifoint_disableall(struct lpc54_dev_s *priv,
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
   if (intset)
     {
       *intset = lpc54_serialin(priv, LPC54_USART_FIFOINTENCLR_OFFSET);
     }
 
   lpc54_serialout(priv, LPC54_USART_FIFOINTENCLR_OFFSET, USART_FIFOINT_ALL);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/arm/src/sam34/sam_lowputc.c
+++ b/arch/arm/src/sam34/sam_lowputc.c
@@ -27,6 +27,7 @@
 #include <stdint.h>
 
 #include <nuttx/irq.h>
+#include <nuttx/arch.h>
 
 #include "arm_internal.h"
 #include "sam_gpio.h"
@@ -277,18 +278,18 @@ void arm_lowputc(char ch)
        * atomic.
        */
 
-      flags = enter_critical_section();
+      flags = spin_lock_irqsave(NULL);
       if ((getreg32(SAM_CONSOLE_BASE + SAM_UART_SR_OFFSET) &
         UART_INT_TXEMPTY) != 0)
         {
           /* Send the character */
 
           putreg32((uint32_t)ch, SAM_CONSOLE_BASE + SAM_UART_THR_OFFSET);
-          leave_critical_section(flags);
+          spin_unlock_irqrestore(NULL, flags);
           return;
         }
 
-      leave_critical_section(flags);
+      spin_unlock_irqrestore(NULL, flags);
     }
 #endif
 }

--- a/arch/arm/src/sama5/sam_lowputc.c
+++ b/arch/arm/src/sama5/sam_lowputc.c
@@ -27,6 +27,7 @@
 #include <stdint.h>
 
 #include <nuttx/irq.h>
+#include <nuttx/arch.h>
 
 #include "arm_internal.h"
 #include "sam_pio.h"
@@ -235,18 +236,18 @@ void arm_lowputc(char ch)
        * atomic.
        */
 
-      flags = enter_critical_section();
+      flags = spin_lock_irqsave(NULL);
       if ((getreg32(SAM_CONSOLE_VBASE + SAM_UART_SR_OFFSET) &
         UART_INT_TXEMPTY) != 0)
         {
           /* Send the character */
 
           putreg32((uint32_t)ch, SAM_CONSOLE_VBASE + SAM_UART_THR_OFFSET);
-          leave_critical_section(flags);
+          spin_unlock_irqrestore(NULL, flags);
           return;
         }
 
-      leave_critical_section(flags);
+      spin_unlock_irqrestore(NULL, flags);
     }
 
 #elif defined(SAMA5_HAVE_FLEXCOM_CONSOLE)

--- a/arch/arm/src/samd2l2/sam_serial.c
+++ b/arch/arm/src/samd2l2/sam_serial.c
@@ -1045,7 +1045,7 @@ int up_putc(int ch)
    * interrupts from firing in the serial driver code.
    */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
 
   /* Check for LF */
 
@@ -1057,7 +1057,7 @@ int up_putc(int ch)
     }
 
   sam_lowputc(ch);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 #endif
   return ch;
 }

--- a/arch/arm/src/samd5e5/sam_serial.c
+++ b/arch/arm/src/samd5e5/sam_serial.c
@@ -1104,7 +1104,7 @@ int up_putc(int ch)
    * interrupts from firing in the serial driver code.
    */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
 
   /* Check for LF */
 
@@ -1116,7 +1116,7 @@ int up_putc(int ch)
     }
 
   sam_lowputc(ch);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 #endif
   return ch;
 }

--- a/arch/arm/src/samv7/sam_lowputc.c
+++ b/arch/arm/src/samv7/sam_lowputc.c
@@ -27,6 +27,7 @@
 #include <stdint.h>
 
 #include <nuttx/irq.h>
+#include <nuttx/arch.h>
 #include <arch/board/board.h>
 
 #include "arm_internal.h"
@@ -183,18 +184,18 @@ void arm_lowputc(char ch)
        * atomic.
        */
 
-      flags = enter_critical_section();
+      flags = spin_lock_irqsave(NULL);
       if ((getreg32(SAM_CONSOLE_BASE + SAM_UART_SR_OFFSET) &
         UART_INT_TXEMPTY) != 0)
         {
           /* Send the character */
 
           putreg32((uint32_t)ch, SAM_CONSOLE_BASE + SAM_UART_THR_OFFSET);
-          leave_critical_section(flags);
+          spin_unlock_irqrestore(NULL, flags);
           return;
         }
 
-      leave_critical_section(flags);
+      spin_unlock_irqrestore(NULL, flags);
     }
 #endif
 }

--- a/arch/arm/src/stm32/stm32_serial.c
+++ b/arch/arm/src/stm32/stm32_serial.c
@@ -1339,11 +1339,11 @@ static void up_restoreusartint(struct up_dev_s *priv, uint16_t ie)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
 
   up_setusartint(priv, ie);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -1354,7 +1354,7 @@ static void up_disableusartint(struct up_dev_s *priv, uint16_t *ie)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
 
   if (ie)
     {
@@ -1395,7 +1395,7 @@ static void up_disableusartint(struct up_dev_s *priv, uint16_t *ie)
 
   up_setusartint(priv, 0);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/arm/src/stm32f0l0g0/stm32_serial_v1.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_serial_v1.c
@@ -803,7 +803,7 @@ static void stm32serial_disableusartint(struct stm32_serial_s *priv,
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
 
   if (ie)
     {
@@ -847,7 +847,7 @@ static void stm32serial_disableusartint(struct stm32_serial_s *priv,
 
   stm32serial_setusartint(priv, 0);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/arm/src/stm32f0l0g0/stm32_serial_v2.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_serial_v2.c
@@ -531,11 +531,11 @@ static void up_restoreusartint(struct up_dev_s *priv, uint16_t ie)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
 
   up_setusartint(priv, ie);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -546,7 +546,7 @@ static void up_disableusartint(struct up_dev_s *priv, uint16_t *ie)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
 
   if (ie)
     {
@@ -590,7 +590,7 @@ static void up_disableusartint(struct up_dev_s *priv, uint16_t *ie)
 
   up_setusartint(priv, 0);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/arm/src/stm32f7/stm32_serial.c
+++ b/arch/arm/src/stm32f7/stm32_serial.c
@@ -1405,11 +1405,11 @@ static void up_restoreusartint(struct up_dev_s *priv, uint16_t ie)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
 
   up_setusartint(priv, ie);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -1420,7 +1420,7 @@ static void up_disableusartint(struct up_dev_s *priv, uint16_t *ie)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
 
   if (ie)
     {
@@ -1464,7 +1464,7 @@ static void up_disableusartint(struct up_dev_s *priv, uint16_t *ie)
 
   up_setusartint(priv, 0);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/arm/src/stm32h7/stm32_serial.c
+++ b/arch/arm/src/stm32h7/stm32_serial.c
@@ -1566,11 +1566,11 @@ static void up_restoreusartint(struct up_dev_s *priv, uint16_t ie)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
 
   up_setusartint(priv, ie);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 #endif
 
@@ -1582,7 +1582,7 @@ static void up_disableusartint(struct up_dev_s *priv, uint16_t *ie)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
 
   if (ie)
     {
@@ -1626,7 +1626,7 @@ static void up_disableusartint(struct up_dev_s *priv, uint16_t *ie)
 
   up_setusartint(priv, 0);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/arm/src/stm32l4/stm32l4_serial.c
+++ b/arch/arm/src/stm32l4/stm32l4_serial.c
@@ -901,11 +901,11 @@ static void stm32l4serial_restoreusartint(struct stm32l4_serial_s *priv,
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
 
   stm32l4serial_setusartint(priv, ie);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -917,7 +917,7 @@ static void stm32l4serial_disableusartint(struct stm32l4_serial_s *priv,
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
 
   if (ie)
     {
@@ -965,7 +965,7 @@ static void stm32l4serial_disableusartint(struct stm32l4_serial_s *priv,
 
   stm32l4serial_setusartint(priv, 0);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/arm/src/stm32l5/stm32l5_serial.c
+++ b/arch/arm/src/stm32l5/stm32l5_serial.c
@@ -906,11 +906,11 @@ static void stm32l5serial_restoreusartint(struct stm32l5_serial_s *priv,
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
 
   stm32l5serial_setusartint(priv, ie);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -922,7 +922,7 @@ static void stm32l5serial_disableusartint(struct stm32l5_serial_s *priv,
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
 
   if (ie)
     {
@@ -965,7 +965,7 @@ static void stm32l5serial_disableusartint(struct stm32l5_serial_s *priv,
 
   stm32l5serial_setusartint(priv, 0);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/arm/src/stm32u5/stm32_serial.c
+++ b/arch/arm/src/stm32u5/stm32_serial.c
@@ -922,7 +922,7 @@ static void stm32serial_disableusartint(struct stm32_serial_s *priv,
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
 
   if (ie)
     {
@@ -965,7 +965,7 @@ static void stm32serial_disableusartint(struct stm32_serial_s *priv,
 
   stm32serial_setusartint(priv, 0);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/arm/src/stm32wb/stm32wb_serial.c
+++ b/arch/arm/src/stm32wb/stm32wb_serial.c
@@ -556,11 +556,11 @@ static void stm32wb_serial_restoreusartint(struct stm32wb_serial_s *priv,
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
 
   stm32wb_serial_setusartint(priv, ie);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -572,7 +572,7 @@ static void stm32wb_serial_disableusartint(struct stm32wb_serial_s *priv,
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
 
   if (ie)
     {
@@ -620,7 +620,7 @@ static void stm32wb_serial_disableusartint(struct stm32wb_serial_s *priv,
 
   stm32wb_serial_setusartint(priv, 0);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/arm/src/stm32wl5/stm32wl5_serial.c
+++ b/arch/arm/src/stm32wl5/stm32wl5_serial.c
@@ -661,11 +661,11 @@ static void stm32wl5serial_restoreusartint(struct stm32wl5_serial_s *priv,
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
 
   stm32wl5serial_setusartint(priv, ie);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -677,7 +677,7 @@ static void stm32wl5serial_disableusartint(struct stm32wl5_serial_s *priv,
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
 
   if (ie)
     {
@@ -720,7 +720,7 @@ static void stm32wl5serial_disableusartint(struct stm32wl5_serial_s *priv,
 
   stm32wl5serial_setusartint(priv, 0);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/arm/src/tms570/tms570_lowputc.c
+++ b/arch/arm/src/tms570/tms570_lowputc.c
@@ -50,6 +50,7 @@
 #include <errno.h>
 
 #include <nuttx/irq.h>
+#include <nuttx/arch.h>
 #include <arch/board/board.h>
 
 #include "arm_internal.h"
@@ -200,18 +201,18 @@ void arm_lowputc(char ch)
        * atomic.
        */
 
-      flags = enter_critical_section();
+      flags = spin_lock_irqsave(NULL);
       if ((getreg32(TMS570_CONSOLE_BASE + TMS570_SCI_FLR_OFFSET) &
         SCI_FLR_TXRDY) != 0)
         {
           /* Send the character */
 
           putreg32((uint32_t)ch, TMS570_CONSOLE_BASE + TMS570_SCI_TD_OFFSET);
-          leave_critical_section(flags);
+          spin_unlock_irqrestore(NULL, flags);
           return;
         }
 
-      leave_critical_section(flags);
+      spin_unlock_irqrestore(NULL, flags);
     }
 #endif
 }

--- a/arch/arm/src/xmc4/xmc4_serial.c
+++ b/arch/arm/src/xmc4/xmc4_serial.c
@@ -551,14 +551,14 @@ static inline void xmc4_modifyreg(struct xmc4_dev_s *priv, unsigned
   uintptr_t regaddr = priv->uartbase + offset;
   uint32_t regval;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
 
   regval = getreg32(regaddr);
   regval &= ~clrbits;
   regval |= setbits;
   putreg32(regval, regaddr);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -573,9 +573,9 @@ static void xmc4_setuartint(struct xmc4_dev_s *priv)
    * bits in priv->ccr.
    */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
   xmc4_modifyreg(priv, XMC4_USIC_CCR_OFFSET, CCR_ALL_EVENTS, priv->ccr);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -590,10 +590,10 @@ static void xmc4_restoreuartint(struct xmc4_dev_s *priv, uint32_t ccr)
    * in the ccr argument.
    */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
   priv->ccr = ccr;
   xmc4_setuartint(priv);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -604,14 +604,14 @@ static void xmc4_disableuartint(struct xmc4_dev_s *priv, uint32_t *ccr)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
   if (ccr)
     {
       *ccr = priv->ccr;
     }
 
   xmc4_restoreuartint(priv, 0);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/arm64/src/a64/a64_serial.c
+++ b/arch/arm64/src/a64/a64_serial.c
@@ -965,7 +965,7 @@ static int a64_uart_init(uint32_t gating, uint32_t rst, pio_pinset_t tx,
   irqstate_t flags;
   int ret = OK;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
 
   /* Enable clocking to UART */
 
@@ -991,7 +991,7 @@ static int a64_uart_init(uint32_t gating, uint32_t rst, pio_pinset_t tx,
         }
     }
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
   return ret;
 };
 

--- a/arch/mips/src/pic32mx/pic32mx_serial.c
+++ b/arch/mips/src/pic32mx/pic32mx_serial.c
@@ -305,10 +305,10 @@ static void up_restoreuartint(struct uart_dev_s *dev, uint8_t im)
    * of bits in im.
    */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
   up_rxint(dev, RX_ENABLED(im));
   up_txint(dev, TX_ENABLED(im));
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -320,14 +320,14 @@ static void up_disableuartint(struct uart_dev_s *dev, uint8_t *im)
   struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
   if (im)
     {
       *im = priv->im;
     }
 
   up_restoreuartint(dev, 0);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/mips/src/pic32mz/pic32mz_serial.c
+++ b/arch/mips/src/pic32mz/pic32mz_serial.c
@@ -622,10 +622,10 @@ static void up_restoreuartint(struct uart_dev_s *dev, uint8_t im)
    * in im
    */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
   up_rxint(dev, RX_ENABLED(im));
   up_txint(dev, TX_ENABLED(im));
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -637,14 +637,14 @@ static void up_disableuartint(struct uart_dev_s *dev, uint8_t *im)
   struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
   if (im)
     {
       *im = priv->im;
     }
 
   up_restoreuartint(dev, 0);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/or1k/src/mor1kx/mor1kx_serial.c
+++ b/arch/or1k/src/mor1kx/mor1kx_serial.c
@@ -115,7 +115,7 @@ int up_putc(int ch)
    * interrupts from firing in the serial driver code.
    */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
 
   /* Check for LF */
 
@@ -128,7 +128,7 @@ int up_putc(int ch)
 
   /* or1k_lowputc(ch); */
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 #endif
   return ch;
 }

--- a/arch/risc-v/src/bl602/bl602_serial.c
+++ b/arch/risc-v/src/bl602/bl602_serial.c
@@ -888,7 +888,7 @@ void riscv_serialinit(void)
 int up_putc(int ch)
 {
 #ifdef HAVE_SERIAL_CONSOLE
-  irqstate_t flags = enter_critical_section();
+  irqstate_t flags = spin_lock_irqsave(NULL);
 
   /* Check for LF */
 
@@ -900,7 +900,7 @@ int up_putc(int ch)
     }
 
   riscv_lowputc(ch);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 #endif
   return ch;
 }

--- a/arch/risc-v/src/c906/c906_serial.c
+++ b/arch/risc-v/src/c906/c906_serial.c
@@ -214,12 +214,12 @@ static void up_serialout(struct up_dev_s *priv, int offset, uint32_t value)
 
 static void up_restoreuartint(struct up_dev_s *priv, uint8_t im)
 {
-  irqstate_t flags = enter_critical_section();
+  irqstate_t flags = spin_lock_irqsave(NULL);
 
   priv->im = im;
   up_serialout(priv, UART_IE_OFFSET, im);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -228,7 +228,7 @@ static void up_restoreuartint(struct up_dev_s *priv, uint8_t im)
 
 static void up_disableuartint(struct up_dev_s *priv, uint8_t *im)
 {
-  irqstate_t flags = enter_critical_section();
+  irqstate_t flags = spin_lock_irqsave(NULL);
 
   /* Return the current interrupt mask value */
 
@@ -241,7 +241,7 @@ static void up_disableuartint(struct up_dev_s *priv, uint8_t *im)
 
   priv->im = 0;
   up_serialout(priv, UART_IE_OFFSET, 0);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/common/espressif/esp_lowputc.c
+++ b/arch/risc-v/src/common/espressif/esp_lowputc.c
@@ -207,7 +207,7 @@ void esp_lowputc_disable_all_uart_int(const struct esp_uart_s *priv,
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
 
   if (current_status != NULL)
     {
@@ -224,7 +224,7 @@ void esp_lowputc_disable_all_uart_int(const struct esp_uart_s *priv,
 
   uart_hal_clr_intsts_mask(priv->hal, UINT32_MAX);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/esp32c3-legacy/esp32c3_lowputc.c
+++ b/arch/risc-v/src/esp32c3-legacy/esp32c3_lowputc.c
@@ -710,7 +710,7 @@ void esp32c3_lowputc_disable_all_uart_int(const struct esp32c3_uart_s *priv,
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
 
   if (current_status != NULL)
     {
@@ -727,7 +727,7 @@ void esp32c3_lowputc_disable_all_uart_int(const struct esp32c3_uart_s *priv,
 
   putreg32(0xffffffff, UART_INT_CLR_REG(priv->id));
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/fe310/fe310_serial.c
+++ b/arch/risc-v/src/fe310/fe310_serial.c
@@ -214,12 +214,12 @@ static void up_serialout(struct up_dev_s *priv, int offset, uint32_t value)
 
 static void up_restoreuartint(struct up_dev_s *priv, uint8_t im)
 {
-  irqstate_t flags = enter_critical_section();
+  irqstate_t flags = spin_lock_irqsave(NULL);
 
   priv->im = im;
   up_serialout(priv, UART_IE_OFFSET, im);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -228,7 +228,7 @@ static void up_restoreuartint(struct up_dev_s *priv, uint8_t im)
 
 static void up_disableuartint(struct up_dev_s *priv, uint8_t *im)
 {
-  irqstate_t flags = enter_critical_section();
+  irqstate_t flags = spin_lock_irqsave(NULL);
 
   /* Return the current interrupt mask value */
 
@@ -241,7 +241,7 @@ static void up_disableuartint(struct up_dev_s *priv, uint8_t *im)
 
   priv->im = 0;
   up_serialout(priv, UART_IE_OFFSET, 0);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/hpm6750/hpm6750_serial.c
+++ b/arch/risc-v/src/hpm6750/hpm6750_serial.c
@@ -233,12 +233,12 @@ static void up_serialmodfiy(struct up_dev_s *priv, int offset,
 
 static void up_restoreuartint(struct up_dev_s *priv, uint8_t im)
 {
-  irqstate_t flags = enter_critical_section();
+  irqstate_t flags = spin_lock_irqsave(NULL);
 
   priv->im = im;
   up_serialout(priv, UART_IER_OFFSET, im);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -247,7 +247,7 @@ static void up_restoreuartint(struct up_dev_s *priv, uint8_t im)
 
 static void up_disableuartint(struct up_dev_s *priv, uint8_t *im)
 {
-  irqstate_t flags = enter_critical_section();
+  irqstate_t flags = spin_lock_irqsave(NULL);
 
   /* Return the current interrupt mask value */
 
@@ -260,7 +260,7 @@ static void up_disableuartint(struct up_dev_s *priv, uint8_t *im)
 
   priv->im = 0;
   up_serialout(priv, UART_IER_OFFSET, 0);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/k210/k210_serial.c
+++ b/arch/risc-v/src/k210/k210_serial.c
@@ -214,12 +214,12 @@ static void up_serialout(struct up_dev_s *priv, int offset, uint32_t value)
 
 static void up_restoreuartint(struct up_dev_s *priv, uint8_t im)
 {
-  irqstate_t flags = enter_critical_section();
+  irqstate_t flags = spin_lock_irqsave(NULL);
 
   priv->im = im;
   up_serialout(priv, UART_IE_OFFSET, im);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -228,7 +228,7 @@ static void up_restoreuartint(struct up_dev_s *priv, uint8_t im)
 
 static void up_disableuartint(struct up_dev_s *priv, uint8_t *im)
 {
-  irqstate_t flags = enter_critical_section();
+  irqstate_t flags = spin_lock_irqsave(NULL);
 
   /* Return the current interrupt mask value */
 
@@ -241,7 +241,7 @@ static void up_disableuartint(struct up_dev_s *priv, uint8_t *im)
 
   priv->im = 0;
   up_serialout(priv, UART_IE_OFFSET, 0);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/litex/litex_serial.c
+++ b/arch/risc-v/src/litex/litex_serial.c
@@ -237,7 +237,7 @@ static void up_serialout(struct up_dev_s *priv, int offset, uint32_t value)
 
 static void up_restoreuartint(struct up_dev_s *priv, uint8_t im)
 {
-  irqstate_t flags = enter_critical_section();
+  irqstate_t flags = spin_lock_irqsave(NULL);
 
   priv->im = im;
 
@@ -245,7 +245,7 @@ static void up_restoreuartint(struct up_dev_s *priv, uint8_t im)
                     LITEX_CONSOLE_BASE + UART_EV_PENDING_OFFSET);
   up_serialout(priv, UART_EV_ENABLE_OFFSET, im);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -254,7 +254,7 @@ static void up_restoreuartint(struct up_dev_s *priv, uint8_t im)
 
 static void up_disableuartint(struct up_dev_s *priv, uint8_t *im)
 {
-  irqstate_t flags = enter_critical_section();
+  irqstate_t flags = spin_lock_irqsave(NULL);
 
   /* Return the current interrupt mask value */
 
@@ -271,7 +271,7 @@ static void up_disableuartint(struct up_dev_s *priv, uint8_t *im)
                     LITEX_CONSOLE_BASE + UART_EV_PENDING_OFFSET);
   up_serialout(priv, UART_EV_ENABLE_OFFSET, 0);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/rv32m1/rv32m1_serial.c
+++ b/arch/risc-v/src/rv32m1/rv32m1_serial.c
@@ -343,11 +343,11 @@ static void up_putreg(struct up_dev_s *priv, int offset, uint32_t value)
 
 static void up_restoreuartint(struct up_dev_s *priv, uint32_t im)
 {
-  irqstate_t flags = enter_critical_section();
+  irqstate_t flags = spin_lock_irqsave(NULL);
 
   up_putreg(priv, RV32M1_LPUART_CTRL_OFFSET, im);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -356,7 +356,7 @@ static void up_restoreuartint(struct up_dev_s *priv, uint32_t im)
 
 static void up_disableuartint(struct up_dev_s *priv, uint32_t *im)
 {
-  irqstate_t flags = enter_critical_section();
+  irqstate_t flags = spin_lock_irqsave(NULL);
   uint32_t regval = up_getreg(priv, RV32M1_LPUART_CTRL_OFFSET);
 
   /* Return the current interrupt mask value */
@@ -371,7 +371,7 @@ static void up_disableuartint(struct up_dev_s *priv, uint32_t *im)
   regval &= ~(LPUART_CTRL_TCIE | LPUART_CTRL_TIE | LPUART_CTRL_RIE);
   up_putreg(priv, RV32M1_LPUART_CTRL_OFFSET, regval);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/sparc/src/bm3803/bm3803-serial.c
+++ b/arch/sparc/src/bm3803/bm3803-serial.c
@@ -359,10 +359,10 @@ static void up_restoreuartint(struct uart_dev_s *dev, uint8_t im)
    * in im
    */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
   up_rxint(dev, RX_ENABLED(im));
   up_txint(dev, TX_ENABLED(im));
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -374,14 +374,14 @@ static void up_disableuartint(struct uart_dev_s *dev, uint8_t *im)
   struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
   if (im)
     {
       *im = priv->im;
     }
 
   up_restoreuartint(dev, 0);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/sparc/src/bm3823/bm3823-serial.c
+++ b/arch/sparc/src/bm3823/bm3823-serial.c
@@ -361,10 +361,10 @@ static void up_restoreuartint(struct uart_dev_s *dev, uint8_t im)
    * im
    */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
   up_rxint(dev, RX_ENABLED(im));
   up_txint(dev, TX_ENABLED(im));
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -376,14 +376,14 @@ static void up_disableuartint(struct uart_dev_s *dev, uint8_t *im)
   struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
   if (im)
     {
       *im = priv->im;
     }
 
   up_restoreuartint(dev, 0);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32s2/esp32s2_lowputc.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_lowputc.c
@@ -653,7 +653,7 @@ void esp32s2_lowputc_disable_all_uart_int(const struct esp32s2_uart_s *priv,
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(NULL);
 
   if (current_status != NULL)
     {
@@ -670,7 +670,7 @@ void esp32s2_lowputc_disable_all_uart_int(const struct esp32s2_uart_s *priv,
 
   putreg32(UINT32_MAX, UART_INT_CLR_REG(priv->id));
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/z16/src/z16f/z16f_serial.c
+++ b/arch/z16/src/z16f/z16f_serial.c
@@ -213,7 +213,7 @@ static uart_dev_t g_uart1port;
 static uint8_t z16f_disableuartirq(struct uart_dev_s *dev)
 {
   struct z16f_uart_s *priv  = (struct z16f_uart_s *)dev->priv;
-  irqstate_t          flags = enter_critical_section();
+  irqstate_t          flags = spin_lock_irqsave(NULL);
   uint8_t             state = priv->rxenabled ? STATE_RXENABLED :
                                                 STATE_DISABLED |
                               priv->txenabled ? STATE_TXENABLED :
@@ -222,7 +222,7 @@ static uint8_t z16f_disableuartirq(struct uart_dev_s *dev)
   z16f_txint(dev, false);
   z16f_rxint(dev, false);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
   return state;
 }
 
@@ -232,12 +232,12 @@ static uint8_t z16f_disableuartirq(struct uart_dev_s *dev)
 
 static void z16f_restoreuartirq(struct uart_dev_s *dev, uint8_t state)
 {
-  irqstate_t flags = enter_critical_section();
+  irqstate_t flags = spin_lock_irqsave(NULL);
 
   z16f_txint(dev, (state & STATE_TXENABLED) ? true : false);
   z16f_rxint(dev, (state & STATE_RXENABLED) ? true : false);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/z80/src/z8/z8_serial.c
+++ b/arch/z80/src/z8/z8_serial.c
@@ -253,7 +253,7 @@ static inline uint8_t z8_getuart(FAR struct z8_uart_s *priv, uint8_t offset)
 static uint8_t z8_disableuartirq(FAR struct uart_dev_s *dev)
 {
   struct z8_uart_s *priv    = (struct z8_uart_s *)dev->priv;
-  irqstate_t          flags = enter_critical_section();
+  irqstate_t          flags = spin_lock_irqsave(NULL);
   uint8_t             state = priv->rxenabled ?
                               STATE_RXENABLED : STATE_DISABLED | \
                               priv->txenabled ?
@@ -262,7 +262,7 @@ static uint8_t z8_disableuartirq(FAR struct uart_dev_s *dev)
   z8_txint(dev, false);
   z8_rxint(dev, false);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
   return state;
 }
 
@@ -272,12 +272,12 @@ static uint8_t z8_disableuartirq(FAR struct uart_dev_s *dev)
 
 static void z8_restoreuartirq(FAR struct uart_dev_s *dev, uint8_t state)
 {
-  irqstate_t flags = enter_critical_section();
+  irqstate_t flags = spin_lock_irqsave(NULL);
 
   z8_txint(dev, (state & STATE_TXENABLED) ? true : false);
   z8_rxint(dev, (state & STATE_RXENABLED) ? true : false);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/drivers/serial/uart_16550.c
+++ b/drivers/serial/uart_16550.c
@@ -1694,8 +1694,12 @@ static bool u16550_txempty(struct uart_dev_s *dev)
 #ifdef HAVE_16550_CONSOLE
 static void u16550_putc(FAR struct u16550_s *priv, int ch)
 {
+  irqstate_t flags;
+
+  flags = spin_lock_irqsave(NULL);
   while ((u16550_serialin(priv, UART_LSR_OFFSET) & UART_LSR_THRE) == 0);
   u16550_serialout(priv, UART_THR_OFFSET, (uart_datawidth_t)ch);
+  spin_unlock_irqrestore(NULL, flags);
 }
 #endif
 
@@ -1768,13 +1772,6 @@ void u16550_serialinit(void)
 int up_putc(int ch)
 {
   FAR struct u16550_s *priv = (FAR struct u16550_s *)CONSOLE_DEV.priv;
-  irqstate_t flags;
-
-  /* All interrupts must be disabled to prevent re-entrancy and to prevent
-   * interrupts from firing in the serial driver code.
-   */
-
-  flags = enter_critical_section();
 
   /* Check for LF */
 
@@ -1786,7 +1783,6 @@ int up_putc(int ch)
     }
 
   u16550_putc(priv, ch);
-  leave_critical_section(flags);
 
   return ch;
 }

--- a/sched/irq/irq_attach.c
+++ b/sched/irq/irq_attach.c
@@ -72,7 +72,7 @@ int irq_attach(int irq, xcpt_t isr, FAR void *arg)
        * to the unexpected interrupt handler.
        */
 
-      flags = enter_critical_section();
+      flags = spin_lock_irqsave(NULL);
       if (isr == NULL)
         {
           /* Disable the interrupt if we can before detaching it.  We might
@@ -121,7 +121,7 @@ int irq_attach(int irq, xcpt_t isr, FAR void *arg)
       g_irqvector[ndx].count   = 0;
 #endif
 
-      leave_critical_section(flags);
+      spin_unlock_irqrestore(NULL, flags);
       ret = OK;
     }
 

--- a/sched/irq/irq_chain.c
+++ b/sched/irq/irq_chain.c
@@ -218,7 +218,7 @@ int irqchain_detach(int irq, xcpt_t isr, FAR void *arg)
       ndx = irq;
 #endif
 
-      flags = enter_critical_section();
+      flags = spin_lock_irqsave(NULL);
 
       if (g_irqvector[ndx].handler == irqchain_dispatch)
         {
@@ -264,7 +264,7 @@ int irqchain_detach(int irq, xcpt_t isr, FAR void *arg)
           ret = irq_detach(irq);
         }
 
-      leave_critical_section(flags);
+      spin_unlock_irqrestore(NULL, flags);
     }
 
   return ret;

--- a/sched/irq/irq_csection.c
+++ b/sched/irq/irq_csection.c
@@ -188,212 +188,205 @@ irqstate_t enter_critical_section(void)
 try_again:
   ret = up_irq_save();
 
-  /* Verify that the system has sufficiently initialized so that the task
-   * lists are valid.
+  /* If called from an interrupt handler, then just take the spinlock.
+   * If we are already in a critical section, this will lock the CPU
+   * in the interrupt handler.  Sounds worse than it is.
    */
 
-  if (nxsched_get_initstate() >= OSINIT_TASKLISTS)
+  if (up_interrupt_context())
     {
-      /* If called from an interrupt handler, then just take the spinlock.
-       * If we are already in a critical section, this will lock the CPU
-       * in the interrupt handler.  Sounds worse than it is.
+      /* We are in an interrupt handler.  How can this happen?
+       *
+       *   1. We were not in a critical section when the interrupt
+       *      occurred.  In this case, the interrupt was entered with:
+       *
+       *      g_cpu_irqlock = SP_UNLOCKED.
+       *      g_cpu_nestcount = 0
+       *      All CPU bits in g_cpu_irqset should be zero
+       *
+       *   2. We were in a critical section and interrupts on this
+       *      this CPU were disabled -- this is an impossible case.
+       *
+       *   3. We were in critical section, but up_irq_save() only
+       *      disabled local interrupts on a different CPU;
+       *      Interrupts could still be enabled on this CPU.
+       *
+       *      g_cpu_irqlock = SP_LOCKED.
+       *      g_cpu_nestcount = 0
+       *      The bit in g_cpu_irqset for this CPU should be zero
+       *
+       *   4. An extension of 3 is that we may be re-entered numerous
+       *      times from the same interrupt handler.  In that case:
+       *
+       *      g_cpu_irqlock = SP_LOCKED.
+       *      g_cpu_nestcount > 0
+       *      The bit in g_cpu_irqset for this CPU should be zero
+       *
+       * NOTE: However, the interrupt entry conditions can change due
+       * to previous processing by the interrupt handler that may
+       * instantiate a new thread that has irqcount > 0 and may then
+       * set the bit in g_cpu_irqset and g_cpu_irqlock = SP_LOCKED
        */
 
-      if (up_interrupt_context())
+      /* Handle nested calls to enter_critical_section() from the same
+       * interrupt.
+       */
+
+      cpu = this_cpu();
+      if (g_cpu_nestcount[cpu] > 0)
         {
-          /* We are in an interrupt handler.  How can this happen?
-           *
-           *   1. We were not in a critical section when the interrupt
-           *      occurred.  In this case, the interrupt was entered with:
-           *
-           *      g_cpu_irqlock = SP_UNLOCKED.
-           *      g_cpu_nestcount = 0
-           *      All CPU bits in g_cpu_irqset should be zero
-           *
-           *   2. We were in a critical section and interrupts on this
-           *      this CPU were disabled -- this is an impossible case.
-           *
-           *   3. We were in critical section, but up_irq_save() only
-           *      disabled local interrupts on a different CPU;
-           *      Interrupts could still be enabled on this CPU.
-           *
-           *      g_cpu_irqlock = SP_LOCKED.
-           *      g_cpu_nestcount = 0
-           *      The bit in g_cpu_irqset for this CPU should be zero
-           *
-           *   4. An extension of 3 is that we may be re-entered numerous
-           *      times from the same interrupt handler.  In that case:
-           *
-           *      g_cpu_irqlock = SP_LOCKED.
-           *      g_cpu_nestcount > 0
-           *      The bit in g_cpu_irqset for this CPU should be zero
-           *
-           * NOTE: However, the interrupt entry conditions can change due
-           * to previous processing by the interrupt handler that may
-           * instantiate a new thread that has irqcount > 0 and may then
-           * set the bit in g_cpu_irqset and g_cpu_irqlock = SP_LOCKED
+          DEBUGASSERT(spin_is_locked(&g_cpu_irqlock) &&
+                      g_cpu_nestcount[cpu] < UINT8_MAX);
+          g_cpu_nestcount[cpu]++;
+        }
+
+      /* This is the first call to enter_critical_section from the
+       * interrupt handler.
+       */
+
+      else
+        {
+          int paused = false;
+
+          /* Make sure that the g_cpu_irqset was not already set
+           * by previous logic on this CPU that was executed by the
+           * interrupt handler.  We know that the bit in g_cpu_irqset
+           * for this CPU was zero on entry into the interrupt handler,
+           * so if it is non-zero now then we know that was the case.
            */
 
-          /* Handle nested calls to enter_critical_section() from the same
-           * interrupt.
-           */
-
-          cpu = this_cpu();
-          if (g_cpu_nestcount[cpu] > 0)
+          if ((g_cpu_irqset & (1 << cpu)) == 0)
             {
-              DEBUGASSERT(spin_is_locked(&g_cpu_irqlock) &&
-                          g_cpu_nestcount[cpu] < UINT8_MAX);
-              g_cpu_nestcount[cpu]++;
-            }
-
-          /* This is the first call to enter_critical_section from the
-           * interrupt handler.
-           */
-
-          else
-            {
-              int paused = false;
-
-              /* Make sure that the g_cpu_irqset was not already set
-               * by previous logic on this CPU that was executed by the
-               * interrupt handler.  We know that the bit in g_cpu_irqset
-               * for this CPU was zero on entry into the interrupt handler,
-               * so if it is non-zero now then we know that was the case.
+              /* Wait until we can get the spinlock (meaning that we are
+               * no longer blocked by the critical section).
                */
-
-              if ((g_cpu_irqset & (1 << cpu)) == 0)
-                {
-                  /* Wait until we can get the spinlock (meaning that we are
-                   * no longer blocked by the critical section).
-                   */
 
 try_again_in_irq:
-                  if (!irq_waitlock(cpu))
-                    {
-                      /* We are in a deadlock condition due to a pending
-                       * pause request interrupt.  Break the deadlock by
-                       * handling the pause request now.
-                       */
-
-                      if (!paused)
-                        {
-                          up_cpu_paused_save();
-                        }
-
-                      DEBUGVERIFY(up_cpu_paused(cpu));
-                      paused = true;
-
-                      /* NOTE: As the result of up_cpu_paused(cpu), this CPU
-                       * might set g_cpu_irqset in nxsched_resume_scheduler()
-                       * However, another CPU might hold g_cpu_irqlock.
-                       * To avoid this situation, releae g_cpu_irqlock first.
-                       */
-
-                      if ((g_cpu_irqset & (1 << cpu)) != 0)
-                        {
-                          spin_clrbit(&g_cpu_irqset, cpu, &g_cpu_irqsetlock,
-                                      &g_cpu_irqlock);
-                        }
-
-                      /* NOTE: Here, this CPU does not hold g_cpu_irqlock,
-                       * so call irq_waitlock(cpu) to acquire g_cpu_irqlock.
-                       */
-
-                      goto try_again_in_irq;
-                    }
-                }
-
-              /* In any event, the nesting count is now one */
-
-              g_cpu_nestcount[cpu] = 1;
-
-              /* Also set the CPU bit so that other CPUs will be aware that
-               * this CPU holds the critical section.
-               */
-
-              spin_setbit(&g_cpu_irqset, cpu, &g_cpu_irqsetlock,
-                          &g_cpu_irqlock);
-              if (paused)
+              if (!irq_waitlock(cpu))
                 {
-                  up_cpu_paused_restore();
+                  /* We are in a deadlock condition due to a pending
+                   * pause request interrupt.  Break the deadlock by
+                   * handling the pause request now.
+                   */
+
+                  if (!paused)
+                    {
+                      up_cpu_paused_save();
+                    }
+
+                  DEBUGVERIFY(up_cpu_paused(cpu));
+                  paused = true;
+
+                  /* NOTE: As the result of up_cpu_paused(cpu), this CPU
+                   * might set g_cpu_irqset in nxsched_resume_scheduler()
+                   * However, another CPU might hold g_cpu_irqlock.
+                   * To avoid this situation, releae g_cpu_irqlock first.
+                   */
+
+                  if ((g_cpu_irqset & (1 << cpu)) != 0)
+                    {
+                      spin_clrbit(&g_cpu_irqset, cpu, &g_cpu_irqsetlock,
+                                  &g_cpu_irqlock);
+                    }
+
+                  /* NOTE: Here, this CPU does not hold g_cpu_irqlock,
+                   * so call irq_waitlock(cpu) to acquire g_cpu_irqlock.
+                   */
+
+                  goto try_again_in_irq;
                 }
             }
+
+          /* In any event, the nesting count is now one */
+
+          g_cpu_nestcount[cpu] = 1;
+
+          /* Also set the CPU bit so that other CPUs will be aware that
+           * this CPU holds the critical section.
+           */
+
+          spin_setbit(&g_cpu_irqset, cpu, &g_cpu_irqsetlock,
+                      &g_cpu_irqlock);
+          if (paused)
+            {
+              up_cpu_paused_restore();
+            }
+        }
+    }
+  else
+    {
+      /* Normal tasking environment.
+       *
+       * Get the TCB of the currently executing task on this CPU (avoid
+       * using this_task() which can recurse.
+       */
+
+      cpu  = this_cpu();
+      rtcb = current_task(cpu);
+      DEBUGASSERT(rtcb != NULL);
+
+      /* Do we already have interrupts disabled? */
+
+      if (rtcb->irqcount > 0)
+        {
+          /* Yes... make sure that the spinlock is set and increment the
+           * IRQ lock count.
+           *
+           * NOTE: If irqcount > 0 then (1) we are in a critical section,
+           * and (2) this CPU should hold the lock.
+           */
+
+          DEBUGASSERT(spin_is_locked(&g_cpu_irqlock) &&
+                      (g_cpu_irqset & (1 << this_cpu())) != 0 &&
+                      rtcb->irqcount < INT16_MAX);
+          rtcb->irqcount++;
         }
       else
         {
-          /* Normal tasking environment.
-           *
-           * Get the TCB of the currently executing task on this CPU (avoid
-           * using this_task() which can recurse.
+          /* If we get here with irqcount == 0, then we know that the
+           * current task running on this CPU is not in a critical
+           * section.  However other tasks on other CPUs may be in a
+           * critical section.  If so, we must wait until they release
+           * the spinlock.
            */
 
-          cpu  = this_cpu();
-          rtcb = current_task(cpu);
-          DEBUGASSERT(rtcb != NULL);
+          DEBUGASSERT((g_cpu_irqset & (1 << cpu)) == 0);
 
-          /* Do we already have interrupts disabled? */
-
-          if (rtcb->irqcount > 0)
+          if (!irq_waitlock(cpu))
             {
-              /* Yes... make sure that the spinlock is set and increment the
-               * IRQ lock count.
-               *
-               * NOTE: If irqcount > 0 then (1) we are in a critical section,
-               * and (2) this CPU should hold the lock.
+              /* We are in a deadlock condition due to a pending pause
+               * request interrupt.  Re-enable interrupts on this CPU
+               * and try again.  Briefly re-enabling interrupts should
+               * be sufficient to permit processing the pending pause
+               * request.
                */
 
-              DEBUGASSERT(spin_is_locked(&g_cpu_irqlock) &&
-                          (g_cpu_irqset & (1 << this_cpu())) != 0 &&
-                          rtcb->irqcount < INT16_MAX);
-              rtcb->irqcount++;
+              up_irq_restore(ret);
+              goto try_again;
             }
-          else
-            {
-              /* If we get here with irqcount == 0, then we know that the
-               * current task running on this CPU is not in a critical
-               * section.  However other tasks on other CPUs may be in a
-               * critical section.  If so, we must wait until they release
-               * the spinlock.
-               */
 
-              DEBUGASSERT((g_cpu_irqset & (1 << cpu)) == 0);
+          /* Then set the lock count to 1.
+           *
+           * Interrupts disables must follow a stacked order.  We
+           * cannot other context switches to re-order the enabling
+           * disabling of interrupts.
+           *
+           * The scheduler accomplishes this by treating the irqcount
+           * like lockcount:  Both will disable pre-emption.
+           */
 
-              if (!irq_waitlock(cpu))
-                {
-                  /* We are in a deadlock condition due to a pending pause
-                   * request interrupt.  Re-enable interrupts on this CPU
-                   * and try again.  Briefly re-enabling interrupts should
-                   * be sufficient to permit processing the pending pause
-                   * request.
-                   */
+          spin_setbit(&g_cpu_irqset, cpu, &g_cpu_irqsetlock,
+                      &g_cpu_irqlock);
+          rtcb->irqcount = 1;
 
-                  up_irq_restore(ret);
-                  goto try_again;
-                }
-
-              /* Then set the lock count to 1.
-               *
-               * Interrupts disables must follow a stacked order.  We
-               * cannot other context switches to re-order the enabling
-               * disabling of interrupts.
-               *
-               * The scheduler accomplishes this by treating the irqcount
-               * like lockcount:  Both will disable pre-emption.
-               */
-
-              spin_setbit(&g_cpu_irqset, cpu, &g_cpu_irqsetlock,
-                          &g_cpu_irqlock);
-              rtcb->irqcount = 1;
-
-              /* Note that we have entered the critical section */
+          /* Note that we have entered the critical section */
 
 #ifdef CONFIG_SCHED_CRITMONITOR
-              nxsched_critmon_csection(rtcb, true);
+          nxsched_critmon_csection(rtcb, true);
 #endif
 #ifdef CONFIG_SCHED_INSTRUMENTATION_CSECTION
-              sched_note_csection(rtcb, true);
+          sched_note_csection(rtcb, true);
 #endif
-            }
         }
     }
 
@@ -412,11 +405,9 @@ irqstate_t enter_critical_section(void)
 
   ret = up_irq_save();
 
-  /* Check if we were called from an interrupt handler and that the task
-   * lists have been initialized.
-   */
+  /* Check if we were called from an interrupt handler */
 
-  if (!up_interrupt_context() && nxsched_get_initstate() >= OSINIT_TASKLISTS)
+  if (!up_interrupt_context())
     {
       FAR struct tcb_s *rtcb = this_task();
       DEBUGASSERT(rtcb != NULL);
@@ -459,108 +450,101 @@ void leave_critical_section(irqstate_t flags)
 {
   int cpu;
 
-  /* Verify that the system has sufficiently initialized so that the task
-   * lists are valid.
+  /* If called from an interrupt handler, then just release the
+   * spinlock.  The interrupt handling logic should already hold the
+   * spinlock if enter_critical_section() has been called.  Unlocking
+   * the spinlock will allow interrupt handlers on other CPUs to execute
+   * again.
    */
 
-  if (nxsched_get_initstate() >= OSINIT_TASKLISTS)
+  if (up_interrupt_context())
     {
-      /* If called from an interrupt handler, then just release the
-       * spinlock.  The interrupt handling logic should already hold the
-       * spinlock if enter_critical_section() has been called.  Unlocking
-       * the spinlock will allow interrupt handlers on other CPUs to execute
-       * again.
+      /* We are in an interrupt handler. Check if the last call to
+       * enter_critical_section() was nested.
        */
 
-      if (up_interrupt_context())
+      cpu = this_cpu();
+      if (g_cpu_nestcount[cpu] > 1)
         {
-          /* We are in an interrupt handler. Check if the last call to
-           * enter_critical_section() was nested.
-           */
+          /* Yes.. then just decrement the nesting count */
 
-          cpu = this_cpu();
-          if (g_cpu_nestcount[cpu] > 1)
-            {
-              /* Yes.. then just decrement the nesting count */
-
-              DEBUGASSERT(spin_is_locked(&g_cpu_irqlock));
-              g_cpu_nestcount[cpu]--;
-            }
-          else
-            {
-              /* No, not nested. Restore the g_cpu_irqset for this CPU
-               * and release the spinlock (if necessary).
-               */
-
-              DEBUGASSERT(spin_is_locked(&g_cpu_irqlock) &&
-                          g_cpu_nestcount[cpu] == 1);
-
-              FAR struct tcb_s *rtcb = current_task(cpu);
-              DEBUGASSERT(rtcb != NULL);
-
-              if (rtcb->irqcount <= 0)
-                {
-                  spin_clrbit(&g_cpu_irqset, cpu, &g_cpu_irqsetlock,
-                              &g_cpu_irqlock);
-                }
-
-              g_cpu_nestcount[cpu] = 0;
-            }
+          DEBUGASSERT(spin_is_locked(&g_cpu_irqlock));
+          g_cpu_nestcount[cpu]--;
         }
       else
         {
-          FAR struct tcb_s *rtcb;
-
-          /* Get the TCB of the currently executing task on this CPU (avoid
-           * using this_task() which can recurse.
+          /* No, not nested. Restore the g_cpu_irqset for this CPU
+           * and release the spinlock (if necessary).
            */
 
-          cpu  = this_cpu();
-          rtcb = current_task(cpu);
-          DEBUGASSERT(rtcb != NULL && rtcb->irqcount > 0);
+          DEBUGASSERT(spin_is_locked(&g_cpu_irqlock) &&
+                      g_cpu_nestcount[cpu] == 1);
 
-          /* Normal tasking context.  We need to coordinate with other
-           * tasks.
-           *
-           * Will we still have interrupts disabled after decrementing the
-           * count?
-           */
+          FAR struct tcb_s *rtcb = current_task(cpu);
+          DEBUGASSERT(rtcb != NULL);
 
-          if (rtcb->irqcount > 1)
+          if (rtcb->irqcount <= 0)
             {
-              /* Yes... the spinlock should remain set */
-
-              DEBUGASSERT(spin_is_locked(&g_cpu_irqlock));
-              rtcb->irqcount--;
-            }
-          else
-            {
-              /* No.. Note that we have left the critical section */
-
-#ifdef CONFIG_SCHED_CRITMONITOR
-              nxsched_critmon_csection(rtcb, false);
-#endif
-#ifdef CONFIG_SCHED_INSTRUMENTATION_CSECTION
-              sched_note_csection(rtcb, false);
-#endif
-              /* Decrement our count on the lock.  If all CPUs have
-               * released, then unlock the spinlock.
-               */
-
-              DEBUGASSERT(spin_is_locked(&g_cpu_irqlock) &&
-                          (g_cpu_irqset & (1 << cpu)) != 0);
-
-              /* Now, possibly on return from a context switch, clear our
-               * count on the lock.  If all CPUs have released the lock,
-               * then unlock the global IRQ spinlock.
-               */
-
-              rtcb->irqcount = 0;
               spin_clrbit(&g_cpu_irqset, cpu, &g_cpu_irqsetlock,
                           &g_cpu_irqlock);
-
-              /* Have all CPUs released the lock? */
             }
+
+          g_cpu_nestcount[cpu] = 0;
+        }
+    }
+  else
+    {
+      FAR struct tcb_s *rtcb;
+
+      /* Get the TCB of the currently executing task on this CPU (avoid
+       * using this_task() which can recurse.
+       */
+
+      cpu  = this_cpu();
+      rtcb = current_task(cpu);
+      DEBUGASSERT(rtcb != NULL && rtcb->irqcount > 0);
+
+      /* Normal tasking context.  We need to coordinate with other
+       * tasks.
+       *
+       * Will we still have interrupts disabled after decrementing the
+       * count?
+       */
+
+      if (rtcb->irqcount > 1)
+        {
+          /* Yes... the spinlock should remain set */
+
+          DEBUGASSERT(spin_is_locked(&g_cpu_irqlock));
+          rtcb->irqcount--;
+        }
+      else
+        {
+          /* No.. Note that we have left the critical section */
+
+#ifdef CONFIG_SCHED_CRITMONITOR
+          nxsched_critmon_csection(rtcb, false);
+#endif
+#ifdef CONFIG_SCHED_INSTRUMENTATION_CSECTION
+          sched_note_csection(rtcb, false);
+#endif
+          /* Decrement our count on the lock.  If all CPUs have
+           * released, then unlock the spinlock.
+           */
+
+          DEBUGASSERT(spin_is_locked(&g_cpu_irqlock) &&
+                      (g_cpu_irqset & (1 << cpu)) != 0);
+
+          /* Now, possibly on return from a context switch, clear our
+           * count on the lock.  If all CPUs have released the lock,
+           * then unlock the global IRQ spinlock.
+           */
+
+          rtcb->irqcount = 0;
+          spin_clrbit(&g_cpu_irqset, cpu, &g_cpu_irqsetlock,
+                      &g_cpu_irqlock);
+
+          /* Have all CPUs released the lock? */
         }
     }
 
@@ -579,7 +563,7 @@ void leave_critical_section(irqstate_t flags)
    * lists have been initialized.
    */
 
-  if (!up_interrupt_context() && nxsched_get_initstate() >= OSINIT_TASKLISTS)
+  if (!up_interrupt_context())
     {
       FAR struct tcb_s *rtcb = this_task();
       DEBUGASSERT(rtcb != NULL);


### PR DESCRIPTION
## Summary
We can save execution time by removing judgments.

## Impact
We should avoid calling enter_critical_section at startup.
## Testing

compiling
make distclean -j20; ./tools/configure.sh -l qemu-armv8a:nsh_smp ;make -j20
running
qemu-system-aarch64 -cpu cortex-a53 -smp 4 -nographic -machine virt,virtualization=on,gic-version=3 -net none -chardev stdio,id=con,mux=on -serial chardev:con -mon chardev=con,mode=readline -kernel ./nuttx

or
compiling
make distclean -j20; ./tools/configure.sh -l sabre-6quad:smp ;make -j20
running
qemu-system-arm  -semihosting -M sabrelite -m 1024 -smp 4 -kernel nuttx/nuttx -nographic