### PR TITLE
sched/sched: CONFIG_SCHED_RESUMESCHEDULER macro define error

### DIFF
--- a/arch/sparc/src/s698pm/s698pm_cpustart.c
+++ b/arch/sparc/src/s698pm/s698pm_cpustart.c
@@ -71,8 +71,6 @@ volatile static spinlock_t g_cpu_boot;
 
 void s698pm_cpu_boot(void)
 {
-  struct tcb_s *tcb = this_task();
-
   _info("CPU%d Started\n", this_cpu());
 
   /* Initialize CPU interrupts */
@@ -84,12 +82,12 @@ void s698pm_cpu_boot(void)
 #ifdef CONFIG_SCHED_INSTRUMENTATION
   /* Notify that this CPU has started */
 
-  sched_note_cpu_started(tcb);
+  sched_note_cpu_started(this_task());
 #endif
 
   /* Reset scheduler parameters */
 
-  nxsched_resume_scheduler(tcb);
+  nxsched_resume_scheduler(this_task());
 
   /* And finally, enable cpu interrupts */
 

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -1210,7 +1210,7 @@ int group_exitinfo(pid_t pid, FAR struct binary_s *bininfo);
  *
  ****************************************************************************/
 
-#if CONFIG_RR_INTERVAL > 0 || defined(CONFIG_SCHED_RESUMESCHEDULER)
+#if defined(CONFIG_SCHED_RESUMESCHEDULER)
 void nxsched_resume_scheduler(FAR struct tcb_s *tcb);
 #else
 #  define nxsched_resume_scheduler(tcb)

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -351,7 +351,6 @@ config SMP
 	depends on ARCH_HAVE_TESTSET
 	depends on ARCH_INTERRUPTSTACK != 0
 	select SPINLOCK
-	select SCHED_RESUMESCHEDULER
 	select IRQCOUNT
 	---help---
 		Enables support for Symmetric Multi-Processing (SMP) on a multi-CPU

--- a/sched/sched/sched_resumescheduler.c
+++ b/sched/sched/sched_resumescheduler.c
@@ -33,7 +33,7 @@
 #include "irq/irq.h"
 #include "sched/sched.h"
 
-#if CONFIG_RR_INTERVAL > 0 || defined(CONFIG_SCHED_RESUMESCHEDULER)
+#if defined(CONFIG_SCHED_RESUMESCHEDULER)
 
 /****************************************************************************
  * Public Functions


### PR DESCRIPTION
## Summary
CONFIG_SCHED_RESUMESCHEDULER macro define error

we removed "select SCHED_RESUMESCHEDULER",
As SCHED_RESUMESCHEDULER is not a necessary feature in SMP,
turning it on by default may affect performance.

## Impact
NULL

## Testing
We can use qemu for testing.
compiling
make distclean -j20; ./tools/configure.sh -l qemu-armv8a:nsh_smp ;make -j20 running
qemu-system-aarch64 -cpu cortex-a53 -smp 4 -nographic -machine virt,virtualization=on,gic-version=3 -net none -chardev stdio,id=con,mux=on -serial chardev:con -mon chardev=con,mode=readline -kernel ./nuttx
