### PR TITLE
sched/signal: There is no need to use sched_[un]lock

### DIFF
--- a/sched/signal/sig_kill.c
+++ b/sched/signal/sig_kill.c
@@ -79,7 +79,6 @@ int nxsig_kill(pid_t pid, int signo)
   FAR struct tcb_s *rtcb = this_task();
 #endif
   siginfo_t info;
-  int ret;
 
   /* We do not support sending signals to process groups */
 
@@ -95,10 +94,6 @@ int nxsig_kill(pid_t pid, int signo)
       return -EINVAL;
     }
 
-  /* Keep things stationary through the following */
-
-  sched_lock();
-
   /* Create the siginfo structure */
 
   info.si_signo           = signo;
@@ -112,10 +107,7 @@ int nxsig_kill(pid_t pid, int signo)
 
   /* Send the signal */
 
-  ret = nxsig_dispatch(pid, &info);
-
-  sched_unlock();
-  return ret;
+  return nxsig_dispatch(pid, &info);
 }
 
 /****************************************************************************

--- a/sched/signal/sig_procmask.c
+++ b/sched/signal/sig_procmask.c
@@ -91,8 +91,6 @@ int nxsig_procmask(int how, FAR const sigset_t *set, FAR sigset_t *oset)
   irqstate_t flags;
   int        ret = OK;
 
-  sched_lock();
-
   /* Return the old signal mask if requested */
 
   if (oset != NULL)
@@ -148,7 +146,6 @@ int nxsig_procmask(int how, FAR const sigset_t *set, FAR sigset_t *oset)
       nxsig_unmask_pendingsignal();
     }
 
-  sched_unlock();
   return ret;
 }
 

--- a/sched/signal/sig_queue.c
+++ b/sched/signal/sig_queue.c
@@ -80,7 +80,6 @@ int nxsig_queue(int pid, int signo, union sigval value)
   FAR struct tcb_s *rtcb = this_task();
 #endif
   siginfo_t info;
-  int ret;
 
   sinfo("pid=0x%08x signo=%d value=%d\n", pid, signo, value.sival_int);
 
@@ -105,11 +104,7 @@ int nxsig_queue(int pid, int signo, union sigval value)
 
   /* Send the signal */
 
-  sched_lock();
-  ret = nxsig_dispatch(pid, &info);
-  sched_unlock();
-
-  return ret;
+  return nxsig_dispatch(pid, &info);
 }
 
 /****************************************************************************

--- a/sched/signal/sig_tgkill.c
+++ b/sched/signal/sig_tgkill.c
@@ -89,10 +89,6 @@ int tgkill(pid_t pid, pid_t tid, int signo)
       goto errout;
     }
 
-  /* Keep things stationary through the following */
-
-  sched_lock();
-
   /* Create the siginfo structure */
 
   info.si_signo           = signo;
@@ -110,7 +106,7 @@ int tgkill(pid_t pid, pid_t tid, int signo)
   if (!stcb)
     {
       ret = -ESRCH;
-      goto errout_with_lock;
+      goto errout;
     }
 
   /* Dispatch the signal to thread, bypassing normal task group thread
@@ -118,7 +114,6 @@ int tgkill(pid_t pid, pid_t tid, int signo)
    */
 
   ret = nxsig_tcbdispatch(stcb, &info);
-  sched_unlock();
 
   if (ret < 0)
     {
@@ -127,8 +122,6 @@ int tgkill(pid_t pid, pid_t tid, int signo)
 
   return OK;
 
-errout_with_lock:
-  sched_unlock();
 errout:
   set_errno(-ret);
   return ERROR;


### PR DESCRIPTION
purpose:
1 sched_lock is very time-consuming, and reducing its invocations can improve performance. 2 sched_lock is prone to misuse, and narrowing its scope of use is to prevent people from referencing incorrect code and using it

test:
We can use qemu for testing.
compiling
make distclean -j20; ./tools/configure.sh -l qemu-armv8a:nsh_smp ;make -j20 running
qemu-system-aarch64 -cpu cortex-a53 -smp 4 -nographic -machine virt,virtualization=on,gic-version=3 -net none -chardev stdio,id=con,mux=on -serial chardev:con -mon chardev=con,mode=readline -kernel ./nuttx

We have also tested this patch on other ARM hardware platforms.
