### PR TITLE
tee: In tee, we need to disable the IRQ interrupt to make the A core policy consistent with the M core.

### DIFF
--- a/arch/arm/src/armv7-a/arm_initialstate.c
+++ b/arch/arm/src/armv7-a/arm_initialstate.c
@@ -137,13 +137,18 @@ void up_initial_state(struct tcb_s *tcb)
 
   cpsr |= (PSR_I_BIT | PSR_F_BIT);
 
-#elif !defined(CONFIG_ARCH_TRUSTZONE_SECURE) && !defined(CONFIG_ARCH_HIPRI_INTERRUPT)
+#elif defined(CONFIG_ARCH_TRUSTZONE_SECURE)
+  /* In tee, we need to disable the IRQ interrupt to make the A core
+   * policy consistent with the M core.
+   */
+
+  cpsr |= PSR_I_BIT;
+#elif !defined(CONFIG_ARCH_HIPRI_INTERRUPT)
   /* Leave IRQs enabled (Also FIQs if CONFIG_ARCH_TRUSTZONE_SECURE or
    * CONFIG_ARCH_HIPRI_INTERRUPT is selected)
    */
 
   cpsr |= PSR_F_BIT;
-
 #endif
 
 #ifdef CONFIG_ARM_THUMB

--- a/sched/sched/sched_addreadytorun.c
+++ b/sched/sched/sched_addreadytorun.c
@@ -165,6 +165,7 @@ bool nxsched_add_readytorun(FAR struct tcb_s *btcb)
     {
       /* Yes.. that is the CPU we must use */
 
+      task_state = TSTATE_TASK_ASSIGNED;
       cpu = btcb->cpu;
     }
   else
@@ -173,6 +174,7 @@ bool nxsched_add_readytorun(FAR struct tcb_s *btcb)
        * (possibly its IDLE task).
        */
 
+      task_state = TSTATE_TASK_READYTORUN;
       cpu = nxsched_select_cpu(btcb->affinity);
     }
 
@@ -189,24 +191,6 @@ bool nxsched_add_readytorun(FAR struct tcb_s *btcb)
   if (rtcb->sched_priority < btcb->sched_priority)
     {
       task_state = TSTATE_TASK_RUNNING;
-    }
-
-  /* If it will not be running, but is locked to a CPU, then it will be in
-   * the assigned state.
-   */
-
-  else if ((btcb->flags & TCB_FLAG_CPU_LOCKED) != 0)
-    {
-      task_state = TSTATE_TASK_ASSIGNED;
-      cpu        = btcb->cpu;
-    }
-
-  /* Otherwise, it will be ready-to-run, but not not yet running */
-
-  else
-    {
-      task_state = TSTATE_TASK_READYTORUN;
-      cpu        = 0;  /* CPU does not matter */
     }
 
   /* If the selected state is TSTATE_TASK_RUNNING, then we would like to


### PR DESCRIPTION
arch: armv7-a: Disable IRQ to make the A core policy consistent with the M core for TEE