### PR TITLE
Added support in Nucleo-L476RG board for BMP280 sensor.

### DIFF
--- a/boards/arm/stm32l4/nucleo-l476rg/src/Makefile
+++ b/boards/arm/stm32l4/nucleo-l476rg/src/Makefile
@@ -85,6 +85,10 @@ ifeq ($(CONFIG_SENSORS_BMP180),y)
 CSRCS += stm32_bmp180.c
 endif
 
+ifeq ($(CONFIG_SENSORS_BMP280),y)
+  CSRCS += stm32_bmp280.c
+endif
+
 ifeq ($(CONFIG_PWM),y)
 CSRCS += stm32_pwm.c
 endif

--- a/boards/arm/stm32l4/nucleo-l476rg/src/stm32_appinit.c
+++ b/boards/arm/stm32l4/nucleo-l476rg/src/stm32_appinit.c
@@ -51,6 +51,10 @@
 
 #include "stm32l4_i2c.h"
 
+#ifdef CONFIG_SENSORS_BMP280
+#  include "stm32_bmp280.h"
+#endif
+
 /****************************************************************************
  * Private Data
  ****************************************************************************/
@@ -426,6 +430,21 @@ int board_app_initialize(uintptr_t arg)
       syslog(LOG_ERR, "ERROR: stm32l4_cc1101_initialize failed: %d\n",
              ret);
       return ret;
+    }
+#endif
+
+#ifdef CONFIG_SENSORS_BMP280
+  /* Try to register BMP280 device in I2C1 */
+
+  ret = board_bmp280_initialize(0, 1);
+
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "Failed to initialize BMP280 driver: %d\n", ret);
+    }
+  else
+    {
+      syslog(LOG_ERR, "Initialized BMP280 driver: %d\n", ret);
     }
 #endif
 

--- a/boards/arm/stm32l4/nucleo-l476rg/src/stm32_bmp280.c
+++ b/boards/arm/stm32l4/nucleo-l476rg/src/stm32_bmp280.c
@@ -1,0 +1,109 @@
+/****************************************************************************
+ * boards/arm/stm32l4/nucleo-l476rg/src/stm32_bmp280.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdio.h>
+#include <debug.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/sensors/bmp280.h>
+#include <nuttx/i2c/i2c_master.h>
+
+#include "stm32l4.h"
+#include "stm32l4_i2c.h"
+#include "stm32_bmp280.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_bmp280_initialize
+ *
+ * Description:
+ *   Initialize and register the BMP280 Pressure Sensor driver.
+ *
+ * Input Parameters:
+ *   devno - The device number, used to build the device path as /dev/pressN
+ *   busno - The I2C bus number
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int board_bmp280_initialize(int devno, int busno)
+{
+  struct i2c_master_s *i2c;
+  int ret;
+
+  sninfo("Initializing BMP280!\n");
+
+  /* Initialize BMP280 */
+
+  i2c = stm32l4_i2cbus_initialize(busno);
+
+  if (i2c)
+    {
+      /* Then try to register the barometer sensor in I2Cx */
+
+      ret = bmp280_register(devno, i2c);
+      if (ret < 0)
+        {
+          snerr("ERROR: Error registering BMP280 in I2C%d\n", busno);
+        }
+    }
+  else
+    {
+      ret = -ENODEV;
+    }
+
+  return ret;
+}
+

--- a/boards/arm/stm32l4/nucleo-l476rg/src/stm32_bmp280.h
+++ b/boards/arm/stm32l4/nucleo-l476rg/src/stm32_bmp280.h
@@ -1,0 +1,84 @@
+/****************************************************************************
+ * boards/arm/stm32l4/nucleo-l476rg/src/stm32_bmp280.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __BOARDS_ARM_STM32L4_NUCLEO_L476RG_INCLUDE_NUCLEO_L476RG_BMP280_H
+#define __BOARDS_ARM_STM32L4_NUCLEO_L476RG_INCLUDE_NUCLEO_L476RG_BMP280_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Type Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Inline Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_bmp280_initialize
+ *
+ * Description:
+ *   Initialize and register the BMP280 Pressure Sensor driver.
+ *
+ * Input Parameters:
+ *   devno - The device number, used to build the device path as /dev/pressN
+ *   busno - The I2C bus number
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int board_bmp280_initialize(int devno, int busno);
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __BOARDS_ARM_STM32L4_NUCLEO_L476RG_INCLUDE_NUCLEO_L476RG_BMP280_H */


### PR DESCRIPTION
## Summary

This commit adds the support for the Bosch BMP280 pressure sensor to the ST Nucleo-L476RG board.

## Impact

Nothing else is impacted.

## Testing

It is tested on Nucleo-L476RG board and it is working fine.