### PR TITLE
arch/risc-v: Make bl602 allocate idle stack after ebss

### DIFF
--- a/arch/risc-v/src/bl602/bl602_allocateheap.c
+++ b/arch/risc-v/src/bl602/bl602_allocateheap.c
@@ -28,13 +28,13 @@
 #include <nuttx/arch.h>
 
 #include "chip.h"
+#include "riscv_internal.h"
 
 /****************************************************************************
  * Public Variables
  ****************************************************************************/
 
-extern uint8_t _heap_start[];
-extern uint8_t _heap_size[];
+extern uint8_t __heap_end[];
 extern uint8_t _heap_wifi_start[];
 extern uint8_t _heap_wifi_size[];
 
@@ -59,8 +59,8 @@ extern uint8_t _heap_wifi_size[];
 
 void up_allocate_heap(void **heap_start, size_t *heap_size)
 {
-  *heap_start = (void *)_heap_start;
-  *heap_size  = (size_t)_heap_size;
+  *heap_start = (void *)g_idle_topstack;
+  *heap_size  = (size_t)((uintptr_t)__heap_end - g_idle_topstack);
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/bl602/bl602_head.S
+++ b/arch/risc-v/src/bl602/bl602_head.S
@@ -46,12 +46,9 @@ bl602_start:
 
     la gp, __global_pointer$
 .option pop
-    la sp, g_idle_stack
-    add s11, sp, zero
-
+    la sp, _ebss
     li t0, SMP_STACK_SIZE
     add sp, sp, t0
-    andi sp, sp, ~0xF
 
 #ifndef RUN_IN_RAM
 
@@ -106,8 +103,8 @@ bl602_entry_load_data_section_end:
 
     /* Clear bss section */
 
-    la a0, __bss_start
-    la a1, __bss_end
+    la a0, _sbss
+    la a1, _ebss
     bgeu a0, a1, bl602_entry_zero_bss_end
 
 bl602_entry_zero_bss_loop:

--- a/arch/risc-v/src/bl602/bl602_start.c
+++ b/arch/risc-v/src/bl602/bl602_start.c
@@ -56,19 +56,6 @@
  * Private Data
  ****************************************************************************/
 
-/* g_idle_topstack: _sbss is the start of the BSS region as defined by the
- * linker script. _ebss lies at the end of the BSS region. The idle task
- * stack starts at the end of BSS and is of size CONFIG_IDLETHREAD_STACKSIZE.
- * The IDLE thread is the thread that the system boots on and, eventually,
- * becomes the IDLE, do nothing task that runs only when there is nothing
- * else to run.  The heap continues from there until the end of memory.
- * g_idle_topstack is a read-only variable the provides this computed
- * address.
- */
-
-uint8_t g_idle_stack[SMP_STACK_SIZE]
-  locate_data(".noinit_idle_stack");
-
 /* Dont change the name of variable, since we refer this
  * g_boot2_partition_table in linker script
  */
@@ -79,7 +66,7 @@ static struct boot2_partition_table_s g_boot2_partition_table used_data;
  * Public Data
  ****************************************************************************/
 
-uintptr_t g_idle_topstack;
+uintptr_t g_idle_topstack = (uintptr_t)_ebss + SMP_STACK_SIZE;
 
 /****************************************************************************
  * Public Functions
@@ -163,13 +150,9 @@ void bfl_main(void)
 
   asm volatile("csrw mtvec, %0" ::"r"((uintptr_t)exception_common + 2));
 
-  /* Configure IDLE stack */
-
-  g_idle_topstack = ((uint32_t)g_idle_stack + SMP_STACK_SIZE);
-
   /* Setup base stack */
 
-  riscv_set_basestack((uintptr_t)g_idle_stack, SMP_STACK_SIZE);
+  riscv_set_basestack((uintptr_t)_ebss, SMP_STACK_SIZE);
 
   /* Configure the UART so we can get debug output */
 

--- a/boards/risc-v/bl602/bl602evb/scripts/ld.script
+++ b/boards/risc-v/bl602/bl602evb/scripts/ld.script
@@ -164,39 +164,21 @@ SECTIONS
     PROVIDE ( __boot2_flash_cfg_end = . );
   } > ram_tcm
 
-  .noinit (NOLOAD) :
-  {
-    . = ALIGN(16);
-    *(.noinit_idle_stack*)
-  } > ram_tcm
-
   .bss (NOLOAD)   :
   {
-    PROVIDE( __bss_start = ADDR(.bss) );
-    PROVIDE( __bss_end = ADDR(.bss) + SIZEOF(.bss) );
-
-    PROVIDE( _sbss = __bss_start );
-    PROVIDE( _ebss = __bss_end );
+    PROVIDE( _sbss = ADDR(.bss) );
 
     *(.sbss*)
     *(.gnu.linkonce.sb.*)
     *(.bss .bss.*)
     *(.gnu.linkonce.b.*)
     *(COMMON)
+    . = ALIGN(32);
+    _ebss = ABSOLUTE(.);
   } > ram_tcm
 
-  . = ALIGN(4);
-
-  PROVIDE( _heap_start = . );
-  PROVIDE( _heap_size = ADDR(.stack) - _heap_start );
-
-  /* .stack ORIGIN(ram_tcm) + LENGTH(ram_tcm) - __stack_size (NOLOAD) : */
-  .stack ORIGIN(ram_tcm) + LENGTH(ram_tcm) (NOLOAD) :
-  {
-    PROVIDE( _sp_irq_base = . );
-    /* . = . + __stack_size; */
-    /* PROVIDE( _sp_main = . ); */
-  } >ram_tcm
+  /* Heap end used in code */
+  PROVIDE(__heap_end = ORIGIN(ram_tcm) + LENGTH(ram_tcm));
 
   /*CFG FW used in code*/
   PROVIDE( _ld_bl_static_cfg_entry_start = _bl_static_fw_cfg_entry_start );


### PR DESCRIPTION
Although almost all board support allocating idle stack after ebss, bl602 have a different memory layout for idle stack. To unify them, make idle stack allocated from ebss for bl602. This will also improve #12265 as we can use `_ebss` for all board.

Although this patch should have no side effect. I have no idea about the memory layout of bl602. It seems the ld script of  this SoC describe a different memory layout from the [datasheet](https://github.com/bouffalolab/bl_docs/blob/main/BL602_DS/en/BL602_BL604_DS_1.6_en.pdf) from bouffalolab.