### PR TITLE
arch/risc-v: Make esp32 SoCs allocate idle stack after ebss

### DIFF
--- a/arch/risc-v/src/common/espressif/esp_allocateheap.c
+++ b/arch/risc-v/src/common/espressif/esp_allocateheap.c
@@ -32,6 +32,7 @@
 #include <nuttx/board.h>
 #include <nuttx/mm/mm.h>
 
+#include "riscv_internal.h"
 #include "rom/rom_layout.h"
 
 /****************************************************************************
@@ -74,13 +75,11 @@ void up_allocate_heap(void **heap_start, size_t *heap_size)
    * Check boards/risc-v/espressif.
    */
 
-  extern uint8_t _sheap[];
-
   board_autoled_on(LED_HEAPALLOCATE);
 
-  *heap_start = _sheap;
+  *heap_start = (void *)g_idle_topstack;
   *heap_size  = (uintptr_t)ets_rom_layout_p->dram0_rtos_reserved_start -
-                (uintptr_t)_sheap;
+                           g_idle_topstack;
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/common/espressif/esp_head.S
+++ b/arch/risc-v/src/common/espressif/esp_head.S
@@ -26,6 +26,7 @@
 
 #include <arch/irq.h>
 
+#include "riscv_internal.h"
 #include "chip.h"
 
 /****************************************************************************
@@ -50,8 +51,9 @@ __start:
 
   /* Set stack pointer to the idle thread stack */
 
-  lui  sp, %hi(ESP_IDLESTACK_TOP)
-  addi sp, sp, %lo(ESP_IDLESTACK_TOP)
+  la   sp, _ebss
+  li   t0, SMP_STACK_SIZE
+  add  sp, sp, t0
 
   /* Set gp pointer */
 

--- a/arch/risc-v/src/common/espressif/esp_memorymap.h
+++ b/arch/risc-v/src/common/espressif/esp_memorymap.h
@@ -33,14 +33,4 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* Idle thread stack starts from _ebss */
-
-#ifndef __ASSEMBLY__
-#define ESP_IDLESTACK_BASE  (uint32_t)&g_idlestack
-#else
-#define ESP_IDLESTACK_BASE  g_idlestack
-#endif
-
-#define ESP_IDLESTACK_TOP  (ESP_IDLESTACK_BASE + SMP_STACK_SIZE)
-
 #endif /* __ARCH_RISCV_SRC_COMMON_ESPRESSIF_ESP_MEMORYMAP_H */

--- a/arch/risc-v/src/common/espressif/esp_start.c
+++ b/arch/risc-v/src/common/espressif/esp_start.c
@@ -174,11 +174,7 @@ HDR_ATTR static void (*_entry_point)(void) = __start;
  * Public Data
  ****************************************************************************/
 
-/* Address of the IDLE thread */
-
-uint8_t g_idlestack[SMP_STACK_SIZE]
-  aligned_data(16) locate_data(".noinit");
-uintptr_t g_idle_topstack = ESP_IDLESTACK_TOP;
+uintptr_t g_idle_topstack = (uintptr_t)_ebss + SMP_STACK_SIZE;
 
 /****************************************************************************
  * Private Functions
@@ -461,7 +457,7 @@ void __esp_start(void)
 
   /* Setup base stack */
 
-  riscv_set_basestack(ESP_IDLESTACK_BASE, SMP_STACK_SIZE);
+  riscv_set_basestack((uintptr_t)_ebss, SMP_STACK_SIZE);
 
   /* Setup the syscall table needed by the ROM code */
 

--- a/arch/risc-v/src/esp32c3-legacy/esp32c3_allocateheap.c
+++ b/arch/risc-v/src/esp32c3-legacy/esp32c3_allocateheap.c
@@ -36,6 +36,7 @@
 #include <arch/board/board_memorymap.h>
 #endif
 
+#include "riscv_internal.h"
 #include "esp32c3.h"
 #include "hardware/esp32c3_rom_layout.h"
 
@@ -91,14 +92,13 @@ void up_allocate_heap(void **heap_start, size_t *heap_size)
    * Check boards/risc-v/esp32c3-legacy.
    */
 
-  extern uint8_t _sheap[];
   extern const struct esp32c3_rom_layout_s *ets_rom_layout_p;
 
   board_autoled_on(LED_HEAPALLOCATE);
 
-  *heap_start = _sheap;
-  *heap_size  = ets_rom_layout_p->dram0_rtos_reserved_start -
-                (uintptr_t)_sheap;
+  *heap_start = (void *)g_idle_topstack;
+  *heap_size  = (uintptr_t)ets_rom_layout_p->dram0_rtos_reserved_start -
+                           g_idle_topstack;
 #endif /* CONFIG_BUILD_PROTECTED && CONFIG_MM_KERNEL_HEAP */
 }
 
@@ -123,9 +123,7 @@ void up_allocate_kheap(void **heap_start, size_t *heap_size)
    * Check boards/risc-v/esp32c3-legacy.
    */
 
-  extern uint8_t _sheap[];
-
-  uintptr_t kbase = (uintptr_t)_sheap;
+  uintptr_t kbase = g_idle_topstack;
   uintptr_t ktop  = KDRAM_END;
   size_t    ksize = ktop - kbase;
 

--- a/arch/risc-v/src/esp32c3-legacy/esp32c3_head.S
+++ b/arch/risc-v/src/esp32c3-legacy/esp32c3_head.S
@@ -25,6 +25,7 @@
 #include <nuttx/config.h>
 #include <arch/irq.h>
 
+#include "riscv_internal.h"
 #include "chip.h"
 
 /****************************************************************************
@@ -49,8 +50,9 @@ __start:
 
   /* Set stack pointer to the idle thread stack */
 
-  lui  sp, %hi(ESP32C3_IDLESTACK_TOP)
-  addi sp, sp, %lo(ESP32C3_IDLESTACK_TOP)
+  la   sp, _ebss
+  li   t0, SMP_STACK_SIZE
+  add  sp, sp, t0
 
   /* Set gp pointer */
 

--- a/arch/risc-v/src/esp32c3-legacy/esp32c3_memorymap.h
+++ b/arch/risc-v/src/esp32c3-legacy/esp32c3_memorymap.h
@@ -31,14 +31,4 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* Idle thread stack starts from _ebss */
-
-#ifndef __ASSEMBLY__
-#define ESP32C3_IDLESTACK_BASE  (uint32_t)&g_idlestack
-#else
-#define ESP32C3_IDLESTACK_BASE  g_idlestack
-#endif
-
-#define ESP32C3_IDLESTACK_TOP  (ESP32C3_IDLESTACK_BASE + SMP_STACK_SIZE)
-
 #endif /* __ARCH_RISCV_SRC_ESP32C3_LEGACY_ESP32C3_MEMORYMAP_H */

--- a/arch/risc-v/src/esp32c3-legacy/esp32c3_start.c
+++ b/arch/risc-v/src/esp32c3-legacy/esp32c3_start.c
@@ -127,11 +127,7 @@ HDR_ATTR static void (*_entry_point)(void) = __start;
  * Public Data
  ****************************************************************************/
 
-/* Address of the IDLE thread */
-
-uint8_t g_idlestack[SMP_STACK_SIZE]
-  aligned_data(16) locate_data(".noinit");
-uintptr_t g_idle_topstack = ESP32C3_IDLESTACK_TOP;
+uintptr_t g_idle_topstack = (uintptr_t)_ebss + SMP_STACK_SIZE;
 
 /****************************************************************************
  * Private Functions
@@ -296,7 +292,7 @@ void __esp32c3_start(void)
 
   /* Setup base stack */
 
-  riscv_set_basestack(ESP32C3_IDLESTACK_BASE, SMP_STACK_SIZE);
+  riscv_set_basestack((uintptr_t)_ebss, SMP_STACK_SIZE);
 
   /* Setup the syscall table needed by the ROM code */
 

--- a/boards/risc-v/esp32c3-legacy/common/scripts/kernel-space.ld
+++ b/boards/risc-v/esp32c3-legacy/common/scripts/kernel-space.ld
@@ -85,31 +85,6 @@ SECTIONS
     . = ORIGIN(KDRAM) + _iram_end - _iram_start;
   } >KDRAM
 
-  /* Shared RAM */
-
-  .dram0.bss (NOLOAD) :
-  {
-    . = ALIGN (8);
-    _sbss = ABSOLUTE(.);
-    *(.dynsbss)
-    *(.sbss)
-    *(.sbss.*)
-    *(.gnu.linkonce.sb.*)
-    *(.scommon)
-    *(.sbss2)
-    *(.sbss2.*)
-    *(.gnu.linkonce.sb2.*)
-    *(.dynbss)
-    *(.bss)
-    *(.bss.*)
-    *(.share.mem)
-    *(.gnu.linkonce.b.*)
-    *(COMMON)
-
-    . = ALIGN (8);
-    _ebss = ABSOLUTE(.);
-  } >KDRAM
-
   .noinit (NOLOAD):
   {
     /* This section contains data that is not initialized during load,
@@ -139,10 +114,31 @@ SECTIONS
     *(.dram1.*)
     . = ALIGN(4);
     _edata = ABSOLUTE(.);
+  } >KDRAM
 
-    /* Heap starts at the end of .data */
+  /* Shared RAM */
 
-    _sheap = ABSOLUTE(.);
+  .dram0.bss (NOLOAD) :
+  {
+    . = ALIGN (8);
+    _sbss = ABSOLUTE(.);
+    *(.dynsbss)
+    *(.sbss)
+    *(.sbss.*)
+    *(.gnu.linkonce.sb.*)
+    *(.scommon)
+    *(.sbss2)
+    *(.sbss2.*)
+    *(.gnu.linkonce.sb2.*)
+    *(.dynbss)
+    *(.bss)
+    *(.bss.*)
+    *(.share.mem)
+    *(.gnu.linkonce.b.*)
+    *(COMMON)
+
+    . = ALIGN (32);
+    _ebss = ABSOLUTE(.);
   } >KDRAM
 
   .flash.text :

--- a/boards/risc-v/esp32c3-legacy/common/scripts/legacy_sections.ld
+++ b/boards/risc-v/esp32c3-legacy/common/scripts/legacy_sections.ld
@@ -54,31 +54,6 @@ SECTIONS
     . = ORIGIN(dram0_0_seg) + _iram_end - _iram_start;
   } >dram0_0_seg
 
-  /* Shared RAM */
-
-  .dram0.bss (NOLOAD) :
-  {
-    . = ALIGN (8);
-    _sbss = ABSOLUTE(.);
-    *(.dynsbss)
-    *(.sbss)
-    *(.sbss.*)
-    *(.gnu.linkonce.sb.*)
-    *(.scommon)
-    *(.sbss2)
-    *(.sbss2.*)
-    *(.gnu.linkonce.sb2.*)
-    *(.dynbss)
-    *(.bss)
-    *(.bss.*)
-    *(.share.mem)
-    *(.gnu.linkonce.b.*)
-    *(COMMON)
-
-    . = ALIGN (8);
-    _ebss = ABSOLUTE(.);
-  } >dram0_0_seg
-
   .noinit (NOLOAD):
   {
     /* This section contains data that is not initialized during load,
@@ -108,10 +83,31 @@ SECTIONS
     *(.dram1.*)
     . = ALIGN(4);
     _edata = ABSOLUTE(.);
+  } >dram0_0_seg
 
-    /* Heap starts at the end of .data */
+  /* Shared RAM */
 
-    _sheap = ABSOLUTE(.);
+  .dram0.bss (NOLOAD) :
+  {
+    . = ALIGN (8);
+    _sbss = ABSOLUTE(.);
+    *(.dynsbss)
+    *(.sbss)
+    *(.sbss.*)
+    *(.gnu.linkonce.sb.*)
+    *(.scommon)
+    *(.sbss2)
+    *(.sbss2.*)
+    *(.gnu.linkonce.sb2.*)
+    *(.dynbss)
+    *(.bss)
+    *(.bss.*)
+    *(.share.mem)
+    *(.gnu.linkonce.b.*)
+    *(COMMON)
+
+    . = ALIGN (32);
+    _ebss = ABSOLUTE(.);
   } >dram0_0_seg
 
   .flash.text :

--- a/boards/risc-v/esp32c3-legacy/common/scripts/mcuboot_sections.ld
+++ b/boards/risc-v/esp32c3-legacy/common/scripts/mcuboot_sections.ld
@@ -144,32 +144,6 @@ SECTIONS
     . = ORIGIN(dram0_0_seg) + _iram_end - _iram_start;
   } >dram0_0_seg
 
-  /* Shared RAM */
-
-  .dram0.bss (NOLOAD) :
-  {
-    /* .bss initialized on power-up */
-
-    . = ALIGN (8);
-    _sbss = ABSOLUTE(.);
-    *(.dynsbss)
-    *(.sbss)
-    *(.sbss.*)
-    *(.gnu.linkonce.sb.*)
-    *(.scommon)
-    *(.sbss2)
-    *(.sbss2.*)
-    *(.gnu.linkonce.sb2.*)
-    *(.dynbss)
-    KEEP (*(.bss))
-    *(.bss.*)
-    *(.share.mem)
-    *(.gnu.linkonce.b.*)
-    *(COMMON)
-    . = ALIGN(8);
-    _ebss = ABSOLUTE(.);
-  } >dram0_0_seg
-
   .noinit (NOLOAD):
   {
     /* This section contains data that is not initialized during load,
@@ -205,11 +179,33 @@ SECTIONS
     esp32c3_start.*(.rodata .rodata.*)
     _edata = ABSOLUTE(.);
     . = ALIGN(4);
-
-    /* Heap starts at the end of .data */
-
-    _sheap = ABSOLUTE(.);
   } >dram0_0_seg AT>ROM
+
+  /* Shared RAM */
+
+  .dram0.bss (NOLOAD) :
+  {
+    /* .bss initialized on power-up */
+
+    . = ALIGN (8);
+    _sbss = ABSOLUTE(.);
+    *(.dynsbss)
+    *(.sbss)
+    *(.sbss.*)
+    *(.gnu.linkonce.sb.*)
+    *(.scommon)
+    *(.sbss2)
+    *(.sbss2.*)
+    *(.gnu.linkonce.sb2.*)
+    *(.dynbss)
+    KEEP (*(.bss))
+    *(.bss.*)
+    *(.share.mem)
+    *(.gnu.linkonce.b.*)
+    *(COMMON)
+    . = ALIGN(8);
+    _ebss = ABSOLUTE(.);
+  } >dram0_0_seg
 
   /* Marks the end of IRAM code segment */
 

--- a/boards/risc-v/esp32c3-legacy/common/scripts/user-space.ld
+++ b/boards/risc-v/esp32c3-legacy/common/scripts/user-space.ld
@@ -147,31 +147,6 @@ SECTIONS
     . = ORIGIN(UDRAM) + _iram_end - _iram_start;
   } >UDRAM
 
-  /* Shared RAM */
-
-  .bss (NOLOAD) :
-  {
-    . = ALIGN (8);
-    _sbss = ABSOLUTE(.);
-    *(.dynsbss)
-    *(.sbss)
-    *(.sbss.*)
-    *(.gnu.linkonce.sb.*)
-    *(.scommon)
-    *(.sbss2)
-    *(.sbss2.*)
-    *(.gnu.linkonce.sb2.*)
-    *(.dynbss)
-    *(.bss)
-    *(.bss.*)
-    *(.share.mem)
-    *(.gnu.linkonce.b.*)
-    *(COMMON)
-
-    . = ALIGN (8);
-    _ebss = ABSOLUTE(.);
-  } >UDRAM
-
   .noinit (NOLOAD):
   {
     /* This section contains data that is not initialized during load,
@@ -201,6 +176,31 @@ SECTIONS
     . = ALIGN(4);
     _edata = ABSOLUTE(.);
   } >UDRAM AT>ROM
+
+  /* Shared RAM */
+
+  .bss (NOLOAD) :
+  {
+    . = ALIGN (8);
+    _sbss = ABSOLUTE(.);
+    *(.dynsbss)
+    *(.sbss)
+    *(.sbss.*)
+    *(.gnu.linkonce.sb.*)
+    *(.scommon)
+    *(.sbss2)
+    *(.sbss2.*)
+    *(.gnu.linkonce.sb2.*)
+    *(.dynbss)
+    *(.bss)
+    *(.bss.*)
+    *(.share.mem)
+    *(.gnu.linkonce.b.*)
+    *(COMMON)
+
+    . = ALIGN (32);
+    _ebss = ABSOLUTE(.);
+  } >UDRAM
 
   .flash_text_dummy (NOLOAD) : ALIGN(0x00010000)
   {

--- a/boards/risc-v/esp32c3/common/scripts/esp32c3_legacy_sections.ld
+++ b/boards/risc-v/esp32c3/common/scripts/esp32c3_legacy_sections.ld
@@ -59,31 +59,6 @@ SECTIONS
     . = ORIGIN(dram0_0_seg) + _iram_end - _iram_start;
   } >dram0_0_seg
 
-  /* Shared RAM */
-
-  .dram0.bss (NOLOAD) :
-  {
-    . = ALIGN (8);
-    _sbss = ABSOLUTE(.);
-    *(.dynsbss)
-    *(.sbss)
-    *(.sbss.*)
-    *(.gnu.linkonce.sb.*)
-    *(.scommon)
-    *(.sbss2)
-    *(.sbss2.*)
-    *(.gnu.linkonce.sb2.*)
-    *(.dynbss)
-    *(.bss)
-    *(.bss.*)
-    *(.share.mem)
-    *(.gnu.linkonce.b.*)
-    *(COMMON)
-
-    . = ALIGN (8);
-    _ebss = ABSOLUTE(.);
-  } >dram0_0_seg
-
   .noinit (NOLOAD):
   {
     /* This section contains data that is not initialized during load,
@@ -126,10 +101,31 @@ SECTIONS
     *libsched.a:irq_dispatch.*(.rodata .rodata.*)
     . = ALIGN(4);
     _edata = ABSOLUTE(.);
+  } >dram0_0_seg
 
-    /* Heap starts at the end of .data */
+  /* Shared RAM */
 
-    _sheap = ABSOLUTE(.);
+  .dram0.bss (NOLOAD) :
+  {
+    . = ALIGN (8);
+    _sbss = ABSOLUTE(.);
+    *(.dynsbss)
+    *(.sbss)
+    *(.sbss.*)
+    *(.gnu.linkonce.sb.*)
+    *(.scommon)
+    *(.sbss2)
+    *(.sbss2.*)
+    *(.gnu.linkonce.sb2.*)
+    *(.dynbss)
+    *(.bss)
+    *(.bss.*)
+    *(.share.mem)
+    *(.gnu.linkonce.b.*)
+    *(COMMON)
+
+    . = ALIGN (8);
+    _ebss = ABSOLUTE(.);
   } >dram0_0_seg
 
   .flash.text :

--- a/boards/risc-v/esp32c3/common/scripts/esp32c3_mcuboot_sections.ld
+++ b/boards/risc-v/esp32c3/common/scripts/esp32c3_mcuboot_sections.ld
@@ -147,32 +147,6 @@ SECTIONS
     . = ORIGIN(dram0_0_seg) + _iram_end - _iram_start;
   } >dram0_0_seg
 
-  /* Shared RAM */
-
-  .dram0.bss (NOLOAD) :
-  {
-    /* .bss initialized on power-up */
-
-    . = ALIGN (8);
-    _sbss = ABSOLUTE(.);
-    *(.dynsbss)
-    *(.sbss)
-    *(.sbss.*)
-    *(.gnu.linkonce.sb.*)
-    *(.scommon)
-    *(.sbss2)
-    *(.sbss2.*)
-    *(.gnu.linkonce.sb2.*)
-    *(.dynbss)
-    KEEP (*(.bss))
-    *(.bss.*)
-    *(.share.mem)
-    *(.gnu.linkonce.b.*)
-    *(COMMON)
-    . = ALIGN(8);
-    _ebss = ABSOLUTE(.);
-  } >dram0_0_seg
-
   .noinit (NOLOAD):
   {
     /* This section contains data that is not initialized during load,
@@ -210,12 +184,33 @@ SECTIONS
     esp_head.*(.rodata .rodata.*)
     esp_start.*(.rodata .rodata.*)
     _edata = ABSOLUTE(.);
-    . = ALIGN(4);
-
-    /* Heap starts at the end of .data */
-
-    _sheap = ABSOLUTE(.);
   } >dram0_0_seg AT>ROM
+
+  /* Shared RAM */
+
+  .dram0.bss (NOLOAD) :
+  {
+    /* .bss initialized on power-up */
+
+    . = ALIGN (8);
+    _sbss = ABSOLUTE(.);
+    *(.dynsbss)
+    *(.sbss)
+    *(.sbss.*)
+    *(.gnu.linkonce.sb.*)
+    *(.scommon)
+    *(.sbss2)
+    *(.sbss2.*)
+    *(.gnu.linkonce.sb2.*)
+    *(.dynbss)
+    KEEP (*(.bss))
+    *(.bss.*)
+    *(.share.mem)
+    *(.gnu.linkonce.b.*)
+    *(COMMON)
+    . = ALIGN(32);
+    _ebss = ABSOLUTE(.);
+  } >dram0_0_seg
 
   /* Marks the end of IRAM code segment */
 

--- a/boards/risc-v/esp32c3/common/scripts/esp32c3_simple_boot_sections.ld
+++ b/boards/risc-v/esp32c3/common/scripts/esp32c3_simple_boot_sections.ld
@@ -103,33 +103,6 @@ SECTIONS
     . = ORIGIN(dram0_0_seg) + _iram_end - _iram_start;
   } >dram0_0_seg
 
-  /* Shared RAM */
-
-  .dram0.bss (NOLOAD) :
-  {
-    . = ALIGN (8);
-    _bss_start = ABSOLUTE(.);
-    _sbss = ABSOLUTE(.);
-    *(.dynsbss)
-    *(.sbss)
-    *(.sbss.*)
-    *(.gnu.linkonce.sb.*)
-    *(.scommon)
-    *(.sbss2)
-    *(.sbss2.*)
-    *(.gnu.linkonce.sb2.*)
-    *(.dynbss)
-    *(.bss)
-    *(.bss.*)
-    *(.share.mem)
-    *(.gnu.linkonce.b.*)
-    *(COMMON)
-
-    . = ALIGN (8);
-    _ebss = ABSOLUTE(.);
-    _bss_end = ABSOLUTE(.);
-  } >dram0_0_seg
-
   .noinit (NOLOAD):
   {
     /* This section contains data that is not initialized during load,
@@ -219,11 +192,34 @@ SECTIONS
     . = ALIGN(4);
     _edata = ABSOLUTE(.);
     _data_end = ABSOLUTE(.);
-
-    /* Heap starts at the end of .data */
-
-    _sheap = ABSOLUTE(.);
   } >dram0_0_seg AT > ROM
+
+  /* Shared RAM */
+
+  .dram0.bss (NOLOAD) :
+  {
+    . = ALIGN (8);
+    _bss_start = ABSOLUTE(.);
+    _sbss = ABSOLUTE(.);
+    *(.dynsbss)
+    *(.sbss)
+    *(.sbss.*)
+    *(.gnu.linkonce.sb.*)
+    *(.scommon)
+    *(.sbss2)
+    *(.sbss2.*)
+    *(.gnu.linkonce.sb2.*)
+    *(.dynbss)
+    *(.bss)
+    *(.bss.*)
+    *(.share.mem)
+    *(.gnu.linkonce.b.*)
+    *(COMMON)
+
+    . = ALIGN (8);
+    _ebss = ABSOLUTE(.);
+    _bss_end = ABSOLUTE(.);
+  } >dram0_0_seg
 
   _image_irom_vma = ADDR(.flash.text);
   _image_irom_lma = LOADADDR(.flash.text);

--- a/boards/risc-v/esp32c6/common/scripts/esp32c6_legacy_sections.ld
+++ b/boards/risc-v/esp32c6/common/scripts/esp32c6_legacy_sections.ld
@@ -83,31 +83,6 @@ SECTIONS
     . = ORIGIN(dram0_0_seg) + _iram_end - _iram_start;
   } >dram0_0_seg
 
-  /* Shared RAM */
-
-  .dram0.bss (NOLOAD) :
-  {
-    . = ALIGN(8);
-    _sbss = ABSOLUTE(.);
-    *(.dynsbss)
-    *(.sbss)
-    *(.sbss.*)
-    *(.gnu.linkonce.sb.*)
-    *(.scommon)
-    *(.sbss2)
-    *(.sbss2.*)
-    *(.gnu.linkonce.sb2.*)
-    *(.dynbss)
-    *(.bss)
-    *(.bss.*)
-    *(.share.mem)
-    *(.gnu.linkonce.b.*)
-    *(COMMON)
-
-    . = ALIGN(8);
-    _ebss = ABSOLUTE(.);
-  } >dram0_0_seg
-
   .noinit (NOLOAD):
   {
     /* This section contains data that is not initialized during load,
@@ -153,10 +128,31 @@ SECTIONS
     *libsched.a:irq_dispatch.*(.rodata .rodata.*)
     . = ALIGN(4);
     _edata = ABSOLUTE(.);
+  } >dram0_0_seg
 
-    /* Heap starts at the end of .data */
+  /* Shared RAM */
 
-    _sheap = ABSOLUTE(.);
+  .dram0.bss (NOLOAD) :
+  {
+    . = ALIGN(8);
+    _sbss = ABSOLUTE(.);
+    *(.dynsbss)
+    *(.sbss)
+    *(.sbss.*)
+    *(.gnu.linkonce.sb.*)
+    *(.scommon)
+    *(.sbss2)
+    *(.sbss2.*)
+    *(.gnu.linkonce.sb2.*)
+    *(.dynbss)
+    *(.bss)
+    *(.bss.*)
+    *(.share.mem)
+    *(.gnu.linkonce.b.*)
+    *(COMMON)
+
+    . = ALIGN(32);
+    _ebss = ABSOLUTE(.);
   } >dram0_0_seg
 
   .flash.text :

--- a/boards/risc-v/esp32c6/common/scripts/esp32c6_simple_boot_sections.ld
+++ b/boards/risc-v/esp32c6/common/scripts/esp32c6_simple_boot_sections.ld
@@ -137,33 +137,6 @@ SECTIONS
     . = ORIGIN(dram0_0_seg) + _iram_end - _iram_start;
   } >dram0_0_seg
 
-  /* Shared RAM */
-
-  .dram0.bss (NOLOAD) :
-  {
-    . = ALIGN (8);
-    _bss_start = ABSOLUTE(.);
-    _sbss = ABSOLUTE(.);
-    *(.dynsbss)
-    *(.sbss)
-    *(.sbss.*)
-    *(.gnu.linkonce.sb.*)
-    *(.scommon)
-    *(.sbss2)
-    *(.sbss2.*)
-    *(.gnu.linkonce.sb2.*)
-    *(.dynbss)
-    *(.bss)
-    *(.bss.*)
-    *(.share.mem)
-    *(.gnu.linkonce.b.*)
-    *(COMMON)
-
-    . = ALIGN (8);
-    _ebss = ABSOLUTE(.);
-    _bss_end = ABSOLUTE(.);
-  } >dram0_0_seg
-
   .noinit (NOLOAD):
   {
     /* This section contains data that is not initialized during load,
@@ -263,11 +236,34 @@ SECTIONS
     . = ALIGN(4);
     _edata = ABSOLUTE(.);
     _data_end = ABSOLUTE(.);
-
-    /* Heap starts at the end of .data */
-
-    _sheap = ABSOLUTE(.);
   } >dram0_0_seg AT > ROM
+
+  /* Shared RAM */
+
+  .dram0.bss (NOLOAD) :
+  {
+    . = ALIGN (8);
+    _bss_start = ABSOLUTE(.);
+    _sbss = ABSOLUTE(.);
+    *(.dynsbss)
+    *(.sbss)
+    *(.sbss.*)
+    *(.gnu.linkonce.sb.*)
+    *(.scommon)
+    *(.sbss2)
+    *(.sbss2.*)
+    *(.gnu.linkonce.sb2.*)
+    *(.dynbss)
+    *(.bss)
+    *(.bss.*)
+    *(.share.mem)
+    *(.gnu.linkonce.b.*)
+    *(COMMON)
+
+    . = ALIGN (32);
+    _ebss = ABSOLUTE(.);
+    _bss_end = ABSOLUTE(.);
+  } >dram0_0_seg
 
   _image_irom_vma = ADDR(.flash.text);
   _image_irom_lma = LOADADDR(.flash.text);

--- a/boards/risc-v/esp32h2/common/scripts/esp32h2_legacy_sections.ld
+++ b/boards/risc-v/esp32h2/common/scripts/esp32h2_legacy_sections.ld
@@ -83,31 +83,6 @@ SECTIONS
     . = ORIGIN(dram0_0_seg) + _iram_end - _iram_start;
   } >dram0_0_seg
 
-  /* Shared RAM */
-
-  .dram0.bss (NOLOAD) :
-  {
-    . = ALIGN(8);
-    _sbss = ABSOLUTE(.);
-    *(.dynsbss)
-    *(.sbss)
-    *(.sbss.*)
-    *(.gnu.linkonce.sb.*)
-    *(.scommon)
-    *(.sbss2)
-    *(.sbss2.*)
-    *(.gnu.linkonce.sb2.*)
-    *(.dynbss)
-    *(.bss)
-    *(.bss.*)
-    *(.share.mem)
-    *(.gnu.linkonce.b.*)
-    *(COMMON)
-
-    . = ALIGN(8);
-    _ebss = ABSOLUTE(.);
-  } >dram0_0_seg
-
   .noinit (NOLOAD):
   {
     /* This section contains data that is not initialized during load,
@@ -153,10 +128,31 @@ SECTIONS
     *libsched.a:irq_dispatch.*(.rodata .rodata.*)
     . = ALIGN(4);
     _edata = ABSOLUTE(.);
+  } >dram0_0_seg
 
-    /* Heap starts at the end of .data */
+  /* Shared RAM */
 
-    _sheap = ABSOLUTE(.);
+  .dram0.bss (NOLOAD) :
+  {
+    . = ALIGN(8);
+    _sbss = ABSOLUTE(.);
+    *(.dynsbss)
+    *(.sbss)
+    *(.sbss.*)
+    *(.gnu.linkonce.sb.*)
+    *(.scommon)
+    *(.sbss2)
+    *(.sbss2.*)
+    *(.gnu.linkonce.sb2.*)
+    *(.dynbss)
+    *(.bss)
+    *(.bss.*)
+    *(.share.mem)
+    *(.gnu.linkonce.b.*)
+    *(COMMON)
+
+    . = ALIGN(32);
+    _ebss = ABSOLUTE(.);
   } >dram0_0_seg
 
   .flash.text :

--- a/boards/risc-v/esp32h2/common/scripts/esp32h2_simple_boot_sections.ld
+++ b/boards/risc-v/esp32h2/common/scripts/esp32h2_simple_boot_sections.ld
@@ -137,33 +137,6 @@ SECTIONS
     . = ORIGIN(dram0_0_seg) + _iram_end - _iram_start;
   } >dram0_0_seg
 
-  /* Shared RAM */
-
-  .dram0.bss (NOLOAD) :
-  {
-    . = ALIGN (8);
-    _bss_start = ABSOLUTE(.);
-    _sbss = ABSOLUTE(.);
-    *(.dynsbss)
-    *(.sbss)
-    *(.sbss.*)
-    *(.gnu.linkonce.sb.*)
-    *(.scommon)
-    *(.sbss2)
-    *(.sbss2.*)
-    *(.gnu.linkonce.sb2.*)
-    *(.dynbss)
-    *(.bss)
-    *(.bss.*)
-    *(.share.mem)
-    *(.gnu.linkonce.b.*)
-    *(COMMON)
-
-    . = ALIGN (8);
-    _ebss = ABSOLUTE(.);
-    _bss_end = ABSOLUTE(.);
-  } >dram0_0_seg
-
   .noinit (NOLOAD):
   {
     /* This section contains data that is not initialized during load,
@@ -263,11 +236,34 @@ SECTIONS
     . = ALIGN(4);
     _edata = ABSOLUTE(.);
     _data_end = ABSOLUTE(.);
-
-    /* Heap starts at the end of .data */
-
-    _sheap = ABSOLUTE(.);
   } >dram0_0_seg AT > ROM
+
+  /* Shared RAM */
+
+  .dram0.bss (NOLOAD) :
+  {
+    . = ALIGN (8);
+    _bss_start = ABSOLUTE(.);
+    _sbss = ABSOLUTE(.);
+    *(.dynsbss)
+    *(.sbss)
+    *(.sbss.*)
+    *(.gnu.linkonce.sb.*)
+    *(.scommon)
+    *(.sbss2)
+    *(.sbss2.*)
+    *(.gnu.linkonce.sb2.*)
+    *(.dynbss)
+    *(.bss)
+    *(.bss.*)
+    *(.share.mem)
+    *(.gnu.linkonce.b.*)
+    *(COMMON)
+
+    . = ALIGN (32);
+    _ebss = ABSOLUTE(.);
+    _bss_end = ABSOLUTE(.);
+  } >dram0_0_seg
 
   _image_irom_vma = ADDR(.flash.text);
   _image_irom_lma = LOADADDR(.flash.text);


### PR DESCRIPTION
ESP32 SoC use a static allocated array as idle stack. To fit the existed idle stack allocation, make idle stack allocated from ebss for the whole esp32 series.

This is also necessary for simplifying #12265

## Impact
esp32c3-legacy, esp32c3, esp32c6, esp32h2

## Testing
esp32c6-devkitC
