### PR TITLE
libc/lib_bzero:Add bzero prototype.

### DIFF
--- a/include/strings.h
+++ b/include/strings.h
@@ -49,10 +49,6 @@
 #define bcopy(b1,b2,len) memmove(b2,b1,len)
 #endif
 
-#ifndef bzero /* See mm/README.txt */
-#define bzero(s,n)       memset(s,0,n)
-#endif
-
 #define strcasecmp_l(s1, s2, l)     strcasecmp(s1, s2)
 #define strncasecmp_l(s1, s2, n, l) strncasecmp(s1, s2, n)
 
@@ -156,11 +152,13 @@ FAR char *rindex(FAR const char *s, int c);
 int strcasecmp(FAR const char *, FAR const char *);
 int strncasecmp(FAR const char *, FAR const char *, size_t);
 
+void bzero(FAR void *s, size_t n);
+
 #if CONFIG_FORTIFY_SOURCE > 0
 fortify_function(bzero) void bzero(FAR void *s, size_t n)
 {
   fortify_assert(n <= fortify_size(s, 0));
-  return bzero(s, n);
+  return __real_bzero(s, n);
 }
 #endif
 

--- a/libs/libc/string/Make.defs
+++ b/libs/libc/string/Make.defs
@@ -30,7 +30,7 @@ CSRCS += lib_strndup.c lib_strcasestr.c lib_strpbrk.c lib_strrchr.c
 CSRCS += lib_strspn.c lib_strstr.c lib_strtok.c lib_strtokr.c
 CSRCS += lib_strsep.c lib_strerrorr.c lib_explicit_bzero.c lib_strsignal.c
 CSRCS += lib_index.c lib_rindex.c lib_timingsafe_bcmp.c lib_strverscmp.c
-CSRCS += lib_mempcpy.c lib_rawmemchr.c
+CSRCS += lib_mempcpy.c lib_rawmemchr.c lib_bzero.c
 
 CSRCS += lib_memchr.c lib_memcmp.c lib_memmove.c lib_memset.c
 CSRCS += lib_strchr.c lib_strcmp.c lib_strcpy.c lib_strlcat.c

--- a/libs/libc/string/lib_bzero.c
+++ b/libs/libc/string/lib_bzero.c
@@ -1,0 +1,40 @@
+/****************************************************************************
+ * libs/libc/string/lib_bzero.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <sys/types.h>
+#include <strings.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: bzero
+ ****************************************************************************/
+
+void bzero(FAR void *s, size_t n)
+{
+  memset(s, 0, n);
+}


### PR DESCRIPTION
## Summary
Implement the bzero function as an alternative to macro expansion.

and support gcc FORTIFY_SOURCE features for nuttx libc

This function will use gcc's function
__builtin_dynamic_object_size and __builtin_object_size

Its function is to obtain the size of the object through compilation, so as to judge whether there are out-of-bounds operations in commonly used functions. It should be noted that the option -O2 and above is required to enable this function

## Impact

## Testing
cortex-m33
