### PR TITLE
include: When defining NDEBUG, assert will implement alignment standards

### DIFF
--- a/arch/arm/src/armv8-r/arm_gicv3.c
+++ b/arch/arm/src/armv8-r/arm_gicv3.c
@@ -313,7 +313,7 @@ static int arm_gic_send_sgi(unsigned int sgi_id, uint64_t target_aff,
   uint32_t aff1;
   uint64_t sgi_val;
 
-  assert(GIC_IS_SGI(sgi_id));
+  ASSERT(GIC_IS_SGI(sgi_id));
 
   /* Extract affinity fields from target */
 
@@ -448,7 +448,7 @@ static void gicv3_cpuif_init(void)
       CP15_SET(ICC_SRE, icc_sre);
       icc_sre = CP15_GET(ICC_SRE);
 
-      assert(icc_sre & ICC_SRE_ELX_SRE_BIT);
+      ASSERT(icc_sre & ICC_SRE_ELX_SRE_BIT);
     }
 
   CP15_SET(ICC_PMR, GIC_IDLE_PRIO);

--- a/arch/arm/src/imxrt/imxrt_flexspi.c
+++ b/arch/arm/src/imxrt/imxrt_flexspi.c
@@ -370,7 +370,7 @@ static uint32_t imxrt_flexspi_configure_dll(struct flexspi_type_s *base,
           }
         break;
       default:
-          assert(false);
+          ASSERT(false);
           break;
   }
 
@@ -431,7 +431,7 @@ static int imxrt_flexspi_check_and_clear_error(struct flexspi_type_s *base,
         }
       else
         {
-          assert(false);
+          ASSERT(false);
         }
 
       /* Clear the flags */
@@ -808,7 +808,7 @@ void imxrt_flexspi_update_lut_private(struct flexspi_type_s *base,
                                       const uint32_t *cmd,
                                       uint32_t count)
 {
-  assert(index < 64u);
+  ASSERT(index < 64u);
 
   uint32_t i = 0;
   volatile uint32_t *lut_base;

--- a/arch/arm/src/lc823450/lc823450_gpio.c
+++ b/arch/arm/src/lc823450/lc823450_gpio.c
@@ -372,7 +372,7 @@ void lc823450_gpio_write(uint16_t gpiocfg, bool value)
 #ifdef CONFIG_LC823450_VGPIO
   if (port == (GPIO_PORTV >> GPIO_PORT_SHIFT))
     {
-      assert(pin < GPIO_VIRTUAL_NUM);
+      ASSERT(pin < GPIO_VIRTUAL_NUM);
       if (vgpio_ops[pin] && vgpio_ops[pin]->write)
         {
           vgpio_ops[pin]->write(pin, value);
@@ -437,7 +437,7 @@ bool lc823450_gpio_read(uint16_t gpiocfg)
 #ifdef CONFIG_LC823450_VGPIO
   if (port == (GPIO_PORTV >> GPIO_PORT_SHIFT))
     {
-      assert(pin < GPIO_VIRTUAL_NUM);
+      ASSERT(pin < GPIO_VIRTUAL_NUM);
       if (vgpio_ops[pin] && vgpio_ops[pin]->read)
         {
           return vgpio_ops[pin]->read(pin);
@@ -506,7 +506,7 @@ int lc823450_gpio_initialize(void)
 #ifdef CONFIG_LC823450_VGPIO
 int lc823450_vgpio_register(unsigned int pin, struct vgpio_ops_s *ops)
 {
-  assert(pin < GPIO_VIRTUAL_NUM);
+  ASSERT(pin < GPIO_VIRTUAL_NUM);
   vgpio_ops[pin] = ops;
   return OK;
 }

--- a/arch/arm/src/phy62xx/phyplus_timer_lowerhalf.c
+++ b/arch/arm/src/phy62xx/phyplus_timer_lowerhalf.c
@@ -397,7 +397,7 @@ static void phyplus_setcallback(struct timer_lowerhalf_s *lower,
     }
 
   leave_critical_section(flags);
-  assert(ret == OK);
+  ASSERT(ret == OK);
 
   /* #if 0
    *  irqstate_t flags = enter_critical_section();

--- a/arch/arm/src/rp2040/rp2040_clock.c
+++ b/arch/arm/src/rp2040/rp2040_clock.c
@@ -111,7 +111,7 @@ bool rp2040_clock_configure(int clk_index,
 {
   uint32_t div;
 
-  assert(src_freq >= freq);
+  ASSERT(src_freq >= freq);
 
   if (freq > src_freq)
     {

--- a/arch/arm/src/rp2040/rp2040_pio.c
+++ b/arch/arm/src/rp2040/rp2040_pio.c
@@ -127,7 +127,7 @@ static int hw_claim_unused_from_range(uint8_t *bits, bool required,
 static void hw_claim_clear(uint8_t *bits, uint32_t bit_index)
 {
   uint32_t save = hw_claim_lock();
-  assert(bits[bit_index >> 3u] & (1u << (bit_index & 7u)));
+  ASSERT(bits[bit_index >> 3u] & (1u << (bit_index & 7u)));
   bits[bit_index >> 3u] &= (uint8_t) ~(1u << (bit_index & 7u));
   hw_claim_unlock(save);
 }
@@ -135,7 +135,7 @@ static void hw_claim_clear(uint8_t *bits, uint32_t bit_index)
 static int _pio_find_offset_for_program(uint32_t pio,
                                         const rp2040_pio_program_t *program)
 {
-  assert(program->length < PIO_INSTRUCTION_COUNT);
+  ASSERT(program->length < PIO_INSTRUCTION_COUNT);
   uint32_t used_mask = _used_instruction_space[rp2040_pio_get_index(pio)];
   uint32_t program_mask = (1u << program->length) - 1;
 
@@ -306,7 +306,7 @@ void rp2040_pio_remove_program(uint32_t pio,
   uint32_t program_mask = (1u << program->length) - 1;
   program_mask <<= loaded_offset;
   uint32_t save = hw_claim_lock();
-  assert(program_mask ==
+  ASSERT(program_mask ==
          (_used_instruction_space[rp2040_pio_get_index(pio)] &
             program_mask));
   _used_instruction_space[rp2040_pio_get_index(pio)] &= ~program_mask;

--- a/arch/arm/src/rp2040/rp2040_pio_instructions.h
+++ b/arch/arm/src/rp2040/rp2040_pio_instructions.h
@@ -143,11 +143,11 @@ inline static uint32_t _pio_encode_instr_and_args(
   uint32_t major = _pio_major_instr_bits(instr_bits);
   if (major == pio_instr_bits_in || major == pio_instr_bits_out)
     {
-      assert(arg2 && arg2 <= 32);
+      ASSERT(arg2 && arg2 <= 32);
     }
   else
     {
-      assert(arg2 <= 31);
+      ASSERT(arg2 <= 31);
     }
 #endif
   return instr_bits | (arg1 << 5u) | (arg2 & 0x1fu);

--- a/arch/arm/src/rp2040/rp2040_pll.c
+++ b/arch/arm/src/rp2040/rp2040_pll.c
@@ -91,11 +91,11 @@ void rp2040_pll_init(uint32_t base, uint32_t refdiv, uint32_t vco_freq,
 
   /* Check parameter ranges */
 
-  assert(fbdiv >= 16 && fbdiv <= 320);
-  assert((post_div1 >= 1 && post_div1 <= 7) &&
+  ASSERT(fbdiv >= 16 && fbdiv <= 320);
+  ASSERT((post_div1 >= 1 && post_div1 <= 7) &&
          (post_div2 >= 1 && post_div2 <= 7));
-  assert(post_div2 <= post_div1);
-  assert(ref_mhz <= (vco_freq / 16));
+  ASSERT(post_div2 <= post_div1);
+  ASSERT(ref_mhz <= (vco_freq / 16));
 
   /* Put calculated value into feedback divider */
 

--- a/arch/arm/src/rp2040/rp2040_xosc.c
+++ b/arch/arm/src/rp2040/rp2040_xosc.c
@@ -75,7 +75,7 @@ void rp2040_xosc_init(void)
 {
   /* Assumes 1-15 MHz input */
 
-  assert(BOARD_XOSC_FREQ <= (15 * MHZ));
+  ASSERT(BOARD_XOSC_FREQ <= (15 * MHZ));
   putreg32(RP2040_XOSC_CTRL_FREQ_RANGE_1_15MHZ, RP2040_XOSC_CTRL);
 
   /* Set xosc startup delay */

--- a/arch/arm/src/tiva/common/tiva_pwm.c
+++ b/arch/arm/src/tiva/common/tiva_pwm.c
@@ -757,7 +757,7 @@ static int tiva_pwm_ioctl(struct pwm_lowerhalf_s *dev, int cmd,
 
 struct pwm_lowerhalf_s *tiva_pwm_initialize(int channel)
 {
-  assert(channel >= 0 && channel <= 7);
+  ASSERT(channel >= 0 && channel <= 7);
   struct tiva_pwm_chan_s *chan;
 
   switch (channel)
@@ -824,7 +824,7 @@ struct pwm_lowerhalf_s *tiva_pwm_initialize(int channel)
 
   /* Enable PWM controller (refer to TM4C1294NCPDT 23.4.1) */
 
-  assert(chan->controller_id == 0);
+  ASSERT(chan->controller_id == 0);
   tiva_pwm_enablepwr(chan->controller_id);
   tiva_pwm_enableclk(chan->controller_id);
 

--- a/arch/arm64/src/common/arm64_gicv3.c
+++ b/arch/arm64/src/common/arm64_gicv3.c
@@ -361,7 +361,7 @@ static int arm64_gic_send_sgi(unsigned int sgi_id, uint64_t target_aff,
   unsigned long base;
 
   base = gic_get_rdist() + GICR_SGI_BASE_OFF;
-  assert(GIC_IS_SGI(sgi_id));
+  ASSERT(GIC_IS_SGI(sgi_id));
 
   /* Extract affinity fields from target */
 
@@ -505,7 +505,7 @@ static void gicv3_cpuif_init(void)
       write_sysreg(icc_sre, ICC_SRE_EL1);
       icc_sre = read_sysreg(ICC_SRE_EL1);
 
-      assert(icc_sre & ICC_SRE_ELX_SRE_BIT);
+      ASSERT(icc_sre & ICC_SRE_ELX_SRE_BIT);
     }
 
   write_sysreg(GIC_IDLE_PRIO, ICC_PMR_EL1);

--- a/arch/risc-v/src/bl602/bl602_os_hal.c
+++ b/arch/risc-v/src/bl602/bl602_os_hal.c
@@ -933,7 +933,7 @@ void *bl_os_timer_create(void *func, void *argv)
   struct timer_adpt *timer = kmm_malloc(sizeof(struct timer_adpt));
   if (!timer)
     {
-      assert(0);
+      ASSERT(0);
     }
 
   memset((void *)timer, 0, sizeof(struct timer_adpt));
@@ -1066,7 +1066,7 @@ void *bl_os_workqueue_create(void)
   struct work_s *work = kmm_calloc(1, sizeof(struct work_s));
   if (!work)
     {
-      assert(0);
+      ASSERT(0);
     }
 
   return (void *)work;

--- a/arch/risc-v/src/esp32c3-legacy/esp32c3_rt_timer.c
+++ b/arch/risc-v/src/esp32c3-legacy/esp32c3_rt_timer.c
@@ -340,7 +340,7 @@ static int rt_timer_thread(int argc, char *argv[])
       if (ret)
         {
           tmrerr("ERROR: Wait toutsem error=%d\n", ret);
-          assert(0);
+          ASSERT(0);
         }
 
       flags = enter_critical_section();

--- a/arch/xtensa/src/esp32/esp32_psram.c
+++ b/arch/xtensa/src/esp32/esp32_psram.c
@@ -1612,7 +1612,7 @@ psram_enable(int mode, int vaddrmode)   /* psram init */
         }
     }
 
-  assert(mode < PSRAM_CACHE_MAX && "we don't support any other mode.");
+  ASSERT(mode < PSRAM_CACHE_MAX && "we don't support any other mode.");
   s_psram_mode = mode;
 
   putreg32(0x1, SPI_EXT3_REG(0));

--- a/arch/xtensa/src/esp32/esp32_rt_timer.c
+++ b/arch/xtensa/src/esp32/esp32_rt_timer.c
@@ -317,7 +317,7 @@ static int rt_timer_thread(int argc, char *argv[])
       if (ret)
         {
           tmrerr("ERROR: Wait priv->toutsem error=%d\n", ret);
-          assert(0);
+          ASSERT(0);
         }
 
       flags = spin_lock_irqsave(&priv->lock);

--- a/arch/xtensa/src/esp32/esp32_tim_lowerhalf.c
+++ b/arch/xtensa/src/esp32/esp32_tim_lowerhalf.c
@@ -490,7 +490,7 @@ static void esp32_timer_setcallback(struct timer_lowerhalf_s *lower,
     }
 
   spin_unlock_irqrestore(&priv->lock, flags);
-  assert(ret == OK);
+  ASSERT(ret == OK);
 }
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32s2/esp32s2_rt_timer.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_rt_timer.c
@@ -351,7 +351,7 @@ static int rt_timer_thread(int argc, char *argv[])
       if (ret)
         {
           tmrerr("ERROR: Wait priv->toutsem error=%d\n", ret);
-          assert(0);
+          ASSERT(0);
         }
 
       flags = enter_critical_section();

--- a/arch/xtensa/src/esp32s2/esp32s2_spiram.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_spiram.c
@@ -144,7 +144,7 @@ int mmu_map_psram(uint32_t start_paddr, uint32_t end_paddr,
 
   /* should be MMU page aligned */
 
-  assert((start_paddr % MMU_PAGE_SIZE) == 0);
+  ASSERT((start_paddr % MMU_PAGE_SIZE) == 0);
 
   uint32_t start_vaddr = DPORT_CACHE_ADDRESS_LOW;
   uint32_t end_vaddr = start_vaddr + map_length;
@@ -156,7 +156,7 @@ int mmu_map_psram(uint32_t start_paddr, uint32_t end_paddr,
   cache_bus_mask |= (end_vaddr >= DRAM1_ADDRESS_HIGH) ?
                     EXTMEM_PRO_DCACHE_MASK_DRAM0 : 0;
 
-  assert(end_vaddr <= DRAM0_CACHE_ADDRESS_HIGH);
+  ASSERT(end_vaddr <= DRAM0_CACHE_ADDRESS_HIGH);
 
   minfo("start_paddr is %x, map_length is %xB, %d pages",
         start_paddr, map_length, BYTES_TO_MMU_PAGE(map_length));

--- a/arch/xtensa/src/esp32s3/esp32s3_psram_quad.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_psram_quad.c
@@ -397,7 +397,7 @@ static void psram_gpio_config(void)
 
 int psram_enable(int mode, int vaddrmode)
 {
-  assert(mode < PSRAM_CACHE_MAX && \
+  ASSERT(mode < PSRAM_CACHE_MAX && \
          "we don't support any other mode for now.");
 
   psram_gpio_config();

--- a/crypto/bn.c
+++ b/crypto/bn.c
@@ -58,7 +58,7 @@
 
 /* Custom assert macro - easy to disable */
 
-#define require(p, msg) assert(p && msg)
+#define require(p, msg) ASSERT(p && msg)
 
 /****************************************************************************
  * Private Functions Prototype

--- a/drivers/usbdev/usbdev_fs.c
+++ b/drivers/usbdev/usbdev_fs.c
@@ -476,7 +476,7 @@ static int usbdev_fs_open(FAR struct file *filep)
 
   fs_ep->crefs += 1;
 
-  assert(fs_ep->crefs != 0);
+  ASSERT(fs_ep->crefs != 0);
 
   nxmutex_unlock(&fs_ep->lock);
   return ret;
@@ -510,7 +510,7 @@ static int usbdev_fs_close(FAR struct file *filep)
 
   fs_ep->crefs -= 1;
 
-  assert(fs_ep->crefs >= 0);
+  ASSERT(fs_ep->crefs >= 0);
 
   if (fs_ep->unlinked && fs_ep->crefs == 0)
     {

--- a/include/assert.h
+++ b/include/assert.h
@@ -113,17 +113,25 @@
 /* The C standard states that if NDEBUG is defined, assert will do nothing.
  * Users can define and undefine NDEBUG as they see fit to choose when assert
  * does something or does not do anything.
+ *
+ * #define assert(ignore) ((void)0)
+ *
+ * Reference link:
+ * https://pubs.opengroup.org/onlinepubs/009695399/basedefs/assert.h.html
+ *
+ * ASSERT/VERIFY is a non-standard interface, implemented using internal
+ *
  */
 
 #ifdef NDEBUG
-#  define assert(f) ((void)(1 || (f)))
-#  define VERIFY(f) assert(f)
+#  define assert(f) ((void)0)
+#  define ASSERT(f) ((void)(1 || (f)))
+#  define VERIFY(f) ((void)(1 || (f)))
 #else
 #  define assert(f) _ASSERT(f, __ASSERT_FILE__, __ASSERT_LINE__)
+#  define ASSERT(f) _ASSERT(f, __ASSERT_FILE__, __ASSERT_LINE__)
 #  define VERIFY(f) _VERIFY(f, __ASSERT_FILE__, __ASSERT_LINE__)
 #endif
-
-#define ASSERT(f) assert(f)
 
 /* Suppress 3rd party library redefine _assert/__assert */
 

--- a/libs/libc/regex/regcomp.c
+++ b/libs/libc/regex/regcomp.c
@@ -418,7 +418,7 @@ static reg_errcode_t tre_stack_push(tre_stack_t *s,
               return REG_ESPACE;
             }
 
-          assert(new_size > s->size);
+          ASSERT(new_size > s->size);
           s->size   = new_size;
           s->stack  = new_buffer;
           tre_stack_push(s, value);
@@ -1802,7 +1802,7 @@ static reg_errcode_t tre_add_tags(tre_mem_t mem, tre_stack_t *stack,
                           break;
                         }
 
-                      assert(tnfa->submatch_data[id].parents == NULL);
+                      ASSERT(tnfa->submatch_data[id].parents == NULL);
                       tnfa->submatch_data[id].parents = p;
                       for (i = 0; parents[i] >= 0; i++)
                         {
@@ -1870,7 +1870,7 @@ static reg_errcode_t tre_add_tags(tre_mem_t mem, tre_stack_t *stack,
                 }
               else
                 {
-                  assert(!IS_TAG(lit));
+                  ASSERT(!IS_TAG(lit));
                 }
               break;
             }
@@ -2219,7 +2219,7 @@ static reg_errcode_t tre_add_tags(tre_mem_t mem, tre_stack_t *stack,
 
         default:
         {
-          assert(0);
+          ASSERT(0);
         }
         break;
 
@@ -2250,7 +2250,7 @@ static reg_errcode_t tre_add_tags(tre_mem_t mem, tre_stack_t *stack,
       num_minimals++;
     }
 
-  assert(tree->num_tags == num_tags);
+  ASSERT(tree->num_tags == num_tags);
   tnfa->end_tag         = num_tags;
   tnfa->num_tags        = num_tags;
   tnfa->num_minimals    = num_minimals;
@@ -2424,7 +2424,7 @@ static reg_errcode_t tre_copy_ast(tre_mem_t mem, tre_stack_t *stack,
 
             default:
             {
-              assert(0);
+              ASSERT(0);
               break;
             }
             }
@@ -2537,7 +2537,7 @@ static reg_errcode_t tre_expand_ast(tre_mem_t mem, tre_stack_t *stack,
 
             default:
             {
-              assert(0);
+              ASSERT(0);
               break;
             }
             }
@@ -2684,7 +2684,7 @@ static reg_errcode_t tre_expand_ast(tre_mem_t mem, tre_stack_t *stack,
 
         default:
         {
-          assert(0);
+          ASSERT(0);
           break;
         }
         }
@@ -2935,7 +2935,7 @@ static reg_errcode_t tre_match_empty(tre_stack_t *stack,
 
             case ASSERTION:
             {
-              assert(lit->code_max >= 1 || lit->code_max <= ASSERT_LAST);
+              ASSERT(lit->code_max >= 1 || lit->code_max <= ASSERT_LAST);
               if (assertions != NULL)
                 {
                   *assertions |= lit->code_max;
@@ -2950,7 +2950,7 @@ static reg_errcode_t tre_match_empty(tre_stack_t *stack,
 
             default:
             {
-              assert(0);
+              ASSERT(0);
             }
             break;
             }
@@ -2970,7 +2970,7 @@ static reg_errcode_t tre_match_empty(tre_stack_t *stack,
           else if (uni->right->nullable)
               STACK_PUSHX(stack, voidptr, uni->right)
           else
-              assert(0);
+              ASSERT(0);
         }
         break;
 
@@ -2979,8 +2979,8 @@ static reg_errcode_t tre_match_empty(tre_stack_t *stack,
           /* The path must go through both children. */
 
           cat = (tre_catenation_t *)node->obj;
-          assert(cat->left->nullable);
-          assert(cat->right->nullable);
+          ASSERT(cat->left->nullable);
+          ASSERT(cat->right->nullable);
           STACK_PUSHX(stack, voidptr, cat->left);
           STACK_PUSHX(stack, voidptr, cat->right);
         }
@@ -3002,7 +3002,7 @@ static reg_errcode_t tre_match_empty(tre_stack_t *stack,
 
         default:
         {
-          assert(0);
+          ASSERT(0);
         }
         break;
         }
@@ -3323,7 +3323,7 @@ static reg_errcode_t tre_compute_nfl(tre_mem_t mem, tre_stack_t *stack,
 
         default:
         {
-          assert(0);
+          ASSERT(0);
         }
         break;
         }
@@ -3419,8 +3419,8 @@ static reg_errcode_t tre_make_trans(tre_pos_and_tags_t *p1,
                                    NULL ? ASSERT_CHAR_CLASS_NEG : 0);
               if (p1->backref >= 0)
                 {
-                  assert((trans->assertions & ASSERT_CHAR_CLASS) == 0);
-                  assert(p2->backref < 0);
+                  ASSERT((trans->assertions & ASSERT_CHAR_CLASS) == 0);
+                  ASSERT(p2->backref < 0);
                   trans->u.backref  = p1->backref;
                   trans->assertions |= ASSERT_BACKREF;
                 }
@@ -3627,11 +3627,11 @@ static reg_errcode_t tre_ast_to_tnfa(tre_ast_node_t *node,
     case ITERATION:
     {
       iter = (tre_iteration_t *)node->obj;
-      assert(iter->max == -1 || iter->max == 1);
+      ASSERT(iter->max == -1 || iter->max == 1);
 
       if (iter->max == -1)
         {
-          assert(iter->min == 0 || iter->min == 1);
+          ASSERT(iter->min == 0 || iter->min == 1);
 
           /* Add a transition from each last position in the iterated
            * expression to each first position.

--- a/libs/libc/regex/regexec.c
+++ b/libs/libc/regex/regexec.c
@@ -133,7 +133,7 @@ static int tre_tag_order(int num_tags, tre_tag_direction_t *tag_directions,
         }
     }
 
-  /*  assert(0); */
+  /*  ASSERT(0); */
 
   return 0;
 }
@@ -508,7 +508,7 @@ static reg_errcode_t tre_tnfa_run_parallel(const tre_tnfa_t *tnfa,
 
                   else
                     {
-                      assert(reach_pos[trans_i->state_id].pos == pos);
+                      ASSERT(reach_pos[trans_i->state_id].pos == pos);
 
                       /* Another path has also reached this state.  We choose
                        *  the winner by examining the tag values for both
@@ -681,7 +681,7 @@ typedef struct tre_backtrack_struct *tre_backtrack_t;
   do                                       \
     {                                      \
       int i;                               \
-      assert(stack->prev);                 \
+      ASSERT(stack->prev);                 \
       pos       = stack->item.pos;         \
       str_byte  = stack->item.str_byte;    \
       state     = stack->item.state;       \
@@ -1181,10 +1181,10 @@ static void tre_fill_pmatch(size_t nmatch, regmatch_t pmatch[], int cflags,
         {
           if (pmatch[i].rm_eo == -1)
             {
-              assert(pmatch[i].rm_so == -1);
+              ASSERT(pmatch[i].rm_so == -1);
             }
 
-          assert(pmatch[i].rm_so <= pmatch[i].rm_eo);
+          ASSERT(pmatch[i].rm_so <= pmatch[i].rm_eo);
 
           parents = submatch_data[i].parents;
           if (parents != NULL)

--- a/mm/mm_heap/mm_checkcorruption.c
+++ b/mm/mm_heap/mm_checkcorruption.c
@@ -44,18 +44,18 @@ static void checkcorruption_handler(FAR struct mm_allocnode_s *node,
 
   if (MM_NODE_IS_ALLOC(node))
     {
-      assert(nodesize >= MM_SIZEOF_ALLOCNODE);
+      ASSERT(nodesize >= MM_SIZEOF_ALLOCNODE);
     }
   else
     {
       FAR struct mm_freenode_s *fnode = (FAR void *)node;
 
-      assert(nodesize >= MM_MIN_CHUNK);
-      assert(fnode->blink->flink == fnode);
-      assert(MM_SIZEOF_NODE(fnode->blink) <= nodesize);
-      assert(fnode->flink == NULL ||
+      ASSERT(nodesize >= MM_MIN_CHUNK);
+      ASSERT(fnode->blink->flink == fnode);
+      ASSERT(MM_SIZEOF_NODE(fnode->blink) <= nodesize);
+      ASSERT(fnode->flink == NULL ||
              fnode->flink->blink == fnode);
-      assert(fnode->flink == NULL ||
+      ASSERT(fnode->flink == NULL ||
              MM_SIZEOF_NODE(fnode->flink) == 0 ||
              MM_SIZEOF_NODE(fnode->flink) >= nodesize);
     }

--- a/net/ipfrag/ipfrag.c
+++ b/net/ipfrag/ipfrag.c
@@ -171,7 +171,7 @@ ip_fragout_allocfragbuf(FAR struct iob_queue_s *fragq);
 
 static void ip_fragin_timerout_expiry(wdparm_t arg)
 {
-  assert(g_wkfragtimeout.worker == NULL);
+  ASSERT(g_wkfragtimeout.worker == NULL);
   work_queue(IPFRAGWORK, &g_wkfragtimeout, ip_fragin_timerwork, NULL, 0);
 }
 
@@ -525,7 +525,7 @@ ip_fragout_allocfragbuf(FAR struct iob_queue_s *fragq)
 uint32_t ip_frag_remnode(FAR struct ip_fragsnode_s *node)
 {
   g_bufoccupy -= node->bufcnt;
-  assert(g_bufoccupy < CONFIG_IOB_NBUFFERS);
+  ASSERT(g_bufoccupy < CONFIG_IOB_NBUFFERS);
 
   sq_rem((FAR sq_entry_t *)node, &g_assemblyhead_ipid);
   sq_rem((FAR sq_entry_t *)&node->flinkat, &g_assemblyhead_time);
@@ -799,7 +799,7 @@ int32_t ip_fragout_slice(FAR struct iob_s *iob, uint8_t domain, uint16_t mtu,
       return 0;
     }
 
-  assert(iob->io_pktlen > mtu);
+  ASSERT(iob->io_pktlen > mtu);
 
 #ifdef CONFIG_NET_IPv4
   if (domain == PF_INET)

--- a/net/ipfrag/ipv4_frag.c
+++ b/net/ipfrag/ipv4_frag.c
@@ -378,7 +378,7 @@ int32_t ipv4_fragout(FAR struct net_driver_s *dev, uint16_t mtu)
    */
 
   nfrags = ip_fragout_slice(dev->d_iob, PF_INET, mtu, hdrlen, &fragq);
-  assert(nfrags > 1);
+  ASSERT(nfrags > 1);
   netdev_iob_clear(dev);
 
   /* Fill the L3 header into the reserved space */

--- a/net/ipfrag/ipv6_frag.c
+++ b/net/ipfrag/ipv6_frag.c
@@ -588,7 +588,7 @@ int32_t ipv6_fragout(FAR struct net_driver_s *dev, uint16_t mtu)
    */
 
   nfrags = ip_fragout_slice(dev->d_iob, PF_INET6, mtu, unfraglen, &fragq);
-  assert(nfrags > 1);
+  ASSERT(nfrags > 1);
   netdev_iob_clear(dev);
 
   ipid = ++g_ipv6id;


### PR DESCRIPTION
## Summary
As defined by the C standard, if NDEBUG is defined, assert should do nothing but be simply defined as:

  #define assert(ignore) ((void)0)

Reference link:
https://pubs.opengroup.org/onlinepubs/009695399/basedefs/assert.h.html

## Impact

## Testing

