### PR TITLE
icjx: use iC-JX interrupt config instead of the general one

### DIFF
--- a/drivers/ioexpander/Kconfig
+++ b/drivers/ioexpander/Kconfig
@@ -66,11 +66,18 @@ config IOEXPANDER_ICJX
 
 if IOEXPANDER_ICJX
 
-config iC-JX_MULTIPLE
+config ICJX_MULTIPLE
 	bool "Multiple iC-JX Devices"
 	default n
 	---help---
 		Can be defined to support multiple iC-JX devices on board.
+
+config ICJX_INT_ENABLE
+	bool "Enable iC-JX Interrupt Support"
+	default n
+	select IOEXPANDER_INT_ENABLE
+	---help---
+		Enable driver interrupt functionality
 
 endif # IOEXPANDER_ICJX
 

--- a/drivers/ioexpander/icjx.c
+++ b/drivers/ioexpander/icjx.c
@@ -939,10 +939,10 @@ static int icjx_detach(FAR struct ioexpander_dev_s *dev, FAR void *handle)
  *
  ****************************************************************************/
 
+#ifdef CONFIG_ICJX_INT_ENABLE
 static void icjx_interrupt_worker(void *arg)
 {
   FAR struct icjx_dev_s *priv = (FAR struct icjx_dev_s *)arg;
-  uint8_t regaddr;
   uint16_t change_of_input;
   uint16_t isr;
   ioe_pinset_t irq_match;
@@ -1001,7 +1001,8 @@ static int icjx_interrupt(int irq, FAR void *context, FAR void *arg)
   return OK;
 }
 
-#endif
+#endif /* CONFIG_ICJX_INT_ENABLE */
+#endif /* CONFIG_IOEXPANDER_INT_ENABLE */
 
 /****************************************************************************
  * Public Functions


### PR DESCRIPTION
## Summary
There might be multiple expanders, one with interrupt used and other without. This commit fixes initial incorrect interrupt design by introducing ICJX_INT_ENABLE config option.

Also fixes naming of ICJX_MULTIPLE option.

## Impact
This fixes unused functions compile warnings in case of some configuration choices.

