### PR TITLE
sched/pthread: pthread_join null pointer

### DIFF
--- a/sched/pthread/pthread_join.c
+++ b/sched/pthread/pthread_join.c
@@ -158,6 +158,14 @@ errout:
 
   leave_cancellation_point();
 
-  sinfo("Returning %d, exit_value %p\n", ret, *pexit_value);
+  if (pexit_value)
+    {
+      sinfo("Returning %d, exit_value %p\n", ret, *pexit_value);
+    }
+  else
+    {
+      sinfo("Returning %d\n", ret);
+    }
+
   return ret;
 }


### PR DESCRIPTION
## Summary

Adds null pointer check to error out route in pthread_join() as it
crashs ostest sometimes.

## Impact

None

## Testing

- rv-virt with QEMU 6.2 on Ubuntu 22.04
- CI checks
