### PR TITLE
sched/posixspawn: disable tedious logging

### DIFF
--- a/sched/task/task_posixspawn.c
+++ b/sched/task/task_posixspawn.c
@@ -218,9 +218,6 @@ int posix_spawn(FAR pid_t *pid, FAR const char *path,
                 FAR const posix_spawnattr_t *attr,
                 FAR char * const argv[], FAR char * const envp[])
 {
-  sinfo("pid=%p path=%s file_actions=%p attr=%p argv=%p\n",
-        pid, path, file_actions, attr, argv);
-
   return nxposix_spawn_exec(pid, path,
                             file_actions != NULL ?
                             *file_actions : NULL, attr, argv, envp);


### PR DESCRIPTION
## Summary

The posix_spawn: log appears even for NSH internal commands in kernel
build and duplicates a lot with the `task_spawn:` log, so drop it to
make DEBUG_SCHED_INFO more clear.

## Impact

None

## Testing

- rv-virt with QEMU 6.2 on Ubuntu 22.04
- CI checks
