### PR TITLE
sched/misc: dump stack as platform bit width

### DIFF
--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -71,6 +71,13 @@
 #endif
 
 #define DUMP_PTR(p, x) ((uintptr_t)(&(p)[(x)]) < stack_top ? (p)[(x)] : 0)
+#define DUMP_STRIDE    (sizeof(FAR void *) * 8)
+
+#if UINTPTR_MAX <= UINT32_MAX
+#  define DUMP_FORMAT " %08" PRIxPTR ""
+#elif UINTPTR_MAX <= UINT64_MAX
+#  define DUMP_FORMAT " %016" PRIxPTR ""
+#endif
 
 /****************************************************************************
  * Private Data
@@ -128,13 +135,12 @@ static void stack_dump(uintptr_t sp, uintptr_t stack_top)
 {
   uintptr_t stack;
 
-  for (stack = sp; stack <= stack_top; stack += 32)
+  for (stack = sp; stack <= stack_top; stack += DUMP_STRIDE)
     {
-      FAR uint32_t *ptr = (FAR uint32_t *)stack;
+      FAR uintptr_t *ptr = (FAR uintptr_t *)stack;
 
-      _alert("%p: %08" PRIx32 " %08" PRIx32 " %08" PRIx32
-             " %08" PRIx32 " %08" PRIx32 " %08" PRIx32 " %08" PRIx32
-             " %08" PRIx32 "\n",
+      _alert("%p:"DUMP_FORMAT DUMP_FORMAT DUMP_FORMAT DUMP_FORMAT
+             DUMP_FORMAT DUMP_FORMAT DUMP_FORMAT DUMP_FORMAT "\n",
              (FAR void *)stack, DUMP_PTR(ptr, 0), DUMP_PTR(ptr , 1),
              DUMP_PTR(ptr, 2), DUMP_PTR(ptr, 3), DUMP_PTR(ptr, 4),
              DUMP_PTR(ptr, 5), DUMP_PTR(ptr , 6), DUMP_PTR(ptr, 7));
@@ -160,9 +166,9 @@ static void dump_stack(FAR const char *tag, uintptr_t sp,
 
       /* Get more information */
 
-      if (sp - 32 >= base)
+      if (sp - DUMP_STRIDE >= base)
         {
-          sp -= 32;
+          sp -= DUMP_STRIDE;
         }
 
       stack_dump(sp, top);


### PR DESCRIPTION


## Summary

sched/misc: dump stack as platform bit width

before:
```
stack_dump: 0x8002ff80: 8003057b 00000000 00000000 00000000 00000002 00000000 80030068 00000000
stack_dump: 0x8002ffa0: 00000002 00000000 00000000 00000000 80030280 00000000 8000898e 00000000
stack_dump: 0x8002ffc0: 00000000 00000000 00000000 00000000 0000000b 00000000 0000000a 00000000
stack_dump: 0x8002ffe0: 8002a470 00000000 00000000 00000000 00000000 00000000 00000000 00000000
```

after:
```
stack_dump: 0x8002ff80: 000000008003057b 0000000000000000 0000000000000002 0000000080030068 0000000000000002 0000000000000000 0000000080030280 000000008000898e
stack_dump: 0x8002ffc0: 0000000000000000 0000000000000000 000000000000000b 000000000000000a 000000008002a470 0000000000000000 0000000000000000 0000000000000000
```


## Impact

N/A

## Testing

rv-virt/nsh64