### PR TITLE
drivers/mmcsd/mmcsd_sdio.c: Fix SD card 4-bit support

### DIFF
--- a/drivers/mmcsd/mmcsd_sdio.c
+++ b/drivers/mmcsd/mmcsd_sdio.c
@@ -3395,7 +3395,7 @@ static int mmcsd_sdinitialize(FAR struct mmcsd_state_s *priv)
 
   mmcsd_decode_scr(priv, scr);
 
-  if ((priv->caps & SDIO_CAPS_4BIT_ONLY) != 0)
+  if ((priv->caps & SDIO_CAPS_4BIT) != 0)
     {
       /* Select width (4-bit) bus operation (if the card supports it) */
 


### PR DESCRIPTION
Fix a bug which causes that 1-bit mode is always selected. This happens even if the driver sets SDIO_CAPS_4BIT capability in case of the card and the host support 1- and 4-bit wide bus.

## Summary

## Impact

## Testing

