### PR TITLE
sched/tcb: use shared group for kthreads

### DIFF
--- a/include/nuttx/tls.h
+++ b/include/nuttx/tls.h
@@ -122,8 +122,6 @@ struct pthread_atfork_s
 struct task_info_s
 {
   mutex_t         ta_lock;
-  int             ta_argc;                         /* Number of arguments     */
-  FAR char      **ta_argv;                         /* Name+start-up parameters     */
 #if CONFIG_TLS_TASK_NELEM > 0
   uintptr_t       ta_telem[CONFIG_TLS_TASK_NELEM]; /* Task local storage elements */
 #endif

--- a/include/nuttx/tls.h
+++ b/include/nuttx/tls.h
@@ -219,6 +219,7 @@ struct tls_info_s
   int16_t tl_cpcount;                  /* Nested cancellation point count */
 #endif
 
+  uint16_t tl_size;                    /* Actual size with alignments */
   int tl_errno;                        /* Per-thread error number */
 };
 

--- a/sched/environ/env_dup.c
+++ b/sched/environ/env_dup.c
@@ -72,7 +72,7 @@ int env_dup(FAR struct task_group_s *group, FAR char * const *envcp)
 
   /* Is there an environment ? */
 
-  if (envcp != NULL)
+  if (envcp != NULL && group->tg_envp == NULL)
     {
       /* Pre-emption must be disabled throughout the following because the
        * environment may be shared.

--- a/sched/group/group_argvstr.c
+++ b/sched/group/group_argvstr.c
@@ -63,12 +63,11 @@ size_t group_argvstr(FAR struct tcb_s *tcb, FAR char *args, size_t size)
   FAR struct addrenv_s *oldenv;
 #endif
 
-  /* Perform sanity checks */
+  /* Sanity checks and idle tasks */
 
-  if (!tcb || !tcb->group || !tcb->group->tg_info)
+  if (!tcb || !tcb->group || !tcb->group->tg_info || size < 1 ||
+      is_idle_task(tcb))
     {
-      /* Something is very wrong -> get out */
-
       *args = '\0';
       return 0;
     }
@@ -90,7 +89,7 @@ size_t group_argvstr(FAR struct tcb_s *tcb, FAR char *args, size_t size)
   else
 #endif
     {
-      FAR char **argv = tcb->group->tg_info->ta_argv + 1;
+      FAR char **argv = nxsched_get_stackargs(tcb) + 1;
 
       while (*argv != NULL && n < size)
         {

--- a/sched/group/group_setuptaskfiles.c
+++ b/sched/group/group_setuptaskfiles.c
@@ -79,8 +79,12 @@ int group_setuptaskfiles(FAR struct task_tcb_s *tcb,
 
   /* Duplicate the parent task's file descriptors */
 
-  ret = files_duplist(&rtcb->group->tg_filelist,
-                      &group->tg_filelist, actions, cloexec);
+  if (group != rtcb->group)
+    {
+      files_duplist(&rtcb->group->tg_filelist,
+                    &group->tg_filelist, actions, cloexec);
+    }
+
   if (ret >= 0 && actions != NULL)
     {
       ret = spawn_file_actions(&tcb->cmn, actions);

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -209,20 +209,9 @@ static struct tcb_s g_idletcb[CONFIG_SMP_NCPUS];
 
 /* This is the name of the idle task */
 
-#if CONFIG_TASK_NAME_SIZE <= 0 || !defined(CONFIG_SMP)
-#  ifdef CONFIG_SMP
-static const char g_idlename[] = "CPU_Idle";
-#  else
+#if CONFIG_TASK_NAME_SIZE > 0 && !defined(CONFIG_SMP)
 static const char g_idlename[] = "Idle_Task";
-#  endif
 #endif
-
-/* This is IDLE threads argument list.  NOTE: Normally the argument
- * list is created on the stack prior to starting the task.  We have to
- * do things little differently here for the IDLE tasks.
- */
-
-static FAR char *g_idleargv[CONFIG_SMP_NCPUS][2];
 
 /****************************************************************************
  * Private Functions
@@ -419,17 +408,6 @@ static void idle_task_initialize(void)
       strlcpy(tcb->name, g_idlename, CONFIG_TASK_NAME_SIZE);
 #  endif
 
-      /* Configure the task name in the argument list.  The IDLE task does
-       * not really have an argument list, but this name is still useful
-       * for things like the NSH PS command.
-       *
-       * In the kernel mode build, the arguments are saved on the task's
-       * stack and there is no support that yet.
-       */
-
-      g_idleargv[i][0] = tcb->name;
-#else
-      g_idleargv[i][0] = (FAR char *)g_idlename;
 #endif /* CONFIG_TASK_NAME_SIZE */
 
       /* Then add the idle task's TCB to the head of the current ready to
@@ -476,7 +454,6 @@ static void idle_group_initialize(void)
 
       DEBUGVERIFY(
         group_initialize((FAR struct task_tcb_s *)tcb, tcb->flags));
-      tcb->group->tg_info->ta_argv = &g_idleargv[i][0];
 
       /* Initialize the task join */
 

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -205,7 +205,7 @@ uint8_t g_nx_initstate;  /* See enum nx_initstate_e */
  * bringing up the rest of the system.
  */
 
-static struct task_tcb_s g_idletcb[CONFIG_SMP_NCPUS];
+static struct tcb_s g_idletcb[CONFIG_SMP_NCPUS];
 
 /* This is the name of the idle task */
 
@@ -350,10 +350,11 @@ static void tasklist_initialize(void)
 
 static void idle_task_initialize(void)
 {
-  FAR struct task_tcb_s *tcb;
+  FAR struct tcb_s *tcb;
   FAR dq_queue_t *tasklist;
   int i;
 
+  memset(g_idletcb, 0, sizeof(g_idletcb));
   for (i = 0; i < CONFIG_SMP_NCPUS; i++)
     {
       tcb = &g_idletcb[i];
@@ -365,9 +366,8 @@ static void idle_task_initialize(void)
        * that has pid == 0 and sched_priority == 0.
        */
 
-      memset(tcb, 0, sizeof(struct task_tcb_s));
-      tcb->cmn.pid        = i;
-      tcb->cmn.task_state = TSTATE_TASK_RUNNING;
+      tcb->pid        = i;
+      tcb->task_state = TSTATE_TASK_RUNNING;
 
       /* Set the entry point.  This is only for debug purposes.  NOTE: that
        * the start_t entry point is not saved.  That is acceptable, however,
@@ -378,14 +378,14 @@ static void idle_task_initialize(void)
 #ifdef CONFIG_SMP
       if (i > 0)
         {
-          tcb->cmn.start      = nx_idle_trampoline;
-          tcb->cmn.entry.main = (main_t)nx_idle_trampoline;
+          tcb->start      = nx_idle_trampoline;
+          tcb->entry.main = (main_t)nx_idle_trampoline;
         }
       else
 #endif
         {
-          tcb->cmn.start      = nx_start;
-          tcb->cmn.entry.main = (main_t)nx_start;
+          tcb->start      = nx_start;
+          tcb->entry.main = (main_t)nx_start;
         }
 
       /* Set the task flags to indicate that this is a kernel thread and, if
@@ -393,8 +393,8 @@ static void idle_task_initialize(void)
        */
 
 #ifdef CONFIG_SMP
-      tcb->cmn.flags = (TCB_FLAG_TTYPE_KERNEL | TCB_FLAG_CPU_LOCKED);
-      tcb->cmn.cpu   = i;
+      tcb->flags = (TCB_FLAG_TTYPE_KERNEL | TCB_FLAG_CPU_LOCKED);
+      tcb->cpu   = i;
 
       /* Set the affinity mask to allow the thread to run on all CPUs.  No,
        * this IDLE thread can only run on its assigned CPU.  That is
@@ -404,19 +404,19 @@ static void idle_task_initialize(void)
        * the IDLE task.
        */
 
-      tcb->cmn.affinity =
+      tcb->affinity =
         (cpu_set_t)(CONFIG_SMP_DEFAULT_CPUSET & SCHED_ALL_CPUS);
 #else
-      tcb->cmn.flags = TCB_FLAG_TTYPE_KERNEL;
+      tcb->flags = TCB_FLAG_TTYPE_KERNEL;
 #endif
 
 #if CONFIG_TASK_NAME_SIZE > 0
       /* Set the IDLE task name */
 
 #  ifdef CONFIG_SMP
-      snprintf(tcb->cmn.name, CONFIG_TASK_NAME_SIZE, "CPU%d IDLE", i);
+      snprintf(tcb->name, CONFIG_TASK_NAME_SIZE, "CPU%d IDLE", i);
 #  else
-      strlcpy(tcb->cmn.name, g_idlename, CONFIG_TASK_NAME_SIZE);
+      strlcpy(tcb->name, g_idlename, CONFIG_TASK_NAME_SIZE);
 #  endif
 
       /* Configure the task name in the argument list.  The IDLE task does
@@ -427,7 +427,7 @@ static void idle_task_initialize(void)
        * stack and there is no support that yet.
        */
 
-      g_idleargv[i][0] = tcb->cmn.name;
+      g_idleargv[i][0] = tcb->name;
 #else
       g_idleargv[i][0] = (FAR char *)g_idlename;
 #endif /* CONFIG_TASK_NAME_SIZE */
@@ -437,15 +437,15 @@ static void idle_task_initialize(void)
        */
 
 #ifdef CONFIG_SMP
-      tasklist = TLIST_HEAD(&tcb->cmn, i);
+      tasklist = TLIST_HEAD(tcb, i);
 #else
-      tasklist = TLIST_HEAD(&tcb->cmn);
+      tasklist = TLIST_HEAD(tcb);
 #endif
       dq_addfirst((FAR dq_entry_t *)tcb, tasklist);
 
       /* Mark the idle task as the running task */
 
-      g_running_tasks[i] = &tcb->cmn;
+      g_running_tasks[i] = tcb;
     }
 }
 
@@ -459,7 +459,7 @@ static void idle_task_initialize(void)
 
 static void idle_group_initialize(void)
 {
-  FAR struct task_tcb_s *tcb;
+  FAR struct tcb_s *tcb;
   int hashndx;
   int i;
 
@@ -470,16 +470,17 @@ static void idle_group_initialize(void)
       tcb = &g_idletcb[i];
 
       hashndx = PIDHASH(i);
-      g_pidhash[hashndx] = &tcb->cmn;
+      g_pidhash[hashndx] = tcb;
 
       /* Allocate the IDLE group */
 
-      DEBUGVERIFY(group_initialize(tcb, tcb->cmn.flags));
-      tcb->cmn.group->tg_info->ta_argv = &g_idleargv[i][0];
+      DEBUGVERIFY(
+        group_initialize((FAR struct task_tcb_s *)tcb, tcb->flags));
+      tcb->group->tg_info->ta_argv = &g_idleargv[i][0];
 
       /* Initialize the task join */
 
-      nxtask_joininit(&tcb->cmn);
+      nxtask_joininit(tcb);
 
 #ifdef CONFIG_SMP
       /* Create a stack for all CPU IDLE threads (except CPU0 which already
@@ -488,26 +489,24 @@ static void idle_group_initialize(void)
 
       if (i > 0)
         {
-          DEBUGVERIFY(up_cpu_idlestack(i, &tcb->cmn,
-                CONFIG_IDLETHREAD_STACKSIZE));
+          DEBUGVERIFY(up_cpu_idlestack(i, tcb, CONFIG_IDLETHREAD_STACKSIZE));
         }
 #endif
 
       /* Initialize the processor-specific portion of the TCB */
 
-      up_initial_state(&tcb->cmn);
+      up_initial_state(tcb);
 
       /* Initialize the thread local storage */
 
-      tls_init_info(&tcb->cmn);
+      tls_init_info(tcb);
 
       /* Complete initialization of the IDLE group.  Suppress retention
        * of child status in the IDLE group.
        */
 
-      group_postinitialize(tcb);
-      tcb->cmn.group->tg_flags = GROUP_FLAG_NOCLDWAIT |
-                                 GROUP_FLAG_PRIVILEGED;
+      group_postinitialize((FAR struct task_tcb_s *)tcb);
+      tcb->group->tg_flags = GROUP_FLAG_NOCLDWAIT | GROUP_FLAG_PRIVILEGED;
     }
 }
 
@@ -726,7 +725,7 @@ void nx_start(void)
 
   /* Announce that the CPU0 IDLE task has started */
 
-  sched_note_start(&g_idletcb[0].cmn);
+  sched_note_start(&g_idletcb[0]);
 
   /* Initialize stdio for the IDLE task of each CPU */
 
@@ -736,7 +735,8 @@ void nx_start(void)
         {
           /* Clone stdout, stderr, stdin from the CPU0 IDLE task. */
 
-          DEBUGVERIFY(group_setuptaskfiles(&g_idletcb[i], NULL, true));
+          DEBUGVERIFY(group_setuptaskfiles(
+            (FAR struct task_tcb_s *)&g_idletcb[i], NULL, true));
         }
       else
         {

--- a/sched/sched/sched.h
+++ b/sched/sched/sched.h
@@ -435,5 +435,6 @@ bool nxsched_verify_tcb(FAR struct tcb_s *tcb);
 
 struct tls_info_s; /* Forward declare */
 FAR struct tls_info_s *nxsched_get_tls(FAR struct tcb_s *tcb);
+FAR char **nxsched_get_stackargs(FAR struct tcb_s *tcb);
 
 #endif /* __SCHED_SCHED_SCHED_H */

--- a/sched/sched/sched_get_tls.c
+++ b/sched/sched/sched_get_tls.c
@@ -53,3 +53,25 @@ FAR struct tls_info_s *nxsched_get_tls(FAR struct tcb_s *tcb)
 
   return (FAR struct tls_info_s *)tcb->stack_alloc_ptr;
 }
+
+/****************************************************************************
+ * Name: nxsched_get_stackargs
+ *
+ * Description:
+ *   Get args from thread's stack w/o security checks. The args are setup in
+ *   nxtask_setup_stackargs().
+ *
+ * Input Parameters:
+ *   tcb - The tcb to query.
+ *
+ * Returned Value:
+ *   Pointer to a list of stack arguments ended by a NULL pointer.
+ *
+ ****************************************************************************/
+
+FAR char **nxsched_get_stackargs(FAR struct tcb_s *tcb)
+{
+  /* The args data follows the TLS data */
+
+  return (FAR char**)(tcb->stack_alloc_ptr + nxsched_get_tls(tcb)->tl_size);
+}

--- a/sched/task/task_create.c
+++ b/sched/task/task_create.c
@@ -76,13 +76,14 @@ int nxthread_create(FAR const char *name, uint8_t ttype, int priority,
                     FAR void *stack_addr, int stack_size, main_t entry,
                     FAR char * const argv[], FAR char * const envp[])
 {
-  FAR struct task_tcb_s *tcb;
+  FAR struct tcb_s *tcb;
   pid_t pid;
   int ret;
 
   /* Allocate a TCB for the new task. */
 
-  tcb = kmm_zalloc(sizeof(struct task_tcb_s));
+  tcb = kmm_zalloc(ttype == TCB_FLAG_TTYPE_KERNEL ?
+                   sizeof(struct tcb_s) : sizeof(struct task_tcb_s));
   if (!tcb)
     {
       serr("ERROR: Failed to allocate TCB\n");
@@ -91,12 +92,12 @@ int nxthread_create(FAR const char *name, uint8_t ttype, int priority,
 
   /* Setup the task type */
 
-  tcb->cmn.flags = ttype | TCB_FLAG_FREE_TCB;
+  tcb->flags = ttype | TCB_FLAG_FREE_TCB;
 
   /* Initialize the task */
 
-  ret = nxtask_init(tcb, name, priority, stack_addr, stack_size,
-                    entry, argv, envp, NULL);
+  ret = nxtask_init((FAR struct task_tcb_s *)tcb, name, priority,
+                    stack_addr, stack_size, entry, argv, envp, NULL);
   if (ret < OK)
     {
       kmm_free(tcb);
@@ -105,11 +106,11 @@ int nxthread_create(FAR const char *name, uint8_t ttype, int priority,
 
   /* Get the assigned pid before we start the task */
 
-  pid = tcb->cmn.pid;
+  pid = tcb->pid;
 
   /* Activate the task */
 
-  nxtask_activate(&tcb->cmn);
+  nxtask_activate(tcb);
 
   return pid;
 }

--- a/sched/task/task_fork.c
+++ b/sched/task/task_fork.c
@@ -96,6 +96,7 @@ FAR struct task_tcb_s *nxtask_setup_fork(start_t retaddr)
   FAR struct tcb_s *ptcb = this_task();
   FAR struct tcb_s *parent;
   FAR struct task_tcb_s *child;
+  FAR char **argv;
   size_t stack_size;
   uint8_t ttype;
   int priority;
@@ -211,8 +212,8 @@ FAR struct task_tcb_s *nxtask_setup_fork(start_t retaddr)
 
   /* Setup to pass parameters to the new task */
 
-  ret = nxtask_setup_arguments(child, parent->group->tg_info->ta_argv[0],
-                               &parent->group->tg_info->ta_argv[1]);
+  argv = nxsched_get_stackargs(parent);
+  ret = nxtask_setup_arguments(child, argv[0], &argv[1]);
   if (ret < OK)
     {
       goto errout_with_tcb;

--- a/sched/task/task_setup.c
+++ b/sched/task/task_setup.c
@@ -514,6 +514,7 @@ static void nxtask_setup_name(FAR struct task_tcb_s *tcb,
  *
  * Input Parameters:
  *   tcb  - Address of the new task's TCB
+ *   name - Name of the new task
  *   argv - A pointer to an array of input parameters. The array should be
  *          terminated with a NULL argv[] value. If no parameters are
  *          required, argv may be NULL.
@@ -527,6 +528,7 @@ static int nxtask_setup_stackargs(FAR struct task_tcb_s *tcb,
                                   FAR const char *name,
                                   FAR char * const argv[])
 {
+  uint8_t ttype = tcb->cmn.flags & TCB_FLAG_TTYPE_MASK;
   FAR char **stackargv;
   FAR char *str;
   size_t strtablen;
@@ -630,8 +632,11 @@ static int nxtask_setup_stackargs(FAR struct task_tcb_s *tcb,
 
   stackargv[argc + 1] = NULL;
 
-  tcb->cmn.group->tg_info->ta_argc = argc;
-  tcb->cmn.group->tg_info->ta_argv = stackargv;
+  if (ttype != TCB_FLAG_TTYPE_KERNEL)
+    {
+      tcb->cmn.group->tg_info->ta_argc = argc;
+      tcb->cmn.group->tg_info->ta_argv = stackargv;
+    }
 
   return OK;
 }

--- a/sched/task/task_setup.c
+++ b/sched/task/task_setup.c
@@ -528,7 +528,6 @@ static int nxtask_setup_stackargs(FAR struct task_tcb_s *tcb,
                                   FAR const char *name,
                                   FAR char * const argv[])
 {
-  uint8_t ttype = tcb->cmn.flags & TCB_FLAG_TTYPE_MASK;
   FAR char **stackargv;
   FAR char *str;
   size_t strtablen;
@@ -631,12 +630,6 @@ static int nxtask_setup_stackargs(FAR struct task_tcb_s *tcb,
    */
 
   stackargv[argc + 1] = NULL;
-
-  if (ttype != TCB_FLAG_TTYPE_KERNEL)
-    {
-      tcb->cmn.group->tg_info->ta_argc = argc;
-      tcb->cmn.group->tg_info->ta_argv = stackargv;
-    }
 
   return OK;
 }

--- a/sched/tls/tls_initinfo.c
+++ b/sched/tls/tls_initinfo.c
@@ -63,6 +63,10 @@ int tls_init_info(FAR struct tcb_s *tcb)
 
   up_tls_initialize(info);
 
+  /* Derive tl_size w/o arch knowledge */
+
+  info->tl_size = tcb->stack_base_ptr - tcb->stack_alloc_ptr;
+
   /* Attach per-task info in group to TLS */
 
   info->tl_task = tcb->group->tg_info;


### PR DESCRIPTION
## Summary 

Current task group data is embedded in the task TCB, this is also used for kernel threads, which seems can share the `group` as they all live in kernel space.

This patch uses `tcb_s` for kthreads with a shared `group` instance. Thus the overhead is reduced when more kthreads are in use. 

Memory usage of group instance, i.e. `sizeof(task_group_s)`, on `rv-virt` device:

| config  | size |
| ------- | ---- |
| nsh     | 720  |
| nsh64   | 1160 |
| knsh32  | 248  |
| knsh64  | 440  |


Kernel memory footprints collected from attached logs:

| config | kthreads # | upstream | patched  | saved |
| ------ | ---------- | -------- | -------- | ----- |
| nsh    | 1          | 7044     | 7044     | 0     |
| nsh64  | 1          | 10344    | 10344    | 0     |
| knsh32 | 2          | 10348    | 9660     | 588   |
| knsh64 | 2          | 13304    | 12168    | 1136  |

The savings are beyond `sizeof(task_group_s)` due to subordinate data of groups.

## Impact

This may affect all configs.

## Testing

- QEMU 6.2 on Ubuntu 22.04 with configs `nsh`, `nsh64`, `knsh32` and `knsh64`. See [logs-12320.tar.gz](https://github.com/apache/nuttx/files/15341750/logs-12320.tar.gz) for more details:
  - the `embedded` folder has logs from upstream version.
  - the `kthreads` folder has logs from patched version.
- Github CI checks
