### PR TITLE
Zero-Cross driver to ESP32

### DIFF
--- a/boards/xtensa/esp32/common/include/esp32_zerocross.h
+++ b/boards/xtensa/esp32/common/include/esp32_zerocross.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * boards/xtensa/esp32/esp32-wrover-kit/src/esp32-wrover-kit.h
+ * boards/xtensa/esp32/common/include/esp32_zerocross.h
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,47 +18,18 @@
  *
  ****************************************************************************/
 
-#ifndef __BOARDS_XTENSA_ESP32_ESP32_WROVERKIT_SRC_ESP32_WROVERKIT_H
-#define __BOARDS_XTENSA_ESP32_ESP32_WROVERKIT_SRC_ESP32_WROVERKIT_H
+#ifndef __BOARDS_EXTENSA_ESP32_COMMON_INCLUDE_ESPM32_ZEROCROSS_H
+#define __BOARDS_EXTENSA_ESP32_COMMON_INCLUDE_ESPM32_ZEROCROSS_H
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
 
 #include <nuttx/config.h>
-#include <nuttx/compiler.h>
-#include <stdint.h>
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
-
-/* ESP-WROVER-KIT GPIOs *****************************************************/
-
-/* LEDs */
-
-#define GPIO_LED1  0
-#define GPIO_LED2  2
-#define GPIO_LED3  4
-
-/* BOOT Button */
-
-#define BUTTON_BOOT  0
-
-/* TIMERS */
-
-#define TIMER0 0
-#define TIMER1 1
-#define TIMER2 2
-#define TIMER3 3
-
-/* ONESHOT */
-
-#define ONESHOT_TIMER         1
-#define ONESHOT_RESOLUTION_US 1
-
-/* Zero Cross */
-#define GPIO_ZERO_CROSS_IRQ 22
 
 /****************************************************************************
  * Public Types
@@ -68,54 +39,35 @@
  * Public Data
  ****************************************************************************/
 
-#ifndef __ASSEMBLY__
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Inline Functions
+ ****************************************************************************/
 
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
 
 /****************************************************************************
- * Name: esp32_bringup
+ * Name: esp32_zerocross_initialize
  *
  * Description:
- *   Perform architecture-specific initialization
- *
- *   CONFIG_BOARD_LATE_INITIALIZE=y :
- *     Called from board_late_initialize().
- *
- *   CONFIG_BOARD_LATE_INITIALIZE=y && CONFIG_BOARDCTL=y :
- *     Called from the NSH library via board_app_initialize()
+ *   Initialize and register the zero cross driver
  *
  ****************************************************************************/
 
-int esp32_bringup(void);
+int board_zerocross_initialize(int devno);
 
-/****************************************************************************
- * Name: esp32_mmcsd_initialize
- *
- * Description:
- *   Initialize SPI-based SD card and card detect thread.
- *
- ****************************************************************************/
-
-int esp32_mmcsd_initialize(int minor);
-
-/****************************************************************************
- * Name: esp32_spiflash_init
- *
- * Description:
- *   Initialize the SPIFLASH and register the MTD device.
- ****************************************************************************/
-
-int esp32_spiflash_init(void);
-
-/****************************************************************************
- * Name: esp32_gpio_init
- ****************************************************************************/
-
-#ifdef CONFIG_DEV_GPIO
-int esp32_gpio_init(void);
+#undef EXTERN
+#ifdef __cplusplus
+}
 #endif
 
-#endif /* __ASSEMBLY__ */
-#endif /* __BOARDS_XTENSA_ESP32_ESP32_WROVERKIT_SRC_ESP32_WROVERKIT_H */
+#endif /* __BOARDS_EXTENSA_ESP32_COMMON_INCLUDE_ESPM32_ZEROCROSS_H */

--- a/boards/xtensa/esp32/common/src/Make.defs
+++ b/boards/xtensa/esp32/common/src/Make.defs
@@ -148,6 +148,10 @@ endif
   CSRCS += esp32_board_dac.c
 #endif
 
+ifeq ($(CONFIG_SENSORS_ZEROCROSS),y)
+  CSRCS += esp32_zerocross.c
+endif
+
 DEPPATH += --dep-path src
 VPATH += :src
 CFLAGS += ${INCDIR_PREFIX}$(TOPDIR)$(DELIM)arch$(DELIM)$(CONFIG_ARCH)$(DELIM)src$(DELIM)board$(DELIM)src

--- a/boards/xtensa/esp32/common/src/esp32_zerocross.c
+++ b/boards/xtensa/esp32/common/src/esp32_zerocross.c
@@ -1,0 +1,148 @@
+/****************************************************************************
+ * boards/xtensa/esp32/common/src/esp32_zerocross.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+#include <assert.h>
+#include <debug.h>
+
+#include <nuttx/irq.h>
+#include <nuttx/arch.h>
+#include <arch/board/board.h>
+#include <nuttx/sensors/zerocross.h>
+
+#include "esp32_gpio.h"
+#include "hardware/esp32_gpio_sigmap.h"
+#include "esp32-wrover-kit.h"
+#include "esp32_zerocross.h"
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static void zcross_enable(const struct zc_lowerhalf_s *lower,
+                          zc_interrupt_t handler, void *arg);
+
+static int zcross_interrupt(int irq, void *context, void *arg);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/* Current interrupt handler and argument */
+
+static zc_interrupt_t g_zcrosshandler;
+static void *g_zcrossarg;
+
+/* This is the zero cross lower half driver interface */
+
+static struct zc_lowerhalf_s g_zcrosslower =
+{
+    .zc_enable = zcross_enable,
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: zcross_enable
+ *
+ * Description:
+ *   Enable interrupts on the selected zero cross pin.  And empty
+ *   set will disable all interrupts.
+ *
+ ****************************************************************************/
+
+static void zcross_enable(const struct zc_lowerhalf_s *lower,
+                          zc_interrupt_t handler, void *arg)
+{
+  irqstate_t flags;
+  int irq = ESP32_PIN2IRQ(GPIO_ZERO_CROSS_IRQ);
+  int ret;
+
+  flags = enter_critical_section();
+
+  if (handler)
+    {
+      g_zcrosshandler = handler;
+      g_zcrossarg = arg;
+    }
+
+  /* Start with all interrupts disabled */
+
+  esp32_gpioirqdisable(irq);
+
+  ret = irq_attach(irq, zcross_interrupt, NULL);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: zcross_enable() failed: %d\n", ret);
+      leave_critical_section(flags);
+    }
+
+  esp32_gpioirqenable(irq, RISING);
+
+  leave_critical_section(flags);
+}
+
+/****************************************************************************
+ * Name: zcross_interrupt
+ *
+ * Description:
+ *   Zero Cross interrupt handler
+ *
+ ****************************************************************************/
+
+static int zcross_interrupt(int irq, void *context, void *arg)
+{
+  DEBUGASSERT(g_zcrosshandler != NULL);
+  if (g_zcrosshandler)
+    {
+      g_zcrosshandler(&g_zcrosslower, g_zcrossarg);
+    }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: esp32_zerocross_initialize
+ *
+ * Description:
+ *   Initialize and register the zero cross driver
+ *
+ ****************************************************************************/
+
+int board_zerocross_initialize(int devno)
+{
+  esp32_configgpio(GPIO_ZERO_CROSS_IRQ, INPUT_FUNCTION_3 | PULLUP);
+
+  /* Register the zero cross device as /dev/zc0 */
+
+  return zc_register("/dev/zc0", &g_zcrosslower);
+}

--- a/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_bringup.c
+++ b/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_bringup.c
@@ -105,6 +105,10 @@
 #  include "esp32_lcd_backpack.h"
 #endif
 
+#ifdef CONFIG_SENSORS_ZEROCROSS
+#   include "esp32_zerocross.h"
+#endif
+
 #include "esp32-wrover-kit.h"
 
 /****************************************************************************
@@ -382,6 +386,17 @@ int esp32_bringup(void)
     {
       syslog(LOG_ERR,
              "ERROR: Failed to Instantiate the RTC driver: %d\n", ret);
+    }
+#endif
+
+#ifdef CONFIG_SENSORS_ZEROCROSS
+  /* Register Zero Cross Driver */
+
+  ret = board_zerocross_initialize(0);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR,
+            "ERROR: board_zerocross_initialize() failed: %d\n", ret);
     }
 #endif
 


### PR DESCRIPTION
## Summary
The PR aims to add support for ESP32 device support for the Zero Cross driver.
## Impact
None
## Testing
Running apps/examples/zerocross.
