### PR TITLE
arch/risc-v: fix idle stack assign order

### DIFF
--- a/arch/risc-v/src/common/riscv_common_memorymap.h
+++ b/arch/risc-v/src/common/riscv_common_memorymap.h
@@ -68,7 +68,7 @@ EXTERN uintptr_t g_idle_topstack;
 /* Address of per-cpu idle stack base */
 
 #define g_cpux_idlestack(cpuid) \
-   (g_idle_topstack - SMP_STACK_SIZE * ((cpuid) + 1))
+   (g_idle_topstack - SMP_STACK_SIZE * (CONFIG_SMP_NCPUS - (cpuid)))
 
 /* Address of the saved user stack pointer */
 


### PR DESCRIPTION
The bc022f8cd8 introduces a static way to calculate idle stack address for risc-v platform. However, it uses the reverse order to access idle stack, which breaks boards with smp configuration.

Correct the idle stack order of g_cpux_idlestack.

This should fix #12265 (bc022f8cd8) and can close #12325

## Testing
`rv-virt:smp64`, `rv-virt:ksmp64`
