### PR TITLE
esp32s3/esp32s2: Fix D_I_BUS_OFFSET

### DIFF
--- a/arch/xtensa/src/esp32s2/esp32s2_textheap.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_textheap.c
@@ -45,7 +45,7 @@
 #error "No suitable heap available. Enable ESP32S2_RTC_HEAP."
 #endif
 
-#define D_I_BUS_OFFSET  0x700000
+#define D_I_BUS_OFFSET  0x70000
 
 /****************************************************************************
  * Public Functions

--- a/arch/xtensa/src/esp32s3/esp32s3_textheap.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_textheap.c
@@ -45,7 +45,7 @@
 #error "No suitable heap available. Enable ESP32S3_RTC_HEAP."
 #endif
 
-#define D_I_BUS_OFFSET  0x700000
+#define D_I_BUS_OFFSET  0x6f0000
 
 /****************************************************************************
  * Public Functions


### PR DESCRIPTION
## Summary
It seems like a wrong copy-and-paste from esp32c3. Actually, internal memory mapping varies among processors.

## Impact

## Testing
esp32s3: lightly tested with wamr aot
esp32s2: not tested (i have no hardware access)


