### PR TITLE
driver/vnc:fix vnc kbd assert cause by wrong data conversion

### DIFF
--- a/drivers/video/vnc/vnc_receiver.c
+++ b/drivers/video/vnc/vnc_receiver.c
@@ -330,7 +330,7 @@ int vnc_receiver(FAR struct vnc_session_s *session)
                   * CONFIG_VNCSERVER_KBD.
                   */
 
-                  session->kbdout(&session->kbd, keyevent->down,
+                  session->kbdout(session->arg, keyevent->down,
                                   (FAR const uint8_t *)keyevent->key);
 
 #else


### PR DESCRIPTION
## Summary
fix vnc kbd assert cause by wrong data conversion
## Impact
vnc kbd
## Testing
vnc kbd

