### PR TITLE
[net][udp] fix udp wrb-iob leak when NIC was down

### DIFF
--- a/net/udp/udp_sendto_buffered.c
+++ b/net/udp/udp_sendto_buffered.c
@@ -151,12 +151,6 @@ static void sendto_writebuffer_release(FAR struct udp_conn_s *conn)
           wrb = (FAR struct udp_wrbuffer_s *)sq_remfirst(&conn->write_q);
           DEBUGASSERT(wrb != NULL);
 
-          /* Do not need to release wb_iob, the life cycle of wb_iob is
-           * handed over to the network device
-           */
-
-          wrb->wb_iob = NULL;
-
           udp_wrbuffer_release(wrb);
 
           /* Set up for the next packet transfer by setting the connection
@@ -454,6 +448,12 @@ static uint16_t sendto_eventhandler(FAR struct net_driver_s *dev,
 
       dev->d_sndlen = wrb->wb_iob->io_pktlen - udpiplen;
       ninfo("wrb=%p sndlen=%d\n", wrb, dev->d_sndlen);
+
+      /* Do not need to release wb_iob, the life cycle of wb_iob is
+       * handed over to the network device
+       */
+
+      wrb->wb_iob = NULL;
 
 #ifdef NEED_IPDOMAIN_SUPPORT
       /* If both IPv4 and IPv6 support are enabled, then we will need to


### PR DESCRIPTION
## Summary
If NIC was down in func,the sendto_writebuffer_release will not release wrb cause setting "wrb->wb_iob = NULL" behind udp_wrbuffer_release
"sendto_eventhandler" in udp_sendto_buffered.c L382 - L390
```
  if ((flags & NETDEV_DOWN) != 0)
    {
      ninfo("Device down: %04x\n", flags);

      /* Free the write buffer at the head of the queue and attempt to setup
       * the next transfer.
       */

      sendto_writebuffer_release(conn);
      return flags;
    }
```
"sendto_writebuffer_release" in udp_sendto_buffered.c L158 - L160
```
    wrb->wb_iob = NULL;

    udp_wrbuffer_release(wrb);
```
## Impact
UDP wrb

## Testing
Passed on Vela product
