### PR TITLE
sys/socket.h: add the definition of SCM_TIMESTAMP

### DIFF
--- a/include/sys/socket.h
+++ b/include/sys/socket.h
@@ -288,6 +288,7 @@
 #define SCM_RIGHTS      0x01    /* rw: access rights (array of int) */
 #define SCM_CREDENTIALS 0x02    /* rw: struct ucred */
 #define SCM_SECURITY    0x03    /* rw: security label */
+#define SCM_TIMESTAMP   SO_TIMESTAMP
 
 /* Desired design of maximum size and alignment (see RFC2553) */
 


### PR DESCRIPTION
## Summary
Third-party library lcm will use SCM_TIMESTAMP macro definition

## Impact

## Testing
sim:local
