### PR TITLE
net/netdev: Check quota when registering lower-half devices

### DIFF
--- a/include/nuttx/net/netdev_lowerhalf.h
+++ b/include/nuttx/net/netdev_lowerhalf.h
@@ -69,6 +69,7 @@
  */
 
 #define NETPKT_BUFLEN   CONFIG_IOB_BUFSIZE
+#define NETPKT_BUFNUM   CONFIG_IOB_NBUFFERS
 
 /****************************************************************************
  * Public Types


### PR DESCRIPTION
## Summary
Some drivers may set too big quota by accident and consume all of our buffers, so we add a check when registering devices.

## Impact
Upper half of netdev, add check for registering.

## Testing
Manually: Locally changed quota of sim_netdriver and virtio-net to make sure the check works.