### PR TITLE
nxstyle: Ignore long line for file path at line 2

### DIFF
--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -3093,7 +3093,16 @@ int main(int argc, char **argv, char **envp)
 
           if (m > g_maxline && !rhcomment)
             {
-              ERROR("Long line found", lineno, m);
+              /* Ignore the line 2 (file path) */
+
+              if (lineno == 2)
+                {
+                  INFO("Skipping checking line 2: path file\n", 2, m);
+                }
+              else
+                {
+                  ERROR("Long line found", lineno, m);
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
nxstyle: Ignore long line for file path at line 2
## Impact
Fixes issues like that reported on PR #12345 
## Testing
local
