### PR TITLE
Added support in Nucleo-L476RG board for MPU9250 sensor.

### DIFF
--- a/boards/arm/stm32l4/nucleo-l476rg/src/Makefile
+++ b/boards/arm/stm32l4/nucleo-l476rg/src/Makefile
@@ -89,6 +89,10 @@ ifeq ($(CONFIG_SENSORS_BMP280),y)
   CSRCS += stm32_bmp280.c
 endif
 
+ifeq ($(CONFIG_SENSORS_MPU9250),y)
+  CSRCS += stm32_mpu9250.c
+endif
+
 ifeq ($(CONFIG_PWM),y)
 CSRCS += stm32_pwm.c
 endif

--- a/boards/arm/stm32l4/nucleo-l476rg/src/stm32_appinit.c
+++ b/boards/arm/stm32l4/nucleo-l476rg/src/stm32_appinit.c
@@ -52,7 +52,11 @@
 #include "stm32l4_i2c.h"
 
 #ifdef CONFIG_SENSORS_BMP280
-#  include "stm32_bmp280.h"
+#include "stm32_bmp280.h"
+#endif
+
+#ifdef CONFIG_SENSORS_MPU9250
+#include "stm32_mpu9250.h"
 #endif
 
 /****************************************************************************
@@ -437,7 +441,6 @@ int board_app_initialize(uintptr_t arg)
   /* Try to register BMP280 device in I2C1 */
 
   ret = board_bmp280_initialize(0, 1);
-
   if (ret < 0)
     {
       syslog(LOG_ERR, "Failed to initialize BMP280 driver: %d\n", ret);
@@ -445,6 +448,20 @@ int board_app_initialize(uintptr_t arg)
   else
     {
       syslog(LOG_ERR, "Initialized BMP280 driver: %d\n", ret);
+    }
+#endif
+
+#ifdef CONFIG_SENSORS_MPU9250
+  /* Try to register MPU9250 device in I2C1 */
+
+  ret = board_mpu9250_initialize(0, 1);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "Failed to initialize MPU9250 driver: %d\n", ret);
+    }
+  else
+    {
+      syslog(LOG_INFO, "Initialized MPU9250 driver: %d\n", ret);
     }
 #endif
 

--- a/boards/arm/stm32l4/nucleo-l476rg/src/stm32_mpu9250.c
+++ b/boards/arm/stm32l4/nucleo-l476rg/src/stm32_mpu9250.c
@@ -1,0 +1,117 @@
+/****************************************************************************
+ * boards/arm/stm32l4/nucleo-l476rg/src/stm32_mpu9250.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdio.h>
+#include <debug.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/sensors/mpu9250.h>
+#include <nuttx/i2c/i2c_master.h>
+
+#include "stm32l4.h"
+#include "stm32l4_i2c.h"
+#include "stm32_mpu9250.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_mpu9250_initialize
+ *
+ * Description:
+ *   Initialize and register
+ *     MPU9250 (Gyro + Accelerometer + Compass) Sensor driver.
+ *
+ * Input Parameters:
+ *   devno - The device number, used to build the device path as
+ *            /dev/uorb/sensor_accelx
+ *            /dev/uorb/sensor_gyrox
+ *            /dev/uorb/sensor_magx
+ *
+ *   busno - The I2C bus number
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int board_mpu9250_initialize(int devno, int busno)
+{
+  struct i2c_master_s *i2c;
+  int ret;
+
+  sninfo("Initializing MPU9250!\n");
+
+  /* Initialize MPU9250 */
+
+  i2c = stm32l4_i2cbus_initialize(busno);
+  if (i2c)
+    {
+      /* Then try to register the IMU sensor in I2Cx */
+
+      struct mpu9250_config_s mpuc;
+      memset(&mpuc, 0, sizeof(mpuc));
+      mpuc.i2c = i2c;
+      mpuc.addr = 0x68;
+
+      ret = mpu9250_register(devno, &mpuc);
+      if (ret < 0)
+        {
+          snerr("ERROR: Error registering MPU9250 in I2C%d\n", busno);
+        }
+    }
+  else
+    {
+      ret = -ENODEV;
+    }
+
+  return ret;
+}

--- a/boards/arm/stm32l4/nucleo-l476rg/src/stm32_mpu9250.h
+++ b/boards/arm/stm32l4/nucleo-l476rg/src/stm32_mpu9250.h
@@ -1,0 +1,89 @@
+/****************************************************************************
+ * boards/arm/stm32l4/nucleo-l476rg/src/stm32_mpu9250.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __BOARDS_ARM_STM32L4_NUCLEO_L476RG_INCLUDE_NUCLEO_L476RG_MPU9250_H
+#define __BOARDS_ARM_STM32L4_NUCLEO_L476RG_INCLUDE_NUCLEO_L476RG_MPU9250_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Type Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Inline Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_mpu9250_initialize
+ *
+ * Description:
+ *   Initialize and register
+ *       MPU9250 (Gyro + Accelerometer + Compass) Sensor driver.
+ *
+ * Input Parameters:
+ *   devno - The device number, used to build the device path as
+ *            /dev/uorb/sensor_accelx
+ *            /dev/uorb/sensor_gyrox
+ *            /dev/uorb/sensor_magx
+ *
+ *   busno - The I2C bus number
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int board_mpu9250_initialize(int devno, int busno);
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __BOARDS_ARM_STM32L4_NUCLEO_L476RG_INCLUDE_NUCLEO_L476RG_MPU9250_H */


### PR DESCRIPTION
## Summary

This commit adds the support for the Invensense MPU-9250 a 9-axis MotionTracking device that combines a 3-axis gyroscope, 3-axis accelerometer, 3-axis magnetometer to the ST Nucleo-L476RG board.

## Impact

Nothing else is impacted.

## Testing

It is tested on Nucleo-L476RG board with uorb listener and it is working fine.