### PR TITLE
esp32s3_textheap.c: fix range checks

### DIFF
--- a/arch/xtensa/src/esp32s3/esp32s3_textheap.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_textheap.c
@@ -93,7 +93,7 @@ void *up_textheap_memalign(size_t align, size_t size)
            */
 
           uintptr_t addr = (uintptr_t)ret;
-          if (SOC_DIRAM_DRAM_LOW <= addr && addr <= SOC_DIRAM_DRAM_HIGH)
+          if (SOC_DIRAM_DRAM_LOW <= addr && addr < SOC_DIRAM_DRAM_HIGH)
             {
               addr = MAP_DRAM_TO_IRAM(addr);
             }
@@ -135,7 +135,7 @@ void up_textheap_free(void *p)
 #endif
         {
           uintptr_t addr = (uintptr_t)p;
-          if (SOC_DIRAM_IRAM_LOW <= addr && addr <= SOC_DIRAM_IRAM_HIGH)
+          if (SOC_DIRAM_IRAM_LOW <= addr && addr < SOC_DIRAM_IRAM_HIGH)
             {
               addr = MAP_IRAM_TO_DRAM(addr);
             }
@@ -181,7 +181,7 @@ bool up_textheap_heapmember(void *p)
 #endif
 
   uintptr_t addr = (uintptr_t)p;
-  if (SOC_DIRAM_IRAM_LOW <= addr && addr <= SOC_DIRAM_IRAM_HIGH)
+  if (SOC_DIRAM_IRAM_LOW <= addr && addr < SOC_DIRAM_IRAM_HIGH)
     {
       addr = MAP_IRAM_TO_DRAM(addr);
     }


### PR DESCRIPTION
## Summary
While there constants are commented as "First and last words of the D/IRAM region", the _HIGH addresses are actually not in the corresponding region.

## Impact

## Testing

