### PR TITLE
PM: change domain field state after callback done

### DIFF
--- a/drivers/power/pm/pm_changestate.c
+++ b/drivers/power/pm/pm_changestate.c
@@ -272,16 +272,19 @@ int pm_changestate(int domain, enum pm_state_e newstate)
    */
 
   pm_changeall(domain, newstate);
-  if (newstate != PM_RESTORE)
-    {
-      g_pmglobals.domain[domain].state = newstate;
-    }
 
   /* Notify governor of (possible) state change */
 
   if (g_pmglobals.domain[domain].governor->statechanged)
     {
       g_pmglobals.domain[domain].governor->statechanged(domain, newstate);
+    }
+
+  /* Domain state update after statechanged done */
+
+  if (newstate != PM_RESTORE)
+    {
+      g_pmglobals.domain[domain].state = newstate;
     }
 
   /* Restore the interrupt state */


### PR DESCRIPTION
## Summary
Swap the sequence of domain state update and statechanged callback, 
Make sure inside statechanged callback can get the old domain state. 

## Impact
Only have impact on activity governor, no other impacts.

## Testing
CI-test and qemu-arm-v8a.
