### PR TITLE
pm: fix when RTC_HIRES enabled pm procfs err

### DIFF
--- a/drivers/power/pm/pm_initialize.c
+++ b/drivers/power/pm/pm_initialize.c
@@ -95,6 +95,10 @@ void pm_initialize(void)
 #endif
       pm_set_governor(i, gov);
 
+#if defined(CONFIG_PM_PROCFS)
+      clock_systime_timespec(&g_pmglobals.domain[i].start);
+#endif
+
       nxrmutex_init(&g_pmglobals.domain[i].lock);
 
 #if CONFIG_PM_GOVERNOR_EXPLICIT_RELAX


### PR DESCRIPTION
## Summary
In drivers/power/pm/pm_changestate.c pm_stats
fist time do 
```C
clock_systime_timespec(&ts);
clock_timespec_subtract(&ts, &dom->start, &ts);
```
if enabled RTC_HIRES, procfs will not start with 0.

## Impact
pm_initialize will call clock_systime_timespec extra once, if PM_PROCFS enabled.

## Testing
ci-test & qemu-v8a
