### PR TITLE
boards/imx93-evk: Fix potential warning about unused variable

### DIFF
--- a/boards/arm64/imx9/imx93-evk/src/imx9_i2c.c
+++ b/boards/arm64/imx9/imx93-evk/src/imx9_i2c.c
@@ -73,5 +73,5 @@ int imx9_i2c_initialize(void)
     }
 #endif
 
-  return OK;
+  return ret;
 }

--- a/boards/arm64/imx9/imx93-evk/src/imx9_spi.c
+++ b/boards/arm64/imx9/imx93-evk/src/imx9_spi.c
@@ -158,5 +158,5 @@ int imx9_spi_initialize(void)
     }
 #endif /* CONFIG_SPI_DRIVER */
 
-  return OK;
+  return ret;
 }


### PR DESCRIPTION

## Summary
"ret" might be unused, which causes an error due to -Werror

## Impact
Fix minor build issue
## Testing
CI pass
