### PR TITLE
risc-v/mpfs: Change linker symbols _ssbi_ddr and _esbi_ddr into _ssbi…

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_opensbi.c
+++ b/arch/risc-v/src/mpfs/mpfs_opensbi.c
@@ -84,8 +84,8 @@ typedef struct sbi_scratch_holder_s sbi_scratch_holder_t;
 
 extern const uint8_t __mpfs_nuttx_start[];
 extern const uint8_t __mpfs_nuttx_end[];
-extern const uint8_t _ssbi_ddr[];
-extern const uint8_t _esbi_ddr[];
+extern const uint8_t _ssbi_ram[];
+extern const uint8_t _esbi_ram[];
 
 /****************************************************************************
  * Private Function Prototypes
@@ -479,9 +479,9 @@ static void mpfs_opensbi_scratch_setup(uint32_t hartid)
    * them so that OpenSBI has no chance override then.
    */
 
-  g_scratches[hartid].scratch.fw_start = (unsigned long)_ssbi_ddr;
-  g_scratches[hartid].scratch.fw_size  = (unsigned long)_esbi_ddr -
-                                         (unsigned long)_ssbi_ddr;
+  g_scratches[hartid].scratch.fw_start = (unsigned long)_ssbi_ram;
+  g_scratches[hartid].scratch.fw_size  = (unsigned long)_esbi_ram -
+                                         (unsigned long)_ssbi_ram;
 
   g_scratches[hartid].scratch.fw_rw_offset =
       (unsigned long)g_scratches[hartid].scratch.fw_size;

--- a/boards/risc-v/mpfs/icicle/scripts/ld-envm-opensbi.script
+++ b/boards/risc-v/mpfs/icicle/scripts/ld-envm-opensbi.script
@@ -36,12 +36,12 @@ SECTIONS
     PROVIDE(__l2lim_end   = ORIGIN(l2lim) + LENGTH(l2lim));
 
     .text.sbi : {
-      _ssbi_ddr = ABSOLUTE(.);
+      _ssbi_ram = ABSOLUTE(.);
       sbi*
       riscv_atomic*
       riscv_locks*
       riscv_asm*
-      _esbi_ddr = ABSOLUTE(.);
+      _esbi_ram = ABSOLUTE(.);
       . = ALIGN(0x2000);
       . += 16k; /* OpenSBI heap, aligned, at least 16k */
     } > ddr


### PR DESCRIPTION
…_ram and _esbi_ram

The original names are confusing; the symbols' addresses point to the start and end of the sbi executable ram area. This may also reside in l2lim and not in ddr, depending on the configuration, and this is defined in the linker script.

