### PR TITLE
tools/minidump: 64-bit dump support

### DIFF
--- a/tools/minidumpserver.py
+++ b/tools/minidumpserver.py
@@ -387,7 +387,7 @@ class DumpLogFile:
                 start = addr_start
 
         for val in match_res.groupdict()["VALS"].split():
-            data = data + struct.pack("<I", int(val, 16))
+            data = data + struct.pack("<Q", int(val, 16))
 
         return start, data
 


### PR DESCRIPTION

## Summary

This is to follow up patch 12316

## Impact

minidump tool usage with 64bit stack dump logs

## Testings

- checked with `rv-virt/ksmp64`
- CI checks