### PR TITLE
espressif: Add option to disable the GIT_DEPTH to pull submodules

### DIFF
--- a/arch/risc-v/src/common/espressif/Make.defs
+++ b/arch/risc-v/src/common/espressif/Make.defs
@@ -111,7 +111,14 @@ ifndef ESP_HAL_3RDPARTY_VERSION
 endif
 
 ifndef ESP_HAL_3RDPARTY_URL
-	ESP_HAL_3RDPARTY_URL	= https://github.com/espressif/esp-hal-3rdparty.git
+	ESP_HAL_3RDPARTY_URL = https://github.com/espressif/esp-hal-3rdparty.git
+endif
+
+ifndef DISABLE_GIT_DEPTH
+ifndef GIT_DEPTH
+	GIT_DEPTH=1
+endif
+	GIT_DEPTH_PARAMETER = --depth=$(GIT_DEPTH)
 endif
 
 chip/$(ESP_HAL_3RDPARTY_REPO):
@@ -121,7 +128,7 @@ chip/$(ESP_HAL_3RDPARTY_REPO):
 	$(Q) git -C chip/$(ESP_HAL_3RDPARTY_REPO) checkout --quiet $(ESP_HAL_3RDPARTY_VERSION)
 ifeq ($(CONFIG_ESP_WIRELESS),y)
 	$(Q) echo "Espressif HAL for 3rd Party Platforms: initializing submodules..."
-	$(Q) git -C chip/$(ESP_HAL_3RDPARTY_REPO) submodule --quiet update --init --depth=1 components/mbedtls/mbedtls components/esp_phy/lib components/esp_wifi/lib components/esp_coex/lib
+	$(Q) git -C chip/$(ESP_HAL_3RDPARTY_REPO) submodule --quiet update --init $(GIT_DEPTH_PARAMETER) components/mbedtls/mbedtls components/esp_phy/lib components/esp_wifi/lib components/esp_coex/lib
 	$(Q) git -C chip/$(ESP_HAL_3RDPARTY_REPO)/components/mbedtls/mbedtls reset --quiet --hard
 	$(Q) echo "Applying patches..."
 	$(Q) cd chip/$(ESP_HAL_3RDPARTY_REPO)/components/mbedtls/mbedtls && git apply ../../../nuttx/patches/components/mbedtls/mbedtls/*.patch

--- a/arch/xtensa/src/esp32/Make.defs
+++ b/arch/xtensa/src/esp32/Make.defs
@@ -215,6 +215,13 @@ ifndef ESP_HAL_3RDPARTY_URL
 	ESP_HAL_3RDPARTY_URL = https://github.com/espressif/esp-hal-3rdparty.git
 endif
 
+ifndef DISABLE_GIT_DEPTH
+ifndef GIT_DEPTH
+	GIT_DEPTH=1
+endif
+	GIT_DEPTH_PARAMETER = --depth=$(GIT_DEPTH)
+endif
+
 chip/$(ESP_HAL_3RDPARTY_REPO):
 	$(Q) echo "Cloning Espressif HAL for 3rd Party Platforms"
 	$(Q) git clone --quiet $(ESP_HAL_3RDPARTY_URL) chip/$(ESP_HAL_3RDPARTY_REPO)
@@ -238,7 +245,7 @@ include common/espressif/Make.defs
 context:: chip/$(ESP_HAL_3RDPARTY_REPO)
 ifeq ($(CONFIG_ESP32_WIRELESS),y)
 	$(Q) echo "Espressif HAL for 3rd Party Platforms: initializing submodules..."
-	$(Q) git -C chip/$(ESP_HAL_3RDPARTY_REPO) submodule --quiet update --init --depth=1 components/mbedtls/mbedtls components/esp_phy/lib components/esp_wifi/lib components/bt/controller/lib_esp32 components/esp_coex/lib
+	$(Q) git -C chip/$(ESP_HAL_3RDPARTY_REPO) submodule --quiet update --init $(GIT_DEPTH_PARAMETER) components/mbedtls/mbedtls components/esp_phy/lib components/esp_wifi/lib components/bt/controller/lib_esp32 components/esp_coex/lib
 	$(Q) git -C chip/$(ESP_HAL_3RDPARTY_REPO)/components/mbedtls/mbedtls reset --quiet --hard
 	$(Q) echo "Applying patches..."
 	$(Q) cd chip/$(ESP_HAL_3RDPARTY_REPO)/components/mbedtls/mbedtls && git apply ../../../nuttx/patches/components/mbedtls/mbedtls/*.patch

--- a/arch/xtensa/src/esp32s3/Make.defs
+++ b/arch/xtensa/src/esp32s3/Make.defs
@@ -212,6 +212,13 @@ ifndef ESP_HAL_3RDPARTY_URL
 	ESP_HAL_3RDPARTY_URL = https://github.com/espressif/esp-hal-3rdparty.git
 endif
 
+ifndef DISABLE_GIT_DEPTH
+ifndef GIT_DEPTH
+	GIT_DEPTH=1
+endif
+	GIT_DEPTH_PARAMETER = --depth=$(GIT_DEPTH)
+endif
+
 chip/$(ESP_HAL_3RDPARTY_REPO):
 	$(Q) echo "Cloning Espressif HAL for 3rd Party Platforms"
 	$(Q) git clone --quiet $(ESP_HAL_3RDPARTY_URL) chip/$(ESP_HAL_3RDPARTY_REPO)
@@ -238,7 +245,7 @@ include common/espressif/Make.defs
 context:: chip/$(ESP_HAL_3RDPARTY_REPO)
 ifeq ($(CONFIG_ESP32S3_WIRELESS),y)
 	$(Q) echo "Espressif HAL for 3rd Party Platforms: initializing submodules..."
-	$(Q) git -C chip/$(ESP_HAL_3RDPARTY_REPO) submodule --quiet update --init --depth=1 components/mbedtls/mbedtls components/esp_phy/lib components/esp_wifi/lib components/bt/controller/lib_esp32c3_family components/esp_coex/lib
+	$(Q) git -C chip/$(ESP_HAL_3RDPARTY_REPO) submodule --quiet update --init $(GIT_DEPTH_PARAMETER) components/mbedtls/mbedtls components/esp_phy/lib components/esp_wifi/lib components/bt/controller/lib_esp32c3_family components/esp_coex/lib
 	$(Q) git -C chip/$(ESP_HAL_3RDPARTY_REPO)/components/mbedtls/mbedtls reset --quiet --hard
 	$(Q) echo "Applying patches..."
 	$(Q) cd chip/$(ESP_HAL_3RDPARTY_REPO)/components/mbedtls/mbedtls && git apply ../../../nuttx/patches/components/mbedtls/mbedtls/*.patch


### PR DESCRIPTION
## Summary

* espressif: Enable setting the GIT_DEPTH to pull the submodules
  * By default, submodules are cloned with `--depth=1`. This continues to be true if `DISABLE_GIT_DEPTH` environment variable is not defined (and it is not defined by default). But, if defined the submodules will be fully cloned (without the `--depth` parameter).

## Impact

Some testing functionality requires fetching the whole repository (without the `--depth` option). This implementation enables it.

## Testing

Internal CI testing with HW testing.