### PR TITLE
imxrt: 1170 MPU config ensure no lockups can occur

### DIFF
--- a/arch/arm/src/imxrt/imxrt117x_mpuinit.c
+++ b/arch/arm/src/imxrt/imxrt117x_mpuinit.c
@@ -51,6 +51,7 @@
            MPU_RASR_XN;             /* Execute-never to prevent instruction fetch */
   putreg32(regval, MPU_RASR);
 
+#ifdef CONFIG_IMXRT_SEMC
   mpu_configure_region(IMXRT_SEMC0_BASE, 512 * 1024 * 1024,
 
                                            /* Instruction access Enabled */
@@ -62,6 +63,7 @@
                                            /* Not Shareable              */
                                            /* No Subregion disable       */
                        );
+#endif
 
   mpu_configure_region(IMXRT_FLEXSPI2_CIPHER_BASE, 512 * 1024 * 1024,
 
@@ -91,7 +93,7 @@
 
                                            /* Instruction access Enabled */
 
-                       MPU_RASR_AP_RWRW  | /* P:RW   U:RW                */
+                       MPU_RASR_AP_RORO  | /* P:R0   U:R0                */
                        MPU_RASR_TEX_NOR    /* Normal                     */
                                            /* Not Cacheable              */
                                            /* Not Bufferable             */


### PR DESCRIPTION
## Summary
When writing/reading to SEMC without the peripheral enabled the 1170 could lockup.
Don't enable SEMC region if the peripheral is disabled.

Also make sure that ITCM is Read-only when executing from it.

## Impact
imxrt1170

## Testing
vmu_rt1170
