### PR TITLE
sensors: improvements for bmm150 and bh1749nuc

### DIFF
--- a/drivers/sensors/Kconfig
+++ b/drivers/sensors/Kconfig
@@ -326,6 +326,10 @@ config SENSORS_BMM150
 
 if SENSORS_BMM150
 
+config BMM150_I2C_FREQUENCY
+	int "BMM150 I2C frequency"
+	default 400000
+
 config SENSORS_BMM150_POLL
 	bool "Enables polling sensor data"
 	default n

--- a/drivers/sensors/Kconfig
+++ b/drivers/sensors/Kconfig
@@ -143,6 +143,10 @@ config SENSORS_BH1749NUC
 
 if SENSORS_BH1749NUC
 
+config BH1749NUC_I2C_FREQUENCY
+	int "BH1749NUC I2C frequency"
+	default 400000
+
 config SENSORS_BH1749NUC_UORB
 	bool "BH1749NUC UORB Interface"
 	default n

--- a/drivers/sensors/bh1749nuc.c
+++ b/drivers/sensors/bh1749nuc.c
@@ -203,7 +203,7 @@ int bh1749nuc_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   priv->i2c   = i2c;
   priv->addr  = addr;
-  priv->freq  = BH1749NUC_I2C_FREQ;
+  priv->freq  = CONFIG_BH1749NUC_I2C_FREQUENCY;
 
   /* Check Device ID */
 

--- a/drivers/sensors/bh1749nuc_base.h
+++ b/drivers/sensors/bh1749nuc_base.h
@@ -41,8 +41,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define BH1749NUC_I2C_FREQ          400000
-
 #define BH1749NUC_MANUFACTID        0xE0    /* Manufact ID */
 #define BH1749NUC_PARTID            0x0D    /* Part ID */
 

--- a/drivers/sensors/bh1749nuc_uorb.c
+++ b/drivers/sensors/bh1749nuc_uorb.c
@@ -221,10 +221,9 @@ static int bh1749nuc_fetch(FAR struct sensor_lowerhalf_s *lower,
       goto errout;
     }
 
-  /* Wait for data */
-
-  while (!(bh1749nuc_getreg8(dev, BH1749NUC_MODE_CONTROL2) &
-           BH1749NUC_MODE_CONTROL2_VALID));
+  /* Get data without wait for VALID flag - otherwise the sensor freezes
+   * when we read RBG and IR data one after another
+   */
 
   if (lower->type == SENSOR_TYPE_RGB)
     {

--- a/drivers/sensors/bh1749nuc_uorb.c
+++ b/drivers/sensors/bh1749nuc_uorb.c
@@ -450,7 +450,7 @@ int bh1749nuc_register_uorb(int devno, FAR struct bh1749nuc_config_s *config)
 
   dev->dev.i2c  = config->i2c;
   dev->dev.addr = config->addr;
-  dev->dev.freq = BH1749NUC_I2C_FREQ;
+  dev->dev.freq = CONFIG_BH1749NUC_I2C_FREQUENCY;
 
   /* Check Device ID */
 

--- a/drivers/sensors/bh1749nuc_uorb.c
+++ b/drivers/sensors/bh1749nuc_uorb.c
@@ -505,6 +505,11 @@ int bh1749nuc_register_uorb(int devno, FAR struct bh1749nuc_config_s *config)
       goto ir_err;
     }
 
+  /* SW Reset */
+
+  bh1749nuc_putreg8(&dev->dev, BH1749NUC_SYSTEM_CONTROL,
+                    BH1749NUC_SYSTEM_CONTROL_SW_RESET);
+
 #ifdef CONFIG_SENSORS_BH1749NUC_POLL
   /* Create thread for polling sensor data */
 

--- a/drivers/sensors/bmm150_uorb.c
+++ b/drivers/sensors/bmm150_uorb.c
@@ -40,8 +40,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define BMM150_I2C_FREQ          400000
-
 #define BMM150_CHIPID_VAL        0x32
 
 #define BMM150_CHIPID            0x40
@@ -712,7 +710,7 @@ int bmm150_register_uorb(int devno, FAR struct bmm150_config_s *config)
 
   dev->config.i2c  = config->i2c;
   dev->config.addr = config->addr;
-  dev->freq        = BMM150_I2C_FREQ;
+  dev->freq        = CONFIG_BMM150_I2C_FREQUENCY;
 
   /*  Register sensor */
 


### PR DESCRIPTION
## Summary
- sensors/bh1749nuc_uorb.c: add sensor reset
- sensors/bh1749nuc_uorb.c: don't wait for VALID flag in fetch interface ￼…
- sensors/bh1749nuc: configure I2C frequency
- sensors/bmm150: configure I2C frequency


## Impact

## Testing
thingy53
