### PR TITLE
tools/docker: install file/tclsh tools：

### DIFF
--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -267,7 +267,7 @@ RUN mkdir -p cmake && \
 RUN dpkg --add-architecture i386
 # This is used for the final images so make sure to not store apt cache
 # Note: xtensa-esp32-elf-gdb is linked to libpython2.7
-RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" apt-get install -y -qq --no-install-recommends \
+RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" TZ=Etc/UTC apt-get install -y -qq --no-install-recommends \
   -o APT::Immediate-Configure=0 \
   avr-libc \
   ccache \
@@ -306,6 +306,8 @@ RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" apt-get install -y -q
   unzip \
   wget \
   xxd \
+  file \
+  tclsh \
   && rm -rf /var/lib/apt/lists/*
 
 # Set GCC-12 as Default compiler


### PR DESCRIPTION
## Summary
tools/docker: install file/tclsh tools：

fix CI compilation errors:
github/workspace/sources/apps/database/sqlite/sqlite/configure: line 5204: /usr/bin/file: No such file or directory /github/workspace/sources/apps/database/sqlite/sqlite/configure: line 10376: tclsh: command not found /github/workspace/sources/apps/database/sqlite/sqlite/configure: line 10812: tclsh: command not found /github/workspace/sources/apps/database/sqlite/sqlite/configure: line 10826: tclsh: command not found configure: WARNING: Can't find Tcl configuration definitions configure: WARNING: *** Without Tcl the regression tests cannot be executed *** configure: WARNING: *** Consider using --with-tcl=... to define location of Tcl *** make[4]: warning: -j0 forced in submake: resetting jobserver mode. /github/workspace/sources/apps/database/sqlite/sqlite/tool/cktclsh.sh: 5: tclsh: not found make[4]: *** [Makefile:793: has_tclsh84] Error 1
make[4]: Target 'sqlite3.c' not remade because of errors. make[3]: *** [Makefile:52: context] Error 2
make[2]: *** [Makefile:53: /github/workspace/sources/apps/database/sqlite_context] Error 2 make[2]: Target 'context_all' not remade because of errors. make[1]: *** [Makefile:175: context] Error 2
make: *** [tools/Unix.mk:452: /github/workspace/sources/apps/.context] Error 2


## Impact

## Testing

