### PR TITLE
sched: remove redundant variables "switched"

### DIFF
--- a/sched/sched/sched_addreadytorun.c
+++ b/sched/sched/sched_addreadytorun.c
@@ -153,7 +153,6 @@ bool nxsched_add_readytorun(FAR struct tcb_s *btcb)
 {
   FAR struct tcb_s *rtcb;
   FAR dq_queue_t *tasklist;
-  bool switched;
   bool doswitch;
   int task_state;
   int cpu;
@@ -249,14 +248,14 @@ bool nxsched_add_readytorun(FAR struct tcb_s *btcb)
        */
 
       tasklist = list_assignedtasks(cpu);
-      switched = nxsched_add_prioritized(btcb, tasklist);
+      doswitch = nxsched_add_prioritized(btcb, tasklist);
 
       /* If the selected task list was the g_assignedtasks[] list and if the
        * new tasks is the highest priority (RUNNING) task, then a context
        * switch will occur.
        */
 
-      if (switched)
+      if (doswitch)
         {
           FAR struct tcb_s *next;
 
@@ -332,8 +331,6 @@ bool nxsched_add_readytorun(FAR struct tcb_s *btcb)
 
               nxsched_add_prioritized(next, tasklist);
             }
-
-          doswitch = true;
         }
       else
         {


### PR DESCRIPTION


## Summary
sched: remove redundant variables "switched"

## Impact
NONE

## Testing
We can use qemu for testing.

compiling
make distclean -j20; ./tools/configure.sh -l qemu-armv8a:nsh_smp ;make -j20 running
qemu-system-aarch64 -cpu cortex-a53 -smp 4 -nographic -machine virt,virtualization=on,gic-version=3 -net none -chardev stdio,id=con,mux=on -serial chardev:con -mon chardev=con,mode=readline -kernel ./nuttx