### PR TITLE
types: on some arch, execution speed can be accelerated

### DIFF
--- a/include/sys/types.h
+++ b/include/sys/types.h
@@ -268,11 +268,7 @@ typedef int32_t      suseconds_t;
 
 /* This is the smallest integer type that will hold a bitset of all CPUs */
 
-#if (CONFIG_SMP_NCPUS <= 8)
-typedef volatile uint8_t cpu_set_t;
-#elif (CONFIG_SMP_NCPUS <= 16)
-typedef volatile uint16_t cpu_set_t;
-#elif (CONFIG_SMP_NCPUS <= 32)
+#if (CONFIG_SMP_NCPUS <= 32)
 typedef volatile uint32_t cpu_set_t;
 #else
 #  error SMP: Extensions needed to support this number of CPUs


### PR DESCRIPTION
## Summary
in arm64 Let's see how the following code looks like in assembly

volatile cpu_set_t g_cpu_set;
cpu_set_t set_cpu_set_t_set(int cpu) {
  g_cpu_set &= ~(1 << cpu);
  return g_cpu_set;
}

when
typedef volatile uint32_t cpu_set_t;
Dump of assembler code for function set_cpu_set_t_set:
   0x0000000040288570 <+0>:	adrp	x2, 0x403ce000 <g_irqvector+1160>
   0x0000000040288574 <+4>:	ldr	w3, [x2, #2368]
   0x0000000040288578 <+8>:	mov	w1, #0x1
   0x000000004028857c <+12>:	lsl	w1, w1, w0
   0x0000000040288580 <+16>:	bic	w1, w3, w1
   0x0000000040288584 <+20>:	str	w1, [x2, #2368]
   0x0000000040288588 <+24>:	ldr	w0, [x2, #2368]
   0x000000004028858c <+28>:	ret

when
typedef volatile uint8_t cpu_set_t;
Dump of assembler code for function set_cpu_set_t_set:
   0x000000004028856c <+0>:	adrp	x2, 0x403ce000 <g_irqvector+1192>
   0x0000000040288570 <+4>:	ldrb	w3, [x2, #2336]
   0x0000000040288574 <+8>:	mov	w1, #0x1
   0x0000000040288578 <+12>:	and	w3, w3, #0xff           // At this time, there will be one more instruction
   0x000000004028857c <+16>:	lsl	w1, w1, w0
   0x0000000040288580 <+20>:	bic	w1, w3, w1
   0x0000000040288584 <+24>:	strb	w1, [x2, #2336]
   0x0000000040288588 <+28>:	ldrb	w0, [x2, #2336]
   0x000000004028858c <+32>:	ret



## Impact
NONE

## Testing
test:
We can use qemu for testing.

compiling
make distclean -j20; ./tools/configure.sh -l qemu-armv8a:nsh_smp ;make -j20 running
qemu-system-aarch64 -cpu cortex-a53 -smp 4 -nographic -machine virt,virtualization=on,gic-version=3 -net none -chardev stdio,id=con,mux=on -serial chardev:con -mon chardev=con,mode=readline -kernel ./nuttx


