### PR TITLE
armv6/7/8-m: use ISB instruction immediately after the MSR instruction

### DIFF
--- a/arch/arm/src/armv6-m/arm_exception.S
+++ b/arch/arm/src/armv6-m/arm_exception.S
@@ -100,6 +100,7 @@ exception_common:
 	mrs		r1, msp					/* R1=The main stack pointer */
 	subs		r1, #SW_XCPT_SIZE			/* R1=Beginning of context array on the stack */
 	msr		msp, r1					/* Reserved stack space */
+	isb		sy
 	b		2f
 
 1:
@@ -160,6 +161,7 @@ exception_common:
 	mov		r2, r1					/* Reserve signal context */
 	subs		r2, r2, #XCPTCONTEXT_SIZE
 	msr		msp, r2					/* We are using the main stack pointer */
+	isb		sy
 3:
 #endif
 
@@ -197,10 +199,12 @@ exception_common:
 	lsls		r0, #(31 - EXC_RETURN_PROCESS_BITNO)	/* Move to bit 31 */
 	bmi		4f					/* Test bit 31 */
 	msr		msp, r1					/* R1=The main stack pointer */
+	isb		sy
 	b		5f
 
 4:
 	msr		psp, r1					/* R1=The process stack pointer */
+	isb		sy
 
 5:
 

--- a/arch/arm/src/armv6-m/arm_initialstate.c
+++ b/arch/arm/src/armv6-m/arm_initialstate.c
@@ -168,6 +168,7 @@ noinline_function void arm_initialize_stack(void)
 
       "mov %1, sp\n"
       "msr psp, %1\n"
+      "isb sy\n"
 
       /* Select PSP */
 
@@ -179,6 +180,7 @@ noinline_function void arm_initialize_stack(void)
       /* Initialize MSP */
 
       "msr msp, %0\n"
+      "isb sy\n"
       :
       : "r" (stack), "r" (tempa), "r" (tempb)
       : "memory");

--- a/arch/arm/src/armv7-m/arm_exception.S
+++ b/arch/arm/src/armv7-m/arm_exception.S
@@ -138,6 +138,7 @@ exception_common:
 	mrs		r1, msp					/* R1=The main stack pointer (MSP) */
 	sub		r2, r1, #SW_XCPT_SIZE			/* Reserved stack space */
 	msr		msp, r2
+	isb		sy
 
 2:
 	mov		r2, r1					/* R2=Copy of the main/process stack pointer */

--- a/arch/arm/src/armv7-m/arm_initialstate.c
+++ b/arch/arm/src/armv7-m/arm_initialstate.c
@@ -190,6 +190,7 @@ noinline_function void arm_initialize_stack(void)
 
       "mov %1, sp\n"
       "msr psp, %1\n"
+      "isb sy\n"
 
       /* Select PSP */
 
@@ -201,6 +202,7 @@ noinline_function void arm_initialize_stack(void)
       /* Initialize MSP */
 
       "msr msp, %0\n"
+      "isb sy\n"
       :
       : "r" (stack), "r" (temp)
       : "memory");

--- a/arch/arm/src/armv8-m/arm_exception.S
+++ b/arch/arm/src/armv8-m/arm_exception.S
@@ -137,6 +137,7 @@ exception_common:
 	mrs		r1, msp					/* R1=The main stack pointer (MSP) */
 	sub		r2, r1, #SW_XCPT_SIZE			/* Reserve the stack space */
 	msr		msp, r2
+	isb		sy
 2:
 	mov		r2, r1					/* R2=Copy of the main/process stack pointer */
 	add		r2, #HW_XCPT_SIZE			/* R2=MSP/PSP before the interrupt was taken */

--- a/arch/arm/src/armv8-m/arm_initialstate.c
+++ b/arch/arm/src/armv8-m/arm_initialstate.c
@@ -204,6 +204,7 @@ noinline_function void arm_initialize_stack(void)
       "mrs %1, msplim\n"
       "msr psplim, %1\n"
 #endif
+      "isb sy\n"
 
       /* Select PSP */
 
@@ -219,6 +220,7 @@ noinline_function void arm_initialize_stack(void)
 #ifdef CONFIG_ARMV8M_STACKCHECK_HARDWARE
       "msr msplim, %2\n"
 #endif
+      "isb sy\n"
       :
 #ifdef CONFIG_ARMV8M_STACKCHECK_HARDWARE
       : "r" (stack), "r" (temp), "r" (stacklim)


### PR DESCRIPTION
## Summary
when changing the stack pointer, software must use an ISB instruction immediately after the MSR instruction. This ensures that instructions after the ISB instruction execute using the new stack pointer.

https://developer.arm.com/documentation/101928/0101/The-Cortex-M85-Processor--Reference-Material/Programmer-s-model/Core-registers/CONTROL-register?lang=en

" When changing the stack pointer, software must use an ISB instruction immediately after the MSR instruction. This ensures that instructions after the ISB instruction execute using the new stack pointer."
## Impact
NULL

## Testing

