### PR TITLE
sched/pthread: rename pthread_initialize.c

### DIFF
--- a/sched/pthread/CMakeLists.txt
+++ b/sched/pthread/CMakeLists.txt
@@ -38,7 +38,7 @@ if(NOT CONFIG_DISABLE_PTHREAD)
       pthread_condclockwait.c
       pthread_sigmask.c
       pthread_cancel.c
-      pthread_initialize.c
+      pthread_sem.c
       pthread_completejoin.c
       pthread_findjoininfo.c
       pthread_release.c

--- a/sched/pthread/Make.defs
+++ b/sched/pthread/Make.defs
@@ -26,7 +26,7 @@ CSRCS += pthread_mutexinit.c pthread_mutexdestroy.c
 CSRCS += pthread_mutextimedlock.c pthread_mutextrylock.c pthread_mutexunlock.c
 CSRCS += pthread_condwait.c pthread_condsignal.c pthread_condbroadcast.c
 CSRCS += pthread_condclockwait.c pthread_sigmask.c pthread_cancel.c
-CSRCS += pthread_initialize.c pthread_completejoin.c pthread_findjoininfo.c
+CSRCS += pthread_sem.c pthread_completejoin.c pthread_findjoininfo.c
 CSRCS += pthread_release.c pthread_setschedprio.c
 CSRCS += pthread_barrierwait.c
 

--- a/sched/pthread/pthread_sem.c
+++ b/sched/pthread/pthread_sem.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * sched/pthread/pthread_initialize.c
+ * sched/pthread/pthread_sem.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
## Summary

Rename `pthread_initalize.c` as `pthread_sem.c` to be in line with the contents.

## Impact

None

## Testing

- Checkd with rv-virt/nsh rv-virt/knsh64
- CI checks
