### PR TITLE
arch/arm/samv7: fix U(S)ART clock enable for 1-wire

### DIFF
--- a/arch/arm/src/samv7/sam_1wire.c
+++ b/arch/arm/src/samv7/sam_1wire.c
@@ -471,7 +471,7 @@ static int sam_init(struct sam_1wire_s *priv)
       up_enable_irq(priv->irq);
     }
 
-  return OK;
+  return ret;
 }
 
 /****************************************************************************
@@ -885,41 +885,49 @@ struct onewire_dev_s *sam_1wireinitialize(int port)
     {
 #ifdef CONFIG_SAMV7_UART0_1WIREDRIVER
     case 0:
+      sam_uart0_enableclk();
       priv = &sam_1wire0_priv;
       break;
 #endif
 #ifdef CONFIG_SAMV7_UART1_1WIREDRIVER
     case 1:
+      sam_uart1_enableclk();
       priv = &sam_1wire1_priv;
       break;
 #endif
 #ifdef CONFIG_SAMV7_UART2_1WIREDRIVER
     case 2:
+      sam_uart2_enableclk();
       priv = &sam_1wire2_priv;
       break;
 #endif
 #ifdef CONFIG_SAMV7_UART3_1WIREDRIVER
     case 3:
+      sam_uart3_enableclk();
       priv = &sam_1wire3_priv;
       break;
 #endif
 #ifdef CONFIG_SAMV7_UART4_1WIREDRIVER
     case 4:
+      sam_uart4_enableclk();
       priv = &sam_1wire4_priv;
       break;
 #endif
 #ifdef CONFIG_SAMV7_USART0_1WIREDRIVER
     case 5:
+      sam_usart0_enableclk();
       priv = &sam_1wire5_priv;
       break;
 #endif
 #ifdef CONFIG_SAMV7_USART1_1WIREDRIVER
     case 6:
+      sam_usart1_enableclk();
       priv = &sam_1wire6_priv;
       break;
 #endif
 #ifdef CONFIG_SAMV7_USART2_1WIREDRIVER
     case 7:
+      sam_usart2_enableclk();
       priv = &sam_1wire7_priv;
       break;
 #endif

--- a/arch/arm/src/samv7/sam_config.h
+++ b/arch/arm/src/samv7/sam_config.h
@@ -97,28 +97,6 @@
 
 /* USARTs *******************************************************************/
 
-/* If the USART is not being used as a UART or for SPI, then it really isn't
- * enabled for our purposes.
- */
-
-#if !defined(CONFIG_USART0_SERIALDRIVER) && !defined(CONFIG_USART0_ISSPI)
-#  undef CONFIG_SAMV7_USART0
-#  undef CONFIG_USART0_SERIAL_CONSOLE
-#  undef CONFIG_USART0_IFLOWCONTROL
-#endif
-
-#if !defined(CONFIG_USART1_SERIALDRIVER) && !defined(CONFIG_USART1_ISSPI)
-#  undef CONFIG_SAMV7_USART1
-#  undef CONFIG_USART1_SERIAL_CONSOLE
-#  undef CONFIG_USART1_IFLOWCONTROL
-#endif
-
-#if !defined(CONFIG_USART2_SERIALDRIVER) && !defined(CONFIG_USART2_ISSPI)
-#  undef CONFIG_SAMV7_USART2
-#  undef CONFIG_USART2_SERIAL_CONSOLE
-#  undef CONFIG_USART2_IFLOWCONTROL
-#endif
-
 /* Don't enable USARTs not supported by the chip. */
 
 #if SAMV7_NUSART < 1

--- a/arch/arm/src/samv7/sam_lowputc.c
+++ b/arch/arm/src/samv7/sam_lowputc.c
@@ -249,59 +249,59 @@ void sam_lowsetup(void)
 
   /* Enable clocking for all selected UART/USARTs */
 
-#ifdef CONFIG_SAMV7_UART0
+#ifdef CONFIG_UART0_SERIALDRIVER
   sam_uart0_enableclk();
 #endif
-#ifdef CONFIG_SAMV7_UART1
+#ifdef CONFIG_UART1_SERIALDRIVER
   sam_uart1_enableclk();
 #endif
-#ifdef CONFIG_SAMV7_UART2
+#ifdef CONFIG_UART2_SERIALDRIVER
   sam_uart2_enableclk();
 #endif
-#ifdef CONFIG_SAMV7_UART3
+#ifdef CONFIG_UART3_SERIALDRIVER
   sam_uart3_enableclk();
 #endif
-#ifdef CONFIG_SAMV7_UART4
+#ifdef CONFIG_UART4_SERIALDRIVER
   sam_uart4_enableclk();
 #endif
-#ifdef CONFIG_SAMV7_USART0
+#ifdef CONFIG_USART0_SERIALDRIVER
   sam_usart0_enableclk();
 #endif
-#ifdef CONFIG_SAMV7_USART1
+#ifdef CONFIG_USART1_SERIALDRIVER
   sam_usart1_enableclk();
 #endif
-#ifdef CONFIG_SAMV7_USART2
+#ifdef CONFIG_USART2_SERIALDRIVER
   sam_usart2_enableclk();
 #endif
 
   /* Configure UART pins for all selected UART/USARTs */
 
-#ifdef CONFIG_SAMV7_UART0
+#ifdef CONFIG_UART0_SERIALDRIVER
   sam_configgpio(GPIO_UART0_RXD);
   sam_configgpio(GPIO_UART0_TXD);
 #endif
 
-#ifdef CONFIG_SAMV7_UART1
+#ifdef CONFIG_UART1_SERIALDRIVER
   sam_configgpio(GPIO_UART1_RXD);
   sam_configgpio(GPIO_UART1_TXD);
 #endif
 
-#ifdef CONFIG_SAMV7_UART2
+#ifdef CONFIG_UART2_SERIALDRIVER
   sam_configgpio(GPIO_UART2_RXD);
   sam_configgpio(GPIO_UART2_TXD);
 #endif
 
-#ifdef CONFIG_SAMV7_UART3
+#ifdef CONFIG_UART3_SERIALDRIVER
   sam_configgpio(GPIO_UART3_RXD);
   sam_configgpio(GPIO_UART3_TXD);
 #endif
 
-#ifdef CONFIG_SAMV7_UART4
+#ifdef CONFIG_UART4_SERIALDRIVER
   sam_configgpio(GPIO_UART4_RXD);
   sam_configgpio(GPIO_UART4_TXD);
 #endif
 
-#ifdef CONFIG_SAMV7_USART0
+#ifdef CONFIG_USART0_SERIALDRIVER
   sam_configgpio(GPIO_USART0_RXD);
   sam_configgpio(GPIO_USART0_TXD);
 #ifdef CONFIG_USART0_OFLOWCONTROL
@@ -312,7 +312,7 @@ void sam_lowsetup(void)
 #endif
 #endif
 
-#ifdef CONFIG_SAMV7_USART1
+#ifdef CONFIG_USART1_SERIALDRIVER
   sam_configgpio(GPIO_USART1_RXD);
   sam_configgpio(GPIO_USART1_TXD);
 #  ifdef CONFIG_USART1_OFLOWCONTROL
@@ -337,7 +337,7 @@ void sam_lowsetup(void)
 
 #endif
 
-#ifdef CONFIG_SAMV7_USART2
+#ifdef CONFIG_USART2_SERIALDRIVER
   sam_configgpio(GPIO_USART2_RXD);
   sam_configgpio(GPIO_USART2_TXD);
 #ifdef CONFIG_USART2_OFLOWCONTROL


### PR DESCRIPTION
## Summary
By default U(S)ART clocks are enabled in sam_lowput.c but configuration check from sam_config.h may override USART configuration and prevent clocks from been enabled.

This commit fix inconsistency in U(S)ART pinmux and clock configuration

## Impact
Improve U(S)ART support for SAMv7

## Testing
Pass CI