### PR TITLE
esp32s2/esp32s3 textheap: do not require RTC heap

### DIFF
--- a/arch/xtensa/src/esp32s2/esp32s2_textheap.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_textheap.c
@@ -41,10 +41,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#ifndef CONFIG_ESP32S2_RTC_HEAP
-#error "No suitable heap available. Enable ESP32S2_RTC_HEAP."
-#endif
-
 #define D_I_BUS_OFFSET  0x70000
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32s3/esp32s3_textheap.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_textheap.c
@@ -43,10 +43,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#ifndef CONFIG_ESP32S3_RTC_HEAP
-#error "No suitable heap available. Enable ESP32S3_RTC_HEAP."
-#endif
-
 #define EXTRAM_INSTRUCTION_BUS_LOW  0x42000000
 #define EXTRAM_INSTRUCTION_BUS_HIGH 0x44000000
 


### PR DESCRIPTION
## Summary
Unlike esp32, kmm memory is executable.

## Impact

## Testing
Tested wamr aot on esp32s3-devkitc.
esp32s2 part is not tested.
