### PR TITLE
pm: do struct timespec copy to decrease api call times.

### DIFF
--- a/drivers/power/pm/pm_changestate.c
+++ b/drivers/power/pm/pm_changestate.c
@@ -57,10 +57,16 @@
 #ifdef CONFIG_PM_PROCFS
 static void pm_stats(FAR struct pm_domain_s *dom, int curstate, int newstate)
 {
+  struct timespec now;
   struct timespec ts;
 
-  clock_systime_timespec(&ts);
+  clock_systime_timespec(&now);
+  ts = now;
   clock_timespec_subtract(&ts, &dom->start, &ts);
+
+  /* Update start */
+
+  dom->start = now;
 
   if (newstate == PM_RESTORE)
     {
@@ -76,10 +82,6 @@ static void pm_stats(FAR struct pm_domain_s *dom, int curstate, int newstate)
       clock_timespec_add(&ts, &dom->wake[curstate], &dom->wake[curstate]);
       dom->in_sleep = true;
     }
-
-  /* Update start */
-
-  clock_systime_timespec(&dom->start);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
Improve performance of pm procfs by decrease clock_systime_timespec call times.

## Impact
Only decreased function execution time.

## Testing
CI-test, arm-v7a board.
