### PR TITLE
Rename CONFIG_MPU_RESET -> CONFIG_ARM_MPU_RESET  so the the MPU reset so it is compiled

### DIFF
--- a/arch/arm/src/armv7-m/arm_mpu.c
+++ b/arch/arm/src/armv7-m/arm_mpu.c
@@ -185,7 +185,7 @@ static inline uint32_t mpu_subregion_ls(size_t offset, uint8_t l2size)
  *
  ****************************************************************************/
 
-#if defined(CONFIG_MPU_RESET) || defined(CONFIG_ARM_MPU_EARLY_RESET)
+#if defined(CONFIG_ARM_MPU_RESET) || defined(CONFIG_ARM_MPU_EARLY_RESET)
 static void mpu_reset_internal()
 {
   int region;
@@ -423,7 +423,7 @@ void mpu_configure_region(uintptr_t base, size_t size,
  *   MPU initialization.
  *
  ****************************************************************************/
-#if defined(CONFIG_MPU_RESET)
+#if defined(CONFIG_ARM_MPU_RESET)
 void mpu_reset()
 {
   mpu_reset_internal();

--- a/arch/arm/src/armv7-m/mpu.h
+++ b/arch/arm/src/armv7-m/mpu.h
@@ -139,7 +139,7 @@
  *
  ****************************************************************************/
 
-#if defined(CONFIG_MPU_RESET)
+#if defined(CONFIG_ARM_MPU_RESET)
 void mpu_reset(void);
 #else
 #  define mpu_reset()

--- a/arch/arm/src/armv7-r/arm_mpu.c
+++ b/arch/arm/src/armv7-r/arm_mpu.c
@@ -185,7 +185,7 @@ static inline uint32_t mpu_subregion_ls(size_t offset, uint8_t l2size)
  *
  ****************************************************************************/
 
-#if defined(CONFIG_MPU_RESET) || defined(CONFIG_ARM_MPU_EARLY_RESET)
+#if defined(CONFIG_ARM_MPU_RESET) || defined(CONFIG_ARM_MPU_EARLY_RESET)
 static void mpu_reset_internal()
 {
   int region;
@@ -336,7 +336,7 @@ uint32_t mpu_subregion(uintptr_t base, size_t size, uint8_t l2size)
  *   MPU initialization.
  *
  ****************************************************************************/
-#if defined(CONFIG_MPU_RESET)
+#if defined(CONFIG_ARM_MPU_RESET)
 void mpu_reset()
 {
   mpu_reset_internal();

--- a/arch/arm/src/armv7-r/mpu.h
+++ b/arch/arm/src/armv7-r/mpu.h
@@ -128,7 +128,7 @@ extern "C"
  *
  ****************************************************************************/
 
-#if defined(CONFIG_MPU_RESET)
+#if defined(CONFIG_ARM_MPU_RESET)
 void mpu_reset(void);
 #else
 #  define mpu_reset() do { } while (0)

--- a/arch/arm/src/armv8-m/arm_mpu.c
+++ b/arch/arm/src/armv8-m/arm_mpu.c
@@ -79,7 +79,7 @@ unsigned int mpu_allocregion(void)
  *
  ****************************************************************************/
 
-#if defined(CONFIG_MPU_RESET) || defined(CONFIG_ARM_MPU_EARLY_RESET)
+#if defined(CONFIG_ARM_MPU_RESET) || defined(CONFIG_ARM_MPU_EARLY_RESET)
 static void mpu_reset_internal()
 {
   int region;
@@ -184,7 +184,7 @@ void mpu_configure_region(uintptr_t base, size_t size,
  *   MPU initialization.
  *
  ****************************************************************************/
-#if defined(CONFIG_MPU_RESET)
+#if defined(CONFIG_ARM_MPU_RESET)
 void mpu_reset()
 {
   mpu_reset_internal();

--- a/arch/arm/src/armv8-m/mpu.h
+++ b/arch/arm/src/armv8-m/mpu.h
@@ -178,7 +178,7 @@
  *
  ****************************************************************************/
 
-#if defined(CONFIG_MPU_RESET)
+#if defined(CONFIG_ARM_MPU_RESET)
 void mpu_reset(void);
 #else
 #  define mpu_reset() do { } while (0)


### PR DESCRIPTION
## Summary

CONFIG_MPU_RESET -> CONFIG_ARM_MPU_RESET to match what is in Kconfig

## Impact

Will fix the code so the the MPU reset so it is compiled

## Testing

px4_fmu-v6xrt (imxrt)
