### PR TITLE
nuttx/arch.h: Update parameter type to match definition.

### DIFF
--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -2544,7 +2544,7 @@ void nxsched_alarm_tick_expiration(clock_t ticks);
  ****************************************************************************/
 
 #ifdef CONFIG_SCHED_CPULOAD_EXTCLK
-void nxsched_process_cpuload_ticks(uint32_t ticks);
+void nxsched_process_cpuload_ticks(clock_t ticks);
 #  define nxsched_process_cpuload() nxsched_process_cpuload_ticks(1)
 #endif
 


### PR DESCRIPTION
## Summary

The definition of nxsched_process_cpuload_ticks uses clock_t, which is portable across uint32_t and uint64_t timers, and works if CONFIG_SYSTEM_TIME64 is defined.

## Impact

The correct parameter type is resolved when `CONFIG_SYSTEM_TIME64` is used.

## Testing

`arch/litex` with CONFIG_SYSTEM_TIME64 and CONFIG_CPULOAD_PERIOD
