### PR TITLE
drivers/devicetree/fdt: add additional fdt parsing utilities

### DIFF
--- a/include/nuttx/fdt.h
+++ b/include/nuttx/fdt.h
@@ -350,4 +350,63 @@ uintptr_t fdt_get_clock_frequency_from_clocks(FAR const void *fdt,
                                               int offset,
                                               int index);
 
+/****************************************************************************
+ * Name: fdt_node_index_from_label
+ *
+ * Description:
+ *  Get the node index from a device tree label.
+ *
+ * Input Parameters:
+ *  label - The device tree node_label
+ *  count - The number of characters from the end of the label to search
+ *
+ * Returns
+ *  The integer number found at the end of the label. e.g returns 4 for a
+ *  label called (i2c_4). Returns -ENOENT if an integer cannot be found.
+ *
+ ****************************************************************************/
+
+int fdt_node_index_from_label(FAR const char *node_label, int count);
+
+/****************************************************************************
+ * Name: fdt_node_from_compat
+ *
+ * Description:
+ *   Find all devices with a matching compatibility string and call a device
+ *   specific callback.
+ *
+ * Input Parameters:
+ *   fdt - The pointer to the raw FDT.
+ *   compatible_ids - NULL terminated list of compatible ids.
+ *   driver_callback - Function called on every found instance of the ID.
+ *
+ ****************************************************************************/
+
+void fdt_node_from_compat(FAR const void *fdt,
+                          FAR const char **compatible_ids,
+                          FAR void (*driver_callback)(FAR const void *fdt,
+                                                      int offset));
+
+/****************************************************************************
+ * Name: fdt_load_prop_u32
+ *
+ * Description:
+ *   Load an uint32_t type from a property at a given index
+ *
+ * Input Parameters:
+ *   fdt - The pointer to the raw FDT.
+ *   offset - The node offset
+ *   property - The property to load from.
+ *   index - The value index inside the property
+ *   value - Output parameter for found value.
+ *
+ * Returns:
+ *   OK on success, errno of failure.
+ *
+ ****************************************************************************/
+
+int fdt_load_prop_u32(FAR const void *fdt, int offset,
+                      FAR const char *property, int index,
+                      FAR uint32_t *value);
+
 #endif /* __INCLUDE_NUTTX_FDT_H */


### PR DESCRIPTION
## Summary
arch/risc-v/litex: add some litex specific FDT helpers.

## Impact

These utilities remove some of the boilerplate needed for FDT parsing and device initialization. 

## Testing

Litex port with device tree support. Further PRs to follow with driver support.

