### PR TITLE
sched/signal: reclaim sigaction

### DIFF
--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -1548,6 +1548,20 @@ endmenu # RTOS hooks
 
 menu "Signal Configuration"
 
+config SIG_PREALLOC_ACTIONS
+	int "Number of pre-allocated sigactions"
+	default 4
+	---help---
+		The number of pre-allocated sigaction structures.
+
+config SIG_ALLOC_ACTIONS
+	int "Num of sigactions to allocate per time"
+	default 1
+	---help---
+		The number of sigactions to allocate per time. Note that
+		if this number is larger than 1, the allocation won't be
+		returned to the heap but kept in a free list for reuse.
+
 config SIG_PREALLOC_IRQ_ACTIONS
 	int "Number of pre-allocated irq actions"
 	default 4 if DEFAULT_SMALL

--- a/sched/signal/signal.h
+++ b/sched/signal/signal.h
@@ -42,7 +42,6 @@
  * allocate in a block
  */
 
-#define NUM_SIGNAL_ACTIONS       4
 #define NUM_PENDING_ACTIONS      4
 #define NUM_SIGNALS_PENDING      4
 


### PR DESCRIPTION
## Summary

Currently the sigaction objects are never reclaimed after use, thus after running
`ostest` we will see used memory increasion.

This patch uses a configurable number of pre-allocated entries and reclaims dynamic
entries so that to reduce leakage.
                                                                              
## Impact                                                                   
                                                                              
Used memory reduced after running `ostest`.
                                                                              
## Testing                                                                  

- Checked with `rv-virt/nsh`  and  `rv-virt/nsh64`
- CI checks
