### PR TITLE
ci/blocker: temporary fix for imx9evk

### DIFF
--- a/boards/arm64/imx9/imx93-evk/scripts/ocramboot.ld
+++ b/boards/arm64/imx9/imx93-evk/scripts/ocramboot.ld
@@ -31,7 +31,7 @@ EXTERN(__start)
 
 MEMORY
 {
-  ocram (rx) : ORIGIN = 0x2049a000, LENGTH = 0x37ff0
+  ocram (rx) : ORIGIN = 0x2049a000, LENGTH = 0x40000
   ocram_data (rw) : ORIGIN = 0x204e0000, LENGTH = 0x2000
   ocram_noload (rw) : ORIGIN = 0x204f0000, LENGTH = 0x30000
 }


### PR DESCRIPTION
## Summary

Temporary fix to unblock [CI errors](https://github.com/apache/nuttx/actions/runs/9251490607/job/25447280252) like:

```
Configuration/Tool: imx93-evk/bootloader
...
aarch64-none-elf-ld: /github/workspace/sources/nuttx/nuttx section `.rodata' will not fit in region `ocram'
aarch64-none-elf-ld: region `ocram' overflowed by 88 bytes

```
The ocram region has been enlarged.

## Impact

CI checks

## Testing

- CI checks
