### PR TITLE
analog: add configuration option to set DAC FIFO size

### DIFF
--- a/drivers/analog/Kconfig
+++ b/drivers/analog/Kconfig
@@ -245,6 +245,16 @@ config DAC
 
 if DAC
 
+config DAC_FIFOSIZE
+	int "DAC buffer size"
+	default 8
+	range 1 255
+	---help---
+		This variable defines the size of the DAC ring buffer that is used
+		to queue sent DAC data until they can be retrieved by the
+		controller. This size is limited to 255 to fit uint8_t type used
+		in DAC driver.
+
 config DAC_AD5410
 	bool "AD5410 support"
 	default n


### PR DESCRIPTION
## Summary
DAC driver uses CONFIG_DAC_FIFOSIZE, but this is not configurable from Kconfig. This adds the missing option and allows to set DAC FIFO size from the configuration.

## Impact
New config option. No change in C code.

