### PR TITLE
mcp794xx: store datetime in UTC and add trimming support

### DIFF
--- a/drivers/timers/Kconfig
+++ b/drivers/timers/Kconfig
@@ -339,6 +339,13 @@ config RTC_MCP794XX
 
 if RTC_MCP794XX
 
+config MCP794XX_DATETIME_UTC
+	bool "Store datetime in UTC"
+	default n
+	---help---
+		If set, the datetime is stored in UTC timezone instead of timezone
+		defined by local time.
+
 config MCP794XX_I2C_FREQUENCY
 	int "MCP794XX I2C frequency"
 	default 400000

--- a/drivers/timers/mcp794xx.c
+++ b/drivers/timers/mcp794xx.c
@@ -407,11 +407,23 @@ int up_rtc_settime(FAR const struct timespec *tp)
       newtime++;
     }
 
+#ifndef CONFIG_MCP794XX_DATETIME_UTC
+  /* Save datetime in local time. */
+
   if (localtime_r(&newtime, &newtm) == NULL)
     {
       rtcerr("ERROR: localtime_r failed\n");
       return -EINVAL;
     }
+#else
+  /* Save datetime in UTC time. */
+
+  if (gmtime_r(&newtime, &newtm) == NULL)
+    {
+      rtcerr("ERROR: gmtime_r failed\n");
+      return -EINVAL;
+    }
+#endif
 
   rtc_dumptime(&newtm, "New time");
 

--- a/drivers/timers/mcp794xx.c
+++ b/drivers/timers/mcp794xx.c
@@ -77,6 +77,7 @@ struct mcp794xx_dev_s
 {
   FAR struct i2c_master_s *i2c;  /* Contained reference to the I2C bus driver. */
   uint8_t addr;                  /* The I2C device address. */
+  bool coarse_trim;              /* Coarse trim mode */
 };
 
 /****************************************************************************
@@ -183,6 +184,105 @@ static int rtc_bcd2bin(uint8_t value)
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: mcp794xx_rtc_set_trim
+ *
+ * Description:
+ *   Sets the digital trimming to correct for inaccuracies of clock source.
+ *   Digital trimming consists of the MCP794XX periodically adding or
+ *   subtracting clock cycles, resulting in small adjustments in the internal
+ *   timing.
+ *
+ * Input Parameters:
+ *   trim_val    - Calculated trimming value, refer to MCP794XX reference
+ *                 manual.
+ *   rtc_slow    - True indicates RTC is behind real clock, false otherwise.
+ *                 This has to be set to ensure correct trimming direction.
+ *   coarse_mode - MCP794XX allows coarse mode that trims every second
+ *                 instead of every minute.
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno on failure
+ *
+ ****************************************************************************/
+
+int mcp794xx_rtc_set_trim(uint8_t trim_val, bool rtc_slow, bool coarse_mode)
+{
+  struct i2c_msg_s msg[2];
+  uint8_t buffer[2];
+  uint8_t address;
+  uint8_t ctrl;
+  int ret;
+
+  if (g_mcp794xx.coarse_trim != coarse_mode)
+    {
+      address = MCP794XX_REG_CONTROL;
+      msg[0].frequency = CONFIG_MCP794XX_I2C_FREQUENCY;
+      msg[0].addr      = g_mcp794xx.addr;
+      msg[0].flags     = I2C_M_NOSTOP;
+      msg[0].buffer    = &address;
+      msg[0].length    = 1;
+
+      msg[1].frequency = CONFIG_MCP794XX_I2C_FREQUENCY;
+      msg[1].addr      = g_mcp794xx.addr;
+      msg[1].flags     = I2C_M_READ;
+      msg[1].buffer    = &ctrl;
+      msg[1].length    = 1;
+
+      ret = I2C_TRANSFER(g_mcp794xx.i2c, msg, 2);
+      if (ret < 0)
+        {
+          rtcerr("ERROR: I2C_TRANSFER failed: %d\n", ret);
+          return ret;
+        }
+
+      ctrl &= ~MCP794XX_CONTROL_CRSTRIM;
+      if (coarse_mode)
+        {
+          ctrl |= MCP794XX_CONTROL_CRSTRIM;
+        }
+
+      buffer[0] = MCP794XX_REG_CONTROL;
+      buffer[1] = ctrl;
+      msg[0].frequency = CONFIG_MCP794XX_I2C_FREQUENCY;
+      msg[0].addr      = g_mcp794xx.addr;
+      msg[0].flags     = 0;
+      msg[0].buffer    = buffer;
+      msg[0].length    = 2;
+
+      ret = I2C_TRANSFER(g_mcp794xx.i2c, msg, 1);
+      if (ret < 0)
+        {
+          rtcerr("ERROR: I2C_TRANSFER failed: %d\n", ret);
+          return ret;
+        }
+
+      g_mcp794xx.coarse_trim = coarse_mode;
+    }
+
+  buffer[0] = MCP794XX_REG_OSCTRIM;
+  buffer[1] = trim_val & 0x7;
+  if (rtc_slow)
+    {
+      buffer[1] |= MCP794XX_OSCTRIM_SIGN;
+    }
+
+  msg[0].frequency = CONFIG_MCP794XX_I2C_FREQUENCY;
+  msg[0].addr      = g_mcp794xx.addr;
+  msg[0].flags     = 0;
+  msg[0].buffer    = buffer;
+  msg[0].length    = 2;
+
+  ret = I2C_TRANSFER(g_mcp794xx.i2c, msg, 1);
+  if (ret < 0)
+    {
+      rtcerr("ERROR: I2C_TRANSFER failed: %d\n", ret);
+      return ret;
+    }
+
+  return OK;
+}
+
+/****************************************************************************
  * Name: mcp794xx_rtc_initialize
  *
  * Description:
@@ -211,9 +311,10 @@ int mcp794xx_rtc_initialize(FAR struct i2c_master_s *i2c, uint8_t addr)
 {
   /* Remember the i2c device and claim that the RTC is enabled */
 
-  g_mcp794xx.i2c  = i2c;
-  g_mcp794xx.addr = addr;
-  g_rtc_enabled   = true;
+  g_mcp794xx.i2c         = i2c;
+  g_mcp794xx.addr        = addr;
+  g_mcp794xx.coarse_trim = false;
+  g_rtc_enabled          = true;
   return OK;
 }
 

--- a/include/nuttx/timers/mcp794xx.h
+++ b/include/nuttx/timers/mcp794xx.h
@@ -42,6 +42,30 @@ extern "C"
 #endif
 
 /****************************************************************************
+ * Name: mcp794xx_rtc_set_trim
+ *
+ * Description:
+ *   Sets the digital trimming to correct for inaccuracies of clock source.
+ *   Digital trimming consists of the MCP794XX periodically adding or
+ *   subtracting clock cycles, resulting in small adjustments in the internal
+ *   timing.
+ *
+ * Input Parameters:
+ *   trim_val    - Calculated trimming value, refer to MCP794XX reference
+ *                 manual.
+ *   rtc_slow    - True indicates RTC is behind real clock, false otherwise.
+ *                 This has to be set to ensure correct trimming direction.
+ *   coarse_mode - MCP794XX allows coarse mode that trims every second
+ *                 instead of every minute.
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno on failure
+ *
+ ****************************************************************************/
+
+int mcp794xx_rtc_set_trim(uint8_t trim_val, bool rtc_slow, bool coarse_mode);
+
+/****************************************************************************
  * Name: mcp794xx_rtc_initialize
  *
  * Description:


### PR DESCRIPTION
## Summary

#### 81b26a2: timers/mcp794xx: add possibility to store datetime in UTC 

This commit adds configuration option `CONFIG_MCP794XX_DATETIME_UTC`. If set, the datetime is stored in UTC instead of local time. The default value is kept at local time to keep backwards compatibility with devices currently using the RTC.

#### cf3e2a9f: timers/mcp794xx: add option to digital trimming

MCP794XX supports digital trimming that periodically adds or subtracts clock cycles, resulting in small adjustments in the internal timing.This way inaccuracies of clock source can be compensated. 

## Impact

New functionalities for mcp794xx.

## Testing
Tested with SAMv7 and mcp794xx rtc.
