### PR TITLE
tools/ci/testlist: msys2.dat add qemu-v8a:nsh_smp

### DIFF
--- a/tools/ci/testlist/msys2.dat
+++ b/tools/ci/testlist/msys2.dat
@@ -6,3 +6,7 @@
 /arm/stm32/nucleo-l152re/configs/nsh,CONFIG_ARM_TOOLCHAIN_GNU_EABI
 
 /arm/stm32/nucleo-f4x1re/configs/f411-nsh,CONFIG_ARM_TOOLCHAIN_GNU_EABI
+
+# ARM64
+
+/arm64/qemu/qemu-armv8a/configs/nsh_smp


### PR DESCRIPTION
## Summary
add build board qemu-v8a:nsh_smp 64-bit Arm Cortex-A53 Multi-Core
## Impact
none
## Testing

Test NuttX: Arm Cortex-A53 Multi-Core

**Arm64 Toolchain**

Download the latest ARM64 GCC toolchain prebuilt by ARM (arm-gnu-toolchain-13.2.rel1-mingw-w64-i686-aarch64-none-elf.zip)
https://github.com/apache/nuttx/blob/d0f893dfba82c4089eda4cc7c86cde653ecf839e/tools/ci/platforms/msys2.sh#L64


**Compiling**

./tools/configure.sh -g qemu-armv8a:nsh_smp ;make -j4

**Download xpack qemu arm** (xpack-qemu-arm-8.2.2-1-win32-x64.zip)

https://github.com/xpack-dev-tools/qemu-arm-xpack/releases/download/v8.2.2-1/xpack-qemu-arm-8.2.2-1-win32-x64.zip

**Running** 

qemu-system-aarch64 -cpu cortex-a53 -smp 4 -nographic -machine virt,virtualization=on,gic-version=3 -net none -chardev stdio,id=con,mux=on -serial chardev:con -mon chardev=con,mode=readline -kernel nuttx
