### PR TITLE
Fixes for symbol definition in libc.csv and syscall.csv

### DIFF
--- a/libs/libc/libc.csv
+++ b/libs/libc/libc.csv
@@ -52,7 +52,7 @@
 "dq_remfirst","nuttx/queue.h","","FAR dq_entry_t *","FAR dq_queue_t *"
 "dq_remlast","nuttx/queue.h","","FAR dq_entry_t *","FAR dq_queue_t *"
 "ether_ntoa","netinet/ether.h","","FAR char *","FAR const struct ether_addr *"
-"execv","unistd.h","","int","FAR const char *","FAR char *const[]|FAR char *const *"
+"execv","unistd.h","defined(CONFIG_LIBC_EXECFUNCS)","int","FAR const char *","FAR char *const[]|FAR char *const *"
 "exit","stdlib.h","","noreturn","int"
 "fchdir","unistd.h","!defined(CONFIG_DISABLE_ENVIRON)","int","int"
 "fclose","stdio.h","defined(CONFIG_FILE_STREAM)","int","FAR FILE *"

--- a/syscall/syscall.csv
+++ b/syscall/syscall.csv
@@ -154,7 +154,7 @@
 "setgid","unistd.h","defined(CONFIG_SCHED_USER_IDENTITY)","int","gid_t"
 "sethostname","unistd.h","","int","FAR const char *","size_t"
 "setitimer","sys/time.h","!defined(CONFIG_DISABLE_POSIX_TIMERS)","int","int","FAR const struct itimerval *","FAR struct itimerval *"
-"setsockopt","sys/socket.h","defined(CONFIG_NET)","int","int","int","int","FAR const void *","socklen_t"
+"setsockopt","sys/socket.h","defined(CONFIG_NET) && defined(CONFIG_NET_SOCKOPTS)","int","int","int","int","FAR const void *","socklen_t"
 "settimeofday","sys/time.h","","int","FAR const struct timeval *","FAR const struct timezone *"
 "setuid","unistd.h","defined(CONFIG_SCHED_USER_IDENTITY)","int","uid_t"
 "shm_open","sys/mman.h","defined(CONFIG_FS_SHMFS)","int","FAR const char *","int","mode_t"


### PR DESCRIPTION
## Summary
* libc.csv: Guard execv with LIBC_EXECFUNCS
* syscall.csv: Correct macro guard of setsockopt
## Impact
Minor
## Testing
Local machine