### PR TITLE
cmake:bugfix CMake compilation options settings should not use strings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -622,9 +622,8 @@ if(NOT CONFIG_ARCH_SIM)
 
   # TODO: nostart/nodefault not applicable to nuttx toolchain
   target_link_libraries(
-    nuttx
-    PRIVATE ${NUTTX_EXTRA_FLAGS} -Wl,--script=${ldscript} -Wl,--start-group
-            ${nuttx_libs} ${nuttx_extra_libs} -Wl,--end-group)
+    nuttx PRIVATE -Wl,--script=${ldscript} -Wl,--start-group ${nuttx_libs}
+                  ${nuttx_extra_libs} -Wl,--end-group)
 
   # generate binary outputs in different formats (.bin, .hex, etc)
   nuttx_generate_outputs(nuttx)

--- a/arch/arm/src/cmake/Toolchain.cmake
+++ b/arch/arm/src/cmake/Toolchain.cmake
@@ -183,34 +183,24 @@ if(CONFIG_DEBUG_SYMBOLS)
   add_compile_options(-g)
 endif()
 
-set(ARCHCFLAGS "-Wstrict-prototypes")
+add_compile_options(-Wno-attributes -Wno-unknown-pragmas
+                    $<$<COMPILE_LANGUAGE:C>:-Wstrict-prototypes>)
+
+if(CONFIG_CXX_STANDARD)
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-std=${CONFIG_CXX_STANDARD}>)
+endif()
 
 if(NOT CONFIG_LIBCXXTOOLCHAIN)
-  set(ARCHCXXFLAGS "${ARCHCXXFLAGS} -nostdinc++")
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-nostdinc++>)
 endif()
 
 if(NOT CONFIG_CXX_EXCEPTION)
-  string(APPEND ARCHCXXFLAGS " -fno-exceptions -fcheck-new")
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fno-exceptions>
+                      $<$<COMPILE_LANGUAGE:CXX>:-fcheck-new>)
 endif()
 
 if(NOT CONFIG_CXX_RTTI)
-  string(APPEND ARCHCXXFLAGS " -fno-rtti")
-endif()
-
-if(NOT "${CMAKE_C_FLAGS}" STREQUAL "")
-  string(REGEX MATCH "${ARCHCFLAGS}" EXISTS_FLAGS "${CMAKE_C_FLAGS}")
-endif()
-
-if(NOT EXISTS_FLAGS)
-  set(CMAKE_ASM_FLAGS
-      "${CMAKE_ASM_FLAGS} ${ARCHCFLAGS}"
-      CACHE STRING "" FORCE)
-  set(CMAKE_C_FLAGS
-      "${CMAKE_C_FLAGS} ${ARCHCFLAGS}"
-      CACHE STRING "" FORCE)
-  set(CMAKE_CXX_FLAGS
-      "${CMAKE_CXX_FLAGS} ${ARCHCXXFLAGS}"
-      CACHE STRING "" FORCE)
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>)
 endif()
 
 if(CONFIG_ARCH_TOOLCHAIN_CLANG)

--- a/arch/arm/src/cmake/platform.cmake
+++ b/arch/arm/src/cmake/platform.cmake
@@ -56,8 +56,20 @@ else()
   message(FATAL_ERROR "CMAKE_SYSTEM_PROCESSOR not set")
 endif()
 
-get_directory_property(NUTTX_EXTRA_FLAGS DIRECTORY ${CMAKE_SOURCE_DIR}
-                                                   COMPILE_OPTIONS)
+get_directory_property(TOOLCHAIN_DIR_FLAGS DIRECTORY ${CMAKE_SOURCE_DIR}
+                                                     COMPILE_OPTIONS)
+
+set(NUTTX_EXTRA_FLAGS "")
+foreach(FLAG ${TOOLCHAIN_DIR_FLAGS})
+  if(NOT FLAG MATCHES "^\\$<.*>$")
+    list(APPEND NUTTX_EXTRA_FLAGS ${FLAG})
+  else()
+    string(REGEX MATCH "\\$<\\$<COMPILE_LANGUAGE:C>:(.*)>" matched ${FLAG})
+    if(matched)
+      list(APPEND NUTTX_EXTRA_FLAGS ${CMAKE_MATCH_1})
+    endif()
+  endif()
+endforeach()
 
 separate_arguments(CMAKE_C_FLAG_ARGS NATIVE_COMMAND ${CMAKE_C_FLAGS})
 

--- a/arch/arm64/src/cmake/Toolchain.cmake
+++ b/arch/arm64/src/cmake/Toolchain.cmake
@@ -119,31 +119,35 @@ if(CONFIG_ARCH_FPU)
   add_compile_options(-D_LDBL_EQ_DBL)
 endif()
 
-set(ARCHCFLAGS
-    "-Wstrict-prototypes -fno-common -Wall -Wshadow -Werror -Wundef -Wno-attributes -Wno-unknown-pragmas"
-)
-set(ARCHCXXFLAGS
-    "-fno-common -Wall -Wshadow -Wundef -Wno-attributes -Wno-unknown-pragmas")
+add_compile_options(
+  -fno-common
+  -Wall
+  -Wshadow
+  -Wundef
+  -Wno-attributes
+  -Wno-unknown-pragmas
+  $<$<COMPILE_LANGUAGE:C>:-Werror>
+  $<$<COMPILE_LANGUAGE:C>:-Wstrict-prototypes>)
 
 if(NOT CONFIG_LIBCXXTOOLCHAIN)
-  set(ARCHCXXFLAGS "${ARCHCXXFLAGS} -nostdinc++")
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-nostdinc++>)
 endif()
 
-if(NOT ${CONFIG_ARCH_TOOLCHAIN_CLANG})
-  string(APPEND ARCHCFLAGS " -Wno-psabi")
-  string(APPEND ARCHCXXFLAGS " -Wno-psabi")
+if(NOT CONFIG_ARCH_TOOLCHAIN_CLANG)
+  add_compile_options(-Wno-psabi)
 endif()
 
-if(${CONFIG_CXX_STANDARD})
-  string(APPEND ARCHCXXFLAGS " -std=${CONFIG_CXX_STANDARD}")
+if(CONFIG_CXX_STANDARD)
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-std=${CONFIG_CXX_STANDARD}>)
 endif()
 
-if(NOT ${CONFIG_CXX_EXCEPTION})
-  string(APPEND ARCHCXXFLAGS " -fno-exceptions -fcheck-new")
+if(NOT CONFIG_CXX_EXCEPTION)
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fno-exceptions>
+                      $<$<COMPILE_LANGUAGE:CXX>:-fcheck-new>)
 endif()
 
-if(NOT ${CONFIG_CXX_RTTI})
-  string(APPEND ARCHCXXFLAGS " -fno-rtti")
+if(NOT CONFIG_CXX_RTTI)
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>)
 endif()
 
 add_link_options(-nostdlib)
@@ -175,19 +179,4 @@ if(CONFIG_ARCH_TOOLCHAIN_GNU)
   if(GCCVER EQUAL 12)
     add_link_options(-Wl,--no-warn-rwx-segments)
   endif()
-endif()
-
-if(NOT "${CMAKE_C_FLAGS}" STREQUAL "")
-  string(REGEX MATCH "${ARCHCFLAGS}" EXISTS_FLAGS "${CMAKE_C_FLAGS}")
-endif()
-if(NOT EXISTS_FLAGS)
-  set(CMAKE_ASM_FLAGS
-      "${CMAKE_ASM_FLAGS} ${ARCHCFLAGS}"
-      CACHE STRING "" FORCE)
-  set(CMAKE_C_FLAGS
-      "${CMAKE_C_FLAGS} ${ARCHCFLAGS}"
-      CACHE STRING "" FORCE)
-  set(CMAKE_CXX_FLAGS
-      "${CMAKE_CXX_FLAGS} ${ARCHCXXFLAGS}"
-      CACHE STRING "" FORCE)
 endif()

--- a/arch/arm64/src/cmake/platform.cmake
+++ b/arch/arm64/src/cmake/platform.cmake
@@ -17,17 +17,32 @@
 # the License.
 #
 # ##############################################################################
-get_directory_property(NUTTX_EXTRA_FLAGS DIRECTORY ${CMAKE_SOURCE_DIR}
-                                                   COMPILE_OPTIONS)
+get_directory_property(TOOLCHAIN_DIR_FLAGS DIRECTORY ${CMAKE_SOURCE_DIR}
+                                                     COMPILE_OPTIONS)
+
+set(NUTTX_EXTRA_FLAGS "")
+foreach(FLAG ${TOOLCHAIN_DIR_FLAGS})
+  if(NOT FLAG MATCHES "^\\$<.*>$")
+    list(APPEND NUTTX_EXTRA_FLAGS ${FLAG})
+  else()
+    string(REGEX MATCH "\\$<\\$<COMPILE_LANGUAGE:C>:(.*)>" matched ${FLAG})
+    if(matched)
+      list(APPEND NUTTX_EXTRA_FLAGS ${CMAKE_MATCH_1})
+    endif()
+  endif()
+endforeach()
+
+separate_arguments(CMAKE_C_FLAG_ARGS NATIVE_COMMAND ${CMAKE_C_FLAGS})
+
 execute_process(
-  COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS} ${NUTTX_EXTRA_FLAGS}
+  COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
           --print-libgcc-file-name
   OUTPUT_STRIP_TRAILING_WHITESPACE
   OUTPUT_VARIABLE extra_library)
 list(APPEND EXTRA_LIB ${extra_library})
 if(NOT CONFIG_LIBM)
   execute_process(
-    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS} ${NUTTX_EXTRA_FLAGS}
+    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
             --print-file-name=libm.a
     OUTPUT_STRIP_TRAILING_WHITESPACE
     OUTPUT_VARIABLE extra_library)
@@ -35,7 +50,7 @@ if(NOT CONFIG_LIBM)
 endif()
 if(CONFIG_LIBSUPCXX)
   execute_process(
-    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS} ${NUTTX_EXTRA_FLAGS}
+    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
             --print-file-name=libsupc++.a
     OUTPUT_STRIP_TRAILING_WHITESPACE
     OUTPUT_VARIABLE extra_library)
@@ -43,12 +58,13 @@ if(CONFIG_LIBSUPCXX)
 endif()
 if(CONFIG_ARCH_COVERAGE)
   execute_process(
-    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS} ${NUTTX_EXTRA_FLAGS}
+    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
             --print-file-name=libgcov.a
     OUTPUT_STRIP_TRAILING_WHITESPACE
     OUTPUT_VARIABLE extra_library)
   list(APPEND EXTRA_LIB ${extra_library})
 endif()
-set_property(GLOBAL APPEND PROPERTY NUTTX_EXTRA_LIBRARIES ${EXTRA_LIB})
-separate_arguments(CMAKE_C_FLAG_ARGS NATIVE_COMMAND ${CMAKE_C_FLAGS})
+
+nuttx_add_extra_library(${EXTRA_LIB})
+
 set(PREPROCES ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} -E -P -x c)

--- a/arch/risc-v/src/cmake/Toolchain.cmake
+++ b/arch/risc-v/src/cmake/Toolchain.cmake
@@ -150,31 +150,34 @@ if(CONFIG_ARCH_COVERAGE)
   add_compile_options(-fprofile-generate -ftest-coverage)
 endif()
 
-set(ARCHCFLAGS
-    "-Wstrict-prototypes -fno-common -Wall -Wshadow -Wundef -Wno-attributes -Wno-unknown-pragmas"
-)
-set(ARCHCXXFLAGS
-    "-fno-common -Wall -Wshadow -Wundef -Wno-attributes -Wno-unknown-pragmas")
+add_compile_options(
+  -fno-common
+  -Wall
+  -Wshadow
+  -Wundef
+  -Wno-attributes
+  -Wno-unknown-pragmas
+  $<$<COMPILE_LANGUAGE:C>:-Wstrict-prototypes>)
 
 if(NOT CONFIG_LIBCXXTOOLCHAIN)
-  set(ARCHCXXFLAGS "${ARCHCXXFLAGS} -nostdinc++")
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-nostdinc++>)
 endif()
 
 if(NOT ${CONFIG_ARCH_TOOLCHAIN_CLANG})
-  string(APPEND ARCHCFLAGS " -Wno-psabi")
-  string(APPEND ARCHCXXFLAGS " -Wno-psabi")
+  add_compile_options(-Wno-psabi)
 endif()
 
-if(${CONFIG_CXX_STANDARD})
-  string(APPEND ARCHCXXFLAGS " -std=${CONFIG_CXX_STANDARD}")
+if(CONFIG_CXX_STANDARD)
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-std=${CONFIG_CXX_STANDARD}>)
 endif()
 
-if(NOT ${CONFIG_CXX_EXCEPTION})
-  string(APPEND ARCHCXXFLAGS " -fno-exceptions -fcheck-new")
+if(NOT CONFIG_CXX_EXCEPTION)
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fno-exceptions>
+                      $<$<COMPILE_LANGUAGE:CXX>:-fcheck-new>)
 endif()
 
-if(NOT ${CONFIG_CXX_RTTI})
-  string(APPEND ARCHCXXFLAGS " -fno-rtti")
+if(NOT CONFIG_CXX_RTTI)
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>)
 endif()
 
 if(CONFIG_ARCH_RV32)
@@ -198,22 +201,6 @@ endif()
 
 if(CONFIG_DEBUG_SYMBOLS)
   add_compile_options(-g)
-endif()
-
-if(NOT "${CMAKE_C_FLAGS}" STREQUAL "")
-  string(REGEX MATCH "${ARCHCFLAGS}" EXISTS_FLAGS "${CMAKE_C_FLAGS}")
-endif()
-
-if(NOT EXISTS_FLAGS)
-  set(CMAKE_ASM_FLAGS
-      "${CMAKE_ASM_FLAGS} ${ARCHCFLAGS}"
-      CACHE STRING "" FORCE)
-  set(CMAKE_C_FLAGS
-      "${CMAKE_C_FLAGS} ${ARCHCFLAGS}"
-      CACHE STRING "" FORCE)
-  set(CMAKE_CXX_FLAGS
-      "${CMAKE_CXX_FLAGS} ${ARCHCXXFLAGS}"
-      CACHE STRING "" FORCE)
 endif()
 
 # Generic GNU RVG toolchain

--- a/arch/risc-v/src/cmake/platform.cmake
+++ b/arch/risc-v/src/cmake/platform.cmake
@@ -18,8 +18,20 @@
 #
 # ##############################################################################
 
-get_directory_property(NUTTX_EXTRA_FLAGS DIRECTORY ${CMAKE_SOURCE_DIR}
-                                                   COMPILE_OPTIONS)
+get_directory_property(TOOLCHAIN_DIR_FLAGS DIRECTORY ${CMAKE_SOURCE_DIR}
+                                                     COMPILE_OPTIONS)
+
+set(NUTTX_EXTRA_FLAGS "")
+foreach(FLAG ${TOOLCHAIN_DIR_FLAGS})
+  if(NOT FLAG MATCHES "^\\$<.*>$")
+    list(APPEND NUTTX_EXTRA_FLAGS ${FLAG})
+  else()
+    string(REGEX MATCH "\\$<\\$<COMPILE_LANGUAGE:C>:(.*)>" matched ${FLAG})
+    if(matched)
+      list(APPEND NUTTX_EXTRA_FLAGS ${CMAKE_MATCH_1})
+    endif()
+  endif()
+endforeach()
 
 separate_arguments(CMAKE_C_FLAG_ARGS NATIVE_COMMAND ${CMAKE_C_FLAGS})
 

--- a/arch/sim/src/cmake/Toolchain.cmake
+++ b/arch/sim/src/cmake/Toolchain.cmake
@@ -98,32 +98,17 @@ if(CONFIG_CXX_STANDARD)
   add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-std=${CONFIG_CXX_STANDARD}>)
 endif()
 
-set(ARCHCFLAGS "-Wstrict-prototypes")
+add_compile_options($<$<COMPILE_LANGUAGE:C>:-Wstrict-prototypes>)
 
 if(NOT CONFIG_LIBCXXTOOLCHAIN)
-  set(ARCHCXXFLAGS "${ARCHCXXFLAGS} -nostdinc++")
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-nostdinc++>)
 endif()
 
 if(NOT CONFIG_CXX_EXCEPTION)
-  string(APPEND ARCHCXXFLAGS " -fno-exceptions -fcheck-new")
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fno-exceptions>
+                      $<$<COMPILE_LANGUAGE:CXX>:-fcheck-new>)
 endif()
 
 if(NOT CONFIG_CXX_RTTI)
-  string(APPEND ARCHCXXFLAGS " -fno-rtti")
-endif()
-
-if(NOT "${CMAKE_C_FLAGS}" STREQUAL "")
-  string(REGEX MATCH "${ARCHCFLAGS}" EXISTS_FLAGS "${CMAKE_C_FLAGS}")
-endif()
-
-if(NOT EXISTS_FLAGS)
-  set(CMAKE_ASM_FLAGS
-      "${CMAKE_ASM_FLAGS}${ARCHCFLAGS}"
-      CACHE STRING "" FORCE)
-  set(CMAKE_C_FLAGS
-      "${CMAKE_C_FLAGS}${ARCHCFLAGS}"
-      CACHE STRING "" FORCE)
-  set(CMAKE_CXX_FLAGS
-      "${CMAKE_CXX_FLAGS}${ARCHCXXFLAGS}"
-      CACHE STRING "" FORCE)
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>)
 endif()

--- a/arch/x86_64/src/cmake/Toolchain.cmake
+++ b/arch/x86_64/src/cmake/Toolchain.cmake
@@ -85,38 +85,35 @@ if(CONFIG_DEBUG_LINK_MAP)
   add_link_options(-Wl,--cref -Wl,-Map=nuttx.map)
 endif()
 
-set(ARCHCFLAGS
-    "-Wstrict-prototypes -fno-common -Wall -Wshadow -Wundef -Wno-attributes -Wno-unknown-pragmas"
-)
-set(ARCHCXXFLAGS
-    "-fno-common -Wall -Wshadow -Wundef -Wno-attributes -Wno-unknown-pragmas")
+add_compile_options(
+  -fno-common
+  -Wall
+  -Wshadow
+  -Wundef
+  -Wno-attributes
+  -Wno-unknown-pragmas
+  $<$<COMPILE_LANGUAGE:C>:-Wstrict-prototypes>)
+
+if(CONFIG_CXX_STANDARD)
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-std=${CONFIG_CXX_STANDARD}>)
+endif()
 
 if(NOT CONFIG_LIBCXXTOOLCHAIN)
-  set(ARCHCXXFLAGS "${ARCHCXXFLAGS} -nostdinc++")
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-nostdinc++>)
 endif()
 
 if(NOT CONFIG_CXX_EXCEPTION)
-  string(APPEND ARCHCXXFLAGS " -fno-exceptions -fcheck-new")
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fno-exceptions>
+                      $<$<COMPILE_LANGUAGE:CXX>:-fcheck-new>)
 endif()
 
 if(NOT CONFIG_CXX_RTTI)
-  string(APPEND ARCHCXXFLAGS " -fno-rtti")
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>)
 endif()
 
-if(NOT "${CMAKE_C_FLAGS}" STREQUAL "")
-  string(REGEX MATCH "${ARCHCFLAGS}" EXISTS_FLAGS "${CMAKE_C_FLAGS}")
-endif()
-
-if(NOT EXISTS_FLAGS)
-  set(CMAKE_ASM_FLAGS
-      "${CMAKE_ASM_FLAGS} ${ARCHCFLAGS}"
-      CACHE STRING "" FORCE)
-  set(CMAKE_C_FLAGS
-      "${CMAKE_C_FLAGS} ${ARCHCFLAGS}"
-      CACHE STRING "" FORCE)
-  set(CMAKE_CXX_FLAGS
-      "${CMAKE_CXX_FLAGS} ${ARCHCXXFLAGS}"
-      CACHE STRING "" FORCE)
+if(CONFIG_DEBUG_OPT_UNUSED_SECTIONS)
+  add_link_options(-Wl,--gc-sections)
+  add_compile_options(-ffunction-sections -fdata-sections)
 endif()
 
 if(CONFIG_ARCH_INTEL64_HAVE_RDRAND)

--- a/arch/x86_64/src/cmake/platform.cmake
+++ b/arch/x86_64/src/cmake/platform.cmake
@@ -18,8 +18,20 @@
 #
 # ##############################################################################
 
-get_directory_property(NUTTX_EXTRA_FLAGS DIRECTORY ${CMAKE_SOURCE_DIR}
-                                                   COMPILE_OPTIONS)
+get_directory_property(TOOLCHAIN_DIR_FLAGS DIRECTORY ${CMAKE_SOURCE_DIR}
+                                                     COMPILE_OPTIONS)
+
+set(NUTTX_EXTRA_FLAGS "")
+foreach(FLAG ${TOOLCHAIN_DIR_FLAGS})
+  if(NOT FLAG MATCHES "^\\$<.*>$")
+    list(APPEND NUTTX_EXTRA_FLAGS ${FLAG})
+  else()
+    string(REGEX MATCH "\\$<\\$<COMPILE_LANGUAGE:C>:(.*)>" matched ${FLAG})
+    if(matched)
+      list(APPEND NUTTX_EXTRA_FLAGS ${CMAKE_MATCH_1})
+    endif()
+  endif()
+endforeach()
 
 execute_process(
   COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS} ${NUTTX_EXTRA_FLAGS}


### PR DESCRIPTION

## Summary
### Issue
> [!CAUTION]
> when repeatedly enabling and disabling string-controlled configurations, 
> the generated toolchain configuration may be incorrect.

```bash
# init a cxx config
cmake -B build -DBOARD_CONFIG=some-config-disable-cxx-exception
# menuconfig enable CONFIG_CXX_EXCEPTION
cmake --build build -t menuconfig
# re build or re menuconfig
cmake --build build
```
> [!NOTE]  
>  Initialization compilation configuration 
> ![ebf3c9a9-117a-4923-9e87-5b2c7c7b79cd](https://github.com/apache/nuttx/assets/31881278/152cb3c9-343d-471f-9a34-dbb36b01a65e)



> [!WARNING]  
> After the modification
> we can tell that it has not taken effect
> ![56fc9334-ecde-4776-8cf0-deeb5022f55b](https://github.com/apache/nuttx/assets/31881278/29242f0d-4c42-45a2-a8f4-c96ebde70d6e)


### Reason

I found that this was because the compilation options we used **STRINGS** to control in the `Toolchain file` did not work as expected.

### Solution

I plan to remove all **String-controlled** compile options and call `add_compile_options()` instead. 
for the toolchain linked library that needs to be found in the `platform.cmake`, the `execute_process` command is executed in the `congfigure` stage. at this time, the generator expression will not be parsed. 
so i use the currently configured options and regex parse the generator expression.

## Impact

## Testing
CI build
