### PR TITLE
arch/xmc4 vadc driver - background request source partial support

### DIFF
--- a/arch/arm/src/xmc4/hardware/xmc4_memorymap.h
+++ b/arch/arm/src/xmc4/hardware/xmc4_memorymap.h
@@ -47,7 +47,9 @@
  *
  ****************************************************************************/
 
-/* Reference: XMC4500 Reference Manual V1.5 2014-07 Microcontrollers. */
+/* Reference: XMC4500 Reference Manual V1.5 2014-07 Microcontrollers.
+ * This memory map is valid for both XMC45 and XMC4[78] architecture
+ */
 
 #ifndef __ARCH_ARM_SRC_XMC4_HARDWARE_XMC4_MEMORYMAP_H
 #define __ARCH_ARM_SRC_XMC4_HARDWARE_XMC4_MEMORYMAP_H
@@ -223,7 +225,7 @@
 #define XMC4_USB0_EP4_BASE          0x50040980
 #define XMC4_USB0_EP5_BASE          0x500409a0
 #define XMC4_USB0_EP6_BASE          0x500409c0
-#define XMC4_ECAT0_BASE             0x50100000 /* ECAT0 */
+#define XMC4_ECAT0_BASE             0x54010000 /* ECAT0 (XMC4[78] specific) */
 
 #define XMC4_PMU0_BASE              0x58000000 /* PMU0 registers */
 #define XMC4_FLASH0_BASE            0x58001000

--- a/arch/arm/src/xmc4/hardware/xmc4_vadc.h
+++ b/arch/arm/src/xmc4/hardware/xmc4_vadc.h
@@ -1,0 +1,1074 @@
+/******************************************************************************************************************
+ * arch/arm/src/xmc4/hardware/xmc4_vadc.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * May include some logic from sample code provided by Infineon:
+ *
+ * Copyright (C) 2011-2015 Infineon Technologies AG. All rights reserved.
+ *
+ * Infineon Technologies AG (Infineon) is supplying this software for use
+ * with Infineon's microcontrollers.  This file can be freely distributed
+ * within development tools that are supporting such microcontrollers.
+ *
+ * THIS SOFTWARE IS PROVIDED AS IS. NO WARRANTIES, WHETHER EXPRESS,
+ * IMPLIED OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS
+ * SOFTWARE. INFINEON SHALL NOT, IN ANY CIRCUMSTANCES, BE LIABLE FOR
+ * SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, FOR ANY REASON WHATSOEVER.
+ *
+ ******************************************************************************************************************/
+
+/* Reference: XMC4[78]00 Reference Manual V1.3 2016-07 Microcontrollers.
+ * Reference: XMC4500 Reference Manual V1.5 2014-07 Microcontrollers.
+ */
+
+#ifndef __ARCH_ARM_SRC_XMC4_HARDWARE_XMC4_VADC_H
+#define __ARCH_ARM_SRC_XMC4_HARDWARE_XMC4_VADC_H
+
+/******************************************************************************************************************
+ * Included Files
+ ******************************************************************************************************************/
+
+#include <nuttx/config.h>
+#include "hardware/xmc4_memorymap.h"
+
+#include <stdint.h>
+
+/******************************************************************************************************************
+ * Preprocessor Definitions
+ ******************************************************************************************************************/
+
+/* Define XMC4[78] and XMC45 series VADC module specifications */
+
+#if defined(CONFIG_ARCH_CHIP_XMC4700) || defined(CONFIG_ARCH_CHIP_XMC4800)
+#   define XMC_VADC_BOUNDARY_FLAG_SELECT    (1U) /*  Defines the availability of boundary flags in a device*/
+#   define XMC_VADC_EMUX_CH_SEL_STYLE       (1U) /*  Defines the external multiplexer channel selection mode of
+                                                  *  operation for a particular device */
+#   define XMC_VADC_GROUP_SRCREG_AVAILABLE  (1U) /*  Define the availability of a source specific result register */
+#elif defined(CONFIG_ARCH_CHIP_XMC4500)
+#   define XMC_VADC_BOUNDARY_FLAG_SELECT    (0U) /*  Defines the availability of boundary flags in a device*/
+#   define XMC_VADC_EMUX_CH_SEL_STYLE       (0U) /*  Defines the external multiplexer channel selection mode of
+                                                  *  operation for a particular device */
+#   define XMC_VADC_GROUP_SRCREG_AVAILABLE  (0U) /*  Define the availability of a source specific result register */
+#else
+#  error "Unsupported XMC4xxx chip"
+#endif
+
+#define XMC_VADC_MAXIMUM_NUM_GROUPS      (4U)  /* Defines the maximum number of groups available in a device */
+#define XMC_VADC_NUM_RESULT_REGISTERS    (16U) /* Defines the number of result holding registers per ADC group */
+#define XMC_VADC_NUM_CHANNELS_PER_GROUP  (8U)  /* Defines the number of ADC channels per group */
+
+/* Register Offsets */
+
+/* Structures to handle VADC global registers */
+
+typedef struct                                   /* (@ 0x40004000) VADC Structure */
+{
+  volatile uint32_t  CLC;                        /* (@ 0x40004000) Clock Control Register */
+  volatile uint32_t  RESERVED;
+  volatile uint32_t  ID;                         /* (@ 0x40004008) Module Identification Register */
+  volatile uint32_t  RESERVED1[7];
+  volatile uint32_t  OCS;                        /* (@ 0x40004028) OCDS Control and Status Register */
+  volatile uint32_t  RESERVED2[21];
+  volatile uint32_t  GLOBCFG;                    /* (@ 0x40004080) Global Configuration Register */
+  volatile uint32_t  RESERVED3[7];
+  volatile uint32_t  GLOBICLASS[2];              /* (@ 0x400040A0) Input Class Register, Global */
+  volatile uint32_t  RESERVED4[4];
+  volatile uint32_t  GLOBBOUND;                  /* (@ 0x400040B8) Global Boundary Select Register */
+  volatile uint32_t  RESERVED5[9];
+  volatile uint32_t  GLOBEFLAG;                  /* (@ 0x400040E0) Global Event Flag Register */
+  volatile uint32_t  RESERVED6[23];
+  volatile uint32_t  GLOBEVNP;                   /* (@ 0x40004140) Global Event Node Pointer Register */
+  volatile uint32_t  RESERVED7[7];
+  volatile uint32_t  GLOBTF;                     /* (@ 0x40004160) Global Test Functions Register */
+  volatile uint32_t  RESERVED8[7];
+  volatile uint32_t  BRSSEL[4];                  /* (@ 0x40004180) Background Request Source Channel Select Register */
+  volatile uint32_t  RESERVED9[12];
+  volatile uint32_t  BRSPND[4];                  /* (@ 0x400041C0) Background Request Source Pending Register */
+  volatile uint32_t  RESERVED10[12];
+  volatile uint32_t  BRSCTRL;                    /* (@ 0x40004200) Background Request Source Control Register */
+  volatile uint32_t  BRSMR;                      /* (@ 0x40004204) Background Request Source Mode Register */
+  volatile uint32_t  RESERVED11[30];
+  volatile uint32_t  GLOBRCR;                    /* (@ 0x40004280) Global Result Control Register */
+  volatile uint32_t  RESERVED12[31];
+  volatile uint32_t  GLOBRES;                    /* (@ 0x40004300) Global Result Register */
+  volatile uint32_t  RESERVED13[31];
+  volatile uint32_t  GLOBRESD;                   /* (@ 0x40004380) Global Result Register, Debug */
+  volatile uint32_t  RESERVED14[27];
+  volatile uint32_t  EMUXSEL;                    /* (@ 0x400043F0) External Multiplexer Select Register */
+} vadc_global_t;
+
+/* Structures to handle VADC groups registers */
+
+typedef struct                                   /* (@ 0x40004400) */
+{
+  volatile uint32_t  RESERVED[32];
+  volatile uint32_t  ARBCFG;                     /* (@ 0x40004480) Arbitration Configuration Register */
+  volatile uint32_t  ARBPR;                      /* (@ 0x40004484) Arbitration Priority Register */
+  volatile uint32_t  CHASS;                      /* (@ 0x40004488) Channel Assignment Register */
+  volatile uint32_t  RESERVED1[5];
+  volatile uint32_t  ICLASS[2];                  /* (@ 0x400044A0) Input Class Register */
+  volatile uint32_t  RESERVED2[2];
+  volatile uint32_t  ALIAS;                      /* (@ 0x400044B0) Alias Register */
+  volatile uint32_t  RESERVED3;
+  volatile uint32_t  BOUND;                      /* (@ 0x400044B8) Boundary Select Register */
+  volatile uint32_t  RESERVED4;
+  volatile uint32_t  SYNCTR;                     /* (@ 0x400044C0) Synchronization Control Register */
+  volatile uint32_t  RESERVED5;
+  volatile uint32_t  BFL;                        /* (@ 0x400044C8) Boundary Flag Register */
+  #if defined(CONFIG_ARCH_CHIP_XMC4700) || defined(CONFIG_ARCH_CHIP_XMC4800)
+    volatile uint32_t  BFLS;                     /* (@ 0x400044CC) Boundary Flag Software Register */
+    volatile uint32_t  BFLC;                     /* (@ 0x400044D0) Boundary Flag Control Register */
+    volatile uint32_t  BFLNP;                    /* (@ 0x400044D4) Boundary Flag Node Pointer Register */
+    volatile uint32_t  RESERVED6[10];
+  #elif defined(CONFIG_ARCH_CHIP_XMC4500)
+    volatile uint32_t  RESERVED6[13];
+  #endif
+  volatile uint32_t  QCTRL0;                     /* (@ 0x40004500) Queue 0 Source Control Register */
+  volatile uint32_t  QMR0;                       /* (@ 0x40004504) Queue 0 Mode Register */
+  volatile uint32_t  QSR0;                       /* (@ 0x40004508) Queue 0 Status Register */
+  volatile uint32_t  Q0R0;                       /* (@ 0x4000450C) Queue 0 Register 0 */
+
+  union
+  {
+    volatile uint32_t  QBUR0;                    /* (@ 0x40004510) Queue 0 Backup Register */
+    volatile uint32_t  QINR0;                    /* (@ 0x40004510) Queue 0 Input Register */
+  };
+
+  volatile uint32_t  RESERVED7[3];
+  volatile uint32_t  ASCTRL;                     /* (@ 0x40004520) Autoscan Source Control Register */
+  volatile uint32_t  ASMR;                       /* (@ 0x40004524) Autoscan Source Mode Register */
+  volatile uint32_t  ASSEL;                      /* (@ 0x40004528) Autoscan Source Channel Select Register */
+  volatile uint32_t  ASPND;                      /* (@ 0x4000452C) Autoscan Source Pending Register */
+  volatile uint32_t  RESERVED8[20];
+  volatile uint32_t  CEFLAG;                     /* (@ 0x40004580) Channel Event Flag Register */
+  volatile uint32_t  REFLAG;                     /* (@ 0x40004584) Result Event Flag Register */
+  volatile uint32_t  SEFLAG;                     /* (@ 0x40004588) Source Event Flag Register */
+  volatile uint32_t  RESERVED9;
+  volatile uint32_t  CEFCLR;                     /* (@ 0x40004590) Channel Event Flag Clear Register */
+  volatile uint32_t  REFCLR;                     /* (@ 0x40004594) Result Event Flag Clear Register */
+  volatile uint32_t  SEFCLR;                     /* (@ 0x40004598) Source Event Flag Clear Register */
+  volatile uint32_t  RESERVED10;
+  volatile uint32_t  CEVNP0;                     /* (@ 0x400045A0) Channel Event Node Pointer Register 0 */
+  volatile uint32_t  RESERVED11[3];
+  volatile uint32_t  REVNP0;                     /* (@ 0x400045B0) Result Event Node Pointer Register 0 */
+  volatile uint32_t  REVNP1;                     /* (@ 0x400045B4) Result Event Node Pointer Register 1 */
+  volatile uint32_t  RESERVED12[2];
+  volatile uint32_t  SEVNP;                      /* (@ 0x400045C0) Source Event Node Pointer Register */
+  volatile uint32_t  RESERVED13;
+  volatile uint32_t  SRACT;                      /* (@ 0x400045C8) Service Request Software Activation Trigger */
+  volatile uint32_t  RESERVED14[9];
+  volatile uint32_t  EMUXCTR;                    /* (@ 0x400045F0) E0ternal Multiplexer Control Register */
+  volatile uint32_t  RESERVED15;
+  volatile uint32_t  VFR;                        /* (@ 0x400045F8) Valid Flag Register */
+  volatile uint32_t  RESERVED16;
+  volatile uint32_t  CHCTR[8];                   /* (@ 0x40004600) Channel Ctrl. Reg */
+  volatile uint32_t  RESERVED17[24];
+  volatile uint32_t  RCR[16];                    /* (@ 0x40004680) Result Control Register */
+  volatile uint32_t  RESERVED18[16];
+  volatile uint32_t  RES[16];                    /* (@ 0x40004700) Result Register */
+  volatile uint32_t  RESERVED19[16];
+  volatile uint32_t  RESD[16];                   /* (@ 0x40004780) Result Register, Debug */
+} vadc_group_t;
+
+/* Define pointers for VADC global and group stuctures */
+#define VADC      ((vadc_global_t *) XMC4_VADC_BASE)
+#define VADC_G0   ((vadc_group_t *) XMC4_VADC_G0_BASE)
+#define VADC_G1   ((vadc_group_t *) XMC4_VADC_G1_BASE)
+#define VADC_G2   ((vadc_group_t *) XMC4_VADC_G2_BASE)
+#define VADC_G3   ((vadc_group_t *) XMC4_VADC_G3_BASE)
+
+/* Register Bit-Field Definitions */
+
+/* ----------------------------------  VADC_CLC  ---------------------------------- */
+#define VADC_CLC_DISR_SHIFT                     (0UL)
+#define VADC_CLC_DISR_MASK                      (0x1 << VADC_CLC_DISR_SHIFT)
+#define VADC_CLC_DISS_SHIFT                     (2UL)
+#define VADC_CLC_DISS_MASK                      (0x1 << VADC_CLC_DISS_SHIFT)
+#define VADC_CLC_EDIS_SHIFT                     (3UL)
+#define VADC_CLC_EDIS_MASK                      (0x1 << VADC_CLC_EDIS_SHIFT)
+
+/* -----------------------------------  VADC_ID  ---------------------------------- */
+#define VADC_ID_MOD_REV_MASK                    (0xff << VADC_ID_MOD_REV_SHIFT)
+#define VADC_ID_MOD_TYPE_SHIFT                  (8UL)
+#define VADC_ID_MOD_TYPE_MASK                   (0xff << VADC_ID_MOD_TYPE_SHIFT)
+#define VADC_ID_MOD_REV_SHIFT                   (0UL)
+#define VADC_ID_MOD_NUMBER_SHIFT                (16UL)
+#define VADC_ID_MOD_NUMBER_MASK                 (0xffff << VADC_ID_MOD_NUMBER_SHIFT)
+
+/* ----------------------------------  VADC_OCS  ---------------------------------- */
+#define VADC_OCS_TGS_SHIFT                      (0UL)
+#define VADC_OCS_TGS_MASK                       (0x3 << VADC_OCS_TGS_SHIFT)
+#define VADC_OCS_TGB_SHIFT                      (2UL)
+#define VADC_OCS_TGB_MASK                       (0x1 << VADC_OCS_TGB_SHIFT)
+#define VADC_OCS_TG_P_SHIFT                     (3UL)
+#define VADC_OCS_TG_P_MASK                      (0x1 << VADC_OCS_TG_P_SHIFT)
+#define VADC_OCS_SUS_SHIFT                      (24UL)
+#define VADC_OCS_SUS_MASK                       (0xf << VADC_OCS_SUS_SHIFT)
+#define VADC_OCS_SUS_P_SHIFT                    (28UL)
+#define VADC_OCS_SUS_P_MASK                     (0x1 << VADC_OCS_SUS_P_SHIFT)
+#define VADC_OCS_SUSSTA_SHIFT                   (29UL)
+#define VADC_OCS_SUSSTA_MASK                    (0x1 << VADC_OCS_SUSSTA_SHIFT)
+
+/* --------------------------------  VADC_GLOBCFG  -------------------------------- */
+#define VADC_GLOBCFG_DIVA_SHIFT                 (0UL)
+#define VADC_GLOBCFG_DIVA_MASK                  (0x1f << VADC_GLOBCFG_DIVA_SHIFT)
+#define VADC_GLOBCFG_DCMSB_SHIFT                (7UL)
+#define VADC_GLOBCFG_DCMSB_MASK                 (0x1 << VADC_GLOBCFG_DCMSB_SHIFT)
+#define VADC_GLOBCFG_DIVD_SHIFT                 (8UL)
+#define VADC_GLOBCFG_DIVD_MASK                  (0x3 << VADC_GLOBCFG_DIVD_SHIFT)
+#define VADC_GLOBCFG_DIVWC_SHIFT                (15UL)
+#define VADC_GLOBCFG_DIVWC_MASK                 (0x1 << VADC_GLOBCFG_DIVWC_SHIFT)
+#define VADC_GLOBCFG_DPCAL0_SHIFT               (16UL)
+#define VADC_GLOBCFG_DPCAL0_MASK                (0x1 << VADC_GLOBCFG_DPCAL0_SHIFT)
+#define VADC_GLOBCFG_DPCAL1_SHIFT               (17UL)
+#define VADC_GLOBCFG_DPCAL1_MASK                (0x1 << VADC_GLOBCFG_DPCAL1_SHIFT)
+#define VADC_GLOBCFG_DPCAL2_SHIFT               (18UL)
+#define VADC_GLOBCFG_DPCAL2_MASK                (0x1 << VADC_GLOBCFG_DPCAL2_SHIFT)
+#define VADC_GLOBCFG_DPCAL3_SHIFT               (19UL)
+#define VADC_GLOBCFG_DPCAL3_MASK                (0x1 << VADC_GLOBCFG_DPCAL3_SHIFT)
+#define VADC_GLOBCFG_SUCAL_SHIFT                (31UL)
+#define VADC_GLOBCFG_SUCAL_MASK                 (0x1 << VADC_GLOBCFG_SUCAL_SHIFT)
+
+/* -------------------------------  VADC_GLOBICLASS  ------------------------------ */
+#define VADC_GLOBICLASS_STCS_MASK               (0x1f << VADC_GLOBICLASS_STCS_SHIFT)
+#define VADC_GLOBICLASS_CMS_SHIFT               (8UL)
+#define VADC_GLOBICLASS_STCS_SHIFT              (0UL)
+#define VADC_GLOBICLASS_CMS_MASK                (0x7 << VADC_GLOBICLASS_CMS_SHIFT)
+#define VADC_GLOBICLASS_STCE_SHIFT              (16UL)
+#define VADC_GLOBICLASS_STCE_MASK               (0x1f << VADC_GLOBICLASS_STCE_SHIFT)
+#define VADC_GLOBICLASS_CME_SHIFT               (24UL)
+#define VADC_GLOBICLASS_CME_MASK                (0x7 << VADC_GLOBICLASS_CME_SHIFT)
+
+/* -------------------------------  VADC_GLOBBOUND  ------------------------------- */
+#define VADC_GLOBBOUND_BOUNDARY0_SHIFT          (0UL)
+#define VADC_GLOBBOUND_BOUNDARY0_MASK           (0xfff << VADC_GLOBBOUND_BOUNDARY0_SHIFT)
+#define VADC_GLOBBOUND_BOUNDARY1_SHIFT          (16UL)
+#define VADC_GLOBBOUND_BOUNDARY1_MASK           (0xfff << VADC_GLOBBOUND_BOUNDARY1_SHIFT)
+
+/* -------------------------------  VADC_GLOBEFLAG  ------------------------------- */
+#define VADC_GLOBEFLAG_SEVGLB_SHIFT             (0UL)
+#define VADC_GLOBEFLAG_SEVGLB_MASK              (0x1 << VADC_GLOBEFLAG_SEVGLB_SHIFT)
+#define VADC_GLOBEFLAG_REVGLB_SHIFT             (8UL)
+#define VADC_GLOBEFLAG_REVGLB_MASK              (0x1 << VADC_GLOBEFLAG_REVGLB_SHIFT)
+#define VADC_GLOBEFLAG_SEVGLBCLR_SHIFT          (16UL)
+#define VADC_GLOBEFLAG_SEVGLBCLR_MASK           (0x1 << VADC_GLOBEFLAG_SEVGLBCLR_SHIFT)
+#define VADC_GLOBEFLAG_REVGLBCLR_SHIFT          (24UL)
+#define VADC_GLOBEFLAG_REVGLBCLR_MASK           (0x1 << VADC_GLOBEFLAG_REVGLBCLR_SHIFT)
+
+/* --------------------------------  VADC_GLOBEVNP  ------------------------------- */
+#define VADC_GLOBEVNP_SEV0NP_SHIFT              (0UL)
+#define VADC_GLOBEVNP_SEV0NP_MASK               (0xf << VADC_GLOBEVNP_SEV0NP_SHIFT)
+#define VADC_GLOBEVNP_REV0NP_SHIFT              (16UL)
+#define VADC_GLOBEVNP_REV0NP_MASK               (0xf << VADC_GLOBEVNP_REV0NP_SHIFT)
+
+/* ---------------------------------  VADC_GLOBTF  -------------------------------- */
+#define VADC_GLOBTF_CDGR_SHIFT                  (4UL)
+#define VADC_GLOBTF_CDGR_MASK                   (0xf << VADC_GLOBTF_CDGR_SHIFT)
+#define VADC_GLOBTF_CDEN_SHIFT                  (8UL)
+#define VADC_GLOBTF_CDEN_MASK                   (0x1 << VADC_GLOBTF_CDEN_SHIFT)
+#define VADC_GLOBTF_CDSEL_SHIFT                 (9UL)
+#define VADC_GLOBTF_CDSEL_MASK                  (0x3 << VADC_GLOBTF_CDSEL_SHIFT)
+#define VADC_GLOBTF_CDWC_SHIFT                  (15UL)
+#define VADC_GLOBTF_CDWC_MASK                   (0x1 << VADC_GLOBTF_CDWC_SHIFT)
+#define VADC_GLOBTF_PDD_SHIFT                   (16UL)
+#define VADC_GLOBTF_PDD_MASK                    (0x1 << VADC_GLOBTF_PDD_SHIFT)
+#define VADC_GLOBTF_MDWC_SHIFT                  (23UL)
+#define VADC_GLOBTF_MDWC_MASK                   (0x1 << VADC_GLOBTF_MDWC_SHIFT)
+
+/* ---------------------------------  VADC_BRSSELx  -------------------------------- */
+#define VADC_BRSSEL_CHSELG0_SHIFT               (0UL)
+#define VADC_BRSSEL_CHSELG0_MASK                (0x1 << VADC_BRSSEL_CHSELG0_SHIFT)
+#define VADC_BRSSEL_CHSELG1_SHIFT               (1UL)
+#define VADC_BRSSEL_CHSELG1_MASK                (0x1 << VADC_BRSSEL_CHSELG1_SHIFT)
+#define VADC_BRSSEL_CHSELG2_SHIFT               (2UL)
+#define VADC_BRSSEL_CHSELG2_MASK                (0x1 << VADC_BRSSEL_CHSELG2_SHIFT)
+#define VADC_BRSSEL_CHSELG3_SHIFT               (3UL)
+#define VADC_BRSSEL_CHSELG3_MASK                (0x1 << VADC_BRSSEL_CHSELG3_SHIFT)
+#define VADC_BRSSEL_CHSELG4_SHIFT               (4UL)
+#define VADC_BRSSEL_CHSELG4_MASK                (0x1 << VADC_BRSSEL_CHSELG4_SHIFT)
+#define VADC_BRSSEL_CHSELG5_SHIFT               (5UL)
+#define VADC_BRSSEL_CHSELG5_MASK                (0x1 << VADC_BRSSEL_CHSELG5_SHIFT)
+#define VADC_BRSSEL_CHSELG6_SHIFT               (6UL)
+#define VADC_BRSSEL_CHSELG6_MASK                (0x1 << VADC_BRSSEL_CHSELG6_SHIFT)
+#define VADC_BRSSEL_CHSELG7_SHIFT               (7UL)
+#define VADC_BRSSEL_CHSELG7_MASK                (0x1 << VADC_BRSSEL_CHSELG7_SHIFT)
+
+/* ---------------------------------  VADC_BRSPNDx  -------------------------------- */
+#define VADC_BRSPND_CHPNDG0_SHIFT               (0UL)
+#define VADC_BRSPND_CHPNDG0_MASK                (0x1 << VADC_BRSPND_CHPNDG0_SHIFT)
+#define VADC_BRSPND_CHPNDG1_SHIFT               (1UL)
+#define VADC_BRSPND_CHPNDG1_MASK                (0x1 << VADC_BRSPND_CHPNDG1_SHIFT)
+#define VADC_BRSPND_CHPNDG2_SHIFT               (2UL)
+#define VADC_BRSPND_CHPNDG2_MASK                (0x1 << VADC_BRSPND_CHPNDG2_SHIFT)
+#define VADC_BRSPND_CHPNDG3_SHIFT               (3UL)
+#define VADC_BRSPND_CHPNDG3_MASK                (0x1 << VADC_BRSPND_CHPNDG3_SHIFT)
+#define VADC_BRSPND_CHPNDG4_SHIFT               (4UL)
+#define VADC_BRSPND_CHPNDG4_MASK                (0x1 << VADC_BRSPND_CHPNDG4_SHIFT)
+#define VADC_BRSPND_CHPNDG5_SHIFT               (5UL)
+#define VADC_BRSPND_CHPNDG5_MASK                (0x1 << VADC_BRSPND_CHPNDG5_SHIFT)
+#define VADC_BRSPND_CHPNDG6_SHIFT               (6UL)
+#define VADC_BRSPND_CHPNDG6_MASK                (0x1 << VADC_BRSPND_CHPNDG6_SHIFT)
+#define VADC_BRSPND_CHPNDG7_SHIFT               (7UL)
+#define VADC_BRSPND_CHPNDG7_MASK                (0x1 << VADC_BRSPND_CHPNDG7_SHIFT)
+
+/* --------------------------------  VADC_BRSCTRL  -------------------------------- */
+
+/* XMC4800 SPECIFIC */
+#if defined(CONFIG_ARCH_CHIP_XMC4700) || defined(CONFIG_ARCH_CHIP_XMC4800)
+    #define VADC_BRSCTRL_SRCRESREG_SHIFT         (0UL)
+    #define VADC_BRSCTRL_SRCRESREG_MASK          (0xf << VADC_BRSCTRL_SRCRESREG_SHIFT)
+#endif/* XMC4[78]00 SPECIFIC */
+
+#define VADC_BRSCTRL_XTSEL_SHIFT                (8UL)
+#define VADC_BRSCTRL_XTSEL_MASK                 (0xf << VADC_BRSCTRL_XTSEL_SHIFT)
+#define VADC_BRSCTRL_XTLVL_SHIFT                (12UL)
+#define VADC_BRSCTRL_XTLVL_MASK                 (0x1 << VADC_BRSCTRL_XTLVL_SHIFT)
+#define VADC_BRSCTRL_XTMODE_SHIFT               (13UL)
+#define VADC_BRSCTRL_XTMODE_MASK                (0x3 << VADC_BRSCTRL_XTMODE_SHIFT)
+#define VADC_BRSCTRL_XTWC_SHIFT                 (15UL)
+#define VADC_BRSCTRL_XTWC_MASK                  (0x1 << VADC_BRSCTRL_XTWC_SHIFT)
+#define VADC_BRSCTRL_GTSEL_SHIFT                (16UL)
+#define VADC_BRSCTRL_GTSEL_MASK                 (0xf << VADC_BRSCTRL_GTSEL_SHIFT)
+#define VADC_BRSCTRL_GTLVL_SHIFT                (20UL)
+#define VADC_BRSCTRL_GTLVL_MASK                 (0x1 << VADC_BRSCTRL_GTLVL_SHIFT)
+#define VADC_BRSCTRL_GTWC_SHIFT                 (23UL)
+#define VADC_BRSCTRL_GTWC_MASK                  (0x1 << VADC_BRSCTRL_GTWC_SHIFT)
+
+/* ---------------------------------  VADC_BRSMR  --------------------------------- */
+#define VADC_BRSMR_ENGT_SHIFT                   (0UL)
+#define VADC_BRSMR_ENGT_MASK                    (0x03 << VADC_BRSMR_ENGT_SHIFT)
+#define VADC_BRSMR_ENTR_SHIFT                   (2UL)
+#define VADC_BRSMR_ENTR_MASK                    (0x01 << VADC_BRSMR_ENTR_SHIFT)
+#define VADC_BRSMR_ENSI_SHIFT                   (3UL)
+#define VADC_BRSMR_ENSI_MASK                    (0x01 << VADC_BRSMR_ENSI_SHIFT)
+#define VADC_BRSMR_SCAN_SHIFT                   (4UL)
+#define VADC_BRSMR_SCAN_MASK                    (0x01 << VADC_BRSMR_SCAN_SHIFT)
+#define VADC_BRSMR_LDM_SHIFT                    (5UL)
+#define VADC_BRSMR_LDM_MASK                     (0x01 << VADC_BRSMR_LDM_SHIFT)
+#define VADC_BRSMR_REQGT_SHIFT                  (7UL)
+#define VADC_BRSMR_REQGT_MASK                   (0x01 << VADC_BRSMR_REQGT_SHIFT)
+#define VADC_BRSMR_CLRPND_SHIFT                 (8UL)
+#define VADC_BRSMR_CLRPND_MASK                  (0x01 << VADC_BRSMR_CLRPND_SHIFT)
+#define VADC_BRSMR_LDEV_SHIFT                   (9UL)
+#define VADC_BRSMR_LDEV_MASK                    (0x01 << VADC_BRSMR_LDEV_SHIFT)
+#define VADC_BRSMR_RPTDIS_SHIFT                 (16UL)
+#define VADC_BRSMR_RPTDIS_MASK                  (0x01 << VADC_BRSMR_RPTDIS_SHIFT)
+
+/* --------------------------------  VADC_GLOBRCR  -------------------------------- */
+#define VADC_GLOBRCR_DRCTR_MASK                 (0x0f << VADC_GLOBRCR_DRCTR_SHIFT)
+#define VADC_GLOBRCR_WFR_SHIFT                  (24UL)
+#define VADC_GLOBRCR_WFR_MASK                   (0x01 << VADC_GLOBRCR_WFR_SHIFT)
+#define VADC_GLOBRCR_DRCTR_SHIFT                (16UL)
+#define VADC_GLOBRCR_SRGEN_SHIFT                (31UL)
+#define VADC_GLOBRCR_SRGEN_MASK                 (0x01 << VADC_GLOBRCR_SRGEN_SHIFT)
+
+/* --------------------------------  VADC_GLOBRES  -------------------------------- */
+#define VADC_GLOBRES_RESULT_SHIFT               (0UL)
+#define VADC_GLOBRES_RESULT_MASK                (0xffff << VADC_GLOBRES_RESULT_SHIFT)
+#define VADC_GLOBRES_GNR_SHIFT                  (16UL)
+#define VADC_GLOBRES_GNR_MASK                   (0x0f << VADC_GLOBRES_GNR_SHIFT)
+#define VADC_GLOBRES_CHNR_SHIFT                 (20UL)
+#define VADC_GLOBRES_CHNR_MASK                  (0x1f << VADC_GLOBRES_CHNR_SHIFT)
+#define VADC_GLOBRES_EMUX_SHIFT                 (25UL)
+#define VADC_GLOBRES_EMUX_MASK                  (0x07 << VADC_GLOBRES_EMUX_SHIFT)
+#define VADC_GLOBRES_CRS_SHIFT                  (28UL)
+#define VADC_GLOBRES_CRS_MASK                   (0x03 << VADC_GLOBRES_CRS_SHIFT)
+#define VADC_GLOBRES_FCR_SHIFT                  (30UL)
+#define VADC_GLOBRES_FCR_MASK                   (0x01 << VADC_GLOBRES_FCR_SHIFT)
+#define VADC_GLOBRES_VF_SHIFT                   (31UL)
+#define VADC_GLOBRES_VF_MASK                    (0x01 << VADC_GLOBRES_VF_SHIFT)
+
+/* --------------------------------  VADC_GLOBRESD  ------------------------------- */
+#define VADC_GLOBRESD_RESULT_SHIFT              (0UL)
+#define VADC_GLOBRESD_RESULT_MASK               (0xffff << VADC_GLOBRESD_RESULT_SHIFT)
+#define VADC_GLOBRESD_GNR_SHIFT                 (16UL)
+#define VADC_GLOBRESD_GNR_MASK                  (0x0f << VADC_GLOBRESD_GNR_SHIFT)
+#define VADC_GLOBRESD_CHNR_SHIFT                (20UL)
+#define VADC_GLOBRESD_CHNR_MASK                 (0x1f << VADC_GLOBRESD_CHNR_SHIFT)
+#define VADC_GLOBRESD_EMUX_SHIFT                (25UL)
+#define VADC_GLOBRESD_EMUX_MASK                 (0x07 << VADC_GLOBRESD_EMUX_SHIFT)
+#define VADC_GLOBRESD_CRS_SHIFT                 (28UL)
+#define VADC_GLOBRESD_CRS_MASK                  (0x03 << VADC_GLOBRESD_CRS_SHIFT)
+#define VADC_GLOBRESD_FCR_SHIFT                 (30UL)
+#define VADC_GLOBRESD_FCR_MASK                  (0x01 << VADC_GLOBRESD_FCR_SHIFT)
+#define VADC_GLOBRESD_VF_SHIFT                  (31UL)
+#define VADC_GLOBRESD_VF_MASK                   (0x01 << VADC_GLOBRESD_VF_SHIFT)
+
+/* --------------------------------  VADC_EMUXSEL  -------------------------------- */
+#define VADC_EMUXSEL_EMUXGRP0_SHIFT             (0UL)
+#define VADC_EMUXSEL_EMUXGRP0_MASK              (0xf << VADC_EMUXSEL_EMUXGRP0_SHIFT)
+#define VADC_EMUXSEL_EMUXGRP1_SHIFT             (4UL)
+#define VADC_EMUXSEL_EMUXGRP1_MASK              (0xf << VADC_EMUXSEL_EMUXGRP1_SHIFT)
+
+/* Group 'VADC_GX' Position & Mask */
+
+/* --------------------------------  VADC_GXARBCFG  ------------------------------- */
+#define VADC_GXARBCFG_ANONC_SHIFT               (0UL)
+#define VADC_GXARBCFG_ANONC_MASK                (0x03 <<  VADC_GXARBCFG_ANONC_SHIFT)
+#define VADC_GXARBCFG_ARBRND_SHIFT              (4UL)
+#define VADC_GXARBCFG_ARBRND_MASK               (0x03 << VADC_GXARBCFG_ARBRND_SHIFT)
+#define VADC_GXARBCFG_ARBM_SHIFT                (7UL)
+#define VADC_GXARBCFG_ARBM_MASK                 (0x01 << VADC_GXARBCFG_ARBM_SHIFT)
+#define VADC_GXARBCFG_ANONS_SHIFT               (16UL)
+#define VADC_GXARBCFG_ANONS_MASK                (0x03 << VADC_GXARBCFG_ANONS_SHIFT)
+#define VADC_GXARBCFG_CAL_SHIFT                 (28UL)
+#define VADC_GXARBCFG_CAL_MASK                  (0x01 << VADC_GXARBCFG_CAL_SHIFT)
+#define VADC_GXARBCFG_BUSY_SHIFT                (30UL)
+#define VADC_GXARBCFG_BUSY_MASK                 (0x01 << VADC_GXARBCFG_BUSY_SHIFT)
+#define VADC_GXARBCFG_SAMPLE_SHIFT              (31UL)
+#define VADC_GXARBCFG_SAMPLE_MASK               (0x01 << VADC_GXARBCFG_SAMPLE_SHIFT)
+
+/* --------------------------------  VADC_GXARBPR  -------------------------------- */
+#define VADC_GXARBPR_PRIO0_SHIFT                (0UL)
+#define VADC_GXARBPR_PRIO0_MASK                 (0x03 << VADC_GXARBPR_PRIO0_SHIFT)
+#define VADC_GXARBPR_CSM0_SHIFT                 (3UL)
+#define VADC_GXARBPR_CSM0_MASK                  (0x01 << VADC_GXARBPR_CSM0_SHIFT)
+#define VADC_GXARBPR_PRIO1_SHIFT                (4UL)
+#define VADC_GXARBPR_PRIO1_MASK                 (0x03 << VADC_GXARBPR_PRIO1_SHIFT)
+#define VADC_GXARBPR_CSM1_SHIFT                 (7UL)
+#define VADC_GXARBPR_CSM1_MASK                  (0x01 << VADC_GXARBPR_CSM1_SHIFT)
+#define VADC_GXARBPR_PRIO2_SHIFT                (8UL)
+#define VADC_GXARBPR_PRIO2_MASK                 (0x03 << VADC_GXARBPR_PRIO2_SHIFT)
+#define VADC_GXARBPR_CSM2_SHIFT                 (11UL)
+#define VADC_GXARBPR_CSM2_MASK                  (0x01 << VADC_GXARBPR_CSM2_SHIFT)
+#define VADC_GXARBPR_ASEN0_SHIFT                (24UL)
+#define VADC_GXARBPR_ASEN0_MASK                 (0x01 << VADC_GXARBPR_ASEN0_SHIFT)
+#define VADC_GXARBPR_ASEN1_SHIFT                (25UL)
+#define VADC_GXARBPR_ASEN1_MASK                 (0x01 << VADC_GXARBPR_ASEN1_SHIFT)
+#define VADC_GXARBPR_ASEN2_SHIFT                (26UL)
+#define VADC_GXARBPR_ASEN2_MASK                 (0x01 << VADC_GXARBPR_ASEN2_SHIFT)
+
+/* --------------------------------  VADC_GXCHASS  -------------------------------- */
+#define VADC_GXCHASS_ASSCH0_SHIFT               (0UL)
+#define VADC_GXCHASS_ASSCH0_MASK                (0x01 << VADC_GXCHASS_ASSCH0_SHIFT)
+#define VADC_GXCHASS_ASSCH1_SHIFT               (1UL)
+#define VADC_GXCHASS_ASSCH1_MASK                (0x01 << VADC_GXCHASS_ASSCH1_SHIFT)
+#define VADC_GXCHASS_ASSCH2_SHIFT               (2UL)
+#define VADC_GXCHASS_ASSCH2_MASK                (0x01 << VADC_GXCHASS_ASSCH2_SHIFT)
+#define VADC_GXCHASS_ASSCH3_SHIFT               (3UL)
+#define VADC_GXCHASS_ASSCH3_MASK                (0x01 << VADC_GXCHASS_ASSCH3_SHIFT)
+#define VADC_GXCHASS_ASSCH4_SHIFT               (4UL)
+#define VADC_GXCHASS_ASSCH4_MASK                (0x01 << VADC_GXCHASS_ASSCH4_SHIFT)
+#define VADC_GXCHASS_ASSCH5_SHIFT               (5UL)
+#define VADC_GXCHASS_ASSCH5_MASK                (0x01 << VADC_GXCHASS_ASSCH5_SHIFT)
+#define VADC_GXCHASS_ASSCH6_SHIFT               (6UL)
+#define VADC_GXCHASS_ASSCH6_MASK                (0x01 << VADC_GXCHASS_ASSCH6_SHIFT)
+#define VADC_GXCHASS_ASSCH7_SHIFT               (7UL)
+#define VADC_GXCHASS_ASSCH7_MASK                (0x01 << VADC_GXCHASS_ASSCH7_SHIFT)
+
+/* --------------------------------  VADC_GXICLASS  ------------------------------- */
+#define VADC_GXICLASS_STCS_SHIFT                (0UL)
+#define VADC_GXICLASS_STCS_MASK                 (0x1f << VADC_GXICLASS_STCS_SHIFT)
+#define VADC_GXICLASS_CMS_SHIFT                 (8UL)
+#define VADC_GXICLASS_CMS_MASK                  (0x07 << VADC_GXICLASS_CMS_SHIFT)
+#define VADC_GXICLASS_STCE_SHIFT                (16UL)
+#define VADC_GXICLASS_STCE_MASK                 (0x1f << VADC_GXICLASS_STCE_SHIFT)
+#define VADC_GXICLASS_CME_SHIFT                 (24UL)
+#define VADC_GXICLASS_CME_MASK                  (0x07 << VADC_GXICLASS_CME_SHIFT)
+
+/* --------------------------------  VADC_GXALIAS  -------------------------------- */
+#define VADC_GXALIAS_ALIAS0_SHIFT               (0UL)
+#define VADC_GXALIAS_ALIAS0_MASK                (0x1f << VADC_GXALIAS_ALIAS0_SHIFT)
+#define VADC_GXALIAS_ALIAS1_SHIFT               (8UL)
+#define VADC_GXALIAS_ALIAS1_MASK                (0x1f << VADC_GXALIAS_ALIAS1_SHIFT)
+
+/* --------------------------------  VADC_GXBOUND  -------------------------------- */
+#define VADC_GXBOUND_BOUNDARY0_SHIFT            (0UL)
+#define VADC_GXBOUND_BOUNDARY0_MASK             (0xfff << VADC_GXBOUND_BOUNDARY0_SHIFT)
+#define VADC_GXBOUND_BOUNDARY1_SHIFT            (16UL)
+#define VADC_GXBOUND_BOUNDARY1_MASK             (0xfff << VADC_GXBOUND_BOUNDARY1_SHIFT)
+
+/* --------------------------------  VADC_GXSYNCTR  ------------------------------- */
+#define VADC_GXSYNCTR_STSEL_SHIFT               (0UL)
+#define VADC_GXSYNCTR_STSEL_MASK                (0x03 << VADC_GXSYNCTR_STSEL_SHIFT)
+#define VADC_GXSYNCTR_EVALR1_SHIFT              (4UL)
+#define VADC_GXSYNCTR_EVALR1_MASK               (0x01 << VADC_GXSYNCTR_EVALR1_SHIFT)
+#define VADC_GXSYNCTR_EVALR2_SHIFT              (5UL)
+#define VADC_GXSYNCTR_EVALR2_MASK               (0x01 << VADC_GXSYNCTR_EVALR2_SHIFT)
+#define VADC_GXSYNCTR_EVALR3_SHIFT              (6UL)
+#define VADC_GXSYNCTR_EVALR3_MASK               (0x01 << VADC_GXSYNCTR_EVALR3_SHIFT)
+
+/* ---------------------------------  VADC_GXBFL  --------------------------------- */
+#define VADC_GXBFL_BFL0_SHIFT                   (0UL)
+#define VADC_GXBFL_BFL0_MASK                    (0x01 << VADC_GXBFL_BFL0_SHIFT)
+#define VADC_GXBFL_BFL1_SHIFT                   (1UL)
+#define VADC_GXBFL_BFL1_MASK                    (0x01 << VADC_GXBFL_BFL1_SHIFT)
+#define VADC_GXBFL_BFL2_SHIFT                   (2UL)
+#define VADC_GXBFL_BFL2_MASK                    (0x01 << VADC_GXBFL_BFL2_SHIFT)
+#define VADC_GXBFL_BFL3_SHIFT                   (3UL)
+#define VADC_GXBFL_BFL3_MASK                    (0x01 << VADC_GXBFL_BFL3_SHIFT)
+
+#if defined(CONFIG_ARCH_CHIP_XMC4700) || defined(CONFIG_ARCH_CHIP_XMC4800)
+    #define VADC_GXBFL_BFA0_SHIFT               (8UL)
+    #define VADC_GXBFL_BFA0_MASK                (0x01 << VADC_GXBFL_BFA0_SHIFT)
+    #define VADC_GXBFL_BFA1_SHIFT               (9UL)
+    #define VADC_GXBFL_BFA1_MASK                (0x01 << VADC_GXBFL_BFA1_SHIFT)
+    #define VADC_GXBFL_BFA2_SHIFT               (10UL)
+    #define VADC_GXBFL_BFA2_MASK                (0x01 << VADC_GXBFL_BFA2_SHIFT)
+    #define VADC_GXBFL_BFA3_SHIFT               (11UL)
+    #define VADC_GXBFL_BFA3_MASK                (0x01 << VADC_GXBFL_BFA3_SHIFT)
+    #define VADC_GXBFL_BFI0_SHIFT               (16UL)
+    #define VADC_GXBFL_BFI0_MASK                (0x01 << VADC_GXBFL_BFI0_SHIFT)
+    #define VADC_GXBFL_BFI1_SHIFT               (17UL)
+    #define VADC_GXBFL_BFI1_MASK                (0x01 << VADC_GXBFL_BFI1_SHIFT)
+    #define VADC_GXBFL_BFI2_SHIFT               (18UL)
+    #define VADC_GXBFL_BFI2_MASK                (0x01 << VADC_GXBFL_BFI2_SHIFT)
+    #define VADC_GXBFL_BFI3_SHIFT               (19UL)
+    #define VADC_GXBFL_BFI3_MASK                (0x01 << VADC_GXBFL_BFI3_SHIFT)
+#endif /* XMC48700 SPECIFIC */
+
+#if defined(CONFIG_ARCH_CHIP_XMC4500)
+    #define VADC_GXBFL_BFE0_SHIFT                  (16UL)
+    #define VADC_GXBFL_BFE0_MASK                   (0x01 << VADC_GXBFL_BFE0_SHIFT)
+    #define VADC_GXBFL_BFE1_SHIFT                  (17UL)
+    #define VADC_GXBFL_BFE1_MASK                   (0x01 << VADC_GXBFL_BFE1_SHIFT)
+    #define VADC_GXBFL_BFE2_SHIFT                  (18UL)
+    #define VADC_GXBFL_BFE2_MASK                   (0x01 << VADC_GXBFL_BFE2_SHIFT)
+    #define VADC_GXBFL_BFE3_SHIFT                  (19UL)
+    #define VADC_GXBFL_BFE3_MASK                   (0x01 << VADC_GXBFL_BFE3_SHIFT)
+#endif /* XMC4500 SPECIFIC */
+
+#if defined(CONFIG_ARCH_CHIP_XMC4700) || defined(CONFIG_ARCH_CHIP_XMC4800)
+    /* ---------------------------------  VADC_GXBFLS  -------------------------------- */
+    #define VADC_GXBFLS_BFC0_SHIFT                  (0UL)
+    #define VADC_GXBFLS_BFC0_MASK                   (0x01 << VADC_GXBFLS_BFC0_SHIFT)
+    #define VADC_GXBFLS_BFC1_SHIFT                  (1UL)
+    #define VADC_GXBFLS_BFC1_MASK                   (0x01 << VADC_GXBFLS_BFC1_SHIFT)
+    #define VADC_GXBFLS_BFC2_SHIFT                  (2UL)
+    #define VADC_GXBFLS_BFC2_MASK                   (0x01 << VADC_GXBFLS_BFC2_SHIFT)
+    #define VADC_GXBFLS_BFC3_SHIFT                  (3UL)
+    #define VADC_GXBFLS_BFC3_MASK                   (0x01 << VADC_GXBFLS_BFC3_SHIFT)
+    #define VADC_GXBFLS_BFS0_SHIFT                  (16UL)
+    #define VADC_GXBFLS_BFS0_MASK                   (0x01 << VADC_GXBFLS_BFS0_SHIFT)
+    #define VADC_GXBFLS_BFS1_SHIFT                  (17UL)
+    #define VADC_GXBFLS_BFS1_MASK                   (0x01 << VADC_GXBFLS_BFS1_SHIFT)
+    #define VADC_GXBFLS_BFS2_SHIFT                  (18UL)
+    #define VADC_GXBFLS_BFS2_MASK                   (0x01 << VADC_GXBFLS_BFS2_SHIFT)
+    #define VADC_GXBFLS_BFS3_SHIFT                  (19UL)
+    #define VADC_GXBFLS_BFS3_MASK                   (0x01 << VADC_GXBFLS_BFS3_SHIFT)
+
+    /* ---------------------------------  VADC_GXBFLC  -------------------------------- */
+    #define VADC_GXBFLC_BFM0_SHIFT                  (0UL)
+    #define VADC_GXBFLC_BFM0_MASK                   (0x0f << VADC_GXBFLC_BFM0_SHIFT)
+    #define VADC_GXBFLC_BFM1_SHIFT                  (4UL)
+    #define VADC_GXBFLC_BFM1_MASK                   (0x0f << VADC_GXBFLC_BFM1_SHIFT)
+    #define VADC_GXBFLC_BFM2_SHIFT                  (8UL)
+    #define VADC_GXBFLC_BFM2_MASK                   (0x0f << VADC_GXBFLC_BFM2_SHIFT)
+    #define VADC_GXBFLC_BFM3_SHIFT                  (12UL)
+    #define VADC_GXBFLC_BFM3_MASK                   (0x0f << VADC_GXBFLC_BFM3_SHIFT)
+
+    /* --------------------------------  VADC_GXBFLNP  -------------------------------- */
+    #define VADC_GXBFLNP_BFL0NP_SHIFT               (0UL)
+    #define VADC_GXBFLNP_BFL0NP_MASK                (0x0f << VADC_GXBFLNP_BFL0NP_SHIFT)
+    #define VADC_GXBFLNP_BFL1NP_SHIFT               (4UL)
+    #define VADC_GXBFLNP_BFL1NP_MASK                (0x0f << VADC_GXBFLNP_BFL1NP_SHIFT)
+    #define VADC_GXBFLNP_BFL2NP_SHIFT               (8UL)
+    #define VADC_GXBFLNP_BFL2NP_MASK                (0x0f << VADC_GXBFLNP_BFL2NP_SHIFT)
+    #define VADC_GXBFLNP_BFL3NP_SHIFT               (12UL)
+    #define VADC_GXBFLNP_BFL3NP_MASK                (0x0f << VADC_GXBFLNP_BFL3NP_SHIFT)
+#endif /* XMC48700 SPECIFIC */
+
+/* --------------------------------  VADC_GXQCTRL0  ------------------------------- */
+#if defined(CONFIG_ARCH_CHIP_XMC4700) || defined(CONFIG_ARCH_CHIP_XMC4800)
+    #define VADC_GXQCTRL0_SRCRESREG_SHIFT           (0UL)
+    #define VADC_GXQCTRL0_SRCRESREG_MASK            (0x0f << VADC_GXQCTRL0_SRCRESREG_SHIFT)
+#endif/* XMC48700 SPECIFIC */
+
+#define VADC_GXQCTRL0_XTSEL_SHIFT               (8UL)
+#define VADC_GXQCTRL0_XTSEL_MASK                (0x0f << VADC_GXQCTRL0_XTSEL_SHIFT)
+#define VADC_GXQCTRL0_XTLVL_SHIFT               (12UL)
+#define VADC_GXQCTRL0_XTLVL_MASK                (0x01 << VADC_GXQCTRL0_XTLVL_SHIFT)
+#define VADC_GXQCTRL0_XTMODE_SHIFT              (13UL)
+#define VADC_GXQCTRL0_XTMODE_MASK               (0x03 << VADC_GXQCTRL0_XTMODE_SHIFT)
+#define VADC_GXQCTRL0_XTWC_SHIFT                (15UL)
+#define VADC_GXQCTRL0_XTWC_MASK                 (0x01 << VADC_GXQCTRL0_XTWC_SHIFT)
+#define VADC_GXQCTRL0_GTSEL_SHIFT               (16UL)
+#define VADC_GXQCTRL0_GTSEL_MASK                (0x0f << VADC_GXQCTRL0_GTSEL_SHIFT)
+#define VADC_GXQCTRL0_GTLVL_SHIFT               (20UL)
+#define VADC_GXQCTRL0_GTLVL_MASK                (0x01 << VADC_GXQCTRL0_GTLVL_SHIFT)
+#define VADC_GXQCTRL0_GTWC_SHIFT                (23UL)
+#define VADC_GXQCTRL0_GTWC_MASK                 (0x01 << VADC_GXQCTRL0_GTWC_SHIFT)
+#define VADC_GXQCTRL0_TMEN_SHIFT                (28UL)
+#define VADC_GXQCTRL0_TMEN_MASK                 (0x01 << VADC_GXQCTRL0_TMEN_SHIFT)
+#define VADC_GXQCTRL0_TMWC_SHIFT                (31UL)
+#define VADC_GXQCTRL0_TMWC_MASK                 (0x01 << VADC_GXQCTRL0_TMWC_SHIFT)
+
+/* ---------------------------------  VADC_GXQMR0  -------------------------------- */
+#define VADC_GXQMR0_ENGT_SHIFT                  (0UL)
+#define VADC_GXQMR0_ENGT_MASK                   (0x03 << VADC_GXQMR0_ENGT_SHIFT)
+#define VADC_GXQMR0_ENTR_SHIFT                  (2UL)
+#define VADC_GXQMR0_ENTR_MASK                   (0x01 << VADC_GXQMR0_ENTR_SHIFT)
+#define VADC_GXQMR0_CLRV_SHIFT                  (8UL)
+#define VADC_GXQMR0_CLRV_MASK                   (0x01 << VADC_GXQMR0_CLRV_SHIFT)
+#define VADC_GXQMR0_TREV_SHIFT                  (9UL)
+#define VADC_GXQMR0_TREV_MASK                   (0x01 << VADC_GXQMR0_TREV_SHIFT)
+#define VADC_GXQMR0_FLUSH_SHIFT                 (10UL)
+#define VADC_GXQMR0_FLUSH_MASK                  (0x01 << VADC_GXQMR0_FLUSH_SHIFT)
+#define VADC_GXQMR0_CEV_SHIFT                   (11UL)
+#define VADC_GXQMR0_CEV_MASK                    (0x01 << VADC_GXQMR0_CEV_SHIFT)
+#define VADC_GXQMR0_RPTDIS_SHIFT                (16UL)
+#define VADC_GXQMR0_RPTDIS_MASK                 (0x01 << VADC_GXQMR0_RPTDIS_SHIFT)
+
+/* ---------------------------------  VADC_GXQSR0  -------------------------------- */
+#define VADC_GXQSR0_FILL_SHIFT                  (0UL)
+#define VADC_GXQSR0_FILL_MASK                   (0x0f << VADC_GXQSR0_FILL_SHIFT)
+#define VADC_GXQSR0_EMPTY_SHIFT                 (5UL)
+#define VADC_GXQSR0_EMPTY_MASK                  (0x01 << VADC_GXQSR0_EMPTY_SHIFT)
+#define VADC_GXQSR0_REQGT_SHIFT                 (7UL)
+#define VADC_GXQSR0_REQGT_MASK                  (0x01 << VADC_GXQSR0_REQGT_SHIFT)
+#define VADC_GXQSR0_EV_SHIFT                    (8UL)
+#define VADC_GXQSR0_EV_MASK                     (0x01 << VADC_GXQSR0_EV_SHIFT)
+
+/* ---------------------------------  VADC_GXQ0R0  -------------------------------- */
+#define VADC_GXQ0R0_REQCHNR_SHIFT               (0UL)
+#define VADC_GXQ0R0_REQCHNR_MASK                (0x1f << VADC_GXQ0R0_REQCHNR_SHIFT)
+#define VADC_GXQ0R0_RF_SHIFT                    (5UL)
+#define VADC_GXQ0R0_RF_MASK                     (0x01 << VADC_GXQ0R0_RF_SHIFT)
+#define VADC_GXQ0R0_ENSI_SHIFT                  (6UL)
+#define VADC_GXQ0R0_ENSI_MASK                   (0x01 << VADC_GXQ0R0_ENSI_SHIFT)
+#define VADC_GXQ0R0_EXTR_SHIFT                  (7UL)
+#define VADC_GXQ0R0_EXTR_MASK                   (0x01 << VADC_GXQ0R0_EXTR_SHIFT)
+#define VADC_GXQ0R0_V_SHIFT                     (8UL)
+#define VADC_GXQ0R0_V_MASK                      (0x01 << VADC_GXQ0R0_V_SHIFT)
+
+/* --------------------------------  VADC_GXQINR0  -------------------------------- */
+#define VADC_GXQINR0_REQCHNR_SHIFT              (0UL)
+#define VADC_GXQINR0_REQCHNR_MASK               (0x1f << VADC_GXQINR0_REQCHNR_SHIFT)
+#define VADC_GXQINR0_RF_SHIFT                   (5UL)
+#define VADC_GXQINR0_RF_MASK                    (0x01 << VADC_GXQINR0_RF_SHIFT)
+#define VADC_GXQINR0_ENSI_SHIFT                 (6UL)
+#define VADC_GXQINR0_ENSI_MASK                  (0x01 << VADC_GXQINR0_ENSI_SHIFT)
+#define VADC_GXQINR0_EXTR_SHIFT                 (7UL)
+#define VADC_GXQINR0_EXTR_MASK                  (0x01 << VADC_GXQINR0_EXTR_SHIFT)
+
+/* --------------------------------  VADC_GXQBUR0  -------------------------------- */
+#define VADC_GXQBUR0_REQCHNR_SHIFT              (0UL)
+#define VADC_GXQBUR0_REQCHNR_MASK               (0x1f << VADC_GXQBUR0_REQCHNR_SHIFT)
+#define VADC_GXQBUR0_RF_SHIFT                   (5UL)
+#define VADC_GXQBUR0_RF_MASK                    (0x01 << VADC_GXQBUR0_RF_SHIFT)
+#define VADC_GXQBUR0_ENSI_SHIFT                 (6UL)
+#define VADC_GXQBUR0_ENSI_MASK                  (0x01 << VADC_GXQBUR0_ENSI_SHIFT)
+#define VADC_GXQBUR0_EXTR_SHIFT                 (7UL)
+#define VADC_GXQBUR0_EXTR_MASK                  (0x01 << VADC_GXQBUR0_EXTR_SHIFT)
+#define VADC_GXQBUR0_V_SHIFT                    (8UL)
+#define VADC_GXQBUR0_V_MASK                     (0x01 << VADC_GXQBUR0_V_SHIFT)
+
+/* --------------------------------  VADC_GXASCTRL  ------------------------------- */
+#if defined(CONFIG_ARCH_CHIP_XMC4700) || defined(CONFIG_ARCH_CHIP_XMC4800)
+    #define VADC_GXASCTRL_SRCRESREG_SHIFT       (0UL)
+    #define VADC_GXASCTRL_SRCRESREG_MASK        (0x0f << VADC_GXASCTRL_SRCRESREG_SHIFT)
+#endif /* XMC48700 SPECIFIC */
+
+#define VADC_GXASCTRL_XTSEL_SHIFT               (8UL)
+#define VADC_GXASCTRL_XTSEL_MASK                (0x0f << VADC_GXASCTRL_XTSEL_SHIFT)
+#define VADC_GXASCTRL_XTLVL_SHIFT               (12UL)
+#define VADC_GXASCTRL_XTLVL_MASK                (0x01 << VADC_GXASCTRL_XTLVL_SHIFT)
+#define VADC_GXASCTRL_XTMODE_SHIFT              (13UL)
+#define VADC_GXASCTRL_XTMODE_MASK               (0x03 << VADC_GXASCTRL_XTMODE_SHIFT)
+#define VADC_GXASCTRL_XTWC_SHIFT                (15UL)
+#define VADC_GXASCTRL_XTWC_MASK                 (0x01 << VADC_GXASCTRL_XTWC_SHIFT)
+#define VADC_GXASCTRL_GTSEL_SHIFT               (16UL)
+#define VADC_GXASCTRL_GTSEL_MASK                (0x0f << VADC_GXASCTRL_GTSEL_SHIFT)
+#define VADC_GXASCTRL_GTLVL_SHIFT               (20UL)
+#define VADC_GXASCTRL_GTLVL_MASK                (0x01 << VADC_GXASCTRL_GTLVL_SHIFT)
+#define VADC_GXASCTRL_GTWC_SHIFT                (23UL)
+#define VADC_GXASCTRL_GTWC_MASK                 (0x01 << VADC_GXASCTRL_GTWC_SHIFT)
+#define VADC_GXASCTRL_TMEN_SHIFT                (28UL)
+#define VADC_GXASCTRL_TMEN_MASK                 (0x01 << VADC_GXASCTRL_TMEN_SHIFT)
+#define VADC_GXASCTRL_TMWC_SHIFT                (31UL)
+#define VADC_GXASCTRL_TMWC_MASK                 (0x01 << VADC_GXASCTRL_TMWC_SHIFT)
+
+/* ---------------------------------  VADC_GXASMR  -------------------------------- */
+#define VADC_GXASMR_ENGT_SHIFT                  (0UL)
+#define VADC_GXASMR_ENGT_MASK                   (0x03 << VADC_GXASMR_ENGT_SHIFT)
+#define VADC_GXASMR_ENTR_SHIFT                  (2UL)
+#define VADC_GXASMR_ENTR_MASK                   (0x01 << VADC_GXASMR_ENTR_SHIFT)
+#define VADC_GXASMR_ENSI_SHIFT                  (3UL)
+#define VADC_GXASMR_ENSI_MASK                   (0x01 << VADC_GXASMR_ENSI_SHIFT)
+#define VADC_GXASMR_SCAN_SHIFT                  (4UL)
+#define VADC_GXASMR_SCAN_MASK                   (0x01 << VADC_GXASMR_SCAN_SHIFT)
+#define VADC_GXASMR_LDM_SHIFT                   (5UL)
+#define VADC_GXASMR_LDM_MASK                    (0x01 << VADC_GXASMR_LDM_SHIFT)
+#define VADC_GXASMR_REQGT_SHIFT                 (7UL)
+#define VADC_GXASMR_REQGT_MASK                  (0x01 << VADC_GXASMR_REQGT_SHIFT)
+#define VADC_GXASMR_CLRPND_SHIFT                (8UL)
+#define VADC_GXASMR_CLRPND_MASK                 (0x01 << VADC_GXASMR_CLRPND_SHIFT)
+#define VADC_GXASMR_LDEV_SHIFT                  (9UL)
+#define VADC_GXASMR_LDEV_MASK                   (0x01 << VADC_GXASMR_LDEV_SHIFT)
+#define VADC_GXASMR_RPTDIS_SHIFT                (16UL)
+#define VADC_GXASMR_RPTDIS_MASK                 (0x01 << VADC_GXASMR_RPTDIS_SHIFT)
+
+/* --------------------------------  VADC_GXASSEL  -------------------------------- */
+#define VADC_GXASSEL_CHSEL0_SHIFT               (0UL)
+#define VADC_GXASSEL_CHSEL0_MASK                (0x01 << VADC_GXASSEL_CHSEL0_SHIFT)
+#define VADC_GXASSEL_CHSEL1_SHIFT               (1UL)
+#define VADC_GXASSEL_CHSEL1_MASK                (0x01 << VADC_GXASSEL_CHSEL1_SHIFT)
+#define VADC_GXASSEL_CHSEL2_SHIFT               (2UL)
+#define VADC_GXASSEL_CHSEL2_MASK                (0x01 << VADC_GXASSEL_CHSEL2_SHIFT)
+#define VADC_GXASSEL_CHSEL3_SHIFT               (3UL)
+#define VADC_GXASSEL_CHSEL3_MASK                (0x01 << VADC_GXASSEL_CHSEL3_SHIFT)
+#define VADC_GXASSEL_CHSEL4_SHIFT               (4UL)
+#define VADC_GXASSEL_CHSEL4_MASK                (0x01 << VADC_GXASSEL_CHSEL4_SHIFT)
+#define VADC_GXASSEL_CHSEL5_SHIFT               (5UL)
+#define VADC_GXASSEL_CHSEL5_MASK                (0x01 << VADC_GXASSEL_CHSEL5_SHIFT)
+#define VADC_GXASSEL_CHSEL6_SHIFT               (6UL)
+#define VADC_GXASSEL_CHSEL6_MASK                (0x01 << VADC_GXASSEL_CHSEL6_SHIFT)
+#define VADC_GXASSEL_CHSEL7_SHIFT               (7UL)
+#define VADC_GXASSEL_CHSEL7_MASK                (0x01 << VADC_GXASSEL_CHSEL7_SHIFT)
+
+/* --------------------------------  VADC_GXASPND  -------------------------------- */
+#define VADC_GXASPND_CHPND0_SHIFT               (0UL)
+#define VADC_GXASPND_CHPND0_MASK                (0x01 << VADC_GXASPND_CHPND0_SHIFT)
+#define VADC_GXASPND_CHPND1_SHIFT               (1UL)
+#define VADC_GXASPND_CHPND1_MASK                (0x01 << VADC_GXASPND_CHPND1_SHIFT)
+#define VADC_GXASPND_CHPND2_SHIFT               (2UL)
+#define VADC_GXASPND_CHPND2_MASK                (0x01 << VADC_GXASPND_CHPND2_SHIFT)
+#define VADC_GXASPND_CHPND3_SHIFT               (3UL)
+#define VADC_GXASPND_CHPND3_MASK                (0x01 << VADC_GXASPND_CHPND3_SHIFT)
+#define VADC_GXASPND_CHPND4_SHIFT               (4UL)
+#define VADC_GXASPND_CHPND4_MASK                (0x01 << VADC_GXASPND_CHPND4_SHIFT)
+#define VADC_GXASPND_CHPND5_SHIFT               (5UL)
+#define VADC_GXASPND_CHPND5_MASK                (0x01 << VADC_GXASPND_CHPND5_SHIFT)
+#define VADC_GXASPND_CHPND6_SHIFT               (6UL)
+#define VADC_GXASPND_CHPND6_MASK                (0x01 << VADC_GXASPND_CHPND6_SHIFT)
+#define VADC_GXASPND_CHPND7_SHIFT               (7UL)
+#define VADC_GXASPND_CHPND7_MASK                (0x01 << VADC_GXASPND_CHPND7_SHIFT)
+
+/* --------------------------------  VADC_GXCEFLAG  ------------------------------- */
+#define VADC_GXCEFLAG_CEV0_SHIFT                (0UL)
+#define VADC_GXCEFLAG_CEV0_MASK                 (0x01 << VADC_GXCEFLAG_CEV0_SHIFT)
+#define VADC_GXCEFLAG_CEV1_SHIFT                (1UL)
+#define VADC_GXCEFLAG_CEV1_MASK                 (0x01 << VADC_GXCEFLAG_CEV1_SHIFT)
+#define VADC_GXCEFLAG_CEV2_SHIFT                (2UL)
+#define VADC_GXCEFLAG_CEV2_MASK                 (0x01 << VADC_GXCEFLAG_CEV2_SHIFT)
+#define VADC_GXCEFLAG_CEV3_SHIFT                (3UL)
+#define VADC_GXCEFLAG_CEV3_MASK                 (0x01 << VADC_GXCEFLAG_CEV3_SHIFT)
+#define VADC_GXCEFLAG_CEV4_SHIFT                (4UL)
+#define VADC_GXCEFLAG_CEV4_MASK                 (0x01 << VADC_GXCEFLAG_CEV4_SHIFT)
+#define VADC_GXCEFLAG_CEV5_SHIFT                (5UL)
+#define VADC_GXCEFLAG_CEV5_MASK                 (0x01 << VADC_GXCEFLAG_CEV5_SHIFT)
+#define VADC_GXCEFLAG_CEV6_SHIFT                (6UL)
+#define VADC_GXCEFLAG_CEV6_MASK                 (0x01 << VADC_GXCEFLAG_CEV6_SHIFT)
+#define VADC_GXCEFLAG_CEV7_SHIFT                (7UL)
+#define VADC_GXCEFLAG_CEV7_MASK                 (0x01 << VADC_GXCEFLAG_CEV7_SHIFT)
+
+/* --------------------------------  VADC_GXREFLAG  ------------------------------- */
+#define VADC_GXREFLAG_REV0_SHIFT                (0UL)
+#define VADC_GXREFLAG_REV0_MASK                 (0x01 << VADC_GXREFLAG_REV0_SHIFT)
+#define VADC_GXREFLAG_REV1_SHIFT                (1UL)
+#define VADC_GXREFLAG_REV1_MASK                 (0x01 << VADC_GXREFLAG_REV1_SHIFT)
+#define VADC_GXREFLAG_REV2_SHIFT                (2UL)
+#define VADC_GXREFLAG_REV2_MASK                 (0x01 << VADC_GXREFLAG_REV2_SHIFT)
+#define VADC_GXREFLAG_REV3_SHIFT                (3UL)
+#define VADC_GXREFLAG_REV3_MASK                 (0x01 << VADC_GXREFLAG_REV3_SHIFT)
+#define VADC_GXREFLAG_REV4_SHIFT                (4UL)
+#define VADC_GXREFLAG_REV4_MASK                 (0x01 << VADC_GXREFLAG_REV4_SHIFT)
+#define VADC_GXREFLAG_REV5_SHIFT                (5UL)
+#define VADC_GXREFLAG_REV5_MASK                 (0x01 << VADC_GXREFLAG_REV5_SHIFT)
+#define VADC_GXREFLAG_REV6_SHIFT                (6UL)
+#define VADC_GXREFLAG_REV6_MASK                 (0x01 << VADC_GXREFLAG_REV6_SHIFT)
+#define VADC_GXREFLAG_REV7_SHIFT                (7UL)
+#define VADC_GXREFLAG_REV7_MASK                 (0x01 << VADC_GXREFLAG_REV7_SHIFT)
+#define VADC_GXREFLAG_REV8_SHIFT                (8UL)
+#define VADC_GXREFLAG_REV8_MASK                 (0x01 << VADC_GXREFLAG_REV8_SHIFT)
+#define VADC_GXREFLAG_REV9_SHIFT                (9UL)
+#define VADC_GXREFLAG_REV9_MASK                 (0x01 << VADC_GXREFLAG_REV9_SHIFT)
+#define VADC_GXREFLAG_REV10_SHIFT               (10UL)
+#define VADC_GXREFLAG_REV10_MASK                (0x01 << VADC_GXREFLAG_REV10_SHIFT)
+#define VADC_GXREFLAG_REV11_SHIFT               (11UL)
+#define VADC_GXREFLAG_REV11_MASK                (0x01 << VADC_GXREFLAG_REV11_SHIFT)
+#define VADC_GXREFLAG_REV12_SHIFT               (12UL)
+#define VADC_GXREFLAG_REV12_MASK                (0x01 << VADC_GXREFLAG_REV12_SHIFT)
+#define VADC_GXREFLAG_REV13_SHIFT               (13UL)
+#define VADC_GXREFLAG_REV13_MASK                (0x01 << VADC_GXREFLAG_REV13_SHIFT)
+#define VADC_GXREFLAG_REV14_SHIFT               (14UL)
+#define VADC_GXREFLAG_REV14_MASK                (0x01 << VADC_GXREFLAG_REV14_SHIFT)
+#define VADC_GXREFLAG_REV15_SHIFT               (15UL)
+#define VADC_GXREFLAG_REV15_MASK                (0x01 << VADC_GXREFLAG_REV15_SHIFT)
+
+/* --------------------------------  VADC_GXSEFLAG  ------------------------------- */
+#define VADC_GXSEFLAG_SEV0_SHIFT                (0UL)
+#define VADC_GXSEFLAG_SEV0_MASK                 (0x01 << VADC_GXSEFLAG_SEV0_SHIFT)
+#define VADC_GXSEFLAG_SEV1_SHIFT                (1UL)
+#define VADC_GXSEFLAG_SEV1_MASK                 (0x01 << VADC_GXSEFLAG_SEV1_SHIFT)
+
+/* --------------------------------  VADC_GXCEFCLR  ------------------------------- */
+#define VADC_GXCEFCLR_CEV0_SHIFT                (0UL)
+#define VADC_GXCEFCLR_CEV0_MASK                 (0x01 << VADC_GXCEFCLR_CEV0_SHIFT)
+#define VADC_GXCEFCLR_CEV1_SHIFT                (1UL)
+#define VADC_GXCEFCLR_CEV1_MASK                 (0x01 << VADC_GXCEFCLR_CEV1_SHIFT)
+#define VADC_GXCEFCLR_CEV2_SHIFT                (2UL)
+#define VADC_GXCEFCLR_CEV2_MASK                 (0x01 << VADC_GXCEFCLR_CEV2_SHIFT)
+#define VADC_GXCEFCLR_CEV3_SHIFT                (3UL)
+#define VADC_GXCEFCLR_CEV3_MASK                 (0x01 << VADC_GXCEFCLR_CEV3_SHIFT)
+#define VADC_GXCEFCLR_CEV4_SHIFT                (4UL)
+#define VADC_GXCEFCLR_CEV4_MASK                 (0x01 << VADC_GXCEFCLR_CEV4_SHIFT)
+#define VADC_GXCEFCLR_CEV5_SHIFT                (5UL)
+#define VADC_GXCEFCLR_CEV5_MASK                 (0x01 << VADC_GXCEFCLR_CEV5_SHIFT)
+#define VADC_GXCEFCLR_CEV6_SHIFT                (6UL)
+#define VADC_GXCEFCLR_CEV6_MASK                 (0x01 << VADC_GXCEFCLR_CEV6_SHIFT)
+#define VADC_GXCEFCLR_CEV7_SHIFT                (7UL)
+#define VADC_GXCEFCLR_CEV7_MASK                 (0x01 << VADC_GXCEFCLR_CEV7_SHIFT)
+
+/* --------------------------------  VADC_GXREFCLR  ------------------------------- */
+#define VADC_GXREFCLR_REV0_SHIFT                (0UL)
+#define VADC_GXREFCLR_REV0_MASK                 (0x01 << VADC_GXREFCLR_REV0_SHIFT)
+#define VADC_GXREFCLR_REV1_SHIFT                (1UL)
+#define VADC_GXREFCLR_REV1_MASK                 (0x01 << VADC_GXREFCLR_REV1_SHIFT)
+#define VADC_GXREFCLR_REV2_SHIFT                (2UL)
+#define VADC_GXREFCLR_REV2_MASK                 (0x01 << VADC_GXREFCLR_REV2_SHIFT)
+#define VADC_GXREFCLR_REV3_SHIFT                (3UL)
+#define VADC_GXREFCLR_REV3_MASK                 (0x01 << VADC_GXREFCLR_REV3_SHIFT)
+#define VADC_GXREFCLR_REV4_SHIFT                (4UL)
+#define VADC_GXREFCLR_REV4_MASK                 (0x01 << VADC_GXREFCLR_REV4_SHIFT)
+#define VADC_GXREFCLR_REV5_SHIFT                (5UL)
+#define VADC_GXREFCLR_REV5_MASK                 (0x01 << VADC_GXREFCLR_REV5_SHIFT)
+#define VADC_GXREFCLR_REV6_SHIFT                (6UL)
+#define VADC_GXREFCLR_REV6_MASK                 (0x01 << VADC_GXREFCLR_REV6_SHIFT)
+#define VADC_GXREFCLR_REV7_SHIFT                (7UL)
+#define VADC_GXREFCLR_REV7_MASK                 (0x01 << VADC_GXREFCLR_REV7_SHIFT)
+#define VADC_GXREFCLR_REV8_SHIFT                (8UL)
+#define VADC_GXREFCLR_REV8_MASK                 (0x01 << VADC_GXREFCLR_REV8_SHIFT)
+#define VADC_GXREFCLR_REV9_SHIFT                (9UL)
+#define VADC_GXREFCLR_REV9_MASK                 (0x01 << VADC_GXREFCLR_REV9_SHIFT)
+#define VADC_GXREFCLR_REV10_SHIFT               (10UL)
+#define VADC_GXREFCLR_REV10_MASK                (0x01 << VADC_GXREFCLR_REV10_SHIFT)
+#define VADC_GXREFCLR_REV11_SHIFT               (11UL)
+#define VADC_GXREFCLR_REV11_MASK                (0x01 << VADC_GXREFCLR_REV11_SHIFT)
+#define VADC_GXREFCLR_REV12_SHIFT               (12UL)
+#define VADC_GXREFCLR_REV12_MASK                (0x01 << VADC_GXREFCLR_REV12_SHIFT)
+#define VADC_GXREFCLR_REV13_SHIFT               (13UL)
+#define VADC_GXREFCLR_REV13_MASK                (0x01 << VADC_GXREFCLR_REV13_SHIFT)
+#define VADC_GXREFCLR_REV14_SHIFT               (14UL)
+#define VADC_GXREFCLR_REV14_MASK                (0x01 << VADC_GXREFCLR_REV14_SHIFT)
+#define VADC_GXREFCLR_REV15_SHIFT               (15UL)
+#define VADC_GXREFCLR_REV15_MASK                (0x01 << VADC_GXREFCLR_REV15_SHIFT)
+
+/* --------------------------------  VADC_GXSEFCLR  ------------------------------- */
+#define VADC_GXSEFCLR_SEV0_SHIFT                (0UL)
+#define VADC_GXSEFCLR_SEV0_MASK                 (0x01 << VADC_GXSEFCLR_SEV0_SHIFT)
+#define VADC_GXSEFCLR_SEV1_SHIFT                (1UL)
+#define VADC_GXSEFCLR_SEV1_MASK                 (0x01 << VADC_GXSEFCLR_SEV1_SHIFT)
+
+/* --------------------------------  VADC_GXCEVNP0  ------------------------------- */
+#define VADC_GXCEVNP0_CEV0NP_SHIFT              (0UL)
+#define VADC_GXCEVNP0_CEV0NP_MASK               (0x0f << VADC_GXCEVNP0_CEV0NP_SHIFT)
+#define VADC_GXCEVNP0_CEV1NP_SHIFT              (4UL)
+#define VADC_GXCEVNP0_CEV1NP_MASK               (0x0f << VADC_GXCEVNP0_CEV1NP_SHIFT)
+#define VADC_GXCEVNP0_CEV2NP_SHIFT              (8UL)
+#define VADC_GXCEVNP0_CEV2NP_MASK               (0x0f << VADC_GXCEVNP0_CEV2NP_SHIFT)
+#define VADC_GXCEVNP0_CEV3NP_SHIFT              (12UL)
+#define VADC_GXCEVNP0_CEV3NP_MASK               (0x0f << VADC_GXCEVNP0_CEV3NP_SHIFT)
+#define VADC_GXCEVNP0_CEV4NP_SHIFT              (16UL)
+#define VADC_GXCEVNP0_CEV4NP_MASK               (0x0f << VADC_GXCEVNP0_CEV4NP_SHIFT)
+#define VADC_GXCEVNP0_CEV5NP_SHIFT              (20UL)
+#define VADC_GXCEVNP0_CEV5NP_MASK               (0x0f << VADC_GXCEVNP0_CEV5NP_SHIFT)
+#define VADC_GXCEVNP0_CEV6NP_SHIFT              (24UL)
+#define VADC_GXCEVNP0_CEV6NP_MASK               (0x0f << VADC_GXCEVNP0_CEV6NP_SHIFT)
+#define VADC_GXCEVNP0_CEV7NP_SHIFT              (28UL)
+#define VADC_GXCEVNP0_CEV7NP_MASK               (0x0f << VADC_GXCEVNP0_CEV7NP_SHIFT)
+
+/* --------------------------------  VADC_GXREVNP0  ------------------------------- */
+#define VADC_GXREVNP0_REV0NP_SHIFT              (0UL)
+#define VADC_GXREVNP0_REV0NP_MASK               (0x0f << VADC_GXREVNP0_REV0NP_SHIFT)
+#define VADC_GXREVNP0_REV1NP_SHIFT              (4UL)
+#define VADC_GXREVNP0_REV1NP_MASK               (0x0f << VADC_GXREVNP0_REV1NP_SHIFT)
+#define VADC_GXREVNP0_REV2NP_SHIFT              (8UL)
+#define VADC_GXREVNP0_REV2NP_MASK               (0x0f << VADC_GXREVNP0_REV2NP_SHIFT)
+#define VADC_GXREVNP0_REV3NP_SHIFT              (12UL)
+#define VADC_GXREVNP0_REV3NP_MASK               (0x0f << VADC_GXREVNP0_REV3NP_SHIFT)
+#define VADC_GXREVNP0_REV4NP_SHIFT              (16UL)
+#define VADC_GXREVNP0_REV4NP_MASK               (0x0f << VADC_GXREVNP0_REV4NP_SHIFT)
+#define VADC_GXREVNP0_REV5NP_SHIFT              (20UL)
+#define VADC_GXREVNP0_REV5NP_MASK               (0x0f << VADC_GXREVNP0_REV5NP_SHIFT)
+#define VADC_GXREVNP0_REV6NP_SHIFT              (24UL)
+#define VADC_GXREVNP0_REV6NP_MASK               (0x0f << VADC_GXREVNP0_REV6NP_SHIFT)
+#define VADC_GXREVNP0_REV7NP_SHIFT              (28UL)
+#define VADC_GXREVNP0_REV7NP_MASK               (0x0f << VADC_GXREVNP0_REV7NP_SHIFT)
+
+/* --------------------------------  VADC_GXREVNP1  ------------------------------- */
+#define VADC_GXREVNP1_REV8NP_SHIFT              (0UL)
+#define VADC_GXREVNP1_REV8NP_MASK               (0x0f << VADC_GXREVNP1_REV8NP_SHIFT)
+#define VADC_GXREVNP1_REV9NP_SHIFT              (4UL)
+#define VADC_GXREVNP1_REV9NP_MASK               (0x0f << VADC_GXREVNP1_REV9NP_SHIFT)
+#define VADC_GXREVNP1_REV10NP_SHIFT             (8UL)
+#define VADC_GXREVNP1_REV10NP_MASK              (0x0f << VADC_GXREVNP1_REV10NP_SHIFT)
+#define VADC_GXREVNP1_REV11NP_SHIFT             (12UL)
+#define VADC_GXREVNP1_REV11NP_MASK              (0x0f << VADC_GXREVNP1_REV11NP_SHIFT)
+#define VADC_GXREVNP1_REV12NP_SHIFT             (16UL)
+#define VADC_GXREVNP1_REV12NP_MASK              (0x0f << VADC_GXREVNP1_REV12NP_SHIFT)
+#define VADC_GXREVNP1_REV13NP_SHIFT             (20UL)
+#define VADC_GXREVNP1_REV13NP_MASK              (0x0f << VADC_GXREVNP1_REV13NP_SHIFT)
+#define VADC_GXREVNP1_REV14NP_SHIFT             (24UL)
+#define VADC_GXREVNP1_REV14NP_MASK              (0x0f << VADC_GXREVNP1_REV14NP_SHIFT)
+#define VADC_GXREVNP1_REV15NP_SHIFT             (28UL)
+#define VADC_GXREVNP1_REV15NP_MASK              (0x0f << VADC_GXREVNP1_REV15NP_SHIFT)
+
+/* --------------------------------  VADC_GXSEVNP  -------------------------------- */
+#define VADC_GXSEVNP_SEV0NP_SHIFT               (0UL)
+#define VADC_GXSEVNP_SEV0NP_MASK                (0x0f << VADC_GXSEVNP_SEV0NP_SHIFT)
+#define VADC_GXSEVNP_SEV1NP_SHIFT               (4UL)
+#define VADC_GXSEVNP_SEV1NP_MASK                (0x0f << VADC_GXSEVNP_SEV1NP_SHIFT)
+
+/* --------------------------------  VADC_GXSRACT  -------------------------------- */
+#define VADC_GXSRACT_AGSR0_SHIFT                (0UL)
+#define VADC_GXSRACT_AGSR0_MASK                 (0x01 << VADC_GXSRACT_AGSR0_SHIFT)
+#define VADC_GXSRACT_AGSR1_SHIFT                (1UL)
+#define VADC_GXSRACT_AGSR1_MASK                 (0x01 << VADC_GXSRACT_AGSR1_SHIFT)
+#define VADC_GXSRACT_AGSR2_SHIFT                (2UL)
+#define VADC_GXSRACT_AGSR2_MASK                 (0x01 << VADC_GXSRACT_AGSR2_SHIFT)
+#define VADC_GXSRACT_AGSR3_SHIFT                (3UL)
+#define VADC_GXSRACT_AGSR3_MASK                 (0x01 << VADC_GXSRACT_AGSR3_SHIFT)
+#define VADC_GXSRACT_ASSR0_SHIFT                (8UL)
+#define VADC_GXSRACT_ASSR0_MASK                 (0x01 << VADC_GXSRACT_ASSR0_SHIFT)
+#define VADC_GXSRACT_ASSR1_SHIFT                (9UL)
+#define VADC_GXSRACT_ASSR1_MASK                 (0x01 << VADC_GXSRACT_ASSR1_SHIFT)
+#define VADC_GXSRACT_ASSR2_SHIFT                (10UL)
+#define VADC_GXSRACT_ASSR2_MASK                 (0x01 << VADC_GXSRACT_ASSR2_SHIFT)
+#define VADC_GXSRACT_ASSR3_SHIFT                (11UL)
+#define VADC_GXSRACT_ASSR3_MASK                 (0x01 << VADC_GXSRACT_ASSR3_SHIFT)
+
+/* -------------------------------  VADC_GXEMUXCTR  ------------------------------- */
+#define VADC_GXEMUXCTR_EMUXSET_SHIFT            (0UL)
+#define VADC_GXEMUXCTR_EMUXSET_MASK             (0x07 << VADC_GXEMUXCTR_EMUXSET_SHIFT)
+#define VADC_GXEMUXCTR_EMUXACT_SHIFT            (8UL)
+#define VADC_GXEMUXCTR_EMUXACT_MASK             (0x07 << VADC_GXEMUXCTR_EMUXSET_SHIFT)
+#define VADC_GXEMUXCTR_EMUXCH_SHIFT             (16UL)
+
+#if defined(CONFIG_ARCH_CHIP_XMC4700) || defined(CONFIG_ARCH_CHIP_XMC4800)
+    #define VADC_GXEMUXCTR_EMUXCH_MASK          (0x3ff << VADC_GXEMUXCTR_EMUXCH_SHIFT)
+#endif /* XMC48700 SPECIFIC */
+
+#if defined(CONFIG_ARCH_CHIP_XMC4500)
+    #define VADC_GXEMUXCTR_EMUXCH_MASK          (0x1f << VADC_GXEMUXCTR_EMUXCH_SHIFT)
+#endif /* XMC4500 SPECIFIC */
+
+#define VADC_GXEMUXCTR_EMUXMODE_SHIFT           (26UL)
+#define VADC_GXEMUXCTR_EMUXMODE_MASK            (0x03 << VADC_GXEMUXCTR_EMUXMODE_SHIFT)
+#define VADC_GXEMUXCTR_EMXCOD_SHIFT             (28UL)
+#define VADC_GXEMUXCTR_EMXCOD_MASK              (0x01 << VADC_GXEMUXCTR_EMXCOD_SHIFT)
+#define VADC_GXEMUXCTR_EMXST_SHIFT              (29UL)
+#define VADC_GXEMUXCTR_EMXST_MASK               (0x01 << VADC_GXEMUXCTR_EMXST_SHIFT)
+#define VADC_GXEMUXCTR_EMXCSS_SHIFT             (30UL)
+#define VADC_GXEMUXCTR_EMXCSS_MASK              (0x01 << VADC_GXEMUXCTR_EMXCSS_SHIFT)
+#define VADC_GXEMUXCTR_EMXWC_SHIFT              (31UL)
+#define VADC_GXEMUXCTR_EMXWC_MASK               (0x01 << VADC_GXEMUXCTR_EMXWC_SHIFT)
+
+/* ---------------------------------  VADC_GXVFR  --------------------------------- */
+#define VADC_GXVFR_VF0_SHIFT                    (0UL)
+#define VADC_GXVFR_VF0_MASK                     (0x01 << VADC_GXVFR_VF0_SHIFT)
+#define VADC_GXVFR_VF1_SHIFT                    (1UL)
+#define VADC_GXVFR_VF1_MASK                     (0x01 << VADC_GXVFR_VF1_SHIFT)
+#define VADC_GXVFR_VF2_SHIFT                    (2UL)
+#define VADC_GXVFR_VF2_MASK                     (0x01 << VADC_GXVFR_VF2_SHIFT)
+#define VADC_GXVFR_VF3_SHIFT                    (3UL)
+#define VADC_GXVFR_VF3_MASK                     (0x01 << VADC_GXVFR_VF3_SHIFT)
+#define VADC_GXVFR_VF4_SHIFT                    (4UL)
+#define VADC_GXVFR_VF4_MASK                     (0x01 << VADC_GXVFR_VF4_SHIFT)
+#define VADC_GXVFR_VF5_SHIFT                    (5UL)
+#define VADC_GXVFR_VF5_MASK                     (0x01 << VADC_GXVFR_VF5_SHIFT)
+#define VADC_GXVFR_VF6_SHIFT                    (6UL)
+#define VADC_GXVFR_VF6_MASK                     (0x01 << VADC_GXVFR_VF6_SHIFT)
+#define VADC_GXVFR_VF7_SHIFT                    (7UL)
+#define VADC_GXVFR_VF7_MASK                     (0x01 << VADC_GXVFR_VF7_SHIFT)
+#define VADC_GXVFR_VF8_SHIFT                    (8UL)
+#define VADC_GXVFR_VF8_MASK                     (0x01 << VADC_GXVFR_VF8_SHIFT)
+#define VADC_GXVFR_VF9_SHIFT                    (9UL)
+#define VADC_GXVFR_VF9_MASK                     (0x01 << VADC_GXVFR_VF9_SHIFT)
+#define VADC_GXVFR_VF10_SHIFT                   (10UL)
+#define VADC_GXVFR_VF10_MASK                    (0x01 << VADC_GXVFR_VF10_SHIFT)
+#define VADC_GXVFR_VF11_SHIFT                   (11UL)
+#define VADC_GXVFR_VF11_MASK                    (0x01 << VADC_GXVFR_VF11_SHIFT)
+#define VADC_GXVFR_VF12_SHIFT                   (12UL)
+#define VADC_GXVFR_VF12_MASK                    (0x01 << VADC_GXVFR_VF12_SHIFT)
+#define VADC_GXVFR_VF13_SHIFT                   (13UL)
+#define VADC_GXVFR_VF13_MASK                    (0x01 << VADC_GXVFR_VF13_SHIFT)
+#define VADC_GXVFR_VF14_SHIFT                   (14UL)
+#define VADC_GXVFR_VF14_MASK                    (0x01 << VADC_GXVFR_VF14_SHIFT)
+#define VADC_GXVFR_VF15_SHIFT                   (15UL)
+#define VADC_GXVFR_VF15_MASK                    (0x01 << VADC_GXVFR_VF15_SHIFT)
+
+/* --------------------------------  VADC_GXCHCTR  -------------------------------- */
+#define VADC_GXCHCTR_ICLSEL_SHIFT               (0UL)
+#define VADC_GXCHCTR_ICLSEL_MASK                (0x03 << VADC_GXCHCTR_ICLSEL_SHIFT)
+#define VADC_GXCHCTR_BNDSELL_SHIFT              (4UL)
+#define VADC_GXCHCTR_BNDSELL_MASK               (0x03 << VADC_GXCHCTR_BNDSELL_SHIFT)
+#define VADC_GXCHCTR_BNDSELU_SHIFT              (6UL)
+#define VADC_GXCHCTR_BNDSELU_MASK               (0x03 << VADC_GXCHCTR_BNDSELU_SHIFT)
+#define VADC_GXCHCTR_CHEVMODE_SHIFT             (8UL)
+#define VADC_GXCHCTR_CHEVMODE_MASK              (0x03 << VADC_GXCHCTR_CHEVMODE_SHIFT)
+#define VADC_GXCHCTR_SYNC_SHIFT                 (10UL)
+#define VADC_GXCHCTR_SYNC_MASK                  (0x01 << VADC_GXCHCTR_SYNC_SHIFT)
+#define VADC_GXCHCTR_REFSEL_SHIFT               (11UL)
+#define VADC_GXCHCTR_REFSEL_MASK                (0x01 << VADC_GXCHCTR_REFSEL_SHIFT)
+#define VADC_GXCHCTR_RESREG_SHIFT               (16UL)
+#define VADC_GXCHCTR_RESREG_MASK                (0x0f << VADC_GXCHCTR_RESREG_SHIFT)
+#define VADC_GXCHCTR_RESTBS_SHIFT               (20UL)
+#define VADC_GXCHCTR_RESTBS_MASK                (0x01 << VADC_GXCHCTR_RESTBS_SHIFT)
+#define VADC_GXCHCTR_RESPOS_SHIFT               (21UL)
+#define VADC_GXCHCTR_RESPOS_MASK                (0x01 << VADC_GXCHCTR_RESPOS_SHIFT)
+#define VADC_GXCHCTR_BWDCH_SHIFT                (28UL)
+#define VADC_GXCHCTR_BWDCH_MASK                 (0x03 << VADC_GXCHCTR_BWDCH_SHIFT)
+#define VADC_GXCHCTR_BWDEN_SHIFT                (30UL)
+#define VADC_GXCHCTR_BWDEN_MASK                 (0x01 << VADC_GXCHCTR_BWDEN_SHIFT)
+
+/* ---------------------------------  VADC_GXRCR  --------------------------------- */
+#define VADC_GXRCR_DRCTR_SHIFT                  (16UL)
+#define VADC_GXRCR_DRCTR_MASK                   (0x0f << VADC_GXRCR_DRCTR_SHIFT)
+#define VADC_GXRCR_DMM_SHIFT                    (20UL)
+#define VADC_GXRCR_DMM_MASK                     (0x03 << VADC_GXRCR_DMM_SHIFT)
+#define VADC_GXRCR_WFR_SHIFT                    (24UL)
+#define VADC_GXRCR_WFR_MASK                     (0x01 << VADC_GXRCR_WFR_SHIFT)
+#define VADC_GXRCR_FEN_SHIFT                    (25UL)
+#define VADC_GXRCR_FEN_MASK                     (0x03 << VADC_GXRCR_FEN_SHIFT)
+#define VADC_GXRCR_SRGEN_SHIFT                  (31UL)
+#define VADC_GXRCR_SRGEN_MASK                   (0x01 << VADC_GXRCR_SRGEN_SHIFT)
+
+/* ---------------------------------  VADC_GXRES  --------------------------------- */
+#define VADC_GXRES_RESULT_SHIFT                 (0UL)
+#define VADC_GXRES_RESULT_MASK                  (0xffff << VADC_GXRES_RESULT_SHIFT)
+#define VADC_GXRES_DRC_SHIFT                    (16UL)
+#define VADC_GXRES_DRC_MASK                     (0x0f << VADC_GXRES_DRC_SHIFT)
+#define VADC_GXRES_CHNR_SHIFT                   (20UL)
+#define VADC_GXRES_CHNR_MASK                    (0x1f << VADC_GXRES_CHNR_SHIFT)
+#define VADC_GXRES_EMUX_SHIFT                   (25UL)
+#define VADC_GXRES_EMUX_MASK                    (0x07 << VADC_GXRES_EMUX_SHIFT)
+#define VADC_GXRES_CRS_SHIFT                    (28UL)
+#define VADC_GXRES_CRS_MASK                     (0x03 << VADC_GXRES_CRS_SHIFT)
+#define VADC_GXRES_FCR_SHIFT                    (30UL)
+#define VADC_GXRES_FCR_MASK                     (0x01 << VADC_GXRES_FCR_SHIFT)
+#define VADC_GXRES_VF_SHIFT                     (31UL)
+#define VADC_GXRES_VF_MASK                      (0x01 << VADC_GXRES_VF_SHIFT)
+
+/* ---------------------------------  VADC_GXRESD  -------------------------------- */
+#define VADC_GXRESD_RESULT_SHIFT                (0UL)
+#define VADC_GXRESD_RESULT_MASK                 (0xffff << VADC_GXRESD_RESULT_SHIFT)
+#define VADC_GXRESD_DRC_SHIFT                   (16UL)
+#define VADC_GXRESD_DRC_MASK                    (0x0f << VADC_GXRESD_DRC_SHIFT)
+#define VADC_GXRESD_CHNR_SHIFT                  (20UL)
+#define VADC_GXRESD_CHNR_MASK                   (0x1f << VADC_GXRESD_CHNR_SHIFT)
+#define VADC_GXRESD_EMUX_SHIFT                  (25UL)
+#define VADC_GXRESD_EMUX_MASK                   (0x07 << VADC_GXRESD_EMUX_SHIFT)
+#define VADC_GXRESD_CRS_SHIFT                   (28UL)
+#define VADC_GXRESD_CRS_MASK                    (0x03 << VADC_GXRESD_CRS_SHIFT)
+#define VADC_GXRESD_FCR_SHIFT                   (30UL)
+#define VADC_GXRESD_FCR_MASK                    (0x01 << VADC_GXRESD_FCR_SHIFT)
+#define VADC_GXRESD_VF_SHIFT                    (31UL)
+#define VADC_GXRESD_VF_MASK                     (0x01 << VADC_GXRESD_VF_SHIFT)
+
+#endif /* __ARCH_ARM_SRC_XMC4_HARDWARE_XMC4_VADC_H */

--- a/arch/arm/src/xmc4/xmc4_vadc.c
+++ b/arch/arm/src/xmc4/xmc4_vadc.c
@@ -1,0 +1,592 @@
+/**********************************************************************************************
+ * arch/arm/src/xmc4/xmc4_vadc.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * May include some logic from sample code provided by Infineon:
+ *
+ * Copyright (C) 2011-2015 Infineon Technologies AG. All rights reserved.
+ *
+ * Infineon Technologies AG (Infineon) is supplying this software for use
+ * with Infineon's microcontrollers.  This file can be freely distributed
+ * within development tools that are supporting such microcontrollers.
+ *
+ * THIS SOFTWARE IS PROVIDED AS IS. NO WARRANTIES, WHETHER EXPRESS,
+ * IMPLIED OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS
+ * SOFTWARE. INFINEON SHALL NOT, IN ANY CIRCUMSTANCES, BE LIABLE FOR
+ * SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, FOR ANY REASON WHATSOEVER.
+ *
+ **********************************************************************************************/
+
+/**********************************************************************************************
+ * Included Files
+ **********************************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <stdint.h>
+#include <errno.h>
+#include <assert.h>
+
+#include <arch/xmc4/chip.h>
+
+#include "arm_internal.h"
+#include "hardware/xmc4_scu.h"
+#include "xmc4_vadc.h"
+
+/**********************************************************************************************
+ * Private Data
+ **********************************************************************************************/
+
+static vadc_group_t *const g_vadc_group_array[XMC_VADC_MAXIMUM_NUM_GROUPS] =
+{
+  (vadc_group_t *)VADC_G0,
+  (vadc_group_t *)VADC_G1,
+  (vadc_group_t *)VADC_G2,
+  (vadc_group_t *)VADC_G3
+};
+
+/**********************************************************************************************
+ * Public Functions
+ **********************************************************************************************/
+
+/**********************************************************************************************
+ * Name: xmc4_vadc_global_enable
+ *
+ * Description:
+ *   Ungate the clock to the VADC module (if applicable) and bring the VADC
+ *   module out of reset state.
+ *   Called in xmc4_vadc_global_initialize.
+ *
+ **********************************************************************************************/
+
+void xmc4_vadc_global_enable(void)
+{
+  #ifdef XMC4_SCU_GATING
+  /* Check if VADC is gated */
+
+  if ((getreg32(XMC4_SCU_CGATSTAT0) & SCU_CGAT0_VADC) == 1)
+    {
+      /* Disable VADC gating */
+
+      putreg32(SCU_CGAT0_VADC, XMC4_SCU_CGATCLR0);
+    }
+
+  /* Set bit in PRCLR0 to de-assert VADC peripheral reset */
+
+  putreg32(SCU_PR0_VADCRS, XMC4_SCU_PRCLR0);
+  #else
+
+  /* Set bit in PRCLR0 to de-assert VADC peripheral reset */
+
+  putreg32(SCU_PR0_VADCRS, XMC4_SCU_PRCLR0);
+  #endif
+}
+
+/**********************************************************************************************
+ * Name: xmc4_vadc_global_disable
+ *
+ * Description:
+ *   Gate the clock to the VADC module (if applicable) and put the VADC
+ *   module into the reset state
+ *
+ **********************************************************************************************/
+
+void xmc4_vadc_global_disable(void)
+{
+  /* Set bit in PRSET0 to assert VADC peripheral reset */
+
+  putreg32(SCU_PR0_VADCRS, XMC4_SCU_PRSET0);
+
+  #ifdef XMC4_SCU_GATING
+  /* Check if VADC is ungated */
+
+  if ((getreg32(XMC4_SCU_CGATSTAT0) & SCU_CGAT0_VADC) == 0)
+    {
+      /* Enable VADC gating */
+
+      putreg32(SCU_CGAT0_VADC, XMC4_SCU_CGATSET0);
+    }
+  #endif
+}
+
+/**********************************************************************************************
+ * Name: xmc4_vadc_global_initialize
+ *
+ * Description:
+ *   Initializes the VADC global module with given configuration structure.
+ *   It initializes global input classes, boundaries , result resources.
+ *   Configures GLOBICLASS,GLOBBOUND,GLOBRCR registers.
+ *   It also configures the global analog and digital clock dividers
+ *   by setting GLOBCFG register.
+ *
+ **********************************************************************************************/
+
+void xmc4_vadc_global_initialize(const vadc_global_config_t *config)
+{
+  /* Enable the VADC module */
+
+  xmc4_vadc_global_enable();
+
+  VADC->CLC = (uint32_t)(config->clc);
+
+  /* Clock configuration, use DIVWC (write control) to write register */
+
+  VADC->GLOBCFG = (uint32_t)(config->globcfg
+                     | (uint32_t)(VADC_GLOBCFG_DIVWC_MASK));
+
+  /* Global input class 0 configuration */
+
+  VADC->GLOBICLASS[0] = (uint32_t)(config->class0.iclass);
+
+  /* Global input class 1 configuration */
+
+  VADC->GLOBICLASS[1] = (uint32_t)(config->class1.iclass);
+
+  /* Global result generation configuration */
+
+  VADC->GLOBRCR = (uint32_t)(config->globrcr);
+
+  /* Set global boundaries values */
+
+  VADC->GLOBBOUND = (uint32_t)(config->globbound);
+}
+
+/**********************************************************************************************
+ * Name: xmc4_vadc_group_initialize
+ *
+ * Description:
+ *   Initializes the VADC group module with the associated
+ *   configuration structure pointed by config. Initializes group conversion
+ *   class, arbiter configuration, boundary configuration by setting
+ *   GxICLASS,GxARBCFG,GxBOUND, registers.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; A negative errno value is returned to
+ *   indicate the nature of any failure.
+ *
+ **********************************************************************************************/
+
+int xmc4_vadc_group_initialize(vadc_group_t *const group_ptr,
+                                const vadc_group_config_t *config)
+{
+  if (!xmc_vadc_check_group_ptr(group_ptr))
+    {
+      return -EINVAL;
+    }
+
+  /* Configures the group-specific input classes,
+   * each channel is assigned to a class in GxCHCTRy
+   */
+
+  group_ptr->ICLASS[0] = config->class0.iclass;
+  group_ptr->ICLASS[1] = config->class1.iclass;
+
+  /* Configures the group arbitration behavior */
+
+  group_ptr->ARBCFG = config->g_arbcfg;
+
+  /* Configures the group-specific boundaries */
+
+  group_ptr->BOUND = config->g_bound;
+
+  return OK;
+}
+
+/**********************************************************************************************
+ * Name: xmc4_vadc_group_set_powermode
+ *
+ * Description:
+ *   Configures the power mode of a VADC group. For a VADC group to
+ *   actually convert an analog signal, its analog converter must be on.
+ *   Configure the register bit field GxARBCFG.ANONC
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; A negative errno value is returned to
+ *   indicate the nature of any failure.
+ *
+ **********************************************************************************************/
+
+int xmc4_vadc_group_set_powermode(vadc_group_t *const group_ptr,
+                                    const vadc_group_powermode_t power_mode)
+{
+  if (!xmc_vadc_check_group_ptr(group_ptr)
+        || (power_mode > XMC_VADC_GROUP_POWERMODE_NORMAL))
+    {
+      return -EINVAL;
+    }
+
+  uint32_t arbcfg = group_ptr->ARBCFG;
+
+  arbcfg &= ~((uint32_t)VADC_GXARBCFG_ANONC_MASK);
+  arbcfg |= (uint32_t)power_mode;
+
+  group_ptr->ARBCFG = arbcfg;
+
+  return OK;
+}
+
+/**********************************************************************************************
+ * Name: xmc4_vadc_global_start_calibration
+ *
+ * Description:
+ *   Start the calibration process and loops until all active groups
+ *   finish calibration. Call xmc4_vadc_global_enable and
+ *   xmc4_vadc_global_initialize before calibration.
+ *   Configures the register bit field GLOBCFG.SUCAL.
+ *
+ **********************************************************************************************/
+
+void xmc4_vadc_global_start_calibration(void)
+{
+  vadc_group_t * group_ptr;
+
+  /* Start Calibration */
+
+  VADC->GLOBCFG |= (uint32_t) VADC_GLOBCFG_SUCAL_MASK;
+
+  /* Loop until all groups to finish calibration */
+
+  for (int i = 0; i < XMC_VADC_MAXIMUM_NUM_GROUPS; i++)
+    {
+      group_ptr = g_vadc_group_array[i];
+
+      /* Check if group is active */
+
+      if ((group_ptr->ARBCFG) & (uint32_t)(VADC_GXARBCFG_ANONS_MASK))
+        {
+          /* Loop until it finish calibration */
+
+          while ((group_ptr->ARBCFG) & (uint32_t)VADC_GXARBCFG_CAL_MASK)
+            {
+              /* NOP */
+            }
+        }
+    }
+}
+
+/**********************************************************************************************
+ * Name: xmc4_vadc_group_background_enable_arbitrationslot
+ *
+ * Description:
+ *   Enables arbitration slot of the Background request source to
+ *   participate in the arbitration round. Even if a load event occurs the
+ *   Background channel can only be converted when the arbiter comes to the
+ *   Background slot. Thus this must be enabled if any conversion need to
+ *   take place.
+ *   Configure the register bit field GxARBPR.ASEN2.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; A negative errno value is returned to
+ *   indicate the nature of any failure.
+ *
+ **********************************************************************************************/
+
+int xmc4_vadc_group_background_enable_arbitrationslot(vadc_group_t *const group_ptr)
+{
+  if (!xmc_vadc_check_group_ptr(group_ptr))
+    {
+      return -EINVAL;
+    }
+
+  group_ptr->ARBPR |= (uint32_t)VADC_GXARBPR_ASEN2_MASK;
+
+  return OK;
+}
+
+/**********************************************************************************************
+ * Name: xmc4_vadc_group_background_disable_arbitrationslot
+ *
+ * Description:
+ *   Disables arbitration slot of the Background request source to
+ *   participate in the arbitration round. Even if a load event occurs the
+ *   Background channel can only be converted when the arbiter comes to the
+ *   Background slot. Thus this must be enabled if any conversion need to
+ *   take place.
+ *   Configure the register bit field GxARBPR.ASEN2.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; A negative errno value is returned to
+ *   indicate the nature of any failure.
+ *
+ **********************************************************************************************/
+
+int xmc4_vadc_group_background_disable_arbitrationslot(
+                                              vadc_group_t *const group_ptr)
+{
+  if (!xmc_vadc_check_group_ptr(group_ptr))
+    {
+      return -EINVAL;
+    }
+
+  group_ptr->ARBPR &= ~((uint32_t)VADC_GXARBPR_ASEN2_MASK);
+
+  return OK;
+}
+
+/**********************************************************************************************
+ * Name: xmc4_vadc_global_background_initialize
+ *
+ * Description:
+ *   Initializes the Background scan functional block. The BACKGROUND
+ *   SCAN request source functional block converts channels of all VADC groups
+ *   that have not been assigned as a priority channel (priority channels
+ *   can be converted only by queue and scan). Related arbitration slot must
+ *   be disabled to configure background request, then re-enabled.
+ *
+ **********************************************************************************************/
+
+void xmc4_vadc_global_background_initialize(const vadc_background_config_t *config)
+{
+  uint32_t reg;
+  uint32_t conv_start_mask;
+
+  /* Disable background request source to change its parameters */
+
+  for (int i = 0; i < XMC_VADC_MAXIMUM_NUM_GROUPS; i++)
+    {
+      xmc4_vadc_group_background_disable_arbitrationslot(g_vadc_group_array[i]);
+    }
+
+  /* Set start mode */
+
+  conv_start_mask = (uint32_t) 0;
+  if (XMC_VADC_STARTMODE_WFS != (vadc_startmode_t)config->conv_start_mode)
+    {
+      conv_start_mask = (uint32_t)VADC_GXARBPR_CSM2_MASK;
+    }
+
+  /* Configures GxARBPR register for each group */
+
+  for (int i = 0; i < XMC_VADC_MAXIMUM_NUM_GROUPS; i++)
+    {
+      reg = g_vadc_group_array[i]->ARBPR;
+
+      /* Program the priority of the request source : Background Scan is source 2 */
+
+      reg &= ~(uint32_t)(VADC_GXARBPR_PRIO2_MASK);
+      reg |= (uint32_t)((uint32_t)config->req_src_priority << VADC_GXARBPR_PRIO2_SHIFT);
+
+      /* Program the start mode */
+
+      reg |= conv_start_mask;
+
+      g_vadc_group_array[i]->ARBPR = reg;
+    }
+
+  /* Program BackgroundRequestSourceControl register, use XT and GT write control bitfields */
+
+  VADC->BRSCTRL = (uint32_t)(config->asctrl | (uint32_t)VADC_BRSCTRL_XTWC_MASK
+                                            | (uint32_t)VADC_BRSCTRL_GTWC_MASK);
+
+  /* Program Background Request Source Mode register */
+
+  VADC->BRSMR = (uint32_t)((config->asmr)
+                    | (uint32_t)((uint32_t)XMC_VADC_GATEMODE_IGNORE << VADC_BRSMR_ENGT_SHIFT));
+
+  if (XMC_VADC_STARTMODE_CNR == (vadc_startmode_t)(config->conv_start_mode))
+    {
+      VADC->BRSMR |= (uint32_t)VADC_BRSMR_RPTDIS_MASK;
+    }
+
+  /* Re enable request source */
+
+  for (int i = 0; i < XMC_VADC_MAXIMUM_NUM_GROUPS; i++)
+    {
+      xmc4_vadc_group_background_enable_arbitrationslot(g_vadc_group_array[i]);
+    }
+}
+
+/**********************************************************************************************
+ * Name: xmc4_vadc_group_channel_initialize
+ *
+ * Description:
+ *   Initializes the ADC channel for conversion. Must be called after
+ *   request source initialization for each channel to enable their conversion.
+ *   Configures registers GxCHCTRy and boundary flag GxBFL, GxBFLC and GxCHASS.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; A negative errno value is returned to
+ *   indicate the nature of any failure.
+ *
+ **********************************************************************************************/
+
+int xmc4_vadc_group_channel_initialize(vadc_group_t *const group_ptr, const uint32_t ch_num,
+                                        const vadc_channel_config_t *config)
+{
+  if (!xmc_vadc_check_group_ptr(group_ptr) || (ch_num > XMC_VADC_NUM_CHANNELS_PER_GROUP))
+    {
+      return -EINVAL;
+    }
+
+  uint32_t prio  = (uint32_t)config->channel_priority;
+
+  /* Set channel priority, channel_priority must be 0 for background channel */
+
+  uint32_t ch_assign  = group_ptr->CHASS;
+  ch_assign &= ~((uint32_t)((uint32_t)1 << ch_num));
+  ch_assign |= (uint32_t)(prio << ch_num);
+  group_ptr->CHASS = ch_assign;
+
+  /* Alias channel, can replace CH0 and CH1 with another channel number. */
+
+  if (config->alias_channel >= (int32_t)0)
+    {
+      uint32_t mask = (uint32_t)0;
+      if ((uint32_t)1 == ch_num)
+        {
+          mask = VADC_GXALIAS_ALIAS1_SHIFT;
+          group_ptr->ALIAS &= ~(uint32_t)(VADC_GXALIAS_ALIAS1_MASK);
+        }
+      else if ((uint32_t)0 == ch_num)
+        {
+          mask = VADC_GXALIAS_ALIAS0_SHIFT;
+          group_ptr->ALIAS &= ~(uint32_t)(VADC_GXALIAS_ALIAS0_MASK);
+        }
+
+      group_ptr->ALIAS |= (uint32_t)(config->alias_channel << mask);
+    }
+
+  /* Set channel boundaries flag */
+
+  group_ptr->BFL |= config->bfl;
+  #if (XMC_VADC_BOUNDARY_FLAG_SELECT == 1U)
+    group_ptr->BFLC |= config->bflc;
+  #endif
+
+  /* Program the CHCTR register */
+
+  group_ptr->CHCTR[ch_num] = config->chctr;
+
+  return OK;
+}
+
+/**********************************************************************************************
+ * Name: xmc4_vadc_global_background_add_channel_to_sequence
+ *
+ * Description:
+ *   Adds a channel to the background scan sequence. The pending
+ *   register are updated only after a new load event occured.
+ *   Configures the register bit fields of BRSSEL.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; A negative errno value is returned to
+ *   indicate the nature of any failure.
+ *
+ **********************************************************************************************/
+
+int xmc4_vadc_global_background_add_channel_to_sequence(const uint32_t grp_num,
+                                                        const uint32_t ch_num)
+{
+  if ((grp_num > XMC_VADC_MAXIMUM_NUM_GROUPS) || (ch_num > XMC_VADC_NUM_CHANNELS_PER_GROUP))
+    {
+      return -EINVAL;
+    }
+
+  VADC->BRSSEL[grp_num] |= (uint32_t)(1 << ch_num);
+
+  return OK;
+}
+
+/**********************************************************************************************
+ * Name: xmc4_vadc_global_background_enable_autoscan
+ *
+ * Description:
+ *   Enables continuous conversion mode (autoscan). Once all channels
+ *   belonging to a Background request source have been converted, a new  load
+ *   event occurs.
+ *   Configures the register bit field BRSMR.SCAN.
+ *
+ **********************************************************************************************/
+
+void xmc4_vadc_global_background_enable_autoscan(void)
+{
+  VADC->BRSMR |= (uint32_t)VADC_BRSMR_SCAN_MASK;
+}
+
+/**********************************************************************************************
+ * Name: xmc4_vadc_global_background_start_conversion
+ *
+ * Description:
+ *   Generates conversion request (Software initiated conversion).
+ *   The background scan must been init.
+ *   Configures the register bit field BRSMR.LDEV.
+ *
+ **********************************************************************************************/
+
+void xmc4_vadc_global_background_start_conversion(void)
+{
+  VADC->BRSMR |= (uint32_t)VADC_BRSMR_LDEV_MASK;
+}
+
+/**********************************************************************************************
+ * Name: xmc4_vadc_group_get_result
+ *
+ * Description:
+ *   Returns the result of the conversion in the given group result register.
+ *   Get the register bit field GxRES.RESULT.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; A negative errno value is returned to
+ *   indicate the nature of any failure.
+ *
+ **********************************************************************************************/
+
+int xmc4_vadc_group_get_result(vadc_group_t *const group_ptr,
+                                const uint32_t res_reg,
+                                uint16_t *result_ptr)
+{
+  if (!xmc_vadc_check_group_ptr(group_ptr) || (res_reg > XMC_VADC_NUM_RESULT_REGISTERS))
+    {
+      return -EINVAL;
+    }
+
+  *result_ptr = (uint16_t)(group_ptr->RES[res_reg]);
+
+  return OK;
+}
+
+/**********************************************************************************************
+ * Name: xmc4_vadc_group_channel_get_result
+ *
+ * Description:
+ *   Returns the result of the conversion of the given group channel.
+ *   Get the register bit field GxRES.RESULT.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; A negative errno value is returned to
+ *   indicate the nature of any failure.
+ *
+ **********************************************************************************************/
+
+int xmc4_vadc_group_get_channel_result(vadc_group_t *const group_ptr,
+                                        const uint32_t ch_num,
+                                        uint16_t *result_ptr)
+{
+  if (!xmc_vadc_check_group_ptr(group_ptr) || (ch_num > XMC_VADC_NUM_CHANNELS_PER_GROUP))
+    {
+      return -EINVAL;
+    }
+
+  uint8_t resreg = (uint8_t)((group_ptr->CHCTR[ch_num]
+                    & (uint32_t)VADC_GXCHCTR_RESREG_MASK) >> VADC_GXCHCTR_RESREG_SHIFT);
+
+  *result_ptr = (uint16_t)(group_ptr->RES[resreg]);
+
+  return OK;
+}

--- a/arch/arm/src/xmc4/xmc4_vadc.h
+++ b/arch/arm/src/xmc4/xmc4_vadc.h
@@ -1,0 +1,656 @@
+/********************************************************************************************************
+ * arch/arm/src/xmc4/xmc4_vadc.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * May include some logic from sample code provided by Infineon:
+ *
+ * Copyright (C) 2011-2015 Infineon Technologies AG. All rights reserved.
+ *
+ * Infineon Technologies AG (Infineon) is supplying this software for use
+ * with Infineon's microcontrollers.  This file can be freely distributed
+ * within development tools that are supporting such microcontrollers.
+ *
+ * THIS SOFTWARE IS PROVIDED AS IS. NO WARRANTIES, WHETHER EXPRESS,
+ * IMPLIED OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS
+ * SOFTWARE. INFINEON SHALL NOT, IN ANY CIRCUMSTANCES, BE LIABLE FOR
+ * SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, FOR ANY REASON WHATSOEVER.
+ *
+ ********************************************************************************************************/
+
+#ifndef __ARCH_ARM_SRC_XMC4_XMC4_VADC_H
+#define __ARCH_ARM_SRC_XMC4_XMC4_VADC_H
+
+/********************************************************************************************************
+ * Included Files
+ ********************************************************************************************************/
+
+#include <nuttx/config.h>
+#include <stdint.h>
+#include "xmc4_config.h"
+
+#include "hardware/xmc4_vadc.h"
+
+/********************************************************************************************************
+ * Public Types
+ ********************************************************************************************************/
+
+/**
+ *  Structure to handle the global and groups Input Class configurations.
+ *  Configured parameters are sample time and conversion Mode.
+ */
+
+typedef struct
+{
+  /* GLOBICLASSx register config */
+
+  union
+  {
+    struct
+    {
+      uint32_t sample_time_std_conv         : 5;  /* Sample time for channels.
+                                                   * Range:[0x0 to 0x1F] */
+      uint32_t                              : 3;
+      uint32_t conversion_mode_standard     : 3;  /* Conversion mode for channels.
+                                                   * Uses vadc_convmode_t */
+      uint32_t                              : 5;
+      uint32_t sampling_phase_emux_channel  : 5;  /* Sample time for EMUX channels.
+                                                   * Range:[0x0 to 0x1F] */
+      uint32_t                              : 3;
+      uint32_t conversion_mode_emux         : 3;  /* Conversion mode for EMUX.
+                                                   * Uses vadc_convmode_t */
+      uint32_t                              : 5;
+    };
+    uint32_t iclass;
+  };
+} vadc_input_class_config_t;
+
+/**
+ *   Structure to handle the VADC Global registers configurations
+ */
+
+typedef struct
+{
+  /* GLOBBOUND register config */
+
+  union
+  {
+    struct
+    {
+      uint32_t boundary0        : 12;  /* Boundary value for results comparison */
+      uint32_t                  : 4;
+      uint32_t boundary1        : 12;  /* Boundary value for results comparison */
+      uint32_t                  : 4;
+    };
+    uint32_t globbound;
+  };
+
+  /* GLOBCFG register config */
+
+  union
+  {
+    struct
+    {
+      uint32_t analog_clock_divider   : 5;   /* Clock for the converter. Range: [0x0 to 0x1F] */
+      uint32_t                        : 2;
+      uint32_t msb_conversion_clock   : 1;   /* Additional clock cycle for analog converter */
+      uint32_t arbiter_clock_divider  : 2;   /* Request source arbiter clock divider.
+                                              * Range: [0x0 to 0x3] */
+      uint32_t                        : 5;
+      uint32_t                        : 17;
+    };
+    uint32_t globcfg;
+  };
+
+  /* GLOBICLASS0 register config */
+
+  vadc_input_class_config_t class0;
+
+  /* GLOBICLASS1 register config */
+
+  vadc_input_class_config_t class1;
+
+  /* GLOBRCR register config */
+
+  union
+  {
+    struct
+    {
+      uint32_t                        : 16;
+      uint32_t data_reduction_control : 4;   /* Data reduction stages */
+      uint32_t                        : 4;
+      uint32_t wait_for_read_mode     : 1;   /* Results of the next conversion will not be overwritten. */
+      uint32_t                        : 6;
+      uint32_t event_gen_enable       : 1;   /* Generates an event on availability of new result. */
+    };
+    uint32_t globrcr;
+  };
+
+  /* CLC register config */
+
+  union
+  {
+    struct
+    {
+      uint32_t module_disable             : 1;   /* Disables the module clock. */
+      uint32_t                            : 2;
+      uint32_t disable_sleep_mode_control : 1;   /* Set it to true in order to disable the Sleep mode */
+      uint32_t                            : 28;
+    };
+    uint32_t clc;
+  };
+} vadc_global_config_t;
+
+/**
+ *   Structure to handle the VADC Groups registers configurations
+ */
+
+typedef struct
+{
+  /* GxICLASS0 register config */
+
+  vadc_input_class_config_t   class0;
+
+  /* GxICLASS1 register config */
+
+  vadc_input_class_config_t   class1;
+
+  /* GxBOUND register config */
+
+  union
+  {
+    struct
+    {
+      uint32_t boundary0    : 12;  /* Boundary value for results comparison */
+      uint32_t              : 4;
+      uint32_t boundary1    : 12;  /* Boundary value for results comparison */
+      uint32_t              : 4;
+    };
+    uint32_t g_bound;
+  };
+
+  /* GxARBCFG register config */
+
+  union
+  {
+    struct
+    {
+      uint32_t                            : 4;
+      uint32_t arbitration_round_length   : 2;  /* Number of arbiter slots to be considered */
+      uint32_t                            : 1;
+      uint32_t arbiter_mode               : 1;  /* Arbiter mode, either Continuous mode or Demand based. */
+      uint32_t                            : 24;
+    };
+    uint32_t g_arbcfg;
+  };
+} vadc_group_config_t;
+
+/**
+ *   Structure to handle the VADC Groups Channel registers configurations
+ */
+
+typedef struct
+{
+  /* GxCHCTRy register config */
+
+  union
+  {
+    struct
+    {
+      uint32_t input_class                : 2;  /* Input conversion class selection.
+                                                 * Uses vadc_channel_conv_t */
+      uint32_t                            : 2;
+      uint32_t lower_boundary_select      : 2;  /* Which boundary register serves as lower bound? */
+      uint32_t upper_boundary_select      : 2;  /* Which boundary register serves as upper bound? */
+      uint32_t event_gen_criteria         : 2;  /* When should an event be generated? */
+      uint32_t sync_conversion            : 1;  /* Enables synchronous conversion for the configured channel */
+      uint32_t alternate_reference        : 1;  /* Input reference voltage selection either VARef or CH-0. */
+      uint32_t                            : 4;
+      uint32_t result_reg_number          : 4;  /* Group result register number */
+      uint32_t use_global_result          : 1;  /* Use global result register for background request source channels */
+      uint32_t result_alignment           : 1;  /* Alignment of the results read in the result register. */
+      uint32_t                            : 6;
+      uint32_t broken_wire_detect_channel : 2;  /* Source to be used to charge the capacitor for BWD feature. */
+      uint32_t broken_wire_detect         : 1;  /* Configures extra phase before the capacitor is sampled. */
+    };
+    uint32_t chctr;
+  };
+
+  /* GxBFL register config */
+
+  union
+  {
+    struct
+    {
+      uint32_t                           : 8;
+#if (XMC_VADC_BOUNDARY_FLAG_SELECT == 1U)
+      uint32_t flag_output_condition_ch0 : 1;    /* Condition for which the boundary flag should change. */
+      uint32_t flag_output_condition_ch1 : 1;    /* Condition for which the boundary flag should change. */
+      uint32_t flag_output_condition_ch2 : 1;    /* Condition for which the boundary flag should change. */
+      uint32_t flag_output_condition_ch3 : 1;    /* Condition for which the boundary flag should change. */
+#else
+      uint32_t                           : 4;
+#endif
+      uint32_t                           : 4;
+#if (XMC_VADC_BOUNDARY_FLAG_SELECT == 1U)
+      uint32_t invert_boundary_flag_ch0  : 1;    /* Inverts boundary flag output. */
+      uint32_t invert_boundary_flag_ch1  : 1;    /* Inverts boundary flag output. */
+      uint32_t invert_boundary_flag_ch2  : 1;    /* Inverts boundary flag output. */
+      uint32_t invert_boundary_flag_ch3  : 1;    /* Inverts boundary flag output. */
+#else
+      uint32_t boundary_flag_output_ch0  : 1;    /* Enable the boundary flag output on the specific channel. */
+      uint32_t boundary_flag_output_ch1  : 1;    /* Enable the boundary flag output on the specific channel. */
+      uint32_t boundary_flag_output_ch2  : 1;    /* Enable the boundary flag output on the specific channel. */
+      uint32_t boundary_flag_output_ch3  : 1;    /* Enable the boundary flag output on the specific channel. */
+#endif
+      uint32_t                           : 12;
+    };
+    uint32_t bfl;
+  };
+
+#if (XMC_VADC_BOUNDARY_FLAG_SELECT == 1U)
+  /* GxBFLC register config */
+
+  union
+  {
+    struct
+    {
+      uint32_t boundary_flag_mode_ch0    : 4;     /* Specify the basic operation of boundary flag 0 */
+      uint32_t boundary_flag_mode_ch1    : 4;     /* Specify the basic operation of boundary flag 1 */
+      uint32_t boundary_flag_mode_ch2    : 4;     /* Specify the basic operation of boundary flag 2 */
+      uint32_t boundary_flag_mode_ch3    : 4;     /* Specify the basic operation of boundary flag 3 */
+      uint32_t                           : 16;
+    };
+    uint32_t bflc;
+  };
+
+#endif
+
+  bool    channel_priority;              /* Only non priority channels can be converted by Background Request Source */
+  int8_t  alias_channel;                 /* Specifies the channel which has to be aliased with CH0/CH1.
+                                          * Uses vadc_channel_alias_t */
+} vadc_channel_config_t;
+
+/**
+ *  Structure handle the VADC scan request source.
+ *  It can be either Channel Scan (0) or Background Scan (2).
+ */
+
+typedef struct
+{
+  uint32_t conv_start_mode        : 2;   /* This field determines how scan request source would request for
+                                          * Uses vadc_startmode_t */
+  uint32_t req_src_priority       : 2;   /* Request source priority for the arbiter. */
+
+  /* BRSCTRL (Background Request) or GxASCTRL (Autoscan Source) register config */
+
+  union
+  {
+    struct
+    {
+#if(XMC_VADC_GROUP_SRCREG_AVAILABLE == (1U))
+      uint32_t src_specific_result_reg     : 4;     /* Use any one Group related result register as the destination
+                                                     * for all conversions results. To use the  individual result register
+                                                     * from each channel configuration, configure this field with 0x0 */
+#else
+      uint32_t                    : 4;
+#endif
+      uint32_t                    : 4;
+      uint32_t trigger_signal     : 4;   /* Select one of the 16 possibilities for trigger. */
+      uint32_t                    : 1;
+      uint32_t trigger_edge       : 2;   /* Edge selection for trigger signal. */
+      uint32_t                    : 1;
+      uint32_t gate_signal        : 4;   /* Select one of the 16 possibilities for gating. */
+      uint32_t                    : 8;
+      uint32_t timer_mode         : 1;   /* Decides whether timer mode for equi-distant sampling shall be activated or not. */
+      uint32_t                    : 3;
+    };
+    uint32_t asctrl;
+  };
+
+  /* BRSMR (Background Request) or GxASMR (Autoscan Source) register config */
+
+  union
+  {
+    struct
+    {
+      uint32_t                    : 2;
+      uint32_t external_trigger   : 1;   /* Conversions be initiated by external hardware trigger */
+      uint32_t req_src_interrupt  : 1;   /* Request source event can be generated after a conversion sequence. */
+      uint32_t enable_auto_scan   : 1;   /* Enables the continuous conversion mode. */
+      uint32_t load_mode          : 1;   /* Selects load event mode. */
+      uint32_t                    : 26;
+    };
+    uint32_t asmr;
+  };
+} vadc_scan_config_t;
+
+typedef vadc_scan_config_t vadc_background_config_t;
+
+/* Defines the power mode that can be selected for each group. */
+
+typedef enum
+{
+  XMC_VADC_GROUP_POWERMODE_OFF       = 0,   /* Group is powered down */
+  XMC_VADC_GROUP_POWERMODE_RESERVED1,       /* Reserved */
+  XMC_VADC_GROUP_POWERMODE_RESERVED2,       /* Reserved */
+  XMC_VADC_GROUP_POWERMODE_NORMAL    = 3    /* Group is powered up */
+} vadc_group_powermode_t;
+
+/* Defines the conversion input classes that can be selected for each channel. */
+
+typedef enum
+{
+  XMC_VADC_CHANNEL_CONV_GROUP_CLASS0 = 0, /* Iclass0 specific to the group */
+  XMC_VADC_CHANNEL_CONV_GROUP_CLASS1,     /* IClass1 specific to the group */
+  XMC_VADC_CHANNEL_CONV_GLOBAL_CLASS0,    /* Iclass0 Module wide */
+  XMC_VADC_CHANNEL_CONV_GLOBAL_CLASS1     /* IClass1 Module wide */
+} vadc_channel_conv_t;
+
+/* Defines channel alias for channels 0 and 1.
+ * Other Channels can accept only XMC_VADC_CHANNEL_ALIAS_DISABLED.
+ */
+
+typedef enum
+{
+  XMC_VADC_CHANNEL_ALIAS_DISABLED = -1,
+  XMC_VADC_CHANNEL_ALIAS_CH0 = 0,
+  XMC_VADC_CHANNEL_ALIAS_CH1 = 1,
+  XMC_VADC_CHANNEL_ALIAS_CH2 = 2,
+  XMC_VADC_CHANNEL_ALIAS_CH3 = 3,
+  XMC_VADC_CHANNEL_ALIAS_CH4 = 4,
+  XMC_VADC_CHANNEL_ALIAS_CH5 = 5,
+  XMC_VADC_CHANNEL_ALIAS_CH6 = 6,
+  XMC_VADC_CHANNEL_ALIAS_CH7 = 7
+} vadc_channel_alias_t;
+
+/* Defines the conversion mode. It defines the resolution of conversion. */
+
+typedef enum
+{
+  XMC_VADC_CONVMODE_12BIT       = 0,  /* Results of conversion are 12bits wide */
+  XMC_VADC_CONVMODE_10BIT       = 1,  /* Results of conversion are 10bits wide */
+  XMC_VADC_CONVMODE_8BIT        = 2,  /* Results of conversion are 8bits wide */
+  XMC_VADC_CONVMODE_FASTCOMPARE = 5   /* Input signal compared with a preset range */
+} vadc_convmode_t;
+
+/* Defines the mode of operation of a channel, when an ongoing conversion gets interrupted in between. */
+
+typedef enum
+{
+  XMC_VADC_STARTMODE_WFS = 0, /* An ongoing conversion completes without interruption */
+  XMC_VADC_STARTMODE_CIR,     /* An ongoing conversion can be interrupted and resumed later */
+  XMC_VADC_STARTMODE_CNR      /* An ongoing conversion can be interrupted and never resumed, check GxASMR.RPTDIS */
+} vadc_startmode_t;
+
+/* Defines the condition for gating the conversion requests. It can be used to set the ENGT field
+ * of ASMR/BSMR/QMR register respectively for auto_scan/background_scan/queue request sources.
+ */
+
+typedef enum
+{
+  XMC_VADC_GATEMODE_BLOCK = 0,  /* External triggers are permanently blocked */
+  XMC_VADC_GATEMODE_IGNORE,     /* External triggers are unconditionally passed */
+  XMC_VADC_GATEMODE_ACTIVEHIGH, /* External trigger is passed only if the gate signal is high */
+  XMC_VADC_GATEMODE_ACTIVELOW   /* External trigger is passed only if the gate signal is low */
+} vadc_gatemode_t;
+
+/********************************************************************************************************
+ * Private Function
+ ********************************************************************************************************/
+
+static inline bool xmc_vadc_check_group_ptr(vadc_group_t *const group_ptr)
+{
+  return ((group_ptr == VADC_G0) || (group_ptr == VADC_G1)
+            || (group_ptr == VADC_G2) || (group_ptr == VADC_G3));
+}
+
+/********************************************************************************************************
+ * Public Function Prototypes
+ ********************************************************************************************************/
+
+/********************************************************************************************************
+ * Name: xmc4_vadc_global_enable
+ *
+ * Description:
+ *   Ungate the clock to the VADC module (if applicable) and bring the VADC
+ *   module out of reset state.
+ *   Called in xmc4_vadc_global_initialize.
+ *
+ ********************************************************************************************************/
+
+void xmc4_vadc_global_enable(void);
+
+/********************************************************************************************************
+ * Name: xmc4_vadc_global_disable
+ *
+ * Description:
+ *   Gate the clock to the VADC module (if applicable) and put the VADC
+ *   module into the reset state
+ *
+ ********************************************************************************************************/
+
+void xmc4_vadc_global_disable(void);
+
+/********************************************************************************************************
+ * Name: xmc4_vadc_global_initialize
+ *
+ * Description:
+ *   Initializes the VADC global module with the associated
+ *   configuration structure pointed by config. It initializes global input
+ *   classes, boundaries , result resources by setting
+ *   GLOBICLASS,GLOBBOUND,GLOBRCR registers. It also configures the global
+ *   analog and digital clock dividers by setting GLOBCFG register.
+ *
+ ********************************************************************************************************/
+
+void xmc4_vadc_global_initialize(const vadc_global_config_t *config);
+
+/********************************************************************************************************
+ * Name: xmc4_vadc_group_initialize
+ *
+ * Description:
+ *   Initializes the VADC group module with the associated
+ *   configuration structure pointed by config. It initializes group conversion
+ *   class, arbiter configuration, boundary configuration by setting
+ *   GxICLASS,GxARBCFG,GxBOUND, registers.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; A negative errno value is returned to
+ *   indicate the nature of any failure.
+ *
+ ********************************************************************************************************/
+
+int xmc4_vadc_group_initialize(vadc_group_t *const group_ptr, const vadc_group_config_t *config);
+
+/********************************************************************************************************
+ * Name: xmc4_vadc_group_set_powermode
+ *
+ * Description:
+ *   Configures the power mode of a VADC group. For a VADC group to
+ *   actually convert an analog signal, its analog converter must be turned on.
+ *   Configure the register bit field GxARBCFG.ANONC
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; A negative errno value is returned to
+ *   indicate the nature of any failure.
+ *
+ ********************************************************************************************************/
+
+int xmc4_vadc_group_set_powermode(vadc_group_t *const group_ptr,
+                                    const vadc_group_powermode_t power_mode);
+
+/********************************************************************************************************
+ * Name: xmc4_vadc_global_start_calibration
+ *
+ * Description:
+ *   Start the calibration process and loops until all active groups
+ *   finish calibration. Call xmc4_vadc_global_enable and
+ *   xmc4_vadc_global_initialize before calibration.
+ *   Configures the register bit field GLOBCFG.SUCAL.
+ *
+ ********************************************************************************************************/
+
+void xmc4_vadc_global_start_calibration(void);
+
+/********************************************************************************************************
+ * Name: xmc4_vadc_group_background_enable_arbitrationslot
+ *
+ * Description:
+ *   Enables arbitration slot of the Background request source to
+ *   participate in the arbitration round. Even if a load event occurs the
+ *   Background channel can only be converted when the arbiter comes to the
+ *   Background slot. Thus this must be enabled if any conversion need to take
+ *   place.
+ *   Configure the register bit field GxARBPR.ASEN2.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; A negative errno value is returned to
+ *   indicate the nature of any failure.
+ *
+ ********************************************************************************************************/
+
+int xmc4_vadc_group_background_enable_arbitrationslot(vadc_group_t *const group_ptr);
+
+/********************************************************************************************************
+ * Name: xmc4_vadc_group_background_disable_arbitrationslot
+ *
+ * Description:
+ *   Disables arbitration slot of the Background request source to
+ *   participate in the arbitration round. Even if a load event occurs the
+ *   Background channel can only be converted when the arbiter comes to the
+ *   Background slot. Thus this must be enabled if any conversion need to take
+ *   place.
+ *   Configure the register bit field GxARBPR.ASEN2.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; A negative errno value is returned to
+ *   indicate the nature of any failure.
+ *
+ ********************************************************************************************************/
+
+int xmc4_vadc_group_background_disable_arbitrationslot(vadc_group_t *const group_ptr);
+
+/********************************************************************************************************
+ * Name: xmc4_vadc_global_background_initialize
+ *
+ * Description:
+ *   Initializes the Background scan functional block. The BACKGROUND
+ *   SCAN request source functional block converts channels of all VADC groups
+ *   that have not been assigned as a priority channel (priority channels can be
+ *   converted only by queue and scan). Related arbitration slot must be
+ *   disabled to configure background request, then re-enabled.
+ *
+ ********************************************************************************************************/
+
+void xmc4_vadc_global_background_initialize(const vadc_background_config_t *config);
+
+/********************************************************************************************************
+ * Name: xmc4_vadc_group_channel_initialize
+ *
+ * Description:
+ *   Initializes the ADC channel for conversion. Must be called after
+ *   request source initialization for each channel to enable their conversion.
+ *   Configures registers GxCHCTRy and boundary flag GxBFL, GxBFLC and GxCHASS.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; A negative errno value is returned to
+ *   indicate the nature of any failure.
+ *
+ ********************************************************************************************************/
+
+int xmc4_vadc_group_channel_initialize(vadc_group_t *const group_ptr,
+                                        const uint32_t ch_num,
+                                        const vadc_channel_config_t *config);
+
+/********************************************************************************************************
+ * Name: xmc4_vadc_global_background_add_channel_to_sequence
+ *
+ * Description:
+ *   Adds a channel to the background scan sequence. The pending
+ *   register are updated only after a new load event occured.
+ *   Configures the register bit fields of BRSSEL.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; A negative errno value is returned to
+ *   indicate the nature of any failure.
+ *
+ ********************************************************************************************************/
+
+int xmc4_vadc_global_background_add_channel_to_sequence(const uint32_t grp_num,
+                                                        const uint32_t ch_num);
+
+/********************************************************************************************************
+ * Name: xmc4_vadc_global_background_enable_autoscan
+ *
+ * Description:
+ *   Enables continuous conversion mode (autoscan). Once all channels
+ *   belonging to a Background request source have been converted, a new  load
+ *   event occurs.
+ *   Configures the register bit field BRSMR.SCAN.
+ *
+ ********************************************************************************************************/
+
+void xmc4_vadc_global_background_enable_autoscan();
+
+/********************************************************************************************************
+ * Name: xmc4_vadc_global_background_start_conversion
+ *
+ * Description:
+ *   Generates conversion request (Software initiated conversion).
+ *   The background scan must been init.
+ *   Configures the register bit field BRSMR.LDEV.
+ *
+ ********************************************************************************************************/
+
+void xmc4_vadc_global_background_start_conversion();
+
+/********************************************************************************************************
+ * Name: xmc4_vadc_group_get_result
+ *
+ * Description:
+ *   Returns the result of the conversion in the given group result register.
+ *   Get the register bit field GxRES.RESULT.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; A negative errno value is returned to
+ *   indicate the nature of any failure.
+ *
+ ********************************************************************************************************/
+
+int xmc4_vadc_group_get_result(vadc_group_t *const group_ptr,
+                                const uint32_t res_reg,
+                                uint16_t *result_ptr);
+
+/********************************************************************************************************
+ * Name: xmc4_vadc_group_channel_get_result
+ *
+ * Description:
+ *   Returns the result of the conversion of the given group channel.
+ *   Get the register bit field GxRES.RESULT.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; A negative errno value is returned to
+ *   indicate the nature of any failure.
+ *
+ ********************************************************************************************************/
+
+int xmc4_vadc_group_get_channel_result(vadc_group_t *const group_ptr,
+                                        const uint32_t ch_num,
+                                        uint16_t *result_ptr);
+
+#endif /* __ARCH_ARM_SRC_XMC4_XMC4_VADC_H */


### PR DESCRIPTION
## Summary
Added driver for XMC4[78] and XMC45 series VADC peripheral. 
Driver includes :
- Complete register map and bit fields detail for both series.
- VADC Group and Channel config handler for easy register programming. 
- Background Scan request source partial support but working conversion with basic configuration. 

## Impact

## Testing
Tested on a XMC4800 custom board with 3 channels of same group.