### PR TITLE
sched/kconfig: add PID_INITIAL_LENGTH

### DIFF
--- a/include/nuttx/lib/math32.h
+++ b/include/nuttx/lib/math32.h
@@ -52,11 +52,15 @@
 #define FLS2(n)  ((n) & 0x2        ?  1 + FLS1 ((n) >>  1) : FLS1 (n))
 #define FLS1(n)  ((n) & 0x1        ?  1 : 0)
 
+/* Checks if an integer is power of two at compile time */
+
+#define IS_POWER_OF_2(n)           ((n) > 0 && ((n) & (n - 1)) == 0)
+
 /* Returns round up and round down value of log2(n). Note: it can be used at
  * compile time.
  */
 
-#define LOG2_CEIL(n)  ((n) & (n - 1) ? FLS(n) : FLS(n) - 1)
+#define LOG2_CEIL(n)  (IS_POWER_OF_2(n) ? FLS(n) - 1 : FLS(n))
 #define LOG2_FLOOR(n) (FLS(n) - 1)
 
 /****************************************************************************

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -1939,3 +1939,12 @@ config GROUP_KILL_CHILDREN_TIMEOUT_MS
 		> 0 means wait timeout
 		= 0 means don't do kill signal
 
+config PID_INITIAL_COUNT
+	int "Initial length of pid table"
+	default 8 if DEFAULT_SMALL
+	default 16 if !DEFAULT_SMALL
+	---help---
+		This is the initial length of pid table, which the system
+		can still expand when needed. It is rounded up to power of
+		two by current implementation. If the number of threads in
+		your system is known at design time, setting this to it.

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -45,6 +45,7 @@
 #include <nuttx/binfmt/binfmt.h>
 #include <nuttx/drivers/drivers.h>
 #include <nuttx/init.h>
+#include <nuttx/lib/math32.h>
 
 #include "task/task.h"
 #include "sched/sched.h"
@@ -623,7 +624,7 @@ void nx_start(void)
 
   /* Initialize the logic that determine unique process IDs. */
 
-  g_npidhash = 4;
+  g_npidhash = 1 << LOG2_CEIL(CONFIG_PID_INITIAL_COUNT);
   while (g_npidhash <= CONFIG_SMP_NCPUS)
     {
       g_npidhash <<= 1;


### PR DESCRIPTION
## Summary

sched/Kconfig: add INITIAL_PID_LIMIT option

This adds the flexibility to configure pid hash table length. It allows to
provision the table right at once for cases where number of threads are
known at design time.

## Impact

None

## Testing

- Local test with `rv-virt/nsh` and `rv-virt/nsh64`
- CI checking
