### PR TITLE
riscv-v/fork.S: Fix clobbering of s0 in fork()

### DIFF
--- a/arch/risc-v/src/common/fork.S
+++ b/arch/risc-v/src/common/fork.S
@@ -117,8 +117,8 @@ up_fork:
   REGSTORE    s0, FORK_S0_OFFSET(sp)
 #endif
 
-  addi        s0, sp, FORK_SIZEOF
-  REGSTORE    s0, FORK_SP_OFFSET(sp) /* original SP */
+  addi        a0, sp, FORK_SIZEOF
+  REGSTORE    a0, FORK_SP_OFFSET(sp) /* original SP */
   REGSTORE    x1, FORK_RA_OFFSET(sp) /* return address */
 
   /* Floating point registers */


### PR DESCRIPTION
## Summary
Value of s0 (callee-saved) must be preserved through the call, use a0 (caller-saved) to calculate the original SP instead.
## Impact
Fix bug in fork()
## Testing
None
