### PR TITLE
Allow the sim to set the MTU of netdevice and support the jumbo frame.

### DIFF
--- a/arch/sim/Kconfig
+++ b/arch/sim/Kconfig
@@ -223,6 +223,14 @@ config SIM_NETDEV_VPNKIT
 
 endchoice
 
+config SIM_NETDEV_MTU
+    int "The MTU of Simulated Network Device"
+    default 1500
+    range 1280 65535 if NET_IPv6
+    range 576 65535 if !NET_IPv6
+    ---help---
+        The MTU of the network devices.
+
 config SIM_NETDEV_NUMBER
 	int "Number of Simulated Network Device"
 	default 1

--- a/arch/sim/src/sim/posix/sim_tapdev.c
+++ b/arch/sim/src/sim/posix/sim_tapdev.c
@@ -249,10 +249,20 @@ void sim_tapdev_init(int devidx, void *priv,
       close(tapdevfd);
       return;
     }
-#else
+#endif
+
   memset(&ifr, 0, sizeof(ifr));
   strncpy(ifr.ifr_name, gdevname[devidx], IFNAMSIZ);
-#endif
+  ifr.ifr_mtu = CONFIG_SIM_NETDEV_MTU;
+  ret = ioctl(sockfd, SIOCSIFMTU, &ifr);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "TAPDEV: ioctl failed (can't set MTU "
+                      "for %s): %d\n", gdevname[devidx], -ret);
+      close(sockfd);
+      close(tapdevfd);
+      return;
+    }
 
   ret = ioctl(sockfd, SIOCGIFMTU, &ifr);
   close(sockfd);

--- a/arch/sim/src/sim/sim_netdriver.c
+++ b/arch/sim/src/sim/sim_netdriver.c
@@ -71,7 +71,8 @@
 
 #include "sim_internal.h"
 
-#define SIM_NETDEV_BUFSIZE (MAX_NETDEV_PKTSIZE + CONFIG_NET_GUARDSIZE)
+#define SIM_NETDEV_BUFSIZE (CONFIG_SIM_NETDEV_MTU + ETH_HDRLEN + \
+                            CONFIG_NET_GUARDSIZE)
 
 /* We don't know packet length before receiving, so we can only offload it
  * when netpkt's buffer is long enough.

--- a/include/nuttx/net/netdev.h
+++ b/include/nuttx/net/netdev.h
@@ -998,6 +998,21 @@ int netdev_iob_prepare(FAR struct net_driver_s *dev, bool throttled,
                        unsigned int timeout);
 
 /****************************************************************************
+ * Name: netdev_iob_prepare_dynamic
+ *
+ * Description:
+ *   Pre-alloc the iob for the data to be sent.
+ *
+ * Assumptions:
+ *   The caller has locked the network.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_IOB_ALLOC
+void netdev_iob_prepare_dynamic(FAR struct net_driver_s *dev, uint16_t size);
+#endif
+
+/****************************************************************************
  * Name: netdev_iob_replace
  *
  * Description:

--- a/net/Kconfig
+++ b/net/Kconfig
@@ -146,6 +146,13 @@ config NET_LL_GUARDSIZE
 		the L2/L3 (MAC/IP) data on Network layer, which will be beneficial
 		to L3 network layer protocol transparent transmission and forwarding
 
+config NET_JUMBO_FRAME
+	bool "Net jumbo frame"
+	depends on IOB_ALLOC
+	default n
+	---help---
+		Optimize the sending of the JUMBO frame in network stack.
+
 config NET_RECV_BUFSIZE
 	int "Net Default Receive buffer size"
 	default 0

--- a/net/icmp/icmp_sendmsg.c
+++ b/net/icmp/icmp_sendmsg.c
@@ -99,6 +99,10 @@ static void sendto_request(FAR struct net_driver_s *dev,
 {
   FAR struct icmp_hdr_s *icmp;
 
+#ifdef CONFIG_NET_JUMBO_FRAME
+  netdev_iob_prepare_dynamic(dev, pstate->snd_buflen + IPv4_HDRLEN);
+#endif
+
   /* Set-up to send that amount of data. */
 
   devif_send(dev, pstate->snd_buf, pstate->snd_buflen, IPv4_HDRLEN);

--- a/net/icmpv6/icmpv6_sendmsg.c
+++ b/net/icmpv6/icmpv6_sendmsg.c
@@ -98,6 +98,10 @@ static void sendto_request(FAR struct net_driver_s *dev,
 {
   FAR struct icmpv6_echo_request_s *icmpv6;
 
+#ifdef CONFIG_NET_JUMBO_FRAME
+  netdev_iob_prepare_dynamic(dev, pstate->snd_buflen + IPv6_HDRLEN);
+#endif
+
   /* Set-up to send that amount of data. */
 
   devif_send(dev, pstate->snd_buf, pstate->snd_buflen, IPv6_HDRLEN);

--- a/net/netdev/netdev_iob.c
+++ b/net/netdev/netdev_iob.c
@@ -85,6 +85,43 @@ int netdev_iob_prepare(FAR struct net_driver_s *dev, bool throttled,
 }
 
 /****************************************************************************
+ * Name: netdev_iob_prepare_dynamic
+ *
+ * Description:
+ *   Pre-alloc the iob for the data to be sent.
+ *
+ * Assumptions:
+ *   The caller has locked the network.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_IOB_ALLOC
+void netdev_iob_prepare_dynamic(FAR struct net_driver_s *dev, uint16_t size)
+{
+  FAR struct iob_s *iob;
+  size += CONFIG_NET_LL_GUARDSIZE;
+
+  if (dev->d_iob && size <= IOB_BUFSIZE(dev->d_iob))
+    {
+      return;
+    }
+
+  /* alloc new iob for jumbo frame */
+
+  iob = iob_alloc_dynamic(size);
+  if (iob == NULL)
+    {
+      nerr("ERROR: Failed to allocate an I/O buffer.");
+      return;
+    }
+
+  iob_reserve(iob, CONFIG_NET_LL_GUARDSIZE);
+
+  netdev_iob_replace(dev, iob);
+}
+#endif
+
+/****************************************************************************
  * Name: netdev_iob_replace
  *
  * Description:

--- a/net/tcp/tcp_send_buffered.c
+++ b/net/tcp/tcp_send_buffered.c
@@ -747,6 +747,15 @@ static uint16_t psock_send_eventhandler(FAR struct net_driver_s *dev,
 
           tcp_setsequence(conn->sndseq, TCP_WBSEQNO(wrb));
 
+#ifdef CONFIG_NET_JUMBO_FRAME
+          if (sndlen <= conn->mss)
+            {
+              /* alloc iob */
+
+              netdev_iob_prepare_dynamic(dev, sndlen + tcpip_hdrsize(conn));
+            }
+#endif
+
           ret = devif_iob_send(dev, TCP_WBIOB(wrb), sndlen,
                                0, tcpip_hdrsize(conn));
           if (ret <= 0)
@@ -1073,6 +1082,15 @@ static uint16_t psock_send_eventhandler(FAR struct net_driver_s *dev,
            * corresponding to the amount of data already sent. (this
            * won't actually happen until the polling cycle completes).
            */
+
+#ifdef CONFIG_NET_JUMBO_FRAME
+          if (sndlen <= conn->mss)
+            {
+              /* alloc iob */
+
+              netdev_iob_prepare_dynamic(dev, sndlen + tcpip_hdrsize(conn));
+            }
+#endif
 
           ret = devif_iob_send(dev, TCP_WBIOB(wrb), sndlen,
                                TCP_WBSENT(wrb), tcpip_hdrsize(conn));

--- a/net/udp/udp.h
+++ b/net/udp/udp.h
@@ -546,7 +546,11 @@ FAR struct udp_wrbuffer_s *udp_wrbuffer_timedalloc(unsigned int timeout);
  ****************************************************************************/
 
 #ifdef CONFIG_NET_UDP_WRITE_BUFFERS
+#ifdef CONFIG_NET_JUMBO_FRAME
+FAR struct udp_wrbuffer_s *udp_wrbuffer_tryalloc(int len);
+#else
 FAR struct udp_wrbuffer_s *udp_wrbuffer_tryalloc(void);
+#endif
 #endif /* CONFIG_NET_UDP_WRITE_BUFFERS */
 
 /****************************************************************************

--- a/net/udp/udp_sendto_buffered.c
+++ b/net/udp/udp_sendto_buffered.c
@@ -720,6 +720,13 @@ ssize_t psock_udp_sendto(FAR struct socket *psock, FAR const void *buf,
        * unlocked here.
        */
 
+#ifdef CONFIG_NET_JUMBO_FRAME
+
+      /* alloc iob of gso pkt for udp data */
+
+      wrb = udp_wrbuffer_tryalloc(len + udpip_hdrsize(conn) +
+                                  CONFIG_NET_LL_GUARDSIZE);
+#else
       if (nonblock)
         {
           wrb = udp_wrbuffer_tryalloc();
@@ -729,6 +736,7 @@ ssize_t psock_udp_sendto(FAR struct socket *psock, FAR const void *buf,
           wrb = udp_wrbuffer_timedalloc(udp_send_gettimeout(start,
                                                             timeout));
         }
+#endif
 
       if (wrb == NULL)
         {

--- a/net/udp/udp_wrbuffer.c
+++ b/net/udp/udp_wrbuffer.c
@@ -235,7 +235,11 @@ FAR struct udp_wrbuffer_s *udp_wrbuffer_timedalloc(unsigned int timeout)
  *
  ****************************************************************************/
 
+#ifdef CONFIG_NET_JUMBO_FRAME
+FAR struct udp_wrbuffer_s *udp_wrbuffer_tryalloc(int len)
+#else
 FAR struct udp_wrbuffer_s *udp_wrbuffer_tryalloc(void)
+#endif
 {
   FAR struct udp_wrbuffer_s *wrb;
 
@@ -262,7 +266,12 @@ FAR struct udp_wrbuffer_s *udp_wrbuffer_tryalloc(void)
 
   /* Now get the first I/O buffer for the write buffer structure */
 
-  wrb->wb_iob = iob_tryalloc(false);
+  wrb->wb_iob =
+#ifdef CONFIG_NET_JUMBO_FRAME
+    iob_alloc_dynamic(len);
+#else
+    iob_tryalloc(false);
+#endif
   if (!wrb->wb_iob)
     {
       nerr("ERROR: Failed to allocate I/O buffer\n");


### PR DESCRIPTION
## Summary
Support the jumbo frame in the sim.
- First, support setting mtu on sim;
- Then, optimize the use of iob by jumbo frame packets, and pre-alloc an iob in the protocol stack for each jumbo frame packet, supporting the ICMP, UDP and TCP.
## Impact
The sim can support the JUMBO frame packets.
 
## Testing
- First, configure the options, 
 ```
CONFIG_SIM_NETDEV_MTU = 3000
CONFIG_NET_JUMBO_FRAME=y
```
- Then, we use the ICMP to test.
```
ping -s 3000 10.0.1.1
```
- Finally, capture packets on nuttx0 using the Wireshark. We should be able to see ICMP packets with the length of 3042 bytes.

