### PR TITLE
sched/signal: move signal structures pool to bss

### DIFF
--- a/boards/arm/lpc17xx_40xx/lpc4088-devkit/scripts/memory.ld
+++ b/boards/arm/lpc17xx_40xx/lpc4088-devkit/scripts/memory.ld
@@ -73,9 +73,9 @@ MEMORY
 
   /* 64Kb of SRAM in the CPU block */
 
-  ksram (rwx)      : ORIGIN = 0x10000000, LENGTH = 4K   /* May include waste */
-  usram (rwx)      : ORIGIN = 0x10001000, LENGTH = 4K
-  xsram (rwx)      : ORIGIN = 0x10002000, LENGTH = 24K  /* All used as heap */
+  ksram (rwx)      : ORIGIN = 0x10000000, LENGTH = 6K   /* May include waste */
+  usram (rwx)      : ORIGIN = 0x10001800, LENGTH = 4K
+  xsram (rwx)      : ORIGIN = 0x10002800, LENGTH = 22K  /* All used as heap */
 
   /* Other peripheral memory (free, nothing is linked here) */
 

--- a/boards/arm/lpc17xx_40xx/lpc4088-quickstart/scripts/memory.ld
+++ b/boards/arm/lpc17xx_40xx/lpc4088-quickstart/scripts/memory.ld
@@ -73,9 +73,9 @@ MEMORY
 
   /* 64Kb of SRAM in the CPU block */
 
-  ksram (rwx)      : ORIGIN = 0x10000000, LENGTH = 4K   /* May include waste */
-  usram (rwx)      : ORIGIN = 0x10001000, LENGTH = 4K
-  xsram (rwx)      : ORIGIN = 0x10002000, LENGTH = 24K  /* All used as heap */
+  ksram (rwx)      : ORIGIN = 0x10000000, LENGTH = 6K   /* May include waste */
+  usram (rwx)      : ORIGIN = 0x10001800, LENGTH = 4K
+  xsram (rwx)      : ORIGIN = 0x10002800, LENGTH = 22K  /* All used as heap */
 
   /* Other peripheral memory (free, nothing is linked here) */
 

--- a/boards/arm/lpc17xx_40xx/open1788/scripts/memory.ld
+++ b/boards/arm/lpc17xx_40xx/open1788/scripts/memory.ld
@@ -73,9 +73,9 @@ MEMORY
 
   /* 64Kb of SRAM in the CPU block */
 
-  ksram (rwx)      : ORIGIN = 0x10000000, LENGTH = 4K   /* May include waste */
-  usram (rwx)      : ORIGIN = 0x10001000, LENGTH = 4K
-  xsram (rwx)      : ORIGIN = 0x10002000, LENGTH = 24K  /* All used as heap */
+  ksram (rwx)      : ORIGIN = 0x10000000, LENGTH = 6K   /* May include waste */
+  usram (rwx)      : ORIGIN = 0x10001800, LENGTH = 4K
+  xsram (rwx)      : ORIGIN = 0x10002800, LENGTH = 22K  /* All used as heap */
 
   /* Other peripheral memory (free, nothing is linked here) */
 

--- a/boards/arm/sam34/sam3u-ek/scripts/memory.ld
+++ b/boards/arm/sam34/sam3u-ek/scripts/memory.ld
@@ -72,9 +72,9 @@ MEMORY
 
   /* 32Kb SRAM */
 
-  ksram1 (rwx) : ORIGIN = 0x20000000, LENGTH = 4K
-  usram1 (rwx) : ORIGIN = 0x20001000, LENGTH = 4K
-  xsram1 (rwx) : ORIGIN = 0x20002000, LENGTH = 24K
+  ksram1 (rwx) : ORIGIN = 0x20000000, LENGTH = 6K
+  usram1 (rwx) : ORIGIN = 0x20001800, LENGTH = 4K
+  xsram1 (rwx) : ORIGIN = 0x20002800, LENGTH = 22K
 
   /* 16Kb SRAM */
 

--- a/boards/arm/stm32/stm3240g-eval/scripts/memory.ld
+++ b/boards/arm/stm32/stm3240g-eval/scripts/memory.ld
@@ -79,7 +79,7 @@ MEMORY
 
   /* 112Kb of contiguous SRAM */
 
-  ksram (rwx)      : ORIGIN = 0x20000000, LENGTH = 4K
-  usram (rwx)      : ORIGIN = 0x20001000, LENGTH = 4K
-  xsram (rwx)      : ORIGIN = 0x20002000, LENGTH = 104K
+  ksram (rwx)      : ORIGIN = 0x20000000, LENGTH = 6K
+  usram (rwx)      : ORIGIN = 0x20001800, LENGTH = 4K
+  xsram (rwx)      : ORIGIN = 0x20002800, LENGTH = 102K
 }

--- a/sched/mqueue/mq_initialize.c
+++ b/sched/mqueue/mq_initialize.c
@@ -32,6 +32,21 @@
 #include "mqueue/msg.h"
 
 /****************************************************************************
+ * Private Type Definitions
+ ****************************************************************************/
+
+struct msgpool_s
+{
+#ifndef CONFIG_DISABLE_MQUEUE
+  struct mqueue_msg_s mqueue[CONFIG_PREALLOC_MQ_MSGS +
+                             CONFIG_PREALLOC_MQ_IRQ_MSGS];
+#endif
+#ifndef CONFIG_DISABLE_MQUEUE_SYSV
+  struct msgbuf_s msgbuf[CONFIG_PREALLOC_MQ_MSGS];
+#endif
+};
+
+/****************************************************************************
  * Public Data
  ****************************************************************************/
 
@@ -53,6 +68,14 @@ struct list_node g_msgfreeirq;
 #endif
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/* This is a pool of pre-allocated message queue buffers */
+
+static struct msgpool_s g_msgpool;
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -69,8 +92,8 @@ struct list_node g_msgfreeirq;
 
 #ifndef CONFIG_DISABLE_MQUEUE
 static FAR void * mq_msgblockinit(FAR struct list_node *list,
-                                   FAR struct mqueue_msg_s *mqmsgblock,
-                                   uint16_t nmsgs, uint8_t alloc_type)
+                                  FAR struct mqueue_msg_s *mqmsgblock,
+                                  uint16_t nmsgs, uint8_t alloc_type)
 {
   int i;
   for (i = 0; i < nmsgs; i++)
@@ -125,21 +148,9 @@ static FAR void *sysv_msgblockinit(FAR struct list_node *list,
 
 void nxmq_initialize(void)
 {
-  FAR void *msg;
+  FAR void *msg = &g_msgpool;
 
   sched_trace_begin();
-
-  msg = kmm_malloc(
-#ifndef CONFIG_DISABLE_MQUEUE
-                   sizeof(struct mqueue_msg_s) *
-                   (CONFIG_PREALLOC_MQ_MSGS + CONFIG_PREALLOC_MQ_IRQ_MSGS)
-#endif
-#ifndef CONFIG_DISABLE_MQUEUE_SYSV
-                   + sizeof(struct msgbuf_s) * CONFIG_PREALLOC_MQ_MSGS
-#endif
-                   );
-
-  DEBUGASSERT(msg != NULL);
 
   /* Initialize a block of messages for general use */
 


### PR DESCRIPTION
## Summary

sched/signal: move signal structures pool to bss
sched/mqueue: move message queue buffer to bss

Decoupling with memory allocator

## Impact

N/A

## Testing

ostest