### PR TITLE
Kconfig: move LTO options to Build Setup menu

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -2432,6 +2432,44 @@ config DEBUG_OPTLEVEL
 		This string represents the custom optimization level that will be
 		used if DEBUG_CUSTOMOPT.
 
+choice
+	prompt "Link Time Optimization (LTO)"
+	default LTO_NONE
+	---help---
+		This option enables Link Time Optimization (LTO), which allows the
+		compiler to optimize binaries globally.
+
+		If unsure, select LTO_NONE. Note that LTO is very resource-intensive
+		so it's disabled by default.
+
+config LTO_NONE
+	bool "None"
+	---help---
+		Build the kernel normally, without Link Time Optimization (LTO).
+
+config LTO_FULL
+	bool "GNU Full LTO (EXPERIMENTAL)"
+	depends on ARCH_TOOLCHAIN_GNU
+	---help---
+		Link time optimization is implemented as a GCC front end for a bytecode
+		bytecode representation of GIMPLE that is emitted in special sections
+		of .o files. Currently, LTO support is enabled in most ELF-based systems,
+		as well as darwin, cygwin and mingw systems.
+
+config LTO_THIN
+	bool "Clang ThinLTO (EXPERIMENTAL)"
+	depends on ARCH_TOOLCHAIN_CLANG
+	---help---
+		This option enables Clang's ThinLTO, which allows for parallel
+		optimization and faster incremental compiles compared to the
+		CONFIG_LTO_FULL option. More information can be found
+		from Clang's documentation:
+
+		https://clang.llvm.org/docs/ThinLTO.html
+
+		If unsure, say Y.
+endchoice
+
 config DEBUG_OPT_UNUSED_SECTIONS
 	bool "Optimization to eliminate the unused input sections"
 	default y

--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -283,44 +283,6 @@ config ARCH_TOOLCHAIN_TASKING
 	bool
 	default n
 
-choice
-	prompt "Link Time Optimization (LTO)"
-	default LTO_NONE
-	---help---
-		This option enables Link Time Optimization (LTO), which allows the
-		compiler to optimize binaries globally.
-
-		If unsure, select LTO_NONE. Note that LTO is very resource-intensive
-		so it's disabled by default.
-
-config LTO_NONE
-	bool "None"
-	---help---
-		Build the kernel normally, without Link Time Optimization (LTO).
-
-config LTO_FULL
-	bool "GNU Full LTO (EXPERIMENTAL)"
-	depends on ARCH_TOOLCHAIN_GNU
-	---help---
-		Link time optimization is implemented as a GCC front end for a bytecode
-		bytecode representation of GIMPLE that is emitted in special sections
-		of .o files. Currently, LTO support is enabled in most ELF-based systems,
-		as well as darwin, cygwin and mingw systems.
-
-config LTO_THIN
-	bool "Clang ThinLTO (EXPERIMENTAL)"
-	depends on ARCH_TOOLCHAIN_CLANG
-	---help---
-		This option enables Clang's ThinLTO, which allows for parallel
-		optimization and faster incremental compiles compared to the
-		CONFIG_LTO_FULL option. More information can be found
-		from Clang's documentation:
-
-		https://clang.llvm.org/docs/ThinLTO.html
-
-		If unsure, say Y.
-endchoice
-
 config ARCH_GNU_NO_WEAKFUNCTIONS
 	bool
 	depends on ARCH_TOOLCHAIN_GNU


### PR DESCRIPTION
## Summary
Kconfig: move LTO options to Build Setup menu
LTO is optimization option so it's more appropriate to place it in the same place as other optimization options

## Impact
LTO options moved from "system Type" to Build Setup menu

## Testing
local

