### PR TITLE
boards: cxd56xx: Fix read position in cxd5610 gnss driver

### DIFF
--- a/boards/arm/cxd56xx/drivers/sensors/cxd5610_gnss.c
+++ b/boards/arm/cxd56xx/drivers/sensors/cxd5610_gnss.c
@@ -1905,6 +1905,10 @@ static ssize_t cxd5610_gnss_read(struct file *filep, char *buffer,
 
   cxd5610_gnss_buffer_unlock(priv);
 
+  /* Reset read position after read is complete */
+
+  filep->f_pos = 0;
+
   cxd5610_gnss_device_unlock(priv);
   return len;
 }


### PR DESCRIPTION
## Summary
Add process to reset read position after read is complete to fix NMEA output with DC report.

## Impact
Only spresense board.

## Testing

