### PR TITLE
drivers/serial/uart_pl011.c : add the interface about clock and reset control.

### DIFF
--- a/drivers/serial/Kconfig-pl011
+++ b/drivers/serial/Kconfig-pl011
@@ -81,4 +81,8 @@ config UART3_CLK_FREQ
 
 endif # UART3_PL011
 
+config UART_PL011_PLATFORMIF
+	bool "PL011 platform interface"
+	default n
+
 endif # UART_PL011

--- a/drivers/serial/uart_pl011.c
+++ b/drivers/serial/uart_pl011.c
@@ -587,6 +587,15 @@ static int pl011_irq_tx_complete(FAR const struct pl011_uart_port_s *sport)
   return config->uart->fr & PL011_FR_TXFE;
 }
 
+static int pl011_irq_tx_ready(const struct pl011_uart_port_s *sport)
+{
+  const struct pl011_config *config = &sport->config;
+
+  /* check for TX FIFO not full */
+
+  return ((config->uart->fr & PL011_FR_TXFF) == 0);
+}
+
 static int pl011_irq_rx_ready(FAR const struct pl011_uart_port_s *sport)
 {
   FAR const struct pl011_config *config = &sport->config;
@@ -621,7 +630,7 @@ static bool pl011_txready(FAR struct uart_dev_s *dev)
     }
 
   return (config->uart->imsc & PL011_IMSC_TXIM) &&
-         pl011_irq_tx_complete(sport);
+         pl011_irq_tx_ready(sport);
 }
 
 /***************************************************************************

--- a/drivers/serial/uart_pl011.c
+++ b/drivers/serial/uart_pl011.c
@@ -903,8 +903,19 @@ static int pl011_attach(FAR struct uart_dev_s *dev)
 
 static void pl011_shutdown(FAR struct uart_dev_s *dev)
 {
+#ifdef CONFIG_UART_PL011_PLATFORMIF
+  struct pl011_uart_port_s  *sport  = (struct pl011_uart_port_s *)dev->priv;
+  const struct pl011_config *config = &sport->config;
+
+  /* If needed, implement platform specific process such as disabling pl011
+   * to reduce power consumption.
+   */
+
+  pl011_platform_shutdown((uint32_t)config->uart);
+#else
   UNUSED(dev);
   sinfo("%s: call unexpected\n", __func__);
+#endif
 }
 
 static int pl011_setup(FAR struct uart_dev_s *dev)
@@ -915,6 +926,14 @@ static int pl011_setup(FAR struct uart_dev_s *dev)
   int                            ret;
   uint32_t                       lcrh;
   irqstate_t                     i_flags;
+
+#ifdef CONFIG_UART_PL011_PLATFORMIF
+  /* If needed, implement platform specific process such as enabling pl011
+   * to reduce power consumption.
+   */
+
+  pl011_platform_setup((uint32_t)config->uart);
+#endif
 
   i_flags = up_irq_save();
 

--- a/drivers/serial/uart_pl011.c
+++ b/drivers/serial/uart_pl011.c
@@ -762,9 +762,9 @@ static int pl011_receive(FAR struct uart_dev_s *dev,
 
   rx = config->uart->dr;
 
-  *status = 0;
+  *status = rx & 0xf00;
 
-  return rx;
+  return rx & 0xff;
 }
 
 /***************************************************************************

--- a/include/nuttx/serial/uart_pl011.h
+++ b/include/nuttx/serial/uart_pl011.h
@@ -41,5 +41,14 @@ void pl011_earlyserialinit(void);
 
 void pl011_serialinit(void);
 
+#ifdef CONFIG_UART_PL011_PLATFORMIF
+/* If needed, implement platform specific process such as enabling pl011
+ * to reduce power consumption.
+ */
+
+int pl011_platform_setup(uint32_t base);
+int pl011_platform_shutdown(uint32_t base);
+#endif  /* CONFIG_UART_PL011_PLATFORMIF */
+
 #endif  /* CONFIG_UART_PL011 */
 #endif /* __INCLUDE_NUTTX_SERIAL_UART_PL011_H */


### PR DESCRIPTION
## Summary
I want to add the interface about clock and reset control for reducing power consumption.
I added the pl011_platform_shutdown() / _setup(), these functions are called when pl011_shutdown() / _setup() are called. 

The added interface is inteneded as bellows.
* The pl011_platform_shutdown() is for clock off and reset-asserted.
* The pl011_platform_setup() is for clock on and reset-de-asserted.

and

This PR includes as following fixes.
* bug fix about the function : pl011_txready().
* add the bitmask according to PL011 spec. (Although almost no problem)

## Impact
The user of drivers/serial/uart_pl011.c
I think almost no impact as long as do not use CONFIG_UART_PL011_PLATFORMIF.

## Testing
I checked following items with our out-of-tree Board directory, some apps and cxd32xx. (The PR of cxd32xx have not accepted yet.)
* Boot NuttShell(NSH)
* Passs the "apps/testing/ostest"
