### PR TITLE
mm/gran: Fix GRAN_ALIGNED() macro

### DIFF
--- a/mm/mm_gran/mm_gran.h
+++ b/mm/mm_gran/mm_gran.h
@@ -66,6 +66,7 @@
 struct gran_s
 {
   uint8_t    log2gran;  /* Log base 2 of the size of one granule */
+  uint8_t    log2align; /* Log base 2 of required alignment */
   uint16_t   ngranules; /* The total number of (aligned) granules in the heap */
 #ifdef CONFIG_GRAN_INTR
   irqstate_t irqstate;  /* For exclusive access to the GAT */

--- a/mm/mm_gran/mm_graninit.c
+++ b/mm/mm_gran/mm_graninit.c
@@ -132,6 +132,7 @@ GRAN_HANDLE gran_initialize(FAR void *heapstart, size_t heapsize,
       /* Initialize non-zero elements of the granules heap info structure */
 
       priv->log2gran  = log2gran;
+      priv->log2align = log2align;
       priv->ngranules = ngranules;
       priv->heapstart = alignedstart;
 

--- a/mm/mm_gran/mm_grantable.h
+++ b/mm/mm_gran/mm_grantable.h
@@ -36,7 +36,8 @@
 #define MEM2GRAN(g, m)      ((((uintptr_t)m) - g->heapstart) >> g->log2gran)
 #define GRAN2MEM(g, x)      ((((uintptr_t)x) << g->log2gran) + g->heapstart)
 
-#define GRAN_ALIGNED(g, m)  ((((uintptr_t)(m)) & GRANMASK(g)) == 0)
+#define ALIGNMASK(g)        ((1 << g->log2align) - 1)
+#define GRAN_ALIGNED(g, m)  ((((uintptr_t)(m)) & ALIGNMASK(g)) == 0)
 #define GRAN_INRANGE(g, m)  (g->heapstart <= (uintptr_t)(m) && \
                               (uintptr_t)(m) < GRANENDA(g))
 #define GRAN_PRODUCT(g, m)  (GRAN_ALIGNED(g, m) && GRAN_INRANGE(g, m))


### PR DESCRIPTION
## Summary
GRAN_ALIGNED should check that the memory block's alignment (log2align) is correct, not that the memory block is aligned with the granule size.

This fixes DEBUGASSERT() in mm_granfree:
_assert: Assertion failed : at file: mm_gran/mm_granfree.c:49

The assertion triggers if granule size != alignment.
## Impact
Fixes issue with granule allocator.
## Testing
imx93-evk
