### PR TITLE
boards/raspberrypi-pico: Remove early return for error cases in initialization functions.

### DIFF
--- a/boards/arm/rp2040/common/src/rp2040_common_bringup.c
+++ b/boards/arm/rp2040/common/src/rp2040_common_bringup.c
@@ -121,7 +121,6 @@ int rp2040_common_bringup(void)
   if (ret < 0)
     {
       syslog(LOG_ERR, "Failed to initialize I2C0.\n");
-      return ret;
     }
   #endif
 
@@ -130,7 +129,6 @@ int rp2040_common_bringup(void)
   if (ret < 0)
     {
       syslog(LOG_ERR, "Failed to initialize I2C1.\n");
-      return ret;
     }
   #endif
 #endif
@@ -141,7 +139,6 @@ int rp2040_common_bringup(void)
   if (ret < 0)
     {
       syslog(LOG_ERR, "Failed to initialize SPI0.\n");
-      return ret;
     }
   #endif
 
@@ -150,7 +147,6 @@ int rp2040_common_bringup(void)
   if (ret < 0)
     {
       syslog(LOG_ERR, "Failed to initialize SPI1.\n");
-      return ret;
     }
   #endif
 #endif
@@ -187,7 +183,6 @@ int rp2040_common_bringup(void)
   if (ret < 0)
     {
       syslog(LOG_ERR, "Failed to initialize PWM0.\n");
-      return ret;
     }
 #  endif
 
@@ -222,7 +217,6 @@ int rp2040_common_bringup(void)
   if (ret < 0)
     {
       syslog(LOG_ERR, "Failed to initialize PWM1.\n");
-      return ret;
     }
 #  endif
 
@@ -257,7 +251,6 @@ int rp2040_common_bringup(void)
   if (ret < 0)
     {
       syslog(LOG_ERR, "Failed to initialize PWM2.\n");
-      return ret;
     }
 #  endif
 
@@ -292,7 +285,6 @@ int rp2040_common_bringup(void)
   if (ret < 0)
     {
       syslog(LOG_ERR, "Failed to initialize PWM3.\n");
-      return ret;
     }
 #  endif
 
@@ -327,7 +319,6 @@ int rp2040_common_bringup(void)
   if (ret < 0)
     {
       syslog(LOG_ERR, "Failed to initialize PWM4.\n");
-      return ret;
     }
 #  endif
 
@@ -362,7 +353,6 @@ int rp2040_common_bringup(void)
   if (ret < 0)
     {
       syslog(LOG_ERR, "Failed to initialize PWM5.\n");
-      return ret;
     }
 #  endif
 
@@ -397,7 +387,6 @@ int rp2040_common_bringup(void)
   if (ret < 0)
     {
       syslog(LOG_ERR, "Failed to initialize PWM6.\n");
-      return ret;
     }
 #  endif
 
@@ -432,7 +421,6 @@ int rp2040_common_bringup(void)
   if (ret < 0)
     {
       syslog(LOG_ERR, "Failed to initialize PWM7.\n");
-      return ret;
     }
 #  endif
 #endif
@@ -485,7 +473,6 @@ int rp2040_common_bringup(void)
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: rp2040_ina219_initialize() failed: %d\n", ret);
-      return ret;
     }
 #endif
 
@@ -494,14 +481,12 @@ int rp2040_common_bringup(void)
   if (ret < 0)
     {
       syslog(LOG_ERR, "Failed to initialize Frame Buffer Driver.\n");
-      return ret;
     }
 #elif defined(CONFIG_LCD)
   ret = board_lcd_initialize();
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: Failed to initialize LCD.\n");
-      return ret;
     }
 #endif
 
@@ -510,7 +495,6 @@ int rp2040_common_bringup(void)
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: lcddev_register() failed: %d\n", ret);
-      return ret;
     }
 #endif
 
@@ -521,8 +505,6 @@ int rp2040_common_bringup(void)
   if (ret < 0)
     {
       syslog(LOG_ERR, "Failed to initialize PCF8574 LCD, error %d\n", ret);
-      return ret;
-      return ret;
     }
 #endif
 
@@ -531,7 +513,6 @@ int rp2040_common_bringup(void)
   if (ret < 0)
     {
       syslog(LOG_ERR, "Failed to initialize I2S.\n");
-      return ret;
     }
 #endif
 
@@ -540,7 +521,6 @@ int rp2040_common_bringup(void)
   if (ret < 0)
     {
       syslog(LOG_ERR, "Failed to initialize GPIO Driver: %d\n", ret);
-      return ret;
     }
 #endif
 
@@ -582,7 +562,6 @@ int rp2040_common_bringup(void)
   if (ret != OK)
     {
       syslog(LOG_ERR, "Failed to initialize ADC Driver: %d\n", ret);
-      return ret;
     }
 
 #endif /* defined(CONFIG_ADC) && defined(CONFIG_RP2040_ADC) */
@@ -598,7 +577,6 @@ int rp2040_common_bringup(void)
                           HAS_WHITE) == NULL)
     {
       syslog(LOG_ERR, "Failed to initialize WS2812: %d\n", errno);
-      return -errno;
     }
 #endif
 
@@ -685,5 +663,5 @@ int rp2040_common_bringup(void)
     }
 
 #endif
-  return OK;
+  return ret;
 }


### PR DESCRIPTION
## Summary

Ensure proper error handling by adding return statements for error cases in various initialization functions.

## Impact

RaspberryPico targets.

## Testing

Internal CI testing
