### PR TITLE
net/inet: Rename ttl to s_ttl in sconn

### DIFF
--- a/include/nuttx/net/net.h
+++ b/include/nuttx/net/net.h
@@ -229,7 +229,7 @@ struct socket_conn_s
   uint8_t       s_tos;       /* IPv4 Type of Service */
 #define s_tclass s_tos       /* IPv6 traffic class defination */
 #if defined(CONFIG_NET_IPv4) || defined(CONFIG_NET_IPv6)
-  uint8_t       ttl;         /* Default time-to-live */
+  uint8_t       s_ttl;       /* Default time-to-live */
 #endif
 
   /* Connection-specific content may follow */

--- a/net/inet/ipv4_setsockopt.c
+++ b/net/inet/ipv4_setsockopt.c
@@ -221,7 +221,7 @@ int ipv4_setsockopt(FAR struct socket *psock, int option,
           else
             {
               conn = psock->s_conn;
-              conn->ttl = ttl;
+              conn->s_ttl = ttl;
               ret = OK;
             }
         }

--- a/net/inet/ipv6_setsockopt.c
+++ b/net/inet/ipv6_setsockopt.c
@@ -99,8 +99,8 @@ int ipv6_setsockopt(FAR struct socket *psock, int option,
         {
           FAR struct socket_conn_s *conn = psock->s_conn;
 
-          conn->ttl = (value_len >= sizeof(int)) ?
-                      *(FAR int *)value : (int)*(FAR unsigned char *)value;
+          conn->s_ttl = (value_len >= sizeof(int)) ?
+                        *(FAR int *)value : (int)*(FAR unsigned char *)value;
           ret = OK;
         }
         break;
@@ -152,8 +152,8 @@ int ipv6_setsockopt(FAR struct socket *psock, int option,
         {
           FAR struct socket_conn_s *conn = psock->s_conn;
 
-          conn->ttl = (value_len >= sizeof(int)) ?
-                      *(FAR int *)value : (int)*(FAR unsigned char *)value;
+          conn->s_ttl = (value_len >= sizeof(int)) ?
+                        *(FAR int *)value : (int)*(FAR unsigned char *)value;
           ret = OK;
         }
         break;

--- a/net/sixlowpan/sixlowpan_udpsend.c
+++ b/net/sixlowpan/sixlowpan_udpsend.c
@@ -227,7 +227,7 @@ ssize_t psock_6lowpan_udp_sendto(FAR struct socket *psock,
   ipv6udp.ipv6.tcf    = 0x00;
   ipv6udp.ipv6.flow   = 0x00;
   ipv6udp.ipv6.proto  = IP_PROTO_UDP;
-  ipv6udp.ipv6.ttl    = conn->sconn.ttl;
+  ipv6udp.ipv6.ttl    = conn->sconn.s_ttl;
 
   /* The IPv6 header length field does not include the size of IPv6 IP
    * header.

--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -780,7 +780,7 @@ FAR struct tcp_conn_s *tcp_alloc(uint8_t domain)
   if (conn)
     {
       memset(conn, 0, sizeof(struct tcp_conn_s));
-      conn->sconn.ttl     = IP_TTL_DEFAULT;
+      conn->sconn.s_ttl   = IP_TTL_DEFAULT;
       conn->tcpstateflags = TCP_ALLOCATED;
 #if defined(CONFIG_NET_IPv4) && defined(CONFIG_NET_IPv6)
       conn->domain        = domain;
@@ -1171,7 +1171,7 @@ FAR struct tcp_conn_s *tcp_alloc_accept(FAR struct net_driver_s *dev,
 #endif
 
       conn->sconn.s_tos      = listener->sconn.s_tos;
-      conn->sconn.ttl        = listener->sconn.ttl;
+      conn->sconn.s_ttl      = listener->sconn.s_ttl;
 #if CONFIG_NET_RECV_BUFSIZE > 0
       conn->rcv_bufs         = listener->rcv_bufs;
 #endif

--- a/net/tcp/tcp_send.c
+++ b/net/tcp/tcp_send.c
@@ -184,7 +184,7 @@ static void tcp_sendcommon(FAR struct net_driver_s *dev,
                         IP_PROTO_TCP,
                         netdev_ipv6_srcaddr(dev, conn->u.ipv6.laddr),
                         conn->u.ipv6.raddr,
-                        conn->sconn.ttl, conn->sconn.s_tclass);
+                        conn->sconn.s_ttl, conn->sconn.s_tclass);
 
       /* Calculate TCP checksum. */
 
@@ -204,7 +204,7 @@ static void tcp_sendcommon(FAR struct net_driver_s *dev,
       ninfo("do IPv4 IP header build!\n");
       ipv4_build_header(IPv4BUF, dev->d_len, IP_PROTO_TCP,
                         &dev->d_ipaddr, &conn->u.ipv4.raddr,
-                        conn->sconn.ttl, conn->sconn.s_tos, NULL);
+                        conn->sconn.s_ttl, conn->sconn.s_tos, NULL);
 
       /* Calculate TCP checksum. */
 
@@ -481,7 +481,7 @@ void tcp_reset(FAR struct net_driver_s *dev, FAR struct tcp_conn_s *conn)
                         IP_PROTO_TCP,
                         netdev_ipv6_srcaddr(dev, ipv6->destipaddr),
                         ipv6->srcipaddr,
-                        conn ? conn->sconn.ttl : IP_TTL_DEFAULT,
+                        conn ? conn->sconn.s_ttl : IP_TTL_DEFAULT,
                         conn ? conn->sconn.s_tos : 0);
       tcp->tcpchksum = 0;
       tcp->tcpchksum = ~tcp_ipv6_chksum(dev);
@@ -497,7 +497,7 @@ void tcp_reset(FAR struct net_driver_s *dev, FAR struct tcp_conn_s *conn)
 
       ipv4_build_header(IPv4BUF, dev->d_len, IP_PROTO_TCP,
                         &dev->d_ipaddr, (FAR in_addr_t *)ipv4->srcipaddr,
-                        conn ? conn->sconn.ttl : IP_TTL_DEFAULT,
+                        conn ? conn->sconn.s_ttl : IP_TTL_DEFAULT,
                         conn ? conn->sconn.s_tos : 0, NULL);
 
       tcp->tcpchksum = 0;

--- a/net/udp/udp_conn.c
+++ b/net/udp/udp_conn.c
@@ -634,17 +634,17 @@ FAR struct udp_conn_s *udp_alloc(uint8_t domain)
     {
       /* Make sure that the connection is marked as uninitialized */
 
-      conn->sconn.ttl = IP_TTL_DEFAULT;
-      conn->flags     = 0;
+      conn->sconn.s_ttl = IP_TTL_DEFAULT;
+      conn->flags       = 0;
 #if defined(CONFIG_NET_IPv4) || defined(CONFIG_NET_IPv6)
-      conn->domain    = domain;
+      conn->domain      = domain;
 #endif
-      conn->lport     = 0;
+      conn->lport       = 0;
 #if CONFIG_NET_RECV_BUFSIZE > 0
-      conn->rcvbufs   = CONFIG_NET_RECV_BUFSIZE;
+      conn->rcvbufs     = CONFIG_NET_RECV_BUFSIZE;
 #endif
 #if CONFIG_NET_SEND_BUFSIZE > 0
-      conn->sndbufs   = CONFIG_NET_SEND_BUFSIZE;
+      conn->sndbufs     = CONFIG_NET_SEND_BUFSIZE;
 
       nxsem_init(&conn->sndsem, 0, 0);
 #endif

--- a/net/udp/udp_send.c
+++ b/net/udp/udp_send.c
@@ -184,7 +184,7 @@ void udp_send(FAR struct net_driver_s *dev, FAR struct udp_conn_s *conn)
           dev->d_len        = dev->d_sndlen + IPv4UDP_HDRLEN;
 
           ipv4_build_header(IPv4BUF, dev->d_len, IP_PROTO_UDP,
-                            &dev->d_ipaddr, &raddr, conn->sconn.ttl,
+                            &dev->d_ipaddr, &raddr, conn->sconn.s_ttl,
                             conn->sconn.s_tos, NULL);
 
 #ifdef CONFIG_NET_STATISTICS
@@ -219,7 +219,7 @@ void udp_send(FAR struct net_driver_s *dev, FAR struct udp_conn_s *conn)
 
           ipv6_build_header(IPv6BUF, dev->d_len, IP_PROTO_UDP,
                             laddr, conn->u.ipv6.raddr,
-                            conn->sconn.ttl, conn->sconn.s_tclass);
+                            conn->sconn.s_ttl, conn->sconn.s_tclass);
 
           /* The total length to send is the size of the application data
            * plus the IPv6 and UDP headers (and, eventually, the link layer


### PR DESCRIPTION
## Summary
uniform naming convention

## Impact

## Testing
sim:local
