### PR TITLE
risc-v/mpfs: Add error handling for PMP conf

### DIFF
--- a/arch/risc-v/src/mpfs/Kconfig
+++ b/arch/risc-v/src/mpfs/Kconfig
@@ -52,7 +52,8 @@ config MPFS_BOARD_PMP
 	default n
 	---help---
 		If true, the board must provide "mpfs_board_pmp_setup" for PMP
-		configuration. If false, set ALL memory accessible for every
+		configuration and "mpfs_board_pmp_error" for PMP error handling.
+		If false, set ALL memory accessible for every
 		configured HART. Only the bootloader should do this.
 
 config MPFS_OPENSBI

--- a/arch/risc-v/src/mpfs/mpfs_entrypoints.c
+++ b/arch/risc-v/src/mpfs/mpfs_entrypoints.c
@@ -107,6 +107,7 @@ void mpfs_jump_to_app(void)
       "la   sp, g_mpfs_boot_stacks\n"        /* Stack area base */
       "add  sp, sp, t0\n"                    /* Set stack pointer */
       "call mpfs_board_pmp_setup\n"          /* Run PMP configuration */
+      "bne  a0, x0, mpfs_board_pmp_error\n"  /* If ret != 0, jump to errhan */
       "csrr a0, mhartid\n"                   /* Restore hartid */
 #else
       "li   t0, -1\n"                        /* Open the whole SoC */


### PR DESCRIPTION
## Summary
Check return value of mpfs_board_pmp_setup() and
jump to mpfs_board_pmp_error() in case of error.

## Impact
MPFS only

## Testing
Custom MPFS board
