### PR TITLE
net/tcp: no need to set tcp_window_scale opt if window less than 65535

### DIFF
--- a/net/tcp/tcp_send.c
+++ b/net/tcp/tcp_send.c
@@ -613,8 +613,13 @@ void tcp_synack(FAR struct net_driver_s *dev, FAR struct tcp_conn_s *conn,
   tcp->optdata[optlen++] = tcp_mss & 0xff;
 
 #ifdef CONFIG_NET_TCP_WINDOW_SCALE
-  if (tcp->flags == TCP_SYN ||
-      ((tcp->flags == (TCP_ACK | TCP_SYN)) && (conn->flags & TCP_WSCALE)))
+  if (tcp_get_recvwindow(dev, conn) < UINT16_MAX)
+    {
+      conn->rcv_scale = 0;
+    }
+  else if (tcp->flags == TCP_SYN ||
+           ((tcp->flags == (TCP_ACK | TCP_SYN)) &&
+           (conn->flags & TCP_WSCALE)))
     {
       tcp->optdata[optlen++] = TCP_OPT_NOOP;
       tcp->optdata[optlen++] = TCP_OPT_WS;


### PR DESCRIPTION
## Summary
If windows size less than 65535，and we set config of NET_TCP_WINDOW_SCALE，we can see the SYNC and SYNC-ACK packet will set opt of tcp_window_scale which does not meet the standard

## Impact
Tcp windows scale

## Testing
Testing on Sim by set NET_TCP_WINDOW_SCALE and recv_buf
