### PR TITLE
net/can: Add SO_RCVBUF option for can socket

### DIFF
--- a/net/can/can.h
+++ b/net/can/can.h
@@ -88,6 +88,10 @@ struct can_conn_s
 
   struct iob_queue_s readahead;      /* remove Read-ahead buffering */
 
+#if CONFIG_NET_RECV_BUFSIZE > 0
+  int32_t recv_buffnum;              /* Recv buffer number */
+#endif
+
   /* CAN-specific content follows */
 
   int16_t crefs;                     /* Reference count */

--- a/net/can/can_callback.c
+++ b/net/can/can_callback.c
@@ -199,7 +199,19 @@ uint16_t can_datahandler(FAR struct net_driver_s *dev,
                          FAR struct can_conn_s *conn)
 {
   FAR struct iob_s *iob = dev->d_iob;
-  int ret;
+  int ret = 0;
+
+#if CONFIG_NET_RECV_BUFSIZE > 0
+  /* Check the frame count pending on conn->readahead */
+
+  if (iob_get_queue_entry_count(&conn->readahead) >= conn->recv_buffnum)
+    {
+      nwarn("WARNNING: There are no free recive buffer to retain the data. "
+            "Recive buffer number:%"PRId32", recived frames:%"PRIuPTR" \n",
+            conn->recv_buffnum, iob_get_queue_entry_count(&conn->readahead));
+      goto errout;
+    }
+#endif
 
   /* Concat the iob to readahead */
 
@@ -222,9 +234,13 @@ uint16_t can_datahandler(FAR struct net_driver_s *dev,
   else
     {
       nerr("ERROR: Failed to queue the I/O buffer chain: %d\n", ret);
-      netdev_iob_release(dev);
+      goto errout;
     }
 
+  return ret;
+
+errout:
+  netdev_iob_release(dev);
   return ret;
 }
 

--- a/net/can/can_getsockopt.c
+++ b/net/can/can_getsockopt.c
@@ -234,6 +234,22 @@ int can_getsockopt(FAR struct socket *psock, int level, int option,
         break;
 #endif
 
+#if CONFIG_NET_RECV_BUFSIZE > 0
+      case SO_RCVBUF:
+        /* Verify that option is the size of an 'int'.  Should also check
+         * that 'value' is properly aligned for an 'int'
+         */
+
+        if (*value_len != sizeof(int))
+          {
+            return -EINVAL;
+          }
+
+        *(FAR int *)value = conn->recv_buffnum * CONFIG_IOB_BUFSIZE;
+
+        break;
+#endif
+
       default:
         nerr("ERROR: Unrecognized RAW CAN socket option: %d\n", option);
         ret = -ENOPROTOOPT;

--- a/net/can/can_setsockopt.c
+++ b/net/can/can_setsockopt.c
@@ -210,6 +210,39 @@ int can_setsockopt(FAR struct socket *psock, int level, int option,
         break;
 #endif
 
+#if CONFIG_NET_RECV_BUFSIZE > 0
+      case SO_RCVBUF:
+        {
+          int buffersize;
+
+          /* Verify that option is the size of an 'int'.  Should also check
+           * that 'value' is properly aligned for an 'int'
+           */
+
+          if (value_len != sizeof(int))
+            {
+              return -EINVAL;
+            }
+
+          /* Get the value.  Is the option being set or cleared? */
+
+          buffersize = *(FAR int *)value;
+          if (buffersize < 0)
+            {
+              return -EINVAL;
+            }
+
+#if CONFIG_NET_MAX_RECV_BUFSIZE > 0
+          buffersize = MIN(buffersize, CONFIG_NET_MAX_RECV_BUFSIZE);
+#endif
+
+          conn->recv_buffnum = (buffersize + CONFIG_IOB_BUFSIZE - 1)
+                              / CONFIG_IOB_BUFSIZE;
+
+          break;
+        }
+#endif
+
       default:
         nerr("ERROR: Unrecognized CAN option: %d\n", option);
         ret = -ENOPROTOOPT;

--- a/net/can/can_sockif.c
+++ b/net/can/can_sockif.c
@@ -220,6 +220,16 @@ static int can_setup(FAR struct socket *psock)
 
       conn->crefs = 1;
 
+      /* If Can Socket Stack recive can frame and pending on the readahead,
+       * but the application layer did not read the frame. This will cause
+       * a memory leak, and it is necessary to limit the readahead.
+       */
+
+#if CONFIG_NET_RECV_BUFSIZE > 0
+      conn->recv_buffnum = (CONFIG_NET_RECV_BUFSIZE + CONFIG_IOB_BUFSIZE - 1)
+                            / CONFIG_IOB_BUFSIZE;
+#endif
+
       /* Attach the connection instance to the socket */
 
       psock->s_conn = conn;


### PR DESCRIPTION
## Summary
If the speed of the CAN stack receiving packets is greater than the speed of the application layer reading packets, then `conn->readahead` will continue to grow, leading to memory leaks.
To prevent memory leaks, users can restrict CAN socket buffer length.

## Impact
CAN socket recive packet.

## Testing
Manually！  
Create a CAN socket, then send CAN frames to this socket,  but the application layer does not read data from this socket.  Then memory leak. 
 

