### PR TITLE
net/can: Add SO_RCVBUF option for can socket

### DIFF
--- a/include/nuttx/mm/iob.h
+++ b/include/nuttx/mm/iob.h
@@ -456,6 +456,7 @@ void iob_free_queue_qentry(FAR struct iob_s *iob,
 
 #if CONFIG_IOB_NCHAINS > 0
 unsigned int iob_get_queue_size(FAR struct iob_queue_s *queue);
+unsigned int iob_get_queue_entry_count(FAR struct iob_queue_s *queue);
 #endif /* CONFIG_IOB_NCHAINS > 0 */
 
 /****************************************************************************

--- a/mm/iob/CMakeLists.txt
+++ b/mm/iob/CMakeLists.txt
@@ -44,7 +44,7 @@ if(CONFIG_MM_IOB)
       iob_navail.c
       iob_free_queue_qentry.c
       iob_tailroom.c
-      iob_get_queue_size.c
+      iob_get_queue_info.c
       iob_reserve.c
       iob_update_pktlen.c
       iob_count.c)

--- a/mm/iob/Make.defs
+++ b/mm/iob/Make.defs
@@ -28,7 +28,7 @@ CSRCS += iob_free_chain.c iob_free_qentry.c iob_free_queue.c
 CSRCS += iob_initialize.c iob_pack.c iob_peek_queue.c iob_remove_queue.c
 CSRCS += iob_statistics.c iob_trimhead.c iob_trimhead_queue.c iob_trimtail.c
 CSRCS += iob_navail.c iob_free_queue_qentry.c iob_tailroom.c
-CSRCS += iob_get_queue_size.c iob_reserve.c iob_update_pktlen.c
+CSRCS += iob_get_queue_info.c iob_reserve.c iob_update_pktlen.c
 CSRCS += iob_count.c
 
 ifeq ($(CONFIG_IOB_NOTIFIER),y)

--- a/mm/iob/iob_get_queue_info.c
+++ b/mm/iob/iob_get_queue_info.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * mm/iob/iob_get_queue_size.c
+ * mm/iob/iob_get_queue_info.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -53,6 +53,25 @@ unsigned int iob_get_queue_size(FAR struct iob_queue_s *queue)
     }
 
   return total;
+}
+
+/****************************************************************************
+ * Name: iob_get_queue_entry_count
+ *
+ * Description:
+ *   Queue helper for get the iob queue entry count.
+ *
+ ****************************************************************************/
+
+unsigned int iob_get_queue_entry_count(FAR struct iob_queue_s *queue)
+{
+  FAR struct iob_qentry_s *iobq;
+  unsigned int count;
+
+  for (iobq = queue->qh_head, count = 0; iobq != NULL;
+       iobq = iobq->qe_flink, count++);
+
+  return count;
 }
 
 #endif /* CONFIG_IOB_NCHAINS > 0 */

--- a/net/can/can.h
+++ b/net/can/can.h
@@ -88,6 +88,10 @@ struct can_conn_s
 
   struct iob_queue_s readahead;      /* remove Read-ahead buffering */
 
+#if CONFIG_NET_RECV_BUFSIZE > 0
+  int32_t recv_buffnum;              /* Recv buffer number */
+#endif
+
   /* CAN-specific content follows */
 
   int16_t crefs;                     /* Reference count */

--- a/net/can/can_callback.c
+++ b/net/can/can_callback.c
@@ -199,7 +199,19 @@ uint16_t can_datahandler(FAR struct net_driver_s *dev,
                          FAR struct can_conn_s *conn)
 {
   FAR struct iob_s *iob = dev->d_iob;
-  int ret;
+  int ret = 0;
+
+#if CONFIG_NET_RECV_BUFSIZE > 0
+  /* Check the frame count pending on conn->readahead */
+
+  if (iob_get_queue_entry_count(&conn->readahead) >= conn->recv_buffnum)
+    {
+      nwarn("WARNNING: There are no free recive buffer to retain the data. "
+            "Recive buffer number:%"PRId32", recived frames:%"PRIuPTR" \n",
+            conn->recv_buffnum, iob_get_queue_entry_count(&conn->readahead));
+      goto errout;
+    }
+#endif
 
   /* Concat the iob to readahead */
 
@@ -222,9 +234,13 @@ uint16_t can_datahandler(FAR struct net_driver_s *dev,
   else
     {
       nerr("ERROR: Failed to queue the I/O buffer chain: %d\n", ret);
-      netdev_iob_release(dev);
+      goto errout;
     }
 
+  return ret;
+
+errout:
+  netdev_iob_release(dev);
   return ret;
 }
 

--- a/net/can/can_getsockopt.c
+++ b/net/can/can_getsockopt.c
@@ -234,6 +234,22 @@ int can_getsockopt(FAR struct socket *psock, int level, int option,
         break;
 #endif
 
+#if CONFIG_NET_RECV_BUFSIZE > 0
+      case SO_RCVBUF:
+        /* Verify that option is the size of an 'int'.  Should also check
+         * that 'value' is properly aligned for an 'int'
+         */
+
+        if (*value_len != sizeof(int))
+          {
+            return -EINVAL;
+          }
+
+        *(FAR int *)value = conn->recv_buffnum * CONFIG_IOB_BUFSIZE;
+
+        break;
+#endif
+
       default:
         nerr("ERROR: Unrecognized RAW CAN socket option: %d\n", option);
         ret = -ENOPROTOOPT;

--- a/net/can/can_setsockopt.c
+++ b/net/can/can_setsockopt.c
@@ -210,6 +210,39 @@ int can_setsockopt(FAR struct socket *psock, int level, int option,
         break;
 #endif
 
+#if CONFIG_NET_RECV_BUFSIZE > 0
+      case SO_RCVBUF:
+        {
+          int buffersize;
+
+          /* Verify that option is the size of an 'int'.  Should also check
+           * that 'value' is properly aligned for an 'int'
+           */
+
+          if (value_len != sizeof(int))
+            {
+              return -EINVAL;
+            }
+
+          /* Get the value.  Is the option being set or cleared? */
+
+          buffersize = *(FAR int *)value;
+          if (buffersize < 0)
+            {
+              return -EINVAL;
+            }
+
+#if CONFIG_NET_MAX_RECV_BUFSIZE > 0
+          buffersize = MIN(buffersize, CONFIG_NET_MAX_RECV_BUFSIZE);
+#endif
+
+          conn->recv_buffnum = (buffersize + CONFIG_IOB_BUFSIZE - 1)
+                              / CONFIG_IOB_BUFSIZE;
+
+          break;
+        }
+#endif
+
       default:
         nerr("ERROR: Unrecognized CAN option: %d\n", option);
         ret = -ENOPROTOOPT;

--- a/net/can/can_sockif.c
+++ b/net/can/can_sockif.c
@@ -220,6 +220,16 @@ static int can_setup(FAR struct socket *psock)
 
       conn->crefs = 1;
 
+      /* If Can Socket Stack recive can frame and pending on the readahead,
+       * but the application layer did not read the frame. This will cause
+       * a memory leak, and it is necessary to limit the readahead.
+       */
+
+#if CONFIG_NET_RECV_BUFSIZE > 0
+      conn->recv_buffnum = (CONFIG_NET_RECV_BUFSIZE + CONFIG_IOB_BUFSIZE - 1)
+                            / CONFIG_IOB_BUFSIZE;
+#endif
+
       /* Attach the connection instance to the socket */
 
       psock->s_conn = conn;


### PR DESCRIPTION
## Summary
If the CAN stack receiving packets fast, but the application layer reading packets slow. Then `conn->readahead` will continue to grow, leading to memory leaks. Finally CAN stack potentially starve out all IOB buffers.

To prevent IOB buffers leaks, users can restrict CAN socket buffer length.

## Impact
Rename mm/iob/iob_get_queue_size.c to mm/iob/iob_get_queue_info.c
Discard subsequent CAN frame， when the CAN socket is full.
 
## Testing
CAN socket can cache x packets. x = (NET_MAX_RECV_BUFSIZE + IOB_BUF_SIZE - 1)/IOB_BUF_SIZE
Set NET_MAX_RECV_BUFSIZE = 1024 when make-menuconfig.
CAN Socket could cache 6 packets.

Create a demo program as follows:
`
int main(int argc, char **argv)
{
    int fd;
    int buf_size;
    struct ifreq ifr_can;
    struct sockaddr_can can_addr_can;

    fd = socket(PF_CAN, SOCK_RAW, CAN_RAW);
    strcpy(ifr_can.ifr_name, "can0");
    ioctl(fd, SIOCGIFINDEX, &ifr_can);
    can_addr_can[i].can_family = AF_CAN;
    can_addr_can.can_ifindex = ifr_can.ifr_ifindex;
    bind(fd, (struct sockaddr*)&can_addr_can, sizeof(can_addr_can));
    //setsockopt(fd, SOL_CAN_RAW, SO_RCVBUF, &buf_size, sizeof(buf_size));
    
    while(1){
        sleep(3);
        //Do not read CAN frame or reading speed slower than writing speed.
    }
    return 0;
}
`
CAN stack potentially starve out all IOB buffers if do not set SO_RCVBUF option. 
