### PR TITLE
mm: fix mm_curused calculate err

### DIFF
--- a/mm/mm_heap/mm_initialize.c
+++ b/mm/mm_heap/mm_initialize.c
@@ -197,6 +197,7 @@ void mm_addregion(FAR struct mm_heap_s *heap, FAR void *heapstart,
   /* Add the single, large free node to the nodelist */
 
   mm_addfreechunk(heap, node);
+  heap->mm_curused += 2 * MM_SIZEOF_ALLOCNODE;
   mm_unlock(heap);
 }
 
@@ -276,6 +277,7 @@ FAR struct mm_heap_s *mm_initialize(FAR const char *name,
 
   /* Add the initial region of memory to the heap */
 
+  heap->mm_curused = sizeof(struct mm_heap_s);
   mm_addregion(heap, heapstart, heapsize);
 
 #if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_MEMINFO)

--- a/mm/mm_heap/mm_memalign.c
+++ b/mm/mm_heap/mm_memalign.c
@@ -146,6 +146,7 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment,
    */
 
   node = (FAR struct mm_allocnode_s *)(rawchunk - MM_SIZEOF_ALLOCNODE);
+  heap->mm_curused -= MM_SIZEOF_NODE(node);
 
   /* Find the aligned subregion */
 

--- a/mm/mm_heap/mm_realloc.c
+++ b/mm/mm_heap/mm_realloc.c
@@ -143,6 +143,7 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
 
       if (newsize < oldsize)
         {
+          heap->mm_curused += newsize - oldsize;
           mm_shrinkchunk(heap, oldnode, newsize);
           kasan_poison((FAR char *)oldnode + MM_SIZEOF_NODE(oldnode) +
                        sizeof(mmsize_t), oldsize - MM_SIZEOF_NODE(oldnode));
@@ -259,7 +260,8 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
 
           if (prevsize < takeprev + MM_MIN_CHUNK)
             {
-              takeprev = prevsize;
+              heap->mm_curused += prevsize - takeprev;
+              takeprev          = prevsize;
             }
 
           /* Extend the node into the previous free chunk */
@@ -332,7 +334,8 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
 
           if (nextsize < takenext + MM_MIN_CHUNK)
             {
-              takenext = nextsize;
+              heap->mm_curused += nextsize - takenext;
+              takenext          = nextsize;
             }
 
           /* Extend the node into the next chunk */


### PR DESCRIPTION
## Summary
fix bug when realloc and mm_memalign used.
inside mm_mallinfo info.fordblks will not equals to heap->mm_curused.

## Impact
before fix, the maxused shown in free command is not accurate.
after fix, already tested in cortex-a7 dual-core platform with maxused shown correct.

## Testing
CI and cortex-a7 dual-core chip platform.
