### PR TITLE
arch/xmc4 uart driver fix

### DIFF
--- a/arch/arm/src/xmc4/Kconfig
+++ b/arch/arm/src/xmc4/Kconfig
@@ -199,10 +199,13 @@ endmenu
 menu "XMC4xxx USIC Configuration"
 	depends on XMC4_USIC
 
-choice
-	prompt "USIC0 Channel 0 Configuration"
-	default XMC4_USIC0_CHAN0_ISUART
+menu "USIC0 Channel 0 Configuration"
+	depends on XMC4_USIC
 	depends on XMC4_USIC0
+
+choice
+	prompt "Protocol"
+	default XMC4_USIC0_CHAN0_ISUART
 
 config XMC4_USIC0_CHAN0_NONE
 	bool "Not used"
@@ -244,12 +247,36 @@ config XMC4_USIC0_CHAN0_ISI2S
 	---help---
 		Configure USIC0 Channel 0 for I2S audio
 
-endchoice # USIC0 Channel 0 Configuration
+endchoice # USIC0 Channel 0 Protocol
+
+config XMC4_USIC0_CHAN0_TX_BUFFER_SIZE
+	int "Tx Fifo Buffer Size"
+	depends on XMC4_USIC0_CHAN0_ISUART
+	default 16
+	---help---
+		Should be a power of 2 between 2 and 64
+		The sum of Rx and Tx buffers sizes of both 
+		channels should be inferior to 64
+
+config XMC4_USIC0_CHAN0_RX_BUFFER_SIZE
+	int "Rx Fifo Buffer Size"
+	depends on XMC4_USIC0_CHAN0_ISUART
+	default 16
+	---help---
+		Should be a power of 2 between 2 and 64
+		The sum of Rx and Tx buffers sizes of both 
+		channels should be inferior to 64
+
+endmenu # USIC0 Channel 0 Configuration
+
+
+menu "USIC0 Channel 1 Configuration"
+	depends on XMC4_USIC
+	depends on XMC4_USIC0
 
 choice
-	prompt "USIC0 Channel 1 Configuration"
+	prompt "Protocol"
 	default XMC4_USIC0_CHAN1_ISUART
-	depends on XMC4_USIC0
 
 config XMC4_USIC0_CHAN1_NONE
 	bool "Not used"
@@ -291,12 +318,35 @@ config XMC4_USIC0_CHAN1_ISI2S
 	---help---
 		Configure USIC0 Channel 1 for I2S audio
 
-endchoice # USIC0 Channel 1 Configuration
+endchoice # USIC0 Channel 1 Protocol 
+
+config XMC4_USIC0_CHAN1_TX_BUFFER_SIZE
+	int "Tx Fifo Buffer Size"
+	depends on XMC4_USIC0_CHAN1_ISUART
+	default 16
+	---help---
+		Should be a power of 2 between 2 and 64
+		The sum of Rx and Tx buffers sizes of both 
+		channels should be inferior to 64
+
+config XMC4_USIC0_CHAN1_RX_BUFFER_SIZE
+	int "Rx Fifo Buffer Size"
+	depends on XMC4_USIC0_CHAN1_ISUART
+	default 16
+	---help---
+		Should be a power of 2 between 2 and 64
+		The sum of Rx and Tx buffers sizes of both 
+		channels should be inferior to 64
+
+endmenu # USIC0 Channel 1 Configuration
+
+menu "USIC1 Channel 0 Configuration"
+	depends on XMC4_USIC
+	depends on XMC4_USIC1
 
 choice
-	prompt "USIC1 Channel 0 Configuration"
+	prompt "Protocol"
 	default XMC4_USIC1_CHAN0_ISUART
-	depends on XMC4_USIC1
 
 config XMC4_USIC1_CHAN0_NONE
 	bool "Not used"
@@ -338,12 +388,35 @@ config XMC4_USIC1_CHAN0_ISI2S
 	---help---
 		Configure USIC1 Channel 0 for I2S audio
 
-endchoice # USIC1 Channel 0 Configuration
+endchoice # USIC1 Channel 0 Protocol 
+
+config XMC4_USIC1_CHAN0_TX_BUFFER_SIZE
+	int "Tx Fifo Buffer Size"
+	depends on XMC4_USIC1_CHAN0_ISUART
+	default 16
+	---help---
+		Should be a power of 2 between 2 and 64
+		The sum of Rx and Tx buffers sizes of both 
+		channels should be inferior to 64
+
+config XMC4_USIC1_CHAN0_RX_BUFFER_SIZE
+	int "Rx Fifo Buffer Size"
+	depends on XMC4_USIC1_CHAN0_ISUART
+	default 16
+	---help---
+		Should be a power of 2 between 2 and 64
+		The sum of Rx and Tx buffers sizes of both 
+		channels should be inferior to 64
+
+endmenu # USIC1 Channel 0 Configuration 
+
+menu "USIC1 Channel 1 Configuration"
+	depends on XMC4_USIC
+	depends on XMC4_USIC1
 
 choice
-	prompt "USIC1 Channel 1 Configuration"
+	prompt "Protocol"
 	default XMC4_USIC1_CHAN1_ISUART
-	depends on XMC4_USIC1
 
 config XMC4_USIC1_CHAN1_NONE
 	bool "Not used"
@@ -385,12 +458,35 @@ config XMC4_USIC1_CHAN1_ISI2S
 	---help---
 		Configure USIC1 Channel 1 for I2S audio
 
-endchoice # USIC1 Channel 1 Configuration
+endchoice # USIC1 Channel 1 Protocol
+
+config XMC4_USIC1_CHAN1_TX_BUFFER_SIZE
+	int "Tx Fifo Buffer Size"
+	depends on XMC4_USIC1_CHAN1_ISUART
+	default 16 
+	---help---
+		Should be a power of 2 between 2 and 64
+		The sum of Rx and Tx buffers sizes of both 
+		channels should be inferior to 64
+
+config XMC4_USIC1_CHAN1_RX_BUFFER_SIZE
+	int "Rx Fifo Buffer Size"
+	depends on XMC4_USIC1_CHAN1_ISUART
+	default 16 
+	---help---
+		Should be a power of 2 between 2 and 64
+		The sum of Rx and Tx buffers sizes of both 
+		channels should be inferior to 64
+
+endmenu # USIC1 Channel 1 Configuration
+
+menu "USIC2 Channel 0 Configuration"
+	depends on XMC4_USIC
+	depends on XMC4_USIC2
 
 choice
-	prompt "USIC2 Channel 0 Configuration"
+	prompt "Protocol"
 	default XMC4_USIC2_CHAN0_ISUART
-	depends on XMC4_USIC2
 
 config XMC4_USIC2_CHAN0_NONE
 	bool "Not used"
@@ -432,12 +528,35 @@ config XMC4_USIC2_CHAN0_ISI2S
 	---help---
 		Configure USIC2 Channel 0 for I2S audio
 
-endchoice # USIC2 Channel 0 Configuration
+endchoice # USIC2 Channel 0 Protocol
+
+config XMC4_USIC2_CHAN0_TX_BUFFER_SIZE
+	int "Tx Fifo Buffer Size"
+	depends on XMC4_USIC2_CHAN0_ISUART
+	default 16 
+	---help---
+		Should be a power of 2 between 2 and 64
+		The sum of Rx and Tx buffers sizes of both 
+		channels should be inferior to 64
+
+config XMC4_USIC2_CHAN0_RX_BUFFER_SIZE
+	int "Rx Fifo Buffer Size"
+	depends on XMC4_USIC2_CHAN0_ISUART
+	default 16 
+	---help---
+		Should be a power of 2 between 2 and 64
+		The sum of Rx and Tx buffers sizes of both 
+		channels should be inferior to 64
+
+endmenu # USIC2 Channel 0 Configuration
+
+menu "USIC2 Channel 1 Configuration"
+	depends on XMC4_USIC
+	depends on XMC4_USIC2
 
 choice
-	prompt "USIC2 Channel 1 Configuration"
+	prompt "Protocol"
 	default XMC4_USIC2_CHAN1_ISUART
-	depends on XMC4_USIC2
 
 config XMC4_USIC2_CHAN1_NONE
 	bool "Not used"
@@ -478,6 +597,26 @@ config XMC4_USIC2_CHAN1_ISI2S
 	select XMC4_USCI_I2S
 	---help---
 		Configure USIC2 Channel 1 for I2S audio
+endchoice # USIC2 Channel 1 Protocol
 
-endchoice # USIC2 Channel 1 Configuration
+config XMC4_USIC2_CHAN1_TX_BUFFER_SIZE
+	int "Tx Fifo Buffer Size"
+	depends on XMC4_USIC2_CHAN1_ISUART
+	default 16
+	---help---
+		Should be a power of 2 between 2 and 64
+		The sum of Rx and Tx buffers sizes of both 
+		channels should be inferior to 64
+
+config XMC4_USIC2_CHAN1_RX_BUFFER_SIZE
+	int "Rx Fifo Buffer Size"
+	depends on XMC4_USIC2_CHAN1_ISUART
+	default 16
+	---help---
+		Should be a power of 2 between 2 and 64
+		The sum of Rx and Tx buffers sizes of both 
+		channels should be inferior to 64
+
+endmenu # USIC2 Channel 1 Configuration
+
 endmenu # XMC4xxx USIC Configuration

--- a/arch/arm/src/xmc4/hardware/xmc4_usic.h
+++ b/arch/arm/src/xmc4/hardware/xmc4_usic.h
@@ -57,6 +57,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/lib/math32.h>
 
 #include "hardware/xmc4_memorymap.h"
 
@@ -1008,12 +1009,7 @@
 #define USIC_TBCTR_SIZE_SHIFT       (24)      /* Bits 24-26: Buffer Size */
 #define USIC_TBCTR_SIZE_MASK        (7 << USIC_TBCTR_SIZE_SHIFT)
 #  define USIC_TBCTR_SIZE_DISABLE   (0 << USIC_TBCTR_SIZE_SHIFT) /* FIFO mechanism is disabled */
-#  define USIC_TBCTR_SIZE_2         (1 << USIC_TBCTR_SIZE_SHIFT) /* FIFO buffer contains 2 entries */
-#  define USIC_TBCTR_SIZE_4         (2 << USIC_TBCTR_SIZE_SHIFT) /* FIFO buffer contains 4 entries */
-#  define USIC_TBCTR_SIZE_8         (3 << USIC_TBCTR_SIZE_SHIFT) /* FIFO buffer contains 8 entries */
-#  define USIC_TBCTR_SIZE_16        (4 << USIC_TBCTR_SIZE_SHIFT) /* FIFO buffer contains 16 entries */
-#  define USIC_TBCTR_SIZE_32        (5 << USIC_TBCTR_SIZE_SHIFT) /* FIFO buffer contains 32 entries */
-#  define USIC_TBCTR_SIZE_64        (6 << USIC_TBCTR_SIZE_SHIFT) /* FIFO buffer contains 64 entries */
+#  define USIC_TBCTR_SIZE(n)        ((uint32_t)(LOG2_CEIL(n)) << USIC_TBCTR_SIZE_SHIFT)
 
 #define USIC_TBCTR_LOF              (1 << 28) /* Bit 28: Buffer Event on Limit Overflow */
 #define USIC_TBCTR_STBIEN           (1 << 30) /* Bit 30: Standard Transmit Buffer Interrupt Enable */
@@ -1058,12 +1054,7 @@
 #define USIC_RBCTR_SIZE_SHIFT       (24)      /* Bits 24-26: Buffer Size */
 #define USIC_RBCTR_SIZE_MASK        (7 << USIC_RBCTR_SIZE_SHIFT)
 #  define USIC_RBCTR_SIZE_DISABLE   (0 << USIC_RBCTR_SIZE_SHIFT) /* FIFO mechanism is disabled */
-#  define USIC_RBCTR_SIZE_2         (1 << USIC_RBCTR_SIZE_SHIFT) /* FIFO buffer contains 2 entries */
-#  define USIC_RBCTR_SIZE_4         (2 << USIC_RBCTR_SIZE_SHIFT) /* FIFO buffer contains 4 entries */
-#  define USIC_RBCTR_SIZE_8         (3 << USIC_RBCTR_SIZE_SHIFT) /* FIFO buffer contains 8 entries */
-#  define USIC_RBCTR_SIZE_16        (4 << USIC_RBCTR_SIZE_SHIFT) /* FIFO buffer contains 16 entries */
-#  define USIC_RBCTR_SIZE_32        (5 << USIC_RBCTR_SIZE_SHIFT) /* FIFO buffer contains 32 entries */
-#  define USIC_RBCTR_SIZE_64        (6 << USIC_RBCTR_SIZE_SHIFT) /* FIFO buffer contains 64 entries */
+#  define USIC_RBCTR_SIZE(n)        ((uint32_t)(LOG2_CEIL(n)) << USIC_RBCTR_SIZE_SHIFT)
 
 #define USIC_RBCTR_RNM              (1 << 27) /* Bit 27: Receiver Notification Mode */
 #define USIC_RBCTR_LOF              (1 << 28) /* Bit 28: Buffer Event on Limit Overflow */

--- a/arch/arm/src/xmc4/xmc4_lowputc.c
+++ b/arch/arm/src/xmc4/xmc4_lowputc.c
@@ -23,6 +23,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/lib/math32.h>
 
 #include <stdint.h>
 #include <errno.h>
@@ -108,6 +109,129 @@
  */
 
 #define UART_OVERSAMPLING    16
+
+#if defined(CONFIG_XMC4_USIC0_CHAN0_ISUART) 
+#if CONFIG_XMC4_USIC0_CHAN0_TX_BUFFER_SIZE  < 2 \
+    || CONFIG_XMC4_USIC0_CHAN0_TX_BUFFER_SIZE > 64 \
+    || !IS_POWER_OF_2(CONFIG_XMC4_USIC0_CHAN0_TX_BUFFER_SIZE)
+#  error Tx Buffer Size should be a power of 2 between 2 and 64
+#endif
+
+#if CONFIG_XMC4_USIC0_CHAN0_RX_BUFFER_SIZE  < 2 \
+    || CONFIG_XMC4_USIC0_CHAN0_RX_BUFFER_SIZE > 64  \
+    || !IS_POWER_OF_2(CONFIG_XMC4_USIC0_CHAN0_RX_BUFFER_SIZE)
+#  error Rx Buffer Size should be a power of 2 between 2 and 64
+#endif
+
+#endif
+
+#if defined(CONFIG_XMC4_USIC0_CHAN1_ISUART) 
+#if CONFIG_XMC4_USIC0_CHAN1_TX_BUFFER_SIZE  < 2 \
+    || CONFIG_XMC4_USIC0_CHAN1_TX_BUFFER_SIZE > 64 \
+    || !IS_POWER_OF_2(CONFIG_XMC4_USIC0_CHAN1_TX_BUFFER_SIZE)
+#  error Tx Buffer Size should be a power of 2 between 2 and 64
+#endif
+
+#if CONFIG_XMC4_USIC0_CHAN1_RX_BUFFER_SIZE  < 2 \
+    || CONFIG_XMC4_USIC0_CHAN1_RX_BUFFER_SIZE > 64  \
+    || !IS_POWER_OF_2(CONFIG_XMC4_USIC0_CHAN1_RX_BUFFER_SIZE)
+#  error Rx Buffer Size should be a power of 2 between 2 and 64
+#endif
+
+#endif
+
+#if defined(CONFIG_XMC4_USIC0_CHAN0_ISUART) && defined(CONFIG_XMC4_USIC0_CHAN1_ISUART)
+#if CONFIG_XMC4_USIC0_CHAN0_TX_BUFFER_SIZE + CONFIG_XMC4_USIC0_CHAN0_RX_BUFFER_SIZE + \
+    CONFIG_XMC4_USIC0_CHAN1_TX_BUFFER_SIZE + CONFIG_XMC4_USIC0_CHAN1_RX_BUFFER_SIZE > 64 
+#  error The sum of Rx and Tx Buffers sizes should be inferior to 64
+#endif
+#endif
+
+#if defined(CONFIG_XMC4_USIC1_CHAN0_ISUART) 
+#if CONFIG_XMC4_USIC1_CHAN0_TX_BUFFER_SIZE  < 2 \
+    || CONFIG_XMC4_USIC1_CHAN0_TX_BUFFER_SIZE > 64 \
+    || !IS_POWER_OF_2(CONFIG_XMC4_USIC1_CHAN0_TX_BUFFER_SIZE)
+#  error Tx Buffer Size should be a power of 2 between 2 and 64
+#endif
+
+#if CONFIG_XMC4_USIC1_CHAN0_RX_BUFFER_SIZE  < 2 \
+    || CONFIG_XMC4_USIC1_CHAN0_RX_BUFFER_SIZE > 64  \
+    || !IS_POWER_OF_2(CONFIG_XMC4_USIC1_CHAN0_RX_BUFFER_SIZE)
+#  error Rx Buffer Size should be a power of 2 between 2 and 64
+#endif
+
+#if CONFIG_XMC4_USIC1_CHAN0_TX_BUFFER_SIZE + CONFIG_XMC4_USIC1_CHAN0_RX_BUFFER_SIZE > 64 
+#  error The sum of Rx and Tx Buffer sizes should be inferior to 64
+#endif
+#endif
+
+#if defined(CONFIG_XMC4_USIC1_CHAN1_ISUART) 
+#if CONFIG_XMC4_USIC1_CHAN1_TX_BUFFER_SIZE  < 2 \
+    || CONFIG_XMC4_USIC1_CHAN1_TX_BUFFER_SIZE > 64 \
+    || !IS_POWER_OF_2(CONFIG_XMC4_USIC1_CHAN1_TX_BUFFER_SIZE)
+#  error Tx Buffer Size should be a power of 2 between 2 and 64
+#endif
+
+#if CONFIG_XMC4_USIC1_CHAN1_RX_BUFFER_SIZE  < 2 \
+    || CONFIG_XMC4_USIC1_CHAN1_RX_BUFFER_SIZE > 64  \
+    || !IS_POWER_OF_2(CONFIG_XMC4_USIC1_CHAN1_RX_BUFFER_SIZE)
+#  error Rx Buffer Size should be a power of 2 between 2 and 64
+#endif
+
+#if CONFIG_XMC4_USIC1_CHAN1_TX_BUFFER_SIZE + CONFIG_XMC4_USIC1_CHAN1_RX_BUFFER_SIZE > 64 
+#  error The sum of Rx and Tx Buffer sizes should be inferior to 64
+#endif
+#endif
+
+#if defined(CONFIG_XMC4_USIC1_CHAN0_ISUART) && defined(CONFIG_XMC4_USIC1_CHAN1_ISUART)
+#if CONFIG_XMC4_USIC1_CHAN0_TX_BUFFER_SIZE + CONFIG_XMC4_USIC1_CHAN0_RX_BUFFER_SIZE + \
+    CONFIG_XMC4_USIC1_CHAN1_TX_BUFFER_SIZE + CONFIG_XMC4_USIC1_CHAN1_RX_BUFFER_SIZE > 64 
+#  error The sum of Rx and Tx Buffers sizes should be inferior to 64
+#endif
+#endif
+
+#if defined(CONFIG_XMC4_USIC2_CHAN0_ISUART) 
+#if CONFIG_XMC4_USIC2_CHAN0_TX_BUFFER_SIZE  < 2 \
+    || CONFIG_XMC4_USIC2_CHAN0_TX_BUFFER_SIZE > 64 \
+    || !IS_POWER_OF_2(CONFIG_XMC4_USIC2_CHAN0_TX_BUFFER_SIZE)
+#  error Tx Buffer Size should be a power of 2 between 2 and 64
+#endif
+
+#if CONFIG_XMC4_USIC2_CHAN0_RX_BUFFER_SIZE  < 2 \
+    || CONFIG_XMC4_USIC2_CHAN0_RX_BUFFER_SIZE > 64  \
+    || !IS_POWER_OF_2(CONFIG_XMC4_USIC2_CHAN0_RX_BUFFER_SIZE)
+#  error Rx Buffer Size should be a power of 2 between 2 and 64
+#endif
+
+#if CONFIG_XMC4_USIC2_CHAN0_TX_BUFFER_SIZE + CONFIG_XMC4_USIC2_CHAN0_RX_BUFFER_SIZE > 64 
+#  error The sum of Rx and Tx Buffer sizes should be inferior to 64
+#endif
+#endif
+
+#if defined(CONFIG_XMC4_USIC2_CHAN1_ISUART) 
+#if CONFIG_XMC4_USIC2_CHAN1_TX_BUFFER_SIZE  < 2 \
+    || CONFIG_XMC4_USIC2_CHAN1_TX_BUFFER_SIZE > 64 \
+    || !IS_POWER_OF_2(CONFIG_XMC4_USIC2_CHAN1_TX_BUFFER_SIZE)
+#  error Tx Buffer Size should be a power of 2 between 2 and 64
+#endif
+
+#if CONFIG_XMC4_USIC2_CHAN1_RX_BUFFER_SIZE  < 2 \
+    || CONFIG_XMC4_USIC2_CHAN1_RX_BUFFER_SIZE > 64  \
+    || !IS_POWER_OF_2(CONFIG_XMC4_USIC2_CHAN1_RX_BUFFER_SIZE)
+#  error Rx Buffer Size should be a power of 2 between 2 and 64
+#endif
+
+#if CONFIG_XMC4_USIC2_CHAN1_TX_BUFFER_SIZE + CONFIG_XMC4_USIC2_CHAN1_RX_BUFFER_SIZE > 64 
+#  error The sum of Rx and Tx Buffer sizes should be inferior to 64
+#endif
+#endif
+
+#if defined(CONFIG_XMC4_USIC2_CHAN0_ISUART) && defined(CONFIG_XMC4_USIC2_CHAN1_ISUART)
+#if CONFIG_XMC4_USIC2_CHAN0_TX_BUFFER_SIZE + CONFIG_XMC4_USIC2_CHAN0_RX_BUFFER_SIZE + \
+    CONFIG_XMC4_USIC2_CHAN1_TX_BUFFER_SIZE + CONFIG_XMC4_USIC2_CHAN1_RX_BUFFER_SIZE > 64 
+#  error The sum of Rx and Tx Buffers sizes should be inferior to 64
+#endif
+#endif
 
 /****************************************************************************
  * Private Data
@@ -357,21 +481,21 @@ int xmc4_uart_configure(enum usic_channel_e channel,
 
   /* Configure transmit FIFO
    *
-   *   - DPTR = 16
    *   - LIMIT = 1
    *   - STBTEN = 0, the trigger of the standard transmit buffer event is
    *     based on the transition of the fill level from equal to below the
    *     limit, not the fact being below
-   *   - SIZE = 16
    *   - LOF = 0, A standard transmit buffer event occurs when the filling
    *     level equals the limit value and gets lower due to transmission of
    *     a data word
    */
 
   regval &= ~(USIC_TBCTR_DPTR_MASK | USIC_TBCTR_LIMIT_MASK |
-              USIC_TBCTR_STBTEN | USIC_TBCTR_SIZE_MASK | USIC_TBCTR_LOF);
-  regval |=  (USIC_TBCTR_DPTR(16) | USIC_TBCTR_LIMIT(1) |
-              USIC_TBCTR_SIZE_16);
+              USIC_TBCTR_STBTEN | USIC_TBCTR_SIZE_MASK |
+              USIC_TBCTR_LOF);
+  regval |=  (USIC_TBCTR_DPTR(config->startbufferptr)) |
+              USIC_TBCTR_LIMIT(1) |
+              USIC_TBCTR_SIZE(config->txbuffersize);
   putreg32(regval, base + XMC4_USIC_TBCTR_OFFSET);
 
   /* Disable the receive FIFO */
@@ -382,9 +506,6 @@ int xmc4_uart_configure(enum usic_channel_e channel,
 
   /* Configure receive FIFO.
    *
-   *   - DPTR = 0
-   *   - LIMIT = 16
-   *   - SIZE = 15
    *   - LOF = 1, A standard receive buffer event occurs when the filling
    *     level equals the limit value and gets bigger due to the reception
    *     of a new data word
@@ -392,7 +513,9 @@ int xmc4_uart_configure(enum usic_channel_e channel,
 
   regval &= ~(USIC_RBCTR_DPTR_MASK | USIC_RBCTR_LIMIT_MASK |
               USIC_RBCTR_SIZE_MASK);
-  regval |= (USIC_RBCTR_DPTR(0) | USIC_RBCTR_LIMIT(15) | USIC_RBCTR_SIZE_16 |
+  regval |= (USIC_RBCTR_DPTR(config->startbufferptr + config->txbuffersize) |
+              USIC_RBCTR_LIMIT(config->rxbuffersize) |
+              USIC_RBCTR_SIZE(config->rxbuffersize) |
              USIC_RBCTR_LOF);
   putreg32(regval, base + XMC4_USIC_RBCTR_OFFSET);
 

--- a/arch/arm/src/xmc4/xmc4_lowputc.h
+++ b/arch/arm/src/xmc4/xmc4_lowputc.h
@@ -41,11 +41,14 @@
 
 struct uart_config_s
 {
-  uint32_t baud;         /* Desired BAUD rate */
-  uint8_t  dx;           /* Input pin 0=DXA, 1=DXB, ... 6=DXG */
-  uint8_t  parity;       /* Parity selection:  0=none, 1=odd, 2=even */
-  uint8_t  nbits;        /* Number of bits per word */
-  bool     stop2;        /* true=2 stop bits; false=1 stop bit */
+  uint32_t baud;           /* Desired BAUD rate */
+  uint8_t  dx;             /* Input pin 0=DXA, 1=DXB, ... 6=DXG */
+  uint8_t  parity;         /* Parity selection:  0=none, 1=odd, 2=even */
+  uint8_t  nbits;          /* Number of bits per word */
+  bool     stop2;          /* true=2 stop bits; false=1 stop bit */
+  uint8_t  startbufferptr; /* Hardware Tx buffer start pointer */
+  uint8_t  txbuffersize;   /* Hardware Tx Buffer Size */
+  uint8_t  rxbuffersize;   /* Hardware Rx Buffer Size */
 };
 
 /****************************************************************************

--- a/arch/arm/src/xmc4/xmc4_serial.c
+++ b/arch/arm/src/xmc4/xmc4_serial.c
@@ -310,16 +310,19 @@ static char g_uart5txbuffer[CONFIG_UART5_TXBUFSIZE];
 #ifdef HAVE_UART0
 static struct xmc4_dev_s g_uart0priv =
 {
-  .uartbase       = XMC4_USIC0_CH0_BASE,
-  .channel        = (uint8_t)USIC0_CHAN0,
-  .irq            = XMC4_IRQ_USIC0_SR0,
-  .config         =
+  .uartbase         = XMC4_USIC0_CH0_BASE,
+  .channel          = (uint8_t)USIC0_CHAN0,
+  .irq              = XMC4_IRQ_USIC0_SR0,
+  .config           =
   {
-    .baud         = CONFIG_UART0_BAUD,
-    .dx           = BOARD_UART0_DX,
-    .parity       = CONFIG_UART0_PARITY,
-    .nbits        = CONFIG_UART0_BITS,
-    .stop2        = CONFIG_UART0_2STOP,
+    .baud           = CONFIG_UART0_BAUD,
+    .dx             = BOARD_UART0_DX,
+    .parity         = CONFIG_UART0_PARITY,
+    .nbits          = CONFIG_UART0_BITS,
+    .stop2          = CONFIG_UART0_2STOP,
+    .startbufferptr = 0,
+    .txbuffersize   = CONFIG_XMC4_USIC0_CHAN0_TX_BUFFER_SIZE,
+    .rxbuffersize   = CONFIG_XMC4_USIC0_CHAN0_RX_BUFFER_SIZE,
   }
 };
 
@@ -345,16 +348,20 @@ static uart_dev_t g_uart0port =
 #ifdef HAVE_UART1
 static struct xmc4_dev_s g_uart1priv =
 {
-  .uartbase       = XMC4_USIC0_CH1_BASE,
-  .channel        = (uint8_t)USIC0_CHAN1,
-  .irq            = XMC4_IRQ_USIC0_SR1,
-  .config         =
+  .uartbase         = XMC4_USIC0_CH1_BASE,
+  .channel          = (uint8_t)USIC0_CHAN1,
+  .irq              = XMC4_IRQ_USIC0_SR1,
+  .config           =
   {
-    .baud         = CONFIG_UART1_BAUD,
-    .dx           = BOARD_UART1_DX,
-    .parity       = CONFIG_UART1_PARITY,
-    .nbits        = CONFIG_UART1_BITS,
-    .stop2        = CONFIG_UART1_2STOP,
+    .baud           = CONFIG_UART1_BAUD,
+    .dx             = BOARD_UART1_DX,
+    .parity         = CONFIG_UART1_PARITY,
+    .nbits          = CONFIG_UART1_BITS,
+    .stop2          = CONFIG_UART1_2STOP,
+    .startbufferptr = CONFIG_XMC4_USIC0_CHAN0_TX_BUFFER_SIZE
+                    + CONFIG_XMC4_USIC0_CHAN0_RX_BUFFER_SIZE,
+    .txbuffersize   = CONFIG_XMC4_USIC0_CHAN1_TX_BUFFER_SIZE,
+    .rxbuffersize   = CONFIG_XMC4_USIC0_CHAN1_RX_BUFFER_SIZE,
   }
 };
 
@@ -380,16 +387,19 @@ static uart_dev_t g_uart1port =
 #ifdef HAVE_UART2
 static struct xmc4_dev_s g_uart2priv =
 {
-  .uartbase       = XMC4_USIC1_CH0_BASE,
-  .channel        = (uint8_t)USIC1_CHAN0,
-  .irq            = XMC4_IRQ_USIC1_SR0,
-  .config         =
+  .uartbase         = XMC4_USIC1_CH0_BASE,
+  .channel          = (uint8_t)USIC1_CHAN0,
+  .irq              = XMC4_IRQ_USIC1_SR0,
+  .config           =
   {
-    .baud         = CONFIG_UART2_BAUD,
-    .dx           = BOARD_UART2_DX,
-    .parity       = CONFIG_UART2_PARITY,
-    .nbits        = CONFIG_UART2_BITS,
-    .stop2        = CONFIG_UART2_2STOP,
+    .baud           = CONFIG_UART2_BAUD,
+    .dx             = BOARD_UART2_DX,
+    .parity         = CONFIG_UART2_PARITY,
+    .nbits          = CONFIG_UART2_BITS,
+    .stop2          = CONFIG_UART2_2STOP,
+    .startbufferptr = 0,
+    .txbuffersize   = CONFIG_XMC4_USIC1_CHAN0_TX_BUFFER_SIZE,
+    .rxbuffersize   = CONFIG_XMC4_USIC1_CHAN0_RX_BUFFER_SIZE,
   }
 };
 
@@ -415,16 +425,20 @@ static uart_dev_t g_uart2port =
 #ifdef HAVE_UART3
 static struct xmc4_dev_s g_uart3priv =
 {
-  .uartbase       = XMC4_USIC1_CH1_BASE,
-  .channel        = (uint8_t)USIC1_CHAN1,
-  .irq            = XMC4_IRQ_USIC1_SR1,
-  .config         =
+  .uartbase         = XMC4_USIC1_CH1_BASE,
+  .channel          = (uint8_t)USIC1_CHAN1,
+  .irq              = XMC4_IRQ_USIC1_SR1,
+  .config           =
   {
-    .baud         = CONFIG_UART3_BAUD,
-    .dx           = BOARD_UART3_DX,
-    .parity       = CONFIG_UART3_PARITY,
-    .nbits        = CONFIG_UART3_BITS,
-    .stop2        = CONFIG_UART3_2STOP,
+    .baud           = CONFIG_UART3_BAUD,
+    .dx             = BOARD_UART3_DX,
+    .parity         = CONFIG_UART3_PARITY,
+    .nbits          = CONFIG_UART3_BITS,
+    .stop2          = CONFIG_UART3_2STOP,
+    .startbufferptr = CONFIG_XMC4_USIC1_CHAN0_TX_BUFFER_SIZE
+                    + CONFIG_XMC4_USIC1_CHAN0_RX_BUFFER_SIZE,
+    .txbuffersize   = CONFIG_XMC4_USIC1_CHAN1_TX_BUFFER_SIZE,
+    .rxbuffersize   = CONFIG_XMC4_USIC1_CHAN1_RX_BUFFER_SIZE,
   }
 };
 
@@ -450,16 +464,19 @@ static uart_dev_t g_uart3port =
 #ifdef HAVE_UART4
 static struct xmc4_dev_s g_uart4priv =
 {
-  .uartbase       = XMC4_USIC2_CH0_BASE,
-  .channel        = (uint8_t)USIC2_CHAN0,
-  .irq            = XMC4_IRQ_USIC2_SR0,
-  .config         =
+  .uartbase         = XMC4_USIC2_CH0_BASE,
+  .channel          = (uint8_t)USIC2_CHAN0,
+  .irq              = XMC4_IRQ_USIC2_SR0,
+  .config           =
   {
-    .baud         = CONFIG_UART4_BAUD,
-    .dx           = BOARD_UART4_DX,
-    .parity       = CONFIG_UART4_PARITY,
-    .nbits        = CONFIG_UART4_BITS,
-    .stop2        = CONFIG_UART4_2STOP,
+    .baud           = CONFIG_UART4_BAUD,
+    .dx             = BOARD_UART4_DX,
+    .parity         = CONFIG_UART4_PARITY,
+    .nbits          = CONFIG_UART4_BITS,
+    .stop2          = CONFIG_UART4_2STOP,
+    .startbufferptr = 0,
+    .txbuffersize   = CONFIG_XMC4_USIC2_CHAN0_TX_BUFFER_SIZE,
+    .rxbuffersize   = CONFIG_XMC4_USIC2_CHAN0_RX_BUFFER_SIZE,
   }
 };
 
@@ -485,16 +502,20 @@ static uart_dev_t g_uart4port =
 #ifdef HAVE_UART5
 static struct xmc4_dev_s g_uart5priv =
 {
-  .uartbase       = XMC4_USIC2_CH1_BASE,
-  .channel        = (uint8_t)USIC2_CHAN1,
-  .irq            = XMC4_IRQ_USIC2_SR1,
-  .config         =
+  .uartbase         = XMC4_USIC2_CH1_BASE,
+  .channel          = (uint8_t)USIC2_CHAN1,
+  .irq              = XMC4_IRQ_USIC2_SR1,
+  .config           =
   {
-    .baud         = CONFIG_UART5_BAUD,
-    .dx           = BOARD_UART5_DX,
-    .parity       = CONFIG_UART5_PARITY,
-    .nbits        = CONFIG_UART5_BITS,
-    .stop2        = CONFIG_UART5_2STOP,
+    .baud           = CONFIG_UART5_BAUD,
+    .dx             = BOARD_UART5_DX,
+    .parity         = CONFIG_UART5_PARITY,
+    .nbits          = CONFIG_UART5_BITS,
+    .stop2          = CONFIG_UART5_2STOP,
+    .startbufferptr = CONFIG_XMC4_USIC2_CHAN0_TX_BUFFER_SIZE
+                    + CONFIG_XMC4_USIC2_CHAN0_RX_BUFFER_SIZE,
+    .txbuffersize   = CONFIG_XMC4_USIC2_CHAN1_TX_BUFFER_SIZE,
+    .rxbuffersize   = CONFIG_XMC4_USIC2_CHAN1_RX_BUFFER_SIZE,
   }
 };
 


### PR DESCRIPTION
## Summary
Using two channels of the same USIC module for UART the output data that should go into one UART was some times sent to the other. 
The trivial implementation of the UART driver for the XMC were using the same address buffer for the two channels. Indeed, the two channels share the same 64 words buffer for Tx And Rx (64 words for all) , that you have to distribute between the two channels and Tx and Rx. The previous implementation used the 16 first words for Rx, and the 16 next for Tx. And that for the two channels. That's why there were a mixing up there. 

What I did is a fully configurable Tx/Rx buffer. The user can choose how many words he wants for Rx/Tx and for the two channel. I've also written checks in the xmc_lowputc.c to ensure that the total is not superior to 64. 

Note : I haven't implemented the possibility to bypass these FIFO buffer.

## Testing
Tested it on xmc4800-relax kit. 
