### PR TITLE
arch/risc-v: support rv64ilp32 ABI

### DIFF
--- a/arch/risc-v/Kconfig
+++ b/arch/risc-v/Kconfig
@@ -337,7 +337,12 @@ config ARCH_RV32
 config ARCH_RV64
 	bool
 	default n
-	select LIBC_ARCH_ELF_64BIT if LIBC_ARCH_ELF
+	select LIBC_ARCH_ELF_64BIT if LIBC_ARCH_ELF && !ARCH_RV64ILP32
+
+config ARCH_RV64ILP32
+	bool
+	depends on ARCH_RV64
+	default n
 
 config ARCH_RV_ISA_M
 	bool
@@ -546,6 +551,14 @@ config RISCV_TOOLCHAIN_GNU_RV32
 config RISCV_TOOLCHAIN_CLANG
 	bool "LLVM Clang toolchain"
 	select ARCH_TOOLCHAIN_CLANG
+
+config RISCV_TOOLCHAIN_GNU_RV64ILP32
+	bool "Generic GNU RV64ILP32 toolchain"
+	select ARCH_TOOLCHAIN_GNU
+	select ARCH_RV64ILP32
+	---help---
+		This option work with Ruyisdk toolchain (GCC 13 or newer)
+		configured for riscv64-unknown-elf.
 
 endchoice # Toolchain Selection
 

--- a/arch/risc-v/include/inttypes.h
+++ b/arch/risc-v/include/inttypes.h
@@ -29,18 +29,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#if defined(CONFIG_ARCH_RV64)
-#define _PRI32PREFIX
-#define _PRI64PREFIX "l"
-#define _PRIPTRPREFIX "l"
-#define _SCN32PREFIX
-#define _SCN64PREFIX "l"
-#define _SCNPTRPREFIX "l"
-#define INT32_C(x)  x
-#define INT64_C(x)  x ## l
-#define UINT32_C(x) x ## u
-#define UINT64_C(x) x ## ul
-#else /* defined(CONFIG_ARCH_RV64) */
+#if defined(CONFIG_ARCH_RV64ILP32) || defined(CONFIG_ARCH_RV32)
 #define _PRI32PREFIX "l"
 #define _PRI64PREFIX "ll"
 #define _PRIPTRPREFIX
@@ -51,7 +40,18 @@
 #define INT64_C(x)  x ## ll
 #define UINT32_C(x) x ## ul
 #define UINT64_C(x) x ## ull
-#endif /* defined(CONFIG_ARCH_RV64) */
+#elif defined(CONFIG_ARCH_RV64)
+#define _PRI32PREFIX
+#define _PRI64PREFIX "l"
+#define _PRIPTRPREFIX "l"
+#define _SCN32PREFIX
+#define _SCN64PREFIX "l"
+#define _SCNPTRPREFIX "l"
+#define INT32_C(x)  x
+#define INT64_C(x)  x ## l
+#define UINT32_C(x) x ## u
+#define UINT64_C(x) x ## ul
+#endif
 
 #define PRId8       "d"
 #define PRId16      "d"

--- a/arch/risc-v/include/irq.h
+++ b/arch/risc-v/include/irq.h
@@ -552,7 +552,7 @@ struct xcptcontext
    * another signal handler is executing will be ignored!
    */
 
-  uintptr_t *saved_regs;
+  uintreg_t *saved_regs;
 
 #ifndef CONFIG_BUILD_FLAT
   /* This is the saved address to use when returning from a user-space
@@ -581,21 +581,21 @@ struct xcptcontext
 
   /* Integer register save area */
 
-  uintptr_t *regs;
+  uintreg_t *regs;
 
   /* FPU register save area */
 
 #if defined(CONFIG_ARCH_FPU) && defined(CONFIG_ARCH_LAZYFPU)
-  uintptr_t fregs[FPU_XCPT_REGS];
+  uintreg_t fregs[FPU_XCPT_REGS];
 #endif
 
 #ifdef CONFIG_ARCH_RV_ISA_V
 #  if CONFIG_ARCH_RV_VECTOR_BYTE_LENGTH > 0
   /* There are 32 vector registers(v0 - v31) with vlenb length. */
 
-  uintptr_t vregs[VPU_XCPTC_SIZE];
+  uintreg_t vregs[VPU_XCPTC_SIZE];
 #  else
-  uintptr_t *vregs;
+  uintreg_t *vregs;
 #  endif
 #endif
 };
@@ -648,7 +648,7 @@ extern "C"
  * such value for each processor that can receive an interrupt.
  */
 
-EXTERN volatile uintptr_t *g_current_regs[CONFIG_SMP_NCPUS];
+EXTERN volatile uintreg_t *g_current_regs[CONFIG_SMP_NCPUS];
 #define CURRENT_REGS (g_current_regs[up_cpu_index()])
 
 /****************************************************************************

--- a/arch/risc-v/include/limits.h
+++ b/arch/risc-v/include/limits.h
@@ -54,7 +54,7 @@
 
 /* These change on 32-bit and 64-bit platforms */
 
-#ifdef CONFIG_ARCH_RV32
+#if defined(CONFIG_ARCH_RV32) || defined(CONFIG_ARCH_RV64ILP32)
 #  define LONG_MIN  (-LONG_MAX - 1)
 #  define LONG_MAX  2147483647L
 #  define ULONG_MAX 4294967295UL

--- a/arch/risc-v/include/types.h
+++ b/arch/risc-v/include/types.h
@@ -54,19 +54,19 @@ typedef unsigned char      _uint8_t;
 typedef signed short       _int16_t;
 typedef unsigned short     _uint16_t;
 
-#ifdef CONFIG_ARCH_RV64
-typedef signed int         _int32_t;
-typedef unsigned int       _uint32_t;
-
-typedef signed long        _int64_t;
-typedef unsigned long      _uint64_t;
-#else /* CONFIG_ARCH_RV64 */
+#if defined(CONFIG_ARCH_RV64ILP32) || defined(CONFIG_ARCH_RV32)
 typedef signed long        _int32_t;
 typedef unsigned long      _uint32_t;
 
 typedef signed long long   _int64_t;
 typedef unsigned long long _uint64_t;
-#endif /* CONFIG_ARCH_RV64 */
+#elif defined(CONFIG_ARCH_RV64)
+typedef signed int         _int32_t;
+typedef unsigned int       _uint32_t;
+
+typedef signed long        _int64_t;
+typedef unsigned long      _uint64_t;
+#endif
 #define __INT64_DEFINED
 
 typedef _int64_t           _intmax_t;
@@ -76,6 +76,14 @@ typedef _uint64_t          _uintmax_t;
 typedef __WCHAR_TYPE__     _wchar_t;
 #else
 typedef int                _wchar_t;
+#endif
+
+/* Use uintreg_t for register-width integers */
+
+#ifdef CONFIG_ARCH_RV32
+typedef _uint32_t          uintreg_t;
+#else
+typedef _uint64_t          uintreg_t;
 #endif
 
 #ifdef CONFIG_ARCH_RV64

--- a/arch/risc-v/src/bl602/bl602_irq_dispatch.c
+++ b/arch/risc-v/src/bl602/bl602_irq_dispatch.c
@@ -41,7 +41,7 @@
  * riscv_dispatch_irq
  ****************************************************************************/
 
-void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
+void *riscv_dispatch_irq(uintptr_t vector, uintreg_t *regs)
 {
   int irq  = vector & 0x3ff; /* E24 [9:0] */
 

--- a/arch/risc-v/src/cmake/Toolchain.cmake
+++ b/arch/risc-v/src/cmake/Toolchain.cmake
@@ -26,6 +26,7 @@ set(CMAKE_CXX_COMPILER_FORCED TRUE)
 
 if(CONFIG_RISCV_TOOLCHAIN_GNU_RV32
    OR CONFIG_RISCV_TOOLCHAIN_GNU_RV64
+   OR CONFIG_RISCV_TOOLCHAIN_GNU_RV64ILP32
    OR CONFIG_RISCV_TOOLCHAIN_CLANG)
   if(NOT CONFIG_RISCV_TOOLCHAIN)
     set(CONFIG_RISCV_TOOLCHAIN GNU_RVG)
@@ -184,7 +185,11 @@ if(CONFIG_ARCH_RV32)
   add_link_options(-Wl,-melf32lriscv)
 elseif(CONFIG_ARCH_RV64)
   add_compile_options(-mcmodel=medany)
-  add_link_options(-Wl,-melf64lriscv)
+  if(CONFIG_ARCH_RV64ILP32)
+    add_link_options(-Wl,-melf32lriscv)
+  else()
+    add_link_options(-Wl,-melf64lriscv)
+  endif()
 endif()
 
 if(CONFIG_DEBUG_OPT_UNUSED_SECTIONS)
@@ -268,7 +273,11 @@ if(${CONFIG_RISCV_TOOLCHAIN} STREQUAL GNU_RVG)
     set(LLVM_ARCHTYPE "riscv32")
   elseif(CONFIG_ARCH_RV64)
     set(ARCHTYPE "rv64")
-    set(ARCHABITYPE "lp64")
+    if(CONFIG_ARCH_RV64ILP32)
+      set(ARCHABITYPE "ilp32")
+    else()
+      set(ARCHABITYPE "lp64")
+    endif()
     set(LLVM_ARCHTYPE "riscv64")
   endif()
 

--- a/arch/risc-v/src/common/Toolchain.defs
+++ b/arch/risc-v/src/common/Toolchain.defs
@@ -29,6 +29,8 @@
 
 ifeq ($(filter y, $(CONFIG_RISCV_TOOLCHAIN_GNU_RV64)),y)
   CONFIG_RISCV_TOOLCHAIN ?= GNU_RVG
+else ifeq ($(filter y, $(CONFIG_RISCV_TOOLCHAIN_GNU_RV64ILP32)),y)
+  CONFIG_RISCV_TOOLCHAIN ?= GNU_RVG
 else ifeq ($(filter y, $(CONFIG_RISCV_TOOLCHAIN_GNU_RV32)),y)
   CONFIG_RISCV_TOOLCHAIN ?= GNU_RVG
 else ifeq ($(filter y, $(CONFIG_RISCV_TOOLCHAIN_CLANG)),y)
@@ -119,6 +121,8 @@ SHMODULEFLAGS = -Bsymbolic -G -Bdynamic --entry=__start
 ifeq ($(CONFIG_ARCH_RV32),y)
 LDFLAGS += -melf32lriscv
 SHMODULEFLAGS += -melf32lriscv
+else ifeq ($(CONFIG_ARCH_RV64ILP32),y)
+LDFLAGS += -melf32lriscv
 else
 LDFLAGS += -melf64lriscv
 endif
@@ -231,7 +235,11 @@ ifeq ($(CONFIG_RISCV_TOOLCHAIN),GNU_RVG)
     LLVM_ARCHTYPE := riscv32
   else ifeq ($(CONFIG_ARCH_RV64),y)
     ARCHTYPE = rv64
-    ARCHABITYPE = lp64
+    ifeq ($(CONFIG_ARCH_RV64ILP32),y)
+      ARCHABITYPE = ilp32
+    else
+      ARCHABITYPE = lp64
+    endif
     LLVM_ARCHTYPE := riscv64
     # https://www.sifive.com/blog/all-aboard-part-4-risc-v-code-models
     ARCHCPUFLAGS = -mcmodel=medany

--- a/arch/risc-v/src/common/espressif/esp_irq.c
+++ b/arch/risc-v/src/common/espressif/esp_irq.c
@@ -553,7 +553,7 @@ void esp_teardown_irq(int source, int cpuint)
  *
  ****************************************************************************/
 
-IRAM_ATTR uintptr_t *riscv_dispatch_irq(uintptr_t mcause, uintptr_t *regs)
+IRAM_ATTR void *riscv_dispatch_irq(uintreg_t mcause, uintreg_t *regs)
 {
   int irq;
   bool is_irq = (RISCV_IRQ_BIT & mcause) != 0;

--- a/arch/risc-v/src/common/riscv_doirq.c
+++ b/arch/risc-v/src/common/riscv_doirq.c
@@ -56,7 +56,7 @@
  * Public Functions
  ****************************************************************************/
 
-uintptr_t *riscv_doirq(int irq, uintptr_t *regs)
+uintreg_t *riscv_doirq(int irq, uintreg_t *regs)
 {
   board_autoled_on(LED_INIRQ);
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
@@ -119,7 +119,7 @@ uintptr_t *riscv_doirq(int irq, uintptr_t *regs)
        * that a context switch occurred during interrupt processing.
        */
 
-      regs = (uintptr_t *)CURRENT_REGS;
+      regs = (uintreg_t *)CURRENT_REGS;
     }
 
   /* Set CURRENT_REGS to NULL to indicate that we are no longer in an

--- a/arch/risc-v/src/common/riscv_exception.c
+++ b/arch/risc-v/src/common/riscv_exception.c
@@ -84,7 +84,7 @@ int riscv_exception(int mcause, void *regs, void *args)
 #ifdef CONFIG_ARCH_KERNEL_STACK
   FAR struct tcb_s *tcb = this_task();
 #endif
-  uintptr_t cause = mcause & RISCV_IRQ_MASK;
+  uintreg_t cause = mcause & RISCV_IRQ_MASK;
 
   _alert("EXCEPTION: %s. MCAUSE: %" PRIxREG ", EPC: %" PRIxREG
          ", MTVAL: %" PRIxREG "\n",

--- a/arch/risc-v/src/common/riscv_fork.c
+++ b/arch/risc-v/src/common/riscv_fork.c
@@ -110,7 +110,7 @@ pid_t riscv_fork(const struct fork_s *context)
   uintptr_t stacktop;
   uintptr_t stackutil;
 #ifdef CONFIG_ARCH_FPU
-  uintptr_t *fregs;
+  uintreg_t *fregs;
 #endif
 
   sinfo("s0:%" PRIxREG " s1:%" PRIxREG " s2:%" PRIxREG " s3:%" PRIxREG ""
@@ -140,7 +140,7 @@ pid_t riscv_fork(const struct fork_s *context)
 
   /* Allocate and initialize a TCB for the child task. */
 
-  child = nxtask_setup_fork((start_t)context->ra);
+  child = nxtask_setup_fork((start_t)(uintptr_t)context->ra);
   if (!child)
     {
       sinfo("nxtask_setup_fork failed\n");
@@ -159,7 +159,7 @@ pid_t riscv_fork(const struct fork_s *context)
   DEBUGASSERT(stacktop > context->sp);
   stackutil = stacktop - context->sp;
 
-  sinfo("Parent: stackutil:%" PRIxREG "\n", stackutil);
+  sinfo("Parent: stackutil:%" PRIxPTR "\n", stackutil);
 
   /* Make some feeble effort to preserve the stack contents.  This is
    * feeble because the stack surely contains invalid pointers and other
@@ -177,7 +177,7 @@ pid_t riscv_fork(const struct fork_s *context)
          child->cmn.xcp.regs, XCPTCONTEXT_SIZE);
 
   child->cmn.xcp.regs = (void *)(newsp - XCPTCONTEXT_SIZE);
-  memcpy((void *)newsp, (const void *)context->sp, stackutil);
+  memcpy((void *)newsp, (const void *)(uintptr_t)context->sp, stackutil);
 
   /* Was there a frame pointer in place before? */
 
@@ -192,14 +192,14 @@ pid_t riscv_fork(const struct fork_s *context)
       newfp = context->fp;
     }
 
-  sinfo("Old stack top:%" PRIxREG " SP:%" PRIxREG " FP:%" PRIxREG "\n",
+  sinfo("Old stack top:%" PRIxPTR " SP:%" PRIxREG " FP:%" PRIxREG "\n",
         stacktop, context->sp, context->fp);
-  sinfo("New stack top:%" PRIxREG " SP:%" PRIxREG " FP:%" PRIxREG "\n",
+  sinfo("New stack top:%" PRIxPTR " SP:%" PRIxPTR " FP:%" PRIxPTR "\n",
         newtop, newsp, newfp);
 #else
-  sinfo("Old stack top:%" PRIxREG " SP:%" PRIxREG "\n",
+  sinfo("Old stack top:%" PRIxPTR " SP:%" PRIxREG "\n",
         stacktop, context->sp);
-  sinfo("New stack top:%" PRIxREG " SP:%" PRIxREG "\n",
+  sinfo("New stack top:%" PRIxPTR " SP:%" PRIxPTR "\n",
         newtop, newsp);
 #endif
 

--- a/arch/risc-v/src/common/riscv_fork.h
+++ b/arch/risc-v/src/common/riscv_fork.h
@@ -119,43 +119,43 @@ struct fork_s
 {
   /* CPU registers */
 
-  uintptr_t s1;   /* Saved register s1 */
-  uintptr_t s2;   /* Saved register s2 */
-  uintptr_t s3;   /* Saved register s3 */
-  uintptr_t s4;   /* Saved register s4 */
-  uintptr_t s5;   /* Saved register s5 */
-  uintptr_t s6;   /* Saved register s6 */
-  uintptr_t s7;   /* Saved register s7 */
-  uintptr_t s8;   /* Saved register s8 */
-  uintptr_t s9;   /* Saved register s9 */
-  uintptr_t s10;  /* Saved register s10 */
-  uintptr_t s11;  /* Saved register s11 */
+  uintreg_t s1;   /* Saved register s1 */
+  uintreg_t s2;   /* Saved register s2 */
+  uintreg_t s3;   /* Saved register s3 */
+  uintreg_t s4;   /* Saved register s4 */
+  uintreg_t s5;   /* Saved register s5 */
+  uintreg_t s6;   /* Saved register s6 */
+  uintreg_t s7;   /* Saved register s7 */
+  uintreg_t s8;   /* Saved register s8 */
+  uintreg_t s9;   /* Saved register s9 */
+  uintreg_t s10;  /* Saved register s10 */
+  uintreg_t s11;  /* Saved register s11 */
 #ifdef CONFIG_RISCV_FRAMEPOINTER
-  uintptr_t fp;   /* Frame pointer */
+  uintreg_t fp;   /* Frame pointer */
 #else
-  uintptr_t s0;   /* Saved register s0 */
+  uintreg_t s0;   /* Saved register s0 */
 #endif
-  uintptr_t sp;   /* Stack pointer */
-  uintptr_t ra;   /* Return address */
+  uintreg_t sp;   /* Stack pointer */
+  uintreg_t ra;   /* Return address */
 #ifdef RISCV_SAVE_GP
-  uintptr_t gp;   /* Global pointer */
+  uintreg_t gp;   /* Global pointer */
 #endif
 
   /* Floating point registers */
 
 #ifdef CONFIG_ARCH_FPU
-  uintptr_t fs0;   /* Saved register fs0 */
-  uintptr_t fs1;   /* Saved register fs1 */
-  uintptr_t fs2;   /* Saved register fs2 */
-  uintptr_t fs3;   /* Saved register fs3 */
-  uintptr_t fs4;   /* Saved register fs4 */
-  uintptr_t fs5;   /* Saved register fs5 */
-  uintptr_t fs6;   /* Saved register fs6 */
-  uintptr_t fs7;   /* Saved register fs7 */
-  uintptr_t fs8;   /* Saved register fs8 */
-  uintptr_t fs9;   /* Saved register fs9 */
-  uintptr_t fs10;  /* Saved register fs10 */
-  uintptr_t fs11;  /* Saved register fs11 */
+  uintreg_t fs0;   /* Saved register fs0 */
+  uintreg_t fs1;   /* Saved register fs1 */
+  uintreg_t fs2;   /* Saved register fs2 */
+  uintreg_t fs3;   /* Saved register fs3 */
+  uintreg_t fs4;   /* Saved register fs4 */
+  uintreg_t fs5;   /* Saved register fs5 */
+  uintreg_t fs6;   /* Saved register fs6 */
+  uintreg_t fs7;   /* Saved register fs7 */
+  uintreg_t fs8;   /* Saved register fs8 */
+  uintreg_t fs9;   /* Saved register fs9 */
+  uintreg_t fs10;  /* Saved register fs10 */
+  uintreg_t fs11;  /* Saved register fs11 */
 #endif
 };
 #endif

--- a/arch/risc-v/src/common/riscv_initialize.c
+++ b/arch/risc-v/src/common/riscv_initialize.c
@@ -32,7 +32,7 @@
  * Public Data
  ****************************************************************************/
 
-volatile uintptr_t *g_current_regs[CONFIG_SMP_NCPUS];
+volatile uintreg_t *g_current_regs[CONFIG_SMP_NCPUS];
 
 /****************************************************************************
  * Private Functions

--- a/arch/risc-v/src/common/riscv_initialstate.c
+++ b/arch/risc-v/src/common/riscv_initialstate.c
@@ -131,7 +131,7 @@ void up_initial_state(struct tcb_s *tcb)
     }
 #endif
 
-  xcp->regs = (uintptr_t *)(topstack - XCPTCONTEXT_SIZE);
+  xcp->regs = (uintreg_t *)(topstack - XCPTCONTEXT_SIZE);
   memset(xcp->regs, 0, XCPTCONTEXT_SIZE);
 
   /* Save the initial stack pointer.  Hmmm.. the stack is set to the very

--- a/arch/risc-v/src/common/riscv_internal.h
+++ b/arch/risc-v/src/common/riscv_internal.h
@@ -87,16 +87,16 @@
 /* Format output with register width and hex */
 
 #ifdef CONFIG_ARCH_RV32
-#  define PRIxREG "08" PRIxPTR
+#  define PRIxREG "08"  PRIx32
 #else
-#  define PRIxREG "016" PRIxPTR
+#  define PRIxREG "016" PRIx64
 #endif
 
 /* In the RISC-V model, the state is saved in stack,
  * only a reference stored in TCB.
  */
 
-#define riscv_savestate(regs) (regs = (uintptr_t *)CURRENT_REGS)
+#define riscv_savestate(regs) (regs = (uintreg_t *)CURRENT_REGS)
 #define riscv_restorestate(regs) (CURRENT_REGS = regs)
 
 /* Determine which (if any) console driver to use.  If a console is enabled
@@ -136,14 +136,14 @@
 
 #define READ_CSR(reg) \
   ({ \
-     uintptr_t __regval; \
+     uintreg_t __regval; \
      __asm__ __volatile__("csrr %0, " __STR(reg) : "=r"(__regval)); \
      __regval; \
   })
 
 #define READ_AND_SET_CSR(reg, bits) \
   ({ \
-     uintptr_t __regval; \
+     uintreg_t __regval; \
      __asm__ __volatile__("csrrs %0, " __STR(reg) ", %1": "=r"(__regval) : "rK"(bits)); \
      __regval; \
   })
@@ -244,12 +244,12 @@ void riscv_exception_attach(void);
 
 #ifdef CONFIG_ARCH_FPU
 void riscv_fpuconfig(void);
-void riscv_savefpu(uintptr_t *regs, uintptr_t *fregs);
-void riscv_restorefpu(uintptr_t *regs, uintptr_t *fregs);
+void riscv_savefpu(uintreg_t *regs, uintreg_t *fregs);
+void riscv_restorefpu(uintreg_t *regs, uintreg_t *fregs);
 
 /* Get FPU register save area */
 
-static inline uintptr_t *riscv_fpuregs(struct tcb_s *tcb)
+static inline uintreg_t *riscv_fpuregs(struct tcb_s *tcb)
 {
 #ifdef CONFIG_ARCH_LAZYFPU
   /* With lazy FPU the registers are simply in tcb */
@@ -258,7 +258,7 @@ static inline uintptr_t *riscv_fpuregs(struct tcb_s *tcb)
 #else
   /* Otherwise they are after the integer registers */
 
-  return (uintptr_t *)((uintptr_t)tcb->xcp.regs + INT_XCPT_SIZE);
+  return (uintreg_t *)((uintptr_t)tcb->xcp.regs + INT_XCPT_SIZE);
 #endif
 }
 #else
@@ -290,7 +290,7 @@ static inline uintptr_t *riscv_vpuregs(struct tcb_s *tcb)
 
 static inline void riscv_savecontext(struct tcb_s *tcb)
 {
-  tcb->xcp.regs = (uintptr_t *)CURRENT_REGS;
+  tcb->xcp.regs = (uintreg_t *)CURRENT_REGS;
 
 #ifdef CONFIG_ARCH_FPU
   /* Save current process FPU state to TCB */
@@ -307,7 +307,7 @@ static inline void riscv_savecontext(struct tcb_s *tcb)
 
 static inline void riscv_restorecontext(struct tcb_s *tcb)
 {
-  CURRENT_REGS = (uintptr_t *)tcb->xcp.regs;
+  CURRENT_REGS = (uintreg_t *)tcb->xcp.regs;
 
 #ifdef CONFIG_ARCH_FPU
   /* Restore FPU state for next process */
@@ -384,7 +384,7 @@ void riscv_netinitialize(void);
 
 /* Exception Handler ********************************************************/
 
-uintptr_t *riscv_doirq(int irq, uintptr_t *regs);
+uintreg_t *riscv_doirq(int irq, uintreg_t *regs);
 int riscv_exception(int mcause, void *regs, void *args);
 int riscv_fillpage(int mcause, void *regs, void *args);
 int riscv_misaligned(int irq, void *context, void *arg);
@@ -417,7 +417,7 @@ uintptr_t riscv_mhartid(void);
 /* If kernel runs in Supervisor mode, a system call trampoline is needed */
 
 #ifdef CONFIG_ARCH_USE_S_MODE
-void *riscv_perform_syscall(uintptr_t *regs);
+void *riscv_perform_syscall(uintreg_t *regs);
 #endif
 
 /* Context switching via system calls ***************************************/

--- a/arch/risc-v/src/common/riscv_percpu.h
+++ b/arch/risc-v/src/common/riscv_percpu.h
@@ -71,10 +71,10 @@ union riscv_percpu_s
   struct
   {
     struct tcb_s       *tcb;       /* Current thread TCB */
-    uintptr_t           hartid;    /* Hart ID */
-    uintptr_t           irq_stack; /* Interrupt stack */
-    uintptr_t           usp;       /* Area to store user sp */
-    uintptr_t           ksp;       /* Area to load kernel sp */
+    uintreg_t           hartid;    /* Hart ID */
+    uintreg_t           irq_stack; /* Interrupt stack */
+    uintreg_t           usp;       /* Area to store user sp */
+    uintreg_t           ksp;       /* Area to load kernel sp */
   };
 };
 

--- a/arch/risc-v/src/common/riscv_registerdump.c
+++ b/arch/risc-v/src/common/riscv_registerdump.c
@@ -53,7 +53,7 @@ uintptr_t up_getusrsp(void *regs)
 
 void up_dump_register(void *dumpregs)
 {
-  volatile uintptr_t *regs = dumpregs ? dumpregs : CURRENT_REGS;
+  volatile uintreg_t *regs = dumpregs ? dumpregs : CURRENT_REGS;
 
   /* Are user registers available from interrupt processing? */
 

--- a/arch/risc-v/src/common/riscv_schedulesigaction.c
+++ b/arch/risc-v/src/common/riscv_schedulesigaction.c
@@ -136,10 +136,10 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * been delivered.
                */
 
-              CURRENT_REGS = (uintptr_t *)((uintptr_t)CURRENT_REGS -
+              CURRENT_REGS = (uintreg_t *)((uintptr_t)CURRENT_REGS -
                                                       XCPTCONTEXT_SIZE);
 
-              memcpy((uintptr_t *)CURRENT_REGS, tcb->xcp.saved_regs,
+              memcpy((uintreg_t *)CURRENT_REGS, tcb->xcp.saved_regs,
                      XCPTCONTEXT_SIZE);
 
               /* Then set up to vector to the trampoline with interrupts
@@ -190,7 +190,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * delivered.
            */
 
-          tcb->xcp.regs = (uintptr_t *)((uintptr_t)tcb->xcp.regs -
+          tcb->xcp.regs = (uintreg_t *)((uintptr_t)tcb->xcp.regs -
                                                    XCPTCONTEXT_SIZE);
 
           memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
@@ -301,7 +301,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                    * been delivered.
                    */
 
-                  tcb->xcp.regs = (uintptr_t *)((uintptr_t)tcb->xcp.regs -
+                  tcb->xcp.regs = (uintreg_t *)((uintptr_t)tcb->xcp.regs -
                                                            XCPTCONTEXT_SIZE);
 
                   memcpy(tcb->xcp.regs, tcb->xcp.saved_regs,
@@ -327,17 +327,17 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                    * been delivered.
                    */
 
-                  tcb->xcp.saved_regs = (uintptr_t *)CURRENT_REGS;
+                  tcb->xcp.saved_regs = (uintreg_t *)CURRENT_REGS;
 
                   /* Duplicate the register context.  These will be
                    * restored by the signal trampoline after the signal has
                    * been delivered.
                    */
 
-                  CURRENT_REGS = (uintptr_t *)((uintptr_t)CURRENT_REGS -
+                  CURRENT_REGS = (uintreg_t *)((uintptr_t)CURRENT_REGS -
                                                           XCPTCONTEXT_SIZE);
 
-                  memcpy((uintptr_t *)CURRENT_REGS, tcb->xcp.saved_regs,
+                  memcpy((uintreg_t *)CURRENT_REGS, tcb->xcp.saved_regs,
                          XCPTCONTEXT_SIZE);
 
                   CURRENT_REGS[REG_SP]      = (uintptr_t)CURRENT_REGS +
@@ -395,7 +395,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * delivered.
            */
 
-          tcb->xcp.regs              = (uintptr_t *)
+          tcb->xcp.regs              = (uintreg_t *)
                                        ((uintptr_t)tcb->xcp.regs -
                                                    XCPTCONTEXT_SIZE);
 

--- a/arch/risc-v/src/common/riscv_sigdeliver.c
+++ b/arch/risc-v/src/common/riscv_sigdeliver.c
@@ -55,7 +55,7 @@
 void riscv_sigdeliver(void)
 {
   struct tcb_s *rtcb = this_task();
-  uintptr_t *regs = rtcb->xcp.saved_regs;
+  uintreg_t *regs = rtcb->xcp.saved_regs;
 
 #ifdef CONFIG_SMP
   /* In the SMP case, we must terminate the critical section while the signal

--- a/arch/risc-v/src/common/riscv_swint.c
+++ b/arch/risc-v/src/common/riscv_swint.c
@@ -154,7 +154,7 @@ uintptr_t dispatch_syscall(unsigned int nbr, uintptr_t parm1,
 
 int riscv_swint(int irq, void *context, void *arg)
 {
-  uintptr_t *regs = (uintptr_t *)context;
+  uintreg_t *regs = (uintreg_t *)context;
 
   DEBUGASSERT(regs && regs == CURRENT_REGS);
 
@@ -190,7 +190,7 @@ int riscv_swint(int irq, void *context, void *arg)
 
       case SYS_restore_context:
         {
-          struct tcb_s *next = (struct tcb_s *)regs[REG_A1];
+          struct tcb_s *next = (struct tcb_s *)(uintptr_t)regs[REG_A1];
 
           DEBUGASSERT(regs[REG_A1] != 0);
           riscv_restorecontext(next);
@@ -216,8 +216,8 @@ int riscv_swint(int irq, void *context, void *arg)
 
       case SYS_switch_context:
         {
-          struct tcb_s *prev = (struct tcb_s *)regs[REG_A1];
-          struct tcb_s *next = (struct tcb_s *)regs[REG_A2];
+          struct tcb_s *prev = (struct tcb_s *)(uintptr_t)regs[REG_A1];
+          struct tcb_s *next = (struct tcb_s *)(uintptr_t)regs[REG_A2];
 
           DEBUGASSERT(regs[REG_A1] != 0 && regs[REG_A2] != 0);
           riscv_savecontext(prev);

--- a/arch/risc-v/src/common/supervisor/riscv_perform_syscall.c
+++ b/arch/risc-v/src/common/supervisor/riscv_perform_syscall.c
@@ -35,7 +35,7 @@
  * Public Functions
  ****************************************************************************/
 
-void *riscv_perform_syscall(uintptr_t *regs)
+void *riscv_perform_syscall(uintreg_t *regs)
 {
   /* Set up the interrupt register set needed by swint() */
 
@@ -76,7 +76,7 @@ void *riscv_perform_syscall(uintptr_t *regs)
        * that a context switch occurred during interrupt processing.
        */
 
-      regs = (uintptr_t *)CURRENT_REGS;
+      regs = (uintreg_t *)CURRENT_REGS;
     }
 
   CURRENT_REGS = NULL;

--- a/arch/risc-v/src/esp32c3-legacy/esp32c3_irq.c
+++ b/arch/risc-v/src/esp32c3-legacy/esp32c3_irq.c
@@ -636,7 +636,7 @@ uint32_t *riscv_int_decode(uint32_t cpuints, uint32_t *regs)
  *
  ****************************************************************************/
 
-IRAM_ATTR uintptr_t *riscv_dispatch_irq(uintptr_t mcause, uintptr_t *regs)
+IRAM_ATTR void *riscv_dispatch_irq(uintptr_t mcause, uintreg_t *regs)
 {
   int irq;
   uint8_t cpuint = mcause & RISCV_IRQ_MASK;

--- a/arch/risc-v/src/fe310/fe310_irq_dispatch.c
+++ b/arch/risc-v/src/fe310/fe310_irq_dispatch.c
@@ -48,7 +48,7 @@
  * riscv_dispatch_irq
  ****************************************************************************/
 
-void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
+void *riscv_dispatch_irq(uintreg_t vector, uintreg_t *regs)
 {
   int irq = (vector >> RV_IRQ_MASK) | (vector & 0xf);
 

--- a/arch/risc-v/src/hpm6000/hpm_irq_dispatch.c
+++ b/arch/risc-v/src/hpm6000/hpm_irq_dispatch.c
@@ -48,7 +48,7 @@
  * riscv_dispatch_irq
  ****************************************************************************/
 
-void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
+void *riscv_dispatch_irq(uintreg_t vector, uintreg_t *regs)
 {
   int irq = (vector >> RV_IRQ_MASK) | (vector & 0xf);
 

--- a/arch/risc-v/src/hpm6750/hpm6750_irq_dispatch.c
+++ b/arch/risc-v/src/hpm6750/hpm6750_irq_dispatch.c
@@ -48,7 +48,7 @@
  * riscv_dispatch_irq
  ****************************************************************************/
 
-void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
+void *riscv_dispatch_irq(uintreg_t vector, uintreg_t *regs)
 {
   int irq = (vector >> RV_IRQ_MASK) | (vector & 0xf);
 

--- a/arch/risc-v/src/qemu-rv/qemu_rv_irq_dispatch.c
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_irq_dispatch.c
@@ -53,7 +53,7 @@
  * riscv_dispatch_irq
  ****************************************************************************/
 
-void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
+void *riscv_dispatch_irq(uintreg_t vector, uintreg_t *regs)
 {
   int irq = (vector >> RV_IRQ_MASK) | (vector & 0xf);
 

--- a/arch/risc-v/src/rv32m1/rv32m1_irq_dispatch.c
+++ b/arch/risc-v/src/rv32m1/rv32m1_irq_dispatch.c
@@ -49,7 +49,7 @@
  ****************************************************************************/
 
 LOCATE_ITCM
-void *rv32m1_dispatch_irq(uintptr_t vector, uintptr_t *regs)
+void *rv32m1_dispatch_irq(uintreg_t vector, uintreg_t *regs)
 {
   uint32_t vec = vector & 0x1f;
   int irq = (vector >> RV_IRQ_MASK) + vec;

--- a/libs/libc/machine/risc-v/arch_elf.c
+++ b/libs/libc/machine/risc-v/arch_elf.c
@@ -346,8 +346,8 @@ bool up_checkarch(const Elf_Ehdr *ehdr)
 
   if ((ehdr->e_entry & 1) != 0)
     {
-      berr("ERROR: Entry point is not properly aligned: %08lx\n",
-           ehdr->e_entry);
+      berr("ERROR: Entry point is not properly aligned: %" PRIxPTR "\n",
+           (uintptr_t)ehdr->e_entry);
     }
 
   /* TODO:  Check ABI here. */
@@ -418,10 +418,10 @@ int up_relocateadd(const Elf_Rela *rel, const Elf_Sym *sym,
       case R_RISCV_64:
         {
           binfo("%s at %08" PRIxPTR " [%08" PRIx32 "] "
-                "to sym=%p st_value=%08lx\n",
+                "to sym=%p st_value=%" PRIxPTR "\n",
                 _get_rname(relotype),
                 addr, _get_val((uint16_t *)addr),
-                sym, sym->st_value);
+                sym, (uintptr_t)sym->st_value);
 
           _set_val((uint16_t *)addr,
                    (uint32_t)(sym->st_value + rel->r_addend));
@@ -434,10 +434,10 @@ int up_relocateadd(const Elf_Rela *rel, const Elf_Sym *sym,
           long imm_lo;
 
           binfo("%s at %08" PRIxPTR " [%08" PRIx32 "] "
-                "to sym=%p st_value=%08lx\n",
+                "to sym=%p st_value=%" PRIxPTR "\n",
                 _get_rname(relotype),
                 addr, _get_val((uint16_t *)addr),
-                sym, sym->st_value);
+                sym, (uintptr_t)sym->st_value);
 
           offset = _find_hi20(arch_data, sym->st_value);
 
@@ -456,10 +456,10 @@ int up_relocateadd(const Elf_Rela *rel, const Elf_Sym *sym,
           long imm_lo;
 
           binfo("%s at %08" PRIxPTR " [%08" PRIx32 "] "
-                "to sym=%p st_value=%08lx\n",
+                "to sym=%p st_value=%" PRIxPTR "\n",
                 _get_rname(relotype),
                 addr, _get_val((uint16_t *)addr),
-                sym, sym->st_value);
+                sym, (uintptr_t)sym->st_value);
 
           offset = _find_hi20(arch_data, sym->st_value);
 
@@ -483,10 +483,10 @@ int up_relocateadd(const Elf_Rela *rel, const Elf_Sym *sym,
           long imm_lo;
 
           binfo("%s at %08" PRIxPTR " [%08" PRIx32 "] "
-                "to sym=%p st_value=%08lx\n",
+                "to sym=%p st_value=%" PRIxPTR "\n",
                 _get_rname(relotype),
                 addr, _get_val((uint16_t *)addr),
-                sym, sym->st_value);
+                sym, (uintptr_t)sym->st_value);
 
           offset = (long)sym->st_value + (long)rel->r_addend - (long)addr;
 
@@ -497,8 +497,8 @@ int up_relocateadd(const Elf_Rela *rel, const Elf_Sym *sym,
 
           if (!_valid_hi20_imm(imm_hi))
             {
-              berr("ERROR: %s at %08" PRIxPTR " bad:%08lx\n",
-                   _get_rname(relotype), addr, imm_hi << 12);
+              berr("ERROR: %s at %08" PRIxPTR " bad:%08" PRIxPTR "\n",
+                   _get_rname(relotype), addr, (uintptr_t)imm_hi << 12);
 
               return -EINVAL;
             }
@@ -520,10 +520,10 @@ int up_relocateadd(const Elf_Rela *rel, const Elf_Sym *sym,
           long imm_lo;
 
           binfo("%s at %08" PRIxPTR " [%08" PRIx32 "] "
-                "to sym=%p st_value=%08lx\n",
+                "to sym=%p st_value=%" PRIxPTR "\n",
                 _get_rname(relotype),
                 addr, _get_val((uint16_t *)addr),
-                sym, sym->st_value);
+                sym, (uintptr_t)sym->st_value);
 
           offset = (long)sym->st_value + (long)rel->r_addend - (long)addr;
 
@@ -531,8 +531,8 @@ int up_relocateadd(const Elf_Rela *rel, const Elf_Sym *sym,
 
           if (!_valid_hi20_imm(imm_hi))
             {
-              berr("ERROR: %s at %08" PRIxPTR " bad:%08lx\n",
-                   _get_rname(relotype), addr, imm_hi << 12);
+              berr("ERROR: %s at %08" PRIxPTR " bad:%08" PRIxPTR "\n",
+                   _get_rname(relotype), addr, (uintptr_t)imm_hi << 12);
 
               return -EINVAL;
             }
@@ -550,10 +550,10 @@ int up_relocateadd(const Elf_Rela *rel, const Elf_Sym *sym,
       case R_RISCV_BRANCH:
         {
           binfo("%s at %08" PRIxPTR " [%08" PRIx32 "] "
-                "to sym=%p st_value=%08lx\n",
+                "to sym=%p st_value=%" PRIxPTR "\n",
                 _get_rname(relotype),
                 addr, _get_val((uint16_t *)addr),
-                sym, sym->st_value);
+                sym, (uintptr_t)sym->st_value);
 
           /* P.23 Conditinal Branches : B type (imm=12bit) */
 
@@ -573,10 +573,10 @@ int up_relocateadd(const Elf_Rela *rel, const Elf_Sym *sym,
       case R_RISCV_JAL:
         {
           binfo("%s at %08" PRIxPTR " [%08" PRIx32 "] "
-                "to sym=%p st_value=%08lx\n",
+                "to sym=%p st_value=%" PRIxPTR "\n",
                 _get_rname(relotype),
                 addr, _get_val((uint16_t *)addr),
-                sym, sym->st_value);
+                sym, (uintptr_t)sym->st_value);
 
           /* P.21 Unconditinal Jumps : UJ type (imm=20bit) */
 
@@ -596,10 +596,10 @@ int up_relocateadd(const Elf_Rela *rel, const Elf_Sym *sym,
       case R_RISCV_HI20:
         {
           binfo("%s at %08" PRIxPTR " [%08" PRIx32 "] "
-                "to sym=%p st_value=%08lx\n",
+                "to sym=%p st_value=%" PRIxPTR "\n",
                 _get_rname(relotype),
                 addr, _get_val((uint16_t *)addr),
-                sym, sym->st_value);
+                sym, (uintptr_t)sym->st_value);
 
           /* P.19 LUI */
 
@@ -614,8 +614,8 @@ int up_relocateadd(const Elf_Rela *rel, const Elf_Sym *sym,
 
           if (!_valid_hi20_imm(imm_hi))
             {
-              berr("ERROR: %s at %08" PRIxPTR " bad:%08lx\n",
-                   _get_rname(relotype), addr, imm_hi << 12);
+              berr("ERROR: %s at %08" PRIxPTR " bad:%08" PRIxPTR "\n",
+                   _get_rname(relotype), addr, (uintptr_t)imm_hi << 12);
 
               return -EINVAL;
             }
@@ -629,10 +629,10 @@ int up_relocateadd(const Elf_Rela *rel, const Elf_Sym *sym,
       case R_RISCV_LO12_I:
         {
           binfo("%s at %08" PRIxPTR " [%08" PRIx32 "] "
-                "to sym=%p st_value=%08lx\n",
+                "to sym=%p st_value=%" PRIxPTR "\n",
                 _get_rname(relotype),
                 addr, _get_val((uint16_t *)addr),
-                sym, sym->st_value);
+                sym, (uintptr_t)sym->st_value);
 
           /* ADDI, FLW, LD, ... : I-type */
 
@@ -651,10 +651,10 @@ int up_relocateadd(const Elf_Rela *rel, const Elf_Sym *sym,
       case R_RISCV_LO12_S:
         {
           binfo("%s at %08" PRIxPTR " [%08" PRIx32 "] "
-                "to sym=%p st_value=%08lx\n",
+                "to sym=%p st_value=%" PRIxPTR "\n",
                 _get_rname(relotype),
                 addr, _get_val((uint16_t *)addr),
-                sym, sym->st_value);
+                sym, (uintptr_t)sym->st_value);
 
           /* SW : S-type.
            * not merge with R_RISCV_HI20 since the compiler
@@ -680,10 +680,10 @@ int up_relocateadd(const Elf_Rela *rel, const Elf_Sym *sym,
       case R_RISCV_RVC_JUMP:
         {
           binfo("%s at %08" PRIxPTR " [%08" PRIx32 "] "
-                "to sym=%p st_value=%08lx\n",
+                "to sym=%p st_value=%" PRIxPTR "\n",
                 _get_rname(relotype),
                 addr, _get_val((uint16_t *)addr),
-                sym, sym->st_value);
+                sym, (uintptr_t)sym->st_value);
 
           /* P.111 Table 16.6 : Instruction listings for RVC */
 
@@ -700,10 +700,10 @@ int up_relocateadd(const Elf_Rela *rel, const Elf_Sym *sym,
       case R_RISCV_RVC_BRANCH:
         {
           binfo("%s at %08" PRIxPTR " [%08" PRIx32 "] "
-                "to sym=%p st_value=%08lx\n",
+                "to sym=%p st_value=%" PRIxPTR "\n",
                 _get_rname(relotype),
                 addr, _get_val((uint16_t *)addr),
-                sym, sym->st_value);
+                sym, (uintptr_t)sym->st_value);
 
           /* P.111 Table 16.6 : Instruction listings for RVC */
 
@@ -725,10 +725,10 @@ int up_relocateadd(const Elf_Rela *rel, const Elf_Sym *sym,
           /* P.29 https://github.com/riscv-non-isa/riscv-elf-psabi-doc */
 
           binfo("%s at %08" PRIxPTR " [%08" PRIx32 "] "
-                "to sym=%p st_value=%08lx\n",
+                "to sym=%p st_value=%" PRIxPTR "\n",
                 _get_rname(relotype),
                 addr, _get_val((uint16_t *)addr),
-                sym, sym->st_value);
+                sym, (uintptr_t)sym->st_value);
 
           addr = (long)sym->st_value + (long)rel->r_addend - (long)addr;
         }
@@ -764,8 +764,8 @@ int up_relocateadd(const Elf_Rela *rel, const Elf_Sym *sym,
         }
         break;
       default:
-        berr("ERROR: Unsupported relocation: %ld\n",
-             ELF_R_TYPE(rel->r_info));
+        berr("ERROR: Unsupported relocation: %" PRIu32 "\n",
+             (uint32_t)ELF_R_TYPE(rel->r_info));
         PANIC();
         return -EINVAL;
     }


### PR DESCRIPTION
## Summary

This supports running NuttX using 32bit pointers and 64-bit registers on 64-bit RISC-V devices, using the rv64ilp32 toolchain from the `ruyisdk/riscv-gnu-toolchain-rv64ilp32` Github repo. See [this page](https://yf13.github.io/nuttx/nuttx-rv64ilp32) for more details.

## Impact

None

## Testing

- Checked on qemu-system-riscv64ilp32
- CI checks
