### PR TITLE
fs/lock: use nxsched_self for modularity

### DIFF
--- a/fs/vfs/fs_lock.c
+++ b/fs/vfs/fs_lock.c
@@ -36,7 +36,6 @@
 #include <nuttx/list.h>
 
 #include "lock.h"
-#include "sched/sched.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -95,7 +94,7 @@ static mutex_t g_protect_lock = NXMUTEX_INITIALIZER;
 
 static int file_lock_get_path(FAR struct file *filep, FAR char *path)
 {
-  FAR struct tcb_s *tcb = this_task();
+  FAR struct tcb_s *tcb = nxsched_self();
 
   /* We only apply file lock on mount points (f_inode won't be NULL). */
 


### PR DESCRIPTION
## Summary

Better use nxsched_self() from outside of `sched/` module.

## Impacts

None

## Testing

- CI checks
