### PR TITLE
nuttx/elf.h: fix build issues

### DIFF
--- a/arch/risc-v/include/elf.h
+++ b/arch/risc-v/include/elf.h
@@ -25,6 +25,16 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+#define EM_ARCH  EM_RISCV
+
+#if defined(CONFIG_RISCV_TOOLCHAIN_GNU_RV64ILP32)
+#define EM_FLAG  0x25
+#elif defined(COFIG_ARCH_RISCV)
+#define EM_FLAG  5
+#else
+#define EM_FLAG  0
+#endif
+
 /* https://github.com/riscv/riscv-elf-psabi-doc/blob/master/riscv-elf.md */
 
 #define R_RISCV_NONE           0

--- a/binfmt/libelf/libelf_coredump.c
+++ b/binfmt/libelf/libelf_coredump.c
@@ -233,7 +233,6 @@ static void elf_emit_tcb_note(FAR struct elf_dumpinfo_s *cinfo,
   elf_prpsinfo_t info;
   FAR uintptr_t *regs;
   Elf_Nhdr nhdr;
-  int i;
 
   memset(&info,   0x0, sizeof(info));
   memset(&status, 0x0, sizeof(status));
@@ -280,9 +279,10 @@ static void elf_emit_tcb_note(FAR struct elf_dumpinfo_s *cinfo,
       regs = (uintptr_t *)tcb->xcp.regs;
     }
 
+#if defined(ARCH_ARM) || defined(ARCH_ARM64)
   if (regs != NULL)
     {
-      for (i = 0; i < nitems(status.pr_regs); i++)
+      for (int i = 0; i < nitems(status.pr_regs); i++)
         {
           if (g_tcbinfo.reg_off.p[i] == UINT16_MAX)
             {
@@ -295,6 +295,7 @@ static void elf_emit_tcb_note(FAR struct elf_dumpinfo_s *cinfo,
             }
         }
     }
+#endif
 
   elf_emit(cinfo, &status, sizeof(status));
 }

--- a/include/nuttx/elf.h
+++ b/include/nuttx/elf.h
@@ -84,7 +84,9 @@ typedef struct elf_prstatus_s
   elf_timeval_t  pr_stime;    /* System time */
   elf_timeval_t  pr_cutime;   /* Cumulative user time */
   elf_timeval_t  pr_cstime;   /* Cumulative system time */
+#if defined(ARCH_ARM) || defined(ARCH_ARM64)
   elf_gregset_t  pr_regs;
+#endif
   int            pr_fpvalid;  /* True if math co-processor being used */
 } elf_prstatus_t;
 #endif


### PR DESCRIPTION
## Summary

This guards `pr_regs` field for ARM/ARM64 as they are missing in other architectures now. It also adds missed `EM_ARCH` and `EM_FLAG` in `arch/elf.h` for RISCV.

These issues were encountered when ELF_COREDUMP is enabled for `rv-virt`.

## Impacts

None

## Testings

- local build
- CI checks
