### PR TITLE
 arch/xmc4 vadc driver - background request source partial support (linked to #12425)

### DIFF
--- a/arch/arm/src/xmc4/Make.defs
+++ b/arch/arm/src/xmc4/Make.defs
@@ -26,6 +26,7 @@ CHIP_CSRCS  = xmc4_allocateheap.c xmc4_clockconfig.c xmc4_clockutils.c
 CHIP_CSRCS += xmc4_clrpend.c xmc4_flash.c xmc4_gpio.c xmc4_irq.c
 CHIP_CSRCS += xmc4_lowputc.c xmc4_serial.c xmc4_start.c xmc4_usic.c
 CHIP_CSRCS += xmc4_ccu4.c
+CHIP_CSRCS += xmc4_vadc.c
 
 # Configuration-dependent Kinetis files
 

--- a/arch/arm/src/xmc4/xmc4_vadc.h
+++ b/arch/arm/src/xmc4/xmc4_vadc.h
@@ -605,7 +605,7 @@ int xmc4_vadc_global_background_add_channel_to_sequence(const uint32_t grp_num,
  *
  ********************************************************************************************************/
 
-void xmc4_vadc_global_background_enable_autoscan();
+void xmc4_vadc_global_background_enable_autoscan(void);
 
 /********************************************************************************************************
  * Name: xmc4_vadc_global_background_start_conversion
@@ -617,7 +617,7 @@ void xmc4_vadc_global_background_enable_autoscan();
  *
  ********************************************************************************************************/
 
-void xmc4_vadc_global_background_start_conversion();
+void xmc4_vadc_global_background_start_conversion(void);
 
 /********************************************************************************************************
  * Name: xmc4_vadc_group_get_result


### PR DESCRIPTION
Linked to  #12425 

## Summary
Added the new xmc4 vadc driver to the Make.defs file

## Impact

## Testing
On a custom XMC4800 board.
