### PR TITLE
boards/thingy53: add sensors support

### DIFF
--- a/Documentation/platforms/arm/nrf53/boards/thingy53/index.rst
+++ b/Documentation/platforms/arm/nrf53/boards/thingy53/index.rst
@@ -22,11 +22,11 @@ Battery monitoring                 No
 Buzzer                             No
 PDM microphone (VM3011)            No
 Front End Module (nRF21540)        No
-Low power accelerometer (ADXL362)  No
-IMU (BMI270)                       No
-Magnetometer (BMM150)              No
-Air quality sensor (HBME688)       No
-Color sensor (VM3011)              No
+Low power accelerometer (ADXL362)  Yes     SPI
+IMU (BMI270)                       Yes     SPI or I2C 0x68
+Magnetometer (BMM150)              Yes     I2C 0x10
+Color sensor (BH1749NUC)           Yes     I2C 0x38
+Air quality sensor (BME688)        No      I2C 0x76
 ================================== ======= =============
 
 Serial Console

--- a/boards/arm/nrf53/common/include/nrf53_adxl362.h
+++ b/boards/arm/nrf53/common/include/nrf53_adxl362.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * boards/arm/nrf53/thingy53/src/nrf53_boot.c
+ * boards/arm/nrf53/common/include/nrf53_adxl362.h
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,67 +18,34 @@
  *
  ****************************************************************************/
 
+#ifndef __BOARDS_ARM_NRF53_COMMON_INCLUDE_NRF53_ADXL362_H
+#define __BOARDS_ARM_NRF53_COMMON_INCLUDE_NRF53_ADXL362_H
+
 /****************************************************************************
  * Included Files
  ****************************************************************************/
 
 #include <nuttx/config.h>
 
-#include <debug.h>
-
-#include <nuttx/board.h>
-#include <arch/board/board.h>
-
-#include "thingy53.h"
-
 /****************************************************************************
- * Public Functions
+ * Public Functions Prototypes
  ****************************************************************************/
 
 /****************************************************************************
- * Name: nrf53_board_initialize
+ * Name: nrf53_adxl362_initialize
  *
  * Description:
- *   All NRF53xxx architectures must provide the following entry point.
- *   This entry point is called early in the initialization -- after all
- *   memory has been configured and mapped but before any devices have been
- *   initialized.
+ *   Initialize and register the ADXL362 as uorb sensor
+ *
+ * Input Parameters:
+ *   devno - The user specifies device number, from 0.
+ *   busno - SPI or I2C bus number
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
  *
  ****************************************************************************/
 
-void nrf53_board_initialize(void)
-{
-  /* Configure on-board LEDs if LED support has been selected. */
+int nrf53_adxl362_init(int devno, int busno);
 
-#ifdef CONFIG_ARCH_LEDS
-  board_autoled_initialize();
-#endif
-
-#ifdef CONFIG_NRF53_SPI_MASTER
-  /* Configure SPI chip selects */
-
-  nrf53_spidev_initialize();
-#endif
-}
-
-/****************************************************************************
- * Name: board_late_initialize
- *
- * Description:
- *   If CONFIG_BOARD_LATE_INITIALIZE is selected, then an additional
- *   initialization call will be performed in the boot-up sequence to a
- *   function called board_late_initialize(). board_late_initialize() will be
- *   called immediately after up_initialize() is called and just before the
- *   initial application is started.  This additional initialization phase
- *   may be used, for example, to initialize board-specific device drivers.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_BOARD_LATE_INITIALIZE
-void board_late_initialize(void)
-{
-  /* Perform board-specific initialization */
-
-  nrf53_bringup();
-}
-#endif
+#endif /* __BOARDS_ARM_NRF53_COMMON_INCLUDE_NRF53_ADXL362_H */

--- a/boards/arm/nrf53/common/include/nrf53_bh1749nuc.h
+++ b/boards/arm/nrf53/common/include/nrf53_bh1749nuc.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * boards/arm/nrf53/thingy53/src/nrf53_boot.c
+ * boards/arm/nrf53/common/include/nrf53_bh1749nuc.h
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,67 +18,35 @@
  *
  ****************************************************************************/
 
+#ifndef __BOARDS_ARM_NRF53_COMMON_INCLUDE_NRF53_BH1749NUC_H
+#define __BOARDS_ARM_NRF53_COMMON_INCLUDE_NRF53_BH1749NUC_H
+
 /****************************************************************************
  * Included Files
  ****************************************************************************/
 
 #include <nuttx/config.h>
 
-#include <debug.h>
-
-#include <nuttx/board.h>
-#include <arch/board/board.h>
-
-#include "thingy53.h"
-
 /****************************************************************************
- * Public Functions
+ * Public Functions Prototypes
  ****************************************************************************/
 
 /****************************************************************************
- * Name: nrf53_board_initialize
+ * Name: nrf53_bh1749nuc_init
  *
  * Description:
- *   All NRF53xxx architectures must provide the following entry point.
- *   This entry point is called early in the initialization -- after all
- *   memory has been configured and mapped but before any devices have been
- *   initialized.
+ *   Initialize and register the BH1749NUC as uorb sensor
+ *
+ * Input Parameters:
+ *   devno - The user specifies device number, from 0.
+ *   busno - I2C bus number
+ *   addr  - The I2C address
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
  *
  ****************************************************************************/
 
-void nrf53_board_initialize(void)
-{
-  /* Configure on-board LEDs if LED support has been selected. */
+int nrf53_bh1749nuc_init(int devno, int busno, uint8_t addr);
 
-#ifdef CONFIG_ARCH_LEDS
-  board_autoled_initialize();
-#endif
-
-#ifdef CONFIG_NRF53_SPI_MASTER
-  /* Configure SPI chip selects */
-
-  nrf53_spidev_initialize();
-#endif
-}
-
-/****************************************************************************
- * Name: board_late_initialize
- *
- * Description:
- *   If CONFIG_BOARD_LATE_INITIALIZE is selected, then an additional
- *   initialization call will be performed in the boot-up sequence to a
- *   function called board_late_initialize(). board_late_initialize() will be
- *   called immediately after up_initialize() is called and just before the
- *   initial application is started.  This additional initialization phase
- *   may be used, for example, to initialize board-specific device drivers.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_BOARD_LATE_INITIALIZE
-void board_late_initialize(void)
-{
-  /* Perform board-specific initialization */
-
-  nrf53_bringup();
-}
-#endif
+#endif /* __BOARDS_ARM_NRF53_COMMON_INCLUDE_NRF53_BH1749NUC_H */

--- a/boards/arm/nrf53/common/include/nrf53_bmi270.h
+++ b/boards/arm/nrf53/common/include/nrf53_bmi270.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * boards/arm/nrf53/thingy53/src/nrf53_boot.c
+ * boards/arm/nrf53/common/include/nrf53_bmi270.h
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,67 +18,40 @@
  *
  ****************************************************************************/
 
+#ifndef __BOARDS_ARM_NRF53_COMMON_INCLUDE_NRF53_BMI270_H
+#define __BOARDS_ARM_NRF53_COMMON_INCLUDE_NRF53_BMI270_H
+
 /****************************************************************************
  * Included Files
  ****************************************************************************/
 
 #include <nuttx/config.h>
 
-#include <debug.h>
-
-#include <nuttx/board.h>
-#include <arch/board/board.h>
-
-#include "thingy53.h"
-
 /****************************************************************************
- * Public Functions
+ * Public Functions Prototypes
  ****************************************************************************/
 
 /****************************************************************************
- * Name: nrf53_board_initialize
+ * Name: nrf53_bmi270spi_initialize
+ *       nrf53_bmi270i2c_initialize
  *
  * Description:
- *   All NRF53xxx architectures must provide the following entry point.
- *   This entry point is called early in the initialization -- after all
- *   memory has been configured and mapped but before any devices have been
- *   initialized.
+ *   Initialize and register the BMI270 as uorb sensor
+ *
+ * Input Parameters:
+ *   devno - The user specifies device number, from 0.
+ *   busno - SPI or I2C bus number
+ *   addr  - (I2C only) The I2C address
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
  *
  ****************************************************************************/
 
-void nrf53_board_initialize(void)
-{
-  /* Configure on-board LEDs if LED support has been selected. */
-
-#ifdef CONFIG_ARCH_LEDS
-  board_autoled_initialize();
+#ifdef CONFIG_SENSORS_BMI270_SPI
+int nrf53_bmi270spi_initialize(int devno, int busno);
+#else  /* CONFIG_SENSORS_BMI270_I2C */
+int nrf53_bmi270i2c_initialize(int devno, int bus, uint8_t addr);
 #endif
 
-#ifdef CONFIG_NRF53_SPI_MASTER
-  /* Configure SPI chip selects */
-
-  nrf53_spidev_initialize();
-#endif
-}
-
-/****************************************************************************
- * Name: board_late_initialize
- *
- * Description:
- *   If CONFIG_BOARD_LATE_INITIALIZE is selected, then an additional
- *   initialization call will be performed in the boot-up sequence to a
- *   function called board_late_initialize(). board_late_initialize() will be
- *   called immediately after up_initialize() is called and just before the
- *   initial application is started.  This additional initialization phase
- *   may be used, for example, to initialize board-specific device drivers.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_BOARD_LATE_INITIALIZE
-void board_late_initialize(void)
-{
-  /* Perform board-specific initialization */
-
-  nrf53_bringup();
-}
-#endif
+#endif /* __BOARDS_ARM_NRF53_COMMON_INCLUDE_NRF53_BMI270_H */

--- a/boards/arm/nrf53/common/include/nrf53_bmm150.h
+++ b/boards/arm/nrf53/common/include/nrf53_bmm150.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * boards/arm/nrf53/thingy53/src/nrf53_boot.c
+ * boards/arm/nrf53/common/include/nrf53_bmm150.h
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,67 +18,35 @@
  *
  ****************************************************************************/
 
+#ifndef __BOARDS_ARM_NRF53_COMMON_INCLUDE_NRF53_BMM150_H
+#define __BOARDS_ARM_NRF53_COMMON_INCLUDE_NRF53_BMM150_H
+
 /****************************************************************************
  * Included Files
  ****************************************************************************/
 
 #include <nuttx/config.h>
 
-#include <debug.h>
-
-#include <nuttx/board.h>
-#include <arch/board/board.h>
-
-#include "thingy53.h"
-
 /****************************************************************************
- * Public Functions
+ * Public Functions Prototypes
  ****************************************************************************/
 
 /****************************************************************************
- * Name: nrf53_board_initialize
+ * Name: nrf53_bmm150_init
  *
  * Description:
- *   All NRF53xxx architectures must provide the following entry point.
- *   This entry point is called early in the initialization -- after all
- *   memory has been configured and mapped but before any devices have been
- *   initialized.
+ *   Initialize and register the BMM150 as uorb sensor
+ *
+ * Input Parameters:
+ *   devno - The user specifies device number, from 0.
+ *   busno - I2C bus number
+ *   addr  - The I2C address
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
  *
  ****************************************************************************/
 
-void nrf53_board_initialize(void)
-{
-  /* Configure on-board LEDs if LED support has been selected. */
+int nrf53_bmm150_init(int devno, int busno, uint8_t addr);
 
-#ifdef CONFIG_ARCH_LEDS
-  board_autoled_initialize();
-#endif
-
-#ifdef CONFIG_NRF53_SPI_MASTER
-  /* Configure SPI chip selects */
-
-  nrf53_spidev_initialize();
-#endif
-}
-
-/****************************************************************************
- * Name: board_late_initialize
- *
- * Description:
- *   If CONFIG_BOARD_LATE_INITIALIZE is selected, then an additional
- *   initialization call will be performed in the boot-up sequence to a
- *   function called board_late_initialize(). board_late_initialize() will be
- *   called immediately after up_initialize() is called and just before the
- *   initial application is started.  This additional initialization phase
- *   may be used, for example, to initialize board-specific device drivers.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_BOARD_LATE_INITIALIZE
-void board_late_initialize(void)
-{
-  /* Perform board-specific initialization */
-
-  nrf53_bringup();
-}
-#endif
+#endif /* __BOARDS_ARM_NRF53_COMMON_INCLUDE_NRF53_BMM150_H */

--- a/boards/arm/nrf53/common/src/CMakeLists.txt
+++ b/boards/arm/nrf53/common/src/CMakeLists.txt
@@ -36,6 +36,22 @@ if(CONFIG_ARCH_BOARD_COMMON)
     list(APPEND SRCS nrf53_reset.c)
   endif()
 
+  if(CONFIG_SENSORS_BMI270)
+    list(APPEND SRCS nrf53_bmi270.c)
+  endif()
+
+  if(CONFIG_SENSORS_ADXL362)
+    list(APPEND SRCS nrf53_adxl362.c)
+  endif()
+
+  if(CONFIG_SENSORS_BH1749NUC)
+    list(APPEND SRCS nrf53_bh1749nuc.c)
+  endif()
+
+  if(CONFIG_SENSORS_BMM150)
+    list(APPEND SRCS nrf53_bmm150.c)
+  endif()
+
   target_sources(board PRIVATE ${SRCS})
 
 endif()

--- a/boards/arm/nrf53/common/src/Make.defs
+++ b/boards/arm/nrf53/common/src/Make.defs
@@ -36,6 +36,22 @@ ifeq ($(CONFIG_BOARDCTL_RESET),y)
   CSRCS += nrf53_reset.c
 endif
 
+ifeq ($(CONFIG_SENSORS_BMI270),y)
+  CSRCS += nrf53_bmi270.c
+endif
+
+ifeq ($(CONFIG_SENSORS_ADXL362),y)
+  CSRCS += nrf53_adxl362.c
+endif
+
+ifeq ($(CONFIG_SENSORS_BH1749NUC),y)
+  CSRCS += nrf53_bh1749nuc.c
+endif
+
+ifeq ($(CONFIG_SENSORS_BMM150),y)
+  CSRCS += nrf53_bmm150.c
+endif
+
 DEPPATH += --dep-path src
 VPATH += :src
 CFLAGS += ${INCDIR_PREFIX}$(TOPDIR)$(DELIM)arch$(DELIM)$(CONFIG_ARCH)$(DELIM)src$(DELIM)board$(DELIM)src

--- a/boards/arm/nrf53/common/src/nrf53_adxl362.c
+++ b/boards/arm/nrf53/common/src/nrf53_adxl362.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * boards/arm/nrf53/thingy53/src/nrf53_boot.c
+ * boards/arm/nrf53/common/src/nrf53_adxl362.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -24,61 +24,56 @@
 
 #include <nuttx/config.h>
 
+#include <stdio.h>
 #include <debug.h>
+#include <errno.h>
 
-#include <nuttx/board.h>
-#include <arch/board/board.h>
+#include <nuttx/sensors/adxl362.h>
 
-#include "thingy53.h"
+#include <nuttx/spi/spi.h>
+#include "nrf53_spi.h"
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
 /****************************************************************************
- * Name: nrf53_board_initialize
+ * Name: nrf53_adxl362_init
  *
  * Description:
- *   All NRF53xxx architectures must provide the following entry point.
- *   This entry point is called early in the initialization -- after all
- *   memory has been configured and mapped but before any devices have been
- *   initialized.
+ *   Initialize and register the ADXL362 device
+ *
+ * Input Parameters:
+ *   devno - The user specifies device number, from 0.
+ *   busno - SPI or I2C bus number
+ *   addr  - (I2C only) The I2C address
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
  *
  ****************************************************************************/
 
-void nrf53_board_initialize(void)
+int nrf53_adxl362_init(int devno, int busno)
 {
-  /* Configure on-board LEDs if LED support has been selected. */
+  struct spi_dev_s *spi;
+  int ret;
 
-#ifdef CONFIG_ARCH_LEDS
-  board_autoled_initialize();
-#endif
+  sninfo("Initializing ADXL362..\n");
 
-#ifdef CONFIG_NRF53_SPI_MASTER
-  /* Configure SPI chip selects */
+  /* Initialize spi device */
 
-  nrf53_spidev_initialize();
-#endif
+  spi = nrf53_spibus_initialize(busno);
+  if (!spi)
+    {
+      snerr("ERROR: Failed to initialize spi%d.\n", busno);
+      return -ENODEV;
+    }
+
+  ret = adxl362_register(devno, spi);
+  if (ret < 0)
+    {
+      snerr("Error registering ADXL362\n");
+    }
+
+  return ret;
 }
-
-/****************************************************************************
- * Name: board_late_initialize
- *
- * Description:
- *   If CONFIG_BOARD_LATE_INITIALIZE is selected, then an additional
- *   initialization call will be performed in the boot-up sequence to a
- *   function called board_late_initialize(). board_late_initialize() will be
- *   called immediately after up_initialize() is called and just before the
- *   initial application is started.  This additional initialization phase
- *   may be used, for example, to initialize board-specific device drivers.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_BOARD_LATE_INITIALIZE
-void board_late_initialize(void)
-{
-  /* Perform board-specific initialization */
-
-  nrf53_bringup();
-}
-#endif

--- a/boards/arm/nrf53/common/src/nrf53_bh1749nuc.c
+++ b/boards/arm/nrf53/common/src/nrf53_bh1749nuc.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * boards/arm/nrf53/thingy53/src/nrf53_boot.c
+ * boards/arm/nrf53/common/src/nrf53_bh1749nuc.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -25,60 +25,68 @@
 #include <nuttx/config.h>
 
 #include <debug.h>
+#include <errno.h>
+#include <stdio.h>
 
-#include <nuttx/board.h>
-#include <arch/board/board.h>
+#include <nuttx/i2c/i2c_master.h>
+#include <nuttx/sensors/bh1749nuc.h>
 
-#include "thingy53.h"
+#include "nrf53_i2c.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifndef CONFIG_SENSORS_BH1749NUC_UORB
+#  error BH1749NUC UORB is only supported
+#endif
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
 /****************************************************************************
- * Name: nrf53_board_initialize
+ * Name: nrf53_bh1749nuc_init
  *
  * Description:
- *   All NRF53xxx architectures must provide the following entry point.
- *   This entry point is called early in the initialization -- after all
- *   memory has been configured and mapped but before any devices have been
- *   initialized.
+ *   Initialize and register the BH1749NUC as uorb sensor
+ *
+ * Input Parameters:
+ *   devno - The user specifies device number, from 0.
+ *   busno - I2C bus number
+ *   addr  - The I2C address
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
  *
  ****************************************************************************/
 
-void nrf53_board_initialize(void)
+int nrf53_bh1749nuc_init(int devno, int busno, uint8_t addr)
 {
-  /* Configure on-board LEDs if LED support has been selected. */
+  struct bh1749nuc_config_s  config;
+  struct i2c_master_s       *i2c;
+  int                        ret;
 
-#ifdef CONFIG_ARCH_LEDS
-  board_autoled_initialize();
-#endif
+  sninfo("Initializing BH1749NUC!\n");
 
-#ifdef CONFIG_NRF53_SPI_MASTER
-  /* Configure SPI chip selects */
+  /* Initialize I2C */
 
-  nrf53_spidev_initialize();
-#endif
+  i2c = nrf53_i2cbus_initialize(busno);
+  if (!i2c)
+    {
+      return -ENODEV;
+    }
+
+  /* Then register the barometer sensor */
+
+  config.i2c  = i2c;
+  config.addr = addr;
+
+  ret = bh1749nuc_register_uorb(devno, &config);
+  if (ret < 0)
+    {
+      snerr("ERROR: Error registering BH1749NUC\n");
+    }
+
+  return ret;
 }
-
-/****************************************************************************
- * Name: board_late_initialize
- *
- * Description:
- *   If CONFIG_BOARD_LATE_INITIALIZE is selected, then an additional
- *   initialization call will be performed in the boot-up sequence to a
- *   function called board_late_initialize(). board_late_initialize() will be
- *   called immediately after up_initialize() is called and just before the
- *   initial application is started.  This additional initialization phase
- *   may be used, for example, to initialize board-specific device drivers.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_BOARD_LATE_INITIALIZE
-void board_late_initialize(void)
-{
-  /* Perform board-specific initialization */
-
-  nrf53_bringup();
-}
-#endif

--- a/boards/arm/nrf53/common/src/nrf53_bmi270.c
+++ b/boards/arm/nrf53/common/src/nrf53_bmi270.c
@@ -1,0 +1,112 @@
+/****************************************************************************
+ * boards/arm/nrf53/common/src/nrf53_bmi270.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdio.h>
+#include <debug.h>
+#include <errno.h>
+
+#include <nuttx/sensors/bmi270.h>
+
+#ifdef CONFIG_SENSORS_BMI270_SPI
+#  include <nuttx/spi/spi.h>
+#  include "nrf53_spi.h"
+#else
+#  include "nrf53_i2c.h"
+#endif
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: nrf53_bmi270spi_initialize
+ *       nrf53_bmi270i2c_initialize
+ *
+ * Description:
+ *   Initialzie and register the BMI270 character device as 'devpath'
+ *
+ * Input Parameters:
+ *   devno - The user specifies device number, from 0.
+ *   busno - SPI or I2C bus number
+ *   addr  - (I2C only) The I2C address
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_SENSORS_BMI270_SPI
+int nrf53_bmi270spi_initialize(int devno, int busno)
+{
+  struct spi_dev_s *spi;
+  int ret;
+
+  sninfo("Initializing BMI270..\n");
+
+  /* Initialize spi device */
+
+  spi = nrf53_spibus_initialize(busno);
+  if (!spi)
+    {
+      snerr("ERROR: Failed to initialize spi%d.\n", busno);
+      return -ENODEV;
+    }
+
+  ret = bmi270_register_uorb(devno, spi);
+  if (ret < 0)
+    {
+      snerr("Error registering BMI160\n");
+    }
+
+  return ret;
+}
+#else  /* CONFIG_SENSORS_BMI270_I2C */
+int nrf53_bmi270i2c_initialize(int devno, int busno, uint8_t addr)
+{
+  struct i2c_master_s *i2c;
+  int ret;
+
+  sninfo("Initializing BMI270!\n");
+
+  /* Initialize I2C */
+
+  i2c = nrf53_i2cbus_initialize(busno);
+  if (!i2c)
+    {
+      return -ENODEV;
+    }
+
+  /* Then register the barometer sensor */
+
+  ret = bmi270_register_uorb(devno, i2c, addr);
+  if (ret < 0)
+    {
+      snerr("ERROR: Error registering BM180\n");
+    }
+
+  return ret;
+}
+#endif

--- a/boards/arm/nrf53/thingy53/src/CMakeLists.txt
+++ b/boards/arm/nrf53/thingy53/src/CMakeLists.txt
@@ -18,7 +18,7 @@
 #
 # ##############################################################################
 
-set(SRCS nrf53_boot.c nrf53_bringup.c)
+set(SRCS nrf53_boot.c nrf53_bringup.c nrf53_sensors.c)
 
 if(CONFIG_BOARDCTL)
   list(APPEND SRCS nrf53_appinit.c)
@@ -30,6 +30,14 @@ endif()
 
 if(CONFIG_ARCH_BUTTONS)
   list(APPEND SRCS nrf53_buttons.c)
+endif()
+
+if(CONFIG_NRF53_SPI_MASTER)
+  list(APPEND SRCS nrf53_spi.c)
+endif()
+
+if(CONFIG_I2C)
+  list(APPEND SRCS nrf53_i2c.c)
 endif()
 
 if(CONFIG_USBDEV)

--- a/boards/arm/nrf53/thingy53/src/Make.defs
+++ b/boards/arm/nrf53/thingy53/src/Make.defs
@@ -20,7 +20,7 @@
 
 include $(TOPDIR)/Make.defs
 
-CSRCS = nrf53_boot.c nrf53_bringup.c
+CSRCS = nrf53_boot.c nrf53_bringup.c nrf53_sensors.c
 
 ifeq ($(CONFIG_BOARDCTL),y)
 CSRCS += nrf53_appinit.c
@@ -32,6 +32,14 @@ endif
 
 ifeq ($(CONFIG_ARCH_BUTTONS),y)
 CSRCS += nrf53_buttons.c
+endif
+
+ifeq ($(CONFIG_NRF53_SPI_MASTER),y)
+CSRCS += nrf53_spi.c
+endif
+
+ifeq ($(CONFIG_I2C),y)
+CSRCS += nrf53_i2c.c
 endif
 
 ifeq ($(CONFIG_USBDEV),y)

--- a/boards/arm/nrf53/thingy53/src/nrf53_bringup.c
+++ b/boards/arm/nrf53/thingy53/src/nrf53_bringup.c
@@ -67,8 +67,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define NRF53_TIMER (0)
-
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
@@ -259,6 +257,16 @@ int nrf53_bringup(void)
       syslog(LOG_ERR, "ERROR: nrf53_rgbled_init failed: %d\n", ret);
     }
 #endif
+
+  /* Initialize on-board sensors */
+
+  ret = nrf53_sensors_init();
+  if (ret < 0)
+    {
+      syslog(LOG_ERR,
+             "ERROR: Failed to initialize sensors: %d\n",
+             ret);
+    }
 
   UNUSED(ret);
   return OK;

--- a/boards/arm/nrf53/thingy53/src/nrf53_sensors.c
+++ b/boards/arm/nrf53/thingy53/src/nrf53_sensors.c
@@ -1,0 +1,137 @@
+/****************************************************************************
+ * boards/arm/nrf53/thingy53/src/nrf53_sensors.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <errno.h>
+#include <sys/types.h>
+#include <syslog.h>
+
+#ifdef CONFIG_SENSORS_BMI270
+#  include "nrf53_bmi270.h"
+#endif
+
+#ifdef CONFIG_SENSORS_ADXL362
+#  include "nrf53_adxl362.h"
+#endif
+
+#ifdef CONFIG_SENSORS_BH1749NUC
+#  include "nrf53_bh1749nuc.h"
+#endif
+
+#ifdef CONFIG_SENSORS_BMM150
+#  include "nrf53_bmm150.h"
+#endif
+
+#include "arm_internal.h"
+
+#include "thingy53.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define BMM150_I2C_BUS     (2)
+#define BMM150_I2C_ADDR    (0x10)
+
+#define BH1749NUC_I2C_BUS  (2)
+#define BH1749NUC_I2C_ADDR (0x38)
+
+#define BME688_I2C_BUS     (2)
+#define BME688_I2C_ADDR    (0x76)
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: nrf53_sensors_init
+ *
+ * Description:
+ *   Initialize on-board sensors
+ *
+ ****************************************************************************/
+
+int nrf53_sensors_init(void)
+{
+  int ret = OK;
+
+  UNUSED(ret);
+
+  /* Enable sensor power.
+   * TODO: this should be controlled by power management logic
+   */
+
+  nrf53_gpio_config(GPIO_SENS_PWRCTRL);
+  nrf53_gpio_write(GPIO_SENS_PWRCTRL, false);
+  up_mdelay(10);
+  nrf53_gpio_write(GPIO_SENS_PWRCTRL, true);
+  up_mdelay(10);
+
+#ifdef CONFIG_SENSORS_BMI270
+  /* Initialize BMI270 */
+
+  ret = nrf53_bmi270spi_initialize(0, BMI270_SPIDEV);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: nrf53_bmi270_initialize failed: %d\n", ret);
+    }
+#endif
+
+#ifdef CONFIG_SENSORS_BH1749NUC
+  /* Initialize BH1749NUC */
+
+  ret = nrf53_bh1749nuc_init(0, BH1749NUC_I2C_BUS, BH1749NUC_I2C_ADDR);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: nrf53_bh1749nuc_init failed: %d\n", ret);
+    }
+#endif
+
+#ifdef CONFIG_SENSORS_BMM150
+  /* Initialize BMM150 */
+
+  ret = nrf53_bmm150_init(0, BMM150_I2C_BUS, BMM150_I2C_ADDR);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: nrf53_bmm150_init failed: %d\n", ret);
+    }
+#endif
+
+#ifdef CONFIG_SENSORS_ADXL362
+  /* Initialize ADXL362 */
+
+  ret = nrf53_adxl362_init(1, ADXL362_SPIDEV);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: nrf53_adxl362_init failed: %d\n", ret);
+    }
+#endif
+
+  return ret;
+}

--- a/boards/arm/nrf53/thingy53/src/nrf53_spi.c
+++ b/boards/arm/nrf53/thingy53/src/nrf53_spi.c
@@ -1,0 +1,226 @@
+/****************************************************************************
+ * boards/arm/nrf53/thingy53/src/nrf53_spi.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <errno.h>
+#include <debug.h>
+
+#include <nuttx/spi/spi.h>
+
+#include "arm_internal.h"
+#include "chip.h"
+#include "nrf53_gpio.h"
+#include "nrf53_spi.h"
+
+#include "thingy53.h"
+#include <arch/board/board.h>
+
+#ifdef CONFIG_NRF53_SPI_MASTER
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: nrf53_spidev_initialize
+ *
+ * Description:
+ *   Called to configure SPI chip select GPIO pins for the Nucleo-144 board.
+ *
+ ****************************************************************************/
+
+void nrf53_spidev_initialize(void)
+{
+#ifdef CONFIG_NRF53_SPI1_MASTER
+  nrf53_gpio_config(GPIO_NRF21540_CSN);
+  nrf53_gpio_write(GPIO_NRF21540_CSN, true);
+
+  nrf53_gpio_config(GPIO_ADXL362_CS);
+  nrf53_gpio_write(GPIO_ADXL362_CS, true);
+
+  nrf53_gpio_config(GPIO_BMI270_CS);
+  nrf53_gpio_write(GPIO_BMI270_CS, true);
+#endif
+}
+
+/****************************************************************************
+ * Name: nrf53_spi0/1/2/3/select and nrf53_spi0/1/2/3/status
+ *
+ * Description:
+ *   The external functions, nrf53_spi0/1/2/3select and
+ *   nrf53_spi0/1/2/3status must be provided by board-specific logic.
+ *   They are implementations of the select and status methods of the SPI
+ *   interface defined by struct spi_ops_s (see include/nuttx/spi/spi.h).
+ *   All other methods (including nrf53_spibus_initialize()) are provided
+ *   by common NRF53 logic.  To use this common SPI logic on your board:
+ *
+ *   1. Provide logic in nrf53_boardinitialize() to configure SPI chip select
+ *      pins.
+ *   2. Provide nrf53_spi0/1/2/3select() and nrf53_spi0/1/2/3status()
+ *      functions in your board-specific logic. These functions will perform
+ *      chip selection and status operations using GPIOs in the way your
+ *      board is configured.
+ *   3. Add a calls to nrf53_spibus_initialize() in your low level
+ *      application initialization logic
+ *   4. The handle returned by nrf53_spibus_initialize() may then be used to
+ *      bind the SPI driver to higher level logic (e.g., calling
+ *      mmcsd_spislotinitialize(), for example, will bind the SPI driver to
+ *      the SPI MMC/SD driver).
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_NRF53_SPI0_MASTER
+void nrf53_spi0select(struct spi_dev_s *dev, uint32_t devid,
+                      bool selected)
+{
+  spiinfo("devid: %08lx CS: %s\n",
+          (unsigned long)devid, selected ? "assert" : "de-assert");
+}
+
+uint8_t nrf53_spi0status(struct spi_dev_s *dev, uint32_t devid)
+{
+  return 0;
+}
+#endif
+
+#ifdef CONFIG_NRF53_SPI1_MASTER
+void nrf53_spi1select(struct spi_dev_s *dev, uint32_t devid,
+                      bool selected)
+{
+  spiinfo("devid: %08lx CS: %s\n",
+          (unsigned long)devid, selected ? "assert" : "de-assert");
+
+  switch (devid)
+    {
+#ifdef CONFIG_SENSORS_BMI270
+      case SPIDEV_IMU(0):
+        {
+          spiinfo("BMI270 device %s\n",
+                  selected ? "asserted" : "de-asserted");
+
+          /* Set the GPIO low to select and high to de-select */
+
+          nrf53_gpio_write(GPIO_BMI270_CS, !selected);
+          break;
+        }
+#endif
+
+#ifdef CONFIG_SENSORS_ADXL362
+      case SPIDEV_ACCELEROMETER(1):
+      {
+        spiinfo("ADXL362 device %s\n",
+                selected ? "asserted" : "de-asserted");
+
+        /* Set the GPIO low to select and high to de-select */
+
+        nrf53_gpio_write(GPIO_ADXL362_CS, !selected);
+        break;
+      }
+#endif
+
+      default:
+        {
+          break;
+        }
+    }
+}
+
+uint8_t nrf53_spi1status(struct spi_dev_s *dev, uint32_t devid)
+{
+  uint8_t status = 0;
+
+  switch (devid)
+    {
+#ifdef CONFIG_SENSORS_BMI270
+      case SPIDEV_IMU(0):
+        {
+          status |= SPI_STATUS_PRESENT;
+          break;
+        }
+#endif
+
+#ifdef CONFIG_SENSORS_ADXL362
+      case SPIDEV_ACCELEROMETER(0):
+        {
+          status |= SPI_STATUS_PRESENT;
+          break;
+        }
+#endif
+
+      default:
+        {
+          break;
+        }
+    }
+
+  return status;
+}
+#endif
+
+#ifdef CONFIG_nrf53_SPI2_MASTER
+void nrf53_spi2select(struct spi_dev_s *dev, uint32_t devid,
+                      bool selected)
+{
+  spiinfo("devid: %08lx CS: %s\n",
+          (unsigned long)devid, selected ? "assert" : "de-assert");
+}
+
+uint8_t nrf53_spi2status(struct spi_dev_s *dev, uint32_t devid)
+{
+  return 0;
+}
+#endif
+
+#ifdef CONFIG_NRF53_SPI3_MASTER
+void nrf53_spi3select(struct spi_dev_s *dev, uint32_t devid,
+                      bool selected)
+{
+  spiinfo("devid: %08lx CS: %s\n",
+          (unsigned long)devid, selected ? "assert" : "de-assert");
+}
+
+uint8_t nrf53_spi3status(struct spi_dev_s *dev, uint32_t devid)
+{
+  return 0;
+}
+#endif
+
+#ifdef CONFIG_NRF53_SPI4_MASTER
+void nrf53_spi4select(struct spi_dev_s *dev, uint32_t devid,
+                      bool selected)
+{
+  spiinfo("devid: %08lx CS: %s\n",
+          (unsigned long)devid, selected ? "assert" : "de-assert");
+}
+
+uint8_t nrf53_spi4status(struct spi_dev_s *dev, uint32_t devid)
+{
+  return 0;
+}
+#endif
+
+#endif /* CONFIG_NRF53_SPI_MASTER */

--- a/boards/arm/nrf53/thingy53/src/thingy53.h
+++ b/boards/arm/nrf53/thingy53/src/thingy53.h
@@ -86,6 +86,7 @@
 
 #define GPIO_ADXL362_INT1 (GPIO_INPUT  | GPIO_PORT0 | GPIO_PIN(19))
 #define GPIO_ADXL362_CS   (GPIO_OUTPUT | GPIO_PORT0 | GPIO_PIN(22))
+#define ADXL362_SPIDEV    (1)
 
 /* BMI270 (I2C address: 0x68)
  *   INT1 - P0.23
@@ -94,6 +95,7 @@
 
 #define GPIO_BMI270_INT1 (GPIO_INPUT  | GPIO_PORT0 | GPIO_PIN(23))
 #define GPIO_BMI270_CS   (GPIO_OUTPUT | GPIO_PORT1 | GPIO_PIN(4))
+#define BMI270_SPIDEV    (1)
 
 /* BMM150 (I2C address: 0x10)
  *   INT  - P0.20
@@ -160,6 +162,16 @@
 int nrf53_bringup(void);
 
 /****************************************************************************
+ * Name: nrf53_sensors_init
+ *
+ * Description:
+ *   Initialize on-board sensors
+ *
+ ****************************************************************************/
+
+int nrf53_sensors_init(void);
+
+/****************************************************************************
  * Name: nrf53_rgbled_initialize
  *
  * Description:
@@ -191,6 +203,19 @@ int nrf53_i2c_register(int bus);
 
 #ifdef CONFIG_SYSTEM_I2CTOOL
 int nrf53_i2ctool(void);
+#endif
+
+/****************************************************************************
+ * Name: nrf53_spidev_initialize
+ *
+ * Description:
+ *   Called to configure SPI chip select GPIO pins for the
+ *   thingy53 board.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_NRF53_SPI_MASTER
+void nrf53_spidev_initialize(void);
 #endif
 
 #endif /* __ASSEMBLY__ */


### PR DESCRIPTION
## Summary
boards/thingy53: add sensors support
Add support for sensros: ADXL362, BH1749NUC, BMI270, BMM150

## Impact

## Testing

