### PR TITLE
nuttx/net: fixed bind can not return error when used same addr.

### DIFF
--- a/net/local/local_bind.c
+++ b/net/local/local_bind.c
@@ -61,7 +61,6 @@ int psock_local_bind(FAR struct socket *psock,
 
   /* Save the address family */
 
-  conn->lc_proto = psock->s_type;
   conn->lc_instance_id = -1;
 
   /* Now determine the type of the Unix domain socket by comparing the size

--- a/net/local/local_sockif.c
+++ b/net/local/local_sockif.c
@@ -138,6 +138,7 @@ static int local_sockif_alloc(FAR struct socket *psock)
 
   /* Save the pre-allocated connection in the socket structure */
 
+  conn->lc_proto = psock->s_type;
   psock->s_conn = conn;
   return OK;
 }


### PR DESCRIPTION
fixed bind can not return error when used same addr.

