### PR TITLE
Support the GSO/GRO function on the SIM.

### DIFF
--- a/arch/sim/src/sim/sim_netdriver.c
+++ b/arch/sim/src/sim/sim_netdriver.c
@@ -68,6 +68,11 @@
 #include <nuttx/net/net.h>
 #include <nuttx/net/netdev_lowerhalf.h>
 #include <nuttx/net/pkt.h>
+#include <nuttx/mm/iob.h>
+
+#ifdef CONFIG_NET_SEG_OFFLOAD
+#include <nuttx/net/offload.h>
+#endif
 
 #include "sim_internal.h"
 
@@ -132,7 +137,40 @@ static const struct netdev_ops_s g_ops =
 static int netdriver_send(struct netdev_lowerhalf_s *dev, netpkt_t *pkt)
 {
   unsigned int len  = netpkt_getdatalen(dev, pkt);
+#ifdef CONFIG_NET_SEG_OFFLOAD
+  netpkt_t *segs;
+  uint32_t features = dev->netdev.d_features;
+#endif
 
+#ifdef CONFIG_NET_GSO
+  if (devif_needs_gso((struct iob_s *)pkt, features))
+    {
+      /* 1. devif_gso_segment */
+
+      segs = devif_gso_segment((struct iob_s *)pkt, features);
+      if (segs == NULL)
+        {
+          devif_gso_list_free(pkt);
+          netpkt_free(dev, pkt, NETPKT_TX);
+          return -EMSGSIZE;
+        }
+
+      /* 2. loop send */
+
+      pkt = segs;
+      while (segs)
+        {
+          sim_netdev_send(DEVIDX(dev), netpkt_getdata(dev, segs),
+                          netpkt_getdatalen(dev, segs));
+          segs = PKT_GSOINFO(segs)->seg_list;
+        }
+
+      /* 3. free all segs */
+
+      devif_gso_list_free(pkt);
+    }
+  else
+#endif
   if (netpkt_is_fragmented(pkt))
     {
       netpkt_copyout(dev, DEVBUF(dev), pkt, len, 0);
@@ -262,6 +300,11 @@ int sim_netdriver_init(void)
         }
 #endif
 
+#ifdef CONFIG_NET_SEG_OFFLOAD
+#ifdef CONFIG_NET_GSO
+      netdev_enable_gso(&dev->netdev);
+#endif
+#endif
       /* Register the device with the OS so that socket IOCTLs can be
        * performed
        */

--- a/arch/sim/src/sim/sim_netdriver.c
+++ b/arch/sim/src/sim/sim_netdriver.c
@@ -304,6 +304,9 @@ int sim_netdriver_init(void)
 #ifdef CONFIG_NET_GSO
       netdev_enable_gso(&dev->netdev);
 #endif
+#ifdef CONFIG_NET_GRO
+      netdev_enable_lro(&dev->netdev);
+#endif
 #endif
       /* Register the device with the OS so that socket IOCTLs can be
        * performed

--- a/drivers/net/netdev_upperhalf.c
+++ b/drivers/net/netdev_upperhalf.c
@@ -305,7 +305,13 @@ static int netdev_upper_txpoll(FAR struct net_driver_s *dev)
 
   pkt = netpkt_get(dev, NETPKT_TX);
 
-  if (netpkt_getdatalen(lower, pkt) > NETDEV_PKTSIZE(dev))
+  if (netpkt_getdatalen(lower, pkt) >
+#ifdef CONFIG_NET_GSO
+      devif_get_max_pktsize(dev)
+#else
+      NETDEV_PKTSIZE(dev)
+#endif
+      )
     {
       nerr("ERROR: Packet too long to send!\n");
       ret = -EMSGSIZE;

--- a/drivers/net/netdev_upperhalf.c
+++ b/drivers/net/netdev_upperhalf.c
@@ -150,6 +150,47 @@ static bool quota_is_valid(FAR struct netdev_lowerhalf_s *lower)
 }
 
 /****************************************************************************
+ * Name: netpkt_alloc_internal
+ *
+ * Description:
+ *   Allocate a netpkt structure.
+ *
+ ****************************************************************************/
+
+static FAR netpkt_t *
+netpkt_alloc_internal(FAR struct netdev_lowerhalf_s *dev,
+                      enum netpkt_type_e type, uint16_t size)
+{
+  FAR netpkt_t *pkt;
+
+  if (quota_fetch_dec(dev, type) <= 0)
+    {
+      quota_fetch_inc(dev, type);
+      return NULL;
+    }
+
+#ifdef CONFIG_IOB_ALLOC
+  if (size > 0)
+    {
+      pkt = iob_alloc_dynamic(size);
+    }
+  else
+#endif
+    {
+      pkt = iob_tryalloc(false);
+    }
+
+  if (pkt == NULL)
+    {
+      quota_fetch_inc(dev, type);
+      return NULL;
+    }
+
+  iob_reserve(pkt, CONFIG_NET_LL_GUARDSIZE);
+  return pkt;
+}
+
+/****************************************************************************
  * Name: netpkt_get
  *
  * Description:
@@ -1271,23 +1312,14 @@ int netdev_lower_quota_load(FAR struct netdev_lowerhalf_s *dev,
 FAR netpkt_t *netpkt_alloc(FAR struct netdev_lowerhalf_s *dev,
                            enum netpkt_type_e type)
 {
-  FAR netpkt_t *pkt;
-
-  if (quota_fetch_dec(dev, type) <= 0)
-    {
-      quota_fetch_inc(dev, type);
-      return NULL;
-    }
-
-  pkt = iob_tryalloc(false);
-  if (pkt == NULL)
-    {
-      quota_fetch_inc(dev, type);
-      return NULL;
-    }
-
-  iob_reserve(pkt, CONFIG_NET_LL_GUARDSIZE);
-  return pkt;
+  return netpkt_alloc_internal(dev, type,
+#ifdef CONFIG_NET_GRO
+                               NETDEV_PKTSIZE(&dev->netdev) +
+                               CONFIG_NET_LL_GUARDSIZE
+#else
+                               0
+#endif
+                              );
 }
 
 /****************************************************************************

--- a/include/netinet/udp.h
+++ b/include/netinet/udp.h
@@ -31,6 +31,15 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+#ifdef CONFIG_NET_SEG_OFFLOAD
+#define UDP_SEGMENT    103      /* Set GSO segmentation size */
+#define UDP_GRO        104      /* This socket can receive UDP GRO packets */
+#endif
+
+/****************************************************************************
+ * Public Type Definitions
+ ****************************************************************************/
+
 /* UDP header as specified by RFC 768, August 1980. */
 
 struct udphdr

--- a/include/nuttx/mm/iob.h
+++ b/include/nuttx/mm/iob.h
@@ -34,6 +34,9 @@
 #  include <nuttx/wqueue.h>
 #endif
 
+#ifdef CONFIG_NET_SEG_OFFLOAD
+#  include <nuttx/net/offload.h>
+#endif
 #ifdef CONFIG_MM_IOB
 
 /****************************************************************************
@@ -124,6 +127,10 @@ struct iob_s
 #  endif
 #endif
   unsigned int io_pktlen; /* Total length of the packet */
+#ifdef CONFIG_NET_SEG_OFFLOAD
+  struct gso_cb gso_info;
+  struct gro_cb gro_info;
+#endif
 
 #ifdef CONFIG_IOB_ALLOC
   iob_free_cb_t io_free;  /* Custom free callback */

--- a/include/nuttx/net/offload.h
+++ b/include/nuttx/net/offload.h
@@ -405,6 +405,71 @@ FAR struct iob_s *udp6_gso_segment(FAR struct iob_s *pkt, uint32_t features);
 #endif
 
 #endif /* CONFIG_NET_GSO */
+
+/****************************************************************************
+ * Name: devif_init_pkt_groinfo
+ *
+ * Description:
+ *  Initialize the GRO information for the GRO packet.
+ *
+ * Input Parameters:
+ *   dev  -  The structure of the network driver that received the packet.
+ *   pkt  - The received packet is GRO packet.
+ *   gro_type  - That indicates the GRO type of the received packet.
+ *   gro_size  - That indicates the GRO Size of the received packet.
+ *   count  - That indicates the number of segments.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_GRO
+void devif_init_pkt_groinfo(FAR struct net_driver_s *dev,
+                            FAR struct iob_s *pkt, int gro_type,
+                            uint16_t gro_size, uint8_t count);
+
+/****************************************************************************
+ * Name: devif_forward_gro_pkt
+ *
+ * Description:
+ *   Initialize the GRO information for the GRO packet.
+ *
+ * Input Parameters:
+ *   dev - An initialized instance of the common forwarding structure that
+ *         includes everything needed to perform the forwarding operation.
+ *   pkt - The packets to be forwarded.
+ *
+ * Returned Value:
+ *   None
+ *
+ * Assumptions:
+ *   The gro packets are list by iob->io_flink.
+ *
+ ****************************************************************************/
+
+void devif_forward_gro_pkt(FAR struct net_driver_s *dev,
+                           FAR struct iob_s *pkt);
+
+/****************************************************************************
+ * Name: netdev_enable_lro
+ *
+ * Description:
+ *   Enable the GRO_HW function for the dev.
+ *   Set the features and GRO-related maximum value.
+ *
+ * Input Parameters:
+ *   dev -  The structure of the network driver that enables the LRO
+ *          function.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void netdev_enable_lro(FAR struct net_driver_s *dev);
+#endif
+
 #endif /* CONFIG_NET_SEG_OFFLOAD */
 
 #endif /* __INCLUDE_NUTTX_NET_SEG_OFFLOAD_H */

--- a/include/nuttx/net/offload.h
+++ b/include/nuttx/net/offload.h
@@ -1,0 +1,351 @@
+/****************************************************************************
+ * include/nuttx/net/offload.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_NUTTX_NET_SEG_OFFLOAD_H
+#define __INCLUDE_NUTTX_NET_SEG_OFFLOAD_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <nuttx/mm/iob.h>
+
+#ifdef CONFIG_NET_SEG_OFFLOAD
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define TCP_CWR 0x80
+#define TCP_ECE 0x40
+
+#define MAX_GSO_SEGS 17
+
+#define IOBDATA_OFFSET(iob, offset) ((FAR void *)(IOB_DATA(iob) + (offset)))
+#define ETHHDR(iob)  ((FAR struct eth_hdr_s *) \
+                   ((FAR uint8_t *)IOBDATA_OFFSET(iob, 0) - ETH_HDRLEN))
+
+#define IPV4HDR(iob) ((FAR struct ipv4_hdr_s *)IOBDATA_OFFSET(iob, 0))
+#define IPV6HDR(iob) ((FAR struct ipv6_hdr_s *)IOBDATA_OFFSET(iob, 0))
+
+/* ip_hdrlen: IPv4_HDRLEN, IPv6_HDRLEN */
+
+#define UDPHDR(iob, ip_hdrlen) ((FAR struct udp_hdr_s *) \
+                                 IOBDATA_OFFSET(iob, ip_hdrlen))
+#define TCPHDR(iob, ip_hdrlen) ((FAR struct tcp_hdr_s *) \
+                                 IOBDATA_OFFSET(iob, ip_hdrlen))
+
+#define GET_IPHDRLEN(pkt) \
+  (PKT_GSOINFO(pkt)->type == ETHTYPE_IP ? IPv4_HDRLEN : IPv6_HDRLEN)
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+struct gso_cb
+{
+  union
+  {
+    int             mac_offset;
+    int             data_offset;
+  };
+  uint16_t          type;        /* for L3 IPv4/IPv6 */
+  uint16_t          protocol;    /* for L4 TCP/UDP */
+  uint32_t          csum;
+  uint16_t          csum_start;
+
+  uint8_t           is_first:1;
+  uint8_t           is_ipv6:1;
+  uint8_t           is_fwd:1;
+  uint8_t           tx_flags;
+  uint16_t          gso_size;
+  uint16_t          gso_segs;
+  uint32_t          gso_type;
+  FAR struct iob_s *seg_list;
+  uint8_t           segs_num;
+};
+
+#define PKT_GSOINFO(pkt) (&(pkt->gso_info))
+
+enum GSO_TYPE_E
+{
+    PKT_GSO_TCPV4 = 1 << 0,
+    PKT_GSO_TCPV6 = 1 << 1,
+    PKT_GSO_UDPV4 = 1 << 2,
+    PKT_GSO_UDPV6 = 1 << 3,
+};
+
+struct gro_cb
+{
+  union
+  {
+    int             mac_offset;
+    int             data_offset;
+  };
+
+  uint8_t           is_first:1;
+  uint8_t           is_ipv6:1;
+  uint8_t           rx_flags;
+  uint16_t          gro_size;
+  uint8_t           segs_count;
+  uint16_t          proto;        /* tcp udp */
+  FAR struct iob_s *seg_list;     /* maybe use io_flink */
+};
+
+#define PKT_GROINFO(pkt) (&(pkt->gro_info))
+
+/****************************************************************************
+ * External structure Declaration
+ ****************************************************************************/
+
+struct net_driver_s; /* Forward reference */
+
+/****************************************************************************
+ * Name: devif_get_max_pktsize
+ *
+ * Description:
+ *   Get the maximum packet size value.
+ *
+ * Input Parameters:
+ *    dev -  The structure of the network driver.
+ *
+ * Returned Value:
+ *   The maximum packet size.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_GSO
+uint16_t devif_get_max_pktsize(FAR struct net_driver_s *dev);
+
+/****************************************************************************
+ * Name: netdev_enable_gso
+ *
+ * Description:
+ *   Enable the GSO function for the dev.
+ *   Set the features and GSO-related maximum value.
+ *
+ * Input Parameters:
+ *    dev -  The structure of the network driver that enables the GSO
+ *           function.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void netdev_enable_gso(FAR struct net_driver_s *dev);
+
+/****************************************************************************
+ * Name: devif_needs_gso
+ *
+ * Description:
+ *   Check whether the packet needs to be segmented.
+ *
+ * Input Parameters:
+ *    pkt  - the packet to be sent by the NIC driver.
+ *    features  - the features are supported by the target dev of the packet.
+ *
+ * Returned Value:
+ *    The false indicates that the packet does not to be divided.
+ *    The true indicates that the packet needs to be divided.
+ *
+ ****************************************************************************/
+
+bool devif_needs_gso(FAR struct iob_s *pkt, int features);
+
+/****************************************************************************
+ * Name: devif_gso_segment
+ *
+ * Description:
+ *   Divide the packet into multiple packets based on the features and
+ *   the GSO information of the packet.
+ *
+ * Input Parameters:
+ *   pkt  - the packet to be sent by the NIC driver.
+ *   features  - the features are supported by the target dev of the packet.
+ *
+ * Returned Value:
+ *   The NULL indicates that the devision is failure.
+ *   The segs is the head of the multiple packets.
+ *
+ ****************************************************************************/
+
+FAR struct iob_s *devif_gso_segment(FAR struct iob_s *pkt,
+                                    uint32_t features);
+
+/****************************************************************************
+ * Name: devif_gso_list_free
+ *
+ * Description:
+ *   Free the packet allocated by devif_pkt_segment and
+ *   clear the GSO information of the fisrt packet.
+ *
+ * Input Parameters:
+ *    pkt  - The GSO packets includes the segments list.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void devif_gso_list_free(FAR struct iob_s *pkt);
+
+/****************************************************************************
+ * Name: devif_pkt_segment
+ *
+ * Description:
+ *   Segment the packet to be divided, and add the header information for all
+ *   the segments.
+ *
+ * Input Parameters:
+ *   pkt  - the packet needs to be divided.
+ *   features  - the features are supported by the target dev of the packet.
+ *
+ * Returned Value:
+ *   The NULL indicates that the devision is failure.
+ *   The segs is the head of the multiple packets.
+ *
+ ****************************************************************************/
+
+FAR struct iob_s *devif_pkt_segment(FAR struct iob_s *pkt,
+                                    uint32_t features);
+
+/****************************************************************************
+ * Name: inet_update_iphdr_len
+ *
+ * Description:
+ *    Update the (ipv4/ipv6) ipheader length based on the pkt->io_pktlen.
+ *
+ * Input Parameters:
+ *
+ *   pkt  - The data iob structure.
+ *   type  - The type of the packet.
+ *
+ ****************************************************************************/
+
+void inet_update_iphdr_len(FAR struct iob_s *pkt, int type);
+
+/****************************************************************************
+ * Name: devif_send_gso_pkt
+ *
+ * Description:
+ *   Allocate the iob for the GSO packet, based on the size and count.
+ *
+ * Input Parameters:
+ *   pkt - The packet is to be sent.
+ *   sndlen - The length of the packet.
+ *   offset - The offset of data in the iob (packet).
+ *   hdrlen - The total header length of L3 and L4 in the packet.
+ *   gso_size - The size of each pachage when pre-segment.
+ *
+ * Returned Value:
+ *   The NULL indicates that the allocation is failure.
+ *   The segs is the head of the multiple iob.
+ *
+ ****************************************************************************/
+
+FAR struct iob_s *devif_send_gso_pkt(FAR struct iob_s *pkt,
+                       unsigned int sndlen, unsigned int offset,
+                       unsigned int hdrlen, uint16_t gso_size);
+/****************************************************************************
+ * Name: inet_gso_segment
+ *
+ * Description:
+ *   Check whether the packet needs to be divided. After the segmentation,
+ *   and update the ipv4 header for all packets.
+ *
+ * Input Parameters:
+ *   pkt  - the packet to be sent by the NIC driver.
+ *   features  - the features are supported by the target dev of the packet.
+ *
+ * Returned Value:
+ *   The NULL indicates that the devision is failure.
+ *   The segs is the head of the multiple packets.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_IPv4
+FAR struct iob_s *inet_gso_segment(FAR struct iob_s *pkt, uint32_t features);
+
+/****************************************************************************
+ * Name: tcp4_gso_segment
+ *
+ * Description:
+ *   Check whether the IPv4 TCP packet can be segmented.
+ *
+ * Input Parameters:
+ *   pkt  - the packet to be sent by the NIC driver.
+ *   features  - the features are supported by the target dev of the packet.
+ *
+ * Returned Value:
+ *   The NULL indicates that the devision is failure.
+ *   The segs is the head of the multiple packets.
+ *
+ ****************************************************************************/
+
+FAR struct iob_s *tcp4_gso_segment(FAR struct iob_s *pkt, uint32_t features);
+#endif
+
+/****************************************************************************
+ * Name: ipv6_gso_segment
+ *
+ * Description:
+ *   Check whether the packet needs to be divided. After the segmentation,
+ *   and update the ipv6 header for all packets.
+ *
+ * Input Parameters:
+ *   pkt  - the packet to be sent by the NIC driver.
+ *   features  - the features are supported by the target dev of the packet.
+ *
+ * Returned Value:
+ *   The NULL indicates that the devision is failure.
+ *   The segs is the head of the multiple packets.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_IPv6
+FAR struct iob_s *ipv6_gso_segment(FAR struct iob_s *pkt, uint32_t features);
+
+/****************************************************************************
+ * Name: tcp6_gso_segment
+ *
+ * Description:
+ *   Check whether the IPv6 TCP packet can be segmented.
+ *
+ * Input Parameters:
+ *   pkt  - the packet to be sent by the NIC driver.
+ *   features  - the features are supported by the target dev of the packet.
+ *
+ * Returned Value:
+ *   The NULL indicates that the devision is failure.
+ *   The segs is the head of the multiple packets.
+ *
+ ****************************************************************************/
+
+struct iob_s *tcp6_gso_segment(FAR struct iob_s *pkt, uint32_t features);
+#endif
+
+#endif
+#endif
+
+#endif /* __INCLUDE_NUTTX_NET_SEG_OFFLOAD_H*/

--- a/include/nuttx/net/offload.h
+++ b/include/nuttx/net/offload.h
@@ -267,6 +267,25 @@ void inet_update_iphdr_len(FAR struct iob_s *pkt, int type);
 FAR struct iob_s *devif_send_gso_pkt(FAR struct iob_s *pkt,
                        unsigned int sndlen, unsigned int offset,
                        unsigned int hdrlen, uint16_t gso_size);
+
+/****************************************************************************
+ * Name: devif_prepare_gso_segments
+ *
+ * Description:
+ *   Allocate the iob for the GSO packet, based on the size and count.
+ *
+ * Input Parameters:
+ *   size  - the sum of L3 header length, L4 header length, and gso_size.
+ *   count  - the features are supported by the target dev of the packet.
+ *
+ * Returned Value:
+ *   The NULL indicates that the allocation is failure.
+ *   The segs is the head of the multiple iob.
+ *
+ ****************************************************************************/
+
+FAR struct iob_s *devif_prepare_gso_segments(uint16_t size, uint32_t count);
+
 /****************************************************************************
  * Name: inet_gso_segment
  *
@@ -345,7 +364,47 @@ FAR struct iob_s *ipv6_gso_segment(FAR struct iob_s *pkt, uint32_t features);
 struct iob_s *tcp6_gso_segment(FAR struct iob_s *pkt, uint32_t features);
 #endif
 
-#endif
+/****************************************************************************
+ * Name: udp4_gso_segment
+ *
+ * Description:
+ *   Check whether the IPv4 UDP packet can be segmented.
+ *
+ * Input Parameters:
+ *   pkt  - the packet to be sent by the NIC driver.
+ *   features  - the features are supported by the target dev of the packet.
+ *
+ * Returned Value:
+ *   The NULL indicates that the devision is failure.
+ *   The segs is the head of the multiple packets.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_IPv4
+FAR struct iob_s *udp4_gso_segment(FAR struct iob_s *pkt, uint32_t features);
 #endif
 
-#endif /* __INCLUDE_NUTTX_NET_SEG_OFFLOAD_H*/
+/****************************************************************************
+ * Name: udp6_gso_segment
+ *
+ * Description:
+ *   Check whether the IPv6 UDP packet can be segmented.
+ *
+ * Input Parameters:
+ *   pkt  - the packet to be sent by the NIC driver.
+ *   features  - the features are supported by the target dev of the packet.
+ *
+ * Returned Value:
+ *   The NULL indicates that the devision is failure.
+ *   The segs is the head of the multiple packets.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_IPv6
+FAR struct iob_s *udp6_gso_segment(FAR struct iob_s *pkt, uint32_t features);
+#endif
+
+#endif /* CONFIG_NET_GSO */
+#endif /* CONFIG_NET_SEG_OFFLOAD */
+
+#endif /* __INCLUDE_NUTTX_NET_SEG_OFFLOAD_H */

--- a/net/Kconfig
+++ b/net/Kconfig
@@ -434,6 +434,24 @@ config NET_STARHUB
 endchoice # Node role
 endmenu # Network Topologies
 
+menu "Net Segment Offload"
+
+config NET_SEG_OFFLOAD
+	bool "Enable net segment offload"
+    depends on IOB_ALLOC
+	default n
+	---help---
+		Enable the net segment offload, including the GSO and LRO function.
+
+config NET_GSO
+	bool "Enable GSO function"
+	default n
+	select  NET_TCP_OFFLOAD
+	---help---
+		The function includes the UDP GSO and TCP GSO. And the TCP GSO is to
+		to be enabled by default.
+
+endmenu # Net Segment Offload
 source "net/route/Kconfig"
 
 endif # NET

--- a/net/Kconfig
+++ b/net/Kconfig
@@ -451,6 +451,13 @@ config NET_GSO
 		The function includes the UDP GSO and TCP GSO. And the TCP GSO is to
 		to be enabled by default.
 
+config NET_GRO
+	bool "Enable GRO function"
+	default n
+	---help---
+		The function just refers to the LRO feature, supporting the UDP
+		and TCP.
+
 endmenu # Net Segment Offload
 source "net/route/Kconfig"
 

--- a/net/devif/Make.defs
+++ b/net/devif/Make.defs
@@ -50,6 +50,12 @@ ifeq ($(CONFIG_MM_IOB),y)
   NET_CSRCS += devif_iobsend.c
   NET_CSRCS += devif_filesend.c
 
+  # Net offload
+
+  ifeq ($(CONFIG_NET_SEG_OFFLOAD),y)
+    NET_CSRCS += devif_offload.c
+  endif
+
 endif
 
 # Include network device interface build support

--- a/net/devif/devif_forward.c
+++ b/net/devif/devif_forward.c
@@ -68,6 +68,10 @@ void devif_forward(FAR struct forward_s *fwd)
 
   fwd->f_dev->d_sndlen = 0;
   fwd->f_iob = NULL;
+
+#ifdef CONFIG_NET_GRO
+  devif_forward_gro_pkt(fwd->f_dev, fwd->f_dev->d_iob);
+#endif
 }
 
 #endif /* CONFIG_NET_IPFORWARD */

--- a/net/devif/devif_offload.c
+++ b/net/devif/devif_offload.c
@@ -1,0 +1,505 @@
+/****************************************************************************
+ * net/devif/devif_offload.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <assert.h>
+#include <debug.h>
+
+#include <nuttx/net/netdev.h>
+#include <nuttx/net/ethernet.h>
+#include <nuttx/mm/iob.h>
+#include <nuttx/net/ip.h>
+#include <nuttx/net/tcp.h>
+#include <nuttx/net/udp.h>
+#include <nuttx/net/offload.h>
+
+#include "devif/devif.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define DIV_ROUND_UP(n, d) (((n) + (d) - 1) / (d))
+
+/****************************************************************************
+ * External Function Prototypes
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_IPv4
+FAR struct iob_s *inet_gso_segment(FAR struct iob_s *pkt, uint32_t features);
+#endif
+#ifdef CONFIG_NET_IPv6
+FAR struct iob_s *ipv6_gso_segment(FAR struct iob_s *pkt, uint32_t features);
+#endif
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: devif_pkt_segment
+ *
+ * Description:
+ *   Segment the packet to be divided, and add the header information for all
+ *   the segments.
+ *
+ * Input Parameters:
+ *   pkt  - the packet needs to be divided.
+ *   features  - the features are supported by the target dev of the packet.
+ *
+ * Returned Value:
+ *   The NULL indicates that the devision is failure.
+ *   The segs is the head of the multiple packets.
+ *
+ ****************************************************************************/
+
+FAR struct iob_s *devif_pkt_segment(FAR struct iob_s *pkt, uint32_t features)
+{
+  FAR struct iob_s *segs;
+  FAR struct iob_s *tmp = NULL;
+  FAR struct iob_s *new_pkt = NULL;
+  int data_len;
+  bool need_alloc = true;
+  uint32_t mss;
+  uint16_t payload_len;
+  uint16_t size;
+  int segs_num = 0;
+  uint32_t header_len = PKT_GSOINFO(pkt)->data_offset;
+
+  /* check */
+
+  data_len = pkt->io_pktlen - header_len;
+
+  if (PKT_GSOINFO(pkt)->is_fwd == true)
+    {
+      /* The MTU is saved during forwarding, and the gso_size can be
+       * calculated based on the MTU value.
+       */
+
+      PKT_GSOINFO(pkt)->gso_size -= header_len;
+
+      if (PKT_GSOINFO(pkt)->gso_size == PKT_GROINFO(pkt)->gro_size)
+        {
+          need_alloc = false;
+        }
+    }
+
+  if (pkt->io_len == PKT_GSOINFO(pkt)->gso_size + header_len)
+    {
+      need_alloc = false;
+    }
+
+  mss = PKT_GSOINFO(pkt)->gso_size;
+  size = mss + header_len + CONFIG_NET_LL_GUARDSIZE;
+
+  if (data_len < mss)
+    {
+      return pkt;
+    }
+
+  if (CONFIG_IOB_BUFSIZE < mss)
+    {
+      nerr("CONFIG_IOB_BUFFERSIZE is smaller than mss.");
+      return NULL;
+    }
+
+  if (MAX_GSO_SEGS < PKT_GSOINFO(pkt)->gso_segs)
+    {
+      nerr("MAX_GSO_SEGS is smaller than gso_segs.");
+      return NULL;
+    }
+
+  /* Recalculate the gso segments. */
+
+  PKT_GSOINFO(pkt)->gso_segs = DIV_ROUND_UP(data_len, mss);
+
+  /* loop segment packet data and copy the header */
+
+  for (segs = NULL; segs_num < PKT_GSOINFO(pkt)->gso_segs;
+       data_len -= mss, segs_num++)
+    {
+      /* 1. create segment */
+
+      /* 1.1 malloc data as iob, alloc_iob */
+
+      new_pkt = iob_alloc_dynamic(size);
+      if (new_pkt == NULL)
+        {
+          nerr("ERROR: Failed to allocate an I/O buffer.");
+          if (segs)
+            {
+              iob_free_chain(segs);
+            }
+
+          return NULL;
+        }
+
+      new_pkt->io_flink = NULL;
+
+      /* need to init the iob and gso_info */
+
+      if (new_pkt)
+        {
+          /* 1.2copy header */
+
+          memcpy(new_pkt->io_data, pkt->io_data,
+                 header_len + pkt->io_offset);
+        }
+      else
+        {
+          new_pkt = segs;
+        }
+
+      /* 1.3 copy data */
+
+      payload_len = data_len > mss ? mss : data_len;
+
+      /* pointer to data */
+
+      new_pkt->io_offset = header_len + pkt->io_offset;
+
+      iob_copyout(new_pkt->io_data + new_pkt->io_offset, pkt,
+                  payload_len, segs_num * mss);
+
+      /* 2. update left data_len */
+
+      new_pkt->io_offset = pkt->io_offset;
+      new_pkt->io_pktlen = header_len + payload_len;
+      new_pkt->io_len = new_pkt->io_pktlen;
+
+      PKT_GSOINFO(new_pkt)->seg_list = NULL;
+      new_pkt->io_flink = NULL;
+
+      /* The first segment. */
+
+      if (segs == NULL)
+        {
+          segs = new_pkt;
+          tmp  = new_pkt;
+          memcpy(PKT_GSOINFO(tmp), PKT_GSOINFO(pkt),
+              sizeof(struct gso_cb));
+        }
+
+      PKT_GSOINFO(tmp)->seg_list = new_pkt;
+      tmp = new_pkt;
+    }
+
+  /* Assumption that a packet uses a single iob structure. */
+
+  if (need_alloc == false)
+    {
+      tmp = segs;
+      while (tmp)
+        {
+          new_pkt = tmp->io_flink;
+          tmp->io_flink = NULL;
+          tmp = new_pkt;
+        }
+    }
+  else
+    {
+      /* free the pkt */
+
+      iob_free_chain(pkt);
+    }
+
+  return segs;
+}
+
+/****************************************************************************
+ * Name: devif_prepare_gso_segments
+ *
+ * Description:
+ *   Allocate the iob for the GSO packet, based on the size and count.
+ *
+ * Input Parameters:
+ *   size  - the sum of L3 header length, L4 header length, and gso_size.
+ *   count  - the features are supported by the target dev of the packet.
+ *
+ * Returned Value:
+ *   The NULL indicates that the allocation is failure.
+ *   The segs is the head of the multiple iob.
+ *
+ ****************************************************************************/
+
+FAR struct iob_s *devif_prepare_gso_segments(uint16_t size, uint32_t count)
+{
+  FAR struct iob_s *segs = NULL;
+  FAR struct iob_s *pkt = NULL;
+  FAR struct iob_s *tmp = NULL;
+
+  while (count--)
+    {
+      pkt = iob_alloc_dynamic(size + CONFIG_NET_LL_GUARDSIZE);
+      if (pkt == NULL)
+        {
+          nerr("ERROR: Failed to allocate an I/O buffer.");
+          iob_free_chain(segs);
+          return NULL;
+        }
+
+      memset(PKT_GSOINFO(pkt), 0, sizeof(struct gso_cb));
+      memset(PKT_GROINFO(pkt), 0, sizeof(struct gro_cb));
+
+      if (segs)
+        {
+          tmp->io_flink = pkt;
+          tmp = pkt;
+        }
+      else
+        {
+          segs = pkt;
+          tmp = segs;
+        }
+    }
+
+  return segs;
+}
+
+/****************************************************************************
+ * Name: devif_send_gso_pkt
+ *
+ * Description:
+ *   Allocate the iob for the GSO packet, based on the size and count.
+ *
+ * Input Parameters:
+ *   pkt - The packet is to be sent.
+ *   sndlen - The length of the packet.
+ *   offset - The offset of data in the iob (packet).
+ *   hdrlen - The total header length of L3 and L4 in the packet.
+ *   gso_size - The size of each pachage when pre-segment.
+ *
+ * Returned Value:
+ *   The NULL indicates that the allocation is failure.
+ *   The segs is the head of the multiple iob.
+ *
+ ****************************************************************************/
+
+FAR struct iob_s *devif_send_gso_pkt(FAR struct iob_s *pkt,
+                       unsigned int sndlen, unsigned int offset,
+                       unsigned int hdrlen, uint16_t gso_size)
+{
+  FAR struct iob_s *segs = NULL;
+  FAR struct iob_s *tmp = NULL;
+  int size = gso_size + hdrlen;
+  int num = 0;
+  int segs_num = DIV_ROUND_UP(sndlen, gso_size);
+  int payload_len;
+
+  segs = devif_prepare_gso_segments(size, segs_num);
+
+  for (tmp = segs; tmp; tmp = tmp->io_flink, num++)
+    {
+      tmp->io_offset = hdrlen + CONFIG_NET_LL_GUARDSIZE;
+      payload_len = num < segs_num - 1 ? gso_size : sndlen - num * gso_size;
+
+      iob_copyout(tmp->io_data + tmp->io_offset, pkt, payload_len,
+                  num * gso_size + offset);
+
+      tmp->io_len = payload_len;
+    }
+
+  if (segs)
+    {
+      segs->io_pktlen = sndlen;
+      segs->io_offset = CONFIG_NET_LL_GUARDSIZE;
+    }
+
+  return segs;
+}
+
+/****************************************************************************
+ * Name: devif_gso_segment
+ *
+ * Description:
+ *   Divide the packet into multiple packets based on the features and
+ *   the GSO information of the packet.
+ *
+ * Input Parameters:
+ *   pkt  - the packet to be sent by the NIC driver.
+ *   features  - the features are supported by the target dev of the packet.
+ *
+ * Returned Value:
+ *   The NULL indicates that the devision is failure.
+ *   The segs is the head of the multiple packets.
+ *
+ ****************************************************************************/
+
+FAR struct iob_s *devif_gso_segment(FAR struct iob_s *pkt, uint32_t features)
+{
+  FAR struct iob_s *segs = NULL;
+  FAR struct eth_hdr_s *eth = ETHHDR(pkt);
+
+  /* PKT_GSOINFO(pkt)->data_offset = ETH_HDRLEN; */
+
+  PKT_GSOINFO(pkt)->type = NTOHS(eth->type);
+  switch (PKT_GSOINFO(pkt)->type)
+    {
+#ifdef CONFIG_NET_IPv4
+    case ETHTYPE_IP:
+          PKT_GSOINFO(pkt)->is_ipv6 = false;
+          segs = inet_gso_segment(pkt, features);
+          break;
+#endif
+#ifdef CONFIG_NET_IPv6
+    case ETHTYPE_IP6:
+          PKT_GSOINFO(pkt)->is_ipv6 = true;
+          segs = ipv6_gso_segment(pkt, features);
+          break;
+#endif
+    default:
+          return NULL;
+    }
+
+  return segs;
+}
+
+/****************************************************************************
+ * Name: devif_needs_gso
+ *
+ * Description:
+ *   Check whether the packet needs to be segmented.
+ *
+ * Input Parameters:
+ *    pkt  - the packet to be sent by the NIC driver.
+ *    features  - the features are supported by the target dev of the packet.
+ *
+ * Returned Value:
+ *    The false indicates that the packet does not to be divided.
+ *    The true indicates that the packet needs to be divided.
+ *
+ ****************************************************************************/
+
+bool devif_needs_gso(FAR struct iob_s *pkt, int features)
+{
+  if (!(features & NETIF_F_GSO))
+    {
+      return false;
+    }
+
+  if (PKT_GSOINFO(pkt)->gso_size == 0)
+    {
+      return false;
+    }
+
+  if (PKT_GSOINFO(pkt)->gso_size > pkt->io_pktlen)
+    {
+      return false;
+    }
+
+  switch (PKT_GSOINFO(pkt)->gso_type)
+    {
+      case PKT_GSO_TCPV4:
+      case PKT_GSO_TCPV6:
+      case PKT_GSO_UDPV4:
+      case PKT_GSO_UDPV6:
+        return true;
+      default:
+        return false;
+    }
+}
+
+/****************************************************************************
+ * Name: devif_get_max_pktsize
+ *
+ * Description:
+ *   Get the maximum packet size value.
+ *
+ * Input Parameters:
+ *    dev -  The structure of the network driver.
+ *
+ * Returned Value:
+ *   The maximum packet size.
+ *
+ ****************************************************************************/
+
+uint16_t devif_get_max_pktsize(FAR struct net_driver_s *dev)
+{
+  if ((dev->d_features & NETIF_F_GSO))
+    {
+      return MAX(dev->d_gso_max_size, dev->d_pktsize);
+    }
+
+  return dev->d_pktsize;
+}
+
+/****************************************************************************
+ * Name: devif_gso_list_free
+ *
+ * Description:
+ *   Free the packet allocated by devif_pkt_segment and
+ *   clear the GSO information of the fisrt packet.
+ *
+ * Input Parameters:
+ *    pkt  - The GSO packets includes the segments list.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void devif_gso_list_free(FAR struct iob_s *pkt)
+{
+  FAR struct iob_s *seg = PKT_GSOINFO(pkt)->seg_list;
+  FAR struct iob_s *tmp;
+
+  /* Free all packets except the header packet. */
+
+  while (seg)
+    {
+      tmp = PKT_GSOINFO(seg)->seg_list;
+      iob_free_chain(seg);
+      seg = tmp;
+    }
+
+  PKT_GSOINFO(pkt)->seg_list = NULL;
+
+  /* Clear the GSO information for the first packet. */
+
+  memset(PKT_GSOINFO(pkt), 0, sizeof(struct gso_cb));
+}
+
+/****************************************************************************
+ * Name: netdev_enable_gso
+ *
+ * Description:
+ *   Enable the GSO function for the dev.
+ *   Set the features and GSO-related maximum value.
+ *
+ * Input Parameters:
+ *    dev -  The structure of the network driver that enables the GSO
+ *           function.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void netdev_enable_gso(FAR struct net_driver_s *dev)
+{
+  dev->d_features |= NETIF_F_GSO;
+  dev->d_gso_max_size = GSO_MAX_SIZE;
+  dev->d_gso_max_segs = GSO_MAX_SIZE;
+}
+

--- a/net/inet/Make.defs
+++ b/net/inet/Make.defs
@@ -38,6 +38,10 @@ ifeq ($(CONFIG_NET_IPv6),y)
 SOCK_CSRCS += ipv6_setsockopt.c ipv6_getsockname.c ipv6_getpeername.c ipv6_build_header.c ipv6_getsockopt.c
 endif
 
+ifeq ($(CONFIG_NET_SEG_OFFLOAD),y)
+SOCK_CSRCS += inet_offload.c
+endif
+
 # Include inet build support
 
 DEPPATH += --dep-path inet

--- a/net/inet/inet_offload.c
+++ b/net/inet/inet_offload.c
@@ -31,6 +31,7 @@
 #include <nuttx/mm/iob.h>
 #include <nuttx/net/ip.h>
 #include <nuttx/net/tcp.h>
+#include <nuttx/net/udp.h>
 #include <nuttx/net/offload.h>
 
 /****************************************************************************
@@ -137,6 +138,11 @@ FAR struct iob_s *inet_gso_segment(FAR struct iob_s *pkt, uint32_t features)
           segs = tcp4_gso_segment(pkt, features);
           break;
 #endif
+#ifdef CONFIG_NET_UDP_OFFLOAD
+      case IP_PROTO_UDP:
+          segs = udp4_gso_segment(pkt, features);
+          break;
+#endif
       default:
           return NULL;
     }
@@ -204,6 +210,11 @@ FAR struct iob_s *ipv6_gso_segment(FAR struct iob_s *pkt, uint32_t features)
 #ifdef CONFIG_NET_TCP_OFFLOAD
       case IP_PROTO_TCP:
           segs = tcp6_gso_segment(pkt, features);
+          break;
+#endif
+#ifdef CONFIG_NET_UDP_OFFLOAD
+      case IP_PROTO_UDP:
+          segs = udp6_gso_segment(pkt, features);
           break;
 #endif
     default:

--- a/net/inet/inet_offload.c
+++ b/net/inet/inet_offload.c
@@ -1,0 +1,229 @@
+/****************************************************************************
+ * net/inet/inet_offload.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <assert.h>
+#include <debug.h>
+
+#include <nuttx/net/netdev.h>
+#include <nuttx/net/ethernet.h>
+#include <nuttx/mm/iob.h>
+#include <nuttx/net/ip.h>
+#include <nuttx/net/tcp.h>
+#include <nuttx/net/offload.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define GET_IPv4ID(ipv4) (ipv4->ipid[0] | ipv4->ipid[1] << 8)
+#define SET_IPv4ID(ipv4, id)    \
+  do {                          \
+    ipv4->ipid[0] = id >> 8;    \
+    ipv4->ipid[1] = id & 0xff;  \
+  } while(0)
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: inet_update_iphdr_len
+ *
+ * Description:
+ *    Update the (ipv4/ipv6) ipheader length based on the pkt->io_pktlen.
+ *
+ * Input Parameters:
+ *
+ *   pkt  - The data iob structure.
+ *   type  - The type of the packet.
+ *
+ ****************************************************************************/
+
+void inet_update_iphdr_len(FAR struct iob_s *pkt, int type)
+{
+#ifdef CONFIG_NET_IPv4
+  FAR struct ipv4_hdr_s *ip4hdr;
+#endif
+#ifdef CONFIG_NET_IPv6
+  FAR struct ipv6_hdr_s *ip6hdr;
+  int payload_len;
+#endif
+
+  /* update the payload length in L3 header, used in checksum. */
+
+  switch (type)
+  {
+#ifdef CONFIG_NET_IPv4
+    case ETHTYPE_IP:
+      {
+        ip4hdr = IPV4HDR(pkt);
+        ip4hdr->len[0] = pkt->io_pktlen >> 8;
+        ip4hdr->len[1] = pkt->io_pktlen & 0xff;
+      }
+      break;
+#endif
+#ifdef CONFIG_NET_IPv6
+    case ETHTYPE_IP6:
+      {
+        payload_len = pkt->io_pktlen - IPv6_HDRLEN;
+        ip6hdr = IPV6HDR(pkt);
+
+        /* update payload length */
+
+        ip6hdr->len[0] = payload_len >> 8;
+        ip6hdr->len[1] = payload_len & 0xff;
+      }
+      break;
+#endif
+    default:
+      nerr("Unknown packet type %d", type);
+      break;
+  }
+}
+
+/****************************************************************************
+ * Name: inet_gso_segment
+ *
+ * Description:
+ *   Check whether the packet needs to be divided. After the segmentation,
+ *   and update the ipv4 header for all packets.
+ *
+ * Input Parameters:
+ *   pkt  - the packet to be sent by the NIC driver.
+ *   features  - the features are supported by the target dev of the packet.
+ *
+ * Returned Value:
+ *   The NULL indicates that the devision is failure.
+ *   The segs is the head of the multiple packets.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_IPv4
+FAR struct iob_s *inet_gso_segment(FAR struct iob_s *pkt, uint32_t features)
+{
+  FAR struct iob_s *segs = NULL;
+  FAR struct ipv4_hdr_s *ip4hdr = IPV4HDR(pkt);
+  uint16_t iphdrlen = (ip4hdr->vhl & IPv4_HLMASK) << 2;
+  uint32_t id;
+  int tot_len;
+
+  PKT_GSOINFO(pkt)->data_offset += iphdrlen;
+  switch (ip4hdr->proto)
+    {
+#ifdef CONFIG_NET_TCP_OFFLOAD
+      case IP_PROTO_TCP:
+          segs = tcp4_gso_segment(pkt, features);
+          break;
+#endif
+      default:
+          return NULL;
+    }
+
+  if (segs == NULL)
+    {
+      nerr("inet gso segment failed.");
+      return NULL;
+    }
+
+  /* loop update ipv4 header for all pkt with ipid, len, chksum */
+
+  ip4hdr = IPV4HDR(segs);
+  id = GET_IPv4ID(ip4hdr);
+  for (pkt = segs; pkt != NULL; pkt = PKT_GSOINFO(pkt)->seg_list)
+    {
+      ip4hdr = IPV4HDR(pkt);
+
+      /* update id */
+
+      /* the first pkt doesn't need to update id */
+
+      SET_IPv4ID(ip4hdr, id);
+
+      id += 1; /* PKT_GSOINFO(pkt)->gso_size; */
+      tot_len = pkt->io_pktlen;
+      ip4hdr->len[0] = tot_len >> 8;
+      ip4hdr->len[1] = tot_len & 0xff;
+
+      ip4hdr->ipchksum = 0;
+      ip4hdr->ipchksum = ~ipv4_chksum(ip4hdr);
+    }
+
+  return segs;
+}
+#endif
+
+/****************************************************************************
+ * Name: ipv6_gso_segment
+ *
+ * Description:
+ *   Check whether the packet needs to be divided. After the segmentation,
+ *   and update the ipv6 header for all packets.
+ *
+ * Input Parameters:
+ *   pkt  - the packet to be sent by the NIC driver.
+ *   features  - the features are supported by the target dev of the packet.
+ *
+ * Returned Value:
+ *   The NULL indicates that the devision is failure.
+ *   The segs is the head of the multiple packets.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_IPv6
+FAR struct iob_s *ipv6_gso_segment(FAR struct iob_s *pkt, uint32_t features)
+{
+  FAR struct iob_s *segs;
+  FAR struct ipv6_hdr_s *ip6hdr = IPV6HDR(pkt);
+  uint16_t payload_len;
+
+  PKT_GSOINFO(pkt)->data_offset += IPv6_HDRLEN;
+  switch (ip6hdr->proto)
+    {
+#ifdef CONFIG_NET_TCP_OFFLOAD
+      case IP_PROTO_TCP:
+          segs = tcp6_gso_segment(pkt, features);
+          break;
+#endif
+    default:
+          return NULL;
+    }
+
+  /* update ipv6 header */
+
+  for (pkt = segs; pkt != NULL; pkt = PKT_GSOINFO(pkt)->seg_list)
+    {
+      ip6hdr = IPV6HDR(pkt);
+
+      /* update payload length */
+
+      payload_len = pkt->io_pktlen - IPv6_HDRLEN;
+      ip6hdr->len[0] = payload_len >> 8;
+      ip6hdr->len[1] = payload_len & 0xff;
+    }
+
+  return segs;
+}
+#endif
+

--- a/net/inet/inet_sockif.c
+++ b/net/inet/inet_sockif.c
@@ -823,6 +823,11 @@ static int inet_getsockopt(FAR struct socket *psock, int level, int option,
         return tcp_getsockopt(psock, option, value, value_len);
 #endif
 
+#ifdef CONFIG_NET_UDPPROTO_OPTIONS
+      case IPPROTO_UDP:
+        return udp_getsockopt(psock, option, value, value_len);
+#endif
+
 #ifdef CONFIG_NET_IPv4
       case IPPROTO_IP:/* IPv4 protocol socket options (see include/netinet/in.h) */
         return ipv4_getsockopt(psock, option, value, value_len);

--- a/net/ipforward/ipv4_forward.c
+++ b/net/ipforward/ipv4_forward.c
@@ -44,6 +44,12 @@
 
 #if defined(CONFIG_NET_IPFORWARD) && defined(CONFIG_NET_IPv4)
 
+#ifdef CONFIG_NET_GSO
+ #define NETDEV_MAXPKTSIZE(fwdev)     devif_get_max_pktsize(fwdev)
+#else
+ #define NETDEV_MAXPKTSIZE(fwdev)     NETDEV_PKTSIZE(fwddev)
+#endif
+
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
@@ -218,7 +224,7 @@ static int ipv4_dev_forward(FAR struct net_driver_s *dev,
    * if DF is set.
    */
 
-  if (NET_LL_HDRLEN(fwddev) + dev->d_len > NETDEV_PKTSIZE(fwddev)
+  if (NET_LL_HDRLEN(fwddev) + dev->d_len > NETDEV_MAXPKTSIZE(fwdev)
 #ifdef CONFIG_NET_IPFRAG
       && (ipv4->ipoffset[0] & (IP_FLAG_DONTFRAG >> 8))
 #endif

--- a/net/ipforward/ipv6_forward.c
+++ b/net/ipforward/ipv6_forward.c
@@ -360,7 +360,13 @@ static int ipv6_dev_forward(FAR struct net_driver_s *dev,
        * MTU.  We provide no support for fragmenting forwarded packets.
        */
 
-      if (NET_LL_HDRLEN(fwddev) + dev->d_len > NETDEV_PKTSIZE(fwddev))
+      if (NET_LL_HDRLEN(fwddev) + dev->d_len >
+#ifdef CONFIG_NET_GSO
+          devif_get_max_pktsize(fwdev)
+#else
+          NETDEV_PKTSIZE(fwddev)
+#endif
+          )
         {
           nwarn("WARNING: Packet > MTU... Dropping\n");
           ret = -EFBIG;

--- a/net/ipfrag/ipfrag.c
+++ b/net/ipfrag/ipfrag.c
@@ -1248,6 +1248,17 @@ int32_t ip_fragout(FAR struct net_driver_s *dev)
       return OK;
     }
 
+#ifdef CONFIG_NET_GSO
+  if ((dev->d_features & NETIF_F_GSO)
+      && (dev->d_iob->gso_info.gso_size != 0))
+    {
+      if (dev->d_iob->io_pktlen <= devif_get_max_pktsize(dev))
+        {
+          return OK;
+        }
+    }
+#endif
+
 #ifdef CONFIG_NET_6LOWPAN
   if (dev->d_lltype == NET_LL_IEEE802154 ||
       dev->d_lltype == NET_LL_PKTRADIO)

--- a/net/socket/Kconfig
+++ b/net/socket/Kconfig
@@ -49,7 +49,7 @@ config NET_TCPPROTO_OPTIONS
 		Enable or disable support for TCP protocol level socket options.
 
 config NET_UDPPROTO_OPTIONS
-	bool
+	bool "UDP proto socket options"
 	default n
 	---help---
 		Enable or disable support for UDP protocol level socket options.

--- a/net/tcp/Kconfig
+++ b/net/tcp/Kconfig
@@ -341,4 +341,14 @@ endif # NET_TCP_DEBUG_DROP_SEND
 
 endif # NET_STATISTICS
 
+if NET_SEG_OFFLOAD
+
+config NET_TCP_OFFLOAD
+	bool "Enable TCP offload"
+	default n
+	---help---
+		Enable the tcp segment offload.
+
+endif # NET_SEG_OFFLOAD
+
 endmenu # TCP/IP Networking

--- a/net/tcp/Make.defs
+++ b/net/tcp/Make.defs
@@ -55,6 +55,10 @@ NET_CSRCS += tcp_send.c tcp_input.c tcp_appsend.c tcp_listen.c tcp_close.c
 NET_CSRCS += tcp_monitor.c tcp_callback.c tcp_backlog.c tcp_ipselect.c
 NET_CSRCS += tcp_recvwindow.c tcp_netpoll.c tcp_ioctl.c tcp_shutdown.c
 
+ifeq ($(CONFIG_NET_TCP_OFFLOAD),y)
+SOCK_CSRCS += tcp_offload.c
+endif
+
 # TCP write buffering
 
 ifeq ($(CONFIG_NET_TCP_WRITE_BUFFERS),y)

--- a/net/tcp/tcp_appsend.c
+++ b/net/tcp/tcp_appsend.c
@@ -212,7 +212,11 @@ void tcp_appsend(FAR struct net_driver_s *dev, FAR struct tcp_conn_s *conn,
        * MSS (the minimum of the MSS and the available window).
        */
 
+#ifdef CONFIG_NET_TCP_OFFLOAD
+      DEBUGASSERT(dev->d_sndlen <= conn->gso_max_size);
+#else
       DEBUGASSERT(dev->d_sndlen <= conn->mss);
+#endif
 
 #if !defined(CONFIG_NET_TCP_WRITE_BUFFERS) || defined(CONFIG_NET_SENDFILE)
 

--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -820,6 +820,14 @@ FAR struct tcp_conn_s *tcp_alloc(uint8_t domain)
           conn->mss = MIN_IPv6_TCP_INITIAL_MSS;
         }
 #endif /* CONFIG_NET_IPv6 */
+
+#ifdef CONFIG_NET_TCP_OFFLOAD
+
+      /* Initialize the variables of GSO. */
+
+      conn->gso_max_segs = GSO_MAX_SIZE;
+      conn->gso_max_size = GSO_MAX_SIZE;
+#endif
     }
 
   return conn;

--- a/net/tcp/tcp_input.c
+++ b/net/tcp/tcp_input.c
@@ -1240,6 +1240,11 @@ found:
 
             conn->tcpstateflags = TCP_ESTABLISHED;
 
+#ifdef CONFIG_NET_TCP_OFFLOAD
+            conn->gso_max_segs = dev->d_gso_max_segs;
+            conn->gso_max_size = dev->d_gso_max_size;
+#endif
+
             /* Wake up any listener waiting for a connection on this port */
 
             if (tcp_accept_connection(dev, conn, tcp->destport) != OK)
@@ -1324,6 +1329,10 @@ found:
             conn->rcv_adv = tcp_getsequence(conn->rcvseq);
             tcp_snd_wnd_init(conn, tcp);
             tcp_snd_wnd_update(conn, tcp);
+#ifdef CONFIG_NET_TCP_OFFLOAD
+            conn->gso_max_segs = dev->d_gso_max_segs;
+            conn->gso_max_size = dev->d_gso_max_size;
+#endif
 
 #ifdef CONFIG_NET_TCP_CC_NEWRENO
             tcp_cc_update(conn, tcp);

--- a/net/tcp/tcp_offload.c
+++ b/net/tcp/tcp_offload.c
@@ -1,0 +1,383 @@
+/****************************************************************************
+ * net/tcp/tcp_offload.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <debug.h>
+#include <assert.h>
+
+#include <nuttx/net/netdev.h>
+#include <nuttx/net/ethernet.h>
+#include <nuttx/mm/iob.h>
+#include <nuttx/net/ip.h>
+#include <nuttx/net/tcp.h>
+#include <nuttx/net/offload.h>
+
+#include "tcp/tcp.h"
+#include "netdev/netdev.h"
+#include "inet/inet.h"
+#include "devif/devif.h"
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static uint16_t tcp_checksum(FAR struct iob_s *pkt, uint16_t type)
+{
+  switch (type)
+    {
+#ifdef CONFIG_NET_IPv4
+      case ETHTYPE_IP:
+        return ipv4_upperlayer_chksum(pkt, IP_PROTO_TCP);
+#endif
+#ifdef CONFIG_NET_IPv6
+      case ETHTYPE_IP6:
+        return ipv6_upperlayer_chksum(pkt, IP_PROTO_TCP, IPv6_HDRLEN);
+#endif
+      default:
+        return 0;
+    }
+}
+
+/****************************************************************************
+ * Name: tcp_gso_segment
+ *
+ * Description:
+ *   Segment the TCP packet and update the TCP headers of all segments.
+ *
+ * Input Parameters:
+ *   pkt  - the packet to be sent by the NIC driver.
+ *   features  - the features are supported by the target dev of the packet.
+ *
+ * Returned Value:
+ *   The NULL indicates that the devision is failure.
+ *   The segs is the head of the multiple packets.
+ *
+ ****************************************************************************/
+
+static FAR struct iob_s *tcp_gso_segment(FAR struct iob_s *pkt,
+                                         uint32_t features)
+{
+  FAR struct iob_s *segs = NULL;
+  uint16_t ip_hdrlen = GET_IPHDRLEN(pkt);
+  FAR struct tcp_hdr_s *th;
+  uint32_t mss;
+  uint32_t seq;
+
+  /* check gso parameters */
+
+  mss = PKT_GSOINFO(pkt)->gso_size;
+  if (mss > pkt->io_pktlen)
+    {
+      return pkt;
+    }
+
+  PKT_GSOINFO(pkt)->data_offset += TCP_HDRLEN;
+
+  /* 2. segment the packet. */
+
+  segs = devif_pkt_segment(pkt, features);
+  if (segs == NULL)
+    {
+      nerr("ERROR: devif_pkt_segment Failed.");
+      return NULL;
+    }
+
+  /* 3.update the header of segs */
+
+  pkt = segs;
+  th = TCPHDR(pkt, ip_hdrlen);
+  seq = tcp_getsequence(th->seqno);
+
+  /* set first seg */
+
+  PKT_GSOINFO(pkt)->is_first = 1;
+
+  /* 3.1 pkt->len=mss */
+
+  while (pkt)
+    {
+      th = TCPHDR(pkt, ip_hdrlen);
+
+      /* fin psh check seq cwr */
+
+      th->flags &= ~(TCP_FIN | TCP_PSH);
+      tcp_setsequence(th->seqno, seq);
+      if (PKT_GSOINFO(pkt)->is_first == 0)
+        {
+          th->flags &= ~TCP_CWR;
+        }
+
+      /* update the payload length in L3 header, used in checksum. */
+
+      inet_update_iphdr_len(pkt, PKT_GSOINFO(segs)->type);
+
+      th->tcpchksum = 0;
+      th->tcpchksum = ~tcp_checksum(pkt, PKT_GSOINFO(segs)->type);
+
+      /* next pkt */
+
+      seq += pkt->io_pktlen - PKT_GSOINFO(segs)->data_offset;
+      pkt = PKT_GSOINFO(pkt)->seg_list;
+    }
+
+  return segs;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: tcp_send_mss
+ *
+ * Description:
+ *
+ * Input Parameters:
+ *   conn - The TCP connection.
+ *   *size_goal  - The maximum lenght of the packet that can be sent.
+ *
+ * Returned Value:
+ *   The current mss value of the TCP connection.
+ *
+ ****************************************************************************/
+
+int tcp_send_mss(FAR struct tcp_conn_s *conn, FAR int *size_goal)
+{
+  int mss_now;
+
+  mss_now = conn->mss;
+
+  *size_goal = tcp_gso_size_goal(conn);
+
+  return mss_now;
+}
+
+/****************************************************************************
+ * Name: tcp_gso_size_goal
+ *
+ * Description:
+ *   Calculate the maximum length of the packet that can be sent currently.
+ *
+ * Input Parameters:
+ *   conn  - The TCP connection of interest.
+ *
+ * Returned Value:
+ *   The maximum lenght of the packet that can be sent.
+ *
+ ****************************************************************************/
+
+int tcp_gso_size_goal(FAR struct tcp_conn_s *conn)
+{
+  uint32_t new_size_goal;
+  uint32_t size_goal;
+
+#ifdef CONFIG_NET_TCP_CC_NEWRENO
+  new_size_goal = MIN(conn->snd_wnd, conn->cwnd) >> 1;
+#else
+  new_size_goal = conn->snd_wnd >> 1;
+#endif
+
+  if (new_size_goal > (CONFIG_IOB_NBUFFERS * CONFIG_IOB_BUFSIZE) >> 1)
+    {
+      new_size_goal = (CONFIG_IOB_NBUFFERS * CONFIG_IOB_BUFSIZE) >> 1;
+    }
+
+  size_goal = conn->gso_max_segs * conn->mss;
+
+  if (new_size_goal < size_goal || new_size_goal >= size_goal + conn->mss)
+    {
+      conn->gso_segs = MIN(new_size_goal / conn->mss,
+                           conn->gso_max_segs);
+      size_goal = conn->gso_segs * conn->mss;
+    }
+
+  return MAX(size_goal, conn->mss);
+}
+
+/****************************************************************************
+ * Name: tcp_gso_segs
+ *
+ * Description:
+ *   Calculates the number of the GSO packet that can be segmented.
+ *
+ * Input Parameters:
+ *   conn  - The TCP connection of interest.
+ *   pktlen  - The length of packet that will be sent.
+ *
+ * Returned Value:
+ *   The number of segments.
+ *
+ ****************************************************************************/
+
+int tcp_gso_segs(FAR struct tcp_conn_s *conn, int pktlen)
+{
+  int gso_segs;
+
+  if (pktlen % conn->mss == 0)
+    {
+      gso_segs = pktlen / conn->mss;
+    }
+  else
+    {
+      gso_segs = pktlen / conn->mss + 1;
+    }
+
+  return gso_segs;
+}
+
+/****************************************************************************
+ * Name: tcp_set_gso
+ *
+ * Description:
+ *   Set the gso information of the packet to be sent,
+ *   including gso_type, gso_size, gso_segs.
+ *
+ * Input Parameters:
+ *   conn - The TCP connection.
+ *   pkt  - Packet to be sent.
+ *   len  - The payload length of the packet.
+ *
+ * Returned Value:
+ *   A negative integer (ENOMEM) indicates that no memory available.
+ *   A positive integer is the length of the packet to be sent.
+ *
+ ****************************************************************************/
+
+void tcp_set_gso(FAR struct tcp_conn_s *conn, FAR struct iob_s *pkt,
+                 size_t len)
+{
+  if (len > conn->mss)
+    {
+      if (conn->domain == PF_INET)
+        {
+          PKT_GSOINFO(pkt)->gso_type = PKT_GSO_TCPV4;
+        }
+      else if (conn->domain == PF_INET6)
+        {
+          PKT_GSOINFO(pkt)->gso_type = PKT_GSO_TCPV6;
+        }
+
+      PKT_GSOINFO(pkt)->gso_size = conn->mss;
+      PKT_GSOINFO(pkt)->gso_segs = tcp_gso_segs(conn, len);
+    }
+}
+
+/****************************************************************************
+ * Name: tcp_send_gso_pkt
+ *
+ * Description:
+ *   Pre-allocate the iobs for the TCP packets to be sent, and copy the data
+ *   into the iobs, in order to reduce the data copy on GSO segmentation.
+ *
+ * Input Parameters:
+ *   conn - The TCP connection.
+ *   dev  - The netdevice structure.
+ *   pkt  - Packet to be sent.
+ *   sndlen  - The length of the packet.
+ *   offset  - The offset of the packet in the iob structure.
+ *
+ * Returned Value:
+ *
+ *
+ ****************************************************************************/
+
+int tcp_send_gso_pkt(FAR struct tcp_conn_s *conn,
+                     FAR struct net_driver_s *dev,
+                     FAR struct iob_s *pkt, unsigned int sndlen,
+                     unsigned int offset)
+{
+  FAR struct iob_s *segs;
+
+  segs = devif_send_gso_pkt(pkt, sndlen, offset, tcpip_hdrsize(conn),
+                            conn->mss);
+  if (segs)
+    {
+      netdev_iob_replace(dev, segs);
+    }
+  else
+    {
+      return -ENOMEM;
+    }
+
+  dev->d_sndlen = sndlen;
+
+  return dev->d_sndlen;
+}
+
+/****************************************************************************
+ * Name: tcp4_gso_segment
+ *
+ * Description:
+ *   Check whether the IPv4 TCP packet can be segmented.
+ *
+ * Input Parameters:
+ *   pkt  - the packet to be sent by the NIC driver.
+ *   features  - the features are supported by the target dev of the packet.
+ *
+ * Returned Value:
+ *   The NULL indicates that the devision is failure.
+ *   The segs is the head of the multiple packets.
+ *
+ ****************************************************************************/
+
+FAR struct iob_s *tcp4_gso_segment(FAR struct iob_s *pkt, uint32_t features)
+{
+  /* check gso_type */
+
+  if (PKT_GSOINFO(pkt)->gso_type != PKT_GSO_TCPV4)
+    {
+      return NULL;
+    }
+
+  return tcp_gso_segment(pkt, features);
+}
+
+/****************************************************************************
+ * Name: tcp6_gso_segment
+ *
+ * Description:
+ *   Check whether the IPv6 TCP packet can be segmented.
+ *
+ * Input Parameters:
+ *   pkt  - the packet to be sent by the NIC driver.
+ *   features  - the features are supported by the target dev of the packet.
+ *
+ * Returned Value:
+ *   The NULL indicates that the devision is failure.
+ *   The segs is the head of the multiple packets.
+ *
+ ****************************************************************************/
+
+struct iob_s *tcp6_gso_segment(FAR struct iob_s *pkt, uint32_t features)
+{
+  /* check gso_type */
+
+  if (PKT_GSOINFO(pkt)->gso_type != PKT_GSO_TCPV6)
+    {
+      return NULL;
+    }
+
+  return tcp_gso_segment(pkt, features);
+}
+

--- a/net/tcp/tcp_send.c
+++ b/net/tcp/tcp_send.c
@@ -188,8 +188,14 @@ static void tcp_sendcommon(FAR struct net_driver_s *dev,
 
       /* Calculate TCP checksum. */
 
-      tcp->tcpchksum = 0;
-      tcp->tcpchksum = ~tcp_ipv6_chksum(dev);
+#ifdef CONFIG_NET_TCP_OFFLOAD
+      if (PKT_GSOINFO(dev->d_iob)->gso_size == 0)
+#endif
+        {
+          tcp->tcpchksum = 0;
+          tcp->tcpchksum = ~tcp_ipv6_chksum(dev);
+        }
+
 #ifdef CONFIG_NET_STATISTICS
       g_netstats.ipv6.sent++;
 #endif
@@ -208,8 +214,14 @@ static void tcp_sendcommon(FAR struct net_driver_s *dev,
 
       /* Calculate TCP checksum. */
 
-      tcp->tcpchksum = 0;
-      tcp->tcpchksum = ~tcp_ipv4_chksum(dev);
+#ifdef CONFIG_NET_TCP_OFFLOAD
+      if (PKT_GSOINFO(dev->d_iob)->gso_size == 0)
+#endif
+        {
+          tcp->tcpchksum = 0;
+          tcp->tcpchksum = ~tcp_ipv4_chksum(dev);
+        }
+
 #ifdef CONFIG_NET_STATISTICS
       g_netstats.ipv4.sent++;
 #endif

--- a/net/udp/CMakeLists.txt
+++ b/net/udp/CMakeLists.txt
@@ -43,6 +43,10 @@ if(CONFIG_NET_UDP AND NOT CONFIG_NET_UDP_NO_STACK)
     endif()
   endif()
 
+  if(CONFIG_NET_UDP_OFFLOAD)
+    list(APPEND SRCS udp_offload.c)
+  endif()
+
   # Transport layer
 
   list(

--- a/net/udp/CMakeLists.txt
+++ b/net/udp/CMakeLists.txt
@@ -27,6 +27,7 @@ if(CONFIG_NET_UDP AND NOT CONFIG_NET_UDP_NO_STACK)
 
   if(CONFIG_NET_UDPPROTO_OPTIONS)
     list(APPEND SRCS udp_setsockopt.c)
+    list(APPEND SRCS udp_getsockopt.c)
   endif()
 
   if(CONFIG_NET_UDP_WRITE_BUFFERS)

--- a/net/udp/Kconfig
+++ b/net/udp/Kconfig
@@ -146,7 +146,7 @@ if NET_SEG_OFFLOAD
 config NET_UDP_OFFLOAD
 	bool "Enable udp segment offload"
 	default n
-	depends on NET_GSO
+	depends on NET_GSO && NET_GRO
 	---help---
 		Enable the UDP segment offload.
 

--- a/net/udp/Kconfig
+++ b/net/udp/Kconfig
@@ -140,4 +140,15 @@ config NET_UDP_NOTIFIER
 		wait for read-ahead data to become available.
 
 endif # NET_UDP && !NET_UDP_NO_STACK
+
+if NET_SEG_OFFLOAD
+
+config NET_UDP_OFFLOAD
+	bool "Enable udp segment offload"
+	default n
+	depends on NET_GSO
+	---help---
+		Enable the UDP segment offload.
+
+endif # NET_SEG_OFFLOAD
 endmenu # UDP Networking

--- a/net/udp/Make.defs
+++ b/net/udp/Make.defs
@@ -29,6 +29,7 @@ SOCK_CSRCS += udp_recvfrom.c
 
 ifeq ($(CONFIG_NET_UDPPROTO_OPTIONS),y)
 SOCK_CSRCS += udp_setsockopt.c
+SOCK_CSRCS += udp_getsockopt.c
 endif
 
 ifeq ($(CONFIG_NET_UDP_WRITE_BUFFERS),y)

--- a/net/udp/Make.defs
+++ b/net/udp/Make.defs
@@ -50,6 +50,10 @@ NET_CSRCS += udp_conn.c udp_devpoll.c udp_send.c udp_input.c udp_finddev.c
 NET_CSRCS += udp_close.c udp_callback.c udp_ipselect.c udp_netpoll.c
 NET_CSRCS += udp_ioctl.c
 
+ifeq ($(CONFIG_NET_UDP_OFFLOAD),y)
+SOCK_CSRCS += udp_offload.c
+endif
+
 # UDP write buffering
 
 ifeq ($(CONFIG_NET_UDP_WRITE_BUFFERS),y)

--- a/net/udp/udp.h
+++ b/net/udp/udp.h
@@ -129,6 +129,8 @@ struct udp_conn_s
   uint16_t gso_max_size;  /* Maximum segment size for gso */
   uint16_t gso_max_segs;  /* Maximum segment number for gso */
   uint16_t gso_size;      /* segment size for udp gso */
+
+  bool     gro_enable;    /* Request GRO aggregation */
 #endif
 
   /* Read-ahead buffering.

--- a/net/udp/udp.h
+++ b/net/udp/udp.h
@@ -477,6 +477,45 @@ int udp_setsockopt(FAR struct socket *psock, int option,
 #endif
 
 /****************************************************************************
+ * Name: udp_getsockopt
+ *
+ * Description:
+ *   udp_getsockopt() retrieves the value for the option specified by the
+ *   'option' argument for the socket specified by the 'psock' argument.  If
+ *   the size of the option value is greater than 'value_len', the value
+ *   stored in the object pointed to by the 'value' argument will be silently
+ *   truncated. Otherwise, the length pointed to by the 'value_len' argument
+ *   will be modified to indicate the actual length of the 'value'.
+ *
+ *   The 'level' argument specifies the protocol level of the option. To
+ *   retrieve options at the socket level, specify the level argument as
+ *   SOL_SOCKET; to retrieve options at the UDP-protocol level, the level
+ *   argument is SOL_UDP.
+ *
+ *   See <sys/socket.h> a complete list of values for the socket-level
+ *   'option' argument.  Protocol-specific options are are protocol specific
+ *   header files (such as netinet/udp.h for the case of the UDP protocol).
+ *
+ * Input Parameters:
+ *   psock     Socket structure of the socket to query
+ *   level     Protocol level to set the option
+ *   option    identifies the option to get
+ *   value     Points to the argument value
+ *   value_len The length of the argument value
+ *
+ * Returned Value:
+ *   Returns zero (OK) on success.  On failure, it returns a negated errno
+ *   value to indicate the nature of the error.  See psock_getsockopt() for
+ *   the complete list of appropriate return error codes.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_UDPPROTO_OPTIONS
+int udp_getsockopt(FAR struct socket *psock, int option,
+                   FAR void *value, FAR socklen_t *value_len);
+#endif
+
+/****************************************************************************
  * Name: udp_wrbuffer_initialize
  *
  * Description:

--- a/net/udp/udp_conn.c
+++ b/net/udp/udp_conn.c
@@ -661,6 +661,7 @@ FAR struct udp_conn_s *udp_alloc(uint8_t domain)
       conn->gso_max_segs = GSO_MAX_SEGS;
       conn->gso_max_size = GSO_MAX_SIZE;
       conn->gso_size = 0;
+      conn->gro_enable = false;
 #endif
       /* Enqueue the connection into the active list */
 

--- a/net/udp/udp_conn.c
+++ b/net/udp/udp_conn.c
@@ -654,6 +654,14 @@ FAR struct udp_conn_s *udp_alloc(uint8_t domain)
 
       sq_init(&conn->write_q);
 #endif
+
+#ifdef CONFIG_NET_UDP_OFFLOAD
+      /* Initialize the variables of GSO. */
+
+      conn->gso_max_segs = GSO_MAX_SEGS;
+      conn->gso_max_size = GSO_MAX_SIZE;
+      conn->gso_size = 0;
+#endif
       /* Enqueue the connection into the active list */
 
       dq_addlast(&conn->sconn.node, &g_active_udp_connections);

--- a/net/udp/udp_getsockopt.c
+++ b/net/udp/udp_getsockopt.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * net/udp/udp_setsockopt.c
+ * net/udp/udp_getsockopt.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -24,22 +24,19 @@
 
 #include <nuttx/config.h>
 
+#include <sys/time.h>
 #include <stdint.h>
 #include <errno.h>
 #include <assert.h>
 #include <debug.h>
 
-#include <net/if.h>
 #include <netinet/udp.h>
 
 #include <nuttx/net/net.h>
-#include <nuttx/net/netdev.h>
 #include <nuttx/net/udp.h>
 
 #include "socket/socket.h"
 #include "utils/utils.h"
-#include "devif/devif.h"
-#include "netdev/netdev.h"
 #include "udp/udp.h"
 
 #ifdef CONFIG_NET_UDPPROTO_OPTIONS
@@ -49,36 +46,49 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: udp_setsockopt
+ * Name: udp_getsockopt
  *
  * Description:
- *   udp_setsockopt() sets the UDP-protocol option specified by the
- *   'option' argument to the value pointed to by the 'value' argument for
- *   the socket specified by the 'psock' argument.
+ *   udp_getsockopt() retrieves the value for the option specified by the
+ *   'option' argument for the socket specified by the 'psock' argument.  If
+ *   the size of the option value is greater than 'value_len', the value
+ *   stored in the object pointed to by the 'value' argument will be silently
+ *   truncated. Otherwise, the length pointed to by the 'value_len' argument
+ *   will be modified to indicate the actual length of the 'value'.
  *
- *   See <netinet/udp.h> for the a complete list of values of UDP protocol
- *   options.
+ *   The 'level' argument specifies the protocol level of the option. To
+ *   retrieve options at the socket level, specify the level argument as
+ *   SOL_SOCKET; to retrieve options at the UDP-protocol level, the level
+ *   argument is SOL_UDP.
+ *
+ *   See <sys/socket.h> a complete list of values for the socket-level
+ *   'option' argument.  Protocol-specific options are are protocol specific
+ *   header files (such as netinet/udp.h for the case of the UDP protocol).
  *
  * Input Parameters:
- *   psock     Socket structure of socket to operate on
- *   option    identifies the option to set
+ *   psock     Socket structure of the socket to query
+ *   level     Protocol level to set the option
+ *   option    identifies the option to get
  *   value     Points to the argument value
  *   value_len The length of the argument value
  *
  * Returned Value:
  *   Returns zero (OK) on success.  On failure, it returns a negated errno
- *   value to indicate the nature of the error.  See psock_setcockopt() for
- *   the list of possible error values.
+ *   value to indicate the nature of the error.  See psock_getsockopt() for
+ *   the complete list of appropriate return error codes.
  *
  ****************************************************************************/
 
-int udp_setsockopt(FAR struct socket *psock, int option,
-                   FAR const void *value, socklen_t value_len)
+int udp_getsockopt(FAR struct socket *psock, int option,
+                   FAR void *value, FAR socklen_t *value_len)
 {
   FAR struct udp_conn_s *conn;
-  int ret = OK;
+  int ret;
 
+  DEBUGASSERT(value != NULL && value_len != NULL);
   conn = psock->s_conn;
+
+  /* All of the UDP protocol options apply only UDP sockets. */
 
   if (psock->s_type != SOCK_DGRAM)
     {
@@ -92,19 +102,16 @@ int udp_setsockopt(FAR struct socket *psock, int option,
     {
 #ifdef CONFIG_NET_UDP_OFFLOAD
       case UDP_SEGMENT:
-        if (value_len < sizeof(int))
+        if (*value_len < sizeof(uint16_t))
           {
-            ret = -EINVAL;
+            return -EINVAL;
           }
         else
           {
-            int gso_size = *(FAR int *)value;
-            if (gso_size > GSO_MAX_SIZE)
-              {
-                return -EINVAL;
-              }
-
-            conn->gso_size = gso_size;
+            FAR uint16_t *gso_size = (FAR uint16_t *)value;
+            *gso_size              = conn->gso_size;
+            *value_len             = sizeof(uint16_t);
+            ret                    = OK;
           }
         break;
 #endif

--- a/net/udp/udp_getsockopt.c
+++ b/net/udp/udp_getsockopt.c
@@ -114,6 +114,19 @@ int udp_getsockopt(FAR struct socket *psock, int option,
             ret                    = OK;
           }
         break;
+      case UDP_GRO:
+        if (*value_len < sizeof(int))
+          {
+            return -EINVAL;
+          }
+        else
+          {
+            FAR int *gro_enable = (FAR int *)value;
+            *gro_enable         = conn->gro_enable;
+            *value_len          = sizeof(int);
+            ret                 = OK;
+          }
+        break;
 #endif
       default:
         nerr("ERROR: Unrecognized UDP option: %d\n", option);

--- a/net/udp/udp_offload.c
+++ b/net/udp/udp_offload.c
@@ -1,0 +1,283 @@
+/****************************************************************************
+ * net/udp/udp_offload.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <debug.h>
+#include <assert.h>
+
+#include <nuttx/mm/iob.h>
+#include <nuttx/net/netdev.h>
+#include <nuttx/net/ethernet.h>
+#include <nuttx/net/net.h>
+#include <nuttx/net/ip.h>
+#include <nuttx/net/udp.h>
+#include <nuttx/net/offload.h>
+
+#include "udp/udp.h"
+#include "netdev/netdev.h"
+#include "inet/inet.h"
+#include "devif/devif.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define DIV_ROUND_UP(n,d)           (((n) + (d) - 1) / (d))
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static uint16_t udp_checksum(FAR struct iob_s *pkt, uint16_t type)
+{
+  switch (type)
+    {
+#ifdef CONFIG_NET_IPv4
+      case ETHTYPE_IP:
+        return ipv4_upperlayer_chksum(pkt, IP_PROTO_UDP);
+#endif
+#ifdef CONFIG_NET_IPv6
+      case ETHTYPE_IP6:
+        return ipv6_upperlayer_chksum(pkt, IP_PROTO_UDP, IPv6_HDRLEN);
+#endif
+      default:
+        return 0;
+    }
+}
+
+/****************************************************************************
+ * Name: udp_gso_segment
+ *
+ * Description:
+ *   Segment the UDP packet and update the UDP headers of all segments.
+ *
+ * Input Parameters:
+ *   pkt  - the packet to be sent by the NIC driver.
+ *   features  - the features are supported by the target dev of the packet.
+ *
+ * Returned Value:
+ *   The NULL indicates that the devision is failure.
+ *   The segs is the head of the multiple packets.
+ *
+ ****************************************************************************/
+
+static FAR struct iob_s *udp_gso_segment(FAR struct iob_s *pkt,
+                                         uint32_t features)
+{
+  FAR struct iob_s *segs = NULL;
+  uint16_t ip_hdrlen = GET_IPHDRLEN(pkt);
+  FAR struct udp_hdr_s *uh;
+  uint32_t mss = PKT_GSOINFO(pkt)->gso_size;
+
+  /* check gso parameters */
+
+  if (mss > pkt->io_pktlen)
+    {
+      return pkt;
+    }
+
+  PKT_GSOINFO(pkt)->data_offset += UDP_HDRLEN;
+
+  /* 2. segment the packet. */
+
+  segs = devif_pkt_segment(pkt, features);
+  if (segs == NULL)
+    {
+      nerr("ERROR: devif_pkt_segment Failed.");
+      return NULL;
+    }
+
+  /* 3.update the udp header of segs */
+
+  pkt = segs;
+
+  /* set first seg */
+
+  PKT_GSOINFO(pkt)->is_first = 1;
+
+  while (pkt)
+    {
+      uh = UDPHDR(pkt, ip_hdrlen);
+
+      /* update len, checksum */
+
+      uh->udplen = HTONS(pkt->io_pktlen - ip_hdrlen);
+
+      /* update the payload length in L3 header, used in checksum. */
+
+      inet_update_iphdr_len(pkt, PKT_GSOINFO(segs)->type);
+
+      uh->udpchksum = 0;
+      uh->udpchksum = ~udp_checksum(pkt, PKT_GSOINFO(segs)->type);
+
+      /* next pkt */
+
+      pkt = PKT_GSOINFO(pkt)->seg_list;
+    }
+
+  return segs;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: udp_prepare_gso_pkt
+ *
+ * Description:
+ *   pre-allocate the iob buffers for the GSO packets.
+ *
+ * Input Parameters:
+ *
+ *   conn    - the UDP connection structure.
+ *   sndlen  - the length of data to be sent.
+ *
+ * Returned Value:
+ *   The I/O buffers are allocated for the GSO packets.
+ *
+ ****************************************************************************/
+
+FAR struct iob_s *udp_prepare_gso_pkt(FAR struct udp_conn_s *conn,
+                                      unsigned int sndlen)
+{
+  FAR struct iob_s *segs = NULL;
+  FAR struct iob_s *tmp = NULL;
+  uint16_t hdrlen = udpip_hdrsize(conn);
+
+  segs = devif_prepare_gso_segments(conn->gso_size + hdrlen,
+                                    DIV_ROUND_UP(sndlen, conn->gso_size));
+  if (segs == NULL)
+    {
+      return segs;
+    }
+
+  for (tmp = segs; tmp; tmp = tmp->io_flink)
+    {
+      tmp->io_offset = hdrlen + CONFIG_NET_LL_GUARDSIZE;
+    }
+
+  return segs;
+}
+
+/****************************************************************************
+ * Name: udp_copy_gso_pkt
+ *
+ * Description:
+ *  Copy data 'len' bytes from a user buffer into the I/O buffer chain,
+ *  starting at 'offset', extending the chain as necessary based on gso_size.
+ *
+ *   segs  - The I/O buffers chain.
+ *   src   - The user data.
+ *   len   - The length of user data.
+ *   hdrlen    - The length of L3 and L4 header.
+ *   gso_size  - The size of UDP packet payload.
+ *
+ * Returned Value:
+ *   The length of data that is copied into the segs I/O buffers.
+ *
+ ****************************************************************************/
+
+int udp_copy_gso_pkt(FAR struct iob_s *segs, FAR const uint8_t *src,
+                     unsigned int len, int hdrlen, int gso_size)
+{
+  FAR struct iob_s *tmp;
+  int num = 0;
+  int segs_num = DIV_ROUND_UP(len, gso_size);
+
+  for (tmp = segs; tmp; tmp = tmp->io_flink, num++)
+    {
+      tmp->io_offset = hdrlen + CONFIG_NET_LL_GUARDSIZE;
+      tmp->io_len = num < segs_num - 1 ? gso_size : len - num * gso_size;
+
+      memcpy(tmp->io_data + tmp->io_offset, src, tmp->io_len);
+      src += tmp->io_len;
+    }
+
+  segs->io_pktlen = len;
+  segs->io_offset = CONFIG_NET_LL_GUARDSIZE;
+
+  return len;
+}
+
+/****************************************************************************
+ * Name: udp4_gso_segment
+ *
+ * Description:
+ *   Check whether the IPv4 UDP packet can be segmented.
+ *
+ * Input Parameters:
+ *   pkt  - the packet to be sent by the NIC driver.
+ *   features  - the features are supported by the target dev of the packet.
+ *
+ * Returned Value:
+ *   The NULL indicates that the devision is failure.
+ *   The segs is the head of the multiple packets.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_IPv4
+FAR struct iob_s *udp4_gso_segment(FAR struct iob_s *pkt, uint32_t features)
+{
+  /* check gso_type */
+
+  if (PKT_GSOINFO(pkt)->gso_type != PKT_GSO_UDPV4)
+    {
+      return NULL;
+    }
+
+  return udp_gso_segment(pkt, features);
+}
+#endif
+
+/****************************************************************************
+ * Name: udp6_gso_segment
+ *
+ * Description:
+ *   Check whether the IPv6 UDP packet can be segmented.
+ *
+ * Input Parameters:
+ *   pkt  - the packet to be sent by the NIC driver.
+ *   features  - the features are supported by the target dev of the packet.
+ *
+ * Returned Value:
+ *   The NULL indicates that the devision is failure.
+ *   The segs is the head of the multiple packets.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_IPv6
+FAR struct iob_s *udp6_gso_segment(FAR struct iob_s *pkt, uint32_t features)
+{
+  /* check gso_type */
+
+  if (PKT_GSOINFO(pkt)->gso_type != PKT_GSO_UDPV6)
+    {
+      return NULL;
+    }
+
+  return udp_gso_segment(pkt, features);
+}
+#endif
+

--- a/net/udp/udp_sendto_buffered.c
+++ b/net/udp/udp_sendto_buffered.c
@@ -290,6 +290,14 @@ static int sendto_next_transfer(FAR struct udp_conn_s *conn)
       return -EHOSTUNREACH;
     }
 
+#ifdef CONFIG_NET_UDP_OFFLOAD
+  if ((udpip_hdrsize(conn) + conn->gso_size) >  devif_get_mtu(dev))
+    {
+      nerr("ERROR: GSO size is out of range!\n");
+      return -E2BIG;
+    }
+#endif
+
 #ifndef CONFIG_NET_IPFRAG
   /* Sanity check if the packet len (with IP hdr) is greater than the MTU */
 

--- a/net/udp/udp_sendto_buffered.c
+++ b/net/udp/udp_sendto_buffered.c
@@ -83,6 +83,8 @@
 #  define UDP_WBDUMP(msg,wrb,len,offset)
 #endif
 
+#define DIV_ROUND_UP(n, d) (((n) + (d) - 1) / (d))
+
 /****************************************************************************
  * Private Function Prototypes
  ****************************************************************************/
@@ -291,7 +293,14 @@ static int sendto_next_transfer(FAR struct udp_conn_s *conn)
 #ifndef CONFIG_NET_IPFRAG
   /* Sanity check if the packet len (with IP hdr) is greater than the MTU */
 
-  if (wrb->wb_iob->io_pktlen > devif_get_mtu(dev))
+  if (wrb->wb_iob->io_pktlen >
+#ifdef CONFIG_NET_UDP_OFFLOAD
+      PKT_GSOINFO(wrb->wb_iob)->gso_size ? devif_get_max_pktsize(dev) :
+      devif_get_mtu(dev)
+#else
+      devif_get_mtu(dev)
+#endif
+      )
     {
       nerr("ERROR: Packet too long to send!\n");
       return -EMSGSIZE;
@@ -756,6 +765,25 @@ ssize_t psock_udp_sendto(FAR struct socket *psock, FAR const void *buf,
           goto errout_with_lock;
         }
 
+#ifdef CONFIG_NET_UDP_OFFLOAD
+      if (conn->gso_size > 0 && len > conn->gso_size)
+        {
+          /* free wrb->wb_iob */
+
+          iob_free_chain(wrb->wb_iob);
+
+          /* alloc iob of gso pkt for udp data */
+
+          wrb->wb_iob = udp_prepare_gso_pkt(conn, len);
+
+          if (wrb->wb_iob == NULL)
+            {
+              ret = -ENOMEM;
+              goto errout_with_lock;
+            }
+        }
+#endif
+
       /* Initialize the write buffer
        *
        * Check if the socket is connected
@@ -808,41 +836,71 @@ ssize_t psock_udp_sendto(FAR struct socket *psock, FAR const void *buf,
 
       udpiplen = udpip_hdrsize(conn);
 
-      iob_reserve(wrb->wb_iob, CONFIG_NET_LL_GUARDSIZE);
-      iob_update_pktlen(wrb->wb_iob, udpiplen, false);
-
-      /* Copy the user data into the write buffer.  We cannot wait for
-       * buffer space if the socket was opened non-blocking.
-       */
-
-      if (nonblock)
+#ifdef CONFIG_NET_UDP_OFFLOAD
+      if (conn->gso_size > 0 && len > conn->gso_size)
         {
-          ret = iob_trycopyin(wrb->wb_iob, (FAR uint8_t *)buf,
-                              len, udpiplen, false);
+          /* copy into the write buffer */
+
+          ret = udp_copy_gso_pkt(wrb->wb_iob, buf, len,
+                                 udpiplen, conn->gso_size);
         }
       else
+#endif
         {
-          unsigned int count;
-          int blresult;
+          iob_reserve(wrb->wb_iob, CONFIG_NET_LL_GUARDSIZE);
+          iob_update_pktlen(wrb->wb_iob, udpiplen, false);
 
-          /* iob_copyin might wait for buffers to be freed, but if
-           * network is locked this might never happen, since network
-           * driver is also locked, therefore we need to break the lock
+          /* Copy the user data into the write buffer.  We cannot wait for
+           * buffer space if the socket was opened non-blocking.
            */
 
-          blresult = net_breaklock(&count);
-          ret = iob_copyin(wrb->wb_iob, (FAR uint8_t *)buf,
-                           len, udpiplen, false);
-          if (blresult >= 0)
+          if (nonblock)
             {
-              net_restorelock(count);
+              ret = iob_trycopyin(wrb->wb_iob, (FAR uint8_t *)buf,
+                                  len, udpiplen, false);
+            }
+          else
+            {
+              unsigned int count;
+              int blresult;
+
+              /* iob_copyin might wait for buffers to be freed, but if
+               * network is locked this might never happen, since network
+               * driver is also locked, therefore we need to break the lock
+               */
+
+              blresult = net_breaklock(&count);
+              ret = iob_copyin(wrb->wb_iob, (FAR uint8_t *)buf,
+                               len, udpiplen, false);
+              if (blresult >= 0)
+                {
+                  net_restorelock(count);
+                }
+            }
+
+          if (ret < 0)
+            {
+              goto errout_with_wrb;
             }
         }
 
-      if (ret < 0)
+#ifdef CONFIG_NET_UDP_OFFLOAD
+      if (conn->gso_size > 0 && ret > conn->gso_size)
         {
-          goto errout_with_wrb;
+          if (psock->s_domain == PF_INET)
+            {
+              PKT_GSOINFO(wrb->wb_iob)->gso_type = PKT_GSO_UDPV4;
+            }
+          else if (psock->s_domain == PF_INET6)
+            {
+              PKT_GSOINFO(wrb->wb_iob)->gso_type = PKT_GSO_UDPV6;
+            }
+
+          PKT_GSOINFO(wrb->wb_iob)->gso_size = conn->gso_size;
+          PKT_GSOINFO(wrb->wb_iob)->gso_segs = DIV_ROUND_UP(ret,
+                                                            conn->gso_size);
         }
+#endif
 
       /* Dump I/O buffer chain */
 

--- a/net/udp/udp_setsockopt.c
+++ b/net/udp/udp_setsockopt.c
@@ -107,6 +107,16 @@ int udp_setsockopt(FAR struct socket *psock, int option,
             conn->gso_size = gso_size;
           }
         break;
+      case UDP_GRO:
+        if (value_len < sizeof(int))
+          {
+            ret = -EINVAL;
+          }
+        else
+          {
+            conn->gro_enable = (bool)(*(FAR int *)value);
+          }
+        break;
 #endif
       default:
         nerr("ERROR: Unrecognized UDP option: %d\n", option);

--- a/net/utils/net_icmpchksum.c
+++ b/net/utils/net_icmpchksum.c
@@ -88,7 +88,7 @@ uint16_t icmp_chksum_iob(FAR struct iob_s *iob)
 #ifdef CONFIG_NET_ICMPv6
 uint16_t icmpv6_chksum(FAR struct net_driver_s *dev, unsigned int iplen)
 {
-  return ipv6_upperlayer_chksum(dev, IP_PROTO_ICMP6, iplen);
+  return ipv6_upperlayer_chksum(dev->d_iob, IP_PROTO_ICMP6, iplen);
 }
 #endif
 

--- a/net/utils/net_ipchksum.c
+++ b/net/utils/net_ipchksum.c
@@ -45,8 +45,7 @@
  *   data payload as necessary.
  *
  * Input Parameters:
- *   dev   - The network driver instance.  The packet data is in the d_buf
- *           of the device.
+ *   pkt   - The packet data is in the d_iob of the device.
  *   proto - The protocol being supported
  *
  * Returned Value:
@@ -56,9 +55,9 @@
 
 #if !defined(CONFIG_NET_ARCH_CHKSUM) && \
     defined(CONFIG_NET_IPv4) && defined(CONFIG_MM_IOB)
-uint16_t ipv4_upperlayer_chksum(FAR struct net_driver_s *dev, uint8_t proto)
+uint16_t ipv4_upperlayer_chksum(FAR struct iob_s *pkt, uint8_t proto)
 {
-  FAR struct ipv4_hdr_s *ipv4 = IPv4BUF;
+  FAR struct ipv4_hdr_s *ipv4 = (FAR struct ipv4_hdr_s *)IOB_DATA(pkt);
   uint16_t upperlen;
   uint16_t iphdrlen;
   uint16_t sum;
@@ -87,7 +86,7 @@ uint16_t ipv4_upperlayer_chksum(FAR struct net_driver_s *dev, uint8_t proto)
 
   /* Sum IP payload data. */
 
-  sum = chksum_iob(sum, dev->d_iob, iphdrlen);
+  sum = chksum_iob(sum, pkt, iphdrlen);
 
   return (sum == 0) ? 0xffff : HTONS(sum);
 }
@@ -101,8 +100,7 @@ uint16_t ipv4_upperlayer_chksum(FAR struct net_driver_s *dev, uint8_t proto)
  *   data payload as necessary.
  *
  * Input Parameters:
- *   dev   - The network driver instance.  The packet data is in the d_buf
- *           of the device.
+ *   iob   - The packet data is in the d_iob of the device.
  *   proto - The protocol being supported
  *   iplen - The size of the IPv6 header.  This may be larger than
  *           IPv6_HDRLEN the IPv6 header if IPv6 extension headers are
@@ -115,14 +113,14 @@ uint16_t ipv4_upperlayer_chksum(FAR struct net_driver_s *dev, uint8_t proto)
 
 #if !defined(CONFIG_NET_ARCH_CHKSUM) && \
     defined(CONFIG_NET_IPv6) && defined(CONFIG_MM_IOB)
-uint16_t ipv6_upperlayer_chksum(FAR struct net_driver_s *dev,
+uint16_t ipv6_upperlayer_chksum(FAR struct iob_s *iob,
                                 uint8_t proto, unsigned int iplen)
 {
-  FAR struct ipv6_hdr_s *ipv6 = IPv6BUF;
+  FAR struct ipv6_hdr_s *ipv6 = (FAR struct ipv6_hdr_s *)IOB_DATA(iob);
   uint16_t upperlen;
   uint16_t sum;
 
-  DEBUGASSERT(dev != NULL && iplen >= IPv6_HDRLEN);
+  DEBUGASSERT(iob != NULL && iplen >= IPv6_HDRLEN);
 
   /* The length reported in the IPv6 header is the length of the payload
    * that follows the header.  If extension heders are present, then this
@@ -149,7 +147,7 @@ uint16_t ipv6_upperlayer_chksum(FAR struct net_driver_s *dev,
 
   /* Sum IP payload data. */
 
-  sum = chksum_iob(sum, dev->d_iob, iplen);
+  sum = chksum_iob(sum, iob, iplen);
 
   return (sum == 0) ? 0xffff : HTONS(sum);
 }

--- a/net/utils/net_tcpchksum.c
+++ b/net/utils/net_tcpchksum.c
@@ -55,14 +55,14 @@
 #ifdef CONFIG_NET_IPv4
 uint16_t tcp_ipv4_chksum(FAR struct net_driver_s *dev)
 {
-  return ipv4_upperlayer_chksum(dev, IP_PROTO_TCP);
+  return ipv4_upperlayer_chksum(dev->d_iob, IP_PROTO_TCP);
 }
 #endif /* CONFIG_NET_IPv4 */
 
 #ifdef CONFIG_NET_IPv6
 uint16_t tcp_ipv6_chksum(FAR struct net_driver_s *dev)
 {
-  return ipv6_upperlayer_chksum(dev, IP_PROTO_TCP, IPv6_HDRLEN);
+  return ipv6_upperlayer_chksum(dev->d_iob, IP_PROTO_TCP, IPv6_HDRLEN);
 }
 #endif /* CONFIG_NET_IPv6 */
 

--- a/net/utils/net_udpchksum.c
+++ b/net/utils/net_udpchksum.c
@@ -44,7 +44,7 @@
 #if defined(CONFIG_NET_UDP_CHECKSUMS) && defined(CONFIG_NET_IPv4)
 uint16_t udp_ipv4_chksum(FAR struct net_driver_s *dev)
 {
-  return ipv4_upperlayer_chksum(dev, IP_PROTO_UDP);
+  return ipv4_upperlayer_chksum(dev->d_iob, IP_PROTO_UDP);
 }
 #endif
 
@@ -59,7 +59,7 @@ uint16_t udp_ipv4_chksum(FAR struct net_driver_s *dev)
 #if defined(CONFIG_NET_UDP_CHECKSUMS) && defined(CONFIG_NET_IPv6)
 uint16_t udp_ipv6_chksum(FAR struct net_driver_s *dev)
 {
-  return ipv6_upperlayer_chksum(dev, IP_PROTO_UDP, IPv6_HDRLEN);
+  return ipv6_upperlayer_chksum(dev->d_iob, IP_PROTO_UDP, IPv6_HDRLEN);
 }
 #endif
 


### PR DESCRIPTION
## Summary
Implement GSO/GRO functions on the sim,  which mainly support the TCP and UDP.

## Impact
The sent packets will not be fragmented by IP Layer, but will be segmented through GSO function.

## Testing
- Enable the following configuration options:
```
CONFIG_NET_OFFLOAD=y
CONFIG_NET_GSO=y
CONFIG_NET_TCP_OFFLOAD=y
CONFIG_NET_UDP_OFFLOAD=y
CONFIG_NET_UDPPROTO_OPTIONS=y

CONFIG_NET_GRO=y
```
- Take the TCP as an example, perform streaming and use the wireshark to capture packets on tap0 interface. We will be able to see the complete TCP packets instead of the fragmented packet.
