### PR TITLE
Fix SHMODULEFLAGS so that we link dynamically correctly

### DIFF
--- a/arch/arm/src/common/Toolchain.defs
+++ b/arch/arm/src/common/Toolchain.defs
@@ -409,3 +409,12 @@ include $(TOPDIR)/tools/Rust.defs
 # LDC (LLVM D Compiler) toolchain
 
 include $(TOPDIR)/tools/D.defs
+
+# Shared library build flags
+
+SHCCFLAGS = -fPIC -fPIE -fvisibility=default
+SHLDFLAGS = -shared -Bsymbolic -Bdynamic -G
+
+ifeq ($(CONFIG_SIM_M32),y)
+  SHLDFLAGS += -melf_i386
+endif

--- a/arch/risc-v/src/common/Toolchain.defs
+++ b/arch/risc-v/src/common/Toolchain.defs
@@ -403,3 +403,12 @@ include $(TOPDIR)/tools/Rust.defs
 # LDC (LLVM D Compiler) toolchain
 
 include $(TOPDIR)/tools/D.defs
+
+# Shared library build flags
+
+SHCCFLAGS = -fPIC -fPIE -fvisibility=default
+SHLDFLAGS = -shared -Bsymbolic -Bdynamic -G
+
+ifeq ($(CONFIG_SIM_M32),y)
+  SHLDFLAGS += -melf_i386
+endif

--- a/arch/risc-v/src/common/Toolchain.defs
+++ b/arch/risc-v/src/common/Toolchain.defs
@@ -114,8 +114,11 @@ ifneq ($(CONFIG_CXX_RTTI),y)
   ARCHCXXFLAGS += -fno-rtti
 endif
 
+SHMODULEFLAGS = -Bsymbolic -G -Bdynamic --entry=__start
+
 ifeq ($(CONFIG_ARCH_RV32),y)
 LDFLAGS += -melf32lriscv
+SHMODULEFLAGS += -melf32lriscv
 else
 LDFLAGS += -melf64lriscv
 endif

--- a/arch/xtensa/src/lx6/Toolchain.defs
+++ b/arch/xtensa/src/lx6/Toolchain.defs
@@ -134,6 +134,8 @@ endif
 
 LDFLAGS += -nostdlib
 
+SHMODULEFLAGS = -Bsymbolic -G -Bdynamic --entry=__start
+
 # Optimization of unused sections
 
 ifeq ($(CONFIG_DEBUG_OPT_UNUSED_SECTIONS),y)

--- a/arch/xtensa/src/lx7/Toolchain.defs
+++ b/arch/xtensa/src/lx7/Toolchain.defs
@@ -138,6 +138,8 @@ endif
 
 LDFLAGS += -nostdlib
 
+SHMODULEFLAGS = -Bsymbolic -G -Bdynamic --entry=__start
+
 # Optimization of unused sections
 
 ifeq ($(CONFIG_DEBUG_OPT_UNUSED_SECTIONS),y)

--- a/boards/arm64/qemu/qemu-armv8a/scripts/Make.defs
+++ b/boards/arm64/qemu/qemu-armv8a/scripts/Make.defs
@@ -46,6 +46,8 @@ CMODULEFLAGS = $(CFLAGS)
 LDMODULEFLAGS = -r -e module_initialize
 LDMODULEFLAGS += -T $(call CONVERT_PATH,$(TOPDIR)/libs/libc/modlib/gnu-elf.ld)
 
+SHMODULEFLAGS = -Bsymbolic -G -Bdynamic
+
 CELFFLAGS = $(CFLAGS) -mlong-calls # --target1-abs
 CXXELFFLAGS = $(CXXFLAGS) -mlong-calls # --target1-abs
 

--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -292,6 +292,12 @@ endif
 SHCCFLAGS = -fPIC -fPIE -fvisibility=default
 SHLDFLAGS = -shared -Bsymbolic -Bdynamic -G
 
+ifeq ($(CONFIG_DEBUG_LINK_MAP),y)
+  ifeq ($(CONFIG_HOST_MACOS),)
+    LDFLAGS += -Wl,-Map=$(TOPDIR)/nuttx.map
+  endif
+endif
+
 ifeq ($(CONFIG_SIM_M32),y)
   LDLINKFLAGS += -melf_i386
   LDFLAGS += -m32

--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -246,7 +246,7 @@ CMODULEFLAGS += -fno-stack-protector
 
 LDMODULEFLAGS = -r -e module_initialize --gc-sections
 LDMODULEFLAGS += -T $(call CONVERT_PATH,$(TOPDIR)/libs/libc/modlib/gnu-elf.ld)
-SHMODULEFLAGS = -Bsymbolic -G -Bdynamic
+SHMODULEFLAGS = -shared -Bsymbolic -G -Bdynamic
 
 # NuttX modules are ELF binaries.
 # Non-ELF platforms like macOS need to use a separate ELF toolchain.

--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -290,7 +290,7 @@ ifeq ($(CONFIG_DEBUG_LINK_MAP),y)
 endif
 
 SHCCFLAGS = -fPIC -fPIE -fvisibility=default
-SHLDFLAGS = -shared -Bsymbolic -Bdynamic -G
+SHMODULEFLAGS = -shared -Bsymbolic -Bdynamic -G
 
 ifeq ($(CONFIG_DEBUG_LINK_MAP),y)
   ifeq ($(CONFIG_HOST_MACOS),)
@@ -302,6 +302,6 @@ ifeq ($(CONFIG_SIM_M32),y)
   LDLINKFLAGS += -melf_i386
   LDFLAGS += -m32
   LDMODULEFLAGS += -melf_i386
-  SHLDFLAGS += -melf_i386
+  SHMODULEFLAGS += -melf_i386
   LDELFFLAGS += -melf_i386
 endif

--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -289,10 +289,13 @@ ifeq ($(CONFIG_DEBUG_LINK_MAP),y)
   endif
 endif
 
+SHCCFLAGS = -fPIC -fPIE -fvisibility=default
+SHLDFLAGS = -shared -Bsymbolic -Bdynamic -G
+
 ifeq ($(CONFIG_SIM_M32),y)
   LDLINKFLAGS += -melf_i386
   LDFLAGS += -m32
   LDMODULEFLAGS += -melf_i386
-  SHMODULEFLAGS += -melf_i386
+  SHLDFLAGS += -melf_i386
   LDELFFLAGS += -melf_i386
 endif


### PR DESCRIPTION
* arch/risc-v/src/common/Toolchain.defs
   arch/xtensa/src/lx6/Toolchain.defs
   arch/xtensa/src/lx7/Toolchain.defs
   - Define SHMODULEFLAGS etc. for sotest/dynload
   - Add --entry=__start to SHMODULEFLAGS

* boards/arm64/qemu/qemu-armv8a/scripts/Make.defs
   boards/sim/sim/sim/scripts/Make.defs
   - Define SHMODULEFLAGS etc. for sotest/dynload