### PR TITLE
fix(Kconfig): spellcheck "randon" to "random"

### DIFF
--- a/crypto/Kconfig
+++ b/crypto/Kconfig
@@ -63,7 +63,7 @@ config CRYPTO_SW_AES
 		aes_cypher() per include/nuttx/crypto/crypto.h.
 
 config CRYPTO_RANDOM_POOL
-	bool "Entropy pool and strong randon number generator"
+	bool "Entropy pool and strong random number generator"
 	default n
 	---help---
 		Entropy pool gathers environmental noise from device drivers,


### PR DESCRIPTION
## Summary

I've noticed a typo in menuconfig while trying out nuttx during the conference and fixed it

## Impact

I don't expect this to have an impact on code because it is a string description in menuconfig.

## Testing

menuconfig in the cryptography category now looks a bit better:

![image](https://github.com/apache/nuttx/assets/583664/f842d9e2-dfba-4d99-bed8-fb82ce04cf96)

