### PR TITLE
pm: change pm lock from mutex to spinlock

### DIFF
--- a/drivers/power/pm/greedy_governor.c
+++ b/drivers/power/pm/greedy_governor.c
@@ -101,7 +101,7 @@ static enum pm_state_e greedy_governor_checkstate(int domain)
    * invoked, which modifies the stay count which we are about to read
    */
 
-  flags = pm_domain_lock(domain);
+  flags = pm_lock(&pdom->lock);
 
   /* Find the lowest power-level which is not locked. */
 
@@ -110,7 +110,7 @@ static enum pm_state_e greedy_governor_checkstate(int domain)
       state++;
     }
 
-  pm_domain_unlock(domain, flags);
+  pm_unlock(&pdom->lock, flags);
 
   /* Return the found state */
 

--- a/drivers/power/pm/pm_activity.c
+++ b/drivers/power/pm/pm_activity.c
@@ -305,7 +305,7 @@ void pm_wakelock_uninit(FAR struct pm_wakelock_s *wakelock)
   dq     = &pdom->wakelock[wakelock->state];
   wdog   = &wakelock->wdog;
 
-  flags = pm_domain_lock(domain);
+  flags = pm_lock(&pdom->lock);
 
   if (wakelock->count > 0)
     {
@@ -316,7 +316,7 @@ void pm_wakelock_uninit(FAR struct pm_wakelock_s *wakelock)
   wd_cancel(wdog);
   pm_wakelock_stats_rm(wakelock);
 
-  pm_domain_unlock(domain, flags);
+  pm_unlock(&pdom->lock, flags);
 }
 
 /****************************************************************************
@@ -353,7 +353,7 @@ void pm_wakelock_stay(FAR struct pm_wakelock_s *wakelock)
   pdom   = &g_pmdomains[domain];
   dq     = &pdom->wakelock[wakelock->state];
 
-  flags = pm_domain_lock(domain);
+  flags = pm_lock(&pdom->lock);
 
   DEBUGASSERT(wakelock->count < UINT32_MAX);
   if (wakelock->count++ == 0)
@@ -362,7 +362,7 @@ void pm_wakelock_stay(FAR struct pm_wakelock_s *wakelock)
       pm_wakelock_stats(wakelock, true);
     }
 
-  pm_domain_unlock(domain, flags);
+  pm_unlock(&pdom->lock, flags);
 
   pm_auto_updatestate(domain);
 }
@@ -400,7 +400,7 @@ void pm_wakelock_relax(FAR struct pm_wakelock_s *wakelock)
   pdom   = &g_pmdomains[domain];
   dq     = &pdom->wakelock[wakelock->state];
 
-  flags = pm_domain_lock(domain);
+  flags = pm_lock(&pdom->lock);
 
   DEBUGASSERT(wakelock->count > 0);
   if (--wakelock->count == 0)
@@ -409,7 +409,7 @@ void pm_wakelock_relax(FAR struct pm_wakelock_s *wakelock)
       pm_wakelock_stats(wakelock, false);
     }
 
-  pm_domain_unlock(domain, flags);
+  pm_unlock(&pdom->lock, flags);
 
   pm_auto_updatestate(domain);
 }
@@ -452,7 +452,7 @@ void pm_wakelock_staytimeout(FAR struct pm_wakelock_s *wakelock, int ms)
   dq     = &pdom->wakelock[wakelock->state];
   wdog   = &wakelock->wdog;
 
-  flags = pm_domain_lock(domain);
+  flags  = pm_lock(&pdom->lock);
 
   if (!WDOG_ISACTIVE(wdog))
     {
@@ -469,7 +469,7 @@ void pm_wakelock_staytimeout(FAR struct pm_wakelock_s *wakelock, int ms)
       wd_start(wdog, MSEC2TICK(ms), pm_waklock_cb, (wdparm_t)wakelock);
     }
 
-  pm_domain_unlock(domain, flags);
+  pm_unlock(&pdom->lock, flags);
 
   pm_auto_updatestate(domain);
 }

--- a/drivers/power/pm/pm_initialize.c
+++ b/drivers/power/pm/pm_initialize.c
@@ -92,7 +92,7 @@ void pm_initialize(void)
       clock_systime_timespec(&g_pmdomains[i].start);
 #endif
 
-      nxrmutex_init(&g_pmdomains[i].lock);
+      spin_lock_init(&g_pmdomains[i].lock);
 
 #if CONFIG_PM_GOVERNOR_EXPLICIT_RELAX
       for (state = 0; state < PM_COUNT; state++)

--- a/drivers/power/pm/pm_lock.c
+++ b/drivers/power/pm/pm_lock.c
@@ -37,26 +37,6 @@
  * Public Functions
  ****************************************************************************/
 
-irqstate_t pm_lock(FAR rmutex_t *lock)
-{
-  if (!up_interrupt_context() && !sched_idletask())
-    {
-      nxrmutex_lock(lock);
-    }
-
-  return enter_critical_section();
-}
-
-void pm_unlock(FAR rmutex_t *lock, irqstate_t flags)
-{
-  leave_critical_section(flags);
-
-  if (!up_interrupt_context() && !sched_idletask())
-    {
-      nxrmutex_unlock(lock);
-    }
-}
-
 irqstate_t pm_domain_lock(int domain)
 {
   return pm_lock(&g_pmdomains[domain].lock);

--- a/drivers/power/pm/stability_governor.c
+++ b/drivers/power/pm/stability_governor.c
@@ -165,7 +165,7 @@ static enum pm_state_e stability_governor_checkstate(int domain)
    * invoked, which modifies the stay count which we are about to read
    */
 
-  flags = pm_domain_lock(domain);
+  flags = pm_lock(&pdom->lock);
 
   /* Find the lowest power-level which is not locked. */
 
@@ -201,7 +201,7 @@ static enum pm_state_e stability_governor_checkstate(int domain)
         }
     }
 
-  pm_domain_unlock(domain, flags);
+  pm_unlock(&pdom->lock, flags);
 
   /* Return the found state */
 


### PR DESCRIPTION
## Summary
As we always want to take critical_section, and it is not long time job, take mutex is not necessary, use spinlock_irq_save as a replace is better, dont't have to take global critial_section in pm.

## Impact
If we did lots of job inside pm callback, will make the 2nd waiter change from  mutex wait to the spinlock wait. maybe have few side effect.
But we shall not make it happen. so only benifit from removed mutex operation.
Also global critical_section is not necessary here.

## Testing
CI-test and cortex-M33 chip board.
