### PR TITLE
arch/risc-v: revise MMIO for rv64ilp32

### DIFF
--- a/arch/risc-v/src/common/riscv_internal.h
+++ b/arch/risc-v/src/common/riscv_internal.h
@@ -125,14 +125,55 @@
 
 #ifndef __ASSEMBLY__
 
-#define getreg8(a)          (*(volatile uint8_t *)(a))
-#define putreg8(v,a)        (*(volatile uint8_t *)(a) = (v))
-#define getreg16(a)         (*(volatile uint16_t *)(a))
-#define putreg16(v,a)       (*(volatile uint16_t *)(a) = (v))
-#define getreg32(a)         (*(volatile uint32_t *)(a))
-#define putreg32(v,a)       (*(volatile uint32_t *)(a) = (v))
-#define getreg64(a)         (*(volatile uint64_t *)(a))
-#define putreg64(v,a)       (*(volatile uint64_t *)(a) = (v))
+/* Use ASM as rv64ilp32 compiler generated address is limited */
+
+static inline uint8_t getreg8(const volatile uintreg_t a)
+{
+  uint8_t v;
+  __asm__ __volatile__("lb %0, 0(%1)" : "=r" (v) : "r" (a));
+  return v;
+}
+
+static inline void putreg8(uint8_t v, const volatile uintreg_t a)
+{
+  __asm__ __volatile__("sb %0, 0(%1)" : : "r" (v), "r" (a));
+}
+
+static inline uint16_t getreg16(const volatile uintreg_t a)
+{
+  uint16_t v;
+  __asm__ __volatile__("lh %0, 0(%1)" : "=r" (v) : "r" (a));
+  return v;
+}
+
+static inline void putreg16(uint16_t v, const volatile uintreg_t a)
+{
+  __asm__ __volatile__("sh %0, 0(%1)" : : "r" (v), "r" (a));
+}
+
+static inline uint32_t getreg32(const volatile uintreg_t a)
+{
+  uint32_t v;
+  __asm__ __volatile__("lw %0, 0(%1)" : "=r" (v) : "r" (a));
+  return v;
+}
+
+static inline void putreg32(uint32_t v, const volatile uintreg_t a)
+{
+  __asm__ __volatile__("sw %0, 0(%1)" : : "r" (v), "r" (a));
+}
+
+static inline uint64_t getreg64(const volatile uintreg_t a)
+{
+  uint64_t v;
+  __asm__ __volatile__("ld %0, 0(%1)" : "=r" (v) : "r" (a));
+  return v;
+}
+
+static inline void putreg64(uint64_t v, const volatile uintreg_t a)
+{
+  __asm__ __volatile__("sd %0, 0(%1)" : : "r" (v), "r" (a));
+}
 
 #define READ_CSR(reg) \
   ({ \
@@ -222,7 +263,7 @@ extern "C"
 #ifndef __ASSEMBLY__
 /* Atomic modification of registers */
 
-void modifyreg32(uintptr_t addr, uint32_t clearbits, uint32_t setbits);
+void modifyreg32(uintreg_t addr, uint32_t clearbits, uint32_t setbits);
 
 /* Memory allocation ********************************************************/
 

--- a/arch/risc-v/src/common/riscv_modifyreg32.c
+++ b/arch/risc-v/src/common/riscv_modifyreg32.c
@@ -43,7 +43,7 @@
  *
  ****************************************************************************/
 
-void modifyreg32(uintptr_t addr, uint32_t clearbits, uint32_t setbits)
+void modifyreg32(uintreg_t addr, uint32_t clearbits, uint32_t setbits)
 {
   irqstate_t flags;
   uint32_t   regval;

--- a/arch/risc-v/src/k210/k210_fpioa.c
+++ b/arch/risc-v/src/k210/k210_fpioa.c
@@ -39,5 +39,5 @@ void k210_fpioa_config(uint32_t io, uint32_t ioflags)
 {
   uint32_t *fpioa = (uint32_t *)K210_FPIOA_BASE;
   DEBUGASSERT(io < K210_IO_NUMBER);
-  putreg32(ioflags, &fpioa[io]);
+  putreg32(ioflags, (uintptr_t)&fpioa[io]);
 }

--- a/arch/risc-v/src/mpfs/mpfs_dsn.c
+++ b/arch/risc-v/src/mpfs/mpfs_dsn.c
@@ -78,7 +78,7 @@
 int mpfs_read_dsn(uint8_t *dsn, size_t len)
 {
   uint32_t reg;
-  uint8_t *p = (uint8_t *)MSS_SCBMAILBOX;
+  uintptr_t p = MSS_SCBMAILBOX;
   irqstate_t flags = enter_critical_section();
   unsigned retries = RETRIES;
 

--- a/arch/risc-v/src/mpfs/mpfs_ethernet.c
+++ b/arch/risc-v/src/mpfs/mpfs_ethernet.c
@@ -412,7 +412,7 @@ static void mpfs_interrupt_work(void *arg);
 static inline void mac_putreg(struct mpfs_ethmac_s *priv,
                               uint32_t offset, uint32_t val)
 {
-  uint32_t *addr = (uint32_t *)(priv->regbase + offset);
+  uintptr_t addr = (uintptr_t)(priv->regbase + offset);
 #if defined(CONFIG_DEBUG_NET) && defined(CONFIG_MPFS_ETHMAC_REGDEBUG)
   ninfo("0x%08x <- 0x%08x\n", addr, val);
 #endif
@@ -437,7 +437,7 @@ static inline void mac_putreg(struct mpfs_ethmac_s *priv,
 static inline uint32_t mac_getreg(struct mpfs_ethmac_s *priv,
                                   uint32_t offset)
 {
-  uint32_t *addr = (uint32_t *)(priv->regbase + offset);
+  uintptr_t addr = (uintptr_t)(priv->regbase + offset);
   uint32_t value = getreg32(addr);
 #if defined(CONFIG_DEBUG_NET) && defined(CONFIG_MPFS_ETHMAC_REGDEBUG)
   ninfo("0x%08x -> 0x%08x\n", addr, value);


### PR DESCRIPTION
## Summary

This revises the MMIO register access methods for RV64ILP32 so that
to reach peripherals beyond rv64ilp32 compiler generated addresses.

## Impacts

risc-v

## Testing

- local checks with rv-virt target
- CI checks

