### PR TITLE
arch/xtensa/src/esp32s3/Bootloader.mk: Correction for MCUBoot Version Config Variable 

### DIFF
--- a/arch/xtensa/src/esp32s3/Bootloader.mk
+++ b/arch/xtensa/src/esp32s3/Bootloader.mk
@@ -96,7 +96,7 @@ BOOTLOADER_BIN        = $(TOPDIR)/mcuboot-esp32s3.bin
 $(MCUBOOT_SRCDIR): $(BOOTLOADER_DIR)
 	$(Q) echo "Cloning MCUboot"
 	$(Q) git clone --quiet $(MCUBOOT_URL) $(MCUBOOT_SRCDIR)
-	$(Q) git -C "$(MCUBOOT_SRCDIR)" checkout --quiet $(CONFIG_ESP32S2_MCUBOOT_VERSION)
+	$(Q) git -C "$(MCUBOOT_SRCDIR)" checkout --quiet $(CONFIG_ESP32S3_MCUBOOT_VERSION)
 	$(Q) git -C "$(MCUBOOT_SRCDIR)" submodule --quiet update --init --recursive ext/mbedtls
 
 $(BOOTLOADER_BIN): chip/$(ESP_HAL_3RDPARTY_REPO) $(MCUBOOT_SRCDIR) $(BOOTLOADER_CONFIG)


### PR DESCRIPTION
## Correction:
ESP32S3 bootloader.mk file has a typo error. In the file,  **CONFIG_ESP32S2_MCUBOOT_VERSION** config variable (in line 99) is declared, while the correct config variable for esp32s3 bootloader.mk file is **CONFIG_ESP32S3_MCUBOOT_VERSION** which is defined in the main "**.config**" file when the config is generated for ESP32S3-devkit board.

## Impact
MCUBoot version variable is defined for ESP32S3 board only but file is calling ESP32S2 board version. Correct variable which is defined in .config file should be used.

## Testing
./tools/checkpatch.sh script was run for arch/xtensa/src/esp32s3/Bootloader.mk and no errors were displayed.
