### PR TITLE
drivers/can/sja1000: fix Rx buffer pointer issue

### DIFF
--- a/drivers/can/sja1000.c
+++ b/drivers/can/sja1000.c
@@ -282,13 +282,11 @@ static void sja1000_reset(struct can_dev_s *dev)
       sja1000_putreg(priv, SJA1000_MODE_REG, 0);
     }
 
-  /* Abort transmission, release RX buffer and clear overrun.
+  /* Abort transmission and clear overrun.
    * Command register can only be modified when in Operation Mode.
    */
 
-  sja1000_putreg(priv, SJA1000_CMD_REG, SJA1000_ABORT_TX_M
-                                               | SJA1000_RELEASE_BUF_M
-                                               | SJA1000_CLR_OVERRUN_M);
+  sja1000_write_cmdreg(priv, SJA1000_ABORT_TX_M | SJA1000_CLR_OVERRUN_M);
 
 #ifdef CONFIG_ARCH_HAVE_MULTICPU
   spin_unlock_irqrestore(&priv->lock, flags);


### PR DESCRIPTION
## Summary
Fix SJA1000 Rx buffer pointer issue.

On the SJA1000_FDTOL IP implementation of this controller, if a buffer release is performed with nothing in the Rx FIFO, the internal FIFO pointers wrap around and the controller never recovers.

This patch removes the call to release the buffer on initialisation which fixes this issue and should also be safe for all other implementations of this controller as a reset of the controller clears the FIFO. 

## Impact
Any system using this common SJA1000 driver.

## Testing
Built and tested on the [Digilent ARTY_A7](https://digilent.com/shop/arty-a7-artix-7-fpga-development-board/) development board with an [SJA1000_FDTOL](https://gitlab.fel.cvut.cz/canbus/zynq/sja1000-fdtol) IP core integrated.
