### PR TITLE
net: Support packet filter (firewall) and corresponding iptables/ip6tables

### DIFF
--- a/Documentation/components/net/index.rst
+++ b/Documentation/components/net/index.rst
@@ -8,6 +8,7 @@ Network Support
   sixlowpan.rst
   socketcan.rst
   pkt.rst
+  ipfilter.rst
   nat.rst
   netdev.rst
   netdriver.rst

--- a/Documentation/components/net/ipfilter.rst
+++ b/Documentation/components/net/ipfilter.rst
@@ -1,0 +1,125 @@
+================
+IP Packet Filter
+================
+
+NuttX supports IP packet filter (firewall) compatible with Linux's iptables and
+netfilter. It is a stateless packet filter that can be used to filter packets
+based on source and destination IP addresses, source and destination ports,
+protocol, and interface.
+
+Workflow
+========
+
+Similar to Linux's iptables, NuttX's IP packet filter defines chains at similar
+points in the packet processing path. The following diagram shows the packet
+processing path and the chains that are defined in NuttX's IP packet filter.
+
+::
+
+   NIC ──> ipv[46]_input ─┬─> ipv[46]_forward ──> [FORWARD CHAIN] ──> devif_poll_out ──> NIC
+                          │                                                 ^
+                          │                  ┌─>  tcp  ─┐                   │
+                          │                  ├─>  udp  ─┤                   │
+                          └─> [INPUT CHAIN] ─┼─> icmp  ─┼─> [OUTPUT CHAIN] ─┘
+                                             ├─> icmp6 ─┤
+                                             └─>  ...  ─┘
+
+Configuration Options
+=====================
+
+``CONFIG_NET_IPFILTER``
+  Enable this option to enable the IP packet filter (firewall).
+
+``CONFIG_NET_IPTABLES``
+  Enable or disable iptables compatible interface (including ip6tables).
+
+``CONFIG_SYSTEM_IPTABLES``
+  Enable support for the 'iptables' command.
+
+``CONFIG_SYSTEM_IP6TABLES``
+  Enable support for the 'ip6tables' command.
+
+Usage
+=====
+
+With `iptables` command, we can add, delete, and list rules in the IP packet
+filter. It's similar to the `iptables` command in Linux.
+
+The following examples show the commands we support:
+
+..  code-block:: shell
+
+  > iptables -h
+
+  USAGE: iptables -t table -[AD] chain rule-specification
+         iptables -t table -I chain [rulenum] rule-specification
+         iptables -t table -D chain rulenum
+         iptables -t table -P chain target
+         iptables -t table -[FL] [chain]
+
+  Commands:
+      --append        -A chain            Append a rule to chain
+      --insert        -I chain [rulenum]  Insert a rule to chain at rulenum (default = 1)
+      --delete        -D chain [rulenum]  Delete matching rule from chain
+      --policy        -P chain target     Set policy for chain to target
+      --flush         -F [chain]          Delete all rules in chain or all chains
+      --list          -L [chain]          List all rules in chain or all chains
+
+  Options:
+      --table         -t table            Table to manipulate (default: filter)
+      --jump          -j target           Target for rule
+  [!] --in-interface  -i dev              Input network interface name
+  [!] --out-interface -o dev              Output network interface name
+  [!] --source        -s address[/mask]   Source address
+  [!] --destination   -d address[/mask]   Destination address
+  [!] --protocol      -p proto            Protocol (tcp, udp, icmp, esp, all)
+  [!] --source-port,--sport
+                         port[:port]      Source port
+  [!] --destination-port,--dport
+                         port[:port]      Destination port
+  [!] --icmp-type        type             ICMP type
+  [!] --icmpv6-type      type             ICMPv6 type
+
+..  code-block:: shell
+
+  > iptables -P FORWARD DROP
+  > iptables -I INPUT -i eth0 ! -p icmp -j DROP
+  > iptables -t filter -A FORWARD -p tcp -s 10.0.1.2/24 -d 10.0.3.4/24 -i eth0 -o eth1 --sport 3000:3200 --dport 123:65535 -j ACCEPT
+  > iptables -t filter -I FORWARD 2 -p icmp ! -s 123.123.123.123 ! -i eth0 -o eth1 ! --icmp-type 255 -j REJECT
+
+  > iptables -L
+  Chain INPUT (policy ACCEPT)
+  target        prot  idev  odev  source              destination
+  DROP         !icmp  eth0  any   anywhere            anywhere
+
+  Chain FORWARD (policy DROP)
+  target        prot  idev  odev  source              destination
+  ACCEPT        tcp   eth0  eth1  10.0.1.2/24         10.0.3.4/24        tcp spts:3000:3200 dpts:123:65535
+  REJECT        icmp !eth0  eth1 !123.123.123.123/32  anywhere           icmp !type 255
+
+  Chain OUTPUT (policy ACCEPT)
+  target        prot  idev  odev  source              destination
+
+..  code-block:: shell
+
+  > ip6tables -P FORWARD DROP
+  > ip6tables -t filter -I FORWARD -p tcp -s fc00::2/64 -d 2001:da8::2:4/64 -i eth0 -o eth1 --sport 3000:3200 --dport 123:65535 -j ACCEPT
+  > ip6tables -t filter -I FORWARD -p icmpv6 -s fc00::2/64 -d 2001:da8::2:4/64 -i eth0 -o eth1 --icmpv6-type 123 -j ACCEPT
+  > ip6tables -t filter -I FORWARD -p tcp -i eth0 -o eth1 --sport 3000 -j ACCEPT
+  > ip6tables -t filter -I FORWARD 1 ! -p tcp ! -s fc00::2/64 ! -d 2001:da8::2:4/64 ! -i eth0 ! -o eth1 ! --sport 3000:3200 ! --dport 0:123 -j DROP
+  > ip6tables -t filter -I FORWARD 3 ! -p icmpv6 ! -s fc00::2/64 -d 2001:da8::2:4/64 ! -i eth0 -o eth1 ! --icmpv6-type 255 -j REJECT
+
+  > ip6tables -L
+  Chain INPUT (policy ACCEPT)
+  target        prot  idev  odev  source              destination
+
+  Chain FORWARD (policy DROP)
+  target        prot  idev  odev  source              destination
+  DROP         !tcp  !eth0 !eth1 !fc00::2/64         !2001:da8::2:4/64   tcp spts:!3000:3200 dpts:!0:123
+  ACCEPT        tcp   eth0  eth1  anywhere            anywhere           tcp spts:3000:3000 dpts:0:65535
+  REJECT       !ipv6-icmp !eth0  eth1 !fc00::2/64          2001:da8::2:4/64   ipv6-icmp !type 255
+  ACCEPT        ipv6-icmp  eth0  eth1  fc00::2/64          2001:da8::2:4/64   ipv6-icmp type 123
+  ACCEPT        tcp   eth0  eth1  fc00::2/64          2001:da8::2:4/64   tcp spts:3000:3200 dpts:123:65535
+
+  Chain OUTPUT (policy ACCEPT)
+  target        prot  idev  odev  source              destination

--- a/include/nuttx/net/netfilter/ip6_tables.h
+++ b/include/nuttx/net/netfilter/ip6_tables.h
@@ -71,6 +71,14 @@
 #define ip6t_entry_target               xt_entry_target
 #define ip6t_entry_match                xt_entry_match
 
+/* Foreach macro for entries. */
+
+#define ip6t_entry_for_every(entry, head, size) \
+  for ((entry) = (FAR struct ip6t_entry *)(head); \
+       (entry) < (FAR struct ip6t_entry *)((FAR uint8_t *)(head) + (size)); \
+       (entry) = (FAR struct ip6t_entry *) \
+                     ((FAR uint8_t *)(entry) + (entry)->next_offset))
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/

--- a/include/nuttx/net/netfilter/ip6_tables.h
+++ b/include/nuttx/net/netfilter/ip6_tables.h
@@ -65,7 +65,16 @@
 #define IP6T_INV_PROTO                  XT_INV_PROTO
 #define IP6T_INV_MASK                   0x7F    /* All possible flag bits mask. */
 
+/* Values for "inv" field for struct ip6t_icmp. */
+
+#define IP6T_ICMP_INV                   0x01    /* Invert the sense of type/code test */
+
+/* Standard return verdict, or do jump. */
+
 #define IP6T_STANDARD_TARGET            XT_STANDARD_TARGET
+
+/* Error verdict. */
+
 #define IP6T_ERROR_TARGET               XT_ERROR_TARGET
 
 #define ip6t_entry_target               xt_entry_target
@@ -78,6 +87,27 @@
        (entry) < (FAR struct ip6t_entry *)((FAR uint8_t *)(head) + (size)); \
        (entry) = (FAR struct ip6t_entry *) \
                      ((FAR uint8_t *)(entry) + (entry)->next_offset))
+
+/* Get pointer to match from an entry pointer. */
+
+#define IP6T_MATCH(e) \
+  ((FAR struct xt_entry_match *)((FAR struct ip6t_entry *)(e) + 1))
+#define IP6T_TARGET(e) \
+  ((FAR struct xt_entry_target *)((FAR uint8_t *)(e) + (e)->target_offset))
+
+/* Auto fill common fields of entry and target. */
+
+#define IP6T_FILL_ENTRY(e, target_name) \
+  do \
+    { \
+      (e)->entry.target_offset = offsetof(typeof(*(e)), target); \
+      (e)->entry.next_offset = sizeof(*(e)); \
+      (e)->target.target.u.target_size = sizeof(*(e)) - \
+                                         (e)->entry.target_offset; \
+      strlcpy((e)->target.target.u.user.name, (target_name), \
+              sizeof((e)->target.target.u.user.name)); \
+    } \
+  while(0)
 
 /****************************************************************************
  * Public Types
@@ -246,6 +276,15 @@ struct ip6t_replace
   /* The entries (hang off end: not really an array). */
 
   struct ip6t_entry entries[1];
+};
+
+/* ICMPv6 matching stuff */
+
+struct ip6t_icmp
+{
+  uint8_t type;     /* type to match */
+  uint8_t code[2];  /* range of code */
+  uint8_t invflags; /* Inverse flags */
 };
 
 /****************************************************************************

--- a/include/nuttx/net/netfilter/ip_tables.h
+++ b/include/nuttx/net/netfilter/ip_tables.h
@@ -58,6 +58,10 @@
 #define IPT_INV_PROTO              XT_INV_PROTO
 #define IPT_INV_MASK               0x7F    /* All possible flag bits mask. */
 
+/* Values for "inv" field for struct ipt_icmp. */
+
+#define IPT_ICMP_INV               0x01    /* Invert the sense of type/code test */
+
 /* Standard return verdict, or do jump. */
 
 #define IPT_STANDARD_TARGET        XT_STANDARD_TARGET
@@ -78,8 +82,10 @@
        (entry) = (FAR struct ipt_entry *) \
                      ((FAR uint8_t *)(entry) + (entry)->next_offset))
 
-/* Get pointer to target from an entry pointer. */
+/* Get pointer to match / target from an entry pointer. */
 
+#define IPT_MATCH(e) \
+  ((FAR struct xt_entry_match *)((FAR struct ipt_entry *)(e) + 1))
 #define IPT_TARGET(e) \
   ((FAR struct xt_entry_target *)((FAR uint8_t *)(e) + (e)->target_offset))
 
@@ -88,9 +94,10 @@
 #define IPT_FILL_ENTRY(e, target_name) \
   do \
     { \
-      (e)->entry.target_offset = sizeof((e)->entry); \
+      (e)->entry.target_offset = offsetof(typeof(*(e)), target); \
       (e)->entry.next_offset = sizeof(*(e)); \
-      (e)->target.target.u.target_size = sizeof(*(e)) - sizeof((e)->entry); \
+      (e)->target.target.u.target_size = sizeof(*(e)) - \
+                                         (e)->entry.target_offset; \
       strlcpy((e)->target.target.u.user.name, (target_name), \
               sizeof((e)->target.target.u.user.name)); \
     } \
@@ -267,6 +274,15 @@ struct ipt_get_entries
   /* The entries. */
 
   struct ipt_entry entrytable[0];
+};
+
+/* ICMP matching stuff */
+
+struct ipt_icmp
+{
+  uint8_t type;     /* type to match */
+  uint8_t code[2];  /* range of code */
+  uint8_t invflags; /* Inverse flags */
 };
 
 /****************************************************************************

--- a/include/nuttx/net/netfilter/x_tables.h
+++ b/include/nuttx/net/netfilter/x_tables.h
@@ -39,9 +39,36 @@
 
 #define XT_INV_PROTO            0x40 /* Invert the sense of PROTO. */
 
+/* Values for "inv" field in struct xt_tcp. */
+
+#define XT_TCP_INV_SRCPT        0x01 /* Invert the sense of source ports. */
+#define XT_TCP_INV_DSTPT        0x02 /* Invert the sense of dest ports. */
+#define XT_TCP_INV_FLAGS        0x04 /* Invert the sense of TCP flags. */
+#define XT_TCP_INV_OPTION       0x08 /* Invert the sense of option test. */
+#define XT_TCP_INV_MASK         0x0F /* All possible flags. */
+
+/* Values for "invflags" field in struct xt_udp. */
+
+#define XT_UDP_INV_SRCPT        0x01 /* Invert the sense of source ports. */
+#define XT_UDP_INV_DSTPT        0x02 /* Invert the sense of dest ports. */
+#define XT_UDP_INV_MASK         0x03 /* All possible flags. */
+
+/* Target names */
+
 #define XT_STANDARD_TARGET      ""   /* Standard return verdict, or do jump. */
 #define XT_ERROR_TARGET         "ERROR"
 #define XT_MASQUERADE_TARGET    "MASQUERADE"
+#define XT_REJECT_TARGET        "REJECT"
+
+/* Match name to simplify our code */
+
+#define XT_MATCH_NAME_TCP       "tcp"
+#define XT_MATCH_NAME_UDP       "udp"
+#define XT_MATCH_NAME_ICMP      "icmp"
+
+/* Table name to simplify our code */
+
+#define XT_TABLE_NAME_FILTER    "filter"
 
 /* For standard target */
 
@@ -154,6 +181,27 @@ struct xt_entry_match
     uint16_t match_size;
   } u;
   unsigned char data[1];
+};
+
+/* TCP matching stuff */
+
+struct xt_tcp
+{
+  uint16_t spts[2]; /* Source port range. */
+  uint16_t dpts[2]; /* Destination port range. */
+  uint8_t option;   /* TCP Option iff non-zero */
+  uint8_t flg_mask; /* TCP flags mask byte */
+  uint8_t flg_cmp;  /* TCP flags compare byte */
+  uint8_t invflags; /* Inverse flags */
+};
+
+/* UDP matching stuff */
+
+struct xt_udp
+{
+  uint16_t spts[2]; /* Source port range. */
+  uint16_t dpts[2]; /* Destination port range. */
+  uint8_t invflags; /* Inverse flags */
 };
 
 #endif /* __INCLUDE_NUTTX_NET_NETFILTER_X_TABLES_H */

--- a/include/nuttx/net/netfilter/x_tables.h
+++ b/include/nuttx/net/netfilter/x_tables.h
@@ -65,6 +65,7 @@
 #define XT_MATCH_NAME_TCP       "tcp"
 #define XT_MATCH_NAME_UDP       "udp"
 #define XT_MATCH_NAME_ICMP      "icmp"
+#define XT_MATCH_NAME_ICMP6     "icmp6"
 
 /* Table name to simplify our code */
 

--- a/net/Kconfig
+++ b/net/Kconfig
@@ -359,6 +359,7 @@ menuconfig NET_6LOWPAN
 source "net/sixlowpan/Kconfig"
 source "net/ipforward/Kconfig"
 source "net/nat/Kconfig"
+source "net/ipfilter/Kconfig"
 source "net/netfilter/Kconfig"
 source "net/ipfrag/Kconfig"
 

--- a/net/Makefile
+++ b/net/Makefile
@@ -47,6 +47,7 @@ include sixlowpan/Make.defs
 include bluetooth/Make.defs
 include ieee802154/Make.defs
 include devif/Make.defs
+include ipfilter/Make.defs
 include ipforward/Make.defs
 include nat/Make.defs
 include netfilter/Make.defs

--- a/net/devif/devif_poll.c
+++ b/net/devif/devif_poll.c
@@ -47,6 +47,7 @@
 #include "mld/mld.h"
 #include "ipforward/ipforward.h"
 #include "sixlowpan/sixlowpan.h"
+#include "ipfilter/ipfilter.h"
 #include "ipfrag/ipfrag.h"
 #include "inet/inet.h"
 
@@ -183,6 +184,32 @@ static void devif_packet_conversion(FAR struct net_driver_s *dev,
 #else
 #  define devif_packet_conversion(dev,pkttype)
 #endif /* CONFIG_NET_6LOWPAN */
+
+/****************************************************************************
+ * Name: devif_poll_local_out
+ *
+ * Description:
+ *   Generic callback before device output to build L2 headers before sending
+ *   with packet filter for TCP/UDP/ICMP(v6).
+ *
+ * Assumptions:
+ *   This function is called from the MAC device driver with the network
+ *   locked.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_IPFILTER
+static int devif_poll_local_out(FAR struct net_driver_s *dev,
+                                devif_poll_callback_t callback)
+{
+  /* Maybe we need to reply REJECT to ourself, so filter before loopback. */
+
+  ipfilter_out(dev);
+  return devif_poll_out(dev, callback);
+}
+#else
+#  define devif_poll_local_out(dev, callback) devif_poll_out(dev, callback)
+#endif /* CONFIG_NET_IPFILTER */
 
 /****************************************************************************
  * Name: devif_poll_pkt_connections
@@ -397,7 +424,7 @@ static inline int devif_poll_icmp(FAR struct net_driver_s *dev,
 
           /* Call back into the driver */
 
-          bstop = devif_poll_out(dev, callback);
+          bstop = devif_poll_local_out(dev, callback);
         }
     }
 
@@ -444,7 +471,7 @@ static inline int devif_poll_icmpv6(FAR struct net_driver_s *dev,
 
           /* Call back into the driver */
 
-          bstop = devif_poll_out(dev, callback);
+          bstop = devif_poll_local_out(dev, callback);
         }
     }
   while (!bstop && (conn = icmpv6_nextconn(conn)) != NULL);
@@ -581,7 +608,7 @@ static int devif_poll_udp_connections(FAR struct net_driver_s *dev,
 
           /* Call back into the driver */
 
-          bstop = devif_poll_out(dev, callback);
+          bstop = devif_poll_local_out(dev, callback);
         }
     }
 
@@ -626,7 +653,7 @@ static inline int devif_poll_tcp_connections(FAR struct net_driver_s *dev,
 
           /* Call back into the driver */
 
-          bstop = devif_poll_out(dev, callback);
+          bstop = devif_poll_local_out(dev, callback);
         }
     }
 

--- a/net/devif/ipv6_input.c
+++ b/net/devif/ipv6_input.c
@@ -52,6 +52,7 @@
 #include "ipforward/ipforward.h"
 #include "inet/inet.h"
 #include "devif/devif.h"
+#include "ipfilter/ipfilter.h"
 #include "ipfrag/ipfrag.h"
 
 /****************************************************************************
@@ -420,6 +421,14 @@ static int ipv6_in(FAR struct net_driver_s *dev)
     }
 #endif
 
+#ifdef CONFIG_NET_IPFILTER
+  if (ipv6_filter_in(dev) != IPFILTER_TARGET_ACCEPT)
+    {
+      ninfo("Drop/Reject INPUT packet due to filter.\n");
+      goto done;
+    }
+#endif
+
   /* Now process the incoming packet according to the protocol specified in
    * the next header IPv6 field.
    */
@@ -518,7 +527,11 @@ static int ipv6_in(FAR struct net_driver_s *dev)
         goto drop;
     }
 
-#ifdef CONFIG_NET_IPFORWARD
+#ifdef CONFIG_NET_IPFILTER
+  ipfilter_out(dev);
+#endif
+
+#if defined(CONFIG_NET_IPFORWARD) || defined(CONFIG_NET_IPFILTER)
 done:
 #endif
 

--- a/net/inet/ipv6_getsockopt.c
+++ b/net/inet/ipv6_getsockopt.c
@@ -33,6 +33,7 @@
 #include <nuttx/net/net.h>
 
 #include "mld/mld.h"
+#include "netfilter/iptables.h"
 #include "inet/inet.h"
 #include "udp/udp.h"
 
@@ -75,6 +76,13 @@ int ipv6_getsockopt(FAR struct socket *psock, int option,
   net_lock();
   switch (option)
     {
+#ifdef CONFIG_NET_IPTABLES
+      case IP6T_SO_GET_INFO:
+      case IP6T_SO_GET_ENTRIES:
+        ret = ip6t_getsockopt(psock, option, value, value_len);
+        break;
+#endif
+
       case IPV6_TCLASS:
         {
           FAR struct socket_conn_s *conn = psock->s_conn;

--- a/net/inet/ipv6_setsockopt.c
+++ b/net/inet/ipv6_setsockopt.c
@@ -33,6 +33,7 @@
 #include <nuttx/net/net.h>
 
 #include "netdev/netdev.h"
+#include "netfilter/iptables.h"
 #include "mld/mld.h"
 #include "inet/inet.h"
 #include "socket/socket.h"
@@ -215,6 +216,12 @@ int ipv6_setsockopt(FAR struct socket *psock, int option,
             }
         }
         break;
+
+#ifdef CONFIG_NET_IPTABLES
+      case IP6T_SO_SET_REPLACE:
+        ret = ip6t_setsockopt(psock, option, value, value_len);
+        break;
+#endif
 
       default:
         nerr("ERROR: Unrecognized IPv6 option: %d\n", option);

--- a/net/ipfilter/CMakeLists.txt
+++ b/net/ipfilter/CMakeLists.txt
@@ -1,0 +1,27 @@
+# ##############################################################################
+# net/ipfilter/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+# IP filter source files
+
+if(CONFIG_NET_IPFILTER)
+
+  target_sources(net PRIVATE ipfilter.c)
+
+endif()

--- a/net/ipfilter/Kconfig
+++ b/net/ipfilter/Kconfig
@@ -1,0 +1,16 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config NET_IPFILTER
+	bool "Enable IP packet filter (firewall)"
+	default n
+	depends on NET_IPv4 || NET_IPv6
+	---help---
+		Enable this option to enable the IP packet filter (firewall).
+		Our IP packet filter is a netfilter-like packet filter that
+		operates on the IP (and transport) layer.  It is a stateless
+		packet filter that can be used to filter packets based on
+		source and destination IP addresses, source and destination
+		ports, protocol, and interface.

--- a/net/ipfilter/Make.defs
+++ b/net/ipfilter/Make.defs
@@ -1,0 +1,32 @@
+############################################################################
+# net/ipfilter/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+# IP filter source files
+
+ifeq ($(CONFIG_NET_IPFILTER),y)
+
+NET_CSRCS += ipfilter.c
+
+# Include IP filter build support
+
+DEPPATH += --dep-path ipfilter
+VPATH += :ipfilter
+
+endif

--- a/net/ipfilter/ipfilter.c
+++ b/net/ipfilter/ipfilter.c
@@ -1,0 +1,632 @@
+/****************************************************************************
+ * net/ipfilter/ipfilter.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <debug.h>
+
+#include <nuttx/kmalloc.h>
+#include <nuttx/net/icmpv6.h>
+#include <nuttx/net/netdev.h>
+#include <nuttx/net/udp.h>
+#include <nuttx/queue.h>
+
+#include "icmp/icmp.h"
+#include "icmpv6/icmpv6.h"
+#include "ipfilter/ipfilter.h"
+#include "utils/utils.h"
+
+#ifdef CONFIG_NET_IPFILTER
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define SPORT_MATCH(entry, sport) \
+  (((sport) >= (entry)->match.tcpudp.sports[0] && \
+    (sport) <= (entry)->match.tcpudp.sports[1]) ^ (entry)->inv_sport)
+
+#define DPORT_MATCH(entry, dport) \
+  (((dport) >= (entry)->match.tcpudp.dports[0] && \
+    (dport) <= (entry)->match.tcpudp.dports[1]) ^ (entry)->inv_dport)
+
+#define ICMP_MATCH(entry, icmphdr) \
+  (((entry)->match.icmp.type == 0xFF || \
+    (entry)->match.icmp.type == (icmphdr)->type) ^ (entry)->inv_icmp)
+
+/* Getting L4 header from IPv4/IPv6 header. */
+
+#define IPv4_L4HDR(ipv4) \
+  ((FAR void *)((FAR uint8_t *)(ipv4) + (((ipv4)->vhl & IPv4_HLMASK) << 2)))
+
+#define IPv6_L4HDR(ipv6, proto) \
+  ((FAR void *)(net_ipv6_payload((FAR struct ipv6_hdr_s *)(ipv6), &(proto))))
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_IPv4
+static sq_queue_t g_ipv4_filters[IPFILTER_CHAIN_MAX];
+#endif
+#ifdef CONFIG_NET_IPv6
+static sq_queue_t g_ipv6_filters[IPFILTER_CHAIN_MAX];
+#endif
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: ipfilter_match_device
+ *
+ * Description:
+ *   Match the packet with the filter entries on devices.
+ *
+ * Input Parameters:
+ *   entry  - The filter entry to match
+ *   indev  - The network device that the packet comes from
+ *   outdev - The network device that the packet goes to
+ *
+ * Returned Value:
+ *   true  - The input packet is matched
+ *   false - The input packet is not matched
+ *
+ ****************************************************************************/
+
+static bool ipfilter_match_device(FAR const struct ipfilter_entry_s *entry,
+                                  FAR const struct net_driver_s *indev,
+                                  FAR const struct net_driver_s *outdev)
+{
+  bool matched;
+
+  if (indev != NULL && entry->indev != NULL)
+    {
+      matched = (indev == entry->indev) ^ entry->inv_indev;
+      if (!matched)
+        {
+          return false;
+        }
+    }
+
+  if (outdev != NULL && entry->outdev != NULL)
+    {
+      matched = (outdev == entry->outdev) ^ entry->inv_outdev;
+      if (!matched)
+        {
+          return false;
+        }
+    }
+
+  return true;
+}
+
+/****************************************************************************
+ * Name: ipfilter_match_proto
+ *
+ * Description:
+ *
+ * Input Parameters:
+ *
+ * Returned Value:
+ *
+ ****************************************************************************/
+
+static bool ipfilter_match_proto(FAR const struct ipfilter_entry_s *entry,
+                                 FAR const void *l4hdr, uint8_t proto)
+{
+  bool matched;
+
+  if (entry->proto)
+    {
+      matched = (entry->proto == proto) ^ entry->inv_proto;
+      if (!matched)
+        {
+          return false;
+        }
+    }
+
+  if (entry->inv_proto)
+    {
+      /* Cannot match port/type for inversed proto, just success. */
+
+      return true;
+    }
+
+  switch (proto)
+    {
+      case IP_PROTO_TCP:
+      case IP_PROTO_UDP:
+        if (entry->match_tcpudp)
+          {
+            /* Ports in TCP & UDP headers have same offset. */
+
+            FAR const struct udp_hdr_s *udp = l4hdr;
+            return SPORT_MATCH(entry, NTOHS(udp->srcport)) &&
+                   DPORT_MATCH(entry, NTOHS(udp->destport));
+          }
+
+      case IP_PROTO_ICMP:
+        if (entry->match_icmp)
+          {
+            FAR const struct icmp_hdr_s *icmp = l4hdr;
+            return ICMP_MATCH(entry, icmp);
+          }
+
+      case IP_PROTO_ICMP6:
+        if (entry->match_icmp)
+          {
+            FAR const struct icmpv6_hdr_s *icmpv6 = l4hdr;
+            return ICMP_MATCH(entry, icmpv6);
+          }
+
+      default:
+        return true;
+    }
+}
+
+/****************************************************************************
+ * Name: ipv4_filter_match / ipv6_filter_match
+ *
+ * Description:
+ *   Match the input packet with the filter entries in the specified chain.
+ *
+ * Input Parameters:
+ *   indev     - The network device that the packet comes from
+ *   outdev    - The network device that the packet goes to
+ *   ipv4/ipv6 - The IPv4/IPv6 header
+ *   chain     - The chain to match the filter entries
+ *
+ * Returned Value:
+ *   IPFILTER_TARGET_ACCEPT(0)  - The input packet is accepted
+ *   IPFILTER_TARGET_DROP(-1)   - The input packet needs to be dropped
+ *   IPFILTER_TARGET_REJECT(-2) - The input packet is rejected
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_IPv4
+static int ipv4_filter_match(FAR const struct net_driver_s *indev,
+                             FAR const struct net_driver_s *outdev,
+                             FAR const struct ipv4_hdr_s *ipv4,
+                             enum ipfilter_chain_e chain)
+{
+  FAR const struct ipv4_filter_entry_s *filter;
+  FAR const sq_queue_t *queue = &g_ipv4_filters[chain];
+  FAR const sq_entry_t *entry;
+  FAR const void *l4hdr;
+  in_addr_t ipaddr;
+  bool matched;
+
+  /* Handle unexpected status, return ACCEPT to indicate doing nothing. */
+
+  if ((indev == NULL && outdev == NULL) || ipv4 == NULL)
+    {
+      return IPFILTER_TARGET_ACCEPT;
+    }
+
+  l4hdr = IPv4_L4HDR(ipv4);
+
+  sq_for_every(queue, entry)
+    {
+      filter = (FAR struct ipv4_filter_entry_s *)entry;
+
+      /* Match device */
+
+      if (!ipfilter_match_device(&filter->common, indev, outdev))
+        {
+          continue;
+        }
+
+      /* Match addresses */
+
+      ipaddr  = net_ip4addr_conv32(ipv4->srcipaddr);
+      matched = net_ipv4addr_maskcmp(filter->sip, ipaddr, filter->smsk)
+                ^ filter->common.inv_srcip;
+      if (!matched)
+        {
+          continue;
+        }
+
+      ipaddr  = net_ip4addr_conv32(ipv4->destipaddr);
+      matched = net_ipv4addr_maskcmp(filter->dip, ipaddr, filter->dmsk)
+                ^ filter->common.inv_dstip;
+      if (!matched)
+        {
+          continue;
+        }
+
+      /* Match protocol */
+
+      if (!ipfilter_match_proto(&filter->common, l4hdr, ipv4->proto))
+        {
+          continue;
+        }
+
+      /* Return the target action if matched. */
+
+      return filter->common.target;
+    }
+
+  /* Normally there should be a default rule in chain, won't reach here. */
+
+  ninfo("No filter matched, maybe uninitialized.\n");
+  return IPFILTER_TARGET_ACCEPT;
+}
+#endif
+
+#ifdef CONFIG_NET_IPv6
+static int ipv6_filter_match(FAR const struct net_driver_s *indev,
+                             FAR const struct net_driver_s *outdev,
+                             FAR const struct ipv6_hdr_s *ipv6,
+                             enum ipfilter_chain_e chain)
+{
+  FAR const struct ipv6_filter_entry_s *filter;
+  FAR const sq_queue_t *queue = &g_ipv6_filters[chain];
+  FAR const sq_entry_t *entry;
+  FAR const void *l4hdr;
+  uint8_t proto;
+  bool matched;
+
+  /* Handle unexpected status, return ACCEPT to indicate doing nothing. */
+
+  if ((indev == NULL && outdev == NULL) || ipv6 == NULL)
+    {
+      return IPFILTER_TARGET_ACCEPT;
+    }
+
+  l4hdr = IPv6_L4HDR(ipv6, proto);
+
+  sq_for_every(queue, entry)
+    {
+      filter = (FAR struct ipv6_filter_entry_s *)entry;
+
+      /* Match device */
+
+      if (!ipfilter_match_device(&filter->common, indev, outdev))
+        {
+          continue;
+        }
+
+      /* Match addresses */
+
+      matched = net_ipv6addr_maskcmp(filter->sip, ipv6->srcipaddr,
+                                     filter->smsk)
+                ^ filter->common.inv_srcip;
+      if (!matched)
+        {
+          continue;
+        }
+
+      matched = net_ipv6addr_maskcmp(filter->dip, ipv6->destipaddr,
+                                     filter->dmsk)
+                ^ filter->common.inv_dstip;
+      if (!matched)
+        {
+          continue;
+        }
+
+      /* Match protocol */
+
+      if (!ipfilter_match_proto(&filter->common, l4hdr, proto))
+        {
+          continue;
+        }
+
+      /* Return the target action if matched. */
+
+      return filter->common.target;
+    }
+
+  /* Normally there should be a default rule in chain, won't reach here. */
+
+  ninfo("No filter matched, maybe uninitialized.\n");
+  return IPFILTER_TARGET_ACCEPT;
+}
+#endif
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: ipfilter_cfg_alloc
+ *
+ * Description:
+ *   Allocate a new filter configuration entry for the given address family.
+ *
+ * Input Parameters:
+ *   family - The address family of the filter entry
+ *
+ * Returned Value:
+ *   A pointer to the newly allocated filter entry.  NULL is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+FAR struct ipfilter_entry_s *ipfilter_cfg_alloc(sa_family_t family)
+{
+  /* We may optimize alloc / free later if we really have lots of configs. */
+
+#ifdef CONFIG_NET_IPv4
+  if (family == PF_INET)
+    {
+      return kmm_zalloc(sizeof(struct ipv4_filter_entry_s));
+    }
+#endif
+
+#ifdef CONFIG_NET_IPv6
+  if (family == PF_INET6)
+    {
+      return kmm_zalloc(sizeof(struct ipv6_filter_entry_s));
+    }
+#endif
+
+  return NULL;
+}
+
+/****************************************************************************
+ * Name: ipfilter_cfg_add
+ *
+ * Description:
+ *   Add a new filter configuration entry for the given address family to the
+ *   end of specified chain.
+ *
+ * Input Parameters:
+ *   entry  - The filter entry to add
+ *   family - The address family of the filter entry
+ *   chain  - The chain to add the filter entry to
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void ipfilter_cfg_add(FAR struct ipfilter_entry_s *entry,
+                      sa_family_t family, enum ipfilter_chain_e chain)
+{
+#ifdef CONFIG_NET_IPv4
+  if (family == PF_INET)
+    {
+      sq_addlast((FAR sq_entry_t *)entry, &g_ipv4_filters[chain]);
+    }
+#endif
+
+#ifdef CONFIG_NET_IPv6
+  if (family == PF_INET6)
+    {
+      sq_addlast((FAR sq_entry_t *)entry, &g_ipv6_filters[chain]);
+    }
+#endif
+}
+
+/****************************************************************************
+ * Name: ipfilter_cfg_clear
+ *
+ * Description:
+ *   Clear all filter configuration entries for the given address family from
+ *   the specified chain.
+ *
+ * Input Parameters:
+ *   family - The address family of the filter entry to clear
+ *   chain  - The chain to clear the filter entries from
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void ipfilter_cfg_clear(sa_family_t family, enum ipfilter_chain_e chain)
+{
+#ifdef CONFIG_NET_IPv4
+  if (family == PF_INET)
+    {
+      FAR sq_queue_t *queue = &g_ipv4_filters[chain];
+      while (!sq_empty(queue))
+        {
+          kmm_free(sq_remfirst(queue));
+        }
+    }
+#endif
+
+#ifdef CONFIG_NET_IPv6
+  if (family == PF_INET6)
+    {
+      FAR sq_queue_t *queue = &g_ipv6_filters[chain];
+      while (!sq_empty(queue))
+        {
+          kmm_free(sq_remfirst(queue));
+        }
+    }
+#endif
+}
+
+/****************************************************************************
+ * Name: ipv4_filter_in / ipv6_filter_in
+ *
+ * Description:
+ *   Handling IPv4/IPv6 filter on local input.  Do nothing if the input
+ *   packet is accepted, set d_len to 0 if the input packet needs to be
+ *   dropped, and set d_iob to reject reply if the input packet is rejected.
+ *
+ * Input Parameters:
+ *   dev - The network device that the packet comes from
+ *
+ * Returned Value:
+ *   IPFILTER_TARGET_ACCEPT(0)  - The input packet is accepted
+ *   IPFILTER_TARGET_DROP(-1)   - The input packet needs to be dropped
+ *   IPFILTER_TARGET_REJECT(-2) - The input packet is rejected
+ *
+ * Assumptions:
+ *   The network is locked.  The d_iob and d_len in the dev are set.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_IPv4
+int ipv4_filter_in(FAR struct net_driver_s *dev)
+{
+  FAR struct ipv4_hdr_s *ipv4 = IPv4BUF;
+  int ret = ipv4_filter_match(dev, NULL, ipv4, IPFILTER_CHAIN_INPUT);
+
+  if (ret == IPFILTER_TARGET_DROP)
+    {
+      dev->d_len = 0;
+    }
+
+  if (ret == IPFILTER_TARGET_REJECT)
+    {
+      /* TODO: Support more --reject-with types later. */
+
+      icmp_reply(dev, ICMP_DEST_UNREACHABLE, ICMP_NET_UNREACH);
+    }
+
+  return ret;
+}
+#endif
+
+#ifdef CONFIG_NET_IPv6
+int ipv6_filter_in(FAR struct net_driver_s *dev)
+{
+  FAR struct ipv6_hdr_s *ipv6 = IPv6BUF;
+  int ret = ipv6_filter_match(dev, NULL, ipv6, IPFILTER_CHAIN_INPUT);
+
+  if (ret == IPFILTER_TARGET_DROP)
+    {
+      dev->d_len = 0;
+    }
+
+  if (ret == IPFILTER_TARGET_REJECT)
+    {
+      /* TODO: Support more --reject-with types later. */
+
+      icmpv6_reply(dev, ICMPv6_DEST_UNREACHABLE, ICMPv6_ADDR_UNREACH, 0);
+    }
+
+  return ret;
+}
+#endif
+
+/****************************************************************************
+ * Name: ipfilter_out
+ *
+ * Description:
+ *   Handling filter on local output.  Do nothing if the output packet
+ *   is accepted, set d_len to 0 if the output packet needs to be dropped,
+ *   and set d_iob to reject reply if the output packet is rejected.
+ *
+ * Input Parameters:
+ *   dev - The network device that the packet goes to
+ *
+ * Returned Value:
+ *   None
+ *
+ * Assumptions:
+ *   The network is locked.  Only IPv4 and IPv6 packets call this function.
+ *
+ ****************************************************************************/
+
+void ipfilter_out(FAR struct net_driver_s *dev)
+{
+  if (dev->d_iob == NULL || dev->d_len == 0)
+    {
+      return;
+    }
+
+#ifdef CONFIG_NET_IPv4
+  if (IFF_IS_IPv4(dev->d_flags))
+    {
+      FAR struct ipv4_hdr_s *ipv4 = IPv4BUF;
+      int ret = ipv4_filter_match(NULL, dev, ipv4, IPFILTER_CHAIN_OUTPUT);
+
+      if (ret == IPFILTER_TARGET_DROP)
+        {
+          dev->d_len = 0;
+        }
+
+      if (ret == IPFILTER_TARGET_REJECT)
+        {
+          icmp_reply(dev, ICMP_DEST_UNREACHABLE, ICMP_NET_UNREACH);
+        }
+    }
+#endif
+
+#ifdef CONFIG_NET_IPv6
+  if (IFF_IS_IPv6(dev->d_flags))
+    {
+      FAR struct ipv6_hdr_s *ipv6 = IPv6BUF;
+      int ret = ipv6_filter_match(NULL, dev, ipv6, IPFILTER_CHAIN_OUTPUT);
+
+      if (ret == IPFILTER_TARGET_DROP)
+        {
+          dev->d_len = 0;
+        }
+
+      if (ret == IPFILTER_TARGET_REJECT)
+        {
+          icmpv6_reply(dev, ICMPv6_DEST_UNREACHABLE, ICMPv6_ADDR_UNREACH, 0);
+        }
+    }
+#endif
+}
+
+/****************************************************************************
+ * Name: ipv4_filter_fwd / ipv6_filter_fwd
+ *
+ * Description:
+ *   Handling IPv4/IPv6 filter on forwarding.  Just return the target action,
+ *   and relies on the caller to do the actual drop / reject.
+ *
+ * Input Parameters:
+ *   indev     - The network device that the packet comes from
+ *   outdev    - The network device that the packet goes to
+ *   ipv4/ipv6 - The IPv4/IPv6 header
+ *
+ * Returned Value:
+ *   IPFILTER_TARGET_ACCEPT(0)  - The input packet is accepted
+ *   IPFILTER_TARGET_DROP(-1)   - The input packet needs to be dropped
+ *   IPFILTER_TARGET_REJECT(-2) - The input packet needs to be rejected
+ *
+ * Assumptions:
+ *   The network is locked.
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_NET_IPFORWARD) && defined(CONFIG_NET_IPv4)
+int ipv4_filter_fwd(FAR struct net_driver_s *indev,
+                    FAR struct net_driver_s *outdev,
+                    FAR struct ipv4_hdr_s *ipv4)
+{
+  return ipv4_filter_match(indev, outdev, ipv4, IPFILTER_CHAIN_FORWARD);
+}
+#endif
+
+#if defined(CONFIG_NET_IPFORWARD) && defined(CONFIG_NET_IPv6)
+int ipv6_filter_fwd(FAR struct net_driver_s *indev,
+                    FAR struct net_driver_s *outdev,
+                    FAR struct ipv6_hdr_s *ipv6)
+{
+  return ipv6_filter_match(indev, outdev, ipv6, IPFILTER_CHAIN_FORWARD);
+}
+#endif
+
+#endif /* CONFIG_NET_IPFILTER */

--- a/net/ipfilter/ipfilter.h
+++ b/net/ipfilter/ipfilter.h
@@ -1,0 +1,266 @@
+/****************************************************************************
+ * net/ipfilter/ipfilter.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __NET_IPFILTER_IPFILTER_H
+#define __NET_IPFILTER_IPFILTER_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+
+#include <nuttx/compiler.h>
+#include <nuttx/net/ip.h>
+
+#ifdef CONFIG_NET_IPFILTER
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define IPFILTER_TARGET_ACCEPT (0)
+#define IPFILTER_TARGET_DROP   (-1)
+#define IPFILTER_TARGET_REJECT (-2)
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+enum ipfilter_chain_e
+{
+  IPFILTER_CHAIN_INPUT   = 0, /* = NF_IP_LOCAL_IN  - 1, Input chain */
+  IPFILTER_CHAIN_FORWARD = 1, /* = NF_IP_FORWARD   - 1, Forward chain */
+  IPFILTER_CHAIN_OUTPUT  = 2, /* = NF_IP_LOCAL_OUT - 1, Output chain */
+  IPFILTER_CHAIN_MAX
+};
+
+/* The filter configuration entry */
+
+struct ipfilter_entry_s
+{
+  FAR struct ipfilter_entry_s *flink;
+
+  FAR struct net_driver_s *indev;
+  FAR struct net_driver_s *outdev;
+
+  union /* Matches in host byte order (because it's range) */
+  {
+    struct
+    {
+      uint16_t sports[2]; /* Source port range */
+      uint16_t dports[2]; /* Destination port range */
+    } tcpudp;
+
+    struct
+    {
+      uint8_t type;       /* Type to match, 0xFF = ALL (Same as Linux) */
+    } icmp;
+  } match;
+
+  uint8_t proto;          /* Protocol to match, 0 = ALL (Same as Linux) */
+  int8_t  target;
+
+  /* Match flags, whether we need to match protocol in detail */
+
+  uint8_t match_tcpudp : 1; /* Match TCP/UDP */
+  uint8_t match_icmp   : 1; /* Match ICMP */
+
+  /* Inverse flags */
+
+  uint8_t inv_indev  : 1; /* Inverse input device */
+  uint8_t inv_outdev : 1; /* Inverse output device */
+  uint8_t inv_proto  : 1; /* Inverse protocol */
+  uint8_t inv_srcip  : 1; /* Inverse source IP */
+  uint8_t inv_dstip  : 1; /* Inverse destination IP */
+  uint8_t inv_sport  : 1; /* Inverse source port */
+  uint8_t inv_dport  : 1; /* Inverse destination port */
+  uint8_t inv_icmp   : 1; /* Inverse ICMP type */
+};
+
+struct ipv4_filter_entry_s
+{
+  struct ipfilter_entry_s common;
+
+  /* Addresses in network byte order */
+
+  in_addr_t sip;
+  in_addr_t dip;
+  in_addr_t smsk;
+  in_addr_t dmsk;
+};
+
+struct ipv6_filter_entry_s
+{
+  struct ipfilter_entry_s common;
+
+  /* Addresses in network byte order */
+
+  net_ipv6addr_t sip;
+  net_ipv6addr_t dip;
+  net_ipv6addr_t smsk;
+  net_ipv6addr_t dmsk;
+};
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: ipfilter_cfg_alloc
+ *
+ * Description:
+ *   Allocate a new filter configuration entry for the given address family.
+ *
+ * Input Parameters:
+ *   family - The address family of the filter entry
+ *
+ * Returned Value:
+ *   A pointer to the newly allocated filter entry.  NULL is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+FAR struct ipfilter_entry_s *ipfilter_cfg_alloc(sa_family_t family);
+
+/****************************************************************************
+ * Name: ipfilter_cfg_add
+ *
+ * Description:
+ *   Add a new filter configuration entry for the given address family to the
+ *   end of specified chain.
+ *
+ * Input Parameters:
+ *   entry  - The filter entry to add
+ *   family - The address family of the filter entry
+ *   chain  - The chain to add the filter entry to
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void ipfilter_cfg_add(FAR struct ipfilter_entry_s *entry,
+                      sa_family_t family, enum ipfilter_chain_e chain);
+
+/****************************************************************************
+ * Name: ipfilter_cfg_clear
+ *
+ * Description:
+ *   Clear all filter configuration entries for the given address family from
+ *   the specified chain.
+ *
+ * Input Parameters:
+ *   family - The address family of the filter entry to clear
+ *   chain  - The chain to clear the filter entries from
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void ipfilter_cfg_clear(sa_family_t family, enum ipfilter_chain_e chain);
+
+/****************************************************************************
+ * Name: ipv4_filter_in / ipv6_filter_in
+ *
+ * Description:
+ *   Handling IPv4/IPv6 filter on local input.  Do nothing if the input
+ *   packet is accepted, set d_len to 0 if the input packet needs to be
+ *   dropped, and set d_iob to reject reply if the input packet is rejected.
+ *
+ * Input Parameters:
+ *   dev - The network device that the packet comes from
+ *
+ * Returned Value:
+ *   IPFILTER_TARGET_ACCEPT(0)  - The input packet is accepted
+ *   IPFILTER_TARGET_DROP(-1)   - The input packet needs to be dropped
+ *   IPFILTER_TARGET_REJECT(-2) - The input packet is rejected
+ *
+ * Assumptions:
+ *   The network is locked.  The d_iob and d_len in the dev are set.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_IPv4
+int ipv4_filter_in(FAR struct net_driver_s *dev);
+#endif
+#ifdef CONFIG_NET_IPv6
+int ipv6_filter_in(FAR struct net_driver_s *dev);
+#endif
+
+/****************************************************************************
+ * Name: ipfilter_out
+ *
+ * Description:
+ *   Handling filter on local output.  Do nothing if the output packet
+ *   is accepted, set d_len to 0 if the output packet needs to be dropped,
+ *   and set d_iob to reject reply if the output packet is rejected.
+ *
+ * Input Parameters:
+ *   dev - The network device that the packet goes to
+ *
+ * Returned Value:
+ *   None
+ *
+ * Assumptions:
+ *   The network is locked.  Only IPv4 and IPv6 packets call this function.
+ *
+ ****************************************************************************/
+
+void ipfilter_out(FAR struct net_driver_s *dev);
+
+/****************************************************************************
+ * Name: ipv4_filter_fwd / ipv6_filter_fwd
+ *
+ * Description:
+ *   Handling IPv4/IPv6 filter on forwarding.  Just return the target action,
+ *   and relies on the caller to do the actual drop / reject.
+ *
+ * Input Parameters:
+ *   indev     - The network device that the packet comes from
+ *   outdev    - The network device that the packet goes to
+ *   ipv4/ipv6 - The IPv4/IPv6 header
+ *
+ * Returned Value:
+ *   IPFILTER_TARGET_ACCEPT(0)  - The input packet is accepted
+ *   IPFILTER_TARGET_DROP(-1)   - The input packet needs to be dropped
+ *   IPFILTER_TARGET_REJECT(-2) - The input packet needs to be rejected
+ *
+ * Assumptions:
+ *   The network is locked.
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_NET_IPFORWARD) && defined(CONFIG_NET_IPv4)
+int ipv4_filter_fwd(FAR struct net_driver_s *indev,
+                    FAR struct net_driver_s *outdev,
+                    FAR struct ipv4_hdr_s *ipv4);
+#endif
+#if defined(CONFIG_NET_IPFORWARD) && defined(CONFIG_NET_IPv6)
+int ipv6_filter_fwd(FAR struct net_driver_s *indev,
+                    FAR struct net_driver_s *outdev,
+                    FAR struct ipv6_hdr_s *ipv6);
+#endif
+
+#endif /* CONFIG_NET_IPFILTER */
+#endif /* __NET_IPFILTER_IPFILTER_H */

--- a/net/ipforward/ipv6_forward.c
+++ b/net/ipforward/ipv6_forward.c
@@ -40,6 +40,7 @@
 #include "sixlowpan/sixlowpan.h"
 #include "devif/devif.h"
 #include "icmpv6/icmpv6.h"
+#include "ipfilter/ipfilter.h"
 #include "ipforward/ipforward.h"
 
 #if defined(CONFIG_NET_IPFORWARD) && defined(CONFIG_NET_IPv6)
@@ -336,6 +337,27 @@ static int ipv6_dev_forward(FAR struct net_driver_s *dev,
   int hdrsize;
 #endif
   int ret;
+
+#ifdef CONFIG_NET_IPFILTER
+  /* Do filter before forwarding, to make sure we drop silently before
+   * replying any other errors.
+   */
+
+  ret = ipv6_filter_fwd(dev, fwddev, ipv6);
+  if (ret < 0)
+    {
+      ninfo("Drop/Reject FORWARD packet due to filter %d\n", ret);
+
+      /* Let ipv6_forward reply the reject. */
+
+      if (ret == IPFILTER_TARGET_REJECT)
+        {
+          ret = -ENETUNREACH;
+        }
+
+      goto errout;
+    }
+#endif
 
   /* If the interface isn't "up", we can't forward. */
 

--- a/net/netfilter/CMakeLists.txt
+++ b/net/netfilter/CMakeLists.txt
@@ -28,5 +28,9 @@ if(CONFIG_NET_IPTABLES)
     list(APPEND SRCS ipt_nat.c)
   endif()
 
+  if(CONFIG_NET_IPFILTER)
+    list(APPEND SRCS ipt_filter.c)
+  endif()
+
   target_sources(net PRIVATE ${SRCS})
 endif()

--- a/net/netfilter/CMakeLists.txt
+++ b/net/netfilter/CMakeLists.txt
@@ -22,7 +22,13 @@
 
 if(CONFIG_NET_IPTABLES)
 
-  set(SRCS ipt_sockopt.c)
+  if(CONFIG_NET_IPv4)
+    list(APPEND SRCS ipt_sockopt.c)
+  endif()
+
+  if(CONFIG_NET_IPv6)
+    list(APPEND SRCS ip6t_sockopt.c)
+  endif()
 
   if(CONFIG_NET_NAT)
     list(APPEND SRCS ipt_nat.c)

--- a/net/netfilter/Kconfig
+++ b/net/netfilter/Kconfig
@@ -4,9 +4,9 @@
 #
 
 config NET_IPTABLES
-	bool "Iptables Interface"
+	bool "Iptables & Ip6tables Interface"
 	default y
-	depends on NET_IPv4
+	depends on NET_IPv4 || NET_IPv6
 	depends on NET_SOCKOPTS
 	depends on NET_NAT || NET_IPFILTER
 	---help---

--- a/net/netfilter/Kconfig
+++ b/net/netfilter/Kconfig
@@ -8,6 +8,6 @@ config NET_IPTABLES
 	default y
 	depends on NET_IPv4
 	depends on NET_SOCKOPTS
-	depends on NET_NAT # May change dependency if we have firewall later.
+	depends on NET_NAT || NET_IPFILTER
 	---help---
 		Enable or disable iptables compatible interface (for NAT).

--- a/net/netfilter/Make.defs
+++ b/net/netfilter/Make.defs
@@ -28,6 +28,10 @@ ifeq ($(CONFIG_NET_NAT),y)
 NET_CSRCS += ipt_nat.c
 endif
 
+ifeq ($(CONFIG_NET_IPFILTER),y)
+NET_CSRCS += ipt_filter.c
+endif
+
 # Include Netfilter build support
 
 DEPPATH += --dep-path netfilter

--- a/net/netfilter/Make.defs
+++ b/net/netfilter/Make.defs
@@ -22,7 +22,13 @@
 
 ifeq ($(CONFIG_NET_IPTABLES),y)
 
+ifeq ($(CONFIG_NET_IPv4),y)
 NET_CSRCS += ipt_sockopt.c
+endif
+
+ifeq ($(CONFIG_NET_IPv6),y)
+NET_CSRCS += ip6t_sockopt.c
+endif
 
 ifeq ($(CONFIG_NET_NAT),y)
 NET_CSRCS += ipt_nat.c

--- a/net/netfilter/ip6t_sockopt.c
+++ b/net/netfilter/ip6t_sockopt.c
@@ -78,6 +78,9 @@ struct ip6t_error_entry_s
 
 static struct ip6t_table_s g_tables[] =
 {
+#ifdef CONFIG_NET_IPFILTER
+  {NULL, ip6t_filter_init, ip6t_filter_apply},
+#endif
 };
 
 /****************************************************************************
@@ -381,7 +384,7 @@ FAR struct ip6t_replace *ip6t_alloc_table(FAR const char *table,
       repl->underflow[hook] = repl->hook_entry[hook];
 
       entry->target.verdict = -NF_ACCEPT - 1;
-      IPT_FILL_ENTRY(entry, XT_STANDARD_TARGET);
+      IP6T_FILL_ENTRY(entry, XT_STANDARD_TARGET);
 
       entry++;
     }
@@ -389,7 +392,7 @@ FAR struct ip6t_replace *ip6t_alloc_table(FAR const char *table,
   error_entry = (FAR struct ip6t_error_entry_s *)entry;
   strlcpy(error_entry->target.errorname, XT_ERROR_TARGET,
           sizeof(error_entry->target.errorname));
-  IPT_FILL_ENTRY(error_entry, XT_ERROR_TARGET);
+  IP6T_FILL_ENTRY(error_entry, XT_ERROR_TARGET);
 
   return repl;
 }

--- a/net/netfilter/ip6t_sockopt.c
+++ b/net/netfilter/ip6t_sockopt.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * net/netfilter/ipt_sockopt.c
+ * net/netfilter/ip6t_sockopt.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -47,11 +47,11 @@
  * init/apply functions.
  */
 
-struct ipt_table_s
+struct ip6t_table_s
 {
-  FAR struct ipt_replace *repl;
-  FAR struct ipt_replace *(*init_func)(void);
-  FAR int (*apply_func)(FAR const struct ipt_replace *);
+  FAR struct ip6t_replace *repl;
+  FAR struct ip6t_replace *(*init_func)(void);
+  FAR int (*apply_func)(FAR const struct ip6t_replace *);
 };
 
 /* Following structs represent the layout of an entry with standard/error
@@ -60,15 +60,15 @@ struct ipt_table_s
  * might be matches between entry and target in data from user space.
  */
 
-struct ipt_standard_entry_s
+struct ip6t_standard_entry_s
 {
-  struct ipt_entry entry;
+  struct ip6t_entry entry;
   struct xt_standard_target target;
 };
 
-struct ipt_error_entry_s
+struct ip6t_error_entry_s
 {
-  struct ipt_entry entry;
+  struct ip6t_entry entry;
   struct xt_error_target target;
 };
 
@@ -76,14 +76,8 @@ struct ipt_error_entry_s
  * Private Data
  ****************************************************************************/
 
-static struct ipt_table_s g_tables[] =
+static struct ip6t_table_s g_tables[] =
 {
-#ifdef CONFIG_NET_NAT
-  {NULL, ipt_nat_init, ipt_nat_apply},
-#endif
-#ifdef CONFIG_NET_IPFILTER
-  {NULL, ipt_filter_init, ipt_filter_apply},
-#endif
 };
 
 /****************************************************************************
@@ -91,14 +85,14 @@ static struct ipt_table_s g_tables[] =
  ****************************************************************************/
 
 /****************************************************************************
- * Name: ipt_table_init
+ * Name: ip6t_table_init
  *
  * Description:
  *   Try initialize the table data if not initialized.
  *
  ****************************************************************************/
 
-static void ipt_table_init(FAR struct ipt_table_s *table)
+static void ip6t_table_init(FAR struct ip6t_table_s *table)
 {
   if (table->repl == NULL && table->init_func != NULL)
     {
@@ -107,19 +101,19 @@ static void ipt_table_init(FAR struct ipt_table_s *table)
 }
 
 /****************************************************************************
- * Name: ipt_table
+ * Name: ip6t_table
  *
  * Description:
  *   Find table data by table name.
  *
  ****************************************************************************/
 
-static FAR struct ipt_table_s *ipt_table(FAR const char *name)
+static FAR struct ip6t_table_s *ip6t_table(FAR const char *name)
 {
   int i;
   for (i = 0; i < nitems(g_tables); i++)
     {
-      ipt_table_init(&g_tables[i]);
+      ip6t_table_init(&g_tables[i]);
       if (g_tables[i].repl != NULL &&
           strcmp(g_tables[i].repl->name, name) == 0)
         {
@@ -131,16 +125,16 @@ static FAR struct ipt_table_s *ipt_table(FAR const char *name)
 }
 
 /****************************************************************************
- * Name: ipt_table_repl
+ * Name: ip6t_table_repl
  *
  * Description:
  *   Find table data by table name.
  *
  ****************************************************************************/
 
-static FAR struct ipt_replace *ipt_table_repl(FAR const char *name)
+static FAR struct ip6t_replace *ip6t_table_repl(FAR const char *name)
 {
-  FAR struct ipt_table_s *table = ipt_table(name);
+  FAR struct ip6t_table_s *table = ip6t_table(name);
   if (table)
     {
       return table->repl;
@@ -153,23 +147,23 @@ static FAR struct ipt_replace *ipt_table_repl(FAR const char *name)
  * Name: get_info
  *
  * Description:
- *   Fill table info into ipt_getinfo structure.
+ *   Fill table info into ip6t_getinfo structure.
  *
  * Input Parameters:
  *   get, len - The parameters from getsockopt.
  *
  ****************************************************************************/
 
-static int get_info(FAR struct ipt_getinfo *get, FAR socklen_t *len)
+static int get_info(FAR struct ip6t_getinfo *get, FAR socklen_t *len)
 {
-  FAR struct ipt_replace *repl;
+  FAR struct ip6t_replace *repl;
 
   if (*len != sizeof(*get))
     {
       return -EINVAL;
     }
 
-  repl = ipt_table_repl(get->name);
+  repl = ip6t_table_repl(get->name);
   if (repl == NULL)
     {
       return -ENOENT;
@@ -188,23 +182,23 @@ static int get_info(FAR struct ipt_getinfo *get, FAR socklen_t *len)
  * Name: get_entries
  *
  * Description:
- *   Fill entry info into ipt_get_entries structure.
+ *   Fill entry info into ip6t_get_entries structure.
  *
  * Input Parameters:
  *   get, len - The parameters from getsockopt.
  *
  ****************************************************************************/
 
-static int get_entries(FAR struct ipt_get_entries *get, FAR socklen_t *len)
+static int get_entries(FAR struct ip6t_get_entries *get, FAR socklen_t *len)
 {
-  FAR struct ipt_replace *repl;
+  FAR struct ip6t_replace *repl;
 
   if (*len < sizeof(*get) || *len != sizeof(*get) + get->size)
     {
       return -EINVAL;
     }
 
-  repl = ipt_table_repl(get->name);
+  repl = ip6t_table_repl(get->name);
   if (repl == NULL)
     {
       return -ENOENT;
@@ -224,22 +218,22 @@ static int get_entries(FAR struct ipt_get_entries *get, FAR socklen_t *len)
  * Name: check_replace
  *
  * Description:
- *   Check whether an ipt_replace structure from user space is valid.
+ *   Check whether an ip6t_replace structure from user space is valid.
  *
  * Input Parameters:
- *   repl - The ipt_replace structure to check.
+ *   repl - The ip6t_replace structure to check.
  *
  * Returned Value:
  *   OK if repl is valid, otherwise -EINVAL.
  *
  ****************************************************************************/
 
-static int check_replace(FAR const struct ipt_replace *repl)
+static int check_replace(FAR const struct ip6t_replace *repl)
 {
-  FAR struct ipt_entry *entry;
+  FAR struct ip6t_entry *entry;
   unsigned int entry_count = 0;
 
-  ipt_entry_for_every(entry, repl->entries, repl->size)
+  ip6t_entry_for_every(entry, repl->entries, repl->size)
     {
       entry_count++;
       if (entry->next_offset == 0)
@@ -269,11 +263,12 @@ static int check_replace(FAR const struct ipt_replace *repl)
  *
  ****************************************************************************/
 
-static int replace_entries(FAR const struct ipt_replace *repl, socklen_t len)
+static int replace_entries(FAR const struct ip6t_replace *repl,
+                           socklen_t len)
 {
   int ret;
-  FAR struct ipt_replace *new_repl;
-  FAR struct ipt_table_s *table = ipt_table(repl->name);
+  FAR struct ip6t_replace *new_repl;
+  FAR struct ip6t_table_s *table = ip6t_table(repl->name);
 
   if (table == NULL || table->repl == NULL)
     {
@@ -321,7 +316,7 @@ static int replace_entries(FAR const struct ipt_replace *repl, socklen_t len)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: ipt_alloc_table
+ * Name: ip6t_alloc_table
  *
  * Description:
  *   Allocate an initial table info with valid_hooks specified.
@@ -333,16 +328,16 @@ static int replace_entries(FAR const struct ipt_replace *repl, socklen_t len)
  *   valid_hooks - The valid_hooks of the table, it's a bitmask.
  *
  * Returned Value:
- *   Newly generated ipt_replace structure.
+ *   Newly generated ip6t_replace structure.
  *
  ****************************************************************************/
 
-FAR struct ipt_replace *ipt_alloc_table(FAR const char *table,
-                                        unsigned int valid_hooks)
+FAR struct ip6t_replace *ip6t_alloc_table(FAR const char *table,
+                                          unsigned int valid_hooks)
 {
-  FAR struct ipt_replace *repl;
-  FAR struct ipt_standard_entry_s *entry;
-  FAR struct ipt_error_entry_s *error_entry;
+  FAR struct ip6t_replace *repl;
+  FAR struct ip6t_standard_entry_s *entry;
+  FAR struct ip6t_error_entry_s *error_entry;
   size_t entry_size;
   unsigned int hook;
   unsigned int num_hooks;
@@ -356,11 +351,11 @@ FAR struct ipt_replace *ipt_alloc_table(FAR const char *table,
 
   /* There will be num_hooks entries with standard target (ACCEPT). */
 
-  entry_size = num_hooks * sizeof(struct ipt_standard_entry_s);
+  entry_size = num_hooks * sizeof(struct ip6t_standard_entry_s);
 
   /* An error target as final entry. */
 
-  entry_size += sizeof(struct ipt_error_entry_s);
+  entry_size += sizeof(struct ip6t_error_entry_s);
 
   repl = kmm_zalloc(sizeof(*repl) + entry_size);
   if (repl == NULL)
@@ -373,7 +368,7 @@ FAR struct ipt_replace *ipt_alloc_table(FAR const char *table,
   repl->num_entries = num_hooks + 1;
   repl->size = entry_size;
 
-  entry = (FAR struct ipt_standard_entry_s *)(repl->entries);
+  entry = (FAR struct ip6t_standard_entry_s *)(repl->entries);
 
   for (hook = 0; hook < NF_INET_NUMHOOKS; hook++)
     {
@@ -391,7 +386,7 @@ FAR struct ipt_replace *ipt_alloc_table(FAR const char *table,
       entry++;
     }
 
-  error_entry = (FAR struct ipt_error_entry_s *)entry;
+  error_entry = (FAR struct ip6t_error_entry_s *)entry;
   strlcpy(error_entry->target.errorname, XT_ERROR_TARGET,
           sizeof(error_entry->target.errorname));
   IPT_FILL_ENTRY(error_entry, XT_ERROR_TARGET);
@@ -400,19 +395,19 @@ FAR struct ipt_replace *ipt_alloc_table(FAR const char *table,
 }
 
 /****************************************************************************
- * Name: ipt_setsockopt
+ * Name: ip6t_setsockopt
  *
  * Description:
  *   setsockopt function of iptables.
  *
  ****************************************************************************/
 
-int ipt_setsockopt(FAR struct socket *psock, int option,
-                   FAR const void *value, socklen_t value_len)
+int ip6t_setsockopt(FAR struct socket *psock, int option,
+                    FAR const void *value, socklen_t value_len)
 {
   switch (option)
     {
-      case IPT_SO_SET_REPLACE:
+      case IP6T_SO_SET_REPLACE:
         return replace_entries(value, value_len);
 
       default:
@@ -421,22 +416,22 @@ int ipt_setsockopt(FAR struct socket *psock, int option,
 }
 
 /****************************************************************************
- * Name: ipt_getsockopt
+ * Name: ip6t_getsockopt
  *
  * Description:
  *   getsockopt function of iptables.
  *
  ****************************************************************************/
 
-int ipt_getsockopt(FAR struct socket *psock, int option,
-                   FAR void *value, FAR socklen_t *value_len)
+int ip6t_getsockopt(FAR struct socket *psock, int option,
+                    FAR void *value, FAR socklen_t *value_len)
 {
   switch (option)
     {
-      case IPT_SO_GET_INFO:
+      case IP6T_SO_GET_INFO:
         return get_info(value, value_len);
 
-      case IPT_SO_GET_ENTRIES:
+      case IP6T_SO_GET_ENTRIES:
         return get_entries(value, value_len);
 
       default:

--- a/net/netfilter/ipt_filter.c
+++ b/net/netfilter/ipt_filter.c
@@ -1,0 +1,408 @@
+/****************************************************************************
+ * net/netfilter/ipt_filter.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <debug.h>
+#include <errno.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <nuttx/kmalloc.h>
+#include <nuttx/net/netfilter/ip_tables.h>
+#include <nuttx/net/netfilter/x_tables.h>
+
+#include "ipfilter/ipfilter.h"
+#include "netdev/netdev.h"
+#include "netfilter/iptables.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define FILTER_VALID_HOOKS ((1 << NF_INET_LOCAL_IN) | \
+                            (1 << NF_INET_FORWARD)  | \
+                            (1 << NF_INET_LOCAL_OUT))
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: convert_chain
+ *
+ * Description:
+ *   Convert iptables chain to ipfilter chain.
+ *
+ ****************************************************************************/
+
+static enum ipfilter_chain_e convert_chain(enum nf_inet_hooks hook)
+{
+  switch (hook)
+    {
+      case NF_INET_LOCAL_IN:
+        return IPFILTER_CHAIN_INPUT;
+
+      case NF_INET_FORWARD:
+        return IPFILTER_CHAIN_FORWARD;
+
+      case NF_INET_LOCAL_OUT:
+      default:
+        return IPFILTER_CHAIN_OUTPUT;
+    }
+}
+
+/****************************************************************************
+ * Name: convert_invflags
+ *
+ * Description:
+ *   Convert iptables invflags to ipfilter invflags.
+ *
+ * Input Parameters:
+ *   entry    - The ipfilter entry to be filled.
+ *   invflags - The iptables invflags to be converted.
+ *
+ ****************************************************************************/
+
+static void convert_invflags(FAR struct ipfilter_entry_s *entry,
+                             uint8_t invflags)
+{
+  entry->inv_indev  = !!(invflags & IPT_INV_VIA_IN);
+  entry->inv_outdev = !!(invflags & IPT_INV_VIA_OUT);
+  entry->inv_proto  = !!(invflags & IPT_INV_PROTO);
+  entry->inv_srcip  = !!(invflags & IPT_INV_SRCIP);
+  entry->inv_dstip  = !!(invflags & IPT_INV_DSTIP);
+}
+
+/****************************************************************************
+ * Name: convert_tcpudp
+ *
+ * Description:
+ *   Convert iptables tcp/udp match to ipfilter entry.
+ *
+ * Input Parameters:
+ *   entry    - The ipfilter entry to be filled.
+ *   spts     - The source ports to be converted.
+ *   dpts     - The destination ports to be converted.
+ *   invflags - The iptables tcp/udp invflags to be converted.
+ *
+ ****************************************************************************/
+
+static void convert_tcpudp(FAR struct ipfilter_entry_s *entry,
+                           uint16_t spts[2], uint16_t dpts[2],
+                           uint8_t invflags)
+{
+  entry->match.tcpudp.sports[0] = spts[0];
+  entry->match.tcpudp.sports[1] = spts[1];
+  entry->match.tcpudp.dports[0] = dpts[0];
+  entry->match.tcpudp.dports[1] = dpts[1];
+
+  entry->inv_sport = !!(invflags & XT_TCP_INV_SRCPT);
+  entry->inv_dport = !!(invflags & XT_TCP_INV_DSTPT);
+
+  entry->match_tcpudp = 1;
+}
+
+/****************************************************************************
+ * Name: convert_icmp
+ *
+ * Description:
+ *   Convert iptables icmp match to ipfilter entry.
+ *
+ * Input Parameters:
+ *   entry    - The ipfilter entry to be filled.
+ *   type     - The icmp type to be converted.
+ *   invflags - The iptables icmp invflags to be converted.
+ *
+ ****************************************************************************/
+
+static void convert_icmp(FAR struct ipfilter_entry_s *entry, uint8_t type,
+                         uint8_t invflags)
+{
+  entry->match.icmp.type = type;
+  entry->inv_icmp = !!(invflags & IPT_ICMP_INV);
+  entry->match_icmp = 1;
+}
+
+/****************************************************************************
+ * Name: convert_target
+ *
+ * Description:
+ *   Convert iptables target to ipfilter target.
+ *
+ * Input Parameters:
+ *   target - The iptables target to be converted.
+ *
+ * Returned Value:
+ *   The converted ipfilter target.
+ *
+ ****************************************************************************/
+
+static uint8_t convert_target(FAR const struct xt_entry_target *target)
+{
+  if (strcmp(target->u.user.name, XT_REJECT_TARGET) == 0)
+    {
+      return IPFILTER_TARGET_REJECT;
+    }
+
+  if (strcmp(target->u.user.name, XT_STANDARD_TARGET) == 0)
+    {
+      int verdict = ((FAR const struct xt_standard_target *)target)->verdict;
+      verdict = -verdict - 1;
+
+      if (verdict == NF_ACCEPT)
+        {
+          return IPFILTER_TARGET_ACCEPT;
+        }
+      else if (verdict == NF_DROP)
+        {
+          return IPFILTER_TARGET_DROP;
+        }
+    }
+
+  nwarn("WARNING: Unsupported target %s\n", target->u.user.name);
+  return IPFILTER_TARGET_DROP;
+}
+
+/****************************************************************************
+ * Name: convert_entry
+ *
+ * Description:
+ *   Convert iptables entry to ipfilter entry.
+ *
+ * Input Parameters:
+ *   entry - The iptables entry to be converted.
+ *
+ * Returned Value:
+ *   The converted ipfilter entry.
+ *
+ ****************************************************************************/
+
+static FAR struct ipv4_filter_entry_s *
+convert_entry(FAR const struct ipt_entry *entry)
+{
+  FAR const struct xt_entry_match *match;
+  FAR const struct xt_entry_target *target;
+  FAR struct ipv4_filter_entry_s *filter =
+              (FAR struct ipv4_filter_entry_s *)ipfilter_cfg_alloc(PF_INET);
+  if (filter == NULL)
+    {
+      return NULL;
+    }
+
+  match  = IPT_MATCH(entry);
+  target = IPT_TARGET(entry);
+
+  /* Convert common fields */
+
+  filter->sip  = entry->ip.src.s_addr;
+  filter->dip  = entry->ip.dst.s_addr;
+  filter->smsk = entry->ip.smsk.s_addr;
+  filter->dmsk = entry->ip.dmsk.s_addr;
+
+  filter->common.indev  = netdev_findbyname(entry->ip.iniface);
+  filter->common.outdev = netdev_findbyname(entry->ip.outiface);
+  filter->common.proto  = entry->ip.proto;
+  filter->common.target = convert_target(target);
+
+  convert_invflags(&filter->common, entry->ip.invflags);
+
+  /* Convert match fields */
+
+  if (entry->target_offset < sizeof(struct xt_entry_match))
+    {
+      ninfo("No match inside entry, skip match conversion.\n");
+      goto skip_match;
+    }
+
+  switch (entry->ip.proto)
+    {
+      case IPPROTO_TCP:
+        if (strcmp(match->u.user.name, XT_MATCH_NAME_TCP) == 0)
+          {
+            FAR struct xt_tcp *tcp = (FAR struct xt_tcp *)(match + 1);
+            convert_tcpudp(&filter->common, tcp->spts, tcp->dpts,
+                           tcp->invflags);
+          }
+        break;
+
+      case IPPROTO_UDP:
+        if (strcmp(match->u.user.name, XT_MATCH_NAME_TCP) == 0)
+          {
+            FAR struct xt_udp *udp = (FAR struct xt_udp *)(match + 1);
+            convert_tcpudp(&filter->common, udp->spts, udp->dpts,
+                           udp->invflags);
+          }
+        break;
+
+      case IPPROTO_ICMP:
+        if (strcmp(match->u.user.name, XT_MATCH_NAME_ICMP) == 0)
+          {
+            FAR struct ipt_icmp *icmp = (FAR struct ipt_icmp *)(match + 1);
+            convert_icmp(&filter->common, icmp->type, icmp->invflags);
+          }
+        break;
+
+      default:
+        break;
+    }
+
+skip_match:
+  return filter;
+}
+
+/****************************************************************************
+ * Name: adjust_filter
+ *
+ * Description:
+ *   Adjust filter config according to the iptables config.
+ *
+ * Input Parameters:
+ *   repl - The config got from user space to control filter table.
+ *
+ ****************************************************************************/
+
+static void adjust_filter(FAR const struct ipt_replace *repl)
+{
+  FAR const struct ipt_entry *entry;
+  FAR const uint8_t *head;
+  enum ipfilter_chain_e chain;
+  enum nf_inet_hooks hook;
+  size_t size;
+
+  for (hook = NF_INET_LOCAL_IN; hook <= NF_INET_LOCAL_OUT; hook++)
+    {
+      /* Clear all filter config first. */
+
+      chain = convert_chain(hook);
+      ipfilter_cfg_clear(PF_INET, chain);
+
+      /* Set filter config according to iptables config. */
+
+      head = (FAR const uint8_t *)repl->entries + repl->hook_entry[hook];
+      size = repl->underflow[hook] - repl->hook_entry[hook];
+
+      /* We need the underflow entry as the default of the chain. */
+
+      size++;
+
+      ipt_entry_for_every(entry, head, size)
+        {
+          FAR struct ipv4_filter_entry_s *filter = convert_entry(entry);
+          if (filter != NULL)
+            {
+              ipfilter_cfg_add(&filter->common, PF_INET, chain);
+            }
+          else
+            {
+              nwarn("WARNING: Failed to convert entry!\n");
+            }
+        }
+    }
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: ipt_filter_init
+ *
+ * Description:
+ *   Init filter table data.
+ *
+ ****************************************************************************/
+
+FAR struct ipt_replace *ipt_filter_init(void)
+{
+  return ipt_alloc_table(XT_TABLE_NAME_FILTER, FILTER_VALID_HOOKS);
+}
+
+/****************************************************************************
+ * Name: ipt_filter_apply
+ *
+ * Description:
+ *   Try to apply filter rules, will do nothing if failed.
+ *
+ * Input Parameters:
+ *   repl - The config got from user space to control filter table.
+ *
+ ****************************************************************************/
+
+int ipt_filter_apply(FAR const struct ipt_replace *repl)
+{
+  FAR const struct ipt_entry *entry;
+  FAR const struct xt_entry_match *match;
+  FAR const struct xt_entry_target *target;
+
+  /* Check config first. */
+
+  ipt_entry_for_every(entry, repl->entries, repl->size)
+    {
+      match  = IPT_MATCH(entry);
+      target = IPT_TARGET(entry);
+
+      /* Check match type matches the protocol */
+
+      if (entry->target_offset >= sizeof(struct xt_entry_match))
+        {
+          if (strcmp(match->u.user.name, XT_MATCH_NAME_TCP) == 0 &&
+              entry->ip.proto != IPPROTO_TCP)
+            {
+              nwarn("WARNING: TCP match for non-TCP protocol\n");
+              return -EINVAL;
+            }
+
+          if (strcmp(match->u.user.name, XT_MATCH_NAME_UDP) == 0 &&
+              entry->ip.proto != IPPROTO_UDP)
+            {
+              nwarn("WARNING: UDP match for non-UDP protocol\n");
+              return -EINVAL;
+            }
+
+          if (strcmp(match->u.user.name, XT_MATCH_NAME_ICMP) == 0 &&
+              entry->ip.proto != IPPROTO_ICMP)
+            {
+              nwarn("WARNING: ICMP match for non-ICMP protocol\n");
+              return -EINVAL;
+            }
+        }
+
+      /* Check target type */
+
+      if (strcmp(target->u.user.name, XT_REJECT_TARGET) != 0 &&
+          strcmp(target->u.user.name, XT_STANDARD_TARGET) != 0 &&
+          strcmp(target->u.user.name, XT_ERROR_TARGET) != 0)
+        {
+          nwarn("WARNING: Unsupported target %s\n", target->u.user.name);
+          return -EINVAL;
+        }
+    }
+
+  /* Set config table into ip filter. */
+
+  adjust_filter(repl);
+
+  return OK;
+}

--- a/net/netfilter/ipt_sockopt.c
+++ b/net/netfilter/ipt_sockopt.c
@@ -81,6 +81,9 @@ static struct ipt_table_s g_tables[] =
 #ifdef CONFIG_NET_NAT
   {NULL, ipt_nat_init, ipt_nat_apply},
 #endif
+#ifdef CONFIG_NET_IPFILTER
+  {NULL, ipt_filter_init, ipt_filter_apply},
+#endif
 };
 
 /****************************************************************************

--- a/net/netfilter/iptables.h
+++ b/net/netfilter/iptables.h
@@ -29,6 +29,7 @@
 
 #include <nuttx/net/net.h>
 #include <nuttx/net/netfilter/ip_tables.h>
+#include <nuttx/net/netfilter/ip6_tables.h>
 
 #ifdef CONFIG_NET_IPTABLES
 
@@ -44,8 +45,14 @@
  *
  ****************************************************************************/
 
+#ifdef CONFIG_NET_IPv4
 int ipt_setsockopt(FAR struct socket *psock, int option,
                    FAR const void *value, socklen_t value_len);
+#endif
+#ifdef CONFIG_NET_IPv6
+int ip6t_setsockopt(FAR struct socket *psock, int option,
+                    FAR const void *value, socklen_t value_len);
+#endif
 
 /****************************************************************************
  * Name: ipt_getsockopt
@@ -55,8 +62,14 @@ int ipt_setsockopt(FAR struct socket *psock, int option,
  *
  ****************************************************************************/
 
+#ifdef CONFIG_NET_IPv4
 int ipt_getsockopt(FAR struct socket *psock, int option,
                    FAR void *value, FAR socklen_t *value_len);
+#endif
+#ifdef CONFIG_NET_IPv6
+int ip6t_getsockopt(FAR struct socket *psock, int option,
+                    FAR void *value, FAR socklen_t *value_len);
+#endif
 
 /****************************************************************************
  * Name: ipt_alloc_table
@@ -75,8 +88,14 @@ int ipt_getsockopt(FAR struct socket *psock, int option,
  *
  ****************************************************************************/
 
+#ifdef CONFIG_NET_IPv4
 FAR struct ipt_replace *ipt_alloc_table(FAR const char *table,
                                         unsigned int valid_hooks);
+#endif
+#ifdef CONFIG_NET_IPv6
+FAR struct ip6t_replace *ip6t_alloc_table(FAR const char *table,
+                                          unsigned int valid_hooks);
+#endif
 
 /****************************************************************************
  * Name: ipt_nat_init

--- a/net/netfilter/iptables.h
+++ b/net/netfilter/iptables.h
@@ -105,5 +105,32 @@ FAR struct ipt_replace *ipt_nat_init(void);
 int ipt_nat_apply(FAR const struct ipt_replace *repl);
 #endif
 
+/****************************************************************************
+ * Name: ipt_filter_init
+ *
+ * Description:
+ *   Init filter table data.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_IPFILTER
+FAR struct ipt_replace *ipt_filter_init(void);
+#endif
+
+/****************************************************************************
+ * Name: ipt_filter_apply
+ *
+ * Description:
+ *   Try to apply filter rules, will do nothing if failed.
+ *
+ * Input Parameters:
+ *   repl - The config got from user space to control filter table.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_IPFILTER
+int ipt_filter_apply(FAR const struct ipt_replace *repl);
+#endif
+
 #endif /* CONFIG_NET_IPTABLES */
 #endif /* __NET_NETFILTER_IPTABLES_H */

--- a/net/netfilter/iptables.h
+++ b/net/netfilter/iptables.h
@@ -133,7 +133,12 @@ int ipt_nat_apply(FAR const struct ipt_replace *repl);
  ****************************************************************************/
 
 #ifdef CONFIG_NET_IPFILTER
+#  ifdef CONFIG_NET_IPv4
 FAR struct ipt_replace *ipt_filter_init(void);
+#  endif
+#  ifdef CONFIG_NET_IPv6
+FAR struct ip6t_replace *ip6t_filter_init(void);
+#  endif
 #endif
 
 /****************************************************************************
@@ -148,7 +153,12 @@ FAR struct ipt_replace *ipt_filter_init(void);
  ****************************************************************************/
 
 #ifdef CONFIG_NET_IPFILTER
+#  ifdef CONFIG_NET_IPv4
 int ipt_filter_apply(FAR const struct ipt_replace *repl);
+#  endif
+#  ifdef CONFIG_NET_IPv6
+int ip6t_filter_apply(FAR const struct ip6t_replace *repl);
+#  endif
 #endif
 
 #endif /* CONFIG_NET_IPTABLES */


### PR DESCRIPTION
## Summary

Patches included:
- net: Support IP packet filter
- net/netfilter: Add filter table in iptables.
- net: Add set/getsockopt options compatible with ip6tables
- net/netfilter: Add filter table in ip6tables
- Documentation: Add docs for ipfilter

Add a firewall compatible with Linux's iptables and ip6tables, with chains at similar points in the packet processing path. More details and examples are in the doc.

```
   NIC ──> ipv[46]_input ─┬─> ipv[46]_forward ──> [FORWARD CHAIN] ──> devif_poll_out ──> NIC
                          │                                                 ^
                          │                  ┌─>  tcp  ─┐                   │
                          │                  ├─>  udp  ─┤                   │
                          └─> [INPUT CHAIN] ─┼─> icmp  ─┼─> [OUTPUT CHAIN] ─┘
                                             ├─> icmp6 ─┤
                                             └─>  ...  ─┘
```


## Impact

Changes limited in `net/ipfilter`(firewall) `net/netfilter` (interface) and minimized in other modules, all controlled by `CONFIG_NET_IPFILTER`

## Testing

Together with https://github.com/apache/nuttx-apps/pull/2415

