### PR TITLE
BMI270 typo fix

### DIFF
--- a/drivers/sensors/bmi270_base.c
+++ b/drivers/sensors/bmi270_base.c
@@ -30,7 +30,7 @@
  * Public Data
  ****************************************************************************/
 
-/* BMI270 configuration file - provided by BOSH */
+/* BMI270 configuration file - provided by BOSCH */
 
 const uint8_t g_bmi270_config_file[] =
 {


### PR DESCRIPTION
## Summary
Little typo in the spelling of Bosch.

## Impact
None.

## Testing
Not Applicable.
