### PR TITLE
arch/risc-v/include/elf.f: Support coredump for rv32 and rv64 targets.

### DIFF
--- a/arch/risc-v/include/elf.h
+++ b/arch/risc-v/include/elf.h
@@ -86,6 +86,9 @@
 #define ARCH_ELFDATA          1
 #define ARCH_ELF_RELCNT       8
 
+#define EM_ARCH               EM_RISCV
+#define EF_FLAG               0
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/
@@ -102,6 +105,14 @@ struct arch_elfdata_s
   hi20_rels[ARCH_ELF_RELCNT];
 };
 typedef struct arch_elfdata_s arch_elfdata_t;
+
+struct user_pt_regs
+{
+  uintreg_t regs[32];
+};
+
+#define ELF_NGREG (sizeof(struct user_pt_regs) / sizeof(uintreg_t))
+typedef uintreg_t elf_gregset_t[ELF_NGREG];
 
 #endif /* __ASSEMBLY__ */
 #endif /* __ARCH_RISCV_INCLUDE_ELF_H */

--- a/arch/risc-v/src/common/riscv_tcbinfo.c
+++ b/arch/risc-v/src/common/riscv_tcbinfo.c
@@ -34,7 +34,7 @@
 
 static const uint16_t g_reg_offs[] =
 {
-  UINT16_MAX,                       /* x0 */
+  TCB_REG_OFF(REG_EPC_NDX),
   TCB_REG_OFF(REG_X1_NDX),
   TCB_REG_OFF(REG_X2_NDX),
   TCB_REG_OFF(REG_X3_NDX),
@@ -66,7 +66,6 @@ static const uint16_t g_reg_offs[] =
   TCB_REG_OFF(REG_X29_NDX),
   TCB_REG_OFF(REG_X30_NDX),
   TCB_REG_OFF(REG_X31_NDX),
-  TCB_REG_OFF(REG_EPC_NDX),
 
 #if 0
 #  ifdef CONFIG_ARCH_FPU


### PR DESCRIPTION
## Summary

Adds the missing elf_gregset_t type definition so pr_regs field can be resolved. Coredumps can be produced for both 32 and 64 bit targets.

## Impact

Can produce coredumps for postmortem or runtime analysis.

## Testing

`rv-virt:nsh` and `rv-virt:nsh64` with:

```
CONFIG_BOARD_COREDUMP_SYSLOG=y
CONFIG_ELF_COREDUMP=y
CONFIG_SYSTEM_COREDUMP=y
```

And our custom Litex based target which also uses `CONFIG_BUILD_KERNEL`. Although system coredump is not available in user context.

Using the same procedure outlined in: https://nuttx.incubator.apache.org/docs/latest/guides/coredump.html

Example gdb session:

```
GNU gdb (Ubuntu 12.1-0ubuntu1~22.04) 12.1
Copyright (C) 2022 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from nuttx/nuttx...

warning: core file may not match specified executable file.
[New process 2]
[New LWP 1]
[New LWP 2]
Core was generated by `'.
#0  0x80006c54 in up_idle () at common/riscv_idle.c:75
75      }
[Current thread is 1 (process 2)]
(gdb) info threads
  Id   Target Id         Frame 
* 1    process 2         0x80006c54 in up_idle () at common/riscv_idle.c:75
  2    LWP 1             sys_call2 (nbr=2, parm2=2147708528, parm1=2147704744) at /workspaces/nuttx-clean/nuttx/include/arch/syscall.h:227
  3    LWP 2             elf_emit_tcb_note (cinfo=0x80037954, tcb=0x80036e70) at libelf/libelf_coredump.c:283
(gdb) thread 3
[Switching to thread 3 (LWP 2)]
#0  elf_emit_tcb_note (cinfo=0x80037954, tcb=0x80036e70) at libelf/libelf_coredump.c:283
283       if (regs != NULL)
(gdb) info reg
ra             0x80011cba       0x80011cba <elf_emit_tcb_note+278>
sp             0x80037760       0x80037760
gp             0x0      0x0
tp             0x0      0x0
t0             0x8003fee9       -2147221783
t1             0x1b     27
t2             0x2000   8192
fp             0x80037954       0x80037954
s1             0x80034000       -2147270656
a0             0x80034380       -2147269760
a1             0x80037778       -2147256456
a2             0x20     32
a3             0xde     222
a4             0x0      0
a5             0x80036e70       -2147258768
a6             0x80040074       -2147221388
a7             0x8003feeb       -2147221781
s2             0x80036f10       -2147258608
s3             0x2088   8328
s4             0x80035000       -2147266560
s5             0x80035000       -2147266560
s6             0xc      12
s7             0x70     112
s8             0x0      0
s9             0x0      0
s10            0x0      0
s11            0x0      0
t3             0x0      0
t4             0x80040074       -2147221388
t5             0x2a0000 2752512
t6             0x8003faec       -2147222804
pc             0x80011cba       0x80011cba <elf_emit_tcb_note+278>
(gdb) bt
#0  elf_emit_tcb_note (cinfo=0x80037954, tcb=0x80036e70) at libelf/libelf_coredump.c:283
#1  0x80012034 in elf_emit_stack (cinfo=0x80037954) at libelf/libelf_coredump.c:402
#2  elf_coredump (cinfo=cinfo@entry=0x80037954) at libelf/libelf_coredump.c:623
#3  0x80011150 in elf_dumpbinary (regions=<optimized out>, stream=<optimized out>, pid=<optimized out>) at elf.c:379
#4  0x800110c0 in core_dump (regions=regions@entry=0x0, stream=stream@entry=0x80037ad4, pid=pid@entry=-1) at binfmt_coredump.c:59
#5  0x80016e92 in coredump_now (filename=<optimized out>, pid=-1) at coredump.c:317
#6  coredump_main (argc=argc@entry=2, argv=argv@entry=0x80037240) at coredump.c:419
#7  0x8000455c in nxtask_startup (entrypt=0x80016d26 <coredump_main>, argc=2, argv=0x80037240) at sched/task_startup.c:70
#8  0x800016ee in nxtask_start () at task/task_start.c:112
#9  0x00000000 in ?? ()
Backtrace stopped: frame did not save the PC
```

I'm not sure on the wider implications of the change in `g_reg_offs`. On inspection it looks fine, and the three targets i've tested work.