### PR TITLE
sensors/bmi270: fix bmi270_uorb build

### DIFF
--- a/drivers/sensors/Make.defs
+++ b/drivers/sensors/Make.defs
@@ -67,7 +67,7 @@ endif
 ifeq ($(CONFIG_SENSORS_BMI270),y)
   CSRCS += bmi270_base.c
 ifeq ($(CONFIG_SENSORS_BMI270_UORB),y)
-  CSRCS += bmi270_bmi.c
+  CSRCS += bmi270_uorb.c
 else
   CSRCS += bmi270.c
 endif


### PR DESCRIPTION
## Summary
Fix apparent typo in makefile to build in the bmi270_uorb file.
Mirrors what has been done in the cmake environment.

## Impact
Users of BMI270 UORB building with Make.

## Testing
Build with CONFIG_SENSORS_BMI270_UORB=y.
Without patch - fails.
With patch - passes.
