### PR TITLE
cmake:reuse OpenAMP own CMake script for CMake build

### DIFF
--- a/openamp/.gitignore
+++ b/openamp/.gitignore
@@ -4,3 +4,4 @@
 /open-amp
 /*.zip
 /.openamp_patch
+/detect_64_atomic*

--- a/openamp/libmetal.defs
+++ b/openamp/libmetal.defs
@@ -56,6 +56,20 @@ CSRCS += libmetal/lib/version.c
 
 CFLAGS += -DMETAL_INTERNAL
 
+# Check whether the current toolchain supports 64-bit atomic
+ATOMIC_DETECT_CODE := detect_64_atomic.c
+ATOMIC_DETECT_BIN := detect_64_atomic_bin
+DETECT_ATOMIC_SUPPORT = \
+    echo '\#include <stdatomic.h>' > $(ATOMIC_DETECT_CODE); \
+    echo 'int main() { _Atomic long long x = 0; return x; }' >> $(ATOMIC_DETECT_CODE); \
+    if $(CC) -o $(ATOMIC_DETECT_BIN) $(ATOMIC_DETECT_CODE) 2>/dev/null; then \
+        echo ""; \
+    else \
+        echo "-DNO_ATOMIC_64_SUPPORT"; \
+    fi; \
+
+CFLAGS += $(shell $(DETECT_ATOMIC_SUPPORT))
+
 LIBMETAL_HDRS_SEDEXP := \
 	"s/@PROJECT_VERSION_MAJOR@/0/g; \
 	 s/@PROJECT_VERSION_MINOR@/1/g; \
@@ -105,5 +119,7 @@ ifeq ($(wildcard libmetal/.git),)
 	$(call DELFILE, libmetal.zip)
 endif
 	$(call DELFILE, .libmetal_headers)
+	$(call DELFILE, $(ATOMIC_DETECT_CODE))
+	$(call DELFILE, $(ATOMIC_DETECT_BIN))
 
 endif

--- a/openamp/open-amp.cmake
+++ b/openamp/open-amp.cmake
@@ -86,28 +86,25 @@ if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/open-amp)
   endif()
 endif()
 
-nuttx_add_kernel_library(openamp)
-
 if(CONFIG_OPENAMP_CACHE)
-  target_compile_options(openamp PRIVATE -DVIRTIO_CACHED_BUFFERS)
-  target_compile_options(openamp PRIVATE -DVIRTIO_CACHED_VRINGS)
+  set(WITH_DCACHE_VRINGS ON)
 endif()
 
 if(CONFIG_OPENAMP_RPMSG_DEBUG)
-  target_compile_options(openamp PRIVATE -DRPMSG_DEBUG)
+  add_compile_definitions(RPMSG_DEBUG)
 endif()
 
 if(CONFIG_OPENAMP_VQUEUE_DEBUG)
-  target_compile_options(openamp PRIVATE -DVQUEUE_DEBUG)
+  add_compile_definitions(VQUEUE_DEBUG)
 endif()
 
-target_sources(
-  openamp
-  PRIVATE open-amp/lib/remoteproc/elf_loader.c
-          open-amp/lib/remoteproc/remoteproc.c
-          open-amp/lib/remoteproc/remoteproc_virtio.c
-          open-amp/lib/remoteproc/rsc_table_parser.c
-          open-amp/lib/rpmsg/rpmsg.c
-          open-amp/lib/rpmsg/rpmsg_virtio.c
-          open-amp/lib/virtio/virtio.c
-          open-amp/lib/virtio/virtqueue.c)
+set(WITH_LIBMETAL_FIND OFF)
+
+if(NOT CMAKE_SYSTEM_PROCESSOR)
+  set(CMAKE_SYSTEM_PROCESSOR ${CONFIG_ARCH})
+endif()
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/open-amp
+                 ${CMAKE_CURRENT_BINARY_DIR}/open-amp EXCLUDE_FROM_ALL)
+
+nuttx_add_external_library(open_amp-static MODE KERNEL)


### PR DESCRIPTION
## Summary

- use `nuttx_add_external_library` to reuse OpenAMP CMake scripts for CMake build
- automatically detect `HAVE_STDATOMIC_H` with CMake
- add support for `64-bit` ATOMIC checks to both Makefile and CMake

## Impact

## Testing
CI test
