### PR TITLE
drivers/can/sja1000: fix cmd register write

### DIFF
--- a/drivers/can/sja1000.c
+++ b/drivers/can/sja1000.c
@@ -286,7 +286,8 @@ static void sja1000_reset(struct can_dev_s *dev)
    * Command register can only be modified when in Operation Mode.
    */
 
-  sja1000_write_cmdreg(priv, SJA1000_ABORT_TX_M | SJA1000_CLR_OVERRUN_M);
+  sja1000_putreg(priv,
+      SJA1000_CMD_REG, SJA1000_ABORT_TX_M | SJA1000_CLR_OVERRUN_M);
 
 #ifdef CONFIG_ARCH_HAVE_MULTICPU
   spin_unlock_irqrestore(&priv->lock, flags);


### PR DESCRIPTION
## Summary
Fix a typo to the command register write that was introduced in 695381442584466727c5c74ec46a2ebc04d6ce11

## Impact
Any system using this common SJA1000 driver.

## Testing
Built and tested on the [Digilent ARTY_A7](https://digilent.com/shop/arty-a7-artix-7-fpga-development-board/) development board with an [SJA1000_FDTOL](https://gitlab.fel.cvut.cz/canbus/zynq/sja1000-fdtol) IP core integrated.
