### PR TITLE
tools/ci/docker/linux/Dockerfile: add AVR32 GCC toolchain

### DIFF
--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -119,6 +119,17 @@ RUN mkdir gcc-aarch64-none-elf && \
   | tar -C gcc-aarch64-none-elf --strip-components 1 -xJ
 
 ###############################################################################
+# Build image for tool required by AVR32 builds
+###############################################################################
+FROM nuttx-toolchain-base AS nuttx-toolchain-avr32
+# Download the prebuilt AVR32 GCC toolchain
+RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" apt-get install -y -qq \
+  git
+# Clone Main Repository 
+RUN mkdir -p gcc-avr32-gnu && \
+  git clone --depth 1 https://github.com/ramangopalan/avr32-gnu-toolchain-linux_x86 gcc-avr32-gnu
+
+###############################################################################
 # Build image for tool required by Pinguino builds
 ###############################################################################
 FROM nuttx-toolchain-base AS nuttx-toolchain-pinguino
@@ -260,9 +271,9 @@ RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" apt-get install -y -q
   libssl-dev
 
 RUN mkdir -p cmake && \
-    curl -s -L wget https://cmake.org/files/v3.26/cmake-3.26.0.tar.gz \
-    | tar -C cmake --strip-components=1 -xz && \
-    cd cmake && ./bootstrap && make && make install && rm -rf cmake
+  curl -s -L wget https://cmake.org/files/v3.26/cmake-3.26.0.tar.gz \
+  | tar -C cmake --strip-components=1 -xz && \
+  cd cmake && ./bootstrap && make && make install && rm -rf cmake
 
 RUN dpkg --add-architecture i386
 # This is used for the final images so make sure to not store apt cache
@@ -383,6 +394,10 @@ ENV PATH="/tools/gcc-arm-none-eabi/bin:$PATH"
 COPY --from=nuttx-toolchain-arm64 /tools/gcc-aarch64-none-elf/ gcc-aarch64-none-elf/
 ENV PATH="/tools/gcc-aarch64-none-elf/bin:$PATH"
 
+# AVR32 toolchain
+COPY --from=nuttx-toolchain-avr32 /tools/gcc-avr32-gnu/ gcc-avr32-gnu/
+ENV PATH="/tools/gcc-avr32-gnu/bin:$PATH"
+
 # MIPS toolchain
 COPY --from=nuttx-toolchain-pinguino /tools/pinguino-compilers/p32/ pinguino-compilers/p32/
 ENV PATH="/tools/pinguino-compilers/p32/bin:$PATH"
@@ -438,6 +453,8 @@ RUN mkdir -p /tools/ccache/bin && \
   ln -sf `which ccache` /tools/ccache/bin/arm-none-eabi-g++ && \
   ln -sf `which ccache` /tools/ccache/bin/avr-gcc && \
   ln -sf `which ccache` /tools/ccache/bin/avr-g++ && \
+  ln -sf `which ccache` /tools/ccache/bin/avr32-gcc && \
+  ln -sf `which ccache` /tools/ccache/bin/avr32-g++ && \
   ln -sf `which ccache` /tools/ccache/bin/cc && \
   ln -sf `which ccache` /tools/ccache/bin/c++ && \
   ln -sf `which ccache` /tools/ccache/bin/clang && \


### PR DESCRIPTION
## Summary
Add prebuilt AVR32 GCC toolchain from ramangopalan

https://github.com/ramangopalan/avr32-gnu-toolchain-linux_x86

at32uc3a0: Initial work for SimpleMachines' Mizar32-A #11709

## Impact
none
## Testing
https://github.com/apache/nuttx/actions/runs/9537180645/job/26284964386
