### PR TITLE
arch/risc-v: revise mtimer for rv64ilp32

### DIFF
--- a/arch/risc-v/src/common/riscv_mtimer.c
+++ b/arch/risc-v/src/common/riscv_mtimer.c
@@ -42,8 +42,8 @@
 struct riscv_mtimer_lowerhalf_s
 {
   struct oneshot_lowerhalf_s lower;
-  uintptr_t                  mtime;
-  uintptr_t                  mtimecmp;
+  uintreg_t                  mtime;
+  uintreg_t                  mtimecmp;
   uint64_t                   freq;
   uint64_t                   alarm;
   oneshot_callback_t         callback;
@@ -347,7 +347,7 @@ static int riscv_mtimer_interrupt(int irq, void *context, void *arg)
  ****************************************************************************/
 
 struct oneshot_lowerhalf_s *
-riscv_mtimer_initialize(uintptr_t mtime, uintptr_t mtimecmp,
+riscv_mtimer_initialize(uintreg_t mtime, uintreg_t mtimecmp,
                         int irq, uint64_t freq)
 {
   struct riscv_mtimer_lowerhalf_s *priv;

--- a/arch/risc-v/src/common/riscv_mtimer.h
+++ b/arch/risc-v/src/common/riscv_mtimer.h
@@ -40,7 +40,7 @@ extern "C"
 #endif
 
 struct oneshot_lowerhalf_s *
-riscv_mtimer_initialize(uintptr_t mtime, uintptr_t mtimecmp,
+riscv_mtimer_initialize(uintreg_t mtime, uintreg_t mtimecmp,
                         int irq, uint64_t freq);
 
 #undef EXTERN


### PR DESCRIPTION
## Summary

This revises `mtime` and `mtimecmp` registers address types to support rv64ilp32 ABI.

## Impacts

risc-v port

## Testing

- local checks with `rv-virt`
- CI checks


