### PR TITLE
arm64: align stack pointer and misc update

### DIFF
--- a/arch/arm64/src/common/arm64_head.S
+++ b/arch/arm64/src/common/arm64_head.S
@@ -354,17 +354,18 @@ out:
  */
 
 boot_stage_puts:
+    stp   xzr, x30, [sp, #-16]!
+1:
     ldrb  w0, [x1], #1       /* Load next char */
     cmp   w0, 0
-    beq   1f                 /* Exit on nul */
-    stp   xzr, x30, [sp, #-16]!
+    beq   2f                 /* Exit on nul */
     bl    arm64_lowputc
+    b     1b                 /* Loop */
+2:
     ldp   xzr, x30, [sp], #16
-    b     boot_stage_puts
-1:
     ret
 
-.type boot_low_puts, %function;
+.type boot_stage_puts, %function;
 
 #endif /* !CONFIG_ARCH_EARLY_PRINT */
 

--- a/arch/arm64/src/common/arm64_internal.h
+++ b/arch/arm64/src/common/arm64_internal.h
@@ -165,7 +165,7 @@ extern "C"
     EXTERN char sym[n][size]
 
 #define STACK_PTR_TO_FRAME(type, ptr) \
-    (type *)((uintptr_t)(ptr) - sizeof(type))
+    (type *)STACK_ALIGN_DOWN((uintptr_t)(ptr) - sizeof(type))
 
 #define INTSTACK_SIZE        (CONFIG_ARCH_INTERRUPTSTACK & ~STACK_ALIGN_MASK)
 


### PR DESCRIPTION
## Summary
- 1. minor update to `boot_stage_puts`, save/restore LR out of the loop.
- 2. pointer to stack frame must be aligned.
## Impact
No.
## Testing
Internal project and qemu.