### PR TITLE
arch/arm64: use serr for error log

### DIFF
--- a/arch/arm64/src/common/arm64_cpustart.c
+++ b/arch/arm64/src/common/arm64_cpustart.c
@@ -181,8 +181,8 @@ static void arm64_start_cpu(int cpu_num, char *stack, int stack_sz,
 #ifdef CONFIG_ARCH_HAVE_PSCI
   if (psci_cpu_on(cpu_mpid, (uint64_t)__start))
     {
-      sinfo("Failed to boot secondary CPU core %d (MPID:%#lx)\n", cpu_num,
-            cpu_mpid);
+      serr("Failed to boot secondary CPU core %d (MPID:%#lx)\n", cpu_num,
+           cpu_mpid);
       return;
     }
 #else

--- a/arch/arm64/src/common/arm64_fatal.h
+++ b/arch/arm64/src/common/arm64_fatal.h
@@ -46,7 +46,7 @@
 #define __builtin_unreachable()    \
   do                               \
     {                              \
-      sinfo("Unreachable code\n"); \
+      serr("Unreachable code\n"); \
       PANIC();                     \
     } while (true)
 

--- a/arch/arm64/src/common/arm64_gicv3.c
+++ b/arch/arm64/src/common/arm64_gicv3.c
@@ -852,7 +852,7 @@ static int gic_validate_dist_version(void)
     }
   else
     {
-      sinfo("No GIC version detect\n");
+      serr("No GIC version detect\n");
       return -ENODEV;
     }
 
@@ -871,7 +871,7 @@ static int gic_validate_dist_version(void)
 
   if (typer & GICD_TYPER_MBIS)
     {
-      sinfo("MBIs is present, But No support\n");
+      swarn("MBIs is present, But No support\n");
     }
 
   return 0;
@@ -892,7 +892,7 @@ static int gic_validate_redist_version(void)
   if (reg != GICR_PIDR2_ARCH_GICV3 &&
              reg != GICR_PIDR2_ARCH_GICV4)
     {
-      sinfo("No redistributor present 0x%lx\n", redist_base);
+      serr("No redistributor present 0x%lx\n", redist_base);
       return -ENODEV;
     }
 
@@ -926,7 +926,7 @@ static void arm64_gic_init(void)
   err = gic_validate_redist_version();
   if (err)
     {
-      sinfo("no redistributor detected, giving up ret=%d\n", err);
+      swarn("no redistributor detected, giving up ret=%d\n", err);
       return;
     }
 
@@ -949,7 +949,7 @@ int arm64_gic_initialize(void)
   err = gic_validate_dist_version();
   if (err)
     {
-      sinfo("no distributor detected, giving up ret=%d\n", err);
+      swarn("no distributor detected, giving up ret=%d\n", err);
       return err;
     }
 


### PR DESCRIPTION
## Summary
Use correct log level for errors.

## Impact
No.

## Testing
qemu
