### PR TITLE
risc-v/k230: initial rv64ilp32 support

### DIFF
--- a/arch/risc-v/src/k230/hardware/k230_memorymap.h
+++ b/arch/risc-v/src/k230/hardware/k230_memorymap.h
@@ -27,7 +27,7 @@
 
 /* Devices Base Address */
 
-#define K230_PLIC_BASE    0xF00000000UL
+#define K230_PLIC_BASE    UINT64_C(0xF00000000)
 #define K230_CLINT_BASE   (K230_PLIC_BASE + 0x04000000)
 #define K230_CPU1_BOOTA   0x91102104UL
 #define K230_CPU1_RESET   0x9110100cUL
@@ -46,5 +46,5 @@
 
 /* Enable RV PBMT */
 
-#define MENVCFG_PBMT     (1ul << 62)
+#define MENVCFG_PBMT     (UINT64_C(1) << 62)
 #endif /* __ARCH_RISCV_SRC_K230_HARDWARE_K230_MEMORYMAP_H */

--- a/arch/risc-v/src/k230/k230_hart.c
+++ b/arch/risc-v/src/k230/k230_hart.c
@@ -169,7 +169,7 @@ void k230_hart_big_stop(void)
 
   putreg32(RESET_RQST_BIT | RESET_RQST_ENW, K230_CPU1_RESET);
   up_udelay(RESET_WAIT_USEC);
-  sinfo("reg: %x\n", getreg32(K230_CPU1_RESET));
+  sinfo("reg: %" PRIx32 "\n", getreg32(K230_CPU1_RESET));
 }
 
 /****************************************************************************
@@ -184,7 +184,7 @@ void k230_hart_big_boot(uintptr_t addr)
   /* learned from U-Boot baremetal and RTT sysctl_reset_cpu */
 
   if (addr) putreg32(addr, K230_CPU1_BOOTA);
-  sinfo("addr=%lx\n", addr);
+  sinfo("addr=%"PRIxPTR"\n", addr);
 
   /* 0x10001000 clear DONE bit */
 

--- a/arch/risc-v/src/k230/k230_irq.c
+++ b/arch/risc-v/src/k230/k230_irq.c
@@ -36,7 +36,15 @@
 #include "riscv_ipi.h"
 #include "chip.h"
 
-#define STATUS_LOW  (READ_CSR(CSR_STATUS) & 0xffffffff) /* STATUS low part */
+/****************************************************************************
+ * Preprocessor definitions
+ ****************************************************************************/
+
+/* lower word of STATUS register */
+
+#define STATUS_LOW  (uint32_t)(READ_CSR(CSR_STATUS) & UINT32_MAX)
+#define IE_STS_IRQ  "ie=%"PRIxREG" sts=%"PRIx32" irq=%d\n"
+#define IE_STS_CTX  "ie=%"PRIxREG" sts=%"PRIx32" ctx=%d\n"
 
 /****************************************************************************
  * Public Functions
@@ -70,7 +78,7 @@ void up_irqinitialize(void)
 
   for (id = 1; id <= NR_IRQS; id++)
     {
-      putreg32(1, (uintptr_t)(K230_PLIC_PRIORITY + 4 * id));
+      putreg32(1, K230_PLIC_PRIORITY + 4 * id);
     }
 
   sinfo("prioritized %d irqs\n", NR_IRQS);
@@ -140,7 +148,7 @@ void up_disable_irq(int irq)
         }
     }
 
-  sinfo("ie=%lx sts=%lx irq=%d\n", READ_CSR(CSR_IE), STATUS_LOW, irq);
+  sinfo(IE_STS_IRQ, READ_CSR(CSR_IE), STATUS_LOW, irq);
 }
 
 /****************************************************************************
@@ -184,7 +192,7 @@ void up_enable_irq(int irq)
         }
     }
 
-  sinfo("ie=%lx sts=%lx irq=%d\n", READ_CSR(CSR_IE), STATUS_LOW, irq);
+  sinfo(IE_STS_IRQ, READ_CSR(CSR_IE), STATUS_LOW, irq);
 }
 
 irqstate_t up_irq_enable(void)
@@ -198,8 +206,6 @@ irqstate_t up_irq_enable(void)
   /* Read and enable global interrupts (M/SIE) in m/sstatus */
 
   oldstat = READ_AND_SET_CSR(CSR_STATUS, STATUS_IE);
-  sinfo("ie=%lx sts=%lx ctx=%d\n", READ_CSR(CSR_IE), STATUS_LOW,
-        XCPTCONTEXT_SIZE);
-
+  sinfo(IE_STS_CTX, READ_CSR(CSR_IE), STATUS_LOW, XCPTCONTEXT_SIZE);
   return oldstat;
 }

--- a/arch/risc-v/src/k230/k230_irq_dispatch.c
+++ b/arch/risc-v/src/k230/k230_irq_dispatch.c
@@ -53,7 +53,7 @@
  * riscv_dispatch_irq
  ****************************************************************************/
 
-void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
+void *riscv_dispatch_irq(uintreg_t vector, uintreg_t *regs)
 {
   int irq = (vector >> RV_IRQ_MASK) | (vector & 0xf);
 


### PR DESCRIPTION
## Summary

This adds initial support of rv64ilp32 for K230 device. It allows FLAT build to run on K230 devices.

## Impacts

k230 devices

## Testing

- local test with CanMV230 device
- CI checks