### PR TITLE
driver: add note when driver registers

### DIFF
--- a/fs/driver/fs_registerdriver.c
+++ b/fs/driver/fs_registerdriver.c
@@ -28,6 +28,7 @@
 #include <errno.h>
 
 #include <nuttx/fs/fs.h>
+#include <nuttx/sched_note.h>
 
 #include "inode/inode.h"
 
@@ -64,6 +65,8 @@ int register_driver(FAR const char *path,
 {
   FAR struct inode *node;
   int ret;
+
+  sched_note_mark(NOTE_TAG_DRIVERS, path);
 
   /* Insert a dummy node -- we need to hold the inode semaphore because we
    * will have a momentarily bad structure.


### PR DESCRIPTION
## Summary

Add note mark when a new driver is registered. This can roughly show us how much time every driver initialization takes because normally all drivers are registered sequentially.

![image](https://github.com/apache/nuttx/assets/25867991/1b7ce441-c1f9-43e6-b9a3-9cab125f718b)

## Impact
No

## Testing
Internal project.
