### PR TITLE
pm_runtime: lock use pm_runtime_lock

### DIFF
--- a/drivers/power/pm/pm_runtime.c
+++ b/drivers/power/pm/pm_runtime.c
@@ -29,8 +29,7 @@
 #include <errno.h>
 #include <nuttx/clock.h>
 #include <nuttx/power/pm_runtime.h>
-
-#include "pm.h"
+#include <sched/sched.h>
 
 /****************************************************************************
  * Private Function Prototypes
@@ -45,6 +44,26 @@ static int rpm_changestate(FAR struct pm_runtime_s *rpm, rpm_state_e state);
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
+
+static irqstate_t pm_runtime_lock(FAR rmutex_t *lock)
+{
+  if (!up_interrupt_context() && !sched_idletask())
+    {
+      nxrmutex_lock(lock);
+    }
+
+  return enter_critical_section();
+}
+
+static void pm_runtime_unlock(FAR rmutex_t *lock, irqstate_t flags)
+{
+  leave_critical_section(flags);
+
+  if (!up_interrupt_context() && !sched_idletask())
+    {
+      nxrmutex_unlock(lock);
+    }
+}
 
 static int rpm_suspend(FAR struct pm_runtime_s *rpm)
 {
@@ -75,7 +94,7 @@ static void rpm_autosuspend_cb(FAR void *arg)
   FAR struct pm_runtime_s *rpm = arg;
   irqstate_t flags;
 
-  flags = pm_lock(&rpm->lock);
+  flags = pm_runtime_lock(&rpm->lock);
 
   if (rpm->state != RPM_SUSPENDING || !work_available(&rpm->suspend_work))
     {
@@ -93,7 +112,7 @@ static void rpm_autosuspend_cb(FAR void *arg)
     }
 
 out:
-  pm_unlock(&rpm->lock, flags);
+  pm_runtime_unlock(&rpm->lock, flags);
 }
 
 static int rpm_changestate(FAR struct pm_runtime_s *rpm, rpm_state_e state)
@@ -190,7 +209,7 @@ int pm_runtime_get(FAR struct pm_runtime_s *rpm)
   int ret = 0;
 
   DEBUGASSERT(rpm != NULL);
-  flags = pm_lock(&rpm->lock);
+  flags = pm_runtime_lock(&rpm->lock);
 
   if (rpm->use_count++ > 0)
     {
@@ -207,7 +226,7 @@ int pm_runtime_get(FAR struct pm_runtime_s *rpm)
 
   rpm->state = RPM_ACTIVE;
 out:
-  pm_unlock(&rpm->lock, flags);
+  pm_runtime_unlock(&rpm->lock, flags);
   return ret;
 }
 
@@ -230,7 +249,7 @@ int pm_runtime_put(FAR struct pm_runtime_s *rpm)
   int ret = 0;
 
   DEBUGASSERT(rpm != NULL);
-  flags = pm_lock(&rpm->lock);
+  flags = pm_runtime_lock(&rpm->lock);
   if (rpm->use_count == 0)
     {
       ret = -EPERM;
@@ -252,7 +271,7 @@ int pm_runtime_put(FAR struct pm_runtime_s *rpm)
 
   rpm->state = RPM_SUSPENDED;
 out:
-  pm_unlock(&rpm->lock, flags);
+  pm_runtime_unlock(&rpm->lock, flags);
   return ret;
 }
 
@@ -276,7 +295,7 @@ int pm_runtime_put_autosuspend(FAR struct pm_runtime_s *rpm)
   int ret = 0;
 
   DEBUGASSERT(rpm != NULL);
-  flags = pm_lock(&rpm->lock);
+  flags = pm_runtime_lock(&rpm->lock);
   if (rpm->use_count == 0)
     {
       ret = -EPERM;
@@ -298,7 +317,7 @@ int pm_runtime_put_autosuspend(FAR struct pm_runtime_s *rpm)
 
   rpm->state = RPM_SUSPENDING;
 out:
-  pm_unlock(&rpm->lock, flags);
+  pm_runtime_unlock(&rpm->lock, flags);
   return ret;
 }
 
@@ -322,7 +341,7 @@ void pm_runtime_set_autosuspend_delay(FAR struct pm_runtime_s *rpm,
   irqstate_t flags;
 
   DEBUGASSERT(rpm != NULL);
-  flags = pm_lock(&rpm->lock);
+  flags = pm_runtime_lock(&rpm->lock);
   rpm->suspend_delay = delay;
-  pm_unlock(&rpm->lock, flags);
+  pm_runtime_unlock(&rpm->lock, flags);
 }


### PR DESCRIPTION
## Summary
isolate with pm_runtime and pm_domain, for further usage optimise.

there is critical_section inside rpm_changestate,
use seperate spinlock is not compatible.

## Impact
before fix, #12503 will be blocked.
None.

## Testing
CI-test

