### PR TITLE
stm32h7: allow Ethernet MAC without PHY

### DIFF
--- a/arch/arm/src/stm32h7/Kconfig
+++ b/arch/arm/src/stm32h7/Kconfig
@@ -5519,6 +5519,10 @@ config STM32H7_ETHMAC_REGDEBUG
 		Enable very low-level register access debug.  Depends on
 		CONFIG_DEBUG_FEATURES.
 
+config STM32H7_NO_PHY
+	bool "MAC has no PHY"
+	default n
+
 endmenu # Ethernet MAC configuration
 
 if STM32H7_LTDC


### PR DESCRIPTION
## Summary
- In some cases, an operational Ethernet MAC may have no PHY, for example when the system has a direct RMII MAC-to-MAC link.
- New config option STM32H7_NO_PHY
- With this option, PHY-specific code in the ethernet driver is not built
- This option is inherently incompatible with autonegotiation and speed and duplex settings must be compiled in

## Impact
- With STM32H7_NO_PHY, a MAC-to-MAC link without any PHY can be used.  Without STM32H7_NO_PHY, no impact.

## Testing
- Tested with STM32H7_NO_PHY with px4_fmu-v6s and an RMII MAC-to-MAC link
- Without STM32H7_NO_PHY - which is the default - it is reasonable to determine by inspection that this PR does not change the code from before the introduction of the option.