### PR TITLE
arch/risc-v/bl808: Add courier system driver

### DIFF
--- a/arch/risc-v/include/bl808/irq.h
+++ b/arch/risc-v/include/bl808/irq.h
@@ -31,16 +31,31 @@
 
 /* Map RISC-V exception code to NuttX IRQ */
 
-#define NR_IRQS (RISCV_IRQ_SEXT + 114)
-
 #define BL808_IRQ_NUM_BASE (16)
-#define BL808_M0_IRQ_OFFSET (64) // IRQs tied to M0 core are given a virtual IRQ number
+
+/* IRQs tied to M0 core are given a virtual IRQ number.
+ * Offset of 67 chosen to avoid overlap with highest D0
+ * IRQ, the PDS interrupt.
+ */
+
+#define BL808_M0_IRQ_OFFSET (67)
+
+#define BL808_D0_MAX_EXTIRQ (BL808_IRQ_NUM_BASE + 66)
+#define BL808_M0_MAX_EXTIRQ (BL808_IRQ_NUM_BASE + 63)
+
+/* NR_IRQs corresponds to highest possible
+ * interrupt number, WIFI IPC IRQ on M0.
+ */
+
+#define NR_IRQS (RISCV_IRQ_SEXT + BL808_M0_IRQ_OFFSET + BL808_M0_MAX_EXTIRQ)
 
 /* D0 IRQs ******************************************************************/
+
 #define BL808_IRQ_UART3 (RISCV_IRQ_SEXT + BL808_IRQ_NUM_BASE + 4)
 #define BL808_IRQ_D0_IPC (RISCV_IRQ_SEXT + BL808_IRQ_NUM_BASE + 38)
 
 /* M0 IRQs ******************************************************************/
+
 #define BL808_IRQ_UART0 (RISCV_IRQ_SEXT + BL808_IRQ_NUM_BASE + BL808_M0_IRQ_OFFSET + 28)
 #define BL808_IRQ_UART1 (RISCV_IRQ_SEXT + BL808_IRQ_NUM_BASE + BL808_M0_IRQ_OFFSET + 29)
 #define BL808_IRQ_UART2 (RISCV_IRQ_SEXT + BL808_IRQ_NUM_BASE + BL808_M0_IRQ_OFFSET + 30)

--- a/arch/risc-v/src/bl808/Make.defs
+++ b/arch/risc-v/src/bl808/Make.defs
@@ -28,3 +28,4 @@ HEAD_ASRC = bl808_head.S
 CHIP_CSRCS  = bl808_start.c bl808_irq_dispatch.c bl808_irq.c
 CHIP_CSRCS += bl808_timerisr.c bl808_allocateheap.c
 CHIP_CSRCS += bl808_mm_init.c bl808_pgalloc.c bl808_serial.c
+CHIP_CSRCS += bl808_courier.c

--- a/arch/risc-v/src/bl808/bl808_courier.c
+++ b/arch/risc-v/src/bl808/bl808_courier.c
@@ -1,0 +1,123 @@
+/****************************************************************************
+ * arch/risc-v/src/bl808/bl808_courier.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/arch.h>
+
+#include <sys/types.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <errno.h>
+#include <debug.h>
+
+#include <nuttx/irq.h>
+
+#include "hardware/bl808_ipc.h"
+#include "riscv_internal.h"
+#include "chip.h"
+#include "bl808_courier.h"
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: courier_interrupt
+ *
+ * Description:
+ *   Interrupt handler for IPC. Reads the IPC message, gets the interrupt
+ *   number and dispatches the appropriate handler.
+ *
+ ****************************************************************************/
+
+static int __courier_interrupt(int irq, void *context, void *arg)
+{
+  uint32_t msg = getreg32(IPC2_MSG_READ);
+  int m0_extirq = msg & BL808_COURIER_IRQN_MASK;
+  int irqn = m0_extirq + BL808_M0_IRQ_OFFSET + RISCV_IRQ_SEXT;
+
+  irq_dispatch(irqn, NULL);
+
+  bl808_courier_req_irq_enable(m0_extirq);
+
+  putreg32(msg, IPC2_MSG_ACK);
+  return OK;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: bl808_courier_req_irq_disable
+ *
+ * Description:
+ *   Sends an IPC message to M0 core to enable m0_extirq.
+ *
+ ****************************************************************************/
+
+void bl808_courier_req_irq_enable(int m0_extirq)
+{
+  putreg32((m0_extirq & BL808_COURIER_IRQN_MASK)
+           | (1 << BL808_INT_SIG_SHIFT)
+           | (1 << BL808_INT_EN_SHIFT),
+           IPC0_MSG_SEND);
+}
+
+/****************************************************************************
+ * Name: bl808_courier_req_irq_disable
+ *
+ * Description:
+ *   Sends an IPC message to M0 core to disable m0_extirq.
+ *
+ ****************************************************************************/
+
+void bl808_courier_req_irq_disable(int m0_extirq)
+{
+  putreg32((m0_extirq & BL808_COURIER_IRQN_MASK)
+           | (1 << BL808_INT_SIG_SHIFT),
+           IPC0_MSG_SEND);
+}
+
+/****************************************************************************
+ * Name: bl808_courier_init
+ *
+ * Description:
+ *   Enables the IPC interrupt on D0 core and attaches its handler.
+ *
+ ****************************************************************************/
+
+int bl808_courier_init(void)
+{
+  putreg32((1 << BL808_INT_SIG_SHIFT), IPC2_INT_UNMASK);
+
+  int ret = irq_attach(BL808_IRQ_D0_IPC, __courier_interrupt, NULL);
+  if (ret == OK)
+    {
+      up_enable_irq(BL808_IRQ_D0_IPC);
+    }
+
+  return ret;
+}

--- a/arch/risc-v/src/bl808/bl808_courier.h
+++ b/arch/risc-v/src/bl808/bl808_courier.h
@@ -1,0 +1,66 @@
+/****************************************************************************
+ * arch/risc-v/src/bl808/bl808_courier.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_RISC_V_SRC_BL808_BL808_COURIER_H
+#define __ARCH_RISC_V_SRC_BL808_BL808_COURIER_H
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define BL808_COURIER_IRQN_MASK 0xff
+#define BL808_INT_SIG_SHIFT 8
+#define BL808_INT_EN_SHIFT 9
+
+/****************************************************************************
+ * Public Functions Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: bl808_courier_req_irq_enable
+ *
+ * Description:
+ *   Sends an IPC message to M0 core to enable m0_extirq.
+ *
+ ****************************************************************************/
+
+void bl808_courier_req_irq_enable(int m0_extirq);
+
+/****************************************************************************
+ * Name: bl808_courier_req_irq_disable
+ *
+ * Description:
+ *   Sends an IPC message to M0 core to disable m0_extirq.
+ *
+ ****************************************************************************/
+
+void bl808_courier_req_irq_disable(int m0_extirq);
+
+/****************************************************************************
+ * Name: bl808_courier_init
+ *
+ * Description:
+ *   Enables the IPC interrupt on D0 core and attaches its handler.
+ *
+ ****************************************************************************/
+
+int bl808_courier_init(void);
+
+#endif /* __ARCH_RISC_V_SRC_BL808_BL808_COURIER_H */

--- a/arch/risc-v/src/bl808/bl808_irq.c
+++ b/arch/risc-v/src/bl808/bl808_irq.c
@@ -132,14 +132,16 @@ void up_disable_irq(int irq)
     {
       extirq = irq - RISCV_IRQ_EXT;
 
-      /* Clear enable bit for the irq */
-
-      if (0 <= extirq && extirq <= 63)
+      if (0 <= extirq && extirq <= BL808_D0_MAX_EXTIRQ)
         {
+          /* Clear enable bit for the irq */
+
           modifyreg32(BL808_PLIC_ENABLE1 + (4 * (extirq / 32)),
                       1 << (extirq % 32), 0);
         }
-      else if (64 <= extirq && extirq <= 127)
+      else if ((BL808_D0_MAX_EXTIRQ + 1) <= extirq
+               && extirq <= (BL808_M0_MAX_EXTIRQ
+                             + BL808_M0_IRQ_OFFSET))
         {
           int m0_extirq = extirq - BL808_M0_IRQ_OFFSET;
           bl808_courier_req_irq_disable(m0_extirq);
@@ -179,14 +181,16 @@ void up_enable_irq(int irq)
     {
       extirq = irq - RISCV_IRQ_EXT;
 
-      /* Set enable bit for the irq */
-
-      if (0 <= extirq && extirq <= 63)
+      if (0 <= extirq && extirq <= BL808_D0_MAX_EXTIRQ)
         {
+          /* Set enable bit for the irq */
+
           modifyreg32(BL808_PLIC_ENABLE1 + (4 * (extirq / 32)),
                       0, 1 << (extirq % 32));
         }
-      else if (64 <= extirq && extirq <= 127)
+      else if ((BL808_D0_MAX_EXTIRQ + 1) <= extirq
+               && extirq <= (BL808_M0_MAX_EXTIRQ
+                             + BL808_M0_IRQ_OFFSET))
         {
           int m0_extirq = extirq - BL808_M0_IRQ_OFFSET;
           bl808_courier_req_irq_enable(m0_extirq);

--- a/arch/risc-v/src/bl808/bl808_irq.c
+++ b/arch/risc-v/src/bl808/bl808_irq.c
@@ -36,6 +36,8 @@
 #include "riscv_ipi.h"
 #include "chip.h"
 
+#include "bl808_courier.h"
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -137,6 +139,11 @@ void up_disable_irq(int irq)
           modifyreg32(BL808_PLIC_ENABLE1 + (4 * (extirq / 32)),
                       1 << (extirq % 32), 0);
         }
+      else if (64 <= extirq && extirq <= 127)
+        {
+          int m0_extirq = extirq - BL808_M0_IRQ_OFFSET;
+          bl808_courier_req_irq_disable(m0_extirq);
+        }
       else
         {
           PANIC();
@@ -178,6 +185,11 @@ void up_enable_irq(int irq)
         {
           modifyreg32(BL808_PLIC_ENABLE1 + (4 * (extirq / 32)),
                       0, 1 << (extirq % 32));
+        }
+      else if (64 <= extirq && extirq <= 127)
+        {
+          int m0_extirq = extirq - BL808_M0_IRQ_OFFSET;
+          bl808_courier_req_irq_enable(m0_extirq);
         }
       else
         {

--- a/arch/risc-v/src/bl808/hardware/bl808_ipc.h
+++ b/arch/risc-v/src/bl808/hardware/bl808_ipc.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/risc-v/include/bl808/irq.h
+ * arch/risc-v/src/bl808/hardware/bl808_ipc.h
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,31 +18,23 @@
  *
  ****************************************************************************/
 
-#ifndef __ARCH_RISCV_INCLUDE_BL808_IRQ_H
-#define __ARCH_RISCV_INCLUDE_BL808_IRQ_H
-
-/****************************************************************************
- * Included Files
- ****************************************************************************/
+#ifndef __ARCH_RISCV_SRC_BL808_HARDWARE_BL808_IPC_H
+#define __ARCH_RISCV_SRC_BL808_HARDWARE_BL808_IPC_H
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* Map RISC-V exception code to NuttX IRQ */
+#define IPC_MSG_SEND_OFFSET 0x0
+#define IPC0_MSG_SEND       (IPC0_BASE + IPC_MSG_SEND_OFFSET)
 
-#define NR_IRQS (RISCV_IRQ_SEXT + 114)
+#define IPC_MSG_READ_OFFSET 0x24
+#define IPC2_MSG_READ       (IPC2_BASE + IPC_MSG_READ_OFFSET)
 
-#define BL808_IRQ_NUM_BASE (16)
-#define BL808_M0_IRQ_OFFSET (64) // IRQs tied to M0 core are given a virtual IRQ number
+#define IPC_MSG_ACK_OFFSET  0x28
+#define IPC2_MSG_ACK        (IPC2_BASE + IPC_MSG_ACK_OFFSET)
 
-/* D0 IRQs ******************************************************************/
-#define BL808_IRQ_UART3 (RISCV_IRQ_SEXT + BL808_IRQ_NUM_BASE + 4)
-#define BL808_IRQ_D0_IPC (RISCV_IRQ_SEXT + BL808_IRQ_NUM_BASE + 38)
+#define IPC_INT_UNMASK_OFFSET 0x2c
+#define IPC2_INT_UNMASK       (IPC2_BASE + IPC_INT_UNMASK_OFFSET)
 
-/* M0 IRQs ******************************************************************/
-#define BL808_IRQ_UART0 (RISCV_IRQ_SEXT + BL808_IRQ_NUM_BASE + BL808_M0_IRQ_OFFSET + 28)
-#define BL808_IRQ_UART1 (RISCV_IRQ_SEXT + BL808_IRQ_NUM_BASE + BL808_M0_IRQ_OFFSET + 29)
-#define BL808_IRQ_UART2 (RISCV_IRQ_SEXT + BL808_IRQ_NUM_BASE + BL808_M0_IRQ_OFFSET + 30)
-
-#endif /* __ARCH_RISCV_INCLUDE_BL808_IRQ_H */
+#endif /* __ARCH_RISCV_SRC_BL808_HARDWARE_BL808_IPC_H */

--- a/arch/risc-v/src/bl808/hardware/bl808_memorymap.h
+++ b/arch/risc-v/src/bl808/hardware/bl808_memorymap.h
@@ -28,6 +28,10 @@
 /* Register Base Address ****************************************************/
 
 #define BL808_UART3_BASE   0x30002000ul
-#define BL808_PLIC_BASE    0xe0000000ul
+
+#define IPC0_BASE          0x2000a800ul
+#define IPC2_BASE          0x30005000ul          
+
+#define BL808_PLIC_BASE    0xe0000000ul 
 
 #endif /* __ARCH_RISCV_SRC_BL808_HARDWARE_BL808_MEMORYMAP_H */

--- a/boards/risc-v/bl808/ox64/src/bl808_appinit.c
+++ b/boards/risc-v/bl808/ox64/src/bl808_appinit.c
@@ -34,6 +34,7 @@
 #include <sys/mount.h>
 #include <sys/boardctl.h>
 #include <arch/board/board_memorymap.h>
+#include "bl808_courier.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -156,6 +157,10 @@ void board_late_initialize(void)
   /* Mount the RAM Disk */
 
   mount_ramdisk();
+
+  /* Initialize courier to get IRQs from M0 */
+
+  bl808_courier_init();
 
   /* Perform board-specific initialization */
 


### PR DESCRIPTION
## Summary
This change implements a system for allowing the D0 core (which runs NuttX) to receive forwarded interrupts from the M0 core (the peripheral / wireless core). This is implemented using the IPC interrupt: when the M0 core receives an interrupt, it sends an IPC notification to the D0 core containing the IRQ number. This triggers an ISR on D0, which takes the message and dispatches the appropriate ISR using virtual interrupt identifiers within NuttX.
**Note: Currently, the boot system for NuttX on the BL808 depends on a piece of firmware originally meant for Linux support, named m0_lowload. The system described in this PR requires a somewhat modified version of this firmware to be flashed, which is available [here](https://github.com/henryrov/OBLFR/releases/tag/m0_lowload_nuttx_v1).**

## Impact
This system makes it possible to implement BL808 peripheral drivers that depend on interrupts (e.g. UART, SPI, I2C) for peripherals that are attached to the M0 core, instead of being restricted to ones attached to D0 (e.g. UART3). As implemented, the courier should also be mostly transparent to these drivers, outside of applying the virtual IRQ number offset when defining constants for M0 IRQs (as done for BL808_IRQ_UART0, 1 and 2 in this PR).

## Testing
I have been working on [modifying the existing BL808 serial driver to add support for UARTs 0-2 ](https://github.com/henryrov/nuttx/tree/bl808_uart_wip), which depends on the courier system. The modified driver is currently functional, and successfully receives interrupts from UARTs attached to M0 via the courier, and responds to them using the same ISR as UART3. Further testing can be done by enabling logging when building m0_lowload_nuttx and monitoring UART0 (logging is disabled in the release build to free up UART0 for use in NuttX).