### PR TITLE
arch/risc-v: move PRIxREG to inttypes.h

### DIFF
--- a/arch/risc-v/include/inttypes.h
+++ b/arch/risc-v/include/inttypes.h
@@ -136,4 +136,12 @@
 #define UINT8_C(x)  x
 #define UINT16_C(x) x
 
+/* Format output with register width and hex */
+
+#ifdef CONFIG_ARCH_RV32
+#  define PRIxREG "08"  PRIx32
+#else
+#  define PRIxREG "016" PRIx64
+#endif
+
 #endif /* __ARCH_RISCV_INCLUDE_INTTYPES_H */

--- a/arch/risc-v/src/common/riscv_internal.h
+++ b/arch/risc-v/src/common/riscv_internal.h
@@ -85,14 +85,6 @@
 /* Interrupt Stack macros */
 #define INT_STACK_SIZE  (STACK_ALIGN_DOWN(CONFIG_ARCH_INTERRUPTSTACK))
 
-/* Format output with register width and hex */
-
-#ifdef CONFIG_ARCH_RV32
-#  define PRIxREG "08"  PRIx32
-#else
-#  define PRIxREG "016" PRIx64
-#endif
-
 /* In the RISC-V model, the state is saved in stack,
  * only a reference stored in TCB.
  */


### PR DESCRIPTION
## Summary

This moves PRIxREG to inttypes.h to make it available for both kernel
and user spaces.

## Impact

arch/risc-v

## Testing

- local tests with `rv-virt`
- CI checks
