### PR TITLE
riscv/nuttsbi: add MTVAL argument

### DIFF
--- a/arch/risc-v/src/nuttsbi/sbi_mexception.c
+++ b/arch/risc-v/src/nuttsbi/sbi_mexception.c
@@ -30,8 +30,9 @@
  * Public Functions
  ****************************************************************************/
 
-void sbi_mexception(uintptr_t mcause, uintptr_t *mepc)
+void sbi_mexception(uintreg_t mcause, uintreg_t *mepc, uintreg_t tval)
 {
-  (void) mcause;
-  (void) mepc;
+  UNUSED(mcause);
+  UNUSED(mepc);
+  UNUSED(tval);
 }

--- a/arch/risc-v/src/nuttsbi/sbi_mtrap.S
+++ b/arch/risc-v/src/nuttsbi/sbi_mtrap.S
@@ -127,6 +127,7 @@ machine_trap:
 
   csrr        a0, CSR_MCAUSE     /* Interrupt cause [arg0] */
   csrr        a1, CSR_MEPC       /* Interrupt PC (instruction) [arg1] */
+  csrr        a2, CSR_MTVAL      /* The MTVAL value [arg2] */
   jal         x1, sbi_mexception
   j           __start
 


### PR DESCRIPTION
## Summary

This adds MTVAL argument to sbi_mexception() so that to have a complete story about the exception. this is useful for debugging.

## Impacts

NUTTSBI exception

## Testing

- local tesing with k230 device
- CI checks
