### PR TITLE
fs/fat/fs_fat32.c Return EOF when reading past the end of the file.

### DIFF
--- a/fs/fat/fs_fat32.c
+++ b/fs/fat/fs_fat32.c
@@ -535,6 +535,16 @@ static ssize_t fat_read(FAR struct file *filep, FAR char *buffer,
       goto errout_with_lock;
     }
 
+  /* Check that the file position is not past the end of the file */
+
+  if (filep->f_pos > ff->ff_size)
+    {
+      /* Return EOF */
+
+      ret = 0;
+      goto errout_with_lock;
+    }
+
   /* Get the number of bytes left in the file */
 
   bytesleft = ff->ff_size - filep->f_pos;


### PR DESCRIPTION
## Summary
Return EOF when a read is requested after the file pointer has been set past the end of the file.

## Impact

Resolves part of the issue outlined in #12496. 

## Testing

Using the example program  in #12496. 

```
open test_file with mode w
file position 0
write: test_file, len: 10
file position 10
file size 10
open test_file with mode r
file position 0
read: 'test_file' len: 10
file position 10
file size 10
seek to: 18, ret: 0
file position 18
file position 18
read: '' len: 0
file position 18
file size 10
```
