### PR TITLE
mm: add mm_initialize_pool, make pool more flexible

### DIFF
--- a/include/nuttx/mm/mm.h
+++ b/include/nuttx/mm/mm.h
@@ -153,6 +153,16 @@
 
 struct mm_heap_s; /* Forward reference */
 
+struct mempool_init_s
+{
+  FAR const size_t *poolsize;
+  size_t            npools;
+  size_t            threshold;
+  size_t            chunksize;
+  size_t            expandsize;
+  size_t            dict_expendsize;
+};
+
 /****************************************************************************
  * Public Data
  ****************************************************************************/
@@ -213,6 +223,18 @@ EXTERN FAR struct mm_heap_s *g_kmmheap;
 
 FAR struct mm_heap_s *mm_initialize(FAR const char *name,
                                     FAR void *heap_start, size_t heap_size);
+
+#ifdef CONFIG_MM_HEAP_MEMPOOL
+FAR struct mm_heap_s *
+mm_initialize_pool(FAR const char *name,
+                   FAR void *heap_start, size_t heap_size,
+                   FAR const struct mempool_init_s *init);
+
+#else
+#  define mm_initialize_pool(name, heap_start, heap_size, init) \
+          mm_initialize(name, heap_start, heap_size)
+#endif
+
 void mm_addregion(FAR struct mm_heap_s *heap, FAR void *heapstart,
                   size_t heapsize);
 void mm_uninitialize(FAR struct mm_heap_s *heap);

--- a/mm/kmm_heap/kmm_initialize.c
+++ b/mm/kmm_heap/kmm_initialize.c
@@ -58,7 +58,7 @@ FAR struct mm_heap_s *g_kmmheap;
 
 void kmm_initialize(FAR void *heap_start, size_t heap_size)
 {
-  g_kmmheap = mm_initialize("Kmem", heap_start, heap_size);
+  g_kmmheap = mm_initialize_pool("Kmem", heap_start, heap_size, NULL);
 }
 
 #endif /* CONFIG_MM_KERNEL_HEAP */

--- a/mm/umm_heap/umm_initialize.c
+++ b/mm/umm_heap/umm_initialize.c
@@ -84,9 +84,9 @@
 void umm_initialize(FAR void *heap_start, size_t heap_size)
 {
 #ifdef CONFIG_BUILD_KERNEL
-  USR_HEAP = mm_initialize(NULL, heap_start, heap_size);
+  USR_HEAP = mm_initialize_pool(NULL, heap_start, heap_size, NULL);
 #else
-  USR_HEAP = mm_initialize("Umem", heap_start, heap_size);
+  USR_HEAP = mm_initialize_pool("Umem", heap_start, heap_size, NULL);
 #endif
 }
 


### PR DESCRIPTION
## Summary
now allow enable pool for extra heap, and disable umm/kmm pool.

## Impact
The mm_initialize now always init without pool, and replaced with mm_initialize_pool

## Testing
CI-test and Cortex-A7 board
