### PR TITLE
compiler.h: rename CMSE extension attribute macros

### DIFF
--- a/boards/arm/nrf91/common/src/nrf91_boot_image.c
+++ b/boards/arm/nrf91/common/src/nrf91_boot_image.c
@@ -56,7 +56,7 @@
  ****************************************************************************/
 
 #ifdef CONFIG_NRF91_NONSECURE_BOOT
-typedef void cmse_nonsecure_call nsfunc(void);
+typedef void tz_nonsecure_call nsfunc(void);
 #endif
 
 /* This structure represents the first two entries on NVIC vector table */

--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -491,8 +491,8 @@
 /* CMSE extention */
 
 #  ifdef CONFIG_ARCH_HAVE_TRUSTZONE
-#    define cmse_nonsecure_entry __attribute__((cmse_nonsecure_entry))
-#    define cmse_nonsecure_call __attribute__((cmse_nonsecure_call))
+#    define tz_nonsecure_entry __attribute__((cmse_nonsecure_entry))
+#    define tz_nonsecure_call  __attribute__((cmse_nonsecure_call))
 #  endif
 
 /* SDCC-specific definitions ************************************************/


### PR DESCRIPTION
## Summary
rename CMSE extension attribute macros to avoid conflicts with 3rd party code:

  cmse_nonsecure_entry -> tz_nonsecure_netry
  cmse_nonsecure_call -> tz_nonsecure_call
  
## Impact
Code using these CMSE macros needs to be updated

## Testing
CI
