### PR TITLE
sched/tcb: ammending patch 12320

### DIFF
--- a/sched/init/nx_bringup.c
+++ b/sched/init/nx_bringup.c
@@ -529,9 +529,11 @@ int nx_bringup(void)
 
 #if !defined(CONFIG_DISABLE_ENVIRON) && (defined(CONFIG_PATH_INITIAL) || \
      defined(CONFIG_LDPATH_INITIAL))
-  /* We an save a few bytes by discarding the IDLE thread's environment. */
+  /* We would save a few bytes by discarding the IDLE thread's environment.
+   * But when kthreads share the same group, this is no longer proper, so
+   * we can't do clearenv() now.
+   */
 
-  clearenv();
 #endif
 
   sched_trace_end();

--- a/sched/sched/sched_releasetcb.c
+++ b/sched/sched/sched_releasetcb.c
@@ -170,9 +170,9 @@ int nxsched_release_tcb(FAR struct tcb_s *tcb, uint8_t ttype)
 
       nxtask_joindestroy(tcb);
 
-      /* Kernel thread and group still reference by pthread */
+      /* Task still referenced by pthread */
 
-      if (ttype != TCB_FLAG_TTYPE_PTHREAD)
+      if (ttype == TCB_FLAG_TTYPE_TASK)
         {
           ttcb = (FAR struct task_tcb_s *)tcb;
           if (!sq_empty(&ttcb->group.tg_members)

--- a/sched/task/exit.c
+++ b/sched/task/exit.c
@@ -64,7 +64,11 @@ void _exit(int status)
    * exit through a different mechanism.
    */
 
-  group_kill_children(tcb);
+  if ((tcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL)
+    {
+      group_kill_children(tcb);
+    }
+
 #endif
 
   /* Perform common task termination logic.  This will get called again later


### PR DESCRIPTION
## Summary

This attempts to fix the regression issues in 12320.

## Impact

Kernel builds using `AppBringup` thread.

## Testing

- local checks on `rv-virt` using `knsh64 + BOARD_LATE_INITIALIZE`
- CI checks


