### PR TITLE
esp32: make ESP32_IGNORE_CHIP_REVISION_CHECK a kconfig option

### DIFF
--- a/arch/xtensa/src/esp32/Kconfig
+++ b/arch/xtensa/src/esp32/Kconfig
@@ -2647,4 +2647,8 @@ config ESP32_TICKLESS
 	select ARCH_HAVE_TICKLESS
 	select SCHED_TICKLESS
 
+config ESP32_IGNORE_CHIP_REVISION_CHECK
+	bool "Ignore chip revision"
+	default n
+
 endif # ARCH_CHIP_ESP32

--- a/arch/xtensa/src/esp32/esp32_start.c
+++ b/arch/xtensa/src/esp32/esp32_start.c
@@ -232,7 +232,7 @@ static noreturn_function void __esp32_start(void)
 
   if (chip_rev < 300)
     {
-#ifndef ESP32_IGNORE_CHIP_REVISION_CHECK
+#ifndef CONFIG_ESP32_IGNORE_CHIP_REVISION_CHECK
       ets_printf("ERROR: NuttX supports ESP32 chip revision >= v3.0"
                  " (chip revision is v%d.%01d)\n",
                  chip_rev / 100, chip_rev % 100);
@@ -241,7 +241,7 @@ static noreturn_function void __esp32_start(void)
       ets_printf("WARNING: NuttX supports ESP32 chip revision >= v3.0"
                  " (chip is v%d.%01d).\n"
                  "Ignoring this error and continuing because "
-                 "`ESP32_IGNORE_CHIP_REVISION_CHECK` is set...\n"
+                 "`CONFIG_ESP32_IGNORE_CHIP_REVISION_CHECK` is set...\n"
                  "THIS MAY NOT WORK! DON'T USE THIS CHIP IN PRODUCTION!\n",
                  chip_rev / 100, chip_rev % 100);
     }


### PR DESCRIPTION
## Summary
my esp32-devkitc seems to be the old version, which is rejected by this version check.
i don't want to patch the code whenever i test nuttx on the board.

## Impact

## Testing

