### PR TITLE
[bugfix] cmake:fix a few issues during CMake build

### DIFF
--- a/arch/sim/src/cmake/Toolchain.cmake
+++ b/arch/sim/src/cmake/Toolchain.cmake
@@ -75,6 +75,7 @@ endif()
 
 if(CONFIG_SIM_ASAN)
   add_compile_options(-fsanitize=address)
+  add_link_options(-fsanitize=address)
   add_compile_options(-fsanitize-address-use-after-scope)
   add_compile_options(-fsanitize=pointer-compare)
   add_compile_options(-fsanitize=pointer-subtract)

--- a/fs/CMakeLists.txt
+++ b/fs/CMakeLists.txt
@@ -19,4 +19,5 @@
 # ##############################################################################
 nuttx_add_kernel_library(fs fs_initialize.c)
 nuttx_add_subdirectory()
-target_include_directories(fs PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(fs PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+                                      ${NUTTX_DIR}/sched)

--- a/libs/libc/machine/arm/armv7-a/CMakeLists.txt
+++ b/libs/libc/machine/arm/armv7-a/CMakeLists.txt
@@ -18,8 +18,6 @@
 #
 # ##############################################################################
 
-set(SRCS arch_elf.c)
-
 if(CONFIG_ARCH_TOOLCHAIN_GNU)
   set(ARCH_TOOLCHAIN_DIR gnu)
 endif()
@@ -46,6 +44,10 @@ endif()
 
 if(CONFIG_ARMV7A_STRLEN)
   list(APPEND SRCS ${ARCH_TOOLCHAIN_DIR}/arch_strlen.S)
+endif()
+
+if(CONFIG_LIBC_ARCH_ELF)
+  list(APPEND SRCS arch_elf.c)
 endif()
 
 target_sources(c PRIVATE ${SRCS})

--- a/libs/libc/machine/arm/armv7-m/CMakeLists.txt
+++ b/libs/libc/machine/arm/armv7-m/CMakeLists.txt
@@ -20,28 +20,36 @@
 
 set(SRCS)
 
+if(CONFIG_ARCH_TOOLCHAIN_GNU)
+  set(ARCH_TOOLCHAIN_DIR gnu)
+endif()
+
+if(CONFIG_ARMV7M_MEMCHR)
+  list(APPEND SRCS ${ARCH_TOOLCHAIN_DIR}/arch_memchr.S)
+endif()
+
 if(CONFIG_ARMV7M_MEMCPY)
-  list(APPEND SRCS gnu/arch_memcpy.S)
+  list(APPEND SRCS ${ARCH_TOOLCHAIN_DIR}/arch_memcpy.S)
 endif()
 
 if(CONFIG_ARMV7M_MEMSET)
-  list(APPEND SRCS arch_memset.S)
+  list(APPEND SRCS ${ARCH_TOOLCHAIN_DIR}/arch_memset.S)
 endif()
 
 if(CONFIG_ARMV7M_MEMMOVE)
-  list(APPEND SRCS arch_memmove.S)
+  list(APPEND SRCS ${ARCH_TOOLCHAIN_DIR}/arch_memmove.S)
 endif()
 
 if(CONFIG_ARMV7M_STRCMP)
-  list(APPEND SRCS arch_strcmp.S)
+  list(APPEND SRCS ${ARCH_TOOLCHAIN_DIR}/arch_strcmp.S)
 endif()
 
 if(CONFIG_ARMV7M_STRCPY)
-  list(APPEND SRCS arch_strcpy.S)
+  list(APPEND SRCS ${ARCH_TOOLCHAIN_DIR}/arch_strcpy.S)
 endif()
 
 if(CONFIG_ARMV7M_STRLEN)
-  list(APPEND SRCS arch_strlen.S)
+  list(APPEND SRCS ${ARCH_TOOLCHAIN_DIR}/arch_strlen.S)
 endif()
 
 if(CONFIG_LIBC_ARCH_ELF)

--- a/libs/libc/machine/arm/armv7-r/CMakeLists.txt
+++ b/libs/libc/machine/arm/armv7-r/CMakeLists.txt
@@ -18,10 +18,38 @@
 #
 # ##############################################################################
 
+set(SRCS)
+
+if(CONFIG_ARCH_TOOLCHAIN_GNU)
+  set(ARCH_TOOLCHAIN_DIR gnu)
+endif()
+
+if(CONFIG_ARMV7R_MEMCHR)
+  list(APPEND SRCS ${ARCH_TOOLCHAIN_DIR}/arch_memchr.S)
+endif()
+
 if(CONFIG_ARMV7R_MEMCPY)
-  target_sources(c PRIVATE gnu/arch_memcpy.S)
+  list(APPEND SRCS ${ARCH_TOOLCHAIN_DIR}/arch_memcpy.S)
+endif()
+
+if(CONFIG_ARMV7R_MEMSET)
+  list(APPEND SRCS ${ARCH_TOOLCHAIN_DIR}/arch_memset.S)
+endif()
+
+if(CONFIG_ARMV7R_MEMMOVE)
+  list(APPEND SRCS ${ARCH_TOOLCHAIN_DIR}/arch_memmove.S)
+endif()
+
+if(CONFIG_ARMV7R_STRCMP)
+  list(APPEND SRCS ${ARCH_TOOLCHAIN_DIR}/arch_strcmp.S)
+endif()
+
+if(CONFIG_ARMV7R_STRLEN)
+  list(APPEND SRCS ${ARCH_TOOLCHAIN_DIR}/arch_strlen.S)
 endif()
 
 if(CONFIG_LIBC_ARCH_ELF)
-  target_sources(c PRIVATE arch_elf.c)
+  list(APPEND SRCS arch_elf.c)
 endif()
+
+target_sources(c PRIVATE ${SRCS})

--- a/libs/libc/machine/arm/armv8-m/CMakeLists.txt
+++ b/libs/libc/machine/arm/armv8-m/CMakeLists.txt
@@ -20,36 +20,40 @@
 
 set(SRCS)
 
+if(CONFIG_ARCH_TOOLCHAIN_GNU)
+  set(ARCH_TOOLCHAIN_DIR gnu)
+endif()
+
 if(CONFIG_LIBC_ARCH_ELF)
   list(APPEND SRCS arch_elf.c)
 endif()
 
 if(CONFIG_ARMV8M_MEMCHR)
-  list(APPEND SRCS arch_memchr.S)
+  list(APPEND SRCS ${ARCH_TOOLCHAIN_DIR}/arch_memchr.S)
 endif()
 
 if(CONFIG_ARMV8M_MEMCPY)
-  list(APPEND SRCS arch_memcpy.S)
+  list(APPEND SRCS ${ARCH_TOOLCHAIN_DIR}/arch_memcpy.S)
 endif()
 
 if(CONFIG_ARMV8M_MEMSET)
-  list(APPEND SRCS arch_memset.S)
+  list(APPEND SRCS ${ARCH_TOOLCHAIN_DIR}/arch_memset.S)
 endif()
 
 if(CONFIG_ARMV8M_MEMMOVE)
-  list(APPEND SRCS arch_memmove.S)
+  list(APPEND SRCS ${ARCH_TOOLCHAIN_DIR}/arch_memmove.S)
 endif()
 
 if(CONFIG_ARMV8M_STRCMP)
-  list(APPEND SRCS arch_strcmp.S)
+  list(APPEND SRCS ${ARCH_TOOLCHAIN_DIR}/arch_strcmp.S)
 endif()
 
 if(CONFIG_ARMV8M_STRCPY)
-  list(APPEND SRCS arch_strcpy.S)
+  list(APPEND SRCS ${ARCH_TOOLCHAIN_DIR}/arch_strcpy.S)
 endif()
 
 if(CONFIG_ARMV8M_STRLEN)
-  list(APPEND SRCS arch_strlen.S)
+  list(APPEND SRCS ${ARCH_TOOLCHAIN_DIR}/arch_strlen.S)
 endif()
 
 target_sources(c PRIVATE ${SRCS})


### PR DESCRIPTION
## Summary
1. Fix SIM `-fsanitize=address` not effective at linking stage

2. Fix missing include directory path for fs

3. Fix enable `ARCH_STRING_FUNCTION` CMake build fail, add missing libc/machine/ sources

## Impact

## Testing

CI build