### PR TITLE
libm{libm|newlib}: fix broken sincos optimization for GCC

### DIFF
--- a/libs/libm/libm/lib_sincos.c
+++ b/libs/libm/libm/lib_sincos.c
@@ -27,12 +27,21 @@
 
 #include <math.h>
 
+/* Disable sincos optimization for all functions in this file,
+ * otherwise gcc would generate infinite calls.
+ * Refer to gcc PR46926.
+ * -fno-builtin-sin or -fno-builtin-cos can disable sincos optimization,
+ * but these two options do not work inside optimize pragma in-file.
+ * Thus we just enforce -O0 when compiling this file.
+ */
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
 #ifdef CONFIG_HAVE_DOUBLE
 
+nooptimiziation_function
 void sincos(double x, double *s, double *c)
 {
   *s = sin(x);

--- a/libs/libm/libm/lib_sincosf.c
+++ b/libs/libm/libm/lib_sincosf.c
@@ -27,10 +27,19 @@
 
 #include <math.h>
 
+/* Disable sincos optimization for all functions in this file,
+ * otherwise gcc would generate infinite calls.
+ * Refer to gcc PR46926.
+ * -fno-builtin-sin or -fno-builtin-cos can disable sincos optimization,
+ * but these two options do not work inside optimize pragma in-file.
+ * Thus we just enforce -O0 when compiling this file.
+ */
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
+nooptimiziation_function
 void sincosf(float x, float *s, float *c)
 {
   *s = sinf(x);

--- a/libs/libm/libm/lib_sincosl.c
+++ b/libs/libm/libm/lib_sincosl.c
@@ -27,12 +27,21 @@
 
 #include <math.h>
 
+/* Disable sincos optimization for all functions in this file,
+ * otherwise gcc would generate infinite calls.
+ * Refer to gcc PR46926.
+ * -fno-builtin-sin or -fno-builtin-cos can disable sincos optimization,
+ * but these two options do not work inside optimize pragma in-file.
+ * Thus we just enforce -O0 when compiling this file.
+ */
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 
+nooptimiziation_function
 void sincosl(long double x, long double *s, long double *c)
 {
   *s = sinl(x);

--- a/libs/libm/newlib/0004-newlib-disable-optmisation-for-sincos.patch
+++ b/libs/libm/newlib/0004-newlib-disable-optmisation-for-sincos.patch
@@ -1,0 +1,73 @@
+From b88abc9c31c450c44c384feaf2e2653c8c4c69e4 Mon Sep 17 00:00:00 2001
+From: p-szafonimateusz <p-szafonimateusz@xiaomi.com>
+Date: Fri, 24 May 2024 09:19:03 +0200
+Subject: [PATCH] newlib: disable optmisation for sincos
+
+Change-Id: Ie571e357485384655f67cdc9af2be1c60cacfeee
+Signed-off-by: p-szafonimateusz <p-szafonimateusz@xiaomi.com>
+---
+ newlib/libm/math/w_sincos.c  |  9 +++++++++
+ newlib/libm/math/wf_sincos.c | 10 ++++++++++
+ 2 files changed, 19 insertions(+)
+
+diff --git a/newlib/newlib/newlib/libm/math/w_sincos.c newlib/newlib/newlib/libm/math/w_sincos.c
+index 491efa418..6f85c27ab 100644
+--- a/newlib/newlib/newlib/libm/math/w_sincos.c
++++ newlib/newlib/newlib/libm/math/w_sincos.c
+@@ -4,8 +4,19 @@
+ #include "fdlibm.h"
+ #include <errno.h>
+ 
++/* Disable sincos optimization for all functions in this file,
++ * otherwise gcc would generate infinite calls.
++ * Refer to gcc PR46926.
++ * -fno-builtin-sin or -fno-builtin-cos can disable sincos optimization,
++ * but these two options do not work inside optimize pragma in-file.
++ * Thus we just enforce -O0 when compiling this file.
++ */
++
+ #ifndef _DOUBLE_IS_32BITS
+ 
++#ifdef __GNUC__
++__attribute__((optimize("O0")))
++#endif
+ #ifdef __STDC__
+ 	void sincos(double x, double *sinx, double *cosx)
+ #else
+diff --git a/newlib/newlib/newlib/libm/math/wf_sincos.c newlib/newlib/newlib/libm/math/wf_sincos.c
+index 69eb922c9..2e9b5ca62 100644
+--- a/newlib/newlib/newlib/libm/math/wf_sincos.c
++++ newlib/newlib/newlib/libm/math/wf_sincos.c
+@@ -3,8 +3,19 @@
+ #include "fdlibm.h"
+ #if __OBSOLETE_MATH
+ 
++/* Disable sincos optimization for all functions in this file,
++ * otherwise gcc would generate infinite calls.
++ * Refer to gcc PR46926.
++ * -fno-builtin-sin or -fno-builtin-cos can disable sincos optimization,
++ * but these two options do not work inside optimize pragma in-file.
++ * Thus we just enforce -O0 when compiling this file.
++ */
++
+ #include <errno.h>
+ 
++#ifdef __GNUC__
++__attribute__((optimize("O0")))
++#endif
+ #ifdef __STDC__
+ 	void sincosf(float x, float *sinx, float *cosx)
+ #else
+@@ -20,6 +29,9 @@
+ 
+ #ifdef _DOUBLE_IS_32BITS
+ 
++#ifdef __GNUC__
++__attribute__((optimize("O0")))
++#endif
+ #ifdef __STDC__
+ 	void sincos(double x, double *sinx, double *cosx)
+ #else
+-- 
+2.44.0
+

--- a/libs/libm/newlib/CMakeLists.txt
+++ b/libs/libm/newlib/CMakeLists.txt
@@ -42,7 +42,10 @@ if(CONFIG_LIBM_NEWLIB)
         && patch -p1 -d ${CMAKE_CURRENT_LIST_DIR} <
         ${CMAKE_CURRENT_LIST_DIR}/0002-newlib-libm-remove-include-reent.h.patch
         && patch -p1 -d ${CMAKE_CURRENT_LIST_DIR} <
-        ${CMAKE_CURRENT_LIST_DIR}/0003-newlib-fix-compilation-for-x86.patch)
+        ${CMAKE_CURRENT_LIST_DIR}/0003-newlib-fix-compilation-for-x86.patch &&
+        patch -p1 -d ${CMAKE_CURRENT_LIST_DIR} <
+        ${CMAKE_CURRENT_LIST_DIR}/0004-newlib-disable-optmisation-for-sincos.patch
+    )
 
     FetchContent_GetProperties(newlib_fetch)
 

--- a/libs/libm/newlib/Make.defs
+++ b/libs/libm/newlib/Make.defs
@@ -40,6 +40,7 @@ newlib/newlib: $(NEWLIB_BASENAME)-$(NEWLIB_VERSION).tar.gz
 	$(Q) patch -p0 < newlib/0001-newlib-libm-fix-__RCSID-build-error.patch
 	$(Q) patch -p0 < newlib/0002-newlib-libm-remove-include-reent.h.patch
 	$(Q) patch -p0 < newlib/0003-newlib-fix-compilation-for-x86.patch
+	$(Q) patch -p0 < newlib/0004-newlib-disable-optmisation-for-sincos.patch
 	$(Q) touch $@
 endif
 

--- a/libs/libm/newlib/sincosl.c
+++ b/libs/libm/newlib/sincosl.c
@@ -24,10 +24,19 @@
 
 #include <math.h>
 
+/* Disable sincos optimization for all functions in this file,
+ * otherwise gcc would generate infinite calls.
+ * Refer to gcc PR46926.
+ * -fno-builtin-sin or -fno-builtin-cos can disable sincos optimization,
+ * but these two options do not work inside optimize pragma in-file.
+ * Thus we just enforce -O0 when compiling this file.
+ */
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
+nooptimiziation_function
 void sincosl(long double x, long double *s, long double *c)
 {
   *s = sinl(x);


### PR DESCRIPTION
## Summary
- libm/libm: disable optimization for sincos
- libm/newlib: disable optimization for sincos

    Disable sincos optimization otherwise gcc would generate infinite calls.
    Refer to gcc bug 46926: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=46926
    
    -fno-builtin-sin or -fno-builtin-cos can disable sincos optimization,
    but these two options do not work inside optimize pragma in-file.
    Thus we just enforce -O0 when compiling this file.

## Impact
fix broken sincos when high optimization enabled

## Testing
x86 with -O3
