### PR TITLE
arch/intel64: get TSC frequency only when not provided from Kconfig

### DIFF
--- a/arch/x86_64/src/intel64/Kconfig
+++ b/arch/x86_64/src/intel64/Kconfig
@@ -77,7 +77,8 @@ config ARCH_INTEL64_CORE_FREQ_KHZ
 	default 2000000
 	---help---
 		The CPU Core frequency (without Turbo boost). This is used
-		to set the TSC deadline timer frequency.
+		to set the TSC deadline timer frequency. If set to 0 we try to get
+		frequency from CPUID.
 
 endif
 

--- a/arch/x86_64/src/intel64/intel64_freq.c
+++ b/arch/x86_64/src/intel64/intel64_freq.c
@@ -72,7 +72,7 @@ extern unsigned long g_x86_64_timer_freq;
 void x86_64_timer_calibrate_freq(void)
 {
 #ifdef CONFIG_ARCH_INTEL64_TSC_DEADLINE
-
+#  if CONFIG_ARCH_INTEL64_CORE_FREQ_KHZ == 0
   unsigned long crystal_freq;
   unsigned long numerator;
   unsigned long denominator;
@@ -84,13 +84,15 @@ void x86_64_timer_calibrate_freq(void)
 
   if (numerator == 0 || denominator == 0 || crystal_freq == 0)
     {
-      g_x86_64_timer_freq = CONFIG_ARCH_INTEL64_CORE_FREQ_KHZ * 1000L;
+      PANIC();
     }
   else
     {
       g_x86_64_timer_freq = crystal_freq / denominator * numerator;
     }
-
+#  else
+  g_x86_64_timer_freq = CONFIG_ARCH_INTEL64_CORE_FREQ_KHZ * 1000L;
+#  endif
 #elif defined(CONFIG_ARCH_INTEL64_TSC)
   g_x86_64_timer_freq = CONFIG_ARCH_INTEL64_APIC_FREQ_KHZ * 1000L;
 #endif


### PR DESCRIPTION
## Summary
- arch/intel64: get TSC frequency only when not provided from Kconfig
  On ACRN hypervisor obtaining frequency from CPUID seems to be broken, so we have to specify this value from Kconfig.  If frequency autodetection is enabled but the returned data are incorrect - crash early.
## Impact
handle properly broken cpuid data
## Testing
x86 hardware
