### PR TITLE
esp32[c3|c6|h2]: Add GDMA support

### DIFF
--- a/Documentation/platforms/risc-v/esp32c3/index.rst
+++ b/Documentation/platforms/risc-v/esp32c3/index.rst
@@ -162,7 +162,7 @@ AES          No
 Bluetooth    No
 CAN/TWAI     Yes
 CDC Console  Yes    Rev.3
-DMA          No
+DMA          Yes
 eFuse        No
 GPIO         Yes
 I2C          No

--- a/Documentation/platforms/risc-v/esp32c6/index.rst
+++ b/Documentation/platforms/risc-v/esp32c6/index.rst
@@ -142,7 +142,7 @@ ADC              No
 AES              No
 Bluetooth        No
 CAN/TWAI         Yes
-DMA              No
+DMA              Yes
 ECC              No
 eFuse            No
 GPIO             Yes

--- a/Documentation/platforms/risc-v/esp32h2/index.rst
+++ b/Documentation/platforms/risc-v/esp32h2/index.rst
@@ -142,7 +142,7 @@ ADC              No
 AES              No
 Bluetooth        No
 CAN/TWAI         Yes
-DMA              No
+DMA              Yes
 ECC              No
 eFuse            No
 GPIO             Yes

--- a/arch/risc-v/src/common/espressif/Kconfig
+++ b/arch/risc-v/src/common/espressif/Kconfig
@@ -328,6 +328,11 @@ config ESPRESSIF_SPIFLASH
 	bool "SPI Flash"
 	default n
 
+config ESPRESSIF_DMA
+	bool "General DMA (GDMA)"
+	default n
+	select ARCH_DMA
+
 config ESPRESSIF_HR_TIMER
 	bool
 	default RTC_DRIVER

--- a/arch/risc-v/src/common/espressif/Make.defs
+++ b/arch/risc-v/src/common/espressif/Make.defs
@@ -65,6 +65,10 @@ ifeq ($(CONFIG_ESPRESSIF_HR_TIMER),y)
 	CHIP_CSRCS += esp_hr_timer.c esp_ets_timer_legacy.c
 endif
 
+ifeq ($(CONFIG_ESPRESSIF_DMA),y)
+	CHIP_CSRCS += esp_dma.c
+endif
+
 ifeq ($(CONFIG_ESPRESSIF_TWAI),y)
 	CHIP_CSRCS += esp_twai.c
 endif

--- a/arch/risc-v/src/common/espressif/esp_dma.c
+++ b/arch/risc-v/src/common/espressif/esp_dma.c
@@ -1,0 +1,417 @@
+/****************************************************************************
+ * arch/risc-v/src/common/espressif/esp_dma.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/param.h>
+#include <sys/types.h>
+#include <stdint.h>
+#include <string.h>
+#include <assert.h>
+#include <debug.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/irq.h>
+#include <nuttx/mutex.h>
+#include <nuttx/kmalloc.h>
+#include <arch/irq.h>
+
+#include "riscv_internal.h"
+#include "esp_dma.h"
+
+#include "soc/gdma_periph.h"
+#include "hal/gdma_hal.h"
+#include "hal/gdma_types.h"
+#include "hal/gdma_ll.h"
+#include "periph_ctrl.h"
+#include "hal/dma_types.h"
+
+/****************************************************************************
+ * Pre-processor Macros
+ ****************************************************************************/
+
+#ifndef ALIGN_UP
+#  define ALIGN_UP(num, align) (((num) + ((align) - 1)) & ~((align) - 1))
+#endif
+
+/* DMA channel number */
+
+#define ESPRESSIF_DMA_CHAN_MAX  (SOC_GDMA_PAIRS_PER_GROUP)
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static bool g_dma_chan_used[ESPRESSIF_DMA_CHAN_MAX];
+static mutex_t g_dma_lock = NXMUTEX_INITIALIZER;
+static gdma_hal_context_t ctx;
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: esp_dma_request
+ *
+ * Description:
+ *   Request DMA channel and config it with given parameters.
+ *
+ * Input Parameters:
+ *   periph   - Peripheral for which the DMA channel request was made
+ *   tx_prio  - Interrupt priority
+ *   rx_prio  - Interrupt flags
+ *   burst_en - Enable burst transmission
+ *
+ * Returned Value:
+ *   DMA channel number (>=0) if success or -1 if fail.
+ *
+ ****************************************************************************/
+
+int32_t esp_dma_request(enum esp_dma_periph_e periph,
+                        uint32_t tx_prio,
+                        uint32_t rx_prio,
+                        bool burst_en)
+{
+  int chan;
+
+  DEBUGASSERT((periph  <= (int)ESPRESSIF_DMA_PERIPH_PARLIO));
+
+  DEBUGASSERT(tx_prio <= GDMA_LL_CHANNEL_MAX_PRIORITY);
+  DEBUGASSERT(rx_prio <= GDMA_LL_CHANNEL_MAX_PRIORITY);
+
+  dmainfo("periph=%" PRIu32 " tx_prio=%" PRIu32 " rx_prio=%" PRIu32 "\n",
+          (uint32_t)periph, tx_prio, rx_prio);
+
+  nxmutex_lock(&g_dma_lock);
+
+  for (chan = 0; chan < SOC_GDMA_PAIRS_PER_GROUP; chan++)
+    {
+      if (!g_dma_chan_used[chan])
+        {
+          g_dma_chan_used[chan] = true;
+          break;
+        }
+    }
+
+  if (chan == SOC_GDMA_PAIRS_PER_GROUP)
+    {
+      dmaerr("No available GDMA channel for allocation\n");
+
+      nxmutex_unlock(&g_dma_lock);
+      return ERROR;
+    }
+
+  dmainfo("Allocated channel=%d\n", chan);
+
+  gdma_ll_rx_connect_to_periph(ctx.dev, chan, periph, periph);
+  gdma_ll_tx_connect_to_periph(ctx.dev, chan, periph, periph);
+
+  if (burst_en)
+    {
+      /* Enable DMA TX/RX channels burst sending data */
+
+      gdma_ll_tx_enable_data_burst(ctx.dev, chan, true);
+      gdma_ll_rx_enable_data_burst(ctx.dev, chan, true);
+
+      /* Enable DMA TX/RX channels burst reading descriptor link */
+
+      gdma_ll_tx_enable_descriptor_burst(ctx.dev, chan, true);
+      gdma_ll_rx_enable_descriptor_burst(ctx.dev, chan, true);
+    }
+
+  /* Set priority for DMA TX/RX channels */
+
+  gdma_ll_tx_set_priority(ctx.dev, chan, tx_prio);
+  gdma_ll_rx_set_priority(ctx.dev, chan, rx_prio);
+
+  nxmutex_unlock(&g_dma_lock);
+  return chan;
+}
+
+/****************************************************************************
+ * Name: esp_dma_setup
+ *
+ * Description:
+ *   Set up DMA descriptor with given parameters.
+ *
+ * Input Parameters:
+ *   chan    - DMA channel
+ *   tx      - true: TX mode; false: RX mode
+ *   dmadesc - DMA descriptor pointer
+ *   num     - DMA descriptor number
+ *   pbuf    - Buffer pointer
+ *   len     - Buffer length by byte
+ *
+ * Returned Value:
+ *   Bind pbuf data bytes.
+ *
+ ****************************************************************************/
+
+uint32_t esp_dma_setup(int chan, bool tx,
+                       struct esp_dmadesc_s *dmadesc, uint32_t num,
+                       uint8_t *pbuf, uint32_t len)
+{
+  int i;
+  uint32_t regval;
+  uint32_t bytes = len;
+  uint8_t *pdata = pbuf;
+  uint32_t data_len;
+  uint32_t buf_len;
+  dma_descriptor_t *dma_desc = (dma_descriptor_t *)dmadesc;
+
+  DEBUGASSERT(chan >= 0);
+  DEBUGASSERT(dmadesc != NULL);
+  DEBUGASSERT(num > 0);
+  DEBUGASSERT(pbuf != NULL);
+  DEBUGASSERT(len > 0);
+
+  for (i = 0; i < num; i++)
+    {
+      data_len = MIN(bytes, ESPRESSIF_DMA_BUFLEN_MAX);
+
+      /* Buffer length must be rounded to next 32-bit boundary. */
+
+      buf_len = ALIGN_UP(data_len, sizeof(uintptr_t));
+
+      dma_desc[i].dw0.size = buf_len;
+      dma_desc[i].dw0.length = data_len;
+      dma_desc[i].dw0.owner = 1;
+      dma_desc[i].buffer = pdata;
+
+      dmadesc[i].next = &dmadesc[i + 1];
+
+      bytes -= data_len;
+      if (bytes == 0)
+        {
+          break;
+        }
+
+      pdata += data_len;
+    }
+
+  dma_desc[i].dw0.suc_eof = 1;
+  dmadesc[i].next  = NULL;
+
+  if (tx)
+    {
+      /* Reset DMA TX channel FSM and FIFO pointer */
+
+      gdma_ll_tx_reset_channel(ctx.dev, chan);
+
+      /* Set the descriptor link base address for TX channel */
+
+      gdma_ll_tx_set_desc_addr(ctx.dev, chan, (uint32_t)dmadesc);
+    }
+  else
+    {
+      /* Reset DMA RX channel FSM and FIFO pointer */
+
+      gdma_ll_rx_reset_channel(ctx.dev, chan);
+
+      /* Set the descriptor link base address for RX channel */
+
+      gdma_ll_rx_set_desc_addr(ctx.dev, chan, (uint32_t)dmadesc);
+    }
+
+  return len - bytes;
+}
+
+/****************************************************************************
+ * Name: esp_dma_load
+ *
+ * Description:
+ *   Load the address of the first DMA descriptor of an already bound
+ *   inlink/outlink to the corresponding GDMA_<IN/OUT>LINK_ADDR_CHn register
+ *
+ * Input Parameters:
+ *   dmadesc - Pointer of the previously bound inlink/outlink
+ *   chan    - DMA channel of the receiver/transmitter
+ *   tx      - true: TX mode (transmitter); false: RX mode (receiver)
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void esp_dma_load(struct esp_dmadesc_s *dmadesc, int chan, bool tx)
+{
+  uint32_t regval;
+
+  DEBUGASSERT(chan >= 0);
+  DEBUGASSERT(dmadesc != NULL);
+
+  if (tx)
+    {
+      /* Reset DMA TX channel FSM and FIFO pointer */
+
+      gdma_ll_rx_reset_channel(ctx.dev, chan);
+
+      /* Set the descriptor link base address for TX channel */
+
+      gdma_ll_tx_set_desc_addr(ctx.dev, chan, (uint32_t)dmadesc);
+    }
+  else
+    {
+      /* Reset DMA RX channel FSM and FIFO pointer */
+
+      gdma_ll_rx_reset_channel(ctx.dev, chan);
+
+      /* Set the descriptor link base address for RX channel */
+
+      gdma_ll_rx_set_desc_addr(ctx.dev, chan, (uint32_t)dmadesc);
+    }
+}
+
+/****************************************************************************
+ * Name: esp_dma_enable
+ *
+ * Description:
+ *   Enable DMA channel transmission.
+ *
+ * Input Parameters:
+ *   chan - DMA channel
+ *   tx   - true: TX mode; false: RX mode
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void esp_dma_enable(int chan, bool tx)
+{
+  if (tx)
+    {
+      gdma_ll_tx_start(ctx.dev, chan);
+    }
+  else
+    {
+      gdma_ll_rx_start(ctx.dev, chan);
+    }
+}
+
+/****************************************************************************
+ * Name: esp_dma_disable
+ *
+ * Description:
+ *   Disable DMA channel transmission.
+ *
+ * Input Parameters:
+ *   chan - DMA channel
+ *   tx   - true: TX mode; false: RX mode
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void esp_dma_disable(int chan, bool tx)
+{
+  if (tx)
+    {
+      gdma_ll_tx_stop(ctx.dev, chan);
+    }
+  else
+    {
+      gdma_ll_rx_stop(ctx.dev, chan);
+    }
+}
+
+/****************************************************************************
+ * Name: esp_dma_wait_idle
+ *
+ * Description:
+ *   Wait until transmission ends.
+ *
+ * Input Parameters:
+ *   chan - DMA channel
+ *   tx   - true: TX mode; false: RX mode
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void esp_dma_wait_idle(int chan, bool tx)
+{
+  if (tx)
+    {
+      while (gdma_ll_tx_is_fsm_idle(ctx.dev, chan) == 0);
+    }
+  else
+    {
+      while (gdma_ll_rx_is_fsm_idle(ctx.dev, chan) == 0);
+    }
+}
+
+/****************************************************************************
+ * Name: esp_dma_init
+ *
+ * Description:
+ *   Initialize DMA driver.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void esp_dma_init(void)
+{
+  periph_module_enable(PERIPH_GDMA_MODULE);
+  gdma_hal_init(&ctx, 0);
+  gdma_ll_enable_clock(ctx.dev, true);
+}
+
+/****************************************************************************
+ * Name: esp_dma_deinit
+ *
+ * Description:
+ *   Deinitialize DMA driver.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void esp_dma_deinit(void)
+{
+  nxmutex_lock(&g_dma_lock);
+
+  /* Disable DMA clock gating */
+
+  gdma_ll_enable_clock(ctx.dev, false);
+
+  /* Disable DMA module by gating the clock and asserting the reset
+   * signal.
+   */
+
+  periph_module_disable(PERIPH_GDMA_MODULE);
+
+  nxmutex_unlock(&g_dma_lock);
+}

--- a/arch/risc-v/src/common/espressif/esp_dma.h
+++ b/arch/risc-v/src/common/espressif/esp_dma.h
@@ -1,0 +1,240 @@
+/****************************************************************************
+ * arch/risc-v/src/common/espressif/esp_dma.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#ifndef __ARCH_RISCV_SRC_COMMON_ESPRESSIF_ESP_DMA_H
+#define __ARCH_RISCV_SRC_COMMON_ESPRESSIF_ESP_DMA_H
+
+#include <nuttx/config.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifndef __ASSEMBLY__
+
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Pre-processor Macros
+ ****************************************************************************/
+
+/* DMA max data length */
+
+#define ESPRESSIF_DMA_DATALEN_MAX (0x1000 - 4)
+
+/* DMA max buffer length */
+
+#define ESPRESSIF_DMA_BUFLEN_MAX  ESPRESSIF_DMA_DATALEN_MAX
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+enum esp_dma_periph_e
+{
+  ESPRESSIF_DMA_PERIPH_M2M,
+  ESPRESSIF_DMA_PERIPH_UHCI,
+  ESPRESSIF_DMA_PERIPH_SPI,
+  ESPRESSIF_DMA_PERIPH_I2S,
+  ESPRESSIF_DMA_PERIPH_AES,
+  ESPRESSIF_DMA_PERIPH_SHA,
+  ESPRESSIF_DMA_PERIPH_ADC,
+  ESPRESSIF_DMA_PERIPH_DAC,
+  ESPRESSIF_DMA_PERIPH_LCD,
+  ESPRESSIF_DMA_PERIPH_CAM,
+  ESPRESSIF_DMA_PERIPH_RMT,
+  ESPRESSIF_DMA_PERIPH_PARLIO,
+};
+
+/* DMA descriptor type */
+
+struct esp_dmadesc_s
+{
+  uint32_t ctrl;                /* DMA control block */
+  const uint8_t *pbuf;          /* DMA TX/RX buffer address */
+  struct esp_dmadesc_s *next;   /* Next DMA descriptor address */
+};
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: esp_dma_request
+ *
+ * Description:
+ *   Request DMA channel and config it with given parameters.
+ *
+ * Input Parameters:
+ *   periph  - Peripheral for which the DMA channel request was made
+ *   tx_prio - Interrupt priority
+ *   rx_prio - Interrupt flags
+ *
+ * Returned Value:
+ *   DMA channel number (>=0) if success or -1 if fail.
+ *
+ ****************************************************************************/
+
+int32_t esp_dma_request(enum esp_dma_periph_e periph,
+                        uint32_t tx_prio,
+                        uint32_t rx_prio,
+                        bool burst_en);
+
+/****************************************************************************
+ * Name: esp_dma_setup
+ *
+ * Description:
+ *   Set up DMA descriptor with given parameters.
+ *
+ * Input Parameters:
+ *   chan    - DMA channel
+ *   tx      - true: TX mode; false: RX mode
+ *   dmadesc - DMA descriptor pointer
+ *   num     - DMA descriptor number
+ *   pbuf    - Buffer pointer
+ *   len     - Buffer length by byte
+ *
+ * Returned Value:
+ *   Bind pbuf data bytes.
+ *
+ ****************************************************************************/
+
+uint32_t esp_dma_setup(int chan, bool tx,
+                       struct esp_dmadesc_s *dmadesc, uint32_t num,
+                       uint8_t *pbuf, uint32_t len);
+
+/****************************************************************************
+ * Name: esp_dma_load
+ *
+ * Description:
+ *   Load the address of the first DMA descriptor of an already bound
+ *   inlink/outlink to the corresponding GDMA_<IN/OUT>LINK_ADDR_CHn register
+ *
+ * Input Parameters:
+ *   dmadesc - Pointer of the previously bound inlink/outlink
+ *   chan    - DMA channel of the receiver/transmitter
+ *   tx      - true: TX mode (transmitter); false: RX mode (receiver)
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void esp_dma_load(struct esp_dmadesc_s *dmadesc, int chan, bool tx);
+
+/****************************************************************************
+ * Name: esp_dma_enable
+ *
+ * Description:
+ *   Enable DMA channel transmission.
+ *
+ * Input Parameters:
+ *   chan - DMA channel
+ *   tx   - true: TX mode; false: RX mode
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void esp_dma_enable(int chan, bool tx);
+
+/****************************************************************************
+ * Name: esp_dma_disable
+ *
+ * Description:
+ *   Disable DMA channel transmission.
+ *
+ * Input Parameters:
+ *   chan - DMA channel
+ *   tx   - true: TX mode; false: RX mode
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void esp_dma_disable(int chan, bool tx);
+
+/****************************************************************************
+ * Name: esp_dma_wait_idle
+ *
+ * Description:
+ *   Wait until transmission ends.
+ *
+ * Input Parameters:
+ *   chan - DMA channel
+ *   tx   - true: TX mode; false: RX mode
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void esp_dma_wait_idle(int chan, bool tx);
+
+/****************************************************************************
+ * Name: esp_dma_init
+ *
+ * Description:
+ *   Initialize DMA driver.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void esp_dma_init(void);
+
+/****************************************************************************
+ * Name: esp_dma_deinit
+ *
+ * Description:
+ *   Deinitialize DMA driver.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void esp_dma_deinit(void);
+
+#ifdef __cplusplus
+}
+#endif
+#undef EXTERN
+
+#endif /* __ASSEMBLY__ */
+#endif /* __ARCH_RISCV_SRC_COMMON_ESPRESSIF_ESP_DMA_H */

--- a/arch/risc-v/src/esp32c3/hal_esp32c3.mk
+++ b/arch/risc-v/src/esp32c3/hal_esp32c3.mk
@@ -115,6 +115,7 @@ CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)esp_
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)hal$(DELIM)adc_hal_common.c
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)hal$(DELIM)brownout_hal.c
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)hal$(DELIM)efuse_hal.c
+CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)hal$(DELIM)gdma_hal.c
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)hal$(DELIM)gpio_hal.c
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)hal$(DELIM)ledc_hal.c
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)hal$(DELIM)ledc_hal_iram.c

--- a/arch/risc-v/src/esp32c6/hal_esp32c6.mk
+++ b/arch/risc-v/src/esp32c6/hal_esp32c6.mk
@@ -120,6 +120,7 @@ CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)esp_
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)esp_system$(DELIM)port$(DELIM)soc$(DELIM)$(CHIP_SERIES)$(DELIM)system_internal.c
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)hal$(DELIM)brownout_hal.c
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)hal$(DELIM)efuse_hal.c
+CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)hal$(DELIM)gdma_hal.c
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)hal$(DELIM)gpio_hal.c
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)hal$(DELIM)ledc_hal.c
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)hal$(DELIM)ledc_hal_iram.c

--- a/arch/risc-v/src/esp32h2/hal_esp32h2.mk
+++ b/arch/risc-v/src/esp32h2/hal_esp32h2.mk
@@ -106,6 +106,7 @@ CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)esp_
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)hal$(DELIM)brownout_hal.c
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)hal$(DELIM)cache_hal.c
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)hal$(DELIM)efuse_hal.c
+CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)hal$(DELIM)gdma_hal.c
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)hal$(DELIM)gpio_hal.c
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)hal$(DELIM)ledc_hal.c
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)hal$(DELIM)ledc_hal_iram.c


### PR DESCRIPTION
## Summary

- esp32[c3|c6|h2]: Add GDMA support

## Impact

ESP32-C3, ESP32-C6 and ESP32-H2

## Testing

Tested with a custom app
