### PR TITLE
arch/riscv: add all region in NAPOT

### DIFF
--- a/arch/risc-v/src/common/riscv_pmp.c
+++ b/arch/risc-v/src/common/riscv_pmp.c
@@ -134,6 +134,13 @@ static bool pmp_check_region_attrs(uintptr_t base, uintptr_t size,
 
     case PMPCFG_A_NAPOT:
       {
+        /* Special range for the whole range */
+
+        if (base == 0 && size == 0)
+          {
+            return true;
+          }
+
         /* For NAPOT, Naturally aligned power-of-two region, >= 8 bytes */
 
         if ((base & 0x07) != 0 || size < 8 || (size & (size - 1)) != 0)


### PR DESCRIPTION
## Summary

This allows using 0 base and size as the special whole region in NAPOT format, as sometimes we need permissive entry at tail of PMP list.

## Impact

PMP configuration

## Testing

- local check on CanMV230
- CI checks
