### PR TITLE
arm64: inline up_cpu_index

### DIFF
--- a/arch/arm64/include/fvp-v8r/irq.h
+++ b/arch/arm64/include/fvp-v8r/irq.h
@@ -29,6 +29,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define NR_IRQS                 220  /* Total number of interrupts */
+#define NR_IRQS            220  /* Total number of interrupts */
+#define MPID_TO_CORE(mpid) (((mpid) >> MPIDR_AFF0_SHIFT) & MPIDR_AFFLVL_MASK)
 
 #endif /* __ARCH_ARM64_INCLUDE_FVP_V8R_IRQ_H */

--- a/arch/arm64/include/goldfish/irq.h
+++ b/arch/arm64/include/goldfish/irq.h
@@ -29,6 +29,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define NR_IRQS                 220  /* Total number of interrupts */
+#define NR_IRQS            220  /* Total number of interrupts */
+#define MPID_TO_CORE(mpid) (((mpid) >> MPIDR_AFF0_SHIFT) & MPIDR_AFFLVL_MASK)
 
 #endif /* __ARCH_ARM64_INCLUDE_GOLDFISH_IRQ_H */

--- a/arch/arm64/include/qemu/irq.h
+++ b/arch/arm64/include/qemu/irq.h
@@ -29,6 +29,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define NR_IRQS                 220  /* Total number of interrupts */
+#define NR_IRQS            220  /* Total number of interrupts */
+#define MPID_TO_CORE(mpid) (((mpid) >> MPIDR_AFF0_SHIFT) & MPIDR_AFFLVL_MASK)
 
 #endif /* __ARCH_ARM64_INCLUDE_QEMU_IRQ_H */

--- a/arch/arm64/src/common/arm64_arch.h
+++ b/arch/arm64/src/common/arm64_arch.h
@@ -148,38 +148,10 @@
 
 #define GET_EL(mode)  (((mode) >> MODE_EL_SHIFT) & MODE_EL_MASK)
 
-/* MPIDR_EL1, Multiprocessor Affinity Register */
-
-#define MPIDR_AFFLVL_MASK   (0xff)
-#define MPIDR_ID_MASK       (0xff00ffffff)
-
-#define MPIDR_AFF0_SHIFT    (0)
-#define MPIDR_AFF1_SHIFT    (8)
-#define MPIDR_AFF2_SHIFT    (16)
-#define MPIDR_AFF3_SHIFT    (32)
-
-/* mpidr_el1 register, the register is define:
- *   - bit 0~7:   Aff0
- *   - bit 8~15:  Aff1
- *   - bit 16~23: Aff2
- *   - bit 24:    MT, multithreading
- *   - bit 25~29: RES0
- *   - bit 30:    U, multiprocessor/Uniprocessor
- *   - bit 31:    RES1
- *   - bit 32~39: Aff3
- *   - bit 40~63: RES0
- *   Different ARM64 Core will use different Affn define, the mpidr_el1
- *  value is not CPU number, So we need to change CPU number to mpid
- *  and vice versa
- */
-
-#define GET_MPIDR()             read_sysreg(mpidr_el1)
+#define MPIDR_ID_MASK (0xff00ffffff)
 
 #define MPIDR_AFFLVL(mpidr, aff_level) \
   (((mpidr) >> MPIDR_AFF ## aff_level ## _SHIFT) & MPIDR_AFFLVL_MASK)
-
-#define MPID_TO_CORE(mpid, aff_level) \
-  (((mpid) >> MPIDR_AFF ## aff_level ## _SHIFT) & MPIDR_AFFLVL_MASK)
 
 #define CORE_TO_MPID(core, aff_level) \
   ({ \

--- a/arch/arm64/src/fvp-v8r/fvp_boot.c
+++ b/arch/arm64/src/fvp-v8r/fvp_boot.c
@@ -121,35 +121,6 @@ void arm64_el_init(void)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_cpu_index
- *
- * Description:
- *   Return an index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- *   If TLS is enabled, then the RTOS can get this information from the TLS
- *   info structure.  Otherwise, the MCU-specific logic must provide some
- *   mechanism to provide the CPU index.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   An integer index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- ****************************************************************************/
-
-int up_cpu_index(void)
-{
-  /* Read the Multiprocessor Affinity Register (MPIDR)
-   * And return the CPU ID field
-   */
-
-  return MPID_TO_CORE(GET_MPIDR(), 0);
-}
-
-/****************************************************************************
  * Name: arm64_get_mpid
  *
  * Description:
@@ -175,7 +146,7 @@ uint64_t arm64_get_mpid(int cpu)
 
 int arm64_get_cpuid(uint64_t mpid)
 {
-  return MPID_TO_CORE(mpid, 0);
+  return MPID_TO_CORE(mpid);
 }
 
 #endif /* CONFIG_SMP */

--- a/arch/arm64/src/goldfish/goldfish_boot.c
+++ b/arch/arm64/src/goldfish/goldfish_boot.c
@@ -85,35 +85,6 @@ const struct arm_mmu_config g_mmu_config =
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_cpu_index
- *
- * Description:
- *   Return an index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- *   If TLS is enabled, then the RTOS can get this information from the TLS
- *   info structure.  Otherwise, the MCU-specific logic must provide some
- *   mechanism to provide the CPU index.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   An integer index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- ****************************************************************************/
-
-int up_cpu_index(void)
-{
-  /* Read the Multiprocessor Affinity Register (MPIDR)
-   * And return the CPU ID field
-   */
-
-  return MPID_TO_CORE(GET_MPIDR(), 0);
-}
-
-/****************************************************************************
  * Name: arm64_get_mpid
  *
  * Description:
@@ -139,7 +110,7 @@ uint64_t arm64_get_mpid(int cpu)
 
 int arm64_get_cpuid(uint64_t mpid)
 {
-  return MPID_TO_CORE(mpid, 0);
+  return MPID_TO_CORE(mpid);
 }
 
 #endif /* CONFIG_SMP */

--- a/arch/arm64/src/qemu/qemu_boot.c
+++ b/arch/arm64/src/qemu/qemu_boot.c
@@ -81,35 +81,6 @@ const struct arm_mmu_config g_mmu_config =
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_cpu_index
- *
- * Description:
- *   Return an index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- *   If TLS is enabled, then the RTOS can get this information from the TLS
- *   info structure.  Otherwise, the MCU-specific logic must provide some
- *   mechanism to provide the CPU index.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   An integer index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- ****************************************************************************/
-
-int up_cpu_index(void)
-{
-  /* Read the Multiprocessor Affinity Register (MPIDR)
-   * And return the CPU ID field
-   */
-
-  return MPID_TO_CORE(GET_MPIDR(), 0);
-}
-
-/****************************************************************************
  * Name: arm64_get_mpid
  *
  * Description:
@@ -135,7 +106,7 @@ uint64_t arm64_get_mpid(int cpu)
 
 int arm64_get_cpuid(uint64_t mpid)
 {
-  return MPID_TO_CORE(mpid, 0);
+  return MPID_TO_CORE(mpid);
 }
 
 #endif /* CONFIG_SMP */


### PR DESCRIPTION
## Summary
arm64: inline up_cpu_index

## Impact
reduce the time consumed by function call

## Testing
We can use qemu for testing.
compiling
make distclean -j20; ./tools/configure.sh -l qemu-armv8a:nsh_smp ;make -j20 running
qemu-system-aarch64 -cpu cortex-a53 -smp 4 -nographic -machine virt,virtualization=on,gic-version=3 -net none -chardev stdio,id=con,mux=on -serial chardev:con -mon chardev=con,mode=readline -kernel ./nuttx
