### PR TITLE
cmake: Fix build failure when -DNUTTX_APPS_DIR is specified

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,7 @@ endif()
 include(nuttx_kconfig)
 nuttx_export_kconfig_by_value(${NUTTX_DEFCONFIG} "CONFIG_APPS_DIR")
 
-if(NOT CONFIG_APPS_DIR)
+if((NOT NUTTX_APPS_DIR) AND (NOT CONFIG_APPS_DIR))
   if(EXISTS "${NUTTX_DIR}/../apps")
     set(NUTTX_APPS_DIR "${NUTTX_DIR}/../apps")
   elseif(EXISTS "${NUTTX_DIR}/../nuttx-apps")


### PR DESCRIPTION
## Summary
Fix cmake build failure that apps directory is not found when -DNUTTX_APPS_DIR is specified.

## Impact
CMake build when -DNUTTX_APPS_DIR is specified.

## Testing

