### PR TITLE
Fix cmake for cxd56xx

### DIFF
--- a/arch/arm/src/cxd56xx/CMakeLists.txt
+++ b/arch/arm/src/cxd56xx/CMakeLists.txt
@@ -120,6 +120,13 @@ if(CONFIG_CXD56_CHARGER)
   list(APPEND SRCS cxd56_charger.c)
 endif()
 
+if(CONFIG_AUDIO_CXD56)
+  list(APPEND SRCS cxd56_nxaudio.c)
+  if(CONFIG_AUDIO_CXD56_SRC)
+    list(APPEND SRCS cxd56_nxaudio_src.c)
+  endif()
+endif()
+
 if(CONFIG_CXD56_GE2D)
   list(APPEND SRCS cxd56_ge2d.c)
 endif()

--- a/arch/arm/src/cxd56xx/CMakeLists.txt
+++ b/arch/arm/src/cxd56xx/CMakeLists.txt
@@ -163,4 +163,8 @@ if(CONFIG_CXD56_HOSTIF)
   list(APPEND SRCS cxd56_hostif.c)
 endif()
 
+if(CONFIG_CXD56_GNSS_HEAP)
+  list(APPEND SRCS cxd56_gnssheap.c)
+endif()
+
 target_sources(arch PRIVATE ${SRCS})

--- a/boards/arm/cxd56xx/common/CMakeLists.txt
+++ b/boards/arm/cxd56xx/common/CMakeLists.txt
@@ -27,8 +27,8 @@ if(CONFIG_ARCH_BOARD_COMMON)
     list(APPEND SRCS src/cxd56_audio.c)
   endif()
 
-  if(CONFIG_MODEM_ALTMDM)
-    list(APPEND SRCS src/cxd56_altmdm.c)
+  if(CONFIG_MODEM_ALT1250)
+    list(APPEND SRCS src/cxd56_alt1250.c)
   endif()
 
   if(CONFIG_BOARDCTL_UNIQUEID)
@@ -177,6 +177,10 @@ if(CONFIG_ARCH_BOARD_COMMON)
 
   if(CONFIG_BOARD_USBDEV_SERIALSTR)
     list(APPEND SRCS src/cxd56_usbdevserialstr.c)
+  endif()
+
+  if(CONFIG_PM)
+    list(APPEND SRCS src/cxd56_pm.c)
   endif()
 
   if(CONFIG_CXD56_GNSS_ADDON)

--- a/boards/arm/cxd56xx/drivers/CMakeLists.txt
+++ b/boards/arm/cxd56xx/drivers/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/cxd56xx/drivers/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+nuttx_add_subdirectory()

--- a/boards/arm/cxd56xx/drivers/audio/CMakeLists.txt
+++ b/boards/arm/cxd56xx/drivers/audio/CMakeLists.txt
@@ -1,0 +1,41 @@
+# ##############################################################################
+# boards/arm/cxd56xx/drivers/audio/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_CXD56_AUDIO)
+  set(SRCS
+      cxd56_audio.c
+      cxd56_audio_config.c
+      cxd56_audio_analog.c
+      cxd56_audio_power.c
+      cxd56_audio_filter.c
+      cxd56_audio_mic.c
+      cxd56_audio_volume.c
+      cxd56_audio_digital.c
+      cxd56_audio_beep.c
+      cxd56_audio_irq.c
+      cxd56_audio_dma.c
+      cxd56_audio_ac_reg.c
+      cxd56_audio_bca_reg.c
+      cxd56_audio_aca.c
+      cxd56_audio_pin.c)
+
+  target_sources(drivers PRIVATE ${SRCS})
+  target_include_directories(drivers PRIVATE ${NUTTX_CHIP_ABS_DIR})
+endif()

--- a/boards/arm/cxd56xx/drivers/sensors/CMakeLists.txt
+++ b/boards/arm/cxd56xx/drivers/sensors/CMakeLists.txt
@@ -1,0 +1,71 @@
+# ##############################################################################
+# boards/arm/cxd56xx/drivers/sensors/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS)
+
+if(CONFIG_SENSORS_AK09912_SCU)
+  list(APPEND SRC ak09912_scu.c)
+endif()
+
+if(CONFIG_SENSORS_APDS9930_SCU)
+  list(APPEND SRC apds9930_scu.c)
+endif()
+
+if(CONFIG_SENSORS_BH1721FVC_SCU)
+  list(APPEND SRC bh1721fvc_scu.c)
+endif()
+
+if(CONFIG_SENSORS_BH1745NUC_SCU)
+  list(APPEND SRC bh1745nuc_scu.c)
+endif()
+
+if(CONFIG_SENSORS_BM1383GLV_SCU)
+  list(APPEND SRC bm1383glv_scu.c)
+endif()
+
+if(CONFIG_SENSORS_BM1422GMV_SCU)
+  list(APPEND SRC bm1422gmv_scu.c)
+endif()
+
+if(CONFIG_SENSORS_BMI160_SCU)
+  list(APPEND SRC bmi160_scu.c)
+endif()
+
+if(CONFIG_SENSORS_BMP280_SCU)
+  list(APPEND SRC bmp280_scu.c)
+endif()
+
+if(CONFIG_SENSORS_KX022_SCU)
+  list(APPEND SRC kx022_scu.c)
+endif()
+
+if(CONFIG_SENSORS_LT1PA01_SCU)
+  list(APPEND SRC lt1pa01_scu.c)
+endif()
+
+if(CONFIG_SENSORS_RPR0521RS_SCU)
+  list(APPEND SRC rpr0521rs_scu.c)
+endif()
+
+if(CONFIG_SENSORS_CXD5610_GNSS)
+  list(APPEND SRC cxd5610_gnss.c)
+endif()
+
+target_sources(drivers PRIVATE ${SRCS})

--- a/boards/arm/cxd56xx/spresense/src/CMakeLists.txt
+++ b/boards/arm/cxd56xx/spresense/src/CMakeLists.txt
@@ -41,9 +41,7 @@ if(CONFIG_ARCH_BUTTONS)
   list(APPEND SRCS cxd56_buttons.c)
 endif()
 
-if(CONFIG_CXD56_GPIO_IRQ)
-  list(APPEND SRCS cxd56_gpioif.c)
-endif()
+list(APPEND SRCS cxd56_gpioif.c)
 
 if(CONFIG_CXD56_PWM)
   list(APPEND SRCS cxd56_pwm.c)

--- a/drivers/audio/CMakeLists.txt
+++ b/drivers/audio/CMakeLists.txt
@@ -23,13 +23,6 @@
 if(CONFIG_DRIVERS_AUDIO)
   set(SRCS)
 
-  if(CONFIG_AUDIO_CXD56)
-    list(APPEND SRCS cxd56.c)
-    if(CONFIG_AUDIO_CXD56_SRC)
-      list(APPEND SRCS cxd56_src.c)
-    endif()
-  endif()
-
   if(CONFIG_AUDIO_VS1053)
     list(APPEND SRCS vs1053.c)
   endif()


### PR DESCRIPTION
## Summary
* arch: cxd56xx: Add audio sources to CMakeLists.txt
* arch: cxd56xx: Add gnss source to CMakeLists.txt
* drivers/audio: Remove useless descriptions from CMakeLists.txt
* boards: cxd56xx: Fix CMakeLists.txt
* boards: cxd56xx: Add CMakeLists.txt for the specific drivers

## Impact
Only for spresense board

## Testing

