### PR TITLE
libc/execinfo: extract a common backtrace format function

### DIFF
--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -38,6 +38,7 @@
 #include <errno.h>
 #include <debug.h>
 #include <malloc.h>
+#include <execinfo.h>
 
 #ifdef CONFIG_SCHED_CRITMONITOR
 #  include <time.h>

--- a/include/execinfo.h
+++ b/include/execinfo.h
@@ -27,15 +27,24 @@
 
 #include <nuttx/sched.h>
 
+#include <assert.h>
+#include <stdio.h>
 #include <sys/types.h>
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define backtrace(buffer, size) sched_backtrace(_SCHED_GETTID(), \
-                                                buffer, size, 0)
-#define dump_stack()            sched_dumpstack(_SCHED_GETTID())
+/* 3: ' 0x' prefix */
+
+#define BACKTRACE_PTR_FMT_WIDTH  ((int)sizeof(uintptr_t) * 2 + 3)
+
+/* Buffer size needed to hold formatted `depth` backtraces */
+
+#define BACKTRACE_BUFFER_SIZE(d) (BACKTRACE_PTR_FMT_WIDTH * (d) + 1)
+
+#define backtrace(b, s) sched_backtrace(_SCHED_GETTID(), b, s, 0)
+#define dump_stack()    sched_dumpstack(_SCHED_GETTID())
 
 /****************************************************************************
  * Public Function Prototypes
@@ -52,6 +61,8 @@ extern "C"
 
 FAR char **backtrace_symbols(FAR void *const *buffer, int size);
 void backtrace_symbols_fd(FAR void *const *buffer, int size, int fd);
+int backtrace_format(FAR char *buffer, int size,
+                     FAR void *backtrace[], int depth);
 
 #undef EXTERN
 #if defined(__cplusplus)

--- a/libs/libc/misc/lib_execinfo.c
+++ b/libs/libc/misc/lib_execinfo.c
@@ -88,3 +88,39 @@ void backtrace_symbols_fd(FAR void *const *buffer, int size, int fd)
       dprintf(fd, "%pS\n", buffer[i]);
     }
 }
+
+/****************************************************************************
+ * Name: backtrace_format
+ *
+ * Description:
+ *  Format a backtrace into a buffer for dumping.
+ *
+ ****************************************************************************/
+
+int backtrace_format(FAR char *buffer, int size,
+                     FAR void *backtrace[], int depth)
+{
+  FAR const char *format = "%0*p ";
+  int len = 0;
+  int i;
+
+  if (size < 1)
+    {
+      return 0;
+    }
+
+  buffer[0] = '\0';
+  for (i = 0; i < depth && backtrace[i]; i++)
+    {
+      if (i * BACKTRACE_PTR_FMT_WIDTH >= size)
+        {
+          break;
+        }
+
+      len += snprintf(buffer + i * BACKTRACE_PTR_FMT_WIDTH,
+                      size - i * BACKTRACE_PTR_FMT_WIDTH,
+                      format, BACKTRACE_PTR_FMT_WIDTH - 1, backtrace[i]);
+    }
+
+  return len;
+}

--- a/mm/mempool/mempool.c
+++ b/mm/mempool/mempool.c
@@ -23,6 +23,7 @@
  ****************************************************************************/
 
 #include <assert.h>
+#include <execinfo.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <syslog.h>
@@ -32,12 +33,6 @@
 #include <nuttx/sched.h>
 
 #include "kasan/kasan.h"
-
-#if UINTPTR_MAX <= UINT32_MAX
-#  define MM_PTR_FMT_WIDTH 11
-#elif UINTPTR_MAX <= UINT64_MAX
-#  define MM_PTR_FMT_WIDTH 19
-#endif
 
 #undef  ALIGN_UP
 #define ALIGN_UP(x, a) (((x) + ((a) - 1)) & (~((a) - 1)))
@@ -484,13 +479,13 @@ void mempool_memdump(FAR struct mempool_s *pool,
       sq_for_every(&pool->queue, entry)
         {
           syslog(LOG_INFO, "%12zu%*p\n",
-                 blocksize, MM_PTR_FMT_WIDTH, (FAR char *)entry);
+                 blocksize, BACKTRACE_PTR_FMT_WIDTH, (FAR char *)entry);
         }
 
       sq_for_every(&pool->iqueue, entry)
         {
           syslog(LOG_INFO, "%12zu%*p\n",
-                 blocksize, MM_PTR_FMT_WIDTH, (FAR char *)entry);
+                 blocksize, BACKTRACE_PTR_FMT_WIDTH, (FAR char *)entry);
         }
     }
 #if CONFIG_MM_BACKTRACE >= 0
@@ -506,23 +501,19 @@ void mempool_memdump(FAR struct mempool_s *pool,
                MM_DUMP_LEAK(dump->pid, buf->pid)) &&
               buf->seqno >= dump->seqmin && buf->seqno <= dump->seqmax)
             {
-              char tmp[CONFIG_MM_BACKTRACE * MM_PTR_FMT_WIDTH + 1] = "";
-
 #  if CONFIG_MM_BACKTRACE > 0
-              FAR const char *format = " %0*p";
-              int i;
+              char tmp[BACKTRACE_BUFFER_SIZE(CONFIG_MM_BACKTRACE)];
 
-              for (i = 0; i < CONFIG_MM_BACKTRACE && buf->backtrace[i]; i++)
-                {
-                  snprintf(tmp + i * MM_PTR_FMT_WIDTH,
-                           sizeof(tmp) - i * MM_PTR_FMT_WIDTH,
-                           format, MM_PTR_FMT_WIDTH - 1, buf->backtrace[i]);
-                }
+              backtrace_format(tmp, sizeof(tmp), buf->backtrace,
+                               CONFIG_MM_BACKTRACE);
+#  else
+              char *tmp = "";
 #  endif
 
-              syslog(LOG_INFO, "%6d%12zu%12lu%*p%s\n",
+              syslog(LOG_INFO, "%6d%12zu%12lu%*p %s\n",
                      buf->pid, blocksize, buf->seqno,
-                     MM_PTR_FMT_WIDTH, ((FAR char *)buf - blocksize), tmp);
+                     BACKTRACE_PTR_FMT_WIDTH, ((FAR char *)buf - blocksize),
+                     tmp);
             }
         }
     }


### PR DESCRIPTION
## Summary

Extract a common method to format backtrace.

## Impact
No.

## Testing

boards/arm64/qemu/qemu-armv8a/configs/nsh with related options enabled.
