### PR TITLE
riscv_exception.c: Add missing comma in exception reasons array

### DIFF
--- a/arch/risc-v/src/common/riscv_exception.c
+++ b/arch/risc-v/src/common/riscv_exception.c
@@ -75,7 +75,7 @@ static const char *g_reasons_str[RISCV_MAX_EXCEPTION + 1] =
   "Software check",
 #endif
 #if RISCV_MAX_EXCEPTION > 18
-  "Hardware error"
+  "Hardware error",
 #endif
 #ifdef RISCV_CUSTOM_EXCEPTION_REASONS
   RISCV_CUSTOM_EXCEPTION_REASONS


### PR DESCRIPTION
## Summary
riscv_exception.c: Add missing comma in exception reasons array
## Impact
Minor
## Testing
CI and local machine