### PR TITLE
Fs backtrace tweak

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -1041,7 +1041,6 @@ config ARCH_STACKDUMP_MAX_LENGTH
 config DUMP_ON_EXIT
 	bool "Dump all tasks state on exit"
 	default n
-	depends on DEBUG_SCHED_INFO
 	---help---
 		Dump all tasks state on exit()
 

--- a/arch/arm/src/common/arm_exit.c
+++ b/arch/arm/src/common/arm_exit.c
@@ -62,8 +62,6 @@ void up_exit(int status)
 
   enter_critical_section();
 
-  nxsched_dumponexit();
-
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();

--- a/arch/arm64/src/common/arm64_exit.c
+++ b/arch/arm64/src/common/arm64_exit.c
@@ -66,8 +66,6 @@ void up_exit(int status)
 
   enter_critical_section();
 
-  nxsched_dumponexit();
-
   /* Destroy the task at the head of the ready to run list. */
 #ifdef CONFIG_ARCH_FPU
   arm64_destory_fpu(tcb);

--- a/arch/avr/src/common/avr_exit.c
+++ b/arch/avr/src/common/avr_exit.c
@@ -61,8 +61,6 @@ void up_exit(int status)
 
   enter_critical_section();
 
-  nxsched_dumponexit();
-
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();

--- a/arch/hc/src/common/hc_exit.c
+++ b/arch/hc/src/common/hc_exit.c
@@ -60,8 +60,6 @@ void up_exit(int status)
 
   enter_critical_section();
 
-  nxsched_dumponexit();
-
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();

--- a/arch/mips/src/common/mips_exit.c
+++ b/arch/mips/src/common/mips_exit.c
@@ -62,8 +62,6 @@ void up_exit(int status)
 
   enter_critical_section();
 
-  nxsched_dumponexit();
-
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();

--- a/arch/misoc/src/lm32/lm32_exit.c
+++ b/arch/misoc/src/lm32/lm32_exit.c
@@ -62,8 +62,6 @@ void up_exit(int status)
 
   enter_critical_section();
 
-  nxsched_dumponexit();
-
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();

--- a/arch/misoc/src/minerva/minerva_exit.c
+++ b/arch/misoc/src/minerva/minerva_exit.c
@@ -62,8 +62,6 @@ void up_exit(int status)
 
   enter_critical_section();
 
-  nxsched_dumponexit();
-
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();

--- a/arch/or1k/src/common/or1k_exit.c
+++ b/arch/or1k/src/common/or1k_exit.c
@@ -62,8 +62,6 @@ void up_exit(int status)
 
   enter_critical_section();
 
-  nxsched_dumponexit();
-
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();

--- a/arch/renesas/src/common/renesas_exit.c
+++ b/arch/renesas/src/common/renesas_exit.c
@@ -60,8 +60,6 @@ void up_exit(int status)
 
   enter_critical_section();
 
-  nxsched_dumponexit();
-
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();

--- a/arch/risc-v/src/common/riscv_exit.c
+++ b/arch/risc-v/src/common/riscv_exit.c
@@ -62,8 +62,6 @@ void up_exit(int status)
 
   enter_critical_section();
 
-  nxsched_dumponexit();
-
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();

--- a/arch/sparc/src/common/sparc_exit.c
+++ b/arch/sparc/src/common/sparc_exit.c
@@ -62,8 +62,6 @@ void up_exit(int status)
 
   (void)enter_critical_section();
 
-  nxsched_dumponexit();
-
   /* Update scheduler parameters */
 
   nxsched_suspend_scheduler(tcb);

--- a/arch/tricore/src/common/tricore_exit.c
+++ b/arch/tricore/src/common/tricore_exit.c
@@ -62,8 +62,6 @@ void up_exit(int status)
 
   enter_critical_section();
 
-  nxsched_dumponexit();
-
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();

--- a/arch/x86/src/common/x86_exit.c
+++ b/arch/x86/src/common/x86_exit.c
@@ -61,8 +61,6 @@ void up_exit(int status)
 
   enter_critical_section();
 
-  nxsched_dumponexit();
-
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();

--- a/arch/x86_64/src/common/x86_64_exit.c
+++ b/arch/x86_64/src/common/x86_64_exit.c
@@ -60,8 +60,6 @@ void up_exit(int status)
 
   enter_critical_section();
 
-  nxsched_dumponexit();
-
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();

--- a/arch/xtensa/src/common/xtensa_exit.c
+++ b/arch/xtensa/src/common/xtensa_exit.c
@@ -62,8 +62,6 @@ void up_exit(int status)
 
   enter_critical_section();
 
-  nxsched_dumponexit();
-
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();

--- a/arch/z16/src/common/z16_exit.c
+++ b/arch/z16/src/common/z16_exit.c
@@ -60,8 +60,6 @@ void up_exit(int status)
 
   enter_critical_section();
 
-  nxsched_dumponexit();
-
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();

--- a/arch/z80/src/common/z80_exit.c
+++ b/arch/z80/src/common/z80_exit.c
@@ -62,8 +62,6 @@ void up_exit(int status)
 
   enter_critical_section();
 
-  nxsched_dumponexit();
-
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();

--- a/fs/inode/fs_files.c
+++ b/fs/inode/fs_files.c
@@ -27,14 +27,17 @@
 #include <sys/types.h>
 #include <string.h>
 #include <assert.h>
+#include <execinfo.h>
 #include <sched.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <debug.h>
 #include <stdio.h>
 
 #include <nuttx/fs/fs.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/cancelpt.h>
+#include <nuttx/fs/ioctl.h>
 #include <nuttx/mutex.h>
 #include <nuttx/sched.h>
 #include <nuttx/spawn.h>
@@ -306,6 +309,67 @@ void files_initlist(FAR struct filelist *list)
   list->fl_rows = 1;
   list->fl_files = &list->fl_prefile;
   list->fl_prefile = list->fl_prefiles;
+}
+
+/****************************************************************************
+ * Name: files_dumplist
+ *
+ * Description:
+ *   Dump the list of files.
+ *
+ ****************************************************************************/
+
+void files_dumplist(FAR struct filelist *list)
+{
+  int count = files_countlist(list);
+  int i;
+
+  syslog(LOG_INFO, "%-4s%-4s%-8s%-5s%-10s%-14s"
+#if CONFIG_FS_BACKTRACE > 0
+        " BACKTRACE"
+#endif
+        "\n",
+        "PID", "FD", "FLAGS", "TYPE", "POS", "PATH"
+        );
+
+  for (i = 0; i < count; i++)
+    {
+      FAR struct file *filep = files_fget(list, i);
+      char path[PATH_MAX];
+
+#if CONFIG_FS_BACKTRACE > 0
+      char buf[BACKTRACE_BUFFER_SIZE(CONFIG_FS_BACKTRACE)];
+#endif
+
+      /* Is there an inode associated with the file descriptor? */
+
+      if (filep == NULL || filep->f_inode == NULL)
+        {
+          continue;
+        }
+
+      if (file_ioctl(filep, FIOC_FILEPATH, path) < 0)
+        {
+          path[0] = '\0';
+        }
+
+#if CONFIG_FS_BACKTRACE > 0
+      backtrace_format(buf, sizeof(buf), filep->f_backtrace,
+                       CONFIG_FS_BACKTRACE);
+#endif
+
+      syslog(LOG_INFO, "%-4d%-4d%-8d%-5x%-10ld%-14s"
+#if CONFIG_FS_BACKTRACE > 0
+            " %s"
+#endif
+            "\n", getpid(), i, filep->f_oflags,
+            INODE_GET_TYPE(filep->f_inode),
+            (long)filep->f_pos, path
+#if CONFIG_FS_BACKTRACE > 0
+            , buf
+#endif
+            );
+    }
 }
 
 /****************************************************************************

--- a/fs/inode/fs_files.c
+++ b/fs/inode/fs_files.c
@@ -554,17 +554,6 @@ int file_allocate(FAR struct inode *inode, int oflags, off_t pos,
                                 pos, priv, minfd, addref);
 }
 
-FAR char *file_dump_backtrace(FAR struct file *filep, FAR char *buffer,
-                              size_t len)
-{
-#if CONFIG_FS_BACKTRACE > 0
-  backtrace_format(buffer, len, filep->f_backtrace, CONFIG_FS_BACKTRACE);
-#else
-  buffer[0] = '\0';
-#endif
-  return buffer;
-}
-
 /****************************************************************************
  * Name: files_duplist
  *

--- a/fs/inode/fs_files.c
+++ b/fs/inode/fs_files.c
@@ -494,17 +494,7 @@ FAR char *file_dump_backtrace(FAR struct file *filep, FAR char *buffer,
                               size_t len)
 {
 #if CONFIG_FS_BACKTRACE > 0
-  FAR const char *format = "%0*p ";
-  int k;
-
-  buffer[0] = '\0';
-  for (k = 0; k < CONFIG_FS_BACKTRACE && filep->f_backtrace[k]; k++)
-    {
-      snprintf(buffer + k * FS_BACKTRACE_WIDTH,
-               len - k * FS_BACKTRACE_WIDTH,
-               format, FS_BACKTRACE_WIDTH - 1,
-               filep->f_backtrace[k]);
-    }
+  backtrace_format(buffer, len, filep->f_backtrace, CONFIG_FS_BACKTRACE);
 #else
   buffer[0] = '\0';
 #endif

--- a/fs/inode/inode.h
+++ b/fs/inode/inode.h
@@ -70,12 +70,13 @@
 #  define FS_ADD_BACKTRACE(filep) \
      do \
        { \
-          int n = sched_backtrace(_SCHED_GETTID(), filep->f_backtrace, \
+          int n = sched_backtrace(_SCHED_GETTID(), \
+                                  (filep)->f_backtrace, \
                                   CONFIG_FS_BACKTRACE, \
                                   CONFIG_FS_BACKTRACE_SKIP); \
           if (n < CONFIG_FS_BACKTRACE) \
             { \
-              (filep->f_backtrace)[n] = NULL; \
+              (filep)->f_backtrace[n] = NULL; \
             } \
        } \
      while (0)

--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -1245,16 +1245,15 @@ static ssize_t proc_groupfd(FAR struct proc_file_s *procfile,
                             size_t buflen, off_t offset)
 {
   FAR struct task_group_s *group = tcb->group;
+  FAR struct file *filep;
+  char backtrace[BACKTRACE_BUFFER_SIZE(CONFIG_FS_BACKTRACE)];
+  char path[PATH_MAX];
   size_t remaining;
   size_t linesize;
   size_t copysize;
   size_t totalsize;
   int count;
   int i;
-
-  FAR struct file *filep;
-  char path[PATH_MAX];
-  char backtrace[FS_BACKTRACE_BUFFER_LEN];
 
   DEBUGASSERT(group != NULL);
 

--- a/fs/vfs/fs_open.c
+++ b/fs/vfs/fs_open.c
@@ -350,6 +350,11 @@ int file_open(FAR struct file *filep, FAR const char *path, int oflags, ...)
   ret = file_vopen(filep, path, oflags, 0, ap);
   va_end(ap);
 
+  if (ret >= OK)
+    {
+      FS_ADD_BACKTRACE(filep);
+    }
+
   return ret;
 }
 

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -865,6 +865,16 @@ int nx_umount2(FAR const char *target, unsigned int flags);
 void files_initlist(FAR struct filelist *list);
 
 /****************************************************************************
+ * Name: files_dumplist
+ *
+ * Description:
+ *   Dump the list of files.
+ *
+ ****************************************************************************/
+
+void files_dumplist(FAR struct filelist *list);
+
+/****************************************************************************
  * Name: files_releaselist
  *
  * Description:

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -164,9 +164,6 @@
 #define CH_STAT_ATIME      (1 << 3)
 #define CH_STAT_MTIME      (1 << 4)
 
-#define FS_BACKTRACE_WIDTH      (sizeof(uintptr_t) * 2 + 3) /* 3: ' 0x' prefix */
-#define FS_BACKTRACE_BUFFER_LEN (CONFIG_FS_BACKTRACE * FS_BACKTRACE_WIDTH + 1)
-
 /****************************************************************************
  * Public Type Definitions
  ****************************************************************************/
@@ -962,20 +959,6 @@ int file_allocate_from_tcb(FAR struct tcb_s *tcb, FAR struct inode *inode,
 
 int file_allocate(FAR struct inode *inode, int oflags, off_t pos,
                   FAR void *priv, int minfd, bool addref);
-
-/****************************************************************************
- * Name: file_dump_backtrace
- *
- * Description:
- *   Dump the backtrace of the file open to given buffer.
- *
- * Returned Value:
- *     Returns the backtrace string, it could be empty.
- *
- ****************************************************************************/
-
-FAR char *file_dump_backtrace(FAR struct file *filep, FAR char *buffer,
-                              size_t len);
 
 /****************************************************************************
  * Name: file_dup

--- a/sched/sched/sched_dumponexit.c
+++ b/sched/sched/sched_dumponexit.c
@@ -52,26 +52,14 @@
 static void dumphandler(FAR struct tcb_s *tcb, FAR void *arg)
 {
   FAR struct filelist *filelist;
-  int i;
-  int j;
 
-  sinfo("  TCB=%p name=%s\n", tcb, tcb->name);
-  sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
+  syslog(LOG_INFO, "tcb=%p name=%s, pid:%d, priority=%d state=%d "
+         "stack_alloc_ptr: %p, adj_stack_size: %zu\n",
+         tcb, tcb->name, tcb->pid, tcb->sched_priority, tcb->task_state,
+         tcb->stack_alloc_ptr, tcb->adj_stack_size);
 
   filelist = &tcb->group->tg_filelist;
-  for (i = 0; i < filelist->fl_rows; i++)
-    {
-      for (j = 0; j < CONFIG_NFILE_DESCRIPTORS_PER_BLOCK; j++)
-        {
-          struct inode *inode = filelist->fl_files[i][j].f_inode;
-          if (inode)
-            {
-              sinfo("      fd=%d refcount=%d\n",
-                    i * CONFIG_NFILE_DESCRIPTORS_PER_BLOCK + j,
-                    inode->i_crefs);
-            }
-        }
-    }
+  files_dumplist(filelist);
 }
 
 /****************************************************************************

--- a/sched/task/task_exithook.c
+++ b/sched/task/task_exithook.c
@@ -432,6 +432,8 @@ void nxtask_exithook(FAR struct tcb_s *tcb, int status)
       return;
     }
 
+  nxsched_dumponexit();
+
   /* If the task was terminated by another task, it may be in an unknown
    * state.  Make some feeble effort to recover the state.
    */


### PR DESCRIPTION
## Summary

~Add option to dump fdinfo when assert happens, as required in~

`file_ioctl` is required to get file path, thus not available in assert. Currently file list is only dumped on task exit.


https://github.com/apache/nuttx/pull/12532#issuecomment-2179500766

nxsched_dumponexit has been moved forward to task_exithook, in order to access the `group` before it's destroyed.


Example of crash log:
```
nsh> mw -1
_assert: Current Version: NuttX  12.5.1 a8d7f155b8 Jun 28 2024 23:19:10 arm64
_assert: Assertion failed panic: at file: /home/neo/projects/nuttx/nuttx/arch/arm64/src/common/arm64_fatal.c:375 task: nsh_main process: nsh_main 0x402a10a8
up_dump_register: stack = 0x4040a230
up_dump_register: x0:   0xffffffffffffffff  x1:   0x0
up_dump_register: x2:   0x4040a300          x3:   0x0
up_dump_register: x4:   0x402a7934          x5:   0xa820a8a8aaa8aaaa
up_dump_register: x6:   0x80adb1808080      x7:   0xfefefefefeff766c
up_dump_register: x8:   0x7f7f7f7f7f7f7f7f  x9:   0x7f7f7f7f7f7f7f7f
up_dump_register: x10:  0x101010101010101   x11:  0x10
up_dump_register: x12:  0x1                 x13:  0xffffffffffffffff
up_dump_register: x14:  0xffff000000000000  x15:  0xffffffffffffffff
up_dump_register: x16:  0x0                 x17:  0x0
up_dump_register: x18:  0x0                 x19:  0x1
up_dump_register: x20:  0x403f1038          x21:  0x0
up_dump_register: x22:  0x0                 x23:  0x0
up_dump_register: x24:  0x0                 x25:  0x0
up_dump_register: x26:  0x0                 x27:  0x0
up_dump_register: x28:  0x0                 x29:  0x4040a360
up_dump_register: x30:  0x402b2298
up_dump_register:
up_dump_register: STATUS Registers:
up_dump_register: SPSR:      0x80000005
up_dump_register: ELR:       0x402b22c4
up_dump_register: SP_EL0:    0x4040a640
up_dump_register: SP_ELX:    0x4040a360
up_dump_register: TPIDR_EL0: 0x40406220
up_dump_register: TPIDR_EL1: 0x40406220
up_dump_register: EXE_DEPTH: 0x0
backtrace:
[ 2] [<0x402b22c4>] cmd_mw+0x58/0x100
[ 2] [<0x402ac514>] nsh_command+0x10c/0x11c
[ 2] [<0x402a91a0>] nsh_execute+0x390/0x40c
[ 2] [<0x402ab2a0>] nsh_parse_command+0x4d4/0x524
[ 2] [<0x402ab3a0>] nsh_parse+0xb0/0x1b4
[ 2] [<0x402a7f70>] nsh_session+0x284/0x298
[ 2] [<0x402a77b8>] nsh_consolemain+0x74/0x94
[ 2] [<0x402a1100>] nsh_main+0x58/0x84
[ 2] [<0x402a4208>] nxtask_startup+0x58/0x5c
[ 2] [<0x4029e59c>] nxtask_start+0xe8/0xf0
dump_tasks:    PID GROUP PRI POLICY   TYPE    NPX STATE   EVENT      SIGMASK          STACKBASE  STACKSIZE      USED   FILLED    COMMAND
dump_tasks:   ----   --- --- -------- ------- --- ------- ---------- ---------------- 0x40402000      4096       544    13.2%    irq
dump_task:       0     0   0 FIFO     Kthread - Ready              0000000000000000 0x40400010      8176      2080    25.4%    Idle_Task
dump_task:       1     0 192 RR       Kthread - Waiting Semaphore  0000000000000000 0x40404210      8112      1256    15.4%    hpwork 0x403fb2d0 0x403fb2f8
dump_task:       2     2 100 RR       Task    - Running            0000000000000000 0x404089b0      8144      4076    50.0%    nsh_main
backtrace:
[ 0] [<0x402a2350>] arch_cpu_idle+0x8/0xc
[ 0] [<0x402975d8>] nx_start+0x244/0x248
[ 0] [<0x402810e8>] arm64_boot_primary_c_routine+0x18/0x24
backtrace:
[ 1] [<0x402a1694>] sys_call2+0x24/0x2c
[ 1] [<0x402a170c>] up_switch_context+0x70/0x7c
[ 1] [<0x402991f8>] nxsem_wait+0x1f0/0x22c
[ 1] [<0x40299248>] nxsem_wait_uninterruptible+0x14/0x30
[ 1] [<0x4029b1a4>] work_thread+0x114/0x118
[ 1] [<0x4029e580>] nxtask_start+0xcc/0xf0
backtrace:
[ 2] [<0x402b22c4>] cmd_mw+0x58/0x100
[ 2] [<0x402ac514>] nsh_command+0x10c/0x11c
[ 2] [<0x402a91a0>] nsh_execute+0x390/0x40c
[ 2] [<0x402ab2a0>] nsh_parse_command+0x4d4/0x524
[ 2] [<0x402ab3a0>] nsh_parse+0xb0/0x1b4
[ 2] [<0x402a7f70>] nsh_session+0x284/0x298
[ 2] [<0x402a77b8>] nsh_consolemain+0x74/0x94
[ 2] [<0x402a1100>] nsh_main+0x58/0x84
[ 2] [<0x402a4208>] nxtask_startup+0x58/0x5c
[ 2] [<0x4029e59c>] nxtask_start+0xe8/0xf0
fd: 0  , oflags: 3       type: 1    pos: 0        path: /dev/console BACKTRACE: 0x00000000402a2ee4 0x00000000402a3058 0x000000004029bb8c 0x0000000040297544 0x00000000402810e8
fd: 1  , oflags: 3       type: 1    pos: 0        path: /dev/console BACKTRACE: 0x000000004028d84c 0x000000004028e18c 0x000000004028e1b4 0x000000004029bba8 0x0000000040297544 0x00000000402810e8
fd: 2  , oflags: 3       type: 1    pos: 0        path: /dev/console BACKTRACE: 0x000000004028d84c 0x000000004028e18c 0x000000004028e1b4 0x000000004029bbb4 0x0000000040297544 0x00000000402810e8
fd: 0  , oflags: 3       type: 1    pos: 0        path: /dev/console BACKTRACE: 0x00000000402a2ee4 0x00000000402a3058 0x000000004029bb8c 0x0000000040297544 0x00000000402810e8
fd: 1  , oflags: 3       type: 1    pos: 0        path: /dev/console BACKTRACE: 0x000000004028d84c 0x000000004028e18c 0x000000004028e1b4 0x000000004029bba8 0x0000000040297544 0x00000000402810e8
fd: 2  , oflags: 3       type: 1    pos: 0        path: /dev/console BACKTRACE: 0x000000004028d84c 0x000000004028e18c 0x000000004028e1b4 0x000000004029bbb4 0x0000000040297544 0x00000000402810e8
fd: 0  , oflags: 3       type: 1    pos: 0        path: /dev/console BACKTRACE: 0x000000004028f1f8 0x000000004028e050 0x000000004029bd08 0x000000004029da10 0x000000004029a36c 0x000000004029a4d8 0x000000004029a5a8 0x0000000040297644 0x0000000040297698 0x00000000402976cc 0x0000000040297598 0x00000000402810e8
fd: 1  , oflags: 3       type: 1    pos: 0        path: /dev/console BACKTRACE: 0x000000004028f1f8 0x000000004028e050 0x000000004029bd08 0x000000004029da10 0x000000004029a36c 0x000000004029a4d8 0x000000004029a5a8 0x0000000040297644 0x0000000040297698 0x00000000402976cc 0x0000000040297598 0x00000000402810e8
fd: 2  , oflags: 3       type: 1    pos: 0        path: /dev/console BACKTRACE: 0x000000004028f1f8 0x000000004028e050 0x000000004029bd08 0x000000004029da10 0x000000004029a36c 0x000000004029a4d8 0x000000004029a5a8 0x0000000040297644 0x0000000040297698 0x00000000402976cc 0x0000000040297598 0x00000000402810e8

```
## Impact

No

## Testing

qemu-armv8a:nsh with related options enabled.

