### PR TITLE
arch/intel64: add support for inter-processor signaling

### DIFF
--- a/arch/x86_64/Kconfig
+++ b/arch/x86_64/Kconfig
@@ -32,6 +32,7 @@ config ARCH_INTEL64
 	select ARCH_HAVE_SSE4A
 	select ARCH_ICACHE
 	select ARCH_DCACHE
+	select ARCH_HAVE_IRQTRIGGER
 	---help---
 		Intel x86_64 architecture
 

--- a/arch/x86_64/include/intel64/arch.h
+++ b/arch/x86_64/include/intel64/arch.h
@@ -226,8 +226,10 @@
 #  define MSR_X2APIC_ICR_DEASSERT      0x00000000
 #  define MSR_X2APIC_ICR_LEVEL         0x00008000  /* Level triggered */
 #  define MSR_X2APIC_ICR_BCAST         0x00080000  /* Send to all APICs, including self. */
+#  define MSR_X2APIC_ICR_OTHERS        0x000c0000  /* Send to all APICs, excluding self. */
 #  define MSR_X2APIC_ICR_BUSY          0x00001000
 #  define MSR_X2APIC_ICR_FIXED         0x00000000
+#  define MSR_X2APIC_DESTINATION(d)    ((d) << 32ul)
 #define MSR_X2APIC_LVTT         0x832
 #  define MSR_X2APIC_LVTT_X1           0x0000000B  /* divide counts by 1 */
 #  define MSR_X2APIC_LVTT_PERIODIC     0x00020000  /* Periodic */

--- a/arch/x86_64/src/intel64/intel64_irq.c
+++ b/arch/x86_64/src/intel64/intel64_irq.c
@@ -564,3 +564,29 @@ int up_prioritize_irq(int irq, int priority)
   return OK;
 }
 #endif
+
+/****************************************************************************
+ * Name: up_trigger_irq
+ *
+ * Description:
+ *   Trigger IRQ interrupt.
+ *
+ ****************************************************************************/
+
+void up_trigger_irq(int irq, cpu_set_t cpuset)
+{
+  uint32_t cpu = 0;
+
+  for (cpu = 0; cpu < CONFIG_SMP_NCPUS; cpu++)
+    {
+      if (CPU_ISSET(cpu, &cpuset))
+        {
+          write_msr(MSR_X2APIC_ICR,
+                    MSR_X2APIC_ICR_FIXED |
+                    MSR_X2APIC_ICR_ASSERT |
+                    MSR_X2APIC_DESTINATION(
+                      (uint64_t)x86_64_cpu_to_loapic(cpu)) |
+                    irq);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- arch/intel64: add support for inter-processor signaling
Add support for inter-processor signaling in x86_64 based on up_trigger_irq() interface. Preparations for SMP.

## Impact
new x86 api

## Testing
x86 smp
