### PR TITLE
libmetal/atomic: enable 64-bit atomic by toolchain builtin flags

### DIFF
--- a/openamp/0004-libmetal-atomic-enable-64-bit-atomic-by-toolchain-bu.patch
+++ b/openamp/0004-libmetal-atomic-enable-64-bit-atomic-by-toolchain-bu.patch
@@ -1,0 +1,44 @@
+From f17ee493475793be52b364b0ad7cd7042bc27ffe Mon Sep 17 00:00:00 2001
+From: chao an <anchao@lixiang.com>
+Date: Sat, 29 Jun 2024 09:40:26 +0800
+Subject: [PATCH] libmetal/atomic: enable 64-bit atomic by toolchain builtin
+ flags
+
+Fix compile error:
+arm-none-eabi-ld: (remoteproc_virtio.o): in function `metal_io_read':
+metal/io.h:252: undefined reference to `__atomic_load_8'
+arm-none-eabi-ld: (remoteproc_virtio.o): in function `metal_io_write':
+metal/io.h:290: undefined reference to `__atomic_store_8'
+
+Not all 32-bit architectures support 64bit atomic, gcc/clang
+toolchains have built-in properties to indicate whether support atomic64:
+
+| $ arm-none-eabi-gcc -march=armv7e-m  -dM -E - < /dev/null | grep SYNC
+| #define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_1 1
+| #define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_2 1
+| #define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_4 1
+
+Signed-off-by: chao an <anchao@lixiang.com>
+---
+ openamp/libmetal/lib/io.h | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/lib/io.h libmetal/lib/io.h
+index ba416dd505..8cd03e41db 100644
+--- a/lib/io.h
++++ libmetal/lib/io.h
+@@ -30,8 +30,9 @@ extern "C" {
+  *  @{
+  */
+ 
+-#ifdef __MICROBLAZE__
+-#define NO_ATOMIC_64_SUPPORT
++#if defined(__MICROBLAZE__) || \
++   (defined(__GNUC__) && !defined(__GCC_HAVE_SYNC_COMPARE_AND_SWAP_8))
++#  define NO_ATOMIC_64_SUPPORT
+ #endif
+ 
+ struct metal_io_region;
+-- 
+2.34.1
+

--- a/openamp/libmetal.cmake
+++ b/openamp/libmetal.cmake
@@ -66,27 +66,6 @@ set(MACHINE ${CONFIG_ARCH})
 set(CMAKE_SYSTEM_NAME NuttX)
 set(WITH_DOC OFF)
 
-# cmake-format: off
-set(ATOMIC_TEST_CODE
-  [-[
-    #include <stdatomic.h>
-    int main() {
-        _Atomic long long x = 0;
-        return x;
-    }
-  ]-]
-)
-# cmake-format: on
-
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/test_atomic.c ${ATOMIC_TEST_CODE})
-
-try_compile(HAS_64BIT_ATOMIC_SUPPORT ${CMAKE_CURRENT_BINARY_DIR}
-            ${CMAKE_CURRENT_BINARY_DIR}/test_atomic.c)
-
-if(NOT HAS_64BIT_ATOMIC_SUPPORT)
-  add_compile_options(-DNO_ATOMIC_64_SUPPORT)
-endif()
-
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/libmetal
                  ${CMAKE_CURRENT_BINARY_DIR}/libmetal EXCLUDE_FROM_ALL)
 

--- a/openamp/libmetal.cmake
+++ b/openamp/libmetal.cmake
@@ -40,6 +40,8 @@ if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/libmetal)
       ${CMAKE_CURRENT_LIST_DIR}/0002-libmetal-nuttx-io.c-align-access-when-read-write-siz.patch
       && patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
       ${CMAKE_CURRENT_LIST_DIR}/0003-libmetal-nuttx-io.c-Fix-void-pointer-arithmetic-in-a.patch
+      && patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
+      ${CMAKE_CURRENT_LIST_DIR}/0004-libmetal-atomic-enable-64-bit-atomic-by-toolchain-bu.patch
     DOWNLOAD_NO_PROGRESS true
     TIMEOUT 30)
 

--- a/openamp/libmetal.defs
+++ b/openamp/libmetal.defs
@@ -80,6 +80,7 @@ libmetal.zip:
 	$(Q) patch -p0 < 0001-libmetal-add-metal_list_for_each_safe-support.patch
 	$(Q) patch -p0 < 0002-libmetal-nuttx-io.c-align-access-when-read-write-siz.patch
 	$(Q) patch -p0 < 0003-libmetal-nuttx-io.c-Fix-void-pointer-arithmetic-in-a.patch
+	$(Q) patch -p0 < 0004-libmetal-atomic-enable-64-bit-atomic-by-toolchain-bu.patch
 
 .libmetal_headers: libmetal.zip
 else

--- a/openamp/libmetal.defs
+++ b/openamp/libmetal.defs
@@ -56,20 +56,6 @@ CSRCS += libmetal/lib/version.c
 
 CFLAGS += -DMETAL_INTERNAL
 
-# Check whether the current toolchain supports 64-bit atomic
-ATOMIC_DETECT_CODE := detect_64_atomic.c
-ATOMIC_DETECT_BIN := detect_64_atomic_bin
-DETECT_ATOMIC_SUPPORT = \
-    echo '\#include <stdatomic.h>' > $(ATOMIC_DETECT_CODE); \
-    echo 'int main() { _Atomic long long x = 0; return x; }' >> $(ATOMIC_DETECT_CODE); \
-    if $(CC) -o $(ATOMIC_DETECT_BIN) $(ATOMIC_DETECT_CODE) 2>/dev/null; then \
-        echo ""; \
-    else \
-        echo "-DNO_ATOMIC_64_SUPPORT"; \
-    fi; \
-
-CFLAGS += $(shell $(DETECT_ATOMIC_SUPPORT))
-
 LIBMETAL_HDRS_SEDEXP := \
 	"s/@PROJECT_VERSION_MAJOR@/0/g; \
 	 s/@PROJECT_VERSION_MINOR@/1/g; \
@@ -119,7 +105,5 @@ ifeq ($(wildcard libmetal/.git),)
 	$(call DELFILE, libmetal.zip)
 endif
 	$(call DELFILE, .libmetal_headers)
-	$(call DELFILE, $(ATOMIC_DETECT_CODE))
-	$(call DELFILE, $(ATOMIC_DETECT_BIN))
 
 endif


### PR DESCRIPTION
## Summary

libmetal/atomic: enable 64-bit atomic by toolchain builtin flags

Fix compile error:
```
arm-none-eabi-ld: (remoteproc_virtio.o): in function `metal_io_read':
metal/io.h:252: undefined reference to `__atomic_load_8'
arm-none-eabi-ld: (remoteproc_virtio.o): in function `metal_io_write':
metal/io.h:290: undefined reference to `__atomic_store_8'
```

Not all 32-bit architectures support 64bit atomic, gcc/clang
toolchains have built-in properties to indicate whether support atomic64:

```
| $ arm-none-eabi-gcc -march=armv7e-m  -dM -E - < /dev/null | grep SYNC
| #define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_1 1
| #define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_2 1
| #define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_4 1
```

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A 

## Testing

CI-CHECK