### PR TITLE
cmake:refine sim cmake redefine symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -727,7 +727,7 @@ else()
         ${nuttx_libs_paths} ${nuttx_extra_libs}
         $<$<NOT:$<BOOL:${APPLE}>>:-Wl,--end-group> -o nuttx.rel
       COMMAND ${CMAKE_OBJCOPY} --redefine-syms=nuttx-names.dat nuttx.rel
-      DEPENDS ${nuttx_libs} ${nuttx_extra_libs} sim_head
+      DEPENDS ${nuttx_libs} ${nuttx_extra_libs} sim_head sim_redefine_symbols
       COMMAND_EXPAND_LISTS)
   endif()
   add_custom_target(nuttx-rel DEPENDS nuttx.rel

--- a/cmake/nuttx_redefine_symbols.cmake
+++ b/cmake/nuttx_redefine_symbols.cmake
@@ -18,129 +18,13 @@
 #
 # ##############################################################################
 
-set(NXSYMBOLS
-    __cxa_atexit
-    abort
-    accept
-    access
-    atexit
-    backtrace
-    bind
-    calloc
-    chmod
-    chown
-    clock_gettime
-    close
-    closedir
-    connect
-    dlsym
-    dup
-    exit
-    fchmod
-    fchown
-    fclose
-    fcntl
-    fdopen
-    fopen
-    fprintf
-    fread
-    free
-    fseek
-    fstat
-    fsync
-    ftell
-    ftruncate
-    futimens
-    fwrite
-    getpeername
-    getsockname
-    getenv
-    getpid
-    getsockopt
-    if_nametoindex
-    ioctl
-    listen
-    longjmp
-    lseek
-    malloc
-    malloc_size
-    malloc_usable_size
-    memcpy
-    mkdir
-    mmap
-    mprotect
-    munmap
-    open
-    opendir
-    perror
-    poll
-    posix_memalign
-    pthread_attr_init
-    pthread_attr_setstack
-    pthread_attr_destroy
-    pthread_cond_destroy
-    pthread_cond_init
-    pthread_cond_signal
-    pthread_cond_wait
-    pthread_create
-    pthread_getspecific
-    pthread_key_create
-    pthread_kill
-    pthread_mutex_destroy
-    pthread_mutex_init
-    pthread_mutex_lock
-    pthread_mutex_unlock
-    pthread_setspecific
-    pthread_sigmask
-    puts
-    read
-    readdir
-    readv
-    realloc
-    recvfrom
-    rename
-    rewinddir
-    rmdir
-    sched_yield
-    select
-    sendmsg
-    sendto
-    setitimer
-    setbuf
-    setjmp
-    setsockopt
-    shutdown
-    sigaction
-    sigaddset
-    sigemptyset
-    sigfillset
-    sleep
-    socket
-    stat
-    statvfs
-    stderr
-    strcat
-    strchr
-    strerror
-    strlen
-    strtol
-    sysconf
-    syslog
-    tcgetattr
-    tcsetattr
-    unlink
-    usleep
-    utimensat
-    write
-    writev)
+set(REDEFINE_INPUT_FILE ${NUTTX_DIR}/arch/sim/src/nuttx-names.in)
+set(REDEFINE_OUTPUT_FILE ${CMAKE_BINARY_DIR}/nuttx-names.dat)
 
-set(NXSYMBOL_RENAMES)
-foreach(NXSYMBOL ${NXSYMBOLS})
-  if(APPLE OR (CYGWIN AND CONFIG_SIM_CYGWIN_DECORATED))
-    list(APPEND NXSYMBOL_RENAMES "_${NXSYMBOL} NX${NXSYMBOL}")
-  else()
-    list(APPEND NXSYMBOL_RENAMES "${NXSYMBOL} NX${NXSYMBOL}")
-  endif()
-endforeach()
-string(REPLACE ";" "\n" NXSYMBOL_RENAMES "${NXSYMBOL_RENAMES}")
-file(WRITE ${CMAKE_BINARY_DIR}/nuttx-names.dat "${NXSYMBOL_RENAMES}\n")
+add_custom_command(
+  OUTPUT ${REDEFINE_OUTPUT_FILE}
+  COMMAND ${CMAKE_C_COMPILER} -E -P -x c -I${CMAKE_BINARY_DIR}/include
+          ${REDEFINE_INPUT_FILE} > ${REDEFINE_OUTPUT_FILE}
+  DEPENDS nuttx_context ${REDEFINE_INPUT_FILE})
+
+add_custom_target(sim_redefine_symbols DEPENDS ${REDEFINE_OUTPUT_FILE})


### PR DESCRIPTION

## Summary


fix error:

```
[100%] Linking C executable nuttx
/usr/bin/ld: nuttx.rel: in function `uv_key_create': /home/data/vela/github/apps/system/libuv/libuv/src/unix/thread.c:846: undefined reference to `NXpthread_key_create' /usr/bin/ld: nuttx.rel: in function `uv_key_get':
/home/data/vela/github/apps/system/libuv/libuv/src/unix/thread.c:857: undefined reference to `NXpthread_getspecific' /usr/bin/ld: nuttx.rel: in function `uv_key_set':
/home/data/vela/github/apps/system/libuv/libuv/src/unix/thread.c:862: undefined reference to `NXpthread_setspecific' collect2: error: ld returned 1 exit status
```
## Impact

this PR is needed by https://github.com/apache/nuttx-apps/pull/2426

## Testing
CI
