### PR TITLE
x86_64/irq.h: use 32bit operations in up_cpu_index()

### DIFF
--- a/arch/x86_64/include/irq.h
+++ b/arch/x86_64/include/irq.h
@@ -98,11 +98,11 @@ extern "C"
 #ifdef CONFIG_SMP
 static inline_function int up_cpu_index(void)
 {
-  unsigned long cpu;
+  int cpu;
 
   asm volatile(
-    "\tmovq %%gs:(%c1), %0\n"
-    : "=rm" (cpu)
+    "\tmovl %%gs:(%c1), %0\n"
+    : "=r" (cpu)
     : "i" (offsetof(struct intel64_cpu_s, id))
     :);
 


### PR DESCRIPTION
## Summary
Use 32bit operations for id field in intel64_cpu_s which is int type.

This fixes an error that appears when enabling some debug options:
  Error: operand size mismatch for `movq'`

## Impact

## Testing
CI
