### PR TITLE
irq: remove restore_critical_section in irq

### DIFF
--- a/arch/arm/src/armv6-m/arm_doirq.c
+++ b/arch/arm/src/armv6-m/arm_doirq.c
@@ -79,7 +79,6 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
           g_running_tasks[this_cpu()] = this_task();
 
-          restore_critical_section();
           regs = (uint32_t *)CURRENT_REGS;
         }
 

--- a/arch/arm/src/armv7-a/arm_doirq.c
+++ b/arch/arm/src/armv7-a/arm_doirq.c
@@ -92,7 +92,6 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
       g_running_tasks[this_cpu()] = this_task();
 
-      restore_critical_section();
       regs = (uint32_t *)CURRENT_REGS;
     }
 

--- a/arch/arm/src/armv7-m/arm_doirq.c
+++ b/arch/arm/src/armv7-m/arm_doirq.c
@@ -79,7 +79,6 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
           g_running_tasks[this_cpu()] = this_task();
 
-          restore_critical_section();
           regs = (uint32_t *)CURRENT_REGS;
         }
 

--- a/arch/arm/src/armv7-r/arm_doirq.c
+++ b/arch/arm/src/armv7-r/arm_doirq.c
@@ -71,7 +71,6 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
       g_running_tasks[this_cpu()] = this_task();
 
-      restore_critical_section();
       regs = (uint32_t *)CURRENT_REGS;
     }
 

--- a/arch/arm/src/armv8-m/arm_doirq.c
+++ b/arch/arm/src/armv8-m/arm_doirq.c
@@ -128,7 +128,6 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
           g_running_tasks[this_cpu()] = this_task();
 
-          restore_critical_section();
           regs = (uint32_t *)CURRENT_REGS;
         }
 

--- a/arch/arm/src/armv8-r/arm_doirq.c
+++ b/arch/arm/src/armv8-r/arm_doirq.c
@@ -64,7 +64,6 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
   if (regs != CURRENT_REGS)
     {
-      restore_critical_section();
       regs = (uint32_t *)CURRENT_REGS;
     }
 

--- a/arch/arm/src/tlsr82/tc32/tc32_doirq.c
+++ b/arch/arm/src/tlsr82/tc32/tc32_doirq.c
@@ -98,7 +98,6 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
       if (regs != CURRENT_REGS)
         {
-          restore_critical_section();
           regs = (uint32_t *)CURRENT_REGS;
         }
 

--- a/arch/arm64/src/common/arm64_doirq.c
+++ b/arch/arm64/src/common/arm64_doirq.c
@@ -99,9 +99,6 @@ uint64_t *arm64_doirq(int irq, uint64_t * regs)
 
       g_running_tasks[this_cpu()] = this_task();
 
-      /* Restore the cpu lock */
-
-      restore_critical_section();
       regs = (uint64_t *)CURRENT_REGS;
     }
 

--- a/arch/ceva/src/common/ceva_doirq.c
+++ b/arch/ceva/src/common/ceva_doirq.c
@@ -85,7 +85,6 @@ uint32_t *ceva_doirq(int irq, uint32_t *regs)
 
           g_running_tasks[this_cpu()] = this_task();
 
-          restore_critical_section();
           regs = CURRENT_REGS;
         }
 

--- a/arch/risc-v/src/common/riscv_doirq.c
+++ b/arch/risc-v/src/common/riscv_doirq.c
@@ -109,10 +109,6 @@ uintreg_t *riscv_doirq(int irq, uintreg_t *regs)
 
       g_running_tasks[this_cpu()] = this_task();
 
-      /* Restore the cpu lock */
-
-      restore_critical_section();
-
       /* If a context switch occurred while processing the interrupt then
        * CURRENT_REGS may have change value.  If we return any value
        * different from the input regs, then the lower level will know

--- a/arch/sim/src/sim/sim_switchcontext.c
+++ b/arch/sim/src/sim/sim_switchcontext.c
@@ -75,10 +75,6 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
       nxsched_resume_scheduler(tcb);
 
-      /* Restore the cpu lock */
-
-      restore_critical_section();
-
       /* Then switch contexts */
 
       sim_restorestate(tcb->xcp.regs);

--- a/arch/sparc/src/sparc_v8/sparc_v8_doirq.c
+++ b/arch/sparc/src/sparc_v8/sparc_v8_doirq.c
@@ -118,13 +118,6 @@ uint32_t *sparc_doirq(int irq, uint32_t *regs)
   regs = (uint32_t *)((uint32_t)CURRENT_REGS -
                                 CPU_MINIMUM_STACK_FRAME_SIZE);
 
-  /* Restore the cpu lock */
-
-  if (regs != CURRENT_REGS)
-    {
-      restore_critical_section();
-    }
-
   /* Set CURRENT_REGS to NULL to indicate that we are no longer in an
    * interrupt handler.
    */

--- a/arch/xtensa/src/common/xtensa_irqdispatch.c
+++ b/arch/xtensa/src/common/xtensa_irqdispatch.c
@@ -94,7 +94,6 @@ uint32_t *xtensa_irq_dispatch(int irq, uint32_t *regs)
 
   if (regs != CURRENT_REGS)
     {
-      restore_critical_section();
       regs = (uint32_t *)CURRENT_REGS;
     }
 


### PR DESCRIPTION


## Summary
irq: remove restore_critical_section in irq

Only in the non-critical region， nuttx can the respond to the irq and not hold the lock When returning from the irq, there is no need to check whether the lock needs to be restored

## Impact

## Testing
We can use qemu for testing.
compiling
make distclean -j20; ./tools/configure.sh -l qemu-armv8a:nsh_smp ;make -j20 running
qemu-system-aarch64 -cpu cortex-a53 -smp 4 -nographic -machine virt,virtualization=on,gic-version=3 -net none -chardev stdio,id=con,mux=on -serial chardev:con -mon chardev=con,mode=readline -kernel ./nuttx