### PR TITLE
mkstemp: permission 0666 to 0600

### DIFF
--- a/libs/libc/stdlib/lib_mkstemp.c
+++ b/libs/libc/stdlib/lib_mkstemp.c
@@ -66,7 +66,7 @@ int mkstemp(FAR char *path_template)
 
   if (path)
     {
-      ret = open(path, O_RDWR | O_CREAT | O_EXCL, 0666);
+      ret = open(path, O_RDWR | O_CREAT | O_EXCL, 0600);
     }
 
   return ret;


### PR DESCRIPTION
## Summary
As a reference, https://man7.org/linux/man-pages/man3/mkstemp.3.html
We should remove the read/write permission of other users for temp file.

## Impact
should be lower permission risk.

## Testing
CI-test
