### PR TITLE
libc: scanf, printf %z change switch const to if

### DIFF
--- a/libs/libc/stdio/lib_libvscanf.c
+++ b/libs/libc/stdio/lib_libvscanf.c
@@ -317,33 +317,33 @@ int lib_vscanf(FAR struct lib_instream_s *stream, FAR int *lastc,
                 }
               else if (fmt_char(fmt) == 'z')
                 {
-                  switch (sizeof(size_t))
+                  if (sizeof(size_t) == sizeof(unsigned short))
                     {
-                    /* The only known cases that the default will be hit are
-                     * (1) the eZ80 which has sizeof(size_t) = 3 which is the
-                     * same as the sizeof(int).  And (2) if
-                     * CONFIG_HAVE_LONG_LONG
-                     * is not enabled and sizeof(size_t) is equal to
-                     * sizeof(unsigned long long).  This latter case is an
-                     * error.
-                     */
-
-                    default:
-                      continue;  /* Treat as integer with no size qualifier. */
-
-                    case sizeof(unsigned short):
                       modifier = H_MOD;
-                      break;
-
-                    case sizeof(unsigned long):
+                    }
+                  else if (sizeof(size_t) == sizeof(unsigned long))
+                    {
                       modifier = L_MOD;
-                      break;
-
+                    }
 #if defined(CONFIG_HAVE_LONG_LONG) && ULLONG_MAX != ULONG_MAX
-                    case sizeof(unsigned long long):
+                  else if (sizeof(size_t) == sizeof(unsigned long long))
+                    {
                       modifier = LL_MOD;
-                      break;
+                    }
 #endif
+                  else
+                    {
+                      /* The only known cases that the default will be hit
+                       * are (1) the eZ80 which has sizeof(size_t) = 3 which
+                       * is the same as the sizeof(int).  And (2) if
+                       * CONFIG_HAVE_LONG_LONG
+                       * is not enabled and sizeof(size_t) is equal to
+                       * sizeof(unsigned long long).  This latter case is an
+                       * error.
+                       * Treat as integer with no size qualifier.
+                       */
+
+                      continue;
                     }
                 }
               else if (fmt_char(fmt) == 'j')

--- a/libs/libc/stdio/lib_libvsprintf.c
+++ b/libs/libc/stdio/lib_libvsprintf.c
@@ -389,7 +389,23 @@ static int vsprintf_internal(FAR struct lib_outstream_s *stream,
 
           if (c == 'z' || c == 't')
             {
-              switch (sizeof(size_t))
+              if (sizeof(size_t) == sizeof(unsigned short))
+                {
+                  c = 'h';
+                }
+              else if (sizeof(size_t) == sizeof(unsigned long))
+                {
+                  c = 'l';
+                }
+#if defined(CONFIG_HAVE_LONG_LONG) && ULLONG_MAX != ULONG_MAX
+              else if (sizeof(size_t) == sizeof(unsigned long long))
+                {
+                  c = 'l';
+                  flags |= FL_LONG;
+                  flags &= ~FL_SHORT;
+                }
+#endif
+              else
                 {
                   /* The only known cases that the default will be hit are
                    * (1) the eZ80 which has sizeof(size_t) = 3 which is the
@@ -398,26 +414,10 @@ static int vsprintf_internal(FAR struct lib_outstream_s *stream,
                    * is not enabled and sizeof(size_t) is equal to
                    * sizeof(unsigned long long).  This latter case is an
                    * error.
+                   * Treat as integer with no size qualifier.
                    */
 
-                  default:
-                    continue;  /* Treat as integer with no size qualifier. */
-
-                  case sizeof(unsigned short):
-                    c = 'h';
-                    break;
-
-#if defined(CONFIG_HAVE_LONG_LONG) && ULLONG_MAX != ULONG_MAX
-                  case sizeof(unsigned long long):
-                    c = 'l';
-                    flags |= FL_LONG;
-                    flags &= ~FL_SHORT;
-                    break;
-#else
-                  case sizeof(unsigned long):
-                    c = 'l';
-                    break;
-#endif
+                  continue;
                 }
             }
 


### PR DESCRIPTION
## Summary
Will cause a ”switch_selector_expr_is_constant“ catched by coverity.
switch const may not good for compile optimize?
And put sizeof in #if look like not a good style.

## Impact
when optimise levels enabled, will auto slim to a single value copy. No actual difference.

## Testing
CI-test
