### PR TITLE
cmake/add_library: enable library install by default

### DIFF
--- a/cmake/nuttx_add_library.cmake
+++ b/cmake/nuttx_add_library.cmake
@@ -51,6 +51,9 @@ function(nuttx_add_library_internal target)
   target_include_directories(
     ${target}
     PRIVATE $<GENEX_EVAL:$<TARGET_PROPERTY:nuttx,NUTTX_INCLUDE_DIRECTORIES>>)
+
+  # Set install config for all library
+  install(TARGETS ${target})
 endfunction()
 
 # Auxiliary libraries
@@ -101,9 +104,6 @@ function(nuttx_add_system_library target)
 
   # add to list of libraries to link to final nuttx binary
   set_property(GLOBAL APPEND PROPERTY NUTTX_SYSTEM_LIBRARIES ${target})
-
-  # install to library dir
-  install(TARGETS ${target} DESTINATION lib)
 endfunction()
 
 # Kernel Libraries
@@ -182,11 +182,6 @@ function(nuttx_add_library target)
   add_library(${target} ${ARGN})
 
   set_property(GLOBAL APPEND PROPERTY NUTTX_SYSTEM_LIBRARIES ${target})
-
-  get_target_property(target_type ${target} TYPE)
-  if(${target_type} STREQUAL "STATIC_LIBRARY")
-    install(TARGETS ${target} ARCHIVE DESTINATION ${CMAKE_BINARY_DIR}/staging)
-  endif()
 
   nuttx_add_library_internal(${target})
 endfunction()


### PR DESCRIPTION

## Summary

cmake/add_library: enable library install by default

enable library install by default to support nuttx export for cmake

```
$ cmake --install build  --prefix $PWD/build/staging/
-- Install configuration: ""
-- Installing: /home/archer/code/nuttx/n3/nuttx/build/staging/lib/libarch.a
-- Installing: /home/archer/code/nuttx/n3/nuttx/build/staging/lib/libbinfmt.a
-- Installing: /home/archer/code/nuttx/n3/nuttx/build/staging/lib/libdrivers.a
-- Installing: /home/archer/code/nuttx/n3/nuttx/build/staging/lib/libfs.a
-- Installing: /home/archer/code/nuttx/n3/nuttx/build/staging/lib/libc.a
-- Installing: /home/archer/code/nuttx/n3/nuttx/build/staging/lib/liblibcxxmini.a
-- Installing: /home/archer/code/nuttx/n3/nuttx/build/staging/lib/libmm.a
-- Installing: /home/archer/code/nuttx/n3/nuttx/build/staging/lib/libsched.a
-- Installing: /home/archer/code/nuttx/n3/nuttx/build/staging/lib/libboard.a
-- Installing: /home/archer/code/nuttx/n3/nuttx/build/staging/lib/libapps.a
-- Installing: /home/archer/code/nuttx/n3/nuttx/build/staging/lib/libapps_nsh.a
-- Installing: /home/archer/code/nuttx/n3/nuttx/build/staging/lib/libapps_sh.a
-- Installing: /home/archer/code/nuttx/n3/nuttx/build/staging/lib/libapps_taskset.a
-- Installing: /home/archer/code/nuttx/n3/nuttx/build/staging/lib/libapps_getprime.a
-- Installing: /home/archer/code/nuttx/n3/nuttx/build/staging/lib/libapps_ostest.a
-- Installing: /home/archer/code/nuttx/n3/nuttx/build/staging/lib/libapps_smp.a
-- Installing: /home/archer/code/nuttx/n3/nuttx/build/staging/lib/libapps_hello.a
-- Installing: /home/archer/code/nuttx/n3/nuttx/build/staging/lib/libapps_builtin.a
```



## Impact

N/A

## Testing

ci-check