### PR TITLE
rp2040: Add support to MAX6675

### DIFF
--- a/boards/arm/rp2040/common/include/rp2040_max6675.h
+++ b/boards/arm/rp2040/common/include/rp2040_max6675.h
@@ -1,0 +1,84 @@
+/****************************************************************************
+ * boards/arm/rp2040/common/include/rp2040_max6675.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __BOARDS_ARM_RP2040_COMMON_INCLUDE_RP2040_MAX6675_H
+#define __BOARDS_ARM_RP2040_COMMON_INCLUDE_RP2040_MAX6675_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Type Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Inline Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_max6675_initialize
+ *
+ * Description:
+ *   Initialize and register the MAX6675 Temperature Sensor driver.
+ *
+ * Input Parameters:
+ *   devno - The device number, used to build the device path as /dev/tempN
+ *   busno - The SPI bus number
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int board_max6675_initialize(int devno, int busno);
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __BOARDS_ARM_RP2040_COMMON_INCLUDE_RP2040_MAX6675_H */

--- a/boards/arm/rp2040/common/src/Make.defs
+++ b/boards/arm/rp2040/common/src/Make.defs
@@ -103,6 +103,10 @@ ifeq ($(CONFIG_NET_W5500),y)
 CSRCS += rp2040_w5500.c
 endif
 
+ifeq ($(CONFIG_SENSORS_MAX6675),y)
+  CSRCS += rp2040_max6675.c
+endif
+
 DEPPATH += --dep-path src
 VPATH += :src
 CFLAGS += ${INCDIR_PREFIX}$(TOPDIR)$(DELIM)arch$(DELIM)$(CONFIG_ARCH)$(DELIM)src$(DELIM)board$(DELIM)src

--- a/boards/arm/rp2040/common/src/rp2040_common_bringup.c
+++ b/boards/arm/rp2040/common/src/rp2040_common_bringup.c
@@ -68,6 +68,11 @@
 #include "rp2040_bmp280.h"
 #endif
 
+#ifdef CONFIG_SENSORS_MAX6675
+#include <nuttx/sensors/max6675.h>
+#include "rp2040_max6675.h"
+#endif
+
 #ifdef CONFIG_RP2040_PWM
 #include "rp2040_pwm.h"
 #include "rp2040_pwmdev.h"
@@ -463,6 +468,16 @@ int rp2040_common_bringup(void)
   if (ret < 0)
     {
       syslog(LOG_ERR, "Failed to initialize BMP280 driver: %d\n", ret);
+    }
+#endif
+
+#ifdef CONFIG_SENSORS_MAX6675
+  /* Try to register MAX6675 device as /dev/temp0 at SPI0 */
+
+  ret = board_max6675_initialize(0, 0);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "Failed to initialize MAX6675 driver: %d\n", ret);
     }
 #endif
 

--- a/boards/arm/rp2040/common/src/rp2040_max6675.c
+++ b/boards/arm/rp2040/common/src/rp2040_max6675.c
@@ -1,0 +1,86 @@
+/****************************************************************************
+ * boards/arm/rp2040/common/src/rp2040_max6675.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <debug.h>
+#include <errno.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/board.h>
+#include <nuttx/spi/spi.h>
+#include <nuttx/sensors/max6675.h>
+
+#include "rp2040_spi.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name:  board_max6675_initialize
+ *
+ * Description:
+ *   Initialize the MAX6675 sensor.
+ * Input:
+ *   devno - Device number to register, i.e. 0 for /dev/temp0
+ *   busno - The SPI controller port used. i.e. 0 for SPI0
+ *
+ ****************************************************************************/
+
+int board_max6675_initialize(int devno, int busno)
+{
+  struct spi_dev_s *spi;
+  char devpath[12];
+  int ret;
+
+  spi = rp2040_spibus_initialize(busno);
+  if (spi == NULL)
+    {
+      lcderr("ERROR: Failed to initialize SPI port %d\n", busno);
+      return -ENODEV;
+    }
+
+  /* Then register the temperature sensor */
+
+  snprintf(devpath, 12, "/dev/temp%d", devno);
+  ret = max6675_register(devpath, spi);
+  if (ret < 0)
+    {
+      snerr("ERROR: Error registering MAX6675\n");
+    }
+
+  return OK;
+}
+


### PR DESCRIPTION
## Summary
Add support to MAX6675, see: https://www.embeddedrelated.com/showarticle/1673.php
## Impact
For users
## Testing
RaspberryPi Pico
