### PR TITLE
refactor(esp32-qemu-openeth): use lower half driver interface

### DIFF
--- a/arch/xtensa/src/esp32/Kconfig
+++ b/arch/xtensa/src/esp32/Kconfig
@@ -265,13 +265,6 @@ config ESP32_OPENETH_DMA_RX_BUFFER_NUM
 	---help---
 		Number of DMA receive buffers, each buffer is 1600 bytes.
 
-config ESP32_OPENETH_DMA_TX_BUFFER_NUM
-	int "Number of Ethernet DMA Tx buffers"
-	range 1 64
-	default 1
-	---help---
-		Number of DMA transmit buffers, each buffer is 1600 bytes.
-
 endif # ESP32_OPENETH
 
 config ESP32_I2C


### PR DESCRIPTION
## Summary

This current driver does not handle well netpkts used in the write buffers.

I learned about this document:

https://github.com/apache/nuttx/blob/master/Documentation/components/net/netdriver.rst

After I ported and contributed the original driver.

However from the document, I understand these types of drivers are simpler to implement and I could simplify the driver and handle correctly the TCP write buffers.

## Impact

ESP32-opencores mac can handle writebuffers correctly.

## Testing

Only local testing. Now I can even run mbedtls' ssl_client2.