### PR TITLE
ESP32: emac initialization adding cpu id

### DIFF
--- a/arch/xtensa/src/esp32/esp32_emac.c
+++ b/arch/xtensa/src/esp32/esp32_emac.c
@@ -198,7 +198,8 @@ struct esp32_emac_s
   struct work_s         timeoutwork; /* For TX timeout work to the work queue */
   struct work_s         pollwork;    /* For deferring poll work to the work queue */
 
-  int                   cpuint;      /* SPI interrupt ID */
+  uint8_t               cpu;         /* CPU ID */
+  int                   cpuint;      /* CPU interrupt assigned to EMAC */
 
   sq_queue_t            freeb;       /* The free buffer list */
 
@@ -2034,7 +2035,8 @@ int esp32_emac_init(void)
 
   memset(priv, 0, sizeof(struct esp32_emac_s));
 
-  priv->cpuint = esp32_setup_irq(0, ESP32_PERIPH_EMAC,
+  priv->cpu = up_cpu_index();
+  priv->cpuint = esp32_setup_irq(priv->cpu, ESP32_PERIPH_EMAC,
                                  1, ESP32_CPUINT_LEVEL);
   if (priv->cpuint < 0)
     {
@@ -2085,7 +2087,7 @@ int esp32_emac_init(void)
   return 0;
 
 errout_with_attachirq:
-  esp32_teardown_irq(0, ESP32_PERIPH_EMAC, priv->cpuint);
+  esp32_teardown_irq(priv->cpu, ESP32_PERIPH_EMAC, priv->cpuint);
 
 error:
   return ret;


### PR DESCRIPTION
## Summary
      ESP32: emac initialization adding cpu id
## Impact
      Only ESP32
## Testing

