### PR TITLE
sim: make possible keep ubsan and bypass feature

### DIFF
--- a/arch/sim/Kconfig
+++ b/arch/sim/Kconfig
@@ -83,6 +83,13 @@ config SIM_UBSAN
 		Compile-time instrumentation is used to detect various undefined behaviours
 		at runtime.
 
+config SIM_UBSAN_DUMMY
+	bool "Bypass Undefined Behaviour Sanitizer"
+	default n
+	depends on SIM_UBSAN
+	---help---
+		Keep SIM_UBSAN compile time but disable runtime actions.
+
 choice
 	prompt "X64_64 ABI"
 	default SIM_X8664_SYSTEMV if HOST_LINUX

--- a/arch/sim/src/sim/sim_head.c
+++ b/arch/sim/src/sim/sim_head.c
@@ -142,8 +142,12 @@ const char *__lsan_default_options(void)
 #ifdef CONFIG_SIM_UBSAN
 const char *__ubsan_default_options(void)
 {
+#ifdef CONFIG_SIM_UBSAN_DUMMY
+  return "";
+#else
   return "print_stacktrace=1"
          " fast_unwind_on_malloc=0";
+#endif
 }
 #endif
 


### PR DESCRIPTION
## Summary
sometimes ubsan work with asan trigger a mistake report, make it possible to export library with ubsan, and bypass runtime feature.

## Impact
No-impact for default,
can disable ubsan malloc/etc. in kconfig after this commit.

## Testing
CI-test
