### PR TITLE
arch/sim: add custom data section support 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -695,7 +695,9 @@ else()
       COMMAND
         echo ARGS
         '__init_array_start = .\; __init_array_end = .\; __fini_array_start = .\; __fini_array_end = .\;'
-        >> nuttx.ld)
+        >> nuttx.ld
+      COMMAND sed -i '/\\.data *:/i " ${CONFIG_SIM_CUSTOM_DATA_SECTION} " '
+              nuttx.ld)
   endif()
 
   # conflicting symbols to rename

--- a/arch/sim/Kconfig
+++ b/arch/sim/Kconfig
@@ -794,4 +794,11 @@ config SIM_USB_PRIO
 
 endif
 
+config SIM_CUSTOM_DATA_SECTION
+	string "Custom data section name for Simulator"
+	default ""
+	---help---
+		Custom data section name for Simulator to allow
+		developer to define special data sections.
+
 endif # ARCH_SIM

--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -414,6 +414,9 @@ ifeq ($(CONFIG_MM_KASAN_GLOBAL),y)
 	            .kasan.global : {KEEP(*(.data..LASAN0)) KEEP (*(.data.rel.local..LASAN0)) }\n  \
 	            .interp : {*(.interp)}/g' nuttx.ld
 endif
+ifneq ($(CONFIG_SIM_CUSTOM_DATA_SECTION),"")
+	$(Q) sed -i '/\.data *:/i $(subst ",, $(CONFIG_SIM_CUSTOM_DATA_SECTION))' nuttx.ld
+endif
 ifeq ($(CONFIG_ALLSYMS)$(CONFIG_MM_KASAN_GLOBAL),)
 	$(if $(CONFIG_HAVE_CXX),\
 	$(Q) "$(CXX)" $(CFLAGS) $(LDFLAGS) -o $(TOPDIR)/$@ $(HEADOBJ) nuttx.rel $(HOSTOBJS) $(STDLIBS),\


### PR DESCRIPTION
## Summary

arch/sim: add custom data section support

The link script of NuttX Simulator is generated through compilation
options. This PR will support configure special data sections in
kconfig to meet the support of 3rd party applications.

we need to follow the syntax of linker script. In 3rd-party applications, some data will be labeled as section:

```
| a.c:
| struct task_s a __attribute__((section(".data.custom.taska")));
| b.c:
| struct task_s b __attribute__((section(".data.custom.taskb")));
```

Data of the same type struct can be placed in a fixed location to reduce the overhead caused by searching:

```
|   .data           :
|   {
|     _custom_data_table_start = .;
|     KEEP(*(.data.custom.*))
|     _custom_data_table_end = .;
|   }
```

Such section declare can be configured via Kconfig in the PR:

```
| CONFIG_SIM_CUSTOM_DATA_SECTION=" .data : { _custom_data_table_start = .; KEEP(*(.data.custom.*)) _custom_data_table_end = .; } "
```

Signed-off-by: chao an <anchao@lixiang.com>



## Impact

N/A

## Testing

ci-check