### PR TITLE
samv7/sam_mcan.c: fix TSEG1, TSEG2 and SJW compile warnings for MCAN1

### DIFF
--- a/arch/arm/src/samv7/sam_mcan.c
+++ b/arch/arm/src/samv7/sam_mcan.c
@@ -412,13 +412,13 @@
                         (float)CONFIG_SAMV7_MCAN1_BITRATE)) - 1))
 #  define MCAN1_SJW    (CONFIG_SAMV7_MCAN1_FSJW - 1)
 
-#  if MCAN1_NTSEG1 > 63
+#  if MCAN1_TSEG1 > 63
 #    error Invalid MCAN1 NTSEG1
 #  endif
-#  if MCAN1_NTSEG2 > 15
+#  if MCAN1_TSEG2 > 15
 #    error Invalid MCAN1 NTSEG2
 #  endif
-#  if MCAN1_NSJW > 15
+#  if MCAN1_SJW > 15
 #    error Invalid MCAN1 NSJW
 #  endif
 


### PR DESCRIPTION
## Summary
Following error caused by incorrect naming of few defines.

```
chip/sam_mcan.c:415:7: warning: "MCAN1_NTSEG1" is not defined, evaluates to 0 [-Wundef]
  415 | #  if MCAN1_NTSEG1 > 63
      |       ^~~~~~~~~~~~
chip/sam_mcan.c:418:7: warning: "MCAN1_NTSEG2" is not defined, evaluates to 0 [-Wundef]
  418 | #  if MCAN1_NTSEG2 > 15
      |       ^~~~~~~~~~~~
chip/sam_mcan.c:421:7: warning: "MCAN1_NSJW" is not defined, evaluates to 0 [-Wundef]
  421 | #  if MCAN1_NSJW > 15
```

## Testing
Build passes.

