### PR TITLE
WIP: spinlock: fix struct comparison for ticket spinlock

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_testset.c
+++ b/arch/arm/src/cxd56xx/cxd56_testset.c
@@ -106,7 +106,7 @@ spinlock_t up_testset(volatile spinlock_t *lock)
 
   ret = *lock;
 
-  if (ret == SP_UNLOCKED)
+  if (!spin_is_locked(&ret))
     {
       *lock = SP_LOCKED;
       SP_DMB();

--- a/arch/arm/src/lc823450/lc823450_testset.c
+++ b/arch/arm/src/lc823450/lc823450_testset.c
@@ -83,7 +83,7 @@ spinlock_t up_testset(volatile spinlock_t *lock)
 
   ret = *lock;
 
-  if (ret == SP_UNLOCKED)
+  if (!spin_is_locked(&ret))
     {
       *lock = SP_LOCKED;
     }

--- a/arch/arm/src/rp2040/rp2040_testset.c
+++ b/arch/arm/src/rp2040/rp2040_testset.c
@@ -70,7 +70,7 @@ spinlock_t up_testset(volatile spinlock_t *lock)
 
   ret = *lock;
 
-  if (ret == SP_UNLOCKED)
+  if (!spin_is_locked(&ret))
     {
       *lock = SP_LOCKED;
       SP_DMB();

--- a/arch/ceva/include/xm6/spinlock.h
+++ b/arch/ceva/include/xm6/spinlock.h
@@ -121,7 +121,7 @@ static inline spinlock_t up_testset(volatile spinlock_t *lock)
 
       /* Is it already locked by other? */
 
-      if (old == SP_LOCKED)
+      if (spin_is_locked(&old))
         {
           break; /* Yes, exit */
         }

--- a/boards/boardctl.c
+++ b/boards/boardctl.c
@@ -809,7 +809,7 @@ int boardctl(unsigned int cmd, uintptr_t arg)
             }
           else
             {
-              ret = up_testset(lock) == SP_LOCKED ? 1 : 0;
+              ret = spin_is_locked(&up_testset(lock)) ? 1 : 0;
             }
         }
         break;

--- a/include/nuttx/spinlock.h
+++ b/include/nuttx/spinlock.h
@@ -155,7 +155,7 @@ static inline spinlock_t up_testset(FAR volatile spinlock_t *lock)
 
   ret = *lock;
 
-  if (ret == SP_UNLOCKED)
+  if (!spin_is_locked(&ret))
     {
       *lock = SP_LOCKED;
     }
@@ -327,7 +327,7 @@ void spin_unlock_wo_note(FAR volatile spinlock_t *lock);
  * Name: spin_is_locked
  *
  * Description:
- *   Release one count on a non-reentrant spinlock.
+ *   Test whether a spinlock is locked.
  *
  * Input Parameters:
  *   lock - A reference to the spinlock object to test.

--- a/libs/libc/pthread/pthread_spinlock.c
+++ b/libs/libc/pthread/pthread_spinlock.c
@@ -186,7 +186,7 @@ int pthread_spin_lock(pthread_spinlock_t *lock)
   do
     {
 #ifdef CONFIG_BUILD_FLAT
-      ret = up_testset(&lock->sp_lock) == SP_LOCKED ? 1 : 0;
+      ret = spin_is_locked(&up_testset(&lock->sp_lock)) ? 1 : 0;
 #else
       ret = boardctl(BOARDIOC_TESTSET, (uintptr_t)&lock->sp_lock);
 #endif

--- a/sched/semaphore/spinlock.c
+++ b/sched/semaphore/spinlock.c
@@ -81,7 +81,7 @@ void spin_lock(FAR volatile spinlock_t *lock)
     atomic_fetch_add((FAR atomic_ushort *)&lock->tickets.next, 1);
   while (atomic_load((FAR atomic_ushort *)&lock->tickets.owner) != ticket)
 #else /* CONFIG_SPINLOCK */
-  while (up_testset(lock) == SP_LOCKED)
+  while (spin_is_locked(&up_testset(lock)))
 #endif
     {
       SP_DSB();
@@ -125,7 +125,7 @@ void spin_lock_wo_note(FAR volatile spinlock_t *lock)
     atomic_fetch_add((FAR atomic_ushort *)&lock->tickets.next, 1);
   while (atomic_load((FAR atomic_ushort *)&lock->tickets.owner) != ticket)
 #else /* CONFIG_TICKET_SPINLOCK */
-  while (up_testset(lock) == SP_LOCKED)
+  while (spin_is_locked(&up_testset(lock)))
 #endif
     {
       SP_DSB();
@@ -183,7 +183,7 @@ bool spin_trylock(FAR volatile spinlock_t *lock)
   if (!atomic_compare_exchange_strong((FAR atomic_uint *)&lock->value,
                                       &old.value, new.value))
 #else /* CONFIG_TICKET_SPINLOCK */
-  if (up_testset(lock) == SP_LOCKED)
+  if (spin_is_locked(&up_testset(lock)))
 #endif /* CONFIG_TICKET_SPINLOCK */
     {
 #ifdef CONFIG_SCHED_INSTRUMENTATION_SPINLOCKS
@@ -249,7 +249,7 @@ bool spin_trylock_wo_note(FAR volatile spinlock_t *lock)
   if (!atomic_compare_exchange_strong((FAR atomic_uint *)&lock->value,
                                       &old.value, new.value))
 #else /* CONFIG_TICKET_SPINLOCK */
-  if (up_testset(lock) == SP_LOCKED)
+  if (spin_is_locked(&up_testset(lock)))
 #endif /* CONFIG_TICKET_SPINLOCK */
     {
       SP_DSB();


### PR DESCRIPTION
## Summary

Previously compilation with ticket spinlock enabled failed for the rp2040 board due to comparisons between structs:

```
CC:  netdb/lib_proto.c chip/rp2040_testset.c: In function 'up_testset':
chip/rp2040_testset.c:73:11: error: invalid operands to binary == (have 'spinlock_t' {aka 'union spinlock_u'} and 'union spinlock_u')
   73 |   if (ret == SP_UNLOCKED)
      |           ^~
```

Now all occurrences of comparisons are replaced with the existing macro `spin_is_locked`.
Most of these occurrences were not relevant, since they were located in the spinlock code branches for "non-ticket" mode (with `spinlock_t` being an integer).
But in order to keep everything clear and predictable, we want to avoid potential struct comparisons everywhere.

## Impact
Based on the existing definition of the `spin_is_locked` macro for non-ticket mode there should be no change compared to the previous simple comparison:
```
#ifdef CONFIG_TICKET_SPINLOCK
#  define spin_is_locked(l) ((*l).tickets.owner != (*l).tickets.next)
#else
#  define spin_is_locked(l) (*(l) == SP_LOCKED)
#endif
```

## Testing

Now the code compiles cleanly for rp2040.