### PR TITLE
sim/cmake: enable garbage collection of unused input sections

### DIFF
--- a/arch/sim/src/cmake/Toolchain.cmake
+++ b/arch/sim/src/cmake/Toolchain.cmake
@@ -94,6 +94,11 @@ else()
   endif()
 endif()
 
+if(CONFIG_DEBUG_OPT_UNUSED_SECTIONS)
+  add_link_options(-Wl,--gc-sections)
+  add_compile_options(-ffunction-sections -fdata-sections)
+endif()
+
 if(CONFIG_CXX_STANDARD)
   add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-std=${CONFIG_CXX_STANDARD}>)
 endif()


### PR DESCRIPTION
## Summary

sim/cmake: enable garbage collection of unused input sections

enable --gc-sections for linker
enable -ffunction-sections -fdata-sections for compiler

Signed-off-by: chao an <anchao@lixiang.com>

## Impact

N/A

## Testing

ci-check