### PR TITLE
Kconfig: Add option to disable error checking for lazy dependencies

### DIFF
--- a/Documentation/introduction/index.rst
+++ b/Documentation/introduction/index.rst
@@ -12,4 +12,5 @@ In the following sections you will find basic information introducing main NuttX
   licensing.rst
   trademarks.rst
   resources.rst
+  rules_check.rst
 

--- a/Documentation/introduction/rules_check.rst
+++ b/Documentation/introduction/rules_check.rst
@@ -1,0 +1,54 @@
+============
+Rules Checks
+============
+
+.. note:: this should be revised
+
+NuttX uses Kconfig and its main checking for rules and dependencies between
+features to guarantee that the system will compile correctly.
+
+Another resource used to enforce that none pre-required feature was left behind
+is the "#ifdef" inside the source code. Although effective to detect configuration
+issue, this technic should be avoid in favor of more well though rules inside
+Kconfig.
+
+However, it is not possible to enforce many rules inside the Kconfig, otherwise
+the configuration becomes very inflexible and will not allow some use cases.
+
+For those case where Kconfig rule cannot fix everything, we need to return to
+#ifdef approach inside the code. But there is an issue: imagine we put a rule
+inside the file_feature_A.c:
+
+.. code-block:: c
+
+  #if !defined(CONFIG_FEATURE_B)
+  #error "You need FEATURE_B to normal use case"
+  #endif
+
+It will give a hint to users to select FEATURE_B, but imagine we have a smart
+user that knows how to use FEATURE_A without FEATURE_B, or want to it with
+FEATURE_C instead of FEATURE_B.
+
+This special user for instance knows all the IP addresses from all domains under
+the sun and decided that he can use the network without DNS support. How we can
+support this user and yet keep to rules in place for "ordinaries" users?
+
+For this we have an option to disable those #ifdef common checking, as explained
+in the next section.
+
+Ignoring Rules Checks
+=====================
+
+A way to ignore the forcing of those common usage #ifdef is using an option to
+disable rules check: CONFIG_IGNORE_RULES_CHECK.
+
+So, for the above example the new rules will include a test to confirm that the
+CONFIG_IGNORE_RULES_CHECK is not enabled:
+
+.. code-block:: c
+
+  #if !defined(CONFIG_IGNORE_RULES_CHECK) && !defined(CONFIG_FEATURE_B)
+  #error "You need FEATURE_B to normal use case or enable CONFIG_IGNORE_RULES_CHECK"
+  #endif
+
+Note: In order to enable CONFIG_IGNORE_RULES_CHECK you need first enable CONFIG_EXPERIMENTAL.

--- a/Kconfig
+++ b/Kconfig
@@ -109,6 +109,22 @@ config EXPERIMENTAL
 		hidden in the Kconfig menus. Enabling "Show experimental options"
 		makes these options visible and makes it possible to enable them.
 
+config IGNORE_RULES_CHECK
+	bool "Ignore rules checks for drivers and subsystems"
+	depends on EXPERIMENTAL
+	---help---
+		Many features on NuttX normally have lazy depencies and we cannot
+		force it on menuconfig because otherwise we could remove some use
+		cases not so common. An example reported by a user was caused by
+		the fact that he enabled the DHCPC but forgot to enable DNS.
+		Although in theory it is possible to use DHCPC without DNS, it is
+		suppose that almost 99% of use cases will use DHCPC with DNS, so
+		we cannot put a rigid rule in the menuconfig, but we can create a
+		error checked in dhcpc.c file like this:
+		#if !defined(CONFIG_IGNORE_RULES_CHECK) && !defined(CONFIG_NETDB_DNSCLIENT)
+		#error "Enable CONFIG_NETDB_DNSCLIENT or enable CONFIG_IGNORE_RULES_CHECK"
+		#endif
+
 config DEFAULT_SMALL
 	bool "Default to smallest size"
 	default n


### PR DESCRIPTION
## Summary
Some rules on NuttX cannot be defined on Kconfig, otherwise we could limit some use cases. However in the other hand many errors happen when users select a feature and forgot to enable other. A way to detect these lazy dependencies is using #ifdefs inside the source code. NuttX uses this resource a lot, but in some cases when we have more than one use cases, we need some way to disable this constrain.
## Impact
Allow to create #ifdef rules to check CONFIGs consistency that cannot be enforced on Kconfig and allow advanced users that want to use features in specific ways ignore that enforced checked rules
## Testing
SIM
