### PR TITLE
drivers: add API for drivers early initialization

### DIFF
--- a/Documentation/components/drivers/index.rst
+++ b/Documentation/components/drivers/index.rst
@@ -283,3 +283,15 @@ The following skeleton files are available:
 * ``drivers/mtd/skeleton.c`` Skeleton memory technology device drivers
 * ``drivers/net/skeleton.c`` Skeleton network/Ethernet drivers
 * ``drivers/usbhost/usbhost_skeleton.c`` Skeleton USB host class driver
+
+Drivers Early Initialization
+============================
+
+To initialize drivers early in the boot process, the :c:func:`drivers_early_initialize`
+function is introduced. This is particularly beneficial for certain drivers,
+such as SEGGER SystemView, or others that require initialization before the
+system is fully operational.
+
+It is important to note that during this early initialization phase,
+system resources are not yet available for use. This includes memory allocation,
+file systems, and any other system resources.

--- a/drivers/drivers_initialize.c
+++ b/drivers/drivers_initialize.c
@@ -54,6 +54,26 @@
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: drivers_early_initialize
+ *
+ * Description:
+ *   drivers_early_initialize will be called once before OS initialization
+ *   when no system resource is ready to use.
+ *
+ *   drivers_early_initialize serves the purpose of bringing up drivers as
+ *   early as possible, so they can be used even during OS initialization.
+ *   It must not rely on any system resources, such as heap memory.
+ *
+ ****************************************************************************/
+
+void drivers_early_initialize(void)
+{
+#ifdef CONFIG_DRIVERS_NOTE
+  note_early_initialize();
+#endif
+}
+
+/****************************************************************************
  * Name: drivers_initialize
  *
  * Description:

--- a/drivers/note/note_initialize.c
+++ b/drivers/note/note_initialize.c
@@ -36,6 +36,46 @@
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: note_early_initialize
+ *
+ * Description:
+ *   Registers note drivers early, without depending on system features
+ *   such as heap memory.
+ *
+ * Input Parameters:
+ *   None.
+ *
+ * Returned Value:
+ *   Zero on success. A negated errno value is returned on a failure.
+ *
+ ****************************************************************************/
+
+int note_early_initialize(void)
+{
+  int ret = 0;
+
+#ifdef CONFIG_SEGGER_SYSVIEW
+  ret = note_sysview_initialize();
+  if (ret < 0)
+    {
+      serr("note_sysview_initialize failed %d\n", ret);
+      return ret;
+    }
+#endif
+
+#ifdef CONFIG_DRIVERS_NOTESNAP
+  ret = notesnap_register();
+  if (ret < 0)
+    {
+      serr("notesnap_register failed %d\n", ret);
+      return ret;
+    }
+#endif
+
+  return ret;
+}
+
+/****************************************************************************
  * Name: note_initialize
  *
  * Description:
@@ -46,7 +86,7 @@
  *   None.
  *
  * Returned Value:
- *   Zero on succress. A negated errno value is returned on a failure.
+ *   Zero on success. A negated errno value is returned on a failure.
  *
  ****************************************************************************/
 
@@ -77,24 +117,6 @@ int note_initialize(void)
   if (ret < 0)
     {
       serr("notectl_register failed %d\n", ret);
-      return ret;
-    }
-#endif
-
-#ifdef CONFIG_SEGGER_SYSVIEW
-  ret = note_sysview_initialize();
-  if (ret < 0)
-    {
-      serr("note_sysview_initialize failed %d\n", ret);
-      return ret;
-    }
-#endif
-
-#ifdef CONFIG_DRIVERS_NOTESNAP
-  ret = notesnap_register();
-  if (ret < 0)
-    {
-      serr("notesnap_register failed %d\n", ret);
       return ret;
     }
 #endif

--- a/include/nuttx/drivers/drivers.h
+++ b/include/nuttx/drivers/drivers.h
@@ -44,6 +44,17 @@ extern "C"
 #endif
 
 /****************************************************************************
+ * Name: drivers_early_initialize
+ *
+ * Description:
+ *   Performs one-time, early driver initialization that doesn't rely on OS
+ *   resources being ready.
+ *
+ ****************************************************************************/
+
+void drivers_early_initialize(void);
+
+/****************************************************************************
  * Name: drivers_initialize
  *
  * Description:

--- a/include/nuttx/note/note_driver.h
+++ b/include/nuttx/note/note_driver.h
@@ -112,6 +112,25 @@ struct note_driver_s
 
 #if defined(__KERNEL__) || defined(CONFIG_BUILD_FLAT)
 
+#ifdef CONFIG_DRIVERS_NOTE
+
+/****************************************************************************
+ * Name: note_early_initialize
+ *
+ * Description:
+ *   Early register sched note related drivers that do not rely on system
+ *   features like mm.
+ *
+ * Input Parameters:
+ *   None.
+ *
+ * Returned Value:
+ *   Zero on success. A negative errno value is returned on a failure.
+ *
+ ****************************************************************************/
+
+int note_early_initialize(void);
+
 /****************************************************************************
  * Name: note_initialize
  *
@@ -123,11 +142,10 @@ struct note_driver_s
  *   None.
  *
  * Returned Value:
- *   Zero on succress. A negated errno value is returned on a failure.
+ *   Zero on success. A negative errno value is returned on a failure.
  *
  ****************************************************************************/
 
-#ifdef CONFIG_DRIVERS_NOTE
 int note_initialize(void);
 #endif
 

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -518,10 +518,6 @@ void nx_start(void)
 
   g_nx_initstate = OSINIT_BOOT;
 
-  /* Initialize RTOS Data ***************************************************/
-
-  sched_trace_begin();
-
   /* Initialize task list table *********************************************/
 
   tasklist_initialize();
@@ -533,6 +529,12 @@ void nx_start(void)
   /* Task lists are initialized */
 
   g_nx_initstate = OSINIT_TASKLISTS;
+
+  /* Initialize RTOS Data ***************************************************/
+
+  drivers_early_initialize();
+
+  sched_trace_begin();
 
   /* Initialize RTOS facilities *********************************************/
 


### PR DESCRIPTION
## Summary

Add `drivers_early_initialize` for drivers not reply on system resource. `note_sysview_initialize` is one of them to allow note to work as early as possible.

## Impact
No.

## Testing

stm32f429i-disco with systemview.
