### PR TITLE
syscall/docs: fix a few typos

### DIFF
--- a/Documentation/components/syscall.rst
+++ b/Documentation/components/syscall.rst
@@ -48,7 +48,7 @@ This header file is provided by the platform-specific logic and declares
 platform.  The following functions must be declared (or defined) in this
 header file:
 
-- ``SWI`` with ``SYS_`` call number and one parameter:
+- ``SWI`` with ``SYS_`` call number only:
 
   .. code-block:: C
 
@@ -149,12 +149,12 @@ or arbitrary types cannot be represented as system calls.
 using the non- variadic form of the OS interface that accepts a ``va_list``
 as an argument, ``vsyslog()`` in this case.
 
-There there are many functions that have a variadic form but take only
-one or two arguments optional arguments.  There can be handled as system
+There are many functions that have a variadic form but take only
+one or two optional arguments.  There can be handled as system
 calls, but only by treating them as though they had a fixed number of
 arguments.
 
-These are are handled in ``syscall.csv`` by appending the number and type of
+These are handled in ``syscall.csv`` by appending the number and type of
 optional arguments.  For example, consider the ``open()`` OS interface.  Its
 prototype is:
 
@@ -163,14 +163,14 @@ prototype is:
       int open(const char *path, int oflag, ...);
 
 In reality, open may take only a single optional argument of type ``mode_t``
-and is represented in syscall.cvs like this::
+and is represented in ``syscall.csv`` like this::
 
       "open","fcntl.h","","int","const char*","int","...","mode_t"
 
 The existence of the ``mode_t`` tells ``tools/mksyscall`` that there is at most
 one optional parameter and, if present, it is of type ``mode_t``.
 
-NOTE: This CSV file is used both to support the generate of trap information,
+NOTE: This CSV file is used not only to support the generate of trap information,
 but also for the generation of symbol tables.  See ``Documentation/components/tools/``
 and ``Documentation/components/libs/`` for further information.
 
@@ -201,7 +201,7 @@ Sub-Directories
 mksyscall
 ---------
 
-mksyscall is C program that is used used during the initial NuttX build
+mksyscall is C program that is used during the initial NuttX build
 by the logic in the top-level ``syscall/`` directory. Information about the
 stubs and proxies is maintained in a comma separated value (CSV) file
 in the ``syscall/`` directory.  The mksyscall program will accept this CSV


### PR DESCRIPTION
## Summary

This fixes a few typos in `syscall.rst`.

## Impacts

None

## Testing

CI checks
