### PR TITLE
riscv_tcbinfo: Fix register ordering for PC

### DIFF
--- a/arch/risc-v/src/common/riscv_tcbinfo.c
+++ b/arch/risc-v/src/common/riscv_tcbinfo.c
@@ -34,7 +34,7 @@
 
 static const uint16_t g_reg_offs[] =
 {
-  TCB_REG_OFF(REG_EPC_NDX),
+  TCB_REG_OFF(REG_EPC_NDX), /* X0, but it will be ommited by gdb client */
   TCB_REG_OFF(REG_X1_NDX),
   TCB_REG_OFF(REG_X2_NDX),
   TCB_REG_OFF(REG_X3_NDX),
@@ -66,6 +66,7 @@ static const uint16_t g_reg_offs[] =
   TCB_REG_OFF(REG_X29_NDX),
   TCB_REG_OFF(REG_X30_NDX),
   TCB_REG_OFF(REG_X31_NDX),
+  TCB_REG_OFF(REG_EPC_NDX),
 
 #if 0
 #  ifdef CONFIG_ARCH_FPU


### PR DESCRIPTION

## Summary
X0 is always 0 but still should be transfered to the client, but it don't existed in thread context, use any other register for it, and its value will be omitted by gdb client.

## Impact
Minor, tcbinfo
## Testing
Tested on ESP32-C3

Before:
![屏幕截图 2024-07-08 173747](https://github.com/apache/nuttx/assets/9030616/d8ddee13-e74b-4d0c-8a37-af38cc86d727)
After:
![屏幕截图 2024-07-08 173616](https://github.com/apache/nuttx/assets/9030616/35bf0af0-d6ff-40ee-a946-21f4dbe047dd)

