### PR TITLE
tools/imx9: prepare bootable bootloader image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ tools/gdb/__pycache__
 /build
 .ccls-cache
 compile_commands.json
+imx9-sdimage.img

--- a/Documentation/platforms/arm64/imx9/boards/imx93-evk/README.txt
+++ b/Documentation/platforms/arm64/imx9/boards/imx93-evk/README.txt
@@ -4,8 +4,9 @@ README.txt
 The kit i.MX93 Evaluation Kit has a pre-installed Linux image which contains
 u-boot and the i.MX93 reference Linux installation.
 
-u-boot is required to boot NuttX (for now) as it initializes the hardware for
-us, i.e. DDR, clocks, I/O muxes etc.
+NuttX may work as the bootloader, replacing u-boot completely. Currently it
+doesn't initialize the DDR memory yet. In other words, DDR training is still
+missing.
 
 ==========================================
 
@@ -13,7 +14,9 @@ How to run nuttx on i.MX93 Evaluation Kit.
 
 ==========================================
 
-Below is a set of instructions on how to run NuttX on the i.MX93 EVK
+Below is a set of instructions on how to run NuttX on the i.MX93 EVK, on top
+of the u-boot. Also, instructions on running NuttX as the bootloader will
+follow.
 
 ==========================================
 
@@ -76,11 +79,12 @@ Loading and running the NuttX image
 
 ==========================================
 
-You have three options:
+You have four options:
 
 1 - Load via u-boot from SD-card
 2 - Load via gdb
 3 - Load via JLink
+4 - Run from SD-card, without u-boot
 
 ==========================================
 
@@ -144,3 +148,22 @@ Option 3: load with JLink:
 3. Load nuttx. Note that JLink expects the .elf extension, the default build output of nuttx is just "nuttx" without the extension, so it must be added to the file...
 
     J-Link>LoadFile <path_to>/nuttx.elf
+
+==========================================
+
+Option 4: Run from SD-card, without u-boot
+
+==========================================
+
+1. Make sure CONFIG_IMX9_BOOTLOADER is set and system is configured properly for bootloader operation:
+
+  tools/configure.sh imx93-evk:bootloader
+
+2. The build outputs a file "imx9-sdimage.img". This image also contains the Ahab container. It's required to grant Trusted Resource Domain Controller (TRDC) permissions.
+   Flash it to an SD-card, where sdX may be sda or something else; verify the block device name properly (eg. /dev/sda, /dev/sdb etc):
+
+  sudo dd if=imx9-sdimage.img of=/dev/sdX bs=1k && sync
+
+3. Insert the SD-card into the imx93-evk, make sure BMODE switch is [1,2,3,4] = [Off, On, Off, Off] so that it boots from the SD-card.
+
+  This should boot into NuttShell in EL3 level.

--- a/tools/imx9/Makefile.host
+++ b/tools/imx9/Makefile.host
@@ -1,0 +1,47 @@
+############################################################################
+# tools/imx9/Makefile.host
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+-include $(TOPDIR)/Make.defs
+all: mkimage_imx9
+default: mkimage_imx9
+.PHONY: clean
+
+# Add CFLAGS=-g on the make command line to build debug versions
+
+CFLAGS = -g -O2 -Wall -std=c99 -static
+
+# mkimage_imx9 - combine and sign a bootloader image for flashing
+
+mkimage_imx9: imx8qxb0.c mkimage_imx8.c
+	@gcc $(CFLAGS) -o mkimage_imx9 imx8qxb0.c mkimage_imx8.c
+
+clean:
+ifneq ($(CONFIG_WINDOWS_NATIVE),y)
+	$(Q) rm -rf *.dSYM
+endif
+	$(call DELFILE, mkimage_imx9)
+	$(call DELFILE, mkimage_imx9.exe)
+	$(call DELFILE, mkimage_imx8.c)
+	$(call DELFILE, imx8qxb0.c)
+	$(call DELFILE, mkimage_common.h)
+	$(call DELFILE, build_info.h)
+	$(call DELFILE, firmware-ele-imx-0.1.1.bin)
+	$(call DELDIR, firmware-ele-imx-0.1.1)
+	$(call CLEAN)


### PR DESCRIPTION
This does the following:
  1. Fetches mkimage_imx8 (same used with imx9) source code
  2. Fetches the ELE / AHAB binary
  3. Extracts the ELE / AHAB binary
  4. Compiles the mkimage with hostcc
  5. Utilizes the mkimage tool to create a bootable SD image, combining the ELE / AHAB image with the NuttX bootloader
  6. dd is used to prepend empty space in place of BL31
  7. Outputs sdimage.img which is a bootable binary
  8. Removes all binaries, sources code images that have been downloaded

## Summary

This creates the steps necessary for creating a bootable bootloader image for SD card.

## Impact

imx9 bootloader version

## Testing

imx9-evkit, various bootloaders

