### PR TITLE
drivers/note: remove unnecessary logic to improve the performance

### DIFF
--- a/drivers/note/note_driver.c
+++ b/drivers/note/note_driver.c
@@ -233,27 +233,14 @@ static void note_common(FAR struct tcb_s *tcb,
 
   /* Save all of the common fields */
 
-  note->nc_length = length;
-  note->nc_type   = type;
-
-  if (tcb == NULL)
-    {
-      note->nc_priority = CONFIG_INIT_PRIORITY;
+  note->nc_length       = length;
+  note->nc_type         = type;
+  note->nc_priority     = tcb->sched_priority;
 #ifdef CONFIG_SMP
-      note->nc_cpu = 0;
+  note->nc_cpu          = tcb->cpu;
 #endif
-      note->nc_pid = 0;
-    }
-  else
-    {
-      note->nc_priority = tcb->sched_priority;
-#ifdef CONFIG_SMP
-      note->nc_cpu      = tcb->cpu;
-#endif
-      note->nc_pid = tcb->pid;
-    }
-
-  note->nc_systime_sec = ts.tv_sec;
+  note->nc_pid          = tcb->pid;
+  note->nc_systime_sec  = ts.tv_sec;
   note->nc_systime_nsec = ts.tv_nsec;
 }
 

--- a/drivers/note/note_initialize.c
+++ b/drivers/note/note_initialize.c
@@ -52,11 +52,11 @@
 
 int note_early_initialize(void)
 {
-  int ret = 0;
+  int ret = OK;
 
 #ifdef CONFIG_SEGGER_SYSVIEW
   ret = note_sysview_initialize();
-  if (ret < 0)
+  if (ret != OK)
     {
       serr("note_sysview_initialize failed %d\n", ret);
       return ret;
@@ -65,7 +65,7 @@ int note_early_initialize(void)
 
 #ifdef CONFIG_DRIVERS_NOTESNAP
   ret = notesnap_register();
-  if (ret < 0)
+  if (ret != OK)
     {
       serr("notesnap_register failed %d\n", ret);
       return ret;
@@ -92,11 +92,11 @@ int note_early_initialize(void)
 
 int note_initialize(void)
 {
-  int ret = 0;
+  int ret = OK;
 
 #ifdef CONFIG_DRIVERS_NOTERAM
   ret = noteram_register();
-  if (ret < 0)
+  if (ret != OK)
     {
       serr("noteram_register failed %d\n", ret);
       return ret;
@@ -105,7 +105,7 @@ int note_initialize(void)
 
 #ifdef CONFIG_NOTE_RTT
   ret = notertt_register();
-  if (ret < 0)
+  if (ret != OK)
     {
       serr("notertt_register failed %d\n", ret);
       return ret;
@@ -114,7 +114,7 @@ int note_initialize(void)
 
 #ifdef CONFIG_DRIVERS_NOTECTL
   ret = notectl_register();
-  if (ret < 0)
+  if (ret != OK)
     {
       serr("notectl_register failed %d\n", ret);
       return ret;


### PR DESCRIPTION
## Summary

1. drivers/note: remove unnecessary logic to improve the performance

All trace functions will start after the core resource is initialized.



2. drivers/note: update some ignored review comments

comment ignored from https://github.com/apache/nuttx/pull/12641



## Impact

N/A

## Testing

ci-check