### PR TITLE
can: fixes and tweaks for CAN FD support

### DIFF
--- a/arch/arm/src/samv7/Kconfig
+++ b/arch/arm/src/samv7/Kconfig
@@ -3264,21 +3264,21 @@ config SAMV7_MCAN0_PROPSEG
 
 config SAMV7_MCAN0_PHASESEG1
 	int "MCAN0 PhaseSeg1"
-	default 11
+	default 9
 	range 1 63
 	---help---
 		The length of the bit time is Tquanta * (SyncSeg + PropSeg + PhaseSeg1 + PhaseSeg2).
 
 config SAMV7_MCAN0_PHASESEG2
 	int "MCAN0 PhaseSeg2"
-	default 11
+	default 1
 	range 1 63
 	---help---
 		The length of the bit time is Tquanta * (SyncSeg + PropSeg + PhaseSeg1 + PhaseSeg2).
 
 config SAMV7_MCAN0_FSJW
 	int "MCAN0 synchronization jump width"
-	default 4
+	default 2
 	range 1 5
 	---help---
 		The duration of a synchronization jump is Tcan_clk x FSJW.
@@ -3299,14 +3299,14 @@ config SAMV7_MCAN0_FPROPSEG
 
 config SAMV7_MCAN0_FPHASESEG1
 	int "MCAN0 fast PhaseSeg1"
-	default 4
+	default 9
 	range 1 63
 	---help---
 		The length of the bit time is Tquanta * (SyncSeg + PropSeg + PhaseSeg1 + PhaseSeg2).
 
 config SAMV7_MCAN0_FPHASESEG2
 	int "MCAN0 fast PhaseSeg2"
-	default 4
+	default 1
 	range 1 63
 	---help---
 		The length of the bit time is Tquanta * (SyncSeg + PropSeg + PhaseSeg1 + PhaseSeg2).
@@ -3342,31 +3342,31 @@ config SAMV7_MCAN0_RXFIFO0_8BYTES
 
 config SAMV7_MCAN0_RXFIFO0_12BYTES
 	bool "12 bytes"
-	depends on SAMV7_MCAN0_FD
+	depends on SAMV7_MCAN0_FD || SAMV7_MCAN0_FD_BSW
 
 config SAMV7_MCAN0_RXFIFO0_16BYTES
 	bool "16 bytes"
-	depends on SAMV7_MCAN0_FD
+	depends on SAMV7_MCAN0_FD || SAMV7_MCAN0_FD_BSW
 
 config SAMV7_MCAN0_RXFIFO0_20BYTES
 	bool "20 bytes"
-	depends on SAMV7_MCAN0_FD
+	depends on SAMV7_MCAN0_FD || SAMV7_MCAN0_FD_BSW
 
 config SAMV7_MCAN0_RXFIFO0_24BYTES
 	bool "24 bytes"
-	depends on SAMV7_MCAN0_FD
+	depends on SAMV7_MCAN0_FD || SAMV7_MCAN0_FD_BSW
 
 config SAMV7_MCAN0_RXFIFO0_32BYTES
 	bool "32 bytes"
-	depends on SAMV7_MCAN0_FD
+	depends on SAMV7_MCAN0_FD || SAMV7_MCAN0_FD_BSW
 
 config SAMV7_MCAN0_RXFIFO0_48BYTES
 	bool "48 bytes"
-	depends on SAMV7_MCAN0_FD
+	depends on SAMV7_MCAN0_FD || SAMV7_MCAN0_FD_BSW
 
 config SAMV7_MCAN0_RXFIFO0_64BYTES
 	bool "64 bytes"
-	depends on SAMV7_MCAN0_FD
+	depends on SAMV7_MCAN0_FD || SAMV7_MCAN0_FD_BSW
 
 endchoice # MCAN0 RX buffer element size
 
@@ -3386,31 +3386,31 @@ config SAMV7_MCAN0_RXFIFO1_8BYTES
 
 config SAMV7_MCAN0_RXFIFO1_12BYTES
 	bool "12 bytes"
-	depends on SAMV7_MCAN0_FD
+	depends on SAMV7_MCAN0_FD || SAMV7_MCAN0_FD_BSW
 
 config SAMV7_MCAN0_RXFIFO1_16BYTES
 	bool "16 bytes"
-	depends on SAMV7_MCAN0_FD
+	depends on SAMV7_MCAN0_FD || SAMV7_MCAN0_FD_BSW
 
 config SAMV7_MCAN0_RXFIFO1_20BYTES
 	bool "20 bytes"
-	depends on SAMV7_MCAN0_FD
+	depends on SAMV7_MCAN0_FD || SAMV7_MCAN0_FD_BSW
 
 config SAMV7_MCAN0_RXFIFO1_24BYTES
 	bool "24 bytes"
-	depends on SAMV7_MCAN0_FD
+	depends on SAMV7_MCAN0_FD || SAMV7_MCAN0_FD_BSW
 
 config SAMV7_MCAN0_RXFIFO1_32BYTES
 	bool "32 bytes"
-	depends on SAMV7_MCAN0_FD
+	depends on SAMV7_MCAN0_FD || SAMV7_MCAN0_FD_BSW
 
 config SAMV7_MCAN0_RXFIFO1_48BYTES
 	bool "48 bytes"
-	depends on SAMV7_MCAN0_FD
+	depends on SAMV7_MCAN0_FD || SAMV7_MCAN0_FD_BSW
 
 config SAMV7_MCAN0_RXFIFO1_64BYTES
 	bool "64 bytes"
-	depends on SAMV7_MCAN0_FD
+	depends on SAMV7_MCAN0_FD || SAMV7_MCAN0_FD_BSW
 
 endchoice # MCAN0 RX buffer element size
 
@@ -3430,31 +3430,31 @@ config SAMV7_MCAN0_RXBUFFER_8BYTES
 
 config SAMV7_MCAN0_RXBUFFER_12BYTES
 	bool "12 bytes"
-	depends on SAMV7_MCAN0_FD
+	depends on SAMV7_MCAN0_FD || SAMV7_MCAN0_FD_BSW
 
 config SAMV7_MCAN0_RXBUFFER_16BYTES
 	bool "16 bytes"
-	depends on SAMV7_MCAN0_FD
+	depends on SAMV7_MCAN0_FD || SAMV7_MCAN0_FD_BSW
 
 config SAMV7_MCAN0_RXBUFFER_20BYTES
 	bool "20 bytes"
-	depends on SAMV7_MCAN0_FD
+	depends on SAMV7_MCAN0_FD || SAMV7_MCAN0_FD_BSW
 
 config SAMV7_MCAN0_RXBUFFER_24BYTES
 	bool "24 bytes"
-	depends on SAMV7_MCAN0_FD
+	depends on SAMV7_MCAN0_FD || SAMV7_MCAN0_FD_BSW
 
 config SAMV7_MCAN0_RXBUFFER_32BYTES
 	bool "32 bytes"
-	depends on SAMV7_MCAN0_FD
+	depends on SAMV7_MCAN0_FD || SAMV7_MCAN0_FD_BSW
 
 config SAMV7_MCAN0_RXBUFFER_48BYTES
 	bool "48 bytes"
-	depends on SAMV7_MCAN0_FD
+	depends on SAMV7_MCAN0_FD || SAMV7_MCAN0_FD_BSW
 
 config SAMV7_MCAN0_RXBUFFER_64BYTES
 	bool "64 bytes"
-	depends on SAMV7_MCAN0_FD
+	depends on SAMV7_MCAN0_FD || SAMV7_MCAN0_FD_BSW
 
 endchoice # MCAN0 RX buffer element size
 
@@ -3477,31 +3477,31 @@ config SAMV7_MCAN0_TXBUFFER_8BYTES
 
 config SAMV7_MCAN0_TXBUFFER_12BYTES
 	bool "12 bytes"
-	depends on SAMV7_MCAN0_FD
+	depends on SAMV7_MCAN0_FD || SAMV7_MCAN0_FD_BSW
 
 config SAMV7_MCAN0_TXBUFFER_16BYTES
 	bool "16 bytes"
-	depends on SAMV7_MCAN0_FD
+	depends on SAMV7_MCAN0_FD || SAMV7_MCAN0_FD_BSW
 
 config SAMV7_MCAN0_TXBUFFER_20BYTES
 	bool "20 bytes"
-	depends on SAMV7_MCAN0_FD
+	depends on SAMV7_MCAN0_FD || SAMV7_MCAN0_FD_BSW
 
 config SAMV7_MCAN0_TXBUFFER_24BYTES
 	bool "24 bytes"
-	depends on SAMV7_MCAN0_FD
+	depends on SAMV7_MCAN0_FD || SAMV7_MCAN0_FD_BSW
 
 config SAMV7_MCAN0_TXBUFFER_32BYTES
 	bool "32 bytes"
-	depends on SAMV7_MCAN0_FD
+	depends on SAMV7_MCAN0_FD || SAMV7_MCAN0_FD_BSW
 
 config SAMV7_MCAN0_TXBUFFER_48BYTES
 	bool "48 bytes"
-	depends on SAMV7_MCAN0_FD
+	depends on SAMV7_MCAN0_FD || SAMV7_MCAN0_FD_BSW
 
 config SAMV7_MCAN0_TXBUFFER_64BYTES
 	bool "64 bytes"
-	depends on SAMV7_MCAN0_FD
+	depends on SAMV7_MCAN0_FD || SAMV7_MCAN0_FD_BSW
 
 endchoice # MCAN0 TX buffer element size
 
@@ -3580,21 +3580,21 @@ config SAMV7_MCAN1_PROPSEG
 
 config SAMV7_MCAN1_PHASESEG1
 	int "MCAN1 PhaseSeg1"
-	default 11
+	default 9
 	range 1 63
 	---help---
 		The length of the bit time is Tquanta * (SyncSeg + PropSeg + PhaseSeg1 + PhaseSeg2).
 
 config SAMV7_MCAN1_PHASESEG2
 	int "MCAN1 PhaseSeg2"
-	default 11
+	default 1
 	range 1 63
 	---help---
 		The length of the bit time is Tquanta * (SyncSeg + PropSeg + PhaseSeg1 + PhaseSeg2).
 
 config SAMV7_MCAN1_FSJW
 	int "MCAN1 synchronization jump width"
-	default 4
+	default 2
 	range 1 5
 	---help---
 		The duration of a synchronization jump is Tcan_clk x FSJW.
@@ -3615,14 +3615,14 @@ config SAMV7_MCAN1_FPROPSEG
 
 config SAMV7_MCAN1_FPHASESEG1
 	int "MCAN1 fast PhaseSeg1"
-	default 4
+	default 9
 	range 1 63
 	---help---
 		The length of the bit time is Tquanta * (SyncSeg + PropSeg + PhaseSeg1 + PhaseSeg2).
 
 config SAMV7_MCAN1_FPHASESEG2
 	int "MCAN1 fast PhaseSeg2"
-	default 4
+	default 1
 	range 1 63
 	---help---
 		The length of the bit time is Tquanta * (SyncSeg + PropSeg + PhaseSeg1 + PhaseSeg2).
@@ -3658,31 +3658,31 @@ config SAMV7_MCAN1_RXFIFO0_8BYTES
 
 config SAMV7_MCAN1_RXFIFO0_12BYTES
 	bool "12 bytes"
-	depends on SAMV7_MCAN1_FD
+	depends on SAMV7_MCAN1_FD || SAMV7_MCAN1_FD_BSW
 
 config SAMV7_MCAN1_RXFIFO0_16BYTES
 	bool "16 bytes"
-	depends on SAMV7_MCAN1_FD
+	depends on SAMV7_MCAN1_FD || SAMV7_MCAN1_FD_BSW
 
 config SAMV7_MCAN1_RXFIFO0_20BYTES
 	bool "20 bytes"
-	depends on SAMV7_MCAN1_FD
+	depends on SAMV7_MCAN1_FD || SAMV7_MCAN1_FD_BSW
 
 config SAMV7_MCAN1_RXFIFO0_24BYTES
 	bool "24 bytes"
-	depends on SAMV7_MCAN1_FD
+	depends on SAMV7_MCAN1_FD || SAMV7_MCAN1_FD_BSW
 
 config SAMV7_MCAN1_RXFIFO0_32BYTES
 	bool "32 bytes"
-	depends on SAMV7_MCAN1_FD
+	depends on SAMV7_MCAN1_FD || SAMV7_MCAN1_FD_BSW
 
 config SAMV7_MCAN1_RXFIFO0_48BYTES
 	bool "48 bytes"
-	depends on SAMV7_MCAN1_FD
+	depends on SAMV7_MCAN1_FD || SAMV7_MCAN1_FD_BSW
 
 config SAMV7_MCAN1_RXFIFO0_64BYTES
 	bool "64 bytes"
-	depends on SAMV7_MCAN1_FD
+	depends on SAMV7_MCAN1_FD || SAMV7_MCAN1_FD_BSW
 
 endchoice # MCAN1 RX buffer element size
 
@@ -3702,31 +3702,31 @@ config SAMV7_MCAN1_RXFIFO1_8BYTES
 
 config SAMV7_MCAN1_RXFIFO1_12BYTES
 	bool "12 bytes"
-	depends on SAMV7_MCAN1_FD
+	depends on SAMV7_MCAN1_FD || SAMV7_MCAN1_FD_BSW
 
 config SAMV7_MCAN1_RXFIFO1_16BYTES
 	bool "16 bytes"
-	depends on SAMV7_MCAN1_FD
+	depends on SAMV7_MCAN1_FD || SAMV7_MCAN1_FD_BSW
 
 config SAMV7_MCAN1_RXFIFO1_20BYTES
 	bool "20 bytes"
-	depends on SAMV7_MCAN1_FD
+	depends on SAMV7_MCAN1_FD || SAMV7_MCAN1_FD_BSW
 
 config SAMV7_MCAN1_RXFIFO1_24BYTES
 	bool "24 bytes"
-	depends on SAMV7_MCAN1_FD
+	depends on SAMV7_MCAN1_FD || SAMV7_MCAN1_FD_BSW
 
 config SAMV7_MCAN1_RXFIFO1_32BYTES
 	bool "32 bytes"
-	depends on SAMV7_MCAN1_FD
+	depends on SAMV7_MCAN1_FD || SAMV7_MCAN1_FD_BSW
 
 config SAMV7_MCAN1_RXFIFO1_48BYTES
 	bool "48 bytes"
-	depends on SAMV7_MCAN1_FD
+	depends on SAMV7_MCAN1_FD || SAMV7_MCAN1_FD_BSW
 
 config SAMV7_MCAN1_RXFIFO1_64BYTES
 	bool "64 bytes"
-	depends on SAMV7_MCAN1_FD
+	depends on SAMV7_MCAN1_FD || SAMV7_MCAN1_FD_BSW
 
 endchoice # MCAN1 RX buffer element size
 
@@ -3746,31 +3746,31 @@ config SAMV7_MCAN1_RXBUFFER_8BYTES
 
 config SAMV7_MCAN1_RXBUFFER_12BYTES
 	bool "12 bytes"
-	depends on SAMV7_MCAN1_FD
+	depends on SAMV7_MCAN1_FD || SAMV7_MCAN1_FD_BSW
 
 config SAMV7_MCAN1_RXBUFFER_16BYTES
 	bool "16 bytes"
-	depends on SAMV7_MCAN1_FD
+	depends on SAMV7_MCAN1_FD || SAMV7_MCAN1_FD_BSW
 
 config SAMV7_MCAN1_RXBUFFER_20BYTES
 	bool "20 bytes"
-	depends on SAMV7_MCAN1_FD
+	depends on SAMV7_MCAN1_FD || SAMV7_MCAN1_FD_BSW
 
 config SAMV7_MCAN1_RXBUFFER_24BYTES
 	bool "24 bytes"
-	depends on SAMV7_MCAN1_FD
+	depends on SAMV7_MCAN1_FD || SAMV7_MCAN1_FD_BSW
 
 config SAMV7_MCAN1_RXBUFFER_32BYTES
 	bool "32 bytes"
-	depends on SAMV7_MCAN1_FD
+	depends on SAMV7_MCAN1_FD || SAMV7_MCAN1_FD_BSW
 
 config SAMV7_MCAN1_RXBUFFER_48BYTES
 	bool "48 bytes"
-	depends on SAMV7_MCAN1_FD
+	depends on SAMV7_MCAN1_FD || SAMV7_MCAN1_FD_BSW
 
 config SAMV7_MCAN1_RXBUFFER_64BYTES
 	bool "64 bytes"
-	depends on SAMV7_MCAN1_FD
+	depends on SAMV7_MCAN1_FD || SAMV7_MCAN1_FD_BSW
 
 endchoice # MCAN1 RX buffer element size
 
@@ -3793,31 +3793,31 @@ config SAMV7_MCAN1_TXBUFFER_8BYTES
 
 config SAMV7_MCAN1_TXBUFFER_12BYTES
 	bool "12 bytes"
-	depends on SAMV7_MCAN1_FD
+	depends on SAMV7_MCAN1_FD || SAMV7_MCAN1_FD_BSW
 
 config SAMV7_MCAN1_TXBUFFER_16BYTES
 	bool "16 bytes"
-	depends on SAMV7_MCAN1_FD
+	depends on SAMV7_MCAN1_FD || SAMV7_MCAN1_FD_BSW
 
 config SAMV7_MCAN1_TXBUFFER_20BYTES
 	bool "20 bytes"
-	depends on SAMV7_MCAN1_FD
+	depends on SAMV7_MCAN1_FD || SAMV7_MCAN1_FD_BSW
 
 config SAMV7_MCAN1_TXBUFFER_24BYTES
 	bool "24 bytes"
-	depends on SAMV7_MCAN1_FD
+	depends on SAMV7_MCAN1_FD || SAMV7_MCAN1_FD_BSW
 
 config SAMV7_MCAN1_TXBUFFER_32BYTES
 	bool "32 bytes"
-	depends on SAMV7_MCAN1_FD
+	depends on SAMV7_MCAN1_FD || SAMV7_MCAN1_FD_BSW
 
 config SAMV7_MCAN1_TXBUFFER_48BYTES
 	bool "48 bytes"
-	depends on SAMV7_MCAN1_FD
+	depends on SAMV7_MCAN1_FD || SAMV7_MCAN1_FD_BSW
 
 config SAMV7_MCAN1_TXBUFFER_64BYTES
 	bool "64 bytes"
-	depends on SAMV7_MCAN1_FD
+	depends on SAMV7_MCAN1_FD || SAMV7_MCAN1_FD_BSW
 
 endchoice # MCAN1 TX buffer element size
 

--- a/arch/arm/src/samv7/sam_mcan.c
+++ b/arch/arm/src/samv7/sam_mcan.c
@@ -144,10 +144,10 @@
                         (float)CONFIG_SAMV7_MCAN0_FBITRATE)) - 1))
 #  define MCAN0_DSJW   (CONFIG_SAMV7_MCAN0_FFSJW - 1)
 
-#  if MCAN0_DTSEG1 > 15
+#  if MCAN0_DTSEG1 > 31
 #    error Invalid MCAN0 DTSEG1
 #  endif
-#  if MCAN0_DTSEG2 > 7
+#  if MCAN0_DTSEG2 > 15
 #    error Invalid MCAN0 DTSEG2
 #  endif
 #  if MCAN0_DSJW > 3
@@ -429,10 +429,10 @@
                         (float)CONFIG_SAMV7_MCAN1_FBITRATE)) - 1))
 #  define MCAN1_DSJW   (CONFIG_SAMV7_MCAN1_FFSJW - 1)
 
-#if MCAN1_DTSEG1 > 15
+#if MCAN1_DTSEG1 > 31
 #  error Invalid MCAN1 DTSEG1
 #endif
-#if MCAN1_DTSEG2 > 7
+#if MCAN1_DTSEG2 > 15
 #  error Invalid MCAN1 DTSEG2
 #endif
 #if MCAN1_DSJW > 3
@@ -2650,33 +2650,70 @@ static int mcan_ioctl(struct can_dev_s *dev, int cmd, unsigned long arg)
 
           DEBUGASSERT(bt != NULL);
 
-          regval       = mcan_getreg(priv, SAM_MCAN_NBTP_OFFSET);
-
-          if (priv->rev == 0)
+#ifdef CONFIG_CAN_FD
+          if (bt->type == CAN_BITTIMING_DATA)
             {
-              /* Revision A */
+              if (priv->rev == 0)
+                {
+                  /* Revision A */
 
-              bt->bt_sjw   = ((regval & MCAN_REVA_BTP_SJW_MASK) >>
-                              MCAN_REVA_BTP_SJW_SHIFT) + 1;
-              bt->bt_tseg1 = ((regval & MCAN_REVA_BTP_TSEG1_MASK) >>
-                              MCAN_REVA_BTP_TSEG1_SHIFT) + 1;
-              bt->bt_tseg2 = ((regval & MCAN_REVA_BTP_TSEG2_MASK) >>
-                              MCAN_REVA_BTP_TSEG2_SHIFT) + 1;
-              brp          = ((regval & MCAN_REVA_BTP_BRP_MASK) >>
-                              MCAN_REVA_BTP_BRP_SHIFT) + 1;
+                  regval       = mcan_getreg(priv,
+                                  SAM_MCAN_REVA_FBTP_OFFSET);
+                  bt->bt_sjw   = ((regval & MCAN_REVA_FBTP_FSJW_MASK) >>
+                                  MCAN_REVA_FBTP_FSJW_SHIFT) + 1;
+                  bt->bt_tseg1 = ((regval & MCAN_REVA_FBTP_FTSEG1_MASK) >>
+                                  MCAN_REVA_FBTP_FTSEG1_SHIFT) + 1;
+                  bt->bt_tseg2 = ((regval & MCAN_REVA_FBTP_FTSEG2_MASK) >>
+                                  MCAN_REVA_FBTP_FTSEG2_SHIFT) + 1;
+                  brp          = ((regval & MCAN_REVA_FBTP_FBRP_MASK) >>
+                                  MCAN_REVA_FBTP_FBRP_SHIFT) + 1;
+                }
+              else
+                {
+                  /* Revision B */
+
+                  regval       = mcan_getreg(priv, SAM_MCAN_DBTP_OFFSET);
+                  bt->bt_sjw   = ((regval & MCAN_DBTP_DSJW_MASK) >>
+                                  MCAN_DBTP_DSJW_SHIFT) + 1;
+                  bt->bt_tseg1 = ((regval & MCAN_DBTP_DTSEG1_MASK) >>
+                                  MCAN_DBTP_DTSEG1_SHIFT) + 1;
+                  bt->bt_tseg2 = ((regval & MCAN_DBTP_DTSEG2_MASK) >>
+                                  MCAN_DBTP_DTSEG2_SHIFT) + 1;
+                  brp          = ((regval & MCAN_DBTP_DBRP_MASK) >>
+                                  MCAN_DBTP_DBRP_SHIFT) + 1;
+                }
             }
           else
+#endif
             {
-              /* Revision B */
+              if (priv->rev == 0)
+                {
+                  /* Revision A */
 
-              bt->bt_sjw   = ((regval & MCAN_NBTP_NSJW_MASK) >>
-                              MCAN_NBTP_NSJW_SHIFT) + 1;
-              bt->bt_tseg1 = ((regval & MCAN_NBTP_NTSEG1_MASK) >>
-                              MCAN_NBTP_NTSEG1_SHIFT) + 1;
-              bt->bt_tseg2 = ((regval & MCAN_NBTP_NTSEG2_MASK) >>
-                              MCAN_NBTP_NTSEG2_SHIFT) + 1;
-              brp          = ((regval & MCAN_NBTP_NBRP_MASK) >>
-                              MCAN_NBTP_NBRP_SHIFT) + 1;
+                  regval       = mcan_getreg(priv, SAM_MCAN_REVA_BTP_OFFSET);
+                  bt->bt_sjw   = ((regval & MCAN_REVA_BTP_SJW_MASK) >>
+                                  MCAN_REVA_BTP_SJW_SHIFT) + 1;
+                  bt->bt_tseg1 = ((regval & MCAN_REVA_BTP_TSEG1_MASK) >>
+                                  MCAN_REVA_BTP_TSEG1_SHIFT) + 1;
+                  bt->bt_tseg2 = ((regval & MCAN_REVA_BTP_TSEG2_MASK) >>
+                                  MCAN_REVA_BTP_TSEG2_SHIFT) + 1;
+                  brp          = ((regval & MCAN_REVA_BTP_BRP_MASK) >>
+                                  MCAN_REVA_BTP_BRP_SHIFT) + 1;
+                }
+              else
+                {
+                  /* Revision B */
+
+                  regval       = mcan_getreg(priv, SAM_MCAN_NBTP_OFFSET);
+                  bt->bt_sjw   = ((regval & MCAN_NBTP_NSJW_MASK) >>
+                                  MCAN_NBTP_NSJW_SHIFT) + 1;
+                  bt->bt_tseg1 = ((regval & MCAN_NBTP_NTSEG1_MASK) >>
+                                  MCAN_NBTP_NTSEG1_SHIFT) + 1;
+                  bt->bt_tseg2 = ((regval & MCAN_NBTP_NTSEG2_MASK) >>
+                                  MCAN_NBTP_NTSEG2_SHIFT) + 1;
+                  brp          = ((regval & MCAN_NBTP_NBRP_MASK) >>
+                                  MCAN_NBTP_NBRP_SHIFT) + 1;
+                }
             }
 
           bt->bt_baud  = SAMV7_MCANCLK_FREQUENCY / brp /
@@ -2733,17 +2770,41 @@ static int mcan_ioctl(struct can_dev_s *dev, int cmd, unsigned long arg)
           /* Save the value of the new bit timing register */
 
           flags = enter_critical_section();
-          if (priv->rev == 0)
+#ifdef CONFIG_CAN_FD
+          if (bt->type == CAN_BITTIMING_DATA)
             {
-              priv->btp = MCAN_REVA_BTP_BRP(brp) |
-                          MCAN_REVA_BTP_TSEG1(tseg1) |
-                          MCAN_REVA_BTP_TSEG2(tseg2) |
-                          MCAN_REVA_BTP_SJW(sjw);
+              if (priv->rev == 0)
+                {
+                  priv->fbtp = MCAN_REVA_FBTP_FBRP(brp) |
+                               MCAN_REVA_FBTP_FTSEG1(tseg1) |
+                               MCAN_REVA_FBTP_FTSEG2(tseg2) |
+                               MCAN_REVA_FBTP_FSJW(sjw);
+                }
+              else
+                {
+                  priv->fbtp = MCAN_DBTP_DBRP(brp) |
+                               MCAN_DBTP_DTSEG1(tseg1) |
+                               MCAN_DBTP_DTSEG2(tseg2) |
+                               MCAN_DBTP_DSJW(sjw);
+                }
             }
           else
+#endif
             {
-              priv->btp = MCAN_NBTP_NBRP(brp) | MCAN_NBTP_NTSEG1(tseg1) |
-                          MCAN_NBTP_NTSEG2(tseg2) | MCAN_NBTP_NSJW(sjw);
+              if (priv->rev == 0)
+                {
+                  priv->btp = MCAN_REVA_BTP_BRP(brp) |
+                              MCAN_REVA_BTP_TSEG1(tseg1) |
+                              MCAN_REVA_BTP_TSEG2(tseg2) |
+                              MCAN_REVA_BTP_SJW(sjw);
+                }
+              else
+                {
+                  priv->btp = MCAN_NBTP_NBRP(brp) |
+                              MCAN_NBTP_NTSEG1(tseg1) |
+                              MCAN_NBTP_NTSEG2(tseg2) |
+                              MCAN_NBTP_NSJW(sjw);
+                }
             }
 
           /* We need to reset to instantiate the new timing.  Save

--- a/drivers/can/can.c
+++ b/drivers/can/can.c
@@ -96,12 +96,6 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-/* CAN helpers */
-
-static uint8_t        can_dlc2bytes(uint8_t dlc);
-#if 0 /* Not used */
-static uint8_t        can_bytes2dlc(uint8_t nbytes);
-#endif
 #ifdef CONFIG_CAN_TXREADY
 static void           can_txready_work(FAR void *arg);
 #endif
@@ -143,124 +137,6 @@ static const struct file_operations g_canops =
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
-
-/****************************************************************************
- * Name: can_dlc2bytes
- *
- * Description:
- *   In the CAN FD format, the coding of the DLC differs from the standard
- *   CAN format. The DLC codes 0 to 8 have the same coding as in standard
- *   CAN.  But the codes 9 to 15 all imply a data field of 8 bytes with
- *   standard CAN.  In CAN FD mode, the values 9 to 15 are encoded to values
- *   in the range 12 to 64.
- *
- * Input Parameters:
- *   dlc    - the DLC value to convert to a byte count
- *
- * Returned Value:
- *   The number of bytes corresponding to the DLC value.
- *
- ****************************************************************************/
-
-static uint8_t can_dlc2bytes(uint8_t dlc)
-{
-  if (dlc > 8)
-    {
-#ifdef CONFIG_CAN_FD
-      switch (dlc)
-        {
-          case 9:
-            return 12;
-
-          case 10:
-            return 16;
-
-          case 11:
-            return 20;
-
-          case 12:
-            return 24;
-
-          case 13:
-            return 32;
-
-          case 14:
-            return 48;
-
-          default:
-          case 15:
-            return 64;
-        }
-#else
-      return 8;
-#endif
-    }
-
-  return dlc;
-}
-
-/****************************************************************************
- * Name: can_bytes2dlc
- *
- * Description:
- *   In the CAN FD format, the coding of the DLC differs from the standard
- *   CAN format. The DLC codes 0 to 8 have the same coding as in standard
- *   CAN.  But the codes 9 to 15 all imply a data field of 8 bytes with
- *   standard CAN.  In CAN FD mode, the values 9 to 15 are encoded to values
- *   in the range 12 to 64.
- *
- * Input Parameters:
- *   nbytes - the byte count to convert to a DLC value
- *
- * Returned Value:
- *   The encoded DLC value corresponding to at least that number of bytes.
- *
- ****************************************************************************/
-
-#if 0 /* Not used */
-static uint8_t can_bytes2dlc(FAR struct sam_can_s *priv, uint8_t nbytes)
-{
-  if (nbytes <= 8)
-    {
-      return nbytes;
-    }
-#ifdef CONFIG_CAN_FD
-  else if (nbytes <= 12)
-    {
-      return 9;
-    }
-  else if (nbytes <= 16)
-    {
-      return 10;
-    }
-  else if (nbytes <= 20)
-    {
-      return 11;
-    }
-  else if (nbytes <= 24)
-    {
-      return 12;
-    }
-  else if (nbytes <= 32)
-    {
-      return 13;
-    }
-  else if (nbytes <= 48)
-    {
-      return 14;
-    }
-  else /* if (nbytes <= 64) */
-    {
-      return 15;
-    }
-#else
-  else
-    {
-      return 8;
-    }
-#endif
-}
-#endif
 
 /****************************************************************************
  * Name: can_txready_work
@@ -1694,4 +1570,121 @@ int can_txready(FAR struct can_dev_s *dev)
   return ret;
 }
 #endif /* CONFIG_CAN_TXREADY */
+
+/****************************************************************************
+ * Name: can_bytes2dlc
+ *
+ * Description:
+ *   In the CAN FD format, the coding of the DLC differs from the standard
+ *   CAN format. The DLC codes 0 to 8 have the same coding as in standard
+ *   CAN.  But the codes 9 to 15 all imply a data field of 8 bytes with
+ *   standard CAN.  In CAN FD mode, the values 9 to 15 are encoded to values
+ *   in the range 12 to 64.
+ *
+ * Input Parameters:
+ *   nbytes - the byte count to convert to a DLC value
+ *
+ * Returned Value:
+ *   The encoded DLC value corresponding to at least that number of bytes.
+ *
+ ****************************************************************************/
+
+uint8_t can_bytes2dlc(uint8_t nbytes)
+{
+  if (nbytes <= 8)
+    {
+      return nbytes;
+    }
+#ifdef CONFIG_CAN_FD
+  else if (nbytes <= 12)
+    {
+      return 9;
+    }
+  else if (nbytes <= 16)
+    {
+      return 10;
+    }
+  else if (nbytes <= 20)
+    {
+      return 11;
+    }
+  else if (nbytes <= 24)
+    {
+      return 12;
+    }
+  else if (nbytes <= 32)
+    {
+      return 13;
+    }
+  else if (nbytes <= 48)
+    {
+      return 14;
+    }
+  else /* if (nbytes <= 64) */
+    {
+      return 15;
+    }
+#else
+  else
+    {
+      return 8;
+    }
+#endif
+}
+
+/****************************************************************************
+ * Name: can_dlc2bytes
+ *
+ * Description:
+ *   In the CAN FD format, the coding of the DLC differs from the standard
+ *   CAN format. The DLC codes 0 to 8 have the same coding as in standard
+ *   CAN.  But the codes 9 to 15 all imply a data field of 8 bytes with
+ *   standard CAN.  In CAN FD mode, the values 9 to 15 are encoded to values
+ *   in the range 12 to 64.
+ *
+ * Input Parameters:
+ *   dlc    - the DLC value to convert to a byte count
+ *
+ * Returned Value:
+ *   The number of bytes corresponding to the DLC value.
+ *
+ ****************************************************************************/
+
+uint8_t can_dlc2bytes(uint8_t dlc)
+{
+  if (dlc > 8)
+    {
+#ifdef CONFIG_CAN_FD
+      switch (dlc)
+        {
+          case 9:
+            return 12;
+
+          case 10:
+            return 16;
+
+          case 11:
+            return 20;
+
+          case 12:
+            return 24;
+
+          case 13:
+            return 32;
+
+          case 14:
+            return 48;
+
+          default:
+          case 15:
+            return 64;
+        }
+#else
+      return 8;
+#endif
+    }
+
+  return dlc;
+}
+
 #endif /* CONFIG_CAN */

--- a/include/nuttx/can/can.h
+++ b/include/nuttx/can/can.h
@@ -438,6 +438,11 @@
 #define CAN_FILTER_DUAL           1  /* Dual address match */
 #define CAN_FILTER_RANGE          2  /* Match a range of addresses */
 
+/* CAN bit timing support ***************************************************/
+
+#define CAN_BITTIMING_NOMINAL     0  /* Specifies nominal bittiming */
+#define CAN_BITTIMING_DATA        1  /* Specifies data bittiming */
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/
@@ -713,6 +718,13 @@ struct canioc_rtr_s
 
 struct canioc_bittiming_s
 {
+#ifdef CONFIG_CAN_FD
+  uint8_t               type;            /* Nominal/Data bit timing. This is
+                                          * used to specify which bit timing
+                                          * should be set/obtained. Applies
+                                          * only if CAN FD is configured.
+                                          */
+#endif
   uint32_t              bt_baud;         /* Bit rate = 1 / bit time */
   uint8_t               bt_tseg1;        /* TSEG1 in time quanta */
   uint8_t               bt_tseg2;        /* TSEG2 in time quanta */

--- a/include/nuttx/can/can.h
+++ b/include/nuttx/can/can.h
@@ -936,6 +936,46 @@ int can_txdone(FAR struct can_dev_s *dev);
 int can_txready(FAR struct can_dev_s *dev);
 #endif
 
+/****************************************************************************
+ * Name: can_bytes2dlc
+ *
+ * Description:
+ *   In the CAN FD format, the coding of the DLC differs from the standard
+ *   CAN format. The DLC codes 0 to 8 have the same coding as in standard
+ *   CAN.  But the codes 9 to 15 all imply a data field of 8 bytes with
+ *   standard CAN.  In CAN FD mode, the values 9 to 15 are encoded to values
+ *   in the range 12 to 64.
+ *
+ * Input Parameters:
+ *   nbytes - the byte count to convert to a DLC value
+ *
+ * Returned Value:
+ *   The encoded DLC value corresponding to at least that number of bytes.
+ *
+ ****************************************************************************/
+
+uint8_t can_bytes2dlc(uint8_t nbytes);
+
+/****************************************************************************
+ * Name: can_dlc2bytes
+ *
+ * Description:
+ *   In the CAN FD format, the coding of the DLC differs from the standard
+ *   CAN format. The DLC codes 0 to 8 have the same coding as in standard
+ *   CAN.  But the codes 9 to 15 all imply a data field of 8 bytes with
+ *   standard CAN.  In CAN FD mode, the values 9 to 15 are encoded to values
+ *   in the range 12 to 64.
+ *
+ * Input Parameters:
+ *   dlc    - the DLC value to convert to a byte count
+ *
+ * Returned Value:
+ *   The number of bytes corresponding to the DLC value.
+ *
+ ****************************************************************************/
+
+uint8_t can_dlc2bytes(uint8_t dlc);
+
 #undef EXTERN
 #if defined(__cplusplus)
 }


### PR DESCRIPTION
## Summary

### can: enhance API to allow better CAN FD handling

This commit moves `can_bytes2dlc` and `can_dlc2bytes` from kernel internal functions to API. These functions are necessary to convert bytes to dlc for CAN FD frames and has to be accessible from the application since `can_hdr_s` does not store message length in bytes but directly in dlc.

### can: enhance bit timing ioctl to set both nominal and data bit timing 

This adds field type to `canioc_bittiming_s` structure that allows to set/obtain bit timing for both CAN CC and CAN FD. `CANIOC_GET_BITTIMING` is now bidirectional: user specifies type field and gets other fields from the controller.

The commit also updates current CAN FD capable controllers using the ioctl. The type is not checked for classical CAN only controllers and nominal bit timing is returned regardless of type value. 

### samv7: fix CAN FD configuration

Larger RX/TX buffers might be required for both FD and FD_BSW modes. Default bit timing values are also changed since the original ones did not provide correct results for default SAMv7 board clock selection (150 MHz clock frequency). The current values provide correct bit timing with sample point as close to 87.5 %.

## Testing

Tested on SAMv7 custom board against SocketCAN Linux stack and RTEMS CAN FD stack.  CAN FD frames both with and without bit rate switch now works on SAMv7.

