### PR TITLE
mm_ubsan: add dummy to bypass runtime actions

### DIFF
--- a/mm/Kconfig
+++ b/mm/Kconfig
@@ -338,6 +338,13 @@ config MM_UBSAN_TRAP_ON_ERROR
 		The undefined instruction trap should cause your program to crash,
 		save the code space significantly.
 
+config MM_UBSAN_DUMMY
+	bool "Bypass Undefined Behaviour Sanitizer Runtime Actions"
+	default n
+	depends on MM_UBSAN
+	---help---
+		Keep UBSAN compile time but disable runtime actions.
+
 config MM_FILL_ALLOCATIONS
 	bool "Fill allocations with debug value"
 	default n

--- a/mm/ubsan/ubsan.c
+++ b/mm/ubsan/ubsan.c
@@ -29,6 +29,8 @@
 
 #include "ubsan.h"
 
+#ifndef CONFIG_MM_UBSAN_DUMMY
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -388,3 +390,79 @@ void __ubsan_handle_dynamic_type_cache_miss(FAR void *data,
 {
   ubsan_prologue_epilogue(data, "dynamic-type-cache-miss");
 }
+
+#else
+void __ubsan_handle_out_of_bounds(FAR void *data, FAR void *index)
+{
+}
+
+void __ubsan_handle_shift_out_of_bounds(FAR void *data,
+                                        FAR void *lhs, FAR void *rhs)
+{
+}
+
+void __ubsan_handle_divrem_overflow(FAR void *data,
+                                    FAR void *lhs, FAR void *rhs)
+{
+}
+
+void __ubsan_handle_alignment_assumption(FAR void *data, uintptr_t ptr,
+                                         uintptr_t align, uintptr_t offset)
+{
+}
+
+void __ubsan_handle_type_mismatch(FAR struct type_mismatch_data *data,
+                                  FAR void *ptr)
+{
+}
+
+void __ubsan_handle_type_mismatch_v1(FAR void *_data, FAR void *ptr)
+{
+}
+
+void __ubsan_handle_builtin_unreachable(FAR void *data)
+{
+  PANIC();
+}
+
+void __ubsan_handle_nonnull_arg(FAR void *data)
+{
+}
+
+void __ubsan_handle_add_overflow(FAR void *data,
+                                 FAR void *lhs, FAR void *rhs)
+{
+}
+
+void __ubsan_handle_sub_overflow(FAR void *data,
+                                 FAR void *lhs, FAR void *rhs)
+{
+}
+
+void __ubsan_handle_mul_overflow(FAR void *data,
+                                 FAR void *lhs, FAR void *rhs)
+{
+}
+
+void __ubsan_handle_load_invalid_value(FAR void *data, FAR void *ptr)
+{
+}
+
+void __ubsan_handle_negate_overflow(FAR void *data, FAR void *ptr)
+{
+}
+
+void __ubsan_handle_pointer_overflow(FAR void *data,
+                                     FAR void *ptr, FAR void *result)
+{
+}
+
+void __ubsan_handle_invalid_builtin(FAR void *data)
+{
+}
+
+void __ubsan_handle_dynamic_type_cache_miss(FAR void *data,
+                                            FAR void *ptr, FAR void *hash)
+{
+}
+#endif


### PR DESCRIPTION
## Summary
The dummy string in sim_ubsan did not work as expected, redirect ubsan to local .c files works pretty good in my case, so commit a code to make it possible in Kconfig.
need a PANIC in __ubsan_handle_builtin_unreachable to make sure no_return;

## Impact
No impact for default config.
after merge, possible redirect to local ubsan and disable all malloc/print etc, actions.

## Testing
CI-test, local ubuntu sim environment.
