### PR TITLE
arch/armv8-r: fix typos in config

### DIFF
--- a/arch/arm/include/armv8-r/irq.h
+++ b/arch/arm/include/armv8-r/irq.h
@@ -357,7 +357,7 @@ static inline irqstate_t up_irq_save(void)
     (
       "\tmrs    %0, cpsr\n"
       "\tcpsid  i\n"
-#if defined(CONFIG_ARMV7R_DECODEFIQ)
+#if defined(CONFIG_ARMV8R_DECODEFIQ)
       "\tcpsid  f\n"
 #endif
       : "=r" (cpsr)
@@ -378,7 +378,7 @@ static inline irqstate_t up_irq_enable(void)
     (
       "\tmrs    %0, cpsr\n"
       "\tcpsie  i\n"
-#if defined(CONFIG_ARMV7R_DECODEFIQ)
+#if defined(CONFIG_ARMV8R_DECODEFIQ)
       "\tcpsie  f\n"
 #endif
       : "=r" (cpsr)

--- a/arch/arm/src/armv8-r/Kconfig
+++ b/arch/arm/src/armv8-r/Kconfig
@@ -6,7 +6,7 @@
 comment "ARMv8-R Configuration Options"
 
 config ARMV8R_HAVE_GICv3
-	bool "ARMV7R_GICv3 support"
+	bool "ARMV8R_GICv3 support"
 	select ARCH_HAVE_IRQTRIGGER
 	default y
 	---help---
@@ -44,7 +44,7 @@ config ARMV8R_HAVE_DECODEFIQ
 config ARMV8R_DECODEFIQ
 	bool "FIQ Handler"
 	default n
-	depends on ARMV7R_HAVE_DECODEFIQ
+	depends on ARMV8R_HAVE_DECODEFIQ
 	---help---
 		Select this option if your platform supports the function
 		arm_decodefiq().

--- a/arch/arm/src/armv8-r/arm_arch_timer.h
+++ b/arch/arm/src/armv8-r/arm_arch_timer.h
@@ -18,8 +18,8 @@
  *
  ****************************************************************************/
 
-#ifndef __ARCH_ARM_SRC_ARMV7_R_ARM_ARCH_TIMER_H
-#define __ARCH_ARM_SRC_ARMV7_R_ARM_ARCH_TIMER_H
+#ifndef __ARCH_ARM_SRC_ARMV8_R_ARM_ARCH_TIMER_H
+#define __ARCH_ARM_SRC_ARMV8_R_ARM_ARCH_TIMER_H
 
 /****************************************************************************
  * Included Files
@@ -55,4 +55,4 @@
 void arm_arch_timer_secondary_init(void);
 #endif
 
-#endif /* __ARCH_ARM_SRC_ARMV7_R_ARM_ARCH_TIMER_H */
+#endif /* __ARCH_ARM_SRC_ARMV8_R_ARM_ARCH_TIMER_H */

--- a/arch/arm/src/armv8-r/arm_initialstate.c
+++ b/arch/arm/src/armv8-r/arm_initialstate.c
@@ -131,13 +131,13 @@ void up_initial_state(struct tcb_s *tcb)
   cpsr |= (PSR_I_BIT | PSR_F_BIT);
 
 #else /* CONFIG_SUPPRESS_INTERRUPTS */
-  /* Leave IRQs enabled (Also FIQs if CONFIG_ARMV7R_DECODEFIQ is selected) */
+  /* Leave IRQs enabled (Also FIQs if CONFIG_ARMV8R_DECODEFIQ is selected) */
 
 #ifndef CONFIG_ARMV8R_DECODEFIQ
 
   cpsr |= PSR_F_BIT;
 
-#endif /* !CONFIG_ARMV7R_DECODEFIQ */
+#endif /* !CONFIG_ARMV8R_DECODEFIQ */
 
 #ifdef CONFIG_ARM_THUMB
   cpsr |= PSR_T_BIT;

--- a/arch/arm/src/armv8-r/arm_vectors.S
+++ b/arch/arm/src/armv8-r/arm_vectors.S
@@ -755,7 +755,7 @@ g_intstacktop:
  *  Name: g_fiqstackalloc/g_fiqstacktop
  ****************************************************************************/
 
-#ifdef CONFIG_ARMV7R_DECODEFIQ
+#ifdef CONFIG_ARMV8R_DECODEFIQ
 	.globl	g_fiqstackalloc
 	.type	g_fiqstackalloc, object
 	.globl	g_fiqstacktop

--- a/arch/arm/src/armv8-r/cp15_cacheops.h
+++ b/arch/arm/src/armv8-r/cp15_cacheops.h
@@ -46,8 +46,8 @@
  *   ARM DDI 0406C.c (ID051414)
  */
 
-#ifndef __ARCH_ARM_SRC_ARMV7_R_CP15_CACHEOPS_H
-#define __ARCH_ARM_SRC_ARMV7_R_CP15_CACHEOPS_H
+#ifndef __ARCH_ARM_SRC_ARMV8_R_CP15_CACHEOPS_H
+#define __ARCH_ARM_SRC_ARMV8_R_CP15_CACHEOPS_H
 
 /****************************************************************************
  * Included Files
@@ -1135,4 +1135,4 @@ uint32_t cp15_cache_linesize(void);
 #endif
 #endif /* __ASSEMBLY__ */
 
-#endif /* __ARCH_ARM_SRC_ARMV7_R_CP15_CACHEOPS_H */
+#endif /* __ARCH_ARM_SRC_ARMV8_R_CP15_CACHEOPS_H */


### PR DESCRIPTION


## Summary

arch/armv8-r: fix typos in config

replace ARMV7R to ARMV8R



## Impact

N/A

## Testing

cortex-r52 