### PR TITLE
arch/armv8-r: new config to set SPIs Configuration to edge-triggered

### DIFF
--- a/arch/arm/src/armv8-r/Kconfig
+++ b/arch/arm/src/armv8-r/Kconfig
@@ -13,7 +13,7 @@ config ARMV8R_HAVE_GICv3
 		Selected by the configuration tool if the architecture supports the
 		Generic Interrupt Controller (GIC)
 
-if ARMV8R_HAVE_GICv2
+if ARMV8R_HAVE_GICv3
 
 config ARMV8R_GIC_EOIMODE
 	bool
@@ -22,7 +22,13 @@ config ARMV8R_GIC_EOIMODE
 		Enable GICC_CTLR.EOImode, this will separates the priority drop and interrupt
 		deactivation operations.
 
-endif # ARMV8R_GIC_EOIMODE
+config ARMV8R_GIC_SPI_EDGE
+	bool "Configure all SPIs(Shared Peripheral Interrupts) as edge-triggered by default"
+	default n
+	---help---
+		Configure all SPIs(Shared Peripheral Interrupts) as edge-triggered by default.
+
+endif # ARMV8R_HAVE_GICv3
 
 config ARMV8R_MEMINIT
 	bool

--- a/arch/arm/src/armv8-r/arm_gicv3.c
+++ b/arch/arm/src/armv8-r/arm_gicv3.c
@@ -528,7 +528,15 @@ static void gicv3_dist_init(void)
        intid += GIC_NUM_CFG_PER_REG)
     {
       idx = intid / GIC_NUM_CFG_PER_REG;
+#ifdef CONFIG_ARMV8R_GIC_SPI_EDGE
+      /* Configure all SPIs as edge-triggered by default */
+
+      putreg32(0xaaaaaaaa, ICFGR(base, idx));
+#else
+      /* Configure all SPIs as level-sensitive by default */
+
       putreg32(0, ICFGR(base, idx));
+#endif
     }
 
   /* TODO: Some arrch64 Cortex-A core maybe without security state


### PR DESCRIPTION

## Summary

arch/armv8-r: new config to set SPIs Configuration to edge-triggered

Configure all SPIs(Shared Peripheral Interrupts) as edge-triggered by default

Signed-off-by: chao an <anchao@lixiang.com>

## Impact

N/A

## Testing

Cortex-R52