### PR TITLE
arch/armv8-r: update g_running_tasks before context switch

### DIFF
--- a/arch/arm/src/armv8-r/arm_doirq.c
+++ b/arch/arm/src/armv8-r/arm_doirq.c
@@ -31,6 +31,7 @@
 
 #include <nuttx/board.h>
 #include <arch/board/board.h>
+#include <sched/sched.h>
 
 #include "arm_internal.h"
 #include "arm_gic.h"
@@ -64,6 +65,13 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
   if (regs != CURRENT_REGS)
     {
+      /* Record the new "running" task when context switch occurred.
+       * g_running_tasks[] is only used by assertion logic for reporting
+       * crashes.
+       */
+
+      g_running_tasks[this_cpu()] = this_task();
+
       restore_critical_section();
       regs = (uint32_t *)CURRENT_REGS;
     }


### PR DESCRIPTION
## Summary

arch/armv8-r: update g_running_tasks before context switch

fix invalid running_task() in assertion logic

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

Cortex-R52