### PR TITLE
cmake: strip file full path to save the code size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,7 @@ if(NOT EXISTS "${NUTTX_APPS_DIR}")
   message(FATAL_ERROR "Application directory ${NUTTX_APPS_DIR} is not found")
 endif()
 
+get_filename_component(NUTTX_APPS_DIR ${NUTTX_APPS_DIR} ABSOLUTE)
 get_filename_component(apps_dir ${NUTTX_APPS_DIR} NAME)
 set(NUTTX_APPS_BINDIR "${CMAKE_BINARY_DIR}/${apps_dir}")
 
@@ -511,6 +512,20 @@ endif()
 
 if(CONFIG_NDEBUG)
   add_compile_options(-DNDEBUG)
+endif()
+
+# Cmake build provide absolute paths to compile files. If __FILE__ macros are
+# used in the source code(ASSERT), the binary will contain many invalid paths.
+# This saves some memory, stops exposing build systems locations in binaries,
+# make failure logs more deterministic and most importantly makes builds more
+# failure logs more deterministic and most importantly makes builds more
+# deterministic. Debuggers usually have a path mapping feature to ensure the
+# files are still found.
+if(CONFIG_OUTPUT_STRIP_PATHS)
+  add_compile_options(-fmacro-prefix-map=${NUTTX_DIR}=)
+  add_compile_options(-fmacro-prefix-map=${NUTTX_APPS_DIR}=)
+  add_compile_options(-fmacro-prefix-map=${NUTTX_BOARD_ABS_DIR}=)
+  add_compile_options(-fmacro-prefix-map=${NUTTX_CHIP_ABS_DIR}=)
 endif()
 
 add_definitions(-D__NuttX__)

--- a/Kconfig
+++ b/Kconfig
@@ -447,6 +447,22 @@ config DFU_PID
 	hex "PID to use for DFU image"
 
 endif # DFU_BINARY
+
+config OUTPUT_STRIP_PATHS
+	bool "Strip absolute paths from binaries"
+	default y
+	depends on ARCH_TOOLCHAIN_GNU
+	---help---
+	  Cmake build provide absolute paths to compile files. If __FILE__
+	  macros are used in the source code(ASSERT), the binary will contain
+	  many invalid paths.
+	  This saves some memory, stops exposing build systems locations in binaries,
+	  make failure logs more deterministic and most importantly makes builds more
+	  failure logs more deterministic and most importantly makes builds more
+	  deterministic.
+	  Debuggers usually have a path mapping feature to ensure the files are
+	  still found.
+
 endmenu # Binary Output Formats
 
 menu "Customize Header Files"


### PR DESCRIPTION
## Summary

cmake: strip file full path to save the code size

Cmake build provide absolute paths to compile files. If `__FILE__`
macros are used in the source code(ASSERT), the binary will be occupied
by many invalid paths.

If the compiler support preprocessing files and expand the "`__FILE__`"
and "`__BASE_FILE__`" macros as if the files resided in directory new instead.
This saves some memory, stops leaking user locations in binaries, makes
failure logs more deterministic and most importantly makes builds more
deterministic.  Debuggers usually have a path mapping feature to ensure
the files are still found.

Test config sabre-6quad/citest:

Before:
```
$ size build/nuttx
   text    data     bss     dec     hex filename
 279309     908   13652  293869   47bed build/nuttx

[ 2] nsh_main: _assert: Assertion failed panic: at file: /home/archer/code2/nuttx/l2/harley/nuttx/arch/arm/src/armv8-r/arm_dataabort.c:66 task: nsh_main process: nsh_main 0x10007add
```

After:
```
$ size build/nuttx
   text    data     bss     dec     hex filename
 269313     908   13652  283873   454e1 build/nuttx

[ 2] nsh_main: _assert: Assertion failed panic: at file: /arch/arm/src/armv8-r/arm_dataabort.c:66 task: nsh_main process: nsh_main 0x10007add
```

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

ci-check
