### PR TITLE
tools/ci: enable avr32dev1 build

### DIFF
--- a/arch/avr/src/avr32/avr_doirq.c
+++ b/arch/avr/src/avr32/avr_doirq.c
@@ -114,7 +114,7 @@ uint32_t *avr_doirq(int irq, uint32_t *regs)
    * switch occurred during interrupt processing.
    */
 
-  regs = g_current_regs;
+  regs = (uint32_t *)g_current_regs;
 
   /* Set g_current_regs to NULL to indicate that we are no longer in
    * an interrupt handler.

--- a/boards/avr/at32uc3/avr32dev1/src/avr32_bringup.c
+++ b/boards/avr/at32uc3/avr32dev1/src/avr32_bringup.c
@@ -51,7 +51,7 @@ int avr32_bringup(void)
 {
   int ret = OK;
 
-  #warning "Not Implemented"
+  /* #warning "Not Implemented" */
 
   return ret;
 }

--- a/tools/ci/testlist/other.dat
+++ b/tools/ci/testlist/other.dat
@@ -1,8 +1,6 @@
 # We do not have a toolchain for avr32 outside of Microchip login wall.
 # The work was never upstreamed to GCC.
 /avr
--avr32dev1:nsh
--avr32dev1:ostest
 
 # PINGUINOL toolchain doesn't provide macOS binaries
 # with the same name


### PR DESCRIPTION
## Summary

removed in the tools/ci/testlist/other.dat file the entries
 -avr32dev1:nsh
 -avr32dev1:ostest

avr32_bringup.c
Fix  Error: ./avr32_bringup.c:54:4: error: #warning "Not Implemented" #11709

comment out directive '#warning'
/* #warning "Not Implemented" */

avr_doirq.c

fix avr32/avr_doirq.c:117: error: assignment discards qualifiers from pointer target type
  regs = g_current_regs; -> regs = (uint32_t *)g_current_regs;

## Impact
There should be no impact.

## Testing

We tested on GitHub
