### PR TITLE
boards/esp32[c3|c6|h2|s2|s3]: Ignore etctmp in common board

### DIFF
--- a/boards/risc-v/esp32c3/common/.gitignore
+++ b/boards/risc-v/esp32c3/common/.gitignore
@@ -1,0 +1,2 @@
+etctmp
+etctmp.c

--- a/boards/risc-v/esp32c6/common/.gitignore
+++ b/boards/risc-v/esp32c6/common/.gitignore
@@ -1,0 +1,2 @@
+etctmp
+etctmp.c

--- a/boards/risc-v/esp32h2/common/.gitignore
+++ b/boards/risc-v/esp32h2/common/.gitignore
@@ -1,0 +1,2 @@
+etctmp
+etctmp.c

--- a/boards/xtensa/esp32/common/.gitignore
+++ b/boards/xtensa/esp32/common/.gitignore
@@ -1,0 +1,2 @@
+etctmp
+etctmp.c

--- a/boards/xtensa/esp32s2/common/.gitignore
+++ b/boards/xtensa/esp32s2/common/.gitignore
@@ -1,0 +1,2 @@
+etctmp
+etctmp.c

--- a/boards/xtensa/esp32s3/common/.gitignore
+++ b/boards/xtensa/esp32s3/common/.gitignore
@@ -1,0 +1,2 @@
+etctmp
+etctmp.c


### PR DESCRIPTION
## Summary
boards/esp32[c3|c6|h2|s2|s3]: Ignore etctmp in common board
## Impact
None
## Testing
CI