### PR TITLE
Reimplement readv to deal with short reads

### DIFF
--- a/libs/libc/uio/lib_readv.c
+++ b/libs/libc/uio/lib_readv.c
@@ -22,6 +22,8 @@
  * Included Files
  ****************************************************************************/
 
+#include <nuttx/cancelpt.h>
+
 #include <sys/types.h>
 #include <sys/uio.h>
 #include <stdlib.h>
@@ -98,6 +100,7 @@ ssize_t readv(int fildes, FAR const struct iovec *iov, int iovcnt)
       return 0;
     }
 
+  enter_cancellation_point();
   buffer = malloc(total_size);
   if (buffer == NULL)
     {
@@ -108,6 +111,7 @@ ssize_t readv(int fildes, FAR const struct iovec *iov, int iovcnt)
   if (nread == -1)
     {
       free(buffer);
+      leave_cancellation_point();
       return nread;
     }
 
@@ -128,5 +132,6 @@ ssize_t readv(int fildes, FAR const struct iovec *iov, int iovcnt)
     }
 
   free(buffer);
+  leave_cancellation_point();
   return nread;
 }

--- a/libs/libc/uio/lib_readv.c
+++ b/libs/libc/uio/lib_readv.c
@@ -24,6 +24,8 @@
 
 #include <sys/types.h>
 #include <sys/uio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 
 /****************************************************************************
@@ -68,56 +70,63 @@
 
 ssize_t readv(int fildes, FAR const struct iovec *iov, int iovcnt)
 {
-  ssize_t ntotal;
-  ssize_t nread;
-  size_t remaining;
   FAR uint8_t *buffer;
+  ssize_t nread;
+  size_t tocopy;
+  size_t total_size;
+  size_t offset;
   int i;
 
-  /* Process each entry in the struct iovec array */
-
-  for (i = 0, ntotal = 0; i < iovcnt; i++)
+  if (iovcnt == 0)
     {
-      /* Ignore zero-length reads */
-
-      if (iov[i].iov_len > 0)
-        {
-          buffer    = iov[i].iov_base;
-          remaining = iov[i].iov_len;
-
-          /* Read repeatedly as necessary to fill buffer */
-
-          do
-            {
-              /* NOTE:  read() is a cancellation point */
-
-              nread = read(fildes, buffer, remaining);
-
-              /* Check for a read error */
-
-              if (nread < 0)
-                {
-                  return nread;
-                }
-
-              /* Check for an end-of-file condition */
-
-              else if (nread == 0)
-                {
-                  return ntotal;
-                }
-
-              /* Update pointers and counts in order to handle partial
-               * buffer reads.
-               */
-
-              buffer    += nread;
-              remaining -= nread;
-              ntotal    += nread;
-            }
-          while (remaining > 0);
-        }
+      return 0;
     }
 
-  return ntotal;
+  if (iovcnt == 1)
+    {
+      return read(fildes, iov->iov_base, iov->iov_len);
+    }
+
+  total_size = 0;
+  for (i = 0; i < iovcnt; i++)
+    {
+      total_size += iov[i].iov_len;
+    }
+
+  if (total_size == 0)
+    {
+      return 0;
+    }
+
+  buffer = malloc(total_size);
+  if (buffer == NULL)
+    {
+      return -1;
+    }
+
+  nread = read(fildes, buffer, total_size);
+  if (nread == -1)
+    {
+      free(buffer);
+      return nread;
+    }
+
+  tocopy = nread;
+  offset = 0;
+  for (i = 0; i < iovcnt; i++)
+    {
+      FAR uint8_t *p = iov[i].iov_base;
+      size_t len = iov[i].iov_len;
+      if (tocopy <= len)
+        {
+          memcpy(p, buffer + offset, tocopy);
+          break;
+        }
+
+      memcpy(p, buffer + offset, len);
+      offset += len;
+    }
+
+  free(buffer);
+  return nread;
 }


### PR DESCRIPTION
## Summary
The original implementation seems to have an assumption that the file is a regular file.

This commit re-implements it so that it can deal with tty, sockets, etc.

## Impact

## Testing

