### PR TITLE
samv7: fix compile warning in PWM driver

### DIFF
--- a/arch/arm/src/samv7/sam_serial.c
+++ b/arch/arm/src/samv7/sam_serial.c
@@ -2261,7 +2261,6 @@ static void sam_dma_txint(struct uart_dev_s *dev, bool enable)
 static void sam_dma_txavailable(struct uart_dev_s *dev)
 {
   struct sam_dev_s *priv = (struct sam_dev_s *)dev->priv;
-  int rv;
 
   /* Only send when the DMA is idle */
 


### PR DESCRIPTION
## Summary
The following warning is fixed:

```
chip/sam_pwm.c:961:12: warning: unused variable 'regval' [-Wunused-variable]
  961 |   uint32_t regval;
```

