### PR TITLE
net/pkt: correct PF_PACKET family sending errors

### DIFF
--- a/net/devif/devif.h
+++ b/net/devif/devif.h
@@ -465,7 +465,7 @@ uint16_t devif_dev_event(FAR struct net_driver_s *dev, uint16_t flags);
  ****************************************************************************/
 
 int devif_send(FAR struct net_driver_s *dev, FAR const void *buf,
-               int len, unsigned int offset);
+               int len, int offset);
 
 /****************************************************************************
  * Name: devif_iob_send

--- a/net/devif/devif_send.c
+++ b/net/devif/devif_send.c
@@ -67,7 +67,7 @@
  ****************************************************************************/
 
 int devif_send(FAR struct net_driver_s *dev, FAR const void *buf,
-               int len, unsigned int offset)
+               int len, int offset)
 {
   int ret;
 
@@ -102,7 +102,7 @@ int devif_send(FAR struct net_driver_s *dev, FAR const void *buf,
 
   /* Prepare device buffer before poll callback */
 
-  iob_update_pktlen(dev->d_iob, offset, false);
+  iob_update_pktlen(dev->d_iob, offset < 0 ? 0 : offset, false);
 
   ret = iob_trycopyin(dev->d_iob, buf, len, offset, false);
   if (ret != len)

--- a/net/pkt/pkt_sendmsg.c
+++ b/net/pkt/pkt_sendmsg.c
@@ -106,13 +106,14 @@ static uint16_t psock_send_eventhandler(FAR struct net_driver_s *dev,
           /* Copy the packet data into the device packet buffer and send it */
 
           int ret = devif_send(dev, pstate->snd_buffer,
-                               pstate->snd_buflen, 0);
+                               pstate->snd_buflen, -NET_LL_HDRLEN(dev));
           if (ret <= 0)
             {
               pstate->snd_sent = ret;
               goto end_wait;
             }
 
+          dev->d_len       = dev->d_sndlen -= NET_LL_HDRLEN(dev);
           pstate->snd_sent = pstate->snd_buflen;
 
           /* Make sure no ARP request overwrites this ARP request.  This


### PR DESCRIPTION
## Summary
Enable the pkt_sendmsg interface to send packets containing Layer 2 headers.
## Impact

## Testing
qemu x64
