### PR TITLE
net/netfilter: fix windows compile error

### DIFF
--- a/net/netfilter/ip6t_sockopt.c
+++ b/net/netfilter/ip6t_sockopt.c
@@ -80,6 +80,8 @@ static struct ip6t_table_s g_tables[] =
 {
 #ifdef CONFIG_NET_IPFILTER
   {NULL, ip6t_filter_init, ip6t_filter_apply},
+#else
+  {NULL, NULL, NULL}
 #endif
 };
 


### PR DESCRIPTION
## Summary
Resolve compilation errors encountered during compilation in windows platform.

## Impact

## Testing
sim:local
