### PR TITLE
ioctl.h: add SIOCATMARK definition to resolve compilation errors

### DIFF
--- a/include/nuttx/net/ioctl.h
+++ b/include/nuttx/net/ioctl.h
@@ -140,6 +140,11 @@
 
 #define SIOCETHTOOL        _SIOC(0x003D)  /* Ethtool interface */
 
+/* TCP socket control *******************************************************/
+
+#define SIOCATMARK         _SIOC(0x003E)  /* Determine whether socket is at
+                                           * out-of-band mark */
+
 /****************************************************************************
  * Public Type Definitions
  ****************************************************************************/


### PR DESCRIPTION
## Summary
This definition was added in order to solve some compilation problems encountered when porting third-party libraries

## Impact

## Testing
qemu local:x64
