### PR TITLE
sched.h: add SCHED_BATCH and SCHED_IDLE definition

### DIFF
--- a/include/sched.h
+++ b/include/sched.h
@@ -46,6 +46,8 @@
 #define SCHED_FIFO                1  /* FIFO priority scheduling policy */
 #define SCHED_RR                  2  /* Round robin scheduling policy */
 #define SCHED_SPORADIC            3  /* Sporadic scheduling policy */
+#define SCHED_BATCH               4  /* Batch scheduling policy */
+#define SCHED_IDLE                5  /* Idle scheduling policy */
 
 /* Maximum number of SCHED_SPORADIC replenishments */
 


### PR DESCRIPTION
## Summary
Resolve undefined compile-time issues encountered when porting third-party libraries.

## Impact

## Testing
qemu local:x64
