### PR TITLE
sysinfo.h: add get_nprocs_conf/get_nprocs definition

### DIFF
--- a/include/sys/sysinfo.h
+++ b/include/sys/sysinfo.h
@@ -33,6 +33,14 @@
 
 #define SI_LOAD_SHIFT 16
 
+#ifdef CONFIG_SMP_NCPUS
+#define get_nprocs()      CONFIG_SMP_NCPUS
+#define get_nprocs_conf() CONFIG_SMP_NCPUS
+#else
+#define get_nprocs()      1
+#define get_nprocs_conf() 1
+#endif
+
 /****************************************************************************
  * Type Definitions
  ****************************************************************************/


### PR DESCRIPTION
## Summary
This definition was added in order to solve some compilation problems encountered when porting third-party libraries

## Impact

## Testing
qemu local:x64
