### PR TITLE
libc/unistd: added an implementation of the lib_flock function

### DIFF
--- a/include/fcntl.h
+++ b/include/fcntl.h
@@ -109,6 +109,13 @@
 #define F_WRLCK     1  /* Take out a write lease */
 #define F_UNLCK     2  /* Remove a lease */
 
+/* Operations for bsd flock(), also used by the kernel implementation */
+
+#define LOCK_SH     1  /* Shared lock */
+#define LOCK_EX     2  /* Exclusive lock */
+#define LOCK_NB     4  /* Or'd with one of the above to prevent blocking */
+#define LOCK_UN     8  /* Remove lock */
+
 /* close-on-exec flag for F_GETFD and F_SETFD */
 
 #define FD_CLOEXEC  1

--- a/include/sys/file.h
+++ b/include/sys/file.h
@@ -28,4 +28,23 @@
 #include <unistd.h>
 #include <fcntl.h>
 
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+int flock(int fd, int cmd);
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __INCLUDE_SYS_FILE_H */

--- a/libs/libc/unistd/CMakeLists.txt
+++ b/libs/libc/unistd/CMakeLists.txt
@@ -62,6 +62,7 @@ set(SRCS
     lib_linkat.c
     lib_readlinkat.c
     lib_symlinkat.c
+    lib_flock.c
     lib_unlinkat.c)
 
 if(NOT CONFIG_SCHED_USER_IDENTITY)

--- a/libs/libc/unistd/Make.defs
+++ b/libs/libc/unistd/Make.defs
@@ -30,7 +30,7 @@ CSRCS += lib_setrlimit.c lib_getrlimit.c lib_setpriority.c lib_getpriority.c
 CSRCS += lib_futimes.c lib_lutimes.c lib_gethostname.c lib_sethostname.c
 CSRCS += lib_fchownat.c lib_linkat.c lib_readlinkat.c lib_symlinkat.c
 CSRCS += lib_unlinkat.c lib_usleep.c lib_getpgrp.c lib_getpgid.c
-CSRCS += lib_lockf.c
+CSRCS += lib_lockf.c lib_flock.c
 
 ifneq ($(CONFIG_SCHED_USER_IDENTITY),y)
 CSRCS += lib_setuid.c lib_setgid.c lib_getuid.c lib_getgid.c

--- a/libs/libc/unistd/lib_flock.c
+++ b/libs/libc/unistd/lib_flock.c
@@ -1,0 +1,95 @@
+/****************************************************************************
+ * libs/libc/unistd/lib_flock.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: flock
+ *
+ * Description:
+ *   flock() is a function that allows a process to apply or remove an
+ *   advisory lock on an open file. The lock can be either a shared (read)
+ *   lock or an exclusive (write) lock. This lock is advisory, meaning that
+ *   it is not enforced by the system and it is up to cooperating processes
+ *   to honor the lock.
+ *
+ * Input Parameters:
+ *   fd  - File descriptor of the open file.
+ *   cmd - Specifies the type of lock operation to be performed.
+ *   It can be one of the following:
+ *     LOCK_SH: Request a shared (read) lock. If the lock is not available.
+ *     LOCK_EX: Request an exclusive (write) lock. If the lock is not
+ *              available.
+ *     LOCK_UN: Unlock an existing lock.
+ *     LOCK_NB: Do not block when locking.
+ *
+ * Returned Value:
+ *   The returned value of flock() depends on the success or failure of the
+ *   operation. On success, the return value is 0. On failure, the return
+ *   value is -1, and the errno variable is set to indicate the specific
+ *   error.
+ *
+ ****************************************************************************/
+
+int flock(int fd, int cmd)
+{
+  struct flock lock;
+
+  lock.l_whence = SEEK_SET;
+  lock.l_start = 0;
+  lock.l_len = 0;
+
+  if ((cmd & LOCK_SH) != 0)
+    {
+      lock.l_type = F_RDLCK;
+    }
+  else if ((cmd & LOCK_EX) != 0)
+    {
+      lock.l_type = F_WRLCK;
+    }
+  else if ((cmd & LOCK_UN) != 0)
+    {
+      lock.l_type = F_UNLCK;
+    }
+  else
+    {
+      set_errno(EINVAL);
+      return ERROR;
+    }
+
+  if ((cmd & LOCK_NB) != 0)
+    {
+      return fcntl(fd, F_SETLK, &lock);
+    }
+  else
+    {
+      return fcntl(fd, F_SETLKW, &lock);
+    }
+}


### PR DESCRIPTION
## Summary
To solve some compilation issues encountered during the porting of third-party libraries, this function has been added.

## Impact

## Testing
qemu local:x64
