### PR TITLE
riscv/k230: fix apps ROMFS cmake

### DIFF
--- a/boards/risc-v/k230/canmv230/src/CMakeLists.txt
+++ b/boards/risc-v/k230/canmv230/src/CMakeLists.txt
@@ -21,8 +21,8 @@
 set(SRCS canmv_init.c)
 
 if(CONFIG_BUILD_KERNEL)
-  if(EXISTS romfs_boot.c)
-    list(APPEND SRCS romfs_boot.c)
+  if(EXISTS ${CMAKE_BINARY_DIR}/romfs_boot.c)
+    list(APPEND SRCS ${CMAKE_BINARY_DIR}/romfs_boot.c)
   else()
     list(APPEND SRCS romfs_stub.c)
   endif()


### PR DESCRIPTION
## Summary

This fixes the issue that CMake fails to detect apps ROMFS source due to lack of path. Now with this the `romfs_boot.c` in build folder will be built as part of the NuttX kernel image.

## Impacts

CMake uses for KERNEL mode k230 configs

## Testing

- local checks with canmv230:nsbi
- CI checks

