### PR TITLE
arm64/arm64_boot.c: Fix exception caused by accesses to ICC_SRE_EL3 when GICv3 was not implemented

### DIFF
--- a/arch/arm64/src/common/arm64_boot.c
+++ b/arch/arm64/src/common/arm64_boot.c
@@ -89,6 +89,7 @@ void arm64_boot_el3_init(void)
           SCR_SMD_BIT);   /* Do not trap SMC */
   write_sysreg(reg, scr_el3);
 
+#if CONFIG_ARM64_GIC_VERSION > 2
   reg = read_sysreg(ICC_SRE_EL3);
   reg |= (ICC_SRE_ELX_DFB_BIT |   /* Disable FIQ bypass */
           ICC_SRE_ELX_DIB_BIT |   /* Disable IRQ bypass */
@@ -96,6 +97,7 @@ void arm64_boot_el3_init(void)
           ICC_SRE_EL3_EN_BIT);    /* Enables lower Exception level access to
                                    * ICC_SRE_EL1 */
   write_sysreg(reg, ICC_SRE_EL3);
+#endif
 
   ARM64_ISB();
 }


### PR DESCRIPTION
## Summary
[https://developer.arm.com/documentation/ddi0595/2021-09/AArch64-Registers/ICC-SRE-EL3--Interrupt-Controller-System-Register-Enable-register--EL3-?lang=en](url)
ICC_SRE_EL3 register is present only when GICv3 is implemented and EL3 is implemented. Otherwise, direct accesses to ICC_SRE_EL3 are UNDEFINED.
![Screenshot from 2024-07-14 21-13-28](https://github.com/user-attachments/assets/6122b13b-9414-4024-9a95-425c181a1cec)

Some chip's interrupt controller is GIC-400(GICv2), there will an exception when accesses ICC_SRE_EL3 register.
## Impact
Allwinner A64, Zynq MPSOC
## Testing
ZCU111 board
