### PR TITLE
Feature/mcuboot toolchain support

### DIFF
--- a/arch/risc-v/src/common/espressif/Bootloader.mk
+++ b/arch/risc-v/src/common/espressif/Bootloader.mk
@@ -34,6 +34,7 @@ BOOTLOADER_CONFIG    = $(BOOTLOADER_SRCDIR)/bootloader.conf
 MCUBOOT_SRCDIR     = $(BOOTLOADER_SRCDIR)/mcuboot
 MCUBOOT_ESPDIR     = $(MCUBOOT_SRCDIR)/boot/espressif
 MCUBOOT_URL        = https://github.com/mcu-tools/mcuboot
+MCUBOOT_TOOLCHAIN  = $(TOOLSDIR)/mcuboot_toolchain_espressif.cmake
 
 # Helpers for creating the configuration file
 
@@ -95,7 +96,8 @@ $(BOOTLOADER_BIN): chip/$(ESP_HAL_3RDPARTY_REPO) $(MCUBOOT_SRCDIR) $(BOOTLOADER_
 		-c $(CHIP_SERIES) \
 		-f $(BOOTLOADER_CONFIG) \
 		-p $(BOOTLOADER_SRCDIR) \
-		-e $(HALDIR)
+		-e $(HALDIR) \
+		-d $(MCUBOOT_TOOLCHAIN)
 	$(call COPYFILE, $(BOOTLOADER_OUTDIR)/mcuboot-$(CHIP_SERIES).bin, $(TOPDIR))
 
 bootloader: $(BOOTLOADER_CONFIG) $(BOOTLOADER_BIN)

--- a/arch/risc-v/src/esp32c3-legacy/Bootloader.mk
+++ b/arch/risc-v/src/esp32c3-legacy/Bootloader.mk
@@ -125,7 +125,7 @@ $(MCUBOOT_SRCDIR):
 
 $(BOOTLOADER_BIN): chip/$(ESP_HAL_3RDPARTY_REPO) $(MCUBOOT_SRCDIR) $(BOOTLOADER_CONFIG)
 	$(Q) echo "Building Bootloader"
-	$(Q) $(TOOLSDIR)/build_mcuboot.sh \
+	$(Q) $(TOOLSDIR)/build_mcuboot_esp32c3_legacy.sh \
 		-c esp32c3 \
 		-f $(BOOTLOADER_CONFIG) \
 		-p $(BOOTLOADER_DIR) \

--- a/arch/xtensa/src/esp32/Bootloader.mk
+++ b/arch/xtensa/src/esp32/Bootloader.mk
@@ -36,6 +36,7 @@ BOOTLOADER_CONFIG  = $(BOOTLOADER_DIR)/bootloader.conf
 MCUBOOT_SRCDIR     = $(BOOTLOADER_DIR)/mcuboot
 MCUBOOT_ESPDIR     = $(MCUBOOT_SRCDIR)/boot/espressif
 MCUBOOT_URL        = https://github.com/mcu-tools/mcuboot
+MCUBOOT_TOOLCHAIN  = $(TOPDIR)/tools/esp32/mcuboot_toolchain_esp32.cmake
 
 # Helpers for creating the configuration file
 
@@ -135,7 +136,8 @@ $(BOOTLOADER_BIN): chip/$(ESP_HAL_3RDPARTY_REPO) $(MCUBOOT_SRCDIR) $(BOOTLOADER_
 		-c esp32 \
 		-f $(BOOTLOADER_CONFIG) \
 		-p $(BOOTLOADER_DIR) \
-		-e $(HALDIR)
+		-e $(HALDIR) \
+		-d $(MCUBOOT_TOOLCHAIN)
 	$(call COPYFILE, $(BOOTLOADER_DIR)/$(BOOTLOADER_OUTDIR)/mcuboot-esp32.bin, $(TOPDIR))
 
 bootloader: $(BOOTLOADER_CONFIG) $(BOOTLOADER_BIN)

--- a/arch/xtensa/src/esp32s2/Bootloader.mk
+++ b/arch/xtensa/src/esp32s2/Bootloader.mk
@@ -36,6 +36,7 @@ BOOTLOADER_CONFIG  = $(BOOTLOADER_DIR)/bootloader.conf
 MCUBOOT_SRCDIR     = $(BOOTLOADER_DIR)/mcuboot
 MCUBOOT_ESPDIR     = $(MCUBOOT_SRCDIR)/boot/espressif
 MCUBOOT_URL        = https://github.com/mcu-tools/mcuboot
+MCUBOOT_TOOLCHAIN  = $(TOPDIR)/tools/esp32s2/mcuboot_toolchain_esp32s2.cmake
 
 $(BOOTLOADER_DIR):
 	$(Q) mkdir -p $(BOOTLOADER_DIR) &>/dev/null
@@ -128,7 +129,8 @@ $(BOOTLOADER_BIN): chip/$(ESP_HAL_3RDPARTY_REPO) $(MCUBOOT_SRCDIR) $(BOOTLOADER_
 		-c esp32s2 \
 		-f $(BOOTLOADER_CONFIG) \
 		-p $(BOOTLOADER_DIR) \
-		-e $(HALDIR)
+		-e $(HALDIR) \
+		-d $(MCUBOOT_TOOLCHAIN)
 	$(call COPYFILE, $(BOOTLOADER_DIR)/$(BOOTLOADER_OUTDIR)/mcuboot-esp32s2.bin, $(TOPDIR))
 
 bootloader: $(BOOTLOADER_CONFIG) $(BOOTLOADER_BIN)

--- a/arch/xtensa/src/esp32s3/Bootloader.mk
+++ b/arch/xtensa/src/esp32s3/Bootloader.mk
@@ -36,6 +36,7 @@ BOOTLOADER_CONFIG  = $(BOOTLOADER_DIR)/bootloader.conf
 MCUBOOT_SRCDIR     = $(BOOTLOADER_DIR)/mcuboot
 MCUBOOT_ESPDIR     = $(MCUBOOT_SRCDIR)/boot/espressif
 MCUBOOT_URL        = https://github.com/mcu-tools/mcuboot
+MCUBOOT_TOOLCHAIN  = $(TOPDIR)/tools/esp32s3/mcuboot_toolchain_esp32s3.cmake
 
 $(BOOTLOADER_DIR):
 	$(Q) mkdir -p $(BOOTLOADER_DIR) &>/dev/null
@@ -105,7 +106,8 @@ $(BOOTLOADER_BIN): chip/$(ESP_HAL_3RDPARTY_REPO) $(MCUBOOT_SRCDIR) $(BOOTLOADER_
 		-c esp32s3 \
 		-f $(BOOTLOADER_CONFIG) \
 		-p $(BOOTLOADER_DIR) \
-		-e $(HALDIR)
+		-e $(HALDIR) \
+		-d $(MCUBOOT_TOOLCHAIN)
 	$(call COPYFILE, $(BOOTLOADER_DIR)/$(BOOTLOADER_OUTDIR)/mcuboot-esp32s3.bin, $(TOPDIR))
 
 bootloader: $(BOOTLOADER_CONFIG) $(BOOTLOADER_BIN)

--- a/tools/esp32/mcuboot_toolchain_esp32.cmake
+++ b/tools/esp32/mcuboot_toolchain_esp32.cmake
@@ -1,0 +1,40 @@
+# ##############################################################################
+# tools/esp32/mcuboot_toolchain_esp32.cmake
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(CMAKE_SYSTEM_NAME Generic)
+
+set(CMAKE_C_COMPILER xtensa-esp32-elf-gcc)
+set(CMAKE_CXX_COMPILER xtensa-esp32-elf-g++)
+set(CMAKE_ASM_COMPILER xtensa-esp32-elf-gcc)
+set(_CMAKE_TOOLCHAIN_PREFIX xtensa-esp32-elf-)
+
+set(CMAKE_C_FLAGS
+    "${UNIQ_CMAKE_C_FLAGS}"
+    CACHE STRING "C Compiler Base Flags" FORCE)
+set(CMAKE_CXX_FLAGS
+    "${UNIQ_CMAKE_CXX_FLAGS}"
+    CACHE STRING "C++ Compiler Base Flags" FORCE)
+set(CMAKE_ASM_FLAGS
+    "${UNIQ_CMAKE_ASM_FLAGS}"
+    CACHE STRING "ASM Compiler Base Flags" FORCE)
+
+set(CMAKE_EXE_LINKER_FLAGS
+    "-Wl,--gc-sections"
+    CACHE STRING "Linker Base Flags")

--- a/tools/esp32s2/mcuboot_toolchain_esp32s2.cmake
+++ b/tools/esp32s2/mcuboot_toolchain_esp32s2.cmake
@@ -1,0 +1,36 @@
+# ##############################################################################
+# tools/esp32s2/mcuboot_toolchain_esp32s2.cmake
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(CMAKE_SYSTEM_NAME Generic)
+
+set(CMAKE_C_COMPILER xtensa-esp32s2-elf-gcc)
+set(CMAKE_CXX_COMPILER xtensa-esp32s2-elf-g++)
+set(CMAKE_ASM_COMPILER xtensa-esp32s2-elf-gcc)
+
+set(CMAKE_C_FLAGS
+    "-mlongcalls"
+    CACHE STRING "C Compiler Base Flags")
+set(CMAKE_CXX_FLAGS
+    "-mlongcalls"
+    CACHE STRING "C++ Compiler Base Flags")
+
+set(CMAKE_EXE_LINKER_FLAGS
+    "-Wl,--gc-sections"
+    CACHE STRING "Linker Base Flags")

--- a/tools/esp32s3/mcuboot_toolchain_esp32s3.cmake
+++ b/tools/esp32s3/mcuboot_toolchain_esp32s3.cmake
@@ -1,0 +1,40 @@
+# ##############################################################################
+# tools/esp32s3/mcuboot_toolchain_esp32s3.cmake
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(CMAKE_SYSTEM_NAME Generic)
+
+set(CMAKE_C_COMPILER xtensa-esp32s3-elf-gcc)
+set(CMAKE_CXX_COMPILER xtensa-esp32s3-elf-g++)
+set(CMAKE_ASM_COMPILER xtensa-esp32s3-elf-gcc)
+set(_CMAKE_TOOLCHAIN_PREFIX xtensa-esp32s3-elf-)
+
+set(CMAKE_C_FLAGS
+    "-mlongcalls"
+    CACHE STRING "C Compiler Base Flags" FORCE)
+set(CMAKE_CXX_FLAGS
+    "-mlongcalls"
+    CACHE STRING "C++ Compiler Base Flags" FORCE)
+set(CMAKE_ASM_FLAGS
+    "${UNIQ_CMAKE_ASM_FLAGS}"
+    CACHE STRING "ASM Compiler Base Flags" FORCE)
+
+set(CMAKE_EXE_LINKER_FLAGS
+    "-Wl,--gc-sections"
+    CACHE STRING "Linker Base Flags")

--- a/tools/espressif/build_mcuboot.sh
+++ b/tools/espressif/build_mcuboot.sh
@@ -11,6 +11,7 @@ usage() {
   echo "  -f <config> Path to file containing configuration options"
   echo "  -p <path> Path to execute the script"
   echo "  -e <hal> Path to HAL directory"
+  echo "  -d <path> Path to toolchain file"
   echo "  -h Show usage and terminate"
   echo ""
 }
@@ -22,7 +23,7 @@ build_mcuboot() {
   local build_dir=".build-${target}"
   local source_dir="boot/espressif"
   local output_dir="${exec_path}/out"
-  local toolchain_file="tools/toolchain-${target}.cmake"
+  local toolchain_file="tools/nuttx-toolchain-${target}.cmake"
   local mcuboot_config
   local mcuboot_flashsize
   local mcuboot_flashmode
@@ -47,6 +48,12 @@ build_mcuboot() {
   mcuboot_flashfreq=$(sed -n 's/^CONFIG_ESPTOOLPY_FLASHFREQ_\(.*\)M=1/\1m/p' "${mcuboot_config}")
   if [ -z "${mcuboot_flashfreq}" ]; then
     mcuboot_flashfreq="40m"
+  fi
+
+  if ! [ -z "${nuttx_toolchain}" ]; then
+    cp "${nuttx_toolchain}" "${mcuboot_dir}/${source_dir}/${toolchain_file}"
+  else
+    toolchain_file="tools/toolchain-${target}.cmake"
   fi
 
   pushd "${exec_path}" &>/dev/null
@@ -84,7 +91,7 @@ build_mcuboot() {
   popd &>/dev/null
 }
 
-while getopts ":hc:f:p:e:" arg; do
+while getopts ":hc:f:p:e:d:" arg; do
   case "${arg}" in
     c)
       chip=${OPTARG}
@@ -97,6 +104,9 @@ while getopts ":hc:f:p:e:" arg; do
       ;;
     e)
       esp_hal=${OPTARG}
+      ;;
+    d)
+      nuttx_toolchain=${OPTARG}
       ;;
     h)
       usage

--- a/tools/espressif/build_mcuboot_esp32c3_legacy.sh
+++ b/tools/espressif/build_mcuboot_esp32c3_legacy.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+
+SCRIPT_NAME=$(basename "${BASH_SOURCE[0]}")
+
+usage() {
+  echo ""
+  echo "USAGE: ${SCRIPT_NAME} [-h] -c <chip> -f <config> -p <path> -e <hal>"
+  echo ""
+  echo "Where:"
+  echo "  -c <chip> Target chip"
+  echo "  -f <config> Path to file containing configuration options"
+  echo "  -p <path> Path to execute the script"
+  echo "  -e <hal> Path to HAL directory"
+  echo "  -h Show usage and terminate"
+  echo ""
+}
+
+build_mcuboot() {
+  local target=${1}
+  local config=${2}
+  local mcuboot_dir="${exec_path}/mcuboot"
+  local build_dir=".build-${target}"
+  local source_dir="boot/espressif"
+  local output_dir="${exec_path}/out"
+  local toolchain_file="tools/toolchain-${target}.cmake"
+  local mcuboot_config
+  local mcuboot_flashsize
+  local mcuboot_flashmode
+  local mcuboot_flashfreq
+  local make_generator
+
+  mcuboot_config=$(realpath "${config:-${exec_path}/mcuboot.conf}")
+
+  # Try parsing Flash parameters from the mcuboot config file.
+  # If not found, let's assume some commonplace values.
+
+  mcuboot_flashsize=$(sed -n 's/^CONFIG_ESPTOOLPY_FLASHSIZE_\(.*\)MB=1/\1MB/p' "${mcuboot_config}")
+  if [ -z "${mcuboot_flashsize}" ]; then
+    mcuboot_flashsize="4MB"
+  fi
+
+  mcuboot_flashmode=$(sed -n 's/^CONFIG_ESPTOOLPY_FLASHMODE_\(.*\)=1/\L\1/p' "${mcuboot_config}")
+  if [ -z "${mcuboot_flashmode}" ]; then
+    mcuboot_flashmode="dio"
+  fi
+
+  mcuboot_flashfreq=$(sed -n 's/^CONFIG_ESPTOOLPY_FLASHFREQ_\(.*\)M=1/\1m/p' "${mcuboot_config}")
+  if [ -z "${mcuboot_flashfreq}" ]; then
+    mcuboot_flashfreq="40m"
+  fi
+
+  pushd "${exec_path}" &>/dev/null
+  mkdir -p "${output_dir}" &>/dev/null
+
+  # Build with Ninja if installed
+
+  if command -v ninja &>/dev/null; then
+    make_generator="-GNinja"
+  fi
+
+  # Build bootloader for selected target
+
+  cd "${mcuboot_dir}" &>/dev/null
+  cmake -DCMAKE_TOOLCHAIN_FILE="${toolchain_file}"     \
+        -DMCUBOOT_TARGET="${target}"                   \
+        -DMCUBOOT_CONFIG_FILE="${mcuboot_config}"      \
+        -DESP_HAL_PATH="${esp_hal}"                    \
+        -DCONFIG_ESP_FLASH_SIZE="${mcuboot_flashsize}" \
+        -DESP_FLASH_MODE="${mcuboot_flashmode}"        \
+        -DESP_FLASH_FREQ="${mcuboot_flashfreq}"        \
+        -B "${build_dir}"                              \
+        "${make_generator}"                            \
+        "${source_dir}"
+  cmake --build "${build_dir}"/
+
+  # Copy bootloader binary file to output directory
+
+  cp "${build_dir}"/mcuboot_"${target}".bin "${output_dir}"/mcuboot-"${target}".bin &>/dev/null
+
+  # Remove build directory
+
+  rm -rf "${build_dir}" &>/dev/null
+
+  popd &>/dev/null
+}
+
+while getopts ":hc:f:p:e:" arg; do
+  case "${arg}" in
+    c)
+      chip=${OPTARG}
+      ;;
+    f)
+      config=${OPTARG}
+      ;;
+    p)
+      exec_path=${OPTARG}
+      ;;
+    e)
+      esp_hal=${OPTARG}
+      ;;
+    h)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "${chip}" ]; then
+  printf "ERROR: Missing target chip.\n"
+  usage
+  exit 1
+fi
+
+if ! [ -d "${esp_hal}" ]; then
+  printf "ERROR: Invalid HAL path.\n"
+  usage
+  exit 1
+fi
+
+if [ ! -d "${exec_path}" ]; then
+  printf "ERROR: Invalid exec path.\n"
+  usage
+  exit 1
+fi
+
+if [ -n "${config}" ] && [ ! -f "${config}" ]; then
+  printf "ERROR: Configuration file %s not found.\n" "${config}"
+  usage
+  exit 1
+fi
+
+build_mcuboot "${chip}" "${config}"

--- a/tools/espressif/mcuboot_toolchain_espressif.cmake
+++ b/tools/espressif/mcuboot_toolchain_espressif.cmake
@@ -1,0 +1,35 @@
+# ##############################################################################
+# tools/espressif/mcuboot_toolchain_espressif.cmake
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(CMAKE_SYSTEM_NAME Generic)
+
+set(CMAKE_C_COMPILER riscv-none-elf-gcc)
+set(CMAKE_CXX_COMPILER riscv-none-elf-g++)
+set(CMAKE_ASM_COMPILER riscv-none-elf-gcc)
+
+set(CMAKE_C_FLAGS
+    "-march=rv32imc_zicsr_zifencei"
+    CACHE STRING "C Compiler Base Flags")
+set(CMAKE_CXX_FLAGS
+    "-march=rv32imc_zicsr_zifencei"
+    CACHE STRING "C++ Compiler Base Flags")
+set(CMAKE_EXE_LINKER_FLAGS
+    "-nostartfiles -march=rv32imc_zicsr_zifencei --specs=nosys.specs"
+    CACHE STRING "Linker Base Flags")


### PR DESCRIPTION
## Summary

- esp32[s2]: Add nuttx toolchain support on mcuboot
- esp32[s3]: Add nuttx toolchain support on mcuboot
- esp32: Add nuttx toolchain support on mcuboot
- esp32[c3|c6|h2]: Add nuttx toolchain support on mcuboot

## Impact

ESP32, ESP32-S2, ESP32-S3, ESP32-C3, ESP32-C6 and ESP32-H2

## Testing

Configs used:

```
esp32-devkitc:mcuboot_nsh
esp32s2-saola-1:mcuboot_nsh
esp32s3-devkit:mcuboot_nsh
esp32c6-devkitc:mcuboot_nsh
esp32h2-devkit:mcuboot_nsh
esp32c3-generic:mcuboot_nsh
```
