### PR TITLE
arch/tricore: synchronize instruction/data following MTCR/MFCR

### DIFF
--- a/arch/tricore/src/common/tricore_csa.c
+++ b/arch/tricore/src/common/tricore_csa.c
@@ -50,9 +50,17 @@ uintptr_t *tricore_alloc_csa(uintptr_t pc, uintptr_t sp,
 
   plcsa = (uintptr_t *)tricore_csa2addr(__mfcr(CPU_FCX));
 
+  /* DSYNC instruction should be executed immediately prior to the MTCR */
+
+  __dsync();
+
   pucsa = (uintptr_t *)tricore_csa2addr(plcsa[REG_UPCXI]);
 
   __mtcr(CPU_FCX, pucsa[REG_UPCXI]);
+
+  /* ISYNC instruction executed immediately following MTCR */
+
+  __isync();
 
   memset(pucsa, 0, XCPTCONTEXT_SIZE);
   memset(plcsa, 0, XCPTCONTEXT_SIZE);

--- a/arch/tricore/src/common/tricore_svcall.c
+++ b/arch/tricore/src/common/tricore_svcall.c
@@ -57,7 +57,13 @@ void tricore_svcall(volatile void *trap)
   uintptr_t *regs;
   uint32_t cmd;
 
-  regs = tricore_csa2addr(__mfcr(CPU_PCXI));
+  regs = (uintptr_t *)__mfcr(CPU_PCXI);
+
+  /* DSYNC instruction should be executed immediately prior to the MTCR */
+
+  __dsync();
+
+  regs = tricore_csa2addr((uintptr_t)regs);
 
   CURRENT_REGS = regs;
 

--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -993,7 +993,8 @@
 #  define end_packed_struct             __attribute__((packed))
 #  define reentrant_function
 #  define naked_function
-#  define always_inline_function        __attribute__((always_inline))
+#  define always_inline_function        __attribute__((always_inline,no_instrument_function))
+#  define inline_function               __attribute__((always_inline)) inline
 #  define noinline_function             __attribute__((noinline))
 #  define noinstrument_function
 #  define nooptimiziation_function      __attribute__((optimize(0)))


### PR DESCRIPTION
## Summary

1. arch/tricore: synchronize instruction/data following MTCR/MFCR

Some barrier are necessary to avoid compiler optimizations

Signed-off-by: chao an <anchao@lixiang.com>


2. compiler/tasking: fix build break after inline spinlock change

Regression by:
```
| commit a4fece3450be99fbca5815558dec9374d4ee04e3
| Author: hujun5 <hujun5@xiaomi.com>
| Date:   Wed Jul 3 15:10:49 2024 +0800
|
|     spin_lock: inline spin_lock
```

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

tc397