### PR TITLE
cmake/boards: fix build break on custom board

### DIFF
--- a/cmake/menuconfig.cmake
+++ b/cmake/menuconfig.cmake
@@ -73,7 +73,7 @@ add_custom_target(
   COMMAND grep "^CONFIG_ARCH_CHIP_" ${CMAKE_BINARY_DIR}/.config >>
           ${CMAKE_BINARY_DIR}/defconfig.tmp || true
   COMMAND grep "CONFIG_ARCH_CHIP=" ${CMAKE_BINARY_DIR}/.config >>
-          ${CMAKE_BINARY_DIR}/defconfig.tmp
+          ${CMAKE_BINARY_DIR}/defconfig.tmp || true
   COMMAND grep "CONFIG_ARCH_BOARD=" ${CMAKE_BINARY_DIR}/.config >>
           ${CMAKE_BINARY_DIR}/defconfig.tmp || true
   COMMAND grep "^CONFIG_ARCH_CUSTOM" ${CMAKE_BINARY_DIR}/.config >>


### PR DESCRIPTION
## Summary

cmake/boards: fix build break on custom board

Special string filters can be ignored normally

```
Loaded configuration '.config'
Minimal configuration saved to 'defconfig.tmp'
gmake[3]: *** [CMakeFiles/savedefconfig.dir/build.make:73: CMakeFiles/savedefconfig] Error 1
gmake[2]: *** [CMakeFiles/Makefile2:17869: CMakeFiles/savedefconfig.dir/all] Error 2
gmake[1]: *** [CMakeFiles/Makefile2:17876: CMakeFiles/savedefconfig.dir/rule] Error 2
gmake: *** [Makefile:208: savedefconfig] Error 2
```

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

ci-check