### PR TITLE
risc-v/bl808, sg2000: Configure MMU to cache Kernel Text, Data and Heap (T-Head C906)

### DIFF
--- a/arch/risc-v/src/bl808/bl808_mm_init.c
+++ b/arch/risc-v/src/bl808/bl808_mm_init.c
@@ -40,12 +40,23 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* T-Head C906 MMU requires Strong Order and Shareable for I/O Memory */
+/* T-Head C906 MMU Extensions */
 
 #define MMU_THEAD_SHAREABLE    (1ul << 60)
+#define MMU_THEAD_BUFFERABLE   (1ul << 61)
+#define MMU_THEAD_CACHEABLE    (1ul << 62)
 #define MMU_THEAD_STRONG_ORDER (1ul << 63)
+
+/* T-Head C906 MMU requires Strong Order and Shareable for I/O Memory */
+
 #define MMU_THEAD_IO_FLAGS     (MMU_IO_FLAGS | MMU_THEAD_SHAREABLE | \
                                 MMU_THEAD_STRONG_ORDER)
+
+/* T-Head C906 MMU requires Kernel Memory to be explicitly cached */
+
+#define MMU_THEAD_PMA_FLAGS    (MMU_THEAD_SHAREABLE | \
+                                MMU_THEAD_BUFFERABLE | \
+                                MMU_THEAD_CACHEABLE)
 
 /* Map the I/O and PLIC Memory with vaddr = paddr mappings */
 
@@ -258,10 +269,12 @@ void bl808_kernel_mappings(void)
   /* Map the kernel text and data for L2/L3 */
 
   binfo("map kernel text\n");
-  map_region(KFLASH_START, KFLASH_START, KFLASH_SIZE, MMU_KTEXT_FLAGS);
+  map_region(KFLASH_START, KFLASH_START, KFLASH_SIZE,
+             MMU_KTEXT_FLAGS | MMU_THEAD_PMA_FLAGS);
 
   binfo("map kernel data\n");
-  map_region(KSRAM_START, KSRAM_START, KSRAM_SIZE, MMU_KDATA_FLAGS);
+  map_region(KSRAM_START, KSRAM_START, KSRAM_SIZE,
+             MMU_KDATA_FLAGS | MMU_THEAD_PMA_FLAGS);
 
   /* Connect the L1 and L2 page tables for the kernel text and data */
 
@@ -272,7 +285,7 @@ void bl808_kernel_mappings(void)
 
   binfo("map the page pool\n");
   mmu_ln_map_region(2, PGT_L2_VBASE, PGPOOL_START, PGPOOL_START, PGPOOL_SIZE,
-                    MMU_KDATA_FLAGS);
+                    MMU_KDATA_FLAGS | MMU_THEAD_PMA_FLAGS);
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/sg2000/sg2000_mm_init.c
+++ b/arch/risc-v/src/sg2000/sg2000_mm_init.c
@@ -40,12 +40,23 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* T-Head C906 MMU requires Strong Order and Shareable for I/O Memory */
+/* T-Head C906 MMU Extensions */
 
 #define MMU_THEAD_SHAREABLE    (1ul << 60)
+#define MMU_THEAD_BUFFERABLE   (1ul << 61)
+#define MMU_THEAD_CACHEABLE    (1ul << 62)
 #define MMU_THEAD_STRONG_ORDER (1ul << 63)
+
+/* T-Head C906 MMU requires Strong Order and Shareable for I/O Memory */
+
 #define MMU_THEAD_IO_FLAGS     (MMU_IO_FLAGS | MMU_THEAD_SHAREABLE | \
                                 MMU_THEAD_STRONG_ORDER)
+
+/* T-Head C906 MMU requires Kernel Memory to be explicitly cached */
+
+#define MMU_THEAD_PMA_FLAGS    (MMU_THEAD_SHAREABLE | \
+                                MMU_THEAD_BUFFERABLE | \
+                                MMU_THEAD_CACHEABLE)
 
 /* Map the I/O and PLIC Memory with vaddr = paddr mappings */
 
@@ -258,10 +269,12 @@ void sg2000_kernel_mappings(void)
   /* Map the kernel text and data for L2/L3 */
 
   binfo("map kernel text\n");
-  map_region(KFLASH_START, KFLASH_START, KFLASH_SIZE, MMU_KTEXT_FLAGS);
+  map_region(KFLASH_START, KFLASH_START, KFLASH_SIZE,
+             MMU_KTEXT_FLAGS | MMU_THEAD_PMA_FLAGS);
 
   binfo("map kernel data\n");
-  map_region(KSRAM_START, KSRAM_START, KSRAM_SIZE, MMU_KDATA_FLAGS);
+  map_region(KSRAM_START, KSRAM_START, KSRAM_SIZE,
+             MMU_KDATA_FLAGS | MMU_THEAD_PMA_FLAGS);
 
   /* Connect the L1 and L2 page tables for the kernel text and data */
 
@@ -272,7 +285,7 @@ void sg2000_kernel_mappings(void)
 
   binfo("map the page pool\n");
   mmu_ln_map_region(2, PGT_L2_VBASE, PGPOOL_START, PGPOOL_START, PGPOOL_SIZE,
-                    MMU_KDATA_FLAGS);
+                    MMU_KDATA_FLAGS | MMU_THEAD_PMA_FLAGS);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

This PR configures the BL808 and SG2000 MMU (inside T-Head C906) to cache the the Kernel Text, Data and Heap.  We set the MMU Flags (Shareable, Bufferable and Cacheable) as [explained in this article](https://lupyuen.github.io/articles/plic3#appendix-mmu-caching-for-t-head-c906).

This PR fixes the Slow Memory Access for NuttX Kernel on BL808 and SG2000: https://github.com/apache/nuttx/issues/12696. In the next PR, we will fix the Slow Memory Access for NuttX Apps, by caching the User Text and Data.

`arch/risc-v/src/bl808/bl808_mm_init.c`: Added MMU Flags (Shareable, Bufferable and Cacheable) for BL808 Kernel Text, Data and Heap

`arch/risc-v/src/sg2000/sg2000_mm_init.c`: Added MMU Flags (Shareable, Bufferable and Cacheable) for SG2000 Kernel Text, Data and Heap

## Impact

This PR only affects Kernel Memory Caching for Ox64 BL808 SBC and Milk-V Duo S SG2000 SBC.

No other platforms are affected.

## Testing

We test Ox64 BL808 SBC and Milk-V Duo S SG2000 SBC with a [NOP Loop](https://github.com/lupyuen2/wip-nuttx/pull/68/files) that iterates 40,000,000 times:

```text
After MMU: mmu_enable(g_kernel_pgt_pbase, 0);
0 [NOP Loop Delay] 1
```

- __Without MMU Caching:__ NOP Loop completes after 10 seconds

  [Ox64 Video](https://youtu.be/nPChSAS7CHI) / [Ox64 Log](https://gist.github.com/lupyuen/86980e832ba70748dc037f8cf05a440b#file-ox64-mmu-delay2-log)

  [Duo S Video](https://youtu.be/iHLN9_drmlk) / [Duo S Log](https://gist.github.com/lupyuen/335cd4b03400c0b198d1d825c066ecf9#file-sg2000-mmu-delay5-log)

- __With MMU Caching:__ NOP Loop completes immediately

  [Ox64 Video](https://youtu.be/8C77_J3gqrc) / [Ox64 Log](https://gist.github.com/lupyuen/a8bcc27fcfb194f13c1e8da3a2177667#file-ox64-mmu-delay-log)

  [Duo S Video](https://youtu.be/U_4V_KQ7dv4) / [Duo S Log](https://gist.github.com/lupyuen/2d4a8ac8180431cf5dadcc62ac445d2b#file-sg2000-mmu-delay4-log)

For Regression Testing: We successfully tested OSTest on Ox64 BL808 SBC and Milk-V Duo S SG2000 SBC:

- [Ox64 Video](https://youtu.be/8C77_J3gqrc) / [Ox64 Log](https://gist.github.com/lupyuen/a8bcc27fcfb194f13c1e8da3a2177667#file-ox64-mmu-delay-log)

- [Duo S Video](https://youtu.be/U_4V_KQ7dv4) / [Duo S Log](https://gist.github.com/lupyuen/2d4a8ac8180431cf5dadcc62ac445d2b#file-sg2000-mmu-delay4-log)

Thanks to @henryrov for tracking down the problem.