### PR TITLE
tricore/cmake: add support of cmake build for tricore

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -637,7 +637,7 @@ if(NOT CONFIG_ARCH_SIM)
 
   # TODO: nostart/nodefault not applicable to nuttx toolchain
   target_link_libraries(
-    nuttx PRIVATE -Wl,--script=${ldscript} -Wl,--start-group ${nuttx_libs}
+    nuttx PRIVATE -T${ldscript} -Wl,--start-group ${nuttx_libs}
                   ${nuttx_extra_libs} -Wl,--end-group)
 
   # generate binary outputs in different formats (.bin, .hex, etc)
@@ -770,7 +770,7 @@ if(CONFIG_BUILD_PROTECTED)
   get_property(nuttx_apps_libs GLOBAL PROPERTY NUTTX_APPS_LIBRARIES)
 
   get_property(user_ldscript GLOBAL PROPERTY LD_SCRIPT_USER)
-  list(TRANSFORM user_ldscript PREPEND "-Wl,--script=")
+  list(TRANSFORM user_ldscript PREPEND "-T")
 
   execute_process(
     COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS} ${NUTTX_EXTRA_FLAGS}

--- a/arch/tricore/CMakeLists.txt
+++ b/arch/tricore/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# arch/tricore/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+nuttx_add_subdirectory()

--- a/arch/tricore/src/CMakeLists.txt
+++ b/arch/tricore/src/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# arch/tricore/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(${ARCH_SUBDIR})
+add_subdirectory(${NUTTX_CHIP_ABS_DIR} EXCLUDE_FROM_ALL exclude_chip)
+add_subdirectory(common)
+
+# Include directories (before system ones) as PUBLIC so that it can be exposed
+# to libboard
+target_include_directories(arch BEFORE PUBLIC ${NUTTX_CHIP_ABS_DIR} common
+                                              ${ARCH_SUBDIR})
+
+if(NOT CONFIG_BUILD_FLAT)
+  target_include_directories(arch_interface BEFORE PUBLIC ${NUTTX_CHIP_ABS_DIR}
+                                                          common ${ARCH_SUBDIR})
+endif()

--- a/arch/tricore/src/cmake/Toolchain.cmake
+++ b/arch/tricore/src/cmake/Toolchain.cmake
@@ -1,0 +1,149 @@
+# ##############################################################################
+# arch/tricore/src/cmake/Toolchain.cmake
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+# Toolchain
+
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_VERSION 1)
+
+set(ARCH_SUBDIR)
+
+if(CONFIG_ARCH_TC3XX) # TC3XX
+  set(ARCH_SUBDIR tc3xx)
+else()
+  set(ARCH_SUBDIR tc3xx)
+endif()
+
+include(${ARCH_SUBDIR})
+
+set(TOOLCHAIN_PREFIX tricore-elf)
+set(CMAKE_LIBRARY_ARCHITECTURE ${TOOLCHAIN_PREFIX})
+set(CMAKE_C_COMPILER_TARGET ${TOOLCHAIN_PREFIX})
+set(CMAKE_CXX_COMPILER_TARGET ${TOOLCHAIN_PREFIX})
+
+set(CMAKE_ASM_COMPILER ${TOOLCHAIN_PREFIX}-gcc)
+set(CMAKE_C_COMPILER ${CMAKE_ASM_COMPILER})
+set(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}-g++)
+set(CMAKE_STRIP ${TOOLCHAIN_PREFIX}-strip --strip-unneeded)
+set(CMAKE_OBJCOPY ${TOOLCHAIN_PREFIX}-objcopy)
+set(CMAKE_OBJDUMP ${TOOLCHAIN_PREFIX}-objdump)
+
+set(CMAKE_LINKER ${TOOLCHAIN_PREFIX}-gcc)
+set(CMAKE_LD ${TOOLCHAIN_PREFIX}-gcc)
+set(CMAKE_AR ${TOOLCHAIN_PREFIX}-gcc-ar)
+set(CMAKE_NM ${TOOLCHAIN_PREFIX}-gcc-nm)
+set(CMAKE_RANLIB ${TOOLCHAIN_PREFIX}-gcc-ranlib)
+
+# override the ARCHIVE command
+
+set(CMAKE_C_ARCHIVE_CREATE "<CMAKE_AR> rcs <TARGET> <LINK_FLAGS> <OBJECTS>")
+set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> rcs <TARGET> <LINK_FLAGS> <OBJECTS>")
+set(CMAKE_ASM_ARCHIVE_CREATE "<CMAKE_AR> rcs <TARGET> <LINK_FLAGS> <OBJECTS>")
+
+# Architecture flags
+
+add_compile_options(-fno-common)
+add_compile_options(-Wall -Wshadow -Wundef)
+add_compile_options(-nostdlib)
+
+if(CONFIG_DEBUG_CUSTOMOPT)
+  add_compile_options(${CONFIG_DEBUG_OPTLEVEL})
+elseif(CONFIG_DEBUG_FULLOPT)
+  add_compile_options(-Os)
+endif()
+
+if(NOT CONFIG_DEBUG_NOOPT)
+  add_compile_options(-fno-strict-aliasing)
+endif()
+
+if(CONFIG_FRAME_POINTER)
+  add_compile_options(-fno-omit-frame-pointer -fno-optimize-sibling-calls)
+else()
+  add_compile_options(-fomit-frame-pointer)
+endif()
+
+if(CONFIG_STACK_CANARIES)
+  add_compile_options(-fstack-protector-all)
+endif()
+
+if(CONFIG_ARCH_COVERAGE)
+  add_compile_options(-fprofile-generate -ftest-coverage)
+endif()
+
+# Optimization of unused sections
+
+if(CONFIG_DEBUG_OPT_UNUSED_SECTIONS)
+  add_link_options(-Wl,--gc-sections)
+  add_compile_options(-ffunction-sections -fdata-sections)
+endif()
+
+# Debug --whole-archive
+
+if(CONFIG_DEBUG_LINK_WHOLE_ARCHIVE)
+  add_link_options(-Wl,--whole-archive)
+endif()
+
+if(CONFIG_ENDIAN_BIG)
+  add_compile_options(-mbig-endian)
+endif()
+
+# Link Time Optimization
+
+if(CONFIG_LTO_THIN)
+  add_compile_options(-flto=thin)
+elseif(CONFIG_LTO_FULL)
+  add_compile_options(-flto)
+  if(CONFIG_ARCH_TOOLCHAIN_GNU)
+    add_compile_options(-fno-builtin)
+    add_compile_options(-fuse-linker-plugin)
+  endif()
+endif()
+
+# Debug link map
+
+if(CONFIG_DEBUG_LINK_MAP)
+  add_link_options(-Wl,--cref -Wl,-Map=nuttx.map)
+endif()
+
+if(CONFIG_DEBUG_SYMBOLS)
+  add_compile_options(-g)
+endif()
+
+add_link_options(-Wl,--no-warn-rwx-segments)
+
+add_compile_options(-Wno-attributes -Wno-unknown-pragmas
+                    $<$<COMPILE_LANGUAGE:C>:-Wstrict-prototypes>)
+
+if(CONFIG_CXX_STANDARD)
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-std=${CONFIG_CXX_STANDARD}>)
+endif()
+
+if(NOT CONFIG_LIBCXXTOOLCHAIN)
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-nostdinc++>)
+endif()
+
+if(NOT CONFIG_CXX_EXCEPTION)
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fno-exceptions>
+                      $<$<COMPILE_LANGUAGE:CXX>:-fcheck-new>)
+endif()
+
+if(NOT CONFIG_CXX_RTTI)
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>)
+endif()

--- a/arch/tricore/src/cmake/platform.cmake
+++ b/arch/tricore/src/cmake/platform.cmake
@@ -1,0 +1,70 @@
+# ##############################################################################
+# arch/tricore/src/cmake/platform.cmake
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+get_directory_property(TOOLCHAIN_DIR_FLAGS DIRECTORY ${CMAKE_SOURCE_DIR}
+                                                     COMPILE_OPTIONS)
+
+set(NUTTX_EXTRA_FLAGS "")
+foreach(FLAG ${TOOLCHAIN_DIR_FLAGS})
+  if(NOT FLAG MATCHES "^\\$<.*>$")
+    list(APPEND NUTTX_EXTRA_FLAGS ${FLAG})
+  else()
+    string(REGEX MATCH "\\$<\\$<COMPILE_LANGUAGE:C>:(.*)>" matched ${FLAG})
+    if(matched)
+      list(APPEND NUTTX_EXTRA_FLAGS ${CMAKE_MATCH_1})
+    endif()
+  endif()
+endforeach()
+
+separate_arguments(CMAKE_C_FLAG_ARGS NATIVE_COMMAND ${CMAKE_C_FLAGS})
+
+execute_process(
+  COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
+          --print-libgcc-file-name
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  OUTPUT_VARIABLE extra_library)
+list(APPEND EXTRA_LIB ${extra_library})
+if(NOT CONFIG_LIBM)
+  execute_process(
+    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
+            --print-file-name=libm.a
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE extra_library)
+  list(APPEND EXTRA_LIB ${extra_library})
+endif()
+if(CONFIG_LIBSUPCXX)
+  execute_process(
+    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
+            --print-file-name=libsupc++.a
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE extra_library)
+  list(APPEND EXTRA_LIB ${extra_library})
+endif()
+if(CONFIG_ARCH_COVERAGE)
+  execute_process(
+    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
+            --print-file-name=libgcov.a
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE extra_library)
+  list(APPEND EXTRA_LIB ${extra_library})
+endif()
+
+nuttx_add_extra_library(${EXTRA_LIB})
+
+set(PREPROCES ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} -E -P -x c)

--- a/arch/tricore/src/cmake/tc3xx.cmake
+++ b/arch/tricore/src/cmake/tc3xx.cmake
@@ -1,0 +1,33 @@
+# ##############################################################################
+# arch/tricore/src/cmake/tc3xx.cmake
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(PLATFORM_FLAGS)
+
+if(CONFIG_ARCH_CHIP_TC397)
+  list(APPEND PLATFORM_FLAGS -mcpu=tc39xx -mtc162)
+  list(APPEND PLATFORM_FLAGS
+       -I${NUTTX_CHIP_ABS_DIR}/tc397/Libraries/iLLD/TC39B/Tricore/Cpu/Std)
+  list(APPEND PLATFORM_FLAGS
+       -I${NUTTX_CHIP_ABS_DIR}/tc397/Libraries/Infra/Platform)
+  list(APPEND PLATFORM_FLAGS -I${NUTTX_CHIP_ABS_DIR}/tc397/Configurations)
+endif()
+
+add_compile_options(${PLATFORM_FLAGS})
+add_link_options(${PLATFORM_FLAGS})

--- a/arch/tricore/src/common/CMakeLists.txt
+++ b/arch/tricore/src/common/CMakeLists.txt
@@ -1,0 +1,60 @@
+# ##############################################################################
+# arch/tricore/src/common/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS
+    tricore_allocateheap.c
+    tricore_checkstack.c
+    tricore_createstack.c
+    tricore_csa.c
+    tricore_exit.c
+    tricore_getintstack.c
+    tricore_idle.c
+    tricore_initialize.c
+    tricore_initialstate.c
+    tricore_irq.c
+    tricore_main.c
+    tricore_mdelay.c
+    tricore_nputs.c
+    tricore_registerdump.c
+    tricore_releasestack.c
+    tricore_saveusercontext.c
+    tricore_schedulesigaction.c
+    tricore_sigdeliver.c
+    tricore_stackframe.c
+    tricore_svcall.c
+    tricore_switchcontext.c
+    tricore_tcbinfo.c
+    tricore_trapcall.c
+    tricore_systimer.c
+    tricore_usestack.c)
+
+if(CONFIG_SPINLOCK)
+  list(APPEND SRCS tricore_testset.c)
+endif()
+
+set(IFXFLAGS -DIFX_CFG_EXTEND_TRAP_HOOKS -DIFX_USE_SW_MANAGED_INT)
+
+target_sources(arch PRIVATE ${SRCS})
+target_sources(nuttx PRIVATE tricore_doirq.c)
+target_compile_options(arch PRIVATE ${IFXFLAGS})
+target_compile_options(nuttx PRIVATE ${IFXFLAGS})
+target_include_directories(
+  nuttx SYSTEM PRIVATE ${CMAKE_SOURCE_DIR}/include ${CMAKE_BINARY_DIR}/include
+                       ${CMAKE_BINARY_DIR}/include_arch)

--- a/arch/tricore/src/tc3xx/CMakeLists.txt
+++ b/arch/tricore/src/tc3xx/CMakeLists.txt
@@ -1,0 +1,41 @@
+# ##############################################################################
+# arch/tricore/src/tc3xx/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS tc3xx_timerisr.c tc3xx_serial.c)
+
+target_sources(arch PRIVATE ${SRCS})
+
+if(CONFIG_ARCH_CHIP_TC397)
+
+  if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/tc397)
+    FetchContent_Declare(
+      tc397
+      URL https://github.com/anchao/tc397_sdk/archive/refs/heads/master.tar.gz
+          SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/tc397 BINARY_DIR
+          ${CMAKE_BINARY_DIR}/arch/${CONFIG_ARCH}/src/${CONFIG_ARCH_CHIP}/tc397)
+    FetchContent_GetProperties(tc397)
+    if(NOT tc397_POPULATED)
+      FetchContent_Populate(tc397)
+    endif()
+  endif()
+
+  add_subdirectory(tc397)
+
+endif()

--- a/boards/tricore/tc3xx/tc397/CMakeLists.txt
+++ b/boards/tricore/tc3xx/tc397/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/tricore/tc3xx/tc397/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/tricore/tc3xx/tc397/src/CMakeLists.txt
+++ b/boards/tricore/tc3xx/tc397/src/CMakeLists.txt
@@ -1,0 +1,34 @@
+# ##############################################################################
+# boards/tricore/tc3xx/tc397/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS tc397_appinit.c tc397_boardinit.c tc397_bringup.c)
+
+target_sources(board PRIVATE ${SRCS})
+
+# TODO: make this the default and then allow boards to redefine
+if(CONFIG_TRICORE_TOOLCHAIN_TASKING)
+  set_property(
+    GLOBAL PROPERTY LD_SCRIPT
+                    "${NUTTX_BOARD_DIR}/scripts/Lcf_Tasking_Tricore_Tc.lsl")
+else()
+  set_property(
+    GLOBAL PROPERTY LD_SCRIPT
+                    "${NUTTX_BOARD_DIR}/scripts/Lcf_Gnuc_Tricore_Tc.lsl")
+endif()

--- a/libs/libc/machine/tricore/CMakeLists.txt
+++ b/libs/libc/machine/tricore/CMakeLists.txt
@@ -1,0 +1,19 @@
+# ##############################################################################
+# libs/libc/machine/tricore/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################


### PR DESCRIPTION
## Summary

tricore/cmake: add support of cmake build for tricore

Toolchain Upstream:
https://github.com/EEESlab/tricore-gcc-toolchain-11.3.0

CMake command:
```
$ cmake -B build -DBOARD_CONFIG=tc397/nsh -GNinja
$ cmake --build build
```

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

tc397/nsh