### PR TITLE
arch/risc-v: make common up_allocate_heap weak symbol

### DIFF
--- a/arch/risc-v/src/common/riscv_allocateheap.c
+++ b/arch/risc-v/src/common/riscv_allocateheap.c
@@ -64,7 +64,7 @@
  *
  ****************************************************************************/
 
-void up_allocate_heap(void **heap_start, size_t *heap_size)
+void weak_function up_allocate_heap(void **heap_start, size_t *heap_size)
 {
   board_autoled_on(LED_HEAPALLOCATE);
   *heap_start = (void *)g_idle_topstack;


### PR DESCRIPTION
The common `up_allocate_heap` is a strong symbol, which leads to error when building with CONFIG_DEBUG_LINK_WHOLE_ARCHIVE. Make `up_allocate_heap` weak function to mitigate this problem.

This should mitigate #12603.

## Testing
`rv-virt/flats64`