### PR TITLE
arch/risc-v: does not clear IPI address in S mode

### DIFF
--- a/arch/risc-v/src/common/riscv_ipi.h
+++ b/arch/risc-v/src/common/riscv_ipi.h
@@ -45,7 +45,7 @@ static inline void riscv_ipi_send(int cpu)
 
 static inline void riscv_ipi_clear(int cpu)
 {
-#if defined(RISCV_IPI)
+#if defined(RISCV_IPI) && !defined(CONFIG_ARCH_USE_S_MODE)
   putreg32(0, (uintptr_t)RISCV_IPI + (4 * cpu));
 #endif
   CLEAR_CSR(CSR_IP, IP_SIP);


### PR DESCRIPTION
According to the riscv-aclint doc, writing 0 to SSWI address has no effect. Remove this unnecessary write for S mode.

Link: https://github.com/riscv/riscv-aclint/blob/main/riscv-aclint.adoc

## Testing
`rv-virt:flats64`
