### PR TITLE
Fix-SAMA5D2-LCDC-framebuffer-artefacts-(LVGL)

### DIFF
--- a/arch/arm/src/sama5/Kconfig
+++ b/arch/arm/src/sama5/Kconfig
@@ -767,6 +767,7 @@ config SAMA5_LCDC
 	bool "LCD Controller (LCDC)"
 	default n
 	depends on SAMA5_HAVE_LCDC
+	select FB_UPDATE
 
 config SAMA5_ISI
 	bool "Image Sensor Interface (ISI)"
@@ -1311,16 +1312,31 @@ config SAMA5_LCDC_FB_VBASE
 	---help---
 		If you are using the LCDC, then you must provide the virtual
 		address of the start of the framebuffer.  This address must be
-		aligned to a 1MB bounder (i.e., the last five "digits" of the
+		aligned to a 1MB boundary (i.e., the last five "digits" of the
 		hexadecimal address must be zero).
+		The memory location chosen should be large enough to allow a buffer
+		of size SAMA5_LCDC_FB_SIZE to exist.		
 
 config SAMA5_LCDC_FB_PBASE
-	hex "Framebuffer memory start address (virtual)"
+	hex "Framebuffer memory start address (physical)"
 	---help---
 		If you are using the LCDC, then you must provide the physical
 		address of the start of the framebuffer.  This address must be
-		aligned to a 1MB bounder (i.e., the last five "digits" of the
+		aligned to a 1MB boundary (i.e., the last five "digits" of the
 		hexadecimal address must be zero).
+		The memory location chosen should be large enough to allow a buffer
+		of size SAMA5_LCDC_FB_SIZE to exist.		
+
+config SAMA5_LCDC_FB_EXTBASE
+	hex "Framebuffer external (app) memory start address"
+	---help---
+		If you are using the LCDC, then the application (e.g. LVGL) cannot
+		write directly to the physical FB memory and an additional buffer
+		memory area must be provided. The driver will copy data from this
+		mempory to the LCDC's DMA'd FB when a call to the FB UPDATE ioctl
+		function is made.
+		The memory location chosen should be large enough to allow a buffer
+		of size SAMA5_LCDC_FB_SIZE to exist.
 
 config SAMA5_LCDC_FB_SIZE
 	int "Framebuffer memory size (bytes)"


### PR DESCRIPTION
The SAMA5D2 LCDC driver has memory mapped framebuffers that LVGL (for example) can write to directly causing issues. LVGL - and presumably other applications - need a buffer that they can render to and only when done should that be copied to the "real" framebuffers of the LCDC.

I have added a function `CONFIG_FB_UPDATE`  that can be called via the relevant IOCTL that does the copy and it has fixed the issue I was seeing in relation to screen artefacts I noted as an issue in the nuttx-apps repo [here](https://github.com/apache/nuttx-apps/issues/2416).

I am not 100% sure what the correct way to address this is, so for now I have added a new Kconfig entry to allow an "EXT" memory buffer to be declared, and that is what is reported as the `pinfo->fbmem` memory location but it doesn't really feel right - and it seems there are no other architectures that address this so it is perhaps unique to the SAMA5D2?

There must be a better/neater/proper way to be doing this?

## Impact
It allows LVGL V9 to behave as expected, on this processor. I have tried to ensure that the driver reverts to the previous methodology if the new Kconfig entry is not present.

## Testing
Custom board with SAMA5D27-D1G and 800x480 LCDC. Manually deleted new Kconfig entry to check the driver reverts to as before and, similarly, deleted the newly enforced `CONFIG FB_UPDATE` entry to check.

