### PR TITLE
fix compile error

### DIFF
--- a/include/nuttx/spinlock.h
+++ b/include/nuttx/spinlock.h
@@ -42,6 +42,8 @@ extern "C++"
 #    define CONFIG_HAVE_INLINE_SPINLOCK
   using std::atomic_int;
   using std::atomic_load;
+  using std::atomic_uint;
+  using std::atomic_ushort;
   using std::atomic_fetch_add;
   using std::atomic_fetch_sub;
   using std::atomic_compare_exchange_strong;
@@ -343,14 +345,14 @@ static inline_function bool spin_trylock(FAR volatile spinlock_t *lock)
   unsigned short ticket =
     atomic_load((FAR atomic_ushort *)&lock->tickets.next);
 
-  spinlock_t old =
+  spinlock_t oldval =
     {
       {
         ticket, ticket
       }
     };
 
-  spinlock_t new =
+  spinlock_t newval =
     {
       {
         ticket, ticket + 1
@@ -358,7 +360,7 @@ static inline_function bool spin_trylock(FAR volatile spinlock_t *lock)
     };
 
   if (!atomic_compare_exchange_strong((FAR atomic_uint *)&lock->value,
-                                      &old.value, new.value))
+                                      &oldval.value, newval.value))
 #else /* CONFIG_TICKET_SPINLOCK */
   if (up_testset(lock) == SP_LOCKED)
 #endif /* CONFIG_TICKET_SPINLOCK */
@@ -410,14 +412,14 @@ spin_trylock_wo_note(FAR volatile spinlock_t *lock)
   unsigned short ticket =
     atomic_load((FAR atomic_ushort *)&lock->tickets.next);
 
-  spinlock_t old =
+  spinlock_t oldval =
     {
       {
         ticket, ticket
       }
     };
 
-  spinlock_t new =
+  spinlock_t newval =
     {
       {
         ticket, ticket + 1
@@ -425,7 +427,7 @@ spin_trylock_wo_note(FAR volatile spinlock_t *lock)
     };
 
   if (!atomic_compare_exchange_strong((FAR atomic_uint *)&lock->value,
-                                      &old.value, new.value))
+                                      &oldval.value, newval.value))
 #else /* CONFIG_TICKET_SPINLOCK */
   if (up_testset(lock) == SP_LOCKED)
 #endif /* CONFIG_TICKET_SPINLOCK */


### PR DESCRIPTION

## Summary
error msg
/home/hujun5/downloads1/vela_sim/nuttx/include/nuttx/spinlock.h: In function 'bool spin_trylock_wo_note(volatile spinlock_t*)': /home/hujun5/downloads1/vela_sim/nuttx/include/nuttx/spinlock.h:401:22: error: 'atomic_ushort' was not declared in this scope; did you mean 'std::__1::atomic_ushort'?
  401 |     atomic_load((FAR atomic_ushort *)&lock->tickets.next);
      |                      ^~~~~~~~~~~~~
      |                      std::__1::atomic_ushort
/home/hujun5/downloads1/vela_sim/nuttx/include/libcxx/__atomic/aliases.h:33:7: note: 'std::__1::atomic_ushort' declared here
   33 | using atomic_ushort = atomic<unsigned short>;
      |       ^~~~~~~~~~~~~
/home/hujun5/downloads1/vela_sim/nuttx/include/nuttx/spinlock.h:401:37: error: expected primary-expression before ')' token
  401 |     atomic_load((FAR atomic_ushort *)&lock->tickets.next);
      |                                     ^
/home/hujun5/downloads1/vela_sim/nuttx/include/nuttx/spinlock.h:410:14: error: expected unqualified-id before 'new'
  410 |   spinlock_t new =
      |              ^~~
/home/hujun5/downloads1/vela_sim/nuttx/include/nuttx/spinlock.h:417:44: error: 'atomic_uint' was not declared in this scope; did you mean 'std::__1::atomic_uint'?
  417 |   if (!atomic_compare_exchange_strong((FAR atomic_uint *)&lock->value,
      |                                            ^~~~~~~~~~~
      |                                            std::__1::atomic_uint
/home/hujun5/downloads1/vela_sim/nuttx/include/libcxx/__atomic/aliases.h:35:7: note: 'std::__1::atomic_uint' declared here
   35 | using atomic_uint   = atomic<unsigned int>;
      |       ^~~~~~~~~~~
/home/hujun5/downloads1/vela_sim/nuttx/include/nuttx/spinlock.h:417:57: error: expected primary-expression before ')' token
  417 |   if (!atomic_compare_exchange_strong((FAR atomic_uint *)&lock->value,
      |                                                         ^
/home/hujun5/downloads1/vela_sim/nuttx/include/nuttx/spinlock.h:418:54: error: expected type-specifier before '.' token
  418 |                                       &old.value, new.value))


## Impact

## Testing

