### PR TITLE
Fix pin LTDC_B0, should be PJ12 instead of PF0

### DIFF
--- a/Documentation/platforms/arm/stm32h7/boards/linum-stm32h753bi/index.rst
+++ b/Documentation/platforms/arm/stm32h7/boards/linum-stm32h753bi/index.rst
@@ -259,7 +259,7 @@ The LINUM-STM32H753BI has a external SDRAM with 16Mbits connected to FMC periphe
   =========== =====
   FMC         PINS
   =========== =====
-  FMC_A0      PF0
+  FMC_A0      PJ12
   FMC_A1      PF1
   FMC_A2      PF2
   FMC_A3      PF3


### PR DESCRIPTION
## Summary
Fix a small issue found on Linum-STM32H753BI Documentation.
## Impact
Doc fix
## Testing
N/A
