### PR TITLE
sched: Improve Kconfig help of INIT_ENTRYPOINT

### DIFF
--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -445,6 +445,20 @@ config INIT_ENTRYPOINT
 		applications this is of the form 'app_main' where 'app' is the application
 		name. If not defined, INIT_ENTRYPOINT defaults to "main".
 
+		Note that main must take "argc" and "argv" arguments:
+
+		int main(int argc, FAR char *argv[])
+
+		Otherwise, if using a signature such as "int main(void)" a compilation
+		error will result:
+
+		> $ make
+		> CC:  CustomHello.c <command-line>: error: conflicting types for
+		> 'custom_hello_main'
+		> CustomHello.c:3:5: note: in expansion of macro 'main'
+		>     3 | int main(void)
+		>       |     ^~~~
+
 config INIT_ENTRYNAME
 	string "Application entry name"
 	default INIT_ENTRYPOINT


### PR DESCRIPTION
## Summary

In the "--help--" text of `sched/Kconfig` `CONFIG_INIT_ENTRYPOINT`, document that "main" should include "argc" and "argv" to avoid the issue discussed in the email thread "[basically, I get an error when I do make](https://lists.apache.org/thread/9j2s3647ysdhy204g4ombn4o09bn11c1)" started 18 Jul 2024.

## Impact

Improve documentation and hopefully prevent others from running into the same compilation problem.

## Testing

None.