### PR TITLE
usbdev: delete unsigned comparison with 0

### DIFF
--- a/drivers/usbdev/usbdev_fs.c
+++ b/drivers/usbdev/usbdev_fs.c
@@ -510,8 +510,6 @@ static int usbdev_fs_close(FAR struct file *filep)
 
   fs_ep->crefs -= 1;
 
-  ASSERT(fs_ep->crefs >= 0);
-
   if (fs_ep->unlinked && fs_ep->crefs == 0)
     {
       bool do_free = true;


### PR DESCRIPTION
## Summary
The unsigned type is always greater than or equal to 0

## Impact

## Testing

