### PR TITLE
build.yml: Updated the workflow to use version v4 of the actions/upload-artifact and actions/download-artifact.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,7 @@ jobs:
         run: tar zcf sources.tar.gz sources
 
       - name: Archive Source Bundle
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: source-bundle
           path: sources.tar.gz
@@ -127,7 +127,7 @@ jobs:
 
     steps:
       - name: Download Source Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: source-bundle
           path: .
@@ -165,10 +165,10 @@ jobs:
                 ./cibuild.sh -c -A -N -R testlist/${{matrix.boards}}.dat
             fi
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
-          name: linux-builds
+          name: linux-${{matrix.boards}}-builds
           path: buildartifacts/
         continue-on-error: true
 
@@ -182,7 +182,7 @@ jobs:
         boards: [macos, sim-01, sim-02]
     steps:
       - name: Download Source Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: source-bundle
           path: .
@@ -214,9 +214,9 @@ jobs:
           cd sources/nuttx/tools/ci
           ./cibuild.sh -i -c -A -R testlist/${{matrix.boards}}.dat
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: macos-builds
+          name: macos-${{matrix.boards}}-builds
           path: buildartifacts/
         continue-on-error: true
 
@@ -262,7 +262,7 @@ jobs:
       - run: git config --global core.autocrlf false
 
       - name: Download Source Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: source-bundle
           path: .
@@ -282,8 +282,8 @@ jobs:
           cd sources/nuttx/tools/ci
           ./cibuild.sh -g -i -A -C -R testlist/${{matrix.boards}}.dat
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: msys2-builds
+          name: msys2-${{matrix.boards}}-builds
           path: buildartifacts/
         continue-on-error: true


### PR DESCRIPTION
## Summary

Starting November 30, 2024, GitHub Actions customers will no longer be able to use v3 of actions/upload-artifact or actions/download-artifact.

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

**Breaking change using V4**

Due to how Artifacts are created in this new version, it is no longer possible to upload to the same named Artifact multiple times.

https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes

Currently in our workflow each type of runner processing work (Linux, Mac and Windows) in the artifacts generates a single file with all jobs.

**Solution present in this PR**

modified
https://github.com/apache/nuttx/blob/17aec1328a6c993d4cb8009fb2ac1893103ba936/.github/workflows/build.yml#L171C18-L171C27

**name: linux-builds -> name: linux-${{matrix.boards}}-builds**


So, in the artifacts produced at runtime, instead of having one linux-builds file, we will have x files as many as jobs.
linux example:

linux-arm-01-builds

linux-arm-02-builds

etc.

Of course, the same is true for mac and msys2.


**This PR removes the following warning annotations:**

The following actions uses Node.js version which is deprecated and will be forced to run on node20: actions/upload-artifact@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
The following actions uses Node.js version which is deprecated and will be forced to run on node20: actions/download-artifact@v3, actions/upload-artifact@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
## Impact
**Improvements**
Uploads are significantly faster, upwards of 90% improvement in worst case scenarios.
https://github.com/actions/upload-artifact?tab=readme-ov-file#improvements
## Testing
CI