### PR TITLE
doc.yml: Updated the workflow to use version v4 of the actions/upload-artifact

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -44,7 +44,7 @@ jobs:
           pip3 install pipenv
           pipenv install
           pipenv run make html latexpdf
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: sphinx-docs
           path: |


### PR DESCRIPTION
## Summary

Starting November 30, 2024, GitHub Actions customers will no longer be able to use v3 of actions/upload-artifact or actions/download-artifact.

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

This PR removes the following warning annotations:

The following actions uses Node.js version which is deprecated and will be forced to run on node20: actions/upload-artifact@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

## Impact
Improvements
Uploads are significantly faster, upwards of 90% improvement in worst case scenarios.
https://github.com/actions/upload-artifact?tab=readme-ov-file#improvements
## Testing
CI

