### PR TITLE
up_backtrace: fix maybe backtrace the exiting thread

### DIFF
--- a/arch/arm/src/common/arm_backtrace_fp.c
+++ b/arch/arm/src/common/arm_backtrace_fp.c
@@ -99,13 +99,20 @@ static int backtrace(uintptr_t *base, uintptr_t *limit,
  * Returned Value:
  *   up_backtrace() returns the number of addresses returned in buffer
  *
+ * Assumptions:
+ *   Have to make sure tcb keep safe during function executing, it means
+ *   1. Tcb have to be self or not-running.  In SMP case, the running task
+ *      PC & SP cannot be backtrace, as whose get from tcb is not the newest.
+ *   2. Tcb have to keep not be freed.  In task exiting case, have to
+ *      make sure the tcb get from pid and up_backtrace in one critical
+ *      section procedure.
+ *
  ****************************************************************************/
 
 int up_backtrace(struct tcb_s *tcb,
                  void **buffer, int size, int skip)
 {
   struct tcb_s *rtcb = running_task();
-  irqstate_t flags;
   int ret;
 
   if (size <= 0 || !buffer)
@@ -149,15 +156,11 @@ int up_backtrace(struct tcb_s *tcb,
     }
   else
     {
-      flags = enter_critical_section();
-
       ret = backtrace(tcb->stack_base_ptr,
                       tcb->stack_base_ptr + tcb->adj_stack_size,
                       (void *)tcb->xcp.regs[REG_FP],
                       (void *)tcb->xcp.regs[REG_PC],
                       buffer, size, &skip);
-
-      leave_critical_section(flags);
     }
 
   return ret;

--- a/arch/arm/src/common/arm_backtrace_sp.c
+++ b/arch/arm/src/common/arm_backtrace_sp.c
@@ -230,6 +230,14 @@ void up_backtrace_init_code_regions(void **regions)
  * Returned Value:
  *   up_backtrace() returns the number of addresses returned in buffer
  *
+ * Assumptions:
+ *   Have to make sure tcb keep safe during function executing, it means
+ *   1. Tcb have to be self or not-running.  In SMP case, the running task
+ *      PC & SP cannot be backtrace, as whose get from tcb is not the newest.
+ *   2. Tcb have to keep not be freed.  In task exiting case, have to
+ *      make sure the tcb get from pid and up_backtrace in one critical
+ *      section procedure.
+ *
  ****************************************************************************/
 
 nosanitize_address
@@ -237,7 +245,6 @@ int up_backtrace(struct tcb_s *tcb,
                  void **buffer, int size, int skip)
 {
   struct tcb_s *rtcb = running_task();
-  irqstate_t flags;
   unsigned long sp;
   int ret;
 
@@ -287,8 +294,6 @@ int up_backtrace(struct tcb_s *tcb,
     {
       ret = 0;
 
-      flags = enter_critical_section();
-
       if (tcb->xcp.regs[REG_PC] && skip-- <= 0)
         {
           buffer[ret++] = (void *)tcb->xcp.regs[REG_PC];
@@ -299,8 +304,6 @@ int up_backtrace(struct tcb_s *tcb,
                               tcb->stack_base_ptr +
                               tcb->adj_stack_size, sp,
                               &buffer[ret], size - ret, &skip);
-
-      leave_critical_section(flags);
     }
 
   return ret;

--- a/arch/risc-v/src/common/riscv_backtrace.c
+++ b/arch/risc-v/src/common/riscv_backtrace.c
@@ -124,12 +124,19 @@ static int backtrace(uintptr_t *base, uintptr_t *limit,
  * Returned Value:
  *   up_backtrace() returns the number of addresses returned in buffer
  *
+ * Assumptions:
+ *   Have to make sure tcb keep safe during function executing, it means
+ *   1. Tcb have to be self or not-running.  In SMP case, the running task
+ *      PC & SP cannot be backtrace, as whose get from tcb is not the newest.
+ *   2. Tcb have to keep not be freed.  In task exiting case, have to
+ *      make sure the tcb get from pid and up_backtrace in one critical
+ *      section procedure.
+ *
  ****************************************************************************/
 
 int up_backtrace(struct tcb_s *tcb, void **buffer, int size, int skip)
 {
   struct tcb_s *rtcb = running_task();
-  irqstate_t flags;
   int ret;
 
   if (size <= 0 || !buffer)
@@ -181,8 +188,6 @@ int up_backtrace(struct tcb_s *tcb, void **buffer, int size, int skip)
     }
   else
     {
-      flags = enter_critical_section();
-
 #ifdef CONFIG_ARCH_KERNEL_STACK
       if (tcb->xcp.ustkptr != NULL)
         {
@@ -200,8 +205,6 @@ int up_backtrace(struct tcb_s *tcb, void **buffer, int size, int skip)
                           (void *)tcb->xcp.regs[REG_EPC],
                           buffer, size, &skip);
         }
-
-      leave_critical_section(flags);
     }
 
   return ret;

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -495,6 +495,14 @@ void up_dump_register(FAR void *regs);
  * Returned Value:
  *   up_backtrace() returns the number of addresses returned in buffer
  *
+ * Assumptions:
+ *   Have to make sure tcb keep safe during function executing, it means
+ *   1. Tcb have to be self or not-running.  In SMP case, the running task
+ *      PC & SP cannot be backtrace, as whose get from tcb is not the newest.
+ *   2. Tcb have to keep not be freed.  In task exiting case, have to
+ *      make sure the tcb get from pid and up_backtrace in one critical
+ *      section procedure.
+ *
  ****************************************************************************/
 
 int up_backtrace(FAR struct tcb_s *tcb,

--- a/sched/sched/sched_backtrace.c
+++ b/sched/sched/sched_backtrace.c
@@ -43,17 +43,21 @@
 #ifdef CONFIG_ARCH_HAVE_BACKTRACE
 int sched_backtrace(pid_t tid, FAR void **buffer, int size, int skip)
 {
-  FAR struct tcb_s *rtcb = NULL;
-
+  FAR struct tcb_s *rtcb;
+  irqstate_t flags;
+  int ret = 0;
   if (tid >= 0)
     {
-      rtcb = nxsched_get_tcb(tid);
-      if (rtcb == NULL)
+      flags = enter_critical_section();
+      rtcb  = nxsched_get_tcb(tid);
+      if (rtcb != NULL)
         {
-          return 0;
+          ret = up_backtrace(rtcb, buffer, size, skip);
         }
+
+      leave_critical_section(flags);
     }
 
-  return up_backtrace(rtcb, buffer, size, skip);
+  return ret;
 }
 #endif


### PR DESCRIPTION
## Summary
when trying to show information at task quit and thread still running, try dump callstack found maybe some problem.
Need this patch to solve dump exiting thread callstack. need another patch to fix dump running thread stack.

## Impact
Can dump the exiting thread after patch.

## Testing
CI & qemu-armv7a & SMP armv7a board.
