### PR TITLE
{bp-12560} espressif: Fix error while evaluating Wi-Fi task ID

### DIFF
--- a/arch/risc-v/src/esp32c3-legacy/esp32c3_wifi_adapter.c
+++ b/arch/risc-v/src/esp32c3-legacy/esp32c3_wifi_adapter.c
@@ -2094,7 +2094,7 @@ static int32_t esp_task_ms_to_tick(uint32_t ms)
 
 static void *esp_task_get_current_task(void)
 {
-  pid_t pid = nxsched_getpid();
+  pid_t pid = nxsched_gettid();
 
   return (void *)((uintptr_t)pid);
 }
@@ -4769,7 +4769,7 @@ int esp_wifi_notify_subscribe(pid_t pid, struct sigevent *event)
             {
               if (pid == 0)
                 {
-                  pid = nxsched_getpid();
+                  pid = nxsched_gettid();
                   wlinfo("Actual PID=%d\n", pid);
                 }
 

--- a/arch/risc-v/src/esp32c3/esp_wifi_adapter.c
+++ b/arch/risc-v/src/esp32c3/esp_wifi_adapter.c
@@ -3273,7 +3273,7 @@ static void task_delete_wrapper(void *task_handle)
  *
  * Description:
  *   This function gets the current task's PID and returns it as a void
- *   pointer. This is a wrapper around the NuttX function nxsched_getpid.
+ *   pointer. This is a wrapper around the NuttX function nxsched_gettid.
  *
  * Input Parameters:
  *   None
@@ -3285,7 +3285,7 @@ static void task_delete_wrapper(void *task_handle)
 
 static void *task_get_current_task_wrapper(void)
 {
-  pid_t pid = nxsched_getpid();
+  pid_t pid = nxsched_gettid();
 
   return (void *)((uintptr_t)pid);
 }
@@ -3601,7 +3601,7 @@ int esp_wifi_notify_subscribe(pid_t pid, struct sigevent *event)
             {
               if (pid == 0)
                 {
-                  pid = nxsched_getpid();
+                  pid = nxsched_gettid();
                   wlinfo("Actual PID=%d\n", pid);
                 }
 

--- a/arch/risc-v/src/esp32c6/esp_wifi_adapter.c
+++ b/arch/risc-v/src/esp32c6/esp_wifi_adapter.c
@@ -3227,7 +3227,7 @@ static void task_delete_wrapper(void *task_handle)
  *
  * Description:
  *   This function gets the current task's PID and returns it as a void
- *   pointer. This is a wrapper around the NuttX function nxsched_getpid.
+ *   pointer. This is a wrapper around the NuttX function nxsched_gettid.
  *
  * Input Parameters:
  *   None
@@ -3239,7 +3239,7 @@ static void task_delete_wrapper(void *task_handle)
 
 static void *task_get_current_task_wrapper(void)
 {
-  pid_t pid = nxsched_getpid();
+  pid_t pid = nxsched_gettid();
 
   return (void *)((uintptr_t)pid);
 }
@@ -3555,7 +3555,7 @@ int esp_wifi_notify_subscribe(pid_t pid, struct sigevent *event)
             {
               if (pid == 0)
                 {
-                  pid = nxsched_getpid();
+                  pid = nxsched_gettid();
                   wlinfo("Actual PID=%d\n", pid);
                 }
 

--- a/arch/xtensa/src/esp32/esp32_wifi_adapter.c
+++ b/arch/xtensa/src/esp32/esp32_wifi_adapter.c
@@ -1938,7 +1938,7 @@ static int32_t esp_task_ms_to_tick(uint32_t ms)
 
 static void *esp_task_get_current_task(void)
 {
-  pid_t pid = nxsched_getpid();
+  pid_t pid = nxsched_gettid();
 
   return (void *)((uintptr_t)pid);
 }
@@ -4422,7 +4422,7 @@ int esp_wifi_notify_subscribe(pid_t pid, struct sigevent *event)
             {
               if (pid == 0)
                 {
-                  pid = nxsched_getpid();
+                  pid = nxsched_gettid();
                   wlinfo("Actual PID=%d\n", pid);
                 }
 

--- a/arch/xtensa/src/esp32s3/esp32s3_wifi_adapter.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_wifi_adapter.c
@@ -1945,7 +1945,7 @@ static int32_t esp_task_ms_to_tick(uint32_t ms)
 
 static void *esp_task_get_current_task(void)
 {
-  pid_t pid = nxsched_getpid();
+  pid_t pid = nxsched_gettid();
 
   return (void *)((uintptr_t)pid);
 }
@@ -4466,7 +4466,7 @@ int esp_wifi_notify_subscribe(pid_t pid, struct sigevent *event)
             {
               if (pid == 0)
                 {
-                  pid = nxsched_getpid();
+                  pid = nxsched_gettid();
                   wlinfo("Actual PID=%d\n", pid);
                 }
 


### PR DESCRIPTION
## Summary
Use `nxsched_gettid` instead of `nxsched_getpid`. Previously each kernel thread was modelled as a task, so the pid is the same of the kthread id. Now, with shared kthread group (introduced by #12320), the pid of all kthreads will be 0 by design in shared group.

## Impact
RELEASE

## Testing
ESP32, ESP32-S3, ESP32-C3
