### PR TITLE
{bp-12717} arch/riscv: fix trap sp restore logic

### DIFF
--- a/arch/risc-v/src/common/riscv_exception_common.S
+++ b/arch/risc-v/src/common/riscv_exception_common.S
@@ -231,7 +231,11 @@ return_from_exception:
 
   load_ctx   sp
 
+#ifdef CONFIG_ARCH_KERNEL_STACK
   REGLOAD    sp, REG_SP(sp)      /* restore original sp */
+#else
+  addi       sp, sp, XCPTCONTEXT_SIZE
+#endif
 
   /* Return from exception */
 

--- a/arch/risc-v/src/common/riscv_fork.c
+++ b/arch/risc-v/src/common/riscv_fork.c
@@ -246,6 +246,14 @@ pid_t riscv_fork(const struct fork_s *context)
   fregs[REG_FS11]               = context->fs11; /* Saved register fs11 */
 #endif
 
+#ifdef CONFIG_BUILD_PROTECTED
+  /* Forked task starts at `dispatch_syscall()`, which requires TP holding
+   * TCB pointer as per e6973c764c, so we please it here to support vfork.
+   */
+
+  child->cmn.xcp.regs[REG_TP]   = (uintptr_t)child;
+#endif
+
   /* And, finally, start the child task.  On a failure, nxtask_start_fork()
    * will discard the TCB by calling nxtask_abort_fork().
    */


### PR DESCRIPTION
## Summary
Summary

This amends pull https://github.com/apache/nuttx/pull/12435 and attempts to fix issue https://github.com/apache/nuttx/issues/12635 of PROTECTED build vfork failure since commit https://github.com/apache/nuttx/commit/e6973c764cd5314aa4d6ccfadaebdd715f2dd709.

Investigation revealed two separate issues:

    The optimized dispatch_syscall now requires TP to be prepared, which normally isn't a problem. But for the very first run of the forked child, it was zero. So we need prepare it for the forked child specially before its first run.

    When returning from exception, the SP restored from stack normally works, As forked child stack is copied from parent, thus restored SP from child stack actually points to the parent stack area! So if child executes ealier that parent reaches the waitpid, parent will crash later due to corrupted stack. Unfortunately this is true with PROTECTED build now.

Impacts

riscv devices
Testing

    Local checks with canmv230:pnsh for issue 

https://github.com/apache/nuttx/issues/12635 verification
Local checks with following configs for regression

    canmv230: nsh, nsbi
    rv-virt: nsh, flats, knsh32, smp, ksmp

CI checks
