### PR TITLE
boards/imx93-evk: add sdimage cleanup

### DIFF
--- a/boards/arm64/imx9/imx93-evk/src/Makefile
+++ b/boards/arm64/imx9/imx93-evk/src/Makefile
@@ -43,3 +43,9 @@ CSRCS += imx9_usdhc.c
 endif
 
 include $(TOPDIR)/boards/Board.mk
+
+ifeq ($(CONFIG_IMX9_BOOTLOADER),y)
+.PHONY: distclean
+distclean::
+	$(call DELFILE, ${TOPDIR}${DELIM}imx9-sdimage.img)
+endif


### PR DESCRIPTION
## Summary

adds cleanup of `imx9-sdimage.img` upon distclean to unblock CI system.

## Impacts

CI checks

## Testing

- local check with imx93-evk:bootloader
- CI checks

