### PR TITLE
virtio-serial: support custom the virtio serial device name

### DIFF
--- a/drivers/virtio/Kconfig
+++ b/drivers/virtio/Kconfig
@@ -74,6 +74,16 @@ if DRIVERS_VIRTIO_SERIAL
 config DRIVERS_VIRTIO_SERIAL_BUFSIZE
 	int "Virtio serial driver buffer size"
 	default 256
+
+config DRIVERS_VIRTIO_SERIAL_NAME
+	string "Virtio serial driver name"
+	default ""
+	---help---
+		Using this config to custom the virtio serial registered device name,
+		using ";" to split the names.
+		For example, if DRIVERS_VIRTIO_SERIAL_NAME = "ttyBT;ttyTEL" and pass
+		three virtio-serial devices to the qemu, we will get three uart devices
+		with names: "/dev/ttyBT", "/dev/ttyTEL", "/dev/ttyV2"
 endif
 
 config DRIVERS_VIRTIO_SOUND


### PR DESCRIPTION
## Summary
By setting config CONFIG_DRIVERS_VIRTIO_SERIAL_NAME to "ttyXX0;ttyXX1;..." to customize the virtio serial name.

For example:
If CONFIG_DRIVERS_VIRTIO_SERIAL_NAME="ttyBT;ttyTest0;ttyTest1", virtio-serial will register three uart devices with names: "/dev/ttyBT", "/dev/ttyTest0", "/dev/ttyTest1" to the VFS.

nsh> ls dev
/dev:
 console
 null
 telnet
 ttyBT
 ttyS0
 ttyTest0
 ttyTest1
 zero

## Impact
VirtIO-Serial

## Testing
Test with arm64 nsh
