### PR TITLE
dlfcn: Add stub for dladdr

### DIFF
--- a/include/dlfcn.h
+++ b/include/dlfcn.h
@@ -78,6 +78,30 @@
 #define RTLD_LOCAL  (1 << 2)
 
 /****************************************************************************
+ * Public Type Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: Dl_info
+ *
+ * Description: The Dl_info structure is used by the dladdr() function.
+ *
+ * Notice:
+ *   The name of this structure is Dl_info_t in POSIX.
+ *   But, the Dl_info (maybe from Linux?) seems to be used more widely:
+ *   https://man7.org/linux/man-pages/man3/dladdr.3.html
+ *   So, we use Dl_info here.
+ ****************************************************************************/
+
+typedef struct
+{
+  FAR const char *dli_fname;  /* Pathname of shared object that contains address */
+  FAR void       *dli_fbase;  /* Base address at which shared object is loaded */
+  FAR const char *dli_sname;  /* Name of symbol whose definition overlaps addr */
+  FAR void       *dli_saddr;  /* Exact address of symbol named in dli_sname */
+} Dl_info;
+
+/****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
 
@@ -308,6 +332,26 @@ int dlclose(FAR void *handle);
  ****************************************************************************/
 
 FAR char *dlerror(void);
+
+/****************************************************************************
+ * Name: dladdr
+ *
+ * Description:
+ *   dladdr() provides information about the address of a symbol in a
+ *   dynamically loaded object.
+ *
+ * Input Parameters:
+ *   addr - The address of the symbol for which information is desired.
+ *   info - A pointer to a Dl_info structure that is filled in by dladdr().
+ *
+ * Returned Value:
+ *   On success, these functions return a nonzero value.
+ *
+ * Reference: OpenGroup.org
+ *
+ ****************************************************************************/
+
+int dladdr(const FAR void *addr, FAR Dl_info *info);
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/libs/libc/dlfcn/CMakeLists.txt
+++ b/libs/libc/dlfcn/CMakeLists.txt
@@ -19,5 +19,5 @@
 # ##############################################################################
 if(CONFIG_LIBC_DLFCN)
   target_sources(c PRIVATE lib_dlopen.c lib_dlclose.c lib_dlsym.c lib_dlerror.c
-                           lib_dlsymtab.c)
+                           lib_dlsymtab.c lib_dladdr.c)
 endif()

--- a/libs/libc/dlfcn/Make.defs
+++ b/libs/libc/dlfcn/Make.defs
@@ -23,6 +23,7 @@ ifeq ($(CONFIG_LIBC_DLFCN),y)
 # Add the dlfcn.h files to the build
 
 CSRCS += lib_dlopen.c lib_dlclose.c lib_dlsym.c lib_dlerror.c lib_dlsymtab.c
+CSRCS += lib_dladdr.c
 
 # Add the dlfcn.h directory to the build
 

--- a/libs/libc/dlfcn/lib_dladdr.c
+++ b/libs/libc/dlfcn/lib_dladdr.c
@@ -1,0 +1,42 @@
+/****************************************************************************
+ * libs/libc/dlfcn/lib_dladdr.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <errno.h>
+#include <dlfcn.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: dladdr
+ ****************************************************************************/
+
+int dladdr(const FAR void *addr, FAR Dl_info *info)
+{
+  set_errno(ENOTSUP);
+  return 0;
+}

--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -184,6 +184,7 @@ static const struct file_section_s g_section_info[] =
 static const char *g_white_prefix[] =
 {
   "ASCII_",  /* Ref:  include/nuttx/ascii.h */
+  "Dl_info", /* Ref:  include/dlfcn.h */
   "Elf",     /* Ref:  include/elf.h, include/elf32.h, include/elf64.h */
   "PRId",    /* Ref:  inttypes.h */
   "PRIi",    /* Ref:  inttypes.h */


### PR DESCRIPTION
## Summary
Implement a stub for dladdr() to avoid build errors with some applications that use dladdr().

The API definition is from:
1. https://man7.org/linux/man-pages/man3/dladdr.3.html
2. https://pubs.opengroup.org/onlinepubs/9799919799.2024edition/functions/dladdr.html
## Impact
New API
## Testing
Local machine
