### PR TITLE
nrf9160-dk: disable FPU for modem example 

### DIFF
--- a/arch/arm/src/nrf53/nrf53_start.c
+++ b/arch/arm/src/nrf53/nrf53_start.c
@@ -240,7 +240,7 @@ void __start(void)
   arm_stack_check_init();
 #endif
 
-#ifdef CONFIG_ARCH_HAVE_FPU
+#ifdef CONFIG_ARCH_FPU
   /* Initialize the FPU (if available) */
 
   arm_fpuconfig();

--- a/arch/arm/src/nrf91/nrf91_start.c
+++ b/arch/arm/src/nrf91/nrf91_start.c
@@ -224,7 +224,7 @@ void __start(void)
 
   showprogress('C');
 
-#ifdef CONFIG_ARCH_HAVE_FPU
+#ifdef CONFIG_ARCH_FPU
   /* Initialize the FPU (if available) */
 
   arm_fpuconfig();

--- a/boards/arm/nrf91/nrf9160-dk/configs/miniboot_s/defconfig
+++ b/boards/arm/nrf91/nrf9160-dk/configs/miniboot_s/defconfig
@@ -5,6 +5,7 @@
 # You can then do "make savedefconfig" to generate a new defconfig file that includes your
 # modifications.
 #
+# CONFIG_ARCH_FPU is not set
 # CONFIG_STANDARD_SERIAL is not set
 CONFIG_ARCH="arm"
 CONFIG_ARCH_BOARD="nrf9160-dk"
@@ -28,6 +29,7 @@ CONFIG_DEBUG_USAGEFAULT=y
 CONFIG_EXPERIMENTAL=y
 CONFIG_INIT_ENTRYPOINT="miniboot_main"
 CONFIG_INTELHEX_BINARY=y
+CONFIG_LIBC_FLOATINGPOINT=y
 CONFIG_MM_REGIONS=2
 CONFIG_NRF91_APP_FORMAT_MCUBOOT=y
 CONFIG_NRF91_FLASH_NS_START=2

--- a/boards/arm/nrf91/nrf9160-dk/configs/modem_ns/defconfig
+++ b/boards/arm/nrf91/nrf9160-dk/configs/modem_ns/defconfig
@@ -5,6 +5,7 @@
 # You can then do "make savedefconfig" to generate a new defconfig file that includes your
 # modifications.
 #
+# CONFIG_ARCH_FPU is not set
 # CONFIG_NET_ETHERNET is not set
 # CONFIG_STANDARD_SERIAL is not set
 CONFIG_ALLOW_BSDNORDIC_COMPONENTS=y
@@ -34,6 +35,7 @@ CONFIG_GPSUTILS_MINMEA_LIB=y
 CONFIG_IDLETHREAD_STACKSIZE=2048
 CONFIG_INIT_ENTRYPOINT="nsh_main"
 CONFIG_INTELHEX_BINARY=y
+CONFIG_LIBC_FLOATINGPOINT=y
 CONFIG_MM_IOB=y
 CONFIG_MM_REGIONS=2
 CONFIG_NET=y


### PR DESCRIPTION
## Summary
-  boards/arm/nrf91/nrf9160-dk: disable FPU for modem example  
    it looks like FPU doesn't work in non-secure environment now

- arch/arm/{nrf53|nrf91}: enable fpu if CONFIG_ARCH_FPU=y
    enable fpu if CONFIG_ARCH_FPU=y, the previous condition depended on CONFIG_ARCH_HAVE_FPU=y
    
## Impact

## Testing

