### PR TITLE
build/cmake: add user_ldscript preprocessing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -770,6 +770,21 @@ if(CONFIG_BUILD_PROTECTED)
   get_property(nuttx_apps_libs GLOBAL PROPERTY NUTTX_APPS_LIBRARIES)
 
   get_property(user_ldscript GLOBAL PROPERTY LD_SCRIPT_USER)
+
+  if(DEFINED PREPROCES)
+    get_filename_component(LD_SCRIPT_NAME ${user_ldscript} NAME)
+    set(LD_SCRIPT_TMP "${CMAKE_BINARY_DIR}/${LD_SCRIPT_NAME}.tmp")
+    add_custom_command(
+      OUTPUT ${LD_SCRIPT_TMP}
+      DEPENDS ${user_ldscript}
+      COMMAND ${PREPROCES} -I${CMAKE_BINARY_DIR}/include -I${NUTTX_CHIP_ABS_DIR}
+              ${user_ldscript} > ${LD_SCRIPT_TMP}
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+    add_custom_target(user_ldscript_tmp DEPENDS ${LD_SCRIPT_TMP})
+    add_dependencies(nuttx_user user_ldscript_tmp)
+    set(user_ldscript ${LD_SCRIPT_TMP})
+  endif()
+
   list(TRANSFORM user_ldscript PREPEND "-T")
 
   execute_process(


### PR DESCRIPTION
## Summary

This allows PROTECTED mode userspace linker script to be preprocessed so
that to use defs in <nuttx/config.h> and avoid hardcoded values.

## Impact

PROTECTED mode cmake uses

## Testing

- local testing
- CI checks

