### PR TITLE
drivers/video: Add config for API compatibility

### DIFF
--- a/drivers/video/Kconfig
+++ b/drivers/video/Kconfig
@@ -163,6 +163,14 @@ config VIDEO_SCENE_TEXT
 	default y
 	---help---
 		Enable text scene
+
+config VIDEO_COMPAT_OLD_APIS
+	bool "Use old API symbols for keeping compatibility"
+	default n
+	---help---
+		The video_initialize() is re-named capture_initialize() in newest.
+		This options restore it to older one.
+
 endif
 
 config VIDEO_MAX7456

--- a/include/nuttx/video/v4l2_cap.h
+++ b/include/nuttx/video/v4l2_cap.h
@@ -24,8 +24,14 @@
  * Included Files
  ****************************************************************************/
 
+#include <nuttx/config.h>
 #include <nuttx/video/imgdata.h>
 #include <nuttx/video/imgsensor.h>
+
+#ifdef CONFIG_VIDEO_COMPAT_OLD_APIS
+#  define capture_initialize   video_initialize
+#  define capture_uninitialize video_uninitialize
+#endif
 
 #ifdef __cplusplus
 extern "C"

--- a/include/nuttx/video/video.h
+++ b/include/nuttx/video/video.h
@@ -31,6 +31,7 @@
 
 #include <sys/videoio.h>
 #include <nuttx/fs/fs.h>
+#include <nuttx/video/v4l2_cap.h>
 
 #ifdef __cplusplus
 extern "C"


### PR DESCRIPTION
## Summary

Add a Kconfig option for supporting old APIs on video driver.
The video_initialize() and video_uninitialize() are re-named to capture_initialize() and capture_uninitialize().
But this modification made break compatibility on user APIs.
So this commit add a option on Kconfig to use old API symbol name.

## Impact

No impact except enabling the additional Kconfig option.
Video I/F has an impact when the option is enabled.

## Testing

Test spresense:camera, if it can be build and works well.