### PR TITLE
build.yml: fix error: externally-managed-environment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -257,6 +257,7 @@ jobs:
 
       - name: pip3 install
         run: |
+          python3 -m venv --system-site-packages /usr/local
           pip3 install --root-user-action=ignore --no-cache-dir pyelftools cxxfilt kconfiglib
 
       - run: git config --global core.autocrlf false


### PR DESCRIPTION
## Summary
**job msys2** fix
https://github.com/apache/nuttx/actions/runs/10140159746/job/28034852319?pr=12787#step:4:1

error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try 'pacman -S
    python-xyz', where xyz is the package you are trying to
    install.
    
    If you wish to install a non-MSYS2-packaged Python package,
    create a virtual environment using 'python -m venv path/to/venv'.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 66[8](https://github.com/apache/nuttx/actions/runs/10140159746/job/28034852319?pr=12787#step:4:9) for the detailed specification.

## Impact
none
## Testing
CI
