### PR TITLE
fs/spiffs: Return OK on `spiffs_fstat` success

### DIFF
--- a/fs/spiffs/src/spiffs_vfs.c
+++ b/fs/spiffs/src/spiffs_vfs.c
@@ -1187,7 +1187,10 @@ static int spiffs_fstat(FAR const struct file *filep, FAR struct stat *buf)
     }
 
   spiffs_unlock_volume(fs);
-  return spiffs_map_errno(ret);
+
+  ret = spiffs_map_errno(ret);
+
+  return ret >= 0 ? OK : ret;
 }
 
 /****************************************************************************
@@ -1929,7 +1932,8 @@ static int spiffs_stat(FAR struct inode *mountpt, FAR const char *relpath,
 
 errout_with_lock:
   spiffs_unlock_volume(fs);
-  return spiffs_map_errno(ret);
+  ret = spiffs_map_errno(ret);
+  return ret >= 0 ? OK : ret;
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

According to the POSIX standard, `fstat` should return 0 (`OK`) on success. This PR changed the underlying `spiffs` implementation to follow the POSIX standard.

## Impact

Make it consistent with POSIX compliant!

## Testing

Internal CI testing