### PR TITLE
mtd/Kconfig: fix W25_SLOWREAD menu item.

### DIFF
--- a/drivers/mtd/Kconfig
+++ b/drivers/mtd/Kconfig
@@ -1320,7 +1320,7 @@ config W25_SECTOR512
 	default n
 
 config W25_SLOWREAD
-	bool
+	bool "Enable slow read mode"
 	default n
 
 endif # MTD_W25


### PR DESCRIPTION
There was no comment next to this menu option and the option wouldn't be displayed in menu.

## Summary
Enable user to select W25_SLOWREAD option in menuconfig for W25

## Impact

## Testing
start menuconfig, see if you can select,  select it, build code with that conditioned code in.
