### PR TITLE
w25c: add W25_DEBUG sub-menu config option and update debug traces.

### DIFF
--- a/drivers/mtd/Kconfig
+++ b/drivers/mtd/Kconfig
@@ -1323,6 +1323,10 @@ config W25_SLOWREAD
 	bool
 	default n
 
+config W25_DEBUG
+	bool "Enable syslog W25 specific syslog traces"
+	default n
+
 endif # MTD_W25
 
 config MTD_GD25

--- a/drivers/mtd/w25.c
+++ b/drivers/mtd/w25.c
@@ -49,6 +49,18 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+/* You can enable just the W25 traces; else its convoluted potentially with
+ * high number of other traces from fs.
+ */
+
+#ifdef CONFIG_W25_DEBUG
+#  define w25_finfo  _info
+#  define w25_ferr   _err
+#else
+#  define w25_finfo  finfo
+#  define w25_ferr   ferr
+#endif
+
 /* Configuration ************************************************************/
 
 /* Per the data sheet, the W25 parts can be driven with either SPI mode 0
@@ -361,7 +373,7 @@ static inline int w25_readid(struct w25_dev_s *priv)
   uint16_t memory;
   uint16_t capacity;
 
-  finfo("priv: %p\n", priv);
+  w25_finfo("priv: %p\n", priv);
 
   /* Lock and configure the SPI bus */
 
@@ -387,7 +399,7 @@ static inline int w25_readid(struct w25_dev_s *priv)
   SPI_SELECT(priv->spi, SPIDEV_FLASH(0), false);
   w25_unlock(priv->spi);
 
-  finfo("manufacturer: %02x memory: %02x capacity: %02x\n",
+  w25_finfo("manufacturer: %02x memory: %02x capacity: %02x\n",
         manufacturer, memory, capacity);
 
   /* Check for a valid manufacturer and memory type */
@@ -467,7 +479,7 @@ static inline int w25_readid(struct w25_dev_s *priv)
         {
           /* Nope.. we don't understand this capacity. */
 
-          ferr("ERROR: Unsupported capacity: %02x\n", capacity);
+          w25_ferr("ERROR: Unsupported capacity: %02x\n", capacity);
           return -ENODEV;
         }
 
@@ -476,7 +488,7 @@ static inline int w25_readid(struct w25_dev_s *priv)
 
   /* We don't understand the manufacturer or the memory type */
 
-  ferr("ERROR: Unrecognized manufacturer/memory type: %02x/%02x\n",
+  w25_ferr("ERROR: Unrecognized manufacturer/memory type: %02x/%02x\n",
        manufacturer, memory);
   return -ENODEV;
 }
@@ -669,7 +681,7 @@ static void w25_sectorerase(struct w25_dev_s *priv, off_t sector)
 {
   off_t address = sector << W25_SECTOR_SHIFT;
 
-  finfo("sector: %08lx\n", (long)sector);
+  w25_finfo("sector: %08lx\n", (long)sector);
 
   /* Check if sector is already erased. */
 
@@ -716,7 +728,7 @@ static void w25_sectorerase(struct w25_dev_s *priv, off_t sector)
 
 static inline int w25_chiperase(struct w25_dev_s *priv)
 {
-  finfo("priv: %p\n", priv);
+  w25_finfo("priv: %p\n", priv);
 
   /* Wait for any preceding write or erase operation to complete. */
 
@@ -738,7 +750,7 @@ static inline int w25_chiperase(struct w25_dev_s *priv)
   /* Deselect the FLASH */
 
   SPI_SELECT(priv->spi, SPIDEV_FLASH(0), false);
-  finfo("Return: OK\n");
+  w25_finfo("Return: OK\n");
   return OK;
 }
 
@@ -751,7 +763,7 @@ static void w25_byteread(FAR struct w25_dev_s *priv, FAR uint8_t *buffer,
 {
   uint8_t status;
 
-  finfo("address: %08lx nbytes: %d\n", (long)address, (int)nbytes);
+  w25_finfo("address: %08lx nbytes: %d\n", (long)address, (int)nbytes);
 
   /* Wait for any preceding write or erase operation to complete. */
 
@@ -807,7 +819,7 @@ static void w25_pagewrite(struct w25_dev_s *priv, FAR const uint8_t *buffer,
 {
   uint8_t status;
 
-  finfo("address: %08lx nwords: %d\n", (long)address, (int)nbytes);
+  w25_finfo("address: %08lx nwords: %d\n", (long)address, (int)nbytes);
   DEBUGASSERT(priv && buffer && (address & 0xff) == 0 &&
              (nbytes & 0xff) == 0);
 
@@ -867,7 +879,7 @@ static inline void w25_bytewrite(struct w25_dev_s *priv,
                                  off_t offset,
                                  uint16_t count)
 {
-  finfo("offset: %08lx  count:%d\n", (long)offset, count);
+  w25_finfo("offset: %08lx  count:%d\n", (long)offset, count);
 
   /* Wait for any preceding write to complete.  We could simplify things by
    * perform this wait at the end of each write operation (rather than at
@@ -903,7 +915,7 @@ static inline void w25_bytewrite(struct w25_dev_s *priv,
   /* Deselect the FLASH: Chip Select high */
 
   SPI_SELECT(priv->spi, SPIDEV_FLASH(0), false);
-  finfo("Written\n");
+  w25_finfo("Written\n");
 }
 #endif /* defined(CONFIG_MTD_BYTE_WRITE) && !defined(CONFIG_W25_READONLY) */
 
@@ -954,7 +966,7 @@ static FAR uint8_t *w25_cacheread(struct w25_dev_s *priv, off_t sector)
 
   shift   = W25_SECTOR_SHIFT - W25_SECTOR512_SHIFT;
   esectno = sector >> shift;
-  finfo("sector: %ld esectno: %d shift=%d\n", sector, esectno, shift);
+  w25_finfo("sector: %ld esectno: %d shift=%d\n", sector, esectno, shift);
 
   /* Check if the requested erase block is already in the cache */
 
@@ -1013,7 +1025,7 @@ static void w25_cacheerase(struct w25_dev_s *priv, off_t sector)
   if (!IS_ERASED(priv))
     {
       off_t esectno  = sector >> (W25_SECTOR_SHIFT - W25_SECTOR512_SHIFT);
-      finfo("sector: %ld esectno: %d\n", sector, esectno);
+      w25_finfo("sector: %ld esectno: %d\n", sector, esectno);
 
       w25_sectorerase(priv, esectno);
       SET_ERASED(priv);
@@ -1058,7 +1070,7 @@ static void w25_cachewrite(FAR struct w25_dev_s *priv,
         {
           off_t esectno  = sector >>
                            (W25_SECTOR_SHIFT - W25_SECTOR512_SHIFT);
-          finfo("sector: %ld esectno: %d\n", sector, esectno);
+          w25_finfo("sector: %ld esectno: %d\n", sector, esectno);
 
           w25_sectorerase(priv, esectno);
           SET_ERASED(priv);
@@ -1095,7 +1107,8 @@ static int w25_erase(FAR struct mtd_dev_s *dev,
   FAR struct w25_dev_s *priv = (FAR struct w25_dev_s *)dev;
   size_t blocksleft = nblocks;
 
-  finfo("startblock: %08lx nblocks: %d\n", (long)startblock, (int)nblocks);
+  w25_finfo("startblock: %08lx nblocks: %d\n", (long)startblock,
+                                          (int)nblocks);
 
   /* Lock access to the SPI bus until we complete the erase */
 
@@ -1135,7 +1148,7 @@ static ssize_t w25_bread(FAR struct mtd_dev_s *dev,
 {
   ssize_t nbytes;
 
-  finfo("startblock: %08lx nblocks: %d\n",
+  w25_finfo("startblock: %08lx nblocks: %d\n",
        (long)startblock, (int)nblocks);
 
   /* On this device, we can handle the block read just like the byte-oriented
@@ -1174,7 +1187,8 @@ static ssize_t w25_bwrite(FAR struct mtd_dev_s *dev, off_t startblock,
 #else
   FAR struct w25_dev_s *priv = (FAR struct w25_dev_s *)dev;
 
-  finfo("startblock: %08lx nblocks: %d\n", (long)startblock, (int)nblocks);
+  w25_finfo("startblock: %08lx nblocks: %d\n", (long)startblock,
+                                                  (int)nblocks);
 
   /* Lock the SPI bus and write all of the pages to FLASH */
 
@@ -1203,7 +1217,7 @@ static ssize_t w25_read(FAR struct mtd_dev_s *dev,
 {
   FAR struct w25_dev_s *priv = (FAR struct w25_dev_s *)dev;
 
-  finfo("offset: %08lx nbytes: %d\n", (long)offset, (int)nbytes);
+  w25_finfo("offset: %08lx nbytes: %d\n", (long)offset, (int)nbytes);
 
   /* Lock the SPI bus and select this FLASH part */
 
@@ -1211,7 +1225,7 @@ static ssize_t w25_read(FAR struct mtd_dev_s *dev,
   w25_byteread(priv, buffer, offset, nbytes);
   w25_unlock(priv->spi);
 
-  finfo("return nbytes: %d\n", (int)nbytes);
+  w25_finfo("return nbytes: %d\n", (int)nbytes);
   return nbytes;
 }
 
@@ -1232,7 +1246,7 @@ static ssize_t w25_write(FAR struct mtd_dev_s *dev,
   int    index;
   int    bytestowrite;
 
-  finfo("offset: %08lx nbytes: %d\n", (long)offset, (int)nbytes);
+  w25_finfo("offset: %08lx nbytes: %d\n", (long)offset, (int)nbytes);
 
   /* We must test if the offset + count crosses one or more pages
    * and perform individual writes.  The devices can only write in
@@ -1298,7 +1312,7 @@ static int w25_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
   FAR struct w25_dev_s *priv = (FAR struct w25_dev_s *)dev;
   int ret = -EINVAL; /* Assume good command with bad parameters */
 
-  finfo("cmd: %d\n", cmd);
+  w25_finfo("cmd: %d\n", cmd);
 
   switch (cmd)
     {
@@ -1332,7 +1346,7 @@ static int w25_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
 #endif
               ret               = OK;
 
-              finfo("blocksize: %" PRIu32 " erasesize: %" PRIu32
+              w25_finfo("blocksize: %" PRIu32 " erasesize: %" PRIu32
                     " neraseblocks: %" PRIu32 "\n",
                     geo->blocksize, geo->erasesize, geo->neraseblocks);
             }
@@ -1385,7 +1399,7 @@ static int w25_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
         break;
     }
 
-  finfo("return %d\n", ret);
+  w25_finfo("return %d\n", ret);
   return ret;
 }
 
@@ -1408,7 +1422,7 @@ FAR struct mtd_dev_s *w25_initialize(FAR struct spi_dev_s *spi)
   FAR struct w25_dev_s *priv;
   int ret;
 
-  finfo("spi: %p\n", spi);
+  w25_finfo("spi: %p\n", spi);
 
   /* Allocate a state structure (we allocate the structure instead of using
    * a fixed, static allocation so that we can handle multiple FLASH devices.
@@ -1448,7 +1462,7 @@ FAR struct mtd_dev_s *w25_initialize(FAR struct spi_dev_s *spi)
            * return NULL
            */
 
-          ferr("ERROR: Unrecognized\n");
+          w25_ferr("ERROR: Unrecognized\n");
           kmm_free(priv);
           return NULL;
         }
@@ -1470,7 +1484,7 @@ FAR struct mtd_dev_s *w25_initialize(FAR struct spi_dev_s *spi)
             {
               /* Discard all of that work we just did and return NULL */
 
-              ferr("ERROR: Allocation failed\n");
+              w25_ferr("ERROR: Allocation failed\n");
               kmm_free(priv);
               return NULL;
             }
@@ -1480,6 +1494,6 @@ FAR struct mtd_dev_s *w25_initialize(FAR struct spi_dev_s *spi)
 
   /* Return the implementation-specific state structure as the MTD device */
 
-  finfo("Return %p\n", priv);
+  w25_finfo("Return %p\n", priv);
   return (FAR struct mtd_dev_s *)priv;
 }


### PR DESCRIPTION
 - Allows optionally to separate traces from potentially irrelevant fs syslog traces it would go with currently.

## Summary

If user wants, can enable W25_DEBUg to not mix W25 specific dbg traces with fs traces, which can be very verbose and
irrelevant.

## Impact

Optional

## Testing

Menuconfig select, rebuild, run, see log
