### PR TITLE
riscv/qemu-rv: skip reloading mhartid

### DIFF
--- a/arch/risc-v/src/qemu-rv/qemu_rv_head.S
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_head.S
@@ -43,11 +43,7 @@
 __start:
 
   /* Preserve a1 as it contains the pointer to DTB */
-  /* Load mhartid (cpuid) */
-
-#ifndef CONFIG_ARCH_USE_S_MODE
-  csrr a0, CSR_MHARTID
-#endif
+  /* Preserve a0 as it has mhartid */
 
   /* Load the number of CPUs that the kernel supports */
   li   t1, CONFIG_SMP_NCPUS


### PR DESCRIPTION
## Summary

This revises qemu_rv_head.S to avoid loading the mhartid again as
it has already in a0 register upon entry.

## Impact

qemu-rv devices

## Testing

- local checks on rv-virt with configs: `nsh`, `nsh64`, `flats`, `flats64`, `knsh32`, `knsh64`, `smp`, `smp64`, `ksmp64` etc.
- CI checks
