### PR TITLE
arch/x86_64/src/intel64/intel64_cpu.c: remove workaround for spin_lock

### DIFF
--- a/arch/x86_64/src/intel64/intel64_cpu.c
+++ b/arch/x86_64/src/intel64/intel64_cpu.c
@@ -43,12 +43,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* Avoid undefined error when CONFIG_SPINLOCK=n */
-
-#ifndef spin_lock
-#  define spin_lock(s)
-#endif
-
 #define IRQ_STACK_ALLOC (IRQ_STACK_SIZE * CONFIG_SMP_NCPUS)
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
arch/x86_64/src/intel64/intel64_cpu.c: remove workaround for spin_lock
remove workaround for spin_lock which is no longer needed after inline splinlock change

## Impact

## Testing
CI