### PR TITLE
arch/intel64: add support for HPET as system clock

### DIFF
--- a/arch/x86_64/src/intel64/CMakeLists.txt
+++ b/arch/x86_64/src/intel64/CMakeLists.txt
@@ -76,6 +76,10 @@ if(CONFIG_INTEL64_HPET)
   list(APPEND SRCS intel64_hpet.c)
 endif()
 
+if(CONFIG_ARCH_INTEL64_HPET_ALARM)
+  list(APPEND SRCS intel64_hpet_alarm.c)
+endif()
+
 if(CONFIG_INTEL64_ONESHOT)
   list(APPEND SRCS intel64_oneshot.c intel64_oneshot_lower.c)
 endif()

--- a/arch/x86_64/src/intel64/Kconfig
+++ b/arch/x86_64/src/intel64/Kconfig
@@ -68,6 +68,14 @@ config ARCH_INTEL64_TSC
 	---help---
 		Select to enable the use of TSC APIC timer of x86_64
 
+config ARCH_INTEL64_HPET_ALARM
+	bool "HPET timer alarm support"
+	depends on ALARM_ARCH
+	---help---
+		With this option you can enable ALARM_ARCH features that works on top of
+		the HPET timer instance. This is an alternative method to TSC timer to
+		provide the system clock.
+
 endchoice # System Timer Source
 
 if ARCH_INTEL64_TSC_DEADLINE
@@ -107,6 +115,11 @@ config INTEL64_HPET_BASE
 	---help---
 		Configure base address for HPET. In the future, we can get this address from
 		the ACPI table if ACPI support is enabled.
+
+config ARCH_INTEL64_HPET_ALARM_CHAN
+	int "HPET timer alarm channel"
+	depends on ARCH_INTEL64_HPET_ALARM
+	default 0
 
 config INTEL64_HPET_CHANNELS
 	int "HPET timer supported channels"

--- a/arch/x86_64/src/intel64/Make.defs
+++ b/arch/x86_64/src/intel64/Make.defs
@@ -66,6 +66,10 @@ ifeq ($(CONFIG_INTEL64_HPET),y)
 CHIP_CSRCS += intel64_hpet.c
 endif
 
+ifeq ($(CONFIG_ARCH_INTEL64_HPET_ALARM),y)
+CHIP_CSRCS += intel64_hpet_alarm.c
+endif
+
 ifeq ($(CONFIG_INTEL64_ONESHOT),y)
 CHIP_CSRCS += intel64_oneshot.c intel64_oneshot_lower.c
 endif

--- a/arch/x86_64/src/intel64/intel64_hpet_alarm.c
+++ b/arch/x86_64/src/intel64/intel64_hpet_alarm.c
@@ -1,0 +1,42 @@
+/****************************************************************************
+ * arch/x86_64/src/intel64/intel64_hpet_alarm.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <nuttx/timers/arch_alarm.h>
+
+#include "intel64_oneshot.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_ARCH_INTEL64_HPET_ALARM
+void up_timer_initialize(void)
+{
+  struct oneshot_lowerhalf_s *lower =
+    oneshot_initialize(CONFIG_ARCH_INTEL64_HPET_ALARM_CHAN, 10);
+  up_alarm_set_lowerhalf(lower);
+}
+#endif

--- a/arch/x86_64/src/intel64/intel64_oneshot.h
+++ b/arch/x86_64/src/intel64/intel64_oneshot.h
@@ -168,6 +168,17 @@ int intel64_oneshot_start(struct intel64_oneshot_s *oneshot,
 int intel64_oneshot_cancel(struct intel64_oneshot_s *oneshot,
                            struct timespec *ts);
 
+/****************************************************************************
+ * Name: intel64_oneshot_current
+ *
+ * Description:
+ *   Get the current time.
+ *
+ ****************************************************************************/
+
+int intel64_oneshot_current(struct intel64_oneshot_s *oneshot,
+                            uint64_t *usec);
+
 #undef EXTERN
 #if defined(__cplusplus)
 }

--- a/boards/x86_64/intel64/qemu-intel64/src/qemu_bringup.c
+++ b/boards/x86_64/intel64/qemu-intel64/src/qemu_bringup.c
@@ -40,6 +40,19 @@
 #include "qemu_intel64.h"
 
 /****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifdef CONFIG_ARCH_INTEL64_HPET_ALARM
+#  if CONFIG_ARCH_INTEL64_HPET_ALARM_CHAN != 0
+#    error this logic requires that HPET_ALARM_CHAN is set to 0
+#  endif
+#  define ONESHOT_TIMER 1
+#else
+#  define ONESHOT_TIMER 0
+#endif
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -72,7 +85,7 @@ int qemu_bringup(void)
 #endif
 
 #ifdef CONFIG_ONESHOT
-  os = oneshot_initialize(0, 10);
+  os = oneshot_initialize(ONESHOT_TIMER, 10);
   if (os)
     {
       oneshot_register("/dev/oneshot", os);


### PR DESCRIPTION
## Summary
arch/intel64: add support for HPET as system clock

## Impact

## Testing
qemu and intel HW
