### PR TITLE
riscv/debug: Add support for steppoint

### DIFF
--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -2973,7 +2973,7 @@ bool up_fpucmp(FAR const void *saveregs1, FAR const void *saveregs2);
 #ifdef CONFIG_ARCH_HAVE_DEBUG
 
 /****************************************************************************
- * Name: up_debugpoint
+ * Name: up_debugpoint_add
  *
  * Description:
  *   Add a debugpoint.


### PR DESCRIPTION

## Summary
Steppoint can be implemented by icount(instruction count) from RISC-V debug extension, but it may not implemented in all RISC-V cores.

Unfortunately, the currently supported RISC-V cores do not implement it.

## Impact
New feature
## Testing
Local machine
