### PR TITLE
libm/copysign: respect signed zero/NaN handling in copysign

### DIFF
--- a/libs/libm/libm/lib_copysign.c
+++ b/libs/libm/libm/lib_copysign.c
@@ -34,7 +34,7 @@
 #ifdef CONFIG_HAVE_DOUBLE
 double copysign(double x, double y)
 {
-  if (y < 0)
+  if (signbit(y))
     {
       return -fabs(x);
     }

--- a/libs/libm/libm/lib_copysignl.c
+++ b/libs/libm/libm/lib_copysignl.c
@@ -34,7 +34,7 @@
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 long double copysignl(long double x, long double y)
 {
-  if (y < 0)
+  if (signbit(y))
     {
       return -fabsl(x);
     }


### PR DESCRIPTION
## Summary

Use `signbit(y)` instead of `y < 0` to fix the result of copysign/copysignl: https://alive2.llvm.org/ce/z/kjNLyh
```
copysign(+0.0, -0.0) returns +0.0. It should be -0.0.
copysign(+0.0, NaN with signbit) returns +0.0. It should be -0.0.
```
I found this bug while working on my LLVM middle-end optimization patch https://github.com/llvm/llvm-project/pull/101324. Don't worry about the potential performance regression. I will file another PR in LLVM to handle this pattern :)

## Impact

Fix the implementation of copysign/copysignl.

## Testing

x86 with -O3