### PR TITLE
task_fork.c: Fix vfork for BUILD_KERNEL

### DIFF
--- a/sched/task/task_fork.c
+++ b/sched/task/task_fork.c
@@ -145,6 +145,19 @@ FAR struct task_tcb_s *nxtask_setup_fork(start_t retaddr)
 
   child->cmn.flags |= TCB_FLAG_FREE_TCB;
 
+#if defined(CONFIG_ARCH_ADDRENV)
+  /* Join the parent address environment (REVISIT: vfork() only) */
+
+  if (ttype != TCB_FLAG_TTYPE_KERNEL)
+    {
+      ret = addrenv_join(parent, &child->cmn);
+      if (ret < 0)
+        {
+          goto errout_with_tcb;
+        }
+    }
+#endif
+
   /* Initialize the task join */
 
   nxtask_joininit(&child->cmn);
@@ -183,6 +196,19 @@ FAR struct task_tcb_s *nxtask_setup_fork(start_t retaddr)
     {
       goto errout_with_tcb;
     }
+
+#if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_ARCH_KERNEL_STACK)
+  /* Allocate the kernel stack */
+
+  if (ttype != TCB_FLAG_TTYPE_KERNEL)
+    {
+      ret = up_addrenv_kstackalloc(&child->cmn);
+      if (ret < 0)
+        {
+          goto errout_with_tcb;
+        }
+    }
+#endif
 
   /* Setup thread local storage */
 


### PR DESCRIPTION
## Summary
Two things need to be done when vfork'ing:
- Must attach to parent's address environment (the addrenv is shared)
- Must allocate a kernel stack (where would the register context go otherwise)

Note that this code assumes the address environment is shared, since we don't support fork() which would _clone_ the address environment instead.

## Impact
Fix vfork() for BUILD_KERNEL
## Testing
rv-virt:knsh64 + ostest pass
