### PR TITLE
k230_start.c: Fix condition for k230_copy_init_data()

### DIFF
--- a/arch/risc-v/src/k230/k230_start.c
+++ b/arch/risc-v/src/k230/k230_start.c
@@ -117,7 +117,8 @@ void k230_start(int mhartid, const char *dtb)
 
 #ifdef CONFIG_RISCV_PERCPU_SCRATCH
       riscv_percpu_add_hart(mhartid);
-#else
+#endif
+#ifndef CONFIG_BUILD_KERNEL
       k230_copy_init_data();
 #endif
     }


### PR DESCRIPTION
## Summary
Fixes regression from https://github.com/apache/nuttx/pull/12220

Error: chip/k230_start.c:80:13: error: 'k230_copy_init_data' defined but not used [-Werror=unused-function]
   80 | static void k230_copy_init_data(void)
      |             ^~~~~~~~~~~~~~~~~~~

## Impact
Fix build error
## Testing
Build passes

Gates merge of: https://github.com/apache/nuttx/pull/12812