### PR TITLE
Issues: Added Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/001_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/001_bug_report.yml
@@ -1,0 +1,147 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name: Bug report
+description: Report a bug to improve NuttX stability
+title: "[BUG] <title>"
+labels: [👀 needs triage, bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Hello NuttX Community member! Please keep things tidy by putting your post in the proper place:
+
+        Reporting a bug: use this form.
+        Asking a question or getting help: use the [General Help](https://github.com/simbit18/nuttx-testing-templates/issues/new?assignees=&labels=question&projects=&template=003_help.yml&title=help%3A+help+title) form or [Mailing list](https://nuttx.apache.org/community/).
+        Requesting a new feature: use the [Feature request](https://github.com/simbit18/nuttx-testing-templates/issues/new?assignees=&labels=enhancement&projects=&template=002_feature_request.yml) form.
+  - type: textarea
+    attributes:
+      label: "Description / Steps to reproduce the issue"
+      description: "A clear and concise description of what the bug is, and why you consider it to be a bug, and steps for how to reproduce it"
+      placeholder: |
+        A description with steps to reproduce the issue.
+        May include logs, images, or videos.
+        1. Step 1
+        2. Step 2
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ### Environment
+        Please specify your environment.
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: On which OS does this issue occur?
+      multiple: true
+      options:
+        - "[Linux]"
+        - "[Mac]"
+        - "[Windows]"
+        - "[Other]"
+    validations:
+      required: true
+
+  - type: input
+    id: os_version
+    attributes:
+      label: What is the version of your OS?
+      description: Please fill out the distro or OS version from the previous dropdown
+      placeholder: "MacOS 14, Ubuntu 23.10, Windows 10/MSYS_NT-10.0-19045, ecc"
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: NuttX Version
+      placeholder: "e.g., master, 12.5.1, ecc"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: architecture
+    attributes:
+      label: Issue Architecture
+      description: What architecture(s) are you seeing the problem on?
+      multiple: true
+      options:
+        - "[all]"
+        - "[arm]"
+        - "[arm64]"
+        - "[avr]"
+        - "[ceva]"
+        - "[hc]"
+        - "[mips]"
+        - "[misoc]"
+        - "[openrisc]"
+        - "[renesas]"
+        - "[risc-v]"
+        - "[simulator]"
+        - "[sparc]"
+        - "[tricore]"
+        - "[x86]"
+        - "[x86_64]"
+        - "[xtensa]"
+        - "[z16]"
+        - "[z80]"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Issue Area
+      description: What area(s) are you seeing the problem on?
+      multiple: true
+      options:
+        - "[Other]"
+        - "[Applications]"
+        - "[Api]"
+        - "[Board support]"
+        - "[Build System]"
+        - "[Configuring]"
+        - "[Debugging]"
+        - "[Drivers]"
+        - "[File System]"
+        - "[Installing]"
+        - "[Kconfig]"
+        - "[Kernel]"
+        - "[Memory Management]"
+        - "[Native port]"
+        - "[Networking]"
+        - "[OS Components]"
+        - "[Posix]"
+        - "[Sensors]"
+        - "[Specific Peripheral]"
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ### Before You Submit
+
+        Please verify that you've followed these steps:
+          - Confirm the problem is reproducible on [**master**](https://github.com/apache/nuttx) or [**latest stable**](https://nuttx.apache.org/download) release.
+          - Run `make distclean` when encountering build issues.
+          - Search [existing issues](https://github.com/apache/nuttx/issues) (including [closed](https://github.com/apache/nuttx/issues?q=is%3Aissue+is%3Aclosed))
+          - Read the [FAQ](https://nuttx.apache.org/docs/latest/faq/index.html).
+
+  - type: checkboxes
+    attributes:
+      label: "Verification"
+      options:
+        - label: "I have verified before submitting the report."
+          required: true

--- a/.github/ISSUE_TEMPLATE/002_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/002_feature_request.yml
@@ -1,0 +1,62 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name: Feature request
+description: Request an enhancement for NuttX
+title: "[FEATURE] <title>"
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Hello NuttX Community member! Please keep things tidy by putting your post in the proper place:
+
+        Requesting a new feature: use this form.
+        Asking a question or getting help: use the [General Help](https://github.com/simbit18/nuttx-testing-templates/issues/new?assignees=&labels=question&projects=&template=003_help.yml&title=help%3A+help+title) form or [Mailing list](https://nuttx.apache.org/community/).
+        Reporting a bug: use the [Bug report](https://github.com/simbit18/nuttx-testing-templates/issues/new?assignees=&labels=bug&projects=&template=001_bug_report.yml) form.
+     
+  - type: textarea
+    id: question-description
+    attributes:
+      label: Is your feature request related to a problem? Please describe.
+      description: Please provide a clear and concise description of what the problem is. Add relevant issue link.
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the solution you'd like
+      description: Please provide a clear and concise description of what you want to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Describe alternatives you've considered
+      description: Please provide a clear and concise description of any alternative solutions or features you've considered.
+
+  - type: markdown
+    attributes:
+      value: |
+        ### Before You Submit
+
+        Please verify that you've followed these steps:
+          - Search [existing feature requests](https://github.com/apache/nuttx/issues) (including [closed](https://github.com/apache/nuttx/issues?q=is%3Aissue+is%3Aclosed))
+
+  - type: checkboxes
+    attributes:
+      label: "Verification"
+      options:
+        - label: "I have verified before submitting the report."
+          required: true

--- a/.github/ISSUE_TEMPLATE/003_help.yml
+++ b/.github/ISSUE_TEMPLATE/003_help.yml
@@ -1,0 +1,54 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name: General Help
+description: Get general support regarding NuttX
+title: "[HELP] <title>"
+labels: [question]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Hello NuttX Community member! Please keep things tidy by putting your post in the proper place:
+
+        Asking a question or getting help: use this form or [Mailing list](https://nuttx.apache.org/community/).
+        Reporting a bug: use the [Bug report](https://github.com/simbit18/nuttx-testing-templates/issues/new?assignees=&labels=bug&projects=&template=001_bug_report.yml) form.
+        Requesting a new feature: use the [Feature request](https://github.com/simbit18/nuttx-testing-templates/issues/new?assignees=&labels=enhancement&projects=&template=002_feature_request.yml) form
+
+  - type: markdown
+    attributes:
+      value: |
+        ### Whether you're a beginner or an experienced developer, NuttX Help is here to assist you with all your NuttX questions and concerns.
+
+  - type: textarea
+    id: question-description
+    attributes:
+      label: Description
+      description: Explain the background or context of your question. This helps others understand your problem or inquiry better.
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ### Before You Submit
+
+        Please verify that you've followed these steps:
+          - I have searched [NuttX Documentation](https://nuttx.apache.org/docs/latest/) and didn't find an answer to my question.
+          - Search [existing issues](https://github.com/apache/nuttx/issues) (including [closed](https://github.com/apache/nuttx/issues?q=is%3Aissue+is%3Aclosed))
+
+  - type: checkboxes
+    attributes:
+      label: "Verification"
+      options:
+        - label: "I have verified before submitting the report."
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/workflows/issue_labeler.yml
+++ b/.github/workflows/issue_labeler.yml
@@ -1,0 +1,50 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name: Issue Labeler
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Add labels issues automatically based on their body.
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.issue.body;
+            const bodySplit = body.split(/\[|\]/).map(e => e.toLowerCase());
+            const oskeywords = ['other', 'linux', 'mac', 'Windows'];
+            const archkeywords1 = ['all', 'arm', 'arm64', 'avr', 'ceva', 'hc', 'mips', 'misoc', 'openrisc', 'renesas'];
+            const archkeywords2 = ['risc-v', 'simulator', 'sparc', 'tricore', 'x86', 'x86_64', 'xtensa', 'z16', 'z80', 'renesas'];
+            const areakeywords1 = ['applications', 'api', 'board support', 'build system', 'configuring', 'debugging', 'drivers', 'file system', 'installing', 'kconfig'];
+            const areakeywords2 = ['kernel', 'memory management', 'native port', 'networking', 'os components', 'posix', 'sensors', 'specific peripheral', 'openrisc', 'renesas'];
+            const keywords = [...oskeywords, ...archkeywords1, ...archkeywords2, ...areakeywords1, ...areakeywords2];
+            var keywordsfound = new Set();
+            for (const keyword of keywords) {
+              if (bodySplit.includes(keyword)) {
+                keywordsfound.add(keyword)
+              }
+            }
+            if (keywordsfound.size !== 0) {
+              github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: Array.from(keywordsfound)
+              })
+            }


### PR DESCRIPTION
## Summary

**-Template**
 Bug report
Report a bug to improve NuttX stability

Feature request
Request an enhancement for NuttX

General Help
Get general support regarding NuttX

Of course, others can be added. !!! :)

**-Action**
An action for automatically labelling issues


 **Keywords**

Keywords are present in the dropdowns (the user can select more than one option) of the form Bug report and are:

    - Linux, Mac, Windows, Other
    - all, arm, arm64, avr, ceva, hc, mips, misoc, openrisc, renesas, risc-v, simulator, sparc, tricore, x86, x86_64, xtensa, z16, z80
    - Applications, Api, Board support, Build System, Configuring, Debugging, Drivers, File System, Installing, Kconfig, Kernel, Memory Management, Native port, Networking, OS Components, Posix, Sensors, Specific Peripheral


**To work, the labels must have the same name as the keywords !!!**

**So before the merge it is necessary to add them.**

Of course these keywords are examples so you can add, edit or delete them.

[Creating a label](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#creating-a-label)

see https://github.com/apache/nuttx/issues/12748

## Impact
none
## Testing
CI