### PR TITLE
riscv/common: add missing header to riscv_cpustart.c

### DIFF
--- a/arch/risc-v/src/common/riscv_cpustart.c
+++ b/arch/risc-v/src/common/riscv_cpustart.c
@@ -39,7 +39,10 @@
 #include "init/init.h"
 #include "riscv_internal.h"
 #include "riscv_ipi.h"
+
+#ifdef CONFIG_RISCV_PERCPU_SCRATCH
 #include "riscv_percpu.h"
+#endif
 
 #ifdef CONFIG_BUILD_KERNEL
 #  include "riscv_mmu.h"


### PR DESCRIPTION
## Summary

This adds missing header to riscv_cpustart.c to unblock pull#12812

## Impacts

unblock pull#12812

## Testing

- local check with maix-bit:knsh_smp
- CI checkings
