### PR TITLE
driver/ssd1680: Add support for 1.54 inch e-paper display

### DIFF
--- a/drivers/lcd/Kconfig
+++ b/drivers/lcd/Kconfig
@@ -1645,11 +1645,11 @@ config LCD_FT80X_AUDIO_GPIO
 endif # LCD_FT80X
 
 config LCD_SSD1680
-	bool "SSD1680 E-PAPER Single Chip Driver"
+	bool "SSD1680/SSD1681 E-PAPER Single Chip Driver"
 	default n
 	select SPI_CMDDATA
 	---help---
-		e-paper Display Module based on SSD1680 controller.
+		e-paper Display Module based on SSD1680/SSD1681 controller.
 
 		Required SPI driver settings:
 		SPI_CMDDATA - Include support for cmd/data selection.
@@ -1671,6 +1671,11 @@ config LCD_SSD1680_2_90
 
 config LCD_SSD1680_2_90_RED
 	bool "2.9 inch 128/296 tri color (red)"
+
+config LCD_SSD1681_1_54
+	bool "1.54 inch 200/200 mono"
+	---help---
+		1.54 inch 200x200 e-paper display module based on SSD1681 controller.
 
 endchoice # Display size
 

--- a/drivers/lcd/ssd1680.h
+++ b/drivers/lcd/ssd1680.h
@@ -41,7 +41,8 @@
 
 /* Limitations of the current configuration that I hope to fix someday */
 
-#if !defined(CONFIG_LCD_SSD1680_2_13_V2) && !defined(CONFIG_LCD_SSD1680_2_90)
+#if !defined(CONFIG_LCD_SSD1680_2_13_V2) &&                                 \
+    !defined(CONFIG_LCD_SSD1680_2_90) && !defined(CONFIG_LCD_SSD1681_1_54)
 #  error "Unknown and unsupported SSD16800 LCD"
 #endif
 
@@ -119,16 +120,21 @@
 #  define SSD1680_VALUE_VCOM          0x55
 #  define SSD1680_VALUE_DUMMY_LINE    0x30
 #  define SSD1680_VALUE_GATE_TIME     0x0A
+#  define SSD1680_VALUE_UPDATE_CTRL   0xC7
 #elif defined(CONFIG_LCD_SSD1680_2_90) || defined(CONFIG_LCD_SSD1680_2_90_RED)
 #  define SSD1680_VALUE_VCOM          0xA8
 #  define SSD1680_VALUE_DUMMY_LINE    0x1A
 #  define SSD1680_VALUE_GATE_TIME     0x08
+#  define SSD1680_VALUE_UPDATE_CTRL   0xC7
+#elif defined(CONFIG_LCD_SSD1681_1_54)
+#  define SSD1680_VALUE_UPDATE_CTRL   0xF7
 #else
 #  error "Not supported display"
 #endif
 
 /* Color Properties *********************************************************/
-#if defined(CONFIG_LCD_SSD1680_2_13_V2) || defined(CONFIG_LCD_SSD1680_2_90)
+#if defined(CONFIG_LCD_SSD1680_2_13_V2) ||                                  \
+    defined(CONFIG_LCD_SSD1680_2_90) || defined(CONFIG_LCD_SSD1681_1_54)
 /* 1 bit per pixel */
 #  define SSD1680_DEV_COLORFMT  FB_FMT_Y1
 #  define SSD1680_DEV_BPP       1
@@ -169,6 +175,10 @@
 #  define SSD1680_DEV_GATE_LAYOUT 0x00
 #  define SSD1680_DEV_NATIVE_XRES 128
 #  define SSD1680_DEV_NATIVE_YRES 296
+#elif defined(CONFIG_LCD_SSD1681_1_54)
+#  define SSD1680_DEV_GATE_LAYOUT 0x01
+#  define SSD1680_DEV_NATIVE_XRES 200
+#  define SSD1680_DEV_NATIVE_YRES 200
 #else
 #  error "Unknown resolution"
 #endif


### PR DESCRIPTION


## Summary
Add configuration and driver support for the SSD1681 1.54 inch e-paper display, including the necessary waveforms and settings for proper operation. This extends the existing SSD1680 e-paper driver to accommodate the new display module.

The changes involve updates to the Kconfig file for additional configuration options, modifications to the driver implementation in ssd1680.c to include SSD1681 specific logic, and updates to the header file ssd1680.h to reflect the added support.
## Impact
New feature
## Testing
Custom board
