### PR TITLE
spinlock: inline no trace implement to remove duplicate logic

### DIFF
--- a/arch/x86_64/src/intel64/intel64_cpu.c
+++ b/arch/x86_64/src/intel64/intel64_cpu.c
@@ -311,7 +311,9 @@ uint8_t x86_64_cpu_to_loapic(uint8_t cpu)
 
 void x86_64_cpu_ready_set(uint8_t cpu)
 {
-  spin_lock(&g_ap_boot);
+  irqstate_t flags;
+
+  flags = spin_lock_irqsave(&g_ap_boot);
 
   if (!g_cpu_priv[cpu].ready)
     {
@@ -319,7 +321,7 @@ void x86_64_cpu_ready_set(uint8_t cpu)
       g_cpu_count++;
     }
 
-  spin_unlock(&g_ap_boot);
+  spin_unlock_irqrestore(&g_ap_boot, flags);
 }
 
 /****************************************************************************
@@ -333,11 +335,12 @@ void x86_64_cpu_ready_set(uint8_t cpu)
 bool x86_64_cpu_ready_get(uint8_t cpu)
 {
   struct intel64_cpu_s *priv  = &g_cpu_priv[cpu];
+  irqstate_t flags;
   bool ready;
 
-  spin_lock(&g_ap_boot);
+  flags = spin_lock_irqsave(&g_ap_boot);
   ready = priv->ready;
-  spin_unlock(&g_ap_boot);
+  spin_unlock_irqrestore(&g_ap_boot, flags);
 
   return ready;
 }
@@ -352,11 +355,12 @@ bool x86_64_cpu_ready_get(uint8_t cpu)
 
 uint8_t x86_64_cpu_count_get(void)
 {
+  irqstate_t flags;
   uint8_t count;
 
-  spin_lock(&g_ap_boot);
+  flags = spin_lock_irqsave(&g_ap_boot);
   count = g_cpu_count;
-  spin_unlock(&g_ap_boot);
+  spin_unlock_irqrestore(&g_ap_boot, flags);
 
   return count;
 }

--- a/arch/x86_64/src/intel64/intel64_irq.c
+++ b/arch/x86_64/src/intel64/intel64_irq.c
@@ -75,7 +75,7 @@ static inline void up_idtinit(void);
 
 static struct idt_entry_s        g_idt_entries[NR_IRQS];
 static struct intel64_irq_priv_s g_irq_priv[NR_IRQS];
-static spinlock_t                g_irq_spin;
+static spinlock_t                g_irq_spinlock;
 
 /****************************************************************************
  * Private Functions
@@ -482,7 +482,7 @@ void up_irqinitialize(void)
 void up_disable_irq(int irq)
 {
 #ifndef CONFIG_ARCH_INTEL64_DISABLE_INT_INIT
-  irqstate_t flags = spin_lock_irqsave(&g_irq_spin);
+  irqstate_t flags = spin_lock_irqsave(&g_irq_spinlock);
 
   if (irq > IRQ255)
     {
@@ -508,7 +508,7 @@ void up_disable_irq(int irq)
         }
     }
 
-  spin_unlock_irqrestore(&g_irq_spin, flags);
+  spin_unlock_irqrestore(&g_irq_spinlock, flags);
 #endif
 }
 
@@ -523,7 +523,7 @@ void up_disable_irq(int irq)
 void up_enable_irq(int irq)
 {
 #ifndef CONFIG_ARCH_INTEL64_DISABLE_INT_INIT
-  irqstate_t flags = spin_lock_irqsave(&g_irq_spin);
+  irqstate_t flags = spin_lock_irqsave(&g_irq_spinlock);
 
 #  ifndef CONFIG_IRQCHAIN
   /* Check if IRQ is free if we don't support IRQ chains */
@@ -553,7 +553,7 @@ void up_enable_irq(int irq)
 
   CPU_SET(up_cpu_index(), &g_irq_priv[irq].busy);
 
-  spin_unlock_irqrestore(&g_irq_spin, flags);
+  spin_unlock_irqrestore(&g_irq_spinlock, flags);
 #endif
 }
 

--- a/include/nuttx/spinlock.h
+++ b/include/nuttx/spinlock.h
@@ -589,7 +589,7 @@ irqstate_t spin_lock_irqsave_wo_note(FAR spinlock_t *lock);
 #if defined(CONFIG_SPINLOCK)
 void spin_unlock_irqrestore(FAR spinlock_t *lock, irqstate_t flags);
 #else
-#  define spin_unlock_irqrestore(l, f) up_irq_restore(f)
+#  define spin_unlock_irqrestore(l, f) ((void)(l), up_irq_restore(f))
 #endif
 
 /****************************************************************************
@@ -599,7 +599,7 @@ void spin_unlock_irqrestore(FAR spinlock_t *lock, irqstate_t flags);
 #if defined(CONFIG_SPINLOCK)
 void spin_unlock_irqrestore_wo_note(FAR spinlock_t *lock, irqstate_t flags);
 #else
-#  define spin_unlock_irqrestore_wo_note(l, f) up_irq_restore(f)
+#  define spin_unlock_irqrestore_wo_note(l, f) ((void)(l), up_irq_restore(f))
 #endif
 
 #if defined(CONFIG_RW_SPINLOCK)
@@ -914,7 +914,7 @@ irqstate_t read_lock_irqsave(FAR rwlock_t *lock);
 #if defined(CONFIG_SPINLOCK)
 void read_unlock_irqrestore(FAR rwlock_t *lock, irqstate_t flags);
 #else
-#  define read_unlock_irqrestore(l, f) up_irq_restore(f)
+#  define read_unlock_irqrestore(l, f) ((void)(l), up_irq_restore(f))
 #endif
 
 /****************************************************************************
@@ -988,7 +988,7 @@ irqstate_t write_lock_irqsave(FAR rwlock_t *lock);
 #if defined(CONFIG_SPINLOCK)
 void write_unlock_irqrestore(FAR rwlock_t *lock, irqstate_t flags);
 #else
-#  define write_unlock_irqrestore(l, f) up_irq_restore(f)
+#  define write_unlock_irqrestore(l, f) ((void)(l), up_irq_restore(f))
 #endif
 
 #endif /* CONFIG_RW_SPINLOCK */

--- a/include/nuttx/spinlock.h
+++ b/include/nuttx/spinlock.h
@@ -156,7 +156,7 @@ void sched_note_spinlock_unlock(FAR volatile spinlock_t *spinlock);
 #  define sched_note_spinlock_lock(spinlock)
 #  define sched_note_spinlock_locked(spinlock)
 #  define sched_note_spinlock_abort(spinlock)
-#  define sched_note_spinlock_unlocked(spinlock)
+#  define sched_note_spinlock_unlock(spinlock)
 #endif
 
 /****************************************************************************

--- a/include/nuttx/spinlock.h
+++ b/include/nuttx/spinlock.h
@@ -256,6 +256,7 @@ static inline spinlock_t up_testset(FAR volatile spinlock_t *lock)
  *
  ****************************************************************************/
 
+#ifdef CONFIG_SPINLOCK
 static inline_function void spin_lock_wo_note(FAR volatile spinlock_t *lock)
 {
 #ifdef CONFIG_TICKET_SPINLOCK
@@ -272,6 +273,7 @@ static inline_function void spin_lock_wo_note(FAR volatile spinlock_t *lock)
 
   SP_DMB();
 }
+#endif /* CONFIG_SPINLOCK */
 
 /****************************************************************************
  * Name: spin_lock
@@ -296,6 +298,7 @@ static inline_function void spin_lock_wo_note(FAR volatile spinlock_t *lock)
  *
  ****************************************************************************/
 
+#ifdef CONFIG_SPINLOCK
 static inline_function void spin_lock(FAR volatile spinlock_t *lock)
 {
   /* Notify that we are waiting for a spinlock */
@@ -310,6 +313,7 @@ static inline_function void spin_lock(FAR volatile spinlock_t *lock)
 
   sched_note_spinlock_locked(lock);
 }
+#endif /* CONFIG_SPINLOCK */
 
 /****************************************************************************
  * Name: spin_trylock_wo_note
@@ -333,6 +337,7 @@ static inline_function void spin_lock(FAR volatile spinlock_t *lock)
  *
  ****************************************************************************/
 
+#ifdef CONFIG_SPINLOCK
 static inline_function bool
 spin_trylock_wo_note(FAR volatile spinlock_t *lock)
 {
@@ -367,6 +372,7 @@ spin_trylock_wo_note(FAR volatile spinlock_t *lock)
   SP_DMB();
   return true;
 }
+#endif /* CONFIG_SPINLOCK */
 
 /****************************************************************************
  * Name: spin_trylock
@@ -387,6 +393,7 @@ spin_trylock_wo_note(FAR volatile spinlock_t *lock)
  *
  ****************************************************************************/
 
+#ifdef CONFIG_SPINLOCK
 static inline_function bool spin_trylock(FAR volatile spinlock_t *lock)
 {
   bool locked;
@@ -413,6 +420,7 @@ static inline_function bool spin_trylock(FAR volatile spinlock_t *lock)
 
   return locked;
 }
+#endif /* CONFIG_SPINLOCK */
 
 /****************************************************************************
  * Name: spin_unlock_wo_note
@@ -434,6 +442,7 @@ static inline_function bool spin_trylock(FAR volatile spinlock_t *lock)
  *
  ****************************************************************************/
 
+#ifdef CONFIG_SPINLOCK
 static inline_function void
 spin_unlock_wo_note(FAR volatile spinlock_t *lock)
 {
@@ -446,6 +455,7 @@ spin_unlock_wo_note(FAR volatile spinlock_t *lock)
   SP_DSB();
   SP_SEV();
 }
+#endif /* CONFIG_SPINLOCK */
 
 /****************************************************************************
  * Name: spin_unlock
@@ -464,7 +474,8 @@ spin_unlock_wo_note(FAR volatile spinlock_t *lock)
  *
  ****************************************************************************/
 
-#ifdef __SP_UNLOCK_FUNCTION
+#ifdef CONFIG_SPINLOCK
+#  ifdef __SP_UNLOCK_FUNCTION
 static inline_function void spin_unlock(FAR volatile spinlock_t *lock)
 {
   /* Unlock without trace note */
@@ -475,9 +486,10 @@ static inline_function void spin_unlock(FAR volatile spinlock_t *lock)
 
   sched_note_spinlock_unlock(lock);
 }
-#else
-#  define spin_unlock(l)  do { *(l) = SP_UNLOCKED; } while (0)
-#endif
+#  else
+#    define spin_unlock(l)  do { *(l) = SP_UNLOCKED; } while (0)
+#  endif
+#endif /* CONFIG_SPINLOCK */
 
 /****************************************************************************
  * Name: spin_is_locked
@@ -528,7 +540,7 @@ static inline_function void spin_unlock(FAR volatile spinlock_t *lock)
  *
  ****************************************************************************/
 
-#if defined(CONFIG_SPINLOCK)
+#ifdef CONFIG_SPINLOCK
 static inline_function
 irqstate_t spin_lock_irqsave_wo_note(FAR volatile spinlock_t *lock)
 {
@@ -590,7 +602,7 @@ irqstate_t spin_lock_irqsave_wo_note(FAR volatile spinlock_t *lock)
  *
  ****************************************************************************/
 
-#if defined(CONFIG_SPINLOCK)
+#ifdef CONFIG_SPINLOCK
 static inline_function
 irqstate_t spin_lock_irqsave(FAR volatile spinlock_t *lock)
 {
@@ -622,7 +634,7 @@ irqstate_t spin_lock_irqsave(FAR volatile spinlock_t *lock)
  *
  ****************************************************************************/
 
-#if defined(CONFIG_SPINLOCK)
+#ifdef CONFIG_SPINLOCK
 static inline_function
 void spin_unlock_irqrestore_wo_note(FAR volatile spinlock_t *lock,
                                     irqstate_t flags)
@@ -678,7 +690,7 @@ void spin_unlock_irqrestore_wo_note(FAR volatile spinlock_t *lock,
  *
  ****************************************************************************/
 
-#if defined(CONFIG_SPINLOCK)
+#ifdef CONFIG_SPINLOCK
 static inline_function
 void spin_unlock_irqrestore(FAR volatile spinlock_t *lock,
                             irqstate_t flags)
@@ -971,7 +983,7 @@ static inline_function void write_unlock(FAR volatile rwlock_t *lock)
  *
  ****************************************************************************/
 
-#if defined(CONFIG_SPINLOCK)
+#ifdef CONFIG_SPINLOCK
 irqstate_t read_lock_irqsave(FAR rwlock_t *lock);
 #else
 #  define read_lock_irqsave(l) ((void)(l), up_irq_save())
@@ -1004,7 +1016,7 @@ irqstate_t read_lock_irqsave(FAR rwlock_t *lock);
  *
  ****************************************************************************/
 
-#if defined(CONFIG_SPINLOCK)
+#ifdef CONFIG_SPINLOCK
 void read_unlock_irqrestore(FAR rwlock_t *lock, irqstate_t flags);
 #else
 #  define read_unlock_irqrestore(l, f) ((void)(l), up_irq_restore(f))
@@ -1043,7 +1055,7 @@ void read_unlock_irqrestore(FAR rwlock_t *lock, irqstate_t flags);
  *
  ****************************************************************************/
 
-#if defined(CONFIG_SPINLOCK)
+#ifdef CONFIG_SPINLOCK
 irqstate_t write_lock_irqsave(FAR rwlock_t *lock);
 #else
 #  define write_lock_irqsave(l) ((void)(l), up_irq_save())
@@ -1078,7 +1090,7 @@ irqstate_t write_lock_irqsave(FAR rwlock_t *lock);
  *
  ****************************************************************************/
 
-#if defined(CONFIG_SPINLOCK)
+#ifdef CONFIG_SPINLOCK
 void write_unlock_irqrestore(FAR rwlock_t *lock, irqstate_t flags);
 #else
 #  define write_unlock_irqrestore(l, f) ((void)(l), up_irq_restore(f))

--- a/sched/irq/irq_spinlock.c
+++ b/sched/irq/irq_spinlock.c
@@ -39,11 +39,11 @@
 
 /* Used for access control */
 
-static volatile spinlock_t g_irq_spin = SP_UNLOCKED;
+volatile spinlock_t g_irq_spin = SP_UNLOCKED;
 
 /* Handles nested calls to spin_lock_irqsave and spin_unlock_irqrestore */
 
-static volatile uint8_t g_irq_spin_count[CONFIG_SMP_NCPUS];
+volatile uint8_t g_irq_spin_count[CONFIG_SMP_NCPUS];
 
 #ifdef CONFIG_RW_SPINLOCK
 /* Used for access control */
@@ -59,166 +59,6 @@ static volatile uint8_t g_irq_rwspin_count[CONFIG_SMP_NCPUS];
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
-
-/****************************************************************************
- * Name: spin_lock_irqsave
- *
- * Description:
- *   If SMP is enabled:
- *     If the argument lock is not specified (i.e. NULL),
- *     disable local interrupts and take the global spinlock (g_irq_spin)
- *     if the call counter (g_irq_spin_count[cpu]) equals to 0. Then the
- *     counter on the CPU is incremented to allow nested call and return
- *     the interrupt state.
- *
- *     If the argument lock is specified,
- *     disable local interrupts and take the given lock and return the
- *     interrupt state.
- *
- *     NOTE: This API is very simple to protect data (e.g. H/W register
- *     or internal data structure) in SMP mode. But do not use this API
- *     with kernel APIs which suspend a caller thread. (e.g. nxsem_wait)
- *
- *   If SMP is not enabled:
- *     This function is equivalent to up_irq_save().
- *
- * Input Parameters:
- *   lock - Caller specific spinlock. If specified NULL, g_irq_spin is used
- *          and can be nested. Otherwise, nested call for the same lock
- *          would cause a deadlock
- *
- * Returned Value:
- *   An opaque, architecture-specific value that represents the state of
- *   the interrupts prior to the call to spin_lock_irqsave(lock);
- *
- ****************************************************************************/
-
-irqstate_t spin_lock_irqsave(spinlock_t *lock)
-{
-  irqstate_t ret;
-  ret = up_irq_save();
-
-  if (NULL == lock)
-    {
-      int me = up_cpu_index();
-      if (0 == g_irq_spin_count[me])
-        {
-          spin_lock(&g_irq_spin);
-        }
-
-      g_irq_spin_count[me]++;
-      DEBUGASSERT(0 != g_irq_spin_count[me]);
-    }
-  else
-    {
-      spin_lock(lock);
-    }
-
-  return ret;
-}
-
-/****************************************************************************
- * Name: spin_lock_irqsave_wo_note
- ****************************************************************************/
-
-irqstate_t spin_lock_irqsave_wo_note(spinlock_t *lock)
-{
-  irqstate_t ret;
-  ret = up_irq_save();
-
-  if (NULL == lock)
-    {
-      int me = up_cpu_index();
-      if (0 == g_irq_spin_count[me])
-        {
-          spin_lock_wo_note(&g_irq_spin);
-        }
-
-      g_irq_spin_count[me]++;
-      DEBUGASSERT(0 != g_irq_spin_count[me]);
-    }
-  else
-    {
-      spin_lock_wo_note(lock);
-    }
-
-  return ret;
-}
-
-/****************************************************************************
- * Name: spin_unlock_irqrestore
- *
- * Description:
- *   If SMP is enabled:
- *     If the argument lock is not specified (i.e. NULL),
- *     decrement the call counter (g_irq_spin_count[cpu]) and if it
- *     decrements to zero then release the spinlock (g_irq_spin) and
- *     restore the interrupt state as it was prior to the previous call to
- *     spin_lock_irqsave(NULL).
- *
- *     If the argument lock is specified, release the lock and restore
- *     the interrupt state as it was prior to the previous call to
- *     spin_lock_irqsave(lock).
- *
- *   If SMP is not enabled:
- *     This function is equivalent to up_irq_restore().
- *
- * Input Parameters:
- *   lock - Caller specific spinlock. If specified NULL, g_irq_spin is used.
- *
- *   flags - The architecture-specific value that represents the state of
- *           the interrupts prior to the call to spin_lock_irqsave(lock);
- *
- * Returned Value:
- *   None
- *
- ****************************************************************************/
-
-void spin_unlock_irqrestore(spinlock_t *lock, irqstate_t flags)
-{
-  if (NULL == lock)
-    {
-      int me = up_cpu_index();
-      DEBUGASSERT(0 < g_irq_spin_count[me]);
-      g_irq_spin_count[me]--;
-
-      if (0 == g_irq_spin_count[me])
-        {
-          spin_unlock(&g_irq_spin);
-        }
-    }
-  else
-    {
-      spin_unlock(lock);
-    }
-
-  up_irq_restore(flags);
-}
-
-/****************************************************************************
- * Name: spin_unlock_irqrestore_wo_note
- ****************************************************************************/
-
-void spin_unlock_irqrestore_wo_note(spinlock_t *lock, irqstate_t flags)
-{
-  if (NULL == lock)
-    {
-      int me = up_cpu_index();
-      DEBUGASSERT(0 < g_irq_spin_count[me]);
-      g_irq_spin_count[me]--;
-
-      if (0 == g_irq_spin_count[me])
-        {
-          spin_unlock_wo_note(&g_irq_spin);
-        }
-    }
-  else
-    {
-      spin_unlock_wo_note(lock);
-    }
-
-  up_irq_restore(flags);
-}
 
 #ifdef CONFIG_RW_SPINLOCK
 

--- a/sched/irq/irq_spinlock.c
+++ b/sched/irq/irq_spinlock.c
@@ -196,7 +196,7 @@ void spin_unlock_irqrestore(spinlock_t *lock, irqstate_t flags)
 }
 
 /****************************************************************************
- * Name: spin_lock_irqsave_wo_note
+ * Name: spin_unlock_irqrestore_wo_note
  ****************************************************************************/
 
 void spin_unlock_irqrestore_wo_note(spinlock_t *lock, irqstate_t flags)


### PR DESCRIPTION
## Summary

1. spinlock: inline no trace implement to remove duplicate logic

minor changes to remove duplicate logic

2. splinlock: fix typo of sched_note_spinlock_unlock()

should be sched_note_spinlock_unlock() not sched_note_spinlock_unlocked()

3. spinlock: inline irqsaved spinlock
Reference pull request: https://github.com/apache/nuttx/pull/12599

4. spinlock: compile spinlock only if CONFIG_SPINLOCK is enabled
Regression by: https://github.com/apache/nuttx/pull/12599

Signed-off-by: chao an <anchao@lixiang.com>

## Impact

N/A

## Testing

ci-check