### PR TITLE
tools/[Rust|D]: Fix build break for RISC-V

### DIFF
--- a/tools/D.defs
+++ b/tools/D.defs
@@ -47,7 +47,25 @@ ifeq ($(CONFIG_ARCH_SIM),y)
   endif
 else ifeq ($(CONFIG_ARCH_RISCV),y)
   # Traget triple is riscv[32|64][isa]-unknown-none-elf
-  DFLAGS += -mtriple=$(LLVM_ARCHTYPE)$(ARCHRVISAM)$(ARCHRVISAA)$(ARCHRVISAF)$(ARCHRVISAD)$(ARCHRVISAC)-unknown-none-elf
+
+  D_ARCHTYPE = $(LLVM_ARCHTYPE)i
+  ifeq ($(CONFIG_ARCH_RV_ISA_M),y)
+    D_ARCHTYPE := $(D_ARCHTYPE)m
+  endif
+  ifeq ($(CONFIG_ARCH_RV_ISA_A),y)
+    D_ARCHTYPE := $(D_ARCHTYPE)a
+  endif
+  ifeq ($(CONFIG_ARCH_RV_ISA_F),y)
+    D_ARCHTYPE := $(D_ARCHTYPE)f
+  endif
+  ifeq ($(CONFIG_ARCH_RV_ISA_D),y)
+    D_ARCHTYPE := $(D_ARCHTYPE)d
+  endif
+  ifeq ($(CONFIG_ARCH_RV_ISA_C),y)
+    D_ARCHTYPE := $(D_ARCHTYPE)c
+  endif
+
+  DFLAGS += -mtriple=$(D_ARCHTYPE)-unknown-none-elf
   DFLAGS += -mattr=+m,+a,+f,+d,+c -mabi=ilp32d
   DFLAGS += -mcpu=generic-rv32
 else

--- a/tools/Rust.defs
+++ b/tools/Rust.defs
@@ -46,7 +46,25 @@ ifeq ($(CONFIG_ARCH_SIM),y)
   endif
 else ifeq ($(CONFIG_ARCH_RISCV),y)
   # Traget triple is riscv[32|64][isa]-unknown-none-elf
-  RUSTFLAGS += --target $(LLVM_ARCHTYPE)i$(ARCHRVISAM)$(ARCHRVISAA)$(ARCHRVISAF)$(ARCHRVISAD)$(ARCHRVISAC)-unknown-none-elf
+
+  RUST_ARCHTYPE = $(LLVM_ARCHTYPE)i
+  ifeq ($(CONFIG_ARCH_RV_ISA_M),y)
+    RUST_ARCHTYPE := $(RUST_ARCHTYPE)m
+  endif
+  ifeq ($(CONFIG_ARCH_RV_ISA_A),y)
+    RUST_ARCHTYPE := $(RUST_ARCHTYPE)a
+  endif
+  ifeq ($(CONFIG_ARCH_RV_ISA_F),y)
+    RUST_ARCHTYPE := $(RUST_ARCHTYPE)f
+  endif
+  ifeq ($(CONFIG_ARCH_RV_ISA_D),y)
+    RUST_ARCHTYPE := $(RUST_ARCHTYPE)d
+  endif
+  ifeq ($(CONFIG_ARCH_RV_ISA_C),y)
+    RUST_ARCHTYPE := $(RUST_ARCHTYPE)c
+  endif
+
+  RUSTFLAGS += --target $(RUST_ARCHTYPE)-unknown-none-elf
 else
   # For arm, but there are some other archs not support yet,
   # such as xtensa, x86 bare metal, etc.


### PR DESCRIPTION
## Summary
Rust/D support for RISC-V is broken after https://github.com/apache/nuttx/pull/11549,
since the target triple is quite different bewteen Rust/D toolchain and GCC,
only few RISC-V targets are supported by Rust toolchain now, so it's better to
construct target triple in Rust.defs/D.defs for RISC-V.
## Impact
Minor
## Testing
Local machine
