### PR TITLE
riscv/nsbi: fix up_udelay for rv32

### DIFF
--- a/arch/risc-v/src/common/supervisor/riscv_sbi.c
+++ b/arch/risc-v/src/common/supervisor/riscv_sbi.c
@@ -111,7 +111,11 @@ uint64_t riscv_sbi_get_time(void)
   sbiret_t ret = sbi_ecall(SBI_EXT_FIRMWARE, SBI_EXT_FIRMWARE_GET_MTIME,
                            0, 0, 0, 0, 0, 0);
 
+#  ifdef CONFIG_ARCH_RV64
   return ret.error;
+#  else
+  return (((uint64_t)ret.value << 32) | ret.error);
+#  endif
 #elif defined(CONFIG_ARCH_RV64)
   return READ_CSR(CSR_TIME);
 #else


### PR DESCRIPTION
## Summary

Fixes RV32 `riscv_sbi_get_time()` when NuttSBI is used.

## Impact

rv32 up_udelay when NuttSBI is used

## Testing

- local checks with rv-virt:nsbi
- CI checks
