### PR TITLE
Fix the inline asm code build error with greenhills compiler

### DIFF
--- a/arch/arm/include/syscall.h
+++ b/arch/arm/include/syscall.h
@@ -136,6 +136,18 @@
 
 static inline uintptr_t sys_call0(unsigned int nbr)
 {
+#ifdef __ghs__
+  register long reg0 = (long)(nbr);
+
+  __asm__ __volatile__
+  (
+    "mov r0, %2\n\t"
+    "svc %1"
+    : "=r"(reg0)
+    : "i"(SYS_syscall), "r"(reg0)
+    : "memory", "r14", "r0"
+  );
+#else
   register long reg0 __asm__("r0") = (long)(nbr);
 
   __asm__ __volatile__
@@ -145,6 +157,7 @@ static inline uintptr_t sys_call0(unsigned int nbr)
     : "i"(SYS_syscall), "r"(reg0)
     : "memory", "r14"
   );
+#endif
 
   return reg0;
 }
@@ -153,6 +166,20 @@ static inline uintptr_t sys_call0(unsigned int nbr)
 
 static inline uintptr_t sys_call1(unsigned int nbr, uintptr_t parm1)
 {
+#ifdef __ghs__
+  register long reg0 = (long)(nbr);
+  register long reg1 = (long)(parm1);
+
+  __asm__ __volatile__
+  (
+    "mov r0, %2\n\t"
+    "mov r1, %3\n\t"
+    "svc %1"
+    : "=r"(reg0)
+    : "i"(SYS_syscall), "r"(reg0), "r"(reg1)
+    : "memory", "r14", "r0", "r1"
+  );
+#else
   register long reg0 __asm__("r0") = (long)(nbr);
   register long reg1 __asm__("r1") = (long)(parm1);
 
@@ -163,6 +190,7 @@ static inline uintptr_t sys_call1(unsigned int nbr, uintptr_t parm1)
     : "i"(SYS_syscall), "r"(reg0), "r"(reg1)
     : "memory", "r14"
   );
+#endif
 
   return reg0;
 }
@@ -172,6 +200,22 @@ static inline uintptr_t sys_call1(unsigned int nbr, uintptr_t parm1)
 static inline uintptr_t sys_call2(unsigned int nbr, uintptr_t parm1,
                                   uintptr_t parm2)
 {
+#ifdef __ghs__
+  register long reg0 = (long)nbr;
+  register long reg2 = (long)parm2;
+  register long reg1 = (long)parm1;
+
+  __asm__ __volatile__
+  (
+    "mov r0, %2\n\t"
+    "mov r1, %3\n\t"
+    "mov r2, %4\n\t"
+    "svc %1"
+    : "=r"(reg0)
+    : "i"(SYS_syscall), "r"(reg0), "r"(reg1), "r"(reg2)
+    : "memory", "r14", "r0", "r1", "r2"
+  );
+#else
   register long reg0 __asm__("r0") = (long)(nbr);
   register long reg2 __asm__("r2") = (long)(parm2);
   register long reg1 __asm__("r1") = (long)(parm1);
@@ -183,6 +227,7 @@ static inline uintptr_t sys_call2(unsigned int nbr, uintptr_t parm1,
     : "i"(SYS_syscall), "r"(reg0), "r"(reg1), "r"(reg2)
     : "memory", "r14"
   );
+#endif
 
   return reg0;
 }
@@ -192,6 +237,24 @@ static inline uintptr_t sys_call2(unsigned int nbr, uintptr_t parm1,
 static inline uintptr_t sys_call3(unsigned int nbr, uintptr_t parm1,
                                   uintptr_t parm2, uintptr_t parm3)
 {
+#ifdef __ghs__
+  register long reg0 = (long)(nbr);
+  register long reg3 = (long)(parm3);
+  register long reg2 = (long)(parm2);
+  register long reg1 = (long)(parm1);
+
+  __asm__ __volatile__
+  (
+    "mov r0, %2\n\t"
+    "mov r1, %3\n\t"
+    "mov r2, %4\n\t"
+    "mov r3, %5\n\t"
+    "svc %1"
+    : "=r"(reg0)
+    : "i"(SYS_syscall), "r"(reg0), "r"(reg1), "r"(reg2), "r"(reg3)
+    : "memory", "r14", "r0", "r1", "r2", "r3"
+  );
+#else
   register long reg0 __asm__("r0") = (long)(nbr);
   register long reg3 __asm__("r3") = (long)(parm3);
   register long reg2 __asm__("r2") = (long)(parm2);
@@ -204,6 +267,7 @@ static inline uintptr_t sys_call3(unsigned int nbr, uintptr_t parm1,
     : "i"(SYS_syscall), "r"(reg0), "r"(reg1), "r"(reg2), "r"(reg3)
     : "memory", "r14"
   );
+#endif
 
   return reg0;
 }
@@ -214,6 +278,27 @@ static inline uintptr_t sys_call4(unsigned int nbr, uintptr_t parm1,
                                   uintptr_t parm2, uintptr_t parm3,
                                   uintptr_t parm4)
 {
+#ifdef __ghs__
+  register long reg0 = (long)(nbr);
+  register long reg4 = (long)(parm4);
+  register long reg3 = (long)(parm3);
+  register long reg2 = (long)(parm2);
+  register long reg1 = (long)(parm1);
+
+  __asm__ __volatile__
+  (
+    "mov r0, %2\n\t"
+    "mov r1, %3\n\t"
+    "mov r2, %4\n\t"
+    "mov r3, %5\n\t"
+    "mov r4, %6\n\t"
+    "svc %1"
+    : "=r"(reg0)
+    : "i"(SYS_syscall), "r"(reg0), "r"(reg1), "r"(reg2),
+      "r"(reg3), "r"(reg4)
+    : "memory", "r14", "r0", "r1", "r2", "r3", "r4"
+  );
+#else
   register long reg0 __asm__("r0") = (long)(nbr);
   register long reg4 __asm__("r4") = (long)(parm4);
   register long reg3 __asm__("r3") = (long)(parm3);
@@ -228,6 +313,7 @@ static inline uintptr_t sys_call4(unsigned int nbr, uintptr_t parm1,
       "r"(reg3), "r"(reg4)
     : "memory", "r14"
   );
+#endif
 
   return reg0;
 }
@@ -238,6 +324,29 @@ static inline uintptr_t sys_call5(unsigned int nbr, uintptr_t parm1,
                                   uintptr_t parm2, uintptr_t parm3,
                                   uintptr_t parm4, uintptr_t parm5)
 {
+#ifdef __ghs__
+  register long reg0 = (long)(nbr);
+  register long reg5 = (long)(parm5);
+  register long reg4 = (long)(parm4);
+  register long reg3 = (long)(parm3);
+  register long reg2 = (long)(parm2);
+  register long reg1 = (long)(parm1);
+
+  __asm__ __volatile__
+  (
+    "mov r0, %2\n\t"
+    "mov r1, %3\n\t"
+    "mov r2, %4\n\t"
+    "mov r3, %5\n\t"
+    "mov r4, %6\n\t"
+    "mov r5, %7\n\t"
+    "svc %1"
+    : "=r"(reg0)
+    : "i"(SYS_syscall), "r"(reg0), "r"(reg1), "r"(reg2),
+      "r"(reg3), "r"(reg4), "r"(reg5)
+    : "memory", "r14", "r0", "r1", "r2", "r3", "r4", "r5"
+  );
+#else
   register long reg0 __asm__("r0") = (long)(nbr);
   register long reg5 __asm__("r5") = (long)(parm5);
   register long reg4 __asm__("r4") = (long)(parm4);
@@ -253,6 +362,7 @@ static inline uintptr_t sys_call5(unsigned int nbr, uintptr_t parm1,
       "r"(reg3), "r"(reg4), "r"(reg5)
     : "memory", "r14"
   );
+#endif
 
   return reg0;
 }
@@ -264,6 +374,31 @@ static inline uintptr_t sys_call6(unsigned int nbr, uintptr_t parm1,
                                   uintptr_t parm4, uintptr_t parm5,
                                   uintptr_t parm6)
 {
+#ifdef __ghs__
+  register long reg0 = (long)(nbr);
+  register long reg6 = (long)(parm6);
+  register long reg5 = (long)(parm5);
+  register long reg4 = (long)(parm4);
+  register long reg3 = (long)(parm3);
+  register long reg2 = (long)(parm2);
+  register long reg1 = (long)(parm1);
+
+  __asm__ __volatile__
+  (
+    "mov r0, %2\n\t"
+    "mov r1, %3\n\t"
+    "mov r2, %4\n\t"
+    "mov r3, %5\n\t"
+    "mov r4, %6\n\t"
+    "mov r5, %7\n\t"
+    "mov r6, %8\n\t"
+    "svc %1"
+    : "=r"(reg0)
+    : "i"(SYS_syscall), "r"(reg0), "r"(reg1), "r"(reg2),
+      "r"(reg3), "r"(reg4), "r"(reg5), "r"(reg6)
+    : "memory", "r14", "r0", "r1", "r2", "r3", "r4", "r5", "r6"
+  );
+#else
   register long reg0 __asm__("r0") = (long)(nbr);
   register long reg6 __asm__("r6") = (long)(parm6);
   register long reg5 __asm__("r5") = (long)(parm5);
@@ -280,6 +415,7 @@ static inline uintptr_t sys_call6(unsigned int nbr, uintptr_t parm1,
       "r"(reg3), "r"(reg4), "r"(reg5), "r"(reg6)
     : "memory", "r14"
   );
+#endif
 
   return reg0;
 }
@@ -288,6 +424,26 @@ static inline uintptr_t sys_call6(unsigned int nbr, uintptr_t parm1,
 
 static inline long smh_call(unsigned int nbr, void *parm)
 {
+#ifdef __ghs__
+  register long reg0 = (long)(nbr);
+  register long reg1 = (long)(parm);
+
+  __asm__ __volatile__
+  (
+    "mov r0, %2\n\t"
+    "mov r1, %3\n\t"
+#if defined(CONFIG_ARCH_ARMV6M) || \
+    defined(CONFIG_ARCH_ARMV7M) || \
+    defined(CONFIG_ARCH_ARMV8M)
+  "bkpt %1"
+#else
+  "svc %1"
+#endif
+    : "=r"(reg0)
+    : "i"(SYS_smhcall), "r"(reg0), "r"(reg1)
+    : "memory", "r14", "r0", "r1"
+  );
+#else
   register long reg0 __asm__("r0") = (long)(nbr);
   register long reg1 __asm__("r1") = (long)(parm);
 
@@ -304,6 +460,7 @@ static inline long smh_call(unsigned int nbr, void *parm)
     : "i"(SYS_smhcall), "r"(reg0), "r"(reg1)
     : "memory", "r14"
   );
+#endif
 
   return reg0;
 }


### PR DESCRIPTION
## Summary
Fixed the compilation error caused by incompatible inline assembly code for the Green Hills compiler platform.

## Impact

## Testing

