### PR TITLE
binfmt/elf_loadfile: Set sh_addr even if SHF_ALLOC == 0

### DIFF
--- a/binfmt/libelf/libelf_load.c
+++ b/binfmt/libelf/libelf_load.c
@@ -191,15 +191,6 @@ static inline int elf_loadfile(FAR struct elf_loadinfo_s *loadinfo)
     {
       FAR Elf_Shdr *shdr = &loadinfo->shdr[i];
 
-      /* SHF_ALLOC indicates that the section requires memory during
-       * execution.
-       */
-
-      if ((shdr->sh_flags & SHF_ALLOC) == 0)
-        {
-          continue;
-        }
-
       /* SHF_WRITE indicates that the section address space is write-
        * able
        */
@@ -215,6 +206,18 @@ static inline int elf_loadfile(FAR struct elf_loadinfo_s *loadinfo)
       else
         {
           pptr = &text;
+        }
+
+      /* SHF_ALLOC indicates that the section requires memory during
+       * execution.
+       */
+
+      if ((shdr->sh_flags & SHF_ALLOC) == 0)
+        {
+          /* Set the VMA regardless, some relocations might depend on this */
+
+          shdr->sh_addr = (uintptr_t)*pptr;
+          continue;
         }
 
       if (*pptr == NULL)


### PR DESCRIPTION
## Summary
Set sh_addr for regions that are not allocated. Some relocations might depend on this.

The fault in my case occurs when setting CONFIG_HAVE_CXX=y. In this case, the .ctor and .dtor sections do not get allocated, but the crt code depends on linker defined symbols _sctors/_ectors etc. These generate PC relative relocations and thus, the .ctor and .dtor output sections need an output VMA even though nothing is there. Otherwise the relocations will point to god knows where (in my case to address 0).

The problem results in full system crash later:
elf_symvalue: Other: 00000000+00000001=00000001
up_relocateadd: PCREL_HI20 at c00002dc [00000417] to sym=0x80409e80 st_value=1
_calc_imm: offset=-3221226203: hi=-786432 lo=-731
up_relocateadd: ERROR: PCREL_HI20 at c00002dc bad:ffffffff40000000 
elf_relocateadd: ERROR: Section 2 reloc 52: Relocation failed: -22

The RISC-V elf64 linker does not like the uninitialized PC relative relocation entries, as the relocation offset cannot be reached with with the RV64 instruction set.

More about this issue can be found here:
https://github.com/apache/nuttx/pull/11322
## Impact
Fix issue with elf loader
## Testing
- rv-virt:knsh64 with CONFIG_BINFMT_ELF_EXECUTABLE=n and CONFIG_HAVE_CXX=y
- Downstream MPFS target with CONFIG_HAVE_CXX=y
