### PR TITLE
tools/[Rust|D]: Fix the Rust and D Builds for QEMU RISC-V

### DIFF
--- a/tools/D.defs
+++ b/tools/D.defs
@@ -46,28 +46,18 @@ ifeq ($(CONFIG_ARCH_SIM),y)
     DFLAGS += -mtriple=$(LLVM_ARCHTYPE)-apple-$(LLVM_ABITYPE)
   endif
 else ifeq ($(CONFIG_ARCH_RISCV),y)
-  # Traget triple is riscv[32|64][isa]-unknown-none-elf
+  # Target triple is riscv[32|64]-unknown-none-elf
+  DFLAGS += -mtriple=$(LLVM_ARCHTYPE)-unknown-none-elf
+  DFLAGS += -mattr=+m,+a,+f,+d,+c
 
-  D_ARCHTYPE = $(LLVM_ARCHTYPE)i
-  ifeq ($(CONFIG_ARCH_RV_ISA_M),y)
-    D_ARCHTYPE := $(D_ARCHTYPE)m
+  # Handle ABI and CPU
+  ifeq ($(CONFIG_ARCH_RV32),y)
+    DFLAGS += -mcpu=generic-rv32
+    DFLAGS += -mabi=ilp32d
+  else ifeq ($(CONFIG_ARCH_RV64),y)
+    DFLAGS += -mcpu=generic-rv64
+    DFLAGS += -mabi=lp64d
   endif
-  ifeq ($(CONFIG_ARCH_RV_ISA_A),y)
-    D_ARCHTYPE := $(D_ARCHTYPE)a
-  endif
-  ifeq ($(CONFIG_ARCH_RV_ISA_F),y)
-    D_ARCHTYPE := $(D_ARCHTYPE)f
-  endif
-  ifeq ($(CONFIG_ARCH_RV_ISA_D),y)
-    D_ARCHTYPE := $(D_ARCHTYPE)d
-  endif
-  ifeq ($(CONFIG_ARCH_RV_ISA_C),y)
-    D_ARCHTYPE := $(D_ARCHTYPE)c
-  endif
-
-  DFLAGS += -mtriple=$(D_ARCHTYPE)-unknown-none-elf
-  DFLAGS += -mattr=+m,+a,+f,+d,+c -mabi=ilp32d
-  DFLAGS += -mcpu=generic-rv32
 else
   # For arm, but there are some other archs not support yet,
   # such as xtensa, x86 bare metal, etc.

--- a/tools/Rust.defs
+++ b/tools/Rust.defs
@@ -45,23 +45,28 @@ ifeq ($(CONFIG_ARCH_SIM),y)
     RUSTFLAGS += --target $(LLVM_ARCHTYPE)-apple-$(LLVM_ABITYPE)
   endif
 else ifeq ($(CONFIG_ARCH_RISCV),y)
-  # Traget triple is riscv[32|64][isa]-unknown-none-elf
+  # Target triple is riscv[32|64][isa]-unknown-none-elf
+  # "imafdc" becomes "gc"
 
-  RUST_ARCHTYPE = $(LLVM_ARCHTYPE)i
-  ifeq ($(CONFIG_ARCH_RV_ISA_M),y)
-    RUST_ARCHTYPE := $(RUST_ARCHTYPE)m
-  endif
-  ifeq ($(CONFIG_ARCH_RV_ISA_A),y)
-    RUST_ARCHTYPE := $(RUST_ARCHTYPE)a
-  endif
-  ifeq ($(CONFIG_ARCH_RV_ISA_F),y)
-    RUST_ARCHTYPE := $(RUST_ARCHTYPE)f
-  endif
-  ifeq ($(CONFIG_ARCH_RV_ISA_D),y)
-    RUST_ARCHTYPE := $(RUST_ARCHTYPE)d
-  endif
-  ifeq ($(CONFIG_ARCH_RV_ISA_C),y)
-    RUST_ARCHTYPE := $(RUST_ARCHTYPE)c
+  ifeq ($(CONFIG_ARCH_RV_ISA_M)$(CONFIG_ARCH_RV_ISA_A)$(CONFIG_ARCH_FPU)$(CONFIG_ARCH_DPFPU)$(CONFIG_ARCH_RV_ISA_C),yyyyy)
+    RUST_ARCHTYPE = $(LLVM_ARCHTYPE)gc
+  else
+    RUST_ARCHTYPE = $(LLVM_ARCHTYPE)i
+    ifeq ($(CONFIG_ARCH_RV_ISA_M),y)
+      RUST_ARCHTYPE := $(RUST_ARCHTYPE)m
+    endif
+    ifeq ($(CONFIG_ARCH_RV_ISA_A),y)
+      RUST_ARCHTYPE := $(RUST_ARCHTYPE)a
+    endif
+    ifeq ($(CONFIG_ARCH_FPU),y)
+      RUST_ARCHTYPE := $(RUST_ARCHTYPE)f
+    endif
+    ifeq ($(CONFIG_ARCH_DPFPU),y)
+      RUST_ARCHTYPE := $(RUST_ARCHTYPE)d
+    endif
+    ifeq ($(CONFIG_ARCH_RV_ISA_C),y)
+      RUST_ARCHTYPE := $(RUST_ARCHTYPE)c
+    endif
   endif
 
   RUSTFLAGS += --target $(RUST_ARCHTYPE)-unknown-none-elf


### PR DESCRIPTION
## Summary

This PR fixes the build for Rust Apps and D Apps on QEMU RISC-V. Previously the Rust Build selected the [incorrect Rust Target riscv64i-unknown-none-elf](https://lupyuen.github.io/articles/rust5#rust-target-is-incorrect). Now the Rust Build selects the correct Rust Target: riscv64gc-unknown-none-elf.

This PR also fixes the 32-bit RISC-V Target for D Apps. D Targets ("riscv32") are named differently from Rust Targets ("riscv32gc"), this PR restores the correct Target Names.

Note that Rust Apps won't build correctly for QEMU RISC-V 32-bit. This requires a [Rust Custom Target for riscv32gc](https://lupyuen.github.io/articles/rust4#custom-target-for-rust), which will make the NuttX Makefiles much more complicated.

Also note that `hello_d` won't build correctly for 64-bit `rv-virt:nsh64`. To date, NuttX has never supported 64-bit RISC-V for D Apps.

### Modified Files

`tools/Rust.defs`: Rename the RISC-V ISA `imafdc` to `gc` for Rust Targets

`tools/D.defs`: Exclude the RISC-V ISA for D Targets

## Impact

Previously, Rust and D Apps failed to build for QEMU RISC-V due to the incorrect target. With this PR, they will build correctly. There is no impact on C Apps.

## Testing

__For Rust Apps:__ We tested the `leds_rust` example app on `rv-virt:leds64` (QEMU RISC-V 64-bit): [Test Log](https://gist.github.com/lupyuen/1b0c06826a50900f4eab65ebec17aba9)

```text
$ tools/configure.sh rv-virt:leds64
$ rustup target add riscv64gc-unknown-none-elf
$ kconfig-tweak --enable CONFIG_EXAMPLES_LEDS_RUST
$ make olddefconfig
...
NuttShell (NSH) NuttX-12.4.0
nsh> uname -a
NuttX 12.4.0 37a5a951258 Aug  6 2024 18:47:27 risc-v rv-virt

nsh> leds_rust
Hello, Rust!!
Opening /dev/userleds
Set LED 1 to 1
board_userled: LED 1 set to 1
board_userled: LED 2 set to 0
board_userled: LED 3 set to 0
Sleeping...
Set LED 1 to 0
board_userled: LED 1 set to 0
board_userled: LED 2 set to 0
board_userled: LED 3 set to 0
```

Note that `leds_rust` won't build correctly for 32-bit `rv-virt:leds`. To date, NuttX has never supported Rust Apps for QEMU RISC-V 32-bit, because the [Rust Custom Target for riscv32gc](https://lupyuen.github.io/articles/rust4#custom-target-for-rust) is missing: [Build Log](https://gist.github.com/lupyuen/0ea3dfea5a7fb9ddb7f712f80e1940d4)

```text
$ tools/configure.sh rv-virt:leds
$ kconfig-tweak --enable CONFIG_EXAMPLES_LEDS_RUST
$ make olddefconfig
$ make
error: Error loading target specification:
Could not find specification for target "riscv32gc-unknown-none-elf"
```

__For D Apps:__ We tested the `hello_d` example app on `rv-virt:nsh` (QEMU RISC-V 32-bit): [Test Log](https://gist.github.com/lupyuen/c978c91f9896ebfa1d49e3785bc671a3)

```text
$ tools/configure.sh rv-virt:nsh
$ kconfig-tweak --enable CONFIG_EXAMPLES_HELLO_D
$ make olddefconfig
...
NuttShell (NSH) NuttX-12.4.0
nsh> uname -a
NuttX 12.4.0 37a5a951258 Aug  6 2024 18:50:00 risc-v rv-virt

nsh> hello_d
Hello World, [generic-rv32]!
hello_d_main: Saying hello from the dynamically constructed instance
DHelloWorld.HelloWorld: CONSTRUCTION FAILED!
hello_d_main: Saying hello from the instance constructed on the stack
DHelloWorld.HelloWorld: Hello, World!!
```

Note that `hello_d` won't build correctly for 64-bit `rv-virt:nsh64`. To date, NuttX has never supported 64-bit RISC-V for D Apps: [Build Log](https://gist.github.com/lupyuen/e7dbd6ec3ea0a15c87201f75c4334415)

```text
$ tools/configure.sh rv-virt:nsh64
$ kconfig-tweak --enable CONFIG_EXAMPLES_HELLO_D
$ make olddefconfig
$ make
nuttx/staging/libapps.a(hello_d_main.d.apps.examples.hello_d_1.o): in function `DHelloWorld::HelloWorld()':
apps/examples/hello_d/hello_d_main.d:67:(.text._ZN11DHelloWorld10HelloWorldEv+0x14): relocation truncated to fit: R_RISCV_HI20 against `.L.str'
nuttx/staging/libapps.a(hello_d_main.d.apps.examples.hello_d_1.o): in function `hello_d_main':
apps/examples/hello_d/hello_d_main.d:106:(.text.hello_d_main+0x14): relocation truncated to fit: R_RISCV_HI20 against `.L.str.2'
```
