### PR TITLE
build: Fix libc/pwd CMakeLists.txt

### DIFF
--- a/libs/libc/pwd/CMakeLists.txt
+++ b/libs/libc/pwd/CMakeLists.txt
@@ -17,10 +17,12 @@
 # the License.
 #
 # ##############################################################################
-set(SRCS lib_getpwnam.c lib_getpwnamr.c lib_getpwuid.c lib_getpwuidr.c)
+
+set(SRCS lib_getpwnam.c lib_getpwnamr.c lib_getpwuid.c lib_getpwuidr.c
+         lib_pwd_globals.c)
 
 if(CONFIG_LIBC_PASSWD_FILE)
-  list(APPEND SRCS lib_find_pwdfile.c lib_pwd_globals.c)
+  list(APPEND SRCS lib_find_pwdfile.c)
 else()
   list(APPEND SRCS lib_getpwbuf.c lib_getpwbufr.c)
 endif()


### PR DESCRIPTION
Hello NuttX community :)!

This PR fixes erroneous assignment of lib_pwd_globals.c previously guarded by CONFIG_LIBC_PASSWD_FILE. Original Make.defs file has this in CSRCS scope.

## Summary

As an example - sim:adb build worked only with Make based build system - now it's also possible to proceed with CMake based build.

## Impact

Hard to estimate.

## Testing

Local build of sim:adb and fiddling around adb client with sim:adb simulator.
