### PR TITLE
tools/ci: Add Rust Target for QEMU RISC-V 64-bit

### DIFF
--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -66,7 +66,8 @@ ENV RUSTUP_HOME=$RUST_HOME/rustup
 RUN mkdir -p $CARGO_HOME \
   && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
   && $CARGO_HOME/bin/rustup target add thumbv6m-none-eabi \
-  && $CARGO_HOME/bin/rustup target add thumbv7m-none-eabi
+  && $CARGO_HOME/bin/rustup target add thumbv7m-none-eabi \
+  && $CARGO_HOME/bin/rustup target add riscv64gc-unknown-none-elf
 
 RUN mkdir /tools/gn -p \
   && cd /tools/gn \

--- a/tools/ci/platforms/msys2.sh
+++ b/tools/ci/platforms/msys2.sh
@@ -181,6 +181,7 @@ rust() {
     # Install targets supported from NuttX
     "$CARGO_HOME"/bin/rustup target add thumbv6m-none-eabi
     "$CARGO_HOME"/bin/rustup target add thumbv7m-none-eabi
+    "$CARGO_HOME"/bin/rustup target add riscv64gc-unknown-none-elf
     rm rustup-init.exe
   fi
   command rustc --version

--- a/tools/ci/platforms/ubuntu.sh
+++ b/tools/ci/platforms/ubuntu.sh
@@ -230,6 +230,7 @@ rust() {
     # Install targets supported from NuttX
     rustup target add thumbv6m-none-eabi
     rustup target add thumbv7m-none-eabi
+    rustup target add riscv64gc-unknown-none-elf
   fi
 
   command rustc --version


### PR DESCRIPTION
## Summary

This PR updates the Docker Image for NuttX CI, so that it builds Rust Apps correctly for QEMU RISC-V 64-bit. We add the Rust Target for `riscv64gc-unknown-none-elf` to the Docker Image.

In the next PR, we will call the Updated Docker Image to [compile the Rust App `leds_rust`](https://github.com/apache/nuttx/pull/12852), at every run of NuttX CI. This will validate whether Rust Apps are built correctly for QEMU RISC-V 64-bit.

### Modified Files

`tools/ci/docker/linux/Dockerfile`: Add Rust Target `riscv64gc-unknown-none-elf` for Docker CI

`tools/ci/platforms/ubuntu.sh`: Same as above, but for Ubuntu CI

`tools/ci/platforms/msys2.sh`: Same as above, but for MSYS2 CI

## Impact

No impact on existing CI, since the Rust Target `riscv64gc-unknown-none-elf` is not used by existing code.

## Testing

We tested the CI Docker Image by rebuilding it [(only the essential parts)](https://github.com/lupyuen2/wip-nuttx/commit/a4c52e10bee3d6dfc6b02347fc0687c99512953f), and running the CI Build for `rv-virt:*`. Which successfully compiles [`rv-virt:leds64_rust`](https://github.com/lupyuen2/wip-nuttx/blob/safer-rust-blinky9/boards/risc-v/qemu-rv/rv-virt/configs/leds64_rust/defconfig) and the Rust App `leds_rust`:

- [Docker Build Log](https://gist.github.com/lupyuen/23da1272aaf55f7fe37bc6ab5fe94401#file-nuttx-ci-docker-log-L1077-L1086)
- [Docker Build Instructions](https://gist.github.com/lupyuen/a04f2324fa319026fab505ac0269e3bc)

```text
$ cd nuttx/tools/ci/docker/linux
$ docker build -t nuttx:v1 .
$ docker run -it nuttx:v1 /bin/bash 
# cd
# git clone https://github.com/lupyuen2/wip-nuttx nuttx --branch safer-rust-blinky9
# git clone https://github.com/apache/nuttx-apps apps
# cd nuttx/tools/ci
# ./cibuild.sh -c -A -N -R testlist/risc-v-02.dat

Configuration/Tool: rv-virt/leds64_rust
  Cleaning...
  Configuring...
  Building NuttX...
riscv-none-elf-ld: warning: /root/nuttx/nuttx has a LOAD segment with RWX permissions
  Normalize rv-virt/leds64_rust
```
