### PR TITLE
riscv/fork: fix fp/gp handling

### DIFF
--- a/arch/risc-v/src/common/fork.S
+++ b/arch/risc-v/src/common/fork.S
@@ -123,6 +123,10 @@ up_fork:
   REGSTORE    s0, FORK_S0_OFFSET(sp)
 #endif
 
+#ifdef RISCV_SAVE_GP
+  REGSTORE    gp, FORK_GP_OFFSET(sp)
+#endif
+
   addi        a0, sp, FORK_SIZEOF
   REGSTORE    a0, FORK_SP_OFFSET(sp) /* original SP */
   REGSTORE    x1, FORK_RA_OFFSET(sp) /* return address */

--- a/arch/risc-v/src/common/riscv_fork.c
+++ b/arch/risc-v/src/common/riscv_fork.c
@@ -308,7 +308,7 @@ pid_t riscv_fork(const struct fork_s *context)
 #endif
   child->cmn.xcp.regs[REG_SP]   = newsp;        /* Stack pointer */
 #ifdef RISCV_SAVE_GP
-  child->cmn.xcp.regs[REG_GP]   = newsp;        /* Global pointer */
+  child->cmn.xcp.regs[REG_GP]   = context->gp;  /* Global pointer */
 #endif
 #ifdef CONFIG_ARCH_FPU
   fregs                         = riscv_fpuregs(&child->cmn);

--- a/arch/risc-v/src/common/riscv_fork.h
+++ b/arch/risc-v/src/common/riscv_fork.h
@@ -119,6 +119,11 @@ struct fork_s
 {
   /* CPU registers */
 
+#ifdef CONFIG_RISCV_FRAMEPOINTER
+  uintreg_t fp;   /* Frame pointer */
+#else
+  uintreg_t s0;   /* Saved register s0 */
+#endif
   uintreg_t s1;   /* Saved register s1 */
   uintreg_t s2;   /* Saved register s2 */
   uintreg_t s3;   /* Saved register s3 */
@@ -130,11 +135,6 @@ struct fork_s
   uintreg_t s9;   /* Saved register s9 */
   uintreg_t s10;  /* Saved register s10 */
   uintreg_t s11;  /* Saved register s11 */
-#ifdef CONFIG_RISCV_FRAMEPOINTER
-  uintreg_t fp;   /* Frame pointer */
-#else
-  uintreg_t s0;   /* Saved register s0 */
-#endif
   uintreg_t sp;   /* Stack pointer */
   uintreg_t ra;   /* Return address */
 #ifdef RISCV_SAVE_GP


### PR DESCRIPTION
## Summary

This fixes riscv fp/gp issues in fork.

## Impacts

vfork() when FP or GP are used.

## Testing

- local checks with rv-virt:nsh, rv-virt:flats64 etc.
- CI checks
