### PR TITLE
build/cmake: fix system include dir for PROTECTED mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -812,6 +812,11 @@ if(CONFIG_BUILD_PROTECTED)
             $<$<BOOL:${CONFIG_HAVE_CXX}>:supc++>
             $<$<NOT:$<BOOL:${APPLE}>>:-Wl,--end-group>)
 
+  target_include_directories(
+    nuttx_user SYSTEM
+    PRIVATE ${CMAKE_SOURCE_DIR}/include ${CMAKE_BINARY_DIR}/include
+            ${CMAKE_BINARY_DIR}/include_arch)
+
   add_custom_command(
     OUTPUT User.map
     COMMAND ${CMAKE_NM} nuttx_user > User.map


### PR DESCRIPTION
## Summary

This fixes build issues encountered when using Ubuntu stock gcc-riscv64-unknown-elf 10.2 toolchain for PROTECTED target like `rv-virt:pnsh`: 

```
boards/risc-v/qemu-rv/rv-virt/kernel/rv_virt_userspace.c:25:10: fatal error: nuttx/config.h: No such file or directory
```

## Impact

cmake PROTECTED

## Testing

- local checks with rv-virt:pnsh, rv-virt:pnsh64, canmv230:pnsh etc.
- CI checks
