### PR TITLE
boards/rv-virt: cmake for pnsh and nsbi

### DIFF
--- a/arch/risc-v/src/qemu-rv/CMakeLists.txt
+++ b/arch/risc-v/src/qemu-rv/CMakeLists.txt
@@ -39,4 +39,8 @@ if(CONFIG_MM_PGALLOC)
   list(APPEND SRCS qemu_rv_pgalloc.c)
 endif()
 
+if(CONFIG_BUILD_PROTECTED)
+  list(APPEND SRCS qemu_rv_userspace.c)
+endif()
+
 target_sources(arch PRIVATE ${SRCS})

--- a/boards/arm/tiva/lm3s6965-ek/scripts/memory.ld
+++ b/boards/arm/tiva/lm3s6965-ek/scripts/memory.ld
@@ -26,8 +26,8 @@ MEMORY
 {
     /* 256Kb FLASH */
 
-  kflash (rx)      : ORIGIN = 0x00000000, LENGTH = 128K
-  uflash (rx)      : ORIGIN = 0x00020000, LENGTH = 128K
+  kflash (rx)      : ORIGIN = 0x00000000, LENGTH = 124K
+  uflash (rx)      : ORIGIN = 0x00020000, LENGTH = 132K
   xflash (rx)      : ORIGIN = 0x00040000, LENGTH = 0K
 
     /* 64Kb of contiguous SRAM */

--- a/boards/risc-v/qemu-rv/rv-virt/CMakeLists.txt
+++ b/boards/risc-v/qemu-rv/rv-virt/CMakeLists.txt
@@ -19,3 +19,10 @@
 # ##############################################################################
 
 add_subdirectory(src)
+
+if(CONFIG_BUILD_PROTECTED)
+  add_subdirectory(kernel)
+  set_property(
+    GLOBAL PROPERTY LD_SCRIPT_USER
+                    ${CMAKE_CURRENT_LIST_DIR}/scripts/ld-userland.script)
+endif()

--- a/boards/risc-v/qemu-rv/rv-virt/kernel/CMakeLists.txt
+++ b/boards/risc-v/qemu-rv/rv-virt/kernel/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# boards/risc-v/qemu-rv/rv-virt/src/CMakeLists.txt
+# boards/risc-v/qemu-rv/rv-virt/kernel/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
@@ -18,28 +18,4 @@
 #
 # ##############################################################################
 
-set(SRCS qemu_rv_appinit.c)
-
-if(CONFIG_ARCH_LEDS)
-  list(APPEND SRCS qemu_rv_autoleds.c)
-endif()
-
-if(CONFIG_USERLED)
-  list(APPEND SRCS qemu_rv_userleds.c)
-endif()
-
-target_sources(board PRIVATE ${SRCS})
-
-if(CONFIG_ARCH_CHIP_QEMU_RV)
-  if(CONFIG_NUTTSBI)
-    set(LDFILE ld-nuttsbi.script)
-  elseif(CONFIG_BUILD_KERNEL)
-    set(LDFILE ld-kernel.script)
-  elseif(CONFIG_BUILD_PROTECTED)
-    set(LDFILE ld-protected.script)
-  else()
-    set(LDFILE ld.script)
-  endif()
-endif()
-
-set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/${LDFILE}")
+target_sources(nuttx_user PRIVATE rv_virt_userspace.c)

--- a/boards/risc-v/qemu-rv/rv-virt/src/CMakeLists.txt
+++ b/boards/risc-v/qemu-rv/rv-virt/src/CMakeLists.txt
@@ -31,9 +31,11 @@ endif()
 target_sources(board PRIVATE ${SRCS})
 
 if(CONFIG_ARCH_CHIP_QEMU_RV)
-
   if(CONFIG_BUILD_KERNEL)
     set(LDFILE ld-kernel.script)
+    if(CONFIG_NUTTSBI)
+      set(LDFILE ld-nuttsbi.script)
+    endif()
   else()
     set(LDFILE ld.script)
   endif()


### PR DESCRIPTION
## Summary

This adds cmake scripts for NuttSBI and PROTECTED builds.
PROTECTED check should be done with pull/12022.

## Impact

N/A

## Testing

- local checks with rv-virt target and `nsbi`, `nsbi64`, `pnsh`, `pnsh64` etc.
- CI checks
