### PR TITLE
xtensa/esp32s3: Update the rtc code to fix system blocking issue

### DIFF
--- a/arch/xtensa/src/esp32s3/esp32s3_rtc.h
+++ b/arch/xtensa/src/esp32s3/esp32s3_rtc.h
@@ -302,22 +302,6 @@ enum esp32s3_rtc_xtal_freq_e esp32s3_rtc_clk_xtal_freq_get(void);
 void esp32s3_rtc_update_to_xtal(int freq, int div);
 
 /****************************************************************************
- * Name: esp32s3_rtc_bbpll_enable
- *
- * Description:
- *   Reset BBPLL configuration.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   None
- *
- ****************************************************************************/
-
-void esp32s3_rtc_bbpll_enable(void);
-
-/****************************************************************************
  * Name: esp32s3_rtc_clk_set
  *
  * Description:
@@ -433,22 +417,6 @@ uint64_t esp32s3_rtc_time_slowclk_to_us(uint64_t rtc_cycles,
  ****************************************************************************/
 
 uint32_t esp32s3_clk_slowclk_cal_get(void);
-
-/****************************************************************************
- * Name: esp32s3_rtc_bbpll_disable
- *
- * Description:
- *   disable BBPLL.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   None
- *
- ****************************************************************************/
-
-void esp32s3_rtc_bbpll_disable(void);
 
 /****************************************************************************
  * Name: esp32s3_rtc_sleep_set_wakeup_time

--- a/arch/xtensa/src/esp32s3/hardware/esp32s3_rtccntl.h
+++ b/arch/xtensa/src/esp32s3/hardware/esp32s3_rtccntl.h
@@ -5843,6 +5843,13 @@
 #define RTC_CNTL_DATE_V  0x0fffffff
 #define RTC_CNTL_DATE_S  0
 
+/* LDO SLAVE : R/W ;bitpos:[18:13] ; default: 6'd0 ; */
+
+#define RTC_CNTL_SLAVE_PD    0x0000003F
+#define RTC_CNTL_SLAVE_PD_M  ((RTC_CNTL_SLAVE_PD_V)<<(RTC_CNTL_SLAVE_PD_S))
+#define RTC_CNTL_SLAVE_PD_V  0x3f
+#define RTC_CNTL_SLAVE_PD_S  13
+
 /* Deep sleep (power down digital domain) */
 
 #define RTC_SLEEP_PD_DIG                BIT(0)


### PR DESCRIPTION
## Summary

- For some reasons, the bootloader will set CPU source to BBPLL and enable it, but there are calibration issues, so we need turn off the BBPLL and do calibration again to fix the issue.

- Corresponding issue link: https://github.com/espressif/esp-idf/commit/89cc9084ab5d889761cb5eff7560a2661236842a

## Impact

## Testing

