### PR TITLE
fix stm32wl5_rcc.h: Add the missing argument to RCC_PLLCFG_PLLP define.

### DIFF
--- a/arch/arm/src/stm32wl5/hardware/stm32wl5_rcc.h
+++ b/arch/arm/src/stm32wl5/hardware/stm32wl5_rcc.h
@@ -276,7 +276,7 @@
 
 #define RCC_PLLCFG_PLLP_SHIFT            (17)      /* Bit 17-21: Main PLL div factor for PLLPCLK */
 #define RCC_PLLCFG_PLLP_MASK             (0x1f << RCC_PLLCFG_PLLP_SHIFT)
-#  define RCC_PLLCFG_PLLP                (((n)-1) << RCC_PLLCFG_PLLP_SHIFT) /* 2..32 */
+#define RCC_PLLCFG_PLLP(n)               (((n)-1) << RCC_PLLCFG_PLLP_SHIFT) /* 2..32 */
 
 #define RCC_PLLCFG_PLLQEN                (1 << 24) /* Bit 24: Main PLL PLLQCLK output enable */
 


### PR DESCRIPTION
## Summary
The RCC_PLLCFG_PLLP define was missing an argument in it's definition.

## Impact
Would not compile if STM32WL5_PLLCFG_PLLP_ENABLED was set on stm32wl5 architecture.

## Testing
Built and ran on a board with a stm32wl5.
