### PR TITLE
boards/lm3s6965-ek: fix memory.ld for PROTECTED

### DIFF
--- a/boards/arm/tiva/lm3s6965-ek/scripts/memory.ld
+++ b/boards/arm/tiva/lm3s6965-ek/scripts/memory.ld
@@ -27,7 +27,7 @@ MEMORY
     /* 256Kb FLASH */
 
   kflash (rx)      : ORIGIN = 0x00000000, LENGTH = 124K
-  uflash (rx)      : ORIGIN = 0x00020000, LENGTH = 132K
+  uflash (rx)      : ORIGIN = 0x0001f000, LENGTH = 132K
   xflash (rx)      : ORIGIN = 0x00040000, LENGTH = 0K
 
     /* 64Kb of contiguous SRAM */


### PR DESCRIPTION
## Summary

This completes kflash size adjustion in pull/12868 by fixing the uflash origin, otherwise the linked program may go beyond valid flash range.

## Impacts

lm3s6965-ek/qemu-protected

## Testing

- CI checks