### PR TITLE
greenhills support: add up_getsp() implementation to adapting greenhills compiler

### DIFF
--- a/arch/arm/include/armv6-m/irq.h
+++ b/arch/arm/include/armv6-m/irq.h
@@ -330,6 +330,19 @@ static inline void setcontrol(uint32_t control)
       : "memory");
 }
 
+static inline_function uint32_t up_getsp(void)
+{
+  register uint32_t sp;
+
+  __asm__ __volatile__
+  (
+    "mov %0, sp\n"
+    : "=r" (sp)
+  );
+
+  return sp;
+}
+
 #endif /* __ASSEMBLY__ */
 
 /****************************************************************************

--- a/arch/arm/include/armv7-a/irq.h
+++ b/arch/arm/include/armv7-a/irq.h
@@ -406,6 +406,19 @@ noinstrument_function static inline void up_irq_restore(irqstate_t flags)
     );
 }
 
+static inline_function uint32_t up_getsp(void)
+{
+  register uint32_t sp;
+
+  __asm__ __volatile__
+  (
+    "mov %0, sp\n"
+    : "=r" (sp)
+  );
+
+  return sp;
+}
+
 #endif /* __ASSEMBLY__ */
 
 /****************************************************************************

--- a/arch/arm/include/armv7-m/irq.h
+++ b/arch/arm/include/armv7-m/irq.h
@@ -535,6 +535,19 @@ static inline void setcontrol(uint32_t control)
       : "memory");
 }
 
+static inline_function uint32_t up_getsp(void)
+{
+  register uint32_t sp;
+
+  __asm__ __volatile__
+  (
+    "mov %0, sp\n"
+    : "=r" (sp)
+  );
+
+  return sp;
+}
+
 #endif /* __ASSEMBLY__ */
 
 /****************************************************************************

--- a/arch/arm/include/armv7-r/irq.h
+++ b/arch/arm/include/armv7-r/irq.h
@@ -402,6 +402,19 @@ static inline void up_irq_restore(irqstate_t flags)
     );
 }
 
+static inline_function uint32_t up_getsp(void)
+{
+  register uint32_t sp;
+
+  __asm__ __volatile__
+  (
+    "mov %0, sp\n"
+    : "=r" (sp)
+  );
+
+  return sp;
+}
+
 #endif /* __ASSEMBLY__ */
 
 /****************************************************************************

--- a/arch/arm/include/armv8-m/irq.h
+++ b/arch/arm/include/armv8-m/irq.h
@@ -508,6 +508,19 @@ static inline void setcontrol(uint32_t control)
       : "memory");
 }
 
+static inline_function uint32_t up_getsp(void)
+{
+  uint32_t sp;
+
+  __asm__ __volatile__
+  (
+    "mov %0, sp\n"
+    : "=r" (sp)
+  );
+
+  return sp;
+}
+
 #endif /* __ASSEMBLY__ */
 
 /****************************************************************************

--- a/arch/arm/include/armv8-r/irq.h
+++ b/arch/arm/include/armv8-r/irq.h
@@ -402,6 +402,19 @@ static inline void up_irq_restore(irqstate_t flags)
     );
 }
 
+static inline_function uint32_t up_getsp(void)
+{
+  register uint32_t sp;
+
+  __asm__ __volatile__
+  (
+    "mov %0, sp\n"
+    : "=r" (sp)
+  );
+
+  return sp;
+}
+
 #endif /* __ASSEMBLY__ */
 
 /****************************************************************************

--- a/arch/arm/include/irq.h
+++ b/arch/arm/include/irq.h
@@ -66,8 +66,6 @@
  * Pre-processor Prototypes
  ****************************************************************************/
 
-#define up_getsp() (uintptr_t)__builtin_frame_address(0)
-
 #ifndef __ASSEMBLY__
 
 #ifdef __cplusplus

--- a/arch/arm/include/tlsr82/irq.h
+++ b/arch/arm/include/tlsr82/irq.h
@@ -236,6 +236,19 @@ static inline uint32_t getcontrol(void)
   return 0;
 }
 
+static inline_function uint32_t up_getsp(void)
+{
+  register uint32_t sp;
+
+  __asm__ __volatile__
+  (
+    "tmov %0, sp\n"
+    : "=r" (sp)
+  );
+
+  return sp;
+}
+
 #endif /* __ASSEMBLY__ */
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
1. the up_getsp() function is needed by "__builtin_frame_address", and the "__builtin_frame_address" is a gcc builtin function, which is bound to gcc specific platform, so we provide a new implementaiton of up_getsp(), which make the up_getsp() is independent from specific compiler.

## Impact

## Testing

