### PR TITLE
build: set CMake policy to allow FetchContent_Populate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,11 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
   cmake_policy(SET CMP0135 NEW)
 endif()
 
+if(POLICY CMP0169)
+  # allow to call FetchContent_Populate directly
+  cmake_policy(SET CMP0169 OLD)
+endif()
+
 # Basic CMake configuration ##################################################
 
 set(CMAKE_CXX_EXTENSIONS OFF)


### PR DESCRIPTION
## Summary

FetchContent_Populate is depracated starting from CMake 3.30. Setting this policy to OLD allows clean (no warnings) CMake builds for configurations that rely on CMake fetch content feature.

## Impact

If we want to keep up with CMake versioning - FetchContent_Populate is deprecated in 3.30 - and it's gonna be disabled in future version.

https://cmake.org/cmake/help/latest/module/FetchContent.html#command:fetchcontent_populate

## Testing

Local builds (or rather configure steps) using CMake 3.30.2 

Was there any specific reason for calling FetchContent_Populate instead of FetchContent_MakeAvailable?

