### PR TITLE
arch/riscv: add cluster local hartid

### DIFF
--- a/arch/risc-v/Kconfig
+++ b/arch/risc-v/Kconfig
@@ -451,6 +451,20 @@ config ARCH_RV_MMIO_BITS
 	default 32 if ARCH_RV32
 	default 64 if ARCH_RV64
 
+config ARCH_RV_HARTID_BASE
+	int "Base hartid of this cluster"
+	default 0
+	---help---
+		Some RV chips have multiple cluster of harts with
+		globally numbered mhartids, like qemu-rv, mpfs and
+		jh7110 etc.  Clusters with SMP ability can be managed
+		by NuttX. As NuttX expects cluster-local hart ids,
+		we can shift mhartid by this value to derive such
+		local ids. The SMP_NCPUS still defines number of
+		harts in the cluster. Note that we assume that global
+		ids for each cluster are continuous. Note that there
+		are chips like k230 which don't have global mhartid.
+
 config ARCH_FAMILY
 	string
 	default "rv32" if ARCH_RV32

--- a/arch/risc-v/src/common/riscv_macros.S
+++ b/arch/risc-v/src/common/riscv_macros.S
@@ -362,6 +362,9 @@
   REGLOAD \out, RISCV_PERCPU_HARTID(\out)
 #else
   csrr    \out, CSR_MHARTID
+#  if CONFIG_ARCH_RV_HARTID_BASE > 0
+  add    \out, \out, - CONFIG_ARCH_RV_HARTID_BASE
+#  endif
 #endif
 .endm
 


### PR DESCRIPTION
## Summary

arch/riscv: add cluster local hartid

Some RV chips (mpfs, jh7110, qemu-rv etc) have hart clusters and globally numbered mhartids. Clusters with single hart or SMP support can be managed by one NuttX instance. Currently NuttX expects to use cluster-local ids.

This allows us to get local ids by offsetting mhartids with provisioned base hartid for each cluster.

Note that there are chips (e.g. k230) that use cluster-local ids directly, so this is not needed for them.

## Impacts

None

## Testing

CI checks
