### PR TITLE
board/lm3s6965-ek: restore 128K kflash

### DIFF
--- a/boards/arm/tiva/lm3s6965-ek/scripts/memory.ld
+++ b/boards/arm/tiva/lm3s6965-ek/scripts/memory.ld
@@ -26,8 +26,8 @@ MEMORY
 {
     /* 256Kb FLASH */
 
-  kflash (rx)      : ORIGIN = 0x00000000, LENGTH = 124K
-  uflash (rx)      : ORIGIN = 0x0001f000, LENGTH = 132K
+  kflash (rx)      : ORIGIN = 0x00000000, LENGTH = 128K
+  uflash (rx)      : ORIGIN = 0x00020000, LENGTH = 128K
   xflash (rx)      : ORIGIN = 0x00040000, LENGTH = 0K
 
     /* 64Kb of contiguous SRAM */


### PR DESCRIPTION
## Summary

This reverts both 2afdcfb6a6 and 0a0af89de9 to restore the 128K kflash design as the implementation depends on that to work, checked with:

```
$ qemu-system-arm -M lm3s6965evb -nographic -device loader,file=nuttx.bin,addr=0x0 -device loader,file=nuttx_user.bin,addr=0x2000
```

Thanks to patch 12873, 128K uflash is enough now for `qemu-protected`.

## Impact

lm3s6965-ek device

## Testing

- local check with lm3s6965-ek:qemu-protected
- CI checks
