### PR TITLE
greenhills support: fix the asm build error for adapting to greenhills compiler

### DIFF
--- a/arch/arm/include/spinlock.h
+++ b/arch/arm/include/spinlock.h
@@ -59,8 +59,8 @@
  *            all memory accesses are complete
  */
 
-#define SP_DSB(n) __asm__ __volatile__ ("dsb sy" : : : "memory")
-#define SP_DMB(n) __asm__ __volatile__ ("dmb st" : : : "memory")
+#define SP_DSB() __asm__ __volatile__ ("dsb sy" : : : "memory")
+#define SP_DMB() __asm__ __volatile__ ("dmb st" : : : "memory")
 
 #ifdef CONFIG_ARM_HAVE_WFE_SEV
 #define SP_WFE() __asm__ __volatile__ ("wfe" : : : "memory")

--- a/arch/arm/include/syscall.h
+++ b/arch/arm/include/syscall.h
@@ -136,6 +136,18 @@
 
 static inline uintptr_t sys_call0(unsigned int nbr)
 {
+#ifdef __ghs__
+  register long reg0 = (long)(nbr);
+
+  __asm__ __volatile__
+  (
+    "mov r0, %2\n\t"
+    "svc %1"
+    : "=r"(reg0)
+    : "i"(SYS_syscall), "r"(reg0)
+    : "memory", "r14", "r0"
+  );
+#else
   register long reg0 __asm__("r0") = (long)(nbr);
 
   __asm__ __volatile__
@@ -145,6 +157,7 @@ static inline uintptr_t sys_call0(unsigned int nbr)
     : "i"(SYS_syscall), "r"(reg0)
     : "memory", "r14"
   );
+#endif
 
   return reg0;
 }
@@ -153,6 +166,20 @@ static inline uintptr_t sys_call0(unsigned int nbr)
 
 static inline uintptr_t sys_call1(unsigned int nbr, uintptr_t parm1)
 {
+#ifdef __ghs__
+  register long reg0 = (long)(nbr);
+  register long reg1 = (long)(parm1);
+
+  __asm__ __volatile__
+  (
+    "mov r0, %2\n\t"
+    "mov r1, %3\n\t"
+    "svc %1"
+    : "=r"(reg0)
+    : "i"(SYS_syscall), "r"(reg0), "r"(reg1)
+    : "memory", "r14", "r0", "r1"
+  );
+#else
   register long reg0 __asm__("r0") = (long)(nbr);
   register long reg1 __asm__("r1") = (long)(parm1);
 
@@ -163,6 +190,7 @@ static inline uintptr_t sys_call1(unsigned int nbr, uintptr_t parm1)
     : "i"(SYS_syscall), "r"(reg0), "r"(reg1)
     : "memory", "r14"
   );
+#endif
 
   return reg0;
 }
@@ -172,6 +200,22 @@ static inline uintptr_t sys_call1(unsigned int nbr, uintptr_t parm1)
 static inline uintptr_t sys_call2(unsigned int nbr, uintptr_t parm1,
                                   uintptr_t parm2)
 {
+#ifdef __ghs__
+  register long reg0 = (long)nbr;
+  register long reg2 = (long)parm2;
+  register long reg1 = (long)parm1;
+
+  __asm__ __volatile__
+  (
+    "mov r0, %2\n\t"
+    "mov r1, %3\n\t"
+    "mov r2, %4\n\t"
+    "svc %1"
+    : "=r"(reg0)
+    : "i"(SYS_syscall), "r"(reg0), "r"(reg1), "r"(reg2)
+    : "memory", "r14", "r0", "r1", "r2"
+  );
+#else
   register long reg0 __asm__("r0") = (long)(nbr);
   register long reg2 __asm__("r2") = (long)(parm2);
   register long reg1 __asm__("r1") = (long)(parm1);
@@ -183,6 +227,7 @@ static inline uintptr_t sys_call2(unsigned int nbr, uintptr_t parm1,
     : "i"(SYS_syscall), "r"(reg0), "r"(reg1), "r"(reg2)
     : "memory", "r14"
   );
+#endif
 
   return reg0;
 }
@@ -192,6 +237,24 @@ static inline uintptr_t sys_call2(unsigned int nbr, uintptr_t parm1,
 static inline uintptr_t sys_call3(unsigned int nbr, uintptr_t parm1,
                                   uintptr_t parm2, uintptr_t parm3)
 {
+#ifdef __ghs__
+  register long reg0 = (long)(nbr);
+  register long reg3 = (long)(parm3);
+  register long reg2 = (long)(parm2);
+  register long reg1 = (long)(parm1);
+
+  __asm__ __volatile__
+  (
+    "mov r0, %2\n\t"
+    "mov r1, %3\n\t"
+    "mov r2, %4\n\t"
+    "mov r3, %5\n\t"
+    "svc %1"
+    : "=r"(reg0)
+    : "i"(SYS_syscall), "r"(reg0), "r"(reg1), "r"(reg2), "r"(reg3)
+    : "memory", "r14", "r0", "r1", "r2", "r3"
+  );
+#else
   register long reg0 __asm__("r0") = (long)(nbr);
   register long reg3 __asm__("r3") = (long)(parm3);
   register long reg2 __asm__("r2") = (long)(parm2);
@@ -204,6 +267,7 @@ static inline uintptr_t sys_call3(unsigned int nbr, uintptr_t parm1,
     : "i"(SYS_syscall), "r"(reg0), "r"(reg1), "r"(reg2), "r"(reg3)
     : "memory", "r14"
   );
+#endif
 
   return reg0;
 }
@@ -214,6 +278,27 @@ static inline uintptr_t sys_call4(unsigned int nbr, uintptr_t parm1,
                                   uintptr_t parm2, uintptr_t parm3,
                                   uintptr_t parm4)
 {
+#ifdef __ghs__
+  register long reg0 = (long)(nbr);
+  register long reg4 = (long)(parm4);
+  register long reg3 = (long)(parm3);
+  register long reg2 = (long)(parm2);
+  register long reg1 = (long)(parm1);
+
+  __asm__ __volatile__
+  (
+    "mov r0, %2\n\t"
+    "mov r1, %3\n\t"
+    "mov r2, %4\n\t"
+    "mov r3, %5\n\t"
+    "mov r4, %6\n\t"
+    "svc %1"
+    : "=r"(reg0)
+    : "i"(SYS_syscall), "r"(reg0), "r"(reg1), "r"(reg2),
+      "r"(reg3), "r"(reg4)
+    : "memory", "r14", "r0", "r1", "r2", "r3", "r4"
+  );
+#else
   register long reg0 __asm__("r0") = (long)(nbr);
   register long reg4 __asm__("r4") = (long)(parm4);
   register long reg3 __asm__("r3") = (long)(parm3);
@@ -228,6 +313,7 @@ static inline uintptr_t sys_call4(unsigned int nbr, uintptr_t parm1,
       "r"(reg3), "r"(reg4)
     : "memory", "r14"
   );
+#endif
 
   return reg0;
 }
@@ -238,6 +324,29 @@ static inline uintptr_t sys_call5(unsigned int nbr, uintptr_t parm1,
                                   uintptr_t parm2, uintptr_t parm3,
                                   uintptr_t parm4, uintptr_t parm5)
 {
+#ifdef __ghs__
+  register long reg0 = (long)(nbr);
+  register long reg5 = (long)(parm5);
+  register long reg4 = (long)(parm4);
+  register long reg3 = (long)(parm3);
+  register long reg2 = (long)(parm2);
+  register long reg1 = (long)(parm1);
+
+  __asm__ __volatile__
+  (
+    "mov r0, %2\n\t"
+    "mov r1, %3\n\t"
+    "mov r2, %4\n\t"
+    "mov r3, %5\n\t"
+    "mov r4, %6\n\t"
+    "mov r5, %7\n\t"
+    "svc %1"
+    : "=r"(reg0)
+    : "i"(SYS_syscall), "r"(reg0), "r"(reg1), "r"(reg2),
+      "r"(reg3), "r"(reg4), "r"(reg5)
+    : "memory", "r14", "r0", "r1", "r2", "r3", "r4", "r5"
+  );
+#else
   register long reg0 __asm__("r0") = (long)(nbr);
   register long reg5 __asm__("r5") = (long)(parm5);
   register long reg4 __asm__("r4") = (long)(parm4);
@@ -253,6 +362,7 @@ static inline uintptr_t sys_call5(unsigned int nbr, uintptr_t parm1,
       "r"(reg3), "r"(reg4), "r"(reg5)
     : "memory", "r14"
   );
+#endif
 
   return reg0;
 }
@@ -264,6 +374,31 @@ static inline uintptr_t sys_call6(unsigned int nbr, uintptr_t parm1,
                                   uintptr_t parm4, uintptr_t parm5,
                                   uintptr_t parm6)
 {
+#ifdef __ghs__
+  register long reg0 = (long)(nbr);
+  register long reg6 = (long)(parm6);
+  register long reg5 = (long)(parm5);
+  register long reg4 = (long)(parm4);
+  register long reg3 = (long)(parm3);
+  register long reg2 = (long)(parm2);
+  register long reg1 = (long)(parm1);
+
+  __asm__ __volatile__
+  (
+    "mov r0, %2\n\t"
+    "mov r1, %3\n\t"
+    "mov r2, %4\n\t"
+    "mov r3, %5\n\t"
+    "mov r4, %6\n\t"
+    "mov r5, %7\n\t"
+    "mov r6, %8\n\t"
+    "svc %1"
+    : "=r"(reg0)
+    : "i"(SYS_syscall), "r"(reg0), "r"(reg1), "r"(reg2),
+      "r"(reg3), "r"(reg4), "r"(reg5), "r"(reg6)
+    : "memory", "r14", "r0", "r1", "r2", "r3", "r4", "r5", "r6"
+  );
+#else
   register long reg0 __asm__("r0") = (long)(nbr);
   register long reg6 __asm__("r6") = (long)(parm6);
   register long reg5 __asm__("r5") = (long)(parm5);
@@ -280,6 +415,7 @@ static inline uintptr_t sys_call6(unsigned int nbr, uintptr_t parm1,
       "r"(reg3), "r"(reg4), "r"(reg5), "r"(reg6)
     : "memory", "r14"
   );
+#endif
 
   return reg0;
 }
@@ -288,6 +424,26 @@ static inline uintptr_t sys_call6(unsigned int nbr, uintptr_t parm1,
 
 static inline long smh_call(unsigned int nbr, void *parm)
 {
+#ifdef __ghs__
+  register long reg0 = (long)(nbr);
+  register long reg1 = (long)(parm);
+
+  __asm__ __volatile__
+  (
+    "mov r0, %2\n\t"
+    "mov r1, %3\n\t"
+#if defined(CONFIG_ARCH_ARMV6M) || \
+    defined(CONFIG_ARCH_ARMV7M) || \
+    defined(CONFIG_ARCH_ARMV8M)
+  "bkpt %1"
+#else
+  "svc %1"
+#endif
+    : "=r"(reg0)
+    : "i"(SYS_smhcall), "r"(reg0), "r"(reg1)
+    : "memory", "r14", "r0", "r1"
+  );
+#else
   register long reg0 __asm__("r0") = (long)(nbr);
   register long reg1 __asm__("r1") = (long)(parm);
 
@@ -304,6 +460,7 @@ static inline long smh_call(unsigned int nbr, void *parm)
     : "i"(SYS_smhcall), "r"(reg0), "r"(reg1)
     : "memory", "r14"
   );
+#endif
 
   return reg0;
 }

--- a/arch/arm/src/armv6-m/barriers.h
+++ b/arch/arm/src/armv6-m/barriers.h
@@ -31,12 +31,12 @@
 
 /* ARMv6-M memory barriers */
 
-#define arm_isb(n) __asm__ __volatile__ ("isb " #n : : : "memory")
-#define arm_dsb(n) __asm__ __volatile__ ("dsb " #n : : : "memory")
-#define arm_dmb(n) __asm__ __volatile__ ("dmb " #n : : : "memory")
+#define arm_dsb()  __asm__ __volatile__ ("dsb " : : : "memory")
+#define arm_isb()  __asm__ __volatile__ ("isb " : : : "memory")
+#define arm_dmb()  __asm__ __volatile__ ("dmb " : : : "memory")
 
-#define ARM_DSB()  arm_dsb(15)
-#define ARM_ISB()  arm_isb(15)
-#define ARM_DMB()  arm_dmb(15)
+#define ARM_DSB()  arm_dsb()
+#define ARM_ISB()  arm_isb()
+#define ARM_DMB()  arm_dmb()
 
 #endif /* __ARCH_ARM_SRC_ARMV6_M_BARRIERS_H */

--- a/arch/arm/src/armv7-a/barriers.h
+++ b/arch/arm/src/armv7-a/barriers.h
@@ -31,15 +31,15 @@
 
 /* ARMv7-A memory barriers */
 
-#define arm_isb(n) __asm__ __volatile__ ("isb " #n : : : "memory")
 #define arm_dsb(n) __asm__ __volatile__ ("dsb " #n : : : "memory")
 #define arm_dmb(n) __asm__ __volatile__ ("dmb " #n : : : "memory")
+#define arm_isb()  __asm__ __volatile__ ("isb " : : : "memory")
 #define arm_nop()  __asm__ __volatile__ ("nop\n")
 #define arm_sev()  __asm__ __volatile__ ("sev\n")
 
 #define ARM_DSB()  arm_dsb(15)
-#define ARM_ISB()  arm_isb(15)
 #define ARM_DMB()  arm_dmb(15)
+#define ARM_ISB()  arm_isb()
 #define ARM_NOP()  arm_nop()
 #define ARM_SEV()  arm_sev()
 

--- a/arch/arm/src/armv7-m/arm_exception.S
+++ b/arch/arm/src/armv7-m/arm_exception.S
@@ -87,9 +87,12 @@
  ****************************************************************************/
 
 	.globl		exception_common
-
+#ifdef __ghs__
+	.thumb2
+#else
 	.syntax		unified
 	.thumb
+#endif
 	.file		"arm_exception.S"
 
 /****************************************************************************
@@ -119,8 +122,12 @@
 
 	.text
 	.section    .text.exception_common
+#ifdef __ghs__
+	.type	exception_common, $function
+#else
 	.thumb_func
 	.type	exception_common, function
+#endif
 exception_common:
 
 	mrs		r0, ipsr				/* R0=exception number */

--- a/arch/arm/src/armv7-m/arm_saveusercontext.S
+++ b/arch/arm/src/armv7-m/arm_saveusercontext.S
@@ -28,8 +28,12 @@
 	.file	"arm_saveusercontext.S"
 
 	.text
+#ifdef __ghs__
+	.thumb2
+#else
 	.syntax	unified
 	.thumb
+#endif
 
 /****************************************************************************
  * Public Functions
@@ -52,7 +56,11 @@
 
 	.globl	up_saveusercontext
 	.globl	up_saveusercontext
+#ifdef __ghs__
+	.type	up_saveusercontext, $function
+#else
 	.type	up_saveusercontext, %function
+#endif
 
 up_saveusercontext:
 

--- a/arch/arm/src/armv7-m/barriers.h
+++ b/arch/arm/src/armv7-m/barriers.h
@@ -31,12 +31,12 @@
 
 /* ARMv7-M memory barriers */
 
-#define arm_isb(n) __asm__ __volatile__ ("isb " #n : : : "memory")
-#define arm_dsb(n) __asm__ __volatile__ ("dsb " #n : : : "memory")
-#define arm_dmb(n) __asm__ __volatile__ ("dmb " #n : : : "memory")
+#define arm_dsb()  __asm__ __volatile__ ("dsb " : : : "memory")
+#define arm_isb()  __asm__ __volatile__ ("isb " : : : "memory")
+#define arm_dmb()  __asm__ __volatile__ ("dmb " : : : "memory")
 
-#define ARM_DSB()  arm_dsb(15)
-#define ARM_ISB()  arm_isb(15)
-#define ARM_DMB()  arm_dmb(15)
+#define ARM_DSB()  arm_dsb()
+#define ARM_ISB()  arm_isb()
+#define ARM_DMB()  arm_dmb()
 
 #endif /* __ARCH_ARM_SRC_ARMV7_M_BARRIERS_H */

--- a/arch/arm/src/armv7-r/barriers.h
+++ b/arch/arm/src/armv7-r/barriers.h
@@ -31,15 +31,15 @@
 
 /* ARMv7-R memory barriers */
 
-#define arm_isb(n) __asm__ __volatile__ ("isb " #n : : : "memory")
 #define arm_dsb(n) __asm__ __volatile__ ("dsb " #n : : : "memory")
 #define arm_dmb(n) __asm__ __volatile__ ("dmb " #n : : : "memory")
+#define arm_isb()  __asm__ __volatile__ ("isb " : : : "memory")
 #define arm_nop()  __asm__ __volatile__ ("nop\n")
 #define arm_sev()  __asm__ __volatile__ ("sev\n")
 
 #define ARM_DSB()  arm_dsb(15)
-#define ARM_ISB()  arm_isb(15)
 #define ARM_DMB()  arm_dmb(15)
+#define ARM_ISB()  arm_isb()
 #define ARM_NOP()  arm_nop()
 #define ARM_SEV()  arm_sev()
 

--- a/arch/arm/src/armv8-m/barriers.h
+++ b/arch/arm/src/armv8-m/barriers.h
@@ -31,12 +31,12 @@
 
 /* ARMv8-M memory barriers */
 
-#define arm_isb(n) __asm__ __volatile__ ("isb " #n : : : "memory")
+#define arm_isb()  __asm__ __volatile__ ("isb " : : : "memory")
+#define arm_dmb()  __asm__ __volatile__ ("dmb " : : : "memory")
 #define arm_dsb(n) __asm__ __volatile__ ("dsb " #n : : : "memory")
-#define arm_dmb(n) __asm__ __volatile__ ("dmb " #n : : : "memory")
 
+#define ARM_ISB()  arm_isb()
+#define ARM_DMB()  arm_dmb()
 #define ARM_DSB()  arm_dsb(15)
-#define ARM_ISB()  arm_isb(15)
-#define ARM_DMB()  arm_dmb(15)
 
 #endif /* __ARCH_ARM_SRC_ARMV8_M_BARRIERS_H */

--- a/arch/arm/src/armv8-r/barriers.h
+++ b/arch/arm/src/armv8-r/barriers.h
@@ -31,15 +31,15 @@
 
 /* ARMv8-R memory barriers */
 
-#define arm_isb(n) __asm__ __volatile__ ("isb " #n : : : "memory")
 #define arm_dsb(n) __asm__ __volatile__ ("dsb " #n : : : "memory")
 #define arm_dmb(n) __asm__ __volatile__ ("dmb " #n : : : "memory")
+#define arm_isb()  __asm__ __volatile__ ("isb " : : : "memory")
 #define arm_nop()  __asm__ __volatile__ ("nop\n")
 #define arm_sev()  __asm__ __volatile__ ("sev\n")
 
 #define ARM_DSB()  arm_dsb(15)
-#define ARM_ISB()  arm_isb(15)
 #define ARM_DMB()  arm_dmb(15)
+#define ARM_ISB()  arm_isb()
 #define ARM_NOP()  arm_nop()
 #define ARM_SEV()  arm_sev()
 

--- a/arch/arm/src/common/gnu/fork.S
+++ b/arch/arm/src/common/gnu/fork.S
@@ -26,7 +26,6 @@
 
 #include "arm_fork.h"
 
-	.syntax	unified
 	.file	"fork.S"
 
 /****************************************************************************
@@ -78,7 +77,11 @@
  ****************************************************************************/
 
 	.globl	up_fork
+#ifdef __ghs__
+	.type	up_fork, $function
+#else
 	.type	up_fork, function
+#endif
 
 up_fork:
 	/* Create a stack frame */

--- a/arch/arm64/include/spinlock.h
+++ b/arch/arm64/include/spinlock.h
@@ -59,8 +59,8 @@
  *            all memory accesses are complete
  */
 
-#define SP_DSB(n) __asm__ __volatile__ ("dsb sy" : : : "memory")
-#define SP_DMB(n) __asm__ __volatile__ ("dmb st" : : : "memory")
+#define SP_DSB() __asm__ __volatile__ ("dsb sy" : : : "memory")
+#define SP_DMB() __asm__ __volatile__ ("dmb st" : : : "memory")
 
 #define SP_WFE() __asm__ __volatile__ ("wfe" : : : "memory")
 #define SP_SEV() __asm__ __volatile__ ("sev" : : : "memory")

--- a/arch/ceva/include/spinlock.h
+++ b/arch/ceva/include/spinlock.h
@@ -61,8 +61,8 @@
  *
  */
 
-#define SP_DSB(n) up_dsb()
-#define SP_DMB(n) up_dmb()
+#define SP_DSB() up_dsb()
+#define SP_DMB() up_dmb()
 
 /****************************************************************************
  * Public Types

--- a/arch/risc-v/include/spinlock.h
+++ b/arch/risc-v/include/spinlock.h
@@ -59,8 +59,8 @@
  *
  */
 
-#define SP_DSB(n) __asm__ __volatile__ ("fence")
-#define SP_DMB(n) __asm__ __volatile__ ("fence")
+#define SP_DSB() __asm__ __volatile__ ("fence")
+#define SP_DMB() __asm__ __volatile__ ("fence")
 
 /****************************************************************************
  * Public Types

--- a/arch/x86_64/include/spinlock.h
+++ b/arch/x86_64/include/spinlock.h
@@ -55,8 +55,8 @@
  *
  */
 
-#define SP_DSB(n) __asm__ __volatile__ ("mfence")
-#define SP_DMB(n) __asm__ __volatile__ ("mfence")
+#define SP_DSB() __asm__ __volatile__ ("mfence")
+#define SP_DMB() __asm__ __volatile__ ("mfence")
 
 /****************************************************************************
  * Public Types

--- a/libs/libc/machine/arm/gnu/arch_setjmp.S
+++ b/libs/libc/machine/arm/gnu/arch_setjmp.S
@@ -31,7 +31,9 @@
 	.globl	setjmp
 	.globl	longjmp
 
+#ifndef __ghs__
 	.syntax	unified
+#endif
 	.file	"setjmp.S"
 
 /****************************************************************************
@@ -59,7 +61,12 @@
  *
  ****************************************************************************/
 
+#ifndef __ghs__
 	.type	setjmp, function
+#else
+	.type	setjmp, $function
+#endif
+
 setjmp:
 
 	/* Store callee-saved Core registers */
@@ -121,7 +128,11 @@ setjmp:
  *
  ****************************************************************************/
 
+#ifndef __ghs__
 	.type	longjmp, function
+#else
+	.type	longjmp, $function
+#endif
 longjmp:
 
 	/* Load callee-saved Core registers */

--- a/libs/libc/modlib/modlib_globals.S
+++ b/libs/libc/modlib/modlib_globals.S
@@ -16,7 +16,11 @@
 	.type	SYMBOL(\ep), "object"
 	.endm
 	.macro SIZE ep
+#  if defined(__ghs__)
+	.size	SYMBOL(ep), . - SYMBOL(ep)
+#  else
 	.size	SYMBOL(\ep), . - SYMBOL(\ep)
+#  endif
 	.endm
 #else
 #  define SYMBOL(s) _##s


### PR DESCRIPTION
## Summary
1. fix the asm grammer error when build with greenhills compiler

## Impact

## Testing

