### PR TITLE
Coredump enhancement, optimized prompt statements

### DIFF
--- a/include/elf.h
+++ b/include/elf.h
@@ -233,6 +233,12 @@
 #define PF_X               1          /* Execute */
 #define PF_W               2          /* Write */
 #define PF_R               4          /* Read */
+#define PF_MASKOS          0x0ff00000 /* All bits included in the PF_MASKOS
+                                       * mask are reserved for operating system-specific
+                                       * semantics.
+                                       */
+#define PF_REGISTER        0x00100000 /* Register, need pointer aligned access */
+
 #define PF_MASKPROC        0xf0000000 /* Unspecified */
 
 /* Figure 5-10: Dynamic Array Tags, d_tag */

--- a/include/nuttx/coredump.h
+++ b/include/nuttx/coredump.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * sched/misc/coredump.h
+ * include/nuttx/coredump.h
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,18 +18,29 @@
  *
  ****************************************************************************/
 
-#ifndef __SCHED_MISC_COREDUMP_H
-#define __SCHED_MISC_COREDUMP_H
+#ifndef __INCLUDE_NUTTX_COREDUMP_H
+#define __INCLUDE_NUTTX_COREDUMP_H
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
 
+#include <nuttx/memoryregion.h>
 #include <unistd.h>
 
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
+
+/****************************************************************************
+ * Name: coredump_set_memory_region
+ *
+ * Description:
+ *   Set do coredump memory region.
+ *
+ ****************************************************************************/
+
+int coredump_set_memory_region(FAR struct memory_region_s *region);
 
 /****************************************************************************
  * Name: coredump_initialize
@@ -55,4 +66,4 @@ int coredump_initialize(void);
 
 void coredump_dump(pid_t pid);
 
-#endif /* __SCHED_MISC_COREDUMP_H */
+#endif /* __INCLUDE_NUTTX_COREDUMP_H */

--- a/sched/init/nx_bringup.c
+++ b/sched/init/nx_bringup.c
@@ -32,6 +32,7 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
+#include <nuttx/coredump.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/init.h>
 #include <nuttx/nuttx.h>
@@ -49,7 +50,6 @@
 #include "sched/sched.h"
 #include "wqueue/wqueue.h"
 #include "init/init.h"
-#include "misc/coredump.h"
 
 #ifdef CONFIG_ETC_ROMFS
 #  include <nuttx/drivers/ramdisk.h>

--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -26,6 +26,7 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
+#include <nuttx/coredump.h>
 #include <nuttx/irq.h>
 #include <nuttx/tls.h>
 #include <nuttx/signal.h>
@@ -46,7 +47,6 @@
 #include "irq/irq.h"
 #include "sched/sched.h"
 #include "group/group.h"
-#include "misc/coredump.h"
 
 /****************************************************************************
  * Pre-processor Definitions

--- a/sched/misc/coredump.c
+++ b/sched/misc/coredump.c
@@ -23,10 +23,9 @@
  ****************************************************************************/
 
 #include <nuttx/binfmt/binfmt.h>
+#include <nuttx/coredump.h>
 #include <syslog.h>
 #include <debug.h>
-
-#include "misc/coredump.h"
 
 /****************************************************************************
  * Private Data
@@ -166,6 +165,22 @@ static void coredump_dump_blkdev(pid_t pid)
 #endif
 
 /****************************************************************************
+ * Name: coredump_set_memory_region
+ *
+ * Description:
+ *   Set do coredump memory region.
+ *
+ ****************************************************************************/
+
+int coredump_set_memory_region(FAR struct memory_region_s *region)
+{
+  /* Not free g_regions, because allow call this fun when crash */
+
+  g_regions = region;
+  return 0;
+}
+
+/****************************************************************************
  * Name: coredump_initialize
  *
  * Description:
@@ -180,7 +195,8 @@ int coredump_initialize(void)
 
   if (CONFIG_BOARD_MEMORY_RANGE[0] != '\0')
     {
-      g_regions = alloc_memory_region(CONFIG_BOARD_MEMORY_RANGE);
+      coredump_set_memory_region(
+         alloc_memory_region(CONFIG_BOARD_MEMORY_RANGE));
       if (g_regions == NULL)
         {
           _alert("Coredump memory region alloc fail\n");

--- a/sched/misc/coredump.c
+++ b/sched/misc/coredump.c
@@ -115,7 +115,7 @@ static void coredump_dump_blkdev(pid_t pid)
 
   if (g_blockstream.inode == NULL)
     {
-      _alert("Coredump Device Not Found\n");
+      _alert("Coredump device not found\n");
       return;
     }
 
@@ -123,14 +123,15 @@ static void coredump_dump_blkdev(pid_t pid)
                       g_blockinfo, g_blockstream.geo.geo_nsectors - 1, 1);
   if (ret < 0)
     {
-      _alert("Coredump Device Read Fail\n");
+      _alert("Coredump information read fail\n");
       return;
     }
 
   info = (FAR struct coredump_info_s *)g_blockinfo;
   if (info->magic == COREDUMP_MAGIC)
     {
-      _alert("Coredump Device Already Used\n");
+      _alert("Coredump exists in %s, skip\n",
+              CONFIG_BOARD_COREDUMP_BLKDEV_PATH);
       return;
     }
 
@@ -143,7 +144,7 @@ static void coredump_dump_blkdev(pid_t pid)
   ret = core_dump(g_regions, stream, pid);
   if (ret < 0)
     {
-      _alert("Coredump Fail\n");
+      _alert("Coredump fail\n");
       return;
     }
 
@@ -151,8 +152,16 @@ static void coredump_dump_blkdev(pid_t pid)
   info->size  = g_blockstream.common.nput;
   info->time = time(NULL);
   uname(&info->name);
-  g_blockstream.inode->u.i_bops->write(g_blockstream.inode,
+  ret = g_blockstream.inode->u.i_bops->write(g_blockstream.inode,
                 (FAR void *)info, g_blockstream.geo.geo_nsectors - 1, 1);
+  if (ret < 0)
+    {
+      _alert("Coredump information write fail\n");
+      return;
+    }
+
+  _alert("Finish coredump, write %d bytes to %s\n",
+         info->size, CONFIG_BOARD_COREDUMP_BLKDEV_PATH);
 }
 #endif
 
@@ -174,7 +183,7 @@ int coredump_initialize(void)
       g_regions = alloc_memory_region(CONFIG_BOARD_MEMORY_RANGE);
       if (g_regions == NULL)
         {
-          _alert("Memory Region Alloc Fail\n");
+          _alert("Coredump memory region alloc fail\n");
           return -ENOMEM;
         }
     }
@@ -184,7 +193,7 @@ int coredump_initialize(void)
                               CONFIG_BOARD_COREDUMP_BLKDEV_PATH);
   if (ret < 0)
     {
-      _alert("%s Coredump Device Not Found\n",
+      _alert("%s Coredump device not found\n",
              CONFIG_BOARD_COREDUMP_BLKDEV_PATH);
       free_memory_region(g_regions);
       g_regions = NULL;
@@ -194,7 +203,7 @@ int coredump_initialize(void)
   g_blockinfo = kmm_malloc(g_blockstream.geo.geo_sectorsize);
   if (g_blockinfo == NULL)
     {
-      _alert("Coredump Device Memory Alloc Fail\n");
+      _alert("Coredump device memory alloc fail\n");
       free_memory_region(g_regions);
       g_regions = NULL;
       lib_blkoutstream_close(&g_blockstream);


### PR DESCRIPTION
## Summary

Coredump enhancement, optimized prompt statements
1. In some architectures, registers cannot be copied using memcpy. However, reading the register contents by uintptr is supported.
2. Optimized the message prompts after successfully or unsuccessfully using coredump.

## Impact
coredump
## Testing

vela & qemu wtih mpsan547 use coredump