### PR TITLE
libc:Add macro restrictions to code that uses floating point numbers

### DIFF
--- a/include/time.h
+++ b/include/time.h
@@ -217,7 +217,7 @@ time_t time(FAR time_t *timep);
 
 #ifdef CONFIG_HAVE_DOUBLE
 double difftime(time_t time1, time_t time0);
-#else
+#elif defined(CONFIG_HAVE_FLOAT)
 float difftime(time_t time1, time_t time0);
 #endif
 

--- a/include/wchar.h
+++ b/include/wchar.h
@@ -202,7 +202,9 @@ FAR wchar_t      *wcsstr(FAR const wchar_t *, FAR const wchar_t *);
 #ifdef CONFIG_HAVE_DOUBLE
 double            wcstod(FAR const wchar_t *, FAR wchar_t **);
 #endif
+#ifdef CONFIG_HAVE_FLOAT
 float             wcstof(FAR const wchar_t *, FAR wchar_t **);
+#endif
 FAR wchar_t      *wcstok(FAR wchar_t *, FAR const wchar_t *, FAR wchar_t **);
 long int          wcstol(FAR const wchar_t *, FAR wchar_t **, int);
 #ifdef CONFIG_HAVE_LONG_DOUBLE

--- a/libs/libc/stdio/lib_libvscanf.c
+++ b/libs/libc/stdio/lib_libvscanf.c
@@ -174,7 +174,10 @@ doswitch:
     }
 
 doexit:
-  if (v)                        /* Default => accept */
+
+  /* Default => accept */
+
+  if (v)
     {
       for (i = 0; i < 32; i++)  /* Invert all */
         {
@@ -950,7 +953,10 @@ int lib_vscanf(FAR struct lib_instream_s *stream, FAR int *lastc,
 #ifdef CONFIG_HAVE_DOUBLE
               FAR double *pd = NULL;
 #endif
+
+#ifdef CONFIG_HAVE_FLOAT
               FAR float *pf = NULL;
+#endif
 
               linfo("Performing floating point conversion\n");
 
@@ -973,10 +979,12 @@ int lib_vscanf(FAR struct lib_instream_s *stream, FAR int *lastc,
                     }
                   else
 #endif
+#ifdef CONFIG_HAVE_FLOAT
                     {
                       pf = va_arg(ap, FAR float *);
                       *pf = 0.0;
                     }
+#endif
                 }
 
 #ifdef CONFIG_LIBC_FLOATINGPOINT
@@ -994,7 +1002,9 @@ int lib_vscanf(FAR struct lib_instream_s *stream, FAR int *lastc,
 
               if (c > 0)
                 {
+#  if defined(CONFIG_HAVE_DOUBLE) || defined(CONFIG_HAVE_FLOAT)
                   FAR char *endptr;
+#  endif
                   bool expnt;
                   bool dot;
                   bool sign;
@@ -1003,8 +1013,9 @@ int lib_vscanf(FAR struct lib_instream_s *stream, FAR int *lastc,
 #  ifdef CONFIG_HAVE_DOUBLE
                   double dvalue;
 #  endif
+#  ifdef CONFIG_HAVE_FLOAT
                   float fvalue;
-
+#  endif
                   /* Was a fieldwidth specified? */
 
                   if (!width || width > sizeof(tmp) - 1)
@@ -1093,17 +1104,21 @@ int lib_vscanf(FAR struct lib_instream_s *stream, FAR int *lastc,
                     }
                   else
 #  endif
+#  ifdef CONFIG_HAVE_FLOAT
                     {
                       fvalue = strtof(tmp, &endptr);
                     }
+#  endif
 
                   /* Check if the number was successfully converted */
 
+#  if defined(CONFIG_HAVE_DOUBLE) || defined(CONFIG_HAVE_FLOAT)
                   if (tmp == endptr || get_errno() == ERANGE)
                     {
                       *lastc = c;
                       return assigncount;
                     }
+#endif
 
                   set_errno(errsave);
 
@@ -1126,8 +1141,10 @@ int lib_vscanf(FAR struct lib_instream_s *stream, FAR int *lastc,
                         {
                           /* Return the float value */
 
+#  ifdef CONFIG_HAVE_FLOAT
                           linfo("Return %f to %p\n", (double)fvalue, pf);
                           *pf = fvalue;
+#  endif
                         }
 
                       assigncount++;

--- a/libs/libc/stdio/lib_libvsprintf.c
+++ b/libs/libc/stdio/lib_libvsprintf.c
@@ -131,7 +131,9 @@ struct arg_s
 #ifdef CONFIG_HAVE_LONG_LONG
     unsigned long long ull;
 #endif
+#ifdef CONFIG_HAVE_DOUBLE
     double d;
+#endif
     FAR char *cp;
   } value;
 };
@@ -1350,9 +1352,11 @@ int lib_vsprintf(FAR struct lib_outstream_s *stream,
           arglist[i].value.u = va_arg(ap, unsigned int);
           break;
 
+#ifdef CONFIG_HAVE_DOUBLE
         case TYPE_DOUBLE:
           arglist[i].value.d = va_arg(ap, double);
           break;
+#endif
 
         case TYPE_CHAR_POINTER:
           arglist[i].value.cp = va_arg(ap, FAR char *);

--- a/libs/libc/stdlib/Kconfig
+++ b/libs/libc/stdlib/Kconfig
@@ -8,10 +8,11 @@ menu "stdlib Options"
 config LIBC_RAND_ORDER
 	int "Order of the random number generate"
 	default 1
-	range 1 3
+	range 0 3
 	---help---
-		The order of the random number generator. 1=fast but very bad random
+		The order of the random number generator. 0=fast but very bad random
 		numbers, 3=slow but very good random numbers.
+		0 just use integer generation, 1-3 use floating point generation
 
 config LIBC_HOMEDIR
 	string "Home directory"

--- a/libs/libc/stdlib/lib_srand.c
+++ b/libs/libc/stdlib/lib_srand.c
@@ -218,6 +218,7 @@ static float_t frand3(void)
 static unsigned long nrand_r(unsigned long limit,
                              FAR unsigned long *seed)
 {
+#if CONFIG_LIBC_RAND_ORDER > 0
   unsigned long result;
   float_t ratio;
 
@@ -227,11 +228,11 @@ static unsigned long nrand_r(unsigned long limit,
     {
       /* Get a random integer in the range 0.0 - 1.0 */
 
-#if (CONFIG_LIBC_RAND_ORDER == 1)
+#  if (CONFIG_LIBC_RAND_ORDER == 1)
       ratio = frand1(seed);
-#elif (CONFIG_LIBC_RAND_ORDER == 2)
+#  elif (CONFIG_LIBC_RAND_ORDER == 2)
       ratio = frand2();
-#else /* if (CONFIG_LIBC_RAND_ORDER > 2) */
+#  elif (CONFIG_LIBC_RAND_ORDER > 2)
       ratio = frand3();
 #endif
 
@@ -246,6 +247,9 @@ static unsigned long nrand_r(unsigned long limit,
   while (result >= limit);
 
   return result;
+#else
+  return fgenerate1(seed) % limit;
+#endif
 }
 
 /****************************************************************************

--- a/libs/libc/stdlib/lib_strtold.c
+++ b/libs/libc/stdlib/lib_strtold.c
@@ -94,6 +94,8 @@
  * Private Functions
  ****************************************************************************/
 
+#ifdef CONFIG_HAVE_LONG_DOUBLE
+
 /****************************************************************************
  * Name: scanexp
  *
@@ -769,14 +771,10 @@ float strtof(FAR const char *str, FAR char **endptr)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_HAVE_DOUBLE
-
 double strtod(FAR const char *str, FAR char **endptr)
 {
   return strtox(str, endptr, 2);
 }
-
-#endif /* CONFIG_HAVE_DOUBLE */
 
 /****************************************************************************
  * Name: strtold
@@ -793,11 +791,8 @@ double strtod(FAR const char *str, FAR char **endptr)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_HAVE_LONG_DOUBLE
-
 long double strtold(FAR const char *str, FAR char **endptr)
 {
   return strtox(str, endptr, 3);
 }
-
 #endif /* CONFIG_HAVE_LONG_DOUBLE */

--- a/libs/libc/time/lib_difftime.c
+++ b/libs/libc/time/lib_difftime.c
@@ -48,7 +48,7 @@ double difftime(time_t time1, time_t time0)
 {
   return (double)time1 - (double)time0;
 }
-#else
+#elif defined(CONFIG_HAVE_FLOAT)
 float difftime(time_t time1, time_t time0)
 {
   if (time1 >= time0)

--- a/libs/libc/wchar/lib_wcstod.c
+++ b/libs/libc/wchar/lib_wcstod.c
@@ -48,7 +48,9 @@
  *
  ****************************************************************************/
 
+#ifdef CONFIG_HAVE_DOUBLE
 double wcstod(FAR const wchar_t *nptr, FAR wchar_t **endptr)
 {
   return strtod((FAR const char *)nptr, (FAR char **)endptr);
 }
+#endif

--- a/libs/libc/wchar/lib_wcstof.c
+++ b/libs/libc/wchar/lib_wcstof.c
@@ -48,7 +48,9 @@
  *
  ****************************************************************************/
 
+#ifdef CONFIG_HAVE_FLOAT
 float wcstof(FAR const wchar_t *nptr, FAR wchar_t **endptr)
 {
   return strtof((FAR const char *)nptr, (FAR char **)endptr);
 }
+#endif

--- a/libs/libc/wchar/lib_wcstold.c
+++ b/libs/libc/wchar/lib_wcstold.c
@@ -48,7 +48,9 @@
  *
  ****************************************************************************/
 
+#ifdef CONFIG_HAVE_LONG_DOUBLE
 long double wcstold(FAR const wchar_t *nptr, FAR wchar_t **endptr)
 {
   return strtold((FAR const char *)nptr, (FAR char **)endptr);
 }
+#endif


### PR DESCRIPTION
## Summary
Enclosed floating-point related functions using macros to be more compatible with chips that do not have an FPU.
## Impact
use float fuction
## Testing
vela & qmue arm64 with out fpu
