### PR TITLE
Reimplemented the mempool traversal function and fixed some existing bugs in the mempool

### DIFF
--- a/include/nuttx/mm/mempool.h
+++ b/include/nuttx/mm/mempool.h
@@ -61,6 +61,8 @@ typedef CODE FAR void *(*mempool_alloc_t)(FAR struct mempool_s *pool,
                                           size_t size);
 typedef CODE void (*mempool_free_t)(FAR struct mempool_s *pool,
                                     FAR void *addr);
+typedef CODE void (*mempool_check_t)(FAR struct mempool_s *pool,
+                                     FAR void *addr);
 
 typedef CODE FAR void *(*mempool_multiple_alloc_t)(FAR void *arg,
                                                    size_t alignment,
@@ -100,6 +102,7 @@ struct mempool_s
   FAR void  *priv;          /* This pointer is used to store the user's private data */
   mempool_alloc_t alloc;    /* The alloc function for mempool */
   mempool_free_t  free;     /* The free function for mempool */
+  mempool_check_t check;    /* The check function for mempool */
 
   /* Private data for memory pool */
 

--- a/include/nuttx/mm/mempool.h
+++ b/include/nuttx/mm/mempool.h
@@ -110,13 +110,9 @@ struct mempool_s
   sq_queue_t queue;   /* The free block queue in normal mempool */
   sq_queue_t iqueue;  /* The free block queue in interrupt mempool */
   sq_queue_t equeue;  /* The expand block queue for normal mempool */
-#if CONFIG_MM_BACKTRACE >= 0
-  struct list_node alist;     /* The used block list in mempool */
-#else
-  size_t     nalloc;    /* The number of used block in mempool */
-#endif
-  spinlock_t lock;      /* The protect lock to mempool */
-  sem_t      waitsem;   /* The semaphore of waiter get free block */
+  size_t     nalloc;  /* The number of used block in mempool */
+  spinlock_t lock;    /* The protect lock to mempool */
+  sem_t      waitsem; /* The semaphore of waiter get free block */
 #if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_MEMPOOL)
   struct mempool_procfs_entry_s procfs; /* The entry of procfs */
 #endif
@@ -125,7 +121,9 @@ struct mempool_s
 #if CONFIG_MM_BACKTRACE >= 0
 struct mempool_backtrace_s
 {
-  struct list_node node;
+  unsigned int magic; /* The guard byte, mark is alloc / free, and check
+                       * if there is any out of bounds.
+                       */
   pid_t pid;
   unsigned long seqno; /* The sequence of memory malloc */
 #  if CONFIG_MM_BACKTRACE > 0

--- a/mm/mempool/mempool.c
+++ b/mm/mempool/mempool.c
@@ -533,7 +533,6 @@ mempool_info_task(FAR struct mempool_s *pool,
                   FAR const struct malltask *task)
 {
   size_t blocksize = MEMPOOL_REALBLOCKSIZE(pool);
-  irqstate_t flags = spin_lock_irqsave(&pool->lock);
   struct mallinfo_task info =
     {
       0, 0
@@ -541,8 +540,11 @@ mempool_info_task(FAR struct mempool_s *pool,
 
   if (task->pid == PID_MM_FREE)
     {
+      irqstate_t flags = spin_lock_irqsave(&pool->lock);
       size_t count = sq_count(&pool->queue) +
                      sq_count(&pool->iqueue);
+
+      spin_unlock_irqrestore(&pool->lock, flags);
       info.aordblks += count;
       info.uordblks += count * blocksize;
     }
@@ -558,7 +560,6 @@ mempool_info_task(FAR struct mempool_s *pool,
     }
 #endif
 
-  spin_unlock_irqrestore(&pool->lock, flags);
   return info;
 }
 

--- a/mm/mempool/mempool.c
+++ b/mm/mempool/mempool.c
@@ -221,7 +221,7 @@ static void mempool_memdump_callback(FAR struct mempool_s *pool,
       syslog(LOG_INFO, "%6d%12zu%12lu%*p%s\n",
              buf->pid, blocksize, buf->seqno,
              MM_PTR_FMT_WIDTH,
-             ((FAR char *)buf - blocksize), tmp);
+             ((FAR char *)buf - pool->blocksize), tmp);
     }
 }
 
@@ -235,7 +235,8 @@ mempool_memdump_free_callback(FAR struct mempool_s *pool,
   if (buf->magic == MEMPOOL_MAGIC_FREE)
     {
       syslog(LOG_INFO, "%12zu%*p\n",
-             blocksize, MM_PTR_FMT_WIDTH, ((FAR char *)buf - blocksize));
+             blocksize, MM_PTR_FMT_WIDTH,
+             ((FAR char *)buf - pool->blocksize));
     }
 }
 #endif

--- a/mm/mempool/mempool.c
+++ b/mm/mempool/mempool.c
@@ -646,6 +646,8 @@ int mempool_deinit(FAR struct mempool_s *pool)
   while ((blk = mempool_remove_queue(pool, &pool->equeue)) != NULL)
     {
       blk = (FAR sq_entry_t *)((FAR char *)blk - count * blocksize);
+
+      kasan_unpoison(blk, count * blocksize + sizeof(sq_entry_t));
       pool->free(pool, blk);
       if (pool->expandsize >= blocksize + sizeof(sq_entry_t))
         {
@@ -655,6 +657,8 @@ int mempool_deinit(FAR struct mempool_s *pool)
 
   if (pool->ibase)
     {
+      kasan_unpoison(pool->ibase,
+                     pool->interruptsize / blocksize * blocksize);
       pool->free(pool, pool->ibase);
     }
 

--- a/mm/mempool/mempool.c
+++ b/mm/mempool/mempool.c
@@ -202,7 +202,7 @@ static void mempool_memdump_callback(FAR struct mempool_s *pool,
        MM_DUMP_LEAK(dump->pid, buf->pid)) &&
       buf->seqno >= dump->seqmin && buf->seqno <= dump->seqmax)
     {
-      char tmp[CONFIG_MM_BACKTRACE * MM_PTR_FMT_WIDTH + 1] = "";
+      char tmp[CONFIG_MM_BACKTRACE * BACKTRACE_PTR_FMT_WIDTH + 1] = "";
 
 #  if CONFIG_MM_BACKTRACE > 0
       FAR const char *format = " %0*p";
@@ -211,16 +211,16 @@ static void mempool_memdump_callback(FAR struct mempool_s *pool,
       for (i = 0; i < CONFIG_MM_BACKTRACE &&
                       buf->backtrace[i]; i++)
         {
-          snprintf(tmp + i * MM_PTR_FMT_WIDTH,
-                   sizeof(tmp) - i * MM_PTR_FMT_WIDTH,
-                   format, MM_PTR_FMT_WIDTH - 1,
+          snprintf(tmp + i * BACKTRACE_PTR_FMT_WIDTH,
+                   sizeof(tmp) - i * BACKTRACE_PTR_FMT_WIDTH,
+                   format, BACKTRACE_PTR_FMT_WIDTH - 1,
                    buf->backtrace[i]);
         }
 #  endif
 
       syslog(LOG_INFO, "%6d%12zu%12lu%*p%s\n",
              buf->pid, blocksize, buf->seqno,
-             MM_PTR_FMT_WIDTH,
+             BACKTRACE_PTR_FMT_WIDTH,
              ((FAR char *)buf - pool->blocksize), tmp);
     }
 }
@@ -235,7 +235,7 @@ mempool_memdump_free_callback(FAR struct mempool_s *pool,
   if (buf->magic == MEMPOOL_MAGIC_FREE)
     {
       syslog(LOG_INFO, "%12zu%*p\n",
-             blocksize, MM_PTR_FMT_WIDTH,
+             blocksize, BACKTRACE_PTR_FMT_WIDTH,
              ((FAR char *)buf - pool->blocksize));
     }
 }
@@ -601,7 +601,7 @@ void mempool_memdump(FAR struct mempool_s *pool,
   /* Avoid race condition */
 
   syslog(LOG_INFO, "%12zu%*p skip block dump\n",
-         blocksize, MM_PTR_FMT_WIDTH, pool);
+         blocksize, BACKTRACE_PTR_FMT_WIDTH, pool);
 #endif
 }
 

--- a/mm/mempool/mempool_multiple.c
+++ b/mm/mempool/mempool_multiple.c
@@ -754,6 +754,12 @@ mempool_multiple_mallinfo(FAR struct mempool_multiple_s *mpool)
   struct mallinfo info;
   size_t i;
 
+  if (mpool == NULL)
+    {
+      memset(&info, 0, sizeof(struct mallinfo));
+      return info;
+    }
+
   memset(&info, 0, sizeof(struct mallinfo));
 
   nxrmutex_lock(&mpool->lock);
@@ -838,6 +844,11 @@ void mempool_multiple_memdump(FAR struct mempool_multiple_s *mpool,
 {
   size_t i;
 
+  if (mpool == NULL)
+    {
+      return;
+    }
+
   for (i = 0; i < mpool->npools; i++)
     {
       mempool_memdump(mpool->pools + i, dump);
@@ -859,7 +870,10 @@ void mempool_multiple_deinit(FAR struct mempool_multiple_s *mpool)
 {
   size_t i;
 
-  DEBUGASSERT(mpool != NULL);
+  if (mpool == NULL)
+    {
+      return;
+    }
 
   for (i = 0; i < mpool->npools; i++)
     {

--- a/mm/mempool/mempool_multiple.c
+++ b/mm/mempool/mempool_multiple.c
@@ -315,6 +315,15 @@ mempool_multiple_get_dict(FAR struct mempool_multiple_s *mpool,
     }
 
   addr = (FAR void *)ALIGN_DOWN(blk, mpool->expandsize);
+  if (blk == addr)
+    {
+      /* It is not a memory block allocated by mempool
+       * Because the blk is need not aligned with the expandsize
+       * in head memory.
+       */
+
+      return NULL;
+    }
 
   index = *(FAR size_t *)addr;
   if (index >= mpool->dict_used)

--- a/mm/mempool/mempool_multiple.c
+++ b/mm/mempool/mempool_multiple.c
@@ -895,5 +895,5 @@ void mempool_multiple_deinit(FAR struct mempool_multiple_s *mpool)
   mempool_multiple_free_chunk(mpool, mpool->dict);
   mempool_multiple_free_chunk(mpool, mpool->pools);
   nxrmutex_destroy(&mpool->lock);
-  mpool->free(mpool, mpool);
+  mpool->free(mpool->arg, mpool);
 }

--- a/mm/mempool/mempool_multiple.c
+++ b/mm/mempool/mempool_multiple.c
@@ -335,6 +335,24 @@ mempool_multiple_get_dict(FAR struct mempool_multiple_s *mpool,
 }
 
 /****************************************************************************
+ * Name: mempool_multiple_check
+ *
+ * Description:
+ *   Check the blk is in the pool
+ *
+ * Input Parameters:
+ *   mpool - The handle of the multiple memory pool to be used.
+ *   blk   - The pointer of memory block.
+ *
+ ****************************************************************************/
+
+static void mempool_multiple_check(FAR struct mempool_s *pool,
+                                   FAR void *blk)
+{
+  assert(mempool_multiple_get_dict(pool->priv, blk));
+}
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -439,6 +457,8 @@ mempool_multiple_init(FAR const char *name,
       pools[i].priv = mpool;
       pools[i].alloc = mempool_multiple_alloc_callback;
       pools[i].free = mempool_multiple_free_callback;
+      pools[i].check = mempool_multiple_check;
+
       ret = mempool_init(pools + i, name);
       if (ret < 0)
         {

--- a/tools/gdb/memdump.py
+++ b/tools/gdb/memdump.py
@@ -21,20 +21,23 @@
 import argparse
 
 import gdb
-import utils
-from lists import list_for_each_entry, sq_for_every, sq_queue
-
-mempool_backtrace = utils.CachedType("struct mempool_backtrace_s")
+from lists import sq_for_every, sq_queue
+from utils import get_symbol_value
 
 MM_ALLOC_BIT = 0x1
 MM_PREVFREE_BIT = 0x2
 MM_MASK_BIT = MM_ALLOC_BIT | MM_PREVFREE_BIT
-
+MEMPOOL_MAGIC_ALLOC = 0x55555555
 
 PID_MM_FREE = -4
 PID_MM_ALLOC = -3
 PID_MM_LEAK = -2
 PID_MM_MEMPOOL = -1
+
+
+def align_up(size, align) -> int:
+    """Align the size to the specified alignment"""
+    return (size + (align - 1)) & ~(align - 1)
 
 
 def mm_nodesize(size) -> int:
@@ -67,6 +70,48 @@ def mempool_multiple_foreach(mpool):
         i += 1
 
 
+def mempool_realblocksize(pool):
+    """Return the real block size of a mempool"""
+
+    if get_symbol_value("CONFIG_MM_DFAULT_ALIGNMENT") == 0:
+        mempool_align = 2 * gdb.lookup_type("size_t").sizeof
+    else:
+        mempool_align = get_symbol_value("CONFIG_MM_DFAULT_ALIGNMENT")
+
+    if get_symbol_value("CONFIG_MM_BACKTRACE") >= 0:
+        return align_up(
+            pool["blocksize"] + gdb.lookup_type("struct mempool_backtrace_s").sizeof,
+            mempool_align,
+        )
+    else:
+        return pool["blocksize"]
+
+
+def mempool_foreach(pool):
+    """Iterate over all block in a mempool"""
+
+    blocksize = mempool_realblocksize(pool)
+    if pool["ibase"] != 0:
+        nblk = pool["interruptsize"] / blocksize
+        while nblk > 0:
+            bufaddr = gdb.Value(pool["ibase"] + nblk * blocksize + pool["blocksize"])
+            buf = bufaddr.cast(gdb.lookup_type("struct mempool_backtrace_s").pointer())
+            yield buf
+            nblk -= 1
+
+    entry = sq_queue.get_type().pointer()
+    for entry in sq_for_every(pool["equeue"], entry):
+        nblk = (pool["expandsize"] - gdb.lookup_type("sq_entry_t").sizeof) / blocksize
+        base = (
+            gdb.Value(entry).cast(gdb.lookup_type("char").pointer()) - nblk * blocksize
+        )
+        while nblk > 0:
+            bufaddr = gdb.Value(base + nblk * blocksize + pool["blocksize"])
+            buf = bufaddr.cast(gdb.lookup_type("struct mempool_backtrace_s").pointer())
+            yield buf
+            nblk -= 1
+
+
 class Nxmemdump(gdb.Command):
     """Dump the heap and mempool memory"""
 
@@ -89,31 +134,31 @@ class Nxmemdump(gdb.Command):
                     self.aordblks += 1
                     self.uordblks += pool["blocksize"]
             else:
-                for node in list_for_each_entry(
-                    pool["alist"], mempool_backtrace.get_type().pointer(), "node"
-                ):
-                    if (pid == node["pid"] or pid == PID_MM_ALLOC) and (
-                        node["seqno"] >= seqmin and node["seqno"] < seqmax
+                for buf in mempool_foreach(pool):
+                    if (
+                        (pid == buf["pid"] or pid == PID_MM_ALLOC)
+                        and (buf["seqno"] >= seqmin and buf["seqno"] < seqmax)
+                        and buf["magic"] == MEMPOOL_MAGIC_ALLOC
                     ):
-                        charnode = gdb.Value(node).cast(
+                        charnode = gdb.Value(buf).cast(
                             gdb.lookup_type("char").pointer()
                         )
                         gdb.write(
                             "%6d%12u%12u%#*x"
                             % (
-                                node["pid"],
+                                buf["pid"],
                                 mm_nodesize(pool["blocksize"]),
-                                node["seqno"],
+                                buf["seqno"],
                                 self.align,
                                 (int)(charnode - pool["blocksize"]),
                             )
                         )
-                        if node.type.has_key("backtrace"):
-                            max = node["backtrace"].type.range()[1]
+                        if buf.type.has_key("backtrace"):
+                            max = buf["backtrace"].type.range()[1]
                             for x in range(0, max):
                                 gdb.write(" ")
                                 gdb.write(
-                                    node["backtrace"][x].format_string(
+                                    buf["backtrace"][x].format_string(
                                         raw=False, symbols=True, address=False
                                     )
                                 )

--- a/tools/gdb/utils.py
+++ b/tools/gdb/utils.py
@@ -179,3 +179,10 @@ def is_target_smp():
         return True
     else:
         return False
+
+
+def get_symbol_value(name):
+    """Return the value of a symbol value etc: Variable, Marco"""
+
+    gdb.execute("set $_%s = %s" % (name, name))
+    return gdb.parse_and_eval("$_%s" % name)


### PR DESCRIPTION
## Summary
Reimplemented the mempool traversal function and fixed some existing bugs in the mempool.

Re-implementation:
The previous implementation could not effectively handle the use of memdump in an SMP environment because syslog would create race conditions under SMP. Therefore, instead of traversing the linked list, we directly traverse the entire memory address space. This approach avoids race conditions in an SMP environment and makes debugging easier.

bug fix:
1. fix bug when deinit mpool, wrong parameters used
2. Need check mpool is NULL
3. need unposion memory when deinit
4. fix bug when free a alignment address
5. fix mempool memdump address incorrect printing
6. fix memdump leak will hang on spinlock

## Impact
mempool
## Testing
vela & qmue mpsan547 mm testing with mempool
