### PR TITLE
armv8-m:fix log warnning

### DIFF
--- a/arch/arm/src/armv8-m/arm_hardfault.c
+++ b/arch/arm/src/armv8-m/arm_hardfault.c
@@ -162,7 +162,7 @@ int arm_hardfault(int irq, void *context, void *arg)
 
   hfalert("PANIC!!! Hard Fault!:");
   hfalert("\tIRQ: %d regs: %p\n", irq, context);
-  hfalert("\tBASEPRI: %08x PRIMASK: %08x IPSR: %08"
+  hfalert("\tBASEPRI: %08" PRIx8 " PRIMASK: %08" PRIx8 " IPSR: %08"
           PRIx32 " CONTROL: %08" PRIx32 "\n",
           getbasepri(), getprimask(), getipsr(), getcontrol());
   hfalert("\tCFSR: %08" PRIx32 " HFSR: %08" PRIx32 " DFSR: %08"

--- a/arch/arm/src/armv8-m/arm_memfault.c
+++ b/arch/arm/src/armv8-m/arm_memfault.c
@@ -66,9 +66,9 @@ int arm_memfault(int irq, void *context, void *arg)
 
   mfalert("PANIC!!! Memory Management Fault:\n");
   mfalert("\tIRQ: %d context: %p\n", irq, context);
-  mfalert("\tCFSR: %08x MMFAR: %08x\n",
+  mfalert("\tCFSR: %08" PRIx32 " MMFAR: %08" PRIx32 "\n",
           getreg32(NVIC_CFAULTS), getreg32(NVIC_MEMMANAGE_ADDR));
-  mfalert("\tBASEPRI: %08x PRIMASK: %08x IPSR: %08"
+  mfalert("\tBASEPRI: %08" PRIx32 " PRIMASK: %08" PRIx32 " IPSR: %08"
           PRIx32 " CONTROL: %08" PRIx32 "\n",
           getbasepri(), getprimask(), getipsr(), getcontrol());
 

--- a/arch/arm/src/armv8-m/arm_securefault.c
+++ b/arch/arm/src/armv8-m/arm_securefault.c
@@ -66,12 +66,13 @@ int arm_securefault(int irq, void *context, void *arg)
 
   sfalert("PANIC!!! Secure Fault:\n");
   sfalert("\tIRQ: %d regs: %p\n", irq, context);
-  sfalert("\tBASEPRI: %08x PRIMASK: %08x IPSR: %08"
+  sfalert("\tBASEPRI: %08" PRIx8 " PRIMASK: %08" PRIx8 " IPSR: %08"
           PRIx32 " CONTROL: %08" PRIx32 "\n",
           getbasepri(), getprimask(), getipsr(), getcontrol());
-  sfalert("\tCFSR: %08x HFSR: %08x DFSR: %08x\n", getreg32(NVIC_CFAULTS),
-          getreg32(NVIC_HFAULTS), getreg32(NVIC_DFAULTS));
-  sfalert("\tBFAR: %08x AFSR: %08x SFAR: %08x\n",
+  sfalert("\tCFSR: %08" PRIx32 " HFSR: %08" PRIx32 " DFSR: %08" PRIx32 "\n",
+          getreg32(NVIC_CFAULTS), getreg32(NVIC_HFAULTS),
+          getreg32(NVIC_DFAULTS));
+  sfalert("\tBFAR: %08" PRIx32 " AFSR: %08" PRIx32 " SFAR: %08" PRIx32 "\n",
           getreg32(NVIC_BFAULT_ADDR), getreg32(NVIC_AFAULTS),
           getreg32(SAU_SFAR));
 


### PR DESCRIPTION
armv8-m/arm_securefault.c:72:11: warning: format '%x' expects argument of type 'unsigned int', but argument 3 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
   72 |   sfalert("\tCFSR: %08x HFSR: %08x DFSR: %08x\n", getreg32(NVIC_CFAULTS),
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

## Summary
warnning fix
## Impact
armv8-m
## Testing
qemu mps3an547
