### PR TITLE
riscv/qemu-rv: add cluster PLIC/CLINT configs

### DIFF
--- a/arch/risc-v/src/qemu-rv/Kconfig
+++ b/arch/risc-v/src/qemu-rv/Kconfig
@@ -40,4 +40,24 @@ config ARCH_CHIP_QEMU_RV_ISA_V
 	default n
 	select ARCH_RV_ISA_V
 
-endif
+config ARCH_CHIP_QEMU_RV_CLUSTER
+	bool "Enable cluster support"
+	default n
+
+if ARCH_CHIP_QEMU_RV_CLUSTER
+
+config ARCH_CHIP_QEMU_RV_PLIC
+	hex "Base address of PLIC device"
+	default 0xc000000
+
+config ARCH_CHIP_QEMU_RV_CLINT
+	hex "Base address of CLINT device"
+	default 0x2000000
+
+config ARCH_CHIP_QEMU_RV_ACLINT
+	hex "Base address of ACLINT device"
+	default 0x2f00000
+
+endif # ARCH_CHIP_QEMU_RV_CLUSTER
+
+endif # ARCH_CHIP_QEMU_RV

--- a/arch/risc-v/src/qemu-rv/hardware/qemu_rv_memorymap.h
+++ b/arch/risc-v/src/qemu-rv/hardware/qemu_rv_memorymap.h
@@ -27,11 +27,25 @@
 
 /* Register Base Address ****************************************************/
 
-#define QEMU_RV_CLINT_BASE   0x02000000
-#define QEMU_RV_ACLINT_BASE  0x02f00000
-#define QEMU_RV_PLIC_BASE    0x0c000000
+#ifdef CONFIG_ARCH_CHIP_QEMU_RV_PLIC
+#  define QEMU_RV_PLIC_BASE    CONFIG_ARCH_CHIP_QEMU_RV_PLIC
+#else
+#  define QEMU_RV_PLIC_BASE    0xc000000
+#endif
 
-#define QEMU_RV_RESET_BASE   0x100000
+#ifdef CONFIG_ARCH_CHIP_QEMU_RV_CLINT
+#  define QEMU_RV_CLINT_BASE   CONFIG_ARCH_CHIP_QEMU_RV_CLINT
+#else
+#  define QEMU_RV_CLINT_BASE   0x2000000
+#endif
+
+#ifdef CONFIG_ARCH_CHIP_QEMU_RV_ACLINT
+#  define QEMU_RV_ACLINT_BASE  CONFIG_ARCH_CHIP_QEMU_RV_ACLINT
+#else
+#  define QEMU_RV_ACLINT_BASE  0x2f00000
+#endif
+
+#define   QEMU_RV_RESET_BASE   0x100000
 
 #ifdef CONFIG_ARCH_USE_S_MODE
 #  define QEMU_RV_APLIC_BASE   0x0d000000


### PR DESCRIPTION
## Summary

This adds cluster specific configs for PLIC, CLINT and ACLINT devices. The guard `QEMU_RV_CLUSTER` helps to avoid refreshing existing defconfig.

## Impacts

None

## Testing

CI checks
