### PR TITLE
arch/sim/src/cmake/Toolchain.cmake: macOS fix unknown options: --gc-sections

### DIFF
--- a/arch/sim/src/cmake/Toolchain.cmake
+++ b/arch/sim/src/cmake/Toolchain.cmake
@@ -97,7 +97,11 @@ else()
 endif()
 
 if(CONFIG_DEBUG_OPT_UNUSED_SECTIONS)
-  add_link_options(-Wl,--gc-sections)
+  if(APPLE)
+    add_link_options(-Wl,-dead_strip)
+  else()
+    add_link_options(-Wl,--gc-sections)
+  endif()
   add_compile_options(-ffunction-sections -fdata-sections)
 endif()
 


### PR DESCRIPTION
## Summary
macOS board -> sim  
fix ->  ld: unknown options: --gc-sections
added -> add_link_options(-Wl,-dead_strip)

## Impact
none
## Testing
CI