### PR TITLE
[bugfix] keep the incrementally compiled version time updated

### DIFF
--- a/libs/libc/misc/CMakeLists.txt
+++ b/libs/libc/misc/CMakeLists.txt
@@ -112,4 +112,12 @@ if(CONFIG_FDCHECK)
   list(APPEND SRCS lib_fdcheck.c)
 endif()
 
+if(NOT CONFIG_LIBC_UNAME_DISABLE_TIMESTAMP)
+  add_custom_target(
+    always_rebuild_lib_utsname
+    COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_CURRENT_SOURCE_DIR}/lib_utsname.c)
+
+  add_dependencies(c always_rebuild_lib_utsname)
+endif()
+
 target_sources(c PRIVATE ${SRCS})

--- a/libs/libc/misc/Make.defs
+++ b/libs/libc/misc/Make.defs
@@ -80,7 +80,7 @@ endif
 # add lib_utsname.o to phony target for force rebuild
 
 #if !defined(CONFIG_LIBC_UNAME_DISABLE_TIMESTAMP)
-.PHONY: lib_utsname$(OBJEXT)
+.PHONY: bin$(DELIM)lib_utsname$(OBJEXT) kbin$(DELIM)lib_utsname$(OBJEXT)
 #endif
 
 # Add the misc directory to the build


### PR DESCRIPTION
## Summary

when building incrementally, the ustname time information is wrong.

this patch fix phoney target mismatch issue, always rebuild ustname.

## Impact

## Testing

