### PR TITLE
[cmake] add_application supports only registration but not compilation

### DIFF
--- a/cmake/nuttx_add_application.cmake
+++ b/cmake/nuttx_add_application.cmake
@@ -161,6 +161,10 @@ function(nuttx_add_application)
         PRIVATE
           $<GENEX_EVAL:$<TARGET_PROPERTY:nuttx,NUTTX_ELF_APP_COMPILE_OPTIONS>>)
     endif()
+  else()
+    set(TARGET "apps_${NAME}")
+    add_custom_target(${TARGET})
+    set_property(GLOBAL APPEND PROPERTY NUTTX_APPS_ONLY_REGISTER ${TARGET})
   endif()
 
   # store parameters into properties (used during builtin list generation)


### PR DESCRIPTION
## Summary

for sources that have implemented _**`multiple`**_ prog_main in main src, 
there is a situation where we don't need to add source files 
BUT need to register. 

this patch support nuttx `nuttx_add_application` method is enhanced so that it can be registered without entering SRCS.

```c

/**
  demo_main.c
  has two builtin function
**/

int main(int argc, char *argv[])
{
    do_start();
}

int demo_stop_main(int argc, char *argv[])
{
    do_stop();
}

``` 

```cmake
 # add application with source
  nuttx_add_application(NAME demo_start SRCS demo_main.c)
 # add application only register
  nuttx_add_application(NAME demo_stop)
``` 

linkage: https://github.com/apache/nuttx-apps/pull/2478

## Impact

## Testing
CI build
