### PR TITLE
[bugfix] fix CMake build block when enable  LTO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -642,8 +642,8 @@ if(NOT CONFIG_ARCH_SIM)
 
   # TODO: nostart/nodefault not applicable to nuttx toolchain
   target_link_libraries(
-    nuttx PRIVATE -T${ldscript} -Wl,--start-group ${nuttx_libs}
-                  ${nuttx_extra_libs} -Wl,--end-group)
+    nuttx PRIVATE ${NUTTX_EXTRA_FLAGS} -T${ldscript} -Wl,--start-group
+                  ${nuttx_libs} ${nuttx_extra_libs} -Wl,--end-group)
 
   # generate binary outputs in different formats (.bin, .hex, etc)
   nuttx_generate_outputs(nuttx)

--- a/libs/libc/assert/CMakeLists.txt
+++ b/libs/libc/assert/CMakeLists.txt
@@ -24,7 +24,10 @@ if(CONFIG_STACK_CANARIES)
   list(APPEND SRCS lib_stackchk.c)
 endif()
 
-set_source_files_properties(lib_assert.c PROPERTIES COMPILE_FLAGS -fno-lto)
-set_source_files_properties(lib_stackchk.c PROPERTIES COMPILE_FLAGS -fno-lto)
-
+if(CONFIG_ARCH_TOOLCHAIN_GNU AND NOT CONFIG_LTO_NONE)
+  set_source_files_properties(lib_assert.c DIRECTORY .. PROPERTIES COMPILE_FLAGS
+                                                                   -fno-lto)
+  set_source_files_properties(lib_stackchk.c DIRECTORY ..
+                              PROPERTIES COMPILE_FLAGS -fno-lto)
+endif()
 target_sources(c PRIVATE ${SRCS})


### PR DESCRIPTION

## Summary
it was wrong in https://github.com/apache/nuttx/pull/12423/files#r1618852245 
`EXTRA_FLAGS` is useful in LTO for pass option to lto linker

error massage:
```shell
 [1131/1132] Linking C executable nuttx
 FAILED: nuttx 
 : && arm-none-eabi-gcc  --specs=nosys.specs   -Wl,--entry=__start -nostdlib -Wl,--gc-sections -Wl,--cref -Wl,-Map=nuttx.map CMakeFiles/nuttx.dir/empty.c.obj -o nuttx  -Wl,--script=ld.script.multi.tmp  -Wl,--start-group  arch/libarch.a  binfmt/libbinfmt.a  drivers/libdrivers.a  fs/libfs.a  libs/libc/libc.a  mm/libmm.a  sched/libsched.a  boards/libboard.a  apps/libapps.a  apps/external/android/libandroid.a  apps/builtin/libapps_builtin.a  apps/system/nsh/libapps_nsh.a  apps/system/nsh/libapps_sh.a  apps/examples/hello/libapps_hello.a  /home/work/linux/arm/bin/../lib/gcc/arm-none-eabi/13.2.1/thumb/v7e-m+fp/hard/libgcc.a  /home/work/linux/arm/bin/../lib/gcc/arm-none-eabi/13.2.1/../../../../arm-none-eabi/lib/thumb/v7e-m+fp/hard/libm.a  -Wl,--end-group && :
 lto-wrapper: warning: using serial compilation of 5 LTRANS jobs
 lto-wrapper: note: see the '-flto' option documentation for more information
 /tmp/ccSQzikY.s: Assembler messages:
 /tmp/ccSQzikY.s:135: Error: invalid constant (18) after fixup
 /tmp/ccSQzikY.s:204: Error: invalid constant (a200000) after fixup
 /tmp/ccSQzikY.s:226: Error: invalid constant (a200000) after fixup
 /tmp/ccSQzikY.s:316: Error: invalid constant (800000) after fixup
 /tmp/ccSQzikY.s:338: Error: invalid constant (800000) after fixup
 /tmp/ccSQzikY.s:523: Error: invalid constant (800000) after fixup
 /tmp/ccSQzikY.s:539: Error: invalid constant (300) after fixup
 /tmp/ccSQzikY.s:548: Error: invalid constant (700) after fixup
 /tmp/ccSQzikY.s:549: Error: invalid constant (7) after fixup
 /tmp/ccSQzikY.s:550: Error: invalid constant (70000) after fixup
 /tmp/ccSQzikY.s:555: Error: invalid constant (1) after fixup
 /tmp/ccSQzikY.s:579: Error: invalid constant (7000000) after fixup
 /tmp/ccSQzikY.s:582: Error: invalid constant (70000000) after fixup
 /tmp/ccSQzikY.s:585: Error: invalid constant (3e8) after fixup
 /tmp/ccSQzikY.s:592: Error: invalid constant (70000000) after fixup
 /tmp/ccSQzikY.s:597: Error: invalid constant (6d) after fixup
 /tmp/ccSQzikY.s:605: Error: invalid constant (3) after fixup
 /tmp/ccSQzikY.s:627: Error: invalid constant (6d) after fixup
 /tmp/ccSQzikY.s:630: Error: invalid constant (6d) after fixup
 /tmp/ccSQzikY.s:654: Error: invalid constant (800000) after fixup
 /tmp/ccSQzikY.s:663: Error: invalid constant (1) after fixup
 /tmp/ccSQzikY.s:696: Error: invalid constant (1f00) after fixup
 /tmp/ccSQzikY.s:697: Error: invalid constant (1) after fixup
 /tmp/ccSQzikY.s:700: Error: invalid constant (30) after fixup
 /tmp/ccSQzikY.s:710: Error: invalid constant (700) after fixup
 /tmp/ccSQzikY.s:711: Error: invalid constant (7) after fixup
 /tmp/ccSQzikY.s:712: Error: invalid constant (70000) after fixup
 /tmp/ccSQzikY.s:738: Error: invalid constant (7000000) after fixup
 /tmp/ccSQzikY.s:748: Error: invalid constant (4000000) after fixup
 /tmp/ccSQzikY.s:755: Error: invalid constant (70000000) after fixup
 /tmp/ccSQzikY.s:758: Error: invalid constant (3e8) after fixup
 /tmp/ccSQzikY.s:765: Error: invalid constant (70000000) after fixup
 /tmp/ccSQzikY.s:775: Error: invalid constant (1) after fixup
 /tmp/ccSQzikY.s:779: Error: invalid constant (6d) after fixup
 /tmp/ccSQzikY.s:784: Error: invalid constant (1) after fixup
 /tmp/ccSQzikY.s:787: Error: invalid constant (6d) after fixup
 /tmp/ccSQzikY.s:873: Error: invalid constant (7) after fixup
 /tmp/ccSQzikY.s:874: Error: invalid constant (4) after fixup
 /tmp/ccSQzikY.s:876: Error: invalid constant (0) after fixup
 /tmp/ccSQzikY.s:935: Error: invalid constant (1) after fixup
 /tmp/ccSQzikY.s:937: Error: invalid constant (1) after fixup
 /tmp/ccSQzikY.s:966: Error: invalid constant (ffffffffffffffff) after fixup
....
....
 /tmp/ccSQzikY.s:16425: Error: invalid constant (2000000) after fixup
 lto-wrapper: fatal error: /home/work/linux/arm/bin/arm-none-eabi-gcc returned 1 exit status
 compilation terminated.
 compilation terminated.
 /home/work/linux/arm/bin/../lib/gcc/arm-none-eabi/13.2.1/../../../../arm-none-eabi/bin/ld: error: lto-wrapper failed
 collect2: error: ld returned 1 exit status
 ninja: build stopped: subcommand failed.
``` 
## Impact

## Testing
CI build
