### PR TITLE
xtensa/esp32s3: reserve memory for a mutex struct depending on the OS

### DIFF
--- a/arch/xtensa/src/common/espressif/platform_include/sys/lock.h
+++ b/arch/xtensa/src/common/espressif/platform_include/sys/lock.h
@@ -39,7 +39,15 @@
 
 struct __lock
 {
+#ifdef CONFIG_PRIORITY_INHERITANCE
+#  if CONFIG_SEM_PREALLOCHOLDERS > 0
+  int reserved[5];
+#  else
+  int reserved[8];
+#  endif
+#else
   int reserved[4];
+#endif
 };
 
 typedef _LOCK_T _lock_t;


### PR DESCRIPTION
Enabling CONFIG_PRIORITY_INHERITANCE config causes a build error

Based on Nuttx OS reserve memory for mutex struct.

Pass build based on
 - CONFIG_PRIORITY_INHERITANCE y
 - CONFIG_SEM_PREALLOCHOLDERS 0/8

## Summary

## Impact

## Testing

