### PR TITLE
mm/map/vm_region.c: Fix usage of void* arithmetics

### DIFF
--- a/mm/map/vm_region.c
+++ b/mm/map/vm_region.c
@@ -128,8 +128,10 @@ FAR void *vm_map_region(uintptr_t paddr, size_t size)
   return (FAR void *)((uintptr_t)vaddr + (MM_PGMASK & paddr));
 
 error:
-  if (i)   /* undo alway mapped pages */
+  if (i)
     {
+      /* Undo alway mapped pages */
+
       up_shmdt((uintptr_t)vaddr, i);
     }
 

--- a/mm/map/vm_region.c
+++ b/mm/map/vm_region.c
@@ -125,7 +125,7 @@ FAR void *vm_map_region(uintptr_t paddr, size_t size)
         }
     }
 
-  return vaddr + (MM_PGMASK & paddr);
+  return (FAR void *)((uintptr_t)vaddr + (MM_PGMASK & paddr));
 
 error:
   if (i)   /* undo alway mapped pages */


### PR DESCRIPTION

## Summary
Fixes build error:
map/vm_region.c: In function 'vm_map_region':
map/vm_region.c:128:16: error: pointer of type 'void *' used in arithmetic [-Werror=pointer-arith]
  128 |   return vaddr + (MM_PGMASK & paddr);
      |                ^
cc1: all warnings being treated as errors

## Impact
Fix build error
## Testing
Build / CI pass
