### PR TITLE
arm/armv8-r: invalidate d-cache on boot

### DIFF
--- a/arch/arm/src/armv8-r/arm_head.S
+++ b/arch/arm/src/armv8-r/arm_head.S
@@ -199,7 +199,7 @@ __cpu0_start:
 	mov		r0, #0
 	mcr		CP15_BPIALL(r0)		/* Invalidate entire branch prediction array */
 	mcr		CP15_ICIALLU(r0)	/* Invalidate I-cache */
-	mov		r0, CP15_CACHE_INVALIDATE
+	mov		r1, CP15_CACHE_INVALIDATE
 	bl		cp15_dcache_op_level
 	isb
 


### PR DESCRIPTION
## Summary

 arm/armv8-r: invalidate d-cache on boot
 
 Pass CP15_CACHE_INVALIDATE argument with r1 register to cp15_dcache_op_level.
 cache level is 0(L1 D-Cache) with r0 register.
 prototype:
 void cp15_dcache_op_level(uint32_t level, int op)
 
 Signed-off-by: Jinliang Li <lijinliang1@lixiang.com>


## Impact

N/A

## Testing

Cortex-R52