### PR TITLE
arm/armv8-r: init HSCTLR and HACTLR for EL2

### DIFF
--- a/arch/arm/src/armv8-r/arm_head.S
+++ b/arch/arm/src/armv8-r/arm_head.S
@@ -203,7 +203,10 @@ __cpu0_start:
 	bl		cp15_dcache_op_level
 	isb
 
-	bl		sctlr_initialize
+	bl		hsctlr_initialize  /* Init Hyp system control register */
+
+	ldr		r0, =HACTLR_INIT
+	mcr		CP15_HACTLR(r0)  /* Enable EL1 access all IMP DEFINED registers */
 
 	/* Initialize .bss and .data assumt that RAM that is ready to use. */
 	bl		arm_data_initialize
@@ -217,6 +220,8 @@ __cpu0_start:
 
 	adr		r0, 1f
 	msr		elr_hyp, r0
+	dsb
+	isb
 	eret
 
 1:
@@ -323,7 +328,39 @@ arm_data_initialize:
 #endif
 
 /***************************************************************************
- * Name: arm_data_initialize
+ * Name: hsctlr_initialize
+ ***************************************************************************/
+
+	.global	hsctlr_initialize
+	.type	hsctlr_initialize, #function
+
+hsctlr_initialize:
+	mrc		CP15_HSCTLR(r0)		/* Get Hyp System Control Register */
+
+#if !defined(CONFIG_ARMV8R_DCACHE_DISABLE) && !defined(CONFIG_SMP)
+	/* Dcache enable
+	 *
+	 *   SCTLR_C    Bit 2:  DCache enable
+	 */
+
+	orr		r0, r0, #(SCTLR_C)
+#endif
+
+#if !defined(CONFIG_ARMV8R_ICACHE_DISABLE) && !defined(CONFIG_SMP)
+	/* Icache enable
+	 *
+	 *   SCTLR_I    Bit 12: ICache enable
+	 */
+
+	orr		r0, r0, #(SCTLR_I)
+#endif
+
+	mcr		CP15_HSCTLR(r0)		/* Write Hyp System Control Register */
+
+	bx		lr
+
+/***************************************************************************
+ * Name: sctlr_initialize
  ***************************************************************************/
 
 	.global	sctlr_initialize

--- a/arch/arm/src/armv8-r/cp15.h
+++ b/arch/arm/src/armv8-r/cp15.h
@@ -87,6 +87,8 @@
 #define CP15_AIDR(r)       _CP15(1, r, c0, c0, 7)   /* Auxiliary ID Register */
 #define CP15_CSSELR(r)     _CP15(2, r, c0, c0, 0)   /* Cache Size Selection Register */
 
+#define CP15_HSCTLR(r)     _CP15(4, r, c1, c0, 0)   /* Hyp System Control Register */
+#define CP15_HACTLR(r)     _CP15(4, r, c1, c0, 1)   /* Hyp Auxiliary Control Register */
 #define CP15_SCTLR(r)      _CP15(0, r, c1, c0, 0)   /* System Control Register */
 #define CP15_ACTLR(r)      _CP15(0, r, c1, c0, 1)   /* Auxiliary Control Register */
 #define CP15_CPACR(r)      _CP15(0, r, c1, c0, 2)   /* Coprocessor Access Control Register */

--- a/arch/arm/src/armv8-r/sctlr.h
+++ b/arch/arm/src/armv8-r/sctlr.h
@@ -170,6 +170,27 @@
                                      /* Bits 28-29: Reserved */
 #define SCTLR_TE           (1 << 30) /* Bit 30: Thumb exception enable */
 
+/* Hyp Auxiliary Control Register */
+#define HACTLR_CPUACTLR         (1 << 0)  /* Bit 0: Enable write access IMP_CPUACTLR from EL1 */
+#define HACTLR_CDBGDCI          (1 << 1)  /* Bit 1: Enable access CDBGDCI from EL1 */
+                                          /* Bits 2-6: Reserved */
+#define HACTLR_FLASHIFREGIONR   (1 << 7)  /* Bit 7: Enable access IMP_FLASHIFREGIONR from EL1 */
+#define HACTLR_PERIPHPREGIONR   (1 << 8)  /* Bit 8: Enable access IMP_PERIPHPREGIONR from EL1 */
+#define HACTLR_QOSR_BIT         (1 << 9)  /* Bit 9: Enable access QOSR from EL1 */
+#define HACTLR_BUSTIMEOUTR_BIT  (1 << 10) /* Bit 10: Enable access IMP_BUSTIMEOUTR from EL1 */
+                                          /* Bit 11: Reserved */
+#define HACTLR_INTMONR_BIT      (1 << 12) /* Bit 12: Enable access IMP_INTMONR from EL1 */
+#define HACTLR_ERR_BIT          (1 << 13) /* Bit 13: Enable access IMP_*ERR registers from EL1 */
+                                          /* Bit 14: Reserved */
+#define HACTLR_TESTR1_BIT       (1 << 15) /* Bit 15: Enable access IMP_TESTR1 registers from EL0 and EL1 */
+                                          /* Bits 16-31: Reserved */
+
+/* Enable all IMP DEF registers access from EL1 except for TESTR1 */
+#define HACTLR_INIT (HACTLR_ERR_BIT | HACTLR_INTMONR_BIT | \
+        HACTLR_BUSTIMEOUTR_BIT | HACTLR_QOSR_BIT | \
+        HACTLR_PERIPHPREGIONR | HACTLR_FLASHIFREGIONR | \
+        HACTLR_CDBGDCI | HACTLR_CPUACTLR)
+
 /* Auxiliary Control Register (ACTLR): CRn=c1, opc1=0, CRm=c0, opc2=1 */
 
 #define ACTLR_FW                 (1 << 0)  /* Bit 0: Enable Cache/TLB maintenance broadcast */


### PR DESCRIPTION

## Summary

arm/armv8-r: init HSCTLR and HACTLR for EL2

1. init HSCTLR to enable i-cache/d-cache for EL2
2. init HACTLR to enable all access to implementation defined
   registers for EL1.
3. add dsb/isb before switch to EL1 from EL2

Signed-off-by: Jinliang Li <lijinliang1@lixiang.com>


## Impact

N/A

## Testing

Cortex-R52