### PR TITLE
serial/uart_16550: include stdint.h in uart_16550.h

### DIFF
--- a/include/nuttx/serial/uart_16550.h
+++ b/include/nuttx/serial/uart_16550.h
@@ -27,6 +27,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <stdint.h>
 
 #ifdef CONFIG_16550_UART
 


### PR DESCRIPTION
## Summary

serial/uart_16550: include stdint.h in uart_16550.h

stdint.h is needed in uart_16550.h for some types, e.g. uint32_t,
uintptr_t. Otherwise there will be building issue unless that stdint.h
is added before uart_16550.h by all files which needs uart_16550.h.

Signed-off-by: Jinliang Li <lijinliang1@lixiang.com>



## Impact

N/A

## Testing

ci-check