### PR TITLE
make/disassembly: generate disassembly file

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -410,6 +410,12 @@ config RAW_BINARY
 		different loaders using the GNU objcopy program.  This option
 		should not be selected if you are not using the GNU toolchain.
 
+config RAW_DISASSEMBLY
+	bool "Create a disassembly file"
+	default n
+	---help---
+		Create the nuttx.asm in the disassembly format using the objdump program.
+
 menuconfig UBOOT_UIMAGE
 	bool "U-Boot uImage"
 	select RAW_BINARY

--- a/cmake/nuttx_generate_outputs.cmake
+++ b/cmake/nuttx_generate_outputs.cmake
@@ -45,4 +45,13 @@ function(nuttx_generate_outputs target)
     add_custom_target(${target}-bin ALL DEPENDS ${target}.bin)
     file(APPEND ${CMAKE_BINARY_DIR}/nuttx.manifest "${target}.bin\n")
   endif()
+
+  if(CONFIG_RAW_DISASSEMBLY)
+    add_custom_command(
+      OUTPUT ${target}.asm
+      COMMAND ${CMAKE_OBJDUMP} -d ${target} > ${target}.asm
+      DEPENDS ${target})
+    add_custom_target(${target}-asm ALL DEPENDS ${target}.asm)
+    file(APPEND ${CMAKE_BINARY_DIR}/nuttx.manifest "${target}.asm\n")
+  endif()
 endfunction(nuttx_generate_outputs)

--- a/tools/Unix.mk
+++ b/tools/Unix.mk
@@ -573,6 +573,11 @@ ifeq ($(CONFIG_UBOOT_UIMAGE),y)
 	fi
 	$(Q) echo "uImage" >> nuttx.manifest
 endif
+ifeq ($(CONFIG_RAW_DISASSEMBLY),y)
+	@echo "CP: nuttx.asm"
+	$(Q) $(OBJDUMP) -d $(BIN) > nuttx.asm
+	$(Q) echo nuttx.bin >> nuttx.asm
+endif
 	$(call POSTBUILD, $(TOPDIR))
 
 # flash (or download : DEPRECATED)


### PR DESCRIPTION
## Summary

make/disassembly: generate disassembly file

Create the nuttx.asm in the disassembly format using the objdump program.

NOTE:
'>', objdump doesn't take arguments for output file,
but result is printed to standard out, and is redirected.

Signed-off-by: fanjiangang <fanjiangang@lixiang.com>
Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

ci-check