### PR TITLE
drivers/virtio-net: Support VIRTIO_F_ANY_LAYOUT

### DIFF
--- a/include/nuttx/virtio/virtio.h
+++ b/include/nuttx/virtio/virtio.h
@@ -38,6 +38,12 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+/* Virtio common feature bits */
+
+#define VIRTIO_F_ANY_LAYOUT   27
+
+/* Virtio helper functions */
+
 #define virtio_has_feature(vdev, fbit) \
       (((vdev)->features & (1UL << (fbit))) != 0)
 


### PR DESCRIPTION
## Summary
According to Virtual I/O Spec:
When using legacy interfaces, transitional drivers which have not negotiated `VIRTIO_F_ANY_LAYOUT` MUST use a single descriptor for the `struct virtio_net_hdr` on both transmit and receive, with the network data in the following descriptors.

https://docs.oasis-open.org/virtio/virtio/v1.2/cs01/virtio-v1.2-cs01.html#x1-2280006 (Section 5.1.6.6)

## Impact
Virtio-Net on environments without `VIRTIO_F_ANY_LAYOUT`.

## Testing
Manually.
