### PR TITLE
pm: add debug_assert for cb register/unregister api

### DIFF
--- a/drivers/power/pm/pm_register.c
+++ b/drivers/power/pm/pm_register.c
@@ -57,8 +57,12 @@
 
 int pm_domain_register(int domain, FAR struct pm_callback_s *cb)
 {
+  FAR struct pm_domain_s *pdom;
   irqstate_t flags;
-  struct pm_domain_s *pdom = &g_pmdomains[domain];
+
+  DEBUGASSERT(domain >= 0 && domain < CONFIG_PM_NDOMAINS);
+
+  pdom  = &g_pmdomains[domain];
   flags = spin_lock_irqsave(&pdom->lock);
 
   /* Add the new entry to the end of the list of registered callbacks */

--- a/drivers/power/pm/pm_unregister.c
+++ b/drivers/power/pm/pm_unregister.c
@@ -56,8 +56,12 @@
 
 int pm_domain_unregister(int domain, FAR struct pm_callback_s *cb)
 {
+  FAR struct pm_domain_s *pdom;
   irqstate_t flags;
-  struct pm_domain_s *pdom = &g_pmdomains[domain];
+
+  DEBUGASSERT(domain >= 0 && domain < CONFIG_PM_NDOMAINS);
+
+  pdom  = &g_pmdomains[domain];
   flags = spin_lock_irqsave(&pdom->lock);
 
   /* Remove entry from the list of registered callbacks. */


### PR DESCRIPTION
## Summary
As we changed the defintion of pm_register/unregister, possible the domain is not a correct value. will cause data abort. use debug assert to expose problems before real aceess wrong memory.

## Impact
None

## Testing
CI test
