### PR TITLE
irq: remove restore_critical_section in irq

### DIFF
--- a/arch/arm/src/armv6-m/arm_doirq.c
+++ b/arch/arm/src/armv6-m/arm_doirq.c
@@ -79,7 +79,6 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
           g_running_tasks[this_cpu()] = this_task();
 
-          restore_critical_section();
           regs = (uint32_t *)CURRENT_REGS;
         }
 

--- a/arch/arm/src/armv6-m/arm_svcall.c
+++ b/arch/arm/src/armv6-m/arm_svcall.c
@@ -34,6 +34,7 @@
 #include <arch/irq.h>
 #include <nuttx/sched.h>
 
+#include "sched/sched.h"
 #include "signal/signal.h"
 #include "exc_return.h"
 #include "arm_internal.h"
@@ -472,6 +473,11 @@ int arm_svcall(int irq, void *context, void *arg)
     }
 #  endif
 #endif
+
+  if (regs != CURRENT_REGS)
+    {
+      restore_critical_section();
+    }
 
   return OK;
 }

--- a/arch/arm/src/armv7-a/arm_doirq.c
+++ b/arch/arm/src/armv7-a/arm_doirq.c
@@ -92,7 +92,6 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
       g_running_tasks[this_cpu()] = this_task();
 
-      restore_critical_section();
       regs = (uint32_t *)CURRENT_REGS;
     }
 

--- a/arch/arm/src/armv7-m/arm_doirq.c
+++ b/arch/arm/src/armv7-m/arm_doirq.c
@@ -79,7 +79,6 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
           g_running_tasks[this_cpu()] = this_task();
 
-          restore_critical_section();
           regs = (uint32_t *)CURRENT_REGS;
         }
 

--- a/arch/arm/src/armv7-m/arm_svcall.c
+++ b/arch/arm/src/armv7-m/arm_svcall.c
@@ -35,6 +35,7 @@
 #include <nuttx/sched.h>
 #include <nuttx/userspace.h>
 
+#include "sched/sched.h"
 #include "signal/signal.h"
 #include "exc_return.h"
 #include "arm_internal.h"
@@ -481,6 +482,11 @@ int arm_svcall(int irq, void *context, void *arg)
     }
 #  endif
 #endif
+
+  if (regs != CURRENT_REGS)
+    {
+      restore_critical_section();
+    }
 
   return OK;
 }

--- a/arch/arm/src/armv7-r/arm_doirq.c
+++ b/arch/arm/src/armv7-r/arm_doirq.c
@@ -71,7 +71,6 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
       g_running_tasks[this_cpu()] = this_task();
 
-      restore_critical_section();
       regs = (uint32_t *)CURRENT_REGS;
     }
 

--- a/arch/arm/src/armv8-m/arm_doirq.c
+++ b/arch/arm/src/armv8-m/arm_doirq.c
@@ -128,7 +128,6 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
           g_running_tasks[this_cpu()] = this_task();
 
-          restore_critical_section();
           regs = (uint32_t *)CURRENT_REGS;
         }
 

--- a/arch/arm/src/armv8-m/arm_svcall.c
+++ b/arch/arm/src/armv8-m/arm_svcall.c
@@ -34,6 +34,7 @@
 #include <nuttx/sched.h>
 #include <nuttx/userspace.h>
 
+#include "sched/sched.h"
 #include "signal/signal.h"
 #include "exc_return.h"
 #include "arm_internal.h"
@@ -482,6 +483,11 @@ int arm_svcall(int irq, void *context, void *arg)
     }
 #  endif
 #endif
+
+  if (regs != CURRENT_REGS)
+    {
+      restore_critical_section();
+    }
 
   return OK;
 }

--- a/arch/arm/src/armv8-r/arm_doirq.c
+++ b/arch/arm/src/armv8-r/arm_doirq.c
@@ -71,8 +71,6 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
        */
 
       g_running_tasks[this_cpu()] = this_task();
-
-      restore_critical_section();
       regs = (uint32_t *)CURRENT_REGS;
     }
 

--- a/arch/arm/src/tlsr82/tc32/tc32_doirq.c
+++ b/arch/arm/src/tlsr82/tc32/tc32_doirq.c
@@ -98,7 +98,6 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
       if (regs != CURRENT_REGS)
         {
-          restore_critical_section();
           regs = (uint32_t *)CURRENT_REGS;
         }
 

--- a/arch/arm64/src/common/arm64_doirq.c
+++ b/arch/arm64/src/common/arm64_doirq.c
@@ -99,9 +99,6 @@ uint64_t *arm64_doirq(int irq, uint64_t * regs)
 
       g_running_tasks[this_cpu()] = this_task();
 
-      /* Restore the cpu lock */
-
-      restore_critical_section();
       regs = (uint64_t *)CURRENT_REGS;
     }
 

--- a/arch/ceva/src/common/ceva_doirq.c
+++ b/arch/ceva/src/common/ceva_doirq.c
@@ -85,7 +85,6 @@ uint32_t *ceva_doirq(int irq, uint32_t *regs)
 
           g_running_tasks[this_cpu()] = this_task();
 
-          restore_critical_section();
           regs = CURRENT_REGS;
         }
 

--- a/arch/risc-v/src/common/riscv_doirq.c
+++ b/arch/risc-v/src/common/riscv_doirq.c
@@ -109,10 +109,6 @@ uintreg_t *riscv_doirq(int irq, uintreg_t *regs)
 
       g_running_tasks[this_cpu()] = this_task();
 
-      /* Restore the cpu lock */
-
-      restore_critical_section();
-
       /* If a context switch occurred while processing the interrupt then
        * CURRENT_REGS may have change value.  If we return any value
        * different from the input regs, then the lower level will know

--- a/arch/risc-v/src/common/riscv_swint.c
+++ b/arch/risc-v/src/common/riscv_swint.c
@@ -40,6 +40,7 @@
 #  include <syscall.h>
 #endif
 
+#include "sched/sched.h"
 #include "signal/signal.h"
 #include "riscv_internal.h"
 #include "addrenv.h"
@@ -497,6 +498,11 @@ int riscv_swint(int irq, void *context, void *arg)
       svcinfo("SWInt Return: %" PRIxPTR "\n", regs[REG_A0]);
     }
 #endif
+
+  if (regs != CURRENT_REGS)
+    {
+      restore_critical_section();
+    }
 
   return OK;
 }

--- a/arch/sparc/src/sparc_v8/sparc_v8_doirq.c
+++ b/arch/sparc/src/sparc_v8/sparc_v8_doirq.c
@@ -118,13 +118,6 @@ uint32_t *sparc_doirq(int irq, uint32_t *regs)
   regs = (uint32_t *)((uint32_t)CURRENT_REGS -
                                 CPU_MINIMUM_STACK_FRAME_SIZE);
 
-  /* Restore the cpu lock */
-
-  if (regs != CURRENT_REGS)
-    {
-      restore_critical_section();
-    }
-
   /* Set CURRENT_REGS to NULL to indicate that we are no longer in an
    * interrupt handler.
    */

--- a/arch/xtensa/src/common/xtensa_irqdispatch.c
+++ b/arch/xtensa/src/common/xtensa_irqdispatch.c
@@ -94,7 +94,6 @@ uint32_t *xtensa_irq_dispatch(int irq, uint32_t *regs)
 
   if (regs != CURRENT_REGS)
     {
-      restore_critical_section();
       regs = (uint32_t *)CURRENT_REGS;
     }
 

--- a/arch/xtensa/src/common/xtensa_swint.c
+++ b/arch/xtensa/src/common/xtensa_swint.c
@@ -32,6 +32,7 @@
 #include <nuttx/arch.h>
 #include <sys/syscall.h>
 
+#include "sched/sched.h"
 #include "chip.h"
 #include "signal/signal.h"
 #include "xtensa.h"
@@ -438,6 +439,11 @@ int xtensa_swint(int irq, void *context, void *arg)
       svcinfo("SYSCALL Return: %" PRIu32 "\n", cmd);
     }
 #endif
+
+  if (regs != CURRENT_REGS)
+    {
+      restore_critical_section();
+    }
 
   return OK;
 }


### PR DESCRIPTION

## Summary
Only in the non-critical region， nuttx can the respond to the irq and not hold the lock When returning from the irq, there is no need to check whether the lock needs to be released we also need keep restore_critical_section in svc call
## Impact

## Testing
    Configuring NuttX and compile:
    $ ./tools/configure.sh -l qemu-armv8a:nsh_smp
    $ make
    Running with qemu
    $ qemu-system-aarch64 -cpu cortex-a53 -smp 4 -nographic \
       -machine virt,virtualization=on,gic-version=3 \
       -net none -chardev stdio,id=con,mux=on -serial chardev:con \
       -mon chardev=con,mode=readline -kernel ./nuttx
