### PR TITLE
fs/mnemofs: Fix journal log rw issue, rw size issue

### DIFF
--- a/drivers/mtd/mtd_nandram.c
+++ b/drivers/mtd/mtd_nandram.c
@@ -295,7 +295,7 @@ int nand_ram_eraseblock(FAR struct nand_raw_s *raw, off_t block)
   for (i = start_page; i < end_page; i++)
     {
       nand_ram_flash_spare[i].n_erase++;
-      nand_ram_flash_spare[i].free = 1;
+      nand_ram_flash_spare[i].free = NAND_RAM_PAGE_FREE;
     }
 
   NAND_RAM_LOG("[LOWER %lu | %s] Done\n", nand_ram_ins_i, "eraseblock");
@@ -331,11 +331,10 @@ int nand_ram_rawread(FAR struct nand_raw_s *raw, off_t block,
   struct nand_ram_data_s  *read_page_data;
   struct nand_ram_spare_s *read_page_spare;
 
+  ret             = OK;
   read_page       = (block << NAND_RAM_LOG_PAGES_PER_BLOCK) + page;
   read_page_data  = nand_ram_flash_data + read_page;
   read_page_spare = nand_ram_flash_spare + read_page;
-
-  ret = OK;
 
   nxmutex_lock(&nand_ram_dev_mut);
   nand_ram_ins_i++;
@@ -362,7 +361,8 @@ int nand_ram_rawread(FAR struct nand_raw_s *raw, off_t block,
         }
       else
         {
-          memcpy(data, (const void *)read_page_data, NAND_RAM_PAGE_SIZE);
+          memcpy(data, (const void *)read_page_data->page,
+                 NAND_RAM_PAGE_SIZE);
         }
     }
 
@@ -407,11 +407,10 @@ int nand_ram_rawwrite(FAR struct nand_raw_s *raw, off_t block,
   struct nand_ram_data_s  *write_page_data;
   struct nand_ram_spare_s *write_page_spare;
 
+  ret               = OK;
   write_page        = (block << NAND_RAM_LOG_PAGES_PER_BLOCK) + page;
   write_page_data   = nand_ram_flash_data + write_page;
   write_page_spare  = nand_ram_flash_spare + write_page;
-
-  ret = OK;
 
   nxmutex_lock(&nand_ram_dev_mut);
   nand_ram_ins_i++;
@@ -429,16 +428,17 @@ int nand_ram_rawwrite(FAR struct nand_raw_s *raw, off_t block,
     }
 
   nand_ram_flash_spare[write_page].n_write++;
+  nand_ram_flash_spare[write_page].free = NAND_RAM_PAGE_WRITTEN;
 
-  memset((void *)write_page_data, 0, NAND_RAM_PAGE_SIZE);
+  memset((void *)write_page_data->page, 0, NAND_RAM_PAGE_SIZE);
   if (data != NULL)
     {
-      memcpy((void *)write_page_data, data, NAND_RAM_PAGE_SIZE);
+      memcpy((void *)write_page_data->page, data, NAND_RAM_PAGE_SIZE);
     }
 
   if (spare != NULL)
     {
-      memcpy((void *)write_page_spare, data, NAND_RAM_PAGE_SIZE);
+      memcpy((void *)write_page_spare, data, NAND_RAM_SPARE_SIZE);
     }
 
   NAND_RAM_LOG("[LOWER %lu | %s] Done\n", nand_ram_ins_i, "rawwrite");

--- a/fs/mnemofs/mnemofs_master.c
+++ b/fs/mnemofs/mnemofs_master.c
@@ -100,7 +100,7 @@
 static FAR char       *ser_mn(const struct mfs_mn_s mn,
                               FAR char * const out);
 static FAR const char *deser_mn(FAR const char * const in,
-                                FAR struct mfs_mn_s *mn, FAR uint8_t *hash);
+                                FAR struct mfs_mn_s *mn, FAR uint16_t *hash);
 
 /****************************************************************************
  * Private Data
@@ -141,7 +141,9 @@ static FAR char *ser_mn(const struct mfs_mn_s mn, FAR char * const out)
   tmp = mfs_ser_ctz(&mn.root_ctz, tmp);
   tmp = mfs_ser_mfs(mn.root_sz, tmp);
   tmp = mfs_ser_timespec(&mn.ts, tmp);
-  tmp = mfs_ser_8(mfs_arrhash(out, tmp - out), tmp);
+  tmp = mfs_ser_16(mfs_hash(out, tmp - out), tmp);
+
+  /* TODO: Update this, and the make a macro for size of MN. */
 
   return tmp;
 }
@@ -166,7 +168,7 @@ static FAR char *ser_mn(const struct mfs_mn_s mn, FAR char * const out)
  ****************************************************************************/
 
 static FAR const char *deser_mn(FAR const char * const in,
-                                FAR struct mfs_mn_s *mn, FAR uint8_t *hash)
+                                FAR struct mfs_mn_s *mn, FAR uint16_t *hash)
 {
   FAR const char *tmp = in;
 
@@ -175,7 +177,9 @@ static FAR const char *deser_mn(FAR const char * const in,
   tmp = mfs_deser_ctz(tmp, &mn->root_ctz);
   tmp = mfs_deser_mfs(tmp, &mn->root_sz);
   tmp = mfs_deser_timespec(tmp, &mn->ts);
-  tmp = mfs_deser_8(tmp, hash);
+  tmp = mfs_deser_16(tmp, hash);
+
+  /* TODO: Update this, and the make a macro for size of MN. */
 
   return tmp;
 }
@@ -192,15 +196,14 @@ int mfs_mn_init(FAR struct mfs_sb_s * const sb, const mfs_t jrnl_blk)
   mfs_t           mblk2;
   mfs_t           jrnl_blk_tmp;
   bool            found        = false;
-  uint8_t         hash;
+  uint16_t        hash;
   struct mfs_mn_s mn;
   const mfs_t     sz           = sizeof(struct mfs_mn_s) - sizeof(mn.pg);
   char            buftmp[4];
   char            buf[sz + 1];
 
-  mblk1 = mfs_jrnl_blkidx2blk(sb, MFS_JRNL(sb).n_blks);
-  mblk2 = mfs_jrnl_blkidx2blk(sb, MFS_JRNL(sb).n_blks + 1);
-
+  mblk1       = mfs_jrnl_blkidx2blk(sb, MFS_JRNL(sb).n_blks);
+  mblk2       = mfs_jrnl_blkidx2blk(sb, MFS_JRNL(sb).n_blks + 1);
   mn.jrnl_blk = mn.jrnl_blk;
   mn.mblk_idx = 0;
   mn.pg       = MFS_BLK2PG(sb, mblk1);
@@ -238,7 +241,6 @@ int mfs_mn_init(FAR struct mfs_sb_s * const sb, const mfs_t jrnl_blk)
     }
   else
     {
-      mn.mblk_idx--;
       mn.pg--;
     }
 
@@ -247,7 +249,7 @@ int mfs_mn_init(FAR struct mfs_sb_s * const sb, const mfs_t jrnl_blk)
   /* Deserialize. */
 
   deser_mn(buf, &mn, &hash);
-  if (hash != mfs_arrhash(buf, sz))
+  if (hash != mfs_hash(buf, sz))
     {
       ret = -EINVAL;
       goto errout;
@@ -263,12 +265,11 @@ errout:
   return ret;
 }
 
-int mfs_mn_fmt(FAR struct mfs_sb_s * const sb, const mfs_t jrnl_blk)
+int mfs_mn_fmt(FAR struct mfs_sb_s * const sb, const mfs_t mblk1,
+               const mfs_t mblk2, const mfs_t jrnl_blk)
 {
   int              ret         = OK;
   mfs_t            pg;
-  mfs_t            mblk1;
-  mfs_t            mblk2;
   struct mfs_mn_s  mn;
   struct timespec  ts;
   const mfs_t      sz          = sizeof(struct mfs_mn_s) - sizeof(mn.pg);
@@ -277,9 +278,6 @@ int mfs_mn_fmt(FAR struct mfs_sb_s * const sb, const mfs_t jrnl_blk)
   clock_gettime(CLOCK_REALTIME, &ts);
 
   memset(buf, 0, sz + 1);
-
-  mblk1 = mfs_jrnl_blkidx2blk(sb, MFS_JRNL(sb).n_blks);
-  mblk2 = mfs_jrnl_blkidx2blk(sb, MFS_JRNL(sb).n_blks + 1);
 
   pg = mfs_ba_getpg(sb);
   if (predict_false(pg == 0))
@@ -318,6 +316,7 @@ int mfs_mn_fmt(FAR struct mfs_sb_s * const sb, const mfs_t jrnl_blk)
       goto errout;
     }
 
+  mn.mblk_idx = 1;
   MFS_MN(sb) = mn;
   finfo("Master node written. Now at page %d, timestamp %lld.%.9ld.",
         MFS_MN(sb).pg, (long long)MFS_MN(sb).ts.tv_sec,
@@ -346,9 +345,9 @@ int mfs_mn_move(FAR struct mfs_sb_s * const sb, struct mfs_ctz_s root,
   mblk2 = mfs_jrnl_blkidx2blk(sb, MFS_JRNL(sb).n_blks + 1);
   mn    = MFS_MN(sb);
 
-  mn.root_ctz    = root;
+  mn.root_ctz = root;
   mn.root_sz = root_sz;
-  mn.mblk_idx++;
+  mn.mblk_idx++; /* TODO */
   mn.pg++;
 
   ser_mn(mn, buf);
@@ -359,6 +358,58 @@ int mfs_mn_move(FAR struct mfs_sb_s * const sb, struct mfs_ctz_s root,
       goto errout;
     }
 
+  MFS_MN(sb) = mn;
+
+errout:
+  return ret;
+}
+
+int mfs_mn_sync(FAR struct mfs_sb_s *sb,
+                FAR struct mfs_path_s * const new_loc,
+                const mfs_t blk1, const mfs_t blk2, const mfs_t jrnl_blk)
+{
+  int              ret         = OK;
+  struct timespec  ts;
+  struct mfs_mn_s  mn;
+  const mfs_t      sz          = sizeof(struct mfs_mn_s) - sizeof(mn.pg);
+  char             buf[sz + 1];
+
+  mn = MFS_MN(sb);
+
+  clock_gettime(CLOCK_REALTIME, &ts);
+
+  if (mn.mblk_idx == MFS_PGINBLK(sb))
+    {
+      /* New blocks have been already allocated by the journal. */
+
+      mn.mblk_idx = 0;
+      mn.pg       = MFS_BLK2PG(sb, blk1);
+    }
+
+  mn.ts        = ts;
+  mn.root_sz   = new_loc->sz;
+  mn.root_ctz  = new_loc->ctz;
+  mn.root_mode = 0777 | S_IFDIR;
+
+  /* TODO: Root timestamps. */
+
+  /* Serialize. */
+
+  ser_mn(mn, buf);
+
+  ret = mfs_write_page(sb, buf, sz, MFS_BLK2PG(sb, blk1) + mn.mblk_idx, 0);
+  if (predict_false(ret < 0))
+    {
+      goto errout;
+    }
+
+  ret = mfs_write_page(sb, buf, sz, MFS_BLK2PG(sb, blk2) + mn.mblk_idx, 0);
+  if (predict_false(ret < 0))
+    {
+      goto errout;
+    }
+
+  mn.mblk_idx++;
   MFS_MN(sb) = mn;
 
 errout:

--- a/fs/mnemofs/mnemofs_util.c
+++ b/fs/mnemofs/mnemofs_util.c
@@ -88,8 +88,8 @@
 
 uint8_t mfs_arrhash(FAR const char *arr, ssize_t len)
 {
-  ssize_t l = 0;
-  ssize_t r = len - 1;
+  ssize_t  l    = 0;
+  ssize_t  r    = len - 1;
   uint16_t hash = 0;
 
   /* TODO: Change the array checksum to be 16 bit long. */
@@ -109,8 +109,8 @@ uint8_t mfs_arrhash(FAR const char *arr, ssize_t len)
 
 uint16_t mfs_hash(FAR const char *arr, ssize_t len)
 {
-  ssize_t l = 0;
-  ssize_t r = len - 1;
+  ssize_t  l    = 0;
+  ssize_t  r    = len - 1;
   uint32_t hash = 0;
 
   /* TODO: Change the array checksum to be 16 bit long. */


### PR DESCRIPTION
## Summary
- Fixes the journal log read and write size and overlap issues
- Fixes rw return value issue.

## Impact
mnemofs can now store logs properly, and flush properly.

## Testing
nsh:sim and checkpatch.
