### PR TITLE
rpmsgfs_client:Fix error return exception

### DIFF
--- a/fs/rpmsgfs/rpmsgfs_client.c
+++ b/fs/rpmsgfs/rpmsgfs_client.c
@@ -174,6 +174,7 @@ static int rpmsgfs_ioctl_handler(FAR struct rpmsg_endpoint *ept,
       (FAR struct rpmsgfs_cookie_s *)(uintptr_t)header->cookie;
   FAR struct rpmsgfs_ioctl_s *rsp = data;
 
+  cookie->result = header->result;
   if (cookie->result >= 0 && rsp->arglen > 0)
     {
       memcpy(cookie->data, (FAR void *)(uintptr_t)rsp->buf, rsp->arglen);


### PR DESCRIPTION
## Summary
When handling errors through ioctl, the error returned by the server is always 0 on the client, because cookie.result is not assigned, the error returned should be in msg->result

## Impact
If the server handles an error, the error result returned by the cookie can be correctly handled by the client

## Testing
Local test pass
