### PR TITLE
Rpmsgfs support filelock

### DIFF
--- a/fs/rpmsgfs/rpmsgfs_server.c
+++ b/fs/rpmsgfs/rpmsgfs_server.c
@@ -479,8 +479,18 @@ static int rpmsgfs_ioctl_handler(FAR struct rpmsg_endpoint *ept,
   filep = rpmsgfs_get_file(priv, msg->fd);
   if (filep != NULL)
     {
-      ret = file_ioctl(filep, msg->request, msg->arglen > 0 ?
-                       (unsigned long)msg->buf : msg->arg);
+      unsigned long arg;
+
+      arg = msg->arglen > 0 ? (unsigned long)msg->buf : msg->arg;
+      switch (msg->request)
+        {
+          case FIOC_SETLK:
+          case FIOC_GETLK:
+            ret = file_fcntl(filep, msg->request, arg);
+            break;
+          default:
+            ret = file_ioctl(filep, msg->request, arg);
+        }
     }
 
   msg->header.result = ret;

--- a/fs/rpmsgfs/rpmsgfs_server.c
+++ b/fs/rpmsgfs/rpmsgfs_server.c
@@ -479,18 +479,8 @@ static int rpmsgfs_ioctl_handler(FAR struct rpmsg_endpoint *ept,
   filep = rpmsgfs_get_file(priv, msg->fd);
   if (filep != NULL)
     {
-      unsigned long arg;
-
-      arg = msg->arglen > 0 ? (unsigned long)msg->buf : msg->arg;
-      switch (msg->request)
-        {
-          case FIOC_SETLK:
-          case FIOC_GETLK:
-            ret = file_fcntl(filep, msg->request, arg);
-            break;
-          default:
-            ret = file_ioctl(filep, msg->request, arg);
-        }
+      ret = file_ioctl(filep, msg->request, msg->arglen > 0 ?
+                       (unsigned long)msg->buf : msg->arg);
     }
 
   msg->header.result = ret;

--- a/fs/vfs/fs_fcntl.c
+++ b/fs/vfs/fs_fcntl.c
@@ -198,7 +198,11 @@ static int file_vfcntl(FAR struct file *filep, int cmd, va_list ap)
 
         {
           FAR struct flock *flock = va_arg(ap, FAR struct flock *);
-          ret = file_getlk(filep, flock);
+          ret = file_ioctl(filep, FIOC_GETLK, flock);
+          if (ret < 0)
+            {
+              ret = file_getlk(filep, flock);
+            }
         }
 
         break;
@@ -215,7 +219,11 @@ static int file_vfcntl(FAR struct file *filep, int cmd, va_list ap)
 
         {
           FAR struct flock *flock = va_arg(ap, FAR struct flock *);
-          ret = file_setlk(filep, flock, true);
+          ret = file_ioctl(filep, FIOC_SETLK, flock);
+          if (ret < 0)
+            {
+              ret = file_setlk(filep, flock, true);
+            }
         }
 
         break;
@@ -231,7 +239,11 @@ static int file_vfcntl(FAR struct file *filep, int cmd, va_list ap)
 
         {
           FAR struct flock *flock = va_arg(ap, FAR struct flock *);
-          ret = file_setlk(filep, flock, false);
+          ret = file_ioctl(filep, FIOC_SETLKW, flock);
+          if (ret < 0)
+            {
+              ret = file_setlk(filep, flock, false);
+            }
         }
 
         break;

--- a/fs/vfs/fs_fcntl.c
+++ b/fs/vfs/fs_fcntl.c
@@ -35,7 +35,6 @@
 #include <nuttx/fs/fs.h>
 
 #include "inode/inode.h"
-#include "lock.h"
 
 /****************************************************************************
  * Private Functions
@@ -197,12 +196,8 @@ static int file_vfcntl(FAR struct file *filep, int cmd, va_list ap)
          */
 
         {
-          FAR struct flock *flock = va_arg(ap, FAR struct flock *);
-          ret = file_ioctl(filep, FIOC_GETLK, flock);
-          if (ret < 0)
-            {
-              ret = file_getlk(filep, flock);
-            }
+          ret = file_ioctl(filep, FIOC_GETLK,
+                           va_arg(ap, FAR struct flock *));
         }
 
         break;
@@ -218,12 +213,8 @@ static int file_vfcntl(FAR struct file *filep, int cmd, va_list ap)
          */
 
         {
-          FAR struct flock *flock = va_arg(ap, FAR struct flock *);
-          ret = file_ioctl(filep, FIOC_SETLK, flock);
-          if (ret < 0)
-            {
-              ret = file_setlk(filep, flock, true);
-            }
+          ret = file_ioctl(filep, FIOC_SETLK,
+                           va_arg(ap, FAR struct flock *));
         }
 
         break;
@@ -238,12 +229,8 @@ static int file_vfcntl(FAR struct file *filep, int cmd, va_list ap)
          */
 
         {
-          FAR struct flock *flock = va_arg(ap, FAR struct flock *);
-          ret = file_ioctl(filep, FIOC_SETLKW, flock);
-          if (ret < 0)
-            {
-              ret = file_setlk(filep, flock, false);
-            }
+          ret = file_ioctl(filep, FIOC_SETLKW,
+                           va_arg(ap, FAR struct flock *));
         }
 
         break;

--- a/fs/vfs/fs_ioctl.c
+++ b/fs/vfs/fs_ioctl.c
@@ -31,6 +31,7 @@
 #include <assert.h>
 
 #include "inode/inode.h"
+#include "lock.h"
 
 /****************************************************************************
  * Private Functions
@@ -106,6 +107,29 @@ static int file_vioctl(FAR struct file *filep, int req, va_list ap)
         if (ret == -ENOTTY && !INODE_IS_MOUNTPT(inode))
           {
             ret = inode_getpath(inode, (FAR char *)(uintptr_t)arg, PATH_MAX);
+          }
+        break;
+
+      case FIOC_GETLK:
+        if (ret == -ENOTTY)
+          {
+            ret = file_getlk(filep, (FAR struct flock *)(uintptr_t)arg);
+          }
+        break;
+
+      case FIOC_SETLK:
+        if (ret == -ENOTTY)
+          {
+            ret = file_setlk(filep, (FAR struct flock *)(uintptr_t)arg,
+                             true);
+          }
+        break;
+
+      case FIOC_SETLKW:
+        if (ret == -ENOTTY)
+          {
+            ret = file_setlk(filep, (FAR struct flock *)(uintptr_t)arg,
+                             false);
           }
         break;
 

--- a/include/nuttx/fs/ioctl.h
+++ b/include/nuttx/fs/ioctl.h
@@ -213,6 +213,16 @@
                                            */
 #endif
 
+#define FIOC_SETLK          _FIOC(0x0012) /* IN:  Pointer to flock
+                                           * OUT: None
+                                           */
+#define FIOC_GETLK          _FIOC(0x0013) /* IN:  Pointer to flock
+                                           * OUT: None
+                                           */
+#define FIOC_SETLKW         _FIOC(0x0014) /* IN:  Pointer to flock
+                                           * OUT: None
+                                           */
+
 /* NuttX file system ioctl definitions **************************************/
 
 #define _DIOCVALID(c)   (_IOC_TYPE(c)==_DIOCBASE)


### PR DESCRIPTION
## Summary
There is now support for locking files on the server side via rpmsgfs. The main changes are:
1. move filelock call from fcntl to ioctl, use ioctl FIOC_XXXLK to lock server-side files.
2. because there are blocking operations in the file lock, the client side can only do a polling request to find out if the server is currently blocked.

## Impact
1. The file lock call has changed
2. rpmsgfs support cross-core filelock

## Testing
Local test Pass
