### PR TITLE
Hostfs support get filepath by ioctl

### DIFF
--- a/fs/hostfs/hostfs.c
+++ b/fs/hostfs/hostfs.c
@@ -609,12 +609,14 @@ static int hostfs_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
       switch (cmd)
         {
           case FIOC_FILEPATH:
-            FAR char *path = (FAR char *)(uintptr_t)arg;
-            ret = inode_getpath(filep->f_inode, path, PATH_MAX);
-            if (ret >= 0)
-              {
-                strlcat(path, hf->relpath, PATH_MAX);
-              }
+            {
+              FAR char *path = (FAR char *)(uintptr_t)arg;
+              ret = inode_getpath(filep->f_inode, path, PATH_MAX);
+              if (ret >= 0)
+                {
+                  strlcat(path, hf->relpath, PATH_MAX);
+                }
+            }
 
             break;
           default:

--- a/fs/hostfs/hostfs.c
+++ b/fs/hostfs/hostfs.c
@@ -604,14 +604,21 @@ static int hostfs_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   /* Call our internal routine to perform the ioctl */
 
   ret = host_ioctl(hf->fd, cmd, arg);
-
-  if (ret < 0 && cmd == FIOC_FILEPATH)
+  if (ret < 0)
     {
-      FAR char *path = (FAR char *)(uintptr_t)arg;
-      ret = inode_getpath(filep->f_inode, path, PATH_MAX);
-      if (ret >= 0)
+      switch (cmd)
         {
-          strlcat(path, hf->relpath, PATH_MAX);
+          case FIOC_FILEPATH:
+            FAR char *path = (FAR char *)(uintptr_t)arg;
+            ret = inode_getpath(filep->f_inode, path, PATH_MAX);
+            if (ret >= 0)
+              {
+                strlcat(path, hf->relpath, PATH_MAX);
+              }
+
+            break;
+          default:
+            ret = -ENOTTY;
         }
     }
 

--- a/fs/hostfs/hostfs.h
+++ b/fs/hostfs/hostfs.h
@@ -47,10 +47,11 @@
 
 struct hostfs_ofile_s
 {
-  struct hostfs_ofile_s    *fnext;      /* Supports a singly linked list */
-  int16_t                   crefs;      /* Reference count */
-  mode_t                    oflags;     /* Open mode */
+  struct hostfs_ofile_s    *fnext;   /* Supports a singly linked list */
+  int16_t                   crefs;   /* Reference count */
+  mode_t                    oflags;  /* Open mode */
   int                       fd;
+  char                      relpath[1];
 };
 
 /* This structure represents the overall mountpoint state.  An instance of


### PR DESCRIPTION
## Summary
1. hostfs supports getting the path information of an opened fd through ioctl
2. When the command is not supported, -ENOTTY should be returned

## Impact
hostfs support get filepath

## Testing
Local test pass

