### PR TITLE
fs/hostfs: Replace strcpy with memcpy

### DIFF
--- a/fs/hostfs/hostfs.c
+++ b/fs/hostfs/hostfs.c
@@ -245,6 +245,7 @@ static int hostfs_open(FAR struct file *filep, FAR const char *relpath,
   FAR struct hostfs_mountpt_s *fs;
   FAR struct hostfs_ofile_s  *hf;
   char path[HOSTFS_MAX_PATH];
+  size_t len;
   int ret;
 
   /* Sanity checks */
@@ -270,7 +271,8 @@ static int hostfs_open(FAR struct file *filep, FAR const char *relpath,
 
   /* Allocate memory for the open file */
 
-  hf = kmm_malloc(sizeof(*hf) + strlen(relpath));
+  len = strlen(relpath);
+  hf = kmm_malloc(sizeof(*hf) + len);
   if (hf == NULL)
     {
       ret = -ENOMEM;
@@ -322,7 +324,7 @@ static int hostfs_open(FAR struct file *filep, FAR const char *relpath,
   hf->fnext = fs->fs_head;
   hf->crefs = 1;
   hf->oflags = oflags;
-  strcpy(hf->relpath, relpath);
+  memcpy(hf->relpath, relpath, len + 1);
   fs->fs_head = hf;
 
   ret = OK;


### PR DESCRIPTION
## Summary

The strcpy function is dangerous because it does not check the length of the

## Impact

code refactor only

## Testing

ci