### PR TITLE
mm/mempool: rename the mempool_alloc and mempool_free function

### DIFF
--- a/include/nuttx/mm/mempool.h
+++ b/include/nuttx/mm/mempool.h
@@ -174,7 +174,7 @@ extern "C"
 int mempool_init(FAR struct mempool_s *pool, FAR const char *name);
 
 /****************************************************************************
- * Name: mempool_alloc
+ * Name: mempool_allocate
  *
  * Description:
  *   Allocate an block from a specific memory pool.
@@ -190,10 +190,10 @@ int mempool_init(FAR struct mempool_s *pool, FAR const char *name);
  *
  ****************************************************************************/
 
-FAR void *mempool_alloc(FAR struct mempool_s *pool);
+FAR void *mempool_allocate(FAR struct mempool_s *pool);
 
 /****************************************************************************
- * Name: mempool_free
+ * Name: mempool_release
  *
  * Description:
  *   Release an memory block to the pool.
@@ -203,7 +203,7 @@ FAR void *mempool_alloc(FAR struct mempool_s *pool);
  *   blk  - The pointer of memory block.
  ****************************************************************************/
 
-void mempool_free(FAR struct mempool_s *pool, FAR void *blk);
+void mempool_release(FAR struct mempool_s *pool, FAR void *blk);
 
 /****************************************************************************
  * Name: mempool_info

--- a/mm/mempool/mempool.c
+++ b/mm/mempool/mempool.c
@@ -198,7 +198,7 @@ int mempool_init(FAR struct mempool_s *pool, FAR const char *name)
 }
 
 /****************************************************************************
- * Name: mempool_alloc
+ * Name: mempool_allocate
  *
  * Description:
  *   Allocate an block from a specific memory pool.
@@ -214,7 +214,7 @@ int mempool_init(FAR struct mempool_s *pool, FAR const char *name)
  *
  ****************************************************************************/
 
-FAR void *mempool_alloc(FAR struct mempool_s *pool)
+FAR void *mempool_allocate(FAR struct mempool_s *pool)
 {
   FAR sq_entry_t *blk;
   irqstate_t flags;
@@ -285,7 +285,7 @@ out_with_lock:
 }
 
 /****************************************************************************
- * Name: mempool_free
+ * Name: mempool_release
  *
  * Description:
  *   Release a memory block to the pool.
@@ -295,7 +295,7 @@ out_with_lock:
  *   blk  - The pointer of memory block.
  ****************************************************************************/
 
-void mempool_free(FAR struct mempool_s *pool, FAR void *blk)
+void mempool_release(FAR struct mempool_s *pool, FAR void *blk)
 {
   irqstate_t flags = spin_lock_irqsave(&pool->lock);
   size_t blocksize = MEMPOOL_REALBLOCKSIZE(pool);

--- a/mm/mempool/mempool_multiple.c
+++ b/mm/mempool/mempool_multiple.c
@@ -524,7 +524,7 @@ FAR void *mempool_multiple_alloc(FAR struct mempool_multiple_s *mpool,
   end = mpool->pools + mpool->npools;
   do
     {
-      FAR void *blk = mempool_alloc(pool);
+      FAR void *blk = mempool_allocate(pool);
 
       if (blk)
         {
@@ -610,7 +610,7 @@ int mempool_multiple_free(FAR struct mempool_multiple_s *mpool,
   blk = (FAR char *)blk - (((FAR char *)blk -
                            ((FAR char *)dict->addr + mpool->minpoolsize)) %
                            MEMPOOL_REALBLOCKSIZE(dict->pool));
-  mempool_free(dict->pool, blk);
+  mempool_release(dict->pool, blk);
   return 0;
 }
 
@@ -689,7 +689,7 @@ FAR void *mempool_multiple_memalign(FAR struct mempool_multiple_s *mpool,
   end = mpool->pools + mpool->npools;
   do
     {
-      FAR char *blk = mempool_alloc(pool);
+      FAR char *blk = mempool_allocate(pool);
       if (blk != NULL)
         {
           return (FAR void *)ALIGN_UP(blk, alignment);


### PR DESCRIPTION
## Summary
the mempool_alloc and mempool_free function are duplicate with the mempool method that provided in optee_os, in order to port optee_os, so we rename the mempool related functions in nuttx

## Impact

## Testing

