### PR TITLE
assert: add compile_assert macro

### DIFF
--- a/include/assert.h
+++ b/include/assert.h
@@ -152,6 +152,8 @@
 #  endif
 #endif
 
+#define COMPILE_TIME_ASSERT(x) static_assert(x, "compile time assert failed")
+
 /* Force a compilation error if condition is true, but also produce a
  * result (of value 0 and type int), so the expression can be used
  * e.g. in a structure initializer (or where-ever else comma expressions


### PR DESCRIPTION
## Summary
the COMPILE_TIME_ASSERT macro is used in many third-party libraries

## Impact

## Testing

