### PR TITLE
arm/armv[7|8]-m: add syn barrier for MPU ops

### DIFF
--- a/arch/arm/src/armv7-m/arm_mpu.c
+++ b/arch/arm/src/armv7-m/arm_mpu.c
@@ -29,6 +29,7 @@
 
 #include "mpu.h"
 #include "arm_internal.h"
+#include "barriers.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -201,6 +202,9 @@ static void mpu_reset_internal()
     }
 
   putreg32(0, MPU_CTRL);
+
+  ARM_DSB();
+  ARM_ISB();
 }
 #endif
 
@@ -356,6 +360,11 @@ void mpu_control(bool enable, bool hfnmiena, bool privdefena)
     }
 
   putreg32(regval, MPU_CTRL);
+
+  /* Ensure MPU setting take effects */
+
+  ARM_DSB();
+  ARM_ISB();
 }
 
 /****************************************************************************
@@ -413,6 +422,11 @@ void mpu_configure_region(uintptr_t base, size_t size,
            ((uint32_t)subregions << MPU_RASR_SRD_SHIFT) | /* Sub-regions    */
            flags;
   putreg32(regval, MPU_RASR);
+
+  /* Ensure MPU setting take effects */
+
+  ARM_DSB();
+  ARM_ISB();
 }
 
 /****************************************************************************

--- a/arch/arm/src/armv8-m/arm_mpu.c
+++ b/arch/arm/src/armv8-m/arm_mpu.c
@@ -29,6 +29,7 @@
 
 #include "mpu.h"
 #include "arm_internal.h"
+#include "barriers.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -95,6 +96,9 @@ static void mpu_reset_internal()
     }
 
   putreg32(0, MPU_CTRL);
+
+  ARM_DSB();
+  ARM_ISB();
 }
 #endif
 
@@ -139,6 +143,11 @@ void mpu_control(bool enable, bool hfnmiena, bool privdefena)
     }
 
   putreg32(regval, MPU_CTRL);
+
+  /* Ensure MPU setting take effects */
+
+  ARM_DSB();
+  ARM_ISB();
 }
 
 /****************************************************************************
@@ -174,6 +183,11 @@ void mpu_configure_region(uintptr_t base, size_t size,
 
   putreg32(base | flags1, MPU_RBAR);
   putreg32(limit | flags2 | MPU_RLAR_ENABLE, MPU_RLAR);
+
+  /* Ensure MPU setting take effects */
+
+  ARM_DSB();
+  ARM_ISB();
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
From cortex spec, when setting up the MPU, execute  a DSB instruction and then an ISB instruction to ensure that all subsequent memory taking effect. 

## Impact
arm mpu programming

## Testing
testing in lm3s6965-ek:qemu-protected

