### PR TITLE
armv7a/irq: enable fiq in tee, enable irq in ap

### DIFF
--- a/arch/arm/include/armv7-a/irq.h
+++ b/arch/arm/include/armv7-a/irq.h
@@ -379,10 +379,11 @@ static inline irqstate_t up_irq_enable(void)
   __asm__ __volatile__
     (
       "\tmrs    %0, cpsr\n"
-#if defined(CONFIG_ARCH_TRUSTZONE_SECURE) || defined(CONFIG_ARCH_HIPRI_INTERRUPT)
+#if defined(CONFIG_ARCH_HIPRI_INTERRUPT)
+      "\tcpsie  if\n"
+#elif defined(CONFIG_ARCH_TRUSTZONE_SECURE)
       "\tcpsie  f\n"
-#endif
-#ifndef CONFIG_ARCH_TRUSTZONE_SECURE
+#else
       "\tcpsie  i\n"
 #endif
       : "=r" (cpsr)


### PR DESCRIPTION
## Summary
the reason for this fix:
According to the current design on the armv7-a platform, only fiq is processed in TEE, while irq and fiq are processed in REE. If we enable the irq function in TEE, when we process some signal-related scenarios in TEE, such as the ostest sighand testcase, this testcase will call up_irq_enable() to enable irq interrupt in the arm_sigdeliver() function. After the signal processing logic is executed, irq will be disabled again.
During the interval of enabling irq, some external device irq interrupts will be enabled, but these external device irqs do not have corresponding handlers registered in TEE, so an "unexpected irq isr exception" will be triggered. Therefore, a better implementation is to keep the original implementation of the up_irq_enable() function, that is, to enable only fiq in TEE and to enable irq and fiq in REE. Then, for vendor-specific requirements, such as the need to briefly enable irq during the TEE initialization process and then disable irq before starting APz in TEE, we directly provide a separate implementation of enabling irq in the vendor, without modifying the implementation of the public up_enable_irq() function.

## Impact

## Testing

