### PR TITLE
lib_remove:Repair the logical judgment

### DIFF
--- a/libs/libc/stdio/lib_remove.c
+++ b/libs/libc/stdio/lib_remove.c
@@ -55,9 +55,7 @@ int remove(FAR const char *path)
    * more frequently the necessary action.
    */
 
-  if (unlink(path) != 0     && /* If it is indeed a directory...  */
-      (get_errno() != EISDIR || /* ...try to remove it.  */
-       rmdir(path) != 0))
+  if (unlink(path) != 0 && (get_errno() != EISDIR || rmdir(path) != 0))
     {
       /* Cannot remove the object for whatever reason. */
 

--- a/libs/libc/stdio/lib_remove.c
+++ b/libs/libc/stdio/lib_remove.c
@@ -56,7 +56,7 @@ int remove(FAR const char *path)
    */
 
   if (unlink(path) != 0     && /* If it is indeed a directory...  */
-      (get_errno() != EPERM || /* ...try to remove it.  */
+      (get_errno() != EISDIR || /* ...try to remove it.  */
        rmdir(path) != 0))
     {
       /* Cannot remove the object for whatever reason. */


### PR DESCRIPTION
## Summary
  When the deleted path is a file, the return value of get_errno is -EISDIR, so in Condition Two
```
(get_errno() ! = EPERM && /* .... . try to remove it. */
       rmdir(path) ! = 0)
```
The judgment holds directly, so it can't actually execute to rmdir

## Impact
None

## Testing
Local test pass
