### PR TITLE
MPU update

### DIFF
--- a/arch/arm/src/armv7-m/arm_mpu.c
+++ b/arch/arm/src/armv7-m/arm_mpu.c
@@ -618,8 +618,8 @@ void mpu_dump_region(void)
       putreg32(i, MPU_RNR);
       rasr = getreg32(MPU_RASR);
       rbar = getreg32(MPU_RBAR);
-      _info("MPU-%d, alignedbase=0%08X l2size=%"PRIu32" SRD=%X"
-            "AP=%X XN=%u\n", i, rbar & MPU_RBAR_ADDR_MASK,
+      _info("MPU-%d, alignedbase=%08"PRIx32" l2size=%"PRIu32" SRD=%"PRIx32""
+            "AP=%"PRIx32" XN=%"PRIu32"\n", i, rbar & MPU_RBAR_ADDR_MASK,
             rasr & MPU_RASR_SIZE_MASK, rasr & MPU_RASR_SRD_MASK,
             rasr & MPU_RASR_AP_MASK, rasr & MPU_RASR_XN);
       if (rasr & MPU_RASR_ENABLE)

--- a/arch/arm/src/armv7-m/arm_mpu.c
+++ b/arch/arm/src/armv7-m/arm_mpu.c
@@ -558,6 +558,7 @@ unsigned int mpu_configure_region(uintptr_t base, size_t size,
  *
  * Input Parameters:
  *   table      - MPU initialization table.
+ *   count      - Initialize the number of entries in the region table.
  *   hfnmiena   - A boolean indicating whether the MPU should enable the
  *                HFNMIENA bit.
  *   privdefena - A boolean indicating whether the MPU should enable the
@@ -568,14 +569,14 @@ unsigned int mpu_configure_region(uintptr_t base, size_t size,
  *
  ****************************************************************************/
 
-void mpu_initialize(const struct mpu_region_s *table, bool hfnmiena,
-                    bool privdefena)
+void mpu_initialize(const struct mpu_region_s *table, size_t count,
+                    bool hfnmiena, bool privdefena)
 {
   const struct mpu_region_s *conf;
-  int index;
+  size_t index;
 
   mpu_control(false, false, false);
-  for (index = 0; index < nitems(table); index++)
+  for (index = 0; index < count; index++)
     {
       conf = &table[index];
       mpu_configure_region(conf->base, conf->size, conf->flags);

--- a/arch/arm/src/armv7-m/mpu.h
+++ b/arch/arm/src/armv7-m/mpu.h
@@ -380,6 +380,7 @@ unsigned int mpu_configure_region(uintptr_t base, size_t size,
  *
  * Input Parameters:
  *   table      - MPU initialization table.
+ *   count      - Initialize the number of entries in the region table.
  *   hfnmiena   - A boolean indicating whether the MPU should enable the
  *                HFNMIENA bit.
  *   privdefena - A boolean indicating whether the MPU should enable the
@@ -390,8 +391,8 @@ unsigned int mpu_configure_region(uintptr_t base, size_t size,
  *
  ****************************************************************************/
 
-void mpu_initialize(const struct mpu_region_s *table, bool hfnmiena,
-                    bool privdefena);
+void mpu_initialize(const struct mpu_region_s *table, size_t count,
+                    bool hfnmiena, bool privdefena);
 
 /****************************************************************************
  * Inline Functions

--- a/arch/arm/src/armv7-m/mpu.h
+++ b/arch/arm/src/armv7-m/mpu.h
@@ -130,12 +130,33 @@
 #    define MPU_RASR_AP_RORO    (6 << MPU_RASR_AP_SHIFT)  /* P:RO   U:RO   */
 #  define MPU_RASR_XN           (1 << 28)                 /* Bit 28: Instruction access disable */
 
+struct mpu_region_s
+{
+  /* Region Base Address */
+
+  uintptr_t base;
+
+  /* Region Size */
+
+  size_t size;
+
+  /* Region Attributes */
+
+  uint32_t flags;
+};
+
 /****************************************************************************
  * Name: mpu_reset
  *
  * Description:
  *   Conditional public interface that resets the MPU to disabled during
  *   MPU initialization.
+ *
+ * Input Parameters:
+ *   None.
+ *
+ * Returned Value:
+ *   None.
  *
  ****************************************************************************/
 
@@ -151,6 +172,12 @@ void mpu_reset(void);
  * Description:
  *   Conditional public interface that resets the MPU to disabled immediately
  *   after reset.
+ *
+ * Input Parameters:
+ *   None.
+ *
+ * Returned Value:
+ *   None.
  *
  ****************************************************************************/
 
@@ -180,11 +207,33 @@ extern "C"
  * Name: mpu_allocregion
  *
  * Description:
- *  Allocate the next region
+ *   Allocate the next region
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   The index of the allocated region.
  *
  ****************************************************************************/
 
 unsigned int mpu_allocregion(void);
+
+/****************************************************************************
+ * Name: mpu_freeregion
+ *
+ * Description:
+ *   Free target region.
+ *
+ * Input Parameters:
+ *  region - The index of the region to be freed.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void mpu_freeregion(unsigned int region);
 
 /****************************************************************************
  * Name: mpu_log2regionceil
@@ -194,6 +243,12 @@ unsigned int mpu_allocregion(void);
  *   following is true:
  *
  *   size <= (1 << l2size)
+ *
+ * Input Parameters:
+ *   size - The size of the region.
+ *
+ * Returned Value:
+ *   The logarithm base 2 of the ceiling value for the MPU region size.
  *
  ****************************************************************************/
 
@@ -208,6 +263,12 @@ uint8_t mpu_log2regionceil(size_t size);
  *
  *   size >= (1 << l2size)
  *
+ * Input Parameters:
+ *   size - The size of the region.
+ *
+ * Returned Value:
+ *   The logarithm base 2 of the floor value for the MPU region size.
+ *
  ****************************************************************************/
 
 uint8_t mpu_log2regionfloor(size_t size);
@@ -216,13 +277,21 @@ uint8_t mpu_log2regionfloor(size_t size);
  * Name: mpu_subregion
  *
  * Description:
- *   Given (1) the offset to the beginning of valid data, (2) the size of the
- *   memory to be mapped and (2) the log2 size of the mapping to use,
- *   determine the minimal sub-region set to span that memory region.
+ *   Given the size of the (1) memory to be mapped and (2) the log2 size
+ *   of the mapping to use, determine the minimal sub-region set to span
+ *   that memory region.
  *
  * Assumption:
  *   l2size has the same properties as the return value from
  *   mpu_log2regionceil()
+ *
+ * Input Parameters:
+ *   base   - The base address of the region.
+ *   size   - The size of the region.
+ *   l2size - Log2 of the actual region size is <= (1 << l2size).
+ *
+ * Returned Value:
+ *   The subregion settings as a 32-bit value.
  *
  ****************************************************************************/
 
@@ -234,9 +303,55 @@ uint32_t mpu_subregion(uintptr_t base, size_t size, uint8_t l2size);
  * Description:
  *   Configure and enable (or disable) the MPU
  *
+ * Input Parameters:
+ *   enable     - Flag indicating whether to enable the MPU.
+ *   hfnmiena   - Flag indicating whether to enable the MPU during hard
+ *                fult, NMI, and FAULTMAS.
+ *   privdefena - Flag indicating whether to enable privileged access to
+ *                the default memory map.
+ *
+ * Returned Value:
+ *   None.
+ *
  ****************************************************************************/
 
 void mpu_control(bool enable, bool hfnmiena, bool privdefena);
+
+/****************************************************************************
+ * Name: mpu_dump_region
+ *
+ * Description:
+ *   Dump the region that has been used.
+ *
+ * Input Parameters:
+ *   None.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void mpu_dump_region(void);
+
+/****************************************************************************
+ * Name: mpu_modify_region
+ *
+ * Description:
+ *   Modify a region for privileged, strongly ordered memory
+ *
+ * Input Parameters:
+ *   region - Region number to modify.
+ *   base   - Base address of the region.
+ *   size   - Size of the region.
+ *   flags  - Flags to configure the region.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void mpu_modify_region(unsigned int region, uintptr_t base, size_t size,
+                       uint32_t flags);
 
 /****************************************************************************
  * Name: mpu_configure_region
@@ -244,9 +359,39 @@ void mpu_control(bool enable, bool hfnmiena, bool privdefena);
  * Description:
  *   Configure a region for privileged, strongly ordered memory
  *
+ * Input Parameters:
+ *   base - Base address of the region.
+ *   size - Size of the region.
+ *   flags - Flags to configure the region.
+ *
+ * Returned Value:
+ *   The region number allocated for the configured region.
+ *
  ****************************************************************************/
 
-void mpu_configure_region(uintptr_t base, size_t size, uint32_t flags);
+unsigned int mpu_configure_region(uintptr_t base, size_t size,
+                                  uint32_t flags);
+
+/****************************************************************************
+ * Name: mpu_initialize
+ *
+ * Description:
+ *   Configure a region for privileged, strongly ordered memory
+ *
+ * Input Parameters:
+ *   table      - MPU initialization table.
+ *   hfnmiena   - A boolean indicating whether the MPU should enable the
+ *                HFNMIENA bit.
+ *   privdefena - A boolean indicating whether the MPU should enable the
+ *                PRIVDEFENA bit.
+ *
+ * Returned Value:
+ *   NULL.
+ *
+ ****************************************************************************/
+
+void mpu_initialize(const struct mpu_region_s *table, bool hfnmiena,
+                    bool privdefena);
 
 /****************************************************************************
  * Inline Functions
@@ -284,18 +429,14 @@ void mpu_configure_region(uintptr_t base, size_t size, uint32_t flags);
  ****************************************************************************/
 
 #define mpu_priv_stronglyordered(base, size) \
-  do \
-    { \
-      /* The configure the region */ \
-      mpu_configure_region(base, size, \
-                           MPU_RASR_TEX_SO  | /* Ordered            */ \
-                                              /* Not Cacheable      */ \
-                                              /* Not Bufferable     */ \
-                           MPU_RASR_S       | /* Shareable          */ \
-                           MPU_RASR_AP_RWNO   /* P:RW   U:None      */ \
-                                              /* Instruction access */); \
-    } \
-  while (0)
+  /* The configure the region */ \
+  mpu_configure_region(base, size, \
+                       MPU_RASR_TEX_SO  | /* Ordered            */ \
+                                          /* Not Cacheable      */ \
+                                          /* Not Bufferable     */ \
+                       MPU_RASR_S       | /* Shareable          */ \
+                       MPU_RASR_AP_RWNO   /* P:RW   U:None      */ \
+                                          /* Instruction access */)
 
 /****************************************************************************
  * Name: mpu_user_flash
@@ -306,18 +447,14 @@ void mpu_configure_region(uintptr_t base, size_t size, uint32_t flags);
  ****************************************************************************/
 
 #define mpu_user_flash(base, size) \
-  do \
-    { \
-      /* The configure the region */ \
-      mpu_configure_region(base, size, \
-                           MPU_RASR_TEX_SO  | /* Ordered            */ \
-                           MPU_RASR_C       | /* Cacheable          */ \
-                                              /* Not Bufferable     */ \
-                                              /* Not Shareable      */ \
-                           MPU_RASR_AP_RORO   /* P:RO   U:RO        */ \
-                                              /* Instruction access */); \
-    } \
-  while (0)
+  /* The configure the region */ \
+  mpu_configure_region(base, size, \
+                       MPU_RASR_TEX_SO  | /* Ordered            */ \
+                       MPU_RASR_C       | /* Cacheable          */ \
+                                          /* Not Bufferable     */ \
+                                          /* Not Shareable      */ \
+                       MPU_RASR_AP_RORO   /* P:RO   U:RO        */ \
+                                          /* Instruction access */)
 
 /****************************************************************************
  * Name: mpu_priv_flash
@@ -328,18 +465,14 @@ void mpu_configure_region(uintptr_t base, size_t size, uint32_t flags);
  ****************************************************************************/
 
 #define mpu_priv_flash(base, size) \
-  do \
-    { \
-      /* The configure the region */ \
-      mpu_configure_region(base, size, \
-                           MPU_RASR_TEX_SO   | /* Ordered            */ \
-                           MPU_RASR_C        | /* Cacheable          */ \
-                                               /* Not Bufferable     */ \
-                                               /* Not Shareable      */ \
-                           MPU_RASR_AP_RONO    /* P:RO   U:None      */ \
-                                               /* Instruction access */); \
-    } \
-  while (0)
+  /* The configure the region */ \
+  mpu_configure_region(base, size, \
+                       MPU_RASR_TEX_SO   | /* Ordered            */ \
+                       MPU_RASR_C        | /* Cacheable          */ \
+                                           /* Not Bufferable     */ \
+                                           /* Not Shareable      */ \
+                       MPU_RASR_AP_RONO    /* P:RO   U:None      */ \
+                                           /* Instruction access */)
 
 /****************************************************************************
  * Name: mpu_user_intsram
@@ -350,18 +483,14 @@ void mpu_configure_region(uintptr_t base, size_t size, uint32_t flags);
  ****************************************************************************/
 
 #define mpu_user_intsram(base, size) \
-  do \
-    { \
-      /* The configure the region */ \
-      mpu_configure_region(base, size, \
-                           MPU_RASR_TEX_SO   | /* Ordered            */ \
-                           MPU_RASR_C        | /* Cacheable          */ \
-                                               /* Not Bufferable     */ \
-                           MPU_RASR_S        | /* Shareable          */ \
-                           MPU_RASR_AP_RWRW    /* P:RW   U:RW        */ \
-                                               /* Instruction access */); \
-    } \
-  while (0)
+  /* The configure the region */ \
+  mpu_configure_region(base, size, \
+                       MPU_RASR_TEX_SO   | /* Ordered            */ \
+                       MPU_RASR_C        | /* Cacheable          */ \
+                                           /* Not Bufferable     */ \
+                       MPU_RASR_S        | /* Shareable          */ \
+                       MPU_RASR_AP_RWRW    /* P:RW   U:RW        */ \
+                                           /* Instruction access */)
 
 /****************************************************************************
  * Name: mpu_priv_intsram
@@ -372,18 +501,14 @@ void mpu_configure_region(uintptr_t base, size_t size, uint32_t flags);
  ****************************************************************************/
 
 #define mpu_priv_intsram(base, size) \
-  do \
-    { \
-      /* The configure the region */ \
-      mpu_configure_region(base, size, \
-                           MPU_RASR_TEX_SO  | /* Ordered            */ \
-                           MPU_RASR_C       | /* Cacheable          */ \
-                                              /* Not Bufferable     */ \
-                           MPU_RASR_S       | /* Shareable          */ \
-                           MPU_RASR_AP_RWNO   /* P:RW   U:None      */ \
-                                              /* Instruction access */); \
-    } \
-  while (0)
+  /* The configure the region */ \
+  mpu_configure_region(base, size, \
+                       MPU_RASR_TEX_SO  | /* Ordered            */ \
+                       MPU_RASR_C       | /* Cacheable          */ \
+                                          /* Not Bufferable     */ \
+                       MPU_RASR_S       | /* Shareable          */ \
+                       MPU_RASR_AP_RWNO   /* P:RW   U:None      */ \
+                                          /* Instruction access */)
 
 /****************************************************************************
  * Name: mpu_priv_shmem
@@ -393,18 +518,15 @@ void mpu_configure_region(uintptr_t base, size_t size, uint32_t flags);
  *
  ****************************************************************************/
 
-#define mpu_priv_shmem(base, size)                                      \
-  do                                                                    \
-    {                                                                   \
-      /* The configure the region */                                    \
-      mpu_configure_region(base, size,                                  \
-                           MPU_RASR_TEX_SO   | /* Ordered            */ \
-                                               /* Not Cacheable      */ \
-                           MPU_RASR_B        | /* Bufferable         */ \
-                           MPU_RASR_S        | /* Shareable          */ \
-                           MPU_RASR_AP_RWNO  | /* P:RW   U:None      */ \
-                           MPU_RASR_XN         /* No Instruction access */); \
-    } while (0)
+#define mpu_priv_shmem(base, size) \
+  /* The configure the region */ \
+  mpu_configure_region(base, size, \
+                       MPU_RASR_TEX_SO   | /* Ordered            */ \
+                                           /* Not Cacheable      */ \
+                       MPU_RASR_B        | /* Bufferable         */ \
+                       MPU_RASR_S        | /* Shareable          */ \
+                       MPU_RASR_AP_RWNO  | /* P:RW   U:None      */ \
+                       MPU_RASR_XN         /* No Instruction access */)
 
 /****************************************************************************
  * Name: mpu_user_extsram
@@ -415,17 +537,14 @@ void mpu_configure_region(uintptr_t base, size_t size, uint32_t flags);
  ****************************************************************************/
 
 #define mpu_user_extsram(base, size) \
-  do \
-    { \
-      /* The configure the region */ \
-      mpu_configure_region(base, size, \
-                           MPU_RASR_TEX_SO   | /* Ordered            */ \
-                           MPU_RASR_C        | /* Cacheable          */ \
-                           MPU_RASR_B        | /* Bufferable         */ \
-                           MPU_RASR_S        | /* Shareable          */ \
-                           MPU_RASR_AP_RWRW    /* P:RW   U:RW        */ \
-                                               /* Instruction access */); \
-    } while (0)
+  /* The configure the region */ \
+  mpu_configure_region(base, size, \
+                       MPU_RASR_TEX_SO   | /* Ordered            */ \
+                       MPU_RASR_C        | /* Cacheable          */ \
+                       MPU_RASR_B        | /* Bufferable         */ \
+                       MPU_RASR_S        | /* Shareable          */ \
+                       MPU_RASR_AP_RWRW    /* P:RW   U:RW        */ \
+                                           /* Instruction access */)
 
 /****************************************************************************
  * Name: mpu_priv_extsram
@@ -436,17 +555,14 @@ void mpu_configure_region(uintptr_t base, size_t size, uint32_t flags);
  ****************************************************************************/
 
 #define mpu_priv_extsram(base, size) \
-  do \
-    { \
-      /* The configure the region */ \
-      mpu_configure_region(base, size, \
-                           MPU_RASR_TEX_SO   | /* Ordered            */ \
-                           MPU_RASR_C        | /* Cacheable          */ \
-                           MPU_RASR_B        | /* Bufferable         */ \
-                           MPU_RASR_S        | /* Shareable          */ \
-                           MPU_RASR_AP_RWNO    /* P:RW   U:None      */ \
-                                               /* Instruction access */); \
-    } while (0)
+  /* The configure the region */ \
+  mpu_configure_region(base, size, \
+                       MPU_RASR_TEX_SO   | /* Ordered            */ \
+                       MPU_RASR_C        | /* Cacheable          */ \
+                       MPU_RASR_B        | /* Bufferable         */ \
+                       MPU_RASR_S        | /* Shareable          */ \
+                       MPU_RASR_AP_RWNO    /* P:RW   U:None      */ \
+                                           /* Instruction access */)
 
 /****************************************************************************
  * Name: mpu_peripheral
@@ -457,17 +573,14 @@ void mpu_configure_region(uintptr_t base, size_t size, uint32_t flags);
  ****************************************************************************/
 
 #define mpu_peripheral(base, size) \
-  do \
-    { \
-      /* Then configure the region */ \
-      mpu_configure_region(base, size, \
-                           MPU_RASR_TEX_DEV  | /* Device                */ \
-                                               /* Not Cacheable         */ \
-                           MPU_RASR_B        | /* Bufferable            */ \
-                           MPU_RASR_S        | /* Shareable             */ \
-                           MPU_RASR_AP_RWNO  | /* P:RW   U:None         */ \
-                           MPU_RASR_XN         /* No Instruction access */); \
-    } while (0)
+  /* Then configure the region */ \
+  mpu_configure_region(base, size, \
+                       MPU_RASR_TEX_DEV  | /* Device                */ \
+                                           /* Not Cacheable         */ \
+                       MPU_RASR_B        | /* Bufferable            */ \
+                       MPU_RASR_S        | /* Shareable             */ \
+                       MPU_RASR_AP_RWNO  | /* P:RW   U:None         */ \
+                       MPU_RASR_XN         /* No Instruction access */)
 
 /****************************************************************************
  * Name: mpu_user_peripheral
@@ -478,17 +591,14 @@ void mpu_configure_region(uintptr_t base, size_t size, uint32_t flags);
  ****************************************************************************/
 
 #define mpu_user_peripheral(base, size) \
-  do \
-    { \
-      /* Then configure the region */ \
-      mpu_configure_region(base, size, \
-                           MPU_RASR_TEX_DEV  | /* Device                */ \
-                                               /* Not Cacheable         */ \
-                           MPU_RASR_B        | /* Bufferable            */ \
-                           MPU_RASR_S        | /* Shareable             */ \
-                           MPU_RASR_AP_RWRW  | /* P:RW     U:RW         */ \
-                           MPU_RASR_XN         /* No Instruction access */); \
-    } while (0)
+  /* Then configure the region */ \
+  mpu_configure_region(base, size, \
+                       MPU_RASR_TEX_DEV  | /* Device                */ \
+                                           /* Not Cacheable         */ \
+                       MPU_RASR_B        | /* Bufferable            */ \
+                       MPU_RASR_S        | /* Shareable             */ \
+                       MPU_RASR_AP_RWRW  | /* P:RW     U:RW         */ \
+                       MPU_RASR_XN         /* No Instruction access */)
 
 #undef EXTERN
 #if defined(__cplusplus)

--- a/arch/arm/src/armv7-r/arm_mpu.c
+++ b/arch/arm/src/armv7-r/arm_mpu.c
@@ -486,19 +486,20 @@ unsigned int mpu_configure_region(uintptr_t base, size_t size,
  *
  * Input Parameters:
  *   table - MPU Initiaze table.
+ *   count - Initialize the number of entries in the region table.
  *
  * Returned Value:
  *   NULL.
  *
  ****************************************************************************/
 
-void mpu_initialize(const struct mpu_region_s *table)
+void mpu_initialize(const struct mpu_region_s *table, size_t count)
 {
   const struct mpu_region_s *conf;
-  int index;
+  size_t index;
 
   mpu_control(false);
-  for (index = 0; index < nitems(table); index++)
+  for (index = 0; index < count; index++)
     {
       conf = &table[index];
       mpu_configure_region(conf->base, conf->size, conf->flags);

--- a/arch/arm/src/armv7-r/arm_mpu.c
+++ b/arch/arm/src/armv7-r/arm_mpu.c
@@ -26,6 +26,7 @@
 
 #include <stdint.h>
 #include <assert.h>
+#include <debug.h>
 
 #include "mpu.h"
 #include "arm_internal.h"
@@ -68,9 +69,9 @@ static const uint8_t g_ls_regionmask[9] =
   0x00, 0x01, 0x03, 0x07, 0x0f, 0x1f, 0x3f, 0x7f, 0xff
 };
 
-/* The next available region number */
+/* The available region bitmap */
 
-static uint8_t g_region;
+static unsigned int g_mpu_region;
 
 /****************************************************************************
  * Private Functions
@@ -87,6 +88,13 @@ static uint8_t g_region;
  * Assumption:
  *   l2size has the same properties as the return value from
  *   mpu_log2regionceil()
+ *
+ * Input Parameters:
+ *   size: The size of the region.
+ *   l2size: The L2 size of the region.
+ *
+ * Returned Value:
+ *   The sub-region bitmask.
  *
  ****************************************************************************/
 
@@ -139,6 +147,13 @@ static inline uint32_t mpu_subregion_ms(size_t size, uint8_t l2size)
  *   l2size has the same properties as the return value from
  *   mpu_log2regionceil()
  *
+ * Input Parameters:
+ *   offset: The offset of the region.
+ *   l2size: The L2 size of the region.
+ *
+ * Returned Value:
+ *   The sub-region bitmask.
+ *
  ****************************************************************************/
 
 static inline uint32_t mpu_subregion_ls(size_t offset, uint8_t l2size)
@@ -183,6 +198,12 @@ static inline uint32_t mpu_subregion_ls(size_t offset, uint8_t l2size)
  * Description:
  *   Resets the MPU to disabled.
  *
+ * * Input Parameters:
+ *   None.
+ *
+ * Returned Value:
+ *   None.
+ *
  ****************************************************************************/
 
 #if defined(CONFIG_ARM_MPU_RESET) || defined(CONFIG_ARM_MPU_EARLY_RESET)
@@ -214,17 +235,52 @@ static void mpu_reset_internal()
  * Description:
  *   Allocate the next region
  *
- * Assumptions:
- *   - Regions are never deallocated
- *   - Regions are only allocated early in initialization, so no special
- *     protection against re-entrancy is required;
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   The index of the allocated region.
  *
  ****************************************************************************/
 
 unsigned int mpu_allocregion(void)
 {
-  DEBUGASSERT(g_region < CONFIG_ARM_MPU_NREGIONS);
-  return (unsigned int)g_region++;
+  unsigned int i = ffs(~g_mpu_region) - 1;
+
+  /* There are not enough regions to apply */
+
+  DEBUGASSERT(i < CONFIG_ARM_MPU_NREGIONS);
+  g_mpu_region |= 1 << i;
+  return i;
+}
+
+/****************************************************************************
+ * Name: mpu_freeregion
+ *
+ * Description:
+ *   Free target region.
+ *
+ * Input Parameters:
+ *  region - The index of the region to be freed.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void mpu_freeregion(unsigned int region)
+{
+  DEBUGASSERT(region < CONFIG_ARM_MPU_NREGIONS);
+
+  /* Clear and disable the given MPU Region */
+
+  mpu_set_rgnr(region);
+  mpu_set_drbar(0);
+  mpu_set_dracr(0);
+  mpu_set_drsr(0);
+  g_mpu_region &= ~(1 << region);
+  ARM_DSB();
+  ARM_ISB();
 }
 
 /****************************************************************************
@@ -235,6 +291,12 @@ unsigned int mpu_allocregion(void)
  *   following is true:
  *
  *   size <= (1 << l2size)
+ *
+ * Input Parameters:
+ *   size - The size of the region.
+ *
+ * Returned Value:
+ *   The logarithm base 2 of the ceiling value for the MPU region size.
  *
  ****************************************************************************/
 
@@ -256,6 +318,12 @@ uint8_t mpu_log2regionceil(size_t size)
  *   following is true:
  *
  *   size >= (1 << l2size)
+ *
+ * Input Parameters:
+ *   size - The size of the region.
+ *
+ * Returned Value:
+ *   The logarithm base 2 of the floor value for the MPU region size.
  *
  ****************************************************************************/
 
@@ -282,6 +350,14 @@ uint8_t mpu_log2regionfloor(size_t size)
  * Assumption:
  *   l2size has the same properties as the return value from
  *   mpu_log2regionceil()
+ *
+ * Input Parameters:
+ *   base   - The base address of the region.
+ *   size   - The size of the region.
+ *   l2size - Log2 of the actual region size is <= (1 << l2size).
+ *
+ * Returned Value:
+ *   The subregion settings as a 32-bit value.
  *
  ****************************************************************************/
 
@@ -329,11 +405,167 @@ uint32_t mpu_subregion(uintptr_t base, size_t size, uint8_t l2size)
 }
 
 /****************************************************************************
+ * Name: mpu_modify_region
+ *
+ * Description:
+ *   Modify a region for privileged, strongly ordered memory
+ *
+ * Input Parameters:
+ *   region - Region number to modify.
+ *   base   - Base address of the region.
+ *   size   - Size of the region.
+ *   flags  - Flags to configure the region.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void mpu_modify_region(unsigned int region, uintptr_t base, size_t size,
+                       uint32_t flags)
+{
+  uint32_t regval;
+  uint8_t l2size;
+  uint8_t subregions;
+
+  /* Check that the region is valid */
+
+  DEBUGASSERT(g_mpu_region & (1 << region));
+
+  /* Select the region */
+
+  mpu_set_rgnr(region);
+
+  /* Select the region base address */
+
+  mpu_set_drbar(base & MPU_RBAR_ADDR_MASK);
+
+  /* Select the region size and the sub-region map */
+
+  l2size = mpu_log2regionceil(size);
+  subregions = mpu_subregion(base, size, l2size);
+
+  /* Configure the Region */
+
+  mpu_set_dracr(flags);
+  regval = MPU_RASR_ENABLE                              | /* Enable region */
+           MPU_RASR_RSIZE_LOG2(l2size)                  | /* Region size   */
+           (subregions << MPU_RASR_SRD_SHIFT);            /* Sub-regions   */
+  mpu_set_drsr(regval);
+}
+
+/****************************************************************************
+ * Name: mpu_configure_region
+ *
+ * Description:
+ *   Configure a region.
+ *
+ * Input Parameters:
+ *   base - Base address of the region.
+ *   size - Size of the region.
+ *   flags - Flags to configure the region.
+ *
+ * Returned Value:
+ *   The region number allocated for the configured region.
+ *
+ ****************************************************************************/
+
+unsigned int mpu_configure_region(uintptr_t base, size_t size,
+                                  uint32_t flags)
+{
+  unsigned int region = mpu_allocregion();
+  mpu_modify_region(region, base, size, flags);
+  return region;
+}
+
+/****************************************************************************
+ * Name: mpu_initialize
+ *
+ * Description:
+ *   Configure a region for privileged, strongly ordered memory
+ *
+ * Input Parameters:
+ *   table - MPU Initiaze table.
+ *
+ * Returned Value:
+ *   NULL.
+ *
+ ****************************************************************************/
+
+void mpu_initialize(const struct mpu_region_s *table)
+{
+  const struct mpu_region_s *conf;
+  int index;
+
+  mpu_control(false);
+  for (index = 0; index < nitems(table); index++)
+    {
+      conf = &table[index];
+      mpu_configure_region(conf->base, conf->size, conf->flags);
+    }
+
+  mpu_control(true);
+}
+
+/****************************************************************************
+ * Name: mpu_dump_region
+ *
+ * Description:
+ *   Dump the region that has been used.
+ *
+ * Input Parameters:
+ *   None.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void mpu_dump_region(void)
+{
+  int i;
+  int count = 0;
+  uint32_t dracr;
+  uint32_t drbar;
+  uint32_t drsr;
+  uint32_t sctrl;
+
+  /* Get free region */
+
+  sctrl = cp15_rdsctlr();
+  _info("MPU-SCTRL Enable:%" PRIu32 "\n", sctrl & SCTLR_M);
+  for (i = 0; i < CONFIG_ARM_MPU_NREGIONS; i++)
+    {
+      mpu_set_rgnr(i);
+      drbar = mpu_get_drbar();
+      dracr = mpu_get_dracr();
+      drsr = mpu_get_drsr();
+      _info("MPU-%d, base=0%08X l2size=%"PRIu32" bufferable=%u"
+            "cacheable=%u shareable=%u\n", i, drbar & MPU_RBAR_ADDR_MASK,
+            drsr & MPU_RASR_RSIZE_MASK, dracr & MPU_RACR_B,
+            dracr & MPU_RACR_C, dracr & MPU_RACR_S);
+      if (drsr & MPU_RASR_ENABLE)
+        {
+          count++;
+        }
+    }
+
+  _info("Total Use Region:%d, Remaining Available:%d\n", count,
+        CONFIG_ARM_MPU_NREGIONS - count);
+}
+
+/****************************************************************************
  * Name: mpu_reset
  *
  * Description:
  *   Conditional public interface that resets the MPU to disabled during
  *   MPU initialization.
+ *
+ * Input Parameters:
+ *   None.
+ *
+ * Returned Value:
+ *   None.
  *
  ****************************************************************************/
 #if defined(CONFIG_ARM_MPU_RESET)
@@ -349,6 +581,12 @@ void mpu_reset()
  * Description:
  *   Conditional public interface that resets the MPU to disabled immediately
  *   after reset.
+ *
+ * Input Parameters:
+ *   None.
+ *
+ * Returned Value:
+ *   None.
  *
  ****************************************************************************/
 #if defined(CONFIG_ARM_MPU_EARLY_RESET)

--- a/arch/arm/src/armv7-r/mpu.h
+++ b/arch/arm/src/armv7-r/mpu.h
@@ -318,13 +318,14 @@ unsigned int mpu_configure_region(uintptr_t base, size_t size,
  *
  * Input Parameters:
  *   table - MPU Initiaze table.
+ *   count - Initialize the number of entries in the region table.
  *
  * Returned Value:
  *   NULL.
  *
  ****************************************************************************/
 
-void mpu_initialize(const struct mpu_region_s *table);
+void mpu_initialize(const struct mpu_region_s *table, size_t count);
 
 /****************************************************************************
  * Inline Functions

--- a/arch/arm/src/armv8-m/arm_mpu.c
+++ b/arch/arm/src/armv8-m/arm_mpu.c
@@ -350,10 +350,10 @@ void mpu_dump_region(void)
       putreg32(i, MPU_RNR);
       rlar = getreg32(MPU_RLAR);
       rbar = getreg32(MPU_RBAR);
-      _info("MPU-%d, 0x%08X-0x%08X SH=%X AP=%X XN=%u\n",
-            i, rbar & MPU_RBAR_BASE_MASK, rlar & MPU_RLAR_LIMIT_MASK,
-            rbar & MPU_RBAR_SH_MASK, rbar & MPU_RBAR_AP_MASK,
-            rbar & MPU_RBAR_XN);
+      _info("MPU-%d, 0x%08"PRIx32"-0x%08"PRIx32" SH=%"PRIx32" AP=%"PRIx32""
+            "XN=%"PRIu32"\n", i, rbar & MPU_RBAR_BASE_MASK,
+            rlar & MPU_RLAR_LIMIT_MASK, rbar & MPU_RBAR_SH_MASK,
+            rbar & MPU_RBAR_AP_MASK, rbar & MPU_RBAR_XN);
       if (rlar & MPU_RLAR_ENABLE)
         {
           count++;

--- a/arch/arm/src/armv8-m/arm_mpu.c
+++ b/arch/arm/src/armv8-m/arm_mpu.c
@@ -289,6 +289,7 @@ unsigned int mpu_configure_region(uintptr_t base, size_t size,
  *
  * Input Parameters:
  *   table      - MPU initialization table.
+ *   count      - Initialize the number of entries in the region table.
  *   hfnmiena   - A boolean indicating whether the MPU should enable the
  *                HFNMIENA bit.
  *   privdefena - A boolean indicating whether the MPU should enable the
@@ -299,14 +300,14 @@ unsigned int mpu_configure_region(uintptr_t base, size_t size,
  *
  ****************************************************************************/
 
-void mpu_initialize(const struct mpu_region_s *table, bool hfnmiena,
-                    bool privdefena)
+void mpu_initialize(const struct mpu_region_s *table, size_t count,
+                    bool hfnmiena, bool privdefena)
 {
   const struct mpu_region_s *conf;
-  int index;
+  size_t index;
 
   mpu_control(false, false, false);
-  for (index = 0; index < nitems(table); index++)
+  for (index = 0; index < count; index++)
     {
       conf = &table[index];
       mpu_configure_region(conf->base, conf->size, conf->flags1,

--- a/arch/arm/src/armv8-m/arm_mpu.c
+++ b/arch/arm/src/armv8-m/arm_mpu.c
@@ -26,6 +26,8 @@
 
 #include <stdint.h>
 #include <assert.h>
+#include <debug.h>
+#include <sys/param.h>
 
 #include "mpu.h"
 #include "arm_internal.h"
@@ -45,38 +47,25 @@
  * Private Data
  ****************************************************************************/
 
-/* The next available region number */
+/* The available region bitmap */
 
-static uint8_t g_region;
+static unsigned int g_mpu_region;
 
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
 
 /****************************************************************************
- * Name: mpu_allocregion
- *
- * Description:
- *   Allocate the next region
- *
- * Assumptions:
- *   - Regions are never deallocated
- *   - Regions are only allocated early in initialization, so no special
- *     protection against re-entrancy is required;
- *
- ****************************************************************************/
-
-unsigned int mpu_allocregion(void)
-{
-  DEBUGASSERT(g_region < CONFIG_ARM_MPU_NREGIONS);
-  return (unsigned int)g_region++;
-}
-
-/****************************************************************************
  * Name: mpu_reset_internal
  *
  * Description:
  *   Resets the MPU to disabled.
+ *
+ * Input Parameters:
+ *   None.
+ *
+ * Returned Value:
+ *   None.
  *
  ****************************************************************************/
 
@@ -91,7 +80,7 @@ static void mpu_reset_internal()
   for (region = 0; region < regions; region++)
     {
       putreg32(region, MPU_RNR);
-      putreg32(0, MPU_RASR);
+      putreg32(0, MPU_RLAR);
       putreg32(0, MPU_RBAR);
     }
 
@@ -107,10 +96,73 @@ static void mpu_reset_internal()
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: mpu_allocregion
+ *
+ * Description:
+ *   Allocate the next region
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   The index of the allocated region.
+ *
+ ****************************************************************************/
+
+unsigned int mpu_allocregion(void)
+{
+  unsigned int i = ffs(~g_mpu_region) - 1;
+
+  /* There are not enough regions to apply */
+
+  DEBUGASSERT(i < CONFIG_ARM_MPU_NREGIONS);
+  g_mpu_region |= 1 << i;
+  return i;
+}
+
+/****************************************************************************
+ * Name: mpu_freeregion
+ *
+ * Description:
+ *   Free target region.
+ *
+ * Input Parameters:
+ *  region - The index of the region to be freed.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void mpu_freeregion(unsigned int region)
+{
+  DEBUGASSERT(region < CONFIG_ARM_MPU_NREGIONS);
+
+  /* Clear and disable the given MPU Region */
+
+  putreg32(region, MPU_RNR);
+  putreg32(0, MPU_RLAR);
+  putreg32(0, MPU_RBAR);
+  g_mpu_region &= ~(1 << region);
+  ARM_DSB();
+  ARM_ISB();
+}
+
+/****************************************************************************
  * Name: mpu_control
  *
  * Description:
  *   Configure and enable (or disable) the MPU
+ *
+ * Input Parameters:
+ *   enable     - Flag indicating whether to enable the MPU.
+ *   hfnmiena   - Flag indicating whether to enable the MPU during hard
+ *                fult, NMI, and FAULTMAS.
+ *   privdefena - Flag indicating whether to enable privileged access to
+ *                the default memory map.
+ *
+ * Returned Value:
+ *   None.
  *
  ****************************************************************************/
 
@@ -151,18 +203,32 @@ void mpu_control(bool enable, bool hfnmiena, bool privdefena)
 }
 
 /****************************************************************************
- * Name: mpu_configure_region
+ * Name: mpu_modify_region
  *
  * Description:
- *   Configure a region for privileged, strongly ordered memory
+ *   Modify a region for privileged, strongly ordered memory
+ *
+ * Input Parameters:
+ *   region - The index of the MPU region to modify.
+ *   base   - The base address of the region.
+ *   size   - The size of the region.
+ *   flags1 - Additional flags for the region.
+ *   flags2 - Additional flags for the region.
+ *
+ * Returned Value:
+ *   None.
  *
  ****************************************************************************/
 
-void mpu_configure_region(uintptr_t base, size_t size,
-                          uint32_t flags1, uint32_t flags2)
+void mpu_modify_region(unsigned int region, uintptr_t base, size_t size,
+                       uint32_t flags1, uint32_t flags2)
 {
-  unsigned int region = mpu_allocregion();
-  uintptr_t    limit;
+  uintptr_t limit;
+  uintptr_t rbase;
+
+  /* Check that the region is valid */
+
+  DEBUGASSERT(g_mpu_region & (1 << region));
 
   /* Ensure the base address alignment
    *
@@ -173,7 +239,7 @@ void mpu_configure_region(uintptr_t base, size_t size,
    */
 
   limit = (base + size - 1) & MPU_RLAR_LIMIT_MASK;
-  base &= MPU_RBAR_BASE_MASK;
+  rbase = base & MPU_RBAR_BASE_MASK;
 
   /* Select the region */
 
@@ -181,7 +247,7 @@ void mpu_configure_region(uintptr_t base, size_t size,
 
   /* Set the region base, limit and attribute */
 
-  putreg32(base | flags1, MPU_RBAR);
+  putreg32(rbase | flags1, MPU_RBAR);
   putreg32(limit | flags2 | MPU_RLAR_ENABLE, MPU_RLAR);
 
   /* Ensure MPU setting take effects */
@@ -191,11 +257,124 @@ void mpu_configure_region(uintptr_t base, size_t size,
 }
 
 /****************************************************************************
+ * Name: mpu_configure_region
+ *
+ * Description:
+ *   Configure a region for privileged, strongly ordered memory
+ *
+ * Input Parameters:
+ *   base   - The base address of the region.
+ *   size   - The size of the region.
+ *   flags1 - Additional flags for the region.
+ *   flags2 - Additional flags for the region.
+ *
+ * Returned Value:
+ *   The region number allocated for the configured region.
+ *
+ ****************************************************************************/
+
+unsigned int mpu_configure_region(uintptr_t base, size_t size,
+                                  uint32_t flags1, uint32_t flags2)
+{
+  unsigned int region = mpu_allocregion();
+  mpu_modify_region(region, base, size, flags1, flags2);
+  return region;
+}
+
+/****************************************************************************
+ * Name: mpu_initialize
+ *
+ * Description:
+ *   Configure a region for privileged, strongly ordered memory
+ *
+ * Input Parameters:
+ *   table      - MPU initialization table.
+ *   hfnmiena   - A boolean indicating whether the MPU should enable the
+ *                HFNMIENA bit.
+ *   privdefena - A boolean indicating whether the MPU should enable the
+ *                PRIVDEFENA bit.
+ *
+ * Returned Value:
+ *   NULL.
+ *
+ ****************************************************************************/
+
+void mpu_initialize(const struct mpu_region_s *table, bool hfnmiena,
+                    bool privdefena)
+{
+  const struct mpu_region_s *conf;
+  int index;
+
+  mpu_control(false, false, false);
+  for (index = 0; index < nitems(table); index++)
+    {
+      conf = &table[index];
+      mpu_configure_region(conf->base, conf->size, conf->flags1,
+                           conf->flags2);
+    }
+
+  mpu_control(true, hfnmiena, privdefena);
+}
+
+/****************************************************************************
+ * Name: mpu_dump_region
+ *
+ * Description:
+ *   Dump the region that has been used.
+ *
+ * Input Parameters:
+ *   None.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void mpu_dump_region(void)
+{
+  int i;
+  int count = 0;
+  uint32_t rlar;
+  uint32_t rbar;
+  uint32_t ctrl;
+
+  /* Get free region */
+
+  ctrl = getreg32(MPU_CTRL);
+  _info("MPU-CTRL Enable:%" PRIu32 ", HFNMIENA:%"PRIu32","
+        "PRIVDEFENA:%" PRIu32 "\n", ctrl & MPU_CTRL_ENABLE,
+        ctrl & MPU_CTRL_HFNMIENA, ctrl & MPU_CTRL_PRIVDEFENA);
+  for (i = 0; i < CONFIG_ARM_MPU_NREGIONS; i++)
+    {
+      putreg32(i, MPU_RNR);
+      rlar = getreg32(MPU_RLAR);
+      rbar = getreg32(MPU_RBAR);
+      _info("MPU-%d, 0x%08X-0x%08X SH=%X AP=%X XN=%u\n",
+            i, rbar & MPU_RBAR_BASE_MASK, rlar & MPU_RLAR_LIMIT_MASK,
+            rbar & MPU_RBAR_SH_MASK, rbar & MPU_RBAR_AP_MASK,
+            rbar & MPU_RBAR_XN);
+      if (rlar & MPU_RLAR_ENABLE)
+        {
+          count++;
+        }
+    }
+
+  _info("Total Use Region:%d, Remaining Available:%d\n", count,
+        CONFIG_ARM_MPU_NREGIONS - count);
+}
+
+/****************************************************************************
  * Name: mpu_reset
  *
  * Description:
  *   Conditional public interface that resets the MPU to disabled during
  *   MPU initialization.
+ *
+ * Input Parameters:
+ *   None.
+ *
+ * Returned Value:
+ *   None.
  *
  ****************************************************************************/
 #if defined(CONFIG_ARM_MPU_RESET)
@@ -211,6 +390,12 @@ void mpu_reset()
  * Description:
  *   Conditional public interface that resets the MPU to disabled immediately
  *   after reset.
+ *
+ * Input Parameters:
+ *   None.
+ *
+ * Returned Value:
+ *   None.
  *
  ****************************************************************************/
 #if defined(CONFIG_ARM_MPU_EARLY_RESET)

--- a/arch/arm/src/armv8-m/mpu.h
+++ b/arch/arm/src/armv8-m/mpu.h
@@ -168,6 +168,21 @@
                                  MPU_MAIR_OUTER_RA | MPU_MAIR_OUTER_WA | \
                                  MPU_MAIR_INNER_NT | MPU_MAIR_INNER_WB | \
                                  MPU_MAIR_INNER_RA | MPU_MAIR_INNER_WA)
+struct mpu_region_s
+{
+  /* Region Base Address */
+
+  uintptr_t base;
+
+  /* Region Size */
+
+  size_t size;
+
+  /* Region Attributes */
+
+  uint32_t flags1;
+  uint32_t flags2;
+};
 
 /****************************************************************************
  * Name: mpu_reset
@@ -216,14 +231,93 @@ extern "C"
 #endif
 
 /****************************************************************************
+ * Name: mpu_allocregion
+ *
+ * Description:
+ *   Allocate the next region
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   The index of the allocated region.
+ *
+ ****************************************************************************/
+
+unsigned int mpu_allocregion(void);
+
+/****************************************************************************
+ * Name: mpu_freeregion
+ *
+ * Description:
+ *   Free target region.
+ *
+ * Input Parameters:
+ *  region - The index of the region to be freed.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void mpu_freeregion(unsigned int region);
+
+/****************************************************************************
  * Name: mpu_control
  *
  * Description:
  *   Configure and enable (or disable) the MPU
  *
+ * Input Parameters:
+ *   enable     - Flag indicating whether to enable the MPU.
+ *   hfnmiena   - Flag indicating whether to enable the MPU during hard
+ *                fult, NMI, and FAULTMAS.
+ *   privdefena - Flag indicating whether to enable privileged access to
+ *                the default memory map.
+ *
+ * Returned Value:
+ *   None.
+ *
  ****************************************************************************/
 
 void mpu_control(bool enable, bool hfnmiena, bool privdefena);
+
+/****************************************************************************
+ * Name: mpu_dump_region
+ *
+ * Description:
+ *   Dump the region that has been used.
+ *
+ * Input Parameters:
+ *   None.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void mpu_dump_region(void);
+
+/****************************************************************************
+ * Name: mpu_modify_region
+ *
+ * Description:
+ *   Modify a region for privileged, strongly ordered memory
+ *
+ * Input Parameters:
+ *   region - The index of the MPU region to modify.
+ *   base   - The base address of the region.
+ *   size   - The size of the region.
+ *   flags1 - Additional flags for the region.
+ *   flags2 - Additional flags for the region.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void mpu_modify_region(unsigned int region, uintptr_t base, size_t size,
+                       uint32_t flags1, uint32_t flags2);
 
 /****************************************************************************
  * Name: mpu_configure_region
@@ -231,10 +325,40 @@ void mpu_control(bool enable, bool hfnmiena, bool privdefena);
  * Description:
  *   Configure a region for privileged, strongly ordered memory
  *
+ * Input Parameters:
+ *   base   - The base address of the region.
+ *   size   - The size of the region.
+ *   flags1 - Additional flags for the region.
+ *   flags2 - Additional flags for the region.
+ *
+ * Returned Value:
+ *   The region number allocated for the configured region.
+ *
  ****************************************************************************/
 
-void mpu_configure_region(uintptr_t base, size_t size,
-                          uint32_t flags1, uint32_t flags2);
+unsigned int mpu_configure_region(uintptr_t base, size_t size,
+                                  uint32_t flags1, uint32_t flags2);
+
+/****************************************************************************
+ * Name: mpu_initialize
+ *
+ * Description:
+ *   Configure a region for privileged, strongly ordered memory
+ *
+ * Input Parameters:
+ *   table      - MPU initialization table.
+ *   hfnmiena   - A boolean indicating whether the MPU should enable the
+ *                HFNMIENA bit.
+ *   privdefena - A boolean indicating whether the MPU should enable the
+ *                PRIVDEFENA bit.
+ *
+ * Returned Value:
+ *   NULL.
+ *
+ ****************************************************************************/
+
+void mpu_initialize(const struct mpu_region_s *table, bool hfnmiena,
+                    bool privdefena);
 
 /****************************************************************************
  * Inline Functions
@@ -271,14 +395,11 @@ void mpu_configure_region(uintptr_t base, size_t size,
  ****************************************************************************/
 
 #define mpu_priv_stronglyordered(base, size) \
-  do \
-    { \
-      /* The configure the region */ \
-      mpu_configure_region(base, size, \
-                           MPU_RBAR_AP_RWNO, \
-                           MPU_RLAR_STRONGLY_ORDER | \
-                           MPU_RLAR_PXN); \
-    } while (0)
+  /* The configure the region */ \
+  mpu_configure_region(base, size, \
+                       MPU_RBAR_AP_RWNO, \
+                       MPU_RLAR_STRONGLY_ORDER | \
+                       MPU_RLAR_PXN)
 
 /****************************************************************************
  * Name: mpu_user_flash
@@ -289,13 +410,10 @@ void mpu_configure_region(uintptr_t base, size_t size,
  ****************************************************************************/
 
 #define mpu_user_flash(base, size) \
-  do \
-    { \
-      /* The configure the region */ \
-      mpu_configure_region(base, size, \
-                           MPU_RBAR_AP_RORO, \
-                           MPU_RLAR_WRITE_BACK); \
-    } while (0)
+  /* The configure the region */ \
+  mpu_configure_region(base, size, \
+                       MPU_RBAR_AP_RORO, \
+                       MPU_RLAR_WRITE_BACK)
 
 /****************************************************************************
  * Name: mpu_priv_flash
@@ -306,13 +424,10 @@ void mpu_configure_region(uintptr_t base, size_t size,
  ****************************************************************************/
 
 #define mpu_priv_flash(base, size) \
-  do \
-    { \
-      /* The configure the region */ \
-      mpu_configure_region(base, size, \
-                           MPU_RBAR_AP_RONO, \
-                           MPU_RLAR_WRITE_BACK); \
-    } while (0)
+  /* The configure the region */ \
+  mpu_configure_region(base, size, \
+                       MPU_RBAR_AP_RONO, \
+                       MPU_RLAR_WRITE_BACK)
 
 /****************************************************************************
  * Name: mpu_user_intsram
@@ -323,15 +438,12 @@ void mpu_configure_region(uintptr_t base, size_t size,
  ****************************************************************************/
 
 #define mpu_user_intsram(base, size) \
-  do \
-    { \
-      /* The configure the region */ \
-      mpu_configure_region(base, size, \
-                           MPU_RBAR_XN | \
-                           MPU_RBAR_AP_RWRW, \
-                           MPU_RLAR_NONCACHEABLE | \
-                           MPU_RLAR_PXN); \
-    } while (0)
+  /* The configure the region */ \
+  mpu_configure_region(base, size, \
+                       MPU_RBAR_XN | \
+                       MPU_RBAR_AP_RWRW, \
+                       MPU_RLAR_NONCACHEABLE | \
+                       MPU_RLAR_PXN)
 
 /****************************************************************************
  * Name: mpu_priv_intsram
@@ -342,14 +454,11 @@ void mpu_configure_region(uintptr_t base, size_t size,
  ****************************************************************************/
 
 #define mpu_priv_intsram(base, size) \
-  do \
-    { \
-      /* The configure the region */ \
-      mpu_configure_region(base, size, \
-                           MPU_RBAR_AP_RWNO, \
-                           MPU_RLAR_NONCACHEABLE | \
-                           MPU_RLAR_PXN); \
-    } while (0)
+  /* The configure the region */ \
+  mpu_configure_region(base, size, \
+                       MPU_RBAR_AP_RWNO, \
+                       MPU_RLAR_NONCACHEABLE | \
+                       MPU_RLAR_PXN)
 
 /****************************************************************************
  * Name: mpu_priv_shmem
@@ -359,16 +468,13 @@ void mpu_configure_region(uintptr_t base, size_t size,
  *
  ****************************************************************************/
 
-#define mpu_priv_shmem(base, size)                  \
-  do                                                \
-    {                                               \
-      /* The configure the region */                \
-      mpu_configure_region(base, size,              \
-                           MPU_RBAR_AP_RWNO,        \
-                           MPU_RLAR_NONCACHEABLE |  \
-                           MPU_RBAR_SH_INNER |      \
-                           MPU_RLAR_PXN);           \
-    } while (0)
+#define mpu_priv_shmem(base, size) \
+  /* The configure the region */ \
+  mpu_configure_region(base, size, \
+                       MPU_RBAR_AP_RWNO, \
+                       MPU_RLAR_NONCACHEABLE | \
+                       MPU_RBAR_SH_INNER | \
+                       MPU_RLAR_PXN)
 
 /****************************************************************************
  * Name: mpu_user_extsram
@@ -379,16 +485,13 @@ void mpu_configure_region(uintptr_t base, size_t size,
  ****************************************************************************/
 
 #define mpu_user_extsram(base, size) \
-  do \
-    { \
-      /* The configure the region */ \
-      mpu_configure_region(base, size, \
-                           MPU_RBAR_XN | \
-                           MPU_RBAR_AP_RWRW | \
-                           MPU_RBAR_SH_OUTER, \
-                           MPU_RLAR_WRITE_BACK | \
-                           MPU_RLAR_PXN); \
-    } while (0)
+  /* The configure the region */ \
+  mpu_configure_region(base, size, \
+                       MPU_RBAR_XN | \
+                       MPU_RBAR_AP_RWRW | \
+                       MPU_RBAR_SH_OUTER, \
+                       MPU_RLAR_WRITE_BACK | \
+                       MPU_RLAR_PXN)
 
 /****************************************************************************
  * Name: mpu_priv_extsram
@@ -399,15 +502,12 @@ void mpu_configure_region(uintptr_t base, size_t size,
  ****************************************************************************/
 
 #define mpu_priv_extsram(base, size) \
-  do \
-    { \
-      /* The configure the region */ \
-      mpu_configure_region(base, size, \
-                           MPU_RBAR_AP_RWNO | \
-                           MPU_RBAR_SH_OUTER, \
-                           MPU_RLAR_WRITE_BACK | \
-                           MPU_RLAR_PXN); \
-    } while (0)
+  /* The configure the region */ \
+  mpu_configure_region(base, size, \
+                       MPU_RBAR_AP_RWNO | \
+                       MPU_RBAR_SH_OUTER, \
+                       MPU_RLAR_WRITE_BACK | \
+                       MPU_RLAR_PXN)
 
 /****************************************************************************
  * Name: mpu_peripheral
@@ -418,14 +518,11 @@ void mpu_configure_region(uintptr_t base, size_t size,
  ****************************************************************************/
 
 #define mpu_peripheral(base, size) \
-  do \
-    { \
-      /* Then configure the region */ \
-      mpu_configure_region(base, size, \
-                           MPU_RBAR_AP_RWNO, \
-                           MPU_RLAR_DEVICE | \
-                           MPU_RLAR_PXN); \
-    } while (0)
+  /* Then configure the region */ \
+  mpu_configure_region(base, size, \
+                       MPU_RBAR_AP_RWNO, \
+                       MPU_RLAR_DEVICE | \
+                       MPU_RLAR_PXN)
 
 /****************************************************************************
  * Name: mpu_user_peripheral
@@ -436,15 +533,12 @@ void mpu_configure_region(uintptr_t base, size_t size,
  ****************************************************************************/
 
 #define mpu_user_peripheral(base, size) \
-  do \
-    { \
-      /* Then configure the region */ \
-      mpu_configure_region(base, size, \
-                           MPU_RBAR_XN | \
-                           MPU_RBAR_AP_RWRW, \
-                           MPU_RLAR_DEVICE | \
-                           MPU_RLAR_PXN); \
-    } while (0)
+  /* Then configure the region */ \
+  mpu_configure_region(base, size, \
+                       MPU_RBAR_XN | \
+                       MPU_RBAR_AP_RWRW, \
+                       MPU_RLAR_DEVICE | \
+                       MPU_RLAR_PXN)
 
 #undef EXTERN
 #if defined(__cplusplus)

--- a/arch/arm/src/armv8-m/mpu.h
+++ b/arch/arm/src/armv8-m/mpu.h
@@ -347,6 +347,7 @@ unsigned int mpu_configure_region(uintptr_t base, size_t size,
  *
  * Input Parameters:
  *   table      - MPU initialization table.
+ *   count      - Initialize the number of entries in the region table.
  *   hfnmiena   - A boolean indicating whether the MPU should enable the
  *                HFNMIENA bit.
  *   privdefena - A boolean indicating whether the MPU should enable the
@@ -357,8 +358,8 @@ unsigned int mpu_configure_region(uintptr_t base, size_t size,
  *
  ****************************************************************************/
 
-void mpu_initialize(const struct mpu_region_s *table, bool hfnmiena,
-                    bool privdefena);
+void mpu_initialize(const struct mpu_region_s *table, size_t count,
+                    bool hfnmiena, bool privdefena);
 
 /****************************************************************************
  * Inline Functions

--- a/arch/arm64/src/common/arm64_mpu.h
+++ b/arch/arm64/src/common/arm64_mpu.h
@@ -304,6 +304,131 @@ extern const struct arm64_mpu_config g_mpu_config;
  * Public Function Prototypes
  ****************************************************************************/
 
+/****************************************************************************
+ * Name: mpu_allocregion
+ *
+ * Description:
+ *   Allocate the next region
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   The index of the allocated region.
+ *
+ ****************************************************************************/
+
+unsigned int mpu_allocregion(void);
+
+/****************************************************************************
+ * Name: mpu_freeregion
+ *
+ * Description:
+ *   Free target region.
+ *
+ * Input Parameters:
+ *  region - The index of the region to be freed.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void mpu_freeregion(unsigned int region);
+
+/****************************************************************************
+ * Name: arm64_mpu_enable
+ *
+ * Description:
+ *   Enable the MPU
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Return Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void arm64_mpu_enable(void);
+
+/****************************************************************************
+ * Name: arm64_mpu_disable
+ *
+ * Description:
+ *   Disable the MPU
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Return Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void arm64_mpu_disable(void);
+
+/****************************************************************************
+ * Name: mpu_dump_region
+ *
+ * Description:
+ *   Dump the region that has been used.
+ *
+ * Input Parameters:
+ *   None.
+ *
+ * Returned Value:
+ *   None.
+ ****************************************************************************/
+
+void mpu_dump_region(void);
+
+/****************************************************************************
+ * Name: mpu_modify_region
+ *
+ * Description:
+ *   Modify a region for privileged, strongly ordered memory
+ *
+ * Input Parameters:
+ *   region - The index of the MPU region to modify.
+ *   table  - Pointer to a struct containing the configuration
+ *            parameters for the region.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void mpu_modify_region(unsigned int region,
+                       const struct arm64_mpu_region *table);
+
+/****************************************************************************
+ * Name: mpu_configure_region
+ *
+ * Description:
+ *   Configure a region for privileged, strongly ordered memory
+ *
+ * Input Parameters:
+ *   table - Pointer to a struct containing the configuration
+ *           parameters for the region.
+ *
+ * Returned Value:
+ *   The region number allocated for the configured region.
+ *
+ ****************************************************************************/
+
+unsigned int mpu_configure_region(const struct arm64_mpu_region *
+                                  table);
+
+/****************************************************************************
+ * Name: arm64_mpu_init
+ *
+ * Description:
+ *   This function here provides the default configuration mechanism
+ *   for the Memory Protection Unit (MPU).
+ *
+ ****************************************************************************/
+
 void arm64_mpu_init(bool is_primary_core);
 
 #endif  /* __ASSEMBLY__ */

--- a/arch/xtensa/src/common/mpu.h
+++ b/arch/xtensa/src/common/mpu.h
@@ -50,6 +50,14 @@
         (((ENCODE_MEMORY_TYPE(memtype)) << (12)) | \
         (((access) & (0xf)) << (8)))
 
+struct mpu_region_s
+{
+  uintptr_t base;    /* Region Base Address */
+  size_t    size;    /* Unused */
+  uint32_t  acc;     /* Access permissions */
+  uint32_t  memtype; /* memory type */
+};
+
 /****************************************************************************
  *  MPU access rights constants
  ****************************************************************************/
@@ -185,7 +193,18 @@ extern "C"
  * Name: mpu_allocregion
  *
  * Description:
- *  Allocate the next region
+ *   Allocate the next region
+ *
+ * Assumptions:
+ *   - Regions are never deallocated
+ *   - Regions are only allocated early in initialization, so no special
+ *     protection against re-entrancy is required;
+ *
+ * Input Parameters:
+ *   None.
+ *
+ * Returned Value:
+ *   The index of the allocated region.
  *
  ****************************************************************************/
 
@@ -197,20 +216,91 @@ unsigned int mpu_allocregion(void);
  * Description:
  *   Configure and enable (or disable) the MPU
  *
+ * Input Parameters:
+ *   enable - Flag indicating whether to enable the MPU.
+ *
+ * Returned Value:
+ *   None.
+ *
  ****************************************************************************/
 
 void mpu_control(bool enable);
 
 /****************************************************************************
+ * Name: mpu_modify_region
+ *
+ * Description:
+ *   Modify a region for privileged, strongly ordered memory
+ *
+ * Input Parameters:
+ *   region  - Region number to modify.
+ *   base    - Base address of the region.
+ *   size    - Unused.
+ *   acc     - A uint32_t value representing the access permissions of
+ *             the region.
+ *   memtype - A uint32_t value representing the memory type of the region.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void mpu_modify_region(unsigned int region, uintptr_t base, size_t size,
+                       uint32_t acc, uint32_t memtype);
+
+/****************************************************************************
  * Name: mpu_configure_region
+ *
+ * Description:
+ *   Configure a region
+ *
+ * Input Parameters:
+ *   base    - Base address of the region.
+ *   size    - Unused.
+ *   acc     - A uint32_t value representing the access permissions of
+ *             the region.
+ *   memtype - A uint32_t value representing the memory type of the region.
+ *
+ * Returned Value:
+ *   The region number allocated for the configured region.
+ *
+ ****************************************************************************/
+
+unsigned int mpu_configure_region(uintptr_t base, size_t size,
+                                  uint32_t acc, uint32_t memtype);
+
+/****************************************************************************
+ * Name: mpu_initialize
  *
  * Description:
  *   Configure a region for privileged, strongly ordered memory
  *
+ * Input Parameters:
+ *   table - MPU initialization table.
+ *   count - Initialize the number of entries in the region table.
+ *
+ * Returned Value:
+ *   NULL.
+ *
  ****************************************************************************/
 
-void mpu_configure_region(uintptr_t base, size_t size,
-                          uint32_t acc, uint32_t memtype);
+void mpu_initialize(const struct mpu_region_s *table, size_t count);
+
+/****************************************************************************
+ * Name: mpu_dump_region
+ *
+ * Description:
+ *   Dump the region that has been used.
+ *
+ * Input Parameters:
+ *   None.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void mpu_dump_region(void);
 
 /****************************************************************************
  * Name: mpu_priv_stronglyordered
@@ -221,13 +311,10 @@ void mpu_configure_region(uintptr_t base, size_t size,
  ****************************************************************************/
 
 #define mpu_priv_stronglyordered(base, size) \
-  do \
-    { \
-      /* The configure the region */ \
-      mpu_configure_region(base, size, \
-                          MPU_AR_RWX, \
-                          MPU_MEM_DEVICE); \
-    } while (0)
+  /* The configure the region */ \
+  mpu_configure_region(base, size, \
+                       MPU_AR_RWX, \
+                       MPU_MEM_DEVICE)
 
 /****************************************************************************
  * Name: mpu_user_flash
@@ -238,13 +325,10 @@ void mpu_configure_region(uintptr_t base, size_t size,
  ****************************************************************************/
 
 #define mpu_user_flash(base, size) \
-  do \
-    { \
-      /* The configure the region */ \
-      mpu_configure_region(base, size, \
-                          MPU_AR_RXrx, \
-                          MPU_MEM_WRITEBACK);\
-    } while (0)
+  /* The configure the region */ \
+  mpu_configure_region(base, size, \
+                       MPU_AR_RXrx, \
+                       MPU_MEM_WRITEBACK)
 
 /****************************************************************************
  * Name: mpu_priv_flash
@@ -255,13 +339,10 @@ void mpu_configure_region(uintptr_t base, size_t size,
  ****************************************************************************/
 
 #define mpu_priv_flash(base, size) \
-  do \
-    { \
-      /* The configure the region */   \
-      mpu_configure_region(base, size, \
-                          MPU_AR_RX, \
-                          MPU_MEM_WRITEBACK);\
-    } while (0)
+  /* The configure the region */   \
+  mpu_configure_region(base, size, \
+                       MPU_AR_RX, \
+                       MPU_MEM_WRITEBACK)
 
 /****************************************************************************
  * Name: mpu_user_intsram
@@ -272,13 +353,10 @@ void mpu_configure_region(uintptr_t base, size_t size,
  ****************************************************************************/
 
 #define mpu_user_intsram(base, size) \
-  do \
-    { \
-      /* The configure the region */ \
-      mpu_configure_region(base, size, \
-                          MPU_AR_RWXrwx, \
-                          MPU_MEM_WRITEBACK);\
-    } while (0)
+  /* The configure the region */ \
+  mpu_configure_region(base, size, \
+                       MPU_AR_RWXrwx, \
+                       MPU_MEM_WRITEBACK)
 
 /****************************************************************************
  * Name: mpu_priv_intsram
@@ -289,13 +367,10 @@ void mpu_configure_region(uintptr_t base, size_t size,
  ****************************************************************************/
 
 #define mpu_priv_intsram(base, size) \
-  do \
-    { \
-      /* The configure the region */ \
-      mpu_configure_region(base, size,\
-                          MPU_AR_RWX, \
-                          MPU_MEM_WRITEBACK);\
-    } while (0)
+  /* The configure the region */ \
+  mpu_configure_region(base, size,\
+                       MPU_AR_RWX, \
+                       MPU_MEM_WRITEBACK)
 
 /****************************************************************************
  * Name: mpu_user_extsram
@@ -306,13 +381,10 @@ void mpu_configure_region(uintptr_t base, size_t size,
  ****************************************************************************/
 
 #define mpu_user_extsram(base, size) \
-  do \
-    { \
-      /* The configure the region */ \
-      mpu_configure_region(base, size, \
-                          MPU_AR_RWXrwx, \
-                          MPU_MEM_WRITEBACK);\
-    } while (0)
+  /* The configure the region */ \
+  mpu_configure_region(base, size, \
+                       MPU_AR_RWXrwx, \
+                       MPU_MEM_WRITEBACK)
 
 /****************************************************************************
  * Name: mpu_priv_extsram
@@ -323,13 +395,10 @@ void mpu_configure_region(uintptr_t base, size_t size,
  ****************************************************************************/
 
 #define mpu_priv_extsram(base, size) \
-  do \
-    { \
-      /* The configure the region */ \
-      mpu_configure_region(base, size,  \
-                          MPU_AR_RWX, \
-                          MPU_MEM_WRITEBACK);\
-    } while (0)
+  /* The configure the region */ \
+  mpu_configure_region(base, size,  \
+                       MPU_AR_RWX, \
+                       MPU_MEM_WRITEBACK)
 
 /****************************************************************************
  * Name: mpu_peripheral
@@ -340,13 +409,10 @@ void mpu_configure_region(uintptr_t base, size_t size,
  ****************************************************************************/
 
 #define mpu_peripheral(base, size) \
-  do \
-    { \
-      /* Then configure the region */  \
-      mpu_configure_region(base, size, \
-                          MPU_AR_RW, \
-                          MPU_MEM_DEVICE);\
-    } while (0)
+  /* Then configure the region */  \
+  mpu_configure_region(base, size, \
+                       MPU_AR_RW, \
+                       MPU_MEM_DEVICE)
 
 /****************************************************************************
  * Name: mpu_user_peripheral
@@ -357,13 +423,10 @@ void mpu_configure_region(uintptr_t base, size_t size,
  ****************************************************************************/
 
 #define mpu_user_peripheral(base, size) \
-  do \
-    { \
-      /* Then configure the region */     \
-      mpu_configure_region(base, size,    \
-                          MPU_AR_RWrw,  \
-                          MPU_MEM_DEVICE);\
-    } while (0)
+  /* Then configure the region */     \
+  mpu_configure_region(base, size,    \
+                       MPU_AR_RWrw,  \
+                       MPU_MEM_DEVICE)
 
 #undef EXTERN
 #if defined(__cplusplus)

--- a/arch/xtensa/src/common/xtensa_mpu.c
+++ b/arch/xtensa/src/common/xtensa_mpu.c
@@ -23,6 +23,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <debug.h>
 
 #include "mpu.h"
 
@@ -55,6 +56,12 @@ static uint8_t g_region = XCHAL_MPU_ENTRIES;
  *   - Regions are only allocated early in initialization, so no special
  *     protection against re-entrancy is required;
  *
+ * Input Parameters:
+ *   None.
+ *
+ * Returned Value:
+ *   The index of the allocated region.
+ *
  ****************************************************************************/
 
 unsigned int mpu_allocregion(void)
@@ -68,6 +75,12 @@ unsigned int mpu_allocregion(void)
  *
  * Description:
  *   Configure and enable (or disable) the MPU
+ *
+ * Input Parameters:
+ *   enable - Flag indicating whether to enable the MPU.
+ *
+ * Returned Value:
+ *   None.
  *
  ****************************************************************************/
 
@@ -88,17 +101,27 @@ void mpu_control(bool enable)
 }
 
 /****************************************************************************
- * Name: mpu_configure_region
+ * Name: mpu_modify_region
  *
  * Description:
- *   Configure a region
+ *   Modify a region for privileged, strongly ordered memory
+ *
+ * Input Parameters:
+ *   region  - Region number to modify.
+ *   base    - Base address of the region.
+ *   size    - Unused.
+ *   acc     - A uint32_t value representing the access permissions of
+ *             the region.
+ *   memtype - A uint32_t value representing the memory type of the region.
+ *
+ * Returned Value:
+ *   None.
  *
  ****************************************************************************/
 
-void mpu_configure_region(uintptr_t base, size_t size,
-                          uint32_t acc, uint32_t memtype)
+void mpu_modify_region(unsigned int region, uintptr_t base, size_t size,
+                       uint32_t acc, uint32_t memtype)
 {
-  unsigned int region = mpu_allocregion();
   uint32_t at;
   uint32_t as;
 
@@ -124,7 +147,7 @@ void mpu_configure_region(uintptr_t base, size_t size,
 
   at |= region;
 
-  /* update mpu entry .. requires an memw on same cache line */
+  /* Update mpu entry .. requires an memw on same cache line */
 
   __asm__ __volatile__
     (
@@ -136,7 +159,93 @@ void mpu_configure_region(uintptr_t base, size_t size,
       : "a" (at), "a"(as)
     );
 
+  /* Save base information for check overlap */
+
   xtensa_mpu_base[region] = base;
+}
+
+/****************************************************************************
+ * Name: mpu_configure_region
+ *
+ * Description:
+ *   Configure a region
+ *
+ * Input Parameters:
+ *   base    - Base address of the region.
+ *   size    - Unused.
+ *   acc     - A uint32_t value representing the access permissions of
+ *             the region.
+ *   memtype - A uint32_t value representing the memory type of the region.
+ *
+ * Returned Value:
+ *   The region number allocated for the configured region.
+ *
+ ****************************************************************************/
+
+unsigned int mpu_configure_region(uintptr_t base, size_t size,
+                                  uint32_t acc, uint32_t memtype)
+{
+  unsigned int region = mpu_allocregion();
+  mpu_modify_region(region, base, size, acc, memtype);
+  return region;
+}
+
+/****************************************************************************
+ * Name: mpu_initialize
+ *
+ * Description:
+ *   Configure a region for privileged, strongly ordered memory
+ *
+ * Input Parameters:
+ *   table - MPU initialization table.
+ *   count - Initialize the number of entries in the region table.
+ *
+ * Returned Value:
+ *   NULL.
+ *
+ ****************************************************************************/
+
+void mpu_initialize(const struct mpu_region_s *table, size_t count)
+{
+  const struct mpu_region_s *conf;
+  size_t index;
+
+  mpu_control(false);
+  for (index = 0; index < count; index++)
+    {
+      conf = &table[index];
+      mpu_configure_region(conf->base, conf->size, conf->acc, conf->memtype);
+    }
+
+  mpu_control(true);
+}
+
+/****************************************************************************
+ * Name: mpu_dump_region
+ *
+ * Description:
+ *   Dump the region that has been used.
+ *
+ * Input Parameters:
+ *   None.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void mpu_dump_region(void)
+{
+  int i;
+
+  for (i = XCHAL_MPU_ENTRIES - 1; i >= g_region; i--)
+    {
+      _info("MPU-Index(%d) Enable, Base:%" PRIu32 "\n", i,
+            xtensa_mpu_base[i]);
+    }
+
+  _info("Total Use Region:%d, Remaining Available:%d\n",
+        XCHAL_MPU_ENTRIES - g_region, g_region);
 }
 
 #endif /* defined(XCHAL_MPU_ENTRIES) && XCHAL_MPU_ENTRIES > 0 */


### PR DESCRIPTION
## Summary
In the current NuttX MPU implementation, it is not possible to reconfigure a region that has already been set. Therefore, the purpose of this MPU upgrade is to enhance the ability of NuttX MPU to more accurately adjust the region.

The main interfaces are
```
void mpu_modify_region(unsigned int region, uinptr_t base, size_t size, uint32_t flags);
void mpu_clear_region(unsigned int region).
```

And change the g_region at the beginning to a bitmap to indicate whether each region has been allocated or not.

## Impact
update mpu for:
armv7m
armv8m
armv7r
arm64
xtensa

## Testing
Local test pass
