### PR TITLE
Fslock optimize

### DIFF
--- a/fs/vfs/fs_lock.c
+++ b/fs/vfs/fs_lock.c
@@ -30,6 +30,7 @@
 #include <unistd.h>
 #include <sys/stat.h>
 
+#include <nuttx/fs/fs.h>
 #include <nuttx/lib/lib.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/mutex.h>
@@ -715,6 +716,10 @@ retry:
       goto out;
     }
 
+  /* Update filep lock state */
+
+  filep->locked = true;
+
   /* When there is a lock change, we need to wake up the blocking lock */
 
   if (bucket->nwaiter > 0)
@@ -751,6 +756,11 @@ void file_closelk(FAR struct file *filep)
   bool deleted = false;
   int ret;
 
+  if (filep->locked == false)
+    {
+      return;
+    }
+
   path = lib_get_pathbuffer();
   if (path == NULL)
     {
@@ -784,6 +794,7 @@ void file_closelk(FAR struct file *filep)
         {
           deleted = true;
           file_lock_delete(file_lock);
+          filep->locked = false;
         }
     }
 

--- a/fs/vfs/fs_lock.c
+++ b/fs/vfs/fs_lock.c
@@ -767,15 +767,16 @@ void file_closelk(FAR struct file *filep)
       goto out;
     }
 
+  nxmutex_lock(&g_protect_lock);
   bucket = file_lock_find_bucket(path);
   if (bucket == NULL)
     {
       /* There is no bucket here, so we don't need to free it. */
 
+      nxmutex_unlock(&g_protect_lock);
       goto out;
     }
 
-  nxmutex_lock(&g_protect_lock);
   list_for_every_entry_safe(&bucket->list, file_lock, temp,
                             struct file_lock_s, fl_node)
     {

--- a/fs/vfs/fs_lock.c
+++ b/fs/vfs/fs_lock.c
@@ -610,7 +610,7 @@ out:
 
 out_free:
   lib_put_pathbuffer(path);
-  return OK;
+  return ret;
 }
 
 /****************************************************************************
@@ -756,7 +756,7 @@ void file_closelk(FAR struct file *filep)
   bool deleted = false;
   int ret;
 
-  if (filep->locked == false)
+  if (!filep->locked)
     {
       return;
     }
@@ -774,7 +774,7 @@ void file_closelk(FAR struct file *filep)
        * it.
        */
 
-      goto out;
+      goto out_free;
     }
 
   nxmutex_lock(&g_protect_lock);
@@ -783,7 +783,6 @@ void file_closelk(FAR struct file *filep)
     {
       /* There is no bucket here, so we don't need to free it. */
 
-      nxmutex_unlock(&g_protect_lock);
       goto out;
     }
 
@@ -807,8 +806,9 @@ void file_closelk(FAR struct file *filep)
       file_lock_delete_bucket(bucket, path);
     }
 
-  nxmutex_unlock(&g_protect_lock);
 out:
+  nxmutex_unlock(&g_protect_lock);
+out_free:
   lib_put_pathbuffer(path);
 }
 

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -480,6 +480,10 @@ struct file
 #if CONFIG_FS_BACKTRACE > 0
   FAR void         *f_backtrace[CONFIG_FS_BACKTRACE]; /* Backtrace to while file opens */
 #endif
+
+#if CONFIG_FS_LOCK_BUCKET_SIZE > 0
+  bool              locked; /* Filelock state: false - unlocked, true - locked */
+#endif
 };
 
 /* This defines a two layer array of files indexed by the file descriptor.

--- a/include/nuttx/lib/lib.h
+++ b/include/nuttx/lib/lib.h
@@ -116,6 +116,11 @@ FAR struct file_struct *lib_get_stream(int fd);
 
 unsigned long nrand(unsigned long limit);
 
+/* Functions defined in lib_pathbuffer.c ************************************/
+
+FAR char *lib_get_pathbuffer(void);
+void lib_put_pathbuffer(FAR char *buffer);
+
 #undef EXTERN
 #ifdef __cplusplus
 }

--- a/libs/libc/misc/CMakeLists.txt
+++ b/libs/libc/misc/CMakeLists.txt
@@ -43,7 +43,8 @@ list(
   lib_mkdirat.c
   lib_utimensat.c
   lib_memoryregion.c
-  lib_getnprocs.c)
+  lib_getnprocs.c
+  lib_pathbuffer.c)
 
 # Support for platforms that do not have long long types
 

--- a/libs/libc/misc/Kconfig
+++ b/libs/libc/misc/Kconfig
@@ -120,3 +120,9 @@ config LIBC_MAX_PATHBUFFER
 	---help---
 		This value is the maximum size of the buffer that will hold the full
 		file path.
+
+config LIBC_PATHBUFFER_MALLOC
+	bool "Enable malloc pathbuffer"
+	default y
+	---help---
+		Enable malloc path buffer from the heap when pathbuffer is insufficient.

--- a/libs/libc/misc/Kconfig
+++ b/libs/libc/misc/Kconfig
@@ -112,3 +112,11 @@ config LIBC_MEM_FD_VFS_PATH
 	depends on !LIBC_MEMFD_ERROR
 	---help---
 		The relative path to where memfd will exist in the tmpfs namespace.
+
+config LIBC_MAX_PATHBUFFER
+	int "Maximum size of a temporary file path buffer array"
+	range 0 32
+	default 2
+	---help---
+		This value is the maximum size of the buffer that will hold the full
+		file path.

--- a/libs/libc/misc/Make.defs
+++ b/libs/libc/misc/Make.defs
@@ -25,7 +25,7 @@ CSRCS += lib_xorshift128.c lib_tea_encrypt.c lib_tea_decrypt.c
 CSRCS += lib_cxx_initialize.c lib_impure.c lib_memfd.c lib_mutex.c
 CSRCS += lib_fchmodat.c lib_fstatat.c lib_getfullpath.c lib_openat.c
 CSRCS += lib_mkdirat.c lib_utimensat.c lib_mallopt.c lib_memoryregion.c
-CSRCS += lib_idr.c lib_getnprocs.c
+CSRCS += lib_idr.c lib_getnprocs.c lib_pathbuffer.c
 
 # Support for platforms that do not have long long types
 

--- a/libs/libc/misc/lib_pathbuffer.c
+++ b/libs/libc/misc/lib_pathbuffer.c
@@ -1,0 +1,138 @@
+/****************************************************************************
+ * libs/libc/misc/lib_pathbuffer.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/mutex.h>
+#include <nuttx/lib/lib.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+/****************************************************************************
+ * Pre-processor definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct pathbuffer_s
+{
+  mutex_t lock;         /* Lock for the buffer */
+  int free_bitmap;      /* Bitmap of free buffer */
+  char buffer[CONFIG_LIBC_MAX_PATHBUFFER][PATH_MAX];
+};
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static struct pathbuffer_s g_pathbuffer =
+{
+  NXMUTEX_INITIALIZER,
+  (1u << CONFIG_LIBC_MAX_PATHBUFFER) - 1,
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: lib_get_pathbuffer
+ *
+ * Description:
+ *   The lib_get_pathbuffer() function returns a pointer to a temporary
+ *   buffer.  The buffer is allocated from a pool of pre-allocated buffers
+ *   and if the pool is exhausted, a new buffer is allocated through
+ *   kmm_malloc(). The size of the buffer is PATH_MAX, and must freed by
+ *   calling lib_put_pathbuffer().
+ *
+ * Returned Value:
+ *   On success, lib_get_pathbuffer() returns a pointer to a temporary
+ *   buffer.  On failure, NULL is returned.
+ *
+ ****************************************************************************/
+
+FAR char *lib_get_pathbuffer(void)
+{
+  int index;
+
+  /* Try to find a free buffer */
+
+  nxmutex_lock(&g_pathbuffer.lock);
+  index = ffs(g_pathbuffer.free_bitmap) - 1;
+  if (index >= 0 && index < CONFIG_LIBC_MAX_PATHBUFFER)
+    {
+      g_pathbuffer.free_bitmap &= ~(1u << index);
+      nxmutex_unlock(&g_pathbuffer.lock);
+      return g_pathbuffer.buffer[index];
+    }
+
+  nxmutex_unlock(&g_pathbuffer.lock);
+
+  /* If no free buffer is found, allocate a new one */
+
+  return lib_malloc(PATH_MAX);
+}
+
+/****************************************************************************
+ * Name: lib_put_pathbuffer
+ *
+ * Description:
+ *   The lib_put_pathbuffer() function frees a temporary buffer that was
+ *   allocated by lib_get_pathbuffer(). If the buffer was allocated
+ *   dynamically, it is freed by calling kmm_free(). Otherwise, the buffer
+ *   is marked as free in the pool of pre-allocated buffers.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void lib_put_pathbuffer(FAR char *buffer)
+{
+  int index;
+
+  nxmutex_lock(&g_pathbuffer.lock);
+  index = (buffer - &g_pathbuffer.buffer[0][0]) / PATH_MAX;
+
+  if (index >= 0 && index < CONFIG_LIBC_MAX_PATHBUFFER)
+    {
+      /* Mark the corresponding bit as free */
+
+      g_pathbuffer.free_bitmap |= 1u << index;
+      nxmutex_unlock(&g_pathbuffer.lock);
+      return;
+    }
+
+  nxmutex_unlock(&g_pathbuffer.lock);
+
+  /* Free the buffer if it was dynamically allocated */
+
+  lib_free(buffer);
+}

--- a/libs/libc/misc/lib_pathbuffer.c
+++ b/libs/libc/misc/lib_pathbuffer.c
@@ -39,8 +39,8 @@
 
 struct pathbuffer_s
 {
-  mutex_t lock;         /* Lock for the buffer */
-  int free_bitmap;      /* Bitmap of free buffer */
+  mutex_t lock;             /* Lock for the buffer */
+  unsigned int free_bitmap; /* Bitmap of free buffer */
   char buffer[CONFIG_LIBC_MAX_PATHBUFFER][PATH_MAX];
 };
 

--- a/libs/libc/misc/lib_pathbuffer.c
+++ b/libs/libc/misc/lib_pathbuffer.c
@@ -95,9 +95,15 @@ FAR char *lib_get_pathbuffer(void)
 
   nxmutex_unlock(&g_pathbuffer.lock);
 
-  /* If no free buffer is found, allocate a new one */
+  /* If no free buffer is found, allocate a new one if
+   * CONFIG_LIBC_PATHBUFFER_MALLOC is enabled
+   */
 
+#ifdef CONFIG_LIBC_PATHBUFFER_MALLOC
   return lib_malloc(PATH_MAX);
+#else
+  return NULL;
+#endif
 }
 
 /****************************************************************************
@@ -134,5 +140,7 @@ void lib_put_pathbuffer(FAR char *buffer)
 
   /* Free the buffer if it was dynamically allocated */
 
-  lib_free(buffer);
+#ifdef CONFIG_LIBC_PATHBUFFER_MALLOC
+  return lib_free(buffer);
+#endif
 }


### PR DESCRIPTION
## Summary
1. Add lib_get_pathbuffer / lib_put_pathbuffer instead of temporary variable.
2. Reduce stack size. Getting the tmp buffer through the lib_get_pathbuffer function reduces the declaration of temporary variables
3. Fix an unsynchronized lock acquisition by closelk in multi-threaded scenarios. Ensure atomic behavior when acquiring lock status.
4. Optimized additional performance overhead due to closelk in the close phase (even if the fd doesn't use fslock)
Optimizing performance:
Before: Time taken to close the file: 33984 nsec
After: Time taken to close the file: 23744 nsec
Improvement of about 10 msec

## Impact
Optimizing fslock

## Testing
Local test pass
