### PR TITLE
libs: fix the default value of process-shared attribute

### DIFF
--- a/libs/libc/pthread/pthread_condattr_init.c
+++ b/libs/libc/pthread/pthread_condattr_init.c
@@ -61,6 +61,7 @@ int pthread_condattr_init(FAR pthread_condattr_t *attr)
   else
     {
       attr->clockid = CLOCK_REALTIME;
+      attr->pshared = PTHREAD_PROCESS_PRIVATE;
     }
 
   linfo("Returning %d\n", ret);


### PR DESCRIPTION
## Summary
pass ltp case: open_posix_testsuite/conformance/interfaces/pthread_condattr_getpshared/2-1.c

Reference:
https://pubs.opengroup.org/onlinepubs/009696899/functions/pthread_mutexattr_getpshared.html

## Impact
None

## Testing
pass LTP
