### PR TITLE
add fb_vsync_pollnotify

### DIFF
--- a/arch/sim/src/sim/sim_framebuffer.c
+++ b/arch/sim/src/sim/sim_framebuffer.c
@@ -426,6 +426,7 @@ void sim_x11loop(void)
   if (now - last >= MSEC2TICK(16))
     {
       last = now;
+      fb_notify_vsync(&g_fbobject, FB_NO_OVERLAY);
       if (fb_paninfo_count(&g_fbobject, FB_NO_OVERLAY) > 1)
         {
           fb_remove_paninfo(&g_fbobject, FB_NO_OVERLAY);
@@ -463,7 +464,8 @@ int up_fbinitialize(int display)
 
 #ifdef CONFIG_SIM_X11FB
   g_planeinfo.xres_virtual = CONFIG_SIM_FBWIDTH;
-  g_planeinfo.yres_virtual = CONFIG_SIM_FBHEIGHT * CONFIG_SIM_FRAMEBUFFER_COUNT;
+  g_planeinfo.yres_virtual = CONFIG_SIM_FBHEIGHT *
+                             CONFIG_SIM_FRAMEBUFFER_COUNT;
   ret = sim_x11initialize(CONFIG_SIM_FBWIDTH, CONFIG_SIM_FBHEIGHT,
                           &g_planeinfo.fbmem, &g_planeinfo.fblen,
                           &g_planeinfo.bpp, &g_planeinfo.stride,

--- a/arch/sim/src/sim/sim_framebuffer.c
+++ b/arch/sim/src/sim/sim_framebuffer.c
@@ -426,7 +426,7 @@ void sim_x11loop(void)
   if (now - last >= MSEC2TICK(16))
     {
       last = now;
-      fb_notify_vsync(&g_fbobject, FB_NO_OVERLAY);
+      fb_notify_vsync(&g_fbobject);
       if (fb_paninfo_count(&g_fbobject, FB_NO_OVERLAY) > 1)
         {
           fb_remove_paninfo(&g_fbobject, FB_NO_OVERLAY);

--- a/drivers/video/goldfish_fb.c
+++ b/drivers/video/goldfish_fb.c
@@ -126,6 +126,8 @@ static void goldfish_fb_vsync_irq(FAR struct goldfish_fb_s *fb)
     }
 #endif
 
+  fb_notify_vsync(&fb->vtable, FB_NO_OVERLAY);
+
   if (fb_peek_paninfo(&fb->vtable, &info, FB_NO_OVERLAY) == OK)
     {
       uintptr_t buf = (uintptr_t)(fb->planeinfo.fbmem +

--- a/drivers/video/goldfish_fb.c
+++ b/drivers/video/goldfish_fb.c
@@ -126,7 +126,7 @@ static void goldfish_fb_vsync_irq(FAR struct goldfish_fb_s *fb)
     }
 #endif
 
-  fb_notify_vsync(&fb->vtable, FB_NO_OVERLAY);
+  fb_notify_vsync(&fb->vtable);
 
   if (fb_peek_paninfo(&fb->vtable, &info, FB_NO_OVERLAY) == OK)
     {

--- a/include/nuttx/video/fb.h
+++ b/include/nuttx/video/fb.h
@@ -1015,11 +1015,10 @@ void up_fbuninitialize(int display);
  *
  * Input Parameters:
  *   vtable  - Pointer to framebuffer's virtual table.
- *   overlay - Overlay index.
  *
  ****************************************************************************/
 
-void fb_notify_vsync(FAR struct fb_vtable_s *vtable, int overlay);
+void fb_notify_vsync(FAR struct fb_vtable_s *vtable);
 
 /****************************************************************************
  * Name: fb_peek_paninfo

--- a/include/nuttx/video/fb.h
+++ b/include/nuttx/video/fb.h
@@ -1009,6 +1009,19 @@ FAR struct fb_vtable_s *up_fbgetvplane(int display, int vplane);
 void up_fbuninitialize(int display);
 
 /****************************************************************************
+ * Name: fb_notify_vsync
+ * Description:
+ *   notify that the vsync comes.
+ *
+ * Input Parameters:
+ *   vtable  - Pointer to framebuffer's virtual table.
+ *   overlay - Overlay index.
+ *
+ ****************************************************************************/
+
+void fb_notify_vsync(FAR struct fb_vtable_s *vtable, int overlay);
+
+/****************************************************************************
  * Name: fb_peek_paninfo
  * Description:
  *   Peek a frame from pan info queue of the specified overlay.


### PR DESCRIPTION
## Summary
add fb_vsync_pollnotify for sim and goldfish_fb
when the vsync comes, fb drivers should call fb_vsync_pollnotify to notify POLLPRI, so that users can catch the synchronization time of vsync and do something
## Impact
users can catch the synchronization time of vsync
## Testing
None