### PR TITLE
note:fix build error.

### DIFF
--- a/drivers/note/note_driver.c
+++ b/drivers/note/note_driver.c
@@ -160,11 +160,6 @@ static void note_driver_instrument_enter(FAR void *this_fn,
             FAR void *call_site, FAR void *arg) noinstrument_function;
 static void note_driver_instrument_leave(FAR void *this_fn,
             FAR void *call_site, FAR void *arg) noinstrument_function;
-static struct instrument_s g_note_instrument =
-{
-  .enter = note_driver_instrument_enter,
-  .leave = note_driver_instrument_leave,
-};
 #endif
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_FILTER

--- a/drivers/note/note_initialize.c
+++ b/drivers/note/note_initialize.c
@@ -32,6 +32,18 @@
 #include <nuttx/segger/sysview.h>
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#ifdef CONFIG_SCHED_INSTRUMENTATION_FUNCTION
+static struct instrument_s g_note_instrument =
+{
+  .enter = note_driver_instrument_enter,
+  .leave = note_driver_instrument_leave,
+};
+#endif
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 


### PR DESCRIPTION
## Summary
CC:  mqueue/msgctl.c note/note_driver.c:156:15: error: variable 'g_note_instrument' has initializer but incomplete type
  156 | static struct instrument_s g_note_instrument =
      |               ^~~~~~~~~~~~
note/note_driver.c:158:4: error: 'struct instrument_s' has no member named 'enter'
  158 |   .enter = note_driver_instrument_enter,
      |    ^~~~~
CC:  libsodium/src/libsodium/crypto_aead/aegis128l/aead_aegis128l.c note/note_driver.c:158:12: error: 'note_driver_instrument_enter' undeclared here (not in a function)
  158 |   .enter = note_driver_instrument_enter,
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
note/note_driver.c:158:12: warning: excess elements in struct initializer
note/note_driver.c:158:12: note: (near initialization for 'g_note_instrument')
note/note_driver.c:159:4: error: 'struct instrument_s' has no member named 'leave'
  159 |   .leave = note_driver_instrument_leave,
      |    ^~~~~
note/note_initialize.c: In function 'note_initialize':
note/note_initialize.c:92:24: error: 'g_note_instrument' undeclared (first use in this function)
   92 |   instrument_register(&g_note_instrument);
      |                        ^~~~~~~~~~~~~~~~~
note/note_initialize.c:92:24: note: each undeclared identifier is reported only once for each function it appears in
At top level:
note/note_initialize.c:59:13: warning: 'note_driver_instrument_leave' defined but not used [-Wunused-function]
   59 | static void note_driver_instrument_leave(FAR void *this_fn,
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
note/note_initialize.c:51:13: warning: 'note_driver_instrument_enter' defined but not used [-Wunused-function]
   51 | static void note_driver_instrument_enter(FAR void *this_fn,
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
note/note_driver.c:159:12: error: 'note_driver_instrument_leave' undeclared here (not in a function)
  159 |   .leave = note_driver_instrument_leave,
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~

## Impact

## Testing

