### PR TITLE
tools/parsetrace.py:fix parsetrace script error.

### DIFF
--- a/tools/parsetrace.py
+++ b/tools/parsetrace.py
@@ -26,18 +26,18 @@ import re
 import subprocess
 from typing import Union
 
-from pycstruct import pycstruct
-
 try:
     import cxxfilt
     import parse
     from elftools.elf.elffile import ELFFile
     from elftools.elf.sections import SymbolTableSection
+    from pycstruct import pycstruct
     from pydantic import BaseModel
 
 except ModuleNotFoundError:
     print("Please execute the following command to install dependencies:")
-    print("pip install pyelftools cxxfilt pydantic parse")
+    print("pip install pyelftools cxxfilt pydantic parse pycstruct")
+    exit(1)
 
 
 class SymbolTables(object):


### PR DESCRIPTION
## Summary
Traceback (most recent call last):
  File nuttx/tools/parsetrace.py, line 29, in <module>
    from pycstruct import pycstruct
ModuleNotFoundError: No module named 'pycstruct'

## Impact

## Testing

