### PR TITLE
nuttx/note:fix runtime error.

### DIFF
--- a/arch/sim/src/sim/sim_heap.c
+++ b/arch/sim/src/sim/sim_heap.c
@@ -33,6 +33,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/fs/procfs.h>
 #include <nuttx/mm/mm.h>
+#include <nuttx/sched_note.h>
 
 #include "sim_internal.h"
 
@@ -185,6 +186,7 @@ static void mm_delayfree(struct mm_heap_s *heap, void *mem, bool delay)
       int size = host_mallocsize(mem);
       atomic_fetch_sub(&heap->aordblks, 1);
       atomic_fetch_sub(&heap->uordblks, size);
+      sched_note_heap(false, heap, mem, size);
       host_free(mem);
     }
 }
@@ -339,22 +341,27 @@ void *mm_realloc(struct mm_heap_s *heap, void *oldmem,
   int uordblks;
   int usmblks;
   int newsize;
+  int oldsize;
 
-  free_delaylist(heap, false);
+  mm_free_delaylist(heap, false);
 
-  if (size == 0)
-    {
-      mm_free(heap, oldmem);
-      return NULL;
-    }
-
-  atomic_fetch_sub(&heap->uordblks, host_mallocsize(oldmem));
+  oldsize = host_mallocsize(oldmem);
+  atomic_fetch_sub(&heap->uordblks, oldsize);
   mem = host_realloc(oldmem, size);
 
   atomic_fetch_add(&heap->aordblks, oldmem == NULL && mem != NULL);
   newsize = host_mallocsize(mem ? mem : oldmem);
   atomic_fetch_add(&heap->uordblks, newsize);
   usmblks = atomic_load(&heap->usmblks);
+  if (mem != NULL)
+    {
+      if (oldmem != NULL)
+        {
+          sched_note_heap(false, heap, oldmem, oldsize);
+        }
+
+      sched_note_heap(true, heap, mem, newsize);
+    }
 
   do
     {
@@ -445,6 +452,7 @@ void *mm_memalign(struct mm_heap_s *heap, size_t alignment, size_t size)
     }
 
   size = host_mallocsize(mem);
+  sched_note_heap(true, heap, mem, size);
   atomic_fetch_add(&heap->aordblks, 1);
   atomic_fetch_add(&heap->uordblks, size);
   usmblks = atomic_load(&heap->usmblks);

--- a/drivers/note/note_driver.c
+++ b/drivers/note/note_driver.c
@@ -592,10 +592,10 @@ static void note_record_taskname(pid_t pid, FAR const char *name)
 
   ti = (FAR struct note_taskname_info_s *)
         &g_note_taskname.buffer[g_note_taskname.head];
-  ti->size = tilen;
+  ti->size = NOTE_ALIGN(tilen);
   ti->pid = pid;
   strlcpy(ti->name, name, namelen + 1);
-  g_note_taskname.head += tilen;
+  g_note_taskname.head += ti->size;
 }
 #endif
 

--- a/drivers/note/note_driver.c
+++ b/drivers/note/note_driver.c
@@ -152,7 +152,7 @@ struct note_taskname_s
 #endif
 
 /****************************************************************************
- * Private Data
+ * Private Function Prototypes
  ****************************************************************************/
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_FUNCTION
@@ -160,6 +160,13 @@ static void note_driver_instrument_enter(FAR void *this_fn,
             FAR void *call_site, FAR void *arg) noinstrument_function;
 static void note_driver_instrument_leave(FAR void *this_fn,
             FAR void *call_site, FAR void *arg) noinstrument_function;
+#endif
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#ifdef CONFIG_SCHED_INSTRUMENTATION_FUNCTION
 static struct instrument_s g_note_instrument =
 {
   .enter = note_driver_instrument_enter,

--- a/drivers/note/note_driver.c
+++ b/drivers/note/note_driver.c
@@ -1065,7 +1065,6 @@ void sched_note_premption(FAR struct tcb_s *tcb, bool locked)
       if (!formatted)
         {
           formatted = true;
-          note.npr_count = tcb->lockcount;
           note_common(tcb, &note.npr_cmn, sizeof(struct note_preempt_s),
                       locked ? NOTE_PREEMPT_LOCK : NOTE_PREEMPT_UNLOCK);
           note.npr_count = tcb->lockcount;
@@ -1399,9 +1398,9 @@ void sched_note_string_ip(uint32_t tag, uintptr_t ip, FAR const char *buf)
               length = sizeof(data);
             }
 
-          note->nst_ip = ip;
           note_common(tcb, &note->nst_cmn, length, NOTE_DUMP_STRING);
           memcpy(note->nst_data, buf, length - sizeof(struct note_string_s));
+          note->nst_ip = ip;
           data[length - 1] = '\0';
           note->nst_ip = ip;
         }
@@ -1451,8 +1450,8 @@ void sched_note_event_ip(uint32_t tag, uintptr_t ip, uint8_t event,
               length = sizeof(data);
             }
 
-          note->nbi_ip = ip;
           note_common(tcb, &note->nbi_cmn, length, event);
+          note->nbi_ip = ip;
           memcpy(note->nbi_data, buf,
                  length - sizeof(struct note_binary_s) + 1);
           note->nbi_ip = ip;
@@ -1507,8 +1506,8 @@ void sched_note_vprintf_ip(uint32_t tag, uintptr_t ip,
               length = sizeof(data);
             }
 
-          note->nst_ip = ip;
           note_common(tcb, &note->nst_cmn, length, NOTE_DUMP_STRING);
+          note->nst_ip = ip;
         }
 
       /* Add the note to circular buffer */

--- a/drivers/note/note_driver.c
+++ b/drivers/note/note_driver.c
@@ -1065,6 +1065,7 @@ void sched_note_premption(FAR struct tcb_s *tcb, bool locked)
       if (!formatted)
         {
           formatted = true;
+          note.npr_count = tcb->lockcount;
           note_common(tcb, &note.npr_cmn, sizeof(struct note_preempt_s),
                       locked ? NOTE_PREEMPT_LOCK : NOTE_PREEMPT_UNLOCK);
           note.npr_count = tcb->lockcount;
@@ -1398,11 +1399,9 @@ void sched_note_string_ip(uint32_t tag, uintptr_t ip, FAR const char *buf)
               length = sizeof(data);
             }
 
+          note->nst_ip = ip;
           note_common(tcb, &note->nst_cmn, length, NOTE_DUMP_STRING);
-          if (buf != NULL)
-            {
-              memcpy(note->nst_data, buf, length - sizeof(struct note_string_s));
-            }
+          memcpy(note->nst_data, buf, length - sizeof(struct note_string_s));
           data[length - 1] = '\0';
           note->nst_ip = ip;
         }
@@ -1452,6 +1451,7 @@ void sched_note_event_ip(uint32_t tag, uintptr_t ip, uint8_t event,
               length = sizeof(data);
             }
 
+          note->nbi_ip = ip;
           note_common(tcb, &note->nbi_cmn, length, event);
           memcpy(note->nbi_data, buf,
                  length - sizeof(struct note_binary_s) + 1);
@@ -1507,8 +1507,8 @@ void sched_note_vprintf_ip(uint32_t tag, uintptr_t ip,
               length = sizeof(data);
             }
 
-          note_common(tcb, &note->nst_cmn, length, NOTE_DUMP_STRING);
           note->nst_ip = ip;
+          note_common(tcb, &note->nst_cmn, length, NOTE_DUMP_STRING);
         }
 
       /* Add the note to circular buffer */
@@ -1724,8 +1724,8 @@ void sched_note_vbprintf_ip(uint32_t tag, uintptr_t ip,
             }
 
           length = SIZEOF_NOTE_BINARY(next);
-          note_common(tcb, &note->nbi_cmn, length, NOTE_DUMP_BINARY);
           note->nbi_ip = ip;
+          note_common(tcb, &note->nbi_cmn, length, NOTE_DUMP_BINARY);
         }
 
       /* Add the note to circular buffer */

--- a/drivers/note/note_driver.c
+++ b/drivers/note/note_driver.c
@@ -92,6 +92,8 @@
 #define note_irqhandler(drv, irq, handler, enter)                            \
   ((drv)->ops->irqhandler &&                                                 \
   ((drv)->ops->irqhandler(drv, irq, handler, enter), true))
+#define note_heap(drv, alloc, data, mem, size)                               \
+  ((drv)->ops->heap && ((drv)->ops->heap(drv, alloc, data, mem, size), true))
 #define note_string(drv, ip, buf)                                            \
   ((drv)->ops->string && ((drv)->ops->string(drv, ip, buf), true))
 #define note_event(drv, ip, event, buf, len)                                 \
@@ -1355,6 +1357,50 @@ void sched_note_irqhandler(int irq, FAR void *handler, bool enter)
       /* Add the note to circular buffer */
 
       note_add(*driver, &note, sizeof(struct note_irqhandler_s));
+    }
+}
+#endif
+
+#ifdef CONFIG_SCHED_INSTRUMENTATION_HEAP
+void sched_note_heap(bool alloc, FAR void *heap, FAR void *mem, size_t size)
+{
+  FAR struct note_driver_s **driver;
+  struct note_heap_s note;
+  bool formatted = false;
+  FAR struct tcb_s *tcb = this_task();
+
+#ifdef CONFIG_SCHED_INSTRUMENTATION_FILTER
+  if (!note_isenabled())
+    {
+      return;
+    }
+#endif
+
+  for (driver = g_note_drivers; *driver; driver++)
+    {
+      if (note_heap(*driver, alloc, heap, mem, size))
+        {
+          continue;
+        }
+
+      if ((*driver)->ops->add == NULL)
+        {
+          continue;
+        }
+
+      if (!formatted)
+        {
+          enum note_type_e type = alloc ? NOTE_ALLOC : NOTE_FREE;
+          formatted = true;
+          note_common(tcb, &note.nmm_cmn, sizeof(note), type);
+          note.heap = heap;
+          note.mem = mem;
+          note.size = size;
+        }
+
+      /* Add the note to circular buffer */
+
+      note_add(*driver, &note, sizeof(note));
     }
 }
 #endif

--- a/drivers/note/note_driver.c
+++ b/drivers/note/note_driver.c
@@ -1392,7 +1392,10 @@ void sched_note_string_ip(uint32_t tag, uintptr_t ip, FAR const char *buf)
             }
 
           note_common(tcb, &note->nst_cmn, length, NOTE_DUMP_STRING);
-          memcpy(note->nst_data, buf, length - sizeof(struct note_string_s));
+          if (buf != NULL)
+            {
+              memcpy(note->nst_data, buf, length - sizeof(struct note_string_s));
+            }
           data[length - 1] = '\0';
           note->nst_ip = ip;
         }

--- a/drivers/note/noteram_driver.c
+++ b/drivers/note/noteram_driver.c
@@ -295,7 +295,7 @@ static void noteram_remove(FAR struct noteram_driver_s *drv)
 
   /* Get the length of the note at the tail index */
 
-  length = drv->ni_buffer[tail];
+  length = NOTE_ALIGN(drv->ni_buffer[tail]);
   DEBUGASSERT(length <= noteram_length(drv));
 
   /* Increment the tail index to remove the entire note from the circular
@@ -387,7 +387,7 @@ static ssize_t noteram_get(FAR struct noteram_driver_s *drv,
       remaining--;
     }
 
-  drv->ni_read = read;
+  drv->ni_read = NOTE_ALIGN(read);
 
   return notelen;
 }
@@ -594,7 +594,7 @@ static void noteram_add(FAR struct note_driver_s *driver,
   space = space < notelen ? space : notelen;
   memcpy(drv->ni_buffer + head, note, space);
   memcpy(drv->ni_buffer, buf + space, notelen - space);
-  drv->ni_head = noteram_next(drv, head, notelen);
+  drv->ni_head = noteram_next(drv, head, NOTE_ALIGN(notelen));
   spin_unlock_irqrestore_wo_note(&drv->lock, flags);
 }
 

--- a/drivers/note/noteram_driver.c
+++ b/drivers/note/noteram_driver.c
@@ -809,7 +809,6 @@ static int noteram_dump_one(FAR uint8_t *p, FAR struct lib_outstream_s *s,
       {
         FAR struct note_syscall_enter_s *nsc;
         int i;
-        int j;
         uintptr_t arg;
 
         nsc = (FAR struct note_syscall_enter_s *)p;
@@ -823,7 +822,7 @@ static int noteram_dump_one(FAR uint8_t *p, FAR struct lib_outstream_s *s,
         ret += lib_sprintf(s, "sys_%s(",
                            g_funcnames[nsc->nsc_nr - CONFIG_SYS_RESERVED]);
 
-        for (i = j = 0; i < nsc->nsc_argc; i++)
+        for (i = 0; i < nsc->nsc_argc; i++)
           {
             arg = nsc->nsc_args[i];
             if (i == 0)

--- a/drivers/note/noteram_driver.c
+++ b/drivers/note/noteram_driver.c
@@ -650,6 +650,8 @@ static int noteram_dump_header(FAR struct lib_outstream_s *s,
   uint32_t sec = note->nc_systime_sec;
   int ret;
 
+  nsec = note->nc_systime_nsec;
+  sec = note->nc_systime_sec;
   pid = note->nc_pid;
 #ifdef CONFIG_SMP
   int cpu = note->nc_cpu;

--- a/include/nuttx/note/note_driver.h
+++ b/include/nuttx/note/note_driver.h
@@ -89,6 +89,10 @@ struct note_driver_ops_s
   CODE void (*irqhandler)(FAR struct note_driver_s *drv, int irq,
                           FAR void *handler, bool enter);
 #endif
+#ifdef CONFIG_SCHED_INSTRUMENTATION_HEAP
+  CODE void (*heap)(FAR struct note_driver_s *drv, bool alloc,
+                    FAR void *heap, FAR void *mem, size_t size);
+#endif
 #ifdef CONFIG_SCHED_INSTRUMENTATION_DUMP
   CODE void (*string)(FAR struct note_driver_s *drv, uintptr_t ip,
                       FAR const char *buf);

--- a/include/nuttx/sched_note.h
+++ b/include/nuttx/sched_note.h
@@ -51,6 +51,9 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+#define NOTE_ALIGN(a) (((a) + sizeof(uintptr_t) - 1) & \
+                       ~(sizeof(uintptr_t) - 1))
+
 /* Provide defaults for some configuration settings (could be undefined with
  * old configuration files)
  */

--- a/include/nuttx/sched_note.h
+++ b/include/nuttx/sched_note.h
@@ -164,34 +164,40 @@
 
 enum note_type_e
 {
-  NOTE_START           = 0,
-  NOTE_STOP            = 1,
-  NOTE_SUSPEND         = 2,
-  NOTE_RESUME          = 3,
-  NOTE_CPU_START       = 4,
-  NOTE_CPU_STARTED     = 5,
-  NOTE_CPU_PAUSE       = 6,
-  NOTE_CPU_PAUSED      = 7,
-  NOTE_CPU_RESUME      = 8,
-  NOTE_CPU_RESUMED     = 9,
-  NOTE_PREEMPT_LOCK    = 10,
-  NOTE_PREEMPT_UNLOCK  = 11,
-  NOTE_CSECTION_ENTER  = 12,
-  NOTE_CSECTION_LEAVE  = 13,
-  NOTE_SPINLOCK_LOCK   = 14,
-  NOTE_SPINLOCK_LOCKED = 15,
-  NOTE_SPINLOCK_UNLOCK = 16,
-  NOTE_SPINLOCK_ABORT  = 17,
-  NOTE_SYSCALL_ENTER   = 18,
-  NOTE_SYSCALL_LEAVE   = 19,
-  NOTE_IRQ_ENTER       = 20,
-  NOTE_IRQ_LEAVE       = 21,
-  NOTE_DUMP_STRING     = 22,
-  NOTE_DUMP_BINARY     = 23,
-  NOTE_DUMP_BEGIN      = 24,
-  NOTE_DUMP_END        = 25,
-  NOTE_DUMP_MARK       = 28,
-  NOTE_DUMP_COUNTER    = 29,
+  NOTE_START,
+  NOTE_STOP,
+  NOTE_SUSPEND,
+  NOTE_RESUME,
+  NOTE_CPU_START,
+  NOTE_CPU_STARTED,
+  NOTE_CPU_PAUSE,
+  NOTE_CPU_PAUSED,
+  NOTE_CPU_RESUME,
+  NOTE_CPU_RESUMED,
+  NOTE_PREEMPT_LOCK,
+  NOTE_PREEMPT_UNLOCK,
+  NOTE_CSECTION_ENTER,
+  NOTE_CSECTION_LEAVE,
+  NOTE_SPINLOCK_LOCK,
+  NOTE_SPINLOCK_LOCKED,
+  NOTE_SPINLOCK_UNLOCK,
+  NOTE_SPINLOCK_ABORT,
+  NOTE_SYSCALL_ENTER,
+  NOTE_SYSCALL_LEAVE,
+  NOTE_IRQ_ENTER,
+  NOTE_IRQ_LEAVE,
+  NOTE_ALLOC,
+  NOTE_FREE,
+  NOTE_REALLOC,
+  NOTE_DUMP_STRING,
+  NOTE_DUMP_BINARY,
+  NOTE_DUMP_BEGIN,
+  NOTE_DUMP_END,
+  NOTE_DUMP_MARK,
+  NOTE_DUMP_COUNTER,
+
+  /* Always last */
+
   NOTE_TYPE_LAST
 };
 
@@ -397,6 +403,14 @@ struct note_binary_s
 #define SIZEOF_NOTE_BINARY(n) (sizeof(struct note_binary_s) + \
                                ((n) - 1) * sizeof(uint8_t))
 
+struct note_heap_s
+{
+  struct note_common_s nmm_cmn;      /* Common note parameters */
+  FAR void *heap;
+  FAR void *mem;
+  size_t size;
+};
+
 struct note_counter_s
 {
   long int value;
@@ -537,6 +551,12 @@ void sched_note_syscall_leave(int nr, uintptr_t result);
 void sched_note_irqhandler(int irq, FAR void *handler, bool enter);
 #else
 #  define sched_note_irqhandler(i,h,e)
+#endif
+
+#ifdef CONFIG_SCHED_INSTRUMENTATION_HEAP
+void sched_note_heap(bool alloc, FAR void *heap, FAR void *mem, size_t size);
+#else
+#  define sched_note_heap(a,h,m,s)
 #endif
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_DUMP

--- a/mm/mm_heap/mm_free.c
+++ b/mm/mm_heap/mm_free.c
@@ -30,6 +30,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/sched.h>
 #include <nuttx/mm/mm.h>
+#include <nuttx/sched_note.h>
 
 #include "mm_heap/mm.h"
 #include "kasan/kasan.h"
@@ -97,11 +98,12 @@ void mm_delayfree(FAR struct mm_heap_s *heap, FAR void *mem, bool delay)
       return;
     }
 
+  nodesize = mm_malloc_size(heap, mem);
 #ifdef CONFIG_MM_FILL_ALLOCATIONS
-  memset(mem, MM_FREE_MAGIC, mm_malloc_size(heap, mem));
-#endif
+  memset(mem, MM_FREE_MAGIC, nodesize);
+endif
 
-  kasan_poison(mem, mm_malloc_size(heap, mem));
+  kasan_poison(mem, nodesize);
 
   if (delay)
     {
@@ -124,6 +126,7 @@ void mm_delayfree(FAR struct mm_heap_s *heap, FAR void *mem, bool delay)
   /* Update heap statistics */
 
   heap->mm_curused -= nodesize;
+  sched_note_heap(false, heap, mem, nodesize);
 
   /* Check if the following node is free and, if so, merge it */
 

--- a/mm/mm_heap/mm_malloc.c
+++ b/mm/mm_heap/mm_malloc.c
@@ -31,6 +31,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/mm/mm.h>
 #include <nuttx/sched.h>
+#include <nuttx/sched_note.h>
 
 #include "mm_heap/mm.h"
 #include "kasan/kasan.h"
@@ -304,7 +305,8 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
 
       /* Update heap statistics */
 
-      heap->mm_curused += MM_SIZEOF_NODE(node);
+      nodesize = MM_SIZEOF_NODE(node);
+      heap->mm_curused += nodesize;
       if (heap->mm_curused > heap->mm_maxused)
         {
           heap->mm_maxused = heap->mm_curused;
@@ -322,7 +324,8 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
   if (ret)
     {
       MM_ADD_BACKTRACE(heap, node);
-      kasan_unpoison(ret, mm_malloc_size(heap, ret));
+      kasan_unpoison(ret, nodesize);
+      sched_note_heap(true, heap, ret, nodesize);
 #ifdef CONFIG_MM_FILL_ALLOCATIONS
       memset(ret, MM_ALLOC_MAGIC, alignsize - MM_ALLOCNODE_OVERHEAD);
 #endif

--- a/mm/mm_heap/mm_realloc.c
+++ b/mm/mm_heap/mm_realloc.c
@@ -31,6 +31,7 @@
 #include <assert.h>
 
 #include <nuttx/mm/mm.h>
+#include <nuttx/sched_note.h>
 
 #include "mm_heap/mm.h"
 #include "kasan/kasan.h"
@@ -380,10 +381,12 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
           heap->mm_maxused = heap->mm_curused;
         }
 
+      sched_note_heap(false, heap, oldmem, oldsize);
+      sched_note_heap(true, heap, newmem, newsize);
       mm_unlock(heap);
       MM_ADD_BACKTRACE(heap, (FAR char *)newmem - MM_SIZEOF_ALLOCNODE);
 
-      kasan_unpoison(newmem, mm_malloc_size(heap, newmem));
+      kasan_unpoison(newmem, newsize);
       if (newmem != oldmem)
         {
           /* Now we have to move the user contents 'down' in memory.  memcpy

--- a/mm/tlsf/mm_tlsf.c
+++ b/mm/tlsf/mm_tlsf.c
@@ -40,6 +40,7 @@
 #include <nuttx/mm/mm.h>
 #include <nuttx/sched.h>
 #include <nuttx/mm/mempool.h>
+#include <nuttx/sched_note.h>
 
 #include "tlsf/tlsf.h"
 #include "kasan/kasan.h"
@@ -491,15 +492,16 @@ static void mm_delayfree(FAR struct mm_heap_s *heap, FAR void *mem,
 {
   if (mm_lock(heap) == 0)
     {
+      size_t size = mm_malloc_size(heap, mem);
 #ifdef CONFIG_MM_FILL_ALLOCATIONS
       memset(mem, MM_FREE_MAGIC, mm_malloc_size(heap, mem));
 #endif
 
-      kasan_poison(mem, mm_malloc_size(heap, mem));
+      kasan_poison(mem, size);
 
       /* Update heap statistics */
 
-      heap->mm_curused -= mm_malloc_size(heap, mem);
+      heap->mm_curused -= size;
 
       /* Pass, return to the tlsf pool */
 
@@ -509,6 +511,7 @@ static void mm_delayfree(FAR struct mm_heap_s *heap, FAR void *mem,
         }
       else
         {
+          sched_note_heap(false, heap, mem, size);
           tlsf_free(heap->mm_tlsf, mem);
         }
 
@@ -1133,6 +1136,7 @@ size_t mm_malloc_size(FAR struct mm_heap_s *heap, FAR void *mem)
 
 FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
 {
+  size_t nodesize;
   FAR void *ret;
 
   /* In case of zero-length allocations allocate the minimum size object */
@@ -1167,7 +1171,8 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
   ret = tlsf_malloc(heap->mm_tlsf, size);
 #endif
 
-  heap->mm_curused += mm_malloc_size(heap, ret);
+  nodesize = mm_malloc_size(heap, ret);
+  heap->mm_curused += nodesize;
   if (heap->mm_curused > heap->mm_maxused)
     {
       heap->mm_maxused = heap->mm_curused;
@@ -1178,11 +1183,13 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
   if (ret)
     {
 #if CONFIG_MM_BACKTRACE >= 0
-      FAR struct memdump_backtrace_s *buf = ret + mm_malloc_size(heap, ret);
+      FAR struct memdump_backtrace_s *buf = ret + nodesize;
 
       memdump_backtrace(heap, buf);
 #endif
-      kasan_unpoison(ret, mm_malloc_size(heap, ret));
+
+      kasan_unpoison(ret, nodesize);
+      sched_note_heap(true, heap, ret, nodesize);
 
 #ifdef CONFIG_MM_FILL_ALLOCATIONS
       memset(ret, 0xaa, nodesize);
@@ -1217,6 +1224,7 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
 FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment,
                       size_t size)
 {
+  size_t nodesize;
   FAR void *ret;
 
 #ifdef CONFIG_MM_HEAP_MEMPOOL
@@ -1244,7 +1252,8 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment,
   ret = tlsf_memalign(heap->mm_tlsf, alignment, size);
 #endif
 
-  heap->mm_curused += mm_malloc_size(heap, ret);
+  nodesize = mm_malloc_size(heap, ret);
+  heap->mm_curused += nodesize;
   if (heap->mm_curused > heap->mm_maxused)
     {
       heap->mm_maxused = heap->mm_curused;
@@ -1255,11 +1264,12 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment,
   if (ret)
     {
 #if CONFIG_MM_BACKTRACE >= 0
-      FAR struct memdump_backtrace_s *buf = ret + mm_malloc_size(heap, ret);
+      FAR struct memdump_backtrace_s *buf = ret + nodesize;
 
       memdump_backtrace(heap, buf);
 #endif
-      kasan_unpoison(ret, mm_malloc_size(heap, ret));
+      kasan_unpoison(ret, nodesize);
+      sched_note_heap(true, heap, ret, nodesize);
     }
 
 #if CONFIG_MM_FREE_DELAYCOUNT_MAX > 0
@@ -1301,6 +1311,8 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
                      size_t size)
 {
   FAR void *newmem;
+  size_t oldsize;
+  size_t newsize;
 
   /* If oldmem is NULL, then realloc is equivalent to malloc */
 
@@ -1360,7 +1372,8 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
   /* Allocate from the tlsf pool */
 
   DEBUGVERIFY(mm_lock(heap));
-  heap->mm_curused -= mm_malloc_size(heap, oldmem);
+  oldsize = mm_malloc_size(heap, oldmem);
+  heap->mm_curused -= oldsize;
 #if CONFIG_MM_BACKTRACE >= 0
   newmem = tlsf_realloc(heap->mm_tlsf, oldmem, size +
                         sizeof(struct memdump_backtrace_s));
@@ -1368,7 +1381,8 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
   newmem = tlsf_realloc(heap->mm_tlsf, oldmem, size);
 #endif
 
-  heap->mm_curused += mm_malloc_size(heap, newmem ? newmem : oldmem);
+  newsize = mm_malloc_size(heap, newmem);
+  heap->mm_curused += newmem ? newsize : oldsize;
   if (heap->mm_curused > heap->mm_maxused)
     {
       heap->mm_maxused = heap->mm_curused;
@@ -1376,20 +1390,21 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
 
   mm_unlock(heap);
 
-#if CONFIG_MM_BACKTRACE >= 0
   if (newmem)
     {
-      FAR struct memdump_backtrace_s *buf =
-        newmem + mm_malloc_size(heap, newmem);
-
+#if CONFIG_MM_BACKTRACE >= 0
+      FAR struct memdump_backtrace_s *buf = newmem + newsize;
       memdump_backtrace(heap, buf);
-    }
 #endif
+
+      sched_note_heap(false, heap, oldmem, oldsize);
+      sched_note_heap(true, heap, newmem, newsize);
+    }
 
 #if CONFIG_MM_FREE_DELAYCOUNT_MAX > 0
   /* Try again after free delay list */
 
-  if (newmem == NULL && free_delaylist(heap, true))
+  else if (free_delaylist(heap, true))
     {
       return mm_realloc(heap, oldmem, size);
     }

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -1286,6 +1286,14 @@ config SCHED_INSTRUMENTATION_IRQHANDLER
 
 			void sched_note_irqhandler(int irq, FAR void *handler, bool enter);
 
+config SCHED_INSTRUMENTATION_HEAP
+	bool "Heap monitor hooks"
+	default n
+	---help---
+		Enables additional hooks for heap allocation.
+
+			void sched_note_heap(bool alloc, FAR void* heap, FAR void *mem, size_t size)
+
 config SCHED_INSTRUMENTATION_DUMP
 	bool "Use note dump for instrumentation"
 	default n


### PR DESCRIPTION
## Summary
note/note_driver.c:1405:11: runtime error: null pointer passed as argument 2, which is declared to never be null
    #0 0x33bf5cc in sched_note_event_ip note/note_driver.c:1405
    #1 0x33bfb57 in note_driver_instrument_enter note/note_initialize.c:55
    #2 0x347b084 in __cyg_profile_func_enter misc/lib_instrument.c:68
    #3 0x34179de in binder_initialize binder/binder.c:669
    #4 0x339a936 in drivers_initialize nuttx/drivers/drivers_initialize.c:242
    #5 0x335a179 in nx_start init/nx_start.c:632
    #6 0x32f755c in main sim/sim_head.c:180
    #7 0xf6821518  (/lib/i386-linux-gnu/libc.so.6+0x21518) (BuildId: 7f64b917aaa97b9680d8e44931bf7611c5a1f036)
    #8 0xf68215f2 in __libc_start_main (/lib/i386-linux-gnu/libc.so.6+0x215f2) (BuildId: 7f64b917aaa97b9680d8e44931bf7611c5a1f036)
    #9 0x32b401a in _start (nuttx/nuttx+0x32b401a) (BuildId: 33f8f7b361d44a008de87fea1bc970b22b48b700)

## Impact

## Testing

