### PR TITLE
minidumpserver: fix parsing bug

### DIFF
--- a/tools/minidumpserver.py
+++ b/tools/minidumpserver.py
@@ -699,11 +699,10 @@ def auto_parse_log_file(logfile):
         start = False
         for line in f.readlines():
             line = line.strip()
-            if (
-                "up_dump_register" in line
-                or "dump_stack" in line
-                or "stack_dump" in line
-            ):
+            if len(line) == 0:
+                continue
+
+            if "up_dump_register" in line or "stack" in line:
                 start = True
             else:
                 if start:


### PR DESCRIPTION
## Summary

stack dump add new region `show stacks`, but this script is not support now this is fixed with adding check condition for all lines contains stack word

## Impact

## Testing

