### PR TITLE
nuttx/boards:Uniform initialization format for init_array.

### DIFF
--- a/binfmt/libelf/gnu-elf.ld
+++ b/binfmt/libelf/gnu-elf.ld
@@ -73,9 +73,8 @@ SECTIONS
   .ctors :
     {
       _sctors = . ;
-      *(.ctors)       /* Old ABI:  Unallocated */
-      *(.init_array)  /* New ABI:  Allocated */
-      *(SORT(.init_array.*))
+      KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+      KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
       _ectors = . ;
     }
 

--- a/boards/arm/a1x/pcduino-a10/scripts/sdram.ld
+++ b/boards/arm/a1x/pcduino-a10/scripts/sdram.ld
@@ -55,7 +55,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > sdram
 

--- a/boards/arm/am335x/beaglebone-black/scripts/sdram.ld
+++ b/boards/arm/am335x/beaglebone-black/scripts/sdram.ld
@@ -60,7 +60,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > ddr
 

--- a/boards/arm/at32/at32f437-mini/scripts/kernel-space.ld
+++ b/boards/arm/at32/at32f437-mini/scripts/kernel-space.ld
@@ -44,7 +44,8 @@ SECTIONS
 
     .init_section : {
         _sinit = ABSOLUTE(.);
-        *(.init_array .init_array.*)
+        KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > kflash
 

--- a/boards/arm/at32/at32f437-mini/scripts/ld.script
+++ b/boards/arm/at32/at32f437-mini/scripts/ld.script
@@ -61,7 +61,8 @@ SECTIONS
 
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
-        KEEP(*(.init_array .init_array.*))
+        KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/at32/at32f437-mini/scripts/user-space.ld
+++ b/boards/arm/at32/at32f437-mini/scripts/user-space.ld
@@ -46,7 +46,8 @@ SECTIONS
 
     .init_section : {
         _sinit = ABSOLUTE(.);
-        *(.init_array .init_array.*)
+        KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > uflash
 

--- a/boards/arm/cxd56xx/spresense/scripts/ramconfig-new.ld
+++ b/boards/arm/cxd56xx/spresense/scripts/ramconfig-new.ld
@@ -94,7 +94,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > ram
 

--- a/boards/arm/cxd56xx/spresense/scripts/ramconfig.ld
+++ b/boards/arm/cxd56xx/spresense/scripts/ramconfig.ld
@@ -94,7 +94,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > ram
 

--- a/boards/arm/efm32/efm32-g8xx-stk/scripts/efm32-g8xx-stk.ld
+++ b/boards/arm/efm32/efm32-g8xx-stk/scripts/efm32-g8xx-stk.ld
@@ -49,7 +49,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/efm32/efm32gg-stk3700/scripts/ld.script
+++ b/boards/arm/efm32/efm32gg-stk3700/scripts/ld.script
@@ -49,7 +49,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/efm32/olimex-efm32g880f128-stk/scripts/ld.script
+++ b/boards/arm/efm32/olimex-efm32g880f128-stk/scripts/ld.script
@@ -49,7 +49,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/eoss3/quickfeather/scripts/ld.script
+++ b/boards/arm/eoss3/quickfeather/scripts/ld.script
@@ -55,7 +55,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/fvp-v8r-aarch32/fvp-armv8r-aarch32/scripts/dramboot.ld
+++ b/boards/arm/fvp-v8r-aarch32/fvp-armv8r-aarch32/scripts/dramboot.ld
@@ -54,7 +54,8 @@ SECTIONS
     .init_section :
     {
         _sinit = ABSOLUTE(.);
-        *(.init_array .init_array.*)
+        KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > FLASH
 

--- a/boards/arm/gd32f4/gd32f450zk-eval/scripts/kernel-space.ld
+++ b/boards/arm/gd32f4/gd32f450zk-eval/scripts/kernel-space.ld
@@ -46,7 +46,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > kflash
 

--- a/boards/arm/gd32f4/gd32f450zk-eval/scripts/ld.script
+++ b/boards/arm/gd32f4/gd32f450zk-eval/scripts/ld.script
@@ -62,7 +62,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/gd32f4/gd32f450zk-eval/scripts/user-space.ld
+++ b/boards/arm/gd32f4/gd32f450zk-eval/scripts/user-space.ld
@@ -60,7 +60,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > uflash
 

--- a/boards/arm/gd32f4/gd32f470zk-eval/scripts/kernel-space.ld
+++ b/boards/arm/gd32f4/gd32f470zk-eval/scripts/kernel-space.ld
@@ -46,7 +46,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > kflash
 

--- a/boards/arm/gd32f4/gd32f470zk-eval/scripts/ld.script
+++ b/boards/arm/gd32f4/gd32f470zk-eval/scripts/ld.script
@@ -62,7 +62,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/gd32f4/gd32f470zk-eval/scripts/user-space.ld
+++ b/boards/arm/gd32f4/gd32f470zk-eval/scripts/user-space.ld
@@ -60,7 +60,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > uflash
 

--- a/boards/arm/imx6/sabre-6quad/scripts/dramboot.ld
+++ b/boards/arm/imx6/sabre-6quad/scripts/dramboot.ld
@@ -61,7 +61,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > ddr3
 

--- a/boards/arm/imx6/sabre-6quad/scripts/dramboot.sct
+++ b/boards/arm/imx6/sabre-6quad/scripts/dramboot.sct
@@ -59,8 +59,8 @@ OSCRAM_SECTIONS DDR3_START DDR3_SIZE
 
   init_section AlignExpr(ImageLimit(text), 0x4)
     {
-      *(.init_array)
-      *(.init_array.*)
+      KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+      KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
     }
 
   ARM.extab AlignExpr(ImageLimit(init_section), 0x4)

--- a/boards/arm/imxrt/imxrt1020-evk/scripts/flash-ocram.ld
+++ b/boards/arm/imxrt/imxrt1020-evk/scripts/flash-ocram.ld
@@ -78,7 +78,7 @@ SECTIONS
 	{
 		_sinit = ABSOLUTE(.);
 		KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-		KEEP(*(.init_array .ctors))
+		KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
 		_einit = ABSOLUTE(.);
 	} > flash
 

--- a/boards/arm/imxrt/imxrt1050-evk/scripts/flash-ocram.ld
+++ b/boards/arm/imxrt/imxrt1050-evk/scripts/flash-ocram.ld
@@ -77,7 +77,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/imxrt/imxrt1050-evk/scripts/kernel-space.ld
+++ b/boards/arm/imxrt/imxrt1050-evk/scripts/kernel-space.ld
@@ -49,7 +49,7 @@ SECTIONS
   {
     _sinit = ABSOLUTE(.);
     KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-    KEEP(*(.init_array .ctors))
+    KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
     _einit = ABSOLUTE(.);
   } > kflash
 

--- a/boards/arm/imxrt/imxrt1050-evk/scripts/user-space.ld
+++ b/boards/arm/imxrt/imxrt1050-evk/scripts/user-space.ld
@@ -63,7 +63,7 @@ SECTIONS
   {
     _sinit = ABSOLUTE(.);
     KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-    KEEP(*(.init_array .ctors))
+    KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
     _einit = ABSOLUTE(.);
   } > uflash
 

--- a/boards/arm/imxrt/imxrt1060-evk/scripts/flash-ocram.ld
+++ b/boards/arm/imxrt/imxrt1060-evk/scripts/flash-ocram.ld
@@ -123,7 +123,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/imxrt/imxrt1060-evk/scripts/flash.ld
+++ b/boards/arm/imxrt/imxrt1060-evk/scripts/flash.ld
@@ -76,7 +76,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/imxrt/imxrt1060-evk/scripts/kernel-space.ld
+++ b/boards/arm/imxrt/imxrt1060-evk/scripts/kernel-space.ld
@@ -70,7 +70,7 @@ SECTIONS
   {
     _sinit = ABSOLUTE(.);
     KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-    KEEP(*(.init_array .ctors))
+    KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
     _einit = ABSOLUTE(.);
   } > kflash
 

--- a/boards/arm/imxrt/imxrt1060-evk/scripts/user-space.ld
+++ b/boards/arm/imxrt/imxrt1060-evk/scripts/user-space.ld
@@ -63,7 +63,7 @@ SECTIONS
   {
     _sinit = ABSOLUTE(.);
     KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-    KEEP(*(.init_array .ctors))
+    KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
     _einit = ABSOLUTE(.);
   } > uflash
 

--- a/boards/arm/imxrt/imxrt1064-evk/scripts/flash-mcuboot-app.ld
+++ b/boards/arm/imxrt/imxrt1064-evk/scripts/flash-mcuboot-app.ld
@@ -55,7 +55,8 @@ SECTIONS
     .init_section :
     {
         _sinit = ABSOLUTE(.);
-        *(.init_array .init_array.*)
+        KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/imxrt/imxrt1064-evk/scripts/flash-mcuboot-loader.ld
+++ b/boards/arm/imxrt/imxrt1064-evk/scripts/flash-mcuboot-loader.ld
@@ -75,7 +75,8 @@ SECTIONS
     .init_section :
     {
         _sinit = ABSOLUTE(.);
-        *(.init_array .init_array.*)
+        KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/imxrt/imxrt1064-evk/scripts/flash-ocram.ld
+++ b/boards/arm/imxrt/imxrt1064-evk/scripts/flash-ocram.ld
@@ -123,7 +123,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/imxrt/imxrt1064-evk/scripts/flash.ld
+++ b/boards/arm/imxrt/imxrt1064-evk/scripts/flash.ld
@@ -76,7 +76,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/imxrt/imxrt1064-evk/scripts/kernel-space.ld
+++ b/boards/arm/imxrt/imxrt1064-evk/scripts/kernel-space.ld
@@ -49,7 +49,7 @@ SECTIONS
   {
     _sinit = ABSOLUTE(.);
     KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-    KEEP(*(.init_array .ctors))
+    KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
     _einit = ABSOLUTE(.);
   } > kflash
 

--- a/boards/arm/imxrt/imxrt1064-evk/scripts/user-space.ld
+++ b/boards/arm/imxrt/imxrt1064-evk/scripts/user-space.ld
@@ -63,7 +63,7 @@ SECTIONS
   {
     _sinit = ABSOLUTE(.);
     KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-    KEEP(*(.init_array .ctors))
+    KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
     _einit = ABSOLUTE(.);
   } > uflash
 

--- a/boards/arm/imxrt/teensy-4.x/scripts/flash-ocram.ld
+++ b/boards/arm/imxrt/teensy-4.x/scripts/flash-ocram.ld
@@ -123,7 +123,7 @@ SECTIONS
 	{
 		_sinit = ABSOLUTE(.);
 		KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-		KEEP(*(.init_array .ctors))
+		KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
 		_einit = ABSOLUTE(.);
 	} > flash
 

--- a/boards/arm/imxrt/teensy-4.x/scripts/flash.ld
+++ b/boards/arm/imxrt/teensy-4.x/scripts/flash.ld
@@ -76,7 +76,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/imxrt/teensy-4.x/scripts/kernel-space.ld
+++ b/boards/arm/imxrt/teensy-4.x/scripts/kernel-space.ld
@@ -49,7 +49,7 @@ SECTIONS
   {
     _sinit = ABSOLUTE(.);
     KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-    KEEP(*(.init_array .ctors))
+    KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
     _einit = ABSOLUTE(.);
   } > kflash
 

--- a/boards/arm/imxrt/teensy-4.x/scripts/user-space.ld
+++ b/boards/arm/imxrt/teensy-4.x/scripts/user-space.ld
@@ -63,7 +63,7 @@ SECTIONS
   {
     _sinit = ABSOLUTE(.);
     KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-    KEEP(*(.init_array .ctors))
+    KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
     _einit = ABSOLUTE(.);
   } > uflash
 

--- a/boards/arm/kinetis/freedom-k28f/scripts/flash.ld
+++ b/boards/arm/kinetis/freedom-k28f/scripts/flash.ld
@@ -85,7 +85,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progflash
 

--- a/boards/arm/kinetis/freedom-k64f/scripts/flash.ld
+++ b/boards/arm/kinetis/freedom-k64f/scripts/flash.ld
@@ -73,7 +73,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progflash
 

--- a/boards/arm/kinetis/freedom-k66f/scripts/flash.ld
+++ b/boards/arm/kinetis/freedom-k66f/scripts/flash.ld
@@ -69,7 +69,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progflash
 

--- a/boards/arm/kinetis/kwikstik-k40/scripts/kwikstik-k40.ld
+++ b/boards/arm/kinetis/kwikstik-k40/scripts/kwikstik-k40.ld
@@ -73,7 +73,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progflash
 

--- a/boards/arm/kinetis/teensy-3.x/scripts/mk20dx128vlh5.ld
+++ b/boards/arm/kinetis/teensy-3.x/scripts/mk20dx128vlh5.ld
@@ -73,7 +73,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progflash
 

--- a/boards/arm/kinetis/teensy-3.x/scripts/mk20dx256vlh7.ld
+++ b/boards/arm/kinetis/teensy-3.x/scripts/mk20dx256vlh7.ld
@@ -73,7 +73,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progflash
 

--- a/boards/arm/kinetis/twr-k60n512/scripts/twr-k60n512.ld
+++ b/boards/arm/kinetis/twr-k60n512/scripts/twr-k60n512.ld
@@ -73,7 +73,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progflash
 

--- a/boards/arm/kinetis/twr-k64f120m/scripts/ld.script
+++ b/boards/arm/kinetis/twr-k64f120m/scripts/ld.script
@@ -73,7 +73,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progflash
 

--- a/boards/arm/kl/freedom-kl25z/scripts/freedom-kl25z.ld
+++ b/boards/arm/kl/freedom-kl25z/scripts/freedom-kl25z.ld
@@ -64,7 +64,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progflash
 

--- a/boards/arm/kl/freedom-kl26z/scripts/freedom-kl26z.ld
+++ b/boards/arm/kl/freedom-kl26z/scripts/freedom-kl26z.ld
@@ -64,7 +64,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progflash
 

--- a/boards/arm/kl/teensy-lc/scripts/teensy-lc.ld
+++ b/boards/arm/kl/teensy-lc/scripts/teensy-lc.ld
@@ -64,7 +64,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progflash
 

--- a/boards/arm/lc823450/lc823450-xgevk/scripts/ld-ipl2.script
+++ b/boards/arm/lc823450/lc823450-xgevk/scripts/ld-ipl2.script
@@ -50,7 +50,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/arm/lc823450/lc823450-xgevk/scripts/ld-spif-boot.script
+++ b/boards/arm/lc823450/lc823450-xgevk/scripts/ld-spif-boot.script
@@ -51,7 +51,7 @@ SECTIONS
     {
       _sinit = ABSOLUTE(.);
       KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-      KEEP(*(.init_array .ctors))
+      KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
       _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/lc823450/lc823450-xgevk/scripts/ld.script
+++ b/boards/arm/lc823450/lc823450-xgevk/scripts/ld.script
@@ -58,7 +58,7 @@ SECTIONS
     {
       _sinit = ABSOLUTE(.);
       KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-      KEEP(*(.init_array .ctors))
+      KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
       _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/arm/lc823450/lc823450-xgevk/scripts/user-space.ld
+++ b/boards/arm/lc823450/lc823450-xgevk/scripts/user-space.ld
@@ -47,7 +47,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > uflash
 

--- a/boards/arm/lpc17xx_40xx/lincoln60/scripts/ld.script
+++ b/boards/arm/lpc17xx_40xx/lincoln60/scripts/ld.script
@@ -55,7 +55,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/lpc17xx_40xx/lpc4088-devkit/scripts/kernel-space.ld
+++ b/boards/arm/lpc17xx_40xx/lpc4088-devkit/scripts/kernel-space.ld
@@ -46,7 +46,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > kflash
 

--- a/boards/arm/lpc17xx_40xx/lpc4088-devkit/scripts/ld.script
+++ b/boards/arm/lpc17xx_40xx/lpc4088-devkit/scripts/ld.script
@@ -61,7 +61,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > FLASH
 

--- a/boards/arm/lpc17xx_40xx/lpc4088-devkit/scripts/user-space.ld
+++ b/boards/arm/lpc17xx_40xx/lpc4088-devkit/scripts/user-space.ld
@@ -47,7 +47,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > uflash
 

--- a/boards/arm/lpc17xx_40xx/lpc4088-quickstart/scripts/kernel-space.ld
+++ b/boards/arm/lpc17xx_40xx/lpc4088-quickstart/scripts/kernel-space.ld
@@ -46,7 +46,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > kflash
 

--- a/boards/arm/lpc17xx_40xx/lpc4088-quickstart/scripts/ld.script
+++ b/boards/arm/lpc17xx_40xx/lpc4088-quickstart/scripts/ld.script
@@ -61,7 +61,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > FLASH
 

--- a/boards/arm/lpc17xx_40xx/lpc4088-quickstart/scripts/user-space.ld
+++ b/boards/arm/lpc17xx_40xx/lpc4088-quickstart/scripts/user-space.ld
@@ -47,7 +47,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > uflash
 

--- a/boards/arm/lpc17xx_40xx/lpcxpresso-lpc1768/scripts/ld.script
+++ b/boards/arm/lpc17xx_40xx/lpcxpresso-lpc1768/scripts/ld.script
@@ -55,7 +55,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/lpc17xx_40xx/lx_cpu/scripts/kernel-space.ld
+++ b/boards/arm/lpc17xx_40xx/lx_cpu/scripts/kernel-space.ld
@@ -46,7 +46,7 @@ SECTIONS
     .init_section :  ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > kflash
 

--- a/boards/arm/lpc17xx_40xx/lx_cpu/scripts/link-flash-app.ld
+++ b/boards/arm/lpc17xx_40xx/lx_cpu/scripts/link-flash-app.ld
@@ -65,7 +65,7 @@ SECTIONS
     .init_section : ALIGN(16) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > FLASH
 

--- a/boards/arm/lpc17xx_40xx/lx_cpu/scripts/link-flash-boot.ld
+++ b/boards/arm/lpc17xx_40xx/lx_cpu/scripts/link-flash-boot.ld
@@ -63,7 +63,7 @@ SECTIONS
     .init_section : ALIGN(16) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > FLASH
 

--- a/boards/arm/lpc17xx_40xx/lx_cpu/scripts/link-sdram.ld
+++ b/boards/arm/lpc17xx_40xx/lx_cpu/scripts/link-sdram.ld
@@ -66,7 +66,7 @@ SECTIONS
     .init_section : ALIGN(16) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > SDRAM
 

--- a/boards/arm/lpc17xx_40xx/lx_cpu/scripts/user-space.ld
+++ b/boards/arm/lpc17xx_40xx/lx_cpu/scripts/user-space.ld
@@ -47,7 +47,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > uflash
 

--- a/boards/arm/lpc17xx_40xx/mbed/scripts/ld.script
+++ b/boards/arm/lpc17xx_40xx/mbed/scripts/ld.script
@@ -55,7 +55,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/lpc17xx_40xx/mcb1700/scripts/ld.script
+++ b/boards/arm/lpc17xx_40xx/mcb1700/scripts/ld.script
@@ -55,7 +55,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/lpc17xx_40xx/olimex-lpc1766stk/scripts/ld.script
+++ b/boards/arm/lpc17xx_40xx/olimex-lpc1766stk/scripts/ld.script
@@ -55,7 +55,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/lpc17xx_40xx/open1788/scripts/kernel-space.ld
+++ b/boards/arm/lpc17xx_40xx/open1788/scripts/kernel-space.ld
@@ -46,7 +46,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > kflash
 

--- a/boards/arm/lpc17xx_40xx/open1788/scripts/ld.script
+++ b/boards/arm/lpc17xx_40xx/open1788/scripts/ld.script
@@ -61,7 +61,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > FLASH
 

--- a/boards/arm/lpc17xx_40xx/open1788/scripts/user-space.ld
+++ b/boards/arm/lpc17xx_40xx/open1788/scripts/user-space.ld
@@ -47,7 +47,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > uflash
 

--- a/boards/arm/lpc17xx_40xx/pnev5180b/scripts/kernel-space.ld
+++ b/boards/arm/lpc17xx_40xx/pnev5180b/scripts/kernel-space.ld
@@ -46,7 +46,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > kflash
 

--- a/boards/arm/lpc17xx_40xx/pnev5180b/scripts/user-space.ld
+++ b/boards/arm/lpc17xx_40xx/pnev5180b/scripts/user-space.ld
@@ -47,7 +47,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > uflash
 

--- a/boards/arm/lpc17xx_40xx/u-blox-c027/scripts/u-blox-c027.ld
+++ b/boards/arm/lpc17xx_40xx/u-blox-c027/scripts/u-blox-c027.ld
@@ -55,7 +55,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/lpc214x/mcu123-lpc214x/scripts/ld.script
+++ b/boards/arm/lpc214x/mcu123-lpc214x/scripts/ld.script
@@ -58,7 +58,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/lpc214x/zp214xpa/scripts/ld.script
+++ b/boards/arm/lpc214x/zp214xpa/scripts/ld.script
@@ -58,7 +58,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/lpc2378/olimex-lpc2378/scripts/ld.script
+++ b/boards/arm/lpc2378/olimex-lpc2378/scripts/ld.script
@@ -69,7 +69,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > ROM
 

--- a/boards/arm/lpc31xx/ea3131/scripts/ld.script
+++ b/boards/arm/lpc31xx/ea3131/scripts/ld.script
@@ -52,7 +52,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > isram
 

--- a/boards/arm/lpc31xx/ea3131/scripts/pg-ld.script
+++ b/boards/arm/lpc31xx/ea3131/scripts/pg-ld.script
@@ -81,7 +81,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > locked
 

--- a/boards/arm/lpc31xx/ea3152/scripts/ea3152.ld
+++ b/boards/arm/lpc31xx/ea3152/scripts/ea3152.ld
@@ -52,7 +52,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > isram
 

--- a/boards/arm/lpc31xx/olimex-lpc-h3131/scripts/ld.script
+++ b/boards/arm/lpc31xx/olimex-lpc-h3131/scripts/ld.script
@@ -52,7 +52,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > isram
 

--- a/boards/arm/lpc43xx/bambino-200e/scripts/ramconfig.ld
+++ b/boards/arm/lpc43xx/bambino-200e/scripts/ramconfig.ld
@@ -90,7 +90,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/arm/lpc43xx/bambino-200e/scripts/spificonfig.ld
+++ b/boards/arm/lpc43xx/bambino-200e/scripts/spificonfig.ld
@@ -86,7 +86,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/arm/lpc43xx/bambino-200e/scripts/user-space.ld
+++ b/boards/arm/lpc43xx/bambino-200e/scripts/user-space.ld
@@ -47,7 +47,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > uflash
 

--- a/boards/arm/lpc43xx/lpc4330-xplorer/scripts/ramconfig.ld
+++ b/boards/arm/lpc43xx/lpc4330-xplorer/scripts/ramconfig.ld
@@ -90,7 +90,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/arm/lpc43xx/lpc4330-xplorer/scripts/spificonfig.ld
+++ b/boards/arm/lpc43xx/lpc4330-xplorer/scripts/spificonfig.ld
@@ -86,7 +86,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/arm/lpc43xx/lpc4337-ws/scripts/flashaconfig.ld
+++ b/boards/arm/lpc43xx/lpc4337-ws/scripts/flashaconfig.ld
@@ -91,7 +91,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/arm/lpc43xx/lpc4337-ws/scripts/ramconfig.ld
+++ b/boards/arm/lpc43xx/lpc4337-ws/scripts/ramconfig.ld
@@ -90,7 +90,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/arm/lpc43xx/lpc4357-evb/scripts/flashaconfig.ld
+++ b/boards/arm/lpc43xx/lpc4357-evb/scripts/flashaconfig.ld
@@ -91,7 +91,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/arm/lpc43xx/lpc4357-evb/scripts/ramconfig.ld
+++ b/boards/arm/lpc43xx/lpc4357-evb/scripts/ramconfig.ld
@@ -80,7 +80,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/arm/lpc43xx/lpc4357-evb/scripts/spificonfig.ld
+++ b/boards/arm/lpc43xx/lpc4357-evb/scripts/spificonfig.ld
@@ -70,7 +70,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/arm/lpc43xx/lpc4370-link2/scripts/ramconfig.ld
+++ b/boards/arm/lpc43xx/lpc4370-link2/scripts/ramconfig.ld
@@ -90,7 +90,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/arm/lpc43xx/lpc4370-link2/scripts/spificonfig.ld
+++ b/boards/arm/lpc43xx/lpc4370-link2/scripts/spificonfig.ld
@@ -86,7 +86,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/arm/lpc54xx/lpcxpresso-lpc54628/scripts/flash.ld
+++ b/boards/arm/lpc54xx/lpcxpresso-lpc54628/scripts/flash.ld
@@ -54,7 +54,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/arm/max326xx/max32660-evsys/scripts/flash.ld
+++ b/boards/arm/max326xx/max32660-evsys/scripts/flash.ld
@@ -53,7 +53,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/max326xx/max32660-evsys/scripts/sram.ld
+++ b/boards/arm/max326xx/max32660-evsys/scripts/sram.ld
@@ -53,7 +53,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/moxart/moxa/scripts/moxa.ld
+++ b/boards/arm/moxart/moxa/scripts/moxa.ld
@@ -51,7 +51,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > sram0
 

--- a/boards/arm/mps/mps3-an547/scripts/flash.ld
+++ b/boards/arm/mps/mps3-an547/scripts/flash.ld
@@ -50,7 +50,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/mx8mp/verdin-mx8mp/scripts/ddr.ld
+++ b/boards/arm/mx8mp/verdin-mx8mp/scripts/ddr.ld
@@ -66,7 +66,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/mx8mp/verdin-mx8mp/scripts/itcm.ld
+++ b/boards/arm/mx8mp/verdin-mx8mp/scripts/itcm.ld
@@ -64,7 +64,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/nrf52/arduino-nano-33ble-rev2/scripts/flash_config.ld
+++ b/boards/arm/nrf52/arduino-nano-33ble-rev2/scripts/flash_config.ld
@@ -58,7 +58,8 @@ SECTIONS
     .init_section :
     {
         _sinit = ABSOLUTE(.);
-        *(.init_array .init_array.*)
+        KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/arm/nrf52/arduino-nano-33ble/scripts/flash_config.ld
+++ b/boards/arm/nrf52/arduino-nano-33ble/scripts/flash_config.ld
@@ -58,7 +58,8 @@ SECTIONS
     .init_section :
     {
         _sinit = ABSOLUTE(.);
-        *(.init_array .init_array.*)
+        KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/arm/nrf52/common/scripts/flash_config.ld
+++ b/boards/arm/nrf52/common/scripts/flash_config.ld
@@ -70,7 +70,8 @@ SECTIONS
     .init_section :
     {
         _sinit = ABSOLUTE(.);
-        *(.init_array .init_array.*)
+        KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/arm/nrf52/nrf52-feather/scripts/flash_config.ld
+++ b/boards/arm/nrf52/nrf52-feather/scripts/flash_config.ld
@@ -50,7 +50,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/arm/nrf52/nrf52832-dk/scripts/flash_config.ld
+++ b/boards/arm/nrf52/nrf52832-dk/scripts/flash_config.ld
@@ -50,7 +50,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/arm/nrf52/nrf52832-mdk/scripts/flash_config.ld
+++ b/boards/arm/nrf52/nrf52832-mdk/scripts/flash_config.ld
@@ -49,7 +49,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/arm/nrf52/nrf52832-sparkfun/scripts/flash_config.ld
+++ b/boards/arm/nrf52/nrf52832-sparkfun/scripts/flash_config.ld
@@ -50,7 +50,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/arm/nrf52/nrf52840-dk/scripts/flash_config.ld
+++ b/boards/arm/nrf52/nrf52840-dk/scripts/flash_config.ld
@@ -50,7 +50,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/arm/nrf52/nrf52840-dongle/scripts/flash_config.ld
+++ b/boards/arm/nrf52/nrf52840-dongle/scripts/flash_config.ld
@@ -50,7 +50,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/arm/nrf52/nrf9160-dk-nrf52/scripts/flash_config.ld
+++ b/boards/arm/nrf52/nrf9160-dk-nrf52/scripts/flash_config.ld
@@ -50,7 +50,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/arm/nrf52/thingy52/scripts/flash_config.ld
+++ b/boards/arm/nrf52/thingy52/scripts/flash_config.ld
@@ -50,7 +50,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/arm/nrf52/thingy91-nrf52/scripts/flash_config.ld
+++ b/boards/arm/nrf52/thingy91-nrf52/scripts/flash_config.ld
@@ -50,7 +50,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/arm/nrf53/common/scripts/flash_app.ld
+++ b/boards/arm/nrf53/common/scripts/flash_app.ld
@@ -81,7 +81,8 @@ SECTIONS
     .init_section :
     {
         _sinit = ABSOLUTE(.);
-        *(.init_array .init_array.*)
+        KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/arm/nrf53/common/scripts/flash_net.ld
+++ b/boards/arm/nrf53/common/scripts/flash_net.ld
@@ -86,7 +86,8 @@ SECTIONS
     .init_section :
     {
         _sinit = ABSOLUTE(.);
-        *(.init_array .init_array.*)
+        KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/arm/nrf53/nrf5340-audio-dk/scripts/flash_app.ld
+++ b/boards/arm/nrf53/nrf5340-audio-dk/scripts/flash_app.ld
@@ -58,7 +58,8 @@ SECTIONS
     .init_section :
     {
         _sinit = ABSOLUTE(.);
-        *(.init_array .init_array.*)
+        KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/arm/nrf53/nrf5340-audio-dk/scripts/flash_net.ld
+++ b/boards/arm/nrf53/nrf5340-audio-dk/scripts/flash_net.ld
@@ -59,7 +59,8 @@ SECTIONS
     .init_section :
     {
         _sinit = ABSOLUTE(.);
-        *(.init_array .init_array.*)
+        KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/arm/nrf53/nrf5340-dk/scripts/flash_app.ld
+++ b/boards/arm/nrf53/nrf5340-dk/scripts/flash_app.ld
@@ -58,7 +58,8 @@ SECTIONS
     .init_section :
     {
         _sinit = ABSOLUTE(.);
-        *(.init_array .init_array.*)
+        KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/arm/nrf53/nrf5340-dk/scripts/flash_net.ld
+++ b/boards/arm/nrf53/nrf5340-dk/scripts/flash_net.ld
@@ -59,7 +59,8 @@ SECTIONS
     .init_section :
     {
         _sinit = ABSOLUTE(.);
-        *(.init_array .init_array.*)
+        KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/arm/nrf53/thingy53/scripts/flash_app.ld
+++ b/boards/arm/nrf53/thingy53/scripts/flash_app.ld
@@ -58,7 +58,8 @@ SECTIONS
     .init_section :
     {
         _sinit = ABSOLUTE(.);
-        *(.init_array .init_array.*)
+        KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/arm/nrf53/thingy53/scripts/flash_net.ld
+++ b/boards/arm/nrf53/thingy53/scripts/flash_net.ld
@@ -60,7 +60,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/arm/nrf91/common/scripts/flash_app.ld
+++ b/boards/arm/nrf91/common/scripts/flash_app.ld
@@ -116,7 +116,8 @@ SECTIONS
     .init_section :
     {
         _sinit = ABSOLUTE(.);
-        *(.init_array .init_array.*)
+        KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/arm/nrf91/nrf9160-dk/scripts/flash_app.ld
+++ b/boards/arm/nrf91/nrf9160-dk/scripts/flash_app.ld
@@ -59,7 +59,8 @@ SECTIONS
     .init_section :
     {
         _sinit = ABSOLUTE(.);
-        *(.init_array .init_array.*)
+        KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/arm/nrf91/thingy91/scripts/flash_app.ld
+++ b/boards/arm/nrf91/thingy91/scripts/flash_app.ld
@@ -59,7 +59,8 @@ SECTIONS
     .init_section :
     {
         _sinit = ABSOLUTE(.);
-        *(.init_array .init_array.*)
+        KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/arm/nuc1xx/nutiny-nuc120/scripts/nutiny-nuc120.ld
+++ b/boards/arm/nuc1xx/nutiny-nuc120/scripts/nutiny-nuc120.ld
@@ -53,7 +53,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/phy62xx/phy6222/scripts/flash.ld
+++ b/boards/arm/phy62xx/phy6222/scripts/flash.ld
@@ -24,7 +24,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/qemu/qemu-armv7a/scripts/dramboot.ld
+++ b/boards/arm/qemu/qemu-armv7a/scripts/dramboot.ld
@@ -53,7 +53,7 @@ SECTIONS
   .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
   } :text
   . = ALIGN(4096);

--- a/boards/arm/rp2040/adafruit-feather-rp2040/scripts/adafruit-feather-rp2040-flash.ld
+++ b/boards/arm/rp2040/adafruit-feather-rp2040/scripts/adafruit-feather-rp2040-flash.ld
@@ -59,7 +59,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/rp2040/adafruit-feather-rp2040/scripts/adafruit-feather-rp2040-sram.ld
+++ b/boards/arm/rp2040/adafruit-feather-rp2040/scripts/adafruit-feather-rp2040-sram.ld
@@ -51,7 +51,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/rp2040/adafruit-kb2040/scripts/adafruit-kb2040-flash.ld
+++ b/boards/arm/rp2040/adafruit-kb2040/scripts/adafruit-kb2040-flash.ld
@@ -59,7 +59,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/rp2040/adafruit-kb2040/scripts/adafruit-kb2040-sram.ld
+++ b/boards/arm/rp2040/adafruit-kb2040/scripts/adafruit-kb2040-sram.ld
@@ -51,7 +51,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/rp2040/adafruit-qt-py-rp2040/scripts/adafruit-qt-py-rp2040-flash.ld
+++ b/boards/arm/rp2040/adafruit-qt-py-rp2040/scripts/adafruit-qt-py-rp2040-flash.ld
@@ -59,7 +59,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/rp2040/adafruit-qt-py-rp2040/scripts/adafruit-qt-py-rp2040-sram.ld
+++ b/boards/arm/rp2040/adafruit-qt-py-rp2040/scripts/adafruit-qt-py-rp2040-sram.ld
@@ -51,7 +51,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/rp2040/pimoroni-tiny2040/scripts/pimoroni-tiny2040-flash.ld
+++ b/boards/arm/rp2040/pimoroni-tiny2040/scripts/pimoroni-tiny2040-flash.ld
@@ -59,7 +59,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/rp2040/pimoroni-tiny2040/scripts/pimoroni-tiny2040-sram.ld
+++ b/boards/arm/rp2040/pimoroni-tiny2040/scripts/pimoroni-tiny2040-sram.ld
@@ -51,7 +51,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/rp2040/raspberrypi-pico-w/scripts/raspberrypi-pico-flash.ld
+++ b/boards/arm/rp2040/raspberrypi-pico-w/scripts/raspberrypi-pico-flash.ld
@@ -59,7 +59,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/rp2040/raspberrypi-pico-w/scripts/raspberrypi-pico-sram.ld
+++ b/boards/arm/rp2040/raspberrypi-pico-w/scripts/raspberrypi-pico-sram.ld
@@ -51,7 +51,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/rp2040/raspberrypi-pico/scripts/raspberrypi-pico-flash.ld
+++ b/boards/arm/rp2040/raspberrypi-pico/scripts/raspberrypi-pico-flash.ld
@@ -59,7 +59,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/rp2040/raspberrypi-pico/scripts/raspberrypi-pico-sram.ld
+++ b/boards/arm/rp2040/raspberrypi-pico/scripts/raspberrypi-pico-sram.ld
@@ -51,7 +51,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/rp2040/waveshare-rp2040-lcd-1.28/scripts/waveshare-rp2040-lcd-1-28-flash.ld
+++ b/boards/arm/rp2040/waveshare-rp2040-lcd-1.28/scripts/waveshare-rp2040-lcd-1-28-flash.ld
@@ -59,7 +59,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/rp2040/waveshare-rp2040-lcd-1.28/scripts/waveshare-rp2040-lcd-1-28-sram.ld
+++ b/boards/arm/rp2040/waveshare-rp2040-lcd-1.28/scripts/waveshare-rp2040-lcd-1-28-sram.ld
@@ -51,7 +51,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/s32k1xx/rddrone-bms772/scripts/flash.ld
+++ b/boards/arm/s32k1xx/rddrone-bms772/scripts/flash.ld
@@ -76,7 +76,7 @@ SECTIONS
   {
     _sinit = ABSOLUTE(.);
     KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-    KEEP(*(.init_array .ctors))
+    KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
     _einit = ABSOLUTE(.);
   } > dflash
 

--- a/boards/arm/s32k1xx/rddrone-bms772/scripts/sram.ld
+++ b/boards/arm/s32k1xx/rddrone-bms772/scripts/sram.ld
@@ -64,7 +64,7 @@ SECTIONS
   {
     _sinit = ABSOLUTE(.);
     KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-    KEEP(*(.init_array .ctors))
+    KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
     _einit = ABSOLUTE(.);
   } > sram
 

--- a/boards/arm/s32k1xx/s32k118evb/scripts/flash.ld
+++ b/boards/arm/s32k1xx/s32k118evb/scripts/flash.ld
@@ -74,7 +74,7 @@ SECTIONS
   {
     _sinit = ABSOLUTE(.);
     KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-    KEEP(*(.init_array .ctors))
+    KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
     _einit = ABSOLUTE(.);
   } > dflash
 

--- a/boards/arm/s32k1xx/s32k144evb/scripts/flash.ld
+++ b/boards/arm/s32k1xx/s32k144evb/scripts/flash.ld
@@ -74,7 +74,7 @@ SECTIONS
   {
     _sinit = ABSOLUTE(.);
     KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-    KEEP(*(.init_array .ctors))
+    KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
     _einit = ABSOLUTE(.);
   } > dflash
 

--- a/boards/arm/s32k1xx/s32k144evb/scripts/sram.ld
+++ b/boards/arm/s32k1xx/s32k144evb/scripts/sram.ld
@@ -62,7 +62,7 @@ SECTIONS
   {
     _sinit = ABSOLUTE(.);
     KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-    KEEP(*(.init_array .ctors))
+    KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
     _einit = ABSOLUTE(.);
   } > sram
 

--- a/boards/arm/s32k1xx/s32k146evb/scripts/flash.ld
+++ b/boards/arm/s32k1xx/s32k146evb/scripts/flash.ld
@@ -74,7 +74,7 @@ SECTIONS
   {
     _sinit = ABSOLUTE(.);
     KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-    KEEP(*(.init_array .ctors))
+    KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
     _einit = ABSOLUTE(.);
   } > dflash
 

--- a/boards/arm/s32k1xx/s32k146evb/scripts/sram.ld
+++ b/boards/arm/s32k1xx/s32k146evb/scripts/sram.ld
@@ -62,7 +62,7 @@ SECTIONS
   {
     _sinit = ABSOLUTE(.);
     KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-    KEEP(*(.init_array .ctors))
+    KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
     _einit = ABSOLUTE(.);
   } > sram
 

--- a/boards/arm/s32k1xx/s32k148evb/scripts/flash.ld
+++ b/boards/arm/s32k1xx/s32k148evb/scripts/flash.ld
@@ -74,7 +74,7 @@ SECTIONS
   {
     _sinit = ABSOLUTE(.);
     KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-    KEEP(*(.init_array .ctors))
+    KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
     _einit = ABSOLUTE(.);
   } > dflash
 

--- a/boards/arm/s32k1xx/s32k148evb/scripts/sram.ld
+++ b/boards/arm/s32k1xx/s32k148evb/scripts/sram.ld
@@ -62,7 +62,7 @@ SECTIONS
   {
     _sinit = ABSOLUTE(.);
     KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-    KEEP(*(.init_array .ctors))
+    KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
     _einit = ABSOLUTE(.);
   } > sram
 

--- a/boards/arm/s32k1xx/ucans32k146/scripts/flash.ld
+++ b/boards/arm/s32k1xx/ucans32k146/scripts/flash.ld
@@ -74,7 +74,7 @@ SECTIONS
   {
     _sinit = ABSOLUTE(.);
     KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-    KEEP(*(.init_array .ctors))
+    KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
     _einit = ABSOLUTE(.);
   } > dflash
 

--- a/boards/arm/s32k1xx/ucans32k146/scripts/sram.ld
+++ b/boards/arm/s32k1xx/ucans32k146/scripts/sram.ld
@@ -62,7 +62,7 @@ SECTIONS
   {
     _sinit = ABSOLUTE(.);
     KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-    KEEP(*(.init_array .ctors))
+    KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
     _einit = ABSOLUTE(.);
   } > sram
 

--- a/boards/arm/s32k3xx/mr-canhubk3/scripts/flash.ld
+++ b/boards/arm/s32k3xx/mr-canhubk3/scripts/flash.ld
@@ -81,7 +81,7 @@ SECTIONS
   {
     _sinit = ABSOLUTE(.);
     KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-    KEEP(*(.init_array .ctors))
+    KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
     _einit = ABSOLUTE(.);
   } > flash
 

--- a/boards/arm/s32k3xx/mr-canhubk3/scripts/kernel-space.ld
+++ b/boards/arm/s32k3xx/mr-canhubk3/scripts/kernel-space.ld
@@ -92,8 +92,8 @@ SECTIONS
      */
     .init_section : {
         _sinit = ABSOLUTE(.);
-	KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-       KEEP(*(.init_array .ctors))
+        KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > kflash
 

--- a/boards/arm/s32k3xx/mr-canhubk3/scripts/user-space.ld
+++ b/boards/arm/s32k3xx/mr-canhubk3/scripts/user-space.ld
@@ -65,7 +65,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > uflash
 

--- a/boards/arm/s32k3xx/s32k344evb/scripts/flash.ld
+++ b/boards/arm/s32k3xx/s32k344evb/scripts/flash.ld
@@ -78,7 +78,7 @@ SECTIONS
   {
     _sinit = ABSOLUTE(.);
     KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-    KEEP(*(.init_array .ctors))
+    KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
     _einit = ABSOLUTE(.);
   } > flash
 

--- a/boards/arm/sam34/arduino-due/scripts/arduino-due.ld
+++ b/boards/arm/sam34/arduino-due/scripts/arduino-due.ld
@@ -56,7 +56,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/sam34/flipnclick-sam3x/scripts/flash.ld
+++ b/boards/arm/sam34/flipnclick-sam3x/scripts/flash.ld
@@ -56,7 +56,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/sam34/sam3u-ek/scripts/kernel-space.ld
+++ b/boards/arm/sam34/sam3u-ek/scripts/kernel-space.ld
@@ -46,7 +46,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > kflash
 

--- a/boards/arm/sam34/sam3u-ek/scripts/ld.script
+++ b/boards/arm/sam34/sam3u-ek/scripts/ld.script
@@ -57,7 +57,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/sam34/sam3u-ek/scripts/user-space.ld
+++ b/boards/arm/sam34/sam3u-ek/scripts/user-space.ld
@@ -48,7 +48,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > uflash
 

--- a/boards/arm/sam34/sam4cmp-db/scripts/sam4cmp-db.ld
+++ b/boards/arm/sam34/sam4cmp-db/scripts/sam4cmp-db.ld
@@ -52,7 +52,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/sam34/sam4e-ek/scripts/flash.ld
+++ b/boards/arm/sam34/sam4e-ek/scripts/flash.ld
@@ -55,7 +55,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/sam34/sam4l-xplained/scripts/sam4l-xplained.ld
+++ b/boards/arm/sam34/sam4l-xplained/scripts/sam4l-xplained.ld
@@ -52,7 +52,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/sam34/sam4s-xplained-pro/scripts/sam4s-xplained-pro.ld
+++ b/boards/arm/sam34/sam4s-xplained-pro/scripts/sam4s-xplained-pro.ld
@@ -57,7 +57,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash0
 

--- a/boards/arm/sam34/sam4s-xplained/scripts/sam4s-xplained.ld
+++ b/boards/arm/sam34/sam4s-xplained/scripts/sam4s-xplained.ld
@@ -52,7 +52,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/sama5/giant-board/scripts/dramboot.ld
+++ b/boards/arm/sama5/giant-board/scripts/dramboot.ld
@@ -60,7 +60,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > sdram
 

--- a/boards/arm/sama5/giant-board/scripts/isram.ld
+++ b/boards/arm/sama5/giant-board/scripts/isram.ld
@@ -57,7 +57,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > isram
 

--- a/boards/arm/sama5/giant-board/scripts/uboot.ld
+++ b/boards/arm/sama5/giant-board/scripts/uboot.ld
@@ -61,7 +61,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > sdram
 

--- a/boards/arm/sama5/jupiter-nano/scripts/dramboot.ld
+++ b/boards/arm/sama5/jupiter-nano/scripts/dramboot.ld
@@ -60,7 +60,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > sdram
 

--- a/boards/arm/sama5/jupiter-nano/scripts/isram.ld
+++ b/boards/arm/sama5/jupiter-nano/scripts/isram.ld
@@ -57,7 +57,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > isram
 

--- a/boards/arm/sama5/jupiter-nano/scripts/uboot.ld
+++ b/boards/arm/sama5/jupiter-nano/scripts/uboot.ld
@@ -61,7 +61,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > sdram
 

--- a/boards/arm/sama5/sama5d2-xult/scripts/dramboot.ld
+++ b/boards/arm/sama5/sama5d2-xult/scripts/dramboot.ld
@@ -60,7 +60,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > sdram
 

--- a/boards/arm/sama5/sama5d2-xult/scripts/isram.ld
+++ b/boards/arm/sama5/sama5d2-xult/scripts/isram.ld
@@ -57,7 +57,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > isram
 

--- a/boards/arm/sama5/sama5d2-xult/scripts/uboot.ld
+++ b/boards/arm/sama5/sama5d2-xult/scripts/uboot.ld
@@ -61,7 +61,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > sdram
 

--- a/boards/arm/sama5/sama5d3-xplained/scripts/ddram.ld
+++ b/boards/arm/sama5/sama5d3-xplained/scripts/ddram.ld
@@ -61,7 +61,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > sdram
 

--- a/boards/arm/sama5/sama5d3-xplained/scripts/isram.ld
+++ b/boards/arm/sama5/sama5d3-xplained/scripts/isram.ld
@@ -57,7 +57,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > isram
 

--- a/boards/arm/sama5/sama5d3x-ek/scripts/ddram.ld
+++ b/boards/arm/sama5/sama5d3x-ek/scripts/ddram.ld
@@ -61,7 +61,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > sdram
 

--- a/boards/arm/sama5/sama5d3x-ek/scripts/isram.ld
+++ b/boards/arm/sama5/sama5d3x-ek/scripts/isram.ld
@@ -57,7 +57,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > isram
 

--- a/boards/arm/sama5/sama5d3x-ek/scripts/nor-ddram.ld
+++ b/boards/arm/sama5/sama5d3x-ek/scripts/nor-ddram.ld
@@ -66,7 +66,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > norflash
 

--- a/boards/arm/sama5/sama5d3x-ek/scripts/nor-isram.ld
+++ b/boards/arm/sama5/sama5d3x-ek/scripts/nor-isram.ld
@@ -62,7 +62,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > norflash
 

--- a/boards/arm/sama5/sama5d3x-ek/scripts/pg-sram.ld
+++ b/boards/arm/sama5/sama5d3x-ek/scripts/pg-sram.ld
@@ -83,7 +83,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > locked
 

--- a/boards/arm/sama5/sama5d4-ek/scripts/dramboot.ld
+++ b/boards/arm/sama5/sama5d4-ek/scripts/dramboot.ld
@@ -60,7 +60,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > sdram
 

--- a/boards/arm/sama5/sama5d4-ek/scripts/isram.ld
+++ b/boards/arm/sama5/sama5d4-ek/scripts/isram.ld
@@ -57,7 +57,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > isram
 

--- a/boards/arm/sama5/sama5d4-ek/scripts/uboot.ld
+++ b/boards/arm/sama5/sama5d4-ek/scripts/uboot.ld
@@ -61,7 +61,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > sdram
 

--- a/boards/arm/samd2l2/arduino-m0/scripts/flash.ld
+++ b/boards/arm/samd2l2/arduino-m0/scripts/flash.ld
@@ -53,7 +53,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/samd2l2/circuit-express/scripts/flash.ld
+++ b/boards/arm/samd2l2/circuit-express/scripts/flash.ld
@@ -53,7 +53,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/samd2l2/samd20-xplained/scripts/flash.ld
+++ b/boards/arm/samd2l2/samd20-xplained/scripts/flash.ld
@@ -53,7 +53,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/samd2l2/samd21-xplained/scripts/flash.ld
+++ b/boards/arm/samd2l2/samd21-xplained/scripts/flash.ld
@@ -53,7 +53,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/samd2l2/saml21-xplained/scripts/flash.ld
+++ b/boards/arm/samd2l2/saml21-xplained/scripts/flash.ld
@@ -55,7 +55,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/samd5e5/metro-m4/scripts/flash.ld
+++ b/boards/arm/samd5e5/metro-m4/scripts/flash.ld
@@ -54,7 +54,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/samd5e5/metro-m4/scripts/sram.ld
+++ b/boards/arm/samd5e5/metro-m4/scripts/sram.ld
@@ -55,7 +55,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/samd5e5/same54-xplained-pro/scripts/flash.ld
+++ b/boards/arm/samd5e5/same54-xplained-pro/scripts/flash.ld
@@ -54,7 +54,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/samd5e5/same54-xplained-pro/scripts/sram.ld
+++ b/boards/arm/samd5e5/same54-xplained-pro/scripts/sram.ld
@@ -55,7 +55,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/samv7/common/scripts/flash.ld.template
+++ b/boards/arm/samv7/common/scripts/flash.ld.template
@@ -72,8 +72,9 @@ SECTIONS
 
     .init_section : {
         _sinit = ABSOLUTE(.);
-KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-       KEEP(*(.init_array .ctors))        _einit = ABSOLUTE(.);
+        KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
+        _einit = ABSOLUTE(.);
     } > flash
 
     .ARM.extab : {

--- a/boards/arm/samv7/common/scripts/kernel-space.ld
+++ b/boards/arm/samv7/common/scripts/kernel-space.ld
@@ -47,7 +47,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > kflash
 

--- a/boards/arm/samv7/common/scripts/user-space.ld
+++ b/boards/arm/samv7/common/scripts/user-space.ld
@@ -60,7 +60,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > uflash
 

--- a/boards/arm/stm32/axoloti/scripts/kernel-space.ld
+++ b/boards/arm/stm32/axoloti/scripts/kernel-space.ld
@@ -46,7 +46,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > kflash
 

--- a/boards/arm/stm32/axoloti/scripts/ld.script
+++ b/boards/arm/stm32/axoloti/scripts/ld.script
@@ -62,7 +62,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/axoloti/scripts/user-space.ld
+++ b/boards/arm/stm32/axoloti/scripts/user-space.ld
@@ -60,7 +60,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > uflash
 

--- a/boards/arm/stm32/b-g431b-esc1/scripts/ld.script
+++ b/boards/arm/stm32/b-g431b-esc1/scripts/ld.script
@@ -74,7 +74,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/b-g474e-dpow1/scripts/ld.script
+++ b/boards/arm/stm32/b-g474e-dpow1/scripts/ld.script
@@ -74,7 +74,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/b-g474e-dpow1/scripts/ld.script.dfu
+++ b/boards/arm/stm32/b-g474e-dpow1/scripts/ld.script.dfu
@@ -77,7 +77,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/clicker2-stm32/scripts/flash.ld
+++ b/boards/arm/stm32/clicker2-stm32/scripts/flash.ld
@@ -62,7 +62,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/clicker2-stm32/scripts/kernel-space.ld
+++ b/boards/arm/stm32/clicker2-stm32/scripts/kernel-space.ld
@@ -48,7 +48,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > kflash
 

--- a/boards/arm/stm32/clicker2-stm32/scripts/user-space.ld
+++ b/boards/arm/stm32/clicker2-stm32/scripts/user-space.ld
@@ -50,7 +50,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > uflash
 

--- a/boards/arm/stm32/cloudctrl/scripts/cloudctrl-dfu.ld
+++ b/boards/arm/stm32/cloudctrl/scripts/cloudctrl-dfu.ld
@@ -54,7 +54,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/cloudctrl/scripts/cloudctrl.ld
+++ b/boards/arm/stm32/cloudctrl/scripts/cloudctrl.ld
@@ -52,7 +52,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/emw3162/scripts/ld.script
+++ b/boards/arm/stm32/emw3162/scripts/ld.script
@@ -66,7 +66,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/et-stm32-stamp/scripts/ld.script
+++ b/boards/arm/stm32/et-stm32-stamp/scripts/ld.script
@@ -56,7 +56,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/fire-stm32v2/scripts/fire-stm32v2-dfu.ld
+++ b/boards/arm/stm32/fire-stm32v2/scripts/fire-stm32v2-dfu.ld
@@ -54,7 +54,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/fire-stm32v2/scripts/fire-stm32v2.ld
+++ b/boards/arm/stm32/fire-stm32v2/scripts/fire-stm32v2.ld
@@ -55,7 +55,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/hymini-stm32v/scripts/ld.script
+++ b/boards/arm/stm32/hymini-stm32v/scripts/ld.script
@@ -55,7 +55,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/maple/scripts/ld.script
+++ b/boards/arm/stm32/maple/scripts/ld.script
@@ -55,7 +55,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/maple/scripts/ld.script.dfu
+++ b/boards/arm/stm32/maple/scripts/ld.script.dfu
@@ -53,10 +53,10 @@ SECTIONS
         } > flash
 
         .init_section : ALIGN(4) {
-                _sinit = ABSOLUTE(.);
-                KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
-                _einit = ABSOLUTE(.);
+            _sinit = ABSOLUTE(.);
+            KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+            KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
+            _einit = ABSOLUTE(.);
         } > flash
 
         .ARM.extab : ALIGN(4) {

--- a/boards/arm/stm32/mikroe-stm32f4/scripts/kernel-space.ld
+++ b/boards/arm/stm32/mikroe-stm32f4/scripts/kernel-space.ld
@@ -46,7 +46,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > kflash
 

--- a/boards/arm/stm32/mikroe-stm32f4/scripts/ld.script
+++ b/boards/arm/stm32/mikroe-stm32f4/scripts/ld.script
@@ -61,7 +61,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/mikroe-stm32f4/scripts/user-space.ld
+++ b/boards/arm/stm32/mikroe-stm32f4/scripts/user-space.ld
@@ -47,7 +47,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > uflash
 

--- a/boards/arm/stm32/nucleo-f103rb/scripts/ld.script
+++ b/boards/arm/stm32/nucleo-f103rb/scripts/ld.script
@@ -56,7 +56,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/nucleo-f207zg/scripts/ld.script
+++ b/boards/arm/stm32/nucleo-f207zg/scripts/ld.script
@@ -59,7 +59,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/nucleo-f302r8/scripts/ld.script
+++ b/boards/arm/stm32/nucleo-f302r8/scripts/ld.script
@@ -56,7 +56,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/nucleo-f303re/scripts/ld.script
+++ b/boards/arm/stm32/nucleo-f303re/scripts/ld.script
@@ -56,7 +56,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/nucleo-f303ze/scripts/ld.script
+++ b/boards/arm/stm32/nucleo-f303ze/scripts/ld.script
@@ -56,7 +56,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/nucleo-f334r8/scripts/ld.script
+++ b/boards/arm/stm32/nucleo-f334r8/scripts/ld.script
@@ -56,7 +56,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/nucleo-f410rb/scripts/f410rb.ld
+++ b/boards/arm/stm32/nucleo-f410rb/scripts/f410rb.ld
@@ -55,7 +55,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/nucleo-f412zg/scripts/f412zg.ld
+++ b/boards/arm/stm32/nucleo-f412zg/scripts/f412zg.ld
@@ -55,7 +55,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/nucleo-f429zi/scripts/kernel-space.ld
+++ b/boards/arm/stm32/nucleo-f429zi/scripts/kernel-space.ld
@@ -46,7 +46,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > kflash
 

--- a/boards/arm/stm32/nucleo-f429zi/scripts/ld.script
+++ b/boards/arm/stm32/nucleo-f429zi/scripts/ld.script
@@ -62,7 +62,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/nucleo-f429zi/scripts/user-space.ld
+++ b/boards/arm/stm32/nucleo-f429zi/scripts/user-space.ld
@@ -60,7 +60,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > uflash
 

--- a/boards/arm/stm32/nucleo-f446re/scripts/f446re.ld
+++ b/boards/arm/stm32/nucleo-f446re/scripts/f446re.ld
@@ -55,7 +55,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/nucleo-f4x1re/scripts/f401re.ld
+++ b/boards/arm/stm32/nucleo-f4x1re/scripts/f401re.ld
@@ -55,7 +55,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/nucleo-f4x1re/scripts/f411re.ld
+++ b/boards/arm/stm32/nucleo-f4x1re/scripts/f411re.ld
@@ -55,7 +55,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/nucleo-g431kb/scripts/ld.script
+++ b/boards/arm/stm32/nucleo-g431kb/scripts/ld.script
@@ -74,7 +74,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/nucleo-g431rb/scripts/ld.script
+++ b/boards/arm/stm32/nucleo-g431rb/scripts/ld.script
@@ -74,7 +74,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/nucleo-g474re/scripts/ld.script
+++ b/boards/arm/stm32/nucleo-g474re/scripts/ld.script
@@ -74,7 +74,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/nucleo-g474re/scripts/ld.script.dfu
+++ b/boards/arm/stm32/nucleo-g474re/scripts/ld.script.dfu
@@ -77,7 +77,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/nucleo-l152re/scripts/ld.script
+++ b/boards/arm/stm32/nucleo-l152re/scripts/ld.script
@@ -56,7 +56,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/olimex-stm32-e407/scripts/f407ze.ld
+++ b/boards/arm/stm32/olimex-stm32-e407/scripts/f407ze.ld
@@ -61,7 +61,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/olimex-stm32-e407/scripts/f407zg.ld
+++ b/boards/arm/stm32/olimex-stm32-e407/scripts/f407zg.ld
@@ -61,7 +61,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/olimex-stm32-h405/scripts/ld.script
+++ b/boards/arm/stm32/olimex-stm32-h405/scripts/ld.script
@@ -61,7 +61,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/olimex-stm32-h407/scripts/ld.script
+++ b/boards/arm/stm32/olimex-stm32-h407/scripts/ld.script
@@ -60,7 +60,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/olimex-stm32-p107/scripts/ld.script
+++ b/boards/arm/stm32/olimex-stm32-p107/scripts/ld.script
@@ -48,7 +48,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/olimex-stm32-p107/scripts/ld.script.dfu
+++ b/boards/arm/stm32/olimex-stm32-p107/scripts/ld.script.dfu
@@ -47,10 +47,10 @@ SECTIONS
         } > flash
 
         .init_section : ALIGN(4) {
-                _sinit = ABSOLUTE(.);
-                KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
-                _einit = ABSOLUTE(.);
+            _sinit = ABSOLUTE(.);
+            KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+            KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
+            _einit = ABSOLUTE(.);
         } > flash
 
         .ARM.extab : ALIGN(4) {

--- a/boards/arm/stm32/olimex-stm32-p207/scripts/ld.script
+++ b/boards/arm/stm32/olimex-stm32-p207/scripts/ld.script
@@ -60,7 +60,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/olimex-stm32-p407/scripts/flash.ld
+++ b/boards/arm/stm32/olimex-stm32-p407/scripts/flash.ld
@@ -60,7 +60,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/olimex-stm32-p407/scripts/kernel-space.ld
+++ b/boards/arm/stm32/olimex-stm32-p407/scripts/kernel-space.ld
@@ -47,7 +47,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > kflash
 

--- a/boards/arm/stm32/olimex-stm32-p407/scripts/user-space.ld
+++ b/boards/arm/stm32/olimex-stm32-p407/scripts/user-space.ld
@@ -60,7 +60,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > uflash
 

--- a/boards/arm/stm32/olimexino-stm32/scripts/ld.script
+++ b/boards/arm/stm32/olimexino-stm32/scripts/ld.script
@@ -55,7 +55,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/olimexino-stm32/scripts/ld.script.dfu
+++ b/boards/arm/stm32/olimexino-stm32/scripts/ld.script.dfu
@@ -47,10 +47,10 @@ SECTIONS
         } > flash
 
         .init_section : ALIGN(4) {
-                _sinit = ABSOLUTE(.);
-                KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
-                _einit = ABSOLUTE(.);
+            _sinit = ABSOLUTE(.);
+            KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+            KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
+            _einit = ABSOLUTE(.);
         } > flash
 
         .ARM.extab : ALIGN(4) {

--- a/boards/arm/stm32/omnibusf4/scripts/kernel-space.ld
+++ b/boards/arm/stm32/omnibusf4/scripts/kernel-space.ld
@@ -45,7 +45,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > kflash
 

--- a/boards/arm/stm32/omnibusf4/scripts/ld.script
+++ b/boards/arm/stm32/omnibusf4/scripts/ld.script
@@ -61,7 +61,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/omnibusf4/scripts/user-space.ld
+++ b/boards/arm/stm32/omnibusf4/scripts/user-space.ld
@@ -47,7 +47,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > uflash
 

--- a/boards/arm/stm32/photon/scripts/photon_dfu.ld
+++ b/boards/arm/stm32/photon/scripts/photon_dfu.ld
@@ -69,7 +69,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/photon/scripts/photon_jtag.ld
+++ b/boards/arm/stm32/photon/scripts/photon_jtag.ld
@@ -57,7 +57,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/shenzhou/scripts/ld.script
+++ b/boards/arm/stm32/shenzhou/scripts/ld.script
@@ -52,7 +52,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/shenzhou/scripts/ld.script.dfu
+++ b/boards/arm/stm32/shenzhou/scripts/ld.script.dfu
@@ -52,10 +52,10 @@ SECTIONS
         } > flash
 
         .init_section : ALIGN(4) {
-                _sinit = ABSOLUTE(.);
-                KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
-                _einit = ABSOLUTE(.);
+            _sinit = ABSOLUTE(.);
+            KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+            KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
+            _einit = ABSOLUTE(.);
         } > flash
 
         .ARM.extab : ALIGN(4) {

--- a/boards/arm/stm32/stm3210e-eval/scripts/ld.script
+++ b/boards/arm/stm32/stm3210e-eval/scripts/ld.script
@@ -55,7 +55,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/stm3210e-eval/scripts/ld.script.dfu
+++ b/boards/arm/stm32/stm3210e-eval/scripts/ld.script.dfu
@@ -52,10 +52,10 @@ SECTIONS
         } > flash
 
         .init_section : ALIGN(4) {
-                _sinit = ABSOLUTE(.);
-                KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
-                _einit = ABSOLUTE(.);
+            _sinit = ABSOLUTE(.);
+            KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+            KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
+            _einit = ABSOLUTE(.);
         } > flash
 
         .ARM.extab : ALIGN(4) {

--- a/boards/arm/stm32/stm3220g-eval/scripts/ld.script
+++ b/boards/arm/stm32/stm3220g-eval/scripts/ld.script
@@ -60,7 +60,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/stm3240g-eval/scripts/kernel-space.ld
+++ b/boards/arm/stm32/stm3240g-eval/scripts/kernel-space.ld
@@ -46,7 +46,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > kflash
 

--- a/boards/arm/stm32/stm3240g-eval/scripts/ld.script
+++ b/boards/arm/stm32/stm3240g-eval/scripts/ld.script
@@ -61,7 +61,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/stm3240g-eval/scripts/user-space.ld
+++ b/boards/arm/stm32/stm3240g-eval/scripts/user-space.ld
@@ -47,7 +47,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > uflash
 

--- a/boards/arm/stm32/stm32_tiny/scripts/ld.script
+++ b/boards/arm/stm32/stm32_tiny/scripts/ld.script
@@ -55,7 +55,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/stm32butterfly2/scripts/dfu.ld
+++ b/boards/arm/stm32/stm32butterfly2/scripts/dfu.ld
@@ -48,7 +48,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/stm32butterfly2/scripts/flash.ld
+++ b/boards/arm/stm32/stm32butterfly2/scripts/flash.ld
@@ -48,7 +48,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/stm32f103-minimum/scripts/ld.script
+++ b/boards/arm/stm32/stm32f103-minimum/scripts/ld.script
@@ -60,7 +60,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/stm32f103-minimum/scripts/ld.script.dfu
+++ b/boards/arm/stm32/stm32f103-minimum/scripts/ld.script.dfu
@@ -52,10 +52,10 @@ SECTIONS
         } > flash
 
         .init_section : ALIGN(4) {
-                _sinit = ABSOLUTE(.);
-                KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
-                _einit = ABSOLUTE(.);
+            _sinit = ABSOLUTE(.);
+            KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+            KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
+            _einit = ABSOLUTE(.);
         } > flash
 
         .ARM.extab : ALIGN(4) {

--- a/boards/arm/stm32/stm32f334-disco/scripts/ld.script
+++ b/boards/arm/stm32/stm32f334-disco/scripts/ld.script
@@ -56,7 +56,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/stm32f3discovery/scripts/ld.script
+++ b/boards/arm/stm32/stm32f3discovery/scripts/ld.script
@@ -56,7 +56,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/stm32f411-minimum/scripts/stm32f411ce.ld
+++ b/boards/arm/stm32/stm32f411-minimum/scripts/stm32f411ce.ld
@@ -55,7 +55,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/stm32f411e-disco/scripts/f411ve.ld
+++ b/boards/arm/stm32/stm32f411e-disco/scripts/f411ve.ld
@@ -55,7 +55,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/stm32f429i-disco/scripts/kernel-space.ld
+++ b/boards/arm/stm32/stm32f429i-disco/scripts/kernel-space.ld
@@ -46,7 +46,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > kflash
 

--- a/boards/arm/stm32/stm32f429i-disco/scripts/ld.script
+++ b/boards/arm/stm32/stm32f429i-disco/scripts/ld.script
@@ -62,7 +62,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/stm32f429i-disco/scripts/ofloader.ld
+++ b/boards/arm/stm32/stm32f429i-disco/scripts/ofloader.ld
@@ -66,7 +66,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32/stm32f429i-disco/scripts/user-space.ld
+++ b/boards/arm/stm32/stm32f429i-disco/scripts/user-space.ld
@@ -60,7 +60,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > uflash
 

--- a/boards/arm/stm32/stm32f4discovery/scripts/kernel-space.ld
+++ b/boards/arm/stm32/stm32f4discovery/scripts/kernel-space.ld
@@ -45,7 +45,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > kflash
 

--- a/boards/arm/stm32/stm32f4discovery/scripts/ld.script
+++ b/boards/arm/stm32/stm32f4discovery/scripts/ld.script
@@ -61,7 +61,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/stm32f4discovery/scripts/user-space.ld
+++ b/boards/arm/stm32/stm32f4discovery/scripts/user-space.ld
@@ -47,7 +47,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > uflash
 

--- a/boards/arm/stm32/stm32ldiscovery/scripts/stm32l152rb.ld
+++ b/boards/arm/stm32/stm32ldiscovery/scripts/stm32l152rb.ld
@@ -58,7 +58,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/stm32ldiscovery/scripts/stm32l152rc.ld
+++ b/boards/arm/stm32/stm32ldiscovery/scripts/stm32l152rc.ld
@@ -58,7 +58,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/stm32vldiscovery/scripts/stm32vldiscovery.ld
+++ b/boards/arm/stm32/stm32vldiscovery/scripts/stm32vldiscovery.ld
@@ -55,7 +55,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/viewtool-stm32f107/scripts/dfu.ld
+++ b/boards/arm/stm32/viewtool-stm32f107/scripts/dfu.ld
@@ -48,7 +48,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32/viewtool-stm32f107/scripts/flash.ld
+++ b/boards/arm/stm32/viewtool-stm32f107/scripts/flash.ld
@@ -48,7 +48,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32f0l0g0/b-l072z-lrwan1/scripts/ld.script
+++ b/boards/arm/stm32f0l0g0/b-l072z-lrwan1/scripts/ld.script
@@ -56,7 +56,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32f0l0g0/nucleo-f072rb/scripts/flash.ld
+++ b/boards/arm/stm32f0l0g0/nucleo-f072rb/scripts/flash.ld
@@ -59,7 +59,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32f0l0g0/nucleo-f091rc/scripts/flash.ld
+++ b/boards/arm/stm32f0l0g0/nucleo-f091rc/scripts/flash.ld
@@ -59,7 +59,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32f0l0g0/nucleo-g070rb/scripts/ld.script
+++ b/boards/arm/stm32f0l0g0/nucleo-g070rb/scripts/ld.script
@@ -56,7 +56,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32f0l0g0/nucleo-g071rb/scripts/ld.script
+++ b/boards/arm/stm32f0l0g0/nucleo-g071rb/scripts/ld.script
@@ -56,7 +56,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32f0l0g0/nucleo-l073rz/scripts/ld.script
+++ b/boards/arm/stm32f0l0g0/nucleo-l073rz/scripts/ld.script
@@ -56,7 +56,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32f0l0g0/stm32f051-discovery/scripts/flash.ld
+++ b/boards/arm/stm32f0l0g0/stm32f051-discovery/scripts/flash.ld
@@ -57,7 +57,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32f0l0g0/stm32f072-discovery/scripts/flash.ld
+++ b/boards/arm/stm32f0l0g0/stm32f072-discovery/scripts/flash.ld
@@ -57,7 +57,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32f0l0g0/stm32g071b-disco/scripts/ld.script
+++ b/boards/arm/stm32f0l0g0/stm32g071b-disco/scripts/ld.script
@@ -56,7 +56,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32f0l0g0/stm32l0538-disco/scripts/ld.script
+++ b/boards/arm/stm32f0l0g0/stm32l0538-disco/scripts/ld.script
@@ -56,7 +56,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32f7/nucleo-144/scripts/f722-flash.ld
+++ b/boards/arm/stm32f7/nucleo-144/scripts/f722-flash.ld
@@ -83,7 +83,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32f7/nucleo-144/scripts/f746-flash.ld
+++ b/boards/arm/stm32f7/nucleo-144/scripts/f746-flash.ld
@@ -83,7 +83,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32f7/nucleo-144/scripts/f767-flash.ld
+++ b/boards/arm/stm32f7/nucleo-144/scripts/f767-flash.ld
@@ -83,7 +83,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32f7/nucleo-144/scripts/kernel-space.ld
+++ b/boards/arm/stm32f7/nucleo-144/scripts/kernel-space.ld
@@ -45,7 +45,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > kflash
 

--- a/boards/arm/stm32f7/nucleo-144/scripts/user-space.ld
+++ b/boards/arm/stm32f7/nucleo-144/scripts/user-space.ld
@@ -47,7 +47,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > uflash
 

--- a/boards/arm/stm32f7/steval-eth001v1/scripts/flash.ld
+++ b/boards/arm/stm32f7/steval-eth001v1/scripts/flash.ld
@@ -83,7 +83,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32f7/stm32f746-ws/scripts/flash.ld
+++ b/boards/arm/stm32f7/stm32f746-ws/scripts/flash.ld
@@ -83,7 +83,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32f7/stm32f746-ws/scripts/kernel-space.ld
+++ b/boards/arm/stm32f7/stm32f746-ws/scripts/kernel-space.ld
@@ -45,7 +45,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > kflash
 

--- a/boards/arm/stm32f7/stm32f746-ws/scripts/user-space.ld
+++ b/boards/arm/stm32f7/stm32f746-ws/scripts/user-space.ld
@@ -47,7 +47,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > uflash
 

--- a/boards/arm/stm32f7/stm32f746g-disco/scripts/flash.ld
+++ b/boards/arm/stm32f7/stm32f746g-disco/scripts/flash.ld
@@ -83,7 +83,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32f7/stm32f746g-disco/scripts/kernel-space.ld
+++ b/boards/arm/stm32f7/stm32f746g-disco/scripts/kernel-space.ld
@@ -45,7 +45,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > kflash
 

--- a/boards/arm/stm32f7/stm32f746g-disco/scripts/user-space.ld
+++ b/boards/arm/stm32f7/stm32f746g-disco/scripts/user-space.ld
@@ -47,7 +47,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > uflash
 

--- a/boards/arm/stm32f7/stm32f769i-disco/scripts/flash.ld
+++ b/boards/arm/stm32f7/stm32f769i-disco/scripts/flash.ld
@@ -83,7 +83,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32f7/stm32f769i-disco/scripts/kernel-space.ld
+++ b/boards/arm/stm32f7/stm32f769i-disco/scripts/kernel-space.ld
@@ -45,7 +45,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > kflash
 

--- a/boards/arm/stm32f7/stm32f769i-disco/scripts/user-space.ld
+++ b/boards/arm/stm32f7/stm32f769i-disco/scripts/user-space.ld
@@ -47,7 +47,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > uflash
 

--- a/boards/arm/stm32f7/stm32f777zit6-meadow/scripts/kernel-space.ld
+++ b/boards/arm/stm32f7/stm32f777zit6-meadow/scripts/kernel-space.ld
@@ -45,7 +45,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > kflash
 

--- a/boards/arm/stm32f7/stm32f777zit6-meadow/scripts/ld.script
+++ b/boards/arm/stm32f7/stm32f777zit6-meadow/scripts/ld.script
@@ -83,7 +83,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32f7/stm32f777zit6-meadow/scripts/user-space.ld
+++ b/boards/arm/stm32f7/stm32f777zit6-meadow/scripts/user-space.ld
@@ -47,7 +47,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > uflash
 

--- a/boards/arm/stm32h7/nucleo-h743zi/scripts/flash-mcuboot-app.ld
+++ b/boards/arm/stm32h7/nucleo-h743zi/scripts/flash-mcuboot-app.ld
@@ -133,7 +133,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32h7/nucleo-h743zi/scripts/flash-mcuboot-loader.ld
+++ b/boards/arm/stm32h7/nucleo-h743zi/scripts/flash-mcuboot-loader.ld
@@ -133,7 +133,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32h7/nucleo-h743zi/scripts/flash.ld
+++ b/boards/arm/stm32h7/nucleo-h743zi/scripts/flash.ld
@@ -133,7 +133,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32h7/nucleo-h743zi/scripts/kernel.space.ld
+++ b/boards/arm/stm32h7/nucleo-h743zi/scripts/kernel.space.ld
@@ -45,7 +45,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > kflash
 

--- a/boards/arm/stm32h7/nucleo-h743zi/scripts/user-space.ld
+++ b/boards/arm/stm32h7/nucleo-h743zi/scripts/user-space.ld
@@ -47,7 +47,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > uflash
 

--- a/boards/arm/stm32h7/nucleo-h743zi2/scripts/flash.ld
+++ b/boards/arm/stm32h7/nucleo-h743zi2/scripts/flash.ld
@@ -133,7 +133,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32h7/nucleo-h743zi2/scripts/user-space.ld
+++ b/boards/arm/stm32h7/nucleo-h743zi2/scripts/user-space.ld
@@ -47,7 +47,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > uflash
 

--- a/boards/arm/stm32h7/nucleo-h745zi/scripts/flash.ld
+++ b/boards/arm/stm32h7/nucleo-h745zi/scripts/flash.ld
@@ -76,7 +76,8 @@ SECTIONS
     .init_section :
     {
         _sinit = ABSOLUTE(.);
-        *(.init_array .init_array.*)
+        KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32h7/nucleo-h745zi/scripts/flash_m4.ld
+++ b/boards/arm/stm32h7/nucleo-h745zi/scripts/flash_m4.ld
@@ -68,7 +68,8 @@ SECTIONS
     .init_section :
     {
         _sinit = ABSOLUTE(.);
-        *(.init_array .init_array.*)
+        KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32h7/stm32h745i-disco/scripts/flash.ld
+++ b/boards/arm/stm32h7/stm32h745i-disco/scripts/flash.ld
@@ -151,7 +151,8 @@ SECTIONS
     .init_section :
     {
         _sinit = ABSOLUTE(.);
-        *(.init_array .init_array.*)
+        KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32h7/stm32h745i-disco/scripts/user-space.ld
+++ b/boards/arm/stm32h7/stm32h745i-disco/scripts/user-space.ld
@@ -46,7 +46,8 @@ SECTIONS
 
     .init_section : {
         _sinit = ABSOLUTE(.);
-        *(.init_array .init_array.*)
+        KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > uflash
 

--- a/boards/arm/stm32h7/stm32h747i-disco/scripts/flash.ld
+++ b/boards/arm/stm32h7/stm32h747i-disco/scripts/flash.ld
@@ -131,7 +131,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32h7/stm32h747i-disco/scripts/kernel.space.ld
+++ b/boards/arm/stm32h7/stm32h747i-disco/scripts/kernel.space.ld
@@ -45,7 +45,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > kflash
 

--- a/boards/arm/stm32h7/stm32h747i-disco/scripts/user-space.ld
+++ b/boards/arm/stm32h7/stm32h747i-disco/scripts/user-space.ld
@@ -47,7 +47,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > uflash
 

--- a/boards/arm/stm32l4/b-l475e-iot01a/scripts/flash.ld
+++ b/boards/arm/stm32l4/b-l475e-iot01a/scripts/flash.ld
@@ -59,7 +59,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32l4/nucleo-l432kc/scripts/l432kc.ld
+++ b/boards/arm/stm32l4/nucleo-l432kc/scripts/l432kc.ld
@@ -54,7 +54,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32l4/nucleo-l452re/scripts/l452re-flash.ld
+++ b/boards/arm/stm32l4/nucleo-l452re/scripts/l452re-flash.ld
@@ -54,7 +54,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32l4/nucleo-l476rg/scripts/l476rg.ld
+++ b/boards/arm/stm32l4/nucleo-l476rg/scripts/l476rg.ld
@@ -54,7 +54,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32l4/nucleo-l496zg/scripts/kernel-space.ld
+++ b/boards/arm/stm32l4/nucleo-l496zg/scripts/kernel-space.ld
@@ -45,7 +45,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > kflash
 

--- a/boards/arm/stm32l4/nucleo-l496zg/scripts/l496zg-flash.ld
+++ b/boards/arm/stm32l4/nucleo-l496zg/scripts/l496zg-flash.ld
@@ -54,7 +54,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32l4/nucleo-l496zg/scripts/user-space.ld
+++ b/boards/arm/stm32l4/nucleo-l496zg/scripts/user-space.ld
@@ -47,7 +47,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > uflash
 

--- a/boards/arm/stm32l4/steval-stlcs01v1/scripts/ld.script
+++ b/boards/arm/stm32l4/steval-stlcs01v1/scripts/ld.script
@@ -54,7 +54,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32l4/stm32l476-mdk/scripts/stm32l476-mdk.ld
+++ b/boards/arm/stm32l4/stm32l476-mdk/scripts/stm32l476-mdk.ld
@@ -59,7 +59,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32l4/stm32l476vg-disco/scripts/kernel-space.ld
+++ b/boards/arm/stm32l4/stm32l476vg-disco/scripts/kernel-space.ld
@@ -45,7 +45,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > kflash
 

--- a/boards/arm/stm32l4/stm32l476vg-disco/scripts/stm32l476vg-disco.ld
+++ b/boards/arm/stm32l4/stm32l476vg-disco/scripts/stm32l476vg-disco.ld
@@ -59,7 +59,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32l4/stm32l476vg-disco/scripts/user-space.ld
+++ b/boards/arm/stm32l4/stm32l476vg-disco/scripts/user-space.ld
@@ -47,7 +47,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > uflash
 

--- a/boards/arm/stm32l4/stm32l4r9ai-disco/scripts/kernel-space.ld
+++ b/boards/arm/stm32l4/stm32l4r9ai-disco/scripts/kernel-space.ld
@@ -45,7 +45,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > kflash
 

--- a/boards/arm/stm32l4/stm32l4r9ai-disco/scripts/stm32l4r9ai-disco.ld
+++ b/boards/arm/stm32l4/stm32l4r9ai-disco/scripts/stm32l4r9ai-disco.ld
@@ -62,7 +62,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32l4/stm32l4r9ai-disco/scripts/user-space.ld
+++ b/boards/arm/stm32l4/stm32l4r9ai-disco/scripts/user-space.ld
@@ -47,7 +47,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > uflash
 

--- a/boards/arm/stm32l5/nucleo-l552ze/scripts/flash.ld
+++ b/boards/arm/stm32l5/nucleo-l552ze/scripts/flash.ld
@@ -54,7 +54,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32l5/stm32l562e-dk/scripts/tfm-ns.ld
+++ b/boards/arm/stm32l5/stm32l562e-dk/scripts/tfm-ns.ld
@@ -65,7 +65,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32u5/b-u585i-iot02a/scripts/flash.ld
+++ b/boards/arm/stm32u5/b-u585i-iot02a/scripts/flash.ld
@@ -54,7 +54,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32u5/b-u585i-iot02a/scripts/tfm-ns.ld
+++ b/boards/arm/stm32u5/b-u585i-iot02a/scripts/tfm-ns.ld
@@ -65,7 +65,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32u5/nucleo-u5a5zj-q/scripts/flash.ld
+++ b/boards/arm/stm32u5/nucleo-u5a5zj-q/scripts/flash.ld
@@ -53,7 +53,8 @@ SECTIONS
 
     .init_section : {
         _sinit = ABSOLUTE(.);
-        *(.init_array .init_array.*)
+        KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32u5/nucleo-u5a5zj-q/scripts/tfm-ns.ld
+++ b/boards/arm/stm32u5/nucleo-u5a5zj-q/scripts/tfm-ns.ld
@@ -64,7 +64,8 @@ SECTIONS
 
     .init_section : {
         _sinit = ABSOLUTE(.);
-        *(.init_array .init_array.*)
+        KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32wb/flipperzero/scripts/flipperzero.ld
+++ b/boards/arm/stm32wb/flipperzero/scripts/flipperzero.ld
@@ -63,7 +63,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32wb/nucleo-wb55rg/scripts/wb55rg.ld
+++ b/boards/arm/stm32wb/nucleo-wb55rg/scripts/wb55rg.ld
@@ -63,7 +63,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/stm32wl5/nucleo-wl55jc/scripts/wl55jc.ld
+++ b/boards/arm/stm32wl5/nucleo-wl55jc/scripts/wl55jc.ld
@@ -54,7 +54,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/str71x/olimex-strp711/scripts/ld.script
+++ b/boards/arm/str71x/olimex-strp711/scripts/ld.script
@@ -61,7 +61,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/tiva/dk-tm4c129x/scripts/ld.script
+++ b/boards/arm/tiva/dk-tm4c129x/scripts/ld.script
@@ -53,7 +53,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/tiva/eagle100/scripts/ld.script
+++ b/boards/arm/tiva/eagle100/scripts/ld.script
@@ -55,7 +55,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/tiva/ekk-lm3s9b96/scripts/ekk-lm3s9b96.ld
+++ b/boards/arm/tiva/ekk-lm3s9b96/scripts/ekk-lm3s9b96.ld
@@ -52,7 +52,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/tiva/launchxl-cc1310/scripts/flash.ld
+++ b/boards/arm/tiva/launchxl-cc1310/scripts/flash.ld
@@ -53,7 +53,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/tiva/launchxl-cc1312r1/scripts/flash.ld
+++ b/boards/arm/tiva/launchxl-cc1312r1/scripts/flash.ld
@@ -53,7 +53,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/tiva/launchxl-cc1312r1/scripts/sram.ld
+++ b/boards/arm/tiva/launchxl-cc1312r1/scripts/sram.ld
@@ -53,7 +53,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/tiva/lm3s6432-s2e/scripts/lm3s6432-s2e.ld
+++ b/boards/arm/tiva/lm3s6432-s2e/scripts/lm3s6432-s2e.ld
@@ -52,7 +52,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/tiva/lm3s6965-ek/scripts/kernel-space.ld
+++ b/boards/arm/tiva/lm3s6965-ek/scripts/kernel-space.ld
@@ -45,7 +45,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > kflash
 

--- a/boards/arm/tiva/lm3s6965-ek/scripts/ld.script
+++ b/boards/arm/tiva/lm3s6965-ek/scripts/ld.script
@@ -52,7 +52,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/tiva/lm3s6965-ek/scripts/user-space.ld
+++ b/boards/arm/tiva/lm3s6965-ek/scripts/user-space.ld
@@ -47,7 +47,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > uflash
 

--- a/boards/arm/tiva/lm3s8962-ek/scripts/ld.script
+++ b/boards/arm/tiva/lm3s8962-ek/scripts/ld.script
@@ -52,7 +52,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/tiva/lm4f120-launchpad/scripts/lm4f120-launchpad.ld
+++ b/boards/arm/tiva/lm4f120-launchpad/scripts/lm4f120-launchpad.ld
@@ -53,7 +53,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/tiva/tm4c123g-launchpad/scripts/tm4c123g-launchpad.ld
+++ b/boards/arm/tiva/tm4c123g-launchpad/scripts/tm4c123g-launchpad.ld
@@ -53,7 +53,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/tiva/tm4c1294-launchpad/scripts/ld.script
+++ b/boards/arm/tiva/tm4c1294-launchpad/scripts/ld.script
@@ -53,7 +53,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/tiva/tm4c129e-launchpad/scripts/ld.script
+++ b/boards/arm/tiva/tm4c129e-launchpad/scripts/ld.script
@@ -53,7 +53,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/tms570/launchxl-tms57004/scripts/flash-sram.ld
+++ b/boards/arm/tms570/launchxl-tms57004/scripts/flash-sram.ld
@@ -52,7 +52,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/tms570/tms570ls31x-usb-kit/scripts/flash-sram.ld
+++ b/boards/arm/tms570/tms570ls31x-usb-kit/scripts/flash-sram.ld
@@ -56,7 +56,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/xmc4/xmc4500-relax/scripts/flash.ld
+++ b/boards/arm/xmc4/xmc4500-relax/scripts/flash.ld
@@ -58,7 +58,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm/xmc4/xmc4700-relax/scripts/flash.ld
+++ b/boards/arm/xmc4/xmc4700-relax/scripts/flash.ld
@@ -63,7 +63,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/arm64/a64/pinephone/scripts/dramboot.ld
+++ b/boards/arm64/a64/pinephone/scripts/dramboot.ld
@@ -46,7 +46,7 @@ SECTIONS
   .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
   }
 

--- a/boards/arm64/fvp-v8r/fvp-armv8r/scripts/dramboot.ld
+++ b/boards/arm64/fvp-v8r/fvp-armv8r/scripts/dramboot.ld
@@ -46,7 +46,7 @@ SECTIONS
   .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
   }
 

--- a/boards/arm64/imx8/imx8qm-mek/scripts/dramboot.ld
+++ b/boards/arm64/imx8/imx8qm-mek/scripts/dramboot.ld
@@ -46,7 +46,7 @@ SECTIONS
   .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
   }
 

--- a/boards/arm64/qemu/qemu-armv8a/scripts/dramboot.ld
+++ b/boards/arm64/qemu/qemu-armv8a/scripts/dramboot.ld
@@ -62,7 +62,7 @@ SECTIONS
   .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
   }
 

--- a/boards/arm64/rk3399/nanopi_m4/scripts/dramboot.ld
+++ b/boards/arm64/rk3399/nanopi_m4/scripts/dramboot.ld
@@ -56,7 +56,7 @@ SECTIONS
   .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
   }
 

--- a/boards/arm64/rk3399/pinephonepro/scripts/dramboot.ld
+++ b/boards/arm64/rk3399/pinephonepro/scripts/dramboot.ld
@@ -47,7 +47,7 @@ SECTIONS
   .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
   }
 

--- a/boards/arm64/vdk/vdk-armv8r/scripts/dramboot.ld
+++ b/boards/arm64/vdk/vdk-armv8r/scripts/dramboot.ld
@@ -1,0 +1,128 @@
+/****************************************************************************
+ * boards/arm64/vdk/vdk-armv8r/scripts/dramboot.ld
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+OUTPUT_ARCH(aarch64)
+
+ENTRY(__start)
+
+PHDRS
+{
+  text PT_LOAD ;
+}
+
+SECTIONS
+{
+  . = 0x80000000;  /* uboot load address */
+  _start = .;
+  .text : {
+        _stext = .;            /* Text section */
+       *(.text)
+       *(.text.cold)
+       *(.text.unlikely)
+       *(.fixup)
+       *(.gnu.warning)
+  } :text = 0x9090
+
+  . = ALIGN(4096);
+
+  .init_section : {
+        _sinit = ABSOLUTE(.);
+        KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
+        _einit = ABSOLUTE(.);
+  }
+
+  . = ALIGN(4096);
+
+  .vector : {
+        _vector_start = .;
+        KEEP(*(.exc_vector_table))
+        KEEP(*(".exc_vector_table.*"))
+        KEEP(*(.vectors))
+       _vector_end = .;
+  } :text
+  . = ALIGN(4096);
+  _etext = .; /* End_1 of .text */
+  _sztext = _etext - _stext;
+
+  . = ALIGN(4096);
+  .rodata : {
+        _srodata = .;          /* Read-only data */
+       *(.rodata)
+       *(.rodata.*)
+       *(.data.rel.ro)
+       *(.data.rel.ro.*)
+  } :text
+  . = ALIGN(4096);
+  _erodata = .;                /* End of read-only data */
+  _szrodata = _erodata - _srodata;
+  _eronly = .;  /* End of read-only data */
+
+  . = ALIGN(4096);
+  .data : {                    /* Data */
+        _sdata = .;
+       *(.data.page_aligned)
+       *(.data)
+       . = ALIGN(8);
+       *(.data.rel)
+       *(.data.rel.*)
+       CONSTRUCTORS
+  } :text
+  _edata = .; /* End+1 of .data */
+
+  .bss : {                     /* BSS */
+       . = ALIGN(8);
+       _sbss = .;
+       *(.bss)
+       . = ALIGN(8);
+  } :text
+  . = ALIGN(4096);
+  _ebss = .;
+  _szbss = _ebss - _sbss;
+
+  .initstack : {             /* INIT STACK */
+       _s_initstack = .;
+       *(.initstack)
+       . = ALIGN(16);
+  } :text
+  . = ALIGN(4096);
+  _e_initstack = . ;
+  g_idle_topstack = . ;
+
+  _szdata = _e_initstack - _sdata;
+
+  /* Sections to be discarded */
+  /DISCARD/ : {
+       *(.exit.text)
+       *(.exit.data)
+       *(.exitcall.exit)
+       *(.eh_frame)
+  }
+
+  /* Stabs debugging sections.  */
+  .stab 0 : { *(.stab) }
+  .stabstr 0 : { *(.stabstr) }
+  .stab.excl 0 : { *(.stab.excl) }
+  .stab.exclstr 0 : { *(.stab.exclstr) }
+  .stab.index 0 : { *(.stab.index) }
+  .stab.indexstr 0 : { *(.stab.indexstr) }
+  .comment 0 : { *(.comment) }
+}
+

--- a/boards/or1k/mor1kx/or1k/scripts/flash.ld
+++ b/boards/or1k/mor1kx/or1k/scripts/flash.ld
@@ -50,7 +50,7 @@ SECTIONS
     {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > dram
 

--- a/boards/renesas/rx65n/rx65n-grrose/scripts/linker_script.ld
+++ b/boards/renesas/rx65n/rx65n-grrose/scripts/linker_script.ld
@@ -58,7 +58,7 @@ SECTIONS
 		__preinit_array_end = .;
 		__init_array_start = (. + 3) & ~ 3;
 		KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-		KEEP(*(.init_array .ctors))
+		KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
 		__init_array_end = .;
 		__fini_array_start = .;
 		KEEP(*(.fini_array))

--- a/boards/renesas/rx65n/rx65n-rsk1mb/scripts/linker_script.ld
+++ b/boards/renesas/rx65n/rx65n-rsk1mb/scripts/linker_script.ld
@@ -49,7 +49,7 @@ SECTIONS
 		__preinit_array_end = .;
 		__init_array_start = (. + 3) & ~ 3;
 		KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-		KEEP(*(.init_array .ctors))
+		KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
 		__init_array_end = .;
 		__fini_array_start = .;
 		KEEP(*(.fini_array))

--- a/boards/renesas/rx65n/rx65n-rsk2mb/scripts/linker_script.ld
+++ b/boards/renesas/rx65n/rx65n-rsk2mb/scripts/linker_script.ld
@@ -50,7 +50,7 @@ SECTIONS
 		__preinit_array_end = .;
 		__init_array_start = (. + 3) & ~ 3;
 		KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-		KEEP(*(.init_array .ctors))
+		KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
 		__init_array_end = .;
 		__fini_array_start = .;
 		KEEP(*(.fini_array))

--- a/boards/renesas/rx65n/rx65n/scripts/linker_script.ld
+++ b/boards/renesas/rx65n/rx65n/scripts/linker_script.ld
@@ -58,7 +58,7 @@ SECTIONS
 		__preinit_array_end = .;
 		__init_array_start = (. + 3) & ~ 3;
 		KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-		KEEP(*(.init_array .ctors))
+		KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
 		__init_array_end = .;
 		__fini_array_start = .;
 		KEEP(*(.fini_array))

--- a/boards/risc-v/c906/smartl-c906/scripts/ld-qemu.script
+++ b/boards/risc-v/c906/smartl-c906/scripts/ld-qemu.script
@@ -49,7 +49,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/risc-v/c906/smartl-c906/scripts/ld.script
+++ b/boards/risc-v/c906/smartl-c906/scripts/ld.script
@@ -49,7 +49,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/risc-v/c906/smartl-c906/scripts/user-space.ld
+++ b/boards/risc-v/c906/smartl-c906/scripts/user-space.ld
@@ -58,7 +58,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > uflash
 

--- a/boards/risc-v/fe310/hifive1-revb/scripts/ld-qemu.script
+++ b/boards/risc-v/fe310/hifive1-revb/scripts/ld-qemu.script
@@ -49,7 +49,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/risc-v/fe310/hifive1-revb/scripts/ld.script
+++ b/boards/risc-v/fe310/hifive1-revb/scripts/ld.script
@@ -49,7 +49,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/risc-v/hpm6750/hpm6750evk2/scripts/ld.script
+++ b/boards/risc-v/hpm6750/hpm6750evk2/scripts/ld.script
@@ -48,7 +48,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > ilm
 

--- a/boards/risc-v/k210/maix-bit/scripts/ld.script
+++ b/boards/risc-v/k210/maix-bit/scripts/ld.script
@@ -56,7 +56,7 @@ SECTIONS
     .init_section : ALIGN(8) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         . = ALIGN(8);
         _einit = ABSOLUTE(.);
     } > progmem

--- a/boards/risc-v/k210/maix-bit/scripts/user-space.ld
+++ b/boards/risc-v/k210/maix-bit/scripts/user-space.ld
@@ -48,7 +48,7 @@ SECTIONS
     .init_section : ALIGN(8) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         . = ALIGN(8);
         _einit = ABSOLUTE(.);
     } > uflash

--- a/boards/risc-v/litex/arty_a7/scripts/gnu-elf.ld
+++ b/boards/risc-v/litex/arty_a7/scripts/gnu-elf.ld
@@ -76,8 +76,8 @@ SECTIONS
     {
       _sctors = . ;
       KEEP (*(.ctors))       /* Old ABI:  Unallocated */
-      KEEP (*(.init_array))  /* New ABI:  Allocated */
-      KEEP (*(SORT(.init_array.*)))
+      KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+      KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
       _ectors = . ;
     }
 

--- a/boards/risc-v/litex/arty_a7/scripts/ld-kernel.script
+++ b/boards/risc-v/litex/arty_a7/scripts/ld-kernel.script
@@ -71,7 +71,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > kflash
 

--- a/boards/risc-v/litex/arty_a7/scripts/ld.script
+++ b/boards/risc-v/litex/arty_a7/scripts/ld.script
@@ -49,7 +49,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/risc-v/mpfs/icicle/scripts/kernel-space.ld
+++ b/boards/risc-v/mpfs/icicle/scripts/kernel-space.ld
@@ -62,7 +62,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > kflash
 

--- a/boards/risc-v/mpfs/icicle/scripts/ld-envm-opensbi.script
+++ b/boards/risc-v/mpfs/icicle/scripts/ld-envm-opensbi.script
@@ -79,7 +79,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > envm
 

--- a/boards/risc-v/mpfs/icicle/scripts/ld-envm.script
+++ b/boards/risc-v/mpfs/icicle/scripts/ld-envm.script
@@ -57,7 +57,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > envm
 

--- a/boards/risc-v/mpfs/icicle/scripts/ld-ihc-ch2.script
+++ b/boards/risc-v/mpfs/icicle/scripts/ld-ihc-ch2.script
@@ -78,7 +78,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/risc-v/mpfs/icicle/scripts/ld-ihc.script
+++ b/boards/risc-v/mpfs/icicle/scripts/ld-ihc.script
@@ -78,7 +78,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/risc-v/mpfs/icicle/scripts/ld-kernel.script
+++ b/boards/risc-v/mpfs/icicle/scripts/ld-kernel.script
@@ -68,7 +68,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > kflash
 

--- a/boards/risc-v/mpfs/icicle/scripts/ld.script
+++ b/boards/risc-v/mpfs/icicle/scripts/ld.script
@@ -53,7 +53,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/risc-v/mpfs/icicle/scripts/user-space.ld
+++ b/boards/risc-v/mpfs/icicle/scripts/user-space.ld
@@ -58,7 +58,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > uflash
 

--- a/boards/risc-v/mpfs/m100pfsevp/scripts/ld-envm.script
+++ b/boards/risc-v/mpfs/m100pfsevp/scripts/ld-envm.script
@@ -50,7 +50,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > envm
 

--- a/boards/risc-v/mpfs/m100pfsevp/scripts/ld.script
+++ b/boards/risc-v/mpfs/m100pfsevp/scripts/ld.script
@@ -49,7 +49,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > progmem
 

--- a/boards/risc-v/mpfs/m100pfsevp/scripts/user-space.ld
+++ b/boards/risc-v/mpfs/m100pfsevp/scripts/user-space.ld
@@ -58,7 +58,7 @@ SECTIONS
     .init_section : {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > uflash
 

--- a/boards/risc-v/rv32m1/rv32m1-vega/scripts/ld-itcm.script
+++ b/boards/risc-v/rv32m1/rv32m1-vega/scripts/ld-itcm.script
@@ -56,7 +56,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 

--- a/boards/risc-v/rv32m1/rv32m1-vega/scripts/ld.script
+++ b/boards/risc-v/rv32m1/rv32m1-vega/scripts/ld.script
@@ -55,7 +55,7 @@ SECTIONS
     .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array .ctors))
+        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 


### PR DESCRIPTION
## Summary
(1) Keep the `.init_array` and `.ctors` symbols and sort them according to their initialization priority. 
(2) Exclude symbols ending with crtend.* and crtbegin.* to support c++ application.if we not exclude crtend.* crtbegin.* frame_dummy will be added when enable any c++ application with global variables, this symbol execution is problematic, removing it does not affect the application.
## Impact

## Testing

