### PR TITLE
nuttx/sim:By default, stack-use-after-return is not checked when enabling SIM_ASAN.

### DIFF
--- a/arch/sim/src/sim/sim_head.c
+++ b/arch/sim/src/sim/sim_head.c
@@ -115,7 +115,8 @@ const char *__asan_default_options(void)
          " allocator_frees_and_returns_null_on_realloc_zero=0"
          " check_initialization_order=1"
          " fast_unwind_on_malloc=0"
-         " strict_init_order=1";
+         " strict_init_order=1"
+         " detect_stack_use_after_return=0";
 }
 
 const char *__lsan_default_options(void)


### PR DESCRIPTION
## Summary
==263401==ERROR: AddressSanitizer: stack-use-after-return on address 0xf515f260 at pc 0x042434f0 bp 0x9ac24e78 sp 0x9ac24e68 WRITE of size 4 at 0xf515f260 thread T0
    #0 0x42434ef in nxsem_get_value semaphore/sem_getvalue.c:65
    #1 0x413110d in work_thread wqueue/kwork_thread.c:195
    #2 0x412c4f6 in nxtask_start task/task_start.c:129
    #3 0x427b1fc in pre_start sim/sim_initialstate.c:52

Address 0xf515f260 is located in stack of thread T0 at offset 32 in frame
    #0 0x928c9e3 in host_settimer sim/posix/sim_hosttime.c:104

  This frame has 1 object(s):
    [32, 48) 'it' (line 105) <== Memory access at offset 32 is inside this variable
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
## Impact

## Testing

