### PR TITLE
fs/mmap: Fix build warning with [-Wmaybe-uninitialized].

### DIFF
--- a/fs/mmap/fs_rammap.c
+++ b/fs/mmap/fs_rammap.c
@@ -52,7 +52,7 @@ static int unmap_rammap(FAR struct task_group_s *group,
                         FAR void *start,
                         size_t length)
 {
-  FAR void *newaddr;
+  FAR void *newaddr = NULL;
   off_t offset;
   bool kernel = entry->priv.i;
   int ret = OK;


### PR DESCRIPTION
## Summary
mmap/fs_rammap.c: In function ‘unmap_rammap’:
mmap/fs_rammap.c:117:20: warning: ‘newaddr’ may be used uninitialized [-Wmaybe-uninitialized]
  117 |       entry->vaddr = newaddr;
      |       ~~~~~~~~~~~~~^~~~~~~~~
mmap/fs_rammap.c:56:13: note: ‘newaddr’ was declared here
   56 |   FAR void *newaddr;
      |             ^~~~~~~

## Impact

## Testing

