### PR TITLE
netinet/in.h: add macro definitions to resolve compilation errors

### DIFF
--- a/include/netinet/in.h
+++ b/include/netinet/in.h
@@ -225,6 +225,12 @@
    (a)->s6_addr32[1] == 0 && \
    (a)->s6_addr32[2] == HTONL(0xffff))
 
+#define IN6_IS_ADDR_MC_LINKLOCAL(a) \
+  (IN6_IS_ADDR_MULTICAST(a) && ((a)->s6_addr[1] & 0xf) == 0x2)
+
+#define IN6_IS_ADDR_SITELOCAL(a) \
+  (((a)->s6_addr16[0] & HTONS(0xffc0)) == HTONS(0xfec0))
+
 /* This macro to convert a 16/32-bit constant values quantity from host byte
  * order to network byte order.  The 16-bit version of this macro is required
  * for uIP:


### PR DESCRIPTION
## Summary
solve the compiling problem of the third-party library, add IN6_IS_ADDR_MC_LINKLOCAL and IN6_IS_ADDR_SITELOCAL definitions.

## Impact

## Testing
qemu:local
