### PR TITLE
Bug fix for munmap and typo issues.

### DIFF
--- a/fs/mmap/fs_mmap.c
+++ b/fs/mmap/fs_mmap.c
@@ -202,7 +202,7 @@ int file_mmap(FAR struct file *filep, FAR void *start, size_t length,
  *        only file system that meets this requirement.
  *     b. The underlying block driver supports the BIOC_XIPBASE ioctl
  *        command that maps the underlying media to a randomly accessible
- *        address. At  present, only the RAM/ROM disk driver does this.
+ *        address. At present, only the RAM/ROM disk driver does this.
  *
  *   2. If CONFIG_FS_RAMMAP is defined in the configuration, then mmap() will
  *      support simulation of memory mapped files by copying files whole

--- a/fs/mmap/fs_munmap.c
+++ b/fs/mmap/fs_munmap.c
@@ -62,11 +62,13 @@ static int file_munmap_(FAR void *start, size_t length, bool kernel)
     {
       entry = mm_map_find(mm, start, length);
 
-      /* If entry don't find, the start and length is invalid. */
+      /* If the mapping created by certain FS driver, the corresponding
+       * entry will not be added to the queue.In this case entry == NULL
+       * should not set an errno.
+       */
 
       if (entry == NULL)
         {
-          ret = -EINVAL;
           goto unlock;
         }
 

--- a/fs/mmap/fs_munmap.c
+++ b/fs/mmap/fs_munmap.c
@@ -120,19 +120,19 @@ int file_munmap(FAR void *start, size_t length)
  *   1. mmap() is the API that is used to support direct access to random
  *     access media under the following very restrictive conditions:
  *
- *     a. The filesystem impelements the mmap file operation.  Any file
+ *     a. The filesystem implements the mmap file operation.  Any file
  *        system that maps files contiguously on the media should support
  *        this ioctl. (vs. file system that scatter files over the media
  *        in non-contiguous sectors).  As of this writing, ROMFS is the
  *        only file system that meets this requirement.
  *     b. The underlying block driver supports the BIOC_XIPBASE ioctl
  *        command that maps the underlying media to a randomly accessible
- *        address. At  present, only the RAM/ROM disk driver does this.
+ *        address. At present, only the RAM/ROM disk driver does this.
  *
- *     munmap() is still not required in this first case.  In this first
- *     The mapped address is a static address in the MCUs address space
- *     does not need to be munmapped.  Support for munmap() in this case
- *     provided by the simple definition in sys/mman.h:
+ *     munmap() is still not required in this first case. The mapped address
+ *     is a static address in the MCUs address space does not need to be
+ *     munmapped.  Support for munmap() in this case provided by the simple
+ *     definition in sys/mman.h:
  *
  *        #define munmap(start, length)
  *
@@ -143,10 +143,10 @@ int file_munmap(FAR void *start, size_t length)
  *
  * Input Parameters:
  *   start   The start address of the mapping to delete.  For this
- *           simplified munmap() implementation, the *must* be the start
+ *           simplified munmap() implementation, the must be the start
  *           address of the memory region (the same address returned by
  *           mmap()).
- *   length  The length region to be umapped.
+ *   length  The length region to be unmapped.
  *
  * Returned Value:
  *   On success, munmap() returns 0, on failure -1, and errno is set


### PR DESCRIPTION
## Summary
Bug fix for munmap and typo issues.

## Impact
According to the munmap(3p) specification 'The behavior of this function is unspecified if the mapping was not established by
a call to mmap()', mmap and munmap are used in paried.

However, some mmap implementation driven by FS do not add
corresponding entries to the queue. The relevant patches as follow:
1.https://github.com/apache/nuttx/commit/dd97900221a84a2dc50ff229176fd14577ae9604
2.https://github.com/apache/nuttx/commit/f33dc4df3fcbf5bcb1f5a5b4d4d982f611fd92a9

In this case, munmap will not find the entry and errno will be set as EINVAL, this isn't developers want.

## Testing
Pass.

The other patch is a fix for comment description.

