### PR TITLE
net/pkt: fix issue that set nonblock by fcntl does not take effect

### DIFF
--- a/net/pkt/pkt_sockif.c
+++ b/net/pkt/pkt_sockif.c
@@ -168,7 +168,7 @@ static int pkt_setup(FAR struct socket *psock)
 
 static sockcaps_t pkt_sockcaps(FAR struct socket *psock)
 {
-  return 0;
+  return SOCKCAP_NONBLOCKING;
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
pkt_sockcaps returns SOCKCAP_NONBLOCKING to indicate that pkt supports nonblock configuration.

## Impact

## Testing
x86_64 board.
