### PR TITLE
riscv/qemu-rv: add RPTUN cmake

### DIFF
--- a/arch/risc-v/src/qemu-rv/CMakeLists.txt
+++ b/arch/risc-v/src/qemu-rv/CMakeLists.txt
@@ -43,4 +43,8 @@ if(CONFIG_BUILD_PROTECTED)
   list(APPEND SRCS qemu_rv_userspace.c)
 endif()
 
+if(CONFIG_RPTUN)
+  list(APPEND SRCS qemu_rv_rptun.c)
+endif()
+
 target_sources(arch PRIVATE ${SRCS})


### PR DESCRIPTION
## Summary

This adds CMake support of RPTUN devices for QEMU-RV chip.

## Impacts

None

## Testing

- local checks with QEMU-RV
- CI checks
