### PR TITLE
tcp: fix tcp crash when thread_cancel the thread

### DIFF
--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -442,8 +442,7 @@ struct tcp_callback_s
 {
   FAR struct tcp_conn_s *tc_conn;
   FAR struct devif_callback_s *tc_cb;
-  sem_t *tc_sem;
-  bool tc_free;
+  FAR sem_t *tc_sem;
 };
 
 /****************************************************************************

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -438,6 +438,14 @@ struct tcp_backlog_s
 };
 #endif
 
+struct tcp_callback_s
+{
+  FAR struct tcp_conn_s *tc_conn;
+  FAR struct devif_callback_s *tc_cb;
+  sem_t *tc_sem;
+  bool tc_free;
+};
+
 /****************************************************************************
  * Public Data
  ****************************************************************************/
@@ -1387,6 +1395,19 @@ uint16_t tcp_datahandler(FAR struct net_driver_s *dev,
  *   Called from network socket logic.  The network may or may not be locked.
  *
  ****************************************************************************/
+
+/****************************************************************************
+ * Name: tcp_callback_cleanup
+ *
+ * Description:
+ *   Cleanup data and cb when thread is canceled.
+ *
+ * Input Parameters:
+ *   arg - A pointer with conn and callback struct.
+ *
+ ****************************************************************************/
+
+void tcp_callback_cleanup(FAR void *arg);
 
 #ifdef CONFIG_NET_TCPBACKLOG
 int tcp_backlogcreate(FAR struct tcp_conn_s *conn, int nblg);

--- a/net/tcp/tcp_callback.c
+++ b/net/tcp/tcp_callback.c
@@ -420,4 +420,35 @@ uint16_t tcp_datahandler(FAR struct net_driver_s *dev,
   return buflen;
 }
 
+/****************************************************************************
+ * Name: tcp_callback_cleanup
+ *
+ * Description:
+ *   Cleanup data and cb when thread is canceled.
+ *
+ * Input Parameters:
+ *   arg - A pointer with conn and callback struct.
+ *
+ ****************************************************************************/
+
+void tcp_callback_cleanup(FAR void *arg)
+{
+  FAR struct tcp_callback_s *cb = (FAR struct tcp_callback_s *)arg;
+
+  nerr("ERROR: pthread is being canceled, need to cleanup cb\n");
+
+  tcp_callback_free(cb->tc_conn, cb->tc_cb);
+  if (cb->tc_sem)
+    {
+      nxsem_destroy(cb->tc_sem);
+    }
+
+  /* Only connect canceled need to tcp_free */
+
+  if (cb->tc_free)
+    {
+      tcp_free(cb->tc_conn);
+    }
+}
+
 #endif /* NET_TCP_HAVE_STACK */

--- a/net/tcp/tcp_callback.c
+++ b/net/tcp/tcp_callback.c
@@ -436,19 +436,7 @@ void tcp_callback_cleanup(FAR void *arg)
   FAR struct tcp_callback_s *cb = (FAR struct tcp_callback_s *)arg;
 
   nerr("ERROR: pthread is being canceled, need to cleanup cb\n");
-
   tcp_callback_free(cb->tc_conn, cb->tc_cb);
-  if (cb->tc_sem)
-    {
-      nxsem_destroy(cb->tc_sem);
-    }
-
-  /* Only connect canceled need to tcp_free */
-
-  if (cb->tc_free)
-    {
-      tcp_free(cb->tc_conn);
-    }
+  nxsem_destroy(cb->tc_sem);
 }
-
 #endif /* NET_TCP_HAVE_STACK */

--- a/net/tcp/tcp_connect.c
+++ b/net/tcp/tcp_connect.c
@@ -35,6 +35,7 @@
 #include <arch/irq.h>
 
 #include <nuttx/semaphore.h>
+#include <nuttx/tls.h>
 #include <nuttx/net/net.h>
 #include <nuttx/net/netdev.h>
 #include <nuttx/net/udp.h>
@@ -287,6 +288,7 @@ int psock_tcp_connect(FAR struct socket *psock,
 {
   FAR struct tcp_conn_s *conn;
   struct tcp_connect_s   state;
+  struct tcp_callback_s  info;
   int                    ret = OK;
 
   /* Interrupts must be disabled through all of the following because
@@ -303,6 +305,11 @@ int psock_tcp_connect(FAR struct socket *psock,
   if (conn == NULL) /* Should always be non-NULL */
     {
       ret = -EINVAL;
+    }
+  else if (conn->tcpstateflags == TCP_CLOSED)
+    {
+      nerr("ERROR: tcp conn was released, connect failed \n");
+      ret = -ENOTCONN;
     }
   else
     {
@@ -359,6 +366,16 @@ int psock_tcp_connect(FAR struct socket *psock,
           ret = psock_setup_callbacks(psock, &state);
           if (ret >= 0)
             {
+              /* Push a cancellation point onto the stack.  This will be
+               * called if the thread is canceled.
+               */
+
+              info.tc_conn = conn;
+              info.tc_cb = state.tc_cb;
+              info.tc_sem = &state.tc_sem;
+              info.tc_free = true;
+              tls_cleanup_push(tls_get_info(), tcp_callback_cleanup, &info);
+
               /* Wait for either the connect to complete or for an
                * error/timeout to occur.
                * NOTES:  net_sem_wait will also terminate if a
@@ -366,6 +383,8 @@ int psock_tcp_connect(FAR struct socket *psock,
                */
 
               ret = net_sem_wait(&state.tc_sem);
+
+              tls_cleanup_pop(tls_get_info(), 0);
 
               /* Uninitialize the state structure */
 

--- a/net/tcp/tcp_connect.c
+++ b/net/tcp/tcp_connect.c
@@ -373,7 +373,6 @@ int psock_tcp_connect(FAR struct socket *psock,
               info.tc_conn = conn;
               info.tc_cb = state.tc_cb;
               info.tc_sem = &state.tc_sem;
-              info.tc_free = true;
               tls_cleanup_push(tls_get_info(), tcp_callback_cleanup, &info);
 
               /* Wait for either the connect to complete or for an

--- a/net/tcp/tcp_recvfrom.c
+++ b/net/tcp/tcp_recvfrom.c
@@ -31,6 +31,7 @@
 #include <assert.h>
 
 #include <nuttx/semaphore.h>
+#include <nuttx/tls.h>
 #include <nuttx/net/net.h>
 #include <nuttx/mm/iob.h>
 #include <nuttx/net/netdev.h>
@@ -615,6 +616,7 @@ ssize_t psock_tcp_recvfrom(FAR struct socket *psock, FAR struct msghdr *msg,
   size_t                 len     = msg->msg_iov->iov_len;
   struct tcp_recvfrom_s  state;
   FAR struct tcp_conn_s *conn;
+  struct tcp_callback_s  info;
   int                    ret;
 
   net_lock();
@@ -722,6 +724,16 @@ ssize_t psock_tcp_recvfrom(FAR struct socket *psock, FAR struct msghdr *msg,
           state.ir_cb->priv    = (FAR void *)&state;
           state.ir_cb->event   = tcp_recvhandler;
 
+          /* Push a cancellation point onto the stack.  This will be
+           * called if the thread is canceled.
+           */
+
+          info.tc_conn = conn;
+          info.tc_cb   = state.ir_cb;
+          info.tc_sem  = &state.ir_sem;
+          info.tc_free = false;
+          tls_cleanup_push(tls_get_info(), tcp_callback_cleanup, &info);
+
           /* Wait for either the receive to complete or for an error/timeout
            * to occur.  net_sem_timedwait will also terminate if a signal is
            * received.
@@ -729,6 +741,7 @@ ssize_t psock_tcp_recvfrom(FAR struct socket *psock, FAR struct msghdr *msg,
 
           ret = net_sem_timedwait(&state.ir_sem,
                                _SO_TIMEOUT(conn->sconn.s_rcvtimeo));
+          tls_cleanup_pop(tls_get_info(), 0);
           if (ret == -ETIMEDOUT)
             {
               ret = -EAGAIN;

--- a/net/tcp/tcp_recvfrom.c
+++ b/net/tcp/tcp_recvfrom.c
@@ -731,7 +731,6 @@ ssize_t psock_tcp_recvfrom(FAR struct socket *psock, FAR struct msghdr *msg,
           info.tc_conn = conn;
           info.tc_cb   = state.ir_cb;
           info.tc_sem  = &state.ir_sem;
-          info.tc_free = false;
           tls_cleanup_push(tls_get_info(), tcp_callback_cleanup, &info);
 
           /* Wait for either the receive to complete or for an error/timeout

--- a/net/tcp/tcp_send_buffered.c
+++ b/net/tcp/tcp_send_buffered.c
@@ -47,6 +47,7 @@
 #include <debug.h>
 
 #include <arch/irq.h>
+#include <nuttx/tls.h>
 #include <nuttx/net/net.h>
 #include <nuttx/mm/iob.h>
 #include <nuttx/net/netdev.h>
@@ -1417,14 +1418,27 @@ ssize_t psock_tcp_send(FAR struct socket *psock, FAR const void *buf,
 
       while (tcp_wrbuffer_inqueue_size(conn) >= conn->snd_bufs)
         {
+          struct tcp_callback_s info;
+
           if (nonblock)
             {
               ret = -EAGAIN;
               goto errout_with_lock;
             }
 
+          /* Push a cancellation point onto the stack.  This will be
+           * called if the thread is canceled.
+           */
+
+          info.tc_conn = conn;
+          info.tc_cb   = conn->sndcb;
+          info.tc_sem  = &conn->snd_sem;
+          info.tc_free = false;
+          tls_cleanup_push(tls_get_info(), tcp_callback_cleanup, &info);
+
           ret = net_sem_timedwait_uninterruptible(&conn->snd_sem,
             tcp_send_gettimeout(start, timeout));
+          tls_cleanup_pop(tls_get_info(), 0);
           if (ret < 0)
             {
               if (ret == -ETIMEDOUT)

--- a/net/tcp/tcp_send_buffered.c
+++ b/net/tcp/tcp_send_buffered.c
@@ -1433,7 +1433,6 @@ ssize_t psock_tcp_send(FAR struct socket *psock, FAR const void *buf,
           info.tc_conn = conn;
           info.tc_cb   = conn->sndcb;
           info.tc_sem  = &conn->snd_sem;
-          info.tc_free = false;
           tls_cleanup_push(tls_get_info(), tcp_callback_cleanup, &info);
 
           ret = net_sem_timedwait_uninterruptible(&conn->snd_sem,

--- a/net/tcp/tcp_send_unbuffered.c
+++ b/net/tcp/tcp_send_unbuffered.c
@@ -611,7 +611,6 @@ ssize_t psock_tcp_send(FAR struct socket *psock,
               info.tc_conn = conn;
               info.tc_cb   = state.snd_cb;
               info.tc_sem  = &state.snd_sem;
-              info.tc_free = false;
               tls_cleanup_push(tls_get_info(), tcp_callback_cleanup, &info);
 
               ret = net_sem_timedwait(&state.snd_sem,

--- a/net/tcp/tcp_send_unbuffered.c
+++ b/net/tcp/tcp_send_unbuffered.c
@@ -40,6 +40,7 @@
 #include <arch/irq.h>
 
 #include <nuttx/semaphore.h>
+#include <nuttx/tls.h>
 #include <nuttx/net/net.h>
 #include <nuttx/net/netdev.h>
 #include <nuttx/net/tcp.h>
@@ -479,6 +480,7 @@ ssize_t psock_tcp_send(FAR struct socket *psock,
                        FAR const void *buf, size_t len, int flags)
 {
   FAR struct tcp_conn_s *conn;
+  struct tcp_callback_s info;
   struct send_s state;
   int ret = OK;
 
@@ -602,8 +604,19 @@ ssize_t psock_tcp_send(FAR struct socket *psock,
             {
               uint32_t acked = state.snd_acked;
 
+              /* Push a cancellation point onto the stack.  This will be
+               * called if the thread is canceled.
+               */
+
+              info.tc_conn = conn;
+              info.tc_cb   = state.snd_cb;
+              info.tc_sem  = &state.snd_sem;
+              info.tc_free = false;
+              tls_cleanup_push(tls_get_info(), tcp_callback_cleanup, &info);
+
               ret = net_sem_timedwait(&state.snd_sem,
                                   _SO_TIMEOUT(conn->sconn.s_sndtimeo));
+              tls_cleanup_pop(tls_get_info(), 0);
               if (ret != -ETIMEDOUT || acked == state.snd_acked)
                 {
                   if (ret == -ETIMEDOUT)


### PR DESCRIPTION
## Summary
tcp in send/recv/connect sem-wait and other thread cancel the sem-wait thread, then the lpwork(or others) do the callback of
tcp send/recv/connect cb will crash.

## Impact
thread_cancel

## Testing
tested on sim and vela product.
You can run to thread, one thread connect and recv TCP socket, the others close the socket in random time and cancel the thread.Using sh to run the case always,can you will see the crash of tcp-callback on sim. 
