### PR TITLE
[driver][bcm43xxx] reset tx_seq of sido-bus when ifdown wlan-if

### DIFF
--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_sdio.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_sdio.c
@@ -895,6 +895,7 @@ int bcmf_bus_sdio_active(FAR struct bcmf_dev_s *priv, bool active)
 exit_uninit_hw:
   sbus->ready = false;
   bcmf_hwuninitialize(sbus);
+  sbus->tx_seq = 0;
 
   return ret;
 }


### PR DESCRIPTION
## Summary
may busyloop when frequently turn up/down wlan NIC 

## Impact
Wifi

## Testing
Test on vela product
