### PR TITLE
audio:fix crash when driver_audio capture

### DIFF
--- a/arch/sim/src/sim/posix/sim_alsa.c
+++ b/arch/sim/src/sim/posix/sim_alsa.c
@@ -719,7 +719,7 @@ static int sim_audio_ioctl(struct audio_lowerhalf_s *dev, int cmd,
           info->nbuffers    = priv->nbuffers;
           info->buffer_size = priv->buffer_size;
 
-          if (priv->ops->get_samples)
+          if (priv->ops && priv->ops->get_samples)
             {
               info->buffer_size = MAX(info->buffer_size,
                                       priv->ops->get_samples(priv->codec) *


### PR DESCRIPTION
## Summary
sim/posix/sim_alsa.c:728:24: runtime error: member access within null pointer of type 'const struct sim_codec_ops_s'
## Impact

## Testing
tested on vela sim.
