### PR TITLE
nuttx/audio: add offload buffer size config

### DIFF
--- a/arch/sim/Kconfig
+++ b/arch/sim/Kconfig
@@ -319,6 +319,24 @@ endchoice
 
 endif
 
+config SIM_OFFLOAD_NUM_BUFFERS
+	int "Number of offload buffers for audio processing"
+	default 2
+	---help---
+		Specifies the number of offload buffers to allocate for audio processing.
+		If Driver Specified buffer sizes is enabled (below), then the
+		low-level drivers will have the opportunity to override this
+		value.
+
+config SIM_OFFLOAD_BUFFER_NUMBYTES
+	int "Size of each offload buffer for audio processing"
+	default 32767
+	---help---
+		Specifies the allocation size for each offload buffer
+		If Driver Specified buffer sizes is enabled (below), then the
+		low-level drivers will have the opportunity to override this
+		value.
+
 config SIM_CAMERA
 	bool "Simulated video support"
 	depends on VIDEO

--- a/arch/sim/src/sim/posix/sim_alsa.c
+++ b/arch/sim/src/sim/posix/sim_alsa.c
@@ -723,6 +723,12 @@ static int sim_audio_ioctl(struct audio_lowerhalf_s *dev, int cmd,
           struct ap_buffer_info_s *info =
               (struct ap_buffer_info_s *)arg;
 
+          if (priv->offload && priv->playback)
+            {
+              priv->nbuffers = CONFIG_SIM_OFFLOAD_NUM_BUFFERS;
+              priv->buffer_size = CONFIG_SIM_OFFLOAD_BUFFER_NUMBYTES;
+            }
+
           if (priv->ops && priv->ops->get_samples)
             {
               priv->buffer_size = MAX(priv->buffer_size,

--- a/arch/sim/src/sim/posix/sim_alsa.c
+++ b/arch/sim/src/sim/posix/sim_alsa.c
@@ -723,7 +723,7 @@ static int sim_audio_ioctl(struct audio_lowerhalf_s *dev, int cmd,
           struct ap_buffer_info_s *info =
               (struct ap_buffer_info_s *)arg;
 
-          if (priv->ops->get_samples)
+          if (priv->ops && priv->ops->get_samples)
             {
               priv->buffer_size = MAX(priv->buffer_size,
                                       priv->ops->get_samples(priv->codec) *


### PR DESCRIPTION
## Summary
add offload buffer size config and fix.
## Impact

## Testing
tested on vela sim.
