### PR TITLE
netdev/lower: Add reclaim callback and use it in virtio-net

### DIFF
--- a/drivers/net/netdev_upperhalf.c
+++ b/drivers/net/netdev_upperhalf.c
@@ -258,7 +258,16 @@ netdev_upper_alloc(FAR struct netdev_lowerhalf_s *dev)
 
 static inline bool netdev_upper_can_tx(FAR struct netdev_upperhalf_s *upper)
 {
-  return netdev_lower_quota_load(upper->lower, NETPKT_TX) > 0;
+  FAR struct netdev_lowerhalf_s *lower = upper->lower;
+  int quota = netdev_lower_quota_load(lower, NETPKT_TX);
+
+  if (quota <= 0 && lower->ops->reclaim)
+    {
+      lower->ops->reclaim(lower);
+      quota = netdev_lower_quota_load(lower, NETPKT_TX);
+    }
+
+  return quota > 0;
 }
 
 /****************************************************************************

--- a/drivers/virtio/virtio-net.c
+++ b/drivers/virtio/virtio-net.c
@@ -160,6 +160,7 @@ static int virtio_net_rmmac(FAR struct netdev_lowerhalf_s *dev,
 static int virtio_net_ioctl(FAR struct netdev_lowerhalf_s *dev,
                             int cmd, unsigned long arg);
 #endif
+static void virtio_net_txfree(FAR struct netdev_lowerhalf_s *dev);
 
 static int  virtio_net_probe(FAR struct virtio_device *vdev);
 static void virtio_net_remove(FAR struct virtio_device *vdev);
@@ -189,6 +190,7 @@ static const struct netdev_ops_s g_virtio_net_ops =
 #ifdef CONFIG_NETDEV_IOCTL
   virtio_net_ioctl,
 #endif
+  virtio_net_txfree
 };
 
 /****************************************************************************
@@ -459,14 +461,6 @@ static netpkt_t *virtio_net_recv(FAR struct netdev_lowerhalf_s *dev)
       /* If we have no buffer left, enable RX callback. */
 
       virtqueue_enable_cb(vq);
-
-      /* We do transmit after recv, now it's time to free TX buffer.
-       * Depends on upper-half order (Call TX after RX).
-       *
-       * TODO: Find a better way to free TX buffer.
-       */
-
-      virtio_net_txfree((FAR struct netdev_lowerhalf_s *)priv);
 
       vrtinfo("get NULL buffer\n");
       return NULL;

--- a/include/nuttx/net/netdev_lowerhalf.h
+++ b/include/nuttx/net/netdev_lowerhalf.h
@@ -168,6 +168,10 @@ struct netdev_ops_s
   int (*ioctl)(FAR struct netdev_lowerhalf_s *dev, int cmd,
                unsigned long arg);
 #endif
+
+  /* reclaim - try to reclaim packets sent by netdev. */
+
+  void (*reclaim)(FAR struct netdev_lowerhalf_s *dev);
 };
 
 /* This structure is a set of wireless handlers, leave unsupported operations


### PR DESCRIPTION
## Summary
Add reclaim callback and use it in virtio-net

Patches included:
- netdev_lowerhalf: add reclaim callback in netdev_ops_s
- drivers/virtio-net: Use reclaim in ops to finish TODO

## Impact
Clear a TODO in virtio-net

## Testing
Manually with QEMU, no effect on speed.
