### PR TITLE
net/pkt: fix raw socket send data length is insufficient

### DIFF
--- a/net/pkt/pkt_sendmsg.c
+++ b/net/pkt/pkt_sendmsg.c
@@ -113,7 +113,7 @@ static uint16_t psock_send_eventhandler(FAR struct net_driver_s *dev,
               goto end_wait;
             }
 
-          dev->d_len       = dev->d_sndlen -= NET_LL_HDRLEN(dev);
+          dev->d_len       = dev->d_sndlen;
           pstate->snd_sent = pstate->snd_buflen;
 
           /* Make sure no ARP request overwrites this ARP request.  This


### PR DESCRIPTION
## Summary
net/pkt: fix raw socket send data length is insufficient
## Impact

## Testing
Using EXAMPLES_NETPKT (data length 128byte) for verification, it was found that the data length is insufficient, exactly missing 14 bytes (i.e., the length of the Ethernet header).
Before the modification, the data length was 14 bytes short. 
![image](https://github.com/user-attachments/assets/ffb13151-33c9-437f-9e66-2065941e1233)

After the modification, the data length is correct.
![image](https://github.com/user-attachments/assets/22b8a9c2-2a8b-404b-8510-b851a49df3be)

