### PR TITLE
irq: add [enter|leave]_critical_section_nonirq

### DIFF
--- a/include/nuttx/irq.h
+++ b/include/nuttx/irq.h
@@ -196,8 +196,10 @@ int irqchain_detach(int irq, xcpt_t isr, FAR void *arg);
  ****************************************************************************/
 
 #ifdef CONFIG_IRQCOUNT
+irqstate_t enter_critical_section_nonirq(void) noinstrument_function;
 irqstate_t enter_critical_section(void) noinstrument_function;
 #else
+#  define enter_critical_section_nonirq() up_irq_save()
 #  define enter_critical_section() up_irq_save()
 #endif
 
@@ -226,8 +228,10 @@ irqstate_t enter_critical_section(void) noinstrument_function;
  ****************************************************************************/
 
 #ifdef CONFIG_IRQCOUNT
+void leave_critical_section_nonirq(irqstate_t flags) noinstrument_function;
 void leave_critical_section(irqstate_t flags) noinstrument_function;
 #else
+#  define leave_critical_section_nonirq(f) up_irq_restore(f)
 #  define leave_critical_section(f) up_irq_restore(f)
 #endif
 

--- a/sched/mqueue/mq_receive.c
+++ b/sched/mqueue/mq_receive.c
@@ -96,7 +96,7 @@ ssize_t file_mq_receive(FAR struct file *mq, FAR char *msg, size_t msglen,
    * because messages can be sent from interrupt level.
    */
 
-  flags = enter_critical_section();
+  flags = enter_critical_section_nonirq();
 
   /* Get the message from the message queue */
 
@@ -114,7 +114,7 @@ ssize_t file_mq_receive(FAR struct file *mq, FAR char *msg, size_t msglen,
       ret = nxmq_do_receive(msgq, mqmsg, msg, prio);
     }
 
-  leave_critical_section(flags);
+  leave_critical_section_nonirq(flags);
 
   return ret;
 }

--- a/sched/mqueue/mq_timedreceive.c
+++ b/sched/mqueue/mq_timedreceive.c
@@ -156,7 +156,7 @@ file_mq_timedreceive_internal(FAR struct file *mq, FAR char *msg,
    * because messages can be sent from interrupt level.
    */
 
-  flags = enter_critical_section();
+  flags = enter_critical_section_nonirq();
 
   /* Check if the message queue is empty.  If it is NOT empty, then we
    * will not need to start timer.
@@ -231,7 +231,7 @@ file_mq_timedreceive_internal(FAR struct file *mq, FAR char *msg,
   /* We can now restore interrupts */
 
 errout_in_critical_section:
-  leave_critical_section(flags);
+  leave_critical_section_nonirq(flags);
 
   return ret;
 }

--- a/sched/mqueue/mq_timedsend.c
+++ b/sched/mqueue/mq_timedsend.c
@@ -144,8 +144,6 @@ file_mq_timedsend_internal(FAR struct file *mq, FAR const char *msg,
   irqstate_t flags;
   int ret;
 
-  DEBUGASSERT(up_interrupt_context() == false);
-
   /* Verify the input parameters on any failures to verify. */
 
   ret = nxmq_verify_send(mq, msg, msglen, prio);

--- a/sched/semaphore/sem_clockwait.c
+++ b/sched/semaphore/sem_clockwait.c
@@ -107,7 +107,7 @@ int nxsem_clockwait(FAR sem_t *sem, clockid_t clockid,
    * enabled while we are blocked waiting for the semaphore.
    */
 
-  flags = enter_critical_section();
+  flags = enter_critical_section_nonirq();
 
   /* Try to take the semaphore without waiting. */
 
@@ -173,7 +173,7 @@ int nxsem_clockwait(FAR sem_t *sem, clockid_t clockid,
   /* We can now restore interrupts and delete the watchdog */
 
 out:
-  leave_critical_section(flags);
+  leave_critical_section_nonirq(flags);
   return ret;
 }
 

--- a/sched/semaphore/sem_tickwait.c
+++ b/sched/semaphore/sem_tickwait.c
@@ -80,7 +80,7 @@ int nxsem_tickwait(FAR sem_t *sem, uint32_t delay)
    * enabled while we are blocked waiting for the semaphore.
    */
 
-  flags = enter_critical_section();
+  flags = enter_critical_section_nonirq();
 
   /* Try to take the semaphore without waiting. */
 
@@ -118,7 +118,7 @@ int nxsem_tickwait(FAR sem_t *sem, uint32_t delay)
   /* We can now restore interrupts */
 
 out:
-  leave_critical_section(flags);
+  leave_critical_section_nonirq(flags);
   return ret;
 }
 

--- a/sched/semaphore/sem_wait.c
+++ b/sched/semaphore/sem_wait.c
@@ -84,7 +84,7 @@ int nxsem_wait(FAR sem_t *sem)
    * handler.
    */
 
-  flags = enter_critical_section();
+  flags = enter_critical_section_nonirq();
 
   /* Make sure we were supplied with a valid semaphore. */
 
@@ -215,7 +215,7 @@ int nxsem_wait(FAR sem_t *sem)
 #endif
     }
 
-  leave_critical_section(flags);
+  leave_critical_section_nonirq(flags);
   return ret;
 }
 


### PR DESCRIPTION
## Summary
In some non-irq scenarios, we can simplify
the implementation of critical sections to improve performance.

## Impact

## Testing
Configuring NuttX and compile:
$ ./tools/configure.sh -l qemu-armv8a:nsh_smp
$ make
Running with qemu
$ qemu-system-aarch64 -cpu cortex-a53 -smp 4 -nographic \
   -machine virt,virtualization=on,gic-version=3 \
   -net none -chardev stdio,id=con,mux=on -serial chardev:con \
   -mon chardev=con,mode=readline -kernel ./nuttx

