### PR TITLE
libc/msic:Implement get_nprocs API

### DIFF
--- a/libs/libc/misc/CMakeLists.txt
+++ b/libs/libc/misc/CMakeLists.txt
@@ -42,7 +42,8 @@ list(
   lib_openat.c
   lib_mkdirat.c
   lib_utimensat.c
-  lib_memoryregion.c)
+  lib_memoryregion.c
+  lib_getnprocs.c)
 
 # Support for platforms that do not have long long types
 

--- a/libs/libc/misc/Make.defs
+++ b/libs/libc/misc/Make.defs
@@ -25,7 +25,7 @@ CSRCS += lib_xorshift128.c lib_tea_encrypt.c lib_tea_decrypt.c
 CSRCS += lib_cxx_initialize.c lib_impure.c lib_memfd.c lib_mutex.c
 CSRCS += lib_fchmodat.c lib_fstatat.c lib_getfullpath.c lib_openat.c
 CSRCS += lib_mkdirat.c lib_utimensat.c lib_mallopt.c lib_memoryregion.c
-CSRCS += lib_idr.c
+CSRCS += lib_idr.c lib_getnprocs.c
 
 # Support for platforms that do not have long long types
 

--- a/libs/libc/misc/lib_getnprocs.c
+++ b/libs/libc/misc/lib_getnprocs.c
@@ -24,6 +24,7 @@
 
 #include <nuttx/config.h>
 #include <sys/sysinfo.h>
+#include <sys/types.h>
 
 /****************************************************************************
  * Public Functions
@@ -50,11 +51,7 @@
 
 int get_nprocs_conf(void)
 {
-#ifdef CONFIG_SMP_NCPUS
   return CONFIG_SMP_NCPUS;
-#else
-  return 1;
-#endif
 }
 
 /****************************************************************************
@@ -78,9 +75,5 @@ int get_nprocs_conf(void)
 
 int get_nprocs(void)
 {
-#ifdef CONFIG_SMP_NCPUS
   return CONFIG_SMP_NCPUS;
-#else
-  return 1;
-#endif
 }

--- a/libs/libc/misc/lib_getnprocs.c
+++ b/libs/libc/misc/lib_getnprocs.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * include/sys/sysinfo.h
+ * libs/libc/misc/lib_getnprocs.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,62 +18,69 @@
  *
  ****************************************************************************/
 
-#ifndef __INCLUDE_SYS_SYSINFO_H
-#define __INCLUDE_SYS_SYSINFO_H
-
 /****************************************************************************
  * Included Files
  ****************************************************************************/
 
-#include <nuttx/compiler.h>
+#include <nuttx/config.h>
+#include <sys/sysinfo.h>
 
 /****************************************************************************
- * Pre-processor Definitions
+ * Public Functions
  ****************************************************************************/
-
-#define SI_LOAD_SHIFT 16
 
 /****************************************************************************
- * Type Definitions
+ * Name: get_nprocs_conf
+ *
+ * Description:
+ *   Retrieve the number of configured processors in the system.
+ *   The get_nprocs_conf() function returns the number of processors (CPUs)
+ *   configured in the system, regardless of whether they are currently
+ *   enabled or available. This function is useful for determining the
+ *   processor configuration in multiprocessor systems.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   On success, the number of configured processors is returned.
+ *   If the system does not define a processor configuration, it returns 1.
+ *
  ****************************************************************************/
 
-struct sysinfo
+int get_nprocs_conf(void)
 {
-  unsigned long uptime;    /* Seconds since boot */
-  unsigned long loads[3];  /* 1, 5, and 15 minute load averages */
-  unsigned long totalram;  /* Total usable main memory size */
-  unsigned long freeram;   /* Available memory size */
-  unsigned long sharedram; /* Amount of shared memory */
-  unsigned long bufferram; /* Memory used by buffers */
-  unsigned long totalswap; /* Total swap space size */
-  unsigned long freeswap;  /* Swap space still available */
-  unsigned short procs;    /* Number of current processes */
-  unsigned short pad;      /* Padding for alignment */
-  unsigned long totalhigh; /* Total high memory size */
-  unsigned long freehigh;  /* Available high memory size */
-  unsigned mem_unit;       /* Memory unit size in bytes */
-};
-
-/****************************************************************************
- * Public Function Prototypes
- ****************************************************************************/
-
-#undef EXTERN
-#if defined(__cplusplus)
-#define EXTERN extern "C"
-extern "C"
-{
+#ifdef CONFIG_SMP_NCPUS
+  return CONFIG_SMP_NCPUS;
 #else
-#define EXTERN extern
+  return 1;
 #endif
-
-int sysinfo(FAR struct sysinfo *info);
-int get_nprocs_conf(void);
-int get_nprocs(void);
-
-#undef EXTERN
-#if defined(__cplusplus)
 }
-#endif
 
-#endif /* __INCLUDE_SYS_SYSINFO_H */
+/****************************************************************************
+ * Name: get_nprocs
+ *
+ * Description:
+ *   Retrieve the number of online processors in the system.
+ *   The get_nprocs() function returns the number of processors (CPUs) that
+ *   are currently online and available for use in the system. This function
+ *   can be useful for determining the number of processors that can be used
+ *   by applications or the operating system for parallel processing.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   On success, the number of online processors is returned.
+ *   If the system does not define a processor configuration, it returns 1.
+ *
+ ****************************************************************************/
+
+int get_nprocs(void)
+{
+#ifdef CONFIG_SMP_NCPUS
+  return CONFIG_SMP_NCPUS;
+#else
+  return 1;
+#endif
+}


### PR DESCRIPTION
## Summary
1.Remove the macro definition of getnproc in sysinfo
2.New get_nprocs_conf and get_nprocs interfaces, return CONFIG_SMP_NCPUS, return 1 when not defined

## Impact
From macro implementation to function implementation

## Testing
Local test pass
