### PR TITLE
fix compile error

### DIFF
--- a/include/pthread.h
+++ b/include/pthread.h
@@ -47,7 +47,7 @@
  * SP_LOCKED and SP_UNLOCKED must constants of type spinlock_t.
  */
 
-#  include <arch/spinlock.h>
+#  include <nuttx/spinlock.h>
 #endif
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
* module: pshinter  (Postscript hinter module)
* module: raster    (monochrome bitmap renderer)
* module: smooth    (anti-aliased bitmap renderer)
* module: sdf       (signed distance field renderer)
* module: bsdf      (bitmap to signed distance field converter)
* module: psaux     (Postscript Type 1 & Type 2 helper module)
* module: psnames   (Postscript & Unicode Glyph name handling)
In file included from /home/hujun5/work/ssd/dev_vela-miot-x4b_secure/nuttx/include/nuttx/sched_note.h:37,
                 from /home/hujun5/work/ssd/dev_vela-miot-x4b_secure/nuttx/include/syslog.h:30,
                 from iperf2/include/headers.h:238,
                 from iperf2/src/Client.cpp:55:
/home/hujun5/work/ssd/dev_vela-miot-x4b_secure/nuttx/include/nuttx/spinlock.h:169:12: error: conflicting declaration of 'spinlock_t up_testset(volatile spinlock_t*)' with 'C' linkage
  169 | spinlock_t up_testset(FAR volatile spinlock_t *lock);
      |            ^~~~~~~~~~
In file included from /home/hujun5/work/ssd/dev_vela-miot-x4b_secure/nuttx/include/pthread.h:50,
                 from /home/hujun5/work/ssd/dev_vela-miot-x4b_secure/nuttx/include/nuttx/userspace.h:33,
                 from /home/hujun5/work/ssd/dev_vela-miot-x4b_secure/nuttx/include/nuttx/mm/mm.h:30,
                 from /home/hujun5/work/ssd/dev_vela-miot-x4b_secure/nuttx/include/nuttx/kmalloc.h:34,
                 from /home/hujun5/work/ssd/dev_vela-miot-x4b_secure/nuttx/include/nuttx/lib/lib.h:31,
                 from /home/hujun5/work/ssd/dev_vela-miot-x4b_secure/nuttx/include/stdio.h:35,
                 from /home/hujun5/work/ssd/dev_vela-miot-x4b_secure/nuttx/include/libcxx/stdio.h:108,
                 from iperf2/include/headers.h:76:
/home/hujun5/work/ssd/dev_vela-miot-x4b_secure/nuttx/include/arch/spinlock.h:118:35: note: previous declaration with 'C++' linkage
  118 | static inline_function spinlock_t up_testset(FAR volatile spinlock_t *lock)
      |                                   ^~~~~~~~~~
make[2]: *** [/home/hujun5/work/ssd/dev_vela-miot-x4b_secure/apps/Application.mk:217：iperf2/src/Client.cpp.home.hujun5.work.ssd.dev_vela-miot-x4b_secure.external.iperf2.o] 错误 1
make[1]: *** [Makefile:51：/home/hujun5/work/ssd/dev_vela-miot-x4b_secure/apps/external/iperf2_all] 错误 2
make[1]: *** 正在等待未完成的任务....
CC:  ffmpeg/libavfilter/asink_adevsink.c ffmpeg/libavdevice/v4l2.c: In function 'mmap_read_frame':
ffmpeg/libavdevice/v4l2.c:571:20: warning: format '%x' expects argument of type 'unsigned int', but argument 6 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
  571 |                    "Dequeued v4l2 buffer contains %"PRIu32" bytes, but %d were expected. Flags: 0x%08"PRIx16".\n",
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  572 |                    buf.bytesused, s->frame_size, buf.flags);
      |                                                  ~~~~~~~~~
      |                                                     |
      |                                                     uint32_t {aka long unsigned int}
In file included from /home/hujun5/work/ssd/dev_vela-miot-x4b_secure/nuttx/include/stdint.h:35,
                 from /home/hujun5/work/ssd/dev_vela-miot-x4b_secure/nuttx/include/stdbool.h:55,
                 from /home/hujun5/work/ssd/dev_vela-miot-x4b_secure/nuttx/include/sys/poll.h:31,
                 from /home/hujun5/work/ssd/dev_vela-miot-x4b_secure/nuttx/include/poll.h:28,
                 from ffmpeg/libavdevice/v4l2.c:33:
/home/hujun5/work/ssd/dev_vela-miot-x4b_secure/nuttx/include/arch/inttypes.h:82:22: note: format string is defined here

## Impact

## Testing
Configuring NuttX and compile:
$ ./tools/configure.sh -l qemu-armv8a:nsh_smp
$ make
Running with qemu
$ qemu-system-aarch64 -cpu cortex-a53 -smp 4 -nographic \
   -machine virt,virtualization=on,gic-version=3 \
   -net none -chardev stdio,id=con,mux=on -serial chardev:con \
   -mon chardev=con,mode=readline -kernel ./nuttx
