### PR TITLE
sched/sched: simplify the implementation of the function nxsched_readytorun_setpriority

### DIFF
--- a/sched/sched/sched_setpriority.c
+++ b/sched/sched/sched_setpriority.c
@@ -212,83 +212,13 @@ static void nxsched_readytorun_setpriority(FAR struct tcb_s *tcb,
 {
   FAR struct tcb_s *rtcb;
 
-#ifdef CONFIG_SMP
-  int cpu;
-
-  /* CASE 2a. The task is ready-to-run (but not running) but not assigned to
-   * a CPU. An increase in priority could cause a context switch may be
-   * caused by the re-prioritization.  The task is not assigned and may run
-   * on any CPU.
-   */
-
-  if (tcb->task_state == TSTATE_TASK_READYTORUN)
-    {
-      cpu = nxsched_select_cpu(tcb->affinity);
-    }
-
-  /* CASE 2b.  The task is ready to run, and assigned to a CPU.  An increase
-   * in priority could cause this task to become running but the task can
-   * only run on its assigned CPU.
-   */
-
-  else
-    {
-      cpu = tcb->cpu;
-    }
-
-  /* The running task is the task at the head of the g_assignedtasks[]
-   * associated with the selected CPU.
-   */
-
-  rtcb = current_task(cpu);
-
-#else
-  /* CASE 2. The task is ready-to-run (but not running) and a context switch
-   * may be caused by the re-prioritization.
-   */
-
   rtcb = this_task();
-#endif
 
-  /* A context switch will occur if the new priority of the ready-to-run
-   * task is (strictly) greater than the current running task
-   */
+  /* A context switch will occur. */
 
-  if (sched_priority > rtcb->sched_priority)
+  if (nxsched_reprioritize_rtr(tcb, sched_priority))
     {
-      /* A context switch will occur. */
-
-      if (nxsched_reprioritize_rtr(tcb, sched_priority))
-        {
-          up_switch_context(this_task(), rtcb);
-        }
-    }
-
-  /* Otherwise, we can just change priority and re-schedule (since it have
-   * no other effect).
-   */
-
-  else
-    {
-      /* Remove the TCB from the ready-to-run task list that it resides in.
-       * It should not be at the head of the list.
-       */
-
-      bool check = nxsched_remove_readytorun(tcb, false);
-      DEBUGASSERT(check == false);
-      UNUSED(check);
-
-      /* Change the task priority */
-
-      tcb->sched_priority = (uint8_t)sched_priority;
-
-      /* Put it back into the correct ready-to-run task list.  It must not
-       * end up at the head of the list.
-       */
-
-      check = nxsched_add_readytorun(tcb);
-      DEBUGASSERT(check == false);
-      UNUSED(check);
+      up_switch_context(this_task(), rtcb);
     }
 }
 


### PR DESCRIPTION
## Summary
If the type of tcb is TSTATE_TASK_ASSIGNED, removing it using nxsched_remove_not_running and then putting it back into the queue may result in a context switch.
## Impact

## Testing

Configuring NuttX and compile:
```
$ ./tools/configure.sh -l qemu-armv8a:nsh_smp
$ make
Running with qemu
$ qemu-system-aarch64 -cpu cortex-a53 -smp 4 -nographic \
   -machine virt,virtualization=on,gic-version=3 \
   -net none -chardev stdio,id=con,mux=on -serial chardev:con \
   -mon chardev=con,mode=readline -kernel ./nuttx
```