### PR TITLE
[cmake] add nuttx_post and app_context inter targets for timing control

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -423,6 +423,7 @@ include(platform)
 # Setup main nuttx target ####################################################
 
 add_executable(nuttx)
+add_custom_target(nuttx_post)
 if(CONFIG_BUILD_PROTECTED)
   add_executable(nuttx_user)
 endif()
@@ -432,6 +433,7 @@ if(CONFIG_ALLSYMS)
 endif()
 
 add_dependencies(nuttx nuttx_context)
+add_dependencies(nuttx_post nuttx)
 
 if(WIN32)
   set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT
@@ -573,6 +575,9 @@ add_subdirectory(boards)
 # with the correct operations for that platform
 
 if(TARGET nuttx_post_build)
+  # ensure thae the custom post build is executed after all steps of the nuttx
+  # build are completed
+  add_dependencies(nuttx_post_build nuttx_post)
   add_custom_target(post_build ALL DEPENDS nuttx_post_build)
 endif()
 

--- a/cmake/nuttx_add_application.cmake
+++ b/cmake/nuttx_add_application.cmake
@@ -167,6 +167,10 @@ function(nuttx_add_application)
     set_property(GLOBAL APPEND PROPERTY NUTTX_APPS_ONLY_REGISTER ${TARGET})
   endif()
 
+  # apps applications need to depends on apps_context by default
+
+  add_dependencies(${TARGET} apps_context)
+
   # store parameters into properties (used during builtin list generation)
 
   set_target_properties(${TARGET} PROPERTIES APP_MAIN ${NAME}_main)

--- a/cmake/nuttx_add_library.cmake
+++ b/cmake/nuttx_add_library.cmake
@@ -79,7 +79,7 @@ endfunction()
 function(nuttx_add_user_library target)
   # declare target
   add_library(${target} OBJECT ${ARGN})
-
+  add_dependencies(${target} apps_context)
   nuttx_add_library_internal(${target} ${ARGN})
 
   # link to final libapps
@@ -180,7 +180,7 @@ define_property(
 #
 function(nuttx_add_library target)
   add_library(${target} ${ARGN})
-
+  add_dependencies(${target} apps_context)
   set_property(GLOBAL APPEND PROPERTY NUTTX_SYSTEM_LIBRARIES ${target})
 
   nuttx_add_library_internal(${target})

--- a/cmake/nuttx_allsyms.cmake
+++ b/cmake/nuttx_allsyms.cmake
@@ -95,7 +95,8 @@ define_allsyms_link_target(nuttx NULL NULL)
 define_allsyms_link_target(allsyms_inter nuttx allsyms_first_link)
 # allsyms link phase 2 since the table offset may changed
 define_allsyms_link_target(allsyms_nuttx allsyms_inter allsyms_final_link)
-
+# fixing timing dependencies
+add_dependencies(nuttx_post allsyms_nuttx)
 # finally use allsyms_nuttx to overwrite the already generated nuttx
 add_custom_command(
   TARGET allsyms_nuttx

--- a/cmake/nuttx_generate_headers.cmake
+++ b/cmake/nuttx_generate_headers.cmake
@@ -152,3 +152,7 @@ add_custom_target(
     $<$<BOOL:${NEED_MATH_H}>:${CMAKE_BINARY_DIR}/include/math.h>
     $<$<BOOL:${CONFIG_ARCH_FLOAT_H}>:${CMAKE_BINARY_DIR}/include/float.h>
     $<$<BOOL:${CONFIG_ARCH_SETJMP_H}>:${CMAKE_BINARY_DIR}/include/setjmp.h>)
+
+# apps_context is a PHONY target used as an intermediate process to control the
+# time order of context preparation actions of app building
+add_custom_target(apps_context ALL DEPENDS nuttx_context)

--- a/cmake/nuttx_generate_outputs.cmake
+++ b/cmake/nuttx_generate_outputs.cmake
@@ -25,6 +25,7 @@ function(nuttx_generate_outputs target)
       COMMAND ${CMAKE_OBJCOPY} -O ihex ${target} ${target}.hex
       DEPENDS ${target})
     add_custom_target(${target}-hex ALL DEPENDS ${target}.hex)
+    add_dependencies(nuttx_post ${target}-hex)
     file(APPEND ${CMAKE_BINARY_DIR}/nuttx.manifest "${target}.hex\n")
   endif()
 
@@ -34,6 +35,7 @@ function(nuttx_generate_outputs target)
       COMMAND ${CMAKE_OBJCOPY} -O srec ${target} ${target}.srec
       DEPENDS ${target})
     add_custom_target(${target}-srec ALL DEPENDS ${target}.srec)
+    add_dependencies(nuttx_post ${target}-srec)
     file(APPEND ${CMAKE_BINARY_DIR}/nuttx.manifest "${target}.srec\n")
   endif()
 
@@ -43,6 +45,7 @@ function(nuttx_generate_outputs target)
       COMMAND ${CMAKE_OBJCOPY} -O binary ${target} ${target}.bin
       DEPENDS ${target})
     add_custom_target(${target}-bin ALL DEPENDS ${target}.bin)
+    add_dependencies(nuttx_post ${target}-bin)
     file(APPEND ${CMAKE_BINARY_DIR}/nuttx.manifest "${target}.bin\n")
   endif()
 


### PR DESCRIPTION
## Summary

Add two intermediate targets to control the correct build timing order

`nuttx_post`:
custom target nuttx_post_build execution timing of a may be confused with other post-build processing.
occasional cause errors:
```shell
[1209/1210] cd /home/work/cmake_out && arm-none-eabi-objcopy -O binary nuttx nuttx.bin && arm-none-eabi-objcopy -O binary nuttx vela_core1.bin && cp nuttx vela_core1.elf && cp nuttx.hex vela_core1.hex && cp nuttx.map vela_core1.mapfile
FAILED: boards/exclude_board/CMakeFiles/nuttx_post_build /home/work/cmake_out/boards/exclude_board/CMakeFiles/nuttx_post_build
cd /home/work/cmake_out && arm-none-eabi-objcopy -O binary nuttx nuttx.bin && arm-none-eabi-objcopy -O binary nuttx vela_core1.bin && cp nuttx vela_core1.elf && cp nuttx.hex vela_core1.hex && cp nuttx.map vela_core1.mapfile
cp: cannot stat 'nuttx.hex': No such file or directory
[1210/1210] Generating nuttx.hex
ninja: build stopped: subcommand failed.
``` 
we add this intermediate target `nuttx_post` to mark that all nuttx processing has been completed. 
Next is the time for custom.

---

`app_context`:
This target is used to control the specific timing of apps. 
Generally speaking, preparations such as downloading can be completed during the CMake configure stage.

However, there may be generation actions across apps modules 
that need to be completed before building, so we add an intermediate target just to control the timing.

## Impact

## Testing

