### PR TITLE
arch/risc-v/esp32c3: fix AP password memcpy typo

### DIFF
--- a/arch/risc-v/src/esp32c3/esp_wifi_adapter.c
+++ b/arch/risc-v/src/esp32c3/esp_wifi_adapter.c
@@ -5119,7 +5119,7 @@ int esp_wifi_softap_password(struct iwreq *iwr, bool set)
 
       if (ext->alg != IW_ENCODE_ALG_NONE)
         {
-          memcpy(wifi_cfg.sta.password, pdata, len);
+          memcpy(wifi_cfg.ap.password, pdata, len);
         }
 
       if (g_softap_started)


### PR DESCRIPTION
## Summary
Fix a typo on password setting where station password was set instead of AP password. Issue reported in #13014 

## Impact
Fix wrong password setting.

## Testing
Test passing on internal CI.
