### PR TITLE
arm: Fix DS1307 initialization for common STM32 logic

### DIFF
--- a/boards/arm/stm32/common/src/stm32_ds1307.c
+++ b/boards/arm/stm32/common/src/stm32_ds1307.c
@@ -63,7 +63,7 @@ int board_ds1307_initialize(int busno)
   struct i2c_master_s *i2c;
   int ret;
 
-  rtcinfo("Initialize I2C%d\n", DS1307_I2C_BUS);
+  rtcinfo("Initialize I2C%d\n", busno);
 
   /* Initialize I2C */
 
@@ -81,7 +81,7 @@ int board_ds1307_initialize(int busno)
   if (ret < 0)
     {
       rtcerr("ERROR: Failed to bind I2C%d to the DS1307 RTC driver\n",
-             DS1307_I2C_BUS);
+             busno);
       return -ENODEV;
     }
 


### PR DESCRIPTION
## Summary
Fix DS1307 initialization for common STM32 logic

## Impact
Users will be able to build using DS1307 and STM32 common logic.

## Testing
- Add DS1307 on bringup for testing board (STM32 based board).
- Enable Common Logic and DS1307 related configs (CONFIG_RTC_DS1307, etc).
- Build and test on the testing board.
