### PR TITLE
modify the type of the ipv6 parameters to solve runtime error

### DIFF
--- a/net/ipfrag/ipv6_frag.c
+++ b/net/ipfrag/ipv6_frag.c
@@ -141,8 +141,9 @@ static int32_t ipv6_fragin_getinfo(FAR struct iob_s *iob,
       fraglink->morefrags = fraglink->fragoff & 0x1;
       fraglink->fragoff  &= 0xfff8;
       fraglink->fraglen   = paylen;
-      fraglink->ipid      = NTOHL((*(uint16_t *)(&fraghdr->id[0]) << 16) +
-                                  *(uint16_t *)(&fraghdr->id[2]));
+      fraglink->ipid      = NTOHL(
+        ((uint32_t)(*(FAR uint16_t *)(&fraghdr->id[0])) << 16) +
+         (uint32_t)(*(FAR uint16_t *)(&fraghdr->id[2])));
 
       fraglink->frag      = iob;
 


### PR DESCRIPTION
## Summary
modify the type of the ipv6 parameters to solve runtime error
## Impact
ipv6 ping
## Testing
![image](https://github.com/user-attachments/assets/fee0234a-abd3-4137-976f-b6872a600cb6)

