### PR TITLE
Add ioctl for SIOCGETCONTEXT and SIOCSETCONTEXT

### DIFF
--- a/include/nuttx/net/ioctl.h
+++ b/include/nuttx/net/ioctl.h
@@ -126,6 +126,8 @@
 /* Network socket control ***************************************************/
 
 #define SIOCDENYINETSOCK _SIOC(0x003C) /* Deny network socket. */
+#define SIOCGETCONTEXT   _SIOC(0x003F) /* Get socket context */
+#define SIOCSETCONTEXT   _SIOC(0x0040) /* Set socket context */
 
 /* Bridge calls *************************************************************/
 

--- a/include/nuttx/net/net.h
+++ b/include/nuttx/net/net.h
@@ -253,6 +253,26 @@ struct socket
   FAR const struct sock_intf_s *s_sockif;
 };
 
+struct socket_ctx_data_s
+{
+  uint8_t s_domain;  /* IP domain */
+  uint8_t s_type;    /* Protocol type */
+  uint8_t s_proto;   /* Socket Protocol */
+  uint8_t s_priv[0]; /* Private socket context */
+};
+
+/* NETDEV ioctl command:
+ *
+ * Command:      SIOCGETCONTEXT or SIOCSETCONTEXT
+ * Description:  Get or Set socket context.
+ */
+
+struct socket_context_s
+{
+  size_t ctx_size;               /* Size of socket context */
+  struct socket_ctx_data_s *ctx; /* Buffer where socket context is stored */
+};
+
 /****************************************************************************
  * Public Data
  ****************************************************************************/

--- a/net/netdev/netdev_ioctl.c
+++ b/net/netdev/netdev_ioctl.c
@@ -1710,6 +1710,10 @@ ssize_t net_ioctl_arglen(uint8_t domain, int cmd)
       case SIOCDENYINETSOCK:
         return sizeof(uint8_t);
 
+      case SIOCGETCONTEXT:
+      case SIOCSETCONTEXT:
+        return sizeof(struct socket_context_s);
+
       default:
 #ifdef CONFIG_NETDEV_IOCTL
 #  ifdef CONFIG_NETDEV_WIRELESS_IOCTL


### PR DESCRIPTION


## Summary
Add ioctl for SIOCGETCONTEXT and SIOCSETCONTEXT.
These ioctl are for getting and setting the socket context held by the usrsock daemon.

## Impact
No impact

## Testing
Test with Spresense LTE board.

