### PR TITLE
solve Problem of tcp parameter calculation exceeding the boundary

### DIFF
--- a/net/tcp/tcp_timer.c
+++ b/net/tcp/tcp_timer.c
@@ -224,7 +224,7 @@ static void tcp_xmit_probe(FAR struct net_driver_s *dev,
 
 void tcp_update_timer(FAR struct tcp_conn_s *conn)
 {
-  int timeout = tcp_get_timeout(conn);
+  sclock_t timeout = tcp_get_timeout(conn);
 
   if (timeout > 0)
     {


### PR DESCRIPTION
## Summary
solve Problem of tcp parameter calculation exceeding the boundary
## Impact
curl download files
## Testing
Manual verification
