### PR TITLE
video/fb: changed circbuf_write assert to warning

### DIFF
--- a/drivers/video/fb.c
+++ b/drivers/video/fb.c
@@ -206,7 +206,10 @@ static int fb_add_paninfo(FAR struct fb_chardev_s *fb,
   /* Write planeinfo information to the queue. */
 
   ret = circbuf_write(panbuf, info, sizeof(union fb_paninfo_u));
-  DEBUGASSERT(ret == sizeof(union fb_paninfo_u));
+  if (ret != sizeof(union fb_paninfo_u))
+    {
+      gwarn("WARNING: circbuf_write(panbuf) failed\n");
+    }
 
   /* Re-enable interrupts */
 


### PR DESCRIPTION
## Summary
changed circbuf_write assert to warning. On some hardware devices, crashes may occur due to assert, which is something  we do not expect.  Changing it to 'warning' may be better.

## Impact
fb
## Testing
fb demo
