### PR TITLE
tcp:set NET_TCP_NPOLLWAITERS default value to 2 & add warning of different events having same event bit

### DIFF
--- a/net/tcp/Kconfig
+++ b/net/tcp/Kconfig
@@ -93,7 +93,7 @@ config NET_TCP_MAX_CONNS
 
 config NET_TCP_NPOLLWAITERS
 	int "Number of TCP poll waiters"
-	default 1
+	default 2
 
 config NET_TCP_RTO
 	int "RTO of TCP/IP connections"

--- a/net/tcp/tcp_netpoll.c
+++ b/net/tcp/tcp_netpoll.c
@@ -228,6 +228,7 @@ int tcp_pollsetup(FAR struct socket *psock, FAR struct pollfd *fds)
   info = conn->pollinfo;
   while (info->conn != NULL)
     {
+      DEBUGASSERT((fds->events & info->fds->events) != 0);
       if (++info >= &conn->pollinfo[CONFIG_NET_TCP_NPOLLWAITERS])
         {
           DEBUGPANIC();


### PR DESCRIPTION
## Summary
1.set NET_TCP_NPOLLWAITERS default value from 1 to 2
2. add warning of different events having same event bit
## Impact
TCP  number of poll to the same fd
## Testing
Manual verification
