### PR TITLE
sim: read the second buffer

### DIFF
--- a/arch/sim/src/sim/posix/sim_x11framebuffer.c
+++ b/arch/sim/src/sim/posix/sim_x11framebuffer.c
@@ -83,11 +83,11 @@ static unsigned short g_fbpixelwidth;
 static unsigned short g_fbpixelheight;
 static int g_fbbpp;
 static int g_fblen;
-static int g_fbcount;
 static int g_shmcheckpoint = 0;
 static int b_useshm;
 
 static unsigned char *g_trans_framebuffer;
+static unsigned int g_offset;
 
 /****************************************************************************
  * Private Functions
@@ -465,7 +465,6 @@ int sim_x11initialize(unsigned short width, unsigned short height,
 
   g_fbbpp = depth;
   g_fblen = *fblen;
-  g_fbcount = fbcount;
 
   /* Create conversion framebuffer */
 
@@ -541,6 +540,7 @@ int sim_x11setoffset(unsigned int offset)
   if (g_fbbpp == 32 && CONFIG_SIM_FBBPP == 16)
     {
       g_image->data = g_framebuffer + (offset << 1);
+      g_offset = offset;
     }
   else
     {
@@ -620,9 +620,9 @@ int sim_x11update(void)
 
   if (g_fbbpp == 32 && CONFIG_SIM_FBBPP == 16)
     {
-      sim_x11depth16to32(g_framebuffer,
-                         g_fblen * g_fbcount,
-                         g_trans_framebuffer);
+      sim_x11depth16to32(g_image->data,
+                         g_fblen,
+                         g_trans_framebuffer + g_offset);
     }
 
   XSync(g_display, 0);

--- a/arch/sim/src/sim/sim_framebuffer.c
+++ b/arch/sim/src/sim/sim_framebuffer.c
@@ -468,6 +468,7 @@ int up_fbinitialize(int display)
                           &g_planeinfo.fbmem, &g_planeinfo.fblen,
                           &g_planeinfo.bpp, &g_planeinfo.stride,
                           CONFIG_SIM_FRAMEBUFFER_COUNT);
+  g_planeinfo.fblen *= CONFIG_SIM_FRAMEBUFFER_COUNT;
 #endif
 
   return ret;

--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -451,6 +451,7 @@ static const char *g_white_content_list[] =
   "AsyncBoth",
   "CurrentTime",
   "XUnmapWindow",
+  "XFree",
 
   /* Ref:
    * nuttx/arch/sim/src/sim_hostdecoder.*


### PR DESCRIPTION
## Summary
It can only read the contents of the first buffer, so fblen should be changed to ensure that it can read the second buffer as well.
## Impact
sim
## Testing
run sim lvgl
cat  /dev/fb0 >/data/frame.raw
transfer frame.raw to rgb32 png