### PR TITLE
netdev_upperhalf: add polling mode support for tx/rx

### DIFF
--- a/drivers/net/Kconfig
+++ b/drivers/net/Kconfig
@@ -38,6 +38,14 @@ config NETDEV_WORK_THREAD
 
 endchoice # Netdev poll worker
 
+config NETDEV_WORK_THREAD_POLLING_PERIOD
+	int "Polling period, the units are microseconds"
+	default 0
+	depends on NETDEV_WORK_THREAD
+	---help---
+		Disable the txdone and rxready interrupt and use polling
+		period to receive packets when the value is not 0.
+
 config NETDEV_WORK_THREAD_PRIORITY
 	int "Priority of work poll thread"
 	default 100

--- a/drivers/net/netdev_upperhalf.c
+++ b/drivers/net/netdev_upperhalf.c
@@ -713,6 +713,27 @@ static void netdev_upper_work(FAR void *arg)
 }
 
 /****************************************************************************
+ * Name: netdev_upper_wait
+ *
+ * Description:
+ *   Wait for timeout or signal.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_NETDEV_WORK_THREAD
+static int netdev_upper_wait(FAR sem_t *sem)
+{
+#if CONFIG_NETDEV_WORK_THREAD_POLLING_PERIOD > 0
+  int ret =
+    nxsem_tickwait(sem, USEC2TICK(CONFIG_NETDEV_WORK_THREAD_POLLING_PERIOD));
+
+  return ret == -ETIMEDOUT ? OK : ret;
+#else
+  return nxsem_wait(sem);
+#endif
+}
+
+/****************************************************************************
  * Name: netdev_upper_loop
  *
  * Description:
@@ -720,13 +741,13 @@ static void netdev_upper_work(FAR void *arg)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_NETDEV_WORK_THREAD
 static int netdev_upper_loop(int argc, FAR char *argv[])
 {
   FAR struct netdev_upperhalf_s *upper =
     (FAR struct netdev_upperhalf_s *)((uintptr_t)strtoul(argv[1], NULL, 16));
 
-  while (nxsem_wait(&upper->sem) == OK && upper->tid != INVALID_PROCESS_ID)
+  while (netdev_upper_wait(&upper->sem) == OK &&
+         upper->tid != INVALID_PROCESS_ID)
     {
       netdev_upper_work(upper);
     }
@@ -1315,7 +1336,9 @@ void netdev_lower_carrier_off(FAR struct netdev_lowerhalf_s *dev)
 
 void netdev_lower_rxready(FAR struct netdev_lowerhalf_s *dev)
 {
+#if CONFIG_NETDEV_WORK_THREAD_POLLING_PERIOD == 0
   netdev_upper_queue_work(&dev->netdev);
+#endif
 }
 
 /****************************************************************************
@@ -1332,7 +1355,9 @@ void netdev_lower_rxready(FAR struct netdev_lowerhalf_s *dev)
 void netdev_lower_txdone(FAR struct netdev_lowerhalf_s *dev)
 {
   NETDEV_TXDONE(&dev->netdev);
+#if CONFIG_NETDEV_WORK_THREAD_POLLING_PERIOD == 0
   netdev_upper_queue_work(&dev->netdev);
+#endif
 }
 
 /****************************************************************************

--- a/include/nuttx/net/netdev_lowerhalf.h
+++ b/include/nuttx/net/netdev_lowerhalf.h
@@ -47,6 +47,10 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+#ifndef CONFIG_NETDEV_WORK_THREAD_POLLING_PERIOD
+#  define CONFIG_NETDEV_WORK_THREAD_POLLING_PERIOD 0
+#endif
+
 /* Layout for net packet:
  *
  * | <-------------- NETPKT_BUFLEN ---------------> |

--- a/include/nuttx/net/netdev_lowerhalf.h
+++ b/include/nuttx/net/netdev_lowerhalf.h
@@ -168,6 +168,10 @@ struct netdev_ops_s
   int (*ioctl)(FAR struct netdev_lowerhalf_s *dev, int cmd,
                unsigned long arg);
 #endif
+
+  /* reclaim - try to reclaim packets sent by netdev. */
+
+  void (*reclaim)(FAR struct netdev_lowerhalf_s *dev);
 };
 
 /* This structure is a set of wireless handlers, leave unsupported operations


### PR DESCRIPTION
## Summary
supports the protocol stack to trigger the NIC driver to reclaim pkt resources.
add polling mode support for netdev_upperhalf tx/rx
## Impact

## Testing
qemu:x86_64
