### PR TITLE
netdb:netdb code support ffmpeg rtsp(getaddrinfo & getnameinfo)

### DIFF
--- a/libs/libc/netdb/lib_getaddrinfo.c
+++ b/libs/libc/netdb/lib_getaddrinfo.c
@@ -169,7 +169,7 @@ int getaddrinfo(FAR const char *hostname, FAR const char *servname,
       FAR char *endp;
 
       port = strtol(servname, &endp, 10);
-      if (port > 0 && port <= 65535 && *endp == '\0')
+      if (port >= 0 && port <= 65535 && *endp == '\0')
         {
           /* Force network byte order */
 

--- a/libs/libc/netdb/lib_getnameinfo.c
+++ b/libs/libc/netdb/lib_getnameinfo.c
@@ -53,7 +53,7 @@ int getnameinfo(FAR const struct sockaddr *addr, socklen_t addrlen,
   int ret;
 
   if (addr && addr->sa_family == AF_INET &&
-      addrlen == sizeof(struct sockaddr_in))
+      addrlen >= sizeof(struct sockaddr_in))
     {
       FAR const struct sockaddr_in *sa_in;
 


### PR DESCRIPTION
## Summary
Related Codes:
1.ffmpeg/libavformat/ip.c
struct addrinfo *ff_ip_resolve_host(void *log_ctx,
                                    const char *hostname, int port,
                                    int type, int family, int flags)
{
    struct addrinfo hints = { 0 }, *res = 0;
    int error;
    char sport[16];
    const char *node = 0, *service = "0";

    if (port > 0) {
        snprintf(sport, sizeof(sport), "%d", port);
        service = sport;
    }
    if ((hostname) && (hostname[0] != '\0') && (hostname[0] != '?')) {
        node = hostname;
    }
    hints.ai_socktype = type;
    hints.ai_family   = family;
    hints.ai_flags    = flags;
    if ((error = getaddrinfo(node, service, &hints, &res))) {
        res = NULL;
        av_log(log_ctx, AV_LOG_ERROR, "getaddrinfo(%s, %s): %s\n",
               node ? node : "unknown",
               service,
               gai_strerror(error));
    }

    return res;
}
2.ffmpeg/libavformat/rtsp.c
static int sdp_read_header(AVFormatContext *s)
{
    RTSPState *rt = s->priv_data;
    RTSPStream *rtsp_st;
    int i, err;
    char url[MAX_URL_SIZE];
    AVBPrint bp;

    if (!ff_network_init())
        return AVERROR(EIO);

    if (s->max_delay < 0) /* Not set by the caller */
        s->max_delay = DEFAULT_REORDERING_DELAY;
    if (rt->rtsp_flags & RTSP_FLAG_CUSTOM_IO)
        rt->lower_transport = RTSP_LOWER_TRANSPORT_CUSTOM;

    /* read the whole sdp file */
    av_bprint_init(&bp, 0, AV_BPRINT_SIZE_UNLIMITED);
    err = avio_read_to_bprint(s->pb, &bp, INT_MAX);
    if (err < 0 ) {
        ff_network_close();
        av_bprint_finalize(&bp, NULL);
        return err;
    }
    err = ff_sdp_parse(s, bp.str);
    av_bprint_finalize(&bp, NULL);
    if (err) goto fail;

    /* open each RTP stream */
    for (i = 0; i < rt->nb_rtsp_streams; i++) {
        char namebuf[50];
        rtsp_st = rt->rtsp_streams[i];

        if (!(rt->rtsp_flags & RTSP_FLAG_CUSTOM_IO)) {
            AVDictionary *opts = map_to_opts(rt);
            char buf[MAX_URL_SIZE];
            const char *p;

            err = getnameinfo((struct sockaddr*) &rtsp_st->sdp_ip,
                              sizeof(rtsp_st->sdp_ip),
                              namebuf, sizeof(namebuf), NULL, 0, NI_NUMERICHOST);
            if (err) {
                av_log(s, AV_LOG_ERROR, "getnameinfo: %s\n", gai_strerror(err));
                err = AVERROR(EIO);
                av_dict_free(&opts);
                goto fail;
            }
            ff_url_join(url, sizeof(url), "rtp", NULL,
                        namebuf, rtsp_st->sdp_port,
                        "?localport=%d&ttl=%d&connect=%d&write_to_source=%d",
                        rtsp_st->sdp_port, rtsp_st->sdp_ttl,
                        rt->rtsp_flags & RTSP_FLAG_FILTER_SRC ? 1 : 0,
                        rt->rtsp_flags & RTSP_FLAG_RTCP_TO_SOURCE ? 1 : 0);

            p = strchr(s->url, '?');
            if (p && av_find_info_tag(buf, sizeof(buf), "localaddr", p))
                av_strlcatf(url, sizeof(url), "&localaddr=%s", buf);
            else if (rt->localaddr && rt->localaddr[0])
                av_strlcatf(url, sizeof(url), "&localaddr=%s", rt->localaddr);
            append_source_addrs(url, sizeof(url), "sources",
                                rtsp_st->nb_include_source_addrs,
                                rtsp_st->include_source_addrs);
            append_source_addrs(url, sizeof(url), "block",
                                rtsp_st->nb_exclude_source_addrs,
                                rtsp_st->exclude_source_addrs);
            err = ffurl_open_whitelist(&rtsp_st->rtp_handle, url, AVIO_FLAG_READ,
                           &s->interrupt_callback, &opts, s->protocol_whitelist, s->protocol_blacklist, NULL);

            av_dict_free(&opts);

            if (err < 0) {
                err = AVERROR_INVALIDDATA;
                goto fail;
            }
        }
        if ((err = ff_rtsp_open_transport_ctx(s, rtsp_st)))
            goto fail;
    }
    return 0;
fail:
    ff_rtsp_close_streams(s);
    ff_network_close();
    return err;
}
## Impact
netdb function getaddrinfo & getnameinfo
## Testing
Manual verification 