### PR TITLE
fix issue about unable to retrieve the next callback after the callback has been deleted

### DIFF
--- a/net/devif/devif_callback.c
+++ b/net/devif/devif_callback.c
@@ -578,6 +578,18 @@ uint16_t devif_dev_event(FAR struct net_driver_s *dev, uint16_t flags)
            */
 
           flags = cb->event(dev, cb->priv, flags);
+          cb->free_flags &= ~DEVIF_CB_DONT_FREE;
+
+          /* update the next callback to prevent previously recorded the
+           * next callback from being deleted
+           */
+
+          next = cb->nxtdev;
+          if ((cb->free_flags & DEVIF_CB_PEND_FREE) != 0)
+            {
+              cb->free_flags &= ~DEVIF_CB_PEND_FREE;
+              devif_dev_callback_free(dev, cb);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
devif_callback
## Impact
devif callback
## Testing
Manual verification
