### PR TITLE
localsocket improvment

### DIFF
--- a/drivers/pipes/pipe.c
+++ b/drivers/pipes/pipe.c
@@ -48,8 +48,6 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-static int pipe_close(FAR struct file *filep);
-
 static int pipe_mmap(FAR struct file *filep,
                      FAR struct mm_map_entry_s *entry);
 
@@ -60,7 +58,7 @@ static int pipe_mmap(FAR struct file *filep,
 static const struct file_operations g_pipe_fops =
 {
   pipecommon_open,     /* open */
-  pipe_close,          /* close */
+  pipecommon_close,    /* close */
   pipecommon_read,     /* read */
   pipecommon_write,    /* write */
   NULL,                /* seek */
@@ -98,31 +96,6 @@ static inline int pipe_allocate(void)
     }
 
   nxmutex_unlock(&g_pipelock);
-  return ret;
-}
-
-/****************************************************************************
- * Name: pipe_close
- ****************************************************************************/
-
-static int pipe_close(FAR struct file *filep)
-{
-  FAR struct inode *inode    = filep->f_inode;
-  FAR struct pipe_dev_s *dev = inode->i_private;
-  int ret;
-
-  DEBUGASSERT(dev);
-
-  /* Perform common close operations */
-
-  ret = pipecommon_close(filep);
-  if (ret == 0 && inode->i_crefs == 1)
-    {
-      /* Release the pipe when there are no further open references to it. */
-
-      pipecommon_freedev(dev);
-    }
-
   return ret;
 }
 
@@ -169,6 +142,8 @@ static int pipe_register(size_t bufsize, int flags,
     {
       return -ENOMEM;
     }
+
+  PIPE_UNLINK(dev->d_flags);
 
   /* Register the pipe device */
 

--- a/drivers/pipes/pipe_common.c
+++ b/drivers/pipes/pipe_common.c
@@ -149,7 +149,7 @@ int pipecommon_open(FAR struct file *filep)
    * is first opened.
    */
 
-  if (dev->d_crefs == 0)
+  if (dev->d_crefs == 0 && PIPE_IS_POLICY_0(dev->d_flags))
     {
       ret = circbuf_init(&dev->d_buffer, NULL, dev->d_bufsize);
       if (ret < 0)
@@ -440,7 +440,7 @@ ssize_t pipecommon_read(FAR struct file *filep, FAR char *buffer, size_t len)
     {
       /* If there are no writers on the pipe, then return end of file */
 
-      if (dev->d_nwriters <= 0)
+      if (dev->d_nwriters <= 0 && PIPE_IS_POLICY_0(dev->d_flags))
         {
           nxmutex_unlock(&dev->d_bflock);
           return 0;
@@ -556,7 +556,7 @@ ssize_t pipecommon_write(FAR struct file *filep, FAR const char *buffer,
        * ignoring this signal, then write(2) fails with the error EPIPE."
        */
 
-      if (dev->d_nreaders <= 0)
+      if (dev->d_nreaders <= 0 && PIPE_IS_POLICY_0(dev->d_flags))
         {
           nxmutex_unlock(&dev->d_bflock);
           return nwritten == 0 ? -EPIPE : nwritten;

--- a/drivers/pipes/pipe_common.c
+++ b/drivers/pipes/pipe_common.c
@@ -144,12 +144,9 @@ int pipecommon_open(FAR struct file *filep)
       return ret;
     }
 
-  /* If this the first reference on the device, then allocate the buffer.
-   * In the case of policy 1, the buffer already be present when the pipe
-   * is first opened.
-   */
+  /* If d_buffer is not initialized, init it. */
 
-  if (dev->d_crefs == 0 && PIPE_IS_POLICY_0(dev->d_flags))
+  if (!circbuf_is_init(&dev->d_buffer))
     {
       ret = circbuf_init(&dev->d_buffer, NULL, dev->d_bufsize);
       if (ret < 0)

--- a/drivers/pipes/pipe_common.c
+++ b/drivers/pipes/pipe_common.c
@@ -846,7 +846,9 @@ int pipecommon_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
           DEBUGASSERT(peek && peek->buf);
 
-          ret = circbuf_peek(&dev->d_buffer, peek->buf, peek->size);
+          ret = circbuf_peekat(&dev->d_buffer,
+                               dev->d_buffer.tail + peek->offset,
+                               peek->buf, peek->size);
         }
         break;
 

--- a/drivers/pipes/pipe_common.h
+++ b/drivers/pipes/pipe_common.h
@@ -126,6 +126,7 @@ struct pipe_dev_s
   uint8_t          d_nwriters;    /* Number of reference counts for write access */
   uint8_t          d_nreaders;    /* Number of reference counts for read access */
   uint8_t          d_flags;       /* See PIPE_FLAG_* definitions */
+  int16_t          d_crefs;       /* References to dev */
   struct circbuf_s d_buffer;      /* Buffer allocated when device opened */
 
   /* The following is a list if poll structures of threads waiting for

--- a/include/nuttx/fs/ioctl.h
+++ b/include/nuttx/fs/ioctl.h
@@ -717,6 +717,7 @@
 struct pipe_peek_s
 {
   FAR void *buf;
+  size_t offset;
   size_t size;
 };
 

--- a/net/local/local.h
+++ b/net/local/local.h
@@ -122,9 +122,6 @@ struct local_conn_s
   char lc_path[UNIX_PATH_MAX];   /* Path assigned by bind() */
   int32_t lc_instance_id;        /* Connection instance ID for stream
                                   * server<->client connection pair */
-#ifdef CONFIG_NET_LOCAL_DGRAM
-  uint16_t pktlen;                 /* Read-ahead packet length */
-#endif /* CONFIG_NET_LOCAL_DGRAM */
 
   FAR struct local_conn_s *
                         lc_peer; /* Peer connection instance */
@@ -438,6 +435,30 @@ ssize_t local_sendmsg(FAR struct socket *psock, FAR struct msghdr *msg,
                       int flags);
 
 /****************************************************************************
+ * Name: local_send_preamble
+ *
+ * Description:
+ *   Send a packet on the write-only FIFO.
+ *
+ * Input Parameters:
+ * conn      A reference to local connection structure
+ * filep     File structure of write-only FIFO.
+ * buf       Data to send
+ * len       Length of data to send
+ * preamble  preamble Flag to indicate the preamble sync header assembly
+ *
+ * Returned Value:
+ *   Packet length is returned on success; a negated errno value is returned
+ *   on any failure.
+ *
+ ****************************************************************************/
+
+int local_send_preamble(FAR struct local_conn_s *conn,
+                        FAR struct file *filep,
+                        FAR const struct iovec *buf,
+                        size_t len);
+
+/****************************************************************************
  * Name: local_send_packet
  *
  * Description:
@@ -447,7 +468,6 @@ ssize_t local_sendmsg(FAR struct socket *psock, FAR struct msghdr *msg,
  *   filep    File structure of write-only FIFO.
  *   buf      Data to send
  *   len      Length of data to send
- *   preamble Flag to indicate the preamble sync header assembly
  *
  * Returned Value:
  *   Zero is returned on success; a negated errno value is returned on any
@@ -456,7 +476,7 @@ ssize_t local_sendmsg(FAR struct socket *psock, FAR struct msghdr *msg,
  ****************************************************************************/
 
 int local_send_packet(FAR struct file *filep, FAR const struct iovec *buf,
-                      size_t len, bool preamble);
+                      size_t len);
 
 /****************************************************************************
  * Name: local_recvmsg
@@ -529,23 +549,6 @@ int local_fifo_read(FAR struct file *filep, FAR uint8_t *buf,
 
 int local_getaddr(FAR struct local_conn_s *conn, FAR struct sockaddr *addr,
                   FAR socklen_t *addrlen);
-
-/****************************************************************************
- * Name: local_sync
- *
- * Description:
- *   Read a sync bytes until the start of the packet is found.
- *
- * Input Parameters:
- *   filep - File structure of write-only FIFO.
- *
- * Returned Value:
- *   The non-zero size of the following packet is returned on success; a
- *   negated errno value is returned on any failure.
- *
- ****************************************************************************/
-
-int local_sync(FAR struct file *filep);
 
 /****************************************************************************
  * Name: local_create_fifos

--- a/net/local/local.h
+++ b/net/local/local.h
@@ -282,6 +282,21 @@ void local_subref(FAR struct local_conn_s *conn);
 FAR struct local_conn_s *local_nextconn(FAR struct local_conn_s *conn);
 
 /****************************************************************************
+ * Name: local_findconn
+ *
+ * Description:
+ *   Traverse the connections list to find the server
+ *
+ * Assumptions:
+ *   This function must be called with the network locked.
+ *
+ ****************************************************************************/
+
+FAR struct local_conn_s *
+local_findconn(FAR const struct local_conn_s *conn,
+               FAR const struct sockaddr_un *unaddr);
+
+/****************************************************************************
  * Name: local_peerconn
  *
  * Description:

--- a/net/local/local_bind.c
+++ b/net/local/local_bind.c
@@ -51,12 +51,22 @@ int psock_local_bind(FAR struct socket *psock,
   FAR struct local_conn_s *conn = psock->s_conn;
   FAR const struct sockaddr_un *unaddr =
     (FAR const struct sockaddr_un *)addr;
+  int index;
 
   DEBUGASSERT(unaddr->sun_family == AF_LOCAL);
 
   if (addrlen <= sizeof(sa_family_t) + 1)
     {
       return -EINVAL;
+    }
+
+  conn = psock->s_conn;
+
+  /* Check if local address is already in use */
+
+  if (local_findconn(conn, unaddr) != NULL)
+    {
+      return -EADDRINUSE;
     }
 
   /* Save the address family */
@@ -72,21 +82,17 @@ int psock_local_bind(FAR struct socket *psock,
       /* Zero-length sun_path... This is an abstract Unix domain socket */
 
       conn->lc_type = LOCAL_TYPE_ABSTRACT;
-
-      /* Copy the path into the connection structure */
-
-      strlcpy(conn->lc_path, &unaddr->sun_path[1], sizeof(conn->lc_path));
+      index = 1;
     }
   else
     {
       /* This is an normal, pathname Unix domain socket */
 
       conn->lc_type = LOCAL_TYPE_PATHNAME;
-
-      /* Copy the path into the connection structure */
-
-      strlcpy(conn->lc_path, unaddr->sun_path, sizeof(conn->lc_path));
+      index = 0;
     }
+
+  strlcpy(conn->lc_path, &unaddr->sun_path[index], sizeof(conn->lc_path));
 
   conn->lc_state = LOCAL_STATE_BOUND;
   return OK;

--- a/net/local/local_bind.c
+++ b/net/local/local_bind.c
@@ -64,10 +64,14 @@ int psock_local_bind(FAR struct socket *psock,
 
   /* Check if local address is already in use */
 
+  net_lock();
   if (local_findconn(conn, unaddr) != NULL)
     {
+      net_unlock();
       return -EADDRINUSE;
     }
+
+  net_unlock();
 
   /* Save the address family */
 

--- a/net/local/local_conn.c
+++ b/net/local/local_conn.c
@@ -69,6 +69,38 @@ FAR struct local_conn_s *local_nextconn(FAR struct local_conn_s *conn)
 }
 
 /****************************************************************************
+ * Name: local_findconn
+ *
+ * Description:
+ *   Traverse the connections list to find the local connection
+ *
+ * Assumptions:
+ *   This function must be called with the network locked.
+ *
+ ****************************************************************************/
+
+FAR struct local_conn_s *
+local_findconn(FAR const struct local_conn_s *local_conn,
+               FAR const struct sockaddr_un *unaddr)
+{
+  FAR struct local_conn_s *conn = NULL;
+
+  int index = unaddr->sun_path[0] == '\0' ? 1 : 0;
+
+  while ((conn = local_nextconn(conn)) != NULL)
+    {
+      if (local_conn->lc_proto == conn->lc_proto &&
+          strncmp(conn->lc_path, &unaddr->sun_path[index],
+                  UNIX_PATH_MAX - 1) == 0)
+        {
+          return conn;
+        }
+    }
+
+  return NULL;
+}
+
+/****************************************************************************
  * Name: local_peerconn
  *
  * Description:

--- a/net/local/local_connect.c
+++ b/net/local/local_connect.c
@@ -109,7 +109,9 @@ static int inline local_stream_connect(FAR struct local_conn_s *client,
 
   DEBUGASSERT(client->lc_outfile.f_inode != NULL);
 
+  net_lock();
   ret = local_alloc_accept(server, client, &conn);
+  net_unlock();
   if (ret < 0)
     {
       nerr("ERROR: Failed to alloc accept conn %s: %d\n",
@@ -150,7 +152,9 @@ static int inline local_stream_connect(FAR struct local_conn_s *client,
   return ret;
 
 errout_with_conn:
+  net_lock();
   local_free(conn);
+  net_unlock();
 
 errout_with_outfd:
   file_close(&client->lc_outfile);

--- a/net/local/local_fifo.c
+++ b/net/local/local_fifo.c
@@ -686,7 +686,7 @@ int local_open_receiver(FAR struct local_conn_s *conn, bool nonblock)
            */
 
           ret = local_set_pollinthreshold(&conn->lc_infile,
-                                          sizeof(uint16_t));
+                                          2 * sizeof(uint16_t));
         }
     }
 
@@ -729,7 +729,7 @@ int local_open_sender(FAR struct local_conn_s *conn, FAR const char *path,
            */
 
           ret = local_set_polloutthreshold(&conn->lc_outfile,
-                                           sizeof(uint16_t));
+                                           2 * sizeof(uint16_t));
         }
     }
 

--- a/net/local/local_recvmsg.c
+++ b/net/local/local_recvmsg.c
@@ -110,11 +110,7 @@ static int psock_fifo_read(FAR struct socket *psock, FAR void *buf,
         }
       else
         {
-          if (ret == -EAGAIN)
-            {
-              nwarn("WARNING: Failed to read packet: %d\n", ret);
-            }
-          else
+          if (ret != -EAGAIN)
             {
               nerr("ERROR: Failed to read packet: %d\n", ret);
             }

--- a/net/local/local_recvmsg.c
+++ b/net/local/local_recvmsg.c
@@ -56,7 +56,8 @@
  ****************************************************************************/
 
 static int psock_fifo_read(FAR struct socket *psock, FAR void *buf,
-                           FAR size_t *readlen, int flags, bool once)
+                           size_t offset, FAR size_t *readlen,
+                           int flags, bool once)
 {
   FAR struct local_conn_s *conn = psock->s_conn;
   int ret;
@@ -66,6 +67,7 @@ static int psock_fifo_read(FAR struct socket *psock, FAR void *buf,
       struct pipe_peek_s peek =
         {
           buf,
+          offset,
           *readlen
         };
 
@@ -270,7 +272,7 @@ psock_stream_recvfrom(FAR struct socket *psock, FAR void *buf, size_t len,
 
   /* Read the packet */
 
-  ret = psock_fifo_read(psock, buf, &readlen, flags, true);
+  ret = psock_fifo_read(psock, buf, 0, &readlen, flags, true);
   if (ret < 0)
     {
       return ret;
@@ -290,6 +292,56 @@ psock_stream_recvfrom(FAR struct socket *psock, FAR void *buf, size_t len,
   return readlen;
 }
 #endif /* CONFIG_NET_LOCAL_STREAM */
+
+/****************************************************************************
+ * Name: psock_fifo_discard
+ *
+ * Description:
+ *   psock_fifo_discard() discard buffer from a local socket.
+ *
+ * Input Parameters:
+ *   psock      A pointer to a NuttX-specific, internal socket structure
+ *   len        Remaining length of buffer
+ *   flags      Receive flags
+ *
+ * Returned Value:
+ *   On success, returns OK.  Otherwise, on errors, errno is returned
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_LOCAL_DGRAM
+static int psock_fifo_discard(FAR struct socket *psock, size_t len,
+                              int flags)
+{
+  uint8_t bitbucket[256];
+  size_t tmplen;
+  int ret;
+
+  if (flags & MSG_PEEK)
+    {
+      return OK;
+    }
+
+  while (len > 0)
+    {
+      /* Read 256 bytes into the bit bucket */
+
+      tmplen = MIN(len, sizeof(bitbucket));
+      ret = psock_fifo_read(psock, bitbucket, 0, &tmplen, flags, false);
+      if (ret < 0)
+        {
+          nerr("ERROR: Failed to get bitbucket : ret %d\n", ret);
+          return ret;
+        }
+
+      /* Adjust the number of bytes len to be read from the packet */
+
+      DEBUGASSERT(tmplen <= len);
+      len -= tmplen;
+    }
+
+  return OK;
+}
 
 /****************************************************************************
  * Name: psock_dgram_recvfrom
@@ -312,7 +364,6 @@ psock_stream_recvfrom(FAR struct socket *psock, FAR void *buf, size_t len,
  *
  ****************************************************************************/
 
-#ifdef CONFIG_NET_LOCAL_DGRAM
 static inline ssize_t
 psock_dgram_recvfrom(FAR struct socket *psock, FAR void *buf, size_t len,
                      int flags, FAR struct sockaddr *from,
@@ -320,8 +371,12 @@ psock_dgram_recvfrom(FAR struct socket *psock, FAR void *buf, size_t len,
 {
   FAR struct local_conn_s *conn = psock->s_conn;
   size_t readlen;
+  size_t pathlen;
   bool bclose = false;
-  int ret = 0;
+  uint16_t addrlen;
+  uint16_t pktlen;
+  int offset = 0;
+  int ret;
 
   /* We keep packet sizes in a uint16_t, so there is a upper limit to the
    * 'len' that can be supported.
@@ -366,33 +421,65 @@ psock_dgram_recvfrom(FAR struct socket *psock, FAR void *buf, size_t len,
         }
     }
 
+  readlen = sizeof(addrlen);
+  ret = psock_fifo_read(psock, &addrlen, offset, &readlen, flags, false);
+  if (ret < 0)
+    {
+      nerr("ERROR: Failed to get path length: ret %d\n", ret);
+      return ret;
+    }
+
   /* Sync to the start of the next packet in the stream and get the size of
    * the next packet.
    */
 
-  if (conn->pktlen <= 0)
+  readlen = sizeof(pktlen);
+  offset += sizeof(addrlen);
+  ret = psock_fifo_read(psock, &pktlen, offset, &readlen, flags, false);
+  if (ret < 0)
     {
-      ret = local_sync(&conn->lc_infile);
+      nerr("ERROR: Failed to get packet length: ret %d\n", ret);
+      goto errout_with_infd;
+    }
+
+  readlen = addrlen;
+  offset += sizeof(pktlen);
+
+  if (from && fromlen && *fromlen)
+    {
+      pathlen = MIN(*fromlen - 1, readlen);
+      ret = psock_fifo_read(psock, from->sa_data, offset,
+                            &pathlen, flags, false);
       if (ret < 0)
         {
-          nerr("ERROR: Failed to get packet length: %d\n", ret);
-          goto errout_with_infd;
-        }
-      else if (ret > UINT16_MAX)
-        {
-          nerr("ERROR: Packet is too big: %d\n", ret);
+          nerr("ERROR: Failed to get path : ret %d\n", ret);
           goto errout_with_infd;
         }
 
-      conn->pktlen = ret;
+      from->sa_family = AF_LOCAL;
+      from->sa_data[pathlen] = '\0';
+      *fromlen = pathlen;
+      readlen -= pathlen;
+    }
+
+  if (readlen)
+    {
+      ret = psock_fifo_discard(psock, readlen, flags);
+      if (ret < 0)
+        {
+          nerr("ERROR: Failed to discard redunance address: ret %d\n", ret);
+          goto errout_with_infd;
+        }
     }
 
   /* Read the packet */
 
-  readlen = MIN(conn->pktlen, len);
-  ret     = psock_fifo_read(psock, buf, &readlen, flags, false);
+  readlen = MIN(pktlen, len);
+  offset += addrlen;
+  ret     = psock_fifo_read(psock, buf, offset, &readlen, flags, false);
   if (ret < 0)
     {
+      nerr("ERROR: Failed to get packet : ret %d\n", ret);
       goto errout_with_infd;
     }
 
@@ -400,55 +487,10 @@ psock_dgram_recvfrom(FAR struct socket *psock, FAR void *buf, size_t len,
    * of the packet to the bit bucket.
    */
 
-  if (flags & MSG_PEEK)
+  DEBUGASSERT(readlen <= pktlen);
+  if (readlen < pktlen)
     {
-      goto skip_flush;
-    }
-
-  DEBUGASSERT(readlen <= conn->pktlen);
-  if (readlen < conn->pktlen)
-    {
-      uint8_t bitbucket[32];
-      uint16_t remaining;
-      size_t tmplen;
-
-      remaining = conn->pktlen - readlen;
-      do
-        {
-          /* Read 32 bytes into the bit bucket */
-
-          tmplen = MIN(remaining, 32);
-          ret = psock_fifo_read(psock, bitbucket, &tmplen, flags, false);
-          if (ret < 0)
-            {
-              goto errout_with_infd;
-            }
-
-          /* Adjust the number of bytes remaining to be read from the
-           * packet
-           */
-
-          DEBUGASSERT(tmplen <= remaining);
-          remaining -= tmplen;
-        }
-      while (remaining > 0);
-    }
-
-  /* The fifo has been read and the pktlen needs to be cleared */
-
-  conn->pktlen = 0;
-
-skip_flush:
-
-  /* Return the address family */
-
-  if (from)
-    {
-      ret = local_getaddr(conn, from, fromlen);
-      if (ret < 0)
-        {
-          return ret;
-        }
+      ret = psock_fifo_discard(psock, pktlen - readlen, flags);
     }
 
 errout_with_infd:

--- a/net/local/local_recvutils.c
+++ b/net/local/local_recvutils.c
@@ -122,34 +122,6 @@ errout:
 }
 
 /****************************************************************************
- * Name: local_sync
- *
- * Description:
- *   Read a sync bytes until the start of the packet is found.
- *
- * Input Parameters:
- *   filep - File structure of write-only FIFO.
- *
- * Returned Value:
- *   The non-zero size of the following packet is returned on success; a
- *   negated errno value is returned on any failure.
- *
- ****************************************************************************/
-
-int local_sync(FAR struct file *filep)
-{
-  size_t readlen;
-  uint16_t pktlen;
-  int ret;
-
-  /* Read the packet length */
-
-  readlen = sizeof(uint16_t);
-  ret     = local_fifo_read(filep, (FAR uint8_t *)&pktlen, &readlen, false);
-  return ret < 0 ? ret : pktlen;
-}
-
-/****************************************************************************
  * Name: local_getaddr
  *
  * Description:

--- a/net/local/local_sendmsg.c
+++ b/net/local/local_sendmsg.c
@@ -262,7 +262,7 @@ static ssize_t local_sendto(FAR struct socket *psock,
 {
 #ifdef CONFIG_NET_LOCAL_DGRAM
   FAR struct local_conn_s *conn = psock->s_conn;
-  FAR struct sockaddr_un *unaddr = (FAR struct sockaddr_un *)to;
+  FAR const struct sockaddr_un *unaddr = (FAR const struct sockaddr_un *)to;
   ssize_t ret;
 
   /* Verify that a valid address has been provided */
@@ -294,6 +294,12 @@ static ssize_t local_sendto(FAR struct socket *psock,
 
       nerr("ERROR: Connected state\n");
       return -EISCONN;
+    }
+
+  if (local_findconn(conn, unaddr) == NULL)
+    {
+      nerr("ERROR: No such file or directory\n");
+      return -ENOENT;
     }
 
   /* The outgoing FIFO should not be open */

--- a/net/local/local_sendmsg.c
+++ b/net/local/local_sendmsg.c
@@ -306,11 +306,15 @@ static ssize_t local_sendto(FAR struct socket *psock,
       return -EISCONN;
     }
 
+  net_lock();
   if (local_findconn(conn, unaddr) == NULL)
     {
+      net_unlock();
       nerr("ERROR: No such file or directory\n");
       return -ENOENT;
     }
+
+  net_unlock();
 
   /* Make sure that dgram is sent safely */
 

--- a/net/local/local_sendpacket.c
+++ b/net/local/local_sendpacket.c
@@ -183,7 +183,11 @@ int local_send_packet(FAR struct file *filep, FAR const struct iovec *buf,
       ret = local_fifo_write(filep, iov->iov_base, iov->iov_len);
       if (ret < 0)
         {
-          nerr("ERROR: local send packet failed ret: %d\n", ret);
+          if (ret != -EAGAIN)
+            {
+              nerr("ERROR: local send packet failed ret: %d\n", ret);
+            }
+
           break;
         }
 

--- a/net/local/local_sockif.c
+++ b/net/local/local_sockif.c
@@ -128,7 +128,10 @@ static int local_sockif_alloc(FAR struct socket *psock)
 {
   /* Allocate the local connection structure */
 
-  FAR struct local_conn_s *conn = local_alloc();
+  FAR struct local_conn_s *conn;
+  net_lock();
+  conn = local_alloc();
+  net_unlock();
   if (conn == NULL)
     {
       /* Failed to reserve a connection structure */


### PR DESCRIPTION
## Summary
For udp localsocket current implementation,the sent information only carries the packet info.
The receiver receives the information,it don't know who the information comes from.
Thus the receiver doesn't know who to send the response message to.

We add sender's binding path info in the information,the receiver knows who sent the information
based on the parsed information.
The receiver knows who to send the response message to.
## Impact
localsocket
## Testing
refer to the https://xiaomi.f.mioffice.cn/wiki/wikk4f0am50AewzAGVhE2iMVpnw chapter 57 the test case
![img_v2_928caa6f-2bbe-40e3-942e-da915cb4d4al](https://github.com/user-attachments/assets/464a2a23-7f94-4165-9ca0-46777f890fa7)

