### PR TITLE
netdev/ioctl: Setting log level to warning on SIOCGIFHWADDR failure

### DIFF
--- a/net/netdev/netdev_ioctl.c
+++ b/net/netdev/netdev_ioctl.c
@@ -1031,7 +1031,7 @@ static int netdev_ifr_ioctl(FAR struct socket *psock, int cmd,
         else
 #endif
           {
-            nerr("Unsupported link layer\n");
+            nwarn("WARNING: Unsupported link layer\n");
             ret = -EAFNOSUPPORT;
           }
         break;


### PR DESCRIPTION
## Summary
When our apps call getifaddrs on lo frequently, the loopback device will failed in SIOCGIFHWADDR and print too many error logs.
## Impact
netdev ioctl
## Testing
Manual verification
