### PR TITLE
can:  CAN code optimization

### DIFF
--- a/drivers/can/can.c
+++ b/drivers/can/can.c
@@ -43,14 +43,7 @@
 #include <nuttx/fs/fs.h>
 #include <nuttx/can/can.h>
 #include <nuttx/kmalloc.h>
-
-#ifdef CONFIG_CAN_TXREADY
-#  include <nuttx/wqueue.h>
-#endif
-
 #include <nuttx/irq.h>
-
-#ifdef CONFIG_CAN
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -196,9 +189,6 @@ static FAR struct can_reader_s *init_can_reader(FAR struct file *filep)
   FAR struct can_reader_s *reader = kmm_zalloc(sizeof(struct can_reader_s));
   DEBUGASSERT(reader != NULL);
 
-  reader->fifo.rx_head  = 0;
-  reader->fifo.rx_tail  = 0;
-
   nxsem_init(&reader->fifo.rx_sem, 0, 0);
   filep->f_priv = reader;
 
@@ -298,7 +288,6 @@ static int can_close(FAR struct file *filep)
   FAR struct can_dev_s *dev   = inode->i_private;
   irqstate_t            flags;
   FAR struct list_node *node;
-  FAR struct list_node *tmp;
   int                   ret;
 
 #ifdef  CONFIG_DEBUG_CAN_INFO
@@ -311,7 +300,7 @@ static int can_close(FAR struct file *filep)
       return ret;
     }
 
-  list_for_every_safe(&dev->cd_readers, node, tmp)
+  list_for_every(&dev->cd_readers, node)
     {
       if (((FAR struct can_reader_s *)node) ==
           ((FAR struct can_reader_s *)filep->f_priv))
@@ -372,14 +361,13 @@ errout:
 static ssize_t can_read(FAR struct file *filep, FAR char *buffer,
                         size_t buflen)
 {
-  FAR struct can_reader_s  *reader;
-  FAR struct can_rxfifo_s  *fifo;
-  size_t                    nread;
-  irqstate_t                flags;
-  int                       ret = 0;
+  FAR struct can_reader_s *reader;
+  FAR struct can_rxfifo_s *fifo;
+  irqstate_t               flags;
+  int                      ret = 0;
 #ifdef CONFIG_CAN_ERRORS
-  FAR struct inode         *inode = filep->f_inode;
-  FAR struct can_dev_s     *dev = inode->i_private;
+  FAR struct inode        *inode = filep->f_inode;
+  FAR struct can_dev_s    *dev = inode->i_private;
 #endif
 
   caninfo("buflen: %zu\n", buflen);
@@ -393,7 +381,6 @@ static ssize_t can_read(FAR struct file *filep, FAR char *buffer,
     {
       DEBUGASSERT(filep->f_priv != NULL);
       reader = (FAR struct can_reader_s *)filep->f_priv;
-
       fifo = &reader->fifo;
 
       /* Interrupts must be disabled while accessing the cd_recv FIFO */
@@ -470,7 +457,6 @@ static ssize_t can_read(FAR struct file *filep, FAR char *buffer,
        * in the user buffer.
        */
 
-      nread = 0;
       do
         {
           /* Will the next message in the FIFO fit into the user buffer? */
@@ -479,15 +465,15 @@ static ssize_t can_read(FAR struct file *filep, FAR char *buffer,
           int nbytes = can_dlc2bytes(msg->cm_hdr.ch_dlc);
           int msglen = CAN_MSGLEN(nbytes);
 
-          if (nread + msglen > buflen)
+          if (ret + msglen > buflen)
             {
               break;
             }
 
           /* Copy the message to the user buffer */
 
-          memcpy(&buffer[nread], msg, msglen);
-          nread += msglen;
+          memcpy(&buffer[ret], msg, msglen);
+          ret += msglen;
 
           /* Increment the head of the circular message buffer */
 
@@ -507,10 +493,6 @@ static ssize_t can_read(FAR struct file *filep, FAR char *buffer,
 
           nxsem_post(&fifo->rx_sem);
         }
-
-      /* Return the number of bytes that were read. */
-
-      ret = nread;
 
 return_with_irqdisabled:
       leave_critical_section(flags);
@@ -637,7 +619,7 @@ static ssize_t can_write(FAR struct file *filep, FAR const char *buffer,
    * shorter than the minimum.
    */
 
-  while (((ssize_t)buflen - nsent) >= CAN_MSGLEN(0))
+  while (buflen - nsent >= CAN_MSGLEN(0))
     {
       /* Check if adding this new message would over-run the drivers ability
        * to enqueue xmit data.
@@ -747,7 +729,7 @@ return_with_irqdisabled:
 static inline ssize_t can_rtrread(FAR struct file *filep,
                                   FAR struct canioc_rtr_s *request)
 {
-  FAR struct can_dev_s *dev = filep->f_inode->i_private;
+  FAR struct can_dev_s     *dev = filep->f_inode->i_private;
   FAR struct can_rtrwait_s *wait = NULL;
   irqstate_t                flags;
   int                       i;
@@ -765,7 +747,6 @@ static inline ssize_t can_rtrread(FAR struct file *filep,
       FAR struct can_rtrwait_s *tmp = &dev->cd_rtr[i];
 
       ret = nxsem_get_value(&tmp->cr_sem, &sval);
-
       if (ret < 0)
         {
           continue;
@@ -777,7 +758,6 @@ static inline ssize_t can_rtrread(FAR struct file *filep,
 
           tmp->cr_msg     = request->ci_msg;
           dev->cd_npendrtr++;
-
           wait            = tmp;
           break;
         }
@@ -814,7 +794,7 @@ static inline ssize_t can_rtrread(FAR struct file *filep,
 
           request->ci_msg->cm_hdr.ch_rtr = 1;
           ret = can_write(filep,
-                          (const char *) request->ci_msg,
+                          (FAR const char *)request->ci_msg,
                           CAN_MSGLEN(request->ci_msg->cm_hdr.ch_dlc));
           request->ci_msg->cm_hdr.ch_rtr = 0;
 #else
@@ -846,8 +826,7 @@ static int can_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   FAR struct inode        *inode  = filep->f_inode;
   FAR struct can_dev_s    *dev    = inode->i_private;
   FAR struct can_reader_s *reader = filep->f_priv;
-
-  int                     ret     = OK;
+  int                      ret    = OK;
 
   caninfo("cmd: %d arg: %ld\n", cmd, arg);
 
@@ -951,10 +930,10 @@ static int can_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 static int can_poll(FAR struct file *filep, FAR struct pollfd *fds,
                     bool setup)
 {
-  FAR struct inode *inode = (FAR struct inode *)filep->f_inode;
+  FAR struct inode *inode = filep->f_inode;
   FAR struct can_dev_s *dev = inode->i_private;
   FAR struct can_reader_s *reader = NULL;
-  pollevent_t eventset;
+  pollevent_t eventset = 0;
   int ndx;
   int sval;
   irqstate_t flags;
@@ -1028,8 +1007,6 @@ static int can_poll(FAR struct file *filep, FAR struct pollfd *fds,
        * should, but that would be a little awkward).
        */
 
-      eventset = 0;
-
       DEBUGASSERT(dev->cd_ntxwaiters < 255);
       dev->cd_ntxwaiters++;
       do
@@ -1099,7 +1076,6 @@ static int can_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
 errout:
   nxmutex_unlock(&dev->cd_polllock);
-
 return_with_irqdisabled:
   leave_critical_section(flags);
   return ret;
@@ -1113,7 +1089,7 @@ return_with_irqdisabled:
  * Name: can_register
  *
  * Description:
- *   Register serial console and serial ports.
+ *   Register a CAN driver.
  *
  ****************************************************************************/
 
@@ -1179,15 +1155,11 @@ int can_receive(FAR struct can_dev_s *dev, FAR struct can_hdr_s *hdr,
                 FAR uint8_t *data)
 {
   FAR struct can_rxfifo_s *fifo;
-  FAR uint8_t             *dest;
   FAR struct list_node    *node;
-  FAR struct list_node    *tmp;
   int                      nexttail;
-  int                      errcode = -ENOMEM;
+  int                      ret = -ENOMEM;
   int                      i;
-  int                      j;
   int                      sval;
-  int                      ret;
 
   caninfo("ID: %" PRId32 " DLC: %d\n", (uint32_t)hdr->ch_id, hdr->ch_dlc);
 
@@ -1212,21 +1184,18 @@ int can_receive(FAR struct can_dev_s *dev, FAR struct can_hdr_s *hdr,
 
           /* Check if the entry is in use and whether the ID matches */
 
-          ret = nxsem_get_value(&wait->cr_sem, &sval);
-
-          if (ret < 0)
+          if (nxsem_get_value(&wait->cr_sem, &sval) < 0)
             {
               continue;
             }
-
           else if (sval < 0
 #ifdef CONFIG_CAN_ERRORS
-                && hdr->ch_error == false
+                   && hdr->ch_error == false
 #endif
 #ifdef CONFIG_CAN_EXTID
-                && waitmsg->cm_hdr.ch_extid == hdr->ch_extid
+                   && waitmsg->cm_hdr.ch_extid == hdr->ch_extid
 #endif
-                && waitmsg->cm_hdr.ch_id == hdr->ch_id)
+                   && waitmsg->cm_hdr.ch_id == hdr->ch_id)
             {
               int nbytes;
 
@@ -1235,11 +1204,7 @@ int can_receive(FAR struct can_dev_s *dev, FAR struct can_hdr_s *hdr,
               memcpy(&waitmsg->cm_hdr, hdr, sizeof(struct can_hdr_s));
 
               nbytes = can_dlc2bytes(hdr->ch_dlc);
-              for (j = 0, dest = waitmsg->cm_data; j < nbytes; j++)
-                {
-                  *dest++ = *data++;
-                }
-
+              memcpy(waitmsg->cm_data, data, nbytes);
               dev->cd_npendrtr--;
 
               /* Restart the waiting thread and mark the entry unused */
@@ -1249,7 +1214,7 @@ int can_receive(FAR struct can_dev_s *dev, FAR struct can_hdr_s *hdr,
         }
     }
 
-  list_for_every_safe(&dev->cd_readers, node, tmp)
+  list_for_every(&dev->cd_readers, node)
     {
       FAR struct can_reader_s *reader = (FAR struct can_reader_s *)node;
       fifo = &reader->fifo;
@@ -1292,7 +1257,6 @@ int can_receive(FAR struct can_dev_s *dev, FAR struct can_hdr_s *hdr,
 
           poll_notify(dev->cd_fds, CONFIG_CAN_NPOLLWAITERS, POLLIN);
 
-          sval = 0;
           if (nxsem_get_value(&fifo->rx_sem, &sval) < 0)
             {
               DEBUGPANIC();
@@ -1314,7 +1278,7 @@ int can_receive(FAR struct can_dev_s *dev, FAR struct can_hdr_s *hdr,
               nxsem_post(&fifo->rx_sem);
             }
 
-          errcode = OK;
+          ret = OK;
         }
 #ifdef CONFIG_CAN_ERRORS
       else
@@ -1326,7 +1290,7 @@ int can_receive(FAR struct can_dev_s *dev, FAR struct can_hdr_s *hdr,
 #endif
     }
 
-  return errcode;
+  return ret;
 }
 
 /****************************************************************************
@@ -1387,8 +1351,6 @@ int can_receive(FAR struct can_dev_s *dev, FAR struct can_hdr_s *hdr,
  *
  * Input Parameters:
  *   dev  - The specific CAN device
- *   hdr  - The 16-bit CAN header
- *   data - An array contain the CAN data.
  *
  * Returned Value:
  *   OK on success; a negated errno on failure.
@@ -1686,5 +1648,3 @@ uint8_t can_dlc2bytes(uint8_t dlc)
 
   return dlc;
 }
-
-#endif /* CONFIG_CAN */

--- a/include/nuttx/can/can.h
+++ b/include/nuttx/can/can.h
@@ -286,7 +286,7 @@
  *   CANIOC_A_CMD2          _CANIOC(CAN_A_FIRST+1)
  *   CANIOC_A_CMD3          _CANIOC(CAN_A_FIRST+2)
  *   ...
- *   CANIOC_A_CMD42            _CANIOC(CAN_A_FIRST+41)
+ *   CANIOC_A_CMD42         _CANIOC(CAN_A_FIRST+41)
  *
  * The next reservation would look like:
  *
@@ -296,16 +296,16 @@
 
 /* Convenience macros *******************************************************/
 
-#define dev_reset(dev)            dev->cd_ops->co_reset(dev)
-#define dev_setup(dev)            dev->cd_ops->co_setup(dev)
-#define dev_shutdown(dev)         dev->cd_ops->co_shutdown(dev)
-#define dev_txint(dev,enable)     dev->cd_ops->co_txint(dev,enable)
-#define dev_rxint(dev,enable)     dev->cd_ops->co_rxint(dev,enable)
-#define dev_ioctl(dev,cmd,arg)    dev->cd_ops->co_ioctl(dev,cmd,arg)
-#define dev_remoterequest(dev,id) dev->cd_ops->co_remoterequest(dev,id)
-#define dev_send(dev,m)           dev->cd_ops->co_send(dev,m)
-#define dev_txready(dev)          dev->cd_ops->co_txready(dev)
-#define dev_txempty(dev)          dev->cd_ops->co_txempty(dev)
+#define dev_reset(dev)            (dev)->cd_ops->co_reset(dev)
+#define dev_setup(dev)            (dev)->cd_ops->co_setup(dev)
+#define dev_shutdown(dev)         (dev)->cd_ops->co_shutdown(dev)
+#define dev_txint(dev,enable)     (dev)->cd_ops->co_txint(dev,enable)
+#define dev_rxint(dev,enable)     (dev)->cd_ops->co_rxint(dev,enable)
+#define dev_ioctl(dev,cmd,arg)    (dev)->cd_ops->co_ioctl(dev,cmd,arg)
+#define dev_remoterequest(dev,id) (dev)->cd_ops->co_remoterequest(dev,id)
+#define dev_send(dev,m)           (dev)->cd_ops->co_send(dev,m)
+#define dev_txready(dev)          (dev)->cd_ops->co_txready(dev)
+#define dev_txempty(dev)          (dev)->cd_ops->co_txempty(dev)
 
 /* CAN message support ******************************************************/
 
@@ -408,7 +408,7 @@
 #  define CANH_ERROR4_SHORT2VCC   0x03
 #  define CANH_ERROR4_SHORT2GND   0x04
 
-#  define CANL_ERROR4_MASK        0xf0 /* Bits 0-3: CANL */
+#  define CANL_ERROR4_MASK        0xf0 /* Bits 4-7: CANL */
 #  define CANL_ERROR4_NOWIRE      0x10
 #  define CANL_ERROR4_SHORT2BAT   0x20
 #  define CANL_ERROR4_SHORT2VCC   0x30
@@ -573,7 +573,7 @@ struct can_txfifo_s
 
 struct can_rtrwait_s
 {
-  sem_t         cr_sem;                  /* Wait for response/is the cd_rtr entry available */
+  sem_t                 cr_sem;          /* Wait for response/is the cd_rtr entry available */
   FAR struct can_msg_s *cr_msg;          /* This is where the RTR response goes */
 };
 
@@ -871,8 +871,6 @@ int can_receive(FAR struct can_dev_s *dev, FAR struct can_hdr_s *hdr,
  *
  * Input Parameters:
  *   dev  - The specific CAN device
- *   hdr  - The 16-bit CAN header
- *   data - An array contain the CAN data.
  *
  * Returned Value:
  *   OK on success; a negated errno on failure.


### PR DESCRIPTION
## Summary

1. Some macro definitions have already been defined in other header files, redundant macro definitions have been removed in include/nuttx/can.h.
2. Align some code.
3. Remove no use struct (can_response_s) and some variables.

## Impact
CAN protocol stack.

## Testing
Brush the modified system to the CAN development board, and the CAN communication between the development board and peripherals is normal. 
