### PR TITLE
Modify the IPV6 address acquisition method and the gateway settings.

### DIFF
--- a/net/icmpv6/icmpv6_autoconfig.c
+++ b/net/icmpv6/icmpv6_autoconfig.c
@@ -437,9 +437,12 @@ got_lladdr:
           nerr("ERROR: Failed send neighbor advertisement: %d\n", senderr);
         }
 
-      /* No off-link communications; No router address. */
+      if (ret != -EADDRNOTAVAIL)
+        {
+          /* No off-link communications; No router address. */
 
-      net_ipv6addr_copy(dev->d_ipv6draddr, g_ipv6_unspecaddr);
+          net_ipv6addr_copy(dev->d_ipv6draddr, g_ipv6_unspecaddr);
+        }
     }
 
   /* 5. Router Direction: The router provides direction to the node on how

--- a/net/icmpv6/icmpv6_input.c
+++ b/net/icmpv6/icmpv6_input.c
@@ -442,22 +442,18 @@ void icmpv6_input(FAR struct net_driver_s *dev, unsigned int iplen)
                     FAR struct icmpv6_prefixinfo_s *prefixopt =
                                       (FAR struct icmpv6_prefixinfo_s *)opt;
 
-                    /* if "M" flag isn't set, and the "A" flag is set.
-                     * Set the new network addresses.
-                     */
+                   /* Is the "A" flag set? */
 
-                    if ((adv->flags & ICMPv6_RADV_FLAG_M) == 0 &&
-                        (prefixopt->flags & ICMPv6_PRFX_FLAG_A) != 0)
+                    if ((prefixopt->flags & ICMPv6_PRFX_FLAG_A) != 0)
                       {
-                         icmpv6_setaddresses(dev, ipv6->srcipaddr,
+                        /* Yes.. Set the new network addresses. */
+
+                        icmpv6_setaddresses(dev, ipv6->srcipaddr,
                                     prefixopt->prefix, prefixopt->preflen);
                         netlink_ipv6_prefix_notify(dev, RTM_NEWPREFIX,
                                                    prefixopt);
                       }
-
-                    /* Set the router address for the stateful process. */
-
-                    if ((adv->flags & ICMPv6_RADV_FLAG_M))
+                    else if ((adv->flags & ICMPv6_RADV_FLAG_M) != 0)
                       {
                         net_ipv6addr_copy(dev->d_ipv6draddr,
                                           ipv6->srcipaddr);

--- a/net/icmpv6/icmpv6_input.c
+++ b/net/icmpv6/icmpv6_input.c
@@ -455,6 +455,14 @@ void icmpv6_input(FAR struct net_driver_s *dev, unsigned int iplen)
                                                    prefixopt);
                       }
 
+                    /* Set the router address for the stateful process. */
+
+                    if ((adv->flags & ICMPv6_RADV_FLAG_M))
+                      {
+                        net_ipv6addr_copy(dev->d_ipv6draddr,
+                                          ipv6->srcipaddr);
+                      }
+
                       /* Notify any waiting threads */
 
                       icmpv6_rnotify(dev, (adv->flags & ICMPv6_RADV_FLAG_M) ?


### PR DESCRIPTION
## Summary

There are two changes here：
- One is to set the gateway for the stateful mode;
- The other is to allow both stateful mode and stateless mode to obtain the IPv6 addresses at the same time.

## Impact
N/A
## Testing
After using the `renew6` command to obtain the IPv6 address, 
and check the obtained IPv6 address by the `ifconfig` command.


