### PR TITLE
add tls cleanup toprotect udp

### DIFF
--- a/net/udp/udp.h
+++ b/net/udp/udp.h
@@ -175,6 +175,14 @@ struct udp_wrbuffer_s
 };
 #endif
 
+struct udp_callback_s
+{
+  FAR struct net_driver_s *dev;
+  FAR struct udp_conn_s *conn;
+  FAR struct devif_callback_s *udp_cb;
+  FAR sem_t *sem;
+};
+
 /****************************************************************************
  * Public Data
  ****************************************************************************/
@@ -722,6 +730,19 @@ udp_find_raddr_device(FAR struct udp_conn_s *conn,
 
 uint16_t udp_callback(FAR struct net_driver_s *dev,
                       FAR struct udp_conn_s *conn, uint16_t flags);
+
+/****************************************************************************
+ * Name: udp_callback_cleanup
+ *
+ * Description:
+ *   Cleanup data and cb when thread is canceled.
+ *
+ * Input Parameters:
+ *   arg - A pointer with conn and callback struct.
+ *
+ ****************************************************************************/
+
+void udp_callback_cleanup(FAR void *arg);
 
 /****************************************************************************
  * Name: psock_udp_recvfrom

--- a/net/udp/udp.h
+++ b/net/udp/udp.h
@@ -893,7 +893,7 @@ int udp_writebuffer_notifier_setup(worker_t worker,
  ****************************************************************************/
 
 #ifdef CONFIG_NET_UDP_NOTIFIER
-void udp_notifier_teardown(int key);
+void udp_notifier_teardown(FAR void *key);
 #endif
 
 /****************************************************************************

--- a/net/udp/udp_callback.c
+++ b/net/udp/udp_callback.c
@@ -327,4 +327,28 @@ uint16_t udp_callback(FAR struct net_driver_s *dev,
   return flags;
 }
 
+/****************************************************************************
+ * Name: udp_callback_cleanup
+ *
+ * Description:
+ *   Cleanup data and cb when thread is canceled.
+ *
+ * Input Parameters:
+ *   arg - A pointer with conn and callback struct.
+ *
+ ****************************************************************************/
+
+void udp_callback_cleanup(FAR void *arg)
+{
+  FAR struct udp_callback_s *cb = (FAR struct udp_callback_s *)arg;
+
+  nerr("ERROR: pthread is being canceled, need to cleanup cb\n");
+
+  udp_callback_free(cb->dev, cb->conn, cb->udp_cb);
+  if (cb->sem)
+    {
+      nxsem_destroy(cb->sem);
+    }
+}
+
 #endif /* CONFIG_NET && CONFIG_NET_UDP */

--- a/net/udp/udp_notifier.c
+++ b/net/udp/udp_notifier.c
@@ -168,11 +168,11 @@ int udp_writebuffer_notifier_setup(worker_t worker,
  *
  ****************************************************************************/
 
-void udp_notifier_teardown(int key)
+void udp_notifier_teardown(FAR void *key)
 {
   /* This is just a simple wrapper around work_notifier_teardown(). */
 
-  work_notifier_teardown(key);
+  work_notifier_teardown(*(FAR int *)key);
 }
 
 /****************************************************************************

--- a/net/udp/udp_recvfrom.c
+++ b/net/udp/udp_recvfrom.c
@@ -37,6 +37,7 @@
 #include <nuttx/net/netdev.h>
 #include <nuttx/net/ip.h>
 #include <nuttx/net/udp.h>
+#include <nuttx/tls.h>
 #include <netinet/in.h>
 
 #include "netdev/netdev.h"
@@ -625,6 +626,7 @@ ssize_t psock_udp_recvfrom(FAR struct socket *psock, FAR struct msghdr *msg,
 {
   FAR struct udp_conn_s *conn = psock->s_conn;
   FAR struct net_driver_s *dev;
+  struct udp_callback_s info;
   struct udp_recvfrom_s state;
   int ret;
 
@@ -693,6 +695,16 @@ ssize_t psock_udp_recvfrom(FAR struct socket *psock, FAR struct msghdr *msg,
           state.ir_cb->priv  = (FAR void *)&state;
           state.ir_cb->event = udp_eventhandler;
 
+          /* Push a cancellation point onto the stack.  This will be
+           * called if the thread is canceled.
+           */
+
+          info.dev  = dev;
+          info.conn = conn;
+          info.udp_cb = state.ir_cb;
+          info.sem = &state.ir_sem;
+          tls_cleanup_push(tls_get_info(), udp_callback_cleanup, &info);
+
           /* Wait for either the receive to complete or for an error/timeout
            * to occur.  net_sem_timedwait will also terminate if a signal is
            * received.
@@ -700,6 +712,7 @@ ssize_t psock_udp_recvfrom(FAR struct socket *psock, FAR struct msghdr *msg,
 
           ret = net_sem_timedwait(&state.ir_sem,
                               _SO_TIMEOUT(conn->sconn.s_rcvtimeo));
+          tls_cleanup_pop(tls_get_info(), 0);
           if (ret == -ETIMEDOUT)
             {
               ret = -EAGAIN;

--- a/net/udp/udp_txdrain.c
+++ b/net/udp/udp_txdrain.c
@@ -29,8 +29,10 @@
 #include <assert.h>
 #include <errno.h>
 
+#include <nuttx/cancelpt.h>
 #include <nuttx/net/net.h>
 #include <nuttx/semaphore.h>
+#include <nuttx/tls.h>
 
 #include "utils/utils.h"
 #include "udp/udp.h"
@@ -94,6 +96,10 @@ int udp_txdrain(FAR struct socket *psock, unsigned int timeout)
 
   DEBUGASSERT(psock->s_type == SOCK_DGRAM);
 
+  /* udp_txdrain() is a cancellation point */
+
+  enter_cancellation_point();
+
   conn = psock->s_conn;
 
   /* Initialize the wait semaphore */
@@ -110,18 +116,22 @@ int udp_txdrain(FAR struct socket *psock, unsigned int timeout)
 
       /* There is pending write data.. wait for it to drain. */
 
+      tls_cleanup_push(tls_get_info(), udp_notifier_teardown, &key);
       ret = net_sem_timedwait_uninterruptible(&waitsem, timeout);
 
       /* Tear down the notifier (in case we timed out or were canceled) */
 
       if (ret < 0)
         {
-          udp_notifier_teardown(key);
+          udp_notifier_teardown(&key);
         }
+
+      tls_cleanup_pop(tls_get_info(), 0);
     }
 
   net_unlock();
   nxsem_destroy(&waitsem);
+  leave_cancellation_point();
   return ret;
 }
 


### PR DESCRIPTION
## Summary
Due to abnormal application exit,so add tls cleanup to protect udp process
## Impact
udp
## Testing
Manual verification
