### PR TITLE
net/tcp: reset the dupack counter.

### DIFF
--- a/net/tcp/tcp_send_buffered.c
+++ b/net/tcp/tcp_send_buffered.c
@@ -629,6 +629,10 @@ static uint16_t psock_send_eventhandler(FAR struct net_driver_s *dev,
 #endif
 #endif
                     }
+
+#ifdef CONFIG_NET_TCP_CC_NEWRENO
+                  conn->dupacks = 0;
+#endif
                 }
             }
         }


### PR DESCRIPTION
## Summary

After setting the retransmission flag, we need to set the `dupack` counter to 0.

## Impact
N/A
## Testing
Locally verified.
