### PR TITLE
fs/mmap/msync: support msync 

### DIFF
--- a/fs/mmap/CMakeLists.txt
+++ b/fs/mmap/CMakeLists.txt
@@ -18,7 +18,7 @@
 #
 # ##############################################################################
 
-set(SRCS fs_mmap.c fs_munmap.c fs_mmisc.c)
+set(SRCS fs_mmap.c fs_munmap.c fs_mmisc.c fs_msync.c)
 
 if(CONFIG_FS_RAMMAP)
   list(APPEND SRCS fs_rammap.c)

--- a/fs/mmap/Make.defs
+++ b/fs/mmap/Make.defs
@@ -18,7 +18,7 @@
 #
 ############################################################################
 
-CSRCS += fs_mmap.c fs_munmap.c fs_mmisc.c
+CSRCS += fs_mmap.c fs_munmap.c fs_mmisc.c fs_msync.c
 
 ifeq ($(CONFIG_FS_RAMMAP),y)
 CSRCS += fs_rammap.c

--- a/fs/mmap/fs_mmap.c
+++ b/fs/mmap/fs_mmap.c
@@ -47,8 +47,8 @@
  ****************************************************************************/
 
 static int file_mmap_(FAR struct file *filep, FAR void *start,
-                      size_t length, int prot, int flags,
-                      off_t offset, bool kernel, FAR void **mapped)
+                      size_t length, int prot, int flags, off_t offset,
+                      enum mm_map_type_e type, FAR void **mapped)
 {
   int ret = -ENOTTY;
 
@@ -107,7 +107,7 @@ static int file_mmap_(FAR struct file *filep, FAR void *start,
 
   if ((flags & MAP_ANONYMOUS) != 0)
     {
-      ret = map_anonymous(&entry, kernel);
+      ret = map_anonymous(&entry, type);
       goto out;
     }
 
@@ -150,7 +150,7 @@ static int file_mmap_(FAR struct file *filep, FAR void *start,
        * do much better in the KERNEL build using the MMU.
        */
 
-      ret = rammap(filep, &entry, kernel);
+      ret = rammap(filep, &entry, type);
     }
 
   /* Return */
@@ -182,7 +182,7 @@ int file_mmap(FAR struct file *filep, FAR void *start, size_t length,
               int prot, int flags, off_t offset, FAR void **mapped)
 {
   return file_mmap_(filep, start, length,
-                    prot, flags, offset, true, mapped);
+                    prot, flags, offset, MAP_KERNEL, mapped);
 }
 
 /****************************************************************************
@@ -274,7 +274,7 @@ FAR void *mmap(FAR void *start, size_t length, int prot, int flags,
     }
 
   ret = file_mmap_(filep, start, length,
-                   prot, flags, offset, false, &mapped);
+                   prot, flags, offset, MAP_USER, &mapped);
   if (ret < 0)
     {
       goto errout;

--- a/fs/mmap/fs_msync.c
+++ b/fs/mmap/fs_msync.c
@@ -1,0 +1,95 @@
+/****************************************************************************
+ * fs/mmap/fs_msync.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sys/mman.h>
+#include <debug.h>
+#include <errno.h>
+
+#include <nuttx/fs/fs.h>
+#include <nuttx/sched.h>
+
+#include "inode/inode.h"
+#include "fs_rammap.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: msync
+ *
+ * Description:
+ *   Equivalent to the standard msync() function except that it accepts
+ *   a struct file instance instead of a memory address and it does not set
+ *   the errno variable.
+ *
+ * Input Parameters:
+ *   file   - A pointer to the struct file instance representing the
+ *            mappedfile
+ *   start  - The starting address of the memory region to be synchronized
+ *   length - The length of the memory region to be synchronized
+ *   flags  - Flags that determine the type of synchronization to be
+ *            performed
+ *
+ * Returned Value:
+ *   On success, returns 0 (OK); On failure, returns a negated errno value.
+ *
+ ****************************************************************************/
+
+int msync(FAR void *start, size_t length, int flags)
+{
+  FAR struct mm_map_entry_s *entry;
+  int ret;
+
+  ret = mm_map_lock();
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  entry = mm_map_find(get_current_mm(), start, length);
+  if (!entry)
+    {
+      ferr("ERROR: Region not found\n");
+      ret = -ENOMEM;
+      goto out;
+    }
+
+  if (entry->msync == NULL)
+    {
+      ret = OK;
+      goto out;
+    }
+
+  ret = entry->msync(entry, start, length, flags);
+out:
+  mm_map_unlock();
+  if (ret < 0)
+    {
+      set_errno(-ret);
+      ret = ERROR;
+    }
+
+  return ret;
+}

--- a/fs/mmap/fs_munmap.c
+++ b/fs/mmap/fs_munmap.c
@@ -42,7 +42,8 @@
  * Private Functions
  ****************************************************************************/
 
-static int file_munmap_(FAR void *start, size_t length, bool kernel)
+static int file_munmap_(FAR void *start, size_t length,
+                        enum mm_map_type_e type)
 {
   FAR struct tcb_s *tcb = nxsched_self();
   FAR struct task_group_s *group = tcb->group;
@@ -99,7 +100,7 @@ unlock:
 
 int file_munmap(FAR void *start, size_t length)
 {
-  return file_munmap_(start, length, true);
+  return file_munmap_(start, length, MAP_KERNEL);
 }
 
 /****************************************************************************
@@ -156,7 +157,7 @@ int munmap(FAR void *start, size_t length)
 {
   int ret;
 
-  ret = file_munmap_(start, length, false);
+  ret = file_munmap_(start, length, MAP_USER);
   if (ret < 0)
     {
       set_errno(-ret);

--- a/fs/mmap/fs_rammap.c
+++ b/fs/mmap/fs_rammap.c
@@ -78,7 +78,7 @@ static int msync_rammap(FAR struct mm_map_entry_s *entry, FAR void *start,
   fpos = file_seek(filep, entry->offset + offset, SEEK_SET);
   if (fpos < 0)
     {
-      ferr("ERRORL Seek to position %"PRIdOFF" failed\n", fpos);
+      ferr("ERROR: Seek to position %"PRIdOFF" failed\n", fpos);
       return fpos;
     }
 
@@ -109,7 +109,15 @@ static int msync_rammap(FAR struct mm_map_entry_s *entry, FAR void *start,
 
   /* Restore file pos */
 
-  file_seek(filep, opos, SEEK_SET);
+  fpos = file_seek(filep, opos, SEEK_SET);
+  if (fpos < 0)
+    {
+      /* Ensure that we finally seek back to the current file pos */
+
+      ferr("ERROR: Seek back to position %"PRIdOFF" failed\n", fpos);
+      return fpos;
+    }
+
   return nwrite >= 0 ? 0 : nwrite;
 }
 

--- a/fs/mmap/fs_rammap.c
+++ b/fs/mmap/fs_rammap.c
@@ -55,7 +55,7 @@
 static int msync_rammap(FAR struct mm_map_entry_s *entry, FAR void *start,
                         size_t length, int flags)
 {
-  FAR struct file *filep = (FAR void *)((uintptr_t)entry->priv.p & ~1);
+  FAR struct file *filep = (FAR void *)((uintptr_t)entry->priv.p & ~3);
   FAR uint8_t *wrbuffer = start;
   ssize_t nwrite = 0;
   off_t offset;
@@ -122,8 +122,8 @@ static int unmap_rammap(FAR struct task_group_s *group,
                         FAR void *start,
                         size_t length)
 {
-  FAR struct file *filep = (FAR void *)((uintptr_t)entry->priv.p & ~1);
-  enum mm_map_type_e type = (uintptr_t)entry->priv.p & 1;
+  FAR struct file *filep = (FAR void *)((uintptr_t)entry->priv.p & ~3);
+  enum mm_map_type_e type = (uintptr_t)entry->priv.p & 3;
   FAR void *newaddr;
   off_t offset;
   int ret = OK;

--- a/fs/mmap/fs_rammap.c
+++ b/fs/mmap/fs_rammap.c
@@ -48,14 +48,84 @@
  * Private Functions
  ****************************************************************************/
 
+/****************************************************************************
+ * Name: msync_rammap
+ ****************************************************************************/
+
+static int msync_rammap(FAR struct mm_map_entry_s *entry, FAR void *start,
+                        size_t length, int flags)
+{
+  FAR struct file *filep = (FAR void *)((uintptr_t)entry->priv.p & ~1);
+  FAR uint8_t *wrbuffer = start;
+  ssize_t nwrite = 0;
+  off_t offset;
+  off_t fpos;
+  off_t opos;
+
+  offset = (uintptr_t)start - (uintptr_t)entry->vaddr;
+  if (length > entry->length - offset)
+    {
+      length = entry->length - offset;
+    }
+
+  opos = file_seek(filep, 0, SEEK_CUR);
+  if (opos < 0)
+    {
+      ferr("ERROR: Get current position failed\n");
+      return opos;
+    }
+
+  fpos = file_seek(filep, entry->offset + offset, SEEK_SET);
+  if (fpos < 0)
+    {
+      ferr("ERRORL Seek to position %"PRIdOFF" failed\n", fpos);
+      return fpos;
+    }
+
+  while (length > 0)
+    {
+      nwrite = file_write(filep, wrbuffer, length);
+      if (nwrite < 0)
+        {
+          /* Handle the special case where the write was interrupted by a
+           * signal.
+           */
+
+          if (nwrite != -EINTR)
+            {
+              /* All other write errors are bad. */
+
+              ferr("ERROR: Write failed: offset=%"PRIdOFF" nwrite=%zd\n",
+                   entry->offset, nwrite);
+              break;
+            }
+        }
+
+      /* Increment number of bytes written */
+
+      wrbuffer += nwrite;
+      length   -= nwrite;
+    }
+
+  /* Restore file pos */
+
+  file_seek(filep, opos, SEEK_SET);
+  return nwrite >= 0 ? 0 : nwrite;
+}
+
+/****************************************************************************
+ * Name: unmap_rammap
+ ****************************************************************************/
+
 static int unmap_rammap(FAR struct task_group_s *group,
                         FAR struct mm_map_entry_s *entry,
                         FAR void *start,
                         size_t length)
 {
-  FAR void *newaddr = NULL;
+  FAR struct file *filep = (FAR void *)((uintptr_t)entry->priv.p & ~1);
+  enum mm_map_type_e type = (uintptr_t)entry->priv.p & 1;
+  FAR void *newaddr;
   off_t offset;
-  enum mm_map_type_e type = entry->priv.i;
   int ret = OK;
 
   /* Get the offset from the beginning of the region and the actual number
@@ -92,6 +162,8 @@ static int unmap_rammap(FAR struct task_group_s *group,
         {
           kumm_free(entry->vaddr);
         }
+
+      fs_putfilep(filep);
 
       /* Then remove the mapping from the list */
 
@@ -247,8 +319,10 @@ int rammap(FAR struct file *filep, FAR struct mm_map_entry_s *entry,
   /* Add the buffer to the list of regions */
 
 out:
-  entry->priv.i = type;
+  fs_reffilep(filep);
+  entry->priv.p = (FAR void *)((uintptr_t)filep | type);
   entry->munmap = unmap_rammap;
+  entry->msync = msync_rammap;
 
   ret = mm_map_add(get_current_mm(), entry);
   if (ret < 0)

--- a/fs/mmap/fs_rammap.c
+++ b/fs/mmap/fs_rammap.c
@@ -131,8 +131,9 @@ static int unmap_rammap(FAR struct task_group_s *group,
                         size_t length)
 {
   FAR struct file *filep = (FAR void *)((uintptr_t)entry->priv.p & ~3);
-  enum mm_map_type_e type = (uintptr_t)entry->priv.p & 3;
-  FAR void *newaddr;
+  enum mm_map_type_e type =
+                    (enum mm_map_type_e)((uintptr_t)entry->priv.p & 3);
+  FAR void *newaddr = NULL;
   off_t offset;
   int ret = OK;
 

--- a/fs/mmap/fs_rammap.h
+++ b/fs/mmap/fs_rammap.h
@@ -47,6 +47,15 @@
 #include <sys/types.h>
 #include <nuttx/mm/map.h>
 
+/* A memory mapping type definition */
+
+enum mm_map_type_e
+{
+  MAP_USER = 0,
+  MAP_KERNEL,
+  MAP_XIP,
+};
+
 #ifdef CONFIG_FS_RAMMAP
 
 /****************************************************************************
@@ -72,8 +81,7 @@
  *   length  The length of the mapping.  For exception #1 above, this length
  *           ignored:  The entire underlying media is always accessible.
  *   offset  The offset into the file to map
- *   kernel  kmm_zalloc or kumm_zalloc
- *   mapped  The pointer to the mapped area
+ *   type    kmm_zalloc or kumm_zalloc or xip_base
  *
  * Returned Value:
  *   On success rammmap returns 0. Otherwise errno is returned appropriately.
@@ -88,9 +96,9 @@
  ****************************************************************************/
 
 int rammap(FAR struct file *filep, FAR struct mm_map_entry_s *entry,
-           bool kernel);
+           enum mm_map_type_e type);
 #else
-#  define rammap(file, entry, kernel) (-ENOSYS)
+#  define rammap(file, entry, type) (-ENOSYS)
 #endif /* CONFIG_FS_RAMMAP */
 
 #endif /* __FS_MMAP_FS_RAMMAP_H */

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -1138,6 +1138,37 @@ int nx_open(FAR const char *path, int oflags, ...);
 int fs_getfilep(int fd, FAR struct file **filep);
 
 /****************************************************************************
+ * Name: fs_reffilep
+ *
+ * Description:
+ *   To specify filep increase the reference count.
+ *
+ * Input Parameters:
+ *   None.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void fs_reffilep(FAR struct file *filep);
+
+/****************************************************************************
+ * Name: fs_putfilep
+ *
+ * Description:
+ *   Release reference counts for files, less than or equal to 0 and close
+ *   the file
+ *
+ * Input Parameters:
+ *   filep  - The caller provided location in which to return the 'struct
+ *            file' instance.
+ *
+ ****************************************************************************/
+
+int fs_putfilep(FAR struct file *filep);
+
+/****************************************************************************
  * Name: file_close
  *
  * Description:

--- a/include/nuttx/mm/map.h
+++ b/include/nuttx/mm/map.h
@@ -56,11 +56,14 @@ struct mm_map_entry_s
     int i;
   } priv;
 
-  /* Drivers which register mappings may also implement the unmap function
-   * to undo anything done in mmap.
-   * Nb. Implementation must NOT use "this_task()->group" since it is not
-   * valid during process exit. The argument "group" will be NULL in this
-   * case.
+  int (*msync)(FAR struct mm_map_entry_s *entry, FAR void *start,
+               size_t length, int flags);
+
+  /* Drivers which register mappings may also
+   * implement the unmap function to undo anything done in mmap.
+   * Nb. Implementation must NOT use "this_task()->group" since
+   * this is not valid during process exit. The argument "group" will be
+   * NULL in this case.
    */
 
   int (*munmap)(FAR struct task_group_s *group,

--- a/include/sys/syscall_lookup.h
+++ b/include/sys/syscall_lookup.h
@@ -248,6 +248,7 @@ SYSCALL_LOOKUP(fchown,                     3)
 SYSCALL_LOOKUP(utimens,                    2)
 SYSCALL_LOOKUP(lutimens,                   2)
 SYSCALL_LOOKUP(futimens,                   2)
+SYSCALL_LOOKUP(msync,                      3)
 SYSCALL_LOOKUP(munmap,                     2)
 
 #if defined(CONFIG_PSEUDOFS_SOFTLINKS)

--- a/syscall/syscall.csv
+++ b/syscall/syscall.csv
@@ -74,6 +74,7 @@
 "mq_timedreceive","mqueue.h","!defined(CONFIG_DISABLE_MQUEUE)","ssize_t","mqd_t","FAR char *","size_t","FAR unsigned int *","FAR const struct timespec *"
 "mq_timedsend","mqueue.h","!defined(CONFIG_DISABLE_MQUEUE)","int","mqd_t","FAR const char *","size_t","unsigned int","FAR const struct timespec *"
 "mq_unlink","mqueue.h","!defined(CONFIG_DISABLE_MQUEUE)","int","FAR const char *"
+"msync","sys/mman.h","","int","FAR void *","size_t","int"
 "munmap","sys/mman.h","","int","FAR void *","size_t"
 "nanosleep","time.h","","int","FAR const struct timespec *","FAR struct timespec *"
 "nx_mkfifo","nuttx/fs/fs.h","defined(CONFIG_PIPES) && CONFIG_DEV_FIFO_SIZE > 0","int","FAR const char *","mode_t","size_t"


### PR DESCRIPTION
## Summary
The msync API implemented base by https://github.com/apache/nuttx/pull/5997 and https://github.com/apache/nuttx/pull/8026.

Follow: https://man7.org/linux/man-pages/man2/msync.2.html

## Impact
Support msync

## Testing
Local test pass
