### PR TITLE
icmp:add net_lock to protect icmp connection

### DIFF
--- a/net/icmp/icmp_sockif.c
+++ b/net/icmp/icmp_sockif.c
@@ -254,6 +254,7 @@ static int icmp_close(FAR struct socket *psock)
 {
   FAR struct icmp_conn_s *conn;
 
+  net_lock();
   conn = psock->s_conn;
 
   /* Is this the last reference to the connection structure (there could be\
@@ -280,6 +281,7 @@ static int icmp_close(FAR struct socket *psock)
       conn->crefs--;
     }
 
+  net_unlock();
   return OK;
 }
 


### PR DESCRIPTION
## Summary
There may be situations where another thread is operating on the icmp socket while releasing it. To prevent exceptions, add netlock  to protect socket release operations
## Impact
icmp ref counts
## Testing
Manual verification
