### PR TITLE
pm: add pm_idle, up_idle only handle pm state execution

### DIFF
--- a/drivers/power/pm/CMakeLists.txt
+++ b/drivers/power/pm/CMakeLists.txt
@@ -35,7 +35,8 @@ if(CONFIG_PM)
     pm_unregister.c
     pm_autoupdate.c
     pm_governor.c
-    pm_lock.c)
+    pm_lock.c
+    pm_idle.c)
 
   if(CONFIG_PM_PROCFS)
     list(APPEND SRCS pm_procfs.c)

--- a/drivers/power/pm/Make.defs
+++ b/drivers/power/pm/Make.defs
@@ -24,6 +24,7 @@ ifeq ($(CONFIG_PM),y)
 
 CSRCS += pm_initialize.c pm_activity.c pm_changestate.c pm_checkstate.c
 CSRCS += pm_register.c pm_unregister.c pm_autoupdate.c pm_governor.c pm_lock.c
+CSRCS += pm_idle.c
 
 ifeq ($(CONFIG_PM_PROCFS),y)
 

--- a/drivers/power/pm/pm_idle.c
+++ b/drivers/power/pm/pm_idle.c
@@ -1,0 +1,73 @@
+/****************************************************************************
+ * drivers/power/pm/pm_idle.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/power/pm.h>
+#include <sched/sched.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: pm_idle
+ *
+ * Description:
+ *   Standard pm idle work flow for up_idle, for not smp case.
+ *
+ * Input Parameters:
+ *   handler - The execution after PM_IDLE_DOMAIN state changed.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void pm_idle(pm_idle_handler_t handler)
+{
+  enum pm_state_e newstate;
+  irqstate_t flags;
+  int ret;
+
+  /* Disable IRQ and lock sched */
+
+  sched_lock();
+  flags = up_irq_save();
+
+  newstate = pm_checkstate(PM_IDLE_DOMAIN);
+  ret      = pm_changestate(PM_IDLE_DOMAIN, newstate);
+  if (ret < 0)
+    {
+      newstate = PM_NORMAL;
+    }
+
+  handler(newstate);
+
+  pm_changestate(PM_IDLE_DOMAIN, PM_RESTORE);
+
+  /* Unlock sched and enable IRQ */
+
+  up_irq_restore(flags);
+  sched_unlock();
+}

--- a/include/nuttx/power/pm.h
+++ b/include/nuttx/power/pm.h
@@ -145,6 +145,8 @@ enum pm_state_e
   PM_COUNT,
 };
 
+typedef void (*pm_idle_handler_t)(enum pm_state_e);
+
 #ifdef CONFIG_PM_PROCFS
 struct pm_preparefail_s
 {
@@ -816,6 +818,22 @@ enum pm_state_e pm_querystate(int domain);
  ****************************************************************************/
 
 void pm_auto_updatestate(int domain);
+
+/****************************************************************************
+ * Name: pm_idle
+ *
+ * Description:
+ *   Standard pm idle work flow for up_idle, for not smp case.
+ *
+ * Input Parameters:
+ *   handler - The execution after PM_IDLE_DOMAIN state changed.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void pm_idle(pm_idle_handler_t handler);
 
 #undef EXTERN
 #ifdef __cplusplus


### PR DESCRIPTION
## Summary
pm process should be done by chip specific, but we can provide a standard flow, then vendor & chip can only focus on handle different state change.

## Impact
No impact for default.
new chip, new vendor can use pm_idle standard workflow as a optional.

## Testing
CI-test & arm-v7m chip self-test.

