### PR TITLE
pm_runtime: fix missing header

### DIFF
--- a/drivers/power/pm/pm_runtime.c
+++ b/drivers/power/pm/pm_runtime.c
@@ -29,6 +29,7 @@
 #include <errno.h>
 #include <sched.h>
 #include <nuttx/clock.h>
+#include <nuttx/arch.h>
 #include <nuttx/power/pm_runtime.h>
 #include <sched/sched.h>
 

--- a/drivers/power/pm/pm_runtime.c
+++ b/drivers/power/pm/pm_runtime.c
@@ -27,6 +27,7 @@
 #include <debug.h>
 #include <assert.h>
 #include <errno.h>
+#include <sched.h>
 #include <nuttx/clock.h>
 #include <nuttx/power/pm_runtime.h>
 #include <sched/sched.h>


### PR DESCRIPTION
## Summary
If the sched.h not included by header already inside .c will cause sched_idletask not defined

## Impact
None

## Testing
CI-test
