### PR TITLE
procfs/mempool: fix did not remove when pool not enabled

### DIFF
--- a/fs/procfs/fs_procfs.c
+++ b/fs/procfs/fs_procfs.c
@@ -150,7 +150,7 @@ static const struct procfs_entry_s g_procfs_entries[] =
   { "meminfo",      &g_meminfo_operations,  PROCFS_FILE_TYPE   },
 #endif
 
-#ifndef CONFIG_FS_PROCFS_EXCLUDE_MEMPOOL
+#if defined(CONFIG_MM_HEAP_MEMPOOL) && !defined(CONFIG_FS_PROCFS_EXCLUDE_MEMPOOL)
   { "mempool",      &g_mempool_operations,  PROCFS_FILE_TYPE   },
 #endif
 


### PR DESCRIPTION
## Summary
will at lease lead to extra code size cost, also possible dataabort.

## Impact
Before fix, if not enabled mempool, should manually select the CONFIG_FS_PROCFS_EXCLUDE_MEMPOOL
after fix, if mempool is not enabled globally, the mempool entry will not able to enabled

## Testing
CI-test
