### PR TITLE
rpmsgfs: set fs type to rpmsgfs when mount through rpmsgfs

### DIFF
--- a/fs/rpmsgfs/rpmsgfs.c
+++ b/fs/rpmsgfs/rpmsgfs.c
@@ -1223,6 +1223,7 @@ static int rpmsgfs_statfs(FAR struct inode *mountpt, FAR struct statfs *buf)
     }
 
   ret = rpmsgfs_client_statfs(fs->handle, fs->fs_root, buf);
+  buf->f_type = RPMSGFS_MAGIC;
 
   nxmutex_unlock(&fs->fs_lock);
   return ret;


### PR DESCRIPTION
## Summary
f_type should be set RPMSGFS_MAGIC when mount through rpmsgfs
or  "df -h" will show

![image](https://github.com/user-attachments/assets/244dcfce-42bd-4a2c-a4ce-cf52966e2748)

## Impact

rpmsgfs_statfs result 

## Testing
![image](https://github.com/user-attachments/assets/4d8269b1-c1fb-4b70-8ada-8c96e2f11b6b)

