### PR TITLE
pm_activity: fix deadlock with spinlock and critcal_section

### DIFF
--- a/drivers/power/pm/pm_activity.c
+++ b/drivers/power/pm/pm_activity.c
@@ -440,6 +440,7 @@ void pm_wakelock_staytimeout(FAR struct pm_wakelock_s *wakelock, int ms)
   FAR struct pm_domain_s *pdom;
   FAR struct dq_queue_s *dq;
   FAR struct wdog_s *wdog;
+  bool wdstart = false;
   irqstate_t flags;
   int domain;
 
@@ -466,10 +467,14 @@ void pm_wakelock_staytimeout(FAR struct pm_wakelock_s *wakelock, int ms)
 
   if (TICK2MSEC(wd_gettime(wdog)) < ms)
     {
-      wd_start(wdog, MSEC2TICK(ms), pm_waklock_cb, (wdparm_t)wakelock);
+      wdstart = true;
     }
 
   spin_unlock_irqrestore(&pdom->lock, flags);
+  if (wdstart)
+    {
+      wd_start(wdog, MSEC2TICK(ms), pm_waklock_cb, (wdparm_t)wakelock);
+    }
 
   pm_auto_updatestate(domain);
 }


### PR DESCRIPTION
## Summary
critical_section is not compatible with irq disabled, have to delay the wd_start after spin_unlock_irqrestore.

## Impact
before fix, pm_wakelock_staytimeout will cause a dead lock directly,
after fix, wd_start will be delay a little bit.

## Testing
CI-test & qemu test-case
