### PR TITLE
crypto: import the ability to clone session

### DIFF
--- a/crypto/cryptosoft.c
+++ b/crypto/cryptosoft.c
@@ -802,6 +802,18 @@ int swcr_newsession(FAR uint32_t *sid, FAR struct cryptoini *cri)
             axf->init((*swd)->sw_ictx);
             (*swd)->sw_axf = axf;
             bcopy((*swd)->sw_ictx, &(*swd)->sw_ctx, axf->ctxsize);
+
+            if (cri->cri_sid != -1)
+              {
+                if (swcr_sessions[cri->cri_sid] == NULL)
+                  {
+                    swcr_freesession(i);
+                    return -EINVAL;
+                  }
+
+                bcopy(&swcr_sessions[cri->cri_sid]->sw_ctx, &(*swd)->sw_ctx,
+                      axf->ctxsize);
+              }
             break;
 
           case CRYPTO_AES_128_GMAC:

--- a/include/crypto/cryptodev.h
+++ b/include/crypto/cryptodev.h
@@ -138,6 +138,7 @@ struct cryptoini
   int cri_alg;       /* Algorithm to use */
   int cri_klen;      /* Key length, in bits */
   int cri_rnd;       /* Algorithm rounds, where relevant */
+  int cri_sid;
   caddr_t cri_key;   /* key to use */
   union
   {


### PR DESCRIPTION
## Summary
The upper can copy the context through dup2(fd1, fd2), which is useful in hashing operations for network.
## Impact
Provides the ability to copy the encryption context, which can save an intermediate state of encryption
## Testing

