### PR TITLE
nucleo-l432kc: Revert the USART2 config to be use by virtual COM port

### DIFF
--- a/boards/arm/stm32l4/nucleo-l432kc/include/board.h
+++ b/boards/arm/stm32l4/nucleo-l432kc/include/board.h
@@ -90,9 +90,13 @@
 #  define GPIO_USART1_TX GPIO_USART1_TX_2    /* PB6  */
 #endif
 
-/* USART2: Connected to STLInk Debug via PA2(TX), PA3(RX) */
+/* USART2: Connected to STLInk Debug via PA2(TX), PA15(RX) */
 
-#define GPIO_USART2_RX   GPIO_USART2_RX_1    /* PA3 */
+#if defined(CONFIG_ARCH_BOARD_USART2_RX_PA3)
+#  define GPIO_USART2_RX   GPIO_USART2_RX_1  /* PA3 */
+#elif defined(CONFIG_ARCH_BOARD_USART2_RX_PA15)
+#  define GPIO_USART2_RX   GPIO_USART2_RX_2  /* PA15 */
+#endif
 #define GPIO_USART2_TX   GPIO_USART2_TX_1    /* PA2 */
 #define GPIO_USART2_RTS  GPIO_USART2_RTS_2
 #define GPIO_USART2_CTS  GPIO_USART2_CTS_2


### PR DESCRIPTION
## Summary
As per board documentation, USART2 can be configured to use PA15 to access the virtual COM port via a USB port.
Accessing NSH via USB port (virtual COM) is a preferred solution, therefore this reverts commit 60236ce94d310935bd9f9663b19454b86fa45957 and fixes the issue reported by https://github.com/apache/nuttx/issues/13061.

## Impact
Users can access NSH via a virtual COM port (USART2).

## Testing
- Configure nucleo-l432kc:nsh 
- Build and flash the board
- Use minicom or picocom to access NSH via virtual COM.

