### PR TITLE
video: fix warning & update sim camera

### DIFF
--- a/arch/sim/Kconfig
+++ b/arch/sim/Kconfig
@@ -320,14 +320,14 @@ endchoice
 endif
 
 config SIM_CAMERA
-	bool "Simulated video support"
+	bool "Simulated camera support"
 	depends on VIDEO
 	default y
 
 if SIM_CAMERA
 
 choice
-	prompt "Simulated video device type"
+	prompt "Simulated camera device type"
 	default SIM_CAMERA_V4L2
 
 config SIM_CAMERA_V4L2
@@ -336,8 +336,8 @@ config SIM_CAMERA_V4L2
 
 endchoice
 
-config HOST_VIDEO_DEV_PATH
-	string "Host video device path"
+config HOST_CAMERA_DEV_PATH
+	string "Host camera device path"
 	default "/dev/video0"
 
 config SIM_CAMERA_DEV_PATH

--- a/arch/sim/src/sim/sim_camera.c
+++ b/arch/sim/src/sim/sim_camera.c
@@ -233,7 +233,7 @@ static int sim_camera_data_init(struct imgdata_s *data)
 {
   sim_camera_priv_t *priv = (sim_camera_priv_t *)data;
 
-  priv->vdev = host_video_init(CONFIG_HOST_VIDEO_DEV_PATH);
+  priv->vdev = host_video_init(CONFIG_HOST_CAMERA_DEV_PATH);
   if (priv->vdev == NULL)
     {
       return -ENODEV;

--- a/arch/sim/src/sim/sim_decoder.c
+++ b/arch/sim/src/sim/sim_decoder.c
@@ -27,6 +27,7 @@
 
 #include <nuttx/kmalloc.h>
 #include <nuttx/video/v4l2_m2m.h>
+#include <nuttx/wqueue.h>
 
 #include "sim_openh264dec.h"
 #include "sim_internal.h"

--- a/arch/sim/src/sim/sim_encoder.c
+++ b/arch/sim/src/sim/sim_encoder.c
@@ -26,6 +26,7 @@
 
 #include <nuttx/kmalloc.h>
 #include <nuttx/video/v4l2_m2m.h>
+#include <nuttx/wqueue.h>
 
 #include "sim_x264encoder.h"
 #include "sim_internal.h"

--- a/drivers/video/v4l2_cap.c
+++ b/drivers/video/v4l2_cap.c
@@ -1295,7 +1295,9 @@ static int validate_frame_setting(FAR capture_mng_t *cmng,
 
 static size_t get_bufsize(FAR video_format_t *vf)
 {
-  size_t ret = vf->width * vf->height;
+  uint32_t width  = vf->width;
+  uint32_t height = vf->height;
+  size_t ret = width * height;
 
   switch (vf->pixelformat)
     {


### PR DESCRIPTION
## Summary

1. Fix build warning & sign extension
2. sim_camera: rename video to camera

## Impact

NA

## Testing

1. [nxcamera](https://nuttx.apache.org/docs/latest/applications/system/nxcamera/index.html)
2. [nxcodec](https://nuttx.apache.org/docs/latest/applications/system/nxcodec/index.html)

