### PR TITLE
sched/irq: correct critical section to spin lock 

### DIFF
--- a/sched/irq/irq_attach.c
+++ b/sched/irq/irq_attach.c
@@ -106,7 +106,7 @@ int irq_attach(int irq, xcpt_t isr, FAR void *arg)
       if (is_irqchain(ndx, isr))
         {
           ret = irqchain_attach(ndx, isr, arg);
-          leave_critical_section(flags);
+          spin_unlock_irqrestore(NULL, flags);
           return ret;
         }
 #endif


### PR DESCRIPTION

## Summary

sched/irq: correct critical section to spin lock

Regression by https://github.com/apache/nuttx/pull/12281:

```
| commit 2ee8aa6f2b4ae5384f7dc984f467702d5f3fbf40
| Author: hujun5 <hujun5@xiaomi.com>
| Date:   Thu Jan 11 11:27:31 2024 +0800
|
|     sched: we use spin_lock_irqsave replace enter_critical_section to protect g_irqvector
|
|     enter_critical_section may be called before os initialized
|
|     Signed-off-by: hujun5 <hujun5@xiaomi.com>
```


## Impact

N/A

## Testing

ci-check