### PR TITLE
nuttx/crypto: support poly1305 and ripemd160 algorithm

### DIFF
--- a/crypto/cryptodev.c
+++ b/crypto/cryptodev.c
@@ -248,6 +248,7 @@ static int cryptof_ioctl(FAR struct file *filep,
             case CRYPTO_SHA2_512_HMAC:
             case CRYPTO_AES_128_GMAC:
             case CRYPTO_MD5:
+            case CRYPTO_POLY1305:
             case CRYPTO_RIPEMD160:
             case CRYPTO_SHA1:
             case CRYPTO_SHA2_224:

--- a/crypto/cryptodev.c
+++ b/crypto/cryptodev.c
@@ -248,6 +248,7 @@ static int cryptof_ioctl(FAR struct file *filep,
             case CRYPTO_SHA2_512_HMAC:
             case CRYPTO_AES_128_GMAC:
             case CRYPTO_MD5:
+            case CRYPTO_RIPEMD160:
             case CRYPTO_SHA1:
             case CRYPTO_SHA2_224:
             case CRYPTO_SHA2_256:

--- a/crypto/cryptosoft.c
+++ b/crypto/cryptosoft.c
@@ -776,6 +776,9 @@ int swcr_newsession(FAR uint32_t *sid, FAR struct cryptoini *cri)
           case CRYPTO_MD5:
             axf = &auth_hash_md5;
             goto auth3common;
+          case CRYPTO_RIPEMD160:
+            axf = &auth_hash_ripemd_160;
+            goto auth3common;
           case CRYPTO_SHA1:
             axf = &auth_hash_sha1;
             goto auth3common;
@@ -941,6 +944,7 @@ int swcr_freesession(uint64_t tid)
           case CRYPTO_AES_256_GMAC:
           case CRYPTO_CHACHA20_POLY1305_MAC:
           case CRYPTO_MD5:
+          case CRYPTO_RIPEMD160:
           case CRYPTO_SHA1:
           case CRYPTO_SHA2_224:
           case CRYPTO_SHA2_256:
@@ -1073,6 +1077,7 @@ int swcr_process(struct cryptop *crp)
             break;
 
           case CRYPTO_MD5:
+          case CRYPTO_RIPEMD160:
           case CRYPTO_SHA1:
           case CRYPTO_SHA2_224:
           case CRYPTO_SHA2_256:
@@ -1211,6 +1216,7 @@ void swcr_init(void)
   algs[CRYPTO_CHACHA20_POLY1305] = CRYPTO_ALG_FLAG_SUPPORTED;
   algs[CRYPTO_CHACHA20_POLY1305_MAC] = CRYPTO_ALG_FLAG_SUPPORTED;
   algs[CRYPTO_MD5] = CRYPTO_ALG_FLAG_SUPPORTED;
+  algs[CRYPTO_RIPEMD160] = CRYPTO_ALG_FLAG_SUPPORTED;
   algs[CRYPTO_SHA1] = CRYPTO_ALG_FLAG_SUPPORTED;
   algs[CRYPTO_SHA2_224] = CRYPTO_ALG_FLAG_SUPPORTED;
   algs[CRYPTO_SHA2_256] = CRYPTO_ALG_FLAG_SUPPORTED;

--- a/crypto/cryptosoft.c
+++ b/crypto/cryptosoft.c
@@ -831,6 +831,10 @@ int swcr_newsession(FAR uint32_t *sid, FAR struct cryptoini *cri)
             axf = &auth_hash_gmac_aes_256;
             goto auth4common;
 
+          case CRYPTO_POLY1305:
+            axf = &auth_hash_poly1305;
+            goto auth4common;
+
           case CRYPTO_CHACHA20_POLY1305_MAC:
             axf = &auth_hash_chacha20_poly1305;
 
@@ -845,6 +849,7 @@ int swcr_newsession(FAR uint32_t *sid, FAR struct cryptoini *cri)
             axf->init((*swd)->sw_ictx);
             axf->setkey((*swd)->sw_ictx, (FAR uint8_t *)cri->cri_key,
                         cri->cri_klen / 8);
+            bcopy((*swd)->sw_ictx, &(*swd)->sw_ctx, axf->ctxsize);
             (*swd)->sw_axf = axf;
             break;
 
@@ -944,6 +949,7 @@ int swcr_freesession(uint64_t tid)
           case CRYPTO_AES_256_GMAC:
           case CRYPTO_CHACHA20_POLY1305_MAC:
           case CRYPTO_MD5:
+          case CRYPTO_POLY1305:
           case CRYPTO_RIPEMD160:
           case CRYPTO_SHA1:
           case CRYPTO_SHA2_224:
@@ -1077,6 +1083,7 @@ int swcr_process(struct cryptop *crp)
             break;
 
           case CRYPTO_MD5:
+          case CRYPTO_POLY1305:
           case CRYPTO_RIPEMD160:
           case CRYPTO_SHA1:
           case CRYPTO_SHA2_224:
@@ -1216,6 +1223,7 @@ void swcr_init(void)
   algs[CRYPTO_CHACHA20_POLY1305] = CRYPTO_ALG_FLAG_SUPPORTED;
   algs[CRYPTO_CHACHA20_POLY1305_MAC] = CRYPTO_ALG_FLAG_SUPPORTED;
   algs[CRYPTO_MD5] = CRYPTO_ALG_FLAG_SUPPORTED;
+  algs[CRYPTO_POLY1305] = CRYPTO_ALG_FLAG_SUPPORTED;
   algs[CRYPTO_RIPEMD160] = CRYPTO_ALG_FLAG_SUPPORTED;
   algs[CRYPTO_SHA1] = CRYPTO_ALG_FLAG_SUPPORTED;
   algs[CRYPTO_SHA2_224] = CRYPTO_ALG_FLAG_SUPPORTED;

--- a/crypto/xform.c
+++ b/crypto/xform.c
@@ -389,6 +389,15 @@ const struct auth_hash auth_hash_md5 =
   (void (*) (FAR uint8_t *, FAR void *)) md5final
 };
 
+const struct auth_hash auth_hash_ripemd_160 =
+{
+  CRYPTO_RIPEMD160, "RIPEMD160",
+  0, 20, 20, sizeof(RMD160_CTX), HMAC_RIPEMD160_BLOCK_LEN,
+  (void (*) (FAR void *)) rmd160init, NULL, NULL,
+  rmd160update_int,
+  (void (*) (FAR uint8_t *, FAR void *)) rmd160final
+};
+
 const struct auth_hash auth_hash_sha1 =
 {
   CRYPTO_SHA1, "SHA1",

--- a/include/crypto/cryptodev.h
+++ b/include/crypto/cryptodev.h
@@ -117,14 +117,15 @@
 #define CRYPTO_CHACHA20_POLY1305 24
 #define CRYPTO_CHACHA20_POLY1305_MAC 25
 #define CRYPTO_MD5              26
-#define CRYPTO_RIPEMD160        27
-#define CRYPTO_SHA1             28
-#define CRYPTO_SHA2_224         29
-#define CRYPTO_SHA2_256         30
-#define CRYPTO_SHA2_384         31
-#define CRYPTO_SHA2_512         32
-#define CRYPTO_ESN              33 /* Support for Extended Sequence Numbers */
-#define CRYPTO_ALGORITHM_MAX    33 /* Keep updated */
+#define CRYPTO_POLY1305         27
+#define CRYPTO_RIPEMD160        28
+#define CRYPTO_SHA1             29
+#define CRYPTO_SHA2_224         30
+#define CRYPTO_SHA2_256         31
+#define CRYPTO_SHA2_384         32
+#define CRYPTO_SHA2_512         33
+#define CRYPTO_ESN              34 /* Support for Extended Sequence Numbers */
+#define CRYPTO_ALGORITHM_MAX    34 /* Keep updated */
 
 /* Algorithm flags */
 

--- a/include/crypto/cryptodev.h
+++ b/include/crypto/cryptodev.h
@@ -117,13 +117,14 @@
 #define CRYPTO_CHACHA20_POLY1305 24
 #define CRYPTO_CHACHA20_POLY1305_MAC 25
 #define CRYPTO_MD5              26
-#define CRYPTO_SHA1             27
-#define CRYPTO_SHA2_224         28
-#define CRYPTO_SHA2_256         29
-#define CRYPTO_SHA2_384         30
-#define CRYPTO_SHA2_512         31
-#define CRYPTO_ESN              32 /* Support for Extended Sequence Numbers */
-#define CRYPTO_ALGORITHM_MAX    32 /* Keep updated */
+#define CRYPTO_RIPEMD160        27
+#define CRYPTO_SHA1             28
+#define CRYPTO_SHA2_224         29
+#define CRYPTO_SHA2_256         30
+#define CRYPTO_SHA2_384         31
+#define CRYPTO_SHA2_512         32
+#define CRYPTO_ESN              33 /* Support for Extended Sequence Numbers */
+#define CRYPTO_ALGORITHM_MAX    33 /* Keep updated */
 
 /* Algorithm flags */
 

--- a/include/crypto/xform.h
+++ b/include/crypto/xform.h
@@ -121,6 +121,7 @@ extern const struct auth_hash auth_hash_gmac_aes_192;
 extern const struct auth_hash auth_hash_gmac_aes_256;
 extern const struct auth_hash auth_hash_chacha20_poly1305;
 extern const struct auth_hash auth_hash_md5;
+extern const struct auth_hash auth_hash_ripemd_160;
 extern const struct auth_hash auth_hash_sha1;
 extern const struct auth_hash auth_hash_sha2_224;
 extern const struct auth_hash auth_hash_sha2_256;

--- a/include/crypto/xform.h
+++ b/include/crypto/xform.h
@@ -121,6 +121,7 @@ extern const struct auth_hash auth_hash_gmac_aes_192;
 extern const struct auth_hash auth_hash_gmac_aes_256;
 extern const struct auth_hash auth_hash_chacha20_poly1305;
 extern const struct auth_hash auth_hash_md5;
+extern const struct auth_hash auth_hash_poly1305;
 extern const struct auth_hash auth_hash_ripemd_160;
 extern const struct auth_hash auth_hash_sha1;
 extern const struct auth_hash auth_hash_sha2_224;


### PR DESCRIPTION
## Summary
1. export poly1305 and ripemd160 algorithm via /dev/crypto
2. implemented software process in cryptosoft.c
## Impact

## Testing

