### PR TITLE
CMakeLists.txt: warning D9002 on Windows + msvc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -528,11 +528,13 @@ endif()
 # failure logs more deterministic and most importantly makes builds more
 # deterministic. Debuggers usually have a path mapping feature to ensure the
 # files are still found.
-if(CONFIG_OUTPUT_STRIP_PATHS)
-  add_compile_options(-fmacro-prefix-map=${NUTTX_DIR}=)
-  add_compile_options(-fmacro-prefix-map=${NUTTX_APPS_DIR}=)
-  add_compile_options(-fmacro-prefix-map=${NUTTX_BOARD_ABS_DIR}=)
-  add_compile_options(-fmacro-prefix-map=${NUTTX_CHIP_ABS_DIR}=)
+if(NOT MSVC)
+  if(CONFIG_OUTPUT_STRIP_PATHS)
+    add_compile_options(-fmacro-prefix-map=${NUTTX_DIR}=)
+    add_compile_options(-fmacro-prefix-map=${NUTTX_APPS_DIR}=)
+    add_compile_options(-fmacro-prefix-map=${NUTTX_BOARD_ABS_DIR}=)
+    add_compile_options(-fmacro-prefix-map=${NUTTX_CHIP_ABS_DIR}=)
+  endif()
 endif()
 
 add_definitions(-D__NuttX__)


### PR DESCRIPTION
## Summary
Resolved compile warning
cl : command line  warning D9002: ignoring unknown option '-fmacro-prefix-map=
## Impact
None
## Testing
local and GITHUB
cmake -B vs2022 -DBOARD_CONFIG=sim/windows -G "Visual Studio 17 2022" -A Win32
