### PR TITLE
Add `oldconfig` and `olddefconfig` custom targets to CMake

### DIFF
--- a/Documentation/quickstart/configuring.rst
+++ b/Documentation/quickstart/configuring.rst
@@ -105,6 +105,10 @@ If you know exactly which configuration symbol you want to change, you can use t
    $ kconfig-tweak --enable CONFIG_DEBUG_NET
    $ make olddefconfig
 
+.. note::
+
+   If you are :doc:`compiling with CMake <compiling_cmake>`, you will need to run all of the commands above inside of the build directory, and use ``cmake --build . -t olddefconfig`` instead of ``make olddefconfig``.
+
 This is also useful to script configuration changes that you perform often:
 
 .. code-block:: bash
@@ -125,6 +129,10 @@ This is also useful to script configuration changes that you perform often:
    kconfig-tweak --disable CONFIG_DEBUG_NOOPT
    kconfig-tweak --disable CONFIG_SYSLOG_TIMESTAMP
    make oldconfig
+
+.. note::
+
+   If you are :doc:`compiling with CMake <compiling_cmake>`, you will need to run all of the commands above inside of the build directory, and use ``cmake --build . -t oldconfig`` instead of ``make oldconfig``.
 
 Reference configuration
 =======================

--- a/cmake/menuconfig.cmake
+++ b/cmake/menuconfig.cmake
@@ -18,8 +18,7 @@
 #
 # ##############################################################################
 
-# menuconfig target this triggers a reconfiguration (TODO: do only if config
-# changes)
+# menuconfig target this triggers a reconfiguration
 
 set(KCONFIG_ENV
     "KCONFIG_CONFIG=${CMAKE_BINARY_DIR}/.config"
@@ -45,10 +44,6 @@ endif()
 add_custom_target(
   menuconfig
   COMMAND ${CMAKE_COMMAND} -E env ${KCONFIG_ENV} ${MENUCONFIG}
-  COMMAND ${CMAKE_COMMAND} -E remove -f
-          ${CMAKE_BINARY_DIR}/include/nuttx/config.h # invalidate existing
-                                                     # config
-  COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_PARENT_LIST_FILE}
   WORKING_DIRECTORY ${NUTTX_DIR}
   USES_TERMINAL)
 
@@ -57,10 +52,6 @@ add_custom_target(
 add_custom_target(
   qconfig
   COMMAND ${CMAKE_COMMAND} -E env ${KCONFIG_ENV} guiconfig
-  COMMAND ${CMAKE_COMMAND} -E remove -f
-          ${CMAKE_BINARY_DIR}/include/nuttx/config.h # invalidate existing
-                                                     # config
-  COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_PARENT_LIST_FILE}
   WORKING_DIRECTORY ${NUTTX_DIR}
   USES_TERMINAL)
 
@@ -77,20 +68,12 @@ add_custom_target(
 add_custom_target(
   oldconfig
   COMMAND ${CMAKE_COMMAND} -E env ${KCONFIG_ENV} oldconfig
-  COMMAND ${CMAKE_COMMAND} -E remove -f
-          ${CMAKE_BINARY_DIR}/include/nuttx/config.h # invalidate existing
-                                                     # config
-  COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_PARENT_LIST_FILE}
   WORKING_DIRECTORY ${NUTTX_DIR}
   USES_TERMINAL) # stdin access required to prompt for new config keys
 
 add_custom_target(
   olddefconfig
   COMMAND ${CMAKE_COMMAND} -E env ${KCONFIG_ENV} olddefconfig
-  COMMAND ${CMAKE_COMMAND} -E remove -f
-          ${CMAKE_BINARY_DIR}/include/nuttx/config.h # invalidate existing
-                                                     # config
-  COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_PARENT_LIST_FILE}
   WORKING_DIRECTORY ${NUTTX_DIR})
 
 # utility target to restore .config from board's defconfig
@@ -101,5 +84,4 @@ add_custom_target(
   COMMAND ${CMAKE_COMMAND} -E env ${KCONFIG_ENV} olddefconfig
   COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/.config
           ${CMAKE_BINARY_DIR}/.config.orig
-  COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_PARENT_LIST_FILE}
   WORKING_DIRECTORY ${NUTTX_DIR})

--- a/cmake/menuconfig.cmake
+++ b/cmake/menuconfig.cmake
@@ -81,7 +81,8 @@ add_custom_target(
           ${CMAKE_BINARY_DIR}/include/nuttx/config.h # invalidate existing
                                                      # config
   COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_PARENT_LIST_FILE}
-  WORKING_DIRECTORY ${NUTTX_DIR})
+  WORKING_DIRECTORY ${NUTTX_DIR}
+  USES_TERMINAL) # stdin access required to prompt for new config keys
 
 add_custom_target(
   olddefconfig

--- a/cmake/menuconfig.cmake
+++ b/cmake/menuconfig.cmake
@@ -74,6 +74,24 @@ add_custom_target(
           ${NUTTX_DEFCONFIG}
   WORKING_DIRECTORY ${NUTTX_DIR})
 
+add_custom_target(
+  oldconfig
+  COMMAND ${CMAKE_COMMAND} -E env ${KCONFIG_ENV} oldconfig
+  COMMAND ${CMAKE_COMMAND} -E remove -f
+          ${CMAKE_BINARY_DIR}/include/nuttx/config.h # invalidate existing
+                                                     # config
+  COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_PARENT_LIST_FILE}
+  WORKING_DIRECTORY ${NUTTX_DIR})
+
+add_custom_target(
+  olddefconfig
+  COMMAND ${CMAKE_COMMAND} -E env ${KCONFIG_ENV} olddefconfig
+  COMMAND ${CMAKE_COMMAND} -E remove -f
+          ${CMAKE_BINARY_DIR}/include/nuttx/config.h # invalidate existing
+                                                     # config
+  COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_PARENT_LIST_FILE}
+  WORKING_DIRECTORY ${NUTTX_DIR})
+
 # utility target to restore .config from board's defconfig
 add_custom_target(
   resetconfig

--- a/cmake/nuttx_generate_headers.cmake
+++ b/cmake/nuttx_generate_headers.cmake
@@ -28,7 +28,6 @@ if(NOT EXISTS ${CMAKE_BINARY_DIR}/include/nuttx)
   file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/include/nuttx)
 endif()
 
-include(nuttx_mkconfig)
 include(nuttx_mkversion)
 
 # Setup symbolic link generation
@@ -136,6 +135,18 @@ if(CONFIG_ARCH_SETJMP_H)
 else()
   file(REMOVE ${CMAKE_BINARY_DIR}/include/setjmp.h)
 endif()
+
+# Generate config.h. This is done through add_custom_command rather than
+# include(nuttx_mkconfig) to be able to mark .config as a dependency of
+# config.h. Otherwise, changes in .config would not cause config.h to be
+# re-generated during incremental builds.
+
+add_custom_command(
+  OUTPUT ${CMAKE_BINARY_DIR}/include/nuttx/config.h
+  COMMAND
+    ${CMAKE_COMMAND} -D NUTTX_DIR=${NUTTX_DIR} -D NUTTX_BOARD=${NUTTX_BOARD} -D
+    NUTTX_CONFIG=${NUTTX_CONFIG} -P ${NUTTX_DIR}/cmake/nuttx_mkconfig.cmake
+  DEPENDS ${CMAKE_BINARY_DIR}/.config ${CMAKE_BINARY_DIR}/.config.orig)
 
 # Add final context target that ties together all of the above The context
 # target is invoked on each target build to assure that NuttX is properly

--- a/cmake/nuttx_mkconfig.cmake
+++ b/cmake/nuttx_mkconfig.cmake
@@ -18,27 +18,24 @@
 #
 # ##############################################################################
 
+# !!! READ BEFORE CHANGING THIS FILE !!!
+#
+# This file is not included by the rest of the CMake configuration, but it is
+# instead invoked separately through `cmake -P`.
+#
+# This means most variables, functions and macros defined in the rest of the
+# CMake configuration are NOT available here. To add missing modules, add the
+# include() declarations below. To add missing variables, change the command
+# execution in nuttx_generate_headers.cmake to add -D flags.
+
+set(CMAKE_MODULE_PATH "${NUTTX_DIR}/cmake")
+include(nuttx_kconfig)
+
 if(NOT EXISTS ${CMAKE_BINARY_DIR}/.config)
   return()
 endif()
 
-if(NOT EXISTS ${CMAKE_BINARY_DIR}/.config.prev)
-  execute_process(
-    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/.config
-            ${CMAKE_BINARY_DIR}/.config.prev
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-endif()
-
-execute_process(
-  COMMAND ${CMAKE_COMMAND} -E compare_files ${CMAKE_BINARY_DIR}/.config
-          ${CMAKE_BINARY_DIR}/.config.prev
-  RESULT_VARIABLE COMPARE_RESULT
-  WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-
 set(CONFIG_H ${CMAKE_BINARY_DIR}/include/nuttx/config.h)
-if(COMPARE_RESULT EQUAL 0 AND EXISTS ${CONFIG_H})
-  return()
-endif()
 
 set(BASE_DEFCONFIG "${NUTTX_BOARD}/${NUTTX_CONFIG}")
 execute_process(


### PR DESCRIPTION
## Summary

The [Fast configuration changes](https://nuttx.apache.org/docs/latest/quickstart/configuring.html#fast-configuration-changes) section of the documentation mentions the need to run `make oldconfig` and `make olddefconfig` after changing the configuration with `kconfig-tweak`, but those commands are not exposed through CMake. This PR adds them, and adds a note in the documentation pointing users to it.

## Impact

This will allow users compiling with CMake to properly use `kconfig-tweak`.

## Testing

```bash
cmake -Bbuild -GNinja -DBOARD_CONFIG=fvp-armv8r-aarch32:nsh
cd build
cat .config | grep MKFATFS  # Doesn't show anything :(
kconfig-tweak --enable CONFIG_FS_FAT
cat .config | grep MKFATFS  # Doesn't show anything :(
cmake --build . -t olddefconfig
cat .config | grep MKFATFS  # Show the newly available option!
```