### PR TITLE
Audio upstream

### DIFF
--- a/audio/Kconfig
+++ b/audio/Kconfig
@@ -128,6 +128,18 @@ config AUDIO_FORMAT_OGG_VORBIS
 	---help---
 		Build in support for the Open Source Ogg Vorbis format.
 
+config AUDIO_FORMAT_AMR
+	bool "AMR Format"
+	default y
+	---help---
+		Build in support for AMR Audio format.
+
+config AUDIO_FORMAT_OPUS
+	bool "OPUS Format"
+	default y
+	---help---
+		Build in support for OPUS Audio format.
+
 endmenu
 
 menu "Exclude Specific Audio Features"

--- a/include/nuttx/audio/audio.h
+++ b/include/nuttx/audio/audio.h
@@ -160,6 +160,7 @@
 #define AUDIO_FMT_MSBC              0x0e
 #define AUDIO_FMT_CVSD              0x0f
 #define AUDIO_FMT_AMR               0x10
+#define AUDIO_FMT_OPUS              0x11
 
 /* Audio Sub-Format Types ***************************************************/
 

--- a/include/nuttx/audio/audio.h
+++ b/include/nuttx/audio/audio.h
@@ -461,6 +461,7 @@ struct ap_buffer_s
   apb_samp_t            nmaxbytes;  /* The maximum number of bytes */
   apb_samp_t            nbytes;     /* The number of bytes used */
   apb_samp_t            curbyte;    /* Next byte to be processed */
+  apb_samp_t            nsamples;   /* The number of samples in the buffer */
   mutex_t               lock;       /* Reference locking mutex */
   uint16_t              flags;      /* Buffer flags */
   uint16_t              crefs;      /* Number of reference counts */


### PR DESCRIPTION
## Summary

- nuttx/audio: add opus format support 
- nuttx/audio: Add amr and opus format control switches 
- nuttx/audio: ap_buffer_s add nsamples Field for non-pcm formats

## Impact

new flags

## Testing

ci and internal test