### PR TITLE
api:add lib_realpath function

### DIFF
--- a/include/nuttx/lib/lib.h
+++ b/include/nuttx/lib/lib.h
@@ -121,6 +121,11 @@ unsigned long nrand(unsigned long limit);
 FAR char *lib_get_pathbuffer(void);
 void lib_put_pathbuffer(FAR char *buffer);
 
+/* Functions defined in lib_realpath.c **************************************/
+
+FAR char *lib_realpath(FAR const char *path, FAR char *resolved,
+                       bool notfollow);
+
 #undef EXTERN
 #ifdef __cplusplus
 }

--- a/libs/libc/stdlib/lib_realpath.c
+++ b/libs/libc/stdlib/lib_realpath.c
@@ -36,7 +36,8 @@
  * Public Functions
  ****************************************************************************/
 
-FAR char *realpath(FAR const char *path, FAR char *resolved)
+FAR char *lib_realpath(FAR const char *path, FAR char *resolved,
+                       bool notfollow)
 {
 #ifdef CONFIG_PSEUDOFS_SOFTLINKS
   FAR char *wbuf[2] =
@@ -179,6 +180,13 @@ loop:
   memcpy(&p[1], path, q - path);
   p[1 + q - path] = '\0';
 
+  if (notfollow)
+    {
+      p += 1 + q - path;
+      path = q;
+      goto loop;
+    }
+
   /* If this component is a symlink, toss it and prepend link
    * target to unresolved path.
    */
@@ -265,4 +273,9 @@ out:
 #endif
 
   return NULL;
+}
+
+FAR char *realpath(FAR const char *path, FAR char *resolved)
+{
+  return lib_realpath(path, resolved, false);
 }


### PR DESCRIPTION

## Summary

add a new api 

FAR char *lib_realpath(FAR const char *path, FAR char *resolved, bool notfollow);

Add the **nofollow** parameter to choose whether to resolve the path if it is a symbolic link.

## Impact

## Testing

