### PR TITLE
board/qemu-armv7a: add CMake support

### DIFF
--- a/arch/arm/src/qemu/CMakeLists.txt
+++ b/arch/arm/src/qemu/CMakeLists.txt
@@ -1,0 +1,27 @@
+# ##############################################################################
+# arch/arm/src/qemu/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS qemu_boot.c qemu_serial.c qemu_irq.c qemu_timer.c qemu_memorymap.c)
+
+if(CONFIG_SMP)
+  list(APPEND SRCS qemu_cpuboot.c)
+endif()
+
+target_sources(arch PRIVATE ${SRCS})

--- a/boards/arm/qemu/qemu-armv7a/CMakeLists.txt
+++ b/boards/arm/qemu/qemu-armv7a/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# boards/arm/qemu/qemu-armv7a/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/dramboot.ld")
+
+add_subdirectory(src)

--- a/boards/arm/qemu/qemu-armv7a/src/CMakeLists.txt
+++ b/boards/arm/qemu/qemu-armv7a/src/CMakeLists.txt
@@ -1,0 +1,31 @@
+# ##############################################################################
+# boards/arm/qemu/qemu-armv7a/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+set(SRCS qemu_boardinit.c qemu_bringup.c)
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS qemu_appinit.c)
+endif()
+
+if(CONFIG_LIBC_FDT)
+  target_include_directories(board
+                             PRIVATE ${NUTTX_DIR}/libs/libc/fdt/dtc/libfdt)
+endif()
+
+target_sources(board PRIVATE ${SRCS})


### PR DESCRIPTION
## Summary

This adds cmake support for `board/qemu-armv7a`.

## Impacts

None

## Testing

- local checks with qemu-armv7a target
- CI checks

