### PR TITLE
Bugfix hcreate

### DIFF
--- a/fs/notify/inotify.c
+++ b/fs/notify/inotify.c
@@ -1010,6 +1010,22 @@ static inline void notify_queue_filep_event(FAR struct file *filep,
 }
 
 /****************************************************************************
+ * Name: notify_free_entry
+ *
+ * Description:
+ *   Deallocate the hash entry.
+ *
+ ****************************************************************************/
+
+static void notify_free_entry(FAR ENTRY *entry)
+{
+  /* Key is alloced by lib_malloc, value is alloced by kmm_malloc */
+
+  lib_free(entry->key);
+  kmm_free(entry->data);
+}
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -1276,6 +1292,7 @@ void notify_initialize(void)
 {
   int ret;
 
+  g_inotify.hash.free_entry = notify_free_entry;
   ret = hcreate_r(CONFIG_FS_NOTIFY_BUCKET_SIZE, &g_inotify.hash);
   if (ret != 1)
     {

--- a/fs/vfs/fs_lock.c
+++ b/fs/vfs/fs_lock.c
@@ -293,6 +293,16 @@ file_lock_find_bucket(FAR const char *filepath)
 }
 
 /****************************************************************************
+ * Name: file_lock_free_entry
+ ****************************************************************************/
+
+static void file_lock_free_entry(FAR ENTRY *entry)
+{
+  lib_free(entry->key);
+  kmm_free(entry->data);
+}
+
+/****************************************************************************
  * Name: file_lock_create_bucket
  ****************************************************************************/
 
@@ -824,5 +834,6 @@ void file_initlk(void)
 {
   /* Initialize file lock context hash table */
 
+  g_file_lock_table.free_entry = file_lock_free_entry;
   hcreate_r(CONFIG_FS_LOCK_BUCKET_SIZE, &g_file_lock_table);
 }

--- a/include/search.h
+++ b/include/search.h
@@ -43,6 +43,7 @@ struct hsearch_data
 {
   FAR struct internal_head *htable;
   size_t htablesize;
+  CODE void (*free_entry)(FAR ENTRY *entry);
 };
 
 /****************************************************************************

--- a/libs/libc/search/hcreate_r.c
+++ b/libs/libc/search/hcreate_r.c
@@ -83,6 +83,16 @@ SLIST_HEAD(internal_head, internal_entry);
 extern uint32_t (*g_default_hash)(FAR const void *, size_t);
 
 /****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static void hfree_r(FAR ENTRY *entry)
+{
+  lib_free(entry->key);
+  lib_free(entry->data);
+}
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -157,6 +167,11 @@ int hcreate_r(size_t nel, FAR struct hsearch_data *htab)
       SLIST_INIT(&(htab->htable[idx]));
     }
 
+  if (htab->free_entry == NULL)
+    {
+      htab->free_entry = hfree_r;
+    }
+
   return 1;
 }
 
@@ -190,8 +205,7 @@ void hdestroy_r(FAR struct hsearch_data *htab)
         {
           ie = SLIST_FIRST(&(htab->htable[idx]));
           SLIST_REMOVE_HEAD(&(htab->htable[idx]), link);
-          lib_free(ie->ent.key);
-          lib_free(ie->ent.data);
+          htab->free_entry(&ie->ent);
           lib_free(ie);
         }
     }
@@ -245,8 +259,7 @@ int hsearch_r(ENTRY item, ACTION action, FAR ENTRY **retval,
       if (ie != NULL)
         {
           SLIST_REMOVE(head, ie, internal_entry, link);
-          lib_free(ie->ent.key);
-          lib_free(ie->ent.data);
+          htab->free_entry(&ie->ent);
           lib_free(ie);
           return 1;
         }


### PR DESCRIPTION
## Summary
Add free func hook for user to deallocate memory

The memory of entry->key && entry->data are allocated by user,
and should be freed by user.

## Impact

## Testing

