### PR TITLE
sim: Support to use of non-consecutive framebuffers

### DIFF
--- a/arch/sim/Kconfig
+++ b/arch/sim/Kconfig
@@ -440,6 +440,16 @@ config SIM_FRAMEBUFFER_COUNT
 		Framebuffer count.
 		Simulated frambuffer count.  Default: 2
 
+config SIM_FB_INTERVAL_LINE
+	int "The line between non-consecutive framebuffers"
+	depends on SIM_FRAMEBUFFER && SIM_FRAMEBUFFER_COUNT > 1
+	default 0
+	---help---
+		When SIM_FB_INTERVAL_LINE = 0, the framebuffers are consecutive.
+		When SIM_FB_INTERVAL_LINE > 0, the first buffer is not consecutive with
+		the second buffer, and the interval between discontinuous buffers is
+		SIM_FB_INTERVAL_LINE * stride.  Default: 0
+
 endmenu
 
 choice

--- a/arch/sim/src/sim/posix/sim_x11framebuffer.c
+++ b/arch/sim/src/sim/posix/sim_x11framebuffer.c
@@ -279,11 +279,12 @@ static void sim_x11uninitialize(void)
 
 static inline int sim_x11mapsharedmem(Display *display,
                                       int depth, unsigned int fblen,
-                                      int fbcount)
+                                      int fbcount, int interval)
 {
 #ifndef CONFIG_SIM_X11NOSHM
   Status result;
 #endif
+  int fbinterval = 0;
 
   atexit(sim_x11uninit);
   g_shmcheckpoint = 1;
@@ -315,7 +316,8 @@ static inline int sim_x11mapsharedmem(Display *display,
 
       g_xshminfo.shmid = shmget(IPC_PRIVATE,
                                 g_image->bytes_per_line *
-                                g_image->height * fbcount,
+                                (g_image->height * fbcount +
+                                interval * (fbcount - 1)),
                                 IPC_CREAT | 0777);
       if (g_xshminfo.shmid < 0)
         {
@@ -357,7 +359,8 @@ shmerror:
 #endif
       b_useshm = 0;
 
-      g_framebuffer = malloc(fblen * fbcount);
+      fbinterval = (depth * g_fbpixelwidth / 8) * interval;
+      g_framebuffer = malloc(fblen * fbcount + fbinterval * (fbcount - 1));
 
       g_image = XCreateImage(display, DefaultVisual(display, g_screen),
                              depth, ZPixmap, 0, g_framebuffer,
@@ -411,10 +414,11 @@ static inline void sim_x11depth16to32(void *d_mem, size_t size,
 
 int sim_x11initialize(unsigned short width, unsigned short height,
                      void **fbmem, size_t *fblen, unsigned char *bpp,
-                     unsigned short *stride, int fbcount)
+                     unsigned short *stride, int fbcount, int interval)
 {
   XWindowAttributes windowattributes;
   Display *display;
+  int fbinterval;
   int depth;
 
   /* Save inputs */
@@ -461,7 +465,8 @@ int sim_x11initialize(unsigned short width, unsigned short height,
 
   /* Map the window to shared memory */
 
-  sim_x11mapsharedmem(display, windowattributes.depth, *fblen, fbcount);
+  sim_x11mapsharedmem(display, windowattributes.depth,
+                      *fblen, fbcount, interval);
 
   g_fbbpp = depth;
   g_fblen = *fblen;
@@ -473,8 +478,10 @@ int sim_x11initialize(unsigned short width, unsigned short height,
       *bpp = CONFIG_SIM_FBBPP;
       *stride = (CONFIG_SIM_FBBPP * width / 8);
       *fblen = (*stride * height);
+      fbinterval = *stride * interval;
 
-      g_trans_framebuffer = malloc((*fblen) * fbcount);
+      g_trans_framebuffer = malloc(*fblen * fbcount +
+                                   fbinterval * (fbcount - 1));
       if (g_trans_framebuffer == NULL)
         {
           syslog(LOG_ERR, "Failed to allocate g_trans_framebuffer\n");
@@ -486,6 +493,11 @@ int sim_x11initialize(unsigned short width, unsigned short height,
   else
     {
       *fbmem = g_framebuffer;
+    }
+
+  if (interval == 0)
+    {
+      *fblen *= fbcount;
     }
 
   g_display = display;

--- a/arch/sim/src/sim/sim_framebuffer.c
+++ b/arch/sim/src/sim/sim_framebuffer.c
@@ -243,7 +243,21 @@ static int sim_getplaneinfo(struct fb_vtable_s *vtable, int planeno,
   ginfo("vtable=%p planeno=%d pinfo=%p\n", vtable, planeno, pinfo);
   if (vtable && planeno == 0 && pinfo)
     {
+#if CONFIG_SIM_FB_INTERVAL_LINE > 0
+      int display = pinfo->display;
+#endif
       memcpy(pinfo, &g_planeinfo, sizeof(struct fb_planeinfo_s));
+
+#if CONFIG_SIM_FB_INTERVAL_LINE > 0
+      if (display - g_planeinfo.display > 0)
+        {
+          pinfo->display = display;
+          pinfo->fbmem = g_planeinfo.fbmem + g_planeinfo.stride *
+             (CONFIG_SIM_FB_INTERVAL_LINE + CONFIG_SIM_FBHEIGHT) *
+             (display - g_planeinfo.display);
+        }
+#endif
+
       return OK;
     }
 
@@ -469,8 +483,8 @@ int up_fbinitialize(int display)
   ret = sim_x11initialize(CONFIG_SIM_FBWIDTH, CONFIG_SIM_FBHEIGHT,
                           &g_planeinfo.fbmem, &g_planeinfo.fblen,
                           &g_planeinfo.bpp, &g_planeinfo.stride,
-                          CONFIG_SIM_FRAMEBUFFER_COUNT);
-  g_planeinfo.fblen *= CONFIG_SIM_FRAMEBUFFER_COUNT;
+                          CONFIG_SIM_FRAMEBUFFER_COUNT,
+                          CONFIG_SIM_FB_INTERVAL_LINE);
 #endif
 
   return ret;

--- a/arch/sim/src/sim/sim_internal.h
+++ b/arch/sim/src/sim/sim_internal.h
@@ -76,6 +76,12 @@
 #  endif
 #endif
 
+/* Use the consecutive framebuffers */
+
+#ifndef CONFIG_SIM_FB_INTERVAL_LINE
+#  define CONFIG_SIM_FB_INTERVAL_LINE 0
+#endif
+
 /* Use a stack alignment of 16 bytes.  If necessary frame_size must be
  * rounded up to the next boundary
  */
@@ -286,7 +292,7 @@ void sim_registerblockdevice(void);
 #ifdef CONFIG_SIM_X11FB
 int sim_x11initialize(unsigned short width, unsigned short height,
                       void **fbmem, size_t *fblen, unsigned char *bpp,
-                      unsigned short *stride, int fbcount);
+                      unsigned short *stride, int fbcount, int interval);
 int sim_x11update(void);
 int sim_x11openwindow(void);
 int sim_x11closewindow(void);

--- a/arch/sim/src/sim/sim_lcd.c
+++ b/arch/sim/src/sim/sim_lcd.c
@@ -507,7 +507,8 @@ int board_lcd_initialize(void)
 #ifdef CONFIG_SIM_X11FB
   ret = sim_x11initialize(CONFIG_SIM_FBWIDTH, CONFIG_SIM_FBHEIGHT,
                           (void**)&g_planeinfo.buffer, &g_fblen,
-                          &g_planeinfo.bpp, &g_stride, CONFIG_LCD_FBCOUNT);
+                          &g_planeinfo.bpp, &g_stride, CONFIG_LCD_FBCOUNT,
+                          0);
 #endif
 
   return ret;


### PR DESCRIPTION
## Summary
Some hardware devices use discontinuous framebuffers, which needs SIM to support for simulating discontinuous framebuffers.
## Impact
sim
## Testing
sim fb