### PR TITLE
tmpfs: old data was loaded when SEEK_SET beyond end of the file

### DIFF
--- a/fs/tmpfs/fs_tmpfs.c
+++ b/fs/tmpfs/fs_tmpfs.c
@@ -281,13 +281,27 @@ static int tmpfs_realloc_file(FAR struct tmpfs_file_s *tfo,
        * zero.
        */
 
-      if (newsize > 0)
+      if (newsize == 0)
+        {
+          /* Free the file object */
+
+          kmm_free(tfo->tfo_data);
+          tfo->tfo_data = NULL;
+          tfo->tfo_alloc = 0;
+          tfo->tfo_size = 0;
+          return OK;
+        }
+      else if (newsize > 0)
         {
           /* Otherwise, don't realloc unless the object has shrunk by a
            * lot.
            */
 
           delta = tfo->tfo_alloc - newsize;
+
+          /* We should make sure the shrunked memory be zero */
+
+          memset(tfo->tfo_data + newsize, 0, delta);
           if (delta <= CONFIG_FS_TMPFS_FILE_FREEGUARD)
             {
               /* Hasn't shrunk enough.. Return doing nothing for now */


### PR DESCRIPTION
## Summary
When using lseek with SEEK_SET and the offset is greater than the file's size,
the space between size and offset should be filled with \0.
However, in tmpfs, it will be filled with old data.

Reproduction:

fd = open(argv[1], O_WRONLY|O_CREAT, 0666);
ret = write(fd, "hello\n", 6);       // Write initial data
close(fd);

fd = open(argv[1], O_WRONLY|O_CREAT|O_TRUNC, 0666); // Here the filesize will be overwritten to 0
ret = lseek(fd, 50, SEEK_SET);  
ret = write(fd, "world\n", 6); // Write new data
close(fd);

Correct result:
world

Incorrect result:
hello
world

## Impact

## Testing

