### PR TITLE
bch:alloc bch->buffer when offset not aligned

### DIFF
--- a/drivers/bch/bchlib_setup.c
+++ b/drivers/bch/bchlib_setup.c
@@ -110,21 +110,6 @@ int bchlib_setup(const char *blkdev, bool readonly, FAR void **handle)
   bch->sectsize = geo.geo_sectorsize;
   bch->sector   = (size_t)-1;
   bch->readonly = readonly;
-
-  /* Allocate the sector I/O buffer */
-
-#if CONFIG_BCH_BUFFER_ALIGNMENT != 0
-  bch->buffer = kmm_memalign(CONFIG_BCH_BUFFER_ALIGNMENT, bch->sectsize);
-#else
-  bch->buffer = kmm_malloc(bch->sectsize);
-#endif
-  if (!bch->buffer)
-    {
-      ferr("ERROR: Failed to allocate sector buffer\n");
-      ret = -ENOMEM;
-      goto errout_with_bch;
-    }
-
   *handle = bch;
   return OK;
 


### PR DESCRIPTION
## Summary

When the buffer to be written is aligned according to the erase block size and its size is a multiple of the erase block size，
we do not need to alloc the bch->buffer

## Impact

## Testing

