### PR TITLE
[BugFix]Command "critmon" error

### DIFF
--- a/fs/procfs/fs_procfscritmon.c
+++ b/fs/procfs/fs_procfscritmon.c
@@ -188,6 +188,21 @@ static ssize_t critmon_read_cpu(FAR struct critmon_file_s *attr,
 
   totalsize = 0;
 
+  /* Generate output for CPU Serial Number */
+
+  linesize = procfs_snprintf(attr->line, CRITMON_LINELEN, "%d", cpu);
+  copysize = procfs_memcpy(attr->line, linesize, buffer, buflen, offset);
+
+  totalsize += copysize;
+  buffer    += copysize;
+  buflen    -= copysize;
+
+  if (buflen <= 0)
+    {
+      return totalsize;
+    }
+
+#if CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION >= 0
   /* Convert the for maximum time pre-emption disabled */
 
   if (g_premp_max[cpu] > 0)
@@ -206,15 +221,16 @@ static ssize_t critmon_read_cpu(FAR struct critmon_file_s *attr,
 
   /* Generate output for maximum time pre-emption disabled */
 
-  linesize = procfs_snprintf(attr->line, CRITMON_LINELEN, "%d,%lu.%09lu,",
-                             cpu, (unsigned long)maxtime.tv_sec,
+  linesize = procfs_snprintf(attr->line, CRITMON_LINELEN, ",%lu.%09lu",
+                             (unsigned long)maxtime.tv_sec,
                              (unsigned long)maxtime.tv_nsec);
   copysize = procfs_memcpy(attr->line, linesize, buffer, buflen, offset);
 
   totalsize += copysize;
   buffer    += copysize;
+  buflen    -= copysize;
 
-  if (totalsize >= buflen)
+  if (buflen <= 0)
     {
       return totalsize;
     }
@@ -237,12 +253,26 @@ static ssize_t critmon_read_cpu(FAR struct critmon_file_s *attr,
 
   /* Generate output for maximum time in a critical section */
 
-  linesize = procfs_snprintf(attr->line, CRITMON_LINELEN, "%lu.%09lu\n",
+  linesize = procfs_snprintf(attr->line, CRITMON_LINELEN, ",%lu.%09lu",
                              (unsigned long)maxtime.tv_sec,
                              (unsigned long)maxtime.tv_nsec);
   copysize = procfs_memcpy(attr->line, linesize, buffer, buflen, offset);
 
   totalsize += copysize;
+  buffer    += copysize;
+  buflen    -= copysize;
+
+  if (buflen <= 0)
+    {
+      return totalsize;
+    }
+#endif
+
+  linesize = procfs_snprintf(attr->line, CRITMON_LINELEN, "\n");
+  copysize = procfs_memcpy(attr->line, linesize, buffer, buflen, offset);
+
+  totalsize += copysize;
+
   return totalsize;
 }
 
@@ -280,8 +310,6 @@ static ssize_t critmon_read(FAR struct file *filep, FAR char *buffer,
         {
           break;
         }
-
-      offset += nbytes;
     }
 
   if (ret > 0)


### PR DESCRIPTION
## Summary

Command "critmon" has some format errors and information errors, such as:
![before](https://github.com/user-attachments/assets/f257c116-a14f-40bc-9a7f-a10f6397cfce)


After bug fix:
![after](https://github.com/user-attachments/assets/7e6528ec-9650-42bf-a4d4-6550b08a41e9)


config is:
![config](https://github.com/user-attachments/assets/0cdc3562-5a7f-4e83-886e-339a264511eb)


## Impact

N/A

## Testing

Execute "critmon" in nsh