### PR TITLE
Documentation/sim: add cdcmbim examples

### DIFF
--- a/Documentation/platforms/sim/sim/boards/sim/index.rst
+++ b/Documentation/platforms/sim/sim/boards/sim/index.rst
@@ -1669,6 +1669,7 @@ This is a configuration with sim usbdev support.
     conn0: adb & rndis
     conn1: cdcacm & cdcecm
     conn2: cdcncm
+    conn3: cdcmbim
 
   You can use the sim:usbdev configuration::
 
@@ -1798,6 +1799,46 @@ This is a configuration with sim usbdev support.
               RX errors 0  dropped 0  overruns 0  frame 0
               TX packets 58  bytes 9143 (9.1 KB)
               TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+  Then you can test the network connection using the ping command or telnet.
+
+    6> Run CDCMBIM:
+
+  NuttX enter command::
+
+      $ conn 3
+      $ ifconfig
+      eth0    Link encap:Ethernet HWaddr 42:67:c6:69:73:51 at RUNNING mtu 1500
+              inet addr:10.0.1.2 DRaddr:10.0.1.1 Mask:255.255.255.0
+      wwan0   Link encap:UNSPEC at RUNNING mtu 1200
+              inet addr:0.0.0.0 DRaddr:0.0.0.0 Mask:0.0.0.0
+      $ ifconfig wwan0 10.0.0.1 netmask 255.255.255.0
+      $ ifconfig
+      eth0    Link encap:Ethernet HWaddr 42:67:c6:69:73:51 at RUNNING mtu 1500
+              inet addr:10.0.1.2 DRaddr:10.0.1.1 Mask:255.255.255.0
+      wwan0   Link encap:UNSPEC at RUNNING mtu 1200
+              inet addr:10.0.0.1 DRaddr:10.0.0.1 Mask:255.255.255.0
+
+      $ echo -n "hello from nuttx" > /dev/cdc-wdm2
+      $ cat /dev/cdc-wdm2
+      hello from linux
+
+  Host PC, you can see the network device named wwx020000112233::
+
+      $ sudo ifconfig wwx020000112233
+      $ sudo ifconfig wwx020000112233 10.0.0.2 netmask 255.255.255.0
+      $ ifconfig
+      wwx020000112233: flags=4226<BROADCAST,NOARP,MULTICAST>  mtu 1500
+              inet 10.0.0.2  netmask 255.255.255.0  broadcast 10.0.0.255
+              ether 02:00:00:11:22:33  txqueuelen 1000  (以太网)
+              RX packets 0  bytes 0 (0.0 B)
+              RX errors 0  dropped 0  overruns 0  frame 0
+              TX packets 58  bytes 9143 (9.1 KB)
+              TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+      $ sudo cat /dev/cdc-wdm1
+      hello from nuttx
+      $ sudo bash -c "echo -n hello from linux > /dev/cdc-wdm1"
 
   Then you can test the network connection using the ping command or telnet.
 


### PR DESCRIPTION
## Summary
We can send and receive data through device files
nuttx: /dev/cdc-wdm2
linux: /dev/cdc-wdm1
The number suffix depends on the actual situation.

And send and receive messages through network cards.

## Impact

## Testing
sim:usbdev
