### PR TITLE
syslog_rpmsg: Ensure the syslog ept is ready when rpmsg_send

### DIFF
--- a/drivers/syslog/syslog_rpmsg.c
+++ b/drivers/syslog/syslog_rpmsg.c
@@ -125,6 +125,11 @@ static bool syslog_rpmsg_transfer(FAR struct syslog_rpmsg_s *priv, bool wait)
   size_t off;
   size_t len_end;
 
+  if (!is_rpmsg_ept_ready(&priv->ept))
+    {
+      return false;
+    }
+
   do
     {
       msg = rpmsg_get_tx_payload_buffer(&priv->ept, &space, wait);


### PR DESCRIPTION
## Summary
syslog_rpmsg: Ensure the syslog ept is ready when rpmsg_send

## Impact
none

## Testing

