### PR TITLE
nxmutex api enhance

### DIFF
--- a/include/nuttx/mutex.h
+++ b/include/nuttx/mutex.h
@@ -393,6 +393,22 @@ int nxrmutex_destroy(FAR rmutex_t *rmutex);
 bool nxrmutex_is_hold(FAR rmutex_t *rmutex);
 
 /****************************************************************************
+ * Name: nxrmutex_is_recursive
+ *
+ * Description:
+ *   This function check whether the recursive mutex is recursive
+ *
+ * Parameters:
+ *   rmutex - Recursive mutex descriptor.
+ *
+ * Return Value:
+ *  If rmutex has returned to True recursively, otherwise returns false.
+ *
+ ****************************************************************************/
+
+bool nxrmutex_is_recursive(FAR rmutex_t *rmutex);
+
+/****************************************************************************
  * Name: nxrmutex_get_holder
  *
  * Description:

--- a/include/nuttx/mutex.h
+++ b/include/nuttx/mutex.h
@@ -315,7 +315,7 @@ void nxmutex_reset(FAR mutex_t *mutex);
  *
  ****************************************************************************/
 
-int nxmutex_breaklock(FAR mutex_t *mutex, FAR bool *locked);
+int nxmutex_breaklock(FAR mutex_t *mutex, FAR unsigned int *locked);
 
 /****************************************************************************
  * Name: nxmutex_restorelock
@@ -334,7 +334,7 @@ int nxmutex_breaklock(FAR mutex_t *mutex, FAR bool *locked);
  *
  ****************************************************************************/
 
-int nxmutex_restorelock(FAR mutex_t *mutex, bool locked);
+int nxmutex_restorelock(FAR mutex_t *mutex, unsigned int locked);
 
 /****************************************************************************
  * Name: nxrmutex_init

--- a/include/nuttx/mutex.h
+++ b/include/nuttx/mutex.h
@@ -132,6 +132,21 @@ int nxmutex_destroy(FAR mutex_t *mutex);
 bool nxmutex_is_hold(FAR mutex_t *mutex);
 
 /****************************************************************************
+ * Name: nxmutex_get_holder
+ *
+ * Description:
+ *   This function get the holder of the mutex referenced by 'mutex'.
+ *
+ * Parameters:
+ *   mutex - mutex descriptor.
+ *
+ * Return Value:
+ *
+ ****************************************************************************/
+
+int nxmutex_get_holder(FAR mutex_t *mutex);
+
+/****************************************************************************
  * Name: nxmutex_is_locked
  *
  * Description:
@@ -190,6 +205,34 @@ int nxmutex_lock(FAR mutex_t *mutex);
  ****************************************************************************/
 
 int nxmutex_trylock(FAR mutex_t *mutex);
+
+/****************************************************************************
+ * Name: nxmutex_clocklock
+ *
+ * Description:
+ *   This function attempts to lock the mutex referenced by 'mutex'.  If the
+ *   mutex value is (<=) zero, then the calling task will not return until it
+ *   successfully acquires the lock or timed out
+ *
+ * Input Parameters:
+ *   mutex   - Mutex object
+ *   clockid - The clock to be used as the time base
+ *   abstime - The absolute time when the mutex lock timed out
+ *
+ * Returned Value:
+ *   OK        The mutex successfully acquires
+ *   EINVAL    The mutex argument does not refer to a valid mutex.  Or the
+ *             thread would have blocked, and the abstime parameter specified
+ *             a nanoseconds field value less than zero or greater than or
+ *             equal to 1000 million.
+ *   ETIMEDOUT The mutex could not be locked before the specified timeout
+ *             expired.
+ *   EDEADLK   A deadlock condition was detected.
+ *
+ ****************************************************************************/
+
+int nxmutex_clocklock(FAR mutex_t *mutex, clockid_t clockid,
+                      FAR const struct timespec *abstime);
 
 /****************************************************************************
  * Name: nxmutex_timedlock
@@ -350,6 +393,21 @@ int nxrmutex_destroy(FAR rmutex_t *rmutex);
 bool nxrmutex_is_hold(FAR rmutex_t *rmutex);
 
 /****************************************************************************
+ * Name: nxrmutex_get_holder
+ *
+ * Description:
+ *   This function get the holder of the mutex referenced by 'mutex'.
+ *
+ * Parameters:
+ *   rmutex - Rmutex descriptor.
+ *
+ * Return Value:
+ *
+ ****************************************************************************/
+
+int nxrmutex_get_holder(FAR rmutex_t *rmutex);
+
+/****************************************************************************
  * Name: nxrmutex_is_locked
  *
  * Description:
@@ -410,6 +468,34 @@ int nxrmutex_lock(FAR rmutex_t *rmutex);
  ****************************************************************************/
 
 int nxrmutex_trylock(FAR rmutex_t *rmutex);
+
+/****************************************************************************
+ * Name: nxrmutex_clocklock
+ *
+ * Description:
+ *   This function attempts to lock the mutex referenced by 'mutex'.  If the
+ *   mutex value is (<=) zero, then the calling task will not return until it
+ *   successfully acquires the lock or timed out
+ *
+ * Input Parameters:
+ *   rmutex  - Rmutex object
+ *   clockid - The clock to be used as the time base
+ *   abstime - The absolute time when the mutex lock timed out
+ *
+ * Returned Value:
+ *   OK        The mutex successfully acquires
+ *   EINVAL    The mutex argument does not refer to a valid mutex.  Or the
+ *             thread would have blocked, and the abstime parameter specified
+ *             a nanoseconds field value less than zero or greater than or
+ *             equal to 1000 million.
+ *   ETIMEDOUT The mutex could not be locked before the specified timeout
+ *             expired.
+ *   EDEADLK   A deadlock condition was detected.
+ *
+ ****************************************************************************/
+
+int nxrmutex_clocklock(FAR rmutex_t *rmutex, clockid_t clockid,
+                       FAR const struct timespec *abstime);
 
 /****************************************************************************
  * Name: nxrmutex_timedlock

--- a/libs/libc/misc/lib_mutex.c
+++ b/libs/libc/misc/lib_mutex.c
@@ -303,7 +303,14 @@ int nxmutex_clocklock(FAR mutex_t *mutex, clockid_t clockid,
 
   do
     {
-      ret = nxsem_clockwait(&mutex->sem, clockid, abstime);
+      if (abstime)
+        {
+          ret = nxsem_clockwait(&mutex->sem, clockid, abstime);
+        }
+      else
+        {
+          ret = nxsem_wait(&mutex->sem);
+        }
     }
   while (ret == -EINTR || ret == -ECANCELED);
 

--- a/libs/libc/misc/lib_mutex.c
+++ b/libs/libc/misc/lib_mutex.c
@@ -441,7 +441,7 @@ void nxmutex_reset(FAR mutex_t *mutex)
  *
  ****************************************************************************/
 
-int nxmutex_breaklock(FAR mutex_t *mutex, FAR bool *locked)
+int nxmutex_breaklock(FAR mutex_t *mutex, FAR unsigned int *locked)
 {
   int ret = OK;
 
@@ -475,7 +475,7 @@ int nxmutex_breaklock(FAR mutex_t *mutex, FAR bool *locked)
  *
  ****************************************************************************/
 
-int nxmutex_restorelock(FAR mutex_t *mutex, bool locked)
+int nxmutex_restorelock(FAR mutex_t *mutex, unsigned int locked)
 {
   return locked ? nxmutex_lock(mutex) : OK;
 }

--- a/libs/libc/misc/lib_mutex.c
+++ b/libs/libc/misc/lib_mutex.c
@@ -241,7 +241,6 @@ int nxmutex_trylock(FAR mutex_t *mutex)
 {
   int ret;
 
-  DEBUGASSERT(!nxmutex_is_hold(mutex));
   ret = nxsem_trywait(&mutex->sem);
   if (ret < 0)
     {

--- a/libs/libc/misc/lib_mutex.c
+++ b/libs/libc/misc/lib_mutex.c
@@ -554,6 +554,25 @@ bool nxrmutex_is_hold(FAR rmutex_t *rmutex)
 }
 
 /****************************************************************************
+ * Name: nxrmutex_is_recursive
+ *
+ * Description:
+ *   This function check whether the recursive mutex is recursive
+ *
+ * Parameters:
+ *   rmutex - Recursive mutex descriptor.
+ *
+ * Return Value:
+ *  If rmutex has returned to True recursively, otherwise returns false.
+ *
+ ****************************************************************************/
+
+bool nxrmutex_is_recursive(FAR rmutex_t *rmutex)
+{
+  return rmutex->count > 1;
+}
+
+/****************************************************************************
  * Name: nxrmutex_get_holder
  *
  * Description:


### PR DESCRIPTION
## Summary
This part of the change is a precondition for changing the implementation of pthread_mutex from a semaphore to a mutex lock.
nxmutex api enhancements, the changes are as follows

Modify nxmutex_breaklock/restorelock parameter from bool to int
int nxmutex_restorelock(FAR mutex_t *mutex, FAR unsigned int *locked);
int nxmutex_breaklock(FAR mutex_t *mutex, FAR unsigned int *locked);

Add the following api:
nxmutex_get_holder, nxrmutex_get_holder
nxmutex_clocklock, nxrmutex_clocklock,
nxrmutex_is_recursive, nxrmutex_is_recursive


## Impact

## Testing
ostest and internal tests
