### PR TITLE
sched: change pthread_mutex implementation from sem to mutex

### DIFF
--- a/arch/arm/src/nrf91/CMakeLists.txt
+++ b/arch/arm/src/nrf91/CMakeLists.txt
@@ -144,14 +144,10 @@ if(CONFIG_NRF91_MODEM)
     set(MODEM_LIB_VARIANT libmodem.a)
   endif()
 
-  nuttx_library_import(
-    modem
+  nuttx_add_extra_library(
     ${NRFXLIB_DIR}/nrf_modem/lib/cortex-m33/${NRFXLIB_LIB_VARIANT}/${MODEM_LIB_VARIANT}
   )
   target_include_directories(arch PRIVATE ${NRFXLIB_DIR}/nrf_modem/include)
-
-  target_link_libraries(arch PRIVATE modem)
-  target_link_libraries(modem INTERFACE arch c net)
 endif()
 
 target_sources(arch PRIVATE ${SRCS})

--- a/include/pthread.h
+++ b/include/pthread.h
@@ -27,6 +27,7 @@
 
 #include <nuttx/config.h>    /* Default settings */
 #include <nuttx/compiler.h>  /* Compiler settings, noreturn_function */
+#include <nuttx/mutex.h>
 
 #include <sys/types.h>       /* Needed for general types */
 #include <stdint.h>          /* C99 fixed width integer types */
@@ -34,7 +35,6 @@
 #include <unistd.h>          /* For getpid */
 #include <signal.h>          /* Needed for sigset_t, includes this file */
 #include <time.h>            /* Needed for struct timespec */
-#include <semaphore.h>       /* For sem_t and SEM_PRIO_* defines */
 
 #ifdef CONFIG_PTHREAD_SPINLOCKS
 /* The architecture specific spinlock.h header file must provide the
@@ -301,18 +301,16 @@ struct pthread_mutex_s
   /* Supports a singly linked list */
 
   FAR struct pthread_mutex_s *flink;
+  uint8_t flags;    /* See _PTHREAD_MFLAGS_* */
 #endif
 
   /* Payload */
 
-  sem_t sem;        /* Semaphore underlying the implementation of the mutex */
-  pid_t pid;        /* ID of the holder of the mutex */
-#ifndef CONFIG_PTHREAD_MUTEX_UNSAFE
-  uint8_t flags;    /* See _PTHREAD_MFLAGS_* */
-#endif
 #ifdef CONFIG_PTHREAD_MUTEX_TYPES
   uint8_t type;     /* Type of the mutex.  See PTHREAD_MUTEX_* definitions */
-  int16_t nlocks;   /* The number of recursive locks held */
+  rmutex_t mutex;   /* Mutex underlying the implementation of the mutex */
+#else
+  mutex_t mutex;    /* Mutex underlying the implementation of the mutex */
 #endif
 };
 
@@ -330,24 +328,24 @@ typedef struct pthread_mutex_s pthread_mutex_t;
 #endif
 
 #if defined(CONFIG_PTHREAD_MUTEX_TYPES) && !defined(CONFIG_PTHREAD_MUTEX_UNSAFE)
-#  define PTHREAD_MUTEX_INITIALIZER {NULL, SEM_INITIALIZER(1), -1, \
-                                     __PTHREAD_MUTEX_DEFAULT_FLAGS, \
-                                     PTHREAD_MUTEX_DEFAULT, 0}
+#  define PTHREAD_MUTEX_INITIALIZER {NULL, __PTHREAD_MUTEX_DEFAULT_FLAGS, \
+                                     PTHREAD_MUTEX_DEFAULT, \
+                                     NXRMUTEX_INITIALIZER}
 #  define PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP \
-                                     {NULL, SEM_INITIALIZER(1), -1, \
-                                     __PTHREAD_MUTEX_DEFAULT_FLAGS, \
-                                     PTHREAD_MUTEX_RECURSIVE, 0}
+                                    {NULL, __PTHREAD_MUTEX_DEFAULT_FLAGS, \
+                                     PTHREAD_MUTEX_RECURSIVE, \
+                                     NXRMUTEX_INITIALIZER,}
 #elif defined(CONFIG_PTHREAD_MUTEX_TYPES)
-#  define PTHREAD_MUTEX_INITIALIZER {SEM_INITIALIZER(1), -1, \
-                                     PTHREAD_MUTEX_DEFAULT, 0}
+#  define PTHREAD_MUTEX_INITIALIZER {PTHREAD_MUTEX_DEFAULT, \
+                                     NXRMUTEX_INITIALIZER,}
 #  define PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP \
-                                     {SEM_INITIALIZER(1), -1, \
-                                     PTHREAD_MUTEX_RECURSIVE, 0}
+                                    {PTHREAD_MUTEX_RECURSIVE, \
+                                     NXRMUTEX_INITIALIZER}
 #elif !defined(CONFIG_PTHREAD_MUTEX_UNSAFE)
-#  define PTHREAD_MUTEX_INITIALIZER {NULL, SEM_INITIALIZER(1), -1,\
-                                     __PTHREAD_MUTEX_DEFAULT_FLAGS}
+#  define PTHREAD_MUTEX_INITIALIZER {NULL, __PTHREAD_MUTEX_DEFAULT_FLAGS,\
+                                     NXMUTEX_INITIALIZER}
 #else
-#  define PTHREAD_MUTEX_INITIALIZER {SEM_INITIALIZER(1), -1}
+#  define PTHREAD_MUTEX_INITIALIZER {NXMUTEX_INITIALIZER}
 #endif
 
 struct pthread_barrierattr_s

--- a/sched/pthread/pthread.h
+++ b/sched/pthread/pthread.h
@@ -37,6 +37,40 @@
 #include <nuttx/sched.h>
 
 /****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifdef CONFIG_PTHREAD_MUTEX_TYPES
+#  define mutex_init(m)          nxrmutex_init(m)
+#  define mutex_destroy(m)       nxrmutex_destroy(m)
+#  define mutex_is_hold(m)       nxrmutex_is_hold(m)
+#  define mutex_is_locked(m)     nxrmutex_is_locked(m)
+#  define mutex_is_recursive(m)  nxrmutex_is_recursive(m)
+#  define mutex_get_holder(m)    nxrmutex_get_holder(m)
+#  define mutex_reset(m)         nxrmutex_reset(m)
+#  define mutex_unlock(m)        nxrmutex_unlock(m)
+#  define mutex_lock(m)          nxrmutex_lock(m)
+#  define mutex_trylock(m)       nxrmutex_trylock(m)
+#  define mutex_breaklock(m,v)   nxrmutex_breaklock(m,v)
+#  define mutex_restorelock(m,v) nxrmutex_restorelock(m,v)
+#  define mutex_clocklock(m,t)   nxrmutex_clocklock(m,CLOCK_REALTIME,t)
+#else
+#  define mutex_init(m)          nxmutex_init(m)
+#  define mutex_destroy(m)       nxmutex_destroy(m)
+#  define mutex_is_hold(m)       nxmutex_is_hold(m)
+#  define mutex_is_recursive(m)  (false)
+#  define mutex_is_locked(m)     nxmutex_is_locked(m)
+#  define mutex_get_holder(m)    nxmutex_get_holder(m)
+#  define mutex_reset(m)         nxmutex_reset(m)
+#  define mutex_unlock(m)        nxmutex_unlock(m)
+#  define mutex_lock(m)          nxmutex_lock(m)
+#  define mutex_trylock(m)       nxmutex_trylock(m)
+#  define mutex_breaklock(m,v)   nxmutex_breaklock(m, v)
+#  define mutex_restorelock(m,v) nxmutex_restorelock(m, v)
+#  define mutex_clocklock(m,t)   nxmutex_clocklock(m,CLOCK_REALTIME,t)
+#endif
+
+/****************************************************************************
  * Public Data
  ****************************************************************************/
 
@@ -76,11 +110,18 @@ int pthread_mutex_take(FAR struct pthread_mutex_s *mutex,
                        FAR const struct timespec *abs_timeout);
 int pthread_mutex_trytake(FAR struct pthread_mutex_s *mutex);
 int pthread_mutex_give(FAR struct pthread_mutex_s *mutex);
+int pthread_mutex_breaklock(FAR struct pthread_mutex_s *mutex,
+                            FAR unsigned int *breakval);
+int pthread_mutex_restorelock(FAR struct pthread_mutex_s *mutex,
+                              unsigned int breakval);
 void pthread_mutex_inconsistent(FAR struct tcb_s *tcb);
 #else
-#  define pthread_mutex_take(m,abs_timeout) pthread_sem_take(&(m)->sem,(abs_timeout))
-#  define pthread_mutex_trytake(m)          pthread_sem_trytake(&(m)->sem)
-#  define pthread_mutex_give(m)             pthread_sem_give(&(m)->sem)
+#  define pthread_mutex_take(m,abs_timeout) -mutex_clocklock(&(m)->mutex, \
+                                                             abs_timeout)
+#  define pthread_mutex_trytake(m)          -mutex_trylock(&(m)->mutex)
+#  define pthread_mutex_give(m)             -mutex_unlock(&(m)->mutex)
+#  define pthread_mutex_breaklock(m,v)      -mutex_breaklock(&(m)->mutex,v)
+#  define pthread_mutex_restorelock(m,v)    -mutex_restorelock(&(m)->mutex,v)
 #endif
 
 #ifdef CONFIG_PTHREAD_MUTEX_TYPES

--- a/sched/pthread/pthread_condclockwait.c
+++ b/sched/pthread/pthread_condclockwait.c
@@ -109,11 +109,7 @@ int pthread_cond_clockwait(FAR pthread_cond_t *cond,
 
   else
     {
-#ifndef CONFIG_PTHREAD_MUTEX_UNSAFE
-      uint8_t mflags;
-#endif
 #ifdef CONFIG_PTHREAD_MUTEX_TYPES
-      uint8_t type;
       int16_t nlocks;
 #endif
 
@@ -131,11 +127,7 @@ int pthread_cond_clockwait(FAR pthread_cond_t *cond,
       /* Give up the mutex */
 
       mutex->pid = INVALID_PROCESS_ID;
-#ifndef CONFIG_PTHREAD_MUTEX_UNSAFE
-      mflags     = mutex->flags;
-#endif
 #ifdef CONFIG_PTHREAD_MUTEX_TYPES
-      type       = mutex->type;
       nlocks     = mutex->nlocks;
 #endif
       ret        = pthread_mutex_give(mutex);
@@ -163,11 +155,7 @@ int pthread_cond_clockwait(FAR pthread_cond_t *cond,
       if (status == OK)
         {
           mutex->pid    = mypid;
-#ifndef CONFIG_PTHREAD_MUTEX_UNSAFE
-          mutex->flags  = mflags;
-#endif
 #ifdef CONFIG_PTHREAD_MUTEX_TYPES
-          mutex->type   = type;
           mutex->nlocks = nlocks;
 #endif
         }

--- a/sched/pthread/pthread_condclockwait.c
+++ b/sched/pthread/pthread_condclockwait.c
@@ -74,7 +74,6 @@ int pthread_cond_clockwait(FAR pthread_cond_t *cond,
                            FAR const struct timespec *abstime)
 {
   irqstate_t flags;
-  int mypid = nxsched_gettid();
   int ret = OK;
   int status;
 
@@ -93,7 +92,7 @@ int pthread_cond_clockwait(FAR pthread_cond_t *cond,
 
   /* Make sure that the caller holds the mutex */
 
-  else if (mutex->pid != mypid)
+  else if (!mutex_is_hold(&mutex->mutex))
     {
       ret = EPERM;
     }
@@ -109,9 +108,7 @@ int pthread_cond_clockwait(FAR pthread_cond_t *cond,
 
   else
     {
-#ifdef CONFIG_PTHREAD_MUTEX_TYPES
-      int16_t nlocks;
-#endif
+      unsigned int nlocks;
 
       sinfo("Give up mutex...\n");
 
@@ -126,11 +123,7 @@ int pthread_cond_clockwait(FAR pthread_cond_t *cond,
 
       /* Give up the mutex */
 
-      mutex->pid = INVALID_PROCESS_ID;
-#ifdef CONFIG_PTHREAD_MUTEX_TYPES
-      nlocks     = mutex->nlocks;
-#endif
-      ret        = pthread_mutex_give(mutex);
+      ret = pthread_mutex_breaklock(mutex, &nlocks);
       if (ret == 0)
         {
           status = nxsem_clockwait_uninterruptible(&cond->sem,
@@ -151,17 +144,10 @@ int pthread_cond_clockwait(FAR pthread_cond_t *cond,
 
       sinfo("Re-locking...\n");
 
-      status = pthread_mutex_take(mutex, NULL);
-      if (status == OK)
+      status = pthread_mutex_restorelock(mutex, nlocks);
+      if (ret == 0)
         {
-          mutex->pid    = mypid;
-#ifdef CONFIG_PTHREAD_MUTEX_TYPES
-          mutex->nlocks = nlocks;
-#endif
-        }
-      else if (ret == 0)
-        {
-          ret           = status;
+          ret = status;
         }
 
       /* Re-enable pre-emption (It is expected that interrupts

--- a/sched/pthread/pthread_condwait.c
+++ b/sched/pthread/pthread_condwait.c
@@ -81,11 +81,7 @@ int pthread_cond_wait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex)
     }
   else
     {
-#ifndef CONFIG_PTHREAD_MUTEX_UNSAFE
-      uint8_t mflags;
-#endif
 #ifdef CONFIG_PTHREAD_MUTEX_TYPES
-      uint8_t type;
       int16_t nlocks;
 #endif
 
@@ -96,11 +92,7 @@ int pthread_cond_wait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex)
       flags = enter_critical_section();
       sched_lock();
       mutex->pid = INVALID_PROCESS_ID;
-#ifndef CONFIG_PTHREAD_MUTEX_UNSAFE
-      mflags     = mutex->flags;
-#endif
 #ifdef CONFIG_PTHREAD_MUTEX_TYPES
-      type       = mutex->type;
       nlocks     = mutex->nlocks;
 #endif
       ret        = pthread_mutex_give(mutex);
@@ -144,11 +136,7 @@ int pthread_cond_wait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex)
           /* Yes.. Then initialize it properly */
 
           mutex->pid    = nxsched_gettid();
-#ifndef CONFIG_PTHREAD_MUTEX_UNSAFE
-          mutex->flags  = mflags;
-#endif
 #ifdef CONFIG_PTHREAD_MUTEX_TYPES
-          mutex->type   = type;
           mutex->nlocks = nlocks;
 #endif
         }

--- a/sched/pthread/pthread_mutexconsistent.c
+++ b/sched/pthread/pthread_mutexconsistent.c
@@ -74,21 +74,24 @@
 int pthread_mutex_consistent(FAR pthread_mutex_t *mutex)
 {
   int ret = EINVAL;
-  int status;
 
   sinfo("mutex=%p\n", mutex);
   DEBUGASSERT(mutex != NULL);
 
   if (mutex != NULL)
     {
+      pid_t pid;
+
       /* Make sure the mutex is stable while we make the following checks. */
 
       sched_lock();
 
+      pid = mutex_get_holder(&mutex->mutex);
+
       /* Is the mutex available? */
 
-      DEBUGASSERT(mutex->pid != 0); /* < 0: available, >0 owned, ==0 error */
-      if (mutex->pid >= 0)
+      DEBUGASSERT(pid != 0); /* < 0: available, >0 owned, ==0 error */
+      if (pid >= 0)
         {
           /* No.. Verify that the thread associated with the PID still
            * exists.  We may be destroying the mutex after cancelling a
@@ -101,28 +104,18 @@ int pthread_mutex_consistent(FAR pthread_mutex_t *mutex)
            * nxsched_get_tcb() does.
            */
 
-          if (nxsched_get_tcb(mutex->pid) == NULL)
+          if (nxsched_get_tcb(pid) == NULL)
             {
-              /* The thread associated with the PID no longer exists */
-
-              mutex->pid    = INVALID_PROCESS_ID;
-              mutex->flags &= _PTHREAD_MFLAGS_ROBUST;
-#ifdef CONFIG_PTHREAD_MUTEX_TYPES
-              mutex->nlocks = 0;
-#endif
               /* Reset the semaphore.  This has the same affect as if the
                * dead task had called pthread_mutex_unlock().
                */
 
-              status = nxsem_reset(&mutex->sem, 1);
-              if (status < 0)
-                {
-                  ret = -status;
-                }
-              else
-                {
-                  ret = OK;
-                }
+              mutex_reset(&mutex->mutex);
+
+              /* The thread associated with the PID no longer exists */
+
+              mutex->flags &= _PTHREAD_MFLAGS_ROBUST;
+              ret = OK;
             }
 
           /* Otherwise the mutex is held by some active thread.  Let's not
@@ -136,9 +129,6 @@ int pthread_mutex_consistent(FAR pthread_mutex_t *mutex)
            */
 
           mutex->flags &= _PTHREAD_MFLAGS_ROBUST;
-#ifdef CONFIG_PTHREAD_MUTEX_TYPES
-          mutex->nlocks = 0;
-#endif
           ret = OK;
         }
 

--- a/sched/pthread/pthread_mutexdestroy.c
+++ b/sched/pthread/pthread_mutexdestroy.c
@@ -65,20 +65,23 @@ int pthread_mutex_destroy(FAR pthread_mutex_t *mutex)
 
   if (mutex != NULL)
     {
+      pid_t pid;
+
       /* Make sure the semaphore is stable while we make the following
        * checks.
        */
 
       sched_lock();
 
+      pid = mutex_get_holder(&mutex->mutex);
+
       /* Is the mutex available? */
 
-      if (mutex->pid >= 0)
+      if (pid >= 0)
         {
           /* < 0: available, >0 owned, ==0 error */
 
-          DEBUGASSERT(mutex->pid != 0);
-
+          DEBUGASSERT(pid != 0);
           /* No.. Verify that the PID still exists.  We may be destroying
            * the mutex after cancelling a pthread and the mutex may have
            * been in a bad state owned by the dead pthread.  NOTE: The
@@ -90,28 +93,22 @@ int pthread_mutex_destroy(FAR pthread_mutex_t *mutex)
            * nxsched_get_tcb() does.
            */
 
-          if (nxsched_get_tcb(mutex->pid) == NULL)
+          if (nxsched_get_tcb(pid) == NULL)
             {
               /* The thread associated with the PID no longer exists */
-
-              mutex->pid = INVALID_PROCESS_ID;
 
               /* Reset the semaphore.  If threads are were on this
                * semaphore, then this will awakened them and make
                * destruction of the semaphore impossible here.
                */
 
-              status = nxsem_reset(&mutex->sem, 1);
-              if (status < 0)
-                {
-                  ret = -status;
-                }
+              mutex_reset(&mutex->mutex);
 
               /* Check if the reset caused some other thread to lock the
                * mutex.
                */
 
-              else if (mutex->pid != INVALID_PROCESS_ID)
+              if (mutex_is_locked(&mutex->mutex))
                 {
                   /* Yes.. then we cannot destroy the mutex now. */
 
@@ -122,7 +119,7 @@ int pthread_mutex_destroy(FAR pthread_mutex_t *mutex)
 
               else
                 {
-                  status = nxsem_destroy(&mutex->sem);
+                  status = mutex_destroy(&mutex->mutex);
                   ret = (status < 0) ? -status : OK;
                 }
             }
@@ -139,7 +136,7 @@ int pthread_mutex_destroy(FAR pthread_mutex_t *mutex)
            * Perhaps this logic should all nxsem_reset() first?
            */
 
-          status = nxsem_destroy(&mutex->sem);
+          status = mutex_destroy(&mutex->mutex);
           ret = ((status < 0) ? -status : OK);
         }
 

--- a/sched/pthread/pthread_mutexinconsistent.c
+++ b/sched/pthread/pthread_mutexinconsistent.c
@@ -80,7 +80,7 @@ void pthread_mutex_inconsistent(FAR struct tcb_s *tcb)
       /* Mark the mutex as INCONSISTENT and wake up any waiting thread */
 
       mutex->flags |= _PTHREAD_MFLAGS_INCONSISTENT;
-      pthread_sem_give(&mutex->sem);
+      mutex_unlock(&mutex->mutex);
     }
 
   sched_unlock();

--- a/sched/pthread/pthread_mutexinit.c
+++ b/sched/pthread/pthread_mutexinit.c
@@ -55,7 +55,6 @@
 int pthread_mutex_init(FAR pthread_mutex_t *mutex,
                        FAR const pthread_mutexattr_t *attr)
 {
-  int pshared = 0;
 #ifdef CONFIG_PTHREAD_MUTEX_TYPES
   uint8_t type = PTHREAD_MUTEX_DEFAULT;
 #endif
@@ -88,7 +87,6 @@ int pthread_mutex_init(FAR pthread_mutex_t *mutex,
 
       if (attr)
         {
-          pshared = attr->pshared;
 #ifdef CONFIG_PRIORITY_INHERITANCE
           proto   = attr->proto;
 #endif
@@ -107,7 +105,7 @@ int pthread_mutex_init(FAR pthread_mutex_t *mutex,
 
       /* Initialize the mutex like a semaphore with initial count = 1 */
 
-      status = nxsem_init(&mutex->sem, pshared, 1);
+      status = nxsem_init(&mutex->sem, 0, 1);
       if (status < 0)
         {
           ret = -ret;

--- a/sched/pthread/pthread_mutexinit.c
+++ b/sched/pthread/pthread_mutexinit.c
@@ -58,13 +58,6 @@ int pthread_mutex_init(FAR pthread_mutex_t *mutex,
 #ifdef CONFIG_PTHREAD_MUTEX_TYPES
   uint8_t type = PTHREAD_MUTEX_DEFAULT;
 #endif
-#ifdef CONFIG_PRIORITY_INHERITANCE
-#  ifdef CONFIG_PTHREAD_MUTEX_DEFAULT_PRIO_INHERIT
-  uint8_t proto = PTHREAD_PRIO_INHERIT;
-#  else
-  uint8_t proto = PTHREAD_PRIO_NONE;
-#  endif
-#endif
 #ifndef CONFIG_PTHREAD_MUTEX_UNSAFE
 #ifdef CONFIG_PTHREAD_MUTEX_DEFAULT_UNSAFE
   uint8_t flags = 0;
@@ -87,9 +80,6 @@ int pthread_mutex_init(FAR pthread_mutex_t *mutex,
 
       if (attr)
         {
-#ifdef CONFIG_PRIORITY_INHERITANCE
-          proto   = attr->proto;
-#endif
 #ifdef CONFIG_PTHREAD_MUTEX_TYPES
           type    = attr->type;
 #endif
@@ -99,41 +89,25 @@ int pthread_mutex_init(FAR pthread_mutex_t *mutex,
 #endif
         }
 
-      /* Indicate that the semaphore is not held by any thread. */
-
-      mutex->pid = INVALID_PROCESS_ID;
-
       /* Initialize the mutex like a semaphore with initial count = 1 */
 
-      status = nxsem_init(&mutex->sem, 0, 1);
-      if (status < 0)
-        {
-          ret = -ret;
-        }
-
-#ifdef CONFIG_PRIORITY_INHERITANCE
-      /* Initialize the semaphore protocol */
-
-      status = nxsem_set_protocol(&mutex->sem, proto);
+      status = mutex_init(&mutex->mutex);
       if (status < 0)
         {
           ret = -status;
         }
-#endif
 
 #ifndef CONFIG_PTHREAD_MUTEX_UNSAFE
       /* Initial internal fields of the mutex */
 
-      mutex->flink  = NULL;
-
-      mutex->flags  = flags;
+      mutex->flink = NULL;
+      mutex->flags = flags;
 #endif
 
 #ifdef CONFIG_PTHREAD_MUTEX_TYPES
       /* Set up attributes unique to the mutex type */
 
-      mutex->type   = type;
-      mutex->nlocks = 0;
+      mutex->type  = type;
 #endif
     }
 

--- a/sched/pthread/pthread_mutextimedlock.c
+++ b/sched/pthread/pthread_mutextimedlock.c
@@ -78,7 +78,6 @@
 int pthread_mutex_timedlock(FAR pthread_mutex_t *mutex,
                             FAR const struct timespec *abs_timeout)
 {
-  pid_t mypid = nxsched_gettid();
   int ret = EINVAL;
   irqstate_t flags;
 
@@ -87,6 +86,10 @@ int pthread_mutex_timedlock(FAR pthread_mutex_t *mutex,
 
   if (mutex != NULL)
     {
+#ifndef CONFIG_PTHREAD_MUTEX_UNSAFE
+      pid_t pid = mutex_get_holder(&mutex->mutex);
+#endif
+
       /* Make sure the semaphore is stable while we make the following
        * checks.  This all needs to be one atomic action.
        */
@@ -98,7 +101,8 @@ int pthread_mutex_timedlock(FAR pthread_mutex_t *mutex,
        * an error if the caller does not hold the mutex.
        */
 
-      if (mutex->type != PTHREAD_MUTEX_NORMAL && mutex->pid == mypid)
+      if (mutex->type != PTHREAD_MUTEX_NORMAL &&
+          mutex_is_hold(&mutex->mutex))
         {
           /* Yes... Is this a recursive mutex? */
 
@@ -108,15 +112,7 @@ int pthread_mutex_timedlock(FAR pthread_mutex_t *mutex,
                * success.
                */
 
-              if (mutex->nlocks < INT16_MAX)
-                {
-                  mutex->nlocks++;
-                  ret = OK;
-                }
-              else
-                {
-                  ret = EOVERFLOW;
-                }
+              ret = pthread_mutex_take(mutex, abs_timeout);
             }
           else
             {
@@ -148,26 +144,26 @@ int pthread_mutex_timedlock(FAR pthread_mutex_t *mutex,
 #ifdef CONFIG_PTHREAD_MUTEX_TYPES
       /* Include check if this is a NORMAL mutex and that it is robust */
 
-      if (mutex->pid > 0 &&
+      if (pid > 0 &&
           ((mutex->flags & _PTHREAD_MFLAGS_ROBUST) != 0 ||
            mutex->type != PTHREAD_MUTEX_NORMAL) &&
-          nxsched_get_tcb(mutex->pid) == NULL)
+          nxsched_get_tcb(pid) == NULL)
 
 #else /* CONFIG_PTHREAD_MUTEX_TYPES */
       /* This can only be a NORMAL mutex.  Include check if it is robust */
 
-      if (mutex->pid > 0 &&
+      if (pid > 0 &&
           (mutex->flags & _PTHREAD_MFLAGS_ROBUST) != 0 &&
-          nxsched_get_tcb(mutex->pid) == NULL)
+          nxsched_get_tcb(pid) == NULL)
 
 #endif /* CONFIG_PTHREAD_MUTEX_TYPES */
 #else /* CONFIG_PTHREAD_MUTEX_ROBUST */
       /* This mutex is always robust, whatever type it is. */
 
-      if (mutex->pid > 0 && nxsched_get_tcb(mutex->pid) == NULL)
+      if (pid > 0 && nxsched_get_tcb(pid) == NULL)
 #endif
         {
-          DEBUGASSERT(mutex->pid != 0); /* < 0: available, >0 owned, ==0 error */
+          DEBUGASSERT(pid != 0); /* < 0: available, >0 owned, ==0 error */
           DEBUGASSERT((mutex->flags & _PTHREAD_MFLAGS_INCONSISTENT) != 0);
 
           /* A thread holds the mutex, but there is no such thread.  POSIX
@@ -189,18 +185,6 @@ int pthread_mutex_timedlock(FAR pthread_mutex_t *mutex,
            */
 
           ret = pthread_mutex_take(mutex, abs_timeout);
-
-          /* If we successfully obtained the semaphore, then indicate
-           * that we own it.
-           */
-
-          if (ret == OK)
-            {
-              mutex->pid    = mypid;
-#ifdef CONFIG_PTHREAD_MUTEX_TYPES
-              mutex->nlocks = 1;
-#endif
-            }
         }
 
       leave_critical_section(flags);

--- a/sched/pthread/pthread_mutextrylock.c
+++ b/sched/pthread/pthread_mutextrylock.c
@@ -76,7 +76,9 @@ int pthread_mutex_trylock(FAR pthread_mutex_t *mutex)
 
   if (mutex != NULL)
     {
-      pid_t mypid = nxsched_gettid();
+#ifndef CONFIG_PTHREAD_MUTEX_UNSAFE
+      pid_t pid = mutex_get_holder(&mutex->mutex);
+#endif
 
       /* Make sure the semaphore is stable while we make the following
        * checks.  This all needs to be one atomic action.
@@ -89,19 +91,6 @@ int pthread_mutex_trylock(FAR pthread_mutex_t *mutex)
       status = pthread_mutex_trytake(mutex);
       if (status == OK)
         {
-          /* If we successfully obtained the semaphore, then indicate
-           * that we own it.
-           */
-
-          mutex->pid = mypid;
-
-#ifdef CONFIG_PTHREAD_MUTEX_TYPES
-          if (mutex->type == PTHREAD_MUTEX_RECURSIVE)
-            {
-              mutex->nlocks = 1;
-            }
-#endif
-
           ret = OK;
         }
 
@@ -111,28 +100,6 @@ int pthread_mutex_trylock(FAR pthread_mutex_t *mutex)
 
       else if (status == EAGAIN)
         {
-#ifdef CONFIG_PTHREAD_MUTEX_TYPES
-          /* Check if recursive mutex was locked by the calling thread. */
-
-          if (mutex->type == PTHREAD_MUTEX_RECURSIVE && mutex->pid == mypid)
-            {
-              /* Increment the number of locks held and return
-               * successfully.
-               */
-
-              if (mutex->nlocks < INT16_MAX)
-                {
-                  mutex->nlocks++;
-                  ret = OK;
-                }
-              else
-                {
-                  ret = EOVERFLOW;
-                }
-            }
-          else
-#endif
-
 #ifndef CONFIG_PTHREAD_MUTEX_UNSAFE
           /* The calling thread does not hold the semaphore.  The correct
            * behavior for the 'robust' mutex is to verify that the holder of
@@ -144,28 +111,28 @@ int pthread_mutex_trylock(FAR pthread_mutex_t *mutex)
 #ifdef CONFIG_PTHREAD_MUTEX_TYPES
           /* Check if this NORMAL mutex is robust */
 
-          if (mutex->pid > 0 &&
+          if (pid > 0 &&
               ((mutex->flags & _PTHREAD_MFLAGS_ROBUST) != 0 ||
                mutex->type != PTHREAD_MUTEX_NORMAL) &&
-              nxsched_get_tcb(mutex->pid) == NULL)
+              nxsched_get_tcb(pid) == NULL)
 
 #else /* CONFIG_PTHREAD_MUTEX_TYPES */
           /* Check if this NORMAL mutex is robust */
 
-          if (mutex->pid > 0 &&
+          if (pid > 0 &&
               (mutex->flags & _PTHREAD_MFLAGS_ROBUST) != 0 &&
-              nxsched_get_tcb(mutex->pid) == NULL)
+              nxsched_get_tcb(pid) == NULL)
 
 #endif /* CONFIG_PTHREAD_MUTEX_TYPES */
 #else /* CONFIG_PTHREAD_MUTEX_ROBUST */
           /* This mutex is always robust, whatever type it is. */
 
-          if (mutex->pid > 0 && nxsched_get_tcb(mutex->pid) == NULL)
+          if (pid > 0 && nxsched_get_tcb(pid) == NULL)
 #endif
             {
               /* < 0: available, >0 owned, ==0 error */
 
-              DEBUGASSERT(mutex->pid != 0);
+              DEBUGASSERT(pid != 0);
               DEBUGASSERT((mutex->flags & _PTHREAD_MFLAGS_INCONSISTENT)
                           != 0);
 


### PR DESCRIPTION
## Summary
Since pthread_mutex is implemented by sem, it is impossible to see in ps who holds the lock and causes the wait.
Replace semaphore with mutex implementation to solve the above problems

## Impact
It depends on https://github.com/apache/nuttx/pull/13104

## Testing
ostest & ltp 
