### PR TITLE
suppress libasan checks

### DIFF
--- a/arch/sim/Kconfig
+++ b/arch/sim/Kconfig
@@ -70,7 +70,7 @@ config SIM_CYGWIN_DECORATED
 config SIM_ASAN
 	bool "Address Sanitizer"
 	default n
-	depends on MM_CUSTOMIZE_MANAGER && FRAME_POINTER
+	depends on !MM_KASAN && MM_CUSTOMIZE_MANAGER && FRAME_POINTER
 	---help---
 		AddressSanitizer (ASan) is a fast compiler-based tool for detecting memory
 		bugs in native code.
@@ -78,7 +78,7 @@ config SIM_ASAN
 config SIM_UBSAN
 	bool "Undefined Behaviour Sanitizer"
 	default n
-	depends on FRAME_POINTER
+	depends on !MM_UBSAN && FRAME_POINTER
 	---help---
 		Compile-time instrumentation is used to detect various undefined behaviours
 		at runtime.

--- a/arch/sim/src/sim/sim_head.c
+++ b/arch/sim/src/sim/sim_head.c
@@ -108,6 +108,11 @@ static void allsyms_relocate(void)
  ****************************************************************************/
 
 #ifdef CONFIG_SIM_ASAN
+const char *__asan_default_suppressions(void)
+{
+  return "interceptor_via_lib:libasan.so";
+}
+
 const char *__asan_default_options(void)
 {
   return "abort_on_error=1"


### PR DESCRIPTION
## Summary
 There is a false positive in asan of gcc-13, we need to mask it to ensure that other parts work properly
    
    sanitizer_common/sanitizer_common_interceptors.inc:
       // FIXME: under ASan the call below may write to freed memory and corrupt
       // its metadata. See
       // https://github.com/google/sanitizers/issues/321.
    
    ==572161==ERROR: AddressSanitizer: dynamic-stack-buffer-overflow on address 0xed3d3f00 at pc 0xef46af64 bp 0xed3d3de8 sp 0xed3d39bc
    WRITE of size 128 at 0xed3d3f00 thread T0
         #0 0xef46af63 in __interceptor_pthread_sigmask ../../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:4419
         #1 0x5486aa7d in up_irq_save sim/posix/sim_hostirq.c:97

## Impact

## Testing

