### PR TITLE
drivers/audio: fix samp rate conversion issue

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_nxaudio.c
+++ b/arch/arm/src/cxd56xx/cxd56_nxaudio.c
@@ -81,18 +81,14 @@
 /* Samplerates field is split into low and high byte */
 
 #ifdef CONFIG_AUDIO_CXD56_SRC
-#define CXD56_SUPP_RATES_L  (AUDIO_SAMP_RATE_8K  | AUDIO_SAMP_RATE_11K | \
-                             AUDIO_SAMP_RATE_16K | AUDIO_SAMP_RATE_22K | \
-                             AUDIO_SAMP_RATE_32K | AUDIO_SAMP_RATE_44K | \
-                             AUDIO_SAMP_RATE_48K)
-#define CXD56_SUPP_RATES_H  ((AUDIO_SAMP_RATE_96K  | AUDIO_SAMP_RATE_128K | \
-                              AUDIO_SAMP_RATE_192K) >> 8)
-#define CXD56_SUPP_RATES    (CXD56_SUPP_RATES_L | CXD56_SUPP_RATES_H)
+#define CXD56_SUPP_RATES  (AUDIO_SAMP_RATE_8K   | AUDIO_SAMP_RATE_11K | \
+                           AUDIO_SAMP_RATE_16K  | AUDIO_SAMP_RATE_22K | \
+                           AUDIO_SAMP_RATE_32K  | AUDIO_SAMP_RATE_44K | \
+                           AUDIO_SAMP_RATE_48K  | AUDIO_SAMP_RATE_96K | \
+                           AUDIO_SAMP_RATE_128K | AUDIO_SAMP_RATE_192K)
 #else
 /* No sample rate converter, only support system rate of 48kHz */
-#define CXD56_SUPP_RATES_L  AUDIO_SAMP_RATE_48K
-#define CXD56_SUPP_RATES_H  0x0
-#define CXD56_SUPP_RATES    (CXD56_SUPP_RATES_L | CXD56_SUPP_RATES_H)
+#define CXD56_SUPP_RATES  AUDIO_SAMP_RATE_48K
 #endif
 
 /* Mic setting definitions */
@@ -2587,8 +2583,6 @@ static int cxd56_getcaps(struct audio_lowerhalf_s *lower, int type,
 {
   DEBUGASSERT(caps && caps->ac_len >= sizeof(struct audio_caps_s));
 
-  uint16_t *ptr;
-
   /* Fill in the caller's structure based on requested info */
 
   caps->ac_format.hw  = 0;
@@ -2633,8 +2627,7 @@ static int cxd56_getcaps(struct audio_lowerhalf_s *lower, int type,
 
               /* Report supported output sample rates */
 
-              ptr  = (uint16_t *)caps->ac_controls.b;
-              *ptr = CXD56_SUPP_RATES_L;
+              caps->ac_controls.hw[0] = CXD56_SUPP_RATES;
               break;
 
             default:
@@ -2654,8 +2647,7 @@ static int cxd56_getcaps(struct audio_lowerhalf_s *lower, int type,
 
               /* Report supported input sample rates */
 
-              ptr  = (uint16_t *)caps->ac_controls.b;
-              *ptr = CXD56_SUPP_RATES_L;
+              caps->ac_controls.hw[0] = CXD56_SUPP_RATES;
               break;
 
             default:

--- a/arch/sim/src/sim/posix/sim_alsa.c
+++ b/arch/sim/src/sim/posix/sim_alsa.c
@@ -309,7 +309,6 @@ static int sim_audio_getcaps(struct audio_lowerhalf_s *dev, int type,
                              struct audio_caps_s *caps)
 {
   struct sim_audio_s *priv = (struct sim_audio_s *)dev;
-  uint16_t *ptr;
   long val;
 
   caps->ac_format.hw  = 0;
@@ -370,16 +369,15 @@ static int sim_audio_getcaps(struct audio_lowerhalf_s *dev, int type,
 
               /* Report the Sample rates we support */
 
-              ptr  = (uint16_t *)caps->ac_controls.b;
-              *ptr = AUDIO_SAMP_RATE_8K |
-                     AUDIO_SAMP_RATE_11K |
-                     AUDIO_SAMP_RATE_12K |
-                     AUDIO_SAMP_RATE_16K |
-                     AUDIO_SAMP_RATE_22K |
-                     AUDIO_SAMP_RATE_24K |
-                     AUDIO_SAMP_RATE_32K |
-                     AUDIO_SAMP_RATE_44K |
-                     AUDIO_SAMP_RATE_48K;
+             caps->ac_controls.hw[0] = AUDIO_SAMP_RATE_8K |
+                                       AUDIO_SAMP_RATE_11K |
+                                       AUDIO_SAMP_RATE_12K |
+                                       AUDIO_SAMP_RATE_16K |
+                                       AUDIO_SAMP_RATE_22K |
+                                       AUDIO_SAMP_RATE_24K |
+                                       AUDIO_SAMP_RATE_32K |
+                                       AUDIO_SAMP_RATE_44K |
+                                       AUDIO_SAMP_RATE_48K;
               break;
 
             default:

--- a/drivers/audio/audio_null.c
+++ b/drivers/audio/audio_null.c
@@ -215,8 +215,6 @@ static int null_getcaps(FAR struct audio_lowerhalf_s *dev, int type,
 
   DEBUGASSERT(caps->ac_len >= sizeof(struct audio_caps_s));
 
-  uint16_t *ptr;
-
   /* Fill in the caller's structure based on requested info */
 
   caps->ac_format.hw  = 0;
@@ -275,14 +273,13 @@ static int null_getcaps(FAR struct audio_lowerhalf_s *dev, int type,
 
               /* Report the Sample rates we support */
 
-              ptr  = (FAR uint16_t *)caps->ac_controls.b;
-              *ptr = AUDIO_SAMP_RATE_8K |
-                     AUDIO_SAMP_RATE_11K |
-                     AUDIO_SAMP_RATE_16K |
-                     AUDIO_SAMP_RATE_22K |
-                     AUDIO_SAMP_RATE_32K |
-                     AUDIO_SAMP_RATE_44K |
-                     AUDIO_SAMP_RATE_48K;
+             caps->ac_controls.hw[0] = AUDIO_SAMP_RATE_8K |
+                                       AUDIO_SAMP_RATE_11K |
+                                       AUDIO_SAMP_RATE_16K |
+                                       AUDIO_SAMP_RATE_22K |
+                                       AUDIO_SAMP_RATE_32K |
+                                       AUDIO_SAMP_RATE_44K |
+                                       AUDIO_SAMP_RATE_48K;
               break;
 
             case AUDIO_FMT_MP3:

--- a/drivers/audio/cs4344.c
+++ b/drivers/audio/cs4344.c
@@ -358,8 +358,6 @@ static int cs4344_getcaps(FAR struct audio_lowerhalf_s *dev, int type,
   DEBUGASSERT(caps && caps->ac_len >= sizeof(struct audio_caps_s));
   audinfo("type=%d ac_type=%d\n", type, caps->ac_type);
 
-  uint16_t *ptr;
-
   /* Fill in the caller's structure based on requested info */
 
   caps->ac_format.hw  = 0;
@@ -418,8 +416,7 @@ static int cs4344_getcaps(FAR struct audio_lowerhalf_s *dev, int type,
 
               /* Report the Sample rates we support */
 
-              ptr  = (FAR uint16_t *)caps->ac_controls.b;
-              *ptr =
+              caps->ac_controls.hw[0] =
                 AUDIO_SAMP_RATE_16K | AUDIO_SAMP_RATE_22K |
                 AUDIO_SAMP_RATE_32K | AUDIO_SAMP_RATE_44K |
                 AUDIO_SAMP_RATE_48K;

--- a/drivers/audio/cs43l22.c
+++ b/drivers/audio/cs43l22.c
@@ -522,8 +522,6 @@ static int cs43l22_getcaps(FAR struct audio_lowerhalf_s *dev, int type,
   DEBUGASSERT(caps && caps->ac_len >= sizeof(struct audio_caps_s));
   audinfo("type=%d ac_type=%d\n", type, caps->ac_type);
 
-  uint16_t *ptr;
-
   /* Fill in the caller's structure based on requested info */
 
   caps->ac_format.hw  = 0;
@@ -582,8 +580,7 @@ static int cs43l22_getcaps(FAR struct audio_lowerhalf_s *dev, int type,
 
               /* Report the Sample rates we support */
 
-              ptr  = (FAR uint16_t *)caps->ac_controls.b;
-              *ptr =
+              caps->ac_controls.hw[0] =
                 AUDIO_SAMP_RATE_8K | AUDIO_SAMP_RATE_11K |
                 AUDIO_SAMP_RATE_16K | AUDIO_SAMP_RATE_22K |
                 AUDIO_SAMP_RATE_32K | AUDIO_SAMP_RATE_44K |

--- a/drivers/audio/es8311.c
+++ b/drivers/audio/es8311.c
@@ -802,8 +802,6 @@ static int es8311_getcaps(FAR struct audio_lowerhalf_s *dev, int type,
   DEBUGASSERT(caps && caps->ac_len >= sizeof(struct audio_caps_s));
   audinfo("getcaps: type=%d ac_type=%d\n", type, caps->ac_type);
 
-  uint16_t *ptr;
-
   /* Fill in the caller's structure based on requested info */
 
   caps->ac_format.hw  = 0;
@@ -847,8 +845,7 @@ static int es8311_getcaps(FAR struct audio_lowerhalf_s *dev, int type,
 
               /* 8kHz is hardware dependent */
 
-              ptr  = (FAR uint16_t *)caps->ac_controls.b;
-              *ptr =
+              caps->ac_controls.hw[0] =
                 AUDIO_SAMP_RATE_11K | AUDIO_SAMP_RATE_16K |
                 AUDIO_SAMP_RATE_22K | AUDIO_SAMP_RATE_32K |
                 AUDIO_SAMP_RATE_44K | AUDIO_SAMP_RATE_48K;
@@ -865,8 +862,7 @@ static int es8311_getcaps(FAR struct audio_lowerhalf_s *dev, int type,
           {
               /* Report supported input sample rates */
 
-              ptr  = (FAR uint16_t *)caps->ac_controls.b;
-              *ptr =
+              caps->ac_controls.hw[0] =
                 AUDIO_SAMP_RATE_11K | AUDIO_SAMP_RATE_16K |
                 AUDIO_SAMP_RATE_22K | AUDIO_SAMP_RATE_32K |
                 AUDIO_SAMP_RATE_44K | AUDIO_SAMP_RATE_48K;

--- a/drivers/audio/es8388.c
+++ b/drivers/audio/es8388.c
@@ -773,8 +773,6 @@ static int es8388_getcaps(FAR struct audio_lowerhalf_s *dev, int type,
   DEBUGASSERT(caps && caps->ac_len >= sizeof(struct audio_caps_s));
   audinfo("getcaps: type=%d ac_type=%d\n", type, caps->ac_type);
 
-  uint16_t *ptr;
-
   /* Fill in the caller's structure based on requested info */
 
   caps->ac_format.hw  = 0;
@@ -830,8 +828,7 @@ static int es8388_getcaps(FAR struct audio_lowerhalf_s *dev, int type,
 
               /* 8kHz is hardware dependent */
 
-              ptr  = (FAR uint16_t *)caps->ac_controls.b;
-              *ptr =
+              caps->ac_controls.hw[0] =
                 AUDIO_SAMP_RATE_11K | AUDIO_SAMP_RATE_16K |
                 AUDIO_SAMP_RATE_22K | AUDIO_SAMP_RATE_32K |
                 AUDIO_SAMP_RATE_44K | AUDIO_SAMP_RATE_48K;
@@ -853,8 +850,7 @@ static int es8388_getcaps(FAR struct audio_lowerhalf_s *dev, int type,
 
               /* Report supported input sample rates */
 
-              ptr  = (FAR uint16_t *)caps->ac_controls.b;
-              *ptr =
+              caps->ac_controls.hw[0] =
                 AUDIO_SAMP_RATE_11K | AUDIO_SAMP_RATE_16K |
                 AUDIO_SAMP_RATE_22K | AUDIO_SAMP_RATE_32K |
                 AUDIO_SAMP_RATE_44K | AUDIO_SAMP_RATE_48K;

--- a/drivers/audio/vs1053.c
+++ b/drivers/audio/vs1053.c
@@ -564,8 +564,6 @@ static int vs1053_getcaps(FAR struct audio_lowerhalf_s *lower, int type,
 
   DEBUGASSERT(caps->ac_len >= sizeof(struct audio_caps_s));
 
-  uint16_t *ptr;
-
   /* Fill in the caller's structure based on requested info */
 
   caps->ac_format.hw  = 0;
@@ -649,14 +647,13 @@ static int vs1053_getcaps(FAR struct audio_lowerhalf_s *lower, int type,
 
               /* Report the Sample rates we support */
 
-              ptr  = (FAR uint16_t *)caps->ac_controls.b;
-              *ptr = AUDIO_SAMP_RATE_8K  |
-                     AUDIO_SAMP_RATE_11K |
-                     AUDIO_SAMP_RATE_16K |
-                     AUDIO_SAMP_RATE_22K |
-                     AUDIO_SAMP_RATE_32K |
-                     AUDIO_SAMP_RATE_44K |
-                     AUDIO_SAMP_RATE_48K;
+              caps->ac_controls.hw[0] = AUDIO_SAMP_RATE_8K  |
+                                        AUDIO_SAMP_RATE_11K |
+                                        AUDIO_SAMP_RATE_16K |
+                                        AUDIO_SAMP_RATE_22K |
+                                        AUDIO_SAMP_RATE_32K |
+                                        AUDIO_SAMP_RATE_44K |
+                                        AUDIO_SAMP_RATE_48K;
               break;
 
             case AUDIO_FMT_MP3:

--- a/drivers/audio/wm8904.c
+++ b/drivers/audio/wm8904.c
@@ -957,8 +957,6 @@ static int wm8904_getcaps(FAR struct audio_lowerhalf_s *dev, int type,
   DEBUGASSERT(caps && caps->ac_len >= sizeof(struct audio_caps_s));
   audinfo("type=%d ac_type=%d\n", type, caps->ac_type);
 
-  uint16_t *ptr;
-
   /* Fill in the caller's structure based on requested info */
 
   caps->ac_format.hw  = 0;
@@ -1018,8 +1016,7 @@ static int wm8904_getcaps(FAR struct audio_lowerhalf_s *dev, int type,
 
               /* Report the Sample rates we support */
 
-              ptr  = (FAR uint16_t *)caps->ac_controls.b;
-              *ptr =
+              caps->ac_controls.hw[0] =
                 AUDIO_SAMP_RATE_8K | AUDIO_SAMP_RATE_11K |
                 AUDIO_SAMP_RATE_16K | AUDIO_SAMP_RATE_22K |
                 AUDIO_SAMP_RATE_32K | AUDIO_SAMP_RATE_44K |

--- a/drivers/audio/wm8994.c
+++ b/drivers/audio/wm8994.c
@@ -655,8 +655,6 @@ static int wm8994_getcaps(FAR struct audio_lowerhalf_s *dev, int type,
   DEBUGASSERT(caps && caps->ac_len >= sizeof(struct audio_caps_s));
   audinfo("type=%d ac_type=%d\n", type, caps->ac_type);
 
-  uint16_t *ptr;
-
   /* Fill in the caller's structure based on requested info */
 
   caps->ac_format.hw  = 0;
@@ -716,8 +714,7 @@ static int wm8994_getcaps(FAR struct audio_lowerhalf_s *dev, int type,
 
               /* Report the Sample rates we support */
 
-              ptr  = (FAR uint16_t *)caps->ac_controls.b;
-              *ptr =
+              caps->ac_controls.hw[0] =
                 AUDIO_SAMP_RATE_8K | AUDIO_SAMP_RATE_11K |
                 AUDIO_SAMP_RATE_16K | AUDIO_SAMP_RATE_22K |
                 AUDIO_SAMP_RATE_32K | AUDIO_SAMP_RATE_44K |


### PR DESCRIPTION
## Summary
use ac_controls.hw to get the correct sample rate intead of ac_controls.b

## Impact

## Testing

