### PR TITLE
libc: compile stackchk function by default

### DIFF
--- a/libs/libc/assert/CMakeLists.txt
+++ b/libs/libc/assert/CMakeLists.txt
@@ -18,11 +18,7 @@
 #
 # ##############################################################################
 
-set(SRCS lib_assert.c)
-
-if(CONFIG_STACK_CANARIES)
-  list(APPEND SRCS lib_stackchk.c)
-endif()
+set(SRCS lib_assert.c lib_stackchk.c)
 
 if(CONFIG_ARCH_TOOLCHAIN_GNU AND NOT CONFIG_LTO_NONE)
   set_source_files_properties(lib_assert.c DIRECTORY .. PROPERTIES COMPILE_FLAGS

--- a/libs/libc/assert/Make.defs
+++ b/libs/libc/assert/Make.defs
@@ -18,11 +18,7 @@
 #
 ############################################################################
 
-CSRCS += lib_assert.c
-
-ifeq ($(CONFIG_STACK_CANARIES),y)
-CSRCS += lib_stackchk.c
-endif
+CSRCS += lib_assert.c lib_stackchk.c
 
 ifeq ($(CONFIG_ARCH_TOOLCHAIN_GNU),y)
   ifeq ($(CONFIG_LTO_NONE),n)

--- a/libs/libc/assert/lib_stackchk.c
+++ b/libs/libc/assert/lib_stackchk.c
@@ -24,8 +24,6 @@
 
 #include <assert.h>
 
-#ifdef CONFIG_STACK_CANARIES
-
 /****************************************************************************
  * Public Data
  ****************************************************************************/
@@ -56,5 +54,3 @@ void __stack_chk_fail(void)
 {
   PANIC();
 }
-
-#endif /* CONFIG_STACK_CANARIES */


### PR DESCRIPTION
## Summary
compile stackchk function by default

## Impact

## Testing

