### PR TITLE
arch/arm: enable WFI in arm_idle.c

### DIFF
--- a/arch/arm/src/common/arm_idle.c
+++ b/arch/arm/src/common/arm_idle.c
@@ -56,8 +56,6 @@ void up_idle(void)
 
   /* Sleep until an interrupt occurs to save power */
 
-#if 0
-  asm("WFI");  /* For example */
-#endif
+  asm("WFI");
 #endif
 }


### PR DESCRIPTION
## Summary

This enables use of WFI in default up_idle() in `arm_idle.c` to avoid busy loops on targets.

## Impacts

arch/arm devices using default `up_idle()`

## Testing

- local check with `qemu-armv7a`
- CI checks
