### PR TITLE
arm/qemu: enable WFI in `up_idle`

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -657,6 +657,7 @@ config ARCH_CHIP_QEMU_ARM
 	select ARCH_HAVE_PSCI
 	select ARCH_HAVE_POWEROFF
 	select ARCH_HAVE_RESET
+	select ARCH_IDLE_CUSTOM
 	---help---
 		QEMU virt platform (ARMv7a)
 

--- a/arch/arm/src/qemu/CMakeLists.txt
+++ b/arch/arm/src/qemu/CMakeLists.txt
@@ -18,7 +18,8 @@
 #
 # ##############################################################################
 
-set(SRCS qemu_boot.c qemu_serial.c qemu_irq.c qemu_timer.c qemu_memorymap.c)
+set(SRCS qemu_boot.c qemu_serial.c qemu_irq.c qemu_timer.c qemu_memorymap.c
+         qemu_idle.c)
 
 if(CONFIG_SMP)
   list(APPEND SRCS qemu_cpuboot.c)

--- a/arch/arm/src/qemu/Make.defs
+++ b/arch/arm/src/qemu/Make.defs
@@ -22,6 +22,7 @@ include armv7-a/Make.defs
 
 # qemu-specific C source files
 CHIP_CSRCS  = qemu_boot.c qemu_serial.c qemu_irq.c qemu_timer.c qemu_memorymap.c
+CHIP_CSRCS += qemu_idle.c
 
 ifeq ($(CONFIG_SMP),y)
   CHIP_CSRCS += qemu_cpuboot.c

--- a/arch/arm/src/qemu/qemu_idle.c
+++ b/arch/arm/src/qemu/qemu_idle.c
@@ -1,0 +1,61 @@
+/****************************************************************************
+ * arch/arm/src/qemu/qemu_idle.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <nuttx/arch.h>
+#include "arm_internal.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_idle
+ *
+ * Description:
+ *   up_idle() is the logic that will be executed when there is no other
+ *   ready-to-run task.  This is processor idle time and will continue until
+ *   some interrupt occurs to cause a context switch from the idle task.
+ *
+ *   Processing in this state may be processor-specific. e.g., this is where
+ *   power management operations might be performed.
+ *
+ ****************************************************************************/
+
+void up_idle(void)
+{
+#if defined(CONFIG_SUPPRESS_INTERRUPTS) || defined(CONFIG_SUPPRESS_TIMER_INTS)
+  /* If the system is idle and there are no timer interrupts, then process
+   * "fake" timer interrupts. Hopefully, something will wake up.
+   */
+
+  nxsched_process_timer();
+#else
+
+  /* Sleep until an interrupt occurs to save power */
+
+  asm("WFI");
+#endif
+}


### PR DESCRIPTION
## Summary

This adds WFI based `qemu_idle.c` to avoid busy loops.

## Impacts

arm/qemu device

## Testing

- local check with `qemu-armv7a`
- CI checks
