### PR TITLE
net/tcp_timer: fix tcp_timer idle loop and retransmission bug

### DIFF
--- a/net/tcp/tcp_input.c
+++ b/net/tcp/tcp_input.c
@@ -1028,6 +1028,7 @@ found:
     {
       uint32_t unackseq;
       uint32_t ackseq;
+      int timeout;
 
       /* The next sequence number is equal to the current sequence
        * number (sndseq) plus the size of the outstanding, unacknowledged
@@ -1137,9 +1138,20 @@ found:
 
       flags |= TCP_ACKDATA;
 
+      /* Check if no packet need to retransmission, clear timer. */
+
+      if (conn->tx_unacked == 0 && conn->tcpstateflags == TCP_ESTABLISHED)
+        {
+          timeout = 0;
+        }
+      else
+        {
+          timeout = conn->rto;
+        }
+
       /* Reset the retransmission timer. */
 
-      tcp_update_retrantimer(conn, conn->rto);
+      tcp_update_retrantimer(conn, timeout);
     }
 
   /* Check if the sequence number of the incoming packet is what we are
@@ -1208,10 +1220,6 @@ found:
           /* Window updated, set the acknowledged flag. */
 
           flags |= TCP_ACKDATA;
-
-          /* Reset the retransmission timer. */
-
-          tcp_update_retrantimer(conn, conn->rto);
         }
     }
 

--- a/net/tcp/tcp_send.c
+++ b/net/tcp/tcp_send.c
@@ -55,6 +55,7 @@
 #include <nuttx/net/netstats.h>
 #include <nuttx/net/ip.h>
 #include <nuttx/net/tcp.h>
+#include <nuttx/wqueue.h>
 
 #include "netdev/netdev.h"
 #include "devif/devif.h"
@@ -146,6 +147,12 @@ static void tcp_sendcommon(FAR struct net_driver_s *dev,
     }
   else
     {
+      if (work_available(&conn->work) && conn->tx_unacked != 0)
+        {
+          conn->timeout = false;
+          tcp_update_retrantimer(conn, conn->rto);
+        }
+
       /* Update the TCP received window based on I/O buffer availability */
 
       uint32_t rcvseq = tcp_getsequence(conn->rcvseq);


### PR DESCRIPTION
## Summary
Interrupt the tcp_timer loop when idle, add it when starting work

## Impact
TCP network / retransmit

## Testing
Retransmission test on SIM with iperf3 (ps: iperf3 -u at the start and end have TCP stat exchange ,so during the testing TCP timer will be canceled)

[SIM] iperf3 -c 120.26.1.167 -u -t 20 -i 1
[Ubuntu during iperf3 test ] iptables -I FORWARD -p tcp --dport 5201 -j DROP

### test result
we can see packets with tcpdump at end of iperf3 and it will retransmit 8 times and can closed.
we also can see tcp timer canceled during iperf3 test by adding debug msg.
