### PR TITLE
timer/alarm: move g_current_tick to oneshot_lowerhalf_s

### DIFF
--- a/drivers/timers/arch_alarm.c
+++ b/drivers/timers/arch_alarm.c
@@ -45,10 +45,6 @@
 
 static FAR struct oneshot_lowerhalf_s *g_oneshot_lower;
 
-#ifndef CONFIG_SCHED_TICKLESS
-static clock_t g_current_tick;
-#endif
-
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
@@ -140,7 +136,7 @@ static void oneshot_callback(FAR struct oneshot_lowerhalf_s *lower,
       clock_t next;
 
       nxsched_process_timer();
-      next = ++g_current_tick;
+      next = ++lower->current_tick;
       ONESHOT_TICK_CURRENT(g_oneshot_lower, &now);
       delta = next - now;
     }
@@ -166,7 +162,7 @@ void up_alarm_set_lowerhalf(FAR struct oneshot_lowerhalf_s *lower)
   ONESHOT_TICK_MAX_DELAY(g_oneshot_lower, &ticks);
   g_oneshot_maxticks = ticks < UINT32_MAX ? ticks : UINT32_MAX;
 #else
-  ONESHOT_TICK_CURRENT(g_oneshot_lower, &g_current_tick);
+  ONESHOT_TICK_CURRENT(g_oneshot_lower, &lower->current_tick);
   ONESHOT_TICK_START(g_oneshot_lower, oneshot_callback, NULL, 1);
 #endif
 }

--- a/include/nuttx/timers/oneshot.h
+++ b/include/nuttx/timers/oneshot.h
@@ -229,6 +229,10 @@ struct oneshot_lowerhalf_s
 
   FAR const struct oneshot_operations_s *ops;
 
+#ifndef CONFIG_SCHED_TICKLESS
+  clock_t current_tick;
+#endif
+
   /* Private lower half data may follow */
 };
 


### PR DESCRIPTION
## Summary

timer/alarm: move g_current_tick to oneshot_lowerhalf_s

move g_current_tick to oneshot_lowerhalf_s



## Impact

N/A

## Testing

ci-check