### PR TITLE
Fix task_setup race condition

### DIFF
--- a/sched/sched/sched_gettcb.c
+++ b/sched/sched/sched_gettcb.c
@@ -56,7 +56,7 @@ FAR struct tcb_s *nxsched_get_tcb(pid_t pid)
   irqstate_t flags;
   int hash_ndx;
 
-  flags = spin_lock_irqsave_wo_note(NULL);
+  flags = enter_critical_section();
 
   /* Verify whether g_pidhash hash table has already been allocated and
    * whether the PID is within range.
@@ -84,7 +84,7 @@ FAR struct tcb_s *nxsched_get_tcb(pid_t pid)
         }
     }
 
-  spin_unlock_irqrestore_wo_note(NULL, flags);
+  leave_critical_section(flags);
 
   /* Return the TCB. */
 


### PR DESCRIPTION
## Summary
When a large number of threads are created in SMP, malloc in nxtask_assign_pid may cause thread switching and create new threads. This may lead to accessing invalid pointers.

## Impact

## Testing

