### PR TITLE
arm/spinlock: up_testset() sould not depends on SMP 

### DIFF
--- a/arch/arm/include/spinlock.h
+++ b/arch/arm/include/spinlock.h
@@ -114,7 +114,7 @@ typedef uint8_t spinlock_t;
  *
  ****************************************************************************/
 
-#if defined(CONFIG_ARCH_HAVE_TESTSET) && defined(CONFIG_SMP) \
+#if defined(CONFIG_ARCH_HAVE_TESTSET) \
     && !defined(CONFIG_ARCH_CHIP_LC823450) \
     && !defined(CONFIG_ARCH_CHIP_CXD56XX) \
     && !defined(CONFIG_ARCH_CHIP_RP2040)


### PR DESCRIPTION
## Summary

arm/spinlock: up_testset() sould not depends on SMP

up_testset() sould not depends on SMP

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

ci-check