### PR TITLE
boards/risc-v/esp32c6/esp32c6-devkitm: Add support to RFID MFRC522

### DIFF
--- a/boards/risc-v/esp32c6/common/include/esp_board_mfrc522.h
+++ b/boards/risc-v/esp32c6/common/include/esp_board_mfrc522.h
@@ -1,0 +1,71 @@
+/****************************************************************************
+ * boards/risc-v/esp32c6/common/include/esp_board_mfrc522.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __BOARDS_RISCV_ESP32C6_COMMON_INCLUDE_ESP_BOARD_MFRC522_H
+#define __BOARDS_RISCV_ESP32C6_COMMON_INCLUDE_ESP_BOARD_MFRC522_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifndef __ASSEMBLY__
+
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: esp32_board_mfrc522i_initialize
+ *
+ * Description:
+ *   Initialize and register the MFRC522 RFID driver.
+ *
+ * Input Parameters:
+ *   devpath - The full path to the driver to register. E.g., "/dev/rfid0"
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int board_mfrc522_initialize(const char *devpath);
+
+#undef EXTERN
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* __ASSEMBLY__ */
+#endif /* __BOARDS_RISCV_ESP32C6_COMMON_INCLUDE_ESP_BOARD_MFRC522_H */

--- a/boards/risc-v/esp32c6/common/src/Make.defs
+++ b/boards/risc-v/esp32c6/common/src/Make.defs
@@ -64,6 +64,10 @@ ifeq ($(CONFIG_ESP_MCPWM),y)
   CSRCS += esp_board_mcpwm.c
 endif
 
+ifeq ($(CONFIG_CL_MFRC522),y)
+  CSRCS += esp_board_mfrc522.c
+endif
+
 DEPPATH += --dep-path src
 VPATH += :src
 CFLAGS += ${INCDIR_PREFIX}$(TOPDIR)$(DELIM)arch$(DELIM)$(CONFIG_ARCH)$(DELIM)src$(DELIM)board$(DELIM)src

--- a/boards/risc-v/esp32c6/common/src/esp_board_mfrc522.c
+++ b/boards/risc-v/esp32c6/common/src/esp_board_mfrc522.c
@@ -1,0 +1,92 @@
+/****************************************************************************
+ * boards/risc-v/esp32c6/common/src/esp_board_mfrc522.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <errno.h>
+#include <debug.h>
+
+#include <nuttx/board.h>
+#include <nuttx/spi/spi.h>
+#include <nuttx/contactless/mfrc522.h>
+
+#include "espressif/esp_spi.h"
+
+#include "esp_board_mfrc522.h"
+
+#if defined(CONFIG_ESPRESSIF_SPI2) && defined(CONFIG_CL_MFRC522)
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define MFRC522_SPI_PORTNO 2   /* On SPI2 */
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: esp32_board_mfrc522_initialize
+ *
+ * Description:
+ *   Initialize and register the MFRC522 RFID driver.
+ *
+ * Input Parameters:
+ *   devpath - The full path to the driver to register. E.g., "/dev/rfid0"
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int board_mfrc522_initialize(const char *devpath)
+{
+  struct spi_dev_s *spi;
+  int ret;
+
+  syslog(LOG_INFO, "Initializing %s...\n", devpath);
+
+  /* Initialize SPI device */
+
+  spi = esp_spibus_initialize(MFRC522_SPI_PORTNO);
+  if (spi == NULL)
+    {
+      syslog(LOG_ERR, "Failed to initialize %s.\n", devpath);
+      return -ENODEV;
+    }
+
+  /* Then register the MFRC522 */
+
+  ret = mfrc522_register(devpath, spi);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "Failed to register %s: %d\n", devpath, ret);
+      esp_spibus_uninitialize(spi);
+    }
+
+  return ret;
+}
+
+#endif /* CONFIG_SPI && CONFIG_MFRC522 */

--- a/boards/risc-v/esp32c6/esp32c6-devkitm/src/esp32c6_bringup.c
+++ b/boards/risc-v/esp32c6/esp32c6-devkitm/src/esp32c6_bringup.c
@@ -89,6 +89,10 @@
 #  include "esp_board_spislavedev.h"
 #endif
 
+#ifdef CONFIG_CL_MFRC522
+  #include "esp_board_mfrc522.h"
+#endif
+
 #include "esp32c6-devkitm.h"
 
 /****************************************************************************
@@ -335,6 +339,14 @@ int esp_bringup(void)
       syslog(LOG_ERR, "ERROR: board_ledc_setup() failed: %d\n", ret);
     }
 #endif /* CONFIG_ESPRESSIF_LEDC */
+
+#ifdef CONFIG_CL_MFRC522
+  ret = board_mfrc522_initialize("/dev/rfid0");
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: board_mfrc522_initialize() failed: %d\n", ret);
+    }
+#endif
 
   /* If we got here then perhaps not all initialization was successful, but
    * at least enough succeeded to bring-up NSH with perhaps reduced


### PR DESCRIPTION
## Summary
  This patch adds support to use rfid card reader MFRC522 on SPI2 for esp32c6-devkitm board

## Impact
  New feature

## Testing
  1-  Enable SPI2;
  2 - Contactless device drive;
  3 - Rfid_readuid example app;
  4 - Build;
  5 - Flash;
  6 - Run example. 
