### PR TITLE
nuttx/crypto: fix wrong implementation in crypto module 

### DIFF
--- a/crypto/cryptodev.c
+++ b/crypto/cryptodev.c
@@ -592,7 +592,7 @@ int cryptodev_key(FAR struct crypt_kop *kop)
         if (in == 3 && out == 1)
           break;
         return -EINVAL;
-      case CRK_RSA_PCKS15_VERIFY:
+      case CRK_RSA_PKCS15_VERIFY:
         if (in == 5 && out == 0)
           break;
         return -EINVAL;

--- a/crypto/cryptosoft.c
+++ b/crypto/cryptosoft.c
@@ -97,7 +97,7 @@ int swcr_encdec(FAR struct cryptop *crp, FAR struct cryptodesc *crd,
         {
           /* Get IV off buf */
 
-          bcopy(crd->crd_iv, buf + crd->crd_inject, ivlen);
+          bcopy(buf + crd->crd_inject, crd->crd_iv, ivlen);
         }
     }
 
@@ -1164,7 +1164,7 @@ int swcr_kprocess(struct cryptkop *krp)
 
   switch (krp->krp_op)
     {
-      case CRK_RSA_PCKS15_VERIFY:
+      case CRK_RSA_PKCS15_VERIFY:
         if ((krp->krp_status = swcr_rsa_verify(krp)) != 0)
           {
             goto done;
@@ -1235,6 +1235,6 @@ void swcr_init(void)
   crypto_register(swcr_id, algs, swcr_newsession,
                   swcr_freesession, swcr_process);
 
-  kalgs[CRK_RSA_PCKS15_VERIFY] = CRYPTO_ALG_FLAG_SUPPORTED;
+  kalgs[CRK_RSA_PKCS15_VERIFY] = CRYPTO_ALG_FLAG_SUPPORTED;
   crypto_kregister(swcr_id, kalgs, swcr_kprocess);
 }

--- a/crypto/poly1305.c
+++ b/crypto/poly1305.c
@@ -236,9 +236,9 @@ void poly1305_update(FAR poly1305_state *st,
 
   if (bytes)
     {
-      for (i = 0; i < bytes; i++)
+      for (i = 0; i < bytes && i < poly1305_block_size; i++)
         {
-          st->buffer[st->leftover + i] = m[i];
+          st->buffer[i] = m[i];
         }
 
       st->leftover += bytes;

--- a/include/crypto/cryptodev.h
+++ b/include/crypto/cryptodev.h
@@ -248,7 +248,7 @@ struct crypt_kop
 #define CRK_DSA_SIGN          2
 #define CRK_DSA_VERIFY        3
 #define CRK_DH_COMPUTE_KEY    4
-#define CRK_RSA_PCKS15_VERIFY 5
+#define CRK_RSA_PKCS15_VERIFY 5
 #define CRK_ALGORITHM_MAX     5 /* Keep updated */
 
 #define CRF_MOD_EXP           (1 << CRK_MOD_EXP)
@@ -256,7 +256,7 @@ struct crypt_kop
 #define CRF_DSA_SIGN          (1 << CRK_DSA_SIGN)
 #define CRF_DSA_VERIFY        (1 << CRK_DSA_VERIFY)
 #define CRF_DH_COMPUTE_KEY    (1 << CRK_DH_COMPUTE_KEY)
-#define CRF_RSA_PCKS15_VERIFY (1 << CRK_RSA_PCKS15_VERIFY)
+#define CRF_RSA_PKCS15_VERIFY (1 << CRK_RSA_PKCS15_VERIFY)
 
 struct cryptkop
 {


### PR DESCRIPTION
## Summary
1. Fix copy iv direction error in symmetric encryption
2. Fix type in rsa verify
3. Fix false positive '-Wstringop-overflow' warning in poly1305 file
## Impact

## Testing

