### PR TITLE
tools/ci: Add more bindings apps for QEMU RISC-V.

### DIFF
--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -69,6 +69,34 @@ RUN mkdir -p $CARGO_HOME \
   && $CARGO_HOME/bin/rustup target add thumbv7m-none-eabi \
   && $CARGO_HOME/bin/rustup target add riscv64gc-unknown-none-elf
 
+# Install Swift
+ENV SWIFT_VERSION=6.0-DEVELOPMENT-SNAPSHOT-2024-08-22-a
+ENV SWIFT_HOME=/tools/swift
+RUN mkdir -p ${SWIFT_HOME} \
+    && curl -s -O -L https://download.swift.org/swift-6.0-branch/ubuntu2204/swift-${SWIFT_VERSION}/swift-${SWIFT_VERSION}-ubuntu22.04.tar.gz \
+    && tar xzf swift-${SWIFT_VERSION}-ubuntu22.04.tar.gz -C ${SWIFT_HOME} \
+    && rm swift-${SWIFT_VERSION}-ubuntu22.04.tar.gz
+
+# Install Zig latest release
+ENV ZIG_VERSION=0.13.0
+ENV ZIG_HOME=/tools/zig
+RUN mkdir -p ${ZIG_HOME} \
+    && curl -s -O -L https://github.com/marler8997/zigup/releases/download/v2024_05_05/zigup-x86_64-linux.tar.gz \
+    && tar xzf zigup-x86_64-linux.tar.gz -C ${ZIG_HOME} \
+    && rm zigup-x86_64-linux.tar.gz \
+    && chmod +x ${ZIG_HOME}/zigup \
+    && ${ZIG_HOME}/zigup fetch --install-dir ${ZIG_HOME} ${ZIG_VERSION} \
+    && chmod +x ${ZIG_HOME}/${ZIG_VERSION}/files/zig
+
+
+# Install LDC2 latest release
+ENV LDC_VERSION=1.39.0
+ENV D_HOME=/tools/ldc2
+RUN mkdir -p ${D_HOME} \
+    && curl -s -O -L https://github.com/ldc-developers/ldc/releases/download/v${LDC_VERSION}/ldc2-${LDC_VERSION}-linux-x86_64.tar.xz \
+    && tar xf ldc2-${LDC_VERSION}-linux-x86_64.tar.xz -C ${D_HOME} \
+    && rm ldc2-${LDC_VERSION}-linux-x86_64.tar.xz
+
 RUN mkdir /tools/gn -p \
   && cd /tools/gn \
   && git clone https://gn.googlesource.com/gn gn \
@@ -382,6 +410,18 @@ COPY --from=nuttx-tools /tools/rust/ /tools/rust/
 ENV CARGO_HOME=/tools/rust/cargo
 ENV RUSTUP_HOME=/tools/rust/rustup
 ENV PATH="/tools/rust/cargo/bin:$PATH"
+
+# Pull in the Zig v0.13.0 toolchain
+COPY --from=nuttx-tools /tools/zig/ /tools/zig/
+ENV PATH="/tools/zig/0.13.0/files:$PATH"
+
+# Pull in the ldc2 1.39.0 toolchain
+COPY --from=nuttx-tools /tools/ldc2/ /tools/ldc2/
+ENV PATH="/tools/ldc2/ldc2-1.39.0-linux-x86_64/bin:$PATH"
+
+# Pull in the swift 6.0 toolchain
+COPY --from=nuttx-tools /tools/swift/ /tools/swift/
+ENV PATH="/tools/swift/swift-6.0-DEVELOPMENT-SNAPSHOT-2024-08-22-a/bin:$PATH"
 
 # ARM toolchain
 COPY --from=nuttx-toolchain-arm /tools/clang-arm-none-eabi/ clang-arm-none-eabi/

--- a/tools/ci/platforms/darwin.sh
+++ b/tools/ci/platforms/darwin.sh
@@ -247,6 +247,20 @@ rust() {
   command rustc --version
 }
 
+dlang() {
+  if ! type ldc2 > /dev/null 2>&1; then
+    brew install ldc
+  fi
+
+  command ldc2 --version | head -n 5
+}
+
+zig() {
+  brew install zig
+
+  command zig cc --version
+}
+
 xtensa_esp32_gcc_toolchain() {
   add_path "${NUTTXTOOLS}"/xtensa-esp32-elf/bin
 
@@ -334,7 +348,7 @@ install_build_tools() {
   mkdir -p "${NUTTXTOOLS}"
   echo "#!/usr/bin/env sh" > "${NUTTXTOOLS}"/env.sh
 
-  install="arm_gcc_toolchain arm64_gcc_toolchain avr_gcc_toolchain binutils bloaty elf_toolchain gen_romfs gperf kconfig_frontends mips_gcc_toolchain python_tools riscv_gcc_toolchain rust xtensa_esp32_gcc_toolchain u_boot_tools util_linux wasi_sdk c_cache"
+  install="arm_gcc_toolchain arm64_gcc_toolchain avr_gcc_toolchain binutils bloaty elf_toolchain gen_romfs gperf kconfig_frontends mips_gcc_toolchain python_tools riscv_gcc_toolchain rust dlang zig xtensa_esp32_gcc_toolchain u_boot_tools util_linux wasi_sdk c_cache"
 
   mkdir -p "${NUTTXTOOLS}"/homebrew
   export HOMEBREW_CACHE=${NUTTXTOOLS}/homebrew

--- a/tools/ci/platforms/ubuntu.sh
+++ b/tools/ci/platforms/ubuntu.sh
@@ -236,6 +236,14 @@ rust() {
   command rustc --version
 }
 
+dlang() {
+  if ! type ldc2 > /dev/null 2>&1; then
+    sudo apt-get install ldc
+  fi
+
+  command ldc2 --version | head -n 5
+}
+
 rx_gcc_toolchain() {
   add_path "${NUTTXTOOLS}"/renesas-toolchain/rx-elf-gcc/bin
 
@@ -436,7 +444,7 @@ install_build_tools() {
   mkdir -p "${NUTTXTOOLS}"
   echo "#!/usr/bin/env sh" > "${NUTTXTOOLS}"/env.sh
 
-  install="arm_clang_toolchain arm_gcc_toolchain arm64_gcc_toolchain avr_gcc_toolchain binutils bloaty clang_tidy gen_romfs gperf kconfig_frontends mips_gcc_toolchain python_tools riscv_gcc_toolchain rust rx_gcc_toolchain sparc_gcc_toolchain xtensa_esp32_gcc_toolchain u_boot_tools util_linux wasi_sdk c_cache"
+  install="arm_clang_toolchain arm_gcc_toolchain arm64_gcc_toolchain avr_gcc_toolchain binutils bloaty clang_tidy gen_romfs gperf kconfig_frontends mips_gcc_toolchain python_tools riscv_gcc_toolchain rust dlang rx_gcc_toolchain sparc_gcc_toolchain xtensa_esp32_gcc_toolchain u_boot_tools util_linux wasi_sdk c_cache"
 
   oldpath=$(cd . && pwd -P)
   for func in ${install}; do


### PR DESCRIPTION
> could you create a new patch to enable hello_swift ci?
> 
>   * [**"Building the Docker Image for NuttX CI"**](https://lupyuen.github.io/articles/pr#appendix-building-the-docker-image-for-nuttx-ci)
> 
>  * [**"Downloading the Docker Image for NuttX CI"**](https://lupyuen.github.io/articles/pr#appendix-downloading-the-docker-image-for-nuttx-ci)


### Reviewers
cc: @lupyuen @xiaoxiang781216 

---

### Steps

Based on #12858, add another languages support on tool/ci.

- **Docker**
  - [x] Zig v0.13.0 support (using zigup - version manager) *static-binary, running any distro.
  - [x] ~~Swiftly support (like, rustup)~~ - no custom install in cli-mode. Use tarball!!
  - [x] ldc2 tarball (no version manager).
- **CI - platforms**
  - brew install: zig, ldc2 - swift only v5 :face_exhaling: 
  - apt-get install: ldc2
  - msys2: no have Swift, D or Zig toolchain. Swift is unstable for Windows (MSVC only)

Tarballs are preferable for Zig and Swift6.