### PR TITLE
greenhills support: fix the build warning while support greenhills build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 *.hex
 *.i
 *.ihx
+*.inf
 *.lib
 *.lod
 *.lst

--- a/drivers/ioexpander/gpio.c
+++ b/drivers/ioexpander/gpio.c
@@ -330,7 +330,7 @@ static int gpio_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
             (FAR enum gpio_pintype_e *)((uintptr_t)arg);
           DEBUGASSERT(ptr != NULL);
 
-          *ptr = dev->gp_pintype;
+          *ptr = (FAR enum gpio_pintype_e)dev->gp_pintype;
           ret = OK;
         }
         break;

--- a/drivers/net/netdev_upperhalf.c
+++ b/drivers/net/netdev_upperhalf.c
@@ -96,9 +96,9 @@ struct netdev_upperhalf_s
 static bool quota_is_valid(FAR struct netdev_lowerhalf_s *lower)
 {
   int total = 0;
-  int type;
+  enum netpkt_type_e type;
 
-  for (type = 0; type < NETPKT_TYPENUM; type++)
+  for (type = NETPKT_TX; type < NETPKT_TYPENUM; type++)
     {
       total += netdev_lower_quota_load(lower, type);
     }

--- a/drivers/spi/spi_transfer.c
+++ b/drivers/spi/spi_transfer.c
@@ -80,7 +80,7 @@ int spi_transfer(FAR struct spi_dev_s *spi, FAR struct spi_sequence_s *seq)
     }
 #endif
 
-  SPI_SETMODE(spi, seq->mode);
+  SPI_SETMODE(spi, (enum spi_mode_e)seq->mode);
   SPI_SETBITS(spi, seq->nbits);
 
   /* Select the SPI device in preparation for the transfer.

--- a/include/nuttx/ioexpander/gpio.h
+++ b/include/nuttx/ioexpander/gpio.h
@@ -150,7 +150,7 @@ struct gpio_dev_s
    * driver when gpio_pin_register() is called.
    */
 
-  uint8_t gp_pintype;  /* See enum gpio_pintype_e */;
+  uint8_t gp_pintype;  /* See enum gpio_pintype_e */
 
   /* Writable storage used by the upper half driver */
 

--- a/include/nuttx/mqueue.h
+++ b/include/nuttx/mqueue.h
@@ -37,7 +37,7 @@
 #include <mqueue.h>
 #include <poll.h>
 
-#if CONFIG_MQ_MAXMSGSIZE > 0
+#if defined(CONFIG_MQ_MAXMSGSIZE) && (CONFIG_MQ_MAXMSGSIZE > 0)
 
 /****************************************************************************
  * Pre-processor Definitions

--- a/include/nuttx/net/netdev.h
+++ b/include/nuttx/net/netdev.h
@@ -274,13 +274,11 @@ struct netdev_varaddr_s
 };
 #endif
 
-#ifdef CONFIG_NET_IPv6
 struct netdev_ifaddr6_s
 {
   net_ipv6addr_t addr; /* Host IPv6 address */
   net_ipv6addr_t mask; /* Network IPv6 subnet mask */
 };
-#endif
 
 /* This structure collects information that is specific to a specific network
  * interface driver.  If the hardware platform supports only a single

--- a/libs/libc/modlib/modlib_bind.c
+++ b/libs/libc/modlib/modlib_bind.c
@@ -731,25 +731,13 @@ static int modlib_relocatedyn(FAR struct module_s *modp,
                 }
             }
 
-          /* Calculate the relocation address. */
-
-          if (rel->r_offset < 0)
-            {
-              berr("ERROR: Section %d reloc %d:"
-                   "Relocation address out of range, offset %u\n",
-                   relidx, i, (int)rel->r_offset);
-              ret = -EINVAL;
-              lib_free(sym);
-              lib_free(rels);
-              lib_free(dyn);
-              return ret;
-            }
-
           /* Now perform the architecture-specific relocation */
 
           if ((idx_sym = ELF_R_SYM(rel->r_info)) != 0)
             {
-              if (sym[idx_sym].st_shndx == SHN_UNDEF) /* We have an external reference */
+              /* We have an external reference */
+
+              if (sym[idx_sym].st_shndx == SHN_UNDEF)
                 {
                     FAR void *ep;
 

--- a/libs/libc/modlib/modlib_globals.S
+++ b/libs/libc/modlib/modlib_globals.S
@@ -33,7 +33,7 @@
 	.endm
 #endif
 
-#if __SIZEOF_POINTER__ == 8
+#if defined(__SIZEOF_POINTER__ ) && __SIZEOF_POINTER__ == 8
 	.macro globalEntry index, ep
 	.quad	.l\index
 	.quad	\ep


### PR DESCRIPTION
## Summary
1. fix the macro misuse warning on ghs compiler
2. fix the enum type misuse warning
3. update the .gitignore rule to exclude the ghs build intermediate files out

## Impact

## Testing

