### PR TITLE
greenhills support: add the "__sync_synchronize" func impl

### DIFF
--- a/libs/libc/machine/arch_atomic.c
+++ b/libs/libc/machine/arch_atomic.c
@@ -754,3 +754,16 @@ SYNC_VAL_CMP_SWAP(4, uint32_t)
 SYNC_VAL_CMP_SWAP(8, uint64_t)
 
 #endif /* __clang__ */
+
+#ifdef __ghs__
+
+/****************************************************************************
+ * Name: __sync_synchronize
+ ****************************************************************************/
+
+void weak_function __sync_synchronize(void)
+{
+  asm volatile("" ::: "memory");
+}
+
+#endif


### PR DESCRIPTION
## Summary
add ghs header file support using to fix the following link error:

 [elxr] (error #412) unresolved symbols: 
 __sync_synchronize 	from libopenamp.a(io.o)

## Impact

## Testing

