### PR TITLE
fs: add fs_heap, support shm/tmpfs/pseudofile with indepent heap

### DIFF
--- a/fs/CMakeLists.txt
+++ b/fs/CMakeLists.txt
@@ -17,7 +17,7 @@
 # the License.
 #
 # ##############################################################################
-nuttx_add_kernel_library(fs fs_initialize.c)
+nuttx_add_kernel_library(fs fs_initialize.c fs_heap.c)
 nuttx_add_subdirectory()
 target_include_directories(fs PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
                                       ${NUTTX_DIR}/sched)

--- a/fs/Kconfig
+++ b/fs/Kconfig
@@ -111,6 +111,14 @@ config SENDFILE_BUFSIZE
 	---help---
 		Size of the I/O buffer to allocate in sendfile().  Default: 512b
 
+config FS_HEAPSIZE
+	int "Independent heap bytes used by shm/tmpfs/pseudofile"
+	default 0
+	depends on FS_SHMFS || FS_TMPFS || PSEUDOFS_FILE
+	---help---
+		Support for shm/tmpfs/fs_pseudofile.c ram based fs memory.
+		default 0 to use kmm directly. independent heap disabled
+
 source "fs/vfs/Kconfig"
 source "fs/aio/Kconfig"
 source "fs/semaphore/Kconfig"

--- a/fs/Makefile
+++ b/fs/Makefile
@@ -20,7 +20,7 @@
 
 include $(TOPDIR)/Make.defs
 
-CSRCS = fs_initialize.c
+CSRCS = fs_initialize.c fs_heap.c
 
 include inode/Make.defs
 include vfs/Make.defs

--- a/fs/fs_heap.c
+++ b/fs/fs_heap.c
@@ -1,0 +1,66 @@
+/****************************************************************************
+ * fs/fs_heap.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include "fs_heap.h"
+
+#if defined(CONFIG_FS_HEAPSIZE) && CONFIG_FS_HEAPSIZE > 0
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static FAR struct mm_heap_s *g_fs_heap;
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void fs_heap_initialize(void)
+{
+  FAR void *buf = kmm_malloc(CONFIG_FS_HEAPSIZE);
+  DEBUGASSERT(buf != NULL);
+  g_fs_heap = mm_initialize("heapfs", buf, CONFIG_FS_HEAPSIZE);
+}
+
+FAR void *fs_heap_zalloc(size_t size)
+{
+  return mm_zalloc(g_fs_heap, size);
+}
+
+size_t fs_heap_malloc_size(FAR void *mem)
+{
+  return mm_malloc_size(g_fs_heap, mem);
+}
+
+FAR void *fs_heap_realloc(FAR void *oldmem, size_t size)
+{
+  return mm_realloc(g_fs_heap, oldmem, size);
+}
+
+void fs_heap_free(FAR void *mem)
+{
+  mm_free(g_fs_heap, mem);
+}
+
+#endif

--- a/fs/fs_heap.h
+++ b/fs/fs_heap.h
@@ -1,0 +1,50 @@
+/****************************************************************************
+ * fs/fs_heap.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __FS_FS_HEAP_H
+#define __FS_FS_HEAP_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/compiler.h>
+#include <nuttx/kmalloc.h>
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#if defined(CONFIG_FS_HEAPSIZE) && CONFIG_FS_HEAPSIZE > 0
+void      fs_heap_initialize(void);
+FAR void *fs_heap_zalloc(size_t size);
+size_t    fs_heap_malloc_size(FAR void *mem);
+FAR void *fs_heap_realloc(FAR void *oldmem, size_t size);
+void      fs_heap_free(FAR void *mem);
+#else
+#  define fs_heap_initialize()
+#  define fs_heap_zalloc       kmm_zalloc
+#  define fs_heap_malloc_size  kmm_malloc_size
+#  define fs_heap_realloc      kmm_realloc
+#  define fs_heap_free         kmm_free
+#endif
+
+#endif

--- a/fs/fs_initialize.c
+++ b/fs/fs_initialize.c
@@ -31,6 +31,7 @@
 #include "inode/inode.h"
 #include "aio/aio.h"
 #include "vfs/lock.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Private Functions
@@ -80,6 +81,8 @@ static struct notifier_block g_sync_nb =
 void fs_initialize(void)
 {
   fs_trace_begin();
+
+  fs_heap_initialize();
 
   /* Initial inode, file, and VFS data structures */
 

--- a/fs/shm/shmfs_alloc.c
+++ b/fs/shm/shmfs_alloc.c
@@ -31,6 +31,7 @@
 #include <nuttx/pgalloc.h>
 
 #include "shm/shmfs.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Public Functions
@@ -54,7 +55,7 @@ FAR struct shmfs_object_s *shmfs_alloc_object(size_t length)
       return NULL;
     }
 
-  object = kmm_zalloc(alloc_size);
+  object = fs_heap_zalloc(alloc_size);
   if (object)
     {
       object->paddr = (FAR char *)(object + 1);
@@ -156,6 +157,6 @@ void shmfs_free_object(FAR struct shmfs_object_s *object)
        * (and the shared memory in case of FLAT build)
        */
 
-      kmm_free(object);
+      fs_heap_free(object);
     }
 }


### PR DESCRIPTION
## Summary
For some case, need large files from tmpfs or shmfs, will lead to high pressure on memory fragments, add a fs_heap to optional support indepent heap for memory fragments issue will benifit.

## Impact
No impact for default case.
If enabled FS_HEAPSIZE, will use a mm_initialize to manage the shm/tmpfs/pseudofile memory

## Testing
CI and Cortex-A7 smp chip.
