### PR TITLE
pty: use mutex to protect alloc minor

### DIFF
--- a/drivers/serial/ptmx.c
+++ b/drivers/serial/ptmx.c
@@ -180,10 +180,10 @@ static int ptmx_open(FAR struct file *filep)
   /* Allocate a PTY minor */
 
   minor = ptmx_minor_allocate();
+  nxmutex_unlock(&g_ptmx.px_lock);
   if (minor < 0)
     {
-      ret = minor;
-      goto errout_with_lock;
+      return minor;
     }
 
   /* Create the master slave pair.  This should create:
@@ -197,7 +197,8 @@ static int ptmx_open(FAR struct file *filep)
   ret = pty_register2(minor, true);
   if (ret < 0)
     {
-      goto errout_with_minor;
+      ptmx_minor_free(minor);
+      return ret;
     }
 
   /* Open the master device:  /dev/ptyN, where N=minor */
@@ -220,15 +221,7 @@ static int ptmx_open(FAR struct file *filep)
   ret = unregister_driver(devname);
   DEBUGASSERT(ret >= 0 || ret == -EBUSY);  /* unregister_driver() should never fail */
 
-  nxmutex_unlock(&g_ptmx.px_lock);
   return OK;
-
-errout_with_minor:
-  ptmx_minor_free(minor);
-
-errout_with_lock:
-  nxmutex_unlock(&g_ptmx.px_lock);
-  return ret;
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

If failed in pty_register2, it is possible to enter unregister_driver function, which eventually calls ptmx_minor_free, resulting in mutex conflict.

## Impact

## Testing

