### PR TITLE
Fixed spacing and typo issues in code comment descriptions

### DIFF
--- a/fs/mmap/fs_mmap.c
+++ b/fs/mmap/fs_mmap.c
@@ -202,7 +202,7 @@ int file_mmap(FAR struct file *filep, FAR void *start, size_t length,
  *        only file system that meets this requirement.
  *     b. The underlying block driver supports the BIOC_XIPBASE ioctl
  *        command that maps the underlying media to a randomly accessible
- *        address. At  present, only the RAM/ROM disk driver does this.
+ *        address. At present, only the RAM/ROM disk driver does this.
  *
  *   2. If CONFIG_FS_RAMMAP is defined in the configuration, then mmap() will
  *      support simulation of memory mapped files by copying files whole

--- a/fs/mmap/fs_munmap.c
+++ b/fs/mmap/fs_munmap.c
@@ -118,19 +118,19 @@ int file_munmap(FAR void *start, size_t length)
  *   1. mmap() is the API that is used to support direct access to random
  *     access media under the following very restrictive conditions:
  *
- *     a. The filesystem impelements the mmap file operation.  Any file
+ *     a. The filesystem implements the mmap file operation.  Any file
  *        system that maps files contiguously on the media should support
  *        this ioctl. (vs. file system that scatter files over the media
  *        in non-contiguous sectors).  As of this writing, ROMFS is the
  *        only file system that meets this requirement.
  *     b. The underlying block driver supports the BIOC_XIPBASE ioctl
  *        command that maps the underlying media to a randomly accessible
- *        address. At  present, only the RAM/ROM disk driver does this.
+ *        address. At present, only the RAM/ROM disk driver does this.
  *
- *     munmap() is still not required in this first case.  In this first
- *     The mapped address is a static address in the MCUs address space
- *     does not need to be munmapped.  Support for munmap() in this case
- *     provided by the simple definition in sys/mman.h:
+ *     munmap() is still not required in this first case. The mapped address
+ *     is a static address in the MCUs address space does not need to be
+ *     munmapped.  Support for munmap() in this case provided by the simple
+ *     definition in sys/mman.h:
  *
  *        #define munmap(start, length)
  *
@@ -141,10 +141,10 @@ int file_munmap(FAR void *start, size_t length)
  *
  * Input Parameters:
  *   start   The start address of the mapping to delete.  For this
- *           simplified munmap() implementation, the *must* be the start
+ *           simplified munmap() implementation, the must be the start
  *           address of the memory region (the same address returned by
  *           mmap()).
- *   length  The length region to be umapped.
+ *   length  The length region to be unmapped.
  *
  * Returned Value:
  *   On success, munmap() returns 0, on failure -1, and errno is set

--- a/sched/environ/env_getenv.c
+++ b/sched/environ/env_getenv.c
@@ -49,7 +49,7 @@
  *   name - The name of the variable to find.
  *
  * Returned Value:
- *   The value of the valiable (read-only) or NULL on failure
+ *   The value of the variable (read-only) or NULL on failure
  *
  * Assumptions:
  *   Not called from an interrupt handler

--- a/sched/environ/env_setenv.c
+++ b/sched/environ/env_setenv.c
@@ -47,7 +47,7 @@
  *
  * Description:
  *   The setenv() function adds the variable name to the environment with the
- *   specified 'value' if the varialbe 'name" does not exist. If the 'name'
+ *   specified 'value' if the variable 'name" does not exist. If the 'name'
  *   does exist in the environment, then its value is changed to 'value' if
  *   'overwrite' is non-zero; if 'overwrite' is zero, then the value of name
  *   unaltered.


### PR DESCRIPTION
1. [env]:Fixed spacing and typo issues in code comment descriptions
2. [FS]:Fixed spacing and typo issues in code comment descriptions
