### PR TITLE
ipfrag: remove assert for actual product reasons

### DIFF
--- a/net/ipfrag/ipfrag.c
+++ b/net/ipfrag/ipfrag.c
@@ -171,8 +171,10 @@ ip_fragout_allocfragbuf(FAR struct iob_queue_s *fragq);
 
 static void ip_fragin_timerout_expiry(wdparm_t arg)
 {
-  ASSERT(g_wkfragtimeout.worker == NULL);
-  work_queue(IPFRAGWORK, &g_wkfragtimeout, ip_fragin_timerwork, NULL, 0);
+  if (g_wkfragtimeout.worker == NULL)
+    {
+      work_queue(IPFRAGWORK, &g_wkfragtimeout, ip_fragin_timerwork, NULL, 0);
+    }
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
If the device's CPU resources are scarce and unable to execute the ip_fragin_timerwork callback in a timely manner, this assert will be triggered. This is a normal scenario that can occur. The logic should be modified to wait for the ip_fragin_timerwork to be executed if it has not been executed yet.
## Impact

## Testing
cortex-m33 board
