### PR TITLE
protected build: userspace threads will unexpectly work in privileged mode after syscall

### DIFF
--- a/arch/arm/include/armv6-m/irq.h
+++ b/arch/arm/include/armv6-m/irq.h
@@ -142,6 +142,7 @@ struct xcpt_syscall_s
 {
   uint32_t excreturn;   /* The EXC_RETURN value */
   uint32_t sysreturn;   /* The return PC */
+  uint32_t ctrlreturn;  /* The return CONTROL value */
 };
 #endif
 

--- a/arch/arm/include/armv7-m/irq.h
+++ b/arch/arm/include/armv7-m/irq.h
@@ -202,6 +202,7 @@ struct xcpt_syscall_s
 {
   uint32_t excreturn;   /* The EXC_RETURN value */
   uint32_t sysreturn;   /* The return PC */
+  uint32_t ctrlreturn;  /* The return CONTROL value */
 };
 #endif
 

--- a/arch/arm/include/armv8-m/irq.h
+++ b/arch/arm/include/armv8-m/irq.h
@@ -213,6 +213,7 @@ struct xcpt_syscall_s
 {
   uint32_t excreturn;   /* The EXC_RETURN value */
   uint32_t sysreturn;   /* The return PC */
+  uint32_t ctrlreturn;  /* The return CONTROL value */
 };
 #endif
 

--- a/arch/arm/src/armv6-m/arm_svcall.c
+++ b/arch/arm/src/armv6-m/arm_svcall.c
@@ -224,6 +224,7 @@ int arm_svcall(int irq, void *context, void *arg)
 
           regs[REG_PC]         = rtcb->xcp.syscall[index].sysreturn;
           regs[REG_EXC_RETURN] = rtcb->xcp.syscall[index].excreturn;
+          regs[REG_CONTROL]    = rtcb->xcp.syscall[index].ctrlreturn;
           rtcb->xcp.nsyscalls  = index;
 
           /* The return value must be in R0-R1.  dispatch_syscall()
@@ -417,6 +418,7 @@ int arm_svcall(int irq, void *context, void *arg)
 
           rtcb->xcp.syscall[index].sysreturn  = regs[REG_PC];
           rtcb->xcp.syscall[index].excreturn  = regs[REG_EXC_RETURN];
+          rtcb->xcp.syscall[index].ctrlreturn = regs[REG_CONTROL];
           rtcb->xcp.nsyscalls  = index + 1;
 
           regs[REG_PC]         = (uint32_t)dispatch_syscall;

--- a/arch/arm/src/armv7-m/arm_svcall.c
+++ b/arch/arm/src/armv7-m/arm_svcall.c
@@ -233,6 +233,7 @@ int arm_svcall(int irq, void *context, void *arg)
 
           regs[REG_PC]         = rtcb->xcp.syscall[index].sysreturn;
           regs[REG_EXC_RETURN] = rtcb->xcp.syscall[index].excreturn;
+          regs[REG_CONTROL]    = rtcb->xcp.syscall[index].ctrlreturn;
           rtcb->xcp.nsyscalls  = index;
 
           /* The return value must be in R0-R1.  dispatch_syscall()
@@ -426,6 +427,7 @@ int arm_svcall(int irq, void *context, void *arg)
 
           rtcb->xcp.syscall[index].sysreturn  = regs[REG_PC];
           rtcb->xcp.syscall[index].excreturn  = regs[REG_EXC_RETURN];
+          rtcb->xcp.syscall[index].ctrlreturn = regs[REG_CONTROL];
           rtcb->xcp.nsyscalls  = index + 1;
 
           regs[REG_PC]         = (uint32_t)dispatch_syscall & ~1;

--- a/arch/arm/src/armv8-m/arm_svcall.c
+++ b/arch/arm/src/armv8-m/arm_svcall.c
@@ -232,6 +232,7 @@ int arm_svcall(int irq, void *context, void *arg)
 
           regs[REG_PC]         = rtcb->xcp.syscall[index].sysreturn;
           regs[REG_EXC_RETURN] = rtcb->xcp.syscall[index].excreturn;
+          regs[REG_CONTROL]    = rtcb->xcp.syscall[index].ctrlreturn;
           rtcb->xcp.nsyscalls  = index;
 
           /* The return value must be in R0-R1.  dispatch_syscall()
@@ -427,6 +428,7 @@ int arm_svcall(int irq, void *context, void *arg)
 
           rtcb->xcp.syscall[index].sysreturn  = regs[REG_PC];
           rtcb->xcp.syscall[index].excreturn  = regs[REG_EXC_RETURN];
+          rtcb->xcp.syscall[index].ctrlreturn = regs[REG_CONTROL];
           rtcb->xcp.nsyscalls  = index + 1;
 
           regs[REG_PC]         = (uint32_t)dispatch_syscall & ~1;


### PR DESCRIPTION
## Summary
In protected build mode, the syscall returns without setting correct value for the CONTROL register, which causes the userspace threads working in the privileged mode after syscall.
## Impact

## Testing

