### PR TITLE
CMake: fix CMake compile errors during the protected build mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -420,6 +420,7 @@ add_executable(nuttx)
 add_custom_target(nuttx_post)
 if(CONFIG_BUILD_PROTECTED)
   add_executable(nuttx_user)
+  nuttx_add_library_internal(nuttx_user)
 endif()
 
 if(CONFIG_ALLSYMS)

--- a/libs/libc/wqueue/CMakeLists.txt
+++ b/libs/libc/wqueue/CMakeLists.txt
@@ -18,7 +18,7 @@
 #
 # ##############################################################################
 
-if(CONFIG_LIB_USRWORK)
+if(CONFIG_LIBC_USRWORK)
   target_sources(c PRIVATE work_usrthread.c work_queue.c work_cancel.c
                            work_signal.c work_lock.c)
 endif()


### PR DESCRIPTION
## Summary
There are 2 CMake compile errors during the protected build mode. One is forget to add library for nuttx_user, another is the wrong macro used when compile wqueue.
## Impact

## Testing

