### PR TITLE
nuttx/crypto: support new algorithm about crc32 and aes-cmac 

### DIFF
--- a/crypto/cryptodev.c
+++ b/crypto/cryptodev.c
@@ -224,6 +224,7 @@ static int cryptof_ioctl(FAR struct file *filep,
             case CRYPTO_BLF_CBC:
             case CRYPTO_CAST_CBC:
             case CRYPTO_AES_CBC:
+            case CRYPTO_AES_CMAC:
             case CRYPTO_AES_CTR:
             case CRYPTO_AES_XTS:
             case CRYPTO_AES_OFB:
@@ -247,6 +248,7 @@ static int cryptof_ioctl(FAR struct file *filep,
             case CRYPTO_SHA2_384_HMAC:
             case CRYPTO_SHA2_512_HMAC:
             case CRYPTO_AES_128_GMAC:
+            case CRYPTO_AES_128_CMAC:
             case CRYPTO_MD5:
             case CRYPTO_POLY1305:
             case CRYPTO_RIPEMD160:
@@ -383,14 +385,6 @@ int cryptodev_op(FAR struct csession *cse,
   FAR struct cryptodesc *crda = NULL;
   int error = OK;
   uint32_t hid;
-
-  if (cse->txform)
-    {
-      if (cop->len == 0)
-        {
-          return -EINVAL;
-        }
-    }
 
   /* number of requests, not logical and */
 

--- a/crypto/cryptodev.c
+++ b/crypto/cryptodev.c
@@ -255,6 +255,7 @@ static int cryptof_ioctl(FAR struct file *filep,
             case CRYPTO_SHA2_256:
             case CRYPTO_SHA2_384:
             case CRYPTO_SHA2_512:
+            case CRYPTO_CRC32:
               thash = true;
               break;
             default:

--- a/crypto/cryptosoft.c
+++ b/crypto/cryptosoft.c
@@ -835,6 +835,10 @@ int swcr_newsession(FAR uint32_t *sid, FAR struct cryptoini *cri)
             axf = &auth_hash_poly1305;
             goto auth4common;
 
+          case CRYPTO_CRC32:
+            axf = &auth_hash_crc32;
+            goto auth4common;
+
           case CRYPTO_CHACHA20_POLY1305_MAC:
             axf = &auth_hash_chacha20_poly1305;
 
@@ -956,6 +960,7 @@ int swcr_freesession(uint64_t tid)
           case CRYPTO_SHA2_256:
           case CRYPTO_SHA2_384:
           case CRYPTO_SHA2_512:
+          case CRYPTO_CRC32:
             axf = swd->sw_axf;
 
             if (swd->sw_ictx)
@@ -1090,6 +1095,7 @@ int swcr_process(struct cryptop *crp)
           case CRYPTO_SHA2_256:
           case CRYPTO_SHA2_384:
           case CRYPTO_SHA2_512:
+          case CRYPTO_CRC32:
             if ((crp->crp_etype = swcr_hash(crp, crd, sw,
                 crp->crp_buf)) != 0)
               {
@@ -1230,6 +1236,7 @@ void swcr_init(void)
   algs[CRYPTO_SHA2_256] = CRYPTO_ALG_FLAG_SUPPORTED;
   algs[CRYPTO_SHA2_384] = CRYPTO_ALG_FLAG_SUPPORTED;
   algs[CRYPTO_SHA2_512] = CRYPTO_ALG_FLAG_SUPPORTED;
+  algs[CRYPTO_CRC32] = CRYPTO_ALG_FLAG_SUPPORTED;
   algs[CRYPTO_ESN] = CRYPTO_ALG_FLAG_SUPPORTED;
 
   crypto_register(swcr_id, algs, swcr_newsession,

--- a/crypto/xform.c
+++ b/crypto/xform.c
@@ -70,6 +70,7 @@
 #include <crypto/cryptodev.h>
 #include <crypto/xform.h>
 #include <crypto/gmac.h>
+#include <crypto/cmac.h>
 #include <crypto/chachapoly.h>
 #include <crypto/poly1305.h>
 #include <nuttx/crc32.h>
@@ -240,6 +241,16 @@ const struct enc_xform enc_xform_aes_gmac =
   NULL
 };
 
+const struct enc_xform enc_xform_aes_cmac =
+{
+  CRYPTO_AES_CMAC, "AES-CMAC",
+  1, 0, 16, 32, 0,
+  null_encrypt,
+  null_decrypt,
+  null_setkey,
+  NULL
+};
+
 const struct enc_xform enc_xform_aes_xts =
 {
   CRYPTO_AES_XTS, "AES-XTS",
@@ -393,6 +404,16 @@ const struct auth_hash auth_hash_chacha20_poly1305 =
   chacha20_poly1305_init, chacha20_poly1305_setkey,
   chacha20_poly1305_reinit, chacha20_poly1305_update,
   chacha20_poly1305_final
+};
+
+const struct auth_hash auth_hash_cmac_aes_128 =
+{
+  CRYPTO_AES_128_CMAC, "CMAC-AES-128",
+  16, AES_CMAC_KEY_LENGTH, AES_CMAC_DIGEST_LENGTH, sizeof(AES_CMAC_CTX),
+  AESCTR_BLOCKSIZE, (void (*)(FAR void *)) aes_cmac_init,
+  (void (*)(FAR void *, FAR const uint8_t *, uint16_t)) aes_cmac_setkey,
+  NULL, (int (*)(FAR void *, FAR const uint8_t *, size_t)) aes_cmac_update,
+  (void (*) (FAR uint8_t *, FAR void *)) aes_cmac_final
 };
 
 const struct auth_hash auth_hash_md5 =

--- a/include/crypto/cryptodev.h
+++ b/include/crypto/cryptodev.h
@@ -125,8 +125,10 @@
 #define CRYPTO_SHA2_384         32
 #define CRYPTO_SHA2_512         33
 #define CRYPTO_CRC32            34
-#define CRYPTO_ESN              35 /* Support for Extended Sequence Numbers */
-#define CRYPTO_ALGORITHM_MAX    35 /* Keep updated */
+#define CRYPTO_AES_CMAC         35
+#define CRYPTO_AES_128_CMAC     36
+#define CRYPTO_ESN              37 /* Support for Extended Sequence Numbers */
+#define CRYPTO_ALGORITHM_MAX    37 /* Keep updated */
 
 /* Algorithm flags */
 
@@ -170,6 +172,7 @@ struct cryptodesc
   #define CRD_F_COMP 0x10          /* Set when doing compression */
   #define CRD_F_ESN 0x20           /* Set when ESN field is provided */
   #define CRD_F_UPDATE 0x40        /* Set just update source */
+  #define CRD_F_UPDATE_AAD 0x80    /* Set just update aad */
 
   struct cryptoini CRD_INI; /* Initialization/context data */
   #define crd_esn CRD_INI.cri_esn
@@ -200,6 +203,7 @@ struct cryptop
                       * value on future requests.
                       */
   int crp_flags;
+  int crp_aadlen;
 
 #define CRYPTO_F_IMBUF 0x0001   /* Input/output are mbuf chains, otherwise contig */
 #define CRYPTO_F_IOV 0x0002     /* Input/output are uio */
@@ -216,6 +220,7 @@ struct cryptop
   caddr_t crp_mac;
   caddr_t crp_dst;
   caddr_t crp_iv;
+  caddr_t crp_aad;
 };
 
 #define CRYPTO_BUF_IOV 0x1
@@ -330,12 +335,19 @@ struct crypt_op
                                    * be used, and the subsequent iv will be saved
                                    * in the driver.
                                    */
+#define COP_FLAG_UPDATE_AAD (1 << 1)
+/* Indicates that this operation processes aad
+ * (Additional Authenticated Data), which is only used
+ * in the authentication algorithm.
+ */
 
   uint16_t flags;
   unsigned len;
+  unsigned aadlen;
   caddr_t src, dst;   /* become iov[] inside kernel */
   caddr_t mac;        /* must be big enough for chosen MAC */
   caddr_t iv;
+  caddr_t aad;
 };
 
 /* hamc buffer, software & hardware need it */

--- a/include/crypto/cryptodev.h
+++ b/include/crypto/cryptodev.h
@@ -124,8 +124,9 @@
 #define CRYPTO_SHA2_256         31
 #define CRYPTO_SHA2_384         32
 #define CRYPTO_SHA2_512         33
-#define CRYPTO_ESN              34 /* Support for Extended Sequence Numbers */
-#define CRYPTO_ALGORITHM_MAX    34 /* Keep updated */
+#define CRYPTO_CRC32            34
+#define CRYPTO_ESN              35 /* Support for Extended Sequence Numbers */
+#define CRYPTO_ALGORITHM_MAX    35 /* Keep updated */
 
 /* Algorithm flags */
 

--- a/include/crypto/xform.h
+++ b/include/crypto/xform.h
@@ -128,5 +128,6 @@ extern const struct auth_hash auth_hash_sha2_224;
 extern const struct auth_hash auth_hash_sha2_256;
 extern const struct auth_hash auth_hash_sha2_384;
 extern const struct auth_hash auth_hash_sha2_512;
+extern const struct auth_hash auth_hash_crc32;
 
 #endif /* __INCLUDE_CRYPTO_XFORM_H */

--- a/include/crypto/xform.h
+++ b/include/crypto/xform.h
@@ -103,6 +103,7 @@ extern const struct enc_xform enc_xform_aes;
 extern const struct enc_xform enc_xform_aes_ctr;
 extern const struct enc_xform enc_xform_aes_gcm;
 extern const struct enc_xform enc_xform_aes_gmac;
+extern const struct enc_xform enc_xform_aes_cmac;
 extern const struct enc_xform enc_xform_aes_xts;
 extern const struct enc_xform enc_xform_aes_ofb;
 extern const struct enc_xform enc_xform_aes_cfb_8;
@@ -129,5 +130,6 @@ extern const struct auth_hash auth_hash_sha2_256;
 extern const struct auth_hash auth_hash_sha2_384;
 extern const struct auth_hash auth_hash_sha2_512;
 extern const struct auth_hash auth_hash_crc32;
+extern const struct auth_hash auth_hash_cmac_aes_128;
 
 #endif /* __INCLUDE_CRYPTO_XFORM_H */


### PR DESCRIPTION
## Summary
1. add a new hash algorithm crc32
2. add a new cmac algorithm with aes
## Impact
N/A
## Testing
ci
