### PR TITLE
Cmake: [arch arm] added initial support for MSYS2 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -281,7 +281,7 @@ jobs:
           git config --global --add safe.directory /github/workspace/sources/nuttx
           git config --global --add safe.directory /github/workspace/sources/apps
           cd sources/nuttx/tools/ci
-          ./cibuild.sh -g -i -A -C -R testlist/${{matrix.boards}}.dat
+          ./cibuild.sh -g -i -A -C -N -R testlist/${{matrix.boards}}.dat
 
       - uses: actions/upload-artifact@v4
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,20 +198,13 @@ set(ENV{DRIVERS_PLATFORM_DIR} dummy) # TODO
 
 set(ENV{HOST_LINUX} n)
 set(ENV{HOST_MACOS} n)
+set(ENV{HOST_BSD} n)
 set(ENV{HOST_WINDOWS} n)
 set(ENV{HOST_OTHER} n)
 
-if(APPLE)
-  set(ENV{HOST_MACOS} y)
-elseif(WIN32)
-  set(ENV{HOST_WINDOWS} y)
-elseif(UNIX)
-  set(ENV{HOST_LINUX} y)
-  set(LINUX TRUE)
-else()
-  set(ENV{HOST_OTHER} y)
-  set(OTHER_OS TRUE)
-endif()
+# We define host
+include(nuttx_sethost)
+nuttx_sethost()
 
 include(nuttx_parse_function_args)
 include(nuttx_add_subdirectory)
@@ -411,6 +404,7 @@ set(CMAKE_TOOLCHAIN_FILE
 # This triggers configuration
 
 project(NuttX LANGUAGES C CXX ASM)
+
 if(WIN32)
   enable_language(ASM_MASM)
 endif()
@@ -484,7 +478,7 @@ if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
   endif()
 endif()
 
-if(WIN32)
+if(MSVC)
   add_compile_options(
     -W2
     -wd4116 # unnamed type definition in parentheses

--- a/arch/arm/src/cmake/platform.cmake
+++ b/arch/arm/src/cmake/platform.cmake
@@ -87,7 +87,12 @@ if(NOT EXISTS ${extra_library} AND CONFIG_ARCH_TOOLCHAIN_CLANG)
     OUTPUT_VARIABLE extra_library)
 endif()
 
-list(APPEND EXTRA_LIB ${extra_library})
+if(CMAKE_HOST_SYSTEM_NAME MATCHES "MSYS|CYGWIN|Windows")
+  cmake_path(GET extra_library FILENAME extra_filename_library)
+  list(APPEND EXTRA_LIB -l:${extra_filename_library})
+else()
+  list(APPEND EXTRA_LIB ${extra_library})
+endif()
 
 if(NOT CONFIG_LIBM)
   execute_process(
@@ -95,7 +100,13 @@ if(NOT CONFIG_LIBM)
             --print-file-name=libm.a
     OUTPUT_STRIP_TRAILING_WHITESPACE
     OUTPUT_VARIABLE extra_library)
-  list(APPEND EXTRA_LIB ${extra_library})
+
+  if(CMAKE_HOST_SYSTEM_NAME MATCHES "MSYS|CYGWIN|Windows")
+    cmake_path(GET extra_library FILENAME extra_filename_library)
+    list(APPEND EXTRA_LIB -l:${extra_filename_library})
+  else()
+    list(APPEND EXTRA_LIB ${extra_library})
+  endif()
 endif()
 
 if(CONFIG_LIBSUPCXX)
@@ -104,7 +115,12 @@ if(CONFIG_LIBSUPCXX)
             --print-file-name=libsupc++.a
     OUTPUT_STRIP_TRAILING_WHITESPACE
     OUTPUT_VARIABLE extra_library)
-  list(APPEND EXTRA_LIB ${extra_library})
+  if(CMAKE_HOST_SYSTEM_NAME MATCHES "MSYS|CYGWIN|Windows")
+    cmake_path(GET extra_library FILENAME extra_filename_library)
+    list(APPEND EXTRA_LIB -l:${extra_filename_library})
+  else()
+    list(APPEND EXTRA_LIB ${extra_library})
+  endif()
 endif()
 
 if(CONFIG_ARCH_COVERAGE)
@@ -113,7 +129,12 @@ if(CONFIG_ARCH_COVERAGE)
             --print-file-name=libgcov.a
     OUTPUT_STRIP_TRAILING_WHITESPACE
     OUTPUT_VARIABLE extra_library)
-  list(APPEND EXTRA_LIB ${extra_library})
+  if(CMAKE_HOST_SYSTEM_NAME MATCHES "MSYS|CYGWIN|Windows")
+    cmake_path(GET extra_library FILENAME extra_filename_library)
+    list(APPEND EXTRA_LIB -l:${extra_filename_library})
+  else()
+    list(APPEND EXTRA_LIB ${extra_library})
+  endif()
 endif()
 
 nuttx_add_extra_library(${EXTRA_LIB})

--- a/boards/CMakeLists.txt
+++ b/boards/CMakeLists.txt
@@ -53,8 +53,8 @@ if(EXISTS ${NUTTX_BOARD_ABS_DIR}/../common/CMakeLists.txt)
   # Create link ARCH_SRC_BOARD_BOARD_SYMLINK
 
   file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/arch/${CONFIG_ARCH}/src/board)
-  file(CREATE_LINK ${NUTTX_BOARD_ABS_DIR}/src
-       ${CMAKE_BINARY_DIR}/arch/${CONFIG_ARCH}/src/board/board SYMBOLIC)
+  nuttx_create_symlink(${NUTTX_BOARD_ABS_DIR}/src
+                       ${CMAKE_BINARY_DIR}/arch/${CONFIG_ARCH}/src/board/board)
 endif()
 
 if(EXISTS ${NUTTX_BOARD_ABS_DIR}/../drivers/CMakeLists.txt)

--- a/cmake/nuttx_create_symlink.cmake
+++ b/cmake/nuttx_create_symlink.cmake
@@ -19,7 +19,8 @@
 # ##############################################################################
 
 function(nuttx_create_symlink old new)
-  if(IS_DIRECTORY ${old} AND WIN32)
+  if(IS_DIRECTORY ${old} AND CMAKE_HOST_SYSTEM_NAME MATCHES
+                             "MSYS|CYGWIN|Windows")
     execute_process(COMMAND ${CMAKE_COMMAND} -E copy_directory ${old} ${new})
   else()
     file(CREATE_LINK ${old} ${new} COPY_ON_ERROR SYMBOLIC)

--- a/cmake/nuttx_kconfig.cmake
+++ b/cmake/nuttx_kconfig.cmake
@@ -156,3 +156,10 @@ function(nuttx_generate_kconfig)
     file(APPEND ${KCONFIG_OUTPUT_FILE} "endmenu # ${MENUDESC}\n")
   endif()
 endfunction()
+
+function(nuttx_setconfig)
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} -E env ${KCONFIG_ENV} setconfig ${ARGN}
+    WORKING_DIRECTORY ${NUTTX_DIR}
+    OUTPUT_QUIET ERROR_QUIET)
+endfunction()

--- a/cmake/nuttx_sethost.cmake
+++ b/cmake/nuttx_sethost.cmake
@@ -1,0 +1,100 @@
+# ##############################################################################
+# cmake/nuttx_sethost.cmake
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+include(nuttx_kconfig)
+
+function(nuttx_sethost)
+
+  if(CMAKE_HOST_WIN32)
+    # https://learn.microsoft.com/en-us/windows/win32/winprog64/wow64-implementation-details
+    if(DEFINED ENV{PROCESSOR_ARCHITEW6432})
+      set(CMAKE_HOST_SYSTEM_PROCESSOR "$ENV{PROCESSOR_ARCHITEW6432}")
+      message(
+        STATUS "ENV{PROCESSOR_ARCHITEW6432} = $ENV{PROCESSOR_ARCHITEW6432}")
+    else()
+      set(CMAKE_HOST_SYSTEM_PROCESSOR "$ENV{PROCESSOR_ARCHITECTURE}")
+      message(
+        STATUS "ENV{PROCESSOR_ARCHITECTURE} = $ENV{PROCESSOR_ARCHITECTURE}")
+    endif()
+  else()
+    execute_process(
+      COMMAND uname -m
+      COMMAND tr -d '\n'
+      OUTPUT_VARIABLE ARCHITECTURE)
+  endif()
+
+  if(CMAKE_HOST_SYSTEM_NAME MATCHES "Linux|Darwin|FreeBSD")
+    nuttx_setconfig(HOST_WINDOWS=n)
+    if(CMAKE_HOST_SYSTEM_NAME MATCHES "Linux")
+      message(" Select HOST_LINUX=y")
+      nuttx_setconfig(HOST_LINUX=y)
+    elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
+      message(" Select HOST_MACOS=y")
+      nuttx_setconfig(HOST_MACOS=y)
+    elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "FreeBSD")
+      message(" Select HOST_BSD=y")
+      nuttx_setconfig(HOST_BSD=y)
+    endif()
+    # Enable the System V ABI
+    nuttx_setconfig(SIM_X8664_SYSTEMV=y)
+  elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "MSYS|CYGWIN|Windows")
+    # Enable Windows and the Microsoft ABI
+    message(" Select HOST_WINDOWS=y")
+    nuttx_setconfig(HOST_LINUX=n)
+    nuttx_setconfig(HOST_MACOS=n)
+    nuttx_setconfig(HOST_BSD=n)
+    nuttx_setconfig(HOST_WINDOWS=y)
+    nuttx_setconfig(SIM_X8664_MICROSOFT=y)
+    if(CMAKE_HOST_SYSTEM_NAME MATCHES "CYGWIN")
+      message(" Select WINDOWS_CYGWIN=y")
+      nuttx_setconfig(WINDOWS_CYGWIN=y)
+    elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "MSYS")
+      message(" Select WINDOWS_MSYS=y")
+      nuttx_setconfig(WINDOWS_MSYS=y)
+    elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Windows")
+      message(" Select WINDOWS_NATIVE=y")
+      nuttx_setconfig(EXPERIMENTAL=y)
+      nuttx_setconfig(WINDOWS_NATIVE=y)
+    endif()
+  else()
+    message(" Select HOST_OTHER=y")
+    nuttx_setconfig(HOST_LINUX=n)
+    nuttx_setconfig(HOST_MACOS=n)
+    nuttx_setconfig(HOST_BSD=n)
+    nuttx_setconfig(HOST_WINDOWS=n)
+    nuttx_setconfig(HOST_OTHER=y)
+    nuttx_setconfig(OTHER_OS=y)
+  endif()
+
+  if(ARCHITECTURE STREQUAL "x86_64")
+    message(" Select HOST_X86_64=y")
+    nuttx_setconfig(HOST_X86_64=y)
+  elseif(ARCHITECTURE STREQUAL "x86")
+    message(" Select HOST_X86=y")
+    nuttx_setconfig(HOST_X86=y)
+  elseif(ARCHITECTURE STREQUAL "arm")
+    message(" Select HOST_ARM=y")
+    nuttx_setconfig(HOST_ARM=y)
+  elseif(ARCHITECTURE STREQUAL "arm64")
+    message(" Select HOST_ARM64=y")
+    nuttx_setconfig(HOST_ARM64=y)
+  endif()
+
+endfunction()

--- a/tools/ci/testlist/msys2.dat
+++ b/tools/ci/testlist/msys2.dat
@@ -10,3 +10,6 @@
 # ARM64
 
 /arm64/qemu/qemu-armv8a/configs/nsh_smp
+
+# Boards build by CMake
+CMake,nucleo-l152re:nsh


### PR DESCRIPTION


## Summary
I took inspiration and expanded from this PR #11608 to support new platforms (same as make).

Currently concerns only arm.

tools/ci/testlist/msys2.dat: 
   At the moment I only added the board nucleo-l152re:nsh

.github/workflows/build.yml: 
  Enabled cmake for msys2

## Impact
There should be no impact.

## Testing
We tested on the local platform MSYS2 and GitHub (docker, darwin and MSYS2)

