### PR TITLE
armv7-a timer:fix timer overflow.

### DIFF
--- a/arch/arm/src/armv7-a/arm_timer.c
+++ b/arch/arm/src/armv7-a/arm_timer.c
@@ -137,7 +137,9 @@ static inline void arm_timer_set_cval(uint64_t cval)
 
 static inline uint64_t nsec_from_count(uint64_t count, uint32_t freq)
 {
-  return (uint64_t)count * NSEC_PER_SEC / freq;
+  uint64_t sec = count / freq;
+  uint64_t nsec = (count % freq) * NSEC_PER_SEC / freq;
+  return sec * NSEC_PER_SEC + nsec;
 }
 
 static inline uint64_t nsec_to_count(uint32_t nsec, uint32_t freq)


### PR DESCRIPTION
## Summary
If the frequency is too high, count * NSEC_PER_SEC will be overflow.
## Impact
armv7-a arm_timer.
## Testing
qemu
