### PR TITLE
armv7-a timer:enable mask in interrupt.

### DIFF
--- a/arch/arm/src/armv7-a/arm_timer.c
+++ b/arch/arm/src/armv7-a/arm_timer.c
@@ -234,6 +234,8 @@ static int arm_timer_interrupt(int irq, void *context, void *arg)
   oneshot_callback_t callback;
   void *cbarg;
 
+  arm_timer_set_ctrl(arm_timer_get_ctrl() | ARM_TIMER_CTRL_INT_MASK);
+
   DEBUGASSERT(lower != NULL);
 
   arm_timer_set_ctrl(arm_timer_get_ctrl() | ARM_TIMER_CTRL_INT_MASK);


### PR DESCRIPTION
## Summary
Interrupts are not masked in the interrupt processing function, causing interrupts to keep coming if there is no new timing to update the comparator.
## Impact
armv7m arm_timer
## Testing
qemu
