### PR TITLE
net/tun: Support changing carrier state of TUN/TAP

### DIFF
--- a/drivers/net/tun.c
+++ b/drivers/net/tun.c
@@ -1268,6 +1268,24 @@ static int tun_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
       return OK;
     }
+  else if (cmd == TUNSETCARRIER)
+    {
+      if (priv == NULL || arg == 0)
+        {
+          return -EINVAL;
+        }
+
+      if (*(FAR int *)((uintptr_t)arg))
+        {
+          netdev_carrier_on(&priv->dev);
+        }
+      else
+        {
+          netdev_carrier_off(&priv->dev);
+        }
+
+      return OK;
+    }
 
   return -ENOTTY;
 }

--- a/include/nuttx/net/ioctl.h
+++ b/include/nuttx/net/ioctl.h
@@ -107,6 +107,7 @@
 
 #define TUNSETIFF        _SIOC(0x0028)  /* Set TUN/TAP interface */
 #define TUNGETIFF        _SIOC(0x0035)  /* Get TUN/TAP interface */
+#define TUNSETCARRIER    _SIOC(0x0040)  /* Set TUN/TAP carrier state */
 
 /* Telnet driver ************************************************************/
 


### PR DESCRIPTION
## Summary
Add `TUNSETCARRIER` ioctl, then we may change the carrier state of TUN dynamically. Note that we don't need an ioctl for getting carrier, it can be done by `SIOCGIFFLAGS` already.

Ref: https://github.com/torvalds/linux/blob/v6.10/drivers/net/tun.c#L3374-L3380

Extra note: `_SIOC(0x003F)` is used by https://github.com/apache/nuttx/pull/13160, so use `_SIOC(0x0040)` here.

## Impact
Support `TUNSETCARRIER` for TUN/TAP

## Testing
Manually
