### PR TITLE
greenhills support: fix the pointless comparison build warning

### DIFF
--- a/drivers/ioexpander/gpio.c
+++ b/drivers/ioexpander/gpio.c
@@ -464,7 +464,7 @@ static int gpio_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
           /* Check if the argument is a valid pintype */
 
-          if (pintype < GPIO_INPUT_PIN || pintype >= GPIO_NPINTYPES)
+          if (pintype >= GPIO_NPINTYPES)
             {
               ret = -EINVAL;
               break;


### PR DESCRIPTION
## Summary
fix the pointless comparison build warning, the detailed warning info are :

"ioexpander/gpio.c", line 529: warning #186-D: pointless comparison of
          unsigned integer with zero
            if (pintype < GPIO_INPUT_PIN || pintype >= GPIO_NPINTYPES)
                        ^
## Impact

## Testing

