### PR TITLE
risc-v/mmu: Configure T-Head MMU to cache User Text, Data and Heap

### DIFF
--- a/arch/risc-v/Kconfig
+++ b/arch/risc-v/Kconfig
@@ -336,6 +336,7 @@ config ARCH_CHIP_SG2000
 	select ARCH_HAVE_MULTICPU
 	select ARCH_HAVE_MPU
 	select ARCH_MMU_TYPE_SV39
+	select ARCH_MMU_EXT_THEAD
 	select ARCH_HAVE_ADDRENV
 	select ARCH_NEED_ADDRENV_MAPPING
 	select ARCH_HAVE_S_MODE
@@ -515,6 +516,13 @@ config ARCH_MMU_TYPE_SV32
 	bool
 	default n
 	select ARCH_HAVE_MMU
+
+config ARCH_MMU_EXT_THEAD
+	bool "Enable T-Head MMU extension support"
+	default n
+	depends on ARCH_HAVE_MMU
+	---help---
+		Enable support for T-Head MMU extension.
 
 config ARCH_HAVE_S_MODE
 	bool

--- a/arch/risc-v/src/common/riscv_addrenv.c
+++ b/arch/risc-v/src/common/riscv_addrenv.c
@@ -231,7 +231,7 @@ static int copy_kernel_mappings(arch_addrenv_t *addrenv)
  ****************************************************************************/
 
 static int create_region(arch_addrenv_t *addrenv, uintptr_t vaddr,
-                         size_t size, uint32_t mmuflags)
+                         size_t size, uint64_t mmuflags)
 {
   uintptr_t ptlast;
   uintptr_t ptprev;

--- a/arch/risc-v/src/common/riscv_exception.c
+++ b/arch/risc-v/src/common/riscv_exception.c
@@ -177,7 +177,7 @@ int riscv_fillpage(int mcause, void *regs, void *args)
   uintptr_t vaddr;
   uint32_t  ptlevel;
   uintptr_t satp;
-  uint32_t  mmuflags;
+  uint64_t  mmuflags;
 
   _info("EXCEPTION: %s. MCAUSE: %" PRIxREG ", EPC: %" PRIxREG
         ", MTVAL: %" PRIxREG "\n",

--- a/arch/risc-v/src/common/riscv_mmu.h
+++ b/arch/risc-v/src/common/riscv_mmu.h
@@ -46,6 +46,22 @@
 #define PTE_A                   (1 << 6) /* Page has been accessed */
 #define PTE_D                   (1 << 7) /* Page is dirty */
 
+/* T-Head MMU needs Text and Data to be Shareable, Bufferable, Cacheable */
+
+#ifdef CONFIG_ARCH_MMU_EXT_THEAD
+#  define PTE_SEC         (1UL << 59) /* Security */
+#  define PTE_SHARE       (1UL << 60) /* Shareable */
+#  define PTE_BUF         (1UL << 61) /* Bufferable */
+#  define PTE_CACHE       (1UL << 62) /* Cacheable */
+#  define PTE_SO          (1UL << 63) /* Strong Order */
+
+#  define EXT_UTEXT_FLAGS (PTE_SHARE | PTE_BUF | PTE_CACHE)
+#  define EXT_UDATA_FLAGS (PTE_SHARE | PTE_BUF | PTE_CACHE)
+#else
+#  define EXT_UTEXT_FLAGS (0)
+#  define EXT_UDATA_FLAGS (0)
+#endif
+
 /* Check if leaf PTE entry or not (if X/W/R are set it is) */
 
 #define PTE_LEAF_MASK           (7 << 1)
@@ -56,8 +72,8 @@
 
 /* Flags for user FLASH (RX) and user RAM (RW) */
 
-#define MMU_UTEXT_FLAGS         (PTE_R | PTE_X | PTE_U)
-#define MMU_UDATA_FLAGS         (PTE_R | PTE_W | PTE_U)
+#define MMU_UTEXT_FLAGS         (PTE_R | PTE_X | PTE_U | EXT_UTEXT_FLAGS)
+#define MMU_UDATA_FLAGS         (PTE_R | PTE_W | PTE_U | EXT_UDATA_FLAGS)
 
 /* I/O region flags */
 


### PR DESCRIPTION
## Summary

This PR configures the T-Head MMU to cache the the User Text, Data and Heap. We enable the MMU Flags for Shareable, Bufferable and Cacheable, as [explained in this article](https://lupyuen.github.io/articles/plic3#appendix-mmu-caching-for-t-head-c906).

This PR fixes the Slow Memory Access for NuttX Apps on BL808 and SG2000 SoCs: https://github.com/apache/nuttx/issues/12696. With this fix, SG2000 NuttX CoreMark jumps from 21 to 2,422. (Close to SG2000 Debian CoreMark)

We introduce a Kconfig Option: `ARCH_MMU_EXT_THEAD` ("System Type > Enable T-Head MMU extension support"). Enabling this Kconfig Option will configure the T-Head MMU to cache the User Text, Data and Heap.

This PR enables the MMU cache for only SG2000 SoC (Milk-V Duo S SBC). The next PR will apply the same settings to BL808 SoC (Pine64 Ox64 SBC).

### Modified Files

`arch/risc-v/Kconfig`: Added Kconfig Option `ARCH_MMU_EXT_THEAD` that will configure the T-Head MMU. Enabled `ARCH_MMU_EXT_THEAD` for SG2000 SoC.

`arch/risc-v/src/common/riscv_mmu.h`: Set the T-Head MMU Flags (Shareable, Bufferable and Cacheable) for User Text, Data and Heap, if `ARCH_MMU_EXT_THEAD` is enabled

`arch/risc-v/src/common/riscv_addrenv.c`: Extended the MMU Flags from 32 bits to 64 bits, to accommodate the T-Head MMU Flags

`arch/risc-v/src/common/riscv_exception.c`: Extended the MMU Flags from 32 bits to 64 bit, to accommodate the T-Head MMU Flags. This code is enabled only for MMU Paging (`CONFIG_PAGING`).

## Impact

This PR affects only the platforms that have `ARCH_MMU_EXT_THEAD` enabled. Right now, only SG2000 SoC enables `ARCH_MMU_EXT_THEAD`.

## Testing

We tested on Milk-V Duo S SBC with SG2000 SoC:

__Before the PR:__ CoreMark is 17 [(NuttX Log)](https://gist.github.com/lupyuen/59d7cb1e0158843356464b15401d47bb)

```text
NuttShell (NSH) NuttX-12.4.0
nsh> uname -a
NuttX 12.4.0 cc8d453b5a7 Aug 27 2024 10:25:24 risc-v milkv_duos
nsh> coremark
CoreMark 1.0 : 17.104738 / GCC13.2.0 -Os -fno-strict-aliasing -fomit-frame-pointer -ffunction-sections -fdata-sections -nostdlib -g / HEAP
```

__After the PR:__ CoreMark increases to 1,759 [(NuttX Log)](https://gist.github.com/lupyuen/be0bd9359437aa670006bfe90b50e7fa)

```text
NuttShell (NSH) NuttX-12.4.0
nsh> uname -a
NuttX 12.4.0 f055ff95c70 Aug 27 2024 10:20:29 risc-v milkv_duos
nsh> coremark
CoreMark 1.0 : 1759.014952 / GCC13.2.0 -Os -fno-strict-aliasing -fomit-frame-pointer -ffunction-sections -fdata-sections -nostdlib -g / HEAP
```

And OSTest completes successfully:

```text
nsh> ostest
ostest_main: Exiting with status 0
```

Note that CoreMark will increase further to 2,422 when we compile [CoreMark optimised with `-O2`](https://github.com/apache/nuttx/issues/12696#issuecomment-2232279326)

__Regression Testing__: We tested OSTest on QEMU RISC-V 32-bit and 64-bit (Flat Build and Kernel Build):

```text
$ tools/configure.sh rv-virt:nsh / nsh64 / knsh / knsh64
...
nsh> uname -a
NuttX 12.4.0 f055ff95c7 Aug 27 2024 03:39:35 risc-v rv-virt
nsh> ostest
ostest_main: Exiting with status 0
```
- [rv-virt:nsh Log](https://github.com/lupyuen/nuttx-riscv64/actions/runs/10571280090/job/29287087539)
- [rv-virt:nsh64 Log](https://github.com/lupyuen/nuttx-riscv64/actions/runs/10571280093/job/29287087531)
- [rv-virt:knsh Log](https://github.com/lupyuen/nuttx-riscv64/actions/runs/10571280088/job/29287087543)
- [rv-virt:knsh64 Log](https://gist.github.com/lupyuen/43ca849dc0af378ccab6638d9089206e)

__MMU Paging:__ With `CONFIG_PAGING` enabled, `rv-virt:knsh_paging` compiles correctly. However we were unable to test `knsh_paging`. OSTest failed with the same error, before and after our PR:

```text
$ tools/configure.sh rv-virt:knsh_paging
...
nsh> ostest
barrier_test: Thread 6 created
riscv_fillpage: EXCEPTION: Store/AMO page fault. MCAUSE: 0000000f, EPC: 8020ce96, MTVAL: 80c00000
riscv_fillpage: PANIC!!! virtual address not mappable: 80c00000
_assert: Current Version: NuttX  12.6.0-RC1 a6df724b4f Aug 27 2024 11:41:56 risc-v
_assert: Assertion failed panic: at file: :0 task: ostest process: ostest 0xc000001c
```
- [Before PR: knsh_paging Log](https://gist.github.com/lupyuen/56945f0a998c8b7893d42f27cf8a968e)
- [After PR: knsh_paging Log](https://gist.github.com/lupyuen/00037d50646960b5fd47f99ad00edcec)
