### PR TITLE
rtc alarm:fix doesn't call nxsig_notification

### DIFF
--- a/drivers/timers/rtc.c
+++ b/drivers/timers/rtc.c
@@ -185,15 +185,15 @@ static void rtc_alarm_callback(FAR void *priv, int alarmid)
 
   if (alarminfo->active)
     {
+      /* The alarm is no longer active */
+
+      alarminfo->active = false;
+
       /* Yes.. signal the alarm expiration */
 
       nxsig_notification(alarminfo->pid, &alarminfo->event,
                          SI_QUEUE, &alarminfo->work);
     }
-
-  /* The alarm is no longer active */
-
-  alarminfo->active = false;
 }
 #endif
 


### PR DESCRIPTION
## Summary
We should set alarminfo->active to false immediately, because we may continue to set it in the alarm expiration.
## Impact
N/A
## Testing

