### PR TITLE
arm64_checkstack.c: Fix traversing of user stack when ARCH_ADDRENV=Y

### DIFF
--- a/arch/arm64/src/common/arm64_checkstack.c
+++ b/arch/arm64/src/common/arm64_checkstack.c
@@ -198,7 +198,27 @@ void arm64_stack_color(void *stackbase, size_t nbytes)
 
 size_t up_check_tcbstack(struct tcb_s *tcb)
 {
-  return arm64_stack_check(tcb->stack_base_ptr, tcb->adj_stack_size);
+  size_t size;
+
+#ifdef CONFIG_ARCH_ADDRENV
+  struct addrenv_s *oldenv;
+
+  if (tcb->addrenv_own != NULL)
+    {
+      addrenv_select(tcb->addrenv_own, &oldenv);
+    }
+#endif
+
+  size = arm64_stack_check(tcb->stack_base_ptr, tcb->adj_stack_size);
+
+#ifdef CONFIG_ARCH_ADDRENV
+  if (tcb->addrenv_own != NULL)
+    {
+      addrenv_restore(oldenv);
+    }
+#endif
+
+  return size;
 }
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 7


### PR DESCRIPTION
## Summary
Need to instantiate the correct address environment when reading from user stack, otherwise the result is very likely a crash
## Impact
Fix crash when ARCH_ADDRENV=y
## Testing
qemu-armv8a:knsh
