### PR TITLE
arm64/imx9: Force 64-bit ELF format

### DIFF
--- a/arch/arm64/Kconfig
+++ b/arch/arm64/Kconfig
@@ -97,6 +97,7 @@ config ARCH_CHIP_IMX9
 	select ARCH_HAVE_I2CRESET
 	select ARCH_HAVE_IRQTRIGGER
 	select ARCH_NEED_ADDRENV_MAPPING
+	select LIBC_ARCH_ELF_64BIT if LIBC_ARCH_ELF
 	---help---
 		NXP i.MX9 (ARMv8.2a) applications processors
 


### PR DESCRIPTION
## Summary
The format is always 64-bits

## Impact
Fix elf file format
## Testing
imx9
