### PR TITLE
greenhills support:  fix the build option warning

### DIFF
--- a/arch/arm/src/common/Toolchain.defs
+++ b/arch/arm/src/common/Toolchain.defs
@@ -45,7 +45,11 @@ ifneq ($(CONFIG_DEBUG_NOOPT),y)
 endif
 
 ifeq ($(CONFIG_FRAME_POINTER),y)
-  ARCHOPTIMIZATION += -fno-omit-frame-pointer -fno-optimize-sibling-calls
+  ifeq ($(CONFIG_ARCH_TOOLCHAIN_GHS),y)
+    ARCHOPTIMIZATION += -ga
+  else
+    ARCHOPTIMIZATION += -fno-omit-frame-pointer -fno-optimize-sibling-calls
+  endif
 else
   ARCHOPTIMIZATION += -fomit-frame-pointer
 endif
@@ -97,7 +101,11 @@ ifeq ($(CONFIG_ARCH_INSTRUMENT_ALL),y)
 endif
 
 ifeq ($(CONFIG_UNWINDER_ARM),y)
-  ARCHOPTIMIZATION += -funwind-tables -fasynchronous-unwind-tables
+  ifeq ($(CONFIG_ARCH_TOOLCHAIN_GHS),y)
+    ARCHOPTIMIZATION += -gtws
+  else
+    ARCHOPTIMIZATION += -funwind-tables -fasynchronous-unwind-tables
+  endif
 endif
 
 # Link Time Optimization


### PR DESCRIPTION
## Summary
fix the build options warning that report by ghs compiler, the detailed warning info:

Warning: Unknown option "-fno-optimize-sibling-calls" ignored.  Did you mean "-mno-long-calls"?

## Impact

## Testing

