### PR TITLE
sched: replace up_cpu_index with this_cpu

### DIFF
--- a/arch/arm/src/armv6-m/arm_initialstate.c
+++ b/arch/arm/src/armv6-m/arm_initialstate.c
@@ -157,7 +157,7 @@ void up_initial_state(struct tcb_s *tcb)
 
 noinline_function void arm_initialize_stack(void)
 {
-  uint32_t stack = up_get_intstackbase(up_cpu_index()) + INTSTACK_SIZE;
+  uint32_t stack = up_get_intstackbase(this_cpu()) + INTSTACK_SIZE;
   uint32_t tempa = 0;
   uint32_t tempb = 2;
 

--- a/arch/arm/src/armv7-a/smp.h
+++ b/arch/arm/src/armv7-a/smp.h
@@ -114,7 +114,7 @@ void __cpu3_start(void);
  *
  * Input Parameters:
  *   cpu - The CPU index.  This is the same value that would be obtained by
- *      calling up_cpu_index();
+ *      calling this_cpu();
  *
  * Returned Value:
  *   Does not return.

--- a/arch/arm/src/armv7-m/arm_initialstate.c
+++ b/arch/arm/src/armv7-m/arm_initialstate.c
@@ -180,7 +180,7 @@ void up_initial_state(struct tcb_s *tcb)
 
 noinline_function void arm_initialize_stack(void)
 {
-  uint32_t stack = up_get_intstackbase(up_cpu_index()) + INTSTACK_SIZE;
+  uint32_t stack = up_get_intstackbase(this_cpu()) + INTSTACK_SIZE;
   uint32_t temp = 0;
 
   __asm__ __volatile__

--- a/arch/arm/src/armv7-r/smp.h
+++ b/arch/arm/src/armv7-r/smp.h
@@ -114,7 +114,7 @@ void __cpu3_start(void);
  *
  * Input Parameters:
  *   cpu - The CPU index.  This is the same value that would be obtained by
- *      calling up_cpu_index();
+ *      calling this_cpu();
  *
  * Returned Value:
  *   Does not return.

--- a/arch/arm/src/armv8-m/arm_doirq.c
+++ b/arch/arm/src/armv8-m/arm_doirq.c
@@ -140,7 +140,7 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
   board_autoled_off(LED_INIRQ);
 
 #ifdef CONFIG_ARMV8M_TRUSTZONE_HYBRID
-  if (((1 << up_cpu_index()) & CONFIG_ARMV8M_TRUSTZONE_CPU_BITMASK) == 0)
+  if (((1 << this_cpu()) & CONFIG_ARMV8M_TRUSTZONE_CPU_BITMASK) == 0)
     {
       regs[REG_EXC_RETURN] &=
         ~(EXC_RETURN_EXC_SECURE | EXC_RETURN_SECURE_STACK);

--- a/arch/arm/src/armv8-m/arm_initialstate.c
+++ b/arch/arm/src/armv8-m/arm_initialstate.c
@@ -186,7 +186,7 @@ void up_initial_state(struct tcb_s *tcb)
 
 noinline_function void arm_initialize_stack(void)
 {
-  uint32_t stacklim = up_get_intstackbase(up_cpu_index());
+  uint32_t stacklim = up_get_intstackbase(this_cpu());
   uint32_t stack = stacklim + INTSTACK_SIZE;
   uint32_t temp = 0;
 

--- a/arch/arm/src/common/arm_backtrace_fp.c
+++ b/arch/arm/src/common/arm_backtrace_fp.c
@@ -125,7 +125,7 @@ int up_backtrace(struct tcb_s *tcb,
       if (up_interrupt_context())
         {
 #if CONFIG_ARCH_INTERRUPTSTACK > 7
-          void *istackbase = (void *)up_get_intstackbase(up_cpu_index());
+          void *istackbase = (void *)up_get_intstackbase(this_cpu());
 
           ret = backtrace(istackbase,
                           istackbase + INTSTACK_SIZE,

--- a/arch/arm/src/common/arm_backtrace_sp.c
+++ b/arch/arm/src/common/arm_backtrace_sp.c
@@ -266,7 +266,7 @@ int up_backtrace(struct tcb_s *tcb,
         {
           unsigned long top =
 #if CONFIG_ARCH_INTERRUPTSTACK > 7
-            up_get_intstackbase(up_cpu_index()) + INTSTACK_SIZE;
+            up_get_intstackbase(this_cpu()) + INTSTACK_SIZE;
 #else
             (unsigned long)rtcb->stack_base_ptr +
                            rtcb->adj_stack_size;

--- a/arch/arm/src/common/arm_backtrace_unwind.c
+++ b/arch/arm/src/common/arm_backtrace_unwind.c
@@ -736,7 +736,7 @@ int up_backtrace(struct tcb_s *tcb,
       if (up_interrupt_context())
         {
 #if CONFIG_ARCH_INTERRUPTSTACK > 7
-          frame.stack_base = up_get_intstackbase(up_cpu_index());
+          frame.stack_base = up_get_intstackbase(this_cpu());
           frame.stack_top = frame.stack_base + INTSTACK_SIZE;
 #endif /* CONFIG_ARCH_INTERRUPTSTACK > 7 */
 

--- a/arch/arm/src/cxd56xx/cxd56_cpupause.c
+++ b/arch/arm/src/cxd56xx/cxd56_cpupause.c
@@ -315,7 +315,7 @@ int up_cpu_paused_restore(void)
 
 int arm_pause_handler(int irq, void *c, void *arg)
 {
-  int cpu = up_cpu_index();
+  int cpu = this_cpu();
   int ret = OK;
 
   DPRINTF("cpu%d will be paused\n", cpu);

--- a/arch/arm/src/cxd56xx/cxd56_cpustart.c
+++ b/arch/arm/src/cxd56xx/cxd56_cpustart.c
@@ -94,7 +94,7 @@ static void appdsp_boot(void)
 {
   int cpu;
 
-  cpu = up_cpu_index();
+  cpu = this_cpu();
   DPRINTF("cpu = %d\n", cpu);
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 7

--- a/arch/arm/src/cxd56xx/cxd56_farapi.c
+++ b/arch/arm/src/cxd56xx/cxd56_farapi.c
@@ -185,7 +185,7 @@ void farapi_main(int id, void *arg, struct modulelist_s *mlist)
   int ret;
 
 #ifdef CONFIG_SMP
-  int cpu = up_cpu_index();
+  int cpu = this_cpu();
   static cpu_set_t cpuset0;
 
   if (0 != cpu)

--- a/arch/arm/src/cxd56xx/cxd56_irq.c
+++ b/arch/arm/src/cxd56xx/cxd56_irq.c
@@ -413,7 +413,7 @@ void up_disable_irq(int irq)
 
       /* If a different cpu requested, send an irq request */
 
-      if (cpu != (int8_t)up_cpu_index())
+      if (cpu != (int8_t)this_cpu())
         {
           up_send_irqreq(1, irq, cpu);
           return;
@@ -462,7 +462,7 @@ void up_enable_irq(int irq)
   if (irq >= CXD56_IRQ_EXTINT)
     {
 #ifdef CONFIG_SMP
-      int cpu = up_cpu_index();
+      int cpu = this_cpu();
 
       /* Set the caller cpu for this irq */
 

--- a/arch/arm/src/cxd56xx/cxd56_testset.c
+++ b/arch/arm/src/cxd56xx/cxd56_testset.c
@@ -94,7 +94,7 @@ spinlock_t up_testset(volatile spinlock_t *lock)
 {
 #ifdef CONFIG_CXD56_TESTSET_WITH_HWSEM
   spinlock_t ret;
-  uint32_t sphlocked = ((up_cpu_index() + 2) << 16) | 0x1;
+  uint32_t sphlocked = ((this_cpu() + 2) << 16) | 0x1;
 
   /* Lock hardware semaphore */
 

--- a/arch/arm/src/imx6/imx_cpuboot.c
+++ b/arch/arm/src/imx6/imx_cpuboot.c
@@ -238,7 +238,7 @@ void imx_cpu_enable(void)
  *
  * Input Parameters:
  *   cpu - The CPU index.  This is the same value that would be obtained by
- *      calling up_cpu_index();
+ *      calling this_cpu();
  *
  * Returned Value:
  *   Does not return.

--- a/arch/arm/src/lc823450/lc823450_cpupause.c
+++ b/arch/arm/src/lc823450/lc823450_cpupause.c
@@ -236,7 +236,7 @@ int up_cpu_paused_restore(void)
 
 int lc823450_pause_handler(int irq, void *c, void *arg)
 {
-  int cpu = up_cpu_index();
+  int cpu = this_cpu();
 
   /* Clear : Pause IRQ */
 

--- a/arch/arm/src/lc823450/lc823450_cpustart.c
+++ b/arch/arm/src/lc823450/lc823450_cpustart.c
@@ -85,7 +85,7 @@ extern int lc823450_pause_handler(int irq, void *c, void *arg);
 
 static void cpu1_boot(void)
 {
-  int cpu = up_cpu_index();
+  int cpu = this_cpu();
 
   DPRINTF("cpu = %d\n", cpu);
 

--- a/arch/arm/src/lc823450/lc823450_dvfs2.c
+++ b/arch/arm/src/lc823450/lc823450_dvfs2.c
@@ -433,7 +433,7 @@ void lc823450_dvfs_get_idletime(uint64_t idletime[])
   memcpy(idletime, g_idle_totaltime, sizeof(g_idle_totaltime));
 
 #if CONFIG_SMP_NCPUS == 2
-  int me = up_cpu_index();
+  int me = this_cpu();
 
   if (0 == _dvfs_another_cpu_state(me))
     {
@@ -504,7 +504,7 @@ void lc823450_dvfs_enter_idle(void)
 {
   irqstate_t flags = spin_lock_irqsave(NULL);
 
-  int me = up_cpu_index();
+  int me = this_cpu();
 
   /* Update my state first : 0 (idle) */
 
@@ -554,7 +554,7 @@ void lc823450_dvfs_exit_idle(int irq)
 {
   irqstate_t flags = spin_lock_irqsave(NULL);
 
-  int me = up_cpu_index();
+  int me = this_cpu();
   uint64_t d;
   uint64_t now;
 

--- a/arch/arm/src/lc823450/lc823450_idle.c
+++ b/arch/arm/src/lc823450/lc823450_idle.c
@@ -86,7 +86,7 @@ void up_idle(void)
   lc823450_dvfs_enter_idle();
 #endif
 
-  board_autoled_off(LED_CPU0 + up_cpu_index());
+  board_autoled_off(LED_CPU0 + this_cpu());
 
   up_irq_restore(flags);
 
@@ -94,7 +94,7 @@ void up_idle(void)
 
   asm("WFI");
 
-  g_idle_counter[up_cpu_index()]++;
+  g_idle_counter[this_cpu()]++;
 
 #endif
 }

--- a/arch/arm/src/lc823450/lc823450_irq.c
+++ b/arch/arm/src/lc823450/lc823450_irq.c
@@ -676,10 +676,10 @@ void arm_ack_irq(int irq)
   lc823450_dvfs_exit_idle(irq);
 #endif
 
-  board_autoled_on(LED_CPU0 + up_cpu_index());
+  board_autoled_on(LED_CPU0 + this_cpu());
 
 #ifdef CONFIG_SMP
-  if (irq > LC823450_IRQ_LPDSP0 && 1 == up_cpu_index())
+  if (irq > LC823450_IRQ_LPDSP0 && 1 == this_cpu())
     {
       /* IRQ should be handled on CPU0 */
 

--- a/arch/arm/src/lc823450/lc823450_testset.c
+++ b/arch/arm/src/lc823450/lc823450_testset.c
@@ -71,7 +71,7 @@ spinlock_t up_testset(volatile spinlock_t *lock)
 
   flags = up_irq_save();
 
-  val = (up_cpu_index() << 16) | 0x1;
+  val = (this_cpu() << 16) | 0x1;
 
   do
     {
@@ -90,7 +90,7 @@ spinlock_t up_testset(volatile spinlock_t *lock)
 
   SP_DMB();
 
-  val = (up_cpu_index() << 16) | 0x0;
+  val = (this_cpu() << 16) | 0x0;
   putreg32(val, MUTEX_REG_MUTEX0);
 
   up_irq_restore(flags);

--- a/arch/arm/src/qemu/qemu_cpuboot.c
+++ b/arch/arm/src/qemu/qemu_cpuboot.c
@@ -111,7 +111,7 @@ void qemu_cpu_enable(void)
  *
  * Input Parameters:
  *   cpu - The CPU index.  This is the same value that would be obtained by
- *      calling up_cpu_index();
+ *      calling this_cpu();
  *
  * Returned Value:
  *   Does not return.

--- a/arch/arm/src/rp2040/rp2040_cpupause.c
+++ b/arch/arm/src/rp2040/rp2040_cpupause.c
@@ -86,7 +86,7 @@ static volatile spinlock_t g_cpu_resumed[CONFIG_SMP_NCPUS];
 
 static void rp2040_handle_irqreq(int irqreq)
 {
-  DEBUGASSERT(up_cpu_index() == 0);
+  DEBUGASSERT(this_cpu() == 0);
 
   /* Unlock the spinlock first */
 
@@ -276,7 +276,7 @@ int up_cpu_paused_restore(void)
 
 int arm_pause_handler(int irq, void *c, void *arg)
 {
-  int cpu = up_cpu_index();
+  int cpu = this_cpu();
   int irqreq;
   uint32_t stat;
 
@@ -379,7 +379,7 @@ int up_cpu_pause(int cpu)
   spin_lock(&g_cpu_wait[cpu]);
   spin_lock(&g_cpu_paused[cpu]);
 
-  DEBUGASSERT(cpu != up_cpu_index());
+  DEBUGASSERT(cpu != this_cpu());
 
   /* Generate IRQ for CPU(cpu) */
 

--- a/arch/arm/src/rp2040/rp2040_flash_mtd.c
+++ b/arch/arm/src/rp2040/rp2040_flash_mtd.c
@@ -93,7 +93,7 @@
                            / FLASH_SECTOR_SIZE
 
 #ifdef CONFIG_SMP
-#  define OTHER_CPU (up_cpu_index() == 0 ? 1 : 0)
+#  define OTHER_CPU (this_cpu() == 0 ? 1 : 0)
 #endif
 
 /****************************************************************************

--- a/arch/arm/src/rp2040/rp2040_irq.c
+++ b/arch/arm/src/rp2040/rp2040_irq.c
@@ -277,7 +277,7 @@ void up_disable_irq(int irq)
 
 #ifdef CONFIG_SMP
   if (irq >= RP2040_IRQ_EXTINT && irq != RP2040_SIO_IRQ_PROC1 &&
-      up_cpu_index() != 0)
+      this_cpu() != 0)
     {
       /* Must be handled by Core 0 */
 
@@ -325,7 +325,7 @@ void up_enable_irq(int irq)
 
 #ifdef CONFIG_SMP
   if (irq >= RP2040_IRQ_EXTINT && irq != RP2040_SIO_IRQ_PROC1 &&
-      up_cpu_index() != 0)
+      this_cpu() != 0)
     {
       /* Must be handled by Core 0 */
 

--- a/arch/arm/src/rp2040/rp2040_start.c
+++ b/arch/arm/src/rp2040/rp2040_start.c
@@ -91,7 +91,7 @@ void __start(void)
 
   __asm__ __volatile__ ("\tmsr msp, %0\n" :: "r" (g_idle_topstack));
 
-  if (up_cpu_index() != 0)
+  if (this_cpu() != 0)
     {
       while (1)
         {

--- a/arch/arm/src/sam34/sam4cm_cpupause.c
+++ b/arch/arm/src/sam34/sam4cm_cpupause.c
@@ -238,7 +238,7 @@ int up_cpu_paused_restore(void)
 
 int arm_pause_handler(int irq, void *c, void *arg)
 {
-  int cpu = up_cpu_index();
+  int cpu = this_cpu();
 
   /* Clear : Pause IRQ */
 

--- a/arch/arm/src/sam34/sam4cm_cpustart.c
+++ b/arch/arm/src/sam34/sam4cm_cpustart.c
@@ -91,7 +91,7 @@ static void cpu1_boot(void)
   putreg32(0, 0x48018008);
   while ((getreg32(0x4801800c) & 0x01) != 0);
 
-  cpu = up_cpu_index();
+  cpu = this_cpu();
   DPRINTF("cpu = %d\n", cpu);
 
   if (cpu == 1)

--- a/arch/arm/src/tlsr82/tc32/tc32_backtrace.c
+++ b/arch/arm/src/tlsr82/tc32/tc32_backtrace.c
@@ -483,7 +483,7 @@ int up_backtrace(struct tcb_s *tcb, void **buffer, int size, int skip)
         {
 #if CONFIG_ARCH_INTERRUPTSTACK > 7
           ret = backtrace_push((void *)(INTSTACK_SIZE +
-                               up_get_intstackbase(up_cpu_index())),
+                               up_get_intstackbase(this_cpu())),
                                &sp, (void *)up_backtrace + 16,
                                buffer, size, &skip);
 #else

--- a/arch/arm64/src/common/arm64_backtrace.c
+++ b/arch/arm64/src/common/arm64_backtrace.c
@@ -134,7 +134,7 @@ int up_backtrace(struct tcb_s *tcb,
       if (up_interrupt_context())
         {
 #if CONFIG_ARCH_INTERRUPTSTACK > 7
-          void *istackbase = (void *)up_get_intstackbase(up_cpu_index());
+          void *istackbase = (void *)up_get_intstackbase(this_cpu());
           ret = backtrace(istackbase,
                           istackbase + INTSTACK_SIZE,
                           (void *)__builtin_frame_address(0),

--- a/arch/arm64/src/common/arm64_smp.h
+++ b/arch/arm64/src/common/arm64_smp.h
@@ -58,7 +58,7 @@
  *
  * Input Parameters:
  *   cpu - The CPU index.  This is the same value that would be obtained by
- *      calling up_cpu_index();
+ *      calling this_cpu();
  *
  * Returned Value:
  *   Does not return.

--- a/arch/risc-v/src/common/espressif/esp_gpio.c
+++ b/arch/risc-v/src/common/espressif/esp_gpio.c
@@ -124,7 +124,7 @@ static int gpio_interrupt(int irq, void *context, void *arg)
   int i;
   uint32_t status;
   uint32_t intr_bitmask;
-  int cpu = up_cpu_index();
+  int cpu = this_cpu();
 
   /* Read the lower GPIO interrupt status */
 
@@ -409,7 +409,7 @@ void esp_gpioirqenable(int irq, gpio_intrtype_t intrtype)
 
   /* Enable interrupt for this pin on the current core */
 
-  cpu = up_cpu_index();
+  cpu = this_cpu();
   gpio_hal_set_intr_type(&g_gpio_hal, pin, intrtype);
   gpio_hal_intr_enable_on_core(&g_gpio_hal, pin, cpu);
 

--- a/arch/risc-v/src/common/espressif/esp_rmt.c
+++ b/arch/risc-v/src/common/espressif/esp_rmt.c
@@ -1076,7 +1076,7 @@ static int rmt_isr_register(int (*fn)(int, void *, void *), void *arg,
 {
   int cpuint;
   int ret;
-  int cpu = up_cpu_index();
+  int cpu = this_cpu();
 
   DEBUGASSERT(fn);
   DEBUGASSERT(g_rmtdev_common.rmt_driver_channels == 0);

--- a/arch/risc-v/src/common/espressif/esp_spiflash.c
+++ b/arch/risc-v/src/common/espressif/esp_spiflash.c
@@ -184,7 +184,7 @@ static IRAM_ATTR void spiflash_start(void)
 
   nxmutex_lock(&s_flash_op_mutex);
   flags = enter_critical_section();
-  cpu = up_cpu_index();
+  cpu = this_cpu();
   s_sched_suspended[cpu] = true;
 
   esp_intr_noniram_disable();
@@ -218,7 +218,7 @@ static IRAM_ATTR void spiflash_end(void)
 
   flags = enter_critical_section();
 
-  cpu = up_cpu_index();
+  cpu = this_cpu();
 
   cache_invalidate_icache_all();
   cache_resume_icache(s_flash_op_cache_state[cpu] >> 16);

--- a/arch/risc-v/src/common/riscv_cpupause.c
+++ b/arch/risc-v/src/common/riscv_cpupause.c
@@ -227,7 +227,7 @@ int up_cpu_paused_restore(void)
 
 int riscv_pause_handler(int irq, void *c, void *arg)
 {
-  int cpu = up_cpu_index();
+  int cpu = this_cpu();
 
   /* Clear IPI (Inter-Processor-Interrupt) */
 

--- a/arch/risc-v/src/qemu-rv/qemu_rv_irq.c
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_irq.c
@@ -50,7 +50,7 @@ static int qemu_ipi_handler(int mcause, void *regs, void *args)
 {
   /* Clear IPI (Inter-Processor-Interrupt) */
 
-  riscv_ipi_clear(up_cpu_index());
+  riscv_ipi_clear(this_cpu());
 
 #ifdef CONFIG_SMP
   riscv_pause_handler(mcause, regs, args);

--- a/arch/sim/src/sim/sim_heap.c
+++ b/arch/sim/src/sim/sim_heap.c
@@ -86,11 +86,11 @@ static void mm_add_delaylist(struct mm_heap_s *heap, void *mem)
 
   flags = up_irq_save();
 
-  tmp->flink = heap->mm_delaylist[up_cpu_index()];
-  heap->mm_delaylist[up_cpu_index()] = tmp;
+  tmp->flink = heap->mm_delaylist[this_cpu()];
+  heap->mm_delaylist[this_cpu()] = tmp;
 
 #if CONFIG_MM_FREE_DELAYCOUNT_MAX > 0
-  heap->mm_delaycount[up_cpu_index()]++;
+  heap->mm_delaycount[this_cpu()]++;
 #endif
 
   up_irq_restore(flags);
@@ -108,20 +108,20 @@ static bool free_delaylist(struct mm_heap_s *heap, bool force)
 
   flags = up_irq_save();
 
-  tmp = heap->mm_delaylist[up_cpu_index()];
+  tmp = heap->mm_delaylist[this_cpu()];
 
 #if CONFIG_MM_FREE_DELAYCOUNT_MAX > 0
   if (tmp == NULL ||
       (!force &&
-        heap->mm_delaycount[up_cpu_index()] < CONFIG_MM_FREE_DELAYCOUNT_MAX))
+        heap->mm_delaycount[this_cpu()] < CONFIG_MM_FREE_DELAYCOUNT_MAX))
     {
       up_irq_restore(flags);
       return false;
     }
 
-  heap->mm_delaycount[up_cpu_index()] = 0;
+  heap->mm_delaycount[this_cpu()] = 0;
 #endif
-  heap->mm_delaylist[up_cpu_index()] = NULL;
+  heap->mm_delaylist[this_cpu()] = NULL;
 
   up_irq_restore(flags);
 

--- a/arch/sparc/src/s698pm/s698pm-irq.c
+++ b/arch/sparc/src/s698pm/s698pm-irq.c
@@ -170,7 +170,7 @@ int s698pm_cpuint_initialize(void)
 #ifdef CONFIG_SMP
   /* Which CPU are we initializing */
 
-  cpu = up_cpu_index();
+  cpu = this_cpu();
   DEBUGASSERT(cpu >= 0 && cpu < CONFIG_SMP_NCPUS);
 #endif
 

--- a/arch/sparc/src/s698pm/s698pm_cpupause.c
+++ b/arch/sparc/src/s698pm/s698pm_cpupause.c
@@ -226,7 +226,7 @@ int up_cpu_paused_restore(void)
 
 int s698pm_pause_handler(int irq, void *c, void *arg)
 {
-  int cpu = up_cpu_index();
+  int cpu = this_cpu();
 
   /* Clear IPI (Inter-Processor-Interrupt) */
 

--- a/arch/x86_64/src/intel64/intel64_cpupause.c
+++ b/arch/x86_64/src/intel64/intel64_cpupause.c
@@ -234,7 +234,7 @@ int up_cpu_paused_restore(void)
 
 int up_pause_handler(int irq, void *c, void *arg)
 {
-  int cpu = up_cpu_index();
+  int cpu = this_cpu();
 
   /* Check for false alarms.  Such false could occur as a consequence of
    * some deadlock breaking logic that might have already serviced the SG2

--- a/arch/x86_64/src/intel64/intel64_irq.c
+++ b/arch/x86_64/src/intel64/intel64_irq.c
@@ -433,7 +433,7 @@ static inline void up_idtinit(void)
 
 void up_irqinitialize(void)
 {
-  int cpu = up_cpu_index();
+  int cpu = this_cpu();
 
   /* Initialize the TSS */
 
@@ -496,7 +496,7 @@ void up_disable_irq(int irq)
       g_irq_priv[irq].busy -= 1;
     }
 
-  CPU_CLR(up_cpu_index(), &g_irq_priv[irq].busy);
+  CPU_CLR(this_cpu(), &g_irq_priv[irq].busy);
 
   if (CPU_COUNT(&g_irq_priv[irq].busy) == 0)
     {
@@ -528,7 +528,7 @@ void up_enable_irq(int irq)
 #  ifndef CONFIG_IRQCHAIN
   /* Check if IRQ is free if we don't support IRQ chains */
 
-  if (CPU_ISSET(up_cpu_index(), &g_irq_priv[irq].busy))
+  if (CPU_ISSET(this_cpu(), &g_irq_priv[irq].busy))
     {
       ASSERT(0);
     }
@@ -551,7 +551,7 @@ void up_enable_irq(int irq)
         }
     }
 
-  CPU_SET(up_cpu_index(), &g_irq_priv[irq].busy);
+  CPU_SET(this_cpu(), &g_irq_priv[irq].busy);
 
   spin_unlock_irqrestore(&g_irq_spinlock, flags);
 #endif

--- a/arch/xtensa/src/common/espressif/esp_mcpwm.c
+++ b/arch/xtensa/src/common/espressif/esp_mcpwm.c
@@ -1635,7 +1635,7 @@ static int esp_mcpwm_isr_register(int (*fn)(int, void *, void *), void *arg)
 {
   int cpuint;
   int ret;
-  int cpu = up_cpu_index();
+  int cpu = this_cpu();
 
   DEBUGASSERT(fn);
 

--- a/arch/xtensa/src/common/espressif/esp_rmt.c
+++ b/arch/xtensa/src/common/espressif/esp_rmt.c
@@ -1123,7 +1123,7 @@ static int rmt_isr_register(int (*fn)(int, void *, void *), void *arg,
 {
   int cpuint;
   int ret;
-  int cpu = up_cpu_index();
+  int cpu = this_cpu();
 
   DEBUGASSERT(fn);
   DEBUGASSERT(g_rmtdev_common.rmt_driver_channels == 0);

--- a/arch/xtensa/src/common/xtensa_backtrace.c
+++ b/arch/xtensa/src/common/xtensa_backtrace.c
@@ -242,7 +242,7 @@ int up_backtrace(struct tcb_s *tcb, void **buffer, int size, int skip)
       if (up_interrupt_context())
         {
 #if CONFIG_ARCH_INTERRUPTSTACK > 15
-          void *istackbase = (void *)up_get_intstackbase(up_cpu_index());
+          void *istackbase = (void *)up_get_intstackbase(this_cpu());
 
           xtensa_window_spill();
           ret = backtrace_stack(istackbase,

--- a/arch/xtensa/src/common/xtensa_cpupause.c
+++ b/arch/xtensa/src/common/xtensa_cpupause.c
@@ -218,7 +218,7 @@ int up_cpu_paused_restore(void)
 
 void xtensa_pause_handler(void)
 {
-  int cpu = up_cpu_index();
+  int cpu = this_cpu();
 
   /* Check for false alarms.  Such false could occur as a consequence of
    * some deadlock breaking logic that might have already serviced the

--- a/arch/xtensa/src/esp32/esp32_cpustart.c
+++ b/arch/xtensa/src/esp32/esp32_cpustart.c
@@ -122,7 +122,7 @@ void IRAM_ATTR xtensa_appcpu_start(void)
                  XCPTCONTEXT_SIZE;
   __asm__ __volatile__("mov sp, %0\n" : : "r"(sp));
 
-  sinfo("CPU%d Started\n", up_cpu_index());
+  sinfo("CPU%d Started\n", this_cpu());
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION
   /* Notify that this CPU has started */

--- a/arch/xtensa/src/esp32/esp32_emac.c
+++ b/arch/xtensa/src/esp32/esp32_emac.c
@@ -2042,7 +2042,7 @@ int esp32_emac_init(void)
 
   memset(priv, 0, sizeof(struct esp32_emac_s));
 
-  priv->cpu = up_cpu_index();
+  priv->cpu = this_cpu();
   priv->cpuint = esp32_setup_irq(priv->cpu, ESP32_PERIPH_EMAC,
                                  1, ESP32_CPUINT_LEVEL);
   if (priv->cpuint < 0)

--- a/arch/xtensa/src/esp32/esp32_gpio.c
+++ b/arch/xtensa/src/esp32/esp32_gpio.c
@@ -469,7 +469,7 @@ void esp32_gpioirqenable(int irq, gpio_intrtype_t intrtype)
   uintptr_t regaddr;
   uint32_t regval;
   int pin;
-  int cpu = up_cpu_index();
+  int cpu = this_cpu();
 
   DEBUGASSERT(irq >= ESP32_FIRST_GPIOIRQ && irq <= ESP32_LAST_GPIOIRQ);
 
@@ -530,7 +530,7 @@ void esp32_gpioirqdisable(int irq)
   uintptr_t regaddr;
   uint32_t regval;
   int pin;
-  int cpu = up_cpu_index();
+  int cpu = this_cpu();
 
   DEBUGASSERT(irq >= ESP32_FIRST_GPIOIRQ && irq <= ESP32_LAST_GPIOIRQ);
 

--- a/arch/xtensa/src/esp32/esp32_i2c.c
+++ b/arch/xtensa/src/esp32/esp32_i2c.c
@@ -1500,7 +1500,7 @@ struct i2c_master_s *esp32_i2cbus_initialize(int port)
 
   /* Set up to receive peripheral interrupts on the current CPU */
 
-  priv->cpu = up_cpu_index();
+  priv->cpu = this_cpu();
   priv->cpuint = esp32_setup_irq(priv->cpu, config->periph,
                                  1, ESP32_CPUINT_LEVEL);
   if (priv->cpuint < 0)

--- a/arch/xtensa/src/esp32/esp32_i2s.c
+++ b/arch/xtensa/src/esp32/esp32_i2s.c
@@ -3002,7 +3002,7 @@ static int i2s_dma_setup(struct esp32_i2s_s *priv)
 
   /* Set up to receive peripheral interrupts on the current CPU */
 
-  priv->cpu = up_cpu_index();
+  priv->cpu = this_cpu();
   priv->cpuint = esp32_setup_irq(priv->cpu, priv->config->periph,
                                  1, ESP32_CPUINT_LEVEL);
   if (priv->cpuint < 0)

--- a/arch/xtensa/src/esp32/esp32_intercpu_interrupt.c
+++ b/arch/xtensa/src/esp32/esp32_intercpu_interrupt.c
@@ -54,7 +54,7 @@ static int IRAM_ATTR esp32_fromcpu_interrupt(int fromcpu)
   uintptr_t regaddr;
 
   DEBUGASSERT((unsigned)fromcpu < CONFIG_SMP_NCPUS);
-  DEBUGASSERT(fromcpu != up_cpu_index());
+  DEBUGASSERT(fromcpu != this_cpu());
 
   /* Clear the interrupt from the other CPU */
 
@@ -106,7 +106,7 @@ int IRAM_ATTR xtensa_intercpu_interrupt(int tocpu, int intcode)
   DEBUGASSERT((unsigned)tocpu < CONFIG_SMP_NCPUS &&
               (unsigned)intcode <= UINT8_MAX);
 
-  fromcpu = up_cpu_index();
+  fromcpu = this_cpu();
   DEBUGASSERT(fromcpu != tocpu);
 
   /* Generate an Inter-Processor Interrupt */

--- a/arch/xtensa/src/esp32/esp32_irq.c
+++ b/arch/xtensa/src/esp32/esp32_irq.c
@@ -448,7 +448,7 @@ static void esp32_free_cpuint(int cpuint)
   bitmask = 1ul << cpuint;
 
 #ifdef CONFIG_SMP
-  if (up_cpu_index() != 0)
+  if (this_cpu() != 0)
     {
       freeints = &g_cpu1_freeints;
     }
@@ -616,7 +616,7 @@ void up_disable_irq(int irq)
        */
 
 #ifdef CONFIG_SMP
-      int me = up_cpu_index();
+      int me = this_cpu();
       if (me != cpu)
         {
           /* It was the other CPU that enabled this interrupt. */
@@ -677,7 +677,7 @@ void up_enable_irq(int irq)
        * we are just overwriting the cpu part of the map.
        */
 
-      int cpu = up_cpu_index();
+      int cpu = this_cpu();
 
       /* Enable the CPU interrupt now for internal CPU. */
 
@@ -782,7 +782,7 @@ int esp32_cpuint_initialize(void)
 #ifdef CONFIG_SMP
   /* Which CPU are we initializing */
 
-  cpu = up_cpu_index();
+  cpu = this_cpu();
   DEBUGASSERT(cpu >= 0 && cpu < CONFIG_SMP_NCPUS);
 #endif
 
@@ -1073,7 +1073,7 @@ uint32_t *xtensa_int_decode(uint32_t cpuints, uint32_t *regs)
 
   /* Select PRO or APP CPU interrupt mapping table */
 
-  cpu = up_cpu_index();
+  cpu = this_cpu();
 
 #ifdef CONFIG_SMP
   if (cpu != 0)
@@ -1164,7 +1164,7 @@ void esp32_irq_noniram_disable(void)
   uint32_t non_iram_ints;
 
   irqstate = enter_critical_section();
-  cpu = up_cpu_index();
+  cpu = this_cpu();
   non_iram_ints = g_non_iram_int_mask[cpu];
 
   ASSERT(!g_non_iram_int_disabled_flag[cpu]);
@@ -1200,7 +1200,7 @@ void esp32_irq_noniram_enable(void)
   uint32_t non_iram_ints;
 
   irqstate = enter_critical_section();
-  cpu = up_cpu_index();
+  cpu = this_cpu();
   non_iram_ints = g_non_iram_int_disabled[cpu];
 
   ASSERT(g_non_iram_int_disabled_flag[cpu]);

--- a/arch/xtensa/src/esp32/esp32_rtc_gpio.c
+++ b/arch/xtensa/src/esp32/esp32_rtc_gpio.c
@@ -340,7 +340,7 @@ void esp32_rtcioirqinitialize(void)
 {
   /* Setup the RTCIO interrupt. */
 
-  int cpu = up_cpu_index();
+  int cpu = this_cpu();
   g_rtcio_cpuint = esp32_setup_irq(cpu, ESP32_PERIPH_RTC_CORE,
                                    1, ESP32_CPUINT_LEVEL);
   DEBUGASSERT(g_rtcio_cpuint >= 0);

--- a/arch/xtensa/src/esp32/esp32_serial.c
+++ b/arch/xtensa/src/esp32/esp32_serial.c
@@ -1056,7 +1056,7 @@ static int esp32_attach(struct uart_dev_s *dev)
 
   /* Set up to receive peripheral interrupts on the current CPU */
 
-  priv->cpu = up_cpu_index();
+  priv->cpu = this_cpu();
   priv->cpuint = esp32_setup_irq(priv->cpu, priv->config->periph,
                                  1, ESP32_CPUINT_LEVEL);
   if (priv->cpuint < 0)
@@ -1186,7 +1186,7 @@ static void dma_attach(uint8_t dma_chan)
 
   /* Set up to receive peripheral interrupts on the current CPU */
 
-  cpu = up_cpu_index();
+  cpu = this_cpu();
   dma_cpuint = esp32_setup_irq(cpu, periph, 1, ESP32_CPUINT_LEVEL);
   if (dma_cpuint < 0)
     {

--- a/arch/xtensa/src/esp32/esp32_spi.c
+++ b/arch/xtensa/src/esp32/esp32_spi.c
@@ -1523,7 +1523,7 @@ struct spi_dev_s *esp32_spibus_initialize(int port)
     {
       /* Set up to receive peripheral interrupts on the current CPU */
 
-      priv->cpu = up_cpu_index();
+      priv->cpu = this_cpu();
       priv->cpuint = esp32_setup_irq(priv->cpu, priv->config->periph,
                                      1, ESP32_CPUINT_LEVEL);
       if (priv->cpuint < 0)

--- a/arch/xtensa/src/esp32/esp32_spi_slave.c
+++ b/arch/xtensa/src/esp32/esp32_spi_slave.c
@@ -1402,7 +1402,7 @@ struct spi_slave_ctrlr_s *esp32_spislv_ctrlr_initialize(int port)
 
   /* Set up to receive peripheral interrupts on the current CPU */
 
-  priv->cpu = up_cpu_index();
+  priv->cpu = this_cpu();
   priv->cpuint = esp32_setup_irq(priv->cpu, priv->config->periph,
                                  1, ESP32_CPUINT_LEVEL);
 

--- a/arch/xtensa/src/esp32/esp32_spiflash.c
+++ b/arch/xtensa/src/esp32/esp32_spiflash.c
@@ -472,7 +472,7 @@ static void esp32_spiflash_opstart(void)
 
   nxsched_set_priority(tcb, SCHED_PRIORITY_MAX);
 
-  cpu = up_cpu_index();
+  cpu = this_cpu();
 #ifdef CONFIG_SMP
   other_cpu = cpu == 1 ? 0 : 1;
 #endif
@@ -521,7 +521,7 @@ static void esp32_spiflash_opstart(void)
 
 static void esp32_spiflash_opdone(void)
 {
-  const int cpu = up_cpu_index();
+  const int cpu = this_cpu();
 #ifdef CONFIG_SMP
   const int other_cpu = cpu ? 0 : 1;
 #endif
@@ -2382,7 +2382,7 @@ static int esp32_ioctl_encrypt(struct mtd_dev_s *dev, int cmd,
 static int spi_flash_op_block_task(int argc, char *argv[])
 {
   struct tcb_s *tcb = this_task();
-  int cpu = up_cpu_index();
+  int cpu = this_cpu();
 
   for (; ; )
     {

--- a/arch/xtensa/src/esp32/esp32_spiram.c
+++ b/arch/xtensa/src/esp32/esp32_spiram.c
@@ -178,7 +178,7 @@ unsigned int IRAM_ATTR cache_sram_mmu_set(int cpu_no, int pid,
 
   if (smp_start)
     {
-      cpu_to_stop = up_cpu_index() == 1 ? 0 : 1;
+      cpu_to_stop = this_cpu() == 1 ? 0 : 1;
       up_cpu_pause(cpu_to_stop);
     }
 

--- a/arch/xtensa/src/esp32/esp32_tim.c
+++ b/arch/xtensa/src/esp32/esp32_tim.c
@@ -550,7 +550,7 @@ static int esp32_tim_setisr(struct esp32_tim_dev_s *dev, xcpt_t handler,
 
       /* Set up to receive peripheral interrupts on the current CPU */
 
-      tim->core = up_cpu_index();
+      tim->core = this_cpu();
       tim->cpuint = esp32_setup_irq(tim->core, tim->periph,
                                     tim->priority, ESP32_CPUINT_LEVEL);
       if (tim->cpuint < 0)

--- a/arch/xtensa/src/esp32/esp32_twai.c
+++ b/arch/xtensa/src/esp32/esp32_twai.c
@@ -475,7 +475,7 @@ static int esp32twai_setup(struct can_dev_s *dev)
       up_disable_irq(priv->irq);
     }
 
-  priv->cpu = up_cpu_index();
+  priv->cpu = this_cpu();
   priv->cpuint = esp32_setup_irq(priv->cpu, priv->periph,
                                  1, ESP32_CPUINT_LEVEL);
   if (priv->cpuint < 0)

--- a/arch/xtensa/src/esp32/esp32_wdt.c
+++ b/arch/xtensa/src/esp32/esp32_wdt.c
@@ -762,7 +762,7 @@ static int esp32_wdt_setisr(struct esp32_wdt_dev_s *dev, xcpt_t handler,
       else
 #endif
         {
-          wdt->cpu = up_cpu_index();
+          wdt->cpu = this_cpu();
           wdt->cpuint = esp32_setup_irq(wdt->cpu, wdt->periph,
                                         1, ESP32_CPUINT_LEVEL);
           if (wdt->cpuint < 0)

--- a/arch/xtensa/src/esp32s2/esp32s2_i2s.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_i2s.c
@@ -2650,7 +2650,7 @@ static int i2s_dma_setup(struct esp32s2_i2s_s *priv)
 
   /* Set up to receive peripheral interrupts on the current CPU */
 
-  priv->cpu = up_cpu_index();
+  priv->cpu = this_cpu();
   priv->cpuint = esp32s2_setup_irq(priv->config->periph, 1,
                                    ESP32S2_CPUINT_LEVEL);
   if (priv->cpuint < 0)

--- a/arch/xtensa/src/esp32s2/esp32s2_spi_slave.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_spi_slave.c
@@ -1628,7 +1628,7 @@ struct spi_slave_ctrlr_s *esp32s2_spislave_ctrlr_initialize(int port)
                          spislave_cs_interrupt,
                          priv));
 
-  priv->cpu = up_cpu_index();
+  priv->cpu = this_cpu();
   priv->cpuint = esp32s2_setup_irq(priv->config->periph,
                                    ESP32S2_INT_PRIO_DEF,
                                    ESP32S2_CPUINT_LEVEL);

--- a/arch/xtensa/src/esp32s3/esp32s3_cpustart.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_cpustart.c
@@ -119,7 +119,7 @@ void xtensa_appcpu_start(void)
                  XCPTCONTEXT_SIZE;
   __asm__ __volatile__("mov sp, %0\n" : : "r"(sp));
 
-  sinfo("CPU%d Started\n", up_cpu_index());
+  sinfo("CPU%d Started\n", this_cpu());
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION
   /* Notify that this CPU has started */

--- a/arch/xtensa/src/esp32s3/esp32s3_gpio.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_gpio.c
@@ -403,7 +403,7 @@ void esp32s3_gpioirqinitialize(void)
 
   /* Setup the GPIO interrupt. */
 
-  cpu = up_cpu_index();
+  cpu = this_cpu();
 
   g_gpio_cpuint = esp32s3_setup_irq(cpu, ESP32S3_PERIPH_GPIO_INT_CPU, 1,
                                     ESP32S3_CPUINT_LEVEL);

--- a/arch/xtensa/src/esp32s3/esp32s3_i2c.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_i2c.c
@@ -1567,7 +1567,7 @@ struct i2c_master_s *esp32s3_i2cbus_initialize(int port)
 
   /* Set up to receive peripheral interrupts on the current CPU */
 
-  priv->cpu = up_cpu_index();
+  priv->cpu = this_cpu();
   priv->cpuint = esp32s3_setup_irq(priv->cpu, config->periph,
                                    1, ESP32S3_CPUINT_LEVEL);
   if (priv->cpuint < 0)

--- a/arch/xtensa/src/esp32s3/esp32s3_i2s.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_i2s.c
@@ -3071,7 +3071,7 @@ static int i2s_dma_setup(struct esp32s3_i2s_s *priv)
    * will be assigned to a different CPU interrupt.
    */
 
-  priv->cpu = up_cpu_index();
+  priv->cpu = this_cpu();
 
 #ifdef I2S_HAVE_TX
   if (priv->config->tx_en)

--- a/arch/xtensa/src/esp32s3/esp32s3_intercpu_interrupt.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_intercpu_interrupt.c
@@ -55,7 +55,7 @@ static int IRAM_ATTR esp32s3_fromcpu_interrupt(int fromcpu)
   uintptr_t regaddr;
 
   DEBUGASSERT((unsigned)fromcpu < CONFIG_SMP_NCPUS);
-  DEBUGASSERT(fromcpu != up_cpu_index());
+  DEBUGASSERT(fromcpu != this_cpu());
 
   /* Clear the interrupt from the other CPU */
 
@@ -107,7 +107,7 @@ int IRAM_ATTR xtensa_intercpu_interrupt(int tocpu, int intcode)
   DEBUGASSERT((unsigned)tocpu < CONFIG_SMP_NCPUS &&
               (unsigned)intcode <= UINT8_MAX);
 
-  fromcpu = up_cpu_index();
+  fromcpu = this_cpu();
   DEBUGASSERT(fromcpu != tocpu);
 
   /* Generate an Inter-Processor Interrupt */

--- a/arch/xtensa/src/esp32s3/esp32s3_irq.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_irq.c
@@ -412,7 +412,7 @@ static void esp32s3_free_cpuint(int cpuint)
   bitmask  = 1ul << cpuint;
 
 #ifdef CONFIG_SMP
-  if (up_cpu_index() != 0)
+  if (this_cpu() != 0)
     {
       freeints = &g_cpu1_freeints;
     }
@@ -565,7 +565,7 @@ void up_disable_irq(int irq)
        */
 
 #ifdef CONFIG_SMP
-      int me = up_cpu_index();
+      int me = this_cpu();
       if (me != cpu)
         {
           /* It was the other CPU that enabled this interrupt. */
@@ -615,7 +615,7 @@ void up_enable_irq(int irq)
        * we are just overwriting the cpu part of the map.
        */
 
-      int cpu = up_cpu_index();
+      int cpu = this_cpu();
 
       /* Enable the CPU interrupt now for internal CPU. */
 
@@ -709,7 +709,7 @@ int esp32s3_cpuint_initialize(void)
 #ifdef CONFIG_SMP
   /* Which CPU are we initializing */
 
-  cpu = up_cpu_index();
+  cpu = this_cpu();
   DEBUGASSERT(cpu >= 0 && cpu < CONFIG_SMP_NCPUS);
 #endif
 
@@ -1002,7 +1002,7 @@ uint32_t *xtensa_int_decode(uint32_t cpuints, uint32_t *regs)
 #endif
   /* Select PRO or APP CPU interrupt mapping table */
 
-  cpu = up_cpu_index();
+  cpu = this_cpu();
 
 #ifdef CONFIG_SMP
   if (cpu != 0)
@@ -1093,7 +1093,7 @@ void esp32s3_irq_noniram_disable(void)
   uint32_t non_iram_ints;
 
   irqstate = enter_critical_section();
-  cpu = up_cpu_index();
+  cpu = this_cpu();
   non_iram_ints = g_non_iram_int_mask[cpu];
 
   ASSERT(!g_non_iram_int_disabled_flag[cpu]);
@@ -1129,7 +1129,7 @@ void esp32s3_irq_noniram_enable(void)
   uint32_t non_iram_ints;
 
   irqstate = enter_critical_section();
-  cpu = up_cpu_index();
+  cpu = this_cpu();
   non_iram_ints = g_non_iram_int_disabled[cpu];
 
   ASSERT(g_non_iram_int_disabled_flag[cpu]);

--- a/arch/xtensa/src/esp32s3/esp32s3_lcd.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_lcd.c
@@ -847,7 +847,7 @@ static int esp32s3_lcd_config(void)
 
   flags = spin_lock_irqsave(&priv->lock);
 
-  priv->cpu = up_cpu_index();
+  priv->cpu = this_cpu();
   priv->cpuint = esp32s3_setup_irq(priv->cpu,
                                    ESP32S3_PERIPH_LCD_CAM,
                                    ESP32S3_INT_PRIO_DEF,

--- a/arch/xtensa/src/esp32s3/esp32s3_otg_device.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_otg_device.c
@@ -5642,7 +5642,7 @@ void xtensa_usbinitialize(void)
 
   /* Attach the OTG interrupt handler */
 
-  priv->cpu = up_cpu_index();
+  priv->cpu = this_cpu();
   priv->cpuint = esp32s3_setup_irq(priv->cpu, ESP32S3_PERIPH_USB,
                                    1, ESP32S3_CPUINT_LEVEL);
   DEBUGASSERT(priv->cpuint >= 0);

--- a/arch/xtensa/src/esp32s3/esp32s3_qspi.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_qspi.c
@@ -1578,7 +1578,7 @@ struct qspi_dev_s *esp32s3_qspibus_initialize(int port)
 
   /* Set up to receive peripheral interrupts on the current CPU */
 
-  priv->cpu = up_cpu_index();
+  priv->cpu = this_cpu();
   priv->cpuint = esp32s3_setup_irq(priv->cpu, priv->config->periph,
                                    ESP32S3_INT_PRIO_DEF,
                                    ESP32S3_CPUINT_LEVEL);

--- a/arch/xtensa/src/esp32s3/esp32s3_rt_timer.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_rt_timer.c
@@ -317,7 +317,7 @@ static int rt_timer_setisr(xcpt_t handler, void *arg)
 
       /* Set up to receive peripheral interrupts on the current CPU */
 
-      priv->core = up_cpu_index();
+      priv->core = this_cpu();
       priv->cpuint = esp32s3_setup_irq(priv->core,
                                        ESP32S3_PERIPH_SYSTIMER_TARGET2,
                                        1, ESP32S3_CPUINT_LEVEL);

--- a/arch/xtensa/src/esp32s3/esp32s3_rtc_gpio.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_rtc_gpio.c
@@ -406,7 +406,7 @@ void esp32s3_rtcioirqinitialize(void)
 {
   /* Setup the RTCIO interrupt. */
 
-  int cpu = up_cpu_index();
+  int cpu = this_cpu();
   g_rtcio_cpuint = esp32s3_setup_irq(cpu, ESP32S3_PERIPH_RTC_CORE,
                                      1, ESP32S3_CPUINT_LEVEL);
   DEBUGASSERT(g_rtcio_cpuint >= 0);

--- a/arch/xtensa/src/esp32s3/esp32s3_sdmmc.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_sdmmc.c
@@ -1626,7 +1626,7 @@ static int esp32s3_attach(struct sdio_dev_s *dev)
   uint32_t regval;
   struct esp32s3_dev_s *priv = (struct esp32s3_dev_s *)dev;
 
-  ret = esp32s3_setup_irq(up_cpu_index(), ESP32S3_PERIPH_SDIO_HOST,
+  ret = esp32s3_setup_irq(this_cpu(), ESP32S3_PERIPH_SDIO_HOST,
                           1, ESP32S3_CPUINT_LEVEL);
   DEBUGASSERT(ret >= 0);
 

--- a/arch/xtensa/src/esp32s3/esp32s3_serial.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_serial.c
@@ -537,7 +537,7 @@ static int esp32s3_attach(struct uart_dev_s *dev)
 
   /* Set up to receive peripheral interrupts on the current CPU */
 
-  priv->cpu = up_cpu_index();
+  priv->cpu = this_cpu();
   priv->cpuint = esp32s3_setup_irq(priv->cpu, priv->periph, priv->int_pri,
                                    ESP32S3_CPUINT_LEVEL);
   if (priv->cpuint < 0)

--- a/arch/xtensa/src/esp32s3/esp32s3_spi.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_spi.c
@@ -1619,7 +1619,7 @@ struct spi_dev_s *esp32s3_spibus_initialize(int port)
 
   /* Set up to receive peripheral interrupts on the current CPU */
 
-  priv->cpu = up_cpu_index();
+  priv->cpu = this_cpu();
   priv->cpuint = esp32s3_setup_irq(priv->cpu, priv->config->periph,
                                    ESP32S3_INT_PRIO_DEF,
                                    ESP32S3_CPUINT_LEVEL);

--- a/arch/xtensa/src/esp32s3/esp32s3_spi_slave.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_spi_slave.c
@@ -1808,7 +1808,7 @@ struct spi_slave_ctrlr_s *esp32s3_spislave_ctrlr_initialize(int port)
                          spislave_cs_interrupt,
                          priv));
 
-  priv->cpu = up_cpu_index();
+  priv->cpu = this_cpu();
   priv->cpuint = esp32s3_setup_irq(priv->cpu,
                                    priv->config->periph,
                                    ESP32S3_INT_PRIO_DEF,

--- a/arch/xtensa/src/esp32s3/esp32s3_spiflash.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_spiflash.c
@@ -241,7 +241,7 @@ static sem_t g_disable_non_iram_isr_on_core[CONFIG_SMP_NCPUS];
 
 static void spiflash_suspend_cache(void)
 {
-  int cpu = up_cpu_index();
+  int cpu = this_cpu();
 #ifdef CONFIG_SMP
   int other_cpu = cpu ? 0 : 1;
 #endif
@@ -261,7 +261,7 @@ static void spiflash_suspend_cache(void)
 
 static void spiflash_resume_cache(void)
 {
-  int cpu = up_cpu_index();
+  int cpu = this_cpu();
 #ifdef CONFIG_SMP
   int other_cpu = cpu ? 0 : 1;
 #endif
@@ -294,7 +294,7 @@ static void spiflash_start(void)
 
   nxsched_set_priority(tcb, SCHED_PRIORITY_MAX);
 
-  cpu = up_cpu_index();
+  cpu = this_cpu();
 #ifdef CONFIG_SMP
   other_cpu = cpu == 1 ? 0 : 1;
 #endif
@@ -308,7 +308,7 @@ static void spiflash_start(void)
     {
       g_flash_op_can_start = false;
 
-      cpu = up_cpu_index();
+      cpu = this_cpu();
       other_cpu = cpu ? 0 : 1;
 
       nxsem_post(&g_disable_non_iram_isr_on_core[other_cpu]);
@@ -343,7 +343,7 @@ static void spiflash_start(void)
 
 static void spiflash_end(void)
 {
-  const int cpu = up_cpu_index();
+  const int cpu = this_cpu();
 #ifdef CONFIG_SMP
   const int other_cpu = cpu ? 0 : 1;
 #endif
@@ -821,7 +821,7 @@ static void spi_flash_restore_cache(void)
 static int spi_flash_op_block_task(int argc, char *argv[])
 {
   struct tcb_s *tcb = this_task();
-  int cpu = up_cpu_index();
+  int cpu = this_cpu();
 
   for (; ; )
     {

--- a/arch/xtensa/src/esp32s3/esp32s3_spiram.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_spiram.c
@@ -289,7 +289,7 @@ int IRAM_ATTR cache_dbus_mmu_map(int vaddr, int paddr, int num)
   irqstate_t flags;
   uint32_t actual_mapped_len;
   uint32_t cache_state[CONFIG_SMP_NCPUS];
-  int cpu = up_cpu_index();
+  int cpu = this_cpu();
 #ifdef CONFIG_SMP
   bool smp_start = OSINIT_OS_READY();
   int other_cpu = cpu ? 0 : 1;

--- a/arch/xtensa/src/esp32s3/esp32s3_tim.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_tim.c
@@ -749,7 +749,7 @@ static int tim_setisr(struct esp32s3_tim_dev_s *dev, xcpt_t handler,
 
       /* Set up to receive peripheral interrupts on the current CPU */
 
-      priv->core = up_cpu_index();
+      priv->core = this_cpu();
       priv->cpuint = esp32s3_setup_irq(priv->core, priv->periph,
                                        priv->priority, ESP32S3_CPUINT_LEVEL);
       if (priv->cpuint < 0)

--- a/arch/xtensa/src/esp32s3/esp32s3_twai.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_twai.c
@@ -472,7 +472,7 @@ static int esp32s3twai_setup(struct can_dev_s *dev)
       up_disable_irq(priv->irq);
     }
 
-  priv->cpu = up_cpu_index();
+  priv->cpu = this_cpu();
   priv->cpuint = esp32s3_setup_irq(priv->cpu, priv->periph,
                                    1, ESP32S3_CPUINT_LEVEL);
   if (priv->cpuint < 0)

--- a/arch/xtensa/src/esp32s3/esp32s3_usbserial.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_usbserial.c
@@ -280,7 +280,7 @@ static int esp32s3_attach(struct uart_dev_s *dev)
 
   /* Try to attach the IRQ to a CPU int */
 
-  priv->cpu = up_cpu_index();
+  priv->cpu = this_cpu();
   priv->cpuint = esp32s3_setup_irq(priv->cpu, priv->periph,
                                    ESP32S3_INT_PRIO_DEF,
                                    ESP32S3_CPUINT_LEVEL);

--- a/arch/xtensa/src/esp32s3/esp32s3_wdt.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_wdt.c
@@ -804,7 +804,7 @@ static int32_t wdt_setisr(struct esp32s3_wdt_dev_s *dev, xcpt_t handler,
       else
 #endif
         {
-          wdt->cpu = up_cpu_index();
+          wdt->cpu = this_cpu();
           wdt->cpuint = esp32s3_setup_irq(wdt->cpu, wdt->periph,
                                           1, ESP32S3_CPUINT_LEVEL);
           if (wdt->cpuint < 0)

--- a/boards/arm/cxd56xx/common/src/cxd56_crashdump.c
+++ b/boards/arm/cxd56xx/common/src/cxd56_crashdump.c
@@ -187,7 +187,7 @@ void board_crashdump(uintptr_t sp, struct tcb_s *tcb,
   /* Get the limits on the interrupt stack memory */
 
   pdump->info.stacks.interrupt.top =
-    up_get_intstackbase(up_cpu_index()) + INTSTACK_SIZE;
+    up_get_intstackbase(this_cpu()) + INTSTACK_SIZE;
   pdump->info.stacks.interrupt.size = INTSTACK_SIZE;
 
   /* If In interrupt Context save the interrupt stack data centered

--- a/boards/arm/cxd56xx/spresense/include/board.h
+++ b/boards/arm/cxd56xx/spresense/include/board.h
@@ -135,7 +135,7 @@
 #define LED_CPU1                (101)
 #define LED_CPU2                (102)
 #define LED_CPU3                (103)
-#define LED_CPU                 (LED_CPU0 + up_cpu_index())
+#define LED_CPU                 (LED_CPU0 + this_cpu())
 #endif
 
 /* Buttons definitions ******************************************************/

--- a/boards/xtensa/esp32/esp32-sparrow-kit/include/board.h
+++ b/boards/xtensa/esp32/esp32-sparrow-kit/include/board.h
@@ -95,7 +95,7 @@
 #ifdef CONFIG_ARCH_LEDS_CPU_ACTIVITY
 #  define LED_CPU0        8
 #  define LED_CPU1        9
-#  define LED_CPU         (LED_CPU0 + up_cpu_index())
+#  define LED_CPU         (LED_CPU0 + this_cpu())
 #endif
 
 /* GPIO pins used by the GPIO Subsystem */

--- a/boards/xtensa/esp32/esp32-wrover-kit/include/board.h
+++ b/boards/xtensa/esp32/esp32-wrover-kit/include/board.h
@@ -117,7 +117,7 @@
 #ifdef CONFIG_ARCH_LEDS_CPU_ACTIVITY
 #  define LED_CPU0        8
 #  define LED_CPU1        9
-#  define LED_CPU         (LED_CPU0 + up_cpu_index())
+#  define LED_CPU         (LED_CPU0 + this_cpu())
 #endif
 
 /* GPIO pins used by the GPIO Subsystem */

--- a/drivers/net/netdev_upperhalf.c
+++ b/drivers/net/netdev_upperhalf.c
@@ -753,7 +753,7 @@ static inline void netdev_upper_queue_work(FAR struct net_driver_s *dev)
   FAR struct netdev_upperhalf_s *upper = dev->d_private;
 
 #ifdef CONFIG_NETDEV_WORK_THREAD
-  int cpu = up_cpu_index();
+  int cpu = this_cpu();
   int semcount;
 
   if (nxsem_get_value(&upper->sem[cpu], &semcount) == OK &&

--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -210,7 +210,7 @@ static void dump_stack(FAR const char *tag, uintptr_t sp,
 static void dump_stacks(FAR struct tcb_s *rtcb, uintptr_t sp)
 {
 #if CONFIG_ARCH_INTERRUPTSTACK > 0
-  uintptr_t intstack_base = up_get_intstackbase(up_cpu_index());
+  uintptr_t intstack_base = up_get_intstackbase(this_cpu());
   size_t intstack_size = CONFIG_ARCH_INTERRUPTSTACK;
   uintptr_t intstack_top = intstack_base + intstack_size;
   uintptr_t intstack_sp = 0;
@@ -259,7 +259,7 @@ static void dump_stacks(FAR struct tcb_s *rtcb, uintptr_t sp)
                  intstack_base,
                  intstack_size,
 #ifdef CONFIG_STACK_COLORATION
-                 up_check_intstack(up_cpu_index())
+                 up_check_intstack(this_cpu())
 #else
                  0
 #endif

--- a/sched/sched/sched.h
+++ b/sched/sched/sched.h
@@ -67,7 +67,7 @@
 #  define current_task(cpu)      ((FAR struct tcb_s *)list_assignedtasks(cpu)->head)
 #else
 #  define current_task(cpu)      ((FAR struct tcb_s *)list_readytorun()->head)
-#  define this_task()            (current_task(up_cpu_index()))
+#  define this_task()            (current_task(this_cpu()))
 #endif
 
 #define is_idle_task(t)          ((t)->pid < CONFIG_SMP_NCPUS)
@@ -77,7 +77,7 @@
  */
 
 #define running_task() \
-  (up_interrupt_context() ? g_running_tasks[up_cpu_index()] : this_task())
+  (up_interrupt_context() ? g_running_tasks[this_cpu()] : this_task())
 
 /* List attribute flags */
 


### PR DESCRIPTION
## Summary
Make this_cpu is arch independent and up_cpu_index do that. In AMP mode, up_cpu_index() may return the index of the physical core, this_cpu() will always return 0.

In SMP mode, up_cpu_index()/this_cpu() are the same, both return the index of the physical core.

## Impact
In AMP mode, carefully check risc-v/xtensa arch.

## Testing
FC7300 board for armv7-m in AMP mode to customize up_cpu_index().
  
