### PR TITLE
mmcsd: fix cmd6 timeout error when repeat called，if CMD6 is sent again before last transmission is complete, a timeout error will be encountered

### DIFF
--- a/drivers/mmcsd/mmcsd_sdio.c
+++ b/drivers/mmcsd/mmcsd_sdio.c
@@ -1023,7 +1023,7 @@ static int mmcsd_switch(FAR struct mmcsd_state_s *priv, uint32_t arg)
    * CMD6(SWITCH) to set the PARTITION_ACCESS bits in the EXT_CSD
    * register, byte[179].After that, master can use the Multiple Block
    * read and write commands (CMD23, CMD18 and CMD25) to access the
-   * RPMB partition.
+   * specified partition.
    * PARTITION_CONFIG[179](see 7.4.69)
    * Bit[2:0] : PARTITION_ACCESS (before BOOT_PARTITION_ACCESS)
    * User selects partitions to access:
@@ -1049,7 +1049,17 @@ static int mmcsd_switch(FAR struct mmcsd_state_s *priv, uint32_t arg)
    *  [2:0] Cmd Set
    */
 
+  int ret;
+
+  ret = mmcsd_transferready(priv);
+  if (ret != OK)
+    {
+      ferr("ERROR: Card not ready: %d\n", ret);
+      return ret;
+    }
+
   mmcsd_sendcmdpoll(priv, MMCSD_CMD6, arg);
+  priv->wrbusy = true;
   return mmcsd_recv_r1(priv, MMCSD_CMD6);
 }
 


### PR DESCRIPTION
## Summary
  If CMD6 is sent again before last transmission is complete, a timeout error will be encountered.
## Impact
  impact cmd6 command continuous execution
## Testing
  test it passed on bes1600 (Cortext M55)
