### PR TITLE
usbdev: extend the usb req len to unit32_t

### DIFF
--- a/arch/arm/src/at32/at32_otgfsdev.c
+++ b/arch/arm/src/at32/at32_otgfsdev.c
@@ -1319,7 +1319,7 @@ static void at32_epin_request(struct at32_usbdev_s *priv,
       return;
     }
 
-  uinfo("EP%d req=%p: len=%d xfrd=%d zlp=%d\n",
+  uinfo("EP%d req=%p: len=%zu xfrd=%zu zlp=%d\n",
         privep->epphy, privreq, privreq->req.len,
         privreq->req.xfrd, privep->zlp);
 
@@ -1589,7 +1589,7 @@ static void at32_epout_complete(struct at32_usbdev_s *priv,
       return;
     }
 
-  uinfo("EP%d: len=%d xfrd=%d\n",
+  uinfo("EP%d: len=%zu xfrd=%zu\n",
         privep->epphy, privreq->req.len, privreq->req.xfrd);
 
   /* Return the completed read request to the class driver and mark the state
@@ -1745,7 +1745,7 @@ static inline void at32_epout_receive(struct at32_ep_s *privep,
       return;
     }
 
-  uinfo("EP%d: len=%d xfrd=%d\n",
+  uinfo("EP%d: len=%zu xfrd=%zu\n",
         privep->epphy, privreq->req.len, privreq->req.xfrd);
   usbtrace(TRACE_READ(privep->epphy), bcnt);
 

--- a/arch/arm/src/efm32/efm32_usbdev.c
+++ b/arch/arm/src/efm32/efm32_usbdev.c
@@ -1223,7 +1223,7 @@ static void efm32_epin_request(struct efm32_usbdev_s *priv,
       return;
     }
 
-  uinfo("EP%d req=%p: len=%d xfrd=%d zlp=%d\n",
+  uinfo("EP%d req=%p: len=%zu xfrd=%zu zlp=%d\n",
         privep->epphy, privreq, privreq->req.len,
         privreq->req.xfrd, privep->zlp);
 
@@ -1506,7 +1506,7 @@ static void efm32_epout_complete(struct efm32_usbdev_s *priv,
       return;
     }
 
-  uinfo("EP%d: len=%d xfrd=%d\n",
+  uinfo("EP%d: len=%zu xfrd=%zu\n",
         privep->epphy, privreq->req.len, privreq->req.xfrd);
 
   /* Return the completed read request to the class driver and mark the state
@@ -1638,7 +1638,7 @@ static inline void efm32_epout_receive(struct efm32_ep_s *privep,
       return;
     }
 
-  uinfo("EP%d: len=%d xfrd=%d\n",
+  uinfo("EP%d: len=%zu xfrd=%zu\n",
         privep->epphy, privreq->req.len, privreq->req.xfrd);
   usbtrace(TRACE_READ(privep->epphy), bcnt);
 

--- a/arch/arm/src/kinetis/kinetis_usbdev.c
+++ b/arch/arm/src/kinetis/kinetis_usbdev.c
@@ -970,10 +970,10 @@ static void khci_wrcomplete(struct khci_usbdev_s *priv,
   epno   = USB_EPNO(privep->ep.eplog);
 
 #ifdef CONFIG_USBDEV_NOWRITEAHEAD
-  uinfo("EP%d: len=%d xfrd=%d inflight=%d\n",
+  uinfo("EP%d: len=%zu xfrd=%zu inflight=%d\n",
         epno, privreq->req.len, privreq->req.xfrd, privreq->inflight[0]);
 #else
-  uinfo("EP%d: len=%d xfrd=%d inflight={%d, %d}\n",
+  uinfo("EP%d: len=%zu xfrd=%zu inflight={%d, %d}\n",
         epno, privreq->req.len, privreq->req.xfrd,
         privreq->inflight[0], privreq->inflight[1]);
 #endif
@@ -1291,7 +1291,7 @@ static int khci_wrstart(struct khci_usbdev_s *priv,
       bytesleft = privreq->req.len;
     }
 
-  uinfo("epno=%d req=%p: len=%d xfrd=%d index=%d nullpkt=%d\n",
+  uinfo("epno=%d req=%p: len=%zu xfrd=%zu index=%d nullpkt=%d\n",
         epno, privreq, privreq->req.len, xfrd, index, privep->txnullpkt);
 
   /* Get the number of bytes left to be sent in the packet */
@@ -1406,7 +1406,7 @@ static int khci_rdcomplete(struct khci_usbdev_s *priv,
   bdtout = privep->bdtout;
   epno   = USB_EPNO(privep->ep.eplog);
 
-  uinfo("EP%d: len=%d xfrd=%d\n",
+  uinfo("EP%d: len=%zu xfrd=%zu\n",
         epno, privreq->req.len, privreq->req.xfrd);
   bdtinfo("EP%d BDT OUT [%p] {%08x, %08x}\n",
         epno, bdtout, bdtout->status, bdtout->addr);

--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_usbdev.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_usbdev.c
@@ -1098,7 +1098,7 @@ static int lpc17_40_wrrequest(struct lpc17_40_ep_s *privep)
       return OK;
     }
 
-  uinfo("epphy=%d req=%p: len=%d xfrd=%d nullpkt=%d\n",
+  uinfo("epphy=%d req=%p: len=%zu xfrd=%zu nullpkt=%d\n",
         privep->epphy, privreq, privreq->req.len, privreq->req.xfrd,
         privep->txnullpkt);
 
@@ -1208,7 +1208,7 @@ static int lpc17_40_rdrequest(struct lpc17_40_ep_s *privep)
       return OK;
     }
 
-  uinfo("len=%d xfrd=%d nullpkt=%d\n",
+  uinfo("len=%zu xfrd=%zu nullpkt=%d\n",
         privreq->req.len, privreq->req.xfrd, privep->txnullpkt);
 
   /* Ignore any attempt to receive a zero length packet */

--- a/arch/arm/src/lpc214x/lpc214x_usbdev.c
+++ b/arch/arm/src/lpc214x/lpc214x_usbdev.c
@@ -1035,7 +1035,7 @@ static int lpc214x_wrrequest(struct lpc214x_ep_s *privep)
       return OK;
     }
 
-  uinfo("epphy=%d req=%p: len=%d xfrd=%d nullpkt=%d\n",
+  uinfo("epphy=%d req=%p: len=%zu xfrd=%zu nullpkt=%d\n",
         privep->epphy, privreq, privreq->req.len, privreq->req.xfrd,
         privep->txnullpkt);
 
@@ -1145,7 +1145,7 @@ static int lpc214x_rdrequest(struct lpc214x_ep_s *privep)
       return OK;
     }
 
-  uinfo("len=%d xfrd=%d nullpkt=%d\n",
+  uinfo("len=%zu xfrd=%zu nullpkt=%d\n",
         privreq->req.len, privreq->req.xfrd, privep->txnullpkt);
 
   /* Ignore any attempt to receive a zero length packet */

--- a/arch/arm/src/nrf52/nrf52_usbd.c
+++ b/arch/arm/src/nrf52/nrf52_usbd.c
@@ -1255,7 +1255,7 @@ static void nrf52_epout_complete(struct nrf52_ep_s *privep)
       return;
     }
 
-  uinfo("EP%d: len=%d xfrd=%d\n", privep->epphy, privreq->req.len,
+  uinfo("EP%d: len=%zu xfrd=%zu\n", privep->epphy, privreq->req.len,
         privreq->req.xfrd);
 
   /* Return the completed read request to the class driver and mark the
@@ -1345,7 +1345,7 @@ static void nrf52_epout_receive(struct nrf52_ep_s *privep)
       return;
     }
 
-  uinfo("EP%d: len=%d xfrd=%d\n", privep->epphy,
+  uinfo("EP%d: len=%zu xfrd=%zu\n", privep->epphy,
         privreq->req.len, privreq->req.xfrd);
   usbtrace(TRACE_READ(privep->epphy), bcnt);
 

--- a/arch/arm/src/nrf53/nrf53_usbd.c
+++ b/arch/arm/src/nrf53/nrf53_usbd.c
@@ -1255,7 +1255,7 @@ static void nrf53_epout_complete(struct nrf53_ep_s *privep)
       return;
     }
 
-  uinfo("EP%d: len=%d xfrd=%d\n", privep->epphy, privreq->req.len,
+  uinfo("EP%d: len=%zu xfrd=%zu\n", privep->epphy, privreq->req.len,
         privreq->req.xfrd);
 
   /* Return the completed read request to the class driver and mark the
@@ -1345,7 +1345,7 @@ static void nrf53_epout_receive(struct nrf53_ep_s *privep)
       return;
     }
 
-  uinfo("EP%d: len=%d xfrd=%d\n", privep->epphy,
+  uinfo("EP%d: len=%zu xfrd=%zu\n", privep->epphy,
         privreq->req.len, privreq->req.xfrd);
   usbtrace(TRACE_READ(privep->epphy), bcnt);
 

--- a/arch/arm/src/sam34/sam_udp.c
+++ b/arch/arm/src/sam34/sam_udp.c
@@ -941,7 +941,7 @@ static int sam_req_write(struct sam_usbdev_s *priv, struct sam_ep_s *privep)
           return -ENOENT;
         }
 
-      uinfo("epno=%d req=%p: len=%d xfrd=%d inflight=%d zlpneeded=%d\n",
+      uinfo("epno=%d req=%p: len=%zu xfrd=%zu inflight=%d zlpneeded=%d\n",
             epno, privreq, privreq->req.len, privreq->req.xfrd,
             privreq->inflight, privep->zlpneeded);
 
@@ -1113,7 +1113,7 @@ static int sam_req_read(struct sam_usbdev_s *priv, struct sam_ep_s *privep,
           return -ENOENT;
         }
 
-      uinfo("EP%d: len=%d xfrd=%d\n",
+      uinfo("EP%d: len=%zu xfrd=%zu\n",
             epno, privreq->req.len, privreq->req.xfrd);
 
       /* Ignore any attempt to receive a zero length packet */

--- a/arch/arm/src/sama5/sam_udphs.c
+++ b/arch/arm/src/sama5/sam_udphs.c
@@ -1360,7 +1360,7 @@ static int sam_req_write(struct sam_usbdev_s *priv, struct sam_ep_s *privep)
           return -ENOENT;
         }
 
-      uinfo("epno=%d req=%p: len=%d xfrd=%d inflight=%d zlpneeded=%d\n",
+      uinfo("epno=%d req=%p: len=%zu xfrd=%zu inflight=%d zlpneeded=%d\n",
             epno, privreq, privreq->req.len, privreq->req.xfrd,
             privreq->inflight, privep->zlpneeded);
 
@@ -1604,7 +1604,7 @@ static int sam_req_read(struct sam_usbdev_s *priv, struct sam_ep_s *privep,
           return -ENOENT;
         }
 
-      uinfo("EP%d: len=%d xfrd=%d\n",
+      uinfo("EP%d: len=%zu xfrd=%zu\n",
             epno, privreq->req.len, privreq->req.xfrd);
 
       /* Ignore any attempt to receive a zero length packet */

--- a/arch/arm/src/samd2l2/sam_usb.c
+++ b/arch/arm/src/samd2l2/sam_usb.c
@@ -1086,7 +1086,7 @@ static int sam_req_write(struct sam_usbdev_s *priv, struct sam_ep_s *privep)
           return -ENOENT;
         }
 
-      uinfo("epno=%d req=%p: len=%d xfrd=%d inflight=%d\n",
+      uinfo("epno=%d req=%p: len=%zu xfrd=%zu inflight=%d\n",
             epno, privreq, privreq->req.len, privreq->req.xfrd,
             privreq->inflight);
 
@@ -1227,7 +1227,7 @@ static int sam_req_read(struct sam_usbdev_s *priv, struct sam_ep_s *privep,
           return -ENOENT;
         }
 
-      uinfo("EP%d: req.len=%d xfrd=%d recvsize=%d\n",
+      uinfo("EP%d: req.len=%zu xfrd=%zu recvsize=%d\n",
             epno, privreq->req.len, privreq->req.xfrd, recvsize);
 
       /* Ignore any attempt to receive a zero length packet */

--- a/arch/arm/src/samd5e5/sam_usb.c
+++ b/arch/arm/src/samd5e5/sam_usb.c
@@ -1748,7 +1748,7 @@ static int sam_req_write(struct sam_usbdev_s *priv, struct sam_ep_s *privep)
           return -ENOENT;
         }
 
-      uinfo("epno=%d req=%p: len=%d xfrd=%d inflight=%d\n",
+      uinfo("epno=%d req=%p: len=%zu xfrd=%zu inflight=%d\n",
             epno, privreq, privreq->req.len, privreq->req.xfrd,
             privreq->inflight);
 
@@ -1890,7 +1890,7 @@ static int sam_req_read(struct sam_usbdev_s *priv, struct sam_ep_s *privep,
           return -ENOENT;
         }
 
-      uinfo("EP%d: req.len=%d xfrd=%d recvsize=%d\n",
+      uinfo("EP%d: req.len=%zu xfrd=%zu recvsize=%d\n",
             epno, privreq->req.len, privreq->req.xfrd, recvsize);
 
       /* Ignore any attempt to receive a zero length packet */

--- a/arch/arm/src/samv7/sam_usbdevhs.c
+++ b/arch/arm/src/samv7/sam_usbdevhs.c
@@ -1431,7 +1431,7 @@ static int sam_req_write(struct sam_usbdev_s *priv, struct sam_ep_s *privep)
           return -ENOENT;
         }
 
-      uinfo("epno=%d req=%p: len=%d xfrd=%d inflight=%d zlpneeded=%d\n",
+      uinfo("epno=%d req=%p: len=%zu xfrd=%zu inflight=%d zlpneeded=%d\n",
             epno, privreq, privreq->req.len, privreq->req.xfrd,
             privreq->inflight, privep->zlpneeded);
 
@@ -1671,7 +1671,7 @@ static int sam_req_read(struct sam_usbdev_s *priv, struct sam_ep_s *privep,
           return -ENOENT;
         }
 
-      uinfo("EP%d: len=%d xfrd=%d\n",
+      uinfo("EP%d: len=%zu xfrd=%zu\n",
             epno, privreq->req.len, privreq->req.xfrd);
 
       /* Ignore any attempt to receive a zero length packet */

--- a/arch/arm/src/stm32/stm32_otgfsdev.c
+++ b/arch/arm/src/stm32/stm32_otgfsdev.c
@@ -1265,7 +1265,7 @@ static void stm32_epin_request(struct stm32_usbdev_s *priv,
       return;
     }
 
-  uinfo("EP%d req=%p: len=%d xfrd=%d zlp=%d\n",
+  uinfo("EP%d req=%p: len=%zu xfrd=%zu zlp=%d\n",
         privep->epphy, privreq, privreq->req.len,
         privreq->req.xfrd, privep->zlp);
 
@@ -1548,7 +1548,7 @@ static void stm32_epout_complete(struct stm32_usbdev_s *priv,
       return;
     }
 
-  uinfo("EP%d: len=%d xfrd=%d\n",
+  uinfo("EP%d: len=%zu xfrd=%zu\n",
         privep->epphy, privreq->req.len, privreq->req.xfrd);
 
   /* Return the completed read request to the class driver and mark the state
@@ -1704,7 +1704,7 @@ static inline void stm32_epout_receive(struct stm32_ep_s *privep,
       return;
     }
 
-  uinfo("EP%d: len=%d xfrd=%d\n",
+  uinfo("EP%d: len=%zu xfrd=%zu\n",
         privep->epphy, privreq->req.len, privreq->req.xfrd);
   usbtrace(TRACE_READ(privep->epphy), bcnt);
 

--- a/arch/arm/src/stm32/stm32_otghsdev.c
+++ b/arch/arm/src/stm32/stm32_otghsdev.c
@@ -1214,7 +1214,7 @@ static void stm32_epin_request(struct stm32_usbdev_s *priv,
       return;
     }
 
-  uinfo("EP%d req=%p: len=%d xfrd=%d zlp=%d\n",
+  uinfo("EP%d req=%p: len=%zu xfrd=%zu zlp=%d\n",
         privep->epphy, privreq, privreq->req.len,
         privreq->req.xfrd, privep->zlp);
 
@@ -1497,7 +1497,7 @@ static void stm32_epout_complete(struct stm32_usbdev_s *priv,
       return;
     }
 
-  uinfo("EP%d: len=%d xfrd=%d\n",
+  uinfo("EP%d: len=%zu xfrd=%zu\n",
         privep->epphy, privreq->req.len, privreq->req.xfrd);
 
   /* Return the completed read request to the class driver and mark the state
@@ -1629,7 +1629,7 @@ static inline void stm32_epout_receive(struct stm32_ep_s *privep,
       return;
     }
 
-  uinfo("EP%d: len=%d xfrd=%d\n",
+  uinfo("EP%d: len=%zu xfrd=%zu\n",
         privep->epphy, privreq->req.len, privreq->req.xfrd);
   usbtrace(TRACE_READ(privep->epphy), bcnt);
 

--- a/arch/arm/src/stm32/stm32_usbdev.c
+++ b/arch/arm/src/stm32/stm32_usbdev.c
@@ -1335,7 +1335,7 @@ static int stm32_wrrequest(struct stm32_usbdev_s *priv,
     }
 
   epno = USB_EPNO(privep->ep.eplog);
-  uinfo("epno=%d req=%p: len=%d xfrd=%d nullpkt=%d\n",
+  uinfo("epno=%d req=%p: len=%zu xfrd=%zu nullpkt=%d\n",
         epno, privreq, privreq->req.len,
         privreq->req.xfrd, privep->txnullpkt);
   UNUSED(epno);
@@ -1484,7 +1484,8 @@ static int stm32_rdrequest(struct stm32_usbdev_s *priv,
       return -ENOENT;
     }
 
-  uinfo("EP%d: len=%d xfrd=%d\n", epno, privreq->req.len, privreq->req.xfrd);
+  uinfo("EP%d: len=%zu xfrd=%zu\n",
+        epno, privreq->req.len, privreq->req.xfrd);
 
   /* Ignore any attempt to receive a zero length packet */
 

--- a/arch/arm/src/stm32/stm32_usbfs.c
+++ b/arch/arm/src/stm32/stm32_usbfs.c
@@ -1311,7 +1311,7 @@ static int stm32_wrrequest(struct stm32_usbdev_s *priv,
     }
 
   epno = USB_EPNO(privep->ep.eplog);
-  uinfo("epno=%d req=%p: len=%d xfrd=%d nullpkt=%d\n",
+  uinfo("epno=%d req=%p: len=%zu xfrd=%zu nullpkt=%d\n",
         epno, privreq, privreq->req.len,
         privreq->req.xfrd, privep->txnullpkt);
   UNUSED(epno);
@@ -1460,7 +1460,8 @@ static int stm32_rdrequest(struct stm32_usbdev_s *priv,
       return -ENOENT;
     }
 
-  uinfo("EP%d: len=%d xfrd=%d\n", epno, privreq->req.len, privreq->req.xfrd);
+  uinfo("EP%d: len=%zu xfrd=%zu\n",
+        epno, privreq->req.len, privreq->req.xfrd);
 
   /* Ignore any attempt to receive a zero length packet */
 

--- a/arch/arm/src/stm32f0l0g0/stm32_usbdev.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_usbdev.c
@@ -1281,7 +1281,7 @@ static int stm32_wrrequest(struct stm32_usbdev_s *priv,
     }
 
   epno = USB_EPNO(privep->ep.eplog);
-  uinfo("epno=%d req=%p: len=%d xfrd=%d nullpkt=%d\n",
+  uinfo("epno=%d req=%p: len=%zu xfrd=%zu nullpkt=%d\n",
         epno, privreq, privreq->req.len,
         privreq->req.xfrd, privep->txnullpkt);
   UNUSED(epno);
@@ -1430,7 +1430,8 @@ static int stm32_rdrequest(struct stm32_usbdev_s *priv,
       return -ENOENT;
     }
 
-  uinfo("EP%d: len=%d xfrd=%d\n", epno, privreq->req.len, privreq->req.xfrd);
+  uinfo("EP%d: len=%zu xfrd=%zu\n",
+        epno, privreq->req.len, privreq->req.xfrd);
 
   /* Ignore any attempt to receive a zero length packet */
 

--- a/arch/arm/src/stm32f7/stm32_otgdev.c
+++ b/arch/arm/src/stm32f7/stm32_otgdev.c
@@ -1327,7 +1327,7 @@ static void stm32_epin_request(struct stm32_usbdev_s *priv,
       return;
     }
 
-  uinfo("EP%d req=%p: len=%d xfrd=%d zlp=%d\n",
+  uinfo("EP%d req=%p: len=%zu xfrd=%zu zlp=%d\n",
         privep->epphy, privreq, privreq->req.len,
         privreq->req.xfrd, privep->zlp);
 
@@ -1608,7 +1608,7 @@ static void stm32_epout_complete(struct stm32_usbdev_s *priv,
       return;
     }
 
-  uinfo("EP%d: len=%d xfrd=%d\n",
+  uinfo("EP%d: len=%zu xfrd=%zu\n",
         privep->epphy, privreq->req.len, privreq->req.xfrd);
 
   /* Return the completed read request to the class driver and mark the state
@@ -1740,7 +1740,7 @@ static inline void stm32_epout_receive(struct stm32_ep_s *privep,
       return;
     }
 
-  uinfo("EP%d: len=%d xfrd=%d\n", privep->epphy, privreq->req.len,
+  uinfo("EP%d: len=%zu xfrd=%zu\n", privep->epphy, privreq->req.len,
         privreq->req.xfrd);
   usbtrace(TRACE_READ(privep->epphy), bcnt);
 

--- a/arch/arm/src/stm32h7/stm32_otgdev.c
+++ b/arch/arm/src/stm32h7/stm32_otgdev.c
@@ -1582,7 +1582,7 @@ static void stm32_epout_complete(struct stm32_usbdev_s *priv,
       return;
     }
 
-  uinfo("EP%d: len=%d xfrd=%d\n",
+  uinfo("EP%d: len=%zu xfrd=%zu\n",
           privep->epphy, privreq->req.len, privreq->req.xfrd);
 
   /* Return the completed read request to the class driver and mark the
@@ -1714,7 +1714,7 @@ static inline void stm32_epout_receive(struct stm32_ep_s *privep,
       return;
     }
 
-  uinfo("EP%d: len=%d xfrd=%d\n", privep->epphy,
+  uinfo("EP%d: len=%zu xfrd=%zu\n", privep->epphy,
         privreq->req.len, privreq->req.xfrd);
   usbtrace(TRACE_READ(privep->epphy), bcnt);
 

--- a/arch/arm/src/stm32l4/stm32l4_otgfsdev.c
+++ b/arch/arm/src/stm32l4/stm32l4_otgfsdev.c
@@ -1325,7 +1325,7 @@ static void stm32l4_epin_request(struct stm32l4_usbdev_s *priv,
       return;
     }
 
-  uinfo("EP%d req=%p: len=%d xfrd=%d zlp=%d\n",
+  uinfo("EP%d req=%p: len=%zu xfrd=%zu zlp=%d\n",
         privep->epphy, privreq, privreq->req.len,
         privreq->req.xfrd, privep->zlp);
 
@@ -1610,7 +1610,7 @@ static void stm32l4_epout_complete(struct stm32l4_usbdev_s *priv,
       return;
     }
 
-  uinfo("EP%d: len=%d xfrd=%d\n",
+  uinfo("EP%d: len=%zu xfrd=%zu\n",
         privep->epphy, privreq->req.len, privreq->req.xfrd);
 
   /* Return the completed read request to the class driver and mark the state
@@ -1742,7 +1742,7 @@ static inline void stm32l4_epout_receive(struct stm32l4_ep_s *privep,
       return;
     }
 
-  uinfo("EP%d: len=%d xfrd=%d\n",
+  uinfo("EP%d: len=%zu xfrd=%zu\n",
          privep->epphy, privreq->req.len, privreq->req.xfrd);
   usbtrace(TRACE_READ(privep->epphy), bcnt);
 

--- a/arch/arm/src/stm32l4/stm32l4_usbdev.c
+++ b/arch/arm/src/stm32l4/stm32l4_usbdev.c
@@ -1335,7 +1335,7 @@ static int stm32l4_wrrequest(struct stm32l4_usbdev_s *priv,
     }
 
   epno = USB_EPNO(privep->ep.eplog);
-  uinfo("epno=%d req=%p: len=%d xfrd=%d nullpkt=%d\n",
+  uinfo("epno=%d req=%p: len=%zu xfrd=%zu nullpkt=%d\n",
         epno, privreq, privreq->req.len, privreq->req.xfrd,
         privep->txnullpkt);
   UNUSED(epno);
@@ -1483,7 +1483,8 @@ static int stm32l4_rdrequest(struct stm32l4_usbdev_s *priv,
       return -ENOENT;
     }
 
-  uinfo("EP%d: len=%d xfrd=%d\n", epno, privreq->req.len, privreq->req.xfrd);
+  uinfo("EP%d: len=%zu xfrd=%zu\n",
+        epno, privreq->req.len, privreq->req.xfrd);
 
   /* Ignore any attempt to receive a zero length packet */
 

--- a/arch/mips/src/pic32mx/pic32mx_usbdev.c
+++ b/arch/mips/src/pic32mx/pic32mx_usbdev.c
@@ -877,10 +877,10 @@ static void pic32mx_wrcomplete(struct pic32mx_usbdev_s *priv,
   epno   = USB_EPNO(privep->ep.eplog);
 
 #ifdef CONFIG_USBDEV_NOWRITEAHEAD
-  uinfo("EP%d: len=%d xfrd=%d inflight=%d\n",
+  uinfo("EP%d: len=%zu xfrd=%zu inflight=%d\n",
         epno, privreq->req.len, privreq->req.xfrd, privreq->inflight[0]);
 #else
-  uinfo("EP%d: len=%d xfrd=%d inflight={%d, %d}\n",
+  uinfo("EP%d: len=%zu xfrd=%zu inflight={%d, %d}\n",
         epno, privreq->req.len, privreq->req.xfrd,
         privreq->inflight[0], privreq->inflight[1]);
 #endif
@@ -1199,7 +1199,7 @@ static int pic32mx_wrstart(struct pic32mx_usbdev_s *priv,
       bytesleft = privreq->req.len;
     }
 
-  uinfo("epno=%d req=%p: len=%d xfrd=%d index=%d nullpkt=%d\n",
+  uinfo("epno=%d req=%p: len=%zu xfrd=%zu index=%d nullpkt=%d\n",
         epno, privreq, privreq->req.len, xfrd, index, privep->txnullpkt);
 
   /* Get the number of bytes left to be sent in the packet */
@@ -1314,7 +1314,7 @@ static int pic32mx_rdcomplete(struct pic32mx_usbdev_s *priv,
   bdtout = privep->bdtout;
   epno   = USB_EPNO(privep->ep.eplog);
 
-  uinfo("EP%d: len=%d xfrd=%d\n",
+  uinfo("EP%d: len=%zu xfrd=%zu\n",
         epno, privreq->req.len, privreq->req.xfrd);
   bdtinfo("EP%d BDT OUT [%p] {%08x, %08x}\n",
         epno, bdtout, bdtout->status, bdtout->addr);

--- a/arch/renesas/src/rx65n/rx65n_usbdev.c
+++ b/arch/renesas/src/rx65n/rx65n_usbdev.c
@@ -1906,7 +1906,7 @@ static int rx65n_wrrequest(uint8_t epno, struct rx65n_usbdev_s *priv,
     }
 
   epno = USB_EPNO(privep->ep.eplog);
-  uinfo("epno=%d req=%p: len=%d xfrd=%d nullpkt=%d\n",
+  uinfo("epno=%d req=%p: len=%zu xfrd=%zu nullpkt=%d\n",
         epno, privreq, privreq->req.len, privreq->req.xfrd,
         privep->txnullpkt);
 
@@ -2007,7 +2007,7 @@ static int rx65n_rdrequest(uint8_t epno, struct rx65n_usbdev_s *priv,
       return OK;
     }
 
-  uinfo("len=%d xfrd=%d nullpkt=%d\n",
+  uinfo("len=%zu xfrd=%zu nullpkt=%d\n",
         privreq->req.len, privreq->req.xfrd, privep->txnullpkt);
 
   usbtrace(TRACE_READ(privep->epphy), privreq->req.xfrd);

--- a/arch/risc-v/src/mpfs/mpfs_usb.c
+++ b/arch/risc-v/src/mpfs/mpfs_usb.c
@@ -952,7 +952,7 @@ static int mpfs_req_write(struct mpfs_usbdev_s *priv,
           return -ENOENT;
         }
 
-      uinfo("epno=%d req=%p: len=%d xfrd=%d inflight=%d\n",
+      uinfo("epno=%d req=%p: len=%zu xfrd=%zu inflight=%d\n",
             epno, privreq, privreq->req.len, privreq->req.xfrd,
             privreq->inflight);
 
@@ -1131,7 +1131,7 @@ static int mpfs_req_read(struct mpfs_usbdev_s *priv,
           return OK;
         }
 
-      uinfo("EP%d: req.len=%d xfrd=%d recvsize=%d\n",
+      uinfo("EP%d: req.len=%zu xfrd=%zu recvsize=%d\n",
             epno, privreq->req.len, privreq->req.xfrd, recvsize);
 
       /* Ignore any attempt to receive a zero length packet */

--- a/arch/xtensa/src/esp32s3/esp32s3_otg_device.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_otg_device.c
@@ -1268,7 +1268,7 @@ static void esp32s3_epin_request(struct esp32s3_usbdev_s *priv,
       return;
     }
 
-  uinfo("EP%d req=%p: len=%d xfrd=%d zlp=%d\n",
+  uinfo("EP%d req=%p: len=%zu xfrd=%zu zlp=%d\n",
         privep->epphy, privreq, privreq->req.len,
         privreq->req.xfrd, privep->zlp);
 
@@ -1550,7 +1550,7 @@ static void esp32s3_epout_complete(struct esp32s3_usbdev_s *priv,
       return;
     }
 
-  uinfo("EP%d: len=%d xfrd=%d\n",
+  uinfo("EP%d: len=%zu xfrd=%zu\n",
         privep->epphy, privreq->req.len, privreq->req.xfrd);
 
   /* Return the completed read request to the class driver and mark the state
@@ -1682,7 +1682,7 @@ static inline void esp32s3_epout_receive(struct esp32s3_ep_s *privep,
       return;
     }
 
-  uinfo("EP%d: len=%d xfrd=%d\n", privep->epphy, privreq->req.len,
+  uinfo("EP%d: len=%zu xfrd=%zu\n", privep->epphy, privreq->req.len,
         privreq->req.xfrd);
   usbtrace(TRACE_READ(privep->epphy), bcnt);
 

--- a/drivers/usbdev/cdcacm.c
+++ b/drivers/usbdev/cdcacm.c
@@ -1227,7 +1227,7 @@ static int cdcacm_bind(FAR struct usbdevclass_driver_s *driver,
   FAR struct cdcacm_wrreq_s *wrcontainer;
   FAR struct cdcacm_rdreq_s *rdcontainer;
   irqstate_t flags;
-  uint16_t reqlen;
+  size_t reqlen;
   int ret;
   int i;
 

--- a/drivers/usbdev/cdcecm.c
+++ b/drivers/usbdev/cdcecm.c
@@ -829,7 +829,7 @@ static void cdcecm_ep0incomplete(FAR struct usbdev_ep_s *ep,
 {
   if (req->result || req->xfrd != req->len)
     {
-      uerr("result: %hd, xfrd: %hu\n", req->result, req->xfrd);
+      uerr("result: %hd, xfrd: %zu\n", req->result, req->xfrd);
     }
 }
 
@@ -846,7 +846,7 @@ static void cdcecm_rdcomplete(FAR struct usbdev_ep_s *ep,
 {
   FAR struct cdcecm_driver_s *self = (FAR struct cdcecm_driver_s *)ep->priv;
 
-  uinfo("buf: %p, flags 0x%hhx, len %hu, xfrd %hu, result %hd\n",
+  uinfo("buf: %p, flags 0x%hhx, len %zu, xfrd %zu, result %hd\n",
         req->buf, req->flags, req->len, req->xfrd, req->result);
 
   switch (req->result)
@@ -887,7 +887,7 @@ static void cdcecm_wrcomplete(FAR struct usbdev_ep_s *ep,
   FAR struct cdcecm_driver_s *self = (FAR struct cdcecm_driver_s *)ep->priv;
   int rc;
 
-  uinfo("buf: %p, flags 0x%hhx, len %hu, xfrd %hu, result %hd\n",
+  uinfo("buf: %p, flags 0x%hhx, len %zu, xfrd %zu, result %hd\n",
         req->buf, req->flags, req->len, req->xfrd, req->result);
 
   /* The single USB device write request is available for upcoming

--- a/drivers/usbdev/cdcncm.c
+++ b/drivers/usbdev/cdcncm.c
@@ -1019,7 +1019,7 @@ static void cdcncm_receive(FAR struct cdcncm_driver_s *self)
 
   if (GETUINT32(tmp) != opts->nthsign)
     {
-      uerr("Wrong NTH SIGN, skblen %d\n", self->rdreq->xfrd);
+      uerr("Wrong NTH SIGN, skblen %zu\n", self->rdreq->xfrd);
       return;
     }
 
@@ -1423,7 +1423,7 @@ static void cdcncm_ep0incomplete(FAR struct usbdev_ep_s *ep,
 {
   if (req->result || req->xfrd != req->len)
     {
-      uerr("result: %hd, xfrd: %hu\n", req->result, req->xfrd);
+      uerr("result: %hd, xfrd: %zu\n", req->result, req->xfrd);
     }
 }
 
@@ -1443,7 +1443,7 @@ static void cdcncm_intcomplete(FAR struct usbdev_ep_s *ep,
 
   if (req->result || req->xfrd != req->len)
     {
-      uerr("result: %hd, xfrd: %hu\n", req->result, req->xfrd);
+      uerr("result: %hd, xfrd: %zu\n", req->result, req->xfrd);
     }
 
   if (self->notify != NCM_NOTIFY_NONE)
@@ -1473,7 +1473,7 @@ static void cdcncm_rdcomplete(FAR struct usbdev_ep_s *ep,
 {
   FAR struct cdcncm_driver_s *self = (FAR struct cdcncm_driver_s *)ep->priv;
 
-  uinfo("buf: %p, flags 0x%hhx, len %hu, xfrd %hu, result %hd\n",
+  uinfo("buf: %p, flags 0x%hhx, len %zu, xfrd %zu, result %hd\n",
         req->buf, req->flags, req->len, req->xfrd, req->result);
 
   switch (req->result)
@@ -1514,7 +1514,7 @@ static void cdcncm_wrcomplete(FAR struct usbdev_ep_s *ep,
   FAR struct cdcncm_driver_s *self = (FAR struct cdcncm_driver_s *)ep->priv;
   int rc;
 
-  uinfo("buf: %p, flags 0x%hhx, len %hu, xfrd %hu, result %hd\n",
+  uinfo("buf: %p, flags 0x%hhx, len %zu, xfrd %zu, result %hd\n",
         req->buf, req->flags, req->len, req->xfrd, req->result);
 
   /* The single USB device write request is available for upcoming

--- a/drivers/usbdev/pl2303.c
+++ b/drivers/usbdev/pl2303.c
@@ -1376,9 +1376,9 @@ static int usbclass_bind(FAR struct usbdevclass_driver_s *driver,
 {
   FAR struct pl2303_dev_s *priv =
                          ((FAR struct pl2303_driver_s *)driver)->dev;
+  size_t reqlen = CONFIG_PL2303_EPBULK_FSSIZE;
   FAR struct pl2303_req_s *reqcontainer;
   irqstate_t flags;
-  uint16_t reqlen = CONFIG_PL2303_EPBULK_FSSIZE;
   int ret;
   int i;
 

--- a/drivers/usbdev/rndis.c
+++ b/drivers/usbdev/rndis.c
@@ -2071,7 +2071,7 @@ static int usbclass_bind(FAR struct usbdevclass_driver_s *driver,
   FAR struct rndis_dev_s *priv = ((FAR struct rndis_driver_s *)driver)->dev;
   FAR struct rndis_req_s *reqcontainer;
   irqstate_t flags;
-  uint16_t reqlen;
+  size_t reqlen;
   int ret;
   int i;
 

--- a/drivers/usbdev/usbdev_fs.c
+++ b/drivers/usbdev/usbdev_fs.c
@@ -934,11 +934,11 @@ static int usbdev_fs_ep_bind(FAR struct usbdev_s *dev, uint8_t epno,
                              FAR struct usbdev_fs_ep_s *fs_ep)
 {
 #if defined(CONFIG_USBDEV_SUPERSPEED)
-  uint16_t reqsize = epinfo->sssize;
+  size_t reqsize = epinfo->sssize;
 #elif defined(CONFIG_USBDEV_DUALSPEED)
-  uint16_t reqsize = epinfo->hssize;
+  size_t reqsize = epinfo->hssize;
 #else
-  uint16_t reqsize = epinfo->fssize;
+  size_t reqsize = epinfo->fssize;
 #endif
   uint16_t i;
 

--- a/drivers/usbdev/usbdev_req.c
+++ b/drivers/usbdev/usbdev_req.c
@@ -68,7 +68,7 @@
  ****************************************************************************/
 
 FAR struct usbdev_req_s *usbdev_allocreq(FAR struct usbdev_ep_s *ep,
-                                         uint16_t len)
+                                         size_t len)
 {
   FAR struct usbdev_req_s *req;
 

--- a/include/nuttx/usb/usbdev.h
+++ b/include/nuttx/usb/usbdev.h
@@ -253,8 +253,8 @@ struct usbdev_req_s
 {
   FAR uint8_t *buf; /* Call: Buffer used for data; Return: Unchanged */
   uint8_t  flags;   /* See USBDEV_REQFLAGS_* definitions */
-  uint16_t len;     /* Call: Total length of data in buf; Return: Unchanged */
-  uint16_t xfrd;    /* Call: zero; Return: Bytes transferred so far */
+  size_t len;       /* Call: Total length of data in buf; Return: Unchanged */
+  size_t xfrd;      /* Call: zero; Return: Bytes transferred so far */
   int16_t  result;  /* Call: zero; Return: Result of transfer (O or -errno) */
 
   /* Callback when the transfer completes */
@@ -398,7 +398,7 @@ extern "C"
  ****************************************************************************/
 
 FAR struct usbdev_req_s *usbdev_allocreq(FAR struct usbdev_ep_s *ep,
-                                         uint16_t len);
+                                         size_t len);
 
 /****************************************************************************
  * Name: usbdev_freereq


### PR DESCRIPTION
Some USB controllers can receive or send multiple data packets then generate one interrupt. This mechanism can reduce the number of data copies. Extend req buf to accommodate this.

## Summary

## Impact

## Testing

