### PR TITLE
arch/arm64: Move ELF_64BIT selection to arch/Kconfig

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -38,6 +38,7 @@ config ARCH_ARM64
 	select ARCH_HAVE_THREAD_LOCAL
 	select ARCH_HAVE_PERF_EVENTS
 	select ONESHOT
+	select LIBC_ARCH_ELF_64BIT if LIBC_ARCH_ELF
 	---help---
 		The ARM64 architectures
 

--- a/arch/arm64/Kconfig
+++ b/arch/arm64/Kconfig
@@ -56,7 +56,6 @@ config ARCH_CHIP_QEMU
 	select ARCH_HAVE_RESET
 	select ARCH_HAVE_TEXT_HEAP
 	select ARM64_HAVE_PSCI
-	select LIBC_ARCH_ELF_64BIT if LIBC_ARCH_ELF
 	---help---
 		QEMU virt platform (ARMv8a)
 
@@ -71,7 +70,6 @@ config ARCH_CHIP_GOLDFISH
 	select ARCH_HAVE_RESET
 	select ARCH_NEED_ADDRENV_MAPPING
 	select ARM64_HAVE_PSCI
-	select LIBC_ARCH_ELF_64BIT if LIBC_ARCH_ELF
 	---help---
 		Android GoldFish platform for NuttX (ARMv8a),
 		based on ARM virt board
@@ -97,7 +95,6 @@ config ARCH_CHIP_IMX9
 	select ARCH_HAVE_I2CRESET
 	select ARCH_HAVE_IRQTRIGGER
 	select ARCH_NEED_ADDRENV_MAPPING
-	select LIBC_ARCH_ELF_64BIT if LIBC_ARCH_ELF
 	---help---
 		NXP i.MX9 (ARMv8.2a) applications processors
 


### PR DESCRIPTION

## Summary
Unify the elf file format for the whole arm64 architecture

## Impact
Remove copy&paste
## Testing
CI pass
