### PR TITLE
nuttx/drivers:Modify errcode returned by relay_ioctl

### DIFF
--- a/drivers/power/relay/relay.c
+++ b/drivers/power/relay/relay.c
@@ -116,7 +116,7 @@ static int relay_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
           }
         else
           {
-            ret = -ENOTSUP;
+            ret = -ENOTTY;
           }
         break;
     }


### PR DESCRIPTION
Fixed system function call failure due to return errcode error

## Summary

## Impact

## Testing

