### PR TITLE
espressif: Fix build with RTC

### DIFF
--- a/boards/risc-v/esp32c3-legacy/common/scripts/legacy_sections.ld
+++ b/boards/risc-v/esp32c3-legacy/common/scripts/legacy_sections.ld
@@ -245,7 +245,9 @@ SECTIONS
   .rtc.data :
   {
     *(.rtc.data)
+    *(.rtc.data.*)
     *(.rtc.rodata)
+    *(.rtc.rodata.*)
 
    /* Whatever is left from the RTC memory is used as a special heap. */
 

--- a/boards/risc-v/esp32c3-legacy/common/scripts/mcuboot_sections.ld
+++ b/boards/risc-v/esp32c3-legacy/common/scripts/mcuboot_sections.ld
@@ -294,7 +294,9 @@ SECTIONS
   .rtc.data :
   {
     *(.rtc.data)
+    *(.rtc.data.*)
     *(.rtc.rodata)
+    *(.rtc.rodata.*)
 
    /* Whatever is left from the RTC memory is used as a special heap. */
 

--- a/boards/risc-v/esp32c3/common/scripts/esp32c3_legacy_sections.ld
+++ b/boards/risc-v/esp32c3/common/scripts/esp32c3_legacy_sections.ld
@@ -265,7 +265,9 @@ SECTIONS
   .rtc.data :
   {
     *(.rtc.data)
+    *(.rtc.data.*)
     *(.rtc.rodata)
+    *(.rtc.rodata.*)
   } >rtc_iram_seg
 
   /* This section holds RTC data that should have fixed addresses.

--- a/boards/risc-v/esp32c6/common/scripts/esp32c6_legacy_sections.ld
+++ b/boards/risc-v/esp32c6/common/scripts/esp32c6_legacy_sections.ld
@@ -261,7 +261,9 @@ SECTIONS
   .rtc.data :
   {
     *(.rtc.data)
+    *(.rtc.data.*)
     *(.rtc.rodata)
+    *(.rtc.rodata.*)
   } >lp_ram_seg
 
   /* This section holds RTC data that should have fixed addresses.

--- a/boards/risc-v/esp32h2/common/scripts/esp32h2_legacy_sections.ld
+++ b/boards/risc-v/esp32h2/common/scripts/esp32h2_legacy_sections.ld
@@ -261,7 +261,9 @@ SECTIONS
   .rtc.data :
   {
     *(.rtc.data)
+    *(.rtc.data.*)
     *(.rtc.rodata)
+    *(.rtc.rodata.*)
   } >lp_ram_seg
 
   /* This section holds RTC data that should have fixed addresses.

--- a/boards/xtensa/esp32/common/scripts/legacy_sections.ld
+++ b/boards/xtensa/esp32/common/scripts/legacy_sections.ld
@@ -359,7 +359,9 @@ SECTIONS
   .rtc.data :
   {
     *(.rtc.data)
+    *(.rtc.data.*)
     *(.rtc.rodata)
+    *(.rtc.rodata.*)
 
    /* Whatever is left from the RTC memory is used as a special heap. */
 

--- a/boards/xtensa/esp32/common/scripts/mcuboot_sections.ld
+++ b/boards/xtensa/esp32/common/scripts/mcuboot_sections.ld
@@ -313,7 +313,9 @@ SECTIONS
   .rtc.data :
   {
     *(.rtc.data)
+    *(.rtc.data.*)
     *(.rtc.rodata)
+    *(.rtc.rodata.*)
 
    /* Whatever is left from the RTC memory is used as a special heap. */
 

--- a/boards/xtensa/esp32/common/scripts/simple_boot_sections.ld
+++ b/boards/xtensa/esp32/common/scripts/simple_boot_sections.ld
@@ -537,7 +537,9 @@ SECTIONS
   .rtc.data :
   {
     *(.rtc.data)
+    *(.rtc.data.*)
     *(.rtc.rodata)
+    *(.rtc.rodata.*)
 
    /* Whatever is left from the RTC memory is used as a special heap. */
 

--- a/boards/xtensa/esp32s2/common/scripts/mcuboot_sections.ld
+++ b/boards/xtensa/esp32s2/common/scripts/mcuboot_sections.ld
@@ -337,7 +337,9 @@ SECTIONS
   .rtc.data :
   {
     *(.rtc.data)
+    *(.rtc.data.*)
     *(.rtc.rodata)
+    *(.rtc.rodata.*)
 
    /* Whatever is left from the RTC memory is used as a special heap. */
 

--- a/boards/xtensa/esp32s2/common/scripts/simple_boot_sections.ld
+++ b/boards/xtensa/esp32s2/common/scripts/simple_boot_sections.ld
@@ -418,7 +418,9 @@ SECTIONS
   .rtc.data :
   {
     *(.rtc.data)
+    *(.rtc.data.*)
     *(.rtc.rodata)
+    *(.rtc.rodata.*)
 
    /* Whatever is left from the RTC memory is used as a special heap. */
 

--- a/boards/xtensa/esp32s3/common/scripts/legacy_sections.ld
+++ b/boards/xtensa/esp32s3/common/scripts/legacy_sections.ld
@@ -386,10 +386,20 @@ SECTIONS
     _iram_end = ABSOLUTE(.);
   } >iram0_0_seg
 
+  /* RTC BSS section. */
+
+  .rtc.bss (NOLOAD) :
+  {
+    *(.rtc.bss)
+  } >rtc_slow_seg
+
   .rtc.data :
   {
+    . = ALIGN(4);
     *(.rtc.data)
+    *(.rtc.data.*)
     *(.rtc.rodata)
+    *(.rtc.rodata.*)
 
    /* Whatever is left from the RTC memory is used as a special heap. */
 

--- a/boards/xtensa/esp32s3/common/scripts/mcuboot_sections.ld
+++ b/boards/xtensa/esp32s3/common/scripts/mcuboot_sections.ld
@@ -465,7 +465,9 @@ SECTIONS
   .rtc.data :
   {
     *(.rtc.data)
+    *(.rtc.data.*)
     *(.rtc.rodata)
+    *(.rtc.rodata.*)
 
    /* Whatever is left from the RTC memory is used as a special heap. */
 


### PR DESCRIPTION
## Summary

This commit ensures that RTC data is properly allocated in the RTC segment in the linker. This fixes the reported problem about using the legacy bootloader and RTC.

## Impact

Fix the reported bug.

## Testing

Internal CI testing + ESP32-S3 DevKitC-1 v1.0

