### PR TITLE
Documentation: replace m2r2 with myst-parser

### DIFF
--- a/Documentation/Pipfile
+++ b/Documentation/Pipfile
@@ -7,7 +7,7 @@ verify_ssl = true
 
 [packages]
 docutils = "==0.18.1"
-m2r2 = "==0.3.2"
+myst-parser = "*"
 sphinx_rtd_theme = "*"
 Sphinx = "~=6.0"
 sphinx-tabs = "*"

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -53,7 +53,7 @@ version = release = "latest"
 # ones.
 extensions = [
     "sphinx_rtd_theme",
-    "m2r2",
+    "myst_parser",
     "sphinx.ext.autosectionlabel",
     "sphinx.ext.todo",
     "sphinx_tabs.tabs",

--- a/Documentation/introduction/inviolables.rst
+++ b/Documentation/introduction/inviolables.rst
@@ -1,1 +1,2 @@
-.. mdinclude:: ../../INVIOLABLES.md
+.. include:: ../../INVIOLABLES.md
+   :parser: myst_parser.sphinx_

--- a/Documentation/introduction/resources.rst
+++ b/Documentation/introduction/resources.rst
@@ -23,4 +23,5 @@ Here's a list of Apache NuttX resources that you might find helpful:
 Legacy README
 =============
 
-.. mdinclude:: ../legacy_README.md
+.. include:: ../legacy_README.md
+   :parser: myst_parser.sphinx_

--- a/Documentation/legacy_README.md
+++ b/Documentation/legacy_README.md
@@ -96,7 +96,8 @@ Get help using NuttX or contribute to the project on our mailing lists:
 
 ## Reporting Security Issues
 
-Found a vulnerability? See our security policy [here](.github/SECURITY.md).
+Found a vulnerability? See our security policy
+[here](https://github.com/apache/nuttx/blob/master/.github/SECURITY.md).
 
 ## Issue Tracker
 


### PR DESCRIPTION
## Summary
- Documentation: replace m2r2 with myst-parser
  sphinx recommends myst-parser for markdown conversion: https://www.sphinx-doc.org/en/master/usage/markdown.html
  
  m2r2 is not supported for Python versions >= 3.12 so we can't build Documentation for example on latest Arch Linux
  
  by the way myst-parser detected a bad link to SECURITY.md that is now fixed

## Impact

## Testing
local build on Arch and python 3.12.3
