### PR TITLE
armv8-r/gicv3: correct cpu index of irouter

### DIFF
--- a/arch/arm/src/armv8-r/arm_gicv3.c
+++ b/arch/arm/src/armv8-r/arm_gicv3.c
@@ -630,7 +630,11 @@ void up_affinity_irq(int irq, cpu_set_t cpuset)
 {
   if (GIC_IS_SPI(irq))
     {
-      arm_gic_write_irouter(cpuset, irq);
+      /* Only support interrupt routing mode 0,
+       * so routing to the first cpu in cpuset.
+       */
+
+      arm_gic_write_irouter(ffs(cpuset) - 1, irq);
     }
 }
 


### PR DESCRIPTION
## Summary

armv8-r/gicv3: correct cpu index of irouter

interrupt routing cpu should be index not cpuset

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

ci-check