### PR TITLE
wqueue: add interface work_queue_priority_wq and work_queue_priority

### DIFF
--- a/include/nuttx/wqueue.h
+++ b/include/nuttx/wqueue.h
@@ -414,6 +414,24 @@ int work_queue_wq(FAR struct kwork_wqueue_s *wqueue,
                   FAR void *arg, clock_t delay);
 
 /****************************************************************************
+ * Name: work_queue_pri
+ *
+ * Description: Get priority of the wqueue. We believe that all worker
+ *   threads have the same priority.
+ *
+ * Input Parameters:
+ *  wqueue - The work queue handle
+ *
+ * Returned Value:
+ *   SCHED_PRIORITY_MIN ~ SCHED_PRIORITY_MAX  on success,
+ *   a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int work_queue_priority(int qid);
+int work_queue_priority_wq(FAR struct kwork_wqueue_s *wqueue);
+
+/****************************************************************************
  * Name: work_cancel/work_cancel_wq
  *
  * Description:

--- a/sched/wqueue/kwork_thread.c
+++ b/sched/wqueue/kwork_thread.c
@@ -394,6 +394,46 @@ int work_queue_free(FAR struct kwork_wqueue_s *wqueue)
 }
 
 /****************************************************************************
+ * Name: work_queue_priority_wq
+ *
+ * Description: Get priority of the wqueue. We believe that all worker
+ *   threads have the same priority.
+ *
+ * Input Parameters:
+ *  wqueue - The work queue handle
+ *
+ * Returned Value:
+ *   SCHED_PRIORITY_MIN ~ SCHED_PRIORITY_MAX  on success,
+ *   a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int work_queue_priority_wq(FAR struct kwork_wqueue_s *wqueue)
+{
+  FAR struct tcb_s *tcb;
+
+  if (wqueue == NULL)
+    {
+      return -EINVAL;
+    }
+
+  /* Find for the TCB associated with matching PID */
+
+  tcb = nxsched_get_tcb(wqueue->worker[0].pid);
+  if (!tcb)
+    {
+      return -ESRCH;
+    }
+
+  return tcb->sched_priority;
+}
+
+int work_queue_priority(int qid)
+{
+  return work_queue_priority_wq(work_qid2wq(qid));
+}
+
+/****************************************************************************
  * Name: work_start_highpri
  *
  * Description:


### PR DESCRIPTION
## Summary
These interfaces are used when we assign interrupt handling of the same priority to the corresponding priority work queues.

## Impact
none

## Testing
ostest

