### PR TITLE
irq: dynaminc create g_irqmap

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -1158,6 +1158,13 @@ config ARCH_MINIMAL_VECTORTABLE
 		IRQMAPPED_MAX, then hardware interrupt vector 42 is not used and
 		if it occurs will result in an unexpected interrupt crash.
 
+config ARCH_MINIMAL_VECTORTABLE_DYNAMIC
+	bool "Dynaminc Minimal RAM usage for vector table"
+	default n
+	depends on ARCH_MINIMAL_VECTORTABLE
+	---help---
+		Use a minimum amount of RAM for the vector table.
+
 config ARCH_NUSER_INTERRUPTS
 	int "Number of interrupts"
 	default 0

--- a/sched/irq/irq.h
+++ b/sched/irq/irq.h
@@ -44,7 +44,9 @@
 #  error CONFIG_ARCH_NUSER_INTERRUPTS is not defined
 #endif
 
-#ifdef CONFIG_ARCH_MINIMAL_VECTORTABLE
+#if defined(CONFIG_ARCH_MINIMAL_VECTORTABLE_DYNAMIC)
+#  define IRQ_TO_NDX(irq) (g_irqmap[irq] ? g_irqmap[irq] : irq_to_ndx(irq))
+#elif defined(CONFIG_ARCH_MINIMAL_VECTORTABLE)
 #  define IRQ_TO_NDX(irq) \
   (g_irqmap[(irq)] < CONFIG_ARCH_NUSER_INTERRUPTS ? g_irqmap[(irq)] : -EINVAL)
 #else
@@ -94,7 +96,6 @@ extern struct irq_info_s g_irqvector[CONFIG_ARCH_NUSER_INTERRUPTS];
 extern struct irq_info_s g_irqvector[NR_IRQS];
 #endif
 
-#ifdef CONFIG_ARCH_MINIMAL_VECTORTABLE
 /* This is the interrupt vector mapping table.  This must be provided by
  * architecture specific logic if CONFIG_ARCH_MINIMAL_VECTORTABLE is define
  * in the configuration.
@@ -104,6 +105,10 @@ extern struct irq_info_s g_irqvector[NR_IRQS];
  * declaration is here for the time being.
  */
 
+#if defined(CONFIG_ARCH_MINIMAL_VECTORTABLE_DYNAMIC)
+extern irq_mapped_t g_irqmap[NR_IRQS];
+int irq_to_ndx(int irq);
+#elif defined(CONFIG_ARCH_MINIMAL_VECTORTABLE)
 extern const irq_mapped_t g_irqmap[NR_IRQS];
 #endif
 

--- a/sched/irq/irq_attach.c
+++ b/sched/irq/irq_attach.c
@@ -31,8 +31,50 @@
 #include "irq/irq.h"
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#ifdef CONFIG_ARCH_MINIMAL_VECTORTABLE_DYNAMIC
+static int g_irqmap_count = 1;
+#endif
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#ifdef CONFIG_ARCH_MINIMAL_VECTORTABLE_DYNAMIC
+
+/* This is the interrupt vector mapping table.  This must be provided by
+ * architecture specific logic if CONFIG_ARCH_MINIMAL_VECTORTABLE is define
+ * in the configuration.
+ *
+ * REVISIT: This should be declared in include/nuttx/irq.h.  The declaration
+ * at that location, however, introduces a circular include dependency so the
+ * declaration is here for the time being.
+ */
+
+irq_mapped_t g_irqmap[NR_IRQS];
+#endif
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
+
+#ifdef CONFIG_ARCH_MINIMAL_VECTORTABLE_DYNAMIC
+int irq_to_ndx(int irq)
+{
+  DEBUGASSERT(g_irqmap_count < CONFIG_ARCH_NUSER_INTERRUPTS);
+
+  irqstate_t flags = spin_lock_irqsave(NULL);
+  if (g_irqmap[irq] == 0)
+    {
+      g_irqmap[irq] = g_irqmap_count++;
+    }
+
+  spin_unlock_irqrestore(NULL, flags);
+  return g_irqmap[irq];
+}
+#endif
 
 /****************************************************************************
  * Name: irq_attach


### PR DESCRIPTION
## Summary
dynaminc create g_irqmap to reduce the use of data segments
CONFIG_ARCH_NUSER_INTERRUPTS should be one more than the number of IRQs actually used

## Impact
none

## Testing
ostest

