### PR TITLE
esp32: fix seemingly wrong calculations

### DIFF
--- a/arch/xtensa/src/esp32/esp32_spiram.c
+++ b/arch/xtensa/src/esp32/esp32_spiram.c
@@ -248,7 +248,7 @@ void IRAM_ATTR esp_spiram_init_cache(void)
   cache_flush(APP_CPU_NUM);
   cache_read_enable(APP_CPU_NUM);
   regval  = getreg32(DPORT_APP_CACHE_CTRL1_REG);
-  regval &= ~(1 << DPORT_APP_CACHE_MASK_DRAM1);
+  regval &= ~DPORT_APP_CACHE_MASK_DRAM1;
   putreg32(regval, DPORT_APP_CACHE_CTRL1_REG);
   cache_sram_mmu_set(1, 0, SOC_EXTRAM_DATA_LOW, 0, 32, 128);
 #endif

--- a/arch/xtensa/src/esp32/esp32_userspace.c
+++ b/arch/xtensa/src/esp32/esp32_userspace.c
@@ -224,7 +224,7 @@ static noinline_function IRAM_ATTR void configure_sram_mmu(void)
 
 #ifdef CONFIG_SMP
   regval  = getreg32(DPORT_APP_CACHE_CTRL1_REG);
-  regval &= ~(1 << DPORT_APP_CACHE_MASK_DRAM1);
+  regval &= ~DPORT_APP_CACHE_MASK_DRAM1;
   putreg32(regval, DPORT_APP_CACHE_CTRL1_REG);
   ASSERT(cache_sram_mmu_set(1, PIDCTRL_PID_KERNEL, SOC_EXTRAM_DATA_LOW, 0,
                             32, 128) == 0);


### PR DESCRIPTION
## Summary
DPORT_APP_CACHE_MASK_DRAM1 is already a mask.

## Impact

## Testing
tested on esp32-devkitc.
the esp32_userspace.c bit is totally untested.
