### PR TITLE
CI: drop stm3240g-eval:knxwm for now

### DIFF
--- a/tools/ci/testlist/arm-09.dat
+++ b/tools/ci/testlist/arm-09.dat
@@ -12,3 +12,4 @@
 /arm/stm32/stm3220g-eval,CONFIG_ARM_TOOLCHAIN_GNU_EABI
 
 /arm/stm32/stm3240g-eval,CONFIG_ARM_TOOLCHAIN_GNU_EABI
+-stm3240g-eval:knxwm


### PR DESCRIPTION
## Summary
CI: drop stm3240g-eval:knxwm for now

cf. https://github.com/apache/nuttx/issues/13246

## Impact

## Testing

