### PR TITLE
esp32: enable APP_CPU cache earlier

### DIFF
--- a/arch/xtensa/src/esp32/esp32_cpustart.c
+++ b/arch/xtensa/src/esp32/esp32_cpustart.c
@@ -57,8 +57,6 @@ static volatile spinlock_t g_appcpu_interlock;
  * ROM function prototypes
  ****************************************************************************/
 
-extern void cache_flush(int cpu);
-extern void cache_read_enable(int cpu);
 extern void ets_set_appcpu_boot_addr(uint32_t start);
 
 /****************************************************************************
@@ -244,11 +242,6 @@ int up_cpu_start(int cpu)
        */
 
       spin_initialize(&g_appcpu_interlock, SP_LOCKED);
-
-      /* Flush and enable I-cache for APP CPU */
-
-      cache_flush(cpu);
-      cache_read_enable(cpu);
 
       /* Unstall the APP CPU */
 

--- a/arch/xtensa/src/esp32/esp32_spiram.c
+++ b/arch/xtensa/src/esp32/esp32_spiram.c
@@ -69,6 +69,13 @@
 #endif
 
 /****************************************************************************
+ * ROM Function Prototypes
+ ****************************************************************************/
+
+extern void cache_flush(int cpu);
+extern void cache_read_enable(int cpu);
+
+/****************************************************************************
  * Private Data
  ****************************************************************************/
 
@@ -238,6 +245,8 @@ void IRAM_ATTR esp_spiram_init_cache(void)
   /* Flush and enable icache for APP CPU */
 
 #ifdef CONFIG_SMP
+  cache_flush(APP_CPU_NUM);
+  cache_read_enable(APP_CPU_NUM);
   regval  = getreg32(DPORT_APP_CACHE_CTRL1_REG);
   regval &= ~(1 << DPORT_APP_CACHE_MASK_DRAM1);
   putreg32(regval, DPORT_APP_CACHE_CTRL1_REG);


### PR DESCRIPTION
## Summary
NuttX uses PSRAM, possibly using the APP_CPU cache MMU, way before starting the APP_CPU in up_cpu_start(). Flushing the cache when launching the APP_CPU can cause data corruptions on PSRAM.
Eg. mm_heap structures if the PSRAM is added to a heap.

## Impact

## Testing
tested on esp32-devkitc with https://github.com/apache/nuttx/pull/13222 and some other local changes.