### PR TITLE
mtd/nvs: fix align size

### DIFF
--- a/drivers/mtd/mtd_config_fs.c
+++ b/drivers/mtd/mtd_config_fs.c
@@ -62,7 +62,7 @@
  * so we make a buffer to do compare or move.
  */
 
-#define NVS_BUFFER_SIZE                 32
+#define NVS_BUFFER_SIZE                 MAX(NVS_ALIGN_UP(32), NVS_ALIGN_SIZE)
 
 /* If data is written after last ate, and power loss happens,
  * we need to find a clean offset by skipping dirty data.


### PR DESCRIPTION
when gc, move data requires byte alignment

## Summary

## Impact

## Testing

