### PR TITLE
cmake/nuttx_kconfig.cmake: fixed the correct .config path in the buid folder

### DIFF
--- a/cmake/nuttx_kconfig.cmake
+++ b/cmake/nuttx_kconfig.cmake
@@ -160,6 +160,6 @@ endfunction()
 function(nuttx_setconfig)
   execute_process(
     COMMAND ${CMAKE_COMMAND} -E env ${KCONFIG_ENV} setconfig ${ARGN}
-    WORKING_DIRECTORY ${NUTTX_DIR}
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     OUTPUT_QUIET ERROR_QUIET)
 endfunction()


### PR DESCRIPTION
## Summary
Fixing the correct .config path during the setconfig process.

changed ${NUTTX_DIR} -> ${CMAKE_BINARY_DIR}

see https://github.com/apache/nuttx/pull/13175#issuecomment-2320360957

@anchao It should now be corrected.

## Impact
There should be no impact.

## Testing
local
