### PR TITLE
espressif: Fix deadlock in RT timer caused by critical section

### DIFF
--- a/arch/risc-v/src/common/espressif/esp_hr_timer.c
+++ b/arch/risc-v/src/common/espressif/esp_hr_timer.c
@@ -216,7 +216,7 @@ static int IRAM_ATTR esp_hr_timer_isr(int irq, void *context, void *arg)
 
   systimer_ll_clear_alarm_int(priv->hal.dev, SYSTIMER_ALARM_ESPTIMER);
 
-  flags = spin_lock_irqsave(&priv->lock);
+  flags = enter_critical_section();
 
   /* Check if there is a timer running */
 
@@ -286,7 +286,7 @@ static int IRAM_ATTR esp_hr_timer_isr(int irq, void *context, void *arg)
         }
     }
 
-  spin_unlock_irqrestore(&priv->lock, flags);
+  leave_critical_section(flags);
 
   return OK;
 }
@@ -576,7 +576,7 @@ void esp_hr_timer_delete(struct esp_hr_timer_s *timer)
 
   struct esp_hr_timer_context_s *priv = &g_hr_timer_context;
 
-  flags = spin_lock_irqsave(&priv->lock);
+  flags = enter_critical_section();
 
   if (timer->state == HR_TIMER_READY)
     {
@@ -603,7 +603,7 @@ void esp_hr_timer_delete(struct esp_hr_timer_s *timer)
     }
 
 exit:
-  spin_unlock_irqrestore(&priv->lock, flags);
+  leave_critical_section(flags);
 }
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32/esp32_rt_timer.c
+++ b/arch/xtensa/src/esp32/esp32_rt_timer.c
@@ -263,7 +263,7 @@ static void delete_rt_timer(struct rt_timer_s *timer)
   irqstate_t flags;
   struct esp32_rt_priv_s *priv = &g_rt_priv;
 
-  flags = spin_lock_irqsave(&priv->lock);
+  flags = enter_critical_section();
 
   if (timer->state == RT_TIMER_READY)
     {
@@ -282,7 +282,7 @@ static void delete_rt_timer(struct rt_timer_s *timer)
   timer->state = RT_TIMER_DELETE;
 
 exit:
-  spin_unlock_irqrestore(&priv->lock, flags);
+  leave_critical_section(flags);
 }
 
 /****************************************************************************
@@ -709,7 +709,7 @@ int esp32_rt_timer_init(void)
   priv->timer = tim;
   priv->pid   = (pid_t)pid;
 
-  flags = spin_lock_irqsave(&priv->lock);
+  flags = enter_critical_section();
 
   /* ESP32 hardware timer configuration:
    *   - 1 counter = 1us
@@ -727,7 +727,7 @@ int esp32_rt_timer_init(void)
 
   ESP32_TIM_START(tim);
 
-  spin_unlock_irqrestore(&priv->lock, flags);
+  leave_critical_section(flags);
 
   return 0;
 }

--- a/arch/xtensa/src/esp32s3/esp32s3_rt_timer.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_rt_timer.c
@@ -611,7 +611,7 @@ static int rt_timer_isr(int irq, void *context, void *arg)
 
   modifyreg32(SYSTIMER_INT_CLR_REG, 0, SYSTIMER_TARGET2_INT_CLR);
 
-  flags = spin_lock_irqsave(&priv->lock);
+  flags = enter_critical_section();
 
   /* Check if there is a timer running */
 
@@ -672,7 +672,7 @@ static int rt_timer_isr(int irq, void *context, void *arg)
         }
     }
 
-  spin_unlock_irqrestore(&priv->lock, flags);
+  leave_critical_section(flags);
 
   return OK;
 }
@@ -805,7 +805,7 @@ void esp32s3_rt_timer_delete(struct rt_timer_s *timer)
   irqstate_t flags;
   struct esp32s3_rt_priv_s *priv = &g_rt_priv;
 
-  flags = spin_lock_irqsave(&priv->lock);
+  flags = enter_critical_section();
 
   if (timer->state == RT_TIMER_READY)
     {
@@ -832,7 +832,7 @@ void esp32s3_rt_timer_delete(struct rt_timer_s *timer)
     }
 
 exit:
-  spin_unlock_irqrestore(&priv->lock, flags);
+  leave_critical_section(flags);
 }
 
 /****************************************************************************
@@ -965,7 +965,7 @@ int esp32s3_rt_timer_init(void)
 
   priv->pid = (pid_t)pid;
 
-  flags = spin_lock_irqsave(&priv->lock);
+  flags = enter_critical_section();
 
   /* ESP32-S3 hardware timer configuration:
    * 1 count = 1/16 us
@@ -1007,7 +1007,7 @@ int esp32s3_rt_timer_init(void)
 
   modifyreg32(SYSTIMER_CONF_REG, 0, SYSTIMER_TIMER_UNIT1_WORK_EN);
 
-  spin_unlock_irqrestore(&priv->lock, flags);
+  leave_critical_section(flags);
 
   return OK;
 }


### PR DESCRIPTION
## Summary

* espressif: Fix deadlock in RT timer caused by critical section

This commit fixes a deadlock in `esp32s3-devkit:sta_softap` defconfig: `spin_lock_irqsave` was being used to enter a critical section that calls `nxsem_post`. In this case, it's recommended to use `[enter|leave]_critical_section` to avoid deadlocks when a context switch may happen, for instance.

## Impact

Fix bug on `esp32s3-devkit:sta_softap`

## Testing

Internal CI testing + ESP32-S3 DevKitC-1 v1.0