### PR TITLE
irq: irq with the same priority share the same wqueue

### DIFF
--- a/include/nuttx/irq.h
+++ b/include/nuttx/irq.h
@@ -47,6 +47,9 @@
  */
 
 #  define irq_detach(irq) irq_attach(irq, NULL, NULL)
+#  define irq_detach_wqueue(irq) irq_attach_wqueue(irq, NULL, NULL, NULL, 0)
+#  define irq_detach_thread(irq) \
+     irq_attach_thread(irq, NULL, NULL, NULL, 0, 0)
 
 /* Maximum/minimum values of IRQ integer types */
 
@@ -193,6 +196,31 @@ int irq_attach(int irq, xcpt_t isr, FAR void *arg);
 
 int irq_attach_thread(int irq, xcpt_t isr, xcpt_t isrthread, FAR void *arg,
                       int priority, int stack_size);
+
+/****************************************************************************
+ * Name: irq_attach_wqueue
+ *
+ * Description:
+ *   Configure the IRQ subsystem so that IRQ number 'irq' is dispatched to
+ *   'wqueue'
+ *
+ * Input Parameters:
+ *   irq - Irq num
+ *   isr - Function to be called when the IRQ occurs, called in interrupt
+ *   context.
+ *   If isr is NULL the default handler is installed(irq_default_handler).
+ *   isrwork - called in thread context, If the isrwork is NULL,
+ *   then the ISR is being detached.
+ *   arg - privdate data
+ *   priority - isrwork pri
+ *
+ * Returned Value:
+ *   Zero on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int irq_attach_wqueue(int irq, xcpt_t isr, xcpt_t isrwork,
+                      FAR void *arg, int priority);
 
 #ifdef CONFIG_IRQCHAIN
 int irqchain_detach(int irq, xcpt_t isr, FAR void *arg);

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -340,6 +340,18 @@ config PREALLOC_IRQCHAIN
 
 endif # IRQCHAIN
 
+config IRQ_NWORKS
+	int "Max num of active irq wqueue"
+	default 8
+	---help---
+		The max num of active irq wqueue.
+
+config IRQ_WORK_STACKSIZE
+	int "The default stack size for isr wqueue"
+	default DEFAULT_TASK_STACKSIZE
+	---help---
+		The default stack size for isr wqueue.
+
 config IRQCOUNT
 	bool
 	default n

--- a/sched/irq/CMakeLists.txt
+++ b/sched/irq/CMakeLists.txt
@@ -18,8 +18,8 @@
 #
 # ##############################################################################
 
-set(SRCS irq_initialize.c irq_attach.c irq_attach_thread.c irq_dispatch.c
-         irq_unexpectedisr.c)
+set(SRCS irq_initialize.c irq_attach.c irq_attach_thread.c irq_attach_wqueue.c
+         irq_dispatch.c irq_unexpectedisr.c)
 
 if(CONFIG_SPINLOCK)
   list(APPEND SRCS irq_spinlock.c)

--- a/sched/irq/Make.defs
+++ b/sched/irq/Make.defs
@@ -19,7 +19,7 @@
 ############################################################################
 
 CSRCS += irq_initialize.c irq_attach.c irq_dispatch.c irq_unexpectedisr.c
-CSRCS += irq_attach_thread.c
+CSRCS += irq_attach_thread.c irq_attach_wqueue.c
 
 ifeq ($(CONFIG_SPINLOCK),y)
 CSRCS += irq_spinlock.c


### PR DESCRIPTION
## Summary
irq with the same priority share the same wqueue

reason:
1 We place interrupt handling functions of the same priority into the work queue corresponding
    to that priority, allowing high-priority interrupts to preempt low-priority ones,
    thus ensuring the real-time performance of high-priority interrupts.    
2 The sole purpose of the interrupt handler is to wake
    up the work queue of the corresponding priority and execute the interrupt handling function.    
3 Compared to the functionality of isr threads, this
    approach saves more memory, particularly when the number of interrupts is large.
## Impact
OS Real-time Capability

## Testing
ostest
