### PR TITLE
arm/gicv3: set routing affinity before enable IRQ

### DIFF
--- a/arch/arm/src/armv8-r/arm_gicv3.c
+++ b/arch/arm/src/armv8-r/arm_gicv3.c
@@ -238,8 +238,6 @@ void arm_gic_irq_enable(unsigned int intid)
   uint32_t mask = BIT(intid & (GIC_NUM_INTR_PER_REG - 1));
   uint32_t idx  = intid / GIC_NUM_INTR_PER_REG;
 
-  putreg32(mask, ISENABLER(GET_DIST_BASE(intid), idx));
-
   /* Affinity routing is enabled for Non-secure state (GICD_CTLR.ARE_NS
    * is set to '1' when GIC distributor is initialized) ,so need to set
    * SPI's affinity, now set it to be the PE on which it is enabled.
@@ -249,6 +247,8 @@ void arm_gic_irq_enable(unsigned int intid)
     {
       arm_gic_write_irouter(up_cpu_index(), intid);
     }
+
+  putreg32(mask, ISENABLER(GET_DIST_BASE(intid), idx));
 }
 
 void arm_gic_irq_disable(unsigned int intid)

--- a/arch/arm64/src/common/arm64_gicv3.c
+++ b/arch/arm64/src/common/arm64_gicv3.c
@@ -249,8 +249,6 @@ void arm64_gic_irq_enable(unsigned int intid)
   uint32_t mask = BIT(intid & (GIC_NUM_INTR_PER_REG - 1));
   uint32_t idx  = intid / GIC_NUM_INTR_PER_REG;
 
-  putreg32(mask, ISENABLER(GET_DIST_BASE(intid), idx));
-
   /* Affinity routing is enabled for Non-secure state (GICD_CTLR.ARE_NS
    * is set to '1' when GIC distributor is initialized) ,so need to set
    * SPI's affinity, now set it to be the PE on which it is enabled.
@@ -260,6 +258,8 @@ void arm64_gic_irq_enable(unsigned int intid)
     {
       arm64_gic_write_irouter((GET_MPIDR() & MPIDR_ID_MASK), intid);
     }
+
+  putreg32(mask, ISENABLER(GET_DIST_BASE(intid), idx));
 }
 
 void arm64_gic_irq_disable(unsigned int intid)


### PR DESCRIPTION
## Summary

arm/gicv3: set routing affinity before enable IRQ

In corner case, the pending ISR will be triggered immediately
after enable the IRQ, this PR will setting CPU affinity first
to avoid routing the unexpected IRQ to other CPUs.

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

ci-check