### PR TITLE
sched/event: clear pending events before enable the scheduler

### DIFF
--- a/sched/event/event_post.c
+++ b/sched/event/event_post.c
@@ -150,12 +150,12 @@ int nxevent_post(FAR nxevent_t *event, nxevent_mask_t events,
             }
         }
 
-      sched_unlock();
-
       if (clear)
         {
           event->events &= ~clear;
         }
+
+      sched_unlock();
     }
 
   leave_critical_section(flags);


### PR DESCRIPTION
## Summary

sched/event: clear pending events before enable the scheduler

enable the scheduler may cause the context to switch to a high-priority task,
which will failure to clear pending events correctly.

Signed-off-by: chao an <anchao@lixiang.com>

## Impact

N/A

## Testing

ci-check