### PR TITLE
sched/policy: move g_policy from data to rodata

### DIFF
--- a/drivers/syslog/syslog_channel.c
+++ b/drivers/syslog/syslog_channel.c
@@ -70,6 +70,10 @@ static ssize_t syslog_default_write(FAR struct syslog_channel_s *channel,
  * Private Data
  ****************************************************************************/
 
+#if defined(CONFIG_SYSLOG_DEFAULT) && defined(CONFIG_ARCH_LOWPUTC)
+static mutex_t g_lowputs_lock = NXMUTEX_INITIALIZER;
+#endif
+
 #if defined(CONFIG_RAMLOG_SYSLOG)
 static const struct syslog_channel_ops_s g_ramlog_channel_ops =
 {
@@ -236,13 +240,11 @@ static ssize_t syslog_default_write(FAR struct syslog_channel_s *channel,
                                     FAR const char *buffer, size_t buflen)
 {
 #if defined(CONFIG_ARCH_LOWPUTC)
-  static mutex_t lock = NXMUTEX_INITIALIZER;
-
-  nxmutex_lock(&lock);
+  nxmutex_lock(&g_lowputs_lock);
 
   up_nputs(buffer, buflen);
 
-  nxmutex_unlock(&lock);
+  nxmutex_unlock(&g_lowputs_lock);
 #endif
 
   UNUSED(channel);

--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -155,7 +155,7 @@ struct proc_envinfo_s
  * Private Data
  ****************************************************************************/
 
-static FAR const char *g_policy[4] =
+static FAR const char * const g_policy[4] =
 {
   "SCHED_FIFO", "SCHED_RR", "SCHED_SPORADIC"
 };

--- a/libs/libc/time/lib_gmtime.c
+++ b/libs/libc/time/lib_gmtime.c
@@ -31,6 +31,12 @@
 #include <nuttx/clock.h>
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static struct tm g_gmtime;
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -44,8 +50,7 @@
 
 FAR struct tm *gmtime(FAR const time_t *timep)
 {
-  static struct tm tm;
-  return gmtime_r(timep, &tm);
+  return gmtime_r(timep, &g_gmtime);
 }
 
 FAR struct tm *localtime(FAR const time_t *timep)

--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -93,7 +93,7 @@
 
 static uintptr_t
 g_last_regs[XCPTCONTEXT_REGS] aligned_data(XCPTCONTEXT_ALIGN);
-static FAR const char *g_policy[4] =
+static FAR const char * const g_policy[4] =
 {
   "FIFO", "RR", "SPORADIC"
 };


### PR DESCRIPTION
## Summary

sched/policy: move g_policy from data to rodata
global/variables: add g_ prefix to some global variables

Signed-off-by: chao an <anchao@lixiang.com>

## Impact

N/A

## Testing

ci-check