### PR TITLE
mq: change mqueue msg mail to dynamic array

### DIFF
--- a/sched/mqueue/mq_initialize.c
+++ b/sched/mqueue/mq_initialize.c
@@ -28,10 +28,20 @@
 
 #include <stdint.h>
 #include <nuttx/kmalloc.h>
+#include <nuttx/nuttx.h>
 #include <nuttx/trace.h>
 
 #include "mqueue/mqueue.h"
 #include "mqueue/msg.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifndef CONFIG_DISABLE_MQUEUE
+#  define MQ_BLOCK_SIZE \
+    ALIGN_UP(MQ_MSG_SIZE(MQ_MAX_BYTES), sizeof(void *))
+#endif
 
 /****************************************************************************
  * Private Type Definitions
@@ -40,8 +50,9 @@
 struct msgpool_s
 {
 #ifndef CONFIG_DISABLE_MQUEUE
-  struct mqueue_msg_s mqueue[CONFIG_PREALLOC_MQ_MSGS +
-                             CONFIG_PREALLOC_MQ_IRQ_MSGS];
+  uint8_t mqueue[MQ_BLOCK_SIZE *
+                 (CONFIG_PREALLOC_MQ_MSGS +
+                  CONFIG_PREALLOC_MQ_IRQ_MSGS)];
 #endif
 #ifndef CONFIG_DISABLE_MQUEUE_SYSV
   struct msgbuf_s msgbuf[CONFIG_PREALLOC_MQ_MSGS];
@@ -94,18 +105,22 @@ static struct msgpool_s g_msgpool;
 
 #ifndef CONFIG_DISABLE_MQUEUE
 static FAR void * mq_msgblockinit(FAR struct list_node *list,
-                                  FAR struct mqueue_msg_s *mqmsgblock,
+                                  FAR uint8_t *block,
                                   uint16_t nmsgs, uint8_t alloc_type)
 {
+  FAR struct mqueue_msg_s *mqmsgblock;
   int i;
+
   for (i = 0; i < nmsgs; i++)
     {
+      mqmsgblock = (FAR struct mqueue_msg_s *)block;
+
       mqmsgblock->type = alloc_type;
       list_add_tail(list, &mqmsgblock->node);
-      mqmsgblock++;
+      block += MQ_BLOCK_SIZE;
     }
 
-  return mqmsgblock;
+  return block;
 }
 #endif
 

--- a/sched/mqueue/mq_send.c
+++ b/sched/mqueue/mq_send.c
@@ -132,7 +132,7 @@ static int nxmq_verify_send(FAR FAR struct file *mq, FAR const char *msg,
  *
  ****************************************************************************/
 
-static FAR struct mqueue_msg_s *nxmq_alloc_msg(uint16_t maxmsgsize)
+static FAR struct mqueue_msg_s *nxmq_alloc_msg(uint16_t msgsize)
 {
   FAR struct mqueue_msg_s *mqmsg;
   irqstate_t flags;
@@ -166,7 +166,7 @@ static FAR struct mqueue_msg_s *nxmq_alloc_msg(uint16_t maxmsgsize)
            * allocate one.
            */
 
-          mqmsg = kmm_malloc((sizeof (struct mqueue_msg_s)));
+          mqmsg = kmm_malloc(MQ_MSG_SIZE(msgsize));
 
           /* Check if we allocated the message */
 
@@ -308,7 +308,7 @@ int file_mq_timedsend_internal(FAR struct file *mq, FAR const char *msg,
 
   /* Pre-allocate a message structure */
 
-  mqmsg = nxmq_alloc_msg(msgq->maxmsgsize);
+  mqmsg = nxmq_alloc_msg(msglen);
   if (!mqmsg)
     {
       return -ENOMEM;

--- a/sched/mqueue/mqueue.h
+++ b/sched/mqueue/mqueue.h
@@ -49,6 +49,8 @@
 #define MQ_MAX_MSGS    16
 #define MQ_PRIO_MAX    _POSIX_MQ_PRIO_MAX
 
+#define MQ_MSG_SIZE(n) (sizeof(struct mqueue_msg_s) + (n) - 1)
+
 /****************************************************************************
  * Public Type Definitions
  ****************************************************************************/
@@ -72,7 +74,7 @@ struct mqueue_msg_s
 #else
   uint16_t msglen;         /* Message data length */
 #endif
-  char mail[MQ_MAX_BYTES]; /* Message data */
+  char mail[1];            /* Message data */
 };
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

Change mqueue_msg_s to a dynamic array so that mqueue msg can be malloc based on the msg size
of the current data when applied dynamically.

## Impact

NA

## Testing

Test config:
boards/arm/imx6/sabre-6quad/configs/nsh

Test case:
ostest pass