### PR TITLE
arch: remove unused up_cpu_pausereq waiting

### DIFF
--- a/arch/arm/src/armv6-m/arm_schedulesigaction.c
+++ b/arch/arm/src/armv6-m/arm_schedulesigaction.c
@@ -267,12 +267,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
                   up_cpu_pause(cpu);
 
-                  /* Wait while the pause request is pending */
-
-                  while (up_cpu_pausereq(cpu))
-                    {
-                    }
-
                   /* Now tcb on the other CPU can be accessed safely */
 
                   /* Copy tcb->xcp.regs to tcp.xcp.saved. These will be

--- a/arch/arm/src/armv7-a/arm_schedulesigaction.c
+++ b/arch/arm/src/armv7-a/arm_schedulesigaction.c
@@ -264,12 +264,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
                   up_cpu_pause(cpu);
 
-                  /* Wait while the pause request is pending */
-
-                  while (up_cpu_pausereq(cpu))
-                    {
-                    }
-
                   /* Now tcb on the other CPU can be accessed safely */
 
                   /* Copy tcb->xcp.regs to tcp.xcp.saved. These will be

--- a/arch/arm/src/armv7-m/arm_schedulesigaction.c
+++ b/arch/arm/src/armv7-m/arm_schedulesigaction.c
@@ -276,12 +276,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
                   up_cpu_pause(cpu);
 
-                  /* Wait while the pause request is pending */
-
-                  while (up_cpu_pausereq(cpu))
-                    {
-                    }
-
                   /* Now tcb on the other CPU can be accessed safely */
 
                   /* Copy tcb->xcp.regs to tcp.xcp.saved. These will be

--- a/arch/arm/src/armv7-r/arm_schedulesigaction.c
+++ b/arch/arm/src/armv7-r/arm_schedulesigaction.c
@@ -267,12 +267,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
                   up_cpu_pause(cpu);
 
-                  /* Wait while the pause request is pending */
-
-                  while (up_cpu_pausereq(cpu))
-                    {
-                    }
-
                   /* Now tcb on the other CPU can be accessed safely */
 
                   /* Copy tcb->xcp.regs to tcp.xcp.saved. These will be

--- a/arch/arm/src/armv8-m/arm_schedulesigaction.c
+++ b/arch/arm/src/armv8-m/arm_schedulesigaction.c
@@ -276,12 +276,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
                   up_cpu_pause(cpu);
 
-                  /* Wait while the pause request is pending */
-
-                  while (up_cpu_pausereq(cpu))
-                    {
-                    }
-
                   /* Now tcb on the other CPU can be accessed safely */
 
                   /* Copy tcb->xcp.regs to tcp.xcp.saved. These will be

--- a/arch/arm/src/armv8-r/arm_schedulesigaction.c
+++ b/arch/arm/src/armv8-r/arm_schedulesigaction.c
@@ -267,12 +267,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
                   up_cpu_pause(cpu);
 
-                  /* Wait while the pause request is pending */
-
-                  while (up_cpu_pausereq(cpu))
-                    {
-                    }
-
                   /* Now tcb on the other CPU can be accessed safely */
 
                   /* Copy tcb->xcp.regs to tcp.xcp.saved. These will be

--- a/arch/arm64/src/common/arm64_schedulesigaction.c
+++ b/arch/arm64/src/common/arm64_schedulesigaction.c
@@ -273,12 +273,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
                   up_cpu_pause(cpu);
 
-                  /* Wait while the pause request is pending */
-
-                  while (up_cpu_pausereq(cpu))
-                    {
-                    }
-
                   /* Now tcb on the other CPU can be accessed safely */
 
                   /* Copy tcb->xcp.regs to tcp.xcp.saved. These will be

--- a/arch/ceva/src/common/ceva_schedulesigaction.c
+++ b/arch/ceva/src/common/ceva_schedulesigaction.c
@@ -130,12 +130,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                   /* Pause the CPU */
 
                   up_cpu_pause(cpu);
-
-                  /* Wait while the pause request is pending */
-
-                  while (up_cpu_pausereq(cpu))
-                    {
-                    }
                 }
 
               /* Now tcb on the other CPU can be accessed safely */

--- a/arch/risc-v/src/common/riscv_schedulesigaction.c
+++ b/arch/risc-v/src/common/riscv_schedulesigaction.c
@@ -274,12 +274,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
                   up_cpu_pause(cpu);
 
-                  /* Wait while the pause request is pending */
-
-                  while (up_cpu_pausereq(cpu))
-                    {
-                    }
-
                   /* Now tcb on the other CPU can be accessed safely */
 
                   /* Copy tcb->xcp.regs to tcp.xcp.saved. These will be

--- a/arch/sparc/src/sparc_v8/sparc_v8_schedulesigaction.c
+++ b/arch/sparc/src/sparc_v8/sparc_v8_schedulesigaction.c
@@ -242,12 +242,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
                   up_cpu_pause(cpu);
 
-                  /* Wait while the pause request is pending */
-
-                  while (up_cpu_pausereq(cpu))
-                    {
-                    }
-
                   /* Now tcb on the other CPU can be accessed safely */
 
                   /* Copy tcb->xcp.regs to tcp.xcp.saved. These will be

--- a/arch/x86_64/src/intel64/intel64_schedulesigaction.c
+++ b/arch/x86_64/src/intel64/intel64_schedulesigaction.c
@@ -226,12 +226,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
                   up_cpu_pause(cpu);
 
-                  /* Wait while the pause request is pending */
-
-                  while (up_cpu_pausereq(cpu))
-                    {
-                    }
-
                   /* Now tcb on the other CPU can be accessed safely */
 
                   /* Copy tcb->xcp.regs to tcp.xcp.saved. These will be

--- a/arch/xtensa/src/common/xtensa_schedsigaction.c
+++ b/arch/xtensa/src/common/xtensa_schedsigaction.c
@@ -273,12 +273,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
                   up_cpu_pause(cpu);
 
-                  /* Wait while the pause request is pending */
-
-                  while (up_cpu_pausereq(cpu))
-                    {
-                    }
-
                   /* Now tcb on the other CPU can be accessed safely */
 
                   /* Copy tcb->xcp.regs to tcp.xcp.saved_regs. These will be


### PR DESCRIPTION
## Summary
After the up_cpu_pause call completes, it guarantees that other CPUs have fully stopped.

## Impact
none 

## Testing
ostest

Configuring NuttX and compile:
$ ./tools/configure.sh -l qemu-armv8a:nsh_smp
$ make
Running with qemu
$ qemu-system-aarch64 -cpu cortex-a53 -smp 4 -nographic \
   -machine virt,virtualization=on,gic-version=3 \
   -net none -chardev stdio,id=con,mux=on -serial chardev:con \
   -mon chardev=con,mode=readline -kernel ./nuttx
