### PR TITLE
sched: use this_task replace nxsched_self

### DIFF
--- a/arch/arm/src/armv6-m/arm_svcall.c
+++ b/arch/arm/src/armv6-m/arm_svcall.c
@@ -211,7 +211,7 @@ int arm_svcall(int irq, void *context, void *arg)
 #ifdef CONFIG_LIB_SYSCALL
       case SYS_syscall_return:
         {
-          struct tcb_s *rtcb = nxsched_self();
+          struct tcb_s *rtcb = this_task();
           int index = (int)rtcb->xcp.nsyscalls - 1;
 
           /* Make sure that there is a saved syscall return address. */
@@ -334,7 +334,7 @@ int arm_svcall(int irq, void *context, void *arg)
 #ifdef CONFIG_BUILD_PROTECTED
       case SYS_signal_handler:
         {
-          struct tcb_s *rtcb   = nxsched_self();
+          struct tcb_s *rtcb   = this_task();
 
           /* Remember the caller's return address */
 
@@ -376,7 +376,7 @@ int arm_svcall(int irq, void *context, void *arg)
 #ifdef CONFIG_BUILD_PROTECTED
       case SYS_signal_handler_return:
         {
-          struct tcb_s *rtcb   = nxsched_self();
+          struct tcb_s *rtcb   = this_task();
 
           /* Set up to return to the kernel-mode signal dispatching logic. */
 
@@ -401,7 +401,7 @@ int arm_svcall(int irq, void *context, void *arg)
       default:
         {
 #ifdef CONFIG_LIB_SYSCALL
-          struct tcb_s *rtcb = nxsched_self();
+          struct tcb_s *rtcb = this_task();
           int index = rtcb->xcp.nsyscalls;
 
           /* Verify that the SYS call number is within range */

--- a/arch/arm/src/armv7-a/arm_addrenv_shm.c
+++ b/arch/arm/src/armv7-a/arm_addrenv_shm.c
@@ -37,6 +37,7 @@
 #include "mmu.h"
 #include "addrenv.h"
 #include "pgalloc.h"
+#include "sched/sched.h"
 
 #if defined(CONFIG_BUILD_KERNEL) && defined(CONFIG_ARCH_VMA_MAPPING)
 
@@ -65,7 +66,7 @@
 
 int up_shmat(uintptr_t *pages, unsigned int npages, uintptr_t vaddr)
 {
-  struct tcb_s *tcb = nxsched_self();
+  struct tcb_s *tcb = this_task();
   struct arch_addrenv_s *addrenv;
   uintptr_t *l1entry;
   uint32_t *l2table;
@@ -188,7 +189,7 @@ int up_shmat(uintptr_t *pages, unsigned int npages, uintptr_t vaddr)
 
 int up_shmdt(uintptr_t vaddr, unsigned int npages)
 {
-  struct tcb_s *tcb = nxsched_self();
+  struct tcb_s *tcb = this_task();
   struct arch_addrenv_s *addrenv;
   uintptr_t *l1entry;
   uint32_t *l2table;

--- a/arch/arm/src/armv7-a/arm_pgalloc.c
+++ b/arch/arm/src/armv7-a/arm_pgalloc.c
@@ -36,6 +36,7 @@
 
 #include "mmu.h"
 #include "pgalloc.h"
+#include "sched/sched.h"
 
 #ifdef CONFIG_BUILD_KERNEL
 
@@ -182,7 +183,7 @@ static int get_pgtable(arch_addrenv_t *addrenv, uintptr_t vaddr)
 
 uintptr_t pgalloc(uintptr_t brkaddr, unsigned int npages)
 {
-  struct tcb_s *tcb = nxsched_self();
+  struct tcb_s *tcb = this_task();
   struct arch_addrenv_s *addrenv;
   uint32_t *l2table;
   irqstate_t flags;

--- a/arch/arm/src/armv7-a/arm_syscall.c
+++ b/arch/arm/src/armv7-a/arm_syscall.c
@@ -204,7 +204,7 @@ uint32_t *arm_syscall(uint32_t *regs)
 #ifdef CONFIG_LIB_SYSCALL
       case SYS_syscall_return:
         {
-          struct tcb_s *rtcb = nxsched_self();
+          struct tcb_s *rtcb = this_task();
           int index = (int)rtcb->xcp.nsyscalls - 1;
 
           /* Make sure that there is a saved SYSCALL return address. */
@@ -386,7 +386,7 @@ uint32_t *arm_syscall(uint32_t *regs)
 
       case SYS_signal_handler:
         {
-          struct tcb_s *rtcb = nxsched_self();
+          struct tcb_s *rtcb = this_task();
 
           /* Remember the caller's return address */
 
@@ -463,7 +463,7 @@ uint32_t *arm_syscall(uint32_t *regs)
 
       case SYS_signal_handler_return:
         {
-          struct tcb_s *rtcb = nxsched_self();
+          struct tcb_s *rtcb = this_task();
 
           /* Set up to return to the kernel-mode signal dispatching logic. */
 
@@ -500,7 +500,7 @@ uint32_t *arm_syscall(uint32_t *regs)
       default:
         {
 #ifdef CONFIG_LIB_SYSCALL
-          struct tcb_s *rtcb = nxsched_self();
+          struct tcb_s *rtcb = this_task();
           int index = rtcb->xcp.nsyscalls;
 
           /* Verify that the SYS call number is within range */

--- a/arch/arm/src/armv7-m/arm_svcall.c
+++ b/arch/arm/src/armv7-m/arm_svcall.c
@@ -220,7 +220,7 @@ int arm_svcall(int irq, void *context, void *arg)
 #ifdef CONFIG_LIB_SYSCALL
       case SYS_syscall_return:
         {
-          struct tcb_s *rtcb = nxsched_self();
+          struct tcb_s *rtcb = this_task();
           int index = (int)rtcb->xcp.nsyscalls - 1;
 
           /* Make sure that there is a saved syscall return address. */
@@ -343,7 +343,7 @@ int arm_svcall(int irq, void *context, void *arg)
 #ifdef CONFIG_BUILD_PROTECTED
       case SYS_signal_handler:
         {
-          struct tcb_s *rtcb   = nxsched_self();
+          struct tcb_s *rtcb   = this_task();
 
           /* Remember the caller's return address */
 
@@ -385,7 +385,7 @@ int arm_svcall(int irq, void *context, void *arg)
 #ifdef CONFIG_BUILD_PROTECTED
       case SYS_signal_handler_return:
         {
-          struct tcb_s *rtcb   = nxsched_self();
+          struct tcb_s *rtcb   = this_task();
 
           /* Set up to return to the kernel-mode signal dispatching logic. */
 
@@ -410,7 +410,7 @@ int arm_svcall(int irq, void *context, void *arg)
       default:
         {
 #ifdef CONFIG_LIB_SYSCALL
-          struct tcb_s *rtcb = nxsched_self();
+          struct tcb_s *rtcb = this_task();
           int index = rtcb->xcp.nsyscalls;
 
           /* Verify that the SYS call number is within range */

--- a/arch/arm/src/armv7-r/arm_syscall.c
+++ b/arch/arm/src/armv7-r/arm_syscall.c
@@ -200,7 +200,7 @@ uint32_t *arm_syscall(uint32_t *regs)
 #ifdef CONFIG_LIB_SYSCALL
       case SYS_syscall_return:
         {
-          struct tcb_s *rtcb = nxsched_self();
+          struct tcb_s *rtcb = this_task();
           int index = (int)rtcb->xcp.nsyscalls - 1;
 
           /* Make sure that there is a saved SYSCALL return address. */
@@ -382,7 +382,7 @@ uint32_t *arm_syscall(uint32_t *regs)
 
       case SYS_signal_handler:
         {
-          struct tcb_s *rtcb = nxsched_self();
+          struct tcb_s *rtcb = this_task();
 
           /* Remember the caller's return address */
 
@@ -459,7 +459,7 @@ uint32_t *arm_syscall(uint32_t *regs)
 
       case SYS_signal_handler_return:
         {
-          struct tcb_s *rtcb = nxsched_self();
+          struct tcb_s *rtcb = this_task();
 
           /* Set up to return to the kernel-mode signal dispatching logic. */
 
@@ -496,7 +496,7 @@ uint32_t *arm_syscall(uint32_t *regs)
       default:
         {
 #ifdef CONFIG_LIB_SYSCALL
-          struct tcb_s *rtcb = nxsched_self();
+          struct tcb_s *rtcb = this_task();
           int index = rtcb->xcp.nsyscalls;
 
           /* Verify that the SYS call number is within range */

--- a/arch/arm/src/armv8-m/arm_svcall.c
+++ b/arch/arm/src/armv8-m/arm_svcall.c
@@ -219,7 +219,7 @@ int arm_svcall(int irq, void *context, void *arg)
 #ifdef CONFIG_LIB_SYSCALL
       case SYS_syscall_return:
         {
-          struct tcb_s *rtcb = nxsched_self();
+          struct tcb_s *rtcb = this_task();
           int index = (int)rtcb->xcp.nsyscalls - 1;
 
           /* Make sure that there is a saved syscall return address. */
@@ -343,7 +343,7 @@ int arm_svcall(int irq, void *context, void *arg)
 #ifdef CONFIG_BUILD_PROTECTED
       case SYS_signal_handler:
         {
-          struct tcb_s *rtcb   = nxsched_self();
+          struct tcb_s *rtcb   = this_task();
 
           /* Remember the caller's return address */
 
@@ -385,7 +385,7 @@ int arm_svcall(int irq, void *context, void *arg)
 #ifdef CONFIG_BUILD_PROTECTED
       case SYS_signal_handler_return:
         {
-          struct tcb_s *rtcb   = nxsched_self();
+          struct tcb_s *rtcb   = this_task();
 
           /* Set up to return to the kernel-mode signal dispatching logic. */
 
@@ -411,7 +411,7 @@ int arm_svcall(int irq, void *context, void *arg)
       default:
         {
 #ifdef CONFIG_LIB_SYSCALL
-          struct tcb_s *rtcb = nxsched_self();
+          struct tcb_s *rtcb = this_task();
           int index = rtcb->xcp.nsyscalls;
 
           /* Verify that the SYS call number is within range */

--- a/arch/arm/src/armv8-r/arm_syscall.c
+++ b/arch/arm/src/armv8-r/arm_syscall.c
@@ -200,7 +200,7 @@ uint32_t *arm_syscall(uint32_t *regs)
 #ifdef CONFIG_LIB_SYSCALL
       case SYS_syscall_return:
         {
-          struct tcb_s *rtcb = nxsched_self();
+          struct tcb_s *rtcb = this_task();
           int index = (int)rtcb->xcp.nsyscalls - 1;
 
           /* Make sure that there is a saved SYSCALL return address. */
@@ -382,7 +382,7 @@ uint32_t *arm_syscall(uint32_t *regs)
 
       case SYS_signal_handler:
         {
-          struct tcb_s *rtcb = nxsched_self();
+          struct tcb_s *rtcb = this_task();
 
           /* Remember the caller's return address */
 
@@ -459,7 +459,7 @@ uint32_t *arm_syscall(uint32_t *regs)
 
       case SYS_signal_handler_return:
         {
-          struct tcb_s *rtcb = nxsched_self();
+          struct tcb_s *rtcb = this_task();
 
           /* Set up to return to the kernel-mode signal dispatching logic. */
 
@@ -496,7 +496,7 @@ uint32_t *arm_syscall(uint32_t *regs)
       default:
         {
 #ifdef CONFIG_LIB_SYSCALL
-          struct tcb_s *rtcb = nxsched_self();
+          struct tcb_s *rtcb = this_task();
           int index = rtcb->xcp.nsyscalls;
 
           /* Verify that the SYS call number is within range */

--- a/arch/arm64/src/common/arm64_addrenv_shm.c
+++ b/arch/arm64/src/common/arm64_addrenv_shm.c
@@ -33,6 +33,7 @@
 #include <nuttx/irq.h>
 #include <nuttx/pgalloc.h>
 
+#include "sched/sched.h"
 #include "addrenv.h"
 #include "barriers.h"
 #include "pgalloc.h"
@@ -65,7 +66,7 @@
 
 int up_shmat(uintptr_t *pages, unsigned int npages, uintptr_t vaddr)
 {
-  struct tcb_s          *tcb     = nxsched_self();
+  struct tcb_s          *tcb     = this_task();
   struct arch_addrenv_s *addrenv = &tcb->addrenv_own->addrenv;
 
   /* Sanity checks */
@@ -99,7 +100,7 @@ int up_shmat(uintptr_t *pages, unsigned int npages, uintptr_t vaddr)
 
 int up_shmdt(uintptr_t vaddr, unsigned int npages)
 {
-  struct tcb_s          *tcb     = nxsched_self();
+  struct tcb_s          *tcb     = this_task();
   struct arch_addrenv_s *addrenv = &tcb->addrenv_own->addrenv;
 
   /* Sanity checks */

--- a/arch/arm64/src/common/arm64_pgalloc.c
+++ b/arch/arm64/src/common/arm64_pgalloc.c
@@ -35,6 +35,7 @@
 #include <nuttx/pgalloc.h>
 #include <nuttx/sched.h>
 
+#include "sched/sched.h"
 #include "addrenv.h"
 #include "barriers.h"
 #include "pgalloc.h"
@@ -89,7 +90,7 @@
 
 uintptr_t pgalloc(uintptr_t brkaddr, unsigned int npages)
 {
-  struct tcb_s          *tcb = nxsched_self();
+  struct tcb_s          *tcb = this_task();
   struct arch_addrenv_s *addrenv;
   uintptr_t              ptlast;
   uintptr_t              paddr;

--- a/arch/arm64/src/common/arm64_syscall.c
+++ b/arch/arm64/src/common/arm64_syscall.c
@@ -313,7 +313,7 @@ int arm64_syscall(uint64_t *regs)
 
       case SYS_signal_handler:
         {
-          struct tcb_s *rtcb = nxsched_self();
+          struct tcb_s *rtcb = this_task();
 
           /* Remember the caller's return address */
 
@@ -377,7 +377,7 @@ int arm64_syscall(uint64_t *regs)
 
       case SYS_signal_handler_return:
         {
-          struct tcb_s *rtcb = nxsched_self();
+          struct tcb_s *rtcb = this_task();
 
           /* Set up to return to the kernel-mode signal dispatching logic. */
 

--- a/arch/mips/src/mips32/mips_swint0.c
+++ b/arch/mips/src/mips32/mips_swint0.c
@@ -199,7 +199,7 @@ int mips_swint0(int irq, void *context, void *arg)
 #ifdef CONFIG_BUILD_KERNEL
       case SYS_syscall_return:
         {
-          struct tcb_s *rtcb = nxsched_self();
+          struct tcb_s *rtcb = this_task();
           int index = (int)rtcb->xcp.nsyscalls - 1;
 
           /* Make sure that there is a saved syscall return address. */
@@ -232,7 +232,7 @@ int mips_swint0(int irq, void *context, void *arg)
       default:
         {
 #ifdef CONFIG_BUILD_KERNEL
-          struct tcb_s *rtcb = nxsched_self();
+          struct tcb_s *rtcb = this_task();
           int index = rtcb->xcp.nsyscalls;
 
           /* Verify that the SYS call number is within range */

--- a/arch/misoc/src/lm32/lm32_swint.c
+++ b/arch/misoc/src/lm32/lm32_swint.c
@@ -197,7 +197,7 @@ int lm32_swint(int irq, void *context, void *arg)
 #ifdef CONFIG_BUILD_KERNEL
       case SYS_syscall_return:
         {
-          struct tcb_s *rtcb = nxsched_self();
+          struct tcb_s *rtcb = this_task();
           int index = (int)rtcb->xcp.nsyscalls - 1;
 
           /* Make sure that there is a saved syscall return address. */
@@ -230,7 +230,7 @@ int lm32_swint(int irq, void *context, void *arg)
       default:
         {
 #ifdef CONFIG_BUILD_KERNEL
-          struct tcb_s *rtcb = nxsched_self();
+          struct tcb_s *rtcb = this_task();
           int index = rtcb->xcp.nsyscalls;
 
           /* Verify that the SYS call number is within range */

--- a/arch/misoc/src/minerva/minerva_swint.c
+++ b/arch/misoc/src/minerva/minerva_swint.c
@@ -167,7 +167,7 @@ int minerva_swint(int irq, void *context, void *arg)
 #ifdef CONFIG_BUILD_KERNEL
     case SYS_syscall_return:
       {
-        struct tcb_s *rtcb = nxsched_self();
+        struct tcb_s *rtcb = this_task();
         int index = (int)rtcb->xcp.nsyscalls - 1;
 
         /* Make sure that there is a saved syscall return address. */
@@ -200,7 +200,7 @@ int minerva_swint(int irq, void *context, void *arg)
     default:
       {
 #ifdef CONFIG_BUILD_KERNEL
-        struct tcb_s *rtcb = nxsched_self();
+        struct tcb_s *rtcb = this_task();
         int index = rtcb->xcp.nsyscalls;
 
         /* Verify that the SYS call number is within range */

--- a/arch/risc-v/src/common/riscv_addrenv_shm.c
+++ b/arch/risc-v/src/common/riscv_addrenv_shm.c
@@ -35,6 +35,7 @@
 
 #include <arch/barriers.h>
 
+#include "sched/sched.h"
 #include "addrenv.h"
 #include "pgalloc.h"
 #include "riscv_mmu.h"
@@ -66,7 +67,7 @@
 
 int up_shmat(uintptr_t *pages, unsigned int npages, uintptr_t vaddr)
 {
-  struct tcb_s          *tcb     = nxsched_self();
+  struct tcb_s          *tcb     = this_task();
   struct arch_addrenv_s *addrenv = &tcb->addrenv_own->addrenv;
 
   /* Sanity checks */
@@ -100,7 +101,7 @@ int up_shmat(uintptr_t *pages, unsigned int npages, uintptr_t vaddr)
 
 int up_shmdt(uintptr_t vaddr, unsigned int npages)
 {
-  struct tcb_s          *tcb     = nxsched_self();
+  struct tcb_s          *tcb     = this_task();
   struct arch_addrenv_s *addrenv = &tcb->addrenv_own->addrenv;
 
   /* Sanity checks */

--- a/arch/risc-v/src/common/riscv_ksp.c
+++ b/arch/risc-v/src/common/riscv_ksp.c
@@ -26,11 +26,13 @@
 
 #include <nuttx/sched.h>
 
+#include "sched/sched.h"
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
 uintptr_t riscv_current_ksp(void)
 {
-  return (uintptr_t)nxsched_self()->xcp.kstkptr;
+  return (uintptr_t)this_task()->xcp.kstkptr;
 }

--- a/arch/risc-v/src/common/riscv_pgalloc.c
+++ b/arch/risc-v/src/common/riscv_pgalloc.c
@@ -37,6 +37,7 @@
 
 #include <arch/barriers.h>
 
+#include "sched/sched.h"
 #include "addrenv.h"
 #include "pgalloc.h"
 #include "riscv_mmu.h"
@@ -94,7 +95,7 @@
 
 uintptr_t pgalloc(uintptr_t brkaddr, unsigned int npages)
 {
-  struct tcb_s          *tcb = nxsched_self();
+  struct tcb_s          *tcb = this_task();
   struct arch_addrenv_s *addrenv;
   uintptr_t              ptlast;
   uintptr_t              paddr;

--- a/arch/risc-v/src/common/riscv_swint.c
+++ b/arch/risc-v/src/common/riscv_swint.c
@@ -292,7 +292,7 @@ int riscv_swint(int irq, void *context, void *arg)
 #ifdef CONFIG_ARCH_KERNEL_STACK
           /* Set the user stack pointer as we are about to return to user */
 
-          struct tcb_s *tcb  = nxsched_self();
+          struct tcb_s *tcb  = this_task();
           regs[REG_SP]       = (uintptr_t)tcb->xcp.ustkptr;
           tcb->xcp.ustkptr   = NULL;
 #endif
@@ -338,7 +338,7 @@ int riscv_swint(int irq, void *context, void *arg)
 #ifdef CONFIG_ARCH_KERNEL_STACK
           /* Set the user stack pointer as we are about to return to user */
 
-          struct tcb_s *tcb  = nxsched_self();
+          struct tcb_s *tcb  = this_task();
           regs[REG_SP]       = (uintptr_t)tcb->xcp.ustkptr;
           tcb->xcp.ustkptr   = NULL;
 #endif
@@ -373,7 +373,7 @@ int riscv_swint(int irq, void *context, void *arg)
 #ifndef CONFIG_BUILD_FLAT
       case SYS_signal_handler:
         {
-          struct tcb_s *rtcb   = nxsched_self();
+          struct tcb_s *rtcb   = this_task();
 
           /* Remember the caller's return address */
 
@@ -450,7 +450,7 @@ int riscv_swint(int irq, void *context, void *arg)
 #ifndef CONFIG_BUILD_FLAT
       case SYS_signal_handler_return:
         {
-          struct tcb_s *rtcb   = nxsched_self();
+          struct tcb_s *rtcb   = this_task();
 
           /* Set up to return to the kernel-mode signal dispatching logic. */
 

--- a/arch/xtensa/src/common/xtensa_swint.c
+++ b/arch/xtensa/src/common/xtensa_swint.c
@@ -160,7 +160,7 @@ int xtensa_swint(int irq, void *context, void *arg)
 #ifdef CONFIG_LIB_SYSCALL
       case SYS_syscall_return:
         {
-          struct tcb_s *rtcb = nxsched_self();
+          struct tcb_s *rtcb = this_task();
           int index = (int)rtcb->xcp.nsyscalls - 1;
 
           /* Make sure that there is a saved syscall return address. */
@@ -299,7 +299,7 @@ int xtensa_swint(int irq, void *context, void *arg)
 #ifndef CONFIG_BUILD_FLAT
       case SYS_signal_handler:
         {
-          struct tcb_s *rtcb  = nxsched_self();
+          struct tcb_s *rtcb  = this_task();
 
           /* Remember the caller's return address */
 
@@ -338,7 +338,7 @@ int xtensa_swint(int irq, void *context, void *arg)
 #ifndef CONFIG_BUILD_FLAT
       case SYS_signal_handler_return:
         {
-          struct tcb_s *rtcb  = nxsched_self();
+          struct tcb_s *rtcb  = this_task();
 
           /* Set up to return to the kernel-mode signal dispatching logic. */
 
@@ -360,7 +360,7 @@ int xtensa_swint(int irq, void *context, void *arg)
       default:
         {
 #ifdef CONFIG_LIB_SYSCALL
-          struct tcb_s *rtcb = nxsched_self();
+          struct tcb_s *rtcb = this_task();
           int index = rtcb->xcp.nsyscalls;
 
           /* Verify that the syscall number is within range */

--- a/fs/inode/fs_files.c
+++ b/fs/inode/fs_files.c
@@ -51,6 +51,7 @@
 #  include <nuttx/fdcheck.h>
 #endif
 
+#include "sched/sched.h"
 #include "inode/inode.h"
 
 /****************************************************************************
@@ -551,7 +552,7 @@ found:
 int file_allocate(FAR struct inode *inode, int oflags, off_t pos,
                   FAR void *priv, int minfd, bool addref)
 {
-  return file_allocate_from_tcb(nxsched_self(), inode, oflags,
+  return file_allocate_from_tcb(this_task(), inode, oflags,
                                 pos, priv, minfd, addref);
 }
 
@@ -746,7 +747,7 @@ int nx_dup2_from_tcb(FAR struct tcb_s *tcb, int fd1, int fd2)
 
 int nx_dup2(int fd1, int fd2)
 {
-  return nx_dup2_from_tcb(nxsched_self(), fd1, fd2);
+  return nx_dup2_from_tcb(this_task(), fd1, fd2);
 }
 
 /****************************************************************************
@@ -785,7 +786,7 @@ int dup3(int fd1, int fd2, int flags)
 {
   int ret;
 
-  ret = nx_dup3_from_tcb(nxsched_self(), fd1, fd2, flags);
+  ret = nx_dup3_from_tcb(this_task(), fd1, fd2, flags);
   if (ret < 0)
     {
       set_errno(-ret);
@@ -872,7 +873,7 @@ int nx_close_from_tcb(FAR struct tcb_s *tcb, int fd)
 
 int nx_close(int fd)
 {
-  return nx_close_from_tcb(nxsched_self(), fd);
+  return nx_close_from_tcb(this_task(), fd);
 }
 
 /****************************************************************************

--- a/fs/mmap/fs_anonmap.c
+++ b/fs/mmap/fs_anonmap.c
@@ -29,6 +29,7 @@
 #include <debug.h>
 
 #include "fs_anonmap.h"
+#include "sched/sched.h"
 
 /****************************************************************************
  * Private Functions

--- a/fs/mmap/fs_munmap.c
+++ b/fs/mmap/fs_munmap.c
@@ -37,6 +37,7 @@
 
 #include "inode/inode.h"
 #include "fs_rammap.h"
+#include "sched/sched.h"
 
 /****************************************************************************
  * Private Functions
@@ -44,7 +45,7 @@
 
 static int file_munmap_(FAR void *start, size_t length, bool kernel)
 {
-  FAR struct tcb_s *tcb = nxsched_self();
+  FAR struct tcb_s *tcb = this_task();
   FAR struct task_group_s *group = tcb->group;
   FAR struct mm_map_entry_s *entry = NULL;
   FAR struct mm_map_s *mm = get_current_mm();

--- a/fs/mmap/fs_rammap.c
+++ b/fs/mmap/fs_rammap.c
@@ -36,6 +36,7 @@
 #include <nuttx/sched.h>
 
 #include "fs_rammap.h"
+#include "sched/sched.h"
 
 #ifdef CONFIG_FS_RAMMAP
 

--- a/fs/shm/shmfs.c
+++ b/fs/shm/shmfs.c
@@ -35,6 +35,7 @@
 
 #include "shm/shmfs.h"
 #include "inode/inode.h"
+#include "sched/sched.h"
 
 /****************************************************************************
  * Private Function Prototypes
@@ -295,7 +296,7 @@ static int shmfs_map_object(FAR struct shmfs_object_s *object,
 #ifdef CONFIG_BUILD_KERNEL
   /* Map the physical pages of the shm object with MMU. */
 
-  FAR struct tcb_s *tcb = nxsched_self();
+  FAR struct tcb_s *tcb = this_task();
   FAR struct task_group_s *group = tcb->group;
   FAR uintptr_t *pages = (FAR uintptr_t *)&object->paddr;
   uintptr_t mapaddr;

--- a/fs/vfs/fs_lock.c
+++ b/fs/vfs/fs_lock.c
@@ -36,6 +36,7 @@
 #include <nuttx/mutex.h>
 #include <nuttx/list.h>
 
+#include "sched/sched.h"
 #include "lock.h"
 
 /****************************************************************************
@@ -95,7 +96,7 @@ static mutex_t g_protect_lock = NXMUTEX_INITIALIZER;
 
 static int file_lock_get_path(FAR struct file *filep, FAR char *path)
 {
-  FAR struct tcb_s *tcb = nxsched_self();
+  FAR struct tcb_s *tcb = this_task();
 
   /* We only apply file lock on mount points (f_inode won't be NULL). */
 

--- a/fs/vfs/fs_open.c
+++ b/fs/vfs/fs_open.c
@@ -36,6 +36,7 @@
 #include <nuttx/cancelpt.h>
 #include <nuttx/fs/fs.h>
 
+#include "sched/sched.h"
 #include "inode/inode.h"
 #include "driver/driver.h"
 #include "notify/notify.h"
@@ -437,7 +438,7 @@ int nx_open(FAR const char *path, int oflags, ...)
   /* Let nx_vopen() do all of the work */
 
   va_start(ap, oflags);
-  fd = nx_vopen(nxsched_self(), path, oflags, ap);
+  fd = nx_vopen(this_task(), path, oflags, ap);
   va_end(ap);
 
   return fd;
@@ -467,7 +468,7 @@ int open(FAR const char *path, int oflags, ...)
   /* Let nx_vopen() do most of the work */
 
   va_start(ap, oflags);
-  fd = nx_vopen(nxsched_self(), path, oflags, ap);
+  fd = nx_vopen(this_task(), path, oflags, ap);
   va_end(ap);
 
   /* Set the errno value if any errors were reported by nx_open() */

--- a/mm/CMakeLists.txt
+++ b/mm/CMakeLists.txt
@@ -19,4 +19,5 @@
 # ##############################################################################
 nuttx_add_kernel_library(mm SPLIT)
 nuttx_add_subdirectory()
-target_include_directories(mm PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(mm PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+                                      ${NUTTX_DIR}/sched)

--- a/mm/Makefile
+++ b/mm/Makefile
@@ -53,6 +53,7 @@ else
 endif
 
 CFLAGS += ${INCDIR_PREFIX}$(TOPDIR)$(DELIM)mm
+CFLAGS += ${INCDIR_PREFIX}$(TOPDIR)$(DELIM)sched
 
 AOBJS = $(patsubst %.S, $(BINDIR)$(DELIMS)%$(OBJEXT), $(ASRCS))
 COBJS = $(patsubst %.c, $(BINDIR)$(DELIMS)%$(OBJEXT), $(CSRCS))

--- a/mm/kmap/kmm_map.c
+++ b/mm/kmap/kmm_map.c
@@ -38,6 +38,8 @@
 
 #include <sys/mman.h>
 
+#include "sched/sched.h"
+
 #if defined(CONFIG_BUILD_KERNEL)
 
 /****************************************************************************
@@ -74,7 +76,7 @@ static struct mm_map_s g_kmm_map;
 
 static int get_user_pages(FAR void **pages, size_t npages, uintptr_t vaddr)
 {
-  FAR struct tcb_s *tcb = nxsched_self();
+  FAR struct tcb_s *tcb = this_task();
   uintptr_t         page;
   int               i;
 
@@ -177,7 +179,7 @@ errout_with_vaddr:
 
 static FAR void *map_single_user_page(uintptr_t vaddr)
 {
-  FAR struct tcb_s *tcb = nxsched_self();
+  FAR struct tcb_s *tcb = this_task();
   uintptr_t         page;
 
   /* Find the page associated with this virtual address */

--- a/mm/map/mm_map.c
+++ b/mm/map/mm_map.c
@@ -32,6 +32,8 @@
 #include <assert.h>
 #include <debug.h>
 
+#include "sched/sched.h"
+
 #if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
 
 /****************************************************************************
@@ -64,7 +66,7 @@ static bool in_range(FAR const void *start, size_t length,
 
 int mm_map_lock(void)
 {
-  FAR struct tcb_s *tcb = nxsched_self();
+  FAR struct tcb_s *tcb = this_task();
   FAR struct task_group_s *group = tcb->group;
 
   if (group == NULL)
@@ -85,7 +87,7 @@ int mm_map_lock(void)
 
 void mm_map_unlock(void)
 {
-  FAR struct tcb_s *tcb = nxsched_self();
+  FAR struct tcb_s *tcb = this_task();
   FAR struct task_group_s *group = tcb->group;
 
   if (group == NULL)

--- a/mm/shm/shmat.c
+++ b/mm/shm/shmat.c
@@ -34,6 +34,7 @@
 #include <nuttx/pgalloc.h>
 #include <nuttx/mm/map.h>
 
+#include "sched/sched.h"
 #include "shm/shm.h"
 
 #ifdef CONFIG_MM_SHM
@@ -222,7 +223,7 @@ FAR void *shmat(int shmid, FAR const void *shmaddr, int shmflg)
 
   /* Get the TCB and group containing our virtual memory allocator */
 
-  tcb = nxsched_self();
+  tcb = this_task();
   DEBUGASSERT(tcb && tcb->group);
 
   group = tcb->group;

--- a/mm/shm/shmdt.c
+++ b/mm/shm/shmdt.c
@@ -34,6 +34,7 @@
 #include <nuttx/pgalloc.h>
 #include <nuttx/mm/map.h>
 
+#include "sched/sched.h"
 #include "shm/shm.h"
 
 #ifdef CONFIG_MM_SHM
@@ -72,7 +73,7 @@ int shmdt(FAR const void *shmaddr)
 
   /* Get the TCB and group containing our virtual memory allocator */
 
-  tcb = nxsched_self();
+  tcb = this_task();
   DEBUGASSERT(tcb && tcb->group);
   group = tcb->group;
 

--- a/sched/clock/clock_gettime.c
+++ b/sched/clock/clock_gettime.c
@@ -37,6 +37,7 @@
 #include <nuttx/queue.h>
 
 #include "clock/clock.h"
+#include "sched/sched.h"
 #ifdef CONFIG_CLOCK_TIMEKEEPING
 #  include "clock/clock_timekeeping.h"
 #endif
@@ -148,7 +149,7 @@ int clock_gettime(clockid_t clock_id, struct timespec *tp)
         {
           /* Fetch the THREAD_CPUTIME for current thread */
 
-          tcb = nxsched_self();
+          tcb = this_task();
         }
       else
         {
@@ -179,7 +180,7 @@ int clock_gettime(clockid_t clock_id, struct timespec *tp)
         {
           /* Fetch the PROCESS_CPUTIME for current process */
 
-          tcb = nxsched_self();
+          tcb = this_task();
         }
       else
         {


### PR DESCRIPTION
## Summary
We can reduce a function call to improve performance.

## Impact
none

## Testing
ostest
