### PR TITLE
spinlock: spin_initialize should add memory barrier

### DIFF
--- a/include/nuttx/spinlock.h
+++ b/include/nuttx/spinlock.h
@@ -510,7 +510,7 @@ static inline_function void spin_unlock(FAR volatile spinlock_t *lock)
 
 /* void spin_initialize(FAR spinlock_t *lock, spinlock_t state); */
 
-#define spin_initialize(l,s) do { *(l) = (s); } while (0)
+#define spin_initialize(l,s) do { SP_DMB(); *(l) = (s); } while (0)
 
 /****************************************************************************
  * Name: spin_lock_irqsave_wo_note


### PR DESCRIPTION
## Summary
spin_initialize is often used to release a lock,
and if we don't include a memory barrier,
it may lead to the lock being released prematurely.

## Impact
none

## Testing
ostest
