### PR TITLE
armv8-r/r52: add neon support into compiler line

### DIFF
--- a/arch/arm/src/armv8-r/Toolchain.defs
+++ b/arch/arm/src/armv8-r/Toolchain.defs
@@ -22,12 +22,18 @@ ARCHCPUFLAGS += -march=armv8-r
 
 ifeq ($(CONFIG_ARCH_FPU),y)
   LLVM_ABITYPE := eabihf
-  ARCHCPUFLAGS += -mfpu=vfpv3-d16
+
+  ifeq ($(CONFIG_ARCH_CORTEXR52)$(CONFIG_ARM_NEON),yy)
+    ARCHCPUFLAGS += -mfpu=neon-fp-armv8
+  else
+    ARCHCPUFLAGS += -mfpu=fpv5-sp-d16
+  endif
   ifeq ($(CONFIG_ARM_FPU_ABI_SOFT),y)
     ARCHCPUFLAGS += -mfloat-abi=softfp
   else
     ARCHCPUFLAGS += -mfloat-abi=hard
   endif
+
 else
   LLVM_ABITYPE := eabi
   ARCHCPUFLAGS += -mfloat-abi=soft

--- a/arch/arm/src/cmake/armv8-r.cmake
+++ b/arch/arm/src/cmake/armv8-r.cmake
@@ -25,7 +25,12 @@ if(CONFIG_ARCH_CORTEXR52)
 endif()
 
 if(CONFIG_ARCH_FPU)
-  list(APPEND PLATFORM_FLAGS -mfpu=vfpv3-d16)
+
+  if(CONFIG_ARCH_CORTEXR52 AND CONFIG_ARM_NEON)
+    list(APPEND PLATFORM_FLAGS -mfpu=neon-fp-armv8)
+  else()
+    list(APPEND PLATFORM_FLAGS -mfpu=fpv5-sp-d16)
+  endif()
   if(CONFIG_ARM_FPU_ABI_SOFT)
     list(APPEND PLATFORM_FLAGS -mfloat-abi=softfp)
   else()


### PR DESCRIPTION

## Summary

armv8-r/r52: add neon support into compiler line

1. correct the armv8-r fpu flag from vfpv3-d16 to fpv5-sp-d16
2. add neon support

This commit updates the build script to specify the FPU type of
`fpv5-sp-d16` when the processor is configured with a single-precision
FPU, and `neon-fp-armv8` when the processor is configured with a
double-precision + Advanced SIMD-capable FPU.

Note that the `fp-armv8` FPU type is an alias for double-precision FPv5
with 32 double-precision registers (refer to the GCC
`gcc/config/arm/arm-cpus.in` for more details); NEON is always
specified in case of a double-precision configuration because the
Cortex-R52 can only be configured as such.

Reference:
https://developer.arm.com/Processors/Cortex-R52

Instruction set:

Arm and Thumb-2. Supports DSP instructions and a configurable Floating-Point
Unit either with single-precision or double precision and Neon.

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

Cortex-R52