### PR TITLE
xtensa/esp32s3: Add timing delay set interface for QSPI

### DIFF
--- a/arch/xtensa/src/esp32s3/esp32s3_qspi.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_qspi.c
@@ -1530,6 +1530,56 @@ int esp32s3_qspibus_set_attr(struct qspi_dev_s *dev,
 }
 
 /****************************************************************************
+ * Name: esp32s3_qspibus_set_delay
+ *
+ * Description:
+ *   Set timing delay for QSPI input and output data.
+ *
+ * Input Parameters:
+ *   dev        - Device-specific state data
+ *   din_mode   - Input mode(0~3) to delay input data
+ *   din_num    - The delay number(0~3) to input data
+ *   dout_mode  - Output mode(0,1) to delay output data
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success.  Otherwise -1 (ERROR).
+ *
+ ****************************************************************************/
+
+int esp32s3_qspibus_set_delay(struct qspi_dev_s *dev,
+                              uint8_t din_mode,
+                              uint8_t din_num,
+                              uint8_t dout_mode)
+{
+  struct esp32s3_qspi_priv_s *priv = (struct esp32s3_qspi_priv_s *)dev;
+  uint8_t id = priv->config->id;
+
+  if ((din_mode > 3) || (din_num > 3) || (dout_mode > 1))
+    {
+      return -1;
+    }
+
+  uint32_t din_mode_reg = (din_mode << SPI_DIN0_MODE_S) |
+                          (din_mode << SPI_DIN1_MODE_S) |
+                          (din_mode << SPI_DIN2_MODE_S) |
+                          (din_mode << SPI_DIN3_MODE_S);
+  uint32_t din_num_reg = (din_num << SPI_DIN0_NUM_S) |
+                         (din_num << SPI_DIN1_NUM_S) |
+                         (din_num << SPI_DIN2_NUM_S) |
+                         (din_num << SPI_DIN3_NUM_S);
+  uint32_t dout_mode_reg = (dout_mode << SPI_DOUT0_MODE_S) |
+                           (dout_mode << SPI_DOUT1_MODE_S) |
+                           (dout_mode << SPI_DOUT2_MODE_S) |
+                           (dout_mode << SPI_DOUT3_MODE_S);
+
+  putreg32(din_mode_reg, SPI_DIN_MODE_REG(id));
+  putreg32(din_num_reg, SPI_DIN_NUM_REG(id));
+  putreg32(dout_mode_reg, SPI_DOUT_MODE_REG(id));
+
+  return 0;
+}
+
+/****************************************************************************
  * Name: esp32s3_qspibus_initialize
  *
  * Description:

--- a/arch/xtensa/src/esp32s3/esp32s3_qspi.h
+++ b/arch/xtensa/src/esp32s3/esp32s3_qspi.h
@@ -85,6 +85,28 @@ int esp32s3_qspibus_set_attr(struct qspi_dev_s *dev,
                              uint8_t data_lines);
 
 /****************************************************************************
+ * Name: esp32s3_qspibus_set_delay
+ *
+ * Description:
+ *   Set timing delay for QSPI input and output data.
+ *
+ * Input Parameters:
+ *   dev        - Device-specific state data
+ *   din_mode   - Input mode(0~3) to delay input data
+ *   din_num    - The delay number(0~3) to input data
+ *   dout_mode  - Output mode(0,1) to delay output data
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success.  Otherwise -1 (ERROR).
+ *
+ ****************************************************************************/
+
+int esp32s3_qspibus_set_delay(struct qspi_dev_s *dev,
+                              uint8_t din_mode,
+                              uint8_t din_num,
+                              uint8_t dout_mode);
+
+/****************************************************************************
  * Name: esp32s3_qspibus_initialize
  *
  * Description:


### PR DESCRIPTION
## Summary
When esp32s3 read from slave device through qspi, the data input signal has timing delay compared to clock signal, the higher the SPI frequency, the more impact to SPI sampling data, cause to receive wrong data.
esp32s3 has SPI timing compensation for this Scenario, add interface qspi driver to set timing compensation for the delay.

## Impact
No impact

## Testing
Build with esp32s3-devkit, test with project board.
