### PR TITLE
arch/riscv: revert pull#12864

### DIFF
--- a/arch/risc-v/include/syscall.h
+++ b/arch/risc-v/include/syscall.h
@@ -139,8 +139,7 @@ extern "C"
 
 long smh_call(unsigned int nbr, void *parm);
 
-#if defined(__KERNEL__)
-
+#if defined(CONFIG_ARCH_USE_S_MODE) && defined(__KERNEL__)
 uintptr_t sys_call0(unsigned int nbr);
 uintptr_t sys_call1(unsigned int nbr, uintptr_t parm1);
 uintptr_t sys_call2(unsigned int nbr, uintptr_t parm1, uintptr_t parm2);

--- a/arch/risc-v/src/common/CMakeLists.txt
+++ b/arch/risc-v/src/common/CMakeLists.txt
@@ -33,7 +33,6 @@ list(APPEND SRCS riscv_releasestack.c riscv_schedulesigaction.c
      riscv_sigdeliver.c)
 list(APPEND SRCS riscv_stackframe.c riscv_tcbinfo.c riscv_swint.c)
 list(APPEND SRCS riscv_switchcontext.c riscv_usestack.c)
-list(APPEND SRCS riscv_syscall.S riscv_perform_syscall.c)
 
 if(NOT CONFIG_ALARM_ARCH)
   if(NOT CONFIG_TIMER_ARCH)
@@ -119,7 +118,7 @@ if(CONFIG_RISCV_PERCPU_SCRATCH)
 endif()
 
 if(CONFIG_ARCH_USE_S_MODE)
-  list(APPEND SRCS riscv_sbi.c)
+  add_subdirectory(supervisor)
 endif()
 
 target_sources(arch PRIVATE ${SRCS})

--- a/arch/risc-v/src/common/Make.defs
+++ b/arch/risc-v/src/common/Make.defs
@@ -25,7 +25,6 @@ endif
 # Specify our general Assembly files
 CMN_ASRCS += riscv_vectors.S riscv_exception_common.S riscv_mhartid.S
 CMN_ASRCS += riscv_saveusercontext.S
-CMN_ASRCS += riscv_syscall.S
 
 # Specify C code within the common directory to be included
 CMN_CSRCS += riscv_initialize.c riscv_swint.c riscv_mtimer.c
@@ -36,7 +35,6 @@ CMN_CSRCS += riscv_idle.c riscv_modifyreg32.c riscv_nputs.c riscv_releasestack.c
 CMN_CSRCS += riscv_registerdump.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS += riscv_sigdeliver.c riscv_switchcontext.c
 CMN_CSRCS += riscv_usestack.c riscv_tcbinfo.c
-CMN_CSRCS += riscv_perform_syscall.c
 
 ifneq ($(CONFIG_ALARM_ARCH),y)
   ifneq ($(CONFIG_TIMER_ARCH),y)
@@ -119,6 +117,8 @@ ifeq ($(CONFIG_RISCV_PERCPU_SCRATCH),y)
 CMN_CSRCS += riscv_percpu.c
 endif
 
+# Kernel runs in supervisor mode or machine mode ?
+
 ifeq ($(CONFIG_ARCH_USE_S_MODE),y)
-CMN_CSRCS += riscv_sbi.c
+include common/supervisor/Make.defs
 endif

--- a/arch/risc-v/src/common/riscv_exception.c
+++ b/arch/risc-v/src/common/riscv_exception.c
@@ -287,7 +287,12 @@ void riscv_exception_attach(void)
 
   irq_attach(RISCV_IRQ_ECALLS, riscv_exception, NULL);
   irq_attach(RISCV_IRQ_ECALLH, riscv_exception, NULL);
+
+#ifndef CONFIG_ARCH_USE_S_MODE
+  irq_attach(RISCV_IRQ_ECALLM, riscv_swint, NULL);
+#else
   irq_attach(RISCV_IRQ_ECALLM, riscv_exception, NULL);
+#endif
 
   irq_attach(RISCV_IRQ_INSTRUCTIONPF, riscv_exception, NULL);
 

--- a/arch/risc-v/src/common/supervisor/CMakeLists.txt
+++ b/arch/risc-v/src/common/supervisor/CMakeLists.txt
@@ -1,0 +1,28 @@
+# ##############################################################################
+# arch/risc-v/src/common/supervisor/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_ARCH_USE_S_MODE)
+  set(SRCS)
+
+  list(APPEND SRCS riscv_syscall.S riscv_perform_syscall.c riscv_sbi.c)
+
+  target_sources(arch PRIVATE ${SRCS})
+
+endif()

--- a/arch/risc-v/src/common/supervisor/Make.defs
+++ b/arch/risc-v/src/common/supervisor/Make.defs
@@ -1,0 +1,28 @@
+############################################################################
+# arch/risc-v/src/common/supervisor/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+# If the NuttX kernel runs in S-mode
+
+CMN_ASRCS += riscv_syscall.S
+CMN_CSRCS += riscv_perform_syscall.c
+CMN_CSRCS += riscv_sbi.c
+
+INCLUDES += ${INCDIR_PREFIX}$(ARCH_SRCDIR)$(DELIM)common$(DELIM)supervisor
+VPATH += common$(DELIM)supervisor

--- a/arch/risc-v/src/common/supervisor/riscv_perform_syscall.c
+++ b/arch/risc-v/src/common/supervisor/riscv_perform_syscall.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/risc-v/src/common/riscv_perform_syscall.c
+ * arch/risc-v/src/common/supervisor/riscv_perform_syscall.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/arch/risc-v/src/common/supervisor/riscv_sbi.c
+++ b/arch/risc-v/src/common/supervisor/riscv_sbi.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/risc-v/src/common/riscv_sbi.c
+ * arch/risc-v/src/common/supervisor/riscv_sbi.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/arch/risc-v/src/common/supervisor/riscv_syscall.S
+++ b/arch/risc-v/src/common/supervisor/riscv_syscall.S
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/risc-v/src/common/riscv_syscall.S
+ * arch/risc-v/src/common/supervisor/riscv_syscall.S
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
## Summary

This reverts commit 6986cd4105 as it breaks critical section as shown by the test in [this comment](https://github.com/apache/nuttx/pull/12864#issuecomment-2325779041)

## Impacts

riscv

## Testing

- local checks on `rv-virt:netnsh`
- checks by @tmedicci on esp32c6 targets
- CI checks
