### PR TITLE
smp: smp call handler add up_cpu_paused_[save|restore]

### DIFF
--- a/sched/sched/sched_smp.c
+++ b/sched/sched/sched_smp.c
@@ -121,6 +121,7 @@ int nxsched_smp_call_handler(int irq, FAR void *context,
 
   call_queue = &g_smp_call_queue[cpu];
 
+  up_cpu_paused_save();
   sq_for_every_safe(call_queue, curr, next)
     {
       FAR struct smp_call_data_s *call_data =
@@ -154,6 +155,7 @@ int nxsched_smp_call_handler(int irq, FAR void *context,
       flags = enter_critical_section();
     }
 
+  up_cpu_paused_restore();
   leave_critical_section(flags);
   return OK;
 }


### PR DESCRIPTION
## Summary
smp call handler add up_cpu_paused_[save|restore]
Since smp call handler may lead to context switching, we need to update the context information by calling up_cpu_paused_[save|restore].

## Impact
none

## Testing
ostesting
