### PR TITLE
include/nuttx.h: replace all the align macros to nuttx version

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_udmac.c
+++ b/arch/arm/src/cxd56xx/cxd56_udmac.c
@@ -34,20 +34,13 @@
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
 #include <nuttx/mutex.h>
+#include <nuttx/nuttx.h>
 #include <nuttx/semaphore.h>
 
 #include "arm_internal.h"
 #include "cxd56_clock.h"
 #include "hardware/cxd56_udmac.h"
 #include "cxd56_udmac.h"
-
-/****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-#define ALIGN_MASK(s)    ((1 << s) - 1)
-#define ALIGN_DOWN(v, m) ((v) & ~m)
-#define ALIGN_UP(v, m)   (((v) + (m)) & ~m)
 
 /****************************************************************************
  * Private Types
@@ -434,7 +427,7 @@ void cxd56_rxudmasetup(DMA_HANDLE handle, uintptr_t paddr, uintptr_t maddr,
    */
 
   xfersize = (1 << shift);
-  nbytes   = ALIGN_DOWN(nbytes, mask);
+  nbytes   = ALIGN_DOWN_MASK(nbytes, mask);
   DEBUGASSERT(nbytes > 0);
 
   /* Save the configuration (for cxd56_udmastart()). */
@@ -531,7 +524,7 @@ void cxd56_txudmasetup(DMA_HANDLE handle, uintptr_t paddr, uintptr_t maddr,
    */
 
   xfersize = (1 << shift);
-  nbytes   = ALIGN_DOWN(nbytes, mask);
+  nbytes   = ALIGN_DOWN_MASK(nbytes, mask);
   DEBUGASSERT(nbytes > 0);
 
   /* Save the configuration (for cxd56_udmastart()). */

--- a/arch/arm/src/efm32/efm32_dma.c
+++ b/arch/arm/src/efm32/efm32_dma.c
@@ -34,20 +34,13 @@
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
 #include <nuttx/mutex.h>
+#include <nuttx/nuttx.h>
 #include <nuttx/semaphore.h>
 
 #include "arm_internal.h"
 #include "hardware/efm32_cmu.h"
 #include "hardware/efm32_dma.h"
 #include "efm32_dma.h"
-
-/****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-#define ALIGN_MASK(s)   ((1 << s) - 1)
-#define ALIGN_DOWN(v,m) ((v) & ~m)
-#define ALIGN_UP(v,m)   (((v) + (m)) & ~m)
 
 /****************************************************************************
  * Private Types
@@ -466,7 +459,7 @@ void efm32_rxdmasetup(DMA_HANDLE handle, uintptr_t paddr, uintptr_t maddr,
    */
 
   xfersize = (1 << shift);
-  nbytes   = ALIGN_DOWN(nbytes, mask);
+  nbytes   = ALIGN_DOWN_MASK(nbytes, mask);
   DEBUGASSERT(nbytes > 0);
 
   /* Save the configuration (for efm32_dmastart()). */
@@ -563,7 +556,7 @@ void efm32_txdmasetup(DMA_HANDLE handle, uintptr_t paddr, uintptr_t maddr,
    */
 
   xfersize = (1 << shift);
-  nbytes   = ALIGN_DOWN(nbytes, mask);
+  nbytes   = ALIGN_DOWN_MASK(nbytes, mask);
   DEBUGASSERT(nbytes > 0);
 
   /* Save the configuration (for efm32_dmastart()). */

--- a/arch/arm/src/nrf52/nrf52_qspi.c
+++ b/arch/arm/src/nrf52/nrf52_qspi.c
@@ -29,6 +29,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/mutex.h>
+#include <nuttx/nuttx.h>
 #include <nuttx/semaphore.h>
 #include <arch/board/board.h>
 
@@ -52,13 +53,6 @@
 /* QSPI memory synchronization */
 
 #define MEMORY_SYNC()     do { ARM_DSB(); ARM_ISB(); } while (0)
-
-/* Ensure that the DMA buffers are word-aligned. */
-
-#define ALIGN_SHIFT       2
-#define ALIGN_MASK        3
-#define ALIGN_UP(n)       (((n)+ALIGN_MASK) & ~ALIGN_MASK)
-#define IS_ALIGNED(n)     (((uint32_t)(n) & ALIGN_MASK) == 0)
 
 /****************************************************************************
  * Private Types
@@ -692,7 +686,9 @@ static int nrf52_qspi_memory(struct qspi_dev_s *dev,
 
 static void *nrf52_qspi_alloc(struct qspi_dev_s *dev, size_t buflen)
 {
-  return kmm_malloc(ALIGN_UP(buflen));
+  /* Ensure that the DMA buffers are word-aligned. */
+
+  return kmm_malloc(ALIGN_UP(buflen, 4));
 }
 
 /****************************************************************************

--- a/arch/arm/src/nrf53/nrf53_qspi.c
+++ b/arch/arm/src/nrf53/nrf53_qspi.c
@@ -29,6 +29,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/mutex.h>
+#include <nuttx/nuttx.h>
 #include <nuttx/semaphore.h>
 #include <arch/board/board.h>
 
@@ -62,13 +63,6 @@
 /* QSPI memory synchronization */
 
 #define MEMORY_SYNC()     do { ARM_DSB(); ARM_ISB(); } while (0)
-
-/* Ensure that the DMA buffers are word-aligned. */
-
-#define ALIGN_SHIFT       2
-#define ALIGN_MASK        3
-#define ALIGN_UP(n)       (((n)+ALIGN_MASK) & ~ALIGN_MASK)
-#define IS_ALIGNED(n)     (((uint32_t)(n) & ALIGN_MASK) == 0)
 
 /****************************************************************************
  * Private Types
@@ -702,7 +696,9 @@ static int nrf53_qspi_memory(struct qspi_dev_s *dev,
 
 static void *nrf53_qspi_alloc(struct qspi_dev_s *dev, size_t buflen)
 {
-  return kmm_malloc(ALIGN_UP(buflen));
+  /* Ensure that the DMA buffers are word-aligned. */
+
+  return kmm_malloc(ALIGN_UP(buflen, 4));
 }
 
 /****************************************************************************

--- a/arch/arm/src/s32k3xx/s32k3xx_qspi.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_qspi.c
@@ -46,6 +46,7 @@
 #include <nuttx/cache.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/mutex.h>
+#include <nuttx/nuttx.h>
 #include <nuttx/spi/qspi.h>
 
 #include "arm_internal.h"
@@ -68,13 +69,6 @@
 /* QSPI memory synchronization */
 
 #define MEMORY_SYNC()     do { ARM_DSB(); ARM_ISB(); } while (0)
-
-/* Ensure that the DMA buffers are word-aligned. */
-
-#define ALIGN_SHIFT       2
-#define ALIGN_MASK        3
-#define ALIGN_UP(n)       (((n)+ALIGN_MASK) & ~ALIGN_MASK)
-#define IS_ALIGNED(n)     (((uint32_t)(n) & ALIGN_MASK) == 0)
 
 /* LUT entries used for various command sequences                 */
 #define QSPI_LUT_READ        0U /* Quad Output read               */
@@ -1402,9 +1396,10 @@ static void *qspi_alloc(struct qspi_dev_s *dev, size_t buflen)
   /* Here we exploit the carnal knowledge the kmm_malloc() will return memory
    * aligned to 64-bit addresses.  The buffer length must be large enough to
    * hold the rested buflen in units a 32-bits.
+   * Ensure that the DMA buffers are word-aligned.
    */
 
-  return kmm_malloc(ALIGN_UP(buflen));
+  return kmm_malloc(ALIGN_UP(buflen, 4));
 }
 
 /****************************************************************************

--- a/arch/arm/src/sam34/sam_cmcc.c
+++ b/arch/arm/src/sam34/sam_cmcc.c
@@ -28,6 +28,8 @@
 #include <stdint.h>
 #include <assert.h>
 
+#include <nuttx/nuttx.h>
+
 #include "arm_internal.h"
 #include "hardware/sam_cmcc.h"
 #include "sam_cmcc.h"
@@ -51,9 +53,6 @@
 #else
 #  error Unknown cache line size
 #endif
-
-#define ALIGN_UP(a)   (((a)+CMCC_MASK) & ~CMCC_MASK)
-#define ALIGN_DOWN(a) ((a) & ~CMCC_MASK)
 
 /****************************************************************************
  * Private Data
@@ -138,8 +137,8 @@ void sam_cmcc_invalidate(uintptr_t start, uintptr_t end)
    * to be invalidated.
    */
 
-  start  = ALIGN_DOWN(start);
-  end    = ALIGN_UP(end);
+  start  = ALIGN_DOWN_MASK(start, CMCC_MASK);
+  end    = ALIGN_UP_MASK(end, CMCC_MASK);
   size   = end - start + 1;
 
   /* If this is a large region (as big as the cache), then just invalidate

--- a/arch/arm/src/sama5/sam_qspi.c
+++ b/arch/arm/src/sama5/sam_qspi.c
@@ -40,6 +40,7 @@
 #include <nuttx/clock.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/mutex.h>
+#include <nuttx/nuttx.h>
 #include <nuttx/semaphore.h>
 #include <nuttx/spi/qspi.h>
 
@@ -118,15 +119,6 @@
 /* QSPI memory synchronization */
 
 #define MEMORY_SYNC()     do { ARM_DSB(); ARM_ISB(); } while (0)
-
-/* The SAMA5x QSPI driver insists that transfers be performed in multiples
- * of 32-bits.  The alignment requirement only applies to RX DMA data.
- */
-
-#define ALIGN_SHIFT       2
-#define ALIGN_MASK        3
-#define ALIGN_UP(n)       (((n)+ALIGN_MASK) & ~ALIGN_MASK)
-#define IS_ALIGNED(n)     (((uint32_t)(n) & ALIGN_MASK) == 0)
 
 /* Debug ********************************************************************/
 
@@ -1613,8 +1605,8 @@ static int qspi_memory(struct qspi_dev_s *dev,
 
   if (priv->candma &&
       meminfo->buflen > CONFIG_SAMA5_QSPI_DMATHRESHOLD &&
-      IS_ALIGNED((uintptr_t)meminfo->buffer) &&
-      IS_ALIGNED(meminfo->buflen))
+      IS_ALIGNED((uintptr_t)meminfo->buffer, 4) &&
+      IS_ALIGNED(meminfo->buflen, 4))
     {
       return qspi_memory_dma(priv, meminfo);
     }
@@ -1648,7 +1640,11 @@ static void *qspi_alloc(struct qspi_dev_s *dev, size_t buflen)
    * enough to hold the rested buflen in units a 32-bits.
    */
 
-  return kmm_malloc(ALIGN_UP(buflen));
+  /* The SAMA5x QSPI driver insists that transfers be performed in multiples
+   * of 32-bits.  The alignment requirement only applies to RX DMA data.
+   */
+
+  return kmm_malloc(ALIGN_UP(buflen, 4));
 }
 
 /****************************************************************************

--- a/arch/arm/src/samd5e5/sam_cmcc.c
+++ b/arch/arm/src/samd5e5/sam_cmcc.c
@@ -28,6 +28,8 @@
 #include <stdint.h>
 #include <assert.h>
 
+#include <nuttx/nuttx.h>
+
 #include "arm_internal.h"
 #include "hardware/sam_cmcc.h"
 #include "sam_cmcc.h"
@@ -51,9 +53,6 @@
 #else
 #  error Unknown cache line size
 #endif
-
-#define ALIGN_UP(a)   (((a)+CMCC_MASK) & ~CMCC_MASK)
-#define ALIGN_DOWN(a) ((a) & ~CMCC_MASK)
 
 /****************************************************************************
  * Private Data
@@ -138,8 +137,8 @@ void sam_cmcc_invalidate(uintptr_t start, uintptr_t end)
    * to be invalidated.
    */
 
-  start  = ALIGN_DOWN(start);
-  end    = ALIGN_UP(end);
+  start  = ALIGN_DOWN_MASK(start, CMCC_MASK);
+  end    = ALIGN_UP_MASK(end, CMCC_MASK);
   size   = end - start + 1;
 
   /* If this is a large region (as big as the cache), then just invalidate

--- a/arch/arm/src/samv7/sam_qspi.c
+++ b/arch/arm/src/samv7/sam_qspi.c
@@ -119,15 +119,6 @@
 
 #define MEMORY_SYNC()     do { ARM_DSB(); ARM_ISB(); } while (0)
 
-/* The SAMV7x QSPI driver insists that transfers be performed in multiples
- * of 32-bits.  The alignment requirement only applies to RX DMA data.
- */
-
-#define ALIGN_SHIFT       2
-#define ALIGN_MASK        3
-#define ALIGN_UP(n)       (((n)+ALIGN_MASK) & ~ALIGN_MASK)
-#define IS_ALIGNED(n)     (((uint32_t)(n) & ALIGN_MASK) == 0)
-
 /* Debug ********************************************************************/
 
 /* Check if QSPI debug is enabled */
@@ -1558,8 +1549,8 @@ static int qspi_memory(struct qspi_dev_s *dev,
 
   if (priv->candma &&
       meminfo->buflen > CONFIG_SAMV7_QSPI_DMATHRESHOLD &&
-      IS_ALIGNED((uintptr_t)meminfo->buffer) &&
-      IS_ALIGNED(meminfo->buflen))
+      IS_ALIGNED((uintptr_t)meminfo->buffer, 4) &&
+      IS_ALIGNED(meminfo->buflen, 4))
     {
       return qspi_memory_dma(priv, meminfo);
     }
@@ -1593,7 +1584,11 @@ static void *qspi_alloc(struct qspi_dev_s *dev, size_t buflen)
    * enough to hold the rested buflen in units a 32-bits.
    */
 
-  return kmm_malloc(ALIGN_UP(buflen));
+  /* The SAMV7x QSPI driver insists that transfers be performed in multiples
+   * of 32-bits.  The alignment requirement only applies to RX DMA data.
+   */
+
+  return kmm_malloc(ALIGN_UP(buflen, 4));
 }
 
 /****************************************************************************

--- a/arch/arm/src/stm32f7/stm32_qspi.c
+++ b/arch/arm/src/stm32f7/stm32_qspi.c
@@ -43,6 +43,7 @@
 #include <nuttx/cache.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/mutex.h>
+#include <nuttx/nuttx.h>
 #include <nuttx/spi/qspi.h>
 
 #include "arm_internal.h"
@@ -62,13 +63,6 @@
 /* QSPI memory synchronization */
 
 #define MEMORY_SYNC()     do { ARM_DSB(); ARM_ISB(); } while (0)
-
-/* Ensure that the DMA buffers are word-aligned. */
-
-#define ALIGN_SHIFT       2
-#define ALIGN_MASK        3
-#define ALIGN_UP(n)       (((n)+ALIGN_MASK) & ~ALIGN_MASK)
-#define IS_ALIGNED(n)     (((uint32_t)(n) & ALIGN_MASK) == 0)
 
 /* Debug ********************************************************************/
 
@@ -2025,7 +2019,7 @@ static int qspi_command(struct qspi_dev_s *dev,
   if (QSPICMD_ISDATA(cmdinfo->flags))
     {
       DEBUGASSERT(cmdinfo->buffer != NULL && cmdinfo->buflen > 0);
-      DEBUGASSERT(IS_ALIGNED(cmdinfo->buffer));
+      DEBUGASSERT(IS_ALIGNED((uintptr_t)cmdinfo->buffer, 4));
 
       if (QSPICMD_ISWRITE(cmdinfo->flags))
         {
@@ -2117,7 +2111,7 @@ static int qspi_command(struct qspi_dev_s *dev,
   if (QSPICMD_ISDATA(cmdinfo->flags))
     {
       DEBUGASSERT(cmdinfo->buffer != NULL && cmdinfo->buflen > 0);
-      DEBUGASSERT(IS_ALIGNED(cmdinfo->buffer));
+      DEBUGASSERT(IS_ALIGNED((uintptr_t)cmdinfo->buffer, 4));
 
       if (QSPICMD_ISWRITE(cmdinfo->flags))
         {
@@ -2204,7 +2198,7 @@ static int qspi_memory(struct qspi_dev_s *dev,
   priv->xctn = &xctn;
 
   DEBUGASSERT(meminfo->buffer != NULL && meminfo->buflen > 0);
-  DEBUGASSERT(IS_ALIGNED(meminfo->buffer));
+  DEBUGASSERT(IS_ALIGNED((uintptr_t)meminfo->buffer, 4));
 
   if (QSPIMEM_ISWRITE(meminfo->flags))
     {
@@ -2264,8 +2258,8 @@ static int qspi_memory(struct qspi_dev_s *dev,
 
   if (priv->candma &&
       meminfo->buflen > CONFIG_STM32F7_QSPI_DMATHRESHOLD &&
-      IS_ALIGNED((uintptr_t)meminfo->buffer) &&
-      IS_ALIGNED(meminfo->buflen))
+      IS_ALIGNED((uintptr_t)meminfo->buffer, 4) &&
+      IS_ALIGNED(meminfo->buflen, 4))
     {
       ret = qspi_memory_dma(priv, meminfo, &xctn);
     }
@@ -2284,7 +2278,7 @@ static int qspi_memory(struct qspi_dev_s *dev,
       /* Transfer data */
 
       DEBUGASSERT(meminfo->buffer != NULL && meminfo->buflen > 0);
-      DEBUGASSERT(IS_ALIGNED(meminfo->buffer));
+      DEBUGASSERT(IS_ALIGNED((uintptr_t)meminfo->buffer, 4));
 
       if (QSPIMEM_ISWRITE(meminfo->flags))
         {
@@ -2315,7 +2309,7 @@ static int qspi_memory(struct qspi_dev_s *dev,
   /* Transfer data */
 
   DEBUGASSERT(meminfo->buffer != NULL && meminfo->buflen > 0);
-  DEBUGASSERT(IS_ALIGNED(meminfo->buffer));
+  DEBUGASSERT(IS_ALIGNED((uintptr_t)meminfo->buffer, 4));
 
   if (QSPIMEM_ISWRITE(meminfo->flags))
     {
@@ -2361,7 +2355,9 @@ static void *qspi_alloc(struct qspi_dev_s *dev, size_t buflen)
    * hold the rested buflen in units a 32-bits.
    */
 
-  return kmm_malloc(ALIGN_UP(buflen));
+  /* Ensure that the DMA buffers are word-aligned. */
+
+  return kmm_malloc(ALIGN_UP(buflen, 4));
 }
 
 /****************************************************************************

--- a/arch/arm/src/stm32h7/stm32_qspi.c
+++ b/arch/arm/src/stm32h7/stm32_qspi.c
@@ -43,6 +43,7 @@
 #include <nuttx/cache.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/mutex.h>
+#include <nuttx/nuttx.h>
 #include <nuttx/semaphore.h>
 #include <nuttx/spi/qspi.h>
 
@@ -63,13 +64,6 @@
 /* QSPI memory synchronization */
 
 #define MEMORY_SYNC()     do { ARM_DSB(); ARM_ISB(); } while (0)
-
-/* Ensure that the DMA buffers are word-aligned. */
-
-#define ALIGN_SHIFT       2
-#define ALIGN_MASK        3
-#define ALIGN_UP(n)       (((n)+ALIGN_MASK) & ~ALIGN_MASK)
-#define IS_ALIGNED(n)     (((uint32_t)(n) & ALIGN_MASK) == 0)
 
 /* Debug ********************************************************************/
 
@@ -2079,7 +2073,7 @@ static int qspi_command(struct qspi_dev_s *dev,
   if (QSPICMD_ISDATA(cmdinfo->flags))
     {
       DEBUGASSERT(cmdinfo->buffer != NULL && cmdinfo->buflen > 0);
-      DEBUGASSERT(IS_ALIGNED(cmdinfo->buffer));
+      DEBUGASSERT(IS_ALIGNED((uintptr_t)cmdinfo->buffer, 4));
 
       if (QSPICMD_ISWRITE(cmdinfo->flags))
         {
@@ -2171,7 +2165,7 @@ static int qspi_command(struct qspi_dev_s *dev,
   if (QSPICMD_ISDATA(cmdinfo->flags))
     {
       DEBUGASSERT(cmdinfo->buffer != NULL && cmdinfo->buflen > 0);
-      DEBUGASSERT(IS_ALIGNED(cmdinfo->buffer));
+      DEBUGASSERT(IS_ALIGNED((uintptr_t)cmdinfo->buffer, 4));
 
       if (QSPICMD_ISWRITE(cmdinfo->flags))
         {
@@ -2258,7 +2252,7 @@ static int qspi_memory(struct qspi_dev_s *dev,
   priv->xctn = &xctn;
 
   DEBUGASSERT(meminfo->buffer != NULL && meminfo->buflen > 0);
-  DEBUGASSERT(IS_ALIGNED(meminfo->buffer));
+  DEBUGASSERT(IS_ALIGNED((uintptr_t)meminfo->buffer, 4));
 
   if (QSPIMEM_ISWRITE(meminfo->flags))
     {
@@ -2318,8 +2312,8 @@ static int qspi_memory(struct qspi_dev_s *dev,
 
   if (priv->candma &&
       meminfo->buflen > CONFIG_STM32H7_QSPI_DMATHRESHOLD &&
-      IS_ALIGNED((uintptr_t)meminfo->buffer) &&
-      IS_ALIGNED(meminfo->buflen))
+      IS_ALIGNED((uintptr_t)meminfo->buffer, 4) &&
+      IS_ALIGNED(meminfo->buflen, 4))
     {
       ret = qspi_memory_dma(priv, meminfo, &xctn);
     }
@@ -2338,7 +2332,7 @@ static int qspi_memory(struct qspi_dev_s *dev,
       /* Transfer data */
 
       DEBUGASSERT(meminfo->buffer != NULL && meminfo->buflen > 0);
-      DEBUGASSERT(IS_ALIGNED(meminfo->buffer));
+      DEBUGASSERT(IS_ALIGNED((uintptr_t)meminfo->buffer, 4));
 
       if (QSPIMEM_ISWRITE(meminfo->flags))
         {
@@ -2369,7 +2363,7 @@ static int qspi_memory(struct qspi_dev_s *dev,
   /* Transfer data */
 
   DEBUGASSERT(meminfo->buffer != NULL && meminfo->buflen > 0);
-  DEBUGASSERT(IS_ALIGNED(meminfo->buffer));
+  DEBUGASSERT(IS_ALIGNED((uintptr_t)meminfo->buffer, 4));
 
   if (QSPIMEM_ISWRITE(meminfo->flags))
     {
@@ -2415,7 +2409,9 @@ static void *qspi_alloc(struct qspi_dev_s *dev, size_t buflen)
    * hold the rested buflen in units a 32-bits.
    */
 
-  return kmm_malloc(ALIGN_UP(buflen));
+  /* Ensure that the DMA buffers are word-aligned. */
+
+  return kmm_malloc(ALIGN_UP(buflen, 4));
 }
 
 /****************************************************************************

--- a/arch/arm/src/stm32l4/stm32l4_qspi.c
+++ b/arch/arm/src/stm32l4/stm32l4_qspi.c
@@ -41,6 +41,7 @@
 #include <nuttx/clock.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/mutex.h>
+#include <nuttx/nuttx.h>
 #include <nuttx/spi/qspi.h>
 
 #include "arm_internal.h"
@@ -62,13 +63,6 @@
 /* QSPI memory synchronization */
 
 #define MEMORY_SYNC()     do { ARM_DSB(); ARM_ISB(); } while (0)
-
-/* Ensure that the DMA buffers are word-aligned. */
-
-#define ALIGN_SHIFT       2
-#define ALIGN_MASK        3
-#define ALIGN_UP(n)       (((n)+ALIGN_MASK) & ~ALIGN_MASK)
-#define IS_ALIGNED(n)     (((uint32_t)(n) & ALIGN_MASK) == 0)
 
 /* Debug ********************************************************************/
 
@@ -1973,7 +1967,7 @@ static int qspi_command(struct qspi_dev_s *dev,
   if (QSPICMD_ISDATA(cmdinfo->flags))
     {
       DEBUGASSERT(cmdinfo->buffer != NULL && cmdinfo->buflen > 0);
-      DEBUGASSERT(IS_ALIGNED(cmdinfo->buffer));
+      DEBUGASSERT(IS_ALIGNED((uintptr_t)cmdinfo->buffer, 4));
 
       if (QSPICMD_ISWRITE(cmdinfo->flags))
         {
@@ -2066,7 +2060,7 @@ static int qspi_command(struct qspi_dev_s *dev,
   if (QSPICMD_ISDATA(cmdinfo->flags))
     {
       DEBUGASSERT(cmdinfo->buffer != NULL && cmdinfo->buflen > 0);
-      DEBUGASSERT(IS_ALIGNED(cmdinfo->buffer));
+      DEBUGASSERT(IS_ALIGNED((uintptr_t)cmdinfo->buffer, 4));
 
       if (QSPICMD_ISWRITE(cmdinfo->flags))
         {
@@ -2153,7 +2147,7 @@ static int qspi_memory(struct qspi_dev_s *dev,
   priv->xctn = &xctn;
 
   DEBUGASSERT(meminfo->buffer != NULL && meminfo->buflen > 0);
-  DEBUGASSERT(IS_ALIGNED(meminfo->buffer));
+  DEBUGASSERT(IS_ALIGNED((uintptr_t)meminfo->buffer, 4));
 
   if (QSPIMEM_ISWRITE(meminfo->flags))
     {
@@ -2213,8 +2207,8 @@ static int qspi_memory(struct qspi_dev_s *dev,
 
   if (priv->candma &&
       meminfo->buflen > CONFIG_STM32L4_QSPI_DMATHRESHOLD &&
-      IS_ALIGNED((uintptr_t)meminfo->buffer) &&
-      IS_ALIGNED(meminfo->buflen))
+      IS_ALIGNED((uintptr_t)meminfo->buffer, 4) &&
+      IS_ALIGNED(meminfo->buflen, 4))
     {
       ret = qspi_memory_dma(priv, meminfo, &xctn);
     }
@@ -2233,7 +2227,7 @@ static int qspi_memory(struct qspi_dev_s *dev,
       /* Transfer data */
 
       DEBUGASSERT(meminfo->buffer != NULL && meminfo->buflen > 0);
-      DEBUGASSERT(IS_ALIGNED(meminfo->buffer));
+      DEBUGASSERT(IS_ALIGNED((uintptr_t)meminfo->buffer, 4));
 
       if (QSPIMEM_ISWRITE(meminfo->flags))
         {
@@ -2264,7 +2258,7 @@ static int qspi_memory(struct qspi_dev_s *dev,
   /* Transfer data */
 
   DEBUGASSERT(meminfo->buffer != NULL && meminfo->buflen > 0);
-  DEBUGASSERT(IS_ALIGNED(meminfo->buffer));
+  DEBUGASSERT(IS_ALIGNED((uintptr_t)meminfo->buffer, 4));
 
   if (QSPIMEM_ISWRITE(meminfo->flags))
     {
@@ -2310,7 +2304,9 @@ static void *qspi_alloc(struct qspi_dev_s *dev, size_t buflen)
    * hold the rested buflen in units a 32-bits.
    */
 
-  return kmm_malloc(ALIGN_UP(buflen));
+  /* Ensure that the DMA buffers are word-aligned. */
+
+  return kmm_malloc(ALIGN_UP(buflen, 4));
 }
 
 /****************************************************************************

--- a/arch/arm64/src/imx9/imx9_flexspi_nor.c
+++ b/arch/arm64/src/imx9/imx9_flexspi_nor.c
@@ -37,6 +37,7 @@
 #include <nuttx/signal.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/mtd/mtd.h>
+#include <nuttx/nuttx.h>
 #include <nuttx/fs/ioctl.h>
 #include <nuttx/drivers/drivers.h>
 #include <arch/board/board.h>
@@ -61,9 +62,6 @@
 #    undef ARMV8A_DCACHE_LINESIZE
 #    define ARMV8A_DCACHE_LINESIZE 64
 #  endif
-
-#define ALIGN_MASK        (ARMV8A_DCACHE_LINESIZE - 1)
-#define ALIGN_UP(n)       (((n)+ALIGN_MASK) & ~ALIGN_MASK)
 
 /* Configuration ************************************************************/
 
@@ -835,10 +833,11 @@ static ssize_t imx9_flexspi_nor_read(struct mtd_dev_s *dev,
     }
 
   src = priv->ahb_base + offset;
-  DEBUGASSERT(((uintptr_t)src & ALIGN_MASK) == 0);
+  DEBUGASSERT(((uintptr_t)src & (ARMV8A_DCACHE_LINESIZE - 1)) == 0);
 
   up_invalidate_dcache((uintptr_t)src,
-                       (uintptr_t)src + ALIGN_UP(nbytes));
+                       (uintptr_t)src +
+                       ALIGN_UP(nbytes, ARMV8A_DCACHE_LINESIZE));
 
   memcpy(buffer, src, nbytes);
 

--- a/arch/risc-v/src/common/espressif/esp_dma.c
+++ b/arch/risc-v/src/common/espressif/esp_dma.c
@@ -34,6 +34,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
 #include <nuttx/mutex.h>
+#include <nuttx/nuttx.h>
 #include <nuttx/kmalloc.h>
 #include <arch/irq.h>
 
@@ -50,10 +51,6 @@
 /****************************************************************************
  * Pre-processor Macros
  ****************************************************************************/
-
-#ifndef ALIGN_UP
-#  define ALIGN_UP(num, align) (((num) + ((align) - 1)) & ~((align) - 1))
-#endif
 
 /* DMA channel number */
 

--- a/arch/risc-v/src/esp32c3-legacy/esp32c3_dma.c
+++ b/arch/risc-v/src/esp32c3-legacy/esp32c3_dma.c
@@ -34,6 +34,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
 #include <nuttx/mutex.h>
+#include <nuttx/nuttx.h>
 #include <nuttx/kmalloc.h>
 #include <arch/irq.h>
 
@@ -55,10 +56,6 @@
 
 #define SET_BITS(_r, _ch, _b)   modifyreg32((_r) + (_ch) * REG_OFF, 0, (_b))
 #define CLR_BITS(_r, _ch, _b)   modifyreg32((_r) + (_ch) * REG_OFF, (_b), 0)
-
-#ifndef ALIGN_UP
-#  define ALIGN_UP(num, align) (((num) + ((align) - 1)) & ~((align) - 1))
-#endif
 
 /****************************************************************************
  * Private Data

--- a/arch/xtensa/include/irq.h
+++ b/arch/xtensa/include/irq.h
@@ -68,10 +68,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#ifndef ALIGN_UP
-#  define ALIGN_UP(num, align) (((num) + ((align) - 1)) & ~((align) - 1))
-#endif
-
 /* IRQ Stack Frame Format.  Each value is a uint32_t register index */
 
 #define REG_PC              (0)  /* Return PC */
@@ -142,9 +138,13 @@
 #endif
 
 #if XCHAL_CP_NUM > 0
-  /* FPU first address must align to CP align size. */
+  /* FPU first address must align to CP align size.
+   * ESP32 3rd party redefine the ALIGN_UP, so define a new macro XALIGN_UP()
+   * instead use ALGIN_UP() in nuttx/nuttx.h
+   */
 
-#  define COMMON_CTX_REGS   ALIGN_UP(_REG_CP_START, XCHAL_TOTAL_SA_ALIGN / 4)
+#  define XALIGN_UP(x,a)    (((x) + ((a) - 1)) & ~((a) - 1))
+#  define COMMON_CTX_REGS   XALIGN_UP(_REG_CP_START, XCHAL_TOTAL_SA_ALIGN / 4)
 #  define COPROC_CTX_REGS   (XTENSA_CP_SA_SIZE / 4)
 #  define RESERVE_REGS      8
 #  define XCPTCONTEXT_REGS  (COMMON_CTX_REGS + COPROC_CTX_REGS + RESERVE_REGS)

--- a/arch/xtensa/src/esp32/esp32_dma.c
+++ b/arch/xtensa/src/esp32/esp32_dma.c
@@ -28,16 +28,10 @@
 #include <sys/param.h>
 #include <sys/types.h>
 
+#include <nuttx/nuttx.h>
+
 #include "hardware/esp32_dma.h"
 #include "esp32_dma.h"
-
-/****************************************************************************
- * Preprocessor Definitions
- ****************************************************************************/
-
-#ifndef ALIGN_UP
-#  define ALIGN_UP(num, align) (((num) + ((align) - 1)) & ~((align) - 1))
-#endif
 
 /****************************************************************************
  * Public Functions

--- a/arch/xtensa/src/esp32/esp32_i2s.c
+++ b/arch/xtensa/src/esp32/esp32_i2s.c
@@ -45,6 +45,7 @@
 #include <nuttx/spinlock.h>
 #include <nuttx/mqueue.h>
 #include <nuttx/circbuf.h>
+#include <nuttx/nuttx.h>
 #include <nuttx/audio/audio.h>
 #include <nuttx/audio/i2s.h>
 
@@ -108,10 +109,6 @@
 #  define I2S_HAVE_RX 1
 #else
 #  define I2S1_RX_ENABLED 0
-#endif
-
-#ifndef ALIGN_UP
-#  define ALIGN_UP(num, align) (((num) + ((align) - 1)) & ~((align) - 1))
 #endif
 
 /* Debug ********************************************************************/

--- a/arch/xtensa/src/esp32s2/esp32s2_dma.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_dma.c
@@ -28,16 +28,10 @@
 #include <sys/param.h>
 #include <sys/types.h>
 
+#include <nuttx/nuttx.h>
+
 #include "hardware/esp32s2_dma.h"
 #include "esp32s2_dma.h"
-
-/****************************************************************************
- * Preprocessor Definitions
- ****************************************************************************/
-
-#ifndef ALIGN_UP
-#  define ALIGN_UP(num, align) (((num) + ((align) - 1)) & ~((align) - 1))
-#endif
 
 /****************************************************************************
  * Public Functions

--- a/arch/xtensa/src/esp32s2/esp32s2_i2s.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_i2s.c
@@ -43,6 +43,7 @@
 #include <nuttx/semaphore.h>
 #include <nuttx/mqueue.h>
 #include <nuttx/circbuf.h>
+#include <nuttx/nuttx.h>
 #include <nuttx/audio/audio.h>
 #include <nuttx/audio/i2s.h>
 
@@ -92,10 +93,6 @@
 #  define I2S_HAVE_RX 1
 #else
 #  define I2S_RX_ENABLED 0
-#endif
-
-#ifndef ALIGN_UP
-#  define ALIGN_UP(num, align) (((num) + ((align) - 1)) & ~((align) - 1))
 #endif
 
 /* Debug ********************************************************************/

--- a/arch/xtensa/src/esp32s3/esp32s3_allocateheap.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_allocateheap.c
@@ -30,6 +30,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
 #include <nuttx/mm/mm.h>
+#include <nuttx/nuttx.h>
 #include <nuttx/userspace.h>
 #include <arch/board/board.h>
 #ifdef CONFIG_MM_KERNEL_HEAP
@@ -58,10 +59,6 @@
 #  define MM_ADDREGION kmm_addregion
 #else
 #  define MM_ADDREGION umm_addregion
-#endif
-
-#ifndef ALIGN_DOWN
-#  define ALIGN_DOWN(num, align)  ((num) & ~((align) - 1))
 #endif
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32s3/esp32s3_dma.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_dma.c
@@ -35,6 +35,7 @@
 #include <nuttx/irq.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/mutex.h>
+#include <nuttx/nuttx.h>
 #include <arch/irq.h>
 
 #include "xtensa.h"
@@ -47,10 +48,6 @@
 /****************************************************************************
  * Pre-processor Macros
  ****************************************************************************/
-
-#ifndef ALIGN_UP
-#  define ALIGN_UP(num, align) (((num) + ((align) - 1)) & ~((align) - 1))
-#endif
 
 #define DMA_INVALID_PERIPH_ID        (0x3F)
 #define GDMA_CH_REG_ADDR(_r, _ch)    ((_r) + (_ch) * GDMA_REG_OFFSET)

--- a/arch/xtensa/src/esp32s3/esp32s3_i2s.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_i2s.c
@@ -46,6 +46,7 @@
 #include <nuttx/spinlock.h>
 #include <nuttx/mqueue.h>
 #include <nuttx/circbuf.h>
+#include <nuttx/nuttx.h>
 #include <nuttx/audio/audio.h>
 #include <nuttx/audio/i2s.h>
 
@@ -109,10 +110,6 @@
 #  define I2S_HAVE_RX 1
 #else
 #  define I2S1_RX_ENABLED 0
-#endif
-
-#ifndef ALIGN_UP
-#  define ALIGN_UP(num, align) (((num) + ((align) - 1)) & ~((align) - 1))
 #endif
 
 /* Debug ********************************************************************/

--- a/arch/xtensa/src/esp32s3/esp32s3_userspace.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_userspace.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include <nuttx/nuttx.h>
 #include <nuttx/userspace.h>
 
 #include <arch/board/board_memorymap.h>
@@ -109,14 +110,6 @@
 
 #define PIF_PMS_MAX_REG_ENTRY     16
 #define PIF_PMS_V                 3
-
-#ifndef ALIGN_UP
-#  define ALIGN_UP(num, align) (((num) + ((align) - 1)) & ~((align) - 1))
-#endif
-
-#ifndef ALIGN_DOWN
-#  define ALIGN_DOWN(num, align)  ((num) & ~((align) - 1))
-#endif
 
 /****************************************************************************
  * Private Types

--- a/drivers/pci/pci_ecam.c
+++ b/drivers/pci/pci_ecam.c
@@ -42,8 +42,6 @@
 #define readl(a)     (*(FAR volatile uint32_t *)(a))
 #define writel(v,a)  (*(FAR volatile uint32_t *)(a) = (v))
 
-#define IS_ALIGNED(x, a) (((x) & ((a) - 1)) == 0)
-
 /****************************************************************************
  * Private Function Prototypes
  ****************************************************************************/

--- a/drivers/rpmsg/rpmsg_virtio.c
+++ b/drivers/rpmsg/rpmsg_virtio.c
@@ -30,6 +30,7 @@
 
 #include <nuttx/kmalloc.h>
 #include <nuttx/kthread.h>
+#include <nuttx/nuttx.h>
 #include <nuttx/semaphore.h>
 #include <nuttx/rpmsg/rpmsg_virtio.h>
 #include <rpmsg/rpmsg_internal.h>
@@ -37,10 +38,6 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
-
-#ifndef ALIGN_UP
-#  define ALIGN_UP(s, a)        (((s) + (a) - 1) & ~((a) - 1))
-#endif
 
 #define RPMSG_VIRTIO_TIMEOUT_MS 20
 #define RPMSG_VIRTIO_NOTIFYID   0

--- a/drivers/rptun/rptun.c
+++ b/drivers/rptun/rptun.c
@@ -35,6 +35,7 @@
 #include <nuttx/kmalloc.h>
 #include <nuttx/kthread.h>
 #include <nuttx/mutex.h>
+#include <nuttx/nuttx.h>
 #include <nuttx/power/pm.h>
 #include <nuttx/rptun/rptun.h>
 #include <nuttx/semaphore.h>
@@ -47,10 +48,6 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
-
-#ifndef ALIGN_UP
-#  define ALIGN_UP(s, a)            (((s) + (a) - 1) & ~((a) - 1))
-#endif
 
 #define RPTUN_TIMEOUT_MS            20
 

--- a/include/nuttx/mm/mempool.h
+++ b/include/nuttx/mm/mempool.h
@@ -32,6 +32,7 @@
 #include <nuttx/list.h>
 #include <nuttx/queue.h>
 #include <nuttx/mm/mm.h>
+#include <nuttx/nuttx.h>
 #include <nuttx/fs/procfs.h>
 #include <nuttx/spinlock.h>
 #include <nuttx/semaphore.h>

--- a/include/nuttx/nuttx.h
+++ b/include/nuttx/nuttx.h
@@ -29,13 +29,19 @@
 
 #include <nuttx/config.h>
 
-#include <stddef.h>
+#ifndef __ASSEMBLY__
+#  include <stddef.h>
+#endif
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
 
 /* Align definitions */
+
+#ifndef IS_ALIGNED
+#  define IS_ALIGNED(x,a)      (((x) & ((a) - 1)) == 0)
+#endif
 
 #ifndef ALIGN_MASK
 #  define ALIGN_MASK(s)        ((1 << (s)) - 1)

--- a/mm/mempool/mempool.c
+++ b/mm/mempool/mempool.c
@@ -33,14 +33,12 @@
 #include <nuttx/kmalloc.h>
 #include <nuttx/mm/kasan.h>
 #include <nuttx/mm/mempool.h>
+#include <nuttx/nuttx.h>
 #include <nuttx/sched.h>
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
-
-#undef  ALIGN_UP
-#define ALIGN_UP(x, a) (((x) + ((a) - 1)) & (~((a) - 1)))
 
 #if CONFIG_MM_BACKTRACE >= 0
 #define MEMPOOL_MAGIC_FREE  0xAAAAAAAA

--- a/mm/mempool/mempool_multiple.c
+++ b/mm/mempool/mempool_multiple.c
@@ -24,25 +24,16 @@
  * Included Files
  ****************************************************************************/
 
+#include <assert.h>
 #include <strings.h>
 #include <syslog.h>
 #include <sys/param.h>
 
 #include <nuttx/mutex.h>
+#include <nuttx/nuttx.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/mm/mempool.h>
 #include <nuttx/mm/kasan.h>
-
-#include <assert.h>
-
-/****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-#undef  ALIGN_UP
-#define ALIGN_UP(x, a)        ((((size_t)x) + ((a) - 1)) & (~((a) - 1)))
-#undef  ALIGN_DOWN
-#define ALIGN_DOWN(x, a)      ((size_t)(x) & (~((a) - 1)))
 
 /****************************************************************************
  * Private Types
@@ -195,7 +186,7 @@ retry:
       sq_addfirst(&chunk->entry, &mpool->chunk_queue);
     }
 
-  ret = (FAR void *)ALIGN_UP(chunk->next, align);
+  ret = (FAR void *)ALIGN_UP((uintptr_t)chunk->next, align);
   if ((uintptr_t)chunk->end - (uintptr_t)ret < size)
     {
       goto retry;
@@ -725,7 +716,7 @@ FAR void *mempool_multiple_memalign(FAR struct mempool_multiple_s *mpool,
       FAR char *blk = mempool_allocate(pool);
       if (blk != NULL)
         {
-          return (FAR void *)ALIGN_UP(blk, alignment);
+          return (FAR void *)ALIGN_UP((uintptr_t)blk, alignment);
         }
     }
   while (++pool < end);

--- a/mm/ubsan/ubsan.c
+++ b/mm/ubsan/ubsan.c
@@ -29,15 +29,11 @@
 #include <debug.h>
 #include <stdio.h>
 
+#include <nuttx/nuttx.h>
+
 #include "ubsan.h"
 
 #ifndef CONFIG_MM_UBSAN_DUMMY
-
-/****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-#define IS_ALIGNED(x, a) (((x) & ((a) - 1)) == 0)
 
 /****************************************************************************
  * Private Data


### PR DESCRIPTION
## Summary
1. add IS_ALIGNED()  definitions for NuttX;
2. replace all the ALIGN_UP() and ALIGN_DOWN() to use common align implementation;

## Impact
Only code refactore

## Testing
CI
