### PR TITLE
mksymtab.c support for structure

### DIFF
--- a/tools/mksymtab.c
+++ b/tools/mksymtab.c
@@ -130,6 +130,7 @@ int main(int argc, char **argv, char **envp)
   char *finalterm;
   char *ptr;
   bool cond;
+  bool parm1;
   FILE *instream;
   FILE *outstream;
   int ch;
@@ -268,6 +269,12 @@ int main(int argc, char **argv, char **envp)
     {
       /* Parse the line from the CVS file */
 
+      g_parm[NAME_INDEX][0] = 0;
+      g_parm[HEADER_INDEX][0] = 0;
+      g_parm[COND_INDEX][0] = 0;
+      g_parm[RETTYPE_INDEX][0] = 0;
+      g_parm[PARM1_INDEX][0] = 0;
+
       int nargs = parse_csvline(ptr);
       if (nargs < PARM1_INDEX)
         {
@@ -286,8 +293,17 @@ int main(int argc, char **argv, char **envp)
 
       /* Output the symbol table entry */
 
-      fprintf(outstream, "%s  { \"%s\", (FAR const void *)%s }",
-              nextterm, g_parm[NAME_INDEX], g_parm[NAME_INDEX]);
+      parm1 = strlen(g_parm[PARM1_INDEX]) > 0;
+      if (parm1)
+        {
+          fprintf(outstream, "%s  { \"%s\", (FAR const void *)%s }",
+                  nextterm, g_parm[NAME_INDEX], g_parm[NAME_INDEX]);
+        }
+      else
+        {
+          fprintf(outstream, "%s  { \"%s\", (FAR const void *)&%s }",
+                  nextterm, g_parm[NAME_INDEX], g_parm[NAME_INDEX]);
+        }
 
       if (cond)
         {


### PR DESCRIPTION
## Summary
Make mksymtab.c to support C structure.

when I import a structure not a function, it can't be used.

## Impact

[NAME],[HEADER],[COND],[RETTYPE],[PARM1]
if PARM1 is available, it is a function,
if not, it is a structure.

## Testing

```
"kHAPAccessoryServerTransport_IP","../../apps/netutils/homekit/HomeKitADK/HAP/HAP.h","defined(CONFIG_NETUTILS_HOMEKIT)","const HAPIPAccessoryServerTransport"
```
