### PR TITLE
tools/ci/docker/linux/Dockerfile: fix cmake download

### DIFF
--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -309,7 +309,7 @@ RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" apt-get install -y -q
   libssl-dev
 
 RUN mkdir -p cmake && \
-  curl -s -L wget https://cmake.org/files/v3.26/cmake-3.26.0.tar.gz \
+  curl -s -L https://cmake.org/files/v3.26/cmake-3.26.0.tar.gz \
   | tar -C cmake --strip-components=1 -xz \
   && cd cmake && ./bootstrap && make && make install && rm -rf cmake
 


### PR DESCRIPTION
remove the leftover `wget` as curl is used
triggers a host not found on my machine

## Summary

## Impact

## Testing

