### PR TITLE
tools/ci/docker/linux/Dockerfile: fix ccache when running container as user

### DIFF
--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -498,7 +498,10 @@ ENV ZAP_INSTALL_PATH=/tools/zap_release
 ENV ZAP_DEVELOPMENT_PATH=/tools/zap
 
 # Configure ccache
-RUN mkdir -p /tools/ccache/bin && \
+# use `/ccache` as cachedir for all users
+RUN mkdir -p /ccache && \
+  chmod 666 /ccache && \
+  mkdir -p /tools/ccache/bin && \
   ln -sf `which ccache` /tools/ccache/bin/aarch64-none-elf-gcc && \
   ln -sf `which ccache` /tools/ccache/bin/aarch64-none-elf-g++ && \
   ln -sf `which ccache` /tools/ccache/bin/arm-none-eabi-gcc && \
@@ -527,5 +530,6 @@ RUN mkdir -p /tools/ccache/bin && \
   ln -sf `which ccache` /tools/ccache/bin/xtensa-esp32s3-elf-g++
 
 ENV PATH="/tools/ccache/bin:$PATH"
+ENV CCACHE_DIR="/ccache"
 
 CMD [ "/bin/bash" ]


### PR DESCRIPTION
Normally ccache places the temporary files in `~/.ccache`, when invoking the container with
  `-u <uid>:<gid>`
as e.g. Jenkins does, this might result in a invalid/unknown home folder. Thus ccache tries to write to `/.ccache` which doesn't exist and the user doesn't have any permissions.

Explicitly set `CCACHE_DIR` to a folder with appropriate permissions.

## Summary

## Impact

## Testing
Before:
```bash
# docker run --rm --tty --interactive -u 1000:1000 ghcr.io/apache/nuttx/apache-nuttx-ci-linux:latest
cd /tmp
touch test.c
arm-none-eabi-gcc -c test.c
# ccache: error: Failed to create directory //.cache/ccache/tmp: Permission denied
```

