### PR TITLE
arch/xmc4 : Add input pin DX0 selection for multiple SPI channel

### DIFF
--- a/arch/arm/src/xmc4/xmc4_spi.c
+++ b/arch/arm/src/xmc4/xmc4_spi.c
@@ -200,6 +200,8 @@ struct xmc4_spidev_s
   uint8_t txintf;               /* TX hardware interface number */
 #endif
 
+  uint8_t dx0;                /* Input signal selection for MISO */
+
   /* Debug stuff */
 
 #ifdef CONFIG_XMC4_SPI_REGDEBUG
@@ -326,6 +328,11 @@ static struct xmc4_spidev_s g_spi0dev =
   .base         = XMC4_USIC0_CH0_BASE,
   .spilock      = NXMUTEX_INITIALIZER,
   .select       = xmc4_spi0select,
+#ifdef BOARD_SPI0_DX
+  .dx0          = BOARD_SPI0_DX,
+#else
+  .dx0          = BOARD_SPI_DX,
+#endif
 #ifdef CONFIG_XMC4_SPI_DMA
   .rxintf       = DMACHAN_INTF_SPI0RX,
   .txintf       = DMACHAN_INTF_SPI0TX,
@@ -364,6 +371,11 @@ static struct xmc4_spidev_s g_spi1dev =
   .base         = XMC4_USIC0_CH1_BASE,
   .spilock      = NXMUTEX_INITIALIZER,
   .select       = xmc4_spi1select,
+#ifdef BOARD_SPI1_DX
+  .dx0          = BOARD_SPI1_DX,
+#else
+  .dx0          = BOARD_SPI_DX,
+#endif
 #ifdef CONFIG_XMC4_SPI_DMA
   .rxintf       = DMACHAN_INTF_SPI1RX,
   .txintf       = DMACHAN_INTF_SPI1TX,
@@ -402,6 +414,11 @@ static struct xmc4_spidev_s g_spi2dev =
   .base         = XMC4_USIC1_CH0_BASE,
   .spilock      = NXMUTEX_INITIALIZER,
   .select       = xmc4_spi2select,
+#ifdef BOARD_SPI2_DX
+  .dx0          = BOARD_SPI2_DX,
+#else
+  .dx0          = BOARD_SPI_DX,
+#endif
 #ifdef CONFIG_XMC4_SPI_DMA
   .rxintf       = DMACHAN_INTF_SPI2RX,
   .txintf       = DMACHAN_INTF_SPI2TX,
@@ -440,6 +457,11 @@ static struct xmc4_spidev_s g_spi3dev =
   .base         = XMC4_USIC1_CH1_BASE,
   .spilock      = NXMUTEX_INITIALIZER,
   .select       = xmc4_spi3select,
+#ifdef BOARD_SPI3_DX
+  .dx0          = BOARD_SPI3_DX,
+#else
+  .dx0          = BOARD_SPI_DX,
+#endif
 #ifdef CONFIG_XMC4_SPI_DMA
   .rxintf       = DMACHAN_INTF_SPI3RX,
   .txintf       = DMACHAN_INTF_SPI3TX,
@@ -478,6 +500,11 @@ static struct xmc4_spidev_s g_spi4dev =
   .base          = XMC4_USIC2_CH0_BASE,
   .spilock      = NXMUTEX_INITIALIZER,
   .select        = xmc4_spi4select,
+#ifdef BOARD_SPI4_DX
+  .dx0          = BOARD_SPI4_DX,
+#else
+  .dx0          = BOARD_SPI_DX,
+#endif
 #ifdef CONFIG_XMC4_SPI_DMA
   .rxintf        = DMACHAN_INTF_SPI4RX,
   .txintf        = DMACHAN_INTF_SPI4TX,
@@ -517,6 +544,11 @@ static struct xmc4_spidev_s g_spi5dev =
   .base         = XMC4_USIC2_CH1_BASE,
   .spilock      = NXMUTEX_INITIALIZER,
   .select       = xmc4_spi5select,
+#ifdef BOARD_SPI5_DX
+  .dx0          = BOARD_SPI5_DX,
+#else
+  .dx0          = BOARD_SPI_DX,
+#endif
 #ifdef CONFIG_XMC4_SPI_DMA
   .rxintf       = DMACHAN_INTF_SPI5RX,
   .txintf       = DMACHAN_INTF_SPI5TX,
@@ -2017,9 +2049,15 @@ struct spi_dev_s *xmc4_spibus_initialize(int channel)
 
       /* Set DX0CR input source path and input switch */
 
+      if (spi->dx0 > 7)
+        {
+          spierr("ERROR:  DX invalid: %d\n", spi->dx0);
+          goto errchannel;
+        }
+
       regval  = getreg32(spi->base + XMC4_USIC_DX0CR_OFFSET);
       regval &= ~USIC_DXCR_DSEL_MASK;
-      regval |= USIC_DXCR_DSEL_DX(BOARD_SPI_DX);
+      regval |= USIC_DXCR_DSEL_DX(spi->dx0);
       regval |= USIC_DXCR_INSW;
       putreg32(regval, spi->base + XMC4_USIC_DX0CR_OFFSET);
 


### PR DESCRIPTION
## Summary
The input stage DX0 is used for MISO signal. The register DX0CR select the pinmux input signal (DX0A, DX0B, ..., DX0G).
Currently only one input signal was possible for all active SPI channel due to global BOARD_SPI_DX define. 
I added the suport for individual BOARD_SPIx_DX for each SPI channel. 

```
/* USIC1 CH0 is used as SPI2
 *
 *  MOSI - P0.5
 *  MISO - P0.4
 *  SCLK - P0.11
 */

#define BOARD_SPI2_DX USIC_DXA
#define GPIO_SPI2_MOSI (GPIO_U1C0_DOUT0_2 | GPIO_PADA2_STRONGMEDIUM | GPIO_OUTPUT_CLEAR)
#define GPIO_SPI2_MISO (GPIO_U1C0_DX0A)
#define GPIO_SPI2_SCLK (GPIO_U1C0_SCLKOUT_1 | GPIO_PADA2_STRONGMEDIUM)
```

## Impact
It is retro-compatible with previous BOARD_SPI_DX define, so old code won't break. 

## Testing
Tested on custom XMC4800 board. 
