### PR TITLE
libs/libm: fix epsilon relaxation in log and logf

### DIFF
--- a/libs/libm/libm/lib_log.c
+++ b/libs/libm/libm/lib_log.c
@@ -98,7 +98,7 @@ double log(double x)
           iter = 0;
         }
 
-      if (relax_factor > 1.0)
+      if (iter == 0)
         {
           epsilon *= relax_factor;
         }

--- a/libs/libm/libm/lib_logf.c
+++ b/libs/libm/libm/lib_logf.c
@@ -94,7 +94,7 @@ float logf(float x)
           iter = 0;
         }
 
-      if (relax_factor > 1.0F)
+      if (iter == 0)
         {
           epsilon *= relax_factor;
         }


### PR DESCRIPTION
## Summary
Fix epsilon relaxation in `log` and `logf`.

Per description on how it should work:
```
To avoid looping forever in particular corner cases, every LOG_MAX_ITER the error criteria is relaxed by a factor LOG_RELAX_MULTIPLIER.
```
but actually as soon as first `LOG_MAX_ITER` number of cycles is reached the epsilon was getting doubled with each next cycle.

## Impact
Improve native `libm`

## Testing
Tried few cases, but needs more testing