### PR TITLE
ci-docker: add subversion to linux dockerfile

### DIFF
--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" apt-get install -y -q
   ninja-build \
   nodejs \
   npm \
+  subversion \
   unzip
 
 RUN mkdir /tools


### PR DESCRIPTION
## Summary

add install subversion to linux dockerfile

- tools/ci/docker/linux/Dockerfile

## Impact

NA

## Testing

NA
