### PR TITLE
can: Before we use pstate, we should check if it is NULL.

### DIFF
--- a/net/can/can_recvmsg.c
+++ b/net/can/can_recvmsg.c
@@ -369,14 +369,15 @@ static uint16_t can_recvfrom_eventhandler(FAR struct net_driver_s *dev,
                                           FAR void *pvpriv, uint16_t flags)
 {
   struct can_recvfrom_s *pstate = pvpriv;
-#if defined(CONFIG_NET_CANPROTO_OPTIONS) || defined(CONFIG_NET_TIMESTAMP)
-  struct can_conn_s *conn = pstate->pr_conn;
-#endif
 
   /* 'priv' might be null in some race conditions (?) */
 
   if (pstate)
     {
+#if defined(CONFIG_NET_CANPROTO_OPTIONS) || defined(CONFIG_NET_TIMESTAMP)
+      struct can_conn_s *conn = pstate->pr_conn;
+#endif
+
       if ((flags & CAN_NEWDATA) != 0)
         {
           /* If a new packet is available, check receive filters


### PR DESCRIPTION
## Summary
Before we use pstate, we should check if it is NULL.
## Impact
none

## Testing
ostest

