### PR TITLE
libs/libm/libm: apply epsilon relax factor only if epsilon is small

### DIFF
--- a/libs/libm/libm/lib_log.c
+++ b/libs/libm/libm/lib_log.c
@@ -98,7 +98,7 @@ double log(double x)
           iter = 0;
         }
 
-      if (iter == 0)
+      if (relax_factor > 1.0)
         {
           epsilon *= relax_factor;
         }

--- a/libs/libm/libm/lib_log.c
+++ b/libs/libm/libm/lib_log.c
@@ -46,7 +46,7 @@
  * todo: might need to adjust the double floating point version too.
  */
 
-#define LOG_MAX_ITER         10
+#define LOG_MAX_ITER         400
 #define LOG_RELAX_MULTIPLIER 2.0
 
 /****************************************************************************

--- a/libs/libm/libm/lib_log.c
+++ b/libs/libm/libm/lib_log.c
@@ -64,15 +64,15 @@ double log(double x)
   double y_old;
   double ey;
   double epsilon;
-  double relax_factor;
+  double rf; /* epsilon relax factor */
   int    iter;
 
   y = 0.0;
   y_old = 1.0;
   epsilon = DBL_EPSILON;
 
-  iter         = 0;
-  relax_factor = 1.0;
+  iter = 0;
+  rf = 1.0;
 
   while (y > y_old + epsilon || y < y_old - epsilon)
     {
@@ -90,17 +90,12 @@ double log(double x)
           y = -DBL_MAX_EXP_X;
         }
 
-      epsilon = (fabs(y) > 1.0) ? fabs(y) * DBL_EPSILON : DBL_EPSILON;
+      epsilon = ((fabs(y) > rf) ? fabs(y) : rf) * DBL_EPSILON;
 
       if (++iter >= LOG_MAX_ITER)
         {
-          relax_factor *= LOG_RELAX_MULTIPLIER;
+          rf *= LOG_RELAX_MULTIPLIER;
           iter = 0;
-        }
-
-      if (relax_factor > 1.0)
-        {
-          epsilon *= relax_factor;
         }
     }
 

--- a/libs/libm/libm/lib_logf.c
+++ b/libs/libm/libm/lib_logf.c
@@ -43,7 +43,7 @@
  * todo: might need to adjust the double floating point version too.
  */
 
-#define LOGF_MAX_ITER         10
+#define LOGF_MAX_ITER         400
 #define LOGF_RELAX_MULTIPLIER 2.0F
 
 /****************************************************************************

--- a/libs/libm/libm/lib_logf.c
+++ b/libs/libm/libm/lib_logf.c
@@ -60,15 +60,15 @@ float logf(float x)
   float y_old;
   float ey;
   float epsilon;
-  float relax_factor;
+  float rf; /* epsilon relax factor */
   int   iter;
 
-  y       = 0.0F;
-  y_old   = 1.0F;
+  y = 0.0F;
+  y_old = 1.0F;
   epsilon = FLT_EPSILON;
 
-  iter         = 0;
-  relax_factor = 1.0F;
+  iter = 0;
+  rf = 1.0F;
 
   while (y > y_old + epsilon || y < y_old - epsilon)
     {
@@ -86,17 +86,12 @@ float logf(float x)
           y = -FLT_MAX_EXP_X;
         }
 
-      epsilon = (fabsf(y) > 1.0F) ? fabsf(y) * FLT_EPSILON : FLT_EPSILON;
+      epsilon = ((fabsf(y) > rf) ? fabsf(y) : rf) * FLT_EPSILON;
 
       if (++iter >= LOGF_MAX_ITER)
         {
-          relax_factor *= LOGF_RELAX_MULTIPLIER;
+          rf *= LOGF_RELAX_MULTIPLIER;
           iter = 0;
-        }
-
-      if (relax_factor > 1.0F)
-        {
-          epsilon *= relax_factor;
         }
     }
 

--- a/libs/libm/libm/lib_logf.c
+++ b/libs/libm/libm/lib_logf.c
@@ -94,7 +94,7 @@ float logf(float x)
           iter = 0;
         }
 
-      if (iter == 0)
+      if (relax_factor > 1.0F)
         {
           epsilon *= relax_factor;
         }


### PR DESCRIPTION
## Summary
The previous attempt to fix `log` and `logf` operation in https://github.com/apache/nuttx/pull/13294 was wrong.
This is a second attempt that reverts previous change and applied relaxation only if `epsilon` calculation is evaluated to `DBL_EPSILON`/`FLT_EPSILON` case.

## Impact
Should fix https://github.com/apache/nuttx/issues/13286

## Testing
Tested few value returned by Nuttx libm `log` and compared with values returned by compiler version of `log`.