### PR TITLE
xtensa: Appease a GCC warning

### DIFF
--- a/arch/xtensa/src/common/xtensa_swint.c
+++ b/arch/xtensa/src/common/xtensa_swint.c
@@ -432,7 +432,7 @@ int xtensa_swint(int irq, void *context, void *arg)
   if (regs != CURRENT_REGS)
     {
       svcinfo("SYSCALL Return: Context switch!\n");
-      up_dump_register(CURRENT_REGS);
+      up_dump_register((void *)CURRENT_REGS);
     }
   else
     {


### PR DESCRIPTION
## Summary
```
common/xtensa_swint.c:442:24: error: passing argument 1 of 'up_dump_register' discards 'volatile' qualifier from pointer target type [-Werror=discarded-qualifiers]
  442 |       up_dump_register(CURRENT_REGS);
      |                        ^~~~~~~~~~~~
```
## Impact

## Testing

Tested on esp32-devkitc