### PR TITLE
ip6_tables.h: fix gcc 14 errors

### DIFF
--- a/include/nuttx/net/netfilter/ip6_tables.h
+++ b/include/nuttx/net/netfilter/ip6_tables.h
@@ -296,7 +296,7 @@ struct ip6t_icmp
 static inline FAR struct xt_entry_target *
 ip6t_get_target(FAR struct ip6t_entry *e)
 {
-  return (FAR char *)e + e->target_offset;
+  return (FAR struct xt_entry_target *)((FAR char *)e + e->target_offset);
 }
 
 #endif /* __INCLUDE_NUTTX_NET_NETFILTER_IP6_TABLES_H */


### PR DESCRIPTION
## Summary
- include/nuttx/net/netfilter/ip6_tables.h: fix gcc 14 errors
fix gcc 14 errors for ip6_tables.h

## Impact

## Testing
CI