### PR TITLE
arch/x86_64: Support QEMU PVH ELF loader

### DIFF
--- a/arch/x86_64/Kconfig
+++ b/arch/x86_64/Kconfig
@@ -124,4 +124,10 @@ config MULTBOOT2_FB_TERM
 
 endif # ARCH_MULTIBOOT2
 
+config ARCH_PVHBOOT
+	bool "Append Xen PVH ELF Note"
+	default y
+	---help---
+		This allow x86 QEMU -kernel boot.
+
 endif # ARCH_X86_64

--- a/arch/x86_64/src/intel64/intel64_head.S
+++ b/arch/x86_64/src/intel64/intel64_head.S
@@ -164,9 +164,6 @@ loader_gdt_ptr:
 
 	.size   __reset_entry, . - __reset_entry
 
-bsp_done:
-	.long   0
-
 #ifdef CONFIG_SMP
 /****************************************************************************
  * Name: __ap_entry
@@ -477,6 +474,9 @@ __enable_pcid:
 
 	.section ".loader.data", "ax"
 
+bsp_done:
+	.long   0
+
 	/* TSS (IST) for 64 bit long mode will be filled in up_irq. */
 	.align(16)
 g_ist64_low:
@@ -539,3 +539,17 @@ g_pt_low:
 	.fill   X86_NUM_PAGE_ENTRY * X86_NUM_PAGE_ENTRY, X86_PAGE_ENTRY_SIZE, 0
 	.fill   X86_NUM_PAGE_ENTRY * X86_NUM_PAGE_ENTRY, X86_PAGE_ENTRY_SIZE, 0
 	.fill   X86_NUM_PAGE_ENTRY * X86_NUM_PAGE_ENTRY, X86_PAGE_ENTRY_SIZE, 0
+
+#ifdef CONFIG_ARCH_PVHBOOT
+	/* PVH Header with pvh_start_addr = start32 */
+	.pushsection .note.nuttx, "a", @note
+	.align 4
+	.long 2f - 1f
+	.long 4f - 3f
+	.long 18
+	1:.asciz "nuttx"
+	2:.align 4
+	3:.long start32
+	4:.align 4
+	.popsection
+#endif


### PR DESCRIPTION
## Summary
Activating the CONFIG_ARCH_PVHBOOT configuration enables the loading of the nuttx.elf binary using the QEMU -kernel command-line option.

## Impact
This change facilitates the direct booting of the NuttX operating system within a QEMU virtual machine, enhancing development and testing workflows for the x86_64 architecture.

## Testing
The functionality has been verified on an x86_64 Ubuntu 22.04 machine. NuttX can be successfully booted using the following command: `sudo qemu-system-x86_64 -enable-kvm -cpu host -m 2G -kernel nuttx.elf -nographic -serial mon:stdio`.
