### PR TITLE
arch/x86_64: Fix wrong RDTSCP implementation

### DIFF
--- a/arch/x86_64/include/intel64/irq.h
+++ b/arch/x86_64/include/intel64/irq.h
@@ -535,7 +535,7 @@ static inline uint64_t rdtscp(void)
   uint32_t lo;
   uint32_t hi;
 
-  asm volatile("rdtscp" : "=a" (lo), "=d" (hi)::"memory");
+  asm volatile("rdtscp" : "=a" (lo), "=d" (hi)::"ecx", "memory");
   return (uint64_t)lo | (((uint64_t)hi) << 32);
 }
 


### PR DESCRIPTION
## Summary
RDTSCP instruction reads the current value of the processor’s time-stamp counter (a 64-bit MSR) into the EDX:EAX registers, and it also reads the value of the IA32_TSC_AUX MSR (address C0000103H) into the ECX register. However, the current RDTSCP implementation does not provide a hint for the compiler that ECX has been changed, resulting in register corrupted and subtle errors.

## Impact
Bug Fixed.

## Testing
