### PR TITLE
drivers/mtd/bch: fix size_t overflow when offset > 4GB

### DIFF
--- a/drivers/bch/bchlib_read.c
+++ b/drivers/bch/bchlib_read.c
@@ -64,7 +64,7 @@
  *
  ****************************************************************************/
 
-ssize_t bchlib_read(FAR void *handle, FAR char *buffer, size_t offset,
+ssize_t bchlib_read(FAR void *handle, FAR char *buffer, off_t offset,
                     size_t len)
 {
   FAR struct bchlib_s *bch = (FAR struct bchlib_s *)handle;

--- a/drivers/bch/bchlib_write.c
+++ b/drivers/bch/bchlib_write.c
@@ -50,7 +50,7 @@
  *
  ****************************************************************************/
 
-ssize_t bchlib_write(FAR void *handle, FAR const char *buffer, size_t offset,
+ssize_t bchlib_write(FAR void *handle, FAR const char *buffer, off_t offset,
         size_t len)
 {
   FAR struct bchlib_s *bch = (FAR struct bchlib_s *)handle;

--- a/drivers/mtd/filemtd.c
+++ b/drivers/mtd/filemtd.c
@@ -725,7 +725,7 @@ static int mtd_loop_ioctl(FAR struct file *filep, int cmd,
  *
  ****************************************************************************/
 
-FAR struct mtd_dev_s *filemtd_initialize(FAR const char *path, size_t offset,
+FAR struct mtd_dev_s *filemtd_initialize(FAR const char *path, off_t offset,
                                          int16_t sectsize, int32_t erasesize)
 {
   FAR struct file_dev_s *priv;

--- a/include/nuttx/drivers/drivers.h
+++ b/include/nuttx/drivers/drivers.h
@@ -231,7 +231,7 @@ int bchlib_teardown(FAR void *handle);
  *
  ****************************************************************************/
 
-ssize_t bchlib_read(FAR void *handle, FAR char *buffer, size_t offset,
+ssize_t bchlib_read(FAR void *handle, FAR char *buffer, off_t offset,
                     size_t len);
 
 /****************************************************************************
@@ -243,7 +243,7 @@ ssize_t bchlib_read(FAR void *handle, FAR char *buffer, size_t offset,
  *
  ****************************************************************************/
 
-ssize_t bchlib_write(FAR void *handle, FAR const char *buffer, size_t offset,
+ssize_t bchlib_write(FAR void *handle, FAR const char *buffer, off_t offset,
                      size_t len);
 
 /****************************************************************************

--- a/include/nuttx/mtd/mtd.h
+++ b/include/nuttx/mtd/mtd.h
@@ -657,7 +657,7 @@ FAR struct mtd_dev_s *w25qxxxjv_initialize(FAR struct qspi_dev_s *qspi,
  *
  ****************************************************************************/
 
-FAR struct mtd_dev_s *filemtd_initialize(FAR const char *path, size_t offset,
+FAR struct mtd_dev_s *filemtd_initialize(FAR const char *path, off_t offset,
                                          int16_t sectsize,
                                          int32_t erasesize);
 


### PR DESCRIPTION
## Summary
drivers/mtd/bch: fix size_t overflow when offset > 4GB
## Impact
Bug Fix
## Testing
Vela