### PR TITLE
drivers/rwbuffer: Bug fix: Set nblocks 0 after direct using wrflush

### DIFF
--- a/drivers/misc/rwbuffer.c
+++ b/drivers/misc/rwbuffer.c
@@ -334,6 +334,8 @@ static ssize_t rwb_writebuffer(FAR struct rwbuffer_s *rwb,
         {
           return ret;
         }
+
+      nblocks = 0;
     }
 
   while (nblocks > 0)


### PR DESCRIPTION
## Summary
drivers/rwbuffer: Set nblocks 0 after direct using wrflush(skip rwbuffer)

## Impact
improve rwbuffer write performance.
## Testing
Vela