### PR TITLE
sched/group/setuptask_file: duplicate idle task fd for kernel thread

### DIFF
--- a/sched/group/group_setuptaskfiles.c
+++ b/sched/group/group_setuptaskfiles.c
@@ -64,7 +64,7 @@ int group_setuptaskfiles(FAR struct task_tcb_s *tcb,
   FAR struct task_group_s *group = tcb->cmn.group;
   int ret = OK;
 #ifndef CONFIG_FDCLONE_DISABLE
-  FAR struct tcb_s *rtcb = this_task();
+  FAR struct tcb_s *rtcb;
 #endif
 
   sched_trace_begin();
@@ -75,7 +75,20 @@ int group_setuptaskfiles(FAR struct task_tcb_s *tcb,
 #endif
 
 #ifndef CONFIG_FDCLONE_DISABLE
-  DEBUGASSERT(rtcb->group);
+
+  /* The The file descriptors of kernel threads should be clean and
+   * should not be generated based on user threads. Instead, an idle
+   * thread should be chosen.
+   */
+
+  if ((tcb->cmn.flags & TCB_FLAG_TTYPE_MASK) == TCB_FLAG_TTYPE_KERNEL)
+    {
+      rtcb = &g_idletcb[this_cpu()];
+    }
+  else
+    {
+      rtcb = this_task();
+    }
 
   /* Duplicate the parent task's file descriptors */
 

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -206,7 +206,7 @@ uint8_t g_nx_initstate;  /* See enum nx_initstate_e */
  * bringing up the rest of the system.
  */
 
-static struct tcb_s g_idletcb[CONFIG_SMP_NCPUS];
+struct tcb_s g_idletcb[CONFIG_SMP_NCPUS];
 
 /* This is the name of the idle task */
 

--- a/sched/sched/sched.h
+++ b/sched/sched/sched.h
@@ -194,6 +194,16 @@ extern dq_queue_t g_assignedtasks[CONFIG_SMP_NCPUS];
 
 extern FAR struct tcb_s *g_running_tasks[CONFIG_SMP_NCPUS];
 
+/* This is an array of task control block (TCB) for the IDLE thread of each
+ * CPU.  For the non-SMP case, this is a a single TCB; For the SMP case,
+ * there is one TCB per CPU.  NOTE: The system boots on CPU0 into the IDLE
+ * task.  The IDLE task later starts the other CPUs and spawns the user
+ * initialization task.  That user initialization task is responsible for
+ * bringing up the rest of the system.
+ */
+
+extern struct tcb_s g_idletcb[CONFIG_SMP_NCPUS];
+
 /* This is the list of all tasks that are ready-to-run, but cannot be placed
  * in the g_readytorun list because:  (1) They are higher priority than the
  * currently active task at the head of the g_readytorun list, and (2) the


### PR DESCRIPTION


## Summary
sched/group/setuptask_file: duplicate idle task fd for kernel thread.

The file descriptors of kernel threads should be clean and should not be generated based on user threads. Instead, an idle thread hould be chosen.
## Impact
Clean the file descriptors of kernel threads 
## Testing
Vela

