### PR TITLE
group/filelist: add reference to protect filelist of group

### DIFF
--- a/fs/inode/fs_files.c
+++ b/fs/inode/fs_files.c
@@ -174,8 +174,7 @@ static void task_fssync(FAR struct tcb_s *tcb, FAR void *arg)
   int i;
   int j;
 
-  list = &tcb->group->tg_filelist;
-
+  list = files_getlist(tcb);
   for (i = 0; i < list->fl_rows; i++)
     {
       for (j = 0; j < CONFIG_NFILE_DESCRIPTORS_PER_BLOCK; j++)
@@ -189,6 +188,8 @@ static void task_fssync(FAR struct tcb_s *tcb, FAR void *arg)
             }
         }
     }
+
+  files_putlist(list);
 }
 
 /****************************************************************************
@@ -309,6 +310,7 @@ void files_initlist(FAR struct filelist *list)
    */
 
   list->fl_rows = 1;
+  list->fl_crefs = 1;
   list->fl_files = &list->fl_prefile;
   list->fl_prefile = list->fl_prefiles;
 }
@@ -375,19 +377,47 @@ void files_dumplist(FAR struct filelist *list)
 }
 
 /****************************************************************************
- * Name: files_releaselist
+ * Name: files_getlist
  *
  * Description:
- *   Release a reference to the file list
+ *   Get the list of files by tcb.
+ *
+ * Assumptions:
+ *   Called during task deletion in a safe context.
  *
  ****************************************************************************/
 
-void files_releaselist(FAR struct filelist *list)
+FAR struct filelist *files_getlist(FAR struct tcb_s *tcb)
+{
+  FAR struct filelist *list = &tcb->group->tg_filelist;
+
+  DEBUGASSERT(list->fl_crefs >= 1);
+  list->fl_crefs++;
+
+  return list;
+}
+
+/****************************************************************************
+ * Name: files_putlist
+ *
+ * Description:
+ *   Release the list of files.
+ *
+ * Assumptions:
+ *   Called during task deletion in a safe context.
+ *
+ ****************************************************************************/
+
+void files_putlist(FAR struct filelist *list)
 {
   int i;
   int j;
 
-  DEBUGASSERT(list);
+  DEBUGASSERT(list->fl_crefs >= 1);
+  if (--list->fl_crefs > 0)
+    {
+      return;
+    }
 
   /* Close each file descriptor .. Normally, you would need take the list
    * mutex, but it is safe to ignore the mutex in this context

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -496,6 +496,7 @@ struct file
 struct filelist
 {
   uint8_t           fl_rows;    /* The number of rows of fl_files array */
+  uint8_t           fl_crefs;   /* The references to filelist */
   FAR struct file **fl_files;   /* The pointer of two layer file descriptors array */
 
   /* Pre-allocated files to avoid allocator access during thread creation
@@ -876,14 +877,24 @@ void files_initlist(FAR struct filelist *list);
 void files_dumplist(FAR struct filelist *list);
 
 /****************************************************************************
- * Name: files_releaselist
+ * Name: files_getlist
  *
  * Description:
- *   Release a reference to the file list
+ *   Get the list of files by tcb.
  *
  ****************************************************************************/
 
-void files_releaselist(FAR struct filelist *list);
+FAR struct filelist *files_getlist(FAR struct tcb_s *tcb);
+
+/****************************************************************************
+ * Name: files_putlist
+ *
+ * Description:
+ *   Release the list of files.
+ *
+ ****************************************************************************/
+
+void files_putlist(FAR struct filelist * list);
 
 /****************************************************************************
  * Name: files_countlist

--- a/sched/group/group_leave.c
+++ b/sched/group/group_leave.c
@@ -96,7 +96,7 @@ group_release(FAR struct task_group_s *group, uint8_t ttype)
 
   /* Free resources held by the file descriptor list */
 
-  files_releaselist(&group->tg_filelist);
+  files_putlist(&group->tg_filelist);
 
 #ifndef CONFIG_DISABLE_ENVIRON
   /* Release all shared environment variables */


### PR DESCRIPTION
## Summary
fs/inode: add reference to protect filelist of group

Before this PR, when we perform a reboot command, the sync() function is called to synchronize all the file descriptors (fds) of tasks. 
**However, if there are tasks exiting at this time, it can lead to the issue of file handles being used after they have been freed. Therefore, we need to add references (refs) to protect this list from being released.**

## Impact
protect filelist.
## Testing
Vela
