### PR TITLE
fs/inode: using inode reference to indicate unlink and simply code 

### DIFF
--- a/fs/inode/fs_inoderelease.c
+++ b/fs/inode/fs_inoderelease.c
@@ -76,7 +76,7 @@ void inode_release(FAR struct inode *inode)
        * now.
        */
 
-      if (inode->i_crefs <= 0 && (inode->i_flags & FSNODEFLAG_DELETED) != 0)
+      if (inode->i_crefs <= 0)
         {
           /* If the inode has been properly unlinked, then the peer pointer
            * should be NULL.

--- a/fs/inode/fs_inoderemove.c
+++ b/fs/inode/fs_inoderemove.c
@@ -96,6 +96,7 @@ static FAR struct inode *inode_unlink(FAR const char *path)
 
       node->i_peer   = NULL;
       node->i_parent = NULL;
+      node->i_crefs--;
     }
 
   RELEASE_SEARCH(&desc);
@@ -135,11 +136,6 @@ int inode_remove(FAR const char *path)
 
       if (node->i_crefs)
         {
-          /* In that case, we will mark it deleted, when the filesystem
-           * releases the inode, we will then, finally delete the subtree
-           */
-
-          node->i_flags |= FSNODEFLAG_DELETED;
           return -EBUSY;
         }
       else

--- a/fs/inode/fs_inodereserve.c
+++ b/fs/inode/fs_inodereserve.c
@@ -85,6 +85,7 @@ static FAR struct inode *inode_alloc(FAR const char *name, mode_t mode)
   if (node)
     {
       node->i_ino   = g_ino++;
+      node->i_crefs = 1;
 #ifdef CONFIG_PSEUDOFS_ATTRIBUTES
       node->i_mode  = mode;
       clock_gettime(CLOCK_REALTIME, &node->i_atime);

--- a/fs/mount/fs_mount.c
+++ b/fs/mount/fs_mount.c
@@ -507,9 +507,7 @@ int nx_mount(FAR const char *source, FAR const char *target,
   /* A lot of goto's!  But they make the error handling much simpler */
 
 errout_with_mountpt:
-  inode_release(mountpt_inode);
   inode_remove(target);
-
 errout_with_lock:
   inode_unlock();
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS

--- a/fs/mount/fs_mount.c
+++ b/fs/mount/fs_mount.c
@@ -298,7 +298,7 @@ int nx_mount(FAR const char *source, FAR const char *target,
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   struct inode_search_s desc;
 #endif
-  void *fshandle = NULL;
+  FAR void *fshandle = NULL;
   int ret;
 
   /* Verify required pointer arguments */
@@ -442,6 +442,8 @@ int nx_mount(FAR const char *source, FAR const char *target,
     }
 #endif
 
+  inode_unlock();
+
   /* On failure, the bind method returns -errorcode */
 
 #if defined(BDFS_SUPPORT) || defined(MDFS_SUPPORT)
@@ -449,6 +451,7 @@ int nx_mount(FAR const char *source, FAR const char *target,
 #else
   ret = mops->bind(NULL, data, &fshandle);
 #endif
+  DEBUGVERIFY(inode_lock() >= 0);
   if (ret < 0)
     {
       /* The inode is unhappy with the driver for some reason.  Back out

--- a/fs/mqueue/mq_open.c
+++ b/fs/mqueue/mq_open.c
@@ -74,7 +74,7 @@ static int nxmq_file_close(FAR struct file *filep)
 {
   FAR struct inode *inode = filep->f_inode;
 
-  if (inode->i_crefs <= 1 && (inode->i_flags & FSNODEFLAG_DELETED))
+  if (inode->i_crefs <= 0)
     {
       FAR struct mqueue_inode_s *msgq = inode->i_private;
 
@@ -322,7 +322,7 @@ static int file_mq_vopen(FAR struct file *mq, FAR const char *mq_name,
 
       /* Set the initial reference count on this inode to one */
 
-      inode->i_crefs    = 1;
+      inode->i_crefs++;
 
       if (created)
         {

--- a/fs/mqueue/mq_unlink.c
+++ b/fs/mqueue/mq_unlink.c
@@ -150,8 +150,8 @@ int file_mq_unlink(FAR const char *mq_name)
     }
 
   /* Remove the old inode from the tree.  Because we hold a reference count
-   * on the inode, it will not be deleted now.  This will set the
-   * FSNODEFLAG_DELETED bit in the inode flags.
+   * on the inode, it will not be deleted now. This will put reference of
+   * inode.
    */
 
   ret = inode_remove(fullpath);

--- a/fs/semaphore/sem_close.c
+++ b/fs/semaphore/sem_close.c
@@ -105,7 +105,7 @@ int nxsem_close(FAR sem_t *sem)
    * now.
    */
 
-  if (inode->i_crefs <= 0 && (inode->i_flags & FSNODEFLAG_DELETED) != 0)
+  if (inode->i_crefs <= 0)
     {
       /* Destroy the semaphore and free the container */
 

--- a/fs/semaphore/sem_open.c
+++ b/fs/semaphore/sem_open.c
@@ -211,7 +211,7 @@ int nxsem_open(FAR sem_t **sem, FAR const char *name, int oflags, ...)
       /* Initialize the inode */
 
       INODE_SET_NAMEDSEM(inode);
-      inode->i_crefs = 1;
+      inode->i_crefs++;
 
       /* Initialize the semaphore */
 

--- a/fs/semaphore/sem_unlink.c
+++ b/fs/semaphore/sem_unlink.c
@@ -115,8 +115,8 @@ int nxsem_unlink(FAR const char *name)
     }
 
   /* Remove the old inode from the tree.  Because we hold a reference count
-   * on the inode, it will not be deleted now.  This will set the
-   * FSNODEFLAG_DELETED bit in the inode flags.
+   * on the inode, it will not be deleted now. This will put reference of
+   * inode.
    */
 
   ret = inode_remove(fullpath);

--- a/fs/shm/shm_open.c
+++ b/fs/shm/shm_open.c
@@ -137,7 +137,7 @@ static int file_shm_open(FAR struct file *shm, FAR const char *name,
       INODE_SET_SHM(inode);
       inode->u.i_ops = &g_shmfs_operations;
       inode->i_private = NULL;
-      inode->i_crefs = 1;
+      inode->i_crefs++;
     }
 
   /* Associate the inode with a file structure */

--- a/fs/shm/shm_unlink.c
+++ b/fs/shm/shm_unlink.c
@@ -117,8 +117,8 @@ static int file_shm_unlink(FAR const char *name)
 #endif
 
   /* Remove the old inode from the tree. If we hold a reference count
-   * on the inode, it will not be deleted now.  This will set the
-   * FSNODEFLAG_DELETED bit in the inode flags.
+   * on the inode, it will not be deleted now. This will put reference of
+   * inode.
    */
 
   ret = inode_remove(fullpath);

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -118,7 +118,6 @@
 #define   FSNODEFLAG_TYPE_SOFTLINK  0x00000008 /*   Soft link              */
 #define   FSNODEFLAG_TYPE_SOCKET    0x00000009 /*   Socket                 */
 #define   FSNODEFLAG_TYPE_PIPE      0x0000000a /*   Pipe                   */
-#define FSNODEFLAG_DELETED          0x00000010 /* Unlinked                 */
 
 #define INODE_IS_TYPE(i,t) \
   (((i)->i_flags & FSNODEFLAG_TYPE_MASK) == (t))


### PR DESCRIPTION
## Summary
fs/inode: using inode reference to indicate unlink and simply code 
## Impact
Change inode i_crefs's initial value to 1, and release inode resource when i_crefs is zero.
Remove inode flags: FSNODEFLAG_DELETED
## Testing
Vela
