### PR TITLE
sched_lock: use critical section to prevent data races

### DIFF
--- a/sched/sched/sched_lock.c
+++ b/sched/sched/sched_lock.c
@@ -195,6 +195,7 @@ int sched_lock(void)
 
   if (rtcb != NULL && !up_interrupt_context())
     {
+      irqstate_t flags = enter_critical_section();
       /* Catch attempts to increment the lockcount beyond the range of the
        * integer type.
        */
@@ -223,6 +224,8 @@ int sched_lock(void)
 #endif
         }
 #endif
+
+      leave_critical_section(flags);
     }
 
   return OK;


### PR DESCRIPTION
## Summary
This was discussed on the mailing list with @patacongo. sched_lock() should only be used within a critical section to prevent data races around the `rtcb->lockcount` variable. No matter the underlying hardware architecture, the C standard does not guarantee the atomicity of read, write, or RMW operations. Gregory suggested adding a DEBUGASSERT inside the function to confirm that we're in a critical section. However, I looked at [sched_unlock](https://github.com/apache/nuttx/blob/f7843e2198be007246986dae3d583cda355b9e10/sched/sched/sched_unlock.c#L233)()'s implementation and it just enters a critical section so the user doesn't have to. I figured I would do the same here.

## Impact
I don't forsee any bugs being caused by this patch. The only negative I can think of is that code that was already entering a critical section before calling sched_lock() will now have to pay the "penalty" of sched_lock() internally calling enter_critical_section() again (which, on ARMv7-m, is essentially just a data memory barrier).

## Testing

