### PR TITLE
netdb: Make NETDB_DNSSERVER_NAMESERVERS effective for NETDB_RESOLVCONF

### DIFF
--- a/libs/libc/netdb/Kconfig
+++ b/libs/libc/netdb/Kconfig
@@ -194,7 +194,6 @@ endif # NETDB_RESOLVCONF
 config NETDB_DNSSERVER_NAMESERVERS
 	int "Max number of configured nameservers"
 	default 1
-	depends on !NETDB_RESOLVCONF
 	---help---
 		This setting determines how many nameservers there can be
 		in use concurrently.

--- a/libs/libc/netdb/lib_dnsaddserver.c
+++ b/libs/libc/netdb/lib_dnsaddserver.c
@@ -122,6 +122,11 @@ int dns_add_nameserver(FAR const struct sockaddr *addr, socklen_t addrlen)
   union dns_addr_u dns_addr;
   FAR uint16_t *pport;
   size_t copylen;
+#if CONFIG_NETDB_DNSSERVER_NAMESERVERS > 1
+  char prev_addr[CONFIG_NETDB_DNSSERVER_NAMESERVERS - 1][DNS_MAX_LINE];
+  int prev_cnt;
+  int i;
+#endif
   int ret;
 
   stream = fopen(CONFIG_NETDB_RESOLVCONF_PATH, "a+");
@@ -223,7 +228,22 @@ int dns_add_nameserver(FAR const struct sockaddr *addr, socklen_t addrlen)
       goto errout;
     }
 
-  /* Write the new record to the end of the resolv.conf file. */
+#if CONFIG_NETDB_DNSSERVER_NAMESERVERS > 1
+  fseek(stream, 0, SEEK_SET);
+  for (prev_cnt = 0; prev_cnt < CONFIG_NETDB_DNSSERVER_NAMESERVERS - 1;
+       prev_cnt++)
+    {
+      if (fgets(prev_addr[prev_cnt], DNS_MAX_LINE, stream) == NULL)
+        {
+          break;
+        }
+    }
+#endif
+
+  fclose(stream);
+  stream = fopen(CONFIG_NETDB_RESOLVCONF_PATH, "w");
+
+  /* Write the new record to the head of the resolv.conf file. */
 
 #ifdef CONFIG_NETDB_RESOLVCONF_NONSTDPORT
   /* The OpenBSD version supports a [host]:port syntax.  When a non-standard
@@ -237,8 +257,7 @@ int dns_add_nameserver(FAR const struct sockaddr *addr, socklen_t addrlen)
   ret = fprintf(stream, "%s [%s]:%u\n",
                 NETDB_DNS_KEYWORD, addrstr, NTOHS(*pport));
 #else
-  ret = fprintf(stream, "%s %s\n",
-                NETDB_DNS_KEYWORD, addrstr);
+  ret = fprintf(stream, "%s %s\n", NETDB_DNS_KEYWORD, addrstr);
 #endif
 
   if (ret < 0)
@@ -248,6 +267,20 @@ int dns_add_nameserver(FAR const struct sockaddr *addr, socklen_t addrlen)
       DEBUGASSERT(ret < 0);
       goto errout;
     }
+
+#if CONFIG_NETDB_DNSSERVER_NAMESERVERS > 1
+  for (i = 0; i < prev_cnt; i++)
+    {
+      ret = fputs(prev_addr[i], stream);
+      if (ret < 0)
+        {
+          ret = -get_errno();
+          nerr("ERROR: fprintf failed: %d\n", ret);
+          DEBUGASSERT(ret < 0);
+          goto errout;
+        }
+    }
+#endif
 
   ret = OK;
 

--- a/libs/libc/netdb/lib_dnsforeach.c
+++ b/libs/libc/netdb/lib_dnsforeach.c
@@ -83,7 +83,7 @@ int dns_foreach_nameserver(dns_callback_t callback, FAR void *arg)
   unsigned int count;
   uint16_t port;
   int keylen;
-  int ret;
+  int ret = OK;
 
   /* Open the resolver configuration file */
 


### PR DESCRIPTION
## Summary
prevent the server list in resolv.conf from increasing indefinitely. 
the one that is overwritten is always the one configured first.

## Impact

## Testing
sim:local
