### PR TITLE
local_socket: add SO_SNDBUF & SO_RCVBUF support

### DIFF
--- a/drivers/pipes/pipe_common.c
+++ b/drivers/pipes/pipe_common.c
@@ -27,6 +27,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/ioctl.h>
+#include <sys/param.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -846,6 +847,32 @@ int pipecommon_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
           ret = circbuf_peekat(&dev->d_buffer,
                                dev->d_buffer.tail + peek->offset,
                                peek->buf, peek->size);
+        }
+        break;
+
+      case PIPEIOC_SETSIZE:
+        {
+          size_t size = (size_t)arg;
+          if (size == 0)
+            {
+              ret = -EINVAL;
+              break;
+            }
+
+          size = MIN(size, CONFIG_DEV_PIPE_MAXSIZE);
+          ret = circbuf_resize(&dev->d_buffer, size);
+          if (ret != 0)
+            {
+              break;
+            }
+
+          dev->d_bufsize = size;
+        }
+        break;
+
+      case PIPEIOC_GETSIZE:
+        {
+          ret = dev->d_bufsize;
         }
         break;
 

--- a/fs/vfs/fs_fcntl.c
+++ b/fs/vfs/fs_fcntl.c
@@ -243,6 +243,26 @@ static int file_vfcntl(FAR struct file *filep, int cmd, va_list ap)
           ret = file_ioctl(filep, FIOC_FILEPATH, va_arg(ap, FAR char *));
         }
 
+        break;
+      case F_SETPIPE_SZ:
+        /* Modify the capacity of the pipe to arg bytes, but not larger than
+         * CONFIG_DEV_PIPE_MAXSIZE.
+         */
+
+        {
+          ret = file_ioctl(filep, PIPEIOC_SETSIZE, va_arg(ap, int));
+        }
+
+        break;
+      case F_GETPIPE_SZ:
+
+        /* Return the capacity of the pipe */
+
+        {
+          ret = file_ioctl(filep, PIPEIOC_GETSIZE);
+        }
+
+        break;
       default:
         break;
     }

--- a/include/fcntl.h
+++ b/include/fcntl.h
@@ -103,6 +103,8 @@
 #define F_ADD_SEALS     16 /* Add the bit-mask argument arg to the set of seals of the inode */
 #define F_GET_SEALS     17 /* Get (as the function result) the current set of seals of the inode */
 #define F_DUPFD_CLOEXEC 18 /* Duplicate file descriptor with close-on-exit set.  */
+#define F_SETPIPE_SZ    19 /* Modify the capacity of the pipe to arg bytes, but not larger than CONFIG_DEV_PIPE_MAXSIZE */
+#define F_GETPIPE_SZ    20 /* Return the capacity of the pipe */
 
 /* For posix fcntl() and lockf() */
 

--- a/include/nuttx/fs/ioctl.h
+++ b/include/nuttx/fs/ioctl.h
@@ -484,6 +484,14 @@
                                                * IN: pipe_peek_s
                                                * OUT: Length of data */
 
+#define PIPEIOC_SETSIZE     _PIPEIOC(0x0005)  /* Pipe get size interface
+                                               * IN: size_t
+                                               * OUT: None */
+
+#define PIPEIOC_GETSIZE     _PIPEIOC(0x0006)  /* Pipe get size interface
+                                               * IN: None
+                                               * OUT: int */
+
 /* RTC driver ioctl definitions *********************************************/
 
 /* (see nuttx/include/rtc.h */

--- a/net/local/local.h
+++ b/net/local/local.h
@@ -49,8 +49,6 @@
 #define LOCAL_NPOLLWAITERS 2
 #define LOCAL_NCONTROLFDS  4
 
-#define LOCAL_SEND_LIMIT   (CONFIG_DEV_FIFO_SIZE - sizeof(uint16_t))
-
 /****************************************************************************
  * Public Type Definitions
  ****************************************************************************/
@@ -122,6 +120,8 @@ struct local_conn_s
   char lc_path[UNIX_PATH_MAX];   /* Path assigned by bind() */
   int32_t lc_instance_id;        /* Connection instance ID for stream
                                   * server<->client connection pair */
+  uint32_t lc_sndsize;           /* Send buffer size */
+  uint32_t lc_rcvsize;           /* Receive buffer size */
 
   FAR struct local_conn_s *
                         lc_peer; /* Peer connection instance */
@@ -558,7 +558,8 @@ int local_getaddr(FAR struct local_conn_s *conn, FAR struct sockaddr *addr,
  *
  ****************************************************************************/
 
-int local_create_fifos(FAR struct local_conn_s *conn);
+int local_create_fifos(FAR struct local_conn_s *conn,
+                       uint32_t cssize, uint32_t scsize);
 
 /****************************************************************************
  * Name: local_create_halfduplex
@@ -570,7 +571,7 @@ int local_create_fifos(FAR struct local_conn_s *conn);
 
 #ifdef CONFIG_NET_LOCAL_DGRAM
 int local_create_halfduplex(FAR struct local_conn_s *conn,
-                            FAR const char *path);
+                            FAR const char *path, uint32_t bufsize);
 #endif
 
 /****************************************************************************

--- a/net/local/local.h
+++ b/net/local/local.h
@@ -49,6 +49,14 @@
 #define LOCAL_NPOLLWAITERS 2
 #define LOCAL_NCONTROLFDS  4
 
+#if CONFIG_DEV_PIPE_MAXSIZE > 65535
+typedef uint32_t lc_size_t;  /* 32-bit index */
+#elif CONFIG_DEV_PIPE_MAXSIZE > 255
+typedef uint16_t lc_size_t;  /* 16-bit index */
+#else
+typedef uint8_t lc_size_t;   /*  8-bit index */
+#endif
+
 /****************************************************************************
  * Public Type Definitions
  ****************************************************************************/
@@ -120,8 +128,7 @@ struct local_conn_s
   char lc_path[UNIX_PATH_MAX];   /* Path assigned by bind() */
   int32_t lc_instance_id;        /* Connection instance ID for stream
                                   * server<->client connection pair */
-  uint32_t lc_sndsize;           /* Send buffer size */
-  uint32_t lc_rcvsize;           /* Receive buffer size */
+  lc_size_t lc_rcvsize;          /* Receive buffer size */
 
   FAR struct local_conn_s *
                         lc_peer; /* Peer connection instance */
@@ -456,7 +463,7 @@ ssize_t local_sendmsg(FAR struct socket *psock, FAR struct msghdr *msg,
 int local_send_preamble(FAR struct local_conn_s *conn,
                         FAR struct file *filep,
                         FAR const struct iovec *buf,
-                        size_t len);
+                        size_t len, size_t rcvsize);
 
 /****************************************************************************
  * Name: local_send_packet

--- a/net/local/local_conn.c
+++ b/net/local/local_conn.c
@@ -153,6 +153,8 @@ FAR struct local_conn_s *local_alloc(void)
        */
 
       conn->lc_crefs = 1;
+      conn->lc_sndsize = CONFIG_DEV_FIFO_SIZE;
+      conn->lc_rcvsize = CONFIG_DEV_FIFO_SIZE;
 
 #ifdef CONFIG_NET_LOCAL_STREAM
       nxsem_init(&conn->lc_waitsem, 0, 0);

--- a/net/local/local_conn.c
+++ b/net/local/local_conn.c
@@ -153,7 +153,6 @@ FAR struct local_conn_s *local_alloc(void)
        */
 
       conn->lc_crefs = 1;
-      conn->lc_sndsize = CONFIG_DEV_FIFO_SIZE;
       conn->lc_rcvsize = CONFIG_DEV_FIFO_SIZE;
 
 #ifdef CONFIG_NET_LOCAL_STREAM

--- a/net/local/local_connect.c
+++ b/net/local/local_connect.c
@@ -35,6 +35,7 @@
 
 #include <arch/irq.h>
 #include <sys/stat.h>
+#include <sys/param.h>
 
 #include "utils/utils.h"
 #include "socket/socket.h"
@@ -87,7 +88,9 @@ static int inline local_stream_connect(FAR struct local_conn_s *client,
 
   /* Create the FIFOs needed for the connection */
 
-  ret = local_create_fifos(client);
+  ret = local_create_fifos(client,
+          MIN(client->lc_sndsize, server->lc_rcvsize),
+          MIN(client->lc_rcvsize, server->lc_sndsize));
   if (ret < 0)
     {
       nerr("ERROR: Failed to create FIFOs for %s: %d\n",

--- a/net/local/local_connect.c
+++ b/net/local/local_connect.c
@@ -88,9 +88,7 @@ static int inline local_stream_connect(FAR struct local_conn_s *client,
 
   /* Create the FIFOs needed for the connection */
 
-  ret = local_create_fifos(client,
-          MIN(client->lc_sndsize, server->lc_rcvsize),
-          MIN(client->lc_rcvsize, server->lc_sndsize));
+  ret = local_create_fifos(client, server->lc_rcvsize, client->lc_rcvsize);
   if (ret < 0)
     {
       nerr("ERROR: Failed to create FIFOs for %s: %d\n",

--- a/net/local/local_fifo.c
+++ b/net/local/local_fifo.c
@@ -166,7 +166,7 @@ static bool local_fifo_exists(FAR const char *path)
  *
  ****************************************************************************/
 
-static int local_create_fifo(FAR const char *path)
+static int local_create_fifo(FAR const char *path, uint32_t bufsize)
 {
   int ret;
 
@@ -174,7 +174,7 @@ static int local_create_fifo(FAR const char *path)
 
   if (!local_fifo_exists(path))
     {
-      ret = nx_mkfifo(path, 0644, CONFIG_DEV_FIFO_SIZE);
+      ret = nx_mkfifo(path, 0644, bufsize);
       if (ret < 0)
         {
           nerr("ERROR: Failed to create FIFO %s: %d\n", path, ret);
@@ -422,7 +422,8 @@ int local_set_pollthreshold(FAR struct local_conn_s *conn,
  *
  ****************************************************************************/
 
-int local_create_fifos(FAR struct local_conn_s *conn)
+int local_create_fifos(FAR struct local_conn_s *conn,
+                       uint32_t cssize, uint32_t scsize)
 {
   char path[LOCAL_FULLPATH_LEN];
   int ret;
@@ -430,13 +431,13 @@ int local_create_fifos(FAR struct local_conn_s *conn)
   /* Create the client-to-server FIFO if it does not already exist. */
 
   local_cs_name(conn, path);
-  ret = local_create_fifo(path);
+  ret = local_create_fifo(path, cssize);
   if (ret >= 0)
     {
       /* Create the server-to-client FIFO if it does not already exist. */
 
       local_sc_name(conn, path);
-      ret = local_create_fifo(path);
+      ret = local_create_fifo(path, scsize);
     }
 
   return ret;
@@ -452,14 +453,14 @@ int local_create_fifos(FAR struct local_conn_s *conn)
 
 #ifdef CONFIG_NET_LOCAL_DGRAM
 int local_create_halfduplex(FAR struct local_conn_s *conn,
-                            FAR const char *path)
+                            FAR const char *path, uint32_t bufsize)
 {
   char fullpath[LOCAL_FULLPATH_LEN];
 
   /* Create the half duplex FIFO if it does not already exist. */
 
   local_hd_name(path, fullpath);
-  return local_create_fifo(fullpath);
+  return local_create_fifo(fullpath, bufsize);
 }
 #endif /* CONFIG_NET_LOCAL_DGRAM */
 

--- a/net/local/local_fifo.c
+++ b/net/local/local_fifo.c
@@ -687,7 +687,7 @@ int local_open_receiver(FAR struct local_conn_s *conn, bool nonblock)
            */
 
           ret = local_set_pollinthreshold(&conn->lc_infile,
-                                          2 * sizeof(uint16_t));
+                                          2 * sizeof(lc_size_t));
         }
     }
 
@@ -730,7 +730,7 @@ int local_open_sender(FAR struct local_conn_s *conn, FAR const char *path,
            */
 
           ret = local_set_polloutthreshold(&conn->lc_outfile,
-                                           2 * sizeof(uint16_t));
+                                           2 * sizeof(lc_size_t));
         }
     }
 

--- a/net/local/local_recvmsg.c
+++ b/net/local/local_recvmsg.c
@@ -369,16 +369,10 @@ psock_dgram_recvfrom(FAR struct socket *psock, FAR void *buf, size_t len,
   size_t readlen;
   size_t pathlen;
   bool bclose = false;
-  uint16_t addrlen;
-  uint16_t pktlen;
+  lc_size_t addrlen;
+  lc_size_t pktlen;
   int offset = 0;
   int ret;
-
-  /* We keep packet sizes in a uint16_t, so there is a upper limit to the
-   * 'len' that can be supported.
-   */
-
-  DEBUGASSERT(len <= UINT16_MAX);
 
   /* Verify that this is a bound, un-connected peer socket */
 

--- a/net/local/local_recvmsg.c
+++ b/net/local/local_recvmsg.c
@@ -397,7 +397,7 @@ psock_dgram_recvfrom(FAR struct socket *psock, FAR void *buf, size_t len,
 
       /* Make sure that half duplex FIFO has been created */
 
-      ret = local_create_halfduplex(conn, conn->lc_path);
+      ret = local_create_halfduplex(conn, conn->lc_path, conn->lc_rcvsize);
       if (ret < 0)
         {
           nerr("ERROR: Failed to create FIFO for %s: %d\n",

--- a/net/local/local_sendmsg.c
+++ b/net/local/local_sendmsg.c
@@ -261,6 +261,7 @@ static ssize_t local_sendto(FAR struct socket *psock,
 {
 #ifdef CONFIG_NET_LOCAL_DGRAM
   FAR struct local_conn_s *conn = psock->s_conn;
+  FAR struct local_conn_s *server;
   FAR const struct sockaddr_un *unaddr = (FAR const struct sockaddr_un *)to;
   ssize_t ret;
 
@@ -307,7 +308,9 @@ static ssize_t local_sendto(FAR struct socket *psock,
     }
 
   net_lock();
-  if (local_findconn(conn, unaddr) == NULL)
+
+  server = local_findconn(conn, unaddr);
+  if (server == NULL)
     {
       net_unlock();
       nerr("ERROR: No such file or directory\n");
@@ -335,7 +338,7 @@ static ssize_t local_sendto(FAR struct socket *psock,
    * REVISIT:  Or should be just make sure that it already exists?
    */
 
-  ret = local_create_halfduplex(conn, unaddr->sun_path, conn->lc_sndsize);
+  ret = local_create_halfduplex(conn, unaddr->sun_path, server->lc_rcvsize);
   if (ret < 0)
     {
       nerr("ERROR: Failed to create FIFO for %s: %zd\n",
@@ -358,7 +361,8 @@ static ssize_t local_sendto(FAR struct socket *psock,
 
   /* Send the preamble */
 
-  ret = local_send_preamble(conn, &conn->lc_outfile, buf, len);
+  ret = local_send_preamble(conn, &conn->lc_outfile, buf, len,
+                            server->lc_rcvsize);
   if (ret < 0)
     {
       nerr("ERROR: Failed to send the preamble: %zd\n", ret);

--- a/net/local/local_sendmsg.c
+++ b/net/local/local_sendmsg.c
@@ -335,7 +335,7 @@ static ssize_t local_sendto(FAR struct socket *psock,
    * REVISIT:  Or should be just make sure that it already exists?
    */
 
-  ret = local_create_halfduplex(conn, unaddr->sun_path);
+  ret = local_create_halfduplex(conn, unaddr->sun_path, conn->lc_sndsize);
   if (ret < 0)
     {
       nerr("ERROR: Failed to create FIFO for %s: %zd\n",

--- a/net/local/local_sendpacket.c
+++ b/net/local/local_sendpacket.c
@@ -114,43 +114,45 @@ static int local_fifo_write(FAR struct file *filep, FAR const uint8_t *buf,
 int local_send_preamble(FAR struct local_conn_s *conn,
                         FAR struct file *filep,
                         FAR const struct iovec *buf,
-                        size_t len)
+                        size_t len, size_t rcvsize)
 {
   FAR const struct iovec *end = buf + len;
   FAR const struct iovec *iov;
   int ret;
-  uint16_t len16 = strlen(conn->lc_path);
+  lc_size_t pathlen;
+  lc_size_t pktlen;
 
-  ret = local_fifo_write(&conn->lc_outfile, (FAR const uint8_t *)&len16,
-                         sizeof(uint16_t));
-  if (ret != sizeof(uint16_t))
+  /* Send the packet length */
+
+  for (pktlen = 0, iov = buf; iov != end; iov++)
+    {
+      pktlen += iov->iov_len;
+    }
+
+  if (pktlen > rcvsize - sizeof(lc_size_t))
+    {
+      nerr("ERROR: Packet is too big: %d\n", pktlen);
+      return -EMSGSIZE;
+    }
+
+  pathlen = strlen(conn->lc_path);
+  ret = local_fifo_write(&conn->lc_outfile, (FAR const uint8_t *)&pathlen,
+                         sizeof(lc_size_t));
+  if (ret != sizeof(lc_size_t))
     {
       nerr("ERROR: local send path length failed ret: %d\n", ret);
       return ret;
     }
 
-  /* Send the packet length */
-
-  for (len16 = 0, iov = buf; iov != end; iov++)
-    {
-      len16 += iov->iov_len;
-    }
-
-  if (len16 > conn->lc_sndsize - sizeof(uint32_t))
-    {
-      nerr("ERROR: Packet is too big: %d\n", len16);
-      return -EMSGSIZE;
-    }
-
-  ret = local_fifo_write(filep, (FAR const uint8_t *)&len16,
-                        sizeof(uint16_t));
-  if (ret != sizeof(uint16_t))
+  ret = local_fifo_write(filep, (FAR const uint8_t *)&pktlen,
+                         sizeof(lc_size_t));
+  if (ret != sizeof(lc_size_t))
     {
       return ret;
     }
 
   return local_fifo_write(&conn->lc_outfile, (uint8_t *)conn->lc_path,
-                          strlen(conn->lc_path));
+                          pathlen);
 }
 
 /****************************************************************************
@@ -176,9 +178,9 @@ int local_send_packet(FAR struct file *filep, FAR const struct iovec *buf,
   FAR const struct iovec *end = buf + len;
   FAR const struct iovec *iov;
   int ret = -EINVAL;
-  uint16_t len16;
+  lc_size_t sendlen;
 
-  for (len16 = 0, iov = buf; iov != end; iov++)
+  for (sendlen = 0, iov = buf; iov != end; iov++)
     {
       ret = local_fifo_write(filep, iov->iov_base, iov->iov_len);
       if (ret < 0)
@@ -193,7 +195,7 @@ int local_send_packet(FAR struct file *filep, FAR const struct iovec *buf,
 
       if (ret > 0)
         {
-          len16 += ret;
+          sendlen += ret;
           if (ret != iov->iov_len)
             {
               break;
@@ -201,5 +203,5 @@ int local_send_packet(FAR struct file *filep, FAR const struct iovec *buf,
         }
     }
 
-  return len16 > 0 ? len16 : ret;
+  return sendlen > 0 ? sendlen : ret;
 }

--- a/net/local/local_sendpacket.c
+++ b/net/local/local_sendpacket.c
@@ -136,7 +136,7 @@ int local_send_preamble(FAR struct local_conn_s *conn,
       len16 += iov->iov_len;
     }
 
-  if (len16 > LOCAL_SEND_LIMIT)
+  if (len16 > conn->lc_sndsize - sizeof(uint32_t))
     {
       nerr("ERROR: Packet is too big: %d\n", len16);
       return -EMSGSIZE;


### PR DESCRIPTION
## Summary
allows user programs to modify pipe size via fcntl(F_SETPIPE_SZ), but not larger than CONFIG_DEV_PIPE_MAXSIZE,
lets a user program modify the size of the local_socket buffer via setsockopt(SO_SNDBUF/SO_RCVBUF).

## Impact

## Testing
sim:local
