### PR TITLE
Revert "Fix unwanted flush in the SPI slave driver"

### DIFF
--- a/drivers/spi/spi_slave_driver.c
+++ b/drivers/spi/spi_slave_driver.c
@@ -320,7 +320,6 @@ static ssize_t spi_slave_read(FAR struct file *filep, FAR char *buffer,
       return -ENOBUFS;
     }
 
-  priv->rx_length = MIN(buflen, sizeof(priv->rx_buffer));
   ret = nxmutex_lock(&priv->lock);
   if (ret < 0)
     {
@@ -692,7 +691,7 @@ static size_t spi_slave_receive(FAR struct spi_slave_dev_s *dev,
                                 FAR const void *data, size_t len)
 {
   FAR struct spi_slave_driver_s *priv = (FAR struct spi_slave_driver_s *)dev;
-  size_t recv_bytes = MIN(len, priv->rx_length);
+  size_t recv_bytes = MIN(len, sizeof(priv->rx_buffer));
 
   memcpy(priv->rx_buffer, data, recv_bytes);
 


### PR DESCRIPTION

## Summary
Revert "Fix unwanted flush in the SPI slave driver"

Because if priv->rx_length is zero , need to call SPIS_CTRLR_QPOLL to receive new data from lower half and update priv->rx_length.

This reverts commit 6cb649ecf6d537383eadb71a8a7ce780959ee8ad.

## Impact
Bug fix for spislave read
## Testing
Vela
