### PR TITLE
binfmt: migrate to SPDX identifier

### DIFF
--- a/binfmt/CMakeLists.txt
+++ b/binfmt/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # binfmt/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/binfmt/Makefile
+++ b/binfmt/Makefile
@@ -1,6 +1,8 @@
 ############################################################################
 # binfmt/Makefile
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/binfmt/binfmt_copyactions.c
+++ b/binfmt/binfmt_copyactions.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/binfmt_copyactions.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/binfmt_copyargv.c
+++ b/binfmt/binfmt_copyargv.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/binfmt_copyargv.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/binfmt_coredump.c
+++ b/binfmt/binfmt_coredump.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/binfmt_coredump.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/binfmt_dumpmodule.c
+++ b/binfmt/binfmt_dumpmodule.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/binfmt_dumpmodule.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/binfmt_exec.c
+++ b/binfmt/binfmt_exec.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/binfmt_exec.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/binfmt_execmodule.c
+++ b/binfmt/binfmt_execmodule.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/binfmt_execmodule.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/binfmt_execsymtab.c
+++ b/binfmt/binfmt_execsymtab.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/binfmt_execsymtab.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/binfmt_exit.c
+++ b/binfmt/binfmt_exit.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/binfmt_exit.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/binfmt_globals.c
+++ b/binfmt/binfmt_globals.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/binfmt_globals.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/binfmt_initialize.c
+++ b/binfmt/binfmt_initialize.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/binfmt_initialize.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/binfmt_loadmodule.c
+++ b/binfmt/binfmt_loadmodule.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/binfmt_loadmodule.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/binfmt_register.c
+++ b/binfmt/binfmt_register.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/binfmt_register.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/binfmt_unloadmodule.c
+++ b/binfmt/binfmt_unloadmodule.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/binfmt_unloadmodule.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/binfmt_unregister.c
+++ b/binfmt/binfmt_unregister.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/binfmt_unregister.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/libelf/CMakeLists.txt
+++ b/binfmt/libelf/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # binfmt/libelf/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/binfmt/libelf/Make.defs
+++ b/binfmt/libelf/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # binfmt/libelf/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/binfmt/libelf/gnu-elf.ld
+++ b/binfmt/libelf/gnu-elf.ld
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/libelf/gnu-elf.ld
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/libelf/libelf.h
+++ b/binfmt/libelf/libelf.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/libelf/libelf.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/libelf/libelf_addrenv.c
+++ b/binfmt/libelf/libelf_addrenv.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/libelf/libelf_addrenv.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/libelf/libelf_bind.c
+++ b/binfmt/libelf/libelf_bind.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/libelf/libelf_bind.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/libelf/libelf_coredump.c
+++ b/binfmt/libelf/libelf_coredump.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/libelf/libelf_coredump.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/libelf/libelf_ctors.c
+++ b/binfmt/libelf/libelf_ctors.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/libelf/libelf_ctors.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/libelf/libelf_dtors.c
+++ b/binfmt/libelf/libelf_dtors.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/libelf/libelf_dtors.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/libelf/libelf_init.c
+++ b/binfmt/libelf/libelf_init.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/libelf/libelf_init.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/libelf/libelf_iobuffer.c
+++ b/binfmt/libelf/libelf_iobuffer.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/libelf/libelf_iobuffer.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/libelf/libelf_load.c
+++ b/binfmt/libelf/libelf_load.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/libelf/libelf_load.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/libelf/libelf_read.c
+++ b/binfmt/libelf/libelf_read.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/libelf/libelf_read.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/libelf/libelf_sections.c
+++ b/binfmt/libelf/libelf_sections.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/libelf/libelf_sections.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/libelf/libelf_symbols.c
+++ b/binfmt/libelf/libelf_symbols.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/libelf/libelf_symbols.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/libelf/libelf_uninit.c
+++ b/binfmt/libelf/libelf_uninit.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/libelf/libelf_uninit.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/libelf/libelf_unload.c
+++ b/binfmt/libelf/libelf_unload.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/libelf/libelf_unload.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/libelf/libelf_verify.c
+++ b/binfmt/libelf/libelf_verify.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/libelf/libelf_verify.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/libnxflat/CMakeLists.txt
+++ b/binfmt/libnxflat/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # binfmt/libnxflat/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/binfmt/libnxflat/Make.defs
+++ b/binfmt/libnxflat/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # binfmt/libnxflat/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/binfmt/libnxflat/gnu-nxflat-gotoff.ld
+++ b/binfmt/libnxflat/gnu-nxflat-gotoff.ld
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/libnxflat/gnu-nxflat-gotoff.ld
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/libnxflat/gnu-nxflat-pcrel.ld
+++ b/binfmt/libnxflat/gnu-nxflat-pcrel.ld
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/libnxflat/gnu-nxflat-pcrel.ld
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/libnxflat/libnxflat.h
+++ b/binfmt/libnxflat/libnxflat.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/libnxflat/libnxflat.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/libnxflat/libnxflat_addrenv.c
+++ b/binfmt/libnxflat/libnxflat_addrenv.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/libnxflat/libnxflat_addrenv.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/libnxflat/libnxflat_bind.c
+++ b/binfmt/libnxflat/libnxflat_bind.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/libnxflat/libnxflat_bind.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/libnxflat/libnxflat_init.c
+++ b/binfmt/libnxflat/libnxflat_init.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/libnxflat/libnxflat_init.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/libnxflat/libnxflat_load.c
+++ b/binfmt/libnxflat/libnxflat_load.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/libnxflat/libnxflat_load.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/libnxflat/libnxflat_read.c
+++ b/binfmt/libnxflat/libnxflat_read.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/libnxflat/libnxflat_read.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/libnxflat/libnxflat_uninit.c
+++ b/binfmt/libnxflat/libnxflat_uninit.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/libnxflat/libnxflat_uninit.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/libnxflat/libnxflat_unload.c
+++ b/binfmt/libnxflat/libnxflat_unload.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/libnxflat/libnxflat_unload.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/libnxflat/libnxflat_verify.c
+++ b/binfmt/libnxflat/libnxflat_verify.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/libnxflat/libnxflat_verify.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The


### PR DESCRIPTION
## Summary
Most tools used for compliance and SBOM generation use SPDX identifiers This change brings us a step closer to an easy SBOM generation.

## Impact
SBOM

## Testing
CI
