### PR TITLE
netdev/statistics: Add bytes for netdev statistics

### DIFF
--- a/arch/arm/src/kinetis/kinetis_enet.c
+++ b/arch/arm/src/kinetis/kinetis_enet.c
@@ -576,10 +576,6 @@ static void kinetis_receive(struct kinetis_driver_s *priv)
 
   while ((priv->rxdesc[priv->rxtail].status1 & RXDESC_E) == 0)
     {
-      /* Update statistics */
-
-      NETDEV_RXPACKETS(&priv->dev);
-
       /* Copy the buffer pointer to priv->dev.d_buf.  Set amount of data in
        * priv->dev.d_len
        */
@@ -587,6 +583,10 @@ static void kinetis_receive(struct kinetis_driver_s *priv)
       priv->dev.d_len = kinesis_swap16(priv->rxdesc[priv->rxtail].length);
       priv->dev.d_buf =
         (uint8_t *)kinesis_swap32((uint32_t)priv->rxdesc[priv->rxtail].data);
+
+      /* Update statistics */
+
+      NETDEV_RXPACKETS(&priv->dev);
 
 #ifdef CONFIG_NET_PKT
       /* When packet sockets are enabled, feed the frame into the tap */

--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_ethernet.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_ethernet.c
@@ -821,10 +821,6 @@ static void lpc17_40_rxdone_work(void *arg)
   fragment = false;
   while (considx != prodidx)
     {
-      /* Update statistics */
-
-      NETDEV_RXPACKETS(&priv->lp_dev);
-
       /* Get the Rx status and packet length (-4+1) */
 
       rxstat   = (uint32_t *)(LPC17_40_RXSTAT_BASE + (considx << 3));
@@ -979,6 +975,10 @@ static void lpc17_40_rxdone_work(void *arg)
               NETDEV_RXDROPPED(&priv->lp_dev);
             }
         }
+
+      /* Update statistics */
+
+      NETDEV_RXPACKETS(&priv->lp_dev);
 
       /* Bump up the consumer index and resample the producer index (which
        * might also have gotten bumped up by the hardware).

--- a/arch/arm/src/lpc54xx/lpc54_ethernet.c
+++ b/arch/arm/src/lpc54xx/lpc54_ethernet.c
@@ -1223,7 +1223,7 @@ static void lpc54_eth_txdone(struct lpc54_ethdriver_s *priv,
     {
       /* Update statistics */
 
-      NETDEV_TXDONE(priv->eth_dev);
+      NETDEV_TXDONE(&priv->eth_dev);
 
       /* Free the Tx buffer assigned to the descriptor */
 
@@ -1321,12 +1321,12 @@ static void lpc54_eth_channel_work(struct lpc54_ethdriver_s *priv,
 
       if ((pending & LPC54_RXERR_INTMASK) != 0)
         {
-          NETDEV_RXERRORS(priv->eth_dev);
+          NETDEV_RXERRORS(&priv->eth_dev);
         }
 
       if ((pending & LPC54_TXERR_INTMASK) != 0)
         {
-          NETDEV_TXERRORS(priv->eth_dev);
+          NETDEV_TXERRORS(&priv->eth_dev);
         }
 
       /* The Receive Buffer Unavailable (RBU) error is a special case.  It
@@ -1375,7 +1375,7 @@ static void lpc54_eth_channel_work(struct lpc54_ethdriver_s *priv,
             {
               /* Update statistics if a packet was dispatched */
 
-              NETDEV_RXPACKETS(priv->eth_dev);
+              NETDEV_RXPACKETS(&priv->eth_dev);
             }
           else
             {
@@ -1576,7 +1576,7 @@ static void lpc54_eth_txtimeout_work(void *arg)
 
   /* Increment statistics and dump debug info */
 
-  NETDEV_TXTIMEOUTS(priv->eth_dev);
+  NETDEV_TXTIMEOUTS(&priv->eth_dev);
 
   /* Then reset the hardware by bringing it down and taking it back up
    * again.

--- a/arch/arm/src/rtl8720c/amebaz_netdev.c
+++ b/arch/arm/src/rtl8720c/amebaz_netdev.c
@@ -107,12 +107,12 @@ void amebaz_netdev_notify_receive(struct amebaz_dev_s *priv,
       return;
     }
 
-  NETDEV_RXPACKETS(&priv->dev);
   net_lock();
   oldbuf = priv->dev.d_buf;
   hdr = (struct eth_hdr_s *)skb->data;
   priv->dev.d_buf = (void *)skb->data;
   priv->dev.d_len = len;
+  NETDEV_RXPACKETS(&priv->dev);
 #ifdef CONFIG_NET_PKT
   pkt_input(&priv->dev);
 #endif

--- a/arch/mips/src/pic32mx/pic32mx_ethernet.c
+++ b/arch/mips/src/pic32mx/pic32mx_ethernet.c
@@ -1290,14 +1290,14 @@ static void pic32mx_rxdone(struct pic32mx_driver_s *priv)
 
       pic32mx_dumprxdesc(rxdesc, "RX Complete");
 
-      /* Update statistics */
-
-      NETDEV_RXPACKETS(&priv->pd_dev);
-
       /* Get the packet length */
 
       priv->pd_dev.d_len = (rxdesc->rsv2 & RXDESC_RSV2_BYTECOUNT_MASK) >>
                             RXDESC_RSV2_BYTECOUNT_SHIFT;
+
+      /* Update statistics */
+
+      NETDEV_RXPACKETS(&priv->pd_dev);
 
       /* Check for errors */
 

--- a/arch/misoc/src/common/misoc_net.c
+++ b/arch/misoc/src/common/misoc_net.c
@@ -194,7 +194,7 @@ static int misoc_net_transmit(struct misoc_net_driver_s *priv)
 
   /* Increment statistics */
 
-  NETDEV_TXPACKETS(priv->misoc_net_dev);
+  NETDEV_TXPACKETS(&priv->misoc_net_dev);
 
   /* Send the packet: address=priv->misoc_net_dev.d_buf,
    * length=priv->misoc_net_dev.d_len
@@ -353,6 +353,7 @@ static void misoc_net_receive(struct misoc_net_driver_s *priv)
 
       priv->misoc_net_dev.d_len = rxlen;
 
+      NETDEV_RXPACKETS(&priv->misoc_net_dev);
 #ifdef CONFIG_NET_PKT
       /* When packet sockets are enabled, feed the frame into the tap */
 
@@ -452,7 +453,7 @@ static void misoc_net_txdone(struct misoc_net_driver_s *priv)
 {
   /* Check for errors and update statistics */
 
-  NETDEV_TXDONE(priv->misoc_net_dev);
+  NETDEV_TXDONE(&priv->misoc_net_dev);
 
   /* Check if there are pending transmissions */
 
@@ -598,7 +599,7 @@ static void misoc_net_txtimeout_work(void *arg)
   /* Increment statistics and dump debug info */
 
   net_lock();
-  NETDEV_TXTIMEOUTS(priv->misoc_net_dev);
+  NETDEV_TXTIMEOUTS(&priv->misoc_net_dev);
 
   /* Then reset the hardware */
 

--- a/arch/risc-v/src/litex/litex_emac.c
+++ b/arch/risc-v/src/litex/litex_emac.c
@@ -551,11 +551,11 @@ static int litex_transmit(struct litex_emac_s *priv)
 
 static void litex_receive(struct litex_emac_s *priv)
 {
+  priv->dev.d_len = getreg16(LITEX_ETHMAC_SRAM_WRITER_LENGTH);
+
   /* Update statistics */
 
   NETDEV_RXPACKETS(&priv->dev);
-
-  priv->dev.d_len = getreg16(LITEX_ETHMAC_SRAM_WRITER_LENGTH);
 
   if (priv->dev.d_len == 0 || priv->dev.d_len > ETHMAC_SLOT_SIZE)
     {

--- a/drivers/net/enc28j60.c
+++ b/drivers/net/enc28j60.c
@@ -1434,10 +1434,6 @@ static void enc_pktif(FAR struct enc_driver_s *priv)
   uint16_t pktlen;
   uint16_t rxstat;
 
-  /* Update statistics */
-
-  NETDEV_RXPACKETS(&priv->dev);
-
   /* Set the read pointer to the start of the received packet (ERDPT) */
 
   DEBUGASSERT(priv->nextpkt <= PKTMEM_RX_END);
@@ -1505,6 +1501,10 @@ static void enc_pktif(FAR struct enc_driver_s *priv)
 
       enc_rxdispatch(priv);
     }
+
+  /* Update statistics */
+
+  NETDEV_RXPACKETS(&priv->dev);
 
   /* Move the RX read pointer to the start of the next received packet.
    * This frees the memory we just read.

--- a/drivers/net/netdev_upperhalf.c
+++ b/drivers/net/netdev_upperhalf.c
@@ -606,8 +606,6 @@ static void netdev_upper_rxpoll_work(FAR struct netdev_upperhalf_s *upper)
 
   while ((pkt = lower->ops->receive(lower)) != NULL)
     {
-      NETDEV_RXPACKETS(dev);
-
       if (!IFF_IS_UP(dev->d_flags))
         {
           /* Interface down, drop frame */
@@ -618,6 +616,7 @@ static void netdev_upper_rxpoll_work(FAR struct netdev_upperhalf_s *upper)
         }
 
       netpkt_put(dev, pkt, NETPKT_RX);
+      NETDEV_RXPACKETS(dev);
 
 #ifdef CONFIG_NET_PKT
       /* When packet sockets are enabled, feed the frame into the tap */

--- a/drivers/net/tun.c
+++ b/drivers/net/tun.c
@@ -271,7 +271,6 @@ static void tun_pollnotify(FAR struct tun_device_s *priv,
 
 static void tun_fd_transmit(FAR struct tun_device_s *priv)
 {
-  NETDEV_TXPACKETS(&priv->dev);
   tun_pollnotify(priv, POLLIN);
 }
 
@@ -307,6 +306,7 @@ static int tun_txpoll(FAR struct net_driver_s *dev)
 
   DEBUGASSERT(priv->read_buf == NULL);
 
+  NETDEV_TXPACKETS(dev);
 #ifdef CONFIG_NET_PKT
   /* When packet sockets are enabled, feed the frame into the tap */
 

--- a/drivers/net/w5500.c
+++ b/drivers/net/w5500.c
@@ -1104,13 +1104,13 @@ static void w5500_transmit(FAR struct w5500_driver_s *self)
   if (!w5500_txbuf_numfree(self))
     {
       ninfo("Dropping Tx packet due to no buffer available.\n");
-      NETDEV_TXERRORS(self->w_dev);
+      NETDEV_TXERRORS(&self->w_dev);
       return;
     }
 
   /* Increment statistics */
 
-  NETDEV_TXPACKETS(self->w_dev);
+  NETDEV_TXPACKETS(&self->w_dev);
 
   /* Copy packet data to TX buffer */
 
@@ -1457,7 +1457,7 @@ static void w5500_txdone(FAR struct w5500_driver_s *self)
 {
   /* Check for errors and update statistics */
 
-  NETDEV_TXDONE(self->w_dev);
+  NETDEV_TXDONE(&self->w_dev);
 
   /* Check if there are pending transmissions. */
 
@@ -1669,7 +1669,7 @@ static void w5500_txtimeout_work(FAR void *arg)
 
   /* Increment statistics and dump debug info */
 
-  NETDEV_TXTIMEOUTS(self->w_dev);
+  NETDEV_TXTIMEOUTS(&self->w_dev);
 
   /* Then reset the hardware */
 

--- a/include/nuttx/net/netdev.h
+++ b/include/nuttx/net/netdev.h
@@ -120,6 +120,11 @@
        } \
      while (0)
 
+#define _NETDEV_BYTES(dev,name) \
+    do { \
+        (dev)->d_statistics.name += (dev)->d_len; \
+    } while (0)
+
 #  if CONFIG_NETDEV_STATISTICS_LOG_PERIOD > 0
 #    define NETDEV_STATISTICS_WORK LPWORK
 #    define _NETDEV_STATISTIC_LOG(dev,name) \
@@ -139,7 +144,12 @@
 #    define _NETDEV_STATISTIC_LOG(dev,name) _NETDEV_STATISTIC(dev,name)
 #  endif
 
-#  define NETDEV_RXPACKETS(dev)   _NETDEV_STATISTIC_LOG(dev,rx_packets)
+#  define NETDEV_RXPACKETS(dev) \
+    do { \
+        _NETDEV_STATISTIC_LOG(dev,rx_packets); \
+        _NETDEV_BYTES(dev,rx_bytes); \
+    } while (0)
+
 #  define NETDEV_RXFRAGMENTS(dev) _NETDEV_STATISTIC(dev,rx_fragments)
 #  define NETDEV_RXERRORS(dev)    _NETDEV_ERROR(dev,rx_errors)
 #  ifdef CONFIG_NET_IPv4
@@ -159,11 +169,15 @@
 #  endif
 #  define NETDEV_RXDROPPED(dev)   _NETDEV_STATISTIC(dev,rx_dropped)
 
-#  define NETDEV_TXPACKETS(dev)   _NETDEV_STATISTIC_LOG(dev,tx_packets)
+#  define NETDEV_TXPACKETS(dev) \
+    do { \
+        _NETDEV_STATISTIC_LOG(dev,tx_packets); \
+        _NETDEV_BYTES(dev,tx_bytes); \
+    } while (0)
+
 #  define NETDEV_TXDONE(dev)      _NETDEV_STATISTIC(dev,tx_done)
 #  define NETDEV_TXERRORS(dev)    _NETDEV_ERROR(dev,tx_errors)
 #  define NETDEV_TXTIMEOUTS(dev)  _NETDEV_ERROR(dev,tx_timeouts)
-
 #  define NETDEV_ERRORS(dev)      _NETDEV_STATISTIC(dev,errors)
 
 #else
@@ -235,6 +249,7 @@ struct netdev_statistics_s
   uint32_t rx_arp;         /* Number of Rx ARP packets received */
 #endif
   uint32_t rx_dropped;     /* Unsupported Rx packets received */
+  uint64_t rx_bytes;       /* Number of bytes received */
 
   /* Tx Status */
 
@@ -242,6 +257,7 @@ struct netdev_statistics_s
   uint32_t tx_done;        /* Number of packets completed */
   uint32_t tx_errors;      /* Number of receive errors (incl timeouts) */
   uint32_t tx_timeouts;    /* Number of Tx timeout errors */
+  uint64_t tx_bytes;       /* Number of bytes send */
 
   /* Other status */
 

--- a/net/netdev/netdev_stats.c
+++ b/net/netdev/netdev_stats.c
@@ -57,11 +57,11 @@ void netdev_statistics_log(FAR void *arg)
   FAR struct net_driver_s *dev = arg;
   FAR struct netdev_statistics_s *stats = &dev->d_statistics;
 
-  stats_log("%s:T%" PRIu32 "/%" PRIu32 ",R"
+  stats_log("%s:T%" PRIu32 "/%" PRIu32 "(%" PRIu64 "B)" ",R"
 #if defined(CONFIG_NET_IPv4) && defined(CONFIG_NET_IPv6)
             "(%" PRIu32 "+%" PRIu32 ")/"
 #endif
-            "%" PRIu32
+            "%" PRIu32 "(%" PRIu64 "B)"
 #ifdef CONFIG_NET_TCP
             " TCP:T%" PRIu16 ",R%" PRIu16 ",D%" PRIu16
 #endif
@@ -75,11 +75,12 @@ void netdev_statistics_log(FAR void *arg)
             " ICMP6:T%" PRIu16 ",R%" PRIu16 ",D%" PRIu16
 #endif
             "\n",
-            dev->d_ifname, stats->tx_done, stats->tx_packets
+            dev->d_ifname,
+            stats->tx_done, stats->tx_packets, stats->tx_bytes
 #if defined(CONFIG_NET_IPv4) && defined(CONFIG_NET_IPv6)
             , stats->rx_ipv4, stats->rx_ipv6
 #endif
-            , stats->rx_packets
+            , stats->rx_packets, stats->rx_bytes
 #ifdef CONFIG_NET_TCP
             , g_netstats.tcp.sent, g_netstats.tcp.recv, g_netstats.tcp.drop
 #endif

--- a/net/procfs/netdev_statistics.c
+++ b/net/procfs/netdev_statistics.c
@@ -410,8 +410,8 @@ static int netprocfs_rxstatistics_header(
     FAR struct netprocfs_file_s *netfile)
 {
   DEBUGASSERT(netfile != NULL);
-  return snprintf(netfile->line, NET_LINELEN , "\tRX: %-8s %-8s %-8s\n",
-                  "Received", "Fragment", "Errors");
+  return snprintf(netfile->line, NET_LINELEN , "\tRX: %-8s %-8s %-8s %-8s\n",
+                  "Received", "Fragment", "Errors", "Bytes");
 }
 #endif /* CONFIG_NETDEV_STATISTICS */
 
@@ -429,10 +429,12 @@ static int netprocfs_rxstatistics(FAR struct netprocfs_file_s *netfile)
   dev = netfile->dev;
   stats = &dev->d_statistics;
 
-  return snprintf(netfile->line, NET_LINELEN, "\t    %08lx %08lx %08lx\n",
+  return snprintf(netfile->line, NET_LINELEN, \
+                  "\t    %08lx %08lx %08lx %-16llx\n",
                   (unsigned long)stats->rx_packets,
                   (unsigned long)stats->rx_fragments,
-                  (unsigned long)stats->rx_errors);
+                  (unsigned long)stats->rx_errors,
+                  (unsigned long long)stats->rx_bytes);
 }
 #endif /* CONFIG_NETDEV_STATISTICS */
 
@@ -524,8 +526,9 @@ static int netprocfs_txstatistics_header(
 {
   DEBUGASSERT(netfile != NULL);
 
-  return snprintf(netfile->line, NET_LINELEN, "\tTX: %-8s %-8s %-8s %-8s\n",
-                 "Queued", "Sent", "Errors", "Timeouts");
+  return snprintf(netfile->line, NET_LINELEN,
+                 "\tTX: %-8s %-8s %-8s %-8s %-8s\n",
+                 "Queued", "Sent", "Errors", "Timeouts", "Bytes");
 }
 #endif /* CONFIG_NETDEV_STATISTICS */
 
@@ -544,11 +547,12 @@ static int netprocfs_txstatistics(FAR struct netprocfs_file_s *netfile)
   stats = &dev->d_statistics;
 
   return snprintf(netfile->line, NET_LINELEN,
-                  "\t    %08lx %08lx %08lx %08lx\n",
+                  "\t    %08lx %08lx %08lx %08lx %-16llx \n",
                   (unsigned long)stats->tx_packets,
                   (unsigned long)stats->tx_done,
                   (unsigned long)stats->tx_errors,
-                  (unsigned long)stats->tx_timeouts);
+                  (unsigned long)stats->tx_timeouts,
+                  (unsigned long long)stats->tx_bytes);
 }
 #endif /* CONFIG_NETDEV_STATISTICS */
 


### PR DESCRIPTION
## Summary
Patches included:
- net/netstatistics: add tx/rx bytes statistics for dev
- netdev/statistics: Add bytes for netdev statistics log

We can see them in ifconfig:
```
ap> ifconfig
wlan0   Link encap:Ethernet HWaddr 42:64:7f:b3:12:03 at UP mtu 1500
        inet addr:10.0.1.2 DRaddr:10.0.1.1 Mask:255.255.255.0
        inet6 DRaddr: ::

        RX: Received Fragment Errors   Bytes
            00000b9b 00000000 00000000 21daf5
            IPv4     IPv6     ARP      Dropped
            00000a33 00000137 00000031 00000000
        TX: Queued   Sent     Errors   Timeouts Bytes
            00000ac4 00000ac4 00000000 00000000 1a2103
        Total Errors: 00000000
```
Now the periodic log looks like:
```
wlan0:T2758/2758(1712845B),R(2613+311)/2973(2219171B) ...
```

## Impact
Add bytes for netdev statistics.

## Testing
Manually, like examples above.
