### PR TITLE
cmake: migrate to SPDX identifier

### DIFF
--- a/cmake/menuconfig.cmake
+++ b/cmake/menuconfig.cmake
@@ -1,6 +1,8 @@
 # ##############################################################################
 # cmake/menuconfig.cmake
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/cmake/nuttx_add_application.cmake
+++ b/cmake/nuttx_add_application.cmake
@@ -1,6 +1,8 @@
 # ##############################################################################
 # cmake/nuttx_add_application.cmake
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/cmake/nuttx_add_dependencies.cmake
+++ b/cmake/nuttx_add_dependencies.cmake
@@ -1,6 +1,8 @@
 # ##############################################################################
 # cmake/nuttx_add_dependencies.cmake
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/cmake/nuttx_add_library.cmake
+++ b/cmake/nuttx_add_library.cmake
@@ -1,6 +1,8 @@
 # ##############################################################################
 # cmake/nuttx_add_library.cmake
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/cmake/nuttx_add_module.cmake
+++ b/cmake/nuttx_add_module.cmake
@@ -1,6 +1,8 @@
 # ##############################################################################
 # cmake/nuttx_add_module.cmake
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/cmake/nuttx_add_romfs.cmake
+++ b/cmake/nuttx_add_romfs.cmake
@@ -1,6 +1,8 @@
 # ##############################################################################
 # cmake/nuttx_add_romfs.cmake
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/cmake/nuttx_add_subdirectory.cmake
+++ b/cmake/nuttx_add_subdirectory.cmake
@@ -1,6 +1,8 @@
 # ##############################################################################
 # cmake/nuttx_add_subdirectory.cmake
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/cmake/nuttx_add_symtab.cmake
+++ b/cmake/nuttx_add_symtab.cmake
@@ -1,6 +1,8 @@
 # ##############################################################################
 # cmake/nuttx_add_symtab.cmake
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/cmake/nuttx_allsyms.cmake
+++ b/cmake/nuttx_allsyms.cmake
@@ -1,6 +1,8 @@
 # ##############################################################################
 # cmake/nuttx_allsyms.cmake
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/cmake/nuttx_create_symlink.cmake
+++ b/cmake/nuttx_create_symlink.cmake
@@ -1,6 +1,8 @@
 # ##############################################################################
 # cmake/nuttx_create_symlink.cmake
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/cmake/nuttx_export_header.cmake
+++ b/cmake/nuttx_export_header.cmake
@@ -1,6 +1,8 @@
 # ##############################################################################
 # cmake/nuttx_export_header.cmake
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/cmake/nuttx_generate_headers.cmake
+++ b/cmake/nuttx_generate_headers.cmake
@@ -1,6 +1,8 @@
 # ##############################################################################
 # cmake/nuttx_generate_headers.cmake
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/cmake/nuttx_generate_outputs.cmake
+++ b/cmake/nuttx_generate_outputs.cmake
@@ -1,6 +1,8 @@
 # ##############################################################################
 # cmake/nuttx_generate_outputs.cmake
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/cmake/nuttx_kconfig.cmake
+++ b/cmake/nuttx_kconfig.cmake
@@ -1,6 +1,8 @@
 # ##############################################################################
 # cmake/nuttx_kconfig.cmake
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/cmake/nuttx_mkconfig.cmake
+++ b/cmake/nuttx_mkconfig.cmake
@@ -1,6 +1,8 @@
 # ##############################################################################
 # cmake/nuttx_mkconfig.cmake
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/cmake/nuttx_mkversion.cmake
+++ b/cmake/nuttx_mkversion.cmake
@@ -1,6 +1,8 @@
 # ##############################################################################
 # cmake/nuttx_mkversion.cmake
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/cmake/nuttx_parse_function_args.cmake
+++ b/cmake/nuttx_parse_function_args.cmake
@@ -1,6 +1,8 @@
 # ##############################################################################
 # cmake/nuttx_parse_function_args.cmake
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/cmake/nuttx_redefine_symbols.cmake
+++ b/cmake/nuttx_redefine_symbols.cmake
@@ -1,6 +1,8 @@
 # ##############################################################################
 # cmake/nuttx_redefine_symbols.cmake
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/cmake/nuttx_sethost.cmake
+++ b/cmake/nuttx_sethost.cmake
@@ -1,6 +1,8 @@
 # ##############################################################################
 # cmake/nuttx_sethost.cmake
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/cmake/nuttx_source_file_properties.cmake
+++ b/cmake/nuttx_source_file_properties.cmake
@@ -1,6 +1,8 @@
 # ##############################################################################
 # cmake/nuttx_source_file_properties.cmake
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/cmake/savedefconfig.cmake
+++ b/cmake/savedefconfig.cmake
@@ -1,6 +1,8 @@
 # ##############################################################################
 # cmake/savedefconfig.cmake
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/cmake/symtab.c.in
+++ b/cmake/symtab.c.in
@@ -1,6 +1,8 @@
 /****************************************************************************
  * cmake/symtab.c.in
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The


### PR DESCRIPTION
## Summary
Most tools used for compliance and SBOM generation use SPDX identifiers 
This change brings us a step closer to an easy SBOM generation.

## Impact
SBOM

## Testing
CI
