### PR TITLE
build: fix memory manager compile options for CMake

### DIFF
--- a/mm/kasan/CMakeLists.txt
+++ b/mm/kasan/CMakeLists.txt
@@ -19,7 +19,11 @@
 # ##############################################################################
 if(CONFIG_MM_KASAN)
   target_sources(mm PRIVATE kasan.c)
-  set_source_files_properties(kasan.c PROPERTIES COMPILE_FLAGS
-                                                 -fno-sanitize=kernel-address)
-  set_source_files_properties(kasan.c PROPERTIES COMPILE_FLAGS -fno-lto)
+
+  target_compile_options(mm PRIVATE -fno-sanitize=kernel-address)
+
+  if(NOT CONFIG_LTO_NONE)
+    target_compile_options(mm PRIVATE -fno-lto)
+  endif()
+
 endif()


### PR DESCRIPTION
## Summary

This enables CMake based build for sim:ostest. Flags which are set by set_source_files_properties are not reflected in final build. Changing these to target_compile_options makes CMake build runnable.

## Impact

CMake based build for sim:ostest now runs.

## Testing

Local build and playing around sim:ostest

