### PR TITLE
smartfs procfs: fix double declare g_smartfs_operations

### DIFF
--- a/fs/procfs/fs_procfs.c
+++ b/fs/procfs/fs_procfs.c
@@ -81,7 +81,7 @@ extern const struct procfs_operations g_mount_operations;
 extern const struct procfs_operations g_net_operations;
 extern const struct procfs_operations g_netroute_operations;
 extern const struct procfs_operations g_part_operations;
-extern const struct procfs_operations g_smartfs_operations;
+extern const struct procfs_operations g_smartfs_procfs_operations;
 
 /****************************************************************************
  * Private Types
@@ -130,7 +130,7 @@ static const struct procfs_entry_s g_procfs_entries[] =
 #endif
 
 #if defined(CONFIG_FS_SMARTFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_SMARTFS)
-  { "fs/smartfs**", &g_smartfs_operations,  PROCFS_UNKOWN_TYPE },
+  { "fs/smartfs**", &g_smartfs_procfs_operations,  PROCFS_UNKOWN_TYPE },
 #endif
 
 #ifndef CONFIG_FS_PROCFS_EXCLUDE_USAGE

--- a/fs/smartfs/smartfs_procfs.c
+++ b/fs/smartfs/smartfs_procfs.c
@@ -168,7 +168,7 @@ static const uint8_t g_direntrycount = sizeof(g_direntry) /
  * with any compiler.
  */
 
-const struct procfs_operations g_smartfs_operations =
+const struct procfs_operations g_smartfs_procfs_operations =
 {
   smartfs_open,       /* open */
   smartfs_close,      /* close */
@@ -349,7 +349,7 @@ static int smartfs_open(FAR struct file *filep, FAR const char *relpath,
    */
 
   if (((oflags & O_WRONLY) != 0 || (oflags & O_RDONLY) == 0) &&
-      (g_smartfs_operations.write == NULL))
+      (g_smartfs_procfs_operations.write == NULL))
     {
       ferr("ERROR: Only O_RDONLY supported\n");
       return -EACCES;


### PR DESCRIPTION
## Summary

If we activate SMARTFS and go to _/proc/fs/smartfs_, we will get a kernel panic:
[dump.txt](https://github.com/user-attachments/files/16936111/dump.txt)

In it we will see _smartfs_dup: Dup 0x3fc8ce1e->0x3fc8c8d0_, the **smartfs_dup** function was called, but not from _smartfs_proc.c_, but from _smartfs_smart.c_

The 'g_smartfs_operations'
`extern const struct mountpt_operations g_smartfs_operations;` was declare into:
- fs/mount/fs_mount.c
- fs/procfs/fs_procfs.c

## Impact

The function **g_smartfs_operations** was renamed to **g_smartfs_procfs_operations** into file _fs/procfs/fs_procfs.c_.

## Testing

`cd /proc/fs/smartfs`
and
`cat status`
