### PR TITLE
net/udp: Fixed the issue of sending ICMP error when the destination address is broadcast/multicast.

### DIFF
--- a/net/udp/udp_input.c
+++ b/net/udp/udp_input.c
@@ -77,7 +77,7 @@
  *
  ****************************************************************************/
 
-#if defined(CONFIG_NET_SOCKOPTS) && defined(CONFIG_NET_BROADCAST)
+#ifdef CONFIG_NET_BROADCAST
 static bool udp_is_broadcast(FAR struct net_driver_s *dev)
 {
   /* Check if the destination address is a broadcast/multicast address */
@@ -329,6 +329,16 @@ static int udp_input(FAR struct net_driver_s *dev, unsigned int iplen)
 
           ret = udp_input_conn(dev, conn, udpiplen);
         }
+#ifdef CONFIG_NET_BROADCAST
+      else if (udp_is_broadcast(dev))
+        {
+          /* Due to RFC 1112, Section 7.2, we don't reply ICMP error
+           * message when the destination address is broadcast/multicast.
+           */
+
+          dev->d_len = 0;
+        }
+#endif
       else
         {
           nwarn("WARNING: No listener on UDP port\n");


### PR DESCRIPTION

## Summary

We don't reply ICMP error message when the destination address is broadcast/multicast.

According to rfc1112, section 7.2:
"An ICMP error message (Destination Unreachable, Time Exceeded, Parameter Problem, Source Quench, or Redirect) is never generated in response to a datagram destined to an IP host group."

## Impact

Response to udp broadcast and multicast.

## Testing
Local packet capture verification.
