### PR TITLE
fs: support VFS-based named event group

### DIFF
--- a/Documentation/reference/os/events.rst
+++ b/Documentation/reference/os/events.rst
@@ -115,3 +115,43 @@ Notifier Chain Interfaces
   :param event: Address of the event object
   :param events: Set of events to wait, 0 will indicate wait from any events
   :param eflags: Events flags
+
+.. c:function:: int nxevent_open(FAR nxevent_t **event, FAR const char *name, int oflags, ...)
+
+  This function establishes a connection between named event groups and a
+  task. the task may reference the event group associated with name using
+  the address returned by this call. The event group may be used in a
+  subsequent calls to nxevent_wait(), or nxevent_post(). And the event
+  group remains usable until the event group is closed by a successful
+  call to nxevent_close().
+
+  If a task makes multiple calls to event_open() with the same name, then
+  the same event group address is returned.
+
+  :param event: Location to return the event group reference.
+  :param name: Event group name.
+  :param oflags: Event group creation options. This may the following settings:
+
+    -  ``oflags`` = 0: Connect to the event group only if it already exists.
+    -  ``oflags`` = O_CREAT: Connect to the event group if it exists, otherwise create the event group.
+    -  ``oflags`` = O_CREAT|O_EXCL: Create a new event group unless already exists.
+
+  :param ...: Optional parameters. When the O_CREAT flag is specified,
+              the two optional parameters are expected:
+
+    -  ``mode``: The mode parameter is of type mode_t. This parameter is
+        required but not used in the present implementation.
+    -  ``events``: The events parameter is type unsigned. The event group
+        is created with an initial value of ``events``.
+
+  :return: 0 (OK), or negated errno if unsuccessful.
+
+.. c:function:: int nxevent_close(FAR nxevent_t *event)
+
+    This function is called to indicate that the calling task is finished
+    with the specified named event group. The event_close() deallocates
+    any system resources allocated by the system for this named event group.
+
+  :param event: event descriptor
+
+  :return: 0 (OK), or negated errno if unsuccessful.

--- a/fs/Kconfig
+++ b/fs/Kconfig
@@ -137,6 +137,7 @@ config FS_REFCOUNT
 source "fs/vfs/Kconfig"
 source "fs/aio/Kconfig"
 source "fs/semaphore/Kconfig"
+source "fs/event/Kconfig"
 source "fs/mqueue/Kconfig"
 source "fs/shm/Kconfig"
 source "fs/mmap/Kconfig"

--- a/fs/Makefile
+++ b/fs/Makefile
@@ -38,6 +38,7 @@ include semaphore/Make.defs
 include mqueue/Make.defs
 include shm/Make.defs
 include socket/Make.defs
+include event/Make.defs
 
 # Additional files required is mount-able file systems are supported
 

--- a/fs/event/CMakeLists.txt
+++ b/fs/event/CMakeLists.txt
@@ -1,0 +1,25 @@
+# ##############################################################################
+# fs/event/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_FS_NAMED_EVENTS)
+
+  target_sources(fs PRIVATE event_open.c event_close.c)
+
+endif()

--- a/fs/event/Kconfig
+++ b/fs/event/Kconfig
@@ -1,0 +1,21 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config FS_NAMED_EVENTS
+	bool "Named event group support"
+	default n
+	depends on SCHED_EVENTS
+	---help---
+		Include support for named event group.
+
+if FS_NAMED_EVENTS
+
+config FS_NAMED_EVENTS_VFS_PATH
+	string "Path to event group storage"
+	default "/var/event"
+	---help---
+		The path to where named event group will exist in the VFS namespace.
+
+endif # FS_NAMED_EVENTS

--- a/fs/event/Make.defs
+++ b/fs/event/Make.defs
@@ -1,0 +1,31 @@
+############################################################################
+# fs/events/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+# Include named event support
+
+ifeq ($(CONFIG_FS_NAMED_EVENTS),y)
+
+CSRCS += event_open.c event_close.c
+
+# Include named event build support
+
+DEPPATH += --dep-path event
+VPATH += :event
+endif

--- a/fs/event/event.h
+++ b/fs/event/event.h
@@ -1,0 +1,57 @@
+/****************************************************************************
+ * fs/event/event.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __FS_EVENT_EVENT_H
+#define __FS_EVENT_EVENT_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define MAX_EVENTPATH 64
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __FS_EVENT_EVENT_H */

--- a/fs/event/event_close.c
+++ b/fs/event/event_close.c
@@ -1,0 +1,97 @@
+/****************************************************************************
+ * fs/event/event_close.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sched.h>
+#include <assert.h>
+#include <errno.h>
+
+#include <nuttx/event.h>
+#include <nuttx/fs/fs.h>
+
+#include "inode/inode.h"
+#include "notify/notify.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name:  nxevent_close
+ *
+ * Description:
+ *   This function is called to indicate that the calling task is finished
+ *   with the specified named event group. The event_close() deallocates
+ *   any system resources allocated by the system for this named event.
+ *
+ * Input Parameters:
+ *  event - event descriptor
+ *
+ * Returned Value:
+ *  0 (OK), or negated errno if unsuccessful.
+ *
+ * Assumptions:
+ *   - Care must be taken to avoid risking the deletion of a event that
+ *     another calling task has already locked.
+ *   - event_close must not be called for an un-named event
+ *
+ ****************************************************************************/
+
+int nxevent_close(FAR nxevent_t *event)
+{
+  FAR struct nevent_inode_s *nevent;
+  struct inode *inode;
+
+  DEBUGASSERT(event);
+
+  /* Upcast to get back to out internal representation */
+
+  nevent = (FAR struct nevent_inode_s *)event;
+  DEBUGASSERT(nevent->ne_inode);
+  inode = nevent->ne_inode;
+
+  /* If the event group was previously unlinked and the reference count has
+   * decremented to zero, then release the event group and delete the inode
+   * now.
+   */
+
+  if (atomic_fetch_sub(&inode->i_crefs, 1) <= 1)
+    {
+      nxevent_destroy(&nevent->ne_event);
+      group_free(NULL, nevent);
+
+      /* Release and free the inode container.  If it has been properly
+       * unlinked, then the peer pointer should be NULL.
+       */
+
+#ifdef CONFIG_FS_NOTIFY
+      notify_close2(inode);
+#endif
+      DEBUGASSERT(inode->i_peer == NULL);
+      inode_free(inode);
+    }
+
+  return OK;
+}

--- a/fs/event/event_open.c
+++ b/fs/event/event_open.c
@@ -1,0 +1,215 @@
+/****************************************************************************
+ * fs/event/event_open.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/stat.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <fcntl.h>
+
+#include <nuttx/kmalloc.h>
+#include <nuttx/event.h>
+#include <nuttx/fs/fs.h>
+
+#include "inode/inode.h"
+#include "notify/notify.h"
+#include "event/event.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: nxevent_open
+ *
+ * Description:
+ *   This function establishes a connection between named event groups and a
+ *   task. the task may reference the event group associated with name using
+ *   the address returned by this call. The event group may be used in a
+ *   subsequent calls to nxevent_wait(), or nxevent_post(). And the event
+ *   group remains usable until the event group is closed by a successful
+ *   call to nxevent_close().
+ *
+ *   If a task makes multiple calls to event_open() with the same name, then
+ *   the same event group address is returned.
+ *
+ * Input Parameters:
+ *   event  - Location to return the event group reference.
+ *   name   - event group name.
+ *   oflags - event group creation options.  This may either or both of the
+ *     following bit settings.
+ *     oflags = 0:  Connect to the event group only if it already exists.
+ *     oflags = O_CREAT:  Connect to the event group if it exists, otherwise
+ *        create the event group.
+ *     oflags = O_CREAT|O_EXCL:  Create a new event group unless
+ *        already exists.
+ *   Optional parameters.  When the O_CREAT flag is specified, two optional
+ *     parameters are expected:
+ *     1. mode_t mode, is required but not used in the present
+ *     implementation.
+ *     2. unsigned events. The event group is created with an initial
+ *     value of events.
+ *
+ * Returned Value:
+ *   0 (OK), or negated errno if unsuccessful.
+ *
+ * Assumptions:
+ *
+ ****************************************************************************/
+
+int nxevent_open(FAR nxevent_t **event, FAR const char *name,
+                 int oflags, ...)
+{
+  FAR struct inode *inode;
+  FAR struct nevent_inode_s *nevent;
+  struct inode_search_s desc;
+  char fullpath[MAX_EVENTPATH];
+  mode_t mode;
+  nxevent_mask_t events = 0;
+  int ret;
+
+  /* Get the full path to the  */
+
+  snprintf(fullpath, MAX_EVENTPATH,
+           CONFIG_FS_NAMED_EVENTS_VFS_PATH "/%s", name);
+
+  /* Get the inode for this event group.  This should succeed if the
+   * event group has already been created.  In this case, inode_find()
+   * will have incremented the reference count on the inode.
+   */
+
+  SETUP_SEARCH(&desc, fullpath, false);
+
+  ret = inode_find(&desc);
+  if (ret >= 0)
+    {
+      /* Something exists at this path.  Get the search results */
+
+      inode = desc.node;
+
+      /* Verify that the inode is a event group */
+
+      if (!INODE_IS_NAMEDEVENT(inode))
+        {
+          ret = -ENXIO;
+          goto errout_with_inode;
+        }
+
+      /* It exists and is a event group.  Check if the caller wanted to
+       * create a new event group with this name.
+       */
+
+      if ((oflags & (O_CREAT | O_EXCL)) == (O_CREAT | O_EXCL))
+        {
+          ret = -EEXIST;
+          goto errout_with_inode;
+        }
+
+      /* Return a reference to the event group, retaining the reference
+       * count on the inode.
+       */
+
+      *event = &inode->u.i_nevent->ne_event;
+    }
+  else
+    {
+      va_list ap;
+
+      /* The event group does not exists.  Were we asked to create it? */
+
+      if ((oflags & O_CREAT) == 0)
+        {
+          /* The event group does not exist and O_CREAT is not set */
+
+          ret = -ENOENT;
+          goto errout_with_search;
+        }
+
+      /* Create the event group.  First we have to extract the additional
+       * parameters from the variable argument list.
+       * REVISIT:  Mode parameter is not currently used.
+       */
+
+      va_start(ap, oflags);
+      mode  = va_arg(ap, mode_t) & ~getumask();
+      events = va_arg(ap, nxevent_mask_t);
+      va_end(ap);
+
+      /* Create an inode in the pseudo-filesystem at this path.  The new
+       * inode will be created with a reference count of zero.
+       */
+
+      inode_lock();
+      ret = inode_reserve(fullpath, mode, &inode);
+      inode_unlock();
+
+      if (ret < 0)
+        {
+          goto errout_with_search;
+        }
+
+      /* Allocate the event group structure (using the appropriate allocator
+       * for the group)
+       */
+
+      nevent = group_malloc(NULL, sizeof(struct nevent_inode_s));
+      if (!nevent)
+        {
+          ret = -ENOMEM;
+          goto errout_with_inode;
+        }
+
+      /* Link to the inode */
+
+      inode->u.i_nevent = nevent;
+      nevent->ne_inode  = inode;
+
+      /* Initialize the inode */
+
+      INODE_SET_NAMEDEVENT(inode);
+      atomic_fetch_add(&inode->i_crefs, 1);
+
+      /* Initialize the event groups */
+
+      nxevent_init(&nevent->ne_event, events);
+
+      /* Return a reference to the event groups */
+
+      *event = &nevent->ne_event;
+    }
+
+  RELEASE_SEARCH(&desc);
+#ifdef CONFIG_FS_NOTIFY
+  notify_open(fullpath, oflags);
+#endif
+  return OK;
+
+errout_with_inode:
+  inode_release(inode);
+
+errout_with_search:
+  RELEASE_SEARCH(&desc);
+  return ret;
+}

--- a/fs/semaphore/sem_open.c
+++ b/fs/semaphore/sem_open.c
@@ -153,7 +153,7 @@ int nxsem_open(FAR sem_t **sem, FAR const char *name, int oflags, ...)
           /* The semaphore does not exist and O_CREAT is not set */
 
           ret = -ENOENT;
-          goto errout_with_lock;
+          goto errout_with_search;
         }
 
       /* Create the semaphore.  First we have to extract the additional
@@ -171,7 +171,7 @@ int nxsem_open(FAR sem_t **sem, FAR const char *name, int oflags, ...)
       if (value > SEM_VALUE_MAX)
         {
           ret = -EINVAL;
-          goto errout_with_lock;
+          goto errout_with_search;
         }
 
       /* Create an inode in the pseudo-filesystem at this path.  The new
@@ -184,7 +184,7 @@ int nxsem_open(FAR sem_t **sem, FAR const char *name, int oflags, ...)
 
       if (ret < 0)
         {
-          goto errout_with_lock;
+          goto errout_with_search;
         }
 
       /* Allocate the semaphore structure (using the appropriate allocator
@@ -226,7 +226,7 @@ int nxsem_open(FAR sem_t **sem, FAR const char *name, int oflags, ...)
 errout_with_inode:
   inode_release(inode);
 
-errout_with_lock:
+errout_with_search:
   RELEASE_SEARCH(&desc);
   return ret;
 }

--- a/include/nuttx/event.h
+++ b/include/nuttx/event.h
@@ -64,6 +64,17 @@ struct nxevent_s
   volatile nxevent_mask_t  events;  /* Pending Events */
 };
 
+#ifdef CONFIG_FS_NAMED_EVENTS
+/* This is the named event inode */
+
+struct inode;
+struct nevent_inode_s
+{
+  nxevent_t         ne_event;
+  FAR struct inode *ne_inode;
+};
+#endif
+
 /****************************************************************************
  * Public Data
  ****************************************************************************/
@@ -251,6 +262,70 @@ nxevent_mask_t nxevent_tickwait(FAR nxevent_t *event, nxevent_mask_t events,
 
 nxevent_mask_t nxevent_trywait(FAR nxevent_t *event, nxevent_mask_t events,
                                nxevent_flags_t eflags);
+
+/****************************************************************************
+ * Name: nxevent_open
+ *
+ * Description:
+ *   This function establishes a connection between named event groups and a
+ *   task. the task may reference the event group associated with name using
+ *   the address returned by this call. The event group may be used in a
+ *   subsequent calls to nxevent_wait(), or nxevent_post(). And the event
+ *   group remains usable until the event group is closed by a successful
+ *   call to nxevent_close().
+ *
+ *   If a task makes multiple calls to event_open() with the same name, then
+ *   the same event group address is returned.
+ *
+ * Input Parameters:
+ *   event  - Location to return the event group reference.
+ *   name   - event group name.
+ *   oflags - event group creation options.  This may either or both of the
+ *     following bit settings.
+ *     oflags = 0:  Connect to the event group only if it already exists.
+ *     oflags = O_CREAT:  Connect to the event group if it exists, otherwise
+ *        create the event group.
+ *     oflags = O_CREAT|O_EXCL:  Create a new event group unless
+ *        already exists.
+ *   Optional parameters.  When the O_CREAT flag is specified, two optional
+ *     parameters are expected:
+ *     1. mode_t mode, is required but not used in the present
+ *     implementation.
+ *     2. unsigned events. The event group is created with an initial
+ *     value of events.
+ *
+ * Returned Value:
+ *   0 (OK), or negated errno if unsuccessful.
+ *
+ * Assumptions:
+ *
+ ****************************************************************************/
+
+int nxevent_open(FAR nxevent_t **event, FAR const char *name,
+                 int oflags, ...);
+
+/****************************************************************************
+ * Name:  nxevent_close
+ *
+ * Description:
+ *   This function is called to indicate that the calling task is finished
+ *   with the specified named event group. The event_close() deallocates
+ *   any system resources allocated by the system for this named event.
+ *
+ * Input Parameters:
+ *  event - event descriptor
+ *
+ * Returned Value:
+ *  0 (OK), or negated errno if unsuccessful.
+ *
+ * Assumptions:
+ *   - Care must be taken to avoid risking the deletion of a event that
+ *     another calling task has already locked.
+ *   - event_close must not be called for an un-named event
+ *
+ ****************************************************************************/
+
+int nxevent_close(FAR nxevent_t *event);
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -109,33 +109,35 @@
  *   Bit 4:   Set if inode has been unlinked and is pending removal.
  */
 
-#define FSNODEFLAG_TYPE_MASK        0x0000000f /* Isolates type field      */
-#define   FSNODEFLAG_TYPE_PSEUDODIR 0x00000000 /*   Pseudo dir (default)   */
-#define   FSNODEFLAG_TYPE_DRIVER    0x00000001 /*   Character driver       */
-#define   FSNODEFLAG_TYPE_BLOCK     0x00000002 /*   Block driver           */
-#define   FSNODEFLAG_TYPE_MOUNTPT   0x00000003 /*   Mount point            */
-#define   FSNODEFLAG_TYPE_NAMEDSEM  0x00000004 /*   Named semaphore        */
-#define   FSNODEFLAG_TYPE_MQUEUE    0x00000005 /*   Message Queue          */
-#define   FSNODEFLAG_TYPE_SHM       0x00000006 /*   Shared memory region   */
-#define   FSNODEFLAG_TYPE_MTD       0x00000007 /*   Named MTD driver       */
-#define   FSNODEFLAG_TYPE_SOFTLINK  0x00000008 /*   Soft link              */
-#define   FSNODEFLAG_TYPE_SOCKET    0x00000009 /*   Socket                 */
-#define   FSNODEFLAG_TYPE_PIPE      0x0000000a /*   Pipe                   */
+#define FSNODEFLAG_TYPE_MASK         0x0000000f /* Isolates type field      */
+#define   FSNODEFLAG_TYPE_PSEUDODIR  0x00000000 /*   Pseudo dir (default)   */
+#define   FSNODEFLAG_TYPE_DRIVER     0x00000001 /*   Character driver       */
+#define   FSNODEFLAG_TYPE_BLOCK      0x00000002 /*   Block driver           */
+#define   FSNODEFLAG_TYPE_MOUNTPT    0x00000003 /*   Mount point            */
+#define   FSNODEFLAG_TYPE_NAMEDSEM   0x00000004 /*   Named semaphore        */
+#define   FSNODEFLAG_TYPE_MQUEUE     0x00000005 /*   Message Queue          */
+#define   FSNODEFLAG_TYPE_SHM        0x00000006 /*   Shared memory region   */
+#define   FSNODEFLAG_TYPE_MTD        0x00000007 /*   Named MTD driver       */
+#define   FSNODEFLAG_TYPE_SOFTLINK   0x00000008 /*   Soft link              */
+#define   FSNODEFLAG_TYPE_SOCKET     0x00000009 /*   Socket                 */
+#define   FSNODEFLAG_TYPE_PIPE       0x0000000a /*   Pipe                   */
+#define   FSNODEFLAG_TYPE_NAMEDEVENT 0x0000000b /*   Named event group      */
 
 #define INODE_IS_TYPE(i,t) \
   (((i)->i_flags & FSNODEFLAG_TYPE_MASK) == (t))
 
-#define INODE_IS_PSEUDODIR(i) INODE_IS_TYPE(i,FSNODEFLAG_TYPE_PSEUDODIR)
-#define INODE_IS_DRIVER(i)    INODE_IS_TYPE(i,FSNODEFLAG_TYPE_DRIVER)
-#define INODE_IS_BLOCK(i)     INODE_IS_TYPE(i,FSNODEFLAG_TYPE_BLOCK)
-#define INODE_IS_MOUNTPT(i)   INODE_IS_TYPE(i,FSNODEFLAG_TYPE_MOUNTPT)
-#define INODE_IS_NAMEDSEM(i)  INODE_IS_TYPE(i,FSNODEFLAG_TYPE_NAMEDSEM)
-#define INODE_IS_MQUEUE(i)    INODE_IS_TYPE(i,FSNODEFLAG_TYPE_MQUEUE)
-#define INODE_IS_SHM(i)       INODE_IS_TYPE(i,FSNODEFLAG_TYPE_SHM)
-#define INODE_IS_MTD(i)       INODE_IS_TYPE(i,FSNODEFLAG_TYPE_MTD)
-#define INODE_IS_SOFTLINK(i)  INODE_IS_TYPE(i,FSNODEFLAG_TYPE_SOFTLINK)
-#define INODE_IS_SOCKET(i)    INODE_IS_TYPE(i,FSNODEFLAG_TYPE_SOCKET)
-#define INODE_IS_PIPE(i)      INODE_IS_TYPE(i,FSNODEFLAG_TYPE_PIPE)
+#define INODE_IS_PSEUDODIR(i)  INODE_IS_TYPE(i,FSNODEFLAG_TYPE_PSEUDODIR)
+#define INODE_IS_DRIVER(i)     INODE_IS_TYPE(i,FSNODEFLAG_TYPE_DRIVER)
+#define INODE_IS_BLOCK(i)      INODE_IS_TYPE(i,FSNODEFLAG_TYPE_BLOCK)
+#define INODE_IS_MOUNTPT(i)    INODE_IS_TYPE(i,FSNODEFLAG_TYPE_MOUNTPT)
+#define INODE_IS_NAMEDSEM(i)   INODE_IS_TYPE(i,FSNODEFLAG_TYPE_NAMEDSEM)
+#define INODE_IS_MQUEUE(i)     INODE_IS_TYPE(i,FSNODEFLAG_TYPE_MQUEUE)
+#define INODE_IS_SHM(i)        INODE_IS_TYPE(i,FSNODEFLAG_TYPE_SHM)
+#define INODE_IS_MTD(i)        INODE_IS_TYPE(i,FSNODEFLAG_TYPE_MTD)
+#define INODE_IS_SOFTLINK(i)   INODE_IS_TYPE(i,FSNODEFLAG_TYPE_SOFTLINK)
+#define INODE_IS_SOCKET(i)     INODE_IS_TYPE(i,FSNODEFLAG_TYPE_SOCKET)
+#define INODE_IS_PIPE(i)       INODE_IS_TYPE(i,FSNODEFLAG_TYPE_PIPE)
+#define INODE_IS_NAMEDEVENT(i) INODE_IS_TYPE(i,FSNODEFLAG_TYPE_NAMEDEVENT)
 
 #define INODE_GET_TYPE(i)     ((i)->i_flags & FSNODEFLAG_TYPE_MASK)
 #define INODE_SET_TYPE(i,t) \
@@ -145,16 +147,17 @@
     } \
   while (0)
 
-#define INODE_SET_DRIVER(i)   INODE_SET_TYPE(i,FSNODEFLAG_TYPE_DRIVER)
-#define INODE_SET_BLOCK(i)    INODE_SET_TYPE(i,FSNODEFLAG_TYPE_BLOCK)
-#define INODE_SET_MOUNTPT(i)  INODE_SET_TYPE(i,FSNODEFLAG_TYPE_MOUNTPT)
-#define INODE_SET_NAMEDSEM(i) INODE_SET_TYPE(i,FSNODEFLAG_TYPE_NAMEDSEM)
-#define INODE_SET_MQUEUE(i)   INODE_SET_TYPE(i,FSNODEFLAG_TYPE_MQUEUE)
-#define INODE_SET_SHM(i)      INODE_SET_TYPE(i,FSNODEFLAG_TYPE_SHM)
-#define INODE_SET_MTD(i)      INODE_SET_TYPE(i,FSNODEFLAG_TYPE_MTD)
-#define INODE_SET_SOFTLINK(i) INODE_SET_TYPE(i,FSNODEFLAG_TYPE_SOFTLINK)
-#define INODE_SET_SOCKET(i)   INODE_SET_TYPE(i,FSNODEFLAG_TYPE_SOCKET)
-#define INODE_SET_PIPE(i)     INODE_SET_TYPE(i,FSNODEFLAG_TYPE_PIPE)
+#define INODE_SET_DRIVER(i)     INODE_SET_TYPE(i,FSNODEFLAG_TYPE_DRIVER)
+#define INODE_SET_BLOCK(i)      INODE_SET_TYPE(i,FSNODEFLAG_TYPE_BLOCK)
+#define INODE_SET_MOUNTPT(i)    INODE_SET_TYPE(i,FSNODEFLAG_TYPE_MOUNTPT)
+#define INODE_SET_NAMEDSEM(i)   INODE_SET_TYPE(i,FSNODEFLAG_TYPE_NAMEDSEM)
+#define INODE_SET_MQUEUE(i)     INODE_SET_TYPE(i,FSNODEFLAG_TYPE_MQUEUE)
+#define INODE_SET_SHM(i)        INODE_SET_TYPE(i,FSNODEFLAG_TYPE_SHM)
+#define INODE_SET_MTD(i)        INODE_SET_TYPE(i,FSNODEFLAG_TYPE_MTD)
+#define INODE_SET_SOFTLINK(i)   INODE_SET_TYPE(i,FSNODEFLAG_TYPE_SOFTLINK)
+#define INODE_SET_SOCKET(i)     INODE_SET_TYPE(i,FSNODEFLAG_TYPE_SOCKET)
+#define INODE_SET_PIPE(i)       INODE_SET_TYPE(i,FSNODEFLAG_TYPE_PIPE)
+#define INODE_SET_NAMEDEVENT(i) INODE_SET_TYPE(i,FSNODEFLAG_TYPE_NAMEDEVENT)
 
 /* The status change flags.
  * These should be or-ed together to figure out what want to change.
@@ -400,6 +403,9 @@ union inode_ops_u
 #endif
 #ifdef CONFIG_FS_NAMED_SEMAPHORES
   FAR struct nsem_inode_s              *i_nsem;   /* Named semaphore */
+#endif
+#ifdef CONFIG_FS_NAMED_EVENTS
+  FAR struct nevent_inode_s            *i_nevent; /* Named event */
 #endif
 #ifdef CONFIG_PSEUDOFS_SOFTLINKS
   FAR char                             *i_link;   /* Full path to link target */


### PR DESCRIPTION
## Summary
This extension for the event group, to establish a connection between named event groups and a task. The task may reference the event group associated with a VFS-based name. Then the event group can be used in subsequent calls to nxevent_wait() or nxevent_post().

This is an extension to [12802](https://github.com/apache/nuttx/pull/12802) 
## Impact
none, add OS interface 

## Testing
vela
