### PR TITLE
arch/risc-v/litex: Fix the litex arty_a7 build

### DIFF
--- a/arch/risc-v/src/litex/litex_irq_dispatch.c
+++ b/arch/risc-v/src/litex/litex_irq_dispatch.c
@@ -47,7 +47,7 @@
  * riscv_dispatch_irq
  ****************************************************************************/
 
-void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
+void *riscv_dispatch_irq(uintptr_t vector, uintreg_t *regs)
 {
 #ifdef CONFIG_LITEX_CORE_VEXRISCV_SMP
   int irq = (vector & 0x3f);

--- a/arch/risc-v/src/litex/litex_serial.c
+++ b/arch/risc-v/src/litex/litex_serial.c
@@ -36,6 +36,7 @@
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
 #include <nuttx/serial/serial.h>
+#include <nuttx/spinlock.h>
 
 #include <arch/board/board.h>
 


### PR DESCRIPTION
## Summary

Fix a couple of regressions in the litex:arty_a7 build.

## Impact

 - Fixes a failing build, due to missing `nuttx/spinlock.h`
 - Fixes a warning produced by the out of date `uintptr_t` type used.

## Testing

Building with the `arty_a7:knsh` configuration.

