### PR TITLE
riscv: Unify the extended context save/restore

### DIFF
--- a/arch/risc-v/Kconfig
+++ b/arch/risc-v/Kconfig
@@ -495,7 +495,6 @@ config ARCH_CHIP
 config ARCH_RISCV_INTXCPT_EXTENSIONS
 	bool "RISC-V Integer Context Extensions"
 	default n
-	depends on RV32M1_OPENISA_TOOLCHAIN
 	---help---
 		RISC-V could be customized with extensions. Some Integer Context
 		Registers have to be saved and restored when Contexts switch.

--- a/arch/risc-v/src/common/riscv_exception_common.S
+++ b/arch/risc-v/src/common/riscv_exception_common.S
@@ -40,6 +40,21 @@
 
 #include "riscv_macros.S"
 
+/*
+ * The riscv_extctx.S should be placed in the chip directory, for example:
+ *   arch/risc-v/src/qemu-rv/riscv_extctx.S
+ *
+ * These macros should be provided by the chip-specific code:
+ *   * save_extctx (extended context save)
+ *   * load_extctx (extended context restore)
+ *
+ * Refer to the riscv_macros.S for implementation details.
+ */
+
+#ifdef CONFIG_ARCH_RISCV_INTXCPT_EXTENSIONS
+#  include "riscv_extctx.S"
+#endif
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -111,6 +126,12 @@ exception_common:
 
   addi       sp, sp, -XCPTCONTEXT_SIZE
   save_ctx   sp
+
+  /* Save the extended context */
+
+#ifdef CONFIG_ARCH_RISCV_INTXCPT_EXTENSIONS
+  save_extctx sp
+#endif
 
   csrr       s0, CSR_STATUS       /* s0=status */
   csrr       s1, CSR_EPC          /* s1=exception PC */
@@ -236,6 +257,12 @@ return_from_exception:
   REGSTORE   a0, RISCV_PERCPU_KSP(s0)
 
 1:
+#endif
+
+  /* Restore the extended context */
+
+#ifdef CONFIG_ARCH_RISCV_INTXCPT_EXTENSIONS
+  load_extctx sp
 #endif
 
   load_ctx   sp

--- a/arch/risc-v/src/common/riscv_initialstate.c
+++ b/arch/risc-v/src/common/riscv_initialstate.c
@@ -163,4 +163,10 @@ void up_initial_state(struct tcb_s *tcb)
 
   regval = riscv_get_newintctx();
   xcp->regs[REG_INT_CTX] = regval;
+
+  /* Initialize the state of the extended context */
+
+#ifdef CONFIG_ARCH_RISCV_INTXCPT_EXTENSIONS
+  riscv_initial_extctx_state(tcb);
+#endif
 }

--- a/arch/risc-v/src/common/riscv_internal.h
+++ b/arch/risc-v/src/common/riscv_internal.h
@@ -354,6 +354,10 @@ static inline void riscv_restorecontext(struct tcb_s *tcb)
 #endif
 }
 
+#ifdef CONFIG_ARCH_RISCV_INTXCPT_EXTENSIONS
+void riscv_initial_extctx_state(struct tcb_s *tcb);
+#endif
+
 /* RISC-V PMP Config ********************************************************/
 
 int riscv_config_pmp_region(uintptr_t region, uintptr_t attr,

--- a/arch/risc-v/src/common/riscv_saveusercontext.S
+++ b/arch/risc-v/src/common/riscv_saveusercontext.S
@@ -26,6 +26,10 @@
 
 #include "riscv_macros.S"
 
+#ifdef CONFIG_ARCH_RISCV_INTXCPT_EXTENSIONS
+#  include "riscv_extctx.S"
+#endif
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -49,6 +53,10 @@
 up_saveusercontext:
 
   save_ctx   a0
+
+#ifdef CONFIG_ARCH_RISCV_INTXCPT_EXTENSIONS
+  save_extctx a0
+#endif
 
   csrr       a1, CSR_STATUS
   REGSTORE   a1, REG_INT_CTX(a0)  /* status */


### PR DESCRIPTION
## Summary
This patch unifies the extended context save/restore for RISC-V, allowing the customized context save/restore to be used, for example, the extended context in rv32m1.

## Impact
Minor
## Testing
CI and local machine

Notice: I can apply the changes to rv32m1, but I don't have such board to verify it, so leave it unchanged for now.
