### PR TITLE
graphics: migrate to SPDX identifier

### DIFF
--- a/graphics/CMakeLists.txt
+++ b/graphics/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # graphics/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/graphics/Makefile
+++ b/graphics/Makefile
@@ -1,6 +1,8 @@
 ############################################################################
 # graphics/Makefile
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/graphics/nxbe/CMakeLists.txt
+++ b/graphics/nxbe/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # graphics/nxbe/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/graphics/nxbe/Make.defs
+++ b/graphics/nxbe/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # graphics/nxbe/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/graphics/nxbe/nxbe.h
+++ b/graphics/nxbe/nxbe.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxbe/nxbe.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxbe/nxbe_bitmap.c
+++ b/graphics/nxbe/nxbe_bitmap.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxbe/nxbe_bitmap.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxbe/nxbe_clipper.c
+++ b/graphics/nxbe/nxbe_clipper.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxbe/nxbe_clipper.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxbe/nxbe_closewindow.c
+++ b/graphics/nxbe/nxbe_closewindow.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxbe/nxbe_closewindow.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxbe/nxbe_colormap.c
+++ b/graphics/nxbe/nxbe_colormap.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxbe/nxbe_colormap.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxbe/nxbe_configure.c
+++ b/graphics/nxbe/nxbe_configure.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxbe/nxbe_configure.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxbe/nxbe_cursor.c
+++ b/graphics/nxbe/nxbe_cursor.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxbe/nxbe_cursor.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxbe/nxbe_cursor_backupdraw.c
+++ b/graphics/nxbe/nxbe_cursor_backupdraw.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxbe/nxbe_cursor_backupdraw.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxbe/nxbe_fill.c
+++ b/graphics/nxbe/nxbe_fill.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxbe/nxbe_fill.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxbe/nxbe_filltrapezoid.c
+++ b/graphics/nxbe/nxbe_filltrapezoid.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxbe/nxbe_filltrapezoid.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxbe/nxbe_flush.c
+++ b/graphics/nxbe/nxbe_flush.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxbe/nxbe_flush.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxbe/nxbe_getrectangle.c
+++ b/graphics/nxbe/nxbe_getrectangle.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxbe/nxbe_getrectangle.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxbe/nxbe_isvisible.c
+++ b/graphics/nxbe/nxbe_isvisible.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxbe/nxbe_isvisible.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxbe/nxbe_lower.c
+++ b/graphics/nxbe/nxbe_lower.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxbe/nxbe_lower.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxbe/nxbe_modal.c
+++ b/graphics/nxbe/nxbe_modal.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxbe/nxbe_modal.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxbe/nxbe_move.c
+++ b/graphics/nxbe/nxbe_move.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxbe/nxbe_move.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxbe/nxbe_notify_rectangle.c
+++ b/graphics/nxbe/nxbe_notify_rectangle.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxbe/nxbe_notify_rectangle.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxbe/nxbe_raise.c
+++ b/graphics/nxbe/nxbe_raise.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxbe/nxbe_raise.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxbe/nxbe_redraw.c
+++ b/graphics/nxbe/nxbe_redraw.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxbe/nxbe_redraw.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxbe/nxbe_redrawbelow.c
+++ b/graphics/nxbe/nxbe_redrawbelow.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxbe/nxbe_redrawbelow.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxbe/nxbe_setpixel.c
+++ b/graphics/nxbe/nxbe_setpixel.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxbe/nxbe_setpixel.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxbe/nxbe_setposition.c
+++ b/graphics/nxbe/nxbe_setposition.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxbe/nxbe_setposition.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxbe/nxbe_setsize.c
+++ b/graphics/nxbe/nxbe_setsize.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxbe/nxbe_setsize.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxbe/nxbe_setvisibility.c
+++ b/graphics/nxbe/nxbe_setvisibility.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxbe/nxbe_setvisibility.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxglib/CMakeLists.txt
+++ b/graphics/nxglib/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # graphics/nxglib/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/graphics/nxglib/Make.defs
+++ b/graphics/nxglib/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # graphics/nxglib/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/graphics/nxglib/Makefile.cursor
+++ b/graphics/nxglib/Makefile.cursor
@@ -1,6 +1,8 @@
 ############################################################################
 # graphics/nxglib/Makefile.cursor
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/graphics/nxglib/Makefile.devblit
+++ b/graphics/nxglib/Makefile.devblit
@@ -1,6 +1,8 @@
 ############################################################################
 # graphics/nxglib/Makefile.devblit
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/graphics/nxglib/Makefile.pwfb
+++ b/graphics/nxglib/Makefile.pwfb
@@ -1,6 +1,8 @@
 ############################################################################
 # graphics/nxglib/Makefile.pwfb
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/graphics/nxglib/cursor/nxglib_cursor_backup.c
+++ b/graphics/nxglib/cursor/nxglib_cursor_backup.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxglib/cursor/nxglib_cursor_backup.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxglib/cursor/nxglib_cursor_draw.c
+++ b/graphics/nxglib/cursor/nxglib_cursor_draw.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxglib/cursor/nxglib_cursor_draw.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxglib/cursor/nxglib_cursor_erase.c
+++ b/graphics/nxglib/cursor/nxglib_cursor_erase.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxglib/cursor/nxglib_cursor_erase.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxglib/fb/nxglib_copyrectangle.c
+++ b/graphics/nxglib/fb/nxglib_copyrectangle.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxglib/fb/nxglib_copyrectangle.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxglib/fb/nxglib_fillrectangle.c
+++ b/graphics/nxglib/fb/nxglib_fillrectangle.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxglib/fb/nxglib_fillrectangle.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxglib/fb/nxglib_filltrapezoid.c
+++ b/graphics/nxglib/fb/nxglib_filltrapezoid.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxglib/fb/nxglib_filltrapezoid.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxglib/fb/nxglib_getrectangle.c
+++ b/graphics/nxglib/fb/nxglib_getrectangle.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxglib/fb/nxglib_getrectangle.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxglib/fb/nxglib_moverectangle.c
+++ b/graphics/nxglib/fb/nxglib_moverectangle.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxglib/fb/nxglib_moverectangle.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxglib/fb/nxglib_setpixel.c
+++ b/graphics/nxglib/fb/nxglib_setpixel.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxglib/fb/nxglib_setpixel.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxglib/lcd/nxglib_copyrectangle.c
+++ b/graphics/nxglib/lcd/nxglib_copyrectangle.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxglib/lcd/nxglib_copyrectangle.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxglib/lcd/nxglib_fillrectangle.c
+++ b/graphics/nxglib/lcd/nxglib_fillrectangle.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxglib/lcd/nxglib_fillrectangle.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxglib/lcd/nxglib_filltrapezoid.c
+++ b/graphics/nxglib/lcd/nxglib_filltrapezoid.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxglib/lcd/nxglib_filltrapezoid.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxglib/lcd/nxglib_getrectangle.c
+++ b/graphics/nxglib/lcd/nxglib_getrectangle.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxglib/lcd/nxglib_getrectangle.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxglib/lcd/nxglib_moverectangle.c
+++ b/graphics/nxglib/lcd/nxglib_moverectangle.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxglib/lcd/nxglib_moverectangle.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxglib/lcd/nxglib_setpixel.c
+++ b/graphics/nxglib/lcd/nxglib_setpixel.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxglib/lcd/nxglib_setpixel.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxglib/nxglib.h
+++ b/graphics/nxglib/nxglib.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxglib/nxglib.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxglib/nxglib_bitblit.h
+++ b/graphics/nxglib/nxglib_bitblit.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxglib/nxglib_bitblit.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxglib/nxglib_copyrun.h
+++ b/graphics/nxglib/nxglib_copyrun.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxglib/nxglib_copyrun.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxglib/nxglib_fillrun.h
+++ b/graphics/nxglib/nxglib_fillrun.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxglib/nxglib_fillrun.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxglib/pwfb/pwfb_copyrectangle.c
+++ b/graphics/nxglib/pwfb/pwfb_copyrectangle.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxglib/pwfb/pwfb_copyrectangle.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxglib/pwfb/pwfb_fillrectangle.c
+++ b/graphics/nxglib/pwfb/pwfb_fillrectangle.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxglib/pwfb/pwfb_fillrectangle.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxglib/pwfb/pwfb_filltrapezoid.c
+++ b/graphics/nxglib/pwfb/pwfb_filltrapezoid.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxglib/pwfb/pwfb_filltrapezoid.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxglib/pwfb/pwfb_getrectangle.c
+++ b/graphics/nxglib/pwfb/pwfb_getrectangle.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxglib/pwfb/pwfb_getrectangle.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxglib/pwfb/pwfb_moverectangle.c
+++ b/graphics/nxglib/pwfb/pwfb_moverectangle.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxglib/pwfb/pwfb_moverectangle.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxglib/pwfb/pwfb_setpixel.c
+++ b/graphics/nxglib/pwfb/pwfb_setpixel.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxglib/pwfb/pwfb_setpixel.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxmu/CMakeLists.txt
+++ b/graphics/nxmu/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # graphics/nxmu/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/graphics/nxmu/Make.defs
+++ b/graphics/nxmu/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # graphics/nxmu/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/graphics/nxmu/nxmu.h
+++ b/graphics/nxmu/nxmu.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxmu/nxmu.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxmu/nxmu_kbdin.c
+++ b/graphics/nxmu/nxmu_kbdin.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxmu/nxmu_kbdin.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxmu/nxmu_mouse.c
+++ b/graphics/nxmu/nxmu_mouse.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxmu/nxmu_mouse.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxmu/nxmu_openwindow.c
+++ b/graphics/nxmu/nxmu_openwindow.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxmu/nxmu_openwindow.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxmu/nxmu_redraw.c
+++ b/graphics/nxmu/nxmu_redraw.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxmu/nxmu_redraw.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxmu/nxmu_releasebkgd.c
+++ b/graphics/nxmu/nxmu_releasebkgd.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxmu/nxmu_releasebkgd.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxmu/nxmu_reportposition.c
+++ b/graphics/nxmu/nxmu_reportposition.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxmu/nxmu_reportposition.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxmu/nxmu_requestbkgd.c
+++ b/graphics/nxmu/nxmu_requestbkgd.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxmu/nxmu_requestbkgd.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxmu/nxmu_sendclient.c
+++ b/graphics/nxmu/nxmu_sendclient.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxmu/nxmu_sendclient.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxmu/nxmu_sendclientwindow.c
+++ b/graphics/nxmu/nxmu_sendclientwindow.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxmu/nxmu_sendclientwindow.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxmu/nxmu_server.c
+++ b/graphics/nxmu/nxmu_server.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxmu/nxmu_server.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxmu/nxmu_start.c
+++ b/graphics/nxmu/nxmu_start.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxmu/nxmu_start.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxterm/CMakeLists.txt
+++ b/graphics/nxterm/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # graphics/nxterm/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/graphics/nxterm/Make.defs
+++ b/graphics/nxterm/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # graphics/nxterm/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/graphics/nxterm/nx_register.c
+++ b/graphics/nxterm/nx_register.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxterm/nx_register.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxterm/nxterm.h
+++ b/graphics/nxterm/nxterm.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxterm/nxterm.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxterm/nxterm_clear.c
+++ b/graphics/nxterm/nxterm_clear.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxterm/nxterm_clear.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxterm/nxterm_driver.c
+++ b/graphics/nxterm/nxterm_driver.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxterm/nxterm_driver.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxterm/nxterm_font.c
+++ b/graphics/nxterm/nxterm_font.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxterm/nxterm_font.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxterm/nxterm_kbdin.c
+++ b/graphics/nxterm/nxterm_kbdin.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxterm/nxterm_kbdin.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxterm/nxterm_putc.c
+++ b/graphics/nxterm/nxterm_putc.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxterm/nxterm_putc.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxterm/nxterm_redraw.c
+++ b/graphics/nxterm/nxterm_redraw.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxterm/nxterm_redraw.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxterm/nxterm_register.c
+++ b/graphics/nxterm/nxterm_register.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxterm/nxterm_register.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxterm/nxterm_resize.c
+++ b/graphics/nxterm/nxterm_resize.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxterm/nxterm_resize.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxterm/nxterm_scroll.c
+++ b/graphics/nxterm/nxterm_scroll.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxterm/nxterm_scroll.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxterm/nxterm_unregister.c
+++ b/graphics/nxterm/nxterm_unregister.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxterm/nxterm_unregister.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxterm/nxterm_vt100.c
+++ b/graphics/nxterm/nxterm_vt100.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxterm/nxterm_vt100.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxterm/nxtk_register.c
+++ b/graphics/nxterm/nxtk_register.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxterm/nxtk_register.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/graphics/nxterm/nxtool_register.c
+++ b/graphics/nxterm/nxtool_register.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * graphics/nxterm/nxtool_register.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The


### PR DESCRIPTION
## Summary
Most tools used for compliance and SBOM generation use SPDX identifiers This change brings us a step closer to an easy SBOM generation.

## Impact
SBOM

## Testing
CI
