### PR TITLE
openamp: migrate to SPDX identifier

### DIFF
--- a/openamp/CMakeLists.txt
+++ b/openamp/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # openamp/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/openamp/Makefile
+++ b/openamp/Makefile
@@ -1,6 +1,8 @@
 ############################################################################
 # openamp/Makefile
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/openamp/libmetal.cmake
+++ b/openamp/libmetal.cmake
@@ -1,6 +1,8 @@
 # ##############################################################################
 # openamp/libmetal.cmake
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/openamp/libmetal.defs
+++ b/openamp/libmetal.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # openamp/libmetal.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/openamp/open-amp.cmake
+++ b/openamp/open-amp.cmake
@@ -1,6 +1,8 @@
 # ##############################################################################
 # openamp/open-amp.cmake
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/openamp/open-amp.defs
+++ b/openamp/open-amp.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # openamp/open-amp.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The


### PR DESCRIPTION
## Summary
Most tools used for compliance and SBOM generation use SPDX identifiers This change brings us a step closer to an easy SBOM generation.

## Impact
SBOM

## Testing
CI
