### PR TITLE
tools: migrate to SPDX identifier

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 ############################################################################
 # Makefile
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/pass1/Makefile
+++ b/pass1/Makefile
@@ -1,6 +1,8 @@
 ############################################################################
 # pass1/Makefile
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # tools/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -1,6 +1,8 @@
 ############################################################################
 # tools/Config.mk
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/D.defs
+++ b/tools/D.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # tools/D.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/Export.mk
+++ b/tools/Export.mk
@@ -1,6 +1,8 @@
 ############################################################################
 # tools/Export.mk
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/FlatLibs.mk
+++ b/tools/FlatLibs.mk
@@ -1,6 +1,8 @@
 ############################################################################
 # tools/FlatLibs.mk
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/KernelLibs.mk
+++ b/tools/KernelLibs.mk
@@ -1,6 +1,8 @@
 ############################################################################
 # tools/KernelLibs.mk
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/Makefile.host
+++ b/tools/Makefile.host
@@ -1,6 +1,8 @@
 ############################################################################
 # tools/Makefile.host
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/ProtectedLibs.mk
+++ b/tools/ProtectedLibs.mk
@@ -1,6 +1,8 @@
 ############################################################################
 # tools/ProtectedLibs.mk
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/Rust.defs
+++ b/tools/Rust.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # tools/Rust.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/Swift.defs
+++ b/tools/Swift.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # tools/Swift.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/Unix.mk
+++ b/tools/Unix.mk
@@ -1,6 +1,8 @@
 ############################################################################
 # tools/Unix.mk
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/Win.mk
+++ b/tools/Win.mk
@@ -1,6 +1,8 @@
 ############################################################################
 # tools/Win.mk
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/Zig.defs
+++ b/tools/Zig.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # tools/Zig.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/apps-or-nuttx-Make.defs
+++ b/tools/apps-or-nuttx-Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # apps-or-nuttx-Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/b16.c
+++ b/tools/b16.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * tools/b16.c
- * Convert b16 fixed precision value to float or vice versa
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/tools/bdf-converter.c
+++ b/tools/bdf-converter.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * tools/bdf-converter.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/tools/build-globals.sh
+++ b/tools/build-globals.sh
@@ -2,6 +2,8 @@
 ############################################################################
 # tools/build-globals.sh
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/callstack.py
+++ b/tools/callstack.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 # tools/callstack.py
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/cfgdefine.c
+++ b/tools/cfgdefine.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * tools/cfgdefine.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/tools/cfgdefine.h
+++ b/tools/cfgdefine.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * tools/cfgdefine.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/tools/cfgparser.c
+++ b/tools/cfgparser.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * tools/cfgparser.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/tools/cfgparser.h
+++ b/tools/cfgparser.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * tools/cfgparser.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/tools/checkpatch.sh
+++ b/tools/checkpatch.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # tools/checkpatch.sh
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.

--- a/tools/checkrelease.sh
+++ b/tools/checkrelease.sh
@@ -2,6 +2,8 @@
 #############################################################################
 # tools/checkrelease.sh
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/ci/cibuild.sh
+++ b/tools/ci/cibuild.sh
@@ -2,6 +2,8 @@
 ############################################################################
 # tools/ci/cibuild.sh
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/ci/cirun.sh
+++ b/tools/ci/cirun.sh
@@ -1,4 +1,25 @@
 #!/usr/bin/env bash
+############################################################################
+# tools/ci/cirun.sh
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
 
 set -e
 set -o xtrace

--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/ci/platforms/darwin.sh
+++ b/tools/ci/platforms/darwin.sh
@@ -2,6 +2,8 @@
 ############################################################################
 # tools/ci/platforms/darwin.sh
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/ci/platforms/linux.sh
+++ b/tools/ci/platforms/linux.sh
@@ -2,6 +2,8 @@
 ############################################################################
 # tools/ci/platforms/linux.sh
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/ci/platforms/msys2.sh
+++ b/tools/ci/platforms/msys2.sh
@@ -2,6 +2,8 @@
 ############################################################################
 # tools/ci/platforms/msys2.sh
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/ci/platforms/ubuntu.sh
+++ b/tools/ci/platforms/ubuntu.sh
@@ -2,6 +2,8 @@
 ############################################################################
 # tools/ci/platforms/ubuntu.sh
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/ci/testrun/script/__init__.py
+++ b/tools/ci/testrun/script/__init__.py
@@ -1,2 +1,23 @@
 #!/usr/bin/env python3
+############################################################################
+# tools/ci/testrun/script/__init__.py
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
 # encoding: utf-8

--- a/tools/ci/testrun/script/conftest.py
+++ b/tools/ci/testrun/script/conftest.py
@@ -1,4 +1,25 @@
 #!/usr/bin/env python3
+############################################################################
+# tools/ci/testrun/script/conftest.py
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
 # encoding: utf-8
 
 import pytest

--- a/tools/ci/testrun/script/test_example/__init__.py
+++ b/tools/ci/testrun/script/test_example/__init__.py
@@ -1,2 +1,23 @@
 #!/usr/bin/env python3
+############################################################################
+# tools/ci/testrun/script/text_example/__init__.py
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
 # encoding: utf-8

--- a/tools/ci/testrun/script/test_example/test_example.py
+++ b/tools/ci/testrun/script/test_example/test_example.py
@@ -1,4 +1,25 @@
 #!/usr/bin/env python3
+############################################################################
+# tools/ci/testrun/script/text_example/test_example.py
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
 # encoding: utf-8
 import pytest
 

--- a/tools/ci/testrun/script/test_framework/__init__.py
+++ b/tools/ci/testrun/script/test_framework/__init__.py
@@ -1,2 +1,23 @@
 #!/usr/bin/python3
+############################################################################
+# tools/ci/testrun/script/test_framework/__init__.py
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
 # encoding: utf-8

--- a/tools/ci/testrun/script/test_framework/test_cmocka.py
+++ b/tools/ci/testrun/script/test_framework/test_cmocka.py
@@ -1,4 +1,25 @@
 #!/usr/bin/python3
+############################################################################
+# tools/ci/testrun/script/test_framework/test_cmocka.py
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
 # encoding: utf-8
 
 import os

--- a/tools/ci/testrun/script/test_libuv/__init__.py
+++ b/tools/ci/testrun/script/test_libuv/__init__.py
@@ -1,2 +1,23 @@
 #!/usr/bin/python3
+############################################################################
+# tools/ci/testrun/script/test_libuv/__init__.py
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
 # encoding: utf-8

--- a/tools/ci/testrun/script/test_libuv/test_libuv.py
+++ b/tools/ci/testrun/script/test_libuv/test_libuv.py
@@ -1,4 +1,25 @@
 #!/usr/bin/python3
+############################################################################
+# tools/ci/testrun/script/test_libuv/test_libuv.py
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
 # encoding: utf-8
 
 import pytest

--- a/tools/ci/testrun/script/test_open_posix/__init__.py
+++ b/tools/ci/testrun/script/test_open_posix/__init__.py
@@ -1,2 +1,23 @@
 #!/usr/bin/python3
+############################################################################
+# tools/ci/testrun/script/test_open_posix/__init__.py
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
 # encoding: utf-8

--- a/tools/ci/testrun/script/test_open_posix/test_openposix_.py
+++ b/tools/ci/testrun/script/test_open_posix/test_openposix_.py
@@ -1,4 +1,25 @@
 #!/usr/bin/python3
+############################################################################
+# tools/ci/testrun/script/test_open_posix/test_openposix_.py
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
 # encoding: utf-8
 import pytest
 

--- a/tools/ci/testrun/script/test_os/__init__.py
+++ b/tools/ci/testrun/script/test_os/__init__.py
@@ -1,2 +1,23 @@
 #!/usr/bin/env python3
+############################################################################
+# tools/ci/testrun/script/test_os/__init__.py
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
 # encoding: utf-8

--- a/tools/ci/testrun/script/test_os/test_os.py
+++ b/tools/ci/testrun/script/test_os/test_os.py
@@ -1,4 +1,25 @@
 #!/usr/bin/env python3
+############################################################################
+# tools/ci/testrun/script/test_os/test_os.py
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
 # encoding: utf-8
 import os
 

--- a/tools/ci/testrun/utils/__init__.py
+++ b/tools/ci/testrun/utils/__init__.py
@@ -1,2 +1,23 @@
 #!/usr/bin/env python3
+############################################################################
+# tools/ci/testrun/utils/__init__.py
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
 # encoding: utf-8

--- a/tools/ci/testrun/utils/common.py
+++ b/tools/ci/testrun/utils/common.py
@@ -1,5 +1,25 @@
 #!/usr/bin/env python3
-
+############################################################################
+# tools/ci/testrun/utils/common.py
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
 import os
 import re
 import subprocess

--- a/tools/ci/testrun/utils/data_model.py
+++ b/tools/ci/testrun/utils/data_model.py
@@ -1,3 +1,25 @@
+############################################################################
+# tools/ci/testrun/utils/data_model.py
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
 import re
 from datetime import datetime
 from typing import Dict, List

--- a/tools/cmpconfig.c
+++ b/tools/cmpconfig.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * tools/cmpconfig.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/tools/cnvwindeps.c
+++ b/tools/cnvwindeps.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * tools/cnvwindeps.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/tools/configure.bat
+++ b/tools/configure.bat
@@ -2,6 +2,8 @@
 
 rem tools/configure.bat
 rem
+rem SPDX-License-Identifier: Apache-2.0
+rem
 rem Licensed to the Apache Software Foundation (ASF) under one or more
 rem  contributor license agreements.  See the NOTICE file distributed with
 rem  this work for additional information regarding copyright ownership.  The

--- a/tools/configure.c
+++ b/tools/configure.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * tools/configure.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/tools/configure.sh
+++ b/tools/configure.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # tools/configure.sh
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/configure_completion.bash
+++ b/tools/configure_completion.bash
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # tools/configure_completion.bash
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/convert-comments.c
+++ b/tools/convert-comments.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * tools/convert-comments.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/tools/copydir.bat
+++ b/tools/copydir.bat
@@ -2,6 +2,8 @@
 
 rem tools/copydir.bat
 rem
+rem SPDX-License-Identifier: Apache-2.0
+rem
 rem Licensed to the Apache Software Foundation (ASF) under one or more
 rem contributor license agreements.  See the NOTICE file distributed with
 rem this work for additional information regarding copyright ownership.  The

--- a/tools/copydir.sh
+++ b/tools/copydir.sh
@@ -2,6 +2,8 @@
 ############################################################################
 # tools/copydir.sh
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/coredump.py
+++ b/tools/coredump.py
@@ -2,6 +2,8 @@
 ############################################################################
 # tools/coredump.py
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/csvparser.c
+++ b/tools/csvparser.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * tools/csvparser.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/tools/csvparser.h
+++ b/tools/csvparser.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * tools/csvparser.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/tools/cxd56/CMakeLists.txt
+++ b/tools/cxd56/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # tools/cxd56/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/tools/cxd56/Config.mk
+++ b/tools/cxd56/Config.mk
@@ -1,6 +1,8 @@
 ############################################################################
 # tools/cxd56/Config.mk
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/cxd56/clefia.c
+++ b/tools/cxd56/clefia.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * tools/cxd56/clefia.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/tools/cxd56/clefia.h
+++ b/tools/cxd56/clefia.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * tools/cxd56/clefia.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/tools/cxd56/elf32.h
+++ b/tools/cxd56/elf32.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * tools/cxd56/elf32.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/tools/cxd56/mkspk.c
+++ b/tools/cxd56/mkspk.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * tools/cxd56/mkspk.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/tools/cxd56/mkspk.h
+++ b/tools/cxd56/mkspk.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * tools/cxd56/mkspk.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/tools/define.bat
+++ b/tools/define.bat
@@ -2,6 +2,8 @@
 
 rem tools/define.bat
 rem
+rem SPDX-License-Identifier: Apache-2.0
+rem
 rem Licensed to the Apache Software Foundation (ASF) under one or more
 rem contributor license agreements.  See the NOTICE file distributed with
 rem this work for additional information regarding copyright ownership.  The

--- a/tools/define.sh
+++ b/tools/define.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # tools/define.sh
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/detab.c
+++ b/tools/detab.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * tools/detab.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/tools/discover.py
+++ b/tools/discover.py
@@ -2,6 +2,8 @@
 ############################################################################
 # tools/discover.py
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/esp32/Config.mk
+++ b/tools/esp32/Config.mk
@@ -1,6 +1,8 @@
 ############################################################################
 # tools/esp32/Config.mk
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/esp32/backtrace.gdbscript
+++ b/tools/esp32/backtrace.gdbscript
@@ -1,6 +1,8 @@
 ############################################################################
 # tools/esp32/backtrace.gdbscript
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/esp32/btdecode.sh
+++ b/tools/esp32/btdecode.sh
@@ -2,6 +2,8 @@
 ############################################################################
 # tools/esp32/btdecode.sh
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/esp32/mcuboot_toolchain_esp32.cmake
+++ b/tools/esp32/mcuboot_toolchain_esp32.cmake
@@ -1,6 +1,8 @@
 # ##############################################################################
 # tools/esp32/mcuboot_toolchain_esp32.cmake
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/tools/esp32c3/Config.mk
+++ b/tools/esp32c3/Config.mk
@@ -1,6 +1,8 @@
 ############################################################################
 # tools/esp32c3/Config.mk
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/esp32s2/Config.mk
+++ b/tools/esp32s2/Config.mk
@@ -1,6 +1,8 @@
 ############################################################################
 # tools/esp32s2/Config.mk
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/esp32s2/mcuboot_toolchain_esp32s2.cmake
+++ b/tools/esp32s2/mcuboot_toolchain_esp32s2.cmake
@@ -1,6 +1,8 @@
 # ##############################################################################
 # tools/esp32s2/mcuboot_toolchain_esp32s2.cmake
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/tools/esp32s3/Config.mk
+++ b/tools/esp32s3/Config.mk
@@ -1,6 +1,8 @@
 ############################################################################
 # tools/esp32s3/Config.mk
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/esp32s3/mcuboot_toolchain_esp32s3.cmake
+++ b/tools/esp32s3/mcuboot_toolchain_esp32s3.cmake
@@ -1,6 +1,8 @@
 # ##############################################################################
 # tools/esp32s3/mcuboot_toolchain_esp32s3.cmake
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/tools/espressif/Config.mk
+++ b/tools/espressif/Config.mk
@@ -1,6 +1,8 @@
 ############################################################################
 # tools/espressif/Config.mk
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/espressif/build_mcuboot.sh
+++ b/tools/espressif/build_mcuboot.sh
@@ -1,5 +1,25 @@
 #!/usr/bin/env bash
-
+############################################################################
+# tools/espressif/build_mcuboot.sh
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
 SCRIPT_NAME=$(basename "${BASH_SOURCE[0]}")
 
 usage() {

--- a/tools/espressif/build_mcuboot_esp32c3_legacy.sh
+++ b/tools/espressif/build_mcuboot_esp32c3_legacy.sh
@@ -1,5 +1,25 @@
 #!/usr/bin/env bash
-
+############################################################################
+# tools/espressif/build_mcuboot_esp32c3_legacy.sh
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
 SCRIPT_NAME=$(basename "${BASH_SOURCE[0]}")
 
 usage() {

--- a/tools/espressif/mcuboot_toolchain_espressif.cmake
+++ b/tools/espressif/mcuboot_toolchain_espressif.cmake
@@ -1,6 +1,8 @@
 # ##############################################################################
 # tools/espressif/mcuboot_toolchain_espressif.cmake
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/tools/flash_writer.py
+++ b/tools/flash_writer.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 # tools/flash_writer.py
 
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/gcov.sh
+++ b/tools/gcov.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # tools/gcov.sh
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.

--- a/tools/gdb/__init__.py
+++ b/tools/gdb/__init__.py
@@ -1,6 +1,8 @@
 ############################################################################
 # tools/gdb/__init__.py
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/gdb/lists.py
+++ b/tools/gdb/lists.py
@@ -1,6 +1,8 @@
 ############################################################################
 # tools/gdb/lists.py
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/gdb/memdump.py
+++ b/tools/gdb/memdump.py
@@ -1,6 +1,8 @@
 ############################################################################
 # tools/gdb/memdump.py
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/gdb/thread.py
+++ b/tools/gdb/thread.py
@@ -1,6 +1,8 @@
 ############################################################################
 # tools/gdb/thread.py
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/gdb/utils.py
+++ b/tools/gdb/utils.py
@@ -1,6 +1,8 @@
 ############################################################################
 # tools/gdb/utils.py
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/gdbserver.py
+++ b/tools/gdbserver.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 # tools/gdbserver.py
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/gencromfs.c
+++ b/tools/gencromfs.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * tools/gencromfs.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/tools/ide_exporter.py
+++ b/tools/ide_exporter.py
@@ -2,6 +2,9 @@
 ############################################################################
 # tools/ide_exporter.py
 #
+# SPDX-License-Identifier: BSD-3-Clause
+#
+#
 #   Copyright (C) 2016 Kha Vo. All rights reserved.
 #   Author: Kha Vo <canhkha@gmail.com>
 #

--- a/tools/imx9/Config.mk
+++ b/tools/imx9/Config.mk
@@ -1,6 +1,8 @@
 ############################################################################
 # tools/imx9/Config.mk
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/imx9/Makefile.host
+++ b/tools/imx9/Makefile.host
@@ -1,6 +1,8 @@
 ############################################################################
 # tools/imx9/Makefile.host
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/incdir.bat
+++ b/tools/incdir.bat
@@ -2,6 +2,8 @@
 
 rem tools/incdir.bat
 rem
+rem SPDX-License-Identifier: Apache-2.0
+rem
 rem Licensed to the Apache Software Foundation (ASF) under one or more
 rem contributor license agreements.  See the NOTICE file distributed with
 rem this work for additional information regarding copyright ownership.  The

--- a/tools/incdir.c
+++ b/tools/incdir.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * tools/incdir.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/tools/incdir.sh
+++ b/tools/incdir.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # tools/incdir.sh
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/indent.sh
+++ b/tools/indent.sh
@@ -2,6 +2,8 @@
 ############################################################################
 # tools/indent.sh
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/initialconfig.c
+++ b/tools/initialconfig.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * tools/initialconfig.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/tools/jlink-nuttx.c
+++ b/tools/jlink-nuttx.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * tools/jlink-nuttx.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/tools/kasan_global.py
+++ b/tools/kasan_global.py
@@ -2,6 +2,8 @@
 ############################################################################
 # tools/kasan_global.py
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/kconfig.bat
+++ b/tools/kconfig.bat
@@ -2,6 +2,8 @@
 
 rem tools/kconfig.bat
 rem
+rem SPDX-License-Identifier: Apache-2.0
+rem
 rem Licensed to the Apache Software Foundation (ASF) under one or more
 rem contributor license agreements.  See the NOTICE file distributed with
 rem this work for additional information regarding copyright ownership.  The

--- a/tools/kconfig2html.c
+++ b/tools/kconfig2html.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * tools/kconfig2html.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/tools/licensing/apachize.py
+++ b/tools/licensing/apachize.py
@@ -8,6 +8,8 @@ apache = r"""
 /****************************************************************************
  * PATH
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/tools/licensing/check.py
+++ b/tools/licensing/check.py
@@ -2,6 +2,8 @@
 
 ############################################################################
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/licensing/log2json.sh
+++ b/tools/licensing/log2json.sh
@@ -2,6 +2,8 @@
 
 ############################################################################
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/link.bat
+++ b/tools/link.bat
@@ -2,6 +2,8 @@
 
 rem tools/link.bat
 rem
+rem SPDX-License-Identifier: Apache-2.0
+rem
 rem Licensed to the Apache Software Foundation (ASF) under one or more
 rem contributor license agreements.  See the NOTICE file distributed with
 rem this work for additional information regarding copyright ownership.  The

--- a/tools/link.sh
+++ b/tools/link.sh
@@ -2,6 +2,8 @@
 ############################################################################
 # tools/link.sh
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/lowhex.c
+++ b/tools/lowhex.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * tools/lowhex.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/tools/lwl/ocdconsole.py
+++ b/tools/lwl/ocdconsole.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/macar-qcs.sh
+++ b/tools/macar-qcs.sh
@@ -1,5 +1,7 @@
 #! /usr/bin/env bash
 
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/tools/merge_config.py
+++ b/tools/merge_config.py
@@ -2,6 +2,8 @@
 ############################################################################
 # tools/merge_config.py
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/mkallsyms.py
+++ b/tools/mkallsyms.py
@@ -2,6 +2,8 @@
 ############################################################################
 # tools/mkallsyms.py
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/mkallsyms.sh
+++ b/tools/mkallsyms.sh
@@ -2,6 +2,8 @@
 ############################################################################
 # tools/mkallsyms.sh
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/mkconfig.c
+++ b/tools/mkconfig.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * tools/mkconfig.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/tools/mkconfigvars.sh
+++ b/tools/mkconfigvars.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # tools/mkconfivars.sh
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/mkctags.sh
+++ b/tools/mkctags.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # tools/mkctags.sh
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/mkdeps.c
+++ b/tools/mkdeps.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * tools/mkdeps.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/tools/mkexport.sh
+++ b/tools/mkexport.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # tools/mkexport.sh
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/mkfsdata.pl
+++ b/tools/mkfsdata.pl
@@ -1,6 +1,8 @@
 #!/usr/bin/perl
 # tools/mkfsdata.pl
 #
+# SPDX-License-Identifier: BSD-3-Clause
+#
 # Extracted from uIP which has a license that is compatible with NuttX.
 # There is no authorship, copyright, or licensing information in the
 # original file.  Possibly written by Adam Dunkels.

--- a/tools/mkfsdata.py
+++ b/tools/mkfsdata.py
@@ -3,6 +3,8 @@
 """
 tools/mkfsdata.py
 
+SPDX-License-Identifier: ???
+
 Copyright (c) 2024 Alexey Matveev
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS

--- a/tools/mknulldeps.sh
+++ b/tools/mknulldeps.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # tools/mknulldeps.sh
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/mkromfsimg.sh
+++ b/tools/mkromfsimg.sh
@@ -2,6 +2,8 @@
 ############################################################################
 # tools/mkromfsimg.sh
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/mksymtab.c
+++ b/tools/mksymtab.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * tools/mksymtab.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/tools/mkversion.c
+++ b/tools/mkversion.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * tools/mkversion.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/tools/mkwindeps.sh
+++ b/tools/mkwindeps.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # tools/mkwindeps.sh
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/mpfs/Config.mk
+++ b/tools/mpfs/Config.mk
@@ -1,6 +1,8 @@
 ############################################################################
 # tools/mpfs/Config.mk
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/netusb.sh
+++ b/tools/netusb.sh
@@ -3,6 +3,8 @@
 #****************************************************************************
 # tools/netusb.sh
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/noteinfo.c
+++ b/tools/noteinfo.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * tools/noteinfo.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -1,6 +1,8 @@
 /********************************************************************************
  * tools/nxstyle.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/tools/parsecallstack.py
+++ b/tools/parsecallstack.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 # tools/parsecallstack.py
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/parsememdump.py
+++ b/tools/parsememdump.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 # tools/parsememdump.py
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/parsetrace.py
+++ b/tools/parsetrace.py
@@ -2,6 +2,8 @@
 ############################################################################
 # tools/parsetrace.py
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/pic32/Config.mk
+++ b/tools/pic32/Config.mk
@@ -1,6 +1,8 @@
 ############################################################################
 # tools/pic32/Config.mk
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/pic32/Makefile.host
+++ b/tools/pic32/Makefile.host
@@ -1,6 +1,8 @@
 ############################################################################
 # tools/pic32/Makefile.host
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/pic32/mkpichex.c
+++ b/tools/pic32/mkpichex.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * tools/pic32/mkpichex.c
- * Convert virtual addresses in nuttx.hex to physical addresses
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/tools/process_config.sh
+++ b/tools/process_config.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # tools/process_config.sh
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/refresh.sh
+++ b/tools/refresh.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # tools/refresh.sh
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/rmcr.c
+++ b/tools/rmcr.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * tools/rmcr.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/tools/rp2040/Config.mk
+++ b/tools/rp2040/Config.mk
@@ -1,6 +1,8 @@
 ############################################################################
 # tools/rp2040/Config.mk
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/rp2040/make_flash_fs.c
+++ b/tools/rp2040/make_flash_fs.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * tools/rp2040/make_flash_fs.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/tools/sethost.sh
+++ b/tools/sethost.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # tools/sethost.sh
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/showsize.sh
+++ b/tools/showsize.sh
@@ -2,6 +2,8 @@
 ############################################################################
 # tools/showsize.sh
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/showstack.sh
+++ b/tools/showstack.sh
@@ -2,6 +2,8 @@
 ############################################################################
 # tools/showstack.sh
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/simbridge.sh
+++ b/tools/simbridge.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # tools/simbridge.sh
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.

--- a/tools/simhostroute.sh
+++ b/tools/simhostroute.sh
@@ -3,6 +3,8 @@
 #****************************************************************************
 # tools/simhostroute.sh
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/simwifi/sim_wifi.sh
+++ b/tools/simwifi/sim_wifi.sh
@@ -3,6 +3,8 @@
 #****************************************************************************
 # tools/simwifi/sim_wifi.sh
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/stm32_pinmap_tool.py
+++ b/tools/stm32_pinmap_tool.py
@@ -2,6 +2,8 @@
 ############################################################################
 # tools/stm32_pinmap_tool.py
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/testbuild.sh
+++ b/tools/testbuild.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # tools/testbuild.sh
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/unlink.bat
+++ b/tools/unlink.bat
@@ -2,6 +2,8 @@
 
 rem tools/unlink.bat
 rem
+rem SPDX-License-Identifier: Apache-2.0
+rem
 rem Licensed to the Apache Software Foundation (ASF) under one or more
 rem contributor license agreements.  See the NOTICE file distributed with
 rem this work for additional information regarding copyright ownership.  The

--- a/tools/unlink.sh
+++ b/tools/unlink.sh
@@ -2,6 +2,8 @@
 ############################################################################
 # tools/unlink.sh
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/version.sh
+++ b/tools/version.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # tools/version.sh
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/xmlrpc_test.py
+++ b/tools/xmlrpc_test.py
@@ -2,6 +2,8 @@
 ############################################################################
 # tools/xmlrpc_test.py
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/zds/Config.mk
+++ b/tools/zds/Config.mk
@@ -1,6 +1,8 @@
 ############################################################################
 # tools/zds/Config.mk
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/zds/Makefile
+++ b/tools/zds/Makefile
@@ -1,6 +1,8 @@
 ############################################################################
 # tools/zds/Makefile
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/zds/zdsar.c
+++ b/tools/zds/zdsar.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * tools/zds/zdsar.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/tools/zipme.sh
+++ b/tools/zipme.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # tools/zipme.sh
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The


### PR DESCRIPTION
## Summary
Most tools used for compliance and SBOM generation use SPDX identifiers This change brings us a step closer to an easy SBOM generation.

## Impact
SBOM

## Testing
CI
