### PR TITLE
arm64_syscall.c: Don't need to set register context during syscall

### DIFF
--- a/arch/arm64/src/common/arm64_syscall.c
+++ b/arch/arm64/src/common/arm64_syscall.c
@@ -94,7 +94,7 @@ static void  arm64_dump_syscall(const char *tag, uint64_t cmd,
 uintptr_t dispatch_syscall(unsigned int nbr, uintptr_t parm1,
                            uintptr_t parm2, uintptr_t parm3,
                            uintptr_t parm4, uintptr_t parm5,
-                           uintptr_t parm6, void *context)
+                           uintptr_t parm6)
 {
   struct tcb_s *rtcb         = this_task();
   register long x0 asm("x0") = (long)(nbr);
@@ -115,10 +115,6 @@ uintptr_t dispatch_syscall(unsigned int nbr, uintptr_t parm1,
 
       return -ENOSYS;
     }
-
-  /* Set the user register context to TCB */
-
-  rtcb->xcp.regs = context;
 
   /* Indicate that we are in a syscall handler */
 

--- a/arch/arm64/src/common/arm64_vectors.S
+++ b/arch/arm64/src/common/arm64_vectors.S
@@ -239,7 +239,6 @@ SECTION_FUNC(text, arm64_sync_exc)
     /* Call dispatch_syscall() on the kernel stack with interrupts enabled */
 
     enable_irq
-    mov    x7, sp /* x7 = context */
     bl     dispatch_syscall
     disable_irq
 


### PR DESCRIPTION
## Summary
The register context is not needed, the original idea was to provide the user stack pointer for signal handler delivery, but the user stack can be obtained via sp_el0 so the context registers are not needed.

SP0 is not stored upon exception entry anyways, so this code is just completely redundant and wrong.

## Impact
Clean up dead code
## Testing
qemu-armv8a:knsh & ostest
