### PR TITLE
 arm64/syscall: (Re-)enable interrupts only if they were previously enabled

### DIFF
--- a/arch/arm64/include/irq.h
+++ b/arch/arm64/include/irq.h
@@ -220,6 +220,14 @@
 #define XCPTCONTEXT_REGS    (XCPTCONTEXT_GP_REGS + XCPTCONTEXT_FPU_REGS)
 #define XCPTCONTEXT_SIZE    (8 * XCPTCONTEXT_REGS)
 
+#ifdef CONFIG_ARM64_DECODEFIQ
+#  define IRQ_DAIF_MASK (3)
+#else
+#  define IRQ_DAIF_MASK (2)
+#endif
+
+#define IRQ_SPSR_MASK (IRQ_DAIF_MASK << 6)
+
 #ifndef __ASSEMBLY__
 
 #ifdef __cplusplus
@@ -349,13 +357,9 @@ static inline irqstate_t up_irq_save(void)
   __asm__ __volatile__
     (
       "mrs %0, daif\n"
-#ifdef CONFIG_ARM64_DECODEFIQ
-      "msr daifset, #3\n"
-#else
-      "msr daifset, #2\n"
-#endif
+      "msr daifset, %1\n"
       : "=r" (flags)
-      :
+      : "i" (IRQ_DAIF_MASK)
       : "memory"
     );
 
@@ -371,13 +375,9 @@ static inline irqstate_t up_irq_enable(void)
   __asm__ __volatile__
     (
       "mrs %0, daif\n"
-#ifdef CONFIG_ARM64_DECODEFIQ
-      "msr daifclr, #3\n"
-#else
-      "msr daifclr, #2\n"
-#endif
+      "msr daifclr, %1\n"
       : "=r" (flags)
-      :
+      : "i" (IRQ_DAIF_MASK)
       : "memory"
     );
   return flags;

--- a/arch/arm64/src/common/arm64_vectors.S
+++ b/arch/arm64/src/common/arm64_vectors.S
@@ -56,22 +56,6 @@
 
 .endm
 
-.macro enable_irq
-#ifdef CONFIG_ARM64_DECODEFIQ
-    msr daifclr, #3
-#else
-    msr daifclr, #2
-#endif
-.endm
-
-.macro disable_irq
-#ifdef CONFIG_ARM64_DECODEFIQ
-    msr daifset, #3
-#else
-    msr daifset, #2
-#endif
-.endm
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -238,9 +222,9 @@ SECTION_FUNC(text, arm64_sync_exc)
 
     /* Call dispatch_syscall() on the kernel stack with interrupts enabled */
 
-    enable_irq
+    msr    daifclr, #IRQ_DAIF_MASK /* Re-enable interrupts */
     bl     dispatch_syscall
-    disable_irq
+    msr    daifset, #IRQ_DAIF_MASK /* Disable interrupts */
 
     /* Save the return value into the user context */
 

--- a/arch/arm64/src/common/arm64_vectors.S
+++ b/arch/arm64/src/common/arm64_vectors.S
@@ -222,7 +222,13 @@ SECTION_FUNC(text, arm64_sync_exc)
 
     /* Call dispatch_syscall() on the kernel stack with interrupts enabled */
 
+    mrs    x10, spsr_el1
+    and    x10, x10, #IRQ_SPSR_MASK
+    cmp    x10, xzr
+    bne    1f
     msr    daifclr, #IRQ_DAIF_MASK /* Re-enable interrupts */
+
+1:
     bl     dispatch_syscall
     msr    daifset, #IRQ_DAIF_MASK /* Disable interrupts */
 


### PR DESCRIPTION
## Summary
Use SPSR_ELx value to determine whether interrupts need to be re-enabled when running user system call
## Impact
User system calls only
## Testing
- qemu-armv8a:knsh
- downstream imx9 target with kernel mode
