### PR TITLE
arm64_addrenv_pgmap.c: Revoke user execution access to kernel mmap'd pages

### DIFF
--- a/arch/arm64/src/common/arm64_addrenv_pgmap.c
+++ b/arch/arm64/src/common/arm64_addrenv_pgmap.c
@@ -271,6 +271,10 @@ int up_addrenv_kmap_pages(void **pages, unsigned int npages, uintptr_t vaddr,
 
   mask &= ~PTE_BLOCK_DESC_NG;
 
+  /* Also, revoke user execute access */
+
+  mask |= PTE_BLOCK_DESC_UXN;
+
   /* Let arm64_map_pages do the work */
 
   return arm64_map_pages(addrenv, (uintptr_t *)pages, npages, vaddr, mask);


### PR DESCRIPTION
## Summary
Revoke execute access for user on kernel memory, otherwise, user can "theoretically" run code from there

## Impact
Fix small, very theoretical security issue
## Testing
CI pass
