### PR TITLE
arm64_vector_table.S: Remove unnecessary instruction

### DIFF
--- a/arch/arm64/src/common/arm64_vector_table.S
+++ b/arch/arm64/src/common/arm64_vector_table.S
@@ -266,8 +266,6 @@ arm64_exit_exc_fpu_done:
     sub    x0, x0, x1
     msr    tpidrro_el0, x0
 
-    ldp    x30, x0,  [sp, #8 * REG_X30]
-    sub    x0,  x0, #8 * XCPTCONTEXT_GP_REGS
     ldp    x0,  x1,  [sp, #8 * REG_X0]
     ldp    x2,  x3,  [sp, #8 * REG_X2]
     ldp    x4,  x5,  [sp, #8 * REG_X4]
@@ -283,6 +281,7 @@ arm64_exit_exc_fpu_done:
     ldp    x24, x25, [sp, #8 * REG_X24]
     ldp    x26, x27, [sp, #8 * REG_X26]
     ldp    x28, x29, [sp, #8 * REG_X28]
+    ldp    x30, xzr, [sp, #8 * REG_X30]
 
     add    sp, sp, #8 * XCPTCONTEXT_GP_REGS
 


### PR DESCRIPTION
## Summary
The expression "sub    x0,  x0, #8 * XCPTCONTEXT_GP_REGS" is void,
as the next instruction overwrites x0 anyway.

## Impact
Remove dead code
## Testing
CI pass
