### PR TITLE
arm64/task/pthread_start: Fix rare issue with context register location

### DIFF
--- a/arch/arm64/include/irq.h
+++ b/arch/arm64/include/irq.h
@@ -272,6 +272,9 @@ struct xcptcontext
   /* task stack reg context */
 
   uint64_t *regs;
+#ifndef CONFIG_BUILD_FLAT
+  uint64_t *initregs;
+#endif
 
   /* task context, for signal process */
 

--- a/arch/arm64/src/common/arm64_initialstate.c
+++ b/arch/arm64/src/common/arm64_initialstate.c
@@ -108,6 +108,10 @@ void arm64_new_task(struct tcb_s * tcb)
   pinitctx->tpidr_el1 = (uint64_t)tcb;
 
   tcb->xcp.regs       = (uint64_t *)pinitctx;
+
+#ifndef CONFIG_BUILD_FLAT
+  tcb->xcp.initregs   = tcb->xcp.regs;
+#endif
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
There is a tiny possibility that when a process is started a trap is taken which causes a context switch. This moves the kernel stack unexpectedly and the task start logic no longer works.

Fix this by recording the initial context location, and use that to trampoline into the user process with interrupts disabled. This ensures the context stays intact AND the kernel stack is fully unwound before the user process starts.

## Impact
Fixes a rare crash when a task / process is starting
## Testing
- qemu-armv8a:knsh
- downstream imx9 target with kernel mode
