### PR TITLE
video: migrate to SPDX identifier

### DIFF
--- a/video/CMakeLists.txt
+++ b/video/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # video/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/video/Makefile
+++ b/video/Makefile
@@ -1,6 +1,8 @@
 ############################################################################
 # video/Makefile
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/video/videomode/CMakeLists.txt
+++ b/video/videomode/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # video/videomode/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/video/videomode/Make.defs
+++ b/video/videomode/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # video/videomode/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/video/videomode/edid_dump.c
+++ b/video/videomode/edid_dump.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * video/videomode/edid_dump.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/video/videomode/edid_parse.c
+++ b/video/videomode/edid_parse.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * video/videomode/edid_parse.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/video/videomode/vesagtf.c
+++ b/video/videomode/vesagtf.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * video/videomode/vesagtf.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/video/videomode/videomode_dump.c
+++ b/video/videomode/videomode_dump.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * video/videomode/videomode_dump.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/video/videomode/videomode_lookup.c
+++ b/video/videomode/videomode_lookup.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * video/videomode/videomode_lookup.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/video/videomode/videomode_sort.c
+++ b/video/videomode/videomode_sort.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * video/videomode/videomode_sort.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The


### PR DESCRIPTION
## Summary
Most tools used for compliance and SBOM generation use SPDX identifiers This change brings us a step closer to an easy SBOM generation.

## Impact
SBOM

## Testing
CI
