### PR TITLE
wireless: migrate to SPDX identifier

### DIFF
--- a/wireless/CMakeLists.txt
+++ b/wireless/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # wireless/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/wireless/Makefile
+++ b/wireless/Makefile
@@ -1,6 +1,8 @@
 ############################################################################
 # wireless/Makefile
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/wireless/bluetooth/CMakeLists.txt
+++ b/wireless/bluetooth/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # wireless/bluetooth/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/wireless/bluetooth/Make.defs
+++ b/wireless/bluetooth/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # wireless/bluetooth/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/wireless/bluetooth/bt_atomic.c
+++ b/wireless/bluetooth/bt_atomic.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * wireless/bluetooth/bt_atomic.c
- * Linux like atomic operations
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/wireless/bluetooth/bt_atomic.h
+++ b/wireless/bluetooth/bt_atomic.h
@@ -1,6 +1,7 @@
 /****************************************************************************
  * wireless/bluetooth/bt_atomic.h
- * Linux like atomic operations
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/wireless/bluetooth/bt_att.c
+++ b/wireless/bluetooth/bt_att.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/bluetooth/bt_att.c
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (c) 2016, Intel Corporation
  *   All rights reserved.
  *

--- a/wireless/bluetooth/bt_att.h
+++ b/wireless/bluetooth/bt_att.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/bluetooth/bt_att.h
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (c) 2016, Intel Corporation
  *   All rights reserved.
  *

--- a/wireless/bluetooth/bt_buf.c
+++ b/wireless/bluetooth/bt_buf.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/bluetooth/bt_buf.c
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (c) 2016, Intel Corporation
  *   All rights reserved.
  *

--- a/wireless/bluetooth/bt_buf.h
+++ b/wireless/bluetooth/bt_buf.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/bluetooth/bt_buf.h
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (c) 2016, Intel Corporation
  *   All rights reserved.
  *

--- a/wireless/bluetooth/bt_conn.c
+++ b/wireless/bluetooth/bt_conn.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/bluetooth/bt_conn.c
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (c) 2016, Intel Corporation
  *   All rights reserved.
  *

--- a/wireless/bluetooth/bt_conn.h
+++ b/wireless/bluetooth/bt_conn.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/bluetooth/bt_conn.h
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (c) 2016, Intel Corporation
  *   All rights reserved.
  *

--- a/wireless/bluetooth/bt_gatt.c
+++ b/wireless/bluetooth/bt_gatt.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/bluetooth/bt_gatt.c
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (c) 2016, Intel Corporation
  *   All rights reserved.
  *

--- a/wireless/bluetooth/bt_hcicore.c
+++ b/wireless/bluetooth/bt_hcicore.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/bluetooth/bt_hcicore.c
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (c) 2016, Intel Corporation
  *   All rights reserved.
  *

--- a/wireless/bluetooth/bt_hcicore.h
+++ b/wireless/bluetooth/bt_hcicore.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/bluetooth/bt_hcicore.h
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (c) 2016, Intel Corporation
  *   All rights reserved.
  *

--- a/wireless/bluetooth/bt_ioctl.c
+++ b/wireless/bluetooth/bt_ioctl.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * wireless/bluetooth/bt_ioctl.c
- * Bluetooth network IOCTL handler
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/wireless/bluetooth/bt_ioctl.h
+++ b/wireless/bluetooth/bt_ioctl.h
@@ -1,6 +1,7 @@
 /****************************************************************************
  * wireless/bluetooth/bt_ioctl.h
- * Bluetooth network IOCTL handler
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/wireless/bluetooth/bt_keys.c
+++ b/wireless/bluetooth/bt_keys.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/bluetooth/bt_keys.c
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (c) 2016, Intel Corporation
  *   All rights reserved.
  *

--- a/wireless/bluetooth/bt_keys.h
+++ b/wireless/bluetooth/bt_keys.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/bluetooth/bt_keys.h
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (c) 2016, Intel Corporation
  *   All rights reserved.
  *

--- a/wireless/bluetooth/bt_l2cap.c
+++ b/wireless/bluetooth/bt_l2cap.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/bluetooth/bt_l2cap.c
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (c) 2016, Intel Corporation
  *   All rights reserved.
  *

--- a/wireless/bluetooth/bt_l2cap.h
+++ b/wireless/bluetooth/bt_l2cap.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/bluetooth/bt_l2cap.h
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (c) 2016, Intel Corporation
  *   All rights reserved.
  *

--- a/wireless/bluetooth/bt_netdev.c
+++ b/wireless/bluetooth/bt_netdev.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * wireless/bluetooth/bt_netdev.c
- * Network stack interface
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/wireless/bluetooth/bt_queue.c
+++ b/wireless/bluetooth/bt_queue.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * wireless/bluetooth/bt_queue.c
- * Inter-thread buffer queue management
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/wireless/bluetooth/bt_queue.h
+++ b/wireless/bluetooth/bt_queue.h
@@ -1,6 +1,7 @@
 /****************************************************************************
  * wireless/bluetooth/bt_queue.h
- * Inter-thread buffer queue management
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/wireless/bluetooth/bt_services.c
+++ b/wireless/bluetooth/bt_services.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/bluetooth/bt_services.c
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (c) 2016, Intel Corporation
  *   All rights reserved.
  *

--- a/wireless/bluetooth/bt_smp.c
+++ b/wireless/bluetooth/bt_smp.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/bluetooth/bt_smp.c
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (c) 2016, Intel Corporation
  *   All rights reserved.
  *

--- a/wireless/bluetooth/bt_smp.h
+++ b/wireless/bluetooth/bt_smp.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/bluetooth/bt_smp.h
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (c) 2016, Intel Corporation
  *   All rights reserved.
  *

--- a/wireless/bluetooth/bt_uuid.c
+++ b/wireless/bluetooth/bt_uuid.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/bluetooth/bt_uuid.c
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (c) 2016, Intel Corporation
  *   All rights reserved.
  *

--- a/wireless/ieee802154/CMakeLists.txt
+++ b/wireless/ieee802154/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # wireless/ieee802154/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/wireless/ieee802154/Make.defs
+++ b/wireless/ieee802154/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # wireless/ieee802154/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/wireless/ieee802154/ieee802154_primitive.c
+++ b/wireless/ieee802154/ieee802154_primitive.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/ieee802154/ieee802154_primitive.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/wireless/ieee802154/mac802154.c
+++ b/wireless/ieee802154/mac802154.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/ieee802154/mac802154.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/wireless/ieee802154/mac802154.h
+++ b/wireless/ieee802154/mac802154.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/ieee802154/mac802154.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/wireless/ieee802154/mac802154_assoc.c
+++ b/wireless/ieee802154/mac802154_assoc.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/ieee802154/mac802154_assoc.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/wireless/ieee802154/mac802154_assoc.h
+++ b/wireless/ieee802154/mac802154_assoc.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/ieee802154/mac802154_assoc.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/wireless/ieee802154/mac802154_bind.c
+++ b/wireless/ieee802154/mac802154_bind.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/ieee802154/mac802154_bind.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/wireless/ieee802154/mac802154_data.c
+++ b/wireless/ieee802154/mac802154_data.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/ieee802154/mac802154_data.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/wireless/ieee802154/mac802154_data.h
+++ b/wireless/ieee802154/mac802154_data.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/ieee802154/mac802154_data.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/wireless/ieee802154/mac802154_device.c
+++ b/wireless/ieee802154/mac802154_device.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/ieee802154/mac802154_device.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/wireless/ieee802154/mac802154_disassoc.c
+++ b/wireless/ieee802154/mac802154_disassoc.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/ieee802154/mac802154_disassoc.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/wireless/ieee802154/mac802154_get_mhrlen.c
+++ b/wireless/ieee802154/mac802154_get_mhrlen.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/ieee802154/mac802154_get_mhrlen.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/wireless/ieee802154/mac802154_getset.c
+++ b/wireless/ieee802154/mac802154_getset.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/ieee802154/mac802154_getset.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/wireless/ieee802154/mac802154_gts.c
+++ b/wireless/ieee802154/mac802154_gts.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/ieee802154/mac802154_gts.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/wireless/ieee802154/mac802154_internal.h
+++ b/wireless/ieee802154/mac802154_internal.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/ieee802154/mac802154_internal.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/wireless/ieee802154/mac802154_ioctl.c
+++ b/wireless/ieee802154/mac802154_ioctl.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/ieee802154/mac802154_ioctl.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/wireless/ieee802154/mac802154_loopback.c
+++ b/wireless/ieee802154/mac802154_loopback.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/ieee802154/mac802154_loopback.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/wireless/ieee802154/mac802154_netdev.c
+++ b/wireless/ieee802154/mac802154_netdev.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/ieee802154/mac802154_netdev.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/wireless/ieee802154/mac802154_orphan.c
+++ b/wireless/ieee802154/mac802154_orphan.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/ieee802154/mac802154_orphan.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/wireless/ieee802154/mac802154_poll.c
+++ b/wireless/ieee802154/mac802154_poll.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/ieee802154/mac802154_poll.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/wireless/ieee802154/mac802154_poll.h
+++ b/wireless/ieee802154/mac802154_poll.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/ieee802154/mac802154_poll.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/wireless/ieee802154/mac802154_purge.c
+++ b/wireless/ieee802154/mac802154_purge.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/ieee802154/mac802154_purge.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/wireless/ieee802154/mac802154_reset.c
+++ b/wireless/ieee802154/mac802154_reset.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/ieee802154/mac802154_reset.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/wireless/ieee802154/mac802154_rxenable.c
+++ b/wireless/ieee802154/mac802154_rxenable.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/ieee802154/mac802154_rxenable.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/wireless/ieee802154/mac802154_scan.c
+++ b/wireless/ieee802154/mac802154_scan.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/ieee802154/mac802154_scan.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/wireless/ieee802154/mac802154_scan.h
+++ b/wireless/ieee802154/mac802154_scan.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/ieee802154/mac802154_scan.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/wireless/ieee802154/mac802154_start.c
+++ b/wireless/ieee802154/mac802154_start.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/ieee802154/mac802154_start.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/wireless/ieee802154/mac802154_sync.c
+++ b/wireless/ieee802154/mac802154_sync.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/ieee802154/mac802154_sync.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/wireless/pktradio/CMakeLists.txt
+++ b/wireless/pktradio/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # wireless/pktradio/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/wireless/pktradio/Make.defs
+++ b/wireless/pktradio/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # wireless/pktradio/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/wireless/pktradio/pktradio_loopback.c
+++ b/wireless/pktradio/pktradio_loopback.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/pktradio/pktradio_loopback.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/wireless/pktradio/pktradio_metadata.c
+++ b/wireless/pktradio/pktradio_metadata.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * wireless/pktradio/pktradio_metadata.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The


### PR DESCRIPTION
## Summary
Most tools used for compliance and SBOM generation use SPDX identifiers This change brings us a step closer to an easy SBOM generation.

## Impact
SBOM

## Testing
CI
