### PR TITLE
syscall: migrate to SPDX identifier

### DIFF
--- a/syscall/CMakeLists.txt
+++ b/syscall/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # syscall/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/syscall/Makefile
+++ b/syscall/Makefile
@@ -1,6 +1,8 @@
 ############################################################################
 # syscall/Makefile
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/syscall/proxies/CMakeLists.txt
+++ b/syscall/proxies/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # syscall/proxies/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/syscall/proxies/Make.defs
+++ b/syscall/proxies/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # syscall/proxies/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/syscall/stubs/CMakeLists.txt
+++ b/syscall/stubs/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # syscall/stubs/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/syscall/stubs/Make.defs
+++ b/syscall/stubs/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # syscall/stubs/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/syscall/syscall_names.c
+++ b/syscall/syscall_names.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * syscall/syscall_names.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/syscall/syscall_stublookup.c
+++ b/syscall/syscall_stublookup.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * syscall/syscall_stublookup.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/syscall/syscall_wraps.h
+++ b/syscall/syscall_wraps.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * syscall/syscall_wraps.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/syscall/wraps/CMakeLists.txt
+++ b/syscall/wraps/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # syscall/wraps/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/syscall/wraps/Make.defs
+++ b/syscall/wraps/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # syscall/wraps/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The


### PR DESCRIPTION
## Summary
Most tools used for compliance and SBOM generation use SPDX identifiers This change brings us a step closer to an easy SBOM generation.

## Impact
SBOM

## Testing
CI
