### PR TITLE
sched: migrate to SPDX identifier

### DIFF
--- a/sched/CMakeLists.txt
+++ b/sched/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # sched/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/sched/Makefile
+++ b/sched/Makefile
@@ -1,6 +1,8 @@
 ############################################################################
 # sched/Makefile
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/sched/addrenv/CMakeLists.txt
+++ b/sched/addrenv/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # sched/addrenv/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/sched/addrenv/Make.defs
+++ b/sched/addrenv/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # sched/addrenv/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/sched/addrenv/addrenv.c
+++ b/sched/addrenv/addrenv.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/addrenv/addrenv.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/clock/CMakeLists.txt
+++ b/sched/clock/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # sched/clock/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/sched/clock/Make.defs
+++ b/sched/clock/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # sched/clock/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/sched/clock/clock.c
+++ b/sched/clock/clock.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/clock/clock.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/clock/clock.h
+++ b/sched/clock/clock.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/clock/clock.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/clock/clock_abstime2ticks.c
+++ b/sched/clock/clock_abstime2ticks.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/clock/clock_abstime2ticks.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/clock/clock_adjtime.c
+++ b/sched/clock/clock_adjtime.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/clock/clock_adjtime.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/clock/clock_dow.c
+++ b/sched/clock/clock_dow.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/clock/clock_dow.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/clock/clock_gettime.c
+++ b/sched/clock/clock_gettime.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/clock/clock_gettime.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/clock/clock_initialize.c
+++ b/sched/clock/clock_initialize.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/clock/clock_initialize.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/clock/clock_perf.c
+++ b/sched/clock/clock_perf.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/clock/clock_perf.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/clock/clock_settime.c
+++ b/sched/clock/clock_settime.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/clock/clock_settime.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/clock/clock_systime_ticks.c
+++ b/sched/clock/clock_systime_ticks.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/clock/clock_systime_ticks.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/clock/clock_systime_timespec.c
+++ b/sched/clock/clock_systime_timespec.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/clock/clock_systime_timespec.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/clock/clock_timekeeping.c
+++ b/sched/clock/clock_timekeeping.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/clock/clock_timekeeping.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/clock/clock_timekeeping.h
+++ b/sched/clock/clock_timekeeping.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/clock/clock_timekeeping.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/environ/CMakeLists.txt
+++ b/sched/environ/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # sched/environ/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/sched/environ/Make.defs
+++ b/sched/environ/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # sched/environ/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/sched/environ/env_clearenv.c
+++ b/sched/environ/env_clearenv.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/environ/env_clearenv.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/environ/env_dup.c
+++ b/sched/environ/env_dup.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/environ/env_dup.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/environ/env_findvar.c
+++ b/sched/environ/env_findvar.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/environ/env_findvar.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/environ/env_foreach.c
+++ b/sched/environ/env_foreach.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/environ/env_foreach.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/environ/env_getenv.c
+++ b/sched/environ/env_getenv.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/environ/env_getenv.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/environ/env_getenvironptr.c
+++ b/sched/environ/env_getenvironptr.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/environ/env_getenvironptr.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/environ/env_putenv.c
+++ b/sched/environ/env_putenv.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/environ/env_putenv.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/environ/env_release.c
+++ b/sched/environ/env_release.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/environ/env_release.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/environ/env_removevar.c
+++ b/sched/environ/env_removevar.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/environ/env_removevar.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/environ/env_setenv.c
+++ b/sched/environ/env_setenv.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/environ/env_setenv.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/environ/env_unsetenv.c
+++ b/sched/environ/env_unsetenv.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/environ/env_unsetenv.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/environ/environ.h
+++ b/sched/environ/environ.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/environ/environ.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/event/CMakeLists.txt
+++ b/sched/event/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # sched/event/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/sched/event/Make.defs
+++ b/sched/event/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # sched/event/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/sched/event/event.h
+++ b/sched/event/event.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/event/event.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/event/event_destroy.c
+++ b/sched/event/event_destroy.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/event/event_destroy.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/event/event_init.c
+++ b/sched/event/event_init.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/event/event_init.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/event/event_post.c
+++ b/sched/event/event_post.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/event/event_post.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/event/event_reset.c
+++ b/sched/event/event_reset.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/event/event_reset.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/event/event_wait.c
+++ b/sched/event/event_wait.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/event/event_wait.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/group/CMakeLists.txt
+++ b/sched/group/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # sched/group/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/sched/group/Make.defs
+++ b/sched/group/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # sched/group/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/sched/group/group.h
+++ b/sched/group/group.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/group/group.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/group/group_argvstr.c
+++ b/sched/group/group_argvstr.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/group/group_argvstr.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/group/group_childstatus.c
+++ b/sched/group/group_childstatus.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/group/group_childstatus.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/group/group_continue.c
+++ b/sched/group/group_continue.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/group/group_continue.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/group/group_create.c
+++ b/sched/group/group_create.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/group/group_create.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/group/group_exitinfo.c
+++ b/sched/group/group_exitinfo.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/group/group_exitinfo.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/group/group_foreachchild.c
+++ b/sched/group/group_foreachchild.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/group/group_foreachchild.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/group/group_free.c
+++ b/sched/group/group_free.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/group/group_free.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/group/group_getegid.c
+++ b/sched/group/group_getegid.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/group/group_getegid.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/group/group_geteuid.c
+++ b/sched/group/group_geteuid.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/group/group_geteuid.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/group/group_getgid.c
+++ b/sched/group/group_getgid.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/group/group_getgid.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/group/group_getuid.c
+++ b/sched/group/group_getuid.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/group/group_getuid.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/group/group_join.c
+++ b/sched/group/group_join.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/group/group_join.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/group/group_killchildren.c
+++ b/sched/group/group_killchildren.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/group/group_killchildren.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/group/group_leave.c
+++ b/sched/group/group_leave.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/group/group_leave.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/group/group_malloc.c
+++ b/sched/group/group_malloc.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/group/group_malloc.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/group/group_realloc.c
+++ b/sched/group/group_realloc.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/group/group_realloc.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/group/group_setegid.c
+++ b/sched/group/group_setegid.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/group/group_setegid.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/group/group_seteuid.c
+++ b/sched/group/group_seteuid.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/group/group_seteuid.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/group/group_setgid.c
+++ b/sched/group/group_setgid.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/group/group_setgid.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/group/group_setuid.c
+++ b/sched/group/group_setuid.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/group/group_setuid.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/group/group_setupidlefiles.c
+++ b/sched/group/group_setupidlefiles.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/group/group_setupidlefiles.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/group/group_setuptaskfiles.c
+++ b/sched/group/group_setuptaskfiles.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/group/group_setuptaskfiles.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/group/group_signal.c
+++ b/sched/group/group_signal.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/group/group_signal.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/group/group_suspendchildren.c
+++ b/sched/group/group_suspendchildren.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/group/group_suspendchildren.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/group/group_waiter.c
+++ b/sched/group/group_waiter.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/group/group_waiter.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/group/group_zalloc.c
+++ b/sched/group/group_zalloc.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/group/group_zalloc.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/init/CMakeLists.txt
+++ b/sched/init/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # sched/init/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/sched/init/Make.defs
+++ b/sched/init/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # sched/init/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/sched/init/init.h
+++ b/sched/init/init.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/init/init.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/init/nx_bringup.c
+++ b/sched/init/nx_bringup.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/init/nx_bringup.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/init/nx_smpstart.c
+++ b/sched/init/nx_smpstart.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/init/nx_smpstart.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/init/nx_start.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/instrument/CMakeLists.txt
+++ b/sched/instrument/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # sched/instrument/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/sched/instrument/Make.defs
+++ b/sched/instrument/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # sched/instrument/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/sched/instrument/instrument.c
+++ b/sched/instrument/instrument.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/instrument/instrument.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/instrument/instrument.h
+++ b/sched/instrument/instrument.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/instrument/instrument.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/instrument/stack_record.c
+++ b/sched/instrument/stack_record.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/instrument/stack_record.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/irq/CMakeLists.txt
+++ b/sched/irq/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # sched/irq/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/sched/irq/Make.defs
+++ b/sched/irq/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # sched/irq/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/sched/irq/irq.h
+++ b/sched/irq/irq.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/irq/irq.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/irq/irq_attach.c
+++ b/sched/irq/irq_attach.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/irq/irq_attach.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/irq/irq_attach_thread.c
+++ b/sched/irq/irq_attach_thread.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/irq/irq_attach_thread.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/irq/irq_attach_wqueue.c
+++ b/sched/irq/irq_attach_wqueue.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/irq/irq_attach_wqueue.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/irq/irq_chain.c
+++ b/sched/irq/irq_chain.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/irq/irq_chain.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/irq/irq_csection.c
+++ b/sched/irq/irq_csection.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/irq/irq_csection.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/irq/irq_dispatch.c
+++ b/sched/irq/irq_dispatch.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/irq/irq_dispatch.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/irq/irq_foreach.c
+++ b/sched/irq/irq_foreach.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/irq/irq_foreach.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/irq/irq_initialize.c
+++ b/sched/irq/irq_initialize.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/irq/irq_initialize.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/irq/irq_procfs.c
+++ b/sched/irq/irq_procfs.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/irq/irq_procfs.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/irq/irq_spinlock.c
+++ b/sched/irq/irq_spinlock.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/irq/irq_spinlock.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/irq/irq_unexpectedisr.c
+++ b/sched/irq/irq_unexpectedisr.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/irq/irq_unexpectedisr.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/misc/CMakeLists.txt
+++ b/sched/misc/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # sched/misc/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/sched/misc/Make.defs
+++ b/sched/misc/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # sched/misc/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/misc/assert.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/misc/coredump.c
+++ b/sched/misc/coredump.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/misc/coredump.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/misc/deadlock.c
+++ b/sched/misc/deadlock.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/misc/deadlock.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/misc/panic_notifier.c
+++ b/sched/misc/panic_notifier.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/misc/panic_notifier.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/misc/reboot_notifier.c
+++ b/sched/misc/reboot_notifier.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/misc/reboot_notifier.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/module/CMakeLists.txt
+++ b/sched/module/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # sched/module/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/sched/module/Make.defs
+++ b/sched/module/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # sched/module/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/sched/module/mod_insmod.c
+++ b/sched/module/mod_insmod.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/module/mod_insmod.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/module/mod_modhandle.c
+++ b/sched/module/mod_modhandle.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/module/mod_modhandle.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/module/mod_modsym.c
+++ b/sched/module/mod_modsym.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/module/mod_modsym.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/module/mod_procfs.c
+++ b/sched/module/mod_procfs.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/module/mod_procfs.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/module/mod_rmmod.c
+++ b/sched/module/mod_rmmod.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/module/mod_rmmod.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/mqueue/CMakeLists.txt
+++ b/sched/mqueue/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # sched/mqueue/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/sched/mqueue/Make.defs
+++ b/sched/mqueue/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # sched/mqueue/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/sched/mqueue/mq_getattr.c
+++ b/sched/mqueue/mq_getattr.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/mqueue/mq_getattr.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/mqueue/mq_initialize.c
+++ b/sched/mqueue/mq_initialize.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/mqueue/mq_initialize.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/mqueue/mq_msgfree.c
+++ b/sched/mqueue/mq_msgfree.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/mqueue/mq_msgfree.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/mqueue/mq_msgqalloc.c
+++ b/sched/mqueue/mq_msgqalloc.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/mqueue/mq_msgqalloc.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/mqueue/mq_msgqfree.c
+++ b/sched/mqueue/mq_msgqfree.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/mqueue/mq_msgqfree.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/mqueue/mq_notify.c
+++ b/sched/mqueue/mq_notify.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/mqueue/mq_notify.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/mqueue/mq_rcvinternal.c
+++ b/sched/mqueue/mq_rcvinternal.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/mqueue/mq_rcvinternal.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/mqueue/mq_receive.c
+++ b/sched/mqueue/mq_receive.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/mqueue/mq_receive.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/mqueue/mq_recover.c
+++ b/sched/mqueue/mq_recover.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/mqueue/mq_recover.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/mqueue/mq_send.c
+++ b/sched/mqueue/mq_send.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/mqueue/mq_send.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/mqueue/mq_setattr.c
+++ b/sched/mqueue/mq_setattr.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/mqueue/mq_setattr.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/mqueue/mq_sndinternal.c
+++ b/sched/mqueue/mq_sndinternal.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/mqueue/mq_sndinternal.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/mqueue/mq_timedreceive.c
+++ b/sched/mqueue/mq_timedreceive.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/mqueue/mq_timedreceive.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/mqueue/mq_timedsend.c
+++ b/sched/mqueue/mq_timedsend.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/mqueue/mq_timedsend.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/mqueue/mq_waitirq.c
+++ b/sched/mqueue/mq_waitirq.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/mqueue/mq_waitirq.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/mqueue/mqueue.h
+++ b/sched/mqueue/mqueue.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/mqueue/mqueue.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/mqueue/msg.h
+++ b/sched/mqueue/msg.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/mqueue/msg.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/mqueue/msgctl.c
+++ b/sched/mqueue/msgctl.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/mqueue/msgctl.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/mqueue/msgget.c
+++ b/sched/mqueue/msgget.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/mqueue/msgget.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/mqueue/msginternal.c
+++ b/sched/mqueue/msginternal.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/mqueue/msginternal.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/mqueue/msgrcv.c
+++ b/sched/mqueue/msgrcv.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/mqueue/msgrcv.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/mqueue/msgsnd.c
+++ b/sched/mqueue/msgsnd.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/mqueue/msgsnd.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/paging/CMakeLists.txt
+++ b/sched/paging/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # sched/paging/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/sched/paging/Make.defs
+++ b/sched/paging/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # sched/paging/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/sched/paging/paging.h
+++ b/sched/paging/paging.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/paging/paging.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/paging/pg_miss.c
+++ b/sched/paging/pg_miss.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/paging/pg_miss.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/paging/pg_worker.c
+++ b/sched/paging/pg_worker.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/paging/pg_worker.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/pthread/CMakeLists.txt
+++ b/sched/pthread/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # sched/pthread/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/sched/pthread/Make.defs
+++ b/sched/pthread/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # sched/pthread/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/sched/pthread/pthread.h
+++ b/sched/pthread/pthread.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/pthread/pthread.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/pthread/pthread_barrierwait.c
+++ b/sched/pthread/pthread_barrierwait.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/pthread/pthread_barrierwait.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/pthread/pthread_cancel.c
+++ b/sched/pthread/pthread_cancel.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/pthread/pthread_cancel.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/pthread/pthread_completejoin.c
+++ b/sched/pthread/pthread_completejoin.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/pthread/pthread_completejoin.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/pthread/pthread_condbroadcast.c
+++ b/sched/pthread/pthread_condbroadcast.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/pthread/pthread_condbroadcast.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/pthread/pthread_condclockwait.c
+++ b/sched/pthread/pthread_condclockwait.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/pthread/pthread_condclockwait.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/pthread/pthread_condsignal.c
+++ b/sched/pthread/pthread_condsignal.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/pthread/pthread_condsignal.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/pthread/pthread_condwait.c
+++ b/sched/pthread/pthread_condwait.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/pthread/pthread_condwait.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/pthread/pthread_create.c
+++ b/sched/pthread/pthread_create.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/pthread/pthread_create.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/pthread/pthread_detach.c
+++ b/sched/pthread/pthread_detach.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/pthread/pthread_detach.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/pthread/pthread_exit.c
+++ b/sched/pthread/pthread_exit.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/pthread/pthread_exit.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/pthread/pthread_findjoininfo.c
+++ b/sched/pthread/pthread_findjoininfo.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/pthread/pthread_findjoininfo.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/pthread/pthread_getaffinity.c
+++ b/sched/pthread/pthread_getaffinity.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/pthread/pthread_getaffinity.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/pthread/pthread_getschedparam.c
+++ b/sched/pthread/pthread_getschedparam.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/pthread/pthread_getschedparam.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/pthread/pthread_join.c
+++ b/sched/pthread/pthread_join.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/pthread/pthread_join.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/pthread/pthread_mutex.c
+++ b/sched/pthread/pthread_mutex.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/pthread/pthread_mutex.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/pthread/pthread_mutexconsistent.c
+++ b/sched/pthread/pthread_mutexconsistent.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/pthread/pthread_mutexconsistent.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/pthread/pthread_mutexdestroy.c
+++ b/sched/pthread/pthread_mutexdestroy.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/pthread/pthread_mutexdestroy.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/pthread/pthread_mutexinconsistent.c
+++ b/sched/pthread/pthread_mutexinconsistent.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/pthread/pthread_mutexinconsistent.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/pthread/pthread_mutexinit.c
+++ b/sched/pthread/pthread_mutexinit.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/pthread/pthread_mutexinit.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/pthread/pthread_mutextimedlock.c
+++ b/sched/pthread/pthread_mutextimedlock.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/pthread/pthread_mutextimedlock.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/pthread/pthread_mutextrylock.c
+++ b/sched/pthread/pthread_mutextrylock.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/pthread/pthread_mutextrylock.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/pthread/pthread_mutexunlock.c
+++ b/sched/pthread/pthread_mutexunlock.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/pthread/pthread_mutexunlock.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/pthread/pthread_release.c
+++ b/sched/pthread/pthread_release.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/pthread/pthread_release.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/pthread/pthread_sem.c
+++ b/sched/pthread/pthread_sem.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/pthread/pthread_sem.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/pthread/pthread_setaffinity.c
+++ b/sched/pthread/pthread_setaffinity.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/pthread/pthread_setaffinity.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/pthread/pthread_setschedparam.c
+++ b/sched/pthread/pthread_setschedparam.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/pthread/pthread_setschedparam.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/pthread/pthread_setschedprio.c
+++ b/sched/pthread/pthread_setschedprio.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/pthread/pthread_setschedprio.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/pthread/pthread_sigmask.c
+++ b/sched/pthread/pthread_sigmask.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/pthread/pthread_sigmask.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/CMakeLists.txt
+++ b/sched/sched/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # sched/sched/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/sched/sched/Make.defs
+++ b/sched/sched/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # sched/sched/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched.h
+++ b/sched/sched/sched.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_addblocked.c
+++ b/sched/sched/sched_addblocked.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_addblocked.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_addprioritized.c
+++ b/sched/sched/sched_addprioritized.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_addprioritized.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_addreadytorun.c
+++ b/sched/sched/sched_addreadytorun.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_addreadytorun.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_backtrace.c
+++ b/sched/sched/sched_backtrace.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_backtrace.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_cpuload.c
+++ b/sched/sched/sched_cpuload.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_cpuload.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_cpuload_oneshot.c
+++ b/sched/sched/sched_cpuload_oneshot.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_cpuload_oneshot.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_cpuload_period.c
+++ b/sched/sched/sched_cpuload_period.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_cpuload_period.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_cpupause.c
+++ b/sched/sched/sched_cpupause.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_cpupause.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_cpuselect.c
+++ b/sched/sched/sched_cpuselect.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_cpuselect.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_critmonitor.c
+++ b/sched/sched/sched_critmonitor.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_critmonitor.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_dumponexit.c
+++ b/sched/sched/sched_dumponexit.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_dumponexit.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_foreach.c
+++ b/sched/sched/sched_foreach.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_foreach.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_get_stackinfo.c
+++ b/sched/sched/sched_get_stackinfo.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_get_stackinfo.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_get_stateinfo.c
+++ b/sched/sched/sched_get_stateinfo.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_get_stateinfo.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_get_tls.c
+++ b/sched/sched/sched_get_tls.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_get_tls.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_getaffinity.c
+++ b/sched/sched/sched_getaffinity.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_getaffinity.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_getcpu.c
+++ b/sched/sched/sched_getcpu.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_getcpu.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_getfiles.c
+++ b/sched/sched/sched_getfiles.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_getfiles.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_getparam.c
+++ b/sched/sched/sched_getparam.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_getparam.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_getscheduler.c
+++ b/sched/sched/sched_getscheduler.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_getscheduler.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_gettcb.c
+++ b/sched/sched/sched_gettcb.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_gettcb.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_idletask.c
+++ b/sched/sched/sched_idletask.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_idletask.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_lock.c
+++ b/sched/sched/sched_lock.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_lock.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_lockcount.c
+++ b/sched/sched/sched_lockcount.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_lockcount.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_mergepending.c
+++ b/sched/sched/sched_mergepending.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_mergepending.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_mergeprioritized.c
+++ b/sched/sched/sched_mergeprioritized.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_mergeprioritized.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_processtimer.c
+++ b/sched/sched/sched_processtimer.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_processtimer.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_releasetcb.c
+++ b/sched/sched/sched_releasetcb.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_releasetcb.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_removeblocked.c
+++ b/sched/sched/sched_removeblocked.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_removeblocked.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_removereadytorun.c
+++ b/sched/sched/sched_removereadytorun.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_removereadytorun.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_reprioritize.c
+++ b/sched/sched/sched_reprioritize.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_reprioritize.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_reprioritizertr.c
+++ b/sched/sched/sched_reprioritizertr.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_reprioritizertr.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_resumescheduler.c
+++ b/sched/sched/sched_resumescheduler.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_resumescheduler.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_roundrobin.c
+++ b/sched/sched/sched_roundrobin.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_roundrobin.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_rrgetinterval.c
+++ b/sched/sched/sched_rrgetinterval.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_rrgetinterval.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_self.c
+++ b/sched/sched/sched_self.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_self.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_setaffinity.c
+++ b/sched/sched/sched_setaffinity.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_setaffinity.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_setparam.c
+++ b/sched/sched/sched_setparam.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_setparam.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_setpriority.c
+++ b/sched/sched/sched_setpriority.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_setpriority.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_setscheduler.c
+++ b/sched/sched/sched_setscheduler.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_setscheduler.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_smp.c
+++ b/sched/sched/sched_smp.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_smp.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_sporadic.c
+++ b/sched/sched/sched_sporadic.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_sporadic.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_suspend.c
+++ b/sched/sched/sched_suspend.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_suspend.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_suspendscheduler.c
+++ b/sched/sched/sched_suspendscheduler.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_suspendscheduler.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_sysinfo.c
+++ b/sched/sched/sched_sysinfo.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_sysinfo.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_timerexpiration.c
+++ b/sched/sched/sched_timerexpiration.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_timerexpiration.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_unlock.c
+++ b/sched/sched/sched_unlock.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_unlock.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_verifytcb.c
+++ b/sched/sched/sched_verifytcb.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_verifytcb.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_wait.c
+++ b/sched/sched/sched_wait.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_wait.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_waitid.c
+++ b/sched/sched/sched_waitid.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_waitid.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_waitpid.c
+++ b/sched/sched/sched_waitpid.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_waitpid.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/sched/sched_yield.c
+++ b/sched/sched/sched_yield.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/sched/sched_yield.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/semaphore/CMakeLists.txt
+++ b/sched/semaphore/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # sched/semaphore/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/sched/semaphore/Make.defs
+++ b/sched/semaphore/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # sched/semaphore/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/sched/semaphore/sem_clockwait.c
+++ b/sched/semaphore/sem_clockwait.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/semaphore/sem_clockwait.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/semaphore/sem_destroy.c
+++ b/sched/semaphore/sem_destroy.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/semaphore/sem_destroy.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/semaphore/sem_holder.c
+++ b/sched/semaphore/sem_holder.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/semaphore/sem_holder.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/semaphore/sem_initialize.c
+++ b/sched/semaphore/sem_initialize.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/semaphore/sem_initialize.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/semaphore/sem_post.c
+++ b/sched/semaphore/sem_post.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/semaphore/sem_post.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/semaphore/sem_protect.c
+++ b/sched/semaphore/sem_protect.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/semaphore/sem_protect.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/semaphore/sem_recover.c
+++ b/sched/semaphore/sem_recover.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/semaphore/sem_recover.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/semaphore/sem_reset.c
+++ b/sched/semaphore/sem_reset.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/semaphore/sem_reset.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/semaphore/sem_rw.c
+++ b/sched/semaphore/sem_rw.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/semaphore/sem_rw.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/semaphore/sem_setprotocol.c
+++ b/sched/semaphore/sem_setprotocol.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/semaphore/sem_setprotocol.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/semaphore/sem_tickwait.c
+++ b/sched/semaphore/sem_tickwait.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/semaphore/sem_tickwait.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/semaphore/sem_timedwait.c
+++ b/sched/semaphore/sem_timedwait.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/semaphore/sem_timedwait.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/semaphore/sem_timeout.c
+++ b/sched/semaphore/sem_timeout.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/semaphore/sem_timeout.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/semaphore/sem_trywait.c
+++ b/sched/semaphore/sem_trywait.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/semaphore/sem_trywait.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/semaphore/sem_wait.c
+++ b/sched/semaphore/sem_wait.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/semaphore/sem_wait.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/semaphore/sem_waitirq.c
+++ b/sched/semaphore/sem_waitirq.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/semaphore/sem_waitirq.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/semaphore/semaphore.h
+++ b/sched/semaphore/semaphore.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/semaphore/semaphore.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/signal/CMakeLists.txt
+++ b/sched/signal/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # sched/signal/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/sched/signal/Make.defs
+++ b/sched/signal/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # sched/signal/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/sched/signal/sig_action.c
+++ b/sched/signal/sig_action.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/signal/sig_action.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/signal/sig_allocpendingsigaction.c
+++ b/sched/signal/sig_allocpendingsigaction.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/signal/sig_allocpendingsigaction.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/signal/sig_cleanup.c
+++ b/sched/signal/sig_cleanup.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/signal/sig_cleanup.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/signal/sig_default.c
+++ b/sched/signal/sig_default.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/signal/sig_default.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/signal/sig_deliver.c
+++ b/sched/signal/sig_deliver.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/signal/sig_deliver.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/signal/sig_dispatch.c
+++ b/sched/signal/sig_dispatch.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/signal/sig_dispatch.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/signal/sig_findaction.c
+++ b/sched/signal/sig_findaction.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/signal/sig_findaction.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/signal/sig_initialize.c
+++ b/sched/signal/sig_initialize.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/signal/sig_initialize.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/signal/sig_kill.c
+++ b/sched/signal/sig_kill.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/signal/sig_kill.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/signal/sig_lowest.c
+++ b/sched/signal/sig_lowest.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/signal/sig_lowest.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/signal/sig_nanosleep.c
+++ b/sched/signal/sig_nanosleep.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/signal/sig_nanosleep.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/signal/sig_notification.c
+++ b/sched/signal/sig_notification.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/signal/sig_notification.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/signal/sig_pause.c
+++ b/sched/signal/sig_pause.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/signal/sig_pause.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/signal/sig_pending.c
+++ b/sched/signal/sig_pending.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/signal/sig_pending.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/signal/sig_ppoll.c
+++ b/sched/signal/sig_ppoll.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/signal/sig_ppoll.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/signal/sig_procmask.c
+++ b/sched/signal/sig_procmask.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/signal/sig_procmask.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/signal/sig_pselect.c
+++ b/sched/signal/sig_pselect.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/signal/sig_pselect.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/signal/sig_queue.c
+++ b/sched/signal/sig_queue.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/signal/sig_queue.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/signal/sig_releasependingsigaction.c
+++ b/sched/signal/sig_releasependingsigaction.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/signal/sig_releasependingsigaction.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/signal/sig_releasependingsignal.c
+++ b/sched/signal/sig_releasependingsignal.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/signal/sig_releasependingsignal.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/signal/sig_removependingsignal.c
+++ b/sched/signal/sig_removependingsignal.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/signal/sig_removependingsignal.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/signal/sig_sleep.c
+++ b/sched/signal/sig_sleep.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/signal/sig_sleep.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/signal/sig_suspend.c
+++ b/sched/signal/sig_suspend.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/signal/sig_suspend.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/signal/sig_tgkill.c
+++ b/sched/signal/sig_tgkill.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/signal/sig_tgkill.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/signal/sig_timedwait.c
+++ b/sched/signal/sig_timedwait.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/signal/sig_timedwait.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/signal/sig_unmaskpendingsignal.c
+++ b/sched/signal/sig_unmaskpendingsignal.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/signal/sig_unmaskpendingsignal.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/signal/sig_usleep.c
+++ b/sched/signal/sig_usleep.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/signal/sig_usleep.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/signal/sig_waitinfo.c
+++ b/sched/signal/sig_waitinfo.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/signal/sig_waitinfo.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/signal/signal.h
+++ b/sched/signal/signal.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/signal/signal.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/task/CMakeLists.txt
+++ b/sched/task/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # sched/task/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/sched/task/Make.defs
+++ b/sched/task/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # sched/task/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/sched/task/exit.c
+++ b/sched/task/exit.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/task/exit.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/task/spawn.h
+++ b/sched/task/spawn.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/task/spawn.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/task/task.h
+++ b/sched/task/task.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/task/task.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/task/task_activate.c
+++ b/sched/task/task_activate.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/task/task_activate.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/task/task_cancelpt.c
+++ b/sched/task/task_cancelpt.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/task/task_cancelpt.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/task/task_create.c
+++ b/sched/task/task_create.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/task/task_create.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/task/task_delete.c
+++ b/sched/task/task_delete.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/task/task_delete.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/task/task_execve.c
+++ b/sched/task/task_execve.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/task/task_execve.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/task/task_exit.c
+++ b/sched/task/task_exit.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/task/task_exit.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/task/task_exithook.c
+++ b/sched/task/task_exithook.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/task/task_exithook.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/task/task_fork.c
+++ b/sched/task/task_fork.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/task/task_fork.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/task/task_getgroup.c
+++ b/sched/task/task_getgroup.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/task/task_getgroup.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/task/task_getpid.c
+++ b/sched/task/task_getpid.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/task/task_getpid.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/task/task_getppid.c
+++ b/sched/task/task_getppid.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/task/task_getppid.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/task/task_gettid.c
+++ b/sched/task/task_gettid.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/task/task_gettid.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/task/task_init.c
+++ b/sched/task/task_init.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/task/task_init.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/task/task_join.c
+++ b/sched/task/task_join.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/task/task_join.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/task/task_posixspawn.c
+++ b/sched/task/task_posixspawn.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/task/task_posixspawn.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/task/task_prctl.c
+++ b/sched/task/task_prctl.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/task/task_prctl.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/task/task_recover.c
+++ b/sched/task/task_recover.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/task/task_recover.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/task/task_reparent.c
+++ b/sched/task/task_reparent.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/task/task_reparent.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/task/task_restart.c
+++ b/sched/task/task_restart.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/task/task_restart.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/task/task_setup.c
+++ b/sched/task/task_setup.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/task/task_setup.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/task/task_spawn.c
+++ b/sched/task/task_spawn.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/task/task_spawn.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/task/task_spawnparms.c
+++ b/sched/task/task_spawnparms.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/task/task_spawnparms.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/task/task_start.c
+++ b/sched/task/task_start.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/task/task_start.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/task/task_starthook.c
+++ b/sched/task/task_starthook.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/task/task_starthook.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/task/task_terminate.c
+++ b/sched/task/task_terminate.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/task/task_terminate.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/timer/CMakeLists.txt
+++ b/sched/timer/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # sched/timer/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/sched/timer/Make.defs
+++ b/sched/timer/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # sched/timer/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/sched/timer/timer.h
+++ b/sched/timer/timer.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/timer/timer.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/timer/timer_create.c
+++ b/sched/timer/timer_create.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/timer/timer_create.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/timer/timer_delete.c
+++ b/sched/timer/timer_delete.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/timer/timer_delete.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/timer/timer_getitimer.c
+++ b/sched/timer/timer_getitimer.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/timer/timer_getitimer.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/timer/timer_getoverrun.c
+++ b/sched/timer/timer_getoverrun.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/timer/timer_getoverrun.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/timer/timer_gettime.c
+++ b/sched/timer/timer_gettime.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/timer/timer_gettime.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/timer/timer_initialize.c
+++ b/sched/timer/timer_initialize.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/timer/timer_initialize.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/timer/timer_release.c
+++ b/sched/timer/timer_release.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/timer/timer_release.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/timer/timer_setitimer.c
+++ b/sched/timer/timer_setitimer.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/timer/timer_setitimer.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/timer/timer_settime.c
+++ b/sched/timer/timer_settime.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/timer/timer_settime.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/tls/CMakeLists.txt
+++ b/sched/tls/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # sched/tls/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/sched/tls/Make.defs
+++ b/sched/tls/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # sched/tls/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/sched/tls/task_initinfo.c
+++ b/sched/tls/task_initinfo.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/tls/task_initinfo.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/tls/task_uninitinfo.c
+++ b/sched/tls/task_uninitinfo.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/tls/task_uninitinfo.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/tls/tls.h
+++ b/sched/tls/tls.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/tls/tls.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/tls/tls_dupinfo.c
+++ b/sched/tls/tls_dupinfo.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/tls/tls_dupinfo.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/tls/tls_initinfo.c
+++ b/sched/tls/tls_initinfo.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/tls/tls_initinfo.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/wdog/CMakeLists.txt
+++ b/sched/wdog/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # sched/wdog/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/sched/wdog/Make.defs
+++ b/sched/wdog/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # sched/wdog/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/sched/wdog/wd_cancel.c
+++ b/sched/wdog/wd_cancel.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/wdog/wd_cancel.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/wdog/wd_gettime.c
+++ b/sched/wdog/wd_gettime.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/wdog/wd_gettime.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/wdog/wd_initialize.c
+++ b/sched/wdog/wd_initialize.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/wdog/wd_initialize.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/wdog/wd_recover.c
+++ b/sched/wdog/wd_recover.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/wdog/wd_recover.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/wdog/wd_start.c
+++ b/sched/wdog/wd_start.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/wdog/wd_start.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/wdog/wdog.h
+++ b/sched/wdog/wdog.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/wdog/wdog.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/wqueue/CMakeLists.txt
+++ b/sched/wqueue/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # sched/wqueue/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/sched/wqueue/Make.defs
+++ b/sched/wqueue/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # sched/wqueue/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/sched/wqueue/kwork_cancel.c
+++ b/sched/wqueue/kwork_cancel.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/wqueue/kwork_cancel.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/wqueue/kwork_inherit.c
+++ b/sched/wqueue/kwork_inherit.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/wqueue/kwork_inherit.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/wqueue/kwork_notifier.c
+++ b/sched/wqueue/kwork_notifier.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/wqueue/kwork_notifier.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/wqueue/kwork_queue.c
+++ b/sched/wqueue/kwork_queue.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/wqueue/kwork_queue.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/wqueue/kwork_thread.c
+++ b/sched/wqueue/kwork_thread.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/wqueue/kwork_thread.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/sched/wqueue/wqueue.h
+++ b/sched/wqueue/wqueue.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * sched/wqueue/wqueue.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The


### PR DESCRIPTION
## Summary
Most tools used for compliance and SBOM generation use SPDX identifiers This change brings us a step closer to an easy SBOM generation.

## Impact
SBOM

## Testing
CI
