### PR TITLE
arm64/Kconfig: Make the ARM64_PA/VA_BITS a true Kconfig variable

### DIFF
--- a/arch/arm64/Kconfig
+++ b/arch/arm64/Kconfig
@@ -344,6 +344,24 @@ config ARM64_ICACHE_DISABLE
 	bool "Disable ICACHE at __start"
 	default n
 
+config ARM64_VA_BITS
+	int "Virtual address space size"
+	default 48
+	---help---
+		Allows choosing one of multiple possible virtual address
+		space sizes. The level of translation table is determined by
+		a combination of page size and virtual address space size.
+
+		The choice could be: 32, 36, 42, 48
+
+config ARM64_PA_BITS
+	int "Physical address space size"
+	default 48
+	---help---
+		Choose the maximum physical address range that the kernel will support.
+
+		The choice could be: 32, 36, 42, 48
+
 if ARCH_CHIP_A64
 source "arch/arm64/src/a64/Kconfig"
 endif

--- a/arch/arm64/src/common/arm64_arch.h
+++ b/arch/arm64/src/common/arm64_arch.h
@@ -265,23 +265,6 @@
 
 #define CONFIG_MAX_XLAT_TABLES      10
 
-/* Virtual address space size
- * Allows choosing one of multiple possible virtual address
- * space sizes. The level of translation table is determined by
- * a combination of page size and virtual address space size.
- *
- * The choice could be: 32, 36, 42, 48
- */
-
-#define CONFIG_ARM64_VA_BITS        48
-/* Physical address space size
- * Choose the maximum physical address range that the kernel will support.
- *
- * The choice could be: 32, 36, 42, 48
- */
-
-#define CONFIG_ARM64_PA_BITS        48
-
 #define L1_CACHE_SHIFT              (6)
 #define L1_CACHE_BYTES              BIT(L1_CACHE_SHIFT)
 


### PR DESCRIPTION
## Summary
Enforcing the default 48-bit VA for everyone also implies a 4 page table translation system. However, if less than 40 bits are needed, a full translation table level can be dropped, making the translations faster.

Thus, make this into a configurable option, instead of enforcing the same address widht for everyone.

## Impact
Make it possible to define the VA range per target, instead of a global value
## Testing
CI pass

The main motivation for doing this is to provide an option to drop page table levels from the translation table walk. Using more than 39 bits enforces using all 4 page table levels, making the translations slower due to the longer table walk.

Many users could be fine with much less than 48 bits, so let's not enforce this.
